### PR TITLE
feat(space): attention LiveQuery and Action tab with reason-based grouping

### DIFF
--- a/docs/space-autonomy-hitl-gaps-claude-opus-4-6.md
+++ b/docs/space-autonomy-hitl-gaps-claude-opus-4-6.md
@@ -80,15 +80,37 @@ Tasks track `prUrl`, `prNumber`, `prCreatedAt` but:
 
 ---
 
-### 2. Approval Notification/Queue UI
+### 2. Approval Notification/Queue UI ✅ PR #TBD
 
 Gates support `writers: ['human']` and `spaceWorkflowRun.approveGate` RPC exists. However:
-- No notification to tell humans a gate is waiting
-- No inbox/queue of pending approvals in the UI
+- ~~No notification to tell humans a gate is waiting~~
+- ~~No inbox/queue of pending approvals in the UI~~
 - No webhook/Slack/email integration for approval requests
-- Human must manually check the workflow run state to discover pending gates
+- ~~Human must manually check the workflow run state to discover pending gates~~
+
+**Implemented:**
+- LiveQuery `spaceTasks.needingAttention` — real-time attention task tracking (review + human-blocked)
+- "Action" tab in SpaceTasks — groups tasks by reason: Needs Input, Gate Pending, Awaiting Review, Blocked
+- Amber attention badge on Tasks sidebar button and SpacesPage cards
+- LiveQuery-backed counts survive reconnect (no missed notifications)
 
 **Impact:** Medium — humans don't know when approval is needed  
+**Effort:** Medium
+
+---
+
+### 2b. Action UI (Approve/Reject/Resolve)
+
+Gap #2 surfaces *that* tasks need human attention, but there is no UI for *taking* that action.
+
+Missing:
+- Approve/reject buttons for gate-pending tasks (`spaceWorkflowRun.approveGate` RPC exists but has no UI)
+- Input form for `human_input_requested` tasks (agent asked a question, human has no way to answer)
+- "Mark done" / "Re-open" actions for tasks in `review` status
+- Contextual display of *why* the task is blocked (gate message, agent's question, dependency chain)
+
+**Depends on:** Gap #2 (notification/queue), Gap #8 (block reasons)  
+**Impact:** High — without action UI, the notification queue is informational only  
 **Effort:** Medium
 
 ---
@@ -226,6 +248,7 @@ Workflow topology is fixed regardless of autonomy level:
 |---|-----|--------|--------|----------|
 | 1 | PR auto-merge for semi-autonomous | High | Medium | **P0** |
 | 2 | Approval notification/queue UI | Medium | Medium | **P1** |
+| 2b | Action UI (approve/reject/resolve) | High | Medium | **P1** |
 | 3 | Approval audit trail | Medium | Low | **P1** |
 | 4 | Execution-time autonomy differentiation | High | High | **P2** |
 | 5 | Task dependency enforcement | Medium | Medium | **P2** |
@@ -239,20 +262,20 @@ Workflow topology is fixed regardless of autonomy level:
 
 ```
 Gap 3 (Audit Trail) ──────┐
-                           ├──► Gap 2 (Notification UI) ──► Gap 1 (PR Auto-Merge)
-Gap 8 (block reasons) ────┘         │
-                                    ▼
-Gap 5 (Dependency Enforcement)  Gap 9 (Review SLA)
-                                    │
-Gap 6 (Tiered Retry) ──────────────┤
-                                    ▼
-                            Gap 4 (Execution-Time Autonomy)
-                                    │
-                                    ▼
-                            Gap 10 (Conditional Branching)
-                                    │
-                                    ▼
-                            Gap 7 (Room/Space Unification)
+                           ├──► Gap 2 (Notification UI) ──► Gap 2b (Action UI) ──► Gap 1 (PR Auto-Merge)
+Gap 8 (block reasons) ────┘                                       │
+                                                                  ▼
+Gap 5 (Dependency Enforcement)                              Gap 9 (Review SLA)
+                                                                  │
+Gap 6 (Tiered Retry) ────────────────────────────────────────────┤
+                                                                  ▼
+                                                          Gap 4 (Execution-Time Autonomy)
+                                                                  │
+                                                                  ▼
+                                                          Gap 10 (Conditional Branching)
+                                                                  │
+                                                                  ▼
+                                                          Gap 7 (Room/Space Unification)
 ```
 
 ### Recommended Implementation Sequence
@@ -263,12 +286,13 @@ Gap 6 (Tiered Retry) ──────────────┤
 | 2 | **#8 Block reason tagging** | Foundation — distinguishes block types for notifications & retry | Low | **Done** (PR #1486) |
 | 3 | **#5 Dependency enforcement** | Standalone, no deps, fixes correctness issue | Medium | **Done** (PR #1488) |
 | 4 | **#2 Notification UI** | Builds on 3+8, unlocks human-in-the-loop usability | Medium | |
-| 5 | **#9 Review SLA** | Small, builds on audit trail | Low | |
-| 6 | **#6 Tiered retry** | Standalone, but informed by needs_attention distinction | Medium | |
-| 7 | **#1 PR auto-merge** | Needs audit trail + notification infra in place | Medium | |
-| 8 | **#4 Execution-time autonomy** | Builds on retry + needs_attention + audit | High | |
-| 9 | **#10 Conditional branching** | Extends execution-time autonomy into workflow topology | High | |
-| 10 | **#7 Room/Space unification** | Last — needs both systems mature before merging patterns | High | |
+| 5 | **#2b Action UI** | Builds on #2, makes notification queue actionable | Medium | |
+| 6 | **#9 Review SLA** | Small, builds on audit trail | Low | |
+| 7 | **#6 Tiered retry** | Standalone, but informed by needs_attention distinction | Medium | |
+| 8 | **#1 PR auto-merge** | Needs audit trail + notification + action UI in place | Medium | |
+| 9 | **#4 Execution-time autonomy** | Builds on retry + needs_attention + audit | High | |
+| 10 | **#10 Conditional branching** | Extends execution-time autonomy into workflow topology | High | |
+| 11 | **#7 Room/Space unification** | Last — needs both systems mature before merging patterns | High | |
 
 ## Key Files Reference
 

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -908,6 +908,25 @@ function mapSessionRow(row: Record<string, unknown>): Record<string, unknown> {
 	};
 }
 
