### PR TITLE
fix: navigate to Tasks tab before asserting short ID badge

### DIFF
--- a/packages/e2e/tests/features/short-id-display.e2e.ts
+++ b/packages/e2e/tests/features/short-id-display.e2e.ts
@@ -82,6 +82,10 @@ test.describe('Short ID Display and Copy', () => {
 			timeout: 10000,
 		});
 
+		// Navigate to the Tasks tab — ShortIdBadge is only rendered in RoomTasks,
+		// not in the overview dashboard's RecentActivityItem.
+		await page.getByRole('button', { name: 'Tasks' }).click();
+
 		// The short ID badge should be visible in the task card
 		const badge = page.locator(`[data-testid="short-id-badge-${shortId}"]`);
 		await expect(badge).toBeVisible({ timeout: 10000 });
@@ -104,6 +108,9 @@ test.describe('Short ID Display and Copy', () => {
 		await expect(page.locator('text=E2E Short ID Display Test Room').first()).toBeVisible({
 			timeout: 10000,
 		});
+
+		// Navigate to the Tasks tab — ShortIdBadge is only rendered in RoomTasks
+		await page.getByRole('button', { name: 'Tasks' }).click();
 
 		// Wait for the short ID badge to appear
 		const badge = page.locator(`[data-testid="short-id-badge-${shortId}"]`);


### PR DESCRIPTION
## Summary
- The `short-id-display.e2e.ts` tests failed because they navigated to `/room/{roomId}` (which defaults to the Overview tab) and immediately looked for the `ShortIdBadge` element. The badge is only rendered inside `RoomTasks`, which is mounted when the "Tasks" tab is active — the Overview dashboard's `RecentActivityItem` does not render it.
- Added `page.getByRole('button', { name: 'Tasks' }).click()` before badge assertions in both affected tests.

## Test plan
- [x] All 3 tests in `short-id-display.e2e.ts` pass locally (`make run-e2e`)
- [ ] Trigger E2E CI to confirm