### PR TITLE
chore: update SDKs, add @openai/codex dep, resolve codex from node_modules

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,9 @@
     "": {
       "name": "neokai",
       "devDependencies": {
-        "@biomejs/biome": "2.4.10",
+        "@biomejs/biome": "2.4.11",
         "@testing-library/preact": "3.2.4",
-        "knip": "6.3.0",
+        "knip": "6.3.1",
         "oxlint": "1.59.0",
         "typescript": "6.0.2",
       },
@@ -34,9 +34,10 @@
       "name": "@neokai/daemon",
       "version": "0.8.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.2.94",
-        "@github/copilot-sdk": "0.2.1",
+        "@anthropic-ai/claude-agent-sdk": "0.2.98",
+        "@github/copilot-sdk": "0.2.2",
         "@neokai/shared": "workspace:*",
+        "@openai/codex": "0.118.0",
         "croner": "10.0.1",
         "simple-git": "3.35.2",
         "zod": "4.3.6",
@@ -107,7 +108,7 @@
     },
   },
   "packages": {
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.94", "", { "dependencies": { "@anthropic-ai/sdk": "^0.80.0", "@modelcontextprotocol/sdk": "^1.27.1" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-XEWIaReW53kmnLRXzPeCd467DwGFcggBlJX6sA8ubnmEor4icNPZhDKskroP5hEuPnJuPsdDxwitz7LbQbq11w=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.98", "", { "dependencies": { "@anthropic-ai/sdk": "^0.80.0", "@modelcontextprotocol/sdk": "^1.27.1" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-pWUx+xY21rKy5wvX0eBZja7p8J5ykOYaHsykvdj9nkTbAVXmP1WusI1mP6jbBByJ8uBJeBc4beAPSZIFcdIpTA=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.80.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g=="],
 
@@ -157,23 +158,23 @@
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.10", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.10", "@biomejs/cli-darwin-x64": "2.4.10", "@biomejs/cli-linux-arm64": "2.4.10", "@biomejs/cli-linux-arm64-musl": "2.4.10", "@biomejs/cli-linux-x64": "2.4.10", "@biomejs/cli-linux-x64-musl": "2.4.10", "@biomejs/cli-win32-arm64": "2.4.10", "@biomejs/cli-win32-x64": "2.4.10" }, "bin": { "biome": "bin/biome" } }, "sha512-xxA3AphFQ1geij4JTHXv4EeSTda1IFn22ye9LdyVPoJU19fNVl0uzfEuhsfQ4Yue/0FaLs2/ccVi4UDiE7R30w=="],
+    "@biomejs/biome": ["@biomejs/biome@2.4.11", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.11", "@biomejs/cli-darwin-x64": "2.4.11", "@biomejs/cli-linux-arm64": "2.4.11", "@biomejs/cli-linux-arm64-musl": "2.4.11", "@biomejs/cli-linux-x64": "2.4.11", "@biomejs/cli-linux-x64-musl": "2.4.11", "@biomejs/cli-win32-arm64": "2.4.11", "@biomejs/cli-win32-x64": "2.4.11" }, "bin": { "biome": "bin/biome" } }, "sha512-nWxHX8tf3Opb/qRgZpBbsTOqOodkbrkJ7S+JxJAruxOReaDPPmPuLBAGQ8vigyUgo0QBB+oQltNEAvalLcjggA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vuzzI1cWqDVzOMIkYyHbKqp+AkQq4K7k+UCXWpkYcY/HDn1UxdsbsfgtVpa40shem8Kax4TLDLlx8kMAecgqiw=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wOt+ed+L2dgZanWyL6i29qlXMc088N11optzpo10peayObBaAshbTcxKUchzEMp9QSY8rh5h6VfAFE3WTS1rqg=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-14fzASRo+BPotwp7nWULy2W5xeUyFnTaq1V13Etrrxkrih+ez/2QfgFm5Ehtf5vSjtgx/IJycMMpn5kPd5ZNaA=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-gZ6zR8XmZlExfi/Pz/PffmdpWOQ8Qhy7oBztgkR8/ylSRyLwfRPSadmiVCV8WQ8PoJ2MWUy2fgID9zmtgUUJmw=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-7MH1CMW5uuxQ/s7FLST63qF8B3Hgu2HRdZ7tA1X1+mk+St4JOuIrqdhIBnnyqeyWJNI+Bww7Es5QZ0wIc1Cmkw=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-avdJaEElXrKceK0va9FkJ4P5ci3N01TGkc6ni3P8l3BElqbOz42Wg2IyX3gbh0ZLEd4HVKEIrmuVu/AMuSeFFA=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-WrJY6UuiSD/Dh+nwK2qOTu8kdMDlLV3dLMmychIghHPAysWFq1/DGC1pVZx8POE3ZkzKR3PUUnVrtZfMfaJjyQ=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-+Sbo1OAmlegtdwqFE8iOxFIWLh1B3OEgsuZfBpyyN/kWuqZ8dx9ZEes6zVnDMo+zRHF2wLynRVhoQmV7ohxl2Q=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.10", "", { "os": "linux", "cpu": "x64" }, "sha512-tZLvEEi2u9Xu1zAqRjTcpIDGVtldigVvzug2fTuPG0ME/g8/mXpRPcNgLB22bGn6FvLJpHHnqLnwliOu8xjYrg=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.11", "", { "os": "linux", "cpu": "x64" }, "sha512-TagWV0iomp5LnEnxWFg4nQO+e52Fow349vaX0Q/PIcX6Zhk4GGBgp3qqZ8PVkpC+cuehRctMf3+6+FgQ8jCEFQ=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.10", "", { "os": "linux", "cpu": "x64" }, "sha512-kDTi3pI6PBN6CiczsWYOyP2zk0IJI08EWEQyDMQWW221rPaaEz6FvjLhnU07KMzLv8q3qSuoB93ua6inSQ55Tw=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.11", "", { "os": "linux", "cpu": "x64" }, "sha512-bexd2IklK7ZgPhrz6jXzpIL6dEAH9MlJU1xGTrypx+FICxrXUp4CqtwfiuoDKse+UlgAlWtzML3jrMqeEAHEhA=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-RJhaTnY8byzxDt4bDVb7AFPHkPcjOPK3xBip4ZRTrN3TEfyhjLRm3r3mqknqydgVTB74XG8l4jMLwEACEeihVg=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.10", "", { "os": "win32", "cpu": "x64" }, "sha512-aW/JU5GuyH4uxMrNYpoC2kjaHlyJGLgIa3XkhPEZI0uKhZhJZU8BuEyJmvgzSPQNGozBwWjC972RaNdcJ9KyJg=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.11", "", { "os": "win32", "cpu": "x64" }, "sha512-A8D3JM/00C2KQgUV3oj8Ba15EHEYwebAGCy5Sf9GAjr5Y3+kJIYOiESoqRDeuRZueuMdCsbLZIUqmPhpYXJE9A=="],
 
     "@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 
@@ -187,21 +188,21 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
-    "@github/copilot": ["@github/copilot@1.0.19", "", { "optionalDependencies": { "@github/copilot-darwin-arm64": "1.0.19", "@github/copilot-darwin-x64": "1.0.19", "@github/copilot-linux-arm64": "1.0.19", "@github/copilot-linux-x64": "1.0.19", "@github/copilot-win32-arm64": "1.0.19", "@github/copilot-win32-x64": "1.0.19" }, "bin": { "copilot": "npm-loader.js" } }, "sha512-hyKDlv/dWg8AMvrDJeSiCdV7UQQwRMnNk8X1/G8DMpfmV4HQE3uVgMzrwMGKvXctz3gKYW6s3fAmwKBWCVRdBw=="],
+    "@github/copilot": ["@github/copilot@1.0.22", "", { "optionalDependencies": { "@github/copilot-darwin-arm64": "1.0.22", "@github/copilot-darwin-x64": "1.0.22", "@github/copilot-linux-arm64": "1.0.22", "@github/copilot-linux-x64": "1.0.22", "@github/copilot-win32-arm64": "1.0.22", "@github/copilot-win32-x64": "1.0.22" }, "bin": { "copilot": "npm-loader.js" } }, "sha512-BR9oTJ1tQ51RV81xcxmlZe0zB3Tf8i/vFsKSTm2f5wRLJgtuVl2LgaFStoI/peTFcmgtZbhrqsnWTu5GkEPK5Q=="],
 
-    "@github/copilot-darwin-arm64": ["@github/copilot-darwin-arm64@1.0.19", "", { "os": "darwin", "cpu": "arm64", "bin": { "copilot-darwin-arm64": "copilot" } }, "sha512-zROVLH0un2OJoj3gI/z+dLpWr7H2yX0cKCyMQ2rORo5DqmtGYc3Db8TyydVqadqihgK3EF1J9b/lquno5uvKJQ=="],
+    "@github/copilot-darwin-arm64": ["@github/copilot-darwin-arm64@1.0.22", "", { "os": "darwin", "cpu": "arm64", "bin": { "copilot-darwin-arm64": "copilot" } }, "sha512-cK42uX+oz46Cjsb7z+rdPw+DIGczfVSFWlc1WDcdVlwBW4cEfV0pzFXExpN1r1z179TFgAaVMbhkgLqhOZ/PeQ=="],
 
-    "@github/copilot-darwin-x64": ["@github/copilot-darwin-x64@1.0.19", "", { "os": "darwin", "cpu": "x64", "bin": { "copilot-darwin-x64": "copilot" } }, "sha512-Oc+HgwzaWjPfVoDu1GsVFX6ejp7w14T2wNK+jXgPqo980FrRxU1B4oAySvThxjd2Q1Ekq/WG1ReGeHZ7lmfK1w=="],
+    "@github/copilot-darwin-x64": ["@github/copilot-darwin-x64@1.0.22", "", { "os": "darwin", "cpu": "x64", "bin": { "copilot-darwin-x64": "copilot" } }, "sha512-Pmw0ipF+yeLbP6JctsEoMS2LUCpVdC2r557BnCoe48BN8lO8i9JLnkpuDDrJ1AZuCk1VjnujFKEQywOOdfVlpA=="],
 
-    "@github/copilot-linux-arm64": ["@github/copilot-linux-arm64@1.0.19", "", { "os": "linux", "cpu": "arm64", "bin": { "copilot-linux-arm64": "copilot" } }, "sha512-w+wrbIDP5n+Vl8968AXEw4TOBU7DO1vP8P7Vg/6pBQYNbnddQ0Exv8oDORhFhK1F+G5TWoO7qsOlS9ByM8+Dlw=="],
+    "@github/copilot-linux-arm64": ["@github/copilot-linux-arm64@1.0.22", "", { "os": "linux", "cpu": "arm64", "bin": { "copilot-linux-arm64": "copilot" } }, "sha512-WVgG67VmZgHoD7GMlkTxEVe1qK8k9Ek9A02/Da7obpsDdtBInt3nJTwBEgm4cNDM4XaenQH17/jmwVtTwXB6lw=="],
 
-    "@github/copilot-linux-x64": ["@github/copilot-linux-x64@1.0.19", "", { "os": "linux", "cpu": "x64", "bin": { "copilot-linux-x64": "copilot" } }, "sha512-81PN9WmfwDN7NP/x1K8HO+yK2uKL26ig3Vitdtbvjs44a55ltwOnOAEO8BWi0cIkC6N9x1WbUH8DfQZLN6kJ0g=="],
+    "@github/copilot-linux-x64": ["@github/copilot-linux-x64@1.0.22", "", { "os": "linux", "cpu": "x64", "bin": { "copilot-linux-x64": "copilot" } }, "sha512-XRkHVFmdC7FMrczXOdPjbNKiknMr13asKtwJoErJO/Xdy4cmzKQHSvNsBk8VNrr7oyWrUcB1F6mbIxb2LFxPOw=="],
 
-    "@github/copilot-sdk": ["@github/copilot-sdk@0.2.1", "", { "dependencies": { "@github/copilot": "^1.0.17", "vscode-jsonrpc": "^8.2.1", "zod": "^4.3.6" } }, "sha512-S1n/4X1viqbSAWcHDZcFyZ/7hgTLAXr3NY7yNmHoX/CL4LTuYIJ6y5w2jrqUnrJNQgtNrMDSFGwFU+H1GeynFw=="],
+    "@github/copilot-sdk": ["@github/copilot-sdk@0.2.2", "", { "dependencies": { "@github/copilot": "^1.0.21", "vscode-jsonrpc": "^8.2.1", "zod": "^4.3.6" } }, "sha512-VZCqS08YlUM90bUKJ7VLeIxgTTEHtfXBo84T1IUMNvXRREX2csjPH6Z+CPw3S2468RcCLvzBXcc9LtJJTLIWFw=="],
 
-    "@github/copilot-win32-arm64": ["@github/copilot-win32-arm64@1.0.19", "", { "os": "win32", "cpu": "arm64", "bin": { "copilot-win32-arm64": "copilot.exe" } }, "sha512-/NnIjIQrKXcnDOlhxqAZELF4oo5pyOZ98GLxd7iKYhQdq+ZBYmi3CPDh/m7h4mkh1X1eCA7zktaAned5CTAOZw=="],
+    "@github/copilot-win32-arm64": ["@github/copilot-win32-arm64@1.0.22", "", { "os": "win32", "cpu": "arm64", "bin": { "copilot-win32-arm64": "copilot.exe" } }, "sha512-Ao6gv1f2ZV+HVlkB1MV7YFdCuaB3NcFCnNu0a6/WLl2ypsfP1vWosPPkIB32jQJeBkT9ku3exOZLRj+XC0P3Mg=="],
 
-    "@github/copilot-win32-x64": ["@github/copilot-win32-x64@1.0.19", "", { "os": "win32", "cpu": "x64", "bin": { "copilot-win32-x64": "copilot.exe" } }, "sha512-GWn7h3Fdm+iS/AwUi7lo975EnmOH0Hap+mwVQTiOYN2TK5JNrLv4VjVAXeItKeT3VFEEVOHwelCLr9QTMe2Aug=="],
+    "@github/copilot-win32-x64": ["@github/copilot-win32-x64@1.0.22", "", { "os": "win32", "cpu": "x64", "bin": { "copilot-win32-x64": "copilot.exe" } }, "sha512-EppcL+3TpxC+X/eQEIYtkN0PaA3/cvtI9UJqldLIkKDPXNYk/0mw877Ru9ypRcBWBWokDN6iKIWk5IxYH+JIvg=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw=="],
 
@@ -272,6 +273,20 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@openai/codex": ["@openai/codex@0.118.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.118.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.118.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.118.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.118.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.118.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.118.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-oJhNOsP/Vu7DBUhodpP15z60cCZv3sKORqUn1+pepleqSTmc0zXJZSjz6fQOLzny9Ra6sRcvprFFKmQ3Q6+E6w=="],
+
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.118.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-sxq7Q2q9YiJN1wNrzvFRCC5oQKXPVUvu9Ejg6SI/CvyyI9YdtyLTO633wQJALGB7XQfT+3tyM5nNBivnSzLA3Q=="],
+
+    "@openai/codex-darwin-x64": ["@openai/codex@0.118.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-iIvrqzsh1iJmVfqyYwLZBiuh0MkN1Suqniz9hBfmRmE6txMWhRVfigb9SMBiOkfCW1C4sjBwLCsCSzg11rvppQ=="],
+
+    "@openai/codex-linux-arm64": ["@openai/codex@0.118.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-YKWmIqLBu9mmBhN3JHQNkLzk0BtAtV6LBPvhnL5eeHkNrChvA6PKrhsjy0O7wvRkiByZY/1dD14qVdAUfxcbiA=="],
+
+    "@openai/codex-linux-x64": ["@openai/codex@0.118.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-vzU2d/gwAmZbf/DnwVzfQiNN3Ri04XpaZiJkHElIvGoqFbdrxRQFYTtslGDISYIO3o+POADZcFZIfamFsZj9yQ=="],
+
+    "@openai/codex-win32-arm64": ["@openai/codex@0.118.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-AU7GPVFqd0Ml3P2OXfy6K6TONcxfCZLUh1zjYkkoPGWJ4A3BVMkOmMP9CAdSiQsnU/RQfdV/9IGqo1xwUQDdjA=="],
+
+    "@openai/codex-win32-x64": ["@openai/codex@0.118.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-9vKW1ANQxIUsLpiY0VsOM+1avZjqxDZgqgxKABJHWRlLMuaSykwXexf8Hqq+BnYFfmn0d6MjxTuE1UtVvg9caw=="],
 
     "@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.121.0", "", { "os": "android", "cpu": "arm" }, "sha512-n07FQcySwOlzap424/PLMtOkbS7xOu8nsJduKL8P3COGHKgKoDYXwoAHCbChfgFpHnviehrLWIPX0lKGtbEk/A=="],
 
