### PR TITLE
fix: refresh context usage after /compact completes

### DIFF
--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -854,12 +854,25 @@ export class SDKMessageHandler {
 	 * Handle compact boundary message (compaction completed)
 	 */
 	private async handleCompactBoundary(message: SDKMessage): Promise<void> {
-		const { stateManager } = this.ctx;
+		const { stateManager, messageQueue } = this.ctx;
 
 		if (!isSDKCompactBoundary(message)) return;
 
 		// Clear isCompacting flag on processing state (flows through state.session)
 		await stateManager.setCompacting(false);
+
+		// Immediately queue /context to refresh context usage after compaction.
+		// Without this, the UI shows stale pre-compact values until the next
+		// regular turn's result message triggers the auto-queue (which may be
+		// skipped for zero-token compact results).
+		if (this.ctx.contextAutoQueueEnabled) {
+			const contextMessageId = generateUUID();
+			this.internalContextCommandIds.add(contextMessageId);
+			messageQueue.enqueueWithId(contextMessageId, '/context', true).catch((error) => {
+				this.internalContextCommandIds.delete(contextMessageId);
+				this.logger.warn('Failed to queue /context after compact:', error);
+			});
+		}
 	}
 
 	/**

--- a/packages/daemon/tests/unit/agent/sdk-message-handler.test.ts
+++ b/packages/daemon/tests/unit/agent/sdk-message-handler.test.ts
@@ -790,6 +790,58 @@ describe('SDKMessageHandler', () => {
 
 			expect(setCompactingSpy).toHaveBeenCalledWith(false);
 		});
+
+		it('should queue /context after compact to refresh context usage', async () => {
+			const enqueueWithIdSpy = mock(async () => {});
+			mockContext.messageQueue = {
+				...mockMessageQueue,
+				enqueueWithId: enqueueWithIdSpy,
+			} as unknown as MessageQueue;
+
+			const freshHandler = new SDKMessageHandler(mockContext);
+
+			const message: SDKMessage = {
+				type: 'system',
+				subtype: 'compact_boundary',
+				uuid: 'test-uuid',
+				compact_metadata: {
+					trigger: 'auto',
+					pre_tokens: 50000,
+				},
+			} as unknown as SDKMessage;
+
+			await freshHandler.handleMessage(message);
+
+			expect(setCompactingSpy).toHaveBeenCalledWith(false);
+			expect(enqueueWithIdSpy).toHaveBeenCalledTimes(1);
+			expect(enqueueWithIdSpy).toHaveBeenCalledWith(expect.any(String), '/context', true);
+		});
+
+		it('should not queue /context when contextAutoQueueEnabled is false', async () => {
+			mockContext.contextAutoQueueEnabled = false;
+			const enqueueWithIdSpy = mock(async () => {});
+			mockContext.messageQueue = {
+				...mockMessageQueue,
+				enqueueWithId: enqueueWithIdSpy,
+			} as unknown as MessageQueue;
+
+			const freshHandler = new SDKMessageHandler(mockContext);
+
+			const message: SDKMessage = {
+				type: 'system',
+				subtype: 'compact_boundary',
+				uuid: 'test-uuid',
+				compact_metadata: {
+					trigger: 'auto',
+					pre_tokens: 50000,
+				},
+			} as unknown as SDKMessage;
+
+			await freshHandler.handleMessage(message);
+
+			expect(setCompactingSpy).toHaveBeenCalledWith(false);
+			expect(enqueueWithIdSpy).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('circuit breaker integration', () => {


### PR DESCRIPTION
## Summary
- Queue an internal `/context` command immediately after receiving a `compact_boundary` message, so the UI refreshes context usage stats right after compaction
- Previously, context usage only refreshed on the next non-zero-token `result` message, which could be skipped (compact may produce zero tokens) or delayed, leaving stale pre-compact values in the UI

## Test plan
- [x] Unit tests: 2 new tests in `sdk-message-handler.test.ts` — verifies `/context` is queued after compact and skipped when `contextAutoQueueEnabled` is false
- [x] All 50 existing SDK message handler tests pass
- [x] Lint, format, typecheck, knip all pass