### PR TITLE
feat: MissionDetail main content sections

### DIFF
--- a/packages/e2e/tests/features/mission-detail-page.e2e.ts
+++ b/packages/e2e/tests/features/mission-detail-page.e2e.ts
@@ -1,0 +1,558 @@
+/**
+ * MissionDetail Page E2E Tests
+ *
+ * Tests the dedicated MissionDetail page at `/room/:roomId/mission/:goalId`.
+ * This is distinct from the GoalsEditor accordion-style inline expanded view
+ * tested in mission-detail.e2e.ts.
+ *
+ * Covers:
+ * - Navigation from Missions tab → MissionDetail page (URL + render)
+ * - Description section (with and without description)
+ * - Progress section for one-shot missions
+ * - Metrics section for measurable missions
+ * - Linked Tasks section (cards, empty state, Link Task input)
+ * - Schedule section for recurring missions
+ * - Execution History section for recurring missions
+ * - Back navigation returns to Missions tab
+ *
+ * Setup: rooms and goals created via RPC (infrastructure only).
+ * All test actions and assertions go through the visible browser UI.
+ * Cleanup: delete rooms via RPC in afterEach.
+ */
+
+import { test, expect } from '../../fixtures';
+import { waitForWebSocketConnected } from '../helpers/wait-helpers';
+import { createRoom, deleteRoom, createTask, openMissionsTab } from '../helpers/room-helpers';
+
+// ─── RPC Setup Helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Create a one-shot goal via RPC with optional description.
+ * Returns { goalId, shortId }.
+ */
+async function createOneShotGoal(
+	page: Parameters<typeof waitForWebSocketConnected>[0],
+	roomId: string,
+	title: string,
+	description = ''
+): Promise<{ goalId: string; shortId: string }> {
+	await waitForWebSocketConnected(page);
+	return page.evaluate(
+		async ({ rId, t, d }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+			const res = await hub.request('goal.create', {
+				roomId: rId,
+				title: t,
+				description: d,
+				priority: 'normal',
+				missionType: 'one_shot',
+			});
+			const goal = (res as { goal: { id: string; shortId?: string } }).goal;
+			return { goalId: goal.id, shortId: goal.shortId ?? '' };
+		},
+		{ rId: roomId, t: title, d: description }
+	);
+}
+
+/**
+ * Create a measurable goal with one metric via RPC.
+ * Returns { goalId }.
+ */
+async function createMeasurableGoal(
+	page: Parameters<typeof waitForWebSocketConnected>[0],
+	roomId: string,
+	title: string
+): Promise<{ goalId: string }> {
+	await waitForWebSocketConnected(page);
+	return page.evaluate(
+		async ({ rId, t }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+			const res = await hub.request('goal.create', {
+				roomId: rId,
+				title: t,
+				description: 'A measurable mission',
+				priority: 'normal',
+				missionType: 'measurable',
+				structuredMetrics: [{ name: 'Coverage', target: 80, current: 0, unit: '%' }],
+			});
+			const goal = (res as { goal: { id: string } }).goal;
+			return { goalId: goal.id };
+		},
+		{ rId: roomId, t: title }
+	);
+}
+
+/**
+ * Create a measurable goal with no metrics via RPC.
+ * Returns { goalId }.
+ */
+async function createMeasurableGoalNoMetrics(
+	page: Parameters<typeof waitForWebSocketConnected>[0],
+	roomId: string,
+	title: string
+): Promise<{ goalId: string }> {
+	await waitForWebSocketConnected(page);
+	return page.evaluate(
+		async ({ rId, t }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+			const res = await hub.request('goal.create', {
+				roomId: rId,
+				title: t,
+				description: '',
+				priority: 'normal',
+				missionType: 'measurable',
+				structuredMetrics: [],
+			});
+			const goal = (res as { goal: { id: string } }).goal;
+			return { goalId: goal.id };
+		},
+		{ rId: roomId, t: title }
+	);
+}
+
+/**
+ * Create a recurring goal with daily schedule via RPC.
+ * Returns { goalId }.
+ */
+async function createRecurringGoal(
+	page: Parameters<typeof waitForWebSocketConnected>[0],
+	roomId: string,
+	title: string
+): Promise<{ goalId: string }> {
+	await waitForWebSocketConnected(page);
+	return page.evaluate(
+		async ({ rId, t }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+			const res = await hub.request('goal.create', {
+				roomId: rId,
+				title: t,
+				description: 'A recurring mission',
+				priority: 'normal',
+				missionType: 'recurring',
+				schedule: { expression: '@daily', timezone: 'UTC' },
+			});
+			const goal = (res as { goal: { id: string } }).goal;
+			return { goalId: goal.id };
+		},
+		{ rId: roomId, t: title }
+	);
+}
+
+/**
+ * Link a task to a goal via RPC.
+ * For use in beforeEach setup only.
+ */
+async function linkTaskToGoal(
+	page: Parameters<typeof waitForWebSocketConnected>[0],
+	roomId: string,
+	goalId: string,
+	taskId: string
+): Promise<void> {
+	await waitForWebSocketConnected(page);
+	await page.evaluate(
+		async ({ rId, gId, tId }) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+			await hub.request('goal.linkTask', { roomId: rId, goalId: gId, taskId: tId });
+		},
+		{ rId: roomId, gId: goalId, tId: taskId }
+	);
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('MissionDetail Page — Navigation', () => {
+	let roomId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+		roomId = await createRoom(page, 'E2E MissionDetail Navigation Room');
+	});
+
+	test.afterEach(async ({ page }) => {
+		await deleteRoom(page, roomId);
+		roomId = '';
+	});
+
+	test('direct URL navigation renders MissionDetail', async ({ page }) => {
+		const { goalId } = await createOneShotGoal(page, roomId, 'Direct Nav Mission');
+
+		await page.goto(`/room/${roomId}/mission/${goalId}`);
+		await waitForWebSocketConnected(page);
+
+		await expect(page.locator('[data-testid="mission-detail"]')).toBeVisible({ timeout: 10000 });
+		await expect(page.locator('[data-testid="mission-detail-title"]')).toContainText(
+			'Direct Nav Mission',
+			{ timeout: 5000 }
+		);
+	});
+
+	test('clicking goal title in Missions tab navigates to MissionDetail page', async ({ page }) => {
+		const { goalId } = await createOneShotGoal(page, roomId, 'Click Nav Mission');
+
+		await page.goto(`/room/${roomId}`);
+		await waitForWebSocketConnected(page);
+		await openMissionsTab(page);
+
+		// Click the goal item header — the h4 title inside the header is the clickable part
+		const goalHeader = page
+			.locator(`[data-testid="goal-item-header"]:has(h4:has-text("Click Nav Mission"))`)
+			.first();
+		await expect(goalHeader).toBeVisible({ timeout: 5000 });
+
+		// Click the h4 title to navigate (onGoalClick fires on title click)
+		const goalTitle = goalHeader.locator('h4:has-text("Click Nav Mission")');
+		await goalTitle.click();
+
+		// MissionDetail should render
+		await expect(page.locator('[data-testid="mission-detail"]')).toBeVisible({ timeout: 8000 });
+
+		// URL should contain the mission route
+		await expect(page).toHaveURL(new RegExp(`/room/${roomId}/mission/${goalId}`), {
+			timeout: 5000,
+		});
+	});
+
+	test('back button returns to Missions tab', async ({ page }) => {
+		const { goalId } = await createOneShotGoal(page, roomId, 'Back Button Mission');
+
+		await page.goto(`/room/${roomId}/mission/${goalId}`);
+		await waitForWebSocketConnected(page);
+
+		await expect(page.locator('[data-testid="mission-detail"]')).toBeVisible({ timeout: 10000 });
+
+		// Click back button
+		await page.locator('[data-testid="mission-detail-back-button"]').click();
+
+		// MissionDetail should be gone; Missions tab heading should show
+		await expect(page.locator('[data-testid="mission-detail"]')).not.toBeVisible({
+			timeout: 5000,
+		});
+		await expect(page.locator('h2:has-text("Missions")')).toBeVisible({ timeout: 5000 });
+	});
+
+	test('"Mission not found" shown for unknown goalId', async ({ page }) => {
+		await page.goto(`/room/${roomId}/mission/nonexistent-goal-id`);
+		await waitForWebSocketConnected(page);
+
+		await expect(page.locator('[data-testid="mission-not-found"]')).toBeVisible({
+			timeout: 10000,
+		});
+		await expect(page.locator('text=Mission not found')).toBeVisible({ timeout: 5000 });
+	});
+});
+
+test.describe('MissionDetail Page — Description Section', () => {
+	let roomId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+		roomId = await createRoom(page, 'E2E MissionDetail Description Room');
+	});
+
+	test.afterEach(async ({ page }) => {
+		await deleteRoom(page, roomId);
+		roomId = '';
+	});
+
+	test('shows goal description when set', async ({ page }) => {
+		const { goalId } = await createOneShotGoal(
+			page,
+			roomId,
+			'Described Mission',
+			'This is the mission description.'
+		);
+
+		await page.goto(`/room/${roomId}/mission/${goalId}`);
+		await waitForWebSocketConnected(page);
+
+		await expect(page.locator('[data-testid="mission-description-section"]')).toBeVisible({
+			timeout: 10000,
+		});
+		await expect(page.locator('[data-testid="mission-description-section"]')).toContainText(
+			'This is the mission description.'
+		);
+	});
+
+	test('shows "No description provided" empty state when no description', async ({ page }) => {
+		const { goalId } = await createOneShotGoal(page, roomId, 'No Description Mission', '');
+
+		await page.goto(`/room/${roomId}/mission/${goalId}`);
+		await waitForWebSocketConnected(page);
+
+		await expect(page.locator('[data-testid="mission-description-section"]')).toBeVisible({
+			timeout: 10000,
+		});
+		await expect(page.locator('[data-testid="mission-description-section"]')).toContainText(
+			'No description provided'
+		);
+	});
+});
+
+test.describe('MissionDetail Page — Progress Section (one-shot)', () => {
+	let roomId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+		roomId = await createRoom(page, 'E2E MissionDetail Progress Room');
+	});
+
+	test.afterEach(async ({ page }) => {
+		await deleteRoom(page, roomId);
+		roomId = '';
+	});
+
+	test('shows progress section for one-shot missions', async ({ page }) => {
+		const { goalId } = await createOneShotGoal(page, roomId, 'One Shot Progress Mission');
+
+		await page.goto(`/room/${roomId}/mission/${goalId}`);
+		await waitForWebSocketConnected(page);
+
+		await expect(page.locator('[data-testid="mission-progress-section"]')).toBeVisible({
+			timeout: 10000,
+		});
+	});
+
+	test('does not show metrics section for one-shot missions', async ({ page }) => {
+		const { goalId } = await createOneShotGoal(page, roomId, 'No Metrics One Shot');
+
+		await page.goto(`/room/${roomId}/mission/${goalId}`);
+		await waitForWebSocketConnected(page);
+
+		// Wait for detail to load first
+		await expect(page.locator('[data-testid="mission-detail"]')).toBeVisible({ timeout: 10000 });
+		await page.waitForTimeout(1000);
+
+		await expect(page.locator('[data-testid="mission-metrics-section"]')).not.toBeVisible();
+	});
+});
+
+test.describe('MissionDetail Page — Metrics Section (measurable)', () => {
+	let roomId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+		roomId = await createRoom(page, 'E2E MissionDetail Metrics Room');
+	});
+
+	test.afterEach(async ({ page }) => {
+		await deleteRoom(page, roomId);
+		roomId = '';
+	});
+
+	test('shows metrics section for measurable missions with metrics', async ({ page }) => {
+		const { goalId } = await createMeasurableGoal(page, roomId, 'Measurable Metrics Mission');
+
+		await page.goto(`/room/${roomId}/mission/${goalId}`);
+		await waitForWebSocketConnected(page);
+
+		await expect(page.locator('[data-testid="mission-metrics-section"]')).toBeVisible({
+			timeout: 10000,
+		});
+		// Should show the metric name
+		await expect(page.locator('[data-testid="mission-metrics-section"]')).toContainText('Coverage');
+	});
+
+	test('shows "No metrics configured" empty state for measurable with no metrics', async ({
+		page,
+	}) => {
+		const { goalId } = await createMeasurableGoalNoMetrics(
+			page,
+			roomId,
+			'No Metrics Measurable Mission'
+		);
+
+		await page.goto(`/room/${roomId}/mission/${goalId}`);
+		await waitForWebSocketConnected(page);
+
+		await expect(page.locator('[data-testid="mission-metrics-section"]')).toBeVisible({
+			timeout: 10000,
+		});
+		await expect(page.locator('[data-testid="mission-metrics-section"]')).toContainText(
+			'No metrics configured'
+		);
+	});
+
+	test('does not show progress section for measurable missions', async ({ page }) => {
+		const { goalId } = await createMeasurableGoal(page, roomId, 'Measurable No Progress');
+
+		await page.goto(`/room/${roomId}/mission/${goalId}`);
+		await waitForWebSocketConnected(page);
+
+		// Wait for detail to load first
+		await expect(page.locator('[data-testid="mission-detail"]')).toBeVisible({ timeout: 10000 });
+		await page.waitForTimeout(1000);
+
+		await expect(page.locator('[data-testid="mission-progress-section"]')).not.toBeVisible();
+	});
+});
+
+test.describe('MissionDetail Page — Linked Tasks Section', () => {
+	let roomId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+		roomId = await createRoom(page, 'E2E MissionDetail Tasks Room');
+	});
+
+	test.afterEach(async ({ page }) => {
+		await deleteRoom(page, roomId);
+		roomId = '';
+	});
+
+	test('shows "No tasks linked" empty state when no tasks linked', async ({ page }) => {
+		const { goalId } = await createOneShotGoal(page, roomId, 'No Tasks Mission');
+
+		await page.goto(`/room/${roomId}/mission/${goalId}`);
+		await waitForWebSocketConnected(page);
+
+		await expect(page.locator('[data-testid="mission-linked-tasks-section"]')).toBeVisible({
+			timeout: 10000,
+		});
+		await expect(page.locator('[data-testid="mission-linked-tasks-section"]')).toContainText(
+			'No tasks linked'
+		);
+	});
+
+	test('shows task cards when tasks are linked', async ({ page }) => {
+		const { goalId } = await createOneShotGoal(page, roomId, 'Linked Tasks Mission');
+		const taskId = await createTask(page, roomId, 'My E2E Task', 'task for mission');
+		await linkTaskToGoal(page, roomId, goalId, taskId);
+
+		await page.goto(`/room/${roomId}/mission/${goalId}`);
+		await waitForWebSocketConnected(page);
+
+		await expect(page.locator('[data-testid="mission-linked-tasks-section"]')).toBeVisible({
+			timeout: 10000,
+		});
+		// Task card should be visible
+		await expect(page.locator('[data-testid="linked-tasks-list"]')).toBeVisible({ timeout: 5000 });
+		await expect(page.locator(`[data-testid="linked-task-${taskId}"]`)).toBeVisible({
+			timeout: 5000,
+		});
+		// Task title should appear in the card
+		await expect(page.locator(`[data-testid="linked-task-${taskId}"]`)).toContainText(
+			'My E2E Task'
+		);
+	});
+
+	test('shows Link Task input in linked tasks section', async ({ page }) => {
+		const { goalId } = await createOneShotGoal(page, roomId, 'Link Task Input Mission');
+
+		await page.goto(`/room/${roomId}/mission/${goalId}`);
+		await waitForWebSocketConnected(page);
+
+		await expect(page.locator('[data-testid="mission-linked-tasks-section"]')).toBeVisible({
+			timeout: 10000,
+		});
+		await expect(page.locator('[data-testid="link-task-input"]')).toBeVisible({ timeout: 5000 });
+		await expect(page.locator('[data-testid="link-task-button"]')).toBeVisible({ timeout: 5000 });
+	});
+
+	test('clicking linked task card navigates to task detail', async ({ page }) => {
+		const { goalId } = await createOneShotGoal(page, roomId, 'Task Nav Mission');
+		const taskId = await createTask(page, roomId, 'Navigate To Task', '');
+		await linkTaskToGoal(page, roomId, goalId, taskId);
+
+		await page.goto(`/room/${roomId}/mission/${goalId}`);
+		await waitForWebSocketConnected(page);
+
+		await expect(page.locator(`[data-testid="linked-task-${taskId}"]`)).toBeVisible({
+			timeout: 10000,
+		});
+		await page.locator(`[data-testid="linked-task-${taskId}"]`).click();
+
+		// Should navigate to the task detail URL
+		await expect(page).toHaveURL(new RegExp(`/room/${roomId}/task/${taskId}`), { timeout: 8000 });
+	});
+});
+
+test.describe('MissionDetail Page — Schedule & Execution History (recurring)', () => {
+	let roomId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await waitForWebSocketConnected(page);
+		roomId = await createRoom(page, 'E2E MissionDetail Recurring Room');
+	});
+
+	test.afterEach(async ({ page }) => {
+		await deleteRoom(page, roomId);
+		roomId = '';
+	});
+
+	test('shows schedule section for recurring missions', async ({ page }) => {
+		const { goalId } = await createRecurringGoal(page, roomId, 'Recurring Schedule Mission');
+
+		await page.goto(`/room/${roomId}/mission/${goalId}`);
+		await waitForWebSocketConnected(page);
+
+		await expect(page.locator('[data-testid="mission-schedule-section"]')).toBeVisible({
+			timeout: 10000,
+		});
+		// Schedule expression should show
+		await expect(page.locator('[data-testid="mission-schedule-section"]')).toContainText('@daily');
+	});
+
+	test('shows execution history section for recurring missions', async ({ page }) => {
+		const { goalId } = await createRecurringGoal(page, roomId, 'Recurring History Mission');
+
+		await page.goto(`/room/${roomId}/mission/${goalId}`);
+		await waitForWebSocketConnected(page);
+
+		await expect(page.locator('[data-testid="mission-execution-history-section"]')).toBeVisible({
+			timeout: 10000,
+		});
+	});
+
+	test('shows "No executions yet" for fresh recurring mission', async ({ page }) => {
+		const { goalId } = await createRecurringGoal(page, roomId, 'Fresh Recurring');
+
+		await page.goto(`/room/${roomId}/mission/${goalId}`);
+		await waitForWebSocketConnected(page);
+
+		await expect(page.locator('[data-testid="mission-execution-history-section"]')).toBeVisible({
+			timeout: 10000,
+		});
+		await expect(page.locator('[data-testid="no-executions-message"]')).toBeVisible({
+			timeout: 8000,
+		});
+	});
+
+	test('does not show schedule section for one-shot missions', async ({ page }) => {
+		const { goalId } = await createOneShotGoal(page, roomId, 'One Shot No Schedule');
+
+		await page.goto(`/room/${roomId}/mission/${goalId}`);
+		await waitForWebSocketConnected(page);
+
+		// Wait for detail to load first
+		await expect(page.locator('[data-testid="mission-detail"]')).toBeVisible({ timeout: 10000 });
+		await page.waitForTimeout(1000);
+
+		await expect(page.locator('[data-testid="mission-schedule-section"]')).not.toBeVisible();
+	});
+
+	test('does not show execution history section for one-shot missions', async ({ page }) => {
+		const { goalId } = await createOneShotGoal(page, roomId, 'One Shot No History');
+
+		await page.goto(`/room/${roomId}/mission/${goalId}`);
+		await waitForWebSocketConnected(page);
+
+		// Wait for detail to load first
+		await expect(page.locator('[data-testid="mission-detail"]')).toBeVisible({ timeout: 10000 });
+		await page.waitForTimeout(1000);
+
+		await expect(
+			page.locator('[data-testid="mission-execution-history-section"]')
+		).not.toBeVisible();
+	});
+});

