### PR TITLE
fix: navigate to Done sub-tab in task-lifecycle E2E test

### DIFF
--- a/packages/e2e/tests/features/task-lifecycle.e2e.ts
+++ b/packages/e2e/tests/features/task-lifecycle.e2e.ts
@@ -144,9 +144,15 @@ test.describe('Task Lifecycle — Reactivate', () => {
 		// Click the Done stat card to switch from overview to the Tasks room-level tab.
 		// Note: the stat card only switches the room tab — it does NOT set the internal
 		// Done sub-filter within RoomTasks, so we must click the Done sub-tab separately.
-		await page.getByRole('button', { name: /Done/ }).click();
+		// Scope the locator to the stats grid (grid-cols-3) which only exists in the
+		// overview dashboard, so waitFor('detached') doesn't match the RoomTasks sub-tab.
+		const doneStatCard = page.locator('.grid-cols-3').getByRole('button', { name: /Done/ });
+		await doneStatCard.click();
 
-		// Now click the Done sub-tab within RoomTasks to filter for completed tasks
+		// Wait for the overview to unmount (stat card detaches) before clicking the
+		// Done sub-tab within RoomTasks, to avoid a race where both buttons exist
+		// momentarily and the second click hits the stat card again (a no-op).
+		await doneStatCard.waitFor({ state: 'detached', timeout: 5000 });
 		await page.getByRole('button', { name: /Done/ }).click();
 
 		// Wait for the task to appear in the list

--- a/packages/e2e/tests/features/task-lifecycle.e2e.ts
+++ b/packages/e2e/tests/features/task-lifecycle.e2e.ts
@@ -132,13 +132,21 @@ test.describe('Task Lifecycle — Reactivate', () => {
 	test('reactivates completed task via Reactivate button in Done tab list', async ({ page }) => {
 		({ roomId, taskId } = await createRoomAndTaskInStatus(page, 'completed'));
 
+		// Clear persisted task filter tab so RoomTasks defaults to "Active"
+		await page.evaluate(() => localStorage.removeItem('neokai:room:taskFilterTab'));
+
 		// Navigate to the room dashboard (not individual task)
 		await page.goto(`/room/${roomId}`);
 		await expect(page.locator('text=E2E Lifecycle Test Room').first()).toBeVisible({
 			timeout: 10000,
 		});
 
-		// Click the Done tab to see completed tasks
+		// Click the Done stat card to switch from overview to the Tasks room-level tab.
+		// Note: the stat card only switches the room tab — it does NOT set the internal
+		// Done sub-filter within RoomTasks, so we must click the Done sub-tab separately.
+		await page.getByRole('button', { name: /Done/ }).click();
+
+		// Now click the Done sub-tab within RoomTasks to filter for completed tasks
 		await page.getByRole('button', { name: /Done/ }).click();
 
 		// Wait for the task to appear in the list
@@ -153,7 +161,7 @@ test.describe('Task Lifecycle — Reactivate', () => {
 		await expect(reactivateBtn).toBeVisible({ timeout: 5000 });
 		await reactivateBtn.click();
 
-		// Task should move from Done tab — click Active tab to confirm it's there
+		// Task should move from Done tab — click Active sub-tab to confirm it's there
 		await page.getByRole('button', { name: /Active/ }).click();
 		await expect(
 			page.getByRole('heading', { name: 'E2E Lifecycle Test Task' }).first()


### PR DESCRIPTION
## Summary
- Fix the "reactivates completed task via Reactivate button in Done tab list" E2E test that was failing because the Done stat card only switches to the Tasks room-level tab but does not set the internal Done sub-filter within RoomTasks
- Add localStorage cleanup for `neokai:room:taskFilterTab` to ensure consistent initial state
- Harden the two-click navigation with `waitFor({ state: 'detached' })` scoped to the overview grid to prevent a race condition (P1 review feedback)

## CI check note
The `cross-provider-1` and `cross-provider-2` CI checks are **pre-existing failures on `dev`**, unrelated to this PR. This PR only touches `packages/e2e/tests/features/task-lifecycle.e2e.ts`. The same cross-provider failures appear on the latest `dev` commit (which only changed a docs file). The failures originate in `packages/daemon/tests/helpers/daemon-actions.ts#L110` — daemon test infrastructure not touched here.

## Test plan
- [x] `make run-e2e TEST=tests/features/task-lifecycle.e2e.ts` — target test passes (9/10, 1 pre-existing failure in a different test unrelated to this change)
- [x] CI E2E No-LLM (features-task-lifecycle) — target test passes in CI