### PR TITLE
fix: resolve SQLite teardown race condition in daemon cleanup

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -606,7 +606,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 
 			// Cleanup RPC handlers (disposes live query subscriptions) before
 			// tearing down the engine so handles are disposed against a live engine.
-			rpcHandlerCleanup();
+			await rpcHandlerCleanup();
 
 			// Dispose live query engine after all subscriptions are cleared
 			liveQueries.dispose();

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -343,17 +343,21 @@ export class QueryRunner {
 					logger.error('Error handling SDK message:', error);
 					logger.error('Message type:', (message as SDKMessage).type);
 
-					const processingState = stateManager.getState();
-					await stateManager.setIdle();
+					// During cleanup the database may already be closed — skip
+					// state persistence to avoid cascading "closed database" errors.
+					if (!this.ctx.isCleaningUp()) {
+						const processingState = stateManager.getState();
+						await stateManager.setIdle();
 
-					await errorManager.handleError(
-						session.id,
-						error as Error,
-						ErrorCategory.MESSAGE,
-						'Error processing SDK message. The session has been reset.',
-						processingState,
-						{ messageType: (message as SDKMessage).type }
-					);
+						await errorManager.handleError(
+							session.id,
+							error as Error,
+							ErrorCategory.MESSAGE,
+							'Error processing SDK message. The session has been reset.',
+							processingState,
+							{ messageType: (message as SDKMessage).type }
+						);
+					}
 				}
 			}
 
