### PR TITLE
chore(deps): update all dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@testing-library/preact": "3.2.4",
         "knip": "6.4.1",
         "oxlint": "1.60.0",
-        "typescript": "6.0.2",
+        "typescript": "6.0.3",
       },
     },
     "packages/cli": {
@@ -101,7 +101,7 @@
         "@vitest/ui": "4.1.4",
         "happy-dom": "20.9.0",
         "tailwindcss": "4.2.2",
-        "typescript": "6.0.2",
+        "typescript": "6.0.3",
         "vite": "8.0.8",
         "vitest": "4.1.4",
       },
@@ -1142,7 +1142,7 @@
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
-    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "unbash": ["unbash@2.2.0", "", {}, "sha512-X2wH19RAPZE3+ldGicOkoj/SIA83OIxcJ6Cuaw23hf8Xc6fQpvZXY0SftE2JgS0QhYLUG4uwodSI3R53keyh7w=="],
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
 		"@testing-library/preact": "3.2.4",
 		"knip": "6.4.1",
 		"oxlint": "1.60.0",
-		"typescript": "6.0.2"
+		"typescript": "6.0.3"
 	}
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -34,7 +34,7 @@
 		"@vitest/ui": "4.1.4",
 		"happy-dom": "20.9.0",
 		"tailwindcss": "4.2.2",
-		"typescript": "6.0.2",
+		"typescript": "6.0.3",
 		"vite": "8.0.8",
 		"vitest": "4.1.4"
 	}


### PR DESCRIPTION
Updates `typescript` from `6.0.2` to `6.0.3` (patch release).

All other dependencies across all workspace packages are already at their latest stable versions — no further updates needed.

- `bun run typecheck` passes
- `make test-daemon` passes (10901 tests)
- `make test-web` passes (6988 tests)
- `bun run check` passes (lint + typecheck + knip)