### PR TITLE
feat(web): add room tab route patterns, extractors, and path creators

### DIFF
--- a/packages/web/src/lib/__tests__/router.test.ts
+++ b/packages/web/src/lib/__tests__/router.test.ts
@@ -14,12 +14,19 @@ import {
 	getSessionIdFromPath,
 	getRoomIdFromPath,
 	getRoomMissionIdFromPath,
+	getRoomTabFromPath,
 	createSessionPath,
 	createRoomMissionPath,
+	createRoomTasksPath,
+	createRoomAgentsPath,
+	createRoomGoalsPath,
+	createRoomSettingsPath,
 	navigateToSession,
 	navigateToRoom,
+	navigateToRoomAgent,
 	navigateToHome,
 	navigateToRoomMission,
+	navigateToRoomTab,
 	initializeRouter,
 	cleanupRouter,
 	getRouterState,
@@ -30,6 +37,8 @@ import {
 	currentRoomIdSignal,
 	currentRoomTaskIdSignal,
 	currentRoomGoalIdSignal,
+	currentRoomAgentActiveSignal,
+	currentRoomActiveTabSignal,
 } from '../signals';
 
 // Store original values (use unknown to avoid type errors at module load time)
@@ -75,6 +84,8 @@ describe('Router Utility', () => {
 		currentRoomIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
+		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 
 		// Reset mocks
 		vi.clearAllMocks();
@@ -104,6 +115,8 @@ describe('Router Utility', () => {
 		currentRoomIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
+		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 	});
 
 	describe('getSessionIdFromPath', () => {
@@ -908,6 +921,267 @@ describe('Router Utility', () => {
 				'/room/550e8400-e29b-41d4-a716-446655440000/mission/660e8400-e29b-41d4-a716-446655440001';
 			navigateToHome();
 			expect(currentRoomGoalIdSignal.value).toBeNull();
+		});
+	});
+
+	// ──────────────────────────────────────────────────────────────────────────
+	// Room tab route tests
+	// ──────────────────────────────────────────────────────────────────────────
+
+	describe('getRoomTabFromPath', () => {
+		it('should extract roomId and tab from tasks path', () => {
+			const result = getRoomTabFromPath('/room/abc-123/tasks');
+			expect(result).toEqual({ roomId: 'abc-123', tab: 'tasks' });
+		});
+
+		it('should extract roomId and tab from agents path', () => {
+			const result = getRoomTabFromPath('/room/abc-123/agents');
+			expect(result).toEqual({ roomId: 'abc-123', tab: 'agents' });
+		});
+
+		it('should extract roomId and tab from goals path', () => {
+			const result = getRoomTabFromPath('/room/abc-123/goals');
+			expect(result).toEqual({ roomId: 'abc-123', tab: 'goals' });
+		});
+
+		it('should extract roomId and tab from settings path', () => {
+			const result = getRoomTabFromPath('/room/abc-123/settings');
+			expect(result).toEqual({ roomId: 'abc-123', tab: 'settings' });
+		});
+
+		it('should map agent path to chat tab', () => {
+			const result = getRoomTabFromPath('/room/abc-123/agent');
+			expect(result).toEqual({ roomId: 'abc-123', tab: 'chat' });
+		});
+
+		it('should return null for plain room path (no tab)', () => {
+			const result = getRoomTabFromPath('/room/abc-123');
+			expect(result).toBeNull();
+		});
+
+		it('should return null for room task detail path (not tab)', () => {
+			const result = getRoomTabFromPath('/room/abc-123/task/some-task-id');
+			expect(result).toBeNull();
+		});
+
+		it('should return null for room mission detail path (not tab)', () => {
+			const result = getRoomTabFromPath('/room/abc-123/mission/some-goal-id');
+			expect(result).toBeNull();
+		});
+
+		it('should return null for non-room paths', () => {
+			expect(getRoomTabFromPath('/')).toBeNull();
+			expect(getRoomTabFromPath('/session/abc-123')).toBeNull();
+			expect(getRoomTabFromPath('/invalid')).toBeNull();
+		});
+
+		it('should return null for path with extra trailing segments', () => {
+			expect(getRoomTabFromPath('/room/abc-123/tasks/extra')).toBeNull();
+			expect(getRoomTabFromPath('/room/abc-123/agents/extra')).toBeNull();
+		});
+	});
+
+	describe('createRoomTasksPath', () => {
+		it('should create correct tasks path', () => {
+			const path = createRoomTasksPath('550e8400-e29b-41d4-a716-446655440000');
+			expect(path).toBe('/room/550e8400-e29b-41d4-a716-446655440000/tasks');
+		});
+	});
+
+	describe('createRoomAgentsPath', () => {
+		it('should create correct agents path', () => {
+			const path = createRoomAgentsPath('550e8400-e29b-41d4-a716-446655440000');
+			expect(path).toBe('/room/550e8400-e29b-41d4-a716-446655440000/agents');
+		});
+	});
+
+	describe('createRoomGoalsPath', () => {
+		it('should create correct goals path', () => {
+			const path = createRoomGoalsPath('550e8400-e29b-41d4-a716-446655440000');
+			expect(path).toBe('/room/550e8400-e29b-41d4-a716-446655440000/goals');
+		});
+	});
+
+	describe('createRoomSettingsPath', () => {
+		it('should create correct settings path', () => {
+			const path = createRoomSettingsPath('550e8400-e29b-41d4-a716-446655440000');
+			expect(path).toBe('/room/550e8400-e29b-41d4-a716-446655440000/settings');
+		});
+	});
+
+	describe('getRoomIdFromPath with tab routes', () => {
+		it('should extract room ID from tasks path', () => {
+			const roomId = getRoomIdFromPath('/room/550e8400-e29b-41d4-a716-446655440000/tasks');
+			expect(roomId).toBe('550e8400-e29b-41d4-a716-446655440000');
+		});
+
+		it('should extract room ID from agents path', () => {
+			const roomId = getRoomIdFromPath('/room/550e8400-e29b-41d4-a716-446655440000/agents');
+			expect(roomId).toBe('550e8400-e29b-41d4-a716-446655440000');
+		});
+
+		it('should extract room ID from goals path', () => {
+			const roomId = getRoomIdFromPath('/room/550e8400-e29b-41d4-a716-446655440000/goals');
+			expect(roomId).toBe('550e8400-e29b-41d4-a716-446655440000');
+		});
+
+		it('should extract room ID from settings path', () => {
+			const roomId = getRoomIdFromPath('/room/550e8400-e29b-41d4-a716-446655440000/settings');
+			expect(roomId).toBe('550e8400-e29b-41d4-a716-446655440000');
+		});
+	});
+
+	describe('navigateToRoomTab', () => {
+		it('should navigate to tasks tab with pushState by default', () => {
+			navigateToRoomTab('550e8400-e29b-41d4-a716-446655440000', 'tasks');
+
+			expect(mockHistory.pushState).toHaveBeenCalledWith(
+				{
+					roomId: '550e8400-e29b-41d4-a716-446655440000',
+					tab: 'tasks',
+					path: '/room/550e8400-e29b-41d4-a716-446655440000/tasks',
+				},
+				'',
+				'/room/550e8400-e29b-41d4-a716-446655440000/tasks'
+			);
+			expect(currentRoomActiveTabSignal.value).toBe('tasks');
+			expect(currentRoomAgentActiveSignal.value).toBe(false);
+			expect(currentRoomIdSignal.value).toBe('550e8400-e29b-41d4-a716-446655440000');
+		});
+
+		it('should navigate to agents tab', () => {
+			navigateToRoomTab('550e8400-e29b-41d4-a716-446655440000', 'agents');
+
+			expect(mockHistory.pushState).toHaveBeenCalledWith(
+				{
+					roomId: '550e8400-e29b-41d4-a716-446655440000',
+					tab: 'agents',
+					path: '/room/550e8400-e29b-41d4-a716-446655440000/agents',
+				},
+				'',
+				'/room/550e8400-e29b-41d4-a716-446655440000/agents'
+			);
+			expect(currentRoomActiveTabSignal.value).toBe('agents');
+		});
+
+		it('should navigate to goals tab', () => {
+			navigateToRoomTab('550e8400-e29b-41d4-a716-446655440000', 'goals');
+
+			expect(mockHistory.pushState).toHaveBeenCalledWith(
+				{
+					roomId: '550e8400-e29b-41d4-a716-446655440000',
+					tab: 'goals',
+					path: '/room/550e8400-e29b-41d4-a716-446655440000/goals',
+				},
+				'',
+				'/room/550e8400-e29b-41d4-a716-446655440000/goals'
+			);
+			expect(currentRoomActiveTabSignal.value).toBe('goals');
+		});
+
+		it('should navigate to settings tab', () => {
+			navigateToRoomTab('550e8400-e29b-41d4-a716-446655440000', 'settings');
+
+			expect(mockHistory.pushState).toHaveBeenCalledWith(
+				{
+					roomId: '550e8400-e29b-41d4-a716-446655440000',
+					tab: 'settings',
+					path: '/room/550e8400-e29b-41d4-a716-446655440000/settings',
+				},
+				'',
+				'/room/550e8400-e29b-41d4-a716-446655440000/settings'
+			);
+			expect(currentRoomActiveTabSignal.value).toBe('settings');
+		});
+
+		it('should delegate to navigateToRoomAgent when tab is chat', () => {
+			navigateToRoomTab('550e8400-e29b-41d4-a716-446655440000', 'chat');
+
+			expect(mockHistory.pushState).toHaveBeenCalledWith(
+				{
+					roomId: '550e8400-e29b-41d4-a716-446655440000',
+					path: '/room/550e8400-e29b-41d4-a716-446655440000/agent',
+				},
+				'',
+				'/room/550e8400-e29b-41d4-a716-446655440000/agent'
+			);
+			expect(currentRoomActiveTabSignal.value).toBe('chat');
+			expect(currentRoomAgentActiveSignal.value).toBe(true);
+		});
+
+		it('should delegate to navigateToRoom when tab is overview and set currentRoomActiveTabSignal', () => {
+			navigateToRoomTab('550e8400-e29b-41d4-a716-446655440000', 'overview');
+
+			expect(mockHistory.pushState).toHaveBeenCalledWith(
+				{
+					roomId: '550e8400-e29b-41d4-a716-446655440000',
+					path: '/room/550e8400-e29b-41d4-a716-446655440000',
+				},
+				'',
+				'/room/550e8400-e29b-41d4-a716-446655440000'
+			);
+			expect(currentRoomActiveTabSignal.value).toBe('overview');
+		});
+
+		it('should use replaceState when replace is true', () => {
+			navigateToRoomTab('550e8400-e29b-41d4-a716-446655440000', 'tasks', true);
+
+			expect(mockHistory.replaceState).toHaveBeenCalled();
+			expect(mockHistory.pushState).not.toHaveBeenCalled();
+		});
+
+		it('should default replace to false', () => {
+			navigateToRoomTab('550e8400-e29b-41d4-a716-446655440000', 'tasks');
+
+			expect(mockHistory.pushState).toHaveBeenCalled();
+			expect(mockHistory.replaceState).not.toHaveBeenCalled();
+		});
+
+		it('should clear unrelated signals when navigating to a tab', () => {
+			currentSessionIdSignal.value = 'some-session';
+			currentRoomTaskIdSignal.value = 'some-task';
+			currentRoomGoalIdSignal.value = 'some-goal';
+
+			navigateToRoomTab('550e8400-e29b-41d4-a716-446655440000', 'tasks');
+
+			expect(currentSessionIdSignal.value).toBeNull();
+			expect(currentRoomTaskIdSignal.value).toBeNull();
+			expect(currentRoomGoalIdSignal.value).toBeNull();
+		});
+
+		it('should not navigate if already on the same tab path', () => {
+			const path = '/room/550e8400-e29b-41d4-a716-446655440000/tasks';
+			mockLocation.pathname = path;
+			currentRoomActiveTabSignal.value = 'tasks';
+
+			navigateToRoomTab('550e8400-e29b-41d4-a716-446655440000', 'tasks');
+
+			expect(mockHistory.pushState).not.toHaveBeenCalled();
+			expect(mockHistory.replaceState).not.toHaveBeenCalled();
+			expect(currentRoomActiveTabSignal.value).toBe('tasks');
+		});
+
+		it('should prevent recursive navigation when isNavigating is true', () => {
+			navigateToRoomTab('550e8400-e29b-41d4-a716-446655440000', 'tasks');
+			const firstCallCount = mockHistory.pushState.mock.calls.length;
+
+			navigateToRoomTab('550e8400-e29b-41d4-a716-446655440000', 'agents');
+
+			expect(mockHistory.pushState.mock.calls.length).toBe(firstCallCount);
+			expect(currentRoomActiveTabSignal.value).toBe('tasks');
+		});
+
+		it('should do nothing for unknown tab', () => {
+			navigateToRoomTab('550e8400-e29b-41d4-a716-446655440000', 'nonexistent');
+
+			expect(mockHistory.pushState).not.toHaveBeenCalled();
+			expect(mockHistory.replaceState).not.toHaveBeenCalled();
+		});
+
+		it('should set navSectionSignal to rooms', () => {
+			navigateToRoomTab('550e8400-e29b-41d4-a716-446655440000', 'tasks');
+			// navSectionSignal is set inside navigateToRoomTab
+			expect(currentRoomActiveTabSignal.value).toBe('tasks');
 		});
 	});
 

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -36,6 +36,10 @@ const ROOM_AGENT_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/agent$/;
 const ROOM_SESSION_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/session\/([a-f0-9-]+)$/;
 const ROOM_TASK_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/task\/([a-f0-9-]+|[a-z]-[1-9]\d*)$/;
 const ROOM_MISSION_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/mission\/([a-f0-9-]+|[a-z]-[1-9]\d*)$/;
+const ROOM_TASKS_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/tasks$/;
+const ROOM_AGENTS_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/agents$/;
+const ROOM_GOALS_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/goals$/;
+const ROOM_SETTINGS_ROUTE_PATTERN = /^\/room\/([a-f0-9-]+)\/settings$/;
 const SESSIONS_ROUTE_PATTERN = /^\/sessions$/;
 const INBOX_ROUTE_PATTERN = /^\/inbox$/;
 const SPACES_ROUTE_PATTERN = /^\/spaces$/;
@@ -93,6 +97,19 @@ export function getRoomIdFromPath(path: string): string | null {
 	// Also check room mission pattern
 	const roomMissionMatch = path.match(ROOM_MISSION_ROUTE_PATTERN);
 	if (roomMissionMatch) return roomMissionMatch[1];
+
+	// Also check room tab patterns (tasks, agents, goals, settings)
+	const roomTasksMatch = path.match(ROOM_TASKS_ROUTE_PATTERN);
+	if (roomTasksMatch) return roomTasksMatch[1];
+
+	const roomAgentsMatch = path.match(ROOM_AGENTS_ROUTE_PATTERN);
+	if (roomAgentsMatch) return roomAgentsMatch[1];
+
+	const roomGoalsMatch = path.match(ROOM_GOALS_ROUTE_PATTERN);
+	if (roomGoalsMatch) return roomGoalsMatch[1];
+
+	const roomSettingsMatch = path.match(ROOM_SETTINGS_ROUTE_PATTERN);
+	if (roomSettingsMatch) return roomSettingsMatch[1];
 
 	// Legacy chat sub-path — the Chat tab was removed; redirect old URLs to the room overview
 	const chatCompatMatch = path.match(ROOM_CHAT_COMPAT_PATTERN);
@@ -248,6 +265,57 @@ export function createRoomTaskPath(roomId: string, taskId: string): string {
  */
 export function createRoomMissionPath(roomId: string, goalId: string): string {
 	return `/room/${roomId}/mission/${goalId}`;
+}
+
+/**
+ * Create room tasks tab URL path
+ */
+export function createRoomTasksPath(roomId: string): string {
+	return `/room/${roomId}/tasks`;
+}
+
+/**
+ * Create room agents tab URL path
+ */
+export function createRoomAgentsPath(roomId: string): string {
+	return `/room/${roomId}/agents`;
+}
+
+/**
+ * Create room goals tab URL path
+ */
+export function createRoomGoalsPath(roomId: string): string {
+	return `/room/${roomId}/goals`;
+}
+
+/**
+ * Create room settings tab URL path
+ */
+export function createRoomSettingsPath(roomId: string): string {
+	return `/room/${roomId}/settings`;
+}
+
+/**
+ * Extract room tab from current URL path
+ * Returns { roomId, tab } if on a room tab route, or null otherwise
+ */
+export function getRoomTabFromPath(path: string): { roomId: string; tab: string } | null {
+	let match = path.match(ROOM_AGENT_ROUTE_PATTERN);
+	if (match) return { roomId: match[1], tab: 'chat' };
+
+	match = path.match(ROOM_TASKS_ROUTE_PATTERN);
+	if (match) return { roomId: match[1], tab: 'tasks' };
+
+	match = path.match(ROOM_AGENTS_ROUTE_PATTERN);
+	if (match) return { roomId: match[1], tab: 'agents' };
+
+	match = path.match(ROOM_GOALS_ROUTE_PATTERN);
+	if (match) return { roomId: match[1], tab: 'goals' };
+
+	match = path.match(ROOM_SETTINGS_ROUTE_PATTERN);
+	if (match) return { roomId: match[1], tab: 'settings' };
+
+	return null;
 }
 
 /**
@@ -655,6 +723,91 @@ export function navigateToRoomMission(roomId: string, goalId: string, replace = 
 		currentRoomTaskIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentSessionIdSignal.value = null;
+		currentSpaceIdSignal.value = null;
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		navSectionSignal.value = 'rooms';
+	} finally {
+		setTimeout(() => {
+			routerState.isNavigating = false;
+		}, 0);
+	}
+}
+
+/**
+ * Navigate to a room tab
+ * Updates URL to /room/:roomId/:tab and sets signals for tab rendering
+ *
+ * @param roomId - The room ID
+ * @param tab - The tab to navigate to ('chat', 'overview', 'tasks', 'agents', 'goals', 'settings')
+ * @param replace - Whether to replace current history entry (default: false)
+ */
+export function navigateToRoomTab(roomId: string, tab: string, replace = false): void {
+	if (routerState.isNavigating) {
+		return;
+	}
+
+	// Delegate to specialized navigators for known tabs
+	if (tab === 'chat') {
+		navigateToRoomAgent(roomId, replace);
+		return;
+	}
+
+	if (tab === 'overview') {
+		navigateToRoom(roomId, replace);
+		// navigateToRoom does NOT set currentRoomActiveTabSignal — set it explicitly
+		currentRoomActiveTabSignal.value = 'overview';
+		return;
+	}
+
+	// Map tab name to path creator
+	let targetPath: string;
+	switch (tab) {
+		case 'tasks':
+			targetPath = createRoomTasksPath(roomId);
+			break;
+		case 'agents':
+			targetPath = createRoomAgentsPath(roomId);
+			break;
+		case 'goals':
+			targetPath = createRoomGoalsPath(roomId);
+			break;
+		case 'settings':
+			targetPath = createRoomSettingsPath(roomId);
+			break;
+		default:
+			return;
+	}
+
+	const currentPath = getCurrentPath();
+
+	if (currentPath === targetPath) {
+		currentRoomIdSignal.value = roomId;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
+		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = tab;
+		currentSessionIdSignal.value = null;
+		currentSpaceIdSignal.value = null;
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		return;
+	}
+
+	routerState.isNavigating = true;
+
+	try {
+		const historyMethod = replace ? 'replaceState' : 'pushState';
+		window.history[historyMethod]({ roomId, tab, path: targetPath }, '', targetPath);
+
+		currentRoomIdSignal.value = roomId;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
+		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = tab;
 		currentSessionIdSignal.value = null;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;


### PR DESCRIPTION
## Summary
- Add four room tab route pattern constants (`ROOM_TASKS_ROUTE_PATTERN`, `ROOM_AGENTS_ROUTE_PATTERN`, `ROOM_GOALS_ROUTE_PATTERN`, `ROOM_SETTINGS_ROUTE_PATTERN`)
- Add `getRoomTabFromPath()` extractor that maps tab sub-paths to `{ roomId, tab }` tuples (agent → 'chat')
- Add four path creator functions: `createRoomTasksPath`, `createRoomAgentsPath`, `createRoomGoalsPath`, `createRoomSettingsPath`
- Add `navigateToRoomTab(roomId, tab, replace)` with delegation to `navigateToRoomAgent` (chat), `navigateToRoom` (overview), and direct navigation for other tabs
- Update `getRoomIdFromPath` to match all four new tab patterns
- 104 unit tests passing

## E2E tests
No E2E tests for this PR — the new tab URLs are not yet wired into the UI. Specifically:
- `handlePopState` and `initializeRouter` don't parse tab patterns from the URL (next task: handlePopState update)
- `Room.tsx` uses local `useState` for tab state, not `currentRoomActiveTabSignal` (next task: signal-driven tabs)

Navigating to `/room/:id/tasks` in a browser right now would correctly load the room (via `getRoomIdFromPath`) but display the overview tab, since no signal is set to drive the tab UI. E2E coverage will be added when the tab URLs become user-visible in later tasks.

## Test plan
- [x] `cd packages/web && bunx vitest run src/lib/__tests__/router.test.ts` — 104 tests pass
- [x] Typecheck passes
- [x] Lint/format passes