### PR TITLE
refactor: replace useState with signal-driven tab in Room.tsx

### DIFF
--- a/packages/web/src/components/room/MissionDetail.tsx
+++ b/packages/web/src/components/room/MissionDetail.tsx
@@ -14,8 +14,7 @@
 import { useState } from 'preact/hooks';
 import type { NeoTask, RoomGoal } from '@neokai/shared';
 import { cn } from '../../lib/utils';
-import { navigateToRoom, navigateToRoomTask } from '../../lib/router';
-import { currentRoomTabSignal } from '../../lib/signals';
+import { navigateToRoomTab, navigateToRoomTask } from '../../lib/router';
 import { useMissionDetailData } from '../../hooks/useMissionDetailData';
 import type { AvailableStatusAction } from '../../hooks/useMissionDetailData';
 import { Button } from '../ui/Button';
@@ -501,8 +500,7 @@ export function MissionDetail({ roomId, goalId }: MissionDetailProps) {
 	const [isDeleteOpen, setIsDeleteOpen] = useState(false);
 
 	function handleBack() {
-		navigateToRoom(roomId);
-		currentRoomTabSignal.value = 'goals';
+		navigateToRoomTab(roomId, 'goals');
 	}
 
 	const handleEditSubmit = async (data: CreateGoalFormData) => {

--- a/packages/web/src/components/room/RoomDashboard.test.tsx
+++ b/packages/web/src/components/room/RoomDashboard.test.tsx
@@ -45,10 +45,6 @@ vi.mock('../../lib/room-store.ts', () => ({
 	},
 }));
 
-vi.mock('../../lib/signals.ts', () => ({
-	currentRoomTabSignal: { value: null },
-}));
-
 const mockNavigateToRoomTask = vi.fn();
 
 vi.mock('../../lib/router.ts', () => ({

--- a/packages/web/src/components/room/RoomDashboard.test.tsx
+++ b/packages/web/src/components/room/RoomDashboard.test.tsx
@@ -12,6 +12,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/preact';
 import { signal } from '@preact/signals';
 import type { TaskSummary, RuntimeState } from '@neokai/shared';
+import { currentRoomIdSignal } from '../../lib/signals';
 
 // Define signals for store mock
 let mockTasks: ReturnType<typeof signal<TaskSummary[]>>;
@@ -46,10 +47,14 @@ vi.mock('../../lib/room-store.ts', () => ({
 }));
 
 const mockNavigateToRoomTask = vi.fn();
+const mockNavigateToRoomTab = vi.fn();
 
 vi.mock('../../lib/router.ts', () => ({
 	get navigateToRoomTask() {
 		return mockNavigateToRoomTask;
+	},
+	get navigateToRoomTab() {
+		return mockNavigateToRoomTab;
 	},
 }));
 
@@ -77,6 +82,7 @@ describe('RoomDashboard', () => {
 		mockGoalByTaskId.value = new Map();
 		mockSessions.value = [];
 		mockRoomId.value = 'room-1';
+		currentRoomIdSignal.value = 'room-1';
 		mockRuntimeState.value = null;
 		mockRuntimeModels.value = { leaderModel: null, workerModel: null };
 		mockPauseRuntime.mockClear();
@@ -84,6 +90,7 @@ describe('RoomDashboard', () => {
 		mockStopRuntime.mockClear();
 		mockStartRuntime.mockClear();
 		mockNavigateToRoomTask.mockClear();
+		mockNavigateToRoomTab.mockClear();
 	});
 
 	afterEach(() => {
@@ -105,14 +112,43 @@ describe('RoomDashboard', () => {
 		...overrides,
 	});
 
-	const selectReviewTab = async (container: Element) => {
-		const reviewTab = Array.from(container.querySelectorAll('button')).find((b) =>
-			b.textContent?.includes('Review')
-		);
-		if (reviewTab) {
-			await fireEvent.click(reviewTab);
-		}
-	};
+	describe('Stat Card Navigation', () => {
+		it('should call navigateToRoomTab with tasks when Active stat is clicked', async () => {
+			mockTasks.value = [createTask('t1', 'in_progress')];
+			const { container } = render(<RoomDashboard />);
+
+			const activeBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.includes('Active')
+			);
+			await fireEvent.click(activeBtn!);
+
+			expect(mockNavigateToRoomTab).toHaveBeenCalledWith('room-1', 'tasks');
+		});
+
+		it('should call navigateToRoomTab with tasks when Review stat is clicked', async () => {
+			mockTasks.value = [createTask('t1', 'in_review')];
+			const { container } = render(<RoomDashboard />);
+
+			const reviewBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.includes('Review')
+			);
+			await fireEvent.click(reviewBtn!);
+
+			expect(mockNavigateToRoomTab).toHaveBeenCalledWith('room-1', 'tasks');
+		});
+
+		it('should call navigateToRoomTab with tasks when Done stat is clicked', async () => {
+			mockTasks.value = [createTask('t1', 'completed')];
+			const { container } = render(<RoomDashboard />);
+
+			const doneBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.includes('Done')
+			);
+			await fireEvent.click(doneBtn!);
+
+			expect(mockNavigateToRoomTab).toHaveBeenCalledWith('room-1', 'tasks');
+		});
+	});
 
 	describe('Runtime State Indicator', () => {
 		it('should not show runtime controls when state is null', () => {

--- a/packages/web/src/components/room/RoomDashboard.tsx
+++ b/packages/web/src/components/room/RoomDashboard.tsx
@@ -12,8 +12,8 @@
 import { useState } from 'preact/hooks';
 import type { RuntimeState, TaskSummary } from '@neokai/shared';
 import { roomStore } from '../../lib/room-store';
-import { navigateToRoomTask } from '../../lib/router';
-import { currentRoomTabSignal } from '../../lib/signals';
+import { navigateToRoomTask, navigateToRoomTab } from '../../lib/router';
+import { currentRoomIdSignal } from '../../lib/signals';
 import { ConfirmModal } from '../ui/ConfirmModal';
 import { cn } from '../../lib/utils';
 
@@ -274,19 +274,28 @@ export function RoomDashboard() {
 					label="Active"
 					count={activeTasks.length}
 					color="border-blue-800/30 text-blue-400"
-					onClick={() => (currentRoomTabSignal.value = 'tasks')}
+					onClick={() => {
+						const rid = currentRoomIdSignal.value;
+						if (rid) navigateToRoomTab(rid, 'tasks');
+					}}
 				/>
 				<StatCard
 					label="Review"
 					count={reviewTasks.length}
 					color="border-purple-800/30 text-purple-400"
-					onClick={() => (currentRoomTabSignal.value = 'tasks')}
+					onClick={() => {
+						const rid = currentRoomIdSignal.value;
+						if (rid) navigateToRoomTab(rid, 'tasks');
+					}}
 				/>
 				<StatCard
 					label="Done"
 					count={doneTasks.length}
 					color="border-green-800/30 text-green-400"
-					onClick={() => (currentRoomTabSignal.value = 'tasks')}
+					onClick={() => {
+						const rid = currentRoomIdSignal.value;
+						if (rid) navigateToRoomTab(rid, 'tasks');
+					}}
 				/>
 			</div>
 

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -2662,8 +2662,6 @@ describe('TaskView — SetStatusModal', () => {
 	});
 });
 
-import { currentRoomTabSignal } from '../../lib/signals.ts';
-
 describe('TaskView — goal badge', () => {
 	beforeEach(() => {
 		mockRequest.mockReset();
@@ -2676,13 +2674,11 @@ describe('TaskView — goal badge', () => {
 		vi.mocked(useAutoScroll).mockClear();
 		// Clear goals between tests
 		roomStore.goalStore.applySnapshot([]);
-		currentRoomTabSignal.value = null;
 	});
 
 	afterEach(() => {
 		cleanup();
 		roomStore.goalStore.applySnapshot([]);
-		currentRoomTabSignal.value = null;
 	});
 
 	it('shows goal badge when task is linked to a goal', async () => {

--- a/packages/web/src/components/room/TaskViewV2.test.tsx
+++ b/packages/web/src/components/room/TaskViewV2.test.tsx
@@ -109,7 +109,6 @@ vi.mock('../../lib/router.ts', () => ({
 }));
 
 vi.mock('../../lib/signals.ts', () => ({
-	currentRoomTabSignal: { value: 'chat' },
 	currentSessionIdSignal: { value: null },
 	slashCommandsSignal: { value: [] },
 }));

--- a/packages/web/src/components/room/__tests__/MissionDetail.test.tsx
+++ b/packages/web/src/components/room/__tests__/MissionDetail.test.tsx
@@ -4,7 +4,7 @@
  * Covers:
  * - Loading skeleton shown when goal is null
  * - Renders mission title and badges when goal is loaded
- * - Back button calls navigateToRoom AND sets currentRoomTabSignal to 'goals'
+ * - Back button calls navigateToRoomTab with 'goals'
  * - Edit button opens edit modal
  * - Delete button opens confirm modal
  * - Status sidebar shows priority, type, autonomy badges
@@ -22,19 +22,14 @@ import { MissionDetail } from '../MissionDetail';
 // ---------------------------------------------------------------------------
 
 // Use vi.hoisted so these values are available when vi.mock factories are hoisted
-const { mockNavigateToRoom, mockNavigateToRoomTask, mockCurrentRoomTabSignal } = vi.hoisted(() => ({
-	mockNavigateToRoom: vi.fn(),
+const { mockNavigateToRoomTask, mockNavigateToRoomTab } = vi.hoisted(() => ({
 	mockNavigateToRoomTask: vi.fn(),
-	mockCurrentRoomTabSignal: { value: null as string | null },
+	mockNavigateToRoomTab: vi.fn(),
 }));
 
 vi.mock('../../../lib/router', () => ({
-	navigateToRoom: (...args: unknown[]) => mockNavigateToRoom(...args),
+	navigateToRoomTab: (...args: unknown[]) => mockNavigateToRoomTab(...args),
 	navigateToRoomTask: (...args: unknown[]) => mockNavigateToRoomTask(...args),
-}));
-
-vi.mock('../../../lib/signals', () => ({
-	currentRoomTabSignal: mockCurrentRoomTabSignal,
 }));
 
 // Mock toast
@@ -238,7 +233,6 @@ function makeDefaultHookResult(
 describe('MissionDetail', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		mockCurrentRoomTabSignal.value = null;
 		mockUseMissionDetailData.mockReturnValue(makeDefaultHookResult());
 	});
 
@@ -276,14 +270,13 @@ describe('MissionDetail', () => {
 		expect(getByText('Mission not found')).toBeTruthy();
 	});
 
-	it('not-found back button calls navigateToRoom and sets tab signal', () => {
+	it('not-found back button calls navigateToRoomTab with goals tab', () => {
 		mockUseMissionDetailData.mockReturnValue(
 			makeDefaultHookResult({ goal: null, goalsLoading: false })
 		);
 		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="bad-id" />);
 		fireEvent.click(getByTestId('mission-not-found-back-button'));
-		expect(mockNavigateToRoom).toHaveBeenCalledWith('room-1');
-		expect(mockCurrentRoomTabSignal.value).toBe('goals');
+		expect(mockNavigateToRoomTab).toHaveBeenCalledWith('room-1', 'goals');
 	});
 
 	it('not-found state does not show the skeleton', () => {
@@ -320,21 +313,15 @@ describe('MissionDetail', () => {
 
 	// ── Back button ───────────────────────────────────────────────────────────
 
-	it('back button calls navigateToRoom with correct roomId', () => {
+	it('back button calls navigateToRoomTab with correct roomId and goals tab', () => {
 		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
 		fireEvent.click(getByTestId('mission-detail-back-button'));
-		expect(mockNavigateToRoom).toHaveBeenCalledWith('room-1');
+		expect(mockNavigateToRoomTab).toHaveBeenCalledWith('room-1', 'goals');
 	});
 
-	it('back button sets currentRoomTabSignal to "goals"', () => {
-		const { getByTestId } = render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
-		fireEvent.click(getByTestId('mission-detail-back-button'));
-		expect(mockCurrentRoomTabSignal.value).toBe('goals');
-	});
-
-	it('does not call navigateToRoom on initial render', () => {
+	it('does not call navigateToRoomTab on initial render', () => {
 		render(<MissionDetail roomId="room-1" goalId="goal-uuid-1" />);
-		expect(mockNavigateToRoom).not.toHaveBeenCalled();
+		expect(mockNavigateToRoomTab).not.toHaveBeenCalled();
 	});
 
 	// ── Edit action ───────────────────────────────────────────────────────────

--- a/packages/web/src/components/room/task-shared/__tests__/TaskHeader.test.tsx
+++ b/packages/web/src/components/room/task-shared/__tests__/TaskHeader.test.tsx
@@ -23,13 +23,10 @@ import type { NeoTask, RoomGoal } from '@neokai/shared';
 // Mocks
 // ---------------------------------------------------------------------------
 
-const { mockNavigateToRoom, mockNavigateToRoomMission, mockCurrentRoomTabSignal } = vi.hoisted(
-	() => ({
-		mockNavigateToRoom: vi.fn(),
-		mockNavigateToRoomMission: vi.fn(),
-		mockCurrentRoomTabSignal: { value: 'chat' },
-	})
-);
+const { mockNavigateToRoom, mockNavigateToRoomMission } = vi.hoisted(() => ({
+	mockNavigateToRoom: vi.fn(),
+	mockNavigateToRoomMission: vi.fn(),
+}));
 
 vi.mock('../../../../lib/router.ts', () => ({
 	get navigateToRoom() {
@@ -41,10 +38,6 @@ vi.mock('../../../../lib/router.ts', () => ({
 	get navigateToRoomMission() {
 		return mockNavigateToRoomMission;
 	},
-}));
-
-vi.mock('../../../../lib/signals.ts', () => ({
-	currentRoomTabSignal: mockCurrentRoomTabSignal,
 }));
 
 vi.mock('../../../ui/CircularProgressIndicator.tsx', () => ({

--- a/packages/web/src/islands/BottomTabBar.tsx
+++ b/packages/web/src/islands/BottomTabBar.tsx
@@ -5,7 +5,6 @@ import {
 	currentRoomIdSignal,
 	currentRoomSessionIdSignal,
 	currentRoomTaskIdSignal,
-	currentRoomTabSignal,
 	currentRoomActiveTabSignal,
 	currentRoomAgentActiveSignal,
 	type NavSection,
@@ -15,8 +14,7 @@ import {
 	navigateToSettings,
 	navigateToRooms,
 	navigateToInbox,
-	navigateToRoom,
-	navigateToRoomAgent,
+	navigateToRoomTab,
 } from '../lib/router.ts';
 import { inboxStore } from '../lib/inbox-store.ts';
 import { InboxBadge } from '../components/ui/InboxBadge.tsx';
@@ -214,31 +212,19 @@ export function BottomTabBar() {
 				navigateToSettings();
 				break;
 			case 'room-overview':
-				if (roomId) {
-					currentRoomTabSignal.value = 'overview';
-					navigateToRoom(roomId);
-				}
+				if (roomId) navigateToRoomTab(roomId, 'overview');
 				break;
 			case 'room-tasks':
-				if (roomId) {
-					currentRoomTabSignal.value = 'tasks';
-					navigateToRoom(roomId);
-				}
+				if (roomId) navigateToRoomTab(roomId, 'tasks');
 				break;
 			case 'room-agent':
-				if (roomId) navigateToRoomAgent(roomId);
+				if (roomId) navigateToRoomTab(roomId, 'chat');
 				break;
 			case 'room-agents':
-				if (roomId) {
-					currentRoomTabSignal.value = 'agents';
-					navigateToRoom(roomId);
-				}
+				if (roomId) navigateToRoomTab(roomId, 'agents');
 				break;
 			case 'room-missions':
-				if (roomId) {
-					currentRoomTabSignal.value = 'goals';
-					navigateToRoom(roomId);
-				}
+				if (roomId) navigateToRoomTab(roomId, 'goals');
 				break;
 		}
 	};

--- a/packages/web/src/islands/Room.tsx
+++ b/packages/web/src/islands/Room.tsx
@@ -59,8 +59,8 @@ export default function Room({ roomId, sessionViewId, taskViewId, missionViewId 
 		return () => {
 			roomStore.select(null);
 			// Clear active tab signal when leaving a room to prevent cross-room contamination.
-			// Note: do NOT clear currentRoomAgentActiveSignal here — navigation functions
-			// (navigateToRoom, navigateToRoomAgent) manage it explicitly. Clearing it during
+			// Note: do NOT clear currentRoomAgentActiveSignal here — router navigation
+			// functions manage it explicitly. Clearing it during
 			// room-to-room navigation would race with the incoming room's agent URL sync and
 			// cause the Coordinator view to be lost.
 			currentRoomActiveTabSignal.value = null;

--- a/packages/web/src/islands/Room.tsx
+++ b/packages/web/src/islands/Room.tsx
@@ -14,15 +14,10 @@ import { roomStore } from '../lib/room-store';
 import {
 	navigateToHome,
 	navigateToRoomTask,
-	navigateToRoom,
-	navigateToRoomAgent,
+	navigateToRoomTab,
 	navigateToRoomMission,
 } from '../lib/router';
-import {
-	currentRoomTabSignal,
-	currentRoomActiveTabSignal,
-	currentRoomAgentActiveSignal,
-} from '../lib/signals';
+import { currentRoomActiveTabSignal, currentRoomAgentActiveSignal } from '../lib/signals';
 import { useRoomLiveQuery } from '../hooks/useRoomLiveQuery';
 import { RoomDashboard } from '../components/room/RoomDashboard';
 import { RoomTasks } from '../components/room/RoomTasks';
@@ -49,9 +44,7 @@ interface RoomProps {
 
 export default function Room({ roomId, sessionViewId, taskViewId, missionViewId }: RoomProps) {
 	const [initialLoad, setInitialLoad] = useState(true);
-	const [activeTab, setActiveTab] = useState<RoomTab>(
-		currentRoomAgentActiveSignal.value ? 'chat' : 'overview'
-	);
+	const activeTab: RoomTab = (currentRoomActiveTabSignal.value as RoomTab) ?? 'overview';
 
 	// Manage LiveQuery subscriptions for tasks and goals.
 	// Intentionally declared before the select() effect so that LiveQuery
@@ -65,49 +58,17 @@ export default function Room({ roomId, sessionViewId, taskViewId, missionViewId 
 		});
 		return () => {
 			roomStore.select(null);
-			// Clear any pending tab signal when leaving a room to prevent cross-room contamination.
+			// Clear active tab signal when leaving a room to prevent cross-room contamination.
 			// Note: do NOT clear currentRoomAgentActiveSignal here — navigation functions
 			// (navigateToRoom, navigateToRoomAgent) manage it explicitly. Clearing it during
 			// room-to-room navigation would race with the incoming room's agent URL sync and
 			// cause the Coordinator view to be lost.
-			currentRoomTabSignal.value = null;
 			currentRoomActiveTabSignal.value = null;
 		};
 	}, [roomId]);
 
-	// Watch for pending tab navigation from goal badges in task list / task view
-	const pendingTab = currentRoomTabSignal.value;
-	useEffect(() => {
-		if (pendingTab && !taskViewId) {
-			const validTabs: RoomTab[] = ['chat', 'overview', 'tasks', 'agents', 'goals', 'settings'];
-			if (validTabs.includes(pendingTab as RoomTab)) {
-				setActiveTab(pendingTab as RoomTab);
-				currentRoomActiveTabSignal.value = pendingTab;
-			}
-			currentRoomTabSignal.value = null;
-		}
-	}, [pendingTab, taskViewId, roomId]);
-
-	// Watch for Room Agent activation (e.g., sidebar click, popstate)
-	const agentActive = currentRoomAgentActiveSignal.value;
-	useEffect(() => {
-		if (agentActive) {
-			setActiveTab('chat');
-		}
-	}, [agentActive]);
-
-	// Update URL when tab changes — uses the pending-tab mechanism
-	// (currentRoomTabSignal) so the Room effect and BottomTabBar stay in sync.
 	const handleTabChange = (tab: RoomTab) => {
-		setActiveTab(tab);
-		currentRoomActiveTabSignal.value = tab;
-		if (tab === 'chat') {
-			navigateToRoomAgent(roomId);
-		} else {
-			currentRoomAgentActiveSignal.value = false;
-			currentRoomTabSignal.value = tab;
-			navigateToRoom(roomId);
-		}
+		navigateToRoomTab(roomId, tab);
 	};
 
 	const loading = roomStore.loading.value;

--- a/packages/web/src/islands/RoomContextPanel.tsx
+++ b/packages/web/src/islands/RoomContextPanel.tsx
@@ -11,12 +11,16 @@
 import { useCallback } from 'preact/hooks';
 import { CollapsibleSection } from '../components/room/CollapsibleSection';
 import { roomStore } from '../lib/room-store';
-import { navigateToRoom, navigateToRoomAgent, navigateToRoomSession } from '../lib/router';
+import {
+	navigateToRoom,
+	navigateToRoomAgent,
+	navigateToRoomSession,
+	navigateToRoomTab,
+} from '../lib/router';
 import {
 	currentRoomSessionIdSignal,
 	currentRoomTaskIdSignal,
 	currentRoomAgentActiveSignal,
-	currentRoomTabSignal,
 } from '../lib/signals';
 import { toast } from '../lib/toast';
 import { cn } from '../lib/utils';
@@ -92,14 +96,12 @@ export function RoomContextPanel({ roomId, onNavigate }: RoomContextPanelProps) 
 	};
 
 	const handleMissionsClick = () => {
-		currentRoomTabSignal.value = 'goals';
-		navigateToRoom(roomId);
+		navigateToRoomTab(roomId, 'goals');
 		onNavigate?.();
 	};
 
 	const handleTasksClick = () => {
-		currentRoomTabSignal.value = 'tasks';
-		navigateToRoom(roomId);
+		navigateToRoomTab(roomId, 'tasks');
 		onNavigate?.();
 	};
 

--- a/packages/web/src/islands/__tests__/BottomTabBar.test.tsx
+++ b/packages/web/src/islands/__tests__/BottomTabBar.test.tsx
@@ -16,8 +16,7 @@ vi.mock('../../lib/router.ts', () => ({
 	navigateToRooms: vi.fn(),
 	navigateToInbox: vi.fn(),
 	navigateToSpaces: vi.fn(),
-	navigateToRoom: vi.fn(),
-	navigateToRoomAgent: vi.fn(),
+	navigateToRoomTab: vi.fn(),
 }));
 
 // Mock inboxStore
@@ -45,7 +44,6 @@ import {
 	currentRoomIdSignal,
 	currentRoomSessionIdSignal,
 	currentRoomTaskIdSignal,
-	currentRoomTabSignal,
 	currentRoomActiveTabSignal,
 	currentRoomAgentActiveSignal,
 } from '../../lib/signals.ts';
@@ -54,8 +52,7 @@ import {
 	navigateToRooms,
 	navigateToSessions,
 	navigateToSettings,
-	navigateToRoom,
-	navigateToRoomAgent,
+	navigateToRoomTab,
 } from '../../lib/router.ts';
 
 describe('BottomTabBar', () => {
@@ -64,7 +61,6 @@ describe('BottomTabBar', () => {
 		currentRoomIdSignal.value = null;
 		currentRoomSessionIdSignal.value = null;
 		currentRoomTaskIdSignal.value = null;
-		currentRoomTabSignal.value = null;
 		currentRoomActiveTabSignal.value = null;
 		currentRoomAgentActiveSignal.value = false;
 		mockItemsSignal.value = [];
@@ -378,52 +374,49 @@ describe('BottomTabBar', () => {
 			expect(agentsTab.getAttribute('aria-selected')).toBe('false');
 		});
 
-		it('should call navigateToRoom when Overview tab is clicked', () => {
+		it('should call navigateToRoomTab with overview when Overview tab is clicked', () => {
 			render(<BottomTabBar />);
 
 			const overviewTab = screen.getByRole('tab', { name: 'Overview' });
 			fireEvent.click(overviewTab);
 
-			expect(navigateToRoom).toHaveBeenCalledWith(ROOM_ID);
+			expect(navigateToRoomTab).toHaveBeenCalledWith(ROOM_ID, 'overview');
 		});
 
-		it('should call navigateToRoom and set currentRoomTabSignal to agents when Agents tab is clicked', () => {
+		it('should call navigateToRoomTab with agents when Agents tab is clicked', () => {
 			render(<BottomTabBar />);
 
 			const agentsTab = screen.getByRole('tab', { name: 'Agents' });
 			fireEvent.click(agentsTab);
 
-			expect(currentRoomTabSignal.value).toBe('agents');
-			expect(navigateToRoom).toHaveBeenCalledWith(ROOM_ID);
+			expect(navigateToRoomTab).toHaveBeenCalledWith(ROOM_ID, 'agents');
 		});
 
-		it('should call navigateToRoom and set currentRoomTabSignal to tasks when Tasks tab is clicked', () => {
+		it('should call navigateToRoomTab with tasks when Tasks tab is clicked', () => {
 			render(<BottomTabBar />);
 
 			const tasksTab = screen.getByRole('tab', { name: 'Tasks' });
 			fireEvent.click(tasksTab);
 
-			expect(currentRoomTabSignal.value).toBe('tasks');
-			expect(navigateToRoom).toHaveBeenCalledWith(ROOM_ID);
+			expect(navigateToRoomTab).toHaveBeenCalledWith(ROOM_ID, 'tasks');
 		});
 
-		it('should call navigateToRoom with roomId and set currentRoomTabSignal to goals when Missions tab is clicked', () => {
+		it('should call navigateToRoomTab with goals when Missions tab is clicked', () => {
 			render(<BottomTabBar />);
 
 			const missionsTab = screen.getByRole('tab', { name: 'Missions' });
 			fireEvent.click(missionsTab);
 
-			expect(currentRoomTabSignal.value).toBe('goals');
-			expect(navigateToRoom).toHaveBeenCalledWith(ROOM_ID);
+			expect(navigateToRoomTab).toHaveBeenCalledWith(ROOM_ID, 'goals');
 		});
 
-		it('should call navigateToRoomAgent when Chat tab is clicked', () => {
+		it('should call navigateToRoomTab with chat when Chat tab is clicked', () => {
 			render(<BottomTabBar />);
 
 			const chatTab = screen.getByRole('tab', { name: 'Coord.' });
 			fireEvent.click(chatTab);
 
-			expect(navigateToRoomAgent).toHaveBeenCalledWith(ROOM_ID);
+			expect(navigateToRoomTab).toHaveBeenCalledWith(ROOM_ID, 'chat');
 		});
 
 		it('should mark Missions tab as active when currentRoomActiveTabSignal is goals', () => {

--- a/packages/web/src/islands/__tests__/Room.test.tsx
+++ b/packages/web/src/islands/__tests__/Room.test.tsx
@@ -6,12 +6,15 @@
  * - taskViewId present → TaskViewToggle overlay (tabs still visible behind it)
  * - sessionViewId present (including synthetic room:chat:<roomId>) → ChatContainer
  * - neither → tabbed dashboard
+ *
+ * Tab state is driven by currentRoomActiveTabSignal (single source of truth).
+ * Tab clicks delegate to navigateToRoomTab which updates both the URL and the signal.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup, screen, fireEvent, act } from '@testing-library/preact';
 import { signal } from '@preact/signals';
-import { currentRoomAgentActiveSignal } from '../../lib/signals';
+import { currentRoomAgentActiveSignal, currentRoomActiveTabSignal } from '../../lib/signals';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
@@ -20,15 +23,15 @@ import { currentRoomAgentActiveSignal } from '../../lib/signals';
 const {
 	mockNavigateToHome,
 	mockNavigateToRoomTask,
-	mockNavigateToRoom,
-	mockNavigateToRoomAgent,
+	mockNavigateToRoomTab,
+	mockNavigateToRoomMission,
 	mockToastSuccess,
 	mockRoomStoreSelect,
 } = vi.hoisted(() => ({
 	mockNavigateToHome: vi.fn(),
 	mockNavigateToRoomTask: vi.fn(),
-	mockNavigateToRoom: vi.fn(),
-	mockNavigateToRoomAgent: vi.fn(),
+	mockNavigateToRoomTab: vi.fn(),
+	mockNavigateToRoomMission: vi.fn(),
 	mockToastSuccess: vi.fn(),
 	// Hoisted so it stays the same reference across all mock accesses
 	mockRoomStoreSelect: vi.fn().mockResolvedValue(undefined),
@@ -37,8 +40,8 @@ const {
 vi.mock('../../lib/router', () => ({
 	navigateToHome: mockNavigateToHome,
 	navigateToRoomTask: mockNavigateToRoomTask,
-	navigateToRoom: mockNavigateToRoom,
-	navigateToRoomAgent: mockNavigateToRoomAgent,
+	navigateToRoomTab: mockNavigateToRoomTab,
+	navigateToRoomMission: mockNavigateToRoomMission,
 }));
 
 vi.mock('../../lib/toast', () => ({
@@ -219,6 +222,7 @@ describe('Room', () => {
 		mockRoomStoreSelect.mockResolvedValue(undefined);
 		initRoomStoreSignals();
 		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
 	});
 
 	afterEach(() => {
@@ -237,8 +241,8 @@ describe('Room', () => {
 			expect(screen.queryByTestId('room-dashboard')).toBeNull();
 		});
 
-		it('renders Chat tab with ChatContainer when agent signal is active', () => {
-			currentRoomAgentActiveSignal.value = true;
+		it('renders Chat tab with ChatContainer when currentRoomActiveTabSignal is "chat"', () => {
+			currentRoomActiveTabSignal.value = 'chat';
 			render(<Room roomId={roomId} />);
 
 			// Chat tab is rendered (always mounted), and dashboard is not visible
@@ -310,29 +314,83 @@ describe('Room', () => {
 	});
 
 	describe('Tab navigation', () => {
-		it('renders Tasks tab content when Tasks tab is clicked', () => {
+		it('renders Tasks tab content when currentRoomActiveTabSignal is "tasks"', () => {
+			currentRoomActiveTabSignal.value = 'tasks';
 			render(<Room roomId={roomId} />);
 
-			// Default is overview (dashboard)
-			expect(screen.getByTestId('room-dashboard')).toBeTruthy();
-
-			fireEvent.click(screen.getByText('Tasks'));
 			expect(screen.getByTestId('room-tasks')).toBeTruthy();
 			expect(screen.queryByTestId('room-dashboard')).toBeNull();
 		});
 
-		it('renders Missions tab content when Missions tab is clicked', () => {
+		it('renders Missions tab content when currentRoomActiveTabSignal is "goals"', () => {
+			currentRoomActiveTabSignal.value = 'goals';
 			render(<Room roomId={roomId} />);
 
-			fireEvent.click(screen.getByText('Missions'));
 			expect(screen.getByTestId('goals-editor')).toBeTruthy();
 		});
 
-		it('renders Settings tab content when Settings tab is clicked', () => {
+		it('renders Settings tab content when currentRoomActiveTabSignal is "settings"', () => {
+			currentRoomActiveTabSignal.value = 'settings';
+			render(<Room roomId={roomId} />);
+
+			expect(screen.getByTestId('room-settings')).toBeTruthy();
+		});
+
+		it('renders Agents tab content when currentRoomActiveTabSignal is "agents"', () => {
+			currentRoomActiveTabSignal.value = 'agents';
+			render(<Room roomId={roomId} />);
+
+			expect(screen.getByTestId('room-agents')).toBeTruthy();
+		});
+
+		it('calls navigateToRoomTab when a tab is clicked', () => {
+			render(<Room roomId={roomId} />);
+
+			fireEvent.click(screen.getByText('Tasks'));
+
+			expect(mockNavigateToRoomTab).toHaveBeenCalledWith(roomId, 'tasks');
+		});
+
+		it('calls navigateToRoomTab with "chat" when Coordinator tab is clicked', () => {
+			render(<Room roomId={roomId} />);
+
+			fireEvent.click(screen.getByText('Coordinator'));
+
+			expect(mockNavigateToRoomTab).toHaveBeenCalledWith(roomId, 'chat');
+		});
+
+		it('calls navigateToRoomTab with "goals" when Missions tab is clicked', () => {
+			render(<Room roomId={roomId} />);
+
+			fireEvent.click(screen.getByText('Missions'));
+
+			expect(mockNavigateToRoomTab).toHaveBeenCalledWith(roomId, 'goals');
+		});
+
+		it('calls navigateToRoomTab with "settings" when Settings tab is clicked', () => {
 			render(<Room roomId={roomId} />);
 
 			fireEvent.click(screen.getByText('Settings'));
-			expect(screen.getByTestId('room-settings')).toBeTruthy();
+
+			expect(mockNavigateToRoomTab).toHaveBeenCalledWith(roomId, 'settings');
+		});
+
+		it('defaults to overview tab when currentRoomActiveTabSignal is null', () => {
+			currentRoomActiveTabSignal.value = null;
+			render(<Room roomId={roomId} />);
+
+			// Overview is the default tab
+			expect(screen.getByTestId('room-dashboard')).toBeTruthy();
+		});
+
+		it('clears currentRoomActiveTabSignal on unmount', async () => {
+			currentRoomActiveTabSignal.value = 'tasks';
+			const { unmount } = render(<Room roomId={roomId} />);
+			await act(async () => {
+				unmount();
+			});
+
+			expect(currentRoomActiveTabSignal.value).toBeNull();
 		});
 	});
 

--- a/packages/web/src/islands/__tests__/RoomContextPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/RoomContextPanel.test.tsx
@@ -19,12 +19,14 @@ const {
 	mockNavigateToRoomSession,
 	mockNavigateToRoom,
 	mockNavigateToRoomAgent,
+	mockNavigateToRoomTab,
 	mockToast,
 } = vi.hoisted(() => ({
 	mockCreateSession: vi.fn().mockResolvedValue('new-session-id'),
 	mockNavigateToRoomSession: vi.fn(),
 	mockNavigateToRoom: vi.fn(),
 	mockNavigateToRoomAgent: vi.fn(),
+	mockNavigateToRoomTab: vi.fn(),
 	mockToast: vi.fn(),
 }));
 
@@ -42,7 +44,6 @@ let mockGoalsSignal!: Signal<RoomGoal[]>;
 let mockCurrentRoomSessionIdSignal!: Signal<string | null>;
 let mockCurrentRoomTaskIdSignal!: Signal<string | null>;
 let mockCurrentRoomAgentActiveSignal!: Signal<boolean>;
-let mockCurrentRoomTabSignal!: Signal<string | null>;
 
 let mockActiveGoals!: ReadonlySignal<RoomGoal[]>;
 
@@ -53,7 +54,6 @@ function initSignals() {
 	mockCurrentRoomSessionIdSignal = signal(null);
 	mockCurrentRoomTaskIdSignal = signal(null);
 	mockCurrentRoomAgentActiveSignal = signal(false);
-	mockCurrentRoomTabSignal = signal(null);
 
 	mockActiveGoals = computed(() => mockGoalsSignal.value.filter((g) => g.status === 'active'));
 }
@@ -75,6 +75,7 @@ vi.mock('../../lib/router.ts', () => ({
 	navigateToRoom: mockNavigateToRoom,
 	navigateToRoomAgent: mockNavigateToRoomAgent,
 	navigateToRoomSession: mockNavigateToRoomSession,
+	navigateToRoomTab: (...args: unknown[]) => mockNavigateToRoomTab(...args),
 }));
 
 vi.mock('../../lib/signals.ts', async (importOriginal) => {
@@ -90,12 +91,10 @@ vi.mock('../../lib/signals.ts', async (importOriginal) => {
 		get currentRoomAgentActiveSignal() {
 			return mockCurrentRoomAgentActiveSignal;
 		},
-		get currentRoomTabSignal() {
-			return mockCurrentRoomTabSignal;
-		},
 	};
 });
 
+import { navigateToRoomTab } from '../../lib/router.ts';
 import { RoomContextPanel } from '../RoomContextPanel';
 
 // -------------------------------------------------------
@@ -171,8 +170,7 @@ describe('RoomContextPanel', () => {
 
 		const statsBtn = screen.getByText('1 active').closest('button');
 		fireEvent.click(statsBtn!);
-		expect(mockCurrentRoomTabSignal.value).toBe('tasks');
-		expect(mockNavigateToRoom).toHaveBeenCalledWith('room-1');
+		expect(mockNavigateToRoomTab).toHaveBeenCalledWith('room-1', 'tasks');
 	});
 
 	// -- Pinned items --
@@ -264,8 +262,7 @@ describe('RoomContextPanel', () => {
 		render(<RoomContextPanel roomId="room-1" onNavigate={onNavigate} />);
 
 		fireEvent.click(screen.getByText('My Mission'));
-		expect(mockCurrentRoomTabSignal.value).toBe('goals');
-		expect(mockNavigateToRoom).toHaveBeenCalledWith('room-1');
+		expect(mockNavigateToRoomTab).toHaveBeenCalledWith('room-1', 'goals');
 		expect(onNavigate).toHaveBeenCalledOnce();
 	});
 

--- a/packages/web/src/lib/__tests__/navigate-to-room-tab-reset.test.ts
+++ b/packages/web/src/lib/__tests__/navigate-to-room-tab-reset.test.ts
@@ -4,8 +4,7 @@
  * and that non-room navigation clears currentRoomAgentActiveSignal.
  *
  * The P0 fix ensures navigateToRoom leaves the tab signal untouched so
- * callers (Room.tsx handleTabChange, BottomTabBar) can set it independently
- * via the pending-tab mechanism (currentRoomTabSignal).
+ * callers (like navigateToRoomTab) can set it independently.
  *
  * The P1 fix ensures navigating away from rooms clears the agent-active
  * signal to prevent stale state from affecting future room visits.

--- a/packages/web/src/lib/signals.ts
+++ b/packages/web/src/lib/signals.ts
@@ -58,12 +58,7 @@ export const contextPanelOpenSignal = signal<boolean>(false);
 // Create Room modal open state - shared between ContextPanel and Lobby
 export const createRoomModalSignal = signal<boolean>(false);
 
-// Room tab navigation signal - set this to navigate to a specific room tab
-// Room.tsx watches this and switches activeTab accordingly, then clears it
-export const currentRoomTabSignal = signal<string | null>(null);
-
 // Persistent signal tracking the current room's active tab
-// This persists across renders unlike currentRoomTabSignal which is transient
 export const currentRoomActiveTabSignal = signal<string | null>(null);
 
 // Whether the room agent chat tab is active (driven by /room/:roomId/agent URL)


### PR DESCRIPTION
Replace local `useState<RoomTab>` in Room.tsx with `currentRoomActiveTabSignal` as the single source of truth for active tab state.

**Changes:**
- Remove `useState<RoomTab>` — read tab from `currentRoomActiveTabSignal.value ?? 'overview'`
- Remove `useEffect` watching `currentRoomTabSignal` (transient pending-tab indirection)
- Remove `useEffect` watching `currentRoomAgentActiveSignal` for tab switching
- Simplify `handleTabChange` to just call `navigateToRoomTab(roomId, tab)`
- Remove `currentRoomTabSignal` import from Room.tsx
- Update tests: tab clicks verify `navigateToRoomTab` calls, tab rendering driven by signal

**Part of:** URL-addressable room tabs (goal: make all room tabs navigable via URL)