### PR TITLE
fix(e2e): fix space-approval-gate-rejection test 4 (Agents tab navigation)

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1220,7 +1220,20 @@ export class SpaceRuntime {
 				(execution) => execution.status === 'pending' && !execution.agentSessionId
 			);
 
-			if (pendingExecutions.length > 0) {
+			// Skip spawning when the canonical task is terminal (done/cancelled/archived).
+			// The task was externally resolved while the run was in_progress — spawning new
+			// agent sub-sessions would conflict with the caller's intent and disturb tests
+			// that mark the task done to prevent agent interference.
+			const canonicalTaskIsTerminal =
+				canonicalTask.status === 'done' ||
+				canonicalTask.status === 'cancelled' ||
+				canonicalTask.status === 'archived';
+
+			if (pendingExecutions.length > 0 && canonicalTaskIsTerminal) {
+				log.info(
+					`SpaceRuntime: skipping agent spawn for run ${runId} — canonical task ${canonicalTask.id} is terminal (${canonicalTask.status})`
+				);
+			} else if (pendingExecutions.length > 0) {
 				if (!space) {
 					log.warn(
 						`SpaceRuntime: cannot spawn workflow node agents for run ${runId} — space ${meta.spaceId} not found`

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -238,6 +238,7 @@ export default defineConfig({
 			DEFAULT_MODEL: 'sonnet', // Maps to GLM-4.7 for E2E tests
 			// Isolated paths for this test run
 			NEOKAI_WORKSPACE_PATH: e2eWorkspaceDir,
+			NEOKAI_WORKSPACE_ROOT: e2eWorkspaceDir,
 			DB_PATH: e2eDatabasePath,
 			// Enable Neo agent for E2E tests (bypasses test-mode guard in app.ts)
 			NEOKAI_ENABLE_NEO_AGENT: '1',

--- a/packages/e2e/tests/features/space-approval-gate-rejection.e2e.ts
+++ b/packages/e2e/tests/features/space-approval-gate-rejection.e2e.ts
@@ -149,10 +149,10 @@ async function rejectViaPopup(page: Page): Promise<void> {
 	// state, which causes Playwright's stability checks to time out. Use force:true to bypass
 	// the actionability checks and click immediately.
 	await waitingGate.click({ force: true });
-	await expect(page.locator('button:has-text("Reject")').first()).toBeVisible({ timeout: 5000 });
+	await expect(page.getByTestId('popup-reject-btn')).toBeVisible({ timeout: 5000 });
 
 	// Click Reject in the popup.
-	await page.locator('button:has-text("Reject")').first().click();
+	await page.getByTestId('popup-reject-btn').click();
 
 	// Wait for the server round-trip: run transitions to needs_attention + gate becomes blocked.
 	// Use data-gate-id to target the specific plan-approval-gate — after rejection ALL gates
@@ -335,10 +335,12 @@ test.describe('Approval Gate Rejection', () => {
 			timeout: 10000,
 		});
 
-		// Tab bar should still be navigable — clicking Agents shows agent content.
+		// Space configure page should still be navigable — clicking Agents shows agent content.
 		// SpaceAgentList does NOT depend on spaceStore.space being non-null (unlike
 		// WorkflowList / SpaceSettings), so it's a more reliable navigation target.
-		await page.locator('button:has-text("Agents")').click();
+		await page.goto(`/space/${spaceId}/configure`);
+		await page.waitForURL(`/space/${spaceId}/configure`, { timeout: 10000 });
+		await page.getByTestId('space-configure-tab-agents').click();
 		await expect(page.locator('text=Planner')).toBeVisible({ timeout: 30000 });
 		await expect(page.locator('text=Coder')).toBeVisible({ timeout: 10000 });
 

--- a/packages/web/src/components/space/ReadOnlyWorkflowCanvas.tsx
+++ b/packages/web/src/components/space/ReadOnlyWorkflowCanvas.tsx
@@ -121,14 +121,16 @@ export function ReadOnlyWorkflowCanvas({
 			if (!gatePopup || !runId) return;
 			setApproving(true);
 			try {
-				const hub = connectionManager.getHubIfConnected();
-				if (!hub) return;
+				const hub = await connectionManager.getHub();
 				await hub.request('spaceWorkflowRun.approveGate', {
 					runId,
 					gateId: gatePopup.gateId,
 					approved,
 				});
 				setGatePopup(null);
+			} catch (err) {
+				// eslint-disable-next-line no-console
+				console.error('[handlePopupDecision] approveGate error:', err);
 			} finally {
 				setApproving(false);
 			}
@@ -232,6 +234,7 @@ export function ReadOnlyWorkflowCanvas({
 									Approve
 								</button>
 								<button
+									data-testid="popup-reject-btn"
 									onClick={() => void handlePopupDecision(false)}
 									disabled={approving}
 									class="flex-1 px-2 py-1.5 text-xs font-medium rounded bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50 disabled:opacity-50 transition-colors"

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -570,10 +570,18 @@ class SpaceStore {
 			space: Space;
 		}>('space.archived', (event) => {
 			if (event.spaceId === spaceId) {
-				// Space archived externally — clear selection
-				this.clearSpace().catch((err) => {
-					logger.error('Failed to clear space after external archive:', err);
-				});
+				// Conditional clear: only clear if still on this space when the promise chain
+				// executes. A late-arriving event for a previous space can otherwise clear the
+				// newly-selected space (race between selectSpace chain and delayed WS events).
+				this.selectPromise = this.selectPromise
+					.then(() => {
+						if (this.spaceId.value === spaceId) {
+							return this.doSelect(null);
+						}
+					})
+					.catch((err) => {
+						logger.error('Failed to clear space after external archive:', err);
+					});
 			}
 		});
 		this.cleanupFunctions.push(unsubSpaceArchived);
@@ -584,10 +592,18 @@ class SpaceStore {
 			spaceId: string;
 		}>('space.deleted', (event) => {
 			if (event.spaceId === spaceId) {
-				// Space deleted externally — clear selection
-				this.clearSpace().catch((err) => {
-					logger.error('Failed to clear space after external delete:', err);
-				});
+				// Conditional clear: only clear if still on this space when the promise chain
+				// executes. A late-arriving event for a previous space can otherwise clear the
+				// newly-selected space (race between selectSpace chain and delayed WS events).
+				this.selectPromise = this.selectPromise
+					.then(() => {
+						if (this.spaceId.value === spaceId) {
+							return this.doSelect(null);
+						}
+					})
+					.catch((err) => {
+						logger.error('Failed to clear space after external delete:', err);
+					});
 			}
 		});
 		this.cleanupFunctions.push(unsubSpaceDeleted);


### PR DESCRIPTION
Fix the remaining e2e test failure in `space-approval-gate-rejection.e2e.ts`.

- Test 4 was timing out clicking `button:has-text("Agents")` on the task detail page, where no such button exists. The Agents tab is part of `SpaceConfigurePage` at `/space/:id/configure`. Fixed by navigating to the configure URL first and using `data-testid="space-configure-tab-agents"`.
- Removed temporary debug console logging from `ReadOnlyWorkflowCanvas` and the `approveGate` RPC handler.
- Removed temporary browser console capture from test `beforeEach`.
- Carries forward permanent fixes: `NEOKAI_WORKSPACE_ROOT` in playwright config, space-store race condition fix, and space-runtime canonical-task terminal guard.

All 5 tests pass locally (13.9s).