### PR TITLE
fix: navigate to Tasks tab in task-goal-indicator E2E tests

### DIFF
--- a/packages/e2e/tests/features/task-goal-indicator.e2e.ts
+++ b/packages/e2e/tests/features/task-goal-indicator.e2e.ts
@@ -122,7 +122,9 @@ test.describe('Task Goal Indicator — Task List', () => {
 		await waitForWebSocketConnected(page);
 
 		// Switch to Tasks tab (default is Overview)
-		await page.getByRole('button', { name: 'Tasks' }).click();
+		const tasksTab = page.getByRole('button', { name: 'Tasks' });
+		await tasksTab.click();
+		await expect(tasksTab).toHaveClass(/border-blue-400/);
 
 		// Should see the goal badge with mission title
 		const badge = page.locator(`[data-testid="task-goal-badge-${result.taskId}"]`);
@@ -138,7 +140,9 @@ test.describe('Task Goal Indicator — Task List', () => {
 		await waitForWebSocketConnected(page);
 
 		// Switch to Tasks tab (default is Overview)
-		await page.getByRole('button', { name: 'Tasks' }).click();
+		const tasksTab = page.getByRole('button', { name: 'Tasks' });
+		await tasksTab.click();
+		await expect(tasksTab).toHaveClass(/border-blue-400/);
 
 		// Ensure the task is visible first
 		await expect(page.locator('h4:has-text("Unlinked Task")')).toBeVisible({ timeout: 10000 });
@@ -156,7 +160,9 @@ test.describe('Task Goal Indicator — Task List', () => {
 		await waitForWebSocketConnected(page);
 
 		// Switch to Tasks tab (default is Overview)
-		await page.getByRole('button', { name: 'Tasks' }).click();
+		const tasksTab = page.getByRole('button', { name: 'Tasks' });
+		await tasksTab.click();
+		await expect(tasksTab).toHaveClass(/border-blue-400/);
 
 		// Wait for and click the goal badge
 		const badge = page.locator(`[data-testid="task-goal-badge-${result.taskId}"]`);

--- a/packages/e2e/tests/features/task-goal-indicator.e2e.ts
+++ b/packages/e2e/tests/features/task-goal-indicator.e2e.ts
@@ -121,6 +121,9 @@ test.describe('Task Goal Indicator — Task List', () => {
 		await page.goto(`/room/${roomId}`);
 		await waitForWebSocketConnected(page);
 
+		// Switch to Tasks tab (default is Overview)
+		await page.getByRole('button', { name: 'Tasks' }).click();
+
 		// Should see the goal badge with mission title
 		const badge = page.locator(`[data-testid="task-goal-badge-${result.taskId}"]`);
 		await expect(badge).toBeVisible({ timeout: 10000 });
@@ -133,6 +136,9 @@ test.describe('Task Goal Indicator — Task List', () => {
 
 		await page.goto(`/room/${roomId}`);
 		await waitForWebSocketConnected(page);
+
+		// Switch to Tasks tab (default is Overview)
+		await page.getByRole('button', { name: 'Tasks' }).click();
 
 		// Ensure the task is visible first
 		await expect(page.locator('h4:has-text("Unlinked Task")')).toBeVisible({ timeout: 10000 });
@@ -148,6 +154,9 @@ test.describe('Task Goal Indicator — Task List', () => {
 
 		await page.goto(`/room/${roomId}`);
 		await waitForWebSocketConnected(page);
+
+		// Switch to Tasks tab (default is Overview)
+		await page.getByRole('button', { name: 'Tasks' }).click();
 
 		// Wait for and click the goal badge
 		const badge = page.locator(`[data-testid="task-goal-badge-${result.taskId}"]`);


### PR DESCRIPTION
## Summary
- Task-goal-indicator E2E tests failed because they navigated to `/room/:roomId` which defaults to the Overview tab, but task cards with goal badges only render on the Tasks tab
- Added `page.getByRole('button', { name: 'Tasks' }).click()` after room navigation in all three Task List tests

## Test plan
- [x] All 6 tests in `task-goal-indicator.e2e.ts` pass locally