### PR TITLE
feat: MissionDetail header and status sidebar

### DIFF
--- a/packages/web/src/components/room/MissionDetail.tsx
+++ b/packages/web/src/components/room/MissionDetail.tsx
@@ -1,55 +1,459 @@
 /**
  * MissionDetail Component
  *
- * Placeholder for the dedicated mission (goal) detail page.
+ * Dedicated page for viewing a single mission (goal) in the Room UI.
  * Rendered as an absolute overlay inside Room, following the same
  * pattern as TaskViewToggle.
  *
- * Full implementation is tracked in the "Add dedicated Mission detail page" goal.
+ * Layout:
+ * - Header: back button, title, short ID, status, edit/delete actions
+ * - Two-column body: main content (left) + status sidebar (right, 320px)
+ * - Status sidebar: priority/type/autonomy badges, quick actions, timestamps
  */
 
+import { useState } from 'preact/hooks';
+import type { RoomGoal } from '@neokai/shared';
+import { cn } from '../../lib/utils';
 import { navigateToRoom } from '../../lib/router';
+import { currentRoomTabSignal } from '../../lib/signals';
+import { useMissionDetailData } from '../../hooks/useMissionDetailData';
+import type { AvailableStatusAction } from '../../hooks/useMissionDetailData';
 import { Button } from '../ui/Button';
 import { MobileMenuButton } from '../ui/MobileMenuButton';
+import { ConfirmModal } from '../ui/ConfirmModal';
+import { Skeleton } from '../ui/Skeleton';
+import { Modal } from '../ui/Modal';
+import {
+	StatusIndicator,
+	PriorityBadge,
+	MissionTypeBadge,
+	AutonomyBadge,
+	GoalShortIdBadge,
+	GoalForm,
+} from './GoalsEditor';
+import type { CreateGoalFormData } from './GoalsEditor';
+
+// ─── Props ─────────────────────────────────────────────────────────────────────
 
 interface MissionDetailProps {
 	roomId: string;
 	goalId: string;
 }
 
