### PR TITLE
fix(e2e): update workspace-selection tests after modal refactor

### DIFF
--- a/packages/e2e/tests/features/provider-model-switching.e2e.ts
+++ b/packages/e2e/tests/features/provider-model-switching.e2e.ts
@@ -23,7 +23,6 @@ import {
 	cleanupTestSession,
 	waitForAssistantResponse,
 	waitForSessionCreated,
-	getWorkspaceRoot,
 	waitForWebSocketConnected,
 	getModal,
 } from '../helpers/wait-helpers';
@@ -33,65 +32,31 @@ import {
 // ---------------------------------------------------------------------------
 
 /**
- * Create a new session by clicking the "New Session" button in the Lobby UI,
- * filling in the workspace path, and submitting the form.
- *
- * NOTE: `getWorkspaceRoot` uses an RPC call for infrastructure purposes only
- * (fetching the test workspace path).  The session itself is created through
- * the UI form — no `session.create` RPC is called directly.
+ * Create a new session by clicking the "New Session" button in the Lobby UI
+ * and submitting the form. Workspace selection has been moved out of the modal
+ * into the inline WorkspaceSelector shown in the chat container after creation.
  */
 async function createSessionViaNewSessionButton(page: Page): Promise<string> {
 	await waitForWebSocketConnected(page);
-	const workspaceRoot = await getWorkspaceRoot(page);
 
-	// Close any stale modal left open from a previous test.  When the SPA does not
-	// fully reset component state across tests, the backdrop blocks the "New Session"
-	// button.  The SPA may keep hidden dialog elements in the DOM — use :visible to
-	// only match dialogs that are actually shown.
-	//
+	// Close any stale modal left open from a previous test.
 	// getModal() excludes the NeoPanel (data-testid="neo-panel") which has role="dialog"
-	// and is permanently in the DOM even when closed (just off-screen via CSS
-	// transform: -translate-x-full).  Playwright considers it "visible" because CSS
-	// transforms do not affect layout boxes; pressing Escape would not close it, so
-	// including it in the stale-dialog check causes a guaranteed toBeHidden() failure.
+	// and is permanently in the DOM even when closed.
 	const anyDialog = getModal(page).locator(':visible');
 	if (await anyDialog.isVisible({ timeout: 500 }).catch(() => false)) {
 		await page.keyboard.press('Escape');
 		await expect(anyDialog).toBeHidden({ timeout: 3000 });
 	}
 
-	// Click the desktop "New Session" button.  There are two buttons with accessible
-	// name "New Session" (desktop text button + mobile icon-only button), so use
-	// :has-text to match only the one with visible text content.
+	// Click the desktop "New Session" button.
 	await page.locator('button:has-text("New Session")').first().click();
 
-	// Wait for the modal dialog to appear and scope all subsequent lookups to the
-	// VISIBLE dialog.  getModal() excludes the NeoPanel (always in DOM with
-	// role="dialog") to avoid strict-mode violations and incorrect element matching.
 	const dialog = getModal(page);
 	await expect(dialog).toBeVisible({ timeout: 5000 });
 
-	// Fill in the workspace path — scoped to the visible dialog.
-	const pathInput = dialog.getByTestId('new-session-workspace-input');
-	await expect(pathInput).toBeVisible({ timeout: 5000 });
-
-	// Wait for the modal's async model fetch to settle before filling the path.
-	// NewSessionModal calls fetchAvailableModels() on open; when the cache is warm
-	// (tests 2+) the promise resolves instantly and triggers a Preact re-render that
-	// resets selectedPath to '' — overwriting a fill that happened too early.
-	// Waiting for the "Model (optional)" label confirms the async render completed.
-	await dialog
-		.getByText('Model (optional)')
-		.isVisible({ timeout: 1500 })
-		.catch(() => {});
-
-	await pathInput.fill(workspaceRoot);
-
-	// Submit the form — scoped to the visible dialog to avoid ambiguity.
+	// Submit the form — workspace is set inline after session creation.
 	await dialog.getByRole('button', { name: 'Create Session' }).click();
 
-	// waitForSessionCreated handles the rest: it waits for navigation away from the
-	// lobby and confirms the chat view is ready.
 	return waitForSessionCreated(page);
 }
 

--- a/packages/e2e/tests/features/workspace-selection.e2e.ts
+++ b/packages/e2e/tests/features/workspace-selection.e2e.ts
@@ -1,14 +1,12 @@
 /**
- * Workspace Selection E2E Tests
+ * New Session Modal E2E Tests
  *
- * Tests the workspace selection flow in the New Session modal:
+ * Tests the New Session modal flow:
  *
  * 1. Modal appears when clicking "New Session" in the Lobby
- * 2. Workspace path is optional — a session can be created without one
- * 3. A workspace path can be typed in the input field
- * 4. Workspace history is persisted via the backend:
- *    - workspace.add is called after creating a session with a path
- *    - The next time the modal opens, the path appears in the history dropdown
+ * 2. Session can be created without a workspace path (workspace selection
+ *    is now handled by the inline WorkspaceSelector in the chat container —
+ *    see workspace-selector.e2e.ts for those tests)
  *
  * All actions are performed via UI interactions only (no direct RPC calls in
  * assertions/actions). The only RPC usage is in afterEach cleanup, which is
@@ -18,7 +16,7 @@
 import { test, expect } from '../../fixtures';
 import { waitForWebSocketConnected, cleanupTestSession } from '../helpers/wait-helpers';
 
-test.describe('Workspace selection in New Session modal', () => {
+test.describe('New Session modal', () => {
 	let createdSessionIds: string[] = [];
 
 	test.beforeEach(async ({ page }) => {
@@ -53,12 +51,10 @@ test.describe('Workspace selection in New Session modal', () => {
 			page.getByRole('dialog').getByRole('heading', { name: 'New Session' })
 		).toBeVisible();
 
-		// The workspace path input should be present and optional (no asterisk / "required" text)
-		const workspaceInput = page.getByTestId('new-session-workspace-input');
-		await expect(workspaceInput).toBeVisible();
-
-		// The label should say workspace is optional (check specific "(optional)" text)
-		await expect(page.getByRole('dialog').getByText('(optional)', { exact: true })).toBeVisible();
+		// Create Session button should be enabled
+		await expect(
+			page.getByRole('dialog').getByRole('button', { name: 'Create Session' })
+		).toBeEnabled();
 
 		// Close the modal
 		await page.keyboard.press('Escape');
@@ -70,15 +66,11 @@ test.describe('Workspace selection in New Session modal', () => {
 		await page.getByRole('button', { name: 'New Session', exact: true }).click();
 		await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
 
-		// Workspace input should be empty
-		const workspaceInput = page.getByTestId('new-session-workspace-input');
-		await expect(workspaceInput).toHaveValue('');
-
-		// Submit button should be enabled even without a path
+		// Submit button should be enabled
 		const submitButton = page.getByRole('dialog').getByRole('button', { name: 'Create Session' });
 		await expect(submitButton).toBeEnabled();
 
-		// Click "Create Session" without entering a path
+		// Click "Create Session"
 		await submitButton.click();
 
 		// Should navigate to a session
@@ -90,84 +82,5 @@ test.describe('Workspace selection in New Session modal', () => {
 		if (sessionIdMatch) {
 			createdSessionIds.push(sessionIdMatch[1]);
 		}
-	});
-
-	test('Session can be created with a workspace path typed manually', async ({ page }) => {
-		// Open the New Session modal
-		await page.getByRole('button', { name: 'New Session', exact: true }).click();
-		await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
-
-		// Type a workspace path
-		const workspaceInput = page.getByTestId('new-session-workspace-input');
-		await workspaceInput.fill('/tmp/test-workspace-e2e');
-
-		// Submit
-		const submitButton = page.getByRole('dialog').getByRole('button', { name: 'Create Session' });
-		await expect(submitButton).toBeEnabled();
-		await submitButton.click();
-
-		// Should navigate to a session
-		await expect(page).not.toHaveURL('/', { timeout: 10000 });
-
-		// Extract session ID from URL for cleanup
-		const url = page.url();
-		const sessionIdMatch = url.match(/\/session\/([^/?#]+)/);
-		if (sessionIdMatch) {
-			createdSessionIds.push(sessionIdMatch[1]);
-		}
-	});
-
-	test('Workspace history is shown in the modal on subsequent opens', async ({ page }) => {
-		const testPath = '/tmp/e2e-workspace-history-test';
-
-		// Create a session with a workspace path to populate history
-		await page.getByRole('button', { name: 'New Session', exact: true }).click();
-		await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
-
-		const workspaceInput = page.getByTestId('new-session-workspace-input');
-		await workspaceInput.fill(testPath);
-
-		const submitButton = page.getByRole('dialog').getByRole('button', { name: 'Create Session' });
-		await submitButton.click();
-
-		// Wait for navigation to session
-		await expect(page).not.toHaveURL('/', { timeout: 10000 });
-
-		// Collect created session ID for cleanup
-		const sessionUrl = page.url();
-		const sessionIdMatch = sessionUrl.match(/\/session\/([^/?#]+)/);
-		if (sessionIdMatch) {
-			createdSessionIds.push(sessionIdMatch[1]);
-		}
-
-		// Go back to lobby
-		await page.goto('/');
-		await waitForWebSocketConnected(page);
-		await expect(page.getByRole('button', { name: 'New Session', exact: true })).toBeVisible({
-			timeout: 15000,
-		});
-
-		// Open the modal again — the workspace history should be loaded from backend
-		await page.getByRole('button', { name: 'New Session', exact: true }).click();
-		await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5000 });
-
-		// Wait a moment for history to load asynchronously
-		await page.waitForTimeout(1500);
-
-		// Check that the history dropdown or path input shows the previously used path
-		// Either via the <select> dropdown (if history was loaded from backend) or via
-		// the path input pre-filled (if auto-selected)
-		const historyDropdown = page.getByRole('dialog').locator('select').first();
-		if (await historyDropdown.isVisible({ timeout: 2000 }).catch(() => false)) {
-			// History dropdown is visible — check it contains our path
-			const dropdownContent = await historyDropdown.textContent();
-			expect(dropdownContent).toContain(testPath);
-		}
-		// If dropdown is not visible, workspace history may not have loaded yet
-		// (backend call is async) — this is acceptable as the history persistence
-		// is verified via backend state, not just UI visibility.
-
-		// Close modal
-		await page.keyboard.press('Escape');
 	});
 });


### PR DESCRIPTION
PR #1472 moved workspace selection out of the New Session modal into the inline `WorkspaceSelector` in the chat container, but two E2E test files still referenced the removed `new-session-workspace-input` field.

**Failures fixed:**
- `E2E No-LLM (features-workspace-selection)` — 4 tests failing
- `E2E LLM (features-provider-model-switching)` — 8 tests failing

**Changes:**
- `workspace-selection.e2e.ts`: rewritten to test only what the modal still does (appears, has Create Session button, creates session without workspace). Workspace path tests are now covered by `workspace-selector.e2e.ts`.
- `provider-model-switching.e2e.ts`: removed workspace-fill from `createSessionViaNewSessionButton` helper and dropped the now-unused `getWorkspaceRoot` import.