### PR TITLE
Plan: Make room tabs URL-addressable with on-demand data loading

### DIFF
--- a/docs/plans/make-room-tabs-url-addressable-with-on-demand-data-loading/00-overview.md
+++ b/docs/plans/make-room-tabs-url-addressable-with-on-demand-data-loading/00-overview.md
@@ -20,6 +20,13 @@ Make all room tabs addressable via URL (`/room/:id/tasks`, `/room/:id/goals`, et
 3. **Conditional LiveQuery subscriptions** -- Split `subscribeRoom` into per-query methods, make goals/skills subscriptions conditional on active tab
 4. **Code-splitting with lazy/Suspense** -- Lazy-load GoalsEditor, RoomAgents, RoomSettings behind `Suspense` boundaries
 
+## Design Notes
+
+- **Overview tab has no URL sub-path.** `/room/:id` maps to the overview tab. There is no `/room/:id/overview` route. This means `navigateToRoomTab(id, 'overview')` delegates to `navigateToRoom` and does not add an `/overview` segment. Bookmarking the overview tab and bookmarking the root room URL are identical.
+- **Chat tab uses the existing `/room/:id/agent` route.** `navigateToRoomTab(id, 'chat')` delegates to `navigateToRoomAgent`. No new `/room/:id/chat` route is added.
+- **Tab navigation uses `pushState` (not `replaceState`)** to match `navigateToRoomAgent` behavior. This means browser back/forward navigates between tabs.
+- **`navigateToRoom` does not set `currentRoomActiveTabSignal`** (intentional existing invariant). `navigateToRoomTab` handles setting the signal explicitly after delegation.
+
 ## Cross-Milestone Dependencies
 
 - Milestone 2 depends on Milestone 1 (needs `navigateToRoomTab` and tab route patterns)

--- a/docs/plans/make-room-tabs-url-addressable-with-on-demand-data-loading/00-overview.md
+++ b/docs/plans/make-room-tabs-url-addressable-with-on-demand-data-loading/00-overview.md
@@ -1,0 +1,31 @@
+# Make Room Tabs URL-Addressable with On-Demand Data Loading
+
+## Goal
+
+Make all room tabs addressable via URL (`/room/:id/tasks`, `/room/:id/goals`, etc.) and load LiveQuery data only when the relevant tab is active. This improves deep-linking, browser history navigation, and reduces unnecessary data fetching.
+
+## Approach
+
+1. Add route patterns and navigation functions for each room tab sub-path in the router
+2. Update `handlePopState` and `initializeRouter` to parse tab from URL and set `currentRoomActiveTabSignal`
+3. Replace local `useState<RoomTab>` in Room.tsx with signal-driven tab state from the URL
+4. Migrate all callers of `currentRoomTabSignal` (the transient pending-tab signal) to use the new `navigateToRoomTab` function
+5. Split `subscribeRoom` in room-store into per-query subscribe/unsubscribe methods so goals and skills LiveQueries only run when their tab is active
+6. Add `lazy()` + `Suspense` code-splitting for GoalsEditor, RoomAgents, and RoomSettings
+
+## Milestones
+
+1. **Router: Add room tab routes and navigation** -- Add route patterns, path creators, extractors, `navigateToRoomTab`, and update `handlePopState`/`initializeRouter`/`getRoomIdFromPath`
+2. **Room.tsx: Drive tab state from URL** -- Replace `useState` with `currentRoomActiveTabSignal`, update tab click handlers and all cross-file callers (BottomTabBar, RoomDashboard, TaskHeader, RoomContextPanel)
+3. **Conditional LiveQuery subscriptions** -- Split `subscribeRoom` into per-query methods, make goals/skills subscriptions conditional on active tab
+4. **Code-splitting with lazy/Suspense** -- Lazy-load GoalsEditor, RoomAgents, RoomSettings behind `Suspense` boundaries
+
+## Cross-Milestone Dependencies
+
+- Milestone 2 depends on Milestone 1 (needs `navigateToRoomTab` and tab route patterns)
+- Milestone 3 depends on Milestone 2 (needs `currentRoomActiveTabSignal` driven by URL to know which tab is active)
+- Milestone 4 is independent and can run in parallel with Milestone 3
+
+## Total Estimated Tasks
+
+7 tasks across 4 milestones

--- a/docs/plans/make-room-tabs-url-addressable-with-on-demand-data-loading/01-router-room-tab-routes.md
+++ b/docs/plans/make-room-tabs-url-addressable-with-on-demand-data-loading/01-router-room-tab-routes.md
@@ -33,19 +33,21 @@ All changes are in `packages/web/src/lib/router.ts` and its test file `packages/
 
 4. Update `getRoomIdFromPath` to also match the four new tab patterns (add checks before the legacy chat compat check, after the mission pattern check).
 
-5. Add a `navigateToRoomTab(roomId: string, tab: string, replace = true): void` function:
+5. Add a `navigateToRoomTab(roomId: string, tab: string, replace = false): void` function:
    - If `tab === 'chat'`, delegate to `navigateToRoomAgent(roomId, replace)` and return.
-   - If `tab === 'overview'`, delegate to `navigateToRoom(roomId, replace)` and return (overview has no sub-path).
+   - If `tab === 'overview'`, delegate to `navigateToRoom(roomId, replace)` and return (overview has no sub-path). **Important:** `navigateToRoom` does NOT set `currentRoomActiveTabSignal` (this is an intentional design choice documented in `navigate-to-room-tab-reset.test.ts`). After delegating, explicitly set `currentRoomActiveTabSignal.value = 'overview'`.
    - For other tabs, compute the target path using the appropriate path creator.
    - Follow the same guard/signal-clearing pattern as `navigateToRoomAgent`:
      - Guard `routerState.isNavigating`
      - Check same-path early return (still update signals)
-     - `replaceState` or `pushState` based on `replace` parameter (default `true` since tab changes should not pollute history)
+     - `pushState` or `replaceState` based on `replace` parameter (default `false` to match `navigateToRoomAgent` behavior and enable proper browser back/forward between tabs)
      - Set `currentRoomIdSignal.value = roomId`
-     - Clear `currentRoomSessionIdSignal`, `currentRoomTaskIdSignal`, `currentRoomGoalIdSignal`, `currentRoomAgentActiveSignal`, `currentSessionIdSignal`, `currentSpaceIdSignal`, `currentSpaceSessionIdSignal`, `currentSpaceTaskIdSignal`
+     - Clear `currentRoomSessionIdSignal`, `currentRoomTaskIdSignal`, `currentRoomGoalIdSignal`, `currentSessionIdSignal`, `currentSpaceIdSignal`, `currentSpaceSessionIdSignal`, `currentSpaceTaskIdSignal`
+     - Explicitly set `currentRoomAgentActiveSignal.value = false` (the agent route is not active when viewing a tab)
      - Set `currentRoomActiveTabSignal.value = tab`
      - Set `navSectionSignal.value = 'rooms'`
    - Use the same `setTimeout(() => { routerState.isNavigating = false }, 0)` pattern in `finally`.
+   - **Design note:** `replace` defaults to `false` (pushState) to match `navigateToRoomAgent` behavior. This means navigating Overview → Tasks → Goals allows the back button to go Goals → Tasks → Overview. This is consistent with the chat tab navigation.
 
 6. Export `navigateToRoomTab`, `getRoomTabFromPath`, and all four path creators.
 
@@ -55,9 +57,10 @@ All changes are in `packages/web/src/lib/router.ts` and its test file `packages/
 - `getRoomTabFromPath('/room/abc-123/agent')` returns `{ roomId: 'abc-123', tab: 'chat' }`
 - `getRoomTabFromPath('/room/abc-123')` returns `null` (overview has no sub-path, handled by existing `getRoomIdFromPath`)
 - `getRoomIdFromPath` returns the roomId for all four new tab paths
-- `navigateToRoomTab(id, 'tasks')` updates the URL to `/room/<id>/tasks` and sets `currentRoomActiveTabSignal.value` to `'tasks'`
-- `navigateToRoomTab(id, 'overview')` delegates to `navigateToRoom`
+- `navigateToRoomTab(id, 'tasks')` updates the URL to `/room/<id>/tasks`, sets `currentRoomActiveTabSignal.value` to `'tasks'`, and sets `currentRoomAgentActiveSignal.value` to `false`
+- `navigateToRoomTab(id, 'overview')` delegates to `navigateToRoom` and explicitly sets `currentRoomActiveTabSignal.value = 'overview'`
 - `navigateToRoomTab(id, 'chat')` delegates to `navigateToRoomAgent`
+- `navigateToRoomTab` defaults `replace` to `false` (consistent with `navigateToRoomAgent`)
 - All new functions have unit tests in `router.test.ts`
 
 **Dependencies:** None
@@ -76,20 +79,28 @@ Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 1. In `handlePopState`, add a new variable: `const roomTab = getRoomTabFromPath(path)`.
 
-2. Insert a new `else if (roomTab)` branch **after** `roomAgent` and **before** `roomMission` in the if/else chain. This is critical -- tab routes must be matched before the plain `roomId` catch-all but after the agent route (which has its own special handling). The branch should:
+2. Insert a new `else if (roomTab)` branch in the if/else chain. **Exact position matters.** The current `handlePopState` branch order is: `roomAgent → roomMission → roomTask → roomSession → roomId`. The new `roomTab` branch must be inserted **after `roomAgent` and before `roomMission`**, giving: `roomAgent → roomTab → roomMission → roomTask → roomSession → roomId`. This ensures tab routes (e.g., `/room/:id/tasks`) are matched before the plain `roomId` catch-all, and before `roomMission`/`roomTask`/`roomSession` (whose regexes include an additional ID segment and won't collide). The branch should:
    - Set `currentRoomIdSignal.value = roomTab.roomId`
    - Set `currentRoomActiveTabSignal.value = roomTab.tab`
-   - Clear all other signals (`currentRoomSessionIdSignal`, `currentRoomTaskIdSignal`, `currentRoomGoalIdSignal`, `currentRoomAgentActiveSignal`, `currentSessionIdSignal`, `currentSpaceIdSignal`, `currentSpaceSessionIdSignal`, `currentSpaceTaskIdSignal`, `currentSpaceViewModeSignal`)
+   - Set `currentRoomAgentActiveSignal.value = false`
+   - Clear all other signals (`currentRoomSessionIdSignal`, `currentRoomTaskIdSignal`, `currentRoomGoalIdSignal`, `currentSessionIdSignal`, `currentSpaceIdSignal`, `currentSpaceSessionIdSignal`, `currentSpaceTaskIdSignal`, `currentSpaceViewModeSignal`)
    - Set `navSectionSignal.value = 'rooms'`
 
 3. In the existing `roomId` (plain room) branch of `handlePopState`, add: `currentRoomActiveTabSignal.value = 'overview'` so that navigating back to `/room/:id` resets the tab.
 
-4. Mirror the exact same changes in `initializeRouter`:
+4. **Reset `currentRoomActiveTabSignal` in non-tab room sub-route branches.** When the user navigates from `/room/:id/goals` to `/room/:id/task/:taskId` via browser back, the `roomTask` branch fires (not the `roomTab` branch). If `currentRoomActiveTabSignal` is not reset, it will retain the stale value `'goals'`, causing incorrect tab rendering or unnecessary LiveQuery subscriptions. Add `currentRoomActiveTabSignal.value = null` to the following `handlePopState` branches:
+   - `roomMission` branch
+   - `roomTask` branch
+   - `roomSession` branch
+   - `sessionId` branch (non-room session)
+
+5. Mirror the exact same changes in `initializeRouter`:
    - Add `const initialRoomTab = getRoomTabFromPath(initialPath)`
    - Insert `else if (initialRoomTab)` branch in the same position (after `initialRoomAgent`, before `initialRoomMission`)
    - In the `initialRoomId` branch, add `currentRoomActiveTabSignal.value = 'overview'`
+   - In the `initialRoomMission`, `initialRoomTask`, `initialRoomSession`, and `initialSessionId` branches, add `currentRoomActiveTabSignal.value = null`
 
-5. Add unit tests verifying:
+6. Add unit tests verifying:
    - `handlePopState` correctly sets `currentRoomActiveTabSignal` when URL is `/room/:id/goals`
    - `initializeRouter` correctly sets `currentRoomActiveTabSignal` when page loads at `/room/:id/settings`
    - Browser back from `/room/:id/tasks` to `/room/:id` resets `currentRoomActiveTabSignal` to `'overview'`

--- a/docs/plans/make-room-tabs-url-addressable-with-on-demand-data-loading/01-router-room-tab-routes.md
+++ b/docs/plans/make-room-tabs-url-addressable-with-on-demand-data-loading/01-router-room-tab-routes.md
@@ -1,0 +1,109 @@
+# Milestone 1: Router -- Add Room Tab Routes and Navigation
+
+## Goal
+
+Extend the SPA router to recognize room tab sub-paths (`/room/:id/tasks`, `/room/:id/agents`, `/room/:id/goals`, `/room/:id/settings`) and provide navigation functions that update the URL and `currentRoomActiveTabSignal`.
+
+## Scope
+
+All changes are in `packages/web/src/lib/router.ts` and its test file `packages/web/src/lib/__tests__/router.test.ts`. The existing `navigateToRoom` (plain `/room/:id`) continues to work and maps to the "overview" tab.
+
+---
+
+### Task 1: Add room tab route patterns, extractors, and path creators
+
+**Description:** Add the route infrastructure for four new room tab sub-paths. Follow the existing pattern established by `ROOM_AGENT_ROUTE_PATTERN` and its associated helpers.
+
+**Subtasks:**
+
+1. Add four route pattern constants after `ROOM_MISSION_ROUTE_PATTERN`:
+   - `ROOM_TASKS_ROUTE_PATTERN` = `/^\/room\/([a-f0-9-]+)\/tasks$/`
+   - `ROOM_AGENTS_ROUTE_PATTERN` = `/^\/room\/([a-f0-9-]+)\/agents$/`
+   - `ROOM_GOALS_ROUTE_PATTERN` = `/^\/room\/([a-f0-9-]+)\/goals$/`
+   - `ROOM_SETTINGS_ROUTE_PATTERN` = `/^\/room\/([a-f0-9-]+)\/settings$/`
+   - Note: `ROOM_TASKS_ROUTE_PATTERN` (`/tasks`) must not collide with `ROOM_TASK_ROUTE_PATTERN` (`/task/:id`) -- the trailing `s` and lack of second capture group distinguishes them.
+
+2. Add extractor function `getRoomTabFromPath(path: string): { roomId: string; tab: string } | null` that tests each of the four tab patterns plus the agent pattern (maps to 'chat') and returns the roomId and tab name, or null.
+
+3. Add path creator functions:
+   - `createRoomTasksPath(roomId: string): string` returning `/room/${roomId}/tasks`
+   - `createRoomAgentsPath(roomId: string): string` returning `/room/${roomId}/agents`
+   - `createRoomGoalsPath(roomId: string): string` returning `/room/${roomId}/goals`
+   - `createRoomSettingsPath(roomId: string): string` returning `/room/${roomId}/settings`
+
+4. Update `getRoomIdFromPath` to also match the four new tab patterns (add checks before the legacy chat compat check, after the mission pattern check).
+
+5. Add a `navigateToRoomTab(roomId: string, tab: string, replace = true): void` function:
+   - If `tab === 'chat'`, delegate to `navigateToRoomAgent(roomId, replace)` and return.
+   - If `tab === 'overview'`, delegate to `navigateToRoom(roomId, replace)` and return (overview has no sub-path).
+   - For other tabs, compute the target path using the appropriate path creator.
+   - Follow the same guard/signal-clearing pattern as `navigateToRoomAgent`:
+     - Guard `routerState.isNavigating`
+     - Check same-path early return (still update signals)
+     - `replaceState` or `pushState` based on `replace` parameter (default `true` since tab changes should not pollute history)
+     - Set `currentRoomIdSignal.value = roomId`
+     - Clear `currentRoomSessionIdSignal`, `currentRoomTaskIdSignal`, `currentRoomGoalIdSignal`, `currentRoomAgentActiveSignal`, `currentSessionIdSignal`, `currentSpaceIdSignal`, `currentSpaceSessionIdSignal`, `currentSpaceTaskIdSignal`
+     - Set `currentRoomActiveTabSignal.value = tab`
+     - Set `navSectionSignal.value = 'rooms'`
+   - Use the same `setTimeout(() => { routerState.isNavigating = false }, 0)` pattern in `finally`.
+
+6. Export `navigateToRoomTab`, `getRoomTabFromPath`, and all four path creators.
+
+**Acceptance Criteria:**
+
+- `getRoomTabFromPath('/room/abc-123/tasks')` returns `{ roomId: 'abc-123', tab: 'tasks' }`
+- `getRoomTabFromPath('/room/abc-123/agent')` returns `{ roomId: 'abc-123', tab: 'chat' }`
+- `getRoomTabFromPath('/room/abc-123')` returns `null` (overview has no sub-path, handled by existing `getRoomIdFromPath`)
+- `getRoomIdFromPath` returns the roomId for all four new tab paths
+- `navigateToRoomTab(id, 'tasks')` updates the URL to `/room/<id>/tasks` and sets `currentRoomActiveTabSignal.value` to `'tasks'`
+- `navigateToRoomTab(id, 'overview')` delegates to `navigateToRoom`
+- `navigateToRoomTab(id, 'chat')` delegates to `navigateToRoomAgent`
+- All new functions have unit tests in `router.test.ts`
+
+**Dependencies:** None
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 2: Update handlePopState and initializeRouter for tab routes
+
+**Description:** Add room tab route matching to the `handlePopState` and `initializeRouter` if/else chains so that browser back/forward and direct URL entry correctly restore the active tab.
+
+**Subtasks:**
+
+1. In `handlePopState`, add a new variable: `const roomTab = getRoomTabFromPath(path)`.
+
+2. Insert a new `else if (roomTab)` branch **after** `roomAgent` and **before** `roomMission` in the if/else chain. This is critical -- tab routes must be matched before the plain `roomId` catch-all but after the agent route (which has its own special handling). The branch should:
+   - Set `currentRoomIdSignal.value = roomTab.roomId`
+   - Set `currentRoomActiveTabSignal.value = roomTab.tab`
+   - Clear all other signals (`currentRoomSessionIdSignal`, `currentRoomTaskIdSignal`, `currentRoomGoalIdSignal`, `currentRoomAgentActiveSignal`, `currentSessionIdSignal`, `currentSpaceIdSignal`, `currentSpaceSessionIdSignal`, `currentSpaceTaskIdSignal`, `currentSpaceViewModeSignal`)
+   - Set `navSectionSignal.value = 'rooms'`
+
+3. In the existing `roomId` (plain room) branch of `handlePopState`, add: `currentRoomActiveTabSignal.value = 'overview'` so that navigating back to `/room/:id` resets the tab.
+
+4. Mirror the exact same changes in `initializeRouter`:
+   - Add `const initialRoomTab = getRoomTabFromPath(initialPath)`
+   - Insert `else if (initialRoomTab)` branch in the same position (after `initialRoomAgent`, before `initialRoomMission`)
+   - In the `initialRoomId` branch, add `currentRoomActiveTabSignal.value = 'overview'`
+
+5. Add unit tests verifying:
+   - `handlePopState` correctly sets `currentRoomActiveTabSignal` when URL is `/room/:id/goals`
+   - `initializeRouter` correctly sets `currentRoomActiveTabSignal` when page loads at `/room/:id/settings`
+   - Browser back from `/room/:id/tasks` to `/room/:id` resets `currentRoomActiveTabSignal` to `'overview'`
+   - Tab routes do not interfere with existing sub-routes (`/room/:id/task/:taskId`, `/room/:id/mission/:missionId`, `/room/:id/session/:sessionId`)
+
+**Acceptance Criteria:**
+
+- Direct navigation to `/room/abc/goals` in a fresh page load sets `currentRoomActiveTabSignal.value === 'goals'` and `currentRoomIdSignal.value === 'abc'`
+- Browser back/forward between `/room/abc/tasks` and `/room/abc` correctly toggles `currentRoomActiveTabSignal` between `'tasks'` and `'overview'`
+- Existing room sub-routes (`/room/:id/agent`, `/room/:id/task/:id`, `/room/:id/mission/:id`, `/room/:id/session/:id`) continue to work without regression
+- Tests pass with `cd packages/web && bunx vitest run src/lib/__tests__/router.test.ts`
+
+**Dependencies:** Task 1 (needs `getRoomTabFromPath` and route patterns)
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.

--- a/docs/plans/make-room-tabs-url-addressable-with-on-demand-data-loading/02-room-tab-state-from-url.md
+++ b/docs/plans/make-room-tabs-url-addressable-with-on-demand-data-loading/02-room-tab-state-from-url.md
@@ -1,0 +1,108 @@
+# Milestone 2: Room.tsx -- Drive Tab State from URL
+
+## Goal
+
+Replace the local `useState<RoomTab>` in Room.tsx with URL-driven tab state via `currentRoomActiveTabSignal`, and migrate all cross-file callers of `currentRoomTabSignal` (the transient pending-tab signal) to use `navigateToRoomTab`.
+
+## Scope
+
+Primary files: `packages/web/src/islands/Room.tsx`, `packages/web/src/islands/BottomTabBar.tsx`, `packages/web/src/components/room/RoomDashboard.tsx`, `packages/web/src/components/room/task-shared/TaskHeader.tsx`, `packages/web/src/islands/RoomContextPanel.tsx`, and their test files.
+
+---
+
+### Task 3: Replace useState with signal-driven tab in Room.tsx
+
+**Description:** Remove the local `activeTab` state in Room.tsx and read the active tab directly from `currentRoomActiveTabSignal`. Update `handleTabChange` to call `navigateToRoomTab` instead of managing signals manually.
+
+**Subtasks:**
+
+1. Remove `useState<RoomTab>` from Room.tsx. Read the active tab as:
+   ```ts
+   const activeTab: RoomTab = (currentRoomActiveTabSignal.value as RoomTab) ?? 'overview';
+   ```
+
+2. Simplify `handleTabChange` to just call `navigateToRoomTab(roomId, tab)`. Remove the manual signal setting and the conditional `navigateToRoomAgent`/`navigateToRoom` branching -- `navigateToRoomTab` handles all of that internally.
+
+3. Remove the `useEffect` that watches `currentRoomTabSignal` (the pending-tab signal). This was the indirection layer for cross-component tab navigation. After this change, cross-component callers will use `navigateToRoomTab` directly, which updates `currentRoomActiveTabSignal` and the URL atomically.
+
+4. Remove the `useEffect` that watches `currentRoomAgentActiveSignal` to set `activeTab('chat')`. This is no longer needed because `navigateToRoomAgent` already sets `currentRoomActiveTabSignal.value = 'chat'`.
+
+5. In the room cleanup effect (`return () => { ... }` in the `[roomId]` useEffect), keep clearing `currentRoomActiveTabSignal.value = null`. Remove the `currentRoomTabSignal.value = null` line (the transient signal is no longer used by Room.tsx).
+
+6. Update the inline `onGoalClick` handler in the tasks tab (line ~319) from `currentRoomTabSignal.value = 'goals'` to `navigateToRoomTab(roomId, 'goals')`.
+
+7. Update `Room.tsx` imports: add `navigateToRoomTab` from router, remove `navigateToRoom` and `navigateToRoomAgent` if they are no longer directly used. Keep `currentRoomActiveTabSignal`. Remove `currentRoomTabSignal` import if no longer referenced. Keep `currentRoomAgentActiveSignal` if still read (for `isSessionTakeover` check).
+
+8. Update `packages/web/src/islands/__tests__/Room.test.tsx` to reflect the new behavior: tab clicks should result in `navigateToRoomTab` calls, not direct signal mutations.
+
+**Acceptance Criteria:**
+
+- Room.tsx has no `useState` for tab management
+- Tab clicks update the URL (verified via `navigateToRoomTab` mock in tests)
+- `currentRoomActiveTabSignal` is the single source of truth for which tab is shown
+- The `currentRoomTabSignal` (transient pending-tab) is no longer imported or used in Room.tsx
+- Tests pass with `cd packages/web && bunx vitest run src/islands/__tests__/Room.test.tsx`
+
+**Dependencies:** Milestone 1 Task 1 and Task 2 (needs `navigateToRoomTab`)
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 4: Migrate cross-file callers to navigateToRoomTab
+
+**Description:** Update BottomTabBar, RoomDashboard, TaskHeader, and RoomContextPanel to use `navigateToRoomTab` instead of setting `currentRoomTabSignal` directly. After this task, `currentRoomTabSignal` can potentially be removed (or kept only if other consumers remain).
+
+**Subtasks:**
+
+1. **BottomTabBar.tsx** (`packages/web/src/islands/BottomTabBar.tsx`):
+   - Import `navigateToRoomTab` from router.
+   - In `handleTabClick`, replace the `room-overview`, `room-tasks`, `room-agents`, `room-missions` cases:
+     - `room-overview`: `navigateToRoomTab(roomId, 'overview')` (instead of setting `currentRoomTabSignal.value = 'overview'` + `navigateToRoom`)
+     - `room-tasks`: `navigateToRoomTab(roomId, 'tasks')`
+     - `room-agents`: `navigateToRoomTab(roomId, 'agents')`
+     - `room-missions`: `navigateToRoomTab(roomId, 'goals')`
+   - Remove `currentRoomTabSignal` import if no longer used.
+   - Update `packages/web/src/islands/__tests__/BottomTabBar.test.tsx` accordingly.
+
+2. **RoomDashboard.tsx** (`packages/web/src/components/room/RoomDashboard.tsx`):
+   - Import `navigateToRoomTab` from router.
+   - Need the roomId -- check if it's available via props or `currentRoomIdSignal`. Currently RoomDashboard reads from `roomStore.room.value`, so `roomStore.room.value?.id` can provide the roomId.
+   - Replace `currentRoomTabSignal.value = 'tasks'` (line ~277, ~283, ~289) with `navigateToRoomTab(roomStore.room.value!.id, 'tasks')`.
+   - Remove `currentRoomTabSignal` import.
+   - Update `packages/web/src/components/room/RoomDashboard.test.tsx`.
+
+3. **TaskHeader.tsx** (`packages/web/src/components/room/task-shared/TaskHeader.tsx`):
+   - Import `navigateToRoomTab` from router.
+   - Replace `currentRoomTabSignal.value = 'goals'` (line ~112) with `navigateToRoomTab(roomId, 'goals')` -- the roomId is available from `currentRoomIdSignal` or the component's props. Check the component's context to determine the best source.
+   - Remove `currentRoomTabSignal` import.
+   - Update `packages/web/src/components/room/task-shared/__tests__/TaskHeader.test.tsx`.
+
+4. **RoomContextPanel.tsx** (`packages/web/src/islands/RoomContextPanel.tsx`):
+   - Import `navigateToRoomTab` from router.
+   - Replace `currentRoomTabSignal.value = 'goals'` (line ~95) with `navigateToRoomTab(roomId, 'goals')`.
+   - Replace `currentRoomTabSignal.value = 'tasks'` (line ~101) with `navigateToRoomTab(roomId, 'tasks')`.
+   - The roomId should be available from `currentRoomIdSignal.value` or equivalent.
+   - Remove `currentRoomTabSignal` import.
+   - Update `packages/web/src/islands/__tests__/RoomContextPanel.test.tsx`.
+
+5. Search for any remaining references to `currentRoomTabSignal` (excluding signal definition and test mocks). If all consumers are migrated, add a deprecation comment on the signal definition in `signals.ts` or remove it entirely if safe.
+
+6. Run full web test suite to confirm no regressions: `cd packages/web && bunx vitest run`.
+
+**Acceptance Criteria:**
+
+- No production code (non-test) sets `currentRoomTabSignal.value = ...` -- all tab navigation goes through `navigateToRoomTab`
+- BottomTabBar tab clicks update the URL to `/room/:id/tasks` etc.
+- Goal badge clicks in TaskHeader and RoomContextPanel navigate to `/room/:id/goals`
+- RoomDashboard "view all tasks" links navigate to `/room/:id/tasks`
+- All affected test files updated and passing
+- `cd packages/web && bunx vitest run` passes
+
+**Dependencies:** Task 3 (Room.tsx must be migrated first so the pending-tab useEffect is removed)
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.

--- a/docs/plans/make-room-tabs-url-addressable-with-on-demand-data-loading/02-room-tab-state-from-url.md
+++ b/docs/plans/make-room-tabs-url-addressable-with-on-demand-data-loading/02-room-tab-state-from-url.md
@@ -70,7 +70,7 @@ Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 2. **RoomDashboard.tsx** (`packages/web/src/components/room/RoomDashboard.tsx`):
    - Import `navigateToRoomTab` from router.
    - Need the roomId -- check if it's available via props or `currentRoomIdSignal`. Currently RoomDashboard reads from `roomStore.room.value`, so `roomStore.room.value?.id` can provide the roomId.
-   - Replace `currentRoomTabSignal.value = 'tasks'` (line ~277, ~283, ~289) with `navigateToRoomTab(roomStore.room.value!.id, 'tasks')`.
+   - Replace `currentRoomTabSignal.value = 'tasks'` (line ~277, ~283, ~289) with `navigateToRoomTab(roomStore.room.value!.id, 'tasks')`. **Safety note:** The non-null assertion (`!`) is safe here because `RoomDashboard` only renders when a room is loaded (the parent component guards this). However, if the implementer prefers defensive coding, use `const roomId = roomStore.room.value?.id; if (roomId) navigateToRoomTab(roomId, 'tasks');`.
    - Remove `currentRoomTabSignal` import.
    - Update `packages/web/src/components/room/RoomDashboard.test.tsx`.
 
@@ -88,7 +88,12 @@ Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
    - Remove `currentRoomTabSignal` import.
    - Update `packages/web/src/islands/__tests__/RoomContextPanel.test.tsx`.
 
-5. Search for any remaining references to `currentRoomTabSignal` (excluding signal definition and test mocks). If all consumers are migrated, add a deprecation comment on the signal definition in `signals.ts` or remove it entirely if safe.
+5. **Concrete `currentRoomTabSignal` cleanup.** After migrating all callers:
+   - Run `grep -r 'currentRoomTabSignal' packages/web/src/ --include='*.ts' --include='*.tsx' -l` to find all remaining references.
+   - Remove the `currentRoomTabSignal` export from `packages/web/src/lib/signals.ts`.
+   - Update any test files that mock or reference `currentRoomTabSignal` to use `currentRoomActiveTabSignal` instead.
+   - Remove the `navigate-to-room-tab-reset.test.ts` test file (tests the old pending-tab mechanism which no longer applies) or rewrite it to test the new `navigateToRoomTab` behavior.
+   - **Acceptance criterion:** No non-test file imports `currentRoomTabSignal`. The signal definition is removed from `signals.ts`.
 
 6. Run full web test suite to confirm no regressions: `cd packages/web && bunx vitest run`.
 

--- a/docs/plans/make-room-tabs-url-addressable-with-on-demand-data-loading/03-conditional-livequery.md
+++ b/docs/plans/make-room-tabs-url-addressable-with-on-demand-data-loading/03-conditional-livequery.md
@@ -1,0 +1,113 @@
+# Milestone 3: Conditional LiveQuery Subscriptions
+
+## Goal
+
+Make goals and skills LiveQuery subscriptions conditional on the active tab, so data is only fetched and kept in sync when the user is actually viewing it. Tasks LiveQuery remains always-on (needed by overview dashboard, tasks tab, and goals editor).
+
+## Scope
+
+Primary files: `packages/web/src/lib/room-store.ts`, `packages/web/src/hooks/useRoomLiveQuery.ts`, and their test files.
+
+---
+
+### Task 5: Split room-store subscribeRoom into per-query methods
+
+**Description:** Refactor the monolithic `subscribeRoom` method into separate per-query subscription methods so that goals and skills subscriptions can be managed independently of the always-on tasks subscription.
+
+**Subtasks:**
+
+1. Add three new methods to the room store class:
+   - `subscribeRoomTasks(roomId: string): Promise<void>` -- subscribes to `tasks.byRoom` LiveQuery only
+   - `subscribeRoomGoals(roomId: string): Promise<void>` -- subscribes to `goals.byRoom` LiveQuery only
+   - `subscribeRoomSkills(roomId: string): Promise<void>` -- subscribes to `skills.byRoom` LiveQuery only
+
+   Each method should follow the same pattern as the current `subscribeRoom` but for a single query:
+   - Guard against double-subscription using a per-query key (e.g., `tasks-${roomId}`, `goals-${roomId}`, `skills-${roomId}`) in `liveQueryActive`
+   - Register snapshot and delta event handlers before sending the subscribe request
+   - Handle reconnect (re-subscribe on `onConnection('connected')`)
+   - Track cleanup functions in `liveQueryCleanups` keyed by the per-query key
+   - Maintain the stale-event guard pattern with `activeSubscriptionIds`
+
+2. Add three corresponding unsubscribe methods:
+   - `unsubscribeRoomTasks(roomId: string): void`
+   - `unsubscribeRoomGoals(roomId: string): void`
+   - `unsubscribeRoomSkills(roomId: string): void`
+
+   Each clears its per-query key from `liveQueryActive`, `activeSubscriptionIds`, and runs its cleanup functions from `liveQueryCleanups`.
+
+3. Rewrite the existing `subscribeRoom(roomId)` to call all three new methods (preserving backward compatibility for any callers). Similarly, `unsubscribeRoom(roomId)` should call all three unsubscribe methods.
+
+4. Preserve the existing `goalStore.loading` management: set `goalStore.loading.value = true` at the start of `subscribeRoomGoals`, clear it on snapshot arrival or error.
+
+5. Add unit tests for the new per-query methods in `packages/web/src/hooks/__tests__/useRoomLiveQuery.test.ts` or a new test file `packages/web/src/lib/__tests__/room-store-livequery.test.ts`:
+   - Verify that subscribing to goals only sends the `goals.byRoom` LiveQuery subscribe request
+   - Verify that unsubscribing from goals does not affect the tasks subscription
+   - Verify that the stale-event guard works per-query (unsubscribe goals, then simulate a stale goals snapshot -- should be discarded)
+
+**Acceptance Criteria:**
+
+- `subscribeRoomTasks`, `subscribeRoomGoals`, `subscribeRoomSkills` can be called independently
+- Unsubscribing one query does not affect the others
+- The existing `subscribeRoom`/`unsubscribeRoom` still work as before (calls all three)
+- No regressions in existing room-store tests
+- `cd packages/web && bunx vitest run` passes
+
+**Dependencies:** None (can be done in parallel with Milestone 2, but Milestone 2 must land first for the hook changes in Task 6)
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+### Task 6: Make useRoomLiveQuery tab-aware
+
+**Description:** Update the `useRoomLiveQuery` hook to subscribe to tasks always, but subscribe to goals only when the active tab is `'goals'` and skills only when the active tab is `'agents'` or `'settings'`.
+
+**Subtasks:**
+
+1. Import `currentRoomActiveTabSignal` in `useRoomLiveQuery.ts`.
+
+2. Change the hook to accept the active tab as a parameter or read it from the signal directly. Reading from the signal is simpler since Preact signals auto-subscribe in render context, but inside `useEffect` we need to read `currentRoomActiveTabSignal.value` explicitly. The cleanest approach: pass `activeTab` as a second parameter so the hook can react to it as a dependency.
+
+   Recommended signature change:
+   ```ts
+   export function useRoomLiveQuery(roomId: string, activeTab: string | null): void
+   ```
+
+3. In the hook body, manage three separate `useEffect` blocks:
+   - **Tasks** (`[roomId]` dependency): always subscribe/unsubscribe via `roomStore.subscribeRoomTasks(roomId)` / `roomStore.unsubscribeRoomTasks(roomId)`.
+   - **Goals** (`[roomId, activeTab]` dependency): subscribe via `roomStore.subscribeRoomGoals(roomId)` only when `activeTab === 'goals'`. Unsubscribe when tab changes away or on unmount.
+   - **Skills** (`[roomId, activeTab]` dependency): subscribe via `roomStore.subscribeRoomSkills(roomId)` only when `activeTab === 'agents' || activeTab === 'settings'`. Unsubscribe when tab changes away or on unmount.
+
+4. Update the call site in Room.tsx to pass the active tab:
+   ```ts
+   useRoomLiveQuery(roomId, currentRoomActiveTabSignal.value ?? 'overview');
+   ```
+
+5. Handle edge cases:
+   - When the user navigates directly to `/room/:id/goals`, the hook mounts with `activeTab === 'goals'` and subscribes to goals immediately.
+   - When switching from goals to tasks tab, goals subscription is torn down, tasks continues.
+   - When switching from tasks to goals, goals subscription starts fresh (snapshot will be pushed).
+   - The goals LiveQuery snapshot handler already manages `goalStore.loading`, so switching tabs shows a brief loading state while the snapshot arrives.
+
+6. Update `packages/web/src/hooks/__tests__/useRoomLiveQuery.test.ts`:
+   - Test that mounting with `activeTab='overview'` only subscribes to tasks
+   - Test that changing `activeTab` to `'goals'` triggers goals subscription
+   - Test that changing `activeTab` away from `'goals'` triggers goals unsubscription
+   - Test that tasks subscription persists across tab changes
+
+**Acceptance Criteria:**
+
+- On room entry (overview tab), only `tasks.byRoom` LiveQuery is subscribed
+- Switching to goals tab triggers `goals.byRoom` subscription; switching away tears it down
+- Switching to agents or settings tab triggers `skills.byRoom` subscription; switching away tears it down
+- Tasks LiveQuery stays active regardless of tab
+- No stale data: when goals tab is re-entered, a fresh snapshot is received
+- `cd packages/web && bunx vitest run` passes
+
+**Dependencies:** Task 5 (needs per-query subscribe/unsubscribe methods), Task 3 (Room.tsx must pass activeTab from signal)
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.

--- a/docs/plans/make-room-tabs-url-addressable-with-on-demand-data-loading/03-conditional-livequery.md
+++ b/docs/plans/make-room-tabs-url-addressable-with-on-demand-data-loading/03-conditional-livequery.md
@@ -4,6 +4,21 @@
 
 Make goals and skills LiveQuery subscriptions conditional on the active tab, so data is only fetched and kept in sync when the user is actually viewing it. Tasks LiveQuery remains always-on (needed by overview dashboard, tasks tab, and goals editor).
 
+## Pre-Implementation: Goals Data Consumer Audit
+
+**Before implementing conditional subscriptions, the implementer must audit all consumers of goals data across the room UI.** Specifically:
+
+1. Search for all reads of `goalStore` / `roomStore.goalStore` / `goals.value` across `packages/web/src/`.
+2. Identify any component that reads goals data and renders **outside** the goals tab.
+3. Known consumers to check:
+   - `RoomDashboard.tsx` — currently shows a "Create a mission to get started" prompt. Verify whether it reads goals data to conditionally show this, or whether it's a static prompt.
+   - `TaskHeader.tsx` — has a goal badge click handler. Check if it reads goal data to render badges, or just navigates.
+   - `RoomContextPanel.tsx` — may show goal summaries or counts.
+4. **If any non-goals-tab component reads goals data for rendering:** either (a) keep goals always-on (remove it from conditional subscriptions), or (b) extract the specific data need into a lightweight separate query.
+5. **If the audit confirms goals data is only consumed on the goals tab:** proceed with conditional subscription as planned.
+
+This audit is a **prerequisite** for Task 6 and must be documented in the PR description.
+
 ## Scope
 
 Primary files: `packages/web/src/lib/room-store.ts`, `packages/web/src/hooks/useRoomLiveQuery.ts`, and their test files.
@@ -68,17 +83,19 @@ Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
 
 1. Import `currentRoomActiveTabSignal` in `useRoomLiveQuery.ts`.
 
-2. Change the hook to accept the active tab as a parameter or read it from the signal directly. Reading from the signal is simpler since Preact signals auto-subscribe in render context, but inside `useEffect` we need to read `currentRoomActiveTabSignal.value` explicitly. The cleanest approach: pass `activeTab` as a second parameter so the hook can react to it as a dependency.
+2. Change the hook to accept the active tab as a **parameter** (not read from signal inside the hook). This is important for Preact Signals reactivity: reading `currentRoomActiveTabSignal.value` inside a `useEffect` dependency array will NOT automatically re-run when the signal changes — Preact signals only trigger re-renders in component render functions or `useSignalEffect`. By passing `activeTab` as a prop from Room.tsx (which reads the signal in render context and thus re-renders on signal change), the `useEffect` dependency array correctly triggers on tab changes.
 
    Recommended signature change:
    ```ts
    export function useRoomLiveQuery(roomId: string, activeTab: string | null): void
    ```
 
+   **Alternative approach:** Use `useSignalEffect` from `@preact/signals` instead of `useEffect` for the tab-dependent subscription effects. This would allow reading `currentRoomActiveTabSignal.value` directly inside the effect. However, the parameter approach is simpler and keeps the hook framework-agnostic.
+
 3. In the hook body, manage three separate `useEffect` blocks:
    - **Tasks** (`[roomId]` dependency): always subscribe/unsubscribe via `roomStore.subscribeRoomTasks(roomId)` / `roomStore.unsubscribeRoomTasks(roomId)`.
    - **Goals** (`[roomId, activeTab]` dependency): subscribe via `roomStore.subscribeRoomGoals(roomId)` only when `activeTab === 'goals'`. Unsubscribe when tab changes away or on unmount.
-   - **Skills** (`[roomId, activeTab]` dependency): subscribe via `roomStore.subscribeRoomSkills(roomId)` only when `activeTab === 'agents' || activeTab === 'settings'`. Unsubscribe when tab changes away or on unmount.
+   - **Skills** (`[roomId, activeTab]` dependency): subscribe via `roomStore.subscribeRoomSkills(roomId)` only when `activeTab === 'agents' || activeTab === 'settings'`. Unsubscribe when tab changes away or on unmount. **Scope note:** `RoomAgents` renders agent configurations (needs skills data), and `RoomSettings` contains `RoomSkillsSettings` as a sub-section. Both tabs need skills data, so subscribing on both `'agents'` and `'settings'` is correct. While settings has sub-sections that don't need skills, the simpler approach of subscribing for the entire settings tab is acceptable — the data payload is small.
 
 4. Update the call site in Room.tsx to pass the active tab:
    ```ts

--- a/docs/plans/make-room-tabs-url-addressable-with-on-demand-data-loading/04-code-splitting.md
+++ b/docs/plans/make-room-tabs-url-addressable-with-on-demand-data-loading/04-code-splitting.md
@@ -27,14 +27,16 @@ Primary files: `packages/web/src/islands/Room.tsx`, `packages/web/src/components
    const RoomAgents = lazy(() => import('../components/room/RoomAgents').then(m => ({ default: m.RoomAgents })));
    const RoomSettings = lazy(() => import('../components/room/RoomSettings').then(m => ({ default: m.RoomSettings })));
    ```
-   Note: The `.then(m => ({ default: m.GoalsEditor }))` wrapper is needed because these are named exports, not default exports. Verify the actual export style in each component file -- if they already use `export default`, the wrapper is not needed.
+   Note: The `.then(m => ({ default: m.GoalsEditor }))` wrapper is **required** — all three components use named exports (`export function GoalsEditor`, `export function RoomAgents`, `export function RoomSettings`), not default exports.
 
 3. Remove the `GoalsEditor`, `RoomSettings`, `RoomAgents` imports from the barrel import (`from '../components/room'`). The `CreateGoalFormData` type import from GoalsEditor needs to remain -- use a separate type-only import:
    ```ts
    import type { CreateGoalFormData } from '../components/room/GoalsEditor';
    ```
 
-4. Wrap each lazy component's rendering in a `<Suspense>` boundary with a simple loading fallback:
+4. **Update the barrel export** in `packages/web/src/components/room/index.ts`. Remove the re-exports for `GoalsEditor`, `RoomAgents`, and `RoomSettings` from the barrel. If any other consumer imports them via the barrel (check with `grep -r "from.*components/room'" packages/web/src/ --include='*.ts' --include='*.tsx'`), update those imports to use direct file paths instead. If the barrel re-exports remain, other consumers will bypass the lazy boundary and cause these modules to be bundled eagerly, defeating the purpose of code splitting.
+
+5. Wrap each lazy component's rendering in a `<Suspense>` boundary with a simple loading fallback:
    ```tsx
    {activeTab === 'goals' && (
      <div class="h-full overflow-y-auto">
@@ -46,15 +48,16 @@ Primary files: `packages/web/src/islands/Room.tsx`, `packages/web/src/components
    ```
    Apply the same pattern for `RoomAgents` and `RoomSettings`.
 
-5. Keep `RoomDashboard` and `RoomTasks` eagerly loaded -- they are the primary entry points (overview and tasks tabs) and should be instantly available.
+6. Keep `RoomDashboard` and `RoomTasks` eagerly loaded -- they are the primary entry points (overview and tasks tabs) and should be instantly available.
 
-6. Verify the Vite build produces separate chunks for the lazy components:
+7. Verify the Vite build produces separate chunks for the lazy components:
    - Run `cd packages/web && bunx vite build` (or `make build`)
    - Check the output for separate chunk files corresponding to GoalsEditor, RoomAgents, RoomSettings
+   - **Note:** Vite/Rollup may merge small chunks depending on its chunk strategy. If separate chunks are not visible, verify via the build output that dynamic imports are present, or check that the main bundle size decreased.
 
-7. Verify that the lazy components load correctly in development mode (`make dev`) by navigating to each tab and confirming the component renders after a brief loading state.
+8. Verify that the lazy components load correctly in development mode (`make dev`) by navigating to each tab and confirming the component renders after a brief loading state.
 
-8. Update Room.test.tsx if needed -- lazy components in tests may need a wrapping `<Suspense>` in the test render, or the test can mock the lazy imports.
+9. Update Room.test.tsx if needed -- lazy components in tests may need a wrapping `<Suspense>` in the test render, or the test can mock the lazy imports.
 
 **Acceptance Criteria:**
 
@@ -65,6 +68,7 @@ Primary files: `packages/web/src/islands/Room.tsx`, `packages/web/src/components
 - No flash of content or layout shift when lazy components load
 - `cd packages/web && bunx vitest run src/islands/__tests__/Room.test.tsx` passes
 - `make build` succeeds without errors
+- E2E test added or existing navigation E2E tests verified to pass with new URL structure (run via `make run-e2e TEST=tests/core/navigation-3-column.e2e.ts` or equivalent)
 
 **Dependencies:** Task 3 (Room.tsx must be refactored to signal-driven tabs first, otherwise the lazy/Suspense additions will conflict with the useState refactor)
 

--- a/docs/plans/make-room-tabs-url-addressable-with-on-demand-data-loading/04-code-splitting.md
+++ b/docs/plans/make-room-tabs-url-addressable-with-on-demand-data-loading/04-code-splitting.md
@@ -1,0 +1,73 @@
+# Milestone 4: Code-Splitting with Lazy/Suspense
+
+## Goal
+
+Lazy-load the three heaviest tab components (GoalsEditor, RoomAgents, RoomSettings) so they are only downloaded when the user navigates to their respective tabs.
+
+## Scope
+
+Primary files: `packages/web/src/islands/Room.tsx`, `packages/web/src/components/room/index.ts` (barrel export).
+
+---
+
+### Task 7: Add lazy loading for GoalsEditor, RoomAgents, and RoomSettings
+
+**Description:** Use Preact's `lazy()` and `Suspense` to code-split GoalsEditor (~2065 lines), RoomAgents (~1093 lines), and RoomSettings (~772 lines) into separate chunks that load on demand.
+
+**Subtasks:**
+
+1. In Room.tsx, add imports:
+   ```ts
+   import { lazy, Suspense } from 'preact/compat';
+   ```
+
+2. Replace the static imports of `GoalsEditor`, `RoomAgents`, and `RoomSettings` with lazy imports:
+   ```ts
+   const GoalsEditor = lazy(() => import('../components/room/GoalsEditor').then(m => ({ default: m.GoalsEditor })));
+   const RoomAgents = lazy(() => import('../components/room/RoomAgents').then(m => ({ default: m.RoomAgents })));
+   const RoomSettings = lazy(() => import('../components/room/RoomSettings').then(m => ({ default: m.RoomSettings })));
+   ```
+   Note: The `.then(m => ({ default: m.GoalsEditor }))` wrapper is needed because these are named exports, not default exports. Verify the actual export style in each component file -- if they already use `export default`, the wrapper is not needed.
+
+3. Remove the `GoalsEditor`, `RoomSettings`, `RoomAgents` imports from the barrel import (`from '../components/room'`). The `CreateGoalFormData` type import from GoalsEditor needs to remain -- use a separate type-only import:
+   ```ts
+   import type { CreateGoalFormData } from '../components/room/GoalsEditor';
+   ```
+
+4. Wrap each lazy component's rendering in a `<Suspense>` boundary with a simple loading fallback:
+   ```tsx
+   {activeTab === 'goals' && (
+     <div class="h-full overflow-y-auto">
+       <Suspense fallback={<div class="flex items-center justify-center h-32"><Skeleton width="200px" height={24} /></div>}>
+         <GoalsEditor ... />
+       </Suspense>
+     </div>
+   )}
+   ```
+   Apply the same pattern for `RoomAgents` and `RoomSettings`.
+
+5. Keep `RoomDashboard` and `RoomTasks` eagerly loaded -- they are the primary entry points (overview and tasks tabs) and should be instantly available.
+
+6. Verify the Vite build produces separate chunks for the lazy components:
+   - Run `cd packages/web && bunx vite build` (or `make build`)
+   - Check the output for separate chunk files corresponding to GoalsEditor, RoomAgents, RoomSettings
+
+7. Verify that the lazy components load correctly in development mode (`make dev`) by navigating to each tab and confirming the component renders after a brief loading state.
+
+8. Update Room.test.tsx if needed -- lazy components in tests may need a wrapping `<Suspense>` in the test render, or the test can mock the lazy imports.
+
+**Acceptance Criteria:**
+
+- GoalsEditor, RoomAgents, and RoomSettings are loaded on demand (not included in the main bundle)
+- Vite build output shows separate chunks for these components
+- Navigating to goals/agents/settings tabs shows a brief loading skeleton then renders the component
+- RoomDashboard and RoomTasks render instantly without Suspense
+- No flash of content or layout shift when lazy components load
+- `cd packages/web && bunx vitest run src/islands/__tests__/Room.test.tsx` passes
+- `make build` succeeds without errors
+
+**Dependencies:** Task 3 (Room.tsx must be refactored to signal-driven tabs first, otherwise the lazy/Suspense additions will conflict with the useState refactor)
+
+**Agent type:** coder
+
+Changes must be on a feature branch with a GitHub PR created via `gh pr create`.


### PR DESCRIPTION
## Summary
- Adds a 4-milestone plan to make room tabs addressable via URL sub-paths (`/room/:id/tasks`, `/room/:id/goals`, etc.)
- Covers router route patterns, signal-driven tab state, conditional LiveQuery subscriptions, and lazy/Suspense code-splitting
- 7 tasks across 4 milestones with clear dependency ordering