### PR TITLE
fix(e2e): fix 10 E2E failures on dev

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -366,7 +366,7 @@ jobs:
       - name: Install sandbox dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list 2>/dev/null || true
+          sudo find /etc/apt/sources.list.d/ \( -name "*microsoft*" -o -name "*azure*" \) -delete 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y bubblewrap socat ripgrep
 
@@ -470,7 +470,7 @@ jobs:
       - name: Install sandbox dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list 2>/dev/null || true
+          sudo find /etc/apt/sources.list.d/ \( -name "*microsoft*" -o -name "*azure*" \) -delete 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y bubblewrap socat ripgrep
 
@@ -530,7 +530,7 @@ jobs:
       - name: Install sandbox dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list 2>/dev/null || true
+          sudo find /etc/apt/sources.list.d/ \( -name "*microsoft*" -o -name "*azure*" \) -delete 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y bubblewrap socat ripgrep
 
@@ -595,7 +595,7 @@ jobs:
       - name: Install sandbox dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list 2>/dev/null || true
+          sudo find /etc/apt/sources.list.d/ \( -name "*microsoft*" -o -name "*azure*" \) -delete 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y bubblewrap socat ripgrep
 
@@ -763,7 +763,7 @@ jobs:
       - name: Install sandbox dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list 2>/dev/null || true
+          sudo find /etc/apt/sources.list.d/ \( -name "*microsoft*" -o -name "*azure*" \) -delete 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y bubblewrap socat ripgrep
 
@@ -925,7 +925,7 @@ jobs:
       - name: Install sandbox dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list 2>/dev/null || true
+          sudo find /etc/apt/sources.list.d/ \( -name "*microsoft*" -o -name "*azure*" \) -delete 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y bubblewrap socat ripgrep
 
@@ -1065,7 +1065,7 @@ jobs:
       - name: Install sandbox dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list 2>/dev/null || true
+          sudo find /etc/apt/sources.list.d/ \( -name "*microsoft*" -o -name "*azure*" \) -delete 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y bubblewrap socat ripgrep
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,7 @@ jobs:
       - name: Install sandbox dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
+          sudo find /etc/apt/sources.list.d/ \( -name "*microsoft*" -o -name "*azure*" \) -delete 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y bubblewrap socat ripgrep
 

--- a/packages/e2e/tests/features/space-approval-gate-rejection.e2e.ts
+++ b/packages/e2e/tests/features/space-approval-gate-rejection.e2e.ts
@@ -243,7 +243,7 @@ test.describe('Approval Gate Rejection', () => {
 		await page.getByTestId('reject-button').click();
 
 		// Overlay should close after the rejection decision.
-		await expect(page.getByTestId('artifacts-panel-overlay')).toBeHidden({ timeout: 5000 });
+		await expect(page.getByTestId('artifacts-panel-overlay')).toBeHidden({ timeout: 15000 });
 
 		// The gate should now show as "blocked" (red lock) on the canvas.
 		// Use 30s — the space store may briefly reload after rejection, causing canvas-view

--- a/packages/e2e/tests/features/space-task-status-control.e2e.ts
+++ b/packages/e2e/tests/features/space-task-status-control.e2e.ts
@@ -80,13 +80,13 @@ test.describe('Space Task Blocked Status & Manual Status Control', () => {
 		await page.waitForURL(`/space/${spaceId}/tasks`, { timeout: 5000 });
 		await expect(page.locator(TASKS_VIEW)).toBeVisible({ timeout: 10000 });
 
-		// Click the "Review" tab which shows blocked + review tasks
+		// Click the "Action" tab which shows blocked + review tasks
 		const tasksView = page.locator(TASKS_VIEW);
-		const reviewTab = tasksView.getByRole('button', { name: 'Review' });
-		await expect(reviewTab).toBeVisible({ timeout: 10000 });
-		await reviewTab.click();
+		const actionTab = tasksView.getByRole('button', { name: 'Action' });
+		await expect(actionTab).toBeVisible({ timeout: 10000 });
+		await actionTab.click();
 
-		// The task title should appear in the Review group
+		// The task title should appear in the Action group
 		await expect(tasksView.getByText(taskTitle, { exact: true })).toBeVisible({ timeout: 5000 });
 
 		// The blocked reason should appear as amber text below the task title

--- a/packages/web/src/components/space/SpacePageHeader.tsx
+++ b/packages/web/src/components/space/SpacePageHeader.tsx
@@ -9,7 +9,7 @@ interface SpacePageHeaderProps {
 export function SpacePageHeader({ spaceName, pageTitle }: SpacePageHeaderProps) {
 	return (
 		<div
-			class={`flex-shrink-0 bg-dark-850 border-b ${borderColors.ui.default} px-4 h-[65px] flex items-center relative z-10`}
+			class={`flex-shrink-0 bg-dark-850 border-b ${borderColors.ui.default} px-4 h-[65px] flex items-center`}
 		>
 			<div class="flex-1 flex items-center gap-3">
 				<button

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -403,7 +403,7 @@ export function ContextPanel() {
 										/>
 									</svg>
 								</button>
-								<h2 class="min-w-0 flex-1 text-lg font-semibold text-gray-100 truncate">
+								<h2 class="min-w-0 flex-1 text-lg font-semibold text-gray-100 truncate pointer-events-none">
 									{headerTitle}
 								</h2>
 								<button


### PR DESCRIPTION
Fixes all 10 E2E failures currently failing on dev:

**Pointer event interceptions (8 tests)**
- Remove `relative z-10` from `SpacePageHeader` — the z-10 stacking context caused the h2 "Overview" to paint over and intercept clicks on ContextPanel's Configure space gear button (affected: space-agent-centric-workflow, space-gate-custom-badges, space-gate-script-check, space-multi-agent-editor, visual-workflow-editor, approval-gate-rejection)
- Add `pointer-events-none` to ContextPanel's space title h2 — the h2 intercepted clicks on the task-back-button in the adjacent SpaceTaskPane column (affected: space-navigation, space-task-fullwidth)

**Tab rename (1 test)**
- `space-task-status-control`: update `'Review'` button selector to `'Action'` following the tab rename in #1491

**CI infrastructure (1 test)**
- `settings-mcp-servers`: broaden apt sources cleanup from specific file names to a glob (`*microsoft*` / `*azure*`) so it catches all variants of the repo list file that GitHub runners may have (e.g. `.sources` deb822 format in addition to `.list`)

**LLM test timing (1 test)**
- `space-approval-gate-rejection`: increase overlay-close timeout from 5 s to 15 s — the rejection involves a server round-trip and the 5 s budget was too tight on loaded CI runners after the lazy-loading changes in #1478