### PR TITLE
fix(ui): standardize panel header heights and fix mobile Safari bottom gap

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -205,8 +205,8 @@ export function App() {
 				{/* Context Panel - always visible */}
 				<ContextPanel />
 
-				{/* Main Content — bottom padding matches actual BottomTabBar height via --bottom-bar-height */}
-				<div class="flex-1 flex flex-col overflow-hidden min-w-0 pb-bottom-bar">
+				{/* Main Content — BottomTabBar is inline (flex-shrink-0) so no extra padding needed */}
+				<div class="flex-1 flex flex-col overflow-hidden min-w-0">
 					<MainContent />
 				</div>
 			</div>

--- a/packages/web/src/components/ChatHeader.tsx
+++ b/packages/web/src/components/ChatHeader.tsx
@@ -186,7 +186,7 @@ export function ChatHeader({
 
 	return (
 		<div
-			class={`flex-shrink-0 bg-dark-850 border-b ${borderColors.ui.default} px-4 py-3 relative z-10`}
+			class={`flex-shrink-0 bg-dark-850 border-b ${borderColors.ui.default} px-4 h-[65px] flex items-center relative z-10`}
 		>
 			<div class="flex items-center gap-3">
 				<MobileMenuButton />

--- a/packages/web/src/components/space/SpacePageHeader.tsx
+++ b/packages/web/src/components/space/SpacePageHeader.tsx
@@ -1,5 +1,5 @@
 import { borderColors } from '../../lib/design-tokens';
-import { MobileMenuButton } from '../ui/MobileMenuButton';
+import { contextPanelOpenSignal } from '../../lib/signals';
 
 interface SpacePageHeaderProps {
 	spaceName: string;
@@ -9,10 +9,24 @@ interface SpacePageHeaderProps {
 export function SpacePageHeader({ spaceName, pageTitle }: SpacePageHeaderProps) {
 	return (
 		<div
-			class={`flex-shrink-0 bg-dark-850 border-b ${borderColors.ui.default} px-4 py-2.5 relative z-10`}
+			class={`flex-shrink-0 bg-dark-850 border-b ${borderColors.ui.default} px-4 h-[65px] flex items-center relative z-10`}
 		>
 			<div class="flex items-center gap-3">
-				<MobileMenuButton />
+				<button
+					onClick={() => (contextPanelOpenSignal.value = true)}
+					class="md:hidden p-1.5 bg-dark-850 border border-dark-700 rounded-lg hover:bg-dark-800 transition-colors text-gray-400 hover:text-gray-100 flex-shrink-0"
+					title="Open menu"
+					aria-label="Open navigation menu"
+				>
+					<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width={2}
+							d="M4 6h16M4 12h16M4 18h16"
+						/>
+					</svg>
+				</button>
 				<div class="flex-1 min-w-0">
 					<div class="text-xs text-gray-500 truncate">{spaceName}</div>
 					<h2 class="text-sm font-semibold text-gray-100 truncate">{pageTitle}</h2>

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -380,7 +380,7 @@ export function ContextPanel() {
 				</div>
 
 				{/* Header */}
-				<div class={`p-4 border-b ${borderColors.ui.default}`}>
+				<div class={`px-4 h-[65px] flex items-center border-b ${borderColors.ui.default}`}>
 					<div
 						class={cn(
 							'flex items-center justify-between',


### PR DESCRIPTION
## Summary
- Apply fixed `h-[65px]` with flex centering to ContextPanel, SpacePageHeader, and ChatHeader so all panel headers are pixel-perfect aligned across devices
- Replace MobileMenuButton import in SpacePageHeader with inline button matching context panel sizing
- Remove stale `pb-bottom-bar` from App.tsx main content wrapper (leftover from fixed-position BottomTabBar; unnecessary with inline flex layout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)