### PR TITLE
feat(space): add Sessions list page and Sessions tab

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -39,6 +39,7 @@ import {
 	navigateToSpace,
 	navigateToSpaceConfigure,
 	navigateToSpaceSessions,
+	navigateToSpaceTasks,
 	navigateToSpaceAgent,
 	navigateToSpaceSession,
 	navigateToSpaceTask,
@@ -51,6 +52,7 @@ import {
 	createSpacePath,
 	createSpaceConfigurePath,
 	createSpaceSessionsPath,
+	createSpaceTasksPath,
 	createSpaceAgentPath,
 	createSpaceSessionPath,
 	createSpaceTaskPath,
@@ -144,25 +146,27 @@ export function App() {
 							? createSpaceSessionPath(spaceId, spaceSessionId)
 							: spaceId && spaceViewMode === 'sessions'
 								? createSpaceSessionsPath(spaceId)
-								: spaceId && spaceViewMode === 'configure'
-									? createSpaceConfigurePath(spaceId)
-									: spaceId
-										? createSpacePath(spaceId)
-										: roomTaskId && roomId
-											? createRoomTaskPath(roomId, roomTaskId)
-											: isAgentRoute
-												? createRoomAgentPath(roomId)
-												: roomSessionId && roomId
-													? createRoomSessionPath(roomId, roomSessionId)
-													: roomGoalId && roomId
-														? createRoomMissionPath(roomId, roomGoalId)
-														: roomId
-															? createRoomPath(roomId)
-															: navSection === 'spaces'
-																? '/spaces'
-																: navSection === 'chats'
-																	? '/sessions'
-																	: '/';
+								: spaceId && spaceViewMode === 'tasks'
+									? createSpaceTasksPath(spaceId)
+									: spaceId && spaceViewMode === 'configure'
+										? createSpaceConfigurePath(spaceId)
+										: spaceId
+											? createSpacePath(spaceId)
+											: roomTaskId && roomId
+												? createRoomTaskPath(roomId, roomTaskId)
+												: isAgentRoute
+													? createRoomAgentPath(roomId)
+													: roomSessionId && roomId
+														? createRoomSessionPath(roomId, roomSessionId)
+														: roomGoalId && roomId
+															? createRoomMissionPath(roomId, roomGoalId)
+															: roomId
+																? createRoomPath(roomId)
+																: navSection === 'spaces'
+																	? '/spaces'
+																	: navSection === 'chats'
+																		? '/sessions'
+																		: '/';
 
 			// Only update URL if it's out of sync
 			// This prevents unnecessary history updates and loops
@@ -177,6 +181,8 @@ export function App() {
 					navigateToSpaceSession(spaceId, spaceSessionId, true);
 				} else if (spaceId && spaceViewMode === 'sessions') {
 					navigateToSpaceSessions(spaceId, true);
+				} else if (spaceId && spaceViewMode === 'tasks') {
+					navigateToSpaceTasks(spaceId, true);
 				} else if (spaceId && spaceViewMode === 'configure') {
 					navigateToSpaceConfigure(spaceId, true);
 				} else if (spaceId) {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -38,6 +38,7 @@ import {
 	navigateToSpacesPage,
 	navigateToSpace,
 	navigateToSpaceConfigure,
+	navigateToSpaceSessions,
 	navigateToSpaceAgent,
 	navigateToSpaceSession,
 	navigateToSpaceTask,
@@ -49,6 +50,7 @@ import {
 	createRoomMissionPath,
 	createSpacePath,
 	createSpaceConfigurePath,
+	createSpaceSessionsPath,
 	createSpaceAgentPath,
 	createSpaceSessionPath,
 	createSpaceTaskPath,
@@ -140,25 +142,27 @@ export function App() {
 						? createSpaceAgentPath(spaceId)
 						: spaceSessionId && spaceId
 							? createSpaceSessionPath(spaceId, spaceSessionId)
-							: spaceId && spaceViewMode === 'configure'
-								? createSpaceConfigurePath(spaceId)
-								: spaceId
-									? createSpacePath(spaceId)
-									: roomTaskId && roomId
-										? createRoomTaskPath(roomId, roomTaskId)
-										: isAgentRoute
-											? createRoomAgentPath(roomId)
-											: roomSessionId && roomId
-												? createRoomSessionPath(roomId, roomSessionId)
-												: roomGoalId && roomId
-													? createRoomMissionPath(roomId, roomGoalId)
-													: roomId
-														? createRoomPath(roomId)
-														: navSection === 'spaces'
-															? '/spaces'
-															: navSection === 'chats'
-																? '/sessions'
-																: '/';
+							: spaceId && spaceViewMode === 'sessions'
+								? createSpaceSessionsPath(spaceId)
+								: spaceId && spaceViewMode === 'configure'
+									? createSpaceConfigurePath(spaceId)
+									: spaceId
+										? createSpacePath(spaceId)
+										: roomTaskId && roomId
+											? createRoomTaskPath(roomId, roomTaskId)
+											: isAgentRoute
+												? createRoomAgentPath(roomId)
+												: roomSessionId && roomId
+													? createRoomSessionPath(roomId, roomSessionId)
+													: roomGoalId && roomId
+														? createRoomMissionPath(roomId, roomGoalId)
+														: roomId
+															? createRoomPath(roomId)
+															: navSection === 'spaces'
+																? '/spaces'
+																: navSection === 'chats'
+																	? '/sessions'
+																	: '/';
 
 			// Only update URL if it's out of sync
 			// This prevents unnecessary history updates and loops
@@ -171,6 +175,8 @@ export function App() {
 					navigateToSpaceAgent(spaceId, true);
 				} else if (spaceSessionId && spaceId) {
 					navigateToSpaceSession(spaceId, spaceSessionId, true);
+				} else if (spaceId && spaceViewMode === 'sessions') {
+					navigateToSpaceSessions(spaceId, true);
 				} else if (spaceId && spaceViewMode === 'configure') {
 					navigateToSpaceConfigure(spaceId, true);
 				} else if (spaceId) {

--- a/packages/web/src/components/space/SpaceSessionsPage.tsx
+++ b/packages/web/src/components/space/SpaceSessionsPage.tsx
@@ -12,28 +12,31 @@ import { getRelativeTime } from '../../lib/utils';
 
 const STATUS_BORDER: Record<string, string> = {
 	active: 'border-l-green-500',
-	paused: 'border-l-amber-500',
+	paused: 'border-l-green-500',
 	pending_worktree_choice: 'border-l-amber-500',
 	ended: 'border-l-gray-600',
 };
 
 const STATUS_LABEL: Record<string, string> = {
 	active: 'Active',
-	paused: 'Paused',
+	paused: 'Pending',
 	pending_worktree_choice: 'Pending',
 	ended: 'Ended',
 };
+
+const ARCHIVED_LIMIT = 5;
 
 interface StatusGroupDef {
 	statuses: string[];
 	title: string;
 	variant: 'green' | 'yellow' | 'gray';
+	limit?: number;
 }
 
 const SESSION_GROUPS: StatusGroupDef[] = [
-	{ statuses: ['active'], title: 'Active', variant: 'green' },
-	{ statuses: ['paused', 'pending_worktree_choice'], title: 'Paused', variant: 'yellow' },
-	{ statuses: ['ended'], title: 'Ended', variant: 'gray' },
+	{ statuses: ['pending_worktree_choice'], title: 'Pending', variant: 'yellow' },
+	{ statuses: ['active', 'paused'], title: 'Active', variant: 'green' },
+	{ statuses: ['ended'], title: 'Archived', variant: 'gray', limit: ARCHIVED_LIMIT },
 ];
 
 function SessionGroup({
@@ -42,13 +45,17 @@ function SessionGroup({
 	variant,
 	sessions,
 	spaceId,
+	limit,
 }: {
 	title: string;
 	count: number;
 	variant: 'green' | 'yellow' | 'gray';
 	sessions: { id: string; title: string; status: string; lastActiveAt: number }[];
 	spaceId: string;
+	limit?: number;
 }) {
+	const displayed = limit ? sessions.slice(0, limit) : sessions;
+	const hidden = limit ? Math.max(0, sessions.length - limit) : 0;
 	const headerStyles: Record<string, string> = {
 		green: 'bg-green-900/20',
 		yellow: 'bg-yellow-900/20',
@@ -77,9 +84,12 @@ function SessionGroup({
 				</h3>
 			</div>
 			<div class="divide-y divide-dark-700">
-				{sessions.map((session) => (
+				{displayed.map((session) => (
 					<SessionItem key={session.id} session={session} spaceId={spaceId} />
 				))}
+				{hidden > 0 && (
+					<div class="px-4 py-2 text-xs text-gray-600 text-center">+{hidden} more not shown</div>
+				)}
 			</div>
 		</div>
 	);
@@ -172,6 +182,7 @@ export function SpaceSessionsPage({ spaceId }: SpaceSessionsPageProps) {
 							variant={group.variant}
 							sessions={groupSessions}
 							spaceId={spaceId}
+							limit={group.limit}
 						/>
 					);
 				})}

--- a/packages/web/src/components/space/SpaceSessionsPage.tsx
+++ b/packages/web/src/components/space/SpaceSessionsPage.tsx
@@ -1,0 +1,84 @@
+/**
+ * SpaceSessionsPage — lists all user-created sessions for a space.
+ *
+ * Excludes system sessions (task worker sessions, workflow sessions).
+ * Sessions can be clicked to navigate into them.
+ */
+
+import { useMemo } from 'preact/hooks';
+import { spaceStore } from '../../lib/space-store';
+import { navigateToSpaceSession } from '../../lib/router';
+import { getRelativeTime, cn } from '../../lib/utils';
+
+const SESSION_STATUS_COLORS: Record<string, string> = {
+	active: 'bg-green-500',
+	pending_worktree_choice: 'bg-amber-500',
+	paused: 'bg-amber-500',
+	ended: 'bg-gray-500',
+};
+
+interface SpaceSessionsPageProps {
+	spaceId: string;
+}
+
+export function SpaceSessionsPage({ spaceId }: SpaceSessionsPageProps) {
+	const storeSessions = spaceStore.sessions.value;
+
+	const sessions = useMemo(() => {
+		const isSystemSpaceSession = (sessionId: string): boolean =>
+			sessionId.startsWith(`space:${spaceId}:task:`) ||
+			sessionId.startsWith(`space:${spaceId}:workflow:`);
+
+		return [...storeSessions]
+			.filter((s) => !isSystemSpaceSession(s.id))
+			.sort((a, b) => (b.lastActiveAt ?? 0) - (a.lastActiveAt ?? 0));
+	}, [storeSessions, spaceId]);
+
+	if (sessions.length === 0) {
+		return (
+			<div class="flex-1 flex items-center justify-center">
+				<div class="text-center">
+					<p class="text-sm text-gray-500">No sessions yet</p>
+					<p class="text-xs text-gray-600 mt-1">
+						Sessions will appear here when created in this space.
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div class="flex-1 overflow-y-auto">
+			<div class="divide-y divide-dark-800">
+				{sessions.map((session) => (
+					<button
+						key={session.id}
+						onClick={() => navigateToSpaceSession(spaceId, session.id)}
+						class={cn(
+							'w-full px-4 py-3 flex items-center gap-3 transition-colors text-left hover:bg-dark-800'
+						)}
+					>
+						<div
+							class={cn(
+								'w-2 h-2 rounded-full flex-shrink-0 mt-0.5',
+								SESSION_STATUS_COLORS[session.status] ?? 'bg-gray-500'
+							)}
+						/>
+						<div class="flex-1 min-w-0">
+							<div class="text-sm text-gray-200 truncate">{session.title || session.id}</div>
+							<div class="text-xs text-gray-500 mt-0.5 flex items-center gap-2">
+								<span class="capitalize">{session.status.replace(/_/g, ' ')}</span>
+								{session.lastActiveAt && (
+									<>
+										<span>·</span>
+										<span>{getRelativeTime(session.lastActiveAt)}</span>
+									</>
+								)}
+							</div>
+						</div>
+					</button>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/space/SpaceSessionsPage.tsx
+++ b/packages/web/src/components/space/SpaceSessionsPage.tsx
@@ -3,12 +3,18 @@
  *
  * Sessions are grouped by status in cards matching the SpaceTasks style.
  * Excludes system sessions (task worker sessions, workflow sessions).
+ *
+ * Navigation: clicking a session calls navigateToSpaceSession() which uses
+ * pushState, so the browser back button naturally returns to /space/:id/sessions
+ * where handlePopState restores spaceViewMode = 'sessions'.
  */
 
-import { useMemo } from 'preact/hooks';
+import { useMemo, useState } from 'preact/hooks';
 import { spaceStore } from '../../lib/space-store';
 import { navigateToSpaceSession } from '../../lib/router';
 import { getRelativeTime } from '../../lib/utils';
+
+type Session = { id: string; title: string; status: string; lastActiveAt: number };
 
 const STATUS_BORDER: Record<string, string> = {
 	active: 'border-l-green-500',
@@ -24,20 +30,91 @@ const STATUS_LABEL: Record<string, string> = {
 	ended: 'Ended',
 };
 
+const ACTIVE_PAGE_SIZE = 10;
 const ARCHIVED_LIMIT = 5;
 
 interface StatusGroupDef {
 	statuses: string[];
 	title: string;
 	variant: 'green' | 'yellow' | 'gray';
-	limit?: number;
+	/** Hard cap with "+N more" footer — used for Archived */
+	hardLimit?: number;
+	/** Paginated with prev/next controls — used for Active */
+	paginated?: boolean;
 }
 
 const SESSION_GROUPS: StatusGroupDef[] = [
 	{ statuses: ['pending_worktree_choice'], title: 'Pending', variant: 'yellow' },
-	{ statuses: ['active', 'paused'], title: 'Active', variant: 'green' },
-	{ statuses: ['ended'], title: 'Archived', variant: 'gray', limit: ARCHIVED_LIMIT },
+	{ statuses: ['active', 'paused'], title: 'Active', variant: 'green', paginated: true },
+	{ statuses: ['ended'], title: 'Archived', variant: 'gray', hardLimit: ARCHIVED_LIMIT },
 ];
+
+function PaginatedSessionGroup({
+	title,
+	count,
+	variant,
+	sessions,
+	spaceId,
+}: {
+	title: string;
+	count: number;
+	variant: 'green' | 'yellow' | 'gray';
+	sessions: Session[];
+	spaceId: string;
+}) {
+	const [page, setPage] = useState(0);
+	const totalPages = Math.ceil(sessions.length / ACTIVE_PAGE_SIZE);
+	const displayed = sessions.slice(page * ACTIVE_PAGE_SIZE, (page + 1) * ACTIVE_PAGE_SIZE);
+
+	const headerStyles: Record<string, string> = {
+		green: 'bg-green-900/20',
+		yellow: 'bg-yellow-900/20',
+		gray: 'bg-dark-800',
+	};
+	const titleStyles: Record<string, string> = {
+		green: 'text-green-400',
+		yellow: 'text-yellow-400',
+		gray: 'text-gray-500',
+	};
+
+	return (
+		<div class="bg-dark-850 border border-dark-700 rounded-xl overflow-hidden">
+			<div
+				class={`px-4 py-3 border-b border-dark-700 ${headerStyles[variant]} flex items-center gap-1`}
+			>
+				<h3 class={`font-semibold ${titleStyles[variant]}`}>
+					{title} ({count})
+				</h3>
+			</div>
+			<div class="divide-y divide-dark-700">
+				{displayed.map((session) => (
+					<SessionItem key={session.id} session={session} spaceId={spaceId} />
+				))}
+			</div>
+			{totalPages > 1 && (
+				<div class="px-4 py-2 border-t border-dark-700 flex items-center justify-between">
+					<button
+						onClick={() => setPage((p) => Math.max(0, p - 1))}
+						disabled={page === 0}
+						class="px-2 py-1 text-xs text-gray-400 hover:text-gray-200 disabled:text-gray-700 disabled:cursor-not-allowed transition-colors"
+					>
+						← Prev
+					</button>
+					<span class="text-xs text-gray-600">
+						{page + 1} / {totalPages}
+					</span>
+					<button
+						onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+						disabled={page === totalPages - 1}
+						class="px-2 py-1 text-xs text-gray-400 hover:text-gray-200 disabled:text-gray-700 disabled:cursor-not-allowed transition-colors"
+					>
+						Next →
+					</button>
+				</div>
+			)}
+		</div>
+	);
+}
 
 function SessionGroup({
 	title,
@@ -45,39 +122,33 @@ function SessionGroup({
 	variant,
 	sessions,
 	spaceId,
-	limit,
+	hardLimit,
 }: {
 	title: string;
 	count: number;
 	variant: 'green' | 'yellow' | 'gray';
-	sessions: { id: string; title: string; status: string; lastActiveAt: number }[];
+	sessions: Session[];
 	spaceId: string;
-	limit?: number;
+	hardLimit?: number;
 }) {
-	const displayed = limit ? sessions.slice(0, limit) : sessions;
-	const hidden = limit ? Math.max(0, sessions.length - limit) : 0;
+	const displayed = hardLimit ? sessions.slice(0, hardLimit) : sessions;
+	const hidden = hardLimit ? Math.max(0, sessions.length - hardLimit) : 0;
+
 	const headerStyles: Record<string, string> = {
 		green: 'bg-green-900/20',
 		yellow: 'bg-yellow-900/20',
 		gray: 'bg-dark-800',
 	};
-
 	const titleStyles: Record<string, string> = {
 		green: 'text-green-400',
 		yellow: 'text-yellow-400',
 		gray: 'text-gray-500',
 	};
 
-	const borderStyles: Record<string, string> = {
-		green: 'border-dark-700',
-		yellow: 'border-dark-700',
-		gray: 'border-dark-700',
-	};
-
 	return (
-		<div class={`bg-dark-850 border rounded-xl overflow-hidden ${borderStyles[variant]}`}>
+		<div class="bg-dark-850 border border-dark-700 rounded-xl overflow-hidden">
 			<div
-				class={`px-4 py-3 border-b ${borderStyles[variant]} ${headerStyles[variant]} flex items-center gap-1`}
+				class={`px-4 py-3 border-b border-dark-700 ${headerStyles[variant]} flex items-center gap-1`}
 			>
 				<h3 class={`font-semibold ${titleStyles[variant]}`}>
 					{title} ({count})
@@ -95,13 +166,7 @@ function SessionGroup({
 	);
 }
 
-function SessionItem({
-	session,
-	spaceId,
-}: {
-	session: { id: string; title: string; status: string; lastActiveAt: number };
-	spaceId: string;
-}) {
+function SessionItem({ session, spaceId }: { session: Session; spaceId: string }) {
 	const borderColor = STATUS_BORDER[session.status] ?? 'border-l-transparent';
 
 	return (
@@ -174,6 +239,18 @@ export function SpaceSessionsPage({ spaceId }: SpaceSessionsPageProps) {
 				{SESSION_GROUPS.map((group) => {
 					const groupSessions = sessions.filter((s) => group.statuses.includes(s.status));
 					if (groupSessions.length === 0) return null;
+					if (group.paginated) {
+						return (
+							<PaginatedSessionGroup
+								key={group.title}
+								title={group.title}
+								count={groupSessions.length}
+								variant={group.variant}
+								sessions={groupSessions}
+								spaceId={spaceId}
+							/>
+						);
+					}
 					return (
 						<SessionGroup
 							key={group.title}
@@ -182,7 +259,7 @@ export function SpaceSessionsPage({ spaceId }: SpaceSessionsPageProps) {
 							variant={group.variant}
 							sessions={groupSessions}
 							spaceId={spaceId}
-							limit={group.limit}
+							hardLimit={group.hardLimit}
 						/>
 					);
 				})}

--- a/packages/web/src/components/space/SpaceSessionsPage.tsx
+++ b/packages/web/src/components/space/SpaceSessionsPage.tsx
@@ -1,21 +1,123 @@
 /**
  * SpaceSessionsPage — lists all user-created sessions for a space.
  *
+ * Sessions are grouped by status in cards matching the SpaceTasks style.
  * Excludes system sessions (task worker sessions, workflow sessions).
- * Sessions can be clicked to navigate into them.
  */
 
 import { useMemo } from 'preact/hooks';
 import { spaceStore } from '../../lib/space-store';
 import { navigateToSpaceSession } from '../../lib/router';
-import { getRelativeTime, cn } from '../../lib/utils';
+import { getRelativeTime } from '../../lib/utils';
 
-const SESSION_STATUS_COLORS: Record<string, string> = {
-	active: 'bg-green-500',
-	pending_worktree_choice: 'bg-amber-500',
-	paused: 'bg-amber-500',
-	ended: 'bg-gray-500',
+const STATUS_BORDER: Record<string, string> = {
+	active: 'border-l-green-500',
+	paused: 'border-l-amber-500',
+	pending_worktree_choice: 'border-l-amber-500',
+	ended: 'border-l-gray-600',
 };
+
+const STATUS_LABEL: Record<string, string> = {
+	active: 'Active',
+	paused: 'Paused',
+	pending_worktree_choice: 'Pending',
+	ended: 'Ended',
+};
+
+interface StatusGroupDef {
+	statuses: string[];
+	title: string;
+	variant: 'green' | 'yellow' | 'gray';
+}
+
+const SESSION_GROUPS: StatusGroupDef[] = [
+	{ statuses: ['active'], title: 'Active', variant: 'green' },
+	{ statuses: ['paused', 'pending_worktree_choice'], title: 'Paused', variant: 'yellow' },
+	{ statuses: ['ended'], title: 'Ended', variant: 'gray' },
+];
+
+function SessionGroup({
+	title,
+	count,
+	variant,
+	sessions,
+	spaceId,
+}: {
+	title: string;
+	count: number;
+	variant: 'green' | 'yellow' | 'gray';
+	sessions: { id: string; title: string; status: string; lastActiveAt: number }[];
+	spaceId: string;
+}) {
+	const headerStyles: Record<string, string> = {
+		green: 'bg-green-900/20',
+		yellow: 'bg-yellow-900/20',
+		gray: 'bg-dark-800',
+	};
+
+	const titleStyles: Record<string, string> = {
+		green: 'text-green-400',
+		yellow: 'text-yellow-400',
+		gray: 'text-gray-500',
+	};
+
+	const borderStyles: Record<string, string> = {
+		green: 'border-dark-700',
+		yellow: 'border-dark-700',
+		gray: 'border-dark-700',
+	};
+
+	return (
+		<div class={`bg-dark-850 border rounded-xl overflow-hidden ${borderStyles[variant]}`}>
+			<div
+				class={`px-4 py-3 border-b ${borderStyles[variant]} ${headerStyles[variant]} flex items-center gap-1`}
+			>
+				<h3 class={`font-semibold ${titleStyles[variant]}`}>
+					{title} ({count})
+				</h3>
+			</div>
+			<div class="divide-y divide-dark-700">
+				{sessions.map((session) => (
+					<SessionItem key={session.id} session={session} spaceId={spaceId} />
+				))}
+			</div>
+		</div>
+	);
+}
+
+function SessionItem({
+	session,
+	spaceId,
+}: {
+	session: { id: string; title: string; status: string; lastActiveAt: number };
+	spaceId: string;
+}) {
+	const borderColor = STATUS_BORDER[session.status] ?? 'border-l-transparent';
+
+	return (
+		<div
+			class={`px-4 py-3 border-l-2 ${borderColor} cursor-pointer hover:bg-dark-800/50 transition-colors`}
+			onClick={() => navigateToSpaceSession(spaceId, session.id)}
+		>
+			<div class="flex items-start justify-between">
+				<div class="flex-1 min-w-0">
+					<h4 class="text-sm font-medium text-gray-100 truncate">{session.title || session.id}</h4>
+					<div class="flex items-center gap-2 mt-1">
+						<span class="text-xs text-gray-500">
+							{STATUS_LABEL[session.status] ?? session.status}
+						</span>
+						{session.lastActiveAt > 0 && (
+							<span class="text-xs text-gray-600">{getRelativeTime(session.lastActiveAt)}</span>
+						)}
+					</div>
+				</div>
+				<div class="ml-4 flex items-center flex-shrink-0">
+					<span class="text-xs text-gray-600">&rarr;</span>
+				</div>
+			</div>
+		</div>
+	);
+}
 
 interface SpaceSessionsPageProps {
 	spaceId: string;
@@ -36,48 +138,43 @@ export function SpaceSessionsPage({ spaceId }: SpaceSessionsPageProps) {
 
 	if (sessions.length === 0) {
 		return (
-			<div class="flex-1 flex items-center justify-center">
-				<div class="text-center">
-					<p class="text-sm text-gray-500">No sessions yet</p>
-					<p class="text-xs text-gray-600 mt-1">
-						Sessions will appear here when created in this space.
-					</p>
-				</div>
+			<div class="w-full px-8 flex flex-col items-center justify-center py-16 text-center">
+				<svg
+					class="w-10 h-10 text-gray-700 mb-3"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width={1.5}
+						d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+					/>
+				</svg>
+				<p class="text-sm text-gray-400 font-medium">No sessions yet</p>
+				<p class="text-xs text-gray-600 mt-1">Sessions will appear here when created</p>
 			</div>
 		);
 	}
 
 	return (
-		<div class="flex-1 overflow-y-auto">
-			<div class="divide-y divide-dark-800">
-				{sessions.map((session) => (
-					<button
-						key={session.id}
-						onClick={() => navigateToSpaceSession(spaceId, session.id)}
-						class={cn(
-							'w-full px-4 py-3 flex items-center gap-3 transition-colors text-left hover:bg-dark-800'
-						)}
-					>
-						<div
-							class={cn(
-								'w-2 h-2 rounded-full flex-shrink-0 mt-0.5',
-								SESSION_STATUS_COLORS[session.status] ?? 'bg-gray-500'
-							)}
+		<div class="flex-1 min-h-0 w-full px-4 py-4 sm:px-8 sm:py-6 overflow-y-auto">
+			<div class="min-h-[calc(100%+1px)] space-y-4">
+				{SESSION_GROUPS.map((group) => {
+					const groupSessions = sessions.filter((s) => group.statuses.includes(s.status));
+					if (groupSessions.length === 0) return null;
+					return (
+						<SessionGroup
+							key={group.title}
+							title={group.title}
+							count={groupSessions.length}
+							variant={group.variant}
+							sessions={groupSessions}
+							spaceId={spaceId}
 						/>
-						<div class="flex-1 min-w-0">
-							<div class="text-sm text-gray-200 truncate">{session.title || session.id}</div>
-							<div class="text-xs text-gray-500 mt-0.5 flex items-center gap-2">
-								<span class="capitalize">{session.status.replace(/_/g, ' ')}</span>
-								{session.lastActiveAt && (
-									<>
-										<span>·</span>
-										<span>{getRelativeTime(session.lastActiveAt)}</span>
-									</>
-								)}
-							</div>
-						</div>
-					</button>
-				))}
+					);
+				})}
 			</div>
 		</div>
 	);

--- a/packages/web/src/islands/BottomTabBar.tsx
+++ b/packages/web/src/islands/BottomTabBar.tsx
@@ -21,6 +21,7 @@ import {
 	navigateToRoomTab,
 	navigateToSpace,
 	navigateToSpaceTasks,
+	navigateToSpaceSessions,
 	navigateToSpaceAgent,
 	navigateToSpaceConfigure,
 } from '../lib/router.ts';
@@ -37,6 +38,7 @@ interface TabItem {
 		| 'room-missions'
 		| 'space-overview'
 		| 'space-tasks'
+		| 'space-sessions'
 		| 'space-agent'
 		| 'space-settings';
 	label: string;
@@ -181,6 +183,17 @@ const SpaceChatIcon = () => (
 	</svg>
 );
 
+const SpaceSessionsIcon = () => (
+	<svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+		<path
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			stroke-width={2}
+			d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+		/>
+	</svg>
+);
+
 const SpaceSettingsIcon = () => (
 	<svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 		<path
@@ -201,6 +214,7 @@ const SpaceSettingsIcon = () => (
 const SPACE_BOTTOM_TABS: TabItem[] = [
 	{ id: 'space-overview', label: 'Overview', icon: SpaceOverviewIcon },
 	{ id: 'space-tasks', label: 'Tasks', icon: SpaceTasksIcon },
+	{ id: 'space-sessions', label: 'Sessions', icon: SpaceSessionsIcon },
 	{ id: 'space-agent', label: 'Agent', icon: SpaceChatIcon },
 	{ id: 'space-settings', label: 'Settings', icon: SpaceSettingsIcon },
 ];
@@ -304,6 +318,9 @@ export function BottomTabBar({ inline }: { inline?: boolean } = {}) {
 			case 'space-tasks':
 				if (spaceId) navigateToSpaceTasks(spaceId);
 				break;
+			case 'space-sessions':
+				if (spaceId) navigateToSpaceSessions(spaceId);
+				break;
 			case 'space-agent':
 				if (spaceId) navigateToSpaceAgent(spaceId);
 				break;
@@ -316,6 +333,7 @@ export function BottomTabBar({ inline }: { inline?: boolean } = {}) {
 	const isTabActive = (id: TabItem['id']): boolean => {
 		if (isInSpaceContext) {
 			if (id === 'space-settings') return spaceViewMode === 'configure';
+			if (id === 'space-sessions') return spaceViewMode === 'sessions';
 			if (id === 'space-agent') return spaceSessionId === `space:chat:${spaceId}`;
 			if (id === 'space-tasks') return spaceViewMode === 'tasks' && spaceTaskId === null;
 			if (id === 'space-overview')

--- a/packages/web/src/islands/SpaceDetailPanel.tsx
+++ b/packages/web/src/islands/SpaceDetailPanel.tsx
@@ -13,6 +13,7 @@ import {
 	navigateToSpace,
 	navigateToSpaceAgent,
 	navigateToSpaceSession,
+	navigateToSpaceSessions,
 	navigateToSpaceTask,
 	navigateToSpaceTasks,
 } from '../lib/router';
@@ -120,6 +121,7 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 		currentSpaceViewModeSignal.value === 'overview';
 	const isSpaceAgentSelected = selectedSessionId === spaceAgentSessionId;
 	const isTasksSelected = currentSpaceViewModeSignal.value === 'tasks';
+	const isSessionsSelected = currentSpaceViewModeSignal.value === 'sessions';
 
 	const { activeCount, reviewCount } = useMemo(() => {
 		let active = 0;
@@ -171,6 +173,11 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 
 	const handleTasksClick = useCallback(() => {
 		navigateToSpaceTasks(spaceId);
+		onNavigate?.();
+	}, [spaceId, onNavigate]);
+
+	const handleSessionsClick = useCallback(() => {
+		navigateToSpaceSessions(spaceId);
 		onNavigate?.();
 	}, [spaceId, onNavigate]);
 
@@ -294,6 +301,38 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 					</svg>
 				</div>
 				<span class="flex-1 text-sm text-gray-200 text-left truncate">Tasks</span>
+			</button>
+
+			<button
+				onClick={handleSessionsClick}
+				data-testid="space-detail-sessions"
+				data-active={isSessionsSelected ? 'true' : 'false'}
+				class={cn(
+					'mx-3 mt-2 w-auto rounded-xl px-3 py-2.5 flex items-center gap-2.5 transition-colors border',
+					isSessionsSelected
+						? 'bg-dark-700 border-dark-600'
+						: 'bg-transparent border-transparent hover:bg-dark-800 hover:border-dark-700'
+				)}
+			>
+				<div class="w-6 h-6 flex-shrink-0 flex items-center justify-center bg-amber-900/40 rounded">
+					<svg
+						class="w-3.5 h-3.5 text-amber-400"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width={2}
+							d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+						/>
+					</svg>
+				</div>
+				<span class="flex-1 text-sm text-gray-200 text-left truncate">Sessions</span>
+				{sessions.length > 0 && (
+					<span class="text-xs text-gray-500 flex-shrink-0">{sessions.length}</span>
+				)}
 			</button>
 
 			<div class="border-t border-dark-700 mx-3 my-3" />

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -23,6 +23,9 @@ import ChatContainer from './ChatContainer';
 const SpaceConfigurePage = lazy(() =>
 	import('../components/space/SpaceConfigurePage').then((m) => ({ default: m.SpaceConfigurePage }))
 );
+const SpaceSessionsPage = lazy(() =>
+	import('../components/space/SpaceSessionsPage').then((m) => ({ default: m.SpaceSessionsPage }))
+);
 const SpaceTasks = lazy(() =>
 	import('../components/space/SpaceTasks').then((m) => ({ default: m.SpaceTasks }))
 );
@@ -147,6 +150,31 @@ export default function SpaceIsland({
 								spaceId={spaceId}
 								onSelectTask={(taskId) => navigateToSpaceTask(spaceId, taskId)}
 							/>
+						</Suspense>
+					</div>
+				</div>
+				{overlaySessionId && (
+					<AgentOverlayChat
+						sessionId={overlaySessionId}
+						agentName={overlayAgentName ?? undefined}
+						onClose={handleOverlayClose}
+					/>
+				)}
+			</>
+		);
+	}
+
+	if (viewMode === 'sessions' && space) {
+		return (
+			<>
+				<div
+					class="flex-1 flex flex-col overflow-hidden bg-dark-900"
+					data-testid="space-sessions-view"
+				>
+					<SpacePageHeader spaceName={space.name} pageTitle="Sessions" />
+					<div class="flex-1 min-w-0 overflow-hidden flex flex-col">
+						<Suspense fallback={lazyFallback}>
+							<SpaceSessionsPage spaceId={spaceId} />
 						</Suspense>
 					</div>
 				</div>

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -14,6 +14,7 @@
  * - Clean URLs: Uses History API for clean URLs without hash
  */
 
+import { batch } from '@preact/signals';
 import {
 	currentSessionIdSignal,
 	currentRoomIdSignal,
@@ -1288,7 +1289,6 @@ export function navigateToSpaceSession(spaceId: string, sessionId: string, repla
 
 	if (currentPath === targetPath) {
 		currentSpaceIdSignal.value = spaceId;
-		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = sessionId;
 		currentSpaceTaskIdSignal.value = null;
 		currentSessionIdSignal.value = null;
@@ -1309,7 +1309,6 @@ export function navigateToSpaceSession(spaceId: string, sessionId: string, repla
 		window.history[historyMethod]({ spaceId, sessionId, path: targetPath }, '', targetPath);
 
 		currentSpaceIdSignal.value = spaceId;
-		currentSpaceViewModeSignal.value = 'overview';
 		currentSpaceSessionIdSignal.value = sessionId;
 		currentSpaceTaskIdSignal.value = null;
 		currentSessionIdSignal.value = null;
@@ -1459,241 +1458,246 @@ function handlePopState(_event: PopStateEvent): void {
 	const spaceAgent = getSpaceAgentFromPath(path);
 	const spaceId = getSpaceIdFromPath(path);
 
-	// Update the signals to match the URL
-	// Space routes take priority over room routes
+	// Update the signals to match the URL.
+	// Wrapped in batch() so the App.tsx URL-sync effect fires exactly once with the final
+	// consistent signal state, rather than once per individual signal write (which would
+	// cause the effect to see stale in-between state and trigger incorrect re-navigations).
+	// Space routes take priority over room routes.
 	// IMPORTANT: Order is load-bearing — roomAgent must be checked before roomTab/roomMission/roomTask/roomSession/roomId
 	// because getRoomIdFromPath also matches agent/tab paths. If reordered, those routes silently
 	// fall through to the plain room handler, losing the synthetic session ID or tab state.
-	if (spaceTask) {
-		currentSpaceIdSignal.value = spaceTask.spaceId;
-		currentSpaceViewModeSignal.value = 'overview';
-		currentSpaceTaskIdSignal.value = spaceTask.taskId;
-		currentSpaceSessionIdSignal.value = null;
-		currentRoomIdSignal.value = null;
-		currentRoomSessionIdSignal.value = null;
-		currentRoomTaskIdSignal.value = null;
-		currentRoomGoalIdSignal.value = null;
-		currentRoomAgentActiveSignal.value = false;
-		currentRoomActiveTabSignal.value = null;
-		currentSessionIdSignal.value = null;
-		navSectionSignal.value = 'spaces';
-	} else if (spaceSession) {
-		currentSpaceIdSignal.value = spaceSession.spaceId;
-		currentSpaceViewModeSignal.value = 'overview';
-		currentSpaceSessionIdSignal.value = spaceSession.sessionId;
-		currentSpaceTaskIdSignal.value = null;
-		currentRoomIdSignal.value = null;
-		currentRoomSessionIdSignal.value = null;
-		currentRoomTaskIdSignal.value = null;
-		currentRoomGoalIdSignal.value = null;
-		currentRoomAgentActiveSignal.value = false;
-		currentRoomActiveTabSignal.value = null;
-		currentSessionIdSignal.value = null;
-		navSectionSignal.value = 'spaces';
-	} else if (spaceAgent) {
-		currentSpaceIdSignal.value = spaceAgent;
-		currentSpaceViewModeSignal.value = 'overview';
-		currentSpaceSessionIdSignal.value = `space:chat:${spaceAgent}`;
-		currentSpaceTaskIdSignal.value = null;
-		currentRoomIdSignal.value = null;
-		currentRoomSessionIdSignal.value = null;
-		currentRoomTaskIdSignal.value = null;
-		currentRoomGoalIdSignal.value = null;
-		currentRoomAgentActiveSignal.value = false;
-		currentRoomActiveTabSignal.value = null;
-		currentSessionIdSignal.value = null;
-		navSectionSignal.value = 'spaces';
-	} else if (spaceTasks) {
-		currentSpaceIdSignal.value = spaceTasks;
-		currentSpaceViewModeSignal.value = 'tasks';
-		currentSpaceSessionIdSignal.value = null;
-		currentSpaceTaskIdSignal.value = null;
-		currentRoomIdSignal.value = null;
-		currentRoomSessionIdSignal.value = null;
-		currentRoomTaskIdSignal.value = null;
-		currentRoomGoalIdSignal.value = null;
-		currentRoomAgentActiveSignal.value = false;
-		currentRoomActiveTabSignal.value = null;
-		currentSessionIdSignal.value = null;
-		navSectionSignal.value = 'spaces';
-	} else if (spaceSessions) {
-		currentSpaceIdSignal.value = spaceSessions;
-		currentSpaceViewModeSignal.value = 'sessions';
-		currentSpaceSessionIdSignal.value = null;
-		currentSpaceTaskIdSignal.value = null;
-		currentRoomIdSignal.value = null;
-		currentRoomSessionIdSignal.value = null;
-		currentRoomTaskIdSignal.value = null;
-		currentRoomGoalIdSignal.value = null;
-		currentRoomAgentActiveSignal.value = false;
-		currentRoomActiveTabSignal.value = null;
-		currentSessionIdSignal.value = null;
-		navSectionSignal.value = 'spaces';
-	} else if (spaceConfigure) {
-		currentSpaceIdSignal.value = spaceConfigure;
-		currentSpaceViewModeSignal.value = 'configure';
-		currentSpaceSessionIdSignal.value = null;
-		currentSpaceTaskIdSignal.value = null;
-		currentRoomIdSignal.value = null;
-		currentRoomSessionIdSignal.value = null;
-		currentRoomTaskIdSignal.value = null;
-		currentRoomGoalIdSignal.value = null;
-		currentRoomAgentActiveSignal.value = false;
-		currentRoomActiveTabSignal.value = null;
-		currentSessionIdSignal.value = null;
-		navSectionSignal.value = 'spaces';
-	} else if (spaceId) {
-		currentSpaceIdSignal.value = spaceId;
-		currentSpaceViewModeSignal.value = 'overview';
-		currentSpaceSessionIdSignal.value = null;
-		currentSpaceTaskIdSignal.value = null;
-		currentRoomIdSignal.value = null;
-		currentRoomSessionIdSignal.value = null;
-		currentRoomTaskIdSignal.value = null;
-		currentRoomGoalIdSignal.value = null;
-		currentRoomAgentActiveSignal.value = false;
-		currentRoomActiveTabSignal.value = null;
-		currentSessionIdSignal.value = null;
-		navSectionSignal.value = 'spaces';
-	} else if (roomAgent) {
-		currentSpaceIdSignal.value = null;
-		currentSpaceViewModeSignal.value = 'overview';
-		currentSpaceSessionIdSignal.value = null;
-		currentSpaceTaskIdSignal.value = null;
-		currentRoomIdSignal.value = roomAgent;
-		currentRoomSessionIdSignal.value = null;
-		currentRoomTaskIdSignal.value = null;
-		currentRoomGoalIdSignal.value = null;
-		currentRoomAgentActiveSignal.value = true;
-		currentRoomActiveTabSignal.value = 'chat';
-		currentSessionIdSignal.value = null;
-		navSectionSignal.value = 'rooms';
-	} else if (roomTab) {
-		currentSpaceIdSignal.value = null;
-		currentSpaceViewModeSignal.value = 'overview';
-		currentSpaceSessionIdSignal.value = null;
-		currentSpaceTaskIdSignal.value = null;
-		currentRoomIdSignal.value = roomTab.roomId;
-		currentRoomActiveTabSignal.value = roomTab.tab;
-		currentRoomAgentActiveSignal.value = false;
-		currentRoomSessionIdSignal.value = null;
-		currentRoomTaskIdSignal.value = null;
-		currentRoomGoalIdSignal.value = null;
-		currentSessionIdSignal.value = null;
-		navSectionSignal.value = 'rooms';
-	} else if (roomMission) {
-		currentSpaceIdSignal.value = null;
-		currentSpaceViewModeSignal.value = 'overview';
-		currentSpaceSessionIdSignal.value = null;
-		currentSpaceTaskIdSignal.value = null;
-		currentRoomIdSignal.value = roomMission.roomId;
-		currentRoomGoalIdSignal.value = roomMission.goalId;
-		currentRoomTaskIdSignal.value = null;
-		currentRoomSessionIdSignal.value = null;
-		currentRoomAgentActiveSignal.value = false;
-		currentRoomActiveTabSignal.value = null;
-		currentSessionIdSignal.value = null;
-		navSectionSignal.value = 'rooms';
-	} else if (roomTask) {
-		currentSpaceIdSignal.value = null;
-		currentSpaceViewModeSignal.value = 'overview';
-		currentSpaceSessionIdSignal.value = null;
-		currentSpaceTaskIdSignal.value = null;
-		currentRoomIdSignal.value = roomTask.roomId;
-		currentRoomTaskIdSignal.value = roomTask.taskId;
-		currentRoomGoalIdSignal.value = null;
-		currentRoomSessionIdSignal.value = null;
-		currentRoomAgentActiveSignal.value = false;
-		currentRoomActiveTabSignal.value = null;
-		currentSessionIdSignal.value = null;
-		navSectionSignal.value = 'rooms';
-	} else if (roomSession) {
-		currentSpaceIdSignal.value = null;
-		currentSpaceViewModeSignal.value = 'overview';
-		currentSpaceSessionIdSignal.value = null;
-		currentSpaceTaskIdSignal.value = null;
-		currentRoomIdSignal.value = roomSession.roomId;
-		currentRoomSessionIdSignal.value = roomSession.sessionId;
-		currentRoomTaskIdSignal.value = null;
-		currentRoomGoalIdSignal.value = null;
-		currentRoomAgentActiveSignal.value = false;
-		currentRoomActiveTabSignal.value = null;
-		currentSessionIdSignal.value = null;
-		navSectionSignal.value = 'rooms';
-	} else if (roomId) {
-		currentSpaceIdSignal.value = null;
-		currentSpaceViewModeSignal.value = 'overview';
-		currentSpaceSessionIdSignal.value = null;
-		currentSpaceTaskIdSignal.value = null;
-		currentRoomIdSignal.value = roomId;
-		currentRoomActiveTabSignal.value = 'overview';
-		currentRoomSessionIdSignal.value = null;
-		currentRoomTaskIdSignal.value = null;
-		currentRoomGoalIdSignal.value = null;
-		currentRoomAgentActiveSignal.value = false;
-		currentSessionIdSignal.value = null;
-		navSectionSignal.value = 'rooms';
-		// Normalize legacy /room/:id/chat URL → /room/:id so the address bar stays clean
-		if (ROOM_CHAT_COMPAT_PATTERN.test(path)) {
-			const canonicalPath = createRoomPath(roomId);
-			window.history.replaceState({ roomId, path: canonicalPath }, '', canonicalPath);
-		}
-	} else if (SESSIONS_ROUTE_PATTERN.test(path)) {
-		currentSpaceIdSignal.value = null;
-		currentSpaceViewModeSignal.value = 'overview';
-		currentSpaceSessionIdSignal.value = null;
-		currentSpaceTaskIdSignal.value = null;
-		currentRoomIdSignal.value = null;
-		currentRoomSessionIdSignal.value = null;
-		currentRoomTaskIdSignal.value = null;
-		currentRoomGoalIdSignal.value = null;
-		currentRoomAgentActiveSignal.value = false;
-		currentRoomActiveTabSignal.value = null;
-		currentSessionIdSignal.value = null;
-		navSectionSignal.value = 'chats';
-	} else if (INBOX_ROUTE_PATTERN.test(path)) {
-		currentSpaceIdSignal.value = null;
-		currentSpaceViewModeSignal.value = 'overview';
-		currentSpaceSessionIdSignal.value = null;
-		currentSpaceTaskIdSignal.value = null;
-		currentRoomIdSignal.value = null;
-		currentRoomSessionIdSignal.value = null;
-		currentRoomTaskIdSignal.value = null;
-		currentRoomGoalIdSignal.value = null;
-		currentRoomAgentActiveSignal.value = false;
-		currentRoomActiveTabSignal.value = null;
-		currentSessionIdSignal.value = null;
-		navSectionSignal.value = 'inbox';
-	} else if (SPACES_ROUTE_PATTERN.test(path)) {
-		currentSpaceIdSignal.value = null;
-		currentSpaceViewModeSignal.value = 'overview';
-		currentSpaceSessionIdSignal.value = null;
-		currentSpaceTaskIdSignal.value = null;
-		currentRoomIdSignal.value = null;
-		currentRoomSessionIdSignal.value = null;
-		currentRoomTaskIdSignal.value = null;
-		currentRoomGoalIdSignal.value = null;
-		currentRoomAgentActiveSignal.value = false;
-		currentRoomActiveTabSignal.value = null;
-		currentSessionIdSignal.value = null;
-		navSectionSignal.value = 'spaces';
-	} else {
-		currentSpaceIdSignal.value = null;
-		currentSpaceViewModeSignal.value = 'overview';
-		currentSpaceSessionIdSignal.value = null;
-		currentSpaceTaskIdSignal.value = null;
-		currentRoomIdSignal.value = null;
-		currentRoomActiveTabSignal.value = null;
-		currentRoomSessionIdSignal.value = null;
-		currentRoomTaskIdSignal.value = null;
-		currentRoomGoalIdSignal.value = null;
-		currentRoomAgentActiveSignal.value = false;
-		currentRoomActiveTabSignal.value = null;
-		currentSessionIdSignal.value = sessionId;
-		if (!sessionId) {
+	batch(() => {
+		if (spaceTask) {
+			currentSpaceIdSignal.value = spaceTask.spaceId;
+			currentSpaceViewModeSignal.value = 'overview';
+			currentSpaceTaskIdSignal.value = spaceTask.taskId;
+			currentSpaceSessionIdSignal.value = null;
+			currentRoomIdSignal.value = null;
+			currentRoomSessionIdSignal.value = null;
+			currentRoomTaskIdSignal.value = null;
+			currentRoomGoalIdSignal.value = null;
+			currentRoomAgentActiveSignal.value = false;
+			currentRoomActiveTabSignal.value = null;
+			currentSessionIdSignal.value = null;
+			navSectionSignal.value = 'spaces';
+		} else if (spaceSession) {
+			currentSpaceIdSignal.value = spaceSession.spaceId;
+			currentSpaceViewModeSignal.value = 'overview';
+			currentSpaceSessionIdSignal.value = spaceSession.sessionId;
+			currentSpaceTaskIdSignal.value = null;
+			currentRoomIdSignal.value = null;
+			currentRoomSessionIdSignal.value = null;
+			currentRoomTaskIdSignal.value = null;
+			currentRoomGoalIdSignal.value = null;
+			currentRoomAgentActiveSignal.value = false;
+			currentRoomActiveTabSignal.value = null;
+			currentSessionIdSignal.value = null;
+			navSectionSignal.value = 'spaces';
+		} else if (spaceAgent) {
+			currentSpaceIdSignal.value = spaceAgent;
+			currentSpaceViewModeSignal.value = 'overview';
+			currentSpaceSessionIdSignal.value = `space:chat:${spaceAgent}`;
+			currentSpaceTaskIdSignal.value = null;
+			currentRoomIdSignal.value = null;
+			currentRoomSessionIdSignal.value = null;
+			currentRoomTaskIdSignal.value = null;
+			currentRoomGoalIdSignal.value = null;
+			currentRoomAgentActiveSignal.value = false;
+			currentRoomActiveTabSignal.value = null;
+			currentSessionIdSignal.value = null;
+			navSectionSignal.value = 'spaces';
+		} else if (spaceTasks) {
+			currentSpaceIdSignal.value = spaceTasks;
+			currentSpaceViewModeSignal.value = 'tasks';
+			currentSpaceSessionIdSignal.value = null;
+			currentSpaceTaskIdSignal.value = null;
+			currentRoomIdSignal.value = null;
+			currentRoomSessionIdSignal.value = null;
+			currentRoomTaskIdSignal.value = null;
+			currentRoomGoalIdSignal.value = null;
+			currentRoomAgentActiveSignal.value = false;
+			currentRoomActiveTabSignal.value = null;
+			currentSessionIdSignal.value = null;
+			navSectionSignal.value = 'spaces';
+		} else if (spaceSessions) {
+			currentSpaceIdSignal.value = spaceSessions;
+			currentSpaceViewModeSignal.value = 'sessions';
+			currentSpaceSessionIdSignal.value = null;
+			currentSpaceTaskIdSignal.value = null;
+			currentRoomIdSignal.value = null;
+			currentRoomSessionIdSignal.value = null;
+			currentRoomTaskIdSignal.value = null;
+			currentRoomGoalIdSignal.value = null;
+			currentRoomAgentActiveSignal.value = false;
+			currentRoomActiveTabSignal.value = null;
+			currentSessionIdSignal.value = null;
+			navSectionSignal.value = 'spaces';
+		} else if (spaceConfigure) {
+			currentSpaceIdSignal.value = spaceConfigure;
+			currentSpaceViewModeSignal.value = 'configure';
+			currentSpaceSessionIdSignal.value = null;
+			currentSpaceTaskIdSignal.value = null;
+			currentRoomIdSignal.value = null;
+			currentRoomSessionIdSignal.value = null;
+			currentRoomTaskIdSignal.value = null;
+			currentRoomGoalIdSignal.value = null;
+			currentRoomAgentActiveSignal.value = false;
+			currentRoomActiveTabSignal.value = null;
+			currentSessionIdSignal.value = null;
+			navSectionSignal.value = 'spaces';
+		} else if (spaceId) {
+			currentSpaceIdSignal.value = spaceId;
+			currentSpaceViewModeSignal.value = 'overview';
+			currentSpaceSessionIdSignal.value = null;
+			currentSpaceTaskIdSignal.value = null;
+			currentRoomIdSignal.value = null;
+			currentRoomSessionIdSignal.value = null;
+			currentRoomTaskIdSignal.value = null;
+			currentRoomGoalIdSignal.value = null;
+			currentRoomAgentActiveSignal.value = false;
+			currentRoomActiveTabSignal.value = null;
+			currentSessionIdSignal.value = null;
+			navSectionSignal.value = 'spaces';
+		} else if (roomAgent) {
+			currentSpaceIdSignal.value = null;
+			currentSpaceViewModeSignal.value = 'overview';
+			currentSpaceSessionIdSignal.value = null;
+			currentSpaceTaskIdSignal.value = null;
+			currentRoomIdSignal.value = roomAgent;
+			currentRoomSessionIdSignal.value = null;
+			currentRoomTaskIdSignal.value = null;
+			currentRoomGoalIdSignal.value = null;
+			currentRoomAgentActiveSignal.value = true;
+			currentRoomActiveTabSignal.value = 'chat';
+			currentSessionIdSignal.value = null;
 			navSectionSignal.value = 'rooms';
+		} else if (roomTab) {
+			currentSpaceIdSignal.value = null;
+			currentSpaceViewModeSignal.value = 'overview';
+			currentSpaceSessionIdSignal.value = null;
+			currentSpaceTaskIdSignal.value = null;
+			currentRoomIdSignal.value = roomTab.roomId;
+			currentRoomActiveTabSignal.value = roomTab.tab;
+			currentRoomAgentActiveSignal.value = false;
+			currentRoomSessionIdSignal.value = null;
+			currentRoomTaskIdSignal.value = null;
+			currentRoomGoalIdSignal.value = null;
+			currentSessionIdSignal.value = null;
+			navSectionSignal.value = 'rooms';
+		} else if (roomMission) {
+			currentSpaceIdSignal.value = null;
+			currentSpaceViewModeSignal.value = 'overview';
+			currentSpaceSessionIdSignal.value = null;
+			currentSpaceTaskIdSignal.value = null;
+			currentRoomIdSignal.value = roomMission.roomId;
+			currentRoomGoalIdSignal.value = roomMission.goalId;
+			currentRoomTaskIdSignal.value = null;
+			currentRoomSessionIdSignal.value = null;
+			currentRoomAgentActiveSignal.value = false;
+			currentRoomActiveTabSignal.value = null;
+			currentSessionIdSignal.value = null;
+			navSectionSignal.value = 'rooms';
+		} else if (roomTask) {
+			currentSpaceIdSignal.value = null;
+			currentSpaceViewModeSignal.value = 'overview';
+			currentSpaceSessionIdSignal.value = null;
+			currentSpaceTaskIdSignal.value = null;
+			currentRoomIdSignal.value = roomTask.roomId;
+			currentRoomTaskIdSignal.value = roomTask.taskId;
+			currentRoomGoalIdSignal.value = null;
+			currentRoomSessionIdSignal.value = null;
+			currentRoomAgentActiveSignal.value = false;
+			currentRoomActiveTabSignal.value = null;
+			currentSessionIdSignal.value = null;
+			navSectionSignal.value = 'rooms';
+		} else if (roomSession) {
+			currentSpaceIdSignal.value = null;
+			currentSpaceViewModeSignal.value = 'overview';
+			currentSpaceSessionIdSignal.value = null;
+			currentSpaceTaskIdSignal.value = null;
+			currentRoomIdSignal.value = roomSession.roomId;
+			currentRoomSessionIdSignal.value = roomSession.sessionId;
+			currentRoomTaskIdSignal.value = null;
+			currentRoomGoalIdSignal.value = null;
+			currentRoomAgentActiveSignal.value = false;
+			currentRoomActiveTabSignal.value = null;
+			currentSessionIdSignal.value = null;
+			navSectionSignal.value = 'rooms';
+		} else if (roomId) {
+			currentSpaceIdSignal.value = null;
+			currentSpaceViewModeSignal.value = 'overview';
+			currentSpaceSessionIdSignal.value = null;
+			currentSpaceTaskIdSignal.value = null;
+			currentRoomIdSignal.value = roomId;
+			currentRoomActiveTabSignal.value = 'overview';
+			currentRoomSessionIdSignal.value = null;
+			currentRoomTaskIdSignal.value = null;
+			currentRoomGoalIdSignal.value = null;
+			currentRoomAgentActiveSignal.value = false;
+			currentSessionIdSignal.value = null;
+			navSectionSignal.value = 'rooms';
+			// Normalize legacy /room/:id/chat URL → /room/:id so the address bar stays clean
+			if (ROOM_CHAT_COMPAT_PATTERN.test(path)) {
+				const canonicalPath = createRoomPath(roomId);
+				window.history.replaceState({ roomId, path: canonicalPath }, '', canonicalPath);
+			}
+		} else if (SESSIONS_ROUTE_PATTERN.test(path)) {
+			currentSpaceIdSignal.value = null;
+			currentSpaceViewModeSignal.value = 'overview';
+			currentSpaceSessionIdSignal.value = null;
+			currentSpaceTaskIdSignal.value = null;
+			currentRoomIdSignal.value = null;
+			currentRoomSessionIdSignal.value = null;
+			currentRoomTaskIdSignal.value = null;
+			currentRoomGoalIdSignal.value = null;
+			currentRoomAgentActiveSignal.value = false;
+			currentRoomActiveTabSignal.value = null;
+			currentSessionIdSignal.value = null;
+			navSectionSignal.value = 'chats';
+		} else if (INBOX_ROUTE_PATTERN.test(path)) {
+			currentSpaceIdSignal.value = null;
+			currentSpaceViewModeSignal.value = 'overview';
+			currentSpaceSessionIdSignal.value = null;
+			currentSpaceTaskIdSignal.value = null;
+			currentRoomIdSignal.value = null;
+			currentRoomSessionIdSignal.value = null;
+			currentRoomTaskIdSignal.value = null;
+			currentRoomGoalIdSignal.value = null;
+			currentRoomAgentActiveSignal.value = false;
+			currentRoomActiveTabSignal.value = null;
+			currentSessionIdSignal.value = null;
+			navSectionSignal.value = 'inbox';
+		} else if (SPACES_ROUTE_PATTERN.test(path)) {
+			currentSpaceIdSignal.value = null;
+			currentSpaceViewModeSignal.value = 'overview';
+			currentSpaceSessionIdSignal.value = null;
+			currentSpaceTaskIdSignal.value = null;
+			currentRoomIdSignal.value = null;
+			currentRoomSessionIdSignal.value = null;
+			currentRoomTaskIdSignal.value = null;
+			currentRoomGoalIdSignal.value = null;
+			currentRoomAgentActiveSignal.value = false;
+			currentRoomActiveTabSignal.value = null;
+			currentSessionIdSignal.value = null;
+			navSectionSignal.value = 'spaces';
+		} else {
+			currentSpaceIdSignal.value = null;
+			currentSpaceViewModeSignal.value = 'overview';
+			currentSpaceSessionIdSignal.value = null;
+			currentSpaceTaskIdSignal.value = null;
+			currentRoomIdSignal.value = null;
+			currentRoomActiveTabSignal.value = null;
+			currentRoomSessionIdSignal.value = null;
+			currentRoomTaskIdSignal.value = null;
+			currentRoomGoalIdSignal.value = null;
+			currentRoomAgentActiveSignal.value = false;
+			currentRoomActiveTabSignal.value = null;
+			currentSessionIdSignal.value = sessionId;
+			if (!sessionId) {
+				navSectionSignal.value = 'rooms';
+			}
 		}
-	}
+	}); // end batch()
 }
 
 /**

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -53,6 +53,7 @@ const SPACE_TASKS_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/tasks$/;
 const SPACE_AGENT_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/agent$/;
 const SPACE_SESSION_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/session\/([a-fA-F0-9-]+)$/;
 const SPACE_TASK_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/task\/([a-fA-F0-9-]+|[a-z]-[1-9]\d*)$/;
+const SPACE_SESSIONS_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/sessions$/;
 
 /**
  * Router state and configuration
@@ -177,7 +178,10 @@ export function getSpaceIdFromPath(path: string): string | null {
 	if (spaceSessionMatch) return spaceSessionMatch[1];
 
 	const spaceTaskMatch = path.match(SPACE_TASK_ROUTE_PATTERN);
-	return spaceTaskMatch ? spaceTaskMatch[1] : null;
+	if (spaceTaskMatch) return spaceTaskMatch[1];
+
+	const spaceSessionsMatch = path.match(SPACE_SESSIONS_ROUTE_PATTERN);
+	return spaceSessionsMatch ? spaceSessionsMatch[1] : null;
 }
 
 /**
@@ -204,6 +208,15 @@ export function getSpaceConfigureFromPath(path: string): string | null {
  */
 export function getSpaceTasksFromPath(path: string): string | null {
 	const match = path.match(SPACE_TASKS_ROUTE_PATTERN);
+	return match ? match[1] : null;
+}
+
+/**
+ * Extract space ID from /space/:id/sessions route
+ * Returns null if not on a space sessions list route
+ */
+export function getSpaceSessionsListFromPath(path: string): string | null {
+	const match = path.match(SPACE_SESSIONS_ROUTE_PATTERN);
 	return match ? match[1] : null;
 }
 
@@ -362,6 +375,13 @@ export function createSpaceSessionPath(spaceId: string, sessionId: string): stri
  */
 export function createSpaceTaskPath(spaceId: string, taskId: string): string {
 	return `/space/${spaceId}/task/${taskId}`;
+}
+
+/**
+ * Create space sessions list URL path
+ */
+export function createSpaceSessionsPath(spaceId: string): string {
+	return `/space/${spaceId}/sessions`;
 }
 
 /**
@@ -1203,6 +1223,59 @@ export function navigateToSpaceTasks(spaceId: string, replace = false): void {
 }
 
 /**
+ * Navigate to the Space sessions list view
+ * Updates URL to /space/:spaceId/sessions and keeps the space context panel active
+ */
+export function navigateToSpaceSessions(spaceId: string, replace = false): void {
+	if (routerState.isNavigating) {
+		return;
+	}
+
+	const targetPath = createSpaceSessionsPath(spaceId);
+	const currentPath = getCurrentPath();
+
+	if (currentPath === targetPath) {
+		currentSpaceIdSignal.value = spaceId;
+		currentSpaceViewModeSignal.value = 'sessions';
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		currentSessionIdSignal.value = null;
+		currentRoomIdSignal.value = null;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
+		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
+		navSectionSignal.value = 'spaces';
+		return;
+	}
+
+	routerState.isNavigating = true;
+
+	try {
+		const historyMethod = replace ? 'replaceState' : 'pushState';
+		window.history[historyMethod]({ spaceId, path: targetPath }, '', targetPath);
+
+		currentSpaceIdSignal.value = spaceId;
+		currentSpaceViewModeSignal.value = 'sessions';
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		currentSessionIdSignal.value = null;
+		currentRoomIdSignal.value = null;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
+		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
+		navSectionSignal.value = 'spaces';
+	} finally {
+		setTimeout(() => {
+			routerState.isNavigating = false;
+		}, 0);
+	}
+}
+
+/**
  * Navigate to a session within a space layout
  */
 export function navigateToSpaceSession(spaceId: string, sessionId: string, replace = false): void {
@@ -1380,6 +1453,7 @@ function handlePopState(_event: PopStateEvent): void {
 	const roomTask = getRoomTaskIdFromPath(path);
 	const spaceConfigure = getSpaceConfigureFromPath(path);
 	const spaceTasks = getSpaceTasksFromPath(path);
+	const spaceSessions = getSpaceSessionsListFromPath(path);
 	const spaceTask = getSpaceTaskIdFromPath(path);
 	const spaceSession = getSpaceSessionIdFromPath(path);
 	const spaceAgent = getSpaceAgentFromPath(path);
@@ -1432,6 +1506,19 @@ function handlePopState(_event: PopStateEvent): void {
 	} else if (spaceTasks) {
 		currentSpaceIdSignal.value = spaceTasks;
 		currentSpaceViewModeSignal.value = 'tasks';
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		currentRoomIdSignal.value = null;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
+		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
+		currentSessionIdSignal.value = null;
+		navSectionSignal.value = 'spaces';
+	} else if (spaceSessions) {
+		currentSpaceIdSignal.value = spaceSessions;
+		currentSpaceViewModeSignal.value = 'sessions';
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = null;
@@ -1633,6 +1720,7 @@ export function initializeRouter(): string | null {
 	const initialRoomTask = getRoomTaskIdFromPath(initialPath);
 	const initialSpaceConfigure = getSpaceConfigureFromPath(initialPath);
 	const initialSpaceTasks = getSpaceTasksFromPath(initialPath);
+	const initialSpaceSessions = getSpaceSessionsListFromPath(initialPath);
 	const initialSpaceTask = getSpaceTaskIdFromPath(initialPath);
 	const initialSpaceSession = getSpaceSessionIdFromPath(initialPath);
 	const initialSpaceAgent = getSpaceAgentFromPath(initialPath);
@@ -1695,6 +1783,19 @@ export function initializeRouter(): string | null {
 	} else if (initialSpaceTasks) {
 		currentSpaceIdSignal.value = initialSpaceTasks;
 		currentSpaceViewModeSignal.value = 'tasks';
+		currentSpaceSessionIdSignal.value = null;
+		currentSpaceTaskIdSignal.value = null;
+		currentRoomIdSignal.value = null;
+		currentRoomSessionIdSignal.value = null;
+		currentRoomTaskIdSignal.value = null;
+		currentRoomGoalIdSignal.value = null;
+		currentRoomAgentActiveSignal.value = false;
+		currentRoomActiveTabSignal.value = null;
+		currentSessionIdSignal.value = null;
+		navSectionSignal.value = 'spaces';
+	} else if (initialSpaceSessions) {
+		currentSpaceIdSignal.value = initialSpaceSessions;
+		currentSpaceViewModeSignal.value = 'sessions';
 		currentSpaceSessionIdSignal.value = null;
 		currentSpaceTaskIdSignal.value = null;
 		currentRoomIdSignal.value = null;

--- a/packages/web/src/lib/signals.ts
+++ b/packages/web/src/lib/signals.ts
@@ -43,7 +43,7 @@ export const navSectionSignal = signal<NavSection>('rooms');
 export const currentSpaceIdSignal = signal<string | null>(null);
 export const currentSpaceSessionIdSignal = signal<string | null>(null);
 export const currentSpaceTaskIdSignal = signal<string | null>(null);
-export type SpaceViewMode = 'overview' | 'tasks' | 'configure';
+export type SpaceViewMode = 'overview' | 'tasks' | 'sessions' | 'configure';
 export const currentSpaceViewModeSignal = signal<SpaceViewMode>('overview');
 
 // Overlay signals — session shown in slide-over panel on top of the current view

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -37,7 +37,13 @@ export default defineConfig({
 		port: 9283,
 		strictPort: true,
 		host: true,
-		allowedHosts: ['localhost', '127.0.0.1', 'ai0.tailcd822a.ts.net', 'tts.tailcd822a.ts.net'],
+		allowedHosts: [
+			'localhost',
+			'127.0.0.1',
+			'ai0.tailcd822a.ts.net',
+			'tts.tailcd822a.ts.net',
+			'tts',
+		],
 		hmr: {
 			overlay: true,
 			protocol: 'ws',


### PR DESCRIPTION
Adds `/space/:id/sessions` page and Sessions tab so users can browse their space sessions from both the sidebar and the mobile bottom tab bar.

- New `SpaceSessionsPage` component — lists user-created sessions (excludes system task/workflow sessions), sorted by `lastActiveAt`, click to navigate into session
- Sessions nav button in `SpaceDetailPanel` sidebar (below Tasks, shows session count badge)
- `space-sessions` tab added to `SPACE_BOTTOM_TABS` between Tasks and Agent
- `SpaceViewMode` union extended with `'sessions'`
- Full router wiring: route pattern, extractor, path creator, `navigateToSpaceSessions()`, `handlePopState`, `initializeRouter`, and `App.tsx` URL sync