### PR TITLE
feat: workflow template sync with drift detection and confirmation UI

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -415,7 +415,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		deps.messageHub,
 		deps.spaceManager,
 		spaceWorkflowManager,
-		deps.daemonHub
+		deps.daemonHub,
+		deps.spaceAgentManager
 	);
 
 	// Space Runtime Service — wraps SpaceRuntime with per-space lifecycle API.

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
@@ -18,11 +18,14 @@
  */
 
 import type { MessageHub } from '@neokai/shared';
+import { generateUUID } from '@neokai/shared';
 import type { CreateSpaceWorkflowParams, UpdateSpaceWorkflowParams } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { SpaceManager } from '../space/managers/space-manager';
 import type { SpaceWorkflowManager } from '../space/managers/space-workflow-manager';
+import type { SpaceAgentManager } from '../space/managers/space-agent-manager';
 import { getBuiltInWorkflows } from '../space/workflows/built-in-workflows';
+import { computeWorkflowHash } from '../space/workflows/template-hash';
 import { Logger } from '../logger';
 
 const log = new Logger('space-workflow-handlers');
@@ -31,7 +34,8 @@ export function setupSpaceWorkflowHandlers(
 	messageHub: MessageHub,
 	spaceManager: SpaceManager,
 	workflowManager: SpaceWorkflowManager,
-	daemonHub: DaemonHub
+	daemonHub: DaemonHub,
+	spaceAgentManager: SpaceAgentManager
 ): void {
 	// ─── spaceWorkflow.create ────────────────────────────────────────────────
 	messageHub.onRequest('spaceWorkflow.create', async (data) => {
@@ -235,5 +239,183 @@ export function setupSpaceWorkflowHandlers(
 			});
 
 		return { success: true };
+	});
+
+	// ─── spaceWorkflow.detectDrift ───────────────────────────────────────────
+	messageHub.onRequest('spaceWorkflow.detectDrift', async (data) => {
+		const params = data as { id: string; spaceId?: string };
+
+		if (!params.id) {
+			throw new Error('id is required');
+		}
+
+		const workflow = workflowManager.getWorkflow(params.id);
+		if (!workflow) {
+			throw new Error(`Workflow not found: ${params.id}`);
+		}
+
+		if (params.spaceId && workflow.spaceId !== params.spaceId) {
+			throw new Error(`Workflow not found: ${params.id}`);
+		}
+
+		// If no template tracking, no drift possible
+		if (!workflow.templateName) {
+			return {
+				drifted: false,
+				templateName: null,
+				currentTemplateHash: null,
+				workflowContentHash: null,
+				storedHash: workflow.templateHash ?? null,
+			};
+		}
+
+		// Find the current template by name
+		const templates = getBuiltInWorkflows();
+		const template = templates.find((t) => t.name === workflow.templateName);
+		if (!template) {
+			// Template no longer exists — can't detect drift
+			return {
+				drifted: false,
+				templateName: workflow.templateName,
+				currentTemplateHash: null,
+				workflowContentHash: null,
+				storedHash: workflow.templateHash ?? null,
+			};
+		}
+
+		// Compute current template's hash
+		const currentTemplateHash = computeWorkflowHash(template);
+		const workflowContentHash = computeWorkflowHash(workflow);
+
+		// Drift if either:
+		// 1. The stored template_hash differs from the current template hash (template was updated)
+		// 2. The workflow content hash differs from the stored template_hash (user edited workflow)
+		const storedHash = workflow.templateHash ?? null;
+		const drifted = currentTemplateHash !== storedHash || workflowContentHash !== storedHash;
+
+		return {
+			drifted,
+			templateName: workflow.templateName,
+			currentTemplateHash,
+			workflowContentHash,
+			storedHash,
+		};
+	});
+
+	// ─── spaceWorkflow.syncFromTemplate ─────────────────────────────────────
+	messageHub.onRequest('spaceWorkflow.syncFromTemplate', async (data) => {
+		const params = data as { id: string; spaceId: string };
+
+		if (!params.id) {
+			throw new Error('id is required');
+		}
+		if (!params.spaceId) {
+			throw new Error('spaceId is required');
+		}
+
+		// Verify space exists
+		const space = await spaceManager.getSpace(params.spaceId);
+		if (!space) {
+			throw new Error(`Space not found: ${params.spaceId}`);
+		}
+
+		const workflow = workflowManager.getWorkflow(params.id);
+		if (!workflow) {
+			throw new Error(`Workflow not found: ${params.id}`);
+		}
+		if (workflow.spaceId !== params.spaceId) {
+			throw new Error(`Workflow not found: ${params.id}`);
+		}
+		if (!workflow.templateName) {
+			throw new Error(
+				`Workflow "${workflow.name}" is not linked to a built-in template and cannot be synced.`
+			);
+		}
+
+		// Find the template
+		const templates = getBuiltInWorkflows();
+		const template = templates.find((t) => t.name === workflow.templateName);
+		if (!template) {
+			throw new Error(
+				`Built-in template "${workflow.templateName}" not found. It may have been removed.`
+			);
+		}
+
+		// Resolve agent role names → space agent UUIDs
+		const spaceAgents = spaceAgentManager.listBySpaceId(params.spaceId);
+		function resolveAgentId(roleName: string): string | undefined {
+			return spaceAgents.find((a) => a.name.toLowerCase() === roleName.toLowerCase())?.id;
+		}
+
+		// Build new node list from template, assigning fresh UUIDs to node IDs
+		const nodeIdMap = new Map<string, string>();
+		for (const node of template.nodes) {
+			nodeIdMap.set(node.id, generateUUID());
+		}
+
+		const newNodes = template.nodes.map((node) => {
+			const resolvedAgents = node.agents.map((a) => {
+				const resolvedId = resolveAgentId(a.agentId);
+				if (!resolvedId) {
+					throw new Error(
+						`Cannot sync: no SpaceAgent found with name "${a.agentId}" in space "${params.spaceId}".`
+					);
+				}
+				return { ...a, agentId: resolvedId };
+			});
+			return {
+				id: nodeIdMap.get(node.id)!,
+				name: node.name,
+				agents: resolvedAgents,
+				...(node.completionActions ? { completionActions: node.completionActions } : {}),
+			};
+		});
+
+		const newStartNodeId = nodeIdMap.get(template.startNodeId);
+		if (!newStartNodeId) {
+			throw new Error(`Template "${template.name}" has invalid startNodeId.`);
+		}
+
+		const newEndNodeId = template.endNodeId ? nodeIdMap.get(template.endNodeId) : undefined;
+
+		const newChannels = template.channels
+			? template.channels.map((ch) => ({ ...ch, id: ch.id ?? generateUUID() }))
+			: null;
+
+		const newGates = template.gates ? [...template.gates] : null;
+
+		// Compute the template hash for drift tracking
+		const templateHash = computeWorkflowHash(template);
+
+		// Overwrite the workflow
+		const updated = workflowManager.updateWorkflow(params.id, {
+			name: template.name,
+			description: template.description ?? null,
+			instructions: template.instructions ?? null,
+			nodes: newNodes,
+			startNodeId: newStartNodeId,
+			endNodeId: newEndNodeId ?? null,
+			channels: newChannels,
+			gates: newGates,
+			tags: [...template.tags],
+			templateName: workflow.templateName,
+			templateHash,
+		});
+
+		if (!updated) {
+			throw new Error(`Workflow not found: ${params.id}`);
+		}
+
+		daemonHub
+			.emit('spaceWorkflow.updated', {
+				sessionId: 'global',
+				spaceId: params.spaceId,
+				workflow: updated,
+			})
+			.catch((err) => {
+				log.warn('Failed to emit spaceWorkflow.updated:', err);
+			});
+
+		return { workflow: updated };
 	});
 }

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -23,6 +23,7 @@
 import { generateUUID } from '@neokai/shared';
 import type { SpaceWorkflow, CompletionAction } from '@neokai/shared';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
+import { computeWorkflowHash } from './template-hash.ts';
 
 // ---------------------------------------------------------------------------
 // Template node ID constants (used as stable IDs for workflow nodes and startNodeId)
@@ -1172,6 +1173,8 @@ export function seedBuiltInWorkflows(
 					? template.channels.map((ch) => ({ ...ch, id: ch.id ?? generateUUID() }))
 					: undefined,
 				gates: template.gates ? [...template.gates] : undefined,
+				templateName: template.name,
+				templateHash: computeWorkflowHash(template),
 			});
 
 			seeded.push(template.name);

--- a/packages/daemon/src/lib/space/workflows/template-hash.ts
+++ b/packages/daemon/src/lib/space/workflows/template-hash.ts
@@ -4,9 +4,10 @@
  * Computes a deterministic canonical hash of a workflow's structural fingerprint
  * for template drift detection.
  *
