### PR TITLE
refactor(test): improve daemon unit test DX with parallel shard runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,7 +105,6 @@ jobs:
       - name: Run Knip
         id: knip
         run: bun run knip
-        continue-on-error: true
 
       - name: Run type check
         id: typecheck

--- a/packages/daemon/tests/unit/1-core/session/sandbox-default.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/sandbox-default.test.ts
@@ -31,16 +31,14 @@ mock.module('@neokai/shared/sdk/type-guards', () => ({
 	isSDKAPIRetryMessage: (msg: { type: string; subtype?: string }) =>
 		msg.type === 'system' && msg.subtype === 'api_retry',
 	isSDKStreamEvent: (msg: { type: string }) => msg.type === 'stream_event',
-	isSDKToolProgressMessage: (msg: { type: string; subtype?: string }) =>
-		msg.type === 'system' && msg.subtype === 'tool_progress',
-	isSDKAuthStatusMessage: (msg: { type: string; subtype?: string }) =>
-		msg.type === 'system' && msg.subtype === 'auth_status',
-	isSDKRateLimitEvent: (msg: { type: string; subtype?: string }) =>
-		msg.type === 'system' && msg.subtype === 'rate_limit',
+	isSDKToolProgressMessage: (msg: { type: string }) => msg.type === 'tool_progress',
+	isSDKAuthStatusMessage: (msg: { type: string }) => msg.type === 'auth_status',
+	isSDKRateLimitEvent: (msg: { type: string }) => msg.type === 'rate_limit_event',
 	isToolUseBlock: (block: { type: string }) => block.type === 'tool_use',
 	isTextBlock: (block: { type: string }) => block.type === 'text',
 	isThinkingBlock: (block: { type: string }) => block.type === 'thinking',
-	isUserVisibleMessage: (msg: { type: string }) => msg.type === 'assistant' || msg.type === 'user',
+	isUserVisibleMessage: (msg: { type: string }) =>
+		msg.type !== 'stream_event' && msg.type !== 'api_retry',
 }));
 
 import {

--- a/packages/daemon/tests/unit/1-core/session/session-lifecycle-sdk-title.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-lifecycle-sdk-title.test.ts
@@ -115,16 +115,14 @@ mock.module('@neokai/shared/sdk/type-guards', () => ({
 	isSDKAPIRetryMessage: (msg: { type: string; subtype?: string }) =>
 		msg.type === 'system' && msg.subtype === 'api_retry',
 	isSDKStreamEvent: (msg: { type: string }) => msg.type === 'stream_event',
-	isSDKToolProgressMessage: (msg: { type: string; subtype?: string }) =>
-		msg.type === 'system' && msg.subtype === 'tool_progress',
-	isSDKAuthStatusMessage: (msg: { type: string; subtype?: string }) =>
-		msg.type === 'system' && msg.subtype === 'auth_status',
-	isSDKRateLimitEvent: (msg: { type: string; subtype?: string }) =>
-		msg.type === 'system' && msg.subtype === 'rate_limit',
+	isSDKToolProgressMessage: (msg: { type: string }) => msg.type === 'tool_progress',
+	isSDKAuthStatusMessage: (msg: { type: string }) => msg.type === 'auth_status',
+	isSDKRateLimitEvent: (msg: { type: string }) => msg.type === 'rate_limit_event',
 	isToolUseBlock: (block: { type: string }) => block.type === 'tool_use',
 	isTextBlock: (block: { type: string }) => block.type === 'text',
 	isThinkingBlock: (block: { type: string }) => block.type === 'thinking',
-	isUserVisibleMessage: (msg: { type: string }) => msg.type === 'assistant' || msg.type === 'user',
+	isUserVisibleMessage: (msg: { type: string }) =>
+		msg.type !== 'stream_event' && msg.type !== 'api_retry',
 }));
 
 import {

--- a/packages/daemon/tests/unit/1-core/session/session-lifecycle.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-lifecycle.test.ts
@@ -31,16 +31,14 @@ mock.module('@neokai/shared/sdk/type-guards', () => ({
 	isSDKAPIRetryMessage: (msg: { type: string; subtype?: string }) =>
 		msg.type === 'system' && msg.subtype === 'api_retry',
 	isSDKStreamEvent: (msg: { type: string }) => msg.type === 'stream_event',
-	isSDKToolProgressMessage: (msg: { type: string; subtype?: string }) =>
-		msg.type === 'system' && msg.subtype === 'tool_progress',
-	isSDKAuthStatusMessage: (msg: { type: string; subtype?: string }) =>
-		msg.type === 'system' && msg.subtype === 'auth_status',
-	isSDKRateLimitEvent: (msg: { type: string; subtype?: string }) =>
-		msg.type === 'system' && msg.subtype === 'rate_limit',
+	isSDKToolProgressMessage: (msg: { type: string }) => msg.type === 'tool_progress',
+	isSDKAuthStatusMessage: (msg: { type: string }) => msg.type === 'auth_status',
+	isSDKRateLimitEvent: (msg: { type: string }) => msg.type === 'rate_limit_event',
 	isToolUseBlock: (block: { type: string }) => block.type === 'tool_use',
 	isTextBlock: (block: { type: string }) => block.type === 'text',
 	isThinkingBlock: (block: { type: string }) => block.type === 'thinking',
-	isUserVisibleMessage: (msg: { type: string }) => msg.type === 'assistant' || msg.type === 'user',
+	isUserVisibleMessage: (msg: { type: string }) =>
+		msg.type !== 'stream_event' && msg.type !== 'api_retry',
 }));
 
 // Mock provider-service so generateTitleAndRenameBranch tests don't hit real credentials.


### PR DESCRIPTION
## Summary
- Add `scripts/test-daemon.sh`: parallel shard runner (~60s wall time), with `--rerun` and `--show-failures` for quick iteration
- Add `bunfig.toml` preload so bare `bun test` from `packages/daemon/` auto-loads `setup.ts`
- Restructure test dirs: merge `3-features/` into `2-handlers/`, split `5-space/space/` into `agent/runtime/workflow/other`
- Wire Makefile, package.json, and CI to use `test-daemon.sh`
- Add `0-shared` shard to isolate `packages/shared/tests` from daemon mock pollution (fixes 10 pre-existing type-guards failures)

## Test plan
- [x] `./scripts/test-daemon.sh` — all 8 shards pass (10,875 tests, 0 failures, 60s wall time)
- [x] `./scripts/test-daemon.sh --rerun` — reruns only failing files
- [x] `make test-daemon` — delegates to wrapper with coverage
- [x] `cd packages/daemon && bun test tests/unit/some-file.test.ts` — works without `--preload`

🤖 Generated with [Claude Code](https://claude.com/claude-code)