### PR TITLE
fix: use nodeExecutions for workflow canvas node status

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-node-execution-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-node-execution-handlers.ts
@@ -3,9 +3,10 @@
  *
  * RPC handlers for NodeExecution queries:
  * - nodeExecution.list - Lists node executions for a workflow run (requires spaceId)
+ * - nodeExecution.create - Creates a node execution record (E2E test infrastructure only)
  */
 
-import type { MessageHub } from '@neokai/shared';
+import type { MessageHub, NodeExecutionStatus } from '@neokai/shared';
 import type { NodeExecutionRepository } from '../../storage/repositories/node-execution-repository';
 import type { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
 
@@ -38,4 +39,42 @@ export function setupNodeExecutionHandlers(
 
 		return { executions };
 	});
+
+	// ─── nodeExecution.create (E2E test infrastructure only) ────────────────
+	//
+	// Creates a node execution record directly. Used by E2E tests to simulate
+	// node activation without spinning up a real agent session or channel router.
+	// Disabled in production to prevent unauthorized state manipulation.
+	if (process.env.NODE_ENV !== 'production')
+		messageHub.onRequest('nodeExecution.create', async (data) => {
+			const params = data as {
+				workflowRunId: string;
+				workflowNodeId: string;
+				agentName: string;
+				status?: NodeExecutionStatus;
+			};
+
+			if (!params.workflowRunId) throw new Error('workflowRunId is required');
+			if (!params.workflowNodeId) throw new Error('workflowNodeId is required');
+			if (!params.agentName) throw new Error('agentName is required');
+
+			const run = workflowRunRepo.getRun(params.workflowRunId);
+			if (!run) throw new Error(`WorkflowRun not found: ${params.workflowRunId}`);
+
+			const execution = nodeExecutionRepo.createOrIgnore({
+				workflowRunId: params.workflowRunId,
+				workflowNodeId: params.workflowNodeId,
+				agentName: params.agentName,
+				status: params.status ?? 'in_progress',
+			});
+
+			// If a specific status was requested and it differs from the created record
+			// (e.g., createOrIgnore returned an existing 'pending' record), update it.
+			if (params.status && execution.status !== params.status) {
+				const updated = nodeExecutionRepo.update(execution.id, { status: params.status });
+				if (updated) return { execution: updated };
+			}
+
+			return { execution };
+		});
 }

--- a/packages/e2e/tests/features/reviewer-feedback-loop.e2e.ts
+++ b/packages/e2e/tests/features/reviewer-feedback-loop.e2e.ts
@@ -169,36 +169,29 @@ async function getCodingNodeId(
 	);
 }
 
-// ─── Create + start a task for a specific workflow node ───────────────────────
+// ─── Create an in_progress node execution for a specific workflow node ───────
 
-async function createActiveTaskForNode(
+async function createActiveNodeExecution(
 	page: Parameters<typeof waitForWebSocketConnected>[0],
-	spaceId: string,
 	runId: string,
-	nodeId: string
+	nodeId: string,
+	agentName: string
 ): Promise<string> {
 	return page.evaluate(
-		async ({ sid, rid, nid }) => {
+		async ({ rid, nid, aname }) => {
 			const hub = window.__messageHub || window.appState?.messageHub;
 			if (!hub?.request) throw new Error('MessageHub not available');
 
-			const task = (await hub.request('spaceTask.create', {
-				spaceId: sid,
-				title: 'E2E: Coding task (re-activated)',
-				description: 'Test task simulating coder re-activation after rejection.',
+			const result = (await hub.request('nodeExecution.create', {
 				workflowRunId: rid,
 				workflowNodeId: nid,
-			})) as { id: string };
-
-			await hub.request('spaceTask.update', {
-				spaceId: sid,
-				taskId: task.id,
+				agentName: aname,
 				status: 'in_progress',
-			});
+			})) as { execution: { id: string } };
 
-			return task.id;
+			return result.execution.id;
 		},
-		{ sid: spaceId, rid: runId, nid: nodeId }
+		{ rid: runId, nid: nodeId, aname: agentName }
 	);
 }
 
@@ -303,11 +296,11 @@ test.describe
 				spaceId = ids.spaceId;
 				runId = ids.runId;
 
-				// Get the Coding node UUID so we can create a task for it
+				// Get the Coding node UUID so we can create a node execution for it
 				codingNodeId = await getCodingNodeId(page, spaceId, runId);
 
-				// Create a task for the Coding node and set it to in_progress
-				await createActiveTaskForNode(page, spaceId, runId, codingNodeId);
+				// Create an in_progress node execution for the Coding node
+				await createActiveNodeExecution(page, runId, codingNodeId, 'Coding');
 			});
 
 			test.afterEach(async ({ page }) => {
@@ -326,12 +319,12 @@ test.describe
 					page.getByTestId('canvas-panel').getByTestId('workflow-canvas-svg')
 				).toBeVisible({ timeout: 30000 });
 
-				// The Coding node with in_progress task renders the g element with animate-pulse class
+				// The Coding node with in_progress execution renders the g element with animate-pulse class
 				const codingNodeEl = page.getByTestId('canvas-panel').getByTestId(`node-${codingNodeId}`);
 				await expect(codingNodeEl).toBeVisible({ timeout: 30000 });
 
 				// Active nodes have animate-pulse CSS class.
-				// Allow extra time for the live query to propagate task status to the canvas.
+				// Allow extra time for the live query to propagate node execution status to the canvas.
 				await expect(codingNodeEl).toHaveClass(/animate-pulse/, { timeout: 15000 });
 			});
 		});

