### PR TITLE
fix(e2e): fix 3 test failures from post-#1472 UI changes

### DIFF
--- a/packages/e2e/tests/features/provider-model-switching.e2e.ts
+++ b/packages/e2e/tests/features/provider-model-switching.e2e.ts
@@ -57,7 +57,17 @@ async function createSessionViaNewSessionButton(page: Page): Promise<string> {
 	// Submit the form — workspace is set inline after session creation.
 	await dialog.getByRole('button', { name: 'Create Session' }).click();
 
-	return waitForSessionCreated(page);
+	const sessionId = await waitForSessionCreated(page);
+
+	// Dismiss the inline WorkspaceSelector if it appears — it overlays the chat
+	// controls (including the Switch Model button) and blocks pointer events.
+	const skipBtn = page.getByRole('button', { name: 'Skip' });
+	if (await skipBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
+		await skipBtn.click();
+		await expect(page.getByText('Select a workspace')).toBeHidden({ timeout: 3000 });
+	}
+
+	return sessionId;
 }
 
 /**

--- a/packages/e2e/tests/features/space-context-panel-switching.e2e.ts
+++ b/packages/e2e/tests/features/space-context-panel-switching.e2e.ts
@@ -58,7 +58,8 @@ test.describe('ContextPanel Space Switching (Level 1 ↔ Level 2)', () => {
 		});
 
 		// SpacesPage header "New Space" button should be visible
-		await expect(page.getByRole('button', { name: 'New Space', exact: true })).toBeVisible({
+		// Use .first() — the page now has two "New Space" buttons (header + dashed card).
+		await expect(page.getByRole('button', { name: 'New Space', exact: true }).first()).toBeVisible({
 			timeout: 5000,
 		});
 
@@ -104,7 +105,7 @@ test.describe('ContextPanel Space Switching (Level 1 ↔ Level 2)', () => {
 		});
 
 		// SpacesPage "New Space" button should be visible
-		await expect(page.getByRole('button', { name: 'New Space', exact: true })).toBeVisible({
+		await expect(page.getByRole('button', { name: 'New Space', exact: true }).first()).toBeVisible({
 			timeout: 5000,
 		});
 

--- a/packages/e2e/tests/features/space-navigation.e2e.ts
+++ b/packages/e2e/tests/features/space-navigation.e2e.ts
@@ -85,7 +85,9 @@ test.describe('Comprehensive Space Navigation', () => {
 		await page.getByRole('button', { name: 'Spaces', exact: true }).click();
 
 		// SpacesPage header: "New Space" button and heading visible
-		await expect(page.getByRole('button', { name: 'New Space', exact: true })).toBeVisible({
+		// Use .first() because the page now renders two "New Space" buttons:
+		// the header button and the dashed empty-state card.
+		await expect(page.getByRole('button', { name: 'New Space', exact: true }).first()).toBeVisible({
 			timeout: 5000,
 		});
 		await expect(page.getByRole('heading', { name: 'Spaces', exact: true })).toBeVisible({
@@ -235,7 +237,7 @@ test.describe('Comprehensive Space Navigation', () => {
 		await page.getByTitle('Back to Spaces').click();
 
 		// Level 1 restored
-		await expect(page.getByRole('button', { name: 'New Space', exact: true })).toBeVisible({
+		await expect(page.getByRole('button', { name: 'New Space', exact: true }).first()).toBeVisible({
 			timeout: 5000,
 		});
 		await expect(page.getByRole('heading', { name: 'Spaces', exact: true })).toBeVisible({


### PR DESCRIPTION
## Summary
- **provider-model-switching**: dismiss inline `WorkspaceSelector` overlay before clicking the Switch Model button — the overlay has `z-20` and intercepts pointer events until dismissed
- **space-navigation** + **space-context-panel-switching**: use `.first()` on the `'New Space'` button — `SpacesPage` now renders two buttons (header + dashed empty-state card) introduced in #1467, causing strict mode violations

All three failures appeared in the CI run after #1477 merged.