### PR TITLE
feat: add workflow_id parameter to create_standalone_task tool

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1595,7 +1595,21 @@ export class SpaceRuntime {
 				if (!fresh || fresh.workflowRunId) continue;
 				if (fresh.status !== 'open') continue;
 
-				const selectedWorkflow = this.selectFallbackWorkflowForStandaloneTask(fresh, workflows);
+				// Prefer the caller-specified workflow; fall back to heuristic selection.
+				let selectedWorkflow: ReturnType<typeof this.selectFallbackWorkflowForStandaloneTask>;
+				if (fresh.preferredWorkflowId) {
+					const explicit = this.config.spaceWorkflowManager.getWorkflow(fresh.preferredWorkflowId);
+					if (explicit) {
+						selectedWorkflow = explicit;
+					} else {
+						log.warn(
+							`SpaceRuntime: preferred_workflow_id "${fresh.preferredWorkflowId}" not found for task ${fresh.id}; falling back to heuristic selection`
+						);
+						selectedWorkflow = this.selectFallbackWorkflowForStandaloneTask(fresh, workflows);
+					}
+				} else {
+					selectedWorkflow = this.selectFallbackWorkflowForStandaloneTask(fresh, workflows);
+				}
 				if (!selectedWorkflow) continue;
 
 				try {

--- a/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
+++ b/packages/daemon/src/lib/space/tools/global-spaces-tools.ts
@@ -353,6 +353,7 @@ export function createGlobalSpacesToolHandlers(
 			description: string;
 			priority?: SpaceTaskPriority;
 			depends_on?: string[];
+			workflow_id?: string;
 		}): Promise<ToolResult> {
 			const resolved = resolveSpaceId(args.space_id);
 			if ('error' in resolved) return jsonResult({ success: false, error: resolved.error });
@@ -363,6 +364,7 @@ export function createGlobalSpacesToolHandlers(
 					description: args.description,
 					priority: args.priority,
 					dependsOn: args.depends_on,
+					preferredWorkflowId: args.workflow_id ?? null,
 				});
 				return jsonResult({ success: true, space_id: resolved.spaceId, task });
 			} catch (err) {
@@ -753,6 +755,12 @@ export function createGlobalSpacesMcpServer(
 					.array(z.string())
 					.optional()
 					.describe('IDs of tasks that must complete before this task can start'),
+				workflow_id: z
+					.string()
+					.optional()
+					.describe(
+						'ID of the workflow to use for this task. When provided, the runtime uses this workflow instead of auto-selecting one. Example: "67b42e04-ae03-425d-b267-40527b042dcc" for Coding with QA Workflow.'
+					),
 			},
 			(args) => handlers.create_standalone_task(args)
 		),

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -306,12 +306,14 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			title: string;
 			description: string;
 			priority?: SpaceTaskPriority;
