### PR TITLE
fix(e2e): fix pointer-events and gate approval connection handling

### DIFF
--- a/packages/web/src/components/space/GateArtifactsView.tsx
+++ b/packages/web/src/components/space/GateArtifactsView.tsx
@@ -114,8 +114,7 @@ export function GateArtifactsView({
 			setApproving(true);
 			setApproveError(null);
 			try {
-				const hub = connectionManager.getHubIfConnected();
-				if (!hub) throw new Error('Not connected');
+				const hub = await connectionManager.getHub();
 				await hub.request('spaceWorkflowRun.approveGate', { runId, gateId, approved });
 				onDecision?.();
 				onClose?.();

--- a/packages/web/src/components/space/__tests__/GateArtifactsView.test.tsx
+++ b/packages/web/src/components/space/__tests__/GateArtifactsView.test.tsx
@@ -36,6 +36,7 @@ const mockHub = { request: mockRequest };
 vi.mock('../../../lib/connection-manager', () => ({
 	connectionManager: {
 		getHubIfConnected: vi.fn(() => mockHub),
+		getHub: vi.fn(() => Promise.resolve(mockHub)),
 	},
 }));
 

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -388,10 +388,10 @@ export function ContextPanel() {
 						)}
 					>
 						{isSpaceDetail ? (
-							<div class="flex items-center gap-1 min-w-0 flex-1 overflow-hidden">
+							<div class="flex items-center gap-1 min-w-0 flex-1 overflow-hidden pointer-events-none">
 								<button
 									onClick={() => navigateToSpaces()}
-									class="p-1 hover:bg-dark-800 rounded-lg transition-colors text-gray-400 hover:text-gray-100 flex-shrink-0"
+									class="p-1 hover:bg-dark-800 rounded-lg transition-colors text-gray-400 hover:text-gray-100 flex-shrink-0 pointer-events-auto"
 									title="Back to Spaces"
 								>
 									<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -409,7 +409,7 @@ export function ContextPanel() {
 								<button
 									onClick={() => navigateToSpaceConfigure(currentSpaceId!)}
 									class={cn(
-										'ml-1 p-1.5 rounded-lg transition-colors flex-shrink-0',
+										'ml-1 p-1.5 rounded-lg transition-colors flex-shrink-0 pointer-events-auto',
 										currentSpaceViewMode === 'configure'
 											? 'bg-dark-800 text-gray-100'
 											: 'text-gray-400 hover:bg-dark-800 hover:text-gray-100'
@@ -439,7 +439,7 @@ export function ContextPanel() {
 						{/* Close button for mobile */}
 						<button
 							onClick={handlePanelClose}
-							class="md:hidden p-1.5 hover:bg-dark-800 rounded-lg transition-colors text-gray-400 hover:text-gray-100 flex-shrink-0"
+							class="md:hidden p-1.5 hover:bg-dark-800 rounded-lg transition-colors text-gray-400 hover:text-gray-100 flex-shrink-0 pointer-events-auto"
 							title="Close panel"
 						>
 							<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">


### PR DESCRIPTION
Fixes two remaining E2E failures after #1492.

**ContextPanel pointer-events** — the header wrapper div was painting over interactive elements in SpaceTaskPane due to ContextPanel's CSS `transform` stacking context. Fixed by adding `pointer-events-none` to the wrapper and `pointer-events-auto` to the three interactive buttons (back, gear/configure, mobile close).

**GateArtifactsView approval** — `handleDecision` used `connectionManager.getHubIfConnected()` which returns `null` if the transport is momentarily not ready (common during long-running LLM tests). This caused the overlay to never close — `space-approval-gate-rejection` timed out after 15s with 19 polls. Fixed by switching to `await connectionManager.getHub()` which waits for the connection to be ready.