+const SPACE_TASKS_NEEDING_ATTENTION_SQL = `
+SELECT
+  st.id AS id,
+  st.title AS title,
+  st.status AS status,
+  st.block_reason AS blockReason,
+  st.result AS result,
+  st.task_number AS taskNumber,
+  st.space_id AS spaceId,
+  st.updated_at AS updatedAt
+FROM space_tasks st
+WHERE st.space_id = ?
+  AND (
+    st.status = 'review'
+    OR (st.status = 'blocked' AND st.block_reason IN ('human_input_requested', 'gate_rejected'))
+  )
+ORDER BY st.updated_at DESC, st.id DESC
+`.trim();
+
 const SPACE_SESSIONS_BY_SPACE_SQL = `
 SELECT
   s.id as id,
@@ -1021,6 +1040,13 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 		'nodeExecutions.byRun',
 		{
 			sql: NODE_EXECUTIONS_BY_RUN_SQL,
+			paramCount: 1,
+		},
+	],
+	[
+		'spaceTasks.needingAttention',
+		{
+			sql: SPACE_TASKS_NEEDING_ATTENTION_SQL,
 			paramCount: 1,
 		},
 	],

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { Database as BunDatabase } from 'bun:sqlite';
-import { createTables, runMigration74 } from '../../../../src/storage/schema';
+import { createTables, runMigration74, runMigrations } from '../../../../src/storage/schema';
 import { NAMED_QUERY_REGISTRY } from '../../../../src/lib/rpc-handlers/live-query-handlers';
 import type { NeoTask, RoomGoal } from '@neokai/shared';
 
@@ -52,6 +52,7 @@ describe('NAMED_QUERY_REGISTRY', () => {
 		expect(NAMED_QUERY_REGISTRY.has('sessionGroupMessages.byGroup')).toBe(true);
 		expect(NAMED_QUERY_REGISTRY.has('spaceTaskActivity.byTask')).toBe(true);
 		expect(NAMED_QUERY_REGISTRY.has('spaceTaskMessages.byTask')).toBe(true);
+		expect(NAMED_QUERY_REGISTRY.has('spaceTasks.needingAttention')).toBe(true);
 		expect(NAMED_QUERY_REGISTRY.has('skills.byRoom')).toBe(true);
 		expect(NAMED_QUERY_REGISTRY.has('neo.messages')).toBe(true);
 		expect(NAMED_QUERY_REGISTRY.has('neo.activity')).toBe(true);
@@ -1065,6 +1066,139 @@ describe('NAMED_QUERY_REGISTRY', () => {
 				const hasIdTiebreaker = /\bID\s+(ASC|DESC)\s*$/.test(sqlForCheck);
 				expect(hasIdTiebreaker).toBe(true, `${name} ORDER BY lacks deterministic id tiebreaker`);
 			}
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// spaceTasks.needingAttention — attention filter by status + block reason
+	// -------------------------------------------------------------------------
+
+	describe('spaceTasks.needingAttention', () => {
+		const spaceId = 'space-attention-test';
+		let attDb: BunDatabase;
+		let taskSeq = 0;
+
+		beforeEach(() => {
+			attDb = new BunDatabase(':memory:');
+			createTables(attDb);
+			runMigrations(attDb, () => {});
+			attDb.exec(
+				`INSERT OR IGNORE INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+				 VALUES ('${spaceId}', '${spaceId}', '/tmp/test', 'Test Space', ${now}, ${now})`
+			);
+			taskSeq = 0;
+		});
+
+		afterEach(() => {
+			attDb.close();
+		});
+
+		function insertAttentionTask(overrides: Record<string, unknown> = {}): string {
+			taskSeq++;
+			const id = (overrides.id as string) ?? `att-task-${taskSeq}`;
+			const status = (overrides.status as string) ?? 'open';
+			const blockReason = (overrides.blockReason as string | null) ?? null;
+			attDb.exec(`
+				INSERT INTO space_tasks (
+					id, space_id, task_number, title, description, status, priority,
+					depends_on, block_reason, created_at, updated_at
+				) VALUES (
+					'${id}', '${spaceId}', ${taskSeq}, 'Task ${taskSeq}', '', '${status}',
+					'normal', '[]',
+					${blockReason ? `'${blockReason}'` : 'NULL'},
+					${now}, ${now}
+				)
+			`);
+			return id;
+		}
+
+		function queryAttention(): Record<string, unknown>[] {
+			const entry = NAMED_QUERY_REGISTRY.get('spaceTasks.needingAttention')!;
+			return attDb.prepare(entry.sql).all(spaceId) as Record<string, unknown>[];
+		}
+
+		test('returns tasks in review status', () => {
+			insertAttentionTask({ status: 'review' });
+			insertAttentionTask({ status: 'open' }); // should not appear
+			const rows = queryAttention();
+			expect(rows).toHaveLength(1);
+			expect(rows[0].status).toBe('review');
+		});
+
+		test('returns blocked tasks with human_input_requested', () => {
+			insertAttentionTask({ status: 'blocked', blockReason: 'human_input_requested' });
+			insertAttentionTask({ status: 'blocked', blockReason: 'agent_crashed' }); // should not appear
+			const rows = queryAttention();
+			expect(rows).toHaveLength(1);
+			expect(rows[0].blockReason).toBe('human_input_requested');
+		});
+
+		test('returns blocked tasks with gate_rejected', () => {
+			insertAttentionTask({ status: 'blocked', blockReason: 'gate_rejected' });
+			const rows = queryAttention();
+			expect(rows).toHaveLength(1);
+			expect(rows[0].blockReason).toBe('gate_rejected');
+		});
+
+		test('excludes non-attention statuses', () => {
+			insertAttentionTask({ status: 'open' });
+			insertAttentionTask({ status: 'in_progress' });
+			insertAttentionTask({ status: 'done' });
+			insertAttentionTask({ status: 'cancelled' });
+			insertAttentionTask({ status: 'blocked', blockReason: 'agent_crashed' });
+			insertAttentionTask({ status: 'blocked', blockReason: 'workflow_invalid' });
+			const rows = queryAttention();
+			expect(rows).toHaveLength(0);
+		});
+
+		test('returns combined review + human-blocked tasks sorted by updatedAt desc', () => {
+			const id1 = insertAttentionTask({ status: 'review' });
+			const id2 = insertAttentionTask({ status: 'blocked', blockReason: 'human_input_requested' });
+			const id3 = insertAttentionTask({ status: 'blocked', blockReason: 'gate_rejected' });
+			// Update timestamps so ordering is deterministic
+			attDb.exec(`UPDATE space_tasks SET updated_at = ${now + 300} WHERE id = '${id3}'`);
+			attDb.exec(`UPDATE space_tasks SET updated_at = ${now + 200} WHERE id = '${id2}'`);
+			attDb.exec(`UPDATE space_tasks SET updated_at = ${now + 100} WHERE id = '${id1}'`);
+
+			const rows = queryAttention();
+			expect(rows).toHaveLength(3);
+			expect(rows[0].id).toBe(id3);
+			expect(rows[1].id).toBe(id2);
+			expect(rows[2].id).toBe(id1);
+		});
+
+		test('only returns tasks for the given space', () => {
+			insertAttentionTask({ status: 'review' });
+			// Insert task in a different space
+			attDb.exec(
+				`INSERT OR IGNORE INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+				 VALUES ('other-space', 'other', '/tmp/other', 'Other', ${now}, ${now})`
+			);
+			attDb.exec(`
+				INSERT INTO space_tasks (
+					id, space_id, task_number, title, description, status, priority,
+					depends_on, created_at, updated_at
+				) VALUES (
+					'other-task', 'other-space', 1, 'Other Task', '', 'review',
+					'normal', '[]', ${now}, ${now}
+				)
+			`);
+			const rows = queryAttention();
+			expect(rows).toHaveLength(1);
+			expect(rows[0].spaceId).toBe(spaceId);
+		});
+
+		test('row shape includes expected columns', () => {
+			insertAttentionTask({ status: 'blocked', blockReason: 'human_input_requested' });
+			const rows = queryAttention();
+			const row = rows[0];
+			expect(row.id).toBeDefined();
+			expect(row.title).toBeDefined();
+			expect(row.status).toBe('blocked');
+			expect(row.blockReason).toBe('human_input_requested');
+			expect(row.taskNumber).toBe(1);
+			expect(row.spaceId).toBe(spaceId);
+			expect(row.updatedAt).toBeDefined();
 		});
 	});
 });

--- a/packages/web/src/components/space/SpaceTasks.tsx
+++ b/packages/web/src/components/space/SpaceTasks.tsx
@@ -1,23 +1,26 @@
 /**
  * SpaceTasks — tabbed task list for a space.
  *
- * Tabs: Active (open + in_progress), Review (blocked + review),
+ * Tabs: Action (review + blocked, grouped by reason), Active (open + in_progress),
  *       Completed (done + cancelled), Archived.
  *
- * Within each tab, tasks are grouped by status in TaskGroup cards,
+ * Within each tab, tasks are grouped by status/reason in TaskGroup cards,
  * matching the RoomTasks component style.
  */
 
 import { useMemo, useState } from 'preact/hooks';
 import { spaceStore } from '../../lib/space-store';
-import type { SpaceTask, SpaceTaskStatus } from '@neokai/shared';
+import type { SpaceBlockReason, SpaceTask, SpaceTaskStatus } from '@neokai/shared';
 import { getRelativeTime } from '../../lib/utils';
 
-type TaskFilterTab = 'active' | 'review' | 'completed' | 'archived';
+type TaskFilterTab = 'action' | 'active' | 'completed' | 'archived';
+
+/** Block reasons that indicate a task needs human attention */
+const ATTENTION_BLOCK_REASONS: SpaceBlockReason[] = ['human_input_requested', 'gate_rejected'];
 
 const TAB_GROUPS: Record<TaskFilterTab, SpaceTaskStatus[]> = {
+	action: ['review', 'blocked'],
 	active: ['open', 'in_progress'],
-	review: ['blocked', 'review'],
 	completed: ['done', 'cancelled'],
 	archived: ['archived'],
 };
@@ -47,16 +50,39 @@ interface StatusGroupDef {
 	status: SpaceTaskStatus;
 	title: string;
 	variant: 'default' | 'yellow' | 'purple' | 'green' | 'red' | 'gray';
+	/** Optional filter override; when provided, used instead of status-only matching */
+	filterFn?: (task: SpaceTask) => boolean;
 }
+
+const ACTION_GROUPS: StatusGroupDef[] = [
+	{
+		status: 'blocked',
+		title: 'Needs Input',
+		variant: 'red',
+		filterFn: (t) =>
+			t.status === 'blocked' && (t.blockReason as SpaceBlockReason) === 'human_input_requested',
+	},
+	{
+		status: 'blocked',
+		title: 'Gate Pending',
+		variant: 'red',
+		filterFn: (t) =>
+			t.status === 'blocked' && (t.blockReason as SpaceBlockReason) === 'gate_rejected',
+	},
+	{ status: 'review', title: 'Awaiting Review', variant: 'purple' },
+	{
+		status: 'blocked',
+		title: 'Blocked',
+		variant: 'yellow',
+		filterFn: (t) =>
+			t.status === 'blocked' &&
+			!ATTENTION_BLOCK_REASONS.includes(t.blockReason as SpaceBlockReason),
+	},
+];
 
 const ACTIVE_GROUPS: StatusGroupDef[] = [
 	{ status: 'in_progress', title: 'In Progress', variant: 'yellow' },
 	{ status: 'open', title: 'Open', variant: 'default' },
-];
-
-const REVIEW_GROUPS: StatusGroupDef[] = [
-	{ status: 'blocked', title: 'Blocked', variant: 'red' },
-	{ status: 'review', title: 'Awaiting Review', variant: 'purple' },
 ];
 
 const COMPLETED_GROUPS: StatusGroupDef[] = [
@@ -69,8 +95,8 @@ const ARCHIVED_GROUPS: StatusGroupDef[] = [
 ];
 
 const TAB_GROUPS_DEF: Record<TaskFilterTab, StatusGroupDef[]> = {
+	action: ACTION_GROUPS,
 	active: ACTIVE_GROUPS,
-	review: REVIEW_GROUPS,
 	completed: COMPLETED_GROUPS,
 	archived: ARCHIVED_GROUPS,
 };
@@ -86,7 +112,7 @@ function TabButton({
 	count: number;
 	isActive: boolean;
 	onClick: () => void;
-	variant?: 'default' | 'purple' | 'green' | 'red' | 'gray';
+	variant?: 'default' | 'amber' | 'purple' | 'green' | 'red' | 'gray';
 }) {
 	const baseClasses =
 		'px-4 py-2 text-sm font-medium transition-colors relative flex items-center gap-1.5';
@@ -94,6 +120,9 @@ function TabButton({
 	const variantClasses: Record<string, string> = {
 		default: isActive
 			? 'text-blue-400 border-b-2 border-blue-400'
+			: 'text-gray-400 hover:text-gray-300 border-b-2 border-transparent',
+		amber: isActive
+			? 'text-amber-400 border-b-2 border-amber-400'
 			: 'text-gray-400 hover:text-gray-300 border-b-2 border-transparent',
 		purple: isActive
 			? 'text-purple-400 border-b-2 border-purple-400'
@@ -115,15 +144,17 @@ function TabButton({
 			{count > 0 && (
 				<span
 					class={`text-xs px-1.5 py-0.5 rounded ${
-						variant === 'purple'
-							? 'bg-purple-900/30'
-							: variant === 'green'
-								? 'bg-green-900/30'
-								: variant === 'red'
-									? 'bg-red-900/30'
-									: variant === 'gray'
-										? 'bg-dark-800'
-										: 'bg-dark-700'
+						variant === 'amber'
+							? 'bg-amber-900/30'
+							: variant === 'purple'
+								? 'bg-purple-900/30'
+								: variant === 'green'
+									? 'bg-green-900/30'
+									: variant === 'red'
+										? 'bg-red-900/30'
+										: variant === 'gray'
+											? 'bg-dark-800'
+											: 'bg-dark-700'
 					}`}
 				>
 					{count}
@@ -135,8 +166,11 @@ function TabButton({
 
 function EmptyTabState({ tab }: { tab: TaskFilterTab }) {
 	const messages: Record<TaskFilterTab, { title: string; description: string }> = {
+		action: {
+			title: 'No tasks needing action',
+			description: 'Tasks requiring human input, review, or unblocking will appear here',
+		},
 		active: { title: 'No active tasks', description: 'Active tasks will appear here' },
-		review: { title: 'No tasks to review', description: 'Tasks needing review will appear here' },
 		completed: { title: 'No completed tasks', description: 'Completed tasks will appear here' },
 		archived: { title: 'No archived tasks', description: 'Archived tasks will appear here' },
 	};
@@ -258,7 +292,12 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 	const [activeTab, setActiveTab] = useState<TaskFilterTab>('active');
 
 	const counts = useMemo(() => {
-		const c: Record<TaskFilterTab, number> = { active: 0, review: 0, completed: 0, archived: 0 };
+		const c: Record<TaskFilterTab, number> = {
+			action: 0,
+			active: 0,
+			completed: 0,
+			archived: 0,
+		};
 		for (const task of tasks) {
 			for (const [tab, statuses] of Object.entries(TAB_GROUPS) as [
 				TaskFilterTab,
@@ -307,17 +346,17 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 			<div class="min-h-[calc(100%+1px)] space-y-6">
 				<div class="flex border-b border-dark-700">
 					<TabButton
+						label="Action"
+						count={counts.action}
+						isActive={activeTab === 'action'}
+						onClick={() => setActiveTab('action')}
+						variant="amber"
+					/>
+					<TabButton
 						label="Active"
 						count={counts.active}
 						isActive={activeTab === 'active'}
 						onClick={() => setActiveTab('active')}
-					/>
-					<TabButton
-						label="Review"
-						count={counts.review}
-						isActive={activeTab === 'review'}
-						onClick={() => setActiveTab('review')}
-						variant="purple"
 					/>
 					<TabButton
 						label="Completed"
@@ -360,11 +399,12 @@ function TaskGroupList({
 	return (
 		<div class="space-y-4">
 			{groups.map((group) => {
-				const groupTasks = tasks.filter((t) => t.status === group.status);
+				const filterFn = group.filterFn ?? ((t: SpaceTask) => t.status === group.status);
+				const groupTasks = tasks.filter(filterFn);
 				if (groupTasks.length === 0) return null;
 				return (
 					<TaskGroup
-						key={group.status}
+						key={group.title}
 						title={group.title}
 						count={groupTasks.length}
 						variant={group.variant}

--- a/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
@@ -9,10 +9,11 @@ import { signal } from '@preact/signals';
 import type { SpaceTask } from '@neokai/shared';
 
 let mockTasks: ReturnType<typeof signal<SpaceTask[]>>;
+let mockAttentionCount: ReturnType<typeof signal<number>>;
 
 vi.mock('../../../lib/space-store', () => ({
 	get spaceStore() {
-		return { tasks: mockTasks };
+		return { tasks: mockTasks, attentionCount: mockAttentionCount };
 	},
 }));
 
@@ -22,6 +23,7 @@ vi.mock('../../../lib/utils', () => ({
 }));
 
 mockTasks = signal<SpaceTask[]>([]);
+mockAttentionCount = signal<number>(0);
 
 import { SpaceTasks } from '../SpaceTasks';
 
@@ -54,6 +56,7 @@ describe('SpaceTasks', () => {
 	beforeEach(() => {
 		cleanup();
 		mockTasks.value = [];
+		mockAttentionCount.value = 0;
 	});
 
 	afterEach(() => {
@@ -63,8 +66,8 @@ describe('SpaceTasks', () => {
 	it('renders all four tabs', () => {
 		mockTasks.value = [makeTask('t1', 'open')];
 		const { getByText } = render(<SpaceTasks spaceId="space-1" />);
+		expect(getByText('Action')).toBeTruthy();
 		expect(getByText('Active')).toBeTruthy();
-		expect(getByText('Review')).toBeTruthy();
 		expect(getByText('Completed')).toBeTruthy();
 		expect(getByText('Archived')).toBeTruthy();
 	});
@@ -75,11 +78,11 @@ describe('SpaceTasks', () => {
 		expect(getByText('Create a task to get started')).toBeTruthy();
 	});
 
-	it('shows empty state for review tab', () => {
+	it('shows empty state for action tab', () => {
 		mockTasks.value = [makeTask('t1', 'open')];
 		const { getByText } = render(<SpaceTasks spaceId="space-1" />);
-		fireEvent.click(getByText('Review'));
-		expect(getByText('No tasks to review')).toBeTruthy();
+		fireEvent.click(getByText('Action'));
+		expect(getByText('No tasks needing action')).toBeTruthy();
 	});
 
 	it('shows empty state for completed tab', () => {
@@ -104,10 +107,10 @@ describe('SpaceTasks', () => {
 		expect(queryByText('No active tasks')).toBeNull();
 	});
 
-	it('displays tasks in review tab (blocked + review)', () => {
+	it('displays tasks in action tab (blocked + review)', () => {
 		mockTasks.value = [makeTask('t1', 'blocked'), makeTask('t2', 'review')];
 		const { getByText } = render(<SpaceTasks spaceId="space-1" />);
-		fireEvent.click(getByText('Review'));
+		fireEvent.click(getByText('Action'));
 		expect(getByText('Task t1')).toBeTruthy();
 		expect(getByText('Task t2')).toBeTruthy();
 	});
@@ -142,7 +145,7 @@ describe('SpaceTasks', () => {
 		const text = Array.from(buttons).map((b) => b.textContent ?? '');
 
 		expect(text.some((t) => t?.includes('Active') && t?.includes('2'))).toBe(true);
-		expect(text.some((t) => t?.includes('Review') && t?.includes('2'))).toBe(true);
+		expect(text.some((t) => t?.includes('Action') && t?.includes('2'))).toBe(true);
 		expect(text.some((t) => t?.includes('Completed') && t?.includes('2'))).toBe(true);
 		expect(text.some((t) => t?.includes('Archived') && t?.includes('1'))).toBe(true);
 	});

--- a/packages/web/src/islands/SpaceDetailPanel.tsx
+++ b/packages/web/src/islands/SpaceDetailPanel.tsx
@@ -23,7 +23,7 @@ import {
 } from '../lib/signals';
 import { cn } from '../lib/utils';
 
-type TaskTab = 'active' | 'review';
+type TaskTab = 'active' | 'action';
 
 const sessionStatusColors: Record<string, string> = {
 	active: 'bg-green-500',
@@ -101,7 +101,7 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 	const selectedTaskId = currentSpaceTaskIdSignal.value;
 	const spaceAgentSessionId = `space:chat:${spaceId}`;
 
-	const [taskTab, setTaskTab] = useState<TaskTab>('review');
+	const [taskTab, setTaskTab] = useState<TaskTab>('action');
 
 	// Auto-switch tab when selectedTaskId or task status changes
 	useEffect(() => {
@@ -109,9 +109,9 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 		const task = tasks.find((t) => t.id === selectedTaskId);
 		if (!task) return;
 		const isActive = task.status === 'open' || task.status === 'in_progress';
-		const isReview = task.status === 'blocked' || task.status === 'review';
+		const isAction = task.status === 'blocked' || task.status === 'review';
 		if (isActive && taskTab !== 'active') setTaskTab('active');
-		else if (isReview && taskTab !== 'review') setTaskTab('review');
+		else if (isAction && taskTab !== 'action') setTaskTab('action');
 	}, [selectedTaskId, tasks]);
 
 	const isOverviewSelected =
@@ -121,21 +121,23 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 	const isSpaceAgentSelected = selectedSessionId === spaceAgentSessionId;
 	const isTasksSelected = currentSpaceViewModeSignal.value === 'tasks';
 
-	const { activeCount, reviewCount } = useMemo(() => {
+	const attentionCount = spaceStore.attentionCount.value;
+
+	const { activeCount, actionCount } = useMemo(() => {
 		let active = 0;
-		let review = 0;
+		let action = 0;
 		for (const task of tasks) {
 			if (task.status === 'open' || task.status === 'in_progress') active++;
-			else if (task.status === 'blocked' || task.status === 'review') review++;
+			else if (task.status === 'blocked' || task.status === 'review') action++;
 		}
-		return { activeCount: active, reviewCount: review };
+		return { activeCount: active, actionCount: action };
 	}, [tasks]);
 
 	const tasksForTab = useMemo(() => {
 		const sorted = [...tasks].sort((a, b) => b.updatedAt - a.updatedAt);
 		let filtered: typeof sorted;
 
-		if (taskTab === 'review') {
+		if (taskTab === 'action') {
 			filtered = sorted.filter((task) => task.status === 'blocked' || task.status === 'review');
 		} else {
 			filtered = sorted.filter((task) => task.status === 'open' || task.status === 'in_progress');
@@ -294,6 +296,11 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 					</svg>
 				</div>
 				<span class="flex-1 text-sm text-gray-200 text-left truncate">Tasks</span>
+				{attentionCount > 0 && (
+					<span class="flex-shrink-0 min-w-[20px] h-5 px-1.5 rounded-full bg-amber-600 text-white text-xs font-medium flex items-center justify-center tabular-nums">
+						{attentionCount}
+					</span>
+				)}
 			</button>
 
 			<div class="border-t border-dark-700 mx-3 my-3" />
@@ -308,10 +315,10 @@ export function SpaceDetailPanel({ spaceId, onNavigate }: SpaceDetailPanelProps)
 							onClick={() => setTaskTab('active')}
 						/>
 						<TaskTabButton
-							label="Review"
-							count={reviewCount}
-							active={taskTab === 'review'}
-							onClick={() => setTaskTab('review')}
+							label="Action"
+							count={actionCount}
+							active={taskTab === 'action'}
+							onClick={() => setTaskTab('action')}
 						/>
 					</div>
 					{tasksForTab.length === 0 ? (

--- a/packages/web/src/islands/SpacesPage.tsx
+++ b/packages/web/src/islands/SpacesPage.tsx
@@ -59,9 +59,17 @@ function SessionRow({ session }: { session: SpaceSessionSummary }) {
 	);
 }
 
+/** Block reasons that indicate a task needs human attention */
+const ATTENTION_REASONS = ['human_input_requested', 'gate_rejected'];
+
 function SpaceCard({ space }: { space: SpaceWithTasks }) {
 	const activeTasks = space.tasks.filter(
 		(t) => t.status === 'open' || t.status === 'in_progress' || t.status === 'review'
+	);
+	const attentionTasks = space.tasks.filter(
+		(t) =>
+			t.status === 'review' ||
+			(t.status === 'blocked' && ATTENTION_REASONS.includes(t.blockReason ?? ''))
 	);
 	const recentTasks = [...space.tasks].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, 3);
 	const activeSessions = (space.sessions ?? []).filter((s) => s.status === 'active').slice(0, 3);
@@ -80,11 +88,18 @@ function SpaceCard({ space }: { space: SpaceWithTasks }) {
 						<p class="text-xs text-gray-500 mt-0.5 line-clamp-2">{space.description}</p>
 					)}
 				</div>
-				{activeTasks.length > 0 && (
-					<span class="flex-shrink-0 rounded-full bg-blue-900/50 border border-blue-800/40 px-2 py-0.5 text-xs font-medium text-blue-300 tabular-nums">
-						{activeTasks.length} active
-					</span>
-				)}
+				<div class="flex items-center gap-1.5 flex-shrink-0">
+					{attentionTasks.length > 0 && (
+						<span class="rounded-full bg-amber-900/50 border border-amber-800/40 px-2 py-0.5 text-xs font-medium text-amber-300 tabular-nums">
+							{attentionTasks.length} action
+						</span>
+					)}
+					{activeTasks.length > 0 && (
+						<span class="rounded-full bg-blue-900/50 border border-blue-800/40 px-2 py-0.5 text-xs font-medium text-blue-300 tabular-nums">
+							{activeTasks.length} active
+						</span>
+					)}
+				</div>
 			</div>
 
 			{/* Active sessions */}

--- a/packages/web/src/islands/__tests__/SpaceDetailPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/SpaceDetailPanel.test.tsx
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup, screen } from '@testing-library/preact';
-import { signal, type Signal } from '@preact/signals';
+import { computed, signal, type Signal } from '@preact/signals';
 import type { SpaceTask, Space } from '@neokai/shared';
 
 const {
@@ -34,6 +34,7 @@ let mockCurrentSpaceSessionIdSignal!: Signal<string | null>;
 let mockCurrentSpaceTaskIdSignal!: Signal<string | null>;
 let mockSpaceOverlaySessionIdSignal!: Signal<string | null>;
 let mockSpaceOverlayAgentNameSignal!: Signal<string | null>;
+let mockAttentionCountSignal!: ReturnType<typeof computed<number>>;
 
 function initSignals() {
 	mockTasksSignal = signal([]);
@@ -41,6 +42,7 @@ function initSignals() {
 	mockLoadingSignal = signal(false);
 	mockSpaceIdSignal = signal('space-1');
 	mockSessionsSignal = signal([]);
+	mockAttentionCountSignal = computed(() => 0);
 	mockCurrentSpaceSessionIdSignal = signal(null);
 	mockCurrentSpaceTaskIdSignal = signal(null);
 	mockSpaceOverlaySessionIdSignal = signal(null);
@@ -57,6 +59,7 @@ vi.mock('../../lib/space-store.ts', () => ({
 			loading: mockLoadingSignal,
 			spaceId: mockSpaceIdSignal,
 			sessions: mockSessionsSignal,
+			attentionCount: mockAttentionCountSignal,
 		};
 	},
 }));
@@ -195,7 +198,7 @@ describe('SpaceDetailPanel', () => {
 		expect(button?.className).toContain('bg-dark-700');
 	});
 
-	it('shows Review tasks by default and includes counters on task tabs', () => {
+	it('shows Action tasks by default and includes counters on task tabs', () => {
 		mockTasksSignal.value = [
 			makeTask('t1', 'Queued Task', 'open'),
 			makeTask('t2', 'In Progress Task', 'in_progress'),
@@ -206,7 +209,7 @@ describe('SpaceDetailPanel', () => {
 		expect(screen.getByText('Blocked Task')).toBeTruthy();
 		expect(screen.queryByText('Queued Task')).toBeNull();
 		expect(screen.getByText('Active')).toBeTruthy();
-		expect(screen.getByText('Review')).toBeTruthy();
+		expect(screen.getByText('Action')).toBeTruthy();
 		expect(screen.getByText('2')).toBeTruthy();
 		expect(screen.getByText('1')).toBeTruthy();
 	});
@@ -298,7 +301,7 @@ describe('SpaceDetailPanel', () => {
 			];
 			render(<SpaceDetailPanel spaceId="space-1" />);
 
-			// Default tab is "review" — shows blocked tasks
+			// Default tab is "action" — shows blocked tasks
 			expect(screen.getByText('Blocked Task')).toBeTruthy();
 			expect(screen.queryByText('Open Task')).toBeNull();
 			expect(screen.queryByText('In Progress Task')).toBeNull();
@@ -331,7 +334,7 @@ describe('SpaceDetailPanel', () => {
 			mockTasksSignal.value = [makeTask('t1', 'Task A', 'open')];
 			const { rerender } = render(<SpaceDetailPanel spaceId="space-1" />);
 
-			// Active: 1, Review: 0
+			// Active: 1, Action: 0
 			expect(screen.getByText('1')).toBeTruthy();
 			expect(screen.getByText('0')).toBeTruthy();
 
@@ -342,7 +345,7 @@ describe('SpaceDetailPanel', () => {
 			];
 			rerender(<SpaceDetailPanel spaceId="space-1" />);
 
-			// Active: 1, Review: 1
+			// Active: 1, Action: 1
 			const badges = screen.getAllByText('1');
 			expect(badges.length).toBe(2);
 		});
@@ -354,7 +357,7 @@ describe('SpaceDetailPanel', () => {
 			];
 			const { rerender } = render(<SpaceDetailPanel spaceId="space-1" />);
 
-			// Review tab (default): shows blocked task
+			// Action tab (default): shows blocked task
 			expect(screen.getByText('Task Two')).toBeTruthy();
 
 			// Simulate task status change: t1 becomes blocked, t2 becomes done
@@ -364,7 +367,7 @@ describe('SpaceDetailPanel', () => {
 			];
 			rerender(<SpaceDetailPanel spaceId="space-1" />);
 
-			// Review tab should now show Task One (blocked) but not Task Two (done)
+			// Action tab should now show Task One (blocked) but not Task Two (done)
 			expect(screen.getByText('Task One')).toBeTruthy();
 			expect(screen.queryByText('Task Two')).toBeNull();
 		});

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -140,9 +140,32 @@ class SpaceStore {
 	/** Stale-event guard for space sessions LiveQuery subscription */
 	private activeSpaceSessionsSubscriptionId: string | null = null;
 
+	/** Tasks needing human attention — reactive via LiveQuery */
+	readonly attentionTasks = signal<
+		Array<{
+			id: string;
+			title: string;
+			status: string;
+			blockReason: string | null;
+			result: string | null;
+			taskNumber: number;
+			spaceId: string;
+			updatedAt: number;
+		}>
+	>([]);
+
+	/** Cleanup functions for the attention tasks LiveQuery subscription */
+	private attentionTasksCleanupFns: Array<() => void> = [];
+
+	/** Stale-event guard for attention tasks LiveQuery subscription */
+	private activeAttentionTasksSubscriptionId: string | null = null;
+
 	// ========================================
 	// Computed Signals
 	// ========================================
+
+	/** Number of tasks needing human attention (review + human-blocked) */
+	readonly attentionCount = computed(() => this.attentionTasks.value.length);
 
 	/** Tasks that are currently in progress */
 	readonly activeTasks = computed(() => this.tasks.value.filter((t) => t.status === 'in_progress'));
@@ -518,6 +541,8 @@ class SpaceStore {
 		this.nodeExecPromise = null;
 		this.sessions.value = [];
 		this.disposeSpaceSessionsSubscription();
+		this.attentionTasks.value = [];
+		this.disposeAttentionTasksSubscription();
 
 		// 3. Update active space (may be updated to real UUID after fetch)
 		this.spaceId.value = spaceIdOrSlug;
@@ -575,6 +600,9 @@ class SpaceStore {
 
 		// --- spaceSessions.bySpace LiveQuery ---
 		this.subscribeSpaceSessions(hub, spaceId);
+
+		// --- spaceTasks.needingAttention LiveQuery ---
+		this.subscribeAttentionTasks(hub, spaceId);
 
 		// --- space.archived ---
 		const unsubSpaceArchived = hub.onEvent<{
@@ -937,6 +965,7 @@ class SpaceStore {
 		this.cleanupFunctions = [];
 		this.unsubscribeTaskActivity();
 		this.unsubscribeNodeExecutions();
+		this.disposeAttentionTasksSubscription();
 	}
 
 	// ========================================
@@ -1333,6 +1362,98 @@ class SpaceStore {
 	}
 
 	// ========================================
+	// LiveQuery: Tasks Needing Attention
+	// ========================================
+
+	private subscribeAttentionTasks(
+		hub: Awaited<ReturnType<typeof connectionManager.getHub>>,
+		spaceId: string
+	): void {
+		const subscriptionId = `spaceTasks-needingAttention-${spaceId}`;
+		if (this.activeAttentionTasksSubscriptionId === subscriptionId) return;
+		this.disposeAttentionTasksSubscription();
+		this.activeAttentionTasksSubscriptionId = subscriptionId;
+
+		type AttentionRow = {
+			id: string;
+			title: string;
+			status: string;
+			blockReason: string | null;
+			result: string | null;
+			taskNumber: number;
+			spaceId: string;
+			updatedAt: number;
+		};
+
+		const unsubSnapshot = hub.onEvent<LiveQuerySnapshotEvent>('liveQuery.snapshot', (event) => {
+			if (event.subscriptionId !== subscriptionId) return;
+			if (this.activeAttentionTasksSubscriptionId !== subscriptionId) return;
+			this.attentionTasks.value = (event.rows as AttentionRow[]) ?? [];
+		});
+		this.attentionTasksCleanupFns.push(unsubSnapshot);
+
+		const unsubDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
+			if (event.subscriptionId !== subscriptionId) return;
+			if (this.activeAttentionTasksSubscriptionId !== subscriptionId) return;
+			const current = this.attentionTasks.value;
+			const next = new Map(current.map((t) => [t.id, t]));
+			for (const row of (event.removed ?? []) as AttentionRow[]) next.delete(row.id);
+			for (const row of (event.updated ?? []) as AttentionRow[]) next.set(row.id, row);
+			for (const row of (event.added ?? []) as AttentionRow[]) next.set(row.id, row);
+			this.attentionTasks.value = [...next.values()];
+		});
+		this.attentionTasksCleanupFns.push(unsubDelta);
+
+		const unsubReconnect = hub.onConnection((state) => {
+			if (state !== 'connected') return;
+			if (this.activeAttentionTasksSubscriptionId !== subscriptionId) return;
+			hub
+				.request('liveQuery.subscribe', {
+					queryName: 'spaceTasks.needingAttention',
+					params: [spaceId],
+					subscriptionId,
+				})
+				.catch((err) => {
+					logger.warn('Attention tasks LiveQuery re-subscribe failed:', err);
+				});
+		});
+		this.attentionTasksCleanupFns.push(unsubReconnect);
+
+		hub
+			.request('liveQuery.subscribe', {
+				queryName: 'spaceTasks.needingAttention',
+				params: [spaceId],
+				subscriptionId,
+			})
+			.catch((err) => {
+				logger.warn('Attention tasks LiveQuery subscribe failed:', err);
+			});
+	}
+
+	private disposeAttentionTasksSubscription(): void {
+		for (const cleanup of this.attentionTasksCleanupFns) {
+			try {
+				cleanup();
+			} catch {
+				// Ignore
+			}
+		}
+		this.attentionTasksCleanupFns = [];
+
+		if (this.activeAttentionTasksSubscriptionId) {
+			const hub = connectionManager.getHubIfConnected();
+			if (hub) {
+				hub
+					.request('liveQuery.unsubscribe', {
+						subscriptionId: this.activeAttentionTasksSubscriptionId,
+					})
+					.catch(() => {});
+			}
+			this.activeAttentionTasksSubscriptionId = null;
+		}
+	}
+
+	// ========================================
 	// Refresh
 	// ========================================
 
@@ -1370,6 +1491,8 @@ class SpaceStore {
 		this.nodeExecPromise = null;
 		this.sessions.value = [];
 		this.disposeSpaceSessionsSubscription();
+		this.attentionTasks.value = [];
+		this.disposeAttentionTasksSubscription();
 
 		try {
 			await this.fetchAndResolveSpace(spaceId);


### PR DESCRIPTION
## Summary
- Add LiveQuery `spaceTasks.needingAttention` for real-time attention task tracking (review + human-blocked tasks)
- Consolidate former Review + Attention tabs into single "Action" tab, grouped by block reason: Needs Input, Gate Pending, Awaiting Review, Blocked
- Amber attention badge on Tasks sidebar button and SpacesPage space cards
- Add Gap #2b (Action UI) to gap analysis doc as follow-up for approve/reject/resolve buttons

## Test plan
- [x] 7 new daemon LiveQuery tests for `spaceTasks.needingAttention` query
- [x] 18 SpaceTasks web tests updated and passing
- [x] Typecheck clean
- [x] Lint + format clean