### PR TITLE
fix(space): render compact Task Agent node on mobile canvas

### DIFF
--- a/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowNode.tsx
@@ -22,6 +22,7 @@ import { isMultiAgentNode, AgentStatusIcon } from '../WorkflowNodeCard';
 import type { Point } from './types';
 import type { AnchorSide } from './semanticWorkflowGraph';
 import { getVisualNodeDimensions } from './nodeMetrics';
+import { useIsMobileCanvas } from '../../../hooks/useIsMobileCanvas';
 
 // ============================================================================
 // Props
@@ -170,7 +171,12 @@ export function WorkflowNode({
 }: WorkflowNodeProps) {
 	const stepId = step.localId;
 	const isTaskAgent = stepId === TASK_AGENT_NODE_ID;
-	const dimensions = getVisualNodeDimensions(step);
+	const isMobileCanvas = useIsMobileCanvas();
+	const baseDimensions = getVisualNodeDimensions(step);
+	// Compact Task Agent on mobile: narrower + shorter to keep the pinned node
+	// from dominating the canvas. Regular nodes keep their normal dimensions so
+	// edge routing / port positions remain stable across breakpoints.
+	const dimensions = isTaskAgent && isMobileCanvas ? { width: 112, height: 36 } : baseDimensions;
 
 	const multi = isMultiAgentNode(step);
 	const singleSlot =
@@ -352,15 +358,33 @@ export function WorkflowNode({
 	const pulseClass = hasActiveExecution ? 'animate-pulse' : '';
 	const activeAnchorSideSet = new Set(activeAnchorSides);
 
-	// Task Agent: render a visually distinct pinned node with no ports
+	// Task Agent: render a visually distinct pinned node with no ports.
+	//
+	// Mobile (< Tailwind md breakpoint): render a compact variant. The visible
+	// "Task Agent" header badge is oversized on small viewports, so we hide it
+	// visually with `sr-only` (keeping it for screen readers) and shrink the
+	// step-name text + padding. The card itself also uses smaller dimensions.
+	// The `aria-label` on the card provides redundant context so focused users
+	// always hear "Task Agent" regardless of the step name.
 	if (isTaskAgent) {
+		const rootPadding = isMobileCanvas ? 'px-2 py-1' : 'px-3 py-2';
+		const badgeClass = isMobileCanvas
+			? 'sr-only'
+			: 'text-xs font-bold text-amber-400 uppercase tracking-wider';
+		const nameClass = isMobileCanvas
+			? 'text-[11px] font-medium text-amber-100 truncate leading-tight'
+			: 'text-sm font-medium text-amber-100 truncate';
+		const nameMaxWidth = isMobileCanvas ? 96 : 180;
+
 		return (
 			<div
 				ref={nodeRef}
 				data-testid={`workflow-node-${stepId}`}
 				data-step-id={stepId}
 				data-task-agent="true"
+				data-task-agent-compact={isMobileCanvas ? 'true' : 'false'}
 				data-pan-canvas="true"
+				aria-label="Task Agent"
 				style={{
 					position: 'absolute',
 					left: position.x,
@@ -374,22 +398,22 @@ export function WorkflowNode({
 				class={`rounded-lg border-2 ${bgClass} ${borderClass}`}
 				onMouseDown={handleMouseDown}
 			>
-				<div class="px-3 py-2">
-					{/* Header row: Task Agent badge */}
-					<div class="flex items-center justify-between mb-1">
-						<span
-							data-testid="task-agent-badge"
-							class="text-xs font-bold text-amber-400 uppercase tracking-wider"
-						>
+				<div class={rootPadding}>
+					{/* Header row: Task Agent badge — visible on desktop/tablet,
+					    sr-only on mobile so screen readers still announce it. */}
+					{isMobileCanvas ? (
+						<span data-testid="task-agent-badge" class={badgeClass}>
 							Task Agent
 						</span>
-					</div>
+					) : (
+						<div class="flex items-center justify-between mb-1">
+							<span data-testid="task-agent-badge" class={badgeClass}>
+								Task Agent
+							</span>
+						</div>
+					)}
 					{/* Name */}
-					<p
-						data-testid="step-name"
-						class="text-sm font-medium text-amber-100 truncate"
-						style={{ maxWidth: 180 }}
-					>
+					<p data-testid="step-name" class={nameClass} style={{ maxWidth: nameMaxWidth }}>
 						{step.name || 'Task Agent'}
 					</p>
 				</div>

--- a/packages/web/src/components/space/visual-editor/__tests__/WorkflowNode.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/WorkflowNode.test.tsx
@@ -18,7 +18,7 @@
  * mouse events because fireEvent(window, ...) does not work in happy-dom.
  */
 
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/preact';
 import { useState } from 'preact/hooks';
 import { WorkflowNode } from '../WorkflowNode';
@@ -28,6 +28,27 @@ import { TASK_AGENT_NODE_ID } from '@neokai/shared';
 import type { AgentTaskState } from '../../WorkflowNodeCard';
 import type { Point } from '../types';
 
+// Default to non-mobile for every test — individual tests (see "mobile"
+// describe blocks) override this before rendering. This keeps matchMedia
+// defined in happy-dom, which otherwise returns undefined.
+function mockMatchMedia(isMobile: boolean) {
+	Object.defineProperty(window, 'matchMedia', {
+		writable: true,
+		configurable: true,
+		value: vi.fn().mockImplementation((query: string) => ({
+			matches: query === '(max-width: 767px)' ? isMobile : false,
+			media: query,
+			onchange: null,
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		})),
+	});
+}
+
+beforeEach(() => mockMatchMedia(false));
 afterEach(() => cleanup());
 
 // ============================================================================
@@ -659,6 +680,119 @@ describe('WorkflowNode Task Agent rendering', () => {
 		const { getByTestId } = render(<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP })} />);
 		const node = getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
 		expect(node.getAttribute('data-pan-canvas')).toBe('true');
+	});
+
+	it('exposes an aria-label for screen readers', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP })} />);
+		const node = getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
+		expect(node.getAttribute('aria-label')).toBe('Task Agent');
+	});
+});
+
+// ============================================================================
+// Task Agent — mobile canvas variant
+// ============================================================================
+
+describe('WorkflowNode Task Agent — mobile canvas variant', () => {
+	beforeEach(() => mockMatchMedia(true));
+
+	it('marks the node as compact on mobile', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP })} />);
+		const node = getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
+		expect(node.getAttribute('data-task-agent-compact')).toBe('true');
+	});
+
+	it('shrinks card dimensions below the desktop baseline', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP })} />);
+		const node = getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
+		// Card shrinks from 160x60 (desktop) to 112x36 (mobile compact)
+		expect(node.style.width).toBe('112px');
+		expect(node.style.minHeight).toBe('36px');
+	});
+
+	it('keeps the Task Agent badge in the DOM but hides it visually with sr-only', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP })} />);
+		const badge = getByTestId('task-agent-badge');
+		// Badge text is still present for screen readers
+		expect(badge.textContent).toBe('Task Agent');
+		// Visible styling is swapped for sr-only (no uppercase/tracking on mobile)
+		expect(badge.className).toContain('sr-only');
+		expect(badge.className).not.toContain('uppercase');
+		expect(badge.className).not.toContain('tracking-wider');
+	});
+
+	it('uses a smaller name text class on mobile', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP })} />);
+		const name = getByTestId('step-name');
+		// Desktop uses text-sm; mobile drops to a compact 11px size
+		expect(name.className).toContain('text-[11px]');
+		expect(name.className).not.toContain('text-sm');
+	});
+
+	it('preserves the aria-label even when the badge is visually hidden', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP })} />);
+		const node = getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
+		expect(node.getAttribute('aria-label')).toBe('Task Agent');
+	});
+
+	it('still prevents dragging on mobile', () => {
+		const onPositionChange = vi.fn();
+		const { getByTestId } = render(
+			<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP, onPositionChange })} />
+		);
+		const node = getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
+		fireEvent.mouseDown(node, { button: 0, clientX: 0, clientY: 0 });
+		windowMouseMove(40, 40);
+		expect(onPositionChange).not.toHaveBeenCalled();
+		windowMouseUp();
+	});
+
+	it('still renders as a canvas pan surface on mobile', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP })} />);
+		const node = getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
+		expect(node.getAttribute('data-pan-canvas')).toBe('true');
+	});
+
+	it('does not apply compact styles to regular (non-Task-Agent) nodes', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps()} />);
+		const node = getByTestId('workflow-node-step-local-1');
+		// Regular nodes preserve their default dimensions even on mobile
+		expect(node.style.width).toBe('160px');
+		expect(node.style.minHeight).toBe('80px');
+		expect(node.getAttribute('data-task-agent-compact')).toBeNull();
+	});
+});
+
+describe('WorkflowNode Task Agent — desktop canvas variant', () => {
+	// Safety net to ensure the desktop rendering is NOT regressed by mobile work.
+	beforeEach(() => mockMatchMedia(false));
+
+	it('marks the node as non-compact on desktop', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP })} />);
+		const node = getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
+		expect(node.getAttribute('data-task-agent-compact')).toBe('false');
+	});
+
+	it('renders the Task Agent badge with the full visible styling', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP })} />);
+		const badge = getByTestId('task-agent-badge');
+		expect(badge.className).toContain('uppercase');
+		expect(badge.className).toContain('tracking-wider');
+		expect(badge.className).not.toContain('sr-only');
+	});
+
+	it('keeps the default desktop dimensions', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP })} />);
+		const node = getByTestId(`workflow-node-${TASK_AGENT_NODE_ID}`);
+		expect(node.style.width).toBe('160px');
+		expect(node.style.minHeight).toBe('60px');
+	});
+
+	it('keeps the original text-sm step-name class on desktop', () => {
+		const { getByTestId } = render(<WorkflowNode {...makeProps({ step: TASK_AGENT_STEP })} />);
+		const name = getByTestId('step-name');
+		expect(name.className).toContain('text-sm');
+		expect(name.className).not.toContain('text-[11px]');
 	});
 });
 

