### PR TITLE
fix: apply non-status fields during spaceTask.update status transitions

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -153,6 +153,15 @@ export function setupSpaceTaskHandlers(
 				task = await taskManager.setTaskStatus(taskId, updateParams.status, {
 					result: updateParams.result ?? undefined,
 				});
+
+				// When a status transition is combined with other field updates
+				// (e.g. taskAgentSessionId), those fields are silently dropped by
+				// setTaskStatus. Apply them in a follow-up updateTask call so
+				// callers can atomically set status + metadata in one RPC.
+				const { status: _s, result: _r, ...otherFields } = updateParams;
+				if (Object.keys(otherFields).length > 0) {
+					task = await taskManager.updateTask(taskId, otherFields);
+				}
 			} else {
 				// Status is the same — treat as a regular field update.
 				// updateParams still contains the unchanged status field; SpaceTaskManager.updateTask

--- a/packages/daemon/tests/unit/rpc-handlers/space-task-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-task-handlers.test.ts
@@ -524,6 +524,42 @@ describe('space-task-handlers', () => {
 			});
 		});
 
+		it('applies non-status fields (e.g. taskAgentSessionId) after status transition', async () => {
+			// setTaskStatus handles the status transition but does not know about
+			// taskAgentSessionId. The handler must follow up with updateTask to
+			// apply the remaining fields.
+			(taskManager.setTaskStatus as ReturnType<typeof mock>).mockResolvedValue({
+				...mockTask,
+				status: 'in_progress' as const,
+			});
+			(taskManager.updateTask as ReturnType<typeof mock>).mockImplementation(
+				async (_taskId: string, params: Record<string, unknown>) => ({
+					...mockTask,
+					status: 'in_progress' as const,
+					...params,
+				})
+			);
+
+			const result = await call('spaceTask.update', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				status: 'in_progress',
+				taskAgentSessionId: 'session-abc',
+			});
+
+			// setTaskStatus was called for the transition
+			expect(taskManager.setTaskStatus).toHaveBeenCalledWith('task-1', 'in_progress', {
+				result: undefined,
+			});
+			// updateTask was called with the non-status fields (no status, no result)
+			expect(taskManager.updateTask).toHaveBeenCalledWith('task-1', {
+				taskAgentSessionId: 'session-abc',
+			});
+			// Final result has both fields
+			expect((result as SpaceTask).status).toBe('in_progress');
+			expect((result as SpaceTask).taskAgentSessionId).toBe('session-abc');
+		});
+
 		it('throws when spaceId is missing', async () => {
 			await expect(call('spaceTask.update', { taskId: 'task-1', title: 'X' })).rejects.toThrow(
 				'spaceId is required'


### PR DESCRIPTION
## Summary
- Fix `spaceTask.update` RPC handler to apply non-status fields (e.g. `taskAgentSessionId`) when combined with a status transition
- Previously, `setTaskStatus` silently dropped fields like `taskAgentSessionId` because it only handles status + result
- Add unit test verifying the combined update path

## Root Cause
When the E2E test calls `spaceTask.update` with `{ status: 'in_progress', taskAgentSessionId: sessionId }`, the handler routed to `setTaskStatus` for the status change but never applied `taskAgentSessionId`. The inline composer in `SpaceTaskPane` requires `taskAgentSessionId` to be set (`showInlineComposer = !!agentSessionId && !isTerminalTask`), so the composer never rendered.

## Test plan
- [x] Unit test: `applies non-status fields (e.g. taskAgentSessionId) after status transition`
- [ ] E2E: trigger `features-space-task-messaging` via workflow_dispatch