### PR TITLE
feat(space): compact task thread polish — cleaner headers, clickable hidden-message divider

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -158,9 +158,9 @@ function mapSpaceTaskMessageRow(row: Record<string, unknown>): Record<string, un
 	const rawId = row.id;
 	const id = typeof rawId === 'string' || typeof rawId === 'number' ? rawId : `row-${createdAt}`;
 	const parentToolUseId = typeof row.parentToolUseId === 'string' ? row.parentToolUseId : null;
-	// `sessionMessageCount` is surfaced only by the compact variant of the query. It
-	// carries the true per-session message total so the client can render an
-	// "N earlier messages" badge when the server-side slice has dropped rows.
+	// Optional backward-compat field from older compact-query variants.
+	// Current compact SQL no longer emits this, but keep tolerant parsing so
+	// historical rows/tests and alternate query variants remain safe.
 	const sessionMessageCount =
 		typeof row.sessionMessageCount === 'number' && Number.isFinite(row.sessionMessageCount)
 			? Number(row.sessionMessageCount)
@@ -841,47 +841,79 @@ ORDER BY createdAt ASC, id ASC
 `.trim();
 
 /**
- * Max rows per session for the compact variant.
+ * Number of rendered "event units" the compact thread keeps from the tail.
  *
- * Chosen as a pragmatic upper bound for the compact event feed — large enough
- * that normal task activity still renders end-to-end, but small enough that a
- * long-running task with thousands of messages does not flood the client.
- *
- * Clients read `sessionMessageCount` to know the real per-session total and
- * can render an "N earlier messages hidden" banner when the server has
- * truncated the result set.
- *
- * Exported so tests and the row mapper can refer to the same constant.
+ * The web renderer now flattens assistant rows by content blocks (tool_use /
+ * thinking / text), so one database row can expand to multiple rendered events.
+ * This query estimates that expansion and returns only the rows needed for:
+ *   - the earliest real (non-synthetic) user anchor message, and
+ *   - the tail rows that cover the last N rendered events.
  */
-export const SPACE_TASK_MESSAGES_COMPACT_LIMIT_PER_SESSION = 50;
+export const SPACE_TASK_MESSAGES_COMPACT_TARGET_EVENT_COUNT = 5;
 
 /**
- * Compact variant — keeps only the last N rows per session (ordered by
- * createdAt DESC so the *newest* rows survive), and attaches
- * `sessionMessageCount` to every surviving row so the client knows the real
- * per-session total. The final output is re-sorted by createdAt ASC, id ASC
- * to match the ordering contract of the legacy query.
+ * Compact variant — returns only the rows needed by the compact task thread.
  *
- * Notes:
- *   - Uses `ROW_NUMBER()` window function (SQLite 3.25+). Bun's bundled
- *     SQLite is well past that cutoff.
- *   - `COUNT(*) OVER (PARTITION BY sessionId)` is computed once per row
- *     and carries the real total regardless of the row slice.
- *   - Result messages (which are always the final message of a session)
- *     naturally remain inside the last N, so "terminal" detection on the
- *     client is unaffected by the slice.
+ * Strategy:
+ *   1. Estimate each row's render weight (`eventCount`):
+ *      - assistant rows: number of content blocks with a string `type`
+ *      - all other rows: 1
+ *   2. Walk rows from newest→oldest with a cumulative event count and keep the
+ *      rows fully inside the last-N tail.
+ *   3. Include one additional "crossing" row when a multi-block assistant row
+ *      straddles the N-event cutoff.
+ *   4. Always include the earliest non-synthetic user row as the anchor.
+ *   5. Return final rows in chronological order (createdAt ASC, id ASC).
  */
 const SPACE_TASK_MESSAGES_BY_TASK_COMPACT_SQL = `
 ${SPACE_TASK_MESSAGES_BASE_CTE},
