### PR TITLE
fix: re-fetch execution history on goal update (MissionDetail reactivity)

### DIFF
--- a/packages/web/src/hooks/__tests__/useMissionDetailData.test.ts
+++ b/packages/web/src/hooks/__tests__/useMissionDetailData.test.ts
@@ -337,6 +337,33 @@ describe('useMissionDetailData — execution loading', () => {
 
 		expect(result.current.executions).toBeNull();
 	});
+
+	it('re-fetches executions when goal updatedAt changes (new execution completed)', async () => {
+		const initialExecs = [makeExecution()];
+		const updatedExecs = [makeExecution(), { ...makeExecution(), executionNumber: 2 }];
+		mockListExecutions.mockResolvedValueOnce(initialExecs).mockResolvedValueOnce(updatedExecs);
+
+		const baseTime = Date.now();
+		mockGoalsSignal.value = [makeGoal({ missionType: 'recurring', updatedAt: baseTime })];
+		mockTasksSignal.value = [];
+
+		const { result } = renderHook(() => useMissionDetailData('room-1', 'goal-1'));
+
+		await waitFor(() => {
+			expect(result.current.executions).toEqual(initialExecs);
+		});
+		expect(mockListExecutions).toHaveBeenCalledTimes(1);
+
+		// Simulate execution completion: daemon updates goal (nextRunAt, updatedAt, etc.)
+		act(() => {
+			mockGoalsSignal.value = [makeGoal({ missionType: 'recurring', updatedAt: baseTime + 5000 })];
+		});
+
+		await waitFor(() => {
+			expect(result.current.executions).toEqual(updatedExecs);
+		});
+		expect(mockListExecutions).toHaveBeenCalledTimes(2);
+	});
 });
 
 describe('useMissionDetailData — availableStatusActions', () => {

--- a/packages/web/src/hooks/useMissionDetailData.ts
+++ b/packages/web/src/hooks/useMissionDetailData.ts
@@ -68,8 +68,13 @@ export function useMissionDetailData(roomId: string, goalId: string): UseMission
 	// (URL change) and goal.value?.missionType so the effect re-runs when:
 	//   1. The goal arrives asynchronously after mount (null → RoomGoal).
 	//   2. The goal's missionType changes to/from 'recurring'.
+	// We also depend on goal.value?.updatedAt so new executions (which update
+	// the goal's nextRunAt/consecutiveFailures/updatedAt via the daemon) cause
+	// a re-fetch of the execution history, satisfying the LiveQuery reactivity
+	// requirement for execution completion events.
 	const goalMissionType = goal.value?.missionType;
 	const resolvedGoalId = goal.value?.id;
+	const goalUpdatedAt = goal.value?.updatedAt;
 	useEffect(() => {
 		const g = goal.value;
 		if (!g || g.missionType !== 'recurring') return;
@@ -96,8 +101,10 @@ export function useMissionDetailData(roomId: string, goalId: string): UseMission
 		};
 		// goalId covers URL changes; resolvedGoalId+goalMissionType cover async goal arrival
 		// and missionType changes (e.g. goal arriving from null → recurring).
+		// goalUpdatedAt triggers a re-fetch when the daemon updates the goal after
+		// an execution completes (changing nextRunAt, consecutiveFailures, etc.).
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [goalId, resolvedGoalId, goalMissionType]);
+	}, [goalId, resolvedGoalId, goalMissionType, goalUpdatedAt]);
 
 	// Derived available status actions based on current goal status.
 	const availableStatusActions = useComputed<AvailableStatusAction[]>(() => {


### PR DESCRIPTION
Fixes the final LiveQuery reactivity gap in the MissionDetail feature: execution history now re-fetches automatically when a recurring mission execution completes.

**Problem:** `useMissionDetailData` loaded execution history imperatively via `useEffect` with deps `[goalId, resolvedGoalId, goalMissionType]`. When an execution completed, the daemon updated the goal record (`nextRunAt`, `consecutiveFailures`, `updatedAt`) which flowed through the existing `goals.byRoom` LiveQuery signal — but `updatedAt` was not a dependency, so the execution list stayed stale until page reload.

**Fix:** Add `goalUpdatedAt` (`goal.value?.updatedAt`) as a dependency to the effect. No backend changes needed — the goal signal already updates reactively via the LiveQuery subscription.

**Test:** New unit test verifies two `listExecutions` calls when `updatedAt` advances (simulating post-execution goal update).