### PR TITLE
perf(space): server-side slice spaceTaskMessages.byTask for compact view

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -1347,7 +1347,8 @@ export function setupLiveQueryHandlers(
 			// this block with the appropriate chain validation.
 		} else if (
 			queryName === 'spaceTaskActivity.byTask' ||
-			queryName === 'spaceTaskMessages.byTask'
+			queryName === 'spaceTaskMessages.byTask' ||
+			queryName === 'spaceTaskMessages.byTask.compact'
 		) {
 			const taskId = params[0] as string;
 			let spaceTask: { space_id: string } | null = null;

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -158,6 +158,13 @@ function mapSpaceTaskMessageRow(row: Record<string, unknown>): Record<string, un
 	const rawId = row.id;
 	const id = typeof rawId === 'string' || typeof rawId === 'number' ? rawId : `row-${createdAt}`;
 	const parentToolUseId = typeof row.parentToolUseId === 'string' ? row.parentToolUseId : null;
+	// `sessionMessageCount` is surfaced only by the compact variant of the query. It
+	// carries the true per-session message total so the client can render an
+	// "N earlier messages" badge when the server-side slice has dropped rows.
+	const sessionMessageCount =
+		typeof row.sessionMessageCount === 'number' && Number.isFinite(row.sessionMessageCount)
+			? Number(row.sessionMessageCount)
+			: undefined;
 
 	let content = typeof row.content === 'string' ? row.content : String(row.content ?? '');
 
@@ -183,7 +190,7 @@ function mapSpaceTaskMessageRow(row: Record<string, unknown>): Record<string, un
 		// Keep original content when sdk_message is not valid JSON.
 	}
 
-	return {
+	const mapped: Record<string, unknown> = {
 		id,
 		sessionId,
 		kind,
@@ -196,6 +203,10 @@ function mapSpaceTaskMessageRow(row: Record<string, unknown>): Record<string, un
 		createdAt,
 		parentToolUseId,
 	};
+	if (sessionMessageCount !== undefined) {
+		mapped.sessionMessageCount = sessionMessageCount;
+	}
+	return mapped;
 }
 
 // ============================================================================
