### PR TITLE
fix(e2e): update gate badge script icon expectation from ⚡ to S

### DIFF
--- a/packages/e2e/tests/features/space-gate-custom-badges.e2e.ts
+++ b/packages/e2e/tests/features/space-gate-custom-badges.e2e.ts
@@ -298,9 +298,9 @@ test.describe('Gate Custom Badges', () => {
 		// Badge should show heuristic "Check" label
 		await expect(gateBadge).toContainText('Check');
 
-		// ── Step 7: Verify script icon ⚡ appears in the badge ──────────────
-		// The script icon is a separate <text> element containing "⚡"
-		await expect(gateBadge).toContainText('\u26A1');
+		// ── Step 7: Verify script icon "S" appears in the badge ─────────────
+		// The script icon is a separate <text> element containing "S"
+		await expect(gateBadge).toContainText('S');
 
 		// ── Step 8: Verify Lint Check preset works ──────────────────────────
 		await gatePanel.getByTestId('gate-editor-preset-lint').click();


### PR DESCRIPTION
## Summary
- Update `space-gate-custom-badges.e2e.ts` to expect `'S'` instead of `'\u26A1'` for the gate badge script icon
- The EdgeRenderer was refactored to render `"S"` instead of `"⚡"`, and the unit test was updated but the E2E test was missed

## Test plan
- [ ] Trigger E2E No-LLM run for `features-space-gate-custom-badges` to verify the fix