### PR TITLE
feat(space): reason-aware blocked task banner with gate approval UI

### DIFF
--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -13,6 +13,7 @@ import { borderColors } from '../../lib/design-tokens';
 import { SpaceTaskUnifiedThread } from './SpaceTaskUnifiedThread';
 import { TaskArtifactsPanel } from './TaskArtifactsPanel';
 import { getTransitionActions, TaskStatusActions } from './TaskStatusActions';
+import { TaskBlockedBanner } from './TaskBlockedBanner';
 import { ThreadedChatComposer } from './ThreadedChatComposer';
 import { ReadOnlyWorkflowCanvas } from './ReadOnlyWorkflowCanvas';
 import { Dropdown, type DropdownMenuItem } from '../ui/Dropdown';
@@ -432,14 +433,12 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 					/>
 				) : (
 					<div class="h-full flex flex-col relative">
-						{task.status === 'blocked' && task.result && (
-							<div
-								class="mb-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2"
-								data-testid="task-blocked-banner"
-							>
-								<p class="text-xs font-medium text-amber-300">Blocked</p>
-								<p class="mt-0.5 text-sm text-amber-200/90">{task.result}</p>
-							</div>
+						{task.status === 'blocked' && (
+							<TaskBlockedBanner
+								task={task}
+								spaceId={runtimeSpaceId}
+								onStatusTransition={handleStatusTransition}
+							/>
 						)}
 						<div class="flex-1 min-h-0" data-testid="task-thread-panel">
 							{hasUnifiedWorkflowThread ? (

--- a/packages/web/src/components/space/TaskBlockedBanner.tsx
+++ b/packages/web/src/components/space/TaskBlockedBanner.tsx
@@ -28,9 +28,11 @@ interface PendingGate {
 	data: Record<string, unknown>;
 }
 
-const REASON_CONFIG: Record<
-	string,
-	{ label: string; border: string; bg: string; title: string; icon: string }
+const REASON_CONFIG: Partial<
+	Record<
+		SpaceBlockReason,
+		{ label: string; border: string; bg: string; title: string; icon: string }
+	>
 > = {
 	human_input_requested: {
 		label: 'Waiting for Input',
@@ -85,7 +87,7 @@ const FALLBACK_CONFIG = {
 };
 
 export function TaskBlockedBanner({ task, spaceId, onStatusTransition }: TaskBlockedBannerProps) {
-	const reason = task.blockReason as SpaceBlockReason | null;
+	const reason = task.blockReason;
 	const config = (reason && REASON_CONFIG[reason]) || FALLBACK_CONFIG;
 
 	const [showGateReview, setShowGateReview] = useState(false);
@@ -165,8 +167,7 @@ export function TaskBlockedBanner({ task, spaceId, onStatusTransition }: TaskBlo
 						<button
 							type="button"
 							onClick={() => setShowGateReview(true)}
-							disabled={gateLoading}
-							class="px-2 py-1 text-xs font-medium text-purple-300 hover:text-purple-200 bg-purple-900/30 hover:bg-purple-900/50 rounded transition-colors disabled:opacity-50"
+							class="px-2 py-1 text-xs font-medium text-purple-300 hover:text-purple-200 bg-purple-900/30 hover:bg-purple-900/50 rounded transition-colors"
 							data-testid="gate-review-btn"
 						>
 							Review & Approve

--- a/packages/web/src/components/space/TaskBlockedBanner.tsx
+++ b/packages/web/src/components/space/TaskBlockedBanner.tsx
@@ -51,28 +51,28 @@ const REASON_CONFIG: Record<
 		border: 'border-red-500/30',
 		bg: 'bg-red-500/10',
 		title: 'text-red-300',
-		icon: '⚠',
+		icon: '⚠️',
 	},
 	agent_crashed: {
 		label: 'Agent Crashed',
 		border: 'border-red-500/30',
 		bg: 'bg-red-500/10',
 		title: 'text-red-300',
-		icon: '⚠',
+		icon: '⚠️',
 	},
 	dependency_failed: {
 		label: 'Blocked by Dependency',
 		border: 'border-gray-500/30',
 		bg: 'bg-gray-500/10',
 		title: 'text-gray-300',
-		icon: '⛓',
+		icon: '⛓️',
 	},
 	workflow_invalid: {
 		label: 'Invalid Workflow',
 		border: 'border-red-500/30',
 		bg: 'bg-red-500/10',
 		title: 'text-red-300',
-		icon: '⚠',
+		icon: '⚠️',
 	},
 };
 
@@ -81,7 +81,7 @@ const FALLBACK_CONFIG = {
 	border: 'border-amber-500/30',
 	bg: 'bg-amber-500/10',
 	title: 'text-amber-300',
-	icon: '⚠',
+	icon: '⚠️',
 };
 
 export function TaskBlockedBanner({ task, spaceId, onStatusTransition }: TaskBlockedBannerProps) {
@@ -90,17 +90,24 @@ export function TaskBlockedBanner({ task, spaceId, onStatusTransition }: TaskBlo
 
 	const [showGateReview, setShowGateReview] = useState(false);
 	const [pendingGate, setPendingGate] = useState<PendingGate | null>(null);
-	const [gateLoading, setGateLoading] = useState(false);
+	const [gateLoading, setGateLoading] = useState(
+		reason === 'gate_rejected' && !!task.workflowRunId
+	);
 
 	// For gate_rejected tasks, fetch the pending gate data on mount
 	useEffect(() => {
 		if (reason !== 'gate_rejected' || !task.workflowRunId) return;
 
+		let cancelled = false;
 		setGateLoading(true);
 		spaceStore
 			.listGateData(task.workflowRunId)
 			.then((records) => {
-				// Find the rejected/unapproved gate
+				if (cancelled) return;
+				// Pick the first rejected/waiting gate. Note: in multi-gate workflows
+				// this may not be the gate that actually blocked the task. A future
+				// improvement would store `blockingGateId` on SpaceTask to remove
+				// ambiguity.
 				const rejected = records.find(
 					(r) => r.data?.approved === false || r.data?.waiting === true
 				);
@@ -111,7 +118,12 @@ export function TaskBlockedBanner({ task, spaceId, onStatusTransition }: TaskBlo
 			.catch(() => {
 				// Gate data fetch is best-effort
 			})
-			.finally(() => setGateLoading(false));
+			.finally(() => {
+				if (!cancelled) setGateLoading(false);
+			});
+		return () => {
+			cancelled = true;
+		};
 	}, [reason, task.workflowRunId]);
 
 	// If showing full gate review, render GateArtifactsView

--- a/packages/web/src/components/space/TaskBlockedBanner.tsx
+++ b/packages/web/src/components/space/TaskBlockedBanner.tsx
@@ -144,7 +144,7 @@ export function TaskBlockedBanner({ task, spaceId, onStatusTransition }: TaskBlo
 
 	return (
 		<div
-			class={`mx-4 mt-2 rounded-lg border ${config.border} ${config.bg} px-3 py-2`}
+			class={`mx-4 mt-2 mb-2 rounded-lg border ${config.border} ${config.bg} px-3 py-2`}
 			data-testid="task-blocked-banner"
 		>
 			<div class="flex items-start justify-between gap-2">
@@ -177,7 +177,7 @@ export function TaskBlockedBanner({ task, spaceId, onStatusTransition }: TaskBlo
 						<button
 							type="button"
 							onClick={() => onStatusTransition?.('in_progress')}
-							class="px-2 py-1 text-xs font-medium text-blue-300 hover:text-blue-200 transition-colors"
+							class="px-2 py-1 text-xs font-medium text-blue-300 hover:text-blue-200 bg-dark-700 hover:bg-dark-600 rounded transition-colors"
 							data-testid="gate-resume-btn"
 						>
 							Resume

--- a/packages/web/src/components/space/TaskBlockedBanner.tsx
+++ b/packages/web/src/components/space/TaskBlockedBanner.tsx
@@ -1,0 +1,187 @@
+/**
+ * TaskBlockedBanner — reason-aware banner for blocked tasks.
+ *
+ * Replaces the generic amber blocked banner in SpaceTaskPane with
+ * distinct UI per blockReason:
+ *   - human_input_requested: blue/info — shows question, prompts "Reply below"
+ *   - gate_rejected: purple — shows gate info + "Review & Approve" expanding to GateArtifactsView
+ *   - execution_failed / agent_crashed: red — shows error + Resume button
+ *   - dependency_failed: gray — informational
+ *   - workflow_invalid: red — informational
+ *   - (null / unknown): amber fallback — matches previous behavior
+ */
+
+import { useState, useEffect } from 'preact/hooks';
+import type { SpaceBlockReason, SpaceTask, SpaceTaskStatus } from '@neokai/shared';
+import { spaceStore } from '../../lib/space-store';
+import { GateArtifactsView } from './GateArtifactsView';
+
+interface TaskBlockedBannerProps {
+	task: SpaceTask;
+	spaceId: string;
+	/** Called when the user triggers a status transition (e.g. Resume → in_progress) */
+	onStatusTransition?: (newStatus: SpaceTaskStatus) => void;
+}
+
+interface PendingGate {
+	gateId: string;
+	data: Record<string, unknown>;
+}
+
+const REASON_CONFIG: Record<
+	string,
+	{ label: string; border: string; bg: string; title: string; icon: string }
+> = {
+	human_input_requested: {
+		label: 'Waiting for Input',
+		border: 'border-blue-500/30',
+		bg: 'bg-blue-500/10',
+		title: 'text-blue-300',
+		icon: '💬',
+	},
+	gate_rejected: {
+		label: 'Gate Pending Approval',
+		border: 'border-purple-500/30',
+		bg: 'bg-purple-500/10',
+		title: 'text-purple-300',
+		icon: '🔒',
+	},
+	execution_failed: {
+		label: 'Execution Failed',
+		border: 'border-red-500/30',
+		bg: 'bg-red-500/10',
+		title: 'text-red-300',
+		icon: '⚠',
+	},
+	agent_crashed: {
+		label: 'Agent Crashed',
+		border: 'border-red-500/30',
+		bg: 'bg-red-500/10',
+		title: 'text-red-300',
+		icon: '⚠',
+	},
+	dependency_failed: {
+		label: 'Blocked by Dependency',
+		border: 'border-gray-500/30',
+		bg: 'bg-gray-500/10',
+		title: 'text-gray-300',
+		icon: '⛓',
+	},
+	workflow_invalid: {
+		label: 'Invalid Workflow',
+		border: 'border-red-500/30',
+		bg: 'bg-red-500/10',
+		title: 'text-red-300',
+		icon: '⚠',
+	},
+};
+
+const FALLBACK_CONFIG = {
+	label: 'Blocked',
+	border: 'border-amber-500/30',
+	bg: 'bg-amber-500/10',
+	title: 'text-amber-300',
+	icon: '⚠',
+};
+
+export function TaskBlockedBanner({ task, spaceId, onStatusTransition }: TaskBlockedBannerProps) {
+	const reason = task.blockReason as SpaceBlockReason | null;
+	const config = (reason && REASON_CONFIG[reason]) || FALLBACK_CONFIG;
+
+	const [showGateReview, setShowGateReview] = useState(false);
+	const [pendingGate, setPendingGate] = useState<PendingGate | null>(null);
+	const [gateLoading, setGateLoading] = useState(false);
+
+	// For gate_rejected tasks, fetch the pending gate data on mount
+	useEffect(() => {
+		if (reason !== 'gate_rejected' || !task.workflowRunId) return;
+
+		setGateLoading(true);
+		spaceStore
+			.listGateData(task.workflowRunId)
+			.then((records) => {
+				// Find the rejected/unapproved gate
+				const rejected = records.find(
+					(r) => r.data?.approved === false || r.data?.waiting === true
+				);
+				if (rejected) {
+					setPendingGate({ gateId: rejected.gateId, data: rejected.data });
+				}
+			})
+			.catch(() => {
+				// Gate data fetch is best-effort
+			})
+			.finally(() => setGateLoading(false));
+	}, [reason, task.workflowRunId]);
+
+	// If showing full gate review, render GateArtifactsView
+	if (showGateReview && pendingGate && task.workflowRunId) {
+		return (
+			<GateArtifactsView
+				runId={task.workflowRunId}
+				gateId={pendingGate.gateId}
+				spaceId={spaceId}
+				gateData={pendingGate.data}
+				onClose={() => setShowGateReview(false)}
+				onDecision={() => setShowGateReview(false)}
+			/>
+		);
+	}
+
+	return (
+		<div
+			class={`mx-4 mt-2 rounded-lg border ${config.border} ${config.bg} px-3 py-2`}
+			data-testid="task-blocked-banner"
+		>
+			<div class="flex items-start justify-between gap-2">
+				<div class="flex-1 min-w-0">
+					<p class={`text-xs font-medium ${config.title}`}>
+						{config.icon} {config.label}
+					</p>
+					{task.result && (
+						<p class="mt-0.5 text-sm text-gray-200/90" data-testid="task-blocked-message">
+							{task.result}
+						</p>
+					)}
+					{reason === 'human_input_requested' && (
+						<p class="mt-1 text-xs text-blue-400/70">Reply below to continue</p>
+					)}
+				</div>
+
+				<div class="flex items-center gap-1.5 flex-shrink-0">
+					{reason === 'gate_rejected' && pendingGate && (
+						<button
+							type="button"
+							onClick={() => setShowGateReview(true)}
+							disabled={gateLoading}
+							class="px-2 py-1 text-xs font-medium text-purple-300 hover:text-purple-200 bg-purple-900/30 hover:bg-purple-900/50 rounded transition-colors disabled:opacity-50"
+							data-testid="gate-review-btn"
+						>
+							Review & Approve
+						</button>
+					)}
+					{reason === 'gate_rejected' && !pendingGate && !gateLoading && (
+						<button
+							type="button"
+							onClick={() => onStatusTransition?.('in_progress')}
+							class="px-2 py-1 text-xs font-medium text-blue-300 hover:text-blue-200 transition-colors"
+							data-testid="gate-resume-btn"
+						>
+							Resume
+						</button>
+					)}
+					{(reason === 'execution_failed' || reason === 'agent_crashed') && (
+						<button
+							type="button"
+							onClick={() => onStatusTransition?.('in_progress')}
+							class="px-2 py-1 text-xs font-medium text-blue-300 hover:text-blue-200 bg-dark-700 hover:bg-dark-600 rounded transition-colors"
+							data-testid="task-resume-btn"
+						>
+							Resume
+						</button>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -62,6 +62,7 @@ vi.mock('../../../lib/space-store', () => ({
 			unsubscribeTaskActivity: mockUnsubscribeTaskActivity,
 			ensureConfigData: vi.fn().mockResolvedValue(undefined),
 			ensureNodeExecutions: vi.fn().mockResolvedValue(undefined),
+			listGateData: vi.fn().mockResolvedValue([]),
 		};
 	},
 }));
@@ -631,12 +632,12 @@ describe('SpaceTaskPane — blocked reason banner', () => {
 		expect(banner.textContent).toContain('Waiting for API key configuration');
 	});
 
-	it('does not show blocked reason banner when task is blocked without result', () => {
+	it('shows blocked banner even when task has no result text', () => {
 		mockTasks.value = [
 			makeTask({ status: 'blocked', result: null, taskAgentSessionId: 'session-abc' }),
 		];
-		const { queryByTestId } = render(<SpaceTaskPane taskId="task-1" />);
-		expect(queryByTestId('task-blocked-banner')).toBeNull();
+		const { getByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(getByTestId('task-blocked-banner')).toBeTruthy();
 	});
 
 	it('does not show blocked banner for non-blocked tasks', () => {

--- a/packages/web/src/components/space/__tests__/TaskBlockedBanner.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskBlockedBanner.test.tsx
@@ -1,0 +1,258 @@
+// @ts-nocheck
+/**
+ * Unit tests for TaskBlockedBanner
+ *
+ * Tests:
+ * - Renders fallback amber banner when blockReason is null
+ * - Renders human_input_requested banner with question and "Reply below" hint
+ * - Renders gate_rejected banner with "Review & Approve" button
+ * - Renders execution_failed banner with Resume button
+ * - Renders agent_crashed banner with Resume button
+ * - Renders dependency_failed banner (informational, no action)
+ * - Renders workflow_invalid banner (informational, no action)
+ * - Resume button calls onStatusTransition with 'in_progress'
+ * - Gate "Review & Approve" opens GateArtifactsView
+ * - Shows result text when present
+ * - Banner always shows even without result text
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { render, cleanup, fireEvent, waitFor } from '@testing-library/preact';
+import type { SpaceTask } from '@neokai/shared';
+
+// ---- Mock space-store ----
+const mockListGateData: Mock = vi.fn();
+
+vi.mock('../../../lib/space-store', () => ({
+	spaceStore: {
+		listGateData: (...args: unknown[]) => mockListGateData(...args),
+	},
+}));
+
+vi.mock('../../../lib/utils', () => ({
+	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+// Mock GateArtifactsView to avoid pulling in connection-manager and its deps
+vi.mock('../GateArtifactsView', () => ({
+	GateArtifactsView: (props: Record<string, unknown>) => (
+		<div data-testid="gate-artifacts-view" data-run-id={props.runId} data-gate-id={props.gateId}>
+			GateArtifactsView
+			<button data-testid="gate-close" onClick={props.onClose as () => void}>
+				Close
+			</button>
+		</div>
+	),
+}));
+
+import { TaskBlockedBanner } from '../TaskBlockedBanner';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeTask(overrides: Partial<SpaceTask> = {}): SpaceTask {
+	return {
+		id: 'task-1',
+		spaceId: 'space-1',
+		taskNumber: 1,
+		title: 'Test Task',
+		description: '',
+		status: 'blocked',
+		priority: 'normal',
+		labels: [],
+		dependsOn: [],
+		result: null,
+		blockReason: null,
+		approvalSource: null,
+		approvalReason: null,
+		approvedAt: null,
+		createdAt: 0,
+		updatedAt: 0,
+		startedAt: null,
+		completedAt: null,
+		archivedAt: null,
+		...overrides,
+	} as SpaceTask;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('TaskBlockedBanner', () => {
+	beforeEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+		mockListGateData.mockResolvedValue([]);
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders fallback amber banner when blockReason is null', () => {
+		const { getByTestId } = render(<TaskBlockedBanner task={makeTask()} spaceId="space-1" />);
+		const banner = getByTestId('task-blocked-banner');
+		expect(banner.className).toContain('border-amber-500');
+		expect(banner.textContent).toContain('Blocked');
+	});
+
+	it('renders human_input_requested banner with question and reply hint', () => {
+		const task = makeTask({
+			blockReason: 'human_input_requested',
+			result: 'What color scheme do you prefer?',
+		});
+		const { getByTestId, getByText } = render(<TaskBlockedBanner task={task} spaceId="space-1" />);
+		const banner = getByTestId('task-blocked-banner');
+		expect(banner.className).toContain('border-blue-500');
+		expect(banner.textContent).toContain('Waiting for Input');
+		expect(getByTestId('task-blocked-message').textContent).toBe(
+			'What color scheme do you prefer?'
+		);
+		expect(getByText('Reply below to continue')).toBeTruthy();
+	});
+
+	it('renders gate_rejected banner with Review & Approve button', async () => {
+		mockListGateData.mockResolvedValue([
+			{ runId: 'run-1', gateId: 'gate-1', data: { approved: false, waiting: true }, updatedAt: 0 },
+		]);
+		const task = makeTask({
+			blockReason: 'gate_rejected',
+			workflowRunId: 'run-1',
+		});
+		const { getByTestId } = render(<TaskBlockedBanner task={task} spaceId="space-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('gate-review-btn')).toBeTruthy();
+		});
+		const banner = getByTestId('task-blocked-banner');
+		expect(banner.className).toContain('border-purple-500');
+		expect(banner.textContent).toContain('Gate Pending Approval');
+	});
+
+	it('renders execution_failed banner with Resume button', () => {
+		const task = makeTask({
+			blockReason: 'execution_failed',
+			result: 'Process exited with code 1',
+		});
+		const { getByTestId } = render(<TaskBlockedBanner task={task} spaceId="space-1" />);
+		const banner = getByTestId('task-blocked-banner');
+		expect(banner.className).toContain('border-red-500');
+		expect(banner.textContent).toContain('Execution Failed');
+		expect(getByTestId('task-resume-btn')).toBeTruthy();
+	});
+
+	it('renders agent_crashed banner with Resume button', () => {
+		const task = makeTask({ blockReason: 'agent_crashed' });
+		const { getByTestId } = render(<TaskBlockedBanner task={task} spaceId="space-1" />);
+		const banner = getByTestId('task-blocked-banner');
+		expect(banner.textContent).toContain('Agent Crashed');
+		expect(getByTestId('task-resume-btn')).toBeTruthy();
+	});
+
+	it('renders dependency_failed banner without action buttons', () => {
+		const task = makeTask({ blockReason: 'dependency_failed' });
+		const { getByTestId, queryByTestId } = render(
+			<TaskBlockedBanner task={task} spaceId="space-1" />
+		);
+		const banner = getByTestId('task-blocked-banner');
+		expect(banner.className).toContain('border-gray-500');
+		expect(banner.textContent).toContain('Blocked by Dependency');
+		expect(queryByTestId('task-resume-btn')).toBeNull();
+		expect(queryByTestId('gate-review-btn')).toBeNull();
+	});
+
+	it('renders workflow_invalid banner without action buttons', () => {
+		const task = makeTask({ blockReason: 'workflow_invalid' });
+		const { getByTestId, queryByTestId } = render(
+			<TaskBlockedBanner task={task} spaceId="space-1" />
+		);
+		expect(getByTestId('task-blocked-banner').textContent).toContain('Invalid Workflow');
+		expect(queryByTestId('task-resume-btn')).toBeNull();
+	});
+
+	it('Resume button calls onStatusTransition with in_progress', () => {
+		const onTransition = vi.fn();
+		const task = makeTask({ blockReason: 'execution_failed' });
+		const { getByTestId } = render(
+			<TaskBlockedBanner task={task} spaceId="space-1" onStatusTransition={onTransition} />
+		);
+		fireEvent.click(getByTestId('task-resume-btn'));
+		expect(onTransition).toHaveBeenCalledWith('in_progress');
+	});
+
+	it('gate Review & Approve opens GateArtifactsView', async () => {
+		mockListGateData.mockResolvedValue([
+			{ runId: 'run-1', gateId: 'gate-1', data: { approved: false }, updatedAt: 0 },
+		]);
+		const task = makeTask({
+			blockReason: 'gate_rejected',
+			workflowRunId: 'run-1',
+		});
+		const { getByTestId, queryByTestId } = render(
+			<TaskBlockedBanner task={task} spaceId="space-1" />
+		);
+
+		await waitFor(() => {
+			expect(getByTestId('gate-review-btn')).toBeTruthy();
+		});
+
+		fireEvent.click(getByTestId('gate-review-btn'));
+
+		expect(getByTestId('gate-artifacts-view')).toBeTruthy();
+		expect(queryByTestId('task-blocked-banner')).toBeNull();
+	});
+
+	it('closing GateArtifactsView returns to banner', async () => {
+		mockListGateData.mockResolvedValue([
+			{ runId: 'run-1', gateId: 'gate-1', data: { approved: false }, updatedAt: 0 },
+		]);
+		const task = makeTask({
+			blockReason: 'gate_rejected',
+			workflowRunId: 'run-1',
+		});
+		const { getByTestId } = render(<TaskBlockedBanner task={task} spaceId="space-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('gate-review-btn')).toBeTruthy();
+		});
+
+		fireEvent.click(getByTestId('gate-review-btn'));
+		expect(getByTestId('gate-artifacts-view')).toBeTruthy();
+
+		fireEvent.click(getByTestId('gate-close'));
+		expect(getByTestId('task-blocked-banner')).toBeTruthy();
+	});
+
+	it('shows result text when present', () => {
+		const task = makeTask({ result: 'Something went wrong' });
+		const { getByTestId } = render(<TaskBlockedBanner task={task} spaceId="space-1" />);
+		expect(getByTestId('task-blocked-message').textContent).toBe('Something went wrong');
+	});
+
+	it('banner renders even without result text', () => {
+		const task = makeTask({ blockReason: 'execution_failed', result: null });
+		const { getByTestId, queryByTestId } = render(
+			<TaskBlockedBanner task={task} spaceId="space-1" />
+		);
+		expect(getByTestId('task-blocked-banner')).toBeTruthy();
+		expect(queryByTestId('task-blocked-message')).toBeNull();
+	});
+
+	it('shows Resume fallback when gate_rejected but no pending gate found', async () => {
+		mockListGateData.mockResolvedValue([]);
+		const task = makeTask({
+			blockReason: 'gate_rejected',
+			workflowRunId: 'run-1',
+		});
+		const { getByTestId, queryByTestId } = render(
+			<TaskBlockedBanner task={task} spaceId="space-1" />
+		);
+
+		await waitFor(() => {
+			expect(queryByTestId('gate-review-btn')).toBeNull();
+		});
+		expect(getByTestId('gate-resume-btn')).toBeTruthy();
+	});
+});

--- a/packages/web/src/components/space/__tests__/TaskBlockedBanner.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskBlockedBanner.test.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Unit tests for TaskBlockedBanner
  *
@@ -40,6 +39,9 @@ vi.mock('../GateArtifactsView', () => ({
 			GateArtifactsView
 			<button data-testid="gate-close" onClick={props.onClose as () => void}>
 				Close
+			</button>
+			<button data-testid="gate-decide" onClick={props.onDecision as () => void}>
+				Decide
 			</button>
 		</div>
 	),
@@ -254,5 +256,54 @@ describe('TaskBlockedBanner', () => {
 			expect(queryByTestId('gate-review-btn')).toBeNull();
 		});
 		expect(getByTestId('gate-resume-btn')).toBeTruthy();
+	});
+
+	it('shows Resume immediately when gate_rejected with no workflowRunId', () => {
+		const task = makeTask({
+			blockReason: 'gate_rejected',
+			workflowRunId: null,
+		});
+		const { getByTestId, queryByTestId } = render(
+			<TaskBlockedBanner task={task} spaceId="space-1" />
+		);
+		// No fetch attempted, no loading, so Resume fallback renders immediately
+		expect(getByTestId('gate-resume-btn')).toBeTruthy();
+		expect(queryByTestId('gate-review-btn')).toBeNull();
+		expect(mockListGateData).not.toHaveBeenCalled();
+	});
+
+	it('does not flash Resume button while gate data is loading', () => {
+		// Never resolve — simulates in-flight fetch
+		mockListGateData.mockReturnValue(new Promise(() => {}));
+		const task = makeTask({
+			blockReason: 'gate_rejected',
+			workflowRunId: 'run-1',
+		});
+		const { queryByTestId } = render(<TaskBlockedBanner task={task} spaceId="space-1" />);
+		// Neither button should show while loading
+		expect(queryByTestId('gate-resume-btn')).toBeNull();
+		expect(queryByTestId('gate-review-btn')).toBeNull();
+	});
+
+	it('GateArtifactsView onDecision callback closes the review', async () => {
+		mockListGateData.mockResolvedValue([
+			{ runId: 'run-1', gateId: 'gate-1', data: { approved: false }, updatedAt: 0 },
+		]);
+		const task = makeTask({
+			blockReason: 'gate_rejected',
+			workflowRunId: 'run-1',
+		});
+		const { getByTestId } = render(<TaskBlockedBanner task={task} spaceId="space-1" />);
+
+		await waitFor(() => {
+			expect(getByTestId('gate-review-btn')).toBeTruthy();
+		});
+
+		fireEvent.click(getByTestId('gate-review-btn'));
+		expect(getByTestId('gate-artifacts-view')).toBeTruthy();
+
+		// onDecision should also close the review view
+		fireEvent.click(getByTestId('gate-decide'));
+		expect(getByTestId('task-blocked-banner')).toBeTruthy();
 	});
 });

--- a/packages/web/src/components/space/__tests__/TaskBlockedBanner.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskBlockedBanner.test.tsx
@@ -28,10 +28,6 @@ vi.mock('../../../lib/space-store', () => ({
 	},
 }));
 
-vi.mock('../../../lib/utils', () => ({
-	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
-}));
-
 // Mock GateArtifactsView to avoid pulling in connection-manager and its deps
 vi.mock('../GateArtifactsView', () => ({
 	GateArtifactsView: (props: Record<string, unknown>) => (

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -1669,26 +1669,6 @@ class SpaceStore {
 	}
 
 	/**
-	 * Approve or reject a gate on a workflow run.
-	 */
-	async approveGate(
-		runId: string,
-		gateId: string,
-		approved: boolean,
-		reason?: string
-	): Promise<void> {
-		const hub = connectionManager.getHubIfConnected();
-		if (!hub) throw new Error('Not connected');
-
-		await hub.request('spaceWorkflowRun.approveGate', {
-			runId,
-			gateId,
-			approved,
-			reason,
-		});
-	}
-
-	/**
 	 * Fetch a paginated snapshot of task-thread messages.
 	 */
 	async getTaskMessages(

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -1642,6 +1642,52 @@ class SpaceStore {
 		});
 	}
 
+	// ========================================
+	// Gate Methods
+	// ========================================
+
+	/**
+	 * List all gate data records for a workflow run.
+	 */
+	async listGateData(
+		runId: string
+	): Promise<
+		Array<{ runId: string; gateId: string; data: Record<string, unknown>; updatedAt: number }>
+	> {
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		const result = await hub.request<{
+			gateData: Array<{
+				runId: string;
+				gateId: string;
+				data: Record<string, unknown>;
+				updatedAt: number;
+			}>;
+		}>('spaceWorkflowRun.listGateData', { runId });
+		return result?.gateData ?? [];
+	}
+
+	/**
+	 * Approve or reject a gate on a workflow run.
+	 */
+	async approveGate(
+		runId: string,
+		gateId: string,
+		approved: boolean,
+		reason?: string
+	): Promise<void> {
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		await hub.request('spaceWorkflowRun.approveGate', {
+			runId,
+			gateId,
+			approved,
+			reason,
+		});
+	}
+
 	/**
 	 * Fetch a paginated snapshot of task-thread messages.
 	 */


### PR DESCRIPTION
## Summary
- Replace generic amber blocked banner with `TaskBlockedBanner` component that shows distinct UI per `blockReason` (human_input_requested, gate_rejected, execution_failed, agent_crashed, dependency_failed, workflow_invalid)
- Wire gate approval flow: `gate_rejected` banner has "Review & Approve" button that opens `GateArtifactsView` inline with full diff review + approve/reject
- Add `listGateData` and `approveGate` methods to `spaceStore` (RPCs already existed, just needed frontend wiring)

Gap #2b from the space autonomy gap analysis.

## Test plan
- [x] 13 new unit tests for TaskBlockedBanner covering all 6 block reasons, gate review flow, resume actions
- [x] Updated SpaceTaskPane test for new always-show-banner behavior
- [x] Full web test suite passes (6953/6954, 1 pre-existing failure unrelated)
- [x] Typecheck, lint, knip all clean
- [x] E2E `space-task-status-control` test compatible (same `task-blocked-banner` testid preserved)