### PR TITLE
fix: deterministic subprocess exit wait to prevent SDK startup timeout after model switch

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -229,6 +229,7 @@ export class AgentSession
 	firstMessageReceived = false;
 	startupTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
 	originalEnvVars: OriginalEnvVars = {};
+	processExitedPromise: Promise<void> | null = null;
 	// Whether to auto-queue /context after each turn (default: true)
 	// Disabled for room-managed agents to prevent interleaved messages after terminal state
 	contextAutoQueueEnabled = true;

--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -48,6 +48,8 @@ export interface QueryLifecycleManagerContext {
 	queryObject: Query | null;
 	queryPromise: Promise<void> | null;
 	firstMessageReceived: boolean;
+	/** Resolves when the SDK subprocess exits. Used by stop() to wait deterministically. */
+	processExitedPromise: Promise<void> | null;
 
 	// Mutable session state
 	pendingRestartReason: 'settings.local.json' | null;
@@ -145,7 +147,20 @@ export class QueryLifecycleManager {
 			}
 		}
 
-		// 5. Clear references
+		// 5. Wait for the SDK subprocess to fully exit after close().
+		// close() sends SIGTERM but the process may take time to clean up.
+		// Without this, starting a new subprocess immediately can fail because
+		// the old process still holds workspace locks (.claude/ files).
+		const processExitedPromise = this.ctx.processExitedPromise;
+		if (processExitedPromise) {
+			await Promise.race([
+				processExitedPromise,
+				new Promise((resolve) => setTimeout(resolve, timeoutMs)),
+			]);
+			this.ctx.processExitedPromise = null;
+		}
+
+		// 6. Clear references
 		this.ctx.queryObject = null;
 		this.ctx.queryPromise = null;
 	}