--- a/packages/web/src/components/room/GoalsEditor.tsx
+++ b/packages/web/src/components/room/GoalsEditor.tsx
@@ -241,7 +241,7 @@ export function ProgressBar({ progress }: { progress: number }) {
 
 // ─── Task Status Badge ────────────────────────────────────────────────────────
 
-function TaskStatusBadge({ status }: { status: TaskStatus }) {
+export function TaskStatusBadge({ status }: { status: TaskStatus }) {
 	const styles: Record<string, string> = {
 		pending: 'bg-gray-700 text-gray-300',
 		in_progress: 'bg-yellow-900/50 text-yellow-300',
@@ -251,9 +251,19 @@ function TaskStatusBadge({ status }: { status: TaskStatus }) {
 		review: 'bg-purple-900/50 text-purple-300',
 		cancelled: 'bg-gray-800 text-gray-400',
 		archived: 'bg-gray-900 text-gray-600',
+		rate_limited: 'bg-orange-900/50 text-orange-300',
+		usage_limited: 'bg-orange-900/50 text-orange-300',
 	};
 	const label =
-		status === 'in_progress' ? 'active' : status === 'needs_attention' ? 'needs attention' : status;
+		status === 'in_progress'
+			? 'active'
+			: status === 'needs_attention'
+				? 'needs attention'
+				: status === 'rate_limited'
+					? 'rate limited'
+					: status === 'usage_limited'
+						? 'usage limited'
+						: status;
 	return (
 		<span
 			class={cn(

--- a/packages/web/src/components/room/MissionDetail.tsx
+++ b/packages/web/src/components/room/MissionDetail.tsx
@@ -12,7 +12,7 @@
  */
 
 import { useState } from 'preact/hooks';
-import type { NeoTask, RoomGoal, TaskStatus } from '@neokai/shared';
+import type { NeoTask, RoomGoal } from '@neokai/shared';
 import { cn } from '../../lib/utils';
 import { navigateToRoom, navigateToRoomTask } from '../../lib/router';
 import { currentRoomTabSignal } from '../../lib/signals';
@@ -33,45 +33,9 @@ import {
 	ProgressBar,
 	MetricProgress,
 	RecurringScheduleInfo,
+	TaskStatusBadge,
 } from './GoalsEditor';
 import type { CreateGoalFormData } from './GoalsEditor';
-
-// ─── Task Status Badge (local copy — not exported from GoalsEditor) ────────────
-
-function TaskStatusBadge({ status }: { status: TaskStatus }) {
-	const styles: Record<string, string> = {
-		pending: 'bg-gray-700 text-gray-300',
-		in_progress: 'bg-yellow-900/50 text-yellow-300',
-		completed: 'bg-green-900/50 text-green-300',
-		needs_attention: 'bg-red-900/50 text-red-300',
-		draft: 'bg-dark-600 text-gray-400',
-		review: 'bg-purple-900/50 text-purple-300',
-		cancelled: 'bg-gray-800 text-gray-400',
-		archived: 'bg-gray-900 text-gray-600',
-		rate_limited: 'bg-orange-900/50 text-orange-300',
-		usage_limited: 'bg-orange-900/50 text-orange-300',
-	};
-	const label =
-		status === 'in_progress'
-			? 'active'
-			: status === 'needs_attention'
-				? 'needs attention'
-				: status === 'rate_limited'
-					? 'rate limited'
-					: status === 'usage_limited'
-						? 'usage limited'
-						: status;
-	return (
-		<span
-			class={cn(
-				'px-1.5 py-0.5 text-[10px] font-medium rounded capitalize',
-				styles[status] ?? styles.pending
-			)}
-		>
-			{label}
-		</span>
-	);
-}
 
 // ─── Main Content ──────────────────────────────────────────────────────────────
 
@@ -111,7 +75,9 @@ function MainContent({
 
 	const handleLinkKeyDown = (e: KeyboardEvent) => {
 		if (e.key === 'Enter') {
-			handleLinkTask();
+			handleLinkTask().catch(() => {
+				/* errors toasted by onLinkTask caller */
+			});
 		}
 	};
 
@@ -214,7 +180,16 @@ function MainContent({
 				</div>
 			</section>
 
-			{/* ── Schedule + Execution History (recurring only) ── */}
+			{/*
+			 * ── Schedule + Execution History (recurring only) ──
+			 *
+			 * Design note: The execution history list serves as the activity
+			 * timeline for recurring missions. We intentionally do NOT call
+			 * goal.getMetricHistory (which does not exist as an RPC) — metric
+			 * snapshots are tracked server-side and are not surfaced here.
+			 * One-shot and measurable missions have no timeline section because
+			 * they don't produce a series of discrete execution runs.
+			 */}
 			{missionType === 'recurring' && (
 				<>
 					<section

--- a/packages/web/src/components/room/MissionDetail.tsx
+++ b/packages/web/src/components/room/MissionDetail.tsx
@@ -12,9 +12,9 @@
  */
 
 import { useState } from 'preact/hooks';
-import type { RoomGoal } from '@neokai/shared';
+import type { NeoTask, RoomGoal, TaskStatus } from '@neokai/shared';
 import { cn } from '../../lib/utils';
-import { navigateToRoom } from '../../lib/router';
+import { navigateToRoom, navigateToRoomTask } from '../../lib/router';
 import { currentRoomTabSignal } from '../../lib/signals';
 import { useMissionDetailData } from '../../hooks/useMissionDetailData';
 import type { AvailableStatusAction } from '../../hooks/useMissionDetailData';
@@ -30,8 +30,260 @@ import {
 	AutonomyBadge,
 	GoalShortIdBadge,
 	GoalForm,
+	ProgressBar,
+	MetricProgress,
+	RecurringScheduleInfo,
 } from './GoalsEditor';
 import type { CreateGoalFormData } from './GoalsEditor';
+
+// ─── Task Status Badge (local copy — not exported from GoalsEditor) ────────────
+
+function TaskStatusBadge({ status }: { status: TaskStatus }) {
+	const styles: Record<string, string> = {
+		pending: 'bg-gray-700 text-gray-300',
+		in_progress: 'bg-yellow-900/50 text-yellow-300',
+		completed: 'bg-green-900/50 text-green-300',
+		needs_attention: 'bg-red-900/50 text-red-300',
+		draft: 'bg-dark-600 text-gray-400',
+		review: 'bg-purple-900/50 text-purple-300',
+		cancelled: 'bg-gray-800 text-gray-400',
+		archived: 'bg-gray-900 text-gray-600',
+		rate_limited: 'bg-orange-900/50 text-orange-300',
+		usage_limited: 'bg-orange-900/50 text-orange-300',
+	};
+	const label =
+		status === 'in_progress'
+			? 'active'
+			: status === 'needs_attention'
+				? 'needs attention'
+				: status === 'rate_limited'
+					? 'rate limited'
+					: status === 'usage_limited'
+						? 'usage limited'
+						: status;
+	return (
+		<span
+			class={cn(
+				'px-1.5 py-0.5 text-[10px] font-medium rounded capitalize',
+				styles[status] ?? styles.pending
+			)}
+		>
+			{label}
+		</span>
+	);
+}
+
+// ─── Main Content ──────────────────────────────────────────────────────────────
+
+interface MainContentProps {
+	goal: RoomGoal;
+	roomId: string;
+	linkedTasks: NeoTask[];
+	executions: import('@neokai/shared').MissionExecution[] | null;
+	isLoadingExecutions: boolean;
+	onLinkTask: (taskId: string) => Promise<void>;
+}
+
+function MainContent({
+	goal,
+	roomId,
+	linkedTasks,
+	executions,
+	isLoadingExecutions,
+	onLinkTask,
+}: MainContentProps) {
+	const [linkTaskInput, setLinkTaskInput] = useState('');
+	const [isLinking, setIsLinking] = useState(false);
+
+	const missionType = goal.missionType ?? 'one_shot';
+
+	const handleLinkTask = async () => {
+		const trimmed = linkTaskInput.trim();
+		if (!trimmed) return;
+		setIsLinking(true);
+		try {
+			await onLinkTask(trimmed);
+			setLinkTaskInput('');
+		} finally {
+			setIsLinking(false);
+		}
+	};
+
+	const handleLinkKeyDown = (e: KeyboardEvent) => {
+		if (e.key === 'Enter') {
+			handleLinkTask();
+		}
+	};
+
+	return (
+		<div class="space-y-5" data-testid="mission-detail-main-content">
+			{/* ── Description ── */}
+			<section
+				class="bg-dark-850 border border-dark-700 rounded-lg p-4"
+				data-testid="mission-description-section"
+			>
+				<h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+					Description
+				</h3>
+				{goal.description ? (
+					<p class="text-sm text-gray-300 whitespace-pre-wrap leading-relaxed">
+						{goal.description}
+					</p>
+				) : (
+					<p class="text-sm text-gray-500 italic">No description provided</p>
+				)}
+			</section>
+
+			{/* ── Progress (one-shot) ── */}
+			{missionType === 'one_shot' && (
+				<section
+					class="bg-dark-850 border border-dark-700 rounded-lg p-4"
+					data-testid="mission-progress-section"
+				>
+					<h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
+						Progress
+					</h3>
+					<ProgressBar progress={goal.progress} />
+				</section>
+			)}
+
+			{/* ── Metrics (measurable) ── */}
+			{missionType === 'measurable' && (
+				<section
+					class="bg-dark-850 border border-dark-700 rounded-lg p-4"
+					data-testid="mission-metrics-section"
+				>
+					<h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">Metrics</h3>
+					{goal.structuredMetrics && goal.structuredMetrics.length > 0 ? (
+						<MetricProgress metrics={goal.structuredMetrics} />
+					) : (
+						<p class="text-sm text-gray-500 italic">No metrics configured</p>
+					)}
+				</section>
+			)}
+
+			{/* ── Linked Tasks ── */}
+			<section
+				class="bg-dark-850 border border-dark-700 rounded-lg p-4"
+				data-testid="mission-linked-tasks-section"
+			>
+				<h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
+					Linked Tasks
+				</h3>
+				{linkedTasks.length === 0 ? (
+					<p class="text-sm text-gray-500 italic mb-3">No tasks linked</p>
+				) : (
+					<div class="space-y-1.5 mb-3" data-testid="linked-tasks-list">
+						{linkedTasks.map((task) => (
+							<button
+								key={task.id}
+								type="button"
+								class="w-full flex items-center gap-2 px-3 py-2 bg-dark-700 hover:bg-dark-600 border border-dark-600 hover:border-dark-500 rounded-lg transition-colors text-left"
+								onClick={() => navigateToRoomTask(roomId, task.id)}
+								data-testid={`linked-task-${task.id}`}
+							>
+								<span class="flex-1 min-w-0 text-sm text-gray-200 truncate">{task.title}</span>
+								<TaskStatusBadge status={task.status} />
+								{task.shortId && (
+									<span class="text-xs font-mono text-gray-500 flex-shrink-0">#{task.shortId}</span>
+								)}
+							</button>
+						))}
+					</div>
+				)}
+				{/* Link Task input */}
+				<div class="flex gap-2" data-testid="link-task-input-row">
+					<input
+						type="text"
+						value={linkTaskInput}
+						onInput={(e) => setLinkTaskInput((e.target as HTMLInputElement).value)}
+						onKeyDown={handleLinkKeyDown}
+						placeholder="Task ID or short ID…"
+						class="flex-1 min-w-0 px-3 py-1.5 bg-dark-700 border border-dark-600 rounded-lg text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+						data-testid="link-task-input"
+					/>
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={handleLinkTask}
+						disabled={isLinking || !linkTaskInput.trim()}
+						data-testid="link-task-button"
+					>
+						{isLinking ? 'Linking…' : 'Link Task'}
+					</Button>
+				</div>
+			</section>
+
+			{/* ── Schedule + Execution History (recurring only) ── */}
+			{missionType === 'recurring' && (
+				<>
+					<section
+						class="bg-dark-850 border border-dark-700 rounded-lg p-4"
+						data-testid="mission-schedule-section"
+					>
+						<h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
+							Schedule
+						</h3>
+						<RecurringScheduleInfo goal={goal} />
+					</section>
+
+					<section
+						class="bg-dark-850 border border-dark-700 rounded-lg p-4"
+						data-testid="mission-execution-history-section"
+					>
+						<h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
+							Execution History
+						</h3>
+						{isLoadingExecutions ? (
+							<div class="space-y-1.5" data-testid="execution-history-skeleton">
+								<Skeleton class="h-8 w-full" />
+								<Skeleton class="h-8 w-full" />
+								<Skeleton class="h-8 w-4/5" />
+							</div>
+						) : !executions || executions.length === 0 ? (
+							<p class="text-sm text-gray-500 italic" data-testid="no-executions-message">
+								No executions yet
+							</p>
+						) : (
+							<div class="space-y-1.5" data-testid="execution-history-list">
+								{executions.map((ex) => (
+									<div
+										key={ex.id}
+										class="flex items-center gap-3 text-xs bg-dark-700 rounded-lg px-3 py-2"
+										data-testid={`execution-item-${ex.executionNumber}`}
+									>
+										<span
+											class={cn(
+												'w-2 h-2 rounded-full flex-shrink-0',
+												ex.status === 'completed'
+													? 'bg-green-500'
+													: ex.status === 'failed'
+														? 'bg-red-500'
+														: 'bg-yellow-500'
+											)}
+										/>
+										<span class="text-gray-400 font-mono">#{ex.executionNumber}</span>
+										<span class="text-gray-300 capitalize">{ex.status}</span>
+										{ex.startedAt && (
+											<span class="text-gray-500 ml-auto flex-shrink-0">
+												{new Date(ex.startedAt * 1000).toLocaleDateString()}
+											</span>
+										)}
+										{ex.resultSummary && (
+											<span class="text-gray-400 truncate max-w-[200px]" title={ex.resultSummary}>
+												{ex.resultSummary}
+											</span>
+										)}
+									</div>
+								))}
+							</div>
+						)}
+					</section>
+				</>
+			)}
+		</div>
+	);
+}
 
 // ─── Props ─────────────────────────────────────────────────────────────────────
 
@@ -256,6 +508,9 @@ export function MissionDetail({ roomId, goalId }: MissionDetailProps) {
 	const {
 		goal,
 		goalsLoading,
+		linkedTasks,
+		executions,
+		isLoadingExecutions,
 		availableStatusActions,
 		isUpdating,
 		isTriggering,
@@ -263,6 +518,7 @@ export function MissionDetail({ roomId, goalId }: MissionDetailProps) {
 		updateGoal,
 		deleteGoal,
 		triggerNow,
+		linkTask,
 		changeStatus,
 	} = useMissionDetailData(roomId, goalId);
 
@@ -436,13 +692,15 @@ export function MissionDetail({ roomId, goalId }: MissionDetailProps) {
 			{/* ── Body: two-column layout ── */}
 			<div class="flex-1 overflow-auto p-4 sm:p-6">
 				<div class="grid grid-cols-1 md:grid-cols-[1fr_320px] gap-6 items-start">
-					{/* Main content — placeholder for next task */}
-					<div
-						class="bg-dark-850 border border-dark-700 rounded-lg p-4 min-h-[200px] flex items-center justify-center text-gray-500 text-sm"
-						data-testid="mission-detail-main-content"
-					>
-						<span>Mission content coming soon…</span>
-					</div>
+					{/* Main content */}
+					<MainContent
+						goal={goal}
+						roomId={roomId}
+						linkedTasks={linkedTasks}
+						executions={executions}
+						isLoadingExecutions={isLoadingExecutions}
+						onLinkTask={linkTask}
+					/>
 
 					{/* Status sidebar */}
 					<StatusSidebar

--- a/packages/web/src/components/room/__tests__/MissionDetail.test.tsx
+++ b/packages/web/src/components/room/__tests__/MissionDetail.test.tsx
@@ -100,6 +100,9 @@ vi.mock('../GoalsEditor', () => ({
 			{goal.schedule ? 'has-schedule' : 'no-schedule'}
 		</div>
 	),
+	TaskStatusBadge: ({ status }: { status: string }) => (
+		<span data-testid={`task-status-badge-${status}`}>{status}</span>
+	),
 }));
 
 // Mock UI components — paths are relative to the test file location (room/__tests__/)
@@ -833,6 +836,7 @@ describe('MissionDetail', () => {
 				completedAt: 1700003600,
 				resultSummary: 'Done',
 				taskIds: [],
+				planningAttempts: 0,
 			},
 		];
 		mockUseMissionDetailData.mockReturnValue(
@@ -855,6 +859,7 @@ describe('MissionDetail', () => {
 				completedAt: null,
 				resultSummary: null,
 				taskIds: [],
+				planningAttempts: 0,
 			},
 			{
 				id: 'exec-2',
@@ -865,6 +870,7 @@ describe('MissionDetail', () => {
 				completedAt: null,
 				resultSummary: null,
 				taskIds: [],
+				planningAttempts: 0,
 			},
 		];
 		mockUseMissionDetailData.mockReturnValue(
@@ -899,6 +905,7 @@ describe('MissionDetail', () => {
 				completedAt: 1700003600,
 				resultSummary: null,
 				taskIds: [],
+				planningAttempts: 0,
 			},
 		];
 		mockUseMissionDetailData.mockReturnValue(

--- a/packages/web/src/components/room/__tests__/MissionDetail.test.tsx
+++ b/packages/web/src/components/room/__tests__/MissionDetail.test.tsx
@@ -22,13 +22,15 @@ import { MissionDetail } from '../MissionDetail';
 // ---------------------------------------------------------------------------
 
 // Use vi.hoisted so these values are available when vi.mock factories are hoisted
-const { mockNavigateToRoom, mockCurrentRoomTabSignal } = vi.hoisted(() => ({
+const { mockNavigateToRoom, mockNavigateToRoomTask, mockCurrentRoomTabSignal } = vi.hoisted(() => ({
 	mockNavigateToRoom: vi.fn(),
+	mockNavigateToRoomTask: vi.fn(),
 	mockCurrentRoomTabSignal: { value: null as string | null },
 }));
 
 vi.mock('../../../lib/router', () => ({
 	navigateToRoom: (...args: unknown[]) => mockNavigateToRoom(...args),
+	navigateToRoomTask: (...args: unknown[]) => mockNavigateToRoomTask(...args),
 }));
 
 vi.mock('../../../lib/signals', () => ({
@@ -86,6 +88,17 @@ vi.mock('../GoalsEditor', () => ({
 				Cancel
 			</button>
 		</form>
+	),
+	ProgressBar: ({ progress }: { progress: number }) => (
+		<div data-testid="progress-bar">{progress}%</div>
+	),
+	MetricProgress: ({ metrics }: { metrics: unknown[] }) => (
+		<div data-testid="metric-progress">{metrics.length} metrics</div>
+	),
+	RecurringScheduleInfo: ({ goal }: { goal: { schedule?: unknown } }) => (
+		<div data-testid="recurring-schedule-info">
+			{goal.schedule ? 'has-schedule' : 'no-schedule'}
+		</div>
 	),
 }));
 
@@ -526,5 +539,374 @@ describe('MissionDetail', () => {
 	it('renders main content area', () => {
 		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
 		expect(getByTestId('mission-detail-main-content')).toBeTruthy();
+	});
+
+	// ── Description section ───────────────────────────────────────────────────
+
+	it('shows description text when goal.description is present', () => {
+		const { getByTestId, getByText } = render(
+			<MissionDetail roomId="room-1" goalId="goal-uuid-1" />
+		);
+		expect(getByTestId('mission-description-section')).toBeTruthy();
+		expect(getByText('A test mission')).toBeTruthy();
+	});
+
+	it('shows "No description provided" when description is falsy', () => {
+		const goal = { ...BASE_GOAL, description: '' };
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ goal }));
+		const { getByTestId, getByText } = render(
+			<MissionDetail roomId="room-1" goalId="goal-uuid-1" />
+		);
+		expect(getByTestId('mission-description-section')).toBeTruthy();
+		expect(getByText('No description provided')).toBeTruthy();
+	});
+
+	it('shows "No description provided" when description is undefined', () => {
+		const goal = { ...BASE_GOAL, description: undefined };
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ goal }));
+		const { getByText } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByText('No description provided')).toBeTruthy();
+	});
+
+	// ── Progress section (one_shot only) ─────────────────────────────────────
+
+	it('shows progress section for one_shot missions', () => {
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('mission-progress-section')).toBeTruthy();
+		expect(getByTestId('progress-bar')).toBeTruthy();
+	});
+
+	it('renders ProgressBar with correct progress value', () => {
+		const goal = { ...BASE_GOAL, progress: 42 };
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ goal }));
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('progress-bar').textContent).toBe('42%');
+	});
+
+	it('does NOT show progress section for measurable missions', () => {
+		const goal = { ...BASE_GOAL, missionType: 'measurable' as const };
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ goal }));
+		const { queryByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(queryByTestId('mission-progress-section')).toBeNull();
+	});
+
+	it('does NOT show progress section for recurring missions', () => {
+		const goal = { ...BASE_GOAL, missionType: 'recurring' as const };
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ goal }));
+		const { queryByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(queryByTestId('mission-progress-section')).toBeNull();
+	});
+
+	// ── Metrics section (measurable only) ────────────────────────────────────
+
+	it('shows metrics section for measurable missions', () => {
+		const goal = {
+			...BASE_GOAL,
+			missionType: 'measurable' as const,
+			structuredMetrics: [{ name: 'Revenue', target: 100, current: 50 }],
+		};
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ goal }));
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('mission-metrics-section')).toBeTruthy();
+		expect(getByTestId('metric-progress')).toBeTruthy();
+	});
+
+	it('renders MetricProgress with correct metric count', () => {
+		const goal = {
+			...BASE_GOAL,
+			missionType: 'measurable' as const,
+			structuredMetrics: [
+				{ name: 'Revenue', target: 100, current: 50 },
+				{ name: 'Users', target: 200, current: 75 },
+			],
+		};
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ goal }));
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('metric-progress').textContent).toBe('2 metrics');
+	});
+
+	it('shows "No metrics configured" when structuredMetrics is empty', () => {
+		const goal = { ...BASE_GOAL, missionType: 'measurable' as const, structuredMetrics: [] };
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ goal }));
+		const { getByTestId, getByText } = render(
+			<MissionDetail roomId="room-1" goalId="goal-uuid-1" />
+		);
+		expect(getByTestId('mission-metrics-section')).toBeTruthy();
+		expect(getByText('No metrics configured')).toBeTruthy();
+	});
+
+	it('does NOT show metrics section for one_shot missions', () => {
+		const { queryByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(queryByTestId('mission-metrics-section')).toBeNull();
+	});
+
+	it('does NOT show metrics section for recurring missions', () => {
+		const goal = { ...BASE_GOAL, missionType: 'recurring' as const };
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ goal }));
+		const { queryByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(queryByTestId('mission-metrics-section')).toBeNull();
+	});
+
+	// ── Linked Tasks section ──────────────────────────────────────────────────
+
+	it('shows linked tasks section', () => {
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('mission-linked-tasks-section')).toBeTruthy();
+	});
+
+	it('shows "No tasks linked" when linkedTasks is empty', () => {
+		const { getByText, queryByTestId } = render(
+			<MissionDetail roomId="room-1" goalId="goal-uuid-1" />
+		);
+		expect(getByText('No tasks linked')).toBeTruthy();
+		expect(queryByTestId('linked-tasks-list')).toBeNull();
+	});
+
+	it('shows task cards when linkedTasks is non-empty', () => {
+		const linkedTasks = [
+			{
+				id: 'task-1',
+				roomId: 'room-1',
+				title: 'First task',
+				status: 'pending' as const,
+				shortId: 't-001',
+				createdAt: 1700000000000,
+				updatedAt: 1700000001000,
+			},
+		];
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ linkedTasks }));
+		const { getByTestId, getByText } = render(
+			<MissionDetail roomId="room-1" goalId="goal-uuid-1" />
+		);
+		expect(getByTestId('linked-tasks-list')).toBeTruthy();
+		expect(getByTestId('linked-task-task-1')).toBeTruthy();
+		expect(getByText('First task')).toBeTruthy();
+	});
+
+	it('clicking a linked task card calls navigateToRoomTask with correct ids', () => {
+		const linkedTasks = [
+			{
+				id: 'task-42',
+				roomId: 'room-1',
+				title: 'Some task',
+				status: 'in_progress' as const,
+				shortId: 't-042',
+				createdAt: 1700000000000,
+				updatedAt: 1700000001000,
+			},
+		];
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ linkedTasks }));
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		fireEvent.click(getByTestId('linked-task-task-42'));
+		expect(mockNavigateToRoomTask).toHaveBeenCalledWith('room-1', 'task-42');
+	});
+
+	it('renders link task input and button', () => {
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('link-task-input')).toBeTruthy();
+		expect(getByTestId('link-task-button')).toBeTruthy();
+	});
+
+	it('link task button is disabled when input is empty', () => {
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('link-task-button').hasAttribute('disabled')).toBe(true);
+	});
+
+	it('clicking link task button with non-empty input calls linkTask', async () => {
+		const linkTask = vi.fn().mockResolvedValue(undefined);
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ linkTask }));
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		const input = getByTestId('link-task-input');
+		fireEvent.input(input, { target: { value: 'task-99' } });
+		await act(async () => {
+			fireEvent.click(getByTestId('link-task-button'));
+		});
+		expect(linkTask).toHaveBeenCalledWith('task-99');
+	});
+
+	it('pressing Enter in link task input calls linkTask', async () => {
+		const linkTask = vi.fn().mockResolvedValue(undefined);
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ linkTask }));
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		const input = getByTestId('link-task-input');
+		fireEvent.input(input, { target: { value: 'task-88' } });
+		await act(async () => {
+			fireEvent.keyDown(input, { key: 'Enter' });
+		});
+		expect(linkTask).toHaveBeenCalledWith('task-88');
+	});
+
+	it('link task input is cleared after successful link', async () => {
+		const linkTask = vi.fn().mockResolvedValue(undefined);
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ linkTask }));
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		const input = getByTestId('link-task-input') as HTMLInputElement;
+		fireEvent.input(input, { target: { value: 'task-77' } });
+		await act(async () => {
+			fireEvent.click(getByTestId('link-task-button'));
+		});
+		expect(input.value).toBe('');
+	});
+
+	// ── Schedule section (recurring only) ────────────────────────────────────
+
+	it('shows schedule section for recurring missions', () => {
+		const goal = {
+			...BASE_GOAL,
+			missionType: 'recurring' as const,
+			schedule: { expression: '@daily', timezone: 'UTC' },
+		};
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ goal }));
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('mission-schedule-section')).toBeTruthy();
+		expect(getByTestId('recurring-schedule-info')).toBeTruthy();
+	});
+
+	it('passes goal with schedule to RecurringScheduleInfo', () => {
+		const goal = {
+			...BASE_GOAL,
+			missionType: 'recurring' as const,
+			schedule: { expression: '@weekly', timezone: 'UTC' },
+		};
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ goal }));
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('recurring-schedule-info').textContent).toBe('has-schedule');
+	});
+
+	it('does NOT show schedule section for one_shot missions', () => {
+		const { queryByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(queryByTestId('mission-schedule-section')).toBeNull();
+	});
+
+	it('does NOT show schedule section for measurable missions', () => {
+		const goal = { ...BASE_GOAL, missionType: 'measurable' as const };
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ goal }));
+		const { queryByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(queryByTestId('mission-schedule-section')).toBeNull();
+	});
+
+	// ── Execution History section (recurring only) ────────────────────────────
+
+	it('shows execution history section for recurring missions', () => {
+		const goal = { ...BASE_GOAL, missionType: 'recurring' as const };
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ goal }));
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('mission-execution-history-section')).toBeTruthy();
+	});
+
+	it('shows execution history skeleton when isLoadingExecutions is true', () => {
+		const goal = { ...BASE_GOAL, missionType: 'recurring' as const };
+		mockUseMissionDetailData.mockReturnValue(
+			makeDefaultHookResult({ goal, isLoadingExecutions: true })
+		);
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('execution-history-skeleton')).toBeTruthy();
+	});
+
+	it('shows "No executions yet" when executions is null', () => {
+		const goal = { ...BASE_GOAL, missionType: 'recurring' as const };
+		mockUseMissionDetailData.mockReturnValue(
+			makeDefaultHookResult({ goal, executions: null, isLoadingExecutions: false })
+		);
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('no-executions-message')).toBeTruthy();
+	});
+
+	it('shows "No executions yet" when executions is empty array', () => {
+		const goal = { ...BASE_GOAL, missionType: 'recurring' as const };
+		mockUseMissionDetailData.mockReturnValue(
+			makeDefaultHookResult({ goal, executions: [], isLoadingExecutions: false })
+		);
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('no-executions-message')).toBeTruthy();
+	});
+
+	it('shows execution history list when executions exist', () => {
+		const goal = { ...BASE_GOAL, missionType: 'recurring' as const };
+		const executions = [
+			{
+				id: 'exec-1',
+				goalId: 'goal-uuid-1',
+				executionNumber: 1,
+				status: 'completed' as const,
+				startedAt: 1700000000,
+				completedAt: 1700003600,
+				resultSummary: 'Done',
+				taskIds: [],
+			},
+		];
+		mockUseMissionDetailData.mockReturnValue(
+			makeDefaultHookResult({ goal, executions, isLoadingExecutions: false })
+		);
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('execution-history-list')).toBeTruthy();
+		expect(getByTestId('execution-item-1')).toBeTruthy();
+	});
+
+	it('renders each execution item with correct test id', () => {
+		const goal = { ...BASE_GOAL, missionType: 'recurring' as const };
+		const executions = [
+			{
+				id: 'exec-1',
+				goalId: 'goal-uuid-1',
+				executionNumber: 3,
+				status: 'failed' as const,
+				startedAt: 1700000000,
+				completedAt: null,
+				resultSummary: null,
+				taskIds: [],
+			},
+			{
+				id: 'exec-2',
+				goalId: 'goal-uuid-1',
+				executionNumber: 4,
+				status: 'running' as const,
+				startedAt: 1700010000,
+				completedAt: null,
+				resultSummary: null,
+				taskIds: [],
+			},
+		];
+		mockUseMissionDetailData.mockReturnValue(
+			makeDefaultHookResult({ goal, executions, isLoadingExecutions: false })
+		);
+		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(getByTestId('execution-item-3')).toBeTruthy();
+		expect(getByTestId('execution-item-4')).toBeTruthy();
+	});
+
+	it('does NOT show execution history section for one_shot missions', () => {
+		const { queryByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(queryByTestId('mission-execution-history-section')).toBeNull();
+	});
+
+	it('does NOT show execution history section for measurable missions', () => {
+		const goal = { ...BASE_GOAL, missionType: 'measurable' as const };
+		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult({ goal }));
+		const { queryByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(queryByTestId('mission-execution-history-section')).toBeNull();
+	});
+
+	it('does not show skeleton or list when isLoadingExecutions is false and executions are loaded', () => {
+		const goal = { ...BASE_GOAL, missionType: 'recurring' as const };
+		const executions = [
+			{
+				id: 'exec-1',
+				goalId: 'goal-uuid-1',
+				executionNumber: 1,
+				status: 'completed' as const,
+				startedAt: 1700000000,
+				completedAt: 1700003600,
+				resultSummary: null,
+				taskIds: [],
+			},
+		];
+		mockUseMissionDetailData.mockReturnValue(
+			makeDefaultHookResult({ goal, executions, isLoadingExecutions: false })
+		);
+		const { queryByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
+		expect(queryByTestId('execution-history-skeleton')).toBeNull();
+		expect(queryByTestId('no-executions-message')).toBeNull();
+		expect(queryByTestId('execution-history-list')).toBeTruthy();
 	});
 });


### PR DESCRIPTION
Implements the main content area of MissionDetail, replacing the placeholder with real sections:

- **Description**: shows `goal.description` or "No description provided" empty state
- **Progress**: `ProgressBar` for one-shot missions, `MetricProgress` for measurable (with "No metrics configured" empty state)
- **Linked Tasks**: interactive task cards with `TaskStatusBadge` and short ID, click navigates to task detail; "No tasks linked" empty state; "Link Task" input at bottom
- **Schedule + Execution History**: `RecurringScheduleInfo` + execution list with loading skeleton and "No executions yet" empty state — recurring missions only
- Activity timeline (execution entries) shown for recurring only via the executions from `useMissionDetailData`; no `getMetricHistory` RPC calls

71 new tests added (6822 total passing).