### PR TITLE
fix: artifacts tab shows empty — use task worktree path for git diff

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -641,7 +641,9 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		gateDataRepo,
 		spaceRuntimeService,
 		spaceWorkflowRunTaskManagerFactory,
-		deps.daemonHub
+		deps.daemonHub,
+		spaceTaskRepo,
+		spaceWorktreeManager
 	);
 
 	// Node execution handlers

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
@@ -24,6 +24,8 @@ import type { SpaceWorkflowRunRepository } from '../../storage/repositories/spac
 import type { GateDataRepository } from '../../storage/repositories/gate-data-repository';
 import type { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
 import type { SpaceTaskManager } from '../space/managers/space-task-manager';
+import type { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
+import type { SpaceWorktreeManager } from '../space/managers/space-worktree-manager';
 import type { WorkflowRunFailureReason, WorkflowRunStatus } from '@neokai/shared';
 import { Logger } from '../logger';
 
@@ -82,6 +84,37 @@ function execGit(args: string[], cwd: string, timeout = 10000): Promise<string> 
 }
 
 /**
+ * Resolve the git worktree path for a workflow run.
+ *
+ * Prefers the task-specific worktree created by the agent (where commits are
+ * actually made) over the space's root `workspacePath`.  Falls back to the
+ * root workspace if no task worktree is found.
+ *
+ * @returns The resolved path, or null if no path can be determined.
+ */
+async function resolveWorktreePath(
+	runId: string,
+	spaceId: string,
+	spaceManager: SpaceManager,
+	spaceTaskRepo: SpaceTaskRepository,
+	spaceWorktreeManager: SpaceWorktreeManager
+): Promise<string | null> {
+	// First: look up the task associated with this run and get its worktree.
+	const tasks = spaceTaskRepo.listByWorkflowRun(runId);
+	if (tasks.length > 0) {
+		const taskId = tasks[0].id;
+		const taskWorktreePath = await spaceWorktreeManager.getTaskWorktreePath(spaceId, taskId);
+		if (taskWorktreePath) {
+			return taskWorktreePath;
+		}
+	}
+
+	// Fallback: use the root workspace path from the space.
+	const space = await spaceManager.getSpace(spaceId);
+	return space?.workspacePath ?? null;
+}
+
+/**
  * Get the diff base ref for a worktree.
  * Tries `origin/dev` merge-base first; falls back to empty string (uncommitted only).
  */
@@ -108,7 +141,9 @@ export function setupSpaceWorkflowRunHandlers(
 	gateDataRepo: GateDataRepository,
 	spaceRuntimeService: SpaceRuntimeService,
 	taskManagerFactory: SpaceWorkflowRunTaskManagerFactory,
-	daemonHub: DaemonHub
+	daemonHub: DaemonHub,
+	spaceTaskRepo: SpaceTaskRepository,
+	spaceWorktreeManager: SpaceWorktreeManager
 ): void {
 	/**
 	 * Helper: notify the channel router that gate data has changed.
@@ -567,8 +602,15 @@ export function setupSpaceWorkflowRunHandlers(
 		const run = workflowRunRepo.getRun(params.runId);
 		if (!run) throw new Error(`WorkflowRun not found: ${params.runId}`);
 
-		const space = await spaceManager.getSpace(run.spaceId);
-		const worktreePath = space?.workspacePath;
+		// Resolve the worktree path: prefer the task-specific git worktree (where
+		// the agent commits its work) over the root workspace path.
+		const worktreePath = await resolveWorktreePath(
+			run.id,
+			run.spaceId,
+			spaceManager,
+			spaceTaskRepo,
+			spaceWorktreeManager
+		);
 		if (!worktreePath) {
 			throw new Error(`No workspace path found for run: ${params.runId}`);
 		}
@@ -607,8 +649,15 @@ export function setupSpaceWorkflowRunHandlers(
 		const run = workflowRunRepo.getRun(params.runId);
 		if (!run) throw new Error(`WorkflowRun not found: ${params.runId}`);
 
-		const space = await spaceManager.getSpace(run.spaceId);
-		const worktreePath = space?.workspacePath;
+		// Resolve the worktree path: prefer the task-specific git worktree (where
+		// the agent commits its work) over the root workspace path.
+		const worktreePath = await resolveWorktreePath(
+			run.id,
+			run.spaceId,
+			spaceManager,
+			spaceTaskRepo,
+			spaceWorktreeManager
+		);
 		if (!worktreePath) {
 			throw new Error(`No workspace path found for run: ${params.runId}`);
 		}

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
@@ -86,9 +86,11 @@ function execGit(args: string[], cwd: string, timeout = 10000): Promise<string> 
 /**
  * Resolve the git worktree path for a workflow run.
  *
- * Prefers the task-specific worktree created by the agent (where commits are
- * actually made) over the space's root `workspacePath`.  Falls back to the
- * root workspace if no task worktree is found.
+ * Resolution order:
+ * 1. If `taskId` is provided, use that task's worktree directly.
+ * 2. Otherwise, look up all tasks for the run and use the first one's worktree.
+ *    (Logs a warning when a run has multiple tasks — only first task is shown.)
+ * 3. Falls back to the space's root `workspacePath` when no task worktree exists.
  *
  * @returns The resolved path, or null if no path can be determined.
  */
@@ -97,15 +99,41 @@ async function resolveWorktreePath(
 	spaceId: string,
 	spaceManager: SpaceManager,
 	spaceTaskRepo: SpaceTaskRepository,
-	spaceWorktreeManager: SpaceWorktreeManager
+	spaceWorktreeManager: SpaceWorktreeManager,
+	taskId?: string
 ): Promise<string | null> {
-	// First: look up the task associated with this run and get its worktree.
-	const tasks = spaceTaskRepo.listByWorkflowRun(runId);
-	if (tasks.length > 0) {
-		const taskId = tasks[0].id;
+	// If the caller provided a specific taskId, use that task's worktree directly.
+	if (taskId) {
 		const taskWorktreePath = await spaceWorktreeManager.getTaskWorktreePath(spaceId, taskId);
 		if (taskWorktreePath) {
 			return taskWorktreePath;
+		}
+		log.warn(
+			`resolveWorktreePath: no worktree found for taskId=${taskId}, falling back to root workspace`
+		);
+	} else {
+		// No taskId provided: look up tasks for the run and use the first one's worktree.
+		const tasks = spaceTaskRepo.listByWorkflowRun(runId);
+		if (tasks.length > 0) {
+			if (tasks.length > 1) {
+				log.warn(
+					`resolveWorktreePath: run ${runId} has ${tasks.length} tasks — showing artifacts for task ${tasks[0].id} only. Pass taskId to target a specific task.`
+				);
+			}
+			const firstTaskWorktreePath = await spaceWorktreeManager.getTaskWorktreePath(
+				spaceId,
+				tasks[0].id
+			);
+			if (firstTaskWorktreePath) {
+				return firstTaskWorktreePath;
+			}
+			log.warn(
+				`resolveWorktreePath: no worktree found for task ${tasks[0].id} in run ${runId}, falling back to root workspace`
+			);
+		} else {
+			log.warn(
+				`resolveWorktreePath: no tasks found for run ${runId}, falling back to root workspace`
+			);
 		}
 	}
 
@@ -595,7 +623,7 @@ export function setupSpaceWorkflowRunHandlers(
 	// Returns the list of changed files and diff summary (additions, deletions)
 	// for the workspace associated with a workflow run.
 	messageHub.onRequest('spaceWorkflowRun.getGateArtifacts', async (data) => {
-		const params = data as { runId: string };
+		const params = data as { runId: string; taskId?: string };
 
 		if (!params.runId) throw new Error('runId is required');
 
@@ -609,7 +637,8 @@ export function setupSpaceWorkflowRunHandlers(
 			run.spaceId,
 			spaceManager,
 			spaceTaskRepo,
-			spaceWorktreeManager
+			spaceWorktreeManager,
+			params.taskId
 		);
 		if (!worktreePath) {
 			throw new Error(`No workspace path found for run: ${params.runId}`);
@@ -636,7 +665,7 @@ export function setupSpaceWorkflowRunHandlers(
 	// Returns the unified diff for a specific file in the run's worktree.
 	// Uses the same base ref logic as getGateArtifacts.
 	messageHub.onRequest('spaceWorkflowRun.getFileDiff', async (data) => {
-		const params = data as { runId: string; filePath: string };
+		const params = data as { runId: string; filePath: string; taskId?: string };
 
 		if (!params.runId) throw new Error('runId is required');
 		if (!params.filePath || params.filePath.trim() === '') {
@@ -656,7 +685,8 @@ export function setupSpaceWorkflowRunHandlers(
 			run.spaceId,
 			spaceManager,
 			spaceTaskRepo,
-			spaceWorktreeManager
+			spaceWorktreeManager,
+			params.taskId
 		);
 		if (!worktreePath) {
 			throw new Error(`No workspace path found for run: ${params.runId}`);

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-gate-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-gate-handlers.test.ts
@@ -26,6 +26,8 @@ import type {
 	GateDataRecord,
 } from '../../../src/storage/repositories/gate-data-repository.ts';
 import type { SpaceRuntimeService } from '../../../src/lib/space/runtime/space-runtime-service.ts';
+import type { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
+import type { SpaceWorktreeManager } from '../../../src/lib/space/managers/space-worktree-manager.ts';
 import type { DaemonHub } from '../../../src/lib/daemon-hub.ts';
 
 // ─── Mock module for execFile (async) ─────────────────────────────────────────
@@ -198,6 +200,21 @@ function createMockRuntimeService(): SpaceRuntimeService {
 	} as unknown as SpaceRuntimeService;
 }
 
+/** Returns an empty task list — causes worktree path resolution to fall back to space.workspacePath */
+function createMockSpaceTaskRepo(): SpaceTaskRepository {
+	return {
+		listByWorkflowRun: mock(() => []),
+		getTask: mock(() => null),
+	} as unknown as SpaceTaskRepository;
+}
+
+/** Returns null worktree path — causes resolution to fall back to space.workspacePath */
+function createMockSpaceWorktreeManager(): SpaceWorktreeManager {
+	return {
+		getTaskWorktreePath: mock(async () => null),
+	} as unknown as SpaceWorktreeManager;
+}
+
 // ─── Test Setup ───────────────────────────────────────────────────────────────
 
 describe('space-workflow-run gate handlers', () => {
@@ -242,7 +259,9 @@ describe('space-workflow-run gate handlers', () => {
 			gateDataRepo,
 			createMockRuntimeService(),
 			taskManagerFactory,
-			daemonHub
+			daemonHub,
+			createMockSpaceTaskRepo(),
+			createMockSpaceWorktreeManager()
 		);
 	}
 

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-handlers.test.ts
@@ -24,6 +24,8 @@ import type { GateDataRepository } from '../../../src/storage/repositories/gate-
 import type { SpaceRuntimeService } from '../../../src/lib/space/runtime/space-runtime-service.ts';
 import type { SpaceRuntime } from '../../../src/lib/space/runtime/space-runtime.ts';
 import type { SpaceTaskManager } from '../../../src/lib/space/managers/space-task-manager.ts';
+import type { SpaceTaskRepository } from '../../../src/storage/repositories/space-task-repository.ts';
+import type { SpaceWorktreeManager } from '../../../src/lib/space/managers/space-worktree-manager.ts';
 import type { DaemonHub } from '../../../src/lib/daemon-hub.ts';
 
 type RequestHandler = (data: unknown) => Promise<unknown>;
@@ -209,6 +211,19 @@ function createMockTaskManager(tasks: SpaceTask[] = []): SpaceTaskManager {
 	} as unknown as SpaceTaskManager;
 }
 
+function createMockSpaceTaskRepo(tasks: SpaceTask[] = [mockTask]): SpaceTaskRepository {
+	return {
+		listByWorkflowRun: mock(() => tasks),
+		getTask: mock(() => null),
+	} as unknown as SpaceTaskRepository;
+}
+
+function createMockSpaceWorktreeManager(worktreePath: string | null = null): SpaceWorktreeManager {
+	return {
+		getTaskWorktreePath: mock(async () => worktreePath),
+	} as unknown as SpaceWorktreeManager;
+}
+
 // ─── Test Suite ───────────────────────────────────────────────────────────────
 
 describe('space-workflow-run-handlers', () => {
@@ -222,6 +237,8 @@ describe('space-workflow-run-handlers', () => {
 	let runtime: SpaceRuntime;
 	let taskManagerFactory: SpaceWorkflowRunTaskManagerFactory;
 	let taskManager: SpaceTaskManager;
+	let spaceTaskRepo: SpaceTaskRepository;
+	let spaceWorktreeManager: SpaceWorktreeManager;
 
 	function setup(
 		opts: {
@@ -231,6 +248,7 @@ describe('space-workflow-run-handlers', () => {
 			run?: SpaceWorkflowRun | null;
 			runs?: SpaceWorkflowRun[];
 			tasks?: SpaceTask[];
+			worktreePath?: string | null;
 		} = {}
 	) {
 		const mh = createMockMessageHub();
@@ -250,6 +268,8 @@ describe('space-workflow-run-handlers', () => {
 		runtimeService = createMockRuntimeService(resolvedSpace ?? null, runtime);
 		taskManager = createMockTaskManager(opts.tasks ?? []);
 		taskManagerFactory = mock(() => taskManager);
+		spaceTaskRepo = createMockSpaceTaskRepo([mockTask]);
+		spaceWorktreeManager = createMockSpaceWorktreeManager(opts.worktreePath ?? null);
 
 		setupSpaceWorkflowRunHandlers(
 			hub,
@@ -259,7 +279,9 @@ describe('space-workflow-run-handlers', () => {
 			createMockGateDataRepo(),
 			runtimeService,
 			taskManagerFactory,
-			daemonHub
+			daemonHub,
+			spaceTaskRepo,
+			spaceWorktreeManager
 		);
 	}
 
@@ -581,7 +603,9 @@ describe('space-workflow-run-handlers', () => {
 				createMockGateDataRepo(),
 				createMockRuntimeService(),
 				taskManagerFactory,
-				daemonHub
+				daemonHub,
+				createMockSpaceTaskRepo([mockTask]),
+				createMockSpaceWorktreeManager()
 			);
 
 			// Should not throw even though one cancelTask failed
@@ -650,12 +674,135 @@ describe('space-workflow-run-handlers', () => {
 				customGateRepo,
 				runtimeService,
 				taskManagerFactory,
-				daemonHub
+				daemonHub,
+				createMockSpaceTaskRepo([mockTask]),
+				createMockSpaceWorktreeManager()
 			);
 
 			const result = await call('spaceWorkflowRun.listGateData', { runId: 'run-1' });
 			expect(result).toEqual({ gateData: gateRecords });
 			expect(customGateRepo.listByRun).toHaveBeenCalledWith('run-1');
+		});
+	});
+
+	// ─── spaceWorkflowRun.getGateArtifacts — worktree path resolution ─────────
+
+	describe('spaceWorkflowRun.getGateArtifacts — worktree resolution', () => {
+		it('throws if runId is missing', async () => {
+			setup();
+			await expect(call('spaceWorkflowRun.getGateArtifacts', {})).rejects.toThrow(
+				'runId is required'
+			);
+		});
+
+		it('throws if run not found', async () => {
+			setup({ run: null });
+			await expect(
+				call('spaceWorkflowRun.getGateArtifacts', { runId: 'nonexistent' })
+			).rejects.toThrow('WorkflowRun not found: nonexistent');
+		});
+
+		it('throws if no workspace path found (no task worktree and no space workspacePath)', async () => {
+			const spaceWithoutWorkspace: Space = { ...mockSpace, workspacePath: '' };
+			setup({ space: spaceWithoutWorkspace, worktreePath: null });
+			await expect(call('spaceWorkflowRun.getGateArtifacts', { runId: 'run-1' })).rejects.toThrow(
+				'No workspace path found for run: run-1'
+			);
+		});
+
+		it('uses task worktree path when available (not root workspace)', async () => {
+			// The task has a worktree at /tmp/task-worktree, not the root /tmp/test-workspace.
+			// We verify the worktree manager is called with the task's ID.
+			const mockWorktreeManager = createMockSpaceWorktreeManager('/tmp/task-worktree');
+			const mockTaskRepo = createMockSpaceTaskRepo([mockTask]);
+
+			const mh = createMockMessageHub();
+			hub = mh.hub;
+			handlers = mh.handlers;
+
+			setupSpaceWorkflowRunHandlers(
+				hub,
+				createMockSpaceManager(mockSpace),
+				createMockWorkflowManager(),
+				createMockRunRepo(mockRun),
+				createMockGateDataRepo(),
+				createMockRuntimeService(),
+				mock(() => createMockTaskManager()),
+				createMockDaemonHub(),
+				mockTaskRepo,
+				mockWorktreeManager
+			);
+
+			// The handler will run git diff in /tmp/task-worktree but that path doesn't exist,
+			// so git will fail. The handler catches the error and returns empty files.
+			// The important check is that getTaskWorktreePath was called with the task's ID.
+			await call('spaceWorkflowRun.getGateArtifacts', { runId: 'run-1' }).catch(() => {});
+
+			expect(mockTaskRepo.listByWorkflowRun).toHaveBeenCalledWith('run-1');
+			expect(mockWorktreeManager.getTaskWorktreePath).toHaveBeenCalledWith('space-1', 'task-1');
+		});
+
+		it('falls back to root workspace path when no task worktree exists', async () => {
+			// No task worktree → worktree manager returns null → falls back to space.workspacePath
+			const mockWorktreeManager = createMockSpaceWorktreeManager(null);
+			const mockTaskRepo = createMockSpaceTaskRepo([mockTask]);
+			const mockSpaceMgr = createMockSpaceManager(mockSpace);
+
+			const mh = createMockMessageHub();
+			hub = mh.hub;
+			handlers = mh.handlers;
+
+			setupSpaceWorkflowRunHandlers(
+				hub,
+				mockSpaceMgr,
+				createMockWorkflowManager(),
+				createMockRunRepo(mockRun),
+				createMockGateDataRepo(),
+				createMockRuntimeService(),
+				mock(() => createMockTaskManager()),
+				createMockDaemonHub(),
+				mockTaskRepo,
+				mockWorktreeManager
+			);
+
+			// The handler will try to run git diff in /tmp/test-workspace (fallback),
+			// which will fail since the path is fake. We just verify the fallback was used.
+			await call('spaceWorkflowRun.getGateArtifacts', { runId: 'run-1' }).catch(() => {});
+
+			expect(mockWorktreeManager.getTaskWorktreePath).toHaveBeenCalledWith('space-1', 'task-1');
+			// spaceManager.getSpace should have been called to get the fallback path
+			expect(mockSpaceMgr.getSpace).toHaveBeenCalled();
+		});
+
+		it('falls back to root workspace when run has no tasks', async () => {
+			// No tasks for this run → skip task lookup → fall back to space.workspacePath
+			const mockWorktreeManager = createMockSpaceWorktreeManager(null);
+			const mockTaskRepo = createMockSpaceTaskRepo([]);
+			const mockSpaceMgr = createMockSpaceManager(mockSpace);
+
+			const mh = createMockMessageHub();
+			hub = mh.hub;
+			handlers = mh.handlers;
+
+			setupSpaceWorkflowRunHandlers(
+				hub,
+				mockSpaceMgr,
+				createMockWorkflowManager(),
+				createMockRunRepo(mockRun),
+				createMockGateDataRepo(),
+				createMockRuntimeService(),
+				mock(() => createMockTaskManager()),
+				createMockDaemonHub(),
+				mockTaskRepo,
+				mockWorktreeManager
+			);
+
+			await call('spaceWorkflowRun.getGateArtifacts', { runId: 'run-1' }).catch(() => {});
+
+			// No tasks → worktree manager should NOT have been called
+			expect(mockWorktreeManager.getTaskWorktreePath).not.toHaveBeenCalled();
+			// Space manager should have been called for the fallback
+			expect(mockSpaceMgr.getSpace).toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-handlers.test.ts
+++ b/packages/daemon/tests/unit/rpc-handlers/space-workflow-run-handlers.test.ts
@@ -710,6 +710,38 @@ describe('space-workflow-run-handlers', () => {
 			);
 		});
 
+		it('uses taskId directly when provided (skips listByWorkflowRun)', async () => {
+			const mockWorktreeManager = createMockSpaceWorktreeManager('/tmp/specific-task-worktree');
+			const mockTaskRepo = createMockSpaceTaskRepo([mockTask]);
+
+			const mh = createMockMessageHub();
+			hub = mh.hub;
+			handlers = mh.handlers;
+
+			setupSpaceWorkflowRunHandlers(
+				hub,
+				createMockSpaceManager(mockSpace),
+				createMockWorkflowManager(),
+				createMockRunRepo(mockRun),
+				createMockGateDataRepo(),
+				createMockRuntimeService(),
+				mock(() => createMockTaskManager()),
+				createMockDaemonHub(),
+				mockTaskRepo,
+				mockWorktreeManager
+			);
+
+			await call('spaceWorkflowRun.getGateArtifacts', {
+				runId: 'run-1',
+				taskId: 'task-1',
+			}).catch(() => {});
+
+			// When taskId is provided, listByWorkflowRun should NOT be called
+			expect(mockTaskRepo.listByWorkflowRun).not.toHaveBeenCalled();
+			// Worktree manager should be called directly with the provided taskId
+			expect(mockWorktreeManager.getTaskWorktreePath).toHaveBeenCalledWith('space-1', 'task-1');
+		});
+
 		it('uses task worktree path when available (not root workspace)', async () => {
 			// The task has a worktree at /tmp/task-worktree, not the root /tmp/test-workspace.
 			// We verify the worktree manager is called with the task's ID.
@@ -803,6 +835,135 @@ describe('space-workflow-run-handlers', () => {
 			expect(mockWorktreeManager.getTaskWorktreePath).not.toHaveBeenCalled();
 			// Space manager should have been called for the fallback
 			expect(mockSpaceMgr.getSpace).toHaveBeenCalled();
+		});
+	});
+
+	// ─── spaceWorkflowRun.getFileDiff — worktree path resolution ─────────────
+
+	describe('spaceWorkflowRun.getFileDiff — worktree resolution', () => {
+		it('throws if runId is missing', async () => {
+			setup();
+			await expect(
+				call('spaceWorkflowRun.getFileDiff', { filePath: 'src/foo.ts' })
+			).rejects.toThrow('runId is required');
+		});
+
+		it('throws if filePath is missing', async () => {
+			setup();
+			await expect(call('spaceWorkflowRun.getFileDiff', { runId: 'run-1' })).rejects.toThrow(
+				'filePath is required'
+			);
+		});
+
+		it('throws if filePath is absolute', async () => {
+			setup();
+			await expect(
+				call('spaceWorkflowRun.getFileDiff', { runId: 'run-1', filePath: '/absolute/path.ts' })
+			).rejects.toThrow('filePath must be a relative path within the worktree');
+		});
+
+		it('throws if filePath contains path traversal', async () => {
+			setup();
+			await expect(
+				call('spaceWorkflowRun.getFileDiff', { runId: 'run-1', filePath: '../outside.ts' })
+			).rejects.toThrow('filePath must be a relative path within the worktree');
+		});
+
+		it('throws if run not found', async () => {
+			setup({ run: null });
+			await expect(
+				call('spaceWorkflowRun.getFileDiff', { runId: 'nonexistent', filePath: 'src/foo.ts' })
+			).rejects.toThrow('WorkflowRun not found: nonexistent');
+		});
+
+		it('uses taskId directly when provided (skips listByWorkflowRun)', async () => {
+			const mockWorktreeManager = createMockSpaceWorktreeManager('/tmp/specific-task-worktree');
+			const mockTaskRepo = createMockSpaceTaskRepo([mockTask]);
+
+			const mh = createMockMessageHub();
+			hub = mh.hub;
+			handlers = mh.handlers;
+
+			setupSpaceWorkflowRunHandlers(
+				hub,
+				createMockSpaceManager(mockSpace),
+				createMockWorkflowManager(),
+				createMockRunRepo(mockRun),
+				createMockGateDataRepo(),
+				createMockRuntimeService(),
+				mock(() => createMockTaskManager()),
+				createMockDaemonHub(),
+				mockTaskRepo,
+				mockWorktreeManager
+			);
+
+			await call('spaceWorkflowRun.getFileDiff', {
+				runId: 'run-1',
+				taskId: 'task-1',
+				filePath: 'src/foo.ts',
+			}).catch(() => {});
+
+			// When taskId is provided, listByWorkflowRun should NOT be called
+			expect(mockTaskRepo.listByWorkflowRun).not.toHaveBeenCalled();
+			// Worktree manager should be called with the provided taskId
+			expect(mockWorktreeManager.getTaskWorktreePath).toHaveBeenCalledWith('space-1', 'task-1');
+		});
+
+		it('falls back to tasks[0] worktree when no taskId provided', async () => {
+			const mockWorktreeManager = createMockSpaceWorktreeManager('/tmp/task-worktree');
+			const mockTaskRepo = createMockSpaceTaskRepo([mockTask]);
+
+			const mh = createMockMessageHub();
+			hub = mh.hub;
+			handlers = mh.handlers;
+
+			setupSpaceWorkflowRunHandlers(
+				hub,
+				createMockSpaceManager(mockSpace),
+				createMockWorkflowManager(),
+				createMockRunRepo(mockRun),
+				createMockGateDataRepo(),
+				createMockRuntimeService(),
+				mock(() => createMockTaskManager()),
+				createMockDaemonHub(),
+				mockTaskRepo,
+				mockWorktreeManager
+			);
+
+			await call('spaceWorkflowRun.getFileDiff', {
+				runId: 'run-1',
+				filePath: 'src/foo.ts',
+			}).catch(() => {});
+
+			expect(mockTaskRepo.listByWorkflowRun).toHaveBeenCalledWith('run-1');
+			expect(mockWorktreeManager.getTaskWorktreePath).toHaveBeenCalledWith('space-1', 'task-1');
+		});
+
+		it('throws if no workspace path found (no task worktree and no space workspacePath)', async () => {
+			const spaceWithoutWorkspace: Space = { ...mockSpace, workspacePath: '' };
+			const mockWorktreeManager = createMockSpaceWorktreeManager(null);
+			const mockTaskRepo = createMockSpaceTaskRepo([]);
+
+			const mh = createMockMessageHub();
+			hub = mh.hub;
+			handlers = mh.handlers;
+
+			setupSpaceWorkflowRunHandlers(
+				hub,
+				createMockSpaceManager(spaceWithoutWorkspace),
+				createMockWorkflowManager(),
+				createMockRunRepo(mockRun),
+				createMockGateDataRepo(),
+				createMockRuntimeService(),
+				mock(() => createMockTaskManager()),
+				createMockDaemonHub(),
+				mockTaskRepo,
+				mockWorktreeManager
+			);
+
+			await expect(
+				call('spaceWorkflowRun.getFileDiff', { runId: 'run-1', filePath: 'src/foo.ts' })
+			).rejects.toThrow('No workspace path found for run: run-1');
 		});
 	});
 });

--- a/packages/web/src/components/space/FileDiffView.tsx
+++ b/packages/web/src/components/space/FileDiffView.tsx
@@ -19,6 +19,8 @@ import { cn } from '../../lib/utils';
 
 export interface FileDiffViewProps {
 	runId: string;
+	/** Task ID — when provided, diffs this task's worktree specifically */
+	taskId?: string;
 	filePath: string;
 	onBack: () => void;
 	class?: string;
@@ -117,7 +119,13 @@ export function parseDiff(diff: string): ParsedLine[] {
 // Component
 // ============================================================================
 
-export function FileDiffView({ runId, filePath, onBack, class: className }: FileDiffViewProps) {
+export function FileDiffView({
+	runId,
+	taskId,
+	filePath,
+	onBack,
+	class: className,
+}: FileDiffViewProps) {
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
 	const [diffText, setDiffText] = useState<string | null>(null);
@@ -139,7 +147,7 @@ export function FileDiffView({ runId, filePath, onBack, class: className }: File
 		hub
 			.request<{ diff: string; additions: number; deletions: number; filePath: string }>(
 				'spaceWorkflowRun.getFileDiff',
-				{ runId, filePath }
+				{ runId, filePath, ...(taskId ? { taskId } : {}) }
 			)
 			.then((result) => {
 				setDiffText(result.diff);
@@ -150,7 +158,7 @@ export function FileDiffView({ runId, filePath, onBack, class: className }: File
 				setError(err instanceof Error ? err.message : 'Failed to load diff');
 			})
 			.finally(() => setLoading(false));
-	}, [runId, filePath]);
+	}, [runId, taskId, filePath]);
 
 	const parsedLines = diffText ? parseDiff(diffText) : [];
 

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -454,6 +454,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 				) : showArtifacts && task.workflowRunId ? (
 					<TaskArtifactsPanel
 						runId={task.workflowRunId}
+						taskId={task.id}
 						onClose={() => setShowArtifacts(false)}
 						class="h-full"
 					/>

--- a/packages/web/src/components/space/TaskArtifactsPanel.tsx
+++ b/packages/web/src/components/space/TaskArtifactsPanel.tsx
@@ -21,6 +21,8 @@ import { FileDiffView } from './FileDiffView';
 export interface TaskArtifactsPanelProps {
 	/** Workflow run ID (from task.workflowRunId) */
 	runId: string;
+	/** Task ID — when provided, diffs this task's worktree specifically */
+	taskId?: string;
 	/** Called when the panel should close */
 	onClose: () => void;
 	class?: string;
@@ -44,7 +46,12 @@ interface ArtifactsResult {
 // Component
 // ============================================================================
 
-export function TaskArtifactsPanel({ runId, onClose, class: className }: TaskArtifactsPanelProps) {
+export function TaskArtifactsPanel({
+	runId,
+	taskId,
+	onClose,
+	class: className,
+}: TaskArtifactsPanelProps) {
 	const [loading, setLoading] = useState(true);
 	const [fetchError, setFetchError] = useState<string | null>(null);
 	const [artifacts, setArtifacts] = useState<ArtifactsResult | null>(null);
@@ -64,19 +71,23 @@ export function TaskArtifactsPanel({ runId, onClose, class: className }: TaskArt
 		}
 
 		hub
-			.request<ArtifactsResult>('spaceWorkflowRun.getGateArtifacts', { runId })
+			.request<ArtifactsResult>('spaceWorkflowRun.getGateArtifacts', {
+				runId,
+				...(taskId ? { taskId } : {}),
+			})
 			.then((result) => setArtifacts(result))
 			.catch((err: unknown) => {
 				setFetchError(err instanceof Error ? err.message : 'Failed to load artifacts');
 			})
 			.finally(() => setLoading(false));
-	}, [runId]);
+	}, [runId, taskId]);
 
 	// If a file is selected, swap to diff view
 	if (selectedFile) {
 		return (
 			<FileDiffView
 				runId={runId}
+				taskId={taskId}
 				filePath={selectedFile}
 				onBack={() => setSelectedFile(null)}
 				class={className}


### PR DESCRIPTION
The artifacts tab (`TaskArtifactsPanel`) was always empty because `getGateArtifacts` and `getFileDiff` ran `git diff` against `space.workspacePath` (the root repository) instead of the task-specific git worktree where the agent actually commits its work.

**Root cause**: Each space task gets a dedicated git worktree created by `SpaceWorktreeManager` (stored in the `space_worktrees` table). The handlers had no access to this path and fell back to the root workspace, which has no changes since all work happens in the child worktree.

**Fix**: Pass `SpaceTaskRepository` and `SpaceWorktreeManager` into `setupSpaceWorkflowRunHandlers`. The new `resolveWorktreePath` helper resolves: run → task IDs → task worktree path, falling back to root `workspacePath` if no task worktree exists.