### PR TITLE
feat(space): LLM-driven workflow selection for standalone tasks

### DIFF
--- a/packages/daemon/src/lib/space/runtime/llm-workflow-selector.ts
+++ b/packages/daemon/src/lib/space/runtime/llm-workflow-selector.ts
@@ -1,0 +1,199 @@
+/**
+ * LLM-based workflow selector.
+ *
+ * Picks the best workflow for a standalone task by asking a small, cheap LLM
+ * (haiku tier) to rank a compact description of each available workflow
+ * against the task title/description.
+ *
+ * Design notes:
+ * - Returns a workflow ID string from the provided list, or `null` if the LLM
+ *   declines/fails. Callers are responsible for the final fallback (e.g. a
+ *   `default`-tagged workflow) so this helper can be mocked cleanly in tests.
+ * - The helper sets `maxTurns: 1`, disables thinking, and hands the SDK an
+ *   empty tool list: we only need a single short text response.
+ * - The input prompt is capped at ~1000 chars per task description so a long
+ *   task body can't drive up token cost or slow the tick.
+ *
+ * Intended wire-up: pass `selectWorkflowWithLlm` into `SpaceRuntimeConfig`.
+ * The runtime calls the callback from `attachStandaloneTasksToWorkflows()`
+ * when more than one workflow is available; callers can swap in a mock in
+ * tests without reaching into the SDK.
+ */
+
+import type { SpaceTask, SpaceWorkflow } from '@neokai/shared';
+import { getProviderService } from '../../provider-service';
+import { resolveSDKCliPath, isRunningUnderBun } from '../../agent/sdk-cli-resolver';
+import { mergeProviderEnvVars } from '../../provider-service';
+import { Logger } from '../../logger';
+
+const log = new Logger('llm-workflow-selector');
+
+/** Maximum characters per field (title + description) sent to the LLM. */
+const MAX_TASK_INPUT_CHARS = 1000;
+/** Maximum characters per workflow field shown in the candidate list. */
+const MAX_WORKFLOW_DESC_CHARS = 240;
+
+/**
+ * Callback signature accepted by `SpaceRuntimeConfig.selectWorkflowWithLlm`.
+ *
+ * Implementations receive the task plus the candidate workflow list and must
+ * return either one of the provided workflow IDs or `null` to defer to the
+ * deterministic fallback.
+ */
+export type SelectWorkflowWithLlm = (
+	task: SpaceTask,
+	workflows: SpaceWorkflow[]
+) => Promise<string | null>;
+
+/**
+ * Default LLM-driven workflow selector that talks to the Claude Agent SDK.
+ *
+ * Safe to use as the production implementation when no other callback is
+ * provided. Returns `null` on any failure so callers can fall back to a
+ * deterministic choice without surfacing errors.
+ */
+export async function selectWorkflowWithLlmDefault(
+	task: SpaceTask,
+	workflows: SpaceWorkflow[]
+): Promise<string | null> {
+	if (workflows.length === 0) return null;
+	if (workflows.length === 1) return workflows[0].id;
+
+	const providerService = getProviderService();
+	let provider: string;
+	try {
+		provider = await providerService.getDefaultProvider();
+	} catch (err) {
+		log.warn('Failed to resolve default provider for workflow selection:', err);
+		return null;
+	}
+
+	let modelId: string;
+	try {
+		const cfg = await providerService.getTitleGenerationConfig(provider);
+		modelId = cfg.modelId;
+	} catch (err) {
+		log.warn('Failed to resolve title-generation model for workflow selection:', err);
+		return null;
+	}
+
+	const prompt = buildSelectionPrompt(task, workflows);
+
+	let originalEnv: ReturnType<typeof providerService.applyEnvVarsToProcessForProvider>;
+	try {
+		originalEnv = providerService.applyEnvVarsToProcessForProvider(provider, modelId);
+	} catch (err) {
+		log.warn('Failed to apply provider env vars for workflow selection:', err);
+		return null;
+	}
+
+	try {
+		const { query } = await import('@anthropic-ai/claude-agent-sdk');
+		const providerEnvVars = providerService.getEnvVarsForModel(modelId, provider);
+		const mergedEnv = mergeProviderEnvVars(providerEnvVars as Record<string, string | undefined>);
+		const cliPath = resolveSDKCliPath();
+
+		const agentQuery = query({
+			prompt,
+			options: {
+				model: provider === 'glm' ? 'haiku' : modelId,
+				maxTurns: 1,
+				permissionMode: 'acceptEdits',
+				allowDangerouslySkipPermissions: false,
+				mcpServers: {},
+				settingSources: [],
+				tools: [],
+				pathToClaudeCodeExecutable: cliPath,
+				executable: isRunningUnderBun() ? 'bun' : undefined,
+				env: mergedEnv,
+				// We only need a short text response; adaptive-thinking models can
+				// otherwise return only thinking blocks with no text payload.
+				thinking: { type: 'disabled' },
+			},
+		});
+
+		const { isSDKAssistantMessage } = await import('@neokai/shared/sdk/type-guards');
+		let raw = '';
+		for await (const message of agentQuery) {
+			if (isSDKAssistantMessage(message)) {
+				const textBlocks = message.message.content.filter(
+					(b: { type: string }) => b.type === 'text'
+				) as Array<{ text?: string }>;
+				raw = textBlocks
+					.map((b) => b.text ?? '')
+					.join(' ')
+					.trim();
+				if (raw) break;
+			}
+		}
+
+		if (!raw) return null;
+
+		const cleaned = cleanIdResponse(raw);
+		if (!cleaned) return null;
+
+		// Match exact ID first; if the LLM echoed `none` or anything outside the
+		// candidate set, return null so the caller can pick a deterministic fallback.
+		const hit = workflows.find((w) => w.id === cleaned);
+		return hit ? hit.id : null;
+	} catch (err) {
+		log.warn('LLM workflow selection failed:', err);
+		return null;
+	} finally {
+		try {
+			providerService.restoreEnvVars(originalEnv);
+		} catch {
+			/* ignore env restore failures */
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function truncate(value: string, max: number): string {
+	if (value.length <= max) return value;
+	return `${value.slice(0, max - 1)}…`;
+}
+
+export function buildSelectionPrompt(task: SpaceTask, workflows: SpaceWorkflow[]): string {
+	const title = truncate(task.title ?? '', MAX_TASK_INPUT_CHARS);
+	const description = truncate(task.description ?? '', MAX_TASK_INPUT_CHARS);
+	const taskBlock = `Task title: ${title}\nTask description: ${description || '(empty)'}`;
+
+	const list = workflows
+		.map((w) => {
+			const name = truncate(w.name ?? '(unnamed)', 120);
+			const desc = truncate(w.description ?? '', MAX_WORKFLOW_DESC_CHARS) || '(no description)';
+			const tags = (w.tags ?? []).slice(0, 8).join(', ') || '(none)';
+			return `- id: ${w.id}\n  name: ${name}\n  description: ${desc}\n  tags: ${tags}`;
+		})
+		.join('\n');
+
+	return `You are selecting the best workflow to execute a task.
+
+${taskBlock}
+
+Candidate workflows:
+${list}
+
+Instructions:
+- Reply with EXACTLY one of the workflow ids above, with no other text.
+- If none of the workflows fit the task, reply with the single word: none
+- Do NOT wrap the id in quotes, backticks, or markdown.
+- Do NOT explain your choice.`;
+}
+
+function cleanIdResponse(raw: string): string | null {
+	let value = raw.trim();
+	// Strip wrapping quotes / backticks if the model ignored the instructions.
+	value = value.replace(/^[`"']+|[`"']+$/g, '').trim();
+	// If the model prefixed with "id:" or "Workflow:" take the final token.
+	if (/[\s:]/.test(value)) {
+		const tokens = value.split(/[\s:]+/).filter(Boolean);
+		if (tokens.length > 0) value = tokens[tokens.length - 1];
+	}
+	if (!value || value.toLowerCase() === 'none') return null;
+	return value;
+}

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -26,6 +26,8 @@ import type { TaskAgentManager } from './task-agent-manager';
 import type { SessionManager } from '../../session-manager';
 import type { DaemonHub } from '../../daemon-hub';
 import { SpaceRuntime } from './space-runtime';
+import type { SelectWorkflowWithLlm } from './llm-workflow-selector';
+import { selectWorkflowWithLlmDefault } from './llm-workflow-selector';
 import { ChannelRouter } from './channel-router';
 import { SpaceTaskManager } from '../managers/space-task-manager';
 import { createSpaceAgentMcpServer } from '../tools/space-agent-tools';
@@ -83,6 +85,12 @@ export interface SpaceRuntimeServiceConfig {
 	 * can resolve artifact data for script env injection.
 	 */
 	artifactRepo?: WorkflowRunArtifactRepository;
+	/**
+	 * Optional LLM-backed workflow selector override. Passed through to
+	 * SpaceRuntime verbatim. Defaults to `selectWorkflowWithLlmDefault` which
+	 * calls the Claude Agent SDK. Tests should supply a deterministic stub.
+	 */
+	selectWorkflowWithLlm?: SelectWorkflowWithLlm;
 }
 
 export class SpaceRuntimeService {
@@ -104,6 +112,7 @@ export class SpaceRuntimeService {
 		this.runtime = new SpaceRuntime({
 			...config,
 			nodeExecutionRepo: this.nodeExecutionRepo,
+			selectWorkflowWithLlm: config.selectWorkflowWithLlm ?? selectWorkflowWithLlmDefault,
 			onTaskUpdated: async ({ spaceId, task }) => {
 				if (!this.config.daemonHub) return;
 				await this.config.daemonHub.emit('space.task.updated', {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -47,6 +47,7 @@ import type { WorkflowRunArtifactRepository } from '../../../storage/repositorie
 import { type NotificationSink, NullNotificationSink } from './notification-sink';
 import { buildRestrictedEnv, collectWithMaxBuffer, MAX_BUFFER_BYTES } from './gate-script-executor';
 import { CompletionDetector } from './completion-detector';
+import type { SelectWorkflowWithLlm } from './llm-workflow-selector';
 import {
 	MAX_BLOCKED_RUN_RETRIES,
 	MAX_TASK_AGENT_CRASH_RETRIES,
@@ -54,47 +55,6 @@ import {
 } from './constants';
 
 const log = new Logger('space-runtime');
-
-const WORKFLOW_SELECTION_STOP_WORDS = new Set([
-	'the',
-	'and',
-	'for',
-	'are',
-	'but',
-	'not',
-	'you',
-	'all',
-	'can',
-	'was',
-	'one',
-	'our',
-	'out',
-	'day',
-	'get',
-	'has',
-	'him',
-	'his',
-	'how',
-	'its',
-	'may',
-	'new',
-	'now',
-	'old',
-	'see',
-	'two',
-	'use',
-	'way',
-	'who',
-	'did',
-	'let',
-	'put',
-	'say',
-	'she',
-	'too',
-	'had',
-	'any',
-	'via',
-]);
 
 // ---------------------------------------------------------------------------
 // Config
@@ -169,6 +129,17 @@ export interface SpaceRuntimeConfig {
 		spaceId: string;
 		run: SpaceWorkflowRun;
 	}) => Promise<void> | void;
+	/**
+	 * Optional LLM-backed workflow selector used when a standalone task has no
+	 * `preferredWorkflowId` and multiple workflows are available. Should return
+	 * one of the provided workflow ids, or `null` to fall back to the
+	 * deterministic tag-based tiebreak (`default` → `v2` → most recently updated).
+	 *
+	 * Dependency-injected so tests can provide a deterministic stub without
+	 * touching the provider SDK. In production, wire this to
+	 * `selectWorkflowWithLlmDefault` from `./llm-workflow-selector`.
+	 */
+	selectWorkflowWithLlm?: SelectWorkflowWithLlm;
 }
 
 interface StartWorkflowRunOptions {
@@ -2023,9 +1994,12 @@ export class SpaceRuntime {
 	 * by the runtime tick (not by Task Agent session creation).
 	 *
 	 * For each open standalone task:
-	 * 1. Select a fallback workflow for the task
+	 * 1. Select a workflow for the task (LLM-driven, with deterministic fallback)
 	 * 2. Start a workflow run
 	 * 3. Attach the original task to the run and mark it in_progress
+	 *
+	 * Selection work runs in parallel across tasks so a slow LLM call on one
+	 * task does not delay the rest of the tick.
 	 */
 	private async attachStandaloneTasksToWorkflows(): Promise<void> {
 		const spaces = await this.listActiveSpaces();
@@ -2040,51 +2014,52 @@ export class SpaceRuntime {
 
 			const taskManager = this.getOrCreateTaskManager(space.id);
 
-			for (const task of standaloneOpenTasks) {
-				// Re-read to avoid racing with external updates between list and attach.
-				const fresh = this.config.taskRepo.getTask(task.id);
-				if (!fresh || fresh.workflowRunId) continue;
-				if (fresh.status !== 'open') continue;
+			// Phase 1 — pick a workflow for every eligible task in parallel. LLM
+			// calls dominate the cost, so running them concurrently keeps the
+			// tick responsive when a space has many standalone tasks queued.
+			const candidates = await Promise.all(
+				standaloneOpenTasks.map(async (task) => {
+					const fresh = this.config.taskRepo.getTask(task.id);
+					if (!fresh || fresh.workflowRunId) return null;
+					if (fresh.status !== 'open') return null;
+					if (!(await taskManager.areDependenciesMet(fresh))) return null;
 
-				// Skip tasks whose dependencies aren't met yet — they'll be
-				// re-evaluated on the next tick when upstream tasks complete.
-				if (!(await taskManager.areDependenciesMet(fresh))) continue;
+					const selected = await this.selectWorkflowForStandaloneTask(fresh, workflows);
+					if (!selected) return null;
+					return { fresh, selected };
+				})
+			);
 
-				// Prefer the caller-specified workflow; fall back to heuristic selection.
-				let selectedWorkflow: ReturnType<typeof this.selectFallbackWorkflowForStandaloneTask>;
-				if (fresh.preferredWorkflowId) {
-					const explicit = this.config.spaceWorkflowManager.getWorkflow(fresh.preferredWorkflowId);
-					if (explicit) {
-						selectedWorkflow = explicit;
-					} else {
-						log.warn(
-							`SpaceRuntime: preferred_workflow_id "${fresh.preferredWorkflowId}" not found for task ${fresh.id}; falling back to heuristic selection`
-						);
-						selectedWorkflow = this.selectFallbackWorkflowForStandaloneTask(fresh, workflows);
-					}
-				} else {
-					selectedWorkflow = this.selectFallbackWorkflowForStandaloneTask(fresh, workflows);
-				}
-				if (!selectedWorkflow) continue;
+			// Phase 2 — apply the attachments sequentially so repo writes and
+			// event emission stay in a predictable order per space.
+			for (const candidate of candidates) {
+				if (!candidate) continue;
+				const { fresh, selected } = candidate;
+
+				// Re-read once more to defend against concurrent updates between
+				// phase 1 and phase 2 (e.g. another actor attached the task).
+				const current = this.config.taskRepo.getTask(fresh.id);
+				if (!current || current.workflowRunId) continue;
+				if (current.status !== 'open') continue;
 
 				try {
 					const { run } = await this.startWorkflowRun(
 						space.id,
-						selectedWorkflow.id,
-						fresh.title,
-						fresh.description,
-						{ parentTaskId: fresh.id }
+						selected.id,
+						current.title,
+						current.description,
+						{ parentTaskId: current.id }
 					);
 
-					await this.updateTaskAndEmit(space.id, fresh.id, {
+					await this.updateTaskAndEmit(space.id, current.id, {
 						workflowRunId: run.id,
 						status: 'in_progress',
-						startedAt: fresh.startedAt ?? Date.now(),
+						startedAt: current.startedAt ?? Date.now(),
 						completedAt: null,
 					});
 				} catch (err) {
 					log.warn(
-						`SpaceRuntime: failed to attach standalone task ${fresh.id} to workflow ${selectedWorkflow.id}:`,
+						`SpaceRuntime: failed to attach standalone task ${current.id} to workflow ${selected.id}:`,
 						err
 					);
 				}
@@ -2093,43 +2068,87 @@ export class SpaceRuntime {
 	}
 
 	/**
-	 * Deterministically select a fallback workflow for a standalone task.
+	 * Pick the workflow to run for a standalone task.
 	 *
-	 * Preference order:
-	 * 1. Highest keyword overlap with task title/description
-	 * 2. `default` tag
-	 * 3. `v2` tag
-	 * 4. Most recently updated workflow
+	 * Order of precedence:
+	 * 1. `task.preferredWorkflowId` when it resolves to an existing workflow.
+	 * 2. The LLM selector (`SpaceRuntimeConfig.selectWorkflowWithLlm`) when
+	 *    provided and it returns an id that exists in the candidate list.
+	 *    Unknown ids, `null` returns, and thrown errors all fall through.
+	 * 3. Deterministic fallback: the first workflow tagged `default`, else the
+	 *    first tagged `v2`, else the most recently updated workflow.
+	 *
+	 * The old substring/keyword scorer was retired in favour of LLM-based
+	 * selection because it mis-routed tasks whose descriptions happened to
+	 * share words with workflow metadata (e.g. a "review feedback" task
+	 * hijacking a "review" workflow even when "coding" was the right fit).
 	 */
-	private selectFallbackWorkflowForStandaloneTask(
+	private async selectWorkflowForStandaloneTask(
 		task: SpaceTask,
 		workflows: SpaceWorkflow[]
-	): SpaceWorkflow | null {
+	): Promise<SpaceWorkflow | null> {
+		if (workflows.length === 0) return null;
+
+		// Caller-specified preferred workflow wins over both LLM and deterministic
+		// fallback. Fall through if the id doesn't resolve (e.g. workflow was
+		// deleted between task creation and attachment).
+		if (task.preferredWorkflowId) {
+			const explicit = this.config.spaceWorkflowManager.getWorkflow(task.preferredWorkflowId);
+			if (explicit) return explicit;
+			log.warn(
+				`SpaceRuntime: preferred_workflow_id "${task.preferredWorkflowId}" not found for task ${task.id}; selecting a workflow automatically`
+			);
+		}
+
+		if (workflows.length === 1) return workflows[0];
+
+		const llmSelector = this.config.selectWorkflowWithLlm;
+		if (llmSelector) {
+			let llmResult: string | null = null;
+			try {
+				llmResult = await llmSelector(task, workflows);
+			} catch (err) {
+				log.warn(
+					`SpaceRuntime: LLM workflow selector threw for task ${task.id}; using deterministic fallback:`,
+					err
+				);
+				llmResult = null;
+			}
+
+			if (llmResult) {
+				const hit = workflows.find((w) => w.id === llmResult);
+				if (hit) return hit;
+				log.warn(
+					`SpaceRuntime: LLM workflow selector returned unknown id "${llmResult}" for task ${task.id}; using deterministic fallback`
+				);
+			}
+		}
+
+		return this.selectDeterministicWorkflowFallback(workflows);
+	}
+
+	/**
+	 * Tiebreak selection when no LLM/preferred workflow is available.
+	 *
+	 * Preference order:
+	 * 1. `default` tag
+	 * 2. `v2` tag
+	 * 3. Most recently updated workflow
+	 */
+	private selectDeterministicWorkflowFallback(workflows: SpaceWorkflow[]): SpaceWorkflow | null {
 		if (workflows.length === 0) return null;
 		if (workflows.length === 1) return workflows[0];
 
-		const keywords = `${task.title} ${task.description}`
-			.toLowerCase()
-			.split(/\W+/)
-			.filter((word) => word.length >= 3 && !WORKFLOW_SELECTION_STOP_WORDS.has(word));
-
 		const scored = workflows.map((workflow) => {
-			const haystack = [workflow.name, workflow.description ?? '', ...(workflow.tags ?? [])]
-				.join(' ')
-				.toLowerCase();
-			const hits =
-				keywords.length === 0 ? 0 : keywords.filter((keyword) => haystack.includes(keyword)).length;
 			const tags = workflow.tags ?? [];
 			return {
 				workflow,
-				hits,
 				isDefault: tags.includes('default') ? 1 : 0,
 				isV2: tags.includes('v2') ? 1 : 0,
 			};
 		});
 
 		scored.sort((a, b) => {
-			if (b.hits !== a.hits) return b.hits - a.hits;
 			if (b.isDefault !== a.isDefault) return b.isDefault - a.isDefault;
 			if (b.isV2 !== a.isV2) return b.isV2 - a.isV2;
 			return b.workflow.updatedAt - a.workflow.updatedAt;

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -33,7 +33,7 @@ import type { SpaceTaskManager } from '../managers/space-task-manager';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
 import type { TaskAgentManager } from '../runtime/task-agent-manager';
 import type { DaemonHub } from '../../daemon-hub';
-import { jsonResult, SUGGEST_WORKFLOW_STOP_WORDS } from './tool-result';
+import { jsonResult } from './tool-result';
 import type { ToolResult } from './tool-result';
 import { canTransition } from '../runtime/workflow-run-status-machine';
 
@@ -236,17 +236,19 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		},
 
 		/**
-		 * Suggest workflows that best match a description of the intended work.
+		 * Return all workflows in the space so the Space Agent LLM can pick one.
 		 *
-		 * Performs a case-insensitive keyword search over workflow names, descriptions,
-		 * and tags. Always returns ALL available workflows, sorted by relevance
-		 * (number of keyword hits descending). When no keywords match, all workflows
-		 * are returned in creation order.
+		 * Previously this tool did keyword pre-ranking, but that could bias the
+		 * LLM toward a substring-overlap pick (e.g. a "review feedback" task
+		 * always surfacing a "review" workflow first). Selection is fully
+		 * LLM-driven, so we just expose the full catalogue and let the caller
+		 * reason over it.
 		 *
-		 * Selection is still LLM-driven: the agent should use this to rank candidates
-		 * before creating a task.
+		 * The `description` argument is retained for forward compatibility and
+		 * call-site clarity, but is not used by the handler. Callers can still
+		 * read it from structured tool logs for observability.
 		 */
-		async suggest_workflow(args: { description: string }): Promise<ToolResult> {
+		async suggest_workflow(_args: { description: string }): Promise<ToolResult> {
 			const allWorkflows = workflowManager.listWorkflows(spaceId);
 			if (allWorkflows.length === 0) {
 				return jsonResult({
@@ -255,47 +257,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 					message: 'No workflows available in this space.',
 				});
 			}
-
-			// Extract meaningful keywords (3+ chars, skip stop words)
-			const keywords = args.description
-				.toLowerCase()
-				.split(/\W+/)
-				.filter((w) => w.length >= 3 && !SUGGEST_WORKFLOW_STOP_WORDS.has(w));
-
-			if (keywords.length === 0) {
-				// No meaningful keywords — return all in creation order
-				return jsonResult({ success: true, workflows: allWorkflows });
-			}
-
-			// Score each workflow by number of keyword hits; return all sorted by score
-			const scored = allWorkflows.map((wf) => {
-				const haystack = [wf.name, wf.description ?? '', ...(wf.tags ?? [])]
-					.join(' ')
-					.toLowerCase();
-				const hits = keywords.filter((kw) => haystack.includes(kw)).length;
-				return { workflow: wf, hits };
-			});
-
-			const anyHits = scored.some((s) => s.hits > 0);
-			if (!anyHits) {
-				// No keyword matches — return all so LLM can still reason
-				return jsonResult({
-					success: true,
-					workflows: allWorkflows,
-					message: 'No direct keyword matches found; returning all workflows for LLM selection.',
-				});
-			}
-
-			// Stable sort descending by hits; tiebreak: prefer 'v2'-tagged workflows (e.g.
-			// FULL_CYCLE_CODING_WORKFLOW over CODING_WORKFLOW) so the full pipeline is
-			// always recommended first when both match equally.
-			scored.sort((a, b) => {
-				if (b.hits !== a.hits) return b.hits - a.hits;
-				const aIsV2 = (a.workflow.tags ?? []).includes('v2') ? 1 : 0;
-				const bIsV2 = (b.workflow.tags ?? []).includes('v2') ? 1 : 0;
-				return bIsV2 - aIsV2;
-			});
-			return jsonResult({ success: true, workflows: scored.map((s) => s.workflow) });
+			return jsonResult({ success: true, workflows: allWorkflows });
 		},
 
 		/**
@@ -798,11 +760,13 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 		),
 		tool(
 			'suggest_workflow',
-			'Get workflow recommendations for a described piece of work. Returns workflows ranked by keyword relevance against names, descriptions, and tags. Use this to narrow candidates before creating a task.',
+			'List all workflows available in this space so you can pick the best one for a described piece of work. Returns every workflow in creation order with its name, description, tags, and nodes — no pre-ranking, so your own reasoning is not biased by keyword overlap.',
 			{
 				description: z
 					.string()
-					.describe('Description of the work you want to do — used for keyword matching'),
+					.describe(
+						'Description of the work you want to do. Provided for context; the tool returns all workflows regardless.'
+					),
 			},
 			(args) => handlers.suggest_workflow(args)
 		),

--- a/packages/daemon/src/lib/space/tools/tool-result.ts
+++ b/packages/daemon/src/lib/space/tools/tool-result.ts
@@ -1,5 +1,5 @@
 /**
- * Shared ToolResult type, jsonResult helper, and common constants for Space MCP tool handlers.
+ * Shared ToolResult type and jsonResult helper for Space MCP tool handlers.
  *
  * Extracted from space-agent-tools.ts and task-agent-tools.ts to eliminate
  * duplication. Both files previously defined identical types inline.
@@ -13,49 +13,3 @@ export interface ToolResult {
 export function jsonResult(data: unknown): ToolResult {
 	return { content: [{ type: 'text', text: JSON.stringify(data) }] };
 }
-
-/**
- * Common English stop words filtered out by suggest_workflow before keyword matching.
- * Hoisted to module scope so the Set is constructed once across all importers.
- */
-export const SUGGEST_WORKFLOW_STOP_WORDS = new Set([
-	'the',
-	'and',
-	'for',
-	'are',
-	'but',
-	'not',
-	'you',
-	'all',
-	'can',
-	'her',
-	'was',
-	'one',
-	'our',
-	'out',
-	'day',
-	'get',
-	'has',
-	'him',
-	'his',
-	'how',
-	'its',
-	'may',
-	'new',
-	'now',
-	'old',
-	'see',
-	'two',
-	'use',
-	'way',
-	'who',
-	'did',
-	'let',
-	'put',
-	'say',
-	'she',
-	'too',
-	'had',
-	'any',
-	'via',
-]);

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -582,7 +582,9 @@ describe('createSpaceAgentToolHandlers — suggest_workflow', () => {
 		expect(parsed.workflows).toEqual([]);
 	});
 
-	test('returns matching workflow ranked first when keywords match name', async () => {
+	test('returns every workflow unranked so the Space Agent LLM can pick', async () => {
+		// suggest_workflow no longer keyword-ranks: it just surfaces the
+		// catalogue so the caller's LLM can reason without bias.
 		buildSingleStepWorkflow(
 			ctx.spaceId,
 			ctx.workflowManager,
@@ -607,82 +609,41 @@ describe('createSpaceAgentToolHandlers — suggest_workflow', () => {
 
 		expect(parsed.success).toBe(true);
 		expect(parsed.workflows).toHaveLength(2);
-		// Coding Workflow should rank first (matches 'coding' in name and description)
-		expect(parsed.workflows[0].name).toBe('Coding Workflow');
+		const names = parsed.workflows.map((w: { name: string }) => w.name).sort();
+		expect(names).toEqual(['Coding Workflow', 'Research Workflow']);
 	});
 
-	test('returns matching workflow when keywords match description', async () => {
-		buildSingleStepWorkflow(
+	test('does not keyword-rank — "review" tag no longer hijacks top spot', async () => {
+		// Regression guard for the P0 bug that prompted switching to LLM-driven
+		// selection: a task description containing "review feedback" used to
+		// push the keyword-matching workflow (Review Flow) in front of the
+		// workflow whose name/description actually fit the work (Coding Flow).
+		const coding = buildSingleStepWorkflow(
 			ctx.spaceId,
 			ctx.workflowManager,
 			ctx.agentId,
-			'Alpha WF',
-			[],
-			'deploys to production environment'
+			'Coding Flow',
+			['coding'],
+			'Write code and open a PR'
 		);
-		buildSingleStepWorkflow(
-			ctx.spaceId,
-			ctx.workflowManager,
-			ctx.agentId,
-			'Beta WF',
-			[],
-			'runs unit tests'
-		);
-
-		const result = await makeHandlers(ctx).suggest_workflow({
-			description: 'deploy to production',
-		});
-		const parsed = JSON.parse(result.content[0].text);
-
-		expect(parsed.success).toBe(true);
-		expect(parsed.workflows[0].name).toBe('Alpha WF');
-	});
-
-	test('returns matching workflow when keywords match tags', async () => {
-		buildSingleStepWorkflow(
+		const review = buildSingleStepWorkflow(
 			ctx.spaceId,
 			ctx.workflowManager,
 			ctx.agentId,
 			'Review Flow',
-			['pullrequest', 'review'],
-			''
-		);
-		buildSingleStepWorkflow(
-			ctx.spaceId,
-			ctx.workflowManager,
-			ctx.agentId,
-			'Deploy Flow',
-			['deployment', 'release'],
-			''
+			['review'],
+			'Review a pull request'
 		);
 
-		const result = await makeHandlers(ctx).suggest_workflow({ description: 'review pullrequest' });
+		const result = await makeHandlers(ctx).suggest_workflow({
+			description: 'address review feedback and re-run the coding loop',
+		});
 		const parsed = JSON.parse(result.content[0].text);
 
 		expect(parsed.success).toBe(true);
-		expect(parsed.workflows[0].name).toBe('Review Flow');
-	});
-
-	test('returns all workflows when no keywords match', async () => {
-		buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'Alpha WF');
-		buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'Beta WF');
-
-		const result = await makeHandlers(ctx).suggest_workflow({ description: 'xyz-unique-term' });
-		const parsed = JSON.parse(result.content[0].text);
-
-		expect(parsed.success).toBe(true);
-		// All workflows returned as fallback
 		expect(parsed.workflows).toHaveLength(2);
-	});
-
-	test('returns all workflows when description contains only stop words', async () => {
-		buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'My WF');
-
-		const result = await makeHandlers(ctx).suggest_workflow({ description: 'the and for' });
-		const parsed = JSON.parse(result.content[0].text);
-
-		expect(parsed.success).toBe(true);
-		expect(parsed.workflows).toHaveLength(1);
+		// Order is creation order (insertion order) — never keyword rank.
+		expect(parsed.workflows.map((w: { id: string }) => w.id)).toEqual([coding.id, review.id]);
 	});
 
 	test('returns all workflows for empty description', async () => {
@@ -693,85 +654,6 @@ describe('createSpaceAgentToolHandlers — suggest_workflow', () => {
 
 		expect(parsed.success).toBe(true);
 		expect(parsed.workflows).toHaveLength(1);
-	});
-
-	test('V2 workflow preferred over V1 when both match equally (coding task)', async () => {
-		buildSingleStepWorkflow(
-			ctx.spaceId,
-			ctx.workflowManager,
-			ctx.agentId,
-			'Coding Workflow',
-			['coding', 'default'],
-			'For writing code'
-		);
-		buildSingleStepWorkflow(
-			ctx.spaceId,
-			ctx.workflowManager,
-			ctx.agentId,
-			'Full-Cycle Coding Workflow',
-			['coding', 'v2', 'parallel-review', 'default'],
-			'For writing code with parallel review'
-		);
-
-		const result = await makeHandlers(ctx).suggest_workflow({
-			description: 'implement a new coding feature',
-		});
-		const parsed = JSON.parse(result.content[0].text);
-
-		expect(parsed.success).toBe(true);
-		expect(parsed.workflows).toHaveLength(2);
-		// V2 must be ranked first (tiebreaker: 'v2' tag)
-		expect(parsed.workflows[0].name).toBe('Full-Cycle Coding Workflow');
-		expect(parsed.workflows[1].name).toBe('Coding Workflow');
-	});
-
-	test('V1 fallback when V2 is not seeded (backward compatibility)', async () => {
-		buildSingleStepWorkflow(
-			ctx.spaceId,
-			ctx.workflowManager,
-			ctx.agentId,
-			'Coding Workflow',
-			['coding', 'default'],
-			'For writing code'
-		);
-
-		const result = await makeHandlers(ctx).suggest_workflow({
-			description: 'implement a new coding feature',
-		});
-		const parsed = JSON.parse(result.content[0].text);
-
-		expect(parsed.success).toBe(true);
-		expect(parsed.workflows).toHaveLength(1);
-		expect(parsed.workflows[0].name).toBe('Coding Workflow');
-	});
-
-	test('non-coding workflows unaffected by v2 tiebreaker', async () => {
-		buildSingleStepWorkflow(
-			ctx.spaceId,
-			ctx.workflowManager,
-			ctx.agentId,
-			'Research Workflow',
-			['research'],
-			'For research tasks'
-		);
-		buildSingleStepWorkflow(
-			ctx.spaceId,
-			ctx.workflowManager,
-			ctx.agentId,
-			'Deploy Workflow',
-			['deploy', 'v2'],
-			'For deployment tasks'
-		);
-
-		// A research query — deploy v2 workflow should NOT hijack top spot
-		const result = await makeHandlers(ctx).suggest_workflow({
-			description: 'research competitors',
-		});
-		const parsed = JSON.parse(result.content[0].text);
-
-		expect(parsed.success).toBe(true);
-		// Research Workflow has more hits; Deploy Workflow should not outrank it
-		expect(parsed.workflows[0].name).toBe('Research Workflow');
 	});
 });
 
@@ -1349,7 +1231,10 @@ describe('createSpaceAgentToolHandlers — task creation and planning node activ
 		expect(tasks[0].status).toBe('open');
 	});
 
-	test('suggest_workflow ranks V2 workflow first for clear coding request', async () => {
+	test('suggest_workflow surfaces every workflow so the LLM can choose', async () => {
+		// Post-refactor behavior: suggest_workflow no longer keyword-ranks.
+		// The whole catalogue is returned in creation order so the caller's
+		// LLM is not biased by substring overlap with the task description.
 		buildSingleStepWorkflow(
 			ctx.spaceId,
 			ctx.workflowManager,
@@ -1373,8 +1258,9 @@ describe('createSpaceAgentToolHandlers — task creation and planning node activ
 		const parsed = JSON.parse(result.content[0].text);
 
 		expect(parsed.success).toBe(true);
-		// V2 must rank first — it has the 'v2' tiebreaker tag
-		expect(parsed.workflows[0].name).toBe('Full-Cycle Coding Workflow');
+		expect(parsed.workflows).toHaveLength(2);
+		const names = parsed.workflows.map((w: { name: string }) => w.name).sort();
+		expect(names).toEqual(['Coding Workflow', 'Full-Cycle Coding Workflow']);
 	});
 });
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-llm-workflow-selection.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-llm-workflow-selection.test.ts
@@ -1,0 +1,279 @@
+/**
+ * SpaceRuntime — LLM-driven workflow selection
+ *
+ * Exercises the `selectWorkflowWithLlm` callback plumbed through
+ * `SpaceRuntimeConfig`:
+ *   - Happy path: LLM returns an id from the candidate list, that workflow is
+ *     selected even though the deterministic fallback would prefer another.
+ *   - LLM returns null: fall back to the deterministic default-tagged workflow.
+ *   - LLM throws: fall back to the deterministic default-tagged workflow (no
+ *     exception escapes the tick).
+ *   - LLM returns an id not in the candidate list (hallucination): fall back
+ *     to the deterministic default-tagged workflow.
+ *   - LLM is not called when only one workflow exists (trivial single-workflow
+ *     short-circuit).
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
+import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
+import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
+import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
+import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
+import { SpaceRuntime } from '../../../../src/lib/space/runtime/space-runtime.ts';
+import type { SpaceRuntimeConfig } from '../../../../src/lib/space/runtime/space-runtime.ts';
+import type { SelectWorkflowWithLlm } from '../../../../src/lib/space/runtime/llm-workflow-selector.ts';
+import type { SpaceWorkflow } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Fixtures — mirrors helpers in space-runtime.test.ts but scoped local
+// ---------------------------------------------------------------------------
+
+function makeDb(): { db: BunDatabase; dir: string } {
+	const dir = join(
+		process.cwd(),
+		'tmp',
+		'test-space-runtime-llm',
+		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
+	);
+	mkdirSync(dir, { recursive: true });
+	const db = new BunDatabase(join(dir, 'test.db'));
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	return { db, dir };
+}
+
+function seedSpaceRow(db: BunDatabase, spaceId: string): void {
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+         allowed_models, session_ids, slug, status, created_at, updated_at)
+         VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, '/tmp/llm-select-ws', `Space ${spaceId}`, spaceId, Date.now(), Date.now());
+}
+
+function seedAgentRow(db: BunDatabase, agentId: string, spaceId: string, name: string): void {
+	db.prepare(
+		`INSERT INTO space_agents (id, space_id, name, description, model, tools, system_prompt, created_at, updated_at)
+         VALUES (?, ?, ?, '', null, '[]', '', ?, ?)`
+	).run(agentId, spaceId, name, Date.now(), Date.now());
+}
+
+function buildWorkflow(
+	spaceId: string,
+	wfManager: SpaceWorkflowManager,
+	name: string,
+	agentId: string,
+	tags: string[] = []
+): SpaceWorkflow {
+	const stepId = `step-${Math.random().toString(36).slice(2)}`;
+	return wfManager.createWorkflow({
+		spaceId,
+		name,
+		description: `${name} description`,
+		nodes: [{ id: stepId, name: 'Step', agentId }],
+		transitions: [],
+		startNodeId: stepId,
+		rules: [],
+		tags,
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('SpaceRuntime — LLM workflow selection', () => {
+	const SPACE_ID = 'space-llm-select';
+	const AGENT_ID = 'agent-llm-worker';
+
+	let db: BunDatabase;
+	let dir: string;
+	let workflowRunRepo: SpaceWorkflowRunRepository;
+	let taskRepo: SpaceTaskRepository;
+	let nodeExecutionRepo: NodeExecutionRepository;
+	let agentManager: SpaceAgentManager;
+	let workflowManager: SpaceWorkflowManager;
+	let spaceManager: SpaceManager;
+
+	beforeEach(() => {
+		({ db, dir } = makeDb());
+		seedSpaceRow(db, SPACE_ID);
+		seedAgentRow(db, AGENT_ID, SPACE_ID, 'LLM Worker');
+
+		workflowRunRepo = new SpaceWorkflowRunRepository(db);
+		taskRepo = new SpaceTaskRepository(db);
+		nodeExecutionRepo = new NodeExecutionRepository(db);
+		agentManager = new SpaceAgentManager(new SpaceAgentRepository(db));
+		workflowManager = new SpaceWorkflowManager(new SpaceWorkflowRepository(db));
+		spaceManager = new SpaceManager(db);
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			/* ignore */
+		}
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	function buildRuntime(selector?: SelectWorkflowWithLlm): SpaceRuntime {
+		const config: SpaceRuntimeConfig = {
+			db,
+			spaceManager,
+			spaceAgentManager: agentManager,
+			spaceWorkflowManager: workflowManager,
+			workflowRunRepo,
+			taskRepo,
+			nodeExecutionRepo,
+			selectWorkflowWithLlm: selector,
+		};
+		return new SpaceRuntime(config);
+	}
+
+	test('LLM pick wins over the deterministic default-tagged workflow', async () => {
+		const defaultWf = buildWorkflow(SPACE_ID, workflowManager, 'Default Flow', AGENT_ID, [
+			'default',
+		]);
+		const codingWf = buildWorkflow(SPACE_ID, workflowManager, 'Coding Flow', AGENT_ID, ['coding']);
+
+		let calls = 0;
+		const selector: SelectWorkflowWithLlm = async (_task, workflows) => {
+			calls += 1;
+			// Always ignore the default-tagged workflow and pick "Coding Flow".
+			const coding = workflows.find((w) => w.name === 'Coding Flow');
+			return coding?.id ?? null;
+		};
+
+		const runtime = buildRuntime(selector);
+
+		const task = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Implement auth',
+			description: 'add login route',
+			status: 'open',
+		});
+
+		await runtime.executeTick();
+
+		expect(calls).toBe(1);
+		const updated = taskRepo.getTask(task.id)!;
+		expect(updated.workflowRunId).not.toBeNull();
+		const run = workflowRunRepo.getRun(updated.workflowRunId!);
+		expect(run).not.toBeNull();
+		expect(run!.workflowId).toBe(codingWf.id);
+		expect(run!.workflowId).not.toBe(defaultWf.id);
+	});
+
+	test('null from LLM falls back to the default-tagged workflow', async () => {
+		const defaultWf = buildWorkflow(SPACE_ID, workflowManager, 'Default Flow', AGENT_ID, [
+			'default',
+		]);
+		buildWorkflow(SPACE_ID, workflowManager, 'Other Flow', AGENT_ID, []);
+
+		const selector: SelectWorkflowWithLlm = async () => null;
+		const runtime = buildRuntime(selector);
+
+		const task = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Do something',
+			description: '',
+			status: 'open',
+		});
+
+		await runtime.executeTick();
+
+		const updated = taskRepo.getTask(task.id)!;
+		expect(updated.workflowRunId).not.toBeNull();
+		const run = workflowRunRepo.getRun(updated.workflowRunId!);
+		expect(run!.workflowId).toBe(defaultWf.id);
+	});
+
+	test('thrown selector errors do not break the tick; falls back to default', async () => {
+		const defaultWf = buildWorkflow(SPACE_ID, workflowManager, 'Default Flow', AGENT_ID, [
+			'default',
+		]);
+		buildWorkflow(SPACE_ID, workflowManager, 'Other Flow', AGENT_ID, []);
+
+		const selector: SelectWorkflowWithLlm = async () => {
+			throw new Error('LLM transport exploded');
+		};
+
+		const runtime = buildRuntime(selector);
+
+		const task = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Needs a workflow',
+			description: '',
+			status: 'open',
+		});
+
+		// Tick itself must not throw.
+		await expect(runtime.executeTick()).resolves.toBeUndefined();
+
+		const updated = taskRepo.getTask(task.id)!;
+		expect(updated.workflowRunId).not.toBeNull();
+		const run = workflowRunRepo.getRun(updated.workflowRunId!);
+		expect(run!.workflowId).toBe(defaultWf.id);
+	});
+
+	test('unknown id (hallucination) from LLM falls back to the default-tagged workflow', async () => {
+		const defaultWf = buildWorkflow(SPACE_ID, workflowManager, 'Default Flow', AGENT_ID, [
+			'default',
+		]);
+		buildWorkflow(SPACE_ID, workflowManager, 'Other Flow', AGENT_ID, []);
+
+		const selector: SelectWorkflowWithLlm = async () => 'workflow-that-does-not-exist';
+		const runtime = buildRuntime(selector);
+
+		const task = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Unknown id scenario',
+			description: '',
+			status: 'open',
+		});
+
+		await runtime.executeTick();
+
+		const updated = taskRepo.getTask(task.id)!;
+		expect(updated.workflowRunId).not.toBeNull();
+		const run = workflowRunRepo.getRun(updated.workflowRunId!);
+		expect(run!.workflowId).toBe(defaultWf.id);
+	});
+
+	test('single-workflow case short-circuits without invoking the LLM', async () => {
+		const onlyWf = buildWorkflow(SPACE_ID, workflowManager, 'Only Flow', AGENT_ID, []);
+
+		let calls = 0;
+		const selector: SelectWorkflowWithLlm = async () => {
+			calls += 1;
+			return null;
+		};
+		const runtime = buildRuntime(selector);
+
+		const task = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Solo',
+			description: '',
+			status: 'open',
+		});
+
+		await runtime.executeTick();
+
+		expect(calls).toBe(0);
+		const updated = taskRepo.getTask(task.id)!;
+		const run = workflowRunRepo.getRun(updated.workflowRunId!);
+		expect(run!.workflowId).toBe(onlyWf.id);
+	});
+});

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -1060,7 +1060,7 @@ export interface CreateSpaceWorkflowParams {
 	channels?: WorkflowChannel[];
 	/** Gate definitions for this workflow. */
 	gates?: Gate[];
-	/** Tags for organizational categorization (default: []). Not used for automatic workflow selection. */
+	/** Tags for organizational categorization (default: []). See `SpaceWorkflow.tags` for runtime semantics. */
 	tags?: string[];
 	/** Visual editor node positions: maps node ID to {x, y} canvas coordinates */
 	layout?: Record<string, { x: number; y: number }>;
@@ -1111,7 +1111,7 @@ export interface UpdateSpaceWorkflowParams {
 	gates?: Gate[] | null;
 	/**
 	 * Replaces the tag list. Pass `[]` or `null` to clear all tags.
-	 * Tags are for organizational categorization only — not used for automatic workflow selection.
+	 * See `SpaceWorkflow.tags` for runtime semantics (used by the deterministic fallback selector).
 	 */
 	tags?: string[] | null;
 	/** Visual editor node positions. Pass `null` to clear. */

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -1001,7 +1001,17 @@ export interface SpaceWorkflow {
 	 * Persisted as JSON in the `gates` column of `space_workflows`.
 	 */
 	gates?: Gate[];
-	/** Tags for organizational categorization. Not used for automatic workflow selection. */
+	/**
+	 * Tags for organizational categorization.
+	 *
+	 * Primary workflow selection for standalone tasks is LLM-driven; tags are
+	 * exposed to the selector as context alongside the workflow name and
+	 * description. Two tag values are also recognized by the deterministic
+	 * fallback (used when the LLM selector is absent or declines to answer):
+	 *   - `default` — preferred fallback over any other workflow
+	 *   - `v2`      — preferred fallback over non-v2 workflows
+	 * Other tag values have no runtime meaning.
+	 */
 	tags: string[];
 	/** Visual editor node positions: maps node ID to {x, y} canvas coordinates */
 	layout?: Record<string, { x: number; y: number }>;


### PR DESCRIPTION
## Summary
- Replace the substring scorer in `selectFallbackWorkflowForStandaloneTask` with an injectable LLM selector; hallucinated/null/thrown responses fall back to a deterministic `default` → `v2` → most-recent tiebreak.
- Run per-task selection in parallel via `Promise.all` so one slow LLM call no longer blocks the whole tick.
- Simplify `suggest_workflow` (drops keyword pre-ranking); fix the `SpaceWorkflow.tags` JSDoc to match how tags are actually used.

## Test plan
- [x] `bun test packages/daemon/tests/unit/5-space/` — 2138 pass
- [x] `bun run check` (lint + typecheck + knip)
- [x] New unit tests cover: LLM pick wins, null → default, throw → default, unknown-id → default, single-workflow short-circuit, simplified `suggest_workflow`