### PR TITLE
feat: add mission route to router and signals

### DIFF
--- a/packages/web/src/lib/__tests__/router.test.ts
+++ b/packages/web/src/lib/__tests__/router.test.ts
@@ -13,15 +13,24 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
 	getSessionIdFromPath,
 	getRoomIdFromPath,
+	getRoomMissionIdFromPath,
 	createSessionPath,
+	createRoomMissionPath,
 	navigateToSession,
+	navigateToRoom,
 	navigateToHome,
+	navigateToRoomMission,
 	initializeRouter,
 	cleanupRouter,
 	getRouterState,
 	isRouterInitialized,
 } from '../router';
-import { currentSessionIdSignal, currentRoomIdSignal } from '../signals';
+import {
+	currentSessionIdSignal,
+	currentRoomIdSignal,
+	currentRoomTaskIdSignal,
+	currentRoomGoalIdSignal,
+} from '../signals';
 
 // Store original values (use unknown to avoid type errors at module load time)
 let originalHistory: unknown;
@@ -64,6 +73,8 @@ describe('Router Utility', () => {
 		// Reset signals
 		currentSessionIdSignal.value = null;
 		currentRoomIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 
 		// Reset mocks
 		vi.clearAllMocks();
@@ -91,6 +102,8 @@ describe('Router Utility', () => {
 		// Reset signals
 		currentSessionIdSignal.value = null;
 		currentRoomIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 	});
 
 	describe('getSessionIdFromPath', () => {
@@ -545,6 +558,358 @@ describe('Router Utility', () => {
 				'',
 				'/room/550e8400-e29b-41d4-a716-446655440000'
 			);
+		});
+	});
+
+	// ──────────────────────────────────────────────────────────────────────────
+	// Mission route tests
+	// ──────────────────────────────────────────────────────────────────────────
+
+	describe('getRoomMissionIdFromPath', () => {
+		it('should extract roomId and goalId from UUID mission path', () => {
+			const result = getRoomMissionIdFromPath(
+				'/room/550e8400-e29b-41d4-a716-446655440000/mission/660e8400-e29b-41d4-a716-446655440001'
+			);
+			expect(result).toEqual({
+				roomId: '550e8400-e29b-41d4-a716-446655440000',
+				goalId: '660e8400-e29b-41d4-a716-446655440001',
+			});
+		});
+
+		it('should extract roomId and goalId from short ID mission path', () => {
+			const result = getRoomMissionIdFromPath(
+				'/room/550e8400-e29b-41d4-a716-446655440000/mission/a-1'
+			);
+			expect(result).toEqual({
+				roomId: '550e8400-e29b-41d4-a716-446655440000',
+				goalId: 'a-1',
+			});
+		});
+
+		it('should extract roomId and goalId from multi-digit short ID mission path', () => {
+			const result = getRoomMissionIdFromPath(
+				'/room/550e8400-e29b-41d4-a716-446655440000/mission/z-123'
+			);
+			expect(result).toEqual({
+				roomId: '550e8400-e29b-41d4-a716-446655440000',
+				goalId: 'z-123',
+			});
+		});
+
+		it('should return null for non-mission paths', () => {
+			expect(getRoomMissionIdFromPath('/room/550e8400-e29b-41d4-a716-446655440000')).toBeNull();
+			expect(
+				getRoomMissionIdFromPath(
+					'/room/550e8400-e29b-41d4-a716-446655440000/task/660e8400-e29b-41d4-a716-446655440001'
+				)
+			).toBeNull();
+			expect(getRoomMissionIdFromPath('/session/550e8400-e29b-41d4-a716-446655440000')).toBeNull();
+			expect(getRoomMissionIdFromPath('/')).toBeNull();
+			expect(getRoomMissionIdFromPath('/invalid/path')).toBeNull();
+		});
+
+		it('should return null for path with extra trailing segments', () => {
+			const result = getRoomMissionIdFromPath(
+				'/room/550e8400-e29b-41d4-a716-446655440000/mission/660e8400-e29b-41d4-a716-446655440001/extra'
+			);
+			expect(result).toBeNull();
+		});
+	});
+
+	describe('createRoomMissionPath', () => {
+		it('should create correct mission path with UUID goal ID', () => {
+			const path = createRoomMissionPath(
+				'550e8400-e29b-41d4-a716-446655440000',
+				'660e8400-e29b-41d4-a716-446655440001'
+			);
+			expect(path).toBe(
+				'/room/550e8400-e29b-41d4-a716-446655440000/mission/660e8400-e29b-41d4-a716-446655440001'
+			);
+		});
+
+		it('should create correct mission path with short goal ID', () => {
+			const path = createRoomMissionPath('550e8400-e29b-41d4-a716-446655440000', 'a-1');
+			expect(path).toBe('/room/550e8400-e29b-41d4-a716-446655440000/mission/a-1');
+		});
+	});
+
+	describe('getRoomIdFromPath with mission route', () => {
+		it('should extract room ID from mission path', () => {
+			const roomId = getRoomIdFromPath(
+				'/room/550e8400-e29b-41d4-a716-446655440000/mission/660e8400-e29b-41d4-a716-446655440001'
+			);
+			expect(roomId).toBe('550e8400-e29b-41d4-a716-446655440000');
+		});
+
+		it('should extract room ID from mission path with short ID', () => {
+			const roomId = getRoomIdFromPath('/room/550e8400-e29b-41d4-a716-446655440000/mission/a-1');
+			expect(roomId).toBe('550e8400-e29b-41d4-a716-446655440000');
+		});
+	});
+
+	describe('navigateToRoomMission', () => {
+		it('should update URL and set currentRoomGoalIdSignal when navigating to mission', () => {
+			navigateToRoomMission(
+				'550e8400-e29b-41d4-a716-446655440000',
+				'660e8400-e29b-41d4-a716-446655440001'
+			);
+
+			const expectedPath =
+				'/room/550e8400-e29b-41d4-a716-446655440000/mission/660e8400-e29b-41d4-a716-446655440001';
+			expect(mockHistory.pushState).toHaveBeenCalledWith(
+				{
+					roomId: '550e8400-e29b-41d4-a716-446655440000',
+					goalId: '660e8400-e29b-41d4-a716-446655440001',
+					path: expectedPath,
+				},
+				'',
+				expectedPath
+			);
+
+			expect(currentRoomGoalIdSignal.value).toBe('660e8400-e29b-41d4-a716-446655440001');
+			expect(currentRoomIdSignal.value).toBe('550e8400-e29b-41d4-a716-446655440000');
+		});
+
+		it('should clear currentRoomTaskIdSignal when navigating to mission', () => {
+			// Pre-set a task ID
+			currentRoomTaskIdSignal.value = 'some-task-id';
+
+			navigateToRoomMission(
+				'550e8400-e29b-41d4-a716-446655440000',
+				'660e8400-e29b-41d4-a716-446655440001'
+			);
+
+			expect(currentRoomTaskIdSignal.value).toBeNull();
+			expect(currentRoomGoalIdSignal.value).toBe('660e8400-e29b-41d4-a716-446655440001');
+		});
+
+		it('should clear currentSessionIdSignal when navigating to mission', () => {
+			currentSessionIdSignal.value = 'some-session-id';
+
+			navigateToRoomMission(
+				'550e8400-e29b-41d4-a716-446655440000',
+				'660e8400-e29b-41d4-a716-446655440001'
+			);
+
+			expect(currentSessionIdSignal.value).toBeNull();
+		});
+
+		it('should use replaceState when replace is true', () => {
+			navigateToRoomMission(
+				'550e8400-e29b-41d4-a716-446655440000',
+				'660e8400-e29b-41d4-a716-446655440001',
+				true
+			);
+
+			expect(mockHistory.replaceState).toHaveBeenCalled();
+			expect(mockHistory.pushState).not.toHaveBeenCalled();
+		});
+
+		it('should not navigate if already on the same mission path', () => {
+			const path =
+				'/room/550e8400-e29b-41d4-a716-446655440000/mission/660e8400-e29b-41d4-a716-446655440001';
+			mockLocation.pathname = path;
+			currentRoomGoalIdSignal.value = '660e8400-e29b-41d4-a716-446655440001';
+
+			navigateToRoomMission(
+				'550e8400-e29b-41d4-a716-446655440000',
+				'660e8400-e29b-41d4-a716-446655440001'
+			);
+
+			expect(mockHistory.pushState).not.toHaveBeenCalled();
+			expect(mockHistory.replaceState).not.toHaveBeenCalled();
+			// Signal remains set idempotently
+			expect(currentRoomGoalIdSignal.value).toBe('660e8400-e29b-41d4-a716-446655440001');
+		});
+
+		it('should prevent recursive navigation when isNavigating is true', () => {
+			navigateToRoomMission(
+				'550e8400-e29b-41d4-a716-446655440000',
+				'660e8400-e29b-41d4-a716-446655440001'
+			);
+			const firstCallCount = mockHistory.pushState.mock.calls.length;
+
+			// isNavigating still true — second call is a no-op
+			navigateToRoomMission(
+				'550e8400-e29b-41d4-a716-446655440000',
+				'770e8400-e29b-41d4-a716-446655440002'
+			);
+
+			expect(mockHistory.pushState.mock.calls.length).toBe(firstCallCount);
+			// Signal stays from the first navigation
+			expect(currentRoomGoalIdSignal.value).toBe('660e8400-e29b-41d4-a716-446655440001');
+		});
+	});
+
+	describe('navigateToRoom clears currentRoomGoalIdSignal', () => {
+		it('should clear currentRoomGoalIdSignal when navigating to a plain room', () => {
+			currentRoomGoalIdSignal.value = 'some-goal-id';
+
+			navigateToRoom('550e8400-e29b-41d4-a716-446655440000');
+
+			expect(currentRoomGoalIdSignal.value).toBeNull();
+		});
+	});
+
+	describe('navigateToSession clears currentRoomGoalIdSignal', () => {
+		it('should clear currentRoomGoalIdSignal when navigating to a session', () => {
+			currentRoomGoalIdSignal.value = 'some-goal-id';
+
+			navigateToSession('550e8400e29b41d4a716446655440007');
+
+			expect(currentRoomGoalIdSignal.value).toBeNull();
+		});
+	});
+
+	describe('navigateToHome clears currentRoomGoalIdSignal', () => {
+		it('should clear currentRoomGoalIdSignal when navigating home', () => {
+			// Start from a mission page so home navigation actually fires
+			mockLocation.pathname =
+				'/room/550e8400-e29b-41d4-a716-446655440000/mission/660e8400-e29b-41d4-a716-446655440001';
+			currentRoomGoalIdSignal.value = '660e8400-e29b-41d4-a716-446655440001';
+
+			navigateToHome();
+
+			expect(currentRoomGoalIdSignal.value).toBeNull();
+		});
+	});
+
+	describe('initializeRouter with mission route', () => {
+		it('should set currentRoomGoalIdSignal and currentRoomIdSignal when URL is a mission path', () => {
+			mockLocation.pathname =
+				'/room/550e8400-e29b-41d4-a716-446655440000/mission/660e8400-e29b-41d4-a716-446655440001';
+
+			initializeRouter();
+
+			expect(currentRoomGoalIdSignal.value).toBe('660e8400-e29b-41d4-a716-446655440001');
+			expect(currentRoomIdSignal.value).toBe('550e8400-e29b-41d4-a716-446655440000');
+			expect(currentRoomTaskIdSignal.value).toBeNull();
+			expect(currentSessionIdSignal.value).toBeNull();
+		});
+
+		it('should set currentRoomGoalIdSignal when URL has a short mission ID', () => {
+			mockLocation.pathname = '/room/550e8400-e29b-41d4-a716-446655440000/mission/a-1';
+
+			initializeRouter();
+
+			expect(currentRoomGoalIdSignal.value).toBe('a-1');
+			expect(currentRoomIdSignal.value).toBe('550e8400-e29b-41d4-a716-446655440000');
+		});
+
+		it('should clear currentRoomGoalIdSignal when URL is a plain room path', () => {
+			currentRoomGoalIdSignal.value = 'pre-existing-goal-id';
+			mockLocation.pathname = '/room/550e8400-e29b-41d4-a716-446655440000';
+
+			initializeRouter();
+
+			expect(currentRoomGoalIdSignal.value).toBeNull();
+			expect(currentRoomIdSignal.value).toBe('550e8400-e29b-41d4-a716-446655440000');
+		});
+
+		it('should clear currentRoomGoalIdSignal when URL is a room task path', () => {
+			currentRoomGoalIdSignal.value = 'pre-existing-goal-id';
+			mockLocation.pathname =
+				'/room/550e8400-e29b-41d4-a716-446655440000/task/660e8400-e29b-41d4-a716-446655440001';
+
+			initializeRouter();
+
+			expect(currentRoomGoalIdSignal.value).toBeNull();
+		});
+	});
+
+	describe('Popstate handling for mission routes', () => {
+		it('should update signals when popstate navigates to a mission path', () => {
+			mockLocation.pathname = '/';
+			initializeRouter();
+
+			mockLocation.pathname =
+				'/room/550e8400-e29b-41d4-a716-446655440000/mission/660e8400-e29b-41d4-a716-446655440001';
+
+			window.dispatchEvent(new PopStateEvent('popstate', {}));
+
+			expect(currentRoomGoalIdSignal.value).toBe('660e8400-e29b-41d4-a716-446655440001');
+			expect(currentRoomIdSignal.value).toBe('550e8400-e29b-41d4-a716-446655440000');
+			expect(currentRoomTaskIdSignal.value).toBeNull();
+			expect(currentSessionIdSignal.value).toBeNull();
+		});
+
+		it('should update signals when popstate navigates to a mission path with short ID', () => {
+			mockLocation.pathname = '/';
+			initializeRouter();
+
+			mockLocation.pathname = '/room/550e8400-e29b-41d4-a716-446655440000/mission/a-1';
+
+			window.dispatchEvent(new PopStateEvent('popstate', {}));
+
+			expect(currentRoomGoalIdSignal.value).toBe('a-1');
+			expect(currentRoomIdSignal.value).toBe('550e8400-e29b-41d4-a716-446655440000');
+		});
+
+		it('should clear currentRoomGoalIdSignal when popstate navigates from mission to room task', () => {
+			mockLocation.pathname =
+				'/room/550e8400-e29b-41d4-a716-446655440000/mission/660e8400-e29b-41d4-a716-446655440001';
+			initializeRouter();
+			currentRoomGoalIdSignal.value = '660e8400-e29b-41d4-a716-446655440001';
+
+			// Navigate to task
+			mockLocation.pathname =
+				'/room/550e8400-e29b-41d4-a716-446655440000/task/770e8400-e29b-41d4-a716-446655440002';
+
+			window.dispatchEvent(new PopStateEvent('popstate', {}));
+
+			expect(currentRoomGoalIdSignal.value).toBeNull();
+			expect(currentRoomTaskIdSignal.value).toBe('770e8400-e29b-41d4-a716-446655440002');
+		});
+
+		it('should clear currentRoomGoalIdSignal when popstate navigates away from mission to home', () => {
+			mockLocation.pathname =
+				'/room/550e8400-e29b-41d4-a716-446655440000/mission/660e8400-e29b-41d4-a716-446655440001';
+			initializeRouter();
+			currentRoomGoalIdSignal.value = '660e8400-e29b-41d4-a716-446655440001';
+
+			mockLocation.pathname = '/';
+
+			window.dispatchEvent(new PopStateEvent('popstate', {}));
+
+			expect(currentRoomGoalIdSignal.value).toBeNull();
+			expect(currentRoomIdSignal.value).toBeNull();
+		});
+
+		it('should prefer mission route over task route when both could match (ordering check)', () => {
+			// This test verifies handlePopState checks roomMission before roomTask
+			mockLocation.pathname = '/';
+			initializeRouter();
+
+			mockLocation.pathname =
+				'/room/550e8400-e29b-41d4-a716-446655440000/mission/660e8400-e29b-41d4-a716-446655440001';
+
+			window.dispatchEvent(new PopStateEvent('popstate', {}));
+
+			// Should use the mission handler, not the task handler
+			expect(currentRoomGoalIdSignal.value).toBe('660e8400-e29b-41d4-a716-446655440001');
+			expect(currentRoomTaskIdSignal.value).toBeNull();
+		});
+	});
+
+	describe('currentRoomGoalIdSignal signal', () => {
+		it('should start as null', () => {
+			expect(currentRoomGoalIdSignal.value).toBeNull();
+		});
+
+		it('should be set after navigateToRoomMission and cleared after navigateToHome', async () => {
+			navigateToRoomMission(
+				'550e8400-e29b-41d4-a716-446655440000',
+				'660e8400-e29b-41d4-a716-446655440001'
+			);
+			expect(currentRoomGoalIdSignal.value).toBe('660e8400-e29b-41d4-a716-446655440001');
+
+			// Wait for isNavigating to clear
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			mockLocation.pathname =
+				'/room/550e8400-e29b-41d4-a716-446655440000/mission/660e8400-e29b-41d4-a716-446655440001';
+			navigateToHome();
+			expect(currentRoomGoalIdSignal.value).toBeNull();
 		});
 	});
 

--- a/packages/web/src/lib/__tests__/router.test.ts
+++ b/packages/web/src/lib/__tests__/router.test.ts
@@ -875,8 +875,7 @@ describe('Router Utility', () => {
 			expect(currentRoomIdSignal.value).toBeNull();
 		});
 
-		it('should prefer mission route over task route when both could match (ordering check)', () => {
-			// This test verifies handlePopState checks roomMission before roomTask
+		it('should set goalId signal and clear taskId signal when popstate navigates to mission path', () => {
 			mockLocation.pathname = '/';
 			initializeRouter();
 
@@ -885,7 +884,6 @@ describe('Router Utility', () => {
 
 			window.dispatchEvent(new PopStateEvent('popstate', {}));
 
-			// Should use the mission handler, not the task handler
 			expect(currentRoomGoalIdSignal.value).toBe('660e8400-e29b-41d4-a716-446655440001');
 			expect(currentRoomTaskIdSignal.value).toBeNull();
 		});

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -19,6 +19,7 @@ import {
 	currentRoomIdSignal,
 	currentRoomSessionIdSignal,
 	currentRoomTaskIdSignal,
+	currentRoomGoalIdSignal,
 	currentRoomAgentActiveSignal,
 	currentRoomActiveTabSignal,
 	currentSpaceIdSignal,
@@ -34,6 +35,7 @@ const ROOM_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)$/;
 const ROOM_AGENT_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/agent$/;
 const ROOM_SESSION_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/session\/([a-f0-9-]+)$/;
 const ROOM_TASK_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/task\/([a-f0-9-]+|[a-z]-[1-9]\d*)$/;
+const ROOM_MISSION_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/mission\/([a-f0-9-]+|[a-z]-[1-9]\d*)$/;
 const SESSIONS_ROUTE_PATTERN = /^\/sessions$/;
 const INBOX_ROUTE_PATTERN = /^\/inbox$/;
 const SPACES_ROUTE_PATTERN = /^\/spaces$/;
@@ -88,6 +90,10 @@ export function getRoomIdFromPath(path: string): string | null {
 	const roomTaskMatch = path.match(ROOM_TASK_ROUTE_PATTERN);
 	if (roomTaskMatch) return roomTaskMatch[1];
 
+	// Also check room mission pattern
+	const roomMissionMatch = path.match(ROOM_MISSION_ROUTE_PATTERN);
+	if (roomMissionMatch) return roomMissionMatch[1];
+
 	// Legacy chat sub-path — the Chat tab was removed; redirect old URLs to the room overview
 	const chatCompatMatch = path.match(ROOM_CHAT_COMPAT_PATTERN);
 	return chatCompatMatch ? chatCompatMatch[1] : null;
@@ -113,6 +119,16 @@ export function getRoomTaskIdFromPath(path: string): { roomId: string; taskId: s
 	const match = path.match(ROOM_TASK_ROUTE_PATTERN);
 	if (!match) return null;
 	return { roomId: match[1], taskId: match[2] };
+}
+
+/**
+ * Extract room mission (goal) ID from current URL path
+ * Returns null if not on a room mission route
+ */
+export function getRoomMissionIdFromPath(path: string): { roomId: string; goalId: string } | null {
+	const match = path.match(ROOM_MISSION_ROUTE_PATTERN);
+	if (!match) return null;
+	return { roomId: match[1], goalId: match[2] };
 }
 
 /**
@@ -228,6 +244,13 @@ export function createRoomTaskPath(roomId: string, taskId: string): string {
 }
 
 /**
+ * Create room mission URL path (mission detail viewed within room layout)
+ */
+export function createRoomMissionPath(roomId: string, goalId: string): string {
+	return `/room/${roomId}/mission/${goalId}`;
+}
+
+/**
  * Create space URL path
  */
 export function createSpacePath(spaceId: string): string {
@@ -284,6 +307,7 @@ export function navigateToSession(sessionId: string, replace = false): void {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
@@ -307,6 +331,7 @@ export function navigateToSession(sessionId: string, replace = false): void {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
@@ -334,6 +359,7 @@ export function navigateToHome(replace = false): void {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
@@ -351,6 +377,7 @@ export function navigateToHome(replace = false): void {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
@@ -383,6 +410,7 @@ export function navigateToRoom(roomId: string, replace = false): void {
 		currentRoomIdSignal.value = roomId;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		currentSpaceIdSignal.value = null;
@@ -406,6 +434,7 @@ export function navigateToRoom(roomId: string, replace = false): void {
 		currentRoomIdSignal.value = roomId;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		currentSpaceIdSignal.value = null;
@@ -439,6 +468,7 @@ export function navigateToRoomAgent(roomId: string, replace = false): void {
 		currentRoomIdSignal.value = roomId;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = true;
 		currentRoomActiveTabSignal.value = 'chat';
 		currentSessionIdSignal.value = null;
@@ -457,6 +487,7 @@ export function navigateToRoomAgent(roomId: string, replace = false): void {
 		currentRoomIdSignal.value = roomId;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = true;
 		currentRoomActiveTabSignal.value = 'chat';
 		currentSessionIdSignal.value = null;
@@ -493,6 +524,7 @@ export function navigateToRoomSession(roomId: string, sessionId: string, replace
 		currentRoomIdSignal.value = roomId;
 		currentRoomSessionIdSignal.value = sessionId;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		currentSpaceIdSignal.value = null;
@@ -516,6 +548,7 @@ export function navigateToRoomSession(roomId: string, sessionId: string, replace
 		currentRoomIdSignal.value = roomId;
 		currentRoomSessionIdSignal.value = sessionId;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		currentSpaceIdSignal.value = null;
@@ -549,6 +582,7 @@ export function navigateToRoomTask(roomId: string, taskId: string, replace = fal
 	if (currentPath === targetPath) {
 		currentRoomIdSignal.value = roomId;
 		currentRoomTaskIdSignal.value = taskId;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
@@ -566,6 +600,59 @@ export function navigateToRoomTask(roomId: string, taskId: string, replace = fal
 
 		currentRoomIdSignal.value = roomId;
 		currentRoomTaskIdSignal.value = taskId;
+		currentRoomGoalIdSignal.value = null;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomAgentActiveSignal.value = false;
+		currentSessionIdSignal.value = null;
+		currentSpaceIdSignal.value = null;
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		navSectionSignal.value = 'rooms';
+	} finally {
+		setTimeout(() => {
+			routerState.isNavigating = false;
+		}, 0);
+	}
+}
+
+/**
+ * Navigate to a mission detail within a room layout
+ * Shows the MissionDetail page while keeping the room context panel
+ *
+ * @param roomId - The room ID
+ * @param goalId - The mission (goal) ID to show the detail view for
+ * @param replace - Whether to replace current history entry (default: false)
+ */
+export function navigateToRoomMission(roomId: string, goalId: string, replace = false): void {
+	if (routerState.isNavigating) {
+		return; // Prevent recursive navigation
+	}
+
+	const targetPath = createRoomMissionPath(roomId, goalId);
+	const currentPath = getCurrentPath();
+
+	if (currentPath === targetPath) {
+		currentRoomIdSignal.value = roomId;
+		currentRoomGoalIdSignal.value = goalId;
+		currentRoomTaskIdSignal.value = null;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomAgentActiveSignal.value = false;
+		currentSessionIdSignal.value = null;
+		currentSpaceIdSignal.value = null;
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		return;
+	}
+
+	routerState.isNavigating = true;
+
+	try {
+		const historyMethod = replace ? 'replaceState' : 'pushState';
+		window.history[historyMethod]({ roomId, goalId, path: targetPath }, '', targetPath);
+
+		currentRoomIdSignal.value = roomId;
+		currentRoomGoalIdSignal.value = goalId;
+		currentRoomTaskIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
@@ -596,6 +683,7 @@ export function navigateToSessions(replace = false): void {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
@@ -613,6 +701,7 @@ export function navigateToSessions(replace = false): void {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
@@ -663,6 +752,7 @@ export function navigateToInbox(replace = false): void {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
@@ -680,6 +770,7 @@ export function navigateToInbox(replace = false): void {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
@@ -732,6 +823,7 @@ export function navigateToSpacesPage(replace = false): void {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
@@ -749,6 +841,7 @@ export function navigateToSpacesPage(replace = false): void {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
@@ -782,6 +875,7 @@ export function navigateToSpace(spaceId: string, replace = false): void {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		navSectionSignal.value = 'spaces';
 		return;
@@ -801,6 +895,7 @@ export function navigateToSpace(spaceId: string, replace = false): void {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		navSectionSignal.value = 'spaces';
 	} finally {
@@ -831,6 +926,7 @@ export function navigateToSpaceConfigure(spaceId: string, replace = false): void
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		navSectionSignal.value = 'spaces';
 		return;
@@ -850,6 +946,7 @@ export function navigateToSpaceConfigure(spaceId: string, replace = false): void
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		navSectionSignal.value = 'spaces';
 	} finally {
@@ -879,6 +976,7 @@ export function navigateToSpaceSession(spaceId: string, sessionId: string, repla
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		navSectionSignal.value = 'spaces';
 		return;
@@ -898,6 +996,7 @@ export function navigateToSpaceSession(spaceId: string, sessionId: string, repla
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		navSectionSignal.value = 'spaces';
 	} finally {
@@ -927,6 +1026,7 @@ export function navigateToSpaceTask(spaceId: string, taskId: string, replace = f
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		navSectionSignal.value = 'spaces';
 		return;
@@ -946,6 +1046,7 @@ export function navigateToSpaceTask(spaceId: string, taskId: string, replace = f
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		navSectionSignal.value = 'spaces';
 	} finally {
@@ -979,6 +1080,7 @@ export function navigateToSpaceAgent(spaceId: string, replace = false): void {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		navSectionSignal.value = 'spaces';
 		return;
@@ -998,6 +1100,7 @@ export function navigateToSpaceAgent(spaceId: string, replace = false): void {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		navSectionSignal.value = 'spaces';
 	} finally {
@@ -1019,6 +1122,7 @@ function handlePopState(_event: PopStateEvent): void {
 	const sessionId = getSessionIdFromPath(path);
 	const roomId = getRoomIdFromPath(path);
 	const roomAgent = getRoomAgentFromPath(path);
+	const roomMission = getRoomMissionIdFromPath(path);
 	const roomSession = getRoomSessionIdFromPath(path);
 	const roomTask = getRoomTaskIdFromPath(path);
 	const spaceConfigure = getSpaceConfigureFromPath(path);
@@ -1029,7 +1133,7 @@ function handlePopState(_event: PopStateEvent): void {
 
 	// Update the signals to match the URL
 	// Space routes take priority over room routes
-	// IMPORTANT: Order is load-bearing — roomAgent must be checked before roomTask/roomSession/roomId
+	// IMPORTANT: Order is load-bearing — roomAgent must be checked before roomMission/roomTask/roomSession/roomId
 	// because getRoomIdFromPath also matches agent paths. If reordered, agent routes silently
 	// fall through to the plain room handler, losing the synthetic session ID.
 	if (spaceTask) {
@@ -1040,6 +1144,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
@@ -1051,6 +1156,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
@@ -1062,6 +1168,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
@@ -1073,6 +1180,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
@@ -1084,6 +1192,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
@@ -1095,8 +1204,21 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomIdSignal.value = roomAgent;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = true;
 		currentRoomActiveTabSignal.value = 'chat';
+		currentSessionIdSignal.value = null;
+		navSectionSignal.value = 'rooms';
+	} else if (roomMission) {
+		currentSpaceIdSignal.value = null;
+		currentSpaceViewModeSignal.value = 'overview';
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		currentRoomIdSignal.value = roomMission.roomId;
+		currentRoomGoalIdSignal.value = roomMission.goalId;
+		currentRoomTaskIdSignal.value = null;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'rooms';
 	} else if (roomTask) {
@@ -1106,6 +1228,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = roomTask.roomId;
 		currentRoomTaskIdSignal.value = roomTask.taskId;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
@@ -1118,6 +1241,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomIdSignal.value = roomSession.roomId;
 		currentRoomSessionIdSignal.value = roomSession.sessionId;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'rooms';
@@ -1129,6 +1253,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomIdSignal.value = roomId;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'rooms';
@@ -1145,6 +1270,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'chats';
@@ -1156,6 +1282,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'inbox';
@@ -1167,6 +1294,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
@@ -1178,6 +1306,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = sessionId;
 		if (!sessionId) {
@@ -1204,6 +1333,7 @@ export function initializeRouter(): string | null {
 	const initialSessionId = getSessionIdFromPath(initialPath);
 	const initialRoomId = getRoomIdFromPath(initialPath);
 	const initialRoomAgent = getRoomAgentFromPath(initialPath);
+	const initialRoomMission = getRoomMissionIdFromPath(initialPath);
 	const initialRoomSession = getRoomSessionIdFromPath(initialPath);
 	const initialRoomTask = getRoomTaskIdFromPath(initialPath);
 	const initialSpaceConfigure = getSpaceConfigureFromPath(initialPath);
@@ -1222,6 +1352,7 @@ export function initializeRouter(): string | null {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
@@ -1233,6 +1364,7 @@ export function initializeRouter(): string | null {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
@@ -1244,6 +1376,7 @@ export function initializeRouter(): string | null {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
@@ -1255,6 +1388,7 @@ export function initializeRouter(): string | null {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
@@ -1266,6 +1400,7 @@ export function initializeRouter(): string | null {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
@@ -1277,8 +1412,21 @@ export function initializeRouter(): string | null {
 		currentRoomIdSignal.value = initialRoomAgent;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = true;
 		currentRoomActiveTabSignal.value = 'chat';
+		currentSessionIdSignal.value = null;
+		navSectionSignal.value = 'rooms';
+	} else if (initialRoomMission) {
+		currentSpaceIdSignal.value = null;
+		currentSpaceViewModeSignal.value = 'overview';
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		currentRoomIdSignal.value = initialRoomMission.roomId;
+		currentRoomGoalIdSignal.value = initialRoomMission.goalId;
+		currentRoomTaskIdSignal.value = null;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'rooms';
 	} else if (initialRoomTask) {
@@ -1288,6 +1436,7 @@ export function initializeRouter(): string | null {
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = initialRoomTask.roomId;
 		currentRoomTaskIdSignal.value = initialRoomTask.taskId;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'rooms';
@@ -1299,6 +1448,7 @@ export function initializeRouter(): string | null {
 		currentRoomIdSignal.value = initialRoomSession.roomId;
 		currentRoomSessionIdSignal.value = initialRoomSession.sessionId;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'rooms';
 	} else if (initialRoomId) {
@@ -1309,6 +1459,7 @@ export function initializeRouter(): string | null {
 		currentRoomIdSignal.value = initialRoomId;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'rooms';
 	} else if (SESSIONS_ROUTE_PATTERN.test(initialPath)) {
@@ -1319,6 +1470,7 @@ export function initializeRouter(): string | null {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'chats';
@@ -1330,6 +1482,7 @@ export function initializeRouter(): string | null {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'inbox';
@@ -1341,6 +1494,7 @@ export function initializeRouter(): string | null {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
@@ -1352,6 +1506,7 @@ export function initializeRouter(): string | null {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		currentSessionIdSignal.value = initialSessionId;
 		if (initialSessionId) {

--- a/packages/web/src/lib/signals.ts
+++ b/packages/web/src/lib/signals.ts
@@ -17,6 +17,10 @@ export const currentRoomSessionIdSignal = signal<string | null>(null);
 // When set, shows the TaskView (Craft + Lead sessions) for the selected task
 export const currentRoomTaskIdSignal = signal<string | null>(null);
 
+// Shared signal for the current room's mission (goal) detail view
+// When set, shows the MissionDetail page for the selected mission
+export const currentRoomGoalIdSignal = signal<string | null>(null);
+
 // Shared signal for sidebar open/closed state on mobile
 export const sidebarOpenSignal = signal<boolean>(false);
 


### PR DESCRIPTION
Add `/room/:roomId/mission/:goalId` routing infrastructure for the Mission detail page feature.

- `currentRoomGoalIdSignal` added to `signals.ts`
- `ROOM_MISSION_ROUTE_PATTERN`, `getRoomMissionIdFromPath`, `createRoomMissionPath`, `navigateToRoomMission` added to `router.ts`
- `getRoomIdFromPath` extended to also match the mission route pattern
- `handlePopState` and `initializeRouter` updated to handle mission routes (checked before roomTask branch)
- `currentRoomGoalIdSignal.value = null` added alongside every `currentRoomTaskIdSignal.value = null` (~54 occurrences) to prevent stale state
- 24 new unit tests covering all new functions and signal clearing behavior