--- a/packages/web/src/hooks/__tests__/useIsMobileCanvas.test.ts
+++ b/packages/web/src/hooks/__tests__/useIsMobileCanvas.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for useIsMobileCanvas hook.
+ *
+ * Verifies:
+ * - Returns true when the (max-width: 767px) media query matches.
+ * - Returns false when it does not match.
+ * - Reacts to media-query change events.
+ * - Safe when matchMedia is unavailable.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/preact';
+import { useIsMobileCanvas, MOBILE_CANVAS_MEDIA_QUERY } from '../useIsMobileCanvas';
+
+type ChangeHandler = (event: MediaQueryListEvent) => void;
+
+interface MockMediaQueryList {
+	matches: boolean;
+	media: string;
+	onchange: null;
+	addListener: ReturnType<typeof vi.fn>;
+	removeListener: ReturnType<typeof vi.fn>;
+	addEventListener: (type: 'change', handler: ChangeHandler) => void;
+	removeEventListener: (type: 'change', handler: ChangeHandler) => void;
+	dispatchEvent: (event: MediaQueryListEvent) => boolean;
+	_trigger: (matches: boolean) => void;
+}
+
+function createMockMediaQueryList(initialMatches: boolean): MockMediaQueryList {
+	const handlers = new Set<ChangeHandler>();
+	const mql: MockMediaQueryList = {
+		matches: initialMatches,
+		media: MOBILE_CANVAS_MEDIA_QUERY,
+		onchange: null,
+		addListener: vi.fn(),
+		removeListener: vi.fn(),
+		addEventListener: (_type, handler) => {
+			handlers.add(handler);
+		},
+		removeEventListener: (_type, handler) => {
+			handlers.delete(handler);
+		},
+		dispatchEvent: () => true,
+		_trigger: (matches: boolean) => {
+			mql.matches = matches;
+			for (const handler of handlers) {
+				handler({ matches, media: MOBILE_CANVAS_MEDIA_QUERY } as MediaQueryListEvent);
+			}
+		},
+	};
+	return mql;
+}
+
+describe('useIsMobileCanvas', () => {
+	let originalMatchMedia: typeof window.matchMedia | undefined;
+
+	beforeEach(() => {
+		originalMatchMedia = window.matchMedia;
+	});
+
+	afterEach(() => {
+		if (originalMatchMedia) {
+			window.matchMedia = originalMatchMedia;
+		} else {
+			// @ts-expect-error allow deletion in test teardown
+			delete window.matchMedia;
+		}
+	});
+
+	it('returns true when matchMedia reports the mobile query matches', () => {
+		const mql = createMockMediaQueryList(true);
+		window.matchMedia = vi.fn().mockReturnValue(mql) as unknown as typeof window.matchMedia;
+
+		const { result } = renderHook(() => useIsMobileCanvas());
+		expect(result.current).toBe(true);
+	});
+
+	it('returns false when the media query does not match', () => {
+		const mql = createMockMediaQueryList(false);
+		window.matchMedia = vi.fn().mockReturnValue(mql) as unknown as typeof window.matchMedia;
+
+		const { result } = renderHook(() => useIsMobileCanvas());
+		expect(result.current).toBe(false);
+	});
+
+	it('queries the canonical mobile media string', () => {
+		const mql = createMockMediaQueryList(false);
+		const spy = vi.fn().mockReturnValue(mql);
+		window.matchMedia = spy as unknown as typeof window.matchMedia;
+
+		renderHook(() => useIsMobileCanvas());
+		expect(spy).toHaveBeenCalledWith(MOBILE_CANVAS_MEDIA_QUERY);
+	});
+
+	it('updates when the media query changes', () => {
+		const mql = createMockMediaQueryList(false);
+		window.matchMedia = vi.fn().mockReturnValue(mql) as unknown as typeof window.matchMedia;
+
+		const { result } = renderHook(() => useIsMobileCanvas());
+		expect(result.current).toBe(false);
+
+		act(() => {
+			mql._trigger(true);
+		});
+		expect(result.current).toBe(true);
+
+		act(() => {
+			mql._trigger(false);
+		});
+		expect(result.current).toBe(false);
+	});
+
+	it('does not throw when matchMedia is unavailable', () => {
+		// @ts-expect-error simulate missing API
+		delete window.matchMedia;
+
+		const { result } = renderHook(() => useIsMobileCanvas());
+		expect(result.current).toBe(false);
+	});
+});