-export function MissionDetail({ roomId, goalId: _goalId }: MissionDetailProps) {
-	function handleBack() {
-		navigateToRoom(roomId);
-	}
+// ─── Loading Skeleton ──────────────────────────────────────────────────────────
 
+function MissionDetailSkeleton() {
 	return (
 		<div class="flex flex-col h-full bg-dark-900">
-			{/* Header */}
-			<div class="flex items-center gap-3 px-4 py-3 border-b border-dark-700 shrink-0">
-				<MobileMenuButton />
-				<Button variant="ghost" size="sm" onClick={handleBack} class="gap-1.5">
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						width="16"
-						height="16"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<path d="M19 12H5" />
-						<path d="M12 19l-7-7 7-7" />
-					</svg>
-					Back to Room
-				</Button>
+			{/* Header skeleton */}
+			<div class="border-b border-dark-700 bg-dark-850 px-3 sm:px-4 py-2.5 sm:py-3 flex-shrink-0">
+				<div class="flex items-center gap-2 sm:gap-3">
+					<Skeleton variant="text" width={28} height={20} />
+					<div class="flex-1 min-w-0">
+						<Skeleton variant="text" width="60%" height={22} />
+					</div>
+					<Skeleton variant="text" width={64} height={32} />
+					<Skeleton variant="text" width={64} height={32} />
+				</div>
+				<div class="flex items-center gap-2 mt-2">
+					<Skeleton variant="text" width={60} height={18} />
+					<Skeleton variant="text" width={48} height={18} />
+					<Skeleton variant="text" width={72} height={18} />
+				</div>
+			</div>
+			{/* Body skeleton */}
+			<div class="flex-1 overflow-auto p-4 sm:p-6">
+				<div class="grid grid-cols-1 md:grid-cols-[1fr_320px] gap-6 h-full">
+					<div class="space-y-4">
+						<Skeleton variant="text" width="80%" height={16} />
+						<Skeleton variant="text" width="60%" height={16} />
+					</div>
+					<div class="space-y-3">
+						<Skeleton variant="text" width="100%" height={20} />
+						<Skeleton variant="text" width="100%" height={20} />
+						<Skeleton variant="text" width="70%" height={20} />
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ─── Quick Action Button ───────────────────────────────────────────────────────
+
+interface QuickActionButtonProps {
+	label: string;
+	onClick: () => void;
+	disabled?: boolean;
+	loading?: boolean;
+	variant?: 'default' | 'success' | 'warning' | 'danger';
+}
+
+function QuickActionButton({
+	label,
+	onClick,
+	disabled = false,
+	loading = false,
+	variant = 'default',
+}: QuickActionButtonProps) {
+	const variantClasses: Record<string, string> = {
+		default:
+			'bg-dark-700 hover:bg-dark-600 text-gray-300 hover:text-white border border-dark-600 hover:border-dark-500',
+		success:
+			'bg-green-900/30 hover:bg-green-900/50 text-green-400 hover:text-green-300 border border-green-800/40',
+		warning:
+			'bg-amber-900/30 hover:bg-amber-900/50 text-amber-400 hover:text-amber-300 border border-amber-800/40',
+		danger:
+			'bg-red-900/30 hover:bg-red-900/50 text-red-400 hover:text-red-300 border border-red-800/40',
+	};
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			disabled={disabled || loading}
+			class={cn(
+				'w-full px-3 py-2 text-sm rounded-lg transition-colors text-left font-medium',
+				'disabled:opacity-50 disabled:cursor-not-allowed',
+				variantClasses[variant]
+			)}
+		>
+			{loading ? 'Working…' : label}
+		</button>
+	);
+}
+
+// ─── Status Sidebar ────────────────────────────────────────────────────────────
+
+interface StatusSidebarProps {
+	goal: RoomGoal;
+	availableStatusActions: AvailableStatusAction[];
+	isTriggering: boolean;
+	isUpdating: boolean;
+	onRunNow: () => void;
+	onChangeStatus: (action: AvailableStatusAction) => Promise<void>;
+}
+
+function StatusSidebar({
+	goal,
+	availableStatusActions,
+	isTriggering,
+	isUpdating,
+	onRunNow,
+	onChangeStatus,
+}: StatusSidebarProps) {
+	const [isChangingStatus, setIsChangingStatus] = useState(false);
+
+	const handleStatusAction = async (action: AvailableStatusAction) => {
+		setIsChangingStatus(true);
+		try {
+			await onChangeStatus(action);
+		} finally {
+			setIsChangingStatus(false);
+		}
+	};
+
+	const formatDate = (ts: number) =>
+		new Date(ts).toLocaleDateString(undefined, {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric',
+			hour: '2-digit',
+			minute: '2-digit',
+		});
+
+	return (
+		<aside class="bg-dark-850 border border-dark-700 rounded-lg p-4 space-y-5 self-start">
+			{/* Badges section */}
+			<div class="space-y-2">
+				<h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Details</h3>
+				<div class="flex flex-wrap gap-1.5">
+					<PriorityBadge priority={goal.priority} />
+					<MissionTypeBadge type={goal.missionType ?? 'one_shot'} />
+					<AutonomyBadge level={goal.autonomyLevel ?? 'supervised'} />
+				</div>
 			</div>
 
-			{/* Body */}
-			<div class="flex-1 flex items-center justify-center text-gray-500">
-				<p>Mission detail view — coming soon</p>
+			{/* Quick actions section */}
+			{(goal.missionType === 'recurring' || availableStatusActions.length > 0) && (
+				<div class="space-y-2">
+					<h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">
+						Quick Actions
+					</h3>
+					<div class="space-y-1.5">
+						{/* Recurring-only: Run Now */}
+						{goal.missionType === 'recurring' && (
+							<QuickActionButton
+								label="▶ Run Now"
+								onClick={onRunNow}
+								loading={isTriggering}
+								disabled={isTriggering || isChangingStatus}
+								variant="default"
+							/>
+						)}
+
+						{/* Status-dependent actions */}
+						{availableStatusActions.includes('reactivate') && (
+							<QuickActionButton
+								label="↺ Reactivate"
+								onClick={() => handleStatusAction('reactivate')}
+								loading={isChangingStatus}
+								disabled={isChangingStatus || isUpdating}
+								variant="success"
+							/>
+						)}
+						{availableStatusActions.includes('needs_human') && (
+							<QuickActionButton
+								label="⚑ Needs Review"
+								onClick={() => handleStatusAction('needs_human')}
+								loading={isChangingStatus}
+								disabled={isChangingStatus || isUpdating}
+								variant="warning"
+							/>
+						)}
+						{availableStatusActions.includes('complete') && (
+							<QuickActionButton
+								label="✓ Mark Complete"
+								onClick={() => handleStatusAction('complete')}
+								loading={isChangingStatus}
+								disabled={isChangingStatus || isUpdating}
+								variant="success"
+							/>
+						)}
+						{availableStatusActions.includes('archive') && (
+							<QuickActionButton
+								label="Archive"
+								onClick={() => handleStatusAction('archive')}
+								loading={isChangingStatus}
+								disabled={isChangingStatus || isUpdating}
+								variant="danger"
+							/>
+						)}
+					</div>
+				</div>
+			)}
+
+			{/* Timestamps section */}
+			<div class="space-y-1.5">
+				<h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Timeline</h3>
+				<div class="space-y-1">
+					<div class="flex items-center justify-between text-xs">
+						<span class="text-gray-500">Created</span>
+						<span class="text-gray-400">{formatDate(goal.createdAt)}</span>
+					</div>
+					<div class="flex items-center justify-between text-xs">
+						<span class="text-gray-500">Updated</span>
+						<span class="text-gray-400">{formatDate(goal.updatedAt)}</span>
+					</div>
+				</div>
 			</div>
+		</aside>
+	);
+}
+
+// ─── Main Component ────────────────────────────────────────────────────────────
+
+export function MissionDetail({ roomId, goalId }: MissionDetailProps) {
+	const {
+		goal,
+		availableStatusActions,
+		isUpdating,
+		isTriggering,
+		isDeleting,
+		updateGoal,
+		deleteGoal,
+		triggerNow,
+		changeStatus,
+	} = useMissionDetailData(roomId, goalId);
+
+	const [isEditOpen, setIsEditOpen] = useState(false);
+	const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+
+	function handleBack() {
+		navigateToRoom(roomId);
+		currentRoomTabSignal.value = 'goals';
+	}
+
+	const handleEditSubmit = async (data: CreateGoalFormData) => {
+		await updateGoal({
+			title: data.title,
+			description: data.description,
+			priority: data.priority,
+			missionType: data.missionType,
+			autonomyLevel: data.autonomyLevel,
+			structuredMetrics: data.structuredMetrics,
+			schedule: data.schedule,
+		});
+		setIsEditOpen(false);
+	};
+
+	const handleDelete = async () => {
+		await deleteGoal();
+		setIsDeleteOpen(false);
+	};
+
+	// ── Loading state ──────────────────────────────────────────────────────────
+	if (goal === null) {
+		// Distinguish between "still loading" (goalId provided) and "not found":
+		// roomStore.goals starts empty and populates asynchronously. Show skeleton
+		// first, then "not found" is shown only if goalId has no match once goals
+		// are populated (i.e., the store has items but none match).
+		return <MissionDetailSkeleton />;
+	}
+
+	// ── Not found state ────────────────────────────────────────────────────────
+	// (unreachable in practice — we return skeleton above; kept for type safety)
+
+	return (
+		<div class="flex flex-col h-full bg-dark-900" data-testid="mission-detail">
+			{/* ── Header ── */}
+			<div
+				class="border-b border-dark-700 bg-dark-850 px-3 sm:px-4 py-2.5 sm:py-3 flex-shrink-0"
+				data-testid="mission-detail-header"
+			>
+				{/* Row 1: Back, title, action buttons */}
+				<div class="flex items-center gap-2 sm:gap-3">
+					<MobileMenuButton />
+
+					<button
+						type="button"
+						class="text-gray-400 hover:text-gray-200 transition-colors text-sm p-1 min-w-[28px] min-h-[28px] sm:min-w-0 sm:min-h-0 sm:p-0 flex items-center justify-center flex-shrink-0"
+						onClick={handleBack}
+						title="Back to missions"
+						data-testid="mission-detail-back-button"
+					>
+						←
+					</button>
+
+					<div class="flex-1 min-w-0">
+						<h2
+							class="text-base font-semibold text-gray-100 truncate leading-tight"
+							data-testid="mission-detail-title"
+						>
+							{goal.title}
+						</h2>
+					</div>
+
+					{/* Edit button */}
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={() => setIsEditOpen(true)}
+						title="Edit mission"
+						data-testid="mission-detail-edit-button"
+					>
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							width="15"
+							height="15"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
+							<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+							<path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+						</svg>
+					</Button>
+
+					{/* Delete button */}
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={() => setIsDeleteOpen(true)}
+						title="Delete mission"
+						data-testid="mission-detail-delete-button"
+						class="text-red-400 hover:text-red-300 hover:bg-red-900/20"
+					>
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							width="15"
+							height="15"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
+							<polyline points="3 6 5 6 21 6" />
+							<path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+							<path d="M10 11v6" />
+							<path d="M14 11v6" />
+							<path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+						</svg>
+					</Button>
+				</div>
+
+				{/* Row 2: Badges */}
+				<div class="flex flex-col sm:flex-row sm:items-center gap-1.5 sm:gap-2 mt-1.5 sm:mt-0">
+					{/* Spacer: aligns badges under the title on desktop */}
+					<div class="hidden sm:block flex-shrink-0" style="width: 28px;" aria-hidden="true" />
+					<div class="flex items-center gap-1.5 flex-wrap">
+						<StatusIndicator status={goal.status} />
+						{goal.shortId && <GoalShortIdBadge shortId={goal.shortId} />}
+					</div>
+				</div>
+			</div>
+
+			{/* ── Body: two-column layout ── */}
+			<div class="flex-1 overflow-auto p-4 sm:p-6">
+				<div class="grid grid-cols-1 md:grid-cols-[1fr_320px] gap-6 items-start">
+					{/* Main content — placeholder for next task */}
+					<div
+						class="bg-dark-850 border border-dark-700 rounded-lg p-4 min-h-[200px] flex items-center justify-center text-gray-500 text-sm"
+						data-testid="mission-detail-main-content"
+					>
+						<span>Mission content coming soon…</span>
+					</div>
+
+					{/* Status sidebar */}
+					<StatusSidebar
+						goal={goal}
+						availableStatusActions={availableStatusActions}
+						isTriggering={isTriggering}
+						isUpdating={isUpdating}
+						onRunNow={triggerNow}
+						onChangeStatus={changeStatus}
+					/>
+				</div>
+			</div>
+
+			{/* ── Edit Modal ── */}
+			<Modal
+				isOpen={isEditOpen}
+				onClose={() => setIsEditOpen(false)}
+				title="Edit Mission"
+				size="lg"
+			>
+				<GoalForm
+					initialTitle={goal.title}
+					initialDescription={goal.description ?? ''}
+					initialPriority={goal.priority}
+					initialMissionType={goal.missionType ?? 'one_shot'}
+					initialAutonomyLevel={goal.autonomyLevel ?? 'supervised'}
+					initialMetrics={goal.structuredMetrics ?? []}
+					initialSchedule={goal.schedule}
+					onSubmit={handleEditSubmit}
+					onCancel={() => setIsEditOpen(false)}
+					isLoading={isUpdating}
+					submitLabel="Save Changes"
+				/>
+			</Modal>
+
+			{/* ── Delete Confirm Modal ── */}
+			<ConfirmModal
+				isOpen={isDeleteOpen}
+				onClose={() => setIsDeleteOpen(false)}
+				onConfirm={handleDelete}
+				title="Delete Mission"
+				message={`Are you sure you want to delete "${goal.title}"? This action cannot be undone.`}
+				confirmText="Delete Mission"
+				confirmButtonVariant="danger"
+				isLoading={isDeleting}
+				confirmTestId="mission-detail-delete-confirm"
+			/>
 		</div>
 	);
 }

--- a/packages/web/src/components/room/MissionDetail.tsx
+++ b/packages/web/src/components/room/MissionDetail.tsx
@@ -255,6 +255,7 @@ function StatusSidebar({
 export function MissionDetail({ roomId, goalId }: MissionDetailProps) {
 	const {
 		goal,
+		goalsLoading,
 		availableStatusActions,
 		isUpdating,
 		isTriggering,
@@ -280,28 +281,61 @@ export function MissionDetail({ roomId, goalId }: MissionDetailProps) {
 			priority: data.priority,
 			missionType: data.missionType,
 			autonomyLevel: data.autonomyLevel,
-			structuredMetrics: data.structuredMetrics,
-			schedule: data.schedule,
+			// Only carry structured metrics for measurable missions; clear otherwise.
+			structuredMetrics: data.missionType === 'measurable' ? data.structuredMetrics : undefined,
+			// Only carry schedule for recurring missions; clear otherwise to avoid
+			// orphaned schedule data when a mission type is changed during edit.
+			schedule: data.missionType === 'recurring' ? data.schedule : undefined,
 		});
 		setIsEditOpen(false);
 	};
 
 	const handleDelete = async () => {
-		await deleteGoal();
+		await deleteGoal().catch(() => {
+			/* toast already shown by hook */
+		});
 		setIsDeleteOpen(false);
 	};
 
 	// ── Loading state ──────────────────────────────────────────────────────────
 	if (goal === null) {
-		// Distinguish between "still loading" (goalId provided) and "not found":
-		// roomStore.goals starts empty and populates asynchronously. Show skeleton
-		// first, then "not found" is shown only if goalId has no match once goals
-		// are populated (i.e., the store has items but none match).
-		return <MissionDetailSkeleton />;
-	}
+		// goalsLoading=true means the LiveQuery snapshot is in flight — show skeleton.
+		// goalsLoading=false means goals have loaded but none matched goalId — show error.
+		if (goalsLoading) {
+			return <MissionDetailSkeleton />;
+		}
 
-	// ── Not found state ────────────────────────────────────────────────────────
-	// (unreachable in practice — we return skeleton above; kept for type safety)
+		// ── Not found state ────────────────────────────────────────────────────
+		return (
+			<div class="flex flex-col h-full bg-dark-900" data-testid="mission-not-found">
+				<div class="flex items-center gap-2 px-3 sm:px-4 py-2.5 border-b border-dark-700 bg-dark-850 flex-shrink-0">
+					<MobileMenuButton />
+					<button
+						type="button"
+						class="text-gray-400 hover:text-gray-200 transition-colors text-sm p-1 flex items-center justify-center"
+						onClick={handleBack}
+						data-testid="mission-not-found-back-button"
+					>
+						←
+					</button>
+				</div>
+				<div class="flex-1 flex flex-col items-center justify-center gap-4 text-center p-8">
+					<div class="text-4xl text-gray-600">⚑</div>
+					<h2 class="text-lg font-semibold text-gray-300">Mission not found</h2>
+					<p class="text-sm text-gray-500 max-w-xs">
+						The mission you're looking for doesn't exist or may have been deleted.
+					</p>
+					<button
+						type="button"
+						onClick={handleBack}
+						class="px-4 py-2 text-sm font-medium text-gray-300 bg-dark-700 hover:bg-dark-600 rounded-lg transition-colors"
+					>
+						← Back to Missions
+					</button>
+				</div>
+			</div>
+		);
+	}
 
 	return (
 		<div class="flex flex-col h-full bg-dark-900" data-testid="mission-detail">
@@ -338,6 +372,7 @@ export function MissionDetail({ roomId, goalId }: MissionDetailProps) {
 						variant="ghost"
 						size="sm"
 						onClick={() => setIsEditOpen(true)}
+						disabled={isUpdating}
 						title="Edit mission"
 						data-testid="mission-detail-edit-button"
 					>
@@ -362,6 +397,7 @@ export function MissionDetail({ roomId, goalId }: MissionDetailProps) {
 						variant="ghost"
 						size="sm"
 						onClick={() => setIsDeleteOpen(true)}
+						disabled={isDeleting}
 						title="Delete mission"
 						data-testid="mission-detail-delete-button"
 						class="text-red-400 hover:text-red-300 hover:bg-red-900/20"

--- a/packages/web/src/components/room/__tests__/MissionDetail.test.tsx
+++ b/packages/web/src/components/room/__tests__/MissionDetail.test.tsx
@@ -2,39 +2,217 @@
  * Tests for MissionDetail Component
  *
  * Covers:
- * - Renders "Mission detail view — coming soon" placeholder text
- * - Renders "Back to Room" button text
- * - Clicking back button calls navigateToRoom with the correct roomId
+ * - Loading skeleton shown when goal is null
+ * - Renders mission title and badges when goal is loaded
+ * - Back button calls navigateToRoom AND sets currentRoomTabSignal to 'goals'
+ * - Edit button opens edit modal
+ * - Delete button opens confirm modal
+ * - Status sidebar shows priority, type, autonomy badges
+ * - Quick actions (reactivate, complete, needs_human, archive) rendered for available actions
+ * - Run Now button shown only for recurring missions
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, cleanup, fireEvent } from '@testing-library/preact';
+import { render, cleanup, fireEvent, act } from '@testing-library/preact';
+import type { RoomGoal } from '@neokai/shared';
 import { MissionDetail } from '../MissionDetail';
 
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
 
-const mockNavigateToRoom = vi.fn();
+// Use vi.hoisted so these values are available when vi.mock factories are hoisted
+const { mockNavigateToRoom, mockCurrentRoomTabSignal } = vi.hoisted(() => ({
+	mockNavigateToRoom: vi.fn(),
+	mockCurrentRoomTabSignal: { value: null as string | null },
+}));
 
 vi.mock('../../../lib/router', () => ({
 	navigateToRoom: (...args: unknown[]) => mockNavigateToRoom(...args),
 }));
 
-vi.mock('../ui/Button', () => ({
+vi.mock('../../../lib/signals', () => ({
+	currentRoomTabSignal: mockCurrentRoomTabSignal,
+}));
+
+// Mock toast
+vi.mock('../../../lib/toast', () => ({
+	toast: {
+		success: vi.fn(),
+		error: vi.fn(),
+		info: vi.fn(),
+	},
+}));
+
+// Mock useMissionDetailData — default returns null goal (loading state)
+const mockUseMissionDetailData = vi.fn();
+vi.mock('../../../hooks/useMissionDetailData', () => ({
+	useMissionDetailData: (...args: unknown[]) => mockUseMissionDetailData(...args),
+}));
+
+// Mock sub-components from GoalsEditor to avoid deep dependency chains
+vi.mock('../GoalsEditor', () => ({
+	StatusIndicator: ({ status }: { status: string }) => (
+		<span data-testid="status-indicator">{status}</span>
+	),
+	PriorityBadge: ({ priority }: { priority: string }) => (
+		<span data-testid="priority-badge">{priority}</span>
+	),
+	MissionTypeBadge: ({ type }: { type: string }) => (
+		<span data-testid="mission-type-badge">{type}</span>
+	),
+	AutonomyBadge: ({ level }: { level: string }) => (
+		<span data-testid="autonomy-badge">{level}</span>
+	),
+	GoalShortIdBadge: ({ shortId }: { shortId: string }) => (
+		<span data-testid="short-id-badge">{shortId}</span>
+	),
+	GoalForm: ({
+		onSubmit,
+		onCancel,
+	}: {
+		onSubmit: (data: unknown) => Promise<void>;
+		onCancel: () => void;
+	}) => (
+		<form
+			data-testid="goal-form"
+			onSubmit={(e: Event) => {
+				e.preventDefault();
+				onSubmit({ title: 'Updated Title' });
+			}}
+		>
+			<button type="submit">Save</button>
+			<button type="button" onClick={onCancel}>
+				Cancel
+			</button>
+		</form>
+	),
+}));
+
+// Mock UI components — paths are relative to the test file location (room/__tests__/)
+// so they need to go up two levels to reach src/components/ui/
+vi.mock('../../ui/Button', () => ({
 	Button: ({
 		children,
 		onClick,
+		...rest
 	}: {
 		children?: import('preact').ComponentChildren;
 		onClick?: () => void;
 		[key: string]: unknown;
-	}) => <button onClick={onClick}>{children}</button>,
+	}) => (
+		<button onClick={onClick} {...rest}>
+			{children}
+		</button>
+	),
 }));
 
-vi.mock('../ui/MobileMenuButton', () => ({
+vi.mock('../../ui/MobileMenuButton', () => ({
 	MobileMenuButton: () => <button data-testid="mobile-menu-button" />,
 }));
+
+vi.mock('../../ui/Modal', () => ({
+	Modal: ({
+		isOpen,
+		children,
+		title,
+		onClose,
+	}: {
+		isOpen: boolean;
+		children: import('preact').ComponentChildren;
+		title: string;
+		onClose: () => void;
+	}) =>
+		isOpen ? (
+			<div data-testid="modal" role="dialog">
+				<span data-testid="modal-title">{title}</span>
+				<button data-testid="modal-close" onClick={onClose}>
+					×
+				</button>
+				{children}
+			</div>
+		) : null,
+}));
+
+vi.mock('../../ui/ConfirmModal', () => ({
+	ConfirmModal: ({
+		isOpen,
+		onClose,
+		onConfirm,
+		title,
+		isLoading,
+		confirmTestId,
+	}: {
+		isOpen: boolean;
+		onClose: () => void;
+		onConfirm: () => void;
+		title: string;
+		isLoading?: boolean;
+		confirmTestId?: string;
+	}) =>
+		isOpen ? (
+			<div data-testid="confirm-modal" role="dialog">
+				<span data-testid="confirm-modal-title">{title}</span>
+				<button
+					data-testid={confirmTestId ?? 'confirm-button'}
+					onClick={onConfirm}
+					disabled={isLoading}
+				>
+					Confirm
+				</button>
+				<button data-testid="cancel-button" onClick={onClose}>
+					Cancel
+				</button>
+			</div>
+		) : null,
+}));
+
+vi.mock('../../ui/Skeleton', () => ({
+	Skeleton: () => <div data-testid="skeleton" />,
+}));
+
+// ---------------------------------------------------------------------------
+// Test Helpers
+// ---------------------------------------------------------------------------
+
+const BASE_GOAL: RoomGoal = {
+	id: 'goal-uuid-1',
+	roomId: 'room-1',
+	shortId: 'g-abc123',
+	title: 'Ship the feature',
+	description: 'A test mission',
+	status: 'active',
+	priority: 'normal',
+	missionType: 'one_shot',
+	autonomyLevel: 'supervised',
+	progress: 0,
+	linkedTaskIds: [],
+	structuredMetrics: [],
+	createdAt: 1700000000000,
+	updatedAt: 1700000001000,
+};
+
+function makeDefaultHookResult(
+	overrides: Partial<ReturnType<typeof mockUseMissionDetailData>> = {}
+) {
+	return {
+		goal: BASE_GOAL,
+		linkedTasks: [],
+		executions: null,
+		isLoadingExecutions: false,
+		isUpdating: false,
+		isTriggering: false,
+		isDeleting: false,
+		availableStatusActions: ['complete', 'needs_human', 'archive'],
+		updateGoal: vi.fn().mockResolvedValue(undefined),
+		deleteGoal: vi.fn().mockResolvedValue(undefined),
+		triggerNow: vi.fn().mockResolvedValue(undefined),
+		scheduleNext: vi.fn().mockResolvedValue(undefined),
+		linkTask: vi.fn().mockResolvedValue(undefined),
+		changeStatus: vi.fn().mockResolvedValue(undefined),
+		...overrides,
+	};
+}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -43,42 +221,249 @@ vi.mock('../ui/MobileMenuButton', () => ({
 describe('MissionDetail', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockCurrentRoomTabSignal.value = null;
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult());
 	});
 
 	afterEach(() => {
 		cleanup();
 	});
 
-	it('renders "Mission detail view — coming soon" placeholder text', () => {
-		const { container } = render(<MissionDetail roomId="room-1" goalId="goal-1" />);
-		expect(container.textContent).toContain('Mission detail view — coming soon');
+	// ── Loading state ──────────────────────────────────────────────────────────
+
+	it('shows skeleton when goal is null (loading state)', () => {
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ goal: null }));
+		const { getAllByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-1" />);
+		expect(getAllByTestId('skeleton').length).toBeGreaterThan(0);
 	});
 
-	it('renders "Back to Room" button text', () => {
-		const { container } = render(<MissionDetail roomId="room-1" goalId="goal-1" />);
-		expect(container.textContent).toContain('Back to Room');
+	it('does not show main content when goal is null', () => {
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ goal: null }));
+		const { queryByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-1" />);
+		expect(queryByTestId('mission-detail')).toBeNull();
 	});
 
-	it('calls navigateToRoom with the correct roomId when back button is clicked', () => {
-		const { container } = render(<MissionDetail roomId="room-1" goalId="goal-1" />);
-		const buttons = container.querySelectorAll('button');
-		const backButton = Array.from(buttons).find((b) => b.textContent?.includes('Back to Room'));
-		expect(backButton).toBeTruthy();
-		fireEvent.click(backButton!);
-		expect(mockNavigateToRoom).toHaveBeenCalledOnce();
+	// ── Header ────────────────────────────────────────────────────────────────
+
+	it('renders mission title in header', () => {
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('mission-detail-title').textContent).toBe('Ship the feature');
+	});
+
+	it('renders status indicator', () => {
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('status-indicator').textContent).toBe('active');
+	});
+
+	it('renders short ID badge when shortId is present', () => {
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('short-id-badge').textContent).toBe('g-abc123');
+	});
+
+	it('does not render short ID badge when shortId is absent', () => {
+		const goal = { ...BASE_GOAL, shortId: undefined };
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ goal }));
+		const { queryByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(queryByTestId('short-id-badge')).toBeNull();
+	});
+
+	// ── Back button ───────────────────────────────────────────────────────────
+
+	it('back button calls navigateToRoom with correct roomId', () => {
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		fireEvent.click(getByTestId('mission-detail-back-button'));
 		expect(mockNavigateToRoom).toHaveBeenCalledWith('room-1');
 	});
 
-	it('calls navigateToRoom with a different roomId when roomId prop changes', () => {
-		const { container } = render(<MissionDetail roomId="room-42" goalId="goal-7" />);
-		const buttons = container.querySelectorAll('button');
-		const backButton = Array.from(buttons).find((b) => b.textContent?.includes('Back to Room'));
-		fireEvent.click(backButton!);
-		expect(mockNavigateToRoom).toHaveBeenCalledWith('room-42');
+	it('back button sets currentRoomTabSignal to "goals"', () => {
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		fireEvent.click(getByTestId('mission-detail-back-button'));
+		expect(mockCurrentRoomTabSignal.value).toBe('goals');
 	});
 
 	it('does not call navigateToRoom on initial render', () => {
-		render(<MissionDetail roomId="room-1" goalId="goal-1" />);
+		render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
 		expect(mockNavigateToRoom).not.toHaveBeenCalled();
+	});
+
+	// ── Edit action ───────────────────────────────────────────────────────────
+
+	it('edit button opens the edit modal', () => {
+		const { getByTestId, queryByTestId } = render(
+			<MissionDetail roomId="room-1" goalId="goal-uuid-1" />
+		);
+		expect(queryByTestId('modal')).toBeNull();
+		fireEvent.click(getByTestId('mission-detail-edit-button'));
+		expect(getByTestId('modal')).toBeTruthy();
+		expect(getByTestId('modal-title').textContent).toBe('Edit Mission');
+	});
+
+	it('edit modal contains GoalForm', () => {
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		fireEvent.click(getByTestId('mission-detail-edit-button'));
+		expect(getByTestId('goal-form')).toBeTruthy();
+	});
+
+	it('closes edit modal when GoalForm cancel is clicked', () => {
+		const { getByTestId, queryByTestId } = render(
+			<MissionDetail roomId="room-1" goalId="goal-uuid-1" />
+		);
+		fireEvent.click(getByTestId('mission-detail-edit-button'));
+		expect(getByTestId('modal')).toBeTruthy();
+		// Click Cancel inside GoalForm mock
+		const cancelBtn = getByTestId('modal').querySelector('button[type="button"]');
+		expect(cancelBtn).toBeTruthy();
+		fireEvent.click(cancelBtn!);
+		expect(queryByTestId('modal')).toBeNull();
+	});
+
+	// ── Delete action ─────────────────────────────────────────────────────────
+
+	it('delete button opens the confirm modal', () => {
+		const { getByTestId, queryByTestId } = render(
+			<MissionDetail roomId="room-1" goalId="goal-uuid-1" />
+		);
+		expect(queryByTestId('confirm-modal')).toBeNull();
+		fireEvent.click(getByTestId('mission-detail-delete-button'));
+		expect(getByTestId('confirm-modal')).toBeTruthy();
+		expect(getByTestId('confirm-modal-title').textContent).toBe('Delete Mission');
+	});
+
+	it('confirm delete calls deleteGoal', async () => {
+		const deleteGoal = vi.fn().mockResolvedValue(undefined);
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ deleteGoal }));
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		fireEvent.click(getByTestId('mission-detail-delete-button'));
+		await act(async () => {
+			fireEvent.click(getByTestId('mission-detail-delete-confirm'));
+		});
+		expect(deleteGoal).toHaveBeenCalled();
+	});
+
+	it('closes confirm modal when cancel is clicked', () => {
+		const { getByTestId, queryByTestId } = render(
+			<MissionDetail roomId="room-1" goalId="goal-uuid-1" />
+		);
+		fireEvent.click(getByTestId('mission-detail-delete-button'));
+		expect(getByTestId('confirm-modal')).toBeTruthy();
+		fireEvent.click(getByTestId('cancel-button'));
+		expect(queryByTestId('confirm-modal')).toBeNull();
+	});
+
+	// ── Status sidebar ────────────────────────────────────────────────────────
+
+	it('renders priority badge in sidebar', () => {
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('priority-badge').textContent).toBe('normal');
+	});
+
+	it('renders mission type badge in sidebar', () => {
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('mission-type-badge').textContent).toBe('one_shot');
+	});
+
+	it('renders autonomy badge in sidebar', () => {
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('autonomy-badge').textContent).toBe('supervised');
+	});
+
+	// ── Quick actions ─────────────────────────────────────────────────────────
+
+	it('shows "Mark Complete" action when complete is available', () => {
+		mockUseMissionDetailData.mockReturnValue(
+			makeDefaultHookResult({ availableStatusActions: ['complete'] })
+		);
+		const { getByText } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByText('✓ Mark Complete')).toBeTruthy();
+	});
+
+	it('shows "Needs Review" action when needs_human is available', () => {
+		mockUseMissionDetailData.mockReturnValue(
+			makeDefaultHookResult({ availableStatusActions: ['needs_human'] })
+		);
+		const { getByText } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByText('⚑ Needs Review')).toBeTruthy();
+	});
+
+	it('shows "Reactivate" action when reactivate is available', () => {
+		mockUseMissionDetailData.mockReturnValue(
+			makeDefaultHookResult({ availableStatusActions: ['reactivate'] })
+		);
+		const { getByText } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByText('↺ Reactivate')).toBeTruthy();
+	});
+
+	it('shows "Archive" action when archive is available', () => {
+		mockUseMissionDetailData.mockReturnValue(
+			makeDefaultHookResult({ availableStatusActions: ['archive'] })
+		);
+		const { getByText } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByText('Archive')).toBeTruthy();
+	});
+
+	it('does NOT show "Run Now" for one_shot missions', () => {
+		const { queryByText } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(queryByText('▶ Run Now')).toBeNull();
+	});
+
+	it('shows "Run Now" for recurring missions', () => {
+		const goal = { ...BASE_GOAL, missionType: 'recurring' as const };
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ goal }));
+		const { getByText } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByText('▶ Run Now')).toBeTruthy();
+	});
+
+	it('clicking "Run Now" calls triggerNow', async () => {
+		const triggerNow = vi.fn().mockResolvedValue(undefined);
+		const goal = { ...BASE_GOAL, missionType: 'recurring' as const };
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ goal, triggerNow }));
+		const { getByText } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		await act(async () => {
+			fireEvent.click(getByText('▶ Run Now'));
+		});
+		expect(triggerNow).toHaveBeenCalled();
+	});
+
+	it('clicking "↺ Reactivate" calls changeStatus with "reactivate"', async () => {
+		const changeStatus = vi.fn().mockResolvedValue(undefined);
+		mockUseMissionDetailData.mockReturnValue(
+			makeDefaultHookResult({ availableStatusActions: ['reactivate'], changeStatus })
+		);
+		const { getByText } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		await act(async () => {
+			fireEvent.click(getByText('↺ Reactivate'));
+		});
+		expect(changeStatus).toHaveBeenCalledWith('reactivate');
+	});
+
+	it('clicking "✓ Mark Complete" calls changeStatus with "complete"', async () => {
+		const changeStatus = vi.fn().mockResolvedValue(undefined);
+		mockUseMissionDetailData.mockReturnValue(
+			makeDefaultHookResult({ availableStatusActions: ['complete'], changeStatus })
+		);
+		const { getByText } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		await act(async () => {
+			fireEvent.click(getByText('✓ Mark Complete'));
+		});
+		expect(changeStatus).toHaveBeenCalledWith('complete');
+	});
+
+	// ── Hook invocation ───────────────────────────────────────────────────────
+
+	it('passes correct roomId and goalId to useMissionDetailData', () => {
+		render(<MissionDetail roomId="room-99" goalId="goal-abc" />);
+		expect(mockUseMissionDetailData).toHaveBeenCalledWith('room-99', 'goal-abc');
+	});
+
+	// ── Layout ────────────────────────────────────────────────────────────────
+
+	it('renders mission-detail root element with correct test id', () => {
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('mission-detail')).toBeTruthy();
+	});
+
+	it('renders main content area', () => {
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('mission-detail-main-content')).toBeTruthy();
 	});
 });

