### PR TITLE
Fix iOS Safari safe area gap + space bottom tab bar

### DIFF
--- a/packages/daemon/src/lib/providers/glm-provider.ts
+++ b/packages/daemon/src/lib/providers/glm-provider.ts
@@ -55,6 +55,17 @@ export class GlmProvider implements Provider {
 			available: true,
 		},
 		{
+			id: 'glm-5.1',
+			name: 'GLM-5.1',
+			alias: 'glm-5.1',
+			family: 'glm',
+			provider: 'glm',
+			contextWindow: 200000,
+			description: 'GLM-5.1 · Enhanced reasoning and instruction following',
+			releaseDate: '2026-04-08',
+			available: true,
+		},
+		{
 			id: 'glm-5-turbo',
 			name: 'GLM-5-Turbo',
 			alias: 'glm-5-turbo',

--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -152,6 +152,11 @@ export function buildCustomAgentTaskMessage(config: CustomAgentConfig): string {
 		sections.push(space.instructions);
 	}
 
+	if (workflow?.instructions) {
+		sections.push(`\n## Workflow Instructions\n`);
+		sections.push(workflow.instructions);
+	}
+
 	if (task.prUrl) {
 		sections.push(`\n## Existing Pull Request\n`);
 		sections.push(`**PR URL:** ${task.prUrl}`);

--- a/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
@@ -211,7 +211,13 @@ export class SpaceWorkflowManager {
 		}
 
 		for (let i = 0; i < nodes.length; i++) {
-			this.validateNodeAgentRef(spaceId, nodes[i], i);
+			const node = nodes[i];
+			if (node.name && node.name.trim().toLowerCase() === 'human') {
+				throw new WorkflowValidationError(
+					`node[${i}]: "human" is a reserved keyword and cannot be used as a node name`
+				);
+			}
+			this.validateNodeAgentRef(spaceId, node, i);
 		}
 	}
 
@@ -243,6 +249,11 @@ export class SpaceWorkflowManager {
 			if (!entry.name || !entry.name.trim()) {
 				throw new WorkflowValidationError(
 					`node[${index}].agents[${j}]: name must be a non-empty string`
+				);
+			}
+			if (entry.name.trim().toLowerCase() === 'human') {
+				throw new WorkflowValidationError(
+					`node[${index}].agents[${j}]: "human" is a reserved keyword and cannot be used as an agent name`
 				);
 			}
 			if (seenNames.has(entry.name)) {

--- a/packages/daemon/src/lib/space/runtime/gate-evaluator.ts
+++ b/packages/daemon/src/lib/space/runtime/gate-evaluator.ts
@@ -105,6 +105,13 @@ export function validateGateFields(fields: unknown, path = 'fields'): string[] {
 
 		if (!Array.isArray(f.writers)) {
 			errors.push(`${fp}.writers: expected array, got ${typeof f.writers}`);
+		} else if (
+			f.writers.includes('human') &&
+			f.writers.some((w: unknown) => typeof w === 'string' && w !== 'human')
+		) {
+			errors.push(
+				`${fp}.writers: "human" is a reserved keyword and must be the sole writer — cannot be mixed with other writers`
+			);
 		}
 
 		// Validate check

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -277,6 +277,7 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 	gates: [
 		{
 			id: 'code-ready-gate',
+			label: 'PR Ready',
 			description: 'Coder has opened an active, mergeable pull request',
 			fields: [
 				{
@@ -406,6 +407,7 @@ export const RESEARCH_WORKFLOW: SpaceWorkflow = {
 	gates: [
 		{
 			id: 'research-ready-gate',
+			label: 'PR Ready',
 			description: 'Research agent has opened an active, mergeable pull request',
 			fields: [
 				{
@@ -680,6 +682,7 @@ export const FULL_CYCLE_CODING_WORKFLOW: SpaceWorkflow = {
 	gates: [
 		{
 			id: 'plan-pr-gate',
+			label: 'PR Ready',
 			description: 'Planning PR is open and mergeable so plan review can start.',
 			fields: [{ name: 'pr_url', type: 'string', writers: ['*'], check: { op: 'exists' } }],
 			script: {
@@ -691,15 +694,16 @@ export const FULL_CYCLE_CODING_WORKFLOW: SpaceWorkflow = {
 		},
 		{
 			id: 'plan-approval-gate',
-			description: 'Plan has been reviewed and approved by the plan reviewer',
+			label: 'Human',
+			description: 'Plan has been reviewed and approved by a human.',
 			fields: [
 				{
 					name: 'approved',
 					type: 'boolean',
-					// 'human' makes this a human-approval gate (UI shows waiting_human state
-					// and the Reject/Approve buttons). 'reviewer' allows the Plan Review AI
-					// agent to also approve the plan in fully-automated runs.
-					writers: ['reviewer', 'human'],
+					// 'human' is a reserved writer keyword — makes this a human-approval gate
+					// (UI shows waiting_human state and the Approve/Reject buttons).
+					// Human approval gates must use writers: ['human'] exclusively.
+					writers: ['human'],
 					check: { op: '==', value: true },
 				},
 			],
@@ -707,6 +711,7 @@ export const FULL_CYCLE_CODING_WORKFLOW: SpaceWorkflow = {
 		},
 		{
 			id: 'code-pr-gate',
+			label: 'PR Ready',
 			description:
 				'Code has been implemented and a pull request has been opened. ' +
 				'resetOnCycle is false: the same PR is updated across fix cycles — coder pushes ' +
@@ -716,6 +721,7 @@ export const FULL_CYCLE_CODING_WORKFLOW: SpaceWorkflow = {
 		},
 		{
 			id: 'review-votes-gate',
+			label: 'Votes',
 			description:
 				'All three reviewers have approved the code changes. ' +
 				'Agents must read the current votes map first, add their entry, then write the full map back ' +
@@ -885,6 +891,7 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
 	gates: [
 		{
 			id: 'code-pr-gate',
+			label: 'PR Ready',
 			description: 'Coding PR is open and mergeable for review.',
 			fields: [{ name: 'pr_url', type: 'string', writers: ['*'], check: { op: 'exists' } }],
 			script: {
@@ -896,6 +903,7 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
 		},
 		{
 			id: 'review-approval-gate',
+			label: 'Review',
 			description: 'Reviewer approved the PR for QA.',
 			fields: [
 				{

--- a/packages/daemon/tests/unit/1-core/providers/glm-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/glm-provider.test.ts
@@ -72,8 +72,8 @@ describe('GlmProvider', () => {
 
 			const models = await provider.getModels();
 
-			expect(models).toHaveLength(3);
-			expect(models.map((m) => m.id)).toEqual(['glm-5', 'glm-5-turbo', 'glm-4.7']);
+			expect(models).toHaveLength(4);
+			expect(models.map((m) => m.id)).toEqual(['glm-5', 'glm-5.1', 'glm-5-turbo', 'glm-4.7']);
 		});
 
 		it('should return empty array when API key is not available', async () => {
@@ -210,8 +210,13 @@ describe('GlmProvider', () => {
 
 	describe('static models', () => {
 		it('should have static models defined', () => {
-			expect(GlmProvider.MODELS).toHaveLength(3);
-			expect(GlmProvider.MODELS.map((m) => m.id)).toEqual(['glm-5', 'glm-5-turbo', 'glm-4.7']);
+			expect(GlmProvider.MODELS).toHaveLength(4);
+			expect(GlmProvider.MODELS.map((m) => m.id)).toEqual([
+				'glm-5',
+				'glm-5.1',
+				'glm-5-turbo',
+				'glm-4.7',
+			]);
 		});
 
 		it('should have correct glm-5-turbo model definition', () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/reference-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/reference-handlers.test.ts
@@ -472,19 +472,6 @@ describe('reference.resolve handler', () => {
 			const filePath = join(testWorkspace, 'hello.txt');
 			await writeFile(filePath, 'Hello world');
 
-			// DEBUG: verify file and workspace exist
-			const { stat } = await import('node:fs/promises');
-			expect(testWorkspace).toBeTruthy();
-			expect(testWorkspace.length).toBeGreaterThan(0);
-			const wsStat = await stat(testWorkspace);
-			expect(wsStat.isDirectory()).toBe(true);
-			const fileStat = await stat(filePath);
-			expect(fileStat.size).toBe(11);
-			// eslint-disable-next-line no-console
-			(globalThis as unknown as Record<string, unknown>).__originalConsole.log(
-				`DEBUG file resolution: testWorkspace="${testWorkspace}" filePath="${filePath}" wsOK=true fileOK=true`
-			);
-
 			const { hub, handlers } = createMockMessageHub();
 			const deps: ReferenceHandlerDeps = {
 				sessionManager: makeSessionManager({ workspacePath: testWorkspace }) as never,
@@ -507,10 +494,6 @@ describe('reference.resolve handler', () => {
 				};
 			};
 
-			// eslint-disable-next-line no-console
-			(globalThis as unknown as Record<string, unknown>).__originalConsole.log(
-				`DEBUG result: ${JSON.stringify(result)}`
-			);
 			expect(result.resolved).not.toBeNull();
 			expect(result.resolved!.type).toBe('file');
 			expect(result.resolved!.id).toBe('hello.txt');

--- a/packages/daemon/tests/unit/5-space/space/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/space/built-in-workflows.test.ts
@@ -444,11 +444,12 @@ describe('FULL_CYCLE_CODING_WORKFLOW template', () => {
 		expect(gate.resetOnCycle).toBe(false);
 	});
 
-	test('plan-approval-gate has boolean == true field with reviewer writer', () => {
+	test('plan-approval-gate has boolean == true field with exclusive human writer', () => {
 		const gate = FULL_CYCLE_CODING_WORKFLOW.gates!.find((g) => g.id === 'plan-approval-gate')!;
 		expect(gate.fields[0].name).toBe('approved');
 		expect(gate.fields[0].check).toMatchObject({ op: '==', value: true });
-		expect(gate.fields[0].writers).toContain('reviewer');
+		expect(gate.fields[0].writers).toEqual(['human']);
+		expect(gate.label).toBe('Human');
 		expect(gate.resetOnCycle).toBe(true);
 	});
 
@@ -1356,9 +1357,8 @@ describe('seedBuiltInWorkflows()', () => {
 			.find((w) => w.name === FULL_CYCLE_CODING_WORKFLOW.name)!;
 		const gate = wf.gates!.find((g) => g.id === 'plan-approval-gate')!;
 		const approvedField = gate.fields.find((f) => f.name === 'approved')!;
-		expect(approvedField.writers).toContain('human');
-		// 'reviewer' is also present so the Plan Review AI agent can also approve in automated runs
-		expect(approvedField.writers).toContain('reviewer');
+		// 'human' must be the sole writer — human approval gates are exclusive
+		expect(approvedField.writers).toEqual(['human']);
 	});
 
 	// ─── getBuiltInWorkflows ordering ────────────────────────────────────────

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -199,7 +199,7 @@ export function App() {
 				<ContextPanel />
 
 				{/* Main Content — bottom padding matches actual BottomTabBar height via --bottom-bar-height */}
-				<div class="flex-1 flex flex-col overflow-hidden pb-bottom-bar min-w-0">
+				<div class="flex-1 flex flex-col overflow-hidden pb-bottom-bar pb-safe min-w-0">
 					<MainContent />
 				</div>
 			</div>

--- a/packages/web/src/components/space/ReadOnlyWorkflowCanvas.tsx
+++ b/packages/web/src/components/space/ReadOnlyWorkflowCanvas.tsx
@@ -5,6 +5,10 @@
  * Shows the same visual style as the full editor but with no editing affordances.
  *
  * Used in SpaceTaskPane to replace the old custom SVG WorkflowCanvas.
+ *
+ * When a gate icon in `waiting_human` state is clicked, a popup appears with
+ * "View Artifacts", "Approve", and "Reject" buttons. "View Artifacts" opens a
+ * full overlay containing GateArtifactsView.
  */
 
 import { useRef, useEffect, useState, useCallback } from 'preact/hooks';
@@ -12,24 +16,39 @@ import { WorkflowCanvas } from './visual-editor/WorkflowCanvas';
 import { CanvasToolbar } from './visual-editor/CanvasToolbar';
 import { useRuntimeCanvasData } from './useRuntimeCanvasData';
 import { ChannelInfoPanel } from './ChannelInfoPanel';
+import { GateArtifactsView } from './GateArtifactsView';
+import { connectionManager } from '../../lib/connection-manager';
 import { cn } from '../../lib/utils';
 
 interface ReadOnlyWorkflowCanvasProps {
 	workflowId: string;
 	runId?: string | null;
+	spaceId?: string;
 	onNodeClick?: (nodeId: string, nodeName: string, agentNames: string[]) => void;
 	class?: string;
+}
+
+interface GatePopupState {
+	gateId: string;
+	x: number;
+	y: number;
 }
 
 export function ReadOnlyWorkflowCanvas({
 	workflowId,
 	runId,
+	spaceId,
 	onNodeClick,
 	class: className,
 }: ReadOnlyWorkflowCanvasProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [containerSize, setContainerSize] = useState({ width: 800, height: 600 });
 	const [selectedChannelId, setSelectedChannelId] = useState<string | null>(null);
+
+	// Gate popup / overlay state
+	const [gatePopup, setGatePopup] = useState<GatePopupState | null>(null);
+	const [artifactsOverlay, setArtifactsOverlay] = useState<{ gateId: string } | null>(null);
+	const [approving, setApproving] = useState(false);
 
 	const {
 		nodeData,
@@ -38,6 +57,7 @@ export function ReadOnlyWorkflowCanvas({
 		viewportState,
 		setViewportState,
 		gateDataLoading,
+		gateDataMap,
 	} = useRuntimeCanvasData(workflowId, runId ?? null);
 
 	// Track container dimensions for the toolbar's fit-to-view
@@ -63,8 +83,9 @@ export function ReadOnlyWorkflowCanvas({
 
 	const handleNodeSelect = useCallback(
 		(stepId: string | null) => {
-			// Clicking a node clears channel selection
+			// Clicking a node clears channel selection and gate popup
 			setSelectedChannelId(null);
+			setGatePopup(null);
 			if (!stepId || !onNodeClick) return;
 			// stepId is localId — find the persisted node ID, name, and agent names
 			const nodeEntry = nodeData.find((n) => n.step.localId === stepId);
@@ -78,6 +99,53 @@ export function ReadOnlyWorkflowCanvas({
 
 	const handleChannelSelect = useCallback((channelId: string | null) => {
 		setSelectedChannelId(channelId);
+		setGatePopup(null);
+	}, []);
+
+	// Gate icon click — open action popup
+	const handleGateClick = useCallback((gateId: string, event: MouseEvent) => {
+		const container = containerRef.current;
+		if (!container) return;
+		const rect = container.getBoundingClientRect();
+		setGatePopup({
+			gateId,
+			x: event.clientX - rect.left,
+			y: event.clientY - rect.top,
+		});
+		setSelectedChannelId(null);
+	}, []);
+
+	// Direct approve/reject from popup
+	const handlePopupDecision = useCallback(
+		async (approved: boolean) => {
+			if (!gatePopup || !runId) return;
+			setApproving(true);
+			try {
+				const hub = connectionManager.getHubIfConnected();
+				if (!hub) return;
+				await hub.request('spaceWorkflowRun.approveGate', {
+					runId,
+					gateId: gatePopup.gateId,
+					approved,
+				});
+				setGatePopup(null);
+			} finally {
+				setApproving(false);
+			}
+		},
+		[gatePopup, runId]
+	);
+
+	// Open artifacts overlay from popup
+	const handleOpenArtifacts = useCallback(() => {
+		if (!gatePopup) return;
+		setArtifactsOverlay({ gateId: gatePopup.gateId });
+		setGatePopup(null);
+	}, [gatePopup]);
+
+	// Close artifacts overlay after decision
+	const handleArtifactsDecision = useCallback(() => {
+		setArtifactsOverlay(null);
 	}, []);
 
 	const selectedChannel = selectedChannelId
@@ -106,6 +174,7 @@ export function ReadOnlyWorkflowCanvas({
 					nodePositions={canvasNodePositions}
 					onNodeSelect={handleNodeSelect}
 					onChannelSelect={handleChannelSelect}
+					onGateClick={handleGateClick}
 					selectedChannelId={selectedChannelId}
 					readOnly
 				/>
@@ -124,7 +193,66 @@ export function ReadOnlyWorkflowCanvas({
 						onClose={() => setSelectedChannelId(null)}
 					/>
 				)}
+
+				{/* Gate action popup */}
+				{gatePopup && (
+					<div
+						class="absolute z-30"
+						style={{
+							left: `${gatePopup.x}px`,
+							top: `${gatePopup.y + 12}px`,
+						}}
+					>
+						<div class="bg-dark-800 border border-dark-600 rounded-lg shadow-xl p-2 space-y-2 min-w-[160px]">
+							<button
+								data-testid="view-artifacts-btn"
+								onClick={handleOpenArtifacts}
+								class="w-full text-left px-3 py-1.5 text-xs text-gray-200 hover:bg-dark-700 rounded transition-colors"
+							>
+								View Artifacts
+							</button>
+							<div class="flex gap-2">
+								<button
+									onClick={() => void handlePopupDecision(true)}
+									disabled={approving}
+									class="flex-1 px-2 py-1.5 text-xs font-medium rounded bg-green-900/40 text-green-300 border border-green-700/50 hover:bg-green-800/50 disabled:opacity-50 transition-colors"
+								>
+									Approve
+								</button>
+								<button
+									onClick={() => void handlePopupDecision(false)}
+									disabled={approving}
+									class="flex-1 px-2 py-1.5 text-xs font-medium rounded bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50 disabled:opacity-50 transition-colors"
+								>
+									Reject
+								</button>
+							</div>
+						</div>
+					</div>
+				)}
 			</div>
+
+			{/* Artifacts panel overlay */}
+			{artifactsOverlay && runId && (
+				<div
+					data-testid="artifacts-panel-overlay"
+					class="absolute inset-0 z-40 bg-black/50 flex items-center justify-center"
+					onClick={(e) => {
+						if (e.target === e.currentTarget) setArtifactsOverlay(null);
+					}}
+				>
+					<div class="w-full max-w-2xl max-h-[80vh] bg-dark-900 border border-dark-600 rounded-xl shadow-2xl overflow-hidden">
+						<GateArtifactsView
+							runId={runId}
+							gateId={artifactsOverlay.gateId}
+							spaceId={spaceId ?? ''}
+							gateData={gateDataMap.get(artifactsOverlay.gateId)}
+							onClose={() => setArtifactsOverlay(null)}
+							onDecision={handleArtifactsDecision}
+						/>
+					</div>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/packages/web/src/components/space/SpaceOverview.tsx
+++ b/packages/web/src/components/space/SpaceOverview.tsx
@@ -4,13 +4,14 @@
  * Overview dashboard showing:
  * - Runtime state indicator with pause/resume/stop/start controls (when available)
  * - Task stats summary (active, review, done counts)
- * - Recent activity feed (latest task updates)
+ * - Recent tasks feed (latest task updates)
+ * - Recent sessions (latest active sessions)
  */
 
 import { useState } from 'preact/hooks';
 import type { RuntimeState, SpaceTask } from '@neokai/shared';
 import { spaceStore } from '../../lib/space-store';
-import { navigateToSpaceTask } from '../../lib/router';
+import { navigateToSpaceTask, navigateToSpaceAgent } from '../../lib/router';
 import { cn, getRelativeTime } from '../../lib/utils';
 import { SpaceCreateTaskDialog } from './SpaceCreateTaskDialog';
 
@@ -98,7 +99,7 @@ function RuntimeControlBar({ state }: { state: RuntimeState }) {
 	);
 }
 
-// ─── Recent Activity ─────────────────────────────────────────────────────────
+// ─── Recent Tasks ─────────────────────────────────────────────────────────
 
 const STATUS_COLORS: Record<string, string> = {
 	in_progress: 'text-blue-400',
@@ -110,7 +111,7 @@ const STATUS_COLORS: Record<string, string> = {
 	archived: 'text-gray-600',
 };
 
-function RecentActivityItem({ task, onClick }: { task: SpaceTask; onClick?: () => void }) {
+function RecentTaskItem({ task, onClick }: { task: SpaceTask; onClick?: () => void }) {
 	const statusColor = STATUS_COLORS[task.status] ?? 'text-gray-400';
 
 	return (
@@ -146,6 +147,11 @@ export function SpaceOverview({ spaceId, onSelectTask }: SpaceOverviewProps) {
 	const tasks = spaceStore.tasks.value;
 	const runtimeState = spaceStore.runtimeState.value;
 
+	// Recent sessions — sorted by lastActiveAt, top 8 (computed before early returns)
+	const recentSessions = [...spaceStore.sessions.value]
+		.sort((a, b) => b.lastActiveAt - a.lastActiveAt)
+		.slice(0, 8);
+
 	if (loading) {
 		return (
 			<div class="flex h-full items-center justify-center">
@@ -172,7 +178,7 @@ export function SpaceOverview({ spaceId, onSelectTask }: SpaceOverviewProps) {
 		(t) => t.status === 'done' || t.status === 'cancelled' || t.status === 'archived'
 	);
 
-	// Recent activity — sorted by updatedAt, top 8
+	// Recent tasks — sorted by updatedAt, top 8
 	const recentTasks = [...tasks].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, 8);
 
 	const handleTaskClick =
@@ -204,12 +210,10 @@ export function SpaceOverview({ spaceId, onSelectTask }: SpaceOverviewProps) {
 				/>
 			</div>
 
-			{/* Recent Activity */}
+			{/* Recent Tasks */}
 			<div>
 				<div class="flex items-center justify-between mb-2 px-1">
-					<h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">
-						Recent Activity
-					</h3>
+					<h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Recent Tasks</h3>
 					<button
 						type="button"
 						onClick={() => setShowCreateTask(true)}
@@ -239,15 +243,49 @@ export function SpaceOverview({ spaceId, onSelectTask }: SpaceOverviewProps) {
 				) : (
 					<div class="rounded-xl border border-dark-700 bg-dark-900/50 divide-y divide-dark-700/50 overflow-hidden">
 						{recentTasks.map((task) => (
-							<RecentActivityItem
-								key={task.id}
-								task={task}
-								onClick={() => handleTaskClick(task.id)}
-							/>
+							<RecentTaskItem key={task.id} task={task} onClick={() => handleTaskClick(task.id)} />
 						))}
 					</div>
 				)}
 			</div>
+
+			{/* Recent Sessions */}
+			{recentSessions.length > 0 && (
+				<div>
+					<div class="flex items-center justify-between mb-2 px-1">
+						<h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">
+							Recent Sessions
+						</h3>
+						<button
+							type="button"
+							onClick={() => navigateToSpaceAgent(spaceId)}
+							class="flex items-center gap-1.5 rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-blue-500"
+						>
+							New Session
+						</button>
+					</div>
+					<div class="rounded-xl border border-dark-700 bg-dark-900/50 divide-y divide-dark-700/50 overflow-hidden">
+						{recentSessions.map((session) => (
+							<button
+								key={session.id}
+								type="button"
+								onClick={() => navigateToSpaceAgent(spaceId)}
+								class="w-full flex items-center gap-3 px-4 py-3 rounded-lg hover:bg-dark-800/60 transition-colors text-left group"
+							>
+								<div class="w-2 h-2 rounded-full flex-shrink-0 bg-indigo-400" />
+								<div class="flex-1 min-w-0">
+									<span class="text-sm text-gray-200 group-hover:text-gray-100 truncate block">
+										{session.title || 'Untitled Session'}
+									</span>
+								</div>
+								<span class="text-xs text-gray-500 flex-shrink-0 tabular-nums">
+									{getRelativeTime(session.lastActiveAt)}
+								</span>
+							</button>
+						))}
+					</div>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -476,6 +476,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 						<ReadOnlyWorkflowCanvas
 							workflowId={canvasWorkflowId}
 							runId={task.workflowRunId}
+							spaceId={spaceId}
 							onNodeClick={handleNodeClick}
 							class="h-full"
 						/>

--- a/packages/web/src/components/space/__tests__/SpaceOverview.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceOverview.test.tsx
@@ -12,6 +12,9 @@ let mockSpace: ReturnType<typeof signal<Space | null>>;
 let mockLoading: ReturnType<typeof signal<boolean>>;
 let mockTasks: ReturnType<typeof signal<SpaceTask[]>>;
 let mockRuntimeState: ReturnType<typeof signal<RuntimeState | null>>;
+let mockSessions: ReturnType<
+	typeof signal<{ id: string; title?: string; status: string; lastActiveAt: number }[]>
+>;
 
 vi.mock('../../../lib/space-store', () => ({
 	get spaceStore() {
@@ -20,18 +23,21 @@ vi.mock('../../../lib/space-store', () => ({
 			loading: mockLoading,
 			tasks: mockTasks,
 			runtimeState: mockRuntimeState,
+			sessions: mockSessions,
 		};
 	},
 }));
 
 vi.mock('../../../lib/router', () => ({
 	navigateToSpaceTask: vi.fn(),
+	navigateToSpaceAgent: vi.fn(),
 }));
 
 mockSpace = signal<Space | null>(null);
 mockLoading = signal(false);
 mockTasks = signal<SpaceTask[]>([]);
 mockRuntimeState = signal<RuntimeState | null>(null);
+mockSessions = signal([]);
 
 import { SpaceOverview } from '../SpaceOverview';
 
@@ -115,7 +121,7 @@ describe('SpaceOverview', () => {
 		expect(getByText('Done')).toBeTruthy();
 	});
 
-	it('renders recent activity with tasks sorted by updatedAt', () => {
+	it('renders recent tasks sorted by updatedAt', () => {
 		mockSpace.value = makeSpace();
 		const now = Date.now();
 		mockTasks.value = [
@@ -125,7 +131,7 @@ describe('SpaceOverview', () => {
 		];
 
 		const { getByText } = render(<SpaceOverview spaceId="space-1" />);
-		expect(getByText('Recent Activity')).toBeTruthy();
+		expect(getByText('Recent Tasks')).toBeTruthy();
 		expect(getByText('Task t1')).toBeTruthy();
 		expect(getByText('Task t2')).toBeTruthy();
 		expect(getByText('Task t3')).toBeTruthy();
@@ -178,7 +184,7 @@ describe('SpaceOverview', () => {
 		expect(queryByText('Stopped')).toBeNull();
 	});
 
-	it('limits recent activity to 8 tasks', () => {
+	it('limits recent tasks to 8', () => {
 		mockSpace.value = makeSpace();
 		const now = Date.now();
 		mockTasks.value = Array.from({ length: 10 }, (_, i) =>

--- a/packages/web/src/components/space/useRuntimeCanvasData.ts
+++ b/packages/web/src/components/space/useRuntimeCanvasData.ts
@@ -109,6 +109,8 @@ export interface RuntimeCanvasData {
 	setViewportState: (state: ViewportState) => void;
 	workflow: SpaceWorkflow | null;
 	gateDataLoading: boolean;
+	/** Gate data keyed by gateId — used by GateArtifactsView for PR link extraction. */
+	gateDataMap: Map<string, Record<string, unknown>>;
 }
 
 export function useRuntimeCanvasData(
@@ -283,6 +285,7 @@ export function useRuntimeCanvasData(
 				targetSide: edge.targetSide,
 				id: edge.id,
 				runtimeStatus,
+				gateId: forwardGateId,
 			};
 		});
 	}, [routedSemanticEdges, channels, endpointNodeIdLookup, gates, gateDataMap, runId]);
@@ -357,5 +360,6 @@ export function useRuntimeCanvasData(
 		setViewportState,
 		workflow,
 		gateDataLoading,
+		gateDataMap,
 	};
 }

--- a/packages/web/src/components/space/visual-editor/EdgeRenderer.tsx
+++ b/packages/web/src/components/space/visual-editor/EdgeRenderer.tsx
@@ -106,6 +106,8 @@ export interface ResolvedWorkflowChannel {
 	targetSide?: AnchorSide;
 	/** Runtime gate status for the forward direction (from→to). Only set in runtime/read-only view mode. */
 	runtimeStatus?: 'open' | 'blocked' | 'waiting_human';
+	/** Forward gate ID — set when the channel has a gate with runtime status. */
+	gateId?: string;
 }
 
 /** Channel edge color -- teal, distinct from transition edge colors */
@@ -141,17 +143,6 @@ const CHANNEL_GATE_BADGE_COLORS: Record<
 	check: '#60a5fa',
 	count: '#ec4899',
 };
-const CHANNEL_GATE_BADGE_LABELS: Record<
-	NonNullable<ResolvedWorkflowChannel['gateType']>,
-	string
-> = {
-	human: 'Human',
-	condition: 'Shell',
-	task_result: 'Result',
-	check: 'Check',
-	count: 'Votes',
-};
-
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -168,6 +159,8 @@ export interface EdgeRendererProps {
 	selectedChannelId?: string | null;
 	/** Called when the user clicks a channel edge. Receives the channel's `id` field. */
 	onChannelSelect?: (channelId: string) => void;
+	/** Called when the user clicks a gate runtime-status icon. Receives the gateId and mouse event for popup positioning. */
+	onGateClick?: (gateId: string, event: MouseEvent) => void;
 	/** When true, the Delete/Backspace keydown listener is not registered. */
 	readOnly?: boolean;
 }
@@ -579,6 +572,7 @@ export function EdgeRenderer({
 	channels = [],
 	selectedChannelId,
 	onChannelSelect,
+	onGateClick,
 	readOnly = false,
 }: EdgeRendererProps) {
 	// Stable per-instance prefix to prevent marker ID collisions across instances
@@ -774,14 +768,12 @@ export function EdgeRenderer({
 				// use the reverse direction's custom fields.
 				const effectiveGateLabel = channel.gateType ? channel.gateLabel : channel.reverseGateLabel;
 				const effectiveGateColor = channel.gateType ? channel.gateColor : channel.reverseGateColor;
-				// Prefer custom gate color, fall back to heuristic color from gateType.
+				// Prefer custom gate color, fall back to type-based color.
 				const gateColor =
 					effectiveGateColor ??
 					(effectiveGateType ? CHANNEL_GATE_BADGE_COLORS[effectiveGateType] : CHANNEL_EDGE_COLOR);
-				// Prefer custom gate label, fall back to heuristic label from gateType.
-				const gateLabel =
-					effectiveGateLabel ??
-					(effectiveGateType ? CHANNEL_GATE_BADGE_LABELS[effectiveGateType] : 'Gate');
+				// gate.label is the authoritative badge text — no heuristic fallback.
+				const gateLabel = effectiveGateLabel ?? 'Gate';
 				// Whether to show a script icon next to the badge.
 				// For bidirectional channels, use the forward direction's hasScript when available.
 				const effectiveHasScript = channel.gateType
@@ -1015,30 +1007,62 @@ export function EdgeRenderer({
 								</text>
 							</g>
 						)}
-						{/* Runtime gate status dot — only rendered in read-only/runtime view mode */}
+						{/* Runtime gate status icon — clickable when waiting_human */}
 						{channel.runtimeStatus && gateBadgePosition && (
-							<circle
-								cx={gateBadgePosition.x + gateBadgeWidth / 2 + 10}
-								cy={gateBadgePosition.y}
-								r={5}
-								fill={
-									channel.runtimeStatus === 'open'
-										? '#16a34a'
-										: channel.runtimeStatus === 'waiting_human'
-											? '#f59e0b'
-											: '#ef4444'
+							<g
+								data-testid={`gate-icon-${channel.runtimeStatus}`}
+								data-gate-id={channel.gateId ?? ''}
+								style={{
+									pointerEvents:
+										channel.runtimeStatus === 'waiting_human' && onGateClick && channel.gateId
+											? 'auto'
+											: 'none',
+									cursor:
+										channel.runtimeStatus === 'waiting_human' && onGateClick && channel.gateId
+											? 'pointer'
+											: 'default',
+								}}
+								onClick={
+									channel.runtimeStatus === 'waiting_human' && onGateClick && channel.gateId
+										? (e: MouseEvent) => {
+												e.stopPropagation();
+												onGateClick(channel.gateId!, e);
+											}
+										: undefined
 								}
-								data-testid={`channel-runtime-status-${channel.id ?? ''}`}
 							>
-								{channel.runtimeStatus === 'waiting_human' && (
-									<animate
-										attributeName="opacity"
-										values="1;0.4;1"
-										dur="1.5s"
-										repeatCount="indefinite"
-									/>
+								<circle
+									cx={gateBadgePosition.x + gateBadgeWidth / 2 + 10}
+									cy={gateBadgePosition.y}
+									r={channel.runtimeStatus === 'waiting_human' ? 7 : 5}
+									fill={
+										channel.runtimeStatus === 'open'
+											? '#16a34a'
+											: channel.runtimeStatus === 'waiting_human'
+												? '#f59e0b'
+												: '#ef4444'
+									}
+									data-testid={`channel-runtime-status-${channel.id ?? ''}`}
+								>
+									{channel.runtimeStatus === 'waiting_human' && (
+										<animate
+											attributeName="opacity"
+											values="1;0.4;1"
+											dur="1.5s"
+											repeatCount="indefinite"
+										/>
+									)}
+								</circle>
+								{/* Blocked icon: small X */}
+								{channel.runtimeStatus === 'blocked' && (
+									<g
+										transform={`translate(${gateBadgePosition.x + gateBadgeWidth / 2 + 10}, ${gateBadgePosition.y})`}
+									>
+										<line x1="-2.5" y1="-2.5" x2="2.5" y2="2.5" stroke="white" stroke-width="1.5" />
+										<line x1="2.5" y1="-2.5" x2="-2.5" y2="2.5" stroke="white" stroke-width="1.5" />
+									</g>
 								)}
-							</circle>
+							</g>
 						)}
 					</g>
 				);

--- a/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowCanvas.tsx
@@ -78,6 +78,8 @@ export interface WorkflowCanvasProps {
 	onDeleteEdge?: (transitionId: string) => void;
 	/** Called when a channel edge is clicked. Receives the channel's id. */
 	onChannelSelect?: (channelId: string | null) => void;
+	/** Called when a gate runtime-status icon is clicked. Receives gateId and mouse event. */
+	onGateClick?: (gateId: string, event: MouseEvent) => void;
 	/** Currently selected channel ID for highlighting. */
 	selectedChannelId?: string | null;
 	/**
@@ -274,6 +276,7 @@ export function WorkflowCanvas({
 	onEdgeSelect,
 	onDeleteEdge,
 	onChannelSelect,
+	onGateClick,
 	selectedChannelId,
 	readOnly = false,
 }: WorkflowCanvasProps) {
@@ -457,6 +460,7 @@ export function WorkflowCanvas({
 					channels={effectiveChannels}
 					selectedChannelId={selectedChannelId}
 					onChannelSelect={onChannelSelect ?? undefined}
+					onGateClick={onGateClick}
 					readOnly={readOnly}
 				/>
 				{dragState.active && dragState.fromPos && dragState.currentPos && (
@@ -474,6 +478,7 @@ export function WorkflowCanvas({
 			dragState,
 			selectedChannelId,
 			onChannelSelect,
+			onGateClick,
 			readOnly,
 		]
 	);

--- a/packages/web/src/components/space/visual-editor/__tests__/EdgeRenderer.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/EdgeRenderer.test.tsx
@@ -662,7 +662,7 @@ describe('EdgeRenderer — channel edge rendering', () => {
 				direction: 'one-way' as const,
 				fromStepId: 'step-1',
 				toStepId: 'step-2',
-				gateType: 'condition',
+				gateType: 'check',
 			},
 		];
 		const { getByTestId, onChannelSelect } = renderEdgesWithChannels({ channels });
@@ -688,7 +688,7 @@ describe('EdgeRenderer — channel edge rendering', () => {
 				direction: 'one-way' as const,
 				fromStepId: 'step-1',
 				toStepId: 'step-2',
-				gateType: 'human',
+				gateType: 'check',
 			},
 		];
 		const { container } = renderEdgesWithChannels({ channels });
@@ -717,12 +717,12 @@ describe('EdgeRenderer — channel edge rendering', () => {
 				direction: 'one-way' as const,
 				fromStepId: 'step-1',
 				toStepId: 'step-2',
-				gateType: 'condition',
+				gateType: 'check',
 			},
 		];
 		const { getByTestId } = renderEdgesWithChannels({ channels });
 		// textContent includes only the <text> label (the polygon has no text content)
-		expect(getByTestId('channel-gate-step-1-step-2').textContent).toBe('Shell');
+		expect(getByTestId('channel-gate-step-1-step-2').textContent).toBe('Gate');
 	});
 
 	it('one-way gated badge renders a directional arrow polygon', () => {
@@ -757,7 +757,7 @@ describe('EdgeRenderer — channel edge rendering', () => {
 		const { getByTestId, queryByTestId } = renderEdgesWithChannels({ channels });
 		expect(queryByTestId('channel-gate-arrow-step-1-step-2')).not.toBeNull();
 		// Plain label — no ⇄ prefix
-		expect(getByTestId('channel-gate-step-1-step-2').textContent).toBe('Check');
+		expect(getByTestId('channel-gate-step-1-step-2').textContent).toBe('Gate');
 	});
 
 	it('bidirectional channel with only reverse gate renders a single reverse arrow', () => {
@@ -802,7 +802,7 @@ describe('EdgeRenderer — channel edge rendering', () => {
 			},
 		];
 		const { getByTestId } = renderEdgesWithChannels({ channels });
-		expect(getByTestId('channel-gate-step-1-step-2').textContent).toBe('Check');
+		expect(getByTestId('channel-gate-step-1-step-2').textContent).toBe('Gate');
 	});
 
 	it('renders a loop badge when a channel is cyclic', () => {
@@ -884,17 +884,17 @@ describe('EdgeRenderer — gate badge custom label/color/hasScript', () => {
 		expect(getByTestId('channel-gate-step-1-step-2').textContent).toContain('Custom Gate');
 	});
 
-	it('falls back to heuristic label when gateLabel is not set', () => {
+	it('falls back to "Gate" when gateLabel is not set', () => {
 		const channels: ResolvedWorkflowChannel[] = [
 			{
 				direction: 'one-way' as const,
 				fromStepId: 'step-1',
 				toStepId: 'step-2',
-				gateType: 'human',
+				gateType: 'check',
 			},
 		];
 		const { getByTestId } = renderEdgesWithChannels({ channels });
-		expect(getByTestId('channel-gate-step-1-step-2').textContent).toContain('Human');
+		expect(getByTestId('channel-gate-step-1-step-2').textContent).toBe('Gate');
 	});
 
 	it('renders custom gateColor on badge text when set', () => {
@@ -933,7 +933,7 @@ describe('EdgeRenderer — gate badge custom label/color/hasScript', () => {
 				direction: 'one-way' as const,
 				fromStepId: 'step-1',
 				toStepId: 'step-2',
-				gateType: 'condition',
+				gateType: 'check',
 				gateColor: '#00ff88',
 			},
 		];
@@ -1078,7 +1078,7 @@ describe('EdgeRenderer — gate badge custom label/color/hasScript', () => {
 				direction: 'one-way' as const,
 				fromStepId: 'step-1',
 				toStepId: 'step-2',
-				gateType: 'human',
+				gateType: 'check',
 				gateLabel: 'Approve',
 				reverseGateType: 'check',
 			},
@@ -1180,7 +1180,7 @@ describe('EdgeRenderer — gate badge custom label/color/hasScript', () => {
 				direction: 'one-way' as const,
 				fromStepId: 'step-1',
 				toStepId: 'step-2',
-				gateType: 'human',
+				gateType: 'check',
 				gateLabel: 'Forward',
 				gateColor: '#ff0000',
 				reverseGateType: 'check',

--- a/packages/web/src/components/space/visual-editor/__tests__/semanticWorkflowGraph.test.ts
+++ b/packages/web/src/components/space/visual-editor/__tests__/semanticWorkflowGraph.test.ts
@@ -158,9 +158,9 @@ describe('buildSemanticWorkflowEdges', () => {
 		expect(result[0].direction).toBe('bidirectional');
 		expect(result[0].hasGate).toBe(true);
 		// Forward gate (plan→review = lowId→highId)
-		expect(result[0].gateType).toBe('human');
+		expect(result[0].gateType).toBe('check');
 		// Reverse gate (review→plan = highId→lowId)
-		expect(result[0].reverseGateType).toBe('human');
+		expect(result[0].reverseGateType).toBe('check');
 	});
 
 	it('does not set reverseGateType when only the forward direction has a gate', () => {
@@ -172,7 +172,7 @@ describe('buildSemanticWorkflowEdges', () => {
 
 		const result = buildSemanticWorkflowEdges(NODES, channels, gates);
 		expect(result[0].direction).toBe('bidirectional');
-		expect(result[0].gateType).toBe('human');
+		expect(result[0].gateType).toBe('check');
 		expect(result[0].reverseGateType).toBeUndefined();
 	});
 
@@ -186,7 +186,7 @@ describe('buildSemanticWorkflowEdges', () => {
 		const result = buildSemanticWorkflowEdges(NODES, channels, gates);
 		expect(result[0].direction).toBe('bidirectional');
 		expect(result[0].gateType).toBeUndefined();
-		expect(result[0].reverseGateType).toBe('human');
+		expect(result[0].reverseGateType).toBe('check');
 	});
 
 	it('a bidirectional underlying channel gates both directions', () => {
@@ -198,8 +198,8 @@ describe('buildSemanticWorkflowEdges', () => {
 
 		const result = buildSemanticWorkflowEdges(NODES, channels, gates);
 		expect(result[0].direction).toBe('bidirectional');
-		expect(result[0].gateType).toBe('human');
-		expect(result[0].reverseGateType).toBe('human');
+		expect(result[0].gateType).toBe('check');
+		expect(result[0].reverseGateType).toBe('check');
 	});
 });
 
@@ -215,7 +215,7 @@ describe('gate label/color/hasScript propagation', () => {
 
 		const result = buildSemanticWorkflowEdges(NODES, channels, gates);
 		expect(result[0]).toMatchObject({
-			gateType: 'human',
+			gateType: 'check',
 			gateLabel: 'Team Lead',
 			gateColor: '#ff5500',
 			hasScript: undefined,
@@ -289,11 +289,11 @@ describe('gate label/color/hasScript propagation', () => {
 		const result = buildSemanticWorkflowEdges(NODES, channels, gates);
 		expect(result).toHaveLength(1);
 		expect(result[0]).toMatchObject({
-			gateType: 'human',
+			gateType: 'check',
 			gateLabel: 'Forward',
 			gateColor: '#00ff00',
 			hasScript: true,
-			reverseGateType: 'human',
+			reverseGateType: 'check',
 			reverseGateLabel: 'Reverse',
 			reverseGateColor: '#ff0000',
 			reverseHasScript: undefined,
@@ -315,11 +315,11 @@ describe('gate label/color/hasScript propagation', () => {
 
 		const result = buildSemanticWorkflowEdges(NODES, channels, gates);
 		expect(result[0]).toMatchObject({
-			gateType: 'human',
+			gateType: 'check',
 			gateLabel: 'Both Ways',
 			gateColor: '#123456',
 			hasScript: true,
-			reverseGateType: 'human',
+			reverseGateType: 'check',
 			reverseGateLabel: 'Both Ways',
 			reverseGateColor: '#123456',
 			reverseHasScript: true,
@@ -487,7 +487,7 @@ describe('gate label/color/hasScript propagation', () => {
 
 	it('gate with both fields and script propagates both gateType and hasScript', () => {
 		// A human gate (with approved field) that also has a script.
-		// Should produce gateType='human' AND hasScript=true.
+		// Should produce gateType='check' AND hasScript=true.
 		const channels: WorkflowChannel[] = [{ from: 'Planning', to: 'Code Review', gateId: 'g1' }];
 		const gates = [
 			humanGate('g1', {
@@ -499,7 +499,7 @@ describe('gate label/color/hasScript propagation', () => {
 
 		const result = buildSemanticWorkflowEdges(NODES, channels, gates);
 		expect(result[0]).toMatchObject({
-			gateType: 'human',
+			gateType: 'check',
 			gateLabel: 'Hybrid Gate',
 			gateColor: '#112233',
 			hasScript: true,

--- a/packages/web/src/components/space/visual-editor/semanticWorkflowGraph.ts
+++ b/packages/web/src/components/space/visual-editor/semanticWorkflowGraph.ts
@@ -93,35 +93,10 @@ function resolveSemanticGateType(
 		const gate = gateLookup.get(channel.gateId);
 		if (!gate) return { type: 'check', hasScript: false };
 
-		// Derive gate type from field declarations
-		const fields = gate.fields ?? [];
-
-		let type: SemanticWorkflowEdge['gateType'];
-
-		if (fields.length === 0) {
-			type = 'check';
-		} else if (fields.some((f) => f.type === 'map' && f.check.op === 'count')) {
-			type = 'count';
-		} else {
-			const approvedField = fields.find((f) => f.name === 'approved' && f.type === 'boolean');
-			if (approvedField && approvedField.check.op === '==' && approvedField.check.value === true) {
-				type = 'human';
-			} else {
-				const resultField = fields.find((f) => f.name === 'result' && f.type === 'string');
-				if (
-					resultField &&
-					resultField.check.op === '==' &&
-					typeof resultField.check.value === 'string'
-				) {
-					type = 'task_result';
-				} else {
-					type = 'check';
-				}
-			}
-		}
-
+		// Gate label is the authoritative display text — no heuristic type inference.
+		// Use 'check' as a generic type so the badge renders (isGated check).
 		return {
-			type,
+			type: 'check',
 			label: gate.label,
 			color: gate.color,
 			hasScript: !!gate.script,

--- a/packages/web/src/islands/BottomTabBar.tsx
+++ b/packages/web/src/islands/BottomTabBar.tsx
@@ -221,38 +221,42 @@ const ROOM_BOTTOM_TABS: TabItem[] = [
 ];
 
 export function BottomTabBar() {
-	const rootRef = useRef<HTMLDivElement>(null);
+	const innerRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
-		const el = rootRef.current;
-		if (!el) return;
+		const inner = innerRef.current;
+		if (!inner) return;
 
 		const updateHeight = () => {
-			const h = el.offsetHeight;
+			if (document.documentElement.classList.contains('keyboard-open')) return;
+			const h = inner.offsetHeight;
 			document.documentElement.style.setProperty('--bottom-bar-height', h + 'px');
 		};
 
-		// ResizeObserver fires when the element itself resizes
+		// Measure the inner content div (excludes pb-safe) so --bottom-bar-height
+		// only tracks tab content height. Safe area is handled separately via pb-safe
+		// on the main content and chat-footer.
 		const ro = new ResizeObserver(updateHeight);
-		ro.observe(el);
+		ro.observe(inner);
 
-		// window resize listener handles breakpoint transitions (md:hidden causes
-		// display:none, which ResizeObserver does not fire for).
-		// requestAnimationFrame ensures the browser applies the new display value first.
-		// The cancelled-rAF guard prevents queuing multiple callbacks during rapid resize.
 		let rafId = 0;
-		const onResize = () => {
+		const scheduleUpdate = () => {
 			cancelAnimationFrame(rafId);
 			rafId = requestAnimationFrame(updateHeight);
 		};
-		window.addEventListener('resize', onResize);
+		window.addEventListener('resize', scheduleUpdate);
 
-		// Initial measurement
+		const vv = window.visualViewport;
+		if (vv) vv.addEventListener('resize', scheduleUpdate);
+
 		updateHeight();
+		const timer = setTimeout(updateHeight, 300);
 
 		return () => {
+			clearTimeout(timer);
 			ro.disconnect();
-			window.removeEventListener('resize', onResize);
+			window.removeEventListener('resize', scheduleUpdate);
+			if (vv) vv.removeEventListener('resize', scheduleUpdate);
 			cancelAnimationFrame(rafId);
 			document.documentElement.style.setProperty('--bottom-bar-height', '0px');
 		};
@@ -355,9 +359,8 @@ export function BottomTabBar() {
 
 	return (
 		<div
-			ref={rootRef}
 			data-testid="bottom-tab-bar"
-			class="flex md:hidden fixed bottom-0 left-0 right-0 z-50 bg-dark-900/90 backdrop-blur-md border-t border-dark-700 pb-safe"
+			class="flex md:hidden fixed bottom-0 left-0 right-0 z-50 bg-dark-900/90 backdrop-blur-md pb-safe"
 			role="tablist"
 			aria-label={
 				isInSpaceContext
@@ -368,7 +371,8 @@ export function BottomTabBar() {
 			}
 		>
 			<div
-				class="flex w-full transition-opacity duration-200 ease-out"
+				ref={innerRef}
+				class="flex w-full border-t border-dark-700 transition-opacity duration-200 ease-out"
 				key={isInSpaceContext ? 'space' : isInRoomContext ? 'room' : 'global'}
 			>
 				{tabs.map((tab) => {

--- a/packages/web/src/islands/BottomTabBar.tsx
+++ b/packages/web/src/islands/BottomTabBar.tsx
@@ -7,6 +7,10 @@ import {
 	currentRoomTaskIdSignal,
 	currentRoomActiveTabSignal,
 	currentRoomAgentActiveSignal,
+	currentSpaceIdSignal,
+	currentSpaceViewModeSignal,
+	currentSpaceSessionIdSignal,
+	currentSpaceTaskIdSignal,
 	type NavSection,
 } from '../lib/signals.ts';
 import {
@@ -15,12 +19,26 @@ import {
 	navigateToRooms,
 	navigateToInbox,
 	navigateToRoomTab,
+	navigateToSpace,
+	navigateToSpaceTasks,
+	navigateToSpaceAgent,
+	navigateToSpaceConfigure,
 } from '../lib/router.ts';
 import { inboxStore } from '../lib/inbox-store.ts';
 import { InboxBadge } from '../components/ui/InboxBadge.tsx';
 
 interface TabItem {
-	id: NavSection | 'room-agent' | 'room-overview' | 'room-tasks' | 'room-agents' | 'room-missions';
+	id:
+		| NavSection
+		| 'room-agent'
+		| 'room-overview'
+		| 'room-tasks'
+		| 'room-agents'
+		| 'room-missions'
+		| 'space-overview'
+		| 'space-tasks'
+		| 'space-agent'
+		| 'space-settings';
 	label: string;
 	icon: () => JSX.Element;
 }
@@ -130,6 +148,63 @@ const RoomOverviewIcon = () => (
 	</svg>
 );
 
+const SpaceOverviewIcon = () => (
+	<svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+		<path
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			stroke-width={2}
+			d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+		/>
+	</svg>
+);
+
+const SpaceTasksIcon = () => (
+	<svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+		<path
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			stroke-width={2}
+			d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
+		/>
+	</svg>
+);
+
+const SpaceChatIcon = () => (
+	<svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+		<path
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			stroke-width={2}
+			d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+		/>
+	</svg>
+);
+
+const SpaceSettingsIcon = () => (
+	<svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+		<path
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			stroke-width={2}
+			d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+		/>
+		<path
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			stroke-width={2}
+			d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+		/>
+	</svg>
+);
+
+const SPACE_BOTTOM_TABS: TabItem[] = [
+	{ id: 'space-overview', label: 'Overview', icon: SpaceOverviewIcon },
+	{ id: 'space-tasks', label: 'Tasks', icon: SpaceTasksIcon },
+	{ id: 'space-agent', label: 'Agent', icon: SpaceChatIcon },
+	{ id: 'space-settings', label: 'Settings', icon: SpaceSettingsIcon },
+];
+
 const GLOBAL_BOTTOM_TABS: TabItem[] = [
 	{ id: 'inbox', label: 'Inbox', icon: InboxIcon },
 	{ id: 'rooms', label: 'Rooms', icon: RoomsIcon },
@@ -185,17 +260,27 @@ export function BottomTabBar() {
 
 	const navSection = navSectionSignal.value;
 	const roomId = currentRoomIdSignal.value;
+	const spaceId = currentSpaceIdSignal.value;
 	const inboxBadgeCount = inboxStore.reviewCount.value;
 
 	const roomSessionId = currentRoomSessionIdSignal.value;
 	const roomTaskId = currentRoomTaskIdSignal.value;
 	const isInRoomContext = navSection === 'rooms' && roomId !== null;
+	const isInSpaceContext = navSection === 'spaces' && spaceId !== null;
 	const isViewingRoomAgent = currentRoomAgentActiveSignal.value;
 	// Overview is only active when on the room dashboard (no task, no session, no agent chat)
 	const isViewingRoomDashboard =
 		!isViewingRoomAgent && roomTaskId === null && roomSessionId === null;
 
-	const tabs = isInRoomContext ? ROOM_BOTTOM_TABS : GLOBAL_BOTTOM_TABS;
+	const spaceViewMode = currentSpaceViewModeSignal.value;
+	const spaceSessionId = currentSpaceSessionIdSignal.value;
+	const spaceTaskId = currentSpaceTaskIdSignal.value;
+
+	const tabs = isInSpaceContext
+		? SPACE_BOTTOM_TABS
+		: isInRoomContext
+			? ROOM_BOTTOM_TABS
+			: GLOBAL_BOTTOM_TABS;
 
 	const handleTabClick = (id: TabItem['id']) => {
 		switch (id) {
@@ -226,10 +311,33 @@ export function BottomTabBar() {
 			case 'room-missions':
 				if (roomId) navigateToRoomTab(roomId, 'goals');
 				break;
+			case 'space-overview':
+				if (spaceId) navigateToSpace(spaceId);
+				break;
+			case 'space-tasks':
+				if (spaceId) navigateToSpaceTasks(spaceId);
+				break;
+			case 'space-agent':
+				if (spaceId) navigateToSpaceAgent(spaceId);
+				break;
+			case 'space-settings':
+				if (spaceId) navigateToSpaceConfigure(spaceId);
+				break;
 		}
 	};
 
 	const isTabActive = (id: TabItem['id']): boolean => {
+		if (isInSpaceContext) {
+			if (id === 'space-settings') return spaceViewMode === 'configure';
+			if (id === 'space-agent') return spaceSessionId === `space:chat:${spaceId}`;
+			if (id === 'space-tasks') return spaceViewMode === 'tasks' && spaceTaskId === null;
+			if (id === 'space-overview')
+				return (
+					spaceViewMode === 'overview' &&
+					spaceTaskId === null &&
+					spaceSessionId !== `space:chat:${spaceId}`
+				);
+		}
 		if (isInRoomContext) {
 			if (id === 'room-agent') return currentRoomActiveTabSignal.value === 'chat';
 			if (id === 'room-tasks') return currentRoomActiveTabSignal.value === 'tasks';
@@ -251,11 +359,17 @@ export function BottomTabBar() {
 			data-testid="bottom-tab-bar"
 			class="flex md:hidden fixed bottom-0 left-0 right-0 z-50 bg-dark-900/90 backdrop-blur-md border-t border-dark-700 pb-safe"
 			role="tablist"
-			aria-label={isInRoomContext ? 'Room navigation' : 'Main navigation'}
+			aria-label={
+				isInSpaceContext
+					? 'Space navigation'
+					: isInRoomContext
+						? 'Room navigation'
+						: 'Main navigation'
+			}
 		>
 			<div
 				class="flex w-full transition-opacity duration-200 ease-out"
-				key={isInRoomContext ? 'room' : 'global'}
+				key={isInSpaceContext ? 'space' : isInRoomContext ? 'room' : 'global'}
 			>
 				{tabs.map((tab) => {
 					const isActive = isTabActive(tab.id);

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -369,12 +369,12 @@ export default function ChatContainer({
 		}
 	});
 
-	// Timeout: if session state doesn't load within 10s, show error instead of infinite spinner
+	// Timeout: if session state doesn't load within 30s, show error instead of infinite spinner
 	useEffect(() => {
 		if (!isInitialLoad) return;
 		const timer = setTimeout(() => {
 			setLoadTimedOut(true);
-		}, 10_000);
+		}, 30_000);
 		return () => clearTimeout(timer);
 	}, [isInitialLoad]);
 

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -1116,7 +1116,6 @@ export default function ChatContainer({
 				<div
 					ref={footerContainerRef}
 					class="pointer-events-auto pt-4 bg-gradient-to-t from-dark-900 from-[calc(100%-32px)] to-dark-900/0"
-					style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
 				>
 					<SessionStatusBar
 						sessionId={sessionId}

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -17,7 +17,6 @@ import {
 	navigateToSession,
 	navigateToSessions,
 	navigateToSettings,
-	navigateToHome,
 	navigateToRooms,
 	navigateToInbox,
 	navigateToSpaces,
@@ -202,13 +201,6 @@ export function ContextPanel() {
 
 	// Section config
 	const sectionConfig = {
-		home: {
-			title: 'Rooms',
-			emptyIcon: '🏢',
-			emptyTitle: 'No rooms yet',
-			emptyDesc: 'Create a room to organize work',
-			actionLabel: 'Create Room',
-		},
 		chats: {
 			title: 'Sessions',
 			emptyIcon: '💬',
@@ -293,7 +285,6 @@ export function ContextPanel() {
 
 	const handleAction = () => {
 		switch (navSection) {
-			case 'home':
 			case 'rooms':
 				createRoomModalSignal.value = true;
 				break;
@@ -314,10 +305,6 @@ export function ContextPanel() {
 
 	const handleMobileNavClick = (section: NavSection) => {
 		switch (section) {
-			case 'home':
-				navSectionSignal.value = 'home';
-				navigateToHome();
-				break;
 			case 'chats':
 				navigateToSessions();
 				break;
@@ -470,9 +457,7 @@ export function ContextPanel() {
 						</button>
 					</div>
 
-					{(navSection === 'home' ||
-						navSection === 'chats' ||
-						(navSection === 'rooms' && !isRoomDetail)) && (
+					{(navSection === 'chats' || (navSection === 'rooms' && !isRoomDetail)) && (
 						<Button
 							onClick={handleAction}
 							loading={isActionLoading}
@@ -501,9 +486,6 @@ export function ContextPanel() {
 					}
 					class="flex-1 overflow-hidden flex flex-col animate-fadeIn"
 				>
-					{navSection === 'home' && (
-						<RoomList onRoomSelect={() => (contextPanelOpenSignal.value = false)} />
-					)}
 					{navSection === 'chats' && (
 						<SessionList onSessionSelect={() => (contextPanelOpenSignal.value = false)} />
 					)}

--- a/packages/web/src/islands/NavRail.tsx
+++ b/packages/web/src/islands/NavRail.tsx
@@ -2,7 +2,6 @@ import { navSectionSignal, type NavSection } from '../lib/signals.ts';
 import {
 	navigateToSessions,
 	navigateToSettings,
-	navigateToHome,
 	navigateToRooms,
 	navigateToInbox,
 	navigateToSpaces,
@@ -21,10 +20,6 @@ export function NavRail() {
 
 	const handleNavClick = (section: NavSection) => {
 		switch (section) {
-			case 'home':
-				navSectionSignal.value = 'home';
-				navigateToHome();
-				break;
 			case 'chats':
 				navigateToSessions();
 				break;

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -60,7 +60,9 @@ export default function SpaceIsland({
 	if (sessionViewId) {
 		return (
 			<>
-				<ChatContainer key={sessionViewId} sessionId={sessionViewId} />
+				<div class="flex-1 flex flex-col overflow-hidden">
+					<ChatContainer key={sessionViewId} sessionId={sessionViewId} />
+				</div>
 				{overlaySessionId && (
 					<AgentOverlayChat
 						sessionId={overlaySessionId}

--- a/packages/web/src/islands/__tests__/ContextPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/ContextPanel.test.tsx
@@ -414,18 +414,6 @@ describe('ContextPanel', () => {
 			// The button should open the modal by setting the signal to true
 			expect(mockCreateRoomModalSignal.value).toBe(true);
 		});
-
-		it('should open create room modal from home section', async () => {
-			mockNavSectionSignal.value = 'home';
-
-			render(<ContextPanel />);
-
-			const button = screen.getByRole('button', { name: /Create Room/i });
-			fireEvent.click(button);
-
-			// The button should open the modal by setting the signal to true
-			expect(mockCreateRoomModalSignal.value).toBe(true);
-		});
 	});
 
 	describe('Mobile Drawer Behavior', () => {

--- a/packages/web/src/islands/__tests__/NavRail.test.tsx
+++ b/packages/web/src/islands/__tests__/NavRail.test.tsx
@@ -14,7 +14,6 @@ import { navSectionSignal } from '../../lib/signals.ts';
 vi.mock('../../lib/router.ts', () => ({
 	navigateToSessions: vi.fn(),
 	navigateToSettings: vi.fn(),
-	navigateToHome: vi.fn(),
 	navigateToRooms: vi.fn(),
 	navigateToSpaces: vi.fn(),
 }));
@@ -23,7 +22,6 @@ vi.mock('../../lib/router.ts', () => ({
 import {
 	navigateToSessions,
 	navigateToSettings,
-	navigateToHome,
 	navigateToRooms,
 	navigateToSpaces,
 } from '../../lib/router.ts';
@@ -47,7 +45,6 @@ describe('NavRail', () => {
 			render(<NavRail />);
 
 			// Check all navigation buttons are rendered
-			expect(screen.getByTitle('Home')).toBeTruthy();
 			expect(screen.getByTitle('Rooms')).toBeTruthy();
 			expect(screen.getByTitle('Chats')).toBeTruthy();
 			expect(screen.getByTitle('Spaces')).toBeTruthy();
@@ -91,14 +88,6 @@ describe('NavRail', () => {
 			const chatsButton = screen.getByRole('button', { name: 'Chats' });
 			expect(chatsButton.getAttribute('aria-pressed')).toBe('false');
 		});
-
-		it('should highlight Home button when navSection is home', () => {
-			navSectionSignal.value = 'home';
-			render(<NavRail />);
-
-			const homeButton = screen.getByRole('button', { name: 'Home' });
-			expect(homeButton.getAttribute('aria-pressed')).toBe('true');
-		});
 	});
 
 	describe('Click Interactions', () => {
@@ -118,15 +107,6 @@ describe('NavRail', () => {
 			fireEvent.click(settingsButton);
 
 			expect(navigateToSettings).toHaveBeenCalledTimes(1);
-		});
-
-		it('should call navigateToHome when Home button is clicked', () => {
-			render(<NavRail />);
-
-			const homeButton = screen.getByRole('button', { name: 'Home' });
-			fireEvent.click(homeButton);
-
-			expect(navigateToHome).toHaveBeenCalledTimes(1);
 		});
 
 		it('should call navigateToRooms when Rooms button is clicked', () => {

--- a/packages/web/src/lib/__tests__/navigate-to-room-tab-reset.test.ts
+++ b/packages/web/src/lib/__tests__/navigate-to-room-tab-reset.test.ts
@@ -65,7 +65,7 @@ describe('navigateToRoom tab signal behavior', () => {
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
-		navSectionSignal.value = 'home';
+		navSectionSignal.value = 'rooms';
 
 		vi.clearAllMocks();
 		cleanupRouter();

--- a/packages/web/src/lib/__tests__/room-agent-router.test.ts
+++ b/packages/web/src/lib/__tests__/room-agent-router.test.ts
@@ -71,7 +71,7 @@ describe('Room Agent Router', () => {
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
-		navSectionSignal.value = 'home';
+		navSectionSignal.value = 'rooms';
 
 		vi.clearAllMocks();
 		cleanupRouter();

--- a/packages/web/src/lib/__tests__/space-agent-router.test.ts
+++ b/packages/web/src/lib/__tests__/space-agent-router.test.ts
@@ -67,7 +67,7 @@ describe('Space Agent Router', () => {
 		currentSpaceIdSignal.value = null;
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
-		navSectionSignal.value = 'home';
+		navSectionSignal.value = 'rooms';
 
 		vi.clearAllMocks();
 		cleanupRouter();

--- a/packages/web/src/lib/__tests__/space-router.test.ts
+++ b/packages/web/src/lib/__tests__/space-router.test.ts
@@ -399,7 +399,7 @@ describe('Popstate handling for space routes', () => {
 		window.dispatchEvent(new PopStateEvent('popstate', {}));
 
 		expect(currentSpaceIdSignal.value).toBeNull();
-		expect(navSectionSignal.value).toBe('home');
+		expect(navSectionSignal.value).toBe('rooms');
 	});
 
 	it('switches from room to space correctly on popstate', () => {
@@ -513,7 +513,7 @@ describe('navigateToSessions clears space signals', () => {
 describe('navigateToSpace same-path branch sets navSection', () => {
 	it('sets navSection to spaces even when already on the same space path', () => {
 		mockLocation.pathname = `/space/${SPACE_ID}`;
-		navSectionSignal.value = 'home'; // simulate out-of-sync state
+		navSectionSignal.value = 'rooms'; // simulate out-of-sync state
 
 		navigateToSpace(SPACE_ID);
 
@@ -525,7 +525,7 @@ describe('navigateToSpace same-path branch sets navSection', () => {
 describe('navigateToSpaceSession same-path branch sets navSection', () => {
 	it('sets navSection to spaces even when already on the same space/session path', () => {
 		mockLocation.pathname = `/space/${SPACE_ID}/session/${SESSION_ID}`;
-		navSectionSignal.value = 'home';
+		navSectionSignal.value = 'rooms';
 
 		navigateToSpaceSession(SPACE_ID, SESSION_ID);
 
@@ -537,7 +537,7 @@ describe('navigateToSpaceSession same-path branch sets navSection', () => {
 describe('navigateToSpaceTask same-path branch sets navSection', () => {
 	it('sets navSection to spaces even when already on the same space/task path', () => {
 		mockLocation.pathname = `/space/${SPACE_ID}/task/${TASK_ID}`;
-		navSectionSignal.value = 'home';
+		navSectionSignal.value = 'rooms';
 
 		navigateToSpaceTask(SPACE_ID, TASK_ID);
 

--- a/packages/web/src/lib/nav-config.tsx
+++ b/packages/web/src/lib/nav-config.tsx
@@ -9,20 +9,6 @@ export interface NavItemConfig {
 
 export const MAIN_NAV_ITEMS: NavItemConfig[] = [
 	{
-		id: 'home',
-		label: 'Home',
-		icon: (
-			<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-				<path
-					stroke-linecap="round"
-					stroke-linejoin="round"
-					stroke-width={2}
-					d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
-				/>
-			</svg>
-		),
-	},
-	{
 		id: 'rooms',
 		label: 'Rooms',
 		icon: (

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -1603,7 +1603,7 @@ function handlePopState(_event: PopStateEvent): void {
 		currentRoomActiveTabSignal.value = null;
 		currentSessionIdSignal.value = sessionId;
 		if (!sessionId) {
-			navSectionSignal.value = 'home';
+			navSectionSignal.value = 'rooms';
 		}
 	}
 }

--- a/packages/web/src/lib/signals.ts
+++ b/packages/web/src/lib/signals.ts
@@ -36,8 +36,8 @@ export const sessionsSignal = signal<Session[]>([]);
 export const slashCommandsSignal = signal<string[]>([]);
 
 // Navigation section signal - which nav item is active
-export type NavSection = 'home' | 'chats' | 'rooms' | 'inbox' | 'projects' | 'spaces' | 'settings';
-export const navSectionSignal = signal<NavSection>('home');
+export type NavSection = 'chats' | 'rooms' | 'inbox' | 'projects' | 'spaces' | 'settings';
+export const navSectionSignal = signal<NavSection>('rooms');
 
 // Space navigation signals
 export const currentSpaceIdSignal = signal<string | null>(null);

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -1345,6 +1345,7 @@ class SpaceStore {
 
 		try {
 			await this.fetchAndResolveSpace(spaceId);
+			await this.startSubscriptions(spaceId);
 			// Re-fetch previously loaded data in background
 			if (hadConfigData) {
 				this.ensureConfigData().catch((err) => {

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -672,6 +672,10 @@ html.keyboard-open [data-testid="bottom-tab-bar"] {
  * chat footer. The keyboard covers the home indicator area, so the extra
  * padding pushes content up unnecessarily.
  */
+.chat-footer {
+	padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
 html.keyboard-open .chat-footer,
 html.keyboard-open .chat-footer > div {
 	padding-bottom: 0px !important;


### PR DESCRIPTION
## Summary
- Fix black gap between content and bottom tab bar on iOS Safari caused by lazy `env(safe-area-inset-bottom)` resolution
- Add space-specific bottom tab bar with Overview/Tasks/Agent/Settings tabs
- Wire GateArtifactsView into canvas approval panel

## iOS Safe Area Fix
iOS Safari starts `env(safe-area-inset-bottom)` at 0 and only resolves it after keyboard interaction. ResizeObserver doesn't fire for this change, so `--bottom-bar-height` became stale. Fixed by measuring the inner tab content (excluding pb-safe) and adding pb-safe separately to the main content div and chat footer.

## Test plan
- [ ] On iPhone Safari: navigate to space agent view, verify no gap between content and bottom tab bar
- [ ] On iPhone Safari: open/close keyboard, verify no gap persists after navigation
- [ ] On desktop: verify no visual regression
- [ ] Verify space bottom tab bar shows correct tabs and navigation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)