### PR TITLE
feat: export GoalsEditor sub-components and add useMissionDetailData hook

### DIFF
--- a/packages/web/src/components/room/GoalsEditor.tsx
+++ b/packages/web/src/components/room/GoalsEditor.tsx
@@ -138,7 +138,7 @@ function goalPriorityBorderClass(priority: GoalPriority): string {
 
 // ─── Status Indicator ─────────────────────────────────────────────────────────
 
-function StatusIndicator({ status }: { status: GoalStatus }) {
+export function StatusIndicator({ status }: { status: GoalStatus }) {
 	const config: Record<GoalStatus, { dot: string; label: string }> = {
 		active: { dot: 'bg-green-400', label: 'Active' },
 		completed: { dot: 'bg-gray-400', label: 'Completed' },
@@ -156,7 +156,7 @@ function StatusIndicator({ status }: { status: GoalStatus }) {
 
 // ─── Priority Badge ───────────────────────────────────────────────────────────
 
-function PriorityBadge({ priority }: { priority: GoalPriority }) {
+export function PriorityBadge({ priority }: { priority: GoalPriority }) {
 	const styles: Record<GoalPriority, string> = {
 		low: 'bg-gray-700 text-gray-300',
 		normal: 'bg-blue-900/50 text-blue-300',
@@ -172,7 +172,7 @@ function PriorityBadge({ priority }: { priority: GoalPriority }) {
 
 // ─── Mission Type Badge ───────────────────────────────────────────────────────
 
-function MissionTypeBadge({ type }: { type: MissionType }) {
+export function MissionTypeBadge({ type }: { type: MissionType }) {
 	const config: Record<MissionType, { label: string; style: string }> = {
 		one_shot: { label: 'One-Shot', style: 'bg-gray-700 text-gray-300' },
 		measurable: { label: 'Measurable', style: 'bg-purple-900/50 text-purple-300' },
@@ -191,7 +191,7 @@ function MissionTypeBadge({ type }: { type: MissionType }) {
 
 // ─── Autonomy Level Badge ─────────────────────────────────────────────────────
 
-function AutonomyBadge({ level }: { level: AutonomyLevel }) {
+export function AutonomyBadge({ level }: { level: AutonomyLevel }) {
 	const config: Record<AutonomyLevel, { label: string; style: string; title: string }> = {
 		supervised: {
 			label: 'Supervised',
@@ -218,7 +218,7 @@ function AutonomyBadge({ level }: { level: AutonomyLevel }) {
 
 // ─── Progress Bar ─────────────────────────────────────────────────────────────
 
-function ProgressBar({ progress }: { progress: number }) {
+export function ProgressBar({ progress }: { progress: number }) {
 	const getColor = (prog: number): string => {
 		if (prog < 30) return 'bg-red-500';
 		if (prog < 70) return 'bg-yellow-500';
@@ -266,7 +266,7 @@ function TaskStatusBadge({ status }: { status: TaskStatus }) {
 
 // ─── Short ID Badge ───────────────────────────────────────────────────────────
 
-function GoalShortIdBadge({ shortId }: { shortId: string }) {
+export function GoalShortIdBadge({ shortId }: { shortId: string }) {
 	const copied = useSignal(false);
 
 	const handleCopy = (e: MouseEvent) => {
@@ -371,7 +371,7 @@ function scheduleToPreset(schedule?: CronSchedule): string {
 		: 'custom';
 }
 
-interface GoalFormProps {
+export interface GoalFormProps {
 	initialTitle?: string;
 	initialDescription?: string;
 	initialPriority?: GoalPriority;
@@ -393,7 +393,7 @@ function newMetricEntry(metric: MissionMetric): MetricEntry {
 	return { id: `m-${++_metricKeyCounter}`, metric };
 }
 
-function GoalForm({
+export function GoalForm({
 	initialTitle = '',
 	initialDescription = '',
 	initialPriority = 'normal',
@@ -1086,7 +1086,7 @@ function CreateGoalWizard({ onSubmit, onCancel, isLoading }: CreateGoalWizardPro
 
 // ─── Metric Progress Display ──────────────────────────────────────────────────
 
-function MetricProgress({ metrics }: { metrics: MissionMetric[] }) {
+export function MetricProgress({ metrics }: { metrics: MissionMetric[] }) {
 	if (metrics.length === 0) return null;
 	return (
 		<div class="space-y-2">
@@ -1118,7 +1118,7 @@ function MetricProgress({ metrics }: { metrics: MissionMetric[] }) {
 
 // ─── Recurring Schedule Display ───────────────────────────────────────────────
 
-function RecurringScheduleInfo({ goal }: { goal: RoomGoal }) {
+export function RecurringScheduleInfo({ goal }: { goal: RoomGoal }) {
 	return (
 		<div class="space-y-2 text-sm">
 			{goal.schedule && (

--- a/packages/web/src/components/room/index.ts
+++ b/packages/web/src/components/room/index.ts
@@ -9,6 +9,16 @@ export { CollapsibleSection } from './CollapsibleSection';
 export type { CollapsibleSectionProps } from './CollapsibleSection';
 // @public - Library export
 export { GoalsEditor } from './GoalsEditor';
+// @public - GoalsEditor sub-components for reuse in MissionDetail and other views
+export { StatusIndicator } from './GoalsEditor';
+export { PriorityBadge } from './GoalsEditor';
+export { MissionTypeBadge } from './GoalsEditor';
+export { AutonomyBadge } from './GoalsEditor';
+export { ProgressBar } from './GoalsEditor';
+export { MetricProgress } from './GoalsEditor';
+export { RecurringScheduleInfo } from './GoalsEditor';
+export { GoalShortIdBadge } from './GoalsEditor';
+export { GoalForm, type GoalFormProps } from './GoalsEditor';
 // @public - Library export
 export { RoomContext } from './RoomContext';
 export type { RoomContextProps } from './RoomContext';

--- a/packages/web/src/hooks/__tests__/useMissionDetailData.test.ts
+++ b/packages/web/src/hooks/__tests__/useMissionDetailData.test.ts
@@ -1,0 +1,670 @@
+/**
+ * Tests for useMissionDetailData hook
+ *
+ * Verifies reactive goal/task derivation, execution loading, available status
+ * action matrix, and action handler behaviour.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act, cleanup } from '@testing-library/preact';
+import { signal } from '@preact/signals';
+import type { MissionExecution, NeoTask, RoomGoal } from '@neokai/shared';
+import { useMissionDetailData } from '../useMissionDetailData';
+import { navigateToRoom } from '../../lib/router';
+import { toast } from '../../lib/toast';
+
+// -------------------------------------------------------
+// Mocks
+// -------------------------------------------------------
+
+const mockRequest = vi.fn();
+
+vi.mock('../useMessageHub.ts', () => ({
+	useMessageHub: () => ({
+		request: mockRequest,
+	}),
+}));
+
+// roomStore mock — goals and tasks are signals so useComputed subscribes reactively.
+const mockGoalsSignal = signal<RoomGoal[]>([]);
+const mockTasksSignal = signal<NeoTask[]>([]);
+
+const mockUpdateGoal = vi.fn();
+const mockDeleteGoal = vi.fn();
+const mockTriggerNow = vi.fn();
+const mockScheduleNext = vi.fn();
+const mockLinkTaskToGoal = vi.fn();
+const mockListExecutions = vi.fn();
+
+vi.mock('../../lib/room-store.ts', () => ({
+	roomStore: {
+		get goals() {
+			return mockGoalsSignal;
+		},
+		get tasks() {
+			return mockTasksSignal;
+		},
+		updateGoal: (...args: unknown[]) => mockUpdateGoal(...args),
+		deleteGoal: (...args: unknown[]) => mockDeleteGoal(...args),
+		triggerNow: (...args: unknown[]) => mockTriggerNow(...args),
+		scheduleNext: (...args: unknown[]) => mockScheduleNext(...args),
+		linkTaskToGoal: (...args: unknown[]) => mockLinkTaskToGoal(...args),
+		listExecutions: (...args: unknown[]) => mockListExecutions(...args),
+	},
+}));
+
+vi.mock('../../lib/router.ts', () => ({
+	navigateToRoom: vi.fn(),
+}));
+
+vi.mock('../../lib/toast.ts', () => ({
+	toast: {
+		success: vi.fn(),
+		error: vi.fn(),
+		info: vi.fn(),
+	},
+}));
+
+// -------------------------------------------------------
+// Helpers
+// -------------------------------------------------------
+
+function makeGoal(overrides: Partial<RoomGoal> = {}): RoomGoal {
+	return {
+		id: 'goal-1',
+		shortId: 'g-1',
+		roomId: 'room-1',
+		title: 'Test Mission',
+		description: 'Test description',
+		status: 'active',
+		priority: 'normal',
+		progress: 0,
+		linkedTaskIds: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		missionType: 'one_shot',
+		...overrides,
+	};
+}
+
+function makeTask(overrides: Partial<NeoTask> = {}): NeoTask {
+	return {
+		id: 'task-1',
+		roomId: 'room-1',
+		title: 'Test Task',
+		status: 'pending',
+		priority: 'normal',
+		description: '',
+		dependsOn: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+function makeExecution(overrides: Partial<MissionExecution> = {}): MissionExecution {
+	return {
+		id: 'exec-1',
+		goalId: 'goal-1',
+		executionNumber: 1,
+		startedAt: Date.now(),
+		status: 'completed',
+		taskIds: [],
+		planningAttempts: 1,
+		...overrides,
+	};
+}
+
+// -------------------------------------------------------
+// Test suites
+// -------------------------------------------------------
+
+describe('useMissionDetailData — goal derivation', () => {
+	beforeEach(() => {
+		mockGoalsSignal.value = [makeGoal()];
+		mockTasksSignal.value = [];
+		mockListExecutions.mockResolvedValue([]);
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it('derives goal by UUID', () => {
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		expect(result.current.goal).not.toBeNull();
+		expect(result.current.goal?.id).toBe('goal-1');
+	});
+
+	it('derives goal by short ID', () => {
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'g-1'));
+
+		expect(result.current.goal).not.toBeNull();
+		expect(result.current.goal?.id).toBe('goal-1');
+		expect(result.current.goal?.shortId).toBe('g-1');
+	});
+
+	it('returns null when goalId does not match any goal', () => {
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'nonexistent'));
+
+		expect(result.current.goal).toBeNull();
+	});
+
+	it('updates reactively when goal appears in store after mount', () => {
+		mockGoalsSignal.value = [];
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		expect(result.current.goal).toBeNull();
+
+		act(() => {
+			mockGoalsSignal.value = [makeGoal()];
+		});
+
+		expect(result.current.goal).not.toBeNull();
+		expect(result.current.goal?.id).toBe('goal-1');
+	});
+
+	it('updates reactively when goal status changes via LiveQuery delta', () => {
+		mockGoalsSignal.value = [makeGoal({ status: 'active' })];
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		expect(result.current.goal?.status).toBe('active');
+
+		act(() => {
+			mockGoalsSignal.value = [makeGoal({ status: 'completed' })];
+		});
+
+		expect(result.current.goal?.status).toBe('completed');
+	});
+});
+
+describe('useMissionDetailData — linked tasks derivation', () => {
+	beforeEach(() => {
+		mockListExecutions.mockResolvedValue([]);
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it('returns empty array when goal has no linked tasks', () => {
+		mockGoalsSignal.value = [makeGoal({ linkedTaskIds: [] })];
+		mockTasksSignal.value = [makeTask()];
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		expect(result.current.linkedTasks).toEqual([]);
+	});
+
+	it('derives linked tasks from roomStore.tasks', () => {
+		mockGoalsSignal.value = [makeGoal({ linkedTaskIds: ['task-1'] })];
+		mockTasksSignal.value = [makeTask({ id: 'task-1' })];
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		expect(result.current.linkedTasks).toHaveLength(1);
+		expect(result.current.linkedTasks[0].id).toBe('task-1');
+	});
+
+	it('omits tasks not present in roomStore (missing task IDs)', () => {
+		mockGoalsSignal.value = [makeGoal({ linkedTaskIds: ['task-1', 'missing-task'] })];
+		mockTasksSignal.value = [makeTask({ id: 'task-1' })];
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		expect(result.current.linkedTasks).toHaveLength(1);
+		expect(result.current.linkedTasks[0].id).toBe('task-1');
+	});
+
+	it('updates reactively when a new linked task appears in store', () => {
+		mockGoalsSignal.value = [makeGoal({ linkedTaskIds: ['task-1'] })];
+		mockTasksSignal.value = [];
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		expect(result.current.linkedTasks).toHaveLength(0);
+
+		act(() => {
+			mockTasksSignal.value = [makeTask({ id: 'task-1' })];
+		});
+
+		expect(result.current.linkedTasks).toHaveLength(1);
+	});
+});
+
+describe('useMissionDetailData — execution loading', () => {
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it('does not load executions for one_shot missions', async () => {
+		mockGoalsSignal.value = [makeGoal({ missionType: 'one_shot' })];
+		mockTasksSignal.value = [];
+
+		renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		await act(async () => {
+			await new Promise((r) => setTimeout(r, 10));
+		});
+
+		expect(mockListExecutions).not.toHaveBeenCalled();
+	});
+
+	it('loads executions for recurring missions', async () => {
+		const execs = [makeExecution()];
+		mockListExecutions.mockResolvedValue(execs);
+		mockGoalsSignal.value = [makeGoal({ missionType: 'recurring' })];
+		mockTasksSignal.value = [];
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		await waitFor(() => {
+			expect(result.current.isLoadingExecutions).toBe(false);
+		});
+
+		expect(mockListExecutions).toHaveBeenCalledWith('goal-1');
+		expect(result.current.executions).toEqual(execs);
+	});
+
+	it('loads executions when goal arrives asynchronously after mount', async () => {
+		const execs = [makeExecution()];
+		mockListExecutions.mockResolvedValue(execs);
+		// Goal not yet in store on mount
+		mockGoalsSignal.value = [];
+		mockTasksSignal.value = [];
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		// No executions yet — goal is null
+		expect(result.current.executions).toBeNull();
+		expect(mockListExecutions).not.toHaveBeenCalled();
+
+		// Goal arrives asynchronously (LiveQuery snapshot)
+		act(() => {
+			mockGoalsSignal.value = [makeGoal({ missionType: 'recurring' })];
+		});
+
+		await waitFor(() => {
+			expect(result.current.isLoadingExecutions).toBe(false);
+		});
+
+		expect(mockListExecutions).toHaveBeenCalledWith('goal-1');
+		expect(result.current.executions).toEqual(execs);
+	});
+
+	it('shows error toast and clears loading on execution fetch failure', async () => {
+		mockListExecutions.mockRejectedValue(new Error('Server error'));
+		mockGoalsSignal.value = [makeGoal({ missionType: 'recurring' })];
+		mockTasksSignal.value = [];
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		await waitFor(() => {
+			expect(result.current.isLoadingExecutions).toBe(false);
+		});
+
+		expect(toast.error).toHaveBeenCalledWith('Server error');
+		expect(result.current.executions).toBeNull();
+	});
+
+	it('executions start as null for non-recurring missions', () => {
+		mockGoalsSignal.value = [makeGoal({ missionType: 'measurable' })];
+		mockTasksSignal.value = [];
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		expect(result.current.executions).toBeNull();
+	});
+});
+
+describe('useMissionDetailData — availableStatusActions', () => {
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it('returns empty array when goal is null', () => {
+		mockGoalsSignal.value = [];
+		mockTasksSignal.value = [];
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		expect(result.current.availableStatusActions).toEqual([]);
+	});
+
+	it('returns complete, needs_human, archive for active goal', () => {
+		mockGoalsSignal.value = [makeGoal({ status: 'active' })];
+		mockTasksSignal.value = [];
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		expect(result.current.availableStatusActions).toEqual(['complete', 'needs_human', 'archive']);
+	});
+
+	it('returns reactivate, complete, archive for needs_human goal', () => {
+		mockGoalsSignal.value = [makeGoal({ status: 'needs_human' })];
+		mockTasksSignal.value = [];
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		expect(result.current.availableStatusActions).toEqual(['reactivate', 'complete', 'archive']);
+	});
+
+	it('returns reactivate, archive for completed goal', () => {
+		mockGoalsSignal.value = [makeGoal({ status: 'completed' })];
+		mockTasksSignal.value = [];
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		expect(result.current.availableStatusActions).toEqual(['reactivate', 'archive']);
+	});
+
+	it('returns only reactivate for archived goal (no archive action)', () => {
+		mockGoalsSignal.value = [makeGoal({ status: 'archived' })];
+		mockTasksSignal.value = [];
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		expect(result.current.availableStatusActions).toEqual(['reactivate']);
+	});
+
+	it('updates reactively when goal status changes', () => {
+		mockGoalsSignal.value = [makeGoal({ status: 'active' })];
+		mockTasksSignal.value = [];
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		expect(result.current.availableStatusActions).toContain('complete');
+
+		act(() => {
+			mockGoalsSignal.value = [makeGoal({ status: 'completed' })];
+		});
+
+		expect(result.current.availableStatusActions).not.toContain('complete');
+		expect(result.current.availableStatusActions).toContain('reactivate');
+	});
+});
+
+describe('useMissionDetailData — action handlers', () => {
+	beforeEach(() => {
+		mockGoalsSignal.value = [makeGoal()];
+		mockTasksSignal.value = [];
+		mockListExecutions.mockResolvedValue([]);
+		mockUpdateGoal.mockResolvedValue(undefined);
+		mockDeleteGoal.mockResolvedValue(undefined);
+		mockTriggerNow.mockResolvedValue(makeGoal());
+		mockScheduleNext.mockResolvedValue(makeGoal());
+		mockLinkTaskToGoal.mockResolvedValue(undefined);
+		mockRequest.mockResolvedValue({});
+		vi.mocked(navigateToRoom).mockClear();
+		vi.mocked(toast.success).mockClear();
+		vi.mocked(toast.info).mockClear();
+		vi.mocked(toast.error).mockClear();
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it('updateGoal calls roomStore.updateGoal with correct args', async () => {
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		await act(async () => {
+			await result.current.updateGoal({ title: 'New title' });
+		});
+
+		expect(mockUpdateGoal).toHaveBeenCalledWith('goal-1', { title: 'New title' });
+		expect(toast.success).toHaveBeenCalledWith('Mission updated');
+	});
+
+	it('updateGoal shows error toast on failure', async () => {
+		mockUpdateGoal.mockRejectedValueOnce(new Error('Update failed'));
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		await act(async () => {
+			await result.current.updateGoal({ title: 'New title' }).catch(() => {});
+		});
+
+		expect(toast.error).toHaveBeenCalledWith('Update failed');
+	});
+
+	it('updateGoal is idempotent while updating', async () => {
+		let resolveUpdate!: () => void;
+		mockUpdateGoal.mockReturnValueOnce(
+			new Promise<void>((res) => {
+				resolveUpdate = res;
+			})
+		);
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		// First call (not awaited)
+		act(() => {
+			void result.current.updateGoal({ title: 'A' });
+		});
+
+		await waitFor(() => expect(result.current.isUpdating).toBe(true));
+
+		// Second call should be ignored because isUpdating is true
+		await act(async () => {
+			await result.current.updateGoal({ title: 'B' });
+		});
+
+		resolveUpdate();
+
+		const calls = mockUpdateGoal.mock.calls;
+		expect(calls).toHaveLength(1);
+	});
+
+	it('deleteGoal calls roomStore.deleteGoal and navigates to room', async () => {
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		await act(async () => {
+			await result.current.deleteGoal();
+		});
+
+		expect(mockDeleteGoal).toHaveBeenCalledWith('goal-1');
+		expect(toast.info).toHaveBeenCalledWith('Mission deleted');
+		expect(navigateToRoom).toHaveBeenCalledWith('room-1');
+	});
+
+	it('deleteGoal shows error toast on failure', async () => {
+		mockDeleteGoal.mockRejectedValueOnce(new Error('Delete failed'));
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		await act(async () => {
+			await result.current.deleteGoal().catch(() => {});
+		});
+
+		expect(toast.error).toHaveBeenCalledWith('Delete failed');
+		expect(navigateToRoom).not.toHaveBeenCalled();
+	});
+
+	it('deleteGoal sets and clears isDeleting', async () => {
+		let resolveDelete!: () => void;
+		mockDeleteGoal.mockReturnValueOnce(new Promise<void>((res) => (resolveDelete = res)));
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		act(() => {
+			void result.current.deleteGoal();
+		});
+
+		await waitFor(() => expect(result.current.isDeleting).toBe(true));
+
+		resolveDelete();
+
+		await waitFor(() => expect(result.current.isDeleting).toBe(false));
+	});
+
+	it('triggerNow calls roomStore.triggerNow', async () => {
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		await act(async () => {
+			await result.current.triggerNow();
+		});
+
+		expect(mockTriggerNow).toHaveBeenCalledWith('goal-1');
+		expect(toast.success).toHaveBeenCalledWith('Mission triggered');
+	});
+
+	it('triggerNow sets and clears isTriggering', async () => {
+		let resolveTrigger!: () => void;
+		mockTriggerNow.mockReturnValueOnce(new Promise<void>((res) => (resolveTrigger = res)));
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		act(() => {
+			void result.current.triggerNow();
+		});
+
+		await waitFor(() => expect(result.current.isTriggering).toBe(true));
+
+		resolveTrigger();
+
+		await waitFor(() => expect(result.current.isTriggering).toBe(false));
+	});
+
+	it('triggerNow shows error toast on failure', async () => {
+		mockTriggerNow.mockRejectedValueOnce(new Error('Trigger failed'));
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		await act(async () => {
+			await result.current.triggerNow().catch(() => {});
+		});
+
+		expect(toast.error).toHaveBeenCalledWith('Trigger failed');
+	});
+
+	it('scheduleNext calls roomStore.scheduleNext', async () => {
+		const nextRun = Date.now() + 3600_000;
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		await act(async () => {
+			await result.current.scheduleNext(nextRun);
+		});
+
+		expect(mockScheduleNext).toHaveBeenCalledWith('goal-1', nextRun);
+		expect(toast.success).toHaveBeenCalledWith('Mission scheduled');
+	});
+
+	it('linkTask calls roomStore.linkTaskToGoal', async () => {
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		await act(async () => {
+			await result.current.linkTask('task-abc');
+		});
+
+		expect(mockLinkTaskToGoal).toHaveBeenCalledWith('goal-1', 'task-abc');
+	});
+});
+
+describe('useMissionDetailData — changeStatus', () => {
+	beforeEach(() => {
+		mockGoalsSignal.value = [makeGoal({ status: 'active' })];
+		mockTasksSignal.value = [];
+		mockListExecutions.mockResolvedValue([]);
+		mockUpdateGoal.mockResolvedValue(undefined);
+		mockRequest.mockResolvedValue({});
+		vi.mocked(toast.success).mockClear();
+		vi.mocked(toast.info).mockClear();
+		vi.mocked(toast.error).mockClear();
+	});
+
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it('complete calls roomStore.updateGoal with status=completed', async () => {
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		await act(async () => {
+			await result.current.changeStatus('complete');
+		});
+
+		expect(mockUpdateGoal).toHaveBeenCalledWith('goal-1', { status: 'completed' });
+		expect(toast.success).toHaveBeenCalledWith('Mission completed');
+	});
+
+	it('archive calls roomStore.updateGoal with status=archived', async () => {
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		await act(async () => {
+			await result.current.changeStatus('archive');
+		});
+
+		expect(mockUpdateGoal).toHaveBeenCalledWith('goal-1', { status: 'archived' });
+		expect(toast.info).toHaveBeenCalledWith('Mission archived');
+	});
+
+	it('reactivate uses dedicated goal.reactivate RPC (has server-side side effects)', async () => {
+		mockGoalsSignal.value = [makeGoal({ status: 'completed' })];
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		await act(async () => {
+			await result.current.changeStatus('reactivate');
+		});
+
+		// Should use dedicated RPC — not generic updateGoal — so server can reset
+		// consecutiveFailures and perform other side effects.
+		expect(mockRequest).toHaveBeenCalledWith('goal.reactivate', {
+			roomId: 'room-1',
+			goalId: 'goal-1',
+		});
+		expect(mockUpdateGoal).not.toHaveBeenCalled();
+		expect(toast.success).toHaveBeenCalledWith('Mission reactivated');
+	});
+
+	it('needs_human uses dedicated goal.needsHuman RPC (has server-side side effects)', async () => {
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		await act(async () => {
+			await result.current.changeStatus('needs_human');
+		});
+
+		// Dedicated RPC ensures recurring schedules are paused and other side effects run.
+		expect(mockRequest).toHaveBeenCalledWith('goal.needsHuman', {
+			roomId: 'room-1',
+			goalId: 'goal-1',
+		});
+		expect(mockUpdateGoal).not.toHaveBeenCalled();
+		expect(toast.info).toHaveBeenCalledWith('Mission marked as needs human input');
+	});
+
+	it('shows error toast on changeStatus failure', async () => {
+		mockUpdateGoal.mockRejectedValueOnce(new Error('Status change failed'));
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		await act(async () => {
+			await result.current.changeStatus('complete').catch(() => {});
+		});
+
+		expect(toast.error).toHaveBeenCalledWith('Status change failed');
+	});
+
+	it('does nothing when goal is null', async () => {
+		mockGoalsSignal.value = [];
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		await act(async () => {
+			await result.current.changeStatus('complete');
+		});
+
+		expect(mockUpdateGoal).not.toHaveBeenCalled();
+		expect(mockRequest).not.toHaveBeenCalled();
+	});
+});

--- a/packages/web/src/hooks/index.ts
+++ b/packages/web/src/hooks/index.ts
@@ -70,3 +70,8 @@ export {
 } from './useReferenceAutocomplete';
 export { useViewportSafety } from './useViewportSafety';
 export { useClickOutside } from './useClickOutside';
+export {
+	useMissionDetailData,
+	type UseMissionDetailDataResult,
+	type AvailableStatusAction,
+} from './useMissionDetailData';

--- a/packages/web/src/hooks/useMissionDetailData.ts
+++ b/packages/web/src/hooks/useMissionDetailData.ts
@@ -1,0 +1,235 @@
+/**
+ * useMissionDetailData
+ *
+ * Encapsulates all data-fetching, action handlers, and derived state for the
+ * MissionDetail page. Follows the same pattern as useTaskViewData.
+ */
+
+import type { GoalStatus, MissionExecution, NeoTask, RoomGoal } from '@neokai/shared';
+import { useComputed } from '@preact/signals';
+import { useCallback, useEffect, useState } from 'preact/hooks';
+import { useMessageHub } from './useMessageHub';
+import { roomStore } from '../lib/room-store';
+import { navigateToRoom } from '../lib/router';
+import { toast } from '../lib/toast';
+
+/** Status transitions available from a given GoalStatus */
+export type AvailableStatusAction = 'complete' | 'reactivate' | 'needs_human' | 'archive';
+
+export interface UseMissionDetailDataResult {
+	/** Goal matching by UUID or short ID, null if not found */
+	goal: RoomGoal | null;
+	/** Tasks linked to this goal, derived reactively */
+	linkedTasks: NeoTask[];
+	/** Execution history — loaded on mount for recurring missions */
+	executions: MissionExecution[] | null;
+	/** Loading states */
+	isLoadingExecutions: boolean;
+	isUpdating: boolean;
+	isTriggering: boolean;
+	/** Status actions available from current goal status */
+	availableStatusActions: AvailableStatusAction[];
+	/** Action handlers */
+	updateGoal: (updates: Partial<RoomGoal>) => Promise<void>;
+	deleteGoal: () => Promise<void>;
+	triggerNow: () => Promise<void>;
+	scheduleNext: (nextRunAt: number) => Promise<void>;
+	linkTask: (taskId: string) => Promise<void>;
+	changeStatus: (action: AvailableStatusAction) => Promise<void>;
+}
+
+export function useMissionDetailData(roomId: string, goalId: string): UseMissionDetailDataResult {
+	const { request } = useMessageHub();
+
+	// Derive goal reactively from roomStore — matches by UUID or short ID so
+	// deep links like /rooms/:roomId/missions/g-abc123 resolve correctly.
+	const goal = useComputed(
+		() => roomStore.goals.value.find((g) => g.id === goalId || g.shortId === goalId) ?? null
+	);
+
+	// Derive linked tasks reactively from roomStore.
+	const linkedTasks = useComputed<NeoTask[]>(() => {
+		const g = goal.value;
+		if (!g || g.linkedTaskIds.length === 0) return [];
+		const taskMap = new Map(roomStore.tasks.value.map((t) => [t.id, t]));
+		return g.linkedTaskIds.map((id) => taskMap.get(id)).filter((t): t is NeoTask => t != null);
+	});
+
+	const [executions, setExecutions] = useState<MissionExecution[] | null>(null);
+	const [isLoadingExecutions, setIsLoadingExecutions] = useState(false);
+	const [isUpdating, setIsUpdating] = useState(false);
+	const [isTriggering, setIsTriggering] = useState(false);
+
+	// Load execution history for recurring missions on mount (or when goalId changes).
+	useEffect(() => {
+		let cancelled = false;
+
+		const load = async () => {
+			// Wait until goal is available before deciding whether to load executions.
+			// goal.value may be null initially while the LiveQuery snapshot arrives.
+			const g = goal.value;
+			if (!g) return;
+			if (g.missionType !== 'recurring') return;
+
+			setIsLoadingExecutions(true);
+			try {
+				const execs = await roomStore.listExecutions(g.id);
+				if (!cancelled) setExecutions(execs);
+			} catch (err) {
+				if (!cancelled) {
+					toast.error(err instanceof Error ? err.message : 'Failed to load executions');
+				}
+			} finally {
+				if (!cancelled) setIsLoadingExecutions(false);
+			}
+		};
+
+		load();
+
+		return () => {
+			cancelled = true;
+		};
+		// We intentionally re-run when goalId changes. goal.value is read inside the
+		// async body — the reactive subscription on the computed happens elsewhere.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [goalId]);
+
+	// Derived available status actions based on current goal status.
+	const availableStatusActions = useComputed<AvailableStatusAction[]>(() => {
+		const g = goal.value;
+		if (!g) return [];
+		const actions: AvailableStatusAction[] = [];
+		const s = g.status as GoalStatus;
+		if (s === 'active') {
+			actions.push('complete', 'needs_human');
+		} else if (s === 'needs_human') {
+			actions.push('reactivate', 'complete');
+		} else if (s === 'completed' || s === 'archived') {
+			actions.push('reactivate');
+		}
+		// 'archive' is always available except when already archived
+		if (s !== 'archived') {
+			actions.push('archive');
+		}
+		return actions;
+	});
+
+	const updateGoal = useCallback(
+		async (updates: Partial<RoomGoal>) => {
+			if (isUpdating) return;
+			setIsUpdating(true);
+			try {
+				const g = goal.value;
+				if (!g) throw new Error('Goal not found');
+				await roomStore.updateGoal(g.id, updates);
+				toast.success('Mission updated');
+			} catch (err) {
+				toast.error(err instanceof Error ? err.message : 'Failed to update mission');
+				throw err;
+			} finally {
+				setIsUpdating(false);
+			}
+		},
+		[isUpdating, goal]
+	);
+
+	const deleteGoal = useCallback(async () => {
+		const g = goal.value;
+		if (!g) return;
+		try {
+			await roomStore.deleteGoal(g.id);
+			toast.info('Mission deleted');
+			navigateToRoom(roomId);
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : 'Failed to delete mission');
+			throw err;
+		}
+	}, [goal, roomId]);
+
+	const triggerNow = useCallback(async () => {
+		if (isTriggering) return;
+		const g = goal.value;
+		if (!g) return;
+		setIsTriggering(true);
+		try {
+			await roomStore.triggerNow(g.id);
+			toast.success('Mission triggered');
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : 'Failed to trigger mission');
+			throw err;
+		} finally {
+			setIsTriggering(false);
+		}
+	}, [isTriggering, goal]);
+
+	const scheduleNext = useCallback(
+		async (nextRunAt: number) => {
+			const g = goal.value;
+			if (!g) return;
+			try {
+				await roomStore.scheduleNext(g.id, nextRunAt);
+				toast.success('Mission scheduled');
+			} catch (err) {
+				toast.error(err instanceof Error ? err.message : 'Failed to schedule mission');
+				throw err;
+			}
+		},
+		[goal]
+	);
+
+	const linkTask = useCallback(
+		async (taskId: string) => {
+			const g = goal.value;
+			if (!g) return;
+			try {
+				await roomStore.linkTaskToGoal(g.id, taskId);
+			} catch (err) {
+				toast.error(err instanceof Error ? err.message : 'Failed to link task');
+				throw err;
+			}
+		},
+		[goal]
+	);
+
+	const changeStatus = useCallback(
+		async (action: AvailableStatusAction) => {
+			const g = goal.value;
+			if (!g) return;
+			try {
+				if (action === 'complete') {
+					await roomStore.updateGoal(g.id, { status: 'completed' });
+					toast.success('Mission completed');
+				} else if (action === 'reactivate') {
+					await request('goal.reactivate', { roomId, goalId: g.id });
+					toast.success('Mission reactivated');
+				} else if (action === 'needs_human') {
+					await request('goal.needsHuman', { roomId, goalId: g.id });
+					toast.info('Mission marked as needs human input');
+				} else if (action === 'archive') {
+					await roomStore.updateGoal(g.id, { status: 'archived' });
+					toast.info('Mission archived');
+				}
+			} catch (err) {
+				toast.error(err instanceof Error ? err.message : 'Failed to change mission status');
+				throw err;
+			}
+		},
+		[goal, request, roomId]
+	);
+
+	return {
+		goal: goal.value,
+		linkedTasks: linkedTasks.value,
+		executions,
+		isLoadingExecutions,
+		isUpdating,
+		isTriggering,
+		availableStatusActions: availableStatusActions.value,
+		updateGoal,
+		deleteGoal,
+		triggerNow,
+		scheduleNext,
+		linkTask,
+		changeStatus,
+	};
+}

--- a/packages/web/src/hooks/useMissionDetailData.ts
+++ b/packages/web/src/hooks/useMissionDetailData.ts
@@ -17,7 +17,7 @@ import { toast } from '../lib/toast';
 export type AvailableStatusAction = 'complete' | 'reactivate' | 'needs_human' | 'archive';
 
 export interface UseMissionDetailDataResult {
-	/** Goal matching by UUID or short ID, null if not found */
+	/** Goal matching by UUID or short ID, null if not found or not yet loaded */
 	goal: RoomGoal | null;
 	/** Tasks linked to this goal, derived reactively */
 	linkedTasks: NeoTask[];
@@ -27,6 +27,7 @@ export interface UseMissionDetailDataResult {
 	isLoadingExecutions: boolean;
 	isUpdating: boolean;
 	isTriggering: boolean;
+	isDeleting: boolean;
 	/** Status actions available from current goal status */
 	availableStatusActions: AvailableStatusAction[];
 	/** Action handlers */
@@ -59,40 +60,42 @@ export function useMissionDetailData(roomId: string, goalId: string): UseMission
 	const [isLoadingExecutions, setIsLoadingExecutions] = useState(false);
 	const [isUpdating, setIsUpdating] = useState(false);
 	const [isTriggering, setIsTriggering] = useState(false);
+	const [isDeleting, setIsDeleting] = useState(false);
 
-	// Load execution history for recurring missions on mount (or when goalId changes).
+	// Load execution history for recurring missions. We depend on both goalId
+	// (URL change) and goal.value?.missionType so the effect re-runs when:
+	//   1. The goal arrives asynchronously after mount (null → RoomGoal).
+	//   2. The goal's missionType changes to/from 'recurring'.
+	const goalMissionType = goal.value?.missionType;
+	const resolvedGoalId = goal.value?.id;
 	useEffect(() => {
+		const g = goal.value;
+		if (!g || g.missionType !== 'recurring') return;
+
 		let cancelled = false;
+		setIsLoadingExecutions(true);
 
-		const load = async () => {
-			// Wait until goal is available before deciding whether to load executions.
-			// goal.value may be null initially while the LiveQuery snapshot arrives.
-			const g = goal.value;
-			if (!g) return;
-			if (g.missionType !== 'recurring') return;
-
-			setIsLoadingExecutions(true);
-			try {
-				const execs = await roomStore.listExecutions(g.id);
+		roomStore
+			.listExecutions(g.id)
+			.then((execs) => {
 				if (!cancelled) setExecutions(execs);
-			} catch (err) {
+			})
+			.catch((err: unknown) => {
 				if (!cancelled) {
 					toast.error(err instanceof Error ? err.message : 'Failed to load executions');
 				}
-			} finally {
+			})
+			.finally(() => {
 				if (!cancelled) setIsLoadingExecutions(false);
-			}
-		};
-
-		load();
+			});
 
 		return () => {
 			cancelled = true;
 		};
-		// We intentionally re-run when goalId changes. goal.value is read inside the
-		// async body — the reactive subscription on the computed happens elsewhere.
+		// goalId covers URL changes; resolvedGoalId+goalMissionType cover async goal arrival
+		// and missionType changes (e.g. goal arriving from null → recurring).
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [goalId]);
+	}, [goalId, resolvedGoalId, goalMissionType]);
 
 	// Derived available status actions based on current goal status.
 	const availableStatusActions = useComputed<AvailableStatusAction[]>(() => {
@@ -107,7 +110,7 @@ export function useMissionDetailData(roomId: string, goalId: string): UseMission
 		} else if (s === 'completed' || s === 'archived') {
 			actions.push('reactivate');
 		}
-		// 'archive' is always available except when already archived
+		// 'archive' is available for any non-archived status
 		if (s !== 'archived') {
 			actions.push('archive');
 		}
@@ -134,17 +137,22 @@ export function useMissionDetailData(roomId: string, goalId: string): UseMission
 	);
 
 	const deleteGoal = useCallback(async () => {
+		if (isDeleting) return;
 		const g = goal.value;
 		if (!g) return;
+		setIsDeleting(true);
 		try {
 			await roomStore.deleteGoal(g.id);
 			toast.info('Mission deleted');
+			// Navigate back to the room view; the missions list is the default room tab.
 			navigateToRoom(roomId);
 		} catch (err) {
 			toast.error(err instanceof Error ? err.message : 'Failed to delete mission');
 			throw err;
+		} finally {
+			setIsDeleting(false);
 		}
-	}, [goal, roomId]);
+	}, [isDeleting, goal, roomId]);
 
 	const triggerNow = useCallback(async () => {
 		if (isTriggering) return;
@@ -196,15 +204,18 @@ export function useMissionDetailData(roomId: string, goalId: string): UseMission
 			const g = goal.value;
 			if (!g) return;
 			try {
-				if (action === 'complete') {
-					await roomStore.updateGoal(g.id, { status: 'completed' });
-					toast.success('Mission completed');
-				} else if (action === 'reactivate') {
+				// reactivate and needs_human use dedicated RPC handlers because they carry
+				// server-side side effects (e.g. resetting consecutiveFailures, pausing schedules).
+				// complete and archive have no dedicated handlers so they go through updateGoal.
+				if (action === 'reactivate') {
 					await request('goal.reactivate', { roomId, goalId: g.id });
 					toast.success('Mission reactivated');
 				} else if (action === 'needs_human') {
 					await request('goal.needsHuman', { roomId, goalId: g.id });
 					toast.info('Mission marked as needs human input');
+				} else if (action === 'complete') {
+					await roomStore.updateGoal(g.id, { status: 'completed' });
+					toast.success('Mission completed');
 				} else if (action === 'archive') {
 					await roomStore.updateGoal(g.id, { status: 'archived' });
 					toast.info('Mission archived');
@@ -224,6 +235,7 @@ export function useMissionDetailData(roomId: string, goalId: string): UseMission
 		isLoadingExecutions,
 		isUpdating,
 		isTriggering,
+		isDeleting,
 		availableStatusActions: availableStatusActions.value,
 		updateGoal,
 		deleteGoal,


### PR DESCRIPTION
Export 9 reusable sub-components from `GoalsEditor.tsx` and create the `useMissionDetailData` hook for the upcoming MissionDetail page.

**GoalsEditor.tsx exports added:**
- `StatusIndicator`, `PriorityBadge`, `MissionTypeBadge`, `AutonomyBadge`
- `ProgressBar`, `MetricProgress`
- `RecurringScheduleInfo`, `GoalShortIdBadge`, `GoalForm` (+ `GoalFormProps` interface)

**New hook `useMissionDetailData(roomId, goalId)`:**
- `goal` — derived via `useComputed` from `roomStore.goals`, matches by UUID or short ID
- `linkedTasks` — derived reactively from `roomStore.tasks`, filtered by `goal.linkedTaskIds`
- `executions` — loaded on mount for recurring missions via `roomStore.listExecutions`
- Loading states: `isLoadingExecutions`, `isUpdating`, `isTriggering`
- Action handlers: `updateGoal`, `deleteGoal` (navigates back on success), `triggerNow`, `scheduleNext`, `linkTask`, `changeStatus`
- `availableStatusActions` derived from current goal status
- Re-exported from `hooks/index.ts` barrel