### PR TITLE
feat: overview page — limit to 5 recent items, Stop/Start runtime control

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-handlers.ts
@@ -302,9 +302,9 @@ export function setupSpaceHandlers(
 
 	// ─── space.stop ─────────────────────────────────────────────────────────────
 	// Stops all active work (terminates running agent sessions, cancels in-progress
-	// tasks and workflow runs) and then archives the space.
-	// Unlike space.archive (which is a metadata-only flag), space.stop ensures
-	// running agents are actually terminated before archival.
+	// tasks and workflow runs) and marks the space as stopped.
+	// Unlike space.archive, a stopped space remains active and can be restarted.
+	// The stopped flag persists across daemon restarts — no work auto-starts.
 	messageHub.onRequest('space.stop', async (data) => {
 		const params = data as { id: string };
 
@@ -317,12 +317,32 @@ export function setupSpaceHandlers(
 			await spaceRuntimeService.stopActiveWork(params.id);
 		}
 
-		const space = await spaceManager.archiveSpace(params.id);
+		const space = await spaceManager.stopSpace(params.id);
 
 		daemonHub
-			.emit('space.archived', { sessionId: 'global', spaceId: params.id, space })
+			.emit('space.updated', { sessionId: 'global', spaceId: params.id, space })
 			.catch((err) => {
-				log.warn('Failed to emit space.archived:', err);
+				log.warn('Failed to emit space.updated:', err);
+			});
+
+		return space;
+	});
+
+	// ─── space.start ────────────────────────────────────────────────────────────
+	// Clears the stopped flag so the runtime resumes scheduling new work.
+	messageHub.onRequest('space.start', async (data) => {
+		const params = data as { id: string };
+
+		if (!params.id) {
+			throw new Error('id is required');
+		}
+
+		const space = await spaceManager.startSpace(params.id);
+
+		daemonHub
+			.emit('space.updated', { sessionId: 'global', spaceId: params.id, space })
+			.catch((err) => {
+				log.warn('Failed to emit space.updated:', err);
 			});
 
 		return space;

--- a/packages/daemon/src/lib/rpc-handlers/space-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-handlers.ts
@@ -300,6 +300,34 @@ export function setupSpaceHandlers(
 		return space;
 	});
 
+	// ─── space.stop ─────────────────────────────────────────────────────────────
+	// Stops all active work (terminates running agent sessions, cancels in-progress
+	// tasks and workflow runs) and then archives the space.
+	// Unlike space.archive (which is a metadata-only flag), space.stop ensures
+	// running agents are actually terminated before archival.
+	messageHub.onRequest('space.stop', async (data) => {
+		const params = data as { id: string };
+
+		if (!params.id) {
+			throw new Error('id is required');
+		}
+
+		// Terminate all running agent sessions and cancel active tasks/workflow runs.
+		if (spaceRuntimeService) {
+			await spaceRuntimeService.stopActiveWork(params.id);
+		}
+
+		const space = await spaceManager.archiveSpace(params.id);
+
+		daemonHub
+			.emit('space.archived', { sessionId: 'global', spaceId: params.id, space })
+			.catch((err) => {
+				log.warn('Failed to emit space.archived:', err);
+			});
+
+		return space;
+	});
+
 	// ─── space.pause ───────────────────────────────────────────────────────────
 	messageHub.onRequest('space.pause', async (data) => {
 		const params = data as { id: string };

--- a/packages/daemon/src/lib/space/managers/space-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-manager.ts
@@ -123,6 +123,42 @@ export class SpaceManager {
 	}
 
 	/**
+	 * Stop a space (marks stopped=true; kills active work; no auto-start on daemon restart)
+	 */
+	async stopSpace(id: string): Promise<Space> {
+		const space = this.spaceRepo.getSpace(id);
+		if (!space) {
+			throw new Error(`Space not found: ${id}`);
+		}
+		if (space.stopped) return space;
+
+		const stopped = this.spaceRepo.stopSpace(id);
+		if (!stopped) {
+			throw new Error(`Failed to stop space: ${id}`);
+		}
+
+		return stopped;
+	}
+
+	/**
+	 * Start (or restart) a stopped space
+	 */
+	async startSpace(id: string): Promise<Space> {
+		const space = this.spaceRepo.getSpace(id);
+		if (!space) {
+			throw new Error(`Space not found: ${id}`);
+		}
+		if (!space.stopped) return space;
+
+		const started = this.spaceRepo.startSpace(id);
+		if (!started) {
+			throw new Error(`Failed to start space: ${id}`);
+		}
+
+		return started;
+	}
+
+	/**
 	 * Archive a space
 	 */
 	async archiveSpace(id: string): Promise<Space> {

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -141,6 +141,53 @@ export class SpaceRuntimeService {
 		this.runtime.setTaskAgentManager(manager);
 	}
 
+	/**
+	 * Stop all active work for a space: terminates running agent sessions and
+	 * cancels all in-progress/open tasks and active workflow runs.
+	 *
+	 * Called by the `space.stop` RPC handler before archiving the space.
+	 * Does NOT archive the space itself — the caller is responsible for that.
+	 */
+	async stopActiveWork(spaceId: string): Promise<void> {
+		const { taskRepo, workflowRunRepo } = this.config;
+
+		// 1. Cancel all active tasks (in_progress or open) and their agent sessions.
+		const activeTasks = taskRepo
+			.listBySpace(spaceId)
+			.filter((t) => t.status === 'in_progress' || t.status === 'open');
+
+		await Promise.allSettled(
+			activeTasks.map(async (task) => {
+				// Stop the agent session first, then mark the task as cancelled in the DB.
+				if (this.taskAgentManager) {
+					await this.taskAgentManager.cleanup(task.id, 'cancelled').catch((err: unknown) => {
+						log.warn(`stopActiveWork: failed to cleanup agent session for task ${task.id}:`, err);
+					});
+				}
+				taskRepo.updateTask(task.id, { status: 'cancelled' });
+			})
+		);
+
+		// 2. Cancel all active workflow runs (pending, in_progress, blocked).
+		const activeRuns = workflowRunRepo
+			.listBySpace(spaceId)
+			.filter(
+				(r) => r.status === 'pending' || r.status === 'in_progress' || r.status === 'blocked'
+			);
+
+		for (const run of activeRuns) {
+			try {
+				workflowRunRepo.transitionStatus(run.id, 'cancelled');
+			} catch (err) {
+				log.warn(`stopActiveWork: failed to cancel workflow run ${run.id}:`, err);
+			}
+		}
+
+		log.info(
+			`stopActiveWork: cancelled ${activeTasks.length} tasks and ${activeRuns.length} workflow runs for space ${spaceId}`
+		);
+	}
+
 	/** Start the underlying SpaceRuntime tick loop. */
 	start(): void {
 		if (this.started) return;

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -371,12 +371,12 @@ export class SpaceRuntime {
 	}
 
 	/**
-	 * Returns active, non-paused spaces.
-	 * Used by tick-loop methods to skip paused spaces.
+	 * Returns active, non-paused, non-stopped spaces.
+	 * Used by tick-loop methods to skip paused and stopped spaces.
 	 */
 	private async listActiveSpaces(): Promise<import('@neokai/shared').Space[]> {
 		const spaces = await this.config.spaceManager.listSpaces(false);
-		return spaces.filter((s) => !s.paused);
+		return spaces.filter((s) => !s.paused && !s.stopped);
 	}
 
 	private async updateTaskAndEmit(
@@ -1247,9 +1247,9 @@ export class SpaceRuntime {
 			}
 
 			// Step 2: Spawn workflow node agents for pending executions without sessions.
-			// Skip spawning for paused spaces — completion/timeout/crash detection above
+			// Skip spawning for paused or stopped spaces — completion/timeout/crash detection above
 			// still runs so in-flight agents are monitored, but no new agents are started.
-			if (space?.paused) return;
+			if (space?.paused || space?.stopped) return;
 
 			nodeExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
 			const pendingExecutions = nodeExecutions.filter(

--- a/packages/daemon/src/storage/repositories/space-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-repository.ts
@@ -193,6 +193,26 @@ export class SpaceRepository {
 	}
 
 	/**
+	 * Stop a space (kills active work; no auto-start on daemon restart)
+	 */
+	stopSpace(id: string): Space | null {
+		const stmt = this.db.prepare(`UPDATE spaces SET stopped = 1, updated_at = ? WHERE id = ?`);
+		stmt.run(Date.now(), id);
+		return this.getSpace(id);
+	}
+
+	/**
+	 * Start (or restart) a stopped space
+	 */
+	startSpace(id: string): Space | null {
+		const stmt = this.db.prepare(
+			`UPDATE spaces SET stopped = 0, paused = 0, updated_at = ? WHERE id = ?`
+		);
+		stmt.run(Date.now(), id);
+		return this.getSpace(id);
+	}
+
+	/**
 	 * Archive a space
 	 */
 	archiveSpace(id: string): Space | null {
@@ -278,6 +298,7 @@ export class SpaceRepository {
 			sessionIds: JSON.parse(row.session_ids as string) as string[],
 			status: row.status as 'active' | 'archived',
 			paused: (row.paused as number) === 1,
+			stopped: (row.stopped as number) === 1,
 			autonomyLevel: ((row.autonomy_level as number) ?? 1) as SpaceAutonomyLevel,
 			config,
 			createdAt: row.created_at as number,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -367,6 +367,11 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	//   - Adds pending_action_index and pending_checkpoint_type to space_tasks.
 	//   - Migrates approval_source values to simplified 3-value type.
 	runMigration86(db);
+
+	// Migration 87: Add stopped column to spaces.
+	//   Allows users to stop/start space runtime execution without archiving.
+	//   Stopped spaces have all active work killed and will not auto-start on daemon restart.
+	runMigration87(db);
 }
 
 /**
@@ -5838,4 +5843,17 @@ function runMigration86(db: BunDatabase): void {
 	} finally {
 		db.exec('PRAGMA foreign_keys = ON');
 	}
+}
+
+/**
+ * Migration 87: Add stopped column to spaces table.
+ *
+ * Allows users to stop/start space runtime execution without archiving.
+ * Stopped spaces have all active work killed on stop and will not auto-start
+ * on daemon restart. Default: 0 (not stopped).
+ */
+function runMigration87(db: BunDatabase): void {
+	if (!tableExists(db, 'spaces')) return;
+	if (tableHasColumn(db, 'spaces', 'stopped')) return;
+	db.exec(`ALTER TABLE spaces ADD COLUMN stopped INTEGER NOT NULL DEFAULT 0`);
 }

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-handlers.test.ts
@@ -7,7 +7,8 @@
  * - space.get: happy path, missing id, not found
  * - space.update: happy path, missing id, not found
  * - space.archive: happy path (emits space.archived with full space), missing id
- * - space.stop: stops active work via runtime service, archives, emits space.archived; missing id; graceful degradation without runtime service
+ * - space.stop: stops active work via runtime service, marks stopped, emits space.updated; missing id; graceful degradation without runtime service
+ * - space.start: clears stopped flag, emits space.updated; missing id
  * - space.delete: happy path, missing id, not found
  * - space.overview: happy path, missing id, not found
  * - DaemonHub events emitted on mutations
@@ -42,6 +43,8 @@ const mockSpace: Space = {
 	instructions: '',
 	sessionIds: [],
 	status: 'active',
+	paused: false,
+	stopped: false,
 	autonomyLevel: 1,
 	createdAt: NOW,
 	updatedAt: NOW,
@@ -118,6 +121,8 @@ function createMockSpaceManager(space: Space | null = mockSpace): SpaceManager {
 		archiveSpace: mock(async () => ({ ...space!, status: 'archived' as const })),
 		pauseSpace: mock(async () => ({ ...space!, paused: true })),
 		resumeSpace: mock(async () => ({ ...space!, paused: false })),
+		stopSpace: mock(async () => ({ ...space!, stopped: true })),
+		startSpace: mock(async () => ({ ...space!, stopped: false, paused: false })),
 		deleteSpace: mock(async () => true),
 		addSession: mock(async () => space!),
 		removeSession: mock(async () => space!),
@@ -644,41 +649,68 @@ describe('space-handlers', () => {
 			setup(mockSpace, undefined, mockRuntimeService);
 		});
 
-		it('stops active work via runtime service, archives the space, and emits space.archived', async () => {
-			const archivedSpace = { ...mockSpace, status: 'archived' as const };
-			(spaceManager.archiveSpace as ReturnType<typeof mock>).mockResolvedValue(archivedSpace);
+		it('stops active work via runtime service, marks space stopped, and emits space.updated', async () => {
+			const stoppedSpace = { ...mockSpace, stopped: true };
+			(spaceManager.stopSpace as ReturnType<typeof mock>).mockResolvedValue(stoppedSpace);
 
 			const result = await call('space.stop', { id: 'space-1' });
 
-			// Must call stopActiveWork before archiving
+			// Must call stopActiveWork before marking stopped
 			expect(mockRuntimeService.stopActiveWork).toHaveBeenCalledWith('space-1');
-			expect(spaceManager.archiveSpace).toHaveBeenCalledWith('space-1');
-			expect((result as Space).status).toBe('archived');
-			expect(daemonHub.emit).toHaveBeenCalledWith('space.archived', {
+			expect(spaceManager.stopSpace).toHaveBeenCalledWith('space-1');
+			expect((result as Space).stopped).toBe(true);
+			// Space is NOT archived — status stays 'active'
+			expect((result as Space).status).toBe('active');
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.updated', {
 				sessionId: 'global',
 				spaceId: 'space-1',
-				space: archivedSpace,
+				space: stoppedSpace,
 			});
 		});
 
 		it('works without runtime service (graceful degradation)', async () => {
 			// Re-setup without runtime service
 			setup(mockSpace, undefined, undefined);
-			const archivedSpace = { ...mockSpace, status: 'archived' as const };
-			(spaceManager.archiveSpace as ReturnType<typeof mock>).mockResolvedValue(archivedSpace);
+			const stoppedSpace = { ...mockSpace, stopped: true };
+			(spaceManager.stopSpace as ReturnType<typeof mock>).mockResolvedValue(stoppedSpace);
 
 			const result = await call('space.stop', { id: 'space-1' });
 
-			expect((result as Space).status).toBe('archived');
-			expect(daemonHub.emit).toHaveBeenCalledWith('space.archived', {
+			expect((result as Space).stopped).toBe(true);
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.updated', {
 				sessionId: 'global',
 				spaceId: 'space-1',
-				space: archivedSpace,
+				space: stoppedSpace,
 			});
 		});
 
 		it('throws when id is missing', async () => {
 			await expect(call('space.stop', {})).rejects.toThrow('id is required');
+		});
+	});
+
+	// ─── space.start ───────────────────────────────────────────────────────────
+
+	describe('space.start', () => {
+		beforeEach(() => setup());
+
+		it('clears stopped flag and emits space.updated', async () => {
+			const startedSpace = { ...mockSpace, stopped: false, paused: false };
+			(spaceManager.startSpace as ReturnType<typeof mock>).mockResolvedValue(startedSpace);
+
+			const result = await call('space.start', { id: 'space-1' });
+
+			expect(spaceManager.startSpace).toHaveBeenCalledWith('space-1');
+			expect((result as Space).stopped).toBe(false);
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.updated', {
+				sessionId: 'global',
+				spaceId: 'space-1',
+				space: startedSpace,
+			});
+		});
+
+		it('throws when id is missing', async () => {
+			await expect(call('space.start', {})).rejects.toThrow('id is required');
 		});
 	});
 

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-handlers.test.ts
@@ -7,6 +7,7 @@
  * - space.get: happy path, missing id, not found
  * - space.update: happy path, missing id, not found
  * - space.archive: happy path (emits space.archived with full space), missing id
+ * - space.stop: stops active work via runtime service, archives, emits space.archived; missing id; graceful degradation without runtime service
  * - space.delete: happy path, missing id, not found
  * - space.overview: happy path, missing id, not found
  * - DaemonHub events emitted on mutations
@@ -627,6 +628,57 @@ describe('space-handlers', () => {
 			);
 
 			await expect(call('space.archive', { id: 'nope' })).rejects.toThrow('Space not found');
+		});
+	});
+
+	// ─── space.stop ────────────────────────────────────────────────────────────
+
+	describe('space.stop', () => {
+		let mockRuntimeService: SpaceRuntimeService;
+
+		beforeEach(() => {
+			mockRuntimeService = {
+				setupSpaceAgentSession: mock(async () => {}),
+				stopActiveWork: mock(async () => {}),
+			} as unknown as SpaceRuntimeService;
+			setup(mockSpace, undefined, mockRuntimeService);
+		});
+
+		it('stops active work via runtime service, archives the space, and emits space.archived', async () => {
+			const archivedSpace = { ...mockSpace, status: 'archived' as const };
+			(spaceManager.archiveSpace as ReturnType<typeof mock>).mockResolvedValue(archivedSpace);
+
+			const result = await call('space.stop', { id: 'space-1' });
+
+			// Must call stopActiveWork before archiving
+			expect(mockRuntimeService.stopActiveWork).toHaveBeenCalledWith('space-1');
+			expect(spaceManager.archiveSpace).toHaveBeenCalledWith('space-1');
+			expect((result as Space).status).toBe('archived');
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.archived', {
+				sessionId: 'global',
+				spaceId: 'space-1',
+				space: archivedSpace,
+			});
+		});
+
+		it('works without runtime service (graceful degradation)', async () => {
+			// Re-setup without runtime service
+			setup(mockSpace, undefined, undefined);
+			const archivedSpace = { ...mockSpace, status: 'archived' as const };
+			(spaceManager.archiveSpace as ReturnType<typeof mock>).mockResolvedValue(archivedSpace);
+
+			const result = await call('space.stop', { id: 'space-1' });
+
+			expect((result as Space).status).toBe('archived');
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.archived', {
+				sessionId: 'global',
+				spaceId: 'space-1',
+				space: archivedSpace,
+			});
+		});
+
+		it('throws when id is missing', async () => {
+			await expect(call('space.stop', {})).rejects.toThrow('id is required');
 		});
 	});
 

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -75,8 +75,13 @@ export interface Space {
 	sessionIds: string[];
 	/** Current status of the Space */
 	status: SpaceStatus;
-	/** Whether the space runtime is paused (no new tasks scheduled or executed) */
+	/** Whether the space runtime is paused (no new tasks scheduled; running work continues) */
 	paused: boolean;
+	/**
+	 * Whether the space runtime is stopped (all active work killed; no auto-start on daemon restart).
+	 * A stopped space must be explicitly started again to resume. Takes precedence over `paused`.
+	 */
+	stopped: boolean;
 	/** Autonomy level — controls how much the Space Agent can act without human approval */
 	autonomyLevel?: SpaceAutonomyLevel;
 	/** Runtime configuration (maxConcurrentTasks, taskTimeoutMs, etc.) */

--- a/packages/web/src/components/space/SpaceOverview.tsx
+++ b/packages/web/src/components/space/SpaceOverview.tsx
@@ -80,12 +80,14 @@ function RuntimeControlBar({
 	onPause,
 	onResume,
 	onStop,
+	onStart,
 }: {
 	state: RuntimeState;
 	actionLoading: boolean;
 	onPause: () => void;
 	onResume: () => void;
 	onStop: () => void;
+	onStart: () => void;
 }) {
 	const style = RUNTIME_STYLES[state];
 
@@ -150,6 +152,15 @@ function RuntimeControlBar({
 							Stop
 						</button>
 					</>
+				)}
+				{state === 'stopped' && (
+					<button
+						onClick={onStart}
+						disabled={actionLoading}
+						class="px-4 py-2 text-sm font-medium text-green-300 bg-green-900/30 hover:bg-green-900/50 border border-green-700/40 rounded-lg transition-colors disabled:opacity-40"
+					>
+						Start
+					</button>
 				)}
 			</div>
 		</div>
@@ -271,6 +282,15 @@ export function SpaceOverview({ spaceId, onSelectTask }: SpaceOverviewProps) {
 		}
 	}, []);
 
+	const handleStart = useCallback(async () => {
+		setActionLoading(true);
+		try {
+			await spaceStore.startSpace();
+		} finally {
+			setActionLoading(false);
+		}
+	}, []);
+
 	const handleAutonomyChange = useCallback(async (level: SpaceAutonomyLevel) => {
 		if (level === spaceStore.space.value?.autonomyLevel) return;
 		try {
@@ -334,7 +354,7 @@ export function SpaceOverview({ spaceId, onSelectTask }: SpaceOverviewProps) {
 			<div class="min-h-[calc(100%+1px)] space-y-6">
 				<SpaceCreateTaskDialog isOpen={showCreateTask} onClose={() => setShowCreateTask(false)} />
 
-				{/* Runtime state with pause/resume/stop controls */}
+				{/* Runtime state with pause/resume/stop/start controls */}
 				{runtimeState && (
 					<RuntimeControlBar
 						state={runtimeState}
@@ -342,6 +362,7 @@ export function SpaceOverview({ spaceId, onSelectTask }: SpaceOverviewProps) {
 						onPause={() => void handlePause()}
 						onResume={() => void handleResume()}
 						onStop={() => setShowStopConfirm(true)}
+						onStart={() => void handleStart()}
 					/>
 				)}
 
@@ -459,7 +480,7 @@ export function SpaceOverview({ spaceId, onSelectTask }: SpaceOverviewProps) {
 					onClose={() => setShowStopConfirm(false)}
 					onConfirm={() => void handleStop()}
 					title="Stop Space"
-					message="Stopping will archive this space and shut down all active work. You can unarchive the space later to resume."
+					message="Stopping will immediately terminate all active sessions and cancel in-progress work. The space will not restart automatically. You can start it again at any time."
 					confirmText="Stop Space"
 					isLoading={actionLoading}
 				/>

--- a/packages/web/src/components/space/SpaceOverview.tsx
+++ b/packages/web/src/components/space/SpaceOverview.tsx
@@ -17,6 +17,7 @@ import { cn, getRelativeTime } from '../../lib/utils';
 import { toast } from '../../lib/toast';
 import { AUTONOMY_LABELS } from '../../lib/space-constants';
 import { SpaceCreateTaskDialog } from './SpaceCreateTaskDialog';
+import { ConfirmModal } from '../ui/ConfirmModal';
 
 // ─── Stat Card ───────────────────────────────────────────────────────────────
 
@@ -78,11 +79,13 @@ function RuntimeControlBar({
 	actionLoading,
 	onPause,
 	onResume,
+	onStop,
 }: {
 	state: RuntimeState;
 	actionLoading: boolean;
 	onPause: () => void;
 	onResume: () => void;
+	onStop: () => void;
 }) {
 	const style = RUNTIME_STYLES[state];
 
@@ -113,22 +116,40 @@ function RuntimeControlBar({
 			</div>
 			<div class="flex items-center gap-2">
 				{state === 'running' && (
-					<button
-						onClick={onPause}
-						disabled={actionLoading}
-						class="px-4 py-2 text-sm font-medium text-yellow-300 bg-yellow-900/30 hover:bg-yellow-900/50 border border-yellow-700/40 rounded-lg transition-colors disabled:opacity-40"
-					>
-						Pause
-					</button>
+					<>
+						<button
+							onClick={onPause}
+							disabled={actionLoading}
+							class="px-4 py-2 text-sm font-medium text-yellow-300 bg-yellow-900/30 hover:bg-yellow-900/50 border border-yellow-700/40 rounded-lg transition-colors disabled:opacity-40"
+						>
+							Pause
+						</button>
+						<button
+							onClick={onStop}
+							disabled={actionLoading}
+							class="px-4 py-2 text-sm font-medium text-red-300 bg-red-900/20 hover:bg-red-900/40 border border-red-700/40 rounded-lg transition-colors disabled:opacity-40"
+						>
+							Stop
+						</button>
+					</>
 				)}
 				{state === 'paused' && (
-					<button
-						onClick={onResume}
-						disabled={actionLoading}
-						class="px-4 py-2 text-sm font-medium text-green-300 bg-green-900/30 hover:bg-green-900/50 border border-green-700/40 rounded-lg transition-colors disabled:opacity-40"
-					>
-						Resume
-					</button>
+					<>
+						<button
+							onClick={onResume}
+							disabled={actionLoading}
+							class="px-4 py-2 text-sm font-medium text-green-300 bg-green-900/30 hover:bg-green-900/50 border border-green-700/40 rounded-lg transition-colors disabled:opacity-40"
+						>
+							Resume
+						</button>
+						<button
+							onClick={onStop}
+							disabled={actionLoading}
+							class="px-4 py-2 text-sm font-medium text-red-300 bg-red-900/20 hover:bg-red-900/40 border border-red-700/40 rounded-lg transition-colors disabled:opacity-40"
+						>
+							Stop
+						</button>
+					</>
 				)}
 			</div>
 		</div>
@@ -220,6 +241,7 @@ interface SpaceOverviewProps {
 export function SpaceOverview({ spaceId, onSelectTask }: SpaceOverviewProps) {
 	const [showCreateTask, setShowCreateTask] = useState(false);
 	const [actionLoading, setActionLoading] = useState(false);
+	const [showStopConfirm, setShowStopConfirm] = useState(false);
 
 	const handlePause = useCallback(async () => {
 		setActionLoading(true);
@@ -236,6 +258,16 @@ export function SpaceOverview({ spaceId, onSelectTask }: SpaceOverviewProps) {
 			await spaceStore.resumeSpace();
 		} finally {
 			setActionLoading(false);
+		}
+	}, []);
+
+	const handleStop = useCallback(async () => {
+		setActionLoading(true);
+		try {
+			await spaceStore.stopSpace();
+		} finally {
+			setActionLoading(false);
+			setShowStopConfirm(false);
 		}
 	}, []);
 
@@ -260,10 +292,10 @@ export function SpaceOverview({ spaceId, onSelectTask }: SpaceOverviewProps) {
 	const tasks = spaceStore.tasks.value;
 	const runtimeState = spaceStore.runtimeState.value;
 
-	// Recent sessions — sorted by lastActiveAt, top 8 (computed before early returns)
+	// Recent sessions — sorted by lastActiveAt, top 5 (computed before early returns)
 	const recentSessions = [...spaceStore.sessions.value]
 		.sort((a, b) => b.lastActiveAt - a.lastActiveAt)
-		.slice(0, 8);
+		.slice(0, 5);
 
 	if (loading) {
 		return (
@@ -291,8 +323,8 @@ export function SpaceOverview({ spaceId, onSelectTask }: SpaceOverviewProps) {
 		(t) => t.status === 'done' || t.status === 'cancelled' || t.status === 'archived'
 	);
 
-	// Recent tasks — sorted by updatedAt, top 8
-	const recentTasks = [...tasks].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, 8);
+	// Recent tasks — sorted by updatedAt, top 5
+	const recentTasks = [...tasks].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, 5);
 
 	const handleTaskClick =
 		onSelectTask ?? ((taskId: string) => navigateToSpaceTask(spaceId, taskId));
@@ -302,13 +334,14 @@ export function SpaceOverview({ spaceId, onSelectTask }: SpaceOverviewProps) {
 			<div class="min-h-[calc(100%+1px)] space-y-6">
 				<SpaceCreateTaskDialog isOpen={showCreateTask} onClose={() => setShowCreateTask(false)} />
 
-				{/* Runtime state with pause/resume controls */}
+				{/* Runtime state with pause/resume/stop controls */}
 				{runtimeState && (
 					<RuntimeControlBar
 						state={runtimeState}
 						actionLoading={actionLoading}
 						onPause={() => void handlePause()}
 						onResume={() => void handleResume()}
+						onStop={() => setShowStopConfirm(true)}
 					/>
 				)}
 
@@ -419,6 +452,17 @@ export function SpaceOverview({ spaceId, onSelectTask }: SpaceOverviewProps) {
 						</div>
 					</div>
 				)}
+
+				{/* Stop Confirmation */}
+				<ConfirmModal
+					isOpen={showStopConfirm}
+					onClose={() => setShowStopConfirm(false)}
+					onConfirm={() => void handleStop()}
+					title="Stop Space"
+					message="Stopping will archive this space and shut down all active work. You can unarchive the space later to resume."
+					confirmText="Stop Space"
+					isLoading={actionLoading}
+				/>
 			</div>
 		</div>
 	);

--- a/packages/web/src/components/space/__tests__/SpaceOverview.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceOverview.test.tsx
@@ -19,6 +19,7 @@ let mockSessions: ReturnType<
 const mockPauseSpace = vi.fn().mockResolvedValue(undefined);
 const mockResumeSpace = vi.fn().mockResolvedValue(undefined);
 const mockStopSpace = vi.fn().mockResolvedValue(undefined);
+const mockStartSpace = vi.fn().mockResolvedValue(undefined);
 const mockUpdateSpace = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('../../../lib/space-store', () => ({
@@ -32,6 +33,7 @@ vi.mock('../../../lib/space-store', () => ({
 			pauseSpace: mockPauseSpace,
 			resumeSpace: mockResumeSpace,
 			stopSpace: mockStopSpace,
+			startSpace: mockStartSpace,
 			updateSpace: mockUpdateSpace,
 		};
 	},
@@ -61,6 +63,7 @@ function makeSpace(overrides: Partial<Space> = {}): Space {
 		sessionIds: [],
 		status: 'active',
 		paused: false,
+		stopped: false,
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
 		...overrides,
@@ -103,6 +106,7 @@ describe('SpaceOverview', () => {
 		mockPauseSpace.mockClear();
 		mockResumeSpace.mockClear();
 		mockStopSpace.mockClear();
+		mockStartSpace.mockClear();
 		mockUpdateSpace.mockClear();
 	});
 
@@ -284,11 +288,12 @@ describe('SpaceOverview', () => {
 			expect(buttons.find((b) => b.textContent === 'Pause')).toBeFalsy();
 		});
 
-		it('shows no Pause/Resume/Stop control buttons when stopped', () => {
+		it('shows Start button when stopped, no Pause/Resume/Stop buttons', () => {
 			mockSpace.value = makeSpace();
 			mockRuntimeState.value = 'stopped';
 			const { container } = render(<SpaceOverview spaceId="space-1" />);
 			const buttons = Array.from(container.querySelectorAll('button'));
+			expect(buttons.find((b) => b.textContent === 'Start')).toBeTruthy();
 			expect(buttons.find((b) => b.textContent === 'Pause')).toBeFalsy();
 			expect(buttons.find((b) => b.textContent === 'Resume')).toBeFalsy();
 			expect(buttons.find((b) => b.textContent === 'Stop')).toBeFalsy();
@@ -343,6 +348,17 @@ describe('SpaceOverview', () => {
 			)!;
 			await fireEvent.click(confirmBtn);
 			expect(mockStopSpace).toHaveBeenCalledTimes(1);
+		});
+
+		it('calls startSpace when Start is clicked while stopped', async () => {
+			mockSpace.value = makeSpace();
+			mockRuntimeState.value = 'stopped';
+			const { container } = render(<SpaceOverview spaceId="space-1" />);
+			const startBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent === 'Start'
+			)!;
+			await fireEvent.click(startBtn);
+			expect(mockStartSpace).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/packages/web/src/components/space/__tests__/SpaceOverview.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceOverview.test.tsx
@@ -18,6 +18,7 @@ let mockSessions: ReturnType<
 
 const mockPauseSpace = vi.fn().mockResolvedValue(undefined);
 const mockResumeSpace = vi.fn().mockResolvedValue(undefined);
+const mockStopSpace = vi.fn().mockResolvedValue(undefined);
 const mockUpdateSpace = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('../../../lib/space-store', () => ({
@@ -30,6 +31,7 @@ vi.mock('../../../lib/space-store', () => ({
 			sessions: mockSessions,
 			pauseSpace: mockPauseSpace,
 			resumeSpace: mockResumeSpace,
+			stopSpace: mockStopSpace,
 			updateSpace: mockUpdateSpace,
 		};
 	},
@@ -100,6 +102,7 @@ describe('SpaceOverview', () => {
 		mockSessions.value = [];
 		mockPauseSpace.mockClear();
 		mockResumeSpace.mockClear();
+		mockStopSpace.mockClear();
 		mockUpdateSpace.mockClear();
 	});
 
@@ -197,7 +200,7 @@ describe('SpaceOverview', () => {
 		expect(queryByText('Stopped')).toBeNull();
 	});
 
-	it('limits recent tasks to 8', () => {
+	it('limits recent tasks to 5', () => {
 		mockSpace.value = makeSpace();
 		const now = Date.now();
 		mockTasks.value = Array.from({ length: 10 }, (_, i) =>
@@ -207,7 +210,7 @@ describe('SpaceOverview', () => {
 		const { container } = render(<SpaceOverview spaceId="space-1" />);
 		// Each task renders as a button inside the activity list
 		const activityButtons = container.querySelectorAll('.divide-y button');
-		expect(activityButtons.length).toBe(8);
+		expect(activityButtons.length).toBe(5);
 	});
 
 	it('stat card counts update when tasks change', () => {
@@ -261,31 +264,34 @@ describe('SpaceOverview', () => {
 	});
 
 	describe('Runtime Control Buttons', () => {
-		it('shows Pause button when running, no Resume button', () => {
+		it('shows Pause and Stop buttons when running, no Resume button', () => {
 			mockSpace.value = makeSpace();
 			mockRuntimeState.value = 'running';
 			const { container } = render(<SpaceOverview spaceId="space-1" />);
 			const buttons = Array.from(container.querySelectorAll('button'));
 			expect(buttons.find((b) => b.textContent === 'Pause')).toBeTruthy();
+			expect(buttons.find((b) => b.textContent === 'Stop')).toBeTruthy();
 			expect(buttons.find((b) => b.textContent === 'Resume')).toBeFalsy();
 		});
 
-		it('shows Resume button when paused, no Pause button', () => {
+		it('shows Resume and Stop buttons when paused, no Pause button', () => {
 			mockSpace.value = makeSpace();
 			mockRuntimeState.value = 'paused';
 			const { container } = render(<SpaceOverview spaceId="space-1" />);
 			const buttons = Array.from(container.querySelectorAll('button'));
 			expect(buttons.find((b) => b.textContent === 'Resume')).toBeTruthy();
+			expect(buttons.find((b) => b.textContent === 'Stop')).toBeTruthy();
 			expect(buttons.find((b) => b.textContent === 'Pause')).toBeFalsy();
 		});
 
-		it('shows no control buttons when stopped', () => {
+		it('shows no Pause/Resume/Stop control buttons when stopped', () => {
 			mockSpace.value = makeSpace();
 			mockRuntimeState.value = 'stopped';
 			const { container } = render(<SpaceOverview spaceId="space-1" />);
 			const buttons = Array.from(container.querySelectorAll('button'));
 			expect(buttons.find((b) => b.textContent === 'Pause')).toBeFalsy();
 			expect(buttons.find((b) => b.textContent === 'Resume')).toBeFalsy();
+			expect(buttons.find((b) => b.textContent === 'Stop')).toBeFalsy();
 		});
 
 		it('calls pauseSpace when Pause is clicked', async () => {
@@ -308,6 +314,35 @@ describe('SpaceOverview', () => {
 			)!;
 			await fireEvent.click(resumeBtn);
 			expect(mockResumeSpace).toHaveBeenCalledTimes(1);
+		});
+
+		it('opens stop confirmation dialog when Stop is clicked while running', () => {
+			mockSpace.value = makeSpace();
+			mockRuntimeState.value = 'running';
+			const { container } = render(<SpaceOverview spaceId="space-1" />);
+			const stopBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent === 'Stop'
+			)!;
+			fireEvent.click(stopBtn);
+			const dialog = document.body.querySelector('[role="dialog"]');
+			expect(dialog).toBeTruthy();
+			expect(dialog?.querySelector('h2')?.textContent).toBe('Stop Space');
+		});
+
+		it('calls stopSpace when Stop is confirmed', async () => {
+			mockSpace.value = makeSpace();
+			mockRuntimeState.value = 'running';
+			const { container } = render(<SpaceOverview spaceId="space-1" />);
+			const stopBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent === 'Stop'
+			)!;
+			fireEvent.click(stopBtn);
+			// Find and click the confirm button in the dialog
+			const confirmBtn = Array.from(document.body.querySelectorAll('button')).find(
+				(b) => b.textContent === 'Stop Space'
+			)!;
+			await fireEvent.click(confirmBtn);
+			expect(mockStopSpace).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -175,6 +175,8 @@ function makeMockHub() {
 			// Daemon returns Space directly (not wrapped)
 			if (method === 'space.pause') return { ...makeSpace(), paused: true };
 			if (method === 'space.resume') return { ...makeSpace(), paused: false };
+			if (method === 'space.stop') return { ...makeSpace(), stopped: true };
+			if (method === 'space.start') return { ...makeSpace(), stopped: false, paused: false };
 			if (method === 'space.update') return makeSpace();
 			// Daemon returns SpaceTask directly (not wrapped)
 			if (method === 'spaceTask.create') return makeTask('new-task');
@@ -1127,6 +1129,38 @@ describe('SpaceStore — CRUD methods', () => {
 		await spaceStore.clearSpace();
 		await expect(spaceStore.resumeSpace()).rejects.toThrow('No space selected');
 	});
+
+	it('stopSpace calls space.stop RPC and updates space + runtimeState to stopped', async () => {
+		await spaceStore.selectSpace('space-1');
+		await spaceStore.stopSpace();
+
+		expect(mockHub.request).toHaveBeenCalledWith('space.stop', { id: 'space-1' });
+		expect(spaceStore.space.value?.stopped).toBe(true);
+		expect(spaceStore.runtimeState.value).toBe('stopped');
+	});
+
+	it('startSpace calls space.start RPC and updates space + runtimeState to running', async () => {
+		await spaceStore.selectSpace('space-1');
+		// First stop, then start
+		await spaceStore.stopSpace();
+		expect(spaceStore.runtimeState.value).toBe('stopped');
+
+		await spaceStore.startSpace();
+
+		expect(mockHub.request).toHaveBeenCalledWith('space.start', { id: 'space-1' });
+		expect(spaceStore.space.value?.stopped).toBe(false);
+		expect(spaceStore.runtimeState.value).toBe('running');
+	});
+
+	it('stopSpace throws when no space selected', async () => {
+		await spaceStore.clearSpace();
+		await expect(spaceStore.stopSpace()).rejects.toThrow('No space selected');
+	});
+
+	it('startSpace throws when no space selected', async () => {
+		await spaceStore.clearSpace();
+		await expect(spaceStore.startSpace()).rejects.toThrow('No space selected');
+	});
 });
 
 describe('SpaceStore — runtimeState', () => {
@@ -1144,6 +1178,23 @@ describe('SpaceStore — runtimeState', () => {
 			if (method === 'space.overview') {
 				return {
 					space: { ...makeSpace(), status: 'archived' },
+					tasks: [],
+					workflowRuns: [],
+					sessions: [],
+				};
+			}
+			return {};
+		});
+
+		await spaceStore.selectSpace('space-1');
+		expect(spaceStore.runtimeState.value).toBe('stopped');
+	});
+
+	it('runtimeState is "stopped" for stopped (non-archived) space', async () => {
+		mockHub.request.mockImplementation(async (method: string) => {
+			if (method === 'space.overview') {
+				return {
+					space: { ...makeSpace(), status: 'active', stopped: true },
 					tasks: [],
 					workflowRuns: [],
 					sessions: [],

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -48,6 +48,7 @@ function makeSpace(id = 'space-1'): Space {
 		sessionIds: [],
 		status: 'active',
 		paused: false,
+		stopped: false,
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
 	};

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -1568,6 +1568,23 @@ class SpaceStore {
 	}
 
 	/**
+	 * Stop the current space (archives it, showing stopped state without navigating away)
+	 */
+	async stopSpace(): Promise<void> {
+		const spaceId = this.spaceId.value;
+		if (!spaceId) throw new Error('No space selected');
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		const space = await hub.request<Space>('space.archive', { id: spaceId });
+		if (space) {
+			this.space.value = space;
+			this.updateRuntimeState(space);
+		}
+	}
+
+	/**
 	 * Pause the current space (stops task scheduling without archiving)
 	 */
 	async pauseSpace(): Promise<void> {

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -171,6 +171,10 @@ class SpaceStore {
 			this.runtimeState.value = 'stopped';
 			return;
 		}
+		if (space.stopped) {
+			this.runtimeState.value = 'stopped';
+			return;
+		}
 		this.runtimeState.value = space.paused ? 'paused' : 'running';
 	}
 
@@ -1568,8 +1572,9 @@ class SpaceStore {
 	}
 
 	/**
-	 * Stop the current space: terminates all running agent sessions, cancels
-	 * in-progress tasks and workflow runs, then archives the space.
+	 * Stop the current space: terminates all running agent sessions and cancels
+	 * in-progress tasks/workflow runs. Marks the space as stopped so it does not
+	 * auto-start on daemon restart. The space remains active and can be restarted.
 	 */
 	async stopSpace(): Promise<void> {
 		const spaceId = this.spaceId.value;
@@ -1579,6 +1584,24 @@ class SpaceStore {
 		if (!hub) throw new Error('Not connected');
 
 		const space = await hub.request<Space>('space.stop', { id: spaceId });
+		if (space) {
+			this.space.value = space;
+			this.updateRuntimeState(space);
+		}
+	}
+
+	/**
+	 * Start (or restart) the current space after it has been stopped.
+	 * Clears the stopped flag so the runtime resumes scheduling new work.
+	 */
+	async startSpace(): Promise<void> {
+		const spaceId = this.spaceId.value;
+		if (!spaceId) throw new Error('No space selected');
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		const space = await hub.request<Space>('space.start', { id: spaceId });
 		if (space) {
 			this.space.value = space;
 			this.updateRuntimeState(space);

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -1568,7 +1568,8 @@ class SpaceStore {
 	}
 
 	/**
-	 * Stop the current space (archives it, showing stopped state without navigating away)
+	 * Stop the current space: terminates all running agent sessions, cancels
+	 * in-progress tasks and workflow runs, then archives the space.
 	 */
 	async stopSpace(): Promise<void> {
 		const spaceId = this.spaceId.value;
@@ -1577,7 +1578,7 @@ class SpaceStore {
 		const hub = connectionManager.getHubIfConnected();
 		if (!hub) throw new Error('Not connected');
 
-		const space = await hub.request<Space>('space.archive', { id: spaceId });
+		const space = await hub.request<Space>('space.stop', { id: spaceId });
 		if (space) {
 			this.space.value = space;
 			this.updateRuntimeState(space);


### PR DESCRIPTION
## What

- Limit recent tasks and sessions lists on the overview page to 5 items each (was 8)
- Add a proper **Stop** / **Start** runtime control alongside the existing Pause/Resume buttons

## Stop semantics

Stop ≠ Archive. A stopped space:
- Immediately terminates all active sessions and in-progress work
- Does **not** auto-start on daemon restart (unlike pause, which only blocks new work)
- Stays `status: 'active'` and can be restarted explicitly via the new **Start** button

## Changes

**Backend**
- `Space` type: new `stopped: boolean` field
- Migration 87: `ALTER TABLE spaces ADD COLUMN stopped INTEGER NOT NULL DEFAULT 0`
- `SpaceRepository`: `stopSpace()` / `startSpace()` methods
- `SpaceManager`: `stopSpace()` / `startSpace()` with idempotency guards
- `space.stop` RPC: terminates active work + sets `stopped=true`, emits `space.updated` (no longer archives)
- `space.start` RPC: clears `stopped` + `paused`, emits `space.updated`
- `SpaceRuntime` tick loop: skips spaces where `stopped || paused`

**Frontend**
- `space-store`: `updateRuntimeState` checks `space.stopped`; new `startSpace()` calling `space.start` RPC
- `SpaceOverview`: Start button shown when `runtimeState === 'stopped'`; Stop triggers a confirmation modal

**Tests**
- Daemon `space-handlers.test.ts`: updated `space.stop` expectations, added `space.start` suite
- Web `SpaceOverview.test.tsx`: Start button and `startSpace` call tests
- Web `space-store.test.ts`: `stopped: false` added to `makeSpace` helper