### PR TITLE
fix(e2e): increase timeout for flaky mission-detail-page tab check

### DIFF
--- a/packages/e2e/tests/features/mission-detail-page.e2e.ts
+++ b/packages/e2e/tests/features/mission-detail-page.e2e.ts
@@ -315,10 +315,10 @@ test.describe('MissionDetail Page — Navigation', () => {
 		// Use exact: true to avoid matching sidebar CollapsibleSection buttons whose accessible
 		// names contain "Missions" as a substring (e.g. "Missions section").
 		await expect(page.getByRole('button', { name: 'Missions', exact: true })).toBeVisible({
-			timeout: 5000,
+			timeout: 10000,
 		});
 		await expect(page.getByRole('button', { name: 'Tasks', exact: true })).toBeVisible({
-			timeout: 5000,
+			timeout: 10000,
 		});
 	});
 });


### PR DESCRIPTION
Pre-existing flaky test — `getByRole('button', { name: 'Tasks' })` times out at 5s under CI load. Increase both "Missions" and "Tasks" checks to 10s.