### PR TITLE
fix: merge listGateData result with event-based updates to prevent race condition

### DIFF
--- a/packages/web/src/components/space/useRuntimeCanvasData.ts
+++ b/packages/web/src/components/space/useRuntimeCanvasData.ts
@@ -152,11 +152,18 @@ export function useRuntimeCanvasData(
 			.request<{ gateData: GateDataRecord[] }>('spaceWorkflowRun.listGateData', { runId })
 			.then((result) => {
 				if (runIdRef.current !== runId) return;
-				const map = new Map<string, Record<string, unknown>>();
-				for (const record of result.gateData) {
-					map.set(record.gateId, record.data);
-				}
-				setGateDataMap(map);
+				setGateDataMap((prev) => {
+					// Build from fetched data, then overlay any event-based updates that
+					// arrived while the request was in-flight — events are more recent.
+					const fetched = new Map<string, Record<string, unknown>>();
+					for (const record of result.gateData) {
+						fetched.set(record.gateId, record.data);
+					}
+					for (const [gateId, data] of prev) {
+						fetched.set(gateId, data);
+					}
+					return fetched;
+				});
 			})
 			.catch(() => {})
 			.finally(() => {


### PR DESCRIPTION
`useRuntimeCanvasData` calls `listGateData` concurrently with subscribing to `space.gateData.updated` events. If a gate rejection happens before `listGateData` completes, the event correctly updates `gateDataMap` with `approved=false`, but when `listGateData` resolves later (with a pre-rejection empty snapshot), the full `setGateDataMap(map)` replacement overwrites the event-based update — reverting the gate back to `waiting_human`. The `space-approval-gate-rejection` test hits this every run because it rejects immediately without waiting for `listGateData` to complete.

Fix: use a functional update that applies the fetched snapshot as base but preserves any event-based entries that arrived during the in-flight request.