### PR TITLE
refactor: add lazy loading for GoalsEditor, RoomAgents, and RoomSettings

### DIFF
--- a/packages/web/src/components/room/index.ts
+++ b/packages/web/src/components/room/index.ts
@@ -7,8 +7,6 @@
 // @public - Library export
 export { CollapsibleSection } from './CollapsibleSection';
 export type { CollapsibleSectionProps } from './CollapsibleSection';
-// @public - Library export
-export { GoalsEditor } from './GoalsEditor';
 // @public - GoalsEditor sub-components for reuse in MissionDetail and other views
 export { StatusIndicator } from './GoalsEditor';
 export { PriorityBadge } from './GoalsEditor';
@@ -22,12 +20,6 @@ export { GoalForm, type GoalFormProps } from './GoalsEditor';
 // @public - Library export
 export { RoomContext } from './RoomContext';
 export type { RoomContextProps } from './RoomContext';
-// @public - Library export
-export { RoomSettings } from './RoomSettings';
-export type { RoomSettingsProps } from './RoomSettings';
-// @public - Library export
-export { RoomAgents } from './RoomAgents';
-export type { RoomAgentsProps } from './RoomAgents';
 // @public - Library export
 export { RoomAgentContextStrip } from './RoomAgentContextStrip';
 // @public - Library export

