### PR TITLE
fix: model dropdown overflow on mobile and click-outside dismiss

### DIFF
--- a/packages/web/src/components/SessionStatusBar.tsx
+++ b/packages/web/src/components/SessionStatusBar.tsx
@@ -13,7 +13,7 @@
  */
 
 import { useSignalEffect } from '@preact/signals';
-import { useState, useCallback, useEffect } from 'preact/hooks';
+import { useState, useCallback, useEffect, useRef } from 'preact/hooks';
 import type { ContextInfo, ModelInfo, ThinkingLevel, SessionFeatures } from '@neokai/shared';
 import type { ProviderAuthStatus } from '@neokai/shared/provider';
 import { DEFAULT_WORKER_FEATURES } from '@neokai/shared';
@@ -23,6 +23,7 @@ import ContextUsageBar from './ContextUsageBar.tsx';
 import { ContentContainer } from './ui/ContentContainer.tsx';
 import {
 	useModal,
+	useClickOutside,
 	getModelFamilyIcon,
 	getProviderLabel,
 	groupModelsByProvider,
@@ -267,6 +268,10 @@ export default function SessionStatusBar({
 	// Dropdowns - only one can be open at a time
 	const modelDropdown = useModal();
 	const thinkingDropdown = useModal();
+	const modelDropdownRef = useRef<HTMLDivElement>(null);
+	const thinkingDropdownRef = useRef<HTMLDivElement>(null);
+	useClickOutside(modelDropdownRef, modelDropdown.close, modelDropdown.isOpen);
+	useClickOutside(thinkingDropdownRef, thinkingDropdown.close, thinkingDropdown.isOpen);
 
 	// Helper to toggle dropdown and close the other one
 	const toggleModelDropdown = useCallback(() => {
@@ -423,7 +428,7 @@ export default function SessionStatusBar({
 
 				{/* Model Switcher + Provider Badge */}
 				<div class="flex items-center gap-1.5">
-					<div class="relative">
+					<div class="relative" ref={modelDropdownRef}>
 						<Tooltip
 							content={currentModelInfo ? `Model: ${currentModelInfo.name}` : 'Switch Model'}
 							position="top"
@@ -445,7 +450,7 @@ export default function SessionStatusBar({
 						{modelDropdown.isOpen && (
 							<div
 								data-testid="model-dropdown"
-								class={`absolute bottom-full mb-2 left-0 bg-dark-800 border ${borderColors.ui.secondary} rounded-lg shadow-xl w-52 py-1 z-50 animate-slideIn`}
+								class={`absolute bottom-full mb-2 left-0 bg-dark-800 border ${borderColors.ui.secondary} rounded-lg shadow-xl w-52 py-1 z-50 animate-slideIn max-h-[60vh] overflow-y-auto`}
 							>
 								<div class="px-3 py-1.5 text-xs font-semibold text-gray-400">Select Model</div>
 								{Array.from(
@@ -520,7 +525,7 @@ export default function SessionStatusBar({
 				</div>
 
 				{/* Thinking Level */}
-				<div class="relative">
+				<div class="relative" ref={thinkingDropdownRef}>
 					<Tooltip
 						content={`Thinking: ${THINKING_LEVEL_LABELS[thinkingLevel]}`}
 						position="top"


### PR DESCRIPTION
## Summary
- Cap model list dropdown height at 60vh with scroll overflow for mobile viewports
- Add click-outside and Escape key dismiss for both model and thinking dropdowns using existing `useClickOutside` hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)