--- a/packages/web/src/components/room/__tests__/MissionDetail.test.tsx
+++ b/packages/web/src/components/room/__tests__/MissionDetail.test.tsx
@@ -197,6 +197,7 @@ function makeDefaultHookResult(
 ) {
 	return {
 		goal: BASE_GOAL,
+		goalsLoading: false,
 		linkedTasks: [],
 		executions: null,
 		isLoadingExecutions: false,
@@ -231,16 +232,50 @@ describe('MissionDetail', () => {
 
 	// ── Loading state ──────────────────────────────────────────────────────────
 
-	it('shows skeleton when goal is null (loading state)', () => {
-		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ goal: null }));
+	it('shows skeleton when goal is null and goalsLoading is true', () => {
+		mockUseMissionDetailData.mockReturnValue(
+			makeDefaultHookResult({ goal: null, goalsLoading: true })
+		);
 		const { getAllByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-1" />);
 		expect(getAllByTestId('skeleton').length).toBeGreaterThan(0);
 	});
 
-	it('does not show main content when goal is null', () => {
-		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ goal: null }));
+	it('does not show main content when loading', () => {
+		mockUseMissionDetailData.mockReturnValue(
+			makeDefaultHookResult({ goal: null, goalsLoading: true })
+		);
 		const { queryByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-1" />);
 		expect(queryByTestId('mission-detail')).toBeNull();
+		expect(queryByTestId('mission-not-found')).toBeNull();
+	});
+
+	// ── Not found state ────────────────────────────────────────────────────────
+
+	it('shows "Mission not found" when goal is null and goals have loaded', () => {
+		mockUseMissionDetailData.mockReturnValue(
+			makeDefaultHookResult({ goal: null, goalsLoading: false })
+		);
+		const { getByTestId, getByText } = render(<MissionDetail roomId="room-1" goalId="bad-id" />);
+		expect(getByTestId('mission-not-found')).toBeTruthy();
+		expect(getByText('Mission not found')).toBeTruthy();
+	});
+
+	it('not-found back button calls navigateToRoom and sets tab signal', () => {
+		mockUseMissionDetailData.mockReturnValue(
+			makeDefaultHookResult({ goal: null, goalsLoading: false })
+		);
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="bad-id" />);
+		fireEvent.click(getByTestId('mission-not-found-back-button'));
+		expect(mockNavigateToRoom).toHaveBeenCalledWith('room-1');
+		expect(mockCurrentRoomTabSignal.value).toBe('goals');
+	});
+
+	it('not-found state does not show the skeleton', () => {
+		mockUseMissionDetailData.mockReturnValue(
+			makeDefaultHookResult({ goal: null, goalsLoading: false })
+		);
+		const { queryByTestId } = render(<MissionDetail roomId="room-1" goalId="bad-id" />);
+		expect(queryByTestId('skeleton')).toBeNull();
 	});
 
 	// ── Header ────────────────────────────────────────────────────────────────
@@ -348,6 +383,32 @@ describe('MissionDetail', () => {
 		expect(getByTestId('confirm-modal')).toBeTruthy();
 		fireEvent.click(getByTestId('cancel-button'));
 		expect(queryByTestId('confirm-modal')).toBeNull();
+	});
+
+	// ── Disabled states ───────────────────────────────────────────────────────
+
+	it('edit button is disabled when isUpdating is true', () => {
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ isUpdating: true }));
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('mission-detail-edit-button').hasAttribute('disabled')).toBe(true);
+	});
+
+	it('edit button is enabled when isUpdating is false', () => {
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ isUpdating: false }));
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('mission-detail-edit-button').hasAttribute('disabled')).toBe(false);
+	});
+
+	it('delete button is disabled when isDeleting is true', () => {
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ isDeleting: true }));
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('mission-detail-delete-button').hasAttribute('disabled')).toBe(true);
+	});
+
+	it('delete button is enabled when isDeleting is false', () => {
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ isDeleting: false }));
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('mission-detail-delete-button').hasAttribute('disabled')).toBe(false);
 	});
 
 	// ── Status sidebar ────────────────────────────────────────────────────────

