### PR TITLE
fix(space): persist completionActions + backfill workflow template tracking (M94)

### DIFF
--- a/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
@@ -115,6 +115,10 @@ export class SpaceWorkflowManager {
 			this.validateName(existing.spaceId, trimmedName, id);
 			params = { ...params, name: trimmedName };
 		}
+		// IMPORTANT: thread `completionActions` through both branches. The
+		// second branch (existing.nodes rehydration) runs on EVERY update call —
+		// including updates that don't touch nodes — so dropping the field here
+		// silently deletes completionActions from any workflow that had them.
 		const effectiveNodes: WorkflowNodeInput[] =
 			params.nodes !== undefined
 				? (params.nodes ?? []).map(
@@ -122,6 +126,7 @@ export class SpaceWorkflowManager {
 							id: n.id,
 							name: n.name,
 							agents: n.agents,
+							...(n.completionActions ? { completionActions: n.completionActions } : {}),
 						})
 					)
 				: existing.nodes.map(
@@ -129,6 +134,7 @@ export class SpaceWorkflowManager {
 							id: n.id,
 							name: n.name,
 							agents: n.agents,
+							...(n.completionActions ? { completionActions: n.completionActions } : {}),
 						})
 					);
 

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -1138,6 +1138,10 @@ export function seedBuiltInWorkflows(
 					...a,
 					agentId: resolvedIds.get(a.agentId)!,
 				})),
+				// Thread completionActions through to persisted nodes. Without this,
+				// end-node actions like MERGE_PR_COMPLETION_ACTION are silently dropped
+				// so report_result() completes the workflow but the PR never merges.
+				...(s.completionActions ? { completionActions: s.completionActions } : {}),
 			}));
 
 			const startNodeId = nodeIdMap.get(template.startNodeId);

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -45,6 +45,8 @@ export { runMigration74 } from './migrations';
 export { runMigration78 } from './migrations';
 // knip-ignore-next-line
 export { runMigration93 } from './migrations';