@@ -373,6 +377,13 @@ export class QueryRunner {
 			}
 		} catch (error) {
 			logger.error('Streaming query error:', error);
+
+			// During cleanup the database may already be closed. Skip all
+			// error-recovery DB writes to avoid cascading "closed database"
+			// errors that escape as unhandled rejections.
+			if (this.ctx.isCleaningUp()) {
+				return;
+			}
 
 			const errorMessage = error instanceof Error ? error.message : String(error);
 			const isAbortError = error instanceof Error && error.name === 'AbortError';

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -131,9 +131,12 @@ export interface RPCHandlerDependencies {
 const log = new Logger('rpc-handlers');
 
 /**
- * Cleanup function type for RPC handlers
+ * Cleanup function type for RPC handlers.
+ *
+ * Returns a Promise to allow async teardown (e.g. awaiting in-flight SpaceRuntime ticks
+ * before the database is closed).
  */
-export type RPCHandlerCleanup = () => void;
+export type RPCHandlerCleanup = () => void | Promise<void>;
 
 /**
  * Result returned by setupRPCHandlers — includes both the cleanup function
@@ -701,11 +704,11 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 
 	// Return result with cleanup function and exposed services
 	return {
-		cleanup: () => {
+		cleanup: async () => {
 			unsubRoomCreated();
 			unsubLiveQuery();
 			roomRuntimeService.stop();
-			spaceRuntimeService.stop();
+			await spaceRuntimeService.stop();
 			fileIndex.dispose();
 		},
 		spaceRuntimeService,

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -707,6 +707,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		cleanup: async () => {
 			unsubRoomCreated();
 			unsubLiveQuery();
+			// roomRuntimeService.stop() is synchronous today. If it becomes
+			// async in the future, add await here to prevent silent promise discard.
 			roomRuntimeService.stop();
 			await spaceRuntimeService.stop();
 			fileIndex.dispose();

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -151,11 +151,11 @@ export class SpaceRuntimeService {
 		log.info('SpaceRuntimeService started');
 	}
 
-	/** Stop the underlying SpaceRuntime tick loop. */
-	stop(): void {
+	/** Stop the underlying SpaceRuntime tick loop and await in-flight ticks. */
+	async stop(): Promise<void> {
 		if (!this.started) return;
 		this.started = false;
-		this.runtime.stop();
+		await this.runtime.stop();
 		for (const unsub of this.unsubscribers) {
 			unsub();
 		}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -550,11 +550,20 @@ export class SpaceRuntime {
 		// reads/writes and DaemonHub event emissions complete before the
 		// caller proceeds to close the database.
 		if (this.tickInFlight) {
+			const MAX_TICK_DRAIN_MS = 30_000;
+			const start = Date.now();
 			await new Promise<void>((resolve) => {
 				const check = () => {
 					if (!this.tickInFlight) {
 						resolve();
+					} else if (Date.now() - start > MAX_TICK_DRAIN_MS) {
+						log.warn(
+							`SpaceRuntime: timed out waiting for in-flight tick after ${MAX_TICK_DRAIN_MS}ms — proceeding with shutdown`
+						);
+						resolve();
 					} else {
+						// 10 ms balances low latency (fast shutdown) against
+						// CPU churn (no busy-spin) during the drain window.
 						setTimeout(check, 10);
 					}
 				};

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -533,14 +533,33 @@ export class SpaceRuntime {
 	}
 
 	/**
-	 * Stops the periodic tick loop.
+	 * Stops the periodic tick loop and waits for any in-flight tick to complete.
+	 *
+	 * This prevents race conditions during shutdown where an in-flight tick
+	 * continues to perform DB operations after the database has been closed.
+	 *
 	 * Does not affect in-progress executors — they remain in the map and can
 	 * be resumed by calling start() again.
 	 */
-	stop(): void {
+	async stop(): Promise<void> {
 		if (this.tickTimer !== null) {
 			clearInterval(this.tickTimer);
 			this.tickTimer = null;
+		}
+		// Wait for any in-flight executeTick() to finish so that all DB
+		// reads/writes and DaemonHub event emissions complete before the
+		// caller proceeds to close the database.
+		if (this.tickInFlight) {
+			await new Promise<void>((resolve) => {
+				const check = () => {
+					if (!this.tickInFlight) {
+						resolve();
+					} else {
+						setTimeout(check, 10);
+					}
+				};
+				check();
+			});
 		}
 	}
 

--- a/packages/daemon/tests/unit/space/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-service.test.ts
@@ -222,26 +222,26 @@ describe('SpaceRuntimeService', () => {
 			expect((service as unknown as { started: boolean }).started).toBe(true);
 		});
 
-		test('stop() sets started to false', () => {
+		test('stop() sets started to false', async () => {
 			service.start();
-			service.stop();
+			await service.stop();
 			expect((service as unknown as { started: boolean }).started).toBe(false);
 		});
 
-		test('stop() is idempotent — calling twice is safe', () => {
+		test('stop() is idempotent — calling twice is safe', async () => {
 			service.start();
-			service.stop();
-			service.stop(); // should not throw
+			await service.stop();
+			await service.stop(); // should not throw
 			expect((service as unknown as { started: boolean }).started).toBe(false);
 		});
 
-		test('stop() on a never-started service is safe', () => {
-			expect(() => service.stop()).not.toThrow();
+		test('stop() on a never-started service is safe', async () => {
+			await expect(service.stop()).resolves.toBeUndefined();
 		});
 
 		test('can restart after stop', async () => {
 			service.start();
-			service.stop();
+			await service.stop();
 			service.start();
 			expect((service as unknown as { started: boolean }).started).toBe(true);
 
@@ -350,10 +350,10 @@ describe('SpaceRuntimeService', () => {
 			// getSessionAsync was called for the existing space
 			expect(sessionManager.getSessionAsync).toHaveBeenCalledWith(`space:chat:${mockSpace.id}`);
 
-			svc.stop();
+			await svc.stop();
 		});
 
-		test('start() subscribes to space.created events when daemonHub provided', () => {
+		test('start() subscribes to space.created events when daemonHub provided', async () => {
 			const session = makeSession();
 			const sessionManager = makeSessionManager(session);
 			const daemonHub: DaemonHub = {
@@ -373,10 +373,10 @@ describe('SpaceRuntimeService', () => {
 			const spaceCreatedCall = onCalls.find(([event]) => event === 'space.created');
 			expect(spaceCreatedCall).toBeDefined();
 
-			svc.stop();
+			await svc.stop();
 		});
 
-		test('stop() unsubscribes from space.created events', () => {
+		test('stop() unsubscribes from space.created events', async () => {
 			const unsubFn = mock(() => {});
 			const session = makeSession();
 			const sessionManager = makeSessionManager(session);
@@ -391,7 +391,7 @@ describe('SpaceRuntimeService', () => {
 			const svc = new SpaceRuntimeService(config);
 
 			svc.start();
-			svc.stop();
+			await svc.stop();
 
 			expect(unsubFn).toHaveBeenCalledTimes(1);
 		});

--- a/packages/daemon/tests/unit/space/space-runtime-tick-loop.test.ts
+++ b/packages/daemon/tests/unit/space/space-runtime-tick-loop.test.ts
@@ -768,7 +768,7 @@ describe('SpaceRuntime — tick loop correctness', () => {
 	// -------------------------------------------------------------------------
 
 	describe('start() / stop() lifecycle', () => {
-		test('start() is idempotent — calling twice does not create duplicate timers', () => {
+		test('start() is idempotent — calling twice does not create duplicate timers', async () => {
 			// Intercept setInterval to count how many timers are created
 			const origSetInterval = globalThis.setInterval;
 			let intervalCount = 0;
@@ -784,13 +784,13 @@ describe('SpaceRuntime — tick loop correctness', () => {
 
 				// Only one interval should have been created
 				expect(intervalCount).toBe(1);
-				rt.stop();
+				await rt.stop();
 			} finally {
 				globalThis.setInterval = origSetInterval;
 			}
 		});
 
-		test('stop() clears the timer — clearInterval is called', () => {
+		test('stop() clears the timer — clearInterval is called', async () => {
 			// Use a deterministic approach: intercept clearInterval to verify it's called
 			const origClearInterval = globalThis.clearInterval;
 			let clearCalled = false;
@@ -804,21 +804,21 @@ describe('SpaceRuntime — tick loop correctness', () => {
 				rt.start();
 				expect(clearCalled).toBe(false);
 
-				rt.stop();
+				await rt.stop();
 				expect(clearCalled).toBe(true);
 			} finally {
 				globalThis.clearInterval = origClearInterval;
 			}
 		});
 
-		test('stop() when not started is a no-op', () => {
+		test('stop() when not started is a no-op', async () => {
 			const rt = new SpaceRuntime(buildConfig());
 
 			// Should not throw
-			expect(() => rt.stop()).not.toThrow();
+			await expect(rt.stop()).resolves.toBeUndefined();
 		});
 
-		test('start() can be called again after stop() — creates a new timer', () => {
+		test('start() can be called again after stop() — creates a new timer', async () => {
 			const origSetInterval = globalThis.setInterval;
 			let intervalCount = 0;
 			globalThis.setInterval = ((...args: Parameters<typeof setInterval>) => {
@@ -832,13 +832,13 @@ describe('SpaceRuntime — tick loop correctness', () => {
 				rt.start();
 				expect(intervalCount).toBe(1);
 
-				rt.stop();
+				await rt.stop();
 
 				// Restart — should create a new interval
 				rt.start();
 				expect(intervalCount).toBe(2);
 
-				rt.stop();
+				await rt.stop();
 			} finally {
 				globalThis.setInterval = origSetInterval;
 			}


### PR DESCRIPTION
## Summary

- **SpaceRuntime.stop()** was synchronous (only `clearInterval`), allowing in-flight `executeTick()` to continue performing DB reads/writes after `db.close()`. Made `stop()` async — it now polls `tickInFlight` until the current tick completes before returning.
- **QueryRunner.runQuery()** error-recovery paths performed DB writes (`stateManager.setIdle`, `errorManager.handleError`) that threw `RangeError: Cannot use a closed database` when cleanup had already closed the DB. These cascading errors escaped as unhandled promise rejections, causing the test process to exit with code 1 despite all tests passing. Added `isCleaningUp()` guards to skip state persistence during teardown.
- **RPCHandlerCleanup** type updated to `() => void | Promise<void>` to support async teardown. `app.ts` cleanup now `await`s the handler cleanup.

## Test plan

- [x] `bun test packages/daemon/tests/online/space/task-agent-lifecycle.test.ts` — passes with exit code 0
- [x] Lint, format, typecheck, knip all pass