### PR TITLE
fix: revive in_progress tasks with no active group instead of blocking

### DIFF
--- a/packages/daemon/src/lib/room/runtime/human-message-routing.ts
+++ b/packages/daemon/src/lib/room/runtime/human-message-routing.ts
@@ -2,22 +2,17 @@
  * Human Message Routing
  *
  * Routes a human message to the worker or leader session of an **active** group.
- * - Active groups (completedAt = null): messages are injected directly
- * - Terminated groups (completedAt set): messages are blocked regardless of status
+ * Uses getActiveGroupsForTask() to find only groups where completed_at IS NULL.
  *
- * Callers are responsible for pre-processing terminated tasks before calling this
- * function. For example:
+ * Callers are responsible for pre-processing tasks before calling this function:
  * - needs_attention/cancelled → caller should use runtime.reviveTaskForMessage()
  * - completed → caller should use runtime.reviveTaskForMessage() or block with an error
+ * - in_progress with no active group (phase transition) → caller should reviveTaskForMessage()
+ * - archived → caller should block immediately (terminal state)
  */
 
-import type { TaskStatus } from '@neokai/shared';
 import type { RoomRuntime } from './room-runtime';
 import type { SessionGroupRepository } from '../state/session-group-repository';
-
-export interface TaskOperator {
-	getTask(taskId: string): Promise<{ status: TaskStatus } | null>;
-}
 
 export interface HumanMessageResult {
 	success: boolean;
@@ -28,11 +23,10 @@ export type HumanMessageTarget = 'worker' | 'leader';
 
 /**
  * Route a human message to the specified agent of an active session group.
- * Returns an error if the group is terminated (completedAt is set).
+ * Returns an error if no active (completedAt = null) group exists for the task.
  *
  * @param runtime       The RoomRuntime instance for the room
  * @param groupRepo     The SessionGroupRepository for DB access
- * @param taskManager   The TaskManager for task operations
  * @param taskId        The task ID to route the message to
  * @param message       The human message content
  * @param target        Target agent ('worker' | 'leader'), defaults to 'worker'
@@ -40,29 +34,17 @@ export type HumanMessageTarget = 'worker' | 'leader';
 export async function routeHumanMessageToGroup(
 	runtime: RoomRuntime,
 	groupRepo: SessionGroupRepository,
-	taskManager: TaskOperator,
 	taskId: string,
 	message: string,
 	target: HumanMessageTarget = 'worker'
 ): Promise<HumanMessageResult> {
-	const group = groupRepo.getGroupByTaskId(taskId);
+	const activeGroups = groupRepo.getActiveGroupsForTask(taskId);
 
-	if (!group) {
+	if (activeGroups.length === 0) {
 		return { success: false, error: 'No active session group found for this task' };
 	}
 
-	// Terminated groups cannot accept injected messages. Callers must revive or
-	// restart the task through the appropriate path before calling this function.
-	if (group.completedAt !== null) {
-		const task = await taskManager.getTask(taskId);
-		const statusLabel = task ? `'${task.status}' status` : 'a terminated state';
-		return {
-			success: false,
-			error: `Task is in ${statusLabel} and cannot receive messages. Use the appropriate restart mechanism.`,
-		};
-	}
-
-	// Simple routing — group is active
+	// Simple routing — at least one active group exists
 	if (target === 'leader') {
 		const injected = await runtime.injectMessageToLeader(taskId, message);
 		return injected

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -828,17 +828,16 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 			// in_progress tasks with no active group: this can happen when set_task_status
 			// transitions a task back to in_progress (e.g., after a phase transition) without
 			// creating a new group. Revive the task so a fresh execution group is created.
+			// Note: no target parameter — reviveTaskForMessage defaults to 'leader', which is
+			// correct here since agents always communicate with the leader session.
 			if (
 				task.status === 'in_progress' &&
 				groupRepo.getActiveGroupsForTask(args.task_id).length === 0
 			) {
 				const revived = await runtime.reviveTaskForMessage(args.task_id, args.message);
 				if (!revived) {
-					try {
-						await taskManager.setTaskStatus(args.task_id, task.status);
-					} catch {
-						// Rollback is best-effort; swallow to avoid masking the original error
-					}
+					// No status rollback needed — unlike needs_attention/cancelled paths, no status
+					// transition was made before calling reviveTaskForMessage (task is already in_progress).
 					return jsonResult({
 						success: false,
 						error:
@@ -846,6 +845,7 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 							`Use set_task_status to restart the task explicitly.`,
 					});
 				}
+				// reviveTaskForMessage emits task updates internally — no extra daemonHub.emit needed.
 				return jsonResult({
 					success: true,
 					message: `Task ${args.task_id} revived and message delivered to agent`,

--- a/packages/daemon/src/lib/room/tools/room-agent-tools.ts
+++ b/packages/daemon/src/lib/room/tools/room-agent-tools.ts
@@ -825,10 +825,36 @@ export function createRoomAgentToolHandlers(config: RoomAgentToolsConfig) {
 				});
 			}
 
+			// in_progress tasks with no active group: this can happen when set_task_status
+			// transitions a task back to in_progress (e.g., after a phase transition) without
+			// creating a new group. Revive the task so a fresh execution group is created.
+			if (
+				task.status === 'in_progress' &&
+				groupRepo.getActiveGroupsForTask(args.task_id).length === 0
+			) {
+				const revived = await runtime.reviveTaskForMessage(args.task_id, args.message);
+				if (!revived) {
+					try {
+						await taskManager.setTaskStatus(args.task_id, task.status);
+					} catch {
+						// Rollback is best-effort; swallow to avoid masking the original error
+					}
+					return jsonResult({
+						success: false,
+						error:
+							`Failed to revive task ${args.task_id}: no active group and revival failed. ` +
+							`Use set_task_status to restart the task explicitly.`,
+					});
+				}
+				return jsonResult({
+					success: true,
+					message: `Task ${args.task_id} revived and message delivered to agent`,
+				});
+			}
+
 			const { success, error } = await routeHumanMessageToGroup(
 				runtime,
 				groupRepo,
-				taskManager,
 				args.task_id,
 				args.message
 			);

--- a/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-handlers.ts
@@ -1083,6 +1083,22 @@ export function setupTaskHandlers(
 			await runtime.clearGroupRateLimit(taskId);
 		}
 
+		const groupRepo = makeGroupRepo();
+
+		// in_progress tasks with no active group: this can happen when task.setStatus() transitions
+		// a task back to in_progress (e.g., after a phase transition) without creating a new group.
+		// Revive the task so a fresh execution group is created and the message can be delivered.
+		if (task.status === 'in_progress' && groupRepo.getActiveGroupsForTask(taskId).length === 0) {
+			const revived = await runtime.reviveTaskForMessage(taskId, params.message.trim(), target);
+			if (!revived) {
+				throw new Error(
+					`Failed to revive task ${taskId}: no active group and revival failed. ` +
+						`Use task.setStatus to restart the task explicitly.`
+				);
+			}
+			return { success: true };
+		}
+
 		// When the task was in review, prepend a context note so the leader knows to
 		// re-submit for review after addressing the human's feedback.
 		const reviewReminder = wasInReview
@@ -1090,11 +1106,9 @@ export function setupTaskHandlers(
 			: '';
 		const messageToRoute = reviewReminder + params.message.trim();
 
-		const groupRepo = makeGroupRepo();
 		const result = await routeHumanMessageToGroup(
 			runtime,
 			groupRepo,
-			taskManager,
 			taskId,
 			messageToRoute,
 			target

--- a/packages/daemon/tests/unit/room/room-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/room/room-agent-tools.test.ts
@@ -1391,6 +1391,90 @@ describe('Room Agent Tools', () => {
 			const task = await taskManager.getTask(taskId);
 			expect(task!.status).toBe('needs_attention');
 		});
+
+		it('should revive in_progress task with no active group (phase transition scenario)', async () => {
+			// Simulates the bug: task.setStatus() transitions task to in_progress without creating
+			// a new group (e.g., after a planning phase completes and execution phase begins).
+			let reviveCalledWith: unknown[] = [];
+			const mockRuntime = {
+				reviveTaskForMessage: async (...args: unknown[]) => {
+					reviveCalledWith = args;
+					return true;
+				},
+				injectMessageToWorker: async () => true,
+				injectMessageToLeader: async () => true,
+			};
+			const h = createRoomAgentToolHandlers({
+				roomId,
+				goalManager,
+				taskManager,
+				groupRepo,
+				runtimeService: { getRuntime: () => mockRuntime as never },
+			});
+			const created = parseResult(await h.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+
+			// Task starts in_progress with a group — then the group gets completed (phase done),
+			// but task stays in_progress (next phase hasn't created its group yet).
+			await taskManager.startTask(taskId);
+			const groupId = insertGroup(taskId, 'awaiting_human');
+			const groupInserted = groupRepo.getGroup(groupId);
+			groupRepo.completeGroup(groupId, groupInserted!.version);
+
+			// Confirm: task is in_progress but no active group
+			const taskBefore = await taskManager.getTask(taskId);
+			expect(taskBefore!.status).toBe('in_progress');
+			expect(groupRepo.getActiveGroupsForTask(taskId)).toHaveLength(0);
+
+			const result = parseResult(
+				await h.send_message_to_task({ task_id: taskId, message: 'continue working' })
+			);
+			expect(result.success).toBe(true);
+			expect(result.message).toContain('revived');
+
+			// reviveTaskForMessage should have been called with taskId and message
+			expect(reviveCalledWith[0]).toBe(taskId);
+			expect(reviveCalledWith[1]).toBe('continue working');
+
+			// Task status remains in_progress (no pre-transition was made, no rollback needed)
+			const taskAfter = await taskManager.getTask(taskId);
+			expect(taskAfter!.status).toBe('in_progress');
+		});
+
+		it('should return failure when in_progress revival fails (no status rollback needed)', async () => {
+			// Unlike cancelled/needs_attention paths, no status transition is made before revival
+			// so there is nothing to roll back when revival fails.
+			const mockRuntime = {
+				reviveTaskForMessage: async () => false,
+				injectMessageToWorker: async () => true,
+				injectMessageToLeader: async () => true,
+			};
+			const h = createRoomAgentToolHandlers({
+				roomId,
+				goalManager,
+				taskManager,
+				groupRepo,
+				runtimeService: { getRuntime: () => mockRuntime as never },
+			});
+			const created = parseResult(await h.create_task({ title: 'T', description: 'd' }));
+			const taskId = created.taskId as string;
+
+			// Task in_progress with terminated group
+			await taskManager.startTask(taskId);
+			const groupId = insertGroup(taskId, 'awaiting_human');
+			const groupInserted = groupRepo.getGroup(groupId);
+			groupRepo.completeGroup(groupId, groupInserted!.version);
+
+			const result = parseResult(
+				await h.send_message_to_task({ task_id: taskId, message: 'continue working' })
+			);
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('no active group and revival failed');
+
+			// Task should still be in_progress — no rollback attempted (none needed)
+			const task = await taskManager.getTask(taskId);
+			expect(task!.status).toBe('in_progress');
+		});
 	});
 
 	describe('get_task_detail', () => {

--- a/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
+++ b/packages/daemon/tests/unit/room/runtime/human-message-routing.test.ts
@@ -2,9 +2,9 @@
  * Tests for routeHumanMessageToGroup
  *
  * Routing behavior:
- * - Active groups (completedAt = null): messages injected directly into worker or leader
- * - Terminated groups (completedAt set): messages are blocked regardless of task status
- *   (callers must pre-process via reviveTaskForMessage or set_task_status)
+ * - Active groups exist (completedAt = null): messages injected directly into worker or leader
+ * - No active groups: returns "No active session group" error regardless of task status
+ *   (callers must pre-process via reviveTaskForMessage before calling this function)
  */
 
 import { describe, expect, it, mock } from 'bun:test';
@@ -14,7 +14,6 @@ import type {
 	SessionGroupRepository,
 	SessionGroup,
 } from '../../../../src/lib/room/state/session-group-repository';
-import type { NeoTask } from '@neokai/shared';
 
 function makeGroup(completedAt: number | null): SessionGroup {
 	return {
@@ -41,25 +40,6 @@ function makeGroup(completedAt: number | null): SessionGroup {
 	};
 }
 
-function makeTask(status: string): NeoTask {
-	return {
-		id: 'task-1',
-		roomId: 'room-1',
-		title: 'Test Task',
-		description: '',
-		status: status as NeoTask['status'],
-		priority: 'normal',
-		createdAt: Date.now(),
-		updatedAt: Date.now(),
-		result: null,
-		error: null,
-		dependsOn: [],
-		dependsOnMet: true,
-		dependsOnCount: 0,
-		metadata: null,
-	};
-}
-
 function makeRuntime(injectResult = true): {
 	runtime: RoomRuntime;
 	injectMessageToLeader: ReturnType<typeof mock>;
@@ -76,17 +56,11 @@ function makeRuntime(injectResult = true): {
 	return { runtime, injectMessageToLeader, injectMessageToWorker };
 }
 
-function makeTaskOperator(task: NeoTask | null = null) {
-	return {
-		getTask: mock(async () => task),
-	};
-}
-
-function makeGroupRepo(group: SessionGroup | null): {
+function makeGroupRepo(activeGroups: SessionGroup[]): {
 	groupRepo: SessionGroupRepository;
 } {
 	const groupRepo = {
-		getGroupByTaskId: mock(() => group),
+		getActiveGroupsForTask: mock(() => activeGroups),
 	} as unknown as SessionGroupRepository;
 
 	return { groupRepo };
@@ -96,20 +70,13 @@ describe('routeHumanMessageToGroup', () => {
 	const taskId = 'task-1';
 	const message = 'Hello from human';
 
-	describe('active group (completedAt = null)', () => {
+	describe('active group exists (completedAt = null)', () => {
 		describe('target=worker (default)', () => {
 			it('injects to worker and returns success', async () => {
 				const { runtime, injectMessageToWorker } = makeRuntime(true);
-				const taskManager = makeTaskOperator(makeTask('in_progress'));
-				const { groupRepo } = makeGroupRepo(makeGroup(null));
+				const { groupRepo } = makeGroupRepo([makeGroup(null)]);
 
-				const result = await routeHumanMessageToGroup(
-					runtime,
-					groupRepo,
-					taskManager,
-					taskId,
-					message
-				);
+				const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
 
 				expect(result.success).toBe(true);
 				expect(injectMessageToWorker).toHaveBeenCalledWith(taskId, message);
@@ -117,16 +84,9 @@ describe('routeHumanMessageToGroup', () => {
 
 			it('returns error when injectMessageToWorker fails', async () => {
 				const { runtime } = makeRuntime(false);
-				const taskManager = makeTaskOperator(makeTask('in_progress'));
-				const { groupRepo } = makeGroupRepo(makeGroup(null));
+				const { groupRepo } = makeGroupRepo([makeGroup(null)]);
 
-				const result = await routeHumanMessageToGroup(
-					runtime,
-					groupRepo,
-					taskManager,
-					taskId,
-					message
-				);
+				const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
 
 				expect(result.success).toBe(false);
 				expect(result.error).toContain('Failed to inject message into worker session');
@@ -136,13 +96,11 @@ describe('routeHumanMessageToGroup', () => {
 		describe('target=leader', () => {
 			it('injects to leader and returns success', async () => {
 				const { runtime, injectMessageToLeader } = makeRuntime(true);
-				const taskManager = makeTaskOperator(makeTask('in_progress'));
-				const { groupRepo } = makeGroupRepo(makeGroup(null));
+				const { groupRepo } = makeGroupRepo([makeGroup(null)]);
 
 				const result = await routeHumanMessageToGroup(
 					runtime,
 					groupRepo,
-					taskManager,
 					taskId,
 					message,
 					'leader'
@@ -154,13 +112,11 @@ describe('routeHumanMessageToGroup', () => {
 
 			it('returns error when injectMessageToLeader fails', async () => {
 				const { runtime } = makeRuntime(false);
-				const taskManager = makeTaskOperator(makeTask('in_progress'));
-				const { groupRepo } = makeGroupRepo(makeGroup(null));
+				const { groupRepo } = makeGroupRepo([makeGroup(null)]);
 
 				const result = await routeHumanMessageToGroup(
 					runtime,
 					groupRepo,
-					taskManager,
 					taskId,
 					message,
 					'leader'
@@ -172,64 +128,29 @@ describe('routeHumanMessageToGroup', () => {
 		});
 	});
 
-	describe('terminated group (completedAt set)', () => {
-		it.each([
-			['needs_attention'],
-			['cancelled'],
-			['completed'],
-		])('blocks messages when task status is %s', async (status) => {
+	describe('no active group (empty list or all terminated)', () => {
+		it('returns "No active session group" when getActiveGroupsForTask returns empty array', async () => {
 			const { runtime, injectMessageToWorker } = makeRuntime(true);
-			const taskManager = makeTaskOperator(makeTask(status));
-			const { groupRepo } = makeGroupRepo(makeGroup(Date.now()));
+			const { groupRepo } = makeGroupRepo([]);
 
-			const result = await routeHumanMessageToGroup(
-				runtime,
-				groupRepo,
-				taskManager,
-				taskId,
-				message
-			);
-
-			expect(result.success).toBe(false);
-			expect(result.error).toContain(`'${status}'`);
-			expect(injectMessageToWorker).not.toHaveBeenCalled();
-		});
-
-		it('returns error with terminated-state message when task not found', async () => {
-			const { runtime, injectMessageToWorker } = makeRuntime(true);
-			const taskManager = makeTaskOperator(null);
-			const { groupRepo } = makeGroupRepo(makeGroup(Date.now()));
-
-			const result = await routeHumanMessageToGroup(
-				runtime,
-				groupRepo,
-				taskManager,
-				taskId,
-				message
-			);
-
-			expect(result.success).toBe(false);
-			expect(result.error).toContain('terminated state');
-			expect(injectMessageToWorker).not.toHaveBeenCalled();
-		});
-	});
-
-	describe('no group', () => {
-		it('returns failure when no group is found', async () => {
-			const { runtime } = makeRuntime(true);
-			const taskManager = makeTaskOperator(makeTask('in_progress'));
-			const { groupRepo } = makeGroupRepo(null);
-
-			const result = await routeHumanMessageToGroup(
-				runtime,
-				groupRepo,
-				taskManager,
-				taskId,
-				message
-			);
+			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
 
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('No active session group');
+			expect(injectMessageToWorker).not.toHaveBeenCalled();
+		});
+
+		it('returns "No active session group" error — callers must revive before routing', async () => {
+			// Simulates the bug scenario: task is in_progress but setStatus was used to transition it
+			// without creating a new group. getActiveGroupsForTask returns [] (only non-null groups).
+			const { runtime, injectMessageToWorker } = makeRuntime(true);
+			const { groupRepo } = makeGroupRepo([]);
+
+			const result = await routeHumanMessageToGroup(runtime, groupRepo, taskId, message);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('No active session group');
+			expect(injectMessageToWorker).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/task-handlers.test.ts
@@ -132,15 +132,30 @@ function makeGroupRow(submittedForReview = false): Record<string, unknown> {
 /**
  * Build a mock Database whose getDatabase() returns a fake Bun SQLite db.
  * All prepare() calls return a statement that responds with the given groupRow.
+ * When groupRow is active (completed_at === null), all() returns it as an active-groups array.
+ * When groupRow is null or terminated (completed_at !== null), all() returns [] (no active groups).
  */
 function makeDb(groupRow: Record<string, unknown> | null): Database {
+	// getActiveGroupsForTask() uses .all() — only return active groups (completed_at = null)
+	const activeRows = groupRow !== null && groupRow['completed_at'] === null ? [groupRow] : [];
 	const stmt = {
 		get: mock(() => groupRow),
 		run: mock(() => ({ lastInsertRowid: 1 })),
-		all: mock(() => []),
+		all: mock(() => activeRows),
 	};
 	const rawDb = { prepare: mock(() => stmt) };
 	return { getDatabase: mock(() => rawDb) } as unknown as Database;
+}
+
+/**
+ * Build a group row that has completed_at set (terminated group).
+ * Use this to simulate an in_progress task whose group was already completed.
+ */
+function makeTerminatedGroupRow(): Record<string, unknown> {
+	return {
+		...makeGroupRow(),
+		completed_at: Date.now() - 1000,
+	};
 }
 
 /** Build a mock RoomRuntimeService with a runtime that can resume/inject. */
@@ -319,18 +334,73 @@ describe('task.sendHumanMessage RPC Handler', () => {
 			expect(result).toEqual({ success: true });
 		});
 
-		it('throws when no active group exists for the task', async () => {
-			// makeDb with null groupRow → getGroupByTaskId returns null
+		it('revives in_progress task that has no active group', async () => {
+			// in_progress + no active group → reviveTaskForMessage (instead of error)
+			// This covers the bug fix: task.setStatus() → in_progress without creating a new group
 			const mh = createMockMessageHub();
 			hub = mh.hub;
 			handlers = mh.handlers;
 
-			const { service } = makeRuntimeService();
+			const { service, runtime } = makeRuntimeService(true, true, true);
 			setupTaskHandlers(
 				hub,
 				mockRoomManager,
 				createMockDaemonHub(),
-				makeDb(null), // no group row
+				makeDb(null), // no group row → getActiveGroupsForTask returns []
+				{ notifyChange: () => {} } as never,
+				makeTaskManagerFactory(mockTask),
+				service
+			);
+
+			const result = await getHandler()(
+				{ roomId: 'room-1', taskId: TASK_UUID, message: 'hello' },
+				{}
+			);
+			expect(result).toEqual({ success: true });
+			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith(TASK_UUID, 'hello', 'worker');
+		});
+
+		it('revives in_progress task whose group is terminated (phase transition scenario)', async () => {
+			// Simulates the core bug: task is in_progress but its group has completed_at set
+			// (e.g., planning group completed → task set to in_progress via setStatus → execution starts)
+			const mh = createMockMessageHub();
+			hub = mh.hub;
+			handlers = mh.handlers;
+
+			const { service, runtime } = makeRuntimeService(true, true, true);
+			setupTaskHandlers(
+				hub,
+				mockRoomManager,
+				createMockDaemonHub(),
+				makeDb(makeTerminatedGroupRow()), // group exists but completed_at is set → all() returns []
+				{ notifyChange: () => {} } as never,
+				makeTaskManagerFactory(mockTask),
+				service
+			);
+
+			const result = await getHandler()(
+				{ roomId: 'room-1', taskId: TASK_UUID, message: 'continue work' },
+				{}
+			);
+			expect(result).toEqual({ success: true });
+			expect(runtime.reviveTaskForMessage).toHaveBeenCalledWith(
+				TASK_UUID,
+				'continue work',
+				'worker'
+			);
+		});
+
+		it('throws when in_progress task has no active group and revival fails', async () => {
+			const mh = createMockMessageHub();
+			hub = mh.hub;
+			handlers = mh.handlers;
+
+			const { service } = makeRuntimeService(true, true, false); // reviveResult = false
+			setupTaskHandlers(
+				hub,
+				mockRoomManager,
+				createMockDaemonHub(),
+				makeDb(null), // no group row → getActiveGroupsForTask returns []
 				{ notifyChange: () => {} } as never,
 				makeTaskManagerFactory(mockTask),
 				service
@@ -338,7 +408,7 @@ describe('task.sendHumanMessage RPC Handler', () => {
 
 			await expect(
 				getHandler()({ roomId: 'room-1', taskId: TASK_UUID, message: 'hello' }, {})
-			).rejects.toThrow('No active session group');
+			).rejects.toThrow('no active group and revival failed');
 		});
 	});
 

--- a/packages/daemon/tests/unit/rpc/task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc/task-handlers.test.ts
@@ -226,15 +226,16 @@ function createMockDatabaseWithGroup(groupState: string = 'awaiting_leader'): Da
 		created_at: Date.now(),
 		completed_at: null,
 	};
+	// getActiveGroupsForTask() uses .all() — return the active group row since completed_at is null
 	const mockRawDb = {
 		prepare: mock(() => ({
 			run: mock(() => ({ changes: 1 })),
 			get: mock(() => groupRow),
-			all: mock(() => []),
+			all: mock(() => [groupRow]),
 		})),
 		run: mock(() => ({ changes: 1 })),
 		get: mock(() => groupRow),
-		all: mock(() => []),
+		all: mock(() => [groupRow]),
 	};
 	return {
 		getDatabase: mock(() => mockRawDb),


### PR DESCRIPTION
Fixes the bug where sending a message to an `in_progress` task fails with "Task is in 'in_progress' status and cannot receive messages." This misleading error occurred when a task was set to `in_progress` via `task.setStatus()` (e.g., during phase transitions) without creating a new session group.

**Root cause:** `routeHumanMessageToGroup` called `getGroupByTaskId()` which returns the most recent group regardless of `completedAt`, then blocked if `completedAt !== null` — incorrectly including `in_progress` tasks whose previous group was terminated.

**Changes:**
- `routeHumanMessageToGroup` now calls `getActiveGroupsForTask()` (filters `completed_at IS NULL`) instead of `getGroupByTaskId()` — only active groups are considered
- Removed `TaskOperator`/`taskManager` from the function signature (only used for the now-removed misleading error message)
- `task.sendHumanMessage` and `send_message_to_task` both auto-revive `in_progress` tasks with no active group, consistent with `cancelled`/`completed` task handling
- Updated all three test files to reflect the new behavior; added tests for the phase-transition revival scenario