--- a/packages/web/src/hooks/index.ts
+++ b/packages/web/src/hooks/index.ts
@@ -70,6 +70,7 @@ export {
 } from './useReferenceAutocomplete';
 export { useViewportSafety } from './useViewportSafety';
 export { useClickOutside } from './useClickOutside';
+export { useIsMobileCanvas, MOBILE_CANVAS_MEDIA_QUERY } from './useIsMobileCanvas';
 export {
 	useMissionDetailData,
 	type UseMissionDetailDataResult,

--- a/packages/web/src/hooks/useIsMobileCanvas.ts
+++ b/packages/web/src/hooks/useIsMobileCanvas.ts
@@ -1,0 +1,70 @@
+/**
+ * useIsMobileCanvas
+ *
+ * Reactive hook that reports `true` when the viewport width is below the
+ * Tailwind `md` breakpoint (< 768px).
+ *
+ * Used by canvas components (for example, the Task Agent node) to render a
+ * compact variant on phone-sized viewports while preserving desktop/tablet
+ * behaviour. Scoped specifically for canvas rendering — the name avoids
+ * accidental collisions with any future broader-purpose `useIsMobile` hook.
+ *
+ * SSR / non-browser safety: returns `false` when `window`/`matchMedia` is not
+ * available. Consumers that need to know whether detection has run can
+ * distinguish the initial tick by reading window size themselves.
+ */
+import { useEffect, useState } from 'preact/hooks';
+
+/** Matches Tailwind's `md` breakpoint — anything below 768px is "mobile". */
+export const MOBILE_CANVAS_MEDIA_QUERY = '(max-width: 767px)';
+
+function readInitialMatch(): boolean {
+	if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+		return false;
+	}
+	try {
+		return window.matchMedia(MOBILE_CANVAS_MEDIA_QUERY).matches;
+	} catch {
+		return false;
+	}
+}
+
+export function useIsMobileCanvas(): boolean {
+	const [isMobile, setIsMobile] = useState<boolean>(readInitialMatch);
+
+	useEffect(() => {
+		if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+			return;
+		}
+
+		const mq = window.matchMedia(MOBILE_CANVAS_MEDIA_QUERY);
+		// Sync after mount — the SSR/initial value may be stale by the time
+		// effects run (e.g. tests that mock matchMedia after render).
+		setIsMobile(mq.matches);
+
+		const handleChange = (event: MediaQueryListEvent) => {
+			setIsMobile(event.matches);
+		};
+
+		// Modern browsers: addEventListener('change'). Fall back to the legacy
+		// addListener API for older WebKit variants.
+		if (typeof mq.addEventListener === 'function') {
+			mq.addEventListener('change', handleChange);
+			return () => mq.removeEventListener('change', handleChange);
+		}
+
+		interface LegacyMediaQueryList {
+			addListener?: (handler: ChangeHandler) => void;
+			removeListener?: (handler: ChangeHandler) => void;
+		}
+		type ChangeHandler = (event: MediaQueryListEvent) => void;
+
+		const legacy = mq as unknown as LegacyMediaQueryList;
+		legacy.addListener?.(handleChange);
+		return () => {
+			legacy.removeListener?.(handleChange);
+		};
+	}, []);
+
+	return isMobile;
+}


