### PR TITLE
feat: completion action resume path, artifactRepo wiring, and UI fix

### DIFF
--- a/docs/space-autonomy-hitl-gaps-claude-opus-4-6.md
+++ b/docs/space-autonomy-hitl-gaps-claude-opus-4-6.md
@@ -308,7 +308,7 @@ Remaining (out of scope, tracked separately):
 
 ### 13. No Dead Loop Detection in Spaces
 
-**Status:** Not implemented
+**Status:** Not implemented — *unblocked by completion-semantics rewrite*
 
 Room has `dead-loop-detector.ts` (Levenshtein similarity-based, 5-fail threshold within 5-minute window)
 that detects infinite gate bounce cycles and escalates to human. Space has nothing equivalent —
@@ -321,6 +321,11 @@ Current Space retry behavior:
 - After exhausting retries → `blocked` with `agent_crashed` reason — but no diagnostic of *why*
 
 Missing:
+- **Stall detection**: with the new completion model (`idle`/`cancelled` are NOT completion
+  signals; only canonical `task.status` is), the runtime can now distinguish "all nodes idle +
+  no pending activations + task still in_progress + no `reportedStatus`" → **stalled**, not
+  complete. Previously this state was misread as completion. See `completion-detector.ts` TODO
+  marker for the entry point.
 - Similarity detection across failure reasons (are retries hitting the same error?)
 - Escalation with diagnostic summary (what was the agent trying when it failed?)
 - Configurable thresholds per space or workflow
@@ -418,6 +423,53 @@ Missing:
 
 ---
 
+### 18. Task Retry RPC
+
+**Status:** Not implemented
+
+With the new completion-semantics rewrite, an unrecoverably blocked end-node leaves
+`task.status = 'blocked'` (with `blockReason='execution_failed'` or `'agent_crashed'`)
+and the workflow run is `blocked`. Humans/agents can already use `task.update` to mark
+the task `cancelled`, `done`, or `archived` — but there is no equivalent for "retry":
+re-spawn the end-node execution and flip the task back to `in_progress`.
+
+Workaround today: cancel the task and start a new workflow run from scratch. This
+discards any partial progress (other node executions, gate artifacts, send_message
+history) and forces re-planning.
+
+Missing:
+- `task.retry` RPC handler that resets blocked node executions to `pending`, clears
+  the task's blocked state, and resumes the existing workflow run
+- UI affordance on `TaskBlockedBanner` to invoke retry
+- Bound on retry attempts to prevent infinite loops (overlaps with Gap #6)
+
+**Depends on:** Gap #6 (retry semantics), Gap #13 (stall/loop detection for retry budget)  
+**Impact:** Medium — currently humans must restart workflows from scratch  
+**Effort:** Low-Medium
+
+---
+
+### 19. End-Node Single-Agent Invariant (Documented)
+
+**Status:** Implemented and enforced — *invariant for future workflow authoring*
+
+End nodes own the workflow's completion signal via `report_result` (the only signal
+the runtime accepts as workflow completion). Multi-agent end nodes create ambiguity
+about who declares the workflow done — there are no quorum semantics defined and a
+race condition would result.
+
+Enforcement: `space-workflow-manager.ts::validateEndNodeId()` rejects workflow
+definitions whose end node has anything other than exactly 1 agent. All built-in
+workflows comply (single-agent Reviewer/QA at the end).
+
+Future workflow authors must respect this invariant; consider it part of the
+"workflow design contract" alongside the reachability and channel-validity rules.
+
+**Impact:** Documentation/invariant — prevents future bugs  
+**Effort:** Done
+
+---
+
 ## Priority Matrix
 
 | # | Gap | Impact | Effort | Priority | Status |
@@ -440,6 +492,8 @@ Missing:
 | 15 | Unified inbox for space approvals | Medium | Low-Medium | **P2** | |
 | 16 | Multi-gate blocking ambiguity | Low | Low | **P3** | |
 | 17 | Consecutive failure escalation | Medium | Low-Medium | **P2** | |
+| 18 | Task retry RPC | Medium | Low-Medium | **P2** | |
+| 19 | End-node single-agent invariant | n/a | Done | n/a | ✅ |
 
 ## Dependency Graph & Implementation Order
 

--- a/docs/space-autonomy-hitl-gaps-claude-opus-4-6.md
+++ b/docs/space-autonomy-hitl-gaps-claude-opus-4-6.md
@@ -343,7 +343,7 @@ Missing:
 PR validation in spaces is handled via two mechanisms in the built-in workflow templates:
 
 1. **End node instructions** — Reviewer/QA prompts now include explicit PR verification steps
-   before calling `report_done()`. The agent can react if the PR isn't in the expected state
+   before calling `report_result()`. The agent can react if the PR isn't in the expected state
    (e.g. resolve conflicts, re-push).
 
 2. **Completion action failure blocks task** — `executeCompletionAction()` now returns

--- a/docs/space-autonomy-hitl-gaps-claude-opus-4-6.md
+++ b/docs/space-autonomy-hitl-gaps-claude-opus-4-6.md
@@ -70,7 +70,7 @@ that must guide every implementation decision in this gap list.
 **Status:** Implemented (completion actions + workflow templates)
 
 PR merge is now handled via two complementary mechanisms:
-- **Short workflows** (Coding, Research): `MERGE_PR_COMPLETION_ACTION` on the end node's `completionActions[]` — a script completion action (`requiredLevel: 4`) that squash-merges via `gh pr merge --squash --delete-branch` and syncs the worktree
+- **Short workflows** (Coding, Research): `MERGE_PR_COMPLETION_ACTION` on the end node's `completionActions[]` — a script completion action (`requiredLevel: 4`) that squash-merges via `gh pr merge --squash` and syncs the worktree
 - **Long workflows** (Full-Cycle, Fullstack QA): QA node prompt includes merge + worktree sync steps (merge is part of the QA validation, not a separate node)
 - **Completion action execution loop** in `SpaceRuntime.resolveCompletionWithActions()` — iterates actions in order, auto-executes when `space.autonomyLevel >= action.requiredLevel`, pauses task at `review` with `pendingActionIndex` otherwise
 - **Gate auto-approval** via `requiredLevel` on gates — `plan-approval-gate` migrated from `writers: ['human']` to `writers: ['reviewer']` + `requiredLevel: 3`
@@ -330,26 +330,27 @@ Missing:
 
 ---
 
-### 14. No PR Merge Validation in Spaces
+### 14. No PR Merge Validation in Spaces ✅
 
-**Status:** Not implemented
+**Status:** Implemented
 
-Room has `lifecycle-hooks.ts` (400+ lines) with two gate points:
-- **Worker exit gate**: `checkNotOnBaseBranch()`, `checkPrExists()`, `checkPrSynced()`, `checkWorkerPrMerged()`
-- **Leader complete gate**: `checkLeaderPrMerged()`, `checkPrHasReviews()`, `checkPrIsMergeable()`
+PR validation in spaces is handled via two mechanisms in the built-in workflow templates:
 
-Space has **zero PR validation**. Node agents can write PR artifacts via `write_artifact(type: 'pr')`,
-and Task Agents can call `report_result(status: 'done')`, but nothing verifies the PR was actually
-merged before the task is marked complete.
+1. **End node instructions** — Reviewer/QA prompts now include explicit PR verification steps
+   before calling `report_done()`. The agent can react if the PR isn't in the expected state
+   (e.g. resolve conflicts, re-push).
 
-This means:
-- A task can be marked `done` while its PR is still open
-- No enforcement that work was actually integrated into the base branch
-- `approve_task` transitions `review` → `done` without checking PR state
+2. **Completion action failure blocks task** — `executeCompletionAction()` now returns
+   success/failure. If a completion action script (e.g. `merge_pr`) fails, the task transitions
+   to `blocked` instead of silently completing as `done`. This is a framework-level fix that
+   applies to all completion actions, not just PR merge.
 
-**Depends on:** Gap #1 (PR auto-merge shares the same merge verification infrastructure)  
-**Impact:** High — tasks complete without verifying work was integrated  
-**Effort:** Medium
+Unlike Room's `lifecycle-hooks.ts` approach (400+ lines of imperative checks baked into the
+runtime), Space uses its existing gate/channel/completion-action primitives. PR validation is
+workflow template data, not framework code — users can customize or remove it.
+
+**Impact:** High — tasks no longer complete without verifying work was integrated  
+**Effort:** Low (workflow data + one runtime behavior change)
 
 ---
 
@@ -435,7 +436,7 @@ Missing:
 | 11 | Runtime lifecycle controls | High | Low-Medium | **P1** | ✅ |
 | 12 | Autonomy level UI toggle | Medium | Medium | **P2** | ✅ |
 | 13 | Dead loop detection in spaces | Medium | Medium | **P2** | |
-| 14 | PR merge validation in spaces | High | Medium | **P1** | |
+| 14 | PR merge validation in spaces | High | Medium | **P1** | ✅ |
 | 15 | Unified inbox for space approvals | Medium | Low-Medium | **P2** | |
 | 16 | Multi-gate blocking ambiguity | Low | Low | **P3** | |
 | 17 | Consecutive failure escalation | Medium | Low-Medium | **P2** | |
@@ -482,7 +483,7 @@ Gap 12 (Autonomy UI Toggle) — standalone, no dependencies
 | 8 | **#17 Consecutive failure escalation** | Foundation for smarter retry/escalation, low effort | Low-Medium | |
 | 9 | **#6 Tiered retry** | Builds on #17, informed by block reason distinction | Medium | |
 | 10 | **#13 Dead loop detection** | Builds on #17, prevents stuck workflows | Medium | |
-| 11 | **#14 PR merge validation** | Correctness — tasks shouldn't complete without verifying PR state | Medium | |
+| 11 | **#14 PR merge validation** | Correctness — tasks shouldn't complete without verifying PR state | Medium | **Done** |
 | 12 | **#1 PR auto-merge** | Builds on #14, needs merge verification + audit trail + action UI | Medium | **Done** |
 | 13 | **#15 Unified inbox** | Cross-space discoverability, builds on notification UI pattern | Low-Medium | |
 | 14 | **#9 Review SLA** | Small, builds on audit trail | Low | |

--- a/docs/space-autonomy-hitl-gaps-claude-opus-4-6.md
+++ b/docs/space-autonomy-hitl-gaps-claude-opus-4-6.md
@@ -76,9 +76,7 @@ PR merge is now handled via two complementary mechanisms:
 - **Gate auto-approval** via `requiredLevel` on gates — `plan-approval-gate` migrated from `writers: ['human']` to `writers: ['reviewer']` + `requiredLevel: 3`
 
 Remaining:
-- `artifactRepo` not yet wired in SpaceRuntime construction (completion actions work but can't resolve artifact data for env injection)
 - No gate script template for "wait for N approvals + CI green" (separate from merge logic)
-- **`pendingActionIndex` resume path not wired**: When a task pauses at a completion action (`pendingCheckpointType: 'completion_action'`, `pendingActionIndex: N`), no RPC handler or runtime tick reads these fields to resume execution from that index after human sign-off. The DB columns and types exist, but the task stays in `review` permanently. Needs: a `task.approveCompletionAction` handler (or similar) that re-enters `resolveCompletionWithActions()` from `pendingActionIndex`.
 
 **Impact:** High  
 **Effort:** Medium

--- a/docs/space-autonomy-hitl-gaps-claude-opus-4-6.md
+++ b/docs/space-autonomy-hitl-gaps-claude-opus-4-6.md
@@ -10,19 +10,20 @@ The space/task/workflow system has three orthogonal control layers:
 | Layer | Scope | Mechanism | Key File |
 |-------|-------|-----------|----------|
 | **Gates** | Per-channel in workflow | Field checks + scripts block message delivery | `runtime/gate-evaluator.ts` |
-| **Autonomy Level** | Per-space | Controls task terminal status (`review` vs `done`) | `runtime/space-runtime.ts:507,1202` |
+| **Autonomy Level** | Per-space | Controls task terminal status (`review` vs `done`) and gates completion-action execution | `runtime/space-runtime.ts` → `resolveCompletionWithActions` |
 | **Task Status Machine** | Per-task | `open -> in_progress -> review -> done` | `managers/space-task-manager.ts` |
 
 ### How Autonomy Works Today
 
-Autonomy has exactly **two decision points** — at `space-runtime.ts:507` (single-node completion) and `:1202` (multi-node workflow run completion):
+Autonomy has exactly **one policy function** — `resolveCompletionWithActions` in `space-runtime.ts` — invoked from two completion paths (the single-task and multi-node-run branches of the tick loop). Levels (1–5) decide both the terminal task status and which completion actions auto-execute:
 
 ```
-supervised:       workflow completes -> task status = 'review' (human must approve)
-semi_autonomous:  workflow completes -> task status = 'done' (auto-completed)
+level 1:          workflow completes -> task status = 'review' (human must approve)
+level >= 2:       workflow completes -> task status = 'done' if autonomy >= every action's requiredLevel
+                                       else 'review' paused at first action whose requiredLevel exceeds autonomy
 ```
 
-During execution, both modes behave identically.
+During execution, all levels behave identically; only the terminal resolution differs.
 
 ---
 

--- a/docs/space-autonomy-hitl-gaps-claude-opus-4-6.md
+++ b/docs/space-autonomy-hitl-gaps-claude-opus-4-6.md
@@ -78,6 +78,7 @@ PR merge is now handled via two complementary mechanisms:
 Remaining:
 - `artifactRepo` not yet wired in SpaceRuntime construction (completion actions work but can't resolve artifact data for env injection)
 - No gate script template for "wait for N approvals + CI green" (separate from merge logic)
+- **`pendingActionIndex` resume path not wired**: When a task pauses at a completion action (`pendingCheckpointType: 'completion_action'`, `pendingActionIndex: N`), no RPC handler or runtime tick reads these fields to resume execution from that index after human sign-off. The DB columns and types exist, but the task stays in `review` permanently. Needs: a `task.approveCompletionAction` handler (or similar) that re-enters `resolveCompletionWithActions()` from `pendingActionIndex`.
 
 **Impact:** High  
 **Effort:** Medium

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -403,13 +403,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		return new SpaceTaskManager(deps.db.getDatabase(), spaceId, deps.reactiveDb);
 	};
 
-	setupSpaceTaskHandlers(
-		deps.messageHub,
-		deps.spaceManager,
-		spaceTaskManagerFactory,
-		deps.daemonHub
-	);
-
 	// Space agent handlers
 	setupSpaceAgentHandlers(
 		deps.messageHub,
@@ -446,7 +439,18 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		channelCycleRepo,
 		sessionManager: deps.sessionManager,
 		daemonHub: deps.daemonHub,
+		artifactRepo,
 	});