+			workflow_id?: string;
 		}): Promise<ToolResult> {
 			try {
 				const task = await taskManager.createTask({
 					title: args.title,
 					description: args.description,
 					priority: args.priority,
+					preferredWorkflowId: args.workflow_id ?? null,
 				});
 				return jsonResult({ success: true, task });
 			} catch (err) {
@@ -592,6 +594,12 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 					.string()
 					.optional()
 					.describe('ID of a custom Space agent to assign this task to'),
+				workflow_id: z
+					.string()
+					.optional()
+					.describe(
+						'ID of the workflow to use for this task. When provided, the runtime uses this workflow instead of auto-selecting one. Example: "67b42e04-ae03-425d-b267-40527b042dcc" for Coding with QA Workflow.'
+					),
 			},
 			(args) => handlers.create_standalone_task(args)
 		),

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -43,8 +43,8 @@ export class SpaceTaskRepository {
 
 			this.db
 				.prepare(
-					`INSERT INTO space_tasks (id, space_id, task_number, title, description, status, priority, labels, workflow_run_id, created_by_task_id, depends_on, task_agent_session_id, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+					`INSERT INTO space_tasks (id, space_id, task_number, title, description, status, priority, labels, workflow_run_id, preferred_workflow_id, created_by_task_id, depends_on, task_agent_session_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 				)
 				.run(
 					id,
@@ -56,6 +56,7 @@ export class SpaceTaskRepository {
 					params.priority ?? 'normal',
 					JSON.stringify(params.labels ?? []),
 					params.workflowRunId ?? null,
+					params.preferredWorkflowId ?? null,
 					params.createdByTaskId ?? null,
 					JSON.stringify(params.dependsOn ?? []),
 					params.taskAgentSessionId ?? null,
@@ -182,6 +183,10 @@ export class SpaceTaskRepository {
 		if (params.workflowRunId !== undefined) {
 			fields.push('workflow_run_id = ?');
 			values.push(params.workflowRunId ?? null);
+		}
+		if (params.preferredWorkflowId !== undefined) {
+			fields.push('preferred_workflow_id = ?');
+			values.push(params.preferredWorkflowId ?? null);
 		}
 		if (params.createdByTaskId !== undefined) {
 			fields.push('created_by_task_id = ?');
@@ -364,6 +369,7 @@ export class SpaceTaskRepository {
 			priority: row.priority as SpaceTask['priority'],
 			labels: JSON.parse((row.labels as string | null) ?? '[]') as string[],
 			workflowRunId: (row.workflow_run_id as string | null) ?? undefined,
+			preferredWorkflowId: (row.preferred_workflow_id as string | null) ?? undefined,
 			createdByTaskId: (row.created_by_task_id as string | null) ?? undefined,
 			result: (row.result as string | null) ?? null,
 			dependsOn: JSON.parse((row.depends_on as string | null) ?? '[]') as string[],

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -337,6 +337,11 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	//   - Adds 'custom_prompt TEXT' column.
 	//   - Migrates data: combines system_prompt and instructions into a single field.
 	runMigration80(db);
+
+	// Migration 81: Add preferred_workflow_id to space_tasks.
+	//   - Stores the caller-specified workflow template ID for standalone task attachment.
+	//   - When set, the runtime uses this workflow instead of heuristic auto-selection.
+	runMigration81(db);
 }
 
 /**
@@ -5540,4 +5545,22 @@ function runMigration80(db: BunDatabase): void {
 			ELSE NULL
 		END
 	`);
+}
+
+/**
+ * Migration 81: Add preferred_workflow_id column to space_tasks.
+ *
+ * Stores the caller-specified workflow template ID for standalone task workflow
+ * attachment. When set via `create_standalone_task({ workflow_id })`, the
+ * SpaceRuntime uses this workflow instead of the heuristic auto-selection.
+ *
+ * The column is nullable with no foreign key — workflows can be deleted
+ * independently of tasks, and the runtime falls back gracefully when the
+ * referenced workflow no longer exists.
+ */
+function runMigration81(db: BunDatabase): void {
+	if (!tableExists(db, 'space_tasks')) return;
+	if (tableHasColumn(db, 'space_tasks', 'preferred_workflow_id')) return;
+
+	db.exec(`ALTER TABLE space_tasks ADD COLUMN preferred_workflow_id TEXT`);
 }

--- a/packages/daemon/tests/unit/5-space/space/global-spaces-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/space/global-spaces-tools.test.ts
@@ -509,6 +509,48 @@ describe('createGlobalSpacesToolHandlers — create_standalone_task', () => {
 		expect(parsed.success).toBe(true);
 		expect(parsed.task.dependsOn).toContain(firstTaskId);
 	});
+
+	test('persists preferredWorkflowId when workflow_id is provided', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+		const wf = ctx.workflowManager.createWorkflow({
+			spaceId: ctx.spaceId,
+			name: 'Coding with QA',
+			description: 'Coder + Reviewer + QA loop',
+			nodes: [{ id: 'step-1', name: 'Coding', agentId: ctx.agentId }],
+			transitions: [],
+			startNodeId: 'step-1',
+			rules: [],
+			tags: ['coding'],
+		});
+
+		const result = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Fix login bug',
+			description: 'Authentication fails for international users',
+			workflow_id: wf.id,
+		});
+
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		const stored = ctx.taskRepo.getTask(parsed.task.id);
+		expect(stored).not.toBeNull();
+		expect(stored?.preferredWorkflowId).toBe(wf.id);
+	});
+
+	test('preferredWorkflowId is null when workflow_id not provided', async () => {
+		const handlers = makeHandlers(ctx, { activeSpaceId: null });
+
+		const result = await handlers.create_standalone_task({
+			space_id: ctx.spaceId,
+			title: 'Generic task',
+			description: 'No explicit workflow',
+		});
+
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		const stored = ctx.taskRepo.getTask(parsed.task.id);
+		expect(stored?.preferredWorkflowId ?? null).toBeNull();
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/5-space/space/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/space/space-agent-tools.test.ts
@@ -836,6 +836,31 @@ describe('createSpaceAgentToolHandlers — create_standalone_task', () => {
 		expect(stored).not.toBeNull();
 		expect(stored?.title).toBe('Stored task');
 	});
+
+	test('persists preferredWorkflowId when workflow_id is provided', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'Coding QA');
+		const result = await makeHandlers(ctx).create_standalone_task({
+			title: 'Fix auth bug',
+			description: 'Authentication fails for international users',
+			workflow_id: wf.id,
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		const stored = ctx.taskRepo.getTask(parsed.task.id);
+		expect(stored).not.toBeNull();
+		expect(stored?.preferredWorkflowId).toBe(wf.id);
+	});
+
+	test('preferredWorkflowId is null when workflow_id not provided', async () => {
+		const result = await makeHandlers(ctx).create_standalone_task({
+			title: 'Generic task',
+			description: 'No explicit workflow',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		const stored = ctx.taskRepo.getTask(parsed.task.id);
+		expect(stored?.preferredWorkflowId ?? null).toBeNull();
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/5-space/space/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/5-space/space/space-runtime.test.ts
@@ -460,6 +460,63 @@ describe('SpaceRuntime', () => {
 			const unchanged = taskRepo.getTask(task.id)!;
 			expect(unchanged.status).toBe('open');
 		});
+
+		test('uses preferredWorkflowId when attaching workflow to standalone task', async () => {
+			// Create two workflows — one preferred, one that would match heuristically
+			const preferredWorkflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Coding', agentId: AGENT_CODER },
+			]);
+			// Second workflow with tags that would win the heuristic for "fix bug" keywords
+			buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_B, name: 'Fix', agentId: AGENT_GENERAL },
+			]);
+
+			// Create task with explicit preferredWorkflowId
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Fix login bug',
+				description: 'Authentication fails for international users',
+				status: 'open',
+				preferredWorkflowId: preferredWorkflow.id,
+			});
+
+			// Tick attaches the preferred workflow
+			await runtime.executeTick();
+
+			const updated = taskRepo.getTask(task.id)!;
+			expect(updated.workflowRunId).not.toBeNull();
+
+			// Verify the run uses the preferred workflow
+			const run = workflowRunRepo.getRun(updated.workflowRunId!);
+			expect(run).not.toBeNull();
+			expect(run!.workflowId).toBe(preferredWorkflow.id);
+		});
+
+		test('falls back to heuristic when preferredWorkflowId workflow is not found', async () => {
+			const fallbackWorkflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Work', agentId: AGENT_CODER },
+			]);
+
+			// Create task with a non-existent preferred workflow ID
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Some task',
+				description: 'Some description',
+				status: 'open',
+				preferredWorkflowId: 'wf-does-not-exist',
+			});
+
+			await runtime.executeTick();
+
+			// Runtime should have fallen back and attached a workflow
+			const updated = taskRepo.getTask(task.id)!;
+			expect(updated.workflowRunId).not.toBeNull();
+
+			const run = workflowRunRepo.getRun(updated.workflowRunId!);
+			expect(run).not.toBeNull();
+			// Fallback: uses the only available workflow
+			expect(run!.workflowId).toBe(fallbackWorkflow.id);
+		});
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -4,7 +4,7 @@
  * Creates the minimal set of tables needed for Space system tests
  * without requiring a full migration run.
  *
