### PR TITLE
refactor: lazy-load heavy deps and improve /spaces page UX

### DIFF
--- a/packages/web/src/components/chat/MarkdownRenderer.tsx
+++ b/packages/web/src/components/chat/MarkdownRenderer.tsx
@@ -1,56 +1,79 @@
-import { useEffect, useRef, useMemo } from 'preact/hooks';
-import { marked } from 'marked';
-import hljs from 'highlight.js';
+import { useEffect, useRef, useState } from 'preact/hooks';
 
 interface MarkdownRendererProps {
 	content: string;
 	class?: string;
 }
 
-// Configure marked once at module level
-marked.setOptions({
-	breaks: true,
-	gfm: true,
-});
+// Lazy-loaded modules — cached after first import
+let markedModule: typeof import('marked') | null = null;
+let hljsModule: typeof import('highlight.js') | null = null;
+
+async function getMarked() {
+	if (!markedModule) {
+		markedModule = await import('marked');
+		markedModule.marked.setOptions({ breaks: true, gfm: true });
+	}
+	return markedModule.marked;
+}
+
+async function getHljs() {
+	if (!hljsModule) {
+		hljsModule = await import('highlight.js');
+	}
+	return hljsModule.default;
+}
 
 export default function MarkdownRenderer({ content, class: className }: MarkdownRendererProps) {
 	const containerRef = useRef<HTMLDivElement>(null);
+	const [html, setHtml] = useState<string | null>(null);
 
-	// Memoize markdown parsing - only re-parse when content changes
-	const html = useMemo(() => {
-		return marked.parse(content) as string;
+	// Parse markdown asynchronously
+	useEffect(() => {
+		let cancelled = false;
+		getMarked().then((marked) => {
+			if (!cancelled) {
+				setHtml(marked.parse(content) as string);
+			}
+		});
+		return () => {
+			cancelled = true;
+		};
 	}, [content]);
 
+	// Apply syntax highlighting after HTML is set
 	useEffect(() => {
-		if (containerRef.current) {
-			// Set innerHTML only when html changes
-			containerRef.current.innerHTML = html;
+		if (html == null || !containerRef.current) return;
+		containerRef.current.innerHTML = html;
 
-			// Apply syntax highlighting to code blocks
-			const codeBlocks = containerRef.current.querySelectorAll('pre code');
-			codeBlocks.forEach((block) => {
-				hljs.highlightElement(block as HTMLElement);
+		// Apply syntax highlighting to code blocks
+		const codeBlocks = containerRef.current.querySelectorAll('pre code');
+		if (codeBlocks.length > 0) {
+			getHljs().then((hljs) => {
+				codeBlocks.forEach((block) => {
+					hljs.highlightElement(block as HTMLElement);
+				});
 			});
+		}
 
-			// Wrap tables in scrollable container to prevent horizontal overflow
-			const tables = containerRef.current.querySelectorAll('table');
-			tables.forEach((table) => {
-				if (!table.parentElement?.classList.contains('prose-table-wrapper')) {
-					const wrapper = document.createElement('div');
-					wrapper.className = 'prose-table-wrapper';
-					table.parentNode?.insertBefore(wrapper, table);
-					wrapper.appendChild(table);
-				}
-			});
-
-			// Remove top margin from first paragraph and bottom margin from last paragraph
-			const paragraphs = containerRef.current.querySelectorAll('p');
-			if (paragraphs.length > 0) {
-				const firstP = paragraphs[0] as HTMLElement;
-				const lastP = paragraphs[paragraphs.length - 1] as HTMLElement;
-				firstP.style.marginTop = '0';
-				lastP.style.marginBottom = '0';
+		// Wrap tables in scrollable container to prevent horizontal overflow
+		const tables = containerRef.current.querySelectorAll('table');
+		tables.forEach((table) => {
+			if (!table.parentElement?.classList.contains('prose-table-wrapper')) {
+				const wrapper = document.createElement('div');
+				wrapper.className = 'prose-table-wrapper';
+				table.parentNode?.insertBefore(wrapper, table);
+				wrapper.appendChild(table);
 			}
+		});
+
+		// Remove top margin from first paragraph and bottom margin from last paragraph
+		const paragraphs = containerRef.current.querySelectorAll('p');
+		if (paragraphs.length > 0) {
+			const firstP = paragraphs[0] as HTMLElement;
+			const lastP = paragraphs[paragraphs.length - 1] as HTMLElement;
+			firstP.style.marginTop = '0';
+			lastP.style.marginBottom = '0';
 		}
 	}, [html]);
 

--- a/packages/web/src/components/chat/__tests__/MarkdownRenderer.test.tsx
+++ b/packages/web/src/components/chat/__tests__/MarkdownRenderer.test.tsx
@@ -6,18 +6,20 @@
  * This prevents global mock pollution that breaks other tests.
 import { describe, it, expect } from 'vitest';
  *
- * Note: Uses synchronous tests where possible since Happy-DOM
- * may have timing issues with async markdown parsing.
+ * Note: MarkdownRenderer uses dynamic imports for marked/highlight.js,
+ * so all content assertions use waitFor to handle async rendering.
  */
 
-import { render } from '@testing-library/preact';
+import { render, waitFor } from '@testing-library/preact';
 import MarkdownRenderer from '../MarkdownRenderer';
 
 describe('MarkdownRenderer', () => {
 	describe('Basic Rendering', () => {
-		it('should render plain text', () => {
+		it('should render plain text', async () => {
 			const { container } = render(<MarkdownRenderer content="Hello World" />);
-			expect(container.textContent).toContain('Hello World');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Hello World');
+			});
 		});
 
 		it('should render with prose class', () => {
@@ -40,120 +42,154 @@ describe('MarkdownRenderer', () => {
 	});
 
 	describe('Markdown Parsing', () => {
-		it('should render headers', () => {
+		it('should render headers', async () => {
 			const { container } = render(<MarkdownRenderer content="# Heading 1" />);
-			expect(container.textContent).toContain('Heading 1');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Heading 1');
+			});
 		});
 
-		it('should render bold text', () => {
+		it('should render bold text', async () => {
 			const { container } = render(<MarkdownRenderer content="This is **bold** text" />);
-			expect(container.textContent).toContain('bold');
+			await waitFor(() => {
+				expect(container.textContent).toContain('bold');
+			});
 		});
 
-		it('should render italic text', () => {
+		it('should render italic text', async () => {
 			const { container } = render(<MarkdownRenderer content="This is *italic* text" />);
-			expect(container.textContent).toContain('italic');
+			await waitFor(() => {
+				expect(container.textContent).toContain('italic');
+			});
 		});
 
-		it('should render links', () => {
+		it('should render links', async () => {
 			const { container } = render(<MarkdownRenderer content="[Link text](https://example.com)" />);
-			expect(container.textContent).toContain('Link text');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Link text');
+			});
 		});
 
-		it('should render inline code', () => {
+		it('should render inline code', async () => {
 			const { container } = render(<MarkdownRenderer content="Use `npm install`" />);
-			expect(container.textContent).toContain('npm install');
+			await waitFor(() => {
+				expect(container.textContent).toContain('npm install');
+			});
 		});
 
-		it('should render unordered lists', () => {
+		it('should render unordered lists', async () => {
 			const { container } = render(<MarkdownRenderer content="- Item 1\n- Item 2\n- Item 3" />);
-			expect(container.textContent).toContain('Item 1');
-			expect(container.textContent).toContain('Item 2');
-			expect(container.textContent).toContain('Item 3');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Item 1');
+				expect(container.textContent).toContain('Item 2');
+				expect(container.textContent).toContain('Item 3');
+			});
 		});
 
-		it('should render ordered lists', () => {
+		it('should render ordered lists', async () => {
 			const { container } = render(<MarkdownRenderer content="1. First\n2. Second\n3. Third" />);
-			expect(container.textContent).toContain('First');
-			expect(container.textContent).toContain('Second');
-			expect(container.textContent).toContain('Third');
+			await waitFor(() => {
+				expect(container.textContent).toContain('First');
+				expect(container.textContent).toContain('Second');
+				expect(container.textContent).toContain('Third');
+			});
 		});
 
-		it('should render blockquotes', () => {
+		it('should render blockquotes', async () => {
 			const { container } = render(<MarkdownRenderer content="> This is a quote" />);
-			expect(container.textContent).toContain('This is a quote');
+			await waitFor(() => {
+				expect(container.textContent).toContain('This is a quote');
+			});
 		});
 
-		it('should render paragraphs', () => {
+		it('should render paragraphs', async () => {
 			const { container } = render(<MarkdownRenderer content="Hello World" />);
-			expect(container.textContent).toContain('Hello World');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Hello World');
+			});
 		});
 	});
 
 	describe('Code Blocks', () => {
-		it('should render code blocks', () => {
+		it('should render code blocks', async () => {
 			const { container } = render(<MarkdownRenderer content="```\nconst x = 1;\n```" />);
-			expect(container.textContent).toContain('const x = 1');
+			await waitFor(() => {
+				expect(container.textContent).toContain('const x = 1');
+			});
 		});
 
-		it('should render code blocks with language', () => {
+		it('should render code blocks with language', async () => {
 			const { container } = render(<MarkdownRenderer content="```javascript\nconst x = 1;\n```" />);
-			expect(container.textContent).toContain('const x = 1');
+			await waitFor(() => {
+				expect(container.textContent).toContain('const x = 1');
+			});
 		});
 	});
 
 	describe('Tables', () => {
-		it('should render tables', () => {
+		it('should render tables', async () => {
 			const tableContent = `| Header 1 | Header 2 |
 |----------|----------|
 | Cell 1   | Cell 2   |`;
 
 			const { container } = render(<MarkdownRenderer content={tableContent} />);
-			expect(container.textContent).toContain('Header 1');
-			expect(container.textContent).toContain('Cell 1');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Header 1');
+				expect(container.textContent).toContain('Cell 1');
+			});
 		});
 
-		it('should wrap tables for scrolling', () => {
+		it('should wrap tables for scrolling', async () => {
 			const tableContent = `| Header 1 | Header 2 |
 |----------|----------|
 | Cell 1   | Cell 2   |`;
 
 			const { container } = render(<MarkdownRenderer content={tableContent} />);
-			expect(container.textContent).toContain('Header 1');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Header 1');
+			});
 		});
 	});
 
 	describe('Paragraph Margins', () => {
-		it('should remove top margin from first paragraph', () => {
+		it('should remove top margin from first paragraph', async () => {
 			const { container } = render(<MarkdownRenderer content="Hello World" />);
-			const paragraphs = container.querySelectorAll('p');
-			expect(paragraphs.length).toBeGreaterThan(0);
-			const firstP = paragraphs[0] as HTMLElement;
-			// Style values may include 'px' suffix
-			expect(firstP.style.marginTop).toMatch(/^0(px)?$/);
+			await waitFor(() => {
+				const paragraphs = container.querySelectorAll('p');
+				expect(paragraphs.length).toBeGreaterThan(0);
+				const firstP = paragraphs[0] as HTMLElement;
+				// Style values may include 'px' suffix
+				expect(firstP.style.marginTop).toMatch(/^0(px)?$/);
+			});
 		});
 
-		it('should remove bottom margin from last paragraph', () => {
+		it('should remove bottom margin from last paragraph', async () => {
 			const { container } = render(<MarkdownRenderer content="Hello World" />);
-			const paragraphs = container.querySelectorAll('p');
-			expect(paragraphs.length).toBeGreaterThan(0);
-			const lastP = paragraphs[paragraphs.length - 1] as HTMLElement;
-			// Style values may include 'px' suffix
-			expect(lastP.style.marginBottom).toMatch(/^0(px)?$/);
+			await waitFor(() => {
+				const paragraphs = container.querySelectorAll('p');
+				expect(paragraphs.length).toBeGreaterThan(0);
+				const lastP = paragraphs[paragraphs.length - 1] as HTMLElement;
+				// Style values may include 'px' suffix
+				expect(lastP.style.marginBottom).toMatch(/^0(px)?$/);
+			});
 		});
 	});
 
 	describe('GFM Support', () => {
-		it('should support line breaks', () => {
+		it('should support line breaks', async () => {
 			const { container } = render(<MarkdownRenderer content="Line 1\nLine 2" />);
-			const content = container.innerHTML;
-			expect(content).toContain('Line 1');
-			expect(content).toContain('Line 2');
+			await waitFor(() => {
+				const content = container.innerHTML;
+				expect(content).toContain('Line 1');
+				expect(content).toContain('Line 2');
+			});
 		});
 
-		it('should support strikethrough', () => {
+		it('should support strikethrough', async () => {
 			const { container } = render(<MarkdownRenderer content="~~deleted~~" />);
-			expect(container.textContent).toContain('deleted');
+			await waitFor(() => {
+				expect(container.textContent).toContain('deleted');
+			});
 		});
 	});
 
@@ -164,21 +200,27 @@ describe('MarkdownRenderer', () => {
 			expect(div).toBeTruthy();
 		});
 
-		it('should handle very long content', () => {
+		it('should handle very long content', async () => {
 			const longContent = 'x'.repeat(10000);
 			const { container } = render(<MarkdownRenderer content={longContent} />);
-			expect(container.textContent?.length).toBeGreaterThan(1000);
+			await waitFor(() => {
+				expect(container.textContent?.length).toBeGreaterThan(1000);
+			});
 		});
 
-		it('should handle special characters', () => {
+		it('should handle special characters', async () => {
 			const { container } = render(<MarkdownRenderer content={'Special: <>&"\''} />);
-			expect(container.textContent).toContain('Special');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Special');
+			});
 		});
 
-		it('should handle content with newlines', () => {
+		it('should handle content with newlines', async () => {
 			const { container } = render(<MarkdownRenderer content="Line 1\n\nLine 2" />);
-			expect(container.textContent).toContain('Line 1');
-			expect(container.textContent).toContain('Line 2');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Line 1');
+				expect(container.textContent).toContain('Line 2');
+			});
 		});
 	});
 });

--- a/packages/web/src/components/sdk/__tests__/SDKAssistantMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKAssistantMessage.test.tsx
@@ -6,7 +6,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-import { render, cleanup, fireEvent } from '@testing-library/preact';
+import { render, cleanup, fireEvent, waitFor } from '@testing-library/preact';
 import { SDKAssistantMessage } from '../SDKAssistantMessage';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import type { UUID } from 'crypto';
@@ -242,19 +242,23 @@ describe('SDKAssistantMessage', () => {
 	});
 
 	describe('Text Content', () => {
-		it('should render text content', () => {
+		it('should render text content', async () => {
 			const message = createTextOnlyMessage('Hello world');
 			const { container } = render(<SDKAssistantMessage message={message} />);
 
-			expect(container.textContent).toContain('Hello world');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Hello world');
+			});
 		});
 
-		it('should render multiple text blocks', () => {
+		it('should render multiple text blocks', async () => {
 			const message = createMixedContentMessage();
 			const { container } = render(<SDKAssistantMessage message={message} />);
 
-			expect(container.textContent).toContain('I will read the file');
-			expect(container.textContent).toContain('The file has been read');
+			await waitFor(() => {
+				expect(container.textContent).toContain('I will read the file');
+				expect(container.textContent).toContain('The file has been read');
+			});
 		});
 
 		it('should show timestamp', () => {
@@ -1056,7 +1060,7 @@ describe('SDKAssistantMessage', () => {
 			expect(onMessageCheckboxChange).toHaveBeenCalledWith(message.uuid, true);
 		});
 
-		it('should render tool use blocks in rewind mode', () => {
+		it('should render tool use blocks in rewind mode', async () => {
 			const message = createMixedContentMessage();
 			const selectedMessages = new Set<string>();
 
@@ -1072,7 +1076,9 @@ describe('SDKAssistantMessage', () => {
 			// Should render the tool use block
 			expect(container.textContent).toContain('Read');
 			// Should also render text
-			expect(container.textContent).toContain('I will read the file');
+			await waitFor(() => {
+				expect(container.textContent).toContain('I will read the file');
+			});
 		});
 
 		it('should render thinking blocks in rewind mode', () => {

--- a/packages/web/src/components/sdk/__tests__/SDKMessageRenderer.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKMessageRenderer.test.tsx
@@ -6,7 +6,7 @@
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-import { render, fireEvent } from '@testing-library/preact';
+import { render, fireEvent, waitFor } from '@testing-library/preact';
 import { SDKMessageRenderer } from '../SDKMessageRenderer';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import type { UUID } from 'crypto';
@@ -241,12 +241,14 @@ describe('SDKMessageRenderer', () => {
 			expect(container.textContent).toContain('Authenticating');
 		});
 
-		it('should render user replay message (slash command response)', () => {
+		it('should render user replay message (slash command response)', async () => {
 			const message = createUserReplayMessage();
 			const { container } = render(<SDKMessageRenderer message={message} />);
 
 			// SlashCommandOutput should handle this
-			expect(container.textContent).toContain('Command output');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Command output');
+			});
 		});
 	});
 

--- a/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKUserMessage.test.tsx
@@ -6,7 +6,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/preact';
 import { SDKUserMessage } from '../SDKUserMessage';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import type { UUID } from 'crypto';
@@ -323,13 +323,15 @@ describe('SDKUserMessage', () => {
 	});
 
 	describe('Replay Messages (Slash Commands)', () => {
-		it('should render command output with SlashCommandOutput', () => {
+		it('should render command output with SlashCommandOutput', async () => {
 			const message = createReplayMessage(
 				'<local-command-stdout>Command executed successfully</local-command-stdout>'
 			);
 			const { container } = render(<SDKUserMessage message={message} isReplay={true} />);
 
-			expect(container.textContent).toContain('Command executed successfully');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Command executed successfully');
+			});
 		});
 
 		it('should hide "Compacted" output (shown in CompactBoundaryMessage)', () => {

--- a/packages/web/src/components/sdk/__tests__/SlashCommandOutput.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SlashCommandOutput.test.tsx
@@ -6,16 +6,18 @@
  */
 import { describe, it, expect } from 'vitest';
 
-import { render } from '@testing-library/preact';
+import { render, waitFor } from '@testing-library/preact';
 import { SlashCommandOutput, isHiddenCommandOutput } from '../SlashCommandOutput';
 
 describe('SlashCommandOutput', () => {
 	describe('Basic Rendering', () => {
-		it('should render command output content', () => {
+		it('should render command output content', async () => {
 			const content = '<local-command-stdout>Command executed successfully</local-command-stdout>';
 			const { container } = render(<SlashCommandOutput content={content} />);
 
-			expect(container.textContent).toContain('Command executed successfully');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Command executed successfully');
+			});
 		});
 
 		it('should show "Command Output" header', () => {
@@ -35,30 +37,36 @@ describe('SlashCommandOutput', () => {
 	});
 
 	describe('Parsing', () => {
-		it('should extract content from local-command-stdout tags', () => {
+		it('should extract content from local-command-stdout tags', async () => {
 			const content = '<local-command-stdout>Extracted content here</local-command-stdout>';
 			const { container } = render(<SlashCommandOutput content={content} />);
 
-			expect(container.textContent).toContain('Extracted content here');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Extracted content here');
+			});
 		});
 
-		it('should handle multiline content', () => {
+		it('should handle multiline content', async () => {
 			const content = `<local-command-stdout>Line 1
 Line 2
 Line 3</local-command-stdout>`;
 			const { container } = render(<SlashCommandOutput content={content} />);
 
-			expect(container.textContent).toContain('Line 1');
-			expect(container.textContent).toContain('Line 2');
-			expect(container.textContent).toContain('Line 3');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Line 1');
+				expect(container.textContent).toContain('Line 2');
+				expect(container.textContent).toContain('Line 3');
+			});
 		});
 
-		it('should trim whitespace from extracted content', () => {
+		it('should trim whitespace from extracted content', async () => {
 			const content = '<local-command-stdout>  Trimmed content  </local-command-stdout>';
 			const { container } = render(<SlashCommandOutput content={content} />);
 
 			// Content should be trimmed
-			expect(container.textContent).toContain('Trimmed content');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Trimmed content');
+			});
 		});
 
 		it('should return null for content without stdout tags', () => {
@@ -75,12 +83,14 @@ Line 3</local-command-stdout>`;
 			expect(container.innerHTML).toBe('');
 		});
 
-		it('should handle content with both stdout and surrounding text', () => {
+		it('should handle content with both stdout and surrounding text', async () => {
 			const content = 'Before <local-command-stdout>Output</local-command-stdout> After';
 			const { container } = render(<SlashCommandOutput content={content} />);
 
 			// Should extract only the stdout content
-			expect(container.textContent).toContain('Output');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Output');
+			});
 		});
 	});
 
@@ -92,11 +102,13 @@ Line 3</local-command-stdout>`;
 			expect(container.innerHTML).toBe('');
 		});
 
-		it('should render other outputs normally', () => {
+		it('should render other outputs normally', async () => {
 			const content = '<local-command-stdout>Not hidden</local-command-stdout>';
 			const { container } = render(<SlashCommandOutput content={content} />);
 
-			expect(container.textContent).toContain('Not hidden');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Not hidden');
+			});
 		});
 	});
 
@@ -155,30 +167,36 @@ Line 3</local-command-stdout>`;
 	});
 
 	describe('Markdown Rendering', () => {
-		it('should render markdown content', () => {
+		it('should render markdown content', async () => {
 			const content =
 				'<local-command-stdout># Heading\n\nSome **bold** text.</local-command-stdout>';
 			const { container } = render(<SlashCommandOutput content={content} />);
 
 			// MarkdownRenderer should process the content
-			expect(container.textContent).toContain('Heading');
-			expect(container.textContent).toContain('bold');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Heading');
+				expect(container.textContent).toContain('bold');
+			});
 		});
 
-		it('should render code blocks in output', () => {
+		it('should render code blocks in output', async () => {
 			const content = '<local-command-stdout>```\ncode here\n```</local-command-stdout>';
 			const { container } = render(<SlashCommandOutput content={content} />);
 
-			expect(container.textContent).toContain('code here');
+			await waitFor(() => {
+				expect(container.textContent).toContain('code here');
+			});
 		});
 
-		it('should render lists', () => {
+		it('should render lists', async () => {
 			const content = '<local-command-stdout>- Item 1\n- Item 2\n- Item 3</local-command-stdout>';
 			const { container } = render(<SlashCommandOutput content={content} />);
 
-			expect(container.textContent).toContain('Item 1');
-			expect(container.textContent).toContain('Item 2');
-			expect(container.textContent).toContain('Item 3');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Item 1');
+				expect(container.textContent).toContain('Item 2');
+				expect(container.textContent).toContain('Item 3');
+			});
 		});
 	});
 
@@ -239,57 +257,69 @@ Line 3</local-command-stdout>`;
 			expect(container.innerHTML).not.toContain('undefined');
 		});
 
-		it('should handle special characters in output', () => {
+		it('should handle special characters in output', async () => {
 			const content =
 				'<local-command-stdout>Special chars: <>&"\' and unicode</local-command-stdout>';
 			const { container } = render(<SlashCommandOutput content={content} />);
 
-			expect(container.textContent).toContain('Special chars');
-			expect(container.textContent).toContain('<>&');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Special chars');
+				expect(container.textContent).toContain('<>&');
+			});
 		});
 
-		it('should handle very long output', () => {
+		it('should handle very long output', async () => {
 			const longOutput = 'x'.repeat(10000);
 			const content = `<local-command-stdout>${longOutput}</local-command-stdout>`;
 			const { container } = render(<SlashCommandOutput content={content} />);
 
 			// Should render without error
-			expect(container.textContent).toContain('x');
+			await waitFor(() => {
+				expect(container.textContent).toContain('x');
+			});
 		});
 
-		it('should handle output with nested angle brackets', () => {
+		it('should handle output with nested angle brackets', async () => {
 			const content = '<local-command-stdout>Result: {count: 5}</local-command-stdout>';
 			const { container } = render(<SlashCommandOutput content={content} />);
 
-			expect(container.textContent).toContain('Result');
-			expect(container.textContent).toContain('count');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Result');
+				expect(container.textContent).toContain('count');
+			});
 		});
 	});
 
 	describe('Command Types', () => {
-		it('should render /help command output', () => {
+		it('should render /help command output', async () => {
 			const content =
 				'<local-command-stdout>Available commands:\n- /help\n- /clear\n- /compact</local-command-stdout>';
 			const { container } = render(<SlashCommandOutput content={content} />);
 
-			expect(container.textContent).toContain('Available commands');
-			expect(container.textContent).toContain('/help');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Available commands');
+				expect(container.textContent).toContain('/help');
+			});
 		});
 
-		it('should render /context command output', () => {
+		it('should render /context command output', async () => {
 			const content = '<local-command-stdout>Context: 50,000 tokens used</local-command-stdout>';
 			const { container } = render(<SlashCommandOutput content={content} />);
 
-			expect(container.textContent).toContain('Context');
-			expect(container.textContent).toContain('50,000 tokens');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Context');
+				expect(container.textContent).toContain('50,000 tokens');
+			});
 		});
 
-		it('should render /cost command output', () => {
+		it('should render /cost command output', async () => {
 			const content = '<local-command-stdout>Total cost: $0.0125</local-command-stdout>';
 			const { container } = render(<SlashCommandOutput content={content} />);
 
-			expect(container.textContent).toContain('Total cost');
-			expect(container.textContent).toContain('$0.0125');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Total cost');
+				expect(container.textContent).toContain('$0.0125');
+			});
 		});
 	});
 });

--- a/packages/web/src/components/sdk/__tests__/SubagentBlock.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SubagentBlock.test.tsx
@@ -6,7 +6,7 @@
  */
 import { describe, it, expect } from 'vitest';
 
-import { render, fireEvent } from '@testing-library/preact';
+import { render, fireEvent, waitFor } from '@testing-library/preact';
 import { SubagentBlock } from '../SubagentBlock';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import type { AgentInput } from '@neokai/shared/sdk/sdk-tools.d.ts';
@@ -252,7 +252,7 @@ describe('SubagentBlock', () => {
 			expect(container.textContent).toContain('Search for test files');
 		});
 
-		it('should show output section when expanded', () => {
+		it('should show output section when expanded', async () => {
 			const input = createAgentInput('Explore', 'Find files', 'Search for test files');
 			const output = 'Found 5 test files in the project.';
 			const { container } = render(
@@ -263,7 +263,9 @@ describe('SubagentBlock', () => {
 			fireEvent.click(button);
 
 			expect(container.textContent).toContain('Output');
-			expect(container.textContent).toContain('Found 5 test files');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Found 5 test files');
+			});
 		});
 
 		it('should show "No output yet..." when output is empty', () => {
@@ -308,7 +310,7 @@ describe('SubagentBlock', () => {
 			expect(container.textContent).toContain('Messages (1)');
 		});
 
-		it('should render nested assistant messages', () => {
+		it('should render nested assistant messages', async () => {
 			const input = createAgentInput('Explore', 'Find files', 'Search for test files');
 			const nestedMessages = [createNestedAssistantMessage('I found 3 test files.')];
 
@@ -319,7 +321,9 @@ describe('SubagentBlock', () => {
 			const button = container.querySelector('button')!;
 			fireEvent.click(button);
 
-			expect(container.textContent).toContain('I found 3 test files');
+			await waitFor(() => {
+				expect(container.textContent).toContain('I found 3 test files');
+			});
 		});
 
 		it('should render nested user messages', () => {
@@ -376,7 +380,7 @@ describe('SubagentBlock', () => {
 	});
 
 	describe('Output Extraction', () => {
-		it('should extract text from string output', () => {
+		it('should extract text from string output', async () => {
 			const input = createAgentInput('Explore', 'Find files', 'Search for test files');
 			const output = 'Simple text output';
 
@@ -387,10 +391,12 @@ describe('SubagentBlock', () => {
 			const button = container.querySelector('button')!;
 			fireEvent.click(button);
 
-			expect(container.textContent).toContain('Simple text output');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Simple text output');
+			});
 		});
 
-		it('should extract text from object output with content field', () => {
+		it('should extract text from object output with content field', async () => {
 			const input = createAgentInput('Explore', 'Find files', 'Search for test files');
 			const output = { content: 'Content from object' };
 
@@ -401,10 +407,12 @@ describe('SubagentBlock', () => {
 			const button = container.querySelector('button')!;
 			fireEvent.click(button);
 
-			expect(container.textContent).toContain('Content from object');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Content from object');
+			});
 		});
 
-		it('should extract text from object output with text field', () => {
+		it('should extract text from object output with text field', async () => {
 			const input = createAgentInput('Explore', 'Find files', 'Search for test files');
 			const output = { text: 'Text from object' };
 
@@ -415,10 +423,12 @@ describe('SubagentBlock', () => {
 			const button = container.querySelector('button')!;
 			fireEvent.click(button);
 
-			expect(container.textContent).toContain('Text from object');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Text from object');
+			});
 		});
 
-		it('should render markdown in output', () => {
+		it('should render markdown in output', async () => {
 			const input = createAgentInput('Explore', 'Find files', 'Search for test files');
 			const output = '# Heading\n\nSome **bold** text.';
 
@@ -430,8 +440,10 @@ describe('SubagentBlock', () => {
 			fireEvent.click(button);
 
 			// MarkdownRenderer should process the content
-			expect(container.textContent).toContain('Heading');
-			expect(container.textContent).toContain('bold');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Heading');
+				expect(container.textContent).toContain('bold');
+			});
 		});
 	});
 
@@ -518,7 +530,7 @@ describe('SubagentBlock', () => {
 	});
 
 	describe('Output Extraction Advanced', () => {
-		it('should extract text from content array with text blocks', () => {
+		it('should extract text from content array with text blocks', async () => {
 			const input = createAgentInput('Explore', 'Find files', 'Search for test files');
 			const output = {
 				content: [
@@ -534,11 +546,13 @@ describe('SubagentBlock', () => {
 			const button = container.querySelector('button')!;
 			fireEvent.click(button);
 
-			expect(container.textContent).toContain('First block');
-			expect(container.textContent).toContain('Second block');
+			await waitFor(() => {
+				expect(container.textContent).toContain('First block');
+				expect(container.textContent).toContain('Second block');
+			});
 		});
 
-		it('should extract text from content array with content field in blocks', () => {
+		it('should extract text from content array with content field in blocks', async () => {
 			const input = createAgentInput('Explore', 'Find files', 'Search for test files');
 			const output = {
 				content: [{ type: 'document', content: 'Document content here' }],
@@ -551,10 +565,12 @@ describe('SubagentBlock', () => {
 			const button = container.querySelector('button')!;
 			fireEvent.click(button);
 
-			expect(container.textContent).toContain('Document content here');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Document content here');
+			});
 		});
 
-		it('should extract text from content array with string items', () => {
+		it('should extract text from content array with string items', async () => {
 			const input = createAgentInput('Explore', 'Find files', 'Search for test files');
 			const output = {
 				content: ['String item 1', 'String item 2'],
@@ -567,11 +583,13 @@ describe('SubagentBlock', () => {
 			const button = container.querySelector('button')!;
 			fireEvent.click(button);
 
-			expect(container.textContent).toContain('String item 1');
-			expect(container.textContent).toContain('String item 2');
+			await waitFor(() => {
+				expect(container.textContent).toContain('String item 1');
+				expect(container.textContent).toContain('String item 2');
+			});
 		});
 
-		it('should extract text from result field', () => {
+		it('should extract text from result field', async () => {
 			const input = createAgentInput('Explore', 'Find files', 'Search for test files');
 			const output = { result: 'Result text here' };
 
@@ -582,10 +600,12 @@ describe('SubagentBlock', () => {
 			const button = container.querySelector('button')!;
 			fireEvent.click(button);
 
-			expect(container.textContent).toContain('Result text here');
+			await waitFor(() => {
+				expect(container.textContent).toContain('Result text here');
+			});
 		});
 
-		it('should fallback to JSON stringify for unknown object structure', () => {
+		it('should fallback to JSON stringify for unknown object structure', async () => {
 			const input = createAgentInput('Explore', 'Find files', 'Search for test files');
 			const output = { unknown_field: 'value', another: 123 };
 
@@ -596,11 +616,13 @@ describe('SubagentBlock', () => {
 			const button = container.querySelector('button')!;
 			fireEvent.click(button);
 
-			expect(container.textContent).toContain('unknown_field');
-			expect(container.textContent).toContain('value');
+			await waitFor(() => {
+				expect(container.textContent).toContain('unknown_field');
+				expect(container.textContent).toContain('value');
+			});
 		});
 
-		it('should convert non-object non-string to string', () => {
+		it('should convert non-object non-string to string', async () => {
 			const input = createAgentInput('Explore', 'Find files', 'Search for test files');
 			const output = 12345;
 
@@ -611,7 +633,9 @@ describe('SubagentBlock', () => {
 			const button = container.querySelector('button')!;
 			fireEvent.click(button);
 
-			expect(container.textContent).toContain('12345');
+			await waitFor(() => {
+				expect(container.textContent).toContain('12345');
+			});
 		});
 	});
 

--- a/packages/web/src/components/sdk/tools/CodeViewer.tsx
+++ b/packages/web/src/components/sdk/tools/CodeViewer.tsx
@@ -6,8 +6,17 @@
  */
 
 import { useEffect, useRef } from 'preact/hooks';
-import hljs from 'highlight.js';
 import { cn } from '../../../lib/utils.ts';
+
+// Lazy-loaded highlight.js — cached after first import
+let hljsModule: typeof import('highlight.js') | null = null;
+
+async function getHljs() {
+	if (!hljsModule) {
+		hljsModule = await import('highlight.js');
+	}
+	return hljsModule.default;
+}
 
 export interface CodeViewerProps {
 	/** The code content to display */
@@ -79,9 +88,15 @@ export function CodeViewer({
 	const detectedLanguage = language || (filePath ? detectLanguageFromPath(filePath) : undefined);
 
 	useEffect(() => {
-		if (codeRef.current) {
+		if (!codeRef.current) return;
+		const el = codeRef.current;
+		let cancelled = false;
+
+		getHljs().then((hljs) => {
+			if (cancelled || !el) return;
+
 			// Clear previous highlighting
-			codeRef.current.removeAttribute('data-highlighted');
+			el.removeAttribute('data-highlighted');
 
 			// Apply syntax highlighting
 			let highlightedCode: string;
@@ -110,11 +125,15 @@ export function CodeViewer({
 						return `<div class="code-line"><span class="code-line-content">${line || ' '}</span></div>`;
 					})
 					.join('');
-				codeRef.current.innerHTML = `<div class="code-with-lines">${wrappedLines}</div>`;
+				el.innerHTML = `<div class="code-with-lines">${wrappedLines}</div>`;
 			} else {
-				codeRef.current.innerHTML = highlightedCode;
+				el.innerHTML = highlightedCode;
 			}
-		}
+		});
+
+		return () => {
+			cancelled = true;
+		};
 	}, [code, detectedLanguage, showLineNumbers]);
 
 	const lines = code.split('\n');

--- a/packages/web/src/components/space/SpaceConfigurePage.tsx
+++ b/packages/web/src/components/space/SpaceConfigurePage.tsx
@@ -1,12 +1,30 @@
 import { useEffect, useState } from 'preact/hooks';
+import { lazy, Suspense } from 'preact/compat';
 import type { Space } from '@neokai/shared';
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@neokai/ui';
 import { spaceStore } from '../../lib/space-store';
 import { cn } from '../../lib/utils';
-import { SpaceAgentList } from './SpaceAgentList';
-import { SpaceSettings } from './SpaceSettings';
-import { WorkflowList } from './WorkflowList';
-import { VisualWorkflowEditor } from './visual-editor/VisualWorkflowEditor';
+
+const SpaceAgentList = lazy(() =>
+	import('./SpaceAgentList').then((m) => ({ default: m.SpaceAgentList }))
+);
+const SpaceSettings = lazy(() =>
+	import('./SpaceSettings').then((m) => ({ default: m.SpaceSettings }))
+);
+const WorkflowList = lazy(() =>
+	import('./WorkflowList').then((m) => ({ default: m.WorkflowList }))
+);
+const VisualWorkflowEditor = lazy(() =>
+	import('./visual-editor/VisualWorkflowEditor').then((m) => ({
+		default: m.VisualWorkflowEditor,
+	}))
+);
+
+const lazyFallback = (
+	<div class="flex-1 flex items-center justify-center py-12">
+		<div class="w-5 h-5 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+	</div>
+);
 
 type ConfigureTab = 'agents' | 'workflows' | 'settings';
 
@@ -92,36 +110,44 @@ export function SpaceConfigurePage({ space }: SpaceConfigurePageProps) {
 
 						<TabPanels class="min-h-0 flex-1 overflow-hidden rounded-3xl border border-dark-700 bg-dark-950/70 lg:rounded-[28px]">
 							<TabPanel>
-								<div class="h-full min-h-[calc(100%+1px)] overflow-y-auto p-4 sm:p-5 lg:p-6">
-									<SpaceAgentList />
-								</div>
+								<Suspense fallback={lazyFallback}>
+									<div class="h-full min-h-[calc(100%+1px)] overflow-y-auto p-4 sm:p-5 lg:p-6">
+										<SpaceAgentList />
+									</div>
+								</Suspense>
 							</TabPanel>
 							<TabPanel>
-								<WorkflowList
-									spaceId={space.id}
-									spaceName={space.name}
-									workflows={workflows}
-									onCreateWorkflow={() => setWorkflowEditId('new')}
-									onEditWorkflow={(id) => setWorkflowEditId(id)}
-								/>
+								<Suspense fallback={lazyFallback}>
+									<WorkflowList
+										spaceId={space.id}
+										spaceName={space.name}
+										workflows={workflows}
+										onCreateWorkflow={() => setWorkflowEditId('new')}
+										onEditWorkflow={(id) => setWorkflowEditId(id)}
+									/>
+								</Suspense>
 							</TabPanel>
 							<TabPanel>
-								<SpaceSettings space={space} />
+								<Suspense fallback={lazyFallback}>
+									<SpaceSettings space={space} />
+								</Suspense>
 							</TabPanel>
 						</TabPanels>
 					</TabGroup>
 				)}
 
 				{showWorkflowEditor && (
-					<div class="min-h-0 flex-1 overflow-hidden rounded-3xl border border-dark-700 bg-dark-950/70 lg:rounded-[28px]">
-						<VisualWorkflowEditor
-							key={workflowEditId}
-							workflow={editingWorkflow}
-							// Keep editor open after save; exit is explicit via Back/Cancel.
-							onSave={() => undefined}
-							onCancel={() => setWorkflowEditId(null)}
-						/>
-					</div>
+					<Suspense fallback={lazyFallback}>
+						<div class="min-h-0 flex-1 overflow-hidden rounded-3xl border border-dark-700 bg-dark-950/70 lg:rounded-[28px]">
+							<VisualWorkflowEditor
+								key={workflowEditId}
+								workflow={editingWorkflow}
+								// Keep editor open after save; exit is explicit via Back/Cancel.
+								onSave={() => undefined}
+								onCancel={() => setWorkflowEditId(null)}
+							/>
+						</div>
+					</Suspense>
 				)}
 			</div>
 		</div>

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -11,17 +11,34 @@
  */
 
 import { useCallback, useEffect } from 'preact/hooks';
+import { lazy, Suspense } from 'preact/compat';
 import type { SpaceViewMode } from '../lib/signals';
 import { spaceOverlaySessionIdSignal, spaceOverlayAgentNameSignal } from '../lib/signals';
-import { SpaceConfigurePage } from '../components/space/SpaceConfigurePage';
-import { SpaceTasks } from '../components/space/SpaceTasks';
-import { SpaceOverview } from '../components/space/SpaceOverview';
-import { SpaceTaskPane } from '../components/space/SpaceTaskPane';
 import { SpacePageHeader } from '../components/space/SpacePageHeader';
 import { AgentOverlayChat } from '../components/space/AgentOverlayChat';
 import { spaceStore } from '../lib/space-store';
 import { navigateToSpace, navigateToSpaceTask } from '../lib/router';
 import ChatContainer from './ChatContainer';
+
+const SpaceConfigurePage = lazy(() =>
+	import('../components/space/SpaceConfigurePage').then((m) => ({ default: m.SpaceConfigurePage }))
+);
+const SpaceTasks = lazy(() =>
+	import('../components/space/SpaceTasks').then((m) => ({ default: m.SpaceTasks }))
+);
+const SpaceOverview = lazy(() =>
+	import('../components/space/SpaceOverview').then((m) => ({ default: m.SpaceOverview }))
+);
+const SpaceTaskPane = lazy(() =>
+	import('../components/space/SpaceTaskPane').then((m) => ({ default: m.SpaceTaskPane }))
+);
+
+/** Shared Suspense fallback for lazy-loaded space views. */
+const lazyFallback = (
+	<div class="flex-1 flex items-center justify-center bg-dark-900">
+		<div class="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+	</div>
+);
 
 interface SpaceIslandProps {
 	spaceId: string;
@@ -101,7 +118,9 @@ export default function SpaceIsland({
 		return (
 			<>
 				<div class="flex-1 flex flex-col overflow-hidden bg-dark-900" data-testid="space-task-pane">
-					<SpaceTaskPane taskId={taskViewId} spaceId={spaceId} onClose={handleTaskPaneClose} />
+					<Suspense fallback={lazyFallback}>
+						<SpaceTaskPane taskId={taskViewId} spaceId={spaceId} onClose={handleTaskPaneClose} />
+					</Suspense>
 				</div>
 				{overlaySessionId && (
 					<AgentOverlayChat
@@ -123,10 +142,12 @@ export default function SpaceIsland({
 				>
 					<SpacePageHeader spaceName={space.name} pageTitle="Tasks" />
 					<div class="flex-1 min-w-0 overflow-hidden flex flex-col">
-						<SpaceTasks
-							spaceId={spaceId}
-							onSelectTask={(taskId) => navigateToSpaceTask(spaceId, taskId)}
-						/>
+						<Suspense fallback={lazyFallback}>
+							<SpaceTasks
+								spaceId={spaceId}
+								onSelectTask={(taskId) => navigateToSpaceTask(spaceId, taskId)}
+							/>
+						</Suspense>
 					</div>
 				</div>
 				{overlaySessionId && (
@@ -149,7 +170,9 @@ export default function SpaceIsland({
 				>
 					<SpacePageHeader spaceName={space.name} pageTitle="Settings" />
 					<div class="flex-1 min-w-0 overflow-hidden flex flex-col">
-						<SpaceConfigurePage space={space} />
+						<Suspense fallback={lazyFallback}>
+							<SpaceConfigurePage space={space} />
+						</Suspense>
 					</div>
 				</div>
 				{overlaySessionId && (
@@ -178,10 +201,12 @@ export default function SpaceIsland({
 			>
 				<SpacePageHeader spaceName={space?.name ?? ''} pageTitle="Overview" />
 				<div class="flex-1 overflow-hidden flex flex-col min-w-0">
-					<SpaceOverview
-						spaceId={spaceId}
-						onSelectTask={(taskId) => navigateToSpaceTask(spaceId, taskId)}
-					/>
+					<Suspense fallback={lazyFallback}>
+						<SpaceOverview
+							spaceId={spaceId}
+							onSelectTask={(taskId) => navigateToSpaceTask(spaceId, taskId)}
+						/>
+					</Suspense>
 				</div>
 			</div>
 		</>

--- a/packages/web/src/islands/SpacesPage.tsx
+++ b/packages/web/src/islands/SpacesPage.tsx
@@ -170,7 +170,7 @@ export function SpacesPage() {
 			<div class="flex-1 min-h-0 overflow-y-auto">
 				<div class="max-w-5xl mx-auto px-4 sm:px-6 py-6">
 					{activeSpaces.length === 0 ? (
-						<div class="flex flex-col items-center justify-center py-20 text-center">
+						<div class="flex flex-col items-center justify-center py-20 text-center max-w-md mx-auto">
 							<svg
 								class="w-12 h-12 text-gray-700 mb-4"
 								fill="none"
@@ -184,14 +184,58 @@ export function SpacesPage() {
 									d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
 								/>
 							</svg>
-							<p class="text-sm text-gray-500">No spaces yet</p>
-							<p class="text-xs text-gray-600 mt-1">Create a space to get started</p>
+							<h2 class="text-base font-semibold text-gray-200 mb-2">No spaces yet</h2>
+							<p class="text-sm text-gray-500 leading-relaxed">
+								Spaces are isolated project environments where AI agents collaborate on tasks. Each
+								space maps to a codebase directory with its own sessions, tasks, and workflows.
+							</p>
+							<button
+								type="button"
+								onClick={() => setCreateSpaceOpen(true)}
+								class="mt-6 inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-sm font-medium text-white transition-colors"
+							>
+								<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width={2}
+										d="M12 4v16m8-8H4"
+									/>
+								</svg>
+								Create Your First Space
+							</button>
 						</div>
 					) : (
-						<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-							{activeSpaces.map((space) => (
-								<SpaceCard key={space.id} space={space} />
-							))}
+						<div class="flex flex-col gap-6">
+							<p class="text-sm text-gray-500">
+								Spaces are isolated project environments where AI agents collaborate on tasks. Each
+								space maps to a codebase directory with its own sessions, tasks, and workflows.
+							</p>
+							<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+								{activeSpaces.map((space) => (
+									<SpaceCard key={space.id} space={space} />
+								))}
+								<button
+									type="button"
+									onClick={() => setCreateSpaceOpen(true)}
+									class="w-full rounded-xl border border-dashed border-dark-600 hover:border-dark-500 bg-transparent hover:bg-dark-900/40 transition-all p-5 flex flex-col items-center justify-center gap-2 min-h-[120px]"
+								>
+									<svg
+										class="w-8 h-8 text-gray-600"
+										fill="none"
+										viewBox="0 0 24 24"
+										stroke="currentColor"
+									>
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width={1.5}
+											d="M12 4v16m8-8H4"
+										/>
+									</svg>
+									<span class="text-xs text-gray-500">New Space</span>
+								</button>
+							</div>
 						</div>
 					)}
 				</div>

--- a/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
+++ b/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/preact';
 import { signal } from '@preact/signals';
 import type { SpaceWorkflow, SpaceAgent, Space } from '@neokai/shared';
 
@@ -150,31 +150,36 @@ afterEach(() => {
 });
 
 describe('SpaceIsland — route-driven views', () => {
-	it('renders the overview view without the legacy top tab bar', () => {
+	it('renders the overview view without the legacy top tab bar', async () => {
 		const { getByTestId, queryByTestId } = render(
 			<SpaceIsland spaceId="space-1" viewMode="overview" />
 		);
+		// Wait for lazy SpaceOverview to load through Suspense
+		await waitFor(() => {
+			expect(getByTestId('space-dashboard')).toBeTruthy();
+		});
 		// Outer wrapper
 		expect(getByTestId('space-overview-view')).toBeTruthy();
 		// Legacy tab bar is removed from overview
 		expect(queryByTestId('space-tab-bar')).toBeNull();
-		// SpaceOverview renders directly for overview
-		expect(getByTestId('space-dashboard')).toBeTruthy();
 	});
 
-	it('renders the configure view when requested', () => {
+	it('renders the configure view when requested', async () => {
 		const { getByTestId } = render(<SpaceIsland spaceId="space-1" viewMode="configure" />);
+		// Wait for lazy SpaceConfigurePage to load through Suspense
+		await waitFor(() => {
+			expect(getByTestId('space-agent-list')).toBeTruthy();
+		});
 		expect(getByTestId('space-configure-view')).toBeTruthy();
-		expect(getByTestId('space-agent-list')).toBeTruthy();
 	});
 });
 
 describe('SpaceIsland — overview content', () => {
-	it('renders the task dashboard directly and removes legacy canvas wrappers', () => {
-		const { getByTestId, queryByTestId } = render(
+	it('renders the task dashboard directly and removes legacy canvas wrappers', async () => {
+		const { findByTestId, queryByTestId } = render(
 			<SpaceIsland spaceId="space-1" viewMode="overview" />
 		);
-		expect(getByTestId('space-dashboard')).toBeTruthy();
+		await findByTestId('space-dashboard');
 		expect(queryByTestId('canvas-panel')).toBeNull();
 		expect(queryByTestId('workflow-canvas')).toBeNull();
 		expect(queryByTestId('dashboard-fallback')).toBeNull();
@@ -182,44 +187,65 @@ describe('SpaceIsland — overview content', () => {
 });
 
 describe('SpaceIsland — configure workflow editor', () => {
-	function renderConfigure() {
-		return render(<SpaceIsland spaceId="space-1" viewMode="configure" />);
+	async function renderConfigure() {
+		const result = render(<SpaceIsland spaceId="space-1" viewMode="configure" />);
+		// Wait for lazy SpaceConfigurePage to load through Suspense
+		await waitFor(() => {
+			expect(result.getByTestId('space-configure-tab-bar')).toBeTruthy();
+		});
+		return result;
 	}
 
-	it('renders configure sub-tabs', () => {
-		const { getByTestId } = renderConfigure();
+	it('renders configure sub-tabs', async () => {
+		const { getByTestId } = await renderConfigure();
 		expect(getByTestId('space-configure-tab-bar')).toBeTruthy();
 		expect(getByTestId('space-configure-tab-agents')).toBeTruthy();
 		expect(getByTestId('space-configure-tab-workflows')).toBeTruthy();
 		expect(getByTestId('space-configure-tab-settings')).toBeTruthy();
 	});
 
-	it('opens the visual editor when creating a workflow', () => {
-		const result = renderConfigure();
+	it('opens the visual editor when creating a workflow', async () => {
+		const result = await renderConfigure();
 		fireEvent.click(result.getByTestId('space-configure-tab-workflows'));
+		await waitFor(() => {
+			expect(result.getByTestId('create-workflow-btn')).toBeTruthy();
+		});
 		fireEvent.click(result.getByTestId('create-workflow-btn'));
-		expect(result.getByTestId('visual-workflow-editor')).toBeTruthy();
+		await waitFor(() => {
+			expect(result.getByTestId('visual-workflow-editor')).toBeTruthy();
+		});
 		expect(capturedVisualEditorProps.workflow).toBeUndefined();
 	});
 
-	it('opens the visual editor when editing a workflow', () => {
-		const result = renderConfigure();
+	it('opens the visual editor when editing a workflow', async () => {
+		const result = await renderConfigure();
 		fireEvent.click(result.getByTestId('space-configure-tab-workflows'));
+		await waitFor(() => {
+			expect(result.getByTestId('edit-workflow-btn')).toBeTruthy();
+		});
 		fireEvent.click(result.getByTestId('edit-workflow-btn'));
-		expect(result.getByTestId('visual-workflow-editor')).toBeTruthy();
+		await waitFor(() => {
+			expect(result.getByTestId('visual-workflow-editor')).toBeTruthy();
+		});
 		expect((capturedVisualEditorProps.workflow as SpaceWorkflow)?.id).toBe('wf-existing');
 	});
 
-	it('hides configure sub-tabs while editing a workflow', () => {
-		const result = renderConfigure();
+	it('hides configure sub-tabs while editing a workflow', async () => {
+		const result = await renderConfigure();
 		fireEvent.click(result.getByTestId('space-configure-tab-workflows'));
+		await waitFor(() => {
+			expect(result.getByTestId('create-workflow-btn')).toBeTruthy();
+		});
 		fireEvent.click(result.getByTestId('create-workflow-btn'));
 		expect(result.queryByTestId('space-configure-tab-bar')).toBeNull();
 	});
 
-	it('keeps workflow editor open after save', () => {
-		const result = renderConfigure();
+	it('keeps workflow editor open after save', async () => {
+		const result = await renderConfigure();
 		fireEvent.click(result.getByTestId('space-configure-tab-workflows'));
+		await waitFor(() => {
+			expect(result.getByTestId('create-workflow-btn')).toBeTruthy();
+		});
 		fireEvent.click(result.getByTestId('create-workflow-btn'));
 		fireEvent.click(result.getByTestId('visual-editor-save'));
 		expect(result.getByTestId('visual-workflow-editor')).toBeTruthy();
@@ -228,23 +254,24 @@ describe('SpaceIsland — configure workflow editor', () => {
 });
 
 describe('SpaceIsland — content priority chain', () => {
-	it('renders ChatContainer when sessionViewId is set', () => {
-		const { getByTestId } = render(
+	it('renders ChatContainer when sessionViewId is set', async () => {
+		const { findByTestId } = render(
 			<SpaceIsland spaceId="space-1" viewMode="overview" sessionViewId="session-abc" />
 		);
-		expect(getByTestId('chat-container')).toBeTruthy();
+		await findByTestId('chat-container');
 	});
 
-	it('renders SpaceTaskPane when taskViewId is set', () => {
-		const { getByTestId } = render(
+	it('renders SpaceTaskPane when taskViewId is set', async () => {
+		const { getByTestId, findByTestId } = render(
 			<SpaceIsland spaceId="space-1" viewMode="overview" taskViewId="task-xyz" />
 		);
+		await findByTestId('space-task-pane-inner');
 		expect(getByTestId('space-task-pane')).toBeTruthy();
 		expect(getByTestId('space-task-pane-inner').getAttribute('data-task-id')).toBe('task-xyz');
 	});
 
-	it('sessionViewId takes priority over taskViewId', () => {
-		const { getByTestId, queryByTestId } = render(
+	it('sessionViewId takes priority over taskViewId', async () => {
+		const { findByTestId, queryByTestId } = render(
 			<SpaceIsland
 				spaceId="space-1"
 				viewMode="overview"
@@ -252,7 +279,7 @@ describe('SpaceIsland — content priority chain', () => {
 				taskViewId="task-xyz"
 			/>
 		);
-		expect(getByTestId('chat-container')).toBeTruthy();
+		await findByTestId('chat-container');
 		expect(queryByTestId('space-task-pane')).toBeNull();
 	});
 });

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -17,6 +17,16 @@ export default defineConfig({
 			input: {
 				main: resolve(__dirname, 'src/index.html'),
 			},
+			output: {
+				manualChunks(id) {
+					if (id.includes('node_modules/marked')) {
+						return 'vendor-marked';
+					}
+					if (id.includes('node_modules/highlight.js')) {
+						return 'vendor-hljs';
+					}
+				},
+			},
 		},
 	},
 


### PR DESCRIPTION
## Summary

- Enhance `/spaces` page with description text explaining what spaces are, plus CTA buttons for both empty and has-spaces states
- Lazy-load `marked` and `highlight.js` via dynamic imports in `MarkdownRenderer` and `CodeViewer`, with separate vendor chunks
- Lazy-load space view components in `SpaceIsland` and tab contents in `SpaceConfigurePage`

Bundle size improvements:
| Chunk | Before | After |
|-------|--------|-------|
| SpaceIsland | 318 kB | 6.6 kB |
| useTurnBlocks | 1,082 kB | 127 kB |
| SpaceConfigurePage | 197 kB | 96 kB |

## Test plan
- [ ] Verify `/spaces` page shows description text and CTA in both empty and populated states
- [ ] Verify markdown rendering still works (agent messages with code blocks)
- [ ] Verify space configure page tabs load correctly (agents, workflows, settings)
- [ ] Verify visual workflow editor opens when creating/editing a workflow
- [ ] Run `make build` and confirm no regressions