### PR TITLE
refactor: split room-store subscribeRoom into per-query methods

### DIFF
--- a/packages/e2e/tests/features/room-livequery-subscriptions.e2e.ts
+++ b/packages/e2e/tests/features/room-livequery-subscriptions.e2e.ts
@@ -35,7 +35,9 @@ import {
 
 async function setupPage(page: import('@playwright/test').Page): Promise<void> {
 	await page.goto('/');
-	// Clear persisted task filter tab so draft tasks are always visible
+	// Clear persisted task filter tab so draft tasks are always visible.
+	// Must run before the app JS bundle hydrates (which reads this key on mount).
+	// page.goto('/') resolves at DOMContentLoaded, before the Preact app mounts.
 	await page.evaluate(() => localStorage.removeItem('neokai:room:taskFilterTab'));
 	await page.getByRole('button', { name: 'New Session', exact: true }).waitFor({ timeout: 10000 });
 }

--- a/packages/e2e/tests/features/room-livequery-subscriptions.e2e.ts
+++ b/packages/e2e/tests/features/room-livequery-subscriptions.e2e.ts
@@ -7,8 +7,8 @@
  * Tests:
  * - Tasks load and display when viewing a room's Tasks tab
  * - Goals load and display when viewing the Missions tab
- * - Subscriptions survive a WebSocket reconnect — data is still visible after
- *   disconnecting and reconnecting
+ * - Re-subscription after WebSocket reconnect delivers fresh snapshots
+ *   (new entities created during disconnect appear after reconnect)
  *
  * Setup: RPC to create room, task, and goal (infrastructure).
  * Test actions and assertions: all through visible UI.
@@ -31,16 +31,139 @@ import {
 	waitForOnlineStatus,
 } from '../helpers/connection-helpers';
 
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+async function setupPage(page: import('@playwright/test').Page): Promise<void> {
+	await page.goto('/');
+	// Clear persisted task filter tab so draft tasks are always visible
+	await page.evaluate(() => localStorage.removeItem('neokai:room:taskFilterTab'));
+	await page.getByRole('button', { name: 'New Session', exact: true }).waitFor({ timeout: 10000 });
+}
+
+/**
+ * Create a task via a raw WebSocket RPC — for use when the main
+ * ConnectionManager's WebSocket is disconnected.
+ *
+ * Opens an independent WebSocket to the server, sends a task.create
+ * request, and returns the task ID from the response.
+ */
+async function createTaskViaRawWs(
+	page: import('@playwright/test').Page,
+	roomId: string,
+	title: string,
+	description = ''
+): Promise<string> {
+	return page.evaluate(
+		async ({ rId, t, d }) => {
+			const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+			const wsUrl = `${protocol}//${window.location.host}/ws`;
+			const requestId = crypto.randomUUID();
+
+			return new Promise<string>((resolve, reject) => {
+				const ws = new WebSocket(wsUrl);
+				const timeout = setTimeout(() => {
+					ws.close();
+					reject(new Error('Raw WS RPC timed out'));
+				}, 10000);
+
+				ws.addEventListener('message', (event) => {
+					const msg = JSON.parse(event.data);
+					if (msg.type === 'RSP' && msg.requestId === requestId) {
+						clearTimeout(timeout);
+						ws.close();
+						if (msg.error) reject(new Error(msg.error));
+						else resolve((msg.data as { task: { id: string } }).task.id);
+					}
+				});
+
+				ws.addEventListener('open', () => {
+					ws.send(
+						JSON.stringify({
+							id: requestId,
+							type: 'REQ',
+							sessionId: 'global',
+							method: 'task.create',
+							data: { roomId: rId, title: t, description: d, status: 'draft' },
+							timestamp: new Date().toISOString(),
+							version: '1.0.0',
+						})
+					);
+				});
+
+				ws.addEventListener('error', () => {
+					clearTimeout(timeout);
+					reject(new Error('Raw WS connection failed'));
+				});
+			});
+		},
+		{ rId: roomId, t: title, d: description }
+	);
+}
+
+/**
+ * Create a goal via a raw WebSocket RPC — for use when the main
+ * ConnectionManager's WebSocket is disconnected.
+ */
+async function createGoalViaRawWs(
+	page: import('@playwright/test').Page,
+	roomId: string,
+	title: string,
+	description = ''
+): Promise<string> {
+	return page.evaluate(
+		async ({ rId, t, d }) => {
+			const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+			const wsUrl = `${protocol}//${window.location.host}/ws`;
+			const requestId = crypto.randomUUID();
+
+			return new Promise<string>((resolve, reject) => {
+				const ws = new WebSocket(wsUrl);
+				const timeout = setTimeout(() => {
+					ws.close();
+					reject(new Error('Raw WS RPC timed out'));
+				}, 10000);
+
+				ws.addEventListener('message', (event) => {
+					const msg = JSON.parse(event.data);
+					if (msg.type === 'RSP' && msg.requestId === requestId) {
+						clearTimeout(timeout);
+						ws.close();
+						if (msg.error) reject(new Error(msg.error));
+						else resolve((msg.data as { goal: { id: string } }).goal.id);
+					}
+				});
+
+				ws.addEventListener('open', () => {
+					ws.send(
+						JSON.stringify({
+							id: requestId,
+							type: 'REQ',
+							sessionId: 'global',
+							method: 'goal.create',
+							data: { roomId: rId, title: t, description: d, priority: 'normal' },
+							timestamp: new Date().toISOString(),
+							version: '1.0.0',
+						})
+					);
+				});
+
+				ws.addEventListener('error', () => {
+					clearTimeout(timeout);
+					reject(new Error('Raw WS connection failed'));
+				});
+			});
+		},
+		{ rId: roomId, t: title, d: description }
+	);
+}
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 test.describe('Room LiveQuery — Tasks Tab', () => {
 	let roomId = '';
 
 	test.beforeEach(async ({ page }) => {
-		await page.goto('/');
-		await page
-			.getByRole('button', { name: 'New Session', exact: true })
-			.waitFor({ timeout: 10000 });
+		await setupPage(page);
 		roomId = '';
 	});
 
@@ -49,7 +172,7 @@ test.describe('Room LiveQuery — Tasks Tab', () => {
 	});
 
 	test('displays tasks in the Tasks tab after room navigation', async ({ page }) => {
-		// Setup: create room with a task via RPC
+		// Setup: create room with tasks via RPC
 		roomId = await createRoom(page, 'E2E Tasks LiveQuery Room');
 		await createTask(page, roomId, 'E2E Task Alpha', 'First test task');
 		await createTask(page, roomId, 'E2E Task Beta', 'Second test task');
@@ -73,10 +196,7 @@ test.describe('Room LiveQuery — Missions Tab', () => {
 	let roomId = '';
 
 	test.beforeEach(async ({ page }) => {
-		await page.goto('/');
-		await page
-			.getByRole('button', { name: 'New Session', exact: true })
-			.waitFor({ timeout: 10000 });
+		await setupPage(page);
 		roomId = '';
 	});
 
@@ -107,10 +227,7 @@ test.describe('Room LiveQuery — WebSocket Reconnect Resilience', () => {
 	let roomId = '';
 
 	test.beforeEach(async ({ page }) => {
-		await page.goto('/');
-		await page
-			.getByRole('button', { name: 'New Session', exact: true })
-			.waitFor({ timeout: 10000 });
+		await setupPage(page);
 		roomId = '';
 	});
 
@@ -118,11 +235,10 @@ test.describe('Room LiveQuery — WebSocket Reconnect Resilience', () => {
 		await deleteRoom(page, roomId);
 	});
 
-	test('tasks remain visible after WebSocket disconnect and reconnect', async ({ page }) => {
-		// Setup: create room with tasks
+	test('re-subscribes to tasks after WebSocket disconnect and reconnect', async ({ page }) => {
+		// Setup: create room with an initial task
 		roomId = await createRoom(page, 'E2E Reconnect Tasks Room');
 		await createTask(page, roomId, 'Reconnect Task One', 'Survives reconnect');
-		await createTask(page, roomId, 'Reconnect Task Two', 'Also survives');
 
 		// Navigate to room and open Tasks tab
 		await page.goto(`/room/${roomId}`);
@@ -132,25 +248,28 @@ test.describe('Room LiveQuery — WebSocket Reconnect Resilience', () => {
 		await tasksTab.click();
 		await expect(tasksTab).toHaveClass(/border-blue-400/);
 
-		// Verify tasks are loaded before disconnect
+		// Verify initial task is loaded
 		await expect(page.locator('h4:has-text("Reconnect Task One")')).toBeVisible({ timeout: 10000 });
-		await expect(page.locator('h4:has-text("Reconnect Task Two")')).toBeVisible({ timeout: 5000 });
 
 		// Disconnect WebSocket
 		await closeWebSocket(page);
 		await waitForOfflineStatus(page);
 
+		// Create a new task via raw WebSocket while disconnected (infrastructure).
+		// This task was never seen before disconnect, so it can only appear
+		// after reconnect if the LiveQuery re-subscribed and received a fresh snapshot.
+		await createTaskViaRawWs(page, roomId, 'Reconnect Task New', 'Created during disconnect');
+
 		// Reconnect WebSocket
 		await restoreWebSocket(page);
 		await waitForOnlineStatus(page);
 
-		// Verify tasks are still visible after reconnect (LiveQuery re-subscribed)
-		await expect(page.locator('h4:has-text("Reconnect Task One")')).toBeVisible({ timeout: 10000 });
-		await expect(page.locator('h4:has-text("Reconnect Task Two")')).toBeVisible({ timeout: 5000 });
+		// The new task must appear — proving re-subscription delivered a fresh snapshot
+		await expect(page.locator('h4:has-text("Reconnect Task New")')).toBeVisible({ timeout: 10000 });
 	});
 
-	test('goals remain visible after WebSocket disconnect and reconnect', async ({ page }) => {
-		// Setup: create room with a goal
+	test('re-subscribes to goals after WebSocket disconnect and reconnect', async ({ page }) => {
+		// Setup: create room with an initial goal
 		roomId = await createRoom(page, 'E2E Reconnect Goals Room');
 		await createGoal(page, roomId, 'Reconnect Mission', 'Survives reconnect');
 
@@ -160,7 +279,7 @@ test.describe('Room LiveQuery — WebSocket Reconnect Resilience', () => {
 
 		await openMissionsTab(page);
 
-		// Verify goal is loaded before disconnect
+		// Verify initial goal is loaded
 		await expect(page.getByRole('button', { name: 'Reconnect Mission' }).first()).toBeVisible({
 			timeout: 10000,
 		});
@@ -169,12 +288,17 @@ test.describe('Room LiveQuery — WebSocket Reconnect Resilience', () => {
 		await closeWebSocket(page);
 		await waitForOfflineStatus(page);
 
+		// Create a new goal via raw WebSocket while disconnected (infrastructure).
+		// This goal was never seen before disconnect, so it can only appear
+		// after reconnect if the LiveQuery re-subscribed and received a fresh snapshot.
+		await createGoalViaRawWs(page, roomId, 'Reconnect Goal New', 'Created during disconnect');
+
 		// Reconnect WebSocket
 		await restoreWebSocket(page);
 		await waitForOnlineStatus(page);
 
-		// Verify goal is still visible after reconnect (LiveQuery re-subscribed)
-		await expect(page.getByRole('button', { name: 'Reconnect Mission' }).first()).toBeVisible({
+		// The new goal must appear — proving re-subscription delivered a fresh snapshot
+		await expect(page.getByRole('button', { name: 'Reconnect Goal New' }).first()).toBeVisible({
 			timeout: 10000,
 		});
 	});

--- a/packages/e2e/tests/features/room-livequery-subscriptions.e2e.ts
+++ b/packages/e2e/tests/features/room-livequery-subscriptions.e2e.ts
@@ -35,127 +35,98 @@ import {
 
 async function setupPage(page: import('@playwright/test').Page): Promise<void> {
 	await page.goto('/');
-	// Clear persisted task filter tab so draft tasks are always visible.
-	// Must run before the app JS bundle hydrates (which reads this key on mount).
-	// page.goto('/') resolves at DOMContentLoaded, before the Preact app mounts.
+	// Defensive: each test gets a fresh browser context (empty localStorage),
+	// so this removeItem is a no-op in normal conditions. It guards against
+	// future test-ordering issues if context isolation ever changes.
 	await page.evaluate(() => localStorage.removeItem('neokai:room:taskFilterTab'));
 	await page.getByRole('button', { name: 'New Session', exact: true }).waitFor({ timeout: 10000 });
 }
 
 /**
- * Create a task via a raw WebSocket RPC — for use when the main
+ * Create an entity via a raw WebSocket RPC — for use when the main
  * ConnectionManager's WebSocket is disconnected.
  *
- * Opens an independent WebSocket to the server, sends a task.create
- * request, and returns the task ID from the response.
+ * Opens an independent WebSocket to the server, sends the given RPC,
+ * and returns the entity ID extracted from the response.
  */
+async function createEntityViaRawWs(
+	page: import('@playwright/test').Page,
+	method: string,
+	data: Record<string, unknown>,
+	responseKey: string
+): Promise<string> {
+	return page.evaluate(
+		async ({ m, d, k }) => {
+			const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+			const wsUrl = `${protocol}//${window.location.host}/ws`;
+			const requestId = crypto.randomUUID();
+
+			return new Promise<string>((resolve, reject) => {
+				const ws = new WebSocket(wsUrl);
+				const timeout = setTimeout(() => {
+					ws.close();
+					reject(new Error('Raw WS RPC timed out'));
+				}, 10000);
+
+				ws.addEventListener('message', (event) => {
+					const msg = JSON.parse(event.data);
+					if (msg.type === 'RSP' && msg.requestId === requestId) {
+						clearTimeout(timeout);
+						ws.close();
+						if (msg.error) reject(new Error(msg.error));
+						else resolve((msg.data as Record<string, { id: string }>)[k].id);
+					}
+				});
+
+				ws.addEventListener('open', () => {
+					ws.send(
+						JSON.stringify({
+							id: requestId,
+							type: 'REQ',
+							sessionId: 'global',
+							method: m,
+							data: d,
+							timestamp: new Date().toISOString(),
+							version: '1.0.0',
+						})
+					);
+				});
+
+				ws.addEventListener('error', () => {
+					clearTimeout(timeout);
+					reject(new Error('Raw WS connection failed'));
+				});
+			});
+		},
+		{ m: method, d: data, k: responseKey }
+	);
+}
+
 async function createTaskViaRawWs(
 	page: import('@playwright/test').Page,
 	roomId: string,
 	title: string,
 	description = ''
 ): Promise<string> {
-	return page.evaluate(
-		async ({ rId, t, d }) => {
-			const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-			const wsUrl = `${protocol}//${window.location.host}/ws`;
-			const requestId = crypto.randomUUID();
-
-			return new Promise<string>((resolve, reject) => {
-				const ws = new WebSocket(wsUrl);
-				const timeout = setTimeout(() => {
-					ws.close();
-					reject(new Error('Raw WS RPC timed out'));
-				}, 10000);
-
-				ws.addEventListener('message', (event) => {
-					const msg = JSON.parse(event.data);
-					if (msg.type === 'RSP' && msg.requestId === requestId) {
-						clearTimeout(timeout);
-						ws.close();
-						if (msg.error) reject(new Error(msg.error));
-						else resolve((msg.data as { task: { id: string } }).task.id);
-					}
-				});
-
-				ws.addEventListener('open', () => {
-					ws.send(
-						JSON.stringify({
-							id: requestId,
-							type: 'REQ',
-							sessionId: 'global',
-							method: 'task.create',
-							data: { roomId: rId, title: t, description: d, status: 'draft' },
-							timestamp: new Date().toISOString(),
-							version: '1.0.0',
-						})
-					);
-				});
-
-				ws.addEventListener('error', () => {
-					clearTimeout(timeout);
-					reject(new Error('Raw WS connection failed'));
-				});
-			});
-		},
-		{ rId: roomId, t: title, d: description }
+	return createEntityViaRawWs(
+		page,
+		'task.create',
+		{ roomId, title, description, status: 'draft' },
+		'task'
 	);
 }
 
-/**
- * Create a goal via a raw WebSocket RPC — for use when the main
- * ConnectionManager's WebSocket is disconnected.
- */
 async function createGoalViaRawWs(
 	page: import('@playwright/test').Page,
 	roomId: string,
 	title: string,
 	description = ''
 ): Promise<string> {
-	return page.evaluate(
-		async ({ rId, t, d }) => {
-			const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-			const wsUrl = `${protocol}//${window.location.host}/ws`;
-			const requestId = crypto.randomUUID();
-
-			return new Promise<string>((resolve, reject) => {
-				const ws = new WebSocket(wsUrl);
-				const timeout = setTimeout(() => {
-					ws.close();
-					reject(new Error('Raw WS RPC timed out'));
-				}, 10000);
-
-				ws.addEventListener('message', (event) => {
-					const msg = JSON.parse(event.data);
-					if (msg.type === 'RSP' && msg.requestId === requestId) {
-						clearTimeout(timeout);
-						ws.close();
-						if (msg.error) reject(new Error(msg.error));
-						else resolve((msg.data as { goal: { id: string } }).goal.id);
-					}
-				});
-
-				ws.addEventListener('open', () => {
-					ws.send(
-						JSON.stringify({
-							id: requestId,
-							type: 'REQ',
-							sessionId: 'global',
-							method: 'goal.create',
-							data: { roomId: rId, title: t, description: d, priority: 'normal' },
-							timestamp: new Date().toISOString(),
-							version: '1.0.0',
-						})
-					);
-				});
-
-				ws.addEventListener('error', () => {
-					clearTimeout(timeout);
-					reject(new Error('Raw WS connection failed'));
-				});
-			});
-		},
-		{ rId: roomId, t: title, d: description }
+	return createEntityViaRawWs(
+		page,
+		'goal.create',
+		{ roomId, title, description, priority: 'normal' },
+		'goal'
 	);
 }
 

--- a/packages/e2e/tests/features/room-livequery-subscriptions.e2e.ts
+++ b/packages/e2e/tests/features/room-livequery-subscriptions.e2e.ts
@@ -1,0 +1,181 @@
+/**
+ * Room LiveQuery Subscription E2E Tests
+ *
+ * Verifies that room LiveQuery subscriptions (tasks, goals, skills) work
+ * correctly after the subscribeRoom refactor into per-query methods.
+ *
+ * Tests:
+ * - Tasks load and display when viewing a room's Tasks tab
+ * - Goals load and display when viewing the Missions tab
+ * - Subscriptions survive a WebSocket reconnect — data is still visible after
+ *   disconnecting and reconnecting
+ *
+ * Setup: RPC to create room, task, and goal (infrastructure).
+ * Test actions and assertions: all through visible UI.
+ * Teardown: RPC room delete.
+ */
+
+import { test, expect } from '../../fixtures';
+import { waitForWebSocketConnected } from '../helpers/wait-helpers';
+import {
+	createRoom,
+	createTask,
+	createGoal,
+	deleteRoom,
+	openMissionsTab,
+} from '../helpers/room-helpers';
+import {
+	closeWebSocket,
+	restoreWebSocket,
+	waitForOfflineStatus,
+	waitForOnlineStatus,
+} from '../helpers/connection-helpers';
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('Room LiveQuery — Tasks Tab', () => {
+	let roomId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await page
+			.getByRole('button', { name: 'New Session', exact: true })
+			.waitFor({ timeout: 10000 });
+		roomId = '';
+	});
+
+	test.afterEach(async ({ page }) => {
+		await deleteRoom(page, roomId);
+	});
+
+	test('displays tasks in the Tasks tab after room navigation', async ({ page }) => {
+		// Setup: create room with a task via RPC
+		roomId = await createRoom(page, 'E2E Tasks LiveQuery Room');
+		await createTask(page, roomId, 'E2E Task Alpha', 'First test task');
+		await createTask(page, roomId, 'E2E Task Beta', 'Second test task');
+
+		// Navigate to the room
+		await page.goto(`/room/${roomId}`);
+		await waitForWebSocketConnected(page);
+
+		// Click the Tasks tab
+		const tasksTab = page.getByRole('button', { name: 'Tasks' });
+		await tasksTab.click();
+		await expect(tasksTab).toHaveClass(/border-blue-400/);
+
+		// Verify both tasks are visible
+		await expect(page.locator('h4:has-text("E2E Task Alpha")')).toBeVisible({ timeout: 10000 });
+		await expect(page.locator('h4:has-text("E2E Task Beta")')).toBeVisible({ timeout: 5000 });
+	});
+});
+
+test.describe('Room LiveQuery — Missions Tab', () => {
+	let roomId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await page
+			.getByRole('button', { name: 'New Session', exact: true })
+			.waitFor({ timeout: 10000 });
+		roomId = '';
+	});
+
+	test.afterEach(async ({ page }) => {
+		await deleteRoom(page, roomId);
+	});
+
+	test('displays goals in the Missions tab after room navigation', async ({ page }) => {
+		// Setup: create room with a goal via RPC
+		roomId = await createRoom(page, 'E2E Goals LiveQuery Room');
+		await createGoal(page, roomId, 'E2E Mission Gamma', 'A test mission');
+
+		// Navigate to the room
+		await page.goto(`/room/${roomId}`);
+		await waitForWebSocketConnected(page);
+
+		// Click the Missions tab
+		await openMissionsTab(page);
+
+		// Verify the mission is visible (rendered as <button> when onGoalClick is provided)
+		await expect(page.getByRole('button', { name: 'E2E Mission Gamma' }).first()).toBeVisible({
+			timeout: 10000,
+		});
+	});
+});
+
+test.describe('Room LiveQuery — WebSocket Reconnect Resilience', () => {
+	let roomId = '';
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await page
+			.getByRole('button', { name: 'New Session', exact: true })
+			.waitFor({ timeout: 10000 });
+		roomId = '';
+	});
+
+	test.afterEach(async ({ page }) => {
+		await deleteRoom(page, roomId);
+	});
+
+	test('tasks remain visible after WebSocket disconnect and reconnect', async ({ page }) => {
+		// Setup: create room with tasks
+		roomId = await createRoom(page, 'E2E Reconnect Tasks Room');
+		await createTask(page, roomId, 'Reconnect Task One', 'Survives reconnect');
+		await createTask(page, roomId, 'Reconnect Task Two', 'Also survives');
+
+		// Navigate to room and open Tasks tab
+		await page.goto(`/room/${roomId}`);
+		await waitForWebSocketConnected(page);
+
+		const tasksTab = page.getByRole('button', { name: 'Tasks' });
+		await tasksTab.click();
+		await expect(tasksTab).toHaveClass(/border-blue-400/);
+
+		// Verify tasks are loaded before disconnect
+		await expect(page.locator('h4:has-text("Reconnect Task One")')).toBeVisible({ timeout: 10000 });
+		await expect(page.locator('h4:has-text("Reconnect Task Two")')).toBeVisible({ timeout: 5000 });
+
+		// Disconnect WebSocket
+		await closeWebSocket(page);
+		await waitForOfflineStatus(page);
+
+		// Reconnect WebSocket
+		await restoreWebSocket(page);
+		await waitForOnlineStatus(page);
+
+		// Verify tasks are still visible after reconnect (LiveQuery re-subscribed)
+		await expect(page.locator('h4:has-text("Reconnect Task One")')).toBeVisible({ timeout: 10000 });
+		await expect(page.locator('h4:has-text("Reconnect Task Two")')).toBeVisible({ timeout: 5000 });
+	});
+
+	test('goals remain visible after WebSocket disconnect and reconnect', async ({ page }) => {
+		// Setup: create room with a goal
+		roomId = await createRoom(page, 'E2E Reconnect Goals Room');
+		await createGoal(page, roomId, 'Reconnect Mission', 'Survives reconnect');
+
+		// Navigate to room and open Missions tab
+		await page.goto(`/room/${roomId}`);
+		await waitForWebSocketConnected(page);
+
+		await openMissionsTab(page);
+
+		// Verify goal is loaded before disconnect
+		await expect(page.getByRole('button', { name: 'Reconnect Mission' }).first()).toBeVisible({
+			timeout: 10000,
+		});
+
+		// Disconnect WebSocket
+		await closeWebSocket(page);
+		await waitForOfflineStatus(page);
+
+		// Reconnect WebSocket
+		await restoreWebSocket(page);
+		await waitForOnlineStatus(page);
+
+		// Verify goal is still visible after reconnect (LiveQuery re-subscribed)
+		await expect(page.getByRole('button', { name: 'Reconnect Mission' }).first()).toBeVisible({
+			timeout: 10000,
+		});
+	});
+});

--- a/packages/web/src/lib/__tests__/connection-manager-comprehensive.test.ts
+++ b/packages/web/src/lib/__tests__/connection-manager-comprehensive.test.ts
@@ -423,15 +423,6 @@ describe('ConnectionManager - Comprehensive Coverage', () => {
 			expect(mockTransportObj.initialize).toHaveBeenCalled();
 		});
 
-		it('should reset transport state before reconnecting', async () => {
-			mockTransportObj.initialize.mockResolvedValue(undefined);
-			await manager.getHub();
-
-			await manager.reconnect();
-
-			expect(mockTransportObj.resetReconnectState).toHaveBeenCalled();
-		});
-
 		it('should use forceReconnect if transport is ready', async () => {
 			mockTransportObj.initialize.mockResolvedValue(undefined);
 			mockTransportObj.isReady.mockReturnValue(true);
@@ -442,6 +433,27 @@ describe('ConnectionManager - Comprehensive Coverage', () => {
 			expect(mockTransportObj.forceReconnect).toHaveBeenCalled();
 		});
 
+		it('should use forceReconnect when transport exists but is not ready (preserves hub)', async () => {
+			// Regression test: when the transport is closed (e.g. after
+			// simulatePermanentDisconnect()), isReady() returns false. The old
+			// code created a brand new hub, discarding all onConnection handlers
+			// (including LiveQuery re-subscriptions). The fix calls forceReconnect()
+			// on the existing transport, preserving the hub and its handlers.
+			mockTransportObj.initialize.mockResolvedValue(undefined);
+			await manager.getHub();
+
+			const hubBefore = (manager as any).messageHub;
+			expect(hubBefore).toBeDefined();
+
+			// Simulate the transport being closed (ws = null, isReady = false)
+			mockTransportObj.isReady.mockReturnValue(false);
+
+			await manager.reconnect();
+
+			expect(mockTransportObj.forceReconnect).toHaveBeenCalled();
+			// The hub reference must be preserved — not replaced with a new instance
+			expect((manager as any).messageHub).toBe(hubBefore);
+		});
 		it('should handle reconnection failure gracefully', async () => {
 			const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 			mockTransportObj.initialize.mockRejectedValue(new Error('Reconnect failed'));

--- a/packages/web/src/lib/__tests__/room-store-per-query-subscriptions.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-per-query-subscriptions.test.ts
@@ -657,7 +657,7 @@ describe('RoomStore — subscribeRoom/unsubscribeRoom backward compatibility', (
 		expect(roomStore.goalsLoading.value).toBe(false);
 	});
 
-	it('reconnect re-subscribes all three after subscribeRoom', async () => {
+	it('reconnect re-subscribes all three and sets goalStore.loading', async () => {
 		await roomStore.subscribeRoom(ROOM_ID);
 
 		// Clear initial loading
@@ -676,9 +676,13 @@ describe('RoomStore — subscribeRoom/unsubscribeRoom backward compatibility', (
 			rows: [],
 			version: 1,
 		});
+		expect(roomStore.goalsLoading.value).toBe(false);
 
 		hub.request.mockClear();
 		hub.fireConnection('connected');
+
+		// Reconnect sets goalsLoading back to true via onSubscribe
+		expect(roomStore.goalsLoading.value).toBe(true);
 
 		const calls = hub.request.mock.calls as [string, unknown][];
 		const subscribeCalls = calls.filter(([method]) => method === 'liveQuery.subscribe');
@@ -689,5 +693,149 @@ describe('RoomStore — subscribeRoom/unsubscribeRoom backward compatibility', (
 		expect(queryNames).toContain('tasks.byRoom');
 		expect(queryNames).toContain('goals.byRoom');
 		expect(queryNames).toContain('skills.byRoom');
+	});
+});
+
+describe('RoomStore — per-query subscribeRoomGoals error paths', () => {
+	let hub: MockHub;
+
+	beforeEach(async () => {
+		hub = createMockHub();
+		setupHubRequests(hub);
+		vi.mocked(connectionManager.getHub).mockResolvedValue(hub as never);
+		vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(hub as never);
+		roomStore.unsubscribeRoom(ROOM_ID);
+		if (roomStore.roomId.value !== null) {
+			await roomStore.select(null);
+		}
+	});
+
+	afterEach(async () => {
+		roomStore.unsubscribeRoom(ROOM_ID);
+		await roomStore.select(null);
+		vi.clearAllMocks();
+	});
+
+	it('resets goalStore.loading when getHub() rejects', async () => {
+		await roomStore.select(ROOM_ID);
+
+		vi.mocked(connectionManager.getHub).mockRejectedValueOnce(new Error('connection failed'));
+
+		await roomStore.subscribeRoomGoals(ROOM_ID);
+
+		// goalStore.loading should be reset even though subscribe failed
+		expect(roomStore.goalsLoading.value).toBe(false);
+	});
+
+	it('resets goalStore.loading when liveQuery.subscribe RPC fails', async () => {
+		await roomStore.select(ROOM_ID);
+
+		// Hub connects fine, but the subscribe RPC rejects
+		hub.request.mockImplementation((method: string) => {
+			if (method === 'liveQuery.subscribe' && method === 'liveQuery.subscribe') {
+				// Reject the first liveQuery.subscribe (goals)
+				if (!hub.request.mock.calls.some(([m]) => m === 'liveQuery.subscribe')) {
+					return Promise.reject(new Error('subscribe failed'));
+				}
+			}
+			if (method === 'room.get') return Promise.resolve({ room: { id: ROOM_ID }, sessions: [] });
+			if (method === 'room.runtime.state') return Promise.reject(new Error('no runtime'));
+			return Promise.resolve({ ok: true });
+		});
+		// Simpler: reject ALL liveQuery.subscribe calls
+		hub.request.mockImplementation((method: string) => {
+			if (method === 'liveQuery.subscribe') return Promise.reject(new Error('subscribe failed'));
+			if (method === 'room.get') return Promise.resolve({ room: { id: ROOM_ID }, sessions: [] });
+			if (method === 'room.runtime.state') return Promise.reject(new Error('no runtime'));
+			return Promise.resolve({ ok: true });
+		});
+
+		await roomStore.subscribeRoomGoals(ROOM_ID);
+
+		expect(roomStore.goalsLoading.value).toBe(false);
+	});
+
+	it('resets goalStore.loading on reconnect subscribe failure', async () => {
+		await roomStore.select(ROOM_ID);
+		await roomStore.subscribeRoomGoals(ROOM_ID);
+
+		// Clear loading with snapshot
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: GOALS_SUB_ID,
+			rows: [],
+			version: 1,
+		});
+		expect(roomStore.goalsLoading.value).toBe(false);
+
+		// Make subscribe fail on reconnect
+		hub.request.mockImplementation((method: string) => {
+			if (method === 'liveQuery.subscribe') return Promise.reject(new Error('reconnect failed'));
+			return Promise.resolve({ ok: true });
+		});
+
+		// Reconnect triggers re-subscribe, sets loading=true, then subscribe fails
+		hub.fireConnection('connected');
+
+		// The reconnect handler sets loading=true synchronously, then the async
+		// subscribe rejection calls onError which resets loading.
+		// Wait for the microtask to process.
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(roomStore.goalsLoading.value).toBe(false);
+	});
+
+	it('clears liveQueryActive on getHub() rejection so re-subscribe is possible', async () => {
+		await roomStore.select(ROOM_ID);
+
+		vi.mocked(connectionManager.getHub).mockRejectedValueOnce(new Error('connection failed'));
+
+		await roomStore.subscribeRoomGoals(ROOM_ID);
+
+		expect(hub._handlers.get('liveQuery.snapshot') ?? []).toHaveLength(0);
+
+		// Restore hub for the second call
+		vi.mocked(connectionManager.getHub).mockResolvedValue(hub as never);
+
+		// Second subscribeRoomGoals should succeed
+		await roomStore.subscribeRoomGoals(ROOM_ID);
+
+		expect((hub._handlers.get('liveQuery.snapshot') ?? []).length).toBeGreaterThan(0);
+	});
+});
+
+describe('RoomStore — per-query subscribeRoomSkills error paths', () => {
+	let hub: MockHub;
+
+	beforeEach(async () => {
+		hub = createMockHub();
+		setupHubRequests(hub);
+		vi.mocked(connectionManager.getHub).mockResolvedValue(hub as never);
+		vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(hub as never);
+		roomStore.unsubscribeRoom(ROOM_ID);
+		if (roomStore.roomId.value !== null) {
+			await roomStore.select(null);
+		}
+	});
+
+	afterEach(async () => {
+		roomStore.unsubscribeRoom(ROOM_ID);
+		await roomStore.select(null);
+		vi.clearAllMocks();
+	});
+
+	it('clears liveQueryActive on getHub() rejection so re-subscribe is possible', async () => {
+		await roomStore.select(ROOM_ID);
+
+		vi.mocked(connectionManager.getHub).mockRejectedValueOnce(new Error('connection failed'));
+
+		await roomStore.subscribeRoomSkills(ROOM_ID);
+
+		expect(hub._handlers.get('liveQuery.snapshot') ?? []).toHaveLength(0);
+
+		vi.mocked(connectionManager.getHub).mockResolvedValue(hub as never);
+
+		await roomStore.subscribeRoomSkills(ROOM_ID);
+
+		expect((hub._handlers.get('liveQuery.snapshot') ?? []).length).toBeGreaterThan(0);
 	});
 });

--- a/packages/web/src/lib/__tests__/room-store-per-query-subscriptions.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-per-query-subscriptions.test.ts
@@ -1,0 +1,693 @@
+/**
+ * Tests for RoomStore per-query subscription methods
+ *
+ * Verifies that subscribeRoomTasks, subscribeRoomGoals, subscribeRoomSkills
+ * can be called independently, that unsubscribing one query does not affect
+ * others, and that the stale-event guard works per-query.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { NeoTask, RoomGoal, GoalStatus, AppSkill } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+type EventHandler<T = unknown> = (data: T) => void;
+
+interface MockHub {
+	_handlers: Map<string, EventHandler[]>;
+	_connectionHandlers: EventHandler[];
+	onEvent: <T>(method: string, handler: EventHandler<T>) => () => void;
+	onConnection: (handler: EventHandler<string>) => () => void;
+	request: ReturnType<typeof vi.fn>;
+	joinChannel: ReturnType<typeof vi.fn>;
+	leaveChannel: ReturnType<typeof vi.fn>;
+	fire: <T>(method: string, data: T) => void;
+	fireConnection: (state: string) => void;
+}
+
+function createMockHub(): MockHub {
+	const _handlers = new Map<string, EventHandler[]>();
+	const _connectionHandlers: EventHandler[] = [];
+	return {
+		_handlers,
+		_connectionHandlers,
+		onEvent: <T>(method: string, handler: EventHandler<T>) => {
+			if (!_handlers.has(method)) _handlers.set(method, []);
+			_handlers.get(method)!.push(handler as EventHandler);
+			return () => {
+				const list = _handlers.get(method);
+				if (list) {
+					const i = list.indexOf(handler as EventHandler);
+					if (i >= 0) list.splice(i, 1);
+				}
+			};
+		},
+		onConnection: (handler: EventHandler<string>) => {
+			_connectionHandlers.push(handler as EventHandler);
+			return () => {
+				const i = _connectionHandlers.indexOf(handler as EventHandler);
+				if (i >= 0) _connectionHandlers.splice(i, 1);
+			};
+		},
+		request: vi.fn(),
+		joinChannel: vi.fn(),
+		leaveChannel: vi.fn(),
+		fire: <T>(method: string, data: T) => {
+			for (const h of _handlers.get(method) ?? []) h(data);
+		},
+		fireConnection: (state: string) => {
+			for (const h of _connectionHandlers) h(state);
+		},
+	};
+}
+
+vi.mock('../connection-manager.ts', () => ({
+	connectionManager: {
+		getHub: vi.fn(),
+		getHubIfConnected: vi.fn(),
+	},
+}));
+vi.mock('../toast', () => ({ toast: { error: vi.fn(), info: vi.fn(), warn: vi.fn() } }));
+vi.mock('../router', () => ({ navigateToRoom: vi.fn() }));
+vi.mock('../signals', () => ({
+	currentRoomSessionIdSignal: { value: null },
+	currentRoomIdSignal: { value: null },
+	currentRoomTaskIdSignal: { value: null },
+	currentSessionIdSignal: { value: null },
+	currentSpaceIdSignal: { value: null },
+	currentSpaceSessionIdSignal: { value: null },
+	currentSpaceTaskIdSignal: { value: null },
+	navSectionSignal: { value: 'lobby' },
+}));
+
+import { connectionManager } from '../connection-manager.js';
+import { roomStore } from '../room-store.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ROOM_ID = 'room-per-query-test';
+const TASKS_SUB_ID = `tasks-byRoom-${ROOM_ID}`;
+const GOALS_SUB_ID = `goals-byRoom-${ROOM_ID}`;
+const SKILLS_SUB_ID = `skills-byRoom-${ROOM_ID}`;
+
+function makeTask(id: string, overrides: Partial<NeoTask> = {}): NeoTask {
+	return {
+		id,
+		roomId: ROOM_ID,
+		title: `Task ${id}`,
+		description: '',
+		status: 'pending',
+		priority: 'normal',
+		progress: 0,
+		dependsOn: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	} as NeoTask;
+}
+
+function makeGoal(id: string, overrides: Partial<RoomGoal> = {}): RoomGoal {
+	return {
+		id,
+		roomId: ROOM_ID,
+		title: `Goal ${id}`,
+		description: '',
+		status: 'active' as GoalStatus,
+		priority: 'normal',
+		progress: 0,
+		linkedTaskIds: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+function makeSkill(
+	id: string,
+	overrides: Partial<AppSkill> = {}
+): AppSkill & { overriddenByRoom: boolean } {
+	return {
+		id,
+		name: `Skill ${id}`,
+		description: '',
+		sourceType: 'builtin',
+		enabled: true,
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		overriddenByRoom: false,
+		...overrides,
+	} as AppSkill & { overriddenByRoom: boolean };
+}
+
+function setupHubRequests(hub: MockHub): void {
+	hub.request.mockImplementation((method: string) => {
+		if (method === 'room.get') return Promise.resolve({ room: { id: ROOM_ID }, sessions: [] });
+		if (method === 'room.runtime.state') return Promise.reject(new Error('no runtime'));
+		return Promise.resolve({ ok: true });
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('RoomStore — per-query subscribe methods', () => {
+	let hub: MockHub;
+
+	beforeEach(async () => {
+		hub = createMockHub();
+		setupHubRequests(hub);
+		vi.mocked(connectionManager.getHub).mockResolvedValue(hub as never);
+		vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(hub as never);
+		await roomStore.select(ROOM_ID);
+	});
+
+	afterEach(async () => {
+		roomStore.unsubscribeRoom(ROOM_ID);
+		await roomStore.select(null);
+		vi.clearAllMocks();
+	});
+
+	it('subscribeRoomGoals only sends goals.byRoom subscribe request', async () => {
+		await roomStore.subscribeRoomGoals(ROOM_ID);
+
+		const calls = hub.request.mock.calls as [string, unknown][];
+		const subscribeCalls = calls.filter(([method]) => method === 'liveQuery.subscribe');
+
+		// Should have exactly one liveQuery.subscribe call for goals
+		expect(subscribeCalls).toHaveLength(1);
+		expect(subscribeCalls[0]![1]).toMatchObject({
+			queryName: 'goals.byRoom',
+			params: [ROOM_ID],
+			subscriptionId: GOALS_SUB_ID,
+		});
+	});
+
+	it('subscribeRoomTasks only sends tasks.byRoom subscribe request', async () => {
+		await roomStore.subscribeRoomTasks(ROOM_ID);
+
+		const calls = hub.request.mock.calls as [string, unknown][];
+		const subscribeCalls = calls.filter(([method]) => method === 'liveQuery.subscribe');
+
+		expect(subscribeCalls).toHaveLength(1);
+		expect(subscribeCalls[0]![1]).toMatchObject({
+			queryName: 'tasks.byRoom',
+			params: [ROOM_ID],
+			subscriptionId: TASKS_SUB_ID,
+		});
+	});
+
+	it('subscribeRoomSkills only sends skills.byRoom subscribe request', async () => {
+		await roomStore.subscribeRoomSkills(ROOM_ID);
+
+		const calls = hub.request.mock.calls as [string, unknown][];
+		const subscribeCalls = calls.filter(([method]) => method === 'liveQuery.subscribe');
+
+		expect(subscribeCalls).toHaveLength(1);
+		expect(subscribeCalls[0]![1]).toMatchObject({
+			queryName: 'skills.byRoom',
+			params: [ROOM_ID],
+			subscriptionId: SKILLS_SUB_ID,
+		});
+	});
+
+	it('subscribeRoomGoals sets and clears goalStore.loading', async () => {
+		// After subscribing (before snapshot), loading should be true
+		await roomStore.subscribeRoomGoals(ROOM_ID);
+		expect(roomStore.goalsLoading.value).toBe(true);
+
+		// Snapshot clears loading
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: GOALS_SUB_ID,
+			rows: [makeGoal('g1')],
+			version: 1,
+		});
+		expect(roomStore.goalsLoading.value).toBe(false);
+	});
+
+	it('subscribeRoomGoals processes snapshot and delta events', async () => {
+		await roomStore.subscribeRoomGoals(ROOM_ID);
+
+		// Snapshot populates goals
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: GOALS_SUB_ID,
+			rows: [makeGoal('g1')],
+			version: 1,
+		});
+		expect(roomStore.goals.value.map((g) => g.id)).toEqual(['g1']);
+
+		// Delta adds goals
+		hub.fire('liveQuery.delta', {
+			subscriptionId: GOALS_SUB_ID,
+			added: [makeGoal('g2')],
+			version: 2,
+		});
+		expect(roomStore.goals.value.map((g) => g.id)).toEqual(['g1', 'g2']);
+	});
+
+	it('subscribeRoomTasks processes snapshot and delta events', async () => {
+		await roomStore.subscribeRoomTasks(ROOM_ID);
+
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: TASKS_SUB_ID,
+			rows: [makeTask('t1')],
+			version: 1,
+		});
+		expect(roomStore.tasks.value.map((t) => t.id)).toEqual(['t1']);
+
+		hub.fire('liveQuery.delta', {
+			subscriptionId: TASKS_SUB_ID,
+			added: [makeTask('t2')],
+			version: 2,
+		});
+		expect(roomStore.tasks.value.map((t) => t.id)).toEqual(['t1', 't2']);
+	});
+
+	it('subscribeRoomSkills processes snapshot and delta events', async () => {
+		await roomStore.subscribeRoomSkills(ROOM_ID);
+
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: SKILLS_SUB_ID,
+			rows: [makeSkill('s1')],
+			version: 1,
+		});
+		expect(roomStore.roomSkills.value.map((s) => s.id)).toEqual(['s1']);
+
+		hub.fire('liveQuery.delta', {
+			subscriptionId: SKILLS_SUB_ID,
+			added: [makeSkill('s2')],
+			version: 2,
+		});
+		expect(roomStore.roomSkills.value.map((s) => s.id)).toEqual(['s1', 's2']);
+	});
+
+	it('per-query methods guard against double subscription', async () => {
+		await roomStore.subscribeRoomGoals(ROOM_ID);
+		const callsBefore = hub.request.mock.calls.length;
+
+		// Second call should be a no-op
+		await roomStore.subscribeRoomGoals(ROOM_ID);
+		expect(hub.request.mock.calls.length).toBe(callsBefore);
+	});
+});
+
+describe('RoomStore — per-query unsubscribe isolation', () => {
+	let hub: MockHub;
+
+	beforeEach(async () => {
+		hub = createMockHub();
+		setupHubRequests(hub);
+		vi.mocked(connectionManager.getHub).mockResolvedValue(hub as never);
+		vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(hub as never);
+		await roomStore.select(ROOM_ID);
+	});
+
+	afterEach(async () => {
+		roomStore.unsubscribeRoom(ROOM_ID);
+		await roomStore.select(null);
+		vi.clearAllMocks();
+	});
+
+	it('unsubscribing goals does not affect tasks subscription', async () => {
+		// Subscribe both independently
+		await roomStore.subscribeRoomTasks(ROOM_ID);
+		await roomStore.subscribeRoomGoals(ROOM_ID);
+
+		// Seed both with data
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: TASKS_SUB_ID,
+			rows: [makeTask('t1')],
+			version: 1,
+		});
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: GOALS_SUB_ID,
+			rows: [makeGoal('g1')],
+			version: 1,
+		});
+
+		// Unsubscribe goals only
+		hub.request.mockClear();
+		roomStore.unsubscribeRoomGoals(ROOM_ID);
+
+		// Verify unsubscribe was sent for goals
+		const calls = hub.request.mock.calls as [string, unknown][];
+		const unsubCalls = calls.filter(
+			([method, params]) =>
+				method === 'liveQuery.unsubscribe' &&
+				(params as { subscriptionId: string }).subscriptionId === GOALS_SUB_ID
+		);
+		expect(unsubCalls).toHaveLength(1);
+
+		// Tasks should still receive delta events
+		hub.fire('liveQuery.delta', {
+			subscriptionId: TASKS_SUB_ID,
+			added: [makeTask('t2')],
+			version: 2,
+		});
+		expect(roomStore.tasks.value.map((t) => t.id)).toEqual(['t1', 't2']);
+
+		// Goals should NOT receive delta events (stale guard)
+		hub.fire('liveQuery.delta', {
+			subscriptionId: GOALS_SUB_ID,
+			added: [makeGoal('g2')],
+			version: 2,
+		});
+		expect(roomStore.goals.value.map((g) => g.id)).toEqual(['g1']);
+	});
+
+	it('unsubscribing tasks does not affect goals subscription', async () => {
+		await roomStore.subscribeRoomTasks(ROOM_ID);
+		await roomStore.subscribeRoomGoals(ROOM_ID);
+
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: TASKS_SUB_ID,
+			rows: [makeTask('t1')],
+			version: 1,
+		});
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: GOALS_SUB_ID,
+			rows: [makeGoal('g1')],
+			version: 1,
+		});
+
+		// Unsubscribe tasks only
+		hub.request.mockClear();
+		roomStore.unsubscribeRoomTasks(ROOM_ID);
+
+		const calls = hub.request.mock.calls as [string, unknown][];
+		const unsubCalls = calls.filter(
+			([method, params]) =>
+				method === 'liveQuery.unsubscribe' &&
+				(params as { subscriptionId: string }).subscriptionId === TASKS_SUB_ID
+		);
+		expect(unsubCalls).toHaveLength(1);
+
+		// Goals should still work
+		hub.fire('liveQuery.delta', {
+			subscriptionId: GOALS_SUB_ID,
+			added: [makeGoal('g2')],
+			version: 2,
+		});
+		expect(roomStore.goals.value.map((g) => g.id)).toEqual(['g1', 'g2']);
+
+		// Tasks should be guarded
+		hub.fire('liveQuery.delta', {
+			subscriptionId: TASKS_SUB_ID,
+			added: [makeTask('t2')],
+			version: 2,
+		});
+		expect(roomStore.tasks.value.map((t) => t.id)).toEqual(['t1']);
+	});
+
+	it('unsubscribing skills does not affect tasks or goals', async () => {
+		await roomStore.subscribeRoomTasks(ROOM_ID);
+		await roomStore.subscribeRoomGoals(ROOM_ID);
+		await roomStore.subscribeRoomSkills(ROOM_ID);
+
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: TASKS_SUB_ID,
+			rows: [makeTask('t1')],
+			version: 1,
+		});
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: GOALS_SUB_ID,
+			rows: [makeGoal('g1')],
+			version: 1,
+		});
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: SKILLS_SUB_ID,
+			rows: [makeSkill('s1')],
+			version: 1,
+		});
+
+		roomStore.unsubscribeRoomSkills(ROOM_ID);
+
+		// Tasks and goals should still work
+		hub.fire('liveQuery.delta', {
+			subscriptionId: TASKS_SUB_ID,
+			added: [makeTask('t2')],
+			version: 2,
+		});
+		hub.fire('liveQuery.delta', {
+			subscriptionId: GOALS_SUB_ID,
+			added: [makeGoal('g2')],
+			version: 2,
+		});
+
+		expect(roomStore.tasks.value.map((t) => t.id)).toEqual(['t1', 't2']);
+		expect(roomStore.goals.value.map((g) => g.id)).toEqual(['g1', 'g2']);
+	});
+
+	it('reconnect re-subscribes only the active queries', async () => {
+		await roomStore.subscribeRoomTasks(ROOM_ID);
+		await roomStore.subscribeRoomGoals(ROOM_ID);
+
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: TASKS_SUB_ID,
+			rows: [],
+			version: 1,
+		});
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: GOALS_SUB_ID,
+			rows: [],
+			version: 1,
+		});
+
+		// Unsubscribe goals
+		roomStore.unsubscribeRoomGoals(ROOM_ID);
+
+		// Reconnect
+		hub.request.mockClear();
+		hub.fireConnection('connected');
+
+		const calls = hub.request.mock.calls as [string, unknown][];
+		const subscribeCalls = calls.filter(([method]) => method === 'liveQuery.subscribe');
+
+		// Only tasks should be re-subscribed, not goals
+		expect(subscribeCalls).toHaveLength(1);
+		expect(subscribeCalls[0]![1]).toMatchObject({
+			queryName: 'tasks.byRoom',
+			subscriptionId: TASKS_SUB_ID,
+		});
+	});
+});
+
+describe('RoomStore — per-query stale-event guard', () => {
+	let hub: MockHub;
+
+	beforeEach(async () => {
+		hub = createMockHub();
+		setupHubRequests(hub);
+		vi.mocked(connectionManager.getHub).mockResolvedValue(hub as never);
+		vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(hub as never);
+		await roomStore.select(ROOM_ID);
+	});
+
+	afterEach(async () => {
+		roomStore.unsubscribeRoom(ROOM_ID);
+		await roomStore.select(null);
+		vi.clearAllMocks();
+	});
+
+	it('discards stale goal events after unsubscribeRoomGoals', async () => {
+		await roomStore.subscribeRoomGoals(ROOM_ID);
+
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: GOALS_SUB_ID,
+			rows: [makeGoal('g1')],
+			version: 1,
+		});
+
+		// Capture handlers before unsubscribe
+		const snapshotHandlers = [...(hub._handlers.get('liveQuery.snapshot') ?? [])];
+
+		roomStore.unsubscribeRoomGoals(ROOM_ID);
+
+		// Fire stale snapshot
+		for (const h of snapshotHandlers) {
+			(h as (data: unknown) => void)({
+				subscriptionId: GOALS_SUB_ID,
+				rows: [makeGoal('g1'), makeGoal('g2')],
+				version: 2,
+			});
+		}
+
+		expect(roomStore.goals.value.map((g) => g.id)).toEqual(['g1']);
+	});
+
+	it('discards stale task events after unsubscribeRoomTasks', async () => {
+		await roomStore.subscribeRoomTasks(ROOM_ID);
+
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: TASKS_SUB_ID,
+			rows: [makeTask('t1')],
+			version: 1,
+		});
+
+		const deltaHandlers = [...(hub._handlers.get('liveQuery.delta') ?? [])];
+
+		roomStore.unsubscribeRoomTasks(ROOM_ID);
+
+		for (const h of deltaHandlers) {
+			(h as (data: unknown) => void)({
+				subscriptionId: TASKS_SUB_ID,
+				added: [makeTask('t2')],
+				version: 2,
+			});
+		}
+
+		expect(roomStore.tasks.value.map((t) => t.id)).toEqual(['t1']);
+	});
+
+	it('goals guard re-establishes after re-subscription', async () => {
+		await roomStore.subscribeRoomGoals(ROOM_ID);
+
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: GOALS_SUB_ID,
+			rows: [makeGoal('g1')],
+			version: 1,
+		});
+
+		roomStore.unsubscribeRoomGoals(ROOM_ID);
+		await roomStore.subscribeRoomGoals(ROOM_ID);
+
+		// New snapshot should be accepted
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: GOALS_SUB_ID,
+			rows: [makeGoal('g1'), makeGoal('g2')],
+			version: 2,
+		});
+		expect(roomStore.goals.value.map((g) => g.id)).toEqual(['g1', 'g2']);
+	});
+});
+
+describe('RoomStore — subscribeRoom/unsubscribeRoom backward compatibility', () => {
+	let hub: MockHub;
+
+	beforeEach(async () => {
+		hub = createMockHub();
+		setupHubRequests(hub);
+		vi.mocked(connectionManager.getHub).mockResolvedValue(hub as never);
+		vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(hub as never);
+		await roomStore.select(ROOM_ID);
+	});
+
+	afterEach(async () => {
+		roomStore.unsubscribeRoom(ROOM_ID);
+		await roomStore.select(null);
+		vi.clearAllMocks();
+	});
+
+	it('subscribeRoom subscribes to all three queries', async () => {
+		await roomStore.subscribeRoom(ROOM_ID);
+
+		const calls = hub.request.mock.calls as [string, unknown][];
+		const subscribeCalls = calls.filter(([method]) => method === 'liveQuery.subscribe');
+
+		const queryNames = subscribeCalls.map(
+			([, params]) => (params as { queryName: string }).queryName
+		);
+		expect(queryNames).toContain('tasks.byRoom');
+		expect(queryNames).toContain('goals.byRoom');
+		expect(queryNames).toContain('skills.byRoom');
+	});
+
+	it('unsubscribeRoom unsubscribes from all three queries', async () => {
+		await roomStore.subscribeRoom(ROOM_ID);
+
+		hub.request.mockClear();
+		roomStore.unsubscribeRoom(ROOM_ID);
+
+		const calls = hub.request.mock.calls as [string, unknown][];
+		const unsubCalls = calls.filter(([method]) => method === 'liveQuery.unsubscribe');
+
+		const subIds = unsubCalls.map(
+			([, params]) => (params as { subscriptionId: string }).subscriptionId
+		);
+		expect(subIds).toContain(TASKS_SUB_ID);
+		expect(subIds).toContain(GOALS_SUB_ID);
+		expect(subIds).toContain(SKILLS_SUB_ID);
+	});
+
+	it('all three queries receive snapshot events after subscribeRoom', async () => {
+		await roomStore.subscribeRoom(ROOM_ID);
+
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: TASKS_SUB_ID,
+			rows: [makeTask('t1')],
+			version: 1,
+		});
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: GOALS_SUB_ID,
+			rows: [makeGoal('g1')],
+			version: 1,
+		});
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: SKILLS_SUB_ID,
+			rows: [makeSkill('s1')],
+			version: 1,
+		});
+
+		expect(roomStore.tasks.value.map((t) => t.id)).toEqual(['t1']);
+		expect(roomStore.goals.value.map((g) => g.id)).toEqual(['g1']);
+		expect(roomStore.roomSkills.value.map((s) => s.id)).toEqual(['s1']);
+	});
+
+	it('goalStore.loading is set by subscribeRoomGoals and cleared by snapshot', async () => {
+		await roomStore.subscribeRoom(ROOM_ID);
+		expect(roomStore.goalsLoading.value).toBe(true);
+
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: GOALS_SUB_ID,
+			rows: [makeGoal('g1')],
+			version: 1,
+		});
+		expect(roomStore.goalsLoading.value).toBe(false);
+	});
+
+	it('goalStore.loading is cleared by unsubscribeRoomGoals', async () => {
+		await roomStore.subscribeRoomGoals(ROOM_ID);
+		expect(roomStore.goalsLoading.value).toBe(true);
+
+		roomStore.unsubscribeRoomGoals(ROOM_ID);
+		expect(roomStore.goalsLoading.value).toBe(false);
+	});
+
+	it('reconnect re-subscribes all three after subscribeRoom', async () => {
+		await roomStore.subscribeRoom(ROOM_ID);
+
+		// Clear initial loading
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: TASKS_SUB_ID,
+			rows: [],
+			version: 1,
+		});
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: GOALS_SUB_ID,
+			rows: [],
+			version: 1,
+		});
+		hub.fire('liveQuery.snapshot', {
+			subscriptionId: SKILLS_SUB_ID,
+			rows: [],
+			version: 1,
+		});
+
+		hub.request.mockClear();
+		hub.fireConnection('connected');
+
+		const calls = hub.request.mock.calls as [string, unknown][];
+		const subscribeCalls = calls.filter(([method]) => method === 'liveQuery.subscribe');
+		const queryNames = subscribeCalls.map(
+			([, params]) => (params as { queryName: string }).queryName
+		);
+
+		expect(queryNames).toContain('tasks.byRoom');
+		expect(queryNames).toContain('goals.byRoom');
+		expect(queryNames).toContain('skills.byRoom');
+	});
+});

--- a/packages/web/src/lib/__tests__/room-store-per-query-subscriptions.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-per-query-subscriptions.test.ts
@@ -730,19 +730,6 @@ describe('RoomStore — per-query subscribeRoomGoals error paths', () => {
 	it('resets goalStore.loading when liveQuery.subscribe RPC fails', async () => {
 		await roomStore.select(ROOM_ID);
 
-		// Hub connects fine, but the subscribe RPC rejects
-		hub.request.mockImplementation((method: string) => {
-			if (method === 'liveQuery.subscribe' && method === 'liveQuery.subscribe') {
-				// Reject the first liveQuery.subscribe (goals)
-				if (!hub.request.mock.calls.some(([m]) => m === 'liveQuery.subscribe')) {
-					return Promise.reject(new Error('subscribe failed'));
-				}
-			}
-			if (method === 'room.get') return Promise.resolve({ room: { id: ROOM_ID }, sessions: [] });
-			if (method === 'room.runtime.state') return Promise.reject(new Error('no runtime'));
-			return Promise.resolve({ ok: true });
-		});
-		// Simpler: reject ALL liveQuery.subscribe calls
 		hub.request.mockImplementation((method: string) => {
 			if (method === 'liveQuery.subscribe') return Promise.reject(new Error('subscribe failed'));
 			if (method === 'room.get') return Promise.resolve({ room: { id: ROOM_ID }, sessions: [] });

--- a/packages/web/src/lib/__tests__/room-store-tasks-live-query.test.ts
+++ b/packages/web/src/lib/__tests__/room-store-tasks-live-query.test.ts
@@ -361,11 +361,11 @@ describe('RoomStore — subscribeRoom error path', () => {
 	it('clears liveQueryActive on getHub() rejection so re-subscribe is possible', async () => {
 		await roomStore.select(ROOM_ID);
 
-		// Make getHub reject for the next call (which will be subscribeRoom)
+		// Make getHub reject for the next call (which will be subscribeRoomTasks)
 		vi.mocked(connectionManager.getHub).mockRejectedValueOnce(new Error('connection failed'));
 
-		// First subscribeRoom — hub rejects, should clean up liveQueryActive
-		await roomStore.subscribeRoom(ROOM_ID);
+		// First subscribeRoomTasks — hub rejects, should clean up liveQueryActive
+		await roomStore.subscribeRoomTasks(ROOM_ID);
 
 		// No snapshot/delta handlers should have been registered (hub was unavailable)
 		expect(hub._handlers.get('liveQuery.snapshot') ?? []).toHaveLength(0);
@@ -373,8 +373,8 @@ describe('RoomStore — subscribeRoom error path', () => {
 		// Restore hub for the second call
 		vi.mocked(connectionManager.getHub).mockResolvedValue(hub as never);
 
-		// Second subscribeRoom should succeed (liveQueryActive was cleared by error path)
-		await roomStore.subscribeRoom(ROOM_ID);
+		// Second subscribeRoomTasks should succeed (liveQueryActive was cleared by error path)
+		await roomStore.subscribeRoomTasks(ROOM_ID);
 
 		// Handlers should now be registered
 		expect((hub._handlers.get('liveQuery.snapshot') ?? []).length).toBeGreaterThan(0);

--- a/packages/web/src/lib/connection-manager.ts
+++ b/packages/web/src/lib/connection-manager.ts
@@ -598,13 +598,12 @@ export class ConnectionManager {
 	 * Use this when user clicks "Reconnect" button or to recover from permanent failure
 	 */
 	async reconnect(): Promise<void> {
-		// Reset transport state to allow fresh connection
 		if (this.transport) {
-			this.transport.resetReconnectState();
 			// Use forceReconnect even when the transport is closed (ws=null).
 			// This preserves the existing MessageHub and its onConnection handlers
 			// (e.g. LiveQuery re-subscriptions). The old path created a brand new
 			// hub, discarding all registered handlers and breaking reconnect logic.
+			// Note: forceReconnect() calls resetReconnectState() internally.
 			this.transport.forceReconnect();
 			return;
 		}

--- a/packages/web/src/lib/connection-manager.ts
+++ b/packages/web/src/lib/connection-manager.ts
@@ -601,14 +601,15 @@ export class ConnectionManager {
 		// Reset transport state to allow fresh connection
 		if (this.transport) {
 			this.transport.resetReconnectState();
-			// Close existing connection if any
-			if (this.transport.isReady()) {
-				this.transport.forceReconnect();
-				return; // forceReconnect will handle the reconnection
-			}
+			// Use forceReconnect even when the transport is closed (ws=null).
+			// This preserves the existing MessageHub and its onConnection handlers
+			// (e.g. LiveQuery re-subscriptions). The old path created a brand new
+			// hub, discarding all registered handlers and breaking reconnect logic.
+			this.transport.forceReconnect();
+			return;
 		}
 
-		// Clear existing state for fresh connection
+		// No transport yet — create from scratch
 		this.messageHub = null;
 		this.connectionPromise = null;
 

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -258,10 +258,10 @@ class RoomStore {
 	/** Subscription cleanup functions */
 	private cleanupFunctions: Array<() => void> = [];
 
-	/** Per-room LiveQuery cleanup functions — owned by subscribeRoom/unsubscribeRoom */
+	/** Per-query LiveQuery cleanup functions — keyed by queryKey (e.g., 'tasks-roomId') */
 	private liveQueryCleanups = new Map<string, Array<() => void>>();
 
-	/** Set of room IDs that currently have an active LiveQuery subscription intent */
+	/** Set of per-query keys that currently have an active LiveQuery subscription intent */
 	private liveQueryActive = new Set<string>();
 
 	/**
@@ -344,157 +344,90 @@ class RoomStore {
 	// LiveQuery Subscription Lifecycle (managed by useRoomLiveQuery hook)
 	// ========================================
 
+	// ========================================
+	// Per-Query Subscription Helpers
+	// ========================================
+
 	/**
-	 * Subscribe this room's tasks and goals via LiveQuery.
-	 *
-	 * Called by the `useRoomLiveQuery` hook on mount / room change.
-	 * Registers snapshot/delta handlers then sends liveQuery.subscribe for
-	 * both tasks.byRoom and goals.byRoom named queries.
-	 *
-	 * Guards against races: if `unsubscribeRoom(roomId)` is called before
-	 * the async hub is available, the subscription is aborted cleanly.
+	 * Build a per-query key used for liveQueryActive and liveQueryCleanups.
+	 * @example queryKey('tasks', 'room-123') → 'tasks-room-123'
 	 */
-	async subscribeRoom(roomId: string): Promise<void> {
-		// Guard: prevent double-subscription for the same roomId
-		if (this.liveQueryActive.has(roomId)) return;
-		this.liveQueryActive.add(roomId);
+	private static queryKey(queryType: string, roomId: string): string {
+		return `${queryType}-${roomId}`;
+	}
+
+	/**
+	 * Build a subscriptionId for a LiveQuery.
+	 * @example subId('tasks', 'room-123') → 'tasks-byRoom-room-123'
+	 */
+	private static subId(queryType: string, roomId: string): string {
+		return `${queryType}-byRoom-${roomId}`;
+	}
+
+	/**
+	 * Core subscribe logic shared by all per-query methods.
+	 *
+	 * @param queryType - 'tasks', 'goals', or 'skills'
+	 * @param roomId - The room to subscribe to
+	 * @param queryName - The named query (e.g., 'tasks.byRoom')
+	 * @param onSubscribe - Called after hub is obtained, before subscribe request.
+	 *                       Used to set loading state (e.g., goalStore.loading).
+	 * @param setupHandlers - Registers snapshot/delta event handlers on the hub.
+	 *                         Must return an array of cleanup functions.
+	 */
+	private async subscribeQuery(
+		queryType: string,
+		roomId: string,
+		queryName: string,
+		onSubscribe: () => void,
+		setupHandlers: (
+			hub: Awaited<ReturnType<typeof connectionManager.getHub>>,
+			subId: string
+		) => Array<() => void>
+	): Promise<void> {
+		const key = RoomStore.queryKey(queryType, roomId);
+		const subscriptionId = RoomStore.subId(queryType, roomId);
+
+		// Guard: prevent double-subscription
+		if (this.liveQueryActive.has(key)) return;
+		this.liveQueryActive.add(key);
 
 		try {
 			const hub = await connectionManager.getHub();
 
-			// Guard: unsubscribeRoom was called before hub became available
-			if (!this.liveQueryActive.has(roomId)) return;
+			// Guard: unsubscribe was called before hub became available
+			if (!this.liveQueryActive.has(key)) return;
 
 			const cleanups: Array<() => void> = [];
-			this.liveQueryCleanups.set(roomId, cleanups);
+			this.liveQueryCleanups.set(key, cleanups);
 
-			// Subscription IDs
-			const tasksSubId = `tasks-byRoom-${roomId}`;
-			const goalsSubId = `goals-byRoom-${roomId}`;
-			const skillsSubId = `skills-byRoom-${roomId}`;
+			// Stale-event guard
+			this.activeSubscriptionIds.add(subscriptionId);
+			cleanups.push(() => this.activeSubscriptionIds.delete(subscriptionId));
 
-			// --- Register ALL snapshot/delta handlers FIRST (synchronous) ---
-			// Handlers must be registered before subscribe calls so we never miss
-			// the initial snapshot that the server pushes synchronously before replying.
+			// Register handlers
+			const handlerCleanups = setupHandlers(hub, subscriptionId);
+			cleanups.push(...handlerCleanups);
 
-			// Stale-event guards: mark subscriptionIds as active before registering
-			// handlers. unsubscribeRoom clears them immediately so any event queued
-			// in the JS event loop after the room switch is discarded.
-			this.activeSubscriptionIds.add(tasksSubId);
-			this.activeSubscriptionIds.add(goalsSubId);
-			this.activeSubscriptionIds.add(skillsSubId);
-			cleanups.push(() => this.activeSubscriptionIds.delete(tasksSubId));
-			cleanups.push(() => this.activeSubscriptionIds.delete(goalsSubId));
-			cleanups.push(() => this.activeSubscriptionIds.delete(skillsSubId));
+			// Set loading state before subscribe
+			onSubscribe();
 
-			// Tasks handlers
-			const unsubTaskSnapshot = hub.onEvent<LiveQuerySnapshotEvent>(
-				'liveQuery.snapshot',
-				(event) => {
-					if (event.subscriptionId !== tasksSubId) return;
-					if (!this.activeSubscriptionIds.has(tasksSubId)) return; // stale-event guard
-					this.taskStore.applySnapshot(event.rows as NeoTask[]);
-				}
-			);
-			cleanups.push(unsubTaskSnapshot);
-
-			const unsubTaskDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
-				if (event.subscriptionId !== tasksSubId) return;
-				if (!this.activeSubscriptionIds.has(tasksSubId)) return; // stale-event guard
-				// Show toast when a known task transitions into review/rate-limited/usage-limited status.
-				// Must read prevTask from the store BEFORE applyDelta overwrites it.
-				// Skip when prevTask is absent to avoid spurious toasts during hydration.
-				if (event.updated?.length) {
-					for (const updatedTask of event.updated as NeoTask[]) {
-						const prevTask = this.taskStore.getById(updatedTask.id);
-						if (prevTask) {
-							if (updatedTask.status === 'review' && prevTask.status !== 'review') {
-								toast.info(`Task ready for review: ${updatedTask.title}`);
-							} else if (
-								(updatedTask.status === 'rate_limited' || updatedTask.status === 'usage_limited') &&
-								prevTask.status !== updatedTask.status
-							) {
-								const limitType = updatedTask.status === 'rate_limited' ? 'rate' : 'usage';
-								toast.warning(`Task paused (${limitType} limit): ${updatedTask.title}`);
-							}
-						}
-					}
-				}
-				this.taskStore.applyDelta(
-					event as { added?: NeoTask[]; removed?: NeoTask[]; updated?: NeoTask[] }
-				);
-			});
-			cleanups.push(unsubTaskDelta);
-
-			// Goals handlers
-			const unsubGoalSnapshot = hub.onEvent<LiveQuerySnapshotEvent>(
-				'liveQuery.snapshot',
-				(event) => {
-					if (event.subscriptionId !== goalsSubId) return;
-					if (!this.activeSubscriptionIds.has(goalsSubId)) return; // stale-event guard
-					this.goalStore.applySnapshot(event.rows as RoomGoal[]);
-				}
-			);
-			cleanups.push(unsubGoalSnapshot);
-
-			const unsubGoalDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
-				if (event.subscriptionId !== goalsSubId) return;
-				if (!this.activeSubscriptionIds.has(goalsSubId)) return; // stale-event guard
-				this.goalStore.applyDelta(
-					event as { added?: RoomGoal[]; removed?: RoomGoal[]; updated?: RoomGoal[] }
-				);
-			});
-			cleanups.push(unsubGoalDelta);
-
-			// Skills handlers
-			const unsubSkillSnapshot = hub.onEvent<LiveQuerySnapshotEvent>(
-				'liveQuery.snapshot',
-				(event) => {
-					if (event.subscriptionId !== skillsSubId) return;
-					if (!this.activeSubscriptionIds.has(skillsSubId)) return; // stale-event guard
-					this.skillStore.applySnapshot(event.rows as EffectiveRoomSkill[]);
-				}
-			);
-			cleanups.push(unsubSkillSnapshot);
-
-			const unsubSkillDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
-				if (event.subscriptionId !== skillsSubId) return;
-				if (!this.activeSubscriptionIds.has(skillsSubId)) return; // stale-event guard
-				this.skillStore.applyDelta(
-					event as {
-						added?: EffectiveRoomSkill[];
-						removed?: EffectiveRoomSkill[];
-						updated?: EffectiveRoomSkill[];
-					}
-				);
-			});
-			cleanups.push(unsubSkillDelta);
-
-			// --- Fire ALL subscribe calls in parallel ---
-			// Use Promise.allSettled so a single failure doesn't leak the other two.
-			// Mark goals loading before subscribing; the snapshot handler clears it.
-			this.goalStore.loading.value = true;
-
-			const subResults = await Promise.allSettled([
-				hub.request('liveQuery.subscribe', {
-					queryName: 'tasks.byRoom',
+			// Fire subscribe request
+			try {
+				await hub.request('liveQuery.subscribe', {
+					queryName,
 					params: [roomId],
-					subscriptionId: tasksSubId,
-				}),
-				hub.request('liveQuery.subscribe', {
-					queryName: 'goals.byRoom',
-					params: [roomId],
-					subscriptionId: goalsSubId,
-				}),
-				hub.request('liveQuery.subscribe', {
-					queryName: 'skills.byRoom',
-					params: [roomId],
-					subscriptionId: skillsSubId,
-				}),
-			]);
-
-			// Guard: abort if unsubscribed while awaiting the subscribe requests
-			if (!this.liveQueryActive.has(roomId)) {
+					subscriptionId,
+				});
+			} catch (subErr) {
+				logger.warn(`${queryName} LiveQuery subscribe failed:`, subErr);
+				// Fire-and-forget unsubscribe in case the server partially registered
+				const h = connectionManager.getHubIfConnected();
+				if (h) {
+					h.request('liveQuery.unsubscribe', { subscriptionId }).catch(() => {});
+				}
+				// Clean up on failure
+				this.liveQueryActive.delete(key);
 				for (const fn of cleanups) {
 					try {
 						fn();
@@ -502,78 +435,49 @@ class RoomStore {
 						/* ignore */
 					}
 				}
-				this.liveQueryCleanups.delete(roomId);
-				this.goalStore.loading.value = false;
+				this.liveQueryCleanups.delete(key);
 				return;
 			}
 
-			const subIds = [tasksSubId, goalsSubId, skillsSubId] as const;
-			const queryNames = ['tasks.byRoom', 'goals.byRoom', 'skills.byRoom'] as const;
-
-			for (let i = 0; i < subResults.length; i++) {
-				const result = subResults[i];
-				const subId = subIds[i];
-				const queryName = queryNames[i];
-
-				if (result.status === 'rejected') {
-					logger.warn(`${queryName} LiveQuery subscribe failed:`, result.reason);
-					// Fire-and-forget unsubscribe in case the server partially registered
-					const h = connectionManager.getHubIfConnected();
-					if (h) {
-						h.request('liveQuery.unsubscribe', { subscriptionId: subId }).catch(() => {});
+			// Guard: abort if unsubscribed while awaiting the subscribe request
+			if (!this.liveQueryActive.has(key)) {
+				for (const fn of cleanups) {
+					try {
+						fn();
+					} catch {
+						/* ignore */
 					}
-					continue;
 				}
-
-				// Successful subscription — add reconnect and cleanup handlers
-				const qn = queryName;
-				const sid = subId;
-
-				if (qn === 'goals.byRoom') {
-					const unsubReconnect = hub.onConnection((state) => {
-						if (state !== 'connected' || !this.liveQueryActive.has(roomId)) return;
-						this.goalStore.loading.value = true;
-						hub
-							.request('liveQuery.subscribe', {
-								queryName: qn,
-								params: [roomId],
-								subscriptionId: sid,
-							})
-							.catch((err) => {
-								logger.warn(`${qn} LiveQuery re-subscribe failed:`, err);
-								this.goalStore.loading.value = false;
-							});
-					});
-					cleanups.push(unsubReconnect);
-				} else {
-					const unsubReconnect = hub.onConnection((state) => {
-						if (state !== 'connected' || !this.liveQueryActive.has(roomId)) return;
-						hub
-							.request('liveQuery.subscribe', {
-								queryName: qn,
-								params: [roomId],
-								subscriptionId: sid,
-							})
-							.catch((err) => {
-								logger.warn(`${qn} LiveQuery re-subscribe failed:`, err);
-							});
-					});
-					cleanups.push(unsubReconnect);
-				}
-
-				cleanups.push(() => {
-					const h = connectionManager.getHubIfConnected();
-					if (h) {
-						h.request('liveQuery.unsubscribe', { subscriptionId: sid }).catch(() => {});
-					}
-				});
+				this.liveQueryCleanups.delete(key);
+				return;
 			}
+
+			// Successful subscription — add reconnect handler
+			const unsubReconnect = hub.onConnection((state) => {
+				if (state !== 'connected' || !this.liveQueryActive.has(key)) return;
+				onSubscribe();
+				hub
+					.request('liveQuery.subscribe', {
+						queryName,
+						params: [roomId],
+						subscriptionId,
+					})
+					.catch((err) => {
+						logger.warn(`${queryName} LiveQuery re-subscribe failed:`, err);
+					});
+			});
+			cleanups.push(unsubReconnect);
+
+			// Add cleanup for unsubscribe
+			cleanups.push(() => {
+				const h = connectionManager.getHubIfConnected();
+				if (h) {
+					h.request('liveQuery.unsubscribe', { subscriptionId }).catch(() => {});
+				}
+			});
 		} catch (err) {
-			this.liveQueryActive.delete(roomId);
-			// Run any cleanups that were registered before the error, so that
-			// event handlers registered up to the point of failure are removed
-			// and activeSubscriptionIds entries are cleared.
-			const failedCleanups = this.liveQueryCleanups.get(roomId);
+			this.liveQueryActive.delete(key);
+			const failedCleanups = this.liveQueryCleanups.get(key);
 			if (failedCleanups) {
 				for (const fn of failedCleanups) {
 					try {
@@ -583,11 +487,216 @@ class RoomStore {
 					}
 				}
 			}
-			this.liveQueryCleanups.delete(roomId);
-			// Reset goalsLoading in case the error occurred after it was set to true.
-			this.goalStore.loading.value = false;
-			logger.error('Failed to subscribe room LiveQuery:', err);
+			this.liveQueryCleanups.delete(key);
+			logger.error(`Failed to subscribe ${queryName} LiveQuery:`, err);
 		}
+	}
+
+	/**
+	 * Core unsubscribe logic shared by all per-query methods.
+	 */
+	private unsubscribeQuery(queryType: string, roomId: string): void {
+		const key = RoomStore.queryKey(queryType, roomId);
+		const subscriptionId = RoomStore.subId(queryType, roomId);
+
+		this.liveQueryActive.delete(key);
+		// Stale-event guard: clear immediately
+		this.activeSubscriptionIds.delete(subscriptionId);
+
+		const cleanups = this.liveQueryCleanups.get(key);
+		if (cleanups) {
+			for (const fn of cleanups) {
+				try {
+					fn();
+				} catch {
+					/* ignore */
+				}
+			}
+			this.liveQueryCleanups.delete(key);
+		}
+	}
+
+	// ========================================
+	// Per-Query Public Subscribe Methods
+	// ========================================
+
+	/**
+	 * Subscribe to tasks.byRoom LiveQuery only.
+	 *
+	 * Can be called independently of subscribeRoomGoals and subscribeRoomSkills.
+	 */
+	async subscribeRoomTasks(roomId: string): Promise<void> {
+		await this.subscribeQuery(
+			'tasks',
+			roomId,
+			'tasks.byRoom',
+			() => {}, // no loading state for tasks
+			(hub, tasksSubId) => {
+				const cleanups: Array<() => void> = [];
+
+				const unsubTaskSnapshot = hub.onEvent<LiveQuerySnapshotEvent>(
+					'liveQuery.snapshot',
+					(event) => {
+						if (event.subscriptionId !== tasksSubId) return;
+						if (!this.activeSubscriptionIds.has(tasksSubId)) return;
+						this.taskStore.applySnapshot(event.rows as NeoTask[]);
+					}
+				);
+				cleanups.push(unsubTaskSnapshot);
+
+				const unsubTaskDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
+					if (event.subscriptionId !== tasksSubId) return;
+					if (!this.activeSubscriptionIds.has(tasksSubId)) return;
+					if (event.updated?.length) {
+						for (const updatedTask of event.updated as NeoTask[]) {
+							const prevTask = this.taskStore.getById(updatedTask.id);
+							if (prevTask) {
+								if (updatedTask.status === 'review' && prevTask.status !== 'review') {
+									toast.info(`Task ready for review: ${updatedTask.title}`);
+								} else if (
+									(updatedTask.status === 'rate_limited' ||
+										updatedTask.status === 'usage_limited') &&
+									prevTask.status !== updatedTask.status
+								) {
+									const limitType = updatedTask.status === 'rate_limited' ? 'rate' : 'usage';
+									toast.warning(`Task paused (${limitType} limit): ${updatedTask.title}`);
+								}
+							}
+						}
+					}
+					this.taskStore.applyDelta(
+						event as { added?: NeoTask[]; removed?: NeoTask[]; updated?: NeoTask[] }
+					);
+				});
+				cleanups.push(unsubTaskDelta);
+
+				return cleanups;
+			}
+		);
+	}
+
+	/**
+	 * Subscribe to goals.byRoom LiveQuery only.
+	 *
+	 * Can be called independently of subscribeRoomTasks and subscribeRoomSkills.
+	 * Sets goalStore.loading = true at start; snapshot/error clears it.
+	 */
+	async subscribeRoomGoals(roomId: string): Promise<void> {
+		await this.subscribeQuery(
+			'goals',
+			roomId,
+			'goals.byRoom',
+			() => {
+				this.goalStore.loading.value = true;
+			},
+			(hub, goalsSubId) => {
+				const cleanups: Array<() => void> = [];
+
+				const unsubGoalSnapshot = hub.onEvent<LiveQuerySnapshotEvent>(
+					'liveQuery.snapshot',
+					(event) => {
+						if (event.subscriptionId !== goalsSubId) return;
+						if (!this.activeSubscriptionIds.has(goalsSubId)) return;
+						this.goalStore.applySnapshot(event.rows as RoomGoal[]);
+					}
+				);
+				cleanups.push(unsubGoalSnapshot);
+
+				const unsubGoalDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
+					if (event.subscriptionId !== goalsSubId) return;
+					if (!this.activeSubscriptionIds.has(goalsSubId)) return;
+					this.goalStore.applyDelta(
+						event as { added?: RoomGoal[]; removed?: RoomGoal[]; updated?: RoomGoal[] }
+					);
+				});
+				cleanups.push(unsubGoalDelta);
+
+				return cleanups;
+			}
+		);
+	}
+
+	/**
+	 * Subscribe to skills.byRoom LiveQuery only.
+	 *
+	 * Can be called independently of subscribeRoomTasks and subscribeRoomGoals.
+	 */
+	async subscribeRoomSkills(roomId: string): Promise<void> {
+		await this.subscribeQuery(
+			'skills',
+			roomId,
+			'skills.byRoom',
+			() => {}, // no loading state for skills
+			(hub, skillsSubId) => {
+				const cleanups: Array<() => void> = [];
+
+				const unsubSkillSnapshot = hub.onEvent<LiveQuerySnapshotEvent>(
+					'liveQuery.snapshot',
+					(event) => {
+						if (event.subscriptionId !== skillsSubId) return;
+						if (!this.activeSubscriptionIds.has(skillsSubId)) return;
+						this.skillStore.applySnapshot(event.rows as EffectiveRoomSkill[]);
+					}
+				);
+				cleanups.push(unsubSkillSnapshot);
+
+				const unsubSkillDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
+					if (event.subscriptionId !== skillsSubId) return;
+					if (!this.activeSubscriptionIds.has(skillsSubId)) return;
+					this.skillStore.applyDelta(
+						event as {
+							added?: EffectiveRoomSkill[];
+							removed?: EffectiveRoomSkill[];
+							updated?: EffectiveRoomSkill[];
+						}
+					);
+				});
+				cleanups.push(unsubSkillDelta);
+
+				return cleanups;
+			}
+		);
+	}
+
+	// ========================================
+	// Per-Query Public Unsubscribe Methods
+	// ========================================
+
+	/** Unsubscribe from tasks.byRoom LiveQuery only. */
+	unsubscribeRoomTasks(roomId: string): void {
+		this.unsubscribeQuery('tasks', roomId);
+	}
+
+	/** Unsubscribe from goals.byRoom LiveQuery only. */
+	unsubscribeRoomGoals(roomId: string): void {
+		this.unsubscribeQuery('goals', roomId);
+		this.goalStore.loading.value = false;
+	}
+
+	/** Unsubscribe from skills.byRoom LiveQuery only. */
+	unsubscribeRoomSkills(roomId: string): void {
+		this.unsubscribeQuery('skills', roomId);
+	}
+
+	// ========================================
+	// Composite Subscribe/Unsubscribe (backward-compatible)
+	// ========================================
+
+	/**
+	 * Subscribe this room's tasks, goals, and skills via LiveQuery.
+	 *
+	 * Called by the `useRoomLiveQuery` hook on mount / room change.
+	 * Delegates to the per-query subscribe methods.
+	 *
+	 * Guards against races: if `unsubscribeRoom(roomId)` is called before
+	 * the async hub is available, the subscription is aborted cleanly.
+	 */
+	async subscribeRoom(roomId: string): Promise<void> {
+		await Promise.all([
+			this.subscribeRoomTasks(roomId),
+			this.subscribeRoomGoals(roomId),
+			this.subscribeRoomSkills(roomId),
+		]);
 	}
 
 	/**
@@ -597,23 +706,9 @@ class RoomStore {
 	 * Idempotent: safe to call even if subscribeRoom was never called.
 	 */
 	unsubscribeRoom(roomId: string): void {
-		this.liveQueryActive.delete(roomId);
-		// Stale-event guard: clear subscriptionIds immediately so any events already
-		// queued in the JS event loop are discarded before the handlers are removed.
-		this.activeSubscriptionIds.delete(`tasks-byRoom-${roomId}`);
-		this.activeSubscriptionIds.delete(`goals-byRoom-${roomId}`);
-		this.activeSubscriptionIds.delete(`skills-byRoom-${roomId}`);
-		const cleanups = this.liveQueryCleanups.get(roomId);
-		if (cleanups) {
-			for (const fn of cleanups) {
-				try {
-					fn();
-				} catch {
-					/* ignore */
-				}
-			}
-			this.liveQueryCleanups.delete(roomId);
-		}
+		this.unsubscribeRoomTasks(roomId);
+		this.unsubscribeRoomGoals(roomId);
+		this.unsubscribeRoomSkills(roomId);
 	}
 
 	// ========================================

--- a/packages/web/src/lib/room-store.ts
+++ b/packages/web/src/lib/room-store.ts
@@ -266,7 +266,7 @@ class RoomStore {
 
 	/**
 	 * Stale-event guard: set of currently active subscriptionIds.
-	 * Cleared immediately in unsubscribeRoom before handler teardown so that
+	 * Cleared immediately in unsubscribeQuery before handler teardown so that
 	 * any in-flight events (queued in the JS event loop between room switch and
 	 * handler removal) are discarded rather than applied to the wrong room's state.
 	 */
@@ -372,6 +372,8 @@ class RoomStore {
 	 * @param queryName - The named query (e.g., 'tasks.byRoom')
 	 * @param onSubscribe - Called after hub is obtained, before subscribe request.
 	 *                       Used to set loading state (e.g., goalStore.loading).
+	 * @param onError - Called when subscription fails or is race-cancelled.
+	 *                   Used to reset loading state (e.g., goalStore.loading).
 	 * @param setupHandlers - Registers snapshot/delta event handlers on the hub.
 	 *                         Must return an array of cleanup functions.
 	 */
@@ -380,6 +382,7 @@ class RoomStore {
 		roomId: string,
 		queryName: string,
 		onSubscribe: () => void,
+		onError: () => void,
 		setupHandlers: (
 			hub: Awaited<ReturnType<typeof connectionManager.getHub>>,
 			subId: string
@@ -428,6 +431,7 @@ class RoomStore {
 				}
 				// Clean up on failure
 				this.liveQueryActive.delete(key);
+				onError();
 				for (const fn of cleanups) {
 					try {
 						fn();
@@ -441,6 +445,7 @@ class RoomStore {
 
 			// Guard: abort if unsubscribed while awaiting the subscribe request
 			if (!this.liveQueryActive.has(key)) {
+				onError();
 				for (const fn of cleanups) {
 					try {
 						fn();
@@ -464,6 +469,7 @@ class RoomStore {
 					})
 					.catch((err) => {
 						logger.warn(`${queryName} LiveQuery re-subscribe failed:`, err);
+						onError();
 					});
 			});
 			cleanups.push(unsubReconnect);
@@ -477,6 +483,7 @@ class RoomStore {
 			});
 		} catch (err) {
 			this.liveQueryActive.delete(key);
+			onError();
 			const failedCleanups = this.liveQueryCleanups.get(key);
 			if (failedCleanups) {
 				for (const fn of failedCleanups) {
@@ -531,6 +538,7 @@ class RoomStore {
 			roomId,
 			'tasks.byRoom',
 			() => {}, // no loading state for tasks
+			() => {}, // no loading state to reset on error
 			(hub, tasksSubId) => {
 				const cleanups: Array<() => void> = [];
 
@@ -589,6 +597,9 @@ class RoomStore {
 			() => {
 				this.goalStore.loading.value = true;
 			},
+			() => {
+				this.goalStore.loading.value = false;
+			},
 			(hub, goalsSubId) => {
 				const cleanups: Array<() => void> = [];
 
@@ -627,6 +638,7 @@ class RoomStore {
 			roomId,
 			'skills.byRoom',
 			() => {}, // no loading state for skills
+			() => {}, // no loading state to reset on error
 			(hub, skillsSubId) => {
 				const cleanups: Array<() => void> = [];
 


### PR DESCRIPTION
Split the monolithic `subscribeRoom` method in `packages/web/src/lib/room-store.ts` into independent per-query subscription methods so goals and skills subscriptions can be managed separately from the always-on tasks subscription.

**New methods:**
- `subscribeRoomTasks(roomId)` / `unsubscribeRoomTasks(roomId)`
- `subscribeRoomGoals(roomId)` / `unsubscribeRoomGoals(roomId)`
- `subscribeRoomSkills(roomId)` / `unsubscribeRoomSkills(roomId)`

**Backward compatible:** `subscribeRoom` and `unsubscribeRoom` delegate to all three per-query methods.

**Key changes:**
- Per-query keys in `liveQueryActive`/`liveQueryCleanups` (e.g., `tasks-${roomId}`) instead of room-level keys
- Each query has independent double-subscription guard and stale-event guard
- Unsubscribing one query does not affect the others
- Shared `subscribeQuery`/`unsubscribeQuery` private helpers eliminate code duplication