- * Keep in sync with the fully-migrated production schema (after M77).
+ * Keep in sync with the fully-migrated production schema (after M81).
  *
  * IMPORTANT: The schema defined here must exactly match the fully-migrated production
  * schema (i.e. after all migrations have run). Never add columns or constraints here
@@ -180,6 +180,7 @@ export function createSpaceTables(db: BunDatabase): void {
 				CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
 			labels TEXT NOT NULL DEFAULT '[]',
 			workflow_run_id TEXT,
+			preferred_workflow_id TEXT,
 			created_by_task_id TEXT,
 			result TEXT,
 			depends_on TEXT NOT NULL DEFAULT '[]',

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -199,6 +199,12 @@ export interface SpaceTask {
 	result: string | null;
 	/** ID of the workflow run that orchestrates this task (links task to its workflow execution) */
 	workflowRunId?: string | null;
+	/**
+	 * Preferred workflow template ID for this task.
+	 * When set by the caller via `create_standalone_task({ workflow_id })`, the runtime
+	 * uses this workflow instead of the heuristic fallback when attaching a workflow run.
+	 */
+	preferredWorkflowId?: string | null;
 	/** ID of the planning task that created this task */
 	createdByTaskId?: string | null;
 	/**
@@ -296,6 +302,12 @@ export interface CreateSpaceTaskParams {
 	status?: SpaceTaskStatus;
 	/** Workflow run that spawned this task */
 	workflowRunId?: string | null;
+	/**
+	 * Preferred workflow template ID.
+	 * When provided, the runtime uses this workflow for standalone task attachment
+	 * instead of the heuristic auto-selection.
+	 */
+	preferredWorkflowId?: string | null;
 	/** ID of planning task that created this task */
 	createdByTaskId?: string | null;
 	/**
@@ -317,6 +329,7 @@ export interface UpdateSpaceTaskParams {
 	dependsOn?: string[];
 	result?: string | null;
 	workflowRunId?: string | null;
+	preferredWorkflowId?: string | null;
 	createdByTaskId?: string | null;
 	activeSession?: 'worker' | 'leader' | null;
 	prUrl?: string | null;


### PR DESCRIPTION
Add optional `workflow_id` parameter to `create_standalone_task` so callers can pin a specific workflow instead of relying on keyword heuristics.

- New `workflow_id` param in both `space-agent-tools` and `global-spaces-tools` schemas
- Persisted as `preferred_workflow_id` on `space_tasks` (migration 81, `ALTER TABLE ... ADD COLUMN`)
- `SpaceRuntime.attachStandaloneTasksToWorkflows()` checks `task.preferredWorkflowId` first; falls back to heuristic with a log warning if the referenced workflow is not found
- Unit tests: tool persistence + runtime attachment behaviour (preferred workflow used, fallback when not found)