### PR TITLE
fix(e2e): scope textarea/send-button to visible elements in task-message-streaming

### DIFF
--- a/packages/e2e/tests/features/task-lifecycle.e2e.ts
+++ b/packages/e2e/tests/features/task-lifecycle.e2e.ts
@@ -176,7 +176,7 @@ test.describe('Task Lifecycle — Reactivate', () => {
 		});
 
 		// The message input should be enabled — completed tasks can send messages to reactivate
-		const textarea = page.locator('textarea').first();
+		const textarea = page.locator('textarea:visible').first();
 		await expect(textarea).toBeEnabled({ timeout: 5000 });
 
 		// Placeholder should mention reactivation

--- a/packages/e2e/tests/features/task-message-streaming.e2e.ts
+++ b/packages/e2e/tests/features/task-message-streaming.e2e.ts
@@ -279,8 +279,11 @@ test.describe('no loading flash when user sends a message (regression)', () => {
 		await expect(page.locator('text=Pre-existing message alpha')).toBeVisible({ timeout: 10000 });
 		await expect(page.locator('text=Pre-existing message beta')).toBeVisible({ timeout: 10000 });
 
-		// Type a message in the human input area (no data-testid on <textarea> in prod)
-		const textarea = page.locator('textarea').first();
+		// Type a message in the task view's human input area.
+		// Use :visible to avoid selecting the hidden ChatContainer textarea
+		// (Room.tsx keeps ChatContainer always-mounted but hidden via CSS for state preservation).
+		// Works for both V1 and V2 task views.
+		const textarea = page.locator('textarea:visible').first();
 		await textarea.fill('Hello, please continue working');
 
 		// Pre-existing messages must still be visible while typing (no wipe on input)
@@ -289,7 +292,7 @@ test.describe('no loading flash when user sends a message (regression)', () => {
 
 		// Click send — the RPC will fail (no real session), but the UI must NOT
 		// clear the conversation pane or flash a loading state at any point
-		await page.locator('[data-testid="send-button"]').click();
+		await page.locator('[data-testid="send-button"]:visible').click();
 
 		// After the send attempt, pre-existing messages must still be visible —
 		// this verifies the conversationKey is NOT bumped on message send


### PR DESCRIPTION
## Summary
- Fix 60s timeout in `task-message-streaming.e2e.ts` regression test caused by `page.locator('textarea').first()` selecting the hidden ChatContainer textarea instead of the task view's visible one
- Room.tsx keeps ChatContainer always-mounted but hidden via CSS (`display: none`) for state preservation across tab switches, so a generic `textarea` selector picks up the wrong element
- Use `:visible` pseudo-class to target only visible textareas and send buttons, working for both V1 and V2 task views

## Test plan
- [x] All 3 tests in `task-message-streaming.e2e.ts` pass locally (15.9s)
- [ ] Trigger E2E No-LLM CI job to verify in CI