### PR TITLE
feat: wire MissionDetail view into Room component

### DIFF
--- a/packages/web/src/components/room/MissionDetail.tsx
+++ b/packages/web/src/components/room/MissionDetail.tsx
@@ -1,0 +1,55 @@
+/**
+ * MissionDetail Component
+ *
+ * Placeholder for the dedicated mission (goal) detail page.
+ * Rendered as an absolute overlay inside Room, following the same
+ * pattern as TaskViewToggle.
+ *
+ * Full implementation is tracked in the "Add dedicated Mission detail page" goal.
+ */
+
+import { navigateToRoom } from '../../lib/router';
+import { Button } from '../ui/Button';
+import { MobileMenuButton } from '../ui/MobileMenuButton';
+
+interface MissionDetailProps {
+	roomId: string;
+	goalId: string;
+}
+
+export function MissionDetail({ roomId, goalId: _goalId }: MissionDetailProps) {
+	function handleBack() {
+		navigateToRoom(roomId);
+	}
+
+	return (
+		<div class="flex flex-col h-full bg-dark-900">
+			{/* Header */}
+			<div class="flex items-center gap-3 px-4 py-3 border-b border-dark-700 shrink-0">
+				<MobileMenuButton />
+				<Button variant="ghost" size="sm" onClick={handleBack} class="gap-1.5">
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						width="16"
+						height="16"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+					>
+						<path d="M19 12H5" />
+						<path d="M12 19l-7-7 7-7" />
+					</svg>
+					Back to Room
+				</Button>
+			</div>
+
+			{/* Body */}
+			<div class="flex-1 flex items-center justify-center text-gray-500">
+				<p>Mission detail view — coming soon</p>
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/room/__tests__/MissionDetail.test.tsx
+++ b/packages/web/src/components/room/__tests__/MissionDetail.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Tests for MissionDetail Component
+ *
+ * Covers:
+ * - Renders "Mission detail view — coming soon" placeholder text
+ * - Renders "Back to Room" button text
+ * - Clicking back button calls navigateToRoom with the correct roomId
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/preact';
+import { MissionDetail } from '../MissionDetail';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockNavigateToRoom = vi.fn();
+
+vi.mock('../../../lib/router', () => ({
+	navigateToRoom: (...args: unknown[]) => mockNavigateToRoom(...args),
+}));
+
+vi.mock('../ui/Button', () => ({
+	Button: ({
+		children,
+		onClick,
+	}: {
+		children?: import('preact').ComponentChildren;
+		onClick?: () => void;
+		[key: string]: unknown;
+	}) => <button onClick={onClick}>{children}</button>,
+}));
+
+vi.mock('../ui/MobileMenuButton', () => ({
+	MobileMenuButton: () => <button data-testid="mobile-menu-button" />,
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MissionDetail', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders "Mission detail view — coming soon" placeholder text', () => {
+		const { container } = render(<MissionDetail roomId="room-1" goalId="goal-1" />);
+		expect(container.textContent).toContain('Mission detail view — coming soon');
+	});
+
+	it('renders "Back to Room" button text', () => {
+		const { container } = render(<MissionDetail roomId="room-1" goalId="goal-1" />);
+		expect(container.textContent).toContain('Back to Room');
+	});
+
+	it('calls navigateToRoom with the correct roomId when back button is clicked', () => {
+		const { container } = render(<MissionDetail roomId="room-1" goalId="goal-1" />);
+		const buttons = container.querySelectorAll('button');
+		const backButton = Array.from(buttons).find((b) => b.textContent?.includes('Back to Room'));
+		expect(backButton).toBeTruthy();
+		fireEvent.click(backButton!);
+		expect(mockNavigateToRoom).toHaveBeenCalledOnce();
+		expect(mockNavigateToRoom).toHaveBeenCalledWith('room-1');
+	});
+
+	it('calls navigateToRoom with a different roomId when roomId prop changes', () => {
+		const { container } = render(<MissionDetail roomId="room-42" goalId="goal-7" />);
+		const buttons = container.querySelectorAll('button');
+		const backButton = Array.from(buttons).find((b) => b.textContent?.includes('Back to Room'));
+		fireEvent.click(backButton!);
+		expect(mockNavigateToRoom).toHaveBeenCalledWith('room-42');
+	});
+
+	it('does not call navigateToRoom on initial render', () => {
+		render(<MissionDetail roomId="room-1" goalId="goal-1" />);
+		expect(mockNavigateToRoom).not.toHaveBeenCalled();
+	});
+});

--- a/packages/web/src/islands/MainContent.tsx
+++ b/packages/web/src/islands/MainContent.tsx
@@ -3,6 +3,7 @@ import {
 	currentRoomIdSignal,
 	currentRoomSessionIdSignal,
 	currentRoomTaskIdSignal,
+	currentRoomGoalIdSignal,
 	currentSpaceIdSignal,
 	currentSpaceSessionIdSignal,
 	currentSpaceTaskIdSignal,
@@ -36,6 +37,7 @@ export default function MainContent() {
 	const roomId = currentRoomIdSignal.value;
 	const roomSessionId = currentRoomSessionIdSignal.value;
 	const roomTaskId = currentRoomTaskIdSignal.value;
+	const roomGoalId = currentRoomGoalIdSignal.value;
 	const spaceId = currentSpaceIdSignal.value;
 	const spaceSessionViewId = currentSpaceSessionIdSignal.value;
 	const spaceTaskViewId = currentSpaceTaskIdSignal.value;
@@ -91,7 +93,13 @@ export default function MainContent() {
 		// Room route
 		if (roomId) {
 			return (
-				<Room key={roomId} roomId={roomId} sessionViewId={roomSessionId} taskViewId={roomTaskId} />
+				<Room
+					key={roomId}
+					roomId={roomId}
+					sessionViewId={roomSessionId}
+					taskViewId={roomTaskId}
+					missionViewId={roomGoalId}
+				/>
 			);
 		}
 

--- a/packages/web/src/islands/Room.tsx
+++ b/packages/web/src/islands/Room.tsx
@@ -30,6 +30,7 @@ import ChatContainer from './ChatContainer';
 import { GoalsEditor, RoomSettings, RoomAgents } from '../components/room';
 import type { CreateGoalFormData } from '../components/room/GoalsEditor';
 import { TaskViewToggle } from '../components/room/TaskViewToggle';
+import { MissionDetail } from '../components/room/MissionDetail';
 import { Skeleton } from '../components/ui/Skeleton';
 import { Button } from '../components/ui/Button';
 import { MobileMenuButton } from '../components/ui/MobileMenuButton';
@@ -42,9 +43,10 @@ interface RoomProps {
 	roomId: string;
 	sessionViewId?: string | null; // When set, show this session content instead of room tabs
 	taskViewId?: string | null; // When set, show TaskView (Craft + Lead) for this task
+	missionViewId?: string | null; // When set, show MissionDetail for this goal
 }
 
-export default function Room({ roomId, sessionViewId, taskViewId }: RoomProps) {
+export default function Room({ roomId, sessionViewId, taskViewId, missionViewId }: RoomProps) {
 	const [initialLoad, setInitialLoad] = useState(true);
 	const [activeTab, setActiveTab] = useState<RoomTab>(
 		currentRoomAgentActiveSignal.value ? 'chat' : 'overview'
@@ -368,6 +370,12 @@ export default function Room({ roomId, sessionViewId, taskViewId }: RoomProps) {
 							{taskViewId && (
 								<div class="absolute inset-0 z-10 bg-dark-900 flex flex-col overflow-hidden">
 									<TaskViewToggle key={taskViewId} roomId={roomId} taskId={taskViewId} />
+								</div>
+							)}
+							{/* Mission slide-over: overlays tab content, keeps header/tabs accessible */}
+							{missionViewId && (
+								<div class="absolute inset-0 z-10 bg-dark-900 flex flex-col overflow-hidden">
+									<MissionDetail key={missionViewId} roomId={roomId} goalId={missionViewId} />
 								</div>
 							)}
 						</div>


### PR DESCRIPTION
Wire `currentRoomGoalIdSignal` through `MainContent` → `Room` and render `MissionDetail` as an absolute overlay when a goal ID is set, following the same pattern as `TaskViewToggle`.

**Changes:**
- `MissionDetail.tsx` — placeholder component with "coming soon" body and a back button that calls `navigateToRoom(roomId)`
- `Room.tsx` — adds `missionViewId?: string | null` to `RoomProps`; renders `<MissionDetail>` in an `absolute inset-0 z-10` overlay (identical pattern to `TaskViewToggle`)
- `MainContent.tsx` — imports `currentRoomGoalIdSignal`, reads `.value` as `roomGoalId`, passes it as `missionViewId` to `<Room>`
- 5 unit tests for `MissionDetail`

Navigating to `/room/:roomId/mission/:goalId` now renders the placeholder overlay; the back button returns to the room view.