--- a/packages/web/src/components/ui/ErrorBoundary.tsx
+++ b/packages/web/src/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,54 @@
+import { Component, type ComponentChildren, type ErrorInfo, type VNode } from 'preact';
+
+export interface ErrorBoundaryProps {
+	children: ComponentChildren;
+	fallback?: VNode;
+	onError?: (error: unknown, errorInfo: ErrorInfo) => void;
+}
+
+export interface ErrorBoundaryState {
+	hasError: boolean;
+}
+
+/**
+ * Catches rendering errors in child components and displays a fallback UI.
+ *
+ * Used to gracefully handle lazy chunk load failures (e.g., stale content hash
+ * after a deploy) without crashing the entire component tree.
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+	state: ErrorBoundaryState = { hasError: false };
+
+	static getDerivedStateFromError(): ErrorBoundaryState {
+		return { hasError: true };
+	}
+
+	componentDidCatch(error: unknown, errorInfo: ErrorInfo): void {
+		this.props.onError?.(error, errorInfo);
+	}
+
+	handleRetry = (): void => {
+		this.setState({ hasError: false });
+	};
+
+	render() {
+		if (this.state.hasError) {
+			if (this.props.fallback) {
+				return this.props.fallback;
+			}
+			return (
+				<div class="flex flex-col items-center justify-center h-full gap-3 p-4">
+					<p class="text-sm text-gray-400">Failed to load component</p>
+					<button
+						type="button"
+						class="text-sm text-blue-400 hover:text-blue-300 underline"
+						onClick={this.handleRetry}
+					>
+						Retry
+					</button>
+				</div>
+			);
+		}
+		return this.props.children;
+	}
+}

--- a/packages/web/src/components/ui/__tests__/ErrorBoundary.test.tsx
+++ b/packages/web/src/components/ui/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/preact';
+import { h } from 'preact';
+import { ErrorBoundary } from '../ErrorBoundary';
+
+// Component that throws on render
+function ThrowOnRender({ error }: { error: Error }): never {
+	throw error;
+}
+
+describe('ErrorBoundary', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders children when no error occurs', () => {
+		render(
+			<ErrorBoundary>
+				<div data-testid="child">Hello</div>
+			</ErrorBoundary>
+		);
+
+		expect(screen.getByTestId('child').textContent).toBe('Hello');
+	});
+
+	it('renders default fallback UI when a child throws', () => {
+		// Suppress the console.error that Preact logs for uncaught errors
+		const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		render(
+			<ErrorBoundary>
+				<ThrowOnRender error={new Error('test error')} />
+			</ErrorBoundary>
+		);
+
+		expect(screen.getByText('Failed to load component')).toBeTruthy();
+		expect(screen.getByText('Retry')).toBeTruthy();
+
+		spy.mockRestore();
+	});
+
+	it('renders custom fallback when provided', () => {
+		const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		render(
+			<ErrorBoundary fallback={<div data-testid="custom-fallback">Custom Error</div>}>
+				<ThrowOnRender error={new Error('test error')} />
+			</ErrorBoundary>
+		);
+
+		expect(screen.getByTestId('custom-fallback').textContent).toBe('Custom Error');
+
+		spy.mockRestore();
+	});
+
+	it('calls onError callback when an error is caught', () => {
+		const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const onError = vi.fn();
+
+		render(
+			<ErrorBoundary onError={onError}>
+				<ThrowOnRender error={new Error('test error')} />
+			</ErrorBoundary>
+		);
+
+		expect(onError).toHaveBeenCalledTimes(1);
+		expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+		expect((onError.mock.calls[0][0] as Error).message).toBe('test error');
+
+		spy.mockRestore();
+	});
+
+	it('resets error state when Retry button is clicked', async () => {
+		const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		render(
+			<ErrorBoundary>
+				<ThrowOnRender error={new Error('test error')} />
+			</ErrorBoundary>
+		);
+
+		// Error state is showing
+		expect(screen.getByText('Failed to load component')).toBeTruthy();
+
+		// Click retry — resets error state, which re-renders children
+		// The child throws again, so the error UI will reappear,
+		// but this confirms the state reset mechanism works.
+		fireEvent.click(screen.getByText('Retry'));
+
+		// Error boundary caught the re-thrown error and shows fallback again
+		expect(screen.getByText('Failed to load component')).toBeTruthy();
+
+		spy.mockRestore();
+	});
+});

--- a/packages/web/src/islands/Room.tsx
+++ b/packages/web/src/islands/Room.tsx
@@ -30,6 +30,7 @@ import { MissionDetail } from '../components/room/MissionDetail';
 import { Skeleton } from '../components/ui/Skeleton';
 import { Button } from '../components/ui/Button';
 import { MobileMenuButton } from '../components/ui/MobileMenuButton';
+import { ErrorBoundary } from '../components/ui/ErrorBoundary';
 import { toast } from '../lib/toast';
 import { cn } from '../lib/utils';
 
@@ -37,11 +38,22 @@ import { cn } from '../lib/utils';
 const GoalsEditor = lazy(() =>
 	import('../components/room/GoalsEditor').then((m) => ({ default: m.GoalsEditor }))
 );
+// NOTE: GoalsEditor's lazy split is ineffective — MissionDetail statically imports
+// sub-components (StatusIndicator, PriorityBadge, etc.) from GoalsEditor.tsx, so
+// the bundler keeps it in the main bundle. A future refactor could extract shared
+// sub-components into a separate module to enable effective code-splitting.
 const RoomAgents = lazy(() =>
 	import('../components/room/RoomAgents').then((m) => ({ default: m.RoomAgents }))
 );
 const RoomSettings = lazy(() =>
 	import('../components/room/RoomSettings').then((m) => ({ default: m.RoomSettings }))
+);
+
+/** Shared Suspense fallback for lazy-loaded tab components. */
+const lazyTabFallback = (
+	<div class="flex items-center justify-center h-32">
+		<Skeleton width="200px" height={24} />
+	</div>
 );
 
 type RoomTab = 'chat' | 'overview' | 'tasks' | 'agents' | 'goals' | 'settings';
