### PR TITLE
fix(space): keep node agent sessions reachable until task archive (#1515)

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1378,16 +1378,23 @@ export class SpaceRuntime {
 					await this.updateTaskAndEmit(meta.spaceId, canonicalTask.id, { result: summary });
 				}
 
-				// Sibling NodeExecution cleanup: cancel siblings still in_progress
-				// when the canonical task reaches a terminal status. The end-node
+				// Sibling NodeExecution quiescing: interrupt siblings still in_progress
+				// when the canonical task reaches a terminal status, transitioning them
+				// to `idle` so they remain reachable via send_message. The end-node
 				// execution itself is excluded so its session can finish writing back
 				// to the agent (it produced the report_result that triggered this
 				// completion path). Skipped when the task is paused at `review` —
 				// the human may yet reject the completion, in which case sibling
 				// progress is still relevant.
+				//
+				// Sessions are deliberately NOT deleted here — they are only destroyed
+				// when the task transitions to `archived` (the true non-recoverable
+				// terminal state). This allows post-completion cross-node messaging,
+				// e.g. a reviewer sending follow-up feedback to a coder whose node
+				// already finished while the PR is still being merged.
 				const taskTerminal = finalTaskStatus === 'done' || finalTaskStatus === 'cancelled';
 				if (taskTerminal) {
-					const siblingsToCancel = this.config.nodeExecutionRepo
+					const siblingsToQuiesce = this.config.nodeExecutionRepo
 						.listByWorkflowRun(runId)
 						.filter(
 							(e) =>
@@ -1395,15 +1402,22 @@ export class SpaceRuntime {
 								e.agentSessionId &&
 								(!endNodeId || e.workflowNodeId !== endNodeId)
 						);
-					for (const sibling of siblingsToCancel) {
-						this.config.nodeExecutionRepo.updateStatus(sibling.id, 'cancelled');
+					for (const sibling of siblingsToQuiesce) {
+						this.config.nodeExecutionRepo.updateStatus(sibling.id, 'idle');
 						if (this.config.taskAgentManager) {
-							this.config.taskAgentManager.cancelBySessionId(sibling.agentSessionId!);
+							void this.config.taskAgentManager
+								.interruptBySessionId(sibling.agentSessionId!)
+								.catch((err) => {
+									log.warn(
+										`SpaceRuntime: failed to interrupt sibling session ${sibling.agentSessionId}:`,
+										err
+									);
+								});
 						}
 						log.info(
-							`SpaceRuntime: cancelled sibling node execution ${sibling.id} ` +
+							`SpaceRuntime: quiesced sibling node execution ${sibling.id} ` +
 								`(node ${sibling.workflowNodeId}, agent ${sibling.agentName}) ` +
-								`for completed run ${runId}`
+								`to idle for completed run ${runId}; session kept alive for post-completion messaging`
 						);
 					}
 				}

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -241,7 +241,39 @@ export class TaskAgentManager {
 	 */
 	private taskDbQueryServers = new Map<string, DbQueryMcpServer>();
 
-	constructor(private readonly config: TaskAgentManagerConfig) {}
+	/**
+	 * Unsubscribe function for the `space.task.updated` listener that triggers
+	 * full session cleanup when a task reaches `archived` state.
+	 * Populated on first cleanup subscription attempt; cleared in `cleanupAll()`.
+	 */
+	private taskArchiveListenerUnsub: (() => void) | null = null;
+
+	constructor(private readonly config: TaskAgentManagerConfig) {
+		this.subscribeToTaskArchiveEvents();
+	}
+
+	/**
+	 * Subscribe to `space.task.updated` and run full cleanup for tasks that
+	 * reach the `archived` state.
+	 *
+	 * `archived` is the only truly non-recoverable terminal state for a task —
+	 * per issue #1515, node agent sessions must remain reachable (e.g. for
+	 * cross-node `send_message` from a reviewer to a completed coder) for the
+	 * full lifetime of the parent task run, and are only torn down when the
+	 * task is archived.
+	 */
+	private subscribeToTaskArchiveEvents(): void {
+		if (this.taskArchiveListenerUnsub) return;
+		this.taskArchiveListenerUnsub = this.config.daemonHub.on('space.task.updated', (event) => {
+			if (event.task?.status !== 'archived') return;
+			const taskId = event.taskId;
+			// Fire-and-forget — cleanup is idempotent and safe to skip on failure
+			// (cleanupAll still sweeps leftovers on daemon shutdown).
+			void this.cleanup(taskId, 'done').catch((err) => {
+				log.warn(`TaskAgentManager: failed to clean up sessions for archived task ${taskId}:`, err);
+			});
+		});
+	}
 
 	// -------------------------------------------------------------------------
 	// Public — Task Agent lifecycle
@@ -1030,6 +1062,33 @@ export class TaskAgentManager {
 		});
 	}
 
+	/**
+	 * Interrupt a sub-session by its agent session ID WITHOUT deleting it.
+	 *
+	 * Unlike `cancelBySessionId`, this preserves the session in memory and in
+	 * the DB, so it remains reachable via `send_message` / `injectSubSessionMessage`
+	 * while the parent task is still active.
+	 *
+	 * Use this when the workflow run completes (end node fires) but the task
+	 * is not yet `archived` — siblings should stop processing but remain
+	 * messageable in case a downstream node needs to follow up (e.g. a reviewer
+	 * sending feedback back to a coder whose node has already finished).
+	 *
+	 * No-op if the session is not found or is not in a state that can be interrupted.
+	 */
+	async interruptBySessionId(agentSessionId: string): Promise<void> {
+		const session = this.agentSessionIndex.get(agentSessionId);
+		if (!session) return;
+		try {
+			await session.handleInterrupt();
+		} catch (err) {
+			log.warn(
+				`TaskAgentManager.interruptBySessionId: failed to interrupt session ${agentSessionId}:`,
+				err
+			);
+		}
+	}
+
 	// -------------------------------------------------------------------------
 	// Public — rehydration
 	// -------------------------------------------------------------------------
@@ -1092,6 +1151,10 @@ export class TaskAgentManager {
 	 * Called on daemon shutdown to release all resources.
 	 */
 	async cleanupAll(): Promise<void> {
+		if (this.taskArchiveListenerUnsub) {
+			this.taskArchiveListenerUnsub();
+			this.taskArchiveListenerUnsub = null;
+		}
 		const taskIds = Array.from(this.taskAgentSessions.keys());
 		await Promise.allSettled(taskIds.map((taskId) => this.cleanup(taskId)));
 		log.info(`TaskAgentManager: cleanupAll complete (${taskIds.length} tasks cleaned up)`);

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-session-lifecycle.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-session-lifecycle.test.ts
@@ -952,6 +952,127 @@ describe('Task Agent Session Lifecycle', () => {
 	});
 
 	// =======================================================================
+	// 5b. Interruption — interruptBySessionId (keep-alive quiesce)
+	// =======================================================================
+	// Regression for issue #1515: node agent sessions must remain reachable
+	// via send_message until the parent task is archived. interruptBySessionId
+	// stops in-flight SDK processing (via handleInterrupt()) but must NOT
+	// delete the session record or clear it from agentSessionIndex.
+
+	describe('interruptBySessionId', () => {
+		test('interrupts the sub-session without deleting it', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			const subSessionId = `space:${ctx.spaceId}:task:${task.id}:step:interrupt-step`;
+			await ctx.manager.createSubSession(task.id, subSessionId, {
+				sessionId: subSessionId,
+				workspacePath: '/tmp/ws',
+			} as unknown as import('../../../../src/lib/agent/agent-session.ts').AgentSessionInit);
+
+			const subSession = ctx.createdSessions.get(subSessionId)!;
+			let interruptCalls = 0;
+			subSession.handleInterrupt = async () => {
+				interruptCalls++;
+			};
+
+			await ctx.manager.interruptBySessionId(subSessionId);
+
+			// Interrupt was invoked on the underlying session.
+			expect(interruptCalls).toBe(1);
+			// Session is NOT deleted — it must remain reachable for send_message.
+			expect(subSession._cleanupCalled).toBe(false);
+			expect(ctx.sessionManagerDeleteCalls).not.toContain(subSessionId);
+		});
+
+		test('is a no-op for unknown session ID', async () => {
+			// Should not throw and should not delete anything.
+			await expect(ctx.manager.interruptBySessionId('does-not-exist')).resolves.toBeUndefined();
+			expect(ctx.sessionManagerDeleteCalls).toHaveLength(0);
+		});
+
+		test('swallows errors thrown by handleInterrupt', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			const subSessionId = `space:${ctx.spaceId}:task:${task.id}:step:interrupt-throws`;
+			await ctx.manager.createSubSession(task.id, subSessionId, {
+				sessionId: subSessionId,
+				workspacePath: '/tmp/ws',
+			} as unknown as import('../../../../src/lib/agent/agent-session.ts').AgentSessionInit);
+
+			const subSession = ctx.createdSessions.get(subSessionId)!;
+			subSession.handleInterrupt = async () => {
+				throw new Error('interrupt boom');
+			};
+
+			// Error should be swallowed — caller should not need to catch.
+			await expect(ctx.manager.interruptBySessionId(subSessionId)).resolves.toBeUndefined();
+			// Session is still not deleted after a failed interrupt.
+			expect(subSession._cleanupCalled).toBe(false);
+		});
+	});
+
+	// =======================================================================
+	// 5c. Task-archive listener — full cleanup only on `archived`
+	// =======================================================================
+	// Regression for issue #1515: TaskAgentManager must retain sub-sessions
+	// while the parent task is in_progress / done. Only `archived` — the true
+	// non-recoverable terminal state — should trigger full teardown.
+
+	describe('task-archive listener', () => {
+		test('archived task triggers cleanup() which deletes sub-sessions', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			const subSessionId = `space:${ctx.spaceId}:task:${task.id}:step:archive-test`;
+			await ctx.manager.createSubSession(task.id, subSessionId, {
+				sessionId: subSessionId,
+				workspacePath: '/tmp/ws',
+			} as unknown as import('../../../../src/lib/agent/agent-session.ts').AgentSessionInit);
+
+			// Fire `space.task.updated` with status='archived'.
+			await ctx.daemonHub.emit('space.task.updated', {
+				sessionId: 'global',
+				spaceId: ctx.spaceId,
+				taskId: task.id,
+				task: { ...task, status: 'archived' },
+			});
+
+			// Cleanup is async — wait for the fire-and-forget promise to settle.
+			await new Promise((r) => setTimeout(r, 50));
+
+			// The sub-session was torn down and the DB session row was deleted.
+			expect(ctx.sessionManagerDeleteCalls).toContain(subSessionId);
+		});
+
+		test('non-archived status updates do NOT trigger cleanup', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			const subSessionId = `space:${ctx.spaceId}:task:${task.id}:step:no-archive`;
+			await ctx.manager.createSubSession(task.id, subSessionId, {
+				sessionId: subSessionId,
+				workspacePath: '/tmp/ws',
+			} as unknown as import('../../../../src/lib/agent/agent-session.ts').AgentSessionInit);
+
+			// Fire a series of non-archived status events.
+			for (const status of ['in_progress', 'review', 'done', 'cancelled'] as const) {
+				await ctx.daemonHub.emit('space.task.updated', {
+					sessionId: 'global',
+					spaceId: ctx.spaceId,
+					taskId: task.id,
+					task: { ...task, status },
+				});
+			}
+			await new Promise((r) => setTimeout(r, 50));
+
+			// Sub-session must remain alive — send_message targeting it must still work.
+			expect(ctx.sessionManagerDeleteCalls).not.toContain(subSessionId);
+		});
+	});
+
+	// =======================================================================
 	// 6. Error handling — handleSubSessionError
 	// =======================================================================
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
@@ -91,6 +91,7 @@ class MockTaskAgentManager {
 	cancelBySessionId(agentSessionId: string): void {
 		this.cancelledSessions.push(agentSessionId);
 	}
+	async interruptBySessionId(_agentSessionId: string): Promise<void> {}
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
@@ -164,6 +164,7 @@ function seedNodeExec(
 
 class MockTaskAgentManager {
 	readonly cancelledSessions: string[] = [];
+	readonly interruptedSessions: string[] = [];
 	readonly spawnedExecutionSessions: string[] = [];
 
 	isTaskAgentAlive(_taskId: string): boolean {
@@ -207,6 +208,10 @@ class MockTaskAgentManager {
 
 	cancelBySessionId(agentSessionId: string): void {
 		this.cancelledSessions.push(agentSessionId);
+	}
+
+	async interruptBySessionId(agentSessionId: string): Promise<void> {
+		this.interruptedSessions.push(agentSessionId);
 	}
 }
 
@@ -1048,10 +1053,14 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			}
 		});
 
-		test('canonical task done triggers sibling exec cancellation', async () => {
-			// Sibling cancellation now fires on canonical task transition to a
-			// terminal status, not on end-node-execution observation. Any still-
-			// in-flight node executions are cancelled so their agents stop work.
+		test('canonical task done interrupts siblings but keeps sessions alive (idle)', async () => {
+			// Per issue #1515: node agent sessions must remain reachable via
+			// send_message until the parent task reaches `archived`. When the
+			// task transitions to `done` / `cancelled`, sibling NodeExecutions
+			// still in flight are interrupted (session stops processing) and
+			// their status transitions to `idle` — NOT `cancelled` — so they
+			// remain a valid message target. The session itself is kept alive
+			// in memory; only `archived` triggers full teardown.
 			const mockTam = new MockTaskAgentManager();
 			mockTam.isSessionAlive = () => true;
 			const rt = makeRuntimeWithTam({
@@ -1060,7 +1069,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 
 			const workflow = workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
-				name: `Sibling Cancel On Task Terminal ${Date.now()}`,
+				name: `Sibling Interrupt On Task Terminal ${Date.now()}`,
 				description: '',
 				nodes: [
 					{ id: 'ec-sibling', name: 'Sibling', agentId: AGENT_A },
@@ -1082,7 +1091,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			);
 			seedNodeExec(db, run.id, 'ec-end', 'End', 'idle');
 
-			// Canonical task transitions to done; runtime cancels in-flight siblings.
+			// Canonical task transitions to done; runtime quiesces in-flight siblings.
 			taskRepo.updateTask(tasks[0].id, { status: 'done' });
 
 			await rt.executeTick();
@@ -1092,11 +1101,83 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 
 			const execs = nodeExecutionRepo.listByWorkflowRun(run.id);
 			const siblingExec = execs.find((e) => e.workflowNodeId === 'ec-sibling');
-			expect(siblingExec?.status).toBe('cancelled');
-			expect(mockTam.cancelledSessions).toContain(siblingSessionId);
+			// Sibling execution transitions to `idle` (reachable), not `cancelled` (destroyed).
+			expect(siblingExec?.status).toBe('idle');
+			// Sibling session retains its agentSessionId so send_message can still reach it.
+			expect(siblingExec?.agentSessionId).toBe(siblingSessionId);
+			// Runtime interrupted the session — but did NOT delete/cancel it.
+			expect(mockTam.interruptedSessions).toContain(siblingSessionId);
+			expect(mockTam.cancelledSessions).not.toContain(siblingSessionId);
 
 			const completedEvents = sink.events.filter((e) => e.kind === 'workflow_run_completed');
 			expect(completedEvents).toHaveLength(1);
+		});
+
+		test('sibling session remains reachable for send_message after workflow completion (#1515)', async () => {
+			// Regression for issue #1515: when a downstream node (e.g. a reviewer)
+			// tries to resolve peers for send_message AFTER an upstream sibling
+			// has completed, the sibling's session must still appear as a valid
+			// target. This test asserts the post-completion state that feeds
+			// AgentMessageRouter.deliverMessage's peer lookup:
+			//
+			//   1. The sibling NodeExecution row status === 'idle' (not cancelled)
+			//   2. The sibling agentSessionId is still populated
+			//
+			// These two invariants are what list_peers / deliverMessage rely on
+			// when the Task Agent asks for a reviewer→coder send_message to
+			// succeed after the coder node has finished.
+			const mockTam = new MockTaskAgentManager();
+			mockTam.isSessionAlive = () => true;
+			const rt = makeRuntimeWithTam({
+				taskAgentManager: mockTam as unknown as TaskAgentManager,
+			});
+
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Post-Completion Messaging ${Date.now()}`,
+				description: '',
+				nodes: [
+					{ id: 'coder-node', name: 'Coder', agentId: AGENT_A },
+					{ id: 'reviewer-node', name: 'Reviewer', agentId: AGENT_B },
+				],
+				startNodeId: 'coder-node',
+				endNodeId: 'reviewer-node',
+				tags: [],
+			});
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			const coderSessionId = 'coder-session-1515';
+			const coderExecId = seedNodeExec(db, run.id, 'coder-node', 'Coder', 'in_progress');
+			db.prepare('UPDATE node_executions SET agent_session_id = ? WHERE id = ?').run(
+				coderSessionId,
+				coderExecId
+			);
+			seedNodeExec(db, run.id, 'reviewer-node', 'Reviewer', 'idle');
+
+			// Reviewer flips the canonical task to done (e.g. after merging a PR).
+			taskRepo.updateTask(tasks[0].id, { status: 'done' });
+			await rt.executeTick();
+
+			// The coder NodeExecution must remain a valid send_message target:
+			// status=idle (listed by list_peers) and agentSessionId preserved
+			// (used by AgentMessageRouter.deliverMessage to locate the session).
+			const coderExec = nodeExecutionRepo
+				.listByWorkflowRun(run.id)
+				.find((e) => e.workflowNodeId === 'coder-node');
+			expect(coderExec?.status).toBe('idle');
+			expect(coderExec?.agentSessionId).toBe(coderSessionId);
+
+			// TaskAgentManager was instructed to interrupt (not destroy) the
+			// coder session — the session object itself is still registered
+			// and reachable for message injection.
+			expect(mockTam.interruptedSessions).toContain(coderSessionId);
+			expect(mockTam.cancelledSessions).not.toContain(coderSessionId);
+
+			// The parent task is `done`, not yet `archived` — in production this
+			// means TaskAgentManager's archive listener has not fired, so the
+			// sub-session record also survives full cleanup.
+			const updatedTask = taskRepo.getTask(tasks[0].id);
+			expect(updatedTask?.status).toBe('done');
 		});
 
 		test('workflow without endNodeId is rejected at start', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-notifications.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-notifications.test.ts
@@ -1257,6 +1257,10 @@ describe('SpaceRuntime — notification events', () => {
 		}
 
 		async rehydrate(): Promise<void> {}
+
+		cancelBySessionId(_agentSessionId: string): void {}
+
+		async interruptBySessionId(_agentSessionId: string): Promise<void> {}
 	}
 
 	describe('workflow_run_completed via CompletionDetector', () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-rehydration.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-rehydration.test.ts
@@ -406,6 +406,7 @@ describe('SpaceRuntime — crash recovery and rehydration', () => {
 					return `session:${t.id}`;
 				},
 				cancelBySessionId: () => {},
+				interruptBySessionId: async () => {},
 				rehydrate: async () => {
 					rehydrateCallCount++;
 				},
@@ -443,6 +444,7 @@ describe('SpaceRuntime — crash recovery and rehydration', () => {
 				isSessionAlive: () => false,
 				spawnWorkflowNodeAgentForExecution: async () => 'session-1',
 				cancelBySessionId: () => {},
+				interruptBySessionId: async () => {},
 				rehydrate: async () => {
 					rehydrateCallCount++;
 				},
@@ -489,6 +491,7 @@ describe('SpaceRuntime — crash recovery and rehydration', () => {
 					return `session:${t.id}`;
 				},
 				cancelBySessionId: () => {},
+				interruptBySessionId: async () => {},
 				rehydrate: async () => {
 					// Capture executor count at the moment rehydrate() is called
 					executorCountAtRehydrate = rtRef?.executorCount ?? 0;
@@ -560,6 +563,7 @@ describe('SpaceRuntime — crash recovery and rehydration', () => {
 					return `session:${t.id}`;
 				},
 				cancelBySessionId: () => {},
+				interruptBySessionId: async () => {},
 				rehydrate: async () => {},
 			};
 
@@ -621,6 +625,7 @@ describe('SpaceRuntime — crash recovery and rehydration', () => {
 					return `session:${t.id}`;
 				},
 				cancelBySessionId: () => {},
+				interruptBySessionId: async () => {},
 				rehydrate: async () => {},
 			};
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
@@ -112,6 +112,7 @@ function makeMockTaskAgentManager(
 		) => Promise<string>;
 		rehydrate?: () => Promise<void>;
 		cancelBySessionId?: (sessionId: string) => void;
+		interruptBySessionId?: (sessionId: string) => Promise<void>;
 	} = {}
 ) {
 	const spawned: string[] = [];
@@ -165,6 +166,7 @@ function makeMockTaskAgentManager(
 		spawnWorkflowNodeAgentForExecution: spawnExecutionImpl,
 		rehydrate: overrides.rehydrate ?? (async () => {}),
 		cancelBySessionId: overrides.cancelBySessionId ?? (() => {}),
+		interruptBySessionId: overrides.interruptBySessionId ?? (async () => {}),
 		_spawned: spawned,
 	};
 }

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
@@ -640,6 +640,7 @@ describe('SpaceRuntime', () => {
 				isTaskAgentAlive?: (taskId: string) => boolean;
 				spawnWorkflowNodeAgent?: (task: unknown) => Promise<string>;
 				cancelBySessionId?: (sessionId: string) => void;
+				interruptBySessionId?: (sessionId: string) => Promise<void>;
 				rehydrate?: () => Promise<void>;
 			} = {}
 		) {
@@ -675,6 +676,7 @@ describe('SpaceRuntime', () => {
 					_execution: unknown
 				) => spawnImpl(task),
 				cancelBySessionId: overrides.cancelBySessionId ?? (() => {}),
+				interruptBySessionId: overrides.interruptBySessionId ?? (async () => {}),
 				rehydrate: overrides.rehydrate ?? (async () => {}),
 				_spawned: spawned,
 			};


### PR DESCRIPTION
Fixes #1515.

Previously, when a workflow run completed, SpaceRuntime cancelled in-progress sibling NodeExecutions and deleted their sub-sessions — even though the parent task was only `done`, not `archived`. That broke cross-node `send_message` (e.g. reviewer → already-finished coder) with "No active sessions found for target agent(s): coder".

- `TaskAgentManager.interruptBySessionId()` stops SDK processing via `handleInterrupt()` without destroying the session.
- TaskAgentManager now subscribes to `space.task.updated` and only runs full `cleanup()` when status === `archived`.
- SpaceRuntime quiesces sibling NodeExecutions to `idle` (not `cancelled`) on task termination, preserving `agentSessionId` so `list_peers` / `AgentMessageRouter` can still reach them.

## Test plan

- [x] Daemon unit tests (`./scripts/test-daemon.sh`) — 10,889/10,889 pass
- [x] `bun run check` (lint + typecheck + knip) — clean
- [x] New regression: `interruptBySessionId` keeps session alive
- [x] New regression: `space.task.updated` cleanup only on `archived`
- [x] New regression: post-completion coder node stays reachable with `status=idle` + `agentSessionId` preserved