### PR TITLE
feat(space): harden channel topology — queue-until-active + Task→Space escalation

### DIFF
--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -491,6 +491,33 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 		data: Record<string, unknown>;
 	};
 
+	// Pending agent message events (queue-until-active)
+	// See packages/daemon/src/storage/repositories/pending-agent-message-repository.ts
+	/** Emitted when a Task Agent's send_message is queued because the target is not yet active. */
+	'space.pendingMessage.queued': {
+		sessionId: string;
+		spaceId: string;
+		workflowRunId: string;
+		taskId: string | null;
+		targetAgentName: string;
+		targetKind: 'node_agent' | 'space_agent';
+		messageId: string;
+		attempts: number;
+		maxAttempts: number;
+		expiresAt: number;
+		deduped: boolean;
+	};
+	/** Emitted when a queued pending message is flushed to the target session. */
+	'space.pendingMessage.delivered': {
+		sessionId: string;
+		spaceId: string;
+		workflowRunId: string;
+		targetAgentName: string;
+		targetKind: string;
+		messageId: string;
+		deliveredSessionId: string;
+	};
+
 	// Space Agent events (channel: 'space:${spaceId}')
 	'spaceAgent.created': {
 		sessionId: string;

--- a/packages/daemon/src/lib/db-query/scope-config.ts
+++ b/packages/daemon/src/lib/db-query/scope-config.ts
@@ -293,6 +293,9 @@ const EXCLUDED_TABLE_NAMES: string[] = [
 	'task_group_events',
 	// Node execution tracking — transient per-run agent state, not useful for ad-hoc queries
 	'node_executions',
+	// Pending agent messages — internal queue-until-active infrastructure for Task Agent
+	// send_message delivery; flushed by TaskAgentManager when target sessions activate.
+	'pending_agent_messages',
 	// Dynamically created tables (managed by FilterConfigManager, not part of static schema)
 	'github_filter_configs',
 	// Workspace history — user-level path bookmarks, not useful for agent queries

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -6,6 +6,9 @@
  */
 
 import type { MessageHub } from '@neokai/shared';
+import { generateUUID } from '@neokai/shared';
+import type { SDKUserMessage } from '@neokai/shared/sdk';
+import type { UUID } from 'crypto';
 import type { DaemonHub } from '../daemon-hub';
 import type { SessionManager } from '../session-manager';
 import type { AuthManager } from '../auth-manager';
@@ -61,6 +64,7 @@ import { SpaceWorkflowRunRepository } from '../../storage/repositories/space-wor
 import { GateDataRepository } from '../../storage/repositories/gate-data-repository';
 import { WorkflowRunArtifactRepository } from '../../storage/repositories/workflow-run-artifact-repository';
 import { ChannelCycleRepository } from '../../storage/repositories/channel-cycle-repository';
+import { PendingAgentMessageRepository } from '../../storage/repositories/pending-agent-message-repository';
 import { setupSpaceAgentHandlers } from './space-agent-handlers';
 import type { SpaceAgentManager } from '../space/managers/space-agent-manager';
 import { SpaceWorkflowRepository } from '../../storage/repositories/space-workflow-repository';
@@ -362,6 +366,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	const gateDataRepo = new GateDataRepository(deps.db.getDatabase());
 	const artifactRepo = new WorkflowRunArtifactRepository(deps.db.getDatabase(), deps.reactiveDb);
 	const channelCycleRepo = new ChannelCycleRepository(deps.db.getDatabase());
+	const pendingMessageRepo = new PendingAgentMessageRepository(deps.db.getDatabase());
 
 	// Space workflow manager — created early so space.create can call seedBuiltInWorkflows
 	const spaceWorkflowRepo = new SpaceWorkflowRepository(deps.db.getDatabase());
@@ -471,6 +476,33 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	// Space Worktree Manager — one worktree per task, shared by all node agents.
 	const spaceWorktreeManager = new SpaceWorktreeManager(deps.db.getDatabase());
 
+	// Space Agent injector — routes Task Agent → Space Agent escalations into the
+	// `space:chat:${spaceId}` session via SessionManager. Shared between
+	// TaskAgentManager (for queue flush) and task-agent tool wiring.
+	const sessionManagerRef = deps.sessionManager;
+	const spaceAgentInjector = async (spaceId: string, message: string): Promise<void> => {
+		const sessionId = `space:chat:${spaceId}`;
+		const session = await sessionManagerRef.getSessionAsync(sessionId);
+		if (!session) {
+			throw new Error(`Space Agent chat session not found: ${sessionId}`);
+		}
+		const messageId = generateUUID();
+		const sdkUserMessage: SDKUserMessage & { isSynthetic: boolean } = {
+			type: 'user' as const,
+			uuid: messageId as UUID,
+			session_id: sessionId,
+			parent_tool_use_id: null,
+			isSynthetic: true,
+			message: {
+				role: 'user' as const,
+				content: [{ type: 'text' as const, text: message }],
+			},
+		};
+		await session.ensureQueryStarted();
+		deps.reactiveDb.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued');
+		await session.messageQueue.enqueueWithId(messageId, message);
+	};
+
 	// Task Agent Manager — manages Task Agent session lifecycle and message injection.
 	// Must be created after spaceRuntimeService so it can get WorkflowExecutors via
 	// spaceRuntimeService.createOrGetRuntime(spaceId).
@@ -498,6 +530,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		nodeExecutionRepo,
 		dbPath: deps.db.getDatabasePath(),
 		artifactRepo,
+		pendingMessageRepo,
+		spaceAgentInjector,
 	});
 
 	// Wire TaskAgentManager into the SpaceRuntime so the tick loop can spawn

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -381,6 +381,17 @@ export class SpaceRuntimeService {
 		);
 
 		log.info(`Space chat session provisioned for space ${space.id}`);
+
+		// Flush any Task Agent → Space Agent messages that were queued before
+		// this session was provisioned (handles the daemon-restart activation race).
+		if (this.taskAgentManager) {
+			const activeRuns = this.config.workflowRunRepo.getActiveRuns(space.id);
+			for (const run of activeRuns) {
+				void this.taskAgentManager
+					.flushPendingMessagesForSpaceAgent(space.id, run.id)
+					.catch(() => {});
+			}
+		}
 	}
 
 	/**

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -68,6 +68,7 @@ import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/s
 import type { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
 import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
 import type { ChannelCycleRepository } from '../../../storage/repositories/channel-cycle-repository';
+import type { PendingAgentMessageRepository } from '../../../storage/repositories/pending-agent-message-repository';
 import type { SpaceWorktreeManager } from '../managers/space-worktree-manager';
 import type { SubSessionMemberInfo } from '../tools/task-agent-tools';
 import { createTaskAgentMcpServer } from '../tools/task-agent-tools';
@@ -161,6 +162,18 @@ export interface TaskAgentManagerConfig {
 	dbPath?: string;
 	/** Workflow run artifact repository — for write_artifact / list_artifacts node agent tools */
 	artifactRepo?: WorkflowRunArtifactRepository;
+	/**
+	 * Persistent queue of Task Agent → peer agent messages waiting for the target
+	 * session to activate. When provided, `createSubSession` flushes all pending
+	 * messages for the newly-activated agent (by name) and `send_message` can
+	 * enqueue instead of failing when the target is declared but not yet active.
+	 */
+	pendingMessageRepo?: PendingAgentMessageRepository;
+	/**
+	 * Callback to inject a message into the Space Agent chat session for a space.
+	 * Used for Task Agent → Space Agent escalation via `send_message`.
+	 */
+	spaceAgentInjector?: (spaceId: string, message: string) => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -542,6 +555,8 @@ export class TaskAgentManager {
 				onGateChanged: (runId, gateId) => {
 					void this.config.spaceRuntimeService.notifyGateDataChanged(runId, gateId).catch(() => {});
 				},
+				pendingMessageRepo: this.config.pendingMessageRepo,
+				spaceAgentInjector: this.config.spaceAgentInjector,
 			});
 
 			// setRuntimeMcpServers expects McpServerConfig but the MCP SDK's `Server`
@@ -914,8 +929,127 @@ export class TaskAgentManager {
 		// Start streaming query for the sub-session
 		await subSession.startStreamingQuery();
 
+		// Flush any queued messages addressed to this agent name so that the
+		// reopen/startup race doesn't drop Task Agent → node-agent messages.
+		if (memberInfo?.agentName) {
+			const parentTask = this.config.taskRepo.getTask(taskId);
+			const runId = parentTask?.workflowRunId;
+			if (runId) {
+				void this.flushPendingMessagesForTarget(runId, memberInfo.agentName, sessionId).catch(
+					(err) => {
+						log.warn(
+							`TaskAgentManager: flushPendingMessagesForTarget failed for ${memberInfo.agentName} (session ${sessionId}): ${err instanceof Error ? err.message : String(err)}`
+						);
+					}
+				);
+			}
+		}
+
 		log.info(`TaskAgentManager: created sub-session ${sessionId} for task ${taskId}`);
 		return sessionId;
+	}
+
+	/**
+	 * Drain the pending-message queue for a specific target in a workflow run,
+	 * delivering each pending message in FIFO order to the given session.
+	 *
+	 * Called immediately after `createSubSession()` activates a sub-session, and
+	 * also invoked by rehydration paths after daemon restart. Safe to call
+	 * repeatedly — rows already marked delivered/expired/failed are ignored.
+	 *
+	 * Expired rows are swept first so they're never delivered. Each successful
+	 * injection calls `markDelivered`; each failure increments attempts via
+	 * `markAttemptFailed` and the row stays pending until `max_attempts` is hit.
+	 */
+	async flushPendingMessagesForTarget(
+		workflowRunId: string,
+		targetAgentName: string,
+		sessionId: string
+	): Promise<void> {
+		const repo = this.config.pendingMessageRepo;
+		if (!repo) return;
+
+		// Expire stale rows first so we don't deliver messages that have exceeded their TTL.
+		repo.expireStale(workflowRunId);
+
+		const pending = repo.listPendingForTarget(workflowRunId, targetAgentName);
+		if (pending.length === 0) return;
+
+		log.info(
+			`TaskAgentManager: flushing ${pending.length} pending message(s) for agent=${targetAgentName} session=${sessionId}`
+		);
+
+		for (const row of pending) {
+			const prefixed = `[Message from ${row.sourceAgentName}]: ${row.message}`;
+			try {
+				await this.injectSubSessionMessage(sessionId, prefixed);
+				repo.markDelivered(row.id, sessionId);
+				this.emitPendingDelivered(row.id, sessionId, row);
+			} catch (err) {
+				const errMsg = err instanceof Error ? err.message : String(err);
+				log.warn(
+					`TaskAgentManager: pending message ${row.id} delivery to ${sessionId} failed: ${errMsg}`
+				);
+				repo.markAttemptFailed(row.id, errMsg);
+				// Keep going — a single per-row failure must not block the rest of the queue.
+			}
+		}
+	}
+
+	/**
+	 * Drain the pending-message queue for the Space Agent target of a workflow run.
+	 * Uses the configured `spaceAgentInjector`. Called after space chat session
+	 * provisioning / rehydration so that Task Agent escalations survive restarts.
+	 */
+	async flushPendingMessagesForSpaceAgent(spaceId: string, workflowRunId: string): Promise<void> {
+		const repo = this.config.pendingMessageRepo;
+		const inject = this.config.spaceAgentInjector;
+		if (!repo || !inject) return;
+
+		repo.expireStale(workflowRunId);
+
+		const pending = repo
+			.listPendingForTarget(workflowRunId, 'space-agent')
+			.filter((r) => r.targetKind === 'space_agent');
+		if (pending.length === 0) return;
+
+		const spaceChatSessionId = `space:chat:${spaceId}`;
+		log.info(
+			`TaskAgentManager: flushing ${pending.length} pending message(s) for Space Agent session=${spaceChatSessionId}`
+		);
+
+		for (const row of pending) {
+			const prefixed = `[Message from ${row.sourceAgentName}]: ${row.message}`;
+			try {
+				await inject(spaceId, prefixed);
+				repo.markDelivered(row.id, spaceChatSessionId);
+				this.emitPendingDelivered(row.id, spaceChatSessionId, row);
+			} catch (err) {
+				const errMsg = err instanceof Error ? err.message : String(err);
+				log.warn(`TaskAgentManager: Space Agent delivery for ${row.id} failed: ${errMsg}`);
+				repo.markAttemptFailed(row.id, errMsg);
+			}
+		}
+	}
+
+	/** Emit observability event that a queued message was delivered. */
+	private emitPendingDelivered(
+		messageId: string,
+		sessionId: string,
+		row: { spaceId: string; workflowRunId: string; targetAgentName: string; targetKind: string }
+	): void {
+		if (!this.config.daemonHub) return;
+		void this.config.daemonHub
+			.emit('space.pendingMessage.delivered', {
+				sessionId: 'global',
+				spaceId: row.spaceId,
+				workflowRunId: row.workflowRunId,
+				targetAgentName: row.targetAgentName,
+				targetKind: row.targetKind,
+				messageId,
+				deliveredSessionId: sessionId,
+			})
+			.catch(() => {});
 	}
 
 	// -------------------------------------------------------------------------