@@ -299,67 +311,55 @@ export default function Room({ roomId, sessionViewId, taskViewId, missionViewId 
 							)}
 							{activeTab === 'agents' && (
 								<div class="h-full overflow-y-auto">
-									<Suspense
-										fallback={
-											<div class="flex items-center justify-center h-32">
-												<Skeleton width="200px" height={24} />
-											</div>
-										}
-									>
-										<RoomAgents room={room} />
-									</Suspense>
+									<ErrorBoundary>
+										<Suspense fallback={lazyTabFallback}>
+											<RoomAgents room={room} />
+										</Suspense>
+									</ErrorBoundary>
 								</div>
 							)}
 							{activeTab === 'goals' && (
 								<div class="h-full overflow-y-auto">
-									<Suspense
-										fallback={
-											<div class="flex items-center justify-center h-32">
-												<Skeleton width="200px" height={24} />
-											</div>
-										}
-									>
-										<GoalsEditor
-											roomId={roomId}
-											goals={roomStore.goals.value}
-											tasks={roomStore.tasks.value}
-											onTaskClick={(taskId) => navigateToRoomTask(roomId, taskId)}
-											onGoalClick={(goalId) => navigateToRoomMission(roomId, goalId)}
-											onCreateGoal={handleCreateGoal}
-											onUpdateGoal={handleUpdateGoal}
-											onDeleteGoal={handleDeleteGoal}
-											onLinkTask={handleLinkTaskToGoal}
-											isLoading={roomStore.goalsLoading.value}
-											autoCompletedNotifications={roomStore.autoCompletedNotifications.value}
-											onDismissNotification={(taskId) => roomStore.dismissAutoCompleted(taskId)}
-											onListExecutions={(goalId) => roomStore.listExecutions(goalId)}
-											onTriggerNow={async (goalId) => {
-												await roomStore.triggerNow(goalId);
-											}}
-											onScheduleNext={async (goalId, nextRunAt) => {
-												await roomStore.scheduleNext(goalId, nextRunAt);
-											}}
-										/>
-									</Suspense>
+									<ErrorBoundary>
+										<Suspense fallback={lazyTabFallback}>
+											<GoalsEditor
+												roomId={roomId}
+												goals={roomStore.goals.value}
+												tasks={roomStore.tasks.value}
+												onTaskClick={(taskId) => navigateToRoomTask(roomId, taskId)}
+												onGoalClick={(goalId) => navigateToRoomMission(roomId, goalId)}
+												onCreateGoal={handleCreateGoal}
+												onUpdateGoal={handleUpdateGoal}
+												onDeleteGoal={handleDeleteGoal}
+												onLinkTask={handleLinkTaskToGoal}
+												isLoading={roomStore.goalsLoading.value}
+												autoCompletedNotifications={roomStore.autoCompletedNotifications.value}
+												onDismissNotification={(taskId) => roomStore.dismissAutoCompleted(taskId)}
+												onListExecutions={(goalId) => roomStore.listExecutions(goalId)}
+												onTriggerNow={async (goalId) => {
+													await roomStore.triggerNow(goalId);
+												}}
+												onScheduleNext={async (goalId, nextRunAt) => {
+													await roomStore.scheduleNext(goalId, nextRunAt);
+												}}
+											/>
+										</Suspense>
+									</ErrorBoundary>
 								</div>
 							)}
 							{activeTab === 'settings' && (
 								<div class="h-full overflow-y-auto">
-									<Suspense
-										fallback={
-											<div class="flex items-center justify-center h-32">
-												<Skeleton width="200px" height={24} />
-											</div>
-										}
-									>
-										<RoomSettings
-											room={room}
-											onSave={(params) => roomStore.updateSettings(params)}
-											onArchive={handleArchiveRoom}
-											onDelete={handleDeleteRoom}
-											isLoading={roomStore.loading.value}
-										/>
-									</Suspense>
+									<ErrorBoundary>
+										<Suspense fallback={lazyTabFallback}>
+											<RoomSettings
+												room={room}
+												onSave={(params) => roomStore.updateSettings(params)}
+												onArchive={handleArchiveRoom}
+												onDelete={handleDeleteRoom}
+												isLoading={roomStore.loading.value}
+											/>
+										</Suspense>
+									</ErrorBoundary>
 								</div>
 							)}
 							{/* Task slide-over: overlays tab content, keeps header/tabs accessible */}

--- a/packages/web/src/islands/Room.tsx
+++ b/packages/web/src/islands/Room.tsx
@@ -9,6 +9,7 @@
  * - Real-time updates via state channels
  */
 