### PR DESCRIPTION
## Summary

The pinned Task Agent node dominated the workflow canvas on phone-width viewports because the uppercase "TASK AGENT" badge plus the step-name line rendered at desktop sizes. This PR introduces a compact mobile variant for viewports below Tailwind's `md` breakpoint (< 768px):

- Card shrinks from 160×60 to 112×36
- Badge is kept in the DOM but rendered `sr-only` so screen readers still announce "Task Agent"
- `aria-label="Task Agent"` is added to the card for redundant a11y context
- Step-name class drops to `text-[11px]` with tighter padding and tighter line-height

A new `useIsMobileCanvas` hook wraps `matchMedia('(max-width: 767px)')` with change-event listening so the variant toggles live if the viewport crosses the breakpoint.

Desktop/tablet rendering (≥ 768px) is unchanged — regular nodes, edges, and port positions are untouched, so channel routing to/from the Task Agent on larger breakpoints is unaffected.

## Test plan

- [x] `bunx vitest run src/hooks/__tests__/useIsMobileCanvas.test.ts` — 5/5 new hook tests pass
- [x] `bunx vitest run src/components/space/visual-editor/__tests__/WorkflowNode.test.tsx` — 69/69 tests pass (including new mobile-variant + desktop-safety-net blocks)
- [x] `bunx vitest run src/components/space` — 1167/1167 pass
- [x] `bun run check` — lint + typecheck + knip all clean