@@ -1781,6 +1915,8 @@ export class TaskAgentManager {
 			onGateChanged: (runId, gateId) => {
 				void this.config.spaceRuntimeService.notifyGateDataChanged(runId, gateId).catch(() => {});
 			},
+			pendingMessageRepo: this.config.pendingMessageRepo,
+			spaceAgentInjector: this.config.spaceAgentInjector,
 		});
 
 		// Merge registry-sourced MCP servers alongside the in-process task-agent server,
@@ -1974,6 +2110,16 @@ export class TaskAgentManager {
 
 		// --- Restart the streaming query (idempotent if already running)
 		await agentSession.startStreamingQuery();
+
+		// Flush any pending Task Agent → this agent messages that accumulated while
+		// the sub-session was not alive in memory.
+		void this.flushPendingMessagesForTarget(workflowRunId, execution.agentName, subSessionId).catch(
+			(err) => {
+				log.warn(
+					`TaskAgentManager.rehydrateSubSession: flushPendingMessagesForTarget failed for ${execution.agentName} (session ${subSessionId}): ${err instanceof Error ? err.message : String(err)}`
+				);
+			}
+		);
 
 		log.info(
 			`TaskAgentManager.rehydrateSubSession: rehydrated sub-session ${subSessionId} for task ${taskId} (node ${execution.workflowNodeId})`

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -870,6 +870,7 @@ export class TaskAgentManager {
 				const existingExecs = this.config.nodeExecutionRepo
 					.listByWorkflowRun(parentTask.workflowRunId)
 					.filter((e) => e.agentName === memberInfo.agentName && e.agentSessionId);
+				// listByWorkflowRun returns rows ORDER BY created_at ASC, so .at(-1) is the most recent.
 				const prevExec = existingExecs.at(-1);
 				if (prevExec?.agentSessionId) {
 					// Reuse existing session — get from memory or restore from DB
@@ -897,7 +898,12 @@ export class TaskAgentManager {
 						}
 
 						// Register a fresh completion callback for this execution turn.
+						// Clear any stale callback registered by a previous execution (e.g. from
+						// rehydrateSubSession, which registers with the old nodeId). Without this,
+						// two callbacks would fire on the next idle: one for the old execution and
+						// one for the new — causing a double NODE_COMPLETE notification.
 						if (memberInfo.nodeId) {
+							this.completionCallbacks.delete(existingSessionId);
 							this.registerCompletionCallback(existingSessionId, async () => {
 								await this.handleSubSessionComplete(taskId, memberInfo.nodeId!, existingSessionId);
 							});

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -557,6 +557,7 @@ export class TaskAgentManager {
 				},
 				pendingMessageRepo: this.config.pendingMessageRepo,
 				spaceAgentInjector: this.config.spaceAgentInjector,
+				taskAgentManager: this,
 			});
 
 			// setRuntimeMcpServers expects McpServerConfig but the MCP SDK's `Server`
@@ -857,6 +858,70 @@ export class TaskAgentManager {
 		init: AgentSessionInit,
 		memberInfo?: SubSessionMemberInfo
 	): Promise<string> {
+		// --- Session reuse: if this agent already has a live session, reuse it.
+		// Each named agent gets exactly one AgentSession per task lifetime; subsequent
+		// node executions inject a new message into the existing session rather than
+		// spawning a fresh one. Sessions are only torn down when the task is archived.
+		// Primary state is in DB: query nodeExecutionRepo for the most recent session ID
+		// for this agent, then check agentSessionIndex (fast path) or lazily rehydrate.
+		if (memberInfo?.agentName) {
+			const parentTask = this.config.taskRepo.getTask(taskId);
+			if (parentTask?.workflowRunId) {
+				const existingExecs = this.config.nodeExecutionRepo
+					.listByWorkflowRun(parentTask.workflowRunId)
+					.filter((e) => e.agentName === memberInfo.agentName && e.agentSessionId);
+				const prevExec = existingExecs.at(-1);
+				if (prevExec?.agentSessionId) {
+					// Reuse existing session — get from memory or restore from DB
+					const existing =
+						this.agentSessionIndex.get(prevExec.agentSessionId) ??
+						(await this.rehydrateSubSession(prevExec.agentSessionId));
+					if (existing) {
+						const existingSessionId = prevExec.agentSessionId;
+						log.info(
+							`TaskAgentManager: reusing session ${existingSessionId} for agent "${memberInfo.agentName}" (task ${taskId}); skipping new session ${sessionId}`
+						);
+
+						// Point the new NodeExecution at the existing session ID.
+						if (memberInfo.nodeId) {
+							const nodeExecs = this.config.nodeExecutionRepo.listByNode(
+								parentTask.workflowRunId,
+								memberInfo.nodeId
+							);
+							const match = nodeExecs.find(
+								(e) => e.agentName === memberInfo.agentName && !e.agentSessionId
+							);
+							if (match) {
+								this.config.nodeExecutionRepo.updateSessionId(match.id, existingSessionId);
+							}
+						}
+
+						// Register a fresh completion callback for this execution turn.
+						if (memberInfo.nodeId) {
+							this.registerCompletionCallback(existingSessionId, async () => {
+								await this.handleSubSessionComplete(taskId, memberInfo.nodeId!, existingSessionId);
+							});
+						}
+
+						// Flush any pending messages for this agent.
+						const runId = parentTask.workflowRunId;
+						void this.flushPendingMessagesForTarget(
+							runId,
+							memberInfo.agentName,
+							existingSessionId
+						).catch((err) => {
+							log.warn(
+								`TaskAgentManager: flushPendingMessagesForTarget failed for ${memberInfo.agentName} (session ${existingSessionId}): ${err instanceof Error ? err.message : String(err)}`
+							);
+						});
+
+						return existingSessionId;
+					}
+				}
+			}
+		}
+
+		// --- First execution for this agent: create a new session.
 		const subSession = AgentSession.fromInit(
 			init,
 			this.config.db,
@@ -1104,6 +1169,45 @@ export class TaskAgentManager {
 			return;
 		}
 		throw new Error(`Sub-session not found: ${subSessionId}`);
+	}
+
+	/**
+	 * Find the live AgentSession for a named agent within a task.
+	 *
+	 * Queries NodeExecution records from DB to find the most recent agentSessionId
+	 * for the given agent name, then returns the live session from agentSessionIndex
+	 * (fast path) or lazily rehydrates it from DB (after daemon restart).
+	 *
+	 * Returns null if the agent has never been spawned for this task.
+	 */
+	async getSubSessionByAgentName(taskId: string, agentName: string): Promise<AgentSession | null> {
+		const task = this.config.taskRepo.getTask(taskId);
+		if (!task?.workflowRunId) return null;
+
+		const executions = this.config.nodeExecutionRepo.listByWorkflowRun(task.workflowRunId);
+		// Most recent execution for this agent that has a session ID assigned
+		const exec = executions.filter((e) => e.agentName === agentName && e.agentSessionId).at(-1);
+		if (!exec?.agentSessionId) return null;
+
+		// Fast path: session already live in memory
+		const cached = this.agentSessionIndex.get(exec.agentSessionId);
+		if (cached) return cached;
+
+		// Slow path: restore from DB (lazy rehydration — no explicit startup step needed)
+		return this.rehydrateSubSession(exec.agentSessionId);
+	}
+
+	/**
+	 * Return all agent names that have an assigned session in this task's workflow run.
+	 * Used by the broadcast ('*') path in send_message.
+	 * Reads from DB so it is correct after daemon restarts without any rehydration step.
+	 */
+	async getAgentNamesForTask(taskId: string): Promise<string[]> {
+		const task = this.config.taskRepo.getTask(taskId);
+		if (!task?.workflowRunId) return [];
+		const executions = this.config.nodeExecutionRepo.listByWorkflowRun(task.workflowRunId);
+		const names = new Set(executions.filter((e) => e.agentSessionId).map((e) => e.agentName));
+		return [...names];
 	}
 
 	// -------------------------------------------------------------------------
@@ -1917,6 +2021,7 @@ export class TaskAgentManager {
 			},
 			pendingMessageRepo: this.config.pendingMessageRepo,
 			spaceAgentInjector: this.config.spaceAgentInjector,
+			taskAgentManager: this,
 		});
 
 		// Merge registry-sourced MCP servers alongside the in-process task-agent server,

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -27,6 +27,10 @@ import type { NodeExecutionRepository } from '../../../storage/repositories/node
 import type { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
+import type {
+	PendingAgentMessageRepository,
+	PendingAgentMessageRecord,
+} from '../../../storage/repositories/pending-agent-message-repository';
 import { jsonResult } from './tool-result';
 import type { ToolResult } from './tool-result';
 import {
@@ -123,6 +127,25 @@ export interface TaskAgentToolsConfig {
 	 * writer authorization.
 	 */
 	myAgentNameAliases?: string[];
+	/**
+	 * Persistent queue for messages whose target node-agent session is not yet
+	 * active. When provided, send_message queues such messages instead of
+	 * failing; TaskAgentManager flushes the queue when the target activates.
+	 * Optional — when absent, the old "no active sessions found" error stands.
+	 */
+	pendingMessageRepo?: PendingAgentMessageRepository;
+	/**
+	 * Injects a message into the Space Agent chat session for this space.
+	 * When provided, `send_message({ target: 'space-agent', ... })` escalates
+	 * directly to the Space Agent without routing through a human.
+	 */
+	spaceAgentInjector?: (spaceId: string, message: string) => Promise<void>;
+	/**
+	 * Optional observability hook — fired whenever a message is queued for
+	 * later delivery via `pendingMessageRepo`. Tests can capture this to
+	 * assert queue behavior without touching DB.
+	 */
+	onMessageQueued?: (record: PendingAgentMessageRecord) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -150,6 +173,9 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		getSpaceAutonomyLevel,
 		myAgentName,
 		myAgentNameAliases,
+		pendingMessageRepo,
+		spaceAgentInjector,
+		onMessageQueued,
 	} = config;
 
 	const agentNameAliases = new Set(
@@ -158,6 +184,30 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 			.map((v) => normalizeAgentNameToken(v))
 			.filter((v) => v.length > 0)
 	);
+
+	/** Reserved agent name used by Task Agent to escalate directly to the Space Agent. */
+	const SPACE_AGENT_TARGET = 'space-agent';
+
+	/** Emit DaemonHub event + invoke observability hook when a message is queued. */
+	function emitQueued(record: PendingAgentMessageRecord): void {
+		onMessageQueued?.(record);
+		if (!daemonHub) return;
+		void daemonHub
+			.emit('space.pendingMessage.queued', {
+				sessionId: 'global',
+				spaceId: space.id,
+				workflowRunId,
+				taskId: record.taskId,
+				targetAgentName: record.targetAgentName,
+				targetKind: record.targetKind,
+				messageId: record.id,
+				attempts: record.attempts,
+				maxAttempts: record.maxAttempts,
+				expiresAt: record.expiresAt,
+				deduped: false,
+			})
+			.catch(() => {});
+	}
 
 	return {
 		/**
@@ -279,36 +329,51 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		 *   - `target: 'coder'` — point-to-point to a single agent
 		 *   - `target: '*'` — broadcast to all permitted targets
 		 *   - `target: ['coder', 'reviewer']` — multicast to multiple agents
+		 *   - `target: 'space-agent'` — escalation to the Space Agent chat session
 		 *
 		 * The Task Agent's agent name is `'task-agent'`. Default bidirectional channels
 		 * are auto-created between the Task Agent and all node agents at
 		 * node-start, so the Task Agent can reach all peers by default.
+		 *
+		 * Queue-until-active:
+		 *   If the target node agent has a declared NodeExecution row but no active
+		 *   session (e.g. during reopen/startup races), the message is persisted to
+		 *   the pending queue and auto-delivered the moment that sub-session becomes
+		 *   active. See `PendingAgentMessageRepository`.
+		 *
+		 * Idempotency:
+		 *   Callers can pass an `idempotency_key` to de-duplicate repeat sends.
+		 *   The key is scoped to `(workflowRunId, targetAgentName)`.
 		 */
-		async send_message(args: SendMessageInput): Promise<ToolResult> {
+		async send_message(args: SendMessageInput & { idempotency_key?: string }): Promise<ToolResult> {
 			const { target, message } = args;
+			const idempotencyKey = args.idempotency_key ?? null;
 			let targetAgentNames: string[];
-			const activeExecutions = nodeExecutionRepo
-				.listByWorkflowRun(workflowRunId)
-				.filter(
-					(execution) =>
-						execution.agentSessionId &&
-						(execution.status === 'in_progress' || execution.status === 'pending')
-				);
-			const knownAgentNames = [
+
+			const allExecutions = nodeExecutionRepo.listByWorkflowRun(workflowRunId);
+			const activeExecutions = allExecutions.filter(
+				(execution) =>
+					execution.agentSessionId &&
+					(execution.status === 'in_progress' || execution.status === 'pending')
+			);
+			// Agents declared in the workflow run — irrespective of current activation state.
+			// Used to distinguish "not-yet-active (queueable)" from "unknown agent (hard error)".
+			const declaredAgentNames = [...new Set(allExecutions.map((e) => e.agentName))];
+			const knownActiveAgentNames = [
 				...new Set(activeExecutions.map((execution) => execution.agentName)),
 			];
 
 			if (target === '*') {
-				if (knownAgentNames.length === 0) {
+				if (knownActiveAgentNames.length === 0) {
 					return jsonResult({
 						success: false,
 						error:
 							`No active workflow agent sessions found for this run. ` +
 							`Broadcast ('*') requires at least one active target.`,
-						availableTargets: knownAgentNames,
+						availableTargets: knownActiveAgentNames,
 					});
 				}
-				targetAgentNames = knownAgentNames;
+				targetAgentNames = knownActiveAgentNames;
 			} else if (Array.isArray(target)) {
 				targetAgentNames = target;
 			} else {
@@ -319,18 +384,114 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				agentName: execution.agentName,
 			}));
 			const delivered: Array<{ agentName: string; sessionId: string }> = [];
+			const queued: Array<{
+				agentName: string;
+				targetKind: 'node_agent' | 'space_agent';
+				messageId: string;
+				deduped: boolean;
+			}> = [];
 			const notFound: string[] = [];
-			const failed: Array<{ agentName: string; sessionId: string; error: string }> = [];
+			const failed: Array<{ agentName: string; sessionId?: string; error: string }> = [];
 
 			// Best-effort delivery: attempt all targets, aggregate errors.
 			for (const targetAgentName of targetAgentNames) {
+				const prefixedMessage = `[Message from task-agent]: ${message}`;
+
+				// --- Space Agent escalation path --------------------------------
+				if (targetAgentName === SPACE_AGENT_TARGET) {
+					if (spaceAgentInjector) {
+						try {
+							await spaceAgentInjector(space.id, prefixedMessage);
+							delivered.push({
+								agentName: targetAgentName,
+								sessionId: `space:chat:${space.id}`,
+							});
+						} catch (err) {
+							const errMsg = err instanceof Error ? err.message : String(err);
+							// Queue for later delivery when possible.
+							if (pendingMessageRepo) {
+								const { record, deduped } = pendingMessageRepo.enqueue({
+									workflowRunId,
+									spaceId: space.id,
+									taskId,
+									targetKind: 'space_agent',
+									targetAgentName: SPACE_AGENT_TARGET,
+									message,
+									idempotencyKey,
+								});
+								queued.push({
+									agentName: targetAgentName,
+									targetKind: 'space_agent',
+									messageId: record.id,
+									deduped,
+								});
+								if (!deduped) emitQueued(record);
+								log.warn(
+									`send_message: Space Agent injection failed (${errMsg}); queued message ${record.id} for retry`
+								);
+							} else {
+								failed.push({ agentName: targetAgentName, error: errMsg });
+							}
+						}
+					} else if (pendingMessageRepo) {
+						// No injector available right now (e.g. Space chat session not yet provisioned);
+						// persist the message so it can be delivered once infrastructure is ready.
+						const { record, deduped } = pendingMessageRepo.enqueue({
+							workflowRunId,
+							spaceId: space.id,
+							taskId,
+							targetKind: 'space_agent',
+							targetAgentName: SPACE_AGENT_TARGET,
+							message,
+							idempotencyKey,
+						});
+						queued.push({
+							agentName: targetAgentName,
+							targetKind: 'space_agent',
+							messageId: record.id,
+							deduped,
+						});
+						if (!deduped) emitQueued(record);
+					} else {
+						failed.push({
+							agentName: targetAgentName,
+							error:
+								'Space Agent escalation is not available in this context ' +
+								'(no injector and no pending-message queue configured).',
+						});
+					}
+					continue;
+				}
+
+				// --- Node-agent path --------------------------------------------
 				const targetSessions = sendPeers.filter((m) => m.agentName === targetAgentName);
 				if (targetSessions.length === 0) {
+					// Agent is declared in the run but no session is active yet.
+					// Queue the message if we have the pending-message repo, else fall back to notFound.
+					const isDeclaredInRun = declaredAgentNames.includes(targetAgentName);
+					if (isDeclaredInRun && pendingMessageRepo) {
+						const { record, deduped } = pendingMessageRepo.enqueue({
+							workflowRunId,
+							spaceId: space.id,
+							taskId,
+							targetKind: 'node_agent',
+							targetAgentName,
+							message,
+							idempotencyKey,
+						});
+						queued.push({
+							agentName: targetAgentName,
+							targetKind: 'node_agent',
+							messageId: record.id,
+							deduped,
+						});
+						if (!deduped) emitQueued(record);
+						continue;
+					}
 					notFound.push(targetAgentName);
 					continue;
 				}
 				for (const targetMember of targetSessions) {
-					const prefixedMessage = `[Message from task-agent]: ${message}`;
 					try {
 						await messageInjector(targetMember.sessionId, prefixedMessage);
 						delivered.push({ agentName: targetAgentName, sessionId: targetMember.sessionId });
@@ -345,7 +506,13 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				}
 			}
 
-			if (notFound.length > 0 && delivered.length === 0 && failed.length === 0) {
+			// If the only outcome was "notFound" with nothing delivered or queued, return hard error.
+			if (
+				notFound.length > 0 &&
+				delivered.length === 0 &&
+				queued.length === 0 &&
+				failed.length === 0
+			) {
 				return jsonResult({
 					success: false,
 					error:
@@ -357,25 +524,37 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 
 			if (failed.length > 0) {
 				return jsonResult({
-					success: delivered.length > 0 ? 'partial' : false,
+					success: delivered.length > 0 || queued.length > 0 ? 'partial' : false,
 					delivered,
+					queued: queued.length > 0 ? queued : undefined,
 					failed,
 					notFoundAgentNames: notFound.length > 0 ? notFound : undefined,
 					message:
-						delivered.length > 0
-							? `Message delivered to ${delivered.length} peer(s) but failed for ${failed.length} peer(s).`
+						delivered.length + queued.length > 0
+							? `Message delivered/queued for ${delivered.length + queued.length} peer(s) but failed for ${failed.length} peer(s).`
 							: `Message delivery failed for all ${failed.length} target(s).`,
 				});
 			}
 
+			const summaryParts: string[] = [];
+			if (delivered.length > 0) {
+				summaryParts.push(
+					`delivered to ${delivered.length} peer(s): ` +
+						delivered.map((t) => `${t.agentName} (${t.sessionId})`).join(', ')
+				);
+			}
+			if (queued.length > 0) {
+				summaryParts.push(
+					`queued for ${queued.length} peer(s) pending activation: ` +
+						queued.map((t) => t.agentName).join(', ')
+				);
+			}
 			return jsonResult({
 				success: true,
 				delivered,
+				queued: queued.length > 0 ? queued : undefined,
 				notFoundAgentNames: notFound.length > 0 ? notFound : undefined,
-				message:
-					`Message delivered to ${delivered.length} peer(s): ` +
-					delivered.map((t) => `${t.agentName} (${t.sessionId})`).join(', ') +
-					'.',
+				message: summaryParts.length > 0 ? `Message ${summaryParts.join('; ')}.` : 'No action.',
 			});
 		},
 
@@ -627,9 +806,23 @@ export function createTaskAgentMcpServer(config: TaskAgentToolsConfig) {
 			'send_message',
 			'Send a message directly to one or more peer node agents via declared channel topology. ' +
 				"Supports point-to-point ('coder'), broadcast ('*'), and multicast (['coder','reviewer']). " +
-				'Validates against declared channels — returns an error with available channels if unauthorized. ' +
+				"Use target 'space-agent' to escalate to the Space Agent without human relay. " +
+				'Messages for declared-but-inactive node agents are persisted to a queue and ' +
+				'auto-delivered once that sub-session activates. ' +
+				'Pass `idempotency_key` to de-duplicate repeated sends. ' +
 				'The Task Agent has default bidirectional channels to all node agents.',
-			SendMessageSchema.shape,
+			{
+				...SendMessageSchema.shape,
+				idempotency_key: z
+					.string()
+					.min(1)
+					.optional()
+					.describe(
+						'Optional idempotency key. If set, re-sends with the same key for the same ' +
+							'(workflowRunId, targetAgentName) are de-duplicated — the existing queued or ' +
+							'delivered message is returned instead of being re-sent.'
+					),
+			},
 			(args) => handlers.send_message(args)
 		),
 		tool(

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -31,6 +31,7 @@ import type {
 	PendingAgentMessageRepository,
 	PendingAgentMessageRecord,
 } from '../../../storage/repositories/pending-agent-message-repository';
+import type { TaskAgentManager } from '../runtime/task-agent-manager';
 import { jsonResult } from './tool-result';
 import type { ToolResult } from './tool-result';
 import {
@@ -146,6 +147,14 @@ export interface TaskAgentToolsConfig {
 	 * assert queue behavior without touching DB.
 	 */
 	onMessageQueued?: (record: PendingAgentMessageRecord) => void;
+	/**
+	 * TaskAgentManager instance for direct session lookup by agent name.
+	 * When provided, send_message uses `getSubSessionByAgentName` and
+	 * `getAgentNamesForTask` to resolve live sessions by name rather than
+	 * filtering NodeExecution records by status. Sessions persist until the
+	 * task is archived, so status-filtered lookup is no longer needed.
+	 */
+	taskAgentManager?: TaskAgentManager;
 }
 
 // ---------------------------------------------------------------------------
@@ -176,6 +185,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		pendingMessageRepo,
 		spaceAgentInjector,
 		onMessageQueued,
+		taskAgentManager,
 	} = config;
 
 	const agentNameAliases = new Set(
@@ -350,39 +360,34 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 			const idempotencyKey = args.idempotency_key ?? null;
 			let targetAgentNames: string[];
 
+			// Agent names that have a live session (DB-driven lookup).
+			// These are reachable regardless of NodeExecution status — sessions persist
+			// until the task is archived, not until the node execution completes.
+			const liveAgentNames = taskAgentManager
+				? await taskAgentManager.getAgentNamesForTask(taskId)
+				: [];
+
+			// Agent names declared in any NodeExecution for this run — used to detect
+			// "agent exists but not yet spawned" (queueable) vs "unknown agent" (hard error).
 			const allExecutions = nodeExecutionRepo.listByWorkflowRun(workflowRunId);
-			const activeExecutions = allExecutions.filter(
-				(execution) =>
-					execution.agentSessionId &&
-					(execution.status === 'in_progress' || execution.status === 'pending')
-			);
-			// Agents declared in the workflow run — irrespective of current activation state.
-			// Used to distinguish "not-yet-active (queueable)" from "unknown agent (hard error)".
 			const declaredAgentNames = [...new Set(allExecutions.map((e) => e.agentName))];
-			const knownActiveAgentNames = [
-				...new Set(activeExecutions.map((execution) => execution.agentName)),
-			];
 
 			if (target === '*') {
-				if (knownActiveAgentNames.length === 0) {
+				if (liveAgentNames.length === 0) {
 					return jsonResult({
 						success: false,
 						error:
 							`No active workflow agent sessions found for this run. ` +
 							`Broadcast ('*') requires at least one active target.`,
-						availableTargets: knownActiveAgentNames,
+						availableTargets: liveAgentNames,
 					});
 				}
-				targetAgentNames = knownActiveAgentNames;
+				targetAgentNames = liveAgentNames;
 			} else if (Array.isArray(target)) {
 				targetAgentNames = target;
 			} else {
 				targetAgentNames = [target];
 			}
-			const sendPeers = activeExecutions.map((execution) => ({
-				sessionId: execution.agentSessionId!,
-				agentName: execution.agentName,
-			}));
 			const delivered: Array<{ agentName: string; sessionId: string }> = [];
 			const queued: Array<{
 				agentName: string;
@@ -464,9 +469,13 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				}
 
 				// --- Node-agent path --------------------------------------------
-				const targetSessions = sendPeers.filter((m) => m.agentName === targetAgentName);
-				if (targetSessions.length === 0) {
-					// Agent is declared in the run but no session is active yet.
+				// Look up the live session directly by agent name. Sessions remain alive
+				// for the full task lifetime (until archive), so no status filter is needed.
+				const liveSession = taskAgentManager
+					? await taskAgentManager.getSubSessionByAgentName(taskId, targetAgentName)
+					: null;
+				if (!liveSession) {
+					// Agent is declared but hasn't been spawned yet (pre-first-execution).
 					// Queue the message if we have the pending-message repo, else fall back to notFound.
 					const isDeclaredInRun = declaredAgentNames.includes(targetAgentName);
 					if (isDeclaredInRun && pendingMessageRepo) {
@@ -491,18 +500,18 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 					notFound.push(targetAgentName);
 					continue;
 				}
-				for (const targetMember of targetSessions) {
-					try {
-						await messageInjector(targetMember.sessionId, prefixedMessage);
-						delivered.push({ agentName: targetAgentName, sessionId: targetMember.sessionId });
-					} catch (err) {
-						const errMsg = err instanceof Error ? err.message : String(err);
-						failed.push({
-							agentName: targetAgentName,
-							sessionId: targetMember.sessionId,
-							error: errMsg,
-						});
-					}
+				// Deliver directly to the live session. injectSubSessionMessage calls
+				// ensureQueryStarted() so an idle session is automatically restarted.
+				try {
+					await messageInjector(liveSession.session.id, prefixedMessage);
+					delivered.push({ agentName: targetAgentName, sessionId: liveSession.session.id });
+				} catch (err) {
+					const errMsg = err instanceof Error ? err.message : String(err);
+					failed.push({
+						agentName: targetAgentName,
+						sessionId: liveSession.session.id,
+						error: errMsg,
+					});
 				}
 			}
 

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -374,6 +374,11 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 
 			if (target === '*') {
 				if (liveAgentNames.length === 0) {
+					if (!taskAgentManager) {
+						log.warn(
+							'send_message: taskAgentManager is absent; broadcast target ("*") cannot resolve live agent names — returning empty-targets error'
+						);
+					}
 					return jsonResult({
 						success: false,
 						error:

--- a/packages/daemon/src/storage/repositories/pending-agent-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/pending-agent-message-repository.ts
@@ -1,0 +1,350 @@
+/**
+ * Pending Agent Message Repository
+ *
+ * Persistent FIFO queue for Task Agent → peer agent (node agent or Space Agent)
+ * messages that could not be delivered immediately because the target session
+ * was not yet active. Rows are drained on target activation, during rehydration
+ * after daemon restart, and by a periodic sweep.
+ *
+ * Design goals:
+ *   - Ordered delivery per `(workflow_run_id, target_agent_name)` via `created_at`
+ *   - Idempotency: `(workflow_run_id, target_agent_name, idempotency_key)` is unique
+ *     when `idempotency_key` is set; re-enqueueing returns the existing row
+ *   - Bounded retries: each failed delivery increments `attempts` and records
+ *     `last_error`; once `attempts >= max_attempts`, the row is moved to
+ *     `status = 'failed'` and no longer drained
+ *   - TTL: `expires_at` is checked on drain; expired rows move to `status = 'expired'`
+ *   - Observability: callers emit `space.pendingMessage.queued` /
+ *     `space.pendingMessage.delivered` events — the repo itself is silent
+ *
+ * Lifecycle statuses:
+ *   pending   — queued, awaiting delivery
+ *   delivered — delivered once; drained from future sweeps
+ *   expired   — never delivered within TTL; kept as a historical record
+ *   failed    — exceeded `max_attempts`; kept as a historical record
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+import { generateUUID } from '@neokai/shared';
+
+export type PendingMessageTargetKind = 'node_agent' | 'space_agent';
+export type PendingMessageStatus = 'pending' | 'delivered' | 'expired' | 'failed';
+
+/** Default TTL for a queued message when the caller doesn't pass `expiresAt`. */
+export const DEFAULT_PENDING_MESSAGE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+/** Default retry cap for delivery attempts. */
+export const DEFAULT_PENDING_MESSAGE_MAX_ATTEMPTS = 5;
+
+export interface PendingAgentMessageRecord {
+	id: string;
+	workflowRunId: string;
+	spaceId: string;
+	taskId: string | null;
+	sourceAgentName: string;
+	targetKind: PendingMessageTargetKind;
+	targetAgentName: string;
+	message: string;
+	idempotencyKey: string | null;
+	attempts: number;
+	maxAttempts: number;
+	lastAttemptAt: number | null;
+	lastError: string | null;
+	status: PendingMessageStatus;
+	deliveredAt: number | null;
+	deliveredSessionId: string | null;
+	expiresAt: number;
+	createdAt: number;
+}
+
+export interface EnqueuePendingMessageInput {
+	workflowRunId: string;
+	spaceId: string;
+	/** Main task ID the Task Agent is orchestrating (optional — null for Space Agent escalations not tied to a specific task). */
+	taskId?: string | null;
+	/** Source agent slot name (defaults to `'task-agent'`). */
+	sourceAgentName?: string;
+	targetKind: PendingMessageTargetKind;
+	targetAgentName: string;
+	message: string;
+	/** Optional idempotency key. If set and a row already exists with the same `(workflowRunId, targetAgentName, idempotencyKey)`, the existing row is returned. */
+	idempotencyKey?: string | null;
+	/** Optional TTL in ms from now; defaults to DEFAULT_PENDING_MESSAGE_TTL_MS. */
+	ttlMs?: number;
+	/** Optional absolute expiry in ms — takes precedence over ttlMs. */
+	expiresAt?: number;
+	/** Optional max attempts cap (defaults to DEFAULT_PENDING_MESSAGE_MAX_ATTEMPTS). */
+	maxAttempts?: number;
+}
+
+export interface EnqueueResult {
+	record: PendingAgentMessageRecord;
+	/** True when this was a pre-existing row matched by idempotency key; false when a new row was inserted. */
+	deduped: boolean;
+}
+
+export class PendingAgentMessageRepository {
+	constructor(private db: BunDatabase) {}
+
+	/**
+	 * Insert a new pending message, or return the existing row if the
+	 * `(workflowRunId, targetAgentName, idempotencyKey)` tuple already exists
+	 * (when `idempotencyKey` is set).
+	 */
+	enqueue(input: EnqueuePendingMessageInput): EnqueueResult {
+		const idempotencyKey = input.idempotencyKey ?? null;
+
+		if (idempotencyKey !== null) {
+			const existing = this.findByIdempotencyKey(
+				input.workflowRunId,
+				input.targetAgentName,
+				idempotencyKey
+			);
+			if (existing) {
+				return { record: existing, deduped: true };
+			}
+		}
+
+		const now = Date.now();
+		const expiresAt = input.expiresAt ?? now + (input.ttlMs ?? DEFAULT_PENDING_MESSAGE_TTL_MS);
+		const id = generateUUID();
+		const sourceAgentName = input.sourceAgentName ?? 'task-agent';
+		const maxAttempts = input.maxAttempts ?? DEFAULT_PENDING_MESSAGE_MAX_ATTEMPTS;
+
+		this.db
+			.prepare(
+				`INSERT INTO pending_agent_messages (
+					id, workflow_run_id, space_id, task_id,
+					source_agent_name, target_kind, target_agent_name,
+					message, idempotency_key,
+					attempts, max_attempts,
+					last_attempt_at, last_error,
+					status, delivered_at, delivered_session_id,
+					expires_at, created_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, NULL, NULL, 'pending', NULL, NULL, ?, ?)`
+			)
+			.run(
+				id,
+				input.workflowRunId,
+				input.spaceId,
+				input.taskId ?? null,
+				sourceAgentName,
+				input.targetKind,
+				input.targetAgentName,
+				input.message,
+				idempotencyKey,
+				maxAttempts,
+				expiresAt,
+				now
+			);
+
+		const record = this.getById(id);
+		if (!record) {
+			throw new Error(`PendingAgentMessageRepository: failed to read back row ${id}`);
+		}
+		return { record, deduped: false };
+	}
+
+	/** Fetch a single row by primary key. */
+	getById(id: string): PendingAgentMessageRecord | null {
+		const row = this.db
+			.prepare('SELECT * FROM pending_agent_messages WHERE id = ?')
+			.get(id) as PendingMessageRow | null;
+		return row ? rowToRecord(row) : null;
+	}
+
+	/** Find a row by its idempotency tuple. Returns null if none matches or if `idempotencyKey` is empty. */
+	findByIdempotencyKey(
+		workflowRunId: string,
+		targetAgentName: string,
+		idempotencyKey: string
+	): PendingAgentMessageRecord | null {
+		if (!idempotencyKey) return null;
+		const row = this.db
+			.prepare(
+				`SELECT * FROM pending_agent_messages
+				 WHERE workflow_run_id = ? AND target_agent_name = ? AND idempotency_key = ?
+				 LIMIT 1`
+			)
+			.get(workflowRunId, targetAgentName, idempotencyKey) as PendingMessageRow | null;
+		return row ? rowToRecord(row) : null;
+	}
+
+	/**
+	 * List pending (still-deliverable) rows for a specific target in a run, oldest first.
+	 * Expired rows are NOT filtered here — callers use `expireStale()` first (or check
+	 * `expiresAt` before delivery) to move expired rows to `status = 'expired'`.
+	 */
+	listPendingForTarget(
+		workflowRunId: string,
+		targetAgentName: string
+	): PendingAgentMessageRecord[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM pending_agent_messages
+				 WHERE workflow_run_id = ? AND target_agent_name = ? AND status = 'pending'
+				 ORDER BY created_at ASC, rowid ASC`
+			)
+			.all(workflowRunId, targetAgentName) as PendingMessageRow[];
+		return rows.map(rowToRecord);
+	}
+
+	/** List all pending rows for a run, oldest first. Used by periodic sweepers. */
+	listPendingForRun(workflowRunId: string): PendingAgentMessageRecord[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM pending_agent_messages
+				 WHERE workflow_run_id = ? AND status = 'pending'
+				 ORDER BY created_at ASC, rowid ASC`
+			)
+			.all(workflowRunId) as PendingMessageRow[];
+		return rows.map(rowToRecord);
+	}
+
+	/** List all pending rows across every run, oldest first. Used by the global sweeper. */
+	listAllPending(): PendingAgentMessageRecord[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM pending_agent_messages
+				 WHERE status = 'pending'
+				 ORDER BY created_at ASC, rowid ASC`
+			)
+			.all() as PendingMessageRow[];
+		return rows.map(rowToRecord);
+	}
+
+	/**
+	 * Mark a row as successfully delivered.
+	 * Records the session ID the message was delivered to and stamps `delivered_at`.
+	 */
+	markDelivered(id: string, sessionId: string): void {
+		const now = Date.now();
+		this.db
+			.prepare(
+				`UPDATE pending_agent_messages
+				 SET status = 'delivered',
+				     delivered_at = ?,
+				     delivered_session_id = ?,
+				     last_attempt_at = ?,
+				     last_error = NULL
+				 WHERE id = ? AND status = 'pending'`
+			)
+			.run(now, sessionId, now, id);
+	}
+
+	/**
+	 * Record a failed delivery attempt.
+	 * Increments `attempts`; if the new count reaches `max_attempts`, the row
+	 * status is set to `'failed'` so it is no longer drained.
+	 */
+	markAttemptFailed(id: string, error: string): PendingAgentMessageRecord | null {
+		const now = Date.now();
+		this.db
+			.prepare(
+				`UPDATE pending_agent_messages
+				 SET attempts = attempts + 1,
+				     last_attempt_at = ?,
+				     last_error = ?,
+				     status = CASE
+				       WHEN attempts + 1 >= max_attempts THEN 'failed'
+				       ELSE status
+				     END
+				 WHERE id = ? AND status = 'pending'`
+			)
+			.run(now, error, id);
+		return this.getById(id);
+	}
+
+	/**
+	 * Sweep expired rows in a run — any pending row with `expires_at <= now`
+	 * is moved to `status = 'expired'`. Returns the number of rows updated.
+	 * Pass `runId = null` to sweep across all runs.
+	 */
+	expireStale(runId: string | null = null): number {
+		const now = Date.now();
+		const stmt =
+			runId === null
+				? this.db.prepare(
+						`UPDATE pending_agent_messages
+						 SET status = 'expired'
+						 WHERE status = 'pending' AND expires_at <= ?`
+					)
+				: this.db.prepare(
+						`UPDATE pending_agent_messages
+						 SET status = 'expired'
+						 WHERE status = 'pending' AND expires_at <= ? AND workflow_run_id = ?`
+					);
+		const result = runId === null ? stmt.run(now) : stmt.run(now, runId);
+		return result.changes;
+	}
+
+	/**
+	 * Delete all rows for a run regardless of status. Used when a workflow run is
+	 * deleted (FK also cascades, but this gives callers an explicit path).
+	 */
+	deleteByRun(workflowRunId: string): number {
+		const result = this.db
+			.prepare('DELETE FROM pending_agent_messages WHERE workflow_run_id = ?')
+			.run(workflowRunId);
+		return result.changes;
+	}
+
+	/** Test helper / diagnostics: list all rows for a run regardless of status. */
+	listAllForRun(workflowRunId: string): PendingAgentMessageRecord[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM pending_agent_messages
+				 WHERE workflow_run_id = ?
+				 ORDER BY created_at ASC, rowid ASC`
+			)
+			.all(workflowRunId) as PendingMessageRow[];
+		return rows.map(rowToRecord);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Internal
+// ---------------------------------------------------------------------------
+
+interface PendingMessageRow {
+	id: string;
+	workflow_run_id: string;
+	space_id: string;
+	task_id: string | null;
+	source_agent_name: string;
+	target_kind: PendingMessageTargetKind;
+	target_agent_name: string;
+	message: string;
+	idempotency_key: string | null;
+	attempts: number;
+	max_attempts: number;
+	last_attempt_at: number | null;
+	last_error: string | null;
+	status: PendingMessageStatus;
+	delivered_at: number | null;
+	delivered_session_id: string | null;
+	expires_at: number;
+	created_at: number;
+}
+
+function rowToRecord(row: PendingMessageRow): PendingAgentMessageRecord {
+	return {
+		id: row.id,
+		workflowRunId: row.workflow_run_id,
+		spaceId: row.space_id,
+		taskId: row.task_id,
+		sourceAgentName: row.source_agent_name,
+		targetKind: row.target_kind,
+		targetAgentName: row.target_agent_name,
+		message: row.message,
+		idempotencyKey: row.idempotency_key,
+		attempts: row.attempts,
+		maxAttempts: row.max_attempts,
+		lastAttemptAt: row.last_attempt_at,
+		lastError: row.last_error,
+		status: row.status,
+		deliveredAt: row.delivered_at,
+		deliveredSessionId: row.delivered_session_id,
+		expiresAt: row.expires_at,
+		createdAt: row.created_at,
+	};
+}

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -392,6 +392,13 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// Migration 91: Add instructions column to space_workflows.
 	//   Stores workflow-level instructions injected into every agent session.
 	runMigration91(db);
+
+	// Migration 92: Persistent queue for Task Agent → node agent / Space Agent
+	//   messages. Enables queue-until-active delivery when a target session is
+	//   declared in the workflow but not yet active (e.g. reopen races, daemon
+	//   restarts, lazy node activation). The flush-on-activate hook in
+	//   TaskAgentManager drains pending rows when a sub-session comes online.
+	runMigration92(db);
 }
 
 /**
@@ -6002,4 +6009,63 @@ function runMigration91(db: BunDatabase): void {
 	if (!tableHasColumn(db, 'space_workflows', 'instructions')) {
 		db.exec(`ALTER TABLE space_workflows ADD COLUMN instructions TEXT DEFAULT NULL`);
 	}
+}
+
+/**
+ * Migration 92: Create the `pending_agent_messages` table.
+ *
+ * Persistent, ordered queue for messages the Task Agent sends to peer agents
+ * (node agents or the Space Agent) when the target session isn't active yet.
+ * Queued rows are drained by `flushPendingMessagesForTarget()` the moment a
+ * sub-session activates, by rehydration paths after daemon restart, and by a
+ * periodic sweep. Rows carry bounded retry (`attempts <= max_attempts`) and
+ * an `expires_at` TTL so stale entries are dropped instead of replayed forever.
+ *
+ * Observability: queued/delivered events are emitted on DaemonHub
+ * (`space.pendingMessage.queued` / `space.pendingMessage.delivered`) so the UI
+ * and tests can observe the queue without polling.
+ */
+export function runMigration92(db: BunDatabase): void {
+	if (!tableExists(db, 'space_workflow_runs')) return;
+	if (tableExists(db, 'pending_agent_messages')) return;
+
+	db.exec(`
+		CREATE TABLE pending_agent_messages (
+			id TEXT PRIMARY KEY,
+			workflow_run_id TEXT NOT NULL,
+			space_id TEXT NOT NULL,
+			task_id TEXT,
+			source_agent_name TEXT NOT NULL DEFAULT 'task-agent',
+			target_kind TEXT NOT NULL
+				CHECK(target_kind IN ('node_agent', 'space_agent')),
+			target_agent_name TEXT NOT NULL,
+			message TEXT NOT NULL,
+			idempotency_key TEXT,
+			attempts INTEGER NOT NULL DEFAULT 0,
+			max_attempts INTEGER NOT NULL DEFAULT 5,
+			last_attempt_at INTEGER,
+			last_error TEXT,
+			status TEXT NOT NULL DEFAULT 'pending'
+				CHECK(status IN ('pending', 'delivered', 'expired', 'failed')),
+			delivered_at INTEGER,
+			delivered_session_id TEXT,
+			expires_at INTEGER NOT NULL,
+			created_at INTEGER NOT NULL,
+			FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE CASCADE
+		)
+	`);
+
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_pending_agent_messages_run_status ` +
+			`ON pending_agent_messages(workflow_run_id, status, created_at)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_pending_agent_messages_run_target ` +
+			`ON pending_agent_messages(workflow_run_id, target_agent_name, status, created_at)`
+	);
+	db.exec(
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_pending_agent_messages_idem ` +
+			`ON pending_agent_messages(workflow_run_id, target_agent_name, idempotency_key) ` +
+			`WHERE idempotency_key IS NOT NULL`
+	);
 }

--- a/packages/daemon/tests/unit/4-space-storage/storage/pending-agent-message-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/pending-agent-message-repository.test.ts
@@ -1,0 +1,498 @@
+/**
+ * PendingAgentMessageRepository Unit Tests
+ *
+ * Covers:
+ *   - enqueue: inserts new row, preserves FIFO order
+ *   - enqueue with idempotencyKey: de-duplicates matching tuples
+ *   - listPendingForTarget / listPendingForRun: filters and orders correctly
+ *   - markDelivered: flips status and records delivery metadata
+ *   - markAttemptFailed: increments attempts and transitions to 'failed' at cap
+ *   - expireStale: moves expired pending rows to 'expired'
+ *   - deleteByRun: removes every row for a run
+ *   - FK cascade: deleting the parent workflow run removes its pending rows
+ */
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import {
+	PendingAgentMessageRepository,
+	DEFAULT_PENDING_MESSAGE_MAX_ATTEMPTS,
+} from '../../../../src/storage/repositories/pending-agent-message-repository.ts';
+import { createSpaceTables } from '../../helpers/space-test-db.ts';
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+let db: Database;
+let repo: PendingAgentMessageRepository;
+
+const SPACE_ID = 'sp1';
+const RUN_ID = 'run-001';
+const TASK_ID = 'task-001';
+
+function freshDb(): Database {
+	const d = new Database(':memory:');
+	createSpaceTables(d);
+	const now = Date.now();
+	d.exec(
+		`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at) VALUES ('${SPACE_ID}', '${SPACE_ID}', '/tmp/test-pending', 'Test Space', ${now}, ${now})`
+	);
+	d.exec(
+		`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at) VALUES ('wf1', '${SPACE_ID}', 'Test Workflow', ${now}, ${now})`
+	);
+	d.exec(
+		`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, started_at, completed_at, created_at, updated_at) VALUES ('${RUN_ID}', '${SPACE_ID}', 'wf1', 'Test Run', 'in_progress', NULL, NULL, ${now}, ${now})`
+	);
+	return d;
+}
+
+beforeEach(() => {
+	db = freshDb();
+	repo = new PendingAgentMessageRepository(db);
+});
+
+// ---------------------------------------------------------------------------
+// enqueue
+// ---------------------------------------------------------------------------
+
+describe('PendingAgentMessageRepository — enqueue', () => {
+	test('inserts a new row with defaults', () => {
+		const { record, deduped } = repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			taskId: TASK_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'review this',
+		});
+
+		expect(deduped).toBe(false);
+		expect(record.workflowRunId).toBe(RUN_ID);
+		expect(record.spaceId).toBe(SPACE_ID);
+		expect(record.taskId).toBe(TASK_ID);
+		expect(record.sourceAgentName).toBe('task-agent');
+		expect(record.targetKind).toBe('node_agent');
+		expect(record.targetAgentName).toBe('coder');
+		expect(record.message).toBe('review this');
+		expect(record.idempotencyKey).toBeNull();
+		expect(record.attempts).toBe(0);
+		expect(record.maxAttempts).toBe(DEFAULT_PENDING_MESSAGE_MAX_ATTEMPTS);
+		expect(record.status).toBe('pending');
+		expect(record.deliveredAt).toBeNull();
+		expect(record.deliveredSessionId).toBeNull();
+		expect(record.lastAttemptAt).toBeNull();
+		expect(record.lastError).toBeNull();
+		expect(record.expiresAt).toBeGreaterThan(Date.now());
+		expect(typeof record.createdAt).toBe('number');
+	});
+
+	test('honours ttlMs by setting expiresAt = now + ttl', () => {
+		const before = Date.now();
+		const { record } = repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'hello',
+			ttlMs: 500,
+		});
+		expect(record.expiresAt).toBeGreaterThanOrEqual(before + 500);
+		// Allow some slack but ensure TTL is short-lived.
+		expect(record.expiresAt).toBeLessThanOrEqual(Date.now() + 1000);
+	});
+
+	test('honours custom maxAttempts', () => {
+		const { record } = repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'hello',
+			maxAttempts: 2,
+		});
+		expect(record.maxAttempts).toBe(2);
+	});
+
+	test('honours custom sourceAgentName', () => {
+		const { record } = repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'space_agent',
+			targetAgentName: 'space-agent',
+			sourceAgentName: 'task-agent',
+			message: 'escalate',
+		});
+		expect(record.sourceAgentName).toBe('task-agent');
+		expect(record.targetKind).toBe('space_agent');
+	});
+
+	test('idempotencyKey de-duplicates repeat enqueues', () => {
+		const first = repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'msg-1',
+			idempotencyKey: 'key-abc',
+		});
+		const second = repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'msg-1-repeat',
+			idempotencyKey: 'key-abc',
+		});
+
+		expect(first.deduped).toBe(false);
+		expect(second.deduped).toBe(true);
+		expect(second.record.id).toBe(first.record.id);
+		// The original message is preserved — re-enqueue does not overwrite.
+		expect(second.record.message).toBe('msg-1');
+	});
+
+	test('idempotencyKey is scoped by (runId, targetAgentName)', () => {
+		const a = repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'for-coder',
+			idempotencyKey: 'shared',
+		});
+		const b = repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'reviewer',
+			message: 'for-reviewer',
+			idempotencyKey: 'shared',
+		});
+		// Different target → different row even with same key.
+		expect(a.record.id).not.toBe(b.record.id);
+		expect(b.deduped).toBe(false);
+	});
+
+	test('two enqueues without idempotencyKey produce distinct rows', () => {
+		const a = repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'a',
+		});
+		const b = repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'b',
+		});
+		expect(a.record.id).not.toBe(b.record.id);
+		expect(b.deduped).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// listPending
+// ---------------------------------------------------------------------------
+
+describe('PendingAgentMessageRepository — listPending', () => {
+	test('listPendingForTarget returns rows in FIFO order', () => {
+		const a = repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'first',
+		});
+		const b = repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'second',
+		});
+
+		const rows = repo.listPendingForTarget(RUN_ID, 'coder');
+		expect(rows.map((r) => r.id)).toEqual([a.record.id, b.record.id]);
+		expect(rows.map((r) => r.message)).toEqual(['first', 'second']);
+	});
+
+	test('listPendingForTarget filters by target', () => {
+		repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'for-coder',
+		});
+		repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'reviewer',
+			message: 'for-reviewer',
+		});
+
+		const forCoder = repo.listPendingForTarget(RUN_ID, 'coder');
+		const forReviewer = repo.listPendingForTarget(RUN_ID, 'reviewer');
+		expect(forCoder).toHaveLength(1);
+		expect(forReviewer).toHaveLength(1);
+		expect(forCoder[0].message).toBe('for-coder');
+		expect(forReviewer[0].message).toBe('for-reviewer');
+	});
+
+	test('listPendingForTarget excludes delivered rows', () => {
+		const { record } = repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'hello',
+		});
+		repo.markDelivered(record.id, 'sess-1');
+
+		const rows = repo.listPendingForTarget(RUN_ID, 'coder');
+		expect(rows).toHaveLength(0);
+	});
+
+	test('listPendingForRun returns every pending row for the run', () => {
+		repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'a',
+		});
+		repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'space_agent',
+			targetAgentName: 'space-agent',
+			message: 'b',
+		});
+		const rows = repo.listPendingForRun(RUN_ID);
+		expect(rows).toHaveLength(2);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// markDelivered
+// ---------------------------------------------------------------------------
+
+describe('PendingAgentMessageRepository — markDelivered', () => {
+	test('transitions a pending row to delivered with session id', () => {
+		const { record } = repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'hi',
+		});
+
+		repo.markDelivered(record.id, 'sess-xyz');
+
+		const after = repo.getById(record.id);
+		expect(after).not.toBeNull();
+		expect(after!.status).toBe('delivered');
+		expect(after!.deliveredSessionId).toBe('sess-xyz');
+		expect(after!.deliveredAt).not.toBeNull();
+		expect(after!.lastAttemptAt).not.toBeNull();
+		expect(after!.lastError).toBeNull();
+	});
+
+	test('is a no-op when the row is no longer pending', () => {
+		const { record } = repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'hi',
+		});
+		repo.markDelivered(record.id, 'sess-1');
+		// Second call must not overwrite the first delivery metadata.
+		repo.markDelivered(record.id, 'sess-2');
+
+		const after = repo.getById(record.id);
+		expect(after!.deliveredSessionId).toBe('sess-1');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// markAttemptFailed
+// ---------------------------------------------------------------------------
+
+describe('PendingAgentMessageRepository — markAttemptFailed', () => {
+	test('increments attempts and records last_error', () => {
+		const { record } = repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'hi',
+			maxAttempts: 3,
+		});
+
+		const after = repo.markAttemptFailed(record.id, 'boom');
+		expect(after!.attempts).toBe(1);
+		expect(after!.lastError).toBe('boom');
+		expect(after!.lastAttemptAt).not.toBeNull();
+		// Still pending because 1 < 3.
+		expect(after!.status).toBe('pending');
+	});
+
+	test('transitions to failed once attempts reach maxAttempts', () => {
+		const { record } = repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'hi',
+			maxAttempts: 2,
+		});
+
+		repo.markAttemptFailed(record.id, 'err-1');
+		const after = repo.markAttemptFailed(record.id, 'err-2');
+
+		expect(after!.attempts).toBe(2);
+		expect(after!.status).toBe('failed');
+		// Subsequent failure calls should be ignored (status is no longer 'pending').
+		repo.markAttemptFailed(record.id, 'err-3');
+		const again = repo.getById(record.id);
+		expect(again!.attempts).toBe(2);
+		expect(again!.lastError).toBe('err-2');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// expireStale
+// ---------------------------------------------------------------------------
+
+describe('PendingAgentMessageRepository — expireStale', () => {
+	test('moves expired pending rows to expired', () => {
+		// Row that expires immediately
+		const { record: stale } = repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'stale',
+			expiresAt: Date.now() - 1_000,
+		});
+		// Fresh row with far-future expiry
+		const { record: fresh } = repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'fresh',
+			expiresAt: Date.now() + 60_000,
+		});
+
+		const count = repo.expireStale(RUN_ID);
+		expect(count).toBe(1);
+
+		const staleAfter = repo.getById(stale.id);
+		expect(staleAfter!.status).toBe('expired');
+		const freshAfter = repo.getById(fresh.id);
+		expect(freshAfter!.status).toBe('pending');
+	});
+
+	test('runId=null sweeps across all runs', () => {
+		// Add a second workflow run
+		const now = Date.now();
+		db.exec(
+			`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, started_at, completed_at, created_at, updated_at) VALUES ('run-002', '${SPACE_ID}', 'wf1', 'Run 2', 'in_progress', NULL, NULL, ${now}, ${now})`
+		);
+
+		repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'a',
+			expiresAt: now - 1,
+		});
+		repo.enqueue({
+			workflowRunId: 'run-002',
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'b',
+			expiresAt: now - 1,
+		});
+
+		const count = repo.expireStale();
+		expect(count).toBe(2);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// deleteByRun + FK cascade
+// ---------------------------------------------------------------------------
+
+describe('PendingAgentMessageRepository — delete + cascade', () => {
+	test('deleteByRun removes every row for a run', () => {
+		repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'a',
+		});
+		repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'reviewer',
+			message: 'b',
+		});
+		const count = repo.deleteByRun(RUN_ID);
+		expect(count).toBe(2);
+		expect(repo.listAllForRun(RUN_ID)).toEqual([]);
+	});
+
+	test('deleting the parent workflow run cascades', () => {
+		repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'a',
+		});
+		expect(repo.listAllForRun(RUN_ID)).toHaveLength(1);
+
+		db.prepare('DELETE FROM space_workflow_runs WHERE id = ?').run(RUN_ID);
+		expect(repo.listAllForRun(RUN_ID)).toHaveLength(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// findByIdempotencyKey
+// ---------------------------------------------------------------------------
+
+describe('PendingAgentMessageRepository — findByIdempotencyKey', () => {
+	test('returns null for unknown keys', () => {
+		expect(repo.findByIdempotencyKey(RUN_ID, 'coder', 'nope')).toBeNull();
+	});
+
+	test('returns null for empty key', () => {
+		expect(repo.findByIdempotencyKey(RUN_ID, 'coder', '')).toBeNull();
+	});
+
+	test('returns the matching row when present', () => {
+		const { record } = repo.enqueue({
+			workflowRunId: RUN_ID,
+			spaceId: SPACE_ID,
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'hi',
+			idempotencyKey: 'k-1',
+		});
+		const found = repo.findByIdempotencyKey(RUN_ID, 'coder', 'k-1');
+		expect(found).not.toBeNull();
+		expect(found!.id).toBe(record.id);
+	});
+});

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
@@ -690,6 +690,189 @@ describe('TaskAgentManager', () => {
 			expect(returnedId).toBe(subSessionId);
 		});
 
+		test('reuses existing session when same agent name is called a second time', async () => {
+			// Seed a workflow run so listByWorkflowRun can return prior NodeExecution rows.
+			// Note: node_executions has a UNIQUE(workflow_run_id, workflow_node_id, agent_name)
+			// constraint, so there is only ever ONE NodeExecution per (run, node, agent).
+			// Re-execution of the same node reuses the same NodeExecution row; createSubSession
+			// detects the pre-existing agentSessionId on that row and skips creating a new session.
+			const wfId = 'wf-reuse-session';
+			const wfRunId = 'run-reuse-session';
+			const now = Date.now();
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, tags, layout, created_at, updated_at)
+         VALUES (?, ?, ?, '', null, '[]', '{}', ?, ?)`
+				)
+				.run(wfId, ctx.spaceId, 'WF Reuse', now, now);
+			const stepId = 'step-reuse-1';
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO space_workflow_nodes (id, workflow_id, name, description, created_at, updated_at)
+         VALUES (?, ?, ?, '', ?, ?)`
+				)
+				.run(stepId, wfId, 'Step 1', now, now);
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at, updated_at)
+         VALUES (?, ?, ?, '', 'in_progress', ?, ?)`
+				)
+				.run(wfRunId, ctx.spaceId, wfId, now, now);
+
+			const parentTask = await ctx.taskManager.createTask({
+				title: 'Reuse task',
+				description: '',
+				taskType: 'coding',
+				status: 'in_progress',
+				workflowRunId: wfRunId,
+			});
+			await ctx.manager.spawnTaskAgent(
+				{ ...parentTask, workflowRunId: wfRunId },
+				ctx.space,
+				null,
+				null
+			);
+
+			// First execution: create the single NodeExecution row for (run, node, coder).
+			const exec = ctx.nodeExecutionRepo.create({
+				workflowRunId: wfRunId,
+				workflowNodeId: stepId,
+				agentName: 'coder',
+				agentId: ctx.agentId,
+				status: 'in_progress',
+			});
+			const subSessionId1 = `space:${ctx.spaceId}:task:${parentTask.id}:exec:${exec.id}`;
+			const returned1 = await ctx.manager.createSubSession(
+				parentTask.id,
+				subSessionId1,
+				{
+					sessionId: subSessionId1,
+					workspacePath: '/tmp/ws',
+				} as unknown as import('../../../../src/lib/agent/agent-session.ts').AgentSessionInit,
+				{ agentId: ctx.agentId, agentName: 'coder', nodeId: stepId }
+			);
+			expect(returned1).toBe(subSessionId1);
+			const sessionsBefore = ctx.createdSessions.size;
+
+			// Second execution: same NodeExecution row, different desired session ID.
+			// The UNIQUE constraint means the runtime would call createOrIgnore (existing row
+			// returned unchanged). createSubSession should detect agentSessionId is already set
+			// and reuse the first session without spawning a new one.
+			const subSessionId2 = `space:${ctx.spaceId}:task:${parentTask.id}:exec:${exec.id}:2`;
+			const returned2 = await ctx.manager.createSubSession(
+				parentTask.id,
+				subSessionId2,
+				{
+					sessionId: subSessionId2,
+					workspacePath: '/tmp/ws',
+				} as unknown as import('../../../../src/lib/agent/agent-session.ts').AgentSessionInit,
+				{ agentId: ctx.agentId, agentName: 'coder', nodeId: stepId }
+			);
+
+			// Should have returned the original session ID, not created a new one.
+			expect(returned2).toBe(subSessionId1);
+			expect(ctx.createdSessions.size).toBe(sessionsBefore);
+		});
+
+		test('second createSubSession for same agent clears stale callbacks before registering new one', async () => {
+			// Seed workflow run — same pattern as the reuse test above.
+			const wfId = 'wf-cb-clear';
+			const wfRunId = 'run-cb-clear';
+			const now = Date.now();
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, tags, layout, created_at, updated_at)
+         VALUES (?, ?, ?, '', null, '[]', '{}', ?, ?)`
+				)
+				.run(wfId, ctx.spaceId, 'WF CB Clear', now, now);
+			const stepId = 'step-cb-clear';
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO space_workflow_nodes (id, workflow_id, name, description, created_at, updated_at)
+         VALUES (?, ?, ?, '', ?, ?)`
+				)
+				.run(stepId, wfId, 'Step CB', now, now);
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at, updated_at)
+         VALUES (?, ?, ?, '', 'in_progress', ?, ?)`
+				)
+				.run(wfRunId, ctx.spaceId, wfId, now, now);
+
+			const parentTask = await ctx.taskManager.createTask({
+				title: 'CB clear task',
+				description: '',
+				taskType: 'coding',
+				status: 'in_progress',
+				workflowRunId: wfRunId,
+			});
+			await ctx.manager.spawnTaskAgent(
+				{ ...parentTask, workflowRunId: wfRunId },
+				ctx.space,
+				null,
+				null
+			);
+
+			// First execution: single NodeExecution row for (run, node, coder).
+			const exec = ctx.nodeExecutionRepo.create({
+				workflowRunId: wfRunId,
+				workflowNodeId: stepId,
+				agentName: 'coder',
+				agentId: ctx.agentId,
+				status: 'in_progress',
+			});
+			const subSessionId = `space:${ctx.spaceId}:task:${parentTask.id}:exec:${exec.id}`;
+			await ctx.manager.createSubSession(
+				parentTask.id,
+				subSessionId,
+				{
+					sessionId: subSessionId,
+					workspacePath: '/tmp/ws',
+				} as unknown as import('../../../../src/lib/agent/agent-session.ts').AgentSessionInit,
+				{ agentId: ctx.agentId, agentName: 'coder', nodeId: stepId }
+			);
+
+			// Manually add a stale extra callback to simulate what rehydrateSubSession would add
+			// (rehydrateSubSession registers a callback with the OLD nodeId).
+			let staleCallbackFired = false;
+			ctx.manager.registerCompletionCallback(subSessionId, async () => {
+				staleCallbackFired = true;
+			});
+
+			// Second createSubSession call for the same agent (re-execution of the node).
+			// Should clear stale callbacks before registering the new one.
+			const subSessionId2 = `space:${ctx.spaceId}:task:${parentTask.id}:exec:${exec.id}:2`;
+			await ctx.manager.createSubSession(
+				parentTask.id,
+				subSessionId2,
+				{
+					sessionId: subSessionId2,
+					workspacePath: '/tmp/ws',
+				} as unknown as import('../../../../src/lib/agent/agent-session.ts').AgentSessionInit,
+				{ agentId: ctx.agentId, agentName: 'coder', nodeId: stepId }
+			);
+
+			// Fire the idle event to trigger callbacks
+			const subSession = ctx.createdSessions.get(subSessionId)!;
+			subSession._sdkMessageCount = 3;
+
+			const taskAgentSessionId = `space:${ctx.spaceId}:task:${parentTask.id}`;
+			const taskAgentSession = ctx.createdSessions.get(taskAgentSessionId)!;
+			const msgsBefore = taskAgentSession._enqueuedMessages.length;
+
+			ctx.daemonHub.emit('session.updated', {
+				sessionId: subSessionId,
+				processingState: { status: 'idle' },
+			});
+			await new Promise((r) => setTimeout(r, 0));
+
+			// The stale callback registered between the two createSubSession calls should
+			// have been cleared by the second createSubSession, so it must NOT have fired.
+			expect(staleCallbackFired).toBe(false);
+			// The new callback (handleSubSessionComplete) should have fired — injecting NODE_COMPLETE
+			expect(taskAgentSession._enqueuedMessages.length).toBeGreaterThan(msgsBefore);
+		});
+
 		test('preserves init mcpServers when app MCP registry servers are injected', async () => {
 			const task = await makeTask(ctx.taskManager);
 			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
@@ -33,6 +33,7 @@ import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.t
 import { SpaceRuntime } from '../../../../src/lib/space/runtime/space-runtime.ts';
 import { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
 import { AgentSession } from '../../../../src/lib/agent/agent-session.ts';
+import { PendingAgentMessageRepository } from '../../../../src/storage/repositories/pending-agent-message-repository.ts';
 import type { Space, SpaceWorkflow, SpaceWorkflowRun, SpaceTask } from '@neokai/shared';
 import type { AgentProcessingState } from '@neokai/shared';
 
@@ -1677,6 +1678,149 @@ describe('TaskAgentManager', () => {
 			}
 
 			restoreSpy.mockRestore();
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// flushPendingMessagesForSpaceAgent
+	// -----------------------------------------------------------------------
+
+	describe('flushPendingMessagesForSpaceAgent', () => {
+		test('delivers queued Space Agent message via spaceAgentInjector', async () => {
+			const { db: testDb, dir: testDir } = makeDb();
+			const testSpaceId = 'space-flush-sa';
+			const testRunId = 'run-flush-sa';
+			const testWfId = 'wf-flush-sa';
+			const now = Date.now();
+
+			seedSpaceRow(testDb, testSpaceId);
+			testDb
+				.prepare(
+					`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, tags, layout, created_at, updated_at)
+           VALUES (?, ?, ?, '', null, '[]', '{}', ?, ?)`
+				)
+				.run(testWfId, testSpaceId, 'Test WF', now, now);
+			testDb
+				.prepare(
+					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at, updated_at)
+           VALUES (?, ?, ?, '', 'in_progress', ?, ?)`
+				)
+				.run(testRunId, testSpaceId, testWfId, now, now);
+
+			const pendingRepo = new PendingAgentMessageRepository(testDb);
+			pendingRepo.enqueue({
+				workflowRunId: testRunId,
+				spaceId: testSpaceId,
+				targetKind: 'space_agent',
+				targetAgentName: 'space-agent',
+				message: 'escalation: please review task',
+			});
+
+			const injectedCalls: string[] = [];
+			const flushManager = new TaskAgentManager({
+				db: ctx.mockDb as unknown as import('../../../../src/storage/database.ts').Database,
+				sessionManager: ctx.manager[
+					'config' as unknown as keyof typeof ctx.manager
+				] as unknown as import('../../../../src/lib/session/session-manager.ts').SessionManager,
+				spaceManager: ctx.spaceManager,
+				spaceAgentManager: ctx.agentManager,
+				spaceWorkflowManager: ctx.workflowManager,
+				spaceRuntimeService:
+					{} as unknown as import('../../../../src/lib/space/runtime/space-runtime-service.ts').SpaceRuntimeService,
+				taskRepo: ctx.taskRepo,
+				workflowRunRepo: ctx.workflowRunRepo,
+				daemonHub:
+					ctx.daemonHub as unknown as import('../../../../src/lib/daemon-hub.ts').DaemonHub,
+				messageHub: {} as unknown as import('@neokai/shared').MessageHub,
+				getApiKey: async () => 'test-key',
+				defaultModel: 'claude-sonnet-4-5-20250929',
+				nodeExecutionRepo: ctx.nodeExecutionRepo,
+				pendingMessageRepo: pendingRepo,
+				spaceAgentInjector: async (_sid: string, msg: string) => {
+					injectedCalls.push(msg);
+				},
+			} as unknown as import('../../../../src/lib/space/runtime/task-agent-manager.ts').TaskAgentManagerConfig);
+
+			await flushManager.flushPendingMessagesForSpaceAgent(testSpaceId, testRunId);
+
+			expect(injectedCalls).toHaveLength(1);
+			expect(injectedCalls[0]).toContain('escalation: please review task');
+
+			// Row should be marked delivered
+			const rows = pendingRepo.listAllForRun(testRunId);
+			expect(rows).toHaveLength(1);
+			expect(rows[0].status).toBe('delivered');
+
+			try {
+				rmSync(testDir, { recursive: true, force: true });
+			} catch {
+				// ignore
+			}
+		});
+
+		test('no-op when pendingMessageRepo is absent', async () => {
+			// ctx.manager has no pendingMessageRepo — should resolve without throwing
+			await expect(
+				ctx.manager.flushPendingMessagesForSpaceAgent(ctx.spaceId, 'any-run')
+			).resolves.toBeUndefined();
+		});
+
+		test('no-op when there are no pending Space Agent messages', async () => {
+			const { db: testDb, dir: testDir } = makeDb();
+			const testSpaceId = 'space-flush-empty';
+			const testRunId = 'run-flush-empty';
+			const testWfId = 'wf-flush-empty';
+			const now = Date.now();
+
+			seedSpaceRow(testDb, testSpaceId);
+			testDb
+				.prepare(
+					`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, tags, layout, created_at, updated_at)
+           VALUES (?, ?, ?, '', null, '[]', '{}', ?, ?)`
+				)
+				.run(testWfId, testSpaceId, 'Test WF', now, now);
+			testDb
+				.prepare(
+					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at, updated_at)
+           VALUES (?, ?, ?, '', 'in_progress', ?, ?)`
+				)
+				.run(testRunId, testSpaceId, testWfId, now, now);
+
+			const pendingRepo = new PendingAgentMessageRepository(testDb);
+			let injectorCalled = false;
+
+			const emptyManager = new TaskAgentManager({
+				db: ctx.mockDb as unknown as import('../../../../src/storage/database.ts').Database,
+				sessionManager: ctx.manager[
+					'config' as unknown as keyof typeof ctx.manager
+				] as unknown as import('../../../../src/lib/session/session-manager.ts').SessionManager,
+				spaceManager: ctx.spaceManager,
+				spaceAgentManager: ctx.agentManager,
+				spaceWorkflowManager: ctx.workflowManager,
+				spaceRuntimeService:
+					{} as unknown as import('../../../../src/lib/space/runtime/space-runtime-service.ts').SpaceRuntimeService,
+				taskRepo: ctx.taskRepo,
+				workflowRunRepo: ctx.workflowRunRepo,
+				daemonHub:
+					ctx.daemonHub as unknown as import('../../../../src/lib/daemon-hub.ts').DaemonHub,
+				messageHub: {} as unknown as import('@neokai/shared').MessageHub,
+				getApiKey: async () => 'test-key',
+				defaultModel: 'claude-sonnet-4-5-20250929',
+				nodeExecutionRepo: ctx.nodeExecutionRepo,
+				pendingMessageRepo: pendingRepo,
+				spaceAgentInjector: async () => {
+					injectorCalled = true;
+				},
+			} as unknown as import('../../../../src/lib/space/runtime/task-agent-manager.ts').TaskAgentManagerConfig);
+
+			await emptyManager.flushPendingMessagesForSpaceAgent(testSpaceId, testRunId);
+			expect(injectorCalled).toBe(false);
+
+			try {
+				rmSync(testDir, { recursive: true, force: true });
+			} catch {
+				// ignore
+			}
 		});
 	});
 });

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-tools.test.ts
@@ -1126,7 +1126,8 @@ describe('createTaskAgentToolHandlers — send_message queue-until-active', () =
 		const wf = buildTwoStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
 		const { run, mainTask } = await startRun(ctx, wf);
 
-		// Active agent: coder.
+		// Coder has a live session (simulated via mock taskAgentManager backed by nodeExecutionRepo).
+		// Reviewer is declared in NodeExecution but has no live session yet.
 		ctx.nodeExecutionRepo.create({
 			workflowRunId: run.id,
 			workflowNodeId: 'active-node',
@@ -1134,7 +1135,6 @@ describe('createTaskAgentToolHandlers — send_message queue-until-active', () =
 			agentSessionId: 'session-coder',
 			status: 'in_progress',
 		});
-		// Declared but inactive: reviewer.
 		ctx.nodeExecutionRepo.create({
 			workflowRunId: run.id,
 			workflowNodeId: 'declared-node',
@@ -1147,6 +1147,15 @@ describe('createTaskAgentToolHandlers — send_message queue-until-active', () =
 		);
 		const pendingRepo = new PendingAgentMessageRepository(ctx.db);
 
+		// Mock taskAgentManager: coder has a live session, reviewer does not.
+		const mockTaskAgentManager = {
+			getAgentNamesForTask: async (_taskId: string) => ['coder'],
+			getSubSessionByAgentName: async (_taskId: string, agentName: string) => {
+				if (agentName === 'coder') return { session: { id: 'session-coder' } };
+				return null;
+			},
+		} as unknown as TaskAgentToolsConfig['taskAgentManager'];
+
 		const delivered: Array<{ sessionId: string; message: string }> = [];
 		const config: TaskAgentToolsConfig = {
 			...makeConfig(ctx, mainTask.id, run.id, {
@@ -1155,6 +1164,7 @@ describe('createTaskAgentToolHandlers — send_message queue-until-active', () =
 				},
 			}),
 			pendingMessageRepo: pendingRepo,
+			taskAgentManager: mockTaskAgentManager,
 		};
 		const handlers = createTaskAgentToolHandlers(config);
 

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-tools.test.ts
@@ -1025,3 +1025,358 @@ describe('createTaskAgentToolHandlers — list_group_members', () => {
 		}
 	});
 });
+
+// ===========================================================================
+// send_message queue-until-active + Space Agent escalation
+// ===========================================================================
+
+describe('createTaskAgentToolHandlers — send_message queue-until-active', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('queues message when target is declared but inactive', async () => {
+		const wf = buildTwoStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		// Declare "reviewer" in the run with no active session (pending, no session id).
+		ctx.nodeExecutionRepo.create({
+			workflowRunId: run.id,
+			workflowNodeId: 'declared-node',
+			agentName: 'reviewer',
+			status: 'pending',
+		});
+
+		const { PendingAgentMessageRepository } = await import(
+			'../../../../src/storage/repositories/pending-agent-message-repository.ts'
+		);
+		const pendingRepo = new PendingAgentMessageRepository(ctx.db);
+
+		const { hub, emittedEvents } = makeMockDaemonHub();
+		const queuedRecords: Array<{ id: string; targetAgentName: string }> = [];
+
+		const config: TaskAgentToolsConfig = {
+			...makeConfig(ctx, mainTask.id, run.id),
+			pendingMessageRepo: pendingRepo,
+			daemonHub: hub,
+			onMessageQueued: (rec) =>
+				queuedRecords.push({ id: rec.id, targetAgentName: rec.targetAgentName }),
+		};
+		const handlers = createTaskAgentToolHandlers(config);
+
+		const result = await handlers.send_message({
+			target: 'reviewer',
+			message: 'ping',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.queued).toHaveLength(1);
+		expect(parsed.queued[0].agentName).toBe('reviewer');
+		expect(parsed.queued[0].targetKind).toBe('node_agent');
+		expect(parsed.queued[0].deduped).toBe(false);
+
+		// Queued record is persisted.
+		const pending = pendingRepo.listPendingForTarget(run.id, 'reviewer');
+		expect(pending).toHaveLength(1);
+		expect(pending[0].message).toBe('ping');
+
+		// Observability: onMessageQueued hook fires + DaemonHub event is emitted.
+		expect(queuedRecords).toHaveLength(1);
+		expect(queuedRecords[0].targetAgentName).toBe('reviewer');
+		const queuedEvent = emittedEvents.find((e) => e.name === 'space.pendingMessage.queued');
+		expect(queuedEvent).toBeDefined();
+		expect(queuedEvent!.payload.targetAgentName).toBe('reviewer');
+		expect(queuedEvent!.payload.targetKind).toBe('node_agent');
+	});
+
+	test('returns notFoundAgentNames when target is not declared in run', async () => {
+		const wf = buildTwoStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		const { PendingAgentMessageRepository } = await import(
+			'../../../../src/storage/repositories/pending-agent-message-repository.ts'
+		);
+		const pendingRepo = new PendingAgentMessageRepository(ctx.db);
+
+		const config: TaskAgentToolsConfig = {
+			...makeConfig(ctx, mainTask.id, run.id),
+			pendingMessageRepo: pendingRepo,
+		};
+		const handlers = createTaskAgentToolHandlers(config);
+
+		const result = await handlers.send_message({
+			target: 'ghost-agent',
+			message: 'hello',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.notFoundAgentNames).toEqual(['ghost-agent']);
+		// Nothing queued because agent isn't declared in the run.
+		expect(pendingRepo.listAllPending()).toHaveLength(0);
+	});
+
+	test('delivers to active target while queuing inactive target (partial)', async () => {
+		const wf = buildTwoStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		// Active agent: coder.
+		ctx.nodeExecutionRepo.create({
+			workflowRunId: run.id,
+			workflowNodeId: 'active-node',
+			agentName: 'coder',
+			agentSessionId: 'session-coder',
+			status: 'in_progress',
+		});
+		// Declared but inactive: reviewer.
+		ctx.nodeExecutionRepo.create({
+			workflowRunId: run.id,
+			workflowNodeId: 'declared-node',
+			agentName: 'reviewer',
+			status: 'pending',
+		});
+
+		const { PendingAgentMessageRepository } = await import(
+			'../../../../src/storage/repositories/pending-agent-message-repository.ts'
+		);
+		const pendingRepo = new PendingAgentMessageRepository(ctx.db);
+
+		const delivered: Array<{ sessionId: string; message: string }> = [];
+		const config: TaskAgentToolsConfig = {
+			...makeConfig(ctx, mainTask.id, run.id, {
+				messageInjector: async (sessionId, message) => {
+					delivered.push({ sessionId, message });
+				},
+			}),
+			pendingMessageRepo: pendingRepo,
+		};
+		const handlers = createTaskAgentToolHandlers(config);
+
+		const result = await handlers.send_message({
+			target: ['coder', 'reviewer'],
+			message: 'hi all',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.delivered).toHaveLength(1);
+		expect(parsed.delivered[0].agentName).toBe('coder');
+		expect(parsed.queued).toHaveLength(1);
+		expect(parsed.queued[0].agentName).toBe('reviewer');
+
+		// The coder got the message right away.
+		expect(delivered).toHaveLength(1);
+		expect(delivered[0].message).toBe('[Message from task-agent]: hi all');
+
+		// The reviewer message is queued.
+		const pending = pendingRepo.listPendingForTarget(run.id, 'reviewer');
+		expect(pending).toHaveLength(1);
+	});
+
+	test('idempotency_key dedupes repeated queue attempts', async () => {
+		const wf = buildTwoStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		ctx.nodeExecutionRepo.create({
+			workflowRunId: run.id,
+			workflowNodeId: 'declared-node',
+			agentName: 'reviewer',
+			status: 'pending',
+		});
+
+		const { PendingAgentMessageRepository } = await import(
+			'../../../../src/storage/repositories/pending-agent-message-repository.ts'
+		);
+		const pendingRepo = new PendingAgentMessageRepository(ctx.db);
+
+		const config: TaskAgentToolsConfig = {
+			...makeConfig(ctx, mainTask.id, run.id),
+			pendingMessageRepo: pendingRepo,
+		};
+		const handlers = createTaskAgentToolHandlers(config);
+
+		const r1 = await handlers.send_message({
+			target: 'reviewer',
+			message: 'v1',
+			idempotency_key: 'dedupe-key-1',
+		});
+		const p1 = JSON.parse(r1.content[0].text);
+		expect(p1.queued[0].deduped).toBe(false);
+
+		const r2 = await handlers.send_message({
+			target: 'reviewer',
+			message: 'v2-replay',
+			idempotency_key: 'dedupe-key-1',
+		});
+		const p2 = JSON.parse(r2.content[0].text);
+		expect(p2.queued[0].deduped).toBe(true);
+		// ID returned is the original record, not a new one.
+		expect(p2.queued[0].messageId).toBe(p1.queued[0].messageId);
+
+		const pending = pendingRepo.listPendingForTarget(run.id, 'reviewer');
+		expect(pending).toHaveLength(1);
+		expect(pending[0].message).toBe('v1');
+	});
+
+	test('escalates to Space Agent via spaceAgentInjector', async () => {
+		const wf = buildTwoStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		const injectorCalls: Array<{ spaceId: string; message: string }> = [];
+		const config: TaskAgentToolsConfig = {
+			...makeConfig(ctx, mainTask.id, run.id),
+			spaceAgentInjector: async (spaceId, message) => {
+				injectorCalls.push({ spaceId, message });
+			},
+		};
+		const handlers = createTaskAgentToolHandlers(config);
+
+		const result = await handlers.send_message({
+			target: 'space-agent',
+			message: 'need your help with scope',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.delivered).toHaveLength(1);
+		expect(parsed.delivered[0].agentName).toBe('space-agent');
+		expect(parsed.delivered[0].sessionId).toBe(`space:chat:${ctx.spaceId}`);
+
+		expect(injectorCalls).toHaveLength(1);
+		expect(injectorCalls[0].spaceId).toBe(ctx.spaceId);
+		expect(injectorCalls[0].message).toBe('[Message from task-agent]: need your help with scope');
+	});
+
+	test('queues for Space Agent when injector fails + pendingMessageRepo is configured', async () => {
+		const wf = buildTwoStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		const { PendingAgentMessageRepository } = await import(
+			'../../../../src/storage/repositories/pending-agent-message-repository.ts'
+		);
+		const pendingRepo = new PendingAgentMessageRepository(ctx.db);
+
+		const config: TaskAgentToolsConfig = {
+			...makeConfig(ctx, mainTask.id, run.id),
+			pendingMessageRepo: pendingRepo,
+			spaceAgentInjector: async () => {
+				throw new Error('Space Agent session not ready');
+			},
+		};
+		const handlers = createTaskAgentToolHandlers(config);
+
+		const result = await handlers.send_message({
+			target: 'space-agent',
+			message: 'queue me',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		// delivery failed, but queued succeeded → overall success=true
+		expect(parsed.success).toBe(true);
+		expect(parsed.queued).toHaveLength(1);
+		expect(parsed.queued[0].targetKind).toBe('space_agent');
+
+		const pending = pendingRepo.listPendingForTarget(run.id, 'space-agent');
+		expect(pending).toHaveLength(1);
+		expect(pending[0].message).toBe('queue me');
+		expect(pending[0].targetKind).toBe('space_agent');
+	});
+
+	test('queues for Space Agent when no injector is configured but pendingMessageRepo is', async () => {
+		const wf = buildTwoStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		const { PendingAgentMessageRepository } = await import(
+			'../../../../src/storage/repositories/pending-agent-message-repository.ts'
+		);
+		const pendingRepo = new PendingAgentMessageRepository(ctx.db);
+
+		const config: TaskAgentToolsConfig = {
+			...makeConfig(ctx, mainTask.id, run.id),
+			pendingMessageRepo: pendingRepo,
+			// no spaceAgentInjector
+		};
+		const handlers = createTaskAgentToolHandlers(config);
+
+		const result = await handlers.send_message({
+			target: 'space-agent',
+			message: 'defer me',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.queued).toHaveLength(1);
+		expect(parsed.queued[0].targetKind).toBe('space_agent');
+
+		const pending = pendingRepo.listPendingForTarget(run.id, 'space-agent');
+		expect(pending).toHaveLength(1);
+	});
+
+	test('fails hard when space-agent target has no injector and no queue repo', async () => {
+		const wf = buildTwoStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		const config: TaskAgentToolsConfig = {
+			...makeConfig(ctx, mainTask.id, run.id),
+			// neither pendingMessageRepo nor spaceAgentInjector
+		};
+		const handlers = createTaskAgentToolHandlers(config);
+
+		const result = await handlers.send_message({
+			target: 'space-agent',
+			message: 'orphan',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		// No infra at all → escalation is a failed target. Because it's the only target,
+		// the handler reports partial-no-delivery.
+		expect(parsed.failed).toBeDefined();
+		expect(parsed.failed[0].agentName).toBe('space-agent');
+	});
+
+	test('send_message tool on MCP server surface accepts idempotency_key', async () => {
+		const wf = buildTwoStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		ctx.nodeExecutionRepo.create({
+			workflowRunId: run.id,
+			workflowNodeId: 'declared-node',
+			agentName: 'reviewer',
+			status: 'pending',
+		});
+
+		const { PendingAgentMessageRepository } = await import(
+			'../../../../src/storage/repositories/pending-agent-message-repository.ts'
+		);
+		const pendingRepo = new PendingAgentMessageRepository(ctx.db);
+
+		const config: TaskAgentToolsConfig = {
+			...makeConfig(ctx, mainTask.id, run.id),
+			pendingMessageRepo: pendingRepo,
+		};
+		const server = createTaskAgentMcpServer(config);
+		const entry = server.instance._registeredTools['send_message'];
+
+		const out = await entry.handler(
+			{ target: 'reviewer', message: 'via mcp', idempotency_key: 'k-mcp' },
+			{}
+		);
+		const parsed = JSON.parse(out.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.queued[0].deduped).toBe(false);
+
+		// Replay with same key → deduped
+		const out2 = await entry.handler(
+			{ target: 'reviewer', message: 'via mcp replay', idempotency_key: 'k-mcp' },
+			{}
+		);
+		const parsed2 = JSON.parse(out2.content[0].text);
+		expect(parsed2.queued[0].deduped).toBe(true);
+	});
+});

--- a/packages/daemon/tests/unit/5-space/other/cross-agent-messaging.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/cross-agent-messaging.test.ts
@@ -408,11 +408,41 @@ async function startRun(ctx: TaskCtx, wf: SpaceWorkflow) {
 	return { run, mainTask };
 }
 
+/**
+ * Build a mock taskAgentManager for unit tests.
+ *
+ * Reads NodeExecution rows with an agentSessionId to simulate the stable
+ * per-agent session map that TaskAgentManager maintains at runtime.
+ * This replaces the old status-filter approach (in_progress / pending)
+ * with a direct name→session lookup.
+ */
+function makeMockTaskAgentManager(
+	nodeExecutionRepo: NodeExecutionRepository,
+	taskId: string,
+	runId: string
+): TaskAgentToolsConfig['taskAgentManager'] {
+	return {
+		async getAgentNamesForTask(_taskId: string): Promise<string[]> {
+			const executions = nodeExecutionRepo.listByWorkflowRun(runId);
+			return [...new Set(executions.filter((e) => e.agentSessionId).map((e) => e.agentName))];
+		},
+		async getSubSessionByAgentName(
+			_taskId: string,
+			agentName: string
+		): Promise<{ session: { id: string } } | null> {
+			const executions = nodeExecutionRepo.listByWorkflowRun(runId);
+			const exec = executions.find((e) => e.agentName === agentName && e.agentSessionId);
+			if (!exec?.agentSessionId) return null;
+			return { session: { id: exec.agentSessionId } };
+		},
+	} as unknown as TaskAgentToolsConfig['taskAgentManager'];
+}
+
 function makeTaskConfig(
 	ctx: TaskCtx,
 	taskId: string,
 	runId: string,
-	factory: SubSessionFactory,
+	_factory: SubSessionFactory,
 	overrides: {
 		messageInjector?: (sessionId: string, message: string) => Promise<void>;
 	} = {}
@@ -421,16 +451,14 @@ function makeTaskConfig(
 		taskId,
 		space: ctx.space,
 		workflowRunId: runId,
-		workspacePath: '/tmp/workspace',
-		workflowManager: ctx.workflowManager,
 		taskRepo: ctx.taskRepo,
 		workflowRunRepo: ctx.workflowRunRepo,
 		nodeExecutionRepo: ctx.nodeExecutionRepo,
-		agentManager: ctx.agentManager,
 		taskManager: ctx.taskManager,
-		sessionFactory: factory,
 		messageInjector: overrides.messageInjector ?? (async () => {}),
-		onSubSessionComplete: async () => {},
+		// Build a mock that looks up live sessions from the NodeExecution table,
+		// mirroring the stable per-agent map that TaskAgentManager maintains at runtime.
+		taskAgentManager: makeMockTaskAgentManager(ctx.nodeExecutionRepo, taskId, runId),
 	};
 }
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -333,6 +333,38 @@ describe('SpaceRuntimeService', () => {
 			await expect(svc.setupSpaceAgentSession(mockSpace)).resolves.toBeUndefined();
 		});
 
+		test('flushes pending Space Agent messages for active runs after provisioning', async () => {
+			const session = makeSession();
+			const sessionManager = makeSessionManager(session);
+
+			// Mock workflowRunRepo with one active run
+			const activeRun = { id: 'run-flush-wiring', status: 'in_progress', spaceId: mockSpace.id };
+			const workflowRunRepo = {
+				getActiveRuns: mock(() => [activeRun]),
+			} as unknown as SpaceWorkflowRunRepository;
+
+			const flushCalls: Array<{ spaceId: string; runId: string }> = [];
+			const mockTaskAgentManager = {
+				flushPendingMessagesForSpaceAgent: mock(async (spaceId: string, runId: string) => {
+					flushCalls.push({ spaceId, runId });
+				}),
+			} as unknown as TaskAgentManager;
+
+			const config: SpaceRuntimeServiceConfig = {
+				...buildConfigWithSession(sessionManager),
+				workflowRunRepo,
+			};
+			const svc = new SpaceRuntimeService(config);
+			svc.setTaskAgentManager(mockTaskAgentManager);
+
+			await svc.setupSpaceAgentSession(mockSpace);
+			// Allow any void-dispatched promises to resolve
+			await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+			expect(flushCalls).toHaveLength(1);
+			expect(flushCalls[0]).toEqual({ spaceId: mockSpace.id, runId: activeRun.id });
+		});
+
 		test('start() provisions existing spaces', async () => {
 			const session = makeSession();
 			const sessionManager = makeSessionManager(session);

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -233,4 +233,45 @@ export function createSpaceTables(db: BunDatabase): void {
 		)
 	`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_wra_run_id ON workflow_run_artifacts(run_id)`);
+
+	// Pending agent messages (Task Agent → peer agent persistent queue).
+	// See migration 90.
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS pending_agent_messages (
+			id TEXT PRIMARY KEY,
+			workflow_run_id TEXT NOT NULL,
+			space_id TEXT NOT NULL,
+			task_id TEXT,
+			source_agent_name TEXT NOT NULL DEFAULT 'task-agent',
+			target_kind TEXT NOT NULL
+				CHECK(target_kind IN ('node_agent', 'space_agent')),
+			target_agent_name TEXT NOT NULL,
+			message TEXT NOT NULL,
+			idempotency_key TEXT,
+			attempts INTEGER NOT NULL DEFAULT 0,
+			max_attempts INTEGER NOT NULL DEFAULT 5,
+			last_attempt_at INTEGER,
+			last_error TEXT,
+			status TEXT NOT NULL DEFAULT 'pending'
+				CHECK(status IN ('pending', 'delivered', 'expired', 'failed')),
+			delivered_at INTEGER,
+			delivered_session_id TEXT,
+			expires_at INTEGER NOT NULL,
+			created_at INTEGER NOT NULL,
+			FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE CASCADE
+		)
+	`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_pending_agent_messages_run_status ` +
+			`ON pending_agent_messages(workflow_run_id, status, created_at)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_pending_agent_messages_run_target ` +
+			`ON pending_agent_messages(workflow_run_id, target_agent_name, status, created_at)`
+	);
+	db.exec(
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_pending_agent_messages_idem ` +
+			`ON pending_agent_messages(workflow_run_id, target_agent_name, idempotency_key) ` +
+			`WHERE idempotency_key IS NOT NULL`
+	);
 }


### PR DESCRIPTION
## Summary

- Fixes the "No active sessions found" failure in the Task Agent's `send_message` during reopen/startup races. Messages for declared-but-inactive node-agent targets are now persisted to a new `pending_agent_messages` queue and auto-delivered the moment that sub-session activates (bounded retry, 10-min TTL, FIFO per target, optional idempotency key).
- Adds a supported `target: 'space-agent'` path to `send_message` so the Task Agent can escalate to the Space Agent chat session without requiring a human relay. If the Space Agent session is not yet ready, the message is queued and flushed when it comes up.
- Emits `space.pendingMessage.queued` / `space.pendingMessage.delivered` on DaemonHub for observability.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] All daemon test shards: 10914 tests pass
- [x] New tests:
  - 22 `PendingAgentMessageRepository` tests (enqueue/dedupe/FIFO/TTL/attempts/cascade)
  - 9 `send_message` tests covering inactive-target queueing, unknown-target hard error, partial delivery, idempotency dedupe, Space Agent escalation success/fallback paths, and MCP-surface idempotency_key pass-through