### PR TITLE
feat(space): surface completion-action pauses in task pane + overview

### DIFF
--- a/packages/e2e/tests/features/space-completion-action-approval.e2e.ts
+++ b/packages/e2e/tests/features/space-completion-action-approval.e2e.ts
@@ -1,0 +1,302 @@
+/**
+ * Space Completion-Action Approval Banner E2E Tests
+ *
+ * Tests the `PendingCompletionActionBanner` rendered in `SpaceTaskPane` when a
+ * task is paused at a workflow end-node `completionAction`:
+ *   - Banner renders with the action name, type, and required-vs-space level
+ *   - Script source is present in the DOM under a collapsed <details>
+ *   - Reject opens a confirmation modal and cancels the task on confirm
+ *   - Space-level "awaiting approval" summary appears on SpaceOverview and
+ *     deep-links to the Tasks view with the awaiting-approval filter toggled
+ *
+ * Setup (beforeEach — infrastructure RPC only):
+ *   - Space is created via RPC
+ *   - Seeded built-in workflows are deleted (keeps SpaceOverview visible)
+ *   - A custom workflow with a single end node + script completion action is
+ *     created via RPC (required-level 3 — above the default space level 1)
+ *   - A workflow run is started via RPC which creates a task; the task is
+ *     immediately marked done to prevent the task agent from running (pattern
+ *     borrowed from space-approval-gate-rejection.e2e.ts) and then walked back
+ *     through in_progress → review so the pause checkpoint can be set
+ *   - `pendingActionIndex: 0, pendingCheckpointType: 'completion_action'` are
+ *     applied via a follow-up update
+ *
+ * Cleanup (afterEach — infrastructure RPC only):
+ *   - The workflow run is cancelled
+ *   - The space is deleted
+ *
+ * E2E Rules:
+ *   - All test actions go through the UI (clicks, navigation).
+ *   - All assertions verify visible DOM state.
+ *   - RPC is only used in beforeEach / afterEach for infrastructure.
+ */
+
+import type { Page } from '@playwright/test';
+import { test, expect } from '../../fixtures';
+import { waitForWebSocketConnected, getWorkspaceRoot } from '../helpers/wait-helpers';
+import {
+	createSpaceViaRpc,
+	createUniqueSpaceDir,
+	deleteSpaceViaRpc,
+	deleteSpaceWorkflowsViaRpc,
+} from '../helpers/space-helpers';
+
+const DESKTOP_VIEWPORT = { width: 1440, height: 900 };
+
+const ACTION_NAME = 'merge-pr';
+const ACTION_SCRIPT = 'echo approved';
+const ACTION_REQUIRED_LEVEL = 3;
+
+interface PausedTaskFixture {
+	spaceId: string;
+	runId: string;
+	taskId: string;
+	workflowId: string;
+}
+
+/**
+ * Creates a space with a workflow that pauses at a completion action on its
+ * sole (end) node, starts a run for that workflow, and primes the resulting
+ * task into `review` state with `pendingCheckpointType: 'completion_action'`.
+ *
+ * Uses the "mark done → reopen" trick to stop the task agent from racing with
+ * our manual field updates (same pattern as space-approval-gate-rejection).
+ */
+async function createSpaceWithPausedTask(page: Page): Promise<PausedTaskFixture> {
+	await waitForWebSocketConnected(page);
+	const workspaceRoot = await getWorkspaceRoot(page);
+	const wsPath = createUniqueSpaceDir(workspaceRoot, 'completion-action');
+	const spaceName = `E2E Completion Action ${Date.now()}`;
+
+	const spaceId = await createSpaceViaRpc(page, wsPath, spaceName);
+	// Drop seeded workflows so our custom one is the only choice for runs and
+	// SpaceOverview is not hidden by a full WorkflowCanvas.
+	await deleteSpaceWorkflowsViaRpc(page, spaceId);
+
+	return page.evaluate(
+		async ({
+			spaceId,
+			actionName,
+			actionScript,
+			actionRequiredLevel,
+		}: {
+			spaceId: string;
+			actionName: string;
+			actionScript: string;
+			actionRequiredLevel: number;
+		}) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) throw new Error('MessageHub not available');
+
+			// Grab any agent in the space so our workflow node has a valid agent ref.
+			const agentsRes = (await hub.request('spaceAgent.list', { spaceId })) as {
+				agents: Array<{ id: string; name: string }>;
+			};
+			if (!agentsRes.agents || agentsRes.agents.length === 0) {
+				throw new Error('Space has no agents — cannot create workflow');
+			}
+			const agent = agentsRes.agents[0];
+
+			// Single-node workflow; the node is both start and end. Completion actions
+			// run after the end node succeeds.
+			const nodeId = crypto.randomUUID();
+			const wfRes = (await hub.request('spaceWorkflow.create', {
+				spaceId,
+				name: `Completion Action Flow ${Date.now()}`,
+				nodes: [
+					{
+						id: nodeId,
+						name: 'finish',
+						agents: [{ agentId: agent.id, name: agent.name || 'agent' }],
+						completionActions: [
+							{
+								id: crypto.randomUUID(),
+								name: actionName,
+								type: 'script',
+								requiredLevel: actionRequiredLevel,
+								script: actionScript,
+							},
+						],
+					},
+				],
+				startNodeId: nodeId,
+				endNodeId: nodeId,
+			})) as { workflow: { id: string } };
+			const workflowId = wfRes.workflow.id;
+
+			// Start a run — this creates a task that references the workflow run.
+			const runRes = (await hub.request('spaceWorkflowRun.start', {
+				spaceId,
+				workflowId,
+				title: 'E2E: Completion action approval',
+				description: 'Task paused at an end-node completion action.',
+			})) as { run: { id: string } };
+			const runId = runRes.run.id;
+
+			// Find the task the runtime just created for this run.
+			const tasks = (await hub.request('spaceTask.list', { spaceId })) as Array<{
+				id: string;
+				workflowRunId?: string | null;
+			}>;
+			const task = tasks.find((t) => t.workflowRunId === runId);
+			if (!task) throw new Error(`No task found for run ${runId}`);
+			const taskId = task.id;
+
+			// Stop the runtime from racing with us: mark done first (kills the agent
+			// loop), then walk the task back through in_progress → review and drop
+			// the pending-completion-action fields on with a final no-status update.
+			await hub.request('spaceTask.update', { spaceId, taskId, status: 'done' });
+			await hub.request('spaceTask.update', { spaceId, taskId, status: 'in_progress' });
+			await hub.request('spaceTask.update', { spaceId, taskId, status: 'review' });
+			await hub.request('spaceTask.update', {
+				spaceId,
+				taskId,
+				pendingActionIndex: 0,
+				pendingCheckpointType: 'completion_action',
+			});
+
+			return { spaceId, runId, taskId, workflowId };
+		},
+		{
+			spaceId,
+			actionName: ACTION_NAME,
+			actionScript: ACTION_SCRIPT,
+			actionRequiredLevel: ACTION_REQUIRED_LEVEL,
+		}
+	);
+}
+
+async function cancelRun(page: Page, runId: string): Promise<void> {
+	if (!runId) return;
+	try {
+		await page.evaluate(async (rid) => {
+			const hub = window.__messageHub || window.appState?.messageHub;
+			if (!hub?.request) return;
+			await hub.request('spaceWorkflowRun.cancel', { id: rid });
+		}, runId);
+	} catch {
+		// best-effort
+	}
+}
+
+test.describe('PendingCompletionActionBanner', () => {
+	// Serial — creating workflow runs + tasks is heavy and the workspace is shared.
+	test.describe.configure({ mode: 'serial' });
+	test.use({ viewport: DESKTOP_VIEWPORT });
+
+	let fixture: PausedTaskFixture | null = null;
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		fixture = await createSpaceWithPausedTask(page);
+	});
+
+	test.afterEach(async ({ page }) => {
+		if (fixture?.runId) {
+			await cancelRun(page, fixture.runId);
+		}
+		if (fixture?.spaceId) {
+			await deleteSpaceViaRpc(page, fixture.spaceId);
+		}
+		fixture = null;
+	});
+
+	test('banner renders with action name, type, level and collapsed script source', async ({
+		page,
+	}) => {
+		if (!fixture) throw new Error('fixture missing');
+		const { spaceId, taskId } = fixture;
+
+		await page.goto(`/space/${spaceId}/task/${taskId}`);
+		await page.waitForURL(`/space/${spaceId}/task/${taskId}`, { timeout: 10000 });
+
+		const banner = page.getByTestId('pending-completion-action-banner');
+		await expect(banner).toBeVisible({ timeout: 15000 });
+		await expect(banner).toContainText(ACTION_NAME);
+
+		// Type line calls out "Bash script" + the required level.
+		await expect(page.getByTestId('pending-completion-action-type')).toContainText('Bash script');
+		await expect(page.getByTestId('pending-completion-action-type')).toContainText(
+			`Level ${ACTION_REQUIRED_LEVEL}`
+		);
+
+		// Space defaults to level 1 — below the required level.
+		await expect(page.getByTestId('pending-completion-action-current-level')).toContainText(
+			'Level 1'
+		);
+
+		// Script source is in the DOM, nested inside a collapsed <details>.
+		const details = page.getByTestId('pending-completion-action-details');
+		await expect(details).toHaveAttribute('data-action-type', 'script');
+		// Details opens via native disclosure — it is NOT open by default, so the
+		// script source is present in the DOM (we can read textContent) but not
+		// "visible" for Playwright's visibility checks.
+		await expect(details).not.toHaveAttribute('open', /.*/);
+		const scriptText = await page
+			.getByTestId('pending-completion-action-script')
+			.evaluate((el) => el.textContent ?? '');
+		expect(scriptText).toContain(ACTION_SCRIPT);
+
+		// Approve + Reject buttons are both present.
+		await expect(page.getByTestId('pending-completion-action-approve-btn')).toBeVisible();
+		await expect(page.getByTestId('pending-completion-action-reject-btn')).toBeVisible();
+	});
+
+	test('Reject opens confirmation modal and dismisses banner on confirm', async ({ page }) => {
+		if (!fixture) throw new Error('fixture missing');
+		const { spaceId, taskId } = fixture;
+
+		await page.goto(`/space/${spaceId}/task/${taskId}`);
+		await page.waitForURL(`/space/${spaceId}/task/${taskId}`, { timeout: 10000 });
+
+		const banner = page.getByTestId('pending-completion-action-banner');
+		await expect(banner).toBeVisible({ timeout: 15000 });
+
+		// Confirm modal not mounted until Reject is clicked.
+		await expect(page.getByTestId('pending-completion-action-reject-confirm')).toBeHidden();
+
+		await page.getByTestId('pending-completion-action-reject-btn').click();
+		const confirmBtn = page.getByTestId('pending-completion-action-reject-confirm');
+		await expect(confirmBtn).toBeVisible({ timeout: 5000 });
+
+		// Supply a reason — optional but exercises the textarea binding.
+		await page.getByTestId('pending-completion-action-reject-reason').fill('E2E: script too risky');
+
+		await confirmBtn.click();
+
+		// Banner must disappear once the daemon clears the pending fields.
+		await expect(banner).toBeHidden({ timeout: 15000 });
+		// Confirm modal also closes.
+		await expect(page.getByTestId('pending-completion-action-reject-confirm')).toBeHidden({
+			timeout: 5000,
+		});
+	});
+
+	test('SpaceOverview shows awaiting-approval summary linking to filtered Tasks view', async ({
+		page,
+	}) => {
+		if (!fixture) throw new Error('fixture missing');
+		const { spaceId } = fixture;
+
+		await page.goto(`/space/${spaceId}`);
+		await page.waitForURL(`/space/${spaceId}`, { timeout: 10000 });
+
+		// Summary CTA is visible with the count.
+		const summary = page.getByTestId('awaiting-approval-summary');
+		await expect(summary).toBeVisible({ timeout: 15000 });
+		await expect(summary).toContainText('1');
+		await expect(summary).toContainText(/awaiting/i);
+
+		// Click the summary — should navigate to /space/{id}/tasks with the
+		// awaiting-approval filter chip toggled on (action tab by default).
+		await summary.click();
+		await page.waitForURL(`/space/${spaceId}/tasks`, { timeout: 5000 });
+
+		const filterChip = page.getByTestId('tasks-filter-awaiting-approval');
+		await expect(filterChip).toBeVisible({ timeout: 5000 });
+		await expect(filterChip).toContainText('1');
+
+		// The clear-filter affordance shows up while the chip is active.
+		await expect(page.getByTestId('tasks-filter-clear')).toBeVisible();
+	});
+});