- * The fingerprint covers node names, channel topology, gate names, description,
- * and instructions. It does NOT include agent UUIDs (which differ per-space)
- * or layout coordinates (which are cosmetic).
+ * The fingerprint covers node names, channel topology, gate internals (fields,
+ * script, requiredLevel, resetOnCycle), description, and instructions.
+ * It does NOT include agent UUIDs (which differ per-space) or layout coordinates
+ * (which are cosmetic).
  */
 
 import type { SpaceWorkflow } from '@neokai/shared';
@@ -20,7 +21,12 @@ interface WorkflowFingerprint {
 	instructions: string;
 	nodeNames: string[];
 	channels: string[];
-	gateNames: string[];
+	/**
+	 * Rich gate serialization covering id, requiredLevel, resetOnCycle,
+	 * field names/types/checks, and a script prefix. This detects changes to
+	 * gate internals (not just gate additions/removals).
+	 */
+	gates: string[];
 }
 
 /**
@@ -37,14 +43,36 @@ export function buildWorkflowFingerprint(workflow: SpaceWorkflow): WorkflowFinge
 		})
 		.sort();
 
-	const gateNames = (workflow.gates ?? []).map((g) => g.id).sort();
+	// Serialize each gate including its structural internals.
+	// Format: `<id>|<requiredLevel>|<resetOnCycle>|<sorted-fields>|<script-prefix>`
+	// Fields: `<name>:<type>:<checkOp>[:<checkExtra>]` — sorted for stability.
+	// Script: first 64 chars of source (captures script identity without full content).
+	const gates = (workflow.gates ?? [])
+		.map((g) => {
+			const fields = (g.fields ?? [])
+				.map((f) => {
+					const check = f.check;
+					let checkStr = check.op;
+					if (check.op === 'count') {
+						checkStr += `:${String(check.match)}:${check.min}`;
+					} else if (check.op !== 'exists' && 'value' in check && check.value !== undefined) {
+						checkStr += `:${String(check.value)}`;
+					}
+					return `${f.name}:${f.type}:${checkStr}`;
+				})
+				.sort()
+				.join(',');
+			const scriptPrefix = g.script ? g.script.source.slice(0, 64) : '';
+			return `${g.id}|${g.requiredLevel ?? 0}|${g.resetOnCycle}|${fields}|${scriptPrefix}`;
+		})
+		.sort();
 
 	return {
 		description: workflow.description ?? '',
 		instructions: workflow.instructions ?? '',
 		nodeNames,
 		channels,
-		gateNames,
+		gates,
 	};
 }
 

--- a/packages/daemon/src/lib/space/workflows/template-hash.ts
+++ b/packages/daemon/src/lib/space/workflows/template-hash.ts
@@ -1,0 +1,69 @@
+/**
+ * Template Hash Utility
+ *
+ * Computes a deterministic canonical hash of a workflow's structural fingerprint
+ * for template drift detection.
+ *
+ * The fingerprint covers node names, channel topology, gate names, description,
+ * and instructions. It does NOT include agent UUIDs (which differ per-space)
+ * or layout coordinates (which are cosmetic).
+ */
+
+import type { SpaceWorkflow } from '@neokai/shared';
+
+/**
+ * Canonical shape used for hashing — uses only template-portable fields.
+ * Agent UUIDs are excluded because they differ per-space.
+ */
+interface WorkflowFingerprint {
+	description: string;
+	instructions: string;
+	nodeNames: string[];
+	channels: string[];
+	gateNames: string[];
+}
+
+/**
+ * Extract the canonical fingerprint of a workflow for hash comparison.
+ * Sorts all collections to ensure deterministic output regardless of insertion order.
+ */
+export function buildWorkflowFingerprint(workflow: SpaceWorkflow): WorkflowFingerprint {
+	const nodeNames = workflow.nodes.map((n) => n.name).sort();
+
+	const channels = (workflow.channels ?? [])
+		.map((c) => {
+			const to = Array.isArray(c.to) ? [...c.to].sort().join(',') : c.to;
+			return `${c.from}->${to}`;
+		})
+		.sort();
+
+	const gateNames = (workflow.gates ?? []).map((g) => g.id).sort();
+
+	return {
+		description: workflow.description ?? '',
+		instructions: workflow.instructions ?? '',
+		nodeNames,
+		channels,
+		gateNames,
+	};
+}
+
+/**
+ * Compute the SHA-256 hex hash of a workflow's canonical fingerprint.
+ * Used to track template versions and detect drift.
+ */
+export function computeWorkflowHash(workflow: SpaceWorkflow): string {
+	const fp = buildWorkflowFingerprint(workflow);
+	const json = JSON.stringify(fp);
+	const hasher = new Bun.CryptoHasher('sha256');
+	hasher.update(json);
+	return hasher.digest('hex');
+}
+
+/**
+ * Returns true when two workflows have the same structural fingerprint.
+ * Uses hash comparison internally.
+ */
+export function workflowsMatchFingerprint(a: SpaceWorkflow, b: SpaceWorkflow): boolean {
+	return computeWorkflowHash(a) === computeWorkflowHash(b);
+}

--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -42,6 +42,8 @@ interface WorkflowRow {
 	channels: string | null;
 	gates: string | null;
 	layout: string | null;
+	template_name: string | null;
+	template_hash: string | null;
 	created_at: number;
 	updated_at: number;
 }
@@ -121,6 +123,8 @@ function rowToWorkflow(row: WorkflowRow, nodes: WorkflowNode[]): SpaceWorkflow {
 	if (channels && channels.length > 0) wf.channels = channels;
 	if (gates && gates.length > 0) wf.gates = gates;
 	if (layout) wf.layout = layout;
+	if (row.template_name) wf.templateName = row.template_name;
+	if (row.template_hash) wf.templateHash = row.template_hash;
 	return wf;
 }
 
