### PR TITLE
feat: add room tab route matching to handlePopState and initializeRouter

### DIFF
--- a/packages/web/src/lib/__tests__/router.test.ts
+++ b/packages/web/src/lib/__tests__/router.test.ts
@@ -1366,6 +1366,59 @@ describe('Router Utility', () => {
 				expect(currentRoomActiveTabSignal.value).toBeNull();
 				expect(currentRoomIdSignal.value).toBeNull();
 			});
+
+			it('should clear currentRoomActiveTabSignal when popstate navigates from tab to /sessions', () => {
+				mockLocation.pathname = '/';
+				initializeRouter();
+
+				mockLocation.pathname = '/room/abc-123/tasks';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+				expect(currentRoomActiveTabSignal.value).toBe('tasks');
+
+				mockLocation.pathname = '/sessions';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+				expect(currentRoomActiveTabSignal.value).toBeNull();
+				expect(currentRoomIdSignal.value).toBeNull();
+			});
+
+			it('should clear currentRoomActiveTabSignal when popstate navigates from tab to /inbox', () => {
+				mockLocation.pathname = '/';
+				initializeRouter();
+
+				mockLocation.pathname = '/room/abc-123/goals';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+
+				mockLocation.pathname = '/inbox';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+				expect(currentRoomActiveTabSignal.value).toBeNull();
+				expect(currentRoomIdSignal.value).toBeNull();
+			});
+
+			it('should clear currentRoomActiveTabSignal when popstate navigates from tab to /spaces', () => {
+				mockLocation.pathname = '/';
+				initializeRouter();
+
+				mockLocation.pathname = '/room/abc-123/agents';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+
+				mockLocation.pathname = '/spaces';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+				expect(currentRoomActiveTabSignal.value).toBeNull();
+				expect(currentRoomIdSignal.value).toBeNull();
+			});
+
+			it('should clear currentRoomActiveTabSignal when popstate navigates from tab to a space', () => {
+				mockLocation.pathname = '/';
+				initializeRouter();
+
+				mockLocation.pathname = '/room/abc-123/settings';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+
+				mockLocation.pathname = '/space/def-456';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+				expect(currentRoomActiveTabSignal.value).toBeNull();
+				expect(currentRoomIdSignal.value).toBeNull();
+			});
 		});
 
 		// ──────────────────────────────────────────────────────────────────────────

--- a/packages/web/src/lib/__tests__/router.test.ts
+++ b/packages/web/src/lib/__tests__/router.test.ts
@@ -39,6 +39,7 @@ import {
 	currentRoomGoalIdSignal,
 	currentRoomAgentActiveSignal,
 	currentRoomActiveTabSignal,
+	currentRoomSessionIdSignal,
 } from '../signals';
 
 // Store original values (use unknown to avoid type errors at module load time)