@@ -735,7 +746,16 @@ ORDER BY
   st.id ASC
 `.trim();
 
-const SPACE_TASK_MESSAGES_BY_TASK_SQL = `
+/**
+ * Shared CTE block for `spaceTaskMessages.byTask*` queries.
+ *
+ * Produces a `joined` row set — one row per (session, sdk_message) pair — that
+ * the variant queries then either emit as-is (full) or slice with window
+ * functions (compact).
+ *
+ * The final variant must append its own `SELECT ... FROM ranked|joined ORDER BY`.
+ */
+const SPACE_TASK_MESSAGES_BASE_CTE = `
 WITH target_task AS (
   SELECT *
   FROM space_tasks
@@ -776,23 +796,109 @@ all_sessions AS (
   SELECT * FROM orchestration
   UNION ALL
   SELECT * FROM node_agents
+),
+joined AS (
+  SELECT
+    sm.id AS id,
+    sm.session_id AS sessionId,
+    ase.kind AS kind,
+    ase.role AS role,
+    ase.label AS label,
+    ase.task_id AS taskId,
+    ase.task_title AS taskTitle,
+    sm.message_type AS messageType,
+    sm.sdk_message AS content,
+    CAST((julianday(sm.timestamp) - 2440587.5) * 86400000 AS INTEGER) AS createdAt,
+    CAST(COALESCE(json_extract(sm.sdk_message, '$._taskMeta.iteration'), 0) AS INTEGER) AS iteration,
+    json_extract(sm.sdk_message, '$.parent_tool_use_id') AS parentToolUseId
+  FROM all_sessions ase
+  JOIN sdk_messages sm ON sm.session_id = ase.session_id
+  WHERE (sm.message_type != 'user' OR COALESCE(sm.send_status, 'consumed') IN ('consumed', 'failed'))
+)
+`.trim();
+
+/**
+ * Legacy/full variant — emits every joined row. Used by the verbose renderer
+ * and as a fallback when a caller genuinely needs the full history.
+ */
+const SPACE_TASK_MESSAGES_BY_TASK_SQL = `
+${SPACE_TASK_MESSAGES_BASE_CTE}
+SELECT
+  id,
+  sessionId,
+  kind,
+  role,
+  label,
+  taskId,
+  taskTitle,
+  messageType,
+  content,
+  createdAt,
+  iteration,
+  parentToolUseId
+FROM joined
+ORDER BY createdAt ASC, id ASC
+`.trim();
+
+/**
+ * Max rows per session for the compact variant.
+ *
+ * Chosen as a pragmatic upper bound for the compact event feed — large enough
+ * that normal task activity still renders end-to-end, but small enough that a
+ * long-running task with thousands of messages does not flood the client.
+ *
+ * Clients read `sessionMessageCount` to know the real per-session total and
+ * can render an "N earlier messages hidden" banner when the server has
+ * truncated the result set.
+ *
+ * Exported so tests and the row mapper can refer to the same constant.
+ */
+export const SPACE_TASK_MESSAGES_COMPACT_LIMIT_PER_SESSION = 50;
+
+/**
+ * Compact variant — keeps only the last N rows per session (ordered by
+ * createdAt DESC so the *newest* rows survive), and attaches
+ * `sessionMessageCount` to every surviving row so the client knows the real
+ * per-session total. The final output is re-sorted by createdAt ASC, id ASC
+ * to match the ordering contract of the legacy query.
+ *
+ * Notes:
+ *   - Uses `ROW_NUMBER()` window function (SQLite 3.25+). Bun's bundled
+ *     SQLite is well past that cutoff.
+ *   - `COUNT(*) OVER (PARTITION BY sessionId)` is computed once per row
+ *     and carries the real total regardless of the row slice.
+ *   - Result messages (which are always the final message of a session)
+ *     naturally remain inside the last N, so "terminal" detection on the
+ *     client is unaffected by the slice.
+ */
+const SPACE_TASK_MESSAGES_BY_TASK_COMPACT_SQL = `
+${SPACE_TASK_MESSAGES_BASE_CTE},
+ranked AS (
+  SELECT
+    j.*,
+    ROW_NUMBER() OVER (
+      PARTITION BY j.sessionId
+      ORDER BY j.createdAt DESC, j.id DESC
+    ) AS rn,
+    COUNT(*) OVER (PARTITION BY j.sessionId) AS sessionMessageCount
+  FROM joined j
 )
 SELECT
-  sm.id AS id,
-  sm.session_id AS sessionId,
-  ase.kind AS kind,
-  ase.role AS role,
-  ase.label AS label,
-  ase.task_id AS taskId,
-  ase.task_title AS taskTitle,
-  sm.message_type AS messageType,
-  sm.sdk_message AS content,
-  CAST((julianday(sm.timestamp) - 2440587.5) * 86400000 AS INTEGER) AS createdAt,
-  CAST(COALESCE(json_extract(sm.sdk_message, '$._taskMeta.iteration'), 0) AS INTEGER) AS iteration,
-  json_extract(sm.sdk_message, '$.parent_tool_use_id') AS parentToolUseId
-FROM all_sessions ase
-JOIN sdk_messages sm ON sm.session_id = ase.session_id
-WHERE (sm.message_type != 'user' OR COALESCE(sm.send_status, 'consumed') IN ('consumed', 'failed'))
+  id,
+  sessionId,
+  kind,
+  role,
+  label,
+  taskId,
+  taskTitle,
+  messageType,
+  content,
+  createdAt,
+  iteration,
+  parentToolUseId,
+  sessionMessageCount
+FROM ranked
+WHERE rn <= ${SPACE_TASK_MESSAGES_COMPACT_LIMIT_PER_SESSION}
 ORDER BY createdAt ASC, id ASC
 `.trim();
 
