### PR TITLE
refactor(ui): redesign demo index page — clean nav, unique IDs, modular structure

### DIFF
--- a/packages/ui/demo/App.tsx
+++ b/packages/ui/demo/App.tsx
@@ -1,356 +1,308 @@
 import { useState, useEffect } from 'preact/hooks';
-import type { ComponentChildren } from 'preact';
-import { ChevronDown, ChevronRight, ChevronUp, Sun, Moon } from 'lucide-preact';
+import type { ComponentType } from 'preact';
+import { Sun, Moon } from 'lucide-preact';
+import { Sidebar } from './Sidebar.tsx';
+
+// ─── Headless component demos ─────────────────────────────────────────────────
 import { ButtonDemo } from './sections/ButtonDemo.tsx';
-import { CheckboxDemo } from './sections/CheckboxDemo.tsx';
-import { ComboboxDemo } from './sections/ComboboxDemo.tsx';
-import { DialogDemo } from './sections/DialogDemo.tsx';
-import { DisclosureDemo } from './sections/DisclosureDemo.tsx';
-import { FieldDemo } from './sections/FieldDemo.tsx';
 import { IconButtonDemo } from './sections/IconButtonDemo.tsx';
-import { InputDemo } from './sections/InputDemo.tsx';
-import { ListboxDemo } from './sections/ListboxDemo.tsx';
-import { MenuDemo } from './sections/MenuDemo.tsx';
-import { PopoverDemo } from './sections/PopoverDemo.tsx';
-import { RadioGroupDemo } from './sections/RadioGroupDemo.tsx';
-import { SkeletonDemo } from './sections/SkeletonDemo.tsx';
-import { SpinnerDemo } from './sections/SpinnerDemo.tsx';
+import { CheckboxDemo } from './sections/CheckboxDemo.tsx';
 import { SwitchDemo } from './sections/SwitchDemo.tsx';
-import { TabsDemo } from './sections/TabsDemo.tsx';
-import { ToastDemo } from './sections/ToastDemo.tsx';
-import { TooltipDemo } from './sections/TooltipDemo.tsx';
-import { TransitionDemo } from './sections/TransitionDemo.tsx';
+import { RadioGroupDemo } from './sections/RadioGroupDemo.tsx';
+import { InputDemo } from './sections/InputDemo.tsx';
+import { FieldDemo } from './sections/FieldDemo.tsx';
+import { DialogDemo } from './sections/DialogDemo.tsx';
 import { CommandPaletteDemo } from './sections/CommandPaletteDemo.tsx';
 import { DrawerDemo } from './sections/DrawerDemo.tsx';
+import { MenuDemo } from './sections/MenuDemo.tsx';
+import { DisclosureDemo } from './sections/DisclosureDemo.tsx';
+import { PopoverDemo } from './sections/PopoverDemo.tsx';
+import { TooltipDemo } from './sections/TooltipDemo.tsx';
+import { ToastDemo } from './sections/ToastDemo.tsx';
 import { NotificationDemo } from './sections/NotificationDemo.tsx';
-import { StatsDemo } from './sections/StatsDemo.tsx';
-import { GridListsDemo } from './sections/GridListsDemo.tsx';
-import { StackedListsDemo } from './sections/StackedListsDemo.tsx';
-import { TablesDemo } from './sections/TablesDemo.tsx';
-import { PaginationDemo } from './sections/PaginationDemo.tsx';
-import { ProgressBarsDemo } from './sections/ProgressBarsDemo.tsx';
-import { VerticalNavigationDemo } from './sections/VerticalNavigationDemo.tsx';
-import { BreadcrumbsDemo } from './sections/BreadcrumbsDemo.tsx';
-import { SidebarNavigationDemo } from './sections/SidebarNavigationDemo.tsx';
-import { CommandPalettesDemo } from './sections/navigation/CommandPalettesDemo.tsx';
-import { NavbarsDemo } from './sections/navigation/NavbarsDemo.tsx';
-import { EmptyStatesDemo } from './sections/EmptyStatesDemo.tsx';
-import { FeedsDemo } from './sections/FeedsDemo.tsx';
-import { CalendarsDemo } from './sections/CalendarsDemo.tsx';
-import { DescriptionListsDemo } from './sections/DescriptionListsDemo.tsx';
+import { TabsDemo } from './sections/TabsDemo.tsx';
+import { ListboxDemo } from './sections/ListboxDemo.tsx';
+import { ComboboxDemo } from './sections/ComboboxDemo.tsx';
+import { TransitionDemo } from './sections/TransitionDemo.tsx';
+import { SpinnerDemo } from './sections/SpinnerDemo.tsx';
+import { SkeletonDemo } from './sections/SkeletonDemo.tsx';
+
+// ─── Application UI demos — Application Shells ───────────────────────────────
 import { MultiColumnDemo } from './sections/MultiColumnDemo.tsx';
-import { AlertsDemo } from './sections/feedback/alerts/AlertsDemo.tsx';
+import { MultiColumnShellsDemo } from './sections/application-shells/multi-column/MultiColumnShellsDemo.tsx';
+import { SidebarShellsDemo } from './sections/application-shells/sidebar/SidebarShellsDemo.tsx';
+import { StackedShellsDemo } from './sections/application-shells/stacked/StackedShellsDemo.tsx';
+
+// ─── Application UI demos — Data Display ─────────────────────────────────────
+import { StatsDemo } from './sections/StatsDemo.tsx';
+import { CalendarsDemo } from './sections/CalendarsDemo.tsx';
+import { CalendarsHeadlessDemo } from './sections/data-display/calendars/CalendarsHeadlessDemo.tsx';
+import { DescriptionListsDemo } from './sections/DescriptionListsDemo.tsx';
+
+// ─── Application UI demos — Elements ─────────────────────────────────────────
 import { AvatarsDemo } from './sections/elements/avatars/AvatarsDemo.tsx';
 import { BadgesDemo } from './sections/elements/badges/BadgesDemo.tsx';
 import { ButtonsDemo } from './sections/elements/buttons/ButtonsDemo.tsx';
 import { ButtonGroupsDemo } from './sections/elements/button-groups/ButtonGroupsDemo.tsx';
+import { DropdownsDemo } from './sections/elements/dropdowns/DropdownsDemo.tsx';
+
+// ─── Application UI demos — Feedback ─────────────────────────────────────────
+import { AlertsDemo } from './sections/feedback/alerts/AlertsDemo.tsx';
+import { EmptyStatesDemo } from './sections/EmptyStatesDemo.tsx';
+
+// ─── Application UI demos — Forms ────────────────────────────────────────────
+import { FormLayoutsDemo } from './sections/forms/form-layouts/FormLayoutsDemo.tsx';
+import { InputGroupsDemo } from './sections/forms/input-groups/InputGroupsDemo.tsx';
+import { RadioGroupsDemo } from './sections/forms/radio-groups/RadioGroupsDemo.tsx';
+import { SelectMenusDemo } from './sections/forms/select-menus/SelectMenusDemo.tsx';
+import { CustomSelectMenusDemo } from './sections/forms/select-menus/CustomSelectMenusDemo.tsx';
+import { ComboboxesDemo } from './sections/forms/comboboxes/ComboboxesDemo.tsx';
+import { ActionPanelsDemo } from './sections/ActionPanelsDemo.tsx';
+import { CheckboxesDemo } from './sections/CheckboxesDemo.tsx';
+import { SignInFormsDemo } from './sections/SignInFormsDemo.tsx';
+import { TextareasDemo } from './sections/TextareasDemo.tsx';
+import { TogglesDemo } from './sections/TogglesDemo.tsx';
+
+// ─── Application UI demos — Headings ─────────────────────────────────────────
 import { CardHeadingsDemo } from './sections/headings/card-headings/CardHeadingsDemo.tsx';
 import { PageHeadingsDemo } from './sections/headings/page-headings/PageHeadingsDemo.tsx';
 import { SectionHeadingsDemo } from './sections/headings/section-headings/SectionHeadingsDemo.tsx';
+
+// ─── Application UI demos — Layout ───────────────────────────────────────────
 import { CardsDemo } from './sections/layout/cards/CardsDemo.tsx';
 import { ContainersDemo } from './sections/layout/containers/ContainersDemo.tsx';
 import { DividersDemo } from './sections/layout/dividers/DividersDemo.tsx';
 import { ListContainersDemo } from './sections/layout/list-containers/ListContainersDemo.tsx';
 import { MediaObjectsDemo } from './sections/layout/media-objects/MediaObjectsDemo.tsx';
-import { ActionPanelsDemo } from './sections/ActionPanelsDemo.tsx';
-import { CheckboxesDemo } from './sections/CheckboxesDemo.tsx';
-import { InputGroupsDemo } from './sections/forms/input-groups/InputGroupsDemo.tsx';
-import { RadioGroupsDemo } from './sections/forms/radio-groups/RadioGroupsDemo.tsx';
-import { SignInFormsDemo } from './sections/SignInFormsDemo.tsx';
-import { TextareasDemo } from './sections/TextareasDemo.tsx';
-import { TogglesDemo } from './sections/TogglesDemo.tsx';
-import { FormLayoutsDemo } from './sections/forms/form-layouts/FormLayoutsDemo.tsx';
-import { SelectMenusDemo } from './sections/forms/select-menus/SelectMenusDemo.tsx';
-import { ComboboxesDemo } from './sections/forms/comboboxes/ComboboxesDemo.tsx';
-import { CustomSelectMenusDemo } from './sections/forms/select-menus/CustomSelectMenusDemo.tsx';
-import { MultiColumnShellsDemo } from './sections/application-shells/multi-column/MultiColumnShellsDemo.tsx';
-import { SidebarShellsDemo } from './sections/application-shells/sidebar/SidebarShellsDemo.tsx';
-import { StackedShellsDemo } from './sections/application-shells/stacked/StackedShellsDemo.tsx';
-import { DropdownsDemo } from './sections/elements/dropdowns/DropdownsDemo.tsx';
-import { CalendarsHeadlessDemo } from './sections/data-display/calendars/CalendarsHeadlessDemo.tsx';
+
+// ─── Application UI demos — Lists ────────────────────────────────────────────
+import { FeedsDemo } from './sections/FeedsDemo.tsx';
+import { GridListsDemo } from './sections/GridListsDemo.tsx';
+import { StackedListsDemo } from './sections/StackedListsDemo.tsx';
+import { TablesDemo } from './sections/TablesDemo.tsx';
+
+// ─── Application UI demos — Navigation ───────────────────────────────────────
+import { BreadcrumbsDemo } from './sections/BreadcrumbsDemo.tsx';
+import { CommandPalettesDemo } from './sections/navigation/CommandPalettesDemo.tsx';
+import { NavbarsDemo } from './sections/navigation/NavbarsDemo.tsx';
+import { PaginationDemo } from './sections/PaginationDemo.tsx';
+import { ProgressBarsDemo } from './sections/ProgressBarsDemo.tsx';
+import { SidebarNavigationDemo } from './sections/SidebarNavigationDemo.tsx';
+import { VerticalNavigationDemo } from './sections/VerticalNavigationDemo.tsx';
+
+// ─── Application UI demos — Overlays ─────────────────────────────────────────
 import { DrawersDemo } from './sections/overlays/DrawersDemo.tsx';
 import { ModalDialogsDemo } from './sections/overlays/ModalDialogsDemo.tsx';
+
+// ─── Application UI demos — Page Examples ────────────────────────────────────
 import { DetailScreensDemo } from './sections/DetailScreensDemo.tsx';
 import { HomeScreensDemo } from './sections/HomeScreensDemo.tsx';
 import { SettingsScreensDemo } from './sections/SettingsScreensDemo.tsx';
 
-interface DemoSectionProps {
+// ─── Section registry ─────────────────────────────────────────────────────────
+
+interface SectionDef {
 	id: string;
 	title: string;
-	children: ComponentChildren;
+	Component: ComponentType;
 }
 
-function DemoSection({ id, title, children }: DemoSectionProps) {
-	return (
-		<section id={id} class="py-12 border-b border-surface-border">
-			<h2 class="text-2xl font-bold mb-6">{title}</h2>
-			{children}
-		</section>
-	);
-}
+const sections: SectionDef[] = [
+	// Headless Components
+	{ id: 'hc-button', title: 'Button', Component: ButtonDemo },
+	{ id: 'hc-icon-button', title: 'IconButton', Component: IconButtonDemo },
+	{ id: 'hc-checkbox', title: 'Checkbox', Component: CheckboxDemo },
+	{ id: 'hc-switch', title: 'Switch', Component: SwitchDemo },
+	{ id: 'hc-radio-group', title: 'RadioGroup', Component: RadioGroupDemo },
+	{ id: 'hc-input', title: 'Input', Component: InputDemo },
+	{ id: 'hc-field', title: 'Field', Component: FieldDemo },
+	{ id: 'hc-dialog', title: 'Dialog', Component: DialogDemo },
+	{
+		id: 'hc-command-palette',
+		title: 'Command Palette (Dialog + Combobox)',
+		Component: CommandPaletteDemo,
+	},
+	{ id: 'hc-drawer', title: 'Drawer', Component: DrawerDemo },
+	{ id: 'hc-menu', title: 'Menu', Component: MenuDemo },
+	{ id: 'hc-disclosure', title: 'Disclosure', Component: DisclosureDemo },
+	{ id: 'hc-popover', title: 'Popover', Component: PopoverDemo },
+	{ id: 'hc-tooltip', title: 'Tooltip', Component: TooltipDemo },
+	{ id: 'hc-toast', title: 'Toast', Component: ToastDemo },
+	{
+		id: 'hc-notification',
+		title: 'Notification (Toast Variants)',
+		Component: NotificationDemo,
+	},
+	{ id: 'hc-tabs', title: 'Tabs', Component: TabsDemo },
+	{ id: 'hc-listbox', title: 'Listbox', Component: ListboxDemo },
+	{ id: 'hc-combobox', title: 'Combobox', Component: ComboboxDemo },
+	{ id: 'hc-transition', title: 'Transition', Component: TransitionDemo },
+	{ id: 'hc-spinner', title: 'Spinner', Component: SpinnerDemo },
+	{ id: 'hc-skeleton', title: 'Skeleton', Component: SkeletonDemo },
 
-// Component category (existing demos)
-const componentSections = [
-	{ id: 'button', label: 'Button' },
-	{ id: 'icon-button', label: 'IconButton' },
-	{ id: 'checkbox', label: 'Checkbox' },
-	{ id: 'switch', label: 'Switch' },
-	{ id: 'radio-group', label: 'RadioGroup' },
-	{ id: 'input', label: 'Input' },
-	{ id: 'field', label: 'Field' },
-	{ id: 'dialog', label: 'Dialog' },
-	{ id: 'command-palette', label: 'Command Palette' },
-	{ id: 'drawer', label: 'Drawer' },
-	{ id: 'menu', label: 'Menu' },
-	{ id: 'disclosure', label: 'Disclosure' },
-	{ id: 'popover', label: 'Popover' },
-	{ id: 'tooltip', label: 'Tooltip' },
-	{ id: 'toast', label: 'Toast' },
-	{ id: 'notification', label: 'Notification' },
-	{ id: 'tabs', label: 'Tabs' },
-	{ id: 'listbox', label: 'Listbox' },
-	{ id: 'combobox', label: 'Combobox' },
-	{ id: 'transition', label: 'Transition' },
-	{ id: 'spinner', label: 'Spinner' },
-	{ id: 'skeleton', label: 'Skeleton' },
-	{ id: 'stats', label: 'Stats' },
-	{ id: 'grid-lists', label: 'Grid Lists' },
-	{ id: 'stacked-lists', label: 'Stacked Lists' },
-	{ id: 'tables', label: 'Tables' },
-	{ id: 'pagination', label: 'Pagination' },
-	{ id: 'progress-bars', label: 'Progress Bars' },
-	{ id: 'vertical-navigation', label: 'Vertical Navigation' },
-	{ id: 'breadcrumbs', label: 'Breadcrumbs' },
-	{ id: 'sidebar-navigation', label: 'Sidebar Navigation' },
-	{ id: 'feeds', label: 'Feeds' },
-	{ id: 'empty-states', label: 'Empty States' },
+	// Application UI — Application Shells
+	{
+		id: 'ui-appshells-multi-column',
+		title: 'Application Shells / Multi-column',
+		Component: MultiColumnDemo,
+	},
+	{
+		id: 'ui-appshells-multi-column-shells',
+		title: 'Application Shells / Multi-column (Headless)',
+		Component: MultiColumnShellsDemo,
+	},
+	{
+		id: 'ui-appshells-sidebar',
+		title: 'Application Shells / Sidebar (Headless)',
+		Component: SidebarShellsDemo,
+	},
+	{
+		id: 'ui-appshells-stacked',
+		title: 'Application Shells / Stacked (Headless)',
+		Component: StackedShellsDemo,
+	},
+
+	// Application UI — Data Display
+	{ id: 'ui-data-display-stats', title: 'Data Display / Stats', Component: StatsDemo },
+	{ id: 'ui-data-display-calendars', title: 'Data Display / Calendars', Component: CalendarsDemo },
+	{
+		id: 'ui-data-display-calendars-hl',
+		title: 'Data Display / Calendars (Headless)',
+		Component: CalendarsHeadlessDemo,
+	},
+	{
+		id: 'ui-data-display-description-lists',
+		title: 'Data Display / Description Lists',
+		Component: DescriptionListsDemo,
+	},
+
+	// Application UI — Elements
+	{ id: 'ui-elements-avatars', title: 'Elements / Avatars', Component: AvatarsDemo },
+	{ id: 'ui-elements-badges', title: 'Elements / Badges', Component: BadgesDemo },
+	{ id: 'ui-elements-buttons', title: 'Elements / Buttons', Component: ButtonsDemo },
+	{
+		id: 'ui-elements-button-groups',
+		title: 'Elements / Button Groups',
+		Component: ButtonGroupsDemo,
+	},
+	{ id: 'ui-elements-dropdowns', title: 'Elements / Dropdowns', Component: DropdownsDemo },
+
+	// Application UI — Feedback
+	{ id: 'ui-feedback-alerts', title: 'Feedback / Alerts', Component: AlertsDemo },
+	{ id: 'ui-feedback-empty-states', title: 'Feedback / Empty States', Component: EmptyStatesDemo },
+
+	// Application UI — Forms
+	{ id: 'ui-forms-form-layouts', title: 'Forms / Form Layouts', Component: FormLayoutsDemo },
+	{ id: 'ui-forms-input-groups', title: 'Forms / Input Groups', Component: InputGroupsDemo },
+	{ id: 'ui-forms-radio-groups', title: 'Forms / Radio Groups', Component: RadioGroupsDemo },
+	{ id: 'ui-forms-select-menus', title: 'Forms / Select Menus', Component: SelectMenusDemo },
+	{
+		id: 'ui-forms-select-menus-hl',
+		title: 'Forms / Select Menus (Headless)',
+		Component: CustomSelectMenusDemo,
+	},
+	{ id: 'ui-forms-comboboxes', title: 'Forms / Comboboxes', Component: ComboboxesDemo },
+	{ id: 'ui-forms-action-panels', title: 'Forms / Action Panels', Component: ActionPanelsDemo },
+	{ id: 'ui-forms-checkboxes', title: 'Forms / Checkboxes', Component: CheckboxesDemo },
+	{ id: 'ui-forms-sign-in-forms', title: 'Forms / Sign-in Forms', Component: SignInFormsDemo },
+	{ id: 'ui-forms-textareas', title: 'Forms / Textareas', Component: TextareasDemo },
+	{ id: 'ui-forms-toggles', title: 'Forms / Toggles', Component: TogglesDemo },
+
+	// Application UI — Headings
+	{
+		id: 'ui-headings-card-headings',
+		title: 'Headings / Card Headings',
+		Component: CardHeadingsDemo,
+	},
+	{
+		id: 'ui-headings-page-headings',
+		title: 'Headings / Page Headings',
+		Component: PageHeadingsDemo,
+	},
+	{
+		id: 'ui-headings-section-headings',
+		title: 'Headings / Section Headings',
+		Component: SectionHeadingsDemo,
+	},
+
+	// Application UI — Layout
+	{ id: 'ui-layout-cards', title: 'Layout / Cards', Component: CardsDemo },
+	{ id: 'ui-layout-containers', title: 'Layout / Containers', Component: ContainersDemo },
+	{ id: 'ui-layout-dividers', title: 'Layout / Dividers', Component: DividersDemo },
+	{
+		id: 'ui-layout-list-containers',
+		title: 'Layout / List Containers',
+		Component: ListContainersDemo,
+	},
+	{
+		id: 'ui-layout-media-objects',
+		title: 'Layout / Media Objects',
+		Component: MediaObjectsDemo,
+	},
+
+	// Application UI — Lists
+	{ id: 'ui-lists-feeds', title: 'Lists / Feeds', Component: FeedsDemo },
+	{ id: 'ui-lists-grid-lists', title: 'Lists / Grid Lists', Component: GridListsDemo },
+	{ id: 'ui-lists-stacked-lists', title: 'Lists / Stacked Lists', Component: StackedListsDemo },
+	{ id: 'ui-lists-tables', title: 'Lists / Tables', Component: TablesDemo },
+
+	// Application UI — Navigation
+	{ id: 'ui-nav-breadcrumbs', title: 'Navigation / Breadcrumbs', Component: BreadcrumbsDemo },
+	{
+		id: 'ui-nav-command-palettes',
+		title: 'Navigation / Command Palettes',
+		Component: CommandPalettesDemo,
+	},
+	{ id: 'ui-nav-navbars', title: 'Navigation / Navbars', Component: NavbarsDemo },
+	{ id: 'ui-nav-pagination', title: 'Navigation / Pagination', Component: PaginationDemo },
+	{
+		id: 'ui-nav-progress-bars',
+		title: 'Navigation / Progress Bars',
+		Component: ProgressBarsDemo,
+	},
+	{
+		id: 'ui-nav-sidebar-navigation',
+		title: 'Navigation / Sidebar Navigation',
+		Component: SidebarNavigationDemo,
+	},
+	{
+		id: 'ui-nav-vertical-navigation',
+		title: 'Navigation / Vertical Navigation',
+		Component: VerticalNavigationDemo,
+	},
+
+	// Application UI — Overlays
+	{ id: 'ui-overlays-drawers', title: 'Overlays / Drawers', Component: DrawersDemo },
+	{
+		id: 'ui-overlays-modal-dialogs',
+		title: 'Overlays / Modal Dialogs',
+		Component: ModalDialogsDemo,
+	},
+	{
+		id: 'ui-overlays-notifications',
+		title: 'Overlays / Notifications',
+		Component: NotificationDemo,
+	},
+
+	// Application UI — Page Examples
+	{
+		id: 'ui-pages-detail-screens',
+		title: 'Page Examples / Detail Screens',
+		Component: DetailScreensDemo,
+	},
+	{
+		id: 'ui-pages-home-screens',
+		title: 'Page Examples / Home Screens',
+		Component: HomeScreensDemo,
+	},
+	{
+		id: 'ui-pages-settings-screens',
+		title: 'Page Examples / Settings Screens',
+		Component: SettingsScreensDemo,
+	},
 ];
 
-// Application UI subcategories
-interface SidebarSection {
-	id: string;
-	label: string;
-	// href overrides the auto-generated `#${category.id}-${section.id}` anchor.
-	// Use when the DemoSection ID uses a plain (non-prefixed) ID shared with the Components section.
-	href?: string;
-}
-
-interface SidebarCategory {
-	id: string;
-	label: string;
-	sections: SidebarSection[];
-}
-
-const applicationUiCategories: SidebarCategory[] = [
-	{
-		id: 'application-shells',
-		label: 'Application Shells',
-		sections: [
-			{ id: 'multi-column', label: 'Multi-column' },
-			{ id: 'multi-column-shells', label: 'Multi-column (Headless+Icon)' },
-			{ id: 'sidebar', label: 'Sidebar' },
-			{ id: 'stacked', label: 'Stacked' },
-		],
-	},
-	{
-		id: 'data-display',
-		label: 'Data Display',
-		sections: [
-			{ id: 'calendars', label: 'Calendars' },
-			{ id: 'calendars-headless', label: 'Calendars (Headless+Icon)' },
-			{ id: 'description-lists', label: 'Description Lists' },
-			// DemoSection uses plain id="stats" (shared with Components section)
-			{ id: 'stats', label: 'Stats', href: 'stats' },
-		],
-	},
-	{
-		id: 'elements',
-		label: 'Elements',
-		sections: [
-			{ id: 'avatars', label: 'Avatars' },
-			{ id: 'badges', label: 'Badges' },
-			{ id: 'button-groups', label: 'Button Groups' },
-			{ id: 'buttons', label: 'Buttons' },
-			{ id: 'dropdowns', label: 'Dropdowns' },
-		],
-	},
-	{
-		id: 'feedback',
-		label: 'Feedback',
-		sections: [
-			{ id: 'alerts', label: 'Alerts' },
-			// DemoSection uses plain id="empty-states" (shared with Components section)
-			{ id: 'empty-states', label: 'Empty States', href: 'empty-states' },
-		],
-	},
-	{
-		id: 'forms',
-		label: 'Forms',
-		sections: [
-			{ id: 'action-panels', label: 'Action Panels' },
-			{ id: 'checkboxes', label: 'Checkboxes' },
-			{ id: 'comboboxes', label: 'Comboboxes' },
-			{ id: 'form-layouts', label: 'Form Layouts' },
-			{ id: 'input-groups', label: 'Input Groups' },
-			{ id: 'radio-groups', label: 'Radio Groups' },
-			{ id: 'select-menus', label: 'Select Menus' },
-			{ id: 'select-menus-headless', label: 'Select Menus (Headless+Icon)' },
-			{ id: 'sign-in-forms', label: 'Sign-in Forms' },
-			{ id: 'textareas', label: 'Textareas' },
-			{ id: 'toggles', label: 'Toggles' },
-		],
-	},
-	{
-		id: 'headings',
-		label: 'Headings',
-		sections: [
-			{ id: 'card-headings', label: 'Card Headings' },
-			{ id: 'page-headings', label: 'Page Headings' },
-			{ id: 'section-headings', label: 'Section Headings' },
-		],
-	},
-	{
-		id: 'layout',
-		label: 'Layout',
-		sections: [
-			{ id: 'cards', label: 'Cards' },
-			{ id: 'containers', label: 'Containers' },
-			{ id: 'dividers', label: 'Dividers' },
-			{ id: 'list-containers', label: 'List Containers' },
-			{ id: 'media-objects', label: 'Media Objects' },
-		],
-	},
-	{
-		id: 'lists',
-		label: 'Lists',
-		// These DemoSections use plain IDs shared with the Components section
-		sections: [
-			{ id: 'feeds', label: 'Feeds', href: 'feeds' },
-			{ id: 'grid-lists', label: 'Grid Lists', href: 'grid-lists' },
-			{ id: 'stacked-lists', label: 'Stacked Lists', href: 'stacked-lists' },
-			{ id: 'tables', label: 'Tables', href: 'tables' },
-		],
-	},
-	{
-		id: 'navigation',
-		label: 'Navigation',
-		sections: [
-			// These DemoSections use plain IDs shared with the Components section
-			{ id: 'breadcrumbs', label: 'Breadcrumbs', href: 'breadcrumbs' },
-			{ id: 'command-palettes', label: 'Command Palettes' },
-			{ id: 'navbars', label: 'Navbars' },
-			{ id: 'pagination', label: 'Pagination', href: 'pagination' },
-			{ id: 'progress-bars', label: 'Progress Bars', href: 'progress-bars' },
-			{ id: 'sidebar-navigation', label: 'Sidebar Navigation', href: 'sidebar-navigation' },
-			{ id: 'tabs', label: 'Tabs', href: 'tabs' },
-			{ id: 'vertical-navigation', label: 'Vertical Navigation', href: 'vertical-navigation' },
-		],
-	},
-	{
-		id: 'overlays',
-		label: 'Overlays',
-		sections: [
-			{ id: 'drawers', label: 'Drawers' },
-			{ id: 'modal-dialogs', label: 'Modal Dialogs' },
-			{ id: 'notifications', label: 'Notifications' },
-		],
-	},
-	{
-		id: 'page-examples',
-		label: 'Page Examples',
-		sections: [
-			{ id: 'detail-screens', label: 'Detail Screens' },
-			{ id: 'home-screens', label: 'Home Screens' },
-			{ id: 'settings-screens', label: 'Settings Screens' },
-		],
-	},
-];
-
-interface CategoryProps {
-	category: SidebarCategory;
-	forceOpen?: boolean;
-	activeSection: string;
-	searchQuery: string;
-}
-
-function Category({ category, forceOpen, activeSection, searchQuery }: CategoryProps) {
-	const [isOpen, setIsOpen] = useState(false);
-	// Tracks whether the user has explicitly collapsed this category to prevent auto-reopen
-	const [userCollapsed, setUserCollapsed] = useState(false);
-
-	// Resolve the actual anchor id for a section (uses href override when set)
-	function sectionAnchorId(section: SidebarSection): string {
-		return section.href ?? `${category.id}-${section.id}`;
-	}
-
-	// This category contains the currently visible section
-	const hasActiveSection = category.sections.some((s) => sectionAnchorId(s) === activeSection);
-
-	// When auto-open conditions go away, clear the user-collapsed flag so the next
-	// time the section becomes active it auto-expands again
-	const autoOpen = hasActiveSection || (forceOpen ?? false);
-	useEffect(() => {
-		if (!autoOpen) {
-			setUserCollapsed(false);
-		}
-	}, [autoOpen]);
-
-	// Open if: explicitly opened by user OR (auto-open AND user hasn't explicitly closed it)
-	const shouldBeOpen = isOpen || (autoOpen && !userCollapsed);
-
-	function toggle() {
-		if (shouldBeOpen) {
-			setIsOpen(false);
-			setUserCollapsed(true);
-		} else {
-			setIsOpen(true);
-			setUserCollapsed(false);
-		}
-	}
-
-	return (
-		<li>
-			<button
-				type="button"
-				onClick={toggle}
-				class="flex items-center w-full px-3 py-2 text-sm font-medium text-text-secondary hover:text-text-primary hover:bg-surface-2 rounded transition-colors cursor-pointer"
-			>
-				{shouldBeOpen ? (
-					<ChevronDown class="w-4 h-4 mr-2 flex-shrink-0" />
-				) : (
-					<ChevronRight class="w-4 h-4 mr-2 flex-shrink-0" />
-				)}
-				{category.label}
-			</button>
-			{shouldBeOpen && (
-				<ul class="ml-4 mt-1 space-y-0.5 border-l border-surface-border pl-2">
-					{category.sections.map((section) => {
-						const anchorId = sectionAnchorId(section);
-						const isActive = anchorId === activeSection;
-						// When searching, only show sections whose label matches (not the category name)
-						const matchesSearch =
-							searchQuery === '' || section.label.toLowerCase().includes(searchQuery.toLowerCase());
-						if (!matchesSearch) return null;
-						return (
-							<li key={section.id}>
-								<a
-									href={`#${anchorId}`}
-									class={`block px-3 py-1.5 text-xs rounded transition-colors ${
-										isActive
-											? 'text-text-primary bg-surface-2 font-medium'
-											: 'text-text-tertiary hover:text-text-primary hover:bg-surface-2'
-									}`}
-								>
-									{section.label}
-								</a>
-							</li>
-						);
-					})}
-				</ul>
-			)}
-		</li>
-	);
-}
+// ─── App ──────────────────────────────────────────────────────────────────────
 
 export function App() {
 	const [theme, setTheme] = useState<'dark' | 'light'>('dark');
@@ -367,10 +319,10 @@ export function App() {
 		}
 	}
 
+	// Scroll-spy: track which section is most visible
 	useEffect(() => {
 		const visibleSections = new Map<string, number>();
 
-		// Use a local variable — no need for a ref since the cleanup closure captures it
 		const observer = new IntersectionObserver(
 			(entries) => {
 				for (const entry of entries) {
@@ -381,7 +333,6 @@ export function App() {
 					}
 				}
 
-				// Pick the section with the highest intersection ratio
 				let bestId = '';
 				let bestRatio = 0;
 				for (const [id, ratio] of visibleSections) {
@@ -390,112 +341,25 @@ export function App() {
 						bestId = id;
 					}
 				}
-				// Clear highlight when no section is in the reading zone
 				setActiveSection(bestId);
 			},
 			{ rootMargin: '-20% 0px -70% 0px', threshold: [0, 0.1, 0.5, 1.0] }
 		);
 
-		const sections = document.querySelectorAll('section[id]');
-		for (const section of sections) {
-			observer.observe(section);
-		}
+		const sectionEls = document.querySelectorAll('section[id]');
+		for (const el of sectionEls) observer.observe(el);
 
-		return () => {
-			observer.disconnect();
-		};
+		return () => observer.disconnect();
 	}, []);
-
-	// Filter component sections by search query
-	const filteredComponentSections =
-		searchQuery === ''
-			? componentSections
-			: componentSections.filter((s) => s.label.toLowerCase().includes(searchQuery.toLowerCase()));
-
-	// Filter application UI categories by search query.
-	// Only match against section labels — category-name-only matches produce empty section lists.
-	const filteredCategories =
-		searchQuery === ''
-			? applicationUiCategories
-			: applicationUiCategories.filter((cat) =>
-					cat.sections.some((s) => s.label.toLowerCase().includes(searchQuery.toLowerCase()))
-				);
 
 	return (
 		<div class="min-h-screen bg-surface-0 text-text-primary">
-			{/* Sidebar */}
-			<nav class="fixed left-0 top-0 w-64 h-screen overflow-y-auto bg-surface-1 border-r border-surface-border z-10 flex flex-col">
-				<div class="p-4 flex-1">
-					{/* Search input */}
-					<div class="mb-4">
-						<input
-							type="search"
-							placeholder="Filter..."
-							value={searchQuery}
-							onInput={(e) => setSearchQuery((e.target as HTMLInputElement).value)}
-							class="w-full px-3 py-1.5 text-sm bg-surface-2 border border-surface-border rounded text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-1 focus:ring-surface-border"
-						/>
-					</div>
+			<Sidebar
+				activeSection={activeSection}
+				searchQuery={searchQuery}
+				setSearchQuery={setSearchQuery}
+			/>
 
-					{/* Components section */}
-					<div class="mb-6">
-						<p class="px-3 text-xs font-semibold uppercase tracking-wider text-text-tertiary mb-2">
-							Components
-						</p>
-						<ul class="space-y-0.5">
-							{filteredComponentSections.map((s) => {
-								const isActive = s.id === activeSection;
-								return (
-									<li key={s.id}>
-										<a
-											href={`#${s.id}`}
-											class={`block px-3 py-1.5 text-sm rounded transition-colors ${
-												isActive
-													? 'text-text-primary bg-surface-2 font-medium'
-													: 'text-text-secondary hover:text-text-primary hover:bg-surface-2'
-											}`}
-										>
-											{s.label}
-										</a>
-									</li>
-								);
-							})}
-						</ul>
-					</div>
-
-					{/* Application UI section */}
-					<div>
-						<p class="px-3 text-xs font-semibold uppercase tracking-wider text-text-tertiary mb-2">
-							Application UI
-						</p>
-						<ul class="space-y-1">
-							{filteredCategories.map((category) => (
-								<Category
-									key={category.id}
-									category={category}
-									forceOpen={searchQuery !== ''}
-									activeSection={activeSection}
-									searchQuery={searchQuery}
-								/>
-							))}
-						</ul>
-					</div>
-				</div>
-
-				{/* Scroll to top button */}
-				<div class="p-2 border-t border-surface-border">
-					<button
-						type="button"
-						onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-						class="w-full flex items-center justify-center gap-1 px-3 py-2 text-xs text-text-tertiary hover:text-text-primary hover:bg-surface-2 rounded transition-colors cursor-pointer"
-					>
-						<ChevronUp class="w-3 h-3" />
-						Scroll to top
-					</button>
-				</div>
-			</nav>
-
-			{/* Content */}
 			<div class="ml-64">
 				{/* Header */}
 				<header class="px-8 pt-10 pb-4 border-b border-surface-border flex items-start justify-between">
@@ -527,256 +391,14 @@ export function App() {
 					</div>
 				</header>
 
-				{/* Main */}
+				{/* Main content — all sections rendered from the registry */}
 				<main class="px-8 max-w-6xl">
-					<DemoSection id="button" title="Button">
-						<ButtonDemo />
-					</DemoSection>
-					<DemoSection id="icon-button" title="IconButton">
-						<IconButtonDemo />
-					</DemoSection>
-					<DemoSection id="checkbox" title="Checkbox">
-						<CheckboxDemo />
-					</DemoSection>
-					<DemoSection id="switch" title="Switch">
-						<SwitchDemo />
-					</DemoSection>
-					<DemoSection id="radio-group" title="RadioGroup">
-						<RadioGroupDemo />
-					</DemoSection>
-					<DemoSection id="input" title="Input">
-						<InputDemo />
-					</DemoSection>
-					<DemoSection id="field" title="Field">
-						<FieldDemo />
-					</DemoSection>
-					<DemoSection id="dialog" title="Dialog">
-						<DialogDemo />
-					</DemoSection>
-					<DemoSection id="command-palette" title="Command Palette (Dialog + Combobox)">
-						<CommandPaletteDemo />
-					</DemoSection>
-					<DemoSection id="drawer" title="Drawer">
-						<DrawerDemo />
-					</DemoSection>
-					<DemoSection id="menu" title="Menu">
-						<MenuDemo />
-					</DemoSection>
-					<DemoSection id="disclosure" title="Disclosure">
-						<DisclosureDemo />
-					</DemoSection>
-					<DemoSection id="popover" title="Popover">
-						<PopoverDemo />
-					</DemoSection>
-					<DemoSection id="tooltip" title="Tooltip">
-						<TooltipDemo />
-					</DemoSection>
-					<DemoSection id="toast" title="Toast">
-						<ToastDemo />
-					</DemoSection>
-					<DemoSection id="notification" title="Notification (Toast Variants)">
-						<NotificationDemo />
-					</DemoSection>
-					<DemoSection id="tabs" title="Tabs">
-						<TabsDemo />
-					</DemoSection>
-					<DemoSection id="listbox" title="Listbox">
-						<ListboxDemo />
-					</DemoSection>
-					<DemoSection id="combobox" title="Combobox">
-						<ComboboxDemo />
-					</DemoSection>
-					<DemoSection id="transition" title="Transition">
-						<TransitionDemo />
-					</DemoSection>
-					<DemoSection id="spinner" title="Spinner">
-						<SpinnerDemo />
-					</DemoSection>
-					<DemoSection id="skeleton" title="Skeleton">
-						<SkeletonDemo />
-					</DemoSection>
-					<DemoSection id="stats" title="Stats">
-						<StatsDemo />
-					</DemoSection>
-					<DemoSection id="grid-lists" title="Grid Lists">
-						<GridListsDemo />
-					</DemoSection>
-					<DemoSection id="stacked-lists" title="Stacked Lists">
-						<StackedListsDemo />
-					</DemoSection>
-					<DemoSection id="tables" title="Tables">
-						<TablesDemo />
-					</DemoSection>
-					<DemoSection id="pagination" title="Pagination">
-						<PaginationDemo />
-					</DemoSection>
-					<DemoSection id="progress-bars" title="Progress Bars">
-						<ProgressBarsDemo />
-					</DemoSection>
-					<DemoSection id="vertical-navigation" title="Vertical Navigation">
-						<VerticalNavigationDemo />
-					</DemoSection>
-					<DemoSection id="breadcrumbs" title="Breadcrumbs">
-						<BreadcrumbsDemo />
-					</DemoSection>
-					<DemoSection id="sidebar-navigation" title="Sidebar Navigation">
-						<SidebarNavigationDemo />
-					</DemoSection>
-					<DemoSection id="feeds" title="Feeds">
-						<FeedsDemo />
-					</DemoSection>
-					<DemoSection id="empty-states" title="Empty States">
-						<EmptyStatesDemo />
-					</DemoSection>
-					{/* Application UI - Feedback */}
-					<DemoSection id="feedback-alerts" title="Feedback / Alerts">
-						<AlertsDemo />
-					</DemoSection>
-
-					{/* Application UI - Elements */}
-					<DemoSection id="elements-avatars" title="Elements / Avatars">
-						<AvatarsDemo />
-					</DemoSection>
-					<DemoSection id="elements-badges" title="Elements / Badges">
-						<BadgesDemo />
-					</DemoSection>
-					<DemoSection id="elements-buttons" title="Elements / Buttons">
-						<ButtonsDemo />
-					</DemoSection>
-					<DemoSection id="elements-button-groups" title="Elements / Button Groups">
-						<ButtonGroupsDemo />
-					</DemoSection>
-
-					{/* Application UI - Headings */}
-					<DemoSection id="headings-card-headings" title="Headings / Card Headings">
-						<CardHeadingsDemo />
-					</DemoSection>
-					<DemoSection id="headings-page-headings" title="Headings / Page Headings">
-						<PageHeadingsDemo />
-					</DemoSection>
-					<DemoSection id="headings-section-headings" title="Headings / Section Headings">
-						<SectionHeadingsDemo />
-					</DemoSection>
-
-					{/* Application UI - Layout */}
-					<DemoSection id="layout-cards" title="Layout / Cards">
-						<CardsDemo />
-					</DemoSection>
-					<DemoSection id="layout-containers" title="Layout / Containers">
-						<ContainersDemo />
-					</DemoSection>
-					<DemoSection id="layout-dividers" title="Layout / Dividers">
-						<DividersDemo />
-					</DemoSection>
-					<DemoSection id="layout-list-containers" title="Layout / List Containers">
-						<ListContainersDemo />
-					</DemoSection>
-					<DemoSection id="layout-media-objects" title="Layout / Media Objects">
-						<MediaObjectsDemo />
-					</DemoSection>
-
-					{/* Application UI - Forms */}
-					<DemoSection id="forms-form-layouts" title="Forms / Form Layouts">
-						<FormLayoutsDemo />
-					</DemoSection>
-					<DemoSection id="forms-input-groups" title="Forms / Input Groups">
-						<InputGroupsDemo />
-					</DemoSection>
-					<DemoSection id="forms-radio-groups" title="Forms / Radio Groups">
-						<RadioGroupsDemo />
-					</DemoSection>
-					<DemoSection id="forms-select-menus" title="Forms / Select Menus">
-						<SelectMenusDemo />
-					</DemoSection>
-					<DemoSection id="forms-action-panels" title="Forms / Action Panels">
-						<ActionPanelsDemo />
-					</DemoSection>
-					<DemoSection id="forms-checkboxes" title="Forms / Checkboxes">
-						<CheckboxesDemo />
-					</DemoSection>
-					<DemoSection id="forms-sign-in-forms" title="Forms / Sign-in Forms">
-						<SignInFormsDemo />
-					</DemoSection>
-					<DemoSection id="forms-textareas" title="Forms / Textareas">
-						<TextareasDemo />
-					</DemoSection>
-					<DemoSection id="forms-toggles" title="Forms / Toggles">
-						<TogglesDemo />
-					</DemoSection>
-
-					{/* Application UI - Application Shells */}
-					<DemoSection
-						id="application-shells-multi-column"
-						title="Multi-column (Application Shell)"
-					>
-						<MultiColumnDemo />
-					</DemoSection>
-					<DemoSection
-						id="application-shells-multi-column-shells"
-						title="Multi-column Shells (Headless+Icon)"
-					>
-						<MultiColumnShellsDemo />
-					</DemoSection>
-					<DemoSection id="application-shells-sidebar" title="Sidebar Shells (Headless+Icon)">
-						<SidebarShellsDemo />
-					</DemoSection>
-					<DemoSection id="application-shells-stacked" title="Stacked Shells (Headless+Icon)">
-						<StackedShellsDemo />
-					</DemoSection>
-
-					{/* Application UI - Forms / Comboboxes */}
-					<DemoSection id="forms-comboboxes" title="Comboboxes (Headless+Icon)">
-						<ComboboxesDemo />
-					</DemoSection>
-					<DemoSection id="forms-select-menus-headless" title="Custom Select Menus (Headless+Icon)">
-						<CustomSelectMenusDemo />
-					</DemoSection>
-
-					{/* Application UI - Elements / Dropdowns */}
-					<DemoSection id="elements-dropdowns" title="Dropdowns (Headless+Icon)">
-						<DropdownsDemo />
-					</DemoSection>
-
-					{/* Application UI - Navigation */}
-					<DemoSection id="navigation-command-palettes" title="Command Palettes (Navigation)">
-						<CommandPalettesDemo />
-					</DemoSection>
-					<DemoSection id="navigation-navbars" title="Navbars (Navigation)">
-						<NavbarsDemo />
-					</DemoSection>
-
-					{/* Application UI - Data Display */}
-					<DemoSection id="data-display-calendars" title="Calendars (Data Display)">
-						<CalendarsDemo />
-					</DemoSection>
-					<DemoSection id="data-display-calendars-headless" title="Calendars (Headless+Icon)">
-						<CalendarsHeadlessDemo />
-					</DemoSection>
-					<DemoSection id="data-display-description-lists" title="Description Lists (Data Display)">
-						<DescriptionListsDemo />
-					</DemoSection>
-
-					{/* Application UI - Overlays */}
-					<DemoSection id="overlays-drawers" title="Overlays / Drawers">
-						<DrawersDemo />
-					</DemoSection>
-					<DemoSection id="overlays-modal-dialogs" title="Overlays / Modal Dialogs">
-						<ModalDialogsDemo />
-					</DemoSection>
-					<DemoSection id="overlays-notifications" title="Overlays / Notifications">
-						<NotificationDemo />
-					</DemoSection>
-
-					{/* Application UI - Page Examples */}
-					<DemoSection id="page-examples-detail-screens" title="Page Examples / Detail Screens">
-						<DetailScreensDemo />
-					</DemoSection>
-					<DemoSection id="page-examples-home-screens" title="Page Examples / Home Screens">
-						<HomeScreensDemo />
-					</DemoSection>
-					<DemoSection id="page-examples-settings-screens" title="Page Examples / Settings Screens">
-						<SettingsScreensDemo />
-					</DemoSection>
+					{sections.map(({ id, title, Component }) => (
+						<section key={id} id={id} class="py-12 border-b border-surface-border">
+							<h2 class="text-2xl font-bold mb-6">{title}</h2>
+							<Component />
+						</section>
+					))}
 				</main>
 			</div>
 		</div>

--- a/packages/ui/demo/App.tsx
+++ b/packages/ui/demo/App.tsx
@@ -1,311 +1,17 @@
 import { useState, useEffect } from 'preact/hooks';
-import type { ComponentType } from 'preact';
 import { Sun, Moon } from 'lucide-preact';
 import { Sidebar } from './Sidebar.tsx';
+import { HomePage } from './pages/HomePage.tsx';
+import { AppUiPage } from './pages/AppUiPage.tsx';
 
-// ─── Headless component demos ─────────────────────────────────────────────────
-import { ButtonDemo } from './sections/ButtonDemo.tsx';
-import { IconButtonDemo } from './sections/IconButtonDemo.tsx';
-import { CheckboxDemo } from './sections/CheckboxDemo.tsx';
-import { SwitchDemo } from './sections/SwitchDemo.tsx';
-import { RadioGroupDemo } from './sections/RadioGroupDemo.tsx';
-import { InputDemo } from './sections/InputDemo.tsx';
-import { FieldDemo } from './sections/FieldDemo.tsx';
-import { DialogDemo } from './sections/DialogDemo.tsx';
-import { CommandPaletteDemo } from './sections/CommandPaletteDemo.tsx';
-import { DrawerDemo } from './sections/DrawerDemo.tsx';
-import { MenuDemo } from './sections/MenuDemo.tsx';
-import { DisclosureDemo } from './sections/DisclosureDemo.tsx';
-import { PopoverDemo } from './sections/PopoverDemo.tsx';
-import { TooltipDemo } from './sections/TooltipDemo.tsx';
-import { ToastDemo } from './sections/ToastDemo.tsx';
-import { NotificationDemo } from './sections/NotificationDemo.tsx';
-import { TabsDemo } from './sections/TabsDemo.tsx';
-import { ListboxDemo } from './sections/ListboxDemo.tsx';
-import { ComboboxDemo } from './sections/ComboboxDemo.tsx';
-import { TransitionDemo } from './sections/TransitionDemo.tsx';
-import { SpinnerDemo } from './sections/SpinnerDemo.tsx';
-import { SkeletonDemo } from './sections/SkeletonDemo.tsx';
-
-// ─── Application UI demos — Application Shells ───────────────────────────────
-import { MultiColumnDemo } from './sections/MultiColumnDemo.tsx';
-import { MultiColumnShellsDemo } from './sections/application-shells/multi-column/MultiColumnShellsDemo.tsx';
-import { SidebarShellsDemo } from './sections/application-shells/sidebar/SidebarShellsDemo.tsx';
-import { StackedShellsDemo } from './sections/application-shells/stacked/StackedShellsDemo.tsx';
-
-// ─── Application UI demos — Data Display ─────────────────────────────────────
-import { StatsDemo } from './sections/StatsDemo.tsx';
-import { CalendarsDemo } from './sections/CalendarsDemo.tsx';
-import { CalendarsHeadlessDemo } from './sections/data-display/calendars/CalendarsHeadlessDemo.tsx';
-import { DescriptionListsDemo } from './sections/DescriptionListsDemo.tsx';
-
-// ─── Application UI demos — Elements ─────────────────────────────────────────
-import { AvatarsDemo } from './sections/elements/avatars/AvatarsDemo.tsx';
-import { BadgesDemo } from './sections/elements/badges/BadgesDemo.tsx';
-import { ButtonsDemo } from './sections/elements/buttons/ButtonsDemo.tsx';
-import { ButtonGroupsDemo } from './sections/elements/button-groups/ButtonGroupsDemo.tsx';
-import { DropdownsDemo } from './sections/elements/dropdowns/DropdownsDemo.tsx';
-
-// ─── Application UI demos — Feedback ─────────────────────────────────────────
-import { AlertsDemo } from './sections/feedback/alerts/AlertsDemo.tsx';
-import { EmptyStatesDemo } from './sections/EmptyStatesDemo.tsx';
-
-// ─── Application UI demos — Forms ────────────────────────────────────────────
-import { FormLayoutsDemo } from './sections/forms/form-layouts/FormLayoutsDemo.tsx';
-import { InputGroupsDemo } from './sections/forms/input-groups/InputGroupsDemo.tsx';
-import { RadioGroupsDemo } from './sections/forms/radio-groups/RadioGroupsDemo.tsx';
-import { SelectMenusDemo } from './sections/forms/select-menus/SelectMenusDemo.tsx';
-import { CustomSelectMenusDemo } from './sections/forms/select-menus/CustomSelectMenusDemo.tsx';
-import { ComboboxesDemo } from './sections/forms/comboboxes/ComboboxesDemo.tsx';
-import { ActionPanelsDemo } from './sections/ActionPanelsDemo.tsx';
-import { CheckboxesDemo } from './sections/CheckboxesDemo.tsx';
-import { SignInFormsDemo } from './sections/SignInFormsDemo.tsx';
-import { TextareasDemo } from './sections/TextareasDemo.tsx';
-import { TogglesDemo } from './sections/TogglesDemo.tsx';
-
-// ─── Application UI demos — Headings ─────────────────────────────────────────
-import { CardHeadingsDemo } from './sections/headings/card-headings/CardHeadingsDemo.tsx';
-import { PageHeadingsDemo } from './sections/headings/page-headings/PageHeadingsDemo.tsx';
-import { SectionHeadingsDemo } from './sections/headings/section-headings/SectionHeadingsDemo.tsx';
-
-// ─── Application UI demos — Layout ───────────────────────────────────────────
-import { CardsDemo } from './sections/layout/cards/CardsDemo.tsx';
-import { ContainersDemo } from './sections/layout/containers/ContainersDemo.tsx';
-import { DividersDemo } from './sections/layout/dividers/DividersDemo.tsx';
-import { ListContainersDemo } from './sections/layout/list-containers/ListContainersDemo.tsx';
-import { MediaObjectsDemo } from './sections/layout/media-objects/MediaObjectsDemo.tsx';
-
-// ─── Application UI demos — Lists ────────────────────────────────────────────
-import { FeedsDemo } from './sections/FeedsDemo.tsx';
-import { GridListsDemo } from './sections/GridListsDemo.tsx';
-import { StackedListsDemo } from './sections/StackedListsDemo.tsx';
-import { TablesDemo } from './sections/TablesDemo.tsx';
-
-// ─── Application UI demos — Navigation ───────────────────────────────────────
-import { BreadcrumbsDemo } from './sections/BreadcrumbsDemo.tsx';
-import { CommandPalettesDemo } from './sections/navigation/CommandPalettesDemo.tsx';
-import { NavbarsDemo } from './sections/navigation/NavbarsDemo.tsx';
-import { PaginationDemo } from './sections/PaginationDemo.tsx';
-import { ProgressBarsDemo } from './sections/ProgressBarsDemo.tsx';
-import { SidebarNavigationDemo } from './sections/SidebarNavigationDemo.tsx';
-import { VerticalNavigationDemo } from './sections/VerticalNavigationDemo.tsx';
-
-// ─── Application UI demos — Overlays ─────────────────────────────────────────
-import { DrawersDemo } from './sections/overlays/DrawersDemo.tsx';
-import { ModalDialogsDemo } from './sections/overlays/ModalDialogsDemo.tsx';
-
-// ─── Application UI demos — Page Examples ────────────────────────────────────
-import { DetailScreensDemo } from './sections/DetailScreensDemo.tsx';
-import { HomeScreensDemo } from './sections/HomeScreensDemo.tsx';
-import { SettingsScreensDemo } from './sections/SettingsScreensDemo.tsx';
-
-// ─── Section registry ─────────────────────────────────────────────────────────
-
-interface SectionDef {
-	id: string;
-	title: string;
-	Component: ComponentType;
+function getCurrentPage(): string {
+	const hash = window.location.hash;
+	return hash.startsWith('#/') ? hash.slice(2) : '';
 }
-
-const sections: SectionDef[] = [
-	// Headless Components
-	{ id: 'hc-button', title: 'Button', Component: ButtonDemo },
-	{ id: 'hc-icon-button', title: 'IconButton', Component: IconButtonDemo },
-	{ id: 'hc-checkbox', title: 'Checkbox', Component: CheckboxDemo },
-	{ id: 'hc-switch', title: 'Switch', Component: SwitchDemo },
-	{ id: 'hc-radio-group', title: 'RadioGroup', Component: RadioGroupDemo },
-	{ id: 'hc-input', title: 'Input', Component: InputDemo },
-	{ id: 'hc-field', title: 'Field', Component: FieldDemo },
-	{ id: 'hc-dialog', title: 'Dialog', Component: DialogDemo },
-	{
-		id: 'hc-command-palette',
-		title: 'Command Palette (Dialog + Combobox)',
-		Component: CommandPaletteDemo,
-	},
-	{ id: 'hc-drawer', title: 'Drawer', Component: DrawerDemo },
-	{ id: 'hc-menu', title: 'Menu', Component: MenuDemo },
-	{ id: 'hc-disclosure', title: 'Disclosure', Component: DisclosureDemo },
-	{ id: 'hc-popover', title: 'Popover', Component: PopoverDemo },
-	{ id: 'hc-tooltip', title: 'Tooltip', Component: TooltipDemo },
-	{ id: 'hc-toast', title: 'Toast', Component: ToastDemo },
-	{
-		id: 'hc-notification',
-		title: 'Notification (Toast Variants)',
-		Component: NotificationDemo,
-	},
-	{ id: 'hc-tabs', title: 'Tabs', Component: TabsDemo },
-	{ id: 'hc-listbox', title: 'Listbox', Component: ListboxDemo },
-	{ id: 'hc-combobox', title: 'Combobox', Component: ComboboxDemo },
-	{ id: 'hc-transition', title: 'Transition', Component: TransitionDemo },
-	{ id: 'hc-spinner', title: 'Spinner', Component: SpinnerDemo },
-	{ id: 'hc-skeleton', title: 'Skeleton', Component: SkeletonDemo },
-
-	// Application UI — Application Shells
-	{
-		id: 'ui-appshells-multi-column',
-		title: 'Application Shells / Multi-column',
-		Component: MultiColumnDemo,
-	},
-	{
-		id: 'ui-appshells-multi-column-shells',
-		title: 'Application Shells / Multi-column (Headless)',
-		Component: MultiColumnShellsDemo,
-	},
-	{
-		id: 'ui-appshells-sidebar',
-		title: 'Application Shells / Sidebar (Headless)',
-		Component: SidebarShellsDemo,
-	},
-	{
-		id: 'ui-appshells-stacked',
-		title: 'Application Shells / Stacked (Headless)',
-		Component: StackedShellsDemo,
-	},
-
-	// Application UI — Data Display
-	{ id: 'ui-data-display-stats', title: 'Data Display / Stats', Component: StatsDemo },
-	{ id: 'ui-data-display-calendars', title: 'Data Display / Calendars', Component: CalendarsDemo },
-	{
-		id: 'ui-data-display-calendars-hl',
-		title: 'Data Display / Calendars (Headless)',
-		Component: CalendarsHeadlessDemo,
-	},
-	{
-		id: 'ui-data-display-description-lists',
-		title: 'Data Display / Description Lists',
-		Component: DescriptionListsDemo,
-	},
-
-	// Application UI — Elements
-	{ id: 'ui-elements-avatars', title: 'Elements / Avatars', Component: AvatarsDemo },
-	{ id: 'ui-elements-badges', title: 'Elements / Badges', Component: BadgesDemo },
-	{ id: 'ui-elements-buttons', title: 'Elements / Buttons', Component: ButtonsDemo },
-	{
-		id: 'ui-elements-button-groups',
-		title: 'Elements / Button Groups',
-		Component: ButtonGroupsDemo,
-	},
-	{ id: 'ui-elements-dropdowns', title: 'Elements / Dropdowns', Component: DropdownsDemo },
-
-	// Application UI — Feedback
-	{ id: 'ui-feedback-alerts', title: 'Feedback / Alerts', Component: AlertsDemo },
-	{ id: 'ui-feedback-empty-states', title: 'Feedback / Empty States', Component: EmptyStatesDemo },
-
-	// Application UI — Forms
-	{ id: 'ui-forms-form-layouts', title: 'Forms / Form Layouts', Component: FormLayoutsDemo },
-	{ id: 'ui-forms-input-groups', title: 'Forms / Input Groups', Component: InputGroupsDemo },
-	{ id: 'ui-forms-radio-groups', title: 'Forms / Radio Groups', Component: RadioGroupsDemo },
-	{ id: 'ui-forms-select-menus', title: 'Forms / Select Menus', Component: SelectMenusDemo },
-	{
-		id: 'ui-forms-select-menus-hl',
-		title: 'Forms / Select Menus (Headless)',
-		Component: CustomSelectMenusDemo,
-	},
-	{ id: 'ui-forms-comboboxes', title: 'Forms / Comboboxes', Component: ComboboxesDemo },
-	{ id: 'ui-forms-action-panels', title: 'Forms / Action Panels', Component: ActionPanelsDemo },
-	{ id: 'ui-forms-checkboxes', title: 'Forms / Checkboxes', Component: CheckboxesDemo },
-	{ id: 'ui-forms-sign-in-forms', title: 'Forms / Sign-in Forms', Component: SignInFormsDemo },
-	{ id: 'ui-forms-textareas', title: 'Forms / Textareas', Component: TextareasDemo },
-	{ id: 'ui-forms-toggles', title: 'Forms / Toggles', Component: TogglesDemo },
-
-	// Application UI — Headings
-	{
-		id: 'ui-headings-card-headings',
-		title: 'Headings / Card Headings',
-		Component: CardHeadingsDemo,
-	},
-	{
-		id: 'ui-headings-page-headings',
-		title: 'Headings / Page Headings',
-		Component: PageHeadingsDemo,
-	},
-	{
-		id: 'ui-headings-section-headings',
-		title: 'Headings / Section Headings',
-		Component: SectionHeadingsDemo,
-	},
-
-	// Application UI — Layout
-	{ id: 'ui-layout-cards', title: 'Layout / Cards', Component: CardsDemo },
-	{ id: 'ui-layout-containers', title: 'Layout / Containers', Component: ContainersDemo },
-	{ id: 'ui-layout-dividers', title: 'Layout / Dividers', Component: DividersDemo },
-	{
-		id: 'ui-layout-list-containers',
-		title: 'Layout / List Containers',
-		Component: ListContainersDemo,
-	},
-	{
-		id: 'ui-layout-media-objects',
-		title: 'Layout / Media Objects',
-		Component: MediaObjectsDemo,
-	},
-
-	// Application UI — Lists
-	{ id: 'ui-lists-feeds', title: 'Lists / Feeds', Component: FeedsDemo },
-	{ id: 'ui-lists-grid-lists', title: 'Lists / Grid Lists', Component: GridListsDemo },
-	{ id: 'ui-lists-stacked-lists', title: 'Lists / Stacked Lists', Component: StackedListsDemo },
-	{ id: 'ui-lists-tables', title: 'Lists / Tables', Component: TablesDemo },
-
-	// Application UI — Navigation
-	{ id: 'ui-nav-breadcrumbs', title: 'Navigation / Breadcrumbs', Component: BreadcrumbsDemo },
-	{
-		id: 'ui-nav-command-palettes',
-		title: 'Navigation / Command Palettes',
-		Component: CommandPalettesDemo,
-	},
-	{ id: 'ui-nav-navbars', title: 'Navigation / Navbars', Component: NavbarsDemo },
-	{ id: 'ui-nav-pagination', title: 'Navigation / Pagination', Component: PaginationDemo },
-	{
-		id: 'ui-nav-progress-bars',
-		title: 'Navigation / Progress Bars',
-		Component: ProgressBarsDemo,
-	},
-	{
-		id: 'ui-nav-sidebar-navigation',
-		title: 'Navigation / Sidebar Navigation',
-		Component: SidebarNavigationDemo,
-	},
-	{
-		id: 'ui-nav-vertical-navigation',
-		title: 'Navigation / Vertical Navigation',
-		Component: VerticalNavigationDemo,
-	},
-
-	// Application UI — Overlays
-	{ id: 'ui-overlays-drawers', title: 'Overlays / Drawers', Component: DrawersDemo },
-	{
-		id: 'ui-overlays-modal-dialogs',
-		title: 'Overlays / Modal Dialogs',
-		Component: ModalDialogsDemo,
-	},
-	{
-		id: 'ui-overlays-notifications',
-		title: 'Overlays / Notifications',
-		Component: NotificationDemo,
-	},
-
-	// Application UI — Page Examples
-	{
-		id: 'ui-pages-detail-screens',
-		title: 'Page Examples / Detail Screens',
-		Component: DetailScreensDemo,
-	},
-	{
-		id: 'ui-pages-home-screens',
-		title: 'Page Examples / Home Screens',
-		Component: HomeScreensDemo,
-	},
-	{
-		id: 'ui-pages-settings-screens',
-		title: 'Page Examples / Settings Screens',
-		Component: SettingsScreensDemo,
-	},
-];
-
-// ─── App ──────────────────────────────────────────────────────────────────────
 
 export function App() {
 	const [theme, setTheme] = useState<'dark' | 'light'>('dark');
+	const [page, setPage] = useState<string>(getCurrentPage);
 	const [activeSection, setActiveSection] = useState<string>('');
 	const [searchQuery, setSearchQuery] = useState<string>('');
 
@@ -319,42 +25,27 @@ export function App() {
 		}
 	}
 
-	// Scroll-spy: track which section is most visible
 	useEffect(() => {
-		const visibleSections = new Map<string, number>();
+		function onHashChange() {
+			const hash = window.location.hash;
+			if (hash.startsWith('#/')) {
+				setPage(hash.slice(2));
+				setActiveSection('');
+			} else if (hash.startsWith('#hc-')) {
+				setPage('');
+				setActiveSection('');
+			}
+			// Otherwise ignore — within-page anchor handled by onClick+scrollIntoView
+		}
 
-		const observer = new IntersectionObserver(
-			(entries) => {
-				for (const entry of entries) {
-					if (entry.isIntersecting) {
-						visibleSections.set(entry.target.id, entry.intersectionRatio);
-					} else {
-						visibleSections.delete(entry.target.id);
-					}
-				}
-
-				let bestId = '';
-				let bestRatio = 0;
-				for (const [id, ratio] of visibleSections) {
-					if (ratio > bestRatio) {
-						bestRatio = ratio;
-						bestId = id;
-					}
-				}
-				setActiveSection(bestId);
-			},
-			{ rootMargin: '-20% 0px -70% 0px', threshold: [0, 0.1, 0.5, 1.0] }
-		);
-
-		const sectionEls = document.querySelectorAll('section[id]');
-		for (const el of sectionEls) observer.observe(el);
-
-		return () => observer.disconnect();
+		window.addEventListener('hashchange', onHashChange);
+		return () => window.removeEventListener('hashchange', onHashChange);
 	}, []);
 
 	return (
 		<div class="min-h-screen bg-surface-0 text-text-primary">
 			<Sidebar
+				currentPage={page}
 				activeSection={activeSection}
 				searchQuery={searchQuery}
 				setSearchQuery={setSearchQuery}
@@ -391,15 +82,12 @@ export function App() {
 					</div>
 				</header>
 
-				{/* Main content — all sections rendered from the registry */}
-				<main class="px-8 max-w-6xl">
-					{sections.map(({ id, title, Component }) => (
-						<section key={id} id={id} class="py-12 border-b border-surface-border">
-							<h2 class="text-2xl font-bold mb-6">{title}</h2>
-							<Component />
-						</section>
-					))}
-				</main>
+				{/* Page content */}
+				{page === '' ? (
+					<HomePage setActiveSection={setActiveSection} />
+				) : (
+					<AppUiPage categoryId={page} setActiveSection={setActiveSection} />
+				)}
 			</div>
 		</div>
 	);

--- a/packages/ui/demo/Sidebar.tsx
+++ b/packages/ui/demo/Sidebar.tsx
@@ -1,0 +1,339 @@
+import { useState, useEffect } from 'preact/hooks';
+import { ChevronDown, ChevronRight, ChevronUp } from 'lucide-preact';
+
+export interface NavItem {
+	id: string;
+	label: string;
+}
+
+export interface NavCategory {
+	id: string;
+	label: string;
+	sections: NavItem[];
+}
+
+// ─── Headless component primitives ───────────────────────────────────────────
+
+export const headlessNavItems: NavItem[] = [
+	{ id: 'hc-button', label: 'Button' },
+	{ id: 'hc-icon-button', label: 'IconButton' },
+	{ id: 'hc-checkbox', label: 'Checkbox' },
+	{ id: 'hc-switch', label: 'Switch' },
+	{ id: 'hc-radio-group', label: 'RadioGroup' },
+	{ id: 'hc-input', label: 'Input' },
+	{ id: 'hc-field', label: 'Field' },
+	{ id: 'hc-dialog', label: 'Dialog' },
+	{ id: 'hc-command-palette', label: 'Command Palette' },
+	{ id: 'hc-drawer', label: 'Drawer' },
+	{ id: 'hc-menu', label: 'Menu' },
+	{ id: 'hc-disclosure', label: 'Disclosure' },
+	{ id: 'hc-popover', label: 'Popover' },
+	{ id: 'hc-tooltip', label: 'Tooltip' },
+	{ id: 'hc-toast', label: 'Toast' },
+	{ id: 'hc-notification', label: 'Notification' },
+	{ id: 'hc-tabs', label: 'Tabs' },
+	{ id: 'hc-listbox', label: 'Listbox' },
+	{ id: 'hc-combobox', label: 'Combobox' },
+	{ id: 'hc-transition', label: 'Transition' },
+	{ id: 'hc-spinner', label: 'Spinner' },
+	{ id: 'hc-skeleton', label: 'Skeleton' },
+];
+
+// ─── Application UI categories ────────────────────────────────────────────────
+
+export const appUiCategories: NavCategory[] = [
+	{
+		id: 'application-shells',
+		label: 'Application Shells',
+		sections: [
+			{ id: 'ui-appshells-multi-column', label: 'Multi-column' },
+			{ id: 'ui-appshells-multi-column-shells', label: 'Multi-column (Headless)' },
+			{ id: 'ui-appshells-sidebar', label: 'Sidebar' },
+			{ id: 'ui-appshells-stacked', label: 'Stacked' },
+		],
+	},
+	{
+		id: 'data-display',
+		label: 'Data Display',
+		sections: [
+			{ id: 'ui-data-display-stats', label: 'Stats' },
+			{ id: 'ui-data-display-calendars', label: 'Calendars' },
+			{ id: 'ui-data-display-calendars-hl', label: 'Calendars (Headless)' },
+			{ id: 'ui-data-display-description-lists', label: 'Description Lists' },
+		],
+	},
+	{
+		id: 'elements',
+		label: 'Elements',
+		sections: [
+			{ id: 'ui-elements-avatars', label: 'Avatars' },
+			{ id: 'ui-elements-badges', label: 'Badges' },
+			{ id: 'ui-elements-buttons', label: 'Buttons' },
+			{ id: 'ui-elements-button-groups', label: 'Button Groups' },
+			{ id: 'ui-elements-dropdowns', label: 'Dropdowns' },
+		],
+	},
+	{
+		id: 'feedback',
+		label: 'Feedback',
+		sections: [
+			{ id: 'ui-feedback-alerts', label: 'Alerts' },
+			{ id: 'ui-feedback-empty-states', label: 'Empty States' },
+		],
+	},
+	{
+		id: 'forms',
+		label: 'Forms',
+		sections: [
+			{ id: 'ui-forms-form-layouts', label: 'Form Layouts' },
+			{ id: 'ui-forms-input-groups', label: 'Input Groups' },
+			{ id: 'ui-forms-radio-groups', label: 'Radio Groups' },
+			{ id: 'ui-forms-select-menus', label: 'Select Menus' },
+			{ id: 'ui-forms-select-menus-hl', label: 'Select Menus (Headless)' },
+			{ id: 'ui-forms-comboboxes', label: 'Comboboxes' },
+			{ id: 'ui-forms-action-panels', label: 'Action Panels' },
+			{ id: 'ui-forms-checkboxes', label: 'Checkboxes' },
+			{ id: 'ui-forms-sign-in-forms', label: 'Sign-in Forms' },
+			{ id: 'ui-forms-textareas', label: 'Textareas' },
+			{ id: 'ui-forms-toggles', label: 'Toggles' },
+		],
+	},
+	{
+		id: 'headings',
+		label: 'Headings',
+		sections: [
+			{ id: 'ui-headings-card-headings', label: 'Card Headings' },
+			{ id: 'ui-headings-page-headings', label: 'Page Headings' },
+			{ id: 'ui-headings-section-headings', label: 'Section Headings' },
+		],
+	},
+	{
+		id: 'layout',
+		label: 'Layout',
+		sections: [
+			{ id: 'ui-layout-cards', label: 'Cards' },
+			{ id: 'ui-layout-containers', label: 'Containers' },
+			{ id: 'ui-layout-dividers', label: 'Dividers' },
+			{ id: 'ui-layout-list-containers', label: 'List Containers' },
+			{ id: 'ui-layout-media-objects', label: 'Media Objects' },
+		],
+	},
+	{
+		id: 'lists',
+		label: 'Lists',
+		sections: [
+			{ id: 'ui-lists-feeds', label: 'Feeds' },
+			{ id: 'ui-lists-grid-lists', label: 'Grid Lists' },
+			{ id: 'ui-lists-stacked-lists', label: 'Stacked Lists' },
+			{ id: 'ui-lists-tables', label: 'Tables' },
+		],
+	},
+	{
+		id: 'navigation',
+		label: 'Navigation',
+		sections: [
+			{ id: 'ui-nav-breadcrumbs', label: 'Breadcrumbs' },
+			{ id: 'ui-nav-command-palettes', label: 'Command Palettes' },
+			{ id: 'ui-nav-navbars', label: 'Navbars' },
+			{ id: 'ui-nav-pagination', label: 'Pagination' },
+			{ id: 'ui-nav-progress-bars', label: 'Progress Bars' },
+			{ id: 'ui-nav-sidebar-navigation', label: 'Sidebar Navigation' },
+			{ id: 'ui-nav-vertical-navigation', label: 'Vertical Navigation' },
+		],
+	},
+	{
+		id: 'overlays',
+		label: 'Overlays',
+		sections: [
+			{ id: 'ui-overlays-drawers', label: 'Drawers' },
+			{ id: 'ui-overlays-modal-dialogs', label: 'Modal Dialogs' },
+			{ id: 'ui-overlays-notifications', label: 'Notifications' },
+		],
+	},
+	{
+		id: 'page-examples',
+		label: 'Page Examples',
+		sections: [
+			{ id: 'ui-pages-detail-screens', label: 'Detail Screens' },
+			{ id: 'ui-pages-home-screens', label: 'Home Screens' },
+			{ id: 'ui-pages-settings-screens', label: 'Settings Screens' },
+		],
+	},
+];
+
+// ─── Category component ───────────────────────────────────────────────────────
+
+interface CategoryProps {
+	category: NavCategory;
+	forceOpen?: boolean;
+	activeSection: string;
+	searchQuery: string;
+}
+
+function Category({ category, forceOpen, activeSection, searchQuery }: CategoryProps) {
+	const [isOpen, setIsOpen] = useState(false);
+	// Tracks whether the user has explicitly collapsed this category to prevent auto-reopen
+	const [userCollapsed, setUserCollapsed] = useState(false);
+
+	const hasActiveSection = category.sections.some((s) => s.id === activeSection);
+	const autoOpen = hasActiveSection || (forceOpen ?? false);
+
+	// When auto-open conditions go away, clear the user-collapsed flag so the next
+	// time the section becomes active it auto-expands again
+	useEffect(() => {
+		if (!autoOpen) setUserCollapsed(false);
+	}, [autoOpen]);
+
+	// Open if: explicitly opened by user OR (auto-open AND user hasn't explicitly closed it)
+	const shouldBeOpen = isOpen || (autoOpen && !userCollapsed);
+
+	function toggle() {
+		if (shouldBeOpen) {
+			setIsOpen(false);
+			setUserCollapsed(true);
+		} else {
+			setIsOpen(true);
+			setUserCollapsed(false);
+		}
+	}
+
+	return (
+		<li>
+			<button
+				type="button"
+				onClick={toggle}
+				class="flex items-center w-full px-3 py-2 text-sm font-medium text-text-secondary hover:text-text-primary hover:bg-surface-2 rounded transition-colors cursor-pointer"
+			>
+				{shouldBeOpen ? (
+					<ChevronDown class="w-4 h-4 mr-2 flex-shrink-0" />
+				) : (
+					<ChevronRight class="w-4 h-4 mr-2 flex-shrink-0" />
+				)}
+				{category.label}
+			</button>
+			{shouldBeOpen && (
+				<ul class="ml-4 mt-1 space-y-0.5 border-l border-surface-border pl-2">
+					{category.sections.map((section) => {
+						const matchesSearch =
+							searchQuery === '' || section.label.toLowerCase().includes(searchQuery.toLowerCase());
+						if (!matchesSearch) return null;
+						const isActive = section.id === activeSection;
+						return (
+							<li key={section.id}>
+								<a
+									href={`#${section.id}`}
+									class={`block px-3 py-1.5 text-xs rounded transition-colors ${
+										isActive
+											? 'text-text-primary bg-surface-2 font-medium'
+											: 'text-text-tertiary hover:text-text-primary hover:bg-surface-2'
+									}`}
+								>
+									{section.label}
+								</a>
+							</li>
+						);
+					})}
+				</ul>
+			)}
+		</li>
+	);
+}
+
+// ─── Sidebar component ────────────────────────────────────────────────────────
+
+interface SidebarProps {
+	activeSection: string;
+	searchQuery: string;
+	setSearchQuery: (q: string) => void;
+}
+
+export function Sidebar({ activeSection, searchQuery, setSearchQuery }: SidebarProps) {
+	const q = searchQuery.toLowerCase();
+
+	const filteredHeadless =
+		q === '' ? headlessNavItems : headlessNavItems.filter((s) => s.label.toLowerCase().includes(q));
+
+	const filteredCategories =
+		q === ''
+			? appUiCategories
+			: appUiCategories.filter((cat) =>
+					cat.sections.some((s) => s.label.toLowerCase().includes(q))
+				);
+
+	return (
+		<nav class="fixed left-0 top-0 w-64 h-screen overflow-y-auto bg-surface-1 border-r border-surface-border z-10 flex flex-col">
+			<div class="p-4 flex-1">
+				{/* Search */}
+				<div class="mb-4">
+					<input
+						type="search"
+						placeholder="Filter..."
+						value={searchQuery}
+						onInput={(e) => setSearchQuery((e.target as HTMLInputElement).value)}
+						class="w-full px-3 py-1.5 text-sm bg-surface-2 border border-surface-border rounded text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-1 focus:ring-surface-border"
+					/>
+				</div>
+
+				{/* Headless Components */}
+				{filteredHeadless.length > 0 && (
+					<div class="mb-6">
+						<p class="px-3 text-xs font-semibold uppercase tracking-wider text-text-tertiary mb-2">
+							Headless Components
+						</p>
+						<ul class="space-y-0.5">
+							{filteredHeadless.map((s) => {
+								const isActive = s.id === activeSection;
+								return (
+									<li key={s.id}>
+										<a
+											href={`#${s.id}`}
+											class={`block px-3 py-1.5 text-sm rounded transition-colors ${
+												isActive
+													? 'text-text-primary bg-surface-2 font-medium'
+													: 'text-text-secondary hover:text-text-primary hover:bg-surface-2'
+											}`}
+										>
+											{s.label}
+										</a>
+									</li>
+								);
+							})}
+						</ul>
+					</div>
+				)}
+
+				{/* Application UI */}
+				{filteredCategories.length > 0 && (
+					<div>
+						<p class="px-3 text-xs font-semibold uppercase tracking-wider text-text-tertiary mb-2">
+							Application UI
+						</p>
+						<ul class="space-y-1">
+							{filteredCategories.map((category) => (
+								<Category
+									key={category.id}
+									category={category}
+									forceOpen={searchQuery !== ''}
+									activeSection={activeSection}
+									searchQuery={searchQuery}
+								/>
+							))}
+						</ul>
+					</div>
+				)}
+			</div>
+
+			{/* Scroll to top */}
+			<div class="p-2 border-t border-surface-border">
+				<button
+					type="button"
+					onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+					class="w-full flex items-center justify-center gap-1 px-3 py-2 text-xs text-text-tertiary hover:text-text-primary hover:bg-surface-2 rounded transition-colors cursor-pointer"
+				>
+					<ChevronUp class="w-3 h-3" />
+					Scroll to top
+				</button>
+			</div>
+		</nav>
+	);
+}

--- a/packages/ui/demo/Sidebar.tsx
+++ b/packages/ui/demo/Sidebar.tsx
@@ -1,5 +1,4 @@
-import { useState, useEffect } from 'preact/hooks';
-import { ChevronDown, ChevronRight, ChevronUp } from 'lucide-preact';
+import { ChevronUp } from 'lucide-preact';
 
 export interface NavItem {
 	id: string;
@@ -161,93 +160,16 @@ export const appUiCategories: NavCategory[] = [
 	},
 ];
 
-// ─── Category component ───────────────────────────────────────────────────────
-
-interface CategoryProps {
-	category: NavCategory;
-	forceOpen?: boolean;
-	activeSection: string;
-	searchQuery: string;
-}
-
-function Category({ category, forceOpen, activeSection, searchQuery }: CategoryProps) {
-	const [isOpen, setIsOpen] = useState(false);
-	// Tracks whether the user has explicitly collapsed this category to prevent auto-reopen
-	const [userCollapsed, setUserCollapsed] = useState(false);
-
-	const hasActiveSection = category.sections.some((s) => s.id === activeSection);
-	const autoOpen = hasActiveSection || (forceOpen ?? false);
-
-	// When auto-open conditions go away, clear the user-collapsed flag so the next
-	// time the section becomes active it auto-expands again
-	useEffect(() => {
-		if (!autoOpen) setUserCollapsed(false);
-	}, [autoOpen]);
-
-	// Open if: explicitly opened by user OR (auto-open AND user hasn't explicitly closed it)
-	const shouldBeOpen = isOpen || (autoOpen && !userCollapsed);
-
-	function toggle() {
-		if (shouldBeOpen) {
-			setIsOpen(false);
-			setUserCollapsed(true);
-		} else {
-			setIsOpen(true);
-			setUserCollapsed(false);
-		}
-	}
-
-	return (
-		<li>
-			<button
-				type="button"
-				onClick={toggle}
-				class="flex items-center w-full px-3 py-2 text-sm font-medium text-text-secondary hover:text-text-primary hover:bg-surface-2 rounded transition-colors cursor-pointer"
-			>
-				{shouldBeOpen ? (
-					<ChevronDown class="w-4 h-4 mr-2 flex-shrink-0" />
-				) : (
-					<ChevronRight class="w-4 h-4 mr-2 flex-shrink-0" />
-				)}
-				{category.label}
-			</button>
-			{shouldBeOpen && (
-				<ul class="ml-4 mt-1 space-y-0.5 border-l border-surface-border pl-2">
-					{category.sections.map((section) => {
-						const matchesSearch =
-							searchQuery === '' || section.label.toLowerCase().includes(searchQuery.toLowerCase());
-						if (!matchesSearch) return null;
-						const isActive = section.id === activeSection;
-						return (
-							<li key={section.id}>
-								<a
-									href={`#${section.id}`}
-									class={`block px-3 py-1.5 text-xs rounded transition-colors ${
-										isActive
-											? 'text-text-primary bg-surface-2 font-medium'
-											: 'text-text-tertiary hover:text-text-primary hover:bg-surface-2'
-									}`}
-								>
-									{section.label}
-								</a>
-							</li>
-						);
-					})}
-				</ul>
-			)}
-		</li>
-	);
-}
-
 // ─── Sidebar component ────────────────────────────────────────────────────────
 
 interface SidebarProps {
+	currentPage: string;
 	activeSection: string;
 	searchQuery: string;
 	setSearchQuery: (q: string) => void;
 }
 
-export function Sidebar({ activeSection, searchQuery, setSearchQuery }: SidebarProps) {
+export function Sidebar({ currentPage, activeSection, searchQuery, setSearchQuery }: SidebarProps) {
 	const q = searchQuery.toLowerCase();
 
 	const filteredHeadless =
@@ -256,8 +178,10 @@ export function Sidebar({ activeSection, searchQuery, setSearchQuery }: SidebarP
 	const filteredCategories =
 		q === ''
 			? appUiCategories
-			: appUiCategories.filter((cat) =>
-					cat.sections.some((s) => s.label.toLowerCase().includes(q))
+			: appUiCategories.filter(
+					(cat) =>
+						cat.label.toLowerCase().includes(q) ||
+						cat.sections.some((s) => s.label.toLowerCase().includes(q))
 				);
 
 	return (
@@ -282,7 +206,7 @@ export function Sidebar({ activeSection, searchQuery, setSearchQuery }: SidebarP
 						</p>
 						<ul class="space-y-0.5">
 							{filteredHeadless.map((s) => {
-								const isActive = s.id === activeSection;
+								const isActive = currentPage === '' && s.id === activeSection;
 								return (
 									<li key={s.id}>
 										<a
@@ -308,16 +232,75 @@ export function Sidebar({ activeSection, searchQuery, setSearchQuery }: SidebarP
 						<p class="px-3 text-xs font-semibold uppercase tracking-wider text-text-tertiary mb-2">
 							Application UI
 						</p>
-						<ul class="space-y-1">
-							{filteredCategories.map((category) => (
-								<Category
-									key={category.id}
-									category={category}
-									forceOpen={searchQuery !== ''}
-									activeSection={activeSection}
-									searchQuery={searchQuery}
-								/>
-							))}
+						<ul class="space-y-0.5">
+							{filteredCategories.map((category) => {
+								const isCategoryActive = currentPage === category.id;
+								const filteredSections =
+									q === ''
+										? category.sections
+										: category.sections.filter((s) => s.label.toLowerCase().includes(q));
+
+								return (
+									<li key={category.id}>
+										<a
+											href={`#/${category.id}`}
+											class={`flex items-center px-3 py-2 text-sm rounded transition-colors ${
+												isCategoryActive
+													? 'text-text-primary bg-surface-2 font-medium'
+													: 'text-text-secondary hover:text-text-primary hover:bg-surface-2'
+											}`}
+										>
+											{category.label}
+										</a>
+										{/* Sub-sections: shown when this category is the active page */}
+										{isCategoryActive && (
+											<ul class="ml-4 mt-1 space-y-0.5 border-l border-surface-border pl-2">
+												{filteredSections.map((section) => {
+													const isActive = section.id === activeSection;
+													return (
+														<li key={section.id}>
+															<button
+																type="button"
+																onClick={(e) => {
+																	e.preventDefault();
+																	const el = document.getElementById(section.id);
+																	if (el) {
+																		el.scrollIntoView({
+																			behavior: 'smooth',
+																		});
+																	}
+																}}
+																class={`block w-full text-left px-3 py-1.5 text-xs rounded transition-colors cursor-pointer ${
+																	isActive
+																		? 'text-text-primary bg-surface-2 font-medium'
+																		: 'text-text-tertiary hover:text-text-primary hover:bg-surface-2'
+																}`}
+															>
+																{section.label}
+															</button>
+														</li>
+													);
+												})}
+											</ul>
+										)}
+										{/* When searching and category is not active but has matching sections */}
+										{!isCategoryActive && q !== '' && filteredSections.length > 0 && (
+											<ul class="ml-4 mt-1 space-y-0.5 border-l border-surface-border pl-2">
+												{filteredSections.map((section) => (
+													<li key={section.id}>
+														<a
+															href={`#/${category.id}`}
+															class="block px-3 py-1.5 text-xs rounded transition-colors text-text-tertiary hover:text-text-primary hover:bg-surface-2"
+														>
+															{section.label}
+														</a>
+													</li>
+												))}
+											</ul>
+										)}
+									</li>
+								);
+							})}
 						</ul>
 					</div>
 				)}

--- a/packages/ui/demo/pages/AppUiPage.tsx
+++ b/packages/ui/demo/pages/AppUiPage.tsx
@@ -1,0 +1,257 @@
+import { useEffect } from 'preact/hooks';
+import type { ComponentType } from 'preact';
+
+// ─── Application Shells ───────────────────────────────────────────────────────
+import { MultiColumnDemo } from '../sections/MultiColumnDemo.tsx';
+import { MultiColumnShellsDemo } from '../sections/application-shells/multi-column/MultiColumnShellsDemo.tsx';
+import { SidebarShellsDemo } from '../sections/application-shells/sidebar/SidebarShellsDemo.tsx';
+import { StackedShellsDemo } from '../sections/application-shells/stacked/StackedShellsDemo.tsx';
+
+// ─── Data Display ─────────────────────────────────────────────────────────────
+import { StatsDemo } from '../sections/StatsDemo.tsx';
+import { CalendarsDemo } from '../sections/CalendarsDemo.tsx';
+import { CalendarsHeadlessDemo } from '../sections/data-display/calendars/CalendarsHeadlessDemo.tsx';
+import { DescriptionListsDemo } from '../sections/DescriptionListsDemo.tsx';
+
+// ─── Elements ─────────────────────────────────────────────────────────────────
+import { AvatarsDemo } from '../sections/elements/avatars/AvatarsDemo.tsx';
+import { BadgesDemo } from '../sections/elements/badges/BadgesDemo.tsx';
+import { ButtonsDemo } from '../sections/elements/buttons/ButtonsDemo.tsx';
+import { ButtonGroupsDemo } from '../sections/elements/button-groups/ButtonGroupsDemo.tsx';
+import { DropdownsDemo } from '../sections/elements/dropdowns/DropdownsDemo.tsx';
+
+// ─── Feedback ─────────────────────────────────────────────────────────────────
+import { AlertsDemo } from '../sections/feedback/alerts/AlertsDemo.tsx';
+import { EmptyStatesDemo } from '../sections/EmptyStatesDemo.tsx';
+
+// ─── Forms ────────────────────────────────────────────────────────────────────
+import { FormLayoutsDemo } from '../sections/forms/form-layouts/FormLayoutsDemo.tsx';
+import { InputGroupsDemo } from '../sections/forms/input-groups/InputGroupsDemo.tsx';
+import { RadioGroupsDemo } from '../sections/forms/radio-groups/RadioGroupsDemo.tsx';
+import { SelectMenusDemo } from '../sections/forms/select-menus/SelectMenusDemo.tsx';
+import { CustomSelectMenusDemo } from '../sections/forms/select-menus/CustomSelectMenusDemo.tsx';
+import { ComboboxesDemo } from '../sections/forms/comboboxes/ComboboxesDemo.tsx';
+import { ActionPanelsDemo } from '../sections/ActionPanelsDemo.tsx';
+import { CheckboxesDemo } from '../sections/CheckboxesDemo.tsx';
+import { SignInFormsDemo } from '../sections/SignInFormsDemo.tsx';
+import { TextareasDemo } from '../sections/TextareasDemo.tsx';
+import { TogglesDemo } from '../sections/TogglesDemo.tsx';
+
+// ─── Headings ─────────────────────────────────────────────────────────────────
+import { CardHeadingsDemo } from '../sections/headings/card-headings/CardHeadingsDemo.tsx';
+import { PageHeadingsDemo } from '../sections/headings/page-headings/PageHeadingsDemo.tsx';
+import { SectionHeadingsDemo } from '../sections/headings/section-headings/SectionHeadingsDemo.tsx';
+
+// ─── Layout ───────────────────────────────────────────────────────────────────
+import { CardsDemo } from '../sections/layout/cards/CardsDemo.tsx';
+import { ContainersDemo } from '../sections/layout/containers/ContainersDemo.tsx';
+import { DividersDemo } from '../sections/layout/dividers/DividersDemo.tsx';
+import { ListContainersDemo } from '../sections/layout/list-containers/ListContainersDemo.tsx';
+import { MediaObjectsDemo } from '../sections/layout/media-objects/MediaObjectsDemo.tsx';
+
+// ─── Lists ────────────────────────────────────────────────────────────────────
+import { FeedsDemo } from '../sections/FeedsDemo.tsx';
+import { GridListsDemo } from '../sections/GridListsDemo.tsx';
+import { StackedListsDemo } from '../sections/StackedListsDemo.tsx';
+import { TablesDemo } from '../sections/TablesDemo.tsx';
+
+// ─── Navigation ───────────────────────────────────────────────────────────────
+import { BreadcrumbsDemo } from '../sections/BreadcrumbsDemo.tsx';
+import { CommandPalettesDemo } from '../sections/navigation/CommandPalettesDemo.tsx';
+import { NavbarsDemo } from '../sections/navigation/NavbarsDemo.tsx';
+import { PaginationDemo } from '../sections/PaginationDemo.tsx';
+import { ProgressBarsDemo } from '../sections/ProgressBarsDemo.tsx';
+import { SidebarNavigationDemo } from '../sections/SidebarNavigationDemo.tsx';
+import { VerticalNavigationDemo } from '../sections/VerticalNavigationDemo.tsx';
+
+// ─── Overlays ─────────────────────────────────────────────────────────────────
+import { DrawersDemo } from '../sections/overlays/DrawersDemo.tsx';
+import { ModalDialogsDemo } from '../sections/overlays/ModalDialogsDemo.tsx';
+import { NotificationDemo } from '../sections/NotificationDemo.tsx';
+
+// ─── Page Examples ────────────────────────────────────────────────────────────
+import { DetailScreensDemo } from '../sections/DetailScreensDemo.tsx';
+import { HomeScreensDemo } from '../sections/HomeScreensDemo.tsx';
+import { SettingsScreensDemo } from '../sections/SettingsScreensDemo.tsx';
+
+interface SectionDef {
+	id: string;
+	title: string;
+	Component: ComponentType;
+}
+
+const categoryMap: Record<string, SectionDef[]> = {
+	'application-shells': [
+		{ id: 'ui-appshells-multi-column', title: 'Multi-column', Component: MultiColumnDemo },
+		{
+			id: 'ui-appshells-multi-column-shells',
+			title: 'Multi-column (Headless)',
+			Component: MultiColumnShellsDemo,
+		},
+		{ id: 'ui-appshells-sidebar', title: 'Sidebar (Headless)', Component: SidebarShellsDemo },
+		{ id: 'ui-appshells-stacked', title: 'Stacked (Headless)', Component: StackedShellsDemo },
+	],
+	'data-display': [
+		{ id: 'ui-data-display-stats', title: 'Stats', Component: StatsDemo },
+		{ id: 'ui-data-display-calendars', title: 'Calendars', Component: CalendarsDemo },
+		{
+			id: 'ui-data-display-calendars-hl',
+			title: 'Calendars (Headless)',
+			Component: CalendarsHeadlessDemo,
+		},
+		{
+			id: 'ui-data-display-description-lists',
+			title: 'Description Lists',
+			Component: DescriptionListsDemo,
+		},
+	],
+	elements: [
+		{ id: 'ui-elements-avatars', title: 'Avatars', Component: AvatarsDemo },
+		{ id: 'ui-elements-badges', title: 'Badges', Component: BadgesDemo },
+		{ id: 'ui-elements-buttons', title: 'Buttons', Component: ButtonsDemo },
+		{ id: 'ui-elements-button-groups', title: 'Button Groups', Component: ButtonGroupsDemo },
+		{ id: 'ui-elements-dropdowns', title: 'Dropdowns', Component: DropdownsDemo },
+	],
+	feedback: [
+		{ id: 'ui-feedback-alerts', title: 'Alerts', Component: AlertsDemo },
+		{ id: 'ui-feedback-empty-states', title: 'Empty States', Component: EmptyStatesDemo },
+	],
+	forms: [
+		{ id: 'ui-forms-form-layouts', title: 'Form Layouts', Component: FormLayoutsDemo },
+		{ id: 'ui-forms-input-groups', title: 'Input Groups', Component: InputGroupsDemo },
+		{ id: 'ui-forms-radio-groups', title: 'Radio Groups', Component: RadioGroupsDemo },
+		{ id: 'ui-forms-select-menus', title: 'Select Menus', Component: SelectMenusDemo },
+		{
+			id: 'ui-forms-select-menus-hl',
+			title: 'Select Menus (Headless)',
+			Component: CustomSelectMenusDemo,
+		},
+		{ id: 'ui-forms-comboboxes', title: 'Comboboxes', Component: ComboboxesDemo },
+		{ id: 'ui-forms-action-panels', title: 'Action Panels', Component: ActionPanelsDemo },
+		{ id: 'ui-forms-checkboxes', title: 'Checkboxes', Component: CheckboxesDemo },
+		{ id: 'ui-forms-sign-in-forms', title: 'Sign-in Forms', Component: SignInFormsDemo },
+		{ id: 'ui-forms-textareas', title: 'Textareas', Component: TextareasDemo },
+		{ id: 'ui-forms-toggles', title: 'Toggles', Component: TogglesDemo },
+	],
+	headings: [
+		{ id: 'ui-headings-card-headings', title: 'Card Headings', Component: CardHeadingsDemo },
+		{ id: 'ui-headings-page-headings', title: 'Page Headings', Component: PageHeadingsDemo },
+		{
+			id: 'ui-headings-section-headings',
+			title: 'Section Headings',
+			Component: SectionHeadingsDemo,
+		},
+	],
+	layout: [
+		{ id: 'ui-layout-cards', title: 'Cards', Component: CardsDemo },
+		{ id: 'ui-layout-containers', title: 'Containers', Component: ContainersDemo },
+		{ id: 'ui-layout-dividers', title: 'Dividers', Component: DividersDemo },
+		{ id: 'ui-layout-list-containers', title: 'List Containers', Component: ListContainersDemo },
+		{ id: 'ui-layout-media-objects', title: 'Media Objects', Component: MediaObjectsDemo },
+	],
+	lists: [
+		{ id: 'ui-lists-feeds', title: 'Feeds', Component: FeedsDemo },
+		{ id: 'ui-lists-grid-lists', title: 'Grid Lists', Component: GridListsDemo },
+		{ id: 'ui-lists-stacked-lists', title: 'Stacked Lists', Component: StackedListsDemo },
+		{ id: 'ui-lists-tables', title: 'Tables', Component: TablesDemo },
+	],
+	navigation: [
+		{ id: 'ui-nav-breadcrumbs', title: 'Breadcrumbs', Component: BreadcrumbsDemo },
+		{ id: 'ui-nav-command-palettes', title: 'Command Palettes', Component: CommandPalettesDemo },
+		{ id: 'ui-nav-navbars', title: 'Navbars', Component: NavbarsDemo },
+		{ id: 'ui-nav-pagination', title: 'Pagination', Component: PaginationDemo },
+		{ id: 'ui-nav-progress-bars', title: 'Progress Bars', Component: ProgressBarsDemo },
+		{
+			id: 'ui-nav-sidebar-navigation',
+			title: 'Sidebar Navigation',
+			Component: SidebarNavigationDemo,
+		},
+		{
+			id: 'ui-nav-vertical-navigation',
+			title: 'Vertical Navigation',
+			Component: VerticalNavigationDemo,
+		},
+	],
+	overlays: [
+		{ id: 'ui-overlays-drawers', title: 'Drawers', Component: DrawersDemo },
+		{ id: 'ui-overlays-modal-dialogs', title: 'Modal Dialogs', Component: ModalDialogsDemo },
+		{ id: 'ui-overlays-notifications', title: 'Notifications', Component: NotificationDemo },
+	],
+	'page-examples': [
+		{ id: 'ui-pages-detail-screens', title: 'Detail Screens', Component: DetailScreensDemo },
+		{ id: 'ui-pages-home-screens', title: 'Home Screens', Component: HomeScreensDemo },
+		{
+			id: 'ui-pages-settings-screens',
+			title: 'Settings Screens',
+			Component: SettingsScreensDemo,
+		},
+	],
+};
+
+interface AppUiPageProps {
+	categoryId: string;
+	setActiveSection: (id: string) => void;
+}
+
+export function AppUiPage({ categoryId, setActiveSection }: AppUiPageProps) {
+	const sections = categoryMap[categoryId];
+
+	// Scroll to top on mount
+	useEffect(() => {
+		window.scrollTo(0, 0);
+	}, [categoryId]);
+
+	// Scroll-spy: track which section is most visible
+	useEffect(() => {
+		if (!sections) return;
+
+		const visibleSections = new Map<string, number>();
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					if (entry.isIntersecting) {
+						visibleSections.set(entry.target.id, entry.intersectionRatio);
+					} else {
+						visibleSections.delete(entry.target.id);
+					}
+				}
+
+				let bestId = '';
+				let bestRatio = 0;
+				for (const [id, ratio] of visibleSections) {
+					if (ratio > bestRatio) {
+						bestRatio = ratio;
+						bestId = id;
+					}
+				}
+				setActiveSection(bestId);
+			},
+			{ rootMargin: '-20% 0px -70% 0px', threshold: [0, 0.1, 0.5, 1.0] }
+		);
+
+		const sectionEls = document.querySelectorAll('section[id]');
+		for (const el of sectionEls) observer.observe(el);
+
+		return () => observer.disconnect();
+	}, [categoryId, sections, setActiveSection]);
+
+	if (!sections) {
+		return (
+			<main class="px-8 py-12">
+				<p class="text-text-tertiary">Page not found: {categoryId}</p>
+			</main>
+		);
+	}
+
+	return (
+		<main class="px-8 max-w-6xl">
+			{sections.map(({ id, title, Component }) => (
+				<section key={id} id={id} class="py-12 border-b border-surface-border">
+					<h2 class="text-2xl font-bold mb-6">{title}</h2>
+					<Component />
+				</section>
+			))}
+		</main>
+	);
+}

--- a/packages/ui/demo/pages/AppUiPage.tsx
+++ b/packages/ui/demo/pages/AppUiPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'preact/hooks';
+import { memo } from 'preact/compat';
 import type { ComponentType } from 'preact';
 
 // ─── Application Shells ───────────────────────────────────────────────────────
@@ -193,7 +194,7 @@ interface AppUiPageProps {
 	setActiveSection: (id: string) => void;
 }
 
-export function AppUiPage({ categoryId, setActiveSection }: AppUiPageProps) {
+function AppUiPageInner({ categoryId, setActiveSection }: AppUiPageProps) {
 	const sections = categoryMap[categoryId];
 
 	// Scroll to top on mount
@@ -234,7 +235,8 @@ export function AppUiPage({ categoryId, setActiveSection }: AppUiPageProps) {
 		for (const el of sectionEls) observer.observe(el);
 
 		return () => observer.disconnect();
-	}, [categoryId, sections, setActiveSection]);
+		// setActiveSection is a stable useState setter — intentionally omitted from deps
+	}, [categoryId, sections]);
 
 	if (!sections) {
 		return (
@@ -255,3 +257,5 @@ export function AppUiPage({ categoryId, setActiveSection }: AppUiPageProps) {
 		</main>
 	);
 }
+
+export const AppUiPage = memo(AppUiPageInner);

--- a/packages/ui/demo/pages/HomePage.tsx
+++ b/packages/ui/demo/pages/HomePage.tsx
@@ -1,0 +1,124 @@
+import { useEffect } from 'preact/hooks';
+import type { ComponentType } from 'preact';
+
+import { ButtonDemo } from '../sections/ButtonDemo.tsx';
+import { IconButtonDemo } from '../sections/IconButtonDemo.tsx';
+import { CheckboxDemo } from '../sections/CheckboxDemo.tsx';
+import { SwitchDemo } from '../sections/SwitchDemo.tsx';
+import { RadioGroupDemo } from '../sections/RadioGroupDemo.tsx';
+import { InputDemo } from '../sections/InputDemo.tsx';
+import { FieldDemo } from '../sections/FieldDemo.tsx';
+import { DialogDemo } from '../sections/DialogDemo.tsx';
+import { CommandPaletteDemo } from '../sections/CommandPaletteDemo.tsx';
+import { DrawerDemo } from '../sections/DrawerDemo.tsx';
+import { MenuDemo } from '../sections/MenuDemo.tsx';
+import { DisclosureDemo } from '../sections/DisclosureDemo.tsx';
+import { PopoverDemo } from '../sections/PopoverDemo.tsx';
+import { TooltipDemo } from '../sections/TooltipDemo.tsx';
+import { ToastDemo } from '../sections/ToastDemo.tsx';
+import { NotificationDemo } from '../sections/NotificationDemo.tsx';
+import { TabsDemo } from '../sections/TabsDemo.tsx';
+import { ListboxDemo } from '../sections/ListboxDemo.tsx';
+import { ComboboxDemo } from '../sections/ComboboxDemo.tsx';
+import { TransitionDemo } from '../sections/TransitionDemo.tsx';
+import { SpinnerDemo } from '../sections/SpinnerDemo.tsx';
+import { SkeletonDemo } from '../sections/SkeletonDemo.tsx';
+
+interface SectionDef {
+	id: string;
+	title: string;
+	Component: ComponentType;
+}
+
+const headlessSections: SectionDef[] = [
+	{ id: 'hc-button', title: 'Button', Component: ButtonDemo },
+	{ id: 'hc-icon-button', title: 'IconButton', Component: IconButtonDemo },
+	{ id: 'hc-checkbox', title: 'Checkbox', Component: CheckboxDemo },
+	{ id: 'hc-switch', title: 'Switch', Component: SwitchDemo },
+	{ id: 'hc-radio-group', title: 'RadioGroup', Component: RadioGroupDemo },
+	{ id: 'hc-input', title: 'Input', Component: InputDemo },
+	{ id: 'hc-field', title: 'Field', Component: FieldDemo },
+	{ id: 'hc-dialog', title: 'Dialog', Component: DialogDemo },
+	{
+		id: 'hc-command-palette',
+		title: 'Command Palette (Dialog + Combobox)',
+		Component: CommandPaletteDemo,
+	},
+	{ id: 'hc-drawer', title: 'Drawer', Component: DrawerDemo },
+	{ id: 'hc-menu', title: 'Menu', Component: MenuDemo },
+	{ id: 'hc-disclosure', title: 'Disclosure', Component: DisclosureDemo },
+	{ id: 'hc-popover', title: 'Popover', Component: PopoverDemo },
+	{ id: 'hc-tooltip', title: 'Tooltip', Component: TooltipDemo },
+	{ id: 'hc-toast', title: 'Toast', Component: ToastDemo },
+	{ id: 'hc-notification', title: 'Notification (Toast Variants)', Component: NotificationDemo },
+	{ id: 'hc-tabs', title: 'Tabs', Component: TabsDemo },
+	{ id: 'hc-listbox', title: 'Listbox', Component: ListboxDemo },
+	{ id: 'hc-combobox', title: 'Combobox', Component: ComboboxDemo },
+	{ id: 'hc-transition', title: 'Transition', Component: TransitionDemo },
+	{ id: 'hc-spinner', title: 'Spinner', Component: SpinnerDemo },
+	{ id: 'hc-skeleton', title: 'Skeleton', Component: SkeletonDemo },
+];
+
+interface HomePageProps {
+	setActiveSection: (id: string) => void;
+}
+
+export function HomePage({ setActiveSection }: HomePageProps) {
+	// Scroll to top on mount, then check if there's an anchor to scroll to
+	useEffect(() => {
+		const hash = window.location.hash;
+		if (hash && !hash.startsWith('#/')) {
+			// Anchor link to a specific section — scroll to it after a brief tick
+			const el = document.getElementById(hash.slice(1));
+			if (el) {
+				el.scrollIntoView({ behavior: 'smooth' });
+			}
+		} else {
+			window.scrollTo(0, 0);
+		}
+	}, []);
+
+	// Scroll-spy: track which section is most visible
+	useEffect(() => {
+		const visibleSections = new Map<string, number>();
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					if (entry.isIntersecting) {
+						visibleSections.set(entry.target.id, entry.intersectionRatio);
+					} else {
+						visibleSections.delete(entry.target.id);
+					}
+				}
+
+				let bestId = '';
+				let bestRatio = 0;
+				for (const [id, ratio] of visibleSections) {
+					if (ratio > bestRatio) {
+						bestRatio = ratio;
+						bestId = id;
+					}
+				}
+				setActiveSection(bestId);
+			},
+			{ rootMargin: '-20% 0px -70% 0px', threshold: [0, 0.1, 0.5, 1.0] }
+		);
+
+		const sectionEls = document.querySelectorAll('section[id]');
+		for (const el of sectionEls) observer.observe(el);
+
+		return () => observer.disconnect();
+	}, [setActiveSection]);
+
+	return (
+		<main class="px-8 max-w-6xl">
+			{headlessSections.map(({ id, title, Component }) => (
+				<section key={id} id={id} class="py-12 border-b border-surface-border">
+					<h2 class="text-2xl font-bold mb-6">{title}</h2>
+					<Component />
+				</section>
+			))}
+		</main>
+	);
+}

--- a/packages/ui/demo/pages/HomePage.tsx
+++ b/packages/ui/demo/pages/HomePage.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'preact/hooks';
+import { memo } from 'preact/compat';
 import type { ComponentType } from 'preact';
 
 import { ButtonDemo } from '../sections/ButtonDemo.tsx';
@@ -63,7 +64,7 @@ interface HomePageProps {
 	setActiveSection: (id: string) => void;
 }
 
-export function HomePage({ setActiveSection }: HomePageProps) {
+function HomePageInner({ setActiveSection }: HomePageProps) {
 	// Scroll to top on mount, then check if there's an anchor to scroll to
 	useEffect(() => {
 		const hash = window.location.hash;
@@ -109,7 +110,8 @@ export function HomePage({ setActiveSection }: HomePageProps) {
 		for (const el of sectionEls) observer.observe(el);
 
 		return () => observer.disconnect();
-	}, [setActiveSection]);
+		// setActiveSection is a stable useState setter — intentionally omitted from deps
+	}, []);
 
 	return (
 		<main class="px-8 max-w-6xl">
@@ -122,3 +124,5 @@ export function HomePage({ setActiveSection }: HomePageProps) {
 		</main>
 	);
 }
+
+export const HomePage = memo(HomePageInner);

--- a/packages/ui/demo/sections/NotificationDemo.tsx
+++ b/packages/ui/demo/sections/NotificationDemo.tsx
@@ -339,7 +339,7 @@ function InlineToastExamples() {
 }
 
 function NotificationWithAvatar() {
-	const [show, setShow] = useState(true);
+	const [show, setShow] = useState(false);
 
 	return (
 		<div class="space-y-4">
@@ -397,7 +397,7 @@ function NotificationWithAvatar() {
 }
 
 function NotificationWithSplitButtons() {
-	const [show, setShow] = useState(true);
+	const [show, setShow] = useState(false);
 
 	return (
 		<div class="space-y-4">
@@ -461,7 +461,7 @@ function NotificationWithSplitButtons() {
 }
 
 function SimpleIconNotification() {
-	const [show, setShow] = useState(true);
+	const [show, setShow] = useState(false);
 
 	return (
 		<div class="space-y-4">
@@ -518,7 +518,7 @@ function SimpleIconNotification() {
 }
 
 function CondensedNotification() {
-	const [show, setShow] = useState(true);
+	const [show, setShow] = useState(false);
 
 	return (
 		<div class="space-y-4">
@@ -577,7 +577,7 @@ function CondensedNotification() {
 }
 
 function NotificationWithActionsBelow() {
-	const [show, setShow] = useState(true);
+	const [show, setShow] = useState(false);
 
 	return (
 		<div class="space-y-4">
@@ -648,7 +648,7 @@ function NotificationWithActionsBelow() {
 }
 
 function NotificationWithButtonsBelow() {
-	const [show, setShow] = useState(true);
+	const [show, setShow] = useState(false);
 
 	return (
 		<div class="space-y-4">

--- a/packages/ui/src/components/toast/toast.tsx
+++ b/packages/ui/src/components/toast/toast.tsx
@@ -1,5 +1,5 @@
 import { type ComponentChildren, createContext, createElement } from 'preact';
-import { useCallback, useContext, useEffect, useRef, useState } from 'preact/hooks';
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { Portal } from '../../internal/portal.ts';
 import { render } from '../../internal/render.ts';
 import type { ElementType } from '../../internal/types.ts';
@@ -175,17 +175,31 @@ function ToastFn({
 		setOpen(false);
 	}, []);
 
-	const ctx: ToastState = {
-		id,
-		open,
-		dismiss,
-		titleId,
-		setTitleId,
-		descriptionId,
-		setDescriptionId,
-		variant,
-		progress: showProgress ? progress : undefined,
-	};
+	const ctx = useMemo<ToastState>(
+		() => ({
+			id,
+			open,
+			dismiss,
+			titleId,
+			setTitleId,
+			descriptionId,
+			setDescriptionId,
+			variant,
+			progress: showProgress ? progress : undefined,
+		}),
+		[
+			id,
+			open,
+			dismiss,
+			titleId,
+			setTitleId,
+			descriptionId,
+			setDescriptionId,
+			variant,
+			showProgress,
+			progress,
+		]
+	);
 
 	const slot = { open };
 


### PR DESCRIPTION
Rebuilds `packages/ui/demo/App.tsx` from scratch and extracts a new `Sidebar.tsx`.

**Key changes:**
- New `Sidebar.tsx` with two clearly-labeled top-level groups: **Headless Components** (22 primitives) and **Application UI** (11 categorized sections)
- Every section has a globally unique prefixed ID (`hc-*` for headless, `ui-{category}-*` for Application UI) — no more duplicate IDs or `href` override hacks
- `App.tsx` replaces 70+ hand-written `<DemoSection>` blocks with a typed section registry array rendered via `.map()`, cutting the file from 785 to ~280 lines
- Items previously shared between both sidebar groups (stats, feeds, grid-lists, tables, breadcrumbs, pagination, etc.) now live exclusively in the appropriate Application UI category
- Search/filter, IntersectionObserver scroll-spy, and dark/light theme toggle are all preserved