### PR TITLE
feat: wire navigateToRoomMission from missions list and task view

### DIFF
--- a/packages/web/src/components/room/GoalsEditor.test.tsx
+++ b/packages/web/src/components/room/GoalsEditor.test.tsx
@@ -1092,4 +1092,109 @@ describe('GoalsEditor', () => {
 			expect(container.querySelector('[data-testid^="goal-short-id-badge-"]')).toBeNull();
 		});
 	});
+
+	describe('Goal Title Navigation (onGoalClick)', () => {
+		it('should render title as a clickable button when onGoalClick is provided', () => {
+			const goals = [createMockGoal('goal-1', { title: 'Clickable Goal' })];
+			const onGoalClick = vi.fn();
+			const { container } = render(
+				<GoalsEditor goals={goals} {...defaultHandlers} onGoalClick={onGoalClick} />
+			);
+
+			// Should be a button, not an h4
+			const titleButton = container.querySelector(
+				'button.text-sm.font-semibold'
+			) as HTMLButtonElement;
+			expect(titleButton).toBeTruthy();
+			expect(titleButton.textContent).toBe('Clickable Goal');
+		});
+
+		it('should render title as a plain h4 when onGoalClick is not provided', () => {
+			const goals = [createMockGoal('goal-1', { title: 'Static Goal' })];
+			const { container } = render(<GoalsEditor goals={goals} {...defaultHandlers} />);
+
+			const h4 = container.querySelector('h4.text-sm.font-semibold');
+			expect(h4).toBeTruthy();
+			expect(h4?.textContent).toBe('Static Goal');
+
+			// No title button
+			expect(container.querySelector('button.text-sm.font-semibold')).toBeNull();
+		});
+
+		it('should call onGoalClick with the correct goalId when title button is clicked', () => {
+			const goals = [createMockGoal('goal-abc', { title: 'Nav Goal' })];
+			const onGoalClick = vi.fn();
+			const { container } = render(
+				<GoalsEditor goals={goals} {...defaultHandlers} onGoalClick={onGoalClick} />
+			);
+
+			const titleButton = container.querySelector(
+				'button.text-sm.font-semibold'
+			) as HTMLButtonElement;
+			fireEvent.click(titleButton);
+
+			expect(onGoalClick).toHaveBeenCalledWith('goal-abc');
+		});
+
+		it('should NOT expand/collapse when the title button is clicked (stopPropagation)', () => {
+			const goals = [
+				createMockGoal('goal-1', { title: 'Stop Prop Goal', description: 'Some description' }),
+			];
+			const onGoalClick = vi.fn();
+			const { container } = render(
+				<GoalsEditor goals={goals} {...defaultHandlers} onGoalClick={onGoalClick} />
+			);
+
+			// The card header has data-testid="goal-item-header"; clicking title should NOT trigger expand
+			const header = container.querySelector('[data-testid="goal-item-header"]') as HTMLElement;
+			const titleButton = container.querySelector(
+				'button.text-sm.font-semibold'
+			) as HTMLButtonElement;
+
+			// Capture whether expansion toggled by checking for expanded content before and after
+			const expandedContentBefore = container.querySelector(
+				'[data-testid="goal-expanded-content"]'
+			);
+			fireEvent.click(titleButton);
+			const expandedContentAfter = container.querySelector('[data-testid="goal-expanded-content"]');
+
+			// onGoalClick was called
+			expect(onGoalClick).toHaveBeenCalledWith('goal-1');
+			// The header's toggle should NOT have fired — expansion state unchanged
+			expect(expandedContentBefore).toBe(expandedContentAfter);
+		});
+
+		it('should still expand/collapse when the card header (outside title) is clicked', () => {
+			const goals = [createMockGoal('goal-1', { title: 'Expandable Goal' })];
+			const onGoalClick = vi.fn();
+			const { container } = render(
+				<GoalsEditor goals={goals} {...defaultHandlers} onGoalClick={onGoalClick} />
+			);
+
+			const header = container.querySelector('[data-testid="goal-item-header"]') as HTMLElement;
+			// Click the header itself (not the button child) to toggle expand
+			fireEvent.click(header);
+
+			// onGoalClick should NOT have been called (clicked header, not title)
+			expect(onGoalClick).not.toHaveBeenCalled();
+		});
+
+		it('should call onGoalClick with the correct goalId for multiple goals', () => {
+			const goals = [
+				createMockGoal('goal-x', { title: 'Goal X' }),
+				createMockGoal('goal-y', { title: 'Goal Y' }),
+			];
+			const onGoalClick = vi.fn();
+			const { container } = render(
+				<GoalsEditor goals={goals} {...defaultHandlers} onGoalClick={onGoalClick} />
+			);
+
+			const titleButtons = container.querySelectorAll('button.text-sm.font-semibold');
+			expect(titleButtons.length).toBe(2);
+
+			fireEvent.click(titleButtons[1]); // click 'Goal Y'
+			expect(onGoalClick).toHaveBeenCalledWith('goal-y');
+			expect(onGoalClick).toHaveBeenCalledTimes(1);
+		});
+	});
 });

