### PR TITLE
feat(space): audit trail for completion-action approvals (approvalReason + thread events)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -160,14 +160,24 @@ export function setupSpaceTaskHandlers(
 					updateParams.status === 'done' &&
 					currentTask.pendingCheckpointType === 'completion_action'
 				) {
-					const resumed = await spaceRuntimeService.resumeCompletionActions(spaceId, taskId);
+					const resumed = await spaceRuntimeService.resumeCompletionActions(spaceId, taskId, {
+						approvalReason: updateParams.approvalReason ?? null,
+					});
 					if (resumed) {
 						task = resumed;
 						// Status is excluded — the resume path already set the final status
-						// (done / blocked / review). Forward `result` so a caller-supplied
-						// audit summary (e.g. "LGTM") lands alongside it. The resume path
-						// emits internally, so we only emit again when extra fields merged.
-						const { status: _s, ...otherFields } = updateParams;
+						// (done / blocked / review). approvalReason has already been
+						// persisted by the runtime on the terminal `done` transition, so
+						// drop it here to avoid a redundant write. Forward any OTHER
+						// caller-supplied fields (e.g. `result`, a corrected title) so
+						// they land alongside the resumed task. The resume path emits
+						// internally, so we only emit again when extra fields merged.
+						const {
+							status: _s,
+							approvalReason: _ar,
+							cancelReason: _cr,
+							...otherFields
+						} = updateParams;
 						if (Object.keys(otherFields).length > 0) {
 							task = await taskManager.updateTask(taskId, otherFields);
 							daemonHub
@@ -193,20 +203,50 @@ export function setupSpaceTaskHandlers(
 					);
 				}
 
-				// Status is changing — validate via setTaskStatus (enforces transitions)
+				// Status is changing — validate via setTaskStatus (enforces transitions).
+				// `approvalReason` is stamped on review→done; `cancelReason` is
+				// persisted into the same underlying column for review→cancelled
+				// transitions (and other terminal rejections). We map both onto the
+				// manager's `approvalReason` option because the DB schema keeps a
+				// single `approval_reason` column doubling as audit trail for
+				// approvals *and* rejections.
+				const mappedReason =
+					updateParams.status === 'cancelled'
+						? (updateParams.cancelReason ?? updateParams.approvalReason ?? undefined)
+						: (updateParams.approvalReason ?? undefined);
+
 				task = await taskManager.setTaskStatus(taskId, updateParams.status, {
 					result: updateParams.result ?? undefined,
 					// Human-initiated approval when transitioning from review → done
 					approvalSource:
 						currentTask.status === 'review' && updateParams.status === 'done' ? 'human' : undefined,
-					approvalReason: updateParams.approvalReason ?? undefined,
+					approvalReason: mappedReason,
 				});
+
+				// When the transition alone cannot carry the rejection reason (e.g.
+				// review → cancelled — setTaskStatus only stamps approvalReason on
+				// review→done), apply it in a follow-up write. Keeps the audit trail
+				// complete regardless of direction.
+				if (
+					updateParams.status === 'cancelled' &&
+					(updateParams.cancelReason ?? updateParams.approvalReason)
+				) {
+					task = await taskManager.updateTask(taskId, {
+						approvalReason: updateParams.cancelReason ?? updateParams.approvalReason ?? null,
+					});
+				}
 
 				// When a status transition is combined with other field updates
 				// (e.g. taskAgentSessionId), those fields are silently dropped by
 				// setTaskStatus. Apply them in a follow-up updateTask call so
 				// callers can atomically set status + metadata in one RPC.
-				const { status: _s, result: _r, ...otherFields } = updateParams;
+				const {
+					status: _s,
+					result: _r,
+					approvalReason: _ar,
+					cancelReason: _cr,
+					...otherFields
+				} = updateParams;
 				if (Object.keys(otherFields).length > 0) {
 					task = await taskManager.updateTask(taskId, otherFields);
 				}

--- a/packages/daemon/src/lib/space/runtime/notification-sink.ts
+++ b/packages/daemon/src/lib/space/runtime/notification-sink.ts
@@ -123,6 +123,43 @@ export interface WorkflowRunNeedsAttentionEvent {
 	timestamp: string;
 }
 
+/**
+ * A completion action attached to a workflow's Done node has successfully
+ * executed. Emitted once per action — both for human-approved resumes and for
+ * actions that auto-executed under sufficient autonomy.
+ *
+ * Used for audit trail and for rendering a visible record of "what actually
+ * ran" in the task's thread.
+ */
+export interface CompletionActionExecutedEvent {
+	kind: 'completion_action_executed';
+	/** Space the task belongs to. */
+	spaceId: string;
+	/** Task whose end-node completion actions are being processed. */
+	taskId: string;
+	/** Workflow run that owns the Done node with completion actions. */
+	runId: string;
+	/** Completion action id (stable, from the workflow definition). */
+	actionId: string;
+	/** Human-readable name of the executed action. */
+	actionName: string;
+	/**
+	 * Who authorized this execution:
+	 * - `human`: a user explicitly approved via `spaceTask.update` / `approve_task`.
+	 * - `auto_policy`: space autonomy level was high enough to execute without review.
+	 */
+	approvedBy: 'human' | 'auto_policy';
+	/**
+	 * Optional rationale supplied by the approver. Only populated for
+	 * `approvedBy === 'human'`; null otherwise.
+	 */
+	approvalReason: string | null;
+	/** ISO-8601 timestamp when execution completed. */
+	executedAt: string;
+	/** ISO-8601 timestamp when the event was emitted (same value as executedAt). */
+	timestamp: string;
+}
+
 /** A workflow run has reached a terminal state (done, cancelled, or blocked). */
 export interface WorkflowRunCompletedEvent {
 	kind: 'workflow_run_completed';
@@ -174,7 +211,8 @@ export type SpaceNotificationEvent =
 	| AgentAutoCompletedEvent
 	| AgentCrashEvent
 	| TaskRetryEvent
-	| WorkflowRunNeedsAttentionEvent;
+	| WorkflowRunNeedsAttentionEvent
+	| CompletionActionExecutedEvent;
 
 // ---------------------------------------------------------------------------
 // NotificationSink interface

--- a/packages/daemon/src/lib/space/runtime/session-notification-sink.ts
+++ b/packages/daemon/src/lib/space/runtime/session-notification-sink.ts
@@ -117,6 +117,8 @@ export function formatEventMessage(
 			return formatTaskRetry(event, autonomyLevel);
 		case 'workflow_run_needs_attention':
 			return formatWorkflowRunNeedsAttention(event, autonomyLevel);
+		case 'completion_action_executed':
+			return formatCompletionActionExecuted(event, autonomyLevel);
 	}
 }
 
@@ -322,6 +324,42 @@ function formatWorkflowRunNeedsAttention(
 		taskId: event.taskId,
 		reason: event.reason,
 		retriesExhausted: event.retriesExhausted,
+		timestamp: event.timestamp,
+		autonomyLevel,
+	});
+}
+
+function formatCompletionActionExecuted(
+	event: {
+		kind: 'completion_action_executed';
+		spaceId: string;
+		taskId: string;
+		runId: string;
+		actionId: string;
+		actionName: string;
+		approvedBy: 'human' | 'auto_policy';
+		approvalReason: string | null;
+		executedAt: string;
+		timestamp: string;
+	},
+	autonomyLevel: SpaceAutonomyLevel
+): string {
+	const approverLabel = event.approvedBy === 'human' ? 'a human reviewer' : 'auto-policy';
+	const reasonSuffix = event.approvalReason ? ` Reason: ${event.approvalReason}` : '';
+	const humanReadable =
+		`Completion action "${event.actionName}" (${event.actionId}) on task ${event.taskId} ` +
+		`in space ${event.spaceId} was approved by ${approverLabel} and executed successfully.` +
+		reasonSuffix;
+	return buildMessage(event.kind, humanReadable, {
+		kind: event.kind,
+		spaceId: event.spaceId,
+		taskId: event.taskId,
+		runId: event.runId,
+		actionId: event.actionId,
+		actionName: event.actionName,
+		approvedBy: event.approvedBy,
+		approvalReason: event.approvalReason,
+		executedAt: event.executedAt,
 		timestamp: event.timestamp,
 		autonomyLevel,
 	});

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -503,8 +503,15 @@ export class SpaceRuntimeService {
 	 * Delegates to SpaceRuntime.resumeCompletionActions(). Called from the
 	 * spaceTask.update RPC handler when a human approves a task that was paused
 	 * at a completion action checkpoint.
+	 *
+	 * @param options.approvalReason Optional human-supplied rationale for the
+	 *   approval. Persisted on the resulting task record for audit.
 	 */
-	async resumeCompletionActions(spaceId: string, taskId: string): Promise<SpaceTask | null> {
-		return this.runtime.resumeCompletionActions(spaceId, taskId);
+	async resumeCompletionActions(
+		spaceId: string,
+		taskId: string,
+		options?: { approvalReason?: string | null }
+	): Promise<SpaceTask | null> {
+		return this.runtime.resumeCompletionActions(spaceId, taskId, options);
 	}
 }

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -44,6 +44,7 @@ import { WorkflowExecutor } from './workflow-executor';
 import { selectWorkflow } from './workflow-selector';
 import { Logger } from '../../logger';
 import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
+import { SDKMessageRepository } from '../../../storage/repositories/sdk-message-repository';
 import { type NotificationSink, NullNotificationSink } from './notification-sink';
 import { buildRestrictedEnv, collectWithMaxBuffer, MAX_BUFFER_BYTES } from './gate-script-executor';
 import { CompletionDetector } from './completion-detector';
@@ -108,6 +109,13 @@ export interface SpaceRuntimeConfig {
 	 * artifact data from the workflow run for script env injection.
 	 */
 	artifactRepo?: WorkflowRunArtifactRepository;
+	/**
+	 * Optional SDK message repository used to emit synthetic SDK messages into
+	 * a task's agent session (e.g. the `completion_action_executed` marker
+	 * rendered by `SpaceTaskUnifiedThread`). Defaults to a repo constructed
+	 * from `db` if not provided — tests can inject a stub to assert emissions.
+	 */
+	sdkMessageRepo?: SDKMessageRepository;
 	/**
 	 * Optional callback emitted when runtime mutates a SpaceTask internally.
 	 * Used to fan out `space.task.updated` events for UI synchronization.
@@ -194,6 +202,13 @@ export class SpaceRuntime {
 	private notificationSink: NotificationSink;
 
 	/**
+	 * Lazy-initialized SDK message repository used for thread-event emission.
+	 * Sourced from `config.sdkMessageRepo` when provided, otherwise constructed
+	 * on first use from `config.db`.
+	 */
+	private sdkMessageRepo: SDKMessageRepository | null = null;
+
+	/**
 	 * Completion detector — inspects canonical `SpaceTask` to decide completion.
 	 * Initialized from config or defaulted to `new CompletionDetector(taskRepo)`.
 	 */
@@ -241,6 +256,49 @@ export class SpaceRuntime {
 	constructor(private config: SpaceRuntimeConfig) {
 		this.notificationSink = config.notificationSink ?? new NullNotificationSink();
 		this.completionDetector = config.completionDetector ?? new CompletionDetector(config.taskRepo);
+		this.sdkMessageRepo = config.sdkMessageRepo ?? null;
+	}
+
+	/**
+	 * Lazy accessor for the SDK message repository. Constructed from `config.db`
+	 * on first use when the caller did not inject one. Centralized here so
+	 * emission sites can stay one-liners and tests can inject a stub via config.
+	 */
+	private getSdkMessageRepo(): SDKMessageRepository {
+		if (!this.sdkMessageRepo) {
+			this.sdkMessageRepo = new SDKMessageRepository(this.config.db);
+		}
+		return this.sdkMessageRepo;
+	}
+
+	/**
+	 * Persist a synthetic SDK `system` message into the target session so it
+	 * surfaces in `SpaceTaskUnifiedThread`. Failures are logged and swallowed —
+	 * thread-event emission must never block a resume or fail a task.
+	 *
+	 * @internal — public for testing only.
+	 */
+	emitTaskThreadEvent(sessionId: string, subtype: string, payload: Record<string, unknown>): void {
+		try {
+			// Shape mirrors the SDK system message contract expected by the web
+			// thread renderer (`isSDKSystemMessage` + subtype switch in
+			// `space-task-thread-events.ts`). Unknown subtypes degrade gracefully
+			// to a generic "system" event, so consumers without the new subtype
+			// branch still show something meaningful.
+			const message = {
+				type: 'system',
+				subtype,
+				session_id: sessionId,
+				uuid: `${subtype}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+				...payload,
+			} as unknown as Parameters<SDKMessageRepository['saveSDKMessage']>[1];
+			this.getSdkMessageRepo().saveSDKMessage(sessionId, message);
+		} catch (err) {
+			log.warn(
+				`[SpaceRuntime] Failed to emit thread event ${subtype} on session ${sessionId}: ` +
+					`${err instanceof Error ? err.message : String(err)}`
+			);
+		}
 	}
 
 	/**
@@ -797,9 +855,19 @@ export class SpaceRuntime {
 	 * remaining actions. If a later action also requires higher autonomy, the task
 	 * pauses again. If all remaining actions complete, the task transitions to 'done'.
 	 *
+	 * @param options.approvalReason Optional human-supplied rationale for the
+	 *   approval. Persisted alongside `approvalSource='human'`/`approvedAt` on
+	 *   the terminal `done` transition (stored in the `approval_reason` column).
+	 *   Written only on the success path — intermediate re-pauses keep the
+	 *   column unchanged so a prior cycle's reason does not leak forward.
+	 *
 	 * @returns The updated task, or null if the task wasn't in a resumable state.
 	 */
-	async resumeCompletionActions(spaceId: string, taskId: string): Promise<SpaceTask | null> {
+	async resumeCompletionActions(
+		spaceId: string,
+		taskId: string,
+		options?: { approvalReason?: string | null }
+	): Promise<SpaceTask | null> {
 		const task = this.config.taskRepo.getTask(taskId);
 		if (!task) {
 			log.warn(`SpaceRuntime.resumeCompletionActions: task ${taskId} not found`);
@@ -871,6 +939,45 @@ export class SpaceRuntime {
 						result: `Completion action "${action.name}" failed`,
 					});
 				}
+				// Emit audit-trail event for each successfully executed action. This
+				// covers both the human-approved resume (i === startIndex) and any
+				// subsequent auto-executed actions. The human-approved entry is the
+				// one most useful to surface in the task thread; downstream renderers
+				// can filter by `approvedBy === 'human'` if they want.
+				const approvedBy = i === startIndex ? 'human' : 'auto_policy';
+				const approvalReason = i === startIndex ? (options?.approvalReason ?? null) : null;
+				const executedAt = new Date().toISOString();
+				await this.safeNotify({
+					kind: 'completion_action_executed',
+					spaceId,
+					taskId,
+					runId: run.id,
+					actionId: action.id,
+					actionName: action.name,
+					approvedBy,
+					approvalReason,
+					executedAt,
+					timestamp: executedAt,
+				});
+				// Also surface the event in the task's own message stream so
+				// SpaceTaskUnifiedThread can render it inline in the timeline. This
+				// writes a synthetic SDK system message into the task agent's
+				// session (if one exists). No-op when the task never had a Task
+				// Agent session — node-agent standalone tasks still get the
+				// notification-sink entry above.
+				const latestTask = this.config.taskRepo.getTask(taskId);
+				if (latestTask?.taskAgentSessionId) {
+					this.emitTaskThreadEvent(latestTask.taskAgentSessionId, 'completion_action_executed', {
+						spaceId,
+						taskId,
+						runId: run.id,
+						actionId: action.id,
+						actionName: action.name,
+						approvedBy,
+						approvalReason,
+						executedAt,
+					});
+				}
 			} else {
 				// Pause at this action — clear stale approvedAt from previous cycle
 				return await this.finalizeResume(spaceId, taskId, {
@@ -882,11 +989,14 @@ export class SpaceRuntime {
 			}
 		}
 
-		// All remaining actions executed — task is done
+		// All remaining actions executed — task is done. Persist the human-supplied
+		// approval reason (when given) so the audit trail records *why* this task
+		// was approved, not just *that* it was.
 		return await this.finalizeResume(spaceId, taskId, {
 			status: 'done',
 			completedAt: Date.now(),
 			approvalSource: 'human',
+			approvalReason: options?.approvalReason ?? null,
 			approvedAt: Date.now(),
 			pendingActionIndex: null,
 			pendingCheckpointType: null,
@@ -1721,6 +1831,41 @@ export class SpaceRuntime {
 						status: 'blocked' as const,
 						result: `Completion action "${action.name}" failed`,
 					};
+				}
+				// Emit audit-trail event for the auto-executed action. Mirrors the
+				// resume path so every successfully-run action is visible in the
+				// space-agent notification stream and — when the task has a task
+				// agent session — in the task's own thread.
+				const executedAt = new Date().toISOString();
+				await this.safeNotify({
+					kind: 'completion_action_executed',
+					spaceId,
+					taskId: '', // resolved below via run → task lookup when possible
+					runId,
+					actionId: action.id,
+					actionName: action.name,
+					approvedBy: 'auto_policy',
+					approvalReason: null,
+					executedAt,
+					timestamp: executedAt,
+				});
+				// Resolve the owning task so the thread-event emission can target
+				// its taskAgentSessionId. The auto-execute path is called from the
+				// tick loop where we don't have the task handy, so look it up now.
+				const owningTasks = this.config.taskRepo.listByWorkflowRun(runId);
+				const owningTask =
+					owningTasks.find((t) => t.workflowRunId === runId) ?? owningTasks[0] ?? null;
+				if (owningTask?.taskAgentSessionId) {
+					this.emitTaskThreadEvent(owningTask.taskAgentSessionId, 'completion_action_executed', {
+						spaceId,
+						taskId: owningTask.id,
+						runId,
+						actionId: action.id,
+						actionName: action.name,
+						approvedBy: 'auto_policy',
+						approvalReason: null,
+						executedAt,
+					});
 				}
 			} else {
 				// Pause at this action — task goes to 'review' with pending action metadata

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -561,7 +561,8 @@ export class SpaceRuntime {
 					workflow,
 					reportedStatus,
 					nextResult,
-					spaceLevel
+					spaceLevel,
+					canonicalTask.id
 				);
 				await this.updateTaskAndEmit(run.spaceId, canonicalTask.id, params);
 			} else if (nextResult && canonicalTask.result !== nextResult) {
@@ -1451,7 +1452,8 @@ export class SpaceRuntime {
 						meta.workflow,
 						reportedStatus,
 						nextTaskResult,
-						spaceLevel
+						spaceLevel,
+						canonicalTask.id
 					);
 					await this.updateTaskAndEmit(meta.spaceId, canonicalTask.id, params);
 					finalTaskStatus = params.status ?? canonicalTask.status;
@@ -1762,7 +1764,8 @@ export class SpaceRuntime {
 		workflow: SpaceWorkflow | null,
 		reportedStatus: SpaceReportedStatus,
 		taskResult: string | null,
-		spaceLevel: SpaceAutonomyLevel
+		spaceLevel: SpaceAutonomyLevel,
+		taskId: string | null
 	): Promise<UpdateSpaceTaskParams> {
 		// Non-success outcomes pass through directly. Completion actions are a
 		// success-path review gate ("flip to done after verifying X"); they
@@ -1837,10 +1840,14 @@ export class SpaceRuntime {
 				// space-agent notification stream and — when the task has a task
 				// agent session — in the task's own thread.
 				const executedAt = new Date().toISOString();
+				// `taskId` is threaded in by callers (both reconcile and tick paths
+				// have canonicalTask.id in scope); fall back to '' only if a future
+				// caller ever omits it.
+				const notifyTaskId = taskId ?? '';
 				await this.safeNotify({
 					kind: 'completion_action_executed',
 					spaceId,
-					taskId: '', // resolved below via run → task lookup when possible
+					taskId: notifyTaskId,
 					runId,
 					actionId: action.id,
 					actionName: action.name,
@@ -1849,12 +1856,10 @@ export class SpaceRuntime {
 					executedAt,
 					timestamp: executedAt,
 				});
-				// Resolve the owning task so the thread-event emission can target
-				// its taskAgentSessionId. The auto-execute path is called from the
-				// tick loop where we don't have the task handy, so look it up now.
-				const owningTasks = this.config.taskRepo.listByWorkflowRun(runId);
-				const owningTask =
-					owningTasks.find((t) => t.workflowRunId === runId) ?? owningTasks[0] ?? null;
+				// Thread-event emission targets the task's own agent session so
+				// SpaceTaskUnifiedThread can render it inline. Only fetch when we
+				// have a real taskId to bind against.
+				const owningTask = taskId ? this.config.taskRepo.getTask(taskId) : null;
 				if (owningTask?.taskAgentSessionId) {
 					this.emitTaskThreadEvent(owningTask.taskAgentSessionId, 'completion_action_executed', {
 						spaceId,

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -706,6 +706,84 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 				return jsonResult({ success: false, error: message });
 			}
 		},
+
+		/**
+		 * Approve a task paused at a completion-action checkpoint
+		 * (`pendingCheckpointType === 'completion_action'`) and resume execution of
+		 * the pending action(s). Unlike `approve_task`, this does not transition the
+		 * task directly to `done` — it delegates to `SpaceRuntime.resumeCompletionActions`,
+		 * which runs the pending action and either:
+		 *   - finishes the task (`done`) once all remaining actions execute,
+		 *   - pauses again (`review`) if another action needs higher autonomy, or
+		 *   - marks the task `blocked` if an action fails.
+		 *
+		 * The optional `reason` is persisted into the task's `approval_reason` column
+		 * as part of the audit trail and surfaces in the `completion_action_executed`
+		 * thread event (with `approvedBy: 'human'`).
+		 */
+		async approve_completion_action(args: {
+			task_id: string;
+			reason?: string;
+		}): Promise<ToolResult> {
+			const task = taskRepo.getTask(args.task_id);
+			if (!task) {
+				return jsonResult({ success: false, error: `Task not found: ${args.task_id}` });
+			}
+			if (task.spaceId !== spaceId) {
+				return jsonResult({
+					success: false,
+					error: `Task ${args.task_id} does not belong to this space.`,
+				});
+			}
+			if (task.status !== 'review') {
+				return jsonResult({
+					success: false,
+					error: `Task is in '${task.status}' status, not 'review'. Only tasks in review can be approved.`,
+				});
+			}
+			if (task.pendingCheckpointType !== 'completion_action') {
+				return jsonResult({
+					success: false,
+					error:
+						`Task ${args.task_id} is not paused at a completion-action checkpoint ` +
+						`(pendingCheckpointType=${task.pendingCheckpointType ?? 'null'}). ` +
+						`Use approve_task for plain review→done approvals.`,
+				});
+			}
+
+			try {
+				const resumed = await runtime.resumeCompletionActions(spaceId, args.task_id, {
+					approvalReason: args.reason ?? null,
+				});
+				if (!resumed) {
+					return jsonResult({
+						success: false,
+						error:
+							`Failed to resume completion actions for task ${args.task_id} — ` +
+							`task state is inconsistent (see daemon logs for details).`,
+					});
+				}
+
+				// SpaceRuntime.resumeCompletionActions emits notification events but does
+				// not emit the RPC-level space.task.updated hub event; mirror the
+				// approve_task behaviour so frontends refresh.
+				if (daemonHub) {
+					void daemonHub
+						.emit('space.task.updated', {
+							sessionId: 'global',
+							spaceId,
+							taskId: args.task_id,
+							task: resumed,
+						})
+						.catch(() => {});
+				}
+
+				return jsonResult({ success: true, task: resumed });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
 	};
 }
 
@@ -927,6 +1005,20 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 				reason: z.string().optional().describe('Reason for approval'),
 			},
 			(args) => handlers.approve_task(args)
+		),
+		tool(
+			'approve_completion_action',
+			"Approve a task paused at a completion-action checkpoint (pendingCheckpointType='completion_action') and resume execution of the pending action(s). Prefer this over approve_task when the task is specifically paused for completion-action review — it runs the pending action instead of bypassing to 'done'.",
+			{
+				task_id: z.string().describe('ID of the task to approve'),
+				reason: z
+					.string()
+					.optional()
+					.describe(
+						'Rationale for approval. Persisted in the task audit trail and surfaced in the completion_action_executed thread event.'
+					),
+			},
+			(args) => handlers.approve_completion_action(args)
 		),
 	];
 

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -681,6 +681,19 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 					error: `Task is in '${task.status}' status, not 'review'. Only tasks in review can be approved.`,
 				});
 			}
+			// Hard guard against bypassing completion-action execution. A plain
+			// `setTaskStatus('done')` here would skip the pending completion
+			// action(s) entirely, defeating the review gate. Callers must use
+			// `approve_completion_action`, which routes through
+			// `SpaceRuntime.resumeCompletionActions` and runs the pending action.
+			if (task.pendingCheckpointType === 'completion_action') {
+				return jsonResult({
+					success: false,
+					error:
+						`Task ${args.task_id} is paused at a completion-action checkpoint. ` +
+						`Use approve_completion_action instead to run the pending action(s).`,
+				});
+			}
 
 			try {
 				const updated = await taskManager.setTaskStatus(args.task_id, 'done', {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
@@ -584,6 +584,70 @@ describe('space-task-handlers', () => {
 			expect(taskManager.setTaskStatus).not.toHaveBeenCalled();
 		});
 
+		it('maps cancelReason onto approvalReason for review→cancelled audit trail', async () => {
+			// Rejecting a paused task goes review→cancelled. The single
+			// `approval_reason` column doubles as an audit trail for both
+			// approvals and rejections, so the handler must fold cancelReason
+			// into the same persistence path.
+			const reviewTask = { ...mockTask, status: 'review' as const };
+			setup(mockSpace, reviewTask);
+			(taskManager.setTaskStatus as ReturnType<typeof mock>).mockResolvedValue({
+				...reviewTask,
+				status: 'cancelled' as const,
+			});
+			(taskManager.updateTask as ReturnType<typeof mock>).mockImplementation(
+				async (_taskId: string, params: Record<string, unknown>) => ({
+					...reviewTask,
+					status: 'cancelled' as const,
+					...params,
+				})
+			);
+
+			await call('spaceTask.update', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				status: 'cancelled',
+				cancelReason: 'not worth shipping',
+			});
+
+			// setTaskStatus is called with the rejection reason mapped onto approvalReason.
+			expect(taskManager.setTaskStatus).toHaveBeenCalledWith('task-1', 'cancelled', {
+				result: undefined,
+				approvalSource: undefined,
+				approvalReason: 'not worth shipping',
+			});
+			// A follow-up updateTask ensures approvalReason lands even though
+			// setTaskStatus only stamps it on review→done.
+			expect(taskManager.updateTask).toHaveBeenCalledWith('task-1', {
+				approvalReason: 'not worth shipping',
+			});
+		});
+
+		it('falls back to approvalReason when cancelReason is omitted on cancel transitions', async () => {
+			const reviewTask = { ...mockTask, status: 'review' as const };
+			setup(mockSpace, reviewTask);
+			(taskManager.setTaskStatus as ReturnType<typeof mock>).mockResolvedValue({
+				...reviewTask,
+				status: 'cancelled' as const,
+			});
+
+			await call('spaceTask.update', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				status: 'cancelled',
+				approvalReason: 'rejected via legacy field',
+			});
+
+			expect(taskManager.setTaskStatus).toHaveBeenCalledWith('task-1', 'cancelled', {
+				result: undefined,
+				approvalSource: undefined,
+				approvalReason: 'rejected via legacy field',
+			});
+			expect(taskManager.updateTask).toHaveBeenCalledWith('task-1', {
+				approvalReason: 'rejected via legacy field',
+			});
+		});
+
 		it('propagates errors from setTaskStatus (invalid transitions)', async () => {
 			const doneTask = { ...mockTask, status: 'done' as const };
 			setup(mockSpace, doneTask);
@@ -646,9 +710,47 @@ describe('space-task-handlers', () => {
 				status: 'done',
 			});
 
-			expect(runtime.resumeCompletionActions).toHaveBeenCalledWith('space-1', 'task-1');
+			expect(runtime.resumeCompletionActions).toHaveBeenCalledWith('space-1', 'task-1', {
+				approvalReason: null,
+			});
 			expect(taskManager.setTaskStatus).not.toHaveBeenCalled();
 			expect((result as SpaceTask).status).toBe('done');
+		});
+
+		it('forwards approvalReason to resumeCompletionActions for audit trail', async () => {
+			const { runtime } = setupWithRuntime();
+
+			await call('spaceTask.update', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				status: 'done',
+				approvalReason: 'LGTM — shipped',
+			});
+
+			expect(runtime.resumeCompletionActions).toHaveBeenCalledWith('space-1', 'task-1', {
+				approvalReason: 'LGTM — shipped',
+			});
+			// The runtime persists the reason on its terminal write; the handler must
+			// NOT redundantly call updateTask with approvalReason again.
+			expect(taskManager.updateTask).not.toHaveBeenCalled();
+		});
+
+		it('does not forward approvalReason as a follow-up updateTask field', async () => {
+			// Regression guard: approvalReason / cancelReason must be stripped from the
+			// `otherFields` follow-up merge on the resume path so we never overwrite the
+			// reason the runtime just persisted on the terminal transition.
+			setupWithRuntime();
+
+			await call('spaceTask.update', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				status: 'done',
+				approvalReason: 'shipped',
+				result: 'done and dusted',
+			});
+
+			expect(taskManager.updateTask).toHaveBeenCalledTimes(1);
+			expect(taskManager.updateTask).toHaveBeenCalledWith('task-1', { result: 'done and dusted' });
 		});
 
 		it('skips the secondary emit when no extra fields were merged', async () => {

--- a/packages/daemon/tests/unit/5-space/other/session-notification-sink.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/session-notification-sink.test.ts
@@ -543,6 +543,99 @@ describe('formatEventMessage — agent_crash', () => {
 	});
 });
 
+describe('formatEventMessage — completion_action_executed', () => {
+	const TIMESTAMP = '2025-01-15T12:00:00.000Z';
+
+	const base = {
+		kind: 'completion_action_executed' as const,
+		spaceId: 'space-ca',
+		taskId: 'task-ca',
+		runId: 'run-ca',
+		actionId: 'merge-pr',
+		actionName: 'Merge PR',
+		executedAt: TIMESTAMP,
+		timestamp: TIMESTAMP,
+	};
+
+	it('formats completion_action_executed with [TASK_EVENT] prefix', () => {
+		const event: SpaceNotificationEvent = {
+			...base,
+			approvedBy: 'human',
+			approvalReason: 'LGTM',
+		};
+
+		const msg = formatEventMessage(event, 2);
+		expect(msg).toContain('[TASK_EVENT] completion_action_executed');
+	});
+
+	it('includes the action name + reason in the human-readable summary for human approvals', () => {
+		const event: SpaceNotificationEvent = {
+			...base,
+			approvedBy: 'human',
+			approvalReason: 'Ship it',
+		};
+
+		const msg = formatEventMessage(event, 2);
+		expect(msg).toContain('Merge PR');
+		expect(msg).toContain('human reviewer');
+		expect(msg).toContain('Ship it');
+	});
+
+	it('labels the approver as auto-policy and omits the reason for auto_policy approvals', () => {
+		const event: SpaceNotificationEvent = {
+			...base,
+			approvedBy: 'auto_policy',
+			approvalReason: null,
+		};
+
+		const msg = formatEventMessage(event, 5);
+		expect(msg).toContain('auto-policy');
+		// Sanity: no stray "Reason:" suffix when the approval has no rationale.
+		expect(msg).not.toContain('Reason:');
+	});
+
+	it('serializes the full audit payload into the JSON block', () => {
+		const event: SpaceNotificationEvent = {
+			...base,
+			approvedBy: 'human',
+			approvalReason: 'ship it',
+		};
+
+		const json = extractJson(formatEventMessage(event, 4));
+		expect(json['kind']).toBe('completion_action_executed');
+		expect(json['actionId']).toBe('merge-pr');
+		expect(json['actionName']).toBe('Merge PR');
+		expect(json['approvedBy']).toBe('human');
+		expect(json['approvalReason']).toBe('ship it');
+		expect(json['taskId']).toBe('task-ca');
+		expect(json['runId']).toBe('run-ca');
+		expect(json['executedAt']).toBe(TIMESTAMP);
+		expect(json['autonomyLevel']).toBe(4);
+	});
+
+	it('SessionNotificationSink.notify() injects completion_action_executed into session', async () => {
+		const factory = makeMockSessionFactory();
+		const sink = new SessionNotificationSink({
+			sessionFactory: factory,
+			sessionId: 'session:spaces:global',
+			autonomyLevel: 2,
+		});
+
+		await sink.notify({
+			...base,
+			approvedBy: 'human',
+			approvalReason: 'approved',
+		});
+
+		expect(factory.calls).toHaveLength(1);
+		const [call] = factory.calls;
+		expect(call.sessionId).toBe('session:spaces:global');
+		expect(call.message).toContain('[TASK_EVENT] completion_action_executed');
+		expect(call.message).toContain('Merge PR');
+		expect(call.opts?.deliveryMode).toBe('defer');
+	});
+});
+
 // ---------------------------------------------------------------------------
 // Test utility: extract the first JSON block from a message
 // ---------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -1369,3 +1369,102 @@ describe('createSpaceAgentToolHandlers — list_tasks search/pagination/compact'
 		expect(parsed.tasks).toHaveLength(1);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// approve_completion_action
+// ---------------------------------------------------------------------------
+
+describe('createSpaceAgentToolHandlers — approve_completion_action', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('rejects tasks that are not at a completion-action checkpoint', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'no pause',
+			description: 'open task',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		// Flip status to review but leave pendingCheckpointType null — this is the
+		// case where approve_task would apply, but approve_completion_action must
+		// decline so callers don't accidentally bypass the runtime resume path.
+		ctx.taskRepo.updateTask(taskId, { status: 'review' });
+
+		const result = await makeHandlers(ctx).approve_completion_action({
+			task_id: taskId,
+			reason: 'whatever',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('not paused at a completion-action checkpoint');
+	});
+
+	test('rejects tasks not in review status', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'open task',
+			description: 'not in review',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+
+		const result = await makeHandlers(ctx).approve_completion_action({
+			task_id: taskId,
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain("not 'review'");
+	});
+
+	test('rejects tasks that do not belong to this space', async () => {
+		// Seed a task in a different space so we can query by that ID.
+		const otherSpaceId = 'space-other';
+		seedSpaceRow(ctx.db, otherSpaceId, '/tmp/other-workspace');
+		const taskId = `task-other-${Math.random().toString(36).slice(2)}`;
+		ctx.db
+			.prepare(
+				`INSERT INTO space_tasks (id, space_id, task_number, title, description,
+					status, priority, depends_on, created_at, updated_at,
+					pending_checkpoint_type, pending_action_index)
+				 VALUES (?, ?, 1, 'Foreign task', '', 'review', 'normal', '[]', ?, ?, 'completion_action', 0)`
+			)
+			.run(taskId, otherSpaceId, Date.now(), Date.now());
+
+		const result = await makeHandlers(ctx).approve_completion_action({ task_id: taskId });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('does not belong to this space');
+	});
+
+	test('returns error when task not found', async () => {
+		const result = await makeHandlers(ctx).approve_completion_action({
+			task_id: 'task-missing',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('task-missing');
+	});
+
+	test('registers the tool in the MCP server', () => {
+		const server = createSpaceAgentMcpServer({
+			spaceId: ctx.spaceId,
+			runtime: ctx.runtime,
+			workflowManager: ctx.workflowManager,
+			taskRepo: ctx.taskRepo,
+			nodeExecutionRepo: ctx.nodeExecutionRepo,
+			workflowRunRepo: ctx.workflowRunRepo,
+			taskManager: ctx.taskManager,
+			spaceAgentManager: ctx.agentManager,
+		});
+		const registered = (server.instance as unknown as { _registeredTools: Record<string, unknown> })
+			._registeredTools;
+		expect(registered).toHaveProperty('approve_completion_action');
+		// approve_task remains for plain review→done approvals that are not
+		// paused at a completion-action checkpoint.
+		expect(registered).toHaveProperty('approve_task');
+	});
+});

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -1468,3 +1468,61 @@ describe('createSpaceAgentToolHandlers — approve_completion_action', () => {
 		expect(registered).toHaveProperty('approve_task');
 	});
 });
+
+// ---------------------------------------------------------------------------
+// approve_task — completion-action checkpoint guard
+// ---------------------------------------------------------------------------
+
+describe('createSpaceAgentToolHandlers — approve_task guard', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('rejects tasks paused at a completion-action checkpoint', async () => {
+		// Bypass guard: a plain `setTaskStatus('done')` on a completion-action
+		// checkpoint would skip the pending action(s) entirely. approve_task
+		// must decline and route callers to approve_completion_action.
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'paused at completion action',
+			description: 'needs resume path',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+		ctx.taskRepo.updateTask(taskId, {
+			status: 'review',
+			pendingCheckpointType: 'completion_action',
+			pendingActionIndex: 0,
+		});
+
+		const result = await makeHandlers(ctx).approve_task({
+			task_id: taskId,
+			reason: 'lgtm',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('completion-action checkpoint');
+		expect(parsed.error).toContain('approve_completion_action');
+	});
+
+	test('allows plain review→done approvals (no completion-action checkpoint)', async () => {
+		const createResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'plain review task',
+			description: 'no pending action',
+		});
+		const taskId = JSON.parse(createResult.content[0].text).task.id;
+		// Plain review (pendingCheckpointType is null) — approve_task should proceed.
+		ctx.taskRepo.updateTask(taskId, { status: 'review' });
+
+		const result = await makeHandlers(ctx).approve_task({
+			task_id: taskId,
+			reason: 'looks good',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.status).toBe('done');
+	});
+});

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
@@ -14,7 +14,7 @@ import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { rmSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
-import { runMigrations } from '../../../../src/storage/schema/index.ts';
+import { createTables, runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
 import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository.ts';
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
@@ -108,6 +108,9 @@ function makeDb(): { db: BunDatabase; dir: string } {
 	mkdirSync(dir, { recursive: true });
 	const db = new BunDatabase(join(dir, 'test.db'));
 	db.exec('PRAGMA foreign_keys = ON');
+	// createTables provisions the base schema (notably sdk_messages, needed by
+	// the thread-event emission path); runMigrations applies schema evolution.
+	createTables(db);
 	runMigrations(db, () => {});
 	return { db, dir };
 }
@@ -619,6 +622,229 @@ describe('SpaceRuntime — completion actions', () => {
 
 		const result = await rt.resumeCompletionActions(SPACE_ID, tasks[0].id);
 		expect(result).toBeNull();
+	});
+
+	// ─── Audit trail: approvalReason + thread events ─────────────────────
+
+	test('resumeCompletionActions persists approvalReason on terminal done transition', async () => {
+		setAutonomyLevel(3);
+		const rt = makeRuntime();
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'action-high',
+				name: 'Ship It',
+				type: 'script',
+				requiredLevel: 5,
+				script: 'echo "shipped"',
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'task complete',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		// Tick pauses at the high-autonomy action awaiting human approval
+		await rt.executeTick();
+		expect(taskRepo.getTask(tasks[0].id)!.pendingCheckpointType).toBe('completion_action');
+
+		// Resume with human-supplied rationale
+		const resumed = await rt.resumeCompletionActions(SPACE_ID, tasks[0].id, {
+			approvalReason: 'Looks good, ship it',
+		});
+
+		expect(resumed).not.toBeNull();
+		expect(resumed!.status).toBe('done');
+		expect(resumed!.approvalSource).toBe('human');
+		expect(resumed!.approvalReason).toBe('Looks good, ship it');
+	});
+
+	test('resumeCompletionActions does NOT leak approvalReason onto intermediate pause', async () => {
+		// When a resume executes one action and pauses again at a second, the reason
+		// supplied for the first approval cycle must not persist onto the new pause —
+		// the next human decision deserves its own audit entry.
+		setAutonomyLevel(2);
+		const rt = makeRuntime();
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'action-1',
+				name: 'First',
+				type: 'script',
+				requiredLevel: 3,
+				script: 'echo "1"',
+			},
+			{
+				id: 'action-2',
+				name: 'Second',
+				type: 'script',
+				requiredLevel: 4,
+				script: 'echo "2"',
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'task complete',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+		expect(taskRepo.getTask(tasks[0].id)!.pendingActionIndex).toBe(0);
+
+		const resumed = await rt.resumeCompletionActions(SPACE_ID, tasks[0].id, {
+			approvalReason: 'first-cycle reason',
+		});
+
+		expect(resumed!.status).toBe('review');
+		expect(resumed!.pendingActionIndex).toBe(1);
+		// The terminal-write path is the only place approvalReason is stamped on
+		// this column; an intermediate re-pause must leave it untouched so the
+		// UI does not mis-attribute the prior cycle's reason to the new pause.
+		expect(resumed!.approvalReason).toBeNull();
+	});
+
+	test('resumeCompletionActions emits completion_action_executed notification once per action', async () => {
+		setAutonomyLevel(3);
+		const rt = makeRuntime();
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'a1',
+				name: 'Approved Action',
+				type: 'script',
+				requiredLevel: 5,
+				script: 'echo "ok"',
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'task complete',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+		sink.clear(); // drop notifications emitted during the pause tick
+
+		await rt.resumeCompletionActions(SPACE_ID, tasks[0].id, {
+			approvalReason: 'ok to run',
+		});
+
+		const events = sink.events.filter((e) => e.kind === 'completion_action_executed');
+		expect(events).toHaveLength(1);
+		const event = events[0];
+		if (event.kind !== 'completion_action_executed') throw new Error('narrow');
+		expect(event.actionId).toBe('a1');
+		expect(event.actionName).toBe('Approved Action');
+		expect(event.approvedBy).toBe('human');
+		expect(event.approvalReason).toBe('ok to run');
+		expect(event.runId).toBe(run.id);
+		expect(event.taskId).toBe(tasks[0].id);
+	});
+
+	test('auto-executed completion actions emit completion_action_executed with auto_policy', async () => {
+		// Symmetry check: the notification must also fire on the auto-execute path
+		// (no human approval), so the audit trail records every action regardless
+		// of who authorized it.
+		setAutonomyLevel(5);
+		const rt = makeRuntime();
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'auto-1',
+				name: 'Auto Action',
+				type: 'script',
+				requiredLevel: 2,
+				script: 'echo "auto"',
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'task complete',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+
+		const events = sink.events.filter((e) => e.kind === 'completion_action_executed');
+		expect(events.length).toBeGreaterThanOrEqual(1);
+		const event = events[0];
+		if (event.kind !== 'completion_action_executed') throw new Error('narrow');
+		expect(event.actionId).toBe('auto-1');
+		expect(event.approvedBy).toBe('auto_policy');
+		expect(event.approvalReason).toBeNull();
+	});
+
+	test('resumeCompletionActions writes thread event into the task agent session', async () => {
+		setAutonomyLevel(3);
+		const rt = makeRuntime();
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'thread-action',
+				name: 'Thread Action',
+				type: 'script',
+				requiredLevel: 5,
+				script: 'echo "t"',
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		// Attach a synthetic task-agent session id so emitTaskThreadEvent has a
+		// target. Real deployments set this when the Task Agent spawns; we short-
+		// circuit that for the test. The sdk_messages table has a FK to sessions,
+		// so we must seed a session row to let the insert succeed.
+		const taskAgentSessionId = `task-agent-${tasks[0].id}`;
+		const nowIso = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO sessions (id, title, created_at, last_active_at, status, config, metadata, type)
+			 VALUES (?, 'Task Agent', ?, ?, 'active', '{}', '{}', 'space_task_agent')`
+		).run(taskAgentSessionId, nowIso, nowIso);
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'task complete',
+			taskAgentSessionId,
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+		await rt.resumeCompletionActions(SPACE_ID, tasks[0].id, {
+			approvalReason: 'merge plz',
+		});
+
+		const rows = db
+			.prepare(
+				`SELECT sdk_message FROM sdk_messages
+				  WHERE session_id = ? AND message_type = 'system' AND message_subtype = 'completion_action_executed'`
+			)
+			.all(taskAgentSessionId) as Array<{ sdk_message: string }>;
+
+		expect(rows).toHaveLength(1);
+		const payload = JSON.parse(rows[0].sdk_message);
+		expect(payload.type).toBe('system');
+		expect(payload.subtype).toBe('completion_action_executed');
+		expect(payload.actionId).toBe('thread-action');
+		expect(payload.actionName).toBe('Thread Action');
+		expect(payload.approvedBy).toBe('human');
+		expect(payload.approvalReason).toBe('merge plz');
 	});
 
 	// ─── completionActions DB persistence ────────────────────────────────

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
@@ -789,6 +789,10 @@ describe('SpaceRuntime — completion actions', () => {
 		expect(event.actionId).toBe('auto-1');
 		expect(event.approvedBy).toBe('auto_policy');
 		expect(event.approvalReason).toBeNull();
+		// The auto-execute notification must carry the owning task's id so
+		// notification-sink consumers can bind the event to a task in the UI —
+		// callers now thread canonicalTask.id into resolveCompletionWithActions.
+		expect(event.taskId).toBe(tasks[0].id);
 	});
 
 	test('resumeCompletionActions writes thread event into the task agent session', async () => {

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -412,6 +412,14 @@ export interface UpdateSpaceTaskParams {
 	approvalSource?: SpaceApprovalSource | null;
 	/** Optional approval reason/comment */
 	approvalReason?: string | null;
+	/**
+	 * Optional cancellation/rejection reason. Stored into the same underlying
+	 * `approval_reason` column as `approvalReason`, but semantically paired with
+	 * transitions that abort work (e.g. review → cancelled, or rejecting a
+	 * paused completion action). When both are provided, the runtime picks the
+	 * one that matches the transition direction.
+	 */
+	cancelReason?: string | null;
 	/** Timestamp when approval occurred; null to clear */
 	approvedAt?: number | null;
 	/** Index of the completion action awaiting approval; null to clear */


### PR DESCRIPTION
## Summary
- Forwards `approvalReason` from `spaceTask.update` through `SpaceRuntime.resumeCompletionActions` so human rationale lands on the terminal `done` transition; introduces `cancelReason` that folds into the same `approval_reason` column for rejections
- Emits a `completion_action_executed` event — both a `NotificationSink` notification and a synthetic SDK `system` message in the task agent session — on every executed action, human-approved and auto-executed alike, so the audit trail surfaces in `SpaceTaskUnifiedThread` inline
- Adds an `approve_completion_action` MCP tool: a semantic alias of `approve_task` that routes through the resume path instead of bypassing completion-action execution

## Test plan
- [x] `bun run check` (lint + typecheck + knip)
- [x] `./scripts/test-daemon.sh` — 11050/11051 pass (1 skipped)
- [x] New tests cover: approvalReason persistence on terminal done, no-leak on intermediate pauses, notification emission for both `human` and `auto_policy` paths, thread-event write into sdk_messages, `cancelReason` mapping on review→cancelled, and `approve_completion_action` tool guards