@@ -167,12 +182,9 @@ export class QueryLifecycleManager {
 			messageHandler.resetCircuitBreaker();
 			await daemonHub.emit('session.errorClear', { sessionId: session.id });
 
+			// stop() now awaits processExitedPromise, so the old SDK subprocess is
+			// guaranteed to have exited before we proceed. No arbitrary delay needed.
 			await this.stop();
-
-			// Small delay to ensure the old SDK subprocess has fully exited.
-			// Without this, the new subprocess may conflict with the old one
-			// on shared resources (session file, API connections).
-			await new Promise((resolve) => setTimeout(resolve, 100));
 
 			// Validate and repair SDK session file before restarting.
 			// The interrupted query may have left the session file in an inconsistent state

--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -279,8 +279,7 @@ export class QueryLifecycleManager {
 
 			// Optionally restart
 			if (restartAfter) {
-				// Small delay to ensure process cleanup completes
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				// No delay needed — stop() already awaits processExitedPromise.
 
 				// Validate and repair SDK session file before restarting.
 				// The interrupted query may have left the session file in an inconsistent state

--- a/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/agent/query-lifecycle-manager.ts
@@ -96,6 +96,10 @@ export class QueryLifecycleManager {
 		const { timeoutMs = DEFAULT_TERMINATION_TIMEOUT_MS, catchQueryErrors = false } = options ?? {};
 		const { messageQueue } = this.ctx;
 
+		// Snapshot BEFORE awaiting — runQuery()'s finally block clears ctx.processExitedPromise
+		// during queryPromise settlement, so capture it here while it's still set.
+		const processExitedPromise = this.ctx.processExitedPromise;
+
 		// 1. Stop the message queue (no new messages processed)
 		messageQueue.stop();
 
@@ -151,7 +155,9 @@ export class QueryLifecycleManager {
 		// close() sends SIGTERM but the process may take time to clean up.
 		// Without this, starting a new subprocess immediately can fail because
 		// the old process still holds workspace locks (.claude/ files).
-		const processExitedPromise = this.ctx.processExitedPromise;
+		// Uses the local snapshot captured at the top — ctx.processExitedPromise may
+		// have already been cleared by runQuery()'s finally block during queryPromise
+		// settlement above (the race condition this snapshot was introduced to fix).
 		if (processExitedPromise) {
 			await Promise.race([
 				processExitedPromise,
@@ -279,7 +285,10 @@ export class QueryLifecycleManager {
 
 			// Optionally restart
 			if (restartAfter) {
-				// No delay needed — stop() already awaits processExitedPromise.
+				// No delay needed — stop() snapshots processExitedPromise before awaiting
+				// queryPromise, so the old SDK subprocess is guaranteed to have exited
+				// before we proceed (even if runQuery()'s finally block already cleared
+				// ctx.processExitedPromise during queryPromise settlement).
 
 				// Validate and repair SDK session file before restarting.
 				// The interrupted query may have left the session file in an inconsistent state

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -42,6 +42,10 @@ export type { OriginalEnvVars } from '../provider-service';
  * Node's ChildProcess structurally satisfies the SDK's SpawnedProcess
  * interface (stdin, stdout, killed, exitCode, kill, on/once/off for
  * 'exit' and 'error' events).
+ *
+ * SDK coupling: This mirrors the internal spawnLocalProcess() in the SDK (sdk.mjs).
+ * Re-verify this implementation matches the SDK's spawn behavior on SDK upgrades —
+ * mismatches in stdio/env/signal can cause subtle subprocess communication failures.
  */
 function defaultSpawn(opts: SpawnOptions): SpawnedProcess {
 	const debugSdk = opts.env?.DEBUG_CLAUDE_AGENT_SDK;
@@ -562,8 +566,10 @@ export class QueryRunner {
 				}
 
 				// Clear process exit tracking — the subprocess has exited (or will be
-				// cleaned up by close() below). Prevents stale resolved promises from
-				// being misread as "subprocess is running" by future callers.
+				// cleaned up by close() below). Prevents a resolved promise from a
+				// previous generation being observed by stop() after a restart: without
+				// this clear, a future stop() call on a new query could snapshot a stale
+				// resolved promise and skip the real wait for the new subprocess's exit.
 				this.ctx.processExitedPromise = null;
 
 				messageQueue.stop();

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -29,21 +29,36 @@ import type { OriginalEnvVars } from '../provider-service';
 export type { OriginalEnvVars } from '../provider-service';
 
 /**
- * Default spawn implementation matching the SDK's internal behavior.
+ * Default spawn implementation matching the SDK's internal spawnLocalProcess().
  * Used when no custom spawnClaudeCodeProcess is configured, so we can
  * still intercept the subprocess and track its exit.
+ *
+ * Mirrors the SDK's spawn behavior (verified in sdk.mjs):
+ * - stdio: ['pipe', 'pipe', stderr] where stderr is 'pipe' when
+ *   DEBUG_CLAUDE_AGENT_SDK is set, otherwise 'ignore'
+ * - windowsHide: true
+ * - Same cwd, env, signal passthrough
+ *
+ * Node's ChildProcess structurally satisfies the SDK's SpawnedProcess
+ * interface (stdin, stdout, killed, exitCode, kill, on/once/off for
+ * 'exit' and 'error' events).
  */
 function defaultSpawn(opts: SpawnOptions): SpawnedProcess {
+	const debugSdk = opts.env?.DEBUG_CLAUDE_AGENT_SDK;
+	const stderr = debugSdk && debugSdk !== '0' && debugSdk !== 'false' ? 'pipe' : 'ignore';
 	const proc = nodeSpawn(opts.command, opts.args, {
 		cwd: opts.cwd,
 		env: opts.env as NodeJS.ProcessEnv,
-		stdio: ['pipe', 'pipe', 'pipe'],
+		stdio: ['pipe', 'pipe', stderr],
 		signal: opts.signal,
+		windowsHide: true,
 	});
 	return proc as unknown as SpawnedProcess;
 }
 
 const DEFAULT_STARTUP_TIMEOUT_MS = 15000;
+/** Max time to wait for subprocess exit before retrying after startup timeout. */
+const RETRY_EXIT_TIMEOUT_MS = 5000;
 
 function getStartupTimeoutMs(): number {
 	const raw = process.env.NEOKAI_SDK_STARTUP_TIMEOUT_MS;
@@ -407,7 +422,10 @@ export class QueryRunner {
 				// release workspace locks before spawning a replacement.
 				const exitPromise = this.ctx.processExitedPromise;
 				if (exitPromise) {
-					await Promise.race([exitPromise, new Promise((resolve) => setTimeout(resolve, 5000))]);
+					await Promise.race([
+						exitPromise,
+						new Promise((resolve) => setTimeout(resolve, RETRY_EXIT_TIMEOUT_MS)),
+					]);
 					this.ctx.processExitedPromise = null;
 				}
 
@@ -542,6 +560,11 @@ export class QueryRunner {
 					abortController.abort();
 					this.ctx.queryAbortController = null;
 				}
+
+				// Clear process exit tracking — the subprocess has exited (or will be
+				// cleaned up by close() below). Prevents stale resolved promises from
+				// being misread as "subprocess is running" by future callers.
+				this.ctx.processExitedPromise = null;
 
 				messageQueue.stop();
 

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -11,7 +11,8 @@
  */
 
 import { query } from '@anthropic-ai/claude-agent-sdk';
-import type { Query } from '@anthropic-ai/claude-agent-sdk';
+import type { Query, SpawnOptions, SpawnedProcess } from '@anthropic-ai/claude-agent-sdk';
+import { spawn as nodeSpawn } from 'node:child_process';
 import type { UUID } from 'crypto';
 import type { Session, MessageHub } from '@neokai/shared';
 import type { SDKMessage } from '@neokai/shared/sdk';
@@ -26,6 +27,21 @@ import type { AskUserQuestionHandler } from './ask-user-question-handler';
 import type { OriginalEnvVars } from '../provider-service';
 // Re-exported for callers that import OriginalEnvVars from this module — canonical definition lives in provider-service.ts.
 export type { OriginalEnvVars } from '../provider-service';
+
+/**
+ * Default spawn implementation matching the SDK's internal behavior.
+ * Used when no custom spawnClaudeCodeProcess is configured, so we can
+ * still intercept the subprocess and track its exit.
+ */
+function defaultSpawn(opts: SpawnOptions): SpawnedProcess {
+	const proc = nodeSpawn(opts.command, opts.args, {
+		cwd: opts.cwd,
+		env: opts.env as NodeJS.ProcessEnv,
+		stdio: ['pipe', 'pipe', 'pipe'],
+		signal: opts.signal,
+	});
+	return proc as unknown as SpawnedProcess;
+}
 
 const DEFAULT_STARTUP_TIMEOUT_MS = 15000;
 
@@ -64,6 +80,8 @@ export interface QueryRunnerContext {
 	firstMessageReceived: boolean;
 	startupTimeoutTimer: ReturnType<typeof setTimeout> | null;
 	originalEnvVars: OriginalEnvVars;
+	/** Resolves when the SDK subprocess exits. Set by QueryRunner via spawnClaudeCodeProcess wrapper. */
+	processExitedPromise: Promise<void> | null;
 	// Methods for state coordination
 	incrementQueryGeneration(): number;
 	getQueryGeneration(): number;
@@ -217,6 +235,17 @@ export class QueryRunner {
 			// Note: PORT and NEOKAI_PORT are cleared inside applyEnvVarsToProcess() above,
 			// so SDK subprocesses cannot inherit the daemon's listening port.
 
+			// Wrap spawnClaudeCodeProcess to track subprocess exit deterministically.
+			// This lets stop() await the actual process exit instead of using arbitrary delays.
+			const originalSpawn = queryOptions.spawnClaudeCodeProcess;
+			queryOptions.spawnClaudeCodeProcess = (opts: SpawnOptions): SpawnedProcess => {
+				const proc = originalSpawn ? originalSpawn(opts) : defaultSpawn(opts);
+				this.ctx.processExitedPromise = new Promise<void>((resolve) => {
+					proc.once('exit', () => resolve());
+				});
+				return proc;
+			};
+
 			// Create query with AsyncGenerator
 			const queryObject = query({
 				prompt: this.createMessageGeneratorWrapper(),
@@ -331,7 +360,10 @@ export class QueryRunner {
 			const isStartupTimeout = errorMessage.includes('SDK startup timeout');
 			const isConversationNotFound = errorMessage.includes('No conversation found');
 
-			// Startup timeout is transient — keep sdkSessionId so resume works on retry.
+			// Startup timeout is transient — always keep sdkSessionId so resume works.
+			// Never clear sdkSessionId on timeout: the session file is valid and the
+			// conversation can be resumed once the workspace lock conflict resolves.
+			// Clearing it would lose the ability to resume the conversation history.
 			// "No conversation found" is permanent — clear sdkSessionId so the next
 			// attempt starts fresh instead of looping on a dead conversation.
 			if (isStartupTimeout && session.sdkSessionId) {
@@ -368,6 +400,15 @@ export class QueryRunner {
 						// Ignore close errors — transport may already be in a broken state
 					}
 					this.ctx.queryObject = null;
+				}
+
+				// Wait for the old subprocess to fully exit before retrying.
+				// close() above terminates the process, but we must wait for it to
+				// release workspace locks before spawning a replacement.
+				const exitPromise = this.ctx.processExitedPromise;
+				if (exitPromise) {
+					await Promise.race([exitPromise, new Promise((resolve) => setTimeout(resolve, 5000))]);
+					this.ctx.processExitedPromise = null;
 				}
 
 				// Use `return await` so this call's finally{} runs only after the retry

--- a/packages/daemon/tests/unit/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/agent/query-lifecycle-manager.test.ts
@@ -106,6 +106,7 @@ describe('QueryLifecycleManager', () => {
 			startStreamingQuery: async () => {
 				startStreamingCalled = true;
 			},
+			processExitedPromise: null,
 			// Cleanup support methods
 			setCleaningUp: mock(() => {}),
 			cleanupEventSubscriptions: mock(() => {}),
@@ -328,6 +329,93 @@ describe('QueryLifecycleManager', () => {
 			expect(closeIdx).not.toBe(-1);
 			expect(interruptIdx).toBeLessThan(promiseIdx);
 			expect(promiseIdx).toBeLessThan(closeIdx);
+		});
+
+		test('awaits processExitedPromise after close() before clearing references', async () => {
+			const callOrder: string[] = [];
+			let resolveExit: () => void;
+			const exitPromise = new Promise<void>((resolve) => {
+				resolveExit = resolve;
+			});
+
+			mockContext.queryObject = {
+				interrupt: mock(async () => {}),
+				close: mock(() => {
+					callOrder.push('close');
+					// Simulate subprocess exit after a short delay (as it would in reality)
+					setTimeout(() => {
+						callOrder.push('process-exited');
+						resolveExit!();
+					}, 20);
+				}),
+			} as unknown as QueryLifecycleManagerContext['queryObject'];
+			mockContext.firstMessageReceived = true;
+			mockContext.queryPromise = Promise.resolve();
+			mockContext.processExitedPromise = exitPromise;
+			manager = new QueryLifecycleManager(mockContext);
+
+			await manager.stop();
+
+			// Process should have exited before stop() returned
+			expect(callOrder).toContain('close');
+			expect(callOrder).toContain('process-exited');
+			expect(mockContext.processExitedPromise).toBeNull();
+		});
+
+		test('stop() times out waiting for processExitedPromise', async () => {
+			mockContext.queryObject = {
+				interrupt: mock(async () => {}),
+				close: mock(() => {}),
+			} as unknown as QueryLifecycleManagerContext['queryObject'];
+			mockContext.firstMessageReceived = true;
+			mockContext.queryPromise = Promise.resolve();
+			// A promise that never resolves — simulates a stuck subprocess
+			mockContext.processExitedPromise = new Promise<void>(() => {});
+			manager = new QueryLifecycleManager(mockContext);
+
+			const start = Date.now();
+			await manager.stop({ timeoutMs: 100 });
+			const elapsed = Date.now() - start;
+
+			// Should have timed out at the specified timeout
+			expect(elapsed).toBeGreaterThanOrEqual(90);
+			expect(elapsed).toBeLessThan(500);
+		});
+
+		test('stop() works when processExitedPromise is null', async () => {
+			mockContext.queryObject = {
+				interrupt: mock(async () => {}),
+				close: mock(() => {}),
+			} as unknown as QueryLifecycleManagerContext['queryObject'];
+			mockContext.firstMessageReceived = true;
+			mockContext.queryPromise = Promise.resolve();
+			mockContext.processExitedPromise = null;
+			manager = new QueryLifecycleManager(mockContext);
+
+			// Should not throw or hang
+			await manager.stop();
+
+			expect(mockContext.queryObject).toBeNull();
+		});
+
+		test('stop() awaits already-resolved processExitedPromise without delay', async () => {
+			mockContext.queryObject = {
+				interrupt: mock(async () => {}),
+				close: mock(() => {}),
+			} as unknown as QueryLifecycleManagerContext['queryObject'];
+			mockContext.firstMessageReceived = true;
+			mockContext.queryPromise = Promise.resolve();
+			// Process already exited
+			mockContext.processExitedPromise = Promise.resolve();
+			manager = new QueryLifecycleManager(mockContext);
+
+			const start = Date.now();
+			await manager.stop();
+			const elapsed = Date.now() - start;
+
+			// Should complete near-instantly
+			expect(elapsed).toBeLessThan(100);
+			expect(mockContext.processExitedPromise).toBeNull();
 		});
 	});
 

--- a/packages/daemon/tests/unit/agent/query-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/agent/query-lifecycle-manager.test.ts
@@ -417,6 +417,44 @@ describe('QueryLifecycleManager', () => {
 			expect(elapsed).toBeLessThan(100);
 			expect(mockContext.processExitedPromise).toBeNull();
 		});
+
+		test('snapshots processExitedPromise before queryPromise settles (regression for race condition)', async () => {
+			// Simulate the race: runQuery's finally block clears ctx.processExitedPromise during settlement.
+			// The old code read this.ctx.processExitedPromise AFTER awaiting queryPromise,
+			// so by then the finally block had already nulled it — making the exit wait a no-op.
+			// The fix snapshots it at the top of stop(), before any awaits.
+			let resolveQueryPromise!: () => void;
+			let resolveProcessExited!: () => void;
+			const processExitedPromise = new Promise<void>((r) => (resolveProcessExited = r));
+
+			// When queryPromise resolves, its finally block clears ctx.processExitedPromise
+			// (mirrors what runQuery() does in production)
+			const queryPromise = new Promise<void>((r) => (resolveQueryPromise = r)).then(() => {
+				mockContext.processExitedPromise = null; // mirrors runQuery()'s finally block
+			});
+
+			mockContext.queryPromise = queryPromise;
+			mockContext.processExitedPromise = processExitedPromise;
+			manager = new QueryLifecycleManager(mockContext);
+
+			// Start stop() but don't await yet
+			const stopPromise = manager.stop();
+
+			// Let queryPromise resolve (clears ctx.processExitedPromise as in production)
+			resolveQueryPromise();
+			await Promise.resolve(); // yield to let .then() run
+
+			// stop() should still be waiting for process exit (via the snapshot)
+			let stopResolved = false;
+			stopPromise.then(() => (stopResolved = true));
+			await Promise.resolve();
+			expect(stopResolved).toBe(false); // not done yet — waiting for process exit
+
+			// Now resolve process exit — stop() should complete
+			resolveProcessExited();
+			await stopPromise;
+			expect(stopResolved).toBe(true);
+		});
 	});
 
 	describe('restart', () => {

--- a/packages/daemon/tests/unit/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/agent/query-runner.test.ts
@@ -885,6 +885,44 @@ describe('QueryRunner', () => {
 			// The finally block may re-check it, but it will see null and skip redundant close.
 			expect(ctx.queryObject).toBeNull();
 		});
+
+		it('should await processExitedPromise before retrying after startup timeout', async () => {
+			// Verify the retry path waits for the old subprocess to exit
+			// before spawning a replacement.
+			const callOrder: string[] = [];
+			let resolveExit: () => void;
+			const exitPromise = new Promise<void>((resolve) => {
+				resolveExit = resolve;
+			});
+
+			const mockQueryObject = {
+				close: () => {
+					callOrder.push('close');
+					// Simulate subprocess exit after a delay
+					setTimeout(() => {
+						callOrder.push('process-exited');
+						resolveExit!();
+					}, 20);
+				},
+				[Symbol.asyncIterator]: function* () {},
+			} as unknown as import('@anthropic-ai/claude-agent-sdk').Query;
+
+			const ctx = createContext({
+				queryObject: mockQueryObject,
+				processExitedPromise: exitPromise,
+			});
+			runner = new QueryRunner(ctx);
+
+			runner.start();
+			await ctx.queryPromise?.catch(() => {});
+
+			// close() and process-exited should both have been called
+			// before the retry attempt proceeded
+			expect(callOrder).toContain('close');
+			expect(callOrder).toContain('process-exited');
+			// processExitedPromise should be cleared after the wait
+			expect(ctx.processExitedPromise).toBeNull();
+		});
 	});
 
 	describe('auto-recovery removal regression guards (Task 2.3)', () => {

--- a/packages/daemon/tests/unit/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/agent/query-runner.test.ts
@@ -188,6 +188,8 @@ describe('QueryRunner', () => {
 			startupTimeoutTimer: null,
 			originalEnvVars: {},
 
+			processExitedPromise: null,
+
 			// Methods for state coordination
 			incrementQueryGeneration: () => ++queryGeneration,
 			getQueryGeneration: () => queryGeneration,


### PR DESCRIPTION
## Summary

- Replace arbitrary `setTimeout` delays with deterministic process exit tracking when restarting SDK subprocess during model switch
- Wrap `spawnClaudeCodeProcess` to capture subprocess reference and listen for `exit` event via `processExitedPromise`
- `stop()` now awaits actual process exit before returning, preventing workspace lock conflicts when the new subprocess starts

**Root cause:** After model switch, `restart()` killed the old subprocess and waited only 100ms before spawning a new one. The dying process still held workspace locks (`.claude/` files), causing the new subprocess to detect "another Claude Code session" and hang until the 15s startup timeout. The auto-retry fired immediately with no delay, hitting the same conflict.

## Test plan

- [x] Unit tests for `stop()` awaiting `processExitedPromise` (4 new tests)
- [x] Existing query-lifecycle-manager tests pass (73 tests)
- [x] Existing query-runner tests pass (78 tests)
- [ ] Manual: switch models in a session and verify no startup timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)