### PR TITLE
fix: resolve task agent worktree path under ~/.neokai instead of source repo

### DIFF
--- a/packages/daemon/src/lib/space/managers/space-worktree-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-worktree-manager.ts
@@ -4,7 +4,7 @@
  * Manages git worktrees for Space tasks. One worktree per task, created from
  * the space's repository workspace path.
  *
- * Worktree location : {spaceWorkspacePath}/.worktrees/{slug}/
+ * Worktree location : ~/.neokai/projects/{shortKey}/worktrees/{slug}/
  * Branch naming     : space/{slug}
  *
  * Does NOT extend Room's WorktreeManager — uses execSync directly.
@@ -20,6 +20,7 @@ import { worktreeSlug } from '../worktree-slug';
 import { Logger } from '../../logger';
 import { retryWithBackoff } from '../runtime/retry-utils';
 import { MAX_NETWORK_RETRIES, NETWORK_RETRY_DELAYS_MS } from '../runtime/constants';
+import { getWorktreeBaseDir } from '../../worktree-path-utils';
 
 export interface SpaceWorktreeInfo {
 	slug: string;
@@ -72,8 +73,8 @@ export class SpaceWorktreeManager {
 		const existingSlugs = this.worktreeRepo.listSlugs(spaceId);
 		const slug = worktreeSlug(taskTitle, taskNumber, existingSlugs);
 
-		// Ensure the .worktrees directory exists inside the workspace
-		const worktreesDir = join(space.workspacePath, '.worktrees');
+		// Resolve worktree base directory under ~/.neokai/projects/{shortKey}/worktrees/
+		const worktreesDir = getWorktreeBaseDir(space.workspacePath, (msg) => this.logger.warn(msg));
 		if (!existsSync(worktreesDir)) {
 			mkdirSync(worktreesDir, { recursive: true });
 		}

--- a/packages/daemon/src/lib/worktree-manager.ts
+++ b/packages/daemon/src/lib/worktree-manager.ts
@@ -1,9 +1,9 @@
 import simpleGit, { SimpleGit } from 'simple-git';
-import { basename, dirname, join, normalize } from 'node:path';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { dirname, join, normalize } from 'node:path';
+import { existsSync, mkdirSync } from 'node:fs';
 import type { WorktreeMetadata, CommitInfo, WorktreeCommitStatus } from '@neokai/shared';
 import { Logger } from './logger';
+import { getProjectShortKey, getWorktreeBaseDir } from './worktree-path-utils';
 
 export interface WorktreeInfo {
 	path: string;
@@ -143,101 +143,23 @@ export class WorktreeManager {
 	}
 
 	/**
-	 * Encode an absolute path to a filesystem-safe directory name
-	 * Uses the same approach as Claude Code (~/.claude/projects/)
-	 *
-	 * Examples:
-	 * - /Users/alice/project → -Users-alice-project
-	 * - /home/john_doe/my_project → -home-john_doe-my_project
-	 * - C:\Users\alice\project → -C--Users-alice-project
-	 */
-	private encodeRepoPath(repoPath: string): string {
-		// Normalize path separators (handle both Unix and Windows)
-		const normalizedPath = repoPath.replace(/\\/g, '/');
-
-		// Strip leading slash (if any) and replace remaining slashes with dashes
-		// Then prepend a dash to indicate it was an absolute path
-		const encoded = normalizedPath.startsWith('/')
-			? '-' + normalizedPath.slice(1).replace(/\//g, '-')
-			: '-' + normalizedPath.replace(/\//g, '-');
-
-		return encoded;
-	}
-
-	/**
 	 * Produce a short, deterministic, human-readable directory name for a repo path.
 	 *
-	 * Format: `{sanitized-basename}-{8-char-hex-hash}`
-	 * Example: `dev-neokai-a3b2c1d4`
-	 *
-	 * The 8-char hex hash is derived from the lower 32 bits of `Bun.hash()` applied
-	 * to the full normalized path, using BigInt arithmetic to avoid truncation above
-	 * 2^53 that `Number(bigint).toString(16)` would silently produce.
+	 * Delegates to the standalone {@link getProjectShortKey} utility.
+	 * Kept as a public instance method for backward compatibility.
 	 */
 	public getProjectShortKey(repoPath: string): string {
-		const normalizedPath = normalize(repoPath).replace(/\\/g, '/');
-		const lastComponent = basename(normalizedPath);
-		// Keep alphanumeric, hyphens, underscores; replace anything else with '-'
-		const sanitized = lastComponent.replace(/[^a-zA-Z0-9_-]/g, '-') || 'project';
-		// Lower 32 bits of Bun.hash as an 8-char zero-padded hex string
-		const hash8 = (BigInt(Bun.hash(normalizedPath)) & 0xffff_ffffn).toString(16).padStart(8, '0');
-		return `${sanitized}-${hash8}`;
+		return getProjectShortKey(repoPath);
 	}
 
 	/**
 	 * Get the worktree base directory for a repository.
 	 *
-	 * Uses a short human-readable key (`{basename}-{hash8}`) instead of the full
-	 * encoded path, with a `.neokai-repo-root` sentinel file for collision detection.
-	 *
-	 * Collision handling:
-	 * - First use   → create `~/.neokai/projects/{shortKey}/` and write sentinel.
-	 * - Same repo   → sentinel matches; proceed normally.
-	 * - Collision   → sentinel belongs to a different repo; log a warning and fall
-	 *                 back to `encodeRepoPath` so both repos use distinct directories.
-	 * - No sentinel → dir was created by an older NeoKai version; write sentinel and
-	 *                 proceed normally.
-	 *
-	 * All I/O is synchronous to keep the method signature synchronous and avoid
-	 * cascading `async` changes to `createWorktree` and its callers.
-	 *
-	 * For testing, set TEST_WORKTREE_BASE_DIR to override the `~/.neokai` prefix.
+	 * Delegates to the standalone {@link getWorktreeBaseDir} utility.
+	 * Kept as a private instance method to avoid cascading async changes.
 	 */
 	private getWorktreeBaseDir(gitRoot: string): string {
-		const normalizedGitRoot = normalize(gitRoot).replace(/\\/g, '/');
-		const shortKey = this.getProjectShortKey(normalizedGitRoot);
-
-		const testBaseDir = process.env.TEST_WORKTREE_BASE_DIR;
-		const projectDir = testBaseDir
-			? join(testBaseDir, shortKey)
-			: join(homedir(), '.neokai', 'projects', shortKey);
-
-		const sentinelFile = join(projectDir, '.neokai-repo-root');
-
-		if (!existsSync(projectDir)) {
-			// First use: create the project directory and record the repo path
-			mkdirSync(projectDir, { recursive: true });
-			writeFileSync(sentinelFile, normalizedGitRoot);
-		} else if (existsSync(sentinelFile)) {
-			const storedPath = readFileSync(sentinelFile, 'utf-8').trim();
-			if (storedPath !== normalizedGitRoot) {
-				// Hash collision: a different repo already owns this short key
-				this.logger.warn(
-					`Short key collision detected for "${shortKey}": expected "${storedPath}", got "${normalizedGitRoot}". Falling back to full encoding.`
-				);
-				const encodedPath = this.encodeRepoPath(normalizedGitRoot);
-				const fallbackProjectDir = testBaseDir
-					? join(testBaseDir, encodedPath)
-					: join(homedir(), '.neokai', 'projects', encodedPath);
-				return join(fallbackProjectDir, 'worktrees');
-			}
-			// Same repo — proceed normally
-		} else {
-			// Directory exists but no sentinel (created by an older NeoKai version)
-			writeFileSync(sentinelFile, normalizedGitRoot);
-		}
-
-		return join(projectDir, 'worktrees');
+		return getWorktreeBaseDir(gitRoot, (msg) => this.logger.warn(msg));
 	}
 
 	/**

--- a/packages/daemon/src/lib/worktree-path-utils.ts
+++ b/packages/daemon/src/lib/worktree-path-utils.ts
@@ -1,0 +1,104 @@
+/**
+ * Shared worktree path utilities.
+ *
+ * Provides standalone functions for resolving worktree base directories
+ * under `~/.neokai/projects/`. Used by both `WorktreeManager` (room sessions)
+ * and `SpaceWorktreeManager` (space task agents).
+ */
+
+import { basename, join, normalize } from 'node:path';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+
+/**
+ * Encode an absolute path to a filesystem-safe directory name.
+ *
+ * Uses the same approach as Claude Code (~/.claude/projects/).
+ *
+ * Examples:
+ * - /Users/alice/project → -Users-alice-project
+ * - /home/john_doe/my_project → -home-john_doe-my_project
+ */
+export function encodeRepoPath(repoPath: string): string {
+	const normalizedPath = repoPath.replace(/\\/g, '/');
+
+	const encoded = normalizedPath.startsWith('/')
+		? '-' + normalizedPath.slice(1).replace(/\//g, '-')
+		: '-' + normalizedPath.replace(/\//g, '-');
+
+	return encoded;
+}
+
+/**
+ * Produce a short, deterministic, human-readable directory name for a repo path.
+ *
+ * Format: `{sanitized-basename}-{8-char-hex-hash}`
+ * Example: `dev-neokai-a3b2c1d4`
+ *
+ * The 8-char hex hash is derived from the lower 32 bits of `Bun.hash()` applied
+ * to the full normalized path, using BigInt arithmetic to avoid truncation above
+ * 2^53 that `Number(bigint).toString(16)` would silently produce.
+ */
+export function getProjectShortKey(repoPath: string): string {
+	const normalizedPath = normalize(repoPath).replace(/\\/g, '/');
+	const lastComponent = basename(normalizedPath);
+	const sanitized = lastComponent.replace(/[^a-zA-Z0-9_-]/g, '-') || 'project';
+	const hash8 = (BigInt(Bun.hash(normalizedPath)) & 0xffff_ffffn).toString(16).padStart(8, '0');
+	return `${sanitized}-${hash8}`;
+}
+
+/**
+ * Resolve the worktree base directory for a git repository.
+ *
+ * Uses a short human-readable key (`{basename}-{hash8}`) instead of the full
+ * encoded path, with a `.neokai-repo-root` sentinel file for collision detection.
+ *
+ * Returns the directory where worktree subdirectories should be created, e.g.:
+ *   `~/.neokai/projects/{shortKey}/worktrees`
+ *
+ * Collision handling:
+ * - First use   → create `~/.neokai/projects/{shortKey}/` and write sentinel.
+ * - Same repo   → sentinel matches; proceed normally.
+ * - Collision   → sentinel belongs to a different repo; fall back to `encodeRepoPath`.
+ * - No sentinel → dir was created by an older NeoKai version; write sentinel and proceed.
+ *
+ * For testing, set TEST_WORKTREE_BASE_DIR to override the `~/.neokai` prefix.
+ *
+ * @param gitRoot  - Absolute path to the git repository root
+ * @param onCollision - Optional callback invoked when a hash collision is detected
+ */
+export function getWorktreeBaseDir(
+	gitRoot: string,
+	onCollision?: (message: string) => void
+): string {
+	const normalizedGitRoot = normalize(gitRoot).replace(/\\/g, '/');
+	const shortKey = getProjectShortKey(normalizedGitRoot);
+
+	const testBaseDir = process.env.TEST_WORKTREE_BASE_DIR;
+	const projectDir = testBaseDir
+		? join(testBaseDir, shortKey)
+		: join(homedir(), '.neokai', 'projects', shortKey);
+
+	const sentinelFile = join(projectDir, '.neokai-repo-root');
+
+	if (!existsSync(projectDir)) {
+		mkdirSync(projectDir, { recursive: true });
+		writeFileSync(sentinelFile, normalizedGitRoot);
+	} else if (existsSync(sentinelFile)) {
+		const storedPath = readFileSync(sentinelFile, 'utf-8').trim();
+		if (storedPath !== normalizedGitRoot) {
+			const msg = `Short key collision detected for "${shortKey}": expected "${storedPath}", got "${normalizedGitRoot}". Falling back to full encoding.`;
+			onCollision?.(msg);
+
+			const encodedPath = encodeRepoPath(normalizedGitRoot);
+			const fallbackProjectDir = testBaseDir
+				? join(testBaseDir, encodedPath)
+				: join(homedir(), '.neokai', 'projects', encodedPath);
+			return join(fallbackProjectDir, 'worktrees');
+		}
+	} else {
+		writeFileSync(sentinelFile, normalizedGitRoot);
+	}
+
+	return join(projectDir, 'worktrees');
+}

--- a/packages/daemon/tests/unit/lib/worktree-path-utils.test.ts
+++ b/packages/daemon/tests/unit/lib/worktree-path-utils.test.ts
@@ -1,0 +1,182 @@
+/**
+ * worktree-path-utils unit tests
+ *
+ * Tests for the shared worktree path resolution utilities used by both
+ * WorktreeManager (room sessions) and SpaceWorktreeManager (space task agents).
+ */
+
+import { describe, test, expect, beforeEach, afterEach, spyOn, mock } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import {
+	encodeRepoPath,
+	getProjectShortKey,
+	getWorktreeBaseDir,
+} from '../../../src/lib/worktree-path-utils';
+
+describe('worktree-path-utils', () => {
+	let existsSyncResults: Map<string, boolean>;
+	let existsSyncSpy: ReturnType<typeof spyOn>;
+	let mkdirSyncSpy: ReturnType<typeof spyOn>;
+	let writeFileSyncSpy: ReturnType<typeof spyOn>;
+	let readFileSyncSpy: ReturnType<typeof spyOn>;
+	let homedirSpy: ReturnType<typeof spyOn>;
+
+	beforeEach(() => {
+		existsSyncResults = new Map();
+
+		existsSyncSpy = spyOn(fs, 'existsSync').mockImplementation((path) => {
+			return existsSyncResults.get(path as string) ?? false;
+		});
+
+		mkdirSyncSpy = spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as unknown as string);
+		writeFileSyncSpy = spyOn(fs, 'writeFileSync').mockImplementation(() => undefined);
+		readFileSyncSpy = spyOn(fs, 'readFileSync').mockImplementation((): string => '/test/repo');
+		homedirSpy = spyOn(os, 'homedir').mockReturnValue('/home/testuser');
+	});
+
+	afterEach(() => {
+		existsSyncSpy.mockRestore();
+		mkdirSyncSpy.mockRestore();
+		writeFileSyncSpy.mockRestore();
+		readFileSyncSpy.mockRestore();
+		homedirSpy.mockRestore();
+	});
+
+	describe('encodeRepoPath', () => {
+		test('encodes absolute Unix paths', () => {
+			expect(encodeRepoPath('/Users/alice/project')).toBe('-Users-alice-project');
+		});
+
+		test('encodes deep paths', () => {
+			expect(encodeRepoPath('/home/john_doe/my_project')).toBe('-home-john_doe-my_project');
+		});
+
+		test('handles non-absolute paths', () => {
+			expect(encodeRepoPath('relative/path')).toBe('-relative-path');
+		});
+
+		test('handles Windows-style paths', () => {
+			// Colons (drive letter separator) are preserved, backslashes become dashes
+			expect(encodeRepoPath('C:\\Users\\alice\\project')).toBe('-C:-Users-alice-project');
+		});
+	});
+
+	describe('getProjectShortKey', () => {
+		test('produces deterministic output for the same path', () => {
+			const path = '/Users/alice/code/my-project';
+			expect(getProjectShortKey(path)).toBe(getProjectShortKey(path));
+		});
+
+		test('produces short key with 8-char hex suffix', () => {
+			const key = getProjectShortKey('/Users/alice/code/my-project');
+			expect(key).toMatch(/^my-project-[0-9a-f]{8}$/);
+		});
+
+		test('sanitizes special characters in basename', () => {
+			const key = getProjectShortKey('/Users/alice/some.weird path/my@project!');
+			// `my@project!` → `my-project-` (trailing dash from `!`), then separator `-` → `my-project--hash`
+			expect(key).toMatch(/^my-project--[0-9a-f]{8}$/);
+		});
+
+		test('different paths produce different keys', () => {
+			const key1 = getProjectShortKey('/Users/alice/project-a');
+			const key2 = getProjectShortKey('/Users/bob/project-a');
+			expect(key1).not.toBe(key2);
+		});
+
+		test('produces a valid key even when basename is all special chars', () => {
+			const key = getProjectShortKey('/path/...');
+			// `...` sanitizes to `---`, then `-` separator + hash8 → `----<hash8>`
+			expect(key).toMatch(/^----[0-9a-f]{8}$/);
+		});
+	});
+
+	describe('getWorktreeBaseDir', () => {
+		test('creates project dir and sentinel on first use', () => {
+			const repoPath = '/Users/alice/my-app';
+			const shortKey = getProjectShortKey(repoPath);
+
+			// Project dir doesn't exist yet
+			existsSyncResults.set(`/home/testuser/.neokai/projects/${shortKey}`, false);
+
+			const result = getWorktreeBaseDir(repoPath);
+
+			expect(result).toBe(`/home/testuser/.neokai/projects/${shortKey}/worktrees`);
+			expect(mkdirSyncSpy).toHaveBeenCalledWith(`/home/testuser/.neokai/projects/${shortKey}`, {
+				recursive: true,
+			});
+			expect(writeFileSyncSpy).toHaveBeenCalledWith(
+				`/home/testuser/.neokai/projects/${shortKey}/.neokai-repo-root`,
+				repoPath
+			);
+		});
+
+		test('returns same path when sentinel matches (same repo)', () => {
+			const repoPath = '/Users/bob/cool-lib';
+			const shortKey = getProjectShortKey(repoPath);
+
+			// Project dir exists
+			existsSyncResults.set(`/home/testuser/.neokai/projects/${shortKey}`, true);
+			// Sentinel exists and matches
+			existsSyncResults.set(`/home/testuser/.neokai/projects/${shortKey}/.neokai-repo-root`, true);
+			readFileSyncSpy.mockImplementation(() => repoPath);
+
+			const result = getWorktreeBaseDir(repoPath);
+
+			expect(result).toBe(`/home/testuser/.neokai/projects/${shortKey}/worktrees`);
+		});
+
+		test('falls back to encoded path on collision', () => {
+			const repoPath = '/Users/carol/projects/app';
+			const shortKey = getProjectShortKey(repoPath);
+			const otherPath = '/Users/dave/different-repo';
+
+			// Project dir exists
+			existsSyncResults.set(`/home/testuser/.neokai/projects/${shortKey}`, true);
+			// Sentinel exists
+			existsSyncResults.set(`/home/testuser/.neokai/projects/${shortKey}/.neokai-repo-root`, true);
+			// Sentinel contains a DIFFERENT repo path → collision
+			readFileSyncSpy.mockImplementation(() => otherPath);
+
+			const collisions: string[] = [];
+			const result = getWorktreeBaseDir(repoPath, (msg) => collisions.push(msg));
+
+			const encoded = encodeRepoPath(repoPath);
+			expect(result).toBe(`/home/testuser/.neokai/projects/${encoded}/worktrees`);
+			expect(collisions.length).toBe(1);
+			expect(collisions[0]).toContain('collision');
+		});
+
+		test('writes sentinel when dir exists but no sentinel (legacy)', () => {
+			const repoPath = '/Users/legacy/app';
+			const shortKey = getProjectShortKey(repoPath);
+
+			// Project dir exists
+			existsSyncResults.set(`/home/testuser/.neokai/projects/${shortKey}`, true);
+			// No sentinel file
+			existsSyncResults.set(`/home/testuser/.neokai/projects/${shortKey}/.neokai-repo-root`, false);
+
+			const result = getWorktreeBaseDir(repoPath);
+
+			expect(result).toBe(`/home/testuser/.neokai/projects/${shortKey}/worktrees`);
+			expect(writeFileSyncSpy).toHaveBeenCalledWith(
+				`/home/testuser/.neokai/projects/${shortKey}/.neokai-repo-root`,
+				repoPath
+			);
+		});
+
+		test('respects TEST_WORKTREE_BASE_DIR env var', () => {
+			const repoPath = '/test/repo';
+			const shortKey = getProjectShortKey(repoPath);
+
+			process.env.TEST_WORKTREE_BASE_DIR = '/tmp/test-worktrees';
+			existsSyncResults.set(`/tmp/test-worktrees/${shortKey}`, false);
+
+			const result = getWorktreeBaseDir(repoPath);
+
+			expect(result).toBe(`/tmp/test-worktrees/${shortKey}/worktrees`);
+			delete process.env.TEST_WORKTREE_BASE_DIR;
+		});
+	});
+});

--- a/packages/daemon/tests/unit/space/space-worktree-manager.test.ts
+++ b/packages/daemon/tests/unit/space/space-worktree-manager.test.ts
@@ -5,6 +5,9 @@
  * operations.  Each test suite creates its own isolated git repo and SQLite
  * database so that tests are fully independent.
  *
+ * TEST_WORKTREE_BASE_DIR is set so worktrees are created under the temp
+ * directory instead of ~/.neokai.
+ *
  * Covered scenarios:
  * - createTaskWorktree: creates filesystem worktree + DB record
  * - createTaskWorktree: idempotent (returns existing record on second call)
@@ -25,6 +28,7 @@ import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../src/storage/schema/index.ts';
 import { SpaceWorktreeManager } from '../../../src/lib/space/managers/space-worktree-manager.ts';
 import { worktreeSlug } from '../../../src/lib/space/worktree-slug.ts';
+import { getProjectShortKey } from '../../../src/lib/worktree-path-utils.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -42,7 +46,7 @@ async function makeGitRepo(label: string): Promise<string> {
 
 	execSync('git -c init.defaultBranch=main init', { cwd: dir, stdio: 'pipe' });
 	execSync('git config user.name "Test User"', { cwd: dir });
-	execSync('git config user.email "test@example.com"', { cwd: dir });
+	execSync('git config user.email "test@example.com"');
 
 	// Create an initial commit so HEAD exists and worktrees can be based on it
 	writeFileSync(join(dir, 'README.md'), '# test\n');
@@ -64,8 +68,8 @@ function makeDb(workspacePath: string): { db: BunDatabase; spaceId: string } {
 	const spaceId = `space-${Math.random().toString(36).slice(2)}`;
 	db.prepare(
 		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-     allowed_models, session_ids, slug, status, created_at, updated_at)
-     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	     allowed_models, session_ids, slug, status, created_at, updated_at)
+	     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
 	).run(spaceId, workspacePath, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
 
 	return { db, spaceId };
@@ -78,19 +82,25 @@ function makeDb(workspacePath: string): { db: BunDatabase; spaceId: string } {
 function seedTask(db: BunDatabase, spaceId: string, taskId: string, taskNumber: number): string {
 	db.prepare(
 		`INSERT INTO space_tasks
-       (id, space_id, task_number, title, description, status, priority, depends_on, created_at, updated_at)
-     VALUES (?, ?, ?, ?, '', 'open', 'normal', '[]', ?, ?)`
+	       (id, space_id, task_number, title, description, status, priority, depends_on, created_at, updated_at)
+	     VALUES (?, ?, ?, ?, '', 'open', 'normal', '[]', ?, ?)`
 	).run(taskId, spaceId, taskNumber, `Task ${taskNumber}`, Date.now(), Date.now());
 	return taskId;
 }
 
 let repoDir: string;
+let testBaseDir: string;
 let db: BunDatabase;
 let spaceId: string;
 let manager: SpaceWorktreeManager;
 
 beforeEach(async () => {
 	repoDir = await makeGitRepo('repo');
+	// Set TEST_WORKTREE_BASE_DIR so worktrees go to a controlled temp location
+	testBaseDir = join(TMP_ROOT, `neokai-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	mkdirSync(testBaseDir, { recursive: true });
+	process.env.TEST_WORKTREE_BASE_DIR = testBaseDir;
+
 	const setup = makeDb(repoDir);
 	db = setup.db;
 	spaceId = setup.spaceId;
@@ -99,8 +109,14 @@ beforeEach(async () => {
 
 afterEach(() => {
 	db.close();
+	delete process.env.TEST_WORKTREE_BASE_DIR;
 	try {
 		rmSync(repoDir, { recursive: true, force: true });
+	} catch {
+		// Ignore cleanup failures in CI
+	}
+	try {
+		rmSync(testBaseDir, { recursive: true, force: true });
 	} catch {
 		// Ignore cleanup failures in CI
 	}
@@ -116,8 +132,18 @@ describe('createTaskWorktree', () => {
 		const result = await manager.createTaskWorktree(spaceId, taskId, 'Add feature', 1);
 
 		expect(result.slug).toBe(worktreeSlug('Add feature', 1));
-		expect(result.path).toContain('.worktrees');
 		expect(result.path).toContain(result.slug);
+		expect(result.path).toContain('worktrees');
+		expect(existsSync(result.path)).toBe(true);
+	});
+
+	test('creates worktree under TEST_WORKTREE_BASE_DIR, not inside source repo', async () => {
+		const taskId = seedTask(db, spaceId, 'task-001b', 1);
+		const result = await manager.createTaskWorktree(spaceId, taskId, 'Feature B', 1);
+
+		// Path should be under testBaseDir, not under repoDir
+		expect(result.path).toContain(testBaseDir);
+		expect(result.path).not.toContain(repoDir);
 		expect(existsSync(result.path)).toBe(true);
 	});
 
@@ -221,7 +247,8 @@ describe('createTaskWorktree', () => {
 	test('recovers from stale directory left by a crashed previous run', async () => {
 		const taskId = seedTask(db, spaceId, 'task-stale-dir', 99);
 		const slug = worktreeSlug('Stale Dir Task', 99);
-		const expectedPath = join(repoDir, '.worktrees', slug);
+		const shortKey = getProjectShortKey(repoDir);
+		const expectedPath = join(testBaseDir, shortKey, 'worktrees', slug);
 
 		// Simulate a partial previous run: directory exists but no DB record
 		mkdirSync(expectedPath, { recursive: true });
@@ -233,12 +260,9 @@ describe('createTaskWorktree', () => {
 	});
 
 	test('recovers stale branch via git worktree prune when branch is in a prunable worktree', async () => {
-		// Simulate a previous crash: create a worktree, then delete its directory
-		// without pruning, leaving git with a stale worktree reference. The branch
-		// `git branch -D` will fail on the first attempt ("used by worktree"), but
-		// after `git worktree prune` the stale reference is removed and the second
-		// attempt should succeed, allowing a fresh worktree to be created.
-		const stalePath = join(repoDir, '.worktrees', 'prune-test-stale');
+		const shortKey = getProjectShortKey(repoDir);
+		const stalePath = join(testBaseDir, shortKey, 'worktrees', 'prune-test-stale');
+		mkdirSync(join(testBaseDir, shortKey, 'worktrees'), { recursive: true });
 		execSync(`git worktree add "${stalePath}" -b space/prune-test HEAD`, { cwd: repoDir });
 		// Verify the branch exists
 		const branchesBeforeRm = execSync('git branch --list', { cwd: repoDir }).toString();
@@ -366,8 +390,8 @@ describe('listWorktrees', () => {
 		const otherSpaceId = `space-other-${Math.random().toString(36).slice(2)}`;
 		db.prepare(
 			`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
-       allowed_models, session_ids, slug, status, created_at, updated_at)
-       VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	       allowed_models, session_ids, slug, status, created_at, updated_at)
+	       VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
 		).run(
 			otherSpaceId,
 			`/tmp/other-workspace-${Math.random()}`,


### PR DESCRIPTION
## Summary
- Extract `getWorktreeBaseDir`, `getProjectShortKey`, `encodeRepoPath` into shared `worktree-path-utils.ts`
- `SpaceWorktreeManager` now resolves worktree paths to `~/.neokai/projects/{shortKey}/worktrees/` instead of `{sourceRepo}/.worktrees/`
- `WorktreeManager` delegates to the same shared utility (no behavioral change)

## Problem
Task agent worktrees were being created inside the source repository directory (e.g., `/Users/lsm/focus/atlas/.worktrees/add-health-check-endpoint`), which:
1. Pollutes source repo directories with `.worktrees/` folders
2. Causes session files to be lost when worktrees are cleaned up from the source side
3. Leads to "No conversation found with session ID" errors when sessions can't be resumed

## Fix
`SpaceWorktreeManager.createTaskWorktree()` now calls `getWorktreeBaseDir()` (from the new shared utility) which resolves to `~/.neokai/projects/{shortKey}/worktrees/` — the same pattern used by `WorktreeManager` for room sessions.

## Test plan
- [x] 14 new unit tests for `worktree-path-utils.ts`
- [x] 22 existing `SpaceWorktreeManager` tests updated and passing
- [x] 53 existing `WorktreeManager` tests still passing (refactoring only)
- [x] 22 existing `TaskAgentManager` worktree tests still passing
- [x] Lint, typecheck, knip all pass