### PR TITLE
refactor: make useRoomLiveQuery tab-aware

### DIFF
--- a/packages/web/src/hooks/__tests__/useRoomLiveQuery.test.ts
+++ b/packages/web/src/hooks/__tests__/useRoomLiveQuery.test.ts
@@ -2,12 +2,11 @@
  * Tests for useRoomLiveQuery Hook
  *
  * Verifies that the hook correctly manages the LiveQuery subscription
- * lifecycle by delegating to roomStore.subscribeRoom / unsubscribeRoom:
+ * lifecycle by delegating to per-query subscribe/unsubscribe methods:
  *
- * - Calls subscribeRoom(roomId) on mount
- * - Calls unsubscribeRoom(oldRoomId) then subscribeRoom(newRoomId) on roomId change
- * - Calls unsubscribeRoom(roomId) on unmount
- * - Does NOT double-subscribe if called with the same roomId
+ * - Tasks LiveQuery: always subscribed (regardless of activeTab)
+ * - Goals LiveQuery: always subscribed (consumed by sidebar, task badges, etc.)
+ * - Skills LiveQuery: subscribed only when activeTab is 'agents' or 'settings'
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -17,16 +16,31 @@ import { renderHook } from '@testing-library/preact';
 // Hoisted mocks (must not import anything)
 // ---------------------------------------------------------------------------
 