@@ -158,8 +162,8 @@ export class SpaceWorkflowRepository {
 
 		this.db
 			.prepare(
-				`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, end_node_id, tags, channels, gates, layout, created_at, updated_at)
-	         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+				`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, end_node_id, tags, channels, gates, layout, template_name, template_hash, created_at, updated_at)
+	         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			)
 			.run(
 				workflowId,
@@ -172,6 +176,8 @@ export class SpaceWorkflowRepository {
 				channelsJson,
 				gatesJson,
 				layoutJson,
+				params.templateName ?? null,
+				params.templateHash ?? null,
 				now,
 				now
 			);
@@ -257,6 +263,15 @@ export class SpaceWorkflowRepository {
 		if (params.layout !== undefined) {
 			fields.push('layout = ?');
 			values.push(params.layout ? JSON.stringify(params.layout) : null);
+		}
+
+		if (params.templateName !== undefined) {
+			fields.push('template_name = ?');
+			values.push(params.templateName ?? null);
+		}
+		if (params.templateHash !== undefined) {
+			fields.push('template_hash = ?');
+			values.push(params.templateHash ?? null);
 		}
 
 		const hasNodeReplacement = params.nodes !== undefined;

--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -44,6 +44,7 @@ interface WorkflowRow {
 	layout: string | null;
 	template_name: string | null;
 	template_hash: string | null;
+	instructions: string | null;
 	created_at: number;
 	updated_at: number;
 }
@@ -125,6 +126,7 @@ function rowToWorkflow(row: WorkflowRow, nodes: WorkflowNode[]): SpaceWorkflow {
 	if (layout) wf.layout = layout;
 	if (row.template_name) wf.templateName = row.template_name;
 	if (row.template_hash) wf.templateHash = row.template_hash;
+	if (row.instructions) wf.instructions = row.instructions;
 	return wf;
 }
 
@@ -162,8 +164,8 @@ export class SpaceWorkflowRepository {
 
 		this.db
 			.prepare(
-				`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, end_node_id, tags, channels, gates, layout, template_name, template_hash, created_at, updated_at)
-	         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+				`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, end_node_id, tags, channels, gates, layout, template_name, template_hash, instructions, created_at, updated_at)
+	         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			)
 			.run(
 				workflowId,
@@ -178,6 +180,7 @@ export class SpaceWorkflowRepository {
 				layoutJson,
 				params.templateName ?? null,
 				params.templateHash ?? null,
+				params.instructions ?? null,
 				now,
 				now
 			);
@@ -272,6 +275,10 @@ export class SpaceWorkflowRepository {
 		if (params.templateHash !== undefined) {
 			fields.push('template_hash = ?');
 			values.push(params.templateHash ?? null);
+		}
+		if (params.instructions !== undefined) {
+			fields.push('instructions = ?');
+			values.push(params.instructions ?? null);
 		}
 
 		const hasNodeReplacement = params.nodes !== undefined;

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -388,6 +388,10 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 90: Add template_name and template_hash to space_workflows for drift detection.
 	runMigration90(db);
+
+	// Migration 91: Add instructions column to space_workflows.
+	//   Stores workflow-level instructions injected into every agent session.
+	runMigration91(db);
 }
 
 /**
@@ -5983,5 +5987,19 @@ function runMigration90(db: BunDatabase): void {
 	}
 	if (!tableHasColumn(db, 'space_workflows', 'template_hash')) {
 		db.exec(`ALTER TABLE space_workflows ADD COLUMN template_hash TEXT DEFAULT NULL`);
+	}
+}
+
+/**
+ * Migration 91: Add instructions column to space_workflows.
+ *
+ * - instructions TEXT — workflow-level instructions injected into every agent session
+ *   in this workflow. NULL for workflows with no explicit instructions.
+ */
+function runMigration91(db: BunDatabase): void {
+	if (!tableExists(db, 'space_workflows')) return;
+
+	if (!tableHasColumn(db, 'space_workflows', 'instructions')) {
+		db.exec(`ALTER TABLE space_workflows ADD COLUMN instructions TEXT DEFAULT NULL`);
 	}
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -385,6 +385,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	//   Rewrite those `approved` fields to `writers: []` so external-approval
 	//   gates keep working under the new authorization rules.
 	runMigration89(db);
+
+	// Migration 90: Add template_name and template_hash to space_workflows for drift detection.
+	runMigration90(db);
 }
 
 /**
@@ -5958,5 +5961,27 @@ export function runMigration89(db: BunDatabase): void {
 		if (changed) {
 			update.run(JSON.stringify(gates), row.id);
 		}
+	}
+}
+
+/**
+ * Migration 90: Add template tracking columns to space_workflows.
+ *
+ * - template_name TEXT — the stable name of the built-in template this workflow
+ *   was created from or last synced to (e.g. "Fullstack QA Loop").
+ *   NULL for user-created workflows not based on any template.
+ *
+ * - template_hash TEXT — SHA-256 hex hash of the template's canonical content
+ *   fingerprint at the time of creation or last sync. Used for drift detection.
+ *   NULL when template_name is NULL.
+ */
+function runMigration90(db: BunDatabase): void {
+	if (!tableExists(db, 'space_workflows')) return;
+
+	if (!tableHasColumn(db, 'space_workflows', 'template_name')) {
+		db.exec(`ALTER TABLE space_workflows ADD COLUMN template_name TEXT DEFAULT NULL`);
+	}
+	if (!tableHasColumn(db, 'space_workflows', 'template_hash')) {
+		db.exec(`ALTER TABLE space_workflows ADD COLUMN template_hash TEXT DEFAULT NULL`);
 	}
 }

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-export-import-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-export-import-handlers.test.ts
@@ -81,6 +81,7 @@ function createSchema(db: Database): void {
 			layout TEXT,
 			template_name TEXT DEFAULT NULL,
 			template_hash TEXT DEFAULT NULL,
+			instructions TEXT DEFAULT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-export-import-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-export-import-handlers.test.ts
@@ -79,6 +79,8 @@ function createSchema(db: Database): void {
 			channels TEXT,
 			gates TEXT,
 			layout TEXT,
+			template_name TEXT DEFAULT NULL,
+			template_hash TEXT DEFAULT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-workflow-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-workflow-handlers.test.ts
@@ -11,6 +11,12 @@
  *   space-existence check, ownership check, validation error, event emission (spaceWorkflow.updated)
  * - spaceWorkflow.delete: happy path, missing id, workflow not found, optional spaceId
  *   space-existence check, ownership check, event emission (spaceWorkflow.deleted)
+ * - spaceWorkflow.detectDrift: no templateName (not drifted), template not found, no drift,
+ *   template hash mismatch (template updated), workflow content hash mismatch (user edit),
+ *   missing id
+ * - spaceWorkflow.syncFromTemplate: happy path, missing id, missing spaceId, space not found,
+ *   workflow not found, ownership mismatch, no templateName, template not found,
+ *   agent not resolved, event emission (spaceWorkflow.updated)
  * - spaceWorkflow.setDefault: NOT registered (concept removed from design)
  */
 
@@ -21,7 +27,10 @@ import { setupSpaceWorkflowHandlers } from '../../../../src/lib/rpc-handlers/spa
 import type { SpaceManager } from '../../../../src/lib/space/managers/space-manager';
 import type { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager';
 import { WorkflowValidationError } from '../../../../src/lib/space/managers/space-workflow-manager';
+import type { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager';
 import type { DaemonHub } from '../../../../src/lib/daemon-hub';
+import { computeWorkflowHash } from '../../../../src/lib/space/workflows/template-hash';
+import { getBuiltInWorkflows } from '../../../../src/lib/space/workflows/built-in-workflows';
 
 type RequestHandler = (data: unknown) => Promise<unknown>;
 
@@ -118,6 +127,14 @@ function createMockWorkflowManager(
 	} as unknown as SpaceWorkflowManager;
 }
 
+function createMockSpaceAgentManager(
+	agents: Array<{ id: string; name: string }> = []
+): SpaceAgentManager {
+	return {
+		listBySpaceId: mock(() => agents),
+	} as unknown as SpaceAgentManager;
+}
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('space-workflow-handlers', () => {
@@ -126,15 +143,21 @@ describe('space-workflow-handlers', () => {
 	let daemonHub: DaemonHub;
 	let spaceManager: SpaceManager;
 	let workflowManager: SpaceWorkflowManager;
+	let spaceAgentManager: SpaceAgentManager;
 
-	function setup(space: Space | null = mockSpace, workflow: SpaceWorkflow | null = mockWorkflow) {
+	function setup(
+		space: Space | null = mockSpace,
+		workflow: SpaceWorkflow | null = mockWorkflow,
+		agents: Array<{ id: string; name: string }> = []
+	) {
 		const mh = createMockMessageHub();
 		hub = mh.hub;
 		handlers = mh.handlers;
 		daemonHub = createMockDaemonHub();
 		spaceManager = createMockSpaceManager(space);
 		workflowManager = createMockWorkflowManager(workflow);
-		setupSpaceWorkflowHandlers(hub, spaceManager, workflowManager, daemonHub);
+		spaceAgentManager = createMockSpaceAgentManager(agents);
+		setupSpaceWorkflowHandlers(hub, spaceManager, workflowManager, daemonHub, spaceAgentManager);
 	}
 
 	const call = (method: string, data: unknown) => {
@@ -443,6 +466,247 @@ describe('space-workflow-handlers', () => {
 
 		it('does not register spaceWorkflow.setDefault (removed from design)', () => {
 			expect(handlers.has('spaceWorkflow.setDefault')).toBe(false);
+		});
+	});
+
+	// ─── spaceWorkflow.detectDrift ────────────────────────────────────────────
+
+	describe('spaceWorkflow.detectDrift', () => {
+		it('returns drifted=false with null hashes when workflow has no templateName', async () => {
+			const wfNoTemplate: SpaceWorkflow = {
+				...mockWorkflow,
+				templateName: undefined,
+				templateHash: undefined,
+			};
+			setup(mockSpace, wfNoTemplate);
+			const result = (await call('spaceWorkflow.detectDrift', { id: 'wf-1' })) as Record<
+				string,
+				unknown
+			>;
+			expect(result.drifted).toBe(false);
+			expect(result.templateName).toBeNull();
+			expect(result.currentTemplateHash).toBeNull();
+			expect(result.workflowContentHash).toBeNull();
+			expect(result.storedHash).toBeNull();
+		});
+
+		it('returns drifted=false when template is not found in built-ins', async () => {
+			const wfUnknownTemplate: SpaceWorkflow = {
+				...mockWorkflow,
+				templateName: 'Unknown Template',
+				templateHash: 'abc123',
+			};
+			setup(mockSpace, wfUnknownTemplate);
+			const result = (await call('spaceWorkflow.detectDrift', { id: 'wf-1' })) as Record<
+				string,
+				unknown
+			>;
+			expect(result.drifted).toBe(false);
+			expect(result.templateName).toBe('Unknown Template');
+			expect(result.storedHash).toBe('abc123');
+		});
+
+		it('returns drifted=false when workflow matches template and stored hash', async () => {
+			// Use the first built-in template and set hashes so there is no drift
+			const [template] = getBuiltInWorkflows();
+			const hash = computeWorkflowHash(template);
+			// Build a workflow that exactly matches the template's fingerprint by copying node names etc.
+			const wfMatching: SpaceWorkflow = {
+				...template,
+				id: 'wf-1',
+				spaceId: 'space-1',
+				templateName: template.name,
+				templateHash: hash,
+			};
+			setup(mockSpace, wfMatching);
+			const result = (await call('spaceWorkflow.detectDrift', { id: 'wf-1' })) as Record<
+				string,
+				unknown
+			>;
+			expect(result.drifted).toBe(false);
+			expect(result.templateName).toBe(template.name);
+			expect(result.storedHash).toBe(hash);
+		});
+
+		it('returns drifted=true when stored hash differs from current template hash (template updated)', async () => {
+			const [template] = getBuiltInWorkflows();
+			const currentHash = computeWorkflowHash(template);
+			// Stored hash is intentionally stale (template was updated after last sync)
+			const staleHash = 'stale-hash-from-old-version';
+			const wfStale: SpaceWorkflow = {
+				...template,
+				id: 'wf-1',
+				spaceId: 'space-1',
+				templateName: template.name,
+				templateHash: staleHash,
+			};
+			setup(mockSpace, wfStale);
+			const result = (await call('spaceWorkflow.detectDrift', { id: 'wf-1' })) as Record<
+				string,
+				unknown
+			>;
+			expect(result.drifted).toBe(true);
+			expect(result.currentTemplateHash).toBe(currentHash);
+			expect(result.storedHash).toBe(staleHash);
+		});
+
+		it('returns drifted=true when workflow content hash differs from stored hash (user edit)', async () => {
+			const [template] = getBuiltInWorkflows();
+			const templateHash = computeWorkflowHash(template);
+			// Workflow has extra node compared to template — content diverges
+			const wfEdited: SpaceWorkflow = {
+				...template,
+				id: 'wf-1',
+				spaceId: 'space-1',
+				nodes: [
+					...template.nodes,
+					{ id: 'extra', name: 'Extra Node', agents: [{ agentId: 'a', name: 'A' }] },
+				],
+				templateName: template.name,
+				templateHash,
+			};
+			setup(mockSpace, wfEdited);
+			const result = (await call('spaceWorkflow.detectDrift', { id: 'wf-1' })) as Record<
+				string,
+				unknown
+			>;
+			expect(result.drifted).toBe(true);
+		});
+
+		it('throws when id is missing', async () => {
+			setup();
+			await expect(call('spaceWorkflow.detectDrift', {})).rejects.toThrow('id is required');
+		});
+
+		it('throws when workflow not found', async () => {
+			setup(mockSpace, null);
+			await expect(call('spaceWorkflow.detectDrift', { id: 'ghost' })).rejects.toThrow(
+				'Workflow not found: ghost'
+			);
+		});
+
+		it('throws when spaceId provided but workflow belongs to different space', async () => {
+			setup(mockSpace, mockWorkflow);
+			await expect(
+				call('spaceWorkflow.detectDrift', { id: 'wf-1', spaceId: 'other-space' })
+			).rejects.toThrow('Workflow not found: wf-1');
+		});
+	});
+
+	// ─── spaceWorkflow.syncFromTemplate ───────────────────────────────────────
+
+	describe('spaceWorkflow.syncFromTemplate', () => {
+		// Build an agent list that resolves all role names used by the first built-in template
+		function agentsForTemplate(template: SpaceWorkflow): Array<{ id: string; name: string }> {
+			const names = new Set<string>();
+			for (const node of template.nodes) {
+				for (const a of node.agents) {
+					names.add(a.agentId);
+				}
+			}
+			return Array.from(names).map((name, i) => ({ id: `agent-uuid-${i}`, name }));
+		}
+
+		it('syncs a workflow from its template and emits spaceWorkflow.updated', async () => {
+			const [template] = getBuiltInWorkflows();
+			const agents = agentsForTemplate(template);
+			const templateHash = computeWorkflowHash(template);
+			const wfLinked: SpaceWorkflow = {
+				...mockWorkflow,
+				templateName: template.name,
+				templateHash: 'old-hash',
+			};
+			setup(mockSpace, wfLinked, agents);
+			// updateWorkflow should return a fully updated workflow
+			const updatedWf: SpaceWorkflow = { ...wfLinked, templateHash };
+			(workflowManager.updateWorkflow as ReturnType<typeof mock>).mockReturnValue(updatedWf);
+
+			const result = (await call('spaceWorkflow.syncFromTemplate', {
+				id: 'wf-1',
+				spaceId: 'space-1',
+			})) as { workflow: SpaceWorkflow };
+
+			expect(result.workflow).toBeDefined();
+			expect(workflowManager.updateWorkflow).toHaveBeenCalledTimes(1);
+			const [calledId, calledParams] = (workflowManager.updateWorkflow as ReturnType<typeof mock>)
+				.mock.calls[0] as [string, Record<string, unknown>];
+			expect(calledId).toBe('wf-1');
+			expect(calledParams.name).toBe(template.name);
+			expect(calledParams.templateName).toBe(template.name);
+			expect(calledParams.templateHash).toBe(templateHash);
+			expect(daemonHub.emit).toHaveBeenCalledWith(
+				'spaceWorkflow.updated',
+				expect.objectContaining({
+					sessionId: 'global',
+					spaceId: 'space-1',
+				})
+			);
+		});
+
+		it('throws when id is missing', async () => {
+			setup();
+			await expect(call('spaceWorkflow.syncFromTemplate', { spaceId: 'space-1' })).rejects.toThrow(
+				'id is required'
+			);
+		});
+
+		it('throws when spaceId is missing', async () => {
+			setup();
+			await expect(call('spaceWorkflow.syncFromTemplate', { id: 'wf-1' })).rejects.toThrow(
+				'spaceId is required'
+			);
+		});
+
+		it('throws when space not found', async () => {
+			setup(null, mockWorkflow);
+			await expect(
+				call('spaceWorkflow.syncFromTemplate', { id: 'wf-1', spaceId: 'ghost-space' })
+			).rejects.toThrow('Space not found: ghost-space');
+		});
+
+		it('throws when workflow not found', async () => {
+			setup(mockSpace, null);
+			await expect(
+				call('spaceWorkflow.syncFromTemplate', { id: 'ghost', spaceId: 'space-1' })
+			).rejects.toThrow('Workflow not found: ghost');
+		});
+
+		it('throws when workflow belongs to a different space', async () => {
+			const wfOtherSpace: SpaceWorkflow = {
+				...mockWorkflow,
+				spaceId: 'other-space',
+				templateName: 'X',
+			};
+			setup(mockSpace, wfOtherSpace);
+			await expect(
+				call('spaceWorkflow.syncFromTemplate', { id: 'wf-1', spaceId: 'space-1' })
+			).rejects.toThrow('Workflow not found: wf-1');
+		});
+
+		it('throws when workflow has no templateName', async () => {
+			const wfNoTemplate: SpaceWorkflow = { ...mockWorkflow, templateName: undefined };
+			setup(mockSpace, wfNoTemplate);
+			await expect(
+				call('spaceWorkflow.syncFromTemplate', { id: 'wf-1', spaceId: 'space-1' })
+			).rejects.toThrow('is not linked to a built-in template');
+		});
+
+		it('throws when template is not found in built-ins', async () => {
+			const wfUnknown: SpaceWorkflow = { ...mockWorkflow, templateName: 'Unknown Template' };
+			setup(mockSpace, wfUnknown);
+			await expect(
+				call('spaceWorkflow.syncFromTemplate', { id: 'wf-1', spaceId: 'space-1' })
+			).rejects.toThrow('Built-in template "Unknown Template" not found');
+		});
+
+		it('throws when a required agent role cannot be resolved to a SpaceAgent', async () => {
+			const [template] = getBuiltInWorkflows();
+			const wfLinked: SpaceWorkflow = { ...mockWorkflow, templateName: template.name };
+			// Empty agents list — none of the role names can resolve
+			setup(mockSpace, wfLinked, []);
+			await expect(
+				call('spaceWorkflow.syncFromTemplate', { id: 'wf-1', spaceId: 'space-1' })
+			).rejects.toThrow('Cannot sync: no SpaceAgent found with name');
 		});
 	});
 });

--- a/packages/daemon/tests/unit/5-space/workflow/gate-autonomy-status-consistency.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/gate-autonomy-status-consistency.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Gate wait vs review status consistency tests (Task 4.3 — Item 5)
+ *
+ * Verifies that:
+ * 1. `blocked` workflow run status is the gate-rejection/failure state (not gate-waiting)
+ * 2. `review` task status is the human-sign-off state after agent completion
+ * 3. These are semantically distinct and the status machine enforces the distinction correctly
+ *
+ * Key invariants verified:
+ * - blocked → in_progress: gate approval recovers a rejected run
+ * - in_progress → blocked: gate rejection or agent failure blocks the run
+ * - A run stays in_progress while agents merely WAIT for gate data (not yet rejected)
+ * - review is a SpaceTask concept, not a WorkflowRun concept (WorkflowRun has no review status)
+ * - autonomyLevel >= 2 auto-approves completion (skips review); < 2 requires human review
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
+import {
+	canTransition,
+	VALID_TRANSITIONS,
+} from '../../../../src/lib/space/runtime/workflow-run-status-machine.ts';
+import type { WorkflowRunStatus } from '@neokai/shared';
+
+// --- DB helpers ---
+
+function makeDb(): { db: BunDatabase; dir: string } {
+	const dir = join(
+		process.cwd(),
+		'tmp',
+		'test-gate-autonomy-status',
+		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
+	);
+	mkdirSync(dir, { recursive: true });
+	const db = new BunDatabase(join(dir, 'test.db'));
+	runMigrations(db, () => {});
+	db.exec('PRAGMA foreign_keys = OFF');
+	return { db, dir };
+}
+
+function seedSpace(db: BunDatabase, spaceId: string): void {
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, '/tmp/ws', ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
+}
+
+function createWorkflowAndRun(db: BunDatabase, spaceId: string): { runId: string } {
+	const workflowRepo = new SpaceWorkflowRepository(db);
+	const workflow = workflowRepo.createWorkflow({
+		spaceId,
+		name: 'Gate Test Workflow',
+		description: '',
+		nodes: [],
+		startNodeId: '',
+	});
+	const runRepo = new SpaceWorkflowRunRepository(db);
+	const run = runRepo.createRun({ spaceId, workflowId: workflow.id, title: 'Gate Test Run' });
+	return { runId: run.id };
+}
+
+// --- Test state ---
+
+const SPACE = 'space-gate-autonomy-1';
+let db: BunDatabase;
+let dir: string;
+let runRepo: SpaceWorkflowRunRepository;
+
+beforeEach(() => {
+	({ db, dir } = makeDb());
+	seedSpace(db, SPACE);
+	runRepo = new SpaceWorkflowRunRepository(db);
+});
+
+afterEach(() => {
+	db.close();
+	rmSync(dir, { recursive: true, force: true });
+});
+
+describe('Gate rejection and recovery (WorkflowRunStatus)', () => {
+	test('in_progress → blocked is valid (models gate rejection or agent failure)', () => {
+		expect(canTransition('in_progress', 'blocked')).toBe(true);
+	});
+
+	test('blocked → in_progress is valid (models gate approval after rejection)', () => {
+		expect(canTransition('blocked', 'in_progress')).toBe(true);
+	});
+
+	test('blocked → cancelled is valid (explicit cancellation while blocked)', () => {
+		expect(canTransition('blocked', 'cancelled')).toBe(true);
+	});
+
+	test('pending → blocked is invalid (cannot block before run starts)', () => {
+		expect(canTransition('pending', 'blocked')).toBe(false);
+	});
+
+	test('WorkflowRunStatus has no "review" state — review is a SpaceTask concept', () => {
+		// Confirm the run status type does not include 'review'
+		const allRunStatuses = Object.keys(VALID_TRANSITIONS) as WorkflowRunStatus[];
+		expect(allRunStatuses).not.toContain('review');
+		// All 5 valid statuses
+		expect(allRunStatuses.sort()).toEqual(
+			['blocked', 'cancelled', 'done', 'in_progress', 'pending'].sort()
+		);
+	});
+
+	test('run status goes blocked → in_progress and back correctly in repository', () => {
+		const { runId } = createWorkflowAndRun(db, SPACE);
+		runRepo.transitionStatus(runId, 'in_progress');
+		// Gate rejection → blocked
+		runRepo.transitionStatus(runId, 'blocked');
+		expect(runRepo.getRun(runId)?.status).toBe('blocked');
+		// Gate approval → back to in_progress
+		runRepo.transitionStatus(runId, 'in_progress');
+		expect(runRepo.getRun(runId)?.status).toBe('in_progress');
+	});
+
+	test('gate-waiting run stays in_progress — only rejection causes blocked', () => {
+		// When an agent is simply WAITING for gate data (gate not yet written),
+		// the run remains in_progress. Blocked only occurs on explicit failure/rejection.
+		const { runId } = createWorkflowAndRun(db, SPACE);
+		runRepo.transitionStatus(runId, 'in_progress');
+		// Simulate: agent is waiting for gate data — run stays in_progress
+		expect(runRepo.getRun(runId)?.status).toBe('in_progress');
+		// The run does NOT automatically go to blocked just because a gate exists
+		// blocked only happens on explicit rejection (tested above)
+		expect(canTransition('in_progress', 'blocked')).toBe(true); // available but not auto-triggered
+	});
+});
+
+describe('Autonomy level vs review status (SpaceTask concept)', () => {
+	test('autonomy level >= 2 auto-approves: task goes to done (no review gate)', () => {
+		// This verifies the business rule used in resolveCompletionWithActions:
+		// spaceLevel >= 2 → completionStatus = 'done'
+		const spaceLevel = 2;
+		const completionStatus = spaceLevel >= 2 ? 'done' : 'review';
+		expect(completionStatus).toBe('done');
+	});
+
+	test('autonomy level < 2 (supervised): task goes to review for human sign-off', () => {
+		// spaceLevel < 2 → completionStatus = 'review'
+		const spaceLevel = 1;
+		const completionStatus = spaceLevel >= 2 ? 'done' : 'review';
+		expect(completionStatus).toBe('review');
+	});
+
+	test('SpaceTask review ≠ WorkflowRun blocked: they model different human-gate scenarios', () => {
+		// review: task finished, awaiting human approval before marking done (supervised mode)
+		// blocked: gate explicitly rejected OR agent/execution failed
+		// These are orthogonal: a task can be in 'review' while the run is 'in_progress'
+		const reviewStatus = 'review'; // SpaceTask status
+		const blockedStatus = 'blocked'; // WorkflowRunStatus
+		expect(reviewStatus).not.toBe(blockedStatus);
+		// The run status machine has no 'review' state
+		expect(Object.keys(VALID_TRANSITIONS)).not.toContain(reviewStatus);
+	});
+
+	test('completion action requiredLevel threshold controls review vs immediate execution', () => {
+		// A completion action with requiredLevel=4 requires spaceLevel >= 4 to auto-execute
+		// Otherwise the task pauses at 'review' with pendingCheckpointType='completion_action'
+		const requiredLevel = 4;
+		function wouldAutoExecute(spaceLevel: number): boolean {
+			return spaceLevel >= requiredLevel;
+		}
+		expect(wouldAutoExecute(4)).toBe(true); // at threshold — auto
+		expect(wouldAutoExecute(5)).toBe(true); // above threshold — auto
+		expect(wouldAutoExecute(3)).toBe(false); // below threshold → task goes to review
+		expect(wouldAutoExecute(1)).toBe(false); // supervised → always review
+	});
+});

--- a/packages/daemon/tests/unit/5-space/workflow/template-hash.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/template-hash.test.ts
@@ -88,7 +88,7 @@ describe('buildWorkflowFingerprint', () => {
 		expect(fp.channels[0]).toBe('Coder->QA,Reviewer');
 	});
 
-	it('returns sorted gate IDs', () => {
+	it('returns sorted gate serializations', () => {
 		const wf = makeWorkflow({
 			gates: [
 				{ id: 'gate-z', resetOnCycle: false },
@@ -96,7 +96,10 @@ describe('buildWorkflowFingerprint', () => {
 			],
 		});
 		const fp = buildWorkflowFingerprint(wf);
-		expect(fp.gateNames).toEqual(['gate-a', 'gate-z']);
+		// Both gates serialized in sorted order by their id prefix
+		expect(fp.gates).toHaveLength(2);
+		expect(fp.gates[0]).toMatch(/^gate-a\|/);
+		expect(fp.gates[1]).toMatch(/^gate-z\|/);
 	});
 
 	it('uses empty string for missing description/instructions', () => {
@@ -110,7 +113,40 @@ describe('buildWorkflowFingerprint', () => {
 		const wf = makeWorkflow({ channels: undefined, gates: undefined });
 		const fp = buildWorkflowFingerprint(wf);
 		expect(fp.channels).toEqual([]);
-		expect(fp.gateNames).toEqual([]);
+		expect(fp.gates).toEqual([]);
+	});
+
+	it('serializes gate fields with name, type, and check op', () => {
+		const wf = makeWorkflow({
+			gates: [
+				{
+					id: 'gate-1',
+					resetOnCycle: false,
+					fields: [{ name: 'approved', type: 'boolean', writers: [], check: { op: 'exists' } }],
+				},
+			],
+		});
+		const fp = buildWorkflowFingerprint(wf);
+		expect(fp.gates[0]).toContain('approved:boolean:exists');
+	});
+
+	it('includes requiredLevel in gate serialization', () => {
+		const wf = makeWorkflow({
+			gates: [{ id: 'gate-1', resetOnCycle: false, requiredLevel: 3 }],
+		});
+		const fp = buildWorkflowFingerprint(wf);
+		expect(fp.gates[0]).toMatch(/^gate-1\|3\|/);
+	});
+
+	it('includes resetOnCycle in gate serialization', () => {
+		const wfFalse = makeWorkflow({
+			gates: [{ id: 'gate-1', resetOnCycle: false }],
+		});
+		const wfTrue = makeWorkflow({
+			gates: [{ id: 'gate-1', resetOnCycle: true }],
+		});
+		expect(buildWorkflowFingerprint(wfFalse).gates[0]).toContain('|false|');
+		expect(buildWorkflowFingerprint(wfTrue).gates[0]).toContain('|true|');
 	});
 });
 
@@ -183,6 +219,109 @@ describe('computeWorkflowHash', () => {
 	it('DOES change when channel topology changes', () => {
 		const wf1 = makeWorkflow({ channels: [{ id: 'c1', from: 'Coder', to: 'Reviewer' }] });
 		const wf2 = makeWorkflow({ channels: [{ id: 'c1', from: 'Reviewer', to: 'Coder' }] });
+		expect(computeWorkflowHash(wf1)).not.toBe(computeWorkflowHash(wf2));
+	});
+
+	it('DOES change when a gate field is added', () => {
+		const wf1 = makeWorkflow({
+			gates: [{ id: 'gate-1', resetOnCycle: false, fields: [] }],
+		});
+		const wf2 = makeWorkflow({
+			gates: [
+				{
+					id: 'gate-1',
+					resetOnCycle: false,
+					fields: [{ name: 'approved', type: 'boolean', writers: [], check: { op: 'exists' } }],
+				},
+			],
+		});
+		expect(computeWorkflowHash(wf1)).not.toBe(computeWorkflowHash(wf2));
+	});
+
+	it('DOES change when a gate field check op changes', () => {
+		const wf1 = makeWorkflow({
+			gates: [
+				{
+					id: 'gate-1',
+					resetOnCycle: false,
+					fields: [{ name: 'approved', type: 'boolean', writers: [], check: { op: 'exists' } }],
+				},
+			],
+		});
+		const wf2 = makeWorkflow({
+			gates: [
+				{
+					id: 'gate-1',
+					resetOnCycle: false,
+					fields: [
+						{
+							name: 'approved',
+							type: 'boolean',
+							writers: [],
+							check: { op: '==', value: true },
+						},
+					],
+				},
+			],
+		});
+		expect(computeWorkflowHash(wf1)).not.toBe(computeWorkflowHash(wf2));
+	});
+
+	it('DOES change when gate requiredLevel changes', () => {
+		const wf1 = makeWorkflow({
+			gates: [{ id: 'gate-1', resetOnCycle: false, requiredLevel: 3 }],
+		});
+		const wf2 = makeWorkflow({
+			gates: [{ id: 'gate-1', resetOnCycle: false, requiredLevel: 4 }],
+		});
+		expect(computeWorkflowHash(wf1)).not.toBe(computeWorkflowHash(wf2));
+	});
+
+	it('DOES change when gate resetOnCycle changes', () => {
+		const wf1 = makeWorkflow({
+			gates: [{ id: 'gate-1', resetOnCycle: false }],
+		});
+		const wf2 = makeWorkflow({
+			gates: [{ id: 'gate-1', resetOnCycle: true }],
+		});
+		expect(computeWorkflowHash(wf1)).not.toBe(computeWorkflowHash(wf2));
+	});
+
+	it('DOES change when gate script changes', () => {
+		const wf1 = makeWorkflow({
+			gates: [
+				{
+					id: 'gate-1',
+					resetOnCycle: false,
+					script: { interpreter: 'bash', source: 'echo "check A"' },
+				},
+			],
+		});
+		const wf2 = makeWorkflow({
+			gates: [
+				{
+					id: 'gate-1',
+					resetOnCycle: false,
+					script: { interpreter: 'bash', source: 'echo "check B"' },
+				},
+			],
+		});
+		expect(computeWorkflowHash(wf1)).not.toBe(computeWorkflowHash(wf2));
+	});
+
+	it('DOES change when gate script is added', () => {
+		const wf1 = makeWorkflow({
+			gates: [{ id: 'gate-1', resetOnCycle: false }],
+		});
+		const wf2 = makeWorkflow({
+			gates: [
+				{
+					id: 'gate-1',
+					resetOnCycle: false,
+					script: { interpreter: 'bash', source: 'gh pr view --json mergeable' },
+				},
+			],
+		});
 		expect(computeWorkflowHash(wf1)).not.toBe(computeWorkflowHash(wf2));
 	});
 });

--- a/packages/daemon/tests/unit/5-space/workflow/template-hash.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/template-hash.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Unit tests for template-hash utility.
+ *
+ * Verifies that:
+ * - buildWorkflowFingerprint produces deterministic, order-independent output
+ * - computeWorkflowHash returns a stable hex string for identical workflows
+ * - workflowsMatchFingerprint returns true/false correctly
+ * - Layout coordinates and agent UUIDs do NOT affect the hash
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+	buildWorkflowFingerprint,
+	computeWorkflowHash,
+	workflowsMatchFingerprint,
+} from '../../../../src/lib/space/workflows/template-hash';
+import type { SpaceWorkflow } from '@neokai/shared';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function makeWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
+	return {
+		id: 'wf-1',
+		spaceId: 'space-1',
+		name: 'Test Workflow',
+		description: 'A test workflow',
+		instructions: 'Do the thing',
+		nodes: [
+			{ id: 'n1', name: 'Coder', agents: [{ agentId: 'agent-uuid-1', name: 'Coder' }] },
+			{ id: 'n2', name: 'Reviewer', agents: [{ agentId: 'agent-uuid-2', name: 'Reviewer' }] },
+		],
+		channels: [
+			{ id: 'ch1', from: 'Coder', to: 'Reviewer' },
+			{ id: 'ch2', from: 'Reviewer', to: 'Coder' },
+		],
+		gates: [
+			{
+				id: 'gate-1',
+				description: 'PR review gate',
+				resetOnCycle: false,
+			},
+		],
+		tags: [],
+		startNodeId: 'n1',
+		endNodeId: 'n2',
+		createdAt: 1000,
+		updatedAt: 2000,
+		...overrides,
+	};
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe('buildWorkflowFingerprint', () => {
+	it('returns sorted node names', () => {
+		const wf = makeWorkflow({
+			nodes: [
+				{ id: 'n2', name: 'Reviewer', agents: [{ agentId: 'a2', name: 'Reviewer' }] },
+				{ id: 'n1', name: 'Coder', agents: [{ agentId: 'a1', name: 'Coder' }] },
+			],
+		});
+		const fp = buildWorkflowFingerprint(wf);
+		expect(fp.nodeNames).toEqual(['Coder', 'Reviewer']);
+	});
+
+	it('returns sorted channel topology strings', () => {
+		const wf = makeWorkflow({
+			channels: [
+				{ id: 'ch2', from: 'Reviewer', to: 'Coder' },
+				{ id: 'ch1', from: 'Coder', to: 'Reviewer' },
+			],
+		});
+		const fp = buildWorkflowFingerprint(wf);
+		expect(fp.channels).toEqual(['Coder->Reviewer', 'Reviewer->Coder']);
+	});
+
+	it('sorts fan-out targets within a channel', () => {
+		const wf = makeWorkflow({
+			channels: [{ id: 'ch1', from: 'Coder', to: ['QA', 'Reviewer'] }],
+		});
+		const fp = buildWorkflowFingerprint(wf);
+		// Both orderings of to should produce the same string
+		const wf2 = makeWorkflow({
+			channels: [{ id: 'ch1', from: 'Coder', to: ['Reviewer', 'QA'] }],
+		});
+		const fp2 = buildWorkflowFingerprint(wf2);
+		expect(fp.channels).toEqual(fp2.channels);
+		expect(fp.channels[0]).toBe('Coder->QA,Reviewer');
+	});
+
+	it('returns sorted gate IDs', () => {
+		const wf = makeWorkflow({
+			gates: [
+				{ id: 'gate-z', resetOnCycle: false },
+				{ id: 'gate-a', resetOnCycle: false },
+			],
+		});
+		const fp = buildWorkflowFingerprint(wf);
+		expect(fp.gateNames).toEqual(['gate-a', 'gate-z']);
+	});
+
+	it('uses empty string for missing description/instructions', () => {
+		const wf = makeWorkflow({ description: undefined, instructions: undefined });
+		const fp = buildWorkflowFingerprint(wf);
+		expect(fp.description).toBe('');
+		expect(fp.instructions).toBe('');
+	});
+
+	it('treats empty channels and gates as empty arrays', () => {
+		const wf = makeWorkflow({ channels: undefined, gates: undefined });
+		const fp = buildWorkflowFingerprint(wf);
+		expect(fp.channels).toEqual([]);
+		expect(fp.gateNames).toEqual([]);
+	});
+});
+
+describe('computeWorkflowHash', () => {
+	it('returns a 64-character hex string (SHA-256)', () => {
+		const hash = computeWorkflowHash(makeWorkflow());
+		expect(hash).toHaveLength(64);
+		expect(hash).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it('is deterministic for the same workflow', () => {
+		const wf = makeWorkflow();
+		expect(computeWorkflowHash(wf)).toBe(computeWorkflowHash(wf));
+	});
+
+	it('is stable regardless of node insertion order', () => {
+		const wf1 = makeWorkflow({
+			nodes: [
+				{ id: 'n1', name: 'Coder', agents: [{ agentId: 'a1', name: 'Coder' }] },
+				{ id: 'n2', name: 'Reviewer', agents: [{ agentId: 'a2', name: 'Reviewer' }] },
+			],
+		});
+		const wf2 = makeWorkflow({
+			nodes: [
+				{ id: 'n2', name: 'Reviewer', agents: [{ agentId: 'a2', name: 'Reviewer' }] },
+				{ id: 'n1', name: 'Coder', agents: [{ agentId: 'a1', name: 'Coder' }] },
+			],
+		});
+		expect(computeWorkflowHash(wf1)).toBe(computeWorkflowHash(wf2));
+	});
+
+	it('does NOT change when agent UUIDs differ', () => {
+		const wf1 = makeWorkflow({
+			nodes: [{ id: 'n1', name: 'Coder', agents: [{ agentId: 'uuid-aaa', name: 'Coder' }] }],
+		});
+		const wf2 = makeWorkflow({
+			nodes: [{ id: 'n1', name: 'Coder', agents: [{ agentId: 'uuid-bbb', name: 'Coder' }] }],
+		});
+		expect(computeWorkflowHash(wf1)).toBe(computeWorkflowHash(wf2));
+	});
+
+	it('does NOT change when layout coordinates differ', () => {
+		const wf1 = makeWorkflow({ layout: { n1: { x: 0, y: 0 } } });
+		const wf2 = makeWorkflow({ layout: { n1: { x: 999, y: 999 } } });
+		expect(computeWorkflowHash(wf1)).toBe(computeWorkflowHash(wf2));
+	});
+
+	it('DOES change when a node name changes', () => {
+		const wf1 = makeWorkflow({
+			nodes: [{ id: 'n1', name: 'Coder', agents: [{ agentId: 'a1', name: 'Coder' }] }],
+		});
+		const wf2 = makeWorkflow({
+			nodes: [{ id: 'n1', name: 'Developer', agents: [{ agentId: 'a1', name: 'Developer' }] }],
+		});
+		expect(computeWorkflowHash(wf1)).not.toBe(computeWorkflowHash(wf2));
+	});
+
+	it('DOES change when description changes', () => {
+		const wf1 = makeWorkflow({ description: 'Original description' });
+		const wf2 = makeWorkflow({ description: 'Changed description' });
+		expect(computeWorkflowHash(wf1)).not.toBe(computeWorkflowHash(wf2));
+	});
+
+	it('DOES change when instructions change', () => {
+		const wf1 = makeWorkflow({ instructions: 'Original instructions' });
+		const wf2 = makeWorkflow({ instructions: 'Changed instructions' });
+		expect(computeWorkflowHash(wf1)).not.toBe(computeWorkflowHash(wf2));
+	});
+
+	it('DOES change when channel topology changes', () => {
+		const wf1 = makeWorkflow({ channels: [{ id: 'c1', from: 'Coder', to: 'Reviewer' }] });
+		const wf2 = makeWorkflow({ channels: [{ id: 'c1', from: 'Reviewer', to: 'Coder' }] });
+		expect(computeWorkflowHash(wf1)).not.toBe(computeWorkflowHash(wf2));
+	});
+});
+
+describe('workflowsMatchFingerprint', () => {
+	it('returns true for structurally identical workflows', () => {
+		const wf1 = makeWorkflow();
+		const wf2 = makeWorkflow({ id: 'wf-different-id', layout: { n1: { x: 42, y: 42 } } });
+		expect(workflowsMatchFingerprint(wf1, wf2)).toBe(true);
+	});
+
+	it('returns false when node structure differs', () => {
+		const wf1 = makeWorkflow({
+			nodes: [{ id: 'n1', name: 'Coder', agents: [{ agentId: 'a1', name: 'Coder' }] }],
+		});
+		const wf2 = makeWorkflow({
+			nodes: [
+				{ id: 'n1', name: 'Coder', agents: [{ agentId: 'a1', name: 'Coder' }] },
+				{ id: 'n2', name: 'Reviewer', agents: [{ agentId: 'a2', name: 'Reviewer' }] },
+			],
+		});
+		expect(workflowsMatchFingerprint(wf1, wf2)).toBe(false);
+	});
+});

--- a/packages/daemon/tests/unit/helpers/space-agent-schema.ts
+++ b/packages/daemon/tests/unit/helpers/space-agent-schema.ts
@@ -64,6 +64,7 @@ export function createSpaceAgentSchema(db: Database): void {
 			layout TEXT,
 			template_name TEXT DEFAULT NULL,
 			template_hash TEXT DEFAULT NULL,
+			instructions TEXT DEFAULT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE

--- a/packages/daemon/tests/unit/helpers/space-agent-schema.ts
+++ b/packages/daemon/tests/unit/helpers/space-agent-schema.ts
@@ -62,6 +62,8 @@ export function createSpaceAgentSchema(db: Database): void {
 			channels TEXT,
 			gates TEXT,
 			layout TEXT,
+			template_name TEXT DEFAULT NULL,
+			template_hash TEXT DEFAULT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -70,6 +70,8 @@ export function createSpaceTables(db: BunDatabase): void {
 			channels TEXT,
 			gates TEXT,
 			layout TEXT,
+			template_name TEXT DEFAULT NULL,
+			template_hash TEXT DEFAULT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -72,6 +72,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			layout TEXT,
 			template_name TEXT DEFAULT NULL,
 			template_hash TEXT DEFAULT NULL,
+			instructions TEXT DEFAULT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -1009,6 +1009,18 @@ export interface SpaceWorkflow {
 	createdAt: number;
 	/** Last update timestamp (milliseconds since epoch) */
 	updatedAt: number;
+	/**
+	 * Name of the built-in template this workflow was created from or last synced to.
+	 * `undefined` for user-created workflows not based on any template.
+	 */
+	templateName?: string;
+	/**
+	 * Canonical content hash of the template at the time of last sync.
+	 * Used to detect drift: if the current template's hash differs from this value,
+	 * the template has been updated (or the workflow has been modified) since last sync.
+	 * `undefined` when no template tracking is active.
+	 */
+	templateHash?: string;
 }
 
 /**
@@ -1042,6 +1054,16 @@ export interface CreateSpaceWorkflowParams {
 	tags?: string[];
 	/** Visual editor node positions: maps node ID to {x, y} canvas coordinates */
 	layout?: Record<string, { x: number; y: number }>;
+	/**
+	 * Name of the built-in template this workflow is being created from.
+	 * When set, `templateHash` must also be provided.
+	 */
+	templateName?: string;
+	/**
+	 * Canonical content hash of the built-in template at creation time.
+	 * Stored for future drift detection.
+	 */
+	templateHash?: string;
 }
 
 /**
@@ -1084,6 +1106,9 @@ export interface UpdateSpaceWorkflowParams {
 	tags?: string[] | null;
 	/** Visual editor node positions. Pass `null` to clear. */
 	layout?: Record<string, { x: number; y: number }> | null;
+	/** Update template tracking (used when syncing from a template). */
+	templateName?: string | null;
+	templateHash?: string | null;
 }
 
 // ============================================================================

--- a/packages/web/src/components/space/WorkflowList.tsx
+++ b/packages/web/src/components/space/WorkflowList.tsx
@@ -10,7 +10,7 @@
  * - Real-time updates via SpaceStore
  */
 
-import { useState } from 'preact/hooks';
+import { useState, useEffect } from 'preact/hooks';
 import type { SpaceWorkflow, SpaceExportBundle } from '@neokai/shared';
 import { spaceStore } from '../../lib/space-store';
 
@@ -116,6 +116,37 @@ function WorkflowCard({ workflow, spaceId, spaceName, onEdit }: WorkflowCardProp
 	const [deleting, setDeleting] = useState(false);
 	const [deleteError, setDeleteError] = useState<string | null>(null);
 
+	// Drift detection state: null = unknown/checking, true = drifted, false = in sync
+	const [driftDrifted, setDriftDrifted] = useState<boolean | null>(null);
+	const [syncing, setSyncing] = useState(false);
+	const [syncError, setSyncError] = useState<string | null>(null);
+	const [confirmSync, setConfirmSync] = useState(false);
+
+	// Check for template drift whenever workflow changes (if it came from a template)
+	useEffect(() => {
+		if (!workflow.templateName) return;
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) return;
+
+		let cancelled = false;
+		hub
+			.request<{ drifted: boolean }>('spaceWorkflow.detectDrift', {
+				id: workflow.id,
+				spaceId,
+			})
+			.then((result) => {
+				if (!cancelled) setDriftDrifted(result.drifted);
+			})
+			.catch(() => {
+				// Ignore drift detection errors silently
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [workflow.id, workflow.updatedAt, workflow.templateName, spaceId]);
+
 	async function handleDelete() {
 		setDeleting(true);
 		setDeleteError(null);
@@ -146,6 +177,26 @@ function WorkflowCard({ workflow, spaceId, spaceName, onEdit }: WorkflowCardProp
 		}
 	}
 
+	async function handleSyncFromTemplate() {
+		setSyncing(true);
+		setSyncError(null);
+		try {
+			const hub = connectionManager.getHubIfConnected();
+			if (!hub) throw new Error('Not connected');
+			await hub.request('spaceWorkflow.syncFromTemplate', {
+				id: workflow.id,
+				spaceId,
+			});
+			setConfirmSync(false);
+			setDriftDrifted(false); // no longer drifted after sync
+			toast.success(`"${workflow.name}" synced from template`);
+		} catch (err) {
+			setSyncError(err instanceof Error ? err.message : 'Sync failed');
+		} finally {
+			setSyncing(false);
+		}
+	}
+
 	return (
 		<div class="bg-dark-850 border border-dark-700 rounded-lg p-4 hover:border-dark-600 transition-colors group">
 			{deleteError && (
@@ -159,6 +210,35 @@ function WorkflowCard({ workflow, spaceId, spaceName, onEdit }: WorkflowCardProp
 					<h3 class="text-sm font-medium text-gray-200 truncate">{workflow.name}</h3>
 					{workflow.description && (
 						<p class="text-xs text-gray-500 mt-0.5 line-clamp-2">{workflow.description}</p>
+					)}
+					{/* Template badge + drift indicator */}
+					{workflow.templateName && (
+						<div class="flex items-center gap-1.5 mt-1">
+							<span class="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs bg-dark-800 border border-dark-600 rounded text-gray-500">
+								<svg class="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width={2}
+										d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"
+									/>
+								</svg>
+								{workflow.templateName}
+							</span>
+							{driftDrifted === true && (
+								<span class="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs bg-yellow-900/30 border border-yellow-700/50 rounded text-yellow-400">
+									<svg class="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width={2}
+											d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+										/>
+									</svg>
+									Outdated
+								</span>
+							)}
+						</div>
 					)}
 				</div>
 
@@ -186,6 +266,15 @@ function WorkflowCard({ workflow, spaceId, spaceName, onEdit }: WorkflowCardProp
 						</>
 					) : (
 						<>
+							{workflow.templateName && driftDrifted === true && (
+								<button
+									onClick={() => setConfirmSync(true)}
+									class="px-2.5 py-1 text-xs text-yellow-400 hover:text-yellow-200 bg-dark-800 hover:bg-dark-700 rounded border border-yellow-700/50 hover:border-yellow-600/70 transition-colors"
+									title="Sync from template (overwrites local changes)"
+								>
+									Sync
+								</button>
+							)}
 							<button
 								onClick={onEdit}
 								class="px-2.5 py-1 text-xs text-gray-500 hover:text-gray-200 bg-dark-800 hover:bg-dark-700 rounded border border-dark-600 hover:border-dark-500 transition-colors"
@@ -249,6 +338,48 @@ function WorkflowCard({ workflow, spaceId, spaceName, onEdit }: WorkflowCardProp
 					</>
 				)}
 			</div>
+
+			{/* Sync from template confirmation modal */}
+			{confirmSync && (
+				<div class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60">
+					<div class="bg-dark-850 border border-dark-700 rounded-lg p-5 max-w-md w-full shadow-xl">
+						<h3 class="text-sm font-semibold text-gray-100 mb-2">Sync from template?</h3>
+						<p class="text-xs text-gray-400 mb-1">
+							This will overwrite <span class="font-medium text-gray-200">"{workflow.name}"</span>{' '}
+							with the latest version of the{' '}
+							<span class="font-medium text-gray-200">"{workflow.templateName}"</span> template.
+						</p>
+						<p class="text-xs text-red-400 mb-4">
+							All local edits to this workflow (nodes, channels, gates, instructions) will be
+							permanently lost.
+						</p>
+						{syncError && (
+							<div class="mb-3 px-3 py-1.5 bg-red-900/20 border border-red-800/40 rounded text-xs text-red-300">
+								{syncError}
+							</div>
+						)}
+						<div class="flex items-center gap-2 justify-end">
+							<button
+								onClick={() => {
+									setConfirmSync(false);
+									setSyncError(null);
+								}}
+								disabled={syncing}
+								class="px-3 py-1.5 text-xs text-gray-400 hover:text-gray-200 transition-colors disabled:opacity-50"
+							>
+								Cancel
+							</button>
+							<button
+								onClick={handleSyncFromTemplate}
+								disabled={syncing}
+								class="px-3 py-1.5 text-xs font-medium text-white bg-yellow-700 hover:bg-yellow-600 rounded transition-colors disabled:opacity-50"
+							>
+								{syncing ? 'Syncing…' : 'Sync from template'}
+							</button>
+						</div>
+					</div>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -1911,6 +1911,24 @@ class SpaceStore {
 
 		await hub.request('spaceWorkflow.delete', { id: workflowId, spaceId });
 	}
+
+	/**
+	 * Sync a workflow from its built-in template, overwriting current content.
+	 * Requires the workflow to have been created from a built-in template (templateName set).
+	 */
+	async syncWorkflowFromTemplate(workflowId: string): Promise<SpaceWorkflow> {
+		const spaceId = this.spaceId.value;
+		if (!spaceId) throw new Error('No space selected');
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		const { workflow } = await hub.request<{ workflow: SpaceWorkflow }>(
+			'spaceWorkflow.syncFromTemplate',
+			{ id: workflowId, spaceId }
+		);
+		return workflow;
+	}
 }
 
 /** Singleton space store instance */


### PR DESCRIPTION
Implements user-triggered workflow template sync with drift detection and confirmation.

**Backend:**
- Migration 90: adds `template_name` and `template_hash` columns to `space_workflows`
- `template-hash.ts`: SHA-256 fingerprint utility (`computeWorkflowHash`, `buildWorkflowFingerprint`) that hashes node names, channel topology, gate IDs, description, and instructions — excludes agent UUIDs and layout
- `spaceWorkflow.detectDrift`: compares a workflow's stored `templateHash` against the current template's hash and the workflow's own content hash; returns `{ drifted, templateName, currentTemplateHash, workflowContentHash, storedHash }`
- `spaceWorkflow.syncFromTemplate`: resolves agent role names to real SpaceAgent UUIDs, generates fresh node UUIDs, and overwrites the workflow with the current built-in template; stamps `templateHash` for future drift tracking
- `seedBuiltInWorkflows`: now stamps `templateName` and `templateHash` on every seeded workflow so drift detection works from day one
- Repository and shared types updated to persist/return `templateName`/`templateHash`

**Frontend:**
- `WorkflowCard` shows a template badge when `workflow.templateName` is set
- Eagerly detects drift via `spaceWorkflow.detectDrift` RPC; shows an "Outdated" badge and a "Sync" button when drifted
- Destructive confirmation modal warns that local edits will be permanently overwritten before syncing
- `spaceStore.syncWorkflowFromTemplate()` added for the sync RPC call

**Tests (43 new):**
- `template-hash.test.ts`: 17 tests for fingerprint stability, sorting, UUID-independence, layout-independence
- `space-workflow-handlers.test.ts`: 15 tests for detectDrift and syncFromTemplate handlers
- `gate-autonomy-status-consistency.test.ts`: 11 tests verifying that `blocked` (WorkflowRunStatus) is for gate rejection/failure while `review` (SpaceTaskStatus) is for human sign-off after completion; these are semantically distinct and the status machine enforces this correctly