### PR TITLE
chore: show failing file:line at end of make test-daemon output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,14 +80,7 @@ test: test-daemon test-web
 
 test-daemon:
 	@echo "Running daemon tests..."
-	@NODE_ENV=test bun test --jobs=1 --preload=./packages/daemon/tests/unit/setup.ts --dots packages/daemon/tests/unit packages/shared/tests --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage; \
-	EXIT=$$?; \
-	if [ $$EXIT -ne 0 ]; then \
-		echo ""; \
-		echo "===== FAILING TESTS ====="; \
-		NODE_ENV=test bun test --jobs=1 --preload=./packages/daemon/tests/unit/setup.ts --only-failures packages/daemon/tests/unit packages/shared/tests 2>&1; \
-	fi; \
-	exit $$EXIT
+	@NODE_ENV=test bun test --jobs=1 --preload=./packages/daemon/tests/unit/setup.ts --only-failures packages/daemon/tests/unit packages/shared/tests --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage
 
 test-web:
 	@echo "Running web tests..."

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,14 @@ test: test-daemon test-web
 
 test-daemon:
 	@echo "Running daemon tests..."
-	@NODE_ENV=test bun test --jobs=1 --preload=./packages/daemon/tests/unit/setup.ts --dots packages/daemon/tests/unit packages/shared/tests --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage
+	@NODE_ENV=test bun test --jobs=1 --preload=./packages/daemon/tests/unit/setup.ts --dots packages/daemon/tests/unit packages/shared/tests --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage; \
+	EXIT=$$?; \
+	if [ $$EXIT -ne 0 ]; then \
+		echo ""; \
+		echo "===== FAILING TESTS ====="; \
+		NODE_ENV=test bun test --jobs=1 --preload=./packages/daemon/tests/unit/setup.ts --only-failures packages/daemon/tests/unit packages/shared/tests 2>&1; \
+	fi; \
+	exit $$EXIT
 
 test-web:
 	@echo "Running web tests..."

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ test: test-daemon test-web
 
 test-daemon:
 	@echo "Running daemon tests..."
-	@NODE_ENV=test bun test --jobs=1 --preload=./packages/daemon/tests/unit/setup.ts --only-failures packages/daemon/tests/unit packages/shared/tests --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage
+	@NODE_ENV=test bun test --jobs=1 --preload=./packages/daemon/tests/unit/setup.ts --dots --only-failures packages/daemon/tests/unit packages/shared/tests --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage
 
 test-web:
 	@echo "Running web tests..."


### PR DESCRIPTION
Combine `--dots` and `--only-failures` flags in the `test-daemon` Makefile target.

- `--dots` provides progress output during the run (one dot per test file)
- `--only-failures` prints full failure details (file, line, error) for any failing tests
- Together they satisfy both goals in a single pass with no CI time penalty

Verified locally: `--only-failures` alone shows no progress output at all; the two flags must be combined.