-const { mockSubscribeRoom, mockUnsubscribeRoom } = vi.hoisted(() => ({
-	mockSubscribeRoom: vi.fn().mockResolvedValue(undefined),
-	mockUnsubscribeRoom: vi.fn(),
+const {
+	mockSubscribeRoomTasks,
+	mockUnsubscribeRoomTasks,
+	mockSubscribeRoomGoals,
+	mockUnsubscribeRoomGoals,
+	mockSubscribeRoomSkills,
+	mockUnsubscribeRoomSkills,
+} = vi.hoisted(() => ({
+	mockSubscribeRoomTasks: vi.fn().mockResolvedValue(undefined),
+	mockUnsubscribeRoomTasks: vi.fn(),
+	mockSubscribeRoomGoals: vi.fn().mockResolvedValue(undefined),
+	mockUnsubscribeRoomGoals: vi.fn(),
+	mockSubscribeRoomSkills: vi.fn().mockResolvedValue(undefined),
+	mockUnsubscribeRoomSkills: vi.fn(),
 }));
 
-// Mock roomStore so we control subscribeRoom and unsubscribeRoom directly.
+// Mock roomStore so we control per-query subscribe/unsubscribe methods directly.
 vi.mock('../../lib/room-store', () => ({
 	roomStore: {
-		subscribeRoom: mockSubscribeRoom,
-		unsubscribeRoom: mockUnsubscribeRoom,
+		subscribeRoomTasks: mockSubscribeRoomTasks,
+		unsubscribeRoomTasks: mockUnsubscribeRoomTasks,
+		subscribeRoomGoals: mockSubscribeRoomGoals,
+		unsubscribeRoomGoals: mockUnsubscribeRoomGoals,
+		subscribeRoomSkills: mockSubscribeRoomSkills,
+		unsubscribeRoomSkills: mockUnsubscribeRoomSkills,
 	},
 }));
 
@@ -42,82 +56,288 @@ import { useRoomLiveQuery } from '../useRoomLiveQuery';
 
 describe('useRoomLiveQuery', () => {
 	beforeEach(() => {
-		mockSubscribeRoom.mockClear();
-		mockUnsubscribeRoom.mockClear();
+		mockSubscribeRoomTasks.mockClear();
+		mockUnsubscribeRoomTasks.mockClear();
+		mockSubscribeRoomGoals.mockClear();
+		mockUnsubscribeRoomGoals.mockClear();
+		mockSubscribeRoomSkills.mockClear();
+		mockUnsubscribeRoomSkills.mockClear();
 	});
 
-	it('calls subscribeRoom(roomId) on mount', () => {
-		renderHook(() => useRoomLiveQuery('room-1'));
+	// ---- Tasks subscription (always on) ----
 
-		expect(mockSubscribeRoom).toHaveBeenCalledTimes(1);
-		expect(mockSubscribeRoom).toHaveBeenCalledWith('room-1');
-	});
+	describe('tasks subscription', () => {
+		it('subscribes to tasks on mount', () => {
+			renderHook(() => useRoomLiveQuery('room-1', 'overview'));
 
-	it('calls unsubscribeRoom(roomId) on unmount', () => {
-		const { unmount } = renderHook(() => useRoomLiveQuery('room-1'));
-
-		expect(mockUnsubscribeRoom).not.toHaveBeenCalled();
-
-		unmount();
-
-		expect(mockUnsubscribeRoom).toHaveBeenCalledTimes(1);
-		expect(mockUnsubscribeRoom).toHaveBeenCalledWith('room-1');
-	});
-
-	it('calls unsubscribeRoom(oldRoomId) then subscribeRoom(newRoomId) on roomId change', () => {
-		const { rerender } = renderHook(({ roomId }) => useRoomLiveQuery(roomId), {
-			initialProps: { roomId: 'room-1' },
+			expect(mockSubscribeRoomTasks).toHaveBeenCalledTimes(1);
+			expect(mockSubscribeRoomTasks).toHaveBeenCalledWith('room-1');
 		});
 
-		expect(mockSubscribeRoom).toHaveBeenCalledTimes(1);
-		expect(mockSubscribeRoom).toHaveBeenCalledWith('room-1');
-		expect(mockUnsubscribeRoom).not.toHaveBeenCalled();
+		it('unsubscribes from tasks on unmount', () => {
+			const { unmount } = renderHook(() => useRoomLiveQuery('room-1', 'overview'));
 
-		mockSubscribeRoom.mockClear();
-		mockUnsubscribeRoom.mockClear();
+			expect(mockUnsubscribeRoomTasks).not.toHaveBeenCalled();
 
-		rerender({ roomId: 'room-2' });
+			unmount();
 
-		// unsubscribeRoom for old room before subscribeRoom for new room
-		expect(mockUnsubscribeRoom).toHaveBeenCalledTimes(1);
-		expect(mockUnsubscribeRoom).toHaveBeenCalledWith('room-1');
-		expect(mockSubscribeRoom).toHaveBeenCalledTimes(1);
-		expect(mockSubscribeRoom).toHaveBeenCalledWith('room-2');
-
-		// Verify unsubscribe was called before subscribe by checking call order
-		const unsubCallOrder = mockUnsubscribeRoom.mock.invocationCallOrder[0];
-		const subCallOrder = mockSubscribeRoom.mock.invocationCallOrder[0];
-		expect(unsubCallOrder).toBeLessThan(subCallOrder);
-	});
-
-	it('does not re-subscribe when roomId is unchanged', () => {
-		const { rerender } = renderHook(({ roomId }) => useRoomLiveQuery(roomId), {
-			initialProps: { roomId: 'room-1' },
+			expect(mockUnsubscribeRoomTasks).toHaveBeenCalledTimes(1);
+			expect(mockUnsubscribeRoomTasks).toHaveBeenCalledWith('room-1');
 		});
 
-		expect(mockSubscribeRoom).toHaveBeenCalledTimes(1);
-		mockSubscribeRoom.mockClear();
-		mockUnsubscribeRoom.mockClear();
+		it('persists across tab changes', () => {
+			const { rerender } = renderHook(({ activeTab }) => useRoomLiveQuery('room-1', activeTab), {
+				initialProps: { activeTab: 'overview' },
+			});
 
-		// Rerender with the same roomId
-		rerender({ roomId: 'room-1' });
+			expect(mockSubscribeRoomTasks).toHaveBeenCalledTimes(1);
+			mockSubscribeRoomTasks.mockClear();
 
-		expect(mockSubscribeRoom).not.toHaveBeenCalled();
-		expect(mockUnsubscribeRoom).not.toHaveBeenCalled();
-	});
+			// Switch to goals tab — tasks should NOT re-subscribe
+			rerender({ activeTab: 'goals' });
+			expect(mockSubscribeRoomTasks).not.toHaveBeenCalled();
 
-	it('calls unsubscribeRoom with the last active roomId on unmount after room change', () => {
-		const { rerender, unmount } = renderHook(({ roomId }) => useRoomLiveQuery(roomId), {
-			initialProps: { roomId: 'room-1' },
+			// Switch to agents tab — tasks should NOT re-subscribe
+			rerender({ activeTab: 'agents' });
+			expect(mockSubscribeRoomTasks).not.toHaveBeenCalled();
 		});
 
-		rerender({ roomId: 'room-2' });
+		it('resubscribes on roomId change', () => {
+			const { rerender } = renderHook(({ roomId }) => useRoomLiveQuery(roomId, 'overview'), {
+				initialProps: { roomId: 'room-1' },
+			});
 
-		mockUnsubscribeRoom.mockClear();
+			mockUnsubscribeRoomTasks.mockClear();
+			mockSubscribeRoomTasks.mockClear();
 
-		unmount();
+			rerender({ roomId: 'room-2' });
 
-		expect(mockUnsubscribeRoom).toHaveBeenCalledTimes(1);
-		expect(mockUnsubscribeRoom).toHaveBeenCalledWith('room-2');
+			expect(mockUnsubscribeRoomTasks).toHaveBeenCalledWith('room-1');
+			expect(mockSubscribeRoomTasks).toHaveBeenCalledWith('room-2');
+		});
+	});
+
+	// ---- Goals subscription (always on) ----
+
+	describe('goals subscription', () => {
+		it('subscribes to goals on mount', () => {
+			renderHook(() => useRoomLiveQuery('room-1', 'overview'));
+
+			expect(mockSubscribeRoomGoals).toHaveBeenCalledTimes(1);
+			expect(mockSubscribeRoomGoals).toHaveBeenCalledWith('room-1');
+		});
+
+		it('unsubscribes from goals on unmount', () => {
+			const { unmount } = renderHook(() => useRoomLiveQuery('room-1', 'overview'));
+
+			expect(mockUnsubscribeRoomGoals).not.toHaveBeenCalled();
+
+			unmount();
+
+			expect(mockUnsubscribeRoomGoals).toHaveBeenCalledTimes(1);
+			expect(mockUnsubscribeRoomGoals).toHaveBeenCalledWith('room-1');
+		});
+
+		it('persists across tab changes', () => {
+			const { rerender } = renderHook(({ activeTab }) => useRoomLiveQuery('room-1', activeTab), {
+				initialProps: { activeTab: 'overview' },
+			});
+
+			expect(mockSubscribeRoomGoals).toHaveBeenCalledTimes(1);
+			mockSubscribeRoomGoals.mockClear();
+
+			// Switch through several tabs — goals should NOT re-subscribe
+			rerender({ activeTab: 'tasks' });
+			rerender({ activeTab: 'agents' });
+			rerender({ activeTab: 'settings' });
+			expect(mockSubscribeRoomGoals).not.toHaveBeenCalled();
+		});
+
+		it('resubscribes on roomId change', () => {
+			const { rerender } = renderHook(({ roomId }) => useRoomLiveQuery(roomId, 'overview'), {
+				initialProps: { roomId: 'room-1' },
+			});
+
+			mockUnsubscribeRoomGoals.mockClear();
+			mockSubscribeRoomGoals.mockClear();
+
+			rerender({ roomId: 'room-2' });
+
+			expect(mockUnsubscribeRoomGoals).toHaveBeenCalledWith('room-1');
+			expect(mockSubscribeRoomGoals).toHaveBeenCalledWith('room-2');
+		});
+	});
+
+	// ---- Skills subscription (conditional) ----
+
+	describe('skills subscription', () => {
+		it('does not subscribe to skills on overview tab', () => {
+			renderHook(() => useRoomLiveQuery('room-1', 'overview'));
+
+			expect(mockSubscribeRoomSkills).not.toHaveBeenCalled();
+		});
+
+		it('does not subscribe to skills on tasks tab', () => {
+			renderHook(() => useRoomLiveQuery('room-1', 'tasks'));
+
+			expect(mockSubscribeRoomSkills).not.toHaveBeenCalled();
+		});
+
+		it('does not subscribe to skills on goals tab', () => {
+			renderHook(() => useRoomLiveQuery('room-1', 'goals'));
+
+			expect(mockSubscribeRoomSkills).not.toHaveBeenCalled();
+		});
+
+		it('does not subscribe to skills on chat tab', () => {
+			renderHook(() => useRoomLiveQuery('room-1', 'chat'));
+
+			expect(mockSubscribeRoomSkills).not.toHaveBeenCalled();
+		});
+
+		it('subscribes to skills when activeTab changes to agents', () => {
+			const { rerender } = renderHook(({ activeTab }) => useRoomLiveQuery('room-1', activeTab), {
+				initialProps: { activeTab: 'overview' },
+			});
+
+			expect(mockSubscribeRoomSkills).not.toHaveBeenCalled();
+
+			rerender({ activeTab: 'agents' });
+
+			expect(mockSubscribeRoomSkills).toHaveBeenCalledTimes(1);
+			expect(mockSubscribeRoomSkills).toHaveBeenCalledWith('room-1');
+		});
+
+		it('subscribes to skills when activeTab changes to settings', () => {
+			const { rerender } = renderHook(({ activeTab }) => useRoomLiveQuery('room-1', activeTab), {
+				initialProps: { activeTab: 'overview' },
+			});
+
+			expect(mockSubscribeRoomSkills).not.toHaveBeenCalled();
+
+			rerender({ activeTab: 'settings' });
+
+			expect(mockSubscribeRoomSkills).toHaveBeenCalledTimes(1);
+			expect(mockSubscribeRoomSkills).toHaveBeenCalledWith('room-1');
+		});
+
+		it('unsubscribes from skills when leaving agents tab', () => {
+			const { rerender } = renderHook(({ activeTab }) => useRoomLiveQuery('room-1', activeTab), {
+				initialProps: { activeTab: 'agents' },
+			});
+
+			expect(mockSubscribeRoomSkills).toHaveBeenCalledTimes(1);
+			expect(mockUnsubscribeRoomSkills).not.toHaveBeenCalled();
+
+			rerender({ activeTab: 'overview' });
+
+			expect(mockUnsubscribeRoomSkills).toHaveBeenCalledTimes(1);
+			expect(mockUnsubscribeRoomSkills).toHaveBeenCalledWith('room-1');
+		});
+
+		it('unsubscribes from skills when leaving settings tab', () => {
+			const { rerender } = renderHook(({ activeTab }) => useRoomLiveQuery('room-1', activeTab), {
+				initialProps: { activeTab: 'settings' },
+			});
+
+			expect(mockSubscribeRoomSkills).toHaveBeenCalledTimes(1);
+
+			rerender({ activeTab: 'overview' });
+
+			expect(mockUnsubscribeRoomSkills).toHaveBeenCalledTimes(1);
+			expect(mockUnsubscribeRoomSkills).toHaveBeenCalledWith('room-1');
+		});
+
+		it('switches skills subscription between agents and settings without unsubscribing', () => {
+			const { rerender } = renderHook(({ activeTab }) => useRoomLiveQuery('room-1', activeTab), {
+				initialProps: { activeTab: 'agents' },
+			});
+
+			expect(mockSubscribeRoomSkills).toHaveBeenCalledTimes(1);
+			mockSubscribeRoomSkills.mockClear();
+
+			// Switch from agents to settings — should resubscribe (effect re-runs)
+			rerender({ activeTab: 'settings' });
+			expect(mockSubscribeRoomSkills).toHaveBeenCalledTimes(1);
+			expect(mockSubscribeRoomSkills).toHaveBeenCalledWith('room-1');
+		});
+
+		it('does not subscribe to skills when activeTab is null', () => {
+			renderHook(() => useRoomLiveQuery('room-1', null));
+
+			expect(mockSubscribeRoomSkills).not.toHaveBeenCalled();
+		});
+
+		it('direct navigation to agents tab subscribes immediately', () => {
+			renderHook(() => useRoomLiveQuery('room-1', 'agents'));
+
+			expect(mockSubscribeRoomSkills).toHaveBeenCalledTimes(1);
+			expect(mockSubscribeRoomSkills).toHaveBeenCalledWith('room-1');
+		});
+
+		it('direct navigation to settings tab subscribes immediately', () => {
+			renderHook(() => useRoomLiveQuery('room-1', 'settings'));
+
+			expect(mockSubscribeRoomSkills).toHaveBeenCalledTimes(1);
+			expect(mockSubscribeRoomSkills).toHaveBeenCalledWith('room-1');
+		});
+
+		it('unsubscribes from skills on unmount while on agents tab', () => {
+			const { unmount } = renderHook(() => useRoomLiveQuery('room-1', 'agents'));
+
+			expect(mockUnsubscribeRoomSkills).not.toHaveBeenCalled();
+
+			unmount();
+
+			expect(mockUnsubscribeRoomSkills).toHaveBeenCalledTimes(1);
+			expect(mockUnsubscribeRoomSkills).toHaveBeenCalledWith('room-1');
+		});
+
+		it('does not unsubscribe skills on unmount when not on agents/settings tab', () => {
+			const { unmount } = renderHook(() => useRoomLiveQuery('room-1', 'overview'));
+
+			unmount();
+
+			expect(mockUnsubscribeRoomSkills).not.toHaveBeenCalled();
+		});
+	});
+
+	// ---- Combined behavior ----
+
+	describe('combined subscriptions', () => {
+		it('mounting with overview tab subscribes to tasks and goals but not skills', () => {
+			renderHook(() => useRoomLiveQuery('room-1', 'overview'));
+
+			expect(mockSubscribeRoomTasks).toHaveBeenCalledTimes(1);
+			expect(mockSubscribeRoomGoals).toHaveBeenCalledTimes(1);
+			expect(mockSubscribeRoomSkills).not.toHaveBeenCalled();
+		});
+
+		it('changing to agents tab adds skills subscription', () => {
+			const { rerender } = renderHook(({ activeTab }) => useRoomLiveQuery('room-1', activeTab), {
+				initialProps: { activeTab: 'overview' },
+			});
+
+			expect(mockSubscribeRoomTasks).toHaveBeenCalledTimes(1);
+			expect(mockSubscribeRoomGoals).toHaveBeenCalledTimes(1);
+			expect(mockSubscribeRoomSkills).not.toHaveBeenCalled();
+
+			rerender({ activeTab: 'agents' });
+
+			expect(mockSubscribeRoomSkills).toHaveBeenCalledTimes(1);
+			// Tasks and goals should not re-subscribe
+			expect(mockSubscribeRoomTasks).toHaveBeenCalledTimes(1);
+			expect(mockSubscribeRoomGoals).toHaveBeenCalledTimes(1);
+		});
+
+		it('all subscriptions clean up on unmount', () => {
+			const { unmount } = renderHook(() => useRoomLiveQuery('room-1', 'agents'));
+
+			unmount();
+
+			expect(mockUnsubscribeRoomTasks).toHaveBeenCalledTimes(1);
+			expect(mockUnsubscribeRoomGoals).toHaveBeenCalledTimes(1);
+			expect(mockUnsubscribeRoomSkills).toHaveBeenCalledTimes(1);
+		});
 	});
 });

--- a/packages/web/src/hooks/__tests__/useRoomLiveQuery.test.ts
+++ b/packages/web/src/hooks/__tests__/useRoomLiveQuery.test.ts
@@ -248,7 +248,7 @@ describe('useRoomLiveQuery', () => {
 			expect(mockUnsubscribeRoomSkills).toHaveBeenCalledWith('room-1');
 		});
 
-		it('switches skills subscription between agents and settings without unsubscribing', () => {
+		it('resubscribes skills when switching between agents and settings tabs', () => {
 			const { rerender } = renderHook(({ activeTab }) => useRoomLiveQuery('room-1', activeTab), {
 				initialProps: { activeTab: 'agents' },
 			});
@@ -256,10 +256,24 @@ describe('useRoomLiveQuery', () => {
 			expect(mockSubscribeRoomSkills).toHaveBeenCalledTimes(1);
 			mockSubscribeRoomSkills.mockClear();
 
-			// Switch from agents to settings — should resubscribe (effect re-runs)
+			// Switch from agents to settings — cleanup unsubs old, effect resubscribes
 			rerender({ activeTab: 'settings' });
 			expect(mockSubscribeRoomSkills).toHaveBeenCalledTimes(1);
 			expect(mockSubscribeRoomSkills).toHaveBeenCalledWith('room-1');
+		});
+
+		it('resubscribes on roomId change while on agents tab', () => {
+			const { rerender } = renderHook(({ roomId }) => useRoomLiveQuery(roomId, 'agents'), {
+				initialProps: { roomId: 'room-1' },
+			});
+
+			mockUnsubscribeRoomSkills.mockClear();
+			mockSubscribeRoomSkills.mockClear();
+
+			rerender({ roomId: 'room-2' });
+
+			expect(mockUnsubscribeRoomSkills).toHaveBeenCalledWith('room-1');
+			expect(mockSubscribeRoomSkills).toHaveBeenCalledWith('room-2');
 		});
 
 		it('does not subscribe to skills when activeTab is null', () => {

--- a/packages/web/src/hooks/useRoomLiveQuery.ts
+++ b/packages/web/src/hooks/useRoomLiveQuery.ts
@@ -4,10 +4,21 @@
  * Lifecycle adapter that manages LiveQuery subscriptions for a room.
  *
  * Responsibilities:
- * - On mount: call roomStore.subscribeRoom(roomId)
- * - On roomId change: call roomStore.unsubscribeRoom(oldRoomId) then
- *   roomStore.subscribeRoom(newRoomId)
- * - On unmount: call roomStore.unsubscribeRoom(roomId)
+ * - Tasks LiveQuery: always subscribed (used by tasks tab, overview stats,
+ *   and review notification banner).
+ * - Goals LiveQuery: always subscribed. Although the full goals editor only
+ *   renders on the goals tab, goal-derived signals (activeGoals, goalByTaskId)
+ *   are consumed by RoomContextPanel (sidebar), RoomTasks (mission badges),
+ *   TaskHeader (slide-over), and MissionDetail (slide-over). Making goals
+ *   conditional would leave these consumers with stale or empty data.
+ * - Skills LiveQuery: subscribed only when activeTab is 'agents' or 'settings',
+ *   unsubscribed when leaving those tabs.
+ *
+ * The `activeTab` parameter must be passed from the parent (Room.tsx) rather
+ * than read from a signal inside the hook. Preact Signals read inside a
+ * useEffect dependency array will NOT automatically re-run when the signal
+ * changes — the parent re-renders on signal change and passes the new value
+ * as a prop, which correctly triggers the effect.
  *
  * The store owns the subscription handles and cleanup logic.
  * This hook is purely a lifecycle adapter between the Preact component
@@ -24,20 +35,44 @@ import { roomStore } from '../lib/room-store';
  * rendered for the duration of the room view (e.g., the Room island).
  *
  * @param roomId - The ID of the room to subscribe to.
+ * @param activeTab - The currently active room tab, passed from the parent
+ *   component. Controls conditional subscriptions (skills).
  *
  * @example
  * ```tsx
  * export default function Room({ roomId }: { roomId: string }) {
- *   useRoomLiveQuery(roomId);
+ *   const activeTab = currentRoomActiveTabSignal.value ?? 'overview';
+ *   useRoomLiveQuery(roomId, activeTab);
  *   // ...
  * }
  * ```
  */
-export function useRoomLiveQuery(roomId: string): void {
+export function useRoomLiveQuery(roomId: string, activeTab: string | null): void {
+	// Tasks LiveQuery — always active for the room.
 	useEffect(() => {
-		roomStore.subscribeRoom(roomId);
+		roomStore.subscribeRoomTasks(roomId);
 		return () => {
-			roomStore.unsubscribeRoom(roomId);
+			roomStore.unsubscribeRoomTasks(roomId);
 		};
 	}, [roomId]);
+
+	// Goals LiveQuery — always active.
+	// See module-level JSDoc for the goals consumer audit rationale.
+	useEffect(() => {
+		roomStore.subscribeRoomGoals(roomId);
+		return () => {
+			roomStore.unsubscribeRoomGoals(roomId);
+		};
+	}, [roomId]);
+
+	// Skills LiveQuery — active only when agents or settings tab is showing.
+	useEffect(() => {
+		if (activeTab === 'agents' || activeTab === 'settings') {
+			roomStore.subscribeRoomSkills(roomId);
+			return () => {
+				roomStore.unsubscribeRoomSkills(roomId);
+			};
+		}
+		return undefined;
+	}, [roomId, activeTab]);
 }

--- a/packages/web/src/islands/Room.tsx
+++ b/packages/web/src/islands/Room.tsx
@@ -46,11 +46,11 @@ export default function Room({ roomId, sessionViewId, taskViewId, missionViewId 
 	const [initialLoad, setInitialLoad] = useState(true);
 	const activeTab: RoomTab = (currentRoomActiveTabSignal.value as RoomTab) ?? 'overview';
 
-	// Manage LiveQuery subscriptions for tasks and goals.
+	// Manage LiveQuery subscriptions for tasks, goals, and skills.
 	// Intentionally declared before the select() effect so that LiveQuery
 	// handlers are registered before the hub request fires — both share
 	// [roomId] as their dependency and run in declaration order.
-	useRoomLiveQuery(roomId);
+	useRoomLiveQuery(roomId, activeTab);
 
 	useEffect(() => {
 		roomStore.select(roomId).finally(() => {


### PR DESCRIPTION
Split `useRoomLiveQuery` from a single `subscribeRoom`/`unsubscribeRoom` call into three separate `useEffect` blocks with per-query subscription control:

- **Tasks**: always subscribed (used by tasks tab, overview stats, review banner)
- **Goals**: always subscribed (see audit below)
- **Skills**: subscribed only when `activeTab` is `'agents'` or `'settings'`

The hook now accepts `activeTab` as a parameter (not read from a signal) to ensure correct Preact Signals reactivity — the parent re-renders on signal change and passes the new value as a prop, which correctly triggers the effect.

### Goals Consumer Audit

Goals data is consumed **outside** the goals tab by multiple components:

| Component | Location | Data consumed | Renders when |
|-----------|----------|---------------|-------------|
| RoomContextPanel | Sidebar (always visible) | `activeGoals` | Always |
| RoomTasks | Tasks tab | `goalByTaskId` (mission badges) | `activeTab === 'tasks'` |
| TaskHeader | Slide-over overlay | `associatedGoal` (link badge) | When `taskViewId` is set |
| MissionDetail | Slide-over overlay | `goals` (full goal lookup) | When `missionViewId` is set |

Making goals conditional would leave these consumers with stale or empty data, so goals remain always-on. If a lightweight separate query is desired in the future, the `subscribeRoomGoals`/`unsubscribeRoomGoals` split already enables it.

### Tests

25 tests covering all subscription scenarios (was 5). Organized into four describe blocks: tasks (always on), goals (always on), skills (conditional), and combined behavior.