### PR TITLE
feat(space): surface completion-action pause reason + task_awaiting_approval event

### DIFF
--- a/packages/daemon/src/lib/space/runtime/notification-sink.ts
+++ b/packages/daemon/src/lib/space/runtime/notification-sink.ts
@@ -106,6 +106,44 @@ export interface TaskRetryEvent {
 	timestamp: string;
 }
 
+/**
+ * A task has paused at a completion action that requires approval because the
+ * space's current autonomy level is below the action's `requiredLevel`.
+ *
+ * Emitted exactly once per pause. Space Agent consumers use this to surface a
+ * review/approval UI or notify stakeholders. The event carries enough metadata
+ * to render a banner ("Awaiting approval: Merge PR") without a second fetch,
+ * but deliberately omits executable bodies (e.g. the `script` payload) —
+ * consumers fetch workflow detail for those.
+ */
+export interface TaskAwaitingApprovalEvent {
+	kind: 'task_awaiting_approval';
+	/** Space the task belongs to. */
+	spaceId: string;
+	/** Task that paused awaiting approval. */
+	taskId: string;
+	/** ID of the completion action currently awaiting approval. */
+	actionId: string;
+	/** Human-readable name of the action (shown in approval UI). */
+	actionName: string;
+	/** Optional human-readable description of the action. */
+	actionDescription?: string;
+	/** Discriminator for the action's execution type. */
+	actionType: 'script' | 'instruction' | 'mcp_call';
+	/** Minimum autonomy level required to auto-execute this action. */
+	requiredLevel: number;
+	/** Space's autonomy level at the time the pause was emitted. */
+	spaceLevel: number;
+	/**
+	 * Alias of `spaceLevel` preserved for API-schema convenience — consumers
+	 * that prefer the more explicit name ("what is the space's autonomy level?")
+	 * can read this instead.
+	 */
+	autonomyLevel: number;
+	/** ISO-8601 timestamp when the event was emitted. */
+	timestamp: string;
+}
+
 /** A blocked workflow run has exhausted automatic retries and needs human/Space Agent attention. */
 export interface WorkflowRunNeedsAttentionEvent {
 	kind: 'workflow_run_needs_attention';
@@ -174,7 +212,8 @@ export type SpaceNotificationEvent =
 	| AgentAutoCompletedEvent
 	| AgentCrashEvent
 	| TaskRetryEvent
-	| WorkflowRunNeedsAttentionEvent;
+	| WorkflowRunNeedsAttentionEvent
+	| TaskAwaitingApprovalEvent;
 
 // ---------------------------------------------------------------------------
 // NotificationSink interface

--- a/packages/daemon/src/lib/space/runtime/pending-action.ts
+++ b/packages/daemon/src/lib/space/runtime/pending-action.ts
@@ -1,0 +1,60 @@
+/**
+ * Helpers for surfacing the currently-pending completion action on a paused
+ * SpaceTask. The `pendingAction` field is a read-path enrichment — derived from
+ * the workflow definition at response time rather than persisted on the task
+ * row. Keeping the derivation centralized lets the various read surfaces
+ * (`get_task_detail`, `list_tasks`, future named queries) share one
+ * implementation.
+ */
+
+import type { SpaceTask } from '@neokai/shared';
+import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
+import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
+
+/**
+ * Return a new `SpaceTask` object with `pendingAction` populated when the task
+ * is paused at a completion action and the backing workflow can be resolved.
+ *
+ * Returns the task unchanged when:
+ * - `pendingCheckpointType !== 'completion_action'` (task isn't paused at a
+ *   completion action — may be paused at a gate instead, or not paused at all)
+ * - `pendingActionIndex` is null
+ * - the task has no `workflowRunId`
+ * - the run, workflow, end node, or action at the index can't be resolved
+ *   (e.g. the workflow was edited between pause and read)
+ *
+ * Script bodies, instruction prompts, and MCP tool args are intentionally
+ * omitted — UIs can fetch workflow detail for those.
+ */
+export function enrichTaskWithPendingAction(
+	task: SpaceTask,
+	workflowRunRepo: SpaceWorkflowRunRepository,
+	workflowManager: SpaceWorkflowManager
+): SpaceTask {
+	if (task.pendingCheckpointType !== 'completion_action') return task;
+	if (task.pendingActionIndex == null) return task;
+	if (!task.workflowRunId) return task;
+
+	const run = workflowRunRepo.getRun(task.workflowRunId);
+	if (!run) return task;
+
+	const workflow = workflowManager.getWorkflow(run.workflowId);
+	if (!workflow) return task;
+
+	const endNode = workflow.nodes.find((n) => n.id === workflow.endNodeId);
+	const actions = endNode?.completionActions;
+	if (!actions || task.pendingActionIndex >= actions.length) return task;
+
+	const action = actions[task.pendingActionIndex];
+
+	return {
+		...task,
+		pendingAction: {
+			id: action.id,
+			name: action.name,
+			description: action.description,
+			type: action.type,
+			requiredLevel: action.requiredLevel,
+		},
+	};
+}

--- a/packages/daemon/src/lib/space/runtime/session-notification-sink.ts
+++ b/packages/daemon/src/lib/space/runtime/session-notification-sink.ts
@@ -117,6 +117,8 @@ export function formatEventMessage(
 			return formatTaskRetry(event, autonomyLevel);
 		case 'workflow_run_needs_attention':
 			return formatWorkflowRunNeedsAttention(event, autonomyLevel);
+		case 'task_awaiting_approval':
+			return formatTaskAwaitingApproval(event, autonomyLevel);
 	}
 }
 