+
+	// Space task handlers — registered after spaceRuntimeService so the resume
+	// path for pending completion actions can delegate to the runtime.
+	setupSpaceTaskHandlers(
+		deps.messageHub,
+		deps.spaceManager,
+		spaceTaskManagerFactory,
+		deps.daemonHub,
+		spaceRuntimeService
+	);
 
 	// Register Space RPC handlers now that spaceRuntimeService exists.
 	// spaceRuntimeService is passed so space.create can call setupSpaceAgentSession()

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -163,20 +163,13 @@ export function setupSpaceTaskHandlers(
 					const resumed = await spaceRuntimeService.resumeCompletionActions(spaceId, taskId);
 					if (resumed) {
 						task = resumed;
-						// Apply additional field updates: keep `result` so a caller-provided
-						// audit summary (e.g. "LGTM") is persisted alongside the resume's
-						// runtime-determined status. Status is excluded — the resume path
-						// already set the final status (done / blocked / review).
+						// Status is excluded — the resume path already set the final status
+						// (done / blocked / review). Forward `result` so a caller-supplied
+						// audit summary (e.g. "LGTM") lands alongside it. The resume path
+						// emits internally, so we only emit again when extra fields merged.
 						const { status: _s, ...otherFields } = updateParams;
 						if (Object.keys(otherFields).length > 0) {
 							task = await taskManager.updateTask(taskId, otherFields);
-						}
-
-						// `resumeCompletionActions` already emitted via `updateTaskAndEmit` →
-						// `onTaskUpdated`. If the follow-up updateTask above ran, emit a
-						// fresh event so subscribers see the merged final state; otherwise
-						// the internal emission is sufficient.
-						if (Object.keys(otherFields).length > 0) {
 							daemonHub
 								.emit('space.task.updated', {
 									sessionId: 'global',

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -184,7 +184,13 @@ export function setupSpaceTaskHandlers(
 
 						return task;
 					}
-					// If resume returned null (unexpected), fall through to normal transition
+					// null = state inconsistency (task deleted, workflow edited, race).
+					// Throw rather than silently falling through to a raw setTaskStatus
+					// that would bypass completion actions.
+					throw new Error(
+						`Cannot resume completion actions for task ${taskId} — ` +
+							'task state is inconsistent (see daemon logs for details)'
+					);
 				}
 
 				// Status is changing — validate via setTaskStatus (enforces transitions)

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -163,22 +163,31 @@ export function setupSpaceTaskHandlers(
 					const resumed = await spaceRuntimeService.resumeCompletionActions(spaceId, taskId);
 					if (resumed) {
 						task = resumed;
-						// Apply any additional field updates
-						const { status: _s, result: _r, ...otherFields } = updateParams;
+						// Apply additional field updates: keep `result` so a caller-provided
+						// audit summary (e.g. "LGTM") is persisted alongside the resume's
+						// runtime-determined status. Status is excluded — the resume path
+						// already set the final status (done / blocked / review).
+						const { status: _s, ...otherFields } = updateParams;
 						if (Object.keys(otherFields).length > 0) {
 							task = await taskManager.updateTask(taskId, otherFields);
 						}
 
-						daemonHub
-							.emit('space.task.updated', {
-								sessionId: 'global',
-								spaceId,
-								taskId,
-								task,
-							})
-							.catch((err) => {
-								log.warn('Failed to emit space.task.updated:', err);
-							});
+						// `resumeCompletionActions` already emitted via `updateTaskAndEmit` →
+						// `onTaskUpdated`. If the follow-up updateTask above ran, emit a
+						// fresh event so subscribers see the merged final state; otherwise
+						// the internal emission is sufficient.
+						if (Object.keys(otherFields).length > 0) {
+							daemonHub
+								.emit('space.task.updated', {
+									sessionId: 'global',
+									spaceId,
+									taskId,
+									task,
+								})
+								.catch((err) => {
+									log.warn('Failed to emit space.task.updated:', err);
+								});
+						}
 
 						return task;
 					}

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -13,6 +13,7 @@ import type { CreateSpaceTaskParams, UpdateSpaceTaskParams } from '@neokai/share
 import type { DaemonHub } from '../daemon-hub';
 import type { SpaceManager } from '../space/managers/space-manager';
 import type { SpaceTaskManager } from '../space/managers/space-task-manager';
+import type { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
 import { Logger } from '../logger';
 
 const log = new Logger('space-task-handlers');
@@ -27,7 +28,8 @@ export function setupSpaceTaskHandlers(
 	messageHub: MessageHub,
 	spaceManager: SpaceManager,
 	taskManagerFactory: SpaceTaskManagerFactory,
-	daemonHub: DaemonHub
+	daemonHub: DaemonHub,
+	spaceRuntimeService?: SpaceRuntimeService
 ): void {
 	// ─── spaceTask.create ───────────────────────────────────────────────────────
 	messageHub.onRequest('spaceTask.create', async (data) => {
@@ -149,6 +151,40 @@ export function setupSpaceTaskHandlers(
 			}
 
 			if (updateParams.status !== currentTask.status) {
+				// Intercept review → done when the task is paused at a completion action.
+				// Instead of directly transitioning to done, resume the completion action
+				// loop from pendingActionIndex — the loop determines the final status.
+				if (
+					spaceRuntimeService &&
+					currentTask.status === 'review' &&
+					updateParams.status === 'done' &&
+					currentTask.pendingCheckpointType === 'completion_action'
+				) {
+					const resumed = await spaceRuntimeService.resumeCompletionActions(spaceId, taskId);
+					if (resumed) {
+						task = resumed;
+						// Apply any additional field updates
+						const { status: _s, result: _r, ...otherFields } = updateParams;
+						if (Object.keys(otherFields).length > 0) {
+							task = await taskManager.updateTask(taskId, otherFields);
+						}
+
+						daemonHub
+							.emit('space.task.updated', {
+								sessionId: 'global',
+								spaceId,
+								taskId,
+								task,
+							})
+							.catch((err) => {
+								log.warn('Failed to emit space.task.updated:', err);
+							});
+
+						return task;
+					}
+					// If resume returned null (unexpected), fall through to normal transition
+				}
+
 				// Status is changing — validate via setTaskStatus (enforces transitions)
 				task = await taskManager.setTaskStatus(taskId, updateParams.status, {
 					result: updateParams.result ?? undefined,

--- a/packages/daemon/src/lib/space/managers/node-execution-manager.ts
+++ b/packages/daemon/src/lib/space/managers/node-execution-manager.ts
@@ -3,15 +3,15 @@
  *
  * Handles:
  * - Node execution status transitions with validation
- * - Terminal status checks for completion detection
+ * - Per-execution lifecycle status checks
  * - Agent session tracking per node execution
  *
  * This separates workflow-internal state from the user-facing SpaceTask.
  *
- * TODO: Wire this class into the RPC handler layer so production code uses it
- * for status transitions instead of raw repo calls. Currently only the pure
- * functions (isValidNodeExecutionTransition, isNodeExecutionTerminal) and the
- * TERMINAL_NODE_EXECUTION_STATUSES set are imported by CompletionDetector.
+ * Note on "terminal" semantics: `TERMINAL_NODE_EXECUTION_STATUSES` describes
+ * the terminal lifecycle of a single node-execution instance, NOT workflow
+ * completion. Workflow completion is decided exclusively by `SpaceTask.status`
+ * (set by `report_result`); see `CompletionDetector`.
  */
 
 import type { Database as BunDatabase } from 'bun:sqlite';
@@ -39,8 +39,22 @@ export const VALID_NODE_EXECUTION_TRANSITIONS: Record<NodeExecutionStatus, NodeE
 	};
 
 /**
- * Terminal node execution statuses — these represent final states where
- * no further processing will occur.
+ * Terminal statuses for a single node-execution instance — the agent's
+ * current turn has ended and no further processing will occur for this
+ * execution row until it is reactivated (via cyclic re-entry) or replaced.
+ *
+ * IMPORTANT: This set is about the per-execution lifecycle ONLY. It does
+ * NOT imply workflow completion. A node going `idle` after sending a
+ * message back through a cyclic channel is not "done" — the workflow may
+ * continue iterating. Workflow completion is decided exclusively by
+ * `SpaceTask.status` being set to a terminal value via `report_result`;
+ * see `CompletionDetector`.
+ *
+ * Used by:
+ * - `ChannelRouter.activateNode` — to decide whether an existing execution
+ *   should be reactivated rather than replaced.
+ * - `ChannelRouter.getActiveExecutionsForNode` — to filter out finished
+ *   executions when checking whether a node is currently active.
  */
 export const TERMINAL_NODE_EXECUTION_STATUSES = new Set<NodeExecutionStatus>(['idle', 'cancelled']);
 
@@ -55,7 +69,8 @@ export function isValidNodeExecutionTransition(
 }
 
 /**
- * Check if a node execution status is terminal (done or cancelled).
+ * Check if a node execution status is terminal for the per-execution
+ * lifecycle (not workflow completion — see {@link TERMINAL_NODE_EXECUTION_STATUSES}).
  */
 export function isNodeExecutionTerminal(status: NodeExecutionStatus): boolean {
 	return TERMINAL_NODE_EXECUTION_STATUSES.has(status);

--- a/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
@@ -316,10 +316,21 @@ export class SpaceWorkflowManager {
 		if (!endNodeId.trim()) {
 			throw new WorkflowValidationError('endNodeId must be a non-empty string');
 		}
-		const nodeIds = new Set(nodes.map((n) => n.id));
-		if (!nodeIds.has(endNodeId)) {
+		const endNode = nodes.find((n) => n.id === endNodeId);
+		if (!endNode) {
 			throw new WorkflowValidationError(
 				`endNodeId "${endNodeId}" does not match any node in this workflow`
+			);
+		}
+		// End nodes own the workflow's completion signal via `report_result`.
+		// Multi-agent end nodes create ambiguity: who declares the workflow done?
+		// Restrict to exactly one agent so there's a single unambiguous owner of
+		// the workflow's commitment.
+		const agentCount = endNode.agents?.length ?? 0;
+		if (agentCount !== 1) {
+			throw new WorkflowValidationError(
+				`endNode "${endNode.name}" must have exactly 1 agent (has ${agentCount}); ` +
+					`end nodes own the workflow completion signal via report_result`
 			);
 		}
 	}

--- a/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
@@ -212,11 +212,6 @@ export class SpaceWorkflowManager {
 
 		for (let i = 0; i < nodes.length; i++) {
 			const node = nodes[i];
-			if (node.name && node.name.trim().toLowerCase() === 'human') {
-				throw new WorkflowValidationError(
-					`node[${i}]: "human" is a reserved keyword and cannot be used as a node name`
-				);
-			}
 			this.validateNodeAgentRef(spaceId, node, i);
 		}
 	}
@@ -249,11 +244,6 @@ export class SpaceWorkflowManager {
 			if (!entry.name || !entry.name.trim()) {
 				throw new WorkflowValidationError(
 					`node[${index}].agents[${j}]: name must be a non-empty string`
-				);
-			}
-			if (entry.name.trim().toLowerCase() === 'human') {
-				throw new WorkflowValidationError(
-					`node[${index}].agents[${j}]: "human" is a reserved keyword and cannot be used as an agent name`
 				);
 			}
 			if (seenNames.has(entry.name)) {

--- a/packages/daemon/src/lib/space/runtime/agent-liveness.ts
+++ b/packages/daemon/src/lib/space/runtime/agent-liveness.ts
@@ -1,8 +1,8 @@
 /**
- * Agent Liveness Guard — Timeout for report_done
+ * Agent Liveness Guard — Timeout for report_result
  *
  * Detects agents that are alive (session active) but have not called
- * `report_done` within the configured timeout. Auto-completes them with a
+ * `report_result` within the configured timeout. Auto-completes them with a
  * system-generated result so the workflow can continue.
  *
  * An agent is considered "stuck" when ALL of the following are true:
@@ -45,7 +45,7 @@ export interface AutoCompletedAgent {
 // ---------------------------------------------------------------------------
 
 /**
- * Scans `nodeTasks` for alive agents that have not called `report_done` within
+ * Scans `nodeTasks` for alive agents that have not called `report_result` within
  * their configured timeout and auto-completes them.
  *
  * For each stuck agent found:
@@ -98,7 +98,7 @@ export async function autoCompleteStuckAgents(
 			continue;
 		}
 
-		// Agent is alive but has not called report_done within the timeout window.
+		// Agent is alive but has not called report_result within the timeout window.
 		//
 		// Note: no notifiedTaskSet dedup is needed here because the status transition
 		// to 'done' means this task will never satisfy the `status === 'in_progress'`
@@ -106,7 +106,7 @@ export async function autoCompleteStuckAgents(
 		// that does not change task status and thus requires dedup to avoid re-emitting
 		// on every subsequent tick while the task remains in_progress.
 		const timeoutMinutes = Math.round(effectiveTimeout / 60_000);
-		const result = `Auto-completed: agent did not call report_done within ${timeoutMinutes} minutes`;
+		const result = `Auto-completed: agent did not call report_result within ${timeoutMinutes} minutes`;
 
 		log.warn(
 			`agent-liveness: auto-completing stuck task ${task.id} ` +

--- a/packages/daemon/src/lib/space/runtime/agent-liveness.ts
+++ b/packages/daemon/src/lib/space/runtime/agent-liveness.ts
@@ -20,7 +20,7 @@ import type { SpaceTask } from '@neokai/shared';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { TaskAgentManager } from './task-agent-manager';
 import type { SpaceNotificationEvent } from './notification-sink';
-import { AGENT_REPORT_DONE_TIMEOUT_MS } from './constants';
+import { AGENT_REPORT_RESULT_TIMEOUT_MS } from './constants';
 export { resolveNodeTimeout } from './constants';
 import { Logger } from '../../logger';
 
@@ -57,7 +57,7 @@ export interface AutoCompletedAgent {
  * @param taskRepo       Repository for persisting task status updates.
  * @param tam            Task Agent Manager for liveness checks.
  * @param notify         Notification callback (should be the `safeNotify` wrapper).
- * @param timeoutMs      Default timeout in milliseconds (default: AGENT_REPORT_DONE_TIMEOUT_MS).
+ * @param timeoutMs      Default timeout in milliseconds (default: AGENT_REPORT_RESULT_TIMEOUT_MS).
  *                       Used when `getTimeoutMs` is not provided or returns undefined.
  * @param getTimeoutMs   Optional per-task timeout resolver. When provided, this takes
  *                       precedence over `timeoutMs` for each individual task. Useful for
@@ -70,7 +70,7 @@ export async function autoCompleteStuckAgents(
 	taskRepo: SpaceTaskRepository,
 	tam: TaskAgentManager,
 	notify: (event: SpaceNotificationEvent) => Promise<void>,
-	timeoutMs: number = AGENT_REPORT_DONE_TIMEOUT_MS,
+	timeoutMs: number = AGENT_REPORT_RESULT_TIMEOUT_MS,
 	getTimeoutMs?: (task: SpaceTask) => number
 ): Promise<AutoCompletedAgent[]> {
 	const now = Date.now();

--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -195,6 +195,20 @@ export interface ChannelRouterConfig {
 	 * always require manual approval).
 	 */
 	getSpaceAutonomyLevel?: (spaceId: string) => Promise<SpaceAutonomyLevel>;
+	/**
+	 * Optional liveness probe for an agent session ID.
+	 *
+	 * Used during cyclic re-entry: when an existing terminal node_execution is
+	 * found, the router would normally preserve its `agentSessionId` so the
+	 * same in-memory agent session is reused (preserving conversation history).
+	 * If this callback is provided and returns `false`, the session is treated
+	 * as unrecoverable and the execution falls back to fresh-spawn semantics
+	 * (`agentSessionId` cleared, status reset to `pending`).
+	 *
+	 * When omitted, the router always preserves `agentSessionId` on cyclic
+	 * re-entry — appropriate for tests and contexts without a TaskAgentManager.
+	 */
+	isSessionAlive?: (sessionId: string) => boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -285,14 +299,34 @@ export class ChannelRouter {
 			const existing = existingByAgentName.get(agentName);
 			if (existing) {
 				// Re-activation path for cyclic channels.
+				//
+				// Default: preserve `agentSessionId` and flip status to `in_progress`,
+				// so the same live agent session continues across cycles with full
+				// conversation history. Inbound messages routed by AgentMessageRouter
+				// will then deliver to the existing session via injectSubSessionMessage.
+				//
+				// Fallback: if `isSessionAlive` reports the session is no longer live
+				// (daemon restart, manual cleanup, crash), null the session id and
+				// reset to `pending` so the tick loop respawns a fresh session.
 				if (TERMINAL_NODE_EXECUTION_STATUSES.has(existing.status)) {
-					this.config.nodeExecutionRepo.update(existing.id, {
-						status: 'pending',
-						agentSessionId: null,
-						result: null,
-						startedAt: null,
-						completedAt: null,
-					});
+					const sessionId = existing.agentSessionId;
+					const probe = this.config.isSessionAlive;
+					// Preserve the session when an id exists and either no probe is
+					// configured (test/no-runtime context) or the probe says it's alive.
+					const sessionAlive = sessionId !== null && (!probe || probe(sessionId));
+					if (sessionAlive) {
+						this.config.nodeExecutionRepo.update(existing.id, {
+							status: 'in_progress',
+						});
+					} else {
+						this.config.nodeExecutionRepo.update(existing.id, {
+							status: 'pending',
+							agentSessionId: null,
+							result: null,
+							startedAt: null,
+							completedAt: null,
+						});
+					}
 				}
 				continue;
 			}

--- a/packages/daemon/src/lib/space/runtime/completion-detector.ts
+++ b/packages/daemon/src/lib/space/runtime/completion-detector.ts
@@ -1,86 +1,67 @@
 /**
  * CompletionDetector
  *
- * Determines whether a workflow run is complete by inspecting
- * `NodeExecution` records instead of `SpaceTask` records.
+ * Determines whether a workflow run is complete by inspecting the canonical
+ * `SpaceTask` — never `NodeExecution`. Per the workflow completion contract:
  *
- * Completion conditions (all-agents-done safety net):
- * 1. At least one node execution exists — workflow has started.
- * 2. Every node execution has a terminal status (done or cancelled).
+ *   - Node-execution statuses (`idle`, `cancelled`, etc.) are about per-execution
+ *     lifecycle, NOT workflow completion. An idle end-node may still re-activate
+ *     via cyclic re-entry; a cancelled execution may be a transient error.
+ *   - The single source of truth for "this workflow is finished" is the canonical
+ *     `SpaceTask` linked to the workflow run.
  *
- * End-node short-circuit:
- * When `endNodeId` is provided, the detector checks if the end node's
- * execution has reached a terminal status. If so, the run is complete
- * regardless of other nodes' statuses (they will be cancelled by the runtime).
+ * Two completion signals — both inspected here:
  *
- * Terminal statuses: `done`, `cancelled`.
- * Non-terminal statuses (block completion): `pending`, `in_progress`, `blocked`.
+ *  1. `task.status` is terminal (`done` | `cancelled`) — the canonical task
+ *     has reached its end state, either via runtime resolution or human override.
+ *     Note: `archived` is also a terminal status but we treat it as "out of scope"
+ *     here — completion handling is for active workflow lifecycle, not soft-delete.
+ *
+ *  2. `task.reportedStatus` is non-null — the end-node agent reported its result
+ *     via `report_result`. The runtime's tick will resolve the final task status
+ *     on the next pass through `resolveCompletionWithActions` (which honors the
+ *     supervised-mode review gate). Returning true here causes that resolution
+ *     to fire.
+ *
+ * TODO: stall detection (gap #13) — once nothing is `pending`/`in_progress` and
+ * the task is still `in_progress` with no `reportedStatus`, the workflow is
+ * stalled (e.g. dead-loop, all agents idle waiting for input). That detection
+ * is out of scope for this change; see `docs/space-autonomy-hitl-gaps-claude-opus-4-6.md`.
  */
 
-import type { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
-import { TERMINAL_NODE_EXECUTION_STATUSES } from '../managers/node-execution-manager';
+import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 
 export interface CompletionOptions {
 	/** Workflow run to inspect */
 	workflowRunId: string;
-	/**
-	 * Optional end node ID for deterministic completion.
-	 * When provided, the run is complete when the end node's execution
-	 * reaches a terminal status, regardless of other nodes.
-	 */
-	endNodeId?: string;
 }
 
 export class CompletionDetector {
-	constructor(private readonly nodeExecutionRepo: NodeExecutionRepository) {}
+	constructor(private readonly taskRepo: SpaceTaskRepository) {}
 
 	/**
-	 * Returns true when the workflow run is complete.
+	 * Returns true when the workflow run is complete or the runtime should
+	 * resolve completion on the next tick.
 	 *
-	 * Two completion strategies:
+	 * - `true` when the canonical task's `status` is terminal (`done` | `cancelled`),
+	 *   OR when `reportedStatus` is non-null (agent has reported a result that the
+	 *   runtime should now resolve through completion-actions).
+	 * - `false` when the task is missing, in a non-terminal status, and the agent
+	 *   has not reported a result yet.
 	 *
-	 * 1. **End-node short-circuit** (when `options.endNodeId` is provided):
-	 *    The run is complete when the end node's execution reaches a terminal
-	 *    status (`done` or `cancelled`). This is the primary completion path
-	 *    for workflows with a defined end node.
-	 *
-	 * 2. **All-agents-done fallback**:
-	 *    The run is complete when every node execution in the run has a
-	 *    terminal status. This acts as a safety net for workflows without
-	 *    an end node or for edge cases.
-	 *
-	 * Both strategies require at least one node execution to exist
-	 * ("no executions" → false — workflow hasn't started).
+	 * Returns `false` when no canonical task is linked to the run — the workflow
+	 * has not started yet from the user-facing perspective.
 	 */
 	isComplete(options: CompletionOptions): boolean {
-		const { workflowRunId, endNodeId } = options;
+		const tasks = this.taskRepo.listByWorkflowRun(options.workflowRunId);
+		if (tasks.length === 0) return false;
 
-		const executions = this.nodeExecutionRepo.listByWorkflowRun(workflowRunId);
-
-		// Workflow has not started yet — no node executions created
-		if (executions.length === 0) return false;
-
-		// End-node short-circuit: if the end node's execution is terminal,
-		// the run is complete regardless of other nodes' statuses.
-		if (endNodeId) {
-			const endNodeExecutions = executions.filter((e) => e.workflowNodeId === endNodeId);
-			if (
-				endNodeExecutions.length > 0 &&
-				endNodeExecutions.every((e) => TERMINAL_NODE_EXECUTION_STATUSES.has(e.status))
-			) {
-				return true;
-			}
-
-			// When an explicit end node exists, we do NOT fall back to
-			// "all current executions terminal". Otherwise a run can complete
-			// prematurely after only early nodes execute (e.g. gated flows where
-			// later nodes have not been activated yet).
-			return false;
+		// A run can have multiple tasks (rare); any single terminal/reported task
+		// signals completion intent.
+		for (const task of tasks) {
+			if (task.status === 'done' || task.status === 'cancelled') return true;
+			if (task.reportedStatus !== null) return true;
 		}
-
-		// All-agents-done fallback: every execution must be terminal
-		if (executions.some((e) => !TERMINAL_NODE_EXECUTION_STATUSES.has(e.status))) return false;
-
-		return true;
+		return false;
 	}
 }

--- a/packages/daemon/src/lib/space/runtime/constants.ts
+++ b/packages/daemon/src/lib/space/runtime/constants.ts
@@ -8,7 +8,7 @@
  * Default timeout for auto-completing a stuck agent.
  *
  * An agent is considered "stuck" when it is alive (session active) but has not
- * called `report_done` after this duration since the task was started. The
+ * called `report_result` after this duration since the task was started. The
  * task is auto-completed with a system-generated result so the workflow can
  * continue without manual intervention.
  *

--- a/packages/daemon/src/lib/space/runtime/constants.ts
+++ b/packages/daemon/src/lib/space/runtime/constants.ts
@@ -14,7 +14,7 @@
  *
  * Default: 10 minutes.
  */
-export const AGENT_REPORT_DONE_TIMEOUT_MS = 10 * 60 * 1000;
+export const AGENT_REPORT_RESULT_TIMEOUT_MS = 10 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // Per-node agent name timeout constants (M9.4)

--- a/packages/daemon/src/lib/space/runtime/gate-evaluator.ts
+++ b/packages/daemon/src/lib/space/runtime/gate-evaluator.ts
@@ -105,13 +105,6 @@ export function validateGateFields(fields: unknown, path = 'fields'): string[] {
 
 		if (!Array.isArray(f.writers)) {
 			errors.push(`${fp}.writers: expected array, got ${typeof f.writers}`);
-		} else if (
-			f.writers.includes('human') &&
-			f.writers.some((w: unknown) => typeof w === 'string' && w !== 'human')
-		) {
-			errors.push(
-				`${fp}.writers: "human" is a reserved keyword and must be the sole writer — cannot be mixed with other writers`
-			);
 		}
 
 		// Validate check

--- a/packages/daemon/src/lib/space/runtime/notification-sink.ts
+++ b/packages/daemon/src/lib/space/runtime/notification-sink.ts
@@ -53,7 +53,7 @@ export interface TaskTimeoutEvent {
 }
 
 /**
- * A stuck agent (alive but never called report_done) was auto-completed by the runtime.
+ * A stuck agent (alive but never called report_result) was auto-completed by the runtime.
  *
  * Emitted after the task is transitioned to `completed` with a system-generated result.
  * Consumers can use this to log warnings or inform the Space Agent.

--- a/packages/daemon/src/lib/space/runtime/session-notification-sink.ts
+++ b/packages/daemon/src/lib/space/runtime/session-notification-sink.ts
@@ -233,7 +233,7 @@ function formatAgentAutoCompleted(
 	const elapsedMinutes = Math.round(event.elapsedMs / 60_000);
 	const humanReadable =
 		`Task ${event.taskId} in space ${event.spaceId} was auto-completed after ${elapsedMinutes} minute(s) ` +
-		`because the agent did not call report_done within the configured timeout.`;
+		`because the agent did not call report_result within the configured timeout.`;
 	return buildMessage(event.kind, humanReadable, {
 		kind: event.kind,
 		spaceId: event.spaceId,

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -404,6 +404,7 @@ export class SpaceRuntimeService {
 			workspacePath = space?.workspacePath;
 		}
 		const spaceManager = this.config.spaceManager;
+		const taskAgentManager = this.taskAgentManager;
 		const router = new ChannelRouter({
 			taskRepo: this.config.taskRepo,
 			workflowRunRepo: this.config.workflowRunRepo,
@@ -418,6 +419,7 @@ export class SpaceRuntimeService {
 				const s = await spaceManager.getSpace(spaceId);
 				return s?.autonomyLevel ?? 1;
 			},
+			isSessionAlive: taskAgentManager ? (sid) => taskAgentManager.isSessionAlive(sid) : undefined,
 		});
 		return router.onGateDataChanged(runId, gateId);
 	}

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -19,6 +19,7 @@ import type { SpaceTaskRepository } from '../../../storage/repositories/space-ta
 import { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
 import type { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
 import type { ChannelCycleRepository } from '../../../storage/repositories/channel-cycle-repository';
+import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
 import type { ReactiveDatabase } from '../../../storage/reactive-database';
 import type { NotificationSink } from './notification-sink';
 import type { TaskAgentManager } from './task-agent-manager';
@@ -76,6 +77,12 @@ export interface SpaceRuntimeServiceConfig {
 	 * provisioned automatically.
 	 */
 	daemonHub?: DaemonHub;
+	/**
+	 * Optional artifact repository for resolving completion action context.
+	 * Passed through to SpaceRuntime so completion actions with `artifactType`
+	 * can resolve artifact data for script env injection.
+	 */
+	artifactRepo?: WorkflowRunArtifactRepository;
 }
 
 export class SpaceRuntimeService {
@@ -413,5 +420,16 @@ export class SpaceRuntimeService {
 			},
 		});
 		return router.onGateDataChanged(runId, gateId);
+	}
+
+	/**
+	 * Resume completion action execution for a task paused at a pending action.
+	 *
+	 * Delegates to SpaceRuntime.resumeCompletionActions(). Called from the
+	 * spaceTask.update RPC handler when a human approves a task that was paused
+	 * at a completion action checkpoint.
+	 */
+	async resumeCompletionActions(spaceId: string, taskId: string): Promise<SpaceTask | null> {
+		return this.runtime.resumeCompletionActions(spaceId, taskId);
 	}
 }

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -808,6 +808,87 @@ export class SpaceRuntime {
 		return this.executors.size;
 	}
 
+	/**
+	 * Resumes completion action execution for a task paused at a pending action.
+	 *
+	 * Called when a human approves a task that has `pendingCheckpointType === 'completion_action'`.
+	 * Executes the pending action (which the human just approved) and continues with
+	 * remaining actions. If a later action also requires higher autonomy, the task
+	 * pauses again. If all remaining actions complete, the task transitions to 'done'.
+	 *
+	 * @returns The updated task, or null if the task wasn't in a resumable state.
+	 */
+	async resumeCompletionActions(spaceId: string, taskId: string): Promise<SpaceTask | null> {
+		const task = this.config.taskRepo.getTask(taskId);
+		if (!task) {
+			log.warn(`SpaceRuntime.resumeCompletionActions: task ${taskId} not found`);
+			return null;
+		}
+		if (task.pendingCheckpointType !== 'completion_action' || task.pendingActionIndex == null) {
+			log.warn(
+				`SpaceRuntime.resumeCompletionActions: task ${taskId} is not paused at a completion action`
+			);
+			return null;
+		}
+		if (!task.workflowRunId) {
+			log.warn(`SpaceRuntime.resumeCompletionActions: task ${taskId} has no workflowRunId`);
+			return null;
+		}
+
+		const run = this.config.workflowRunRepo.getRun(task.workflowRunId);
+		if (!run) {
+			log.warn(
+				`SpaceRuntime.resumeCompletionActions: workflow run ${task.workflowRunId} not found`
+			);
+			return null;
+		}
+
+		const workflow = this.config.spaceWorkflowManager.getWorkflow(run.workflowId);
+		const endNode = workflow?.nodes.find((n) => n.id === workflow.endNodeId);
+		const actions = endNode?.completionActions;
+		if (!actions || actions.length === 0) {
+			log.warn(`SpaceRuntime.resumeCompletionActions: no completion actions on end node`);
+			return null;
+		}
+
+		const space = await this.config.spaceManager.getSpace(spaceId);
+		if (!space?.workspacePath) {
+			log.warn(
+				`SpaceRuntime.resumeCompletionActions: space ${spaceId} not found or has no workspacePath`
+			);
+			return null;
+		}
+
+		const spaceLevel = (space.autonomyLevel ?? 1) as SpaceAutonomyLevel;
+		const startIndex = task.pendingActionIndex;
+
+		// Execute the approved action and continue with remaining
+		for (let i = startIndex; i < actions.length; i++) {
+			const action = actions[i];
+			if (i === startIndex || spaceLevel >= action.requiredLevel) {
+				// First action was human-approved; subsequent ones auto-execute if autonomy permits
+				await this.executeCompletionAction(action, spaceId, run.id, space.workspacePath);
+			} else {
+				// Pause at this action
+				return await this.updateTaskAndEmit(spaceId, taskId, {
+					status: 'review',
+					pendingActionIndex: i,
+					pendingCheckpointType: 'completion_action',
+				});
+			}
+		}
+
+		// All remaining actions executed — task is done
+		return await this.updateTaskAndEmit(spaceId, taskId, {
+			status: 'done',
+			completedAt: Date.now(),
+			approvalSource: 'human',
+			approvedAt: Date.now(),
+			pendingActionIndex: null,
+			pendingCheckpointType: null,
+		});
+	}
+
 	// -------------------------------------------------------------------------
 	// Private — rehydration
 	// -------------------------------------------------------------------------

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -889,14 +889,14 @@ export class SpaceRuntime {
 				// First action was human-approved; subsequent ones auto-execute if autonomy permits
 				const ok = await this.executeCompletionAction(action, spaceId, run.id, space.workspacePath);
 				if (!ok) {
-					return await this.updateTaskAndEmit(spaceId, taskId, {
+					return await this.finalizeResume(spaceId, taskId, {
 						status: 'blocked',
 						result: `Completion action "${action.name}" failed`,
 					});
 				}
 			} else {
 				// Pause at this action — clear stale approvedAt from previous cycle
-				return await this.updateTaskAndEmit(spaceId, taskId, {
+				return await this.finalizeResume(spaceId, taskId, {
 					status: 'review',
 					pendingActionIndex: i,
 					pendingCheckpointType: 'completion_action',
@@ -906,7 +906,7 @@ export class SpaceRuntime {
 		}
 
 		// All remaining actions executed — task is done
-		return await this.updateTaskAndEmit(spaceId, taskId, {
+		return await this.finalizeResume(spaceId, taskId, {
 			status: 'done',
 			completedAt: Date.now(),
 			approvalSource: 'human',
@@ -914,6 +914,33 @@ export class SpaceRuntime {
 			pendingActionIndex: null,
 			pendingCheckpointType: null,
 		});
+	}
+
+	/**
+	 * Closes the race window between `resumeCompletionActions` and concurrent
+	 * tick processing: re-reads the task right before writing and aborts the
+	 * write if another caller has already moved it out of the resumable state
+	 * (e.g. tick saw a script timeout and flipped the task to `blocked`).
+	 *
+	 * Without this guard a long-running completion action (scripts can run for
+	 * up to two minutes) could finish, see stale state, and overwrite a
+	 * legitimate intervening transition.
+	 */
+	private async finalizeResume(
+		spaceId: string,
+		taskId: string,
+		params: UpdateSpaceTaskParams
+	): Promise<SpaceTask | null> {
+		const fresh = this.config.taskRepo.getTask(taskId);
+		if (!fresh) return null;
+		if (fresh.status !== 'review' || fresh.pendingCheckpointType !== 'completion_action') {
+			log.warn(
+				`SpaceRuntime.resumeCompletionActions: task ${taskId} state changed mid-resume ` +
+					`(now status=${fresh.status}, checkpoint=${fresh.pendingCheckpointType}); aborting write`
+			);
+			return fresh;
+		}
+		return await this.updateTaskAndEmit(spaceId, taskId, params);
 	}
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -16,7 +16,7 @@
  * - Clean up executors when runs reach terminal states
  *
  * In the agent-centric model, agents drive workflow progression via send_message
- * and report_done — SpaceRuntime no longer calls advance() directly.
+ * and report_result — SpaceRuntime no longer calls advance() directly.
  */
 
 import type { Database as BunDatabase } from 'bun:sqlite';
@@ -518,6 +518,9 @@ export class SpaceRuntime {
 			const space = await this.config.spaceManager.getSpace(run.spaceId);
 			const spaceLevel = (space?.autonomyLevel ?? 1) as SpaceAutonomyLevel;
 
+			// Re-resolve is safe for non-terminal statuses: resolveCompletionWithActions
+			// is idempotent — non-`done` reportedStatus values (blocked, cancelled)
+			// pass through to a matching task status without side effects.
 			if (canonicalTask.status !== 'done' && canonicalTask.status !== 'review') {
 				const reportedStatus = canonicalTask.reportedStatus ?? 'done';
 				const params = await this.resolveCompletionWithActions(
@@ -1011,7 +1014,7 @@ export class SpaceRuntime {
 	 * - Spawns Task Agent sessions for pending tasks
 	 * - Monitors agent liveness and resets dead agents
 	 *
-	 * Agents drive workflow progression themselves via send_message and report_done.
+	 * Agents drive workflow progression themselves via send_message and report_result.
 	 * This method never calls advance() directly.
 	 *
 	 * Errors from individual runs are caught and re-thrown after all runs have
@@ -1196,7 +1199,7 @@ export class SpaceRuntime {
 		// When a TaskAgentManager is configured, Task Agents drive the workflow.
 		// SpaceRuntime's role here is lifecycle management only: spawn for pending
 		// tasks, check liveness, and recover from crashes. Agents drive progression
-		// themselves via send_message and report_done — SpaceRuntime never calls advance().
+		// themselves via send_message and report_result — SpaceRuntime never calls advance().
 		if (this.config.taskAgentManager) {
 			const tam = this.config.taskAgentManager;
 			let blockedByCrash = false;
@@ -1478,7 +1481,7 @@ export class SpaceRuntime {
 				}
 			}
 
-			// Agents drive workflow progression via send_message and report_done.
+			// Agents drive workflow progression via send_message and report_result.
 			return;
 		}
 	}
@@ -1769,9 +1772,9 @@ export class SpaceRuntime {
 		if (action.type !== 'script') {
 			log.warn(
 				`SpaceRuntime: completion action type "${action.type}" not yet implemented ` +
-					`(action: ${action.id}, space: ${spaceId})`
+					`(action: ${action.id}, space: ${spaceId}); treating as success`
 			);
-			return false;
+			return true;
 		}
 
 		// Resolve artifact data for script env injection

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -23,6 +23,7 @@ import type { Database as BunDatabase } from 'bun:sqlite';
 import type {
 	CompletionAction,
 	SpaceAutonomyLevel,
+	SpaceReportedStatus,
 	SpaceTask,
 	UpdateSpaceTaskParams,
 	SpaceWorkflow,
@@ -46,7 +47,6 @@ import type { WorkflowRunArtifactRepository } from '../../../storage/repositorie
 import { type NotificationSink, NullNotificationSink } from './notification-sink';
 import { buildRestrictedEnv, collectWithMaxBuffer, MAX_BUFFER_BYTES } from './gate-script-executor';
 import { CompletionDetector } from './completion-detector';
-import { TERMINAL_NODE_EXECUTION_STATUSES } from '../managers/node-execution-manager';
 import {
 	MAX_BLOCKED_RUN_RETRIES,
 	MAX_TASK_AGENT_CRASH_RETRIES,
@@ -136,13 +136,10 @@ export interface SpaceRuntimeConfig {
 	 */
 	notificationSink?: NotificationSink;
 	/**
-	 * Completion detector for the all-agents-done completion model.
+	 * Completion detector — inspects the canonical `SpaceTask` to decide whether
+	 * a workflow run is complete or ready for runtime resolution.
 	 *
-	 * When provided (or defaulted from taskRepo), used in processRunTick() to
-	 * detect when all agents in a workflow run have reached a terminal status and
-	 * mark the run as completed. Replaces the old terminal-node detection model.
-	 *
-	 * Defaults to `new CompletionDetector(nodeExecutionRepo)` if not provided.
+	 * Defaults to `new CompletionDetector(taskRepo)` when not provided.
 	 */
 	completionDetector?: CompletionDetector;
 	/**
@@ -226,7 +223,7 @@ export class SpaceRuntime {
 	private notificationSink: NotificationSink;
 
 	/**
-	 * Completion detector for the all-agents-done model.
+	 * Completion detector — inspects canonical `SpaceTask` to decide completion.
 	 * Initialized from config or defaulted to `new CompletionDetector(taskRepo)`.
 	 */
 	private completionDetector: CompletionDetector;
@@ -272,8 +269,7 @@ export class SpaceRuntime {
 
 	constructor(private config: SpaceRuntimeConfig) {
 		this.notificationSink = config.notificationSink ?? new NullNotificationSink();
-		this.completionDetector =
-			config.completionDetector ?? new CompletionDetector(config.nodeExecutionRepo);
+		this.completionDetector = config.completionDetector ?? new CompletionDetector(config.taskRepo);
 	}
 
 	/**
@@ -509,7 +505,13 @@ export class SpaceRuntime {
 			const summaryFromSibling = runTasks
 				.filter((task) => task.id !== canonicalTask.id)
 				.find((task) => !!task.result)?.result;
-			const nextResult = summaryFromWorkflow ?? canonicalTask.result ?? summaryFromSibling ?? null;
+			const reportedSummary = canonicalTask.reportedSummary ?? null;
+			const nextResult =
+				summaryFromWorkflow ??
+				reportedSummary ??
+				canonicalTask.result ??
+				summaryFromSibling ??
+				null;
 
 			// Resolve completion status via completion actions (if defined on end node)
 			// or fall back to binary autonomy check.
@@ -517,10 +519,12 @@ export class SpaceRuntime {
 			const spaceLevel = (space?.autonomyLevel ?? 1) as SpaceAutonomyLevel;
 
 			if (canonicalTask.status !== 'done' && canonicalTask.status !== 'review') {
+				const reportedStatus = canonicalTask.reportedStatus ?? 'done';
 				const params = await this.resolveCompletionWithActions(
 					run.spaceId,
 					run.id,
 					workflow,
+					reportedStatus,
 					nextResult,
 					spaceLevel
 				);
@@ -1080,28 +1084,22 @@ export class SpaceRuntime {
 			this.notifiedTaskSet.delete(`${canonicalTask.id}:timeout`);
 		}
 
-		// ─── End-node bypass ─────────────────────────────────────────────────
-		// When the workflow has an endNodeId and the end node's execution is
-		// terminal (done/cancelled), skip blocked/timeout notifications for
-		// sibling nodes and proceed directly to completion handling.
-		// This prevents spurious "task_blocked" notifications for nodes that
-		// are still running when the end node finishes first.
+		// ─── Completion bypass ───────────────────────────────────────────────
+		// If the canonical task is either already terminal or the end-node agent
+		// has reported a result, skip blocked/timeout notifications for sibling
+		// nodes and proceed directly to completion handling. This prevents
+		// spurious "task_blocked" notifications for sibling nodes that are still
+		// running when the end node finishes first.
+		//
+		// Cached for reuse below at the completion-detection branch — neither
+		// `task.status` nor `reportedStatus` changes between here and there.
 		const endNodeId = meta.workflow.endNodeId;
-		let endNodeBypass = false;
-		if (endNodeId) {
-			const endNodeExecs = nodeExecutions.filter((e) => e.workflowNodeId === endNodeId);
-			if (
-				endNodeExecs.length > 0 &&
-				endNodeExecs.every((e) => TERMINAL_NODE_EXECUTION_STATUSES.has(e.status))
-			) {
-				endNodeBypass = true;
-			}
-		}
+		const runIsComplete = this.completionDetector.isComplete({ workflowRunId: runId });
 
 		// Detect execution-level blocked BEFORE the all-completed guard.
-		// When end-node bypass fires, skip blocked notifications for siblings
-		// — the run will be completed imminently.
-		if (!endNodeBypass && nodeExecutions.some((execution) => execution.status === 'blocked')) {
+		// When the run is already complete, skip blocked notifications for
+		// siblings — the run will be completed imminently.
+		if (!runIsComplete && nodeExecutions.some((execution) => execution.status === 'blocked')) {
 			const blockedReason =
 				nodeExecutions.find((execution) => execution.status === 'blocked')?.result ??
 				'One or more workflow agents are blocked';
@@ -1138,9 +1136,9 @@ export class SpaceRuntime {
 		}
 
 		// Timeout detection: check in_progress tasks against Space.config.taskTimeoutMs.
-		// Skip when end-node bypass is active — the run is completing imminently.
+		// Skip when the run is already complete — it's about to finalize.
 		const space = await this.config.spaceManager.getSpace(meta.spaceId);
-		if (!endNodeBypass) {
+		if (!runIsComplete) {
 			const taskTimeoutMs = space?.config?.taskTimeoutMs;
 			if (taskTimeoutMs !== undefined) {
 				const now = Date.now();
@@ -1296,55 +1294,85 @@ export class SpaceRuntime {
 			nodeExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
 
 			// Step 1.6: Completion detection.
-			if (
-				this.completionDetector.isComplete({
-					workflowRunId: runId,
-					endNodeId: meta.workflow.endNodeId,
-				})
-			) {
+			//
+			// Reuses the `runIsComplete` snapshot from above — neither `task.status`
+			// nor `reportedStatus` is mutated between the two checks (the recovery
+			// branches that could change them all `return` before reaching here).
+			//
+			// In the reported-but-not-yet-resolved case, we resolve the final task
+			// status here through `resolveCompletionWithActions` — which respects
+			// the supervised-mode review gate. This is why `report_result` no
+			// longer calls `setTaskStatus` directly.
+			if (runIsComplete) {
 				await this.transitionRunStatusAndEmit(runId, 'done');
 				const summary = this.resolveCompletionSummary(runId, meta.workflow);
-				const nextTaskResult = summary ?? canonicalTask.result ?? null;
+				const reportedSummary = canonicalTask.reportedSummary ?? null;
+				const nextTaskResult = summary ?? reportedSummary ?? canonicalTask.result ?? null;
 
-				// Resolve completion status via completion actions (if defined on end node)
-				// or fall back to binary autonomy check.
 				const spaceLevel = (space?.autonomyLevel ?? 1) as SpaceAutonomyLevel;
 
-				if (canonicalTask.status !== 'done' && canonicalTask.status !== 'review') {
+				// Skip re-resolution when the task is already at a non-`open`/non-`in_progress`
+				// status — `done`/`cancelled` are terminal; `review` means we've already paused
+				// at a completion-action gate and are awaiting human approval.
+				const taskAlreadyResolved =
+					canonicalTask.status === 'done' ||
+					canonicalTask.status === 'review' ||
+					canonicalTask.status === 'cancelled';
+
+				// Final status drives sibling cancellation. We only kill siblings when
+				// the task reached a true terminal state (`done`/`cancelled`); `review`
+				// means we're still waiting for human approval and siblings may yet
+				// produce useful output if the human rejects completion.
+				let finalTaskStatus: SpaceTask['status'] = canonicalTask.status;
+
+				if (!taskAlreadyResolved) {
+					// Resolve final status using the agent's reported intent as the base.
+					// Defaults to 'done' when the agent did not report (legacy/fallback path);
+					// the runtime never auto-completes without a reported intent in the new
+					// model, but we tolerate the missing-report case for safety.
+					const reportedStatus = canonicalTask.reportedStatus ?? 'done';
 					const params = await this.resolveCompletionWithActions(
 						meta.spaceId,
 						runId,
 						meta.workflow,
+						reportedStatus,
 						nextTaskResult,
 						spaceLevel
 					);
 					await this.updateTaskAndEmit(meta.spaceId, canonicalTask.id, params);
+					finalTaskStatus = params.status ?? canonicalTask.status;
 				} else if (summary && canonicalTask.result !== summary) {
 					await this.updateTaskAndEmit(meta.spaceId, canonicalTask.id, { result: summary });
 				}
 
 				// Sibling NodeExecution cleanup: cancel siblings still in_progress
-				// when the run completes via end-node short-circuit. For each
-				// in_progress node execution with an agentSessionId, cancel the
-				// corresponding agent session via TaskAgentManager.
-				const siblingsToCancel = this.config.nodeExecutionRepo
-					.listByWorkflowRun(runId)
-					.filter(
-						(e) =>
-							e.status === 'in_progress' &&
-							e.agentSessionId &&
-							(!endNodeId || e.workflowNodeId !== endNodeId)
-					);
-				for (const sibling of siblingsToCancel) {
-					this.config.nodeExecutionRepo.updateStatus(sibling.id, 'cancelled');
-					if (this.config.taskAgentManager) {
-						this.config.taskAgentManager.cancelBySessionId(sibling.agentSessionId!);
+				// when the canonical task reaches a terminal status. The end-node
+				// execution itself is excluded so its session can finish writing back
+				// to the agent (it produced the report_result that triggered this
+				// completion path). Skipped when the task is paused at `review` —
+				// the human may yet reject the completion, in which case sibling
+				// progress is still relevant.
+				const taskTerminal = finalTaskStatus === 'done' || finalTaskStatus === 'cancelled';
+				if (taskTerminal) {
+					const siblingsToCancel = this.config.nodeExecutionRepo
+						.listByWorkflowRun(runId)
+						.filter(
+							(e) =>
+								e.status === 'in_progress' &&
+								e.agentSessionId &&
+								(!endNodeId || e.workflowNodeId !== endNodeId)
+						);
+					for (const sibling of siblingsToCancel) {
+						this.config.nodeExecutionRepo.updateStatus(sibling.id, 'cancelled');
+						if (this.config.taskAgentManager) {
+							this.config.taskAgentManager.cancelBySessionId(sibling.agentSessionId!);
+						}
+						log.info(
+							`SpaceRuntime: cancelled sibling node execution ${sibling.id} ` +
+								`(node ${sibling.workflowNodeId}, agent ${sibling.agentName}) ` +
+								`for completed run ${runId}`
+						);
 					}
-					log.info(
-						`SpaceRuntime: cancelled sibling node execution ${sibling.id} ` +
-							`(node ${sibling.workflowNodeId}, agent ${sibling.agentName}) ` +
-							`for completed run ${runId}`
-					);
 				}
 
 				return;
@@ -1604,9 +1632,30 @@ export class SpaceRuntime {
 		spaceId: string,
 		runId: string,
 		workflow: SpaceWorkflow | null,
+		reportedStatus: SpaceReportedStatus,
 		taskResult: string | null,
 		spaceLevel: SpaceAutonomyLevel
 	): Promise<UpdateSpaceTaskParams> {
+		// Non-success outcomes pass through directly. Completion actions are a
+		// success-path review gate ("flip to done after verifying X"); they
+		// don't apply when the agent reported `blocked` or `cancelled`.
+		if (reportedStatus === 'blocked') {
+			return {
+				status: 'blocked' as const,
+				result: taskResult,
+				blockReason: 'execution_failed',
+				completedAt: Date.now(),
+			};
+		}
+		if (reportedStatus === 'cancelled') {
+			return {
+				status: 'cancelled' as const,
+				result: taskResult,
+				completedAt: Date.now(),
+			};
+		}
+
+		// reportedStatus === 'done' — run the success-path review gate.
 		// Find end node's completion actions
 		const endNode = workflow?.nodes.find((n) => n.id === workflow.endNodeId);
 		const actions = endNode?.completionActions;

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -859,8 +859,24 @@ export class SpaceRuntime {
 			return null;
 		}
 
+		// Validate that the task belongs to this space
+		if (task.spaceId !== spaceId) {
+			log.warn(
+				`SpaceRuntime.resumeCompletionActions: task ${taskId} belongs to space ${task.spaceId}, not ${spaceId}`
+			);
+			return null;
+		}
+
 		const spaceLevel = (space.autonomyLevel ?? 1) as SpaceAutonomyLevel;
 		const startIndex = task.pendingActionIndex;
+
+		// Guard against workflow edits that removed actions between pause and resume
+		if (startIndex >= actions.length) {
+			log.warn(
+				`SpaceRuntime.resumeCompletionActions: pendingActionIndex ${startIndex} >= actions.length ${actions.length} (workflow edited?)`
+			);
+			return null;
+		}
 
 		// Execute the approved action and continue with remaining
 		for (let i = startIndex; i < actions.length; i++) {
@@ -869,11 +885,12 @@ export class SpaceRuntime {
 				// First action was human-approved; subsequent ones auto-execute if autonomy permits
 				await this.executeCompletionAction(action, spaceId, run.id, space.workspacePath);
 			} else {
-				// Pause at this action
+				// Pause at this action — clear stale approvedAt from previous cycle
 				return await this.updateTaskAndEmit(spaceId, taskId, {
 					status: 'review',
 					pendingActionIndex: i,
 					pendingCheckpointType: 'completion_action',
+					approvedAt: null,
 				});
 			}
 		}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -935,7 +935,7 @@ export class SpaceRuntime {
 		if (!fresh) return null;
 		if (fresh.status !== 'review' || fresh.pendingCheckpointType !== 'completion_action') {
 			log.warn(
-				`SpaceRuntime.resumeCompletionActions: task ${taskId} state changed mid-resume ` +
+				`SpaceRuntime.finalizeResume: task ${taskId} state changed mid-resume ` +
 					`(now status=${fresh.status}, checkpoint=${fresh.pendingCheckpointType}); aborting write`
 			);
 			return fresh;

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -518,10 +518,13 @@ export class SpaceRuntime {
 			const space = await this.config.spaceManager.getSpace(run.spaceId);
 			const spaceLevel = (space?.autonomyLevel ?? 1) as SpaceAutonomyLevel;
 
-			// Re-resolve is safe for non-terminal statuses: resolveCompletionWithActions
-			// is idempotent — non-`done` reportedStatus values (blocked, cancelled)
-			// pass through to a matching task status without side effects.
-			if (canonicalTask.status !== 'done' && canonicalTask.status !== 'review') {
+			// Skip tasks already at a terminal or paused state — matches the
+			// active-tick guard (`taskAlreadyResolved`) at processRunTick.
+			if (
+				canonicalTask.status !== 'done' &&
+				canonicalTask.status !== 'review' &&
+				canonicalTask.status !== 'cancelled'
+			) {
 				const reportedStatus = canonicalTask.reportedStatus ?? 'done';
 				const params = await this.resolveCompletionWithActions(
 					run.spaceId,

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -883,7 +883,13 @@ export class SpaceRuntime {
 			const action = actions[i];
 			if (i === startIndex || spaceLevel >= action.requiredLevel) {
 				// First action was human-approved; subsequent ones auto-execute if autonomy permits
-				await this.executeCompletionAction(action, spaceId, run.id, space.workspacePath);
+				const ok = await this.executeCompletionAction(action, spaceId, run.id, space.workspacePath);
+				if (!ok) {
+					return await this.updateTaskAndEmit(spaceId, taskId, {
+						status: 'blocked',
+						result: `Completion action "${action.name}" failed`,
+					});
+				}
 			} else {
 				// Pause at this action — clear stale approvedAt from previous cycle
 				return await this.updateTaskAndEmit(spaceId, taskId, {
@@ -1642,7 +1648,13 @@ export class SpaceRuntime {
 			const action = actions[i];
 			if (spaceLevel >= action.requiredLevel) {
 				// Auto-execute
-				await this.executeCompletionAction(action, spaceId, runId, workspacePath);
+				const ok = await this.executeCompletionAction(action, spaceId, runId, workspacePath);
+				if (!ok) {
+					return {
+						status: 'blocked' as const,
+						result: `Completion action "${action.name}" failed`,
+					};
+				}
 			} else {
 				// Pause at this action — task goes to 'review' with pending action metadata
 				return {
@@ -1677,13 +1689,13 @@ export class SpaceRuntime {
 		spaceId: string,
 		runId: string,
 		workspacePath: string
-	): Promise<void> {
+	): Promise<boolean> {
 		if (action.type !== 'script') {
 			log.warn(
 				`SpaceRuntime: completion action type "${action.type}" not yet implemented ` +
 					`(action: ${action.id}, space: ${spaceId})`
 			);
-			return;
+			return false;
 		}
 
 		// Resolve artifact data for script env injection
@@ -1751,17 +1763,21 @@ export class SpaceRuntime {
 					`SpaceRuntime: completion action "${action.name}" timed out ` +
 						`after ${COMPLETION_ACTION_TIMEOUT_MS}ms`
 				);
+				return false;
 			} else if (exitResult.code !== 0) {
 				log.warn(
 					`SpaceRuntime: completion action "${action.name}" failed ` +
 						`(exit ${exitResult.code}): ${stderrResult.text.trim().slice(0, 500)}`
 				);
+				return false;
 			}
+			return true;
 		} catch (err) {
 			log.warn(
 				`SpaceRuntime: completion action "${action.name}" error: ` +
 					`${err instanceof Error ? err.message : String(err)}`
 			);
+			return false;
 		}
 	}
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1290,7 +1290,7 @@ export class TaskAgentManager {
 	 * Called when a node agent sub-session completes (session goes idle).
 	 *
 	 * Automatically transitions the execution to `idle` when the agent's session
-	 * finishes naturally — no explicit `report_done` call needed.
+	 * finishes naturally — no explicit `report_result` call needed.
 	 * Notifies the Task Agent (when present) about workflow node session completion.
 	 */
 	private async handleSubSessionComplete(
@@ -2031,7 +2031,7 @@ export class TaskAgentManager {
 	 * at node-start (stored in the run config by SpaceRuntime.storeResolvedChannels()).
 	 *
 	 * The server gives the node agent peer communication tools (list_peers, send_message,
-	 * report_done) that are scoped to its group, channel topology, and node task.
+	 * report_result) that are scoped to its group, channel topology, and node task.
 	 */
 	private buildNodeAgentMcpServerForSession(
 		taskId: string,

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -2072,6 +2072,7 @@ export class TaskAgentManager {
 				const s = await spaceManager.getSpace(spaceId);
 				return s?.autonomyLevel ?? 1;
 			},
+			isSessionAlive: (sid) => this.isSessionAlive(sid),
 		});
 		const agentMessageRouter = new AgentMessageRouter({
 			nodeExecutionRepo: this.config.nodeExecutionRepo,

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1342,6 +1342,14 @@ export class TaskAgentManager {
 	 *
 	 * This enables event-driven orchestration: Task Agent can react to failures
 	 * without polling node status.
+	 *
+	 * Task-status cascade: marking the execution `blocked` here is picked up on
+	 * the next runtime tick by `space-runtime.ts`'s blocked-execution detection,
+	 * which transitions the canonical task to `status='blocked'` with
+	 * `blockReason='execution_failed'`. End-node failures are surfaced the same
+	 * way — there's no separate end-node-specific handler because any blocked
+	 * execution that can't be auto-recovered (`attemptBlockedRunRecovery`)
+	 * leaves the workflow stuck and needs human/agent intervention.
 	 */
 	private async handleSubSessionError(subSessionId: string, error: string): Promise<void> {
 		const parentTaskId = this.findParentTaskIdForSubSession(subSessionId);
@@ -2094,6 +2102,12 @@ export class TaskAgentManager {
 			: this.agentNameVariants(agentName);
 
 		// Build onReportResult callback for end-node agents so they can close the workflow run.
+		//
+		// Records the agent's reported intent (status + summary) into
+		// `space_tasks.reported_status` / `reported_summary`, but does NOT directly
+		// transition `space_tasks.status`. The runtime resolves the final task status
+		// on the next tick via `resolveCompletionWithActions`, which honors the
+		// supervised-mode review gate. See `CompletionDetector.isComplete`.
 		const isEndNode = !!workflow?.endNodeId && workflowNodeId === workflow.endNodeId;
 		let onReportResult:
 			| ((args: ReportResultInput) => Promise<ReturnType<typeof jsonResult>>)
@@ -2101,46 +2115,47 @@ export class TaskAgentManager {
 		if (isEndNode) {
 			const capturedTaskId = taskId;
 			const capturedSpaceId = spaceId;
-			const capturedWorkflowRunId = workflowRunId;
 			onReportResult = async (args: ReportResultInput) => {
 				const task = this.config.taskRepo.getTask(capturedTaskId);
 				if (!task)
 					return jsonResult({ success: false, error: `Task not found: ${capturedTaskId}` });
 
-				try {
-					const taskManager = new SpaceTaskManager(
-						this.config.db.getDatabase(),
-						capturedSpaceId,
-						this.config.reactiveDb
-					);
-					await taskManager.setTaskStatus(capturedTaskId, args.status, { result: args.summary });
+				// Idempotency: if the agent re-invokes report_result with the same outcome
+				// (retry, double-call, etc.), skip the DB write and the broadcast — they
+				// would be no-ops that still wake every subscriber.
+				const successPayload = jsonResult({
+					success: true,
+					taskId: capturedTaskId,
+					status: args.status,
+					summary: args.summary,
+					message: `Result reported as "${args.status}". The runtime will resolve the final task status (supervised mode may pause for human approval).`,
+				});
+				if (task.reportedStatus === args.status && task.reportedSummary === args.summary) {
+					return successPayload;
+				}
 
-					if (this.config.daemonHub) {
-						const eventName = args.status === 'done' ? 'space.task.done' : 'space.task.failed';
+				try {
+					const updated = this.config.taskRepo.updateTask(capturedTaskId, {
+						reportedStatus: args.status,
+						reportedSummary: args.summary,
+					});
+
+					if (this.config.daemonHub && updated) {
 						void this.config.daemonHub
-							.emit(eventName, {
+							.emit('space.task.updated', {
 								sessionId: 'global',
-								taskId: capturedTaskId,
 								spaceId: capturedSpaceId,
-								status: args.status,
-								summary: args.summary ?? '',
-								workflowRunId: capturedWorkflowRunId,
-								taskTitle: task.title,
+								taskId: capturedTaskId,
+								task: updated,
 							})
 							.catch((err) => {
 								log.warn(
-									`Failed to emit ${eventName} for task ${capturedTaskId}: ${err instanceof Error ? err.message : String(err)}`
+									`Failed to emit space.task.updated for task ${capturedTaskId}: ${err instanceof Error ? err.message : String(err)}`
 								);
 							});
 					}
 
-					return jsonResult({
-						success: true,
-						taskId: capturedTaskId,
-						status: args.status,
-						summary: args.summary,
-						message: `Task has been marked as "${args.status}". The workflow run is now closed.`,
-					});
+					return successPayload;
 				} catch (err) {
 					const message = err instanceof Error ? err.message : String(err);
 					return jsonResult({ success: false, error: message });

--- a/packages/daemon/src/lib/space/runtime/workflow-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-executor.ts
@@ -9,7 +9,7 @@
  * - Condition evaluation for transitions (always, human, condition, task_result)
  * - Timeout enforcement on condition-type evaluations
  *
- * In the agent-centric model, agents self-direct via send_message and report_done.
+ * In the agent-centric model, agents self-direct via send_message and report_result.
  * Workflow advancement is driven by agent-to-agent messaging (channel routing),
  * not by an explicit advance() call. This class provides read-only graph navigation
  * and condition evaluation utilities used by the runtime and channel layer.

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -96,7 +96,7 @@ export interface NodeAgentToolsConfig {
 	myAgentNameAliases?: string[];
 	/** ID of the parent task (used for error messages). */
 	taskId: string;
-	/** Space ID — used for event emission in report_done. */
+	/** Space ID — used for event emission in report_result. */
 	spaceId: string;
 	/**
 	 * Pre-built channel resolver for this sub-session's topology.
@@ -109,7 +109,7 @@ export interface NodeAgentToolsConfig {
 	/** Workflow node ID — used to query peer executions on the same node. */
 	workflowNodeId: string;
 	/**
-	 * Node execution repository for report_done, list_peers, and send_message peer resolution.
+	 * Node execution repository for report_result, list_peers, and send_message peer resolution.
 	 */
 	nodeExecutionRepo: NodeExecutionRepository;
 	/**

--- a/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
@@ -18,17 +18,27 @@
  */
 
 import { z } from 'zod';
+import type { SpaceReportedStatus } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
 // report_result
 // ---------------------------------------------------------------------------
 
 /**
- * Possible final statuses for a task result.
+ * Possible final statuses for a task result. Mirrors `SpaceReportedStatus`
+ * (the shared type written to `space_tasks.reported_status`); the `satisfies`
+ * clause locks the two together so adding a value to one without the other
+ * fails to compile.
  */
-export const TaskResultStatusSchema = z.enum(['done', 'blocked', 'cancelled']);
+const TASK_RESULT_STATUS_VALUES = [
+	'done',
+	'blocked',
+	'cancelled',
+] as const satisfies readonly SpaceReportedStatus[];
 
-export type TaskResultStatus = z.infer<typeof TaskResultStatusSchema>;
+export const TaskResultStatusSchema = z.enum(TASK_RESULT_STATUS_VALUES);
+
+export type TaskResultStatus = SpaceReportedStatus;
 
 /**
  * Schema for `report_result` input.

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -736,7 +736,7 @@ export const FULL_CYCLE_CODING_WORKFLOW: SpaceWorkflow = {
 				{
 					name: 'approved',
 					type: 'boolean',
-					writers: ['reviewer'],
+					writers: [],
 					check: { op: '==', value: true },
 				},
 			],
@@ -945,7 +945,7 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
 				{
 					name: 'approved',
 					type: 'boolean',
-					writers: ['reviewer'],
+					writers: [],
 					check: { op: '==', value: true },
 				},
 			],

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -15,7 +15,7 @@
  * - At Space creation time, preset SpaceAgent records are seeded for each
  *   BuiltinAgentRole. `seedBuiltInWorkflows` must be called after those agents
  *   exist so that the `agentId` values resolve correctly.
- * - Channels use node names (e.g. 'Plan', 'Code') in `from`/`to` so they
+ * - Channels use node names (e.g. 'Plan', 'Coding') in `from`/`to` so they
  *   resolve correctly at runtime without UUID translation in the seeder.
  *   `resolveChannels()` matches node names via the `nodeNameToAgents` lookup.
  */

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -279,8 +279,8 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'3. Write or update tests to cover new behavior\n' +
 							'4. Run the test suite and fix any failures\n' +
 							'5. Open a PR with `gh pr create` — include a clear title and description\n' +
-							'6. Hand off to the Reviewer: send_message(target=\"Review\", message=\"PR ready for ' +
-							'review at <url>\", data={ pr_url: \"<url>\" }). The gate runs a script that verifies ' +
+							'6. Hand off to the Reviewer: send_message(target="Review", message="PR ready for ' +
+							'review at <url>", data={ pr_url: "<url>" }). The gate runs a script that verifies ' +
 							'the PR is open and mergeable, so make sure it actually is before sending.\n\n' +
 							'If re-activated after review:\n' +
 							'1. Pull review comments from GitHub (`gh pr view` and `gh api`)\n' +

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -114,7 +114,7 @@ const PR_MERGE_BASH_SCRIPT = [
 	'  exit 0',
 	'fi',
 	'echo "Merging PR: $PR_URL"',
-	'if ! gh pr merge "$PR_URL" --squash --delete-branch; then',
+	'if ! gh pr merge "$PR_URL" --squash; then',
 	'  echo "Failed to merge PR: $PR_URL" >&2',
 	'  exit 1',
 	'fi',
@@ -203,7 +203,7 @@ const V2_QA_PROMPT =
 	'- Verify the PR is mergeable (no conflicts, required checks passing)\n' +
 	'- Confirm the changes match what was planned and reviewed\n' +
 	'- Spot-check critical paths manually if possible\n\n' +
-	'If QA passes, call report_done() with a concise final validation summary. ' +
+	'If QA passes, call report_result() with a concise final validation summary. ' +
 	'If QA fails, send detailed feedback to Coding so fixes can be made and re-tested.';
 
 const FULLSTACK_CODING_PROMPT =
@@ -214,7 +214,7 @@ const FULLSTACK_CODING_PROMPT =
 	'- Review may send you back for fixes.\n' +
 	'- QA may also send you back after deep verification (including browser tests).\n\n' +
 	'When implementation is ready, ensure the PR is open and mergeable, write code-pr-gate with ' +
-	'field pr_url, then call report_done() to mark Coding complete.';
+	'field pr_url, then call report_result() to mark Coding complete.';
 
 const FULLSTACK_REVIEW_PROMPT =
 	'You are the Reviewer in a Fullstack QA Loop workflow. Review the PR for correctness, ' +
@@ -225,7 +225,7 @@ const FULLSTACK_REVIEW_PROMPT =
 const FULLSTACK_QA_PROMPT =
 	'You are the QA node in a Fullstack QA Loop workflow. Run thorough validation, including backend tests, ' +
 	'frontend tests, and browser-based checks for critical flows.\n\n' +
-	'If everything passes, call report_done() with the QA evidence summary. ' +
+	'If everything passes, call report_result() with the QA evidence summary. ' +
 	'If issues are found, send a detailed fix list to Coding via the QA → Coding channel.';
 
 const RESEARCH_RESEARCH_NODE = 'tpl-research-research';
@@ -244,7 +244,7 @@ const REVIEW_REVIEW_NODE = 'tpl-review-review';
  * - Code → Review: gated by `code-ready-gate` — a bash script verifies that an
  *   open, mergeable PR exists and emits its URL as `{"pr_url":"..."}`.
  * - Review → Code: ungated — Reviewer sends back for changes without any gate.
- *   When satisfied, Reviewer calls `report_done()` on the Review node (endNodeId)
+ *   When satisfied, Reviewer calls `report_result()` on the Review node (endNodeId)
  *   which signals workflow completion.
  */
 export const CODING_WORKFLOW: SpaceWorkflow = {
@@ -299,16 +299,17 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'Workflow context:\n' +
 							'- The Coder has already implemented and opened a PR (verified by code-ready-gate).\n' +
 							'- If you request changes, the Coder is automatically re-activated with your feedback.\n' +
-							'- When you are satisfied, call report_done() to complete the entire workflow.\n' +
-							'- This node is the endNodeId — your report_done() signals workflow completion.\n\n' +
+							'- When you are satisfied, call report_result() to complete the entire workflow.\n' +
+							'- This node is the endNodeId — your report_result() signals workflow completion.\n\n' +
 							'Expected inputs: An open, mergeable PR from the Coder.\n' +
-							'Expected outputs: Either approval (report_done) or specific change requests.\n\n' +
+							'Expected outputs: Either approval (report_result) or specific change requests.\n\n' +
 							'Review checklist:\n' +
 							'1. Read the PR diff thoroughly\n' +
 							'2. Check for correctness, style, and test coverage\n' +
 							'3. Verify the PR description accurately describes the changes\n' +
 							'4. If changes needed: provide specific, actionable feedback (the Coder will be sent back)\n' +
-							'5. If satisfied: call report_done() with a brief summary of your review',
+							'5. If satisfied: verify the PR is still open and mergeable before calling report_result()\n' +
+							'6. Call report_result() with a brief summary of your review',
 					},
 				},
 			],
@@ -365,7 +366,7 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
  *   Review → Research (ungated back-channel, max 5 cycles)
  *
  * Research agent researches thoroughly, commits findings, opens a PR.
- * Reviewer agent reviews the research PR; calls report_done() if satisfied,
+ * Reviewer agent reviews the research PR; calls report_result() if satisfied,
  * or sends back for more research via the back-channel.
  */
 export const RESEARCH_WORKFLOW: SpaceWorkflow = {
@@ -419,17 +420,18 @@ export const RESEARCH_WORKFLOW: SpaceWorkflow = {
 							'Workflow context:\n' +
 							'- The Research agent has investigated and opened a PR (verified by research-ready-gate).\n' +
 							'- If you request more research, the Research agent is automatically re-activated.\n' +
-							'- When satisfied, call report_done() to complete the entire workflow.\n' +
-							'- This node is the endNodeId — your report_done() signals workflow completion.\n\n' +
+							'- When satisfied, call report_result() to complete the entire workflow.\n' +
+							'- This node is the endNodeId — your report_result() signals workflow completion.\n\n' +
 							'Expected inputs: A PR containing research findings from the Research agent.\n' +
-							'Expected outputs: Either approval (report_done) or specific feedback for more research.\n\n' +
+							'Expected outputs: Either approval (report_result) or specific feedback for more research.\n\n' +
 							'Review checklist:\n' +
 							'1. Read all research documents in the PR\n' +
 							'2. Check completeness: does the research answer the original question?\n' +
 							'3. Check accuracy: are claims supported by evidence or sources?\n' +
 							'4. Check clarity: are findings well-organized and easy to follow?\n' +
 							'5. If more research needed: provide specific areas to investigate further\n' +
-							'6. If satisfied: call report_done() with a brief summary',
+							'6. If satisfied: verify the PR is still open and mergeable before calling report_result()\n' +
+							'7. Call report_result() with a brief summary',
 					},
 				},
 			],
@@ -506,7 +508,7 @@ export const REVIEW_ONLY_WORKFLOW: SpaceWorkflow = {
 							'You are the sole Reviewer in a single-node Review-Only workflow. There is no planning ' +
 							'or coding phase — you are reviewing an existing PR or codebase directly.\n\n' +
 							'Workflow context:\n' +
-							'- This is both the start and end node — the workflow completes when you call report_done().\n' +
+							'- This is both the start and end node — the workflow completes when you call report_result().\n' +
 							'- There are no other agents in this workflow; your review is the only node.\n\n' +
 							'Expected inputs: A PR or code to review (specified in the task description).\n' +
 							'Expected outputs: A thorough review summary with actionable findings.\n\n' +
@@ -515,7 +517,7 @@ export const REVIEW_ONLY_WORKFLOW: SpaceWorkflow = {
 							'2. Check for correctness, security, performance, and style issues\n' +
 							'3. Verify test coverage is adequate\n' +
 							'4. Summarize your findings clearly\n' +
-							'5. Call report_done() with your review summary to complete the workflow',
+							'5. Call report_result() with your review summary to complete the workflow',
 					},
 				},
 			],
@@ -532,7 +534,7 @@ export const REVIEW_ONLY_WORKFLOW: SpaceWorkflow = {
  * Full-Cycle Coding Workflow
  *
  * Five-node graph with planning, plan review, coding, parallel code review, and QA.
- * QA is the terminal node and calls report_done() on success.
+ * QA is the terminal node and calls report_result() on success.
  *
  * Main progression:
  *   Planning → Plan Review (plan-pr-gate: script verifies plan PR is open/mergeable)
@@ -699,9 +701,9 @@ export const FULL_CYCLE_CODING_WORKFLOW: SpaceWorkflow = {
 							'3. Verify the PR is mergeable (no conflicts)\n' +
 							'4. Confirm changes match the approved plan\n' +
 							'5. If issues found: send detailed feedback to Coding via QA → Coding channel\n' +
-							'6. If all green: merge the PR with `gh pr merge <URL> --squash --delete-branch`\n' +
+							'6. If all green: merge the PR with `gh pr merge <URL> --squash`\n' +
 							'7. Sync worktree: `git checkout <base-branch> && git pull --ff-only`\n' +
-							'8. Call report_done() confirming merge and sync\n\n' +
+							'8. Call report_result() confirming merge and sync\n\n' +
 							'On failure, Coding fixes issues and reviewers re-vote before QA runs again.',
 					},
 				},
@@ -838,7 +840,7 @@ export const FULL_CYCLE_CODING_WORKFLOW: SpaceWorkflow = {
  *   Review → Coding (changes requested)
  *   QA → Coding (test failures/regressions)
  *
- * QA is the end node. QA calls report_done() on success.
+ * QA is the end node. QA calls report_result() on success.
  */
 export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
 	id: '',
@@ -866,7 +868,7 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
 							'2. Add/update unit, integration, and UI tests as needed\n' +
 							'3. Open or update the PR and ensure it remains mergeable\n' +
 							'4. Write code-pr-gate with field pr_url so Review can activate\n' +
-							'5. Call report_done() with a concise coding handoff summary\n' +
+							'5. Call report_result() with a concise coding handoff summary\n' +
 							'6. Share blockers clearly with Reviewer/QA when needed',
 					},
 				},
@@ -911,9 +913,9 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
 							'2. Run browser-based critical-path validation\n' +
 							'3. Validate CI and mergeability\n' +
 							'4. If fail: send detailed failures and repro steps to Coding\n' +
-							'5. If all green: merge the PR with `gh pr merge <URL> --squash --delete-branch`\n' +
+							'5. If all green: merge the PR with `gh pr merge <URL> --squash`\n' +
 							'6. Sync worktree: `git checkout <base-branch> && git pull --ff-only`\n' +
-							'7. Call report_done() confirming merge and sync',
+							'7. Call report_result() confirming merge and sync',
 					},
 				},
 			],

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -240,10 +240,10 @@ const REVIEW_REVIEW_NODE = 'tpl-review-review';
 /**
  * Coding Workflow
  *
- * Two-node iterative graph: Code ↔ Review (with cycle).
- * - Code → Review: gated by `code-ready-gate` — a bash script verifies that an
+ * Two-node iterative graph: Coding ↔ Review (with cycle).
+ * - Coding → Review: gated by `code-ready-gate` — a bash script verifies that an
  *   open, mergeable PR exists and emits its URL as `{"pr_url":"..."}`.
- * - Review → Code: ungated — Reviewer sends back for changes without any gate.
+ * - Review → Coding: ungated — Reviewer sends back for changes without any gate.
  *   When satisfied, Reviewer calls `report_result()` on the Review node (endNodeId)
  *   which signals workflow completion.
  */
@@ -252,35 +252,40 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 	spaceId: '',
 	name: 'Coding Workflow',
 	description:
-		'Iterative coding workflow with Code ↔ Review loop. Coder implements and opens a PR; Reviewer reviews and either requests changes or signals completion.',
+		'Iterative coding workflow with Coding ↔ Review loop. Engineer implements and opens a PR; Reviewer reviews and either requests changes or signals completion.',
 	nodes: [
 		{
 			id: CODING_CODE_NODE,
-			name: 'Code',
+			name: 'Coding',
 			agents: [
 				{
 					agentId: 'Coder',
 					name: 'coder',
 					customPrompt: {
 						value:
-							'You are the Coder in a Coder→Reviewer iterative workflow. Your job is to implement the ' +
-							'task, write tests, commit all changes, and open a pull request.\n\n' +
+							'You are a software engineer in a Coding→Review iterative workflow. Your job is to ' +
+							'implement the task, write tests, commit your changes, and open a pull request.\n\n' +
 							'Workflow context:\n' +
-							'- You are in the Code node. After you open a PR, the code-ready-gate verifies it is ' +
-							'open and mergeable before the Reviewer sees it.\n' +
-							'- If the Reviewer requests changes, you will be re-activated with their feedback. ' +
-							'Address all feedback, push new commits, and the gate re-checks automatically.\n' +
-							'- This cycle can repeat up to 5 times before the workflow fails.\n\n' +
-							'Expected inputs: Task description from the workflow trigger.\n' +
-							'Expected outputs: A clean, mergeable PR with passing tests.\n\n' +
+							'- After you open a PR, the workflow automatically verifies it is open and mergeable ' +
+							'before the Reviewer sees it.\n' +
+							'- If the Reviewer requests changes, you will be re-activated with their message. ' +
+							'Pull the review comments from GitHub, evaluate each one, address the valid items, ' +
+							'and push back on any you disagree with — explain your reasoning in the reply.\n' +
+							'- This cycle can repeat up to 5 times.\n\n' +
 							'Steps:\n' +
 							'1. Read and understand the task requirements\n' +
-							'2. Implement the changes with atomic, well-described commits\n' +
+							'2. Implement the changes with logical, well-described commits\n' +
 							'3. Write or update tests to cover new behavior\n' +
 							'4. Run the test suite and fix any failures\n' +
 							'5. Open a PR with `gh pr create` — include a clear title and description\n\n' +
-							'If re-activated after review feedback: read the feedback carefully, address each ' +
-							'point, push fixes, and verify tests still pass.',
+							'If re-activated after review:\n' +
+							'1. Pull review comments from GitHub (`gh pr view` and `gh api`)\n' +
+							'2. Evaluate each comment critically — do not blindly accept feedback. Verify ' +
+							'against the code and the task requirements. The Reviewer can be wrong.\n' +
+							'3. For valid items: make the fix and reply to the comment confirming what changed\n' +
+							'4. For items you disagree with: reply explaining why, with evidence from the code ' +
+							'or tests. Do not change code you believe is correct.\n' +
+							'5. Push fixes and verify tests still pass',
 					},
 				},
 			],
@@ -294,22 +299,24 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 					name: 'reviewer',
 					customPrompt: {
 						value:
-							'You are the Reviewer in a Coder→Reviewer iterative workflow. You review the open PR ' +
-							'and either approve it or send it back for changes.\n\n' +
+							'You are the Reviewer in a Coding→Review iterative workflow. You review the work ' +
+							'and either approve it or request changes.\n\n' +
 							'Workflow context:\n' +
-							'- The Coder has already implemented and opened a PR (verified by code-ready-gate).\n' +
-							'- If you request changes, the Coder is automatically re-activated with your feedback.\n' +
-							'- When you are satisfied, call report_result() to complete the entire workflow.\n' +
-							'- This node is the endNodeId — your report_result() signals workflow completion.\n\n' +
-							'Expected inputs: An open, mergeable PR from the Coder.\n' +
-							'Expected outputs: Either approval (report_result) or specific change requests.\n\n' +
+							'- The engineer has already implemented and opened a PR (verified automatically).\n' +
+							'- You share the same worktree as the engineer — review the codebase as a whole, ' +
+							'not just the PR diff. Read related files, run tests, check for issues the diff ' +
+							'might not surface (e.g. callers of changed functions, integration points).\n' +
+							'- Post all feedback as PR review comments on GitHub so the engineer can address ' +
+							'them item by item. Then send a short message to Coding summarizing the request.\n' +
+							'- If you request changes, the engineer is automatically re-activated.\n' +
+							'- When satisfied, call report_result() to complete the workflow.\n\n' +
 							'Review checklist:\n' +
-							'1. Read the PR diff thoroughly\n' +
-							'2. Check for correctness, style, and test coverage\n' +
-							'3. Verify the PR description accurately describes the changes\n' +
-							'4. If changes needed: provide specific, actionable feedback (the Coder will be sent back)\n' +
-							'5. If satisfied: verify the PR is still open and mergeable before calling report_result()\n' +
-							'6. Call report_result() with a brief summary of your review',
+							'1. Read the PR diff (`gh pr diff`) AND explore the worktree for context\n' +
+							'2. Check for correctness, style, test coverage, and integration impact\n' +
+							'3. Run the relevant tests yourself if uncertain\n' +
+							'4. If changes needed: post specific, actionable review comments on GitHub, then ' +
+							'send_message to Coding asking them to address the comments\n' +
+							'5. If satisfied: verify the PR is open and mergeable, then call report_result()',
 					},
 				},
 			],
@@ -344,16 +351,16 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 	],
 	channels: [
 		{
-			from: 'Code',
+			from: 'Coding',
 			to: 'Review',
 			gateId: 'code-ready-gate',
-			label: 'Code → Review',
+			label: 'Coding → Review',
 		},
 		{
 			from: 'Review',
-			to: 'Code',
+			to: 'Coding',
 			maxCycles: 5,
-			label: 'Review → Code (changes requested)',
+			label: 'Review → Coding (changes requested)',
 		},
 	],
 };

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -281,7 +281,9 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'5. Open a PR with `gh pr create` — include a clear title and description\n' +
 							'6. Hand off to the Reviewer: send_message(target="Review", message="PR ready for ' +
 							'review at <url>", data={ pr_url: "<url>" }). The gate runs a script that verifies ' +
-							'the PR is open and mergeable, so make sure it actually is before sending.\n\n' +
+							'the PR is open and mergeable, so make sure it actually is before sending. ' +
+							'**Always include `data: { pr_url }` on every send_message to Review** — the gate ' +
+							'data resets each cycle, so even on round 2+ you must re-supply it.\n\n' +
 							'If re-activated after review:\n' +
 							'1. Pull review comments from GitHub (`gh pr view` and `gh api`)\n' +
 							'2. Evaluate each comment critically — do not blindly accept feedback. Verify ' +
@@ -289,8 +291,8 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'3. For valid items: make the fix and reply to the comment confirming what changed\n' +
 							'4. For items you disagree with: reply explaining why, with evidence from the code ' +
 							'or tests. Do not change code you believe is correct.\n' +
-							'5. Push fixes, verify tests still pass, then send_message to Review again to ' +
-							're-trigger the review cycle',
+							'5. Push fixes, verify tests still pass, then send_message to Review again ' +
+							'(again with `data: { pr_url }`) to re-trigger the review cycle',
 					},
 				},
 			],
@@ -313,15 +315,21 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'might not surface (e.g. callers of changed functions, integration points).\n' +
 							'- Post all feedback as PR review comments on GitHub so the engineer can address ' +
 							'them item by item. Then send a short message to Coding summarizing the request.\n' +
-							'- If you request changes, the engineer is automatically re-activated.\n' +
-							'- When satisfied, call report_result() to complete the workflow.\n\n' +
+							'- If you request changes, the engineer is automatically re-activated.\n\n' +
+							'**You MUST call `report_result` to end this workflow.** It is the only signal ' +
+							'the runtime accepts as completion — finishing your turn without it leaves the ' +
+							'workflow stuck. Do all your review work — read files, run tests, post comments ' +
+							'to GitHub, send messages to Coding — BEFORE calling `report_result`. After it ' +
+							'returns, do not invoke any other tools.\n\n' +
 							'Review checklist:\n' +
 							'1. Read the PR diff (`gh pr diff`) AND explore the worktree for context\n' +
 							'2. Check for correctness, style, test coverage, and integration impact\n' +
 							'3. Run the relevant tests yourself if uncertain\n' +
 							'4. If changes needed: post specific, actionable review comments on GitHub, then ' +
-							'send_message to Coding asking them to address the comments\n' +
-							'5. If satisfied: verify the PR is open and mergeable, then call report_result()',
+							'send_message to Coding asking them to address the comments (do NOT call ' +
+							'`report_result` — leave the workflow open for the next round)\n' +
+							'5. If satisfied: verify the PR is open and mergeable, then call ' +
+							'`report_result(status="done", summary=...)` as your final action',
 					},
 				},
 			],
@@ -342,7 +350,7 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 				{
 					name: 'pr_url',
 					type: 'string',
-					writers: ['*'],
+					writers: ['Coding'],
 					check: { op: 'exists' },
 				},
 			],
@@ -431,9 +439,12 @@ export const RESEARCH_WORKFLOW: SpaceWorkflow = {
 							'research findings for completeness, accuracy, and quality.\n\n' +
 							'Workflow context:\n' +
 							'- The Research agent has investigated and opened a PR (verified by research-ready-gate).\n' +
-							'- If you request more research, the Research agent is automatically re-activated.\n' +
-							'- When satisfied, call report_result() to complete the entire workflow.\n' +
-							'- This node is the endNodeId — your report_result() signals workflow completion.\n\n' +
+							'- If you request more research, the Research agent is automatically re-activated.\n\n' +
+							'**You MUST call `report_result` to end this workflow.** It is the only signal the ' +
+							'runtime accepts as completion — finishing your turn without it leaves the workflow ' +
+							'stuck. Do all your review work BEFORE calling `report_result`; it must be your last ' +
+							'tool call. Do not call it when requesting more research — leave the workflow open ' +
+							'for the next round in that case.\n\n' +
 							'Expected inputs: A PR containing research findings from the Research agent.\n' +
 							'Expected outputs: Either approval (report_result) or specific feedback for more research.\n\n' +
 							'Review checklist:\n' +
@@ -441,9 +452,10 @@ export const RESEARCH_WORKFLOW: SpaceWorkflow = {
 							'2. Check completeness: does the research answer the original question?\n' +
 							'3. Check accuracy: are claims supported by evidence or sources?\n' +
 							'4. Check clarity: are findings well-organized and easy to follow?\n' +
-							'5. If more research needed: provide specific areas to investigate further\n' +
-							'6. If satisfied: verify the PR is still open and mergeable before calling report_result()\n' +
-							'7. Call report_result() with a brief summary',
+							'5. If more research needed: send_message back to Research with specific areas to ' +
+							'investigate (do NOT call `report_result`)\n' +
+							'6. If satisfied: verify the PR is still open and mergeable, then call ' +
+							'`report_result(status="done", summary=...)` as your final action',
 					},
 				},
 			],
@@ -522,6 +534,10 @@ export const REVIEW_ONLY_WORKFLOW: SpaceWorkflow = {
 							'Workflow context:\n' +
 							'- This is both the start and end node — the workflow completes when you call report_result().\n' +
 							'- There are no other agents in this workflow; your review is the only node.\n\n' +
+							'**You MUST call `report_result` to end this workflow.** It is the only signal the ' +
+							'runtime accepts as completion — finishing your turn without it leaves the workflow ' +
+							'stuck. Do all review work BEFORE calling `report_result`; it must be your last tool ' +
+							'call.\n\n' +
 							'Expected inputs: A PR or code to review (specified in the task description).\n' +
 							'Expected outputs: A thorough review summary with actionable findings.\n\n' +
 							'Review checklist:\n' +
@@ -529,7 +545,7 @@ export const REVIEW_ONLY_WORKFLOW: SpaceWorkflow = {
 							'2. Check for correctness, security, performance, and style issues\n' +
 							'3. Verify test coverage is adequate\n' +
 							'4. Summarize your findings clearly\n' +
-							'5. Call report_result() with your review summary to complete the workflow',
+							'5. Call `report_result(status="done", summary=...)` as your final action',
 					},
 				},
 			],
@@ -705,6 +721,10 @@ export const FULL_CYCLE_CODING_WORKFLOW: SpaceWorkflow = {
 						value:
 							V2_QA_PROMPT +
 							'\n\n' +
+							'**You MUST call `report_result` to end this workflow.** It is the only signal the ' +
+							'runtime accepts as completion — finishing your turn without it leaves the workflow ' +
+							'stuck. `report_result` must be your last tool call. Do not call it when sending ' +
+							'feedback to Coding — leave the workflow open for the next round in that case.\n\n' +
 							'Expected inputs: Code Review approved (review-votes-gate: 3 approvals).\n' +
 							'Expected outputs: PR merged and worktree synced, or detailed feedback to Coding.\n\n' +
 							'Steps:\n' +
@@ -712,10 +732,11 @@ export const FULL_CYCLE_CODING_WORKFLOW: SpaceWorkflow = {
 							'2. Check CI pipeline status on the PR\n' +
 							'3. Verify the PR is mergeable (no conflicts)\n' +
 							'4. Confirm changes match the approved plan\n' +
-							'5. If issues found: send detailed feedback to Coding via QA → Coding channel\n' +
+							'5. If issues found: send detailed feedback to Coding via QA → Coding channel ' +
+							'(do NOT call `report_result`)\n' +
 							'6. If all green: merge the PR with `gh pr merge <URL> --squash`\n' +
 							'7. Sync worktree: `git checkout <base-branch> && git pull --ff-only`\n' +
-							'8. Call report_result() confirming merge and sync\n\n' +
+							'8. Call `report_result(status="done", summary=...)` confirming merge and sync\n\n' +
 							'On failure, Coding fixes issues and reviewers re-vote before QA runs again.',
 					},
 				},
@@ -918,16 +939,21 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
 						value:
 							FULLSTACK_QA_PROMPT +
 							'\n\n' +
+							'**You MUST call `report_result` to end this workflow.** It is the only signal the ' +
+							'runtime accepts as completion — finishing your turn without it leaves the workflow ' +
+							'stuck. `report_result` must be your last tool call. Do not call it when sending ' +
+							'feedback to Coding — leave the workflow open for the next round in that case.\n\n' +
 							'Expected inputs: Reviewer-approved PR.\n' +
 							'Expected outputs: PR merged and worktree synced, or QA feedback to Coding.\n\n' +
 							'Steps:\n' +
 							'1. Run backend and frontend test suites\n' +
 							'2. Run browser-based critical-path validation\n' +
 							'3. Validate CI and mergeability\n' +
-							'4. If fail: send detailed failures and repro steps to Coding\n' +
+							'4. If fail: send detailed failures and repro steps to Coding (do NOT call ' +
+							'`report_result`)\n' +
 							'5. If all green: merge the PR with `gh pr merge <URL> --squash`\n' +
 							'6. Sync worktree: `git checkout <base-branch> && git pull --ff-only`\n' +
-							'7. Call report_result() confirming merge and sync',
+							'7. Call `report_result(status="done", summary=...)` confirming merge and sync',
 					},
 				},
 			],

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -266,8 +266,9 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'You are a software engineer in a Coding→Review iterative workflow. Your job is to ' +
 							'implement the task, write tests, commit your changes, and open a pull request.\n\n' +
 							'Workflow context:\n' +
-							'- After you open a PR, the workflow automatically verifies it is open and mergeable ' +
-							'before the Reviewer sees it.\n' +
+							'- The Reviewer is NOT triggered automatically when you finish. You MUST hand off ' +
+							'explicitly by sending a message to the Review node with the PR URL — that send ' +
+							'is what passes the readiness gate and activates the Reviewer.\n' +
 							'- If the Reviewer requests changes, you will be re-activated with their message. ' +
 							'Pull the review comments from GitHub, evaluate each one, address the valid items, ' +
 							'and push back on any you disagree with — explain your reasoning in the reply.\n' +
@@ -277,7 +278,10 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'2. Implement the changes with logical, well-described commits\n' +
 							'3. Write or update tests to cover new behavior\n' +
 							'4. Run the test suite and fix any failures\n' +
-							'5. Open a PR with `gh pr create` — include a clear title and description\n\n' +
+							'5. Open a PR with `gh pr create` — include a clear title and description\n' +
+							'6. Hand off to the Reviewer: send_message(target=\"Review\", message=\"PR ready for ' +
+							'review at <url>\", data={ pr_url: \"<url>\" }). The gate runs a script that verifies ' +
+							'the PR is open and mergeable, so make sure it actually is before sending.\n\n' +
 							'If re-activated after review:\n' +
 							'1. Pull review comments from GitHub (`gh pr view` and `gh api`)\n' +
 							'2. Evaluate each comment critically — do not blindly accept feedback. Verify ' +
@@ -285,7 +289,8 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'3. For valid items: make the fix and reply to the comment confirming what changed\n' +
 							'4. For items you disagree with: reply explaining why, with evidence from the code ' +
 							'or tests. Do not change code you believe is correct.\n' +
-							'5. Push fixes and verify tests still pass',
+							'5. Push fixes, verify tests still pass, then send_message to Review again to ' +
+							're-trigger the review cycle',
 					},
 				},
 			],

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -255,6 +255,14 @@ export class SpaceTaskRepository {
 			fields.push('pending_checkpoint_type = ?');
 			values.push(params.pendingCheckpointType ?? null);
 		}
+		if (params.reportedStatus !== undefined) {
+			fields.push('reported_status = ?');
+			values.push(params.reportedStatus ?? null);
+		}
+		if (params.reportedSummary !== undefined) {
+			fields.push('reported_summary = ?');
+			values.push(params.reportedSummary ?? null);
+		}
 
 		if (fields.length > 0) {
 			fields.push('updated_at = ?');
@@ -395,6 +403,8 @@ export class SpaceTaskRepository {
 			pendingActionIndex: (row.pending_action_index as number | null) ?? null,
 			pendingCheckpointType:
 				(row.pending_checkpoint_type as SpaceTask['pendingCheckpointType']) ?? null,
+			reportedStatus: (row.reported_status as SpaceTask['reportedStatus']) ?? null,
+			reportedSummary: (row.reported_summary as string | null) ?? null,
 			createdAt: row.created_at as number,
 			startedAt: (row.started_at as number | null) ?? null,
 			completedAt: (row.completed_at as number | null) ?? null,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -5897,7 +5897,10 @@ export function runMigration88(db: BunDatabase): void {
 	if (!tableHasColumn(db, 'space_workflows', 'gates')) return;
 
 	const rows = db
-		.prepare(`SELECT id, gates FROM space_workflows WHERE gates IS NOT NULL`)
+		.prepare(
+			`SELECT id, gates FROM space_workflows ` +
+				`WHERE gates IS NOT NULL AND (gates LIKE '%"human"%' OR gates LIKE '%"reviewer"%')`
+		)
 		.all() as { id: string; gates: string }[];
 
 	const update = db.prepare(`UPDATE space_workflows SET gates = ? WHERE id = ?`);

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -367,6 +367,12 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	//   - Adds pending_action_index and pending_checkpoint_type to space_tasks.
 	//   - Migrates approval_source values to simplified 3-value type.
 	runMigration86(db);
+
+	// Migration 87: Decouple `report_result` from canonical task status.
+	//   Adds `reported_status` and `reported_summary` columns to space_tasks
+	//   so the agent's report intent is recorded separately from the runtime's
+	//   final status decision (which goes through completion-actions review).
+	runMigration87(db);
 }
 
 /**
@@ -5837,5 +5843,30 @@ function runMigration86(db: BunDatabase): void {
 		throw err;
 	} finally {
 		db.exec('PRAGMA foreign_keys = ON');
+	}
+}
+
+/**
+ * Migration 87: Decouple `report_result` from canonical task status.
+ *
+ * Adds `reported_status` (TEXT NULL) and `reported_summary` (TEXT NULL) columns to
+ * `space_tasks`. These record the end-node agent's claimed outcome separately from
+ * `space_tasks.status`, which is the runtime's final decision after passing through
+ * the completion-actions review gate (see `SpaceRuntime.resolveCompletionWithActions`).
+ *
+ * `reported_status` constrained to the same values as `TaskResultStatusSchema`:
+ * `'done' | 'blocked' | 'cancelled'`.
+ */
+function runMigration87(db: BunDatabase): void {
+	if (!tableExists(db, 'space_tasks')) return;
+
+	if (!tableHasColumn(db, 'space_tasks', 'reported_status')) {
+		db.exec(
+			`ALTER TABLE space_tasks ADD COLUMN reported_status TEXT DEFAULT NULL ` +
+				`CHECK(reported_status IS NULL OR reported_status IN ('done', 'blocked', 'cancelled'))`
+		);
+	}
+	if (!tableHasColumn(db, 'space_tasks', 'reported_summary')) {
+		db.exec(`ALTER TABLE space_tasks ADD COLUMN reported_summary TEXT DEFAULT NULL`);
 	}
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -373,6 +373,13 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	//   so the agent's report intent is recorded separately from the runtime's
 	//   final status decision (which goes through completion-actions review).
 	runMigration87(db);
+
+	// Migration 88: Drop reserved writer keywords from persisted gates.
+	//   Existing space_workflows.gates rows may contain `writers: ['human']`
+	//   or `writers: ['reviewer']` from before the structural-semantics switch.
+	//   Rewrite those `approved` fields to `writers: []` so external-approval
+	//   gates keep working under the new authorization rules.
+	runMigration88(db);
 }
 
 /**
@@ -5868,5 +5875,67 @@ function runMigration87(db: BunDatabase): void {
 	}
 	if (!tableHasColumn(db, 'space_tasks', 'reported_summary')) {
 		db.exec(`ALTER TABLE space_tasks ADD COLUMN reported_summary TEXT DEFAULT NULL`);
+	}
+}
+
+/**
+ * Migration 88: Strip reserved writer keywords from persisted gates.
+ *
+ * Pre-PR #1505 the gate system used magic writer strings (`'human'`,
+ * `'reviewer'`) to mark external-approval fields. PR #1505 switched to
+ * structural semantics: `writers: []` means "external-only" (RPC or
+ * auto-approval via `requiredLevel`). Existing DBs may still contain the
+ * old keywords inside `space_workflows.gates` and would silently lose
+ * their human-approval behavior.
+ *
+ * For each gate field whose `name === 'approved'`, drop the legacy
+ * keywords from `writers`. If only legacy keywords were present, the
+ * resulting `writers: []` correctly preserves external-only semantics.
+ */
+export function runMigration88(db: BunDatabase): void {
+	if (!tableExists(db, 'space_workflows')) return;
+	if (!tableHasColumn(db, 'space_workflows', 'gates')) return;
+
+	const rows = db
+		.prepare(`SELECT id, gates FROM space_workflows WHERE gates IS NOT NULL`)
+		.all() as { id: string; gates: string }[];
+
+	const update = db.prepare(`UPDATE space_workflows SET gates = ? WHERE id = ?`);
+
+	for (const row of rows) {
+		let gates: unknown;
+		try {
+			gates = JSON.parse(row.gates);
+		} catch {
+			continue;
+		}
+		if (!Array.isArray(gates)) continue;
+
+		let changed = false;
+		for (const gate of gates) {
+			if (!gate || typeof gate !== 'object') continue;
+			const fields = (gate as { fields?: unknown }).fields;
+			if (!Array.isArray(fields)) continue;
+			for (const field of fields) {
+				if (
+					!field ||
+					typeof field !== 'object' ||
+					(field as { name?: unknown }).name !== 'approved'
+				) {
+					continue;
+				}
+				const writers = (field as { writers?: unknown }).writers;
+				if (!Array.isArray(writers)) continue;
+				const filtered = writers.filter((w) => w !== 'human' && w !== 'reviewer');
+				if (filtered.length !== writers.length) {
+					(field as { writers: unknown[] }).writers = filtered;
+					changed = true;
+				}
+			}
+		}
+
+		if (changed) {
+			update.run(JSON.stringify(gates), row.id);
+		}
 	}
 }

--- a/packages/daemon/tests/online/space/helpers/space-test-helpers.ts
+++ b/packages/daemon/tests/online/space/helpers/space-test-helpers.ts
@@ -744,6 +744,46 @@ export async function mockAgentDone(
 }
 
 /**
+ * Mark the end-node execution as idle AND set the canonical task to done.
+ *
+ * The completion detector requires `task.status` to be terminal — idle node
+ * executions alone no longer signal workflow completion. This helper wraps
+ * `mockAgentDone` for end-node call sites that expect the run to finish.
+ */
+export async function mockWorkflowComplete(
+	daemon: DaemonServerContext,
+	spaceId: string,
+	runId: string,
+	endNodeExecutionId: string,
+	result?: string
+): Promise<void> {
+	await mockAgentDone(daemon, spaceId, endNodeExecutionId, result);
+
+	// Find and transition the canonical task to done.
+	const allTasks = (await daemon.messageHub.request('spaceTask.list', {
+		spaceId,
+	})) as SpaceTask[];
+	const canonicalTask = allTasks.find(
+		(t) => t.workflowRunId === runId && t.status !== 'done' && t.status !== 'cancelled'
+	);
+	if (canonicalTask) {
+		if (canonicalTask.status === 'open') {
+			await daemon.messageHub.request('spaceTask.update', {
+				spaceId,
+				taskId: canonicalTask.id,
+				status: 'in_progress',
+			});
+		}
+		await daemon.messageHub.request('spaceTask.update', {
+			spaceId,
+			taskId: canonicalTask.id,
+			status: 'done',
+			result: result ?? 'Mock workflow complete',
+		});
+	}
+}
+
+/**
  * Find projected task-like node executions for a node/slot in a run.
  *
  * Matching order:

--- a/packages/daemon/tests/online/space/helpers/space-test-helpers.ts
+++ b/packages/daemon/tests/online/space/helpers/space-test-helpers.ts
@@ -351,7 +351,7 @@ export async function createTestSpace(daemon: DaemonServerContext): Promise<Test
 					{
 						name: 'approved',
 						type: 'boolean',
-						writers: ['reviewer', 'human'],
+						writers: [],
 						check: { op: '==', value: true },
 					},
 				],
@@ -370,7 +370,7 @@ export async function createTestSpace(daemon: DaemonServerContext): Promise<Test
 					{
 						name: 'votes',
 						type: 'map',
-						writers: ['reviewer'],
+						writers: [],
 						check: { op: 'count', match: 'approved', min: 3 },
 					},
 				],
@@ -383,7 +383,7 @@ export async function createTestSpace(daemon: DaemonServerContext): Promise<Test
 					{
 						name: 'votes',
 						type: 'map',
-						writers: ['reviewer'],
+						writers: [],
 						check: { op: 'count', match: 'rejected', min: 1 },
 					},
 				],

--- a/packages/daemon/tests/online/space/space-happy-path-full-pipeline.test.ts
+++ b/packages/daemon/tests/online/space/space-happy-path-full-pipeline.test.ts
@@ -53,6 +53,7 @@ import {
 	waitForRunStatus,
 	getTasksForNode,
 	mockAgentDone,
+	mockWorkflowComplete,
 } from './helpers/space-test-helpers';
 
 // ---------------------------------------------------------------------------
@@ -278,7 +279,7 @@ describe('Space Happy Path — Full Pipeline End-to-End', () => {
 			const completionSummary =
 				'Feature implemented: PR #99 merged, all tests pass, CI green. ' +
 				'Reviewed by 3 reviewers. QA confirmed mergeable state.';
-			await mockAgentDone(daemon, spaceId, doneTask.id, completionSummary);
+			await mockWorkflowComplete(daemon, spaceId, runId, doneTask.id, completionSummary);
 
 			const completedRun = await waitForRunStatus(daemon, runId, ['done'], RUN_STATUS_TIMEOUT);
 			expect(completedRun.status).toBe('done');
@@ -523,7 +524,7 @@ describe('Space Happy Path — Full Pipeline End-to-End', () => {
 			);
 			expect(doneTask.title).toBe('Done');
 
-			await mockAgentDone(daemon, spaceId, doneTask.id, completionSummary);
+			await mockWorkflowComplete(daemon, spaceId, runId, doneTask.id, completionSummary);
 
 			// ── Final assertions ─────────────────────────────────────────────────
 			const completedRun = await waitForRunStatus(daemon, runId, ['done'], RUN_STATUS_TIMEOUT);

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-export-import-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-export-import-handlers.test.ts
@@ -1613,6 +1613,12 @@ type MultiAgentStepEntry =
 			};
 	  };
 
+// End nodes must have exactly one agent. Tests below construct workflows whose
+// last meaningful node is multi-agent; we auto-append a synthetic single-agent
+// end node referencing the first agent of the last node so the workflow passes
+// validation without each test author having to wire it up.
+const SYNTHETIC_END_NODE_NAME = '__synthetic_end__';
+
 function makeMultiAgentBundle(
 	agents: BundleAgent[],
 	workflows: Array<{
@@ -1655,6 +1661,21 @@ function makeMultiAgentBundle(
 					...(s.systemPrompt ? { systemPrompt: s.systemPrompt } : {}),
 				};
 			});
+
+			const lastSrc = w.nodes[w.nodes.length - 1];
+			if (lastSrc) {
+				const endAgentRef =
+					'multiAgentStep' in lastSrc
+						? lastSrc.multiAgentStep.agents[0]?.agentRef
+						: lastSrc.agentRef;
+				if (endAgentRef) {
+					nodes.push({
+						name: SYNTHETIC_END_NODE_NAME,
+						agents: [{ agentRef: endAgentRef, name: 'end' }],
+					});
+				}
+			}
+
 			return {
 				version: 1,
 				type: 'workflow',
@@ -1855,6 +1876,13 @@ describe('full export→import round-trip', () => {
 						},
 					],
 				},
+				// Synthetic single-agent end node — end nodes own the workflow
+				// completion signal and must have exactly one agent.
+				{
+					id: 'step-end',
+					name: 'End',
+					agents: [{ agentId: 'src-coder', name: 'end' }],
+				},
 			],
 			channels: [{ id: 'ch-1', from: 'coder', to: 'reviewer', label: 'hand-off' }],
 			startNodeId: 'step-ma',
@@ -1992,6 +2020,11 @@ describe('full export→import round-trip', () => {
 						{ agentId: 'src-b', name: 'beta' },
 					],
 				},
+				{
+					id: 'step-end',
+					name: 'End',
+					agents: [{ agentId: 'src-a', name: 'end' }],
+				},
 			],
 			transitions: [],
 			startNodeId: 'step-ow',
@@ -2054,6 +2087,11 @@ describe('full export→import round-trip', () => {
 						{ agentId: 'src-spoke1', name: 'spoke1' },
 						{ agentId: 'src-spoke2', name: 'spoke2' },
 					],
+				},
+				{
+					id: 'step-end',
+					name: 'End',
+					agents: [{ agentId: 'src-hub', name: 'end' }],
 				},
 			],
 			transitions: [],
@@ -2165,6 +2203,11 @@ describe('full export→import round-trip', () => {
 						{ agentId: 'src-review', name: 'reviewer' },
 					],
 				},
+				{
+					id: 'step-end',
+					name: 'End',
+					agents: [{ agentId: 'src-coder2', name: 'end' }],
+				},
 			],
 			channels: [{ id: 'ch-1', from: 'planner', to: 'coder' }],
 			startNodeId: 'step-plan',
@@ -2184,7 +2227,8 @@ describe('full export→import round-trip', () => {
 		});
 
 		const importedWf = workflowRepo.getWorkflow(result.workflows[0].id)!;
-		expect(importedWf.nodes).toHaveLength(2);
+		// Two real steps + synthetic single-agent end node.
+		expect(importedWf.nodes).toHaveLength(3);
 
 		// Step 0: single-agent (plan)
 		const planStep = importedWf.nodes.find((s) => s.name === 'Plan')!;

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
@@ -120,7 +120,11 @@ describe('space-task-handlers', () => {
 	let taskManager: SpaceTaskManager;
 	let taskManagerFactory: SpaceTaskManagerFactory;
 
-	function setup(space: Space | null = mockSpace, task: SpaceTask | null = mockTask) {
+	function setup(
+		space: Space | null = mockSpace,
+		task: SpaceTask | null = mockTask,
+		runtime?: SpaceRuntimeService
+	) {
 		const mh = createMockMessageHub();
 		hub = mh.hub;
 		handlers = mh.handlers;
@@ -128,7 +132,7 @@ describe('space-task-handlers', () => {
 		spaceManager = createMockSpaceManager(space);
 		taskManager = createMockTaskManager(task);
 		taskManagerFactory = mock((_spaceId: string) => taskManager);
-		setupSpaceTaskHandlers(hub, spaceManager, taskManagerFactory, daemonHub);
+		setupSpaceTaskHandlers(hub, spaceManager, taskManagerFactory, daemonHub, runtime);
 	}
 
 	const call = (method: string, data: unknown) => {
@@ -629,17 +633,10 @@ describe('space-task-handlers', () => {
 			task: SpaceTask | null = reviewTask,
 			resumed: SpaceTask | null = { ...reviewTask, status: 'done' as const }
 		): { runtime: SpaceRuntimeService } {
-			const mh = createMockMessageHub();
-			hub = mh.hub;
-			handlers = mh.handlers;
-			daemonHub = createMockDaemonHub();
-			spaceManager = createMockSpaceManager(mockSpace);
-			taskManager = createMockTaskManager(task);
-			taskManagerFactory = mock((_spaceId: string) => taskManager);
 			const runtime = {
 				resumeCompletionActions: mock(async () => resumed),
 			} as unknown as SpaceRuntimeService;
-			setupSpaceTaskHandlers(hub, spaceManager, taskManagerFactory, daemonHub, runtime);
+			setup(mockSpace, task, runtime);
 			return { runtime };
 		}
 

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
@@ -47,7 +47,7 @@ const mockTask: SpaceTask = {
 	taskNumber: 1,
 	title: 'Test Task',
 	description: 'A task description',
-	status: 'pending',
+	status: 'open',
 	priority: 'normal',
 	dependsOn: [],
 	createdAt: NOW,
@@ -417,24 +417,22 @@ describe('space-task-handlers', () => {
 			});
 		});
 
-		it('reactivates a cancelled task to pending', async () => {
+		it('reactivates a cancelled task to open', async () => {
 			const cancelledTask = { ...mockTask, status: 'cancelled' as const };
 			setup(mockSpace, cancelledTask);
 			(taskManager.setTaskStatus as ReturnType<typeof mock>).mockResolvedValue({
 				...cancelledTask,
-				status: 'pending' as const,
-				error: undefined,
-				progress: undefined,
+				status: 'open' as const,
 			});
 
 			const result = await call('spaceTask.update', {
 				spaceId: 'space-1',
 				taskId: 'task-1',
-				status: 'pending',
+				status: 'open',
 			});
 
-			expect((result as SpaceTask).status).toBe('pending');
-			expect(taskManager.setTaskStatus).toHaveBeenCalledWith('task-1', 'pending', {
+			expect((result as SpaceTask).status).toBe('open');
+			expect(taskManager.setTaskStatus).toHaveBeenCalledWith('task-1', 'open', {
 				result: undefined,
 				error: undefined,
 			});
@@ -483,17 +481,17 @@ describe('space-task-handlers', () => {
 		});
 
 		it('does NOT call setTaskStatus when status is unchanged (avoids spurious transition error)', async () => {
-			// mockTask has status: 'pending'; sending status: 'pending' should not call setTaskStatus
+			// mockTask has status: 'open'; sending status: 'open' should not call setTaskStatus
 			const result = await call('spaceTask.update', {
 				spaceId: 'space-1',
 				taskId: 'task-1',
-				status: 'pending', // same as current
+				status: 'open', // same as current
 				title: 'New title',
 			});
 
 			expect(taskManager.setTaskStatus).not.toHaveBeenCalled();
 			expect(taskManager.updateTask).toHaveBeenCalledWith('task-1', {
-				status: 'pending',
+				status: 'open',
 				title: 'New title',
 			});
 			expect(result).toBeDefined();
@@ -587,19 +585,18 @@ describe('space-task-handlers', () => {
 		});
 
 		it('propagates errors from setTaskStatus (invalid transitions)', async () => {
-			// For this test, use a task that is already 'completed' to trigger an invalid transition
-			const completedTask = { ...mockTask, status: 'completed' as const };
-			setup(mockSpace, completedTask);
+			const doneTask = { ...mockTask, status: 'done' as const };
+			setup(mockSpace, doneTask);
 
 			(taskManager.setTaskStatus as ReturnType<typeof mock>).mockRejectedValue(
-				new Error("Invalid status transition from 'completed' to 'pending'. Allowed: none")
+				new Error("Invalid status transition from 'done' to 'review'. Allowed: none")
 			);
 
 			await expect(
 				call('spaceTask.update', {
 					spaceId: 'space-1',
 					taskId: 'task-1',
-					status: 'pending',
+					status: 'review',
 				})
 			).rejects.toThrow('Invalid status transition');
 		});
@@ -692,8 +689,6 @@ describe('space-task-handlers', () => {
 		});
 
 		it('falls through to setTaskStatus when not paused at completion_action', async () => {
-			// review→done without a completion_action checkpoint should follow
-			// the normal transition path.
 			const reviewNoCheckpoint = { ...reviewTask, pendingCheckpointType: undefined };
 			const { runtime } = setupWithRuntime(reviewNoCheckpoint);
 
@@ -705,6 +700,18 @@ describe('space-task-handlers', () => {
 
 			expect(runtime.resumeCompletionActions).not.toHaveBeenCalled();
 			expect(taskManager.setTaskStatus).toHaveBeenCalled();
+		});
+
+		it('throws when resumeCompletionActions returns null (inconsistent state)', async () => {
+			setupWithRuntime(reviewTask, null);
+
+			await expect(
+				call('spaceTask.update', {
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					status: 'done',
+				})
+			).rejects.toThrow('Cannot resume completion actions');
 		});
 	});
 });

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
@@ -19,6 +19,7 @@ import type { SpaceTaskManagerFactory } from '../../../../src/lib/rpc-handlers/s
 import type { SpaceManager } from '../../../../src/lib/space/managers/space-manager';
 import type { SpaceTaskManager } from '../../../../src/lib/space/managers/space-task-manager';
 import type { DaemonHub } from '../../../../src/lib/daemon-hub';
+import type { SpaceRuntimeService } from '../../../../src/lib/space/runtime/space-runtime-service';
 
 type RequestHandler = (data: unknown) => Promise<unknown>;
 
@@ -611,6 +612,102 @@ describe('space-task-handlers', () => {
 					title: 'X',
 				})
 			).rejects.toThrow('Task not found');
+		});
+	});
+
+	// ─── completion-action resume intercept ─────────────────────────────────────
+
+	describe('spaceTask.update — completion-action resume intercept', () => {
+		const reviewTask: SpaceTask = {
+			...mockTask,
+			status: 'review',
+			pendingCheckpointType: 'completion_action',
+			pendingActionIndex: 0,
+		};
+
+		function setupWithRuntime(
+			task: SpaceTask | null = reviewTask,
+			resumed: SpaceTask | null = { ...reviewTask, status: 'done' as const }
+		): { runtime: SpaceRuntimeService } {
+			const mh = createMockMessageHub();
+			hub = mh.hub;
+			handlers = mh.handlers;
+			daemonHub = createMockDaemonHub();
+			spaceManager = createMockSpaceManager(mockSpace);
+			taskManager = createMockTaskManager(task);
+			taskManagerFactory = mock((_spaceId: string) => taskManager);
+			const runtime = {
+				resumeCompletionActions: mock(async () => resumed),
+			} as unknown as SpaceRuntimeService;
+			setupSpaceTaskHandlers(hub, spaceManager, taskManagerFactory, daemonHub, runtime);
+			return { runtime };
+		}
+
+		it('routes review→done to resumeCompletionActions when paused at completion_action', async () => {
+			const { runtime } = setupWithRuntime();
+
+			const result = await call('spaceTask.update', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				status: 'done',
+			});
+
+			expect(runtime.resumeCompletionActions).toHaveBeenCalledWith('space-1', 'task-1');
+			expect(taskManager.setTaskStatus).not.toHaveBeenCalled();
+			expect((result as SpaceTask).status).toBe('done');
+		});
+
+		it('skips the secondary emit when no extra fields were merged', async () => {
+			// resumeCompletionActions emits internally via updateTaskAndEmit. The
+			// handler must NOT emit again when there are no follow-up updates,
+			// otherwise subscribers see a duplicate space.task.updated event.
+			setupWithRuntime();
+
+			await call('spaceTask.update', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				status: 'done',
+			});
+
+			expect(daemonHub.emit).not.toHaveBeenCalled();
+		});
+
+		it('forwards `result` field as a follow-up updateTask and emits once', async () => {
+			// Caller-supplied audit summary (e.g. "LGTM") must be persisted
+			// alongside the runtime-determined status.
+			setupWithRuntime();
+
+			await call('spaceTask.update', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				status: 'done',
+				result: 'LGTM',
+			});
+
+			expect(taskManager.updateTask).toHaveBeenCalledWith('task-1', { result: 'LGTM' });
+			expect(daemonHub.emit).toHaveBeenCalledTimes(1);
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.task.updated', {
+				sessionId: 'global',
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				task: expect.anything(),
+			});
+		});
+
+		it('falls through to setTaskStatus when not paused at completion_action', async () => {
+			// review→done without a completion_action checkpoint should follow
+			// the normal transition path.
+			const reviewNoCheckpoint = { ...reviewTask, pendingCheckpointType: undefined };
+			const { runtime } = setupWithRuntime(reviewNoCheckpoint);
+
+			await call('spaceTask.update', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				status: 'done',
+			});
+
+			expect(runtime.resumeCompletionActions).not.toHaveBeenCalled();
+			expect(taskManager.setTaskStatus).toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-88_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-88_test.ts
@@ -1,0 +1,193 @@
+/**
+ * Migration 88 Tests — Strip reserved writer keywords from persisted gates.
+ *
+ * Migration 88 rewrites legacy `writers: ['human']` / `writers: ['reviewer']`
+ * on `approved` gate fields to `writers: []`, matching the structural
+ * external-only semantics introduced by PR #1505.
+ *
+ * Covers:
+ *  - Legacy ['human'] on approved fields → []
+ *  - Legacy ['reviewer'] on approved fields → []
+ *  - Mixed writers ['reviewer', 'Coding'] on approved → ['Coding']
+ *  - Non-approved fields are untouched (e.g. multi-reviewer `votes` field
+ *    keeps its agent name `'reviewer'`)
+ *  - Workflows with NULL gates are skipped
+ *  - Idempotency
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../../src/storage/schema/index.ts';
+import { runMigration88 } from '../../../../../src/storage/schema/migrations.ts';
+
+function readGates(db: BunDatabase, id: string): unknown {
+	const row = db.prepare(`SELECT gates FROM space_workflows WHERE id = ?`).get(id) as
+		| { gates: string | null }
+		| undefined;
+	return row?.gates ? JSON.parse(row.gates) : null;
+}
+
+function insertWorkflow(db: BunDatabase, id: string, gates: unknown): void {
+	const now = Date.now();
+	db.prepare(
+		`INSERT INTO space_workflows (id, space_id, name, gates, tags, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, '[]', ?, ?)`
+	).run(id, 'sp-1', `WF ${id}`, gates === null ? null : JSON.stringify(gates), now, now);
+}
+
+describe('Migration 88: Strip reserved writer keywords from gates', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(process.cwd(), 'tmp', 'test-migration-88', `test-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+		db = new BunDatabase(join(testDir, 'test.db'));
+		db.exec('PRAGMA foreign_keys = ON');
+		runMigrations(db, () => {});
+
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?)`
+		).run('sp-1', 's', '/ws', 'Space', now, now);
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	test("approved field with writers: ['human'] → writers: []", () => {
+		insertWorkflow(db, 'wf-1', [
+			{
+				id: 'g-1',
+				name: 'plan-approval',
+				fields: [
+					{
+						name: 'approved',
+						type: 'boolean',
+						writers: ['human'],
+						check: { op: '==', value: true },
+					},
+				],
+			},
+		]);
+
+		runMigration88(db);
+
+		const gates = readGates(db, 'wf-1') as Array<{ fields: Array<{ writers: string[] }> }>;
+		expect(gates[0].fields[0].writers).toEqual([]);
+	});
+
+	test("approved field with writers: ['reviewer'] → writers: []", () => {
+		insertWorkflow(db, 'wf-1', [
+			{
+				id: 'g-1',
+				name: 'review-gate',
+				fields: [
+					{
+						name: 'approved',
+						type: 'boolean',
+						writers: ['reviewer'],
+						check: { op: '==', value: true },
+					},
+				],
+			},
+		]);
+
+		runMigration88(db);
+
+		const gates = readGates(db, 'wf-1') as Array<{ fields: Array<{ writers: string[] }> }>;
+		expect(gates[0].fields[0].writers).toEqual([]);
+	});
+
+	test('approved field with mixed writers retains non-keyword entries', () => {
+		insertWorkflow(db, 'wf-1', [
+			{
+				id: 'g-1',
+				name: 'mixed-gate',
+				fields: [
+					{
+						name: 'approved',
+						type: 'boolean',
+						writers: ['reviewer', 'Coding'],
+						check: { op: '==', value: true },
+					},
+				],
+			},
+		]);
+
+		runMigration88(db);
+
+		const gates = readGates(db, 'wf-1') as Array<{ fields: Array<{ writers: string[] }> }>;
+		expect(gates[0].fields[0].writers).toEqual(['Coding']);
+	});
+
+	test('non-approved fields are untouched (agent name "reviewer" preserved)', () => {
+		insertWorkflow(db, 'wf-1', [
+			{
+				id: 'g-1',
+				name: 'votes-gate',
+				fields: [
+					{ name: 'votes', type: 'object', writers: ['reviewer'], check: { op: 'exists' } },
+					{
+						name: 'approved',
+						type: 'boolean',
+						writers: ['human'],
+						check: { op: '==', value: true },
+					},
+				],
+			},
+		]);
+
+		runMigration88(db);
+
+		const gates = readGates(db, 'wf-1') as Array<{
+			fields: Array<{ name: string; writers: string[] }>;
+		}>;
+		expect(gates[0].fields[0].writers).toEqual(['reviewer']);
+		expect(gates[0].fields[1].writers).toEqual([]);
+	});
+
+	test('workflows with NULL gates are skipped', () => {
+		insertWorkflow(db, 'wf-1', null);
+
+		expect(() => runMigration88(db)).not.toThrow();
+
+		expect(readGates(db, 'wf-1')).toBeNull();
+	});
+
+	test('idempotent — running twice yields the same result', () => {
+		insertWorkflow(db, 'wf-1', [
+			{
+				id: 'g-1',
+				name: 'gate',
+				fields: [
+					{
+						name: 'approved',
+						type: 'boolean',
+						writers: ['human'],
+						check: { op: '==', value: true },
+					},
+				],
+			},
+		]);
+
+		runMigration88(db);
+		runMigration88(db);
+
+		const gates = readGates(db, 'wf-1') as Array<{ fields: Array<{ writers: string[] }> }>;
+		expect(gates[0].fields[0].writers).toEqual([]);
+	});
+});

--- a/packages/daemon/tests/unit/5-space/agent/agent-liveness.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-liveness.test.ts
@@ -290,7 +290,7 @@ describe('autoCompleteStuckAgents', () => {
 		expect(updated.status).toBe('done');
 		expect(updated.completedAt).toBeDefined();
 		expect(updated.result).toContain('Auto-completed');
-		expect(updated.result).toContain('report_done');
+		expect(updated.result).toContain('report_result');
 
 		// Event was emitted
 		expect(spy.events).toHaveLength(1);
@@ -323,7 +323,9 @@ describe('autoCompleteStuckAgents', () => {
 		await autoCompleteStuckAgents([task], spaceId, taskRepo, tam, spy.notify, customTimeoutMs);
 
 		const updated = taskRepo.getTask('task-msg')!;
-		expect(updated.result).toBe('Auto-completed: agent did not call report_done within 5 minutes');
+		expect(updated.result).toBe(
+			'Auto-completed: agent did not call report_result within 5 minutes'
+		);
 	});
 
 	test('respects custom timeoutMs parameter', async () => {

--- a/packages/daemon/tests/unit/5-space/agent/agent-liveness.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-liveness.test.ts
@@ -22,7 +22,7 @@ import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
 import { autoCompleteStuckAgents } from '../../../../src/lib/space/runtime/agent-liveness.ts';
 import {
-	AGENT_REPORT_DONE_TIMEOUT_MS,
+	AGENT_REPORT_RESULT_TIMEOUT_MS,
 	resolveNodeTimeout,
 	CODER_NODE_TIMEOUT_MS,
 	REVIEWER_NODE_TIMEOUT_MS,
@@ -156,7 +156,7 @@ describe('autoCompleteStuckAgents', () => {
 		seedTask(db, 'task-1', spaceId, {
 			status: 'in_progress',
 			taskAgentSessionId: null,
-			startedAt: Date.now() - AGENT_REPORT_DONE_TIMEOUT_MS - 1000,
+			startedAt: Date.now() - AGENT_REPORT_RESULT_TIMEOUT_MS - 1000,
 		});
 
 		const task = taskRepo.getTask('task-1')!;
@@ -177,7 +177,7 @@ describe('autoCompleteStuckAgents', () => {
 			seedTask(db, taskId, spaceId, {
 				status,
 				taskAgentSessionId: 'session-123',
-				startedAt: Date.now() - AGENT_REPORT_DONE_TIMEOUT_MS - 1000,
+				startedAt: Date.now() - AGENT_REPORT_RESULT_TIMEOUT_MS - 1000,
 			});
 		}
 
@@ -197,7 +197,7 @@ describe('autoCompleteStuckAgents', () => {
 		seedTask(db, 'task-dead', spaceId, {
 			status: 'in_progress',
 			taskAgentSessionId: 'session-dead',
-			startedAt: Date.now() - AGENT_REPORT_DONE_TIMEOUT_MS - 1000,
+			startedAt: Date.now() - AGENT_REPORT_RESULT_TIMEOUT_MS - 1000,
 		});
 
 		const task = taskRepo.getTask('task-dead')!;
@@ -267,7 +267,7 @@ describe('autoCompleteStuckAgents', () => {
 	});
 
 	test('auto-completes a stuck agent (alive + timed out)', async () => {
-		const stuckStartedAt = Date.now() - AGENT_REPORT_DONE_TIMEOUT_MS - 5000;
+		const stuckStartedAt = Date.now() - AGENT_REPORT_RESULT_TIMEOUT_MS - 5000;
 		seedTask(db, 'task-stuck', spaceId, {
 			status: 'in_progress',
 			taskAgentSessionId: 'session-stuck',
@@ -283,7 +283,7 @@ describe('autoCompleteStuckAgents', () => {
 		// Returns the auto-completed entry
 		expect(result).toHaveLength(1);
 		expect(result[0].taskId).toBe('task-stuck');
-		expect(result[0].elapsedMs).toBeGreaterThan(AGENT_REPORT_DONE_TIMEOUT_MS);
+		expect(result[0].elapsedMs).toBeGreaterThan(AGENT_REPORT_RESULT_TIMEOUT_MS);
 
 		// Task is now completed
 		const updated = taskRepo.getTask('task-stuck')!;
@@ -304,7 +304,7 @@ describe('autoCompleteStuckAgents', () => {
 		};
 		expect(event.spaceId).toBe(spaceId);
 		expect(event.taskId).toBe('task-stuck');
-		expect(event.elapsedMs).toBeGreaterThan(AGENT_REPORT_DONE_TIMEOUT_MS);
+		expect(event.elapsedMs).toBeGreaterThan(AGENT_REPORT_RESULT_TIMEOUT_MS);
 		expect(event.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
 	});
 
@@ -354,7 +354,7 @@ describe('autoCompleteStuckAgents', () => {
 	});
 
 	test('falls back to createdAt when startedAt is missing', async () => {
-		const longAgoCreatedAt = Date.now() - AGENT_REPORT_DONE_TIMEOUT_MS - 5000;
+		const longAgoCreatedAt = Date.now() - AGENT_REPORT_RESULT_TIMEOUT_MS - 5000;
 		// Insert with NULL started_at
 		seedTask(db, 'task-nostartdate', spaceId, {
 			status: 'in_progress',
@@ -381,7 +381,7 @@ describe('autoCompleteStuckAgents', () => {
 	});
 
 	test('handles multiple tasks — only completes the stuck ones', async () => {
-		const stuckStartedAt = Date.now() - AGENT_REPORT_DONE_TIMEOUT_MS - 1000;
+		const stuckStartedAt = Date.now() - AGENT_REPORT_RESULT_TIMEOUT_MS - 1000;
 		const freshStartedAt = Date.now() - 5000;
 
 		seedTask(db, 'task-stuck-a', spaceId, {
@@ -429,7 +429,7 @@ describe('autoCompleteStuckAgents', () => {
 	});
 
 	test('auto-completes multiple stuck agents in a single call', async () => {
-		const stuckStartedAt = Date.now() - AGENT_REPORT_DONE_TIMEOUT_MS - 1000;
+		const stuckStartedAt = Date.now() - AGENT_REPORT_RESULT_TIMEOUT_MS - 1000;
 
 		for (const id of ['task-s1', 'task-s2', 'task-s3']) {
 			seedTask(db, id, spaceId, {
@@ -452,8 +452,8 @@ describe('autoCompleteStuckAgents', () => {
 		}
 	});
 
-	test('AGENT_REPORT_DONE_TIMEOUT_MS is 10 minutes', () => {
-		expect(AGENT_REPORT_DONE_TIMEOUT_MS).toBe(10 * 60 * 1000);
+	test('AGENT_REPORT_RESULT_TIMEOUT_MS is 10 minutes', () => {
+		expect(AGENT_REPORT_RESULT_TIMEOUT_MS).toBe(10 * 60 * 1000);
 	});
 
 	test('per-task timeout via getTimeoutMs overrides default timeoutMs', async () => {
@@ -487,7 +487,7 @@ describe('autoCompleteStuckAgents', () => {
 			taskRepo,
 			tam,
 			spy.notify,
-			AGENT_REPORT_DONE_TIMEOUT_MS, // default (ignored when getTimeoutMs is provided)
+			AGENT_REPORT_RESULT_TIMEOUT_MS, // default (ignored when getTimeoutMs is provided)
 			getTimeoutMs
 		);
 

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -1098,7 +1098,7 @@ describe('node-agent-tools: list_gates', () => {
 				{
 					name: 'approved',
 					type: 'boolean',
-					writers: ['reviewer'],
+					writers: [],
 					check: { op: '==', value: true },
 				},
 			],

--- a/packages/daemon/tests/unit/5-space/other/channel-router-auto-approval.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/channel-router-auto-approval.test.ts
@@ -131,7 +131,7 @@ describe('ChannelRouter — gate auto-approval via requiredLevel', () => {
 				{
 					name: 'approved',
 					type: 'boolean',
-					writers: ['reviewer'],
+					writers: [],
 					check: { op: '==', value: true },
 				},
 			],
@@ -303,7 +303,7 @@ describe('ChannelRouter — gate auto-approval via requiredLevel', () => {
 				{
 					name: 'approved',
 					type: 'boolean',
-					writers: ['reviewer'],
+					writers: [],
 					check: { op: '==', value: true },
 				},
 				{

--- a/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
@@ -86,6 +86,36 @@ function seedAgent(db: BunDatabase, agentId: string, spaceId: string): void {
 // Workflow builder helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * End nodes must have exactly 1 agent (validator enforced — they own the
+ * `report_result` completion signal). When the last user-provided node is
+ * multi-agent, we synthesize a separate terminal single-agent end node so the
+ * multi-agent node remains the start (or middle) and validation passes.
+ */
+function withSyntheticEndNode(
+	nodes: Array<{
+		id: string;
+		name: string;
+		agentId?: string;
+		agents?: Array<{ agentId: string; name: string }>;
+	}>
+): { nodes: typeof nodes; startNodeId: string; endNodeId: string } {
+	const last = nodes[nodes.length - 1];
+	const lastIsMultiAgent = (last.agents?.length ?? 0) > 1;
+	if (!lastIsMultiAgent) {
+		return { nodes, startNodeId: nodes[0].id, endNodeId: last.id };
+	}
+	const endAgentId =
+		nodes.find((n) => n.agentId)?.agentId ?? nodes.find((n) => n.agents)?.agents?.[0]?.agentId;
+	if (!endAgentId) throw new Error('cannot synthesize end node: no agentId found in nodes');
+	const synthetic = { id: '__test_end__', name: 'Synthetic End', agentId: endAgentId };
+	return {
+		nodes: [...nodes, synthetic],
+		startNodeId: nodes[0].id,
+		endNodeId: synthetic.id,
+	};
+}
+
 function buildWorkflow(
 	spaceId: string,
 	workflowManager: SpaceWorkflowManager,
@@ -97,18 +127,20 @@ function buildWorkflow(
 	}>,
 	channels?: WorkflowChannel[]
 ): SpaceWorkflow {
+	const { nodes: finalNodes, startNodeId, endNodeId } = withSyntheticEndNode(nodes);
 	return workflowManager.createWorkflow({
 		spaceId,
 		name: `Test Workflow ${Date.now()}`,
 		description: '',
-		nodes: nodes.map((n) => ({
+		nodes: finalNodes.map((n) => ({
 			id: n.id,
 			name: n.name,
 			agentId: n.agentId,
 			agents: n.agents,
 		})),
 		transitions: [],
-		startNodeId: nodes[0].id,
+		startNodeId,
+		endNodeId,
 		rules: [],
 		tags: [],
 		channels: channels ?? [],
@@ -131,18 +163,20 @@ function buildWorkflowWithGates(
 	channels: WorkflowChannel[],
 	gates: Gate[]
 ): SpaceWorkflow {
+	const { nodes: finalNodes, startNodeId, endNodeId } = withSyntheticEndNode(nodes);
 	return workflowManager.createWorkflow({
 		spaceId,
 		name: `Test Workflow With Gates ${Date.now()}`,
 		description: '',
-		nodes: nodes.map((n) => ({
+		nodes: finalNodes.map((n) => ({
 			id: n.id,
 			name: n.name,
 			agentId: n.agentId,
 			agents: n.agents,
 		})),
 		transitions: [],
-		startNodeId: nodes[0].id,
+		startNodeId,
+		endNodeId,
 		rules: [],
 		tags: [],
 		channels,

--- a/packages/daemon/tests/unit/5-space/other/export-import-round-trip.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/export-import-round-trip.test.ts
@@ -75,6 +75,15 @@ function makeTestAgent(id: string, name: string, overrides: Partial<SpaceAgent> 
 	};
 }
 
+// End nodes must have exactly 1 agent (validator rule). Tests that exercise
+// multi-agent steps append a downstream single-agent end node so the
+// multi-agent step remains an intermediate node.
+const SYNTHETIC_END_NODE = {
+	id: '__test_end__',
+	name: 'Synthetic End',
+	agents: [{ agentId: 'agent-1', name: 'end' }],
+};
+
 function makeWorkflowWithOverrides(): SpaceWorkflow {
 	return {
 		id: 'wf-overrides',
@@ -102,8 +111,10 @@ function makeWorkflowWithOverrides(): SpaceWorkflow {
 					},
 				],
 			},
+			SYNTHETIC_END_NODE,
 		],
 		startNodeId: 'node-1',
+		endNodeId: SYNTHETIC_END_NODE.id,
 		tags: ['review'],
 		createdAt: 1000,
 		updatedAt: 2000,
@@ -124,8 +135,10 @@ function makeWorkflowWithoutOverrides(): SpaceWorkflow {
 					{ agentId: 'agent-2', name: 'reviewer' },
 				],
 			},
+			SYNTHETIC_END_NODE,
 		],
 		startNodeId: 'node-1',
+		endNodeId: SYNTHETIC_END_NODE.id,
 		tags: [],
 		createdAt: 1000,
 		updatedAt: 2000,
@@ -687,8 +700,10 @@ describe('full round-trip: export → import → DB read-back', () => {
 						},
 					],
 				},
+				SYNTHETIC_END_NODE,
 			],
 			startNodeId: 'node-1',
+			endNodeId: SYNTHETIC_END_NODE.id,
 			tags: [],
 			createdAt: 1000,
 			updatedAt: 2000,
@@ -765,9 +780,11 @@ describe('full round-trip: export → import → DB read-back', () => {
 						},
 					],
 				},
+				SYNTHETIC_END_NODE,
 			],
 			transitions: [],
 			startNodeId: 'node-1',
+			endNodeId: SYNTHETIC_END_NODE.id,
 			rules: [],
 			tags: [],
 			createdAt: 1000,

--- a/packages/daemon/tests/unit/5-space/other/gate-types-and-schema.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/gate-types-and-schema.test.ts
@@ -82,7 +82,7 @@ describe('Gate and Channel type validation', () => {
 				{
 					name: 'approved',
 					type: 'boolean',
-					writers: ['reviewer'],
+					writers: [],
 					check: { op: '==', value: true },
 				},
 			],
@@ -153,7 +153,7 @@ describe('SpaceWorkflowRepository — gates round-trip', () => {
 					{
 						name: 'approved',
 						type: 'boolean',
-						writers: ['reviewer'],
+						writers: [],
 						check: { op: '==', value: true },
 					},
 				],
@@ -242,7 +242,7 @@ describe('SpaceWorkflowRepository — gates with label and color round-trip', ()
 					{
 						name: 'approved',
 						type: 'boolean',
-						writers: ['reviewer'],
+						writers: [],
 						check: { op: '==', value: true },
 					},
 				],
@@ -386,7 +386,7 @@ describe('SpaceWorkflowRepository — gates with label and color round-trip', ()
 					{
 						name: 'done',
 						type: 'boolean',
-						writers: ['human'],
+						writers: [],
 						check: { op: '==', value: true },
 					},
 				],
@@ -743,7 +743,7 @@ describe('SpaceWorkflowRepository — script-only gate round-trip', () => {
 						{
 							name: 'approved',
 							type: 'boolean',
-							writers: ['human'],
+							writers: [],
 							check: { op: '==', value: true },
 						},
 					],
@@ -973,7 +973,7 @@ describe('Gate extended interface (label, color, script, optional fields)', () =
 				{
 					name: 'approved',
 					type: 'boolean',
-					writers: ['reviewer'],
+					writers: [],
 					check: { op: '==', value: true },
 				},
 			],
@@ -1100,7 +1100,7 @@ describe('computeGateDefaults with optional fields', () => {
 			{
 				name: 'approved',
 				type: 'boolean',
-				writers: ['reviewer'],
+				writers: [],
 				check: { op: '==', value: true },
 			},
 		];
@@ -1126,7 +1126,7 @@ describe('computeGateDefaults with optional fields', () => {
 			{
 				name: 'status',
 				type: 'string',
-				writers: ['human'],
+				writers: [],
 				check: { op: 'exists' },
 			},
 		];
@@ -1139,7 +1139,7 @@ describe('computeGateDefaults with optional fields', () => {
 			{
 				name: 'approved',
 				type: 'boolean',
-				writers: ['reviewer'],
+				writers: [],
 				check: { op: '==', value: true },
 			},
 			{
@@ -1151,7 +1151,7 @@ describe('computeGateDefaults with optional fields', () => {
 			{
 				name: 'comment',
 				type: 'string',
-				writers: ['human'],
+				writers: [],
 				check: { op: 'exists' },
 			},
 		];
@@ -1164,7 +1164,7 @@ describe('computeGateDefaults with optional fields', () => {
 			{
 				name: 'reviewer_votes',
 				type: 'map',
-				writers: ['reviewer'],
+				writers: [],
 				check: { op: 'count', match: 'approved', min: 1 },
 			},
 			{
@@ -1216,7 +1216,7 @@ describe('evaluateGate with optional fields', () => {
 				{
 					name: 'approved',
 					type: 'boolean',
-					writers: ['reviewer'],
+					writers: [],
 					check: { op: '==', value: true },
 				},
 			],
@@ -1244,7 +1244,7 @@ describe('Backward compatibility — gates without new fields round-trip', () =>
 					{
 						name: 'approved',
 						type: 'boolean',
-						writers: ['reviewer'],
+						writers: [],
 						check: { op: '==', value: true },
 					},
 				],
@@ -1354,7 +1354,7 @@ describe('Backward compatibility — gates without new fields round-trip', () =>
 					{
 						name: 'done',
 						type: 'boolean',
-						writers: ['human'],
+						writers: [],
 						check: { op: 'exists' },
 					},
 				],

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
@@ -257,7 +257,12 @@ describe('SpaceRuntime — completion actions', () => {
 		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager);
 
 		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
-		taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+		// Simulate end-node agent calling report_result — this is the new completion signal.
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'task complete',
+		});
 		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
 
 		await rt.executeTick();
@@ -273,7 +278,12 @@ describe('SpaceRuntime — completion actions', () => {
 		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager);
 
 		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
-		taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+		// Simulate end-node agent calling report_result — this is the new completion signal.
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'task complete',
+		});
 		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
 
 		await rt.executeTick();
@@ -301,7 +311,12 @@ describe('SpaceRuntime — completion actions', () => {
 		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
 
 		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
-		taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+		// Simulate end-node agent calling report_result — this is the new completion signal.
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'task complete',
+		});
 		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
 
 		await rt.executeTick();
@@ -331,7 +346,12 @@ describe('SpaceRuntime — completion actions', () => {
 		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
 
 		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
-		taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+		// Simulate end-node agent calling report_result — this is the new completion signal.
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'task complete',
+		});
 		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
 
 		await rt.executeTick();
@@ -365,7 +385,12 @@ describe('SpaceRuntime — completion actions', () => {
 		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
 
 		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
-		taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+		// Simulate end-node agent calling report_result — this is the new completion signal.
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'task complete',
+		});
 		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
 
 		await rt.executeTick();
@@ -400,7 +425,12 @@ describe('SpaceRuntime — completion actions', () => {
 		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
 
 		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
-		taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+		// Simulate end-node agent calling report_result — this is the new completion signal.
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'task complete',
+		});
 		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
 
 		await rt.executeTick();
@@ -430,7 +460,12 @@ describe('SpaceRuntime — completion actions', () => {
 		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
 
 		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
-		taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+		// Simulate end-node agent calling report_result — this is the new completion signal.
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'task complete',
+		});
 		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
 
 		await rt.executeTick();
@@ -456,7 +491,12 @@ describe('SpaceRuntime — completion actions', () => {
 		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
 
 		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
-		taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+		// Simulate end-node agent calling report_result — this is the new completion signal.
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'task complete',
+		});
 		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
 
 		await rt.executeTick();
@@ -491,7 +531,12 @@ describe('SpaceRuntime — completion actions', () => {
 		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
 
 		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
-		taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+		// Simulate end-node agent calling report_result — this is the new completion signal.
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'task complete',
+		});
 		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
 
 		// First tick: action-low auto-executes, action-high pauses
@@ -540,7 +585,12 @@ describe('SpaceRuntime — completion actions', () => {
 		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
 
 		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
-		taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+		// Simulate end-node agent calling report_result — this is the new completion signal.
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'task complete',
+		});
 		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
 
 		// Tick: pauses at action-1 (requiredLevel 3, autonomy 2)

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
@@ -471,6 +471,107 @@ describe('SpaceRuntime — completion actions', () => {
 		expect(task.approvalSource).toBe('auto_policy');
 	});
 
+	// ─── Resume from pendingActionIndex ─────────────────────────────────
+
+	test('resumeCompletionActions executes pending action and transitions to done', async () => {
+		setAutonomyLevel(3);
+		const rt = makeRuntime();
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'action-low',
+				name: 'Low-Level',
+				type: 'script',
+				requiredLevel: 2,
+				script: 'echo "low"',
+			},
+			{
+				id: 'action-high',
+				name: 'High-Level',
+				type: 'script',
+				requiredLevel: 5,
+				script: 'echo "high"',
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		// First tick: action-low auto-executes, action-high pauses
+		await rt.executeTick();
+		let task = taskRepo.getTask(tasks[0].id)!;
+		expect(task.status).toBe('review');
+		expect(task.pendingActionIndex).toBe(1);
+		expect(task.pendingCheckpointType).toBe('completion_action');
+
+		// Human approves → resume from pendingActionIndex
+		const resumed = await rt.resumeCompletionActions(SPACE_ID, tasks[0].id);
+		expect(resumed).not.toBeNull();
+		expect(resumed!.status).toBe('done');
+		expect(resumed!.approvalSource).toBe('human');
+		expect(resumed!.pendingActionIndex).toBeNull();
+		expect(resumed!.pendingCheckpointType).toBeNull();
+	});
+
+	test('resumeCompletionActions pauses again if next action also needs approval', async () => {
+		setAutonomyLevel(2);
+		const rt = makeRuntime();
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'action-1',
+				name: 'Action 1',
+				type: 'script',
+				requiredLevel: 3,
+				script: 'echo "1"',
+			},
+			{
+				id: 'action-2',
+				name: 'Action 2',
+				type: 'script',
+				requiredLevel: 4,
+				script: 'echo "2"',
+			},
+			{
+				id: 'action-3',
+				name: 'Action 3',
+				type: 'script',
+				requiredLevel: 2,
+				script: 'echo "3"',
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		// Tick: pauses at action-1 (requiredLevel 3, autonomy 2)
+		await rt.executeTick();
+		let task = taskRepo.getTask(tasks[0].id)!;
+		expect(task.pendingActionIndex).toBe(0);
+
+		// Human approves action-1 → executes it, then pauses at action-2 (index 1)
+		const resumed = await rt.resumeCompletionActions(SPACE_ID, tasks[0].id);
+		expect(resumed).not.toBeNull();
+		expect(resumed!.status).toBe('review');
+		expect(resumed!.pendingActionIndex).toBe(1);
+		expect(resumed!.pendingCheckpointType).toBe('completion_action');
+	});
+
+	test('resumeCompletionActions returns null for task without pending checkpoint', async () => {
+		setAutonomyLevel(2);
+		const rt = makeRuntime();
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager);
+
+		const { tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+
+		const result = await rt.resumeCompletionActions(SPACE_ID, tasks[0].id);
+		expect(result).toBeNull();
+	});
+
 	// ─── completionActions DB persistence ────────────────────────────────
 
 	test('completionActions survive DB round-trip via workflow repository', () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
@@ -604,6 +604,9 @@ describe('SpaceRuntime — completion actions', () => {
 		expect(resumed!.status).toBe('review');
 		expect(resumed!.pendingActionIndex).toBe(1);
 		expect(resumed!.pendingCheckpointType).toBe('completion_action');
+		// Stale approval from the previous cycle must be cleared so the UI does
+		// not show the new pause as already-approved.
+		expect(resumed!.approvedAt).toBeNull();
 	});
 
 	test('resumeCompletionActions returns null for task without pending checkpoint', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
@@ -412,6 +412,65 @@ describe('SpaceRuntime — completion actions', () => {
 		expect(task.pendingCheckpointType).toBeNull();
 	});
 
+	// ─── Script failure behavior (fire-and-forget) ─────────────────────
+
+	test('completion action script failure → task still transitions to done', async () => {
+		setAutonomyLevel(5);
+		const rt = makeRuntime();
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'failing-action',
+				name: 'Failing Action',
+				type: 'script',
+				requiredLevel: 3,
+				script: 'echo "error" >&2; exit 1',
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+
+		// Completion actions are best-effort — script failure does not block task completion
+		const task = taskRepo.getTask(tasks[0].id)!;
+		expect(task.status).toBe('done');
+		expect(task.approvalSource).toBe('auto_policy');
+		expect(task.pendingActionIndex).toBeNull();
+	});
+
+	test('completion action script timeout → task still transitions to done', async () => {
+		setAutonomyLevel(5);
+		const rt = makeRuntime();
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'timeout-action',
+				name: 'Timeout Action',
+				type: 'script',
+				requiredLevel: 2,
+				// The script sleeps, but executeCompletionAction has a 120s timeout.
+				// We can't wait 120s in a test, so test with a script that exits non-zero
+				// to exercise the same code path (both log a warning and continue).
+				script: 'exit 42',
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+
+		const task = taskRepo.getTask(tasks[0].id)!;
+		expect(task.status).toBe('done');
+		expect(task.approvalSource).toBe('auto_policy');
+	});
+
 	// ─── completionActions DB persistence ────────────────────────────────
 
 	test('completionActions survive DB round-trip via workflow repository', () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
@@ -6,6 +6,7 @@
  *   - Completion actions auto-execute when space autonomy >= action.requiredLevel
  *   - Task pauses at 'review' with pendingActionIndex when autonomy < action.requiredLevel
  *   - All actions auto-executed → task goes to 'done' with 'auto_policy' approval
+ *   - Script failure → task goes to 'failed' (not fire-and-forget)
  *   - completionActions survive DB round-trip (persisted in node config)
  */
 
@@ -195,7 +196,6 @@ describe('SpaceRuntime — completion actions', () => {
 	let sink: MockNotificationSink;
 
 	const SPACE_ID = 'space-ca-1';
-	const WORKSPACE = '/tmp/ca-ws';
 	const AGENT_A = 'agent-a';
 
 	function makeRuntime(extraConfig?: Partial<SpaceRuntimeConfig>): SpaceRuntime {
@@ -220,7 +220,7 @@ describe('SpaceRuntime — completion actions', () => {
 
 	beforeEach(() => {
 		({ db, dir } = makeDb());
-		seedSpaceRow(db, SPACE_ID, WORKSPACE, 1); // default level 1, overridden per test
+		seedSpaceRow(db, SPACE_ID, dir, 1); // use test dir as workspace so scripts can run
 		seedAgentRow(db, AGENT_A, SPACE_ID);
 
 		workflowRunRepo = new SpaceWorkflowRunRepository(db);
@@ -412,9 +412,9 @@ describe('SpaceRuntime — completion actions', () => {
 		expect(task.pendingCheckpointType).toBeNull();
 	});
 
-	// ─── Script failure behavior (fire-and-forget) ─────────────────────
+	// ─── Script failure behavior ────────────────────────────────────────
 
-	test('completion action script failure → task still transitions to done', async () => {
+	test('completion action script failure → task fails', async () => {
 		setAutonomyLevel(5);
 		const rt = makeRuntime();
 
@@ -435,26 +435,21 @@ describe('SpaceRuntime — completion actions', () => {
 
 		await rt.executeTick();
 
-		// Completion actions are best-effort — script failure does not block task completion
 		const task = taskRepo.getTask(tasks[0].id)!;
-		expect(task.status).toBe('done');
-		expect(task.approvalSource).toBe('auto_policy');
-		expect(task.pendingActionIndex).toBeNull();
+		expect(task.status).toBe('blocked');
+		expect(task.result).toContain('Failing Action');
 	});
 
-	test('completion action script non-zero exit → task still transitions to done', async () => {
+	test('completion action script non-zero exit → task fails', async () => {
 		setAutonomyLevel(5);
 		const rt = makeRuntime();
 
 		const actions: CompletionAction[] = [
 			{
-				id: 'timeout-action',
-				name: 'Timeout Action',
+				id: 'exit-action',
+				name: 'Exit Action',
 				type: 'script',
 				requiredLevel: 2,
-				// The script sleeps, but executeCompletionAction has a 120s timeout.
-				// We can't wait 120s in a test, so test with a script that exits non-zero
-				// to exercise the same code path (both log a warning and continue).
 				script: 'exit 42',
 			},
 		];
@@ -467,8 +462,8 @@ describe('SpaceRuntime — completion actions', () => {
 		await rt.executeTick();
 
 		const task = taskRepo.getTask(tasks[0].id)!;
-		expect(task.status).toBe('done');
-		expect(task.approvalSource).toBe('auto_policy');
+		expect(task.status).toBe('blocked');
+		expect(task.result).toContain('Exit Action');
 	});
 
 	// ─── Resume from pendingActionIndex ─────────────────────────────────

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
@@ -442,7 +442,7 @@ describe('SpaceRuntime — completion actions', () => {
 		expect(task.pendingActionIndex).toBeNull();
 	});
 
-	test('completion action script timeout → task still transitions to done', async () => {
+	test('completion action script non-zero exit → task still transitions to done', async () => {
 		setAutonomyLevel(5);
 		const rt = makeRuntime();
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
@@ -109,6 +109,22 @@ function buildLinearWorkflow(
 	});
 }
 
+// End nodes must have exactly 1 agent (validator rule). For tests that exercise
+// a multi-agent step, append a downstream single-agent end node so the
+// multi-agent step remains an intermediate node.
+const SYNTHETIC_END_NODE_ID = '__test_end__';
+function withSyntheticEnd(endAgentId: string): {
+	id: string;
+	name: string;
+	agents: Array<{ agentId: string; name: string }>;
+} {
+	return {
+		id: SYNTHETIC_END_NODE_ID,
+		name: 'Synthetic End',
+		agents: [{ agentId: endAgentId, name: 'end' }],
+	};
+}
+
 function seedNodeExec(
 	db: BunDatabase,
 	workflowRunId: string,
@@ -391,31 +407,18 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			expect(completedEvents).toHaveLength(1);
 		});
 
-		test('multi-node with one task still in_progress → run does NOT complete', async () => {
+		test('multi-node with canonical task in_progress → run does NOT complete', async () => {
 			const rt = makeRuntimeWithTam();
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: 'node-ip-1', name: 'Plan', agentId: AGENT_B },
 				{ id: 'node-ip-2', name: 'Code', agentId: AGENT_A },
 			]);
 
-			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			const { run } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 
-			// First node done
-			taskRepo.updateTask(tasks[0].id, { status: 'done' });
-
-			// Second node in progress
-			const taskManager = rt.getTaskManagerForSpace(SPACE_ID);
-			await taskManager.createTask({
-				title: 'Code',
-				description: '',
-				workflowRunId: run.id,
-				workflowNodeId: 'node-ip-2',
-				taskType: 'coding',
-				agentName: 'coder',
-				status: 'in_progress',
-			});
-
-			// Create node_execution records — one done, one still in_progress
+			// Canonical task is left in default in_progress; node executions are
+			// in flight. Completion is purely task-status driven, so the run must
+			// not complete while the canonical task is non-terminal.
 			seedNodeExec(db, run.id, 'node-ip-1', 'agent', 'idle');
 			seedNodeExec(db, run.id, 'node-ip-2', 'coder', 'in_progress');
 
@@ -610,15 +613,12 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 	// -------------------------------------------------------------------------
 
 	describe('pending-but-blocked via workflow channels', () => {
-		test('run completes when all active tasks are done (channel topology guard removed in M71)', async () => {
-			// NOTE: The channel-based pending-node-activation guard was removed as part of the M71
-			// schema migration (which dropped workflow_node_id from space_tasks).
-			// A replacement guard using endNodeId will be added in a subsequent task.
-			// This test verifies the CURRENT behavior: a run with all tasks done completes,
-			// even if a channel target node was never activated.
+		test('canonical task done → run completes (task-status drives completion)', async () => {
+			// Completion is purely task-status driven: when the single canonical
+			// task reaches a terminal status, the run completes, regardless of
+			// channel topology or which node the canonical task is attached to.
 			const rt = makeRuntimeWithTam();
 
-			// Create a workflow with channels: Plan → Code
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
 				name: `Channeled Workflow ${Date.now()}`,
@@ -642,18 +642,18 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 			expect(tasks).toHaveLength(1); // Only start node
 
-			// Complete the only node-agent task
+			// Mark the canonical task done; completion fires regardless of
+			// whether downstream nodes were ever activated.
 			taskRepo.updateTask(tasks[0].id, { status: 'done' });
 			seedNodeExec(db, run.id, 'chan-plan', 'Planner', 'idle');
 
 			await rt.executeTick();
 
-			// With explicit endNodeId semantics, completing a non-end node is not enough.
 			const runAfter = workflowRunRepo.getRun(run.id);
-			expect(runAfter?.status).toBe('in_progress');
+			expect(runAfter?.status).toBe('done');
 
 			const completedEvents = sink.events.filter((e) => e.kind === 'workflow_run_completed');
-			expect(completedEvents).toHaveLength(0);
+			expect(completedEvents).toHaveLength(1);
 		});
 
 		test('all channels satisfied — completion proceeds normally', async () => {
@@ -703,7 +703,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			expect(completedEvents).toHaveLength(1);
 		});
 
-		test('no channels on workflow — completion only checks task statuses', async () => {
+		test('no channels on workflow — completion only checks canonical task status', async () => {
 			const rt = makeRuntimeWithTam();
 
 			// Workflow with NO channels
@@ -714,18 +714,17 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 
-			// Complete start node only — second node never activated
+			// Mark canonical task done — completion fires regardless of channels.
 			taskRepo.updateTask(tasks[0].id, { status: 'done' });
 			seedNodeExec(db, run.id, 'no-chan-1', 'agent', 'idle');
 
 			await rt.executeTick();
 
-			// Without channels, explicit endNodeId still gates completion.
 			const completedRun = workflowRunRepo.getRun(run.id);
-			expect(completedRun?.status).toBe('in_progress');
+			expect(completedRun?.status).toBe('done');
 
 			const completedEvents = sink.events.filter((e) => e.kind === 'workflow_run_completed');
-			expect(completedEvents).toHaveLength(0);
+			expect(completedEvents).toHaveLength(1);
 		});
 
 		test('wildcard channel does not block completion', async () => {
@@ -762,7 +761,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 	// -------------------------------------------------------------------------
 
 	describe('multi-agent parallel node', () => {
-		test('all agents in parallel node complete → run completes', async () => {
+		test('multi-agent step + canonical task done → run completes', async () => {
 			const rt = makeRuntimeWithTam();
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
@@ -778,8 +777,10 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 							{ agentId: AGENT_C, name: 'general' },
 						],
 					},
+					withSyntheticEnd(AGENT_A),
 				],
 				startNodeId: 'par-node',
+				endNodeId: SYNTHETIC_END_NODE_ID,
 				rules: [],
 				tags: [],
 				transitions: [],
@@ -788,7 +789,8 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 			expect(tasks).toHaveLength(1);
 
-			// Create node_execution records for CompletionDetector
+			// Completion is task-status driven; mark the canonical task done.
+			taskRepo.updateTask(tasks[0].id, { status: 'done' });
 			seedNodeExec(db, run.id, 'par-node', 'coder', 'idle');
 			seedNodeExec(db, run.id, 'par-node', 'planner', 'idle');
 			seedNodeExec(db, run.id, 'par-node', 'general', 'cancelled');
@@ -803,7 +805,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			expect(completedEvents).toHaveLength(1);
 		});
 
-		test('one agent in parallel node still in_progress → run stays in_progress', async () => {
+		test('multi-agent step + canonical task in_progress → run stays in_progress', async () => {
 			const rt = makeRuntimeWithTam();
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
@@ -818,8 +820,10 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 							{ agentId: AGENT_B, name: 'planner' },
 						],
 					},
+					withSyntheticEnd(AGENT_A),
 				],
 				startNodeId: 'par-partial',
+				endNodeId: SYNTHETIC_END_NODE_ID,
 				rules: [],
 				tags: [],
 				transitions: [],
@@ -827,7 +831,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 
 			const { run } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 
-			// Create node_execution records — one done, one still in_progress
+			// Canonical task left in default in_progress.
 			seedNodeExec(db, run.id, 'par-partial', 'coder', 'idle');
 			seedNodeExec(db, run.id, 'par-partial', 'planner', 'in_progress');
 
@@ -840,7 +844,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			expect(completedEvents).toHaveLength(0);
 		});
 
-		test('agents finish at different ticks — completion detected on final tick', async () => {
+		test('multi-agent step: completion detected when canonical task flips terminal', async () => {
 			const rt = makeRuntimeWithTam();
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
@@ -855,30 +859,29 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 							{ agentId: AGENT_B, name: 'planner' },
 						],
 					},
+					withSyntheticEnd(AGENT_A),
 				],
 				startNodeId: 'stag-node',
+				endNodeId: SYNTHETIC_END_NODE_ID,
 				rules: [],
 				tags: [],
 				transitions: [],
 			});
 
-			const { run } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 
-			// Create node_execution records for both agents (start non-terminal)
-			const exec1Id = seedNodeExec(db, run.id, 'stag-node', 'coder', 'in_progress');
-			const exec2Id = seedNodeExec(db, run.id, 'stag-node', 'planner', 'in_progress');
+			seedNodeExec(db, run.id, 'stag-node', 'coder', 'in_progress');
+			seedNodeExec(db, run.id, 'stag-node', 'planner', 'in_progress');
 
-			// Tick 1: first agent completes
-			db.prepare('UPDATE node_executions SET status = ? WHERE id = ?').run('idle', exec1Id);
+			// Tick 1: canonical task in_progress; no completion.
 			await rt.executeTick();
 			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
 			expect(sink.events.filter((e) => e.kind === 'workflow_run_completed')).toHaveLength(0);
 
-			// Tick 2: second agent completes
-			db.prepare('UPDATE node_executions SET status = ? WHERE id = ?').run('idle', exec2Id);
+			// Tick 2: canonical task flips to done; completion fires.
+			taskRepo.updateTask(tasks[0].id, { status: 'done' });
 			await rt.executeTick();
 
-			// Now the run should be done
 			expect(workflowRunRepo.getRun(run.id)?.status).toBe('done');
 			expect(sink.events.filter((e) => e.kind === 'workflow_run_completed')).toHaveLength(1);
 
@@ -902,20 +905,25 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 							{ agentId: AGENT_B, name: 'reviewer' },
 						],
 					},
+					withSyntheticEnd(AGENT_A),
 				],
 				startNodeId: 'mix-start',
+				endNodeId: SYNTHETIC_END_NODE_ID,
 				rules: [],
 				tags: [],
 				transitions: [],
 			});
 
-			const { run } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 
-			// startWorkflowRun() creates per-agent node_execution records.
-			// Both should be 'pending' initially.
-			const execsBefore = nodeExecutionRepo.listByWorkflowRun(run.id);
-			expect(execsBefore).toHaveLength(2);
-			expect(execsBefore.every((e) => e.status === 'pending')).toBe(true);
+			// startWorkflowRun() creates per-agent node_execution records for the
+			// multi-agent start step (not the synthetic end). Both should be
+			// 'pending' initially.
+			const startExecs = nodeExecutionRepo
+				.listByWorkflowRun(run.id)
+				.filter((e) => e.workflowNodeId === 'mix-start');
+			expect(startExecs).toHaveLength(2);
+			expect(startExecs.every((e) => e.status === 'pending')).toBe(true);
 
 			// Set executions to heterogeneous statuses: coder done, reviewer still in_progress.
 			seedNodeExec(db, run.id, 'mix-start', 'coder', 'idle');
@@ -924,24 +932,28 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			await rt.executeTick();
 
 			// Node executions should reflect the seeded mixed state.
-			const execsAfter = nodeExecutionRepo.listByWorkflowRun(run.id);
+			const execsAfter = nodeExecutionRepo
+				.listByWorkflowRun(run.id)
+				.filter((e) => e.workflowNodeId === 'mix-start');
 			const coderExec = execsAfter.find((e) => e.agentName === 'coder');
 			const reviewerExec = execsAfter.find((e) => e.agentName === 'reviewer');
 			expect(coderExec?.status).toBe('idle');
 			expect(reviewerExec?.status).toBe('in_progress');
 
-			// Run must NOT be done — reviewer is still in progress.
-			const runAfter = workflowRunRepo.getRun(run.id);
-			expect(runAfter?.status).toBe('in_progress');
+			// Run stays in_progress while canonical task is in_progress.
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
 			expect(sink.events.filter((e) => e.kind === 'workflow_run_completed')).toHaveLength(0);
 
-			// Now complete the reviewer task too.
+			// Flip canonical task to done; reviewer execution becomes idle as the
+			// agent finishes.
 			seedNodeExec(db, run.id, 'mix-start', 'reviewer', 'idle');
+			taskRepo.updateTask(tasks[0].id, { status: 'done' });
 			await rt.executeTick();
 
-			// Both execs should now be 'idle', and the run should be done.
-			const execsFinal = nodeExecutionRepo.listByWorkflowRun(run.id);
-			expect(execsFinal.every((e) => e.status === 'idle')).toBe(true);
+			const startExecsFinal = nodeExecutionRepo
+				.listByWorkflowRun(run.id)
+				.filter((e) => e.workflowNodeId === 'mix-start');
+			expect(startExecsFinal.every((e) => e.status === 'idle')).toBe(true);
 			expect(workflowRunRepo.getRun(run.id)?.status).toBe('done');
 			expect(sink.events.filter((e) => e.kind === 'workflow_run_completed')).toHaveLength(1);
 		});
@@ -1036,70 +1048,10 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			}
 		});
 
-		test('non-end node done but end node still in_progress → run stays in_progress', async () => {
-			const rt = makeRuntimeWithTam();
-
-			const workflow = workflowManager.createWorkflow({
-				spaceId: SPACE_ID,
-				name: `Non-End Done ${Date.now()}`,
-				description: '',
-				nodes: [
-					{ id: 'ne-start', name: 'Start', agentId: AGENT_A },
-					{ id: 'ne-end', name: 'End', agentId: AGENT_B },
-				],
-				startNodeId: 'ne-start',
-				endNodeId: 'ne-end',
-				tags: [],
-			});
-
-			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
-			taskRepo.updateTask(tasks[0].id, { status: 'done' });
-
-			// Start node exec is terminal, but end node exec is still in_progress
-			seedNodeExec(db, run.id, 'ne-start', 'Start', 'idle');
-			seedNodeExec(db, run.id, 'ne-end', 'End', 'in_progress');
-
-			await rt.executeTick();
-
-			const runAfter = workflowRunRepo.getRun(run.id);
-			expect(runAfter?.status).toBe('in_progress');
-			expect(sink.events.filter((e) => e.kind === 'workflow_run_completed')).toHaveLength(0);
-		});
-
-		test('end node execution not created AND sibling in_progress → run stays in_progress', async () => {
-			const rt = makeRuntimeWithTam();
-
-			const workflow = workflowManager.createWorkflow({
-				spaceId: SPACE_ID,
-				name: `End Not Created Sibling IP ${Date.now()}`,
-				description: '',
-				nodes: [
-					{ id: 'encip-start', name: 'Start', agentId: AGENT_A },
-					{ id: 'encip-mid', name: 'Middle', agentId: AGENT_B },
-					{ id: 'encip-end', name: 'End', agentId: AGENT_C },
-				],
-				startNodeId: 'encip-start',
-				endNodeId: 'encip-end',
-				tags: [],
-			});
-
-			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
-			taskRepo.updateTask(tasks[0].id, { status: 'done' });
-
-			// Start node done, middle node in_progress, end node not created
-			seedNodeExec(db, run.id, 'encip-start', 'Start', 'idle');
-			seedNodeExec(db, run.id, 'encip-mid', 'Middle', 'in_progress');
-			// No exec for 'encip-end'
-
-			await rt.executeTick();
-
-			// Middle exec is in_progress → fallback returns false → run stays in_progress
-			const runAfter = workflowRunRepo.getRun(run.id);
-			expect(runAfter?.status).toBe('in_progress');
-			expect(sink.events.filter((e) => e.kind === 'workflow_run_completed')).toHaveLength(0);
-		});
-
-		test('end node done while sibling exec in_progress → run completes, sibling exec cancelled', async () => {
+		test('canonical task done triggers sibling exec cancellation', async () => {
+			// Sibling cancellation now fires on canonical task transition to a
+			// terminal status, not on end-node-execution observation. Any still-
+			// in-flight node executions are cancelled so their agents stop work.
 			const mockTam = new MockTaskAgentManager();
 			mockTam.isSessionAlive = () => true;
 			const rt = makeRuntimeWithTam({
@@ -1108,7 +1060,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
-				name: `End Bypass Sibling Cancel ${Date.now()}`,
+				name: `Sibling Cancel On Task Terminal ${Date.now()}`,
 				description: '',
 				nodes: [
 					{ id: 'ec-sibling', name: 'Sibling', agentId: AGENT_A },
@@ -1121,32 +1073,26 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 
-			// Set start task to in_progress (sibling)
-			taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
-
-			// Seed sibling exec as in_progress with an agentSessionId
+			// Sibling exec in flight with an agent session.
 			const siblingExecId = seedNodeExec(db, run.id, 'ec-sibling', 'Sibling', 'in_progress');
 			const siblingSessionId = 'mock-sibling-session-001';
 			db.prepare('UPDATE node_executions SET agent_session_id = ? WHERE id = ?').run(
 				siblingSessionId,
 				siblingExecId
 			);
-
-			// Seed end node exec as done
 			seedNodeExec(db, run.id, 'ec-end', 'End', 'idle');
+
+			// Canonical task transitions to done; runtime cancels in-flight siblings.
+			taskRepo.updateTask(tasks[0].id, { status: 'done' });
 
 			await rt.executeTick();
 
-			// Run should be done (end-node short-circuit)
 			const completedRun = workflowRunRepo.getRun(run.id);
 			expect(completedRun?.status).toBe('done');
 
-			// Sibling exec should be cancelled
 			const execs = nodeExecutionRepo.listByWorkflowRun(run.id);
 			const siblingExec = execs.find((e) => e.workflowNodeId === 'ec-sibling');
 			expect(siblingExec?.status).toBe('cancelled');
-
-			// TAM should have received cancelBySessionId for the sibling session
 			expect(mockTam.cancelledSessions).toContain(siblingSessionId);
 
 			const completedEvents = sink.events.filter((e) => e.kind === 'workflow_run_completed');
@@ -1177,44 +1123,39 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			);
 		});
 
-		test('end-node bypass: blocked sibling does not block run when end node is done', async () => {
+		test('reportedStatus alone is enough to mark a run for completion resolution', async () => {
+			// Even when task.status is non-terminal, a non-null reportedStatus
+			// signals the runtime to resolve completion via completion-actions on
+			// the next tick.
 			const rt = makeRuntimeWithTam();
 
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
-				name: `End Bypass Blocked Sibling ${Date.now()}`,
+				name: `Reported Status Drives Resolution ${Date.now()}`,
 				description: '',
 				nodes: [
-					{ id: 'ebs-sibling', name: 'Sibling', agentId: AGENT_A },
-					{ id: 'ebs-end', name: 'End', agentId: AGENT_B },
+					{ id: 'rs-start', name: 'Start', agentId: AGENT_A },
+					{ id: 'rs-end', name: 'End', agentId: AGENT_B },
 				],
-				startNodeId: 'ebs-sibling',
-				endNodeId: 'ebs-end',
+				startNodeId: 'rs-start',
+				endNodeId: 'rs-end',
 				tags: [],
 			});
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 
-			// Sibling task is blocked
-			taskRepo.updateTask(tasks[0].id, { status: 'blocked' });
-
-			// Sibling exec blocked, end exec done
-			seedNodeExec(db, run.id, 'ebs-sibling', 'Sibling', 'blocked');
-			seedNodeExec(db, run.id, 'ebs-end', 'End', 'idle');
+			// Agent reported result via report_result; task.status not yet flipped.
+			taskRepo.updateTask(tasks[0].id, {
+				reportedStatus: 'done',
+				reportedSummary: 'work complete',
+			});
+			seedNodeExec(db, run.id, 'rs-end', 'End', 'idle');
 
 			await rt.executeTick();
 
-			// End-node bypass is active → blocked task notification skipped
-			// CompletionDetector returns true (end node done) → run completes
 			const runAfter = workflowRunRepo.getRun(run.id);
 			expect(runAfter?.status).toBe('done');
-
-			// No spurious task_blocked events (end-node bypass suppressed them)
-			const blockedEvents = sink.events.filter((e) => e.kind === 'task_blocked');
-			expect(blockedEvents).toHaveLength(0);
-
-			const completedEvents = sink.events.filter((e) => e.kind === 'workflow_run_completed');
-			expect(completedEvents).toHaveLength(1);
+			expect(sink.events.filter((e) => e.kind === 'workflow_run_completed')).toHaveLength(1);
 		});
 
 		test('end node execution cancelled (terminal) also triggers run completion', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-notifications.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-notifications.test.ts
@@ -175,6 +175,23 @@ function buildLinearWorkflow(
 	});
 }
 
+// End nodes must have exactly 1 agent (validator rule). For tests that exercise
+// a multi-agent step, append a downstream single-agent end node so the
+// multi-agent step remains an intermediate node. Returns the synthesized end
+// node id so tests can reference it.
+const SYNTHETIC_END_NODE_ID = '__test_end__';
+function withSyntheticEnd(endAgentId: string): {
+	id: string;
+	name: string;
+	agents: Array<{ agentId: string; name: string }>;
+} {
+	return {
+		id: SYNTHETIC_END_NODE_ID,
+		name: 'Synthetic End',
+		agents: [{ agentId: endAgentId, name: 'end' }],
+	};
+}
+
 // ---------------------------------------------------------------------------
 // Test suite setup
 // ---------------------------------------------------------------------------
@@ -1083,9 +1100,11 @@ describe('SpaceRuntime — notification events', () => {
 							{ agentId: AGENT_PLANNER, name: 'planner' },
 						],
 					},
+					withSyntheticEnd(AGENT_CODER),
 				],
 				transitions: [],
 				startNodeId: STEP_A,
+				endNodeId: SYNTHETIC_END_NODE_ID,
 				rules: [],
 				tags: [],
 			});
@@ -1115,9 +1134,11 @@ describe('SpaceRuntime — notification events', () => {
 							{ agentId: AGENT_PLANNER, name: 'planner' },
 						],
 					},
+					withSyntheticEnd(AGENT_CODER),
 				],
 				transitions: [],
 				startNodeId: STEP_A,
+				endNodeId: SYNTHETIC_END_NODE_ID,
 				rules: [],
 				tags: [],
 			});
@@ -1165,9 +1186,11 @@ describe('SpaceRuntime — notification events', () => {
 							{ agentId: AGENT_PLANNER, name: 'planner' },
 						],
 					},
+					withSyntheticEnd(AGENT_CODER),
 				],
 				transitions: [],
 				startNodeId: STEP_A,
+				endNodeId: SYNTHETIC_END_NODE_ID,
 				rules: [],
 				tags: [],
 			});
@@ -1285,7 +1308,7 @@ describe('SpaceRuntime — notification events', () => {
 			}
 		});
 
-		test('emits workflow_run_completed for multi-agent step when all tasks are terminal', async () => {
+		test('emits workflow_run_completed for multi-agent step when canonical task is terminal', async () => {
 			const rt = makeRuntimeWithTam();
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
@@ -1299,15 +1322,19 @@ describe('SpaceRuntime — notification events', () => {
 							{ agentId: AGENT_PLANNER2, name: 'planner' },
 						],
 					},
+					withSyntheticEnd(AGENT_CODER),
 				],
 				transitions: [],
 				startNodeId: 'step-multi-cd',
+				endNodeId: SYNTHETIC_END_NODE_ID,
 				rules: [],
 				tags: [],
 			});
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 			expect(tasks).toHaveLength(1);
+			// Completion is task-status driven; flip the canonical task to done.
+			taskRepo.updateTask(tasks[0].id, { status: 'done' });
 			seedNodeExec(db, run.id, 'step-multi-cd', 'coder', 'idle');
 			seedNodeExec(db, run.id, 'step-multi-cd', 'planner', 'idle');
 
@@ -1320,7 +1347,7 @@ describe('SpaceRuntime — notification events', () => {
 			expect(completedEvents).toHaveLength(1);
 		});
 
-		test('does NOT emit workflow_run_completed when a task is still in_progress', async () => {
+		test('does NOT emit workflow_run_completed when canonical task is still in_progress', async () => {
 			const rt = makeRuntimeWithTam();
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
@@ -1334,14 +1361,17 @@ describe('SpaceRuntime — notification events', () => {
 							{ agentId: AGENT_PLANNER2, name: 'planner' },
 						],
 					},
+					withSyntheticEnd(AGENT_CODER),
 				],
 				transitions: [],
 				startNodeId: 'step-ip-cd',
+				endNodeId: SYNTHETIC_END_NODE_ID,
 				rules: [],
 				tags: [],
 			});
 
 			const { run } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			// Canonical task left in default in_progress; completion must not fire.
 			seedNodeExec(db, run.id, 'step-ip-cd', 'coder', 'idle');
 			seedNodeExec(db, run.id, 'step-ip-cd', 'planner', 'in_progress');
 
@@ -1414,7 +1444,7 @@ describe('SpaceRuntime — notification events', () => {
 			expect(['in_progress', 'blocked']).toContain(runAfter?.status);
 		});
 
-		test('completes when all tasks are cancelled (terminal) status', async () => {
+		test('completes when canonical task is cancelled (terminal) status', async () => {
 			const rt = makeRuntimeWithTam();
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
@@ -1428,14 +1458,18 @@ describe('SpaceRuntime — notification events', () => {
 							{ agentId: AGENT_PLANNER2, name: 'planner' },
 						],
 					},
+					withSyntheticEnd(AGENT_CODER),
 				],
 				transitions: [],
 				startNodeId: 'step-cancel-cd',
+				endNodeId: SYNTHETIC_END_NODE_ID,
 				rules: [],
 				tags: [],
 			});
 
-			const { run } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			// Cancelled at node-execution level does NOT complete; only task.status terminal does.
+			taskRepo.updateTask(tasks[0].id, { status: 'cancelled' });
 			seedNodeExec(db, run.id, 'step-cancel-cd', 'coder', 'cancelled');
 			seedNodeExec(db, run.id, 'step-cancel-cd', 'planner', 'cancelled');
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
@@ -91,6 +91,31 @@ function buildLinearWorkflow(
 	});
 }
 
+/**
+ * End-node validation requires exactly 1 agent (validator enforced — they own
+ * the `report_result` completion signal). When a test workflow has its last
+ * node as multi-agent (which used to double as start+end), append a synthetic
+ * single-agent terminal node so the multi-agent node remains the start (or
+ * middle) and validation passes. Tests that don't activate the synthetic end
+ * node continue to behave the same.
+ */
+const SYNTHETIC_END_NODE_ID = '__test_end__';
+
+function appendSyntheticEnd<T extends { id: string; agents?: unknown[] }>(
+	nodes: T[],
+	endAgentId: string
+): { nodes: Array<T | { id: string; name: string; agentId: string }>; endNodeId: string } {
+	const last = nodes[nodes.length - 1];
+	const lastIsMultiAgent = (last.agents?.length ?? 0) > 1;
+	if (!lastIsMultiAgent) {
+		return { nodes, endNodeId: last.id };
+	}
+	return {
+		nodes: [...nodes, { id: SYNTHETIC_END_NODE_ID, name: 'Synthetic End', agentId: endAgentId }],
+		endNodeId: SYNTHETIC_END_NODE_ID,
+	};
+}
+
 // ---------------------------------------------------------------------------
 // Test suite setup
 // ---------------------------------------------------------------------------
@@ -345,22 +370,23 @@ describe('SpaceRuntime', () => {
 		});
 
 		test('multi-agent start step: creates one canonical task and node executions per agent', async () => {
+			const startNode = {
+				id: STEP_A,
+				name: 'Multi Step',
+				agents: [
+					{ agentId: AGENT_PLANNER, name: 'planner' },
+					{ agentId: AGENT_CODER, name: 'coder' },
+				],
+			};
+			const { nodes, endNodeId } = appendSyntheticEnd([startNode], AGENT_CODER);
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
 				name: `Multi-Agent Start ${Date.now()}`,
 				description: '',
-				nodes: [
-					{
-						id: STEP_A,
-						name: 'Multi Step',
-						agents: [
-							{ agentId: AGENT_PLANNER, name: 'planner' },
-							{ agentId: AGENT_CODER, name: 'coder' },
-						],
-					},
-				],
+				nodes,
 				transitions: [],
 				startNodeId: STEP_A,
+				endNodeId,
 				rules: [],
 				tags: [],
 			});
@@ -374,22 +400,23 @@ describe('SpaceRuntime', () => {
 		});
 
 		test('multi-agent start step with custom-role first agent: creates canonical task and executions', async () => {
+			const startNode = {
+				id: STEP_A,
+				name: 'Custom Multi Step',
+				agents: [
+					{ agentId: AGENT_CUSTOM, name: 'my-custom-role' },
+					{ agentId: AGENT_CODER, name: 'coder' },
+				],
+			};
+			const { nodes, endNodeId } = appendSyntheticEnd([startNode], AGENT_CODER);
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
 				name: `Multi-Agent Custom ${Date.now()}`,
 				description: '',
-				nodes: [
-					{
-						id: STEP_A,
-						name: 'Custom Multi Step',
-						agents: [
-							{ agentId: AGENT_CUSTOM, name: 'my-custom-role' },
-							{ agentId: AGENT_CODER, name: 'coder' },
-						],
-					},
-				],
+				nodes,
 				transitions: [],
 				startNodeId: STEP_A,
+				endNodeId,
 				rules: [],
 				tags: [],
 			});
@@ -1049,29 +1076,30 @@ describe('SpaceRuntime', () => {
 
 	describe('multi-agent step support', () => {
 		test('startWorkflowRun() creates one canonical task and one execution per agent', async () => {
+			const startNode = {
+				id: STEP_A,
+				name: 'Parallel Start',
+				agents: [
+					{
+						agentId: AGENT_CODER,
+						name: 'coder',
+						instructions: { mode: 'override' as const, value: 'Coder task' },
+					},
+					{
+						agentId: AGENT_PLANNER,
+						name: 'planner',
+						instructions: { mode: 'override' as const, value: 'Planner task' },
+					},
+				],
+			};
+			const { nodes, endNodeId } = appendSyntheticEnd([startNode], AGENT_CODER);
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
 				name: `Multi-Agent Start ${Date.now()}`,
-				nodes: [
-					{
-						id: STEP_A,
-						name: 'Parallel Start',
-						agents: [
-							{
-								agentId: AGENT_CODER,
-								name: 'coder',
-								instructions: { mode: 'override', value: 'Coder task' },
-							},
-							{
-								agentId: AGENT_PLANNER,
-								name: 'planner',
-								instructions: { mode: 'override', value: 'Planner task' },
-							},
-						],
-					},
-				],
+				nodes,
 				transitions: [],
 				startNodeId: STEP_A,
+				endNodeId,
 				rules: [],
 				tags: [],
 			});
@@ -1099,21 +1127,22 @@ describe('SpaceRuntime', () => {
 		});
 
 		test('startWorkflowRun() creates executions for multi-agent start step', async () => {
+			const startNode = {
+				id: STEP_A,
+				name: 'Mixed Start',
+				agents: [
+					{ agentId: AGENT_PLANNER, name: 'planner' },
+					{ agentId: AGENT_CODER, name: 'coder' },
+				],
+			};
+			const { nodes, endNodeId } = appendSyntheticEnd([startNode], AGENT_CODER);
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
 				name: `Multi-Agent TaskType ${Date.now()}`,
-				nodes: [
-					{
-						id: STEP_A,
-						name: 'Mixed Start',
-						agents: [
-							{ agentId: AGENT_PLANNER, name: 'planner' },
-							{ agentId: AGENT_CODER, name: 'coder' },
-						],
-					},
-				],
+				nodes,
 				transitions: [],
 				startNodeId: STEP_A,
+				endNodeId,
 				rules: [],
 				tags: [],
 			});
@@ -1162,21 +1191,22 @@ describe('SpaceRuntime', () => {
 		});
 
 		test('executeTick() marks run blocked when one parallel execution is blocked', async () => {
+			const startNode = {
+				id: STEP_A,
+				name: 'Parallel Fail',
+				agents: [
+					{ agentId: AGENT_CODER, name: 'coder' },
+					{ agentId: AGENT_PLANNER, name: 'planner' },
+				],
+			};
+			const { nodes, endNodeId } = appendSyntheticEnd([startNode], AGENT_CODER);
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
 				name: `Partial Failure ${Date.now()}`,
-				nodes: [
-					{
-						id: STEP_A,
-						name: 'Parallel Fail',
-						agents: [
-							{ agentId: AGENT_CODER, name: 'coder' },
-							{ agentId: AGENT_PLANNER, name: 'planner' },
-						],
-					},
-				],
+				nodes,
 				transitions: [],
 				startNodeId: STEP_A,
+				endNodeId,
 				rules: [],
 				tags: [],
 			});
@@ -1195,21 +1225,22 @@ describe('SpaceRuntime', () => {
 		});
 
 		test('executeTick() marks run blocked when one execution is blocked and one is in_progress', async () => {
+			const startNode = {
+				id: STEP_A,
+				name: 'Parallel Waiting',
+				agents: [
+					{ agentId: AGENT_CODER, name: 'coder' },
+					{ agentId: AGENT_PLANNER, name: 'planner' },
+				],
+			};
+			const { nodes, endNodeId } = appendSyntheticEnd([startNode], AGENT_CODER);
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
 				name: `Partial Terminal ${Date.now()}`,
-				nodes: [
-					{
-						id: STEP_A,
-						name: 'Parallel Waiting',
-						agents: [
-							{ agentId: AGENT_CODER, name: 'coder' },
-							{ agentId: AGENT_PLANNER, name: 'planner' },
-						],
-					},
-				],
+				nodes,
 				transitions: [],
 				startNodeId: STEP_A,
+				endNodeId,
 				rules: [],
 				tags: [],
 			});
@@ -1280,20 +1311,21 @@ describe('SpaceRuntime', () => {
 			seedAgentRow(db, AGENT_CODER_2, SPACE_ID, 'Coder 2');
 
 			const stepId = `step-dedup-${Date.now()}`;
+			const startNode = {
+				id: stepId,
+				name: 'Two Coders',
+				agents: [
+					{ agentId: AGENT_CODER, name: 'coder' },
+					{ agentId: AGENT_CODER_2, name: 'coder-2' },
+				],
+			};
+			const { nodes, endNodeId } = appendSyntheticEnd([startNode], AGENT_CODER);
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
 				name: 'Duplicate Role Test',
-				nodes: [
-					{
-						id: stepId,
-						name: 'Two Coders',
-						agents: [
-							{ agentId: AGENT_CODER, name: 'coder' },
-							{ agentId: AGENT_CODER_2, name: 'coder-2' },
-						],
-					},
-				],
+				nodes,
 				startNodeId: stepId,
+				endNodeId,
 			});
 
 			const { run } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');

--- a/packages/daemon/tests/unit/5-space/runtime/space-workflow.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-workflow.test.ts
@@ -797,6 +797,8 @@ describe('SpaceWorkflowManager', () => {
 						{ agentId: 'agent-b', name: 'b' },
 					],
 				},
+				// Synthetic single-agent end node — multi-agent end nodes are forbidden.
+				{ name: 'End', agentId: 'agent-a' },
 			],
 		});
 		expect(wf.nodes[0].agents).toHaveLength(2);
@@ -1034,7 +1036,11 @@ describe('SpaceWorkflowManager', () => {
 						{ agentId: 'agent-b', name: 'b' },
 					],
 				},
+				// Synthetic single-agent end node — multi-agent end nodes are forbidden.
+				{ id: 'step-end', name: 'End', agents: [{ agentId: 'agent-a', name: 'end' }] },
 			],
+			startNodeId: 'step-new',
+			endNodeId: 'step-end',
 		})!;
 
 		const node = updated.nodes[0];
@@ -1057,7 +1063,11 @@ describe('SpaceWorkflowManager', () => {
 						{ agentId: 'agent-b', name: 'b' },
 					],
 				},
+				// Synthetic single-agent end node — multi-agent end nodes are forbidden.
+				{ id: 'step-end', name: 'End', agentId: 'agent-a' },
 			],
+			startNodeId: 'step-1',
+			endNodeId: 'step-end',
 		});
 
 		expect(manager.deleteWorkflow(wf.id)).toBe(true);
@@ -1083,7 +1093,11 @@ describe('SpaceWorkflowManager', () => {
 						{ agentId: 'agent-y', name: 'y' },
 					],
 				},
+				// Synthetic single-agent end node — multi-agent end nodes are forbidden.
+				{ id: 'step-end', name: 'End', agentId: 'agent-x' },
 			],
+			startNodeId: 'step-m',
+			endNodeId: 'step-end',
 		});
 
 		const workflows = manager.listWorkflows('space-1');
@@ -1147,6 +1161,8 @@ describe('SpaceWorkflowManager', () => {
 						{ agentId: 'agent-a', name: 'quick-reviewer' },
 					],
 				},
+				// Synthetic single-agent end node — multi-agent end nodes are forbidden.
+				{ name: 'End', agentId: 'agent-a' },
 			],
 		});
 		expect(wf.nodes[0].agents).toHaveLength(2);

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -445,7 +445,7 @@ describe('FULL_CYCLE_CODING_WORKFLOW template', () => {
 		const gate = FULL_CYCLE_CODING_WORKFLOW.gates!.find((g) => g.id === 'plan-approval-gate')!;
 		expect(gate.fields[0].name).toBe('approved');
 		expect(gate.fields[0].check).toMatchObject({ op: '==', value: true });
-		expect(gate.fields[0].writers).toEqual(['reviewer']);
+		expect(gate.fields[0].writers).toEqual([]);
 		expect(gate.label).toBe('Approval');
 		expect(gate.requiredLevel).toBe(3);
 		expect(gate.resetOnCycle).toBe(true);
@@ -1343,18 +1343,18 @@ describe('seedBuiltInWorkflows()', () => {
 	test('FULL_CYCLE_CODING_WORKFLOW plan-approval-gate uses requiredLevel instead of human writer', () => {
 		const gate = FULL_CYCLE_CODING_WORKFLOW.gates!.find((g) => g.id === 'plan-approval-gate')!;
 		const approvedField = gate.fields.find((f) => f.name === 'approved')!;
-		expect(approvedField.writers).toEqual(['reviewer']);
+		expect(approvedField.writers).toEqual([]);
 		expect(gate.requiredLevel).toBe(3);
 	});
 
-	test('seeded plan-approval-gate preserves requiredLevel and reviewer writer', () => {
+	test('seeded plan-approval-gate preserves requiredLevel and external-only writers', () => {
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const wf = manager
 			.listWorkflows(SPACE_ID)
 			.find((w) => w.name === FULL_CYCLE_CODING_WORKFLOW.name)!;
 		const gate = wf.gates!.find((g) => g.id === 'plan-approval-gate')!;
 		const approvedField = gate.fields.find((f) => f.name === 'approved')!;
-		expect(approvedField.writers).toEqual(['reviewer']);
+		expect(approvedField.writers).toEqual([]);
 		expect(gate.requiredLevel).toBe(3);
 	});
 

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -96,9 +96,9 @@ function hasLeaderAgentId(wf: SpaceWorkflow): boolean {
 // ---------------------------------------------------------------------------
 
 describe('CODING_WORKFLOW template', () => {
-	test('has two nodes: Code, Review', () => {
+	test('has two nodes: Coding, Review', () => {
 		expect(CODING_WORKFLOW.nodes).toHaveLength(2);
-		expect(CODING_WORKFLOW.nodes.map((s) => s.name)).toEqual(['Code', 'Review']);
+		expect(CODING_WORKFLOW.nodes.map((s) => s.name)).toEqual(['Coding', 'Review']);
 	});
 
 	test('step agentId placeholders are correct', () => {
@@ -110,16 +110,16 @@ describe('CODING_WORKFLOW template', () => {
 		expect(CODING_WORKFLOW.channels).toHaveLength(2);
 	});
 
-	test('Code → Review channel is gated by code-ready-gate', () => {
-		const ch = CODING_WORKFLOW.channels!.find((c) => c.from === 'Code' && c.to === 'Review');
+	test('Coding → Review channel is gated by code-ready-gate', () => {
+		const ch = CODING_WORKFLOW.channels!.find((c) => c.from === 'Coding' && c.to === 'Review');
 		expect(ch).toBeDefined();
 		expect(ch!.gateId).toBe('code-ready-gate');
 		// direction field removed from WorkflowChannel
 		expect(ch!.maxCycles).toBeUndefined();
 	});
 
-	test('Review → Code channel is ungated with maxCycles', () => {
-		const ch = CODING_WORKFLOW.channels!.find((c) => c.from === 'Review' && c.to === 'Code');
+	test('Review → Coding channel is ungated with maxCycles', () => {
+		const ch = CODING_WORKFLOW.channels!.find((c) => c.from === 'Review' && c.to === 'Coding');
 		expect(ch).toBeDefined();
 		expect(ch!.gateId).toBeUndefined();
 		// direction field removed from WorkflowChannel
@@ -147,11 +147,11 @@ describe('CODING_WORKFLOW template', () => {
 		expect(gate.fields).toHaveLength(1);
 	});
 
-	test('code-ready-gate has pr_url exists field with wildcard writer', () => {
+	test('code-ready-gate has pr_url field writable only by Coding', () => {
 		const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'code-ready-gate')!;
 		const prField = gate.fields.find((f) => f.name === 'pr_url')!;
 		expect(prField.type).toBe('string');
-		expect(prField.writers).toEqual(['*']);
+		expect(prField.writers).toEqual(['Coding']);
 		expect(prField.check.op).toBe('exists');
 	});
 
@@ -179,7 +179,7 @@ describe('CODING_WORKFLOW template', () => {
 		expect(gate.resetOnCycle).toBe(true);
 	});
 
-	test('startNodeId points to the Code step', () => {
+	test('startNodeId points to the Coding step', () => {
 		const codeStep = CODING_WORKFLOW.nodes.find((s) => s.agents[0]?.name === 'coder');
 		expect(CODING_WORKFLOW.startNodeId).toBe(codeStep?.id);
 	});
@@ -570,7 +570,7 @@ describe('FULL_CYCLE_CODING_WORKFLOW template', () => {
 	test('QA node agent slot customPrompt describes pass and fail actions', () => {
 		const qa = FULL_CYCLE_CODING_WORKFLOW.nodes.find((n) => n.name === 'QA')!;
 		// Node-level instructions were removed; agent slots carry the task instructions
-		expect(qa.agents[0].customPrompt?.value).toContain('report_done');
+		expect(qa.agents[0].customPrompt?.value).toContain('report_result');
 	});
 
 	test('review-votes-gate description mentions read-merge-write requirement', () => {
@@ -804,16 +804,16 @@ describe('seedBuiltInWorkflows()', () => {
 		expect(wf!.nodes[1].agents[0]?.agentId).toBe(roleMap.reviewer);
 	});
 
-	test('CODING_WORKFLOW seeded with two channels (gated Code→Review, ungated Review→Code)', async () => {
+	test('CODING_WORKFLOW seeded with two channels (gated Coding→Review, ungated Review→Coding)', async () => {
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
 		expect(wf.channels).toHaveLength(2);
 
-		const codeToReview = wf.channels!.find((c) => c.from === 'Code' && c.to === 'Review');
+		const codeToReview = wf.channels!.find((c) => c.from === 'Coding' && c.to === 'Review');
 		expect(codeToReview).toBeDefined();
 		expect(codeToReview!.gateId).toBe('code-ready-gate');
 
-		const reviewToCode = wf.channels!.find((c) => c.from === 'Review' && c.to === 'Code');
+		const reviewToCode = wf.channels!.find((c) => c.from === 'Review' && c.to === 'Coding');
 		expect(reviewToCode).toBeDefined();
 		expect(reviewToCode!.gateId).toBeUndefined();
 		expect(reviewToCode!.maxCycles).toBe(5);
@@ -1240,10 +1240,10 @@ describe('seedBuiltInWorkflows()', () => {
 	test('CODING_WORKFLOW seeded nodes preserve customPrompt content', () => {
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
-		const codeNode = wf.nodes.find((n) => n.name === 'Code');
+		const codeNode = wf.nodes.find((n) => n.name === 'Coding');
 		expect(codeNode?.agents[0].customPrompt?.value).toContain('gh pr create');
 		const reviewNode = wf.nodes.find((n) => n.name === 'Review');
-		expect(reviewNode?.agents[0].customPrompt?.value).toContain('report_done()');
+		expect(reviewNode?.agents[0].customPrompt?.value).toContain('report_result(');
 	});
 
 	test('FULL_CYCLE_CODING_WORKFLOW seeded nodes preserve customPrompt content', () => {
@@ -1256,7 +1256,7 @@ describe('seedBuiltInWorkflows()', () => {
 		const codingNode = wf.nodes.find((n) => n.name === 'Coding');
 		expect(codingNode?.agents[0].customPrompt?.value).toContain('code-pr-gate');
 		const qaNode = wf.nodes.find((n) => n.name === 'QA');
-		expect(qaNode?.agents[0].customPrompt?.value).toContain('report_done');
+		expect(qaNode?.agents[0].customPrompt?.value).toContain('report_result');
 	});
 
 	test('RESEARCH_WORKFLOW seeded nodes preserve customPrompt content', () => {
@@ -1265,7 +1265,7 @@ describe('seedBuiltInWorkflows()', () => {
 		const researchNode = wf.nodes.find((n) => n.name === 'Research');
 		expect(researchNode?.agents[0].customPrompt?.value).toContain('gh pr create');
 		const reviewNode = wf.nodes.find((n) => n.name === 'Review');
-		expect(reviewNode?.agents[0].customPrompt?.value).toContain('report_done()');
+		expect(reviewNode?.agents[0].customPrompt?.value).toContain('report_result(');
 	});
 
 	// ─── Gate preservation per workflow ──────────────────────────────────────
@@ -1329,7 +1329,7 @@ describe('seedBuiltInWorkflows()', () => {
 	test('seeded channels retain all original fields plus a UUID id', () => {
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
-		const codeToReview = wf.channels!.find((c) => c.from === 'Code' && c.to === 'Review');
+		const codeToReview = wf.channels!.find((c) => c.from === 'Coding' && c.to === 'Review');
 		expect(codeToReview).toBeDefined();
 		expect(codeToReview!.id).toMatch(
 			/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
@@ -1622,7 +1622,7 @@ describe('Coding Workflow export/import round-trip', () => {
 		expect(result.ok).toBe(true);
 	});
 
-	test('exported Coding Workflow preserves two channels and Review→Code cycle', () => {
+	test('exported Coding Workflow preserves two channels and Review→Coding cycle', () => {
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
 
@@ -1631,7 +1631,7 @@ describe('Coding Workflow export/import round-trip', () => {
 		// gateId is stripped during export (gates are separate entities)
 		expect(exported.channels).toHaveLength(2);
 
-		const reviewToCode = exported.channels!.find((c) => c.from === 'Review' && c.to === 'Code');
+		const reviewToCode = exported.channels!.find((c) => c.from === 'Review' && c.to === 'Coding');
 		expect(reviewToCode).toBeDefined();
 		expect(reviewToCode!.maxCycles).toBe(5);
 	});
@@ -1688,12 +1688,12 @@ describe('Coding Workflow export/import round-trip', () => {
 		expect(reimported.nodes).toHaveLength(2);
 		expect(reimported.channels).toHaveLength(2);
 
-		// Code → Review channel preserved
-		const codeToReview = reimported.channels!.find((c) => c.from === 'Code' && c.to === 'Review');
+		// Coding → Review channel preserved
+		const codeToReview = reimported.channels!.find((c) => c.from === 'Coding' && c.to === 'Review');
 		expect(codeToReview).toBeDefined();
 
-		// Review → Code channel preserved with maxCycles
-		const reviewToCode = reimported.channels!.find((c) => c.from === 'Review' && c.to === 'Code');
+		// Review → Coding channel preserved with maxCycles
+		const reviewToCode = reimported.channels!.find((c) => c.from === 'Review' && c.to === 'Coding');
 		expect(reviewToCode).toBeDefined();
 		expect(reviewToCode!.maxCycles).toBe(5);
 	});
@@ -1738,8 +1738,8 @@ describe('all built-in workflows have non-empty agent slot prompts', () => {
 });
 
 describe('CODING_WORKFLOW agent slot customPrompt', () => {
-	test('Code node coder has non-empty customPrompt', () => {
-		const codeNode = CODING_WORKFLOW.nodes.find((n) => n.name === 'Code')!;
+	test('Coding node coder has non-empty customPrompt', () => {
+		const codeNode = CODING_WORKFLOW.nodes.find((n) => n.name === 'Coding')!;
 		const coder = codeNode.agents[0];
 		expect(coder.customPrompt?.value).toBeDefined();
 		expect(coder.customPrompt?.value.trim().length).toBeGreaterThan(0);
@@ -1749,7 +1749,7 @@ describe('CODING_WORKFLOW agent slot customPrompt', () => {
 		const reviewNode = CODING_WORKFLOW.nodes.find((n) => n.name === 'Review')!;
 		const reviewer = reviewNode.agents[0];
 		expect(reviewer.customPrompt?.value).toBeDefined();
-		expect(reviewer.customPrompt?.value).toContain('report_done');
+		expect(reviewer.customPrompt?.value).toContain('report_result');
 	});
 });
 
@@ -1765,7 +1765,7 @@ describe('RESEARCH_WORKFLOW agent slot customPrompt', () => {
 		const reviewNode = RESEARCH_WORKFLOW.nodes.find((n) => n.name === 'Review')!;
 		const agent = reviewNode.agents[0];
 		expect(agent.customPrompt?.value).toBeDefined();
-		expect(agent.customPrompt?.value).toContain('report_done');
+		expect(agent.customPrompt?.value).toContain('report_result');
 	});
 });
 
@@ -1774,7 +1774,7 @@ describe('REVIEW_ONLY_WORKFLOW agent slot customPrompt', () => {
 		const reviewNode = REVIEW_ONLY_WORKFLOW.nodes[0];
 		const agent = reviewNode.agents[0];
 		expect(agent.customPrompt?.value).toBeDefined();
-		expect(agent.customPrompt?.value).toContain('report_done');
+		expect(agent.customPrompt?.value).toContain('report_result');
 	});
 
 	test('Review node has agent slot customPrompt (no separate node-level instructions)', () => {
@@ -1819,6 +1819,6 @@ describe('FULL_CYCLE_CODING_WORKFLOW agent slot customPrompt', () => {
 		const node = FULL_CYCLE_CODING_WORKFLOW.nodes.find((n) => n.name === 'QA')!;
 		const agent = node.agents[0];
 		expect(agent.customPrompt?.value).toBeDefined();
-		expect(agent.customPrompt?.value).toContain('report_done');
+		expect(agent.customPrompt?.value).toContain('report_result');
 	});
 });

--- a/packages/daemon/tests/unit/5-space/workflow/completion-detector.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/completion-detector.test.ts
@@ -1,38 +1,12 @@
 /**
  * Unit tests for CompletionDetector
  *
- * Scenarios (32 total):
- *   1.  No executions exist — returns false (workflow not started)
- *   2.  Single execution in_progress — returns false
- *   3.  Single execution idle — returns true
- *   4.  Single execution blocked — returns false (non-terminal)
- *   5.  Single execution cancelled — returns true (terminal)
- *   6.  Single execution pending — returns false (non-terminal)
- *   7.  Multi-node workflow — all agents terminal → true
- *   8.  Multi-node workflow — one agent non-terminal → false
- *   9.  Mixed terminal: idle + cancelled → true
- *  10.  One non-terminal execution blocks completion regardless of terminal count
- *  11.  idle + in_progress → false
- *  12.  Many idle + one blocked → false
- *  13.  All executions in_progress → false
- *  14.  All executions blocked → false
- *  15.  pending + in_progress → false
- *  16. Tasks from different workflow runs do not interfere
- *  17.  Empty run vs run with executions — no cross-contamination
- *  18.  idle + blocked → false
- *  19.  Multiple terminal (idle + cancelled) in one run → true
- *  20.  TERMINAL_NODE_EXECUTION_STATUSES — size=2 (idle, cancelled)
- *  21.  TERMINAL_NODE_EXECUTION_STATUSES — does not contain non-terminal statuses
- *  22.  End-node short-circuit: end node idle → true (other nodes still running)
- *  23.  End-node short-circuit: end node cancelled → true (other nodes still running)
- *  24.  End-node short-circuit: end node in_progress → false
- *  25.  End-node short-circuit: end node blocked → false
- *  26.  End-node short-circuit: no execution for end node → falls through to all-agents-done
- *  27.  End-node short-circuit: endNodeId not provided → all-agents-done fallback
- *  28.  All-agents-done fallback: all terminal with no endNodeId → true
- *  29.  All-agents-done fallback: some non-terminal with no endNodeId → false
- *  30.  No executions with endNodeId → false
- *  31.  End-node short-circuit: end node pending → false
+ * The detector inspects the canonical `SpaceTask` linked to a workflow run.
+ * Node-execution statuses (idle/cancelled/etc.) are NOT completion signals —
+ * they are per-execution lifecycle. Workflow completion is signalled by:
+ *   1. `task.status` being terminal (`done` | `cancelled`), OR
+ *   2. `task.reportedStatus` being non-null (agent called `report_result` —
+ *      runtime will resolve final status on next tick via completion-actions).
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
@@ -40,9 +14,8 @@ import { rmSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
-import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
+import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
 import { CompletionDetector } from '../../../../src/lib/space/runtime/completion-detector.ts';
-import { TERMINAL_NODE_EXECUTION_STATUSES } from '../../../../src/lib/space/managers/node-execution-manager.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -58,55 +31,21 @@ function makeDb(): { db: BunDatabase; dir: string } {
 	mkdirSync(dir, { recursive: true });
 	const db = new BunDatabase(join(dir, 'test.db'));
 	runMigrations(db, () => {});
-	// Disable FK to allow synthetic run IDs without seeding full parent rows.
+	// Disable FK so we can insert tasks with synthetic workflow_run_id values
+	// without seeding a parent row.
 	db.exec('PRAGMA foreign_keys = OFF');
 	return { db, dir };
 }
 
-let execCounter = 0;
-function seedExecution(
-	db: BunDatabase,
-	overrides: {
-		id?: string;
-		workflowRunId?: string;
-		workflowNodeId?: string;
-		agentName?: string;
-		status?: string;
-	} = {}
-): string {
-	const id = overrides.id ?? `exec-${++execCounter}`;
-	const now = Date.now();
-	db.prepare(
-		`INSERT INTO node_executions
-	     (id, workflow_run_id, workflow_node_id, agent_name, agent_id,
-	      agent_session_id, status, result, created_at, started_at,
-	      completed_at, updated_at)
-	     VALUES (?, ?, ?, ?, NULL, NULL, ?, NULL, ?, NULL, NULL, ?)`
-	).run(
-		id,
-		overrides.workflowRunId ?? 'run-1',
-		overrides.workflowNodeId ?? 'node-1',
-		overrides.agentName ?? `agent-${execCounter}`,
-		overrides.status ?? 'in_progress',
-		now,
-		now
-	);
-	return id;
-}
-
-// ---------------------------------------------------------------------------
-// Test setup / teardown
-// ---------------------------------------------------------------------------
-
 let db: BunDatabase;
 let dir: string;
-let nodeExecutionRepo: NodeExecutionRepository;
+let taskRepo: SpaceTaskRepository;
 let detector: CompletionDetector;
 
 beforeEach(() => {
 	({ db, dir } = makeDb());
-	nodeExecutionRepo = new NodeExecutionRepository(db);
-	detector = new CompletionDetector(nodeExecutionRepo);
+	taskRepo = new SpaceTaskRepository(db);
+	detector = new CompletionDetector(taskRepo);
 });
 
 afterEach(() => {
@@ -120,250 +59,149 @@ afterEach(() => {
 
 describe('CompletionDetector', () => {
 	const RUN = 'run-1';
+	const SPACE = 'space-1';
 
-	// ---- Basic completion detection ----
-
-	test('1. no executions exist — returns false (workflow not started)', () => {
+	test('returns false when no task is linked to the run (workflow not started)', () => {
 		expect(detector.isComplete({ workflowRunId: RUN })).toBe(false);
 	});
 
-	test('2. single execution in_progress — returns false', () => {
-		seedExecution(db, { workflowRunId: RUN, status: 'in_progress' });
-		expect(detector.isComplete({ workflowRunId: RUN })).toBe(false);
+	describe('terminal task.status short-circuit', () => {
+		test('task.status === "done" → true', () => {
+			const task = taskRepo.createTask({
+				spaceId: SPACE,
+				title: 'task',
+				workflowRunId: RUN,
+			});
+			taskRepo.updateTask(task.id, { status: 'done' });
+			expect(detector.isComplete({ workflowRunId: RUN })).toBe(true);
+		});
+
+		test('task.status === "cancelled" → true', () => {
+			const task = taskRepo.createTask({
+				spaceId: SPACE,
+				title: 'task',
+				workflowRunId: RUN,
+			});
+			taskRepo.updateTask(task.id, { status: 'cancelled' });
+			expect(detector.isComplete({ workflowRunId: RUN })).toBe(true);
+		});
+
+		test('task.status === "in_progress" without reportedStatus → false', () => {
+			taskRepo.createTask({
+				spaceId: SPACE,
+				title: 'task',
+				status: 'in_progress',
+				workflowRunId: RUN,
+			});
+			expect(detector.isComplete({ workflowRunId: RUN })).toBe(false);
+		});
+
+		test('task.status === "blocked" alone → false (blocked is needs-attention, not complete)', () => {
+			const task = taskRepo.createTask({
+				spaceId: SPACE,
+				title: 'task',
+				workflowRunId: RUN,
+			});
+			taskRepo.updateTask(task.id, { status: 'blocked' });
+			expect(detector.isComplete({ workflowRunId: RUN })).toBe(false);
+		});
+
+		test('task.status === "review" alone → false (paused awaiting human approval)', () => {
+			taskRepo.createTask({
+				spaceId: SPACE,
+				title: 'task',
+				status: 'review',
+				workflowRunId: RUN,
+			});
+			expect(detector.isComplete({ workflowRunId: RUN })).toBe(false);
+		});
 	});
 
-	test('3. single execution idle — returns true', () => {
-		seedExecution(db, { workflowRunId: RUN, status: 'idle' });
-		expect(detector.isComplete({ workflowRunId: RUN })).toBe(true);
+	describe('reportedStatus signal', () => {
+		test('reportedStatus = "done" + task in_progress → true (runtime should resolve)', () => {
+			const task = taskRepo.createTask({
+				spaceId: SPACE,
+				title: 'task',
+				status: 'in_progress',
+				workflowRunId: RUN,
+			});
+			taskRepo.updateTask(task.id, { reportedStatus: 'done', reportedSummary: 'ok' });
+			expect(detector.isComplete({ workflowRunId: RUN })).toBe(true);
+		});
+
+		test('reportedStatus = "blocked" + task in_progress → true', () => {
+			const task = taskRepo.createTask({
+				spaceId: SPACE,
+				title: 'task',
+				status: 'in_progress',
+				workflowRunId: RUN,
+			});
+			taskRepo.updateTask(task.id, { reportedStatus: 'blocked', reportedSummary: 'stuck' });
+			expect(detector.isComplete({ workflowRunId: RUN })).toBe(true);
+		});
+
+		test('reportedStatus = "cancelled" + task in_progress → true', () => {
+			const task = taskRepo.createTask({
+				spaceId: SPACE,
+				title: 'task',
+				status: 'in_progress',
+				workflowRunId: RUN,
+			});
+			taskRepo.updateTask(task.id, { reportedStatus: 'cancelled', reportedSummary: 'cancelled' });
+			expect(detector.isComplete({ workflowRunId: RUN })).toBe(true);
+		});
+
+		test('reportedStatus = null + task in_progress → false', () => {
+			taskRepo.createTask({
+				spaceId: SPACE,
+				title: 'task',
+				status: 'in_progress',
+				workflowRunId: RUN,
+			});
+			expect(detector.isComplete({ workflowRunId: RUN })).toBe(false);
+		});
 	});
-
-	test('4. single execution blocked — returns false (non-terminal)', () => {
-		seedExecution(db, { workflowRunId: RUN, status: 'blocked' });
-		expect(detector.isComplete({ workflowRunId: RUN })).toBe(false);
-	});
-
-	test('5. single execution cancelled — returns true (terminal)', () => {
-		seedExecution(db, { workflowRunId: RUN, status: 'cancelled' });
-		expect(detector.isComplete({ workflowRunId: RUN })).toBe(true);
-	});
-
-	test('6. single execution pending — returns false (non-terminal)', () => {
-		seedExecution(db, { workflowRunId: RUN, status: 'pending' });
-		expect(detector.isComplete({ workflowRunId: RUN })).toBe(false);
-	});
-
-	// ---- Multi-node workflows ----
-
-	test('7. multi-node workflow — all agents terminal → true', () => {
-		seedExecution(db, { workflowRunId: RUN, workflowNodeId: 'node-a', status: 'idle' });
-		seedExecution(db, { workflowRunId: RUN, workflowNodeId: 'node-b', status: 'cancelled' });
-		expect(detector.isComplete({ workflowRunId: RUN })).toBe(true);
-	});
-
-	test('8. multi-node workflow — one agent non-terminal → false', () => {
-		seedExecution(db, { workflowRunId: RUN, workflowNodeId: 'node-a', status: 'idle' });
-		seedExecution(db, { workflowRunId: RUN, workflowNodeId: 'node-b', status: 'in_progress' });
-		expect(detector.isComplete({ workflowRunId: RUN })).toBe(false);
-	});
-
-	// ---- Mixed terminal statuses ----
-
-	test('9. mixed idle + cancelled → true', () => {
-		seedExecution(db, { workflowRunId: RUN, status: 'idle' });
-		seedExecution(db, { workflowRunId: RUN, status: 'cancelled' });
-		expect(detector.isComplete({ workflowRunId: RUN })).toBe(true);
-	});
-
-	test('10. one non-terminal execution blocks completion regardless of terminal count', () => {
-		for (let i = 0; i < 5; i++) {
-			seedExecution(db, { workflowRunId: RUN, status: 'idle' });
-		}
-		seedExecution(db, { workflowRunId: RUN, status: 'blocked' });
-		expect(detector.isComplete({ workflowRunId: RUN })).toBe(false);
-	});
-
-	test('11. idle + in_progress → false', () => {
-		seedExecution(db, { workflowRunId: RUN, status: 'idle' });
-		seedExecution(db, { workflowRunId: RUN, status: 'in_progress' });
-		expect(detector.isComplete({ workflowRunId: RUN })).toBe(false);
-	});
-
-	test('12. many idle + one blocked → false', () => {
-		seedExecution(db, { workflowRunId: RUN, status: 'idle' });
-		seedExecution(db, { workflowRunId: RUN, status: 'idle' });
-		seedExecution(db, { workflowRunId: RUN, status: 'blocked' });
-		expect(detector.isComplete({ workflowRunId: RUN })).toBe(false);
-	});
-
-	test('13. all executions in_progress → false', () => {
-		seedExecution(db, { workflowRunId: RUN, status: 'in_progress' });
-		seedExecution(db, { workflowRunId: RUN, status: 'in_progress' });
-		expect(detector.isComplete({ workflowRunId: RUN })).toBe(false);
-	});
-
-	test('14. all executions blocked → false', () => {
-		seedExecution(db, { workflowRunId: RUN, status: 'blocked' });
-		seedExecution(db, { workflowRunId: RUN, status: 'blocked' });
-		expect(detector.isComplete({ workflowRunId: RUN })).toBe(false);
-	});
-
-	test('15. pending + in_progress → false', () => {
-		seedExecution(db, { workflowRunId: RUN, status: 'pending' });
-		seedExecution(db, { workflowRunId: RUN, status: 'in_progress' });
-		expect(detector.isComplete({ workflowRunId: RUN })).toBe(false);
-	});
-
-	test('18. idle + blocked → false', () => {
-		seedExecution(db, { workflowRunId: RUN, status: 'idle' });
-		seedExecution(db, { workflowRunId: RUN, status: 'blocked' });
-		expect(detector.isComplete({ workflowRunId: RUN })).toBe(false);
-	});
-
-	test('19. multiple terminal (idle + cancelled) in one run → true', () => {
-		seedExecution(db, { workflowRunId: RUN, status: 'idle' });
-		seedExecution(db, { workflowRunId: RUN, status: 'cancelled' });
-		seedExecution(db, { workflowRunId: RUN, status: 'idle' });
-		expect(detector.isComplete({ workflowRunId: RUN })).toBe(true);
-	});
-
-	// ---- Cross-contamination ----
 
 	describe('multiple workflow runs', () => {
-		test('16. tasks from different runs do not interfere — each run evaluated independently', () => {
+		test('runs are evaluated independently', () => {
 			const RUN_A = 'run-a';
 			const RUN_B = 'run-b';
 
-			// Run A: all terminal
-			seedExecution(db, { workflowRunId: RUN_A, status: 'idle' });
-			seedExecution(db, { workflowRunId: RUN_A, status: 'cancelled' });
+			const taskA = taskRepo.createTask({
+				spaceId: SPACE,
+				title: 'a',
+				workflowRunId: RUN_A,
+			});
+			taskRepo.updateTask(taskA.id, { status: 'done' });
 
-			// Run B: one non-terminal
-			seedExecution(db, { workflowRunId: RUN_B, status: 'idle' });
-			seedExecution(db, { workflowRunId: RUN_B, status: 'in_progress' });
+			taskRepo.createTask({
+				spaceId: SPACE,
+				title: 'b',
+				status: 'in_progress',
+				workflowRunId: RUN_B,
+			});
 
 			expect(detector.isComplete({ workflowRunId: RUN_A })).toBe(true);
 			expect(detector.isComplete({ workflowRunId: RUN_B })).toBe(false);
 		});
 
-		test('17. one run has no executions while the other has — no cross-contamination', () => {
-			const RUN_A = 'run-empty';
-			const RUN_B = 'run-with-tasks';
-
-			seedExecution(db, { workflowRunId: RUN_B, status: 'idle' });
-
-			expect(detector.isComplete({ workflowRunId: RUN_A })).toBe(false);
-			expect(detector.isComplete({ workflowRunId: RUN_B })).toBe(true);
-		});
-	});
-
-	// ---- TERMINAL_NODE_EXECUTION_STATUSES ----
-
-	describe('TERMINAL_NODE_EXECUTION_STATUSES', () => {
-		test('20. contains exactly two statuses: idle and cancelled', () => {
-			expect(TERMINAL_NODE_EXECUTION_STATUSES.has('idle')).toBe(true);
-			expect(TERMINAL_NODE_EXECUTION_STATUSES.has('cancelled')).toBe(true);
-			expect(TERMINAL_NODE_EXECUTION_STATUSES.size).toBe(2);
-		});
-
-		test('21. does not contain non-terminal statuses', () => {
-			expect(TERMINAL_NODE_EXECUTION_STATUSES.has('pending')).toBe(false);
-			expect(TERMINAL_NODE_EXECUTION_STATUSES.has('in_progress')).toBe(false);
-			expect(TERMINAL_NODE_EXECUTION_STATUSES.has('blocked')).toBe(false);
-		});
-
-		// ---- End-node short-circuit ----
-
-		describe('end-node short-circuit', () => {
-			const END_NODE_ID = 'end-node';
-
-			test('22. end node idle → true (other nodes still running)', () => {
-				seedExecution(db, {
-					workflowRunId: RUN,
-					workflowNodeId: 'start-node',
-					status: 'in_progress',
-				});
-				seedExecution(db, {
-					workflowRunId: RUN,
-					workflowNodeId: END_NODE_ID,
-					status: 'idle',
-				});
-				expect(detector.isComplete({ workflowRunId: RUN, endNodeId: END_NODE_ID })).toBe(true);
+		test('multi-task run: any single terminal/reported task signals completion', () => {
+			const taskA = taskRepo.createTask({
+				spaceId: SPACE,
+				title: 'a',
+				status: 'in_progress',
+				workflowRunId: RUN,
 			});
-
-			test('23. end node cancelled → true (other nodes still running)', () => {
-				seedExecution(db, {
-					workflowRunId: RUN,
-					workflowNodeId: 'start-node',
-					status: 'in_progress',
-				});
-				seedExecution(db, {
-					workflowRunId: RUN,
-					workflowNodeId: END_NODE_ID,
-					status: 'cancelled',
-				});
-				expect(detector.isComplete({ workflowRunId: RUN, endNodeId: END_NODE_ID })).toBe(true);
+			taskRepo.createTask({
+				spaceId: SPACE,
+				title: 'b',
+				status: 'in_progress',
+				workflowRunId: RUN,
 			});
+			expect(detector.isComplete({ workflowRunId: RUN })).toBe(false);
 
-			test('24. end node in_progress → false', () => {
-				seedExecution(db, { workflowRunId: RUN, workflowNodeId: 'start-node', status: 'idle' });
-				seedExecution(db, {
-					workflowRunId: RUN,
-					workflowNodeId: END_NODE_ID,
-					status: 'in_progress',
-				});
-				expect(detector.isComplete({ workflowRunId: RUN, endNodeId: END_NODE_ID })).toBe(false);
-			});
-
-			test('25. end node blocked → false', () => {
-				seedExecution(db, { workflowRunId: RUN, workflowNodeId: 'start-node', status: 'idle' });
-				seedExecution(db, {
-					workflowRunId: RUN,
-					workflowNodeId: END_NODE_ID,
-					status: 'blocked',
-				});
-				expect(detector.isComplete({ workflowRunId: RUN, endNodeId: END_NODE_ID })).toBe(false);
-			});
-
-			test('26. no execution for end node → not complete', () => {
-				// Only a start-node execution exists; end node has none.
-				seedExecution(db, { workflowRunId: RUN, workflowNodeId: 'start-node', status: 'idle' });
-				expect(detector.isComplete({ workflowRunId: RUN, endNodeId: END_NODE_ID })).toBe(false);
-			});
-
-			test('27. endNodeId not provided → all-agents-done fallback', () => {
-				seedExecution(db, { workflowRunId: RUN, workflowNodeId: END_NODE_ID, status: 'idle' });
-				expect(detector.isComplete({ workflowRunId: RUN })).toBe(true);
-			});
-
-			test('28. no executions with endNodeId → false', () => {
-				expect(detector.isComplete({ workflowRunId: RUN, endNodeId: END_NODE_ID })).toBe(false);
-			});
-
-			test('29. end node pending → false', () => {
-				seedExecution(db, { workflowRunId: RUN, workflowNodeId: 'start-node', status: 'idle' });
-				seedExecution(db, {
-					workflowRunId: RUN,
-					workflowNodeId: END_NODE_ID,
-					status: 'pending',
-				});
-				expect(detector.isComplete({ workflowRunId: RUN, endNodeId: END_NODE_ID })).toBe(false);
-			});
-		});
-
-		// ---- All-agents-done fallback (no endNodeId) ----
-
-		describe('all-agents-done fallback', () => {
-			test('30. all terminal with no endNodeId → true', () => {
-				seedExecution(db, { workflowRunId: RUN, workflowNodeId: 'node-a', status: 'idle' });
-				seedExecution(db, { workflowRunId: RUN, workflowNodeId: 'node-b', status: 'cancelled' });
-				expect(detector.isComplete({ workflowRunId: RUN })).toBe(true);
-			});
-
-			test('31. some non-terminal with no endNodeId → false', () => {
-				seedExecution(db, { workflowRunId: RUN, workflowNodeId: 'node-a', status: 'idle' });
-				seedExecution(db, { workflowRunId: RUN, workflowNodeId: 'node-b', status: 'blocked' });
-				expect(detector.isComplete({ workflowRunId: RUN })).toBe(false);
-			});
+			taskRepo.updateTask(taskA.id, { reportedStatus: 'done', reportedSummary: 'ok' });
+			expect(detector.isComplete({ workflowRunId: RUN })).toBe(true);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/5-space/workflow/workflow-executor-multi-agent.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/workflow-executor-multi-agent.test.ts
@@ -80,6 +80,29 @@ function makeSpaceAgent(id: string, name: string): SpaceAgent {
 	};
 }
 
+/**
+ * End nodes must have exactly 1 agent (validator-enforced — they own
+ * `report_result`). When the last user-provided node is multi-agent, append a
+ * synthetic single-agent terminal end node so the multi-agent node remains the
+ * start (or middle) and validation passes.
+ */
+const SYNTHETIC_END_NODE_ID = '__test_end__';
+
+function appendSyntheticEnd<T extends { id: string; agents?: unknown[] }>(
+	nodes: T[],
+	endAgentId: string
+): { nodes: Array<T | { id: string; name: string; agentId: string }>; endNodeId: string } {
+	const last = nodes[nodes.length - 1];
+	const lastIsMultiAgent = (last.agents?.length ?? 0) > 1;
+	if (!lastIsMultiAgent) {
+		return { nodes, endNodeId: last.id };
+	}
+	return {
+		nodes: [...nodes, { id: SYNTHETIC_END_NODE_ID, name: 'Synthetic End', agentId: endAgentId }],
+		endNodeId: SYNTHETIC_END_NODE_ID,
+	};
+}
+
 // ===========================================================================
 // SpaceRuntime — startWorkflowRun() with multi-agent start step
 // ===========================================================================
@@ -149,21 +172,22 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 	// -------------------------------------------------------------------------
 
 	test('creates one workflow task and one node_execution per start agent', async () => {
+		const startNode = {
+			id: STEP_A,
+			name: 'Parallel Start',
+			agents: [
+				{ agentId: AGENT_CODER, name: 'coder', instructions: 'Write code' },
+				{ agentId: AGENT_PLANNER, name: 'planner', instructions: 'Plan it' },
+			],
+		};
+		const { nodes, endNodeId } = appendSyntheticEnd([startNode], AGENT_CODER);
 		const workflow = workflowManager.createWorkflow({
 			spaceId: SPACE_ID,
 			name: `Multi Start ${Date.now()}`,
-			nodes: [
-				{
-					id: STEP_A,
-					name: 'Parallel Start',
-					agents: [
-						{ agentId: AGENT_CODER, name: 'coder', instructions: 'Write code' },
-						{ agentId: AGENT_PLANNER, name: 'planner', instructions: 'Plan it' },
-					],
-				},
-			],
+			nodes,
 			transitions: [],
 			startNodeId: STEP_A,
+			endNodeId,
 			rules: [],
 			tags: [],
 		});
@@ -182,29 +206,30 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 	});
 
 	test('per-agent instructions are tracked in node executions (not split into multiple tasks)', async () => {
+		const startNode = {
+			id: STEP_A,
+			name: 'Parallel Start',
+			agents: [
+				{
+					agentId: AGENT_CODER,
+					name: 'coder',
+					instructions: { value: 'Coder task', mode: 'override' as const },
+				},
+				{
+					agentId: AGENT_PLANNER,
+					name: 'planner',
+					instructions: { value: 'Planner task', mode: 'override' as const },
+				},
+			],
+		};
+		const { nodes, endNodeId } = appendSyntheticEnd([startNode], AGENT_CODER);
 		const workflow = workflowManager.createWorkflow({
 			spaceId: SPACE_ID,
 			name: `Multi Start Instructions ${Date.now()}`,
-			nodes: [
-				{
-					id: STEP_A,
-					name: 'Parallel Start',
-					agents: [
-						{
-							agentId: AGENT_CODER,
-							name: 'coder',
-							instructions: { value: 'Coder task', mode: 'override' },
-						},
-						{
-							agentId: AGENT_PLANNER,
-							name: 'planner',
-							instructions: { value: 'Planner task', mode: 'override' },
-						},
-					],
-				},
-			],
+			nodes,
 			transitions: [],
 			startNodeId: STEP_A,
+			endNodeId,
 			rules: [],
 			tags: [],
 		});
@@ -218,21 +243,22 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 	});
 
 	test('multi-agent start step still yields a single workflow task', async () => {
+		const startNode = {
+			id: STEP_A,
+			name: 'Mixed Start',
+			agents: [
+				{ agentId: AGENT_PLANNER, name: 'planner' },
+				{ agentId: AGENT_CODER, name: 'coder' },
+			],
+		};
+		const { nodes, endNodeId } = appendSyntheticEnd([startNode], AGENT_CODER);
 		const workflow = workflowManager.createWorkflow({
 			spaceId: SPACE_ID,
 			name: `Multi Start TaskType ${Date.now()}`,
-			nodes: [
-				{
-					id: STEP_A,
-					name: 'Mixed Start',
-					agents: [
-						{ agentId: AGENT_PLANNER, name: 'planner' },
-						{ agentId: AGENT_CODER, name: 'coder' },
-					],
-				},
-			],
+			nodes,
 			transitions: [],
 			startNodeId: STEP_A,
+			endNodeId,
 			rules: [],
 			tags: [],
 		});
@@ -245,21 +271,22 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 	});
 
 	test('custom-role agent in multi-agent start step still uses one workflow task', async () => {
+		const startNode = {
+			id: STEP_A,
+			name: 'Custom Start',
+			agents: [
+				{ agentId: AGENT_CODER, name: 'coder' },
+				{ agentId: AGENT_CUSTOM, name: 'my-custom-role' },
+			],
+		};
+		const { nodes, endNodeId } = appendSyntheticEnd([startNode], AGENT_CODER);
 		const workflow = workflowManager.createWorkflow({
 			spaceId: SPACE_ID,
 			name: `Custom Role Start ${Date.now()}`,
-			nodes: [
-				{
-					id: STEP_A,
-					name: 'Custom Start',
-					agents: [
-						{ agentId: AGENT_CODER, name: 'coder' },
-						{ agentId: AGENT_CUSTOM, name: 'my-custom-role' },
-					],
-				},
-			],
+			nodes,
 			transitions: [],
 			startNodeId: STEP_A,
+			endNodeId,
 			rules: [],
 			tags: [],
 		});
@@ -318,21 +345,22 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 	// -------------------------------------------------------------------------
 
 	test('marks run blocked when any parallel node execution blocks', async () => {
+		const startNode = {
+			id: STEP_A,
+			name: 'Parallel Waiting',
+			agents: [
+				{ agentId: AGENT_CODER, name: 'coder' },
+				{ agentId: AGENT_PLANNER, name: 'planner' },
+			],
+		};
+		const { nodes, endNodeId } = appendSyntheticEnd([startNode], AGENT_CODER);
 		const workflow = workflowManager.createWorkflow({
 			spaceId: SPACE_ID,
 			name: `Partial Terminal ${Date.now()}`,
-			nodes: [
-				{
-					id: STEP_A,
-					name: 'Parallel Waiting',
-					agents: [
-						{ agentId: AGENT_CODER, name: 'coder' },
-						{ agentId: AGENT_PLANNER, name: 'planner' },
-					],
-				},
-			],
+			nodes,
 			transitions: [],
 			startNodeId: STEP_A,
+			endNodeId,
 			rules: [],
 			tags: [],
 		});
@@ -358,21 +386,22 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 	// -------------------------------------------------------------------------
 
 	test('marks run needs_attention when all parallel tasks are terminal and one failed', async () => {
+		const startNode = {
+			id: STEP_A,
+			name: 'Parallel Fail',
+			agents: [
+				{ agentId: AGENT_CODER, name: 'coder' },
+				{ agentId: AGENT_PLANNER, name: 'planner' },
+			],
+		};
+		const { nodes, endNodeId } = appendSyntheticEnd([startNode], AGENT_CODER);
 		const workflow = workflowManager.createWorkflow({
 			spaceId: SPACE_ID,
 			name: `All Terminal Fail ${Date.now()}`,
-			nodes: [
-				{
-					id: STEP_A,
-					name: 'Parallel Fail',
-					agents: [
-						{ agentId: AGENT_CODER, name: 'coder' },
-						{ agentId: AGENT_PLANNER, name: 'planner' },
-					],
-				},
-			],
+			nodes,
 			transitions: [],
 			startNodeId: STEP_A,
+			endNodeId,
 			rules: [],
 			tags: [],
 		});
@@ -397,22 +426,23 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 		const AGENT_EXTRA = 'agent-rt-extra';
 		seedAgent(db, AGENT_EXTRA, SPACE_ID, 'Extra');
 
+		const startNode = {
+			id: STEP_A,
+			name: 'Triple Parallel',
+			agents: [
+				{ agentId: AGENT_CODER, name: 'coder' },
+				{ agentId: AGENT_PLANNER, name: 'planner' },
+				{ agentId: AGENT_EXTRA, name: 'extra-role' },
+			],
+		};
+		const { nodes, endNodeId } = appendSyntheticEnd([startNode], AGENT_CODER);
 		const workflow = workflowManager.createWorkflow({
 			spaceId: SPACE_ID,
 			name: `Three Agent Partial Fail ${Date.now()}`,
-			nodes: [
-				{
-					id: STEP_A,
-					name: 'Triple Parallel',
-					agents: [
-						{ agentId: AGENT_CODER, name: 'coder' },
-						{ agentId: AGENT_PLANNER, name: 'planner' },
-						{ agentId: AGENT_EXTRA, name: 'extra-role' },
-					],
-				},
-			],
+			nodes,
 			transitions: [],
 			startNodeId: STEP_A,
+			endNodeId,
 			rules: [],
 			tags: [],
 		});
@@ -589,21 +619,22 @@ describe('Mixed workflows — single-agent, multi-agent, and channels', () => {
 
 	test('channels for start step are stored in run config after startWorkflowRun()', async () => {
 		// Channels are now at workflow level, not node level
+		const startNode = {
+			id: STEP_A,
+			name: 'Parallel With Channels',
+			agents: [
+				{ agentId: AGENT_CODER, name: 'coder' },
+				{ agentId: AGENT_REVIEWER, name: 'reviewer' },
+			],
+		};
+		const { nodes, endNodeId } = appendSyntheticEnd([startNode], AGENT_CODER);
 		const workflow = workflowManager.createWorkflow({
 			spaceId: SPACE_ID,
 			name: `Channel Start Step ${Date.now()}`,
-			nodes: [
-				{
-					id: STEP_A,
-					name: 'Parallel With Channels',
-					agents: [
-						{ agentId: AGENT_CODER, name: 'coder' },
-						{ agentId: AGENT_REVIEWER, name: 'reviewer' },
-					],
-				},
-			],
+			nodes,
 			transitions: [],
 			startNodeId: STEP_A,
+			endNodeId,
 			rules: [],
 			tags: [],
 		});

--- a/packages/daemon/tests/unit/5-space/workflow/workflow-executor-progression.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/workflow-executor-progression.test.ts
@@ -40,13 +40,11 @@ import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
 import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository.ts';
-import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
 import { WorkflowExecutor } from '../../../../src/lib/space/runtime/workflow-executor.ts';
 import type {
 	CommandRunner,
 	ConditionContext,
 } from '../../../../src/lib/space/runtime/workflow-executor.ts';
-import { CompletionDetector } from '../../../../src/lib/space/runtime/completion-detector.ts';
 import {
 	isChannelOpen,
 	evaluateGate,
@@ -114,7 +112,6 @@ let db: BunDatabase;
 let dir: string;
 let workflowRepo: SpaceWorkflowRepository;
 let runRepo: SpaceWorkflowRunRepository;
-let nodeExecRepo: NodeExecutionRepository;
 
 const SPACE_ID = 'space-1';
 const WORKSPACE = '/tmp/ws-1';
@@ -127,7 +124,6 @@ beforeEach(() => {
 	seedAgent(db, 'agent-c', SPACE_ID, 'Agent C');
 	workflowRepo = new SpaceWorkflowRepository(db);
 	runRepo = new SpaceWorkflowRunRepository(db);
-	nodeExecRepo = new NodeExecutionRepository(db);
 });
 
 afterEach(() => {
@@ -160,24 +156,6 @@ function makeLinearWorkflow(steps: Array<{ id: string; agentId: string }>): {
 	});
 	const run = runRepo.createRun({ spaceId: SPACE_ID, workflowId: workflow.id, title: 'Test' });
 	return { workflow, run };
-}
-
-function seedNodeExecution(
-	workflowRunId: string,
-	nodeId: string,
-	agentName: string,
-	status: string
-): string {
-	const id = `exec-${nodeId}-${agentName}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-	const now = Date.now();
-	db.prepare(
-		`INSERT INTO node_executions
-     (id, workflow_run_id, workflow_node_id, agent_name, agent_id,
-      agent_session_id, status, result, created_at, started_at,
-      completed_at, updated_at)
-     VALUES (?, ?, ?, ?, NULL, NULL, ?, NULL, ?, NULL, NULL, ?)`
-	).run(id, workflowRunId, nodeId, agentName, status, now, now);
-	return id;
 }
 
 // ===========================================================================
@@ -416,116 +394,13 @@ describe('Linear node progression — condition evaluation sequence', () => {
 });
 
 // ===========================================================================
-// C) Parallel branch execution (CompletionDetector)
+// C) Parallel branch execution — see completion-detector.test.ts
 // ===========================================================================
-
-describe('Parallel branch execution — CompletionDetector', () => {
-	let detector: CompletionDetector;
-
-	beforeEach(() => {
-		detector = new CompletionDetector(nodeExecRepo);
-	});
-
-	/**
-	 * Creates a minimal workflow with a single parallel node and returns a run ID.
-	 * The run ID is used to seed node_executions while satisfying FK constraints.
-	 */
-	function makeParallelRun(): string {
-		const { run } = makeLinearWorkflow([{ id: 'node-parallel', agentId: 'agent-a' }]);
-		return run.id;
-	}
-
-	/**
-	 * Creates a linear 2-node workflow (node-a → node-b) and returns a run ID.
-	 */
-	function makeLinearRun(): string {
-		const { run } = makeLinearWorkflow([
-			{ id: 'node-a', agentId: 'agent-a' },
-			{ id: 'node-b', agentId: 'agent-b' },
-		]);
-		return run.id;
-	}
-
-	test('2-agent parallel node: both done → workflow complete', () => {
-		const runId = makeParallelRun();
-		seedNodeExecution(runId, 'node-parallel', 'agent-coder', 'idle');
-		seedNodeExecution(runId, 'node-parallel', 'agent-reviewer', 'idle');
-		expect(detector.isComplete({ workflowRunId: runId })).toBe(true);
-	});
-
-	test('2-agent parallel node: one still in_progress → not complete', () => {
-		const runId = makeParallelRun();
-		seedNodeExecution(runId, 'node-parallel', 'agent-coder', 'idle');
-		seedNodeExecution(runId, 'node-parallel', 'agent-reviewer', 'in_progress');
-		expect(detector.isComplete({ workflowRunId: runId })).toBe(false);
-	});
-
-	test('2-agent parallel node: both in_progress → not complete', () => {
-		const runId = makeParallelRun();
-		seedNodeExecution(runId, 'node-parallel', 'agent-coder', 'in_progress');
-		seedNodeExecution(runId, 'node-parallel', 'agent-reviewer', 'in_progress');
-		expect(detector.isComplete({ workflowRunId: runId })).toBe(false);
-	});
-
-	test('3-agent parallel node: all done → complete', () => {
-		const runId = makeParallelRun();
-		seedNodeExecution(runId, 'node-parallel', 'agent-a', 'idle');
-		seedNodeExecution(runId, 'node-parallel', 'agent-b', 'idle');
-		seedNodeExecution(runId, 'node-parallel', 'agent-c', 'idle');
-		expect(detector.isComplete({ workflowRunId: runId })).toBe(true);
-	});
-
-	test('3-agent parallel node: 2 done, 1 in_progress → not complete', () => {
-		const runId = makeParallelRun();
-		seedNodeExecution(runId, 'node-parallel', 'agent-a', 'idle');
-		seedNodeExecution(runId, 'node-parallel', 'agent-b', 'idle');
-		seedNodeExecution(runId, 'node-parallel', 'agent-c', 'in_progress');
-		expect(detector.isComplete({ workflowRunId: runId })).toBe(false);
-	});
-
-	test('3-agent parallel node: 2 done, 1 blocked → not complete', () => {
-		const runId = makeParallelRun();
-		seedNodeExecution(runId, 'node-parallel', 'agent-a', 'idle');
-		seedNodeExecution(runId, 'node-parallel', 'agent-b', 'idle');
-		seedNodeExecution(runId, 'node-parallel', 'agent-c', 'blocked');
-		expect(detector.isComplete({ workflowRunId: runId })).toBe(false);
-	});
-
-	test('parallel node done + cancelled (mixed terminal) → complete', () => {
-		const runId = makeParallelRun();
-		seedNodeExecution(runId, 'node-parallel', 'agent-a', 'idle');
-		seedNodeExecution(runId, 'node-parallel', 'agent-b', 'cancelled');
-		expect(detector.isComplete({ workflowRunId: runId })).toBe(true);
-	});
-
-	test('linear A done + parallel (B1 done, B2 in_progress) → not complete', () => {
-		const runId = makeLinearRun();
-		// Node A completes (linear)
-		seedNodeExecution(runId, 'node-a', 'agent-a', 'idle');
-		// Node B forks into 2 parallel agents; B2 still running
-		seedNodeExecution(runId, 'node-b', 'agent-b-worker-1', 'idle');
-		seedNodeExecution(runId, 'node-b', 'agent-b-worker-2', 'in_progress');
-		expect(detector.isComplete({ workflowRunId: runId })).toBe(false);
-	});
-
-	test('linear A done + parallel (B1 done, B2 done) → complete', () => {
-		const runId = makeLinearRun();
-		seedNodeExecution(runId, 'node-a', 'agent-a', 'idle');
-		seedNodeExecution(runId, 'node-b', 'agent-b-worker-1', 'idle');
-		seedNodeExecution(runId, 'node-b', 'agent-b-worker-2', 'idle');
-		expect(detector.isComplete({ workflowRunId: runId })).toBe(true);
-	});
-
-	test('end-node short-circuit: parallel end node — first agent done triggers completion', () => {
-		const runId = makeLinearRun();
-		const endNodeId = 'node-b';
-		// Start node still running
-		seedNodeExecution(runId, 'node-a', 'agent-a', 'in_progress');
-		// End node agent completes
-		seedNodeExecution(runId, endNodeId, 'agent-b', 'idle');
-		expect(detector.isComplete({ workflowRunId: runId, endNodeId })).toBe(true);
-	});
-});
+// CompletionDetector now reads the canonical SpaceTask (status / reportedStatus)
+// rather than node_executions. Comprehensive coverage lives in
+// `tests/unit/5-space/workflow/completion-detector.test.ts`. The old
+// node-execution-based block has been removed because its assumptions no
+// longer match the runtime contract.
 
 // ===========================================================================
 // D) Gated channel evaluation

--- a/packages/e2e/tests/features/space-gate-custom-badges.e2e.ts
+++ b/packages/e2e/tests/features/space-gate-custom-badges.e2e.ts
@@ -202,8 +202,8 @@ test.describe('Gate Custom Badges', () => {
 		await expect(gateBadge).toBeVisible({ timeout: 5000 });
 		await expect(gateBadge).toContainText('Gate');
 
-		// ── Step 2: Add Human Approval preset → gate type becomes 'human' ───
-		await gatePanel.getByTestId('gate-editor-preset-human').click();
+		// ── Step 2: Add Approval preset → gate requires external approval ───
+		await gatePanel.getByTestId('gate-editor-preset-approval').click();
 
 		// Badge still shows "Gate" (no heuristic fallback - label is authoritative)
 		await expect(gateBadge).toContainText('Gate', { timeout: 5000 });

--- a/packages/shared/src/types/space-utils.ts
+++ b/packages/shared/src/types/space-utils.ts
@@ -226,10 +226,10 @@ export function validateChannels(workflow: SpaceWorkflow, agents: SpaceAgent[]):
  * gate field given the gate's `writers` list and the channel the gate belongs to.
  *
  * Authorization rules:
- * - `writers` absent or empty  → authorized iff `agentNodeName === channel.from`
- * - `writers` includes `'*'`   → always authorized
- * - `writers` is empty `[]`   → never authorized (external-only gate, written by human via RPC or auto-approval)
- * - `writers` includes node names → authorized iff `agentNodeName` is in the list
+ * - `writers` absent (null/undefined) → authorized iff `agentNodeName === channel.from`
+ * - `writers` is empty `[]`           → never authorized (external-only gate)
+ * - `writers` includes `'*'`          → always authorized
+ * - `writers` includes node names     → authorized iff `agentNodeName` is in the list
  *
  * @param agentNodeName - The name of the node this agent belongs to.
  * @param channel       - The channel the gate is attached to.

--- a/packages/shared/src/types/space-utils.ts
+++ b/packages/shared/src/types/space-utils.ts
@@ -228,7 +228,7 @@ export function validateChannels(workflow: SpaceWorkflow, agents: SpaceAgent[]):
  * Authorization rules:
  * - `writers` absent or empty  → authorized iff `agentNodeName === channel.from`
  * - `writers` includes `'*'`   → always authorized
- * - `writers` includes `'human'` only → never authorized (human-only gate)
+ * - `writers` is empty `[]`   → never authorized (external-only gate, written by human via RPC or auto-approval)
  * - `writers` includes node names → authorized iff `agentNodeName` is in the list
  *
  * @param agentNodeName - The name of the node this agent belongs to.
@@ -240,13 +240,11 @@ export function isGateWriterAuthorized(
 	channel: WorkflowChannel,
 	writers: string[]
 ): boolean {
-	if (!writers || writers.length === 0) {
+	if (!writers) {
 		// Inferred: FROM node agents can write
 		return agentNodeName === channel.from;
 	}
+	if (writers.length === 0) return false; // external-only gate
 	if (writers.includes('*')) return true;
-	// All remaining entries are treated as explicit node names
-	const nonHuman = writers.filter((w) => w !== 'human');
-	if (nonHuman.length === 0) return false; // human-only gate
-	return nonHuman.includes(agentNodeName);
+	return writers.includes(agentNodeName);
 }

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -648,7 +648,7 @@ export interface GateField {
 	name: string;
 	/** Field type. */
 	type: GateFieldType;
-	/** Who can write this field — agent names/slot names, node names, 'human', or '*'. */
+	/** Who can write this field — node names, '*' (any agent), or [] (external-only: human via RPC or auto-approval). */
 	writers: string[];
 	/** Check that must pass for this field to be satisfied. */
 	check: GateFieldCheck;

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -164,6 +164,15 @@ export type SpaceTaskStatus =
 	| 'archived';
 
 /**
+ * Outcome an end-node agent reports via `report_result`.
+ *
+ * This is the agent's claimed terminal state for the workflow — distinct from
+ * `SpaceTask.status`, which is the runtime's final decision after the report
+ * passes through completion-actions review (in supervised autonomy modes).
+ */
+export type SpaceReportedStatus = 'done' | 'blocked' | 'cancelled';
+
+/**
  * Why a task is blocked — set when status transitions to `blocked`,
  * cleared when the task leaves `blocked`.
  */
@@ -270,6 +279,18 @@ export interface SpaceTask {
 	 * - `gate`: paused at a gate requiring human approval
 	 */
 	pendingCheckpointType: 'completion_action' | 'gate' | null;
+	/**
+	 * Status the end-node agent reported via `report_result`. Null until the agent
+	 * reports. Recorded separately from `status` so the runtime can resolve the
+	 * final task status through completion-actions review (supervised modes) without
+	 * the agent bypassing the gate. Once recorded, this field is preserved for audit
+	 * even after `status` reaches a terminal value.
+	 */
+	reportedStatus: SpaceReportedStatus | null;
+	/**
+	 * Summary the end-node agent provided alongside `reportedStatus`. Null until reported.
+	 */
+	reportedSummary: string | null;
 	/** Last update timestamp (milliseconds since epoch) */
 	updatedAt: number;
 }
@@ -392,6 +413,10 @@ export interface UpdateSpaceTaskParams {
 	pendingActionIndex?: number | null;
 	/** Type of checkpoint the task is paused at; null to clear */
 	pendingCheckpointType?: 'completion_action' | 'gate' | null;
+	/** Agent-reported terminal status from `report_result`; null to clear */
+	reportedStatus?: SpaceReportedStatus | null;
+	/** Agent-reported summary from `report_result`; null to clear */
+	reportedSummary?: string | null;
 }
 
 // ============================================================================

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -335,7 +335,7 @@ export interface SpaceTaskActivityMember {
 		agentName: string;
 		/** Execution status */
 		status: NodeExecutionStatus;
-		/** Result output from `report_done`, if set */
+		/** Result output from `report_result`, if set */
 		result?: string | null;
 	} | null;
 	/** Last update timestamp from the linked SpaceTask or backing session metadata */
@@ -503,7 +503,7 @@ export interface UpdateNodeExecutionParams {
  *
  * - `pending`     — run created, awaiting Task Agent to start nodes
  * - `in_progress` — at least one node execution is active
- * - `done`        — end node called `report_done` or all nodes completed
+ * - `done`        — end node called `report_result` or all nodes completed
  * - `blocked`     — run requires human intervention (gate rejection, crash, etc.)
  * - `cancelled`   — run was cancelled before completion
  */
@@ -979,7 +979,7 @@ export interface SpaceWorkflow {
 	startNodeId: string;
 	/**
 	 * ID of the node where execution ends.
-	 * When the end node's execution calls `report_done`, the workflow run is
+	 * When the end node's execution calls `report_result`, the workflow run is
 	 * automatically marked `done`. If absent, completion relies on the
 	 * `CompletionDetector` all-agents-done check as a safety net.
 	 */
@@ -1026,7 +1026,7 @@ export interface CreateSpaceWorkflowParams {
 	startNodeId?: string;
 	/**
 	 * ID of the node where execution ends.
-	 * When the end node's execution calls `report_done`, the workflow run auto-completes.
+	 * When the end node's execution calls `report_result`, the workflow run auto-completes.
 	 */
 	endNodeId?: string;
 	/** Workflow-level messaging channels. */
@@ -1218,7 +1218,7 @@ export interface ExportedSpaceWorkflow {
 	startNode: string;
 	/**
 	 * Name of the node where execution ends (optional — mirrors `SpaceWorkflow.endNodeId`).
-	 * When present, the end node's `report_done` call auto-completes the workflow run.
+	 * When present, the end node's `report_result` call auto-completes the workflow run.
 	 */
 	endNode?: string;
 	/** Tags for categorization */

--- a/packages/shared/tests/space-utils.test.ts
+++ b/packages/shared/tests/space-utils.test.ts
@@ -258,11 +258,8 @@ describe('validateChannels', () => {
 describe('isGateWriterAuthorized', () => {
 	const channel = makeChannel({ from: 'Code', to: 'Review' });
 
-	test('empty writers → FROM node agent authorized', () => {
-		expect(isGateWriterAuthorized('Code', channel, [])).toBe(true);
-	});
-
-	test('empty writers → non-FROM node agent NOT authorized', () => {
+	test('empty writers → external-only gate, no agent authorized', () => {
+		expect(isGateWriterAuthorized('Code', channel, [])).toBe(false);
 		expect(isGateWriterAuthorized('Review', channel, [])).toBe(false);
 	});
 
@@ -272,19 +269,9 @@ describe('isGateWriterAuthorized', () => {
 		expect(isGateWriterAuthorized('SomeOtherNode', channel, ['*'])).toBe(true);
 	});
 
-	test("writers: ['human'] → never authorized (human-only gate)", () => {
-		expect(isGateWriterAuthorized('Code', channel, ['human'])).toBe(false);
-		expect(isGateWriterAuthorized('Review', channel, ['human'])).toBe(false);
-	});
-
 	test('writers with explicit node name → that node authorized', () => {
 		expect(isGateWriterAuthorized('Code', channel, ['Code'])).toBe(true);
 		expect(isGateWriterAuthorized('Review', channel, ['Code'])).toBe(false);
-	});
-
-	test('writers with explicit node name + human → only explicit node authorized', () => {
-		expect(isGateWriterAuthorized('Code', channel, ['Code', 'human'])).toBe(true);
-		expect(isGateWriterAuthorized('Review', channel, ['Code', 'human'])).toBe(false);
 	});
 
 	test('writers with multiple node names → listed nodes authorized', () => {

--- a/packages/web/src/components/space/__tests__/ChannelEdgeConfigPanel.test.tsx
+++ b/packages/web/src/components/space/__tests__/ChannelEdgeConfigPanel.test.tsx
@@ -199,7 +199,12 @@ describe('ChannelEdgeConfigPanel — gate summary', () => {
 	it('renders field rows when gate has both fields and script', () => {
 		const gate = makeGate({
 			fields: [
-				{ name: 'approved', type: 'boolean', writers: ['human'], check: { op: '==', value: true } },
+				{
+					name: 'approved',
+					type: 'boolean',
+					writers: [],
+					check: { op: '==', value: true },
+				},
 				{ name: 'score', type: 'number', writers: ['*'], check: { op: 'exists' } },
 			],
 			script: { interpreter: 'bash', source: 'true' },

--- a/packages/web/src/components/space/__tests__/fixtures/builtInTemplateWorkflows.ts
+++ b/packages/web/src/components/space/__tests__/fixtures/builtInTemplateWorkflows.ts
@@ -200,7 +200,7 @@ export function makeBuiltInTemplateWorkflows(
 						{
 							name: 'approved',
 							type: 'boolean',
-							writers: ['reviewer'],
+							writers: [],
 							check: { op: '==', value: true },
 						},
 					],
@@ -294,7 +294,7 @@ export function makeBuiltInTemplateWorkflows(
 						{
 							name: 'approved',
 							type: 'boolean',
-							writers: ['reviewer'],
+							writers: [],
 							check: { op: '==', value: true },
 						},
 					],

--- a/packages/web/src/components/space/__tests__/useRuntimeCanvasData.test.tsx
+++ b/packages/web/src/components/space/__tests__/useRuntimeCanvasData.test.tsx
@@ -92,9 +92,14 @@ function makeGate(overrides: Partial<Gate> = {}): Gate {
 	return {
 		id: 'gate-1',
 		fields: [
-			{ name: 'approved', type: 'boolean', writers: ['human'], check: { op: '==', value: true } },
+			{
+				name: 'approved',
+				type: 'boolean',
+				writers: [],
+				check: { op: '==', value: true },
+			},
 		],
-		description: 'Human approval',
+		description: 'Reviewer approval',
 		resetOnCycle: false,
 		...overrides,
 	};

--- a/packages/web/src/components/space/useRuntimeCanvasData.ts
+++ b/packages/web/src/components/space/useRuntimeCanvasData.ts
@@ -61,7 +61,7 @@ function evalFieldStatus(field: GateField, data: Record<string, unknown>): GateS
 }
 
 function isHumanApprovalGate(fields: GateField[]): boolean {
-	return fields.some((f) => f.name === 'approved' && f.writers.includes('human'));
+	return fields.some((f) => f.name === 'approved' && f.writers.includes('reviewer'));
 }
 
 function evaluateGateStatus(

--- a/packages/web/src/components/space/useRuntimeCanvasData.ts
+++ b/packages/web/src/components/space/useRuntimeCanvasData.ts
@@ -60,8 +60,8 @@ function evalFieldStatus(field: GateField, data: Record<string, unknown>): GateS
 	return 'blocked';
 }
 
-function isHumanApprovalGate(fields: GateField[]): boolean {
-	return fields.some((f) => f.name === 'approved' && f.writers.includes('reviewer'));
+function isExternalApprovalGate(fields: GateField[]): boolean {
+	return fields.some((f) => f.name === 'approved' && f.writers.length === 0);
 }
 
 function evaluateGateStatus(
@@ -71,7 +71,7 @@ function evaluateGateStatus(
 ): GateStatus {
 	if (scriptFailed) return 'blocked';
 	if ((gate.fields ?? []).length === 0) return 'open';
-	if (isHumanApprovalGate(gate.fields ?? [])) {
+	if (isExternalApprovalGate(gate.fields ?? [])) {
 		const val = data['approved'];
 		if (val === true) {
 			const othersPassed = (gate.fields ?? []).every((f) => {

--- a/packages/web/src/components/space/visual-editor/GateEditorPanel.tsx
+++ b/packages/web/src/components/space/visual-editor/GateEditorPanel.tsx
@@ -174,11 +174,11 @@ export function GateEditorPanel({
 		else if (expandedField !== null && expandedField > index) setExpandedField(expandedField - 1);
 	}
 
-	function addHumanApprovalPreset() {
+	function addApprovalPreset() {
 		const preset: GateField = {
 			name: 'approved',
 			type: 'boolean',
-			writers: ['human'],
+			writers: [],
 			check: { op: '==', value: true },
 		};
 		updateGate({ fields: [...(gate.fields ?? []), preset] });
@@ -432,11 +432,11 @@ export function GateEditorPanel({
 				<div class="flex gap-2">
 					<button
 						type="button"
-						data-testid="gate-editor-preset-human"
-						onClick={addHumanApprovalPreset}
+						data-testid="gate-editor-preset-approval"
+						onClick={addApprovalPreset}
 						class={`flex-1 rounded border px-2 py-1.5 text-xs transition-colors ${modeButtonClass(false)}`}
 					>
-						Human Approval
+						Approval
 					</button>
 					<button
 						type="button"

--- a/packages/web/src/components/space/visual-editor/__tests__/GateEditorPanel.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/GateEditorPanel.test.tsx
@@ -352,7 +352,7 @@ describe('GateEditorPanel — Existing functionality preserved', () => {
 				{
 					name: 'approved',
 					type: 'boolean',
-					writers: ['human'],
+					writers: [],
 					check: { op: '==', value: true },
 				},
 			],
@@ -763,7 +763,7 @@ describe('GateEditorPanel — Gate-level validation', () => {
 
 	it('does not show gate error when fields are present', () => {
 		const gate = makeGate({
-			fields: [{ name: 'approved', type: 'boolean', writers: ['human'], check: { op: 'exists' } }],
+			fields: [{ name: 'approved', type: 'boolean', writers: [], check: { op: 'exists' } }],
 		});
 		const { queryByTestId } = render(<GateEditorPanel {...makeProps(gate)} />);
 
@@ -823,7 +823,7 @@ describe('GateEditorPanel — Empty-fields message context', () => {
 
 	it('does not show empty-fields message when fields are present', () => {
 		const gate = makeGate({
-			fields: [{ name: 'approved', type: 'boolean', writers: ['human'], check: { op: 'exists' } }],
+			fields: [{ name: 'approved', type: 'boolean', writers: [], check: { op: 'exists' } }],
 		});
 		const { queryByText } = render(<GateEditorPanel {...makeProps(gate)} />);
 

--- a/packages/web/src/components/space/visual-editor/__tests__/semanticWorkflowGraph.test.ts
+++ b/packages/web/src/components/space/visual-editor/__tests__/semanticWorkflowGraph.test.ts
@@ -55,7 +55,7 @@ function humanGate(id: string, overrides?: Partial<Gate>): Gate {
 			{
 				name: 'approved',
 				type: 'boolean',
-				writers: ['human'],
+				writers: [],
 				check: { op: '==', value: true },
 			},
 		],

--- a/packages/web/src/components/space/visual-editor/serialization.ts
+++ b/packages/web/src/components/space/visual-editor/serialization.ts
@@ -81,7 +81,7 @@ export interface VisualEditorState {
 	/**
 	 * The step key (step.id for existing, step.localId for new) of the
 	 * end node. Managed explicitly by the user. When set, the workflow
-	 * run auto-completes when the end node's execution calls `report_done`.
+	 * run auto-completes when the end node's execution calls `report_result`.
 	 */
 	endNodeId?: string;
 	tags: string[];

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -75,6 +75,8 @@ function makeTask(id: string, status = 'open', workflowRunId?: string): SpaceTas
 		approvedAt: null,
 		pendingActionIndex: null,
 		pendingCheckpointType: null,
+		reportedStatus: null,
+		reportedSummary: null,
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
 		...(workflowRunId ? { workflowRunId } : {}),


### PR DESCRIPTION
## Summary

- Wire `artifactRepo` through SpaceRuntimeService to SpaceRuntime so completion actions can resolve artifact data for script env injection
- Add `resumeCompletionActions()` on SpaceRuntime/SpaceRuntimeService — resumes paused completion actions from `pendingActionIndex` after human approval
- Intercept review→done in `spaceTask.update` handler when task has `pendingCheckpointType='completion_action'`
- Fix `isHumanApprovalGate` to recognize `writers: ['reviewer']` (was checking `'human'` which no longer exists)
- Add tests: script failure fire-and-forget (2), resume path (3)

## Test plan

- [x] All 2080 space unit tests pass
- [x] Typecheck clean
- [x] Lint + format clean
- [ ] CI