+import { lazy, Suspense } from 'preact/compat';
 import { useEffect, useState } from 'preact/hooks';
 import { roomStore } from '../lib/room-store';
 import {
@@ -23,7 +24,6 @@ import { RoomDashboard } from '../components/room/RoomDashboard';
 import { RoomTasks } from '../components/room/RoomTasks';
 import { RoomAgentContextStrip } from '../components/room/RoomAgentContextStrip';
 import ChatContainer from './ChatContainer';
-import { GoalsEditor, RoomSettings, RoomAgents } from '../components/room';
 import type { CreateGoalFormData } from '../components/room/GoalsEditor';
 import { TaskViewToggle } from '../components/room/TaskViewToggle';
 import { MissionDetail } from '../components/room/MissionDetail';
@@ -32,6 +32,17 @@ import { Button } from '../components/ui/Button';
 import { MobileMenuButton } from '../components/ui/MobileMenuButton';
 import { toast } from '../lib/toast';
 import { cn } from '../lib/utils';
+
+// Lazy-loaded tab components (code-split into separate chunks)
+const GoalsEditor = lazy(() =>
+	import('../components/room/GoalsEditor').then((m) => ({ default: m.GoalsEditor }))
+);
+const RoomAgents = lazy(() =>
+	import('../components/room/RoomAgents').then((m) => ({ default: m.RoomAgents }))
+);
+const RoomSettings = lazy(() =>
+	import('../components/room/RoomSettings').then((m) => ({ default: m.RoomSettings }))
+);
 
 type RoomTab = 'chat' | 'overview' | 'tasks' | 'agents' | 'goals' | 'settings';
 
@@ -288,43 +299,67 @@ export default function Room({ roomId, sessionViewId, taskViewId, missionViewId 
 							)}
 							{activeTab === 'agents' && (
 								<div class="h-full overflow-y-auto">
-									<RoomAgents room={room} />
+									<Suspense
+										fallback={
+											<div class="flex items-center justify-center h-32">
+												<Skeleton width="200px" height={24} />
+											</div>
+										}
+									>
+										<RoomAgents room={room} />
+									</Suspense>
 								</div>
 							)}
 							{activeTab === 'goals' && (
 								<div class="h-full overflow-y-auto">
-									<GoalsEditor
-										roomId={roomId}
-										goals={roomStore.goals.value}
-										tasks={roomStore.tasks.value}
-										onTaskClick={(taskId) => navigateToRoomTask(roomId, taskId)}
-										onGoalClick={(goalId) => navigateToRoomMission(roomId, goalId)}
-										onCreateGoal={handleCreateGoal}
-										onUpdateGoal={handleUpdateGoal}
-										onDeleteGoal={handleDeleteGoal}
-										onLinkTask={handleLinkTaskToGoal}
-										isLoading={roomStore.goalsLoading.value}
-										autoCompletedNotifications={roomStore.autoCompletedNotifications.value}
-										onDismissNotification={(taskId) => roomStore.dismissAutoCompleted(taskId)}
-										onListExecutions={(goalId) => roomStore.listExecutions(goalId)}
-										onTriggerNow={async (goalId) => {
-											await roomStore.triggerNow(goalId);
-										}}
-										onScheduleNext={async (goalId, nextRunAt) => {
-											await roomStore.scheduleNext(goalId, nextRunAt);
-										}}
-									/>
+									<Suspense
+										fallback={
+											<div class="flex items-center justify-center h-32">
+												<Skeleton width="200px" height={24} />
+											</div>
+										}
+									>
+										<GoalsEditor
+											roomId={roomId}
+											goals={roomStore.goals.value}
+											tasks={roomStore.tasks.value}
+											onTaskClick={(taskId) => navigateToRoomTask(roomId, taskId)}
+											onGoalClick={(goalId) => navigateToRoomMission(roomId, goalId)}
+											onCreateGoal={handleCreateGoal}
+											onUpdateGoal={handleUpdateGoal}
+											onDeleteGoal={handleDeleteGoal}
+											onLinkTask={handleLinkTaskToGoal}
+											isLoading={roomStore.goalsLoading.value}
+											autoCompletedNotifications={roomStore.autoCompletedNotifications.value}
+											onDismissNotification={(taskId) => roomStore.dismissAutoCompleted(taskId)}
+											onListExecutions={(goalId) => roomStore.listExecutions(goalId)}
+											onTriggerNow={async (goalId) => {
+												await roomStore.triggerNow(goalId);
+											}}
+											onScheduleNext={async (goalId, nextRunAt) => {
+												await roomStore.scheduleNext(goalId, nextRunAt);
+											}}
+										/>
+									</Suspense>
 								</div>
 							)}
 							{activeTab === 'settings' && (
 								<div class="h-full overflow-y-auto">
-									<RoomSettings
-										room={room}
-										onSave={(params) => roomStore.updateSettings(params)}
-										onArchive={handleArchiveRoom}
-										onDelete={handleDeleteRoom}
-										isLoading={roomStore.loading.value}
-									/>
+									<Suspense
+										fallback={
+											<div class="flex items-center justify-center h-32">
+												<Skeleton width="200px" height={24} />
+											</div>
+										}
+									>
+										<RoomSettings
+											room={room}
+											onSave={(params) => roomStore.updateSettings(params)}
+											onArchive={handleArchiveRoom}
+											onDelete={handleDeleteRoom}
+											isLoading={roomStore.loading.value}
+										/>
+									</Suspense>
 								</div>
 							)}
 							{/* Task slide-over: overlays tab content, keeps header/tabs accessible */}

--- a/packages/web/src/islands/__tests__/Room.test.tsx
+++ b/packages/web/src/islands/__tests__/Room.test.tsx
@@ -16,7 +16,6 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup, screen, fireEvent, act } from '@testing-library/preact';
-import { waitFor } from '@testing-library/preact';
 import { signal } from '@preact/signals';
 import { currentRoomAgentActiveSignal, currentRoomActiveTabSignal } from '../../lib/signals';
 