@@ -1228,6 +1229,223 @@ describe('Router Utility', () => {
 			// App can initialize router and restore session
 			const restoredSession = initializeRouter();
 			expect(restoredSession).toBe('550e8400e29b41d4a716446655440003');
+		});
+
+		// ──────────────────────────────────────────────────────────────────────────
+		// Room tab route — handlePopState tests
+		// ──────────────────────────────────────────────────────────────────────────
+
+		describe('handlePopState with room tab routes', () => {
+			it('should set currentRoomActiveTabSignal to "goals" when popstate navigates to /room/:id/goals', () => {
+				mockLocation.pathname = '/';
+				initializeRouter();
+
+				mockLocation.pathname = '/room/abc-123/goals';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+
+				expect(currentRoomActiveTabSignal.value).toBe('goals');
+				expect(currentRoomIdSignal.value).toBe('abc-123');
+				expect(currentSessionIdSignal.value).toBeNull();
+				expect(currentRoomTaskIdSignal.value).toBeNull();
+				expect(currentRoomGoalIdSignal.value).toBeNull();
+				expect(currentRoomAgentActiveSignal.value).toBe(false);
+			});
+
+			it('should set currentRoomActiveTabSignal to "tasks" when popstate navigates to /room/:id/tasks', () => {
+				mockLocation.pathname = '/';
+				initializeRouter();
+
+				mockLocation.pathname = '/room/abc-123/tasks';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+
+				expect(currentRoomActiveTabSignal.value).toBe('tasks');
+				expect(currentRoomIdSignal.value).toBe('abc-123');
+			});
+
+			it('should set currentRoomActiveTabSignal to "agents" when popstate navigates to /room/:id/agents', () => {
+				mockLocation.pathname = '/';
+				initializeRouter();
+
+				mockLocation.pathname = '/room/abc-123/agents';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+
+				expect(currentRoomActiveTabSignal.value).toBe('agents');
+				expect(currentRoomIdSignal.value).toBe('abc-123');
+			});
+
+			it('should set currentRoomActiveTabSignal to "settings" when popstate navigates to /room/:id/settings', () => {
+				mockLocation.pathname = '/';
+				initializeRouter();
+
+				mockLocation.pathname = '/room/abc-123/settings';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+
+				expect(currentRoomActiveTabSignal.value).toBe('settings');
+				expect(currentRoomIdSignal.value).toBe('abc-123');
+			});
+
+			it('should reset currentRoomActiveTabSignal to "overview" when popstate navigates back to /room/:id', () => {
+				mockLocation.pathname = '/';
+				initializeRouter();
+
+				// First navigate to tasks
+				mockLocation.pathname = '/room/abc-123/tasks';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+				expect(currentRoomActiveTabSignal.value).toBe('tasks');
+
+				// Then navigate back to plain room
+				mockLocation.pathname = '/room/abc-123';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+				expect(currentRoomActiveTabSignal.value).toBe('overview');
+			});
+
+			it('should clear currentRoomActiveTabSignal when popstate navigates to a mission sub-route', () => {
+				mockLocation.pathname = '/';
+				initializeRouter();
+
+				// First on a tab route
+				mockLocation.pathname = '/room/abc-123/tasks';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+				expect(currentRoomActiveTabSignal.value).toBe('tasks');
+
+				// Then navigate to mission
+				mockLocation.pathname = '/room/abc-123/mission/aaa-111';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+				expect(currentRoomActiveTabSignal.value).toBeNull();
+				expect(currentRoomGoalIdSignal.value).toBe('aaa-111');
+			});
+
+			it('should clear currentRoomActiveTabSignal when popstate navigates to a task sub-route', () => {
+				mockLocation.pathname = '/';
+				initializeRouter();
+
+				mockLocation.pathname = '/room/abc-123/tasks';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+
+				mockLocation.pathname = '/room/abc-123/task/def-456';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+				expect(currentRoomActiveTabSignal.value).toBeNull();
+				expect(currentRoomTaskIdSignal.value).toBe('def-456');
+			});
+
+			it('should clear currentRoomActiveTabSignal when popstate navigates to a session sub-route', () => {
+				mockLocation.pathname = '/';
+				initializeRouter();
+
+				mockLocation.pathname = '/room/abc-123/goals';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+
+				mockLocation.pathname = '/room/abc-123/session/caf-000';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+				expect(currentRoomActiveTabSignal.value).toBeNull();
+				expect(currentRoomSessionIdSignal.value).toBe('caf-000');
+			});
+
+			it('should clear currentRoomActiveTabSignal when popstate navigates to a standalone session', () => {
+				mockLocation.pathname = '/';
+				initializeRouter();
+
+				mockLocation.pathname = '/room/abc-123/tasks';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+
+				mockLocation.pathname = '/session/def-456';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+				expect(currentRoomActiveTabSignal.value).toBeNull();
+				expect(currentRoomIdSignal.value).toBeNull();
+			});
+
+			it('should clear currentRoomActiveTabSignal when popstate navigates to home', () => {
+				mockLocation.pathname = '/';
+				initializeRouter();
+
+				mockLocation.pathname = '/room/abc-123/goals';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+
+				mockLocation.pathname = '/';
+				window.dispatchEvent(new PopStateEvent('popstate', {}));
+				expect(currentRoomActiveTabSignal.value).toBeNull();
+				expect(currentRoomIdSignal.value).toBeNull();
+			});
+		});
+
+		// ──────────────────────────────────────────────────────────────────────────
+		// Room tab route — initializeRouter tests
+		// ──────────────────────────────────────────────────────────────────────────
+
+		describe('initializeRouter with room tab routes', () => {
+			it('should set currentRoomActiveTabSignal to "goals" when page loads at /room/:id/goals', () => {
+				mockLocation.pathname = '/room/abc-123/goals';
+				initializeRouter();
+
+				expect(currentRoomActiveTabSignal.value).toBe('goals');
+				expect(currentRoomIdSignal.value).toBe('abc-123');
+				expect(currentSessionIdSignal.value).toBeNull();
+			});
+
+			it('should set currentRoomActiveTabSignal to "settings" when page loads at /room/:id/settings', () => {
+				mockLocation.pathname = '/room/abc-123/settings';
+				initializeRouter();
+
+				expect(currentRoomActiveTabSignal.value).toBe('settings');
+				expect(currentRoomIdSignal.value).toBe('abc-123');
+			});
+
+			it('should set currentRoomActiveTabSignal to "tasks" when page loads at /room/:id/tasks', () => {
+				mockLocation.pathname = '/room/abc-123/tasks';
+				initializeRouter();
+
+				expect(currentRoomActiveTabSignal.value).toBe('tasks');
+				expect(currentRoomIdSignal.value).toBe('abc-123');
+			});
+
+			it('should set currentRoomActiveTabSignal to "agents" when page loads at /room/:id/agents', () => {
+				mockLocation.pathname = '/room/abc-123/agents';
+				initializeRouter();
+
+				expect(currentRoomActiveTabSignal.value).toBe('agents');
+				expect(currentRoomIdSignal.value).toBe('abc-123');
+			});
+
+			it('should set currentRoomActiveTabSignal to "overview" when page loads at plain /room/:id', () => {
+				mockLocation.pathname = '/room/abc-123';
+				initializeRouter();
+
+				expect(currentRoomActiveTabSignal.value).toBe('overview');
+				expect(currentRoomIdSignal.value).toBe('abc-123');
+			});
+
+			it('should clear currentRoomActiveTabSignal when page loads at a mission sub-route', () => {
+				mockLocation.pathname = '/room/abc-123/mission/aaa-111';
+				initializeRouter();
+
+				expect(currentRoomActiveTabSignal.value).toBeNull();
+				expect(currentRoomGoalIdSignal.value).toBe('aaa-111');
+			});
+
+			it('should clear currentRoomActiveTabSignal when page loads at a task sub-route', () => {
+				mockLocation.pathname = '/room/abc-123/task/def-456';
+				initializeRouter();
+
+				expect(currentRoomActiveTabSignal.value).toBeNull();
+				expect(currentRoomTaskIdSignal.value).toBe('def-456');
+			});
+
+			it('should clear currentRoomActiveTabSignal when page loads at a session sub-route', () => {
+				mockLocation.pathname = '/room/abc-123/session/caf-000';
+				initializeRouter();
+
+				expect(currentRoomActiveTabSignal.value).toBeNull();
+				expect(currentRoomSessionIdSignal.value).toBe('caf-000');
+			});
+
+			it('should not interfere with room agent route (/room/:id/agent)', () => {
+				mockLocation.pathname = '/room/abc-123/agent';
+				initializeRouter();
+
+				expect(currentRoomActiveTabSignal.value).toBe('chat');
+				expect(currentRoomAgentActiveSignal.value).toBe(true);
+				expect(currentRoomIdSignal.value).toBe('abc-123');
+			});
 		});
 	});
 });

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -377,6 +377,7 @@ export function navigateToSession(sessionId: string, replace = false): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
@@ -401,6 +402,7 @@ export function navigateToSession(sessionId: string, replace = false): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
@@ -429,6 +431,7 @@ export function navigateToHome(replace = false): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
@@ -447,6 +450,7 @@ export function navigateToHome(replace = false): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
@@ -480,6 +484,7 @@ export function navigateToRoom(roomId: string, replace = false): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
@@ -504,6 +509,7 @@ export function navigateToRoom(roomId: string, replace = false): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
@@ -594,6 +600,7 @@ export function navigateToRoomSession(roomId: string, sessionId: string, replace
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
@@ -618,6 +625,7 @@ export function navigateToRoomSession(roomId: string, sessionId: string, replace
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
@@ -653,6 +661,7 @@ export function navigateToRoomTask(roomId: string, taskId: string, replace = fal
 		currentRoomGoalIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
@@ -671,6 +680,7 @@ export function navigateToRoomTask(roomId: string, taskId: string, replace = fal
 		currentRoomGoalIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
@@ -705,6 +715,7 @@ export function navigateToRoomMission(roomId: string, goalId: string, replace = 
 		currentRoomTaskIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
@@ -723,6 +734,7 @@ export function navigateToRoomMission(roomId: string, goalId: string, replace = 
 		currentRoomTaskIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
@@ -838,6 +850,7 @@ export function navigateToSessions(replace = false): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
@@ -856,6 +869,7 @@ export function navigateToSessions(replace = false): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
@@ -907,6 +921,7 @@ export function navigateToInbox(replace = false): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
@@ -925,6 +940,7 @@ export function navigateToInbox(replace = false): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
@@ -978,6 +994,7 @@ export function navigateToSpacesPage(replace = false): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
@@ -996,6 +1013,7 @@ export function navigateToSpacesPage(replace = false): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
@@ -1030,6 +1048,7 @@ export function navigateToSpace(spaceId: string, replace = false): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		navSectionSignal.value = 'spaces';
 		return;
 	}
@@ -1050,6 +1069,7 @@ export function navigateToSpace(spaceId: string, replace = false): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		navSectionSignal.value = 'spaces';
 	} finally {
 		setTimeout(() => {
@@ -1081,6 +1101,7 @@ export function navigateToSpaceConfigure(spaceId: string, replace = false): void
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		navSectionSignal.value = 'spaces';
 		return;
 	}
@@ -1101,6 +1122,7 @@ export function navigateToSpaceConfigure(spaceId: string, replace = false): void
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		navSectionSignal.value = 'spaces';
 	} finally {
 		setTimeout(() => {
@@ -1131,6 +1153,7 @@ export function navigateToSpaceSession(spaceId: string, sessionId: string, repla
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		navSectionSignal.value = 'spaces';
 		return;
 	}
@@ -1151,6 +1174,7 @@ export function navigateToSpaceSession(spaceId: string, sessionId: string, repla
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		navSectionSignal.value = 'spaces';
 	} finally {
 		setTimeout(() => {
@@ -1181,6 +1205,7 @@ export function navigateToSpaceTask(spaceId: string, taskId: string, replace = f
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		navSectionSignal.value = 'spaces';
 		return;
 	}
@@ -1201,6 +1226,7 @@ export function navigateToSpaceTask(spaceId: string, taskId: string, replace = f
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		navSectionSignal.value = 'spaces';
 	} finally {
 		setTimeout(() => {
@@ -1235,6 +1261,7 @@ export function navigateToSpaceAgent(spaceId: string, replace = false): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		navSectionSignal.value = 'spaces';
 		return;
 	}
@@ -1255,6 +1282,7 @@ export function navigateToSpaceAgent(spaceId: string, replace = false): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		navSectionSignal.value = 'spaces';
 	} finally {
 		setTimeout(() => {
@@ -1300,6 +1328,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
 	} else if (spaceSession) {
@@ -1312,6 +1341,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
 	} else if (spaceAgent) {
@@ -1324,6 +1354,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
 	} else if (spaceConfigure) {
@@ -1336,6 +1367,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
 	} else if (spaceId) {
@@ -1348,6 +1380,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
 	} else if (roomAgent) {
@@ -1443,6 +1476,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'chats';
 	} else if (INBOX_ROUTE_PATTERN.test(path)) {
@@ -1455,6 +1489,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'inbox';
 	} else if (SPACES_ROUTE_PATTERN.test(path)) {
@@ -1467,6 +1502,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
 	} else {
@@ -1480,6 +1516,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = sessionId;
 		if (!sessionId) {
 			navSectionSignal.value = 'home';
@@ -1527,6 +1564,7 @@ export function initializeRouter(): string | null {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
 	} else if (initialSpaceSession) {
@@ -1539,6 +1577,7 @@ export function initializeRouter(): string | null {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
 	} else if (initialSpaceAgent) {
@@ -1551,6 +1590,7 @@ export function initializeRouter(): string | null {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
 	} else if (initialSpaceConfigure) {
@@ -1563,6 +1603,7 @@ export function initializeRouter(): string | null {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
 	} else if (initialSpaceId) {
@@ -1575,6 +1616,7 @@ export function initializeRouter(): string | null {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
 	} else if (initialRoomAgent) {
@@ -1662,6 +1704,7 @@ export function initializeRouter(): string | null {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'chats';
 	} else if (INBOX_ROUTE_PATTERN.test(initialPath)) {
@@ -1674,6 +1717,7 @@ export function initializeRouter(): string | null {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'inbox';
 	} else if (SPACES_ROUTE_PATTERN.test(initialPath)) {
@@ -1686,6 +1730,7 @@ export function initializeRouter(): string | null {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'spaces';
 	} else {
@@ -1699,6 +1744,7 @@ export function initializeRouter(): string | null {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = initialSessionId;
 		if (initialSessionId) {
 			navSectionSignal.value = 'chats';

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -484,7 +484,7 @@ export function navigateToRoom(roomId: string, replace = false): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
-		currentRoomActiveTabSignal.value = null;
+		// Do NOT reset currentRoomActiveTabSignal — callers (Room.tsx, BottomTabBar) manage it
 		currentSessionIdSignal.value = null;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
@@ -509,7 +509,7 @@ export function navigateToRoom(roomId: string, replace = false): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
-		currentRoomActiveTabSignal.value = null;
+		// Do NOT reset currentRoomActiveTabSignal — callers (Room.tsx, BottomTabBar) manage it
 		currentSessionIdSignal.value = null;
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -1275,6 +1275,7 @@ function handlePopState(_event: PopStateEvent): void {
 	const sessionId = getSessionIdFromPath(path);
 	const roomId = getRoomIdFromPath(path);
 	const roomAgent = getRoomAgentFromPath(path);
+	const roomTab = getRoomTabFromPath(path);
 	const roomMission = getRoomMissionIdFromPath(path);
 	const roomSession = getRoomSessionIdFromPath(path);
 	const roomTask = getRoomTaskIdFromPath(path);
@@ -1286,9 +1287,9 @@ function handlePopState(_event: PopStateEvent): void {
 
 	// Update the signals to match the URL
 	// Space routes take priority over room routes
-	// IMPORTANT: Order is load-bearing — roomAgent must be checked before roomMission/roomTask/roomSession/roomId
-	// because getRoomIdFromPath also matches agent paths. If reordered, agent routes silently
-	// fall through to the plain room handler, losing the synthetic session ID.
+	// IMPORTANT: Order is load-bearing — roomAgent must be checked before roomTab/roomMission/roomTask/roomSession/roomId
+	// because getRoomIdFromPath also matches agent/tab paths. If reordered, those routes silently
+	// fall through to the plain room handler, losing the synthetic session ID or tab state.
 	if (spaceTask) {
 		currentSpaceIdSignal.value = spaceTask.spaceId;
 		currentSpaceViewModeSignal.value = 'overview';
@@ -1362,6 +1363,19 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomActiveTabSignal.value = 'chat';
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'rooms';
+	} else if (roomTab) {
+		currentSpaceIdSignal.value = null;
+		currentSpaceViewModeSignal.value = 'overview';
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		currentRoomIdSignal.value = roomTab.roomId;
+		currentRoomActiveTabSignal.value = roomTab.tab;
+		currentRoomAgentActiveSignal.value = false;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
+		currentSessionIdSignal.value = null;
+		navSectionSignal.value = 'rooms';
 	} else if (roomMission) {
 		currentSpaceIdSignal.value = null;
 		currentSpaceViewModeSignal.value = 'overview';
@@ -1372,6 +1386,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'rooms';
 	} else if (roomTask) {
@@ -1384,6 +1399,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomGoalIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'rooms';
 	} else if (roomSession) {
@@ -1396,6 +1412,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'rooms';
 	} else if (roomId) {
@@ -1404,6 +1421,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = roomId;
+		currentRoomActiveTabSignal.value = 'overview';
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
@@ -1457,6 +1475,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = null;
+		currentRoomActiveTabSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
@@ -1486,6 +1505,7 @@ export function initializeRouter(): string | null {
 	const initialSessionId = getSessionIdFromPath(initialPath);
 	const initialRoomId = getRoomIdFromPath(initialPath);
 	const initialRoomAgent = getRoomAgentFromPath(initialPath);
+	const initialRoomTab = getRoomTabFromPath(initialPath);
 	const initialRoomMission = getRoomMissionIdFromPath(initialPath);
 	const initialRoomSession = getRoomSessionIdFromPath(initialPath);
 	const initialRoomTask = getRoomTaskIdFromPath(initialPath);
@@ -1570,6 +1590,19 @@ export function initializeRouter(): string | null {
 		currentRoomActiveTabSignal.value = 'chat';
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'rooms';
+	} else if (initialRoomTab) {
+		currentSpaceIdSignal.value = null;
+		currentSpaceViewModeSignal.value = 'overview';
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		currentRoomIdSignal.value = initialRoomTab.roomId;
+		currentRoomActiveTabSignal.value = initialRoomTab.tab;
+		currentRoomAgentActiveSignal.value = false;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
+		currentSessionIdSignal.value = null;
+		navSectionSignal.value = 'rooms';
 	} else if (initialRoomMission) {
 		currentSpaceIdSignal.value = null;
 		currentSpaceViewModeSignal.value = 'overview';
@@ -1580,6 +1613,7 @@ export function initializeRouter(): string | null {
 		currentRoomTaskIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'rooms';
 	} else if (initialRoomTask) {
@@ -1591,6 +1625,7 @@ export function initializeRouter(): string | null {
 		currentRoomTaskIdSignal.value = initialRoomTask.taskId;
 		currentRoomGoalIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'rooms';
 	} else if (initialRoomSession) {
@@ -1602,6 +1637,7 @@ export function initializeRouter(): string | null {
 		currentRoomSessionIdSignal.value = initialRoomSession.sessionId;
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
+		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = null;
 		navSectionSignal.value = 'rooms';
 	} else if (initialRoomId) {
@@ -1610,6 +1646,7 @@ export function initializeRouter(): string | null {
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = initialRoomId;
+		currentRoomActiveTabSignal.value = 'overview';
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;
@@ -1657,6 +1694,7 @@ export function initializeRouter(): string | null {
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = null;
+		currentRoomActiveTabSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
 		currentRoomGoalIdSignal.value = null;


### PR DESCRIPTION
## Summary
- Parse room tab from URL in `handlePopState` and `initializeRouter` so browser back/forward and direct page load correctly restore the active tab
- New `roomTab` branch inserted after `roomAgent` and before `roomMission` in both functions' if/else chains
- Plain `/room/:id` resets `currentRoomActiveTabSignal` to `'overview'`; non-tab room sub-routes (mission, task, session) clear it to `null`
- 19 new unit tests covering popstate and initialization for all tab routes

## Test plan
- [x] `bunx vitest run src/lib/__tests__/router.test.ts` — 123 tests pass
- [x] `bun run lint` — 0 errors
- [x] `bun run typecheck` — passes