### PR TITLE
fix: update canvas E2E tests to use task pane + canvas toggle

### DIFF
--- a/packages/e2e/tests/features/reviewer-feedback-loop.e2e.ts
+++ b/packages/e2e/tests/features/reviewer-feedback-loop.e2e.ts
@@ -24,10 +24,12 @@
  *
  * Isolation:
  *   - test.describe.serial forces sequential execution to avoid workspace path conflicts
+ *   - createUniqueSpaceDir() gives each test run its own workspace subdirectory
  */
 
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+import { createUniqueSpaceDir } from '../helpers/space-helpers';
 
 const DESKTOP_VIEWPORT = { width: 1440, height: 900 };
 
@@ -36,6 +38,7 @@ const DESKTOP_VIEWPORT = { width: 1440, height: 900 };
 interface SpaceRunIds {
 	spaceId: string;
 	runId: string;
+	taskId: string;
 }
 
 // ─── Infrastructure helpers (RPC — beforeEach / afterEach only) ────────────────
@@ -45,26 +48,14 @@ async function createSpaceWithRun(
 ): Promise<SpaceRunIds> {
 	await waitForWebSocketConnected(page);
 	const workspaceRoot = await getWorkspaceRoot(page);
+	// Use a unique subdirectory to avoid conflicts with other parallel tests
+	// (workspace_path has a UNIQUE constraint in the DB).
+	const wsPath = createUniqueSpaceDir(workspaceRoot, 'reviewer-loop');
 
 	return page.evaluate(
 		async ({ wsPath }) => {
 			const hub = window.__messageHub || window.appState?.messageHub;
 			if (!hub?.request) throw new Error('MessageHub not available');
-
-			// Clean up any leftover space at this workspace path (including archived).
-			const norm = (p: string) => p.replace(/^\/private/, '');
-			try {
-				const list = (await hub.request('space.list', { includeArchived: true })) as Array<{
-					id: string;
-					workspacePath: string;
-				}>;
-				const matches = list.filter((s) => norm(s.workspacePath) === norm(wsPath));
-				for (const s of matches) {
-					await hub.request('space.delete', { id: s.id });
-				}
-			} catch {
-				// Ignore cleanup errors
-			}
 
 			const spaceRes = (await hub.request('space.create', {
 				name: `E2E Reviewer Loop ${Date.now()}`,
@@ -79,24 +70,55 @@ async function createSpaceWithRun(
 			})) as { run: { id: string } };
 			const runId = runRes.run.id;
 
-			return { spaceId, runId };
+			// Poll for the task created by the workflow run
+			const startTime = Date.now();
+			const maxWait = 20000;
+			let taskId = '';
+			while (Date.now() - startTime < maxWait) {
+				const tasks = (await hub.request('spaceTask.list', { spaceId })) as Array<{
+					id: string;
+					workflowRunId?: string;
+				}>;
+				const match = tasks.find((t) => t.workflowRunId === runId);
+				if (match) {
+					taskId = match.id;
+					break;
+				}
+				await new Promise((r) => setTimeout(r, 250));
+			}
+			if (!taskId) throw new Error(`No task found for run ${runId} after ${maxWait}ms`);
+
+			return { spaceId, runId, taskId };
 		},
-		{ wsPath: workspaceRoot }
+		{ wsPath }
 	);
 }
 
 /**
- * Navigate to a space route and wait for WebSocket reconnection before assertions.
+ * Navigate to a task pane, wait for WebSocket reconnection, then click the
+ * Canvas toggle to reveal the workflow canvas.
  *
  * page.goto() causes a full reload, which can briefly disconnect MessageHub transport.
  * Waiting for reconnection prevents flaky follow-up assertions that depend on live data.
  */
-async function gotoSpaceAndWait(
+async function openCanvasAndWait(
 	page: Parameters<typeof waitForWebSocketConnected>[0],
-	spaceId: string
+	spaceId: string,
+	taskId: string
 ): Promise<void> {
-	await page.goto(`/space/${spaceId}`);
+	await page.goto(`/space/${spaceId}/task/${taskId}`);
 	await waitForWebSocketConnected(page);
+
+	// Wait for the Canvas toggle to appear (confirms task data loaded with workflowRunId)
+	await expect(page.getByTestId('canvas-toggle')).toBeVisible({ timeout: 30000 });
+
+	// Click Canvas toggle to reveal the workflow canvas
+	await page.getByTestId('canvas-toggle').click();
+
+	// Wait for canvas SVG to render inside the canvas-view container
+	await expect(page.getByTestId('canvas-view').getByTestId('workflow-canvas-svg')).toBeVisible({
+		timeout: 30000,
+	});
 }
 
 async function writeGateData(
@@ -218,7 +240,7 @@ function gateIcon(
 	status: 'open' | 'blocked' | 'waiting_human'
 ) {
 	return page
-		.getByTestId('canvas-panel')
+		.getByTestId('canvas-view')
 		.locator(`[data-testid="gate-icon-${status}"][data-gate-id="${gateId}"]`);
 }
 
@@ -229,7 +251,7 @@ function voteBadge(
 	text: string
 ) {
 	return page
-		.getByTestId('canvas-panel')
+		.getByTestId('canvas-view')
 		.locator(`[data-gate-id="${gateId}"] [data-testid="gate-vote-count"]:has-text("${text}")`)
 		.first();
 }
@@ -245,12 +267,14 @@ test.describe
 		test.describe('reviewer rejection state', () => {
 			let spaceId = '';
 			let runId = '';
+			let taskId = '';
 
 			test.beforeEach(async ({ page }) => {
 				await page.goto('/');
 				const ids = await createSpaceWithRun(page);
 				spaceId = ids.spaceId;
 				runId = ids.runId;
+				taskId = ids.taskId;
 
 				// Write code-pr-gate to unblock reviewers, then write a rejection vote
 				await writeGateData(page, runId, 'code-pr-gate', {
@@ -262,18 +286,21 @@ test.describe
 			});
 
 			test.afterEach(async ({ page }) => {
+				try {
+					await page.goto('/');
+					await waitForWebSocketConnected(page, 5000);
+				} catch {
+					// If navigation fails, cleanup is best-effort
+				}
 				if (runId) await cancelRun(page, runId);
 				if (spaceId) await deleteSpace(page, spaceId);
 				spaceId = '';
 				runId = '';
+				taskId = '';
 			});
 
 			test('review-reject-gate shows open (green) when one reviewer rejects', async ({ page }) => {
-				await gotoSpaceAndWait(page, spaceId);
-
-				await expect(
-					page.getByTestId('canvas-panel').getByTestId('workflow-canvas-svg')
-				).toBeVisible({ timeout: 30000 });
+				await openCanvasAndWait(page, spaceId, taskId);
 
 				// review-reject-gate condition: count 'rejected' votes >= 1
 				// With 1 rejection written, gate evaluates to open → green checkmark
@@ -285,11 +312,7 @@ test.describe
 			test('review-reject-gate vote count badge shows 1/1 when one reviewer rejects', async ({
 				page,
 			}) => {
-				await gotoSpaceAndWait(page, spaceId);
-
-				await expect(
-					page.getByTestId('canvas-panel').getByTestId('workflow-canvas-svg')
-				).toBeVisible({ timeout: 30000 });
+				await openCanvasAndWait(page, spaceId, taskId);
 
 				// The review-reject-gate (min: 1) should show "1/1" vote count badge
 				await expect(voteBadge(page, 'review-reject-gate', '1/1')).toBeVisible({ timeout: 30000 });
@@ -300,6 +323,7 @@ test.describe
 		test.describe('coder re-activation state', () => {
 			let spaceId = '';
 			let runId = '';
+			let taskId = '';
 			let codingNodeId = '';
 
 			test.beforeEach(async ({ page }) => {
@@ -307,6 +331,7 @@ test.describe
 				const ids = await createSpaceWithRun(page);
 				spaceId = ids.spaceId;
 				runId = ids.runId;
+				taskId = ids.taskId;
 
 				// Get the Coding node UUID so we can create a node execution for it
 				codingNodeId = await getCodingNodeId(page, spaceId, runId);
@@ -316,22 +341,25 @@ test.describe
 			});
 
 			test.afterEach(async ({ page }) => {
+				try {
+					await page.goto('/');
+					await waitForWebSocketConnected(page, 5000);
+				} catch {
+					// If navigation fails, cleanup is best-effort
+				}
 				if (runId) await cancelRun(page, runId);
 				if (spaceId) await deleteSpace(page, spaceId);
 				spaceId = '';
 				runId = '';
+				taskId = '';
 				codingNodeId = '';
 			});
 
 			test('Coding node shows active (blue pulsing) after re-activation', async ({ page }) => {
-				await gotoSpaceAndWait(page, spaceId);
-
-				await expect(
-					page.getByTestId('canvas-panel').getByTestId('workflow-canvas-svg')
-				).toBeVisible({ timeout: 30000 });
+				await openCanvasAndWait(page, spaceId, taskId);
 
 				// The Coding node with in_progress execution renders the g element with animate-pulse class
-				const codingNodeEl = page.getByTestId('canvas-panel').getByTestId(`node-${codingNodeId}`);
+				const codingNodeEl = page.getByTestId('canvas-view').getByTestId(`node-${codingNodeId}`);
 				await expect(codingNodeEl).toBeVisible({ timeout: 30000 });
 
 				// Active nodes have animate-pulse CSS class.
@@ -344,12 +372,14 @@ test.describe
 		test.describe('partial review votes (2 of 3 approved)', () => {
 			let spaceId = '';
 			let runId = '';
+			let taskId = '';
 
 			test.beforeEach(async ({ page }) => {
 				await page.goto('/');
 				const ids = await createSpaceWithRun(page);
 				spaceId = ids.spaceId;
 				runId = ids.runId;
+				taskId = ids.taskId;
 
 				await writeGateData(page, runId, 'code-pr-gate', {
 					pr_url: 'https://github.com/test/repo/pull/1',
@@ -361,18 +391,21 @@ test.describe
 			});
 
 			test.afterEach(async ({ page }) => {
+				try {
+					await page.goto('/');
+					await waitForWebSocketConnected(page, 5000);
+				} catch {
+					// If navigation fails, cleanup is best-effort
+				}
 				if (runId) await cancelRun(page, runId);
 				if (spaceId) await deleteSpace(page, spaceId);
 				spaceId = '';
 				runId = '';
+				taskId = '';
 			});
 
 			test('review-votes-gate remains blocked (2/3 not enough to open)', async ({ page }) => {
-				await gotoSpaceAndWait(page, spaceId);
-
-				await expect(
-					page.getByTestId('canvas-panel').getByTestId('workflow-canvas-svg')
-				).toBeVisible({ timeout: 30000 });
+				await openCanvasAndWait(page, spaceId, taskId);
 
 				// 2 approvals < 3 required → review-votes-gate stays blocked (gray lock)
 				await expect(gateIcon(page, 'review-votes-gate', 'blocked')).toBeVisible({
@@ -381,11 +414,7 @@ test.describe
 			});
 
 			test('review-votes-gate vote count badge shows 2/3', async ({ page }) => {
-				await gotoSpaceAndWait(page, spaceId);
-
-				await expect(
-					page.getByTestId('canvas-panel').getByTestId('workflow-canvas-svg')
-				).toBeVisible({ timeout: 30000 });
+				await openCanvasAndWait(page, spaceId, taskId);
 
 				// review-votes-gate has 3 channels sharing it (Reviewer 1/2/3 → QA)
 				// Each shows the same "2/3" badge — expect at least one
@@ -397,12 +426,14 @@ test.describe
 		test.describe('all reviewers approved (3 of 3)', () => {
 			let spaceId = '';
 			let runId = '';
+			let taskId = '';
 
 			test.beforeEach(async ({ page }) => {
 				await page.goto('/');
 				const ids = await createSpaceWithRun(page);
 				spaceId = ids.spaceId;
 				runId = ids.runId;
+				taskId = ids.taskId;
 
 				await writeGateData(page, runId, 'code-pr-gate', {
 					pr_url: 'https://github.com/test/repo/pull/1',
@@ -417,31 +448,30 @@ test.describe
 			});
 
 			test.afterEach(async ({ page }) => {
+				try {
+					await page.goto('/');
+					await waitForWebSocketConnected(page, 5000);
+				} catch {
+					// If navigation fails, cleanup is best-effort
+				}
 				if (runId) await cancelRun(page, runId);
 				if (spaceId) await deleteSpace(page, spaceId);
 				spaceId = '';
 				runId = '';
+				taskId = '';
 			});
 
 			test('review-votes-gate shows open (green) when all 3 reviewers approve', async ({
 				page,
 			}) => {
-				await gotoSpaceAndWait(page, spaceId);
-
-				await expect(
-					page.getByTestId('canvas-panel').getByTestId('workflow-canvas-svg')
-				).toBeVisible({ timeout: 30000 });
+				await openCanvasAndWait(page, spaceId, taskId);
 
 				// 3 approvals >= 3 required → review-votes-gate opens
 				await expect(gateIcon(page, 'review-votes-gate', 'open')).toBeVisible({ timeout: 30000 });
 			});
 
 			test('review-votes-gate vote count badge shows 3/3', async ({ page }) => {
-				await gotoSpaceAndWait(page, spaceId);
-
-				await expect(
-					page.getByTestId('canvas-panel').getByTestId('workflow-canvas-svg')
-				).toBeVisible({ timeout: 30000 });
+				await openCanvasAndWait(page, spaceId, taskId);
 
 				await expect(voteBadge(page, 'review-votes-gate', '3/3')).toBeVisible({ timeout: 30000 });
 			});
@@ -451,12 +481,14 @@ test.describe
 		test.describe('QA passes → completion state', () => {
 			let spaceId = '';
 			let runId = '';
+			let taskId = '';
 
 			test.beforeEach(async ({ page }) => {
 				await page.goto('/');
 				const ids = await createSpaceWithRun(page);
 				spaceId = ids.spaceId;
 				runId = ids.runId;
+				taskId = ids.taskId;
 
 				// Write all gates to simulate a fully approved + QA-passed state
 				await writeGateData(page, runId, 'code-pr-gate', {
@@ -473,20 +505,23 @@ test.describe
 			});
 
 			test.afterEach(async ({ page }) => {
+				try {
+					await page.goto('/');
+					await waitForWebSocketConnected(page, 5000);
+				} catch {
+					// If navigation fails, cleanup is best-effort
+				}
 				if (runId) await cancelRun(page, runId);
 				if (spaceId) await deleteSpace(page, spaceId);
 				spaceId = '';
 				runId = '';
+				taskId = '';
 			});
 
 			test('QA-to-Done channel gate opens after QA passes (qa-result-gate open)', async ({
 				page,
 			}) => {
-				await gotoSpaceAndWait(page, spaceId);
-
-				await expect(
-					page.getByTestId('canvas-panel').getByTestId('workflow-canvas-svg')
-				).toBeVisible({ timeout: 30000 });
+				await openCanvasAndWait(page, spaceId, taskId);
 
 				// qa-result-gate condition: { type: 'check', field: 'result', op: '==', value: 'passed' }
 				// With result: 'passed' written, the gate opens → green checkmark on QA→Done channel
@@ -496,11 +531,7 @@ test.describe
 			test('canvas shows all three Reviewer nodes and QA + Done (pipeline tail)', async ({
 				page,
 			}) => {
-				await gotoSpaceAndWait(page, spaceId);
-
-				await expect(
-					page.getByTestId('canvas-panel').getByTestId('workflow-canvas-svg')
-				).toBeVisible({ timeout: 30000 });
+				await openCanvasAndWait(page, spaceId, taskId);
 
 				// All key nodes in the reviewer→QA→Done pipeline must be visible
 				await expect(page.locator('text=Reviewer 1')).toBeVisible({ timeout: 5000 });
@@ -515,12 +546,14 @@ test.describe
 		test.describe('review-votes-gate reset after rejection cycle', () => {
 			let spaceId = '';
 			let runId = '';
+			let taskId = '';
 
 			test.beforeEach(async ({ page }) => {
 				await page.goto('/');
 				const ids = await createSpaceWithRun(page);
 				spaceId = ids.spaceId;
 				runId = ids.runId;
+				taskId = ids.taskId;
 
 				// Simulate state AFTER a rejection cycle: code-pr-gate persists (resetOnCycle: false),
 				// review-votes-gate has been cleared (resetOnCycle: true) — no votes written.
@@ -531,18 +564,21 @@ test.describe
 			});
 
 			test.afterEach(async ({ page }) => {
+				try {
+					await page.goto('/');
+					await waitForWebSocketConnected(page, 5000);
+				} catch {
+					// If navigation fails, cleanup is best-effort
+				}
 				if (runId) await cancelRun(page, runId);
 				if (spaceId) await deleteSpace(page, spaceId);
 				spaceId = '';
 				runId = '';
+				taskId = '';
 			});
 
 			test('review-votes-gate shows 0/3 after votes are reset (empty)', async ({ page }) => {
-				await gotoSpaceAndWait(page, spaceId);
-
-				await expect(
-					page.getByTestId('canvas-panel').getByTestId('workflow-canvas-svg')
-				).toBeVisible({ timeout: 30000 });
+				await openCanvasAndWait(page, spaceId, taskId);
 
 				// With no votes written, the review-votes-gate shows 0/3
 				await expect(voteBadge(page, 'review-votes-gate', '0/3')).toBeVisible({ timeout: 30000 });
@@ -553,12 +589,14 @@ test.describe
 		test.describe('rejection-to-approval state transition', () => {
 			let spaceId = '';
 			let runId = '';
+			let taskId = '';
 
 			test.beforeEach(async ({ page }) => {
 				await page.goto('/');
 				const ids = await createSpaceWithRun(page);
 				spaceId = ids.spaceId;
 				runId = ids.runId;
+				taskId = ids.taskId;
 
 				await writeGateData(page, runId, 'code-pr-gate', {
 					pr_url: 'https://github.com/test/repo/pull/1',
@@ -566,17 +604,21 @@ test.describe
 			});
 
 			test.afterEach(async ({ page }) => {
+				try {
+					await page.goto('/');
+					await waitForWebSocketConnected(page, 5000);
+				} catch {
+					// If navigation fails, cleanup is best-effort
+				}
 				if (runId) await cancelRun(page, runId);
 				if (spaceId) await deleteSpace(page, spaceId);
 				spaceId = '';
 				runId = '';
+				taskId = '';
 			});
 
 			test('canvas updates from rejection to full approval in sequence', async ({ page }) => {
-				await gotoSpaceAndWait(page, spaceId);
-				await expect(
-					page.getByTestId('canvas-panel').getByTestId('workflow-canvas-svg')
-				).toBeVisible({ timeout: 30000 });
+				await openCanvasAndWait(page, spaceId, taskId);
 
 				// Step 1: Reviewer 1 rejects — review-reject-gate opens
 				await writeGateData(page, runId, 'review-reject-gate', {

--- a/packages/e2e/tests/features/space-approval-gate-rejection.e2e.ts
+++ b/packages/e2e/tests/features/space-approval-gate-rejection.e2e.ts
@@ -45,7 +45,7 @@ const DESKTOP_VIEWPORT = { width: 1440, height: 900 };
 
 async function createSpaceWithRun(
 	page: Parameters<typeof waitForWebSocketConnected>[0]
-): Promise<{ spaceId: string; runId: string }> {
+): Promise<{ spaceId: string; runId: string; taskId: string }> {
 	await waitForWebSocketConnected(page);
 	const workspaceRoot = await getWorkspaceRoot(page);
 	// Use a unique subdirectory to avoid conflicts with other parallel tests
@@ -72,7 +72,25 @@ async function createSpaceWithRun(
 			})) as { run: { id: string } };
 			const runId = runRes.run.id;
 
-			return { spaceId, runId };
+			// Poll for the task created by the workflow run
+			const startTime = Date.now();
+			const maxWait = 20000;
+			let taskId = '';
+			while (Date.now() - startTime < maxWait) {
+				const tasks = (await hub.request('spaceTask.list', { spaceId })) as Array<{
+					id: string;
+					workflowRunId?: string;
+				}>;
+				const match = tasks.find((t) => t.workflowRunId === runId);
+				if (match) {
+					taskId = match.id;
+					break;
+				}
+				await new Promise((r) => setTimeout(r, 250));
+			}
+			if (!taskId) throw new Error(`No task found for run ${runId} after ${maxWait}ms`);
+
+			return { spaceId, runId, taskId };
 		},
 		{ wsPath }
 	);
@@ -111,23 +129,35 @@ async function deleteSpace(
 // ─── UI action helpers ────────────────────────────────────────────────────────
 
 /**
+ * Navigate to the task pane, wait for WebSocket reconnection, then click the
+ * Canvas toggle to reveal the workflow canvas.
+ */
+async function openCanvasAndWait(page: Page, spaceId: string, taskId: string): Promise<void> {
+	await page.goto(`/space/${spaceId}/task/${taskId}`);
+	await waitForWebSocketConnected(page);
+
+	// Wait for the Canvas toggle to appear (confirms task data loaded with workflowRunId)
+	await expect(page.getByTestId('canvas-toggle')).toBeVisible({ timeout: 30000 });
+
+	// Click Canvas toggle to reveal the workflow canvas
+	await page.getByTestId('canvas-toggle').click();
+
+	// Wait for canvas SVG to render inside the canvas-view container
+	await expect(page.getByTestId('canvas-view').getByTestId('workflow-canvas-svg')).toBeVisible({
+		timeout: 30000,
+	});
+}
+
+/**
  * Waits for the canvas to be fully initialized (SVG rendered + gate data loaded),
  * then rejects the waiting_human gate via the action popup.
  * Resolves once the gate-icon-blocked state is visible on the canvas.
  */
-async function rejectViaPopup(page: Page): Promise<void> {
-	// Wait for canvas to be in runtime mode with gate data fetched.
-	// Both the container and SVG must be visible before gate icons appear.
-	// Use 30s timeout — workflow data from the store (live query) may load slowly under load.
-	await expect(page.getByTestId('canvas-panel').getByTestId('workflow-canvas')).toBeVisible({
-		timeout: 30000,
-	});
-	await expect(page.getByTestId('canvas-panel').getByTestId('workflow-canvas-svg')).toBeVisible({
-		timeout: 30000,
-	});
+async function rejectViaPopup(page: Page, spaceId: string, taskId: string): Promise<void> {
+	await openCanvasAndWait(page, spaceId, taskId);
 
 	// Gate data is fetched async after canvas renders; wait for the gate icon.
-	const waitingGate = page.getByTestId('canvas-panel').getByTestId('gate-icon-waiting_human');
+	const waitingGate = page.getByTestId('canvas-view').getByTestId('gate-icon-waiting_human');
 	await expect(waitingGate).toBeVisible({ timeout: 30000 });
 
 	// Open the action popup.
@@ -142,7 +172,7 @@ async function rejectViaPopup(page: Page): Promise<void> {
 	// may show as blocked (run enters blocked status), causing strict mode violations.
 	await expect(
 		page
-			.getByTestId('canvas-panel')
+			.getByTestId('canvas-view')
 			.locator('[data-gate-id="plan-approval-gate"][data-testid="gate-icon-blocked"]')
 	).toBeVisible({
 		timeout: 10000,
@@ -160,15 +190,23 @@ test.describe('Approval Gate Rejection', () => {
 
 	let spaceId = '';
 	let runId = '';
+	let taskId = '';
 
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/');
 		const ids = await createSpaceWithRun(page);
 		spaceId = ids.spaceId;
 		runId = ids.runId;
+		taskId = ids.taskId;
 	});
 
 	test.afterEach(async ({ page }) => {
+		try {
+			await page.goto('/');
+			await waitForWebSocketConnected(page, 5000);
+		} catch {
+			// If navigation fails, cleanup is best-effort
+		}
 		if (runId) {
 			await cancelRun(page, runId);
 			runId = '';
@@ -177,6 +215,7 @@ test.describe('Approval Gate Rejection', () => {
 			await deleteSpace(page, spaceId);
 			spaceId = '';
 		}
+		taskId = '';
 	});
 
 	// ─── Test 1: Reject via GateArtifactsView closes overlay and transitions run ──
@@ -184,21 +223,10 @@ test.describe('Approval Gate Rejection', () => {
 	test('rejecting via GateArtifactsView closes overlay and transitions run to needs_attention', async ({
 		page,
 	}) => {
-		await page.goto(`/space/${spaceId}`);
-		await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
-
-		// Wait for canvas to be fully initialized (container + SVG + gate data).
-		// Use 30s here — the canvas panel requires workflow data from the store (live query),
-		// which may take longer when the server is under load at test start.
-		await expect(page.getByTestId('canvas-panel').getByTestId('workflow-canvas')).toBeVisible({
-			timeout: 30000,
-		});
-		await expect(page.getByTestId('canvas-panel').getByTestId('workflow-canvas-svg')).toBeVisible({
-			timeout: 30000,
-		});
+		await openCanvasAndWait(page, spaceId, taskId);
 
 		// The plan-approval-gate starts in waiting_human (amber pulsing).
-		const waitingGate = page.getByTestId('canvas-panel').getByTestId('gate-icon-waiting_human');
+		const waitingGate = page.getByTestId('canvas-view').getByTestId('gate-icon-waiting_human');
 		await expect(waitingGate).toBeVisible({ timeout: 30000 });
 
 		// Open the action popup.
@@ -225,7 +253,7 @@ test.describe('Approval Gate Rejection', () => {
 		// The gate should now show as "blocked" (red lock) on the canvas.
 		await expect(
 			page
-				.getByTestId('canvas-panel')
+				.getByTestId('canvas-view')
 				.locator('[data-gate-id="plan-approval-gate"][data-testid="gate-icon-blocked"]')
 		).toBeVisible({
 			timeout: 10000,
@@ -233,7 +261,7 @@ test.describe('Approval Gate Rejection', () => {
 
 		// Canvas banner: "Workflow paused — awaiting approval" (run.failureReason === 'humanRejected').
 		await expect(
-			page.getByTestId('canvas-panel').locator('text=Workflow paused — awaiting approval')
+			page.getByTestId('canvas-view').locator('text=Workflow paused — awaiting approval')
 		).toBeVisible({
 			timeout: 10000,
 		});
@@ -244,17 +272,14 @@ test.describe('Approval Gate Rejection', () => {
 	test('rejecting directly from gate popup sets gate to blocked without opening overlay', async ({
 		page,
 	}) => {
-		await page.goto(`/space/${spaceId}`);
-		await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
-
-		await rejectViaPopup(page);
+		await rejectViaPopup(page, spaceId, taskId);
 
 		// Overlay must NOT have appeared (we never opened it).
 		await expect(page.getByTestId('artifacts-panel-overlay')).toBeHidden({ timeout: 5000 });
 
 		// Canvas banner should indicate needs_attention.
 		await expect(
-			page.getByTestId('canvas-panel').locator('text=Workflow paused — awaiting approval')
+			page.getByTestId('canvas-view').locator('text=Workflow paused — awaiting approval')
 		).toBeVisible({
 			timeout: 10000,
 		});
@@ -263,23 +288,20 @@ test.describe('Approval Gate Rejection', () => {
 	// ─── Test 3: Canvas shows error/attention state after rejection ───────────
 
 	test('canvas shows needs_attention banner and blocked gate after rejection', async ({ page }) => {
-		await page.goto(`/space/${spaceId}`);
-		await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
-
-		await rejectViaPopup(page);
+		await rejectViaPopup(page, spaceId, taskId);
 
 		// Canvas shows the needs_attention banner.
 		await expect(
-			page.getByTestId('canvas-panel').locator('text=Workflow paused — awaiting approval')
+			page.getByTestId('canvas-view').locator('text=Workflow paused — awaiting approval')
 		).toBeVisible({
 			timeout: 5000,
 		});
 
 		// The canvas container and SVG are still present (not replaced by an error fallback).
-		await expect(page.getByTestId('canvas-panel').getByTestId('workflow-canvas')).toBeVisible({
+		await expect(page.getByTestId('canvas-view').getByTestId('workflow-canvas')).toBeVisible({
 			timeout: 5000,
 		});
-		await expect(page.getByTestId('canvas-panel').getByTestId('workflow-canvas-svg')).toBeVisible({
+		await expect(page.getByTestId('canvas-view').getByTestId('workflow-canvas-svg')).toBeVisible({
 			timeout: 5000,
 		});
 	});
@@ -287,38 +309,31 @@ test.describe('Approval Gate Rejection', () => {
 	// ─── Test 4: Space remains usable after rejection ─────────────────────────
 
 	test('space remains fully navigable and usable after gate rejection', async ({ page }) => {
-		await page.goto(`/space/${spaceId}`);
-		await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
-
-		await rejectViaPopup(page);
+		await rejectViaPopup(page, spaceId, taskId);
 
 		// Verify canvas still renders with the blocked gate after rejection.
-		await expect(page.getByTestId('canvas-panel').getByTestId('workflow-canvas')).toBeVisible({
+		await expect(page.getByTestId('canvas-view').getByTestId('workflow-canvas')).toBeVisible({
 			timeout: 10000,
 		});
 		await expect(
 			page
-				.getByTestId('canvas-panel')
+				.getByTestId('canvas-view')
 				.locator('[data-gate-id="plan-approval-gate"][data-testid="gate-icon-blocked"]')
 		).toBeVisible({
 			timeout: 10000,
 		});
 
-		// Tab bar should still be navigable — clicking Agents shows agent content.
-		// SpaceAgentList does NOT depend on spaceStore.space being non-null (unlike
-		// WorkflowList / SpaceSettings), so it's a more reliable navigation target.
-		await page.locator('button:has-text("Agents")').click();
-		await expect(page.locator('text=Planner')).toBeVisible({ timeout: 30000 });
-		await expect(page.locator('text=Coder')).toBeVisible({ timeout: 10000 });
+		// Navigate away from the task pane and back — canvas should still render.
+		// Click the back button to return to the space overview.
+		await page.getByTestId('task-back-button').click();
+		await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
 
-		// Return to Dashboard — canvas should still be visible with the blocked state.
-		await page.locator('button:has-text("Dashboard")').click();
-		await expect(page.getByTestId('canvas-panel').getByTestId('workflow-canvas')).toBeVisible({
-			timeout: 30000,
-		});
+		// Navigate back to the task pane and open canvas again.
+		await openCanvasAndWait(page, spaceId, taskId);
+
 		await expect(
 			page
-				.getByTestId('canvas-panel')
+				.getByTestId('canvas-view')
 				.locator('[data-gate-id="plan-approval-gate"][data-testid="gate-icon-blocked"]')
 		).toBeVisible({
 			timeout: 10000,
@@ -330,23 +345,19 @@ test.describe('Approval Gate Rejection', () => {
 	test('rejected gate icon transitions from waiting_human (amber) to blocked (red lock)', async ({
 		page,
 	}) => {
-		await page.goto(`/space/${spaceId}`);
-		await page.waitForURL(`/space/${spaceId}**`, { timeout: 10000 });
+		await openCanvasAndWait(page, spaceId, taskId);
 
 		// Initially: amber waiting_human gate is visible.
-		await expect(page.getByTestId('canvas-panel').getByTestId('workflow-canvas-svg')).toBeVisible({
-			timeout: 10000,
-		});
 		await expect(
-			page.getByTestId('canvas-panel').getByTestId('gate-icon-waiting_human')
+			page.getByTestId('canvas-view').getByTestId('gate-icon-waiting_human')
 		).toBeVisible({ timeout: 10000 });
 
-		await rejectViaPopup(page);
+		await rejectViaPopup(page, spaceId, taskId);
 
 		// After rejection: blocked gate is visible.
 		await expect(
 			page
-				.getByTestId('canvas-panel')
+				.getByTestId('canvas-view')
 				.locator('[data-gate-id="plan-approval-gate"][data-testid="gate-icon-blocked"]')
 		).toBeVisible({
 			timeout: 10000,
@@ -357,8 +368,8 @@ test.describe('Approval Gate Rejection', () => {
 		// pre-coding phase (plan-approval-gate). If the workflow adds more human gates
 		// in the future, this assertion would need revisiting — but for the current
 		// template it confirms the gate correctly transitioned away from waiting_human.
-		await expect(
-			page.getByTestId('canvas-panel').getByTestId('gate-icon-waiting_human')
-		).toBeHidden({ timeout: 10000 });
+		await expect(page.getByTestId('canvas-view').getByTestId('gate-icon-waiting_human')).toBeHidden(
+			{ timeout: 10000 }
+		);
 	});
 });


### PR DESCRIPTION
## Summary
- The `canvas-panel` test ID was removed when SpaceIsland was simplified from a tabbed layout to a direct SpaceDashboard. The WorkflowCanvas is now only accessible inside SpaceTaskPane via the Canvas toggle button.
- Updated `reviewer-feedback-loop.e2e.ts` and `space-approval-gate-rejection.e2e.ts` to navigate to the task pane, click the Canvas toggle, and use `canvas-view` locators.
- Added `createUniqueSpaceDir()` for workspace isolation and task ID retrieval via `spaceTask.list` polling.

## Test plan
- [ ] Trigger E2E LLM CI for `features-reviewer-feedback-loop`
- [ ] Trigger E2E LLM CI for `features-approval-gate-rejection`