-ranked AS (
+annotated AS (
   SELECT
     j.*,
-    ROW_NUMBER() OVER (
-      PARTITION BY j.sessionId
-      ORDER BY j.createdAt DESC, j.id DESC
-    ) AS rn,
-    COUNT(*) OVER (PARTITION BY j.sessionId) AS sessionMessageCount
+    CASE
+      WHEN j.messageType = 'assistant' THEN COALESCE(
+        NULLIF((
+          SELECT COUNT(*)
+          FROM json_each(json_extract(j.content, '$.message.content')) AS je
+          WHERE json_type(je.value, '$.type') = 'text'
+        ), 0),
+        1
+      )
+      ELSE 1
+    END AS eventCount,
+    CASE
+      WHEN j.messageType = 'user' AND COALESCE(json_extract(j.content, '$.isSynthetic'), 0) != 1 THEN 1
+      ELSE 0
+    END AS isInitialHumanCandidate
   FROM joined j
+),
+weighted AS (
+  SELECT
+    a.*,
+    ROW_NUMBER() OVER (ORDER BY a.createdAt ASC, a.id ASC) AS rnAsc,
+    SUM(a.eventCount) OVER (
+      ORDER BY a.createdAt DESC, a.id DESC
+      ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    ) AS tailEventCum
+  FROM annotated a
+),
+selected AS (
+  SELECT w.*
+  FROM weighted w
+  WHERE
+    w.tailEventCum <= ${SPACE_TASK_MESSAGES_COMPACT_TARGET_EVENT_COUNT}
+    OR (
+      (w.tailEventCum - w.eventCount) < ${SPACE_TASK_MESSAGES_COMPACT_TARGET_EVENT_COUNT}
+      AND w.tailEventCum > ${SPACE_TASK_MESSAGES_COMPACT_TARGET_EVENT_COUNT}
+    )
+    OR (
+      w.isInitialHumanCandidate = 1
+      AND w.rnAsc = (
+        SELECT MIN(w2.rnAsc)
+        FROM weighted w2
+        WHERE w2.isInitialHumanCandidate = 1
+      )
+    )
 )
 SELECT
   id,
@@ -895,10 +927,8 @@ SELECT
   content,
   createdAt,
   iteration,
-  parentToolUseId,
-  sessionMessageCount
-FROM ranked
-WHERE rn <= ${SPACE_TASK_MESSAGES_COMPACT_LIMIT_PER_SESSION}
+  parentToolUseId
+FROM selected
 ORDER BY createdAt ASC, id ASC
 `.trim();
 

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -165,6 +165,14 @@ function mapSpaceTaskMessageRow(row: Record<string, unknown>): Record<string, un
 		typeof row.sessionMessageCount === 'number' && Number.isFinite(row.sessionMessageCount)
 			? Number(row.sessionMessageCount)
 			: undefined;
+	const turnIndex =
+		typeof row.turnIndex === 'number' && Number.isFinite(row.turnIndex)
+			? Number(row.turnIndex)
+			: undefined;
+	const turnHiddenMessageCount =
+		typeof row.turnHiddenMessageCount === 'number' && Number.isFinite(row.turnHiddenMessageCount)
+			? Number(row.turnHiddenMessageCount)
+			: undefined;
 
 	let content = typeof row.content === 'string' ? row.content : String(row.content ?? '');
 
@@ -205,6 +213,12 @@ function mapSpaceTaskMessageRow(row: Record<string, unknown>): Record<string, un
 	};
 	if (sessionMessageCount !== undefined) {
 		mapped.sessionMessageCount = sessionMessageCount;
+	}
+	if (turnIndex !== undefined) {
+		mapped.turnIndex = turnIndex;
+	}
+	if (turnHiddenMessageCount !== undefined) {
+		mapped.turnHiddenMessageCount = turnHiddenMessageCount;
 	}
 	return mapped;
 }
@@ -840,79 +854,115 @@ FROM joined
 ORDER BY createdAt ASC, id ASC
 `.trim();
 
-/**
- * Number of rendered "event units" the compact thread keeps from the tail.
- *
- * The web renderer now flattens assistant rows by content blocks (tool_use /
- * thinking / text), so one database row can expand to multiple rendered events.
- * This query estimates that expansion and returns only the rows needed for:
- *   - the earliest real (non-synthetic) user anchor message, and
- *   - the tail rows that cover the last N rendered events.
- */
-export const SPACE_TASK_MESSAGES_COMPACT_TARGET_EVENT_COUNT = 5;
+/** Maximum non-terminal rows to keep per (session, turn) in compact mode. */
+export const SPACE_TASK_MESSAGES_COMPACT_NON_TERMINAL_PER_TURN_LIMIT = 5;
 
 /**
- * Compact variant — returns only the rows needed by the compact task thread.
+ * Compact variant — server-side turn compaction for task threads.
  *
- * Strategy:
- *   1. Estimate each row's render weight (`eventCount`):
- *      - assistant rows: number of content blocks with a string `type`
- *      - all other rows: 1
- *   2. Walk rows from newest→oldest with a cumulative event count and keep the
- *      rows fully inside the last-N tail.
- *   3. Include one additional "crossing" row when a multi-block assistant row
- *      straddles the N-event cutoff.
- *   4. Always include the earliest non-synthetic user row as the anchor.
- *   5. Return final rows in chronological order (createdAt ASC, id ASC).
+ * Turn model (per session):
+ *   - A turn is rows between terminal result messages.
+ *   - Turn 1 starts at the first row in the session.
+ *   - A terminal row (`messageType = 'result'`) closes the current turn and
+ *     belongs to that turn.
+ *
+ * Visibility:
+ *   - Keep ALL terminal rows.
+ *   - Keep only the last N renderable non-terminal rows per session-turn.
+ *   - Rows that are known to render as `null` in compact UI (currently
+ *     `user` messages whose content is tool_result blocks) are excluded from
+ *     the non-terminal cap and omitted from compact payloads.
+ *   - Return rows globally ordered by `(createdAt ASC, id ASC)`.
  */
 const SPACE_TASK_MESSAGES_BY_TASK_COMPACT_SQL = `
 ${SPACE_TASK_MESSAGES_BASE_CTE},
-annotated AS (
+session_turns AS (
   SELECT
     j.*,
     CASE
-      WHEN j.messageType = 'assistant' THEN COALESCE(
-        NULLIF((
-          SELECT COUNT(*)
-          FROM json_each(json_extract(j.content, '$.message.content')) AS je
-          WHERE json_type(je.value, '$.type') = 'text'
-        ), 0),
-        1
-      )
-      ELSE 1
-    END AS eventCount,
-    CASE
-      WHEN j.messageType = 'user' AND COALESCE(json_extract(j.content, '$.isSynthetic'), 0) != 1 THEN 1
+      WHEN j.messageType = 'result' THEN 1
       ELSE 0
-    END AS isInitialHumanCandidate
+    END AS isTerminal,
+    CASE
+      WHEN j.messageType = 'user'
+        AND json_type(j.content, '$.message.content') = 'array'
+        AND EXISTS (
+        SELECT 1
+        FROM json_each(json_extract(j.content, '$.message.content')) AS je
+        WHERE json_extract(je.value, '$.type') = 'tool_result'
+      ) THEN 0
+      ELSE 1
+    END AS isRenderable,
+    COALESCE(
+      SUM(CASE WHEN j.messageType = 'result' THEN 1 ELSE 0 END) OVER (
+        PARTITION BY j.sessionId
+        ORDER BY j.createdAt ASC, j.id ASC
+        ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+      ),
+      0
+    ) + 1 AS turnIndex
   FROM joined j
 ),
-weighted AS (
+ranked AS (
   SELECT
-    a.*,
-    ROW_NUMBER() OVER (ORDER BY a.createdAt ASC, a.id ASC) AS rnAsc,
-    SUM(a.eventCount) OVER (
-      ORDER BY a.createdAt DESC, a.id DESC
-      ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-    ) AS tailEventCum
-  FROM annotated a
+    st.*,
+    CASE
+      WHEN st.isTerminal = 0 AND st.isRenderable = 1 THEN ROW_NUMBER() OVER (
+        PARTITION BY st.sessionId, st.turnIndex, st.isTerminal, st.isRenderable
+        ORDER BY st.createdAt DESC, st.id DESC
+      )
+      ELSE NULL
+    END AS nonTerminalRankDesc,
+    CASE
+      WHEN st.isTerminal = 0 AND st.isRenderable = 1 AND st.messageType = 'user' THEN ROW_NUMBER() OVER (
+        PARTITION BY st.sessionId, st.turnIndex, st.isTerminal, st.isRenderable, st.messageType
+        ORDER BY st.createdAt ASC, st.id ASC
+      )
+      ELSE NULL
+    END AS userRowRankAsc
+  FROM session_turns st
+),
+scored AS (
+  SELECT
+    r.*,
+    CASE
+      WHEN r.isTerminal = 0 AND r.isRenderable = 1 AND r.nonTerminalRankDesc <= ${SPACE_TASK_MESSAGES_COMPACT_NON_TERMINAL_PER_TURN_LIMIT}
+        THEN 1
+      ELSE 0
+    END AS isTailVisible,
+    CASE
+      WHEN r.isTerminal = 0 AND r.isRenderable = 1 AND r.messageType = 'user' AND r.userRowRankAsc = 1
+        THEN 1
+      ELSE 0
+    END AS isInitialUserVisible,
+    SUM(CASE WHEN r.isTerminal = 0 AND r.isRenderable = 1 THEN 1 ELSE 0 END) OVER (
+      PARTITION BY r.sessionId, r.turnIndex
+    ) AS totalRenderableNonTerminalInTurn,
+    SUM(
+      CASE
+        WHEN r.isTerminal = 0 AND r.isRenderable = 1
+          AND (
+            (r.nonTerminalRankDesc <= ${SPACE_TASK_MESSAGES_COMPACT_NON_TERMINAL_PER_TURN_LIMIT})
+            OR (r.messageType = 'user' AND r.userRowRankAsc = 1)
+          )
+          THEN 1
+        ELSE 0
+      END
+    ) OVER (
+      PARTITION BY r.sessionId, r.turnIndex
+    ) AS visibleRenderableNonTerminalInTurn
+  FROM ranked r
 ),
 selected AS (
-  SELECT w.*
-  FROM weighted w
+  SELECT
+    s.*
+  FROM scored s
   WHERE
-    w.tailEventCum <= ${SPACE_TASK_MESSAGES_COMPACT_TARGET_EVENT_COUNT}
+    s.isTerminal = 1
     OR (
-      (w.tailEventCum - w.eventCount) < ${SPACE_TASK_MESSAGES_COMPACT_TARGET_EVENT_COUNT}
-      AND w.tailEventCum > ${SPACE_TASK_MESSAGES_COMPACT_TARGET_EVENT_COUNT}
-    )
-    OR (
-      w.isInitialHumanCandidate = 1
-      AND w.rnAsc = (
-        SELECT MIN(w2.rnAsc)
-        FROM weighted w2
-        WHERE w2.isInitialHumanCandidate = 1
-      )
+      s.isTerminal = 0
+      AND s.isRenderable = 1
+      AND (s.isTailVisible = 1 OR s.isInitialUserVisible = 1)
     )
 )
 SELECT
@@ -926,6 +976,12 @@ SELECT
   messageType,
   content,
   createdAt,
+  turnIndex,
+  CASE
+    WHEN totalRenderableNonTerminalInTurn > visibleRenderableNonTerminalInTurn
+      THEN totalRenderableNonTerminalInTurn - visibleRenderableNonTerminalInTurn
+    ELSE 0
+  END AS turnHiddenMessageCount,
   iteration,
   parentToolUseId
 FROM selected

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
@@ -404,19 +404,29 @@ describe('NAMED_QUERY_REGISTRY', () => {
 		});
 
 		// -------------------------------------------------------------------------
-		// spaceTaskMessages.byTask.compact — per-session slicing + count
+		// spaceTaskMessages.byTask.compact — render-focused slicing
 		// -------------------------------------------------------------------------
 
 		describe('spaceTaskMessages.byTask.compact', () => {
-			const compactLimit = 50;
-
-			function insertSdkMessageAt(id: string, sessionIdValue: string, timestampMs: number): void {
+			function insertSdkMessageAt(
+				id: string,
+				sessionIdValue: string,
+				timestampMs: number,
+				sdkMessage?: Record<string, unknown>,
+				messageType = 'assistant'
+			): void {
 				const iso = new Date(timestampMs).toISOString();
+				const payload =
+					sdkMessage ??
+					({
+						type: 'assistant',
+						message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
+					} as Record<string, unknown>);
 				db.exec(`
 					INSERT INTO sdk_messages (
 						id, session_id, message_type, message_subtype, sdk_message, timestamp, send_status, origin
 					) VALUES (
-						'${id}', '${sessionIdValue}', 'assistant', NULL, '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}',
+						'${id}', '${sessionIdValue}', '${messageType}', NULL, '${JSON.stringify(payload)}',
 						'${iso}', 'consumed', 'system'
 					)
 				`);
@@ -428,72 +438,105 @@ describe('NAMED_QUERY_REGISTRY', () => {
 				return entry.mapRow ? rows.map(entry.mapRow) : rows;
 			}
 
-			test('returns at most compactLimit rows per session', () => {
+			test('returns only rows needed to cover the last 5 rendered events', () => {
 				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
 				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
 
-				// Insert 2*compactLimit messages for the same session.
-				const total = compactLimit * 2;
-				for (let i = 0; i < total; i++) {
-					insertSdkMessageAt(`sdk-msg-${i}`, sessionId, now + i * 1000);
+				for (let i = 0; i < 9; i++) {
+					insertSdkMessageAt(`sdk-tail-${i}`, sessionId, now + i * 1000);
 				}
 
 				const rows = queryCompact(taskId);
-				expect(rows).toHaveLength(compactLimit);
-			});
-
-			test('keeps the most recent rows (last N by createdAt)', () => {
-				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
-				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
-
-				const total = compactLimit + 5;
-				// Insert in chronological order (i==0 is oldest).
-				for (let i = 0; i < total; i++) {
-					insertSdkMessageAt(`sdk-keep-${String(i).padStart(4, '0')}`, sessionId, now + i * 1000);
-				}
-
-				const rows = queryCompact(taskId);
-				expect(rows).toHaveLength(compactLimit);
-				// The oldest rows (sdk-keep-0000..0004) should be dropped; the newest
-				// (sdk-keep-00{total-1}) should survive.
-				const newestId = `sdk-keep-${String(total - 1).padStart(4, '0')}`;
-				const ids = rows.map((r) => r.id);
-				expect(ids).toContain(newestId);
-				expect(ids).not.toContain('sdk-keep-0000');
-				expect(ids).not.toContain('sdk-keep-0004');
-			});
-
-			test('surfaces sessionMessageCount equal to the true per-session total', () => {
-				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
-				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
-
-				const total = compactLimit + 10;
-				for (let i = 0; i < total; i++) {
-					insertSdkMessageAt(`sdk-count-${i}`, sessionId, now + i * 1000);
-				}
-
-				const rows = queryCompact(taskId);
-				// Every row should carry the true total, not the delivered count.
+				expect(rows).toHaveLength(5);
+				expect(rows.map((r) => r.id)).toEqual([
+					'sdk-tail-4',
+					'sdk-tail-5',
+					'sdk-tail-6',
+					'sdk-tail-7',
+					'sdk-tail-8',
+				]);
 				for (const row of rows) {
-					expect(row.sessionMessageCount).toBe(total);
+					expect(row.sessionMessageCount).toBeUndefined();
 				}
 			});
 
-			test('omits sessionMessageCount when counts match delivered rows (no truncation)', () => {
+			test('includes a cutoff-crossing multi-block assistant row when needed', () => {
 				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
 				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
 
-				// Well under the compact limit.
-				insertSdkMessageAt('sdk-small-1', sessionId, now);
-				insertSdkMessageAt('sdk-small-2', sessionId, now + 1000);
+				insertSdkMessageAt('sdk-old', sessionId, now + 1000);
+				insertSdkMessageAt(
+					'sdk-multi',
+					sessionId,
+					now + 2000,
+					{
+						type: 'assistant',
+						message: {
+							role: 'assistant',
+							content: [
+								{ type: 'text', text: 'm1' },
+								{ type: 'text', text: 'm2' },
+								{ type: 'text', text: 'm3' },
+								{ type: 'text', text: 'm4' },
+							],
+						},
+					},
+					'assistant'
+				);
+				insertSdkMessageAt('sdk-new-1', sessionId, now + 3000);
+				insertSdkMessageAt('sdk-new-2', sessionId, now + 4000);
 
 				const rows = queryCompact(taskId);
-				expect(rows).toHaveLength(2);
-				// sessionMessageCount is always set by the compact SQL, but must equal
-				// the delivered count when the slice didn't drop anything.
-				for (const row of rows) {
-					expect(row.sessionMessageCount).toBe(2);
+				expect(rows.map((r) => r.id)).toEqual(['sdk-multi', 'sdk-new-1', 'sdk-new-2']);
+				expect(rows.map((r) => r.id)).not.toContain('sdk-old');
+			});
+
+			test('always includes the earliest non-synthetic user anchor row', () => {
+				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
+				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
+
+				insertSdkMessageAt(
+					'sdk-user-anchor',
+					sessionId,
+					now,
+					{
+						type: 'user',
+						message: { role: 'user', content: 'Initial ask' },
+					},
+					'user'
+				);
+				for (let i = 0; i < 8; i++) {
+					insertSdkMessageAt(`sdk-after-${i}`, sessionId, now + (i + 1) * 1000);
 				}
+
+				const rows = queryCompact(taskId);
+				expect(rows.map((r) => r.id)).toContain('sdk-user-anchor');
+				expect(rows[0].id).toBe('sdk-user-anchor');
+				expect(rows).toHaveLength(6); // anchor + tail rows for last 5 events
+			});
+
+			test('does not treat synthetic user messages as the anchor', () => {
+				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
+				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
+
+				insertSdkMessageAt(
+					'sdk-user-synth',
+					sessionId,
+					now,
+					{
+						type: 'user',
+						isSynthetic: true,
+						message: { role: 'user', content: 'Synthetic handoff' },
+					},
+					'user'
+				);
+				for (let i = 0; i < 8; i++) {
+					insertSdkMessageAt(`sdk-real-${i}`, sessionId, now + (i + 1) * 1000);
+				}
+
+				const rows = queryCompact(taskId);
+				expect(rows.map((r) => r.id)).not.toContain('sdk-user-synth');
+				expect(rows).toHaveLength(5);
 			});
 
 			test('final ordering is createdAt ASC, id ASC', () => {
@@ -510,63 +553,11 @@ describe('NAMED_QUERY_REGISTRY', () => {
 				expect(createdAts).toEqual(sorted);
 			});
 
-			test('slices independently per session', () => {
-				const orchestrationSessionId = 'space:compact:task:orch-multi';
-				const nodeSessionId = 'node-agent-session-compact-multi';
-				const workflowRunId = 'wr-compact-multi';
-				const workflowNodeId = 'node-compact-multi';
-
-				const taskId = insertSpaceTask({
-					id: 'compact-multi-1',
-					taskAgentSessionId: orchestrationSessionId,
-					workflowRunId,
-					status: 'in_progress',
-				});
-
-				db.exec(`
-					INSERT INTO node_executions (
-						id, workflow_run_id, workflow_node_id, agent_name, agent_id,
-						agent_session_id, status, result, created_at, started_at,
-						completed_at, updated_at
-					) VALUES (
-						'ne-compact-multi', '${workflowRunId}', '${workflowNodeId}', 'coder', NULL,
-						'${nodeSessionId}', 'in_progress', NULL, ${now}, ${now},
-						NULL, ${now}
-					)
-				`);
-
-				insertSession(orchestrationSessionId, 'space_task_agent', '{"status":"processing"}');
-				insertSession(nodeSessionId, 'space_task_agent', '{"status":"processing"}');
-
-				// Orchestration: above the limit; node agent: below.
-				const orchestrationTotal = compactLimit + 7;
-				for (let i = 0; i < orchestrationTotal; i++) {
-					insertSdkMessageAt(`sdk-orch-${i}`, orchestrationSessionId, now + i * 1000);
-				}
-				for (let i = 0; i < 3; i++) {
-					insertSdkMessageAt(`sdk-node-${i}`, nodeSessionId, now + i * 1000);
-				}
-
-				const rows = queryCompact(taskId);
-				const orchestrationRows = rows.filter((r) => r.sessionId === orchestrationSessionId);
-				const nodeRows = rows.filter((r) => r.sessionId === nodeSessionId);
-
-				expect(orchestrationRows).toHaveLength(compactLimit);
-				expect(nodeRows).toHaveLength(3);
-
-				for (const row of orchestrationRows) {
-					expect(row.sessionMessageCount).toBe(orchestrationTotal);
-				}
-				for (const row of nodeRows) {
-					expect(row.sessionMessageCount).toBe(3);
-				}
-			});
-
-			test('legacy full query variant is unaffected (no sessionMessageCount, no slice)', () => {
+			test('legacy full query variant is unaffected (no compact slicing)', () => {
 				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
 				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
 
-				const total = compactLimit + 4;
+				const total = 12;
 				for (let i = 0; i < total; i++) {
 					insertSdkMessageAt(`sdk-full-${i}`, sessionId, now + i * 1000);
 				}

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
@@ -404,7 +404,7 @@ describe('NAMED_QUERY_REGISTRY', () => {
 		});
 
 		// -------------------------------------------------------------------------
-		// spaceTaskMessages.byTask.compact — render-focused slicing
+		// spaceTaskMessages.byTask.compact — per-session turn compaction
 		// -------------------------------------------------------------------------
 
 		describe('spaceTaskMessages.byTask.compact', () => {
@@ -420,7 +420,7 @@ describe('NAMED_QUERY_REGISTRY', () => {
 					sdkMessage ??
 					({
 						type: 'assistant',
-						message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
+						message: { role: 'assistant', content: [{ type: 'text', text: id }] },
 					} as Record<string, unknown>);
 				db.exec(`
 					INSERT INTO sdk_messages (
@@ -432,111 +432,191 @@ describe('NAMED_QUERY_REGISTRY', () => {
 				`);
 			}
 
+			function insertResultMessageAt(
+				id: string,
+				sessionIdValue: string,
+				timestampMs: number,
+				subtype: 'success' | 'error_during_execution' = 'success'
+			): void {
+				insertSdkMessageAt(
+					id,
+					sessionIdValue,
+					timestampMs,
+					{
+						type: 'result',
+						subtype,
+						duration_ms: 1,
+						duration_api_ms: 1,
+						is_error: subtype !== 'success',
+						total_cost_usd: 0,
+						usage: {
+							input_tokens: 1,
+							cached_input_tokens: 0,
+							output_tokens: 1,
+							reasoning_output_tokens: 0,
+							total_tokens: 2,
+						},
+					},
+					'result'
+				);
+			}
+
 			function queryCompact(taskId: string): Record<string, unknown>[] {
 				const entry = NAMED_QUERY_REGISTRY.get('spaceTaskMessages.byTask.compact')!;
 				const rows = db.prepare(entry.sql).all(taskId) as Record<string, unknown>[];
 				return entry.mapRow ? rows.map(entry.mapRow) : rows;
 			}
 
-			test('returns only rows needed to cover the last 5 rendered events', () => {
+			test('keeps last 5 non-terminal rows per turn and always keeps terminal rows', () => {
 				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
 				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
 
-				for (let i = 0; i < 9; i++) {
-					insertSdkMessageAt(`sdk-tail-${i}`, sessionId, now + i * 1000);
+				for (let i = 1; i <= 7; i += 1) {
+					insertSdkMessageAt(`t1-n${i}`, sessionId, now + i * 1000);
 				}
+				insertResultMessageAt('t1-r', sessionId, now + 8000, 'success');
+				for (let i = 1; i <= 7; i += 1) {
+					insertSdkMessageAt(`t2-n${i}`, sessionId, now + (8 + i) * 1000);
+				}
+				insertResultMessageAt('t2-r', sessionId, now + 16000, 'error_during_execution');
 
 				const rows = queryCompact(taskId);
-				expect(rows).toHaveLength(5);
 				expect(rows.map((r) => r.id)).toEqual([
-					'sdk-tail-4',
-					'sdk-tail-5',
-					'sdk-tail-6',
-					'sdk-tail-7',
-					'sdk-tail-8',
+					't1-n3',
+					't1-n4',
+					't1-n5',
+					't1-n6',
+					't1-n7',
+					't1-r',
+					't2-n3',
+					't2-n4',
+					't2-n5',
+					't2-n6',
+					't2-n7',
+					't2-r',
 				]);
-				for (const row of rows) {
-					expect(row.sessionMessageCount).toBeUndefined();
-				}
+				const t1Row = rows.find((r) => r.id === 't1-r')!;
+				const t2Row = rows.find((r) => r.id === 't2-r')!;
+				expect(t1Row.turnIndex).toBe(1);
+				expect(t2Row.turnIndex).toBe(2);
+				expect(t1Row.turnHiddenMessageCount).toBe(2);
+				expect(t2Row.turnHiddenMessageCount).toBe(2);
 			});
 
-			test('includes a cutoff-crossing multi-block assistant row when needed', () => {
+			test('terminal row does not count toward the 5-row non-terminal cap', () => {
 				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
 				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
 
-				insertSdkMessageAt('sdk-old', sessionId, now + 1000);
-				insertSdkMessageAt(
-					'sdk-multi',
-					sessionId,
-					now + 2000,
-					{
-						type: 'assistant',
-						message: {
-							role: 'assistant',
-							content: [
-								{ type: 'text', text: 'm1' },
-								{ type: 'text', text: 'm2' },
-								{ type: 'text', text: 'm3' },
-								{ type: 'text', text: 'm4' },
-							],
-						},
-					},
-					'assistant'
-				);
-				insertSdkMessageAt('sdk-new-1', sessionId, now + 3000);
-				insertSdkMessageAt('sdk-new-2', sessionId, now + 4000);
+				for (let i = 1; i <= 6; i += 1) {
+					insertSdkMessageAt(`n${i}`, sessionId, now + i * 1000);
+				}
+				insertResultMessageAt('r1', sessionId, now + 7000, 'success');
 
 				const rows = queryCompact(taskId);
-				expect(rows.map((r) => r.id)).toEqual(['sdk-multi', 'sdk-new-1', 'sdk-new-2']);
-				expect(rows.map((r) => r.id)).not.toContain('sdk-old');
+				expect(rows.map((r) => r.id)).toEqual(['n2', 'n3', 'n4', 'n5', 'n6', 'r1']);
+				expect(rows).toHaveLength(6);
 			});
 
-			test('always includes the earliest non-synthetic user anchor row', () => {
+			test('pins the initial user message in a turn and places hidden count after it', () => {
 				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
 				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
 
 				insertSdkMessageAt(
-					'sdk-user-anchor',
+					'u-initial',
 					sessionId,
-					now,
-					{
-						type: 'user',
-						message: { role: 'user', content: 'Initial ask' },
-					},
-					'user'
-				);
-				for (let i = 0; i < 8; i++) {
-					insertSdkMessageAt(`sdk-after-${i}`, sessionId, now + (i + 1) * 1000);
-				}
-
-				const rows = queryCompact(taskId);
-				expect(rows.map((r) => r.id)).toContain('sdk-user-anchor');
-				expect(rows[0].id).toBe('sdk-user-anchor');
-				expect(rows).toHaveLength(6); // anchor + tail rows for last 5 events
-			});
-
-			test('does not treat synthetic user messages as the anchor', () => {
-				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
-				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
-
-				insertSdkMessageAt(
-					'sdk-user-synth',
-					sessionId,
-					now,
+					now + 1000,
 					{
 						type: 'user',
 						isSynthetic: true,
-						message: { role: 'user', content: 'Synthetic handoff' },
+						message: { role: 'user', content: 'Initial turn prompt' },
 					},
 					'user'
 				);
-				for (let i = 0; i < 8; i++) {
-					insertSdkMessageAt(`sdk-real-${i}`, sessionId, now + (i + 1) * 1000);
+				for (let i = 1; i <= 7; i += 1) {
+					insertSdkMessageAt(`a${i}`, sessionId, now + (1 + i) * 1000);
 				}
+				insertResultMessageAt('r1', sessionId, now + 10000, 'success');
 
 				const rows = queryCompact(taskId);
-				expect(rows.map((r) => r.id)).not.toContain('sdk-user-synth');
-				expect(rows).toHaveLength(5);
+				expect(rows.map((r) => r.id)).toEqual(['u-initial', 'a3', 'a4', 'a5', 'a6', 'a7', 'r1']);
+				const resultRow = rows.find((r) => r.id === 'r1')!;
+				expect(resultRow.turnHiddenMessageCount).toBe(2);
+			});
+
+			test('applies turn compaction independently per session (agent)', () => {
+				const orchestrationSessionId = 'space:test-space:task:compact-orch';
+				const nodeSessionId = 'space:test-space:task:compact-node';
+				const workflowRunId = 'wr-compact-per-session';
+				const workflowNodeId = 'node-compact';
+				const taskId = insertSpaceTask({
+					taskAgentSessionId: orchestrationSessionId,
+					workflowRunId,
+				});
+
+				insertSession(orchestrationSessionId, 'space_task_agent', '{"status":"processing"}');
+				insertSession(nodeSessionId, 'space_task_agent', '{"status":"processing"}');
+
+				db.exec(`
+					INSERT INTO node_executions (
+						id, workflow_run_id, workflow_node_id, agent_name, agent_id,
+						agent_session_id, status, result, created_at, started_at,
+						completed_at, updated_at
+					) VALUES (
+						'ne-compact', '${workflowRunId}', '${workflowNodeId}', 'coder', NULL,
+						'${nodeSessionId}', 'in_progress', NULL, ${now}, ${now},
+						NULL, ${now}
+					)
+				`);
+
+				for (let i = 1; i <= 6; i += 1) {
+					insertSdkMessageAt(`orch-n${i}`, orchestrationSessionId, now + i * 1000);
+					insertSdkMessageAt(`node-n${i}`, nodeSessionId, now + i * 1000 + 500);
+				}
+				insertResultMessageAt('orch-r', orchestrationSessionId, now + 7000, 'success');
+				insertResultMessageAt('node-r', nodeSessionId, now + 7500, 'success');
+
+				const rows = queryCompact(taskId);
+				const orchIds = rows.filter((r) => r.sessionId === orchestrationSessionId).map((r) => r.id);
+				const nodeIds = rows.filter((r) => r.sessionId === nodeSessionId).map((r) => r.id);
+
+				expect(orchIds).toEqual(['orch-n2', 'orch-n3', 'orch-n4', 'orch-n5', 'orch-n6', 'orch-r']);
+				expect(nodeIds).toEqual(['node-n2', 'node-n3', 'node-n4', 'node-n5', 'node-n6', 'node-r']);
+			});
+
+			test('omits user tool_result rows and excludes them from non-terminal cap', () => {
+				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
+				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
+
+				insertSdkMessageAt('a1', sessionId, now + 1000);
+				insertSdkMessageAt('a2', sessionId, now + 1100);
+				insertSdkMessageAt('a3', sessionId, now + 1200);
+				insertSdkMessageAt('a4', sessionId, now + 1300);
+				insertSdkMessageAt('a5', sessionId, now + 1400);
+				insertSdkMessageAt('a6', sessionId, now + 1500);
+				insertSdkMessageAt(
+					'u1',
+					sessionId,
+					now + 1600,
+					{
+						type: 'user',
+						message: {
+							role: 'user',
+							content: [
+								{
+									type: 'tool_result',
+									tool_use_id: 'toolu_test',
+									content: [{ type: 'text', text: 'result payload' }],
+								},
+							],
+						},
+					},
+					'user'
+				);
+				insertResultMessageAt('r1', sessionId, now + 1700, 'success');
+
+				const rows = queryCompact(taskId);
+				expect(rows.map((r) => r.id)).toEqual(['a2', 'a3', 'a4', 'a5', 'a6', 'r1']);
+				expect(rows.map((r) => r.id)).not.toContain('u1');
 			});
 
 			test('final ordering is createdAt ASC, id ASC', () => {
@@ -545,7 +625,7 @@ describe('NAMED_QUERY_REGISTRY', () => {
 
 				insertSdkMessageAt('sdk-b', sessionId, now + 2000);
 				insertSdkMessageAt('sdk-a', sessionId, now + 1000);
-				insertSdkMessageAt('sdk-c', sessionId, now + 3000);
+				insertResultMessageAt('sdk-r', sessionId, now + 3000, 'success');
 
 				const rows = queryCompact(taskId);
 				const createdAts = rows.map((r) => r.createdAt as number);

--- a/packages/web/src/components/sdk/SDKAssistantMessage.tsx
+++ b/packages/web/src/components/sdk/SDKAssistantMessage.tsx
@@ -60,6 +60,11 @@ interface Props {
 	 * Set by the compact task thread renderer for the last non-terminal message.
 	 */
 	isRunning?: boolean;
+	/**
+	 * When true, Task/Agent tool_use blocks are rendered as normal tool cards
+	 * instead of SubagentBlock.
+	 */
+	flattenSubagentTools?: boolean;
 }
 
 export function SDKAssistantMessage({
@@ -75,6 +80,7 @@ export function SDKAssistantMessage({
 	onMessageCheckboxChange,
 	allMessages: _allMessages,
 	isRunning,
+	flattenSubagentTools = false,
 }: Props) {
 	const { message: apiMessage } = message;
 	const hasError = 'error' in message && message.error !== undefined;
@@ -274,6 +280,7 @@ export function SDKAssistantMessage({
 							resolvedQuestions={resolvedQuestions}
 							pendingQuestion={pendingQuestion}
 							onQuestionResolved={onQuestionResolved}
+							flattenSubagentTools={flattenSubagentTools}
 						/>
 					);
 				})}
@@ -326,6 +333,7 @@ export function SDKAssistantMessage({
 						resolvedQuestions={resolvedQuestions}
 						pendingQuestion={pendingQuestion}
 						onQuestionResolved={onQuestionResolved}
+						flattenSubagentTools={flattenSubagentTools}
 						isRunning={!!isRunning}
 					/>
 				);
@@ -364,6 +372,7 @@ function ToolUseBlock({
 	pendingQuestion,
 	onQuestionResolved,
 	isRunning,
+	flattenSubagentTools = false,
 }: {
 	block: Extract<ContentBlock, { type: 'tool_use' }>;
 	toolResult?: unknown;
@@ -380,6 +389,8 @@ function ToolUseBlock({
 	 * <RunningBorder>. Used by the compact task thread renderer to indicate the
 	 * last still-executing event message. */
 	isRunning?: boolean;
+	/** Render Task/Agent tool_use blocks as generic tool cards when true. */
+	flattenSubagentTools?: boolean;
 }) {
 	// Extract content and metadata from enhanced toolResult structure
 	const resultData = toolResult as
@@ -395,9 +406,9 @@ function ToolUseBlock({
 	const sessionId = resultData?.sessionId || propSessionId;
 	const isOutputRemoved = resultData?.isOutputRemoved || false;
 
-	// Use SubagentBlock for Task tool (no delete button)
+	// Use SubagentBlock for Task tool (no delete button) unless flatten mode is enabled.
 	// SDK 0.2.76+ renamed the tool from 'Task' to 'Agent', support both for compatibility
-	if (block.name === 'Task' || block.name === 'Agent') {
+	if (!flattenSubagentTools && (block.name === 'Task' || block.name === 'Agent')) {
 		return (
 			<SubagentBlock
 				input={block.input as unknown as AgentInput}

--- a/packages/web/src/components/sdk/SDKMessageRenderer.tsx
+++ b/packages/web/src/components/sdk/SDKMessageRenderer.tsx
@@ -76,6 +76,8 @@ interface Props {
 	 * of SubagentBlock.
 	 */
 	flattenSubagentTools?: boolean;
+	/** When true, user messages containing tool_result blocks are rendered. */
+	showToolResultUserMessages?: boolean;
 	/**
 	 * When true, the last non-terminal event message in a compact task thread is
 	 * still executing. The receiving component wraps its visible boundary element
@@ -198,6 +200,7 @@ export function SDKMessageRenderer({
 	taskContext,
 	showSubagentMessages = false,
 	flattenSubagentTools = false,
+	showToolResultUserMessages = false,
 	isRunning,
 }: Props) {
 	// NeoKai-native action messages are always shown and handled separately.
@@ -246,6 +249,7 @@ export function SDKMessageRenderer({
 				sessionInfo={sessionInfo}
 				isReplay={true}
 				sessionId={sessionId}
+				showToolResultMessages={showToolResultUserMessages}
 			/>
 		);
 	} else if (isSDKUserMessage(sdkMessage)) {
@@ -261,6 +265,7 @@ export function SDKMessageRenderer({
 				selectedMessages={selectedMessages}
 				onMessageCheckboxChange={onMessageCheckboxChange}
 				allMessages={_allMessages}
+				showToolResultMessages={showToolResultUserMessages}
 			/>
 		);
 	} else if (isSDKAssistantMessage(sdkMessage)) {

--- a/packages/web/src/components/sdk/SDKMessageRenderer.tsx
+++ b/packages/web/src/components/sdk/SDKMessageRenderer.tsx
@@ -67,6 +67,16 @@ interface Props {
 	/** When true, renders all message types without skipping (for task conversation timelines) */
 	taskContext?: boolean;
 	/**
+	 * When true, keeps sub-agent child messages in the main feed instead of
+	 * suppressing them in favor of nested SubagentBlock rendering.
+	 */
+	showSubagentMessages?: boolean;
+	/**
+	 * When true, renders Task/Agent tool_use blocks as normal tool cards instead
+	 * of SubagentBlock.
+	 */
+	flattenSubagentTools?: boolean;
+	/**
 	 * When true, the last non-terminal event message in a compact task thread is
 	 * still executing. The receiving component wraps its visible boundary element
 	 * (e.g. the assistant message bubble or tool card) in <RunningBorder> so the
@@ -186,6 +196,8 @@ export function SDKMessageRenderer({
 	onMessageCheckboxChange,
 	allMessages: _allMessages,
 	taskContext,
+	showSubagentMessages = false,
+	flattenSubagentTools = false,
 	isRunning,
 }: Props) {
 	// NeoKai-native action messages are always shown and handled separately.
@@ -218,7 +230,7 @@ export function SDKMessageRenderer({
 	}
 
 	// Skip sub-agent messages - they're now shown inside SubagentBlock
-	if (isSubagentMessage(sdkMessage)) {
+	if (!showSubagentMessages && isSubagentMessage(sdkMessage)) {
 		return null;
 	}
 
@@ -265,6 +277,7 @@ export function SDKMessageRenderer({
 				selectedMessages={selectedMessages}
 				onMessageCheckboxChange={onMessageCheckboxChange}
 				allMessages={_allMessages}
+				flattenSubagentTools={flattenSubagentTools}
 				isRunning={isRunning}
 			/>
 		);

--- a/packages/web/src/components/sdk/SDKUserMessage.tsx
+++ b/packages/web/src/components/sdk/SDKUserMessage.tsx
@@ -90,6 +90,8 @@ interface Props {
 	selectedMessages?: Set<string>;
 	onMessageCheckboxChange?: (messageId: string, checked: boolean) => void;
 	allMessages?: ChatMessage[];
+	/** Render user rows whose content is tool_result blocks. */
+	showToolResultMessages?: boolean;
 }
 
 export function SDKUserMessage({
@@ -105,6 +107,7 @@ export function SDKUserMessage({
 	selectedMessages,
 	onMessageCheckboxChange,
 	allMessages: _allMessages,
+	showToolResultMessages = false,
 }: Props) {
 	const { message: apiMessage } = message;
 	const [copied, setCopied] = useState(false);
@@ -120,7 +123,7 @@ export function SDKUserMessage({
 	};
 
 	// Don't render tool result messages - they'll be shown with their tool use blocks
-	if (isToolResultMessage()) {
+	if (isToolResultMessage() && !showToolResultMessages) {
 		return null;
 	}
 
@@ -143,6 +146,28 @@ export function SDKUserMessage({
 						return b.text as string;
 					}
 					// Image blocks or other types - skip or show type
+					if (b.type === 'tool_result') {
+						const rawContent = b.content;
+						if (typeof rawContent === 'string') return rawContent;
+						if (Array.isArray(rawContent)) {
+							return rawContent
+								.map((c: unknown) => {
+									const obj = c as Record<string, unknown>;
+									if (typeof obj.text === 'string') return obj.text;
+									return '';
+								})
+								.filter(Boolean)
+								.join('\n');
+						}
+						if (rawContent && typeof rawContent === 'object') {
+							try {
+								return JSON.stringify(rawContent, null, 2);
+							} catch {
+								return String(rawContent);
+							}
+						}
+						return '';
+					}
 					return '';
 				})
 				.filter(Boolean)

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -159,7 +159,6 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	const canSendThreadMessage = !isTerminalTask && !ensuringThread && !sendingThread;
 	const canShowCanvasTab = !!task.workflowRunId && !!canvasWorkflowId;
 	const canShowArtifactsTab = !!task.workflowRunId;
-	const floatingToggleTopClass = activeView === 'artifacts' ? 'top-14' : 'top-3';
 	const activitySummary = STATUS_LABELS[task.status];
 	const transitionActions = getTransitionActions(task.status);
 	const agentActionLabel =
@@ -337,13 +336,8 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 				</div>
 			)}
 
-			<div class="flex-1 min-h-0 overflow-hidden relative">
-				<div
-					class={cn(
-						'absolute right-4 z-20 flex items-center gap-1 rounded-3xl border border-dark-700 bg-dark-800/60 p-1 backdrop-blur-sm',
-						floatingToggleTopClass
-					)}
-				>
+			<div class="px-4 pb-2 flex-shrink-0 flex justify-center">
+				<div class="flex items-center gap-1 rounded-3xl border border-dark-700 bg-dark-800/60 p-1 backdrop-blur-sm">
 					<button
 						type="button"
 						onClick={() => setActiveView('thread')}
@@ -400,6 +394,8 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 						</button>
 					)}
 				</div>
+			</div>
+			<div class="flex-1 min-h-0 overflow-hidden">
 				{activeView === 'canvas' && task.workflowRunId && canvasWorkflowId ? (
 					<div class="h-full" data-testid="canvas-view">
 						<ReadOnlyWorkflowCanvas

--- a/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
+++ b/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
@@ -1,52 +1,46 @@
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
-import {
-	useSpaceTaskMessages,
-	type SpaceTaskThreadMessageRow,
-} from '../../hooks/useSpaceTaskMessages';
+import { useSpaceTaskMessages } from '../../hooks/useSpaceTaskMessages';
 import { useMessageMaps } from '../../hooks/useMessageMaps';
 import { SpaceTaskThreadEventFeed } from './thread/SpaceTaskThreadEventFeed';
 import { SpaceTaskCardFeed } from './thread/compact/SpaceTaskCardFeed';
 import { buildThreadEvents, parseThreadRow } from './thread/space-task-thread-events';
 import { getSpaceTaskThreadRenderStyle } from '../../lib/space-task-thread-config';
 
-// ── Scroll-spy helpers ───────────────────────────────────────────────────────
-
 interface AgentTag {
 	label: string;
 	color: string;
 }
 
-/** Strips the trailing "Agent" word for compact display, e.g. "Task Agent" → "TASK". */
 function shortAgentLabel(label: string): string {
 	return label.replace(/\s+agent$/i, '').toUpperCase();
 }
 
-/**
- * Walk all `[data-agent-label]` blocks inside `container` and return the agent
- * of the last block whose top edge is at or above the container's top edge.
- * This is the block currently occupying the visible top of the scroll area.
- *
- * Falls back to the first block when nothing has scrolled past the top yet
- * (e.g. scrollTop=0) so the tag is always visible when content exists.
- */
 function findCurrentAgent(container: HTMLElement): AgentTag | null {
-	const blocks = container.querySelectorAll<HTMLElement>('[data-agent-label]');
-	if (blocks.length === 0) return null;
+	const rows = container.querySelectorAll<HTMLElement>('[data-agent-label]');
+	if (rows.length === 0) return null;
+
 	const containerTop = container.getBoundingClientRect().top;
 	let found: AgentTag | null = null;
-	for (const el of Array.from(blocks)) {
-		if (el.getBoundingClientRect().top <= containerTop + 8) {
-			found = { label: el.dataset.agentLabel ?? '', color: el.dataset.agentColor ?? '' };
+	for (const row of Array.from(rows)) {
+		if (row.getBoundingClientRect().top <= containerTop + 8) {
+			found = {
+				label: row.dataset.agentLabel ?? '',
+				color: row.dataset.agentColor ?? '',
+			};
 		} else {
 			break;
 		}
 	}
-	// At scroll=0 nothing is above the fold — show the first block's agent.
+
 	if (!found) {
-		const first = blocks[0] as HTMLElement;
-		found = { label: first.dataset.agentLabel ?? '', color: first.dataset.agentColor ?? '' };
+		const first = rows[0] as HTMLElement;
+		found = {
+			label: first.dataset.agentLabel ?? '',
+			color: first.dataset.agentColor ?? '',
+		};
 	}
+
 	return found;
 }
 
@@ -61,34 +55,6 @@ interface SpaceTaskUnifiedThreadProps {
 	isAgentActive?: boolean;
 }
 
-/**
- * Count how many messages the server has truncated for this task's sessions.
- *
- * The compact LiveQuery variant returns at most N rows per session and
- * attaches `sessionMessageCount` (the true total) to each row. For every
- * session, the hidden count is `sessionMessageCount - deliveredRows`.
- *
- * Returns 0 when the full query variant is used (sessionMessageCount absent
- * on all rows) or when no session was truncated.
- */
-function countHiddenEarlierMessages(rows: SpaceTaskThreadMessageRow[]): number {
-	const deliveredBySession = new Map<string, number>();
-	const totalBySession = new Map<string, number>();
-	for (const row of rows) {
-		const key = row.sessionId ?? '';
-		deliveredBySession.set(key, (deliveredBySession.get(key) ?? 0) + 1);
-		if (typeof row.sessionMessageCount === 'number') {
-			totalBySession.set(key, row.sessionMessageCount);
-		}
-	}
-	let hidden = 0;
-	for (const [sessionKey, total] of totalBySession) {
-		const delivered = deliveredBySession.get(sessionKey) ?? 0;
-		if (total > delivered) hidden += total - delivered;
-	}
-	return hidden;
-}
-
 export function SpaceTaskUnifiedThread({
 	taskId,
 	bottomInsetClass = 'pb-3',
@@ -97,7 +63,7 @@ export function SpaceTaskUnifiedThread({
 	// Read render style on every render so that the value stays fresh after a
 	// localStorage write (e.g. via setSpaceTaskThreadRenderStyle in devtools).
 	const renderStyle = getSpaceTaskThreadRenderStyle();
-	const { rows, isLoading, isReconnecting } = useSpaceTaskMessages(taskId);
+	const { rows, isLoading, isReconnecting } = useSpaceTaskMessages(taskId, 'full');
 	const containerRef = useRef<HTMLDivElement>(null);
 
 	const parsedRows = useMemo(() => rows.map(parseThreadRow), [rows]);
@@ -108,38 +74,37 @@ export function SpaceTaskUnifiedThread({
 		[parsedRows]
 	);
 	const maps = useMessageMaps(parsedMessages, `space-task-${taskId}`);
-	const hiddenEarlierCount = useMemo(() => countHiddenEarlierMessages(rows), [rows]);
 
 	useEffect(() => {
 		if (!containerRef.current) return;
 		containerRef.current.scrollTop = containerRef.current.scrollHeight;
 	}, [parsedRows.length, threadEvents.length]);
 
-	// ── Scroll-spy: floating agent name tag ──────────────────────────────────
+	const hasRows = parsedRows.length > 0;
 	const [currentAgent, setCurrentAgent] = useState<AgentTag | null>(null);
 
-	// Attach scroll listener. Re-registers when renderStyle changes or when rows
-	// first appear (parsedRows.length>0 transitions the early-return path to the
-	// main return path, which is the first time containerRef.current is set).
-	const hasRows = parsedRows.length > 0;
 	useEffect(() => {
-		if (!hasRows) {
+		if (renderStyle !== 'compact' || !hasRows) {
 			setCurrentAgent(null);
 			return;
 		}
+
 		const container = containerRef.current;
 		if (!container) return;
+
 		const update = () => setCurrentAgent(findCurrentAgent(container));
 		update();
 		container.addEventListener('scroll', update, { passive: true });
 		return () => container.removeEventListener('scroll', update);
 	}, [hasRows, renderStyle]);
 
-	// Re-probe when rows change so the tag reflects newly rendered blocks.
 	useEffect(() => {
-		if (!hasRows || !containerRef.current) return;
+		if (renderStyle !== 'compact' || !hasRows || !containerRef.current) {
+			setCurrentAgent(null);
+			return;
+		}
 		setCurrentAgent(findCurrentAgent(containerRef.current));
-	}, [parsedRows.length, hasRows]);
+	}, [parsedRows.length, hasRows, renderStyle]);
 
 	if (isReconnecting) {
 		return (
@@ -173,7 +138,6 @@ export function SpaceTaskUnifiedThread({
 
 	return (
 		<div class="h-full min-h-0 flex flex-col relative" data-testid="space-task-unified-thread">
-			{/* Scroll-spy agent name tag — shows which agent's block is at the top of view */}
 			{currentAgent && (
 				<div
 					class="absolute top-2 left-4 z-10 flex items-center gap-1.5 px-2 py-[3px] rounded bg-dark-900/85 border border-dark-700 backdrop-blur-[2px] pointer-events-none select-none"
@@ -194,15 +158,6 @@ export function SpaceTaskUnifiedThread({
 			)}
 			<div ref={containerRef} class={`flex-1 overflow-y-auto ${bottomInsetClass}`}>
 				<div class="min-h-[calc(100%+1px)]">
-					{hiddenEarlierCount > 0 && (
-						<div
-							class="px-3 py-1.5 text-[11px] uppercase tracking-[0.14em] text-gray-500"
-							data-testid="space-task-thread-earlier-banner"
-						>
-							↑ {hiddenEarlierCount} earlier {hiddenEarlierCount === 1 ? 'message' : 'messages'}{' '}
-							hidden
-						</div>
-					)}
 					{renderStyle === 'compact' ? (
 						<SpaceTaskCardFeed
 							parsedRows={parsedRows}

--- a/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
+++ b/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
@@ -63,8 +63,9 @@ export function SpaceTaskUnifiedThread({
 	// Read render style on every render so that the value stays fresh after a
 	// localStorage write (e.g. via setSpaceTaskThreadRenderStyle in devtools).
 	const renderStyle = getSpaceTaskThreadRenderStyle();
-	const { rows, isLoading, isReconnecting } = useSpaceTaskMessages(taskId, 'full');
+	const { rows, isLoading, isReconnecting } = useSpaceTaskMessages(taskId, 'compact');
 	const containerRef = useRef<HTMLDivElement>(null);
+	const didInitialCompactScrollRef = useRef<string | null>(null);
 
 	const parsedRows = useMemo(() => rows.map(parseThreadRow), [rows]);
 	const threadEvents = useMemo(() => buildThreadEvents(parsedRows), [parsedRows]);
@@ -77,8 +78,15 @@ export function SpaceTaskUnifiedThread({
 
 	useEffect(() => {
 		if (!containerRef.current) return;
+		if (renderStyle === 'compact') {
+			if (didInitialCompactScrollRef.current !== taskId) {
+				containerRef.current.scrollTop = 0;
+				didInitialCompactScrollRef.current = taskId;
+			}
+			return;
+		}
 		containerRef.current.scrollTop = containerRef.current.scrollHeight;
-	}, [parsedRows.length, threadEvents.length]);
+	}, [taskId, renderStyle, parsedRows.length, threadEvents.length]);
 
 	const hasRows = parsedRows.length > 0;
 	const [currentAgent, setCurrentAgent] = useState<AgentTag | null>(null);

--- a/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
+++ b/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
@@ -20,28 +20,36 @@ function findCurrentAgent(container: HTMLElement): AgentTag | null {
 	const rows = container.querySelectorAll<HTMLElement>('[data-agent-label]');
 	if (rows.length === 0) return null;
 
-	const containerTop = container.getBoundingClientRect().top;
-	let found: AgentTag | null = null;
+	const containerRect = container.getBoundingClientRect();
+	const topEdge = containerRect.top + 8;
+	let currentBlock: HTMLElement | null = null;
 	for (const row of Array.from(rows)) {
-		if (row.getBoundingClientRect().top <= containerTop + 8) {
-			found = {
-				label: row.dataset.agentLabel ?? '',
-				color: row.dataset.agentColor ?? '',
-			};
+		if (row.getBoundingClientRect().top <= topEdge) {
+			currentBlock = row;
 		} else {
 			break;
 		}
 	}
 
-	if (!found) {
-		const first = rows[0] as HTMLElement;
-		found = {
-			label: first.dataset.agentLabel ?? '',
-			color: first.dataset.agentColor ?? '',
-		};
+	if (!currentBlock) {
+		currentBlock = rows[0] as HTMLElement;
 	}
 
-	return found;
+	// Hide the floating tag when the block's own inline header is visible in the
+	// viewport — the user can already see which agent they're reading, so the
+	// sticky label is redundant.
+	const header = currentBlock.querySelector<HTMLElement>('[data-testid="compact-block-header"]');
+	if (header) {
+		const headerRect = header.getBoundingClientRect();
+		const isHeaderOnScreen =
+			headerRect.bottom > containerRect.top && headerRect.top < containerRect.bottom;
+		if (isHeaderOnScreen) return null;
+	}
+
+	return {
+		label: currentBlock.dataset.agentLabel ?? '',
+		color: currentBlock.dataset.agentColor ?? '',
+	};
 }
 
 interface SpaceTaskUnifiedThreadProps {

--- a/packages/web/src/components/space/__tests__/SpaceTaskUnifiedThread.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskUnifiedThread.test.tsx
@@ -6,12 +6,8 @@ import { SpaceTaskUnifiedThread } from '../SpaceTaskUnifiedThread';
 let mockRows = [];
 let mockIsLoading = false;
 let mockIsReconnecting = false;
-
-// Control the render style without depending on the mocked localStorage.
-// vitest.setup.ts replaces global localStorage with a vi.fn stub (getItem
-// always returns null, setItem is a no-op). We therefore mock the config
-// module directly so tests can switch between 'compact' and 'legacy'.
 let mockRenderStyle: 'compact' | 'legacy' = 'compact';
+
 vi.mock('../../../lib/space-task-thread-config', () => ({
 	getSpaceTaskThreadRenderStyle: vi.fn(() => mockRenderStyle),
 	setSpaceTaskThreadRenderStyle: vi.fn(),
@@ -35,20 +31,14 @@ vi.mock('../../../hooks/useMessageMaps', () => ({
 	}),
 }));
 
-// Stub the SDK message renderer. The compact card feed now delegates ALL row
-// rendering to SDKMessageRenderer (matching normal-session rendering), so these
-// integration tests assert on the stub's output rather than the old compact
-// rail-style rows. The legacy feed does its own rendering so it's unaffected.
 vi.mock('../../sdk/SDKMessageRenderer', () => ({
 	SDKMessageRenderer: ({ message }: { message: any }) => {
 		const content = message?.message?.content;
-		if (typeof content === 'string') {
-			return <div data-testid="sdk-message-renderer">{content}</div>;
-		}
+		if (typeof content === 'string') return <div data-testid="sdk-message-renderer">{content}</div>;
 		if (Array.isArray(content)) {
 			const text = content
-				.filter((block: any) => block?.type === 'text' && typeof block?.text === 'string')
-				.map((block: any) => block.text)
+				.filter((b: any) => b?.type === 'text' && typeof b?.text === 'string')
+				.map((b: any) => b.text)
 				.join(' ')
 				.trim();
 			return <div data-testid="sdk-message-renderer">{text || message?.type}</div>;
@@ -57,691 +47,166 @@ vi.mock('../../sdk/SDKMessageRenderer', () => ({
 	},
 }));
 
-// ── Row factories ─────────────────────────────────────────────────────────────
-
-/**
- * Rows whose LAST assistant message ends with a tool_use block. Used to
- * exercise the running-border rule that requires the tail event to be a
- * tool invocation.
- */
-function makeToolUseTailRows() {
-	return [
-		{
-			id: 'row-t1',
-			sessionId: 'space:space-1:task:task-1',
-			kind: 'task_agent',
-			role: 'coder',
-			label: 'Task Agent',
-			taskId: 'task-1',
-			taskTitle: 'Task One',
-			messageType: 'assistant',
-			content: JSON.stringify({
-				type: 'assistant',
-				uuid: 'at1',
-				session_id: 'space:space-1:task:task-1',
-				message: {
-					content: [{ type: 'tool_use', id: 'tu1', name: 'Bash', input: { command: 'ls' } }],
-				},
-			}),
-			createdAt: 1_710_000_000_000,
-		},
-	];
+function makeRow(
+	id: string,
+	label: string,
+	message: unknown,
+	createdAt: number,
+	sessionId = 'space:space-1:task:task-1'
+) {
+	return {
+		id,
+		sessionId,
+		kind: 'task_agent',
+		role: 'task',
+		label,
+		taskId: 'task-1',
+		taskTitle: 'Task One',
+		messageType: typeof message === 'object' ? (message as any).type : 'assistant',
+		content: JSON.stringify(message),
+		createdAt,
+	};
 }
 
-/**
- * Rows whose LAST assistant message ends with a plain text block (no
- * tool_use). Running-border rule should keep the indicator hidden even
- * when the agent is active.
- */
-function makeTextTailRows() {
+function makeCompactRows() {
 	return [
-		{
-			id: 'row-x1',
-			sessionId: 'space:space-1:task:task-1',
-			kind: 'task_agent',
-			role: 'coder',
-			label: 'Task Agent',
-			taskId: 'task-1',
-			taskTitle: 'Task One',
-			messageType: 'assistant',
-			content: JSON.stringify({
-				type: 'assistant',
-				uuid: 'ax1',
-				session_id: 'space:space-1:task:task-1',
-				message: {
-					content: [{ type: 'text', text: 'Thinking about next steps...' }],
-				},
-			}),
-			createdAt: 1_710_000_000_000,
-		},
-	];
-}
-
-function makeRows() {
-	return [
-		{
-			id: 'row-1',
-			sessionId: 'space:space-1:task:task-1',
-			kind: 'task_agent',
-			role: 'coder',
-			label: 'Task Agent',
-			taskId: 'task-1',
-			taskTitle: 'Task One',
-			messageType: 'assistant',
-			content: JSON.stringify({
-				type: 'assistant',
-				uuid: 'a1',
-				session_id: 'space:space-1:task:task-1',
-				message: {
-					content: [
-						{ type: 'thinking', thinking: 'Planning implementation details now.' },
-						{ type: 'tool_use', id: 't1', name: 'Glob', input: { pattern: '*.ts' } },
-						{
-							type: 'text',
-							text: 'I found the relevant files and will patch next. This full assistant message should remain visible in compact mode without truncation.',
-						},
-					],
-				},
-			}),
-			createdAt: 1_710_000_000_000,
-		},
-		{
-			id: 'row-2',
-			sessionId: 'space:space-1:task:task-1',
-			kind: 'task_agent',
-			role: 'coder',
-			label: 'Task Agent',
-			taskId: 'task-1',
-			taskTitle: 'Task One',
-			messageType: 'user',
-			content: JSON.stringify({
+		makeRow(
+			'u1',
+			'Task Agent',
+			{
 				type: 'user',
 				uuid: 'u1',
 				session_id: 'space:space-1:task:task-1',
-				parent_tool_use_id: null,
-				message: { content: 'Please keep updates compact.' },
-			}),
-			createdAt: 1_710_000_000_900,
-		},
+				message: { content: 'Initial ask' },
+			},
+			1
+		),
+		makeRow(
+			'a1',
+			'Task Agent',
+			{ type: 'assistant', uuid: 'a1', message: { content: [{ type: 'text', text: 'old-1' }] } },
+			2
+		),
+		makeRow(
+			'a2',
+			'Coder Agent',
+			{ type: 'assistant', uuid: 'a2', message: { content: [{ type: 'text', text: 'old-2' }] } },
+			3
+		),
+		makeRow(
+			'a3',
+			'Reviewer Agent',
+			{ type: 'assistant', uuid: 'a3', message: { content: [{ type: 'text', text: 'old-3' }] } },
+			4
+		),
+		makeRow(
+			'a4',
+			'Task Agent',
+			{ type: 'assistant', uuid: 'a4', message: { content: [{ type: 'text', text: 'tail-1' }] } },
+			5
+		),
+		makeRow(
+			'a5',
+			'Task Agent',
+			{ type: 'assistant', uuid: 'a5', message: { content: [{ type: 'text', text: 'tail-2' }] } },
+			6
+		),
+		makeRow(
+			'a6',
+			'Task Agent',
+			{ type: 'assistant', uuid: 'a6', message: { content: [{ type: 'text', text: 'tail-3' }] } },
+			7
+		),
+		makeRow(
+			'a7',
+			'Task Agent',
+			{ type: 'assistant', uuid: 'a7', message: { content: [{ type: 'text', text: 'tail-4' }] } },
+			8
+		),
+		makeRow(
+			'a8',
+			'Task Agent',
+			{ type: 'assistant', uuid: 'a8', message: { content: [{ type: 'text', text: 'tail-5' }] } },
+			9
+		),
 	];
 }
 
-function makeNoiseRows() {
+function makeLegacyRows() {
 	return [
-		{
-			id: 'sys-init',
-			sessionId: 'space:space-1:task:task-1',
-			kind: 'task_agent',
-			role: 'coder',
-			label: 'Task Agent',
-			taskId: 'task-1',
-			taskTitle: 'Task One',
-			messageType: 'system',
-			content: JSON.stringify({
-				type: 'system',
-				subtype: 'init',
-				uuid: 's1',
-				session_id: 'space:space-1:task:task-1',
-			}),
-			createdAt: 1_710_000_000_000,
-		},
-		{
-			id: 'result-success',
-			sessionId: 'space:space-1:task:task-1',
-			kind: 'task_agent',
-			role: 'coder',
-			label: 'Task Agent',
-			taskId: 'task-1',
-			taskTitle: 'Task One',
-			messageType: 'result',
-			content: JSON.stringify({
-				type: 'result',
-				subtype: 'success',
-				uuid: 'r1',
-				session_id: 'space:space-1:task:task-1',
-				usage: { input_tokens: 10, output_tokens: 5 },
-			}),
-			createdAt: 1_710_000_000_100,
-		},
-		{
-			id: 'rate-allowed',
-			sessionId: 'space:space-1:task:task-1',
-			kind: 'task_agent',
-			role: 'coder',
-			label: 'Task Agent',
-			taskId: 'task-1',
-			taskTitle: 'Task One',
-			messageType: 'rate_limit_event',
-			content: JSON.stringify({
-				type: 'rate_limit_event',
-				uuid: 'rl1',
-				session_id: 'space:space-1:task:task-1',
-				rate_limit_info: {
-					status: 'allowed',
-					rateLimitType: 'five_hour',
-					overageStatus: 'rejected',
-				},
-			}),
-			createdAt: 1_710_000_000_200,
-		},
-		{
-			id: 'rate-rejected',
-			sessionId: 'space:space-1:task:task-1',
-			kind: 'task_agent',
-			role: 'coder',
-			label: 'Task Agent',
-			taskId: 'task-1',
-			taskTitle: 'Task One',
-			messageType: 'rate_limit_event',
-			content: JSON.stringify({
-				type: 'rate_limit_event',
-				uuid: 'rl2',
-				session_id: 'space:space-1:task:task-1',
-				rate_limit_info: { status: 'rejected', rateLimitType: 'five_hour' },
-			}),
-			createdAt: 1_710_000_000_300,
-		},
+		makeRow(
+			'a1',
+			'Task Agent',
+			{ type: 'assistant', uuid: 'a1', message: { content: [{ type: 'text', text: 'legacy-a' }] } },
+			1
+		),
+		makeRow(
+			'a2',
+			'Coder Agent',
+			{ type: 'assistant', uuid: 'a2', message: { content: [{ type: 'text', text: 'legacy-b' }] } },
+			2
+		),
 	];
 }
-
-function makeMultiAgentRows() {
-	return [
-		{
-			id: 'multi-1',
-			sessionId: 'space:space-1:task:task-1',
-			kind: 'task_agent',
-			role: 'task',
-			label: 'Task Agent',
-			taskId: 'task-1',
-			taskTitle: 'Task One',
-			messageType: 'assistant',
-			content: JSON.stringify({
-				type: 'assistant',
-				uuid: 'ma1',
-				session_id: 'space:space-1:task:task-1',
-				message: {
-					content: [{ type: 'text', text: 'Task agent is planning the implementation.' }],
-				},
-			}),
-			createdAt: 1_710_000_000_000,
-		},
-		{
-			id: 'multi-2',
-			sessionId: 'space:space-1:task:task-1:node:coder',
-			kind: 'node_agent',
-			role: 'coder',
-			label: 'Coder Agent',
-			taskId: 'task-1',
-			taskTitle: 'Task One',
-			messageType: 'assistant',
-			content: JSON.stringify({
-				type: 'assistant',
-				uuid: 'ma2',
-				session_id: 'space:space-1:task:task-1:node:coder',
-				message: {
-					content: [{ type: 'text', text: 'Coder agent writing the code changes.' }],
-				},
-			}),
-			createdAt: 1_710_000_001_000,
-		},
-		{
-			id: 'multi-3',
-			sessionId: 'space:space-1:task:task-1:node:reviewer',
-			kind: 'node_agent',
-			role: 'reviewer',
-			label: 'Reviewer Agent',
-			taskId: 'task-1',
-			taskTitle: 'Task One',
-			messageType: 'assistant',
-			content: JSON.stringify({
-				type: 'assistant',
-				uuid: 'ma3',
-				session_id: 'space:space-1:task:task-1:node:reviewer',
-				message: {
-					content: [{ type: 'text', text: 'Reviewer agent checking the changes.' }],
-				},
-			}),
-			createdAt: 1_710_000_002_000,
-		},
-		{
-			id: 'multi-4',
-			sessionId: 'space:space-1:task:task-1',
-			kind: 'task_agent',
-			role: 'task',
-			label: 'Task Agent',
-			taskId: 'task-1',
-			taskTitle: 'Task One',
-			messageType: 'assistant',
-			content: JSON.stringify({
-				type: 'assistant',
-				uuid: 'ma4',
-				session_id: 'space:space-1:task:task-1',
-				message: {
-					content: [{ type: 'text', text: 'Task agent completing final steps.' }],
-				},
-			}),
-			createdAt: 1_710_000_003_000,
-		},
-	];
-}
-
-function makeMultiAgentMixedBlockRows() {
-	return [
-		{
-			id: 'label-1',
-			sessionId: 'space:space-1:task:task-1',
-			kind: 'task_agent',
-			role: 'task',
-			label: 'Task Agent',
-			taskId: 'task-1',
-			taskTitle: 'Task One',
-			messageType: 'assistant',
-			content: JSON.stringify({
-				type: 'assistant',
-				uuid: 'la1',
-				session_id: 'space:space-1:task:task-1',
-				message: {
-					content: [{ type: 'thinking', thinking: 'Deciding the next step.' }],
-				},
-			}),
-			createdAt: 1_710_000_000_000,
-		},
-		{
-			id: 'label-2',
-			sessionId: 'space:space-1:task:task-1:node:coder',
-			kind: 'node_agent',
-			role: 'coder',
-			label: 'Coder Agent',
-			taskId: 'task-1',
-			taskTitle: 'Task One',
-			messageType: 'assistant',
-			content: JSON.stringify({
-				type: 'assistant',
-				uuid: 'la2',
-				session_id: 'space:space-1:task:task-1:node:coder',
-				message: {
-					content: [{ type: 'tool_use', id: 'tu1', name: 'Bash', input: { command: 'npm test' } }],
-				},
-			}),
-			createdAt: 1_710_000_001_000,
-		},
-		{
-			id: 'label-3',
-			sessionId: 'space:space-1:task:task-1:node:reviewer',
-			kind: 'node_agent',
-			role: 'reviewer',
-			label: 'Reviewer Agent',
-			taskId: 'task-1',
-			taskTitle: 'Task One',
-			messageType: 'assistant',
-			content: JSON.stringify({
-				type: 'assistant',
-				uuid: 'la3',
-				session_id: 'space:space-1:task:task-1:node:reviewer',
-				message: {
-					content: [{ type: 'tool_use', id: 'tu2', name: 'Glob', input: { pattern: '*.ts' } }],
-				},
-			}),
-			createdAt: 1_710_000_002_000,
-		},
-	];
-}
-
-function makeTerminalPreservedRows() {
-	// 3 non-terminal body blocks (Coder / Reviewer / Space) followed by a
-	// trailing terminal error result from the Task Agent. The reducer should
-	// keep all three body blocks AND the trailing terminal, producing 4 visible
-	// compact blocks and one ERROR badge.
-	return [
-		{
-			id: 'tp-coder',
-			sessionId: 'space:space-1:task:task-1:node:coder',
-			kind: 'node_agent',
-			role: 'coder',
-			label: 'Coder Agent',
-			taskId: 'task-1',
-			taskTitle: 'Task One',
-			messageType: 'assistant',
-			content: JSON.stringify({
-				type: 'assistant',
-				uuid: 'tp-c1',
-				session_id: 'space:space-1:task:task-1:node:coder',
-				message: { content: [{ type: 'text', text: 'Coder retrying.' }] },
-			}),
-			createdAt: 1_710_000_001_000,
-		},
-		{
-			id: 'tp-reviewer',
-			sessionId: 'space:space-1:task:task-1:node:reviewer',
-			kind: 'node_agent',
-			role: 'reviewer',
-			label: 'Reviewer Agent',
-			taskId: 'task-1',
-			taskTitle: 'Task One',
-			messageType: 'assistant',
-			content: JSON.stringify({
-				type: 'assistant',
-				uuid: 'tp-rv1',
-				session_id: 'space:space-1:task:task-1:node:reviewer',
-				message: { content: [{ type: 'text', text: 'Reviewer re-checking.' }] },
-			}),
-			createdAt: 1_710_000_002_000,
-		},
-		{
-			id: 'tp-space',
-			sessionId: 'space:space-1:task:task-1:node:space',
-			kind: 'node_agent',
-			role: 'space',
-			label: 'Space Agent',
-			taskId: 'task-1',
-			taskTitle: 'Task One',
-			messageType: 'assistant',
-			content: JSON.stringify({
-				type: 'assistant',
-				uuid: 'tp-s1',
-				session_id: 'space:space-1:task:task-1:node:space',
-				message: { content: [{ type: 'text', text: 'Space agent finalising.' }] },
-			}),
-			createdAt: 1_710_000_003_000,
-		},
-		{
-			id: 'tp-result',
-			sessionId: 'space:space-1:task:task-1',
-			kind: 'task_agent',
-			role: 'task',
-			label: 'Task Agent',
-			taskId: 'task-1',
-			taskTitle: 'Task One',
-			messageType: 'result',
-			content: JSON.stringify({
-				type: 'result',
-				subtype: 'error',
-				uuid: 'tp-r1',
-				session_id: 'space:space-1:task:task-1',
-				usage: { input_tokens: 5, output_tokens: 3 },
-			}),
-			createdAt: 1_710_000_004_000,
-		},
-	];
-}
-
-// ── Test suite ────────────────────────────────────────────────────────────────
 
 describe('SpaceTaskUnifiedThread', () => {
 	beforeEach(() => {
 		cleanup();
-		window.localStorage.clear();
 		mockRenderStyle = 'compact';
-		mockRows = makeRows();
+		mockRows = makeCompactRows();
 		mockIsLoading = false;
 		mockIsReconnecting = false;
 	});
 
-	afterEach(() => {
-		cleanup();
-	});
+	afterEach(() => cleanup());
 
-	// ── Default compact mode ──────────────────────────────────────────────────
-
-	it('renders compact mode by default and delegates each row to SDKMessageRenderer', () => {
-		render(<SpaceTaskUnifiedThread taskId="task-1" />);
-		expect(screen.getByTestId('space-task-event-feed-compact')).toBeTruthy();
-		// 2 rows total (assistant + user), both go through SDKMessageRenderer.
-		const rendered = screen.getAllByTestId('sdk-message-renderer');
-		expect(rendered.length).toBe(2);
-		// The assistant's full text block (incl. "patch next") stays visible
-		// — compact mode no longer truncates it.
-		expect(
-			screen.getByText(
-				'I found the relevant files and will patch next. This full assistant message should remain visible in compact mode without truncation.'
-			)
-		).toBeTruthy();
-		// The user message content is rendered too.
-		expect(screen.getByText('Please keep updates compact.')).toBeTruthy();
-	});
-
-	it('does not render compact/verbose toggle controls', () => {
-		render(<SpaceTaskUnifiedThread taskId="task-1" />);
-		expect(screen.queryByTestId('space-task-thread-mode-compact')).toBeNull();
-		expect(screen.queryByTestId('space-task-thread-mode-verbose')).toBeNull();
-	});
-
-	// ── Noise filtering ───────────────────────────────────────────────────────
-
-	it('filters system-init and non-rejected rate-limit noise in compact mode', () => {
-		mockRows = makeNoiseRows();
-		render(<SpaceTaskUnifiedThread taskId="task-1" />);
-
-		// system-init and allowed rate-limit are dropped by preFilterRows;
-		// result-success (terminal) and rate-rejected (error) remain.
-		const rendered = screen.getAllByTestId('sdk-message-renderer');
-		expect(rendered.length).toBe(2);
-
-		// The terminal block's DONE badge is rendered for the success result.
-		expect(screen.getByText('DONE')).toBeTruthy();
-	});
-
-	it('does NOT render the running-block wrapper when the tail block is a terminal result', () => {
-		// makeNoiseRows ends with a terminal result (DONE). Even with
-		// isAgentActive=true, the tail block is terminal so no running indicator.
-		mockRows = makeNoiseRows();
-		render(<SpaceTaskUnifiedThread taskId="task-1" isAgentActive={true} />);
-		expect(screen.queryByTestId('compact-running-block')).toBeNull();
-	});
-
-	it('does NOT render the running-block wrapper when isAgentActive is false', () => {
-		mockRows = makeRows();
-		render(<SpaceTaskUnifiedThread taskId="task-1" isAgentActive={false} />);
-		expect(screen.queryByTestId('compact-running-block')).toBeNull();
-	});
-
-	// ── 3-block limit ─────────────────────────────────────────────────────────
-
-	it('shows only the last 3 logical blocks when more than 3 exist', () => {
-		mockRows = makeMultiAgentRows();
+	it('renders compact feed with full history grouped by turn', () => {
 		render(<SpaceTaskUnifiedThread taskId="task-1" />);
 
 		expect(screen.getByTestId('space-task-event-feed-compact')).toBeTruthy();
-
-		// Last 3 (Coder, Reviewer, Task-final) are visible.
-		expect(screen.getByText('Coder agent writing the code changes.')).toBeTruthy();
-		expect(screen.getByText('Reviewer agent checking the changes.')).toBeTruthy();
-		expect(screen.getByText('Task agent completing final steps.')).toBeTruthy();
-
-		// First block (Task Agent planning) is outside the last-3 window → hidden.
-		expect(screen.queryByText('Task agent is planning the implementation.')).toBeNull();
+		expect(screen.getByText('Initial ask')).toBeTruthy();
+		expect(screen.getByText('old-1')).toBeTruthy();
+		expect(screen.getByText('old-2')).toBeTruthy();
+		expect(screen.getByText('old-3')).toBeTruthy();
+		expect(screen.getByText('tail-1')).toBeTruthy();
+		expect(screen.getByText('tail-5')).toBeTruthy();
+		expect(screen.queryByTestId('compact-flat-hidden-divider')).toBeNull();
+		expect(screen.getByText('Turn 1')).toBeTruthy();
 	});
 
-	it('preserves chronological ordering of the visible blocks', () => {
-		mockRows = makeMultiAgentRows();
+	it('renders the floating agent tag in compact mode', () => {
 		render(<SpaceTaskUnifiedThread taskId="task-1" />);
-
-		const allText = screen.getByTestId('space-task-event-feed-compact').textContent ?? '';
-		const coderIdx = allText.indexOf('Coder agent writing');
-		const reviewerIdx = allText.indexOf('Reviewer agent checking');
-		const taskFinalIdx = allText.indexOf('Task agent completing');
-
-		expect(coderIdx).toBeGreaterThanOrEqual(0);
-		expect(reviewerIdx).toBeGreaterThan(coderIdx);
-		expect(taskFinalIdx).toBeGreaterThan(reviewerIdx);
+		const tag = screen.getByTestId('agent-name-tag');
+		expect(tag).toBeTruthy();
+		expect(tag.textContent).toContain('TASK');
 	});
 
-	// ── Terminal block preservation ───────────────────────────────────────────
-
-	it('always shows terminal blocks even when outside the last-3 window', () => {
-		mockRows = makeTerminalPreservedRows();
-		render(<SpaceTaskUnifiedThread taskId="task-1" />);
-
-		// Terminal block's ERROR badge is present (from block 1's error result).
-		expect(screen.getByText('ERROR')).toBeTruthy();
-
-		// Last-3 block messages still visible.
-		expect(screen.getByText('Coder retrying.')).toBeTruthy();
-		expect(screen.getByText('Reviewer re-checking.')).toBeTruthy();
-		expect(screen.getByText('Space agent finalising.')).toBeTruthy();
-	});
-
-	// ── Running indicator ─────────────────────────────────────────────────────
-
-	it('shows the running-block wrapper when the agent is active, tail block is non-terminal, and the last row has a tool_use', () => {
-		mockRows = makeToolUseTailRows();
-		render(<SpaceTaskUnifiedThread taskId="task-1" isAgentActive={true} />);
-		expect(screen.getByTestId('compact-running-block')).toBeTruthy();
-	});
-
-	it('does NOT render the running-block wrapper when the last row is a plain-text assistant message (no tool_use)', () => {
-		mockRows = makeTextTailRows();
-		render(<SpaceTaskUnifiedThread taskId="task-1" isAgentActive={true} />);
-		expect(screen.queryByTestId('compact-running-block')).toBeNull();
-	});
-
-	// ── Agent identity ────────────────────────────────────────────────────────
-
-	it('renders distinct agent identity headers for each visible block', () => {
-		mockRows = makeMultiAgentMixedBlockRows();
-		const { container } = render(<SpaceTaskUnifiedThread taskId="task-1" />);
-
-		const labels = Array.from(
-			container.querySelectorAll('[data-testid="compact-block-header"] span[style*="color"]')
-		).map((el) => el.textContent);
-
-		expect(labels).toContain('TASK');
-		expect(labels).toContain('CODER');
-		expect(labels).toContain('REVIEWER');
-	});
-
-	it('applies distinct colors to different agent identity headers', () => {
-		mockRows = makeMultiAgentMixedBlockRows();
-		const { container } = render(<SpaceTaskUnifiedThread taskId="task-1" />);
-
-		const colored = Array.from(
-			container.querySelectorAll('[data-testid="compact-block-header"] span[style*="color"]')
-		);
-		const taskLabelSpan = colored.find((el) => el.textContent === 'TASK') as
-			| HTMLElement
-			| undefined;
-		const coderLabelSpan = colored.find((el) => el.textContent === 'CODER') as
-			| HTMLElement
-			| undefined;
-
-		expect(taskLabelSpan).toBeTruthy();
-		expect(coderLabelSpan).toBeTruthy();
-
-		const taskColor = taskLabelSpan!.style.color;
-		const coderColor = coderLabelSpan!.style.color;
-		expect(taskColor).not.toBe('');
-		expect(coderColor).not.toBe('');
-		expect(taskColor).not.toBe(coderColor);
-	});
-
-	it('renders a colored dot alongside each agent header', () => {
-		mockRows = makeMultiAgentRows();
-		const { container } = render(<SpaceTaskUnifiedThread taskId="task-1" />);
-
-		const dots = container.querySelectorAll(
-			'[data-testid="compact-block-header"] span[style*="background-color"]'
-		);
-		// The feed shows at most 3 blocks; so between 1 and 3 dots.
-		expect(dots.length).toBeGreaterThanOrEqual(1);
-		expect(dots.length).toBeLessThanOrEqual(3);
-		dots.forEach((dot) => {
-			expect((dot as HTMLElement).style.backgroundColor).not.toBe('');
-		});
-	});
-
-	// ── Legacy mode ───────────────────────────────────────────────────────────
-
-	it('renders legacy feed when style is set to legacy', () => {
+	it('renders legacy feed when style is legacy', () => {
 		mockRenderStyle = 'legacy';
+		mockRows = makeLegacyRows();
 		render(<SpaceTaskUnifiedThread taskId="task-1" />);
 
 		expect(screen.getByTestId('space-task-event-feed-legacy')).toBeTruthy();
 		expect(screen.queryByTestId('space-task-event-feed-compact')).toBeNull();
 	});
 
-	it('legacy mode shows ALL multi-agent messages (no block limit)', () => {
-		mockRenderStyle = 'legacy';
-		mockRows = makeMultiAgentRows();
-		render(<SpaceTaskUnifiedThread taskId="task-1" />);
-
-		expect(screen.getByText('Task agent is planning the implementation.')).toBeTruthy();
-		expect(screen.getByText('Coder agent writing the code changes.')).toBeTruthy();
-		expect(screen.getByText('Reviewer agent checking the changes.')).toBeTruthy();
-		expect(screen.getByText('Task agent completing final steps.')).toBeTruthy();
-	});
-
-	it('legacy mode hides success result events (unchanged from pre-compact behavior)', () => {
-		mockRenderStyle = 'legacy';
-		mockRows = makeNoiseRows();
-		render(<SpaceTaskUnifiedThread taskId="task-1" />);
-
-		expect(screen.queryByText('Completed')).toBeNull();
-		expect(screen.queryByText('System')).toBeNull();
-	});
-
-	// ── Loading / reconnecting / empty states ─────────────────────────────────
-
-	it('shows loading state when isLoading is true', () => {
+	it('shows loading state when loading', () => {
 		mockIsLoading = true;
 		mockRows = [];
 		render(<SpaceTaskUnifiedThread taskId="task-1" />);
 		expect(screen.getByText('Loading task thread…')).toBeTruthy();
 	});
 
-	it('shows reconnecting state when isReconnecting is true', () => {
+	it('shows reconnecting state when reconnecting', () => {
 		mockIsReconnecting = true;
 		mockRows = [];
 		render(<SpaceTaskUnifiedThread taskId="task-1" />);
 		expect(screen.getByText('Reconnecting task thread…')).toBeTruthy();
 	});
 
-	it('shows empty state when no rows exist', () => {
+	it('shows empty state when no rows', () => {
 		mockRows = [];
 		render(<SpaceTaskUnifiedThread taskId="task-1" />);
 		expect(screen.getByText('No task-agent activity yet.')).toBeTruthy();
-	});
-
-	it('does not render the "earlier messages hidden" banner when nothing is truncated', () => {
-		// The compact query still sets sessionMessageCount even when the slice
-		// matches the delivered rows — the banner must stay hidden.
-		mockRows = makeRows().map((row) => ({ ...row, sessionMessageCount: 2 }));
-		render(<SpaceTaskUnifiedThread taskId="task-1" />);
-		expect(screen.queryByTestId('space-task-thread-earlier-banner')).toBeNull();
-	});
-
-	it('renders a banner with the true hidden count when the compact query has truncated rows', () => {
-		// 2 delivered rows, but 27 total → banner should show 25 hidden.
-		mockRows = makeRows().map((row) => ({ ...row, sessionMessageCount: 27 }));
-		render(<SpaceTaskUnifiedThread taskId="task-1" />);
-		const banner = screen.getByTestId('space-task-thread-earlier-banner');
-		expect(banner).toBeTruthy();
-		expect(banner.textContent).toContain('25');
-		expect(banner.textContent).toContain('earlier');
-	});
-
-	it('aggregates hidden counts across multiple sessions', () => {
-		// Task Agent (session A): 2 delivered, 4 total → 2 hidden
-		// Coder Agent (session B): 1 delivered, 6 total → 5 hidden
-		// Reviewer Agent (session C): 1 delivered, 1 total → 0 hidden
-		// Task Agent (session A again, interleaved): same session as first
-		const rows = makeMultiAgentRows();
-		rows[0] = { ...rows[0], sessionMessageCount: 4 };
-		rows[3] = { ...rows[3], sessionMessageCount: 4 };
-		rows[1] = { ...rows[1], sessionMessageCount: 6 };
-		rows[2] = { ...rows[2], sessionMessageCount: 1 };
-		mockRows = rows;
-
-		render(<SpaceTaskUnifiedThread taskId="task-1" />);
-		const banner = screen.getByTestId('space-task-thread-earlier-banner');
-		expect(banner).toBeTruthy();
-		// (4-2) + (6-1) + 0 = 7
-		expect(banner.textContent).toContain('7');
-	});
-
-	it('does not render a banner when sessionMessageCount is absent (full-query fallback)', () => {
-		// Legacy full query returns rows without sessionMessageCount.
-		mockRows = makeRows();
-		render(<SpaceTaskUnifiedThread taskId="task-1" />);
-		expect(screen.queryByTestId('space-task-thread-earlier-banner')).toBeNull();
 	});
 });

--- a/packages/web/src/components/space/__tests__/SpaceTaskUnifiedThread.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskUnifiedThread.test.tsx
@@ -171,7 +171,7 @@ describe('SpaceTaskUnifiedThread', () => {
 		expect(screen.getByText('tail-1')).toBeTruthy();
 		expect(screen.getByText('tail-5')).toBeTruthy();
 		expect(screen.queryByTestId('compact-flat-hidden-divider')).toBeNull();
-		expect(screen.getByText('Turn 1')).toBeTruthy();
+		expect(screen.queryByTestId('compact-turn-divider')).toBeNull();
 	});
 
 	it('renders the floating agent tag in compact mode', () => {

--- a/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.test.tsx
+++ b/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.test.tsx
@@ -275,7 +275,7 @@ describe('SpaceTaskCardFeed', () => {
 		expect(headers.length).toBe(3);
 		expect(container.textContent).toContain('TASK');
 		expect(container.textContent).toContain('CODER');
-		expect(container.textContent).toContain('Agent Turn');
+		expect(container.textContent).not.toContain('Agent Turn');
 
 		const siderails = container.querySelectorAll('[data-testid="compact-block-siderail"]');
 		expect(siderails.length).toBe(3);
@@ -387,6 +387,36 @@ describe('SpaceTaskCardFeed', () => {
 		expect(
 			initialUser.compareDocumentPosition(divider) & Node.DOCUMENT_POSITION_FOLLOWING
 		).toBeTruthy();
+	});
+
+	it('clicking the earlier-messages pill opens the agent slide-out chat', () => {
+		const rows = [
+			{
+				...makeUserRow('u1', 'Coder Agent', 'Initial ask', 'sess-coder', true),
+				turnIndex: 2,
+				turnHiddenMessageCount: 3,
+			},
+			{
+				...makeAssistantTextRow('a1', 'Coder Agent', 'msg-1', 'sess-coder'),
+				turnIndex: 2,
+				turnHiddenMessageCount: 3,
+			},
+		];
+		render(
+			<SpaceTaskCardFeed
+				parsedRows={rows}
+				taskId="task-1"
+				maps={fakeMaps as any}
+				isAgentActive={false}
+			/>
+		);
+
+		const pill = screen.getByTestId('compact-turn-hidden-divider-button');
+		expect(pill.textContent).toContain('3 earlier messages');
+		expect(pill.textContent?.toLowerCase()).toContain('open chat');
+		fireEvent.click(pill);
+		expect(mockSpaceOverlaySessionIdSignal.value).toBe('sess-coder');
+		expect(mockSpaceOverlayAgentNameSignal.value).toBe('Coder Agent');
 	});
 
 	it('renders subagent result/error rows (no filtering)', () => {

--- a/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.test.tsx
+++ b/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.test.tsx
@@ -27,12 +27,14 @@ vi.mock('../../../sdk/SDKMessageRenderer', () => ({
 		message,
 		taskContext,
 		showSubagentMessages,
+		showToolResultUserMessages,
 		flattenSubagentTools,
 		isRunning,
 	}: {
 		message: any;
 		taskContext?: boolean;
 		showSubagentMessages?: boolean;
+		showToolResultUserMessages?: boolean;
 		flattenSubagentTools?: boolean;
 		isRunning?: boolean;
 	}) => {
@@ -52,6 +54,7 @@ vi.mock('../../../sdk/SDKMessageRenderer', () => ({
 				data-testid="sdk-message-renderer"
 				data-task-context={taskContext ? '1' : '0'}
 				data-show-subagents={showSubagentMessages ? '1' : '0'}
+				data-show-tool-result-users={showToolResultUserMessages ? '1' : '0'}
 				data-flatten-subagent-tools={flattenSubagentTools ? '1' : '0'}
 				data-running={isRunning ? '1' : '0'}
 			>
@@ -68,11 +71,15 @@ const fakeMaps = {
 	sessionInfoMap: new Map(),
 } as const;
 
+function defaultSessionIdForLabel(label: string): string {
+	return `sess-${label.trim().toLowerCase().replace(/\s+/g, '-')}`;
+}
+
 function makeAssistantTextRow(
 	id: string,
 	label: string,
 	text: string,
-	sessionId = `sess-${id}`,
+	sessionId = defaultSessionIdForLabel(label),
 	parentToolUseId?: string
 ): ParsedThreadRow {
 	return {
@@ -82,6 +89,8 @@ function makeAssistantTextRow(
 		taskId: 'task-1',
 		taskTitle: 'Task One',
 		createdAt: Number(id.replace(/\D/g, '') || 0),
+		turnIndex: undefined,
+		turnHiddenMessageCount: undefined,
 		message: {
 			type: 'assistant',
 			uuid: id,
@@ -96,7 +105,7 @@ function makeToolUseRow(
 	id: string,
 	label: string,
 	toolName = 'Bash',
-	sessionId = `sess-${id}`
+	sessionId = defaultSessionIdForLabel(label)
 ): ParsedThreadRow {
 	return {
 		id,
@@ -105,6 +114,8 @@ function makeToolUseRow(
 		taskId: 'task-1',
 		taskTitle: 'Task One',
 		createdAt: Number(id.replace(/\D/g, '') || 0),
+		turnIndex: undefined,
+		turnHiddenMessageCount: undefined,
 		message: {
 			type: 'assistant',
 			uuid: id,
@@ -118,7 +129,7 @@ function makeUserRow(
 	id: string,
 	label: string,
 	text: string,
-	sessionId = `sess-${id}`,
+	sessionId = defaultSessionIdForLabel(label),
 	isSynthetic = false
 ): ParsedThreadRow {
 	return {
@@ -128,6 +139,8 @@ function makeUserRow(
 		taskId: 'task-1',
 		taskTitle: 'Task One',
 		createdAt: Number(id.replace(/\D/g, '') || 0),
+		turnIndex: undefined,
+		turnHiddenMessageCount: undefined,
 		message: {
 			type: 'user',
 			uuid: id,
@@ -142,7 +155,7 @@ function makeResultRow(
 	id: string,
 	label: string,
 	subtype: 'success' | 'error_during_execution' = 'success',
-	sessionId = `sess-${id}`,
+	sessionId = defaultSessionIdForLabel(label),
 	parentToolUseId?: string
 ): ParsedThreadRow {
 	return {
@@ -152,6 +165,8 @@ function makeResultRow(
 		taskId: 'task-1',
 		taskTitle: 'Task One',
 		createdAt: Number(id.replace(/\D/g, '') || 0),
+		turnIndex: undefined,
+		turnHiddenMessageCount: undefined,
 		message: {
 			type: 'result',
 			uuid: id,
@@ -170,7 +185,7 @@ describe('SpaceTaskCardFeed', () => {
 	});
 	afterEach(() => cleanup());
 
-	it('renders whole history (no tail truncation)', () => {
+	it('renders all compact rows while preserving agent-turn block grouping', () => {
 		const rows = [
 			makeUserRow('u1', 'Task Agent', 'Initial ask'),
 			makeAssistantTextRow('a1', 'Task Agent', 'msg-1'),
@@ -192,18 +207,27 @@ describe('SpaceTaskCardFeed', () => {
 		const rendered = Array.from(
 			container.querySelectorAll('[data-testid="sdk-message-renderer"]')
 		).map((el) => el.textContent);
-		expect(rendered).toEqual(['Initial ask', 'msg-1', 'msg-2', 'msg-3', 'msg-4', 'msg-5', 'msg-6']);
+		expect(rendered).toEqual(['Initial ask', 'msg-1', 'msg-4', 'msg-5', 'msg-6', 'msg-2', 'msg-3']);
 		expect(screen.queryByTestId('compact-flat-hidden-divider')).toBeNull();
 	});
 
-	it('groups rows by turn using terminal result/error boundaries', () => {
+	it('groups interleaved messages by agent/session turn and orders by turn start', () => {
 		const rows = [
-			makeAssistantTextRow('a0', 'Task Agent', 'turn1-task'),
-			makeAssistantTextRow('a1', 'Coder Agent', 'turn1-coder'),
-			makeResultRow('r1', 'Task Agent', 'success'),
-			makeAssistantTextRow('a2', 'Task Agent', 'turn2-task'),
-			makeResultRow('r2', 'Task Agent', 'error_during_execution'),
-			makeAssistantTextRow('a3', 'Task Agent', 'turn3-task'),
+			{ ...makeUserRow('u1', 'Coder Agent', 'coder-init', 'sess-coder'), turnIndex: 1 },
+			{ ...makeUserRow('u2', 'Reviewer Agent', 'review-init', 'sess-reviewer'), turnIndex: 1 },
+			{
+				...makeAssistantTextRow('a1', 'Coder Agent', 'coder-progress', 'sess-coder'),
+				turnIndex: 1,
+			},
+			{
+				...makeAssistantTextRow('a2', 'Reviewer Agent', 'review-progress', 'sess-reviewer'),
+				turnIndex: 1,
+			},
+			{ ...makeResultRow('r1', 'Coder Agent', 'success', 'sess-coder'), turnIndex: 1 },
+			{
+				...makeAssistantTextRow('a3', 'Reviewer Agent', 'review-tail', 'sess-reviewer'),
+				turnIndex: 1,
+			},
 		];
 		render(
 			<SpaceTaskCardFeed
@@ -215,17 +239,21 @@ describe('SpaceTaskCardFeed', () => {
 		);
 
 		const turnGroups = screen.getAllByTestId('compact-turn-group');
-		expect(turnGroups.length).toBe(3);
+		expect(turnGroups.length).toBe(2);
 		expect(screen.getByText('Turn 1')).toBeTruthy();
 		expect(screen.getByText('Turn 2')).toBeTruthy();
-		expect(screen.getByText('Turn 3')).toBeTruthy();
-
 		const turn1Msgs = within(turnGroups[0]).getAllByTestId('sdk-message-renderer');
-		expect(turn1Msgs.map((el) => el.textContent)).toEqual(['turn1-task', 'turn1-coder', 'result']);
+		expect(turn1Msgs.map((el) => el.textContent)).toEqual([
+			'coder-init',
+			'coder-progress',
+			'result',
+		]);
 		const turn2Msgs = within(turnGroups[1]).getAllByTestId('sdk-message-renderer');
-		expect(turn2Msgs.map((el) => el.textContent)).toEqual(['turn2-task', 'result']);
-		const turn3Msgs = within(turnGroups[2]).getAllByTestId('sdk-message-renderer');
-		expect(turn3Msgs.map((el) => el.textContent)).toEqual(['turn3-task']);
+		expect(turn2Msgs.map((el) => el.textContent)).toEqual([
+			'review-init',
+			'review-progress',
+			'review-tail',
+		]);
 	});
 
 	it('renders agent headers and color siderails within turns', () => {
@@ -317,7 +345,48 @@ describe('SpaceTaskCardFeed', () => {
 		const rendered = container.querySelector('[data-testid="sdk-message-renderer"]') as HTMLElement;
 		expect(rendered.getAttribute('data-task-context')).toBe('1');
 		expect(rendered.getAttribute('data-show-subagents')).toBe('1');
+		expect(rendered.getAttribute('data-show-tool-result-users')).toBe('0');
 		expect(rendered.getAttribute('data-flatten-subagent-tools')).toBe('0');
+	});
+
+	it('renders turn-level earlier divider after initial user message', () => {
+		const rows = [
+			{
+				...makeUserRow('u1', 'Task Agent', 'Initial ask', 'sess-task', true),
+				turnIndex: 2,
+				turnHiddenMessageCount: 4,
+			},
+			{
+				...makeAssistantTextRow('a1', 'Task Agent', 'msg-1', 'sess-task'),
+				turnIndex: 2,
+				turnHiddenMessageCount: 4,
+			},
+			{
+				...makeAssistantTextRow('a2', 'Task Agent', 'msg-2', 'sess-task'),
+				turnIndex: 2,
+				turnHiddenMessageCount: 4,
+			},
+			{
+				...makeResultRow('r1', 'Task Agent', 'success', 'sess-task'),
+				turnIndex: 2,
+				turnHiddenMessageCount: 4,
+			},
+		];
+		render(
+			<SpaceTaskCardFeed
+				parsedRows={rows}
+				taskId="task-1"
+				maps={fakeMaps as any}
+				isAgentActive={false}
+			/>
+		);
+
+		const divider = screen.getByTestId('compact-turn-hidden-divider');
+		expect(divider.textContent).toContain('4 earlier messages');
+		const initialUser = screen.getByText('Initial ask');
+		expect(
+			initialUser.compareDocumentPosition(divider) & Node.DOCUMENT_POSITION_FOLLOWING
+		).toBeTruthy();
 	});
 
 	it('renders subagent result/error rows (no filtering)', () => {

--- a/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.test.tsx
+++ b/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.test.tsx
@@ -277,10 +277,10 @@ describe('SpaceTaskCardFeed', () => {
 		expect(container.textContent).toContain('CODER');
 		expect(container.textContent).not.toContain('Agent Turn');
 
-		const siderails = container.querySelectorAll('[data-testid="compact-block-siderail"]');
-		expect(siderails.length).toBe(3);
-		siderails.forEach((el) => {
-			expect((el as HTMLElement).style.backgroundColor).not.toBe('');
+		const brackets = container.querySelectorAll('[data-testid="compact-block-bracket"]');
+		expect(brackets.length).toBe(3);
+		brackets.forEach((el) => {
+			expect((el as HTMLElement).style.borderColor).not.toBe('');
 		});
 	});
 

--- a/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.test.tsx
+++ b/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.test.tsx
@@ -240,8 +240,7 @@ describe('SpaceTaskCardFeed', () => {
 
 		const turnGroups = screen.getAllByTestId('compact-turn-group');
 		expect(turnGroups.length).toBe(2);
-		expect(screen.getByText('Turn 1')).toBeTruthy();
-		expect(screen.getByText('Turn 2')).toBeTruthy();
+		expect(screen.queryByTestId('compact-turn-divider')).toBeNull();
 		const turn1Msgs = within(turnGroups[0]).getAllByTestId('sdk-message-renderer');
 		expect(turn1Msgs.map((el) => el.textContent)).toEqual([
 			'coder-init',
@@ -276,6 +275,7 @@ describe('SpaceTaskCardFeed', () => {
 		expect(headers.length).toBe(3);
 		expect(container.textContent).toContain('TASK');
 		expect(container.textContent).toContain('CODER');
+		expect(container.textContent).toContain('Agent Turn');
 
 		const siderails = container.querySelectorAll('[data-testid="compact-block-siderail"]');
 		expect(siderails.length).toBe(3);

--- a/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.test.tsx
+++ b/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.test.tsx
@@ -1,14 +1,14 @@
 // @ts-nocheck
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/preact';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/preact';
 import type { ParsedThreadRow } from '../space-task-thread-events';
+import { SpaceTaskCardFeed } from './SpaceTaskCardFeed';
 
-// ── Signal mocks ─────────────────────────────────────────────────────────────
-// Hoisted plain holders the component mutates; we assert against them in tests.
 const { mockSpaceOverlaySessionIdSignal, mockSpaceOverlayAgentNameSignal } = vi.hoisted(() => ({
 	mockSpaceOverlaySessionIdSignal: { value: null as string | null },
 	mockSpaceOverlayAgentNameSignal: { value: null as string | null },
 }));
+
 vi.mock('../../../../lib/signals', async (importOriginal) => {
 	const actual = await importOriginal();
 	return {
@@ -22,48 +22,42 @@ vi.mock('../../../../lib/signals', async (importOriginal) => {
 	};
 });
 
-// Import the component AFTER vi.mock so the mocked signals are picked up.
-import { SpaceTaskCardFeed } from './SpaceTaskCardFeed';
-
-// Stub SDKMessageRenderer so these tests can focus on the feed's grouping,
-// visibility, agent-header and running-block behavior without pulling in the
-// full SDK render tree. The stub echoes text/user content when available and
-// falls back to the message `type` so terminal/result rows still render
-// something detectable. Synthetic user messages (`isSynthetic=true`) are
-// marked with a distinct testid so the feed's test suite can assert they
-// route to the purple `SyntheticMessageBlock` path rather than the regular
-// user-bubble path.
 vi.mock('../../../sdk/SDKMessageRenderer', () => ({
 	SDKMessageRenderer: ({
 		message,
 		taskContext,
+		showSubagentMessages,
+		flattenSubagentTools,
 		isRunning,
 	}: {
 		message: any;
 		taskContext?: boolean;
+		showSubagentMessages?: boolean;
+		flattenSubagentTools?: boolean;
 		isRunning?: boolean;
 	}) => {
 		const content = message?.message?.content;
-		const isSyntheticUser = message?.type === 'user' && message?.isSynthetic === true;
-		const testId = isSyntheticUser ? 'sdk-synthetic-message' : 'sdk-message-renderer';
-		const attrs = {
-			'data-testid': testId,
-			'data-task-context': taskContext ? '1' : '0',
-			'data-running': isRunning ? '1' : '0',
-			'data-synthetic': isSyntheticUser ? '1' : '0',
-		};
-		if (typeof content === 'string') {
-			return <div {...attrs}>{content}</div>;
-		}
+		let text = message?.type ?? '';
+		if (typeof content === 'string') text = content;
 		if (Array.isArray(content)) {
-			const text = content
-				.filter((b: any) => b?.type === 'text' && typeof b?.text === 'string')
-				.map((b: any) => b.text)
-				.join(' ')
-				.trim();
-			return <div {...attrs}>{text || message?.type || ''}</div>;
+			text =
+				content
+					.filter((b: any) => b?.type === 'text' && typeof b?.text === 'string')
+					.map((b: any) => b.text)
+					.join(' ')
+					.trim() || text;
 		}
-		return <div {...attrs}>{message?.type || ''}</div>;
+		return (
+			<div
+				data-testid="sdk-message-renderer"
+				data-task-context={taskContext ? '1' : '0'}
+				data-show-subagents={showSubagentMessages ? '1' : '0'}
+				data-flatten-subagent-tools={flattenSubagentTools ? '1' : '0'}
+				data-running={isRunning ? '1' : '0'}
+			>
+				{text}
+			</div>
+		);
 	},
 }));
 
@@ -74,13 +68,12 @@ const fakeMaps = {
 	sessionInfoMap: new Map(),
 } as const;
 
-// ── Row factories ────────────────────────────────────────────────────────────
-
 function makeAssistantTextRow(
 	id: string,
 	label: string,
 	text: string,
-	sessionId: string | null = null
+	sessionId = `sess-${id}`,
+	parentToolUseId?: string
 ): ParsedThreadRow {
 	return {
 		id,
@@ -88,22 +81,22 @@ function makeAssistantTextRow(
 		label,
 		taskId: 'task-1',
 		taskTitle: 'Task One',
-		createdAt: Date.now(),
+		createdAt: Number(id.replace(/\D/g, '') || 0),
 		message: {
 			type: 'assistant',
 			uuid: id,
+			parent_tool_use_id: parentToolUseId ?? null,
 			message: { content: [{ type: 'text', text }] },
 		} as any,
 		fallbackText: null,
 	};
 }
 
-/** Assistant row whose content includes a tool_use block — triggers the running border. */
 function makeToolUseRow(
 	id: string,
 	label: string,
-	toolName = 'bash',
-	sessionId: string | null = null
+	toolName = 'Bash',
+	sessionId = `sess-${id}`
 ): ParsedThreadRow {
 	return {
 		id,
@@ -111,13 +104,35 @@ function makeToolUseRow(
 		label,
 		taskId: 'task-1',
 		taskTitle: 'Task One',
-		createdAt: Date.now(),
+		createdAt: Number(id.replace(/\D/g, '') || 0),
 		message: {
 			type: 'assistant',
 			uuid: id,
-			message: {
-				content: [{ type: 'tool_use', id: `tu-${id}`, name: toolName, input: {} }],
-			},
+			message: { content: [{ type: 'tool_use', id: `tu-${id}`, name: toolName, input: {} }] },
+		} as any,
+		fallbackText: null,
+	};
+}
+
+function makeUserRow(
+	id: string,
+	label: string,
+	text: string,
+	sessionId = `sess-${id}`,
+	isSynthetic = false
+): ParsedThreadRow {
+	return {
+		id,
+		sessionId,
+		label,
+		taskId: 'task-1',
+		taskTitle: 'Task One',
+		createdAt: Number(id.replace(/\D/g, '') || 0),
+		message: {
+			type: 'user',
+			uuid: id,
+			isSynthetic,
+			message: { content: text },
 		} as any,
 		fallbackText: null,
 	};
@@ -126,96 +141,26 @@ function makeToolUseRow(
 function makeResultRow(
 	id: string,
 	label: string,
-	subtype: 'success' | 'error' = 'success'
+	subtype: 'success' | 'error_during_execution' = 'success',
+	sessionId = `sess-${id}`,
+	parentToolUseId?: string
 ): ParsedThreadRow {
 	return {
 		id,
-		sessionId: null,
+		sessionId,
 		label,
 		taskId: 'task-1',
 		taskTitle: 'Task One',
-		createdAt: Date.now(),
+		createdAt: Number(id.replace(/\D/g, '') || 0),
 		message: {
 			type: 'result',
+			uuid: id,
 			subtype,
-			uuid: id,
-			usage: { input_tokens: 1, output_tokens: 1 },
+			parent_tool_use_id: parentToolUseId ?? null,
 		} as any,
 		fallbackText: null,
 	};
 }
-
-function makeSystemInitRow(
-	id: string,
-	label: string,
-	overrides: Record<string, unknown> = {}
-): ParsedThreadRow {
-	return {
-		id,
-		sessionId: null,
-		label,
-		taskId: 'task-1',
-		taskTitle: 'Task One',
-		createdAt: Date.now(),
-		message: {
-			type: 'system',
-			subtype: 'init',
-			uuid: id,
-			model: 'claude-opus-4-5',
-			permissionMode: 'default',
-			cwd: '/tmp/work',
-			tools: ['Bash', 'Read', 'Edit'],
-			mcp_servers: [],
-			slash_commands: [],
-			agents: [],
-			apiKeySource: 'user',
-			output_style: 'text',
-			session_id: 'session-1',
-			...overrides,
-		} as any,
-		fallbackText: null,
-	};
-}
-
-function makeRateLimitRow(
-	id: string,
-	label: string,
-	status: 'allowed' | 'allowed_warning' | 'rejected'
-): ParsedThreadRow {
-	return {
-		id,
-		sessionId: null,
-		label,
-		taskId: 'task-1',
-		taskTitle: 'Task One',
-		createdAt: Date.now(),
-		message: {
-			type: 'rate_limit_event',
-			uuid: id,
-			rate_limit_info: { status, rateLimitType: 'five_hour' },
-		} as any,
-		fallbackText: null,
-	};
-}
-
-function makeEmptyUserRow(id: string, label: string): ParsedThreadRow {
-	return {
-		id,
-		sessionId: null,
-		label,
-		taskId: 'task-1',
-		taskTitle: 'Task One',
-		createdAt: Date.now(),
-		message: {
-			type: 'user',
-			uuid: id,
-			message: { content: '' },
-		} as any,
-		fallbackText: null,
-	};
-}
-
-// ── Tests ────────────────────────────────────────────────────────────────────
 
 describe('SpaceTaskCardFeed', () => {
 	beforeEach(() => {
@@ -225,12 +170,15 @@ describe('SpaceTaskCardFeed', () => {
 	});
 	afterEach(() => cleanup());
 
-	// ── Delegation to SDKMessageRenderer (the whole point of this refactor) ──
-
-	it('delegates every visible row to SDKMessageRenderer with taskContext=true', () => {
+	it('renders whole history (no tail truncation)', () => {
 		const rows = [
-			makeAssistantTextRow('r1', 'Task Agent', 'task said hello'),
-			makeAssistantTextRow('r2', 'Coder Agent', 'coder said hi'),
+			makeUserRow('u1', 'Task Agent', 'Initial ask'),
+			makeAssistantTextRow('a1', 'Task Agent', 'msg-1'),
+			makeAssistantTextRow('a2', 'Coder Agent', 'msg-2'),
+			makeAssistantTextRow('a3', 'Reviewer Agent', 'msg-3'),
+			makeAssistantTextRow('a4', 'Task Agent', 'msg-4'),
+			makeAssistantTextRow('a5', 'Task Agent', 'msg-5'),
+			makeAssistantTextRow('a6', 'Task Agent', 'msg-6'),
 		];
 		const { container } = render(
 			<SpaceTaskCardFeed
@@ -241,95 +189,21 @@ describe('SpaceTaskCardFeed', () => {
 			/>
 		);
 
-		const rendered = container.querySelectorAll('[data-testid="sdk-message-renderer"]');
-		expect(rendered.length).toBe(2);
-		expect(rendered[0].textContent).toBe('task said hello');
-		expect(rendered[1].textContent).toBe('coder said hi');
-		// taskContext must be forwarded so system-init/subagent handling is correct.
-		rendered.forEach((el) => expect(el.getAttribute('data-task-context')).toBe('1'));
+		const rendered = Array.from(
+			container.querySelectorAll('[data-testid="sdk-message-renderer"]')
+		).map((el) => el.textContent);
+		expect(rendered).toEqual(['Initial ask', 'msg-1', 'msg-2', 'msg-3', 'msg-4', 'msg-5', 'msg-6']);
+		expect(screen.queryByTestId('compact-flat-hidden-divider')).toBeNull();
 	});
 
-	it('does NOT wrap each block in an outer bordered card', () => {
-		// The whole point of this refactor: no outer per-block border — each
-		// SDK message renders its own chrome (ToolResultCard, ThinkingBlock, …).
+	it('groups rows by turn using terminal result/error boundaries', () => {
 		const rows = [
-			makeAssistantTextRow('r1', 'Task Agent', 'a'),
-			makeAssistantTextRow('r2', 'Coder Agent', 'b'),
-		];
-		const { container } = render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		const blocks = container.querySelectorAll('[data-testid="compact-block"]');
-		expect(blocks.length).toBe(2); // All block sections use compact-block; running-block chrome is on the last row inside the tail block.
-
-		blocks.forEach((blockEl) => {
-			const className = blockEl.getAttribute('class') ?? '';
-			expect(className).not.toContain('border');
-			expect(className).not.toContain('rounded-lg');
-		});
-	});
-
-	// ── Running-block wrapper ────────────────────────────────────────────────
-
-	it('marks the last tool-use row as running and passes isRunning to SDKMessageRenderer', () => {
-		// The running border only fires when the last visible event is a tool_use block.
-		const rows = [
-			makeAssistantTextRow('r1', 'Task Agent', 'prior text'),
-			makeToolUseRow('r2', 'Coder Agent', 'bash'),
-		];
-		const { container } = render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={true}
-			/>
-		);
-
-		// The testid wrapper must exist on the last row.
-		const runningWrapper = screen.getByTestId('compact-running-block');
-		expect(runningWrapper).toBeTruthy();
-
-		// The SDKMessageRenderer inside must receive isRunning=true.
-		const rendererEl = runningWrapper.querySelector('[data-testid="sdk-message-renderer"]');
-		expect(rendererEl?.getAttribute('data-running')).toBe('1');
-
-		// Non-running rows must NOT have isRunning=true.
-		const allRenderers = container.querySelectorAll('[data-testid="sdk-message-renderer"]');
-		const nonRunning = Array.from(allRenderers).filter(
-			(el) => el.getAttribute('data-running') !== '1'
-		);
-		expect(nonRunning.length).toBe(1); // only 'prior text' row is non-running
-	});
-
-	it('suppresses running-block when last visible row is not a tool_use block', () => {
-		// Plain text bubbles should not get the animated border even when agent is active.
-		const rows = [
-			makeAssistantTextRow('r1', 'Task Agent', 'prior'),
-			makeAssistantTextRow('r2', 'Coder Agent', 'just text, no tool use'),
-		];
-		render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={true}
-			/>
-		);
-
-		expect(screen.queryByTestId('compact-running-block')).toBeNull();
-	});
-
-	it('suppresses running-block when isAgentActive is false even with non-terminal tool-use rows', () => {
-		const rows = [
-			makeAssistantTextRow('r1', 'Task Agent', 'prior'),
-			makeToolUseRow('r2', 'Coder Agent', 'read_file'),
+			makeAssistantTextRow('a0', 'Task Agent', 'turn1-task'),
+			makeAssistantTextRow('a1', 'Coder Agent', 'turn1-coder'),
+			makeResultRow('r1', 'Task Agent', 'success'),
+			makeAssistantTextRow('a2', 'Task Agent', 'turn2-task'),
+			makeResultRow('r2', 'Task Agent', 'error_during_execution'),
+			makeAssistantTextRow('a3', 'Task Agent', 'turn3-task'),
 		];
 		render(
 			<SpaceTaskCardFeed
@@ -340,35 +214,26 @@ describe('SpaceTaskCardFeed', () => {
 			/>
 		);
 
-		// No running-block wrapper when agent is not active.
-		expect(screen.queryByTestId('compact-running-block')).toBeNull();
+		const turnGroups = screen.getAllByTestId('compact-turn-group');
+		expect(turnGroups.length).toBe(3);
+		expect(screen.getByText('Turn 1')).toBeTruthy();
+		expect(screen.getByText('Turn 2')).toBeTruthy();
+		expect(screen.getByText('Turn 3')).toBeTruthy();
+
+		const turn1Msgs = within(turnGroups[0]).getAllByTestId('sdk-message-renderer');
+		expect(turn1Msgs.map((el) => el.textContent)).toEqual(['turn1-task', 'turn1-coder', 'result']);
+		const turn2Msgs = within(turnGroups[1]).getAllByTestId('sdk-message-renderer');
+		expect(turn2Msgs.map((el) => el.textContent)).toEqual(['turn2-task', 'result']);
+		const turn3Msgs = within(turnGroups[2]).getAllByTestId('sdk-message-renderer');
+		expect(turn3Msgs.map((el) => el.textContent)).toEqual(['turn3-task']);
 	});
 
-	it('suppresses running-block when all visible blocks are terminal', () => {
-		// All-terminal means the task completed — no border animation.
+	it('renders agent headers and color siderails within turns', () => {
 		const rows = [
-			makeAssistantTextRow('r1', 'Task Agent', 'prior'),
-			makeResultRow('r2', 'Task Agent', 'success'),
-		];
-		render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={true}
-			/>
-		);
-
-		expect(screen.queryByTestId('compact-running-block')).toBeNull();
-	});
-
-	// ── Agent identity header ────────────────────────────────────────────────
-
-	it('renders a colored agent-identity header for each visible block', () => {
-		const rows = [
-			makeAssistantTextRow('r1', 'Task Agent', 'a'),
-			makeAssistantTextRow('r2', 'Coder Agent', 'b'),
-			makeAssistantTextRow('r3', 'Reviewer Agent', 'c'),
+			makeUserRow('u1', 'Task Agent', 'Prompt'),
+			makeAssistantTextRow('a1', 'Task Agent', 'task-msg-1', 'sess-task'),
+			makeAssistantTextRow('a2', 'Task Agent', 'task-msg-2', 'sess-task'),
+			makeAssistantTextRow('a3', 'Coder Agent', 'coder-msg', 'sess-coder'),
 		];
 		const { container } = render(
 			<SpaceTaskCardFeed
@@ -381,167 +246,21 @@ describe('SpaceTaskCardFeed', () => {
 
 		const headers = container.querySelectorAll('[data-testid="compact-block-header"]');
 		expect(headers.length).toBe(3);
+		expect(container.textContent).toContain('TASK');
+		expect(container.textContent).toContain('CODER');
 
-		const labels = Array.from(
-			container.querySelectorAll('[data-testid="compact-block-header"] span[style*="color"]')
-		).map((el) => el.textContent);
-		expect(labels).toContain('TASK');
-		expect(labels).toContain('CODER');
-		expect(labels).toContain('REVIEWER');
+		const siderails = container.querySelectorAll('[data-testid="compact-block-siderail"]');
+		expect(siderails.length).toBe(3);
+		siderails.forEach((el) => {
+			expect((el as HTMLElement).style.backgroundColor).not.toBe('');
+		});
 	});
 
-	it('applies distinct colors to different agent headers', () => {
+	it('clicking agent header opens the slide-out session for that block', () => {
 		const rows = [
-			makeAssistantTextRow('r1', 'Task Agent', 'a'),
-			makeAssistantTextRow('r2', 'Coder Agent', 'b'),
-		];
-		const { container } = render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		const colored = Array.from(
-			container.querySelectorAll('[data-testid="compact-block-header"] span[style*="color"]')
-		);
-		const taskSpan = colored.find((el) => el.textContent === 'TASK') as HTMLElement | undefined;
-		const coderSpan = colored.find((el) => el.textContent === 'CODER') as HTMLElement | undefined;
-		expect(taskSpan).toBeTruthy();
-		expect(coderSpan).toBeTruthy();
-		expect(taskSpan!.style.color).not.toBe('');
-		expect(taskSpan!.style.color).not.toBe(coderSpan!.style.color);
-	});
-
-	it('renders a colored dot alongside the agent label', () => {
-		const rows = [makeAssistantTextRow('r1', 'Task Agent', 'a')];
-		const { container } = render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		const dot = container.querySelector(
-			'[data-testid="compact-block-header"] span[style*="background-color"]'
-		);
-		expect(dot).toBeTruthy();
-		expect((dot as HTMLElement).style.backgroundColor).not.toBe('');
-	});
-
-	// ── Click-to-open agent slide-out ────────────────────────────────────────
-
-	it('opens the agent overlay when the agent-name header is clicked', () => {
-		const rows = [makeAssistantTextRow('r1', 'Task Agent', 'hello', 'session-abc')];
-		render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		const header = screen.getByTestId('compact-block-header');
-		expect(header.getAttribute('data-clickable')).toBe('1');
-		expect(header.getAttribute('role')).toBe('button');
-		expect(header.getAttribute('tabindex')).toBe('0');
-
-		fireEvent.click(header);
-
-		expect(mockSpaceOverlaySessionIdSignal.value).toBe('session-abc');
-		expect(mockSpaceOverlayAgentNameSignal.value).toBe('Task Agent');
-	});
-
-	it('opens the agent overlay when Enter is pressed on the focused header', () => {
-		const rows = [makeAssistantTextRow('r1', 'Coder Agent', 'hi', 'sess-coder')];
-		render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		const header = screen.getByTestId('compact-block-header');
-		fireEvent.keyDown(header, { key: 'Enter' });
-
-		expect(mockSpaceOverlaySessionIdSignal.value).toBe('sess-coder');
-		expect(mockSpaceOverlayAgentNameSignal.value).toBe('Coder Agent');
-	});
-
-	it('opens the agent overlay when Space is pressed on the focused header', () => {
-		const rows = [makeAssistantTextRow('r1', 'Reviewer Agent', 'hi', 'sess-rev')];
-		render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		const header = screen.getByTestId('compact-block-header');
-		fireEvent.keyDown(header, { key: ' ' });
-
-		expect(mockSpaceOverlaySessionIdSignal.value).toBe('sess-rev');
-		expect(mockSpaceOverlayAgentNameSignal.value).toBe('Reviewer Agent');
-	});
-
-	it('does NOT open the overlay when the block has no sessionId on any row', () => {
-		const rows = [
-			makeAssistantTextRow('r1', 'Task Agent', 'hello' /* sessionId defaults to null */),
-		];
-		render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		const header = screen.getByTestId('compact-block-header');
-		expect(header.getAttribute('data-clickable')).toBe('0');
-		expect(header.getAttribute('role')).toBeNull();
-		expect(header.getAttribute('tabindex')).toBeNull();
-
-		// Clicking a non-clickable header is a no-op.
-		fireEvent.click(header);
-		expect(mockSpaceOverlaySessionIdSignal.value).toBeNull();
-		expect(mockSpaceOverlayAgentNameSignal.value).toBeNull();
-	});
-
-	it('uses the first row with a non-null sessionId to derive the block sessionId', () => {
-		// r1 has no sessionId (fallback row scenario), r2 has 'sess-2'.
-		// Both are the same agent → one block; the overlay should open with 'sess-2'.
-		const rows = [
-			makeAssistantTextRow('r1', 'Task Agent', 'first'),
-			makeAssistantTextRow('r2', 'Task Agent', 'second', 'sess-2'),
-		];
-		render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		const header = screen.getByTestId('compact-block-header');
-		fireEvent.click(header);
-		expect(mockSpaceOverlaySessionIdSignal.value).toBe('sess-2');
-	});
-
-	it('each block opens its own agent overlay independently', () => {
-		const rows = [
-			makeAssistantTextRow('r1', 'Task Agent', 'task msg', 'sess-task'),
-			makeAssistantTextRow('r2', 'Coder Agent', 'coder msg', 'sess-coder'),
+			makeUserRow('u1', 'Task Agent', 'Prompt'),
+			makeAssistantTextRow('a1', 'Task Agent', 'task-msg', 'sess-task'),
+			makeAssistantTextRow('a2', 'Coder Agent', 'coder-msg', 'sess-coder'),
 		];
 		render(
 			<SpaceTaskCardFeed
@@ -553,27 +272,40 @@ describe('SpaceTaskCardFeed', () => {
 		);
 
 		const headers = screen.getAllByTestId('compact-block-header');
-		expect(headers.length).toBe(2);
-
-		// Click the Coder header → signals point to Coder.
-		fireEvent.click(headers[1]);
+		fireEvent.click(headers[2]); // coder block header
 		expect(mockSpaceOverlaySessionIdSignal.value).toBe('sess-coder');
 		expect(mockSpaceOverlayAgentNameSignal.value).toBe('Coder Agent');
-
-		// Click the Task header → signals swap to Task.
-		fireEvent.click(headers[0]);
-		expect(mockSpaceOverlaySessionIdSignal.value).toBe('sess-task');
-		expect(mockSpaceOverlayAgentNameSignal.value).toBe('Task Agent');
 	});
 
-	// ── Terminal badge ───────────────────────────────────────────────────────
-
-	it('renders a DONE badge on success terminal blocks', () => {
+	it('marks the last row as running only when active and the tail row is tool_use', () => {
 		const rows = [
-			makeAssistantTextRow('r1', 'Task Agent', 'prior'),
-			makeResultRow('r2', 'Task Agent', 'success'),
+			makeUserRow('u1', 'Task Agent', 'Prompt'),
+			makeAssistantTextRow('a1', 'Task Agent', 'plain'),
+			makeToolUseRow('a2', 'Task Agent', 'Read', 'sess-task'),
 		];
-		render(
+		const { container } = render(
+			<SpaceTaskCardFeed
+				parsedRows={rows}
+				taskId="task-1"
+				maps={fakeMaps as any}
+				isAgentActive={true}
+			/>
+		);
+
+		const wrapper = screen.getByTestId('compact-running-block');
+		expect(wrapper).toBeTruthy();
+		const runningRendered = wrapper.querySelector('[data-testid="sdk-message-renderer"]');
+		expect(runningRendered?.getAttribute('data-running')).toBe('1');
+
+		const allRendered = container.querySelectorAll('[data-testid="sdk-message-renderer"]');
+		expect(
+			Array.from(allRendered).filter((el) => el.getAttribute('data-running') === '1').length
+		).toBe(1);
+	});
+
+	it('keeps default subagent rendering flags (no forced flatten)', () => {
+		const rows = [makeAssistantTextRow('a1', 'Task Agent', 'hello')];
+		const { container } = render(
 			<SpaceTaskCardFeed
 				parsedRows={rows}
 				taskId="task-1"
@@ -582,39 +314,17 @@ describe('SpaceTaskCardFeed', () => {
 			/>
 		);
 
-		const badges = screen.getAllByTestId('compact-block-badge');
-		expect(badges.length).toBe(1);
-		expect(badges[0].textContent).toBe('DONE');
+		const rendered = container.querySelector('[data-testid="sdk-message-renderer"]') as HTMLElement;
+		expect(rendered.getAttribute('data-task-context')).toBe('1');
+		expect(rendered.getAttribute('data-show-subagents')).toBe('1');
+		expect(rendered.getAttribute('data-flatten-subagent-tools')).toBe('0');
 	});
 
-	it('renders an ERROR badge on error terminal blocks', () => {
+	it('renders subagent result/error rows (no filtering)', () => {
 		const rows = [
-			makeAssistantTextRow('r1', 'Task Agent', 'prior'),
-			makeResultRow('r2', 'Task Agent', 'error'),
-		];
-		render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		const badges = screen.getAllByTestId('compact-block-badge');
-		expect(badges.length).toBe(1);
-		expect(badges[0].textContent).toBe('ERROR');
-	});
-
-	// ── Visibility: 3-block limit + terminal preservation ────────────────────
-
-	it('shows at most the last 3 logical blocks', () => {
-		// 4 distinct agents → only last 3 should survive.
-		const rows = [
-			makeAssistantTextRow('r1', 'Task Agent', 'first'),
-			makeAssistantTextRow('r2', 'Coder Agent', 'second'),
-			makeAssistantTextRow('r3', 'Reviewer Agent', 'third'),
-			makeAssistantTextRow('r4', 'Space Agent', 'fourth'),
+			makeToolUseRow('a1', 'Task Agent', 'Task', 'sess-task'),
+			makeAssistantTextRow('a2', 'Coder Agent', 'child step', 'sess-coder', 'tu-a1'),
+			makeResultRow('r1', 'Coder Agent', 'error_during_execution', 'sess-coder', 'tu-a1'),
 		];
 		const { container } = render(
 			<SpaceTaskCardFeed
@@ -625,394 +335,9 @@ describe('SpaceTaskCardFeed', () => {
 			/>
 		);
 
-		const rendered = container.querySelectorAll('[data-testid="sdk-message-renderer"]');
-		const textSet = new Set(Array.from(rendered).map((el) => el.textContent));
-		expect(textSet.has('first')).toBe(false); // First block is outside the last-3 window.
-		expect(textSet.has('second')).toBe(true);
-		expect(textSet.has('third')).toBe(true);
-		expect(textSet.has('fourth')).toBe(true);
-	});
-
-	it('preserves the trailing terminal tail; scattered non-trailing terminals drop out of the window', () => {
-		// Trailing tail: b4, b5 are terminal at the end → always kept.
-		// Body window (last 3 of [b1, b2, b3]) renders first, tail appended.
-		const rows = [
-			makeAssistantTextRow('r1', 'Task Agent', 'first'),
-			makeAssistantTextRow('r2', 'Coder Agent', 'second'),
-			makeAssistantTextRow('r3', 'Reviewer Agent', 'third'),
-			makeResultRow('r4', 'Space Agent', 'error'),
-			makeResultRow('r5', 'Completer Agent', 'success'),
-		];
-		const { container } = render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		const badges = screen.getAllByTestId('compact-block-badge');
-		expect(badges.length).toBe(2); // b4 ERROR + b5 DONE
-		expect(badges.map((b) => b.textContent).sort()).toEqual(['DONE', 'ERROR']);
-
-		// 5 compact-block wrappers: [r1, r2, r3] body window + [r4, r5] terminal tail.
-		const compactBlocks = container.querySelectorAll('[data-testid="compact-block"]').length;
-		expect(compactBlocks).toBe(5);
-	});
-
-	it('drops scattered non-trailing terminal blocks that fall outside the last-3 window', () => {
-		// r1 is a terminal error but it's NOT part of the trailing tail because
-		// r2, r3, r4 are non-terminal rows that follow. Only the last-3 body
-		// window [r2, r3, r4] is shown; r1 is dropped.
-		const rows = [
-			makeResultRow('r1', 'Task Agent', 'error'),
-			makeAssistantTextRow('r2', 'Coder Agent', 'second'),
-			makeAssistantTextRow('r3', 'Reviewer Agent', 'third'),
-			makeAssistantTextRow('r4', 'Space Agent', 'fourth'),
-		];
-		const { container } = render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		expect(screen.queryAllByTestId('compact-block-badge').length).toBe(0);
-		const compactBlocks = container.querySelectorAll('[data-testid="compact-block"]').length;
-		expect(compactBlocks).toBe(3);
-	});
-
-	// ── Hidden-count indicator ───────────────────────────────────────────────
-
-	it('shows per-block hidden-count when a block has more than 3 rows', () => {
-		// One block with 5 rows → 2 hidden, last 3 shown.
-		const rows = [
-			makeAssistantTextRow('r1', 'Task Agent', 'a'),
-			makeAssistantTextRow('r2', 'Task Agent', 'b'),
-			makeAssistantTextRow('r3', 'Task Agent', 'c'),
-			makeAssistantTextRow('r4', 'Task Agent', 'd'),
-			makeAssistantTextRow('r5', 'Task Agent', 'e'),
-		];
-		render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		const label = screen.getByTestId('compact-block-hidden-count');
-		expect(label.textContent).toContain('2');
-		expect(label.textContent?.toLowerCase()).toContain('messages');
-	});
-
-	it('uses singular "message" when exactly 1 row is hidden in a block', () => {
-		// One block with 4 rows → 1 hidden.
-		const rows = [
-			makeAssistantTextRow('r1', 'Task Agent', 'a'),
-			makeAssistantTextRow('r2', 'Task Agent', 'b'),
-			makeAssistantTextRow('r3', 'Task Agent', 'c'),
-			makeAssistantTextRow('r4', 'Task Agent', 'd'),
-		];
-		render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		const label = screen.getByTestId('compact-block-hidden-count');
-		expect(label.textContent).toContain('1');
-		// Should be "message" not "messages".
-		expect(label.textContent).not.toContain('messages');
-		expect(label.textContent?.toLowerCase()).toContain('message');
-	});
-
-	it('does NOT render a hidden-count label when a block has 3 or fewer rows', () => {
-		const rows = [
-			makeAssistantTextRow('r1', 'Task Agent', 'a'),
-			makeAssistantTextRow('r2', 'Task Agent', 'b'),
-			makeAssistantTextRow('r3', 'Task Agent', 'c'),
-		];
-		render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		expect(screen.queryByTestId('compact-block-hidden-count')).toBeNull();
-	});
-
-	it('does NOT render the hidden-count label when parsedRows is empty', () => {
-		render(
-			<SpaceTaskCardFeed
-				parsedRows={[]}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		expect(screen.queryByTestId('compact-block-hidden-count')).toBeNull();
-	});
-
-	it('only shows the last 3 rows of a block when more exist', () => {
-		const rows = [
-			makeAssistantTextRow('r1', 'Task Agent', 'hidden-a'),
-			makeAssistantTextRow('r2', 'Task Agent', 'hidden-b'),
-			makeAssistantTextRow('r3', 'Task Agent', 'shown-c'),
-			makeAssistantTextRow('r4', 'Task Agent', 'shown-d'),
-			makeAssistantTextRow('r5', 'Task Agent', 'shown-e'),
-		];
-		const { container } = render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		const renderers = container.querySelectorAll('[data-testid="sdk-message-renderer"]');
-		// Only last 3 rows rendered.
-		expect(renderers.length).toBe(3);
-		expect(renderers[0].textContent).toBe('shown-c');
-		expect(renderers[1].textContent).toBe('shown-d');
-		expect(renderers[2].textContent).toBe('shown-e');
-	});
-
-	// ── System-init rendering ────────────────────────────────────────────────
-
-	it('renders a system-init row as a SpaceSystemInitCard alongside other rows', () => {
-		const rows = [
-			makeSystemInitRow('s1', 'Task Agent'),
-			makeAssistantTextRow('r1', 'Task Agent', 'visible content'),
-		];
-		const { container } = render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		// The init row must NOT be filtered — it must produce a compact init card.
-		const initCards = container.querySelectorAll('[data-testid="compact-system-init-card"]');
-		expect(initCards.length).toBe(1);
-		expect(initCards[0].textContent).toContain('Session Started');
-
-		// The normal assistant row still renders via SDKMessageRenderer.
-		const rendered = container.querySelectorAll('[data-testid="sdk-message-renderer"]');
-		expect(rendered.length).toBe(1);
-		expect(rendered[0].textContent).toBe('visible content');
-	});
-
-	it('shows collapsed header with model + tool count on the system-init card', () => {
-		const rows = [
-			makeSystemInitRow('s1', 'Task Agent', {
-				tools: ['Bash', 'Read', 'Edit', 'Write'],
-				mcp_servers: [{ name: 'chrome-devtools', status: 'connected' }],
-			}),
-		];
-		render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		const toggle = screen.getByTestId('compact-system-init-toggle');
-		// Model is shown without the `claude-` prefix, and permission mode is appended.
-		expect(toggle.textContent).toContain('opus-4-5');
-		expect(toggle.textContent).toContain('default');
-		// Counts visible in the collapsed state.
-		expect(toggle.textContent).toContain('4 tools');
-		expect(toggle.textContent).toContain('1 MCP');
-	});
-
-	it('expands the system-init card when clicked and reveals cwd + mcp details', () => {
-		const rows = [
-			makeSystemInitRow('s1', 'Task Agent', {
-				cwd: '/Users/dev/focus/neokai',
-				mcp_servers: [
-					{ name: 'chrome-devtools', status: 'connected' },
-					{ name: 'stale-server', status: 'disconnected' },
-				],
-			}),
-		];
-		render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		// Details are hidden until the user clicks the toggle.
-		expect(screen.queryByTestId('compact-system-init-details')).toBeNull();
-
-		fireEvent.click(screen.getByTestId('compact-system-init-toggle'));
-
-		const details = screen.getByTestId('compact-system-init-details');
-		expect(details.textContent).toContain('/Users/dev/focus/neokai');
-		expect(details.textContent).toContain('chrome-devtools');
-		expect(details.textContent).toContain('stale-server');
-
-		// A second click collapses again.
-		fireEvent.click(screen.getByTestId('compact-system-init-toggle'));
-		expect(screen.queryByTestId('compact-system-init-details')).toBeNull();
-	});
-
-	it('does NOT dispatch system-init rows through SDKMessageRenderer (avoids the pill fallback)', () => {
-		const rows = [makeSystemInitRow('s1', 'Task Agent')];
-		const { container } = render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		// Only the init card renders — no SDK renderer for this row.
-		expect(container.querySelectorAll('[data-testid="compact-system-init-card"]').length).toBe(1);
-		expect(container.querySelectorAll('[data-testid="sdk-message-renderer"]').length).toBe(0);
-	});
-
-	// ── Pre-filter (noise removal) ───────────────────────────────────────────
-
-	it('filters out non-rejected rate-limit rows', () => {
-		const rows = [
-			makeRateLimitRow('rl1', 'Task Agent', 'allowed'),
-			makeRateLimitRow('rl2', 'Task Agent', 'allowed_warning'),
-			makeAssistantTextRow('r1', 'Task Agent', 'visible content'),
-			makeRateLimitRow('rl3', 'Task Agent', 'rejected'),
-		];
-		const { container } = render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		// allowed & allowed_warning filtered; visible-content + rejected remain.
-		const rendered = container.querySelectorAll('[data-testid="sdk-message-renderer"]');
-		expect(rendered.length).toBe(2);
-	});
-
-	it('filters out empty user rows', () => {
-		const rows = [
-			makeEmptyUserRow('u1', 'Task Agent'),
-			makeAssistantTextRow('r1', 'Task Agent', 'visible content'),
-		];
-		const { container } = render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		const rendered = container.querySelectorAll('[data-testid="sdk-message-renderer"]');
-		expect(rendered.length).toBe(1);
-		expect(rendered[0].textContent).toBe('visible content');
-	});
-
-	it('routes synthetic user messages to the purple SyntheticMessageBlock and human messages to the blue user bubble', () => {
-		// Both kinds of user rows are kept in the compact feed, but they are
-		// visually distinct: synthetic (agent→agent handoff) → purple synthetic
-		// block; human-typed → blue user bubble. The `isSynthetic` flag is NOT
-		// stripped — it must reach SDKMessageRenderer so the routing happens.
-		const syntheticRow: ParsedThreadRow = {
-			id: 'u-syn',
-			sessionId: null,
-			label: 'Coder Agent',
-			taskId: 'task-1',
-			taskTitle: 'Task One',
-			createdAt: Date.now(),
-			message: {
-				type: 'user',
-				uuid: 'u-syn',
-				isSynthetic: true,
-				message: { content: [{ type: 'text', text: 'Go implement feature X' }] },
-			} as any,
-			fallbackText: null,
-		};
-		const realUserRow: ParsedThreadRow = {
-			id: 'u-real',
-			sessionId: null,
-			label: 'Coder Agent',
-			taskId: 'task-1',
-			taskTitle: 'Task One',
-			createdAt: Date.now(),
-			message: {
-				type: 'user',
-				uuid: 'u-real',
-				// isSynthetic absent — real human message
-				message: { content: [{ type: 'text', text: 'Please build feature X' }] },
-			} as any,
-			fallbackText: null,
-		};
-		const rows = [
-			syntheticRow,
-			realUserRow,
-			makeAssistantTextRow('r1', 'Coder Agent', 'working on it'),
-		];
-		const { container } = render(
-			<SpaceTaskCardFeed
-				parsedRows={rows}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		// Synthetic message renders through the synthetic-block path.
-		const syntheticEls = container.querySelectorAll('[data-testid="sdk-synthetic-message"]');
-		expect(syntheticEls.length).toBe(1);
-		expect(syntheticEls[0].textContent).toBe('Go implement feature X');
-		expect(syntheticEls[0].getAttribute('data-synthetic')).toBe('1');
-
-		// Human user message + assistant reply render through the regular path.
-		const regularEls = container.querySelectorAll('[data-testid="sdk-message-renderer"]');
-		expect(regularEls.length).toBe(2);
-		const regularTexts = Array.from(regularEls).map((el) => el.textContent);
-		expect(regularTexts).toContain('Please build feature X');
-		expect(regularTexts).toContain('working on it');
-		// Neither regular element is marked synthetic.
-		regularEls.forEach((el) => expect(el.getAttribute('data-synthetic')).toBe('0'));
-	});
-
-	// ── Empty input ──────────────────────────────────────────────────────────
-
-	it('renders the root container and no blocks when given no rows', () => {
-		const { container } = render(
-			<SpaceTaskCardFeed
-				parsedRows={[]}
-				taskId="task-1"
-				maps={fakeMaps as any}
-				isAgentActive={false}
-			/>
-		);
-
-		expect(screen.getByTestId('space-task-event-feed-compact')).toBeTruthy();
-		expect(container.querySelectorAll('[data-testid="compact-block"]').length).toBe(0);
-		expect(container.querySelectorAll('[data-testid="compact-running-block"]').length).toBe(0);
+		const rendered = Array.from(
+			container.querySelectorAll('[data-testid="sdk-message-renderer"]')
+		).map((el) => el.textContent);
+		expect(rendered).toEqual(['assistant', 'child step', 'result']);
 	});
 });

--- a/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.tsx
+++ b/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.tsx
@@ -225,7 +225,7 @@ function renderAgentHeaderPill(
 	onKeyDown: (e: KeyboardEvent) => void
 ) {
 	const label = shortAgentLabel(block.label);
-	// Pill fills the arm's width minus `m-2` on the left and `m-1` on the right.
+	// Pill fills the arm's width minus `m-2` on the left; right edge is flush.
 	const pillBase =
 		'flex items-center justify-center w-full px-2.5 py-1 rounded-full border text-[11px] uppercase tracking-[0.12em] font-mono font-semibold whitespace-nowrap transition-colors';
 	const pillInteractive =
@@ -256,7 +256,7 @@ function renderAgentHeaderPill(
 
 	return (
 		<div
-			class="mt-1 pl-2 pr-1"
+			class="mt-1 pl-2 pr-0"
 			style={{ width: 'clamp(96px, 30%, 180px)' }}
 			data-testid="compact-block-header-slot"
 		>

--- a/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.tsx
+++ b/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.tsx
@@ -29,12 +29,6 @@ interface AgentBlock {
 	rows: ParsedThreadRow[];
 }
 
-interface TurnGroup {
-	id: string;
-	index: number;
-	block: AgentBlock;
-}
-
 function normalizeAgentKey(label: string): string {
 	return label.trim().toLowerCase().replace(/\s+/g, ' ');
 }
@@ -98,15 +92,6 @@ function buildAgentTurnBlocks(rows: ParsedThreadRow[]): AgentBlock[] {
 				...block
 			}) => block
 		);
-}
-
-function buildTurns(rows: ParsedThreadRow[]): TurnGroup[] {
-	const blocks = buildAgentTurnBlocks(rows);
-	return blocks.map((block, index) => ({
-		id: `turn-${index + 1}-${block.id}`,
-		index: index + 1,
-		block,
-	}));
 }
 
 function getBlockHiddenCount(rows: ParsedThreadRow[]): number {
@@ -185,9 +170,9 @@ function renderAgentBlock(
 		>
 			<div
 				class={
-					'flex items-center gap-2 px-2 py-2 min-h-[32px] rounded ' +
+					'flex items-center justify-between gap-2 px-3 py-2.5 min-h-[38px] rounded-md border border-dark-700/80 border-l-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] ' +
 					(isClickable
-						? 'cursor-pointer hover:bg-gray-800/40 active:bg-gray-800/60 transition-colors focus:outline-none focus:bg-gray-800/40 focus:ring-1 focus:ring-gray-700'
+						? 'cursor-pointer hover:bg-gray-800/70 active:bg-gray-800/80 transition-colors focus:outline-none focus:bg-gray-800/70 focus:ring-1 focus:ring-gray-700'
 						: '')
 				}
 				data-testid="compact-block-header"
@@ -197,17 +182,26 @@ function renderAgentBlock(
 				aria-label={isClickable ? `Open ${block.label} session details` : undefined}
 				onClick={isClickable ? handleOpenAgentOverlay : undefined}
 				onKeyDown={isClickable ? handleHeaderKeyDown : undefined}
+				style={{
+					borderLeftColor: block.color,
+					background: `linear-gradient(90deg, ${block.color}22 0%, rgba(18, 22, 30, 0.82) 40%)`,
+				}}
 			>
-				<span
-					class="w-2 h-2 rounded-full flex-shrink-0"
-					style={{ backgroundColor: block.color }}
-					aria-hidden="true"
-				/>
-				<span
-					class="text-[11px] uppercase tracking-[0.16em] font-mono font-medium flex-shrink-0"
-					style={{ color: block.color }}
-				>
-					{shortAgentLabel(block.label)}
+				<div class="flex items-center gap-2 flex-1 min-w-0">
+					<span
+						class="w-2.5 h-2.5 rounded-full flex-shrink-0"
+						style={{ backgroundColor: block.color }}
+						aria-hidden="true"
+					/>
+					<span
+						class="text-[12px] uppercase tracking-[0.18em] font-mono font-semibold whitespace-nowrap"
+						style={{ color: block.color }}
+					>
+						{shortAgentLabel(block.label)}
+					</span>
+				</div>
+				<span class="text-[10px] uppercase tracking-[0.14em] font-mono text-gray-400 border border-dark-600/80 bg-dark-900/80 rounded px-1.5 py-0.5 flex-shrink-0">
+					Agent Turn
 				</span>
 			</div>
 
@@ -275,7 +269,7 @@ export function SpaceTaskCardFeed({
 	maps,
 	isAgentActive,
 }: SpaceTaskCardFeedProps) {
-	const turns = useMemo(() => buildTurns(parsedRows), [parsedRows]);
+	const blocks = useMemo(() => buildAgentTurnBlocks(parsedRows), [parsedRows]);
 
 	const runningRowId = useMemo(() => {
 		if (!isAgentActive) return null;
@@ -286,21 +280,16 @@ export function SpaceTaskCardFeed({
 
 	return (
 		<div class="space-y-2 px-4 py-2" data-testid="space-task-event-feed-compact">
-			{turns.map((turn) => {
-				const block = turn.block;
+			{blocks.map((block, index) => {
 				const blockHiddenCount = getBlockHiddenCount(block.rows);
 				const blockPinnedInitialUserRowId =
 					blockHiddenCount > 0 ? getBlockPinnedInitialUserRowId(block.rows) : null;
 				return (
-					<div key={turn.id} class="space-y-1.5" data-testid="compact-turn-group">
-						<div class="relative py-1" data-testid="compact-turn-divider">
-							<div class="border-t border-dark-700" aria-hidden="true" />
-							<div class="absolute inset-0 flex items-center justify-center pointer-events-none">
-								<span class="px-2 text-[11px] uppercase tracking-[0.12em] text-gray-500 bg-dark-900">
-									{`Turn ${turn.index}`}
-								</span>
-							</div>
-						</div>
+					<div
+						key={block.id}
+						class={`space-y-1.5 ${index > 0 ? 'pt-2 border-t border-dark-700/70' : ''}`}
+						data-testid="compact-turn-group"
+					>
 						{renderAgentBlock(
 							block,
 							maps,

--- a/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.tsx
+++ b/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.tsx
@@ -225,7 +225,7 @@ function renderAgentHeaderPill(
 	onKeyDown: (e: KeyboardEvent) => void
 ) {
 	const label = shortAgentLabel(block.label);
-	// Pill fills the arm's width minus `m-2` breathing room on each side.
+	// Pill fills the arm's width minus `m-2` on the left and `m-1` on the right.
 	const pillBase =
 		'flex items-center justify-center w-full px-2.5 py-1 rounded-full border text-[11px] uppercase tracking-[0.12em] font-mono font-semibold whitespace-nowrap transition-colors';
 	const pillInteractive =
@@ -256,7 +256,7 @@ function renderAgentHeaderPill(
 
 	return (
 		<div
-			class="mt-1 px-2"
+			class="mt-1 pl-2 pr-1"
 			style={{ width: 'clamp(96px, 30%, 180px)' }}
 			data-testid="compact-block-header-slot"
 		>

--- a/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.tsx
+++ b/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'preact/hooks';
-import { isSDKResultMessage, isSDKSystemInit } from '@neokai/shared/sdk/type-guards';
+import { isSDKSystemInit, isSDKUserMessage } from '@neokai/shared/sdk/type-guards';
 import type { ParsedThreadRow } from '../space-task-thread-events';
 import type { UseMessageMapsResult } from '../../../../hooks/useMessageMaps';
 import { spaceOverlayAgentNameSignal, spaceOverlaySessionIdSignal } from '../../../../lib/signals';
@@ -32,7 +32,7 @@ interface AgentBlock {
 interface TurnGroup {
 	id: string;
 	index: number;
-	rows: ParsedThreadRow[];
+	block: AgentBlock;
 }
 
 function normalizeAgentKey(label: string): string {
@@ -43,72 +43,84 @@ function shortAgentLabel(label: string): string {
 	return label.replace(/\s+agent$/i, '').toUpperCase();
 }
 
-function isTurnTerminalRow(row: ParsedThreadRow): boolean {
-	if (!row.message) return false;
-	return isSDKResultMessage(row.message);
-}
-
-function buildTurns(rows: ParsedThreadRow[]): TurnGroup[] {
+function buildAgentTurnBlocks(rows: ParsedThreadRow[]): AgentBlock[] {
 	if (rows.length === 0) return [];
 
-	const turns: TurnGroup[] = [];
-	let currentRows: ParsedThreadRow[] = [];
-	let currentStartId: string | number = rows[0].id;
-	let turnIndex = 1;
+	const grouped = new Map<
+		string,
+		AgentBlock & {
+			startCreatedAt: number;
+			startRowId: string;
+			sequence: number;
+		}
+	>();
+	let sequence = 0;
 
 	for (const row of rows) {
-		if (currentRows.length === 0) {
-			currentStartId = row.id;
-		}
-
-		currentRows.push(row);
-
-		if (isTurnTerminalRow(row)) {
-			turns.push({
-				id: `turn-${turnIndex}-${String(currentStartId)}`,
-				index: turnIndex,
-				rows: currentRows,
-			});
-			turnIndex += 1;
-			currentRows = [];
-		}
-	}
-
-	if (currentRows.length > 0) {
-		turns.push({
-			id: `turn-${turnIndex}-${String(currentStartId)}`,
-			index: turnIndex,
-			rows: currentRows,
-		});
-	}
-
-	return turns;
-}
-
-function buildAgentBlocks(rows: ParsedThreadRow[]): AgentBlock[] {
-	if (rows.length === 0) return [];
-
-	const blocks: AgentBlock[] = [];
-	for (const row of rows) {
-		const last = blocks[blocks.length - 1];
-		const rowKey = `${normalizeAgentKey(row.label)}::${row.sessionId ?? ''}`;
-		const lastKey =
-			last === undefined ? null : `${normalizeAgentKey(last.label)}::${last.sessionId ?? ''}`;
-		if (last && lastKey === rowKey) {
-			last.rows.push(row);
+		const sessionKey = row.sessionId ?? `label:${normalizeAgentKey(row.label)}`;
+		const turnKey =
+			typeof row.turnIndex === 'number' && Number.isFinite(row.turnIndex) ? row.turnIndex : 1;
+		const key = `${sessionKey}::turn:${turnKey}`;
+		const existing = grouped.get(key);
+		if (existing) {
+			existing.rows.push(row);
+			if (row.createdAt < existing.startCreatedAt) {
+				existing.startCreatedAt = row.createdAt;
+				existing.startRowId = String(row.id);
+			}
 			continue;
 		}
 
-		blocks.push({
+		grouped.set(key, {
 			id: String(row.id),
 			label: row.label,
 			color: getAgentColor(row.label),
 			sessionId: row.sessionId ?? null,
 			rows: [row],
+			startCreatedAt: row.createdAt,
+			startRowId: String(row.id),
+			sequence: sequence++,
 		});
 	}
 
-	return blocks;
+	return Array.from(grouped.values())
+		.sort((a, b) => {
+			if (a.startCreatedAt !== b.startCreatedAt) {
+				return a.startCreatedAt - b.startCreatedAt;
+			}
+			return a.sequence - b.sequence;
+		})
+		.map(
+			({
+				startCreatedAt: _startCreatedAt,
+				startRowId: _startRowId,
+				sequence: _sequence,
+				...block
+			}) => block
+		);
+}
+
+function buildTurns(rows: ParsedThreadRow[]): TurnGroup[] {
+	const blocks = buildAgentTurnBlocks(rows);
+	return blocks.map((block, index) => ({
+		id: `turn-${index + 1}-${block.id}`,
+		index: index + 1,
+		block,
+	}));
+}
+
+function getBlockHiddenCount(rows: ParsedThreadRow[]): number {
+	let hiddenCount = 0;
+	for (const row of rows) {
+		const hidden = row.turnHiddenMessageCount ?? 0;
+		if (hidden > hiddenCount) hiddenCount = hidden;
+	}
+	return hiddenCount;
+}
+
+function getBlockPinnedInitialUserRowId(rows: ParsedThreadRow[]): string | null {
+	const initialUser = rows.find((row) => row.message !== null && isSDKUserMessage(row.message));
+	return initialUser ? String(initialUser.id) : null;
 }
 
 function renderRow(row: ParsedThreadRow, maps: UseMessageMapsResult, isRunning = false) {
@@ -144,7 +156,9 @@ function renderRow(row: ParsedThreadRow, maps: UseMessageMapsResult, isRunning =
 function renderAgentBlock(
 	block: AgentBlock,
 	maps: UseMessageMapsResult,
-	runningRowId: string | null
+	runningRowId: string | null,
+	pinnedInitialUserRowId: string | null,
+	hiddenCount: number
 ) {
 	const isClickable = !!block.sessionId;
 
@@ -205,17 +219,39 @@ function renderAgentBlock(
 					data-testid="compact-block-siderail"
 				/>
 				<div class="flex-1 min-w-0 space-y-1">
-					{block.rows.map((row) => {
+					{block.rows.flatMap((row) => {
 						const key = String(row.id);
 						const rowNode = renderRow(row, maps, key === runningRowId);
-						if (key === runningRowId) {
-							return (
-								<div key={key} data-testid="compact-running-block">
+						const rowEl =
+							key === runningRowId ? (
+								<div key={`row-${key}`} data-testid="compact-running-block">
 									{rowNode}
 								</div>
+							) : (
+								<div key={`row-${key}`}>{rowNode}</div>
 							);
+						if (
+							hiddenCount > 0 &&
+							pinnedInitialUserRowId !== null &&
+							key === pinnedInitialUserRowId
+						) {
+							return [
+								rowEl,
+								<div
+									key={`hidden-divider-${key}`}
+									class="relative py-1.5"
+									data-testid="compact-turn-hidden-divider"
+								>
+									<div class="border-t border-dark-700" aria-hidden="true" />
+									<div class="absolute inset-0 flex items-center justify-center pointer-events-none">
+										<span class="px-2 text-[11px] uppercase tracking-[0.12em] text-gray-500 bg-dark-900">
+											{`${hiddenCount} earlier ${hiddenCount === 1 ? 'message' : 'messages'}`}
+										</span>
+									</div>
+								</div>,
+							];
 						}
-						return <div key={key}>{rowNode}</div>;
+						return [rowEl];
 					})}
 				</div>
 			</div>
@@ -224,14 +260,14 @@ function renderAgentBlock(
 }
 
 /**
- * SpaceTaskCardFeed — compact renderer grouped by turn and then agent block.
+ * SpaceTaskCardFeed — compact renderer grouped by agent turn blocks.
  *
  * Rendering policy:
- * - Render whole history (no tail truncation).
- * - Group rows into "turns" using terminal result/error messages as boundaries.
- *   Turn N includes rows up to and including the terminal result/error row.
- * - Within each turn, group consecutive rows by agent/session into clickable
- *   agent blocks with color headers/siderails.
+ * - Render the compact server-provided row set.
+ * - Group rows by (agent session, turnIndex) so interleaved messages from the
+ *   same agent turn are rendered in one block.
+ * - Order blocks by turn start time (earliest row in each block).
+ * - Render each block as a clickable agent card with color header/siderail.
  */
 export function SpaceTaskCardFeed({
 	parsedRows,
@@ -240,19 +276,21 @@ export function SpaceTaskCardFeed({
 	isAgentActive,
 }: SpaceTaskCardFeedProps) {
 	const turns = useMemo(() => buildTurns(parsedRows), [parsedRows]);
-	const allRows = useMemo(() => turns.flatMap((turn) => turn.rows), [turns]);
 
 	const runningRowId = useMemo(() => {
 		if (!isAgentActive) return null;
-		const tailLast = allRows[allRows.length - 1];
+		const tailLast = parsedRows[parsedRows.length - 1];
 		if (!tailLast || !rowHasToolUse(tailLast)) return null;
 		return String(tailLast.id);
-	}, [isAgentActive, allRows]);
+	}, [isAgentActive, parsedRows]);
 
 	return (
 		<div class="space-y-2 px-4 py-2" data-testid="space-task-event-feed-compact">
 			{turns.map((turn) => {
-				const blocks = buildAgentBlocks(turn.rows);
+				const block = turn.block;
+				const blockHiddenCount = getBlockHiddenCount(block.rows);
+				const blockPinnedInitialUserRowId =
+					blockHiddenCount > 0 ? getBlockPinnedInitialUserRowId(block.rows) : null;
 				return (
 					<div key={turn.id} class="space-y-1.5" data-testid="compact-turn-group">
 						<div class="relative py-1" data-testid="compact-turn-divider">
@@ -263,7 +301,13 @@ export function SpaceTaskCardFeed({
 								</span>
 							</div>
 						</div>
-						{blocks.map((block) => renderAgentBlock(block, maps, runningRowId))}
+						{renderAgentBlock(
+							block,
+							maps,
+							runningRowId,
+							blockPinnedInitialUserRowId,
+							blockHiddenCount
+						)}
 					</div>
 				);
 			})}

--- a/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.tsx
+++ b/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.tsx
@@ -170,9 +170,9 @@ function renderAgentBlock(
 		>
 			<div
 				class={
-					'flex items-center justify-between gap-2 px-3 py-2.5 min-h-[38px] rounded-md border border-dark-700/80 border-l-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] ' +
+					'group flex items-center gap-2 px-2 py-1.5 min-h-[30px] rounded ' +
 					(isClickable
-						? 'cursor-pointer hover:bg-gray-800/70 active:bg-gray-800/80 transition-colors focus:outline-none focus:bg-gray-800/70 focus:ring-1 focus:ring-gray-700'
+						? 'cursor-pointer hover:bg-dark-800/70 active:bg-dark-800 transition-colors focus:outline-none focus:bg-dark-800/70 focus:ring-1 focus:ring-dark-600'
 						: '')
 				}
 				data-testid="compact-block-header"
@@ -182,27 +182,32 @@ function renderAgentBlock(
 				aria-label={isClickable ? `Open ${block.label} session details` : undefined}
 				onClick={isClickable ? handleOpenAgentOverlay : undefined}
 				onKeyDown={isClickable ? handleHeaderKeyDown : undefined}
-				style={{
-					borderLeftColor: block.color,
-					background: `linear-gradient(90deg, ${block.color}22 0%, rgba(18, 22, 30, 0.82) 40%)`,
-				}}
 			>
-				<div class="flex items-center gap-2 flex-1 min-w-0">
-					<span
-						class="w-2.5 h-2.5 rounded-full flex-shrink-0"
-						style={{ backgroundColor: block.color }}
-						aria-hidden="true"
-					/>
-					<span
-						class="text-[12px] uppercase tracking-[0.18em] font-mono font-semibold whitespace-nowrap"
-						style={{ color: block.color }}
-					>
-						{shortAgentLabel(block.label)}
-					</span>
-				</div>
-				<span class="text-[10px] uppercase tracking-[0.14em] font-mono text-gray-400 border border-dark-600/80 bg-dark-900/80 rounded px-1.5 py-0.5 flex-shrink-0">
-					Agent Turn
+				<span
+					class="w-2 h-2 rounded-full flex-shrink-0"
+					style={{ backgroundColor: block.color }}
+					aria-hidden="true"
+				/>
+				<span
+					class="text-[11px] uppercase tracking-[0.16em] font-mono font-medium flex-shrink-0"
+					style={{ color: block.color }}
+				>
+					{shortAgentLabel(block.label)}
 				</span>
+				{isClickable ? (
+					<svg
+						class="ml-auto w-3 h-3 text-gray-600 opacity-0 group-hover:opacity-100 group-focus:opacity-100 transition-opacity flex-shrink-0"
+						viewBox="0 0 16 16"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="1.5"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						aria-hidden="true"
+					>
+						<path d="M6 4l4 4-4 4" />
+					</svg>
+				) : null}
 			</div>
 
 			<div class="flex gap-2 pl-1 pb-1" data-testid="compact-block-body">
@@ -231,24 +236,86 @@ function renderAgentBlock(
 						) {
 							return [
 								rowEl,
-								<div
-									key={`hidden-divider-${key}`}
-									class="relative py-1.5"
-									data-testid="compact-turn-hidden-divider"
-								>
-									<div class="border-t border-dark-700" aria-hidden="true" />
-									<div class="absolute inset-0 flex items-center justify-center pointer-events-none">
-										<span class="px-2 text-[11px] uppercase tracking-[0.12em] text-gray-500 bg-dark-900">
-											{`${hiddenCount} earlier ${hiddenCount === 1 ? 'message' : 'messages'}`}
-										</span>
-									</div>
-								</div>,
+								renderHiddenDivider(
+									key,
+									hiddenCount,
+									block.label,
+									isClickable,
+									handleOpenAgentOverlay
+								),
 							];
 						}
 						return [rowEl];
 					})}
 				</div>
 			</div>
+		</div>
+	);
+}
+
+function renderHiddenDivider(
+	rowKey: string,
+	hiddenCount: number,
+	agentLabel: string,
+	isClickable: boolean,
+	onOpen: () => void
+) {
+	const label = `${hiddenCount} earlier ${hiddenCount === 1 ? 'message' : 'messages'}`;
+	const pillBase =
+		'relative z-10 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-[11px] uppercase tracking-[0.12em] font-mono whitespace-nowrap transition-colors ';
+	const pillInteractive =
+		'cursor-pointer border-dark-600 bg-dark-850 text-gray-300 hover:border-gray-500 hover:bg-dark-800 hover:text-gray-100 focus:outline-none focus:ring-1 focus:ring-gray-500';
+	const pillStatic = 'border-dark-700 bg-dark-850 text-gray-400';
+	return (
+		<div
+			key={`hidden-divider-${rowKey}`}
+			class="relative flex items-center justify-center py-2"
+			data-testid="compact-turn-hidden-divider"
+		>
+			<div
+				class="absolute inset-x-0 top-1/2 border-t border-dashed border-dark-700"
+				aria-hidden="true"
+			/>
+			{isClickable ? (
+				<button
+					type="button"
+					class={pillBase + pillInteractive}
+					onClick={onOpen}
+					data-testid="compact-turn-hidden-divider-button"
+					aria-label={`${label}. Open ${agentLabel} chat to view earlier messages.`}
+				>
+					<svg
+						class="w-3 h-3"
+						viewBox="0 0 16 16"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="1.5"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						aria-hidden="true"
+					>
+						<path d="M4 10l4-4 4 4" />
+					</svg>
+					<span>{label}</span>
+					<span class="text-gray-500">· open chat</span>
+				</button>
+			) : (
+				<span class={pillBase + pillStatic}>
+					<svg
+						class="w-3 h-3"
+						viewBox="0 0 16 16"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="1.5"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						aria-hidden="true"
+					>
+						<path d="M4 10l4-4 4 4" />
+					</svg>
+					<span>{label}</span>
+				</span>
+			)}
 		</div>
 	);
 }
@@ -287,7 +354,7 @@ export function SpaceTaskCardFeed({
 				return (
 					<div
 						key={block.id}
-						class={`space-y-1.5 ${index > 0 ? 'pt-2 border-t border-dark-700/70' : ''}`}
+						class={`space-y-1 ${index > 0 ? 'pt-2' : ''}`}
 						data-testid="compact-turn-group"
 					>
 						{renderAgentBlock(

--- a/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.tsx
+++ b/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.tsx
@@ -1,23 +1,12 @@
 import { useMemo } from 'preact/hooks';
-import {
-	isSDKRateLimitEvent,
-	isSDKResultMessage,
-	isSDKSystemInit,
-	isSDKUserMessage,
-} from '@neokai/shared/sdk/type-guards';
+import { isSDKResultMessage, isSDKSystemInit } from '@neokai/shared/sdk/type-guards';
 import type { ParsedThreadRow } from '../space-task-thread-events';
 import type { UseMessageMapsResult } from '../../../../hooks/useMessageMaps';
+import { spaceOverlayAgentNameSignal, spaceOverlaySessionIdSignal } from '../../../../lib/signals';
 import { SDKMessageRenderer } from '../../../sdk/SDKMessageRenderer';
 import { getAgentColor } from '../space-task-thread-agent-colors';
-import { spaceOverlayAgentNameSignal, spaceOverlaySessionIdSignal } from '../../../../lib/signals';
 import { SpaceSystemInitCard } from './SpaceSystemInitCard';
-import {
-	buildLogicalBlocks,
-	applyCompactVisibilityRules,
-	applyBlockRowVisibility,
-	resolveRunningBlockIndex,
-	type CompactLogicalBlock,
-} from './space-task-compact-reducer';
+import { rowHasToolUse } from './space-task-compact-reducer';
 
 interface SpaceTaskCardFeedProps {
 	parsedRows: ParsedThreadRow[];
@@ -26,90 +15,100 @@ interface SpaceTaskCardFeedProps {
 	maps: UseMessageMapsResult;
 	/**
 	 * Whether the agent session backing this task is currently active (not idle /
-	 * completed / failed / interrupted). When false the running-border animation
-	 * is suppressed even if non-terminal blocks are present.
+	 * completed / failed / interrupted). Used to gate the running border on the
+	 * last visible row when that row is a tool_use assistant message.
 	 */
 	isAgentActive: boolean;
 }
 
-// ── Row-level pre-filter (structural noise only) ─────────────────────────────
-
-function isEmptyUserRow(row: ParsedThreadRow): boolean {
-	if (!row.message || !isSDKUserMessage(row.message)) return false;
-	const content = (row.message as { message?: { content?: unknown } }).message?.content;
-	if (typeof content === 'string') return content.trim().length === 0;
-	if (Array.isArray(content)) {
-		return !content.some((block) => {
-			if (!block || typeof block !== 'object') return false;
-			const b = block as { type?: unknown; text?: unknown };
-			return b.type === 'text' && typeof b.text === 'string' && b.text.trim().length > 0;
-		});
-	}
-	return true;
+interface AgentBlock {
+	id: string;
+	label: string;
+	color: string;
+	sessionId: string | null;
+	rows: ParsedThreadRow[];
 }
 
-/**
- * Pre-filter parsed rows before block grouping. Removes structural noise that
- * should never appear in the compact view. Result rows are NOT filtered here —
- * they are always preserved so terminal blocks remain visible.
- *
- * `system:init` rows ARE kept — they render as a small "Session Started" card
- * via `SpaceSystemInitCard` so multi-agent session starts stay legible.
- *
- * All user messages are kept — both real human input (isSynthetic=false/absent)
- * and agent→agent handoffs (isSynthetic=true). Human messages render as the
- * normal blue user bubble; synthetic messages render as the purple
- * `SyntheticMessageBlock` so the system-generated origin is visible at a
- * glance. Only content-less user rows are dropped via `isEmptyUserRow`.
- */
-function preFilterRows(rows: ParsedThreadRow[]): ParsedThreadRow[] {
-	return rows.filter((row) => {
-		if (!row.message) return true; // raw fallback rows stay
-		if (isSDKRateLimitEvent(row.message)) {
-			const info = row.message.rate_limit_info;
-			if (info?.status !== 'rejected') return false;
-		}
-		if (isEmptyUserRow(row)) return false;
-		return true;
-	});
+interface TurnGroup {
+	id: string;
+	index: number;
+	rows: ParsedThreadRow[];
+}
+
+function normalizeAgentKey(label: string): string {
+	return label.trim().toLowerCase().replace(/\s+/g, ' ');
 }
 
 function shortAgentLabel(label: string): string {
 	return label.replace(/\s+agent$/i, '').toUpperCase();
 }
 
-/**
- * Pick the authoritative session id for a block — the first row carrying a
- * non-null sessionId. Most rows within a block share the same sessionId, but
- * some fallback rows (e.g. raw parse-failure rows) may have null, so we skip
- * over them and return null only when every row lacks a session.
- */
-function getBlockSessionId(block: CompactLogicalBlock): string | null {
-	for (const row of block.rows) {
-		if (row.sessionId) return row.sessionId;
+function isTurnTerminalRow(row: ParsedThreadRow): boolean {
+	if (!row.message) return false;
+	return isSDKResultMessage(row.message);
+}
+
+function buildTurns(rows: ParsedThreadRow[]): TurnGroup[] {
+	if (rows.length === 0) return [];
+
+	const turns: TurnGroup[] = [];
+	let currentRows: ParsedThreadRow[] = [];
+	let currentStartId: string | number = rows[0].id;
+	let turnIndex = 1;
+
+	for (const row of rows) {
+		if (currentRows.length === 0) {
+			currentStartId = row.id;
+		}
+
+		currentRows.push(row);
+
+		if (isTurnTerminalRow(row)) {
+			turns.push({
+				id: `turn-${turnIndex}-${String(currentStartId)}`,
+				index: turnIndex,
+				rows: currentRows,
+			});
+			turnIndex += 1;
+			currentRows = [];
+		}
 	}
-	return null;
+
+	if (currentRows.length > 0) {
+		turns.push({
+			id: `turn-${turnIndex}-${String(currentStartId)}`,
+			index: turnIndex,
+			rows: currentRows,
+		});
+	}
+
+	return turns;
 }
 
-function getTerminalBadge(block: CompactLogicalBlock): 'DONE' | 'ERROR' | null {
-	if (!block.isTerminal) return null;
-	const hasError = block.rows.some((row) => {
-		if (!row.message || !isSDKResultMessage(row.message)) return false;
-		return row.message.subtype !== 'success';
-	});
-	return hasError ? 'ERROR' : 'DONE';
-}
+function buildAgentBlocks(rows: ParsedThreadRow[]): AgentBlock[] {
+	if (rows.length === 0) return [];
 
-/** Max rows shown per block before older ones are hidden. */
-const MAX_ROWS_PER_BLOCK = 3;
+	const blocks: AgentBlock[] = [];
+	for (const row of rows) {
+		const last = blocks[blocks.length - 1];
+		const rowKey = `${normalizeAgentKey(row.label)}::${row.sessionId ?? ''}`;
+		const lastKey =
+			last === undefined ? null : `${normalizeAgentKey(last.label)}::${last.sessionId ?? ''}`;
+		if (last && lastKey === rowKey) {
+			last.rows.push(row);
+			continue;
+		}
 
-// ── Per-block rendering ──────────────────────────────────────────────────────
+		blocks.push({
+			id: String(row.id),
+			label: row.label,
+			color: getAgentColor(row.label),
+			sessionId: row.sessionId ?? null,
+			rows: [row],
+		});
+	}
 
-interface BlockSectionProps {
-	block: CompactLogicalBlock;
-	maps: UseMessageMapsResult;
-	/** True only for the last visible block when the thread is still running. */
-	isRunningBlock: boolean;
+	return blocks;
 }
 
 function renderRow(row: ParsedThreadRow, maps: UseMessageMapsResult, isRunning = false) {
@@ -120,8 +119,8 @@ function renderRow(row: ParsedThreadRow, maps: UseMessageMapsResult, isRunning =
 			</div>
 		);
 	}
-	// System init messages get a dedicated small card — the normal SDK pipeline
-	// would render a plain inline pill in task context.
+
+	// Keep task init rows compact/expandable in task context.
 	if (isSDKSystemInit(row.message)) {
 		return <SpaceSystemInitCard message={row.message} />;
 	}
@@ -136,49 +135,23 @@ function renderRow(row: ParsedThreadRow, maps: UseMessageMapsResult, isRunning =
 			subagentMessagesMap={maps.subagentMessagesMap}
 			sessionInfo={maps.sessionInfoMap.get(msgUuid)}
 			taskContext={true}
+			showSubagentMessages={true}
 			isRunning={isRunning}
 		/>
 	);
 }
 
-/**
- * Renders a single logical block as a small agent-identity header followed by
- * each row's SDK message delegated to `SDKMessageRenderer`.
- *
- * This matches the normal-session rendering pipeline exactly — a tool use
- * becomes a `ToolResultCard` (bordered card with chevron), a thinking block
- * becomes a `ThinkingBlock` (bordered card), a Task tool becomes a
- * `SubagentBlock`, and a result becomes a `SDKResultMessage` card. No outer
- * wrapper is added around the group; each message renders its own chrome.
- *
- * The agent-identity header is the only space-task-specific addition — it
- * labels each logical block's agent (e.g. TASK, CODER, REVIEWER) so the
- * multi-agent context is visible at a glance.
- *
- * When `isRunningBlock` is true (the session is still executing and this is
- * the last non-terminal block), only the last row is forwarded `isRunning=true`
- * so exactly one inner non-terminal component (ThinkingBlock, ToolResultCard,
- * SubagentBlock, or assistant text bubble) renders the animated arc border.
- * Terminal result cards (SDKResultMessage) never receive the arc because
- * terminal blocks are never selected as the running block.
- */
-function BlockSection({ block, maps, isRunningBlock }: BlockSectionProps) {
-	const agentColor = getAgentColor(block.agentLabel);
-	const terminalBadge = getTerminalBadge(block);
-	const blockSessionId = getBlockSessionId(block);
-	const isClickable = blockSessionId !== null;
-
-	// Trim this turn to its most-recent rows; show the hidden-count under the header.
-	const { visibleRows, hiddenRowCount: hiddenInBlock } = applyBlockRowVisibility(
-		block,
-		MAX_ROWS_PER_BLOCK
-	);
-	const lastVisibleIdx = visibleRows.length - 1;
+function renderAgentBlock(
+	block: AgentBlock,
+	maps: UseMessageMapsResult,
+	runningRowId: string | null
+) {
+	const isClickable = !!block.sessionId;
 
 	const handleOpenAgentOverlay = () => {
-		if (!blockSessionId) return;
-		spaceOverlayAgentNameSignal.value = block.agentLabel;
-		spaceOverlaySessionIdSignal.value = blockSessionId;
+		if (!block.sessionId) return;
+		spaceOverlayAgentNameSignal.value = block.label;
+		spaceOverlaySessionIdSignal.value = block.sessionId;
 	};
 
 	const handleHeaderKeyDown = (e: KeyboardEvent) => {
@@ -191,13 +164,11 @@ function BlockSection({ block, maps, isRunningBlock }: BlockSectionProps) {
 
 	return (
 		<div
+			key={block.id}
 			data-testid="compact-block"
-			data-agent-label={block.agentLabel}
-			data-agent-color={agentColor}
+			data-agent-label={block.label}
+			data-agent-color={block.color}
 		>
-			{/* Agent identity header — clickable to open the agent slide-out.
-			    Taller padding (min-h-[32px], py-2) makes the name a comfortable
-			    click/tap target while keeping the small text style. */}
 			<div
 				class={
 					'flex items-center gap-2 px-2 py-2 min-h-[32px] rounded ' +
@@ -209,66 +180,42 @@ function BlockSection({ block, maps, isRunningBlock }: BlockSectionProps) {
 				data-clickable={isClickable ? '1' : '0'}
 				role={isClickable ? 'button' : undefined}
 				tabIndex={isClickable ? 0 : undefined}
-				aria-label={isClickable ? `Open ${block.agentLabel} session details` : undefined}
+				aria-label={isClickable ? `Open ${block.label} session details` : undefined}
 				onClick={isClickable ? handleOpenAgentOverlay : undefined}
 				onKeyDown={isClickable ? handleHeaderKeyDown : undefined}
 			>
 				<span
 					class="w-2 h-2 rounded-full flex-shrink-0"
-					style={{ backgroundColor: agentColor }}
+					style={{ backgroundColor: block.color }}
 					aria-hidden="true"
 				/>
 				<span
 					class="text-[11px] uppercase tracking-[0.16em] font-mono font-medium flex-shrink-0"
-					style={{ color: agentColor }}
+					style={{ color: block.color }}
 				>
-					{shortAgentLabel(block.agentLabel)}
+					{shortAgentLabel(block.label)}
 				</span>
-				{terminalBadge && (
-					<span
-						class={
-							'ml-1 text-[10px] uppercase tracking-[0.14em] font-mono border rounded px-1 py-px flex-shrink-0 ' +
-							(terminalBadge === 'ERROR'
-								? 'text-red-300 border-red-800/80 bg-red-950/30'
-								: 'text-emerald-300 border-emerald-800/80 bg-emerald-950/30')
-						}
-						data-testid="compact-block-badge"
-					>
-						{terminalBadge}
-					</span>
-				)}
-				{hiddenInBlock > 0 && (
-					<span
-						class="ml-auto text-[10px] font-mono flex-shrink-0"
-						style={{ color: agentColor, opacity: 0.55 }}
-						data-testid="compact-block-hidden-count"
-					>
-						↑ {hiddenInBlock} earlier {hiddenInBlock === 1 ? 'message' : 'messages'}
-					</span>
-				)}
 			</div>
 
-			{/* Siderail + body */}
 			<div class="flex gap-2 pl-1 pb-1" data-testid="compact-block-body">
-				{/* Vertical colored siderail */}
 				<div
 					class="w-0.5 rounded-full flex-shrink-0 self-stretch opacity-40"
-					style={{ backgroundColor: agentColor }}
+					style={{ backgroundColor: block.color }}
 					aria-hidden="true"
+					data-testid="compact-block-siderail"
 				/>
-				{/* Message rows — last MAX_ROWS_PER_BLOCK only */}
 				<div class="flex-1 min-w-0 space-y-1">
-					{visibleRows.map((row, rowIdx) => {
-						// Only the last row of the running block gets the animated border.
-						const isRunningRow = isRunningBlock && rowIdx === lastVisibleIdx;
-						if (isRunningRow) {
+					{block.rows.map((row) => {
+						const key = String(row.id);
+						const rowNode = renderRow(row, maps, key === runningRowId);
+						if (key === runningRowId) {
 							return (
-								<div key={String(row.id)} data-testid="compact-running-block">
-									{renderRow(row, maps, true)}
+								<div key={key} data-testid="compact-running-block">
+									{rowNode}
 								</div>
 							);
 						}
-						return <div key={String(row.id)}>{renderRow(row, maps, false)}</div>;
+						return <div key={key}>{rowNode}</div>;
 					})}
 				</div>
 			</div>
@@ -276,25 +223,15 @@ function BlockSection({ block, maps, isRunningBlock }: BlockSectionProps) {
 	);
 }
 
-// ── Main feed component ──────────────────────────────────────────────────────
-
 /**
- * SpaceTaskCardFeed — compact renderer for Space task threads that reuses the
- * normal-session rendering pipeline.
+ * SpaceTaskCardFeed — compact renderer grouped by turn and then agent block.
  *
- * Each parsed row's SDK message is delegated to `SDKMessageRenderer` (the same
- * router used by `ChatContainer`), which dispatches to the appropriate block
- * component — `ToolResultCard`, `ThinkingBlock`, `SubagentBlock`,
- * `SDKResultMessage`, `SDKAssistantMessage`, `SDKUserMessage`, etc. — so the
- * visual language matches a normal chat session exactly.
- *
- * The only space-task-specific additions are:
- *   - Visibility rules from `space-task-compact-reducer` (max 3 recent logical
- *     blocks, terminal blocks always kept).
- *   - A small agent-identity header above each logical block so multi-agent
- *     context (Task / Coder / Reviewer / …) is readable at a glance.
- *   - `.running-block` chrome wrapping the last individual event message of
- *     the tail block while the thread is still executing (non-terminal last block).
+ * Rendering policy:
+ * - Render whole history (no tail truncation).
+ * - Group rows into "turns" using terminal result/error messages as boundaries.
+ *   Turn N includes rows up to and including the terminal result/error row.
+ * - Within each turn, group consecutive rows by agent/session into clickable
+ *   agent blocks with color headers/siderails.
  */
 export function SpaceTaskCardFeed({
 	parsedRows,
@@ -302,34 +239,34 @@ export function SpaceTaskCardFeed({
 	maps,
 	isAgentActive,
 }: SpaceTaskCardFeedProps) {
-	const visibleBlocks = useMemo(() => {
-		const filtered = preFilterRows(parsedRows);
-		const allBlocks = buildLogicalBlocks(filtered);
-		return applyCompactVisibilityRules(allBlocks, 3);
-	}, [parsedRows]);
+	const turns = useMemo(() => buildTurns(parsedRows), [parsedRows]);
+	const allRows = useMemo(() => turns.flatMap((turn) => turn.rows), [turns]);
 
-	// Running border: shown ONLY when the agent session is actively executing
-	// AND the last visible block is non-terminal AND its last row is a tool_use
-	// event (the agent is currently invoking a tool — read/write/bash/MCP call).
-	// Plain text and thinking-only rows do not qualify. See
-	// `resolveRunningBlockIndex` for the full rule set.
-	const runningBlockIdx = useMemo(
-		() => resolveRunningBlockIndex(visibleBlocks, isAgentActive),
-		[isAgentActive, visibleBlocks]
-	);
+	const runningRowId = useMemo(() => {
+		if (!isAgentActive) return null;
+		const tailLast = allRows[allRows.length - 1];
+		if (!tailLast || !rowHasToolUse(tailLast)) return null;
+		return String(tailLast.id);
+	}, [isAgentActive, allRows]);
 
 	return (
-		// Horizontal padding (px-4) matches SpaceTaskPane's header padding so the
-		// compact thread content aligns with the pane title bar above it.
 		<div class="space-y-2 px-4 py-2" data-testid="space-task-event-feed-compact">
-			{visibleBlocks.map((block, idx) => (
-				<BlockSection
-					key={block.id}
-					block={block}
-					maps={maps}
-					isRunningBlock={idx === runningBlockIdx}
-				/>
-			))}
+			{turns.map((turn) => {
+				const blocks = buildAgentBlocks(turn.rows);
+				return (
+					<div key={turn.id} class="space-y-1.5" data-testid="compact-turn-group">
+						<div class="relative py-1" data-testid="compact-turn-divider">
+							<div class="border-t border-dark-700" aria-hidden="true" />
+							<div class="absolute inset-0 flex items-center justify-center pointer-events-none">
+								<span class="px-2 text-[11px] uppercase tracking-[0.12em] text-gray-500 bg-dark-900">
+									{`Turn ${turn.index}`}
+								</span>
+							</div>
+						</div>
+						{blocks.map((block) => renderAgentBlock(block, maps, runningRowId))}
+					</div>
+				);
+			})}
 		</div>
 	);
 }

--- a/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.tsx
+++ b/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.tsx
@@ -164,91 +164,103 @@ function renderAgentBlock(
 	return (
 		<div
 			key={block.id}
+			class="relative pt-2 pb-1"
 			data-testid="compact-block"
 			data-agent-label={block.label}
 			data-agent-color={block.color}
 		>
+			{/* ⌐ bracket — single stroke that caps the top then runs down the side,
+			    rounded at the inside corner so the arm curves smoothly into the rail. */}
 			<div
-				class={
-					'group flex items-center gap-2 px-2 py-1.5 min-h-[30px] rounded ' +
-					(isClickable
-						? 'cursor-pointer hover:bg-dark-800/70 active:bg-dark-800 transition-colors focus:outline-none focus:bg-dark-800/70 focus:ring-1 focus:ring-dark-600'
-						: '')
-				}
-				data-testid="compact-block-header"
-				data-clickable={isClickable ? '1' : '0'}
-				role={isClickable ? 'button' : undefined}
-				tabIndex={isClickable ? 0 : undefined}
-				aria-label={isClickable ? `Open ${block.label} session details` : undefined}
-				onClick={isClickable ? handleOpenAgentOverlay : undefined}
-				onKeyDown={isClickable ? handleHeaderKeyDown : undefined}
-			>
-				<span
-					class="w-2 h-2 rounded-full flex-shrink-0"
-					style={{ backgroundColor: block.color }}
-					aria-hidden="true"
-				/>
-				<span
-					class="text-[11px] uppercase tracking-[0.16em] font-mono font-medium flex-shrink-0"
-					style={{ color: block.color }}
-				>
-					{shortAgentLabel(block.label)}
-				</span>
-				{isClickable ? (
-					<svg
-						class="ml-auto w-3 h-3 text-gray-600 opacity-0 group-hover:opacity-100 group-focus:opacity-100 transition-opacity flex-shrink-0"
-						viewBox="0 0 16 16"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="1.5"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						aria-hidden="true"
-					>
-						<path d="M6 4l4 4-4 4" />
-					</svg>
-				) : null}
-			</div>
+				class="absolute top-0 left-0 bottom-1 border-l-2 border-t-2 rounded-tl-md pointer-events-none"
+				style={{
+					borderColor: block.color,
+					width: 'clamp(96px, 30%, 180px)',
+				}}
+				aria-hidden="true"
+				data-testid="compact-block-bracket"
+			/>
 
-			<div class="flex gap-2 pl-1 pb-1" data-testid="compact-block-body">
-				<div
-					class="w-0.5 rounded-full flex-shrink-0 self-stretch opacity-40"
-					style={{ backgroundColor: block.color }}
-					aria-hidden="true"
-					data-testid="compact-block-siderail"
-				/>
-				<div class="flex-1 min-w-0 space-y-1">
-					{block.rows.flatMap((row) => {
-						const key = String(row.id);
-						const rowNode = renderRow(row, maps, key === runningRowId);
-						const rowEl =
-							key === runningRowId ? (
-								<div key={`row-${key}`} data-testid="compact-running-block">
-									{rowNode}
-								</div>
-							) : (
-								<div key={`row-${key}`}>{rowNode}</div>
-							);
-						if (
-							hiddenCount > 0 &&
-							pinnedInitialUserRowId !== null &&
-							key === pinnedInitialUserRowId
-						) {
-							return [
-								rowEl,
-								renderHiddenDivider(
-									key,
-									hiddenCount,
-									block.label,
-									isClickable,
-									handleOpenAgentOverlay
-								),
-							];
-						}
-						return [rowEl];
-					})}
-				</div>
+			{renderAgentHeaderPill(block, isClickable, handleOpenAgentOverlay, handleHeaderKeyDown)}
+
+			<div class="pl-4 pt-0.5 space-y-1" data-testid="compact-block-body">
+				{block.rows.flatMap((row) => {
+					const key = String(row.id);
+					const rowNode = renderRow(row, maps, key === runningRowId);
+					const rowEl =
+						key === runningRowId ? (
+							<div key={`row-${key}`} data-testid="compact-running-block">
+								{rowNode}
+							</div>
+						) : (
+							<div key={`row-${key}`}>{rowNode}</div>
+						);
+					if (
+						hiddenCount > 0 &&
+						pinnedInitialUserRowId !== null &&
+						key === pinnedInitialUserRowId
+					) {
+						return [
+							rowEl,
+							renderHiddenDivider(
+								key,
+								hiddenCount,
+								block.label,
+								isClickable,
+								handleOpenAgentOverlay
+							),
+						];
+					}
+					return [rowEl];
+				})}
 			</div>
+		</div>
+	);
+}
+
+function renderAgentHeaderPill(
+	block: AgentBlock,
+	isClickable: boolean,
+	onOpen: () => void,
+	onKeyDown: (e: KeyboardEvent) => void
+) {
+	const label = shortAgentLabel(block.label);
+	// Pill fills the arm's width minus `m-2` breathing room on each side.
+	const pillBase =
+		'flex items-center justify-center w-full px-2.5 py-1 rounded-full border text-[11px] uppercase tracking-[0.12em] font-mono font-semibold whitespace-nowrap transition-colors';
+	const pillInteractive =
+		'cursor-pointer border-dark-600 bg-dark-850 hover:border-gray-500 hover:bg-dark-800 focus:outline-none focus:ring-1 focus:ring-gray-500';
+	const pillStatic = 'border-dark-700 bg-dark-850';
+
+	const pill = !isClickable ? (
+		<span class={`${pillBase} ${pillStatic}`} data-testid="compact-block-header" data-clickable="0">
+			<span class="truncate" style={{ color: block.color }}>
+				{label}
+			</span>
+		</span>
+	) : (
+		<button
+			type="button"
+			class={`${pillBase} ${pillInteractive}`}
+			data-testid="compact-block-header"
+			data-clickable="1"
+			aria-label={`Open ${block.label} session details`}
+			onClick={onOpen}
+			onKeyDown={onKeyDown}
+		>
+			<span class="truncate" style={{ color: block.color }}>
+				{label}
+			</span>
+		</button>
+	);
+
+	return (
+		<div
+			class="mt-1 px-2"
+			style={{ width: 'clamp(96px, 30%, 180px)' }}
+			data-testid="compact-block-header-slot"
+		>
+			{pill}
 		</div>
 	);
 }
@@ -346,17 +358,13 @@ export function SpaceTaskCardFeed({
 	}, [isAgentActive, parsedRows]);
 
 	return (
-		<div class="space-y-2 px-4 py-2" data-testid="space-task-event-feed-compact">
+		<div class="px-4 py-2" data-testid="space-task-event-feed-compact">
 			{blocks.map((block, index) => {
 				const blockHiddenCount = getBlockHiddenCount(block.rows);
 				const blockPinnedInitialUserRowId =
 					blockHiddenCount > 0 ? getBlockPinnedInitialUserRowId(block.rows) : null;
 				return (
-					<div
-						key={block.id}
-						class={`space-y-1 ${index > 0 ? 'pt-2' : ''}`}
-						data-testid="compact-turn-group"
-					>
+					<div key={block.id} class={index > 0 ? 'mt-1' : ''} data-testid="compact-turn-group">
 						{renderAgentBlock(
 							block,
 							maps,

--- a/packages/web/src/components/space/thread/space-task-thread-events.ts
+++ b/packages/web/src/components/space/thread/space-task-thread-events.ts
@@ -34,6 +34,8 @@ export interface ParsedThreadRow {
 	taskId: string;
 	taskTitle: string;
 	createdAt: number;
+	turnIndex?: number;
+	turnHiddenMessageCount?: number;
 	message: SDKMessage | null;
 	fallbackText: string | null;
 }
@@ -332,6 +334,8 @@ export function parseThreadRow(row: SpaceTaskThreadMessageRow): ParsedThreadRow 
 			taskId: row.taskId,
 			taskTitle: row.taskTitle,
 			createdAt: row.createdAt,
+			turnIndex: row.turnIndex,
+			turnHiddenMessageCount: row.turnHiddenMessageCount,
 			message: withTimestamp,
 			fallbackText: null,
 		};
@@ -343,6 +347,8 @@ export function parseThreadRow(row: SpaceTaskThreadMessageRow): ParsedThreadRow 
 			taskId: row.taskId,
 			taskTitle: row.taskTitle,
 			createdAt: row.createdAt,
+			turnIndex: row.turnIndex,
+			turnHiddenMessageCount: row.turnHiddenMessageCount,
 			message: null,
 			fallbackText: row.content,
 		};

--- a/packages/web/src/hooks/useSpaceTaskMessages.ts
+++ b/packages/web/src/hooks/useSpaceTaskMessages.ts
@@ -15,6 +15,16 @@ export interface SpaceTaskThreadMessageRow {
 	createdAt: number;
 	parentToolUseId?: string | null;
 	/**
+	 * Server-computed turn index (per session) for compact thread grouping.
+	 * Present in compact query rows; absent in full rows.
+	 */
+	turnIndex?: number;
+	/**
+	 * Count of earlier non-terminal messages hidden by compact cap in this
+	 * session-turn. Present in compact query rows; absent in full rows.
+	 */
+	turnHiddenMessageCount?: number;
+	/**
 	 * Total messages stored for this session — populated by the compact query
 	 * variant when the server has sliced the result set. When equal to the
 	 * number of delivered rows for this session, nothing was truncated.


### PR DESCRIPTION
## Summary

- Refactors the compact space task thread to group rows by agent turn blocks (4 commits ahead of `dev`)
- Flattens the agent block header — removes gradient background, thick border, and "Agent Turn" badge in favor of a minimal color dot + label with a subtle hover chevron
- Turns the passive "N earlier messages" label into a pill-shaped button that opens the agent's slide-out chat (same target as clicking the header), so hidden history is one click away

## Test plan

- [x] `bunx vitest run packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.test.tsx` (15/15)
- [x] `bunx vitest run packages/web/src/components/space/__tests__/SpaceTaskUnifiedThread.test.tsx`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [ ] Visual check in browser: multiple-agent task shows distinct per-agent blocks, header hover reveals the chevron, hidden-messages pill opens the agent slide-out chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)