--- a/packages/e2e/tests/features/reviewer-feedback-loop.e2e.ts
+++ b/packages/e2e/tests/features/reviewer-feedback-loop.e2e.ts
@@ -12,7 +12,7 @@
  * Setup strategy (per test):
  *   - Space + run created via RPC in beforeEach (infrastructure)
  *   - Gate data injected via `spaceWorkflowRun.writeGateData` RPC (infrastructure)
- *   - For "Coding active" test: task created + set to in_progress via RPC (infrastructure)
+ *   - For "Coding active" test: node execution created as in_progress via RPC (infrastructure)
  *   - All assertions verify visible DOM state only
  *
  * Cleanup:
@@ -324,7 +324,7 @@ test.describe
 				await expect(codingNodeEl).toBeVisible({ timeout: 30000 });
 
 				// Active nodes have animate-pulse CSS class.
-				// Allow extra time for the live query to propagate node execution status to the canvas.
+				// Allow extra time for the initial fetchNodeExecutions() call during space load.
 				await expect(codingNodeEl).toHaveClass(/animate-pulse/, { timeout: 15000 });
 			});
 		});

--- a/packages/web/src/components/space/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/WorkflowCanvas.tsx
@@ -25,7 +25,7 @@ import type { JSX } from 'preact';
 import type {
 	SpaceWorkflow,
 	SpaceWorkflowRun,
-	SpaceTask,
+	NodeExecution,
 	Gate,
 	GateField,
 	WorkflowNode,
@@ -602,7 +602,7 @@ interface NodeBoxProps {
 	node: WorkflowNode;
 	layout: NodeLayout;
 	status: NodeStatus;
-	tasks: SpaceTask[];
+	executions: NodeExecution[];
 	isRuntimeMode: boolean;
 }
 
@@ -610,7 +610,7 @@ function NodeBox({
 	node,
 	layout,
 	status,
-	tasks,
+	executions,
 	isRuntimeMode: _isRuntimeMode,
 }: NodeBoxProps): JSX.Element {
 	const { x, y, width, height } = layout;
@@ -642,15 +642,12 @@ function NodeBox({
 			borderColor = '#16a34a';
 			bgColor = '#052e16';
 			labelColor = '#86efac';
-			// Find most recent completed task for elapsed time
-			const completedTasks = tasks.filter((t) => t.status === 'done' && t.updatedAt);
-			const elapsed =
-				completedTasks.length > 0
-					? formatElapsed(
-							completedTasks[completedTasks.length - 1].updatedAt,
-							completedTasks[completedTasks.length - 1].createdAt
-						)
-					: null;
+			// Find most recent completed execution for elapsed time
+			const completedExecs = executions.filter(
+				(e) => e.status === 'done' && e.completedAt && e.startedAt
+			);
+			const lastExec = completedExecs.length > 0 ? completedExecs[completedExecs.length - 1] : null;
+			const elapsed = lastExec ? formatElapsed(lastExec.completedAt!, lastExec.startedAt!) : null;
 			statusIndicator = (
 				<>
 					<path
@@ -799,30 +796,20 @@ function formatElapsed(endMs: number, startMs: number): string {
 // Determine node status from tasks
 // ============================================================================
 
-function getNodeStatus(
-	nodeId: string,
-	tasks: SpaceTask[],
-	run: SpaceWorkflowRun | null
-): NodeStatus {
-	const nodeTasks = tasks.filter((t) => t.workflowRunId === nodeId);
-
-	if (nodeTasks.length === 0) {
+function getNodeStatus(executions: NodeExecution[], run: SpaceWorkflowRun | null): NodeStatus {
+	if (executions.length === 0) {
 		return 'pending';
 	}
 
-	if (nodeTasks.some((t) => t.status === 'in_progress')) return 'active';
+	if (executions.some((e) => e.status === 'in_progress')) return 'active';
 
-	if (
-		nodeTasks.every(
-			(t) => t.status === 'done' || t.status === 'cancelled' || t.status === 'archived'
-		)
-	) {
+	if (executions.every((e) => e.status === 'done' || e.status === 'cancelled')) {
 		// All terminal — check if they succeeded
-		if (nodeTasks.some((t) => t.status === 'done')) return 'done';
+		if (executions.some((e) => e.status === 'done')) return 'done';
 	}
 
 	if (run?.status === 'blocked' || run?.status === 'cancelled') {
-		if (nodeTasks.some((t) => t.status === 'blocked' || t.status === 'cancelled')) {
+		if (executions.some((e) => e.status === 'blocked' || e.status === 'cancelled')) {
 			return 'failed';
 		}
 	}
@@ -960,12 +947,8 @@ export function WorkflowCanvas({
 		[runId, spaceStore.workflowRuns.value]
 	);
 
-	// All tasks for this run (via workflowRunId)
-	const runTasks = useMemo(
-		() => (runId ? (spaceStore.tasksByRun.value.get(runId) ?? []) : []),
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[runId, spaceStore.tasksByRun.value]
-	);
+	// Node executions grouped by node ID — used for node status and elapsed time
+	const nodeExecsByNodeId = spaceStore.nodeExecutionsByNodeId.value;
 
 	// ---- Gate data state ----
 	const [gateDataMap, setGateDataMap] = useState<Map<string, Record<string, unknown>>>(new Map());
@@ -1307,8 +1290,10 @@ export function WorkflowCanvas({
 					const nodeLayout = layout.get(node.id);
 					if (!nodeLayout) return null;
 
-					const nodeTasks = runTasks.filter((t) => t.workflowRunId === node.id);
-					const status = isRuntimeMode ? getNodeStatus(node.id, runTasks, run) : 'pending';
+					const nodeExecs = (nodeExecsByNodeId.get(node.id) ?? []).filter(
+						(e) => e.workflowRunId === runId
+					);
+					const status = isRuntimeMode ? getNodeStatus(nodeExecs, run) : 'pending';
 
 					return (
 						<NodeBox
@@ -1316,7 +1301,7 @@ export function WorkflowCanvas({
 							node={node}
 							layout={nodeLayout}
 							status={status}
-							tasks={nodeTasks}
+							executions={nodeExecs}
 							isRuntimeMode={isRuntimeMode}
 						/>
 					);

--- a/packages/web/src/components/space/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/WorkflowCanvas.tsx
@@ -793,7 +793,7 @@ function formatElapsed(endMs: number, startMs: number): string {
 }
 
 // ============================================================================
-// Determine node status from tasks
+// Determine node status from node executions
 // ============================================================================
 
 function getNodeStatus(executions: NodeExecution[], run: SpaceWorkflowRun | null): NodeStatus {

--- a/packages/web/src/components/space/__tests__/WorkflowCanvas.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowCanvas.test.tsx
@@ -30,13 +30,22 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
 import { render, cleanup, waitFor, fireEvent } from '@testing-library/preact';
 import { signal, type Signal } from '@preact/signals';
-import type { SpaceWorkflow, SpaceWorkflowRun, SpaceTask, Gate } from '@neokai/shared';
+import type {
+	SpaceWorkflow,
+	SpaceWorkflowRun,
+	SpaceTask,
+	NodeExecution,
+	Gate,
+} from '@neokai/shared';
+import { computed, type ReadonlySignal } from '@preact/signals';
 
 // ---- Signals for mocking ----
 let mockWorkflows: Signal<SpaceWorkflow[]>;
 let mockWorkflowRuns: Signal<SpaceWorkflowRun[]>;
 let mockTasks: Signal<SpaceTask[]>;
 let mockTasksByRun: Signal<Map<string, SpaceTask[]>>;
+let mockNodeExecutions: Signal<NodeExecution[]>;
+let mockNodeExecutionsByNodeId: ReadonlySignal<Map<string, NodeExecution[]>>;
 
 const mockEventListeners = new Map<string, Array<(data: unknown) => void>>();
 const mockHub: { request: Mock; onEvent: Mock } = {
@@ -59,6 +68,8 @@ vi.mock('../../../lib/space-store', () => ({
 			workflowRuns: mockWorkflowRuns,
 			tasks: mockTasks,
 			tasksByRun: mockTasksByRun,
+			nodeExecutions: mockNodeExecutions,
+			nodeExecutionsByNodeId: mockNodeExecutionsByNodeId,
 		};
 	},
 }));
@@ -76,6 +87,19 @@ mockWorkflows = signal<SpaceWorkflow[]>([]);
 mockWorkflowRuns = signal<SpaceWorkflowRun[]>([]);
 mockTasks = signal<SpaceTask[]>([]);
 mockTasksByRun = signal<Map<string, SpaceTask[]>>(new Map());
+mockNodeExecutions = signal<NodeExecution[]>([]);
+mockNodeExecutionsByNodeId = computed(() => {
+	const map = new Map<string, NodeExecution[]>();
+	for (const exec of mockNodeExecutions.value) {
+		let arr = map.get(exec.workflowNodeId);
+		if (!arr) {
+			arr = [];
+			map.set(exec.workflowNodeId, arr);
+		}
+		arr.push(exec);
+	}
+	return map;
+});
 
 vi.mock('../../../lib/state.ts', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('../../../lib/state.ts')>();
@@ -160,6 +184,24 @@ function makeTask(overrides: Partial<SpaceTask> = {}): SpaceTask {
 	};
 }
 
+function makeNodeExecution(overrides: Partial<NodeExecution> = {}): NodeExecution {
+	return {
+		id: 'nexec-1',
+		workflowRunId: 'run-1',
+		workflowNodeId: 'n1',
+		agentName: 'Planner',
+		agentId: null,
+		agentSessionId: null,
+		status: 'pending',
+		result: null,
+		createdAt: 1000,
+		startedAt: null,
+		completedAt: null,
+		updatedAt: 2000,
+		...overrides,
+	};
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -170,6 +212,7 @@ describe('WorkflowCanvas', () => {
 		mockWorkflowRuns.value = [];
 		mockTasks.value = [];
 		mockTasksByRun.value = new Map();
+		mockNodeExecutions.value = [];
 		mockEventListeners.clear();
 		mockHub.request.mockReset();
 		mockHub.request.mockResolvedValue({ gateData: [] });
@@ -340,13 +383,11 @@ describe('WorkflowCanvas', () => {
 
 	// ---- Node status ----
 
-	it('renders active node with animate-pulse class when task is in_progress', () => {
+	it('renders active node with animate-pulse class when node execution is in_progress', () => {
 		const wf = makeWorkflow();
 		mockWorkflows.value = [wf];
 		mockWorkflowRuns.value = [makeRun()];
-		mockTasksByRun.value = new Map([
-			['run-1', [makeTask({ status: 'in_progress', workflowRunId: 'n1' })]],
-		]);
+		mockNodeExecutions.value = [makeNodeExecution({ workflowNodeId: 'n1', status: 'in_progress' })];
 		mockHub.request.mockResolvedValue({ gateData: [] });
 
 		const { getByTestId } = render(
@@ -360,7 +401,14 @@ describe('WorkflowCanvas', () => {
 		const wf = makeWorkflow();
 		mockWorkflows.value = [wf];
 		mockWorkflowRuns.value = [makeRun()];
-		mockTasksByRun.value = new Map([['run-1', [makeTask({ status: 'done' })]]]);
+		mockNodeExecutions.value = [
+			makeNodeExecution({
+				workflowNodeId: 'n2',
+				status: 'done',
+				startedAt: 1000,
+				completedAt: 2000,
+			}),
+		];
 		mockHub.request.mockResolvedValue({ gateData: [] });
 
 		const { getByTestId } = render(


### PR DESCRIPTION
## Summary

- Canvas `getNodeStatus()` was filtering tasks by `t.workflowRunId === node.id` which compared a run UUID against a node UUID — always empty, so nodes never showed active/done status
- Switched to `nodeExecutionsByNodeId` from the space store which correctly maps executions to workflow nodes via `workflowNodeId`
- Added dev-only `nodeExecution.create` RPC so E2E tests can seed in_progress executions
- Updated E2E reviewer-feedback-loop test to create node executions instead of tasks
- Updated unit tests with proper `nodeExecutionsByNodeId` mock

## Test plan

- [x] `WorkflowCanvas.test.tsx` — 41/41 passing
- [x] All quality checks pass (lint, typecheck, knip)
- [ ] E2E `features-reviewer-feedback-loop` should pass in CI