### PR TITLE
fix: use ⚡ script icon in gate badge SVG

### DIFF
--- a/packages/web/src/components/space/visual-editor/EdgeRenderer.tsx
+++ b/packages/web/src/components/space/visual-editor/EdgeRenderer.tsx
@@ -962,7 +962,7 @@ export function EdgeRenderer({
 										fill={isSelected ? 'white' : gateColor}
 										opacity={0.7}
 									>
-										S
+										{'\u26A1'}
 									</text>
 								)}
 							</g>

--- a/packages/web/src/components/space/visual-editor/__tests__/EdgeRenderer.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/EdgeRenderer.test.tsx
@@ -978,7 +978,7 @@ describe('EdgeRenderer — gate badge custom label/color/hasScript', () => {
 		expect(arrow?.getAttribute('fill')).toBe('white');
 	});
 
-	it('renders script indicator (S) when hasScript is true', () => {
+	it('renders script indicator (\u26A1) when hasScript is true', () => {
 		const channels: ResolvedWorkflowChannel[] = [
 			{
 				direction: 'one-way' as const,
@@ -995,7 +995,7 @@ describe('EdgeRenderer — gate badge custom label/color/hasScript', () => {
 		// Should have two text elements: label + script icon
 		expect(badgeTexts).toHaveLength(2);
 		const scriptIconText = badgeTexts[1];
-		expect(scriptIconText.textContent).toBe('S');
+		expect(scriptIconText.textContent).toBe('\u26A1');
 		expect(scriptIconText.getAttribute('opacity')).toBe('0.7');
 	});
 
@@ -1142,7 +1142,7 @@ describe('EdgeRenderer — gate badge custom label/color/hasScript', () => {
 		);
 		// Should have label + script icon
 		expect(badgeTexts).toHaveLength(2);
-		expect(badgeTexts[1].textContent).toBe('S');
+		expect(badgeTexts[1].textContent).toBe('\u26A1');
 	});
 
 	it('uses reverseGateLabel when only reverse gate is set on bidirectional', () => {


### PR DESCRIPTION
## Summary
- The `EdgeRenderer` gate badge SVG used the letter `S` as the script indicator, while `ChannelEdgeConfigPanel` used `⚡` (U+26A1). This inconsistency caused the E2E test `space-gate-script-check` to fail — it expected `toContainText('⚡')` but the badge rendered `CheckS`.
- Updated `EdgeRenderer.tsx` to render `⚡` instead of `S` in the script icon `<text>` element.
- Updated two corresponding EdgeRenderer unit tests.

## Test plan
- [x] All 99 EdgeRenderer unit tests pass
- [x] All 6677 web tests pass
- [x] Typecheck passes
- [ ] E2E `features-space-gate-script-check` passes (trigger CI)
- [ ] E2E `features-space-gate-custom-badges` passes (same ⚡ assertion)