### PR TITLE
ci: remove broken Microsoft apt repos before apt-get update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -373,6 +373,7 @@ jobs:
       - name: Install sandbox dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y bubblewrap socat ripgrep
 
@@ -476,6 +477,7 @@ jobs:
       - name: Install sandbox dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y bubblewrap socat ripgrep
 
@@ -535,6 +537,7 @@ jobs:
       - name: Install sandbox dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y bubblewrap socat ripgrep
 
@@ -599,6 +602,7 @@ jobs:
       - name: Install sandbox dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y bubblewrap socat ripgrep
 
@@ -766,6 +770,7 @@ jobs:
       - name: Install sandbox dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y bubblewrap socat ripgrep
 
@@ -927,6 +932,7 @@ jobs:
       - name: Install sandbox dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y bubblewrap socat ripgrep
 
@@ -1066,6 +1072,7 @@ jobs:
       - name: Install sandbox dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y bubblewrap socat ripgrep
 


### PR DESCRIPTION
## Summary
`packages.microsoft.com` is returning 403 on GitHub-hosted runners, causing `apt-get update` to fail across all E2E jobs that install sandbox dependencies (bubblewrap, socat, ripgrep).

Fix: drop the Microsoft apt repo list files before running `apt-get update`. The packages we need are all in standard Ubuntu repos so this has no functional impact.