--- a/packages/web/src/components/room/GoalsEditor.tsx
+++ b/packages/web/src/components/room/GoalsEditor.tsx
@@ -85,6 +85,8 @@ export interface GoalsEditorProps {
 	onTriggerNow?: (goalId: string) => Promise<void>;
 	/** Set nextRunAt to a specific datetime for a recurring mission (optional) */
 	onScheduleNext?: (goalId: string, nextRunAt: number) => Promise<void>;
+	/** Handler for clicking a goal title to navigate to mission detail */
+	onGoalClick?: (goalId: string) => void;
 }
 
 // ─── Common Schedule Presets ──────────────────────────────────────────────────
@@ -1168,6 +1170,7 @@ interface GoalItemProps {
 	onLinkTask: (taskId: string) => Promise<void>;
 	isExpanded: boolean;
 	onToggleExpand: () => void;
+	onGoalClick?: (goalId: string) => void;
 	onListExecutions?: (goalId: string) => Promise<MissionExecution[]>;
 	onTriggerNow?: (goalId: string) => Promise<void>;
 	onScheduleNext?: (goalId: string, nextRunAt: number) => Promise<void>;
@@ -1182,6 +1185,7 @@ function GoalItem({
 	onLinkTask,
 	isExpanded,
 	onToggleExpand,
+	onGoalClick,
 	onListExecutions,
 	onTriggerNow,
 	onScheduleNext,
@@ -1332,7 +1336,19 @@ function GoalItem({
 					{/* Row 1: Title + actions */}
 					<div class="flex items-start justify-between gap-2 mb-1.5">
 						<div class="flex items-center gap-2 min-w-0">
-							<h4 class="text-sm font-semibold text-gray-100 leading-snug">{goal.title}</h4>
+							{onGoalClick ? (
+								<button
+									class="text-sm font-semibold text-gray-100 leading-snug hover:text-emerald-400 transition-colors text-left"
+									onClick={(e) => {
+										e.stopPropagation();
+										onGoalClick(goal.id);
+									}}
+								>
+									{goal.title}
+								</button>
+							) : (
+								<h4 class="text-sm font-semibold text-gray-100 leading-snug">{goal.title}</h4>
+							)}
 							{goal.shortId && <GoalShortIdBadge shortId={goal.shortId} />}
 						</div>
 						<div class="flex items-center gap-1 flex-shrink-0" onClick={(e) => e.stopPropagation()}>
@@ -1951,6 +1967,7 @@ export function GoalsEditor({
 	onListExecutions,
 	onTriggerNow,
 	onScheduleNext,
+	onGoalClick,
 }: GoalsEditorProps) {
 	const [showCreateModal, setShowCreateModal] = useState(false);
 	const [expandedGoalId, setExpandedGoalId] = useState<string | null>(null);
@@ -2044,6 +2061,7 @@ export function GoalsEditor({
 							onLinkTask={(taskId) => onLinkTask(goal.id, taskId)}
 							isExpanded={expandedGoalId === goal.id}
 							onToggleExpand={() => toggleExpand(goal.id)}
+							onGoalClick={onGoalClick}
 							onListExecutions={onListExecutions}
 							onTriggerNow={onTriggerNow}
 							onScheduleNext={onScheduleNext}

--- a/packages/web/src/components/room/RoomTasks.test.tsx
+++ b/packages/web/src/components/room/RoomTasks.test.tsx
@@ -824,7 +824,7 @@ describe('RoomTasks', () => {
 			) as HTMLButtonElement;
 			fireEvent.click(badge);
 
-			expect(onGoalClick).toHaveBeenCalled();
+			expect(onGoalClick).toHaveBeenCalledWith('goal-1');
 		});
 
 		it('should NOT call onTaskClick when goal badge is clicked (stopPropagation)', () => {
@@ -847,7 +847,7 @@ describe('RoomTasks', () => {
 			) as HTMLButtonElement;
 			fireEvent.click(badge);
 
-			expect(onGoalClick).toHaveBeenCalled();
+			expect(onGoalClick).toHaveBeenCalledWith('goal-1');
 			expect(onTaskClick).not.toHaveBeenCalled();
 		});
 

--- a/packages/web/src/components/room/RoomTasks.tsx
+++ b/packages/web/src/components/room/RoomTasks.tsx
@@ -46,7 +46,7 @@ interface RoomTasksProps {
 	/** Pre-built reverse lookup from roomStore.goalByTaskId.value */
 	goalByTaskId?: Map<string, RoomGoal>;
 	onTaskClick?: (taskId: string) => void;
-	onGoalClick?: () => void;
+	onGoalClick?: (goalId: string) => void;
 	onReactivate?: (taskId: string) => void;
 }
 
@@ -297,7 +297,7 @@ function TaskList({
 	tab: TaskFilterTab;
 	goalByTaskId?: Map<string, RoomGoal>;
 	onTaskClick?: (taskId: string) => void;
-	onGoalClick?: () => void;
+	onGoalClick?: (goalId: string) => void;
 	onReactivate?: (taskId: string) => void;
 }) {
 	if (tab === 'active') {
@@ -455,7 +455,7 @@ function TaskGroup({
 	allTasks: TaskSummary[];
 	goalByTaskId?: Map<string, RoomGoal>;
 	onTaskClick?: (taskId: string) => void;
-	onGoalClick?: () => void;
+	onGoalClick?: (goalId: string) => void;
 	onReactivate?: (taskId: string) => void;
 	showAlert?: boolean;
 	showClock?: boolean;
@@ -595,7 +595,7 @@ function TaskItem({
 	allTasks: TaskSummary[];
 	goal?: RoomGoal;
 	onClick?: (taskId: string) => void;
-	onGoalClick?: () => void;
+	onGoalClick?: (goalId: string) => void;
 	onReactivate?: (taskId: string) => void;
 }) {
 	const isClickable = !!onClick;
@@ -653,7 +653,7 @@ function TaskItem({
 								data-testid={`task-goal-badge-${task.id}`}
 								onClick={(e) => {
 									e.stopPropagation();
-									onGoalClick?.();
+									onGoalClick?.(goal.id);
 								}}
 								class="inline-flex items-center gap-1 text-xs font-medium text-emerald-400 bg-emerald-900/20 border border-emerald-700/40 px-1.5 py-0.5 rounded-full hover:bg-emerald-900/40 transition-colors"
 								title={`Mission: ${goal.title}`}

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -64,6 +64,7 @@ vi.mock('../../hooks/useTaskInputDraft.ts', () => ({
 
 const mockNavigateToRoom = vi.fn();
 const mockNavigateToRoomTask = vi.fn();
+const mockNavigateToRoomMission = vi.fn();
 
 vi.mock('../../lib/router.ts', () => ({
 	get navigateToRoom() {
@@ -71,6 +72,9 @@ vi.mock('../../lib/router.ts', () => ({
 	},
 	get navigateToRoomTask() {
 		return mockNavigateToRoomTask;
+	},
+	get navigateToRoomMission() {
+		return mockNavigateToRoomMission;
 	},
 }));
 
@@ -2732,7 +2736,7 @@ describe('TaskView — goal badge', () => {
 		expect(badge).toBeNull();
 	});
 
-	it('sets currentRoomTabSignal to "goals" and navigates to room when goal badge clicked', async () => {
+	it('navigates to mission detail when goal badge clicked', async () => {
 		roomStore.taskStore.applySnapshot([makeTask('task-1', 'in_progress') as unknown as NeoTask]);
 		mockRequest.mockImplementation(async (method) => {
 			if (method === 'task.getGroup') return { group: null };
@@ -2765,8 +2769,8 @@ describe('TaskView — goal badge', () => {
 		) as HTMLButtonElement;
 		fireEvent.click(badge);
 
-		expect(currentRoomTabSignal.value).toBe('goals');
-		expect(mockNavigateToRoom).toHaveBeenCalledWith('room-1');
+		expect(mockNavigateToRoomMission).toHaveBeenCalledWith('room-1', 'goal-1');
+		expect(mockNavigateToRoom).not.toHaveBeenCalled();
 	});
 
 	it('shows goal title as tooltip on badge', async () => {

--- a/packages/web/src/components/room/task-shared/TaskHeader.tsx
+++ b/packages/web/src/components/room/task-shared/TaskHeader.tsx
@@ -17,8 +17,7 @@
 
 import type { NeoTask, RoomGoal } from '@neokai/shared';
 import { TASK_STATUS_COLORS } from '../../../lib/task-constants';
-import { navigateToRoom } from '../../../lib/router';
-import { currentRoomTabSignal } from '../../../lib/signals';
+import { navigateToRoom, navigateToRoomMission } from '../../../lib/router';
 import { TaskHeaderActions } from './TaskHeaderActions';
 
 export interface TaskHeaderProps {
@@ -107,10 +106,7 @@ export function TaskHeader({
 					{associatedGoal && (
 						<button
 							data-testid="task-view-goal-badge"
-							onClick={() => {
-								navigateToRoom(roomId);
-								currentRoomTabSignal.value = 'goals';
-							}}
+							onClick={() => navigateToRoomMission(roomId, associatedGoal.id)}
 							class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium text-emerald-400 bg-emerald-900/20 border border-emerald-700/40 hover:bg-emerald-900/40 rounded transition-colors flex-shrink-0"
 							title={`Mission: ${associatedGoal.title}`}
 						>

--- a/packages/web/src/components/room/task-shared/__tests__/TaskHeader.test.tsx
+++ b/packages/web/src/components/room/task-shared/__tests__/TaskHeader.test.tsx
@@ -23,10 +23,13 @@ import type { NeoTask, RoomGoal } from '@neokai/shared';
 // Mocks
 // ---------------------------------------------------------------------------
 
-const { mockNavigateToRoom, mockCurrentRoomTabSignal } = vi.hoisted(() => ({
-	mockNavigateToRoom: vi.fn(),
-	mockCurrentRoomTabSignal: { value: 'chat' },
-}));
+const { mockNavigateToRoom, mockNavigateToRoomMission, mockCurrentRoomTabSignal } = vi.hoisted(
+	() => ({
+		mockNavigateToRoom: vi.fn(),
+		mockNavigateToRoomMission: vi.fn(),
+		mockCurrentRoomTabSignal: { value: 'chat' },
+	})
+);
 
 vi.mock('../../../../lib/router.ts', () => ({
 	get navigateToRoom() {
@@ -34,6 +37,9 @@ vi.mock('../../../../lib/router.ts', () => ({
 	},
 	get navigateToRoomTask() {
 		return vi.fn();
+	},
+	get navigateToRoomMission() {
+		return mockNavigateToRoomMission;
 	},
 }));
 
@@ -176,11 +182,12 @@ describe('TaskHeader', () => {
 		expect(container.textContent).toContain('Build feature X');
 	});
 
-	it('navigates to room when mission badge is clicked', () => {
+	it('navigates to mission detail when mission badge is clicked', () => {
 		const goal = makeGoal();
 		const { getByTestId } = render(<TaskHeader {...defaultProps({ associatedGoal: goal })} />);
 		fireEvent.click(getByTestId('task-view-goal-badge'));
-		expect(mockNavigateToRoom).toHaveBeenCalledWith('room-1');
+		expect(mockNavigateToRoomMission).toHaveBeenCalledWith('room-1', goal.id);
+		expect(mockNavigateToRoom).not.toHaveBeenCalled();
 	});
 
 	// --- Progress indicator removed from header (shown in task list / info panel instead) ---

--- a/packages/web/src/islands/Room.tsx
+++ b/packages/web/src/islands/Room.tsx
@@ -16,6 +16,7 @@ import {
 	navigateToRoomTask,
 	navigateToRoom,
 	navigateToRoomAgent,
+	navigateToRoomMission,
 } from '../lib/router';
 import {
 	currentRoomTabSignal,
@@ -317,9 +318,7 @@ export default function Room({ roomId, sessionViewId, taskViewId, missionViewId 
 										onTaskClick={
 											roomId ? (taskId) => navigateToRoomTask(roomId, taskId) : undefined
 										}
-										onGoalClick={() => {
-											currentRoomTabSignal.value = 'goals';
-										}}
+										onGoalClick={(goalId) => navigateToRoomMission(roomId, goalId)}
 										onReactivate={async (taskId) => {
 											await roomStore.setTaskStatus(taskId, 'in_progress');
 										}}
@@ -338,6 +337,7 @@ export default function Room({ roomId, sessionViewId, taskViewId, missionViewId 
 										goals={roomStore.goals.value}
 										tasks={roomStore.tasks.value}
 										onTaskClick={(taskId) => navigateToRoomTask(roomId, taskId)}
+										onGoalClick={(goalId) => navigateToRoomMission(roomId, goalId)}
 										onCreateGoal={handleCreateGoal}
 										onUpdateGoal={handleUpdateGoal}
 										onDeleteGoal={handleDeleteGoal}


### PR DESCRIPTION
Wire up direct navigation to mission detail pages from the missions list and task view, replacing the previous tab-switch behavior.

- `GoalsEditor`: add optional `onGoalClick` prop; when provided, the goal title renders as a clickable button that navigates to the mission detail page
- `RoomTasks`: update `onGoalClick` signature from `() => void` to `(goalId: string) => void`; pass `goal.id` on badge click
- `TaskHeader`: replace two-step navigate+tab-switch with a single `navigateToRoomMission(roomId, associatedGoal.id)` call
- `Room`: pass `onGoalClick={(goalId) => navigateToRoomMission(roomId, goalId)}` to both `RoomTasks` and `GoalsEditor`