@@ -325,6 +327,46 @@ function formatWorkflowRunNeedsAttention(
 		timestamp: event.timestamp,
 		autonomyLevel,
 	});
+}
+
+function formatTaskAwaitingApproval(
+	event: {
+		kind: 'task_awaiting_approval';
+		spaceId: string;
+		taskId: string;
+		actionId: string;
+		actionName: string;
+		actionDescription?: string;
+		actionType: 'script' | 'instruction' | 'mcp_call';
+		requiredLevel: number;
+		spaceLevel: number;
+		autonomyLevel: number;
+		timestamp: string;
+	},
+	autonomyLevel: SpaceAutonomyLevel
+): string {
+	const descPart = event.actionDescription ? ` — ${event.actionDescription}` : '';
+	const humanReadable =
+		`Task ${event.taskId} in space ${event.spaceId} is awaiting approval for completion action ` +
+		`'${event.actionName}' (type: ${event.actionType})${descPart}. ` +
+		`Requires autonomy ${event.requiredLevel}, space is at ${event.spaceLevel}. ` +
+		`Review the action and approve or reject to resume the task.`;
+	const payload: Record<string, unknown> = {
+		kind: event.kind,
+		spaceId: event.spaceId,
+		taskId: event.taskId,
+		actionId: event.actionId,
+		actionName: event.actionName,
+		actionType: event.actionType,
+		requiredLevel: event.requiredLevel,
+		spaceLevel: event.spaceLevel,
+		timestamp: event.timestamp,
+		autonomyLevel,
+	};
+	if (event.actionDescription !== undefined) {
+		payload['actionDescription'] = event.actionDescription;
+	}
+	return buildMessage(event.kind, humanReadable, payload);
 }
 
 function buildMessage(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -56,6 +56,19 @@ import {
 
 const log = new Logger('space-runtime');
 
+/**
+ * Build the human-readable pause reason stored on `SpaceTask.result` when a
+ * task pauses at a completion action awaiting approval. Kept as a standalone
+ * helper so tests can assert the exact wording without pulling in the full
+ * runtime wiring.
+ */
+function buildAwaitingApprovalReason(
+	action: CompletionAction,
+	spaceLevel: SpaceAutonomyLevel
+): string {
+	return `Awaiting approval: ${action.name} (requires autonomy ${action.requiredLevel}, space is at ${spaceLevel})`;
+}
+
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
@@ -503,10 +516,23 @@ export class SpaceRuntime {
 					workflow,
 					reportedStatus,
 					nextResult,
-					spaceLevel
+					spaceLevel,
+					canonicalTask.id
 				);
 				await this.updateTaskAndEmit(run.spaceId, canonicalTask.id, params);
-			} else if (nextResult && canonicalTask.result !== nextResult) {
+			} else if (
+				nextResult &&
+				canonicalTask.result !== nextResult &&
+				// Don't clobber the structured pause-reason surfaced on `result` when the
+				// task is paused at a completion action — that string is what read
+				// surfaces use to explain *why* the task is awaiting review. The
+				// original agent output is still recoverable via `reportedSummary`, and
+				// `resumeCompletionActions` restores `result` from there on resume.
+				!(
+					canonicalTask.status === 'review' &&
+					canonicalTask.pendingCheckpointType === 'completion_action'
+				)
+			) {
 				await this.updateTaskAndEmit(run.spaceId, canonicalTask.id, { result: nextResult });
 			}
 			return;
@@ -872,9 +898,14 @@ export class SpaceRuntime {
 					});
 				}
 			} else {
-				// Pause at this action — clear stale approvedAt from previous cycle
+				// Pause at this action — clear stale approvedAt from previous cycle and
+				// surface a structured pause reason + fresh awaiting-approval event so
+				// the Space Agent and UI learn about this new gate.
+				const pauseReason = buildAwaitingApprovalReason(action, spaceLevel);
+				await this.emitTaskAwaitingApproval(spaceId, taskId, action, spaceLevel);
 				return await this.finalizeResume(spaceId, taskId, {
 					status: 'review',
+					result: pauseReason,
 					pendingActionIndex: i,
 					pendingCheckpointType: 'completion_action',
 					approvedAt: null,
@@ -882,9 +913,12 @@ export class SpaceRuntime {
 			}
 		}
 
-		// All remaining actions executed — task is done
+		// All remaining actions executed — task is done. Restore the result field
+		// to the original agent summary (the pause-reason string was only relevant
+		// while the task was awaiting approval).
 		return await this.finalizeResume(spaceId, taskId, {
 			status: 'done',
+			result: task.reportedSummary ?? null,
 			completedAt: Date.now(),
 			approvalSource: 'human',
 			approvedAt: Date.now(),
@@ -1086,6 +1120,20 @@ export class SpaceRuntime {
 		}
 		if (canonicalTask.status !== 'in_progress') {
 			this.notifiedTaskSet.delete(`${canonicalTask.id}:timeout`);
+		}
+		// awaiting_approval entries are keyed per (task, action); clear them when the
+		// task is no longer paused at a completion action so a future pause — even on
+		// the same action — can fire a fresh event.
+		if (
+			canonicalTask.status !== 'review' ||
+			canonicalTask.pendingCheckpointType !== 'completion_action'
+		) {
+			const awaitingPrefix = `${canonicalTask.id}:awaiting_approval:`;
+			for (const key of this.notifiedTaskSet) {
+				if (key.startsWith(awaitingPrefix)) {
+					this.notifiedTaskSet.delete(key);
+				}
+			}
 		}
 
 		// ─── Completion bypass ───────────────────────────────────────────────
@@ -1341,7 +1389,8 @@ export class SpaceRuntime {
 						meta.workflow,
 						reportedStatus,
 						nextTaskResult,
-						spaceLevel
+						spaceLevel,
+						canonicalTask.id
 					);
 					await this.updateTaskAndEmit(meta.spaceId, canonicalTask.id, params);
 					finalTaskStatus = params.status ?? canonicalTask.status;
@@ -1652,7 +1701,8 @@ export class SpaceRuntime {
 		workflow: SpaceWorkflow | null,
 		reportedStatus: SpaceReportedStatus,
 		taskResult: string | null,
-		spaceLevel: SpaceAutonomyLevel
+		spaceLevel: SpaceAutonomyLevel,
+		taskId?: string
 	): Promise<UpdateSpaceTaskParams> {
 		// Non-success outcomes pass through directly. Completion actions are a
 		// success-path review gate ("flip to done after verifying X"); they
@@ -1723,10 +1773,17 @@ export class SpaceRuntime {
 					};
 				}
 			} else {
-				// Pause at this action — task goes to 'review' with pending action metadata
+				// Pause at this action — task goes to 'review' with pending action metadata.
+				// Populate `result` with a structured pause reason so surfaces can explain
+				// *why* the task is awaiting review. The original agent output is preserved
+				// on the separate `reportedSummary` field.
+				const pauseReason = buildAwaitingApprovalReason(action, spaceLevel);
+				if (taskId) {
+					await this.emitTaskAwaitingApproval(spaceId, taskId, action, spaceLevel);
+				}
 				return {
 					status: 'review' as const,
-					result: taskResult,
+					result: pauseReason,
 					pendingActionIndex: i,
 					pendingCheckpointType: 'completion_action' as const,
 				};
@@ -1743,6 +1800,39 @@ export class SpaceRuntime {
 			pendingActionIndex: null,
 			pendingCheckpointType: null,
 		};
+	}
+
+	/**
+	 * Emit a `task_awaiting_approval` event for a task that just paused at a
+	 * completion action. Deduplicated by `${taskId}:awaiting_approval:${actionId}`
+	 * so we don't re-fire for the same pause across ticks — each distinct pending
+	 * action gets exactly one event per pause.
+	 *
+	 * Callers must ensure the dedup set is cleared when the task leaves the
+	 * paused state (see `updateTaskAndEmit`).
+	 */
+	private async emitTaskAwaitingApproval(
+		spaceId: string,
+		taskId: string,
+		action: CompletionAction,
+		spaceLevel: SpaceAutonomyLevel
+	): Promise<void> {
+		const dedupKey = `${taskId}:awaiting_approval:${action.id}`;
+		if (this.notifiedTaskSet.has(dedupKey)) return;
+		this.notifiedTaskSet.add(dedupKey);
+		await this.safeNotify({
+			kind: 'task_awaiting_approval',
+			spaceId,
+			taskId,
+			actionId: action.id,
+			actionName: action.name,
+			actionDescription: action.description,
+			actionType: action.type,
+			requiredLevel: action.requiredLevel,
+			spaceLevel,
+			autonomyLevel: spaceLevel,
+			timestamp: new Date().toISOString(),
+		});
 	}
 
 	/**

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1809,7 +1809,9 @@ export class SpaceRuntime {
 	 * action gets exactly one event per pause.
 	 *
 	 * Callers must ensure the dedup set is cleared when the task leaves the
-	 * paused state (see `updateTaskAndEmit`).
+	 * paused state — this cleanup runs at the top of `processRunTick`, which
+	 * strips all `${taskId}:awaiting_approval:*` entries once the task is no
+	 * longer at `review` + `completion_action`.
 	 */
 	private async emitTaskAwaitingApproval(
 		spaceId: string,

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -22,7 +22,7 @@
 
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
-import type { SpaceTaskStatus, SpaceTaskPriority } from '@neokai/shared';
+import type { SpaceTask, SpaceTaskStatus, SpaceTaskPriority } from '@neokai/shared';
 import type { SpaceRuntime } from '../runtime/space-runtime';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
@@ -36,6 +36,7 @@ import type { DaemonHub } from '../../daemon-hub';
 import { jsonResult } from './tool-result';
 import type { ToolResult } from './tool-result';
 import { canTransition } from '../runtime/workflow-run-status-machine';
+import { enrichTaskWithPendingAction } from '../runtime/pending-action';
 
 function normalizeAgentNameToken(value: string): string {
 	return value.trim().toLowerCase();
@@ -262,6 +263,10 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 
 		/**
 		 * List SpaceTasks for this space, optionally filtered by status and/or workflowRunId.
+		 *
+		 * Tasks in the non-compact output are enriched with `pendingAction` when they are
+		 * paused at a completion action, so consumers can render an approval banner
+		 * without a second fetch.
 		 */
 		async list_tasks(args: {
 			status?: SpaceTaskStatus;
@@ -271,7 +276,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			offset?: number;
 			compact?: boolean;
 		}): Promise<ToolResult> {
-			let tasks;
+			let tasks: SpaceTask[];
 			if (args.workflow_run_id) {
 				tasks = taskRepo.listByWorkflowRun(args.workflow_run_id);
 				if (args.status) {
@@ -300,7 +305,10 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 				}));
 				return jsonResult({ success: true, total, tasks: compactTasks });
 			}
-			return jsonResult({ success: true, total, tasks });
+			const enrichedTasks = tasks.map((t) =>
+				enrichTaskWithPendingAction(t, workflowRunRepo, workflowManager)
+			);
+			return jsonResult({ success: true, total, tasks: enrichedTasks });
 		},
 
 		/**
@@ -328,9 +336,14 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 
 		/**
 		 * Get the full detail of a task by UUID or by numeric task number (e.g. #5).
+		 *
+		 * When the task is paused at a completion action (`pendingCheckpointType ===
+		 * 'completion_action'`), the returned task is enriched with a `pendingAction`
+		 * field describing the action awaiting approval. Script bodies, instruction
+		 * prompts, and MCP tool args are omitted — consumers fetch the workflow for those.
 		 */
 		async get_task_detail(args: { task_id?: string; task_number?: number }): Promise<ToolResult> {
-			let task = null;
+			let task: SpaceTask | null = null;
 			if (args.task_number !== undefined) {
 				task = await taskManager.getTaskByNumber(args.task_number);
 			} else if (args.task_id) {
@@ -345,7 +358,8 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 				const ref = args.task_number !== undefined ? `#${args.task_number}` : args.task_id;
 				return jsonResult({ success: false, error: `Task not found: ${ref}` });
 			}
-			return jsonResult({ success: true, task });
+			const enriched = enrichTaskWithPendingAction(task, workflowRunRepo, workflowManager);
+			return jsonResult({ success: true, task: enriched });
 		},
 
 		/**

--- a/packages/daemon/tests/unit/5-space/other/session-notification-sink.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/session-notification-sink.test.ts
@@ -544,6 +544,115 @@ describe('formatEventMessage — agent_crash', () => {
 });
 
 // ---------------------------------------------------------------------------
+// task_awaiting_approval event (completion-action pause surface)
+// ---------------------------------------------------------------------------
+
+describe('formatEventMessage — task_awaiting_approval', () => {
+	const TIMESTAMP = '2026-04-19T12:00:00.000Z';
+
+	it('formats task_awaiting_approval with [TASK_EVENT] prefix and action metadata', () => {
+		const event: SpaceNotificationEvent = {
+			kind: 'task_awaiting_approval',
+			spaceId: 'space-a',
+			taskId: 'task-1',
+			actionId: 'merge-pr',
+			actionName: 'Merge PR',
+			actionDescription: 'Merges the staged PR',
+			actionType: 'script',
+			requiredLevel: 4,
+			spaceLevel: 2,
+			autonomyLevel: 2,
+			timestamp: TIMESTAMP,
+		};
+
+		const msg = formatEventMessage(event, 2);
+		expect(msg).toContain('[TASK_EVENT] task_awaiting_approval');
+		expect(msg).toContain('task-1');
+		expect(msg).toContain('space-a');
+		expect(msg).toContain("'Merge PR'");
+		expect(msg).toContain('Merges the staged PR');
+		expect(msg).toContain('Requires autonomy 4');
+		expect(msg).toContain('space is at 2');
+	});
+
+	it('includes action metadata in JSON payload', () => {
+		const event: SpaceNotificationEvent = {
+			kind: 'task_awaiting_approval',
+			spaceId: 'space-a',
+			taskId: 'task-1',
+			actionId: 'merge-pr',
+			actionName: 'Merge PR',
+			actionDescription: 'Merges the staged PR',
+			actionType: 'script',
+			requiredLevel: 4,
+			spaceLevel: 2,
+			autonomyLevel: 2,
+			timestamp: TIMESTAMP,
+		};
+
+		const msg = formatEventMessage(event, 2);
+		const json = extractJson(msg);
+		expect(json['kind']).toBe('task_awaiting_approval');
+		expect(json['actionId']).toBe('merge-pr');
+		expect(json['actionName']).toBe('Merge PR');
+		expect(json['actionDescription']).toBe('Merges the staged PR');
+		expect(json['actionType']).toBe('script');
+		expect(json['requiredLevel']).toBe(4);
+		expect(json['spaceLevel']).toBe(2);
+		expect(json['autonomyLevel']).toBe(2);
+		expect(json['taskId']).toBe('task-1');
+		expect(json['spaceId']).toBe('space-a');
+	});
+
+	it('omits actionDescription from JSON when absent', () => {
+		const event: SpaceNotificationEvent = {
+			kind: 'task_awaiting_approval',
+			spaceId: 'space-a',
+			taskId: 'task-1',
+			actionId: 'deploy',
+			actionName: 'Deploy',
+			actionType: 'mcp_call',
+			requiredLevel: 5,
+			spaceLevel: 1,
+			autonomyLevel: 1,
+			timestamp: TIMESTAMP,
+		};
+
+		const msg = formatEventMessage(event, 1);
+		const json = extractJson(msg);
+		expect(json['actionDescription']).toBeUndefined();
+	});
+
+	it('SessionNotificationSink.notify() injects task_awaiting_approval message', async () => {
+		const factory = makeMockSessionFactory();
+		const sink = new SessionNotificationSink({
+			sessionFactory: factory,
+			sessionId: 'session:spaces:global',
+			autonomyLevel: 2,
+		});
+
+		await sink.notify({
+			kind: 'task_awaiting_approval',
+			spaceId: 'space-a',
+			taskId: 'task-1',
+			actionId: 'merge-pr',
+			actionName: 'Merge PR',
+			actionType: 'script',
+			requiredLevel: 4,
+			spaceLevel: 2,
+			autonomyLevel: 2,
+			timestamp: TIMESTAMP,
+		});
+
+		expect(factory.calls).toHaveLength(1);
+		const [call] = factory.calls;
+		expect(call.message).toContain('[TASK_EVENT] task_awaiting_approval');
+		expect(call.message).toContain('Merge PR');
+		expect(call.opts?.deliveryMode).toBe('defer');
+	});
+});
+
+// ---------------------------------------------------------------------------
 // Test utility: extract the first JSON block from a message
 // ---------------------------------------------------------------------------
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
@@ -660,4 +660,295 @@ describe('SpaceRuntime — completion actions', () => {
 		// completionActions should be absent, not null or undefined
 		expect(endNode!.completionActions).toBeUndefined();
 	});
+
+	// ─── Awaiting-approval pause surface ─────────────────────────────────
+	//
+	// When a task pauses at a completion action because the space's autonomy
+	// level is below the action's `requiredLevel`, the runtime must:
+	//   1. populate `task.result` with a human-readable pause reason so read
+	//      surfaces can explain *why* the task is awaiting review, while
+	//      preserving the original agent output on `reportedSummary`; and
+	//   2. emit a structured `task_awaiting_approval` event exactly once per
+	//      distinct pause (so the Space Agent gets one notification, not one
+	//      per tick).
+	//
+	// The auto-execute path (level sufficient) must not emit the event at all.
+
+	test('pause at completion action populates result with pause-reason string', async () => {
+		setAutonomyLevel(2);
+		const rt = makeRuntime();
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'review-action',
+				name: 'Merge PR',
+				description: 'Merges the staged PR into main',
+				type: 'script',
+				requiredLevel: 4,
+				script: 'echo "merge"',
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'original agent summary',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+
+		const task = taskRepo.getTask(tasks[0].id)!;
+		expect(task.status).toBe('review');
+		expect(task.result).toBe('Awaiting approval: Merge PR (requires autonomy 4, space is at 2)');
+		// Original agent output is still recoverable from reportedSummary
+		expect(task.reportedSummary).toBe('original agent summary');
+	});
+
+	test('pause emits task_awaiting_approval event exactly once across ticks', async () => {
+		setAutonomyLevel(2);
+		const rt = makeRuntime();
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'approval-action',
+				name: 'Deploy to prod',
+				description: 'Promotes the staged build',
+				type: 'script',
+				requiredLevel: 5,
+				script: 'echo "deploy"',
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'task complete',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		// Tick 1: task pauses, event fires
+		await rt.executeTick();
+
+		const firstPauseEvents = sink.events.filter((e) => e.kind === 'task_awaiting_approval');
+		expect(firstPauseEvents).toHaveLength(1);
+		const event = firstPauseEvents[0];
+		if (event.kind !== 'task_awaiting_approval') throw new Error('narrowing');
+		expect(event.spaceId).toBe(SPACE_ID);
+		expect(event.taskId).toBe(tasks[0].id);
+		expect(event.actionId).toBe('approval-action');
+		expect(event.actionName).toBe('Deploy to prod');
+		expect(event.actionDescription).toBe('Promotes the staged build');
+		expect(event.actionType).toBe('script');
+		expect(event.requiredLevel).toBe(5);
+		expect(event.spaceLevel).toBe(2);
+		expect(event.autonomyLevel).toBe(2);
+		expect(typeof event.timestamp).toBe('string');
+
+		// Tick 2: task still paused — event must NOT re-fire
+		await rt.executeTick();
+		const afterSecondTick = sink.events.filter((e) => e.kind === 'task_awaiting_approval');
+		expect(afterSecondTick).toHaveLength(1);
+	});
+
+	test('auto-execute (level sufficient) does NOT emit task_awaiting_approval', async () => {
+		setAutonomyLevel(5);
+		const rt = makeRuntime();
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'auto-action',
+				name: 'Auto Action',
+				type: 'script',
+				requiredLevel: 3,
+				script: 'echo "ok"',
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'task complete',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+
+		const task = taskRepo.getTask(tasks[0].id)!;
+		expect(task.status).toBe('done');
+		// No awaiting-approval event should have fired on the happy path
+		expect(sink.events.filter((e) => e.kind === 'task_awaiting_approval')).toHaveLength(0);
+	});
+
+	test('resume re-pauses at next high-level action and emits a fresh event', async () => {
+		setAutonomyLevel(2);
+		const rt = makeRuntime();
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'first',
+				name: 'First',
+				type: 'script',
+				requiredLevel: 3,
+				script: 'echo "1"',
+			},
+			{
+				id: 'second',
+				name: 'Second',
+				type: 'script',
+				requiredLevel: 4,
+				script: 'echo "2"',
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'task complete',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		// Pause at first action
+		await rt.executeTick();
+		const firstPause = sink.events.filter((e) => e.kind === 'task_awaiting_approval');
+		expect(firstPause).toHaveLength(1);
+		if (firstPause[0].kind !== 'task_awaiting_approval') throw new Error('narrowing');
+		expect(firstPause[0].actionId).toBe('first');
+
+		// Human approves → first action runs, re-pauses at second
+		const resumed = await rt.resumeCompletionActions(SPACE_ID, tasks[0].id);
+		expect(resumed!.status).toBe('review');
+		expect(resumed!.pendingActionIndex).toBe(1);
+		// Re-pause populates the pause-reason string for the new action
+		expect(resumed!.result).toBe('Awaiting approval: Second (requires autonomy 4, space is at 2)');
+
+		const allApprovalEvents = sink.events.filter((e) => e.kind === 'task_awaiting_approval');
+		expect(allApprovalEvents).toHaveLength(2);
+		if (allApprovalEvents[1].kind !== 'task_awaiting_approval') throw new Error('narrowing');
+		expect(allApprovalEvents[1].actionId).toBe('second');
+	});
+
+	test('resume-to-done restores task.result from reportedSummary', async () => {
+		setAutonomyLevel(3);
+		const rt = makeRuntime();
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'only',
+				name: 'Only Action',
+				type: 'script',
+				requiredLevel: 5,
+				script: 'echo "ok"',
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'the real summary the agent produced',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+		const paused = taskRepo.getTask(tasks[0].id)!;
+		expect(paused.result).toContain('Awaiting approval');
+
+		// Force autonomy high enough so resume succeeds (auto-executes the action)
+		setAutonomyLevel(5);
+		const resumed = await rt.resumeCompletionActions(SPACE_ID, tasks[0].id);
+		expect(resumed!.status).toBe('done');
+		expect(resumed!.result).toBe('the real summary the agent produced');
+	});
+
+	// ─── pendingAction read-path enrichment ──────────────────────────────
+
+	test('enrichTaskWithPendingAction populates pendingAction metadata on paused task', async () => {
+		setAutonomyLevel(2);
+		const rt = makeRuntime();
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'merge-pr',
+				name: 'Merge PR',
+				description: 'Merges the staged PR',
+				type: 'script',
+				requiredLevel: 4,
+				script: 'echo "merge"',
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'task complete',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+
+		const task = taskRepo.getTask(tasks[0].id)!;
+		expect(task.status).toBe('review');
+
+		const { enrichTaskWithPendingAction } = await import(
+			'../../../../src/lib/space/runtime/pending-action.ts'
+		);
+		const enriched = enrichTaskWithPendingAction(task, workflowRunRepo, workflowManager);
+		expect(enriched.pendingAction).toBeDefined();
+		expect(enriched.pendingAction).toEqual({
+			id: 'merge-pr',
+			name: 'Merge PR',
+			description: 'Merges the staged PR',
+			type: 'script',
+			requiredLevel: 4,
+		});
+		// Ensure we did not leak the script body into the enriched shape
+		expect((enriched.pendingAction as Record<string, unknown>)['script']).toBeUndefined();
+	});
+
+	test('enrichTaskWithPendingAction leaves non-paused tasks untouched', async () => {
+		setAutonomyLevel(5);
+		const rt = makeRuntime();
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'auto',
+				name: 'Auto',
+				type: 'script',
+				requiredLevel: 2,
+				script: 'echo "ok"',
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'task complete',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+
+		const task = taskRepo.getTask(tasks[0].id)!;
+		expect(task.status).toBe('done');
+
+		const { enrichTaskWithPendingAction } = await import(
+			'../../../../src/lib/space/runtime/pending-action.ts'
+		);
+		const enriched = enrichTaskWithPendingAction(task, workflowRunRepo, workflowManager);
+		expect(enriched.pendingAction).toBeUndefined();
+	});
 });

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -285,6 +285,31 @@ export interface SpaceTask {
 	 */
 	pendingCheckpointType: 'completion_action' | 'gate' | null;
 	/**
+	 * Metadata for the completion action the task is currently paused at, derived from
+	 * `workflow.endNode.completionActions[pendingActionIndex]` at read time.
+	 *
+	 * Populated by read-path enrichers (e.g. `get_task_detail`, `list_tasks`) so UIs can
+	 * render a review/approval banner without fetching workflow detail. Null when the
+	 * task is not paused at a completion action, or when the workflow can't be resolved.
+	 *
+	 * NOT persisted in the database. NOT included in every `SpaceTask` instance —
+	 * callers that load tasks straight from the repo will see `undefined` here.
+	 * Script bodies, instruction prompts, and MCP tool args are intentionally omitted;
+	 * consumers fetch the workflow definition directly if they need those.
+	 */
+	pendingAction?: {
+		/** Unique identifier within the node's completion actions */
+		id: string;
+		/** Human-readable name (shown in approval UI) */
+		name: string;
+		/** Human-readable description if defined on the action */
+		description?: string;
+		/** Discriminator for the action's execution type */
+		type: 'script' | 'instruction' | 'mcp_call';
+		/** Minimum space autonomy level required to auto-execute this action */
+		requiredLevel: SpaceAutonomyLevel;
+	} | null;
+	/**
 	 * Status the end-node agent reported via `report_result`. Null until the agent
 	 * reports. Recorded separately from `status` so the runtime can resolve the
 	 * final task status through completion-actions review (supervised modes) without
@@ -1329,6 +1354,8 @@ interface CompletionActionBase {
 	id: string;
 	/** Human-readable name (shown in approval UI) */
 	name: string;
+	/** Human-readable description of what the action does (shown alongside the name in approval UI) */
+	description?: string;
 	/** Minimum space autonomy level required to auto-execute this action */
 	requiredLevel: SpaceAutonomyLevel;
 	/** Which artifact type to resolve as context for this action */


### PR DESCRIPTION
When a task pauses at a completion action because the space's autonomy level is below the action's `requiredLevel`, populate `SpaceTask.result` with a structured pause reason (`Awaiting approval: <name> (requires autonomy X, space is at Y)`) and emit a new `task_awaiting_approval` `SpaceNotificationEvent` exactly once per pause (deduped by `${taskId}:awaiting_approval:${actionId}`). The original agent output is preserved on `reportedSummary` and restored into `result` when the task resumes to `done`.

Also adds a `pendingAction` read-path enrichment — derived from `workflow.endNode.completionActions[pendingActionIndex]` at response time — to `get_task_detail` and `list_tasks`, so UIs can render an approval banner without a second fetch. Script bodies, instruction prompts, and MCP tool args are intentionally omitted.

The reconcile-terminal-run path had a branch that would overwrite `result` with `reportedSummary` when a task was already at `review`; it now skips tasks paused at a completion action so the pause reason survives across ticks.

## Test plan
- [x] `bun test packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts` — 20/20 pass (6 new)
- [x] `bun test packages/daemon/tests/unit/5-space/other/session-notification-sink.test.ts` — 28/28 pass (4 new)
- [x] `bun test packages/daemon/tests/unit/5-space/` — 2150/2150 pass
- [x] `bun run check` (lint + typecheck + knip) — clean