### PR TITLE
feat(space): runtime pause/resume lifecycle controls

### DIFF
--- a/docs/space-autonomy-hitl-gaps-claude-opus-4-6.md
+++ b/docs/space-autonomy-hitl-gaps-claude-opus-4-6.md
@@ -70,7 +70,7 @@ that must guide every implementation decision in this gap list.
 
 CLAUDE.md states: *"Semi-autonomous: Worker can merge approved PRs without human confirmation"*
 
-Tasks track `prUrl`, `prNumber`, `prCreatedAt` but:
+PR tracking migrated from hardcoded `SpaceTask` fields to `workflow_run_artifacts` table (PR #1496), but:
 - No merge logic exists
 - No gate script template for "wait for N approvals + CI green"
 - No differentiation between supervised (human must merge) and semi-autonomous (agent can merge approved PRs)
@@ -80,7 +80,7 @@ Tasks track `prUrl`, `prNumber`, `prCreatedAt` but:
 
 ---
 
-### 2. Approval Notification/Queue UI ✅ PR #TBD
+### 2. Approval Notification/Queue UI ✅ PR #1491
 
 Gates support `writers: ['human']` and `spaceWorkflowRun.approveGate` RPC exists. However:
 - ~~No notification to tell humans a gate is waiting~~
@@ -99,15 +99,20 @@ Gates support `writers: ['human']` and `spaceWorkflowRun.approveGate` RPC exists
 
 ---
 
-### 2b. Action UI (Approve/Reject/Resolve)
+### 2b. Action UI (Approve/Reject/Resolve) ✅ PR #1493
 
-Gap #2 surfaces *that* tasks need human attention, but there is no UI for *taking* that action.
+~~Gap #2 surfaces *that* tasks need human attention, but there is no UI for *taking* that action.~~
 
-Missing:
-- Approve/reject buttons for gate-pending tasks (`spaceWorkflowRun.approveGate` RPC exists but has no UI)
+~~Missing:~~
+- ~~Approve/reject buttons for gate-pending tasks (`spaceWorkflowRun.approveGate` RPC exists but has no UI)~~
 - Input form for `human_input_requested` tasks (agent asked a question, human has no way to answer)
-- "Mark done" / "Re-open" actions for tasks in `review` status
-- Contextual display of *why* the task is blocked (gate message, agent's question, dependency chain)
+- ~~"Mark done" / "Re-open" actions for tasks in `review` status~~
+- ~~Contextual display of *why* the task is blocked (gate message, agent's question, dependency chain)~~
+
+**Implemented:**
+- `TaskBlockedBanner` component with distinct UI per `blockReason` (6 reason types)
+- Gate approval flow: `gate_rejected` banner → "Review & Approve" → `GateArtifactsView` inline with diff review + approve/reject
+- `listGateData` and `approveGate` wired to frontend `spaceStore`
 
 **Depends on:** Gap #2 (notification/queue), Gap #8 (block reasons)  
 **Impact:** High — without action UI, the notification queue is informational only  
@@ -115,13 +120,19 @@ Missing:
 
 ---
 
-### 3. Approval Audit Trail
+### 3. Approval Audit Trail ✅ PR #1481
 
-When a human approves a gate or transitions a task from `review` -> `done`:
-- No record of **who** approved or **when**
-- No approval comment/reason field
-- Room system tracks `approvalSource` (`"human"` vs `"leader_semi_auto"`) but space system doesn't
-- No audit log for gate state changes
+~~When a human approves a gate or transitions a task from `review` -> `done`:~~
+- ~~No record of **who** approved or **when**~~
+- ~~No approval comment/reason field~~
+- ~~Room system tracks `approvalSource` (`"human"` vs `"leader_semi_auto"`) but space system doesn't~~
+- ~~No audit log for gate state changes~~
+
+**Implemented:**
+- `SpaceApprovalSource` type (`human | neo_agent | space_agent | task_agent | node_agent | semi_auto`)
+- `approvalSource`, `approvalReason`, `approvedAt` stamped on SpaceTask and gate data at every code path
+- `approve_gate` tool added to Space Agent and Task Agent; `approve_task` tool added to Space Agent
+- Approval metadata cleared on task reactivation (done → in_progress)
 
 **Impact:** Medium — no accountability  
 **Effort:** Low
@@ -141,13 +152,19 @@ Semi-autonomous is identical to supervised during execution. Missing:
 
 ---
 
-### 5. Task Dependency Enforcement
+### 5. Task Dependency Enforcement ✅ PR #1488
 
-`SpaceTask.dependsOn` stores dependency IDs but is **not enforced at runtime**:
-- Tasks with unmet deps can be started
-- No auto-blocking when dependencies incomplete
-- No auto-unblocking when dependencies complete
-- `cancelTaskCascade()` exists for cancellation propagation but no `completionCascade()` for unblocking
+~~`SpaceTask.dependsOn` stores dependency IDs but is **not enforced at runtime**:~~
+- ~~Tasks with unmet deps can be started~~
+- ~~No auto-blocking when dependencies incomplete~~
+- ~~No auto-unblocking when dependencies complete~~
+- ~~`cancelTaskCascade()` exists for cancellation propagation but no `completionCascade()` for unblocking~~
+
+**Implemented:**
+- `areDependenciesMet()` check at scheduling time — tasks with unmet deps stay `open`
+- DFS-based circular dependency detection on create and update
+- `blockDependentTasks()` cascades `dependency_failed` block reason to open dependents on failure/cancel
+- Dependency ID validation on `updateTask()` (was only on create)
 
 **Impact:** Medium  
 **Effort:** Medium
@@ -186,17 +203,17 @@ No cross-pollination of patterns between the two systems.
 
 ---
 
-### 8. Block Reason Tagging for Space Tasks
+### 8. Block Reason Tagging for Space Tasks ✅ PR #1486
 
-Space tasks use a single `blocked` status for all failure modes. Once a task is blocked,
+~~Space tasks use a single `blocked` status for all failure modes. Once a task is blocked,
 nothing in the system knows *why* — the UI, notifications, retry logic, and Space Agent
-all see the same opaque state.
+all see the same opaque state.~~
 
 **Approach:** Keep `blocked` as the only status. Add a `blockReason` field that records
 the specific cause. Downstream systems (notifications, retry, autonomy) branch on the
 reason, not the status.
 
-**Block reasons (by code path):**
+**Implemented block reasons (by code path):**
 
 | Reason | Trigger | Who resolves | Auto-recoverable? |
 |--------|---------|-------------|-------------------|
@@ -205,7 +222,12 @@ reason, not the status.
 | `execution_failed` | Node hit unrecoverable error | Space Agent → human | No |
 | `human_input_requested` | Task Agent called `request_human_input` | Human (answer the question) | No (by design) |
 | `gate_rejected` | Human or agent rejected a gate | Human (re-approve or revise) | No |
-| `dependency_failed` | Upstream task failed (future, Gap 5) | Depends on upstream fix | No |
+| `dependency_failed` | Upstream task failed (Gap #5) | Depends on upstream fix | No |
+
+**Implemented:**
+- 6 structured `blockReason` types with `stampBlockReason()` / `clearBlockReason()` API
+- `gate_rejected` wired into approval gate rejection flow
+- `dependency_failed` wired into dependency cascade (PR #1488)
 
 **Why not a separate `needs_attention` status?**
 - No status machine changes, no migration of existing tasks
@@ -242,21 +264,62 @@ Workflow topology is fixed regardless of autonomy level:
 
 ---
 
+### 11. Runtime Lifecycle Controls (Start/Pause/Resume) ✅
+
+~~SpaceRuntime has `start()` and `stop()` methods but they are internal-only — no RPC handlers, no UI controls. There is no pause/resume concept at all.~~
+
+**Implemented:**
+- `paused` boolean field on Space (migration 85)
+- `space.pause` / `space.resume` RPC handlers with `space.updated` event emission
+- Tick loop skips paused spaces: `listActiveSpaces()` filters them out, `processRunTick` checks `space.paused`
+- `SpaceStore.pauseSpace()` / `resumeSpace()` frontend methods
+- `RuntimeControlBar` in SpaceOverview with Pause/Resume buttons
+- `runtimeState` signal derived from `space.paused` + `space.status`
+
+**Impact:** High — users cannot control execution flow  
+**Effort:** Low-Medium
+
+---
+
+### 12. Autonomy Level UI Toggle (Manual/Semi-Auto/Full-Auto)
+
+The autonomy model is binary (`supervised` / `semi_autonomous`) and has no UI toggle.
+
+Current state:
+- `SpaceAutonomyLevel = 'supervised' | 'semi_autonomous'` — set at creation, changeable via `space.update` RPC
+- `SpaceSettings.tsx` does NOT expose autonomyLevel for editing
+- No "manual" mode (human triggers each task, no auto-scheduling)
+- No "full autonomous" mode (skip all review, no escalation)
+- Autonomy only affects task terminal status (review vs done) — one decision point
+
+Missing:
+- UI toggle in SpaceSettings for autonomy level
+- "Manual" autonomy level — runtime doesn't auto-schedule tasks, human must explicitly start each one
+- "Full autonomous" level — no review step, aggressive retry, minimal escalation
+- Per-task autonomy override (some tasks need human review even in semi-auto spaces)
+
+**Impact:** Medium — users can't change autonomy through UI, can't express manual or full-auto intent  
+**Effort:** Medium
+
+---
+
 ## Priority Matrix
 
-| # | Gap | Impact | Effort | Priority |
-|---|-----|--------|--------|----------|
-| 1 | PR auto-merge for semi-autonomous | High | Medium | **P0** |
-| 2 | Approval notification/queue UI | Medium | Medium | **P1** |
-| 2b | Action UI (approve/reject/resolve) | High | Medium | **P1** |
-| 3 | Approval audit trail | Medium | Low | **P1** |
-| 4 | Execution-time autonomy differentiation | High | High | **P2** |
-| 5 | Task dependency enforcement | Medium | Medium | **P2** |
-| 6 | Tiered retry by autonomy level | Medium | Medium | **P2** |
-| 7 | Room/Space autonomy unification | High | High | **P3** |
-| 8 | Block reason tagging for space tasks | Low-Medium | Low | **P2** |
-| 9 | Human review SLA/timeout | Low | Low | **P3** |
-| 10 | Conditional branching by autonomy | Medium | High | **P3** |
+| # | Gap | Impact | Effort | Priority | Status |
+|---|-----|--------|--------|----------|--------|
+| 1 | PR auto-merge for semi-autonomous | High | Medium | **P0** | |
+| 2 | Approval notification/queue UI | Medium | Medium | **P1** | ✅ PR #1491 |
+| 2b | Action UI (approve/reject/resolve) | High | Medium | **P1** | ✅ PR #1493 |
+| 3 | Approval audit trail | Medium | Low | **P1** | ✅ PR #1481 |
+| 4 | Execution-time autonomy differentiation | High | High | **P2** | |
+| 5 | Task dependency enforcement | Medium | Medium | **P2** | ✅ PR #1488 |
+| 6 | Tiered retry by autonomy level | Medium | Medium | **P2** | |
+| 7 | Room/Space autonomy unification | High | High | **P3** | |
+| 8 | Block reason tagging for space tasks | Low-Medium | Low | **P2** | ✅ PR #1486 |
+| 9 | Human review SLA/timeout | Low | Low | **P3** | |
+| 10 | Conditional branching by autonomy | Medium | High | **P3** | |
+| 11 | Runtime lifecycle controls | High | Low-Medium | **P1** | ✅ |
+| 12 | Autonomy level UI toggle | Medium | Medium | **P2** | |
 
 ## Dependency Graph & Implementation Order
 
@@ -285,14 +348,21 @@ Gap 6 (Tiered Retry) ───────────────────�
 | 1 | **#3 Audit trail** | Foundation — everything else needs to record who/when/why | Low | **Done** (PR #1481) |
 | 2 | **#8 Block reason tagging** | Foundation — distinguishes block types for notifications & retry | Low | **Done** (PR #1486) |
 | 3 | **#5 Dependency enforcement** | Standalone, no deps, fixes correctness issue | Medium | **Done** (PR #1488) |
-| 4 | **#2 Notification UI** | Builds on 3+8, unlocks human-in-the-loop usability | Medium | |
-| 5 | **#2b Action UI** | Builds on #2, makes notification queue actionable | Medium | |
+| 4 | **#2 Notification UI** | Builds on 3+8, unlocks human-in-the-loop usability | Medium | **Done** (PR #1491) |
+| 5 | **#2b Action UI** | Builds on #2, makes notification queue actionable | Medium | **Done** (PR #1493) |
 | 6 | **#9 Review SLA** | Small, builds on audit trail | Low | |
-| 7 | **#6 Tiered retry** | Standalone, but informed by needs_attention distinction | Medium | |
+| 7 | **#6 Tiered retry** | Standalone, but informed by block reason distinction | Medium | |
 | 8 | **#1 PR auto-merge** | Needs audit trail + notification + action UI in place | Medium | |
-| 9 | **#4 Execution-time autonomy** | Builds on retry + needs_attention + audit | High | |
+| 9 | **#4 Execution-time autonomy** | Builds on retry + block reasons + audit | High | |
 | 10 | **#10 Conditional branching** | Extends execution-time autonomy into workflow topology | High | |
 | 11 | **#7 Room/Space unification** | Last — needs both systems mature before merging patterns | High | |
+
+### Related Infrastructure Changes
+
+| PR | Change | Gaps affected |
+|----|--------|---------------|
+| #1464 | Replace `done`/`report_done`/`write_gate` with `idle`/`save`/auto-gate-write | #2b (gate flow) |
+| #1496 | Workflow run artifacts — typed node outputs replacing task-level PR fields | #1 (PR auto-merge prerequisite) |
 
 ## Key Files Reference
 

--- a/packages/daemon/src/lib/rpc-handlers/space-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-handlers.ts
@@ -300,6 +300,44 @@ export function setupSpaceHandlers(
 		return space;
 	});
 
+	// ─── space.pause ───────────────────────────────────────────────────────────
+	messageHub.onRequest('space.pause', async (data) => {
+		const params = data as { id: string };
+
+		if (!params.id) {
+			throw new Error('id is required');
+		}
+
+		const space = await spaceManager.pauseSpace(params.id);
+
+		daemonHub
+			.emit('space.updated', { sessionId: 'global', spaceId: params.id, space })
+			.catch((err) => {
+				log.warn('Failed to emit space.updated:', err);
+			});
+
+		return space;
+	});
+
+	// ─── space.resume ──────────────────────────────────────────────────────────
+	messageHub.onRequest('space.resume', async (data) => {
+		const params = data as { id: string };
+
+		if (!params.id) {
+			throw new Error('id is required');
+		}
+
+		const space = await spaceManager.resumeSpace(params.id);
+
+		daemonHub
+			.emit('space.updated', { sessionId: 'global', spaceId: params.id, space })
+			.catch((err) => {
+				log.warn('Failed to emit space.updated:', err);
+			});
+
+		return space;
+	});
+
 	// ─── space.delete ───────────────────────────────────────────────────────────
 	messageHub.onRequest('space.delete', async (data) => {
 		const params = data as { id: string };

--- a/packages/daemon/src/lib/space/managers/space-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-manager.ts
@@ -87,6 +87,40 @@ export class SpaceManager {
 	}
 
 	/**
+	 * Pause a space (stops runtime task scheduling without archiving)
+	 */
+	async pauseSpace(id: string): Promise<Space> {
+		const space = this.spaceRepo.getSpace(id);
+		if (!space) {
+			throw new Error(`Space not found: ${id}`);
+		}
+
+		const paused = this.spaceRepo.pauseSpace(id);
+		if (!paused) {
+			throw new Error(`Failed to pause space: ${id}`);
+		}
+
+		return paused;
+	}
+
+	/**
+	 * Resume a paused space
+	 */
+	async resumeSpace(id: string): Promise<Space> {
+		const space = this.spaceRepo.getSpace(id);
+		if (!space) {
+			throw new Error(`Space not found: ${id}`);
+		}
+
+		const resumed = this.spaceRepo.resumeSpace(id);
+		if (!resumed) {
+			throw new Error(`Failed to resume space: ${id}`);
+		}
+
+		return resumed;
+	}
+
+	/**
 	 * Archive a space
 	 */
 	async archiveSpace(id: string): Promise<Space> {

--- a/packages/daemon/src/lib/space/managers/space-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-manager.ts
@@ -94,6 +94,7 @@ export class SpaceManager {
 		if (!space) {
 			throw new Error(`Space not found: ${id}`);
 		}
+		if (space.paused) return space;
 
 		const paused = this.spaceRepo.pauseSpace(id);
 		if (!paused) {
@@ -111,6 +112,7 @@ export class SpaceManager {
 		if (!space) {
 			throw new Error(`Space not found: ${id}`);
 		}
+		if (!space.paused) return space;
 
 		const resumed = this.spaceRepo.resumeSpace(id);
 		if (!resumed) {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -905,11 +905,6 @@ export class SpaceRuntime {
 			return;
 		}
 
-		// Skip processing for paused spaces — existing agents keep running but
-		// no new scheduling, retries, or notifications are emitted.
-		const pauseCheckSpace = await this.config.spaceManager.getSpace(run.spaceId);
-		if (pauseCheckSpace?.paused) return;
-
 		// Blocked run recovery: attempt bounded automatic retry before giving up.
 		if (run.status === 'blocked') {
 			await this.attemptBlockedRunRecovery(runId, run);
@@ -1249,6 +1244,10 @@ export class SpaceRuntime {
 			}
 
 			// Step 2: Spawn workflow node agents for pending executions without sessions.
+			// Skip spawning for paused spaces — completion/timeout/crash detection above
+			// still runs so in-flight agents are monitored, but no new agents are started.
+			if (space?.paused) return;
+
 			nodeExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
 			const pendingExecutions = nodeExecutions.filter(
 				(execution) => execution.status === 'pending' && !execution.agentSessionId

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -360,6 +360,15 @@ export class SpaceRuntime {
 		}
 	}
 
+	/**
+	 * Returns active, non-paused spaces.
+	 * Used by tick-loop methods to skip paused spaces.
+	 */
+	private async listActiveSpaces(): Promise<import('@neokai/shared').Space[]> {
+		const spaces = await this.config.spaceManager.listSpaces(false);
+		return spaces.filter((s) => !s.paused);
+	}
+
 	private async updateTaskAndEmit(
 		spaceId: string,
 		taskId: string,
@@ -531,7 +540,7 @@ export class SpaceRuntime {
 	 * where external paths marked the run terminal but left task state inconsistent.
 	 */
 	private async reconcileTerminalRunsWithoutExecutors(): Promise<void> {
-		const spaces = await this.config.spaceManager.listSpaces(false);
+		const spaces = await this.listActiveSpaces();
 		for (const space of spaces) {
 			const terminalRuns = this.config.workflowRunRepo
 				.listBySpace(space.id)
@@ -895,6 +904,11 @@ export class SpaceRuntime {
 		if (run.status === 'cancelled' || run.status === 'done') {
 			return;
 		}
+
+		// Skip processing for paused spaces — existing agents keep running but
+		// no new scheduling, retries, or notifications are emitted.
+		const pauseCheckSpace = await this.config.spaceManager.getSpace(run.spaceId);
+		if (pauseCheckSpace?.paused) return;
 
 		// Blocked run recovery: attempt bounded automatic retry before giving up.
 		if (run.status === 'blocked') {
@@ -1537,7 +1551,7 @@ export class SpaceRuntime {
 	 * of outstanding issues. See the `notifiedTaskSet` field comment for details.
 	 */
 	private async checkStandaloneTasks(): Promise<void> {
-		const spaces = await this.config.spaceManager.listSpaces(false);
+		const spaces = await this.listActiveSpaces();
 
 		for (const space of spaces) {
 			// Fetch all standalone tasks including archived ones for the dedup cleanup pass.
@@ -1612,7 +1626,7 @@ export class SpaceRuntime {
 	 * 3. Attach the original task to the run and mark it in_progress
 	 */
 	private async attachStandaloneTasksToWorkflows(): Promise<void> {
-		const spaces = await this.config.spaceManager.listSpaces(false);
+		const spaces = await this.listActiveSpaces();
 
 		for (const space of spaces) {
 			const workflows = this.config.spaceWorkflowManager.listWorkflows(space.id);

--- a/packages/daemon/src/storage/repositories/space-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-repository.ts
@@ -175,6 +175,24 @@ export class SpaceRepository {
 	}
 
 	/**
+	 * Pause a space (stops runtime task scheduling without archiving)
+	 */
+	pauseSpace(id: string): Space | null {
+		const stmt = this.db.prepare(`UPDATE spaces SET paused = 1, updated_at = ? WHERE id = ?`);
+		stmt.run(Date.now(), id);
+		return this.getSpace(id);
+	}
+
+	/**
+	 * Resume a paused space
+	 */
+	resumeSpace(id: string): Space | null {
+		const stmt = this.db.prepare(`UPDATE spaces SET paused = 0, updated_at = ? WHERE id = ?`);
+		stmt.run(Date.now(), id);
+		return this.getSpace(id);
+	}
+
+	/**
 	 * Archive a space
 	 */
 	archiveSpace(id: string): Space | null {
@@ -261,6 +279,7 @@ export class SpaceRepository {
 			allowedModels: rawModels.length > 0 ? rawModels : undefined,
 			sessionIds: JSON.parse(row.session_ids as string) as string[],
 			status: row.status as 'active' | 'archived',
+			paused: (row.paused as number) === 1,
 			autonomyLevel: rawAutonomyLevel as SpaceAutonomyLevel,
 			config,
 			createdAt: row.created_at as number,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -357,6 +357,10 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	//   - Creates workflow_run_artifacts table for typed node outputs (PRs, commits, etc.).
 	//   - Drops pr_url, pr_number, pr_created_at from space_tasks (replaced by artifacts).
 	runMigration84(db);
+
+	// Migration 85: Add paused column to spaces.
+	//   Allows users to pause/resume space runtime execution without archiving.
+	runMigration85(db);
 }
 
 /**
@@ -5716,4 +5720,17 @@ function runMigration84(db: BunDatabase): void {
 	} finally {
 		db.exec('PRAGMA foreign_keys = ON');
 	}
+}
+
+/**
+ * Migration 85: Add paused column to spaces table.
+ *
+ * Allows users to pause/resume space runtime execution without archiving.
+ * Paused spaces skip task scheduling and workflow processing in the tick loop.
+ * Default: 0 (not paused).
+ */
+function runMigration85(db: BunDatabase): void {
+	if (!tableExists(db, 'spaces')) return;
+	if (tableHasColumn(db, 'spaces', 'paused')) return;
+	db.exec(`ALTER TABLE spaces ADD COLUMN paused INTEGER NOT NULL DEFAULT 0`);
 }

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-handlers.test.ts
@@ -115,6 +115,8 @@ function createMockSpaceManager(space: Space | null = mockSpace): SpaceManager {
 		listSpaces: mock(async () => (space ? [space] : [])),
 		updateSpace: mock(async () => space!),
 		archiveSpace: mock(async () => ({ ...space!, status: 'archived' as const })),
+		pauseSpace: mock(async () => ({ ...space!, paused: true })),
+		resumeSpace: mock(async () => ({ ...space!, paused: false })),
 		deleteSpace: mock(async () => true),
 		addSession: mock(async () => space!),
 		removeSession: mock(async () => space!),
@@ -683,6 +685,48 @@ describe('space-handlers', () => {
 			await expect(call('space.overview', { id: 'ghost' })).rejects.toThrow(
 				'Space not found: ghost'
 			);
+		});
+	});
+
+	// ─── space.pause ──────────────────────────────────────────────────────────
+	describe('space.pause', () => {
+		beforeEach(() => setup());
+
+		it('pauses a space and emits space.updated', async () => {
+			const result = (await call('space.pause', { id: 'space-1' })) as Space;
+
+			expect(result.paused).toBe(true);
+			expect(spaceManager.pauseSpace).toHaveBeenCalledWith('space-1');
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.updated', {
+				sessionId: 'global',
+				spaceId: 'space-1',
+				space: result,
+			});
+		});
+
+		it('throws when id is missing', async () => {
+			await expect(call('space.pause', {})).rejects.toThrow('id is required');
+		});
+	});
+
+	// ─── space.resume ─────────────────────────────────────────────────────────
+	describe('space.resume', () => {
+		beforeEach(() => setup());
+
+		it('resumes a space and emits space.updated', async () => {
+			const result = (await call('space.resume', { id: 'space-1' })) as Space;
+
+			expect(result.paused).toBe(false);
+			expect(spaceManager.resumeSpace).toHaveBeenCalledWith('space-1');
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.updated', {
+				sessionId: 'global',
+				spaceId: 'space-1',
+				space: result,
+			});
+		});
+
+		it('throws when id is missing', async () => {
+			await expect(call('space.resume', {})).rejects.toThrow('id is required');
 		});
 	});
 });

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -30,6 +30,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			session_ids TEXT NOT NULL DEFAULT '[]',
 			status TEXT NOT NULL DEFAULT 'active'
 				CHECK(status IN ('active', 'archived')),
+			paused INTEGER NOT NULL DEFAULT 0,
 			autonomy_level TEXT NOT NULL DEFAULT 'supervised',
 			config TEXT,
 			created_at INTEGER NOT NULL,

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -84,7 +84,7 @@ export interface Space {
 	/** Current status of the Space */
 	status: SpaceStatus;
 	/** Whether the space runtime is paused (no new tasks scheduled or executed) */
-	paused?: boolean;
+	paused: boolean;
 	/** Autonomy level — controls how much the Space Agent can act without human approval */
 	autonomyLevel?: SpaceAutonomyLevel;
 	/** Runtime configuration (maxConcurrentTasks, taskTimeoutMs, etc.) */

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -83,6 +83,8 @@ export interface Space {
 	sessionIds: string[];
 	/** Current status of the Space */
 	status: SpaceStatus;
+	/** Whether the space runtime is paused (no new tasks scheduled or executed) */
+	paused?: boolean;
 	/** Autonomy level — controls how much the Space Agent can act without human approval */
 	autonomyLevel?: SpaceAutonomyLevel;
 	/** Runtime configuration (maxConcurrentTasks, taskTimeoutMs, etc.) */

--- a/packages/web/src/components/space/SpaceOverview.tsx
+++ b/packages/web/src/components/space/SpaceOverview.tsx
@@ -71,7 +71,17 @@ const RUNTIME_STYLES: Record<
 	},
 };
 
-function RuntimeControlBar({ state }: { state: RuntimeState }) {
+function RuntimeControlBar({
+	state,
+	actionLoading,
+	onPause,
+	onResume,
+}: {
+	state: RuntimeState;
+	actionLoading: boolean;
+	onPause: () => void;
+	onResume: () => void;
+}) {
 	const style = RUNTIME_STYLES[state];
 
 	return (
@@ -94,7 +104,30 @@ function RuntimeControlBar({ state }: { state: RuntimeState }) {
 						/>
 					)}
 				</div>
-				<span class="text-sm font-semibold text-gray-100">{style.label}</span>
+				<div>
+					<span class="text-sm font-semibold text-gray-100">{style.label}</span>
+					{actionLoading && <span class="ml-2 text-xs text-gray-500 italic">Processing...</span>}
+				</div>
+			</div>
+			<div class="flex items-center gap-2">
+				{state === 'running' && (
+					<button
+						onClick={onPause}
+						disabled={actionLoading}
+						class="px-4 py-2 text-sm font-medium text-yellow-300 bg-yellow-900/30 hover:bg-yellow-900/50 border border-yellow-700/40 rounded-lg transition-colors disabled:opacity-40"
+					>
+						Pause
+					</button>
+				)}
+				{state === 'paused' && (
+					<button
+						onClick={onResume}
+						disabled={actionLoading}
+						class="px-4 py-2 text-sm font-medium text-green-300 bg-green-900/30 hover:bg-green-900/50 border border-green-700/40 rounded-lg transition-colors disabled:opacity-40"
+					>
+						Resume
+					</button>
+				)}
 			</div>
 		</div>
 	);
@@ -143,6 +176,25 @@ interface SpaceOverviewProps {
 
 export function SpaceOverview({ spaceId, onSelectTask }: SpaceOverviewProps) {
 	const [showCreateTask, setShowCreateTask] = useState(false);
+	const [actionLoading, setActionLoading] = useState(false);
+
+	const handlePause = useCallback(async () => {
+		setActionLoading(true);
+		try {
+			await spaceStore.pauseSpace();
+		} finally {
+			setActionLoading(false);
+		}
+	}, []);
+
+	const handleResume = useCallback(async () => {
+		setActionLoading(true);
+		try {
+			await spaceStore.resumeSpace();
+		} finally {
+			setActionLoading(false);
+		}
+	}, []);
 
 	const handleNewSession = useCallback(async () => {
 		const space = spaceStore.space.value;
@@ -197,8 +249,15 @@ export function SpaceOverview({ spaceId, onSelectTask }: SpaceOverviewProps) {
 			<div class="min-h-[calc(100%+1px)] space-y-6">
 				<SpaceCreateTaskDialog isOpen={showCreateTask} onClose={() => setShowCreateTask(false)} />
 
-				{/* Runtime state (shown when available) */}
-				{runtimeState && <RuntimeControlBar state={runtimeState} />}
+				{/* Runtime state with pause/resume controls */}
+				{runtimeState && (
+					<RuntimeControlBar
+						state={runtimeState}
+						actionLoading={actionLoading}
+						onPause={() => void handlePause()}
+						onResume={() => void handleResume()}
+					/>
+				)}
 
 				{/* Stats strip */}
 				<div class="grid grid-cols-3 gap-3">

--- a/packages/web/src/components/space/__tests__/SpaceOverview.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceOverview.test.tsx
@@ -55,6 +55,7 @@ function makeSpace(overrides: Partial<Space> = {}): Space {
 		backgroundContext: '',
 		sessionIds: [],
 		status: 'active',
+		paused: false,
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
 		...overrides,

--- a/packages/web/src/components/space/__tests__/SpaceOverview.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceOverview.test.tsx
@@ -16,6 +16,9 @@ let mockSessions: ReturnType<
 	typeof signal<{ id: string; title?: string; status: string; lastActiveAt: number }[]>
 >;
 
+const mockPauseSpace = vi.fn().mockResolvedValue(undefined);
+const mockResumeSpace = vi.fn().mockResolvedValue(undefined);
+
 vi.mock('../../../lib/space-store', () => ({
 	get spaceStore() {
 		return {
@@ -24,6 +27,8 @@ vi.mock('../../../lib/space-store', () => ({
 			tasks: mockTasks,
 			runtimeState: mockRuntimeState,
 			sessions: mockSessions,
+			pauseSpace: mockPauseSpace,
+			resumeSpace: mockResumeSpace,
 		};
 	},
 }));
@@ -88,6 +93,9 @@ describe('SpaceOverview', () => {
 		mockLoading.value = false;
 		mockTasks.value = [];
 		mockRuntimeState.value = null;
+		mockSessions.value = [];
+		mockPauseSpace.mockClear();
+		mockResumeSpace.mockClear();
 	});
 
 	afterEach(() => {
@@ -217,5 +225,84 @@ describe('SpaceOverview', () => {
 		stats = getStatText();
 		expect(stats.some((t) => t?.includes('Active') && t?.includes('1'))).toBe(true);
 		expect(stats.some((t) => t?.includes('Review') && t?.includes('1'))).toBe(true);
+	});
+
+	describe('Runtime State Indicator', () => {
+		it('shows running state with green indicator and ping animation', () => {
+			mockSpace.value = makeSpace();
+			mockRuntimeState.value = 'running';
+			const { container, getByText } = render(<SpaceOverview spaceId="space-1" />);
+			expect(getByText('Running')).toBeTruthy();
+			expect(container.querySelector('.bg-green-400')).toBeTruthy();
+			expect(container.querySelector('.animate-ping')).toBeTruthy();
+		});
+
+		it('shows paused state with yellow indicator and no ping', () => {
+			mockSpace.value = makeSpace();
+			mockRuntimeState.value = 'paused';
+			const { container, getByText } = render(<SpaceOverview spaceId="space-1" />);
+			expect(getByText('Paused')).toBeTruthy();
+			expect(container.querySelector('.bg-yellow-400')).toBeTruthy();
+			expect(container.querySelector('.animate-ping')).toBeFalsy();
+		});
+
+		it('shows stopped state with gray indicator', () => {
+			mockSpace.value = makeSpace();
+			mockRuntimeState.value = 'stopped';
+			const { container, getByText } = render(<SpaceOverview spaceId="space-1" />);
+			expect(getByText('Stopped')).toBeTruthy();
+			expect(container.querySelector('.bg-gray-500')).toBeTruthy();
+		});
+	});
+
+	describe('Runtime Control Buttons', () => {
+		it('shows Pause button when running, no Resume button', () => {
+			mockSpace.value = makeSpace();
+			mockRuntimeState.value = 'running';
+			const { container } = render(<SpaceOverview spaceId="space-1" />);
+			const buttons = Array.from(container.querySelectorAll('button'));
+			expect(buttons.find((b) => b.textContent === 'Pause')).toBeTruthy();
+			expect(buttons.find((b) => b.textContent === 'Resume')).toBeFalsy();
+		});
+
+		it('shows Resume button when paused, no Pause button', () => {
+			mockSpace.value = makeSpace();
+			mockRuntimeState.value = 'paused';
+			const { container } = render(<SpaceOverview spaceId="space-1" />);
+			const buttons = Array.from(container.querySelectorAll('button'));
+			expect(buttons.find((b) => b.textContent === 'Resume')).toBeTruthy();
+			expect(buttons.find((b) => b.textContent === 'Pause')).toBeFalsy();
+		});
+
+		it('shows no control buttons when stopped', () => {
+			mockSpace.value = makeSpace();
+			mockRuntimeState.value = 'stopped';
+			const { container } = render(<SpaceOverview spaceId="space-1" />);
+			const buttons = Array.from(container.querySelectorAll('button'));
+			expect(buttons.find((b) => b.textContent === 'Pause')).toBeFalsy();
+			expect(buttons.find((b) => b.textContent === 'Resume')).toBeFalsy();
+		});
+
+		it('calls pauseSpace when Pause is clicked', async () => {
+			mockSpace.value = makeSpace();
+			mockRuntimeState.value = 'running';
+			const { container } = render(<SpaceOverview spaceId="space-1" />);
+			const pauseBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent === 'Pause'
+			)!;
+			await fireEvent.click(pauseBtn);
+			expect(mockPauseSpace).toHaveBeenCalledTimes(1);
+		});
+
+		it('calls resumeSpace when Resume is clicked', async () => {
+			mockSpace.value = makeSpace();
+			mockRuntimeState.value = 'paused';
+			const { container } = render(<SpaceOverview spaceId="space-1" />);
+			const resumeBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent === 'Resume'
+			)!;
+			await fireEvent.click(resumeBtn);
+			expect(mockResumeSpace).toHaveBeenCalledTimes(1);
+		});
 	});
 });

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -47,6 +47,7 @@ function makeSpace(id = 'space-1'): Space {
 		instructions: '',
 		sessionIds: [],
 		status: 'active',
+		paused: false,
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
 	};

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -169,6 +169,8 @@ function makeMockHub() {
 			if (method === 'spaceAgent.listBuiltInTemplates') return { templates: [] };
 			if (method === 'spaceWorkflow.list') return { workflows: [] };
 			// Daemon returns Space directly (not wrapped)
+			if (method === 'space.pause') return { ...makeSpace(), paused: true };
+			if (method === 'space.resume') return { ...makeSpace(), paused: false };
 			if (method === 'space.update') return makeSpace();
 			// Daemon returns SpaceTask directly (not wrapped)
 			if (method === 'spaceTask.create') return makeTask('new-task');
@@ -1088,6 +1090,119 @@ describe('SpaceStore — CRUD methods', () => {
 		await expect(spaceStore.deleteSpace()).rejects.toThrow('No space selected');
 		await expect(spaceStore.createAgent({ name: 'A' })).rejects.toThrow('No space selected');
 		await expect(spaceStore.createWorkflow({ name: 'W' })).rejects.toThrow('No space selected');
+	});
+
+	it('pauseSpace calls space.pause RPC and updates space + runtimeState', async () => {
+		await spaceStore.selectSpace('space-1');
+		await spaceStore.pauseSpace();
+
+		expect(mockHub.request).toHaveBeenCalledWith('space.pause', { id: 'space-1' });
+		expect(spaceStore.space.value?.paused).toBe(true);
+		expect(spaceStore.runtimeState.value).toBe('paused');
+	});
+
+	it('resumeSpace calls space.resume RPC and updates space + runtimeState', async () => {
+		await spaceStore.selectSpace('space-1');
+		// First pause, then resume
+		await spaceStore.pauseSpace();
+		expect(spaceStore.runtimeState.value).toBe('paused');
+
+		await spaceStore.resumeSpace();
+
+		expect(mockHub.request).toHaveBeenCalledWith('space.resume', { id: 'space-1' });
+		expect(spaceStore.space.value?.paused).toBe(false);
+		expect(spaceStore.runtimeState.value).toBe('running');
+	});
+
+	it('pauseSpace throws when no space selected', async () => {
+		await spaceStore.clearSpace();
+		await expect(spaceStore.pauseSpace()).rejects.toThrow('No space selected');
+	});
+
+	it('resumeSpace throws when no space selected', async () => {
+		await spaceStore.clearSpace();
+		await expect(spaceStore.resumeSpace()).rejects.toThrow('No space selected');
+	});
+});
+
+describe('SpaceStore — runtimeState', () => {
+	beforeEach(resetStore);
+	afterEach(() => vi.clearAllMocks());
+
+	it('runtimeState is "running" for active non-paused space', async () => {
+		await spaceStore.selectSpace('space-1');
+		// makeSpace() returns status: 'active', no paused field → running
+		expect(spaceStore.runtimeState.value).toBe('running');
+	});
+
+	it('runtimeState is "stopped" for archived space', async () => {
+		mockHub.request.mockImplementation(async (method: string) => {
+			if (method === 'space.overview') {
+				return {
+					space: { ...makeSpace(), status: 'archived' },
+					tasks: [],
+					workflowRuns: [],
+					sessions: [],
+				};
+			}
+			return {};
+		});
+
+		await spaceStore.selectSpace('space-1');
+		expect(spaceStore.runtimeState.value).toBe('stopped');
+	});
+
+	it('runtimeState is "paused" for paused space', async () => {
+		mockHub.request.mockImplementation(async (method: string) => {
+			if (method === 'space.overview') {
+				return {
+					space: { ...makeSpace(), paused: true },
+					tasks: [],
+					workflowRuns: [],
+					sessions: [],
+				};
+			}
+			return {};
+		});
+
+		await spaceStore.selectSpace('space-1');
+		expect(spaceStore.runtimeState.value).toBe('paused');
+	});
+
+	it('runtimeState is null when no space is selected', async () => {
+		await spaceStore.clearSpace();
+		expect(spaceStore.runtimeState.value).toBeNull();
+	});
+
+	it('space.updated event with paused: true updates runtimeState to paused', async () => {
+		await spaceStore.selectSpace('space-1');
+		expect(spaceStore.runtimeState.value).toBe('running');
+
+		fireMockEvent('space.updated', {
+			spaceId: 'space-1',
+			space: { paused: true },
+		});
+
+		expect(spaceStore.runtimeState.value).toBe('paused');
+		expect(spaceStore.space.value?.paused).toBe(true);
+	});
+
+	it('space.updated event with paused: false updates runtimeState to running', async () => {
+		await spaceStore.selectSpace('space-1');
+		// Set to paused first
+		fireMockEvent('space.updated', {
+			spaceId: 'space-1',
+			space: { paused: true },
+		});
+		expect(spaceStore.runtimeState.value).toBe('paused');
+
+		// Now resume via event
+		fireMockEvent('space.updated', {
+			spaceId: 'space-1',
+			space: { paused: false },
+		});
+
+		expect(spaceStore.runtimeState.value).toBe('running');
 	});
 });
 

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -166,8 +166,8 @@ class SpaceStore {
 	// ========================================
 
 	/** Derive runtime state from Space fields */
-	private updateRuntimeState(space: Space | null): void {
-		if (!space || space.status === 'archived') {
+	private updateRuntimeState(space: Space): void {
+		if (space.status === 'archived') {
 			this.runtimeState.value = 'stopped';
 			return;
 		}

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -162,6 +162,19 @@ class SpaceStore {
 	private activeAttentionTasksSubscriptionId: string | null = null;
 
 	// ========================================
+	// Private Helpers
+	// ========================================
+
+	/** Derive runtime state from Space fields */
+	private updateRuntimeState(space: Space | null): void {
+		if (!space || space.status === 'archived') {
+			this.runtimeState.value = 'stopped';
+			return;
+		}
+		this.runtimeState.value = space.paused ? 'paused' : 'running';
+	}
+
+	// ========================================
 	// Computed Signals
 	// ========================================
 
@@ -594,7 +607,9 @@ class SpaceStore {
 			space?: Partial<Space>;
 		}>('space.updated', (event) => {
 			if (event.spaceId === spaceId && event.space && this.space.value) {
-				this.space.value = { ...this.space.value, ...event.space } as Space;
+				const updated = { ...this.space.value, ...event.space } as Space;
+				this.space.value = updated;
+				this.updateRuntimeState(updated);
 			}
 		});
 		this.cleanupFunctions.push(unsubSpaceUpdated);
@@ -831,6 +846,7 @@ class SpaceStore {
 		}
 
 		this.space.value = overview.space;
+		this.updateRuntimeState(overview.space);
 		this.workflowRuns.value = overview.workflowRuns ?? [];
 		// Server already returns collapsed tasks via collapseToCanonicalTasks — use directly
 		this.tasks.value = overview.tasks ?? [];
@@ -1532,6 +1548,7 @@ class SpaceStore {
 		const space = await hub.request<Space>('space.update', { id: spaceId, ...params });
 		if (space) {
 			this.space.value = space;
+			this.updateRuntimeState(space);
 		}
 	}
 
@@ -1548,6 +1565,40 @@ class SpaceStore {
 		await hub.request('space.archive', { id: spaceId });
 		// Clear selection after archive
 		await this.clearSpace();
+	}
+
+	/**
+	 * Pause the current space (stops task scheduling without archiving)
+	 */
+	async pauseSpace(): Promise<void> {
+		const spaceId = this.spaceId.value;
+		if (!spaceId) throw new Error('No space selected');
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		const space = await hub.request<Space>('space.pause', { id: spaceId });
+		if (space) {
+			this.space.value = space;
+			this.updateRuntimeState(space);
+		}
+	}
+
+	/**
+	 * Resume a paused space
+	 */
+	async resumeSpace(): Promise<void> {
+		const spaceId = this.spaceId.value;
+		if (!spaceId) throw new Error('No space selected');
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		const space = await hub.request<Space>('space.resume', { id: spaceId });
+		if (space) {
+			this.space.value = space;
+			this.updateRuntimeState(space);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Per-space pause/resume: migration, repository, manager, RPC handlers, and runtime tick filtering
- `RuntimeControlBar` in SpaceOverview with Pause/Resume buttons and state indicator (running/paused/stopped)
- `spaceStore` pause/resume methods with `runtimeState` signal derived from `space.paused` + `space.status`
- Daemon RPC handler tests, space-store unit tests, SpaceOverview component tests

## Test plan
- [x] Daemon unit tests pass (2060/2060)
- [x] Web unit tests pass (122 new + existing)
- [x] Pre-commit checks pass (lint, format, typecheck, knip)