@@ -879,7 +894,7 @@
 
     "keygrip": ["keygrip@1.1.0", "", { "dependencies": { "tsscmp": "1.0.6" } }, "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ=="],
 
-    "knip": ["knip@6.3.0", "", { "dependencies": { "@nodelib/fs.walk": "^1.2.3", "fast-glob": "^3.3.3", "formatly": "^0.3.0", "get-tsconfig": "4.13.7", "jiti": "^2.6.0", "minimist": "^1.2.8", "oxc-parser": "^0.121.0", "oxc-resolver": "^11.19.1", "picocolors": "^1.1.1", "picomatch": "^4.0.1", "smol-toml": "^1.6.1", "strip-json-comments": "5.0.3", "unbash": "^2.2.0", "yaml": "^2.8.2", "zod": "^4.1.11" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-g6dVPoTw6iNm3cubC5IWxVkVsd0r5hXhTBTbAGIEQN53GdA2ZM/slMTPJ7n5l8pBebNQPHpxjmKxuR4xVQ2/hQ=="],
+    "knip": ["knip@6.3.1", "", { "dependencies": { "@nodelib/fs.walk": "^1.2.3", "fast-glob": "^3.3.3", "formatly": "^0.3.0", "get-tsconfig": "4.13.7", "jiti": "^2.6.0", "minimist": "^1.2.8", "oxc-parser": "^0.121.0", "oxc-resolver": "^11.19.1", "picocolors": "^1.1.1", "picomatch": "^4.0.1", "smol-toml": "^1.6.1", "strip-json-comments": "5.0.3", "unbash": "^2.2.0", "yaml": "^2.8.2", "zod": "^4.1.11" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-22kLJloVcOVOAudCxlFOC0ICAMme7dKsS7pVTEnrmyKGpswb8ieznvAiSKUeFVDJhb01ect6dkDc1Ha1g1sPpg=="],
 
     "koa": ["koa@3.1.2", "", { "dependencies": { "accepts": "^1.3.8", "content-disposition": "~1.0.1", "content-type": "^1.0.5", "cookies": "~0.9.1", "delegates": "^1.0.0", "destroy": "^1.2.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "fresh": "~0.5.2", "http-assert": "^1.5.0", "http-errors": "^2.0.0", "koa-compose": "^4.1.0", "mime-types": "^3.0.1", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-2LOQnFKu3m0VxpE+5sb5+BRTSKrXmNxGgxVRiKwD9s5KQB1zID/FRXhtzeV7RT1L2GVpdEEAfVuclFOMGl1ikA=="],
 

--- a/knip.json
+++ b/knip.json
@@ -33,6 +33,7 @@
 		".claude/**"
 	],
 	"ignoreDependencies": [
+		"@openai/codex",
 		"@testing-library/preact",
 		"tailwindcss",
 		"@floating-ui/dom",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
 		"test:proxy:restart": "./scripts/dev-proxy.sh restart"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.4.10",
+		"@biomejs/biome": "2.4.11",
 		"@testing-library/preact": "3.2.4",
-		"knip": "6.3.0",
+		"knip": "6.3.1",
 		"oxlint": "1.59.0",
 		"typescript": "6.0.2"
 	}

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -19,9 +19,10 @@
 		"test:online": "bun test --coverage --coverage-reporter=text ./tests/online"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.2.94",
-		"@github/copilot-sdk": "0.2.1",
+		"@anthropic-ai/claude-agent-sdk": "0.2.98",
+		"@github/copilot-sdk": "0.2.2",
 		"@neokai/shared": "workspace:*",
+		"@openai/codex": "0.118.0",
 		"croner": "10.0.1",
 		"simple-git": "3.35.2",
 		"zod": "4.3.6"

--- a/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
@@ -36,6 +36,7 @@ import {
 } from './codex-anthropic-bridge/server.js';
 import { Logger } from '../logger.js';
 import * as fs from 'fs/promises';
+import { existsSync } from 'node:fs';
 import * as path from 'path';
 import * as os from 'os';
 import * as http from 'http';
@@ -169,20 +170,65 @@ interface CodexAuthFile {
 }
 
 // ---------------------------------------------------------------------------
-// Helper: locate the `codex` binary on PATH
+// Helper: locate the `codex` binary (bundled dep first, then PATH)
 // ---------------------------------------------------------------------------
 
 function findCodexCli(codexPath = 'codex'): string | null {
+	// 1. Resolve from bundled @openai/codex dependency.
+	//    The package ships bin/codex.js which auto-selects the platform binary.
+	//    Bun installs workspace deps into node_modules/.bun — walk up from this
+	//    file to find the root node_modules, then look for the package.
+	try {
+		const rootDir = path.resolve(import.meta.dir, '..', '..', '..', '..', '..');
+		const candidates = [
+			// Bun's hoisted layout
+			path.join(
+				rootDir,
+				'node_modules',
+				'.bun',
+				'node_modules',
+				'@openai',
+				'codex',
+				'bin',
+				'codex.js'
+			),
+			// Standard node_modules layout
+			path.join(rootDir, 'node_modules', '@openai', 'codex', 'bin', 'codex.js'),
+			// Workspace package node_modules
+			path.join(
+				import.meta.dir,
+				'..',
+				'..',
+				'..',
+				'node_modules',
+				'@openai',
+				'codex',
+				'bin',
+				'codex.js'
+			),
+		];
+		for (const candidate of candidates) {
+			if (existsSync(candidate)) return candidate;
+		}
+	} catch {}
+
+	// 2. Resolve via .bin/codex symlink (workspace hoist).
+	try {
+		const rootDir = path.resolve(import.meta.dir, '..', '..', '..', '..', '..');
+		const binLink = path.join(rootDir, 'node_modules', '.bin', 'codex');
+		if (existsSync(binLink)) return binLink;
+	} catch {}
+
+	// 3. Fall back to system PATH.
 	try {
 		const result = Bun.spawnSync(['which', codexPath], { stderr: 'pipe' });
 		if (result.exitCode === 0) {
 			const found = result.stdout.toString().trim();
 			return found.length > 0 ? found : codexPath;
 		}
-		return null;
-	} catch {
-		return null;
-	}
+	} catch {}
+
+	return null;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/process-manager.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/process-manager.ts
@@ -134,20 +134,22 @@ export class AppServerConn {
 
 	static create(codexPath: string, cwd: string, _auth?: AppServerAuth): AppServerConn {
 		const subEnv: Record<string, string> = { ...process.env } as Record<string, string>;
-		logger.debug(`AppServerConn: spawning ${codexPath} app-server`);
-		const proc = Bun.spawn(
-			[codexPath, 'app-server', '-c', 'cli_auth_credentials_store="ephemeral"'],
-			{
-				cwd,
-				env: subEnv,
-				stdout: 'pipe',
-				// Use 'inherit' so stderr flows to the parent process stderr instead of
-				// buffering in a pipe.  A full stderr pipe blocks the child when the kernel
-				// buffer fills up (typically 64 KB), which would deadlock the app-server.
-				stderr: 'inherit',
-				stdin: 'pipe',
-			}
-		) as unknown as PipedProc;
+		// When resolved from node_modules, codexPath may point to a .js entry
+		// point rather than a native binary — prefix with 'node' so it runs.
+		const args: string[] = codexPath.endsWith('.js')
+			? ['node', codexPath, 'app-server', '-c', 'cli_auth_credentials_store="ephemeral"']
+			: [codexPath, 'app-server', '-c', 'cli_auth_credentials_store="ephemeral"'];
+		logger.debug(`AppServerConn: spawning ${args.join(' ')}`);
+		const proc = Bun.spawn(args, {
+			cwd,
+			env: subEnv,
+			stdout: 'pipe',
+			// Use 'inherit' so stderr flows to the parent process stderr instead of
+			// buffering in a pipe.  A full stderr pipe blocks the child when the kernel
+			// buffer fills up (typically 64 KB), which would deadlock the app-server.
+			stderr: 'inherit',
+			stdin: 'pipe',
+		}) as unknown as PipedProc;
 		return new AppServerConn(proc);
 	}
 


### PR DESCRIPTION
Update all outdated dependencies and bundle `@openai/codex` as a daemon dependency so the Codex bridge resolves its binary from `node_modules` instead of requiring a separate system install.

**Dependency updates:**
- `@anthropic-ai/claude-agent-sdk` 0.2.94 → 0.2.98
- `@github/copilot-sdk` 0.2.1 → 0.2.2
- `@biomejs/biome` 2.4.10 → 2.4.11
- `knip` 6.3.0 → 6.3.1
- Added `@openai/codex` 0.118.0

**Codex binary resolution:**
- `findCodexCli()` now resolves from bundled `@openai/codex` in `node_modules` first, then falls back to system PATH
- `AppServerConn.create()` prefixes with `node` when the resolved path is a `.js` entry point

🤖 Generated with [Claude Code](https://claude.com/claude-code)