### PR TITLE
fix: prevent planning tasks from getting stuck in unrecoverable states

### DIFF
--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -725,27 +725,30 @@ export class RoomRuntime {
 				if (group.workerRole === 'planner' && errorClass.statusCode === 400) {
 					log.info(`Planner HTTP 400 error for group ${groupId} — bouncing worker for retry`);
 					if (
-						!(await this.recordAndCheckDeadLoop(
+						await this.recordAndCheckDeadLoop(
 							groupId,
 							group.taskId,
 							'planner_api_400',
 							errorClass.reason
-						))
+						)
 					) {
-						this.appendGroupEvent(groupId, 'status', {
-							text: `Transient API error (HTTP 400) — retrying with simplified approach`,
-						});
-						await this.sessionFactory.injectMessage(
-							group.workerSessionId,
-							'You encountered a temporary API error (HTTP 400). ' +
-								'This may be due to context size or a transient validation issue.\n\n' +
-								'Please retry your current phase with a more concise approach. ' +
-								'Break your work into smaller steps if needed, and summarize previous ' +
-								'findings rather than including full outputs in your sub-agent prompts.'
-						);
-						return; // Keep worker turn active for retry
+						// Dead loop detected — recordAndCheckDeadLoop already called fail/cleanup/
+						// scheduleTick internally. Return immediately to avoid double-fail.
+						return;
 					}
-					// Dead loop detected — fall through to normal terminal error handling
+					// Not a dead loop yet — bounce the worker back with a retry instruction.
+					this.appendGroupEvent(groupId, 'status', {
+						text: `Transient API error (HTTP 400) — retrying with simplified approach`,
+					});
+					await this.sessionFactory.injectMessage(
+						group.workerSessionId,
+						'You encountered a temporary API error (HTTP 400). ' +
+							'This may be due to context size or a transient validation issue.\n\n' +
+							'Please retry your current phase with a more concise approach. ' +
+							'Break your work into smaller steps if needed, and summarize previous ' +
+							'findings rather than including full outputs in your sub-agent prompts.'
+					);
+					return; // Keep worker turn active for retry
 				}
 				log.info(`Terminal API error in worker output for group ${groupId}: ${errorClass.reason}`);
 				this.appendGroupEvent(groupId, 'status', {
@@ -3815,6 +3818,10 @@ export class RoomRuntime {
 		// in terminal states. These were likely escalated due to transient API errors rather
 		// than genuine planning failures requiring human intervention. Auto-recover them by
 		// resetting to active so the normal replanning path can retry (subject to effectiveMax).
+		//
+		// Note: At most one goal is recovered per tick (this function returns as soon as the
+		// first recoverable goal is found). Multiple stuck goals recover across successive ticks,
+		// which is intentional — processing one goal at a time keeps tick latency bounded.
 		const needsHumanGoals = await this.goalManager.listGoals('needs_human');
 		for (const goal of needsHumanGoals) {
 			if (goal.missionType === 'recurring') continue;
@@ -3827,12 +3834,20 @@ export class RoomRuntime {
 			const validTasks = linkedTasks.filter(Boolean) as NonNullable<(typeof linkedTasks)[number]>[];
 			if (validTasks.length === 0) continue;
 
+			// Note: 'cancelled' and 'archived' are included so that manually-cancelled
+			// planning tasks also qualify for auto-recovery. Trade-off: if a user manually
+			// cancels a planning task while the goal is in needs_human, the next tick will
+			// auto-recover it. This is an acceptable edge-case because the goal can be
+			// archived manually if truly abandoned; the alternative (needs_attention only)
+			// would leave goals stuck when planning tasks are legitimately cancelled.
 			const isTerminal = (status: string) =>
 				status === 'needs_attention' || status === 'cancelled' || status === 'archived';
 
 			// Only recover if ALL linked tasks are planning tasks in terminal states.
 			// If any execution tasks failed, those require genuine human attention.
-			const allArePlanningTasks = validTasks.every((t) => t.taskType === 'planning');
+			// Use the project-standard null-safe pattern: taskType ?? 'coding'
+			// (older task records may have taskType as null/undefined).
+			const allArePlanningTasks = validTasks.every((t) => (t.taskType ?? 'coding') === 'planning');
 			const allAreTerminal = validTasks.every((t) => isTerminal(t.status));
 
 			if (!allArePlanningTasks || !allAreTerminal) continue;
@@ -4659,30 +4674,58 @@ export class RoomRuntime {
 	 * Check whether a GitHub PR URL points to a merged PR.
 	 * Returns true if the PR is merged, false if open/closed/unknown.
 	 * Fails open (returns false) so callers do not get stuck on gh failures.
+	 * Applies a 10-second timeout to prevent the tick from blocking on slow/hung gh calls.
 	 */
 	private async isPrMergedOnGitHub(prUrl: string, workspacePath: string): Promise<boolean> {
+		const TIMEOUT_MS = 10_000;
 		try {
 			if (this.hookOptions?.runCommand) {
-				const { stdout, exitCode } = await this.hookOptions.runCommand(
-					['gh', 'pr', 'view', prUrl, '--json', 'state', '--jq', '.state'],
-					workspacePath
-				);
-				if (exitCode !== 0) return false;
-				return stdout.trim() === 'MERGED';
+				// runCommand is injected by tests — apply timeout via Promise.race
+				const result = await Promise.race([
+					this.hookOptions.runCommand(
+						['gh', 'pr', 'view', prUrl, '--json', 'state', '--jq', '.state'],
+						workspacePath
+					),
+					new Promise<never>((_, reject) =>
+						setTimeout(() => reject(new Error('gh pr view timed out')), TIMEOUT_MS)
+					),
+				]);
+				return result.exitCode === 0 && result.stdout.trim() === 'MERGED';
 			}
 			const proc = Bun.spawn(['gh', 'pr', 'view', prUrl, '--json', 'state', '--jq', '.state'], {
 				cwd: workspacePath,
 				stdout: 'pipe',
 				stderr: 'pipe',
 			});
-			const stdout = await new Response(proc.stdout).text();
-			const exitCode = await proc.exited;
+			// Race the process exit against a timeout so a hung gh call never blocks the tick.
+			const [stdout] = await Promise.all([
+				new Response(proc.stdout).text(),
+				Promise.race([
+					proc.exited,
+					new Promise<never>((_, reject) =>
+						setTimeout(() => {
+							proc.kill();
+							reject(new Error('gh pr view timed out'));
+						}, TIMEOUT_MS)
+					),
+				]),
+			]);
+			const exitCode = await proc.exited.catch(() => 1);
 			if (exitCode !== 0) return false;
 			return stdout.trim() === 'MERGED';
 		} catch {
+			// Timeout, network error, or gh not installed — fail open.
 			return false;
 		}
 	}
+
+	/**
+	 * Per-group last-checked timestamp for recoverMergedPlanGroups.
+	 * Prevents issuing a `gh pr view` call on every tick for each stuck planner group.
+	 * Groups are checked at most once per GH_CHECK_INTERVAL_MS.
+	 */
+	private readonly mergedPlanGroupLastChecked = new Map<string, number>();
+	private static readonly GH_CHECK_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
 	/**
 	 * Fix 5: Auto-detect plan PR merge for planning groups stuck in submitted_for_review.
@@ -4690,6 +4733,9 @@ export class RoomRuntime {
 	 * When a human merges the plan PR directly on GitHub (without clicking "Approve" in NeoKai),
 	 * the planning group stays in submitted_for_review indefinitely because resumeWorkerFromHuman
 	 * is never called. This method scans for such groups and auto-approves them.
+	 *
+	 * Each group is checked at most once per GH_CHECK_INTERVAL_MS to avoid hammering the
+	 * GitHub API on every tick.
 	 *
 	 * Called on each tick (async, awaited in executeTick).
 	 */
@@ -4701,8 +4747,14 @@ export class RoomRuntime {
 		if (plannerGroups.length === 0) return;
 
 		const workspacePath = this.taskGroupManager.workspacePath;
+		const now = Date.now();
 
 		for (const group of plannerGroups) {
+			// Per-group cooldown: avoid checking the same group on every tick
+			const lastChecked = this.mergedPlanGroupLastChecked.get(group.id) ?? 0;
+			if (now - lastChecked < RoomRuntime.GH_CHECK_INTERVAL_MS) continue;
+			this.mergedPlanGroupLastChecked.set(group.id, now);
+
 			const task = await this.taskManager.getTask(group.taskId);
 			if (!task?.prUrl) continue;
 
@@ -4717,6 +4769,10 @@ export class RoomRuntime {
 				text: `Plan PR merged on GitHub — auto-approving and resuming task creation phase`,
 			});
 
+			// Set approvalSource BEFORE resumeWorkerFromHuman so the idempotency guard
+			// in that method preserves 'github_merge_detected' instead of overwriting with 'human'.
+			this.groupRepo.setApprovalSource(group.id, 'github_merge_detected');
+
 			// Resume the leader with an approval message.
 			// resumeWorkerFromHuman sets group.approved = true for planner groups
 			// (see the isApproval logic: workerRole === 'planner' && opts?.approved !== false).
@@ -4727,6 +4783,8 @@ export class RoomRuntime {
 				{ approved: true }
 			);
 			if (!resumed) {
+				// Roll back approvalSource so future ticks can retry
+				this.groupRepo.setApprovalSource(group.id, null);
 				log.warn(`[recoverMergedPlanGroups] resumeWorkerFromHuman failed for task ${group.taskId}`);
 			}
 		}

--- a/packages/daemon/src/lib/room/runtime/room-runtime.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime.ts
@@ -718,10 +718,45 @@ export class RoomRuntime {
 		{
 			const errorClass = classifyError(workerOutputText);
 			if (errorClass?.class === 'terminal') {
+				// Fix 2: For planner workers, HTTP 400 errors are often transient
+				// (context too large, temporary validation issue from a sub-agent spawning
+				// with a large prompt). Bounce the worker back with a retry instruction
+				// instead of failing immediately. The dead-loop guard prevents infinite bounces.
+				if (group.workerRole === 'planner' && errorClass.statusCode === 400) {
+					log.info(`Planner HTTP 400 error for group ${groupId} — bouncing worker for retry`);
+					if (
+						!(await this.recordAndCheckDeadLoop(
+							groupId,
+							group.taskId,
+							'planner_api_400',
+							errorClass.reason
+						))
+					) {
+						this.appendGroupEvent(groupId, 'status', {
+							text: `Transient API error (HTTP 400) — retrying with simplified approach`,
+						});
+						await this.sessionFactory.injectMessage(
+							group.workerSessionId,
+							'You encountered a temporary API error (HTTP 400). ' +
+								'This may be due to context size or a transient validation issue.\n\n' +
+								'Please retry your current phase with a more concise approach. ' +
+								'Break your work into smaller steps if needed, and summarize previous ' +
+								'findings rather than including full outputs in your sub-agent prompts.'
+						);
+						return; // Keep worker turn active for retry
+					}
+					// Dead loop detected — fall through to normal terminal error handling
+				}
 				log.info(`Terminal API error in worker output for group ${groupId}: ${errorClass.reason}`);
 				this.appendGroupEvent(groupId, 'status', {
 					text: `Terminal error: ${errorClass.reason}`,
 				});
+				// Fix 3: Promote any existing draft tasks before failing a planning task.
+				// This preserves partial progress — even if the planner crashed during Phase 2,
+				// the tasks it already created are not lost.
+				if (group.workerRole === 'planner') {
+					await this.promoteDraftTasksIfPlanning(group.taskId);
+				}
 				await this.taskGroupManager.fail(groupId, errorClass.reason);
 				this.cleanupMirroring(groupId, `Terminal API error: ${errorClass.reason}`);
 				await this.emitTaskUpdateById(group.taskId);
@@ -3208,6 +3243,11 @@ export class RoomRuntime {
 		// Note: synchronous scan, only fires async work as fire-and-forget if stuck leaders are found.
 		this.recoverStuckLeaders();
 
+		// Fix 5: Auto-detect plan PR merges for planning groups stuck in submitted_for_review.
+		// When a human merges the plan PR on GitHub without clicking "Approve" in NeoKai,
+		// the group stays blocked. This check auto-approves when the PR is confirmed merged.
+		await this.recoverMergedPlanGroups();
+
 		// Recurring mission scheduler: check for due missions and trigger new executions.
 		// Also checks for completed executions to advance next_run_at.
 		// Runs only when runtime is in 'running' state (enforced by tick() guard above).
@@ -3769,6 +3809,46 @@ export class RoomRuntime {
 			}
 
 			return { goal, replanContext };
+		}
+
+		// Fix 4: Also consider needs_human goals where ALL linked tasks are planning tasks
+		// in terminal states. These were likely escalated due to transient API errors rather
+		// than genuine planning failures requiring human intervention. Auto-recover them by
+		// resetting to active so the normal replanning path can retry (subject to effectiveMax).
+		const needsHumanGoals = await this.goalManager.listGoals('needs_human');
+		for (const goal of needsHumanGoals) {
+			if (goal.missionType === 'recurring') continue;
+			const linkedTaskIds = goal.linkedTaskIds ?? [];
+			if (linkedTaskIds.length === 0) continue;
+
+			const linkedTasks = await Promise.all(
+				linkedTaskIds.map((id) => this.taskManager.getTask(id))
+			);
+			const validTasks = linkedTasks.filter(Boolean) as NonNullable<(typeof linkedTasks)[number]>[];
+			if (validTasks.length === 0) continue;
+
+			const isTerminal = (status: string) =>
+				status === 'needs_attention' || status === 'cancelled' || status === 'archived';
+
+			// Only recover if ALL linked tasks are planning tasks in terminal states.
+			// If any execution tasks failed, those require genuine human attention.
+			const allArePlanningTasks = validTasks.every((t) => t.taskType === 'planning');
+			const allAreTerminal = validTasks.every((t) => isTerminal(t.status));
+
+			if (!allArePlanningTasks || !allAreTerminal) continue;
+
+			const effectiveMax = getEffectiveMaxPlanningAttempts(goal, roomConfig);
+			const attempts = goal.planning_attempts ?? 0;
+
+			if (attempts >= effectiveMax) continue; // Exhausted retries — leave as needs_human
+
+			// Auto-recover: reset to active so the standard planning path retries
+			log.info(
+				`Auto-recovering goal ${goal.id} (${goal.title}) from needs_human — ` +
+					`only planning tasks failed (attempts=${attempts}/${effectiveMax}), resetting to active`
+			);
+			await this.goalManager.updateGoalStatus(goal.id, 'active');
+			return { goal: { ...goal, status: 'active' } };
 		}
 
 		return null;
@@ -4572,6 +4652,83 @@ export class RoomRuntime {
 		} catch {
 			// If git status fails (e.g., not a git repo), treat as clean
 			return false;
+		}
+	}
+
+	/**
+	 * Check whether a GitHub PR URL points to a merged PR.
+	 * Returns true if the PR is merged, false if open/closed/unknown.
+	 * Fails open (returns false) so callers do not get stuck on gh failures.
+	 */
+	private async isPrMergedOnGitHub(prUrl: string, workspacePath: string): Promise<boolean> {
+		try {
+			if (this.hookOptions?.runCommand) {
+				const { stdout, exitCode } = await this.hookOptions.runCommand(
+					['gh', 'pr', 'view', prUrl, '--json', 'state', '--jq', '.state'],
+					workspacePath
+				);
+				if (exitCode !== 0) return false;
+				return stdout.trim() === 'MERGED';
+			}
+			const proc = Bun.spawn(['gh', 'pr', 'view', prUrl, '--json', 'state', '--jq', '.state'], {
+				cwd: workspacePath,
+				stdout: 'pipe',
+				stderr: 'pipe',
+			});
+			const stdout = await new Response(proc.stdout).text();
+			const exitCode = await proc.exited;
+			if (exitCode !== 0) return false;
+			return stdout.trim() === 'MERGED';
+		} catch {
+			return false;
+		}
+	}
+
+	/**
+	 * Fix 5: Auto-detect plan PR merge for planning groups stuck in submitted_for_review.
+	 *
+	 * When a human merges the plan PR directly on GitHub (without clicking "Approve" in NeoKai),
+	 * the planning group stays in submitted_for_review indefinitely because resumeWorkerFromHuman
+	 * is never called. This method scans for such groups and auto-approves them.
+	 *
+	 * Called on each tick (async, awaited in executeTick).
+	 */
+	private async recoverMergedPlanGroups(): Promise<void> {
+		const allActiveGroups = this.groupRepo.getActiveGroups(this.roomId);
+		const plannerGroups = allActiveGroups.filter(
+			(g) => g.submittedForReview && g.workerRole === 'planner' && !g.approved
+		);
+		if (plannerGroups.length === 0) return;
+
+		const workspacePath = this.taskGroupManager.workspacePath;
+
+		for (const group of plannerGroups) {
+			const task = await this.taskManager.getTask(group.taskId);
+			if (!task?.prUrl) continue;
+
+			const merged = await this.isPrMergedOnGitHub(task.prUrl, workspacePath);
+			if (!merged) continue;
+
+			log.info(
+				`[recoverMergedPlanGroups] Plan PR ${task.prUrl} is merged on GitHub — ` +
+					`auto-approving planning group ${group.id} for task ${group.taskId}`
+			);
+			this.appendGroupEvent(group.id, 'status', {
+				text: `Plan PR merged on GitHub — auto-approving and resuming task creation phase`,
+			});
+
+			// Resume the leader with an approval message.
+			// resumeWorkerFromHuman sets group.approved = true for planner groups
+			// (see the isApproval logic: workerRole === 'planner' && opts?.approved !== false).
+			const resumed = await this.resumeWorkerFromHuman(
+				group.taskId,
+				'The plan PR has been merged on GitHub. Please proceed with Phase 2: ' +
+					'create the tasks from the approved plan using the create_task tool.',
+				{ approved: true }
+			);
+			if (!resumed) {
+				log.warn(`[recoverMergedPlanGroups] resumeWorkerFromHuman failed for task ${group.taskId}`);
+			}
 		}
 	}
 }

--- a/packages/daemon/src/lib/room/state/session-group-repository.ts
+++ b/packages/daemon/src/lib/room/state/session-group-repository.ts
@@ -100,7 +100,7 @@ interface TaskGroupMetadata {
 	 * with approved=true. Set to 'leader_semi_auto' when runtime auto-approves in
 	 * semi-autonomous mode. Used as idempotency guard for auto-approve deferred callbacks.
 	 */
-	approvalSource?: 'human' | 'leader_semi_auto' | 'leader_no_pr';
+	approvalSource?: 'human' | 'leader_semi_auto' | 'leader_no_pr' | 'github_merge_detected';
 	/**
 	 * Links this session group to a specific mission_executions row for recurring missions.
 	 * Used by recoverZombieGroups() to correlate recovered groups to their execution after restart.
@@ -174,9 +174,13 @@ export interface SessionGroup {
 	 */
 	workerBypassed: boolean;
 	/**
-	 * Who approved this task ('human', 'leader_semi_auto', or 'leader_no_pr'), or null if not yet approved.
+	 * Who approved this task, or null if not yet approved.
+	 * - 'human': approved via NeoKai UI
+	 * - 'leader_semi_auto': auto-approved in semi-autonomous mode
+	 * - 'leader_no_pr': leader completed without a PR
+	 * - 'github_merge_detected': plan PR merged on GitHub directly (Fix 5 auto-detect)
 	 */
-	approvalSource: 'human' | 'leader_semi_auto' | 'leader_no_pr' | null;
+	approvalSource: 'human' | 'leader_semi_auto' | 'leader_no_pr' | 'github_merge_detected' | null;
 	/**
 	 * Links this session group to a specific mission_executions row for recurring missions.
 	 * Used by recoverZombieGroups() to correlate recovered groups to their execution after restart.
@@ -671,7 +675,7 @@ export class SessionGroupRepository {
 	 */
 	setApprovalSource(
 		groupId: string,
-		source: 'human' | 'leader_semi_auto' | 'leader_no_pr' | null
+		source: 'human' | 'leader_semi_auto' | 'leader_no_pr' | 'github_merge_detected' | null
 	): void {
 		const raw = (
 			this.db.prepare(`SELECT metadata FROM session_groups WHERE id = ?`).get(groupId) as Record<

--- a/packages/daemon/src/storage/repositories/goal-repository.ts
+++ b/packages/daemon/src/storage/repositories/goal-repository.ts
@@ -708,7 +708,7 @@ export class GoalRepository {
  * Priority order:
  * 1. goal.maxPlanningAttempts (per-goal override, stored in DB)
  * 2. roomConfig.maxPlanningRetries + 1 (room-level config, legacy key)
- * 3. Default: 1 (no retries)
+ * 3. Default: 2 (1 retry after first failure)
  */
 export function getEffectiveMaxPlanningAttempts(
 	goal: RoomGoal,
@@ -732,6 +732,9 @@ export function getEffectiveMaxPlanningAttempts(
 		}
 	}
 
-	// Global default: 1 total attempt (no retries)
-	return 1;
+	// Global default: 2 total attempts (1 retry after first failure).
+	// Planning is the most failure-prone phase (large context, multiple API calls,
+	// sub-agent spawning) so a single transient error should not permanently escalate
+	// the goal to needs_human.
+	return 2;
 }

--- a/packages/daemon/tests/unit/room/room-runtime-planning-recovery.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-planning-recovery.test.ts
@@ -1,0 +1,605 @@
+/**
+ * Tests for planning task recovery fixes.
+ *
+ * Covers all 5 fixes from the "Fix planning task recovery" task:
+ *
+ * Fix 1: Default maxPlanningAttempts = 2 (allows 1 retry)
+ * Fix 2: HTTP 400 treated as recoverable (bounce) for planner workers
+ * Fix 3: Promote draft tasks when planning task fails with terminal error
+ * Fix 4: Auto-recover needs_human goals with only failed planning tasks
+ * Fix 5: Auto-detect plan PR merge for stuck submitted_for_review planning groups
+ */
+
+import { describe, expect, it, afterEach, beforeEach } from 'bun:test';
+import { createRuntimeTestContext, type RuntimeTestContext } from './room-runtime-test-helpers';
+import { getEffectiveMaxPlanningAttempts } from '../../../src/storage/repositories/goal-repository';
+import type { RoomGoal } from '@neokai/shared';
+
+// ─── Fix 1: Default maxPlanningAttempts ─────────────────────────────────────
+
+describe('Fix 1: getEffectiveMaxPlanningAttempts defaults to 2', () => {
+	it('returns 2 when no per-goal or room-level override is set', () => {
+		const goal = {
+			id: 'g1',
+			maxPlanningAttempts: 0, // DB default — not a real override
+		} as unknown as RoomGoal;
+		const result = getEffectiveMaxPlanningAttempts(goal, {});
+		expect(result).toBe(2);
+	});
+
+	it('returns 2 when maxPlanningAttempts is 0 (DB default sentinel) and no room config', () => {
+		const goal = { id: 'g1', maxPlanningAttempts: 0 } as unknown as RoomGoal;
+		expect(getEffectiveMaxPlanningAttempts(goal)).toBe(2);
+	});
+
+	it('respects per-goal override when set to a positive integer', () => {
+		const goal = { id: 'g1', maxPlanningAttempts: 5 } as unknown as RoomGoal;
+		expect(getEffectiveMaxPlanningAttempts(goal)).toBe(5);
+	});
+
+	it('respects room-level maxPlanningRetries (N retries → N+1 total)', () => {
+		const goal = { id: 'g1', maxPlanningAttempts: 0 } as unknown as RoomGoal;
+		expect(getEffectiveMaxPlanningAttempts(goal, { maxPlanningRetries: 3 })).toBe(4);
+	});
+
+	it('per-goal override takes precedence over room-level config', () => {
+		const goal = { id: 'g1', maxPlanningAttempts: 3 } as unknown as RoomGoal;
+		expect(getEffectiveMaxPlanningAttempts(goal, { maxPlanningRetries: 10 })).toBe(3);
+	});
+});
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeWorkerMessage(text: string) {
+	return { id: 'msg-1', text, toolCallNames: [] };
+}
+
+/**
+ * Create a goal, let the runtime spawn a planning group, and return the group + planning task.
+ * After this call the runtime has a planner group with workerRole='planner' in awaiting_worker state.
+ */
+async function setupPlannerGroup(ctx: RuntimeTestContext) {
+	const goal = await ctx.goalManager.createGoal({
+		title: 'Build feature X',
+		description: 'Implement feature X end-to-end',
+	});
+	ctx.runtime.start();
+	await ctx.runtime.tick();
+
+	const groups = ctx.groupRepo.getActiveGroups('room-1');
+	const group = groups[0];
+	if (!group) throw new Error('No group spawned after tick');
+
+	// The planning task was created by spawnPlanningGroup
+	const planningTask = await ctx.taskManager.getTask(group.taskId);
+	if (!planningTask) throw new Error('No planning task found');
+
+	return { goal, group, planningTask };
+}
+
+// ─── Fix 2: Planner HTTP 400 bounces instead of failing ─────────────────────
+
+describe('Fix 2: Planner HTTP 400 treated as recoverable (bounce)', () => {
+	let ctx: RuntimeTestContext;
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	it('bounces planner worker on HTTP 400 instead of failing the task', async () => {
+		ctx = createRuntimeTestContext({
+			getWorkerMessages: () => [
+				makeWorkerMessage('API Error: 400 {"error":{"message":"prompt too long for model"}}'),
+			],
+		});
+
+		const { group, planningTask } = await setupPlannerGroup(ctx);
+		expect(group.workerRole).toBe('planner');
+
+		// Capture call count before invoking the terminal state handler
+		const callsBefore = ctx.sessionFactory.calls.length;
+
+		await ctx.runtime.onWorkerTerminalState(group.id, {
+			sessionId: group.workerSessionId,
+			kind: 'idle',
+		});
+
+		// Task should NOT be failed — it should still be in_progress (bounce keeps it alive)
+		const updatedTask = await ctx.taskManager.getTask(planningTask.id);
+		expect(updatedTask!.status).not.toBe('needs_attention');
+
+		// A NEW injectMessage call should have been made after onWorkerTerminalState (bounce message)
+		const newCalls = ctx.sessionFactory.calls.slice(callsBefore);
+		const injectCall = newCalls.find(
+			(c) => c.method === 'injectMessage' && c.args[0] === group.workerSessionId
+		);
+		expect(injectCall).toBeDefined();
+		expect(String(injectCall!.args[1])).toContain('HTTP 400');
+	});
+
+	it('does NOT bounce non-planner workers on HTTP 400 (general/coder still fail)', async () => {
+		// Create a non-planning task for a general worker
+		const goal = await (async () => {
+			const tmpCtx = createRuntimeTestContext({
+				getWorkerMessages: () => [
+					makeWorkerMessage('API Error: 400 {"error":{"message":"bad request"}}'),
+				],
+			});
+			ctx = tmpCtx;
+			return null;
+		})();
+		void goal; // appease linter
+
+		const g = await ctx.goalManager.createGoal({ title: 'G', description: 'D' });
+		const task = await ctx.taskManager.createTask({
+			title: 'Task',
+			description: 'Desc',
+			assignedAgent: 'general',
+		});
+		await ctx.goalManager.linkTaskToGoal(g.id, task.id);
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const groups = ctx.groupRepo.getActiveGroups('room-1');
+		const group = groups[0];
+		expect(group.workerRole).toBe('general');
+
+		await ctx.runtime.onWorkerTerminalState(group.id, {
+			sessionId: group.workerSessionId,
+			kind: 'idle',
+		});
+
+		// Non-planner workers should still fail immediately on 400
+		const updatedTask = await ctx.taskManager.getTask(task.id);
+		expect(updatedTask!.status).toBe('needs_attention');
+	});
+
+	it('does NOT bounce planner on other terminal errors (e.g., 401)', async () => {
+		ctx = createRuntimeTestContext({
+			getWorkerMessages: () => [
+				makeWorkerMessage('API Error: 401 {"error":{"message":"Unauthorized"}}'),
+			],
+		});
+
+		const { group, planningTask } = await setupPlannerGroup(ctx);
+
+		await ctx.runtime.onWorkerTerminalState(group.id, {
+			sessionId: group.workerSessionId,
+			kind: 'idle',
+		});
+
+		// 401 is not recoverable even for planners — task should fail
+		const updatedTask = await ctx.taskManager.getTask(planningTask.id);
+		expect(updatedTask!.status).toBe('needs_attention');
+	});
+
+	it('falls through to fail after dead loop is detected for planner HTTP 400', async () => {
+		// Configure dead loop to trigger after 2 failures (very low threshold for testing)
+		ctx = createRuntimeTestContext({
+			getWorkerMessages: () => [
+				makeWorkerMessage('API Error: 400 {"error":{"message":"context too large"}}'),
+			],
+		});
+
+		const { group, planningTask } = await setupPlannerGroup(ctx);
+
+		// First call — should bounce
+		await ctx.runtime.onWorkerTerminalState(group.id, {
+			sessionId: group.workerSessionId,
+			kind: 'idle',
+		});
+		const taskAfterFirst = await ctx.taskManager.getTask(planningTask.id);
+		expect(taskAfterFirst!.status).not.toBe('needs_attention');
+
+		// Eventually dead loop fires (default is 5 consecutive failures within 10 min).
+		// Simulate enough calls to trigger dead loop by calling many times.
+		for (let i = 0; i < 10; i++) {
+			await ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			});
+		}
+
+		// After dead loop, task should eventually fail
+		const taskAfterLoop = await ctx.taskManager.getTask(planningTask.id);
+		expect(taskAfterLoop!.status).toBe('needs_attention');
+	});
+});
+
+// ─── Fix 3: Promote draft tasks when planning task fails ─────────────────────
+
+describe('Fix 3: Draft tasks promoted when planning task fails with terminal error', () => {
+	let ctx: RuntimeTestContext;
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	it('promotes draft tasks to pending before failing planning task on terminal error (401)', async () => {
+		ctx = createRuntimeTestContext({
+			getWorkerMessages: () => [
+				makeWorkerMessage('API Error: 401 {"error":{"message":"Unauthorized"}}'),
+			],
+		});
+
+		const { group, planningTask, goal } = await setupPlannerGroup(ctx);
+
+		// Create draft tasks as if the planner already made progress in Phase 2
+		const draftTask1 = await ctx.taskManager.createTask({
+			title: 'Draft subtask 1',
+			description: 'Was created by planner before crash',
+			status: 'draft',
+			createdByTaskId: planningTask.id,
+			taskType: 'coding',
+		});
+		const draftTask2 = await ctx.taskManager.createTask({
+			title: 'Draft subtask 2',
+			description: 'Was created by planner before crash',
+			status: 'draft',
+			createdByTaskId: planningTask.id,
+			taskType: 'coding',
+		});
+		// Link draft tasks to goal
+		await ctx.goalManager.linkTaskToGoal(goal.id, draftTask1.id);
+		await ctx.goalManager.linkTaskToGoal(goal.id, draftTask2.id);
+
+		await ctx.runtime.onWorkerTerminalState(group.id, {
+			sessionId: group.workerSessionId,
+			kind: 'idle',
+		});
+
+		// Planning task should be failed
+		const updatedPlanning = await ctx.taskManager.getTask(planningTask.id);
+		expect(updatedPlanning!.status).toBe('needs_attention');
+
+		// Draft tasks should be promoted to pending (not lost)
+		const updatedDraft1 = await ctx.taskManager.getTask(draftTask1.id);
+		const updatedDraft2 = await ctx.taskManager.getTask(draftTask2.id);
+		expect(updatedDraft1!.status).toBe('pending');
+		expect(updatedDraft2!.status).toBe('pending');
+	});
+
+	it('does not fail for planning task with no drafts (no-op)', async () => {
+		ctx = createRuntimeTestContext({
+			getWorkerMessages: () => [
+				makeWorkerMessage('API Error: 422 {"error":{"message":"Validation error"}}'),
+			],
+		});
+
+		const { group, planningTask } = await setupPlannerGroup(ctx);
+
+		// No draft tasks created — should not throw
+		await expect(
+			ctx.runtime.onWorkerTerminalState(group.id, {
+				sessionId: group.workerSessionId,
+				kind: 'idle',
+			})
+		).resolves.toBeUndefined();
+
+		const updatedTask = await ctx.taskManager.getTask(planningTask.id);
+		expect(updatedTask!.status).toBe('needs_attention');
+	});
+
+	it('does not promote draft tasks for non-planner workers on terminal error', async () => {
+		ctx = createRuntimeTestContext({
+			getWorkerMessages: () => [
+				makeWorkerMessage('API Error: 403 {"error":{"message":"Forbidden"}}'),
+			],
+		});
+
+		const goal = await ctx.goalManager.createGoal({ title: 'G', description: 'D' });
+		const execTask = await ctx.taskManager.createTask({
+			title: 'Exec task',
+			description: 'Execution task',
+			assignedAgent: 'general',
+		});
+		await ctx.goalManager.linkTaskToGoal(goal.id, execTask.id);
+
+		// Create a draft task linked to the exec task
+		const draftTask = await ctx.taskManager.createTask({
+			title: 'Draft',
+			description: 'Draft',
+			status: 'draft',
+			createdByTaskId: execTask.id,
+		});
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const groups = ctx.groupRepo.getActiveGroups('room-1');
+		const group = groups[0];
+		expect(group.workerRole).toBe('general');
+
+		await ctx.runtime.onWorkerTerminalState(group.id, {
+			sessionId: group.workerSessionId,
+			kind: 'idle',
+		});
+
+		// Exec task should be failed
+		const updatedExec = await ctx.taskManager.getTask(execTask.id);
+		expect(updatedExec!.status).toBe('needs_attention');
+
+		// Draft task should NOT be promoted (non-planner workers don't trigger Fix 3)
+		const updatedDraft = await ctx.taskManager.getTask(draftTask.id);
+		expect(updatedDraft!.status).toBe('draft');
+	});
+});
+
+// ─── Fix 4: Auto-recover needs_human goals with only failed planning tasks ───
+
+describe('Fix 4: needs_human goals with only failed planning tasks auto-recover', () => {
+	let ctx: RuntimeTestContext;
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	it('resets needs_human goal to active when all linked tasks are failed planning tasks and attempts < max', async () => {
+		ctx = createRuntimeTestContext({
+			getWorkerMessages: () => [],
+		});
+
+		// Create a goal and planning task, simulate escalation
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Feature Y',
+			description: 'Build Y',
+		});
+
+		// Simulate: planning_attempts was incremented once (first planning attempt failed)
+		await ctx.goalManager.incrementPlanningAttempts(goal.id);
+		// With new default max=2, attempts=1 < 2 → auto-recoverable
+
+		// Create a planning task in needs_attention (failed state)
+		const planningTask = await ctx.taskManager.createTask({
+			title: 'Plan: Feature Y',
+			description: 'Planning task for Feature Y',
+			taskType: 'planning',
+			status: 'needs_attention',
+		});
+		await ctx.goalManager.linkTaskToGoal(goal.id, planningTask.id);
+
+		// Set goal to needs_human (as if it was escalated with old max=1)
+		await ctx.goalManager.updateGoalStatus(goal.id, 'needs_human');
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// After tick, goal should be reset to active (auto-recovery)
+		const refreshedGoal = await ctx.goalManager.getGoal(goal.id);
+		// The goal was recovered and a new planning group was spawned, changing status back to active
+		// (getNextGoalForPlanning resets it to active and returns it for spawning)
+		expect(['active']).toContain(refreshedGoal?.status);
+
+		// A new planning group should have been spawned
+		const groups = ctx.groupRepo.getActiveGroups('room-1');
+		expect(groups.length).toBeGreaterThan(0);
+	});
+
+	it('does NOT recover needs_human goal when planning_attempts >= effectiveMax', async () => {
+		ctx = createRuntimeTestContext({
+			getWorkerMessages: () => [],
+		});
+
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Feature Z',
+			description: 'Build Z',
+		});
+
+		// Simulate: planning_attempts = 2 (exhausted new default max=2)
+		await ctx.goalManager.incrementPlanningAttempts(goal.id);
+		await ctx.goalManager.incrementPlanningAttempts(goal.id);
+
+		const planningTask = await ctx.taskManager.createTask({
+			title: 'Plan: Feature Z',
+			description: 'Planning task',
+			taskType: 'planning',
+			status: 'needs_attention',
+		});
+		await ctx.goalManager.linkTaskToGoal(goal.id, planningTask.id);
+		await ctx.goalManager.updateGoalStatus(goal.id, 'needs_human');
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// Goal should remain needs_human — retries exhausted
+		const refreshedGoal = await ctx.goalManager.getGoal(goal.id);
+		expect(refreshedGoal?.status).toBe('needs_human');
+	});
+
+	it('does NOT recover needs_human goal when linked tasks include execution tasks', async () => {
+		ctx = createRuntimeTestContext({
+			getWorkerMessages: () => [],
+		});
+
+		const goal = await ctx.goalManager.createGoal({
+			title: 'Feature W',
+			description: 'Build W',
+		});
+
+		await ctx.goalManager.incrementPlanningAttempts(goal.id);
+
+		const planningTask = await ctx.taskManager.createTask({
+			title: 'Plan: Feature W',
+			description: 'Planning task',
+			taskType: 'planning',
+			status: 'needs_attention',
+		});
+		// Also create a failed EXECUTION task — this means human attention is genuinely needed
+		const execTask = await ctx.taskManager.createTask({
+			title: 'Exec task that failed',
+			description: 'An execution task that genuinely failed',
+			taskType: 'coding',
+			status: 'needs_attention',
+		});
+		await ctx.goalManager.linkTaskToGoal(goal.id, planningTask.id);
+		await ctx.goalManager.linkTaskToGoal(goal.id, execTask.id);
+		await ctx.goalManager.updateGoalStatus(goal.id, 'needs_human');
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		// Goal should remain needs_human — execution tasks failed (real problem)
+		const refreshedGoal = await ctx.goalManager.getGoal(goal.id);
+		expect(refreshedGoal?.status).toBe('needs_human');
+	});
+});
+
+// ─── Fix 5: Auto-detect plan PR merge ────────────────────────────────────────
+
+describe('Fix 5: Auto-detect plan PR merge for stuck planning groups', () => {
+	let ctx: RuntimeTestContext;
+
+	beforeEach(() => {
+		// runCommand returns 'MERGED' for gh pr view commands (PR is merged on GitHub)
+		ctx = createRuntimeTestContext({
+			hookOptions: {
+				runCommand: async (args: string[], _cwd: string) => {
+					// Only mock gh pr view calls
+					if (args[0] === 'gh' && args[1] === 'pr' && args[2] === 'view') {
+						return { stdout: 'MERGED', exitCode: 0 };
+					}
+					return { stdout: '', exitCode: 1 };
+				},
+			},
+			getWorkerMessages: () => [],
+		});
+	});
+
+	afterEach(() => {
+		ctx.runtime.stop();
+		ctx.db.close();
+	});
+
+	it('auto-approves planning group when plan PR is merged on GitHub', async () => {
+		const { group, planningTask } = await setupPlannerGroup(ctx);
+
+		// Simulate: leader called submit_for_review with plan PR URL
+		// Set task prUrl and mark group as submitted for review
+		await ctx.taskManager.reviewTask(planningTask.id, 'https://github.com/org/repo/pull/42');
+		ctx.groupRepo.setSubmittedForReview(group.id, true);
+
+		// Verify group is stuck waiting for human approval
+		expect(ctx.groupRepo.getGroup(group.id)?.approved).toBe(false);
+		expect(ctx.groupRepo.getGroup(group.id)?.submittedForReview).toBe(true);
+
+		// Tick should detect the merged PR and auto-approve
+		await ctx.runtime.tick();
+
+		// Group should now be approved
+		const updatedGroup = ctx.groupRepo.getGroup(group.id);
+		expect(updatedGroup?.approved).toBe(true);
+
+		// The leader should have received a resume message
+		const injectToLeader = ctx.sessionFactory.calls.find(
+			(c) => c.method === 'injectMessage' && c.args[0] === group.leaderSessionId
+		);
+		expect(injectToLeader).toBeDefined();
+		expect(String(injectToLeader!.args[1])).toContain('merged on GitHub');
+	});
+
+	it('does NOT approve when PR is not yet merged (OPEN state)', async () => {
+		// Override runCommand to return OPEN
+		ctx.runtime.stop();
+		ctx.db.close();
+
+		ctx = createRuntimeTestContext({
+			hookOptions: {
+				runCommand: async (args: string[], _cwd: string) => {
+					if (args[0] === 'gh' && args[1] === 'pr' && args[2] === 'view') {
+						return { stdout: 'OPEN', exitCode: 0 };
+					}
+					return { stdout: '', exitCode: 1 };
+				},
+			},
+			getWorkerMessages: () => [],
+		});
+
+		const { group, planningTask } = await setupPlannerGroup(ctx);
+		await ctx.taskManager.reviewTask(planningTask.id, 'https://github.com/org/repo/pull/99');
+		ctx.groupRepo.setSubmittedForReview(group.id, true);
+
+		await ctx.runtime.tick();
+
+		// Group should still be unapproved (PR is OPEN, not MERGED)
+		const updatedGroup = ctx.groupRepo.getGroup(group.id);
+		expect(updatedGroup?.approved).toBe(false);
+	});
+
+	it('does NOT trigger for non-planner groups in submitted_for_review', async () => {
+		// Create a regular (non-planning) task
+		const goal = await ctx.goalManager.createGoal({ title: 'G', description: 'D' });
+		const task = await ctx.taskManager.createTask({
+			title: 'Coder task',
+			description: 'Coding task',
+			assignedAgent: 'coder',
+		});
+		await ctx.goalManager.linkTaskToGoal(goal.id, task.id);
+
+		ctx.runtime.start();
+		await ctx.runtime.tick();
+
+		const groups = ctx.groupRepo.getActiveGroups('room-1');
+		const group = groups[0];
+
+		// Set PR URL and mark as submitted for review
+		await ctx.taskManager.reviewTask(task.id, 'https://github.com/org/repo/pull/77');
+		ctx.groupRepo.setSubmittedForReview(group.id, true);
+
+		const initialCalls = ctx.sessionFactory.calls.length;
+
+		await ctx.runtime.tick();
+
+		// No additional injectMessage calls to leader for non-planner groups
+		// (the recovery only applies to planner groups)
+		const newLeaderInjects = ctx.sessionFactory.calls
+			.slice(initialCalls)
+			.filter((c) => c.method === 'injectMessage' && c.args[0] === group.leaderSessionId);
+		expect(newLeaderInjects.length).toBe(0);
+		expect(ctx.groupRepo.getGroup(group.id)?.approved).toBe(false);
+	});
+
+	it('does NOT trigger when planning group has no prUrl', async () => {
+		const { group } = await setupPlannerGroup(ctx);
+
+		// Mark as submitted for review but NO prUrl on the task
+		ctx.groupRepo.setSubmittedForReview(group.id, true);
+
+		const initialCalls = ctx.sessionFactory.calls.length;
+
+		await ctx.runtime.tick();
+
+		// No resume should have been triggered
+		const newCalls = ctx.sessionFactory.calls.slice(initialCalls);
+		const injectCalls = newCalls.filter((c) => c.method === 'injectMessage');
+		expect(injectCalls.length).toBe(0);
+	});
+
+	it('does NOT trigger when gh command fails (fails open gracefully)', async () => {
+		ctx.runtime.stop();
+		ctx.db.close();
+
+		// runCommand always fails (e.g. gh not installed)
+		ctx = createRuntimeTestContext({
+			hookOptions: {
+				runCommand: async (_args: string[], _cwd: string) => {
+					return { stdout: '', exitCode: 1 };
+				},
+			},
+			getWorkerMessages: () => [],
+		});
+
+		const { group, planningTask } = await setupPlannerGroup(ctx);
+		await ctx.taskManager.reviewTask(planningTask.id, 'https://github.com/org/repo/pull/55');
+		ctx.groupRepo.setSubmittedForReview(group.id, true);
+
+		// Should not throw — fails open
+		await expect(ctx.runtime.tick()).resolves.toBeUndefined();
+
+		// Group should not be auto-approved when gh fails
+		expect(ctx.groupRepo.getGroup(group.id)?.approved).toBe(false);
+	});
+});

--- a/packages/daemon/tests/unit/room/room-runtime-planning-recovery.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime-planning-recovery.test.ts
@@ -119,17 +119,11 @@ describe('Fix 2: Planner HTTP 400 treated as recoverable (bounce)', () => {
 	});
 
 	it('does NOT bounce non-planner workers on HTTP 400 (general/coder still fail)', async () => {
-		// Create a non-planning task for a general worker
-		const goal = await (async () => {
-			const tmpCtx = createRuntimeTestContext({
-				getWorkerMessages: () => [
-					makeWorkerMessage('API Error: 400 {"error":{"message":"bad request"}}'),
-				],
-			});
-			ctx = tmpCtx;
-			return null;
-		})();
-		void goal; // appease linter
+		ctx = createRuntimeTestContext({
+			getWorkerMessages: () => [
+				makeWorkerMessage('API Error: 400 {"error":{"message":"bad request"}}'),
+			],
+		});
 
 		const g = await ctx.goalManager.createGoal({ title: 'G', description: 'D' });
 		const task = await ctx.taskManager.createTask({
@@ -492,6 +486,8 @@ describe('Fix 5: Auto-detect plan PR merge for stuck planning groups', () => {
 		// Group should now be approved
 		const updatedGroup = ctx.groupRepo.getGroup(group.id);
 		expect(updatedGroup?.approved).toBe(true);
+		// approvalSource should be 'github_merge_detected' (not 'human') for audit trail
+		expect(updatedGroup?.approvalSource).toBe('github_merge_detected');
 
 		// The leader should have received a resume message
 		const injectToLeader = ctx.sessionFactory.calls.find(

--- a/packages/daemon/tests/unit/room/room-runtime.test.ts
+++ b/packages/daemon/tests/unit/room/room-runtime.test.ts
@@ -191,8 +191,8 @@ describe('RoomRuntime', () => {
 			expect(goalAfter!.planning_attempts).toBeGreaterThan(attemptsBefore);
 		});
 
-		it('should escalate to needs_human immediately when maxPlanningRetries=0 (default) and execution tasks all failed', async () => {
-			// Default room config: maxPlanningRetries = 0 (no retries)
+		it('should escalate to needs_human after exhausting default planning attempts (2) and execution tasks all failed', async () => {
+			// Default effectiveMax = 2 (allows 1 retry). Two failed attempts → escalate.
 			const goal = await ctx.goalManager.createGoal({
 				title: 'Build API',
 				description: 'Build the REST API',
@@ -213,8 +213,9 @@ describe('RoomRuntime', () => {
 			await ctx.goalManager.linkTaskToGoal(goal.id, execTask.id);
 			await ctx.taskManager.failTask(execTask.id, 'Compilation error');
 
-			// planning_attempts = 1 (initial planning done), maxPlanningAttempts = 0+1 = 1
-			// So attempts >= maxPlanningAttempts → escalate immediately
+			// planning_attempts = 2 (both attempts exhausted), effectiveMax = 2
+			// So attempts >= effectiveMax → escalate immediately
+			await ctx.goalManager.incrementPlanningAttempts(goal.id);
 			await ctx.goalManager.incrementPlanningAttempts(goal.id);
 
 			ctx.runtime.start();

--- a/packages/daemon/tests/unit/storage/migrations/migration-28_test.ts
+++ b/packages/daemon/tests/unit/storage/migrations/migration-28_test.ts
@@ -542,14 +542,14 @@ describe('getEffectiveMaxPlanningAttempts', () => {
 		expect(getEffectiveMaxPlanningAttempts(goal, { maxPlanningRetries: 0 })).toBe(1);
 	});
 
-	test('returns 1 when neither goal nor roomConfig specifies', () => {
+	test('returns 2 when neither goal nor roomConfig specifies (default allows 1 retry)', () => {
 		const goal = makeGoal(undefined);
-		expect(getEffectiveMaxPlanningAttempts(goal)).toBe(1);
+		expect(getEffectiveMaxPlanningAttempts(goal)).toBe(2);
 	});
 
-	test('returns 1 when roomConfig has no maxPlanningRetries', () => {
+	test('returns 2 when roomConfig has no maxPlanningRetries', () => {
 		const goal = makeGoal(undefined);
-		expect(getEffectiveMaxPlanningAttempts(goal, { someOtherKey: 99 })).toBe(1);
+		expect(getEffectiveMaxPlanningAttempts(goal, { someOtherKey: 99 })).toBe(2);
 	});
 
 	test('ignores goal.maxPlanningAttempts of 0 (falls through to roomConfig)', () => {


### PR DESCRIPTION
Fixes 5 issues that caused planning tasks to permanently escalate to `needs_human` on transient API errors with no recovery path.

- **Fix 1**: Default `maxPlanningAttempts` raised from 1 → 2 (allows 1 retry). Planning is the most failure-prone phase and one transient error shouldn't permanently block a goal.
- **Fix 2**: HTTP 400 for planner workers is now treated as recoverable — bounces the worker with a retry message instead of failing immediately. Dead-loop detection caps retries.
- **Fix 3**: Draft tasks created by a planner are promoted to `pending` before the planning task fails on terminal error, preserving Phase 2 partial progress.
- **Fix 4**: `getNextGoalForPlanning()` now also scans `needs_human` goals where all linked tasks are planning tasks in terminal states — auto-resets them to `active` so replanning can proceed (subject to `effectiveMax`).
- **Fix 5**: New `recoverMergedPlanGroups()` tick method detects planning groups stuck in `submitted_for_review` where the plan PR was merged on GitHub directly (bypassing the NeoKai Approve button), and auto-approves them.

All 5 fixes covered by 20 new unit tests in `room-runtime-planning-recovery.test.ts`. Updated 2 existing tests to reflect the new default max of 2.