--- a/packages/web/src/hooks/__tests__/useMissionDetailData.test.ts
+++ b/packages/web/src/hooks/__tests__/useMissionDetailData.test.ts
@@ -28,6 +28,7 @@ vi.mock('../useMessageHub.ts', () => ({
 // roomStore mock — goals and tasks are signals so useComputed subscribes reactively.
 const mockGoalsSignal = signal<RoomGoal[]>([]);
 const mockTasksSignal = signal<NeoTask[]>([]);
+const mockGoalsLoadingSignal = signal<boolean>(false);
 
 const mockUpdateGoal = vi.fn();
 const mockDeleteGoal = vi.fn();
@@ -43,6 +44,9 @@ vi.mock('../../lib/room-store.ts', () => ({
 		},
 		get tasks() {
 			return mockTasksSignal;
+		},
+		get goalsLoading() {
+			return mockGoalsLoadingSignal;
 		},
 		updateGoal: (...args: unknown[]) => mockUpdateGoal(...args),
 		deleteGoal: (...args: unknown[]) => mockDeleteGoal(...args),
@@ -150,6 +154,18 @@ describe('useMissionDetailData — goal derivation', () => {
 		const { result } = renderHook(() => useMissionDetailData('room-1', 'nonexistent'));
 
 		expect(result.current.goal).toBeNull();
+	});
+
+	it('exposes goalsLoading=false when the store loading signal is false', () => {
+		mockGoalsLoadingSignal.value = false;
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+		expect(result.current.goalsLoading).toBe(false);
+	});
+
+	it('exposes goalsLoading=true when the store loading signal is true', () => {
+		mockGoalsLoadingSignal.value = true;
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+		expect(result.current.goalsLoading).toBe(true);
 	});
 
 	it('updates reactively when goal appears in store after mount', () => {

--- a/packages/web/src/hooks/useMissionDetailData.ts
+++ b/packages/web/src/hooks/useMissionDetailData.ts
@@ -19,6 +19,8 @@ export type AvailableStatusAction = 'complete' | 'reactivate' | 'needs_human' | 
 export interface UseMissionDetailDataResult {
 	/** Goal matching by UUID or short ID, null if not found or not yet loaded */
 	goal: RoomGoal | null;
+	/** True while the goals LiveQuery snapshot is in flight */
+	goalsLoading: boolean;
 	/** Tasks linked to this goal, derived reactively */
 	linkedTasks: NeoTask[];
 	/** Execution history — loaded on mount for recurring missions */
@@ -230,6 +232,7 @@ export function useMissionDetailData(roomId: string, goalId: string): UseMission
 
 	return {
 		goal: goal.value,
+		goalsLoading: roomStore.goalsLoading.value,
 		linkedTasks: linkedTasks.value,
 		executions,
 		isLoadingExecutions,


### PR DESCRIPTION
Implements the MissionDetail component header and status sidebar, replacing the placeholder with a full two-column layout.

**Changes:**
- Header: back button (navigates to room + sets goals tab), mission title, short ID badge, status indicator, edit/delete action buttons
- Edit action: opens `GoalForm` in a modal for inline editing
- Delete action: `ConfirmModal` with danger confirmation
- Two-column layout: `md:grid-cols-[1fr_320px]` responsive grid
- Status sidebar: priority/type/autonomy badges, conditional quick actions (Run Now for recurring; Reactivate/Complete/Needs Review/Archive based on status), created/updated timestamps
- Loading skeleton when goal is null
- All sub-components imported from GoalsEditor (no duplication)
- 30 unit tests covering header, back button, edit/delete modals, sidebar badges, quick actions, loading state