### PR TITLE
fix: resolve mission-terminology E2E test failures

### DIFF
--- a/packages/e2e/tests/features/livequery-task-goal-updates.e2e.ts
+++ b/packages/e2e/tests/features/livequery-task-goal-updates.e2e.ts
@@ -89,6 +89,7 @@ test.describe('LiveQuery — task created via RPC appears in room UI without pag
 
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
+		await waitForWebSocketConnected(page);
 		// Clear persisted tab selection so tasks (pending status → Active tab) are always visible
 		await page.evaluate(() => localStorage.removeItem('neokai:room:taskFilterTab'));
 		await page

--- a/packages/e2e/tests/features/mission-creation.e2e.ts
+++ b/packages/e2e/tests/features/mission-creation.e2e.ts
@@ -50,6 +50,7 @@ test.describe('Mission Creation', () => {
 
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
+		await waitForWebSocketConnected(page);
 		roomId = await createRoom(page, 'E2E Mission Creation Test Room');
 	});
 

--- a/packages/e2e/tests/features/mission-detail.e2e.ts
+++ b/packages/e2e/tests/features/mission-detail.e2e.ts
@@ -93,6 +93,7 @@ test.describe('Mission Detail Views', () => {
 
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
+		await waitForWebSocketConnected(page);
 		roomId = await createRoom(page, 'E2E Mission Detail Test Room');
 	});
 

--- a/packages/e2e/tests/features/mission-terminology.e2e.ts
+++ b/packages/e2e/tests/features/mission-terminology.e2e.ts
@@ -4,7 +4,7 @@
  * Verifies that the UI displays "Mission" terminology (not "Goal") after the
  * Task 5 copy rename. Tests cover:
  * - "Missions" tab label in room page
- * - Empty state heading "No missions yet"
+ * - Empty state text "No missions yet"
  * - Empty state call-to-action "Create Mission" button
  * - No residual "Goal" text visible to users
  *

--- a/packages/e2e/tests/features/mission-terminology.e2e.ts
+++ b/packages/e2e/tests/features/mission-terminology.e2e.ts
@@ -25,6 +25,7 @@ test.describe('Mission Terminology', () => {
 
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
+		await waitForWebSocketConnected(page);
 		roomId = await createRoom(page, 'E2E Mission Terminology Test Room');
 	});
 
@@ -70,8 +71,8 @@ test.describe('Mission Terminology', () => {
 		await expect(missionsTab).toBeVisible({ timeout: 10000 });
 		await missionsTab.click();
 
-		// Empty state heading should read "No missions yet"
-		await expect(page.locator('h3:has-text("No missions yet")')).toBeVisible({ timeout: 5000 });
+		// Empty state should read "No missions yet"
+		await expect(page.locator('p:has-text("No missions yet")')).toBeVisible({ timeout: 5000 });
 	});
 
 	test('should show "Create Mission" button in empty state', async ({ page }) => {

--- a/packages/e2e/tests/features/short-id-display.e2e.ts
+++ b/packages/e2e/tests/features/short-id-display.e2e.ts
@@ -56,6 +56,7 @@ test.describe('Short ID Display and Copy', () => {
 
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
+		await waitForWebSocketConnected(page);
 		// Clear persisted tab selection so tasks (pending status → Active tab) are always visible
 		await page.evaluate(() => localStorage.removeItem('neokai:room:taskFilterTab'));
 		await page


### PR DESCRIPTION
## Summary
- Add `waitForWebSocketConnected()` before `createRoom` in `beforeEach` to prevent "Not connected to transport" race condition that caused cascade failures
- Fix wrong CSS selector: GoalsEditor renders "No missions yet" as `<p>` not `<h3>`

## Test plan
- [x] `make run-e2e TEST=tests/features/mission-terminology.e2e.ts` — all 5 tests pass locally
- [ ] CI E2E No-LLM (features-mission-terminology) passes