### PR TITLE
fix(e2e): fix 3 E2E failures on dev

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
@@ -568,9 +568,12 @@ export function setupSpaceWorkflowRunHandlers(
 				workflowRunRepo.updateRun(params.runId, { failureReason: 'humanRejected' }) ?? run;
 
 			// Block the canonical task with gate_rejected reason
+			// Skip terminal tasks (done, cancelled, archived) — their status
+			// cannot transition back to blocked.
+			const TERMINAL_TASK_STATUSES = new Set(['done', 'cancelled', 'archived']);
 			const runTasks = spaceTaskRepo.listByWorkflowRun(params.runId);
 			const canonicalTask = runTasks[0];
-			if (canonicalTask && canonicalTask.status !== 'blocked') {
+			if (canonicalTask && !TERMINAL_TASK_STATUSES.has(canonicalTask.status)) {
 				const taskMgr = taskManagerFactory(run.spaceId);
 				await taskMgr.setTaskStatus(canonicalTask.id, 'blocked', {
 					result: params.reason ?? 'Gate rejected',

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -348,9 +348,10 @@ export function ContextPanel() {
 					flex flex-col
 					pt-safe md:pt-0
 					z-40 md:z-auto
-					transition-transform duration-300 ease-in-out
-					${isPanelOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}
+					max-md:transition-transform max-md:duration-300 max-md:ease-in-out
+					${isPanelOpen ? 'max-md:translate-x-0' : 'max-md:-translate-x-full'}
 					${hideDesktopPanel ? 'md:hidden' : ''}
+					overflow-hidden
 				`}
 			>
 				{/* Mobile nav strip - replaces NavRail on mobile */}

--- a/packages/web/src/islands/__tests__/ContextPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/ContextPanel.test.tsx
@@ -493,39 +493,40 @@ describe('ContextPanel', () => {
 			expect(panel?.className).toContain('md:relative');
 		});
 
-		it('should have -translate-x-full when closed on mobile', () => {
+		it('should have max-md:-translate-x-full when closed on mobile', () => {
 			mockContextPanelOpenSignal.value = false;
 
 			const { container } = render(<ContextPanel />);
 
 			const panel = container.querySelector('.w-70');
-			expect(panel?.className).toContain('-translate-x-full');
+			expect(panel?.className).toContain('max-md:-translate-x-full');
 		});
 
-		it('should have translate-x-0 when open on mobile', () => {
+		it('should have max-md:translate-x-0 when open on mobile', () => {
 			mockContextPanelOpenSignal.value = true;
 
 			const { container } = render(<ContextPanel />);
 
 			const panel = container.querySelector('.w-70');
-			expect(panel?.className).toContain('translate-x-0');
+			expect(panel?.className).toContain('max-md:translate-x-0');
 		});
 
-		it('should have md:translate-x-0 to always show on desktop', () => {
+		it('should not have transform classes on desktop', () => {
 			mockContextPanelOpenSignal.value = false;
 
 			const { container } = render(<ContextPanel />);
 
 			const panel = container.querySelector('.w-70');
-			expect(panel?.className).toContain('md:translate-x-0');
+			expect(panel?.className).not.toContain('translate-x-0');
+			expect(panel?.className).not.toContain('md:translate-x-0');
 		});
 
-		it('should have transition classes for smooth animation', () => {
+		it('should have max-md:transition classes for smooth mobile animation', () => {
 			const { container } = render(<ContextPanel />);
 
 			const panel = container.querySelector('.w-70');
-			expect(panel?.className).toContain('transition-transform');
-			expect(panel?.className).toContain('duration-300');
+			expect(panel?.className).toContain('max-md:transition-transform');
+			expect(panel?.className).toContain('max-md:duration-300');
 		});
 
 		it('should have z-40 for mobile stacking', () => {


### PR DESCRIPTION
- **ContextPanel**: scope slide-in transform/transition to mobile only (`max-md:`) — the `transform: translateX(0px)` on desktop created a stacking context that intercepted pointer events over the main content, causing Playwright click failures in `space-navigation` and `space-task-fullwidth`
- **approveGate handler**: skip blocking the canonical task when it's already terminal (`done`/`cancelled`/`archived`) — the invalid `done → blocked` transition threw, preventing `onClose` from being called and leaving the GateArtifactsView overlay open

Fixes: `space-navigation`, `space-task-fullwidth`, `space-approval-gate-rejection`