### PR TITLE
feat: space task view UX improvements

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
@@ -9,8 +9,10 @@
  * - spaceWorkflowRun.markFailed     - Marks a run as blocked with a specific failure reason
  * - spaceWorkflowRun.approveGate    - Approves or rejects a human approval gate
  * - spaceWorkflowRun.listGateData   - Returns all gate data records for a run
- * - spaceWorkflowRun.getGateArtifacts - Returns changed files and diff summary for a run's worktree
- * - spaceWorkflowRun.getFileDiff    - Returns unified diff for a specific file in the worktree
+ * - spaceWorkflowRun.getGateArtifacts   - Returns uncommitted files and diff summary for a run's worktree
+ * - spaceWorkflowRun.getFileDiff        - Returns unified diff for a specific uncommitted file
+ * - spaceWorkflowRun.getCommits         - Returns git commits between branch point and HEAD with per-commit stats
+ * - spaceWorkflowRun.getCommitFileDiff  - Returns unified diff for a specific file in a specific commit
  * - spaceWorkflowRun.writeGateData  - Writes arbitrary gate data (E2E test infrastructure only)
  */
 
@@ -143,6 +145,19 @@ async function resolveWorktreePath(
 }
 
 /**
+ * Returns true when `worktreePath` is inside a git repository.
+ * Uses `git rev-parse --git-dir` which exits non-zero outside a repo.
+ */
+async function isGitRepo(worktreePath: string): Promise<boolean> {
+	try {
+		await execGit(['rev-parse', '--git-dir'], worktreePath, 5000);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Get the diff base ref for a worktree.
  * Tries `origin/dev` merge-base first; falls back to empty string (uncommitted only).
  */
@@ -156,6 +171,51 @@ async function getDiffBaseRef(worktreePath: string): Promise<string> {
 		}
 	}
 	return '';
+}
+
+interface CommitInfo {
+	sha: string;
+	message: string;
+	author: string;
+	timestamp: number;
+	additions: number;
+	deletions: number;
+	fileCount: number;
+}
+
+/**
+ * Parse `git log --format=COMMIT:%H|%s|%aN|%at --numstat` output.
+ * Each commit block starts with a "COMMIT:" line followed by numstat lines.
+ */
+function parseCommitLog(output: string): CommitInfo[] {
+	const commits: CommitInfo[] = [];
+	let current: CommitInfo | null = null;
+
+	for (const line of output.split('\n')) {
+		if (line.startsWith('COMMIT:')) {
+			if (current) commits.push(current);
+			const parts = line.slice('COMMIT:'.length).split('|');
+			current = {
+				sha: parts[0]?.trim() ?? '',
+				message: parts[1]?.trim() ?? '',
+				author: parts[2]?.trim() ?? '',
+				timestamp: parseInt(parts[3]?.trim() ?? '0', 10) * 1000,
+				additions: 0,
+				deletions: 0,
+				fileCount: 0,
+			};
+		} else if (current && line.trim()) {
+			// numstat line: <additions>\t<deletions>\t<path>
+			const parts = line.split('\t');
+			if (parts.length >= 3) {
+				current.additions += parseInt(parts[0], 10) || 0;
+				current.deletions += parseInt(parts[1], 10) || 0;
+				current.fileCount += 1;
+			}
+		}
+	}
+	if (current) commits.push(current);
+	return commits;
 }
 
 /** Factory that creates a SpaceTaskManager bound to a specific spaceId. */
@@ -644,20 +704,20 @@ export function setupSpaceWorkflowRunHandlers(
 			throw new Error(`No workspace path found for run: ${params.runId}`);
 		}
 
-		const baseRef = await getDiffBaseRef(worktreePath);
-		const diffArgs = baseRef
-			? ['diff', '--numstat', `${baseRef}..HEAD`]
-			: ['diff', '--numstat', 'HEAD'];
+		if (!(await isGitRepo(worktreePath))) {
+			return { files: [], totalAdditions: 0, totalDeletions: 0, worktreePath, isGitRepo: false };
+		}
 
+		// Uncommitted changes only: working tree vs HEAD
 		let numstatOutput = '';
 		try {
-			numstatOutput = await execGit(diffArgs, worktreePath);
+			numstatOutput = await execGit(['diff', 'HEAD', '--numstat'], worktreePath);
 		} catch (err) {
-			log.warn('git diff --numstat failed:', err);
+			log.warn('git diff HEAD --numstat failed:', err);
 		}
 
 		const summary = parseNumstat(numstatOutput);
-		return { ...summary, worktreePath, baseRef: baseRef || null };
+		return { ...summary, worktreePath, isGitRepo: true };
 	});
 
 	// ─── spaceWorkflowRun.getFileDiff ────────────────────────────────────────
@@ -692,17 +752,158 @@ export function setupSpaceWorkflowRunHandlers(
 			throw new Error(`No workspace path found for run: ${params.runId}`);
 		}
 
-		const baseRef = await getDiffBaseRef(worktreePath);
-		const diffRangeArgs = baseRef ? [`${baseRef}..HEAD`] : ['HEAD'];
+		if (!(await isGitRepo(worktreePath))) {
+			return { diff: '', additions: 0, deletions: 0, filePath: params.filePath };
+		}
 
+		// Uncommitted diff: working tree vs HEAD
 		let diff = '';
 		try {
-			diff = await execGit(['diff', ...diffRangeArgs, '--', params.filePath], worktreePath);
+			diff = await execGit(['diff', 'HEAD', '--', params.filePath], worktreePath);
 		} catch (err) {
-			log.warn('git diff for file failed:', err);
+			log.warn('git diff HEAD for file failed:', err);
 		}
 
 		// Parse per-file stats from the diff itself