@@ -444,28 +443,28 @@ describe('Room', () => {
 	});
 
 	describe('Lazy loading', () => {
-		it('GoalsEditor, RoomAgents, and RoomSettings are not in the static import graph', async () => {
+		it('lazy-loaded tab components resolve after dynamic import', async () => {
 			// Verify that navigating to each lazy tab resolves the component
-			// via dynamic import (the mock ensures it resolves synchronously)
+			// via dynamic import (the mock ensures it resolves synchronously within act)
 			currentRoomActiveTabSignal.value = 'goals';
 			await act(async () => {
 				render(<Room roomId={roomId} />);
 			});
-			expect(screen.getByTestId('goals-editor')).toBeTruthy();
+			expect(await screen.findByTestId('goals-editor')).toBeTruthy();
 
 			cleanup();
 			currentRoomActiveTabSignal.value = 'agents';
 			await act(async () => {
 				render(<Room roomId={roomId} />);
 			});
-			expect(screen.getByTestId('room-agents')).toBeTruthy();
+			expect(await screen.findByTestId('room-agents')).toBeTruthy();
 
 			cleanup();
 			currentRoomActiveTabSignal.value = 'settings';
 			await act(async () => {
 				render(<Room roomId={roomId} />);
 			});
-			expect(screen.getByTestId('room-settings')).toBeTruthy();
+			expect(await screen.findByTestId('room-settings')).toBeTruthy();
 		});
 
 		it('RoomDashboard and RoomTasks render without Suspense (eagerly loaded)', () => {

--- a/packages/web/src/islands/__tests__/Room.test.tsx
+++ b/packages/web/src/islands/__tests__/Room.test.tsx
@@ -9,10 +9,14 @@
  *
  * Tab state is driven by currentRoomActiveTabSignal (single source of truth).
  * Tab clicks delegate to navigateToRoomTab which updates both the URL and the signal.
+ *
+ * GoalsEditor, RoomAgents, and RoomSettings are lazy-loaded via preact/compat lazy().
+ * Tests mock the individual module paths (not the barrel) so that lazy() resolves correctly.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup, screen, fireEvent, act } from '@testing-library/preact';
+import { waitFor } from '@testing-library/preact';
 import { signal } from '@preact/signals';
 import { currentRoomAgentActiveSignal, currentRoomActiveTabSignal } from '../../lib/signals';
 
@@ -170,9 +174,16 @@ vi.mock('../../components/room/RoomDashboard', () => ({
 	RoomDashboard: () => <div data-testid="room-dashboard">RoomDashboard</div>,
 }));
 
-vi.mock('../../components/room', () => ({
+// Mock individual component paths (not the barrel) so lazy() resolves correctly
+vi.mock('../../components/room/GoalsEditor', () => ({
 	GoalsEditor: () => <div data-testid="goals-editor">GoalsEditor</div>,
+}));
+
+vi.mock('../../components/room/RoomSettings', () => ({
 	RoomSettings: () => <div data-testid="room-settings">RoomSettings</div>,
+}));
+
+vi.mock('../../components/room/RoomAgents', () => ({
 	RoomAgents: () => <div data-testid="room-agents">RoomAgents</div>,
 }));
 
@@ -322,25 +333,34 @@ describe('Room', () => {
 			expect(screen.queryByTestId('room-dashboard')).toBeNull();
 		});
 
-		it('renders Missions tab content when currentRoomActiveTabSignal is "goals"', () => {
+		it('renders Missions tab content when currentRoomActiveTabSignal is "goals"', async () => {
 			currentRoomActiveTabSignal.value = 'goals';
-			render(<Room roomId={roomId} />);
+			await act(async () => {
+				render(<Room roomId={roomId} />);
+			});
 
-			expect(screen.getByTestId('goals-editor')).toBeTruthy();
+			// GoalsEditor is lazy-loaded — wait for the dynamic import to resolve
+			expect(await screen.findByTestId('goals-editor')).toBeTruthy();
 		});
 
-		it('renders Settings tab content when currentRoomActiveTabSignal is "settings"', () => {
+		it('renders Settings tab content when currentRoomActiveTabSignal is "settings"', async () => {
 			currentRoomActiveTabSignal.value = 'settings';
-			render(<Room roomId={roomId} />);
+			await act(async () => {
+				render(<Room roomId={roomId} />);
+			});
 
-			expect(screen.getByTestId('room-settings')).toBeTruthy();
+			// RoomSettings is lazy-loaded — wait for the dynamic import to resolve
+			expect(await screen.findByTestId('room-settings')).toBeTruthy();
 		});
 
-		it('renders Agents tab content when currentRoomActiveTabSignal is "agents"', () => {
+		it('renders Agents tab content when currentRoomActiveTabSignal is "agents"', async () => {
 			currentRoomActiveTabSignal.value = 'agents';
-			render(<Room roomId={roomId} />);
+			await act(async () => {
+				render(<Room roomId={roomId} />);
+			});
 
-			expect(screen.getByTestId('room-agents')).toBeTruthy();
+			// RoomAgents is lazy-loaded — wait for the dynamic import to resolve
+			expect(await screen.findByTestId('room-agents')).toBeTruthy();
 		});
 
 		it('calls navigateToRoomTab when a tab is clicked', () => {
@@ -420,6 +440,45 @@ describe('Room', () => {
 			render(<Room roomId={roomId} />);
 
 			expect(screen.getByText('Room not found')).toBeTruthy();
+		});
+	});
+
+	describe('Lazy loading', () => {
+		it('GoalsEditor, RoomAgents, and RoomSettings are not in the static import graph', async () => {
+			// Verify that navigating to each lazy tab resolves the component
+			// via dynamic import (the mock ensures it resolves synchronously)
+			currentRoomActiveTabSignal.value = 'goals';
+			await act(async () => {
+				render(<Room roomId={roomId} />);
+			});
+			expect(screen.getByTestId('goals-editor')).toBeTruthy();
+
+			cleanup();
+			currentRoomActiveTabSignal.value = 'agents';
+			await act(async () => {
+				render(<Room roomId={roomId} />);
+			});
+			expect(screen.getByTestId('room-agents')).toBeTruthy();
+
+			cleanup();
+			currentRoomActiveTabSignal.value = 'settings';
+			await act(async () => {
+				render(<Room roomId={roomId} />);
+			});
+			expect(screen.getByTestId('room-settings')).toBeTruthy();
+		});
+
+		it('RoomDashboard and RoomTasks render without Suspense (eagerly loaded)', () => {
+			// Overview tab — RoomDashboard is eagerly loaded
+			currentRoomActiveTabSignal.value = 'overview';
+			render(<Room roomId={roomId} />);
+			expect(screen.getByTestId('room-dashboard')).toBeTruthy();
+
+			cleanup();
+			// Tasks tab — RoomTasks is eagerly loaded
+			currentRoomActiveTabSignal.value = 'tasks';
+			render(<Room roomId={roomId} />);
+			expect(screen.getByTestId('room-tasks')).toBeTruthy();
 		});
 	});
 });


### PR DESCRIPTION
Code-split GoalsEditor, RoomAgents, and RoomSettings using Preact's `lazy()` + `Suspense`. These components now load on demand when their tabs are activated instead of being included in the main bundle.

**Changes:**
- `Room.tsx`: Replace static imports with `lazy()` dynamic imports wrapped in `<Suspense>` with skeleton fallbacks
- `components/room/index.ts`: Remove barrel re-exports for GoalsEditor, RoomSettings, RoomAgents (sub-components kept for MissionDetail)
- `Room.test.tsx`: Mock individual file paths instead of barrel; use `findByTestId` for lazy-loaded tab tests

**Build results:**
- `RoomAgents-zfxL-wfS.js` — 16.78 kB (separate chunk)
- `RoomSettings-44K0Ca_a.js` — 22.33 kB (separate chunk)
- GoalsEditor stays in main bundle due to static imports from MissionDetail (acceptable — MissionDetail is a slide-over available on any tab)

RoomDashboard and RoomTasks remain eagerly loaded (primary entry points).