+// knip-ignore-next-line
+export { runMigration94 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults

--- a/packages/daemon/src/storage/schema/m94-backfill-workflow-templates.ts
+++ b/packages/daemon/src/storage/schema/m94-backfill-workflow-templates.ts
@@ -1,0 +1,573 @@
+/**
+ * Migration 94 — Backfill workflow template tracking & end-node completion actions.
+ *
+ * Context: two silent field-drop bugs in `seedBuiltInWorkflows()` and
+ * `updateWorkflow()` caused existing workflow rows to be persisted without
+ * their `completionActions`, and earlier versions of the seed predated the
+ * `template_name` / `template_hash` columns. As a result, existing Spaces have
+ * workflows that:
+ *   - Match a built-in template by name but have `template_name = NULL`
+ *     (breaking drift detection and the "Sync from template" UI).
+ *   - Have an end node without `MERGE_PR_COMPLETION_ACTION`, so the Reviewer's
+ *     `report_result()` completes the run but the PR never merges.
+ *
+ * This migration realigns legacy rows with the current built-in templates:
+ *   1. For each `space_workflows` row whose (name, node names) structurally
+ *      matches a known built-in, set `template_name` + `template_hash` if
+ *      missing, and reattach the template's `completionActions` on the end
+ *      node if missing.
+ *   2. Delete orphan duplicate workflows — same (space_id, name) as a newer
+ *      row, older `created_at`, and no active `space_workflow_runs` references.
+ *      Keeps the newer row; drops the earlier superseded seed.
+ *
+ * The migration is idempotent: re-running it on a DB that has already been
+ * backfilled is a no-op (template hashes only get rewritten when they differ).
+ *
+ * Self-contained by design — migrations must not depend on runtime app logic
+ * that may drift over time. The built-in template shapes embedded here reflect
+ * the state of the templates at the time this migration was authored; that
+ * matches exactly what the DB needs to be aligned to.
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+
+// ---------------------------------------------------------------------------
+// Template fingerprints (frozen copy of the built-in templates' hashable shape
+// — node names, channels, gates, description, instructions).
+//
+// These MUST match exactly what `computeWorkflowHash(template)` produces for
+// the current built-in templates. If the built-in templates change, add a
+// follow-up migration rather than modifying this one — migrations are
+// historical.
+// ---------------------------------------------------------------------------
+
+interface GateField {
+	name: string;
+	type: string;
+	check:
+		| { op: 'exists' }
+		| { op: '=='; value: unknown }
+		| { op: 'count'; match: string; min: number };
+}
+
+interface GateShape {
+	id: string;
+	requiredLevel?: number;
+	resetOnCycle?: boolean;
+	fields: GateField[];
+	scriptSource?: string;
+}
+
+interface ChannelShape {
+	from: string;
+	to: string | string[];
+}
+
+interface TemplateShape {
+	name: string;
+	description: string;
+	instructions: string;
+	nodeNames: string[];
+	/** Name of the end node — used to locate which node-row to backfill. */
+	endNodeName: string;
+	channels: ChannelShape[];
+	gates: GateShape[];
+	/** Completion action JSON to attach to the end node, if any. */
+	endNodeCompletionActions?: CompletionActionShape[];
+}
+
+interface CompletionActionShape {
+	id: string;
+	name: string;
+	type: 'script' | 'instruction' | 'mcp_call';
+	requiredLevel: number;
+	artifactType?: string;
+	artifactKey?: string;
+	script?: string;
+	targetNodeId?: string;
+	instruction?: string;
+	server?: string;
+	tool?: string;
+	args?: Record<string, string>;
+}
+
+// Inline bash scripts from built-in-workflows.ts — the actual merge script.
+// Kept inline so the migration is self-contained and stable.
+const PR_MERGE_BASH_SCRIPT = [
+	'# Resolve PR URL from artifact data or current branch',
+	'PR_URL=$(jq -r \'.pr_url // .url // empty\' <<< "${NEOKAI_ARTIFACT_DATA_JSON:-{}}" 2>/dev/null || true)',
+	'if [ -z "$PR_URL" ]; then',
+	'  PR_URL=$(gh pr view --json url -q .url 2>/dev/null || true)',
+	'fi',
+	'if [ -z "$PR_URL" ]; then',
+	'  echo "No PR URL found — cannot merge" >&2',
+	'  exit 1',
+	'fi',
+	'# Idempotency guard: skip merge if PR is already merged',
+	'PR_STATE=$(gh pr view "$PR_URL" --json state -q .state 2>/dev/null || true)',
+	'if [ "$PR_STATE" = "MERGED" ]; then',
+	'  echo "PR already merged: $PR_URL"',
+	'  BASE_BRANCH=$(gh pr view "$PR_URL" --json baseRefName -q .baseRefName 2>/dev/null || echo "main")',
+	'  git checkout "$BASE_BRANCH" 2>/dev/null && git pull --ff-only 2>/dev/null || true',
+	'  jq -n --arg url "$PR_URL" \'{"merged_pr_url":$url,"status":"already_merged"}\'',
+	'  exit 0',
+	'fi',
+	'echo "Merging PR: $PR_URL"',
+	'if ! gh pr merge "$PR_URL" --squash; then',
+	'  echo "Failed to merge PR: $PR_URL" >&2',
+	'  exit 1',
+	'fi',
+	'# Sync worktree with base branch after merge',
+	'BASE_BRANCH=$(gh pr view "$PR_URL" --json baseRefName -q .baseRefName 2>/dev/null || echo "main")',
+	'git checkout "$BASE_BRANCH" 2>/dev/null && git pull --ff-only 2>/dev/null || true',
+	'echo "PR merged and worktree synced"',
+	'jq -n --arg url "$PR_URL" \'{"merged_pr_url":$url,"status":"merged"}\'',
+].join('\n');
+
+const MERGE_PR_COMPLETION_ACTION: CompletionActionShape = {
+	id: 'merge-pr',
+	name: 'Merge PR',
+	type: 'script',
+	requiredLevel: 4,
+	artifactType: 'pr',
+	script: PR_MERGE_BASH_SCRIPT,
+};
+
+const PR_READY_SCRIPT_PREFIX = '# Prefer explicit PR URL from gate data JSON when available; f';
+
+/**
+ * Known built-in templates and their fingerprints.
+ * Order is not significant — matched by `name`.
+ */
+const KNOWN_TEMPLATES: TemplateShape[] = [
+	{
+		name: 'Coding Workflow',
+		description:
+			'Iterative coding workflow with Coding ↔ Review loop. Engineer implements and opens a PR; Reviewer reviews and either requests changes or signals completion.',
+		instructions: '',
+		nodeNames: ['Coding', 'Review'],
+		endNodeName: 'Review',
+		channels: [
+			{ from: 'Coding', to: 'Review' },
+			{ from: 'Review', to: 'Coding' },
+		],
+		gates: [
+			{
+				id: 'code-ready-gate',
+				resetOnCycle: true,
+				fields: [{ name: 'pr_url', type: 'string', check: { op: 'exists' } }],
+				scriptSource: PR_READY_SCRIPT_PREFIX,
+			},
+		],
+		endNodeCompletionActions: [MERGE_PR_COMPLETION_ACTION],
+	},
+	{
+		name: 'Research Workflow',
+		description:
+			'Iterative research workflow with gated PR verification. Research agent investigates and opens a PR; Reviewer evaluates findings and requests revisions if needed.',
+		instructions: '',
+		nodeNames: ['Research', 'Review'],
+		endNodeName: 'Review',
+		channels: [
+			{ from: 'Research', to: 'Review' },
+			{ from: 'Review', to: 'Research' },
+		],
+		gates: [
+			{
+				id: 'research-ready-gate',
+				resetOnCycle: true,
+				fields: [{ name: 'pr_url', type: 'string', check: { op: 'exists' } }],
+				scriptSource: PR_READY_SCRIPT_PREFIX,
+			},
+		],
+		endNodeCompletionActions: [MERGE_PR_COMPLETION_ACTION],
+	},
+	{
+		name: 'Review-Only Workflow',
+		description:
+			'Single-node review workflow with no planning phase. Reviewer evaluates directly; the run completes when done.',
+		instructions: '',
+		nodeNames: ['Review'],
+		endNodeName: 'Review',
+		channels: [],
+		gates: [],
+		endNodeCompletionActions: undefined,
+	},
+	{
+		name: 'Full-Cycle Coding Workflow',
+		description:
+			'Full-cycle coding workflow with planning, plan review, parallel code review, and QA. ' +
+			'QA is the terminal node; feedback from review or QA loops back to Coding.',
+		instructions: '',
+		nodeNames: ['Planning', 'Plan Review', 'Coding', 'Code Review', 'QA'],
+		endNodeName: 'QA',
+		channels: [
+			{ from: 'Planning', to: 'Plan Review' },
+			{ from: 'Plan Review', to: 'Coding' },
+			{ from: 'Coding', to: 'Code Review' },
+			{ from: 'Code Review', to: 'QA' },
+			{ from: 'Code Review', to: 'Coding' },
+			{ from: 'QA', to: 'Coding' },
+			{ from: 'Plan Review', to: 'Planning' },
+			{ from: 'Coding', to: 'Planning' },
+		],
+		gates: [
+			{
+				id: 'plan-pr-gate',
+				resetOnCycle: false,
+				fields: [{ name: 'pr_url', type: 'string', check: { op: 'exists' } }],
+				scriptSource: PR_READY_SCRIPT_PREFIX,
+			},
+			{
+				id: 'plan-approval-gate',
+				requiredLevel: 3,
+				resetOnCycle: true,
+				fields: [{ name: 'approved', type: 'boolean', check: { op: '==', value: true } }],
+			},
+			{
+				id: 'code-pr-gate',
+				resetOnCycle: false,
+				fields: [{ name: 'pr_url', type: 'string', check: { op: 'exists' } }],
+			},
+			{
+				id: 'review-votes-gate',
+				resetOnCycle: true,
+				fields: [{ name: 'votes', type: 'map', check: { op: 'count', match: 'approved', min: 3 } }],
+			},
+		],
+		endNodeCompletionActions: undefined,
+	},
+	{
+		name: 'Coding with QA Workflow',
+		description:
+			'Coder ↔ Reviewer loop with explicit QA validation before completion. ' +
+			'Designed for backend+frontend changes that require thorough test coverage, including browser tests.',
+		instructions: '',
+		nodeNames: ['Coding', 'Review', 'QA'],
+		endNodeName: 'QA',
+		channels: [
+			{ from: 'Coding', to: 'Review' },
+			{ from: 'Review', to: 'QA' },
+			{ from: 'Review', to: 'Coding' },
+			{ from: 'QA', to: 'Coding' },
+		],
+		gates: [
+			{
+				id: 'code-pr-gate',
+				resetOnCycle: true,
+				fields: [{ name: 'pr_url', type: 'string', check: { op: 'exists' } }],
+				scriptSource: PR_READY_SCRIPT_PREFIX,
+			},
+			{
+				id: 'review-approval-gate',
+				resetOnCycle: true,
+				fields: [{ name: 'approved', type: 'boolean', check: { op: '==', value: true } }],
+			},
+		],
+		endNodeCompletionActions: undefined,
+	},
+];
+
+// ---------------------------------------------------------------------------
+// Canonical fingerprint / hash — MUST mirror
+// `packages/daemon/src/lib/space/workflows/template-hash.ts`.
+// ---------------------------------------------------------------------------
+
+interface WorkflowFingerprint {
+	description: string;
+	instructions: string;
+	nodeNames: string[];
+	channels: string[];
+	gates: string[];
+}
+
+function serializeGate(gate: GateShape): string {
+	const fields = gate.fields
+		.map((f) => {
+			const check = f.check;
+			let checkStr = check.op;
+			if (check.op === 'count') {
+				checkStr += `:${String(check.match)}:${check.min}`;
+			} else if (check.op !== 'exists' && 'value' in check && check.value !== undefined) {
+				checkStr += `:${String(check.value)}`;
+			}
+			return `${f.name}:${f.type}:${checkStr}`;
+		})
+		.sort()
+		.join(',');
+	const scriptPrefix = gate.scriptSource ? gate.scriptSource.slice(0, 64) : '';
+	// Matches production `template-hash.ts#buildWorkflowFingerprint` exactly — do
+	// NOT coerce resetOnCycle to a default value here; stringifying `undefined`
+	// is intentional in the canonical serialization.
+	return `${gate.id}|${gate.requiredLevel ?? 0}|${gate.resetOnCycle}|${fields}|${scriptPrefix}`;
+}
+
+function buildTemplateFingerprint(tpl: TemplateShape): WorkflowFingerprint {
+	const nodeNames = [...tpl.nodeNames].sort();
+	const channels = tpl.channels
+		.map((c) => {
+			const to = Array.isArray(c.to) ? [...c.to].sort().join(',') : c.to;
+			return `${c.from}->${to}`;
+		})
+		.sort();
+	const gates = tpl.gates.map(serializeGate).sort();
+	return {
+		description: tpl.description ?? '',
+		instructions: tpl.instructions ?? '',
+		nodeNames,
+		channels,
+		gates,
+	};
+}
+
+function buildWorkflowFingerprintFromDb(
+	row: WorkflowRow,
+	nodeNames: string[]
+): WorkflowFingerprint {
+	const parsedChannels = parseJson<Array<{ from?: string; to?: string | string[] }>>(
+		row.channels,
+		[]
+	);
+	const parsedGates = parseJson<
+		Array<{
+			id?: string;
+			requiredLevel?: number;
+			resetOnCycle?: boolean;
+			fields?: GateField[];
+			script?: { source?: string };
+		}>
+	>(row.gates, []);
+
+	const channels = parsedChannels
+		.filter((c) => typeof c.from === 'string' && c.to != null)
+		.map((c) => {
+			const to = Array.isArray(c.to) ? [...(c.to as string[])].sort().join(',') : (c.to as string);
+			return `${c.from}->${to}`;
+		})
+		.sort();
+
+	const gates = parsedGates
+		.map(
+			(g): GateShape => ({
+				id: g.id ?? '',
+				requiredLevel: g.requiredLevel,
+				resetOnCycle: g.resetOnCycle,
+				fields: Array.isArray(g.fields) ? g.fields : [],
+				scriptSource: g.script?.source,
+			})
+		)
+		.map(serializeGate)
+		.sort();
+
+	return {
+		description: row.description ?? '',
+		instructions: row.instructions ?? '',
+		nodeNames: [...nodeNames].sort(),
+		channels,
+		gates,
+	};
+}
+
+function hashFingerprint(fp: WorkflowFingerprint): string {
+	const json = JSON.stringify(fp);
+	const hasher = new Bun.CryptoHasher('sha256');
+	hasher.update(json);
+	return hasher.digest('hex');
+}
+
+// ---------------------------------------------------------------------------
+// DB row shapes
+// ---------------------------------------------------------------------------
+
+interface WorkflowRow {
+	id: string;
+	space_id: string;
+	name: string;
+	description: string;
+	end_node_id: string | null;
+	channels: string | null;
+	gates: string | null;
+	template_name: string | null;
+	template_hash: string | null;
+	instructions: string | null;
+	created_at: number;
+}
+
+interface NodeRow {
+	id: string;
+	workflow_id: string;
+	name: string;
+	config: string | null;
+}
+
+interface NodeConfigJson {
+	agents?: unknown[];
+	completionActions?: CompletionActionShape[];
+}
+
+function parseJson<T>(raw: string | null | undefined, fallback: T): T {
+	if (!raw) return fallback;
+	try {
+		return JSON.parse(raw) as T;
+	} catch {
+		return fallback;
+	}
+}
+
+function tableExists(db: BunDatabase, tableName: string): boolean {
+	const result = db
+		.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`)
+		.get(tableName);
+	return !!result;
+}
+
+function tableHasColumn(db: BunDatabase, tableName: string, columnName: string): boolean {
+	const result = db
+		.prepare(`SELECT name FROM pragma_table_info('${tableName}') WHERE name = ?`)
+		.get(columnName);
+	return !!result;
+}
+
+// ---------------------------------------------------------------------------
+// Migration entrypoint
+// ---------------------------------------------------------------------------
+
+export function runMigration94(db: BunDatabase): void {
+	if (!tableExists(db, 'space_workflows')) return;
+	if (!tableExists(db, 'space_workflow_nodes')) return;
+	// Guard on template columns — if they don't exist yet (migration 90 hasn't
+	// run), skip silently. The normal migration order runs M90 first.
+	if (!tableHasColumn(db, 'space_workflows', 'template_name')) return;
+	if (!tableHasColumn(db, 'space_workflows', 'template_hash')) return;
+
+	// Pre-compute template hashes keyed by name.
+	const templatesByName = new Map<string, { tpl: TemplateShape; hash: string }>();
+	for (const tpl of KNOWN_TEMPLATES) {
+		const hash = hashFingerprint(buildTemplateFingerprint(tpl));
+		templatesByName.set(tpl.name, { tpl, hash });
+	}
+
+	const workflowRows = db
+		.prepare(
+			`SELECT id, space_id, name, description, end_node_id, channels, gates,
+			        template_name, template_hash, instructions, created_at
+			   FROM space_workflows`
+		)
+		.all() as WorkflowRow[];
+
+	const updateWorkflow = db.prepare(
+		`UPDATE space_workflows SET template_name = ?, template_hash = ? WHERE id = ?`
+	);
+	const updateNodeConfig = db.prepare(`UPDATE space_workflow_nodes SET config = ? WHERE id = ?`);
+	const deleteWorkflow = db.prepare(`DELETE FROM space_workflows WHERE id = ?`);
+
+	// Track which rows are considered "backfilled built-ins" — used below for
+	// orphan duplicate detection. (Only consider matched rows; custom user
+	// workflows are never deleted.)
+	const matchedByKey = new Map<string, WorkflowRow[]>(); // key: `${spaceId}|${name}`
+
+	// -----------------------------------------------------------------------
+	// Pass 1 — structural match + backfill template_name/template_hash and
+	// end-node completionActions.
+	// -----------------------------------------------------------------------
+	for (const row of workflowRows) {
+		const known = templatesByName.get(row.name);
+		if (!known) continue; // custom workflow — leave alone
+
+		const nodeRows = db
+			.prepare(
+				`SELECT id, workflow_id, name, config FROM space_workflow_nodes WHERE workflow_id = ?`
+			)
+			.all(row.id) as NodeRow[];
+
+		const nodeNames = nodeRows.map((n) => n.name);
+
+		// Structural check: node name set must match the template.
+		const tplNames = new Set(known.tpl.nodeNames);
+		if (
+			nodeNames.length !== known.tpl.nodeNames.length ||
+			!nodeNames.every((n) => tplNames.has(n))
+		) {
+			continue;
+		}
+
+		// Fingerprint-hash match — a stronger structural check that verifies
+		// description, channels, and gate internals as well. If the row's
+		// fingerprint already equals the template hash, it's a true match.
+		const rowFp = buildWorkflowFingerprintFromDb(row, nodeNames);
+		const rowHash = hashFingerprint(rowFp);
+		const fingerprintMatches = rowHash === known.hash;
+
+		// Collect for duplicate detection.
+		const key = `${row.space_id}|${row.name}`;
+		const bucket = matchedByKey.get(key);
+		if (bucket) bucket.push(row);
+		else matchedByKey.set(key, [row]);
+
+		// ----- Backfill template_name / template_hash -----
+		// Policy: fill in missing template_name if the structure matches the
+		// template (we're confident about the link even if the user made minor
+		// tweaks). Set template_hash to the computed fingerprint hash of the
+		// current row — so drift detection reflects the current state
+		// faithfully. If the row matches the template exactly, that equals the
+		// canonical template hash.
+		const nextTemplateName = row.template_name ?? known.tpl.name;
+		const nextTemplateHash = fingerprintMatches ? known.hash : (row.template_hash ?? rowHash);
+		if (row.template_name !== nextTemplateName || row.template_hash !== nextTemplateHash) {
+			updateWorkflow.run(nextTemplateName, nextTemplateHash, row.id);
+			row.template_name = nextTemplateName;
+			row.template_hash = nextTemplateHash;
+		}
+
+		// ----- Backfill end-node completionActions -----
+		if (known.tpl.endNodeCompletionActions && known.tpl.endNodeCompletionActions.length > 0) {
+			// Prefer end_node_id when set; otherwise fall back to node matched
+			// by endNodeName.
+			const endNode =
+				nodeRows.find((n) => n.id === row.end_node_id) ??
+				nodeRows.find((n) => n.name === known.tpl.endNodeName);
+			if (endNode) {
+				const cfg = parseJson<NodeConfigJson>(endNode.config, {});
+				const existing = cfg.completionActions ?? [];
+				// Only inject if missing — preserve any custom actions the user
+				// may have added.
+				const hasMergePr = existing.some((a) => a?.id === 'merge-pr');
+				if (!hasMergePr) {
+					const newActions = [...existing, ...known.tpl.endNodeCompletionActions];
+					const newCfg: NodeConfigJson = { ...cfg, completionActions: newActions };
+					updateNodeConfig.run(JSON.stringify(newCfg), endNode.id);
+				}
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Pass 2 — delete orphan duplicate built-ins. Keep the newest `created_at`
+	// per (space_id, name); drop older rows that have no active workflow_run
+	// references.
+	// -----------------------------------------------------------------------
+	const hasRunsTable = tableExists(db, 'space_workflow_runs');
+	// "Active" = any non-terminal WorkflowRunStatus. Terminal statuses are
+	// `'done'` and `'cancelled'`. See packages/shared/src/types/space.ts.
+	const activeRunsCount = hasRunsTable
+		? db.prepare(
+				`SELECT COUNT(*) AS n FROM space_workflow_runs
+				  WHERE workflow_id = ?
+				    AND status IN ('pending', 'in_progress', 'blocked')`
+			)
+		: null;
+
+	for (const [, rows] of matchedByKey) {
+		if (rows.length < 2) continue;
+		// Sort newest first
+		rows.sort((a, b) => b.created_at - a.created_at);
+		const [, ...older] = rows;
+		for (const row of older) {
+			if (activeRunsCount) {
+				const res = activeRunsCount.get(row.id) as { n: number } | undefined;
+				if (res && res.n > 0) continue; // keep — has active runs
+			}
+			deleteWorkflow.run(row.id);
+		}
+	}
+}

--- a/packages/daemon/src/storage/schema/m94-backfill-workflow-templates.ts
+++ b/packages/daemon/src/storage/schema/m94-backfill-workflow-templates.ts
@@ -133,7 +133,12 @@ const MERGE_PR_COMPLETION_ACTION: CompletionActionShape = {
 	script: PR_MERGE_BASH_SCRIPT,
 };
 
-const PR_READY_SCRIPT_PREFIX = '# Prefer explicit PR URL from gate data JSON when available; f';
+// First 64 chars of `PR_READY_BASH_SCRIPT` (joined with \n) — matches what
+// `computeWorkflowHash` captures via `g.script.source.slice(0, 64)`. Must be
+// exactly 64 characters; any shorter and `fingerprintMatches` becomes dead
+// code for templates with scripted gates (Coding, Research, Full-Cycle,
+// Coding+QA) and the migration falls back to the row's own hash.
+const PR_READY_SCRIPT_PREFIX = '# Prefer explicit PR URL from gate data JSON when available; fal';
 
 /**
  * Known built-in templates and their fingerprints.

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -10,6 +10,7 @@
  */
 
 import type { Database as BunDatabase } from 'bun:sqlite';
+import { runMigration94 as runMigration94External } from './m94-backfill-workflow-templates';
 
 /**
  * Run all database migrations
@@ -405,6 +406,20 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	//   the session file can be found even when the effective CWD changes between daemon
 	//   restarts (e.g. when a worktree is added/removed after the session was started).
 	runMigration93(db);
+
+	// Migration 94: Backfill workflow template tracking and end-node completion actions
+	//   for workflows seeded by earlier code paths that silently dropped these fields.
+	//   Also removes orphan duplicate built-in workflow rows that have no active runs.
+	runMigration94(db);
+}
+
+/**
+ * Migration 94 — delegated to m94-backfill-workflow-templates.ts so the large
+ * backfill block doesn't bloat this file. The behaviour is documented in that
+ * module. Exported for direct invocation from tests.
+ */
+export function runMigration94(db: BunDatabase): void {
+	runMigration94External(db);
 }
 
 /**

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-94_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-94_test.ts
@@ -1,0 +1,586 @@
+/**
+ * Migration 94 Tests — Backfill workflow template tracking & end-node
+ * completion actions.
+ *
+ * Migration 94 realigns legacy `space_workflows` rows with the current built-in
+ * templates by:
+ *   - Setting `template_name` + `template_hash` on rows whose node names
+ *     structurally match a known template.
+ *   - Re-injecting `MERGE_PR_COMPLETION_ACTION` on end nodes that lost it (seed
+ *     bug A).
+ *   - Deleting orphan duplicate rows that have no active `space_workflow_runs`
+ *     references.
+ *
+ * Covers:
+ *   - Legacy Coding Workflow backfill (template_name + canonical template_hash
+ *     + merge-pr injected on Review end node)
+ *   - Legacy Research Workflow backfill (similar)
+ *   - Review-Only / Full-Cycle workflows backfill template_name but do NOT
+ *     inject completionActions (those templates have no end-node actions)
+ *   - Hash self-verification: the hashes my inlined fingerprints produce for
+ *     each of the 5 built-in templates must match the canonical
+ *     `computeWorkflowHash()` output. This guards against fingerprint drift.
+ *   - Idempotency: running twice yields the same result
+ *   - Custom workflows (non-template name) are untouched
+ *   - Orphan duplicate deletion: older row deleted when no active runs
+ *   - Orphan duplicate retention: older row kept when active runs reference it
+ *   - Existing completionActions on end node preserved (no duplicate injection)
+ *   - Rows with non-matching node structure are not treated as templates
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../../src/storage/schema/index.ts';
+import { runMigration94 } from '../../../../../src/storage/schema/migrations.ts';
+import { getBuiltInWorkflows } from '../../../../../src/lib/space/workflows/built-in-workflows.ts';
+import { computeWorkflowHash } from '../../../../../src/lib/space/workflows/template-hash.ts';
+
+interface WorkflowRow {
+	id: string;
+	template_name: string | null;
+	template_hash: string | null;
+}
+
+interface NodeRow {
+	id: string;
+	config: string | null;
+}
+
+function insertSpace(db: BunDatabase, id: string): void {
+	const now = Date.now();
+	db.prepare(
+		`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`
+	).run(id, id, '/ws', id, now, now);
+}
+
+function insertWorkflow(
+	db: BunDatabase,
+	opts: {
+		id: string;
+		spaceId: string;
+		name: string;
+		description?: string;
+		channels?: unknown[];
+		gates?: unknown[];
+		startNodeId?: string | null;
+		endNodeId?: string | null;
+		templateName?: string | null;
+		templateHash?: string | null;
+		createdAt?: number;
+	}
+): void {
+	const now = opts.createdAt ?? Date.now();
+	db.prepare(
+		`INSERT INTO space_workflows (
+			id, space_id, name, description, start_node_id, end_node_id,
+			tags, channels, gates, created_at, updated_at, template_name, template_hash
+		 ) VALUES (?, ?, ?, ?, ?, ?, '[]', ?, ?, ?, ?, ?, ?)`
+	).run(
+		opts.id,
+		opts.spaceId,
+		opts.name,
+		opts.description ?? '',
+		opts.startNodeId ?? null,
+		opts.endNodeId ?? null,
+		JSON.stringify(opts.channels ?? []),
+		JSON.stringify(opts.gates ?? []),
+		now,
+		now,
+		opts.templateName ?? null,
+		opts.templateHash ?? null
+	);
+}
+
+function insertNode(
+	db: BunDatabase,
+	opts: { id: string; workflowId: string; name: string; config?: unknown }
+): void {
+	const now = Date.now();
+	db.prepare(
+		`INSERT INTO space_workflow_nodes (id, workflow_id, name, config, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`
+	).run(
+		opts.id,
+		opts.workflowId,
+		opts.name,
+		JSON.stringify(opts.config ?? { agents: [] }),
+		now,
+		now
+	);
+}
+
+function insertRun(
+	db: BunDatabase,
+	opts: { id: string; spaceId: string; workflowId: string; status: string }
+): void {
+	const now = Date.now();
+	db.prepare(
+		`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`
+	).run(opts.id, opts.spaceId, opts.workflowId, 'run', opts.status, now, now);
+}
+
+function readWorkflow(db: BunDatabase, id: string): WorkflowRow | undefined {
+	return db
+		.prepare(`SELECT id, template_name, template_hash FROM space_workflows WHERE id = ?`)
+		.get(id) as WorkflowRow | undefined;
+}
+
+function readNodeConfig(db: BunDatabase, id: string): Record<string, unknown> {
+	const row = db.prepare(`SELECT id, config FROM space_workflow_nodes WHERE id = ?`).get(id) as
+		| NodeRow
+		| undefined;
+	return row?.config ? (JSON.parse(row.config) as Record<string, unknown>) : {};
+}
+
+function seedLegacyCodingWorkflow(
+	db: BunDatabase,
+	opts: {
+		id: string;
+		spaceId: string;
+		createdAt?: number;
+		/** Default false — null template_name simulates pre-M90 legacy rows. */
+		withTemplateFields?: boolean;
+		/** Default false — when true, end node has completionActions already. */
+		withCompletionActions?: boolean;
+	}
+): { workflowId: string; codingNodeId: string; reviewNodeId: string } {
+	const template = getBuiltInWorkflows().find((t) => t.name === 'Coding Workflow');
+	if (!template) throw new Error('Coding Workflow template missing');
+
+	const codingNodeId = `${opts.id}-n-coding`;
+	const reviewNodeId = `${opts.id}-n-review`;
+
+	insertWorkflow(db, {
+		id: opts.id,
+		spaceId: opts.spaceId,
+		name: template.name,
+		description: template.description,
+		channels: template.channels ?? [],
+		gates: template.gates ?? [],
+		startNodeId: codingNodeId,
+		endNodeId: reviewNodeId,
+		templateName: opts.withTemplateFields ? template.name : null,
+		templateHash: opts.withTemplateFields ? computeWorkflowHash(template) : null,
+		createdAt: opts.createdAt,
+	});
+
+	insertNode(db, {
+		id: codingNodeId,
+		workflowId: opts.id,
+		name: 'Coding',
+		config: { agents: [{ agentId: 'a-coder', name: 'coder' }] },
+	});
+
+	const reviewConfig: Record<string, unknown> = {
+		agents: [{ agentId: 'a-reviewer', name: 'reviewer' }],
+	};
+	if (opts.withCompletionActions) {
+		reviewConfig.completionActions = [
+			{
+				id: 'merge-pr',
+				name: 'Merge PR',
+				type: 'script',
+				requiredLevel: 4,
+				artifactType: 'pr',
+				script: '# existing script',
+			},
+		];
+	}
+	insertNode(db, { id: reviewNodeId, workflowId: opts.id, name: 'Review', config: reviewConfig });
+
+	return { workflowId: opts.id, codingNodeId, reviewNodeId };
+}
+
+describe('Migration 94: backfill workflow template tracking & completion actions', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(
+			process.cwd(),
+			'tmp',
+			'test-migration-94',
+			`test-${Date.now()}-${Math.random()}`
+		);
+		mkdirSync(testDir, { recursive: true });
+		db = new BunDatabase(join(testDir, 'test.db'));
+		db.exec('PRAGMA foreign_keys = ON');
+		runMigrations(db, () => {});
+		insertSpace(db, 'sp-1');
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	test('hash self-verification: inlined template fingerprints match computeWorkflowHash', () => {
+		// For each built-in template, insert a workflow with the exact template
+		// shape and verify that M94 sets template_hash to the canonical hash.
+		// This guards against fingerprint drift between M94's inlined copies
+		// and the live built-in template definitions.
+		const templates = getBuiltInWorkflows();
+		for (const [i, tpl] of templates.entries()) {
+			const wfId = `wf-verify-${i}`;
+			const endNodeId = `n-${i}-end`;
+			const nodeIds = tpl.nodes.map((n) => ({ id: `n-${i}-${n.name}`, name: n.name }));
+			const resolvedEndNodeId =
+				nodeIds.find((n) => n.name === tpl.nodes.find((x) => x.id === tpl.endNodeId)?.name)?.id ??
+				endNodeId;
+
+			insertWorkflow(db, {
+				id: wfId,
+				spaceId: 'sp-1',
+				name: tpl.name,
+				description: tpl.description,
+				channels: tpl.channels ?? [],
+				gates: tpl.gates ?? [],
+				endNodeId: resolvedEndNodeId,
+			});
+			for (const n of nodeIds) {
+				insertNode(db, { id: n.id, workflowId: wfId, name: n.name });
+			}
+		}
+
+		runMigration94(db);
+
+		for (const [i, tpl] of templates.entries()) {
+			const row = readWorkflow(db, `wf-verify-${i}`);
+			const expectedHash = computeWorkflowHash(tpl);
+			expect(row?.template_name).toBe(tpl.name);
+			expect(row?.template_hash).toBe(expectedHash);
+		}
+	});
+
+	test('legacy Coding Workflow: sets template_name + canonical hash + injects merge-pr', () => {
+		const { workflowId, reviewNodeId } = seedLegacyCodingWorkflow(db, {
+			id: 'wf-1',
+			spaceId: 'sp-1',
+		});
+
+		runMigration94(db);
+
+		const template = getBuiltInWorkflows().find((t) => t.name === 'Coding Workflow')!;
+		const expectedHash = computeWorkflowHash(template);
+
+		const row = readWorkflow(db, workflowId)!;
+		expect(row.template_name).toBe('Coding Workflow');
+		expect(row.template_hash).toBe(expectedHash);
+
+		const cfg = readNodeConfig(db, reviewNodeId) as {
+			completionActions?: Array<{ id: string; type: string; artifactType?: string }>;
+		};
+		expect(cfg.completionActions).toBeDefined();
+		expect(cfg.completionActions).toHaveLength(1);
+		expect(cfg.completionActions?.[0]?.id).toBe('merge-pr');
+		expect(cfg.completionActions?.[0]?.type).toBe('script');
+		expect(cfg.completionActions?.[0]?.artifactType).toBe('pr');
+	});
+
+	test('legacy Research Workflow: sets template_name + canonical hash + injects merge-pr', () => {
+		const template = getBuiltInWorkflows().find((t) => t.name === 'Research Workflow')!;
+		const expectedHash = computeWorkflowHash(template);
+
+		const wfId = 'wf-research';
+		const researchNodeId = 'n-r-research';
+		const reviewNodeId = 'n-r-review';
+
+		insertWorkflow(db, {
+			id: wfId,
+			spaceId: 'sp-1',
+			name: template.name,
+			description: template.description,
+			channels: template.channels ?? [],
+			gates: template.gates ?? [],
+			endNodeId: reviewNodeId,
+		});
+		insertNode(db, { id: researchNodeId, workflowId: wfId, name: 'Research' });
+		insertNode(db, { id: reviewNodeId, workflowId: wfId, name: 'Review' });
+
+		runMigration94(db);
+
+		const row = readWorkflow(db, wfId)!;
+		expect(row.template_name).toBe('Research Workflow');
+		expect(row.template_hash).toBe(expectedHash);
+
+		const cfg = readNodeConfig(db, reviewNodeId) as {
+			completionActions?: Array<{ id: string }>;
+		};
+		expect(cfg.completionActions?.some((a) => a.id === 'merge-pr')).toBe(true);
+	});
+
+	test('Review-Only Workflow: sets template_name but does not inject completionActions', () => {
+		const template = getBuiltInWorkflows().find((t) => t.name === 'Review-Only Workflow')!;
+		const expectedHash = computeWorkflowHash(template);
+
+		const wfId = 'wf-review-only';
+		const reviewNodeId = 'n-ro-review';
+
+		insertWorkflow(db, {
+			id: wfId,
+			spaceId: 'sp-1',
+			name: template.name,
+			description: template.description,
+			channels: template.channels ?? [],
+			gates: template.gates ?? [],
+			endNodeId: reviewNodeId,
+		});
+		insertNode(db, { id: reviewNodeId, workflowId: wfId, name: 'Review' });
+
+		runMigration94(db);
+
+		const row = readWorkflow(db, wfId)!;
+		expect(row.template_name).toBe('Review-Only Workflow');
+		expect(row.template_hash).toBe(expectedHash);
+
+		const cfg = readNodeConfig(db, reviewNodeId) as { completionActions?: unknown[] };
+		// Review-Only has no endNodeCompletionActions; migration must not inject.
+		expect(cfg.completionActions).toBeUndefined();
+	});
+
+	test('idempotent — running twice yields the same result', () => {
+		const { workflowId, reviewNodeId } = seedLegacyCodingWorkflow(db, {
+			id: 'wf-idem',
+			spaceId: 'sp-1',
+		});
+
+		runMigration94(db);
+		const rowAfter1 = readWorkflow(db, workflowId)!;
+		const cfgAfter1 = readNodeConfig(db, reviewNodeId);
+
+		runMigration94(db);
+		const rowAfter2 = readWorkflow(db, workflowId)!;
+		const cfgAfter2 = readNodeConfig(db, reviewNodeId);
+
+		expect(rowAfter2).toEqual(rowAfter1);
+		expect(cfgAfter2).toEqual(cfgAfter1);
+
+		// And the end-node still has exactly one merge-pr action — no duplication.
+		const actions = (cfgAfter2 as { completionActions?: Array<{ id: string }> }).completionActions!;
+		expect(actions.filter((a) => a.id === 'merge-pr')).toHaveLength(1);
+	});
+
+	test('custom workflow with non-matching name is untouched', () => {
+		const wfId = 'wf-custom';
+		insertWorkflow(db, {
+			id: wfId,
+			spaceId: 'sp-1',
+			name: 'My Custom Workflow',
+			description: 'a custom workflow',
+			endNodeId: 'n-c',
+		});
+		insertNode(db, { id: 'n-c', workflowId: wfId, name: 'Custom' });
+
+		runMigration94(db);
+
+		const row = readWorkflow(db, wfId)!;
+		expect(row.template_name).toBeNull();
+		expect(row.template_hash).toBeNull();
+	});
+
+	test('row with matching name but non-matching node structure is NOT treated as a template', () => {
+		// Same name as a template, but wrong node count / names — migration should
+		// skip the fingerprint match and leave template_name unset.
+		const wfId = 'wf-impostor';
+		insertWorkflow(db, {
+			id: wfId,
+			spaceId: 'sp-1',
+			name: 'Coding Workflow',
+			description: 'imposter',
+			endNodeId: 'n-i',
+		});
+		insertNode(db, { id: 'n-i', workflowId: wfId, name: 'NotCodingNotReview' });
+
+		runMigration94(db);
+
+		const row = readWorkflow(db, wfId)!;
+		expect(row.template_name).toBeNull();
+		expect(row.template_hash).toBeNull();
+	});
+
+	test('existing completionActions on end node preserved (no duplicate injection)', () => {
+		const { workflowId, reviewNodeId } = seedLegacyCodingWorkflow(db, {
+			id: 'wf-has-action',
+			spaceId: 'sp-1',
+			withCompletionActions: true, // already has merge-pr
+		});
+
+		runMigration94(db);
+
+		const cfg = readNodeConfig(db, reviewNodeId) as {
+			completionActions?: Array<{ id: string; script?: string }>;
+		};
+		// Must not duplicate — already had a merge-pr with "# existing script".
+		expect(cfg.completionActions).toHaveLength(1);
+		expect(cfg.completionActions?.[0]?.id).toBe('merge-pr');
+		expect(cfg.completionActions?.[0]?.script).toBe('# existing script');
+
+		// template_name + hash still set.
+		const row = readWorkflow(db, workflowId)!;
+		expect(row.template_name).toBe('Coding Workflow');
+	});
+
+	test('orphan duplicate deleted when it has no active runs', () => {
+		// Insert two same-name Coding Workflow rows; older one has no runs.
+		const older = seedLegacyCodingWorkflow(db, {
+			id: 'wf-older',
+			spaceId: 'sp-1',
+			createdAt: 1000,
+		});
+		const newer = seedLegacyCodingWorkflow(db, {
+			id: 'wf-newer',
+			spaceId: 'sp-1',
+			createdAt: 2000,
+		});
+
+		runMigration94(db);
+
+		expect(readWorkflow(db, newer.workflowId)).toBeDefined();
+		expect(readWorkflow(db, older.workflowId)).toBeNull();
+	});
+
+	test('duplicate retained when it has active runs', () => {
+		const older = seedLegacyCodingWorkflow(db, {
+			id: 'wf-older-active',
+			spaceId: 'sp-1',
+			createdAt: 1000,
+		});
+		const newer = seedLegacyCodingWorkflow(db, {
+			id: 'wf-newer-active',
+			spaceId: 'sp-1',
+			createdAt: 2000,
+		});
+
+		// Active run on older row
+		insertRun(db, {
+			id: 'run-1',
+			spaceId: 'sp-1',
+			workflowId: older.workflowId,
+			status: 'in_progress',
+		});
+
+		runMigration94(db);
+
+		expect(readWorkflow(db, newer.workflowId)).toBeDefined();
+		expect(readWorkflow(db, older.workflowId)).toBeDefined(); // kept — has active run
+	});
+
+	test('duplicate retained when only run is pending (still active)', () => {
+		const older = seedLegacyCodingWorkflow(db, {
+			id: 'wf-older-pending',
+			spaceId: 'sp-1',
+			createdAt: 1000,
+		});
+		const newer = seedLegacyCodingWorkflow(db, {
+			id: 'wf-newer-pending',
+			spaceId: 'sp-1',
+			createdAt: 2000,
+		});
+
+		insertRun(db, {
+			id: 'run-p',
+			spaceId: 'sp-1',
+			workflowId: older.workflowId,
+			status: 'pending',
+		});
+
+		runMigration94(db);
+
+		expect(readWorkflow(db, older.workflowId)).toBeDefined();
+		expect(readWorkflow(db, newer.workflowId)).toBeDefined();
+	});
+
+	test('duplicate deleted when its only runs are terminal (done/cancelled)', () => {
+		const older = seedLegacyCodingWorkflow(db, {
+			id: 'wf-older-done',
+			spaceId: 'sp-1',
+			createdAt: 1000,
+		});
+		const newer = seedLegacyCodingWorkflow(db, {
+			id: 'wf-newer-done',
+			spaceId: 'sp-1',
+			createdAt: 2000,
+		});
+
+		insertRun(db, {
+			id: 'run-done',
+			spaceId: 'sp-1',
+			workflowId: older.workflowId,
+			status: 'done',
+		});
+		insertRun(db, {
+			id: 'run-cancelled',
+			spaceId: 'sp-1',
+			workflowId: older.workflowId,
+			status: 'cancelled',
+		});
+
+		runMigration94(db);
+
+		// All runs terminal → older considered orphan → deleted.
+		expect(readWorkflow(db, older.workflowId)).toBeNull();
+		expect(readWorkflow(db, newer.workflowId)).toBeDefined();
+	});
+
+	test('custom workflow rows never considered for duplicate deletion', () => {
+		// Two custom workflows with same name — neither should be deleted because
+		// they are not treated as built-ins.
+		insertWorkflow(db, {
+			id: 'wf-c1',
+			spaceId: 'sp-1',
+			name: 'Custom Workflow',
+			createdAt: 1000,
+			endNodeId: 'n-c1',
+		});
+		insertNode(db, { id: 'n-c1', workflowId: 'wf-c1', name: 'N' });
+
+		insertWorkflow(db, {
+			id: 'wf-c2',
+			spaceId: 'sp-1',
+			name: 'Custom Workflow',
+			createdAt: 2000,
+			endNodeId: 'n-c2',
+		});
+		insertNode(db, { id: 'n-c2', workflowId: 'wf-c2', name: 'N' });
+
+		runMigration94(db);
+
+		expect(readWorkflow(db, 'wf-c1')).toBeDefined();
+		expect(readWorkflow(db, 'wf-c2')).toBeDefined();
+	});
+
+	test('row already backfilled is left alone (no redundant writes)', () => {
+		const template = getBuiltInWorkflows().find((t) => t.name === 'Coding Workflow')!;
+		const { workflowId, reviewNodeId } = seedLegacyCodingWorkflow(db, {
+			id: 'wf-already-backfilled',
+			spaceId: 'sp-1',
+			withTemplateFields: true,
+			withCompletionActions: true,
+		});
+
+		const beforeRow = readWorkflow(db, workflowId)!;
+		const beforeCfg = readNodeConfig(db, reviewNodeId);
+
+		runMigration94(db);
+
+		const afterRow = readWorkflow(db, workflowId)!;
+		const afterCfg = readNodeConfig(db, reviewNodeId);
+
+		expect(afterRow.template_name).toBe(template.name);
+		expect(afterRow.template_hash).toBe(computeWorkflowHash(template));
+		expect(afterCfg).toEqual(beforeCfg);
+		expect(afterRow).toEqual(beforeRow);
+	});
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-94_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-94_test.ts
@@ -264,6 +264,42 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 		}
 	});
 
+	test('divergent row (structure matches template but description differs) → template_hash reflects the row, not the canonical template', () => {
+		// Pins the ELSE branch of `fingerprintMatches ? known.hash : rowHash` in
+		// the migration. Combined with `hash self-verification` above (which
+		// covers the TRUE branch), both branches are exercised.
+		const template = getBuiltInWorkflows().find((t) => t.name === 'Coding Workflow')!;
+		const canonicalHash = computeWorkflowHash(template);
+
+		// Same name + node set as Coding Workflow, but with a tweaked description
+		// — so the structural name match passes but fingerprintMatches is false.
+		const wfId = 'wf-diverged';
+		const codingId = 'n-d-coding';
+		const reviewId = 'n-d-review';
+		insertWorkflow(db, {
+			id: wfId,
+			spaceId: 'sp-1',
+			name: template.name,
+			description: template.description + ' — user edited',
+			channels: template.channels ?? [],
+			gates: template.gates ?? [],
+			endNodeId: reviewId,
+		});
+		insertNode(db, { id: codingId, workflowId: wfId, name: 'Coding' });
+		insertNode(db, { id: reviewId, workflowId: wfId, name: 'Review' });
+
+		runMigration94(db);
+
+		const row = readWorkflow(db, wfId)!;
+		// template_name still set — we're confident it's a Coding Workflow variant.
+		expect(row.template_name).toBe('Coding Workflow');
+		// template_hash must NOT be the canonical hash (fingerprint differs).
+		expect(row.template_hash).not.toBe(canonicalHash);
+		// And it must be non-null — the migration populates it with the row's
+		// own fingerprint hash so drift detection reflects the current state.
+		expect(row.template_hash).toBeTruthy();
+	});
+
 	test('legacy Coding Workflow: sets template_name + canonical hash + injects merge-pr', () => {
 		const { workflowId, reviewNodeId } = seedLegacyCodingWorkflow(db, {
 			id: 'wf-1',

--- a/packages/daemon/tests/unit/5-space/workflow/completion-actions-persistence.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/completion-actions-persistence.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Regression tests for completionActions + templateName/templateHash persistence.
+ *
+ * Context: two silent field-drop bugs prevented `completionActions` from
+ * reaching the database:
+ *   - Bug A: `seedBuiltInWorkflows()` mapped template nodes without threading
+ *     `completionActions`, so MERGE_PR_COMPLETION_ACTION never landed on the
+ *     end node. Reviewer's `report_result()` completed the run but the PR
+ *     stayed open.
+ *   - Bug B: `updateWorkflow()` built its `effectiveNodes` list for validation
+ *     without preserving `completionActions`. Any subsequent update call (even
+ *     a plain rename) would silently strip the action if the field threading
+ *     were extended to the persistence layer.
+ *
+ * These tests lock in:
+ *   1. Seed path: end nodes in Coding Workflow and Research Workflow land in
+ *      the DB with MERGE_PR_COMPLETION_ACTION attached.
+ *   2. Update path: a rename/update preserves both completionActions and
+ *      templateName/templateHash on disk.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
+import {
+	CODING_WORKFLOW,
+	RESEARCH_WORKFLOW,
+	REVIEW_ONLY_WORKFLOW,
+	seedBuiltInWorkflows,
+} from '../../../../src/lib/space/workflows/built-in-workflows.ts';
+import { computeWorkflowHash } from '../../../../src/lib/space/workflows/template-hash.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(): { db: BunDatabase; dir: string } {
+	const dir = join(
+		process.cwd(),
+		'tmp',
+		'test-completion-actions-persistence',
+		`t-${Date.now()}-${Math.random()}`
+	);
+	mkdirSync(dir, { recursive: true });
+	const db = new BunDatabase(join(dir, 'test.db'));
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	return { db, dir };
+}
+
+function seedSpace(db: BunDatabase, spaceId: string): void {
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, `/tmp/ws-${spaceId}`, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
+}
+
+function seedAgent(db: BunDatabase, agentId: string, spaceId: string, name: string): void {
+	db.prepare(
+		`INSERT INTO space_agents (id, space_id, name, description, model, tools, custom_prompt, created_at, updated_at)
+     VALUES (?, ?, ?, '', null, '[]', null, ?, ?)`
+	).run(agentId, spaceId, name, Date.now(), Date.now());
+}
+
+const SPACE_ID = 'space-capp';
+const AGENT_IDS = {
+	planner: 'agent-planner',
+	coder: 'agent-coder',
+	general: 'agent-general',
+	research: 'agent-research',
+	reviewer: 'agent-reviewer',
+	qa: 'agent-qa',
+};
+const roleMap: Record<string, string> = {
+	planner: AGENT_IDS.planner,
+	coder: AGENT_IDS.coder,
+	general: AGENT_IDS.general,
+	research: AGENT_IDS.research,
+	reviewer: AGENT_IDS.reviewer,
+	qa: AGENT_IDS.qa,
+};
+const resolveAgentId = (role: string): string | undefined => roleMap[role.toLowerCase()];
+
+function seedWithAllAgents(db: BunDatabase): void {
+	seedSpace(db, SPACE_ID);
+	seedAgent(db, AGENT_IDS.planner, SPACE_ID, 'Planner');
+	seedAgent(db, AGENT_IDS.coder, SPACE_ID, 'Coder');
+	seedAgent(db, AGENT_IDS.general, SPACE_ID, 'General');
+	seedAgent(db, AGENT_IDS.research, SPACE_ID, 'Research');
+	seedAgent(db, AGENT_IDS.reviewer, SPACE_ID, 'Reviewer');
+	seedAgent(db, AGENT_IDS.qa, SPACE_ID, 'QA');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('completionActions persistence — seed path (Bug A regression)', () => {
+	let db: BunDatabase;
+	let dir: string;
+	let manager: SpaceWorkflowManager;
+
+	beforeEach(() => {
+		({ db, dir } = makeDb());
+		seedWithAllAgents(db);
+		manager = new SpaceWorkflowManager(new SpaceWorkflowRepository(db));
+		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			/* ignore */
+		}
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	test('Coding Workflow end node has MERGE_PR_COMPLETION_ACTION attached', () => {
+		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name);
+		expect(wf).toBeDefined();
+		const endNode = wf!.nodes.find((n) => n.id === wf!.endNodeId);
+		expect(endNode).toBeDefined();
+		expect(endNode!.completionActions).toBeDefined();
+		const mergePr = endNode!.completionActions!.find((a) => a.id === 'merge-pr');
+		expect(mergePr).toBeDefined();
+		expect(mergePr!.type).toBe('script');
+		expect(mergePr!.artifactType).toBe('pr');
+		expect(mergePr!.requiredLevel).toBe(4);
+	});
+
+	test('Research Workflow end node has MERGE_PR_COMPLETION_ACTION attached', () => {
+		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === RESEARCH_WORKFLOW.name);
+		expect(wf).toBeDefined();
+		const endNode = wf!.nodes.find((n) => n.id === wf!.endNodeId);
+		expect(endNode).toBeDefined();
+		expect(endNode!.completionActions?.some((a) => a.id === 'merge-pr')).toBe(true);
+	});
+
+	test('Review-Only Workflow end node has no completionActions (template has none)', () => {
+		// Negative control — only templates with endNodeCompletionActions should
+		// persist them. Review-Only explicitly has none; if we ever start injecting
+		// stray actions, this test catches it.
+		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === REVIEW_ONLY_WORKFLOW.name);
+		expect(wf).toBeDefined();
+		const endNode = wf!.nodes.find((n) => n.id === wf!.endNodeId);
+		expect(endNode).toBeDefined();
+		expect(endNode!.completionActions).toBeUndefined();
+	});
+
+	test('seeded workflows persist templateName + canonical templateHash', () => {
+		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name);
+		expect(wf).toBeDefined();
+		expect(wf!.templateName).toBe(CODING_WORKFLOW.name);
+		expect(wf!.templateHash).toBe(computeWorkflowHash(CODING_WORKFLOW));
+	});
+});
+
+describe('completionActions persistence — updateWorkflow round-trip (Bug B regression)', () => {
+	let db: BunDatabase;
+	let dir: string;
+	let manager: SpaceWorkflowManager;
+
+	beforeEach(() => {
+		({ db, dir } = makeDb());
+		seedWithAllAgents(db);
+		manager = new SpaceWorkflowManager(new SpaceWorkflowRepository(db));
+		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			/* ignore */
+		}
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	test('rename-only update preserves completionActions on end node', () => {
+		const before = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
+		const beforeEndNode = before.nodes.find((n) => n.id === before.endNodeId)!;
+		expect(beforeEndNode.completionActions?.some((a) => a.id === 'merge-pr')).toBe(true);
+
+		const updated = manager.updateWorkflow(before.id, { name: 'Coding Workflow (renamed)' });
+		expect(updated).toBeDefined();
+
+		const after = manager.getWorkflow(before.id)!;
+		expect(after.name).toBe('Coding Workflow (renamed)');
+		const afterEndNode = after.nodes.find((n) => n.id === after.endNodeId)!;
+		expect(afterEndNode.completionActions?.some((a) => a.id === 'merge-pr')).toBe(true);
+		// Full action survives unchanged
+		const action = afterEndNode.completionActions!.find((a) => a.id === 'merge-pr')!;
+		const beforeAction = beforeEndNode.completionActions!.find((a) => a.id === 'merge-pr')!;
+		expect(action).toEqual(beforeAction);
+	});
+
+	test('rename-only update preserves templateName + templateHash', () => {
+		const before = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
+		const beforeName = before.templateName;
+		const beforeHash = before.templateHash;
+		expect(beforeName).toBe(CODING_WORKFLOW.name);
+		expect(beforeHash).toBe(computeWorkflowHash(CODING_WORKFLOW));
+
+		manager.updateWorkflow(before.id, { name: 'Coding Workflow v2' });
+
+		const after = manager.getWorkflow(before.id)!;
+		expect(after.templateName).toBe(beforeName);
+		expect(after.templateHash).toBe(beforeHash);
+	});
+
+	test('node update that omits completionActions on one node preserves the one that has them', () => {
+		// Caller sends nodes without specifying completionActions → manager should
+		// not silently clobber existing completionActions on other nodes. This is
+		// a defensive test for a class of bugs in the update path.
+		const before = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
+		const codingNode = before.nodes.find((n) => n.name === 'Coding')!;
+		const reviewNode = before.nodes.find((n) => n.name === 'Review')!;
+		expect(reviewNode.completionActions?.some((a) => a.id === 'merge-pr')).toBe(true);
+
+		// Pass nodes back as-is (mimicking a UI that re-emits the full node list
+		// on every save, preserving each node's completionActions).
+		manager.updateWorkflow(before.id, {
+			nodes: [
+				{
+					id: codingNode.id,
+					name: codingNode.name,
+					agents: codingNode.agents,
+				},
+				{
+					id: reviewNode.id,
+					name: reviewNode.name,
+					agents: reviewNode.agents,
+					completionActions: reviewNode.completionActions,
+				},
+			],
+		});
+
+		const after = manager.getWorkflow(before.id)!;
+		const afterReview = after.nodes.find((n) => n.name === 'Review')!;
+		expect(afterReview.completionActions?.some((a) => a.id === 'merge-pr')).toBe(true);
+	});
+
+	test('update with explicit completionActions=[] on a node clears them (caller intent honored)', () => {
+		// Complements the test above — confirms that when a caller explicitly
+		// passes an empty completionActions array, the update path respects that.
+		const before = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
+		const reviewNode = before.nodes.find((n) => n.name === 'Review')!;
+		const codingNode = before.nodes.find((n) => n.name === 'Coding')!;
+
+		manager.updateWorkflow(before.id, {
+			nodes: [
+				{
+					id: codingNode.id,
+					name: codingNode.name,
+					agents: codingNode.agents,
+				},
+				{
+					id: reviewNode.id,
+					name: reviewNode.name,
+					agents: reviewNode.agents,
+					completionActions: [],
+				},
+			],
+		});
+
+		const after = manager.getWorkflow(before.id)!;
+		const afterReview = after.nodes.find((n) => n.name === 'Review')!;
+		// Empty array → end node has no actions (repo stores `undefined` when
+		// empty array). Either empty array or undefined is acceptable; assert
+		// that no action is present.
+		expect(afterReview.completionActions?.length ?? 0).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary

Two silent field-drop bugs caused built-in workflow rows to be persisted without their `completionActions`, and a subset of older Spaces also predated the `template_name`/`template_hash` columns. Concretely: the Reviewer's `report_result()` would complete the workflow run but **`MERGE_PR_COMPLETION_ACTION` was never attached to the Review end node**, so the PR stayed open.

- `seedBuiltInWorkflows()` → mapped template nodes without threading `completionActions`
- `SpaceWorkflowManager.updateWorkflow()` → rebuilt `effectiveNodes` without `completionActions` on both branches; the "existing nodes rehydration" branch runs on every update (including plain renames)

Fix both call sites and add a one-time backfill migration (M94) that realigns legacy rows with the current built-in templates and collapses orphan duplicate seeds.

## What M94 does

1. For each `space_workflows` row whose (name, node name set) matches a known built-in template, set `template_name` + `template_hash` if missing and reattach the template's `completionActions` on the end node if missing.
2. Delete orphan duplicate built-in rows — same name, older `created_at`, no active `space_workflow_runs` references. Runs in statuses `pending | in_progress | blocked` retain their workflow.

Idempotent and self-contained: template fingerprints are inlined so behaviour can't drift if live templates change later. A hash self-verification test locks the inlined fingerprints to `computeWorkflowHash()` output.

## Verification

Before (example):
```sql
SELECT id, name, template_name, template_hash FROM space_workflows WHERE space_id = ?;
-- template_name = NULL, template_hash = NULL for Coding/Research rows
SELECT json_extract(config, '$.completionActions') FROM space_workflow_nodes WHERE id = ?;
-- NULL for Review end node
```

After M94:
```sql
-- template_name = 'Coding Workflow', template_hash = fd03c6b1...
-- end-node config now contains [{"id":"merge-pr","type":"script","artifactType":"pr",...}]
```

## Test plan

- [x] New regression tests: seed path (Coding/Research/Review-Only) + updateWorkflow round-trip preserves completionActions and templateName/templateHash
- [x] New migration tests: legacy Coding/Research rows backfilled with canonical hash + merge-pr injected; Review-Only sets template_name but injects nothing; idempotent; custom workflows untouched; orphan duplicate deletion respects active runs; structural mismatch not treated as template; hash self-verification
- [x] `./scripts/test-daemon.sh 4-space-storage 5-space 1-core 2-handlers` — all pass
- [x] `bun run check` (lint + typecheck + knip) — clean
- [x] `bun run format:check` — clean