+		let additions = 0;
+		let deletions = 0;
+		for (const line of diff.split('\n')) {
+			if (line.startsWith('+') && !line.startsWith('+++')) additions++;
+			else if (line.startsWith('-') && !line.startsWith('---')) deletions++;
+		}
+
+		return { diff, additions, deletions, filePath: params.filePath };
+	});
+
+	// ─── spaceWorkflowRun.getCommits ─────────────────────────────────────────
+	//
+	// Returns the list of commits between the branch point (baseRef) and HEAD,
+	// with per-commit addition/deletion/file-count stats.
+	messageHub.onRequest('spaceWorkflowRun.getCommits', async (data) => {
+		const params = data as { runId: string; taskId?: string };
+		if (!params.runId) throw new Error('runId is required');
+
+		const run = workflowRunRepo.getRun(params.runId);
+		if (!run) throw new Error(`WorkflowRun not found: ${params.runId}`);
+
+		const worktreePath = await resolveWorktreePath(
+			run.id,
+			run.spaceId,
+			spaceManager,
+			spaceTaskRepo,
+			spaceWorktreeManager,
+			params.taskId
+		);
+		if (!worktreePath) throw new Error(`No workspace path found for run: ${params.runId}`);
+
+		if (!(await isGitRepo(worktreePath))) {
+			return { commits: [], baseRef: null, isGitRepo: false };
+		}
+
+		const baseRef = await getDiffBaseRef(worktreePath);
+		const range = baseRef ? `${baseRef}..HEAD` : '';
+
+		let logOutput = '';
+		try {
+			const args = ['log', '--format=COMMIT:%H|%s|%aN|%at', '--numstat'];
+			if (range) args.push(range);
+			logOutput = await execGit(args, worktreePath);
+		} catch (err) {
+			log.warn('git log --numstat failed:', err);
+		}
+
+		const commits = parseCommitLog(logOutput);
+		return { commits, baseRef: baseRef || null, isGitRepo: true };
+	});
+
+	// ─── spaceWorkflowRun.getCommitFiles ─────────────────────────────────────
+	//
+	// Returns the list of files changed in a specific commit with per-file stats.
+	// Uses `git diff-tree --numstat -r <sha>`.
+	messageHub.onRequest('spaceWorkflowRun.getCommitFiles', async (data) => {
+		const params = data as { runId: string; taskId?: string; commitSha: string };
+		if (!params.runId) throw new Error('runId is required');
+		if (!params.commitSha || !/^[0-9a-f]{4,64}$/i.test(params.commitSha)) {
+			throw new Error('commitSha must be a valid git sha');
+		}
+
+		const run = workflowRunRepo.getRun(params.runId);
+		if (!run) throw new Error(`WorkflowRun not found: ${params.runId}`);
+
+		const worktreePath = await resolveWorktreePath(
+			run.id,
+			run.spaceId,
+			spaceManager,
+			spaceTaskRepo,
+			spaceWorktreeManager,
+			params.taskId
+		);
+		if (!worktreePath) throw new Error(`No workspace path found for run: ${params.runId}`);
+
+		if (!(await isGitRepo(worktreePath))) {
+			return { files: [] };
+		}
+
+		let numstatOutput = '';
+		try {
+			numstatOutput = await execGit(
+				['diff-tree', '--numstat', '-r', params.commitSha],
+				worktreePath
+			);
+		} catch (err) {
+			log.warn('git diff-tree --numstat failed:', err);
+		}
+
+		const summary = parseNumstat(numstatOutput);
+		return { files: summary.files };
+	});
+
+	// ─── spaceWorkflowRun.getCommitFileDiff ──────────────────────────────────
+	//
+	// Returns the unified diff for a specific file within a specific commit
+	// using `git show <sha> -- <filePath>`.
+	messageHub.onRequest('spaceWorkflowRun.getCommitFileDiff', async (data) => {
+		const params = data as {
+			runId: string;
+			taskId?: string;
+			commitSha: string;
+			filePath: string;
+		};
+		if (!params.runId) throw new Error('runId is required');
+		if (!params.commitSha || !/^[0-9a-f]{4,64}$/i.test(params.commitSha)) {
+			throw new Error('commitSha must be a valid git sha');
+		}
+		if (!params.filePath || params.filePath.trim() === '') {
+			throw new Error('filePath is required');
+		}
+		if (params.filePath.includes('..') || isAbsolute(params.filePath)) {
+			throw new Error('filePath must be a relative path within the worktree');
+		}
+
+		const run = workflowRunRepo.getRun(params.runId);
+		if (!run) throw new Error(`WorkflowRun not found: ${params.runId}`);
+
+		const worktreePath = await resolveWorktreePath(
+			run.id,
+			run.spaceId,
+			spaceManager,
+			spaceTaskRepo,
+			spaceWorktreeManager,
+			params.taskId
+		);
+		if (!worktreePath) throw new Error(`No workspace path found for run: ${params.runId}`);
+
+		if (!(await isGitRepo(worktreePath))) {
+			return { diff: '', additions: 0, deletions: 0, filePath: params.filePath };
+		}
+
+		let diff = '';
+		try {
+			diff = await execGit(['show', params.commitSha, '--', params.filePath], worktreePath);
+		} catch (err) {
+			log.warn('git show for commit file failed:', err);
+		}
+
 		let additions = 0;
 		let deletions = 0;
 		for (const line of diff.split('\n')) {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-workflow-run-gate-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-workflow-run-gate-handlers.test.ts
@@ -542,9 +542,8 @@ describe('space-workflow-run gate handlers', () => {
 		});
 
 		it('returns file stats from git diff --numstat', async () => {
-			// merge-base call returns a base SHA, numstat returns file changes
+			// numstat returns file changes for uncommitted working tree vs HEAD
 			mockExecResult = (args) => {
-				if (args.includes('merge-base')) return 'abc123\n';
 				if (args.includes('--numstat')) return '5\t3\tsrc/foo.ts\n2\t0\tsrc/bar.ts\n';
 				return '';
 			};
@@ -556,7 +555,6 @@ describe('space-workflow-run gate handlers', () => {
 				totalAdditions: number;
 				totalDeletions: number;
 				worktreePath: string;
-				baseRef: string | null;
 			};
 
 			expect(result.files).toHaveLength(2);
@@ -565,23 +563,6 @@ describe('space-workflow-run gate handlers', () => {
 			expect(result.totalAdditions).toBe(7);
 			expect(result.totalDeletions).toBe(3);
 			expect(result.worktreePath).toBe('/tmp/test-workspace');
-			expect(result.baseRef).toBe('abc123');
-		});
-
-		it('falls back to uncommitted diff when merge-base fails', async () => {
-			mockExecResult = (args) => {
-				if (args.includes('merge-base')) throw new Error('not found');
-				if (args.includes('--numstat')) return '10\t2\tsrc/main.ts\n';
-				return '';
-			};
-
-			const result = (await call('spaceWorkflowRun.getGateArtifacts', {
-				runId: 'run-1',
-			})) as { files: Array<{ path: string }>; baseRef: string | null };
-
-			expect(result.files).toHaveLength(1);
-			expect(result.files[0].path).toBe('src/main.ts');
-			expect(result.baseRef).toBeNull();
 		});
 
 		it('returns empty file list when no changes', async () => {
@@ -597,7 +578,6 @@ describe('space-workflow-run gate handlers', () => {
 
 		it('handles binary files (- entries in numstat)', async () => {
 			mockExecResult = (args) => {
-				if (args.includes('merge-base')) return 'abc123\n';
 				if (args.includes('--numstat')) return '-\t-\tassets/image.png\n3\t1\tsrc/foo.ts\n';
 				return '';
 			};
@@ -709,11 +689,8 @@ describe('space-workflow-run gate handlers', () => {
 			expect(result.deletions).toBe(0);
 		});
 
-		it('passes correct git args with baseRef', async () => {
-			mockExecResult = (args) => {
-				if (args.includes('merge-base')) return 'deadbeef\n';
-				return '+added line\n-removed line\n';
-			};
+		it('passes correct git args for uncommitted diff', async () => {
+			mockExecResult = () => '+added line\n-removed line\n';
 
 			await call('spaceWorkflowRun.getFileDiff', {
 				runId: 'run-1',
@@ -726,15 +703,15 @@ describe('space-workflow-run gate handlers', () => {
 				(c: unknown[]) => Array.isArray(c[1]) && c[1].includes('diff') && c[1].includes('--')
 			);
 			expect(diffCall).toBeDefined();
-			expect(diffCall![1]).toContain('deadbeef..HEAD');
-			expect(diffCall![1]).toContain('src/foo.ts');
+			const diffArgs = diffCall![1] as string[];
+			expect(diffArgs).toContain('HEAD');
+			expect(diffArgs).toContain('src/foo.ts');
+			// Should not use range notation (e.g. baseRef..HEAD)
+			expect(diffArgs.some((a) => a.includes('..'))).toBe(false);
 		});
 
-		it('falls back to uncommitted diff range when merge-base fails', async () => {
-			mockExecResult = (args) => {
-				if (args.includes('merge-base')) throw new Error('no remote');
-				return '+new line\n';
-			};
+		it('always uses HEAD-based diff (no merge-base lookup)', async () => {
+			mockExecResult = () => '+new line\n';
 
 			await call('spaceWorkflowRun.getFileDiff', {
 				runId: 'run-1',
@@ -742,11 +719,16 @@ describe('space-workflow-run gate handlers', () => {
 			});
 
 			const calls = mockExecFile.mock.calls;
+			// Confirm no merge-base call was made
+			const mergeBaseCall = calls.find(
+				(c: unknown[]) => Array.isArray(c[1]) && c[1].includes('merge-base')
+			);
+			expect(mergeBaseCall).toBeUndefined();
+
 			const diffCall = calls.find(
 				(c: unknown[]) => Array.isArray(c[1]) && c[1].includes('diff') && c[1].includes('--')
 			);
 			expect(diffCall).toBeDefined();
-			// Should use HEAD (not baseRef..HEAD) when merge-base unavailable
 			const diffArgs = diffCall![1] as string[];
 			expect(diffArgs).toContain('HEAD');
 			expect(diffArgs.some((a) => a.includes('..'))).toBe(false);

--- a/packages/web/src/components/space/FileDiffView.tsx
+++ b/packages/web/src/components/space/FileDiffView.tsx
@@ -22,6 +22,10 @@ export interface FileDiffViewProps {
 	/** Task ID — when provided, diffs this task's worktree specifically */
 	taskId?: string;
 	filePath: string;
+	/** When set, shows the diff for this file within the specific commit (git show) */
+	commitSha?: string;
+	/** When set, skips the RPC fetch and renders this diff directly (non-git fallback) */
+	precomputedDiff?: { diff: string; additions: number; deletions: number };
 	onBack: () => void;
 	class?: string;
 }
@@ -123,16 +127,27 @@ export function FileDiffView({
 	runId,
 	taskId,
 	filePath,
+	commitSha,
+	precomputedDiff,
 	onBack,
 	class: className,
 }: FileDiffViewProps) {
-	const [loading, setLoading] = useState(true);
+	const [loading, setLoading] = useState(!precomputedDiff);
 	const [error, setError] = useState<string | null>(null);
-	const [diffText, setDiffText] = useState<string | null>(null);
-	const [additions, setAdditions] = useState(0);
-	const [deletions, setDeletions] = useState(0);
+	const [diffText, setDiffText] = useState<string | null>(precomputedDiff?.diff ?? null);
+	const [additions, setAdditions] = useState(precomputedDiff?.additions ?? 0);
+	const [deletions, setDeletions] = useState(precomputedDiff?.deletions ?? 0);
 
 	useEffect(() => {
+		// When a pre-computed diff is supplied, skip the RPC entirely.
+		if (precomputedDiff) {
+			setDiffText(precomputedDiff.diff);
+			setAdditions(precomputedDiff.additions);
+			setDeletions(precomputedDiff.deletions);
+			setLoading(false);
+			return;
+		}
+
 		setLoading(true);
 		setError(null);
 		setDiffText(null);
@@ -144,10 +159,17 @@ export function FileDiffView({
 			return;
 		}
 
+		const rpcName = commitSha
+			? 'spaceWorkflowRun.getCommitFileDiff'
+			: 'spaceWorkflowRun.getFileDiff';
+		const rpcParams = commitSha
+			? { runId, filePath, commitSha, ...(taskId ? { taskId } : {}) }
+			: { runId, filePath, ...(taskId ? { taskId } : {}) };
+
 		hub
 			.request<{ diff: string; additions: number; deletions: number; filePath: string }>(
-				'spaceWorkflowRun.getFileDiff',
-				{ runId, filePath, ...(taskId ? { taskId } : {}) }
+				rpcName,
+				rpcParams
 			)
 			.then((result) => {
 				setDiffText(result.diff);
@@ -158,7 +180,7 @@ export function FileDiffView({
 				setError(err instanceof Error ? err.message : 'Failed to load diff');
 			})
 			.finally(() => setLoading(false));
-	}, [runId, taskId, filePath]);
+	}, [runId, taskId, filePath, commitSha, precomputedDiff]);
 
 	const parsedLines = diffText ? parseDiff(diffText) : [];
 

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -9,6 +9,7 @@ import type {
 	SpaceTaskStatus,
 } from '@neokai/shared';
 import { cn } from '../../lib/utils';
+import { borderColors } from '../../lib/design-tokens';
 import { SpaceTaskUnifiedThread } from './SpaceTaskUnifiedThread';
 import { TaskArtifactsPanel } from './TaskArtifactsPanel';
 import { getTransitionActions } from './TaskStatusActions';
@@ -295,13 +296,13 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 
 	return (
 		<div class="flex flex-col h-full overflow-hidden bg-dark-900">
-			<div class="px-4 py-3 flex-shrink-0">
-				<div class="flex items-start gap-3">
+			<div class={`px-4 py-4 flex-shrink-0 bg-dark-850 border-b ${borderColors.ui.default}`}>
+				<div class="flex items-center gap-3">
 					{onClose && (
 						<button
 							type="button"
 							onClick={onClose}
-							class="mt-1 text-gray-400 hover:text-gray-200 transition-colors flex-shrink-0"
+							class="text-gray-400 hover:text-gray-200 transition-colors flex-shrink-0"
 							aria-label="Back"
 							data-testid="task-back-button"
 						>
@@ -315,18 +316,16 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 							</svg>
 						</button>
 					)}
-					<div class="min-w-0 flex-1">
-						<h2 class="text-sm sm:text-lg font-semibold text-gray-100 min-w-0 truncate">
-							{task.title}
-						</h2>
-						<div class="mt-1 flex flex-wrap items-center gap-2 text-sm text-gray-400">
-							<span data-testid="task-status-label">{activitySummary}</span>
-							{task.priority !== 'normal' && (
-								<span class="text-xs uppercase tracking-[0.12em] text-gray-500">
-									{PRIORITY_LABELS[task.priority]} Priority
-								</span>
-							)}
-						</div>
+					<h2 class="text-sm sm:text-lg font-semibold text-gray-100 min-w-0 truncate flex-1">
+						{task.title}
+					</h2>
+					<div class="flex items-center gap-2 text-sm text-gray-400 flex-shrink-0">
+						<span data-testid="task-status-label">{activitySummary}</span>
+						{task.priority !== 'normal' && (
+							<span class="text-xs uppercase tracking-[0.12em] text-gray-500">
+								{PRIORITY_LABELS[task.priority]} Priority
+							</span>
+						)}
 					</div>
 					{taskActionItems.length > 0 && (
 						<Dropdown

--- a/packages/web/src/components/space/TaskArtifactsPanel.tsx
+++ b/packages/web/src/components/space/TaskArtifactsPanel.tsx
@@ -1,29 +1,34 @@
 /**
- * TaskArtifactsPanel — right-side slide-over showing all changed files
- * for a task's workflow run.
+ * TaskArtifactsPanel — grouped artifact view for a task's workflow run.
  *
- * Fetches `spaceWorkflowRun.getGateArtifacts` using the task's workflowRunId
- * and renders:
- *   - Diff summary: N files, +additions, -deletions
- *   - Clickable file list with per-file +/- counts
- *   - FileDiffView on click
+ * Sections:
+ *   - Todos: last TodoWrite per agent, grouped by agent label
+ *   - Commits: git commits between branch point and HEAD (clickable → file list → diff)
+ *   - Uncommitted Changes: staged/unstaged files vs HEAD (clickable → diff)
  */
 
-import { useState, useEffect } from 'preact/hooks';
+import { useState, useEffect, useMemo } from 'preact/hooks';
 import { connectionManager } from '../../lib/connection-manager';
 import { cn } from '../../lib/utils';
 import { FileDiffView } from './FileDiffView';
+import { useSpaceTaskMessages } from '../../hooks/useSpaceTaskMessages';
+import {
+	parseThreadRow,
+	buildThreadEvents,
+	extractFileOperations,
+	buildSyntheticDiff,
+	type TodoItem,
+	type FileOperation,
+} from './thread/space-task-thread-events';
 
 // ============================================================================
 // Types
 // ============================================================================
 
 export interface TaskArtifactsPanelProps {
-	/** Workflow run ID (from task.workflowRunId) */
 	runId: string;
-	/** Task ID — when provided, diffs this task's worktree specifically */
 	taskId?: string;
-	/** Called when the panel should close */
+	/** Called when the panel should close (kept for API compatibility) */
 	onClose: () => void;
 	class?: string;
 }
@@ -34,186 +39,606 @@ interface FileDiffStat {
 	deletions: number;
 }
 
-interface ArtifactsResult {
+interface UncommittedResult {
 	files: FileDiffStat[];
 	totalAdditions: number;
 	totalDeletions: number;
-	worktreePath?: string;
-	baseRef?: string;
+	isGitRepo: boolean;
+}
+
+interface CommitInfo {
+	sha: string;
+	message: string;
+	author: string;
+	timestamp: number;
+	additions: number;
+	deletions: number;
+	fileCount: number;
+}
+
+interface CommitsResult {
+	commits: CommitInfo[];
+	baseRef: string | null;
+	isGitRepo: boolean;
+}
+
+type PanelView =
+	| { mode: 'list' }
+	| { mode: 'commitFiles'; commit: CommitInfo }
+	| { mode: 'fileDiff'; filePath: string; commitSha?: string; fromCommit?: CommitInfo }
+	| { mode: 'syntheticDiff'; op: FileOperation };
+
+// ============================================================================
+// Subcomponents
+// ============================================================================
+
+function SectionHeader({ label, meta }: { label: string; meta?: preact.ComponentChildren }) {
+	return (
+		<div class="px-4 py-2 flex items-center justify-between border-b border-dark-800">
+			<span class="text-xs font-medium text-gray-500 uppercase tracking-wider">{label}</span>
+			{meta && <span class="text-xs text-gray-600 font-mono">{meta}</span>}
+		</div>
+	);
+}
+
+function TodoStatusIcon({ status }: { status: TodoItem['status'] }) {
+	if (status === 'completed') {
+		return (
+			<svg class="w-3.5 h-3.5 text-green-500 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
+				<path
+					fill-rule="evenodd"
+					d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+					clip-rule="evenodd"
+				/>
+			</svg>
+		);
+	}
+	if (status === 'in_progress') {
+		return (
+			<svg
+				class="w-3.5 h-3.5 text-blue-400 flex-shrink-0"
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width={2}
+					d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+				/>
+			</svg>
+		);
+	}
+	return (
+		<svg
+			class="w-3.5 h-3.5 text-gray-600 flex-shrink-0"
+			fill="none"
+			viewBox="0 0 24 24"
+			stroke="currentColor"
+		>
+			<circle cx="12" cy="12" r="9" stroke-width={2} />
+		</svg>
+	);
+}
+
+function FileRow({ file, onClick }: { file: FileDiffStat; onClick: () => void }) {
+	return (
+		<button
+			onClick={onClick}
+			class={cn(
+				'w-full flex items-center gap-3 px-3 py-2 rounded text-left',
+				'hover:bg-dark-700 transition-colors group'
+			)}
+			data-testid="artifacts-file-row"
+			data-file-path={file.path}
+		>
+			<svg
+				class="w-3.5 h-3.5 text-gray-500 flex-shrink-0"
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width={2}
+					d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+				/>
+			</svg>
+			<span
+				class="flex-1 text-xs font-mono text-gray-300 truncate min-w-0 group-hover:text-gray-100"
+				title={file.path}
+			>
+				{file.path}
+			</span>
+			<span class="flex-shrink-0 flex items-center gap-1.5 text-xs font-mono">
+				<span class="text-green-400">+{file.additions}</span>
+				<span class="text-red-400">-{file.deletions}</span>
+			</span>
+			<svg
+				class="w-3 h-3 text-gray-600 flex-shrink-0 group-hover:text-gray-400"
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+			>
+				<path stroke-linecap="round" stroke-linejoin="round" stroke-width={2} d="M9 5l7 7-7 7" />
+			</svg>
+		</button>
+	);
 }
 
 // ============================================================================
-// Component
+// Commit files drill-down view
 // ============================================================================
 
-export function TaskArtifactsPanel({
+function CommitFilesView({
 	runId,
 	taskId,
-	onClose,
-	class: className,
-}: TaskArtifactsPanelProps) {
+	commit,
+	onBack,
+	onFileClick,
+}: {
+	runId: string;
+	taskId?: string;
+	commit: CommitInfo;
+	onBack: () => void;
+	onFileClick: (filePath: string) => void;
+}) {
 	const [loading, setLoading] = useState(true);
-	const [fetchError, setFetchError] = useState<string | null>(null);
-	const [artifacts, setArtifacts] = useState<ArtifactsResult | null>(null);
-	const [selectedFile, setSelectedFile] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [files, setFiles] = useState<FileDiffStat[]>([]);
 
 	useEffect(() => {
 		setLoading(true);
-		setFetchError(null);
-		setArtifacts(null);
-		setSelectedFile(null);
+		setError(null);
 
 		const hub = connectionManager.getHubIfConnected();
 		if (!hub) {
-			setFetchError('Not connected');
+			setError('Not connected');
 			setLoading(false);
 			return;
 		}
 
 		hub
-			.request<ArtifactsResult>('spaceWorkflowRun.getGateArtifacts', {
+			.request<{ files: FileDiffStat[] }>('spaceWorkflowRun.getCommitFiles', {
 				runId,
+				commitSha: commit.sha,
 				...(taskId ? { taskId } : {}),
 			})
-			.then((result) => setArtifacts(result))
+			.then((result) => {
+				setFiles(result.files);
+			})
 			.catch((err: unknown) => {
-				setFetchError(err instanceof Error ? err.message : 'Failed to load artifacts');
+				setError(err instanceof Error ? err.message : 'Failed to load commit files');
 			})
 			.finally(() => setLoading(false));
-	}, [runId, taskId]);
+	}, [runId, taskId, commit.sha]);
 
-	// If a file is selected, swap to diff view
-	if (selectedFile) {
-		return (
-			<FileDiffView
-				runId={runId}
-				taskId={taskId}
-				filePath={selectedFile}
-				onBack={() => setSelectedFile(null)}
-				class={className}
-			/>
-		);
-	}
+	const shortSha = commit.sha.slice(0, 7);
 
 	return (
-		<div
-			class={cn('flex flex-col h-full overflow-hidden', className)}
-			data-testid="artifacts-panel"
-		>
-			{/* Header */}
-			<div class="flex items-center justify-between px-4 py-3 border-b border-dark-700 flex-shrink-0 bg-dark-850">
-				<div>
-					<h2 class="text-sm font-semibold text-gray-100">Artifacts</h2>
-					<p class="text-xs text-gray-500 mt-0.5">Changed files across this workflow run</p>
-				</div>
+		<div class="flex flex-col h-full overflow-hidden">
+			{/* Mini header */}
+			<div class="flex items-center gap-2 px-4 py-3 border-b border-dark-700 flex-shrink-0 bg-dark-850">
 				<button
-					onClick={onClose}
-					class="text-gray-600 hover:text-gray-400 transition-colors flex-shrink-0 ml-3"
-					aria-label="Close artifacts panel"
-					data-testid="artifacts-panel-close"
+					onClick={onBack}
+					class="text-gray-400 hover:text-gray-100 transition-colors flex-shrink-0"
+					aria-label="Back"
 				>
 					<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 						<path
 							stroke-linecap="round"
 							stroke-linejoin="round"
 							stroke-width={2}
-							d="M6 18L18 6M6 6l12 12"
+							d="M15 19l-7-7 7-7"
 						/>
 					</svg>
 				</button>
+				<div class="flex-1 min-w-0">
+					<p class="text-xs text-gray-300 truncate">{commit.message}</p>
+					<p class="text-xs text-gray-600 font-mono">{shortSha}</p>
+				</div>
 			</div>
 
-			{/* Scrollable body */}
+			<div class="flex-1 overflow-y-auto min-h-0">
+				{loading && (
+					<div class="flex items-center justify-center h-24">
+						<div class="w-5 h-5 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+					</div>
+				)}
+				{error && !loading && (
+					<div class="px-4 py-4">
+						<p class="text-sm text-red-400">{error}</p>
+					</div>
+				)}
+				{!loading && !error && (
+					<div class="px-2 py-1 space-y-0.5">
+						{files.length === 0 ? (
+							<p class="px-2 py-3 text-sm text-gray-500">No files changed</p>
+						) : (
+							files.map((file) => (
+								<FileRow key={file.path} file={file} onClick={() => onFileClick(file.path)} />
+							))
+						)}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}
+
+// ============================================================================
+// Main component
+// ============================================================================
+
+export function TaskArtifactsPanel({
+	runId,
+	taskId,
+	onClose: _onClose,
+	class: className,
+}: TaskArtifactsPanelProps) {
+	const [view, setView] = useState<PanelView>({ mode: 'list' });
+
+	// ── Uncommitted changes ──────────────────────────────────────────────────
+	const [uncommittedLoading, setUncommittedLoading] = useState(true);
+	const [uncommittedError, setUncommittedError] = useState<string | null>(null);
+	const [uncommitted, setUncommitted] = useState<UncommittedResult | null>(null);
+
+	// ── Commits ──────────────────────────────────────────────────────────────
+	const [commitsLoading, setCommitsLoading] = useState(true);
+	const [commitsError, setCommitsError] = useState<string | null>(null);
+	const [commitsData, setCommitsData] = useState<CommitsResult | null>(null);
+
+	// ── Todos (from message thread) ──────────────────────────────────────────
+	const { rows: messageRows } = useSpaceTaskMessages(taskId ?? null);
+
+	// File operations from tool calls (Write/Edit) — used when not a git repo
+	const fileOps = useMemo<FileOperation[]>(() => {
+		if (!messageRows.length) return [];
+		const parsedRows = messageRows.map(parseThreadRow);
+		return extractFileOperations(parsedRows);
+	}, [messageRows]);
+
+	// Group by sessionId → take last TodoWrite per session
+	const todosByAgent = useMemo<{ label: string; todos: TodoItem[] }[]>(() => {
+		if (!messageRows.length) return [];
+
+		// Group rows by sessionId
+		const bySession = new Map<string, typeof messageRows>();
+		for (const row of messageRows) {
+			const key = row.sessionId ?? 'unknown';
+			if (!bySession.has(key)) bySession.set(key, []);
+			bySession.get(key)!.push(row);
+		}
+
+		const result: { label: string; todos: TodoItem[] }[] = [];
+		for (const [, rows] of bySession) {
+			const parsedRows = rows.map(parseThreadRow);
+			const events = buildThreadEvents(parsedRows);
+			// Last TodoWrite in this session = current state for this agent
+			let latestTodos: TodoItem[] | null = null;
+			for (let i = events.length - 1; i >= 0; i--) {
+				const t = events[i].todos;
+				if (t && t.length > 0) {
+					latestTodos = t;
+					break;
+				}
+			}
+			if (latestTodos) {
+				const label = rows[0]?.label ?? 'Agent';
+				result.push({ label, todos: latestTodos });
+			}
+		}
+		return result;
+	}, [messageRows]);
+
+	useEffect(() => {
+		setUncommittedLoading(true);
+		setUncommittedError(null);
+		setCommitsLoading(true);
+		setCommitsError(null);
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) {
+			setUncommittedError('Not connected');
+			setUncommittedLoading(false);
+			setCommitsError('Not connected');
+			setCommitsLoading(false);
+			return;
+		}
+
+		const taskParams = taskId ? { taskId } : {};
+
+		hub
+			.request<UncommittedResult>('spaceWorkflowRun.getGateArtifacts', { runId, ...taskParams })
+			.then((r) => setUncommitted(r))
+			.catch((err: unknown) => {
+				setUncommittedError(err instanceof Error ? err.message : 'Failed to load changes');
+			})
+			.finally(() => setUncommittedLoading(false));
+
+		hub
+			.request<CommitsResult>('spaceWorkflowRun.getCommits', { runId, ...taskParams })
+			.then((r) => setCommitsData(r))
+			.catch((err: unknown) => {
+				setCommitsError(err instanceof Error ? err.message : 'Failed to load commits');
+			})
+			.finally(() => setCommitsLoading(false));
+	}, [runId, taskId]);
+
+	// ── View routing ─────────────────────────────────────────────────────────
+
+	if (view.mode === 'syntheticDiff') {
+		const synth = buildSyntheticDiff(view.op);
+		return (
+			<FileDiffView
+				runId={runId}
+				taskId={taskId}
+				filePath={view.op.path}
+				precomputedDiff={synth}
+				onBack={() => setView({ mode: 'list' })}
+				class={className}
+			/>
+		);
+	}
+
+	if (view.mode === 'fileDiff') {
+		return (
+			<FileDiffView
+				runId={runId}
+				taskId={taskId}
+				filePath={view.filePath}
+				commitSha={view.commitSha}
+				onBack={() =>
+					view.fromCommit
+						? setView({ mode: 'commitFiles', commit: view.fromCommit })
+						: setView({ mode: 'list' })
+				}
+				class={className}
+			/>
+		);
+	}
+
+	if (view.mode === 'commitFiles') {
+		return (
+			<CommitFilesView
+				runId={runId}
+				taskId={taskId}
+				commit={view.commit}
+				onBack={() => setView({ mode: 'list' })}
+				onFileClick={(filePath) =>
+					setView({
+						mode: 'fileDiff',
+						filePath,
+						commitSha: view.commit.sha,
+						fromCommit: view.commit,
+					})
+				}
+			/>
+		);
+	}
+
+	// ── List view ────────────────────────────────────────────────────────────
+
+	// A repo is considered non-git when we have a definitive false (not just empty data)
+	const isGitRepo = uncommitted?.isGitRepo !== false && commitsData?.isGitRepo !== false;
+
+	const uncommittedMeta =
+		uncommitted && uncommitted.files.length > 0 ? (
+			<>
+				<span class="text-green-400">+{uncommitted.totalAdditions}</span>
+				<span class="text-red-400 ml-1">-{uncommitted.totalDeletions}</span>
+				<span class="text-gray-600 ml-1.5">
+					{uncommitted.files.length} {uncommitted.files.length === 1 ? 'file' : 'files'}
+				</span>
+			</>
+		) : null;
+
+	const hasTodos = todosByAgent.length > 0;
+
+	return (
+		<div
+			class={cn('flex flex-col h-full overflow-hidden', className)}
+			data-testid="artifacts-panel"
+		>
 			<div class="flex-1 overflow-y-auto min-h-0">
 				<div class="min-h-[calc(100%+1px)]">
-					{/* Loading */}
-					{loading && (
-						<div class="flex items-center justify-center h-32" data-testid="artifacts-loading">
-							<div class="w-5 h-5 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+					{/* ── Todos ───────────────────────────────────────────── */}
+					{hasTodos && (
+						<div class="mb-2">
+							<SectionHeader label="Todos" />
+							<div class="py-1">
+								{todosByAgent.map(({ label, todos }, agentIdx) => (
+									<div key={agentIdx}>
+										{todosByAgent.length > 1 && (
+											<p class="px-4 pt-2 pb-0.5 text-xs text-gray-600 font-medium">{label}</p>
+										)}
+										{[
+											...todos.filter((t) => t.status === 'in_progress'),
+											...todos.filter((t) => t.status === 'pending'),
+											...todos.filter((t) => t.status === 'completed'),
+										].map((todo, i) => (
+											<div key={i} class="flex items-start gap-2.5 px-4 py-1.5">
+												<div class="mt-0.5">
+													<TodoStatusIcon status={todo.status} />
+												</div>
+												<span
+													class={cn(
+														'text-xs leading-relaxed',
+														todo.status === 'completed'
+															? 'text-gray-600 line-through'
+															: 'text-gray-300'
+													)}
+												>
+													{todo.content}
+												</span>
+											</div>
+										))}
+									</div>
+								))}
+							</div>
 						</div>
 					)}
 
-					{/* Fetch error */}
-					{fetchError && !loading && (
-						<div class="px-4 py-4" data-testid="artifacts-error">
-							<p class="text-sm text-red-400">{fetchError}</p>
-						</div>
-					)}
-
-					{/* Artifacts content */}
-					{!loading && !fetchError && artifacts && (
-						<div class="p-4 space-y-4">
-							{/* Diff summary */}
-							<div class="flex items-center gap-4 text-xs" data-testid="artifacts-summary">
-								<span class="text-gray-400">
-									{artifacts.files.length} {artifacts.files.length === 1 ? 'file' : 'files'} changed
-								</span>
-								<span class="text-green-400 font-mono">+{artifacts.totalAdditions}</span>
-								<span class="text-red-400 font-mono">-{artifacts.totalDeletions}</span>
+					{isGitRepo ? (
+						<>
+							{/* ── Commits ───────────────────────────────────────── */}
+							<div class="mb-2">
+								<SectionHeader
+									label="Commits"
+									meta={
+										commitsData?.commits.length
+											? `${commitsData.commits.length} commit${commitsData.commits.length === 1 ? '' : 's'}`
+											: undefined
+									}
+								/>
+								{commitsLoading && (
+									<div class="flex items-center justify-center h-16">
+										<div class="w-4 h-4 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+									</div>
+								)}
+								{commitsError && !commitsLoading && (
+									<p class="px-4 py-3 text-sm text-red-400">{commitsError}</p>
+								)}
+								{!commitsLoading && !commitsError && (
+									<div class="px-2 py-1 space-y-0.5" data-testid="artifacts-commits-list">
+										{!commitsData?.commits.length ? (
+											<p class="px-2 py-3 text-sm text-gray-500">No commits yet</p>
+										) : (
+											commitsData.commits.map((commit) => (
+												<button
+													key={commit.sha}
+													onClick={() => setView({ mode: 'commitFiles', commit })}
+													class={cn(
+														'w-full flex items-start gap-3 px-3 py-2 rounded text-left',
+														'hover:bg-dark-700 transition-colors group'
+													)}
+													data-testid="artifacts-commit-row"
+												>
+													<svg
+														class="w-3.5 h-3.5 text-gray-500 flex-shrink-0 mt-0.5"
+														fill="none"
+														viewBox="0 0 24 24"
+														stroke="currentColor"
+													>
+														<circle cx="12" cy="12" r="3" stroke-width={2} />
+														<path
+															stroke-linecap="round"
+															stroke-width={2}
+															d="M12 3v6m0 6v6M3 12h6m6 0h6"
+														/>
+													</svg>
+													<div class="flex-1 min-w-0">
+														<p class="text-xs text-gray-300 truncate group-hover:text-gray-100">
+															{commit.message}
+														</p>
+														<p class="text-xs text-gray-600 font-mono mt-0.5">
+															{commit.sha.slice(0, 7)}
+															{commit.fileCount > 0 && (
+																<span class="ml-2 font-sans">
+																	{commit.fileCount} file{commit.fileCount === 1 ? '' : 's'}
+																</span>
+															)}
+														</p>
+													</div>
+													<span class="flex-shrink-0 flex items-center gap-1 text-xs font-mono">
+														{commit.additions > 0 && (
+															<span class="text-green-400">+{commit.additions}</span>
+														)}
+														{commit.deletions > 0 && (
+															<span class="text-red-400">-{commit.deletions}</span>
+														)}
+													</span>
+													<svg
+														class="w-3 h-3 text-gray-600 flex-shrink-0 group-hover:text-gray-400 mt-0.5"
+														fill="none"
+														viewBox="0 0 24 24"
+														stroke="currentColor"
+													>
+														<path
+															stroke-linecap="round"
+															stroke-linejoin="round"
+															stroke-width={2}
+															d="M9 5l7 7-7 7"
+														/>
+													</svg>
+												</button>
+											))
+										)}
+									</div>
+								)}
 							</div>
 
-							{/* File list */}
-							{artifacts.files.length === 0 ? (
-								<p class="text-sm text-gray-500" data-testid="artifacts-no-files">
-									No changed files found
-								</p>
-							) : (
-								<div class="space-y-0.5" data-testid="artifacts-file-list">
-									{artifacts.files.map((file) => (
-										<button
-											key={file.path}
-											onClick={() => setSelectedFile(file.path)}
-											class={cn(
-												'w-full flex items-center gap-3 px-3 py-2 rounded text-left',
-												'hover:bg-dark-700 transition-colors group'
-											)}
-											data-testid="artifacts-file-row"
-											data-file-path={file.path}
-										>
-											{/* File icon */}
-											<svg
-												class="w-3.5 h-3.5 text-gray-500 flex-shrink-0"
-												fill="none"
-												viewBox="0 0 24 24"
-												stroke="currentColor"
-											>
-												<path
-													stroke-linecap="round"
-													stroke-linejoin="round"
-													stroke-width={2}
-													d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+							{/* ── Uncommitted Changes ────────────────────────────── */}
+							<div>
+								<SectionHeader label="Uncommitted Changes" meta={uncommittedMeta} />
+								{uncommittedLoading && (
+									<div class="flex items-center justify-center h-16">
+										<div class="w-4 h-4 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+									</div>
+								)}
+								{uncommittedError && !uncommittedLoading && (
+									<p class="px-4 py-3 text-sm text-red-400" data-testid="artifacts-error">
+										{uncommittedError}
+									</p>
+								)}
+								{!uncommittedLoading && !uncommittedError && uncommitted && (
+									<div class="py-1" data-testid="artifacts-file-list">
+										{uncommitted.files.length === 0 ? (
+											<p class="px-4 py-3 text-sm text-gray-500" data-testid="artifacts-no-files">
+												No uncommitted changes
+											</p>
+										) : (
+											<div class="px-2 space-y-0.5">
+												{uncommitted.files.map((file) => (
+													<FileRow
+														key={file.path}
+														file={file}
+														onClick={() => setView({ mode: 'fileDiff', filePath: file.path })}
+													/>
+												))}
+											</div>
+										)}
+									</div>
+								)}
+							</div>
+						</>
+					) : (
+						/* ── Non-git fallback: files from Write/Edit tool calls ── */
+						<div>
+							<SectionHeader
+								label="Files Touched"
+								meta={
+									fileOps.length ? (
+										<span class="text-gray-600">
+											{fileOps.length} file{fileOps.length === 1 ? '' : 's'} · not a git repo
+										</span>
+									) : undefined
+								}
+							/>
+							<div class="py-1" data-testid="artifacts-file-list">
+								{fileOps.length === 0 ? (
+									<p class="px-4 py-3 text-sm text-gray-500">No files written or edited yet</p>
+								) : (
+									<div class="px-2 space-y-0.5">
+										{fileOps.map((op) => {
+											const synth = buildSyntheticDiff(op);
+											return (
+												<FileRow
+													key={op.path}
+													file={{
+														path: op.path,
+														additions: synth.additions,
+														deletions: synth.deletions,
+													}}
+													onClick={() => setView({ mode: 'syntheticDiff', op })}
 												/>
-											</svg>
-											{/* Path */}
-											<span
-												class="flex-1 text-xs font-mono text-gray-300 truncate min-w-0 group-hover:text-gray-100"
-												title={file.path}
-											>
-												{file.path}
-											</span>
-											{/* Stats */}
-											<span class="flex-shrink-0 flex items-center gap-1.5 text-xs font-mono">
-												<span class="text-green-400">+{file.additions}</span>
-												<span class="text-red-400">-{file.deletions}</span>
-											</span>
-											{/* Chevron */}
-											<svg
-												class="w-3 h-3 text-gray-600 flex-shrink-0 group-hover:text-gray-400"
-												fill="none"
-												viewBox="0 0 24 24"
-												stroke="currentColor"
-											>
-												<path
-													stroke-linecap="round"
-													stroke-linejoin="round"
-													stroke-width={2}
-													d="M9 5l7 7-7 7"
-												/>
-											</svg>
-										</button>
-									))}
-								</div>
-							)}
+											);
+										})}
+									</div>
+								)}
+							</div>
 						</div>
 					)}
 				</div>

--- a/packages/web/src/components/space/ThreadedChatComposer.tsx
+++ b/packages/web/src/components/space/ThreadedChatComposer.tsx
@@ -103,7 +103,7 @@ export function ThreadedChatComposer({
 	);
 
 	return (
-		<div class="px-2 pb-2" data-testid="threaded-chat-composer">
+		<div class="px-3 pb-2" data-testid="threaded-chat-composer">
 			{errorMessage && (
 				<p class="rounded border border-red-500/30 bg-red-500/10 px-2 py-1 text-xs text-red-300">
 					{errorMessage}

--- a/packages/web/src/components/space/__tests__/TaskArtifactsPanel.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskArtifactsPanel.test.tsx
@@ -2,6 +2,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { cleanup, fireEvent, render, waitFor } from '@testing-library/preact';
 
+// ---- Mock useSpaceTaskMessages ----
+vi.mock('../../../hooks/useSpaceTaskMessages', () => ({
+	useSpaceTaskMessages: () => ({ rows: [] }),
+}));
+
 // ---- Mock connectionManager ----
 const mockRequest = vi.fn();
 const mockHub = { request: mockRequest };
@@ -30,14 +35,29 @@ vi.mock('../../../lib/utils', () => ({
 
 import { TaskArtifactsPanel } from '../TaskArtifactsPanel';
 
-const ARTIFACTS_RESULT = {
+const UNCOMMITTED_RESULT = {
 	files: [
 		{ path: 'src/foo.ts', additions: 10, deletions: 2 },
 		{ path: 'src/bar.ts', additions: 5, deletions: 0 },
 	],
 	totalAdditions: 15,
 	totalDeletions: 2,
+	isGitRepo: true,
 };
+
+const COMMITS_RESULT = {
+	commits: [],
+	baseRef: null,
+	isGitRepo: true,
+};
+
+function setupDefaultMocks() {
+	mockRequest.mockImplementation((method: string) => {
+		if (method === 'spaceWorkflowRun.getGateArtifacts') return Promise.resolve(UNCOMMITTED_RESULT);
+		if (method === 'spaceWorkflowRun.getCommits') return Promise.resolve(COMMITS_RESULT);
+		return Promise.resolve({});
+	});
+}
 
 describe('TaskArtifactsPanel', () => {
 	beforeEach(() => {
@@ -49,14 +69,14 @@ describe('TaskArtifactsPanel', () => {
 		cleanup();
 	});
 
-	it('shows loading spinner initially', () => {
-		mockRequest.mockReturnValue(new Promise(() => {})); // never resolves
+	it('has data-testid="artifacts-panel" on root element', async () => {
+		setupDefaultMocks();
 		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />);
-		expect(getByTestId('artifacts-loading')).toBeTruthy();
+		expect(getByTestId('artifacts-panel')).toBeTruthy();
 	});
 
 	it('renders file list after successful fetch', async () => {
-		mockRequest.mockResolvedValue(ARTIFACTS_RESULT);
+		setupDefaultMocks();
 		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />);
 		await waitFor(() => expect(getByTestId('artifacts-file-list')).toBeTruthy());
 
@@ -66,7 +86,7 @@ describe('TaskArtifactsPanel', () => {
 	});
 
 	it('shows +/- line counts for each file', async () => {
-		mockRequest.mockResolvedValue(ARTIFACTS_RESULT);
+		setupDefaultMocks();
 		const { container, getByTestId } = render(
 			<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />
 		);
@@ -83,36 +103,24 @@ describe('TaskArtifactsPanel', () => {
 		expect(barRow?.textContent).toContain('-0');
 	});
 
-	it('shows summary totals', async () => {
-		mockRequest.mockResolvedValue(ARTIFACTS_RESULT);
-		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />);
-		await waitFor(() => expect(getByTestId('artifacts-summary')).toBeTruthy());
-
-		const summary = getByTestId('artifacts-summary');
-		expect(summary.textContent).toContain('2 files changed');
-		expect(summary.textContent).toContain('+15');
-		expect(summary.textContent).toContain('-2');
-	});
-
-	it('shows "1 file" singular when only one file changed', async () => {
-		mockRequest.mockResolvedValue({
-			files: [{ path: 'src/only.ts', additions: 3, deletions: 1 }],
-			totalAdditions: 3,
-			totalDeletions: 1,
+	it('shows no-files message when uncommitted files array is empty', async () => {
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'spaceWorkflowRun.getGateArtifacts')
+				return Promise.resolve({
+					files: [],
+					totalAdditions: 0,
+					totalDeletions: 0,
+					isGitRepo: true,
+				});
+			if (method === 'spaceWorkflowRun.getCommits') return Promise.resolve(COMMITS_RESULT);
+			return Promise.resolve({});
 		});
-		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />);
-		await waitFor(() => expect(getByTestId('artifacts-summary')).toBeTruthy());
-		expect(getByTestId('artifacts-summary').textContent).toContain('1 file changed');
-	});
-
-	it('shows no-files message when files array is empty', async () => {
-		mockRequest.mockResolvedValue({ files: [], totalAdditions: 0, totalDeletions: 0 });
 		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />);
 		await waitFor(() => expect(getByTestId('artifacts-no-files')).toBeTruthy());
 	});
 
 	it('clicking a file opens FileDiffView for that file', async () => {
-		mockRequest.mockResolvedValue(ARTIFACTS_RESULT);
+		setupDefaultMocks();
 		const { container, getByTestId, queryByTestId } = render(
 			<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />
 		);
@@ -128,7 +136,7 @@ describe('TaskArtifactsPanel', () => {
 	});
 
 	it('back button in FileDiffView returns to file list', async () => {
-		mockRequest.mockResolvedValue(ARTIFACTS_RESULT);
+		setupDefaultMocks();
 		const { container, getByTestId, queryByTestId } = render(
 			<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />
 		);
@@ -143,16 +151,6 @@ describe('TaskArtifactsPanel', () => {
 		expect(getByTestId('artifacts-file-list')).toBeTruthy();
 	});
 
-	it('calls onClose when close button is clicked', async () => {
-		mockRequest.mockResolvedValue(ARTIFACTS_RESULT);
-		const onClose = vi.fn();
-		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={onClose} />);
-		await waitFor(() => expect(getByTestId('artifacts-panel')).toBeTruthy());
-
-		fireEvent.click(getByTestId('artifacts-panel-close'));
-		expect(onClose).toHaveBeenCalled();
-	});
-
 	it('shows error when not connected', async () => {
 		const { connectionManager } = await import('../../../lib/connection-manager');
 		vi.mocked(connectionManager.getHubIfConnected).mockReturnValueOnce(null);
@@ -162,15 +160,20 @@ describe('TaskArtifactsPanel', () => {
 		expect(getByTestId('artifacts-error').textContent).toContain('Not connected');
 	});
 
-	it('shows fetch error when request fails', async () => {
-		mockRequest.mockRejectedValue(new Error('Server error'));
+	it('shows fetch error when uncommitted request fails', async () => {
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'spaceWorkflowRun.getGateArtifacts')
+				return Promise.reject(new Error('Server error'));
+			if (method === 'spaceWorkflowRun.getCommits') return Promise.resolve(COMMITS_RESULT);
+			return Promise.resolve({});
+		});
 		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />);
 		await waitFor(() => expect(getByTestId('artifacts-error')).toBeTruthy());
 		expect(getByTestId('artifacts-error').textContent).toContain('Server error');
 	});
 
 	it('fetches with the correct runId', async () => {
-		mockRequest.mockResolvedValue(ARTIFACTS_RESULT);
+		setupDefaultMocks();
 		render(<TaskArtifactsPanel runId="run-abc-123" onClose={vi.fn()} />);
 		await waitFor(() =>
 			expect(mockRequest).toHaveBeenCalledWith('spaceWorkflowRun.getGateArtifacts', {
@@ -179,10 +182,63 @@ describe('TaskArtifactsPanel', () => {
 		);
 	});
 
-	it('has data-testid="artifacts-panel" on root element', async () => {
-		mockRequest.mockResolvedValue(ARTIFACTS_RESULT);
+	it('shows commits section with no-commits message when commits list is empty', async () => {
+		setupDefaultMocks();
 		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />);
-		expect(getByTestId('artifacts-panel')).toBeTruthy();
+		await waitFor(() => expect(getByTestId('artifacts-commits-list')).toBeTruthy());
+		expect(getByTestId('artifacts-commits-list').textContent).toContain('No commits yet');
+	});
+
+	it('shows commit rows when commits are returned', async () => {
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'spaceWorkflowRun.getGateArtifacts')
+				return Promise.resolve(UNCOMMITTED_RESULT);
+			if (method === 'spaceWorkflowRun.getCommits')
+				return Promise.resolve({
+					commits: [
+						{
+							sha: 'abc1234',
+							message: 'feat: add feature',
+							author: 'Dev',
+							timestamp: Date.now(),
+							additions: 10,
+							deletions: 2,
+							fileCount: 3,
+						},
+					],
+					baseRef: 'origin/dev',
+					isGitRepo: true,
+				});
+			return Promise.resolve({});
+		});
+
+		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />);
+		await waitFor(() =>
+			expect(getByTestId('artifacts-commits-list').textContent).toContain('feat: add feature')
+		);
+		expect(getByTestId('artifacts-commits-list').textContent).toContain('abc1234');
+	});
+
+	it('shows Files Touched section (not Commits) when isGitRepo is false', async () => {
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'spaceWorkflowRun.getGateArtifacts')
+				return Promise.resolve({
+					files: [],
+					totalAdditions: 0,
+					totalDeletions: 0,
+					isGitRepo: false,
+				});
+			if (method === 'spaceWorkflowRun.getCommits')
+				return Promise.resolve({ commits: [], baseRef: null, isGitRepo: false });
+			return Promise.resolve({});
+		});
+
+		const { getByTestId, queryByTestId } = render(
+			<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />
+		);
+		await waitFor(() => expect(getByTestId('artifacts-file-list')).toBeTruthy());
+		// Commits section should not be present
+		expect(queryByTestId('artifacts-commits-list')).toBeNull();
 	});
 });
 
@@ -227,15 +283,12 @@ describe('SpaceTaskPane — artifacts toggle', () => {
 					agents: signal([]),
 					workflows: signal([]),
 					workflowRuns: signal([]),
-					taskActivity: signal(new Map()),
 					updateTask: vi.fn().mockResolvedValue(undefined),
 					ensureTaskAgentSession: vi.fn().mockResolvedValue({
 						id: 'task-1',
 						taskAgentSessionId: 'session-abc',
 					}),
 					sendTaskMessage: vi.fn().mockResolvedValue(undefined),
-					subscribeTaskActivity: vi.fn().mockResolvedValue(undefined),
-					unsubscribeTaskActivity: vi.fn(),
 					ensureConfigData: vi.fn().mockResolvedValue(undefined),
 					ensureNodeExecutions: vi.fn().mockResolvedValue(undefined),
 				};
@@ -291,12 +344,9 @@ describe('SpaceTaskPane — artifacts toggle', () => {
 					agents: signal([]),
 					workflows: signal([]),
 					workflowRuns: signal([]),
-					taskActivity: signal(new Map()),
 					updateTask: vi.fn().mockResolvedValue(undefined),
 					ensureTaskAgentSession: vi.fn().mockResolvedValue({ id: 'task-2' }),
 					sendTaskMessage: vi.fn().mockResolvedValue(undefined),
-					subscribeTaskActivity: vi.fn().mockResolvedValue(undefined),
-					unsubscribeTaskActivity: vi.fn(),
 					ensureConfigData: vi.fn().mockResolvedValue(undefined),
 					ensureNodeExecutions: vi.fn().mockResolvedValue(undefined),
 				};
@@ -350,15 +400,12 @@ describe('SpaceTaskPane — artifacts toggle', () => {
 					agents: signal([]),
 					workflows: signal([]),
 					workflowRuns: signal([]),
-					taskActivity: signal(new Map()),
 					updateTask: vi.fn().mockResolvedValue(undefined),
 					ensureTaskAgentSession: vi.fn().mockResolvedValue({
 						id: 'task-3',
 						taskAgentSessionId: 'session-toggle',
 					}),
 					sendTaskMessage: vi.fn().mockResolvedValue(undefined),
-					subscribeTaskActivity: vi.fn().mockResolvedValue(undefined),
-					unsubscribeTaskActivity: vi.fn(),
 					ensureConfigData: vi.fn().mockResolvedValue(undefined),
 					ensureNodeExecutions: vi.fn().mockResolvedValue(undefined),
 				};

--- a/packages/web/src/components/space/thread/space-task-thread-events.ts
+++ b/packages/web/src/components/space/thread/space-task-thread-events.ts
@@ -455,3 +455,97 @@ export function buildThreadEvents(parsedRows: ParsedThreadRow[]): SpaceTaskThrea
 
 	return events;
 }
+
+// ============================================================================
+// File operations extraction (for non-git workspaces)
+// ============================================================================
+
+export interface FileOperation {
+	path: string;
+	/** Last tool that touched this file */
+	tool: 'Write' | 'Edit';
+	/** Write: full file content written */
+	content?: string;
+	/** Edit: the string that was replaced */
+	oldString?: string;
+	/** Edit: the replacement string */
+	newString?: string;
+}
+
+/**
+ * Scan all assistant tool-use blocks in `parsedRows` and return the last
+ * Write/Edit operation per file path. Used as a fallback when the workspace
+ * is not a git repository.
+ */
+export function extractFileOperations(parsedRows: ParsedThreadRow[]): FileOperation[] {
+	const opsByFile = new Map<string, FileOperation>();
+
+	for (const row of parsedRows) {
+		const msg = row.message;
+		if (!msg || msg.role !== 'assistant') continue;
+		const content = Array.isArray(msg.content) ? msg.content : [];
+
+		for (const block of content) {
+			if (!isToolUseBlock(block)) continue;
+			const input =
+				typeof block.input === 'object' && block.input !== null
+					? (block.input as Record<string, unknown>)
+					: {};
+
+			if (block.name === 'Write') {
+				const path = typeof input.file_path === 'string' ? input.file_path : null;
+				const fileContent = typeof input.content === 'string' ? input.content : null;
+				if (path && fileContent !== null) {
+					opsByFile.set(path, { path, tool: 'Write', content: fileContent });
+				}
+			} else if (block.name === 'Edit') {
+				const path = typeof input.file_path === 'string' ? input.file_path : null;
+				const oldString = typeof input.old_string === 'string' ? input.old_string : null;
+				const newString = typeof input.new_string === 'string' ? input.new_string : null;
+				if (path && oldString !== null && newString !== null) {
+					opsByFile.set(path, { path, tool: 'Edit', oldString, newString });
+				}
+			}
+		}
+	}
+
+	return Array.from(opsByFile.values());
+}
+
+/**
+ * Build a synthetic unified diff string from a FileOperation so it can be
+ * displayed in FileDiffView without a real git repo.
+ *
+ * - Write → full content shown as a new-file addition
+ * - Edit  → old_string lines as removals, new_string lines as additions
+ */
+export function buildSyntheticDiff(op: FileOperation): {
+	diff: string;
+	additions: number;
+	deletions: number;
+} {
+	if (op.tool === 'Write') {
+		const lines = (op.content ?? '').split('\n');
+		const hunks = lines.map((l) => `+${l}`).join('\n');
+		const diff = [
+			`diff --git a/${op.path} b/${op.path}`,
+			'--- /dev/null',
+			`+++ b/${op.path}`,
+			`@@ -0,0 +1,${lines.length} @@`,
+			hunks,
+		].join('\n');
+		return { diff, additions: lines.length, deletions: 0 };
+	}
+
+	const oldLines = (op.oldString ?? '').split('\n');
+	const newLines = (op.newString ?? '').split('\n');
+	const diff = [
+		`diff --git a/${op.path} b/${op.path}`,
+		`--- a/${op.path}`,
+		`+++ b/${op.path}`,
+		`@@ -1,${oldLines.length} +1,${newLines.length} @@`,
+		...oldLines.map((l) => `-${l}`),
+		...newLines.map((l) => `+${l}`),
+	].join('\n');
+	return { diff, additions: newLines.length, deletions: oldLines.length };
+}

--- a/packages/web/src/components/space/thread/space-task-thread-events.ts
+++ b/packages/web/src/components/space/thread/space-task-thread-events.ts
@@ -482,8 +482,10 @@ export function extractFileOperations(parsedRows: ParsedThreadRow[]): FileOperat
 
 	for (const row of parsedRows) {
 		const msg = row.message;
-		if (!msg || msg.role !== 'assistant') continue;
-		const content = Array.isArray(msg.content) ? msg.content : [];
+		if (!msg || !isSDKAssistantMessage(msg)) continue;
+		const content = Array.isArray(msg.message?.content)
+			? (msg.message.content as ContentBlock[])
+			: [];
 
 		for (const block of content) {
 			if (!isToolUseBlock(block)) continue;


### PR DESCRIPTION
- Chat composer margins fixed (px-2 → px-3)
- Task pane header: fixed height, border-b, bg-dark-850 aligned with context panel
- Artifacts panel: no header/close button; grouped sections (Todos, Commits, Uncommitted Changes)
- Todos grouped per agent (last TodoWrite per sessionId), ordered by status
- Commits: git log branch-point..HEAD, drill into files and diffs
- Uncommitted Changes: git diff HEAD only (working tree, not committed)
- Non-git fallback: extract Write/Edit tool calls from message thread, synthetic unified diffs
- New backend RPCs: getCommits, getCommitFiles, getCommitFileDiff; isGitRepo guard on all git handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)