### PR TITLE
feat(space): surface gate approval on canvas + thread, inline human-input questions

### DIFF
--- a/packages/web/src/components/space/ChannelInfoPanel.tsx
+++ b/packages/web/src/components/space/ChannelInfoPanel.tsx
@@ -16,8 +16,14 @@ interface ChannelInfoPanelProps {
 	onClose: () => void;
 	/** Called when the user approves or rejects the channel's gate from this panel. */
 	onGateDecision?: (gateId: string, approved: boolean) => void | Promise<void>;
-	/** Called when the user clicks "View Artifacts" for the channel's gate. */
-	onViewArtifacts?: (gateId: string) => void;
+	/**
+	 * Called when the user clicks "View Artifacts" for the channel's gate.
+	 * The click event is forwarded so the parent can capture `event.currentTarget`
+	 * for focus restoration on overlay close — `document.activeElement` is
+	 * unreliable for button clicks in Safari/Firefox, which don't move focus
+	 * to a button on click.
+	 */
+	onViewArtifacts?: (gateId: string, event: Event) => void;
 	/** Disables approve/reject buttons while an RPC is in flight. */
 	decisionPending?: boolean;
 	/** Error message from last decision attempt; shown below the action buttons. */
@@ -148,7 +154,7 @@ export function ChannelInfoPanel({
 								{showViewArtifacts && (
 									<button
 										type="button"
-										onClick={() => onViewArtifacts?.(channel.gateId!)}
+										onClick={(e) => onViewArtifacts?.(channel.gateId!, e)}
 										data-testid="channel-view-artifacts-btn"
 										class="px-3 py-1 text-xs font-medium rounded bg-dark-700 text-gray-200 border border-dark-600 hover:bg-dark-600 transition-colors"
 									>

--- a/packages/web/src/components/space/ChannelInfoPanel.tsx
+++ b/packages/web/src/components/space/ChannelInfoPanel.tsx
@@ -14,6 +14,12 @@ interface ChannelInfoPanelProps {
 	fromNodeName: string;
 	toNodeName: string;
 	onClose: () => void;
+	/** Called when the user approves or rejects the channel's gate from this panel. */
+	onGateDecision?: (gateId: string, approved: boolean) => void | Promise<void>;
+	/** Called when the user clicks "View Artifacts" for the channel's gate. */
+	onViewArtifacts?: (gateId: string) => void;
+	/** Disables approve/reject buttons while an RPC is in flight. */
+	decisionPending?: boolean;
 	class?: string;
 }
 
@@ -40,6 +46,9 @@ export function ChannelInfoPanel({
 	fromNodeName,
 	toNodeName,
 	onClose,
+	onGateDecision,
+	onViewArtifacts,
+	decisionPending = false,
 	class: className,
 }: ChannelInfoPanelProps): JSX.Element {
 	const status = channel.runtimeStatus;
@@ -47,6 +56,7 @@ export function ChannelInfoPanel({
 	const gateLabel =
 		channel.gateLabel ?? (channel.gateType ? GATE_TYPE_LABELS[channel.gateType] : null);
 	const isBidirectional = channel.direction === 'bidirectional';
+	const showApprovalActions = status === 'waiting_human' && !!channel.gateId;
 
 	return (
 		<div
@@ -103,6 +113,40 @@ export function ChannelInfoPanel({
 
 						{!gateLabel && !statusConfig && <span class="text-xs text-gray-500">No gate</span>}
 					</div>
+
+					{showApprovalActions && channel.gateId && (
+						<div class="flex items-center gap-2 pt-1" data-testid="channel-gate-actions">
+							<button
+								type="button"
+								onClick={() => void onGateDecision?.(channel.gateId!, true)}
+								disabled={decisionPending || !onGateDecision}
+								data-testid="channel-approve-btn"
+								class="px-3 py-1 text-xs font-medium rounded bg-green-900/40 text-green-300 border border-green-700/50 hover:bg-green-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+							>
+								Approve
+							</button>
+							<button
+								type="button"
+								onClick={() => void onGateDecision?.(channel.gateId!, false)}
+								disabled={decisionPending || !onGateDecision}
+								data-testid="channel-reject-btn"
+								class="px-3 py-1 text-xs font-medium rounded bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+							>
+								Reject
+							</button>
+							{onViewArtifacts && (
+								<button
+									type="button"
+									onClick={() => onViewArtifacts(channel.gateId!)}
+									disabled={decisionPending}
+									data-testid="channel-view-artifacts-btn"
+									class="px-3 py-1 text-xs font-medium rounded bg-dark-700 text-gray-200 border border-dark-600 hover:bg-dark-600 disabled:opacity-50 transition-colors"
+								>
+									View Artifacts
+								</button>
+							)}
+						</div>
+					)}
 				</div>
 
 				<button

--- a/packages/web/src/components/space/ChannelInfoPanel.tsx
+++ b/packages/web/src/components/space/ChannelInfoPanel.tsx
@@ -20,6 +20,8 @@ interface ChannelInfoPanelProps {
 	onViewArtifacts?: (gateId: string) => void;
 	/** Disables approve/reject buttons while an RPC is in flight. */
 	decisionPending?: boolean;
+	/** Error message from last decision attempt; shown below the action buttons. */
+	decisionError?: string | null;
 	class?: string;
 }
 
@@ -49,6 +51,7 @@ export function ChannelInfoPanel({
 	onGateDecision,
 	onViewArtifacts,
 	decisionPending = false,
+	decisionError = null,
 	class: className,
 }: ChannelInfoPanelProps): JSX.Element {
 	const status = channel.runtimeStatus;
@@ -115,37 +118,44 @@ export function ChannelInfoPanel({
 					</div>
 
 					{showApprovalActions && channel.gateId && (
-						<div class="flex items-center gap-2 pt-1" data-testid="channel-gate-actions">
-							<button
-								type="button"
-								onClick={() => void onGateDecision?.(channel.gateId!, true)}
-								disabled={decisionPending || !onGateDecision}
-								data-testid="channel-approve-btn"
-								class="px-3 py-1 text-xs font-medium rounded bg-green-900/40 text-green-300 border border-green-700/50 hover:bg-green-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-							>
-								Approve
-							</button>
-							<button
-								type="button"
-								onClick={() => void onGateDecision?.(channel.gateId!, false)}
-								disabled={decisionPending || !onGateDecision}
-								data-testid="channel-reject-btn"
-								class="px-3 py-1 text-xs font-medium rounded bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-							>
-								Reject
-							</button>
-							{onViewArtifacts && (
+						<>
+							<div class="flex items-center gap-2 pt-1" data-testid="channel-gate-actions">
 								<button
 									type="button"
-									onClick={() => onViewArtifacts(channel.gateId!)}
-									disabled={decisionPending}
-									data-testid="channel-view-artifacts-btn"
-									class="px-3 py-1 text-xs font-medium rounded bg-dark-700 text-gray-200 border border-dark-600 hover:bg-dark-600 disabled:opacity-50 transition-colors"
+									onClick={() => void onGateDecision?.(channel.gateId!, true)}
+									disabled={decisionPending || !onGateDecision}
+									data-testid="channel-approve-btn"
+									class="px-3 py-1 text-xs font-medium rounded bg-green-900/40 text-green-300 border border-green-700/50 hover:bg-green-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
 								>
-									View Artifacts
+									Approve
 								</button>
+								<button
+									type="button"
+									onClick={() => void onGateDecision?.(channel.gateId!, false)}
+									disabled={decisionPending || !onGateDecision}
+									data-testid="channel-reject-btn"
+									class="px-3 py-1 text-xs font-medium rounded bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+								>
+									Reject
+								</button>
+								{onViewArtifacts && (
+									<button
+										type="button"
+										onClick={() => onViewArtifacts(channel.gateId!)}
+										disabled={decisionPending}
+										data-testid="channel-view-artifacts-btn"
+										class="px-3 py-1 text-xs font-medium rounded bg-dark-700 text-gray-200 border border-dark-600 hover:bg-dark-600 disabled:opacity-50 transition-colors"
+									>
+										View Artifacts
+									</button>
+								)}
+							</div>
+							{decisionError && (
+								<p class="text-xs text-red-400" data-testid="channel-gate-error">
+									{decisionError}
+								</p>
 							)}
-						</div>
+						</>
 					)}
 				</div>
 

--- a/packages/web/src/components/space/ChannelInfoPanel.tsx
+++ b/packages/web/src/components/space/ChannelInfoPanel.tsx
@@ -60,6 +60,9 @@ export function ChannelInfoPanel({
 		channel.gateLabel ?? (channel.gateType ? GATE_TYPE_LABELS[channel.gateType] : null);
 	const isBidirectional = channel.direction === 'bidirectional';
 	const showApprovalActions = status === 'waiting_human' && !!channel.gateId;
+	// View Artifacts is useful for any gate with a run (e.g. reviewing a
+	// rejected gate's evidence), not just ones still awaiting approval.
+	const showViewArtifacts = !!channel.gateId && !!onViewArtifacts;
 
 	return (
 		<div
@@ -117,31 +120,35 @@ export function ChannelInfoPanel({
 						{!gateLabel && !statusConfig && <span class="text-xs text-gray-500">No gate</span>}
 					</div>
 
-					{showApprovalActions && channel.gateId && (
+					{(showApprovalActions || showViewArtifacts) && channel.gateId && (
 						<>
 							<div class="flex items-center gap-2 pt-1" data-testid="channel-gate-actions">
-								<button
-									type="button"
-									onClick={() => void onGateDecision?.(channel.gateId!, true)}
-									disabled={decisionPending || !onGateDecision}
-									data-testid="channel-approve-btn"
-									class="px-3 py-1 text-xs font-medium rounded bg-green-900/40 text-green-300 border border-green-700/50 hover:bg-green-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-								>
-									Approve
-								</button>
-								<button
-									type="button"
-									onClick={() => void onGateDecision?.(channel.gateId!, false)}
-									disabled={decisionPending || !onGateDecision}
-									data-testid="channel-reject-btn"
-									class="px-3 py-1 text-xs font-medium rounded bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-								>
-									Reject
-								</button>
-								{onViewArtifacts && (
+								{showApprovalActions && (
+									<>
+										<button
+											type="button"
+											onClick={() => void onGateDecision?.(channel.gateId!, true)}
+											disabled={decisionPending || !onGateDecision}
+											data-testid="channel-approve-btn"
+											class="px-3 py-1 text-xs font-medium rounded bg-green-900/40 text-green-300 border border-green-700/50 hover:bg-green-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+										>
+											Approve
+										</button>
+										<button
+											type="button"
+											onClick={() => void onGateDecision?.(channel.gateId!, false)}
+											disabled={decisionPending || !onGateDecision}
+											data-testid="channel-reject-btn"
+											class="px-3 py-1 text-xs font-medium rounded bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+										>
+											Reject
+										</button>
+									</>
+								)}
+								{showViewArtifacts && (
 									<button
 										type="button"
-										onClick={() => onViewArtifacts(channel.gateId!)}
+										onClick={() => onViewArtifacts?.(channel.gateId!)}
 										data-testid="channel-view-artifacts-btn"
 										class="px-3 py-1 text-xs font-medium rounded bg-dark-700 text-gray-200 border border-dark-600 hover:bg-dark-600 transition-colors"
 									>

--- a/packages/web/src/components/space/ChannelInfoPanel.tsx
+++ b/packages/web/src/components/space/ChannelInfoPanel.tsx
@@ -142,9 +142,8 @@ export function ChannelInfoPanel({
 									<button
 										type="button"
 										onClick={() => onViewArtifacts(channel.gateId!)}
-										disabled={decisionPending}
 										data-testid="channel-view-artifacts-btn"
-										class="px-3 py-1 text-xs font-medium rounded bg-dark-700 text-gray-200 border border-dark-600 hover:bg-dark-600 disabled:opacity-50 transition-colors"
+										class="px-3 py-1 text-xs font-medium rounded bg-dark-700 text-gray-200 border border-dark-600 hover:bg-dark-600 transition-colors"
 									>
 										View Artifacts
 									</button>

--- a/packages/web/src/components/space/PendingGateBanner.tsx
+++ b/packages/web/src/components/space/PendingGateBanner.tsx
@@ -56,6 +56,9 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 	const [fetchError, setFetchError] = useState<string | null>(null);
 	const [fetchAttempt, setFetchAttempt] = useState(0);
 	const decisionCancelledRef = useRef(false);
+	// Tracks the live runId so in-flight decision responses from a previous
+	// run don't stamp busy/error state onto the new run after a runId swap.
+	const currentRunIdRef = useRef(runId);
 
 	useEffect(() => {
 		let cancelled = false;
@@ -64,6 +67,12 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 		setReviewGateId(null);
 		setDecisionErrors(new Map());
 		setFetchError(null);
+		// If a decision RPC is in-flight when runId swaps (e.g. user navigates to
+		// another task's run), the pending promise is abandoned by the cleanup
+		// flag below — but busyGateIds from the prior run would otherwise leak
+		// here and permanently disable a gate's buttons in the new run.
+		setBusyGateIds(new Set());
+		currentRunIdRef.current = runId;
 
 		(async () => {
 			try {
@@ -108,6 +117,11 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 		};
 	}, []);
 
+	// Tracks the element that opened the review overlay so we can restore focus
+	// to it when the overlay closes (WCAG 2.4.3). Captured at open time; cleared
+	// after restore to avoid cross-open leakage.
+	const overlayOpenerRef = useRef<HTMLElement | null>(null);
+
 	// Close the review overlay on Escape (basic modal a11y). We don't implement a
 	// full focus trap — GateArtifactsView's own close button is reachable via Tab.
 	useEffect(() => {
@@ -118,6 +132,22 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 		window.addEventListener('keydown', onKey);
 		return () => window.removeEventListener('keydown', onKey);
 	}, [reviewGateId]);
+
+	// On overlay close, return focus to the element that opened it.
+	useEffect(() => {
+		if (reviewGateId) return;
+		const opener = overlayOpenerRef.current;
+		if (opener && typeof opener.focus === 'function') {
+			opener.focus();
+		}
+		overlayOpenerRef.current = null;
+	}, [reviewGateId]);
+
+	const openReview = useCallback((gateId: string, event: Event) => {
+		const target = event.currentTarget;
+		if (target instanceof HTMLElement) overlayOpenerRef.current = target;
+		setReviewGateId(gateId);
+	}, []);
 
 	const pendingGates: PendingGate[] = [];
 	for (const gate of gates) {
@@ -141,11 +171,13 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 				next.delete(gateId);
 				return next;
 			});
+			const runIdAtCall = runId;
 			try {
 				const hub = await connectionManager.getHub();
 				await hub.request('spaceWorkflowRun.approveGate', { runId, gateId, approved });
 			} catch (err: unknown) {
 				if (decisionCancelledRef.current) return;
+				if (currentRunIdRef.current !== runIdAtCall) return; // stale runId
 				const msg = err instanceof Error ? err.message : 'Failed to submit decision';
 				setDecisionErrors((prev) => {
 					const next = new Map(prev);
@@ -153,7 +185,7 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 					return next;
 				});
 			} finally {
-				if (!decisionCancelledRef.current) {
+				if (!decisionCancelledRef.current && currentRunIdRef.current === runIdAtCall) {
 					setBusyGateIds((prev) => {
 						if (!prev.has(gateId)) return prev;
 						const next = new Set(prev);
@@ -257,7 +289,7 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 										</button>
 										<button
 											type="button"
-											onClick={() => setReviewGateId(gate.gateId)}
+											onClick={(e) => openReview(gate.gateId, e)}
 											data-testid="pending-gate-review-btn"
 											class="px-2 py-1 text-xs font-medium rounded bg-purple-900/30 text-purple-300 border border-purple-700/30 hover:bg-purple-900/50 transition-colors"
 										>

--- a/packages/web/src/components/space/PendingGateBanner.tsx
+++ b/packages/web/src/components/space/PendingGateBanner.tsx
@@ -119,8 +119,11 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 
 	// Tracks the element that opened the review overlay so we can restore focus
 	// to it when the overlay closes (WCAG 2.4.3). Captured at open time; cleared
-	// after restore to avoid cross-open leakage.
+	// after restore to avoid cross-open leakage. If the opener was removed from
+	// the DOM while the overlay was open (e.g. approving a gate removes it from
+	// `pendingGates`), we fall back to a wrapper element that is still mounted.
 	const overlayOpenerRef = useRef<HTMLElement | null>(null);
+	const bannerRef = useRef<HTMLDivElement | null>(null);
 
 	// Close the review overlay on Escape (basic modal a11y). We don't implement a
 	// full focus trap — GateArtifactsView's own close button is reachable via Tab.
@@ -133,12 +136,20 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 		return () => window.removeEventListener('keydown', onKey);
 	}, [reviewGateId]);
 
-	// On overlay close, return focus to the element that opened it.
+	// On overlay close, return focus to the element that opened it. If the
+	// opener was unmounted while the overlay was open (common when Approve/
+	// Reject from GateArtifactsView transitions the gate out of `pendingGates`),
+	// .focus() on the detached node is a no-op — fall back to the banner wrapper
+	// so keyboard focus lands somewhere meaningful rather than collapsing to
+	// <body>.
 	useEffect(() => {
 		if (reviewGateId) return;
 		const opener = overlayOpenerRef.current;
-		if (opener && typeof opener.focus === 'function') {
+		if (!opener) return; // no overlay was open — nothing to restore
+		if (opener.isConnected && typeof opener.focus === 'function') {
 			opener.focus();
+		} else if (bannerRef.current && typeof bannerRef.current.focus === 'function') {
+			bannerRef.current.focus();
 		}
 		overlayOpenerRef.current = null;
 	}, [reviewGateId]);
@@ -250,7 +261,9 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 			{fetchErrorBanner}
 			{pendingGates.length > 0 && (
 				<div
-					class="mx-4 mt-2 mb-2 rounded-lg border border-purple-500/30 bg-purple-500/10 px-3 py-2 space-y-2"
+					ref={bannerRef}
+					tabIndex={-1}
+					class="mx-4 mt-2 mb-2 rounded-lg border border-purple-500/30 bg-purple-500/10 px-3 py-2 space-y-2 focus:outline-none"
 					data-testid="pending-gate-banner"
 				>
 					{pendingGates.map((gate) => {

--- a/packages/web/src/components/space/PendingGateBanner.tsx
+++ b/packages/web/src/components/space/PendingGateBanner.tsx
@@ -79,13 +79,11 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 				const hub = await connectionManager.getHub();
 				if (cancelled) return;
 
-				const result = await hub.request<{ gateData: GateDataRecord[] }>(
-					'spaceWorkflowRun.listGateData',
-					{ runId }
-				);
-				if (cancelled) return;
-				setGateDataMap(new Map(result.gateData.map((r) => [r.gateId, r.data])));
-
+				// Subscribe BEFORE firing the initial fetch so updates that arrive
+				// while the request is in flight aren't dropped. When the fetch
+				// resolves we merge the snapshot into the map, giving event-
+				// delivered data precedence (strictly newer than a fetch that
+				// was serialized before the update was published).
 				unsubscribe = hub.onEvent<{
 					runId: string;
 					gateId: string;
@@ -97,6 +95,24 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 						next.set(event.gateId, event.data);
 						return next;
 					});
+				});
+
+				const result = await hub.request<{ gateData: GateDataRecord[] }>(
+					'spaceWorkflowRun.listGateData',
+					{ runId }
+				);
+				if (cancelled) return;
+				setGateDataMap((prev) => {
+					// Seed from the fetch snapshot, then overlay any event-delivered
+					// entries already in `prev` — those races the fetch and are newer.
+					const merged = new Map<string, Record<string, unknown>>();
+					for (const record of result.gateData) {
+						merged.set(record.gateId, record.data);
+					}
+					for (const [gateId, data] of prev) {
+						merged.set(gateId, data);
+					}
+					return merged;
 				});
 			} catch (err: unknown) {
 				if (cancelled) return;
@@ -263,7 +279,7 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 				<div
 					ref={bannerRef}
 					tabIndex={-1}
-					class="mx-4 mt-2 mb-2 rounded-lg border border-purple-500/30 bg-purple-500/10 px-3 py-2 space-y-2 focus:outline-none"
+					class="mx-4 mt-2 mb-2 rounded-lg border border-purple-500/30 bg-purple-500/10 px-3 py-2 space-y-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400/70"
 					data-testid="pending-gate-banner"
 				>
 					{pendingGates.map((gate) => {

--- a/packages/web/src/components/space/PendingGateBanner.tsx
+++ b/packages/web/src/components/space/PendingGateBanner.tsx
@@ -1,23 +1,29 @@
 /**
  * PendingGateBanner — thread-view CTA for workflow gates awaiting human approval.
  *
- * Shows whenever the task's workflow run has at least one gate in a pending
- * state (data.waiting === true OR data.approved === false), regardless of
- * task.status. Provides Approve / Reject / Review buttons wired to
- * spaceWorkflowRun.approveGate, and opens GateArtifactsView for full review.
+ * Shows whenever the task's workflow run has at least one external-approval
+ * gate that evaluates to `waiting_human` (see `gate-status.ts` for the exact
+ * rule — mirrors the canvas evaluator). Task status is independent — a gate
+ * can be waiting while the task itself is still `in_progress`. Provides
+ * Approve / Reject / Review buttons wired to `spaceWorkflowRun.approveGate`,
+ * and opens `GateArtifactsView` for full review.
  *
- * Distinct from TaskBlockedBanner (which only shows when the task itself is
- * in `blocked` status) — this banner surfaces gate approval even while the
- * task is still `in_progress`.
+ * Distinct from `TaskBlockedBanner` (which only shows when the task itself is
+ * in `blocked` status). Multi-gate workflows render a short stack — one row
+ * per pending gate.
  */
 
-import { useState, useEffect } from 'preact/hooks';
+import { useState, useEffect, useRef } from 'preact/hooks';
+import type { Gate } from '@neokai/shared';
 import { connectionManager } from '../../lib/connection-manager';
+import { spaceStore } from '../../lib/space-store';
 import { GateArtifactsView } from './GateArtifactsView';
+import { evaluateGateStatus, parseScriptResult } from './gate-status';
 
 interface PendingGate {
 	gateId: string;
 	data: Record<string, unknown>;
+	label?: string;
 }
 
 interface GateDataRecord {
@@ -30,55 +36,57 @@ interface GateDataRecord {
 interface PendingGateBannerProps {
 	runId: string;
 	spaceId: string;
+	/** Workflow ID for the run; used to resolve gate definitions. */
+	workflowId: string | null;
 }
 
-function isPending(data: Record<string, unknown>): boolean {
-	return data['waiting'] === true || data['approved'] === false;
-}
+export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBannerProps) {
+	const workflow = workflowId
+		? (spaceStore.workflows.value.find((w) => w.id === workflowId) ?? null)
+		: null;
+	const gates: Gate[] = workflow?.gates ?? [];
 
-export function PendingGateBanner({ runId, spaceId }: PendingGateBannerProps) {
-	const [pending, setPending] = useState<PendingGate | null>(null);
-	const [showReview, setShowReview] = useState(false);
-	const [busy, setBusy] = useState(false);
+	const [gateDataMap, setGateDataMap] = useState<Map<string, Record<string, unknown>>>(new Map());
+	const [reviewGateId, setReviewGateId] = useState<string | null>(null);
+	const [busyGateId, setBusyGateId] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
+	const decisionCancelledRef = useRef(false);
 
 	useEffect(() => {
 		let cancelled = false;
-		setPending(null);
-		setShowReview(false);
+		let unsubscribe: (() => void) | undefined;
+		setGateDataMap(new Map());
+		setReviewGateId(null);
 		setError(null);
 
-		const hub = connectionManager.getHubIfConnected();
-		if (!hub) return;
-
-		hub
-			.request<{ gateData: GateDataRecord[] }>('spaceWorkflowRun.listGateData', { runId })
-			.then((result) => {
+		(async () => {
+			try {
+				const hub = await connectionManager.getHub();
 				if (cancelled) return;
-				const pendingRecord = result.gateData.find((r) => isPending(r.data));
-				if (pendingRecord) {
-					setPending({ gateId: pendingRecord.gateId, data: pendingRecord.data });
-				}
-			})
-			.catch(() => {
-				// Best-effort — leave banner hidden on error
-			});
 
-		const unsubscribe =
-			typeof hub.onEvent === 'function'
-				? hub.onEvent<{
-						runId: string;
-						gateId: string;
-						data: Record<string, unknown>;
-					}>('space.gateData.updated', (event) => {
-						if (cancelled || event.runId !== runId) return;
-						if (isPending(event.data)) {
-							setPending({ gateId: event.gateId, data: event.data });
-						} else {
-							setPending((prev) => (prev?.gateId === event.gateId ? null : prev));
-						}
-					})
-				: undefined;
+				const result = await hub.request<{ gateData: GateDataRecord[] }>(
+					'spaceWorkflowRun.listGateData',
+					{ runId }
+				);
+				if (cancelled) return;
+				setGateDataMap(new Map(result.gateData.map((r) => [r.gateId, r.data])));
+
+				unsubscribe = hub.onEvent<{
+					runId: string;
+					gateId: string;
+					data: Record<string, unknown>;
+				}>('space.gateData.updated', (event) => {
+					if (event.runId !== runId) return;
+					setGateDataMap((prev) => {
+						const next = new Map(prev);
+						next.set(event.gateId, event.data);
+						return next;
+					});
+				});
+			} catch {
+				// Best-effort — leave banner hidden on error
+			}
+		})();
 
 		return () => {
 			cancelled = true;
@@ -86,93 +94,108 @@ export function PendingGateBanner({ runId, spaceId }: PendingGateBannerProps) {
 		};
 	}, [runId]);
 
-	const handleDecision = async (approved: boolean) => {
-		if (!pending) return;
-		setBusy(true);
-		setError(null);
-		try {
-			const hub = await connectionManager.getHub();
-			await hub.request('spaceWorkflowRun.approveGate', {
-				runId,
-				gateId: pending.gateId,
-				approved,
-			});
-			// Local clear — event will also clear, but be responsive.
-			setPending(null);
-		} catch (err: unknown) {
-			setError(err instanceof Error ? err.message : 'Failed to submit decision');
-		} finally {
-			setBusy(false);
+	useEffect(() => {
+		decisionCancelledRef.current = false;
+		return () => {
+			decisionCancelledRef.current = true;
+		};
+	}, []);
+
+	const pendingGates: PendingGate[] = [];
+	for (const gate of gates) {
+		const data = gateDataMap.get(gate.id) ?? {};
+		const scriptResult = parseScriptResult(data);
+		if (evaluateGateStatus(gate, data, scriptResult.failed) === 'waiting_human') {
+			pendingGates.push({ gateId: gate.id, data, label: gate.label ?? gate.description });
 		}
-	};
+	}
 
-	if (!pending) return null;
-
-	if (showReview) {
+	if (reviewGateId) {
+		const gateData = gateDataMap.get(reviewGateId) ?? {};
 		return (
 			<GateArtifactsView
 				runId={runId}
-				gateId={pending.gateId}
+				gateId={reviewGateId}
 				spaceId={spaceId}
-				gateData={pending.data}
-				onClose={() => setShowReview(false)}
-				onDecision={() => setShowReview(false)}
+				gateData={gateData}
+				onClose={() => setReviewGateId(null)}
+				onDecision={() => setReviewGateId(null)}
 			/>
 		);
 	}
 
-	const gateLabel = typeof pending.data['label'] === 'string' ? pending.data['label'] : null;
+	if (pendingGates.length === 0) return null;
+
+	const handleDecision = async (gateId: string, approved: boolean) => {
+		setBusyGateId(gateId);
+		setError(null);
+		try {
+			const hub = await connectionManager.getHub();
+			await hub.request('spaceWorkflowRun.approveGate', { runId, gateId, approved });
+		} catch (err: unknown) {
+			if (decisionCancelledRef.current) return;
+			setError(err instanceof Error ? err.message : 'Failed to submit decision');
+		} finally {
+			if (!decisionCancelledRef.current) setBusyGateId(null);
+		}
+	};
 
 	return (
 		<div
-			class="mx-4 mt-2 mb-2 rounded-lg border border-purple-500/30 bg-purple-500/10 px-3 py-2"
+			class="mx-4 mt-2 mb-2 rounded-lg border border-purple-500/30 bg-purple-500/10 px-3 py-2 space-y-2"
 			data-testid="pending-gate-banner"
 		>
-			<div class="flex items-start justify-between gap-2">
-				<div class="flex-1 min-w-0">
-					<p class="text-xs font-medium text-purple-300">
-						🔒 Gate Awaiting Approval{gateLabel ? ` — ${gateLabel}` : ''}
-					</p>
-					<p class="mt-0.5 text-xs text-purple-400/70">
-						The workflow is paused until a human approves the proposed changes.
-					</p>
-					{error && (
-						<p class="mt-1 text-xs text-red-400" data-testid="pending-gate-error">
-							{error}
-						</p>
-					)}
-				</div>
+			{pendingGates.map((gate) => {
+				const busy = busyGateId === gate.gateId;
+				return (
+					<div key={gate.gateId} class="flex items-start justify-between gap-2">
+						<div class="flex-1 min-w-0">
+							<p class="text-xs font-medium text-purple-300">
+								🔒 Gate Awaiting Approval{gate.label ? ` — ${gate.label}` : ''}
+							</p>
+							<p class="mt-0.5 text-xs text-purple-400/70">
+								The workflow is paused until a human approves the proposed changes.
+							</p>
+						</div>
 
-				<div class="flex items-center gap-1.5 flex-shrink-0">
-					<button
-						type="button"
-						onClick={() => void handleDecision(true)}
-						disabled={busy}
-						data-testid="pending-gate-approve-btn"
-						class="px-2 py-1 text-xs font-medium rounded bg-green-900/40 text-green-300 border border-green-700/50 hover:bg-green-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-					>
-						Approve
-					</button>
-					<button
-						type="button"
-						onClick={() => void handleDecision(false)}
-						disabled={busy}
-						data-testid="pending-gate-reject-btn"
-						class="px-2 py-1 text-xs font-medium rounded bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-					>
-						Reject
-					</button>
-					<button
-						type="button"
-						onClick={() => setShowReview(true)}
-						disabled={busy}
-						data-testid="pending-gate-review-btn"
-						class="px-2 py-1 text-xs font-medium rounded bg-purple-900/30 text-purple-300 border border-purple-700/30 hover:bg-purple-900/50 disabled:opacity-50 transition-colors"
-					>
-						Review
-					</button>
-				</div>
-			</div>
+						<div class="flex items-center gap-1.5 flex-shrink-0">
+							<button
+								type="button"
+								onClick={() => void handleDecision(gate.gateId, true)}
+								disabled={busy}
+								data-testid="pending-gate-approve-btn"
+								class="px-2 py-1 text-xs font-medium rounded bg-green-900/40 text-green-300 border border-green-700/50 hover:bg-green-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+							>
+								Approve
+							</button>
+							<button
+								type="button"
+								onClick={() => void handleDecision(gate.gateId, false)}
+								disabled={busy}
+								data-testid="pending-gate-reject-btn"
+								class="px-2 py-1 text-xs font-medium rounded bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+							>
+								Reject
+							</button>
+							<button
+								type="button"
+								onClick={() => setReviewGateId(gate.gateId)}
+								disabled={busy}
+								data-testid="pending-gate-review-btn"
+								class="px-2 py-1 text-xs font-medium rounded bg-purple-900/30 text-purple-300 border border-purple-700/30 hover:bg-purple-900/50 disabled:opacity-50 transition-colors"
+							>
+								Review
+							</button>
+						</div>
+					</div>
+				);
+			})}
+
+			{error && (
+				<p class="text-xs text-red-400" data-testid="pending-gate-error">
+					{error}
+				</p>
+			)}
 		</div>
 	);
 }

--- a/packages/web/src/components/space/PendingGateBanner.tsx
+++ b/packages/web/src/components/space/PendingGateBanner.tsx
@@ -48,8 +48,11 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 
 	const [gateDataMap, setGateDataMap] = useState<Map<string, Record<string, unknown>>>(new Map());
 	const [reviewGateId, setReviewGateId] = useState<string | null>(null);
-	const [busyGateId, setBusyGateId] = useState<string | null>(null);
-	const [decisionError, setDecisionError] = useState<string | null>(null);
+	// Multiple gates can be pending at once, so busy/error state is keyed by
+	// gateId — otherwise a second click would clobber the first gate's spinner
+	// or error, and an error from gate A could render under gate B's row.
+	const [busyGateIds, setBusyGateIds] = useState<Set<string>>(() => new Set());
+	const [decisionErrors, setDecisionErrors] = useState<Map<string, string>>(() => new Map());
 	const [fetchError, setFetchError] = useState<string | null>(null);
 	const [fetchAttempt, setFetchAttempt] = useState(0);
 	const decisionCancelledRef = useRef(false);
@@ -59,7 +62,7 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 		let unsubscribe: (() => void) | undefined;
 		setGateDataMap(new Map());
 		setReviewGateId(null);
-		setDecisionError(null);
+		setDecisionErrors(new Map());
 		setFetchError(null);
 
 		(async () => {
@@ -105,6 +108,17 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 		};
 	}, []);
 
+	// Close the review overlay on Escape (basic modal a11y). We don't implement a
+	// full focus trap — GateArtifactsView's own close button is reachable via Tab.
+	useEffect(() => {
+		if (!reviewGateId) return;
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') setReviewGateId(null);
+		};
+		window.addEventListener('keydown', onKey);
+		return () => window.removeEventListener('keydown', onKey);
+	}, [reviewGateId]);
+
 	const pendingGates: PendingGate[] = [];
 	for (const gate of gates) {
 		const data = gateDataMap.get(gate.id) ?? {};
@@ -116,16 +130,37 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 
 	const handleDecision = useCallback(
 		async (gateId: string, approved: boolean) => {
-			setBusyGateId(gateId);
-			setDecisionError(null);
+			setBusyGateIds((prev) => {
+				const next = new Set(prev);
+				next.add(gateId);
+				return next;
+			});
+			setDecisionErrors((prev) => {
+				if (!prev.has(gateId)) return prev;
+				const next = new Map(prev);
+				next.delete(gateId);
+				return next;
+			});
 			try {
 				const hub = await connectionManager.getHub();
 				await hub.request('spaceWorkflowRun.approveGate', { runId, gateId, approved });
 			} catch (err: unknown) {
 				if (decisionCancelledRef.current) return;
-				setDecisionError(err instanceof Error ? err.message : 'Failed to submit decision');
+				const msg = err instanceof Error ? err.message : 'Failed to submit decision';
+				setDecisionErrors((prev) => {
+					const next = new Map(prev);
+					next.set(gateId, msg);
+					return next;
+				});
 			} finally {
-				if (!decisionCancelledRef.current) setBusyGateId(null);
+				if (!decisionCancelledRef.current) {
+					setBusyGateIds((prev) => {
+						if (!prev.has(gateId)) return prev;
+						const next = new Set(prev);
+						next.delete(gateId);
+						return next;
+					});
+				}
 			}
 		},
 		[runId]
@@ -138,6 +173,9 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 		<div
 			class="fixed inset-0 z-40 bg-black/50 flex items-center justify-center p-4"
 			data-testid="pending-gate-review-overlay"
+			role="dialog"
+			aria-modal="true"
+			aria-label="Review gate artifacts"
 			onClick={(e) => {
 				if (e.target === e.currentTarget) setReviewGateId(null);
 			}}
@@ -184,55 +222,57 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 					data-testid="pending-gate-banner"
 				>
 					{pendingGates.map((gate) => {
-						const busy = busyGateId === gate.gateId;
+						const busy = busyGateIds.has(gate.gateId);
+						const error = decisionErrors.get(gate.gateId);
 						return (
-							<div key={gate.gateId} class="flex items-start justify-between gap-2">
-								<div class="flex-1 min-w-0">
-									<p class="text-xs font-medium text-purple-300">
-										🔒 Gate Awaiting Approval{gate.label ? ` — ${gate.label}` : ''}
-									</p>
-									<p class="mt-0.5 text-xs text-purple-400/70">
-										The workflow is paused until a human approves the proposed changes.
-									</p>
-								</div>
+							<div key={gate.gateId} class="space-y-1">
+								<div class="flex items-start justify-between gap-2">
+									<div class="flex-1 min-w-0">
+										<p class="text-xs font-medium text-purple-300">
+											🔒 Gate Awaiting Approval{gate.label ? ` — ${gate.label}` : ''}
+										</p>
+										<p class="mt-0.5 text-xs text-purple-400/70">
+											The workflow is paused until a human approves the proposed changes.
+										</p>
+									</div>
 
-								<div class="flex items-center gap-1.5 flex-shrink-0">
-									<button
-										type="button"
-										onClick={() => void handleDecision(gate.gateId, true)}
-										disabled={busy}
-										data-testid="pending-gate-approve-btn"
-										class="px-2 py-1 text-xs font-medium rounded bg-green-900/40 text-green-300 border border-green-700/50 hover:bg-green-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-									>
-										Approve
-									</button>
-									<button
-										type="button"
-										onClick={() => void handleDecision(gate.gateId, false)}
-										disabled={busy}
-										data-testid="pending-gate-reject-btn"
-										class="px-2 py-1 text-xs font-medium rounded bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-									>
-										Reject
-									</button>
-									<button
-										type="button"
-										onClick={() => setReviewGateId(gate.gateId)}
-										data-testid="pending-gate-review-btn"
-										class="px-2 py-1 text-xs font-medium rounded bg-purple-900/30 text-purple-300 border border-purple-700/30 hover:bg-purple-900/50 transition-colors"
-									>
-										Review
-									</button>
+									<div class="flex items-center gap-1.5 flex-shrink-0">
+										<button
+											type="button"
+											onClick={() => void handleDecision(gate.gateId, true)}
+											disabled={busy}
+											data-testid="pending-gate-approve-btn"
+											class="px-2 py-1 text-xs font-medium rounded bg-green-900/40 text-green-300 border border-green-700/50 hover:bg-green-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+										>
+											Approve
+										</button>
+										<button
+											type="button"
+											onClick={() => void handleDecision(gate.gateId, false)}
+											disabled={busy}
+											data-testid="pending-gate-reject-btn"
+											class="px-2 py-1 text-xs font-medium rounded bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+										>
+											Reject
+										</button>
+										<button
+											type="button"
+											onClick={() => setReviewGateId(gate.gateId)}
+											data-testid="pending-gate-review-btn"
+											class="px-2 py-1 text-xs font-medium rounded bg-purple-900/30 text-purple-300 border border-purple-700/30 hover:bg-purple-900/50 transition-colors"
+										>
+											Review
+										</button>
+									</div>
 								</div>
+								{error && (
+									<p class="text-xs text-red-400" data-testid="pending-gate-error">
+										{error}
+									</p>
+								)}
 							</div>
 						);
 					})}
-
-					{decisionError && (
-						<p class="text-xs text-red-400" data-testid="pending-gate-error">
-							{decisionError}
-						</p>
-					)}
 				</div>
 			)}
 			{reviewOverlay}

--- a/packages/web/src/components/space/PendingGateBanner.tsx
+++ b/packages/web/src/components/space/PendingGateBanner.tsx
@@ -6,14 +6,14 @@
  * rule — mirrors the canvas evaluator). Task status is independent — a gate
  * can be waiting while the task itself is still `in_progress`. Provides
  * Approve / Reject / Review buttons wired to `spaceWorkflowRun.approveGate`,
- * and opens `GateArtifactsView` for full review.
+ * and opens `GateArtifactsView` as a full-pane overlay for deeper review.
  *
  * Distinct from `TaskBlockedBanner` (which only shows when the task itself is
  * in `blocked` status). Multi-gate workflows render a short stack — one row
  * per pending gate.
  */
 
-import { useState, useEffect, useRef } from 'preact/hooks';
+import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
 import type { Gate } from '@neokai/shared';
 import { connectionManager } from '../../lib/connection-manager';
 import { spaceStore } from '../../lib/space-store';
@@ -49,7 +49,9 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 	const [gateDataMap, setGateDataMap] = useState<Map<string, Record<string, unknown>>>(new Map());
 	const [reviewGateId, setReviewGateId] = useState<string | null>(null);
 	const [busyGateId, setBusyGateId] = useState<string | null>(null);
-	const [error, setError] = useState<string | null>(null);
+	const [decisionError, setDecisionError] = useState<string | null>(null);
+	const [fetchError, setFetchError] = useState<string | null>(null);
+	const [fetchAttempt, setFetchAttempt] = useState(0);
 	const decisionCancelledRef = useRef(false);
 
 	useEffect(() => {
@@ -57,7 +59,8 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 		let unsubscribe: (() => void) | undefined;
 		setGateDataMap(new Map());
 		setReviewGateId(null);
-		setError(null);
+		setDecisionError(null);
+		setFetchError(null);
 
 		(async () => {
 			try {
@@ -83,8 +86,9 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 						return next;
 					});
 				});
-			} catch {
-				// Best-effort — leave banner hidden on error
+			} catch (err: unknown) {
+				if (cancelled) return;
+				setFetchError(err instanceof Error ? err.message : 'Failed to load gate status');
 			}
 		})();
 
@@ -92,7 +96,7 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 			cancelled = true;
 			unsubscribe?.();
 		};
-	}, [runId]);
+	}, [runId, fetchAttempt]);
 
 	useEffect(() => {
 		decisionCancelledRef.current = false;
@@ -110,92 +114,128 @@ export function PendingGateBanner({ runId, spaceId, workflowId }: PendingGateBan
 		}
 	}
 
-	if (reviewGateId) {
-		const gateData = gateDataMap.get(reviewGateId) ?? {};
-		return (
-			<GateArtifactsView
-				runId={runId}
-				gateId={reviewGateId}
-				spaceId={spaceId}
-				gateData={gateData}
-				onClose={() => setReviewGateId(null)}
-				onDecision={() => setReviewGateId(null)}
-			/>
-		);
-	}
+	const handleDecision = useCallback(
+		async (gateId: string, approved: boolean) => {
+			setBusyGateId(gateId);
+			setDecisionError(null);
+			try {
+				const hub = await connectionManager.getHub();
+				await hub.request('spaceWorkflowRun.approveGate', { runId, gateId, approved });
+			} catch (err: unknown) {
+				if (decisionCancelledRef.current) return;
+				setDecisionError(err instanceof Error ? err.message : 'Failed to submit decision');
+			} finally {
+				if (!decisionCancelledRef.current) setBusyGateId(null);
+			}
+		},
+		[runId]
+	);
 
-	if (pendingGates.length === 0) return null;
+	// Render the artifacts review as a full-pane modal overlay so `h-full`
+	// inside GateArtifactsView resolves against a definite height. Rendering
+	// it inline in the banner slot collapses it (banner is auto-height).
+	const reviewOverlay = reviewGateId ? (
+		<div
+			class="fixed inset-0 z-40 bg-black/50 flex items-center justify-center p-4"
+			data-testid="pending-gate-review-overlay"
+			onClick={(e) => {
+				if (e.target === e.currentTarget) setReviewGateId(null);
+			}}
+		>
+			<div class="w-full max-w-2xl max-h-[80vh] bg-dark-900 border border-dark-600 rounded-xl shadow-2xl overflow-hidden flex flex-col">
+				<GateArtifactsView
+					runId={runId}
+					gateId={reviewGateId}
+					spaceId={spaceId}
+					gateData={gateDataMap.get(reviewGateId) ?? {}}
+					onClose={() => setReviewGateId(null)}
+					onDecision={() => setReviewGateId(null)}
+					class="flex-1 min-h-0"
+				/>
+			</div>
+		</div>
+	) : null;
 
-	const handleDecision = async (gateId: string, approved: boolean) => {
-		setBusyGateId(gateId);
-		setError(null);
-		try {
-			const hub = await connectionManager.getHub();
-			await hub.request('spaceWorkflowRun.approveGate', { runId, gateId, approved });
-		} catch (err: unknown) {
-			if (decisionCancelledRef.current) return;
-			setError(err instanceof Error ? err.message : 'Failed to submit decision');
-		} finally {
-			if (!decisionCancelledRef.current) setBusyGateId(null);
-		}
-	};
+	if (pendingGates.length === 0 && !fetchError) return reviewOverlay;
+
+	const fetchErrorBanner = fetchError ? (
+		<div
+			class="mx-4 mt-2 mb-2 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 flex items-center justify-between gap-2"
+			data-testid="pending-gate-fetch-error"
+		>
+			<p class="text-xs text-red-300 flex-1 min-w-0">Failed to load gate status — {fetchError}</p>
+			<button
+				type="button"
+				onClick={() => setFetchAttempt((n) => n + 1)}
+				data-testid="pending-gate-fetch-retry"
+				class="px-2 py-1 text-xs font-medium rounded bg-red-900/40 text-red-200 border border-red-700/50 hover:bg-red-800/50 transition-colors flex-shrink-0"
+			>
+				Retry
+			</button>
+		</div>
+	) : null;
 
 	return (
-		<div
-			class="mx-4 mt-2 mb-2 rounded-lg border border-purple-500/30 bg-purple-500/10 px-3 py-2 space-y-2"
-			data-testid="pending-gate-banner"
-		>
-			{pendingGates.map((gate) => {
-				const busy = busyGateId === gate.gateId;
-				return (
-					<div key={gate.gateId} class="flex items-start justify-between gap-2">
-						<div class="flex-1 min-w-0">
-							<p class="text-xs font-medium text-purple-300">
-								🔒 Gate Awaiting Approval{gate.label ? ` — ${gate.label}` : ''}
-							</p>
-							<p class="mt-0.5 text-xs text-purple-400/70">
-								The workflow is paused until a human approves the proposed changes.
-							</p>
-						</div>
+		<>
+			{fetchErrorBanner}
+			{pendingGates.length > 0 && (
+				<div
+					class="mx-4 mt-2 mb-2 rounded-lg border border-purple-500/30 bg-purple-500/10 px-3 py-2 space-y-2"
+					data-testid="pending-gate-banner"
+				>
+					{pendingGates.map((gate) => {
+						const busy = busyGateId === gate.gateId;
+						return (
+							<div key={gate.gateId} class="flex items-start justify-between gap-2">
+								<div class="flex-1 min-w-0">
+									<p class="text-xs font-medium text-purple-300">
+										🔒 Gate Awaiting Approval{gate.label ? ` — ${gate.label}` : ''}
+									</p>
+									<p class="mt-0.5 text-xs text-purple-400/70">
+										The workflow is paused until a human approves the proposed changes.
+									</p>
+								</div>
 
-						<div class="flex items-center gap-1.5 flex-shrink-0">
-							<button
-								type="button"
-								onClick={() => void handleDecision(gate.gateId, true)}
-								disabled={busy}
-								data-testid="pending-gate-approve-btn"
-								class="px-2 py-1 text-xs font-medium rounded bg-green-900/40 text-green-300 border border-green-700/50 hover:bg-green-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-							>
-								Approve
-							</button>
-							<button
-								type="button"
-								onClick={() => void handleDecision(gate.gateId, false)}
-								disabled={busy}
-								data-testid="pending-gate-reject-btn"
-								class="px-2 py-1 text-xs font-medium rounded bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-							>
-								Reject
-							</button>
-							<button
-								type="button"
-								onClick={() => setReviewGateId(gate.gateId)}
-								disabled={busy}
-								data-testid="pending-gate-review-btn"
-								class="px-2 py-1 text-xs font-medium rounded bg-purple-900/30 text-purple-300 border border-purple-700/30 hover:bg-purple-900/50 disabled:opacity-50 transition-colors"
-							>
-								Review
-							</button>
-						</div>
-					</div>
-				);
-			})}
+								<div class="flex items-center gap-1.5 flex-shrink-0">
+									<button
+										type="button"
+										onClick={() => void handleDecision(gate.gateId, true)}
+										disabled={busy}
+										data-testid="pending-gate-approve-btn"
+										class="px-2 py-1 text-xs font-medium rounded bg-green-900/40 text-green-300 border border-green-700/50 hover:bg-green-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+									>
+										Approve
+									</button>
+									<button
+										type="button"
+										onClick={() => void handleDecision(gate.gateId, false)}
+										disabled={busy}
+										data-testid="pending-gate-reject-btn"
+										class="px-2 py-1 text-xs font-medium rounded bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+									>
+										Reject
+									</button>
+									<button
+										type="button"
+										onClick={() => setReviewGateId(gate.gateId)}
+										data-testid="pending-gate-review-btn"
+										class="px-2 py-1 text-xs font-medium rounded bg-purple-900/30 text-purple-300 border border-purple-700/30 hover:bg-purple-900/50 transition-colors"
+									>
+										Review
+									</button>
+								</div>
+							</div>
+						);
+					})}
 
-			{error && (
-				<p class="text-xs text-red-400" data-testid="pending-gate-error">
-					{error}
-				</p>
+					{decisionError && (
+						<p class="text-xs text-red-400" data-testid="pending-gate-error">
+							{decisionError}
+						</p>
+					)}
+				</div>
 			)}
-		</div>
+			{reviewOverlay}
+		</>
 	);
 }

--- a/packages/web/src/components/space/PendingGateBanner.tsx
+++ b/packages/web/src/components/space/PendingGateBanner.tsx
@@ -1,0 +1,178 @@
+/**
+ * PendingGateBanner — thread-view CTA for workflow gates awaiting human approval.
+ *
+ * Shows whenever the task's workflow run has at least one gate in a pending
+ * state (data.waiting === true OR data.approved === false), regardless of
+ * task.status. Provides Approve / Reject / Review buttons wired to
+ * spaceWorkflowRun.approveGate, and opens GateArtifactsView for full review.
+ *
+ * Distinct from TaskBlockedBanner (which only shows when the task itself is
+ * in `blocked` status) — this banner surfaces gate approval even while the
+ * task is still `in_progress`.
+ */
+
+import { useState, useEffect } from 'preact/hooks';
+import { connectionManager } from '../../lib/connection-manager';
+import { GateArtifactsView } from './GateArtifactsView';
+
+interface PendingGate {
+	gateId: string;
+	data: Record<string, unknown>;
+}
+
+interface GateDataRecord {
+	runId: string;
+	gateId: string;
+	data: Record<string, unknown>;
+	updatedAt: number;
+}
+
+interface PendingGateBannerProps {
+	runId: string;
+	spaceId: string;
+}
+
+function isPending(data: Record<string, unknown>): boolean {
+	return data['waiting'] === true || data['approved'] === false;
+}
+
+export function PendingGateBanner({ runId, spaceId }: PendingGateBannerProps) {
+	const [pending, setPending] = useState<PendingGate | null>(null);
+	const [showReview, setShowReview] = useState(false);
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		setPending(null);
+		setShowReview(false);
+		setError(null);
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) return;
+
+		hub
+			.request<{ gateData: GateDataRecord[] }>('spaceWorkflowRun.listGateData', { runId })
+			.then((result) => {
+				if (cancelled) return;
+				const pendingRecord = result.gateData.find((r) => isPending(r.data));
+				if (pendingRecord) {
+					setPending({ gateId: pendingRecord.gateId, data: pendingRecord.data });
+				}
+			})
+			.catch(() => {
+				// Best-effort — leave banner hidden on error
+			});
+
+		const unsubscribe =
+			typeof hub.onEvent === 'function'
+				? hub.onEvent<{
+						runId: string;
+						gateId: string;
+						data: Record<string, unknown>;
+					}>('space.gateData.updated', (event) => {
+						if (cancelled || event.runId !== runId) return;
+						if (isPending(event.data)) {
+							setPending({ gateId: event.gateId, data: event.data });
+						} else {
+							setPending((prev) => (prev?.gateId === event.gateId ? null : prev));
+						}
+					})
+				: undefined;
+
+		return () => {
+			cancelled = true;
+			unsubscribe?.();
+		};
+	}, [runId]);
+
+	const handleDecision = async (approved: boolean) => {
+		if (!pending) return;
+		setBusy(true);
+		setError(null);
+		try {
+			const hub = await connectionManager.getHub();
+			await hub.request('spaceWorkflowRun.approveGate', {
+				runId,
+				gateId: pending.gateId,
+				approved,
+			});
+			// Local clear — event will also clear, but be responsive.
+			setPending(null);
+		} catch (err: unknown) {
+			setError(err instanceof Error ? err.message : 'Failed to submit decision');
+		} finally {
+			setBusy(false);
+		}
+	};
+
+	if (!pending) return null;
+
+	if (showReview) {
+		return (
+			<GateArtifactsView
+				runId={runId}
+				gateId={pending.gateId}
+				spaceId={spaceId}
+				gateData={pending.data}
+				onClose={() => setShowReview(false)}
+				onDecision={() => setShowReview(false)}
+			/>
+		);
+	}
+
+	const gateLabel = typeof pending.data['label'] === 'string' ? pending.data['label'] : null;
+
+	return (
+		<div
+			class="mx-4 mt-2 mb-2 rounded-lg border border-purple-500/30 bg-purple-500/10 px-3 py-2"
+			data-testid="pending-gate-banner"
+		>
+			<div class="flex items-start justify-between gap-2">
+				<div class="flex-1 min-w-0">
+					<p class="text-xs font-medium text-purple-300">
+						🔒 Gate Awaiting Approval{gateLabel ? ` — ${gateLabel}` : ''}
+					</p>
+					<p class="mt-0.5 text-xs text-purple-400/70">
+						The workflow is paused until a human approves the proposed changes.
+					</p>
+					{error && (
+						<p class="mt-1 text-xs text-red-400" data-testid="pending-gate-error">
+							{error}
+						</p>
+					)}
+				</div>
+
+				<div class="flex items-center gap-1.5 flex-shrink-0">
+					<button
+						type="button"
+						onClick={() => void handleDecision(true)}
+						disabled={busy}
+						data-testid="pending-gate-approve-btn"
+						class="px-2 py-1 text-xs font-medium rounded bg-green-900/40 text-green-300 border border-green-700/50 hover:bg-green-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+					>
+						Approve
+					</button>
+					<button
+						type="button"
+						onClick={() => void handleDecision(false)}
+						disabled={busy}
+						data-testid="pending-gate-reject-btn"
+						class="px-2 py-1 text-xs font-medium rounded bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+					>
+						Reject
+					</button>
+					<button
+						type="button"
+						onClick={() => setShowReview(true)}
+						disabled={busy}
+						data-testid="pending-gate-review-btn"
+						class="px-2 py-1 text-xs font-medium rounded bg-purple-900/30 text-purple-300 border border-purple-700/30 hover:bg-purple-900/50 disabled:opacity-50 transition-colors"
+					>
+						Review
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/space/ReadOnlyWorkflowCanvas.tsx
+++ b/packages/web/src/components/space/ReadOnlyWorkflowCanvas.tsx
@@ -59,6 +59,8 @@ export function ReadOnlyWorkflowCanvas({
 		setViewportState,
 		gateDataLoading,
 		gateDataMap,
+		gateDataError,
+		retryGateData,
 	} = useRuntimeCanvasData(workflowId, runId ?? null);
 
 	// Track container dimensions for the toolbar's fit-to-view
@@ -204,6 +206,23 @@ export function ReadOnlyWorkflowCanvas({
 			{gateDataLoading && (
 				<div class="absolute top-2 right-2 z-10 text-xs text-gray-500 px-2 py-0.5 bg-dark-800 rounded">
 					Loading…
+				</div>
+			)}
+			{gateDataError && !gateDataLoading && (
+				<div
+					class="absolute top-2 right-2 z-10 flex items-center gap-2 text-xs px-2 py-0.5 bg-red-900/50 border border-red-700/50 text-red-200 rounded"
+					data-testid="canvas-gate-data-error"
+					title={gateDataError}
+				>
+					<span>Gate status unavailable</span>
+					<button
+						type="button"
+						onClick={retryGateData}
+						data-testid="canvas-gate-data-retry"
+						class="underline hover:text-red-100"
+					>
+						Retry
+					</button>
 				</div>
 			)}
 			{isWorkflowRejected && (

--- a/packages/web/src/components/space/ReadOnlyWorkflowCanvas.tsx
+++ b/packages/web/src/components/space/ReadOnlyWorkflowCanvas.tsx
@@ -201,29 +201,33 @@ export function ReadOnlyWorkflowCanvas({
 		[approveGateRequest]
 	);
 
-	// Tracks the element focused when the artifacts overlay opens so focus can
-	// be restored to it on close (WCAG 2.4.3). document.activeElement works for
-	// both popup and ChannelInfoPanel callsites without changing signatures. If
-	// the opener unmounts while the overlay is open (common when approve/reject
-	// from GateArtifactsView clears the popup/channel context), we fall back to
-	// the canvas container so focus lands somewhere keyboard-navigable.
+	// Tracks the element that opened the artifacts overlay so focus can be
+	// restored to it on close (WCAG 2.4.3). We capture `event.currentTarget`
+	// from the triggering click — `document.activeElement` is unreliable here
+	// because Safari and Firefox don't move focus to buttons on click. Mirrors
+	// PendingGateBanner's pattern for consistency. If the opener unmounts
+	// while the overlay is open (e.g. approve/reject clears the popup or
+	// ChannelInfoPanel context), we fall back to the canvas container.
 	const overlayOpenerRef = useRef<HTMLElement | null>(null);
 
 	// Open artifacts overlay directly from channel info panel
-	const handleChannelViewArtifacts = useCallback((gateId: string) => {
-		const active = typeof document !== 'undefined' ? document.activeElement : null;
-		overlayOpenerRef.current = active instanceof HTMLElement ? active : null;
+	const handleChannelViewArtifacts = useCallback((gateId: string, event: Event) => {
+		const target = event.currentTarget;
+		overlayOpenerRef.current = target instanceof HTMLElement ? target : null;
 		setArtifactsOverlay({ gateId });
 	}, []);
 
 	// Open artifacts overlay from popup
-	const handleOpenArtifacts = useCallback(() => {
-		if (!gatePopup) return;
-		const active = typeof document !== 'undefined' ? document.activeElement : null;
-		overlayOpenerRef.current = active instanceof HTMLElement ? active : null;
-		setArtifactsOverlay({ gateId: gatePopup.gateId });
-		setGatePopup(null);
-	}, [gatePopup]);
+	const handleOpenArtifacts = useCallback(
+		(event: MouseEvent) => {
+			if (!gatePopup) return;
+			const target = event.currentTarget;
+			overlayOpenerRef.current = target instanceof HTMLElement ? target : null;
+			setArtifactsOverlay({ gateId: gatePopup.gateId });
+			setGatePopup(null);
+		},
+		[gatePopup]
+	);
 
 	// Close artifacts overlay after decision
 	const handleArtifactsDecision = useCallback(() => {
@@ -302,7 +306,11 @@ export function ReadOnlyWorkflowCanvas({
 					Workflow paused — awaiting approval
 				</div>
 			)}
-			<div ref={containerRef} tabIndex={-1} class="flex-1 min-h-0 relative focus:outline-none">
+			<div
+				ref={containerRef}
+				tabIndex={-1}
+				class="flex-1 min-h-0 relative focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400/70"
+			>
 				<WorkflowCanvas
 					nodes={nodeData}
 					viewportState={viewportState}

--- a/packages/web/src/components/space/ReadOnlyWorkflowCanvas.tsx
+++ b/packages/web/src/components/space/ReadOnlyWorkflowCanvas.tsx
@@ -55,6 +55,20 @@ export function ReadOnlyWorkflowCanvas({
 	const [channelDecisionError, setChannelDecisionError] = useState<string | null>(null);
 	const [popupDecisionError, setPopupDecisionError] = useState<string | null>(null);
 
+	// Reset transient UI state whenever the run or workflow the canvas is
+	// displaying changes. Without this, a gate popup, artifacts overlay, or
+	// in-flight approving entry from the prior run remains mounted after
+	// swap — clicking Approve would then POST a gateId that doesn't exist in
+	// the new run and the server returns an error.
+	useEffect(() => {
+		setGatePopup(null);
+		setArtifactsOverlay(null);
+		setApprovingGateIds(new Set());
+		setSelectedChannelId(null);
+		setChannelDecisionError(null);
+		setPopupDecisionError(null);
+	}, [runId, workflowId]);
+
 	const {
 		nodeData,
 		channelEdges,
@@ -187,14 +201,26 @@ export function ReadOnlyWorkflowCanvas({
 		[approveGateRequest]
 	);
 
+	// Tracks the element focused when the artifacts overlay opens so focus can
+	// be restored to it on close (WCAG 2.4.3). document.activeElement works for
+	// both popup and ChannelInfoPanel callsites without changing signatures. If
+	// the opener unmounts while the overlay is open (common when approve/reject
+	// from GateArtifactsView clears the popup/channel context), we fall back to
+	// the canvas container so focus lands somewhere keyboard-navigable.
+	const overlayOpenerRef = useRef<HTMLElement | null>(null);
+
 	// Open artifacts overlay directly from channel info panel
 	const handleChannelViewArtifacts = useCallback((gateId: string) => {
+		const active = typeof document !== 'undefined' ? document.activeElement : null;
+		overlayOpenerRef.current = active instanceof HTMLElement ? active : null;
 		setArtifactsOverlay({ gateId });
 	}, []);
 
 	// Open artifacts overlay from popup
 	const handleOpenArtifacts = useCallback(() => {
 		if (!gatePopup) return;
+		const active = typeof document !== 'undefined' ? document.activeElement : null;
+		overlayOpenerRef.current = active instanceof HTMLElement ? active : null;
 		setArtifactsOverlay({ gateId: gatePopup.gateId });
 		setGatePopup(null);
 	}, [gatePopup]);
@@ -203,6 +229,32 @@ export function ReadOnlyWorkflowCanvas({
 	const handleArtifactsDecision = useCallback(() => {
 		setArtifactsOverlay(null);
 	}, []);
+
+	// Close the artifacts overlay on Escape — matches PendingGateBanner's twin.
+	useEffect(() => {
+		if (!artifactsOverlay) return;
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') setArtifactsOverlay(null);
+		};
+		window.addEventListener('keydown', onKey);
+		return () => window.removeEventListener('keydown', onKey);
+	}, [artifactsOverlay]);
+
+	// Restore focus to the overlay opener when the overlay closes. If the
+	// opener was detached (e.g. the popup closed when the overlay opened, or
+	// the channel info panel collapsed), fall back to the canvas container so
+	// focus doesn't collapse to <body>.
+	useEffect(() => {
+		if (artifactsOverlay) return;
+		const opener = overlayOpenerRef.current;
+		if (!opener) return;
+		if (opener.isConnected && typeof opener.focus === 'function') {
+			opener.focus();
+		} else if (containerRef.current && typeof containerRef.current.focus === 'function') {
+			containerRef.current.focus();
+		}
+		overlayOpenerRef.current = null;
+	}, [artifactsOverlay]);
 
 	const selectedChannel = selectedChannelId
 		? (channelEdges.find((c) => c.id === selectedChannelId) ?? null)
@@ -250,7 +302,7 @@ export function ReadOnlyWorkflowCanvas({
 					Workflow paused — awaiting approval
 				</div>
 			)}
-			<div ref={containerRef} class="flex-1 min-h-0 relative">
+			<div ref={containerRef} tabIndex={-1} class="flex-1 min-h-0 relative focus:outline-none">
 				<WorkflowCanvas
 					nodes={nodeData}
 					viewportState={viewportState}
@@ -337,6 +389,9 @@ export function ReadOnlyWorkflowCanvas({
 				<div
 					data-testid="artifacts-panel-overlay"
 					class="absolute inset-0 z-40 bg-black/50 flex items-center justify-center"
+					role="dialog"
+					aria-modal="true"
+					aria-label="Review gate artifacts"
 					onClick={(e) => {
 						if (e.target === e.currentTarget) setArtifactsOverlay(null);
 					}}

--- a/packages/web/src/components/space/ReadOnlyWorkflowCanvas.tsx
+++ b/packages/web/src/components/space/ReadOnlyWorkflowCanvas.tsx
@@ -48,7 +48,10 @@ export function ReadOnlyWorkflowCanvas({
 	// Gate popup / overlay state
 	const [gatePopup, setGatePopup] = useState<GatePopupState | null>(null);
 	const [artifactsOverlay, setArtifactsOverlay] = useState<{ gateId: string } | null>(null);
-	const [approving, setApproving] = useState(false);
+	// Per-gate in-flight set so approving one gate never disables another gate's
+	// buttons — previously a single boolean disabled every decision affordance
+	// in the canvas while any RPC was pending.
+	const [approvingGateIds, setApprovingGateIds] = useState<Set<string>>(() => new Set());
 	const [channelDecisionError, setChannelDecisionError] = useState<string | null>(null);
 	const [popupDecisionError, setPopupDecisionError] = useState<string | null>(null);
 
@@ -124,7 +127,11 @@ export function ReadOnlyWorkflowCanvas({
 	const approveGateRequest = useCallback(
 		async (gateId: string, approved: boolean): Promise<{ ok: boolean; error?: string }> => {
 			if (!runId) return { ok: false, error: 'Missing run ID' };
-			setApproving(true);
+			setApprovingGateIds((prev) => {
+				const next = new Set(prev);
+				next.add(gateId);
+				return next;
+			});
 			try {
 				const hub = await connectionManager.getHub();
 				await hub.request('spaceWorkflowRun.approveGate', {
@@ -139,7 +146,12 @@ export function ReadOnlyWorkflowCanvas({
 					error: err instanceof Error ? err.message : 'Failed to submit decision',
 				};
 			} finally {
-				setApproving(false);
+				setApprovingGateIds((prev) => {
+					if (!prev.has(gateId)) return prev;
+					const next = new Set(prev);
+					next.delete(gateId);
+					return next;
+				});
 			}
 		},
 		[runId]
@@ -269,7 +281,9 @@ export function ReadOnlyWorkflowCanvas({
 						}}
 						onGateDecision={handleChannelGateDecision}
 						onViewArtifacts={handleChannelViewArtifacts}
-						decisionPending={approving}
+						decisionPending={
+							!!selectedChannel.gateId && approvingGateIds.has(selectedChannel.gateId)
+						}
 						decisionError={channelDecisionError}
 					/>
 				)}
@@ -294,7 +308,7 @@ export function ReadOnlyWorkflowCanvas({
 							<div class="flex gap-2">
 								<button
 									onClick={() => void handlePopupDecision(true)}
-									disabled={approving}
+									disabled={approvingGateIds.has(gatePopup.gateId)}
 									class="flex-1 px-2 py-1.5 text-xs font-medium rounded bg-green-900/40 text-green-300 border border-green-700/50 hover:bg-green-800/50 disabled:opacity-50 transition-colors"
 								>
 									Approve
@@ -302,7 +316,7 @@ export function ReadOnlyWorkflowCanvas({
 								<button
 									data-testid="popup-reject-btn"
 									onClick={() => void handlePopupDecision(false)}
-									disabled={approving}
+									disabled={approvingGateIds.has(gatePopup.gateId)}
 									class="flex-1 px-2 py-1.5 text-xs font-medium rounded bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50 disabled:opacity-50 transition-colors"
 								>
 									Reject

--- a/packages/web/src/components/space/ReadOnlyWorkflowCanvas.tsx
+++ b/packages/web/src/components/space/ReadOnlyWorkflowCanvas.tsx
@@ -49,6 +49,7 @@ export function ReadOnlyWorkflowCanvas({
 	const [gatePopup, setGatePopup] = useState<GatePopupState | null>(null);
 	const [artifactsOverlay, setArtifactsOverlay] = useState<{ gateId: string } | null>(null);
 	const [approving, setApproving] = useState(false);
+	const [channelDecisionError, setChannelDecisionError] = useState<string | null>(null);
 
 	const {
 		nodeData,
@@ -100,6 +101,7 @@ export function ReadOnlyWorkflowCanvas({
 	const handleChannelSelect = useCallback((channelId: string | null) => {
 		setSelectedChannelId(channelId);
 		setGatePopup(null);
+		setChannelDecisionError(null);
 	}, []);
 
 	// Gate icon click — open action popup
@@ -116,8 +118,8 @@ export function ReadOnlyWorkflowCanvas({
 	}, []);
 
 	const approveGateRequest = useCallback(
-		async (gateId: string, approved: boolean) => {
-			if (!runId) return;
+		async (gateId: string, approved: boolean): Promise<{ ok: boolean; error?: string }> => {
+			if (!runId) return { ok: false, error: 'Missing run ID' };
 			setApproving(true);
 			try {
 				const hub = await connectionManager.getHub();
@@ -126,9 +128,12 @@ export function ReadOnlyWorkflowCanvas({
 					gateId,
 					approved,
 				});
+				return { ok: true };
 			} catch (err) {
-				// eslint-disable-next-line no-console
-				console.error('[approveGateRequest] approveGate error:', err);
+				return {
+					ok: false,
+					error: err instanceof Error ? err.message : 'Failed to submit decision',
+				};
 			} finally {
 				setApproving(false);
 			}
@@ -140,8 +145,8 @@ export function ReadOnlyWorkflowCanvas({
 	const handlePopupDecision = useCallback(
 		async (approved: boolean) => {
 			if (!gatePopup) return;
-			await approveGateRequest(gatePopup.gateId, approved);
-			setGatePopup(null);
+			const result = await approveGateRequest(gatePopup.gateId, approved);
+			if (result.ok) setGatePopup(null);
 		},
 		[gatePopup, approveGateRequest]
 	);
@@ -149,7 +154,13 @@ export function ReadOnlyWorkflowCanvas({
 	// Approve/reject from inline channel info panel
 	const handleChannelGateDecision = useCallback(
 		async (gateId: string, approved: boolean) => {
-			await approveGateRequest(gateId, approved);
+			setChannelDecisionError(null);
+			const result = await approveGateRequest(gateId, approved);
+			if (result.ok) {
+				setSelectedChannelId(null);
+			} else {
+				setChannelDecisionError(result.error ?? 'Failed to submit decision');
+			}
 		},
 		[approveGateRequest]
 	);
@@ -225,10 +236,14 @@ export function ReadOnlyWorkflowCanvas({
 						channel={selectedChannel}
 						fromNodeName={getNodeName(selectedChannel.fromStepId)}
 						toNodeName={getNodeName(selectedChannel.toStepId)}
-						onClose={() => setSelectedChannelId(null)}
+						onClose={() => {
+							setSelectedChannelId(null);
+							setChannelDecisionError(null);
+						}}
 						onGateDecision={handleChannelGateDecision}
 						onViewArtifacts={handleChannelViewArtifacts}
 						decisionPending={approving}
+						decisionError={channelDecisionError}
 					/>
 				)}
 

--- a/packages/web/src/components/space/ReadOnlyWorkflowCanvas.tsx
+++ b/packages/web/src/components/space/ReadOnlyWorkflowCanvas.tsx
@@ -50,6 +50,7 @@ export function ReadOnlyWorkflowCanvas({
 	const [artifactsOverlay, setArtifactsOverlay] = useState<{ gateId: string } | null>(null);
 	const [approving, setApproving] = useState(false);
 	const [channelDecisionError, setChannelDecisionError] = useState<string | null>(null);
+	const [popupDecisionError, setPopupDecisionError] = useState<string | null>(null);
 
 	const {
 		nodeData,
@@ -117,6 +118,7 @@ export function ReadOnlyWorkflowCanvas({
 			y: event.clientY - rect.top,
 		});
 		setSelectedChannelId(null);
+		setPopupDecisionError(null);
 	}, []);
 
 	const approveGateRequest = useCallback(
@@ -147,8 +149,14 @@ export function ReadOnlyWorkflowCanvas({
 	const handlePopupDecision = useCallback(
 		async (approved: boolean) => {
 			if (!gatePopup) return;
+			setPopupDecisionError(null);
 			const result = await approveGateRequest(gatePopup.gateId, approved);
-			if (result.ok) setGatePopup(null);
+			if (result.ok) {
+				setGatePopup(null);
+				setPopupDecisionError(null);
+			} else {
+				setPopupDecisionError(result.error ?? 'Failed to submit decision');
+			}
 		},
 		[gatePopup, approveGateRequest]
 	);
@@ -300,6 +308,11 @@ export function ReadOnlyWorkflowCanvas({
 									Reject
 								</button>
 							</div>
+							{popupDecisionError && (
+								<p class="text-xs text-red-400 break-words" data-testid="popup-decision-error">
+									{popupDecisionError}
+								</p>
+							)}
 						</div>
 					</div>
 				)}

--- a/packages/web/src/components/space/ReadOnlyWorkflowCanvas.tsx
+++ b/packages/web/src/components/space/ReadOnlyWorkflowCanvas.tsx
@@ -115,28 +115,49 @@ export function ReadOnlyWorkflowCanvas({
 		setSelectedChannelId(null);
 	}, []);
 
-	// Direct approve/reject from popup
-	const handlePopupDecision = useCallback(
-		async (approved: boolean) => {
-			if (!gatePopup || !runId) return;
+	const approveGateRequest = useCallback(
+		async (gateId: string, approved: boolean) => {
+			if (!runId) return;
 			setApproving(true);
 			try {
 				const hub = await connectionManager.getHub();
 				await hub.request('spaceWorkflowRun.approveGate', {
 					runId,
-					gateId: gatePopup.gateId,
+					gateId,
 					approved,
 				});
-				setGatePopup(null);
 			} catch (err) {
 				// eslint-disable-next-line no-console
-				console.error('[handlePopupDecision] approveGate error:', err);
+				console.error('[approveGateRequest] approveGate error:', err);
 			} finally {
 				setApproving(false);
 			}
 		},
-		[gatePopup, runId]
+		[runId]
 	);
+
+	// Direct approve/reject from popup
+	const handlePopupDecision = useCallback(
+		async (approved: boolean) => {
+			if (!gatePopup) return;
+			await approveGateRequest(gatePopup.gateId, approved);
+			setGatePopup(null);
+		},
+		[gatePopup, approveGateRequest]
+	);
+
+	// Approve/reject from inline channel info panel
+	const handleChannelGateDecision = useCallback(
+		async (gateId: string, approved: boolean) => {
+			await approveGateRequest(gateId, approved);
+		},
+		[approveGateRequest]
+	);
+
+	// Open artifacts overlay directly from channel info panel
+	const handleChannelViewArtifacts = useCallback((gateId: string) => {
+		setArtifactsOverlay({ gateId });
+	}, []);
 
 	// Open artifacts overlay from popup
 	const handleOpenArtifacts = useCallback(() => {
@@ -205,6 +226,9 @@ export function ReadOnlyWorkflowCanvas({
 						fromNodeName={getNodeName(selectedChannel.fromStepId)}
 						toNodeName={getNodeName(selectedChannel.toStepId)}
 						onClose={() => setSelectedChannelId(null)}
+						onGateDecision={handleChannelGateDecision}
+						onViewArtifacts={handleChannelViewArtifacts}
+						decisionPending={approving}
 					/>
 				)}
 

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -13,6 +13,7 @@ import { SpaceTaskUnifiedThread } from './SpaceTaskUnifiedThread';
 import { TaskArtifactsPanel } from './TaskArtifactsPanel';
 import { getTransitionActions, TaskStatusActions } from './TaskStatusActions';
 import { TaskBlockedBanner } from './TaskBlockedBanner';
+import { PendingGateBanner } from './PendingGateBanner';
 import { ThreadedChatComposer } from './ThreadedChatComposer';
 import { ReadOnlyWorkflowCanvas } from './ReadOnlyWorkflowCanvas';
 import { Dropdown, type DropdownMenuItem } from '../ui/Dropdown';
@@ -418,12 +419,16 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 					/>
 				) : (
 					<div class="h-full flex flex-col relative">
-						{task.status === 'blocked' && (
+						{task.status === 'blocked' ? (
 							<TaskBlockedBanner
 								task={task}
 								spaceId={runtimeSpaceId}
 								onStatusTransition={handleStatusTransition}
 							/>
+						) : (
+							task.workflowRunId && (
+								<PendingGateBanner runId={task.workflowRunId} spaceId={runtimeSpaceId} />
+							)
 						)}
 						<div class="flex-1 min-h-0" data-testid="task-thread-panel">
 							{hasUnifiedWorkflowThread ? (

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -427,7 +427,11 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 							/>
 						) : (
 							task.workflowRunId && (
-								<PendingGateBanner runId={task.workflowRunId} spaceId={runtimeSpaceId} />
+								<PendingGateBanner
+									runId={task.workflowRunId}
+									spaceId={runtimeSpaceId}
+									workflowId={canvasWorkflowId}
+								/>
 							)
 						)}
 						<div class="flex-1 min-h-0" data-testid="task-thread-panel">

--- a/packages/web/src/components/space/TaskBlockedBanner.tsx
+++ b/packages/web/src/components/space/TaskBlockedBanner.tsx
@@ -3,7 +3,9 @@
  *
  * Replaces the generic amber blocked banner in SpaceTaskPane with
  * distinct UI per blockReason:
- *   - human_input_requested: blue/info — shows question, prompts "Reply below"
+ *   - human_input_requested: NOT rendered — the question is surfaced as a
+ *     "Question" message in the thread (see space-task-thread-events.ts),
+ *     so a header banner would just duplicate it. Reply via the composer.
  *   - gate_rejected: purple — shows gate info + "Review & Approve" expanding to GateArtifactsView
  *   - execution_failed / agent_crashed: red — shows error + Resume button
  *   - dependency_failed: gray — informational
@@ -34,13 +36,6 @@ const REASON_CONFIG: Partial<
 		{ label: string; border: string; bg: string; title: string; icon: string }
 	>
 > = {
-	human_input_requested: {
-		label: 'Waiting for Input',
-		border: 'border-blue-500/30',
-		bg: 'bg-blue-500/10',
-		title: 'text-blue-300',
-		icon: '💬',
-	},
 	gate_rejected: {
 		label: 'Gate Pending Approval',
 		border: 'border-purple-500/30',
@@ -88,6 +83,12 @@ const FALLBACK_CONFIG = {
 
 export function TaskBlockedBanner({ task, spaceId, onStatusTransition }: TaskBlockedBannerProps) {
 	const reason = task.blockReason;
+
+	// Human-input requests are surfaced as a "Question" message in the thread,
+	// so a duplicate header banner is not needed. The composer below the thread
+	// is the reply affordance.
+	if (reason === 'human_input_requested') return null;
+
 	const config = (reason && REASON_CONFIG[reason]) || FALLBACK_CONFIG;
 
 	const [showGateReview, setShowGateReview] = useState(false);
@@ -156,9 +157,6 @@ export function TaskBlockedBanner({ task, spaceId, onStatusTransition }: TaskBlo
 						<p class="mt-0.5 text-sm text-gray-200/90" data-testid="task-blocked-message">
 							{task.result}
 						</p>
-					)}
-					{reason === 'human_input_requested' && (
-						<p class="mt-1 text-xs text-blue-400/70">Reply below to continue</p>
 					)}
 				</div>
 

--- a/packages/web/src/components/space/TaskBlockedBanner.tsx
+++ b/packages/web/src/components/space/TaskBlockedBanner.tsx
@@ -3,9 +3,11 @@
  *
  * Replaces the generic amber blocked banner in SpaceTaskPane with
  * distinct UI per blockReason:
- *   - human_input_requested: NOT rendered — the question is surfaced as a
- *     "Question" message in the thread (see space-task-thread-events.ts),
- *     so a header banner would just duplicate it. Reply via the composer.
+ *   - human_input_requested: tiny "reply via composer" hint — the question
+ *     itself is surfaced as a "Question" message in the thread (see
+ *     space-task-thread-events.ts), so we don't duplicate it here. The hint
+ *     is a safety net: if the thread transformation ever fails to render the
+ *     question, the user still sees that input is required.
  *   - gate_rejected: purple — shows gate info + "Review & Approve" expanding to GateArtifactsView
  *   - execution_failed / agent_crashed: red — shows error + Resume button
  *   - dependency_failed: gray — informational
@@ -84,10 +86,21 @@ const FALLBACK_CONFIG = {
 export function TaskBlockedBanner({ task, spaceId, onStatusTransition }: TaskBlockedBannerProps) {
 	const reason = task.blockReason;
 
-	// Human-input requests are surfaced as a "Question" message in the thread,
-	// so a duplicate header banner is not needed. The composer below the thread
-	// is the reply affordance.
-	if (reason === 'human_input_requested') return null;
+	// Human-input requests render the question body as a "Question" message in
+	// the thread (space-task-thread-events.ts). Here we show only a thin hint
+	// pointing users to the composer — enough to be a safety net if the thread
+	// transformation is ever absent, without duplicating the full question.
+	if (reason === 'human_input_requested') {
+		return (
+			<div
+				class="mx-4 mt-2 mb-2 rounded-md border border-sky-500/30 bg-sky-500/10 px-3 py-1.5"
+				data-testid="task-blocked-banner"
+				data-reason="human_input_requested"
+			>
+				<p class="text-xs text-sky-300">💬 Awaiting your input — reply via the composer below.</p>
+			</div>
+		);
+	}
 
 	const config = (reason && REASON_CONFIG[reason]) || FALLBACK_CONFIG;
 

--- a/packages/web/src/components/space/__tests__/PendingGateBanner.test.tsx
+++ b/packages/web/src/components/space/__tests__/PendingGateBanner.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * Unit tests for PendingGateBanner.
+ *
+ * Covers:
+ * - hidden when no pending gates
+ * - rendered when a gate is waiting_human
+ * - multi-gate stack
+ * - approve click fires spaceWorkflowRun.approveGate
+ * - reject click fires spaceWorkflowRun.approveGate with approved=false
+ * - fetch error surfaces with a Retry button
+ * - Review opens the artifacts overlay
+ */
+
+// @ts-nocheck
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/preact';
+import { signal } from '@preact/signals';
+import type { Gate, SpaceWorkflow } from '@neokai/shared';
+
+// ---- Mock hub ----
+const mockRequest: Mock = vi.fn();
+const mockOnEvent: Mock = vi.fn(() => () => {});
+const mockHub = { request: mockRequest, onEvent: mockOnEvent };
+
+vi.mock('../../../lib/connection-manager', () => ({
+	connectionManager: {
+		getHub: vi.fn(() => Promise.resolve(mockHub)),
+		getHubIfConnected: vi.fn(() => mockHub),
+	},
+}));
+
+// ---- Mock space-store.workflows signal ----
+const workflowsSignal = signal<SpaceWorkflow[]>([]);
+vi.mock('../../../lib/space-store', () => ({
+	spaceStore: {
+		get workflows() {
+			return workflowsSignal;
+		},
+	},
+}));
+
+// ---- Mock GateArtifactsView ----
+vi.mock('../GateArtifactsView', () => ({
+	GateArtifactsView: (props: Record<string, unknown>) => (
+		<div data-testid="gate-artifacts-view" data-gate-id={props.gateId as string}>
+			GateArtifactsView
+			<button data-testid="gate-close" onClick={props.onClose as () => void}>
+				Close
+			</button>
+		</div>
+	),
+}));
+
+import { PendingGateBanner } from '../PendingGateBanner';
+
+function approvalGate(id: string, label?: string): Gate {
+	return {
+		id,
+		label,
+		resetOnCycle: false,
+		fields: [
+			{
+				name: 'approved',
+				type: 'boolean',
+				writers: [],
+				check: { op: '==', value: true },
+			},
+		],
+	};
+}
+
+function makeWorkflow(gates: Gate[]): SpaceWorkflow {
+	return {
+		id: 'wf-1',
+		name: 'Test Workflow',
+		description: '',
+		nodes: [],
+		channels: [],
+		gates,
+		startNodeId: null,
+		endNodeId: null,
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		spaceId: 'space-1',
+	} as unknown as SpaceWorkflow;
+}
+
+describe('PendingGateBanner', () => {
+	beforeEach(() => {
+		cleanup();
+		mockRequest.mockReset();
+		mockOnEvent.mockReset();
+		mockOnEvent.mockImplementation(() => () => {});
+		workflowsSignal.value = [];
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders nothing when there are no pending gates', async () => {
+		workflowsSignal.value = [makeWorkflow([approvalGate('g1')])];
+		mockRequest.mockResolvedValue({
+			gateData: [{ runId: 'r1', gateId: 'g1', data: { approved: true }, updatedAt: 0 }],
+		});
+		const { queryByTestId } = render(
+			<PendingGateBanner runId="r1" spaceId="s1" workflowId="wf-1" />
+		);
+		await waitFor(() =>
+			expect(mockRequest).toHaveBeenCalledWith('spaceWorkflowRun.listGateData', { runId: 'r1' })
+		);
+		expect(queryByTestId('pending-gate-banner')).toBeNull();
+		expect(queryByTestId('pending-gate-fetch-error')).toBeNull();
+	});
+
+	it('renders the banner for a gate that is waiting_human', async () => {
+		workflowsSignal.value = [makeWorkflow([approvalGate('g1', 'Merge PR')])];
+		mockRequest.mockResolvedValue({ gateData: [] });
+		const { findByTestId, getByTestId } = render(
+			<PendingGateBanner runId="r1" spaceId="s1" workflowId="wf-1" />
+		);
+		await findByTestId('pending-gate-banner');
+		expect(getByTestId('pending-gate-approve-btn')).toBeTruthy();
+		expect(getByTestId('pending-gate-reject-btn')).toBeTruthy();
+		expect(getByTestId('pending-gate-review-btn')).toBeTruthy();
+	});
+
+	it('renders one row per pending gate in multi-gate workflows', async () => {
+		workflowsSignal.value = [
+			makeWorkflow([approvalGate('g1', 'First'), approvalGate('g2', 'Second')]),
+		];
+		mockRequest.mockResolvedValue({ gateData: [] });
+		const { findByTestId, getAllByTestId } = render(
+			<PendingGateBanner runId="r1" spaceId="s1" workflowId="wf-1" />
+		);
+		await findByTestId('pending-gate-banner');
+		expect(getAllByTestId('pending-gate-approve-btn')).toHaveLength(2);
+	});
+
+	it('approve click fires approveGate with approved=true', async () => {
+		workflowsSignal.value = [makeWorkflow([approvalGate('g1')])];
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'spaceWorkflowRun.listGateData') return Promise.resolve({ gateData: [] });
+			return Promise.resolve({});
+		});
+		const { findByTestId } = render(
+			<PendingGateBanner runId="r1" spaceId="s1" workflowId="wf-1" />
+		);
+		const btn = await findByTestId('pending-gate-approve-btn');
+		fireEvent.click(btn);
+		await waitFor(() =>
+			expect(mockRequest).toHaveBeenCalledWith('spaceWorkflowRun.approveGate', {
+				runId: 'r1',
+				gateId: 'g1',
+				approved: true,
+			})
+		);
+	});
+
+	it('reject click fires approveGate with approved=false', async () => {
+		workflowsSignal.value = [makeWorkflow([approvalGate('g1')])];
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'spaceWorkflowRun.listGateData') return Promise.resolve({ gateData: [] });
+			return Promise.resolve({});
+		});
+		const { findByTestId } = render(
+			<PendingGateBanner runId="r1" spaceId="s1" workflowId="wf-1" />
+		);
+		const btn = await findByTestId('pending-gate-reject-btn');
+		fireEvent.click(btn);
+		await waitFor(() =>
+			expect(mockRequest).toHaveBeenCalledWith('spaceWorkflowRun.approveGate', {
+				runId: 'r1',
+				gateId: 'g1',
+				approved: false,
+			})
+		);
+	});
+
+	it('surfaces fetch errors with a Retry button', async () => {
+		workflowsSignal.value = [makeWorkflow([approvalGate('g1')])];
+		mockRequest.mockRejectedValueOnce(new Error('network down'));
+		const { findByTestId, getByTestId } = render(
+			<PendingGateBanner runId="r1" spaceId="s1" workflowId="wf-1" />
+		);
+		await findByTestId('pending-gate-fetch-error');
+		expect(getByTestId('pending-gate-fetch-error').textContent).toContain('network down');
+		// Retry re-issues the listGateData request
+		mockRequest.mockResolvedValueOnce({ gateData: [] });
+		fireEvent.click(getByTestId('pending-gate-fetch-retry'));
+		await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(2));
+	});
+
+	it('Review button opens the artifacts overlay', async () => {
+		workflowsSignal.value = [makeWorkflow([approvalGate('g1')])];
+		mockRequest.mockResolvedValue({ gateData: [] });
+		const { findByTestId, queryByTestId, getByTestId } = render(
+			<PendingGateBanner runId="r1" spaceId="s1" workflowId="wf-1" />
+		);
+		await findByTestId('pending-gate-banner');
+		expect(queryByTestId('pending-gate-review-overlay')).toBeNull();
+		fireEvent.click(getByTestId('pending-gate-review-btn'));
+		expect(getByTestId('pending-gate-review-overlay')).toBeTruthy();
+		expect(getByTestId('gate-artifacts-view').getAttribute('data-gate-id')).toBe('g1');
+	});
+});

--- a/packages/web/src/components/space/__tests__/PendingGateBanner.test.tsx
+++ b/packages/web/src/components/space/__tests__/PendingGateBanner.test.tsx
@@ -203,4 +203,72 @@ describe('PendingGateBanner', () => {
 		expect(getByTestId('pending-gate-review-overlay')).toBeTruthy();
 		expect(getByTestId('gate-artifacts-view').getAttribute('data-gate-id')).toBe('g1');
 	});
+
+	it('Escape key closes the review overlay', async () => {
+		workflowsSignal.value = [makeWorkflow([approvalGate('g1')])];
+		mockRequest.mockResolvedValue({ gateData: [] });
+		const { findByTestId, queryByTestId, getByTestId } = render(
+			<PendingGateBanner runId="r1" spaceId="s1" workflowId="wf-1" />
+		);
+		await findByTestId('pending-gate-banner');
+		fireEvent.click(getByTestId('pending-gate-review-btn'));
+		expect(getByTestId('pending-gate-review-overlay')).toBeTruthy();
+		fireEvent.keyDown(window, { key: 'Escape' });
+		await waitFor(() => expect(queryByTestId('pending-gate-review-overlay')).toBeNull());
+	});
+
+	it('per-gate busy state: rejecting gate A does not disable gate B buttons', async () => {
+		// Two pending gates. We fire rejection on g1 using a pending request so
+		// the RPC never resolves within the test — if busy state were a single
+		// value, gate B's buttons would appear disabled, which is the bug we
+		// want to prevent.
+		workflowsSignal.value = [
+			makeWorkflow([approvalGate('g1', 'First'), approvalGate('g2', 'Second')]),
+		];
+		let resolveApprove: (v: unknown) => void = () => {};
+		const pending = new Promise((resolve) => {
+			resolveApprove = resolve;
+		});
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'spaceWorkflowRun.listGateData') return Promise.resolve({ gateData: [] });
+			if (method === 'spaceWorkflowRun.approveGate') return pending;
+			return Promise.resolve({});
+		});
+		const { findByTestId, getAllByTestId } = render(
+			<PendingGateBanner runId="r1" spaceId="s1" workflowId="wf-1" />
+		);
+		await findByTestId('pending-gate-banner');
+		const rejectBtns = getAllByTestId('pending-gate-reject-btn') as HTMLButtonElement[];
+		const approveBtns = getAllByTestId('pending-gate-approve-btn') as HTMLButtonElement[];
+		fireEvent.click(rejectBtns[0]);
+		// First gate's buttons become busy; second gate's stay enabled.
+		await waitFor(() => expect(rejectBtns[0].disabled).toBe(true));
+		expect(approveBtns[0].disabled).toBe(true);
+		expect(rejectBtns[1].disabled).toBe(false);
+		expect(approveBtns[1].disabled).toBe(false);
+		resolveApprove({});
+	});
+
+	it('per-gate error: an error on gate A renders inside gate A row, not globally', async () => {
+		workflowsSignal.value = [
+			makeWorkflow([approvalGate('g1', 'First'), approvalGate('g2', 'Second')]),
+		];
+		mockRequest.mockImplementation((method: string, params: { gateId?: string }) => {
+			if (method === 'spaceWorkflowRun.listGateData') return Promise.resolve({ gateData: [] });
+			if (method === 'spaceWorkflowRun.approveGate' && params.gateId === 'g1') {
+				return Promise.reject(new Error('backend exploded'));
+			}
+			return Promise.resolve({});
+		});
+		const { findByTestId, getAllByTestId, findAllByTestId } = render(
+			<PendingGateBanner runId="r1" spaceId="s1" workflowId="wf-1" />
+		);
+		await findByTestId('pending-gate-banner');
+		const rejectBtns = getAllByTestId('pending-gate-reject-btn') as HTMLButtonElement[];
+		fireEvent.click(rejectBtns[0]);
+		const errors = await findAllByTestId('pending-gate-error');
+		// Exactly one error rendered (gate A's), not a global error for both.
+		expect(errors).toHaveLength(1);
+		expect(errors[0].textContent).toContain('backend exploded');
+	});
 });

--- a/packages/web/src/components/space/__tests__/PendingGateBanner.test.tsx
+++ b/packages/web/src/components/space/__tests__/PendingGateBanner.test.tsx
@@ -271,4 +271,46 @@ describe('PendingGateBanner', () => {
 		expect(errors).toHaveLength(1);
 		expect(errors[0].textContent).toContain('backend exploded');
 	});
+
+	it('runId swap clears busyGateIds so buttons are not stuck disabled', async () => {
+		workflowsSignal.value = [makeWorkflow([approvalGate('g1')])];
+		let resolveApprove: (v: unknown) => void = () => {};
+		const pending = new Promise((resolve) => {
+			resolveApprove = resolve;
+		});
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'spaceWorkflowRun.listGateData') return Promise.resolve({ gateData: [] });
+			if (method === 'spaceWorkflowRun.approveGate') return pending;
+			return Promise.resolve({});
+		});
+		const { findByTestId, rerender } = render(
+			<PendingGateBanner runId="r1" spaceId="s1" workflowId="wf-1" />
+		);
+		const rejectBtn = (await findByTestId('pending-gate-reject-btn')) as HTMLButtonElement;
+		fireEvent.click(rejectBtn);
+		await waitFor(() => expect(rejectBtn.disabled).toBe(true));
+		// Swap runId while the RPC is still pending — busyGateIds must reset.
+		rerender(<PendingGateBanner runId="r2" spaceId="s1" workflowId="wf-1" />);
+		const rejectBtnAfterSwap = (await findByTestId('pending-gate-reject-btn')) as HTMLButtonElement;
+		await waitFor(() => expect(rejectBtnAfterSwap.disabled).toBe(false));
+		resolveApprove({});
+	});
+
+	it('closing overlay restores focus to the opening Review button', async () => {
+		workflowsSignal.value = [makeWorkflow([approvalGate('g1')])];
+		mockRequest.mockResolvedValue({ gateData: [] });
+		const { findByTestId, queryByTestId, getByTestId } = render(
+			<PendingGateBanner runId="r1" spaceId="s1" workflowId="wf-1" />
+		);
+		const reviewBtn = (await findByTestId('pending-gate-review-btn')) as HTMLButtonElement;
+		reviewBtn.focus();
+		expect(document.activeElement).toBe(reviewBtn);
+		fireEvent.click(reviewBtn);
+		expect(getByTestId('pending-gate-review-overlay')).toBeTruthy();
+		// Close via Escape
+		fireEvent.keyDown(window, { key: 'Escape' });
+		await waitFor(() => expect(queryByTestId('pending-gate-review-overlay')).toBeNull());
+		// Focus must be restored to the opener
+		expect(document.activeElement).toBe(reviewBtn);
+	});
 });

--- a/packages/web/src/components/space/__tests__/PendingGateBanner.test.tsx
+++ b/packages/web/src/components/space/__tests__/PendingGateBanner.test.tsx
@@ -296,6 +296,43 @@ describe('PendingGateBanner', () => {
 		resolveApprove({});
 	});
 
+	it('merges gate-data events that fire during the initial fetch', async () => {
+		// Regression: previously the subscription was registered AFTER awaiting
+		// listGateData, so updates pushed during the fetch window were dropped.
+		workflowsSignal.value = [makeWorkflow([approvalGate('g1')])];
+		let resolveFetch: (v: unknown) => void = () => {};
+		const pendingFetch = new Promise((resolve) => {
+			resolveFetch = resolve;
+		});
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'spaceWorkflowRun.listGateData') return pendingFetch;
+			return Promise.resolve({});
+		});
+		let emittedEvent: ((payload: unknown) => void) | undefined;
+		mockOnEvent.mockImplementation((_name: string, handler: (payload: unknown) => void) => {
+			emittedEvent = handler;
+			return () => {};
+		});
+
+		const { findByTestId, queryByTestId } = render(
+			<PendingGateBanner runId="r1" spaceId="s1" workflowId="wf-1" />
+		);
+		await waitFor(() => expect(emittedEvent).toBeDefined());
+		// Push an event BEFORE the fetch resolves — this data carries
+		// `approved: true` so the gate should no longer be waiting_human.
+		emittedEvent!({ runId: 'r1', gateId: 'g1', data: { approved: true } });
+		// Now resolve the fetch with a stale snapshot (no data yet).
+		resolveFetch({ gateData: [] });
+		// The banner must NOT appear: the event's approved=true wins over the
+		// empty fetch snapshot. If the race is present, the fetch overwrites
+		// the event and the gate shows as pending.
+		await waitFor(() => expect(queryByTestId('pending-gate-banner')).toBeNull());
+		// Sanity: fetch-error banner should not appear either.
+		expect(queryByTestId('pending-gate-fetch-error')).toBeNull();
+		// Suppress unused warning for findByTestId.
+		void findByTestId;
+	});
+
 	it('closing overlay restores focus to the opening Review button', async () => {
 		workflowsSignal.value = [makeWorkflow([approvalGate('g1')])];
 		mockRequest.mockResolvedValue({ gateData: [] });

--- a/packages/web/src/components/space/__tests__/ReadOnlyWorkflowCanvas.test.tsx
+++ b/packages/web/src/components/space/__tests__/ReadOnlyWorkflowCanvas.test.tsx
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, cleanup, fireEvent } from '@testing-library/preact';
+import { render, cleanup, fireEvent, waitFor } from '@testing-library/preact';
 import { signal } from '@preact/signals';
 import type { SpaceAgent, SpaceTask, SpaceWorkflow } from '@neokai/shared';
 
@@ -55,21 +55,25 @@ vi.mock('../../../lib/utils', () => ({
 // forwarded to WorkflowCanvas, which is tested in WorkflowCanvas's own tests.
 const capturedReadOnly: { value?: boolean } = {};
 let capturedOnChannelSelect: ((id: string | null) => void) | undefined;
+let capturedOnGateClick: ((gateId: string, event: MouseEvent) => void) | undefined;
 
 vi.mock('../visual-editor/WorkflowCanvas', () => ({
 	WorkflowCanvas: ({
 		nodes,
 		onNodeSelect,
 		onChannelSelect,
+		onGateClick,
 		readOnly,
 	}: {
 		nodes: Array<{ step: { localId: string; id?: string; name?: string } }>;
 		readOnly?: boolean;
 		onNodeSelect?: (id: string | null) => void;
 		onChannelSelect?: (id: string | null) => void;
+		onGateClick?: (gateId: string, event: MouseEvent) => void;
 	}) => {
 		capturedReadOnly.value = readOnly;
 		capturedOnChannelSelect = onChannelSelect;
+		capturedOnGateClick = onGateClick;
 		return (
 			<div data-testid="visual-workflow-canvas" data-node-count={nodes.length}>
 				{nodes.map((n) => (
@@ -85,6 +89,14 @@ vi.mock('../visual-editor/WorkflowCanvas', () => ({
 			</div>
 		);
 	},
+}));
+
+vi.mock('../GateArtifactsView', () => ({
+	GateArtifactsView: ({ gateId }: { gateId: string }) => (
+		<div data-testid="gate-artifacts-view" data-gate-id={gateId}>
+			GateArtifactsView
+		</div>
+	),
 }));
 
 vi.mock('../visual-editor/CanvasToolbar', () => ({
@@ -131,6 +143,7 @@ describe('ReadOnlyWorkflowCanvas', () => {
 		mockNodeExecutionsByNodeId.value = new Map();
 		capturedReadOnly.value = undefined;
 		capturedOnChannelSelect = undefined;
+		capturedOnGateClick = undefined;
 		mockHub.request.mockClear();
 		mockHub.request.mockResolvedValue({ gateData: [] });
 	});
@@ -190,5 +203,41 @@ describe('ReadOnlyWorkflowCanvas', () => {
 		mockWorkflows.value = [makeWorkflow()];
 		render(<ReadOnlyWorkflowCanvas workflowId="wf-1" />);
 		expect(capturedReadOnly.value).toBe(true);
+	});
+
+	it('clears gate popup when runId changes so stale gateId is not approvable', async () => {
+		// Regression: swapping runId while the popup was open left a gateId
+		// belonging to the previous run. Clicking Approve then POSTed an id
+		// the server didn't know for the new run.
+		mockWorkflows.value = [makeWorkflow()];
+		const { findByTestId, queryByTestId, rerender } = render(
+			<ReadOnlyWorkflowCanvas workflowId="wf-1" runId="r1" />
+		);
+		// Open the gate popup via the captured onGateClick.
+		const fakeEvent = { clientX: 50, clientY: 60 } as MouseEvent;
+		capturedOnGateClick?.('g-old', fakeEvent);
+		await findByTestId('view-artifacts-btn');
+		// Swap runId — popup should disappear.
+		rerender(<ReadOnlyWorkflowCanvas workflowId="wf-1" runId="r2" />);
+		await waitFor(() => expect(queryByTestId('view-artifacts-btn')).toBeNull());
+	});
+
+	it('artifacts overlay has dialog role + closes on Escape', async () => {
+		mockWorkflows.value = [makeWorkflow()];
+		const { findByTestId, getByTestId, queryByTestId } = render(
+			<ReadOnlyWorkflowCanvas workflowId="wf-1" runId="r1" />
+		);
+		capturedOnGateClick?.('g1', { clientX: 0, clientY: 0 } as MouseEvent);
+		const viewBtn = await findByTestId('view-artifacts-btn');
+		fireEvent.click(viewBtn);
+		const overlay = await findByTestId('artifacts-panel-overlay');
+		expect(overlay.getAttribute('role')).toBe('dialog');
+		expect(overlay.getAttribute('aria-modal')).toBe('true');
+		expect(overlay.getAttribute('aria-label')).toBeTruthy();
+		// Escape closes it.
+		fireEvent.keyDown(window, { key: 'Escape' });
+		await waitFor(() => expect(queryByTestId('artifacts-panel-overlay')).toBeNull());
+		// Suppress unused warning for getByTestId.
+		void getByTestId;
 	});
 });

--- a/packages/web/src/components/space/__tests__/ReadOnlyWorkflowCanvas.test.tsx
+++ b/packages/web/src/components/space/__tests__/ReadOnlyWorkflowCanvas.test.tsx
@@ -214,7 +214,7 @@ describe('ReadOnlyWorkflowCanvas', () => {
 			<ReadOnlyWorkflowCanvas workflowId="wf-1" runId="r1" />
 		);
 		// Open the gate popup via the captured onGateClick.
-		const fakeEvent = { clientX: 50, clientY: 60 } as MouseEvent;
+		const fakeEvent = new MouseEvent('click', { clientX: 50, clientY: 60 });
 		capturedOnGateClick?.('g-old', fakeEvent);
 		await findByTestId('view-artifacts-btn');
 		// Swap runId — popup should disappear.
@@ -227,7 +227,7 @@ describe('ReadOnlyWorkflowCanvas', () => {
 		const { findByTestId, getByTestId, queryByTestId } = render(
 			<ReadOnlyWorkflowCanvas workflowId="wf-1" runId="r1" />
 		);
-		capturedOnGateClick?.('g1', { clientX: 0, clientY: 0 } as MouseEvent);
+		capturedOnGateClick?.('g1', new MouseEvent('click', { clientX: 0, clientY: 0 }));
 		const viewBtn = await findByTestId('view-artifacts-btn');
 		fireEvent.click(viewBtn);
 		const overlay = await findByTestId('artifacts-panel-overlay');

--- a/packages/web/src/components/space/__tests__/TaskArtifactsPanel.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskArtifactsPanel.test.tsx
@@ -298,6 +298,9 @@ describe('SpaceTaskPane — artifacts toggle', () => {
 		vi.doMock('../SpaceTaskUnifiedThread', () => ({
 			SpaceTaskUnifiedThread: () => <div data-testid="space-task-unified-thread" />,
 		}));
+		vi.doMock('../PendingGateBanner', () => ({
+			PendingGateBanner: () => null,
+		}));
 		vi.doMock('../TaskArtifactsPanel', () => ({
 			TaskArtifactsPanel: ({ runId }: { runId: string }) => (
 				<div data-testid="artifacts-panel" data-run-id={runId} />
@@ -355,6 +358,9 @@ describe('SpaceTaskPane — artifacts toggle', () => {
 
 		vi.doMock('../SpaceTaskUnifiedThread', () => ({
 			SpaceTaskUnifiedThread: () => <div data-testid="space-task-unified-thread" />,
+		}));
+		vi.doMock('../PendingGateBanner', () => ({
+			PendingGateBanner: () => null,
 		}));
 		vi.doMock('../TaskArtifactsPanel', () => ({
 			TaskArtifactsPanel: () => <div data-testid="artifacts-panel" />,
@@ -414,6 +420,9 @@ describe('SpaceTaskPane — artifacts toggle', () => {
 
 		vi.doMock('../SpaceTaskUnifiedThread', () => ({
 			SpaceTaskUnifiedThread: () => <div data-testid="space-task-unified-thread" />,
+		}));
+		vi.doMock('../PendingGateBanner', () => ({
+			PendingGateBanner: () => null,
 		}));
 		vi.doMock('../TaskArtifactsPanel', () => ({
 			TaskArtifactsPanel: ({ runId, onClose }: { runId: string; onClose: () => void }) => (

--- a/packages/web/src/components/space/__tests__/TaskBlockedBanner.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskBlockedBanner.test.tsx
@@ -3,7 +3,7 @@
  *
  * Tests:
  * - Renders fallback amber banner when blockReason is null
- * - Renders human_input_requested banner with question and "Reply below" hint
+ * - Returns null for human_input_requested (question renders in the thread instead)
  * - Renders gate_rejected banner with "Review & Approve" button
  * - Renders execution_failed banner with Resume button
  * - Renders agent_crashed banner with Resume button
@@ -96,19 +96,13 @@ describe('TaskBlockedBanner', () => {
 		expect(banner.textContent).toContain('Blocked');
 	});
 
-	it('renders human_input_requested banner with question and reply hint', () => {
+	it('renders nothing for human_input_requested (question surfaces in thread)', () => {
 		const task = makeTask({
 			blockReason: 'human_input_requested',
 			result: 'What color scheme do you prefer?',
 		});
-		const { getByTestId, getByText } = render(<TaskBlockedBanner task={task} spaceId="space-1" />);
-		const banner = getByTestId('task-blocked-banner');
-		expect(banner.className).toContain('border-blue-500');
-		expect(banner.textContent).toContain('Waiting for Input');
-		expect(getByTestId('task-blocked-message').textContent).toBe(
-			'What color scheme do you prefer?'
-		);
-		expect(getByText('Reply below to continue')).toBeTruthy();
+		const { queryByTestId } = render(<TaskBlockedBanner task={task} spaceId="space-1" />);
+		expect(queryByTestId('task-blocked-banner')).toBeNull();
 	});
 
 	it('renders gate_rejected banner with Review & Approve button', async () => {

--- a/packages/web/src/components/space/__tests__/TaskBlockedBanner.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskBlockedBanner.test.tsx
@@ -3,7 +3,7 @@
  *
  * Tests:
  * - Renders fallback amber banner when blockReason is null
- * - Returns null for human_input_requested (question renders in the thread instead)
+ * - Renders a minimal "reply via composer" hint for human_input_requested (full question renders in the thread)
  * - Renders gate_rejected banner with "Review & Approve" button
  * - Renders execution_failed banner with Resume button
  * - Renders agent_crashed banner with Resume button
@@ -96,13 +96,20 @@ describe('TaskBlockedBanner', () => {
 		expect(banner.textContent).toContain('Blocked');
 	});
 
-	it('renders nothing for human_input_requested (question surfaces in thread)', () => {
+	it('renders a minimal "reply via composer" hint for human_input_requested', () => {
+		// The full question renders in the thread; this banner is a safety net
+		// that points the user to the composer in case the thread message is
+		// missing. It must NOT duplicate the full question text.
 		const task = makeTask({
 			blockReason: 'human_input_requested',
 			result: 'What color scheme do you prefer?',
 		});
-		const { queryByTestId } = render(<TaskBlockedBanner task={task} spaceId="space-1" />);
-		expect(queryByTestId('task-blocked-banner')).toBeNull();
+		const { getByTestId } = render(<TaskBlockedBanner task={task} spaceId="space-1" />);
+		const banner = getByTestId('task-blocked-banner');
+		expect(banner.getAttribute('data-reason')).toBe('human_input_requested');
+		expect(banner.textContent).toContain('composer');
+		// Deliberately not rendering task.result inside the banner.
+		expect(banner.textContent).not.toContain('What color scheme');
 	});
 
 	it('renders gate_rejected banner with Review & Approve button', async () => {

--- a/packages/web/src/components/space/__tests__/gate-status.test.ts
+++ b/packages/web/src/components/space/__tests__/gate-status.test.ts
@@ -124,6 +124,16 @@ describe('evaluateGateStatus', () => {
 		expect(evaluateGateStatus(gate([approvedField()]), { approved: false })).toBe('blocked');
 	});
 
+	it('external approval: re-approving after a rejection evaluates as open', () => {
+		// The daemon allows a human to re-submit approved=true after a rejection
+		// (or undefined → false → true transitions). evaluateGateStatus is
+		// stateless and must respect the latest data value.
+		const g = gate([approvedField()]);
+		expect(evaluateGateStatus(g, { approved: false })).toBe('blocked');
+		expect(evaluateGateStatus(g, { approved: true })).toBe('open');
+		expect(evaluateGateStatus(g, {})).toBe('waiting_human');
+	});
+
 	it('external approval: approved=true but peer field still failing → blocked', () => {
 		const g = gate([approvedField(), existsField('pr_url')]);
 		expect(evaluateGateStatus(g, { approved: true })).toBe('blocked');

--- a/packages/web/src/components/space/__tests__/gate-status.test.ts
+++ b/packages/web/src/components/space/__tests__/gate-status.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import type { Gate, GateField } from '@neokai/shared';
+import {
+	evaluateGateStatus,
+	evalFieldStatus,
+	isExternalApprovalGate,
+	parseScriptResult,
+} from '../gate-status';
+
+function approvedField(writers: string[] = []): GateField {
+	return {
+		name: 'approved',
+		type: 'boolean',
+		writers,
+		check: { op: '==', value: true },
+	};
+}
+
+function existsField(name: string): GateField {
+	return {
+		name,
+		type: 'string',
+		writers: ['*'],
+		check: { op: 'exists' },
+	};
+}
+
+function gate(fields: GateField[]): Gate {
+	return { id: 'g1', fields, resetOnCycle: false };
+}
+
+describe('parseScriptResult', () => {
+	it('returns failed=false when _scriptResult is missing', () => {
+		expect(parseScriptResult({})).toEqual({ failed: false });
+	});
+
+	it('returns failed=true with reason when success=false', () => {
+		expect(parseScriptResult({ _scriptResult: { success: false, reason: 'boom' } })).toEqual({
+			failed: true,
+			reason: 'boom',
+		});
+	});
+
+	it('returns failed=false when success=true', () => {
+		expect(parseScriptResult({ _scriptResult: { success: true } })).toEqual({ failed: false });
+	});
+
+	it('ignores primitive _scriptResult (does not treat string/number as failed)', () => {
+		expect(parseScriptResult({ _scriptResult: 'boom' })).toEqual({ failed: false });
+		expect(parseScriptResult({ _scriptResult: 42 })).toEqual({ failed: false });
+		expect(parseScriptResult({ _scriptResult: null })).toEqual({ failed: false });
+	});
+
+	it('ignores reason that is not a string', () => {
+		expect(parseScriptResult({ _scriptResult: { success: false, reason: 42 } })).toEqual({
+			failed: true,
+			reason: undefined,
+		});
+	});
+});
+
+describe('isExternalApprovalGate', () => {
+	it('returns true when a field named "approved" has empty writers', () => {
+		expect(isExternalApprovalGate([approvedField([])])).toBe(true);
+	});
+
+	it('returns false when "approved" has agent writers', () => {
+		expect(isExternalApprovalGate([approvedField(['agent-1'])])).toBe(false);
+	});
+
+	it('returns false when there is no "approved" field', () => {
+		expect(isExternalApprovalGate([existsField('other')])).toBe(false);
+	});
+});
+
+describe('evalFieldStatus', () => {
+	it('exists: open when value is defined', () => {
+		expect(evalFieldStatus(existsField('foo'), { foo: 'x' })).toBe('open');
+		expect(evalFieldStatus(existsField('foo'), {})).toBe('blocked');
+	});
+
+	it('== op: open on equality', () => {
+		const f: GateField = {
+			name: 'approved',
+			type: 'boolean',
+			writers: [],
+			check: { op: '==', value: true },
+		};
+		expect(evalFieldStatus(f, { approved: true })).toBe('open');
+		expect(evalFieldStatus(f, { approved: false })).toBe('blocked');
+	});
+
+	it('count op: open when min met', () => {
+		const f: GateField = {
+			name: 'votes',
+			type: 'map',
+			writers: ['*'],
+			check: { op: 'count', match: 'yes', min: 2 },
+		};
+		expect(evalFieldStatus(f, { votes: { a: 'yes', b: 'yes' } })).toBe('open');
+		expect(evalFieldStatus(f, { votes: { a: 'yes' } })).toBe('blocked');
+		expect(evalFieldStatus(f, { votes: 'not-a-map' })).toBe('blocked');
+	});
+});
+
+describe('evaluateGateStatus', () => {
+	it('script failure short-circuits to blocked', () => {
+		expect(evaluateGateStatus(gate([approvedField()]), { approved: true }, true)).toBe('blocked');
+	});
+
+	it('returns open for a gate with no fields', () => {
+		expect(evaluateGateStatus(gate([]), {})).toBe('open');
+	});
+
+	it('external approval: waiting_human when approved is undefined', () => {
+		expect(evaluateGateStatus(gate([approvedField()]), {})).toBe('waiting_human');
+	});
+
+	it('external approval: open when approved=true', () => {
+		expect(evaluateGateStatus(gate([approvedField()]), { approved: true })).toBe('open');
+	});
+
+	it('external approval: blocked when approved=false', () => {
+		expect(evaluateGateStatus(gate([approvedField()]), { approved: false })).toBe('blocked');
+	});
+
+	it('external approval: approved=true but peer field still failing → blocked', () => {
+		const g = gate([approvedField(), existsField('pr_url')]);
+		expect(evaluateGateStatus(g, { approved: true })).toBe('blocked');
+		expect(evaluateGateStatus(g, { approved: true, pr_url: 'https://…' })).toBe('open');
+	});
+
+	it('non-external gate: blocked until all fields pass', () => {
+		const g = gate([existsField('a'), existsField('b')]);
+		expect(evaluateGateStatus(g, { a: '1' })).toBe('blocked');
+		expect(evaluateGateStatus(g, { a: '1', b: '2' })).toBe('open');
+	});
+});

--- a/packages/web/src/components/space/__tests__/space-task-thread-events.test.ts
+++ b/packages/web/src/components/space/__tests__/space-task-thread-events.test.ts
@@ -342,6 +342,61 @@ describe('buildThreadEvents — multi-agent ordering and label preservation', ()
 		expect(events[0].summary).toBe('Please help me.');
 	});
 
+	it('reshapes request_human_input tool_use into a visible text Question event', () => {
+		const row = makeRow({
+			id: 'hi-row',
+			label: 'Task Agent',
+			content: JSON.stringify({
+				type: 'assistant',
+				uuid: 'hi1',
+				session_id: 'session-1',
+				message: {
+					content: [
+						{
+							type: 'tool_use',
+							id: 't-hi-1',
+							name: 'request_human_input',
+							input: { question: 'Proceed with deploy?', context: 'PR is green.' },
+						},
+					],
+				},
+			}),
+			createdAt: 1_000,
+		});
+		const events = buildThreadEvents([parseThreadRow(row)]);
+		expect(events).toHaveLength(1);
+		expect(events[0].kind).toBe('text');
+		expect(events[0].title).toBe('Question');
+		expect(events[0].summary).toContain('Proceed with deploy?');
+		expect(events[0].summary).toContain('Context: PR is green.');
+	});
+
+	it('skips request_human_input when the question body is empty', () => {
+		const row = makeRow({
+			id: 'hi-empty',
+			label: 'Task Agent',
+			content: JSON.stringify({
+				type: 'assistant',
+				uuid: 'hi2',
+				session_id: 'session-1',
+				message: {
+					content: [
+						{
+							type: 'tool_use',
+							id: 't-hi-2',
+							name: 'request_human_input',
+							input: { question: '   ' },
+						},
+					],
+				},
+			}),
+			createdAt: 1_000,
+		});
+		const events = buildThreadEvents([parseThreadRow(row)]);
+		// Falls through to the generic tool-rendering branch.
+		expect(events[0].kind).toBe('tool');
+	});
+
 	it('handles mixed agent rows with tool events maintaining correct labels', () => {
 		const rows = [
 			makeRow({

--- a/packages/web/src/components/space/__tests__/space-task-thread-events.test.ts
+++ b/packages/web/src/components/space/__tests__/space-task-thread-events.test.ts
@@ -369,6 +369,18 @@ describe('buildThreadEvents — multi-agent ordering and label preservation', ()
 		expect(events[0].title).toBe('Question');
 		expect(events[0].summary).toContain('Proceed with deploy?');
 		expect(events[0].summary).toContain('Context: PR is green.');
+		// The synthesized message must contain ONLY the text block. Keeping
+		// the original tool_use here would make SDKAssistantMessage render a
+		// collapsed tool card alongside the text bubble, defeating the
+		// purpose of surfacing the question as visible text. Tool_use /
+		// tool_result pairing is unaffected: useMessageMaps builds
+		// toolResultsMap from the raw messages array, not from synthesized
+		// events.
+		const synthesized = events[0].message as { message?: { content?: unknown[] } };
+		const content = synthesized.message?.content ?? [];
+		expect(content).toHaveLength(1);
+		expect((content[0] as { type: string }).type).toBe('text');
+		expect(content.some((b) => (b as { type: string }).type === 'tool_use')).toBe(false);
 	});
 
 	it('skips request_human_input when the question body is empty', () => {

--- a/packages/web/src/components/space/gate-status.ts
+++ b/packages/web/src/components/space/gate-status.ts
@@ -24,8 +24,12 @@ export function parseScriptResult(data: Record<string, unknown>): {
 	failed: boolean;
 	reason?: string;
 } {
-	const sr = data._scriptResult as GateScriptResultData | undefined;
-	if (sr && !sr.success) return { failed: true, reason: sr.reason };
+	const raw = data._scriptResult;
+	if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { failed: false };
+	const sr = raw as Partial<GateScriptResultData>;
+	if (sr.success === false) {
+		return { failed: true, reason: typeof sr.reason === 'string' ? sr.reason : undefined };
+	}
 	return { failed: false };
 }
 

--- a/packages/web/src/components/space/gate-status.ts
+++ b/packages/web/src/components/space/gate-status.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared gate-status evaluation mirroring the canvas runtime logic.
+ *
+ * Used by:
+ * - useRuntimeCanvasData.ts — derives ResolvedWorkflowChannel.runtimeStatus
+ * - PendingGateBanner.tsx — surfaces pending human-approval gates in the thread
+ *
+ * Keep these in sync with the daemon's channel evaluator. An external-approval
+ * gate is one where a human writes `approved` (the field's `writers` array is
+ * empty). While `approved` is neither `true` nor `false`, the gate is
+ * `waiting_human`; `true` → `open`, `false` → `blocked` (rejected).
+ */
+
+import type { Gate, GateField } from '@neokai/shared';
+
+export type GateStatus = 'open' | 'blocked' | 'waiting_human';
+
+interface GateScriptResultData {
+	success: boolean;
+	reason?: string;
+}
+
+export function parseScriptResult(data: Record<string, unknown>): {
+	failed: boolean;
+	reason?: string;
+} {
+	const sr = data._scriptResult as GateScriptResultData | undefined;
+	if (sr && !sr.success) return { failed: true, reason: sr.reason };
+	return { failed: false };
+}
+
+export function evalFieldStatus(field: GateField, data: Record<string, unknown>): GateStatus {
+	const check = field.check;
+	if (check.op === 'count') {
+		const map = data[field.name];
+		if (!map || typeof map !== 'object' || Array.isArray(map)) return 'blocked';
+		const count = Object.values(map as Record<string, unknown>).filter(
+			(v) => v === check.match
+		).length;
+		return count >= check.min ? 'open' : 'blocked';
+	}
+	const val = data[field.name];
+	if (check.op === 'exists') return val !== undefined ? 'open' : 'blocked';
+	if (check.op === '==') return val === check.value ? 'open' : 'blocked';
+	if (check.op === '!=') return val !== check.value ? 'open' : 'blocked';
+	return 'blocked';
+}
+
+export function isExternalApprovalGate(fields: GateField[]): boolean {
+	return fields.some((f) => f.name === 'approved' && f.writers.length === 0);
+}
+
+export function evaluateGateStatus(
+	gate: Gate,
+	data: Record<string, unknown>,
+	scriptFailed = false
+): GateStatus {
+	if (scriptFailed) return 'blocked';
+	if ((gate.fields ?? []).length === 0) return 'open';
+	if (isExternalApprovalGate(gate.fields ?? [])) {
+		const val = data['approved'];
+		if (val === true) {
+			const othersPassed = (gate.fields ?? []).every((f) => {
+				if (f.name === 'approved') return true;
+				return evalFieldStatus(f, data) === 'open';
+			});
+			return othersPassed ? 'open' : 'blocked';
+		}
+		if (val === false) return 'blocked';
+		return 'waiting_human';
+	}
+	for (const field of gate.fields ?? []) {
+		const status = evalFieldStatus(field, data);
+		if (status !== 'open') return status;
+	}
+	return 'open';
+}

--- a/packages/web/src/components/space/thread/space-task-thread-events.ts
+++ b/packages/web/src/components/space/thread/space-task-thread-events.ts
@@ -166,6 +166,11 @@ function extractAssistantEvents(
 				const questionContext = typeof input.context === 'string' ? input.context.trim() : '';
 				const body = questionContext ? `${question}\n\nContext: ${questionContext}` : question;
 				if (body) {
+					// Synthesize a text-shaped SDKMessage so renderers that key off
+					// message.message.content (e.g. markdown body rendering) treat
+					// the question as plain text instead of the original tool-use
+					// block. The outer event fields (id, sessionId, etc.) come from
+					// the real row; only the content array is replaced.
 					const questionMessage = {
 						...message,
 						message: {

--- a/packages/web/src/components/space/thread/space-task-thread-events.ts
+++ b/packages/web/src/components/space/thread/space-task-thread-events.ts
@@ -166,11 +166,15 @@ function extractAssistantEvents(
 				const questionContext = typeof input.context === 'string' ? input.context.trim() : '';
 				const body = questionContext ? `${question}\n\nContext: ${questionContext}` : question;
 				if (body) {
-					// Synthesize a text-shaped SDKMessage so renderers that key off
-					// message.message.content (e.g. markdown body rendering) treat
-					// the question as plain text instead of the original tool-use
-					// block. The outer event fields (id, sessionId, etc.) come from
-					// the real row; only the content array is replaced.
+					// Synthesize a text-only SDKMessage so the renderer treats the
+					// question as plain markdown. We intentionally DROP the original
+					// tool_use block from this synthesized event's content: keeping
+					// it would cause SDKAssistantMessage to also render a collapsed
+					// tool card alongside the text bubble (see SDKAssistantMessage
+					// toolBlocks path), defeating the purpose of surfacing the
+					// question as visible text. Tool_use/tool_result pairing is
+					// unaffected — toolResultsMap in useMessageMaps is built from
+					// the raw messages array, not from synthesized events.
 					const questionMessage = {
 						...message,
 						message: {

--- a/packages/web/src/components/space/thread/space-task-thread-events.ts
+++ b/packages/web/src/components/space/thread/space-task-thread-events.ts
@@ -156,6 +156,39 @@ function extractAssistantEvents(
 		}
 
 		if (isToolUseBlock(block)) {
+			// Special-case request_human_input: surface the question as a visible
+			// text message in the thread instead of a collapsed tool card. The
+			// tool stores the question only in task.result, so without this the
+			// question would be invisible in the thread.
+			if (block.name === 'request_human_input') {
+				const input = (block.input ?? {}) as Record<string, unknown>;
+				const question = typeof input.question === 'string' ? input.question.trim() : '';
+				const questionContext = typeof input.context === 'string' ? input.context.trim() : '';
+				const body = questionContext ? `${question}\n\nContext: ${questionContext}` : question;
+				if (body) {
+					const questionMessage = {
+						...message,
+						message: {
+							...message.message,
+							content: [{ type: 'text', text: body }],
+						},
+					} as SDKMessage;
+					events.push({
+						id: eventId,
+						label: row.label,
+						taskId: row.taskId,
+						taskTitle: row.taskTitle,
+						sessionId: row.sessionId,
+						createdAt: row.createdAt,
+						kind: 'text',
+						title: 'Question',
+						summary: body,
+						message: questionMessage,
+					});
+					continue;
+				}
+			}
+
 			const isSubagent = block.name === 'Task';
 			const isBash = block.name === 'Bash';
 			const input = (block.input ?? {}) as Record<string, unknown>;

--- a/packages/web/src/components/space/useRuntimeCanvasData.ts
+++ b/packages/web/src/components/space/useRuntimeCanvasData.ts
@@ -92,7 +92,11 @@ export function useRuntimeCanvasData(
 
 		const hub = connectionManager.getHubIfConnected();
 		if (!hub) {
+			// WS not connected at mount — surface as an error so the Retry chip
+			// renders. Clicking Retry bumps gateDataAttempt and re-enters this
+			// effect; by then the connection may have come back up.
 			setGateDataLoading(false);
+			setGateDataError('Not connected');
 			return;
 		}
 

--- a/packages/web/src/components/space/useRuntimeCanvasData.ts
+++ b/packages/web/src/components/space/useRuntimeCanvasData.ts
@@ -11,7 +11,7 @@
  * - hub RPC spaceWorkflowRun.listGateData + space.gateData.updated events
  */
 
-import { useMemo, useState, useEffect, useRef } from 'preact/hooks';
+import { useMemo, useState, useEffect, useRef, useCallback } from 'preact/hooks';
 import { isChannelCyclic, TASK_AGENT_NODE_ID } from '@neokai/shared';
 import type { Gate, SpaceWorkflow, WorkflowChannel } from '@neokai/shared';
 import { spaceStore } from '../../lib/space-store';
@@ -50,6 +50,10 @@ export interface RuntimeCanvasData {
 	gateDataLoading: boolean;
 	/** Gate data keyed by gateId — used by GateArtifactsView for PR link extraction. */
 	gateDataMap: Map<string, Record<string, unknown>>;
+	/** Last gate-data fetch error, if any. Null when loading or after success. */
+	gateDataError: string | null;
+	/** Re-run the gate-data fetch (e.g. for a Retry button). */
+	retryGateData: () => void;
 }
 
 export function useRuntimeCanvasData(
@@ -71,15 +75,20 @@ export function useRuntimeCanvasData(
 	// ---- Gate data fetching ----
 	const [gateDataMap, setGateDataMap] = useState<Map<string, Record<string, unknown>>>(new Map());
 	const [gateDataLoading, setGateDataLoading] = useState(false);
+	const [gateDataError, setGateDataError] = useState<string | null>(null);
+	const [gateDataAttempt, setGateDataAttempt] = useState(0);
 	const runIdRef = useRef<string | null>(null);
+	const retryGateData = useCallback(() => setGateDataAttempt((n) => n + 1), []);
 
 	useEffect(() => {
 		if (!runId || !workflow) {
 			setGateDataMap(new Map());
+			setGateDataError(null);
 			return;
 		}
 		runIdRef.current = runId;
 		setGateDataLoading(true);
+		setGateDataError(null);
 
 		const hub = connectionManager.getHubIfConnected();
 		if (!hub) {
@@ -104,7 +113,10 @@ export function useRuntimeCanvasData(
 					return fetched;
 				});
 			})
-			.catch(() => {})
+			.catch((err: unknown) => {
+				if (runIdRef.current !== runId) return;
+				setGateDataError(err instanceof Error ? err.message : 'Failed to load gate data');
+			})
 			.finally(() => {
 				if (runIdRef.current === runId) setGateDataLoading(false);
 			});
@@ -125,7 +137,7 @@ export function useRuntimeCanvasData(
 		return () => {
 			unsubscribe?.();
 		};
-	}, [runId, workflow?.id]);
+	}, [runId, workflow?.id, gateDataAttempt]);
 
 	// ---- Build visual state from workflow ----
 	const visualState = useMemo(
@@ -320,5 +332,7 @@ export function useRuntimeCanvasData(
 		workflow,
 		gateDataLoading,
 		gateDataMap,
+		gateDataError,
+		retryGateData,
 	};
 }

--- a/packages/web/src/components/space/useRuntimeCanvasData.ts
+++ b/packages/web/src/components/space/useRuntimeCanvasData.ts
@@ -13,7 +13,7 @@
 
 import { useMemo, useState, useEffect, useRef } from 'preact/hooks';
 import { isChannelCyclic, TASK_AGENT_NODE_ID } from '@neokai/shared';
-import type { Gate, GateField, SpaceWorkflow, WorkflowChannel } from '@neokai/shared';
+import type { Gate, SpaceWorkflow, WorkflowChannel } from '@neokai/shared';
 import { spaceStore } from '../../lib/space-store';
 import { connectionManager } from '../../lib/connection-manager';
 import type { WorkflowNodeData } from './visual-editor/WorkflowCanvas';
@@ -27,68 +27,7 @@ import {
 	routeSemanticWorkflowEdges,
 	buildNodeAnchorUsage,
 } from './visual-editor/semanticWorkflowGraph';
-
-// ---- Gate status evaluation (mirrors logic from old WorkflowCanvas) ----
-
-type GateStatus = 'open' | 'blocked' | 'waiting_human';
-
-interface GateScriptResultData {
-	success: boolean;
-	reason?: string;
-}
-
-function parseScriptResult(data: Record<string, unknown>): { failed: boolean; reason?: string } {
-	const sr = data._scriptResult as GateScriptResultData | undefined;
-	if (sr && !sr.success) return { failed: true, reason: sr.reason };
-	return { failed: false };
-}
-
-function evalFieldStatus(field: GateField, data: Record<string, unknown>): GateStatus {
-	const check = field.check;
-	if (check.op === 'count') {
-		const map = data[field.name];
-		if (!map || typeof map !== 'object' || Array.isArray(map)) return 'blocked';
-		const count = Object.values(map as Record<string, unknown>).filter(
-			(v) => v === check.match
-		).length;
-		return count >= check.min ? 'open' : 'blocked';
-	}
-	const val = data[field.name];
-	if (check.op === 'exists') return val !== undefined ? 'open' : 'blocked';
-	if (check.op === '==') return val === check.value ? 'open' : 'blocked';
-	if (check.op === '!=') return val !== check.value ? 'open' : 'blocked';
-	return 'blocked';
-}
-
-function isExternalApprovalGate(fields: GateField[]): boolean {
-	return fields.some((f) => f.name === 'approved' && f.writers.length === 0);
-}
-
-function evaluateGateStatus(
-	gate: Gate,
-	data: Record<string, unknown>,
-	scriptFailed = false
-): GateStatus {
-	if (scriptFailed) return 'blocked';
-	if ((gate.fields ?? []).length === 0) return 'open';
-	if (isExternalApprovalGate(gate.fields ?? [])) {
-		const val = data['approved'];
-		if (val === true) {
-			const othersPassed = (gate.fields ?? []).every((f) => {
-				if (f.name === 'approved') return true;
-				return evalFieldStatus(f, data) === 'open';
-			});
-			return othersPassed ? 'open' : 'blocked';
-		}
-		if (val === false) return 'blocked';
-		return 'waiting_human';
-	}
-	for (const field of gate.fields ?? []) {
-		const status = evalFieldStatus(field, data);
-		if (status !== 'open') return status;
-	}
-	return 'open';
-}
+import { evaluateGateStatus, parseScriptResult, type GateStatus } from './gate-status';
 
 // ---- Gate data types ----
 


### PR DESCRIPTION
- Canvas `ChannelInfoPanel` now shows inline Approve / Reject / View Artifacts buttons whenever the selected channel's gate is `waiting_human`. No more hunting for the small gate icon.
- New `PendingGateBanner` in the thread view surfaces a pending gate whenever one exists in the task's workflow run, independent of `task.status`. Wires to the same `spaceWorkflowRun.approveGate` RPC.
- `request_human_input` questions are extracted in `space-task-thread-events.ts` and rendered as a normal "Question" message in the thread. The redundant `human_input_requested` header banner is dropped (the composer below is the reply affordance).