### PR TITLE
fix(e2e): fix pointer-event intercept and pb-bottom-bar test failures post-#1482

### DIFF
--- a/packages/e2e/tests/features/ipad-safari-layout.e2e.ts
+++ b/packages/e2e/tests/features/ipad-safari-layout.e2e.ts
@@ -88,22 +88,14 @@ test.describe('iPad Mini portrait (744×1133)', () => {
 		await expect(bottomTabBar).toBeVisible();
 	});
 
-	test('main content area has non-zero computed padding-bottom', async ({ page }) => {
-		// Wait for the BottomTabBar's ResizeObserver to fire and update --bottom-bar-height
+	test('main content area is above bottom tab bar (BottomTabBar is inline)', async ({ page }) => {
 		const bottomTabBar = page.getByRole('tablist', { name: 'Main navigation' });
 		await expect(bottomTabBar).toBeVisible();
 
-		const paddingBottom = await page.evaluate(() => {
-			const el = document.querySelector('.pb-bottom-bar');
-			if (!el) return '0px';
-			return getComputedStyle(el).paddingBottom;
-		});
-
-		// The BottomTabBar is rendered at this width, so padding-bottom should be > 0
-		expect(paddingBottom).not.toBe('0px');
-		// Sanity check: padding-bottom should be a reasonable pixel value
-		const px = parseFloat(paddingBottom);
-		expect(px).toBeGreaterThan(0);
+		// BottomTabBar is an inline flex-shrink-0 element, not fixed/absolute.
+		// Content is naturally laid out above it without needing padding-bottom.
+		const position = await bottomTabBar.evaluate((el) => getComputedStyle(el).position);
+		expect(position).toBe('static');
 	});
 });
 
@@ -133,14 +125,12 @@ test.describe('Desktop (1280×800)', () => {
 		await expect(bottomTabBar).not.toBeVisible();
 	});
 
-	test('main content area has 0px computed padding-bottom', async ({ page }) => {
-		const paddingBottom = await page.evaluate(() => {
-			const el = document.querySelector('.pb-bottom-bar');
-			if (!el) return null;
-			return getComputedStyle(el).paddingBottom;
-		});
-
-		expect(paddingBottom).not.toBeNull();
-		expect(paddingBottom).toBe('0px');
+	test('main content area has no bottom padding (BottomTabBar is not present)', async ({
+		page,
+	}) => {
+		// BottomTabBar is hidden via md:hidden at desktop width and the main content
+		// flex container no longer uses a pb-bottom-bar padding element.
+		const hasPbBottomBar = await page.evaluate(() => !!document.querySelector('.pb-bottom-bar'));
+		expect(hasPbBottomBar).toBe(false);
 	});
 });

--- a/packages/web/src/components/space/SpacePageHeader.tsx
+++ b/packages/web/src/components/space/SpacePageHeader.tsx
@@ -11,7 +11,7 @@ export function SpacePageHeader({ spaceName, pageTitle }: SpacePageHeaderProps) 
 		<div
 			class={`flex-shrink-0 bg-dark-850 border-b ${borderColors.ui.default} px-4 h-[65px] flex items-center relative z-10`}
 		>
-			<div class="flex items-center gap-3">
+			<div class="flex-1 flex items-center gap-3">
 				<button
 					onClick={() => (contextPanelOpenSignal.value = true)}
 					class="md:hidden p-1.5 bg-dark-850 border border-dark-700 rounded-lg hover:bg-dark-800 transition-colors text-gray-400 hover:text-gray-100 flex-shrink-0"

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -383,7 +383,7 @@ export function ContextPanel() {
 				<div class={`px-4 h-[65px] flex items-center border-b ${borderColors.ui.default}`}>
 					<div
 						class={cn(
-							'flex items-center justify-between',
+							'flex-1 flex items-center justify-between',
 							!isRoomDetail && !isSpaceDetail && 'mb-3'
 						)}
 					>


### PR DESCRIPTION
Fixes 8 E2E test failures introduced by #1482's header layout refactor.

**Root causes:**

1. **ContextPanel + SpacePageHeader**: Both headers were changed to `h-[65px] flex items-center` but their inner `justify-between` divs lacked `flex-1`. This made them content-sized, leaving space at the right edge — and because `SpacePageHeader` has `relative z-10`, its `h2` rendered on top of the Configure space / task-back buttons at hit-test coordinates. Fix: add `flex-1` to both inner divs.

2. **ipad-safari-layout tests**: Queried `.pb-bottom-bar` which was removed in #1482 (BottomTabBar moved to inline `flex-shrink-0`). Fix: update assertions to match the new layout behavior.

**Affected tests (fixed):**
- `space-gate-script-check`, `space-gate-custom-badges`, `space-agent-centric-workflow`, `space-multi-agent-editor`, `visual-workflow-editor` — Configure space button click timeout
- `space-task-fullwidth`, `space-navigation` — task-back-button click timeout
- `ipad-safari-layout` — pb-bottom-bar element no longer exists