### PR TITLE
fix: iOS Safari safe area, inline BottomTabBar, and model list race condition

### DIFF
--- a/packages/daemon/tests/unit/2-handlers/rpc/mcp-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc/mcp-handlers.test.ts
@@ -10,7 +10,7 @@
  * - globalTools.saveConfig - Save global tools config
  */
 
-import { describe, expect, it, beforeEach, mock, afterEach } from 'bun:test';
+import { describe, expect, it, beforeEach, mock, afterEach, afterAll } from 'bun:test';
 import { MessageHub, type ToolsConfig, type GlobalToolsConfig } from '@neokai/shared';
 import { registerMcpHandlers } from '../../../../src/lib/rpc-handlers/mcp-handlers';
 import type { SessionManager } from '../../../../src/lib/session-manager';
@@ -135,6 +135,18 @@ describe('MCP/Tools RPC Handlers', () => {
 
 	afterEach(() => {
 		mock.restore();
+		// Re-register the default node:fs/promises mock so that per-test overrides
+		// (e.g. 'not valid json' in mcp.listServers tests) don't leak into other
+		// tests within this file.
+		mock.module('node:fs/promises', () => ({
+			readFile: mock(async () => '{}'),
+		}));
+	});
+
+	// Restore the real node:fs/promises after all tests in this file complete
+	// so the mock doesn't leak into subsequent test files in the same process.
+	afterAll(() => {
+		mock.module('node:fs/promises', () => require('node:fs/promises'));
 	});
 
 	describe('tools.save', () => {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -4,7 +4,6 @@ import { useNeoKeyboardShortcut } from './hooks/useNeoKeyboardShortcut.ts';
 import { useViewportSafety } from './hooks/useViewportSafety.ts';
 
 import { NavRail } from './islands/NavRail.tsx';
-import { BottomTabBar } from './islands/BottomTabBar.tsx';
 import { ContextPanel } from './islands/ContextPanel.tsx';
 import MainContent from './islands/MainContent.tsx';
 import ToastContainer from './islands/ToastContainer.tsx';
@@ -199,13 +198,10 @@ export function App() {
 				<ContextPanel />
 
 				{/* Main Content — bottom padding matches actual BottomTabBar height via --bottom-bar-height */}
-				<div class="flex-1 flex flex-col overflow-hidden pb-bottom-bar pb-safe min-w-0">
+				<div class="flex-1 flex flex-col overflow-hidden min-w-0">
 					<MainContent />
 				</div>
 			</div>
-
-			{/* Bottom Tab Bar (mobile only) */}
-			<BottomTabBar />
 
 			{/* Global Toast Container */}
 			<ToastContainer />

--- a/packages/web/src/components/ChatHeader.tsx
+++ b/packages/web/src/components/ChatHeader.tsx
@@ -238,16 +238,19 @@ export function ChatHeader({
 							<span class="font-mono text-green-400">${displayStats.totalCost.toFixed(4)}</span>
 							{session?.config?.model && (
 								<>
-									<span class="text-gray-600">·</span>
-									<span class="text-blue-400 font-medium" title={session.config.model}>
+									<span class="hidden sm:inline text-gray-600">·</span>
+									<span
+										class="hidden sm:inline text-blue-400 font-medium"
+										title={session.config.model}
+									>
 										{getModelLabel(session.config.model)}
 									</span>
 								</>
 							)}
 							{(session?.worktree?.branch || session?.gitBranch) && (
 								<>
-									<span class="text-gray-600">·</span>
-									<span class="flex items-center gap-1 font-mono text-gray-500">
+									<span class="hidden sm:inline text-gray-600">·</span>
+									<span class="hidden sm:flex items-center gap-1 font-mono text-gray-500">
 										<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 											<path
 												stroke-linecap="round"

--- a/packages/web/src/components/space/SpaceOverview.tsx
+++ b/packages/web/src/components/space/SpaceOverview.tsx
@@ -11,7 +11,11 @@
 import { useState } from 'preact/hooks';
 import type { RuntimeState, SpaceTask } from '@neokai/shared';
 import { spaceStore } from '../../lib/space-store';
-import { navigateToSpaceTask, navigateToSpaceAgent } from '../../lib/router';
+import {
+	navigateToSpaceTask,
+	navigateToSpaceAgent,
+	navigateToSpaceSession,
+} from '../../lib/router';
 import { cn, getRelativeTime } from '../../lib/utils';
 import { SpaceCreateTaskDialog } from './SpaceCreateTaskDialog';
 
@@ -185,7 +189,7 @@ export function SpaceOverview({ spaceId, onSelectTask }: SpaceOverviewProps) {
 		onSelectTask ?? ((taskId: string) => navigateToSpaceTask(spaceId, taskId));
 
 	return (
-		<div class="w-full px-8 py-6 space-y-6">
+		<div class="w-full px-4 py-4 sm:px-8 sm:py-6 space-y-6 overflow-y-auto">
 			<SpaceCreateTaskDialog isOpen={showCreateTask} onClose={() => setShowCreateTask(false)} />
 
 			{/* Runtime state (shown when available) */}
@@ -269,7 +273,7 @@ export function SpaceOverview({ spaceId, onSelectTask }: SpaceOverviewProps) {
 							<button
 								key={session.id}
 								type="button"
-								onClick={() => navigateToSpaceAgent(spaceId)}
+								onClick={() => navigateToSpaceSession(spaceId, session.id)}
 								class="w-full flex items-center gap-3 px-4 py-3 rounded-lg hover:bg-dark-800/60 transition-colors text-left group"
 							>
 								<div class="w-2 h-2 rounded-full flex-shrink-0 bg-indigo-400" />

--- a/packages/web/src/components/space/SpacePageHeader.tsx
+++ b/packages/web/src/components/space/SpacePageHeader.tsx
@@ -1,0 +1,23 @@
+import { borderColors } from '../../lib/design-tokens';
+import { MobileMenuButton } from '../ui/MobileMenuButton';
+
+interface SpacePageHeaderProps {
+	spaceName: string;
+	pageTitle: string;
+}
+
+export function SpacePageHeader({ spaceName, pageTitle }: SpacePageHeaderProps) {
+	return (
+		<div
+			class={`flex-shrink-0 bg-dark-850 border-b ${borderColors.ui.default} px-4 py-2.5 relative z-10`}
+		>
+			<div class="flex items-center gap-3">
+				<MobileMenuButton />
+				<div class="flex-1 min-w-0">
+					<div class="text-xs text-gray-500 truncate">{spaceName}</div>
+					<h2 class="text-sm font-semibold text-gray-100 truncate">{pageTitle}</h2>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -385,7 +385,9 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 						</button>
 					)}
 					<div class="min-w-0 flex-1">
-						<h2 class="text-lg font-semibold text-gray-100 min-w-0 truncate">{task.title}</h2>
+						<h2 class="text-sm sm:text-lg font-semibold text-gray-100 min-w-0 truncate">
+							{task.title}
+						</h2>
 						<div class="mt-1 flex flex-wrap items-center gap-2 text-sm text-gray-400">
 							<span data-testid="task-status-label">{activitySummary}</span>
 							{task.priority !== 'normal' && (

--- a/packages/web/src/components/space/SpaceTasks.tsx
+++ b/packages/web/src/components/space/SpaceTasks.tsx
@@ -298,7 +298,7 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 	}
 
 	return (
-		<div class="w-full px-8 py-6 space-y-6">
+		<div class="w-full px-4 py-4 sm:px-8 sm:py-6 space-y-6 overflow-y-auto">
 			<div class="flex border-b border-dark-700">
 				<TabButton
 					label="Active"

--- a/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
+++ b/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
@@ -26,6 +26,17 @@ vi.mock('../../lib/connection-manager', () => ({
 	},
 }));
 
+// Mock connectionState signal — default to 'connected' so loadModelInfo runs
+const { mockConnectionState } = vi.hoisted(() => {
+	// vi.hoisted runs before imports, so we inline a minimal signal-like object
+	const obj = { value: 'connected' };
+	return { mockConnectionState: obj };
+});
+
+vi.mock('../../lib/state', () => ({
+	connectionState: mockConnectionState,
+}));
+
 // Mock toast
 const mockToastSuccess = vi.fn();
 const mockToastError = vi.fn();
@@ -42,6 +53,7 @@ vi.mock('../../lib/toast', () => ({
 describe('useModelSwitcher', () => {
 	beforeEach(() => {
 		vi.resetAllMocks();
+		mockConnectionState.value = 'connected';
 		mockGetHubIfConnected.mockReturnValue({
 			request: vi.fn().mockResolvedValue({ acknowledged: true }),
 			onEvent: vi.fn().mockReturnValue(() => {}),

--- a/packages/web/src/hooks/useModelSwitcher.ts
+++ b/packages/web/src/hooks/useModelSwitcher.ts
@@ -21,6 +21,7 @@ import { useState, useEffect, useCallback } from 'preact/hooks';
 import type { ModelInfo } from '@neokai/shared';
 import type { ProviderAuthStatus } from '@neokai/shared/provider';
 import { connectionManager } from '../lib/connection-manager';
+import { connectionState } from '../lib/state';
 import { toast } from '../lib/toast';
 
 export interface UseModelSwitcherResult {
@@ -241,10 +242,16 @@ export function useModelSwitcher(sessionId: string): UseModelSwitcherResult {
 		}
 	}, [sessionId]);
 
-	// Load on mount and session change
+	// Load when connected and on session change.
+	// connectionState.value triggers a retry when the WebSocket connects
+	// after mount (e.g. fresh page load where ChatContainer renders before
+	// the hub is ready).
+	const isConnected = connectionState.value === 'connected';
 	useEffect(() => {
-		loadModelInfo();
-	}, [loadModelInfo]);
+		if (isConnected) {
+			loadModelInfo();
+		}
+	}, [loadModelInfo, isConnected]);
 
 	const switchModel = useCallback(
 		async (model: ModelInfo) => {

--- a/packages/web/src/islands/BottomTabBar.tsx
+++ b/packages/web/src/islands/BottomTabBar.tsx
@@ -223,6 +223,20 @@ const ROOM_BOTTOM_TABS: TabItem[] = [
 export function BottomTabBar() {
 	const innerRef = useRef<HTMLDivElement>(null);
 
+	const navSection = navSectionSignal.value;
+	const roomId = currentRoomIdSignal.value;
+	const spaceId = currentSpaceIdSignal.value;
+	const inboxBadgeCount = inboxStore.reviewCount.value;
+
+	const roomSessionId = currentRoomSessionIdSignal.value;
+	const roomTaskId = currentRoomTaskIdSignal.value;
+	const isInRoomContext = navSection === 'rooms' && roomId !== null;
+	const isInSpaceContext = navSection === 'spaces' && spaceId !== null;
+
+	// Context key tracks which tab set is rendered. When it changes, the inner
+	// div is recreated (via its `key` prop) and the ResizeObserver must re-attach.
+	const contextKey = isInSpaceContext ? 'space' : isInRoomContext ? 'room' : 'global';
+
 	useEffect(() => {
 		const inner = innerRef.current;
 		if (!inner) return;
@@ -234,8 +248,8 @@ export function BottomTabBar() {
 		};
 
 		// Measure the inner content div (excludes pb-safe) so --bottom-bar-height
-		// only tracks tab content height. Safe area is handled separately via pb-safe
-		// on the main content and chat-footer.
+		// only tracks tab content height. Safe area is handled separately via
+		// pb-safe on the main content wrapper in App.tsx.
 		const ro = new ResizeObserver(updateHeight);
 		ro.observe(inner);
 
@@ -260,17 +274,8 @@ export function BottomTabBar() {
 			cancelAnimationFrame(rafId);
 			document.documentElement.style.setProperty('--bottom-bar-height', '0px');
 		};
-	}, []);
+	}, [contextKey]);
 
-	const navSection = navSectionSignal.value;
-	const roomId = currentRoomIdSignal.value;
-	const spaceId = currentSpaceIdSignal.value;
-	const inboxBadgeCount = inboxStore.reviewCount.value;
-
-	const roomSessionId = currentRoomSessionIdSignal.value;
-	const roomTaskId = currentRoomTaskIdSignal.value;
-	const isInRoomContext = navSection === 'rooms' && roomId !== null;
-	const isInSpaceContext = navSection === 'spaces' && spaceId !== null;
 	const isViewingRoomAgent = currentRoomAgentActiveSignal.value;
 	// Overview is only active when on the room dashboard (no task, no session, no agent chat)
 	const isViewingRoomDashboard =
@@ -373,7 +378,7 @@ export function BottomTabBar() {
 			<div
 				ref={innerRef}
 				class="flex w-full border-t border-dark-700 transition-opacity duration-200 ease-out"
-				key={isInSpaceContext ? 'space' : isInRoomContext ? 'room' : 'global'}
+				key={contextKey}
 			>
 				{tabs.map((tab) => {
 					const isActive = isTabActive(tab.id);

--- a/packages/web/src/islands/BottomTabBar.tsx
+++ b/packages/web/src/islands/BottomTabBar.tsx
@@ -241,9 +241,6 @@ export function BottomTabBar({ inline }: { inline?: boolean } = {}) {
 	const isInRoomContext = navSection === 'rooms' && roomId !== null;
 	const isInSpaceContext = navSection === 'spaces' && spaceId !== null;
 
-	// When in space context, only render the inline version (inside SpaceIsland layout)
-	if (isInSpaceContext && !inline) return null;
-
 	const isViewingRoomAgent = currentRoomAgentActiveSignal.value;
 	// Overview is only active when on the room dashboard (no task, no session, no agent chat)
 	const isViewingRoomDashboard =

--- a/packages/web/src/islands/BottomTabBar.tsx
+++ b/packages/web/src/islands/BottomTabBar.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from 'preact';
-import { useEffect, useRef } from 'preact/hooks';
+import { useEffect } from 'preact/hooks';
 import {
 	navSectionSignal,
 	currentRoomIdSignal,
@@ -220,8 +220,16 @@ const ROOM_BOTTOM_TABS: TabItem[] = [
 	{ id: 'room-missions', label: 'Missions', icon: MissionIcon },
 ];
 
-export function BottomTabBar() {
-	const innerRef = useRef<HTMLDivElement>(null);
+const BOTTOM_BAR_HEIGHT = 53;
+
+export function BottomTabBar({ inline }: { inline?: boolean } = {}) {
+	// Set CSS variable for other components to account for tab bar height
+	useEffect(() => {
+		document.documentElement.style.setProperty('--bottom-bar-height', BOTTOM_BAR_HEIGHT + 'px');
+		return () => {
+			document.documentElement.style.setProperty('--bottom-bar-height', '0px');
+		};
+	}, []);
 
 	const navSection = navSectionSignal.value;
 	const roomId = currentRoomIdSignal.value;
@@ -233,48 +241,8 @@ export function BottomTabBar() {
 	const isInRoomContext = navSection === 'rooms' && roomId !== null;
 	const isInSpaceContext = navSection === 'spaces' && spaceId !== null;
 
-	// Context key tracks which tab set is rendered. When it changes, the inner
-	// div is recreated (via its `key` prop) and the ResizeObserver must re-attach.
-	const contextKey = isInSpaceContext ? 'space' : isInRoomContext ? 'room' : 'global';
-
-	useEffect(() => {
-		const inner = innerRef.current;
-		if (!inner) return;
-
-		const updateHeight = () => {
-			if (document.documentElement.classList.contains('keyboard-open')) return;
-			const h = inner.offsetHeight;
-			document.documentElement.style.setProperty('--bottom-bar-height', h + 'px');
-		};
-
-		// Measure the inner content div (excludes pb-safe) so --bottom-bar-height
-		// only tracks tab content height. Safe area is handled separately via
-		// pb-safe on the main content wrapper in App.tsx.
-		const ro = new ResizeObserver(updateHeight);
-		ro.observe(inner);
-
-		let rafId = 0;
-		const scheduleUpdate = () => {
-			cancelAnimationFrame(rafId);
-			rafId = requestAnimationFrame(updateHeight);
-		};
-		window.addEventListener('resize', scheduleUpdate);
-
-		const vv = window.visualViewport;
-		if (vv) vv.addEventListener('resize', scheduleUpdate);
-
-		updateHeight();
-		const timer = setTimeout(updateHeight, 300);
-
-		return () => {
-			clearTimeout(timer);
-			ro.disconnect();
-			window.removeEventListener('resize', scheduleUpdate);
-			if (vv) vv.removeEventListener('resize', scheduleUpdate);
-			cancelAnimationFrame(rafId);
-			document.documentElement.style.setProperty('--bottom-bar-height', '0px');
-		};
-	}, [contextKey]);
+	// When in space context, only render the inline version (inside SpaceIsland layout)
+	if (isInSpaceContext && !inline) return null;
 
 	const isViewingRoomAgent = currentRoomAgentActiveSignal.value;
 	// Overview is only active when on the room dashboard (no task, no session, no agent chat)
@@ -365,7 +333,11 @@ export function BottomTabBar() {
 	return (
 		<div
 			data-testid="bottom-tab-bar"
-			class="flex md:hidden fixed bottom-0 left-0 right-0 z-50 bg-dark-900/90 backdrop-blur-md pb-safe"
+			class={
+				inline
+					? 'flex md:hidden flex-shrink-0 bg-dark-900/90 backdrop-blur-md pb-safe'
+					: 'flex md:hidden fixed bottom-0 left-0 right-0 z-50 bg-dark-900/90 backdrop-blur-md pb-safe'
+			}
 			role="tablist"
 			aria-label={
 				isInSpaceContext
@@ -376,9 +348,9 @@ export function BottomTabBar() {
 			}
 		>
 			<div
-				ref={innerRef}
 				class="flex w-full border-t border-dark-700 transition-opacity duration-200 ease-out"
-				key={contextKey}
+				style={{ height: BOTTOM_BAR_HEIGHT + 'px' }}
+				key={isInSpaceContext ? 'space' : isInRoomContext ? 'room' : 'global'}
 			>
 				{tabs.map((tab) => {
 					const isActive = isTabActive(tab.id);

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -910,6 +910,20 @@ export default function ChatContainer({
 				</div>
 			)}
 
+			{/* Error Banner */}
+			{error && (
+				<ErrorBanner
+					error={error}
+					hasDetails={!!storeError?.details}
+					onViewDetails={errorDialog.open}
+					onDismiss={() => {
+						setLocalError(null);
+						sessionStore.clearError();
+					}}
+					actions={errorActions.length > 0 ? errorActions : undefined}
+				/>
+			)}
+
 			{/* Header */}
 			<ChatHeader
 				session={session}
@@ -1097,92 +1111,75 @@ export default function ChatContainer({
 			</div>
 
 			{/* Footer - Floating Status Bar */}
-			<div class="chat-footer absolute bottom-0 left-0 right-0 z-10 pointer-events-none">
-				{/* Error Banner */}
-				{error && (
-					<div class="pointer-events-auto">
-						<ErrorBanner
-							error={error}
-							hasDetails={!!storeError?.details}
-							onViewDetails={errorDialog.open}
-							onDismiss={() => {
-								setLocalError(null);
-								sessionStore.clearError();
-							}}
-							actions={errorActions.length > 0 ? errorActions : undefined}
-						/>
-					</div>
-				)}
-				<div
-					ref={footerContainerRef}
-					class="pointer-events-auto pt-4 bg-gradient-to-t from-dark-900 from-[calc(100%-32px)] to-dark-900/0"
-				>
-					<SessionStatusBar
-						sessionId={sessionId}
-						isProcessing={isProcessing}
-						currentAction={currentAction}
-						streamingPhase={streamingPhase}
-						contextUsage={contextUsage ?? undefined}
-						maxContextTokens={200000}
-						features={features}
-						currentModel={currentModel}
-						currentModelInfo={currentModelInfo}
-						availableModels={availableModels}
-						modelSwitching={modelSwitching}
-						modelLoading={modelLoading}
-						onModelSwitch={handleModelSwitchWithConfirmation}
-						autoScroll={autoScroll}
-						onAutoScrollChange={handleAutoScrollChange}
-						coordinatorMode={coordinatorMode}
-						coordinatorSwitching={coordinatorSwitching}
-						onCoordinatorModeChange={handleCoordinatorModeChange}
-						sandboxEnabled={sandboxEnabled}
-						sandboxSwitching={sandboxSwitching}
-						onSandboxModeChange={handleSandboxModeChange}
-						thinkingLevel={session?.config?.thinkingLevel}
-					/>
+			<div
+				ref={footerContainerRef}
+				class="chat-footer absolute bottom-0 left-0 right-0 z-10 pt-4 bg-gradient-to-t from-dark-900 from-[calc(100%-32px)] to-dark-900/0"
+			>
+				<SessionStatusBar
+					sessionId={sessionId}
+					isProcessing={isProcessing}
+					currentAction={currentAction}
+					streamingPhase={streamingPhase}
+					contextUsage={contextUsage ?? undefined}
+					maxContextTokens={200000}
+					features={features}
+					currentModel={currentModel}
+					currentModelInfo={currentModelInfo}
+					availableModels={availableModels}
+					modelSwitching={modelSwitching}
+					modelLoading={modelLoading}
+					onModelSwitch={handleModelSwitchWithConfirmation}
+					autoScroll={autoScroll}
+					onAutoScrollChange={handleAutoScrollChange}
+					coordinatorMode={coordinatorMode}
+					coordinatorSwitching={coordinatorSwitching}
+					onCoordinatorModeChange={handleCoordinatorModeChange}
+					sandboxEnabled={sandboxEnabled}
+					sandboxSwitching={sandboxSwitching}
+					onSandboxModeChange={handleSandboxModeChange}
+					thinkingLevel={session?.config?.thinkingLevel}
+				/>
 
-					{session?.status === 'archived' ? (
-						<div class="p-4">
-							<div class="max-w-4xl mx-auto">
-								<div
-									class={cn(
-										'rounded-3xl border px-5 py-3 text-center',
-										'bg-dark-800/60 backdrop-blur-sm',
-										borderColors.ui.default
-									)}
-								>
-									<span class="text-gray-400 text-sm flex items-center justify-center gap-2">
-										<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-											<path
-												strokeLinecap="round"
-												strokeLinejoin="round"
-												strokeWidth={2}
-												d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"
-											/>
-										</svg>
-										Session archived
-									</span>
-								</div>
+				{session?.status === 'archived' ? (
+					<div class="p-4">
+						<div class="max-w-4xl mx-auto">
+							<div
+								class={cn(
+									'rounded-3xl border px-5 py-3 text-center',
+									'bg-dark-800/60 backdrop-blur-sm',
+									borderColors.ui.default
+								)}
+							>
+								<span class="text-gray-400 text-sm flex items-center justify-center gap-2">
+									<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										<path
+											strokeLinecap="round"
+											strokeLinejoin="round"
+											strokeWidth={2}
+											d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"
+										/>
+									</svg>
+									Session archived
+								</span>
 							</div>
 						</div>
-					) : (
-						!readonly && (
-							<MessageInput
-								sessionId={sessionId}
-								sessionType={session?.type}
-								onSend={handleSendMessage}
-								disabled={isWaitingForInput || !isConnected}
-								autoScroll={autoScroll}
-								onAutoScrollChange={handleAutoScrollChange}
-								onOpenTools={toolsModal.open}
-								onEnterRewindMode={handleEnterRewindMode}
-								rewindMode={rewindMode}
-								onExitRewindMode={handleExitRewindMode}
-							/>
-						)
-					)}
-				</div>
+					</div>
+				) : (
+					!readonly && (
+						<MessageInput
+							sessionId={sessionId}
+							sessionType={session?.type}
+							onSend={handleSendMessage}
+							disabled={isWaitingForInput || !isConnected}
+							autoScroll={autoScroll}
+							onAutoScrollChange={handleAutoScrollChange}
+							onOpenTools={toolsModal.open}
+							onEnterRewindMode={handleEnterRewindMode}
+							rewindMode={rewindMode}
+							onExitRewindMode={handleExitRewindMode}
+						/>
+					)
+				)}
 			</div>
 
 			{/* Delete Modal */}

--- a/packages/web/src/islands/MainContent.tsx
+++ b/packages/web/src/islands/MainContent.tsx
@@ -14,6 +14,7 @@ import {
 } from '../lib/signals.ts';
 import { sessions } from '../lib/state.ts';
 import Lobby from './Lobby.tsx';
+import { BottomTabBar } from './BottomTabBar.tsx';
 import { MobileMenuButton } from '../components/ui/MobileMenuButton.tsx';
 
 // Lazy-loaded route components — reduces initial module count in dev mode
@@ -216,9 +217,13 @@ export default function MainContent() {
 
 	// Wrap content in a keyed div so Preact remounts it (and replays animate-fadeIn-200)
 	// whenever the major content view changes.
+	// BottomTabBar sits outside the keyed div so it never remounts on view transitions.
 	return (
-		<div key={contentKey} class="flex-1 flex flex-col overflow-hidden animate-fadeIn-200">
-			{renderContent()}
-		</div>
+		<>
+			<div key={contentKey} class="flex-1 flex flex-col overflow-hidden animate-fadeIn-200">
+				{renderContent()}
+			</div>
+			<BottomTabBar inline />
+		</>
 	);
 }

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -22,6 +22,7 @@ import { AgentOverlayChat } from '../components/space/AgentOverlayChat';
 import { spaceStore } from '../lib/space-store';
 import { navigateToSpace, navigateToSpaceTask } from '../lib/router';
 import ChatContainer from './ChatContainer';
+import { BottomTabBar } from './BottomTabBar';
 
 interface SpaceIslandProps {
 	spaceId: string;
@@ -58,12 +59,13 @@ export default function SpaceIsland({
 	}, [spaceId]);
 
 	// Session/agent chat view — render immediately, don't block on space data
+	// ChatContainer's root is already flex-1 flex-col overflow-hidden, so it
+	// sits directly in the flex column alongside the inline BottomTabBar.
+	// AgentOverlayChat uses a Portal so it doesn't affect layout.
 	if (sessionViewId) {
 		return (
 			<>
-				<div class="flex-1 flex flex-col overflow-hidden">
-					<ChatContainer key={sessionViewId} sessionId={sessionViewId} />
-				</div>
+				<ChatContainer key={sessionViewId} sessionId={sessionViewId} />
 				{overlaySessionId && (
 					<AgentOverlayChat
 						sessionId={overlaySessionId}
@@ -71,6 +73,7 @@ export default function SpaceIsland({
 						onClose={handleOverlayClose}
 					/>
 				)}
+				<BottomTabBar inline />
 			</>
 		);
 	}
@@ -108,6 +111,7 @@ export default function SpaceIsland({
 						onClose={handleOverlayClose}
 					/>
 				)}
+				<BottomTabBar inline />
 			</>
 		);
 	}
@@ -134,6 +138,7 @@ export default function SpaceIsland({
 						onClose={handleOverlayClose}
 					/>
 				)}
+				<BottomTabBar inline />
 			</>
 		);
 	}
@@ -157,6 +162,7 @@ export default function SpaceIsland({
 						onClose={handleOverlayClose}
 					/>
 				)}
+				<BottomTabBar inline />
 			</>
 		);
 	}
@@ -182,6 +188,7 @@ export default function SpaceIsland({
 					/>
 				</div>
 			</div>
+			<BottomTabBar inline />
 		</>
 	);
 }

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -22,7 +22,6 @@ import { AgentOverlayChat } from '../components/space/AgentOverlayChat';
 import { spaceStore } from '../lib/space-store';
 import { navigateToSpace, navigateToSpaceTask } from '../lib/router';
 import ChatContainer from './ChatContainer';
-import { BottomTabBar } from './BottomTabBar';
 
 interface SpaceIslandProps {
 	spaceId: string;
@@ -59,8 +58,7 @@ export default function SpaceIsland({
 	}, [spaceId]);
 
 	// Session/agent chat view — render immediately, don't block on space data
-	// ChatContainer's root is already flex-1 flex-col overflow-hidden, so it
-	// sits directly in the flex column alongside the inline BottomTabBar.
+	// ChatContainer's root is already flex-1 flex-col overflow-hidden.
 	// AgentOverlayChat uses a Portal so it doesn't affect layout.
 	if (sessionViewId) {
 		return (
@@ -73,7 +71,6 @@ export default function SpaceIsland({
 						onClose={handleOverlayClose}
 					/>
 				)}
-				<BottomTabBar inline />
 			</>
 		);
 	}
@@ -111,7 +108,6 @@ export default function SpaceIsland({
 						onClose={handleOverlayClose}
 					/>
 				)}
-				<BottomTabBar inline />
 			</>
 		);
 	}
@@ -138,7 +134,6 @@ export default function SpaceIsland({
 						onClose={handleOverlayClose}
 					/>
 				)}
-				<BottomTabBar inline />
 			</>
 		);
 	}
@@ -162,7 +157,6 @@ export default function SpaceIsland({
 						onClose={handleOverlayClose}
 					/>
 				)}
-				<BottomTabBar inline />
 			</>
 		);
 	}
@@ -188,7 +182,6 @@ export default function SpaceIsland({
 					/>
 				</div>
 			</div>
-			<BottomTabBar inline />
 		</>
 	);
 }

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -17,6 +17,7 @@ import { SpaceConfigurePage } from '../components/space/SpaceConfigurePage';
 import { SpaceTasks } from '../components/space/SpaceTasks';
 import { SpaceOverview } from '../components/space/SpaceOverview';
 import { SpaceTaskPane } from '../components/space/SpaceTaskPane';
+import { SpacePageHeader } from '../components/space/SpacePageHeader';
 import { AgentOverlayChat } from '../components/space/AgentOverlayChat';
 import { spaceStore } from '../lib/space-store';
 import { navigateToSpace, navigateToSpaceTask } from '../lib/router';
@@ -114,7 +115,11 @@ export default function SpaceIsland({
 	if (viewMode === 'tasks' && space) {
 		return (
 			<>
-				<div class="flex-1 flex overflow-hidden bg-dark-900" data-testid="space-tasks-view">
+				<div
+					class="flex-1 flex flex-col overflow-hidden bg-dark-900"
+					data-testid="space-tasks-view"
+				>
+					<SpacePageHeader spaceName={space.name} pageTitle="Tasks" />
 					<div class="flex-1 min-w-0 overflow-hidden flex flex-col">
 						<SpaceTasks
 							spaceId={spaceId}
@@ -136,7 +141,11 @@ export default function SpaceIsland({
 	if (viewMode === 'configure' && space) {
 		return (
 			<>
-				<div class="flex-1 flex overflow-hidden bg-dark-900" data-testid="space-configure-view">
+				<div
+					class="flex-1 flex flex-col overflow-hidden bg-dark-900"
+					data-testid="space-configure-view"
+				>
+					<SpacePageHeader spaceName={space.name} pageTitle="Settings" />
 					<div class="flex-1 min-w-0 overflow-hidden flex flex-col">
 						<SpaceConfigurePage space={space} />
 					</div>
@@ -161,7 +170,11 @@ export default function SpaceIsland({
 					onClose={handleOverlayClose}
 				/>
 			)}
-			<div class="flex-1 flex overflow-hidden bg-dark-900" data-testid="space-overview-view">
+			<div
+				class="flex-1 flex flex-col overflow-hidden bg-dark-900"
+				data-testid="space-overview-view"
+			>
+				<SpacePageHeader spaceName={space?.name ?? ''} pageTitle="Overview" />
 				<div class="flex-1 overflow-hidden flex flex-col min-w-0">
 					<SpaceOverview
 						spaceId={spaceId}

--- a/packages/web/src/lib/__tests__/ios-safe-area.test.ts
+++ b/packages/web/src/lib/__tests__/ios-safe-area.test.ts
@@ -34,12 +34,7 @@ describe('iOS iPad Safari safe area support', () => {
 		expect(useViewportSafetyTs).toContain('--safe-height');
 	});
 
-	it('App.tsx uses pb-bottom-bar utility class for dynamic bottom padding', () => {
-		expect(appTsx).toContain('pb-bottom-bar');
-	});
-
 	it('App.tsx does not use hardcoded pb-16 for main content bottom padding', () => {
-		// The main content div should not have pb-16 — dynamic approach is used instead
 		expect(appTsx).not.toContain('pb-16');
 	});
 
@@ -47,18 +42,11 @@ describe('iOS iPad Safari safe area support', () => {
 		expect(bottomTabBarTsx).toContain('--bottom-bar-height');
 	});
 
-	it('BottomTabBar uses ResizeObserver to measure actual height', () => {
-		expect(bottomTabBarTsx).toContain('ResizeObserver');
+	it('BottomTabBar uses a fixed height constant instead of dynamic measurement', () => {
+		expect(bottomTabBarTsx).toContain('BOTTOM_BAR_HEIGHT');
 	});
 
-	it('BottomTabBar adds a window resize listener for breakpoint transitions', () => {
-		expect(bottomTabBarTsx).toContain("window.addEventListener('resize'");
-	});
-
-	it('BottomTabBar cleans up observers and resets --bottom-bar-height on unmount', () => {
-		expect(bottomTabBarTsx).toContain('ro.disconnect()');
-		expect(bottomTabBarTsx).toContain("window.removeEventListener('resize'");
-		expect(bottomTabBarTsx).toContain('cancelAnimationFrame');
+	it('BottomTabBar resets --bottom-bar-height on unmount', () => {
 		expect(bottomTabBarTsx).toContain("'--bottom-bar-height', '0px'");
 	});
 });

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -667,16 +667,6 @@ html.keyboard-open [data-testid="bottom-tab-bar"] {
 	transform: translateY(100%);
 }
 
-/**
- * When the keyboard is open, remove safe-area-inset-bottom padding from the
- * chat footer. The keyboard covers the home indicator area, so the extra
- * padding pushes content up unnecessarily.
- */
-.chat-footer {
-	padding-bottom: env(safe-area-inset-bottom, 0px);
-}
-
-html.keyboard-open .chat-footer,
-html.keyboard-open .chat-footer > div {
-	padding-bottom: 0px !important;
-}
+/* Safe area bottom padding is handled at the app level via pb-safe + pb-bottom-bar
+   on the main content wrapper. The chat footer does not need its own safe area
+   padding — the wrapper already accounts for both the tab bar and home indicator. */

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -138,14 +138,21 @@ body {
 	-moz-osx-font-smoothing: grayscale;
 	/* Prevent page-level scrolling - only message container should scroll */
 	overflow: hidden;
-	/* Use dynamic viewport height for mobile Safari (accounts for address bar) */
-	height: 100dvh;
 	/* Fallback for browsers that don't support dvh */
 	height: 100vh;
+	/* Dynamic viewport height for mobile Safari (accounts for address bar).
+	   MUST come after 100vh so it overrides in supporting browsers. */
+	height: 100dvh;
 	/* Prevent overscroll bounce on body - scrollable children handle their own */
 	overscroll-behavior: none;
 	/* Allow touch manipulation (zoom, pan) but let children control scroll */
 	touch-action: manipulation;
+}
+
+/* Preact mount point — make it invisible to layout so App's root div
+   is effectively a direct child of <body>. */
+#root {
+	display: contents;
 }
 
 /* Smooth scrolling */


### PR DESCRIPTION
## Summary
- Fix iOS Safari viewport gaps: correct CSS ordering (`100vh` then `100dvh`) and add `#root { display: contents }` to eliminate layout wrapper
- Move BottomTabBar from fixed overlay to inline flex layout in MainContent, available on all views
- Replace ResizeObserver height measurement with fixed constant, simplify BottomTabBar architecture
- Fix model list empty on fresh space session page load by gating `useModelSwitcher` on connection state

## Test plan
- [ ] Verify no gaps between tab bar and Safari toolbar on real iOS device
- [ ] Verify BottomTabBar shows correct tabs on all views (spaces, rooms, sessions, settings)
- [ ] Verify model list populates on fresh page load of space agent session
- [ ] Verify tab bar doesn't remount/flash during view transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)