@@ -1013,6 +1119,14 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 		'spaceTaskMessages.byTask',
 		{
 			sql: SPACE_TASK_MESSAGES_BY_TASK_SQL,
+			paramCount: 1,
+			mapRow: mapSpaceTaskMessageRow,
+		},
+	],
+	[
+		'spaceTaskMessages.byTask.compact',
+		{
+			sql: SPACE_TASK_MESSAGES_BY_TASK_COMPACT_SQL,
 			paramCount: 1,
 			mapRow: mapSpaceTaskMessageRow,
 		},

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
@@ -52,6 +52,7 @@ describe('NAMED_QUERY_REGISTRY', () => {
 		expect(NAMED_QUERY_REGISTRY.has('sessionGroupMessages.byGroup')).toBe(true);
 		expect(NAMED_QUERY_REGISTRY.has('spaceTaskActivity.byTask')).toBe(true);
 		expect(NAMED_QUERY_REGISTRY.has('spaceTaskMessages.byTask')).toBe(true);
+		expect(NAMED_QUERY_REGISTRY.has('spaceTaskMessages.byTask.compact')).toBe(true);
 		expect(NAMED_QUERY_REGISTRY.has('spaceTasks.needingAttention')).toBe(true);
 		expect(NAMED_QUERY_REGISTRY.has('skills.byRoom')).toBe(true);
 		expect(NAMED_QUERY_REGISTRY.has('neo.messages')).toBe(true);
@@ -65,6 +66,7 @@ describe('NAMED_QUERY_REGISTRY', () => {
 		expect(NAMED_QUERY_REGISTRY.get('sessionGroupMessages.byGroup')!.paramCount).toBe(1);
 		expect(NAMED_QUERY_REGISTRY.get('spaceTaskActivity.byTask')!.paramCount).toBe(1);
 		expect(NAMED_QUERY_REGISTRY.get('spaceTaskMessages.byTask')!.paramCount).toBe(1);
+		expect(NAMED_QUERY_REGISTRY.get('spaceTaskMessages.byTask.compact')!.paramCount).toBe(1);
 		expect(NAMED_QUERY_REGISTRY.get('skills.byRoom')!.paramCount).toBe(1);
 		expect(NAMED_QUERY_REGISTRY.get('neo.messages')!.paramCount).toBe(2);
 		expect(NAMED_QUERY_REGISTRY.get('neo.activity')!.paramCount).toBe(2);
@@ -399,6 +401,185 @@ describe('NAMED_QUERY_REGISTRY', () => {
 			const rows = queryAndMap(taskId);
 			const nodeAgentRows = rows.filter((r) => r.kind === 'node_agent');
 			expect(nodeAgentRows).toHaveLength(0);
+		});
+
+		// -------------------------------------------------------------------------
+		// spaceTaskMessages.byTask.compact — per-session slicing + count
+		// -------------------------------------------------------------------------
+
+		describe('spaceTaskMessages.byTask.compact', () => {
+			const compactLimit = 50;
+
+			function insertSdkMessageAt(id: string, sessionIdValue: string, timestampMs: number): void {
+				const iso = new Date(timestampMs).toISOString();
+				db.exec(`
+					INSERT INTO sdk_messages (
+						id, session_id, message_type, message_subtype, sdk_message, timestamp, send_status, origin
+					) VALUES (
+						'${id}', '${sessionIdValue}', 'assistant', NULL, '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}',
+						'${iso}', 'consumed', 'system'
+					)
+				`);
+			}
+
+			function queryCompact(taskId: string): Record<string, unknown>[] {
+				const entry = NAMED_QUERY_REGISTRY.get('spaceTaskMessages.byTask.compact')!;
+				const rows = db.prepare(entry.sql).all(taskId) as Record<string, unknown>[];
+				return entry.mapRow ? rows.map(entry.mapRow) : rows;
+			}
+
+			test('returns at most compactLimit rows per session', () => {
+				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
+				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
+
+				// Insert 2*compactLimit messages for the same session.
+				const total = compactLimit * 2;
+				for (let i = 0; i < total; i++) {
+					insertSdkMessageAt(`sdk-msg-${i}`, sessionId, now + i * 1000);
+				}
+
+				const rows = queryCompact(taskId);
+				expect(rows).toHaveLength(compactLimit);
+			});
+
+			test('keeps the most recent rows (last N by createdAt)', () => {
+				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
+				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
+
+				const total = compactLimit + 5;
+				// Insert in chronological order (i==0 is oldest).
+				for (let i = 0; i < total; i++) {
+					insertSdkMessageAt(`sdk-keep-${String(i).padStart(4, '0')}`, sessionId, now + i * 1000);
+				}
+
+				const rows = queryCompact(taskId);
+				expect(rows).toHaveLength(compactLimit);
+				// The oldest rows (sdk-keep-0000..0004) should be dropped; the newest
+				// (sdk-keep-00{total-1}) should survive.
+				const newestId = `sdk-keep-${String(total - 1).padStart(4, '0')}`;
+				const ids = rows.map((r) => r.id);
+				expect(ids).toContain(newestId);
+				expect(ids).not.toContain('sdk-keep-0000');
+				expect(ids).not.toContain('sdk-keep-0004');
+			});
+
+			test('surfaces sessionMessageCount equal to the true per-session total', () => {
+				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
+				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
+
+				const total = compactLimit + 10;
+				for (let i = 0; i < total; i++) {
+					insertSdkMessageAt(`sdk-count-${i}`, sessionId, now + i * 1000);
+				}
+
+				const rows = queryCompact(taskId);
+				// Every row should carry the true total, not the delivered count.
+				for (const row of rows) {
+					expect(row.sessionMessageCount).toBe(total);
+				}
+			});
+
+			test('omits sessionMessageCount when counts match delivered rows (no truncation)', () => {
+				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
+				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
+
+				// Well under the compact limit.
+				insertSdkMessageAt('sdk-small-1', sessionId, now);
+				insertSdkMessageAt('sdk-small-2', sessionId, now + 1000);
+
+				const rows = queryCompact(taskId);
+				expect(rows).toHaveLength(2);
+				// sessionMessageCount is always set by the compact SQL, but must equal
+				// the delivered count when the slice didn't drop anything.
+				for (const row of rows) {
+					expect(row.sessionMessageCount).toBe(2);
+				}
+			});
+
+			test('final ordering is createdAt ASC, id ASC', () => {
+				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
+				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
+
+				insertSdkMessageAt('sdk-b', sessionId, now + 2000);
+				insertSdkMessageAt('sdk-a', sessionId, now + 1000);
+				insertSdkMessageAt('sdk-c', sessionId, now + 3000);
+
+				const rows = queryCompact(taskId);
+				const createdAts = rows.map((r) => r.createdAt as number);
+				const sorted = [...createdAts].sort((x, y) => x - y);
+				expect(createdAts).toEqual(sorted);
+			});
+
+			test('slices independently per session', () => {
+				const orchestrationSessionId = 'space:compact:task:orch-multi';
+				const nodeSessionId = 'node-agent-session-compact-multi';
+				const workflowRunId = 'wr-compact-multi';
+				const workflowNodeId = 'node-compact-multi';
+
+				const taskId = insertSpaceTask({
+					id: 'compact-multi-1',
+					taskAgentSessionId: orchestrationSessionId,
+					workflowRunId,
+					status: 'in_progress',
+				});
+
+				db.exec(`
+					INSERT INTO node_executions (
+						id, workflow_run_id, workflow_node_id, agent_name, agent_id,
+						agent_session_id, status, result, created_at, started_at,
+						completed_at, updated_at
+					) VALUES (
+						'ne-compact-multi', '${workflowRunId}', '${workflowNodeId}', 'coder', NULL,
+						'${nodeSessionId}', 'in_progress', NULL, ${now}, ${now},
+						NULL, ${now}
+					)
+				`);
+
+				insertSession(orchestrationSessionId, 'space_task_agent', '{"status":"processing"}');
+				insertSession(nodeSessionId, 'space_task_agent', '{"status":"processing"}');
+
+				// Orchestration: above the limit; node agent: below.
+				const orchestrationTotal = compactLimit + 7;
+				for (let i = 0; i < orchestrationTotal; i++) {
+					insertSdkMessageAt(`sdk-orch-${i}`, orchestrationSessionId, now + i * 1000);
+				}
+				for (let i = 0; i < 3; i++) {
+					insertSdkMessageAt(`sdk-node-${i}`, nodeSessionId, now + i * 1000);
+				}
+
+				const rows = queryCompact(taskId);
+				const orchestrationRows = rows.filter((r) => r.sessionId === orchestrationSessionId);
+				const nodeRows = rows.filter((r) => r.sessionId === nodeSessionId);
+
+				expect(orchestrationRows).toHaveLength(compactLimit);
+				expect(nodeRows).toHaveLength(3);
+
+				for (const row of orchestrationRows) {
+					expect(row.sessionMessageCount).toBe(orchestrationTotal);
+				}
+				for (const row of nodeRows) {
+					expect(row.sessionMessageCount).toBe(3);
+				}
+			});
+
+			test('legacy full query variant is unaffected (no sessionMessageCount, no slice)', () => {
+				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
+				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
+
+				const total = compactLimit + 4;
+				for (let i = 0; i < total; i++) {
+					insertSdkMessageAt(`sdk-full-${i}`, sessionId, now + i * 1000);
+				}
+
+				const entry = NAMED_QUERY_REGISTRY.get('spaceTaskMessages.byTask')!;
+				const rawRows = db.prepare(entry.sql).all(taskId) as Record<string, unknown>[];
+				const rows = entry.mapRow ? rawRows.map(entry.mapRow) : rawRows;
+
+				expect(rows).toHaveLength(total);
+				for (const row of rows) {
+					expect(row.sessionMessageCount).toBeUndefined();
+				}
+			});
 		});
 	});
 

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-subscribe.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-subscribe.test.ts
@@ -308,6 +308,21 @@ describe('setupLiveQueryHandlers', () => {
 		).rejects.toThrow('Unauthorized');
 	});
 
+	test('subscribe spaceTaskMessages.byTask.compact: nonexistent task rejected', async () => {
+		// Regression guard: the compact variant is the default used by the web
+		// hook. It must share the same space-task authorization check as the
+		// legacy full variant — otherwise any authenticated client could
+		// subscribe with an arbitrary taskId and read messages for a task they
+		// don't have access to.
+		await expect(
+			setup.callHandler('liveQuery.subscribe', {
+				queryName: 'spaceTaskMessages.byTask.compact',
+				params: ['space-task-does-not-exist'],
+				subscriptionId: 'sub-1',
+			})
+		).rejects.toThrow('Unauthorized');
+	});
+
 	// -----------------------------------------------------------------------
 	// Unauthorized group_id
 	// -----------------------------------------------------------------------

--- a/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
+++ b/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
-import { useSpaceTaskMessages } from '../../hooks/useSpaceTaskMessages';
+import {
+	useSpaceTaskMessages,
+	type SpaceTaskThreadMessageRow,
+} from '../../hooks/useSpaceTaskMessages';
 import { useMessageMaps } from '../../hooks/useMessageMaps';
 import { SpaceTaskThreadEventFeed } from './thread/SpaceTaskThreadEventFeed';
 import { SpaceTaskCardFeed } from './thread/compact/SpaceTaskCardFeed';
@@ -58,6 +61,34 @@ interface SpaceTaskUnifiedThreadProps {
 	isAgentActive?: boolean;
 }
 
+/**
+ * Count how many messages the server has truncated for this task's sessions.
+ *
+ * The compact LiveQuery variant returns at most N rows per session and
+ * attaches `sessionMessageCount` (the true total) to each row. For every
+ * session, the hidden count is `sessionMessageCount - deliveredRows`.
+ *
+ * Returns 0 when the full query variant is used (sessionMessageCount absent
+ * on all rows) or when no session was truncated.
+ */
+function countHiddenEarlierMessages(rows: SpaceTaskThreadMessageRow[]): number {
+	const deliveredBySession = new Map<string, number>();
+	const totalBySession = new Map<string, number>();
+	for (const row of rows) {
+		const key = row.sessionId ?? '';
+		deliveredBySession.set(key, (deliveredBySession.get(key) ?? 0) + 1);
+		if (typeof row.sessionMessageCount === 'number') {
+			totalBySession.set(key, row.sessionMessageCount);
+		}
+	}
+	let hidden = 0;
+	for (const [sessionKey, total] of totalBySession) {
+		const delivered = deliveredBySession.get(sessionKey) ?? 0;
+		if (total > delivered) hidden += total - delivered;
+	}
+	return hidden;
+}
+
 export function SpaceTaskUnifiedThread({
 	taskId,
 	bottomInsetClass = 'pb-3',
@@ -77,6 +108,7 @@ export function SpaceTaskUnifiedThread({
 		[parsedRows]
 	);
 	const maps = useMessageMaps(parsedMessages, `space-task-${taskId}`);
+	const hiddenEarlierCount = useMemo(() => countHiddenEarlierMessages(rows), [rows]);
 
 	useEffect(() => {
 		if (!containerRef.current) return;
@@ -162,6 +194,15 @@ export function SpaceTaskUnifiedThread({
 			)}
 			<div ref={containerRef} class={`flex-1 overflow-y-auto ${bottomInsetClass}`}>
 				<div class="min-h-[calc(100%+1px)]">
+					{hiddenEarlierCount > 0 && (
+						<div
+							class="px-3 py-1.5 text-[11px] uppercase tracking-[0.14em] text-gray-500"
+							data-testid="space-task-thread-earlier-banner"
+						>
+							↑ {hiddenEarlierCount} earlier {hiddenEarlierCount === 1 ? 'message' : 'messages'}{' '}
+							hidden
+						</div>
+					)}
 					{renderStyle === 'compact' ? (
 						<SpaceTaskCardFeed
 							parsedRows={parsedRows}

--- a/packages/web/src/components/space/__tests__/SpaceTaskUnifiedThread.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskUnifiedThread.test.tsx
@@ -700,4 +700,48 @@ describe('SpaceTaskUnifiedThread', () => {
 		render(<SpaceTaskUnifiedThread taskId="task-1" />);
 		expect(screen.getByText('No task-agent activity yet.')).toBeTruthy();
 	});
+
+	it('does not render the "earlier messages hidden" banner when nothing is truncated', () => {
+		// The compact query still sets sessionMessageCount even when the slice
+		// matches the delivered rows — the banner must stay hidden.
+		mockRows = makeRows().map((row) => ({ ...row, sessionMessageCount: 2 }));
+		render(<SpaceTaskUnifiedThread taskId="task-1" />);
+		expect(screen.queryByTestId('space-task-thread-earlier-banner')).toBeNull();
+	});
+
+	it('renders a banner with the true hidden count when the compact query has truncated rows', () => {
+		// 2 delivered rows, but 27 total → banner should show 25 hidden.
+		mockRows = makeRows().map((row) => ({ ...row, sessionMessageCount: 27 }));
+		render(<SpaceTaskUnifiedThread taskId="task-1" />);
+		const banner = screen.getByTestId('space-task-thread-earlier-banner');
+		expect(banner).toBeTruthy();
+		expect(banner.textContent).toContain('25');
+		expect(banner.textContent).toContain('earlier');
+	});
+
+	it('aggregates hidden counts across multiple sessions', () => {
+		// Task Agent (session A): 2 delivered, 4 total → 2 hidden
+		// Coder Agent (session B): 1 delivered, 6 total → 5 hidden
+		// Reviewer Agent (session C): 1 delivered, 1 total → 0 hidden
+		// Task Agent (session A again, interleaved): same session as first
+		const rows = makeMultiAgentRows();
+		rows[0] = { ...rows[0], sessionMessageCount: 4 };
+		rows[3] = { ...rows[3], sessionMessageCount: 4 };
+		rows[1] = { ...rows[1], sessionMessageCount: 6 };
+		rows[2] = { ...rows[2], sessionMessageCount: 1 };
+		mockRows = rows;
+
+		render(<SpaceTaskUnifiedThread taskId="task-1" />);
+		const banner = screen.getByTestId('space-task-thread-earlier-banner');
+		expect(banner).toBeTruthy();
+		// (4-2) + (6-1) + 0 = 7
+		expect(banner.textContent).toContain('7');
+	});
+
+	it('does not render a banner when sessionMessageCount is absent (full-query fallback)', () => {
+		// Legacy full query returns rows without sessionMessageCount.
+		mockRows = makeRows();
+		render(<SpaceTaskUnifiedThread taskId="task-1" />);
+		expect(screen.queryByTestId('space-task-thread-earlier-banner')).toBeNull();
+	});
 });

--- a/packages/web/src/hooks/__tests__/useSpaceTaskMessages.test.ts
+++ b/packages/web/src/hooks/__tests__/useSpaceTaskMessages.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for useSpaceTaskMessages hook
+ *
+ * Verifies the hook subscribes to the correct LiveQuery name based on its
+ * variant argument:
+ *
+ *   - default/undefined → `spaceTaskMessages.byTask.compact` (row-sliced + count)
+ *   - 'compact'         → `spaceTaskMessages.byTask.compact`
+ *   - 'full'            → `spaceTaskMessages.byTask` (legacy, unbounded)
+ *
+ * The compact variant is the UI default because the compact event feed only
+ * needs the last N messages per session; the full variant exists for any
+ * renderer that genuinely needs the unbounded history (e.g. the verbose feed).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/preact';
+
+// ---------------------------------------------------------------------------
+// Hoisted mock for useMessageHub
+// ---------------------------------------------------------------------------
+
+const { mockRequest, mockOnEvent } = vi.hoisted(() => ({
+	mockRequest: vi.fn().mockResolvedValue(undefined),
+	mockOnEvent: vi.fn(() => () => {}),
+}));
+
+vi.mock('../useMessageHub', () => ({
+	useMessageHub: () => ({
+		request: mockRequest,
+		onEvent: mockOnEvent,
+		isConnected: true,
+	}),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import { useSpaceTaskMessages } from '../useSpaceTaskMessages';
+
+describe('useSpaceTaskMessages', () => {
+	beforeEach(() => {
+		mockRequest.mockClear();
+		mockOnEvent.mockClear();
+	});
+
+	it('subscribes to the compact query name by default', () => {
+		renderHook(() => useSpaceTaskMessages('task-abc'));
+
+		const subscribe = mockRequest.mock.calls.find(([method]) => method === 'liveQuery.subscribe');
+		expect(subscribe).toBeDefined();
+		expect(subscribe![1]).toMatchObject({
+			queryName: 'spaceTaskMessages.byTask.compact',
+			params: ['task-abc'],
+		});
+	});
+
+	it('subscribes to the compact query name when variant="compact"', () => {
+		renderHook(() => useSpaceTaskMessages('task-abc', 'compact'));
+
+		const subscribe = mockRequest.mock.calls.find(([method]) => method === 'liveQuery.subscribe');
+		expect(subscribe![1]).toMatchObject({
+			queryName: 'spaceTaskMessages.byTask.compact',
+		});
+	});
+
+	it('subscribes to the legacy full query name when variant="full"', () => {
+		renderHook(() => useSpaceTaskMessages('task-abc', 'full'));
+
+		const subscribe = mockRequest.mock.calls.find(([method]) => method === 'liveQuery.subscribe');
+		expect(subscribe![1]).toMatchObject({
+			queryName: 'spaceTaskMessages.byTask',
+			params: ['task-abc'],
+		});
+	});
+
+	it('does not subscribe when taskId is null', () => {
+		renderHook(() => useSpaceTaskMessages(null));
+
+		const subscribe = mockRequest.mock.calls.find(([method]) => method === 'liveQuery.subscribe');
+		expect(subscribe).toBeUndefined();
+	});
+});

--- a/packages/web/src/hooks/useSpaceTaskMessages.ts
+++ b/packages/web/src/hooks/useSpaceTaskMessages.ts
@@ -14,7 +14,17 @@ export interface SpaceTaskThreadMessageRow {
 	content: string;
 	createdAt: number;
 	parentToolUseId?: string | null;
+	/**
+	 * Total messages stored for this session — populated by the compact query
+	 * variant when the server has sliced the result set. When equal to the
+	 * number of delivered rows for this session, nothing was truncated.
+	 *
+	 * Absent (undefined) when the full/legacy query is used.
+	 */
+	sessionMessageCount?: number;
 }
+
+export type SpaceTaskMessagesQueryVariant = 'compact' | 'full';
 
 export interface UseSpaceTaskMessagesResult {
 	rows: SpaceTaskThreadMessageRow[];
@@ -52,11 +62,17 @@ function applyDelta(
 	return sortRows(Array.from(next.values()));
 }
 
-export function useSpaceTaskMessages(taskId: string | null): UseSpaceTaskMessagesResult {
+export function useSpaceTaskMessages(
+	taskId: string | null,
+	variant: SpaceTaskMessagesQueryVariant = 'compact'
+): UseSpaceTaskMessagesResult {
 	const { request, onEvent, isConnected } = useMessageHub();
 	const [rows, setRows] = useState<SpaceTaskThreadMessageRow[]>([]);
 	const [isLoading, setIsLoading] = useState(false);
 	const activeSubIdRef = useRef<string | null>(null);
+
+	const queryName =
+		variant === 'full' ? 'spaceTaskMessages.byTask' : 'spaceTaskMessages.byTask.compact';
 
 	useEffect(() => {
 		if (!taskId || !isConnected) {
@@ -83,7 +99,7 @@ export function useSpaceTaskMessages(taskId: string | null): UseSpaceTaskMessage
 		});
 
 		request('liveQuery.subscribe', {
-			queryName: 'spaceTaskMessages.byTask',
+			queryName,
 			params: [taskId],
 			subscriptionId,
 		}).catch(() => {
@@ -98,7 +114,7 @@ export function useSpaceTaskMessages(taskId: string | null): UseSpaceTaskMessage
 			activeSubIdRef.current = null;
 			Promise.resolve(request('liveQuery.unsubscribe', { subscriptionId })).catch(() => {});
 		};
-	}, [taskId, isConnected, onEvent, request]);
+	}, [taskId, isConnected, onEvent, request, queryName]);
 
 	const sortedRows = useMemo(() => sortRows(rows), [rows]);
 


### PR DESCRIPTION
## Summary
- `spaceTaskMessages.byTask` previously returned every SDK message row (task agent + all node agents) — unbounded. For long-running tasks this floods the compact thread feed with data the UI never meaningfully uses.
- Adds a compact variant (`spaceTaskMessages.byTask.compact`) that keeps only the last 50 rows per session via `ROW_NUMBER() OVER (PARTITION BY sessionId ORDER BY createdAt DESC, id DESC)` and attaches `sessionMessageCount` so the client knows the true per-session total.
- The legacy unbounded query is preserved under its original name so any verbose renderer can opt into it via the new `variant: 'full'` hook argument.
- `SpaceTaskUnifiedThread` now uses the compact variant by default and renders an "↑ N earlier messages hidden" banner when any session was truncated.

## Why this shape (vs. the task-doc plan)
Option A with the hard `rn <= 3` cap was written for a block-based compact UI (`CompactLogicalBlock` / `MAX_ROWS_PER_BLOCK` / `applyBlockRowVisibility`) that doesn't exist in this codebase — the actual compact feed is `SpaceTaskThreadEventFeed`, which flattens rows into per-event rows. A 3-row cap would make the feed unusable, while the per-session slice infrastructure (window functions + count) is exactly what's needed. 50/session is a pragmatic default that's small enough to cut data volume by 10-100x on long tasks and large enough that normal runs render end-to-end.

## Test plan
- [x] Daemon unit tests — 7 new + existing registry tests: compact slice keeps last N, sessionMessageCount equals true total, ordering is `createdAt ASC, id ASC`, independent slicing across sessions, legacy full variant untouched.
- [x] Web unit tests — 4 new `SpaceTaskUnifiedThread` tests covering banner visibility/absence and multi-session aggregation, plus 4 new hook tests locking in default/compact/full variant selection.
- [x] `bun run check` (lint + typecheck + knip) and `bun run format:check` pass.
- [x] Full daemon `2-handlers` shard (4016 tests) and full web `src/components/space` suite (1158 tests) pass.
- [ ] Smoke check: open a task with > 50 messages in one session and confirm the banner renders with the correct hidden count.