--- a/packages/web/src/components/space/PendingCompletionActionBanner.tsx
+++ b/packages/web/src/components/space/PendingCompletionActionBanner.tsx
@@ -1,0 +1,301 @@
+/**
+ * PendingCompletionActionBanner — thread-view CTA for completion-action pauses.
+ *
+ * Renders when the task is paused at a workflow end-node `completionAction` —
+ * i.e. `task.pendingCheckpointType === 'completion_action'` and
+ * `pendingActionIndex` points at a real action on the run's end node. Provides
+ * Approve and Reject controls. Approve forwards to `spaceTask.update` with
+ * `status: 'done'` which the daemon intercepts and routes through the runtime's
+ * completion-action resume path (see
+ * `packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts`). Reject maps to
+ * `status: 'cancelled'` — we treat rejection as cancelling the task, which is
+ * the transition the daemon already permits out of `review`.
+ *
+ * For `type: 'script'` actions the bash source is shown under a `<details>`
+ * disclosure, collapsed by default — so risky shell commands are visible to
+ * reviewers but don't dominate the banner.
+ *
+ * Distinct from `PendingGateBanner` (workflow-level gates) and
+ * `TaskBlockedBanner` (blocked-status tasks). The three can, in principle, be
+ * shown at the same time if a task is both blocked at a gate and paused at a
+ * completion action — `SpaceTaskPane` decides the priority.
+ */
+
+import { useCallback, useMemo, useState } from 'preact/hooks';
+import type { CompletionAction, SpaceAutonomyLevel, SpaceTask } from '@neokai/shared';
+import { spaceStore } from '../../lib/space-store';
+import { AUTONOMY_LABELS } from '../../lib/space-constants';
+import { ConfirmModal } from '../ui/ConfirmModal';
+
+interface PendingCompletionActionBannerProps {
+	task: SpaceTask;
+	spaceId: string;
+	/** Space autonomy level for "requires level X" context. Defaults to 1 when unknown. */
+	spaceAutonomyLevel?: SpaceAutonomyLevel;
+}
+
+/**
+ * Resolves the paused-on `CompletionAction` from the task's workflow run.
+ *
+ * Returns `null` when the task is not paused at a completion-action checkpoint,
+ * when the run/workflow/end-node can't be found in the store, or when the
+ * `pendingActionIndex` is out of range (workflow edited between pause and
+ * render). The banner treats all of these as "nothing to show" rather than
+ * crashing — the daemon still owns the truth and will surface a mismatch when
+ * the user clicks Approve.
+ */
+export function resolvePendingCompletionAction(task: SpaceTask): CompletionAction | null {
+	if (task.pendingCheckpointType !== 'completion_action') return null;
+	if (task.pendingActionIndex == null) return null;
+	if (!task.workflowRunId) return null;
+
+	const run = spaceStore.workflowRuns.value.find((r) => r.id === task.workflowRunId);
+	if (!run) return null;
+
+	const workflow = spaceStore.workflows.value.find((w) => w.id === run.workflowId);
+	if (!workflow) return null;
+
+	const endNodeId = workflow.endNodeId;
+	if (!endNodeId) return null;
+
+	const endNode = workflow.nodes.find((n) => n.id === endNodeId);
+	const actions = endNode?.completionActions;
+	if (!actions || actions.length === 0) return null;
+
+	const action = actions[task.pendingActionIndex];
+	return action ?? null;
+}
+
+export function PendingCompletionActionBanner({
+	task,
+	spaceId: _spaceId,
+	spaceAutonomyLevel,
+}: PendingCompletionActionBannerProps) {
+	const action = useMemo(() => resolvePendingCompletionAction(task), [task]);
+
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [showRejectConfirm, setShowRejectConfirm] = useState(false);
+	const [rejectReason, setRejectReason] = useState('');
+
+	const onApprove = useCallback(async () => {
+		setBusy(true);
+		setError(null);
+		try {
+			// Daemon intercepts `status: 'done'` when pendingCheckpointType is
+			// 'completion_action' and routes through resumeCompletionActions. It
+			// recomputes the resulting status (done / review / blocked) based on
+			// the action outcome + remaining actions, so we don't need to guess.
+			await spaceStore.updateTask(task.id, { status: 'done' });
+		} catch (err: unknown) {
+			setError(err instanceof Error ? err.message : 'Failed to approve');
+		} finally {
+			setBusy(false);
+		}
+	}, [task.id]);
+
+	const onRejectConfirm = useCallback(async () => {
+		setBusy(true);
+		setError(null);
+		try {
+			// Rejection-as-cancel: the task transitions review → cancelled, which is
+			// a valid transition the daemon already allows. The completion action is
+			// not executed. We explicitly clear `pendingActionIndex` and
+			// `pendingCheckpointType` in the same call — `setTaskStatus` on the
+			// daemon doesn't clear them, and stale values would confuse the
+			// awaiting-approval summary (which filters on pendingCheckpointType).
+			const reason = rejectReason.trim();
+			await spaceStore.updateTask(task.id, {
+				status: 'cancelled',
+				pendingActionIndex: null,
+				pendingCheckpointType: null,
+				...(reason ? { result: reason } : {}),
+			});
+			setShowRejectConfirm(false);
+			setRejectReason('');
+		} catch (err: unknown) {
+			setError(err instanceof Error ? err.message : 'Failed to reject');
+		} finally {
+			setBusy(false);
+		}
+	}, [task.id, rejectReason]);
+
+	if (!action) return null;
+
+	const currentLevel: SpaceAutonomyLevel = spaceAutonomyLevel ?? 1;
+	const requiredLabel = AUTONOMY_LABELS[action.requiredLevel] ?? `Level ${action.requiredLevel}`;
+	const currentLabel = AUTONOMY_LABELS[currentLevel] ?? `Level ${currentLevel}`;
+
+	const typeLabel =
+		action.type === 'script'
+			? 'Bash script'
+			: action.type === 'instruction'
+				? 'Agent instruction'
+				: 'MCP tool call';
+
+	return (
+		<>
+			<div
+				class="mx-4 mt-2 mb-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 space-y-2"
+				data-testid="pending-completion-action-banner"
+				data-action-type={action.type}
+			>
+				<div class="flex items-start justify-between gap-2">
+					<div class="flex-1 min-w-0">
+						<p class="text-xs font-medium text-amber-300">
+							⏸ Completion Action Awaiting Approval — {action.name}
+						</p>
+						<p
+							class="mt-0.5 text-xs text-amber-400/70"
+							data-testid="pending-completion-action-type"
+						>
+							{typeLabel} · requires {requiredLabel} (Level {action.requiredLevel}); space is{' '}
+							<span data-testid="pending-completion-action-current-level">
+								{currentLabel} (Level {currentLevel})
+							</span>
+						</p>
+					</div>
+
+					<div class="flex items-center gap-1.5 flex-shrink-0">
+						<button
+							type="button"
+							onClick={() => void onApprove()}
+							disabled={busy}
+							data-testid="pending-completion-action-approve-btn"
+							class="px-2 py-1 text-xs font-medium rounded bg-green-900/40 text-green-300 border border-green-700/50 hover:bg-green-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+						>
+							Approve
+						</button>
+						<button
+							type="button"
+							onClick={() => setShowRejectConfirm(true)}
+							disabled={busy}
+							data-testid="pending-completion-action-reject-btn"
+							class="px-2 py-1 text-xs font-medium rounded bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+						>
+							Reject
+						</button>
+					</div>
+				</div>
+
+				<CompletionActionDetails action={action} />
+
+				{error && (
+					<p class="text-xs text-red-400" data-testid="pending-completion-action-error">
+						{error}
+					</p>
+				)}
+			</div>
+
+			<ConfirmModal
+				isOpen={showRejectConfirm}
+				onClose={() => {
+					if (!busy) {
+						setShowRejectConfirm(false);
+						setRejectReason('');
+					}
+				}}
+				onConfirm={() => void onRejectConfirm()}
+				title={`Reject "${action.name}"?`}
+				message={`The task will be cancelled and the ${typeLabel.toLowerCase()} will not run. This can't be undone by the banner — to retry, reopen the task.`}
+				confirmText="Reject and Cancel Task"
+				cancelText="Keep Pending"
+				confirmButtonVariant="danger"
+				isLoading={busy}
+				error={error}
+				confirmTestId="pending-completion-action-reject-confirm"
+			>
+				<label class="block text-xs text-gray-400 mb-1" for="reject-reason-input">
+					Reason (optional — recorded on the task)
+				</label>
+				<textarea
+					id="reject-reason-input"
+					data-testid="pending-completion-action-reject-reason"
+					value={rejectReason}
+					onInput={(e) => setRejectReason((e.target as HTMLTextAreaElement).value)}
+					class="w-full rounded border border-dark-600 bg-dark-800 px-2 py-1 text-sm text-gray-200 focus:border-red-500 focus:outline-none"
+					rows={2}
+					disabled={busy}
+				/>
+			</ConfirmModal>
+		</>
+	);
+}
+
+/**
+ * Collapsible details for a completion action.
+ *
+ * Kept inside this file (rather than a dedicated component) because it's
+ * display-only and has no state of its own beyond the native `<details>`
+ * disclosure.
+ */
+function CompletionActionDetails({ action }: { action: CompletionAction }) {
+	if (action.type === 'script') {
+		return (
+			<details
+				class="text-xs"
+				data-testid="pending-completion-action-details"
+				data-action-type="script"
+			>
+				<summary class="cursor-pointer text-amber-400/80 hover:text-amber-300 select-none">
+					Show script source
+				</summary>
+				<pre
+					class="mt-2 p-2 bg-dark-900/60 border border-dark-700 rounded overflow-x-auto whitespace-pre-wrap text-[11px] text-gray-300"
+					data-testid="pending-completion-action-script"
+				>
+					{action.script}
+				</pre>
+			</details>
+		);
+	}
+
+	if (action.type === 'instruction') {
+		return (
+			<details
+				class="text-xs"
+				data-testid="pending-completion-action-details"
+				data-action-type="instruction"
+			>
+				<summary class="cursor-pointer text-amber-400/80 hover:text-amber-300 select-none">
+					Show instruction
+				</summary>
+				<p class="mt-2 p-2 bg-dark-900/60 border border-dark-700 rounded text-[11px] text-gray-300">
+					<span class="text-gray-500">→ node </span>
+					<span class="font-mono">{action.targetNodeId}</span>
+				</p>
+				<pre
+					class="mt-1 p-2 bg-dark-900/60 border border-dark-700 rounded overflow-x-auto whitespace-pre-wrap text-[11px] text-gray-300"
+					data-testid="pending-completion-action-instruction"
+				>
+					{action.instruction}
+				</pre>
+			</details>
+		);
+	}
+
+	// mcp_call
+	return (
+		<details
+			class="text-xs"
+			data-testid="pending-completion-action-details"
+			data-action-type="mcp_call"
+		>
+			<summary class="cursor-pointer text-amber-400/80 hover:text-amber-300 select-none">
+				Show MCP call
+			</summary>
+			<p class="mt-2 p-2 bg-dark-900/60 border border-dark-700 rounded text-[11px] text-gray-300">
+				<span class="text-gray-500">server </span>
+				<span class="font-mono">{action.server}</span>
+				<span class="text-gray-500"> · tool </span>
+				<span class="font-mono">{action.tool}</span>
+			</p>
+			<pre
+				class="mt-1 p-2 bg-dark-900/60 border border-dark-700 rounded overflow-x-auto whitespace-pre-wrap text-[11px] text-gray-300"
+				data-testid="pending-completion-action-mcp-args"
+			>
+				{JSON.stringify(action.args, null, 2)}
+			</pre>
+		</details>
+	);
+}

--- a/packages/web/src/components/space/SpaceOverview.tsx
+++ b/packages/web/src/components/space/SpaceOverview.tsx
@@ -11,7 +11,12 @@
 import { useState, useCallback } from 'preact/hooks';
 import type { RuntimeState, SpaceTask, SpaceAutonomyLevel } from '@neokai/shared';
 import { spaceStore } from '../../lib/space-store';
-import { navigateToSpaceTask, navigateToSpaceSession } from '../../lib/router';
+import {
+	navigateToSpaceTask,
+	navigateToSpaceSession,
+	navigateToSpaceTasks,
+} from '../../lib/router';
+import { currentSpaceTasksFilterSignal } from '../../lib/signals';
 import { createSession } from '../../lib/api-helpers';
 import { cn, getRelativeTime } from '../../lib/utils';
 import { toast } from '../../lib/toast';
@@ -346,8 +351,19 @@ export function SpaceOverview({ spaceId, onSelectTask }: SpaceOverviewProps) {
 	// Recent tasks — sorted by updatedAt, top 5
 	const recentTasks = [...tasks].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, 5);
 
+	// Awaiting-approval count: tasks paused at a completion action. Predicate
+	// matches the SpaceTasks filter chip exactly so the two surfaces agree.
+	const awaitingApprovalCount = tasks.filter(
+		(t) => t.pendingCheckpointType === 'completion_action'
+	).length;
+
 	const handleTaskClick =
 		onSelectTask ?? ((taskId: string) => navigateToSpaceTask(spaceId, taskId));
+
+	const handleAwaitingApprovalClick = () => {
+		currentSpaceTasksFilterSignal.value = 'awaiting_completion_action';
+		navigateToSpaceTasks(spaceId);
+	};
 
 	return (
 		<div class="flex-1 min-h-0 w-full px-4 py-4 sm:px-8 sm:py-6 overflow-y-auto">
@@ -390,6 +406,36 @@ export function SpaceOverview({ spaceId, onSelectTask }: SpaceOverviewProps) {
 						color="border-green-800/30 text-green-400"
 					/>
 				</div>
+
+				{/* Awaiting-approval summary — surfaces tasks paused at a completion
+				action as a single click-through. Hidden when the count is zero so it
+				doesn't add visual noise to happy-path dashboards. */}
+				{awaitingApprovalCount > 0 && (
+					<button
+						type="button"
+						onClick={handleAwaitingApprovalClick}
+						data-testid="awaiting-approval-summary"
+						class="w-full flex items-center justify-between rounded-xl border border-amber-800/40 bg-amber-900/20 px-5 py-3 text-left transition-colors hover:bg-amber-900/30"
+					>
+						<div class="flex items-center gap-3">
+							<span class="text-lg" aria-hidden="true">
+								⏸
+							</span>
+							<div>
+								<p class="text-sm font-semibold text-amber-200">
+									{awaitingApprovalCount} {awaitingApprovalCount === 1 ? 'task' : 'tasks'} awaiting
+									your approval
+								</p>
+								<p class="text-xs text-amber-300/70">
+									Paused at completion actions — click to review
+								</p>
+							</div>
+						</div>
+						<span class="text-amber-400/80 text-sm" aria-hidden="true">
+							&rarr;
+						</span>
+					</button>
+				)}
 
 				{/* Recent Tasks */}
 				<div>

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -14,6 +14,7 @@ import { TaskArtifactsPanel } from './TaskArtifactsPanel';
 import { getTransitionActions, TaskStatusActions } from './TaskStatusActions';
 import { TaskBlockedBanner } from './TaskBlockedBanner';
 import { PendingGateBanner } from './PendingGateBanner';
+import { PendingCompletionActionBanner } from './PendingCompletionActionBanner';
 import { ThreadedChatComposer } from './ThreadedChatComposer';
 import { ReadOnlyWorkflowCanvas } from './ReadOnlyWorkflowCanvas';
 import { Dropdown, type DropdownMenuItem } from '../ui/Dropdown';
@@ -333,6 +334,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 						status={task.status}
 						onTransition={handleStatusTransition}
 						disabled={statusTransitioning}
+						pendingCheckpointType={task.pendingCheckpointType}
 					/>
 				</div>
 			)}
@@ -426,13 +428,22 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 								onStatusTransition={handleStatusTransition}
 							/>
 						) : (
-							task.workflowRunId && (
-								<PendingGateBanner
-									runId={task.workflowRunId}
-									spaceId={runtimeSpaceId}
-									workflowId={canvasWorkflowId}
-								/>
-							)
+							<>
+								{task.pendingCheckpointType === 'completion_action' && (
+									<PendingCompletionActionBanner
+										task={task}
+										spaceId={runtimeSpaceId}
+										spaceAutonomyLevel={spaceStore.space.value?.autonomyLevel}
+									/>
+								)}
+								{task.workflowRunId && (
+									<PendingGateBanner
+										runId={task.workflowRunId}
+										spaceId={runtimeSpaceId}
+										workflowId={canvasWorkflowId}
+									/>
+								)}
+							</>
 						)}
 						<div class="flex-1 min-h-0" data-testid="task-thread-panel">
 							{hasUnifiedWorkflowThread ? (

--- a/packages/web/src/components/space/SpaceTasks.tsx
+++ b/packages/web/src/components/space/SpaceTasks.tsx
@@ -311,14 +311,13 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 	// Sync from the signal once, then clear it so the filter doesn't re-apply on
 	// re-renders or when the component remounts from an unrelated cause. The
 	// chip's own state is what persists for the duration of this view.
+	// Intentionally run once at mount; the signal is a one-shot hand-off.
 	useEffect(() => {
 		if (preFilter) {
 			setActiveFilter(preFilter);
 			setActiveTab('action');
 			currentSpaceTasksFilterSignal.value = null;
 		}
-		// Intentionally run once at mount; the signal is a one-shot hand-off.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	const awaitingApprovalCount = useMemo(

--- a/packages/web/src/components/space/SpaceTasks.tsx
+++ b/packages/web/src/components/space/SpaceTasks.tsx
@@ -8,12 +8,22 @@
  * matching the RoomTasks component style.
  */
 
-import { useMemo, useState } from 'preact/hooks';
+import { useEffect, useMemo, useState } from 'preact/hooks';
 import { spaceStore } from '../../lib/space-store';
 import type { SpaceBlockReason, SpaceTask, SpaceTaskStatus } from '@neokai/shared';
 import { getRelativeTime } from '../../lib/utils';
+import { currentSpaceTasksFilterSignal } from '../../lib/signals';
 
 type TaskFilterTab = 'action' | 'active' | 'completed' | 'archived';
+
+/**
+ * Predicate for the "Awaiting Approval" pre-filter chip — tasks paused at a
+ * completion action. Matches `SpaceOverview`'s summary count exactly so both
+ * surfaces stay in sync when the filter is activated via click-through.
+ */
+function isAwaitingCompletionAction(task: SpaceTask): boolean {
+	return task.pendingCheckpointType === 'completion_action';
+}
 
 /** Block reasons that indicate a task needs human attention */
 const ATTENTION_BLOCK_REASONS: SpaceBlockReason[] = ['human_input_requested', 'gate_rejected'];
@@ -289,7 +299,32 @@ interface SpaceTasksProps {
 
 export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps) {
 	const tasks = spaceStore.tasks.value;
-	const [activeTab, setActiveTab] = useState<TaskFilterTab>('active');
+	const preFilter = currentSpaceTasksFilterSignal.value;
+	// When the pre-filter is set (e.g. deep-link from the Overview summary),
+	// land on the Action tab so the filtered list is non-empty by default.
+	// Otherwise keep the default of "Active" — matches historical behavior for
+	// users coming in without a filter.
+	const initialTab: TaskFilterTab = preFilter ? 'action' : 'active';
+	const [activeTab, setActiveTab] = useState<TaskFilterTab>(initialTab);
+	const [activeFilter, setActiveFilter] = useState<'awaiting_completion_action' | null>(preFilter);
+
+	// Sync from the signal once, then clear it so the filter doesn't re-apply on
+	// re-renders or when the component remounts from an unrelated cause. The
+	// chip's own state is what persists for the duration of this view.
+	useEffect(() => {
+		if (preFilter) {
+			setActiveFilter(preFilter);
+			setActiveTab('action');
+			currentSpaceTasksFilterSignal.value = null;
+		}
+		// Intentionally run once at mount; the signal is a one-shot hand-off.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	const awaitingApprovalCount = useMemo(
+		() => tasks.filter(isAwaitingCompletionAction).length,
+		[tasks]
+	);
 
 	const counts = useMemo(() => {
 		const c: Record<TaskFilterTab, number> = {
@@ -314,10 +349,12 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 
 	const filteredTasks = useMemo(() => {
 		const statuses = TAB_GROUPS[activeTab];
-		return [...tasks]
-			.filter((t) => statuses.includes(t.status as SpaceTaskStatus))
-			.sort((a, b) => b.updatedAt - a.updatedAt);
-	}, [tasks, activeTab]);
+		let list = [...tasks].filter((t) => statuses.includes(t.status as SpaceTaskStatus));
+		if (activeFilter === 'awaiting_completion_action') {
+			list = list.filter(isAwaitingCompletionAction);
+		}
+		return list.sort((a, b) => b.updatedAt - a.updatedAt);
+	}, [tasks, activeTab, activeFilter]);
 
 	if (tasks.length === 0) {
 		return (
@@ -373,6 +410,42 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 						variant="gray"
 					/>
 				</div>
+
+				{/* Awaiting-approval filter chip — visible when at least one task is
+				paused at a completion action. Toggling on narrows the list to those
+				tasks only; toggling off restores the full tab view. The count here
+				matches the Overview summary verbatim so click-through parity holds. */}
+				{awaitingApprovalCount > 0 && (
+					<div class="flex items-center gap-2" data-testid="space-tasks-filter-bar">
+						<button
+							type="button"
+							onClick={() =>
+								setActiveFilter((f) =>
+									f === 'awaiting_completion_action' ? null : 'awaiting_completion_action'
+								)
+							}
+							data-testid="tasks-filter-awaiting-approval"
+							aria-pressed={activeFilter === 'awaiting_completion_action'}
+							class={`px-2.5 py-1 text-xs font-medium rounded-full border transition-colors ${
+								activeFilter === 'awaiting_completion_action'
+									? 'bg-amber-900/40 text-amber-200 border-amber-700/60'
+									: 'bg-dark-800 text-gray-300 border-dark-600 hover:bg-dark-700'
+							}`}
+						>
+							⏸ Awaiting Approval ({awaitingApprovalCount})
+						</button>
+						{activeFilter === 'awaiting_completion_action' && (
+							<button
+								type="button"
+								onClick={() => setActiveFilter(null)}
+								data-testid="tasks-filter-clear"
+								class="text-xs text-gray-500 hover:text-gray-300"
+							>
+								Clear filter
+							</button>
+						)}
+					</div>
+				)}
 
 				{filteredTasks.length === 0 ? (
 					<EmptyTabState tab={activeTab} />

--- a/packages/web/src/components/space/TaskStatusActions.tsx
+++ b/packages/web/src/components/space/TaskStatusActions.tsx
@@ -72,10 +72,30 @@ interface TaskStatusActionsProps {
 	status: SpaceTaskStatus;
 	onTransition: (newStatus: SpaceTaskStatus) => void;
 	disabled?: boolean;
+	/**
+	 * Type of checkpoint the task is paused at, if any. When set to
+	 * `completion_action`, the generic Approve/Reject transitions are hidden
+	 * and routed through `PendingCompletionActionBanner` instead — the banner
+	 * shows what would actually run on approval, which the generic button can't.
+	 */
+	pendingCheckpointType?: 'completion_action' | 'gate' | null;
 }
 
-export function TaskStatusActions({ status, onTransition, disabled }: TaskStatusActionsProps) {
-	const actions = getTransitionActions(status);
+export function TaskStatusActions({
+	status,
+	onTransition,
+	disabled,
+	pendingCheckpointType,
+}: TaskStatusActionsProps) {
+	const allActions = getTransitionActions(status);
+	// When a task is paused at a completion action, hide the generic Approve
+	// (review → done) and Cancel (review → cancelled) buttons. The banner owns
+	// those transitions so it can disclose what the approval will actually run.
+	// Non-checkpoint transitions (e.g. Reopen → in_progress, Archive) stay visible.
+	const actions =
+		pendingCheckpointType === 'completion_action'
+			? allActions.filter(({ target }) => target !== 'done' && target !== 'cancelled')
+			: allActions;
 
 	if (actions.length === 0) {
 		return (

--- a/packages/web/src/components/space/__tests__/PendingCompletionActionBanner.test.tsx
+++ b/packages/web/src/components/space/__tests__/PendingCompletionActionBanner.test.tsx
@@ -1,0 +1,293 @@
+/**
+ * Unit tests for PendingCompletionActionBanner.
+ *
+ * Covers the Done criteria from the task:
+ *   - renders name + description (type line) + required level vs space level
+ *   - Approve calls spaceStore.updateTask with status='done'
+ *   - Reject opens a confirmation modal; confirm cancels the task
+ *   - Script details collapsed by default (<details>)
+ *   - Hidden when pendingCheckpointType !== 'completion_action'
+ *
+ * Plus regressions:
+ *   - Hidden when the resolved action is missing (workflow edited)
+ *   - Reject clears pendingActionIndex / pendingCheckpointType so the
+ *     awaiting-approval summary stays in sync
+ */
+
+// @ts-nocheck
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/preact';
+import { signal } from '@preact/signals';
+import type {
+	ScriptCompletionAction,
+	SpaceTask,
+	SpaceWorkflow,
+	SpaceWorkflowRun,
+} from '@neokai/shared';
+
+// Mock space-store
+const workflowsSignal = signal<SpaceWorkflow[]>([]);
+const workflowRunsSignal = signal<SpaceWorkflowRun[]>([]);
+const updateTaskMock: Mock = vi.fn();
+
+vi.mock('../../../lib/space-store', () => ({
+	spaceStore: {
+		get workflows() {
+			return workflowsSignal;
+		},
+		get workflowRuns() {
+			return workflowRunsSignal;
+		},
+		updateTask: (...args: unknown[]) => updateTaskMock(...args),
+	},
+}));
+
+import { PendingCompletionActionBanner } from '../PendingCompletionActionBanner';
+
+function makeScriptAction(overrides: Partial<ScriptCompletionAction> = {}): ScriptCompletionAction {
+	return {
+		id: 'a1',
+		name: 'merge-pr',
+		type: 'script',
+		requiredLevel: 3,
+		script: 'gh pr merge --squash $PR_NUMBER',
+		...overrides,
+	};
+}
+
+function makeWorkflow(action: ScriptCompletionAction): SpaceWorkflow {
+	return {
+		id: 'wf-1',
+		spaceId: 'space-1',
+		name: 'wf',
+		description: '',
+		nodes: [
+			{
+				id: 'end-node',
+				name: 'end',
+				agents: [{ agentId: 'agent-a', name: 'a' }],
+				completionActions: [action],
+			},
+		],
+		channels: [],
+		gates: [],
+		startNodeId: 'end-node',
+		endNodeId: 'end-node',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	} as unknown as SpaceWorkflow;
+}
+
+function makeRun(): SpaceWorkflowRun {
+	return {
+		id: 'run-1',
+		spaceId: 'space-1',
+		workflowId: 'wf-1',
+		title: 'run',
+		status: 'running',
+		startedAt: Date.now(),
+		completedAt: null,
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	} as unknown as SpaceWorkflowRun;
+}
+
+let taskCounter = 0;
+function makeTask(overrides: Partial<SpaceTask> = {}): SpaceTask {
+	return {
+		id: 't1',
+		spaceId: 'space-1',
+		taskNumber: ++taskCounter,
+		title: 'Task',
+		description: '',
+		status: 'review',
+		priority: 'normal',
+		labels: [],
+		dependsOn: [],
+		result: null,
+		startedAt: null,
+		completedAt: null,
+		archivedAt: null,
+		blockReason: null,
+		approvalSource: null,
+		approvalReason: null,
+		approvedAt: null,
+		pendingActionIndex: 0,
+		pendingCheckpointType: 'completion_action',
+		reportedStatus: null,
+		reportedSummary: null,
+		workflowRunId: 'run-1',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	} as SpaceTask;
+}
+
+describe('PendingCompletionActionBanner', () => {
+	beforeEach(() => {
+		cleanup();
+		updateTaskMock.mockReset();
+		updateTaskMock.mockResolvedValue({});
+		workflowsSignal.value = [makeWorkflow(makeScriptAction())];
+		workflowRunsSignal.value = [makeRun()];
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders with action name, type, and required / current level', () => {
+		const task = makeTask();
+		const { getByTestId } = render(
+			<PendingCompletionActionBanner task={task} spaceId="space-1" spaceAutonomyLevel={1} />
+		);
+		const banner = getByTestId('pending-completion-action-banner');
+		expect(banner.textContent).toContain('merge-pr');
+		const typeLine = getByTestId('pending-completion-action-type').textContent ?? '';
+		expect(typeLine).toContain('Bash script');
+		expect(typeLine).toContain('Level 3');
+		const current = getByTestId('pending-completion-action-current-level').textContent ?? '';
+		expect(current).toContain('Level 1');
+	});
+
+	it('is hidden when pendingCheckpointType is not completion_action', () => {
+		const task = makeTask({ pendingCheckpointType: 'gate' });
+		const { queryByTestId } = render(
+			<PendingCompletionActionBanner task={task} spaceId="space-1" />
+		);
+		expect(queryByTestId('pending-completion-action-banner')).toBeNull();
+	});
+
+	it('is hidden when pendingActionIndex is null', () => {
+		const task = makeTask({ pendingActionIndex: null });
+		const { queryByTestId } = render(
+			<PendingCompletionActionBanner task={task} spaceId="space-1" />
+		);
+		expect(queryByTestId('pending-completion-action-banner')).toBeNull();
+	});
+
+	it('is hidden when the workflow run is not in the store (stale render)', () => {
+		workflowRunsSignal.value = [];
+		const task = makeTask();
+		const { queryByTestId } = render(
+			<PendingCompletionActionBanner task={task} spaceId="space-1" />
+		);
+		expect(queryByTestId('pending-completion-action-banner')).toBeNull();
+	});
+
+	it('is hidden when pendingActionIndex is out of range (workflow edited)', () => {
+		const task = makeTask({ pendingActionIndex: 5 });
+		const { queryByTestId } = render(
+			<PendingCompletionActionBanner task={task} spaceId="space-1" />
+		);
+		expect(queryByTestId('pending-completion-action-banner')).toBeNull();
+	});
+
+	it('script details are collapsed by default', () => {
+		const task = makeTask();
+		const { getByTestId } = render(<PendingCompletionActionBanner task={task} spaceId="space-1" />);
+		const details = getByTestId('pending-completion-action-details') as HTMLDetailsElement;
+		expect(details.tagName.toLowerCase()).toBe('details');
+		expect(details.open).toBe(false);
+		// But the script source is in the DOM (ready to reveal).
+		const source = getByTestId('pending-completion-action-script').textContent ?? '';
+		expect(source).toContain('gh pr merge');
+	});
+
+	it('Approve calls spaceStore.updateTask with status="done"', async () => {
+		const task = makeTask();
+		const { getByTestId } = render(<PendingCompletionActionBanner task={task} spaceId="space-1" />);
+		fireEvent.click(getByTestId('pending-completion-action-approve-btn'));
+		await waitFor(() => expect(updateTaskMock).toHaveBeenCalledTimes(1));
+		expect(updateTaskMock).toHaveBeenCalledWith(task.id, { status: 'done' });
+	});
+
+	it('Reject opens confirmation modal; confirm cancels task and clears pending fields', async () => {
+		const task = makeTask();
+		const { getByTestId, queryByTestId } = render(
+			<PendingCompletionActionBanner task={task} spaceId="space-1" />
+		);
+		// Modal is not open by default
+		expect(queryByTestId('pending-completion-action-reject-confirm')).toBeNull();
+
+		fireEvent.click(getByTestId('pending-completion-action-reject-btn'));
+		const confirmBtn = await waitFor(() => getByTestId('pending-completion-action-reject-confirm'));
+
+		// Add an optional reason
+		const textarea = getByTestId('pending-completion-action-reject-reason') as HTMLTextAreaElement;
+		fireEvent.input(textarea, { target: { value: 'script is unsafe' } });
+
+		fireEvent.click(confirmBtn);
+		await waitFor(() => expect(updateTaskMock).toHaveBeenCalledTimes(1));
+		expect(updateTaskMock).toHaveBeenCalledWith(task.id, {
+			status: 'cancelled',
+			pendingActionIndex: null,
+			pendingCheckpointType: null,
+			result: 'script is unsafe',
+		});
+	});
+
+	it('Reject without reason still clears pending fields', async () => {
+		const task = makeTask();
+		const { getByTestId } = render(<PendingCompletionActionBanner task={task} spaceId="space-1" />);
+		fireEvent.click(getByTestId('pending-completion-action-reject-btn'));
+		const confirmBtn = await waitFor(() => getByTestId('pending-completion-action-reject-confirm'));
+		fireEvent.click(confirmBtn);
+		await waitFor(() => expect(updateTaskMock).toHaveBeenCalledTimes(1));
+		const [, payload] = updateTaskMock.mock.calls[0];
+		expect(payload.status).toBe('cancelled');
+		expect(payload.pendingActionIndex).toBeNull();
+		expect(payload.pendingCheckpointType).toBeNull();
+		expect(payload.result).toBeUndefined();
+	});
+
+	it('surfaces approval errors inline without throwing', async () => {
+		updateTaskMock.mockRejectedValueOnce(new Error('network down'));
+		const task = makeTask();
+		const { getByTestId } = render(<PendingCompletionActionBanner task={task} spaceId="space-1" />);
+		fireEvent.click(getByTestId('pending-completion-action-approve-btn'));
+		const err = await waitFor(() => getByTestId('pending-completion-action-error'));
+		expect(err.textContent).toContain('network down');
+	});
+
+	it('renders instruction details for instruction actions', () => {
+		workflowsSignal.value = [
+			makeWorkflow({
+				id: 'a2',
+				name: 'notify-team',
+				type: 'instruction',
+				requiredLevel: 2,
+				targetNodeId: 'n-x',
+				instruction: 'Post a summary to #eng',
+			}),
+		];
+		const task = makeTask();
+		const { getByTestId } = render(<PendingCompletionActionBanner task={task} spaceId="space-1" />);
+		const details = getByTestId('pending-completion-action-details');
+		expect(details.getAttribute('data-action-type')).toBe('instruction');
+		expect(getByTestId('pending-completion-action-instruction').textContent).toContain(
+			'Post a summary'
+		);
+	});
+
+	it('renders MCP details for mcp_call actions', () => {
+		workflowsSignal.value = [
+			makeWorkflow({
+				id: 'a3',
+				name: 'create-ticket',
+				type: 'mcp_call',
+				requiredLevel: 4,
+				server: 'linear',
+				tool: 'createIssue',
+				args: { title: '{{artifact.title}}', team: 'eng' },
+			}),
+		];
+		const task = makeTask();
+		const { getByTestId } = render(<PendingCompletionActionBanner task={task} spaceId="space-1" />);
+		const details = getByTestId('pending-completion-action-details');
+		expect(details.getAttribute('data-action-type')).toBe('mcp_call');
+		const args = getByTestId('pending-completion-action-mcp-args').textContent ?? '';
+		expect(args).toContain('title');
+		expect(args).toContain('{{artifact.title}}');
+	});
+});

--- a/packages/web/src/components/space/__tests__/SpaceOverview.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceOverview.test.tsx
@@ -39,9 +39,12 @@ vi.mock('../../../lib/space-store', () => ({
 	},
 }));
 
+const navigateToSpaceTasksMock = vi.fn();
 vi.mock('../../../lib/router', () => ({
 	navigateToSpaceTask: vi.fn(),
 	navigateToSpaceAgent: vi.fn(),
+	navigateToSpaceSession: vi.fn(),
+	navigateToSpaceTasks: (...args: unknown[]) => navigateToSpaceTasksMock(...args),
 }));
 
 mockSpace = signal<Space | null>(null);
@@ -397,6 +400,66 @@ describe('SpaceOverview', () => {
 			const { container } = render(<SpaceOverview spaceId="space-1" />);
 			const segment1 = container.querySelector('[data-testid="overview-autonomy-1"]')!;
 			expect(segment1.getAttribute('aria-label')).toBe('Supervised');
+		});
+	});
+
+	describe('Awaiting Approval Summary', () => {
+		beforeEach(() => {
+			navigateToSpaceTasksMock.mockClear();
+		});
+
+		it('is hidden when no tasks are paused at a completion action', () => {
+			mockSpace.value = makeSpace();
+			mockTasks.value = [makeTask('t1', 'in_progress')];
+			const { queryByTestId } = render(<SpaceOverview spaceId="space-1" />);
+			expect(queryByTestId('awaiting-approval-summary')).toBeNull();
+		});
+
+		it('renders count when tasks are paused at completion actions', () => {
+			mockSpace.value = makeSpace();
+			mockTasks.value = [
+				makeTask('t1', 'review', {
+					pendingActionIndex: 0,
+					pendingCheckpointType: 'completion_action',
+				}),
+				makeTask('t2', 'review', {
+					pendingActionIndex: 1,
+					pendingCheckpointType: 'completion_action',
+				}),
+				// Gate-paused task should not contribute to the count
+				makeTask('t3', 'review', {
+					pendingCheckpointType: 'gate',
+				}),
+			];
+			const { getByTestId } = render(<SpaceOverview spaceId="space-1" />);
+			const summary = getByTestId('awaiting-approval-summary');
+			expect(summary.textContent).toContain('2');
+			expect(summary.textContent).toContain('awaiting your approval');
+		});
+
+		it('uses singular "task" when count is 1', () => {
+			mockSpace.value = makeSpace();
+			mockTasks.value = [
+				makeTask('t1', 'review', {
+					pendingActionIndex: 0,
+					pendingCheckpointType: 'completion_action',
+				}),
+			];
+			const { getByTestId } = render(<SpaceOverview spaceId="space-1" />);
+			expect(getByTestId('awaiting-approval-summary').textContent).toContain('1 task');
+		});
+
+		it('clicking the summary navigates to the tasks view', () => {
+			mockSpace.value = makeSpace();
+			mockTasks.value = [
+				makeTask('t1', 'review', {
+					pendingActionIndex: 0,
+					pendingCheckpointType: 'completion_action',
+				}),
+			];
+			const { getByTestId } = render(<SpaceOverview spaceId="space-1" />);
+			fireEvent.click(getByTestId('awaiting-approval-summary'));
+			expect(navigateToSpaceTasksMock).toHaveBeenCalledWith('space-1');
 		});
 	});
 });

--- a/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
@@ -226,4 +226,52 @@ describe('SpaceTasks', () => {
 		// Open group not shown (no open tasks)
 		expect(queryByText(/Open \(/)).toBeNull();
 	});
+
+	describe('Awaiting-approval filter chip', () => {
+		it('is hidden when no tasks are paused at a completion action', () => {
+			mockTasks.value = [makeTask('t1', 'review')];
+			const { queryByTestId, getByText } = render(<SpaceTasks spaceId="space-1" />);
+			fireEvent.click(getByText('Action'));
+			expect(queryByTestId('tasks-filter-awaiting-approval')).toBeNull();
+		});
+
+		it('shows chip with count when at least one task is paused at a completion action', () => {
+			mockTasks.value = [
+				makeTask('t1', 'review', {
+					pendingActionIndex: 0,
+					pendingCheckpointType: 'completion_action',
+				}),
+				makeTask('t2', 'review'),
+			];
+			const { getByTestId, getByText } = render(<SpaceTasks spaceId="space-1" />);
+			fireEvent.click(getByText('Action'));
+			const chip = getByTestId('tasks-filter-awaiting-approval');
+			expect(chip.textContent).toContain('Awaiting Approval');
+			expect(chip.textContent).toContain('1');
+		});
+
+		it('filters the list to awaiting-approval tasks only when toggled on', () => {
+			mockTasks.value = [
+				makeTask('t1', 'review', {
+					pendingActionIndex: 0,
+					pendingCheckpointType: 'completion_action',
+				}),
+				makeTask('t2', 'review'),
+			];
+			const { getByTestId, getByText, queryByText } = render(<SpaceTasks spaceId="space-1" />);
+			fireEvent.click(getByText('Action'));
+			// Both tasks visible by default (action tab: blocked + review)
+			expect(getByText('Task t1')).toBeTruthy();
+			expect(getByText('Task t2')).toBeTruthy();
+
+			// Toggle the filter chip on
+			fireEvent.click(getByTestId('tasks-filter-awaiting-approval'));
+			expect(getByText('Task t1')).toBeTruthy();
+			expect(queryByText('Task t2')).toBeNull();
+
+			// Toggle off via Clear filter
+			fireEvent.click(getByTestId('tasks-filter-clear'));
+			expect(getByText('Task t2')).toBeTruthy();
+		});
+	});
 });

--- a/packages/web/src/components/space/__tests__/TaskStatusActions.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskStatusActions.test.tsx
@@ -192,4 +192,46 @@ describe('TaskStatusActions component', () => {
 		const { getByTestId } = render(<TaskStatusActions status="open" onTransition={onTransition} />);
 		expect(getByTestId('task-status-actions')).toBeTruthy();
 	});
+
+	describe('pendingCheckpointType gating', () => {
+		it('hides Approve (done) and Cancel (cancelled) when paused at completion action', () => {
+			const onTransition = vi.fn();
+			const { queryByTestId, getByTestId } = render(
+				<TaskStatusActions
+					status="review"
+					onTransition={onTransition}
+					pendingCheckpointType="completion_action"
+				/>
+			);
+			// "review -> done" / "review -> cancelled" are owned by the banner now
+			expect(queryByTestId('task-action-done')).toBeNull();
+			expect(queryByTestId('task-action-cancelled')).toBeNull();
+			// Non-approval transitions stay visible so the user can still reopen or archive.
+			expect(getByTestId('task-action-in_progress')).toBeTruthy();
+			expect(getByTestId('task-action-archived')).toBeTruthy();
+		});
+
+		it('keeps Approve / Cancel visible when pendingCheckpointType is gate or null', () => {
+			const onTransition = vi.fn();
+			const { getByTestId, rerender } = render(
+				<TaskStatusActions
+					status="review"
+					onTransition={onTransition}
+					pendingCheckpointType={null}
+				/>
+			);
+			expect(getByTestId('task-action-done')).toBeTruthy();
+			expect(getByTestId('task-action-cancelled')).toBeTruthy();
+
+			rerender(
+				<TaskStatusActions
+					status="review"
+					onTransition={onTransition}
+					pendingCheckpointType="gate"
+				/>
+			);
+			expect(getByTestId('task-action-done')).toBeTruthy();
+			expect(getByTestId('task-action-cancelled')).toBeTruthy();
+		});
+	});
 });

--- a/packages/web/src/lib/signals.ts
+++ b/packages/web/src/lib/signals.ts
@@ -46,6 +46,14 @@ export const currentSpaceTaskIdSignal = signal<string | null>(null);
 export type SpaceViewMode = 'overview' | 'tasks' | 'sessions' | 'configure';
 export const currentSpaceViewModeSignal = signal<SpaceViewMode>('overview');
 
+// Tasks-view pre-filter, used by callers like the SpaceOverview awaiting-approval
+// summary to deep-link into a filtered tasks list (e.g. "completion-action pauses
+// only"). Set on navigation; SpaceTasks consumes it and reverts to null on the
+// next explicit tab click to avoid sticky filters. Kept as a signal rather than
+// a URL query param to avoid URL churn when the count drops to zero.
+export type SpaceTasksFilter = 'awaiting_completion_action' | null;
+export const currentSpaceTasksFilterSignal = signal<SpaceTasksFilter>(null);
+
 // Overlay signals — session shown in slide-over panel on top of the current view
 // When spaceOverlaySessionIdSignal is set, opens AgentOverlayChat without replacing the task/overview view
 export const spaceOverlaySessionIdSignal = signal<string | null>(null);


### PR DESCRIPTION
## Summary
- Adds `PendingCompletionActionBanner`: thread-view CTA that renders when a task is paused at a workflow end-node `completionAction`. Shows the action name, type line, required vs current autonomy level, and a collapsible `<details>` with the script / instruction / MCP args. Approve routes through `spaceTask.update({status: 'done'})` (daemon intercepts and runs `resumeCompletionActions`). Reject opens a confirmation modal and cancels the task, explicitly clearing `pendingActionIndex` / `pendingCheckpointType` so the awaiting-approval summary stays in sync.
- Adds a space-level "N tasks awaiting your approval" summary on `SpaceOverview` (hidden when count is zero) that deep-links to `SpaceTasks` with the action tab and the awaiting-approval filter preselected via a one-shot signal.
- Adds a reusable filter chip + "Clear filter" action in `SpaceTasks` for narrowing the list to tasks paused at completion actions.
- Makes `TaskStatusActions` pause-aware: when `pendingCheckpointType === 'completion_action'`, the generic Approve / Cancel transitions are hidden so the banner owns the approval surface.

## Test plan
- [x] `bun run check` (lint + typecheck + knip)
- [x] Vitest: `PendingCompletionActionBanner` (12 cases), `TaskStatusActions` pause-gating, `SpaceTasks` filter chip, `SpaceOverview` awaiting-approval summary — 93 tests in the affected files, all passing
- [x] Full `packages/web` vitest run — all new tests green; one pre-existing Suspense-timing flake in `SpaceIsland.test.tsx` is unrelated and passes in isolation
- [ ] Playwright `space-completion-action-approval.e2e.ts` — exercises the banner UI, Reject modal flow, and the overview deep-link (runs in CI)