### PR TITLE
fix: move space e2e tests to LLM_TESTS and fix ripgrep in sandbox

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -831,6 +831,9 @@ jobs:
             features/rewind-features
             features/session-operations
             features/slash-cmd
+            features/space-approval-gate-rejection
+            features/space-artifacts-panel
+            features/space-canvas-mode
             features/space-happy-path-pipeline
             features/worktree-isolation
             responsive/mobile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -827,9 +827,11 @@ jobs:
             features/message-operations
             features/provider-model-switching
             features/reference-autocomplete
+            features/reviewer-feedback-loop
             features/rewind-features
             features/session-operations
             features/slash-cmd
+            features/space-happy-path-pipeline
             features/worktree-isolation
             responsive/mobile
             responsive/tablet

--- a/packages/daemon/src/lib/agent/sdk-cli-resolver.ts
+++ b/packages/daemon/src/lib/agent/sdk-cli-resolver.ts
@@ -17,6 +17,7 @@ import {
 	lstatSync,
 	mkdirSync,
 	readFileSync,
+	unlinkSync,
 	writeFileSync,
 } from 'node:fs';
 import { execSync } from 'node:child_process';
@@ -134,11 +135,11 @@ function extractEmbeddedCli(): string | undefined {
 			writeFileSync(extractPath, content, { mode: 0o755 });
 		}
 
-		// Ensure vendor ripgrep exists for sandbox mode.
+		// Ensure vendor ripgrep binary exists for sandbox mode.
 		// The SDK checks for ripgrep at vendor/ripgrep/<platform>/rg relative to cli.js.
 		// In compiled binary mode the vendor directory is not bundled, so we copy
 		// the system-installed ripgrep (from apt-get / brew) if available.
-		linkSystemRipgrepToVendor(extractDir);
+		copySystemRipgrepToVendor(extractDir);
 
 		return extractPath;
 	} catch {
@@ -206,21 +207,26 @@ function findSystemRipgrep(): string | undefined {
  * No-op if:
  *  - Platform is Windows (unsupported)
  *  - System ripgrep is not installed
- *  - The vendor binary already exists (valid file, not a broken symlink)
+ *  - The vendor binary already exists as a valid, non-empty regular file
+ *
+ * Replaces broken symlinks or empty files left by previous binary versions.
  */
-function linkSystemRipgrepToVendor(extractDir: string): void {
+function copySystemRipgrepToVendor(extractDir: string): void {
 	const platform = getSdkVendorPlatform();
 	if (!platform) return;
 
 	const ripgrepDir = join(extractDir, 'vendor', 'ripgrep', platform);
 	const ripgrepDest = join(ripgrepDir, 'rg');
 
-	// Check with lstatSync to detect broken symlinks (existsSync follows symlinks
-	// and returns false for a dangling symlink, preventing re-creation).
+	// Use lstatSync (not existsSync) so broken symlinks are detected — existsSync
+	// follows symlinks and returns false for a dangling one, preventing re-creation.
 	try {
 		const stat = lstatSync(ripgrepDest);
 		if (stat.isFile() && stat.size > 0) return; // Already a real, non-empty file
-		// It's a broken symlink or empty file — remove and replace with a real copy
+		// Broken symlink or zero-size file from a previous run — remove it so
+		// copyFileSync can write to this path (on Linux, copying to a dangling
+		// symlink target fails because the OS tries to dereference it).
+		unlinkSync(ripgrepDest);
 	} catch {
 		// Path doesn't exist at all — proceed to copy
 	}

--- a/packages/daemon/src/lib/agent/sdk-cli-resolver.ts
+++ b/packages/daemon/src/lib/agent/sdk-cli-resolver.ts
@@ -10,7 +10,16 @@
  * it to a real filesystem path.
  */
 
-import { existsSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
+import {
+	chmodSync,
+	copyFileSync,
+	existsSync,
+	lstatSync,
+	mkdirSync,
+	readFileSync,
+	writeFileSync,
+} from 'node:fs';
+import { execSync } from 'node:child_process';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
@@ -125,9 +134,9 @@ function extractEmbeddedCli(): string | undefined {
 			writeFileSync(extractPath, content, { mode: 0o755 });
 		}
 
-		// Ensure vendor ripgrep is linked for sandbox mode.
+		// Ensure vendor ripgrep exists for sandbox mode.
 		// The SDK checks for ripgrep at vendor/ripgrep/<platform>/rg relative to cli.js.
-		// In compiled binary mode the vendor directory is not bundled, so we symlink
+		// In compiled binary mode the vendor directory is not bundled, so we copy
 		// the system-installed ripgrep (from apt-get / brew) if available.
 		linkSystemRipgrepToVendor(extractDir);
 
@@ -163,45 +172,69 @@ const SYSTEM_RIPGREP_PATHS = [
 
 /**
  * Locate the system ripgrep executable, or return undefined if not found.
+ *
+ * Checks well-known install paths first; falls back to `which rg` for
+ * non-standard installations (e.g. nix, asdf, custom prefix).
  */
 function findSystemRipgrep(): string | undefined {
 	for (const p of SYSTEM_RIPGREP_PATHS) {
 		if (existsSync(p)) return p;
 	}
+	// Fallback: ask the shell where rg lives
+	try {
+		const result = execSync('which rg', { encoding: 'utf-8', timeout: 2000 }).trim();
+		if (result && existsSync(result)) return result;
+	} catch {
+		// `which` not available or rg not found on PATH — ignore
+	}
 	return undefined;
 }
 
 /**
- * Symlink the system ripgrep into the SDK's expected vendor directory.
+ * Copy the system ripgrep binary into the SDK's expected vendor directory.
  *
  * When the compiled binary extracts cli.js to extractDir, the SDK will look
  * for ripgrep at `<extractDir>/vendor/ripgrep/<platform>/rg`.  This function
- * creates that symlink pointing to the system ripgrep so that sandbox mode
- * works without needing the full vendor bundle embedded in the binary.
+ * copies the system-installed ripgrep binary there so that sandbox mode works
+ * without needing the full vendor bundle embedded in the binary.
+ *
+ * We intentionally COPY (not symlink) the binary so that it is accessible
+ * inside bubblewrap sandbox environments.  The SDK mounts the extract
+ * directory into the sandbox, but the symlink target (e.g. /usr/bin/rg) may
+ * live outside the sandbox mount and therefore appear as ENOENT.
  *
  * No-op if:
  *  - Platform is Windows (unsupported)
  *  - System ripgrep is not installed
- *  - The vendor symlink already exists
+ *  - The vendor binary already exists (valid file, not a broken symlink)
  */
 function linkSystemRipgrepToVendor(extractDir: string): void {
 	const platform = getSdkVendorPlatform();
 	if (!platform) return;
 
 	const ripgrepDir = join(extractDir, 'vendor', 'ripgrep', platform);
-	const ripgrepLink = join(ripgrepDir, 'rg');
+	const ripgrepDest = join(ripgrepDir, 'rg');
 
-	if (existsSync(ripgrepLink)) return;
+	// Check with lstatSync to detect broken symlinks (existsSync follows symlinks
+	// and returns false for a dangling symlink, preventing re-creation).
+	try {
+		const stat = lstatSync(ripgrepDest);
+		if (stat.isFile() && stat.size > 0) return; // Already a real, non-empty file
+		// It's a broken symlink or empty file — remove and replace with a real copy
+	} catch {
+		// Path doesn't exist at all — proceed to copy
+	}
 
 	const systemRg = findSystemRipgrep();
 	if (!systemRg) return;
 
 	try {
 		mkdirSync(ripgrepDir, { recursive: true });
-		symlinkSync(systemRg, ripgrepLink);
+		copyFileSync(systemRg, ripgrepDest);
+		chmodSync(ripgrepDest, 0o755);
 	} catch {
-		// Race condition: another process created it, or filesystem doesn't support symlinks.
-		// Silently ignore — the SDK will either find the symlink or report its own error.
+		// Race condition: another process created it, or filesystem error.
+		// Silently ignore — the SDK will either find the binary or report its own error.
 	}
 }
 

--- a/packages/daemon/tests/unit/agent/sdk-cli-resolver.test.ts
+++ b/packages/daemon/tests/unit/agent/sdk-cli-resolver.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, expect, it, beforeEach, afterEach, spyOn } from 'bun:test';
 import * as fs from 'node:fs';
+import * as childProcess from 'node:child_process';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -67,6 +68,7 @@ describe('sdk-cli-resolver', () => {
 		describe('embedded CLI extraction', () => {
 			let existsSyncSpy: ReturnType<typeof spyOn>;
 			let lstatSyncSpy: ReturnType<typeof spyOn>;
+			let unlinkSyncSpy: ReturnType<typeof spyOn>;
 			let readFileSyncSpy: ReturnType<typeof spyOn>;
 			let writeFileSyncSpy: ReturnType<typeof spyOn>;
 			let mkdirSyncSpy: ReturnType<typeof spyOn>;
@@ -82,10 +84,11 @@ describe('sdk-cli-resolver', () => {
 				testFile = join(tmpdir(), `neokai-test-embedded-${Date.now()}.js`);
 				fs.writeFileSync(testFile, testContent);
 
-				// Always stub copyFileSync and chmodSync so tests don't copy real binaries and
-				// vendor-ripgrep setup doesn't interfere with cli.js write assertions.
+				// Always stub copyFileSync, chmodSync, and unlinkSync so tests don't mutate
+				// real files; vendor-ripgrep setup won't interfere with cli.js write assertions.
 				copyFileSyncSpy = spyOn(fs, 'copyFileSync').mockImplementation(() => {});
 				chmodSyncSpy = spyOn(fs, 'chmodSync').mockImplementation(() => {});
+				unlinkSyncSpy = spyOn(fs, 'unlinkSync').mockImplementation(() => {});
 				// Always stub lstatSync to throw ENOENT by default (ripgrep not yet copied).
 				// Individual tests override this spy to simulate an already-present binary.
 				lstatSyncSpy = spyOn(fs, 'lstatSync').mockImplementation((path: fs.PathLike) => {
@@ -96,6 +99,7 @@ describe('sdk-cli-resolver', () => {
 			afterEach(() => {
 				existsSyncSpy?.mockRestore();
 				lstatSyncSpy?.mockRestore();
+				unlinkSyncSpy?.mockRestore();
 				readFileSyncSpy?.mockRestore();
 				writeFileSyncSpy?.mockRestore();
 				mkdirSyncSpy?.mockRestore();
@@ -359,13 +363,106 @@ describe('sdk-cli-resolver', () => {
 					setEmbeddedCliPath(testFile);
 					resolveSDKCliPath();
 
-					// On Windows, linkSystemRipgrepToVendor no-ops — copyFileSync must NOT be called
+					// On Windows, copySystemRipgrepToVendor no-ops — copyFileSync must NOT be called
 					expect(copyFileSyncSpy).not.toHaveBeenCalled();
 				} finally {
 					Object.defineProperty(process, 'platform', {
 						value: originalPlatform,
 						configurable: true,
 					});
+				}
+			});
+
+			it('replaces broken symlink with real binary copy', () => {
+				const originalReadFileSync = fs.readFileSync.bind(fs);
+				const fakeSystemRg = '/usr/bin/rg';
+
+				existsSyncSpy = spyOn(fs, 'existsSync').mockImplementation((path: fs.PathLike) => {
+					const p = String(path);
+					if (p.includes('node_modules')) return false;
+					if (p.includes('neokai-sdk') && p.endsWith('cli.js')) return false;
+					if (p === fakeSystemRg) return true;
+					return false;
+				});
+
+				// Simulate a dangling symlink at the vendor path (isFile()=false, i.e. a symlink)
+				lstatSyncSpy.mockImplementation((path: fs.PathLike) => {
+					const p = String(path);
+					if (p.includes('vendor') && p.endsWith('/rg')) {
+						// Symlink entry exists but is not a regular file (dangling symlink)
+						return { isFile: () => false, size: 0 } as unknown as fs.Stats;
+					}
+					throw Object.assign(new Error('ENOENT'), { code: 'ENOENT', path: p });
+				});
+
+				readFileSyncSpy = spyOn(fs, 'readFileSync').mockImplementation(
+					(path: fs.PathOrFileDescriptor, options?: unknown) => {
+						return originalReadFileSync(path, options as undefined);
+					}
+				);
+
+				mkdirSyncSpy = spyOn(fs, 'mkdirSync').mockImplementation(
+					() => undefined as unknown as string
+				);
+				writeFileSyncSpy = spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+
+				setEmbeddedCliPath(testFile);
+				resolveSDKCliPath();
+
+				// Broken symlink must be removed before copying
+				expect(unlinkSyncSpy).toHaveBeenCalledTimes(1);
+				const [unlinkedPath] = unlinkSyncSpy.mock.calls[0] as [string];
+				expect(unlinkedPath).toContain('vendor');
+				expect(unlinkedPath).toEndWith('rg');
+				// Then the real binary must be copied in
+				expect(copyFileSyncSpy).toHaveBeenCalledTimes(1);
+				const [src] = copyFileSyncSpy.mock.calls[0] as [string];
+				expect(src).toBe(fakeSystemRg);
+			});
+
+			it('uses which rg fallback when system rg is not at well-known paths', () => {
+				const execSyncSpy = spyOn(childProcess, 'execSync').mockImplementation((cmd: string) => {
+					if (String(cmd) === 'which rg') return '/custom/bin/rg\n' as unknown as Buffer;
+					throw new Error(`unexpected execSync: ${cmd}`);
+				});
+
+				const originalReadFileSync = fs.readFileSync.bind(fs);
+				const fakeSystemRg = '/custom/bin/rg';
+
+				existsSyncSpy = spyOn(fs, 'existsSync').mockImplementation((path: fs.PathLike) => {
+					const p = String(path);
+					if (p.includes('node_modules')) return false;
+					if (p.includes('neokai-sdk') && p.endsWith('cli.js')) return false;
+					// Well-known rg paths are absent — forces fallback to `which rg`
+					if (p === '/usr/bin/rg' || p === '/usr/local/bin/rg') return false;
+					// The path returned by `which rg` does exist
+					if (p === fakeSystemRg) return true;
+					return false;
+				});
+
+				readFileSyncSpy = spyOn(fs, 'readFileSync').mockImplementation(
+					(path: fs.PathOrFileDescriptor, options?: unknown) => {
+						return originalReadFileSync(path, options as undefined);
+					}
+				);
+
+				mkdirSyncSpy = spyOn(fs, 'mkdirSync').mockImplementation(
+					() => undefined as unknown as string
+				);
+				writeFileSyncSpy = spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+
+				try {
+					setEmbeddedCliPath(testFile);
+					resolveSDKCliPath();
+
+					// `which rg` fallback was exercised and the binary was found at the custom path
+					expect(execSyncSpy).toHaveBeenCalledWith('which rg', expect.anything());
+					// copyFileSync should use the path returned by `which rg`
+					expect(copyFileSyncSpy).toHaveBeenCalledTimes(1);
+					const [src] = copyFileSyncSpy.mock.calls[0] as [string];
+					expect(src).toBe(fakeSystemRg);
+				} finally {
+					execSyncSpy.mockRestore();
 				}
 			});
 		});

--- a/packages/daemon/tests/unit/agent/sdk-cli-resolver.test.ts
+++ b/packages/daemon/tests/unit/agent/sdk-cli-resolver.test.ts
@@ -66,10 +66,12 @@ describe('sdk-cli-resolver', () => {
 
 		describe('embedded CLI extraction', () => {
 			let existsSyncSpy: ReturnType<typeof spyOn>;
+			let lstatSyncSpy: ReturnType<typeof spyOn>;
 			let readFileSyncSpy: ReturnType<typeof spyOn>;
 			let writeFileSyncSpy: ReturnType<typeof spyOn>;
 			let mkdirSyncSpy: ReturnType<typeof spyOn>;
-			let symlinkSyncSpy: ReturnType<typeof spyOn>;
+			let copyFileSyncSpy: ReturnType<typeof spyOn>;
+			let chmodSyncSpy: ReturnType<typeof spyOn>;
 			let testFile: string;
 			const testContent = 'console.log("test cli");\n';
 
@@ -80,17 +82,25 @@ describe('sdk-cli-resolver', () => {
 				testFile = join(tmpdir(), `neokai-test-embedded-${Date.now()}.js`);
 				fs.writeFileSync(testFile, testContent);
 
-				// Always stub symlinkSync so tests don't create real symlinks and
-				// vendor-ripgrep linking doesn't interfere with cli.js write assertions.
-				symlinkSyncSpy = spyOn(fs, 'symlinkSync').mockImplementation(() => {});
+				// Always stub copyFileSync and chmodSync so tests don't copy real binaries and
+				// vendor-ripgrep setup doesn't interfere with cli.js write assertions.
+				copyFileSyncSpy = spyOn(fs, 'copyFileSync').mockImplementation(() => {});
+				chmodSyncSpy = spyOn(fs, 'chmodSync').mockImplementation(() => {});
+				// Always stub lstatSync to throw ENOENT by default (ripgrep not yet copied).
+				// Individual tests override this spy to simulate an already-present binary.
+				lstatSyncSpy = spyOn(fs, 'lstatSync').mockImplementation((path: fs.PathLike) => {
+					throw Object.assign(new Error('ENOENT'), { code: 'ENOENT', path: String(path) });
+				});
 			});
 
 			afterEach(() => {
 				existsSyncSpy?.mockRestore();
+				lstatSyncSpy?.mockRestore();
 				readFileSyncSpy?.mockRestore();
 				writeFileSyncSpy?.mockRestore();
 				mkdirSyncSpy?.mockRestore();
-				symlinkSyncSpy?.mockRestore();
+				copyFileSyncSpy?.mockRestore();
+				chmodSyncSpy?.mockRestore();
 				try {
 					fs.unlinkSync(testFile);
 				} catch {
@@ -106,8 +116,8 @@ describe('sdk-cli-resolver', () => {
 				existsSyncSpy = spyOn(fs, 'existsSync').mockImplementation((path: fs.PathLike) => {
 					const p = String(path);
 					if (p.includes('node_modules')) return false;
-					// Prevent ripgrep linking so writeFileSync is only called for cli.js
-					if (p.includes('vendor') && p.includes('ripgrep')) return false;
+					// System rg not available — prevents ripgrep copy
+					if (p.endsWith('/rg') || p === '/usr/bin/rg' || p === '/usr/local/bin/rg') return false;
 					return originalExistsSync(p);
 				});
 
@@ -210,7 +220,7 @@ describe('sdk-cli-resolver', () => {
 				expect(mkdirSyncSpy).not.toHaveBeenCalled();
 			});
 
-			it('links system ripgrep to vendor path when system rg is available', () => {
+			it('copies system ripgrep to vendor path when system rg is available', () => {
 				const originalReadFileSync = fs.readFileSync.bind(fs);
 				const fakeSystemRg = '/usr/bin/rg';
 
@@ -219,12 +229,12 @@ describe('sdk-cli-resolver', () => {
 					if (p.includes('node_modules')) return false;
 					// cli.js not yet extracted
 					if (p.includes('neokai-sdk') && p.endsWith('cli.js')) return false;
-					// Vendor ripgrep symlink not yet created
-					if (p.includes('vendor') && p.includes('ripgrep')) return false;
 					// System ripgrep is available
 					if (p === fakeSystemRg) return true;
 					return false;
 				});
+
+				// lstatSyncSpy already throws ENOENT (from beforeEach) — vendor binary absent
 
 				readFileSyncSpy = spyOn(fs, 'readFileSync').mockImplementation(
 					(path: fs.PathOrFileDescriptor, options?: unknown) => {
@@ -240,22 +250,25 @@ describe('sdk-cli-resolver', () => {
 				setEmbeddedCliPath(testFile);
 				resolveSDKCliPath();
 
-				// symlinkSync should have been called to link system rg into the vendor dir
-				expect(symlinkSyncSpy).toHaveBeenCalledTimes(1);
-				const [target, linkPath] = symlinkSyncSpy.mock.calls[0] as [string, string];
-				expect(target).toBe(fakeSystemRg);
-				expect(linkPath).toContain('vendor');
-				expect(linkPath).toContain('ripgrep');
-				expect(linkPath).toEndWith('rg');
+				// copyFileSync should have been called to copy system rg into the vendor dir
+				expect(copyFileSyncSpy).toHaveBeenCalledTimes(1);
+				const [src, dest] = copyFileSyncSpy.mock.calls[0] as [string, string];
+				expect(src).toBe(fakeSystemRg);
+				expect(dest).toContain('vendor');
+				expect(dest).toContain('ripgrep');
+				expect(dest).toEndWith('rg');
+				// chmodSync should also have been called to mark the copy executable
+				expect(chmodSyncSpy).toHaveBeenCalledTimes(1);
 			});
 
-			it('skips vendor ripgrep linking when system rg is not available', () => {
+			it('skips vendor ripgrep copy when system rg is not available', () => {
 				const originalReadFileSync = fs.readFileSync.bind(fs);
 
 				existsSyncSpy = spyOn(fs, 'existsSync').mockImplementation((path: fs.PathLike) => {
 					const p = String(path);
 					if (p.includes('node_modules')) return false;
 					// All paths return false — simulates environment without system ripgrep
+					// (also covers the `which rg` fallback path returned by execSync)
 					return false;
 				});
 
@@ -273,11 +286,11 @@ describe('sdk-cli-resolver', () => {
 				setEmbeddedCliPath(testFile);
 				resolveSDKCliPath();
 
-				// symlinkSync must NOT be called when no system ripgrep is found
-				expect(symlinkSyncSpy).not.toHaveBeenCalled();
+				// copyFileSync must NOT be called when no system ripgrep is found
+				expect(copyFileSyncSpy).not.toHaveBeenCalled();
 			});
 
-			it('skips vendor ripgrep linking when vendor symlink already exists', () => {
+			it('skips vendor ripgrep copy when vendor binary already exists', () => {
 				const originalReadFileSync = fs.readFileSync.bind(fs);
 				const fakeSystemRg = '/usr/bin/rg';
 
@@ -286,11 +299,18 @@ describe('sdk-cli-resolver', () => {
 					if (p.includes('node_modules')) return false;
 					// cli.js is already extracted
 					if (p.includes('neokai-sdk') && p.endsWith('cli.js')) return true;
-					// Vendor ripgrep symlink already exists
-					if (p.includes('vendor') && p.endsWith('/rg')) return true;
-					// System rg available (but should not be used since vendor link exists)
+					// System rg available (but should not be used since vendor copy exists)
 					if (p === fakeSystemRg) return true;
 					return false;
+				});
+
+				// Override the default lstatSync stub: vendor rg binary already present
+				lstatSyncSpy.mockImplementation((path: fs.PathLike) => {
+					const p = String(path);
+					if (p.includes('vendor') && p.endsWith('/rg')) {
+						return { isFile: () => true, size: 12345 } as unknown as fs.Stats;
+					}
+					throw Object.assign(new Error('ENOENT'), { code: 'ENOENT', path: p });
 				});
 
 				readFileSyncSpy = spyOn(fs, 'readFileSync').mockImplementation(
@@ -305,11 +325,11 @@ describe('sdk-cli-resolver', () => {
 				setEmbeddedCliPath(testFile);
 				resolveSDKCliPath();
 
-				// Symlink already exists — must NOT call symlinkSync again
-				expect(symlinkSyncSpy).not.toHaveBeenCalled();
+				// Binary already exists — must NOT call copyFileSync again
+				expect(copyFileSyncSpy).not.toHaveBeenCalled();
 			});
 
-			it('skips vendor ripgrep linking on Windows (win32 platform)', () => {
+			it('skips vendor ripgrep copy on Windows (win32 platform)', () => {
 				const originalReadFileSync = fs.readFileSync.bind(fs);
 
 				// Simulate Windows by temporarily overriding process.platform
@@ -339,8 +359,8 @@ describe('sdk-cli-resolver', () => {
 					setEmbeddedCliPath(testFile);
 					resolveSDKCliPath();
 
-					// On Windows, linkSystemRipgrepToVendor no-ops — symlinkSync must NOT be called
-					expect(symlinkSyncSpy).not.toHaveBeenCalled();
+					// On Windows, linkSystemRipgrepToVendor no-ops — copyFileSync must NOT be called
+					expect(copyFileSyncSpy).not.toHaveBeenCalled();
 				} finally {
 					Object.defineProperty(process, 'platform', {
 						value: originalPlatform,


### PR DESCRIPTION
Fixes 3 consistently failing CI E2E tests from run 23986543916.

**Tests 1 & 2 — miscategorized No-LLM tests:**
`features/reviewer-feedback-loop` and `features/space-happy-path-pipeline` were in the No-LLM bucket but both call `spaceWorkflowRun.start` which triggers real background task agent execution. Moving them to `LLM_TESTS` lets the dev proxy intercept Anthropic API calls so agents complete without real credentials.

**Test 3 — ripgrep ENOENT in bubblewrap sandbox:**
`features/reference-autocomplete` was failing with `ENOENT: posix_spawn '/tmp/neokai-sdk/.../vendor/ripgrep/x64-linux/rg'`. The root cause: we created a *symlink* pointing to `/usr/bin/rg`, but bubblewrap sandbox only mounts the SDK extract directory — symlink targets outside that mount appear as ENOENT inside the sandbox. Fix: copy the ripgrep binary into the vendor directory instead of symlinking. Additional improvements: `lstatSync` instead of `existsSync` to detect broken/dangling symlinks, and `which rg` fallback for non-standard installs.