### PR TITLE
feat(space): harden Coding Workflow reviewer loop — post to PR + verify

### DIFF
--- a/packages/daemon/src/lib/space/agents/seed-agents.ts
+++ b/packages/daemon/src/lib/space/agents/seed-agents.ts
@@ -136,8 +136,27 @@ const PRESET_AGENTS: PresetDefinition[] = [
 		customPrompt:
 			'You are an expert code reviewer. You review pull requests for correctness, security, performance, ' +
 			'style, and test coverage. You give specific, actionable feedback.\n\n' +
-			'Review the code thoroughly. If satisfied, summarize your findings. If changes are needed, provide ' +
-			'specific feedback.',
+			'Your review MUST be posted to GitHub so the author can see it — an internal summary is not ' +
+			'enough. Use `gh` for every write:\n' +
+			'- Summary-level review: `gh pr review <pr-url> --body-file <file>` with one of ' +
+			'`--approve`, `--request-changes`, or `--comment` (pick the one that matches your verdict).\n' +
+			'- Line-level comments: `gh api repos/{owner}/{repo}/pulls/{number}/comments` with ' +
+			'`body`, `commit_id`, `path`, and `line` (or `start_line`+`line` for a range) so each ' +
+			'comment is anchored to the exact diff line.\n\n' +
+			'Worked example (request changes + one inline comment):\n' +
+			'```\n' +
+			'# 1. Post the summary review\n' +
+			'echo "Tests are missing for the new retry path." > /tmp/review.md\n' +
+			'gh pr review https://github.com/acme/app/pull/42 --request-changes --body-file /tmp/review.md\n\n' +
+			'# 2. Post a line-level comment on src/retry.ts line 88\n' +
+			'gh api repos/acme/app/pulls/42/comments \\\n' +
+			'  -f body="This branch swallows the error — re-throw after logging." \\\n' +
+			'  -f commit_id="$(gh pr view 42 --json headRefOid -q .headRefOid)" \\\n' +
+			'  -f path="src/retry.ts" -F line=88\n' +
+			'```\n\n' +
+			'Review the code thoroughly, then post your findings to GitHub using the commands above ' +
+			'BEFORE summarizing or handing off. If satisfied, `--approve` is sufficient; if changes are ' +
+			'needed, use `--request-changes` and add line-level comments for each issue.',
 	},
 	{
 		name: 'QA',

--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -745,13 +745,19 @@ export class ChannelRouter {
 			return evaluateGate(gateDef, runtimeData);
 		}
 
-		// Script-based gates acquire the semaphore and pass executor + context
+		// Script-based gates acquire the semaphore and pass executor + context.
+		// Inject workflow start time as ISO8601 so scripts that need to filter by
+		// "since workflow start" (e.g. review-posted-gate) have a stable reference.
+		const run = this.config.workflowRunRepo.getRun(runId);
+		const workflowStartIso = run ? new Date(run.createdAt).toISOString() : undefined;
+
 		const scriptExecutor: GateScriptExecutorFn = executeGateScript;
 		const scriptContext: GateScriptContext = {
 			workspacePath: this.config.workspacePath ?? process.cwd(),
 			gateId,
 			runId,
 			gateData: runtimeData,
+			workflowStartIso,
 		};
 
 		return this.withScriptSemaphore(async () => {

--- a/packages/daemon/src/lib/space/runtime/gate-script-executor.ts
+++ b/packages/daemon/src/lib/space/runtime/gate-script-executor.ts
@@ -39,6 +39,15 @@ export interface GateScriptContext {
 	 * Exposed to scripts as NEOKAI_GATE_DATA_JSON.
 	 */
 	gateData?: Record<string, unknown>;
+	/**
+	 * ISO8601 timestamp marking when the workflow run started (workflowRun.createdAt
+	 * converted to ISO8601). Exposed to scripts as NEOKAI_WORKFLOW_START_ISO.
+	 * Gate scripts that compare against fresh activity (e.g. reviews submitted
+	 * since start) rely on this variable.
+	 * Undefined when the context wasn't able to resolve a run start time
+	 * (e.g. in unit tests); the env var is only injected when set.
+	 */
+	workflowStartIso?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -120,6 +129,10 @@ export function buildRestrictedEnv(
 	env['NEOKAI_WORKFLOW_RUN_ID'] = context.runId;
 	env['NEOKAI_WORKSPACE_PATH'] = context.workspacePath;
 
+	if (context.workflowStartIso) {
+		env['NEOKAI_WORKFLOW_START_ISO'] = context.workflowStartIso;
+	}
+
 	const gateData = context.gateData ?? {};
 	try {
 		env['NEOKAI_GATE_DATA_JSON'] = JSON.stringify(gateData);
@@ -135,7 +148,8 @@ export function buildRestrictedEnv(
 				key === 'NEOKAI_GATE_ID' ||
 				key === 'NEOKAI_WORKFLOW_RUN_ID' ||
 				key === 'NEOKAI_WORKSPACE_PATH' ||
-				key === 'NEOKAI_GATE_DATA_JSON'
+				key === 'NEOKAI_GATE_DATA_JSON' ||
+				key === 'NEOKAI_WORKFLOW_START_ISO'
 			) {
 				continue;
 			}

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -2514,8 +2514,15 @@ export class TaskAgentManager {
 			gateDataRepo: this.config.gateDataRepo,
 			onGateDataChanged: (runId, gateId) => nodeAgentChannelRouter.onGateDataChanged(runId, gateId),
 			scriptExecutor: executeGateScript,
-			// gateId is overridden per-gate by the handler ({ ...scriptContext, gateId })
-			scriptContext: { workspacePath, runId: workflowRunId, gateId: '' },
+			// gateId is overridden per-gate by the handler ({ ...scriptContext, gateId }).
+			// workflowStartIso is sourced from the run's createdAt so gate scripts can
+			// filter activity by "since workflow start" (e.g. review-posted-gate).
+			scriptContext: {
+				workspacePath,
+				runId: workflowRunId,
+				gateId: '',
+				workflowStartIso: run ? new Date(run.createdAt).toISOString() : undefined,
+			},
 			onReportResult,
 			artifactRepo: this.config.artifactRepo,
 			getSpaceAutonomyLevel: async (sid) => {

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -362,6 +362,55 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 								);
 								gateWriteResult = { gateId, gateOpen: evalResult.open };
 
+								// Multi-round review history: every time the reviewer writes a
+								// `review_url` to this gate, append an append-only artifact row
+								// so we get one record per cycle (cycle 0, 1, 2 …) without any
+								// deduplication. The per-cycle artifactKey makes each write a
+								// distinct row even though the table uses upsert semantics.
+								//
+								// Note: `comment_urls` is not a gate field (so it's stripped from
+								// `authorizedData`), but we still want to persist it alongside the
+								// review for the audit trail — pull it straight from the original
+								// `data` payload the reviewer supplied.
+								if (
+									config.artifactRepo &&
+									gateId === 'review-posted-gate' &&
+									typeof authorizedData.review_url === 'string' &&
+									authorizedData.review_url.length > 0
+								) {
+									try {
+										const priorReviews = config.artifactRepo.listByRun(workflowRunId, {
+											artifactType: 'review',
+										});
+										const cycle = priorReviews.length;
+										const artifactData: Record<string, unknown> = {
+											review_url: authorizedData.review_url,
+											cycle,
+											submittedAt: new Date().toISOString(),
+										};
+										const rawCommentUrls = (data as Record<string, unknown>).comment_urls;
+										if (
+											Array.isArray(rawCommentUrls) &&
+											rawCommentUrls.every((u) => typeof u === 'string')
+										) {
+											artifactData.comment_urls = rawCommentUrls;
+										}
+										config.artifactRepo.upsert({
+											id: crypto.randomUUID(),
+											runId: workflowRunId,
+											nodeId: workflowNodeId,
+											artifactType: 'review',
+											artifactKey: `cycle-${cycle}`,
+											data: artifactData,
+										});
+									} catch (err) {
+										log.warn(
+											`Failed to append review artifact for run "${workflowRunId}":`,
+											err instanceof Error ? err.message : String(err)
+										);
+									}
+								}
+
 								if (onGateDataChanged) {
 									void onGateDataChanged(workflowRunId, gateId).catch((err) => {
 										log.warn(

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -85,6 +85,46 @@ const PR_READY_BASH_SCRIPT = [
 ].join('\n');
 
 /**
+ * Review-posted gate script.
+ *
+ * Verifies that the Reviewer has actually posted a GitHub review since the
+ * workflow run started. This gate guards the Review → Coding feedback channel:
+ * the runtime refuses to deliver a "changes requested" message until the review
+ * is visible on GitHub, closing the gap where reviewers summarize feedback
+ * internally and never call `gh pr review`.
+ *
+ * Environment variables:
+ *   NEOKAI_GATE_DATA_JSON       — current gate data; may contain `pr_url`
+ *   NEOKAI_WORKFLOW_START_ISO   — ISO8601 timestamp of workflowRun.createdAt,
+ *                                 injected by the gate script runner
+ */
+const REVIEW_POSTED_BASH_SCRIPT = [
+	'PR_URL=$(jq -r \'.pr_url // empty\' <<< "${NEOKAI_GATE_DATA_JSON:-{}}" 2>/dev/null || true)',
+	'if [ -z "$PR_URL" ]; then',
+	'  PR_URL=$(gh pr view --json url -q .url 2>/dev/null || true)',
+	'fi',
+	'if [ -z "$PR_URL" ]; then',
+	'  echo "No PR URL available to verify review" >&2',
+	'  exit 1',
+	'fi',
+	'START_ISO="${NEOKAI_WORKFLOW_START_ISO:-}"',
+	'if [ -z "$START_ISO" ]; then',
+	'  echo "NEOKAI_WORKFLOW_START_ISO not injected — cannot determine review window" >&2',
+	'  exit 1',
+	'fi',
+	'if ! REVIEW_JSON=$(gh pr view "$PR_URL" --json reviews); then',
+	'  echo "Failed to fetch reviews for ${PR_URL}" >&2',
+	'  exit 1',
+	'fi',
+	'REVIEW_COUNT=$(jq --arg since "$START_ISO" \'[.reviews[] | select(.submittedAt > $since)] | length\' <<< "$REVIEW_JSON")',
+	'if [ "$REVIEW_COUNT" = "0" ] || [ -z "$REVIEW_COUNT" ]; then',
+	'  echo "No review submitted on ${PR_URL} since workflow start (${START_ISO})" >&2',
+	'  exit 1',
+	'fi',
+	'jq -n --arg url "$PR_URL" --argjson n "$REVIEW_COUNT" \'{"pr_url":$url,"review_count":$n}\'',
+].join('\n');
+
+/**
  * Merge PR completion action script.
  *
  * Used as a `script` completion action on short workflows (Coding, Research).
@@ -271,8 +311,9 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'explicitly by sending a message to the Review node with the PR URL — that send ' +
 							'is what passes the readiness gate and activates the Reviewer.\n' +
 							'- If the Reviewer requests changes, you will be re-activated with their message. ' +
-							'Pull the review comments from GitHub, evaluate each one, address the valid items, ' +
-							'and push back on any you disagree with — explain your reasoning in the reply.\n' +
+							'The message `data` payload will include `review_url` and `comment_urls` pointing ' +
+							'at the exact GitHub comment threads to address — use those links instead of ' +
+							'scraping the PR blind.\n' +
 							'- This cycle can repeat up to 5 times.\n\n' +
 							'Steps:\n' +
 							'1. Read and understand the task requirements\n' +
@@ -286,12 +327,16 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'**Always include `data: { pr_url }` on every send_message to Review** — the gate ' +
 							'data resets each cycle, so even on round 2+ you must re-supply it.\n\n' +
 							'If re-activated after review:\n' +
-							'1. Pull review comments from GitHub (`gh pr view` and `gh api`)\n' +
-							'2. Evaluate each comment critically — do not blindly accept feedback. Verify ' +
+							'1. Read the incoming message `data` — you should find `review_url` and ' +
+							'`comment_urls` (an array of comment thread URLs). Open each one; do not rely on ' +
+							'a summary.\n' +
+							'2. For each comment: evaluate critically — do not blindly accept feedback. Verify ' +
 							'against the code and the task requirements. The Reviewer can be wrong.\n' +
-							'3. For valid items: make the fix and reply to the comment confirming what changed\n' +
-							'4. For items you disagree with: reply explaining why, with evidence from the code ' +
-							'or tests. Do not change code you believe is correct.\n' +
+							'3. For valid items: make the fix, then reply to that specific thread via ' +
+							'`gh api repos/{owner}/{repo}/pulls/{n}/comments/{comment_id}/replies -f body="<ack>"` ' +
+							'explaining what changed. One reply per comment creates a visible audit trail.\n' +
+							'4. For items you disagree with: reply on the same thread explaining why, with ' +
+							'evidence from the code or tests. Do not change code you believe is correct.\n' +
 							'5. Push fixes, verify tests still pass, then send_message to Review again ' +
 							'(again with `data: { pr_url }`) to re-trigger the review cycle',
 					},
@@ -314,8 +359,13 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'- You share the same worktree as the engineer — review the codebase as a whole, ' +
 							'not just the PR diff. Read related files, run tests, check for issues the diff ' +
 							'might not surface (e.g. callers of changed functions, integration points).\n' +
-							'- Post all feedback as PR review comments on GitHub so the engineer can address ' +
-							'them item by item. Then send a short message to Coding summarizing the request.\n' +
+							'- All feedback MUST be posted to the PR on GitHub — not just summarized in your ' +
+							'response. Use `gh pr review <pr-url> --request-changes --body-file <file>` for ' +
+							'the summary, and `gh api repos/{owner}/{repo}/pulls/{n}/comments` for line-level ' +
+							'comments (one per issue, anchored to the exact path and line).\n' +
+							'- The Review → Coding channel is gated by `review-posted-gate` — the runtime ' +
+							'checks GitHub for a fresh review before releasing your message. If you skip ' +
+							'`gh pr review`, the gate will block and the coder will never hear from you.\n' +
 							'- If you request changes, the engineer is automatically re-activated.\n\n' +
 							'**You MUST call `report_result` to end this workflow.** It is the only signal ' +
 							'the runtime accepts as completion — finishing your turn without it leaves the ' +
@@ -326,10 +376,19 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'1. Read the PR diff (`gh pr diff`) AND explore the worktree for context\n' +
 							'2. Check for correctness, style, test coverage, and integration impact\n' +
 							'3. Run the relevant tests yourself if uncertain\n' +
-							'4. If changes needed: post specific, actionable review comments on GitHub, then ' +
-							'send_message to Coding asking them to address the comments (do NOT call ' +
-							'`report_result` — leave the workflow open for the next round)\n' +
-							'5. If satisfied: verify the PR is open and mergeable, then call ' +
+							'4. If changes needed:\n' +
+							'   a. Post a summary review: `gh pr review <pr-url> --request-changes ' +
+							'--body-file /tmp/review.md`. Capture the returned review URL.\n' +
+							'   b. For each issue, post a line-level comment: `gh api ' +
+							'repos/{owner}/{repo}/pulls/{n}/comments -f body=... -f commit_id=... ' +
+							'-f path=... -F line=...`. Capture each response `html_url`.\n' +
+							'   c. send_message(target="Coding", message="<short request summary>", ' +
+							'data={ pr_url: "<url>", review_url: "<gh pr review url>", ' +
+							'comment_urls: ["<comment #1 url>", "<comment #2 url>"] }). The `data` payload ' +
+							'satisfies the review-posted-gate and gives the coder direct links to each ' +
+							'thread. Do NOT call `report_result` — leave the workflow open for the next round.\n' +
+							'5. If satisfied: post an approval review with `gh pr review <pr-url> --approve ' +
+							'--body-file <file>`, verify the PR is open and mergeable, then call ' +
 							'`report_result(status="done", summary=...)` as your final action',
 					},
 				},
@@ -362,6 +421,28 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 			},
 			resetOnCycle: true,
 		},
+		{
+			id: 'review-posted-gate',
+			label: 'Review Posted',
+			description:
+				'Reviewer has posted a GitHub review (via `gh pr review`) since the workflow ' +
+				'started. Blocks the Review → Coding feedback channel until a real review is ' +
+				'visible on the PR.',
+			fields: [
+				{
+					name: 'review_url',
+					type: 'string',
+					writers: ['reviewer'],
+					check: { op: 'exists' },
+				},
+			],
+			script: {
+				interpreter: 'bash',
+				source: REVIEW_POSTED_BASH_SCRIPT,
+				timeoutMs: 30000,
+			},
+			resetOnCycle: true,
+		},
 	],
 	channels: [
 		{
@@ -373,6 +454,7 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 		{
 			from: 'Review',
 			to: 'Coding',
+			gateId: 'review-posted-gate',
 			maxCycles: 5,
 			label: 'Review → Coding (changes requested)',
 		},
@@ -539,14 +621,23 @@ export const REVIEW_ONLY_WORKFLOW: SpaceWorkflow = {
 							'runtime accepts as completion — finishing your turn without it leaves the workflow ' +
 							'stuck. Do all review work BEFORE calling `report_result`; it must be your last tool ' +
 							'call.\n\n' +
+							'**You MUST post your review to the PR via `gh pr review` BEFORE calling ' +
+							'`report_result`.** An internal summary is not enough — the author must be able to see ' +
+							'your feedback on GitHub. Use:\n' +
+							'- `gh pr review <pr-url> --body-file <file>` with `--approve`, `--request-changes`, or ' +
+							'`--comment`.\n' +
+							'- `gh api repos/{owner}/{repo}/pulls/{n}/comments` for line-level comments anchored to ' +
+							'specific files/lines.\n\n' +
 							'Expected inputs: A PR or code to review (specified in the task description).\n' +
-							'Expected outputs: A thorough review summary with actionable findings.\n\n' +
+							'Expected outputs: A GitHub review posted on the PR + a summary for the task agent.\n\n' +
 							'Review checklist:\n' +
 							'1. Read the PR diff or specified code thoroughly\n' +
 							'2. Check for correctness, security, performance, and style issues\n' +
 							'3. Verify test coverage is adequate\n' +
-							'4. Summarize your findings clearly\n' +
-							'5. Call `report_result(status="done", summary=...)` as your final action',
+							'4. Post your review to the PR via `gh pr review` (+ inline comments via `gh api` ' +
+							'where relevant) — this is required, not optional\n' +
+							'5. Summarize your findings clearly for the task record\n' +
+							'6. Call `report_result(status="done", summary=...)` as your final action',
 					},
 				},
 			],

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -2232,3 +2232,232 @@ describe('node-agent-tools: async gate evaluation', () => {
 		expect(data.gateWrite).toBeUndefined();
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Tests: send_message (review-posted-gate artifact append)
+// ---------------------------------------------------------------------------
+
+describe('node-agent-tools: review-posted-gate multi-round artifact history', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	/**
+	 * Build a workflow with a single Review → Coding channel gated by the
+	 * production review-posted-gate definition. The sender is the reviewer,
+	 * matching the real coding workflow layout.
+	 */
+	function makeReviewPostedWorkflow(): SpaceWorkflow {
+		const gate: Gate = {
+			id: 'review-posted-gate',
+			fields: [
+				{ name: 'review_url', type: 'string', writers: ['reviewer'], check: { op: 'exists' } },
+			],
+			resetOnCycle: true,
+		};
+		return {
+			id: 'wf-review-posted',
+			spaceId: ctx.spaceId,
+			name: 'Test Coding Workflow',
+			description: '',
+			nodes: [],
+			startNodeId: '',
+			rules: [],
+			tags: [],
+			channels: [
+				{ id: 'ch-review-coder', from: 'reviewer', to: 'coder', gateId: 'review-posted-gate' },
+			],
+			gates: [gate],
+		};
+	}
+
+	test('appends one review artifact per cycle with cycle 0, 1, 2 across 3 rounds', async () => {
+		const { WorkflowRunArtifactRepository } = await import(
+			'../../../../src/storage/repositories/workflow-run-artifact-repository.ts'
+		);
+		const artifactRepo = new WorkflowRunArtifactRepository(ctx.db);
+
+		const workflow = makeReviewPostedWorkflow();
+		const config = makeConfig(ctx, {
+			workflow,
+			myAgentName: 'reviewer',
+			mySessionId: ctx.reviewerSessionId,
+			artifactRepo,
+		});
+		const handlers = createNodeAgentToolHandlers(config);
+
+		// Round 1
+		const r1 = await handlers.send_message({
+			target: 'coder',
+			message: 'Round 1 — please fix retry logic',
+			data: {
+				review_url: 'https://github.com/acme/app/pull/42#pullrequestreview-1',
+				comment_urls: ['https://github.com/acme/app/pull/42#discussion_r1001'],
+			},
+		});
+		expect(JSON.parse(r1.content[0].text).gateWrite.gateOpen).toBe(true);
+
+		// Round 2
+		const r2 = await handlers.send_message({
+			target: 'coder',
+			message: 'Round 2 — edge case still broken',
+			data: {
+				review_url: 'https://github.com/acme/app/pull/42#pullrequestreview-2',
+				comment_urls: [
+					'https://github.com/acme/app/pull/42#discussion_r1002',
+					'https://github.com/acme/app/pull/42#discussion_r1003',
+				],
+			},
+		});
+		expect(JSON.parse(r2.content[0].text).gateWrite.gateOpen).toBe(true);
+
+		// Round 3
+		const r3 = await handlers.send_message({
+			target: 'coder',
+			message: 'Round 3 — tests missing',
+			data: {
+				review_url: 'https://github.com/acme/app/pull/42#pullrequestreview-3',
+				comment_urls: [],
+			},
+		});
+		expect(JSON.parse(r3.content[0].text).gateWrite.gateOpen).toBe(true);
+
+		const artifacts = artifactRepo.listByRun(ctx.workflowRunId, { artifactType: 'review' });
+		expect(artifacts).toHaveLength(3);
+
+		// Artifacts are ordered by createdAt ascending. Cycle numbers must be 0,1,2.
+		const cycles = artifacts.map((a) => a.data.cycle);
+		expect(cycles).toEqual([0, 1, 2]);
+
+		// Each artifact carries review_url and comment_urls from its round.
+		expect(artifacts[0].data.review_url).toBe(
+			'https://github.com/acme/app/pull/42#pullrequestreview-1'
+		);
+		expect(artifacts[0].data.comment_urls).toEqual([
+			'https://github.com/acme/app/pull/42#discussion_r1001',
+		]);
+		expect(artifacts[1].data.review_url).toBe(
+			'https://github.com/acme/app/pull/42#pullrequestreview-2'
+		);
+		expect(artifacts[1].data.comment_urls as string[]).toHaveLength(2);
+		expect(artifacts[2].data.review_url).toBe(
+			'https://github.com/acme/app/pull/42#pullrequestreview-3'
+		);
+		expect(artifacts[2].data.comment_urls).toEqual([]);
+
+		// submittedAt is an ISO8601 string set at write time.
+		for (const a of artifacts) {
+			expect(typeof a.data.submittedAt).toBe('string');
+			expect(() => new Date(a.data.submittedAt as string).toISOString()).not.toThrow();
+		}
+
+		// Each artifact must have a unique artifactKey so upsert doesn't collapse rounds.
+		const keys = artifacts.map((a) => a.artifactKey);
+		expect(new Set(keys).size).toBe(3);
+		expect(keys).toEqual(['cycle-0', 'cycle-1', 'cycle-2']);
+	});
+
+	test('skips artifact append when review_url is absent from gate data', async () => {
+		const { WorkflowRunArtifactRepository } = await import(
+			'../../../../src/storage/repositories/workflow-run-artifact-repository.ts'
+		);
+		const artifactRepo = new WorkflowRunArtifactRepository(ctx.db);
+
+		// Use a gate where the reviewer can send data, but we omit review_url.
+		const gate: Gate = {
+			id: 'review-posted-gate',
+			fields: [
+				{ name: 'review_url', type: 'string', writers: ['reviewer'], check: { op: 'exists' } },
+				{ name: 'other', type: 'string', writers: ['reviewer'], check: { op: 'exists' } },
+			],
+			resetOnCycle: true,
+		};
+		const workflow: SpaceWorkflow = {
+			id: 'wf-no-url',
+			spaceId: ctx.spaceId,
+			name: 'Test',
+			description: '',
+			nodes: [],
+			startNodeId: '',
+			rules: [],
+			tags: [],
+			channels: [
+				{ id: 'ch-review-coder', from: 'reviewer', to: 'coder', gateId: 'review-posted-gate' },
+			],
+			gates: [gate],
+		};
+
+		const config = makeConfig(ctx, {
+			workflow,
+			myAgentName: 'reviewer',
+			mySessionId: ctx.reviewerSessionId,
+			artifactRepo,
+		});
+		const handlers = createNodeAgentToolHandlers(config);
+
+		// Write to gate but with only `other`, no `review_url`.
+		await handlers.send_message({
+			target: 'coder',
+			message: 'hi',
+			data: { other: 'value' },
+		});
+
+		// No artifact should have been appended because the review_url field is absent.
+		const artifacts = artifactRepo.listByRun(ctx.workflowRunId, { artifactType: 'review' });
+		expect(artifacts).toHaveLength(0);
+	});
+
+	test('skips artifact append for non-review-posted-gate gates (no false positives)', async () => {
+		const { WorkflowRunArtifactRepository } = await import(
+			'../../../../src/storage/repositories/workflow-run-artifact-repository.ts'
+		);
+		const artifactRepo = new WorkflowRunArtifactRepository(ctx.db);
+
+		// Different gate id — the append block is gated on id === 'review-posted-gate'.
+		const gate: Gate = {
+			id: 'some-other-gate',
+			fields: [
+				{ name: 'review_url', type: 'string', writers: ['reviewer'], check: { op: 'exists' } },
+			],
+			resetOnCycle: false,
+		};
+		const workflow: SpaceWorkflow = {
+			id: 'wf-other',
+			spaceId: ctx.spaceId,
+			name: 'Test',
+			description: '',
+			nodes: [],
+			startNodeId: '',
+			rules: [],
+			tags: [],
+			channels: [
+				{ id: 'ch-review-coder', from: 'reviewer', to: 'coder', gateId: 'some-other-gate' },
+			],
+			gates: [gate],
+		};
+
+		const config = makeConfig(ctx, {
+			workflow,
+			myAgentName: 'reviewer',
+			mySessionId: ctx.reviewerSessionId,
+			artifactRepo,
+		});
+		const handlers = createNodeAgentToolHandlers(config);
+
+		await handlers.send_message({
+			target: 'coder',
+			message: 'hi',
+			data: { review_url: 'https://example.com/pr/1#review-1' },
+		});
+
+		const artifacts = artifactRepo.listByRun(ctx.workflowRunId, { artifactType: 'review' });
+		expect(artifacts).toHaveLength(0);
+	});
+});

--- a/packages/daemon/tests/unit/5-space/other/gate-script-executor.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/gate-script-executor.test.ts
@@ -292,6 +292,37 @@ describe('buildRestrictedEnv', () => {
 	test('works without user env parameter', () => {
 		expect(buildRestrictedEnv(CTX)['NEOKAI_GATE_ID']).toBe('gate-123');
 	});
+
+	test('injects NEOKAI_WORKFLOW_START_ISO when context provides it', () => {
+		const env = buildRestrictedEnv({
+			...CTX,
+			workflowStartIso: '2026-04-19T10:00:00.000Z',
+		});
+		expect(env['NEOKAI_WORKFLOW_START_ISO']).toBe('2026-04-19T10:00:00.000Z');
+	});
+
+	test('does not inject NEOKAI_WORKFLOW_START_ISO when context omits it', () => {
+		// When workflowStartIso isn't resolvable (e.g. old run, test harness),
+		// we leave the var unset rather than defaulting to something misleading.
+		expect(buildRestrictedEnv(CTX)['NEOKAI_WORKFLOW_START_ISO']).toBeUndefined();
+	});
+
+	test('user env cannot override NEOKAI_WORKFLOW_START_ISO', () => {
+		const env = buildRestrictedEnv(
+			{ ...CTX, workflowStartIso: '2026-04-19T10:00:00.000Z' },
+			{ NEOKAI_WORKFLOW_START_ISO: '1970-01-01T00:00:00.000Z' }
+		);
+		expect(env['NEOKAI_WORKFLOW_START_ISO']).toBe('2026-04-19T10:00:00.000Z');
+	});
+
+	test('user env cannot spoof NEOKAI_WORKFLOW_START_ISO when context omits it', () => {
+		// Even with no context-provided value, agents must not be able to set the
+		// var themselves — that would let them backdate reviews and bypass the gate.
+		const env = buildRestrictedEnv(CTX, {
+			NEOKAI_WORKFLOW_START_ISO: '2020-01-01T00:00:00.000Z',
+		});
+		expect(env['NEOKAI_WORKFLOW_START_ISO']).toBeUndefined();
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/5-space/other/seed-agents.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/seed-agents.test.ts
@@ -216,7 +216,8 @@ describe('seedPresetAgents', () => {
 		const reviewer = seeded.find((a) => a.name === 'Reviewer');
 
 		expect(reviewer?.customPrompt).toContain('code reviewer');
-		expect(reviewer?.customPrompt).toContain('specific feedback');
+		// The hardened prompt says "specific, actionable feedback".
+		expect(reviewer?.customPrompt).toContain('specific, actionable feedback');
 	});
 
 	it('Planner custom prompt mentions planning', async () => {
@@ -367,9 +368,39 @@ describe('preset agent exact definitions', () => {
 		expect(reviewer.customPrompt).toBe(
 			'You are an expert code reviewer. You review pull requests for correctness, security, performance, ' +
 				'style, and test coverage. You give specific, actionable feedback.\n\n' +
-				'Review the code thoroughly. If satisfied, summarize your findings. If changes are needed, provide ' +
-				'specific feedback.'
+				'Your review MUST be posted to GitHub so the author can see it — an internal summary is not ' +
+				'enough. Use `gh` for every write:\n' +
+				'- Summary-level review: `gh pr review <pr-url> --body-file <file>` with one of ' +
+				'`--approve`, `--request-changes`, or `--comment` (pick the one that matches your verdict).\n' +
+				'- Line-level comments: `gh api repos/{owner}/{repo}/pulls/{number}/comments` with ' +
+				'`body`, `commit_id`, `path`, and `line` (or `start_line`+`line` for a range) so each ' +
+				'comment is anchored to the exact diff line.\n\n' +
+				'Worked example (request changes + one inline comment):\n' +
+				'```\n' +
+				'# 1. Post the summary review\n' +
+				'echo "Tests are missing for the new retry path." > /tmp/review.md\n' +
+				'gh pr review https://github.com/acme/app/pull/42 --request-changes --body-file /tmp/review.md\n\n' +
+				'# 2. Post a line-level comment on src/retry.ts line 88\n' +
+				'gh api repos/acme/app/pulls/42/comments \\\n' +
+				'  -f body="This branch swallows the error — re-throw after logging." \\\n' +
+				'  -f commit_id="$(gh pr view 42 --json headRefOid -q .headRefOid)" \\\n' +
+				'  -f path="src/retry.ts" -F line=88\n' +
+				'```\n\n' +
+				'Review the code thoroughly, then post your findings to GitHub using the commands above ' +
+				'BEFORE summarizing or handing off. If satisfied, `--approve` is sufficient; if changes are ' +
+				'needed, use `--request-changes` and add line-level comments for each issue.'
 		);
+	});
+
+	it('Reviewer custom prompt requires posting to GitHub via gh pr review', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const reviewer = seeded.find((a) => a.name === 'Reviewer')!;
+		// The whole point of the hardened reviewer loop: reviews must land on the PR.
+		expect(reviewer.customPrompt).toContain('gh pr review');
+		expect(reviewer.customPrompt).toContain('gh api repos/');
+		expect(reviewer.customPrompt).toContain('--body-file');
+		// An internal summary alone is not enough — this must be explicit.
+		expect(reviewer.customPrompt).toContain('posted to GitHub');
 	});
 
 	it('QA has exact custom prompt', async () => {

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -118,10 +118,12 @@ describe('CODING_WORKFLOW template', () => {
 		expect(ch!.maxCycles).toBeUndefined();
 	});
 
-	test('Review → Coding channel is ungated with maxCycles', () => {
+	test('Review → Coding channel is gated by review-posted-gate with maxCycles', () => {
 		const ch = CODING_WORKFLOW.channels!.find((c) => c.from === 'Review' && c.to === 'Coding');
 		expect(ch).toBeDefined();
-		expect(ch!.gateId).toBeUndefined();
+		// The review-posted-gate closes the feedback-loop gap where the reviewer
+		// summarizes feedback internally without posting to GitHub.
+		expect(ch!.gateId).toBe('review-posted-gate');
 		// direction field removed from WorkflowChannel
 		expect(ch!.maxCycles).toBe(5);
 	});
@@ -140,11 +142,43 @@ describe('CODING_WORKFLOW template', () => {
 		}
 	});
 
-	test('has one gate with one field', () => {
-		expect(CODING_WORKFLOW.gates).toHaveLength(1);
-		const gate = CODING_WORKFLOW.gates![0];
-		expect(gate.id).toBe('code-ready-gate');
-		expect(gate.fields).toHaveLength(1);
+	test('has two gates: code-ready-gate and review-posted-gate', () => {
+		expect(CODING_WORKFLOW.gates).toHaveLength(2);
+		const gateIds = CODING_WORKFLOW.gates!.map((g) => g.id).sort();
+		expect(gateIds).toEqual(['code-ready-gate', 'review-posted-gate']);
+		for (const gate of CODING_WORKFLOW.gates!) {
+			expect(gate.fields).toHaveLength(1);
+		}
+	});
+
+	test('review-posted-gate has review_url field writable only by reviewer', () => {
+		const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
+		const field = gate.fields.find((f) => f.name === 'review_url')!;
+		expect(field.type).toBe('string');
+		expect(field.writers).toEqual(['reviewer']);
+		expect(field.check.op).toBe('exists');
+	});
+
+	test('review-posted-gate has bash script verifying a review submitted after workflow start', () => {
+		const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
+		expect(gate.script).toBeDefined();
+		expect(gate.script!.interpreter).toBe('bash');
+		expect(gate.script!.timeoutMs).toBe(30000);
+		// The script must consult the workflow start timestamp injected by the runner.
+		expect(gate.script!.source).toContain('NEOKAI_WORKFLOW_START_ISO');
+		// And query GitHub for the reviews list via the PR URL.
+		expect(gate.script!.source).toContain('gh pr view "$PR_URL" --json reviews');
+		expect(gate.script!.source).toContain('submittedAt');
+		// Must fail loudly when no review has landed since start.
+		expect(gate.script!.source).toContain('exit 1');
+		// Must echo pr_url/review_count on success for downstream consumers.
+		expect(gate.script!.source).toContain('pr_url');
+		expect(gate.script!.source).toContain('review_count');
+	});
+
+	test('review-posted-gate resets on cycle so each feedback round is re-verified', () => {
+		const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
+		expect(gate.resetOnCycle).toBe(true);
 	});
 
 	test('code-ready-gate has pr_url field writable only by Coding', () => {
@@ -804,7 +838,7 @@ describe('seedBuiltInWorkflows()', () => {
 		expect(wf!.nodes[1].agents[0]?.agentId).toBe(roleMap.reviewer);
 	});
 
-	test('CODING_WORKFLOW seeded with two channels (gated Coding→Review, ungated Review→Coding)', async () => {
+	test('CODING_WORKFLOW seeded with two channels (gated Coding→Review, gated Review→Coding)', async () => {
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
 		expect(wf.channels).toHaveLength(2);
@@ -815,16 +849,18 @@ describe('seedBuiltInWorkflows()', () => {
 
 		const reviewToCode = wf.channels!.find((c) => c.from === 'Review' && c.to === 'Coding');
 		expect(reviewToCode).toBeDefined();
-		expect(reviewToCode!.gateId).toBeUndefined();
+		// Review → Coding is now gated by review-posted-gate so the reviewer's
+		// message cannot be delivered until a GitHub review is visible.
+		expect(reviewToCode!.gateId).toBe('review-posted-gate');
 		expect(reviewToCode!.maxCycles).toBe(5);
 	});
 
-	test('CODING_WORKFLOW seeded with one gate (code-ready-gate)', async () => {
+	test('CODING_WORKFLOW seeded with two gates (code-ready-gate + review-posted-gate)', async () => {
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
-		expect(wf.gates).toHaveLength(1);
-		const gateIds = wf.gates!.map((g) => g.id);
-		expect(gateIds).toContain('code-ready-gate');
+		expect(wf.gates).toHaveLength(2);
+		const gateIds = wf.gates!.map((g) => g.id).sort();
+		expect(gateIds).toEqual(['code-ready-gate', 'review-posted-gate']);
 	});
 
 	test('CODING_WORKFLOW seeded channels all have direction one-way', async () => {
@@ -1745,11 +1781,48 @@ describe('CODING_WORKFLOW agent slot customPrompt', () => {
 		expect(coder.customPrompt?.value.trim().length).toBeGreaterThan(0);
 	});
 
+	test('Coding node coder customPrompt teaches inline reply via gh api when re-activated', () => {
+		const codeNode = CODING_WORKFLOW.nodes.find((n) => n.name === 'Coding')!;
+		const coder = codeNode.agents[0];
+		const prompt = coder.customPrompt!.value;
+		// The coder must be told where to find the review links on re-activation
+		// and how to reply inline so each GitHub thread gets a visible response.
+		expect(prompt).toContain('review_url');
+		expect(prompt).toContain('comment_urls');
+		expect(prompt).toContain('/replies');
+	});
+
 	test('Review node reviewer has non-empty customPrompt', () => {
 		const reviewNode = CODING_WORKFLOW.nodes.find((n) => n.name === 'Review')!;
 		const reviewer = reviewNode.agents[0];
 		expect(reviewer.customPrompt?.value).toBeDefined();
 		expect(reviewer.customPrompt?.value).toContain('report_result');
+	});
+
+	test('Review node reviewer customPrompt requires posting to GitHub and echoing review_url', () => {
+		const reviewNode = CODING_WORKFLOW.nodes.find((n) => n.name === 'Review')!;
+		const reviewer = reviewNode.agents[0];
+		const prompt = reviewer.customPrompt!.value;
+		// Reviewer must post to GitHub via gh pr review / gh api.
+		expect(prompt).toContain('gh pr review');
+		expect(prompt).toContain('gh api');
+		// And on the changes-requested path, send_message to Coding must carry
+		// the review URL + comment URLs so the coder can reply inline.
+		expect(prompt).toContain('review_url');
+		expect(prompt).toContain('comment_urls');
+		// The gate name must be mentioned so the reviewer understands the contract.
+		expect(prompt).toContain('review-posted-gate');
+	});
+});
+
+describe('REVIEW_ONLY_WORKFLOW reviewer customPrompt requires gh pr review before report_result', () => {
+	test('reviewer prompt mandates gh pr review before handoff', () => {
+		const agent = REVIEW_ONLY_WORKFLOW.nodes[0].agents[0];
+		const prompt = agent.customPrompt!.value;
+		expect(prompt).toContain('gh pr review');
+		expect(prompt).toContain('report_result');
+		// The ordering matters: post BEFORE calling report_result.
+		expect(prompt).toMatch(/post.*before|BEFORE calling.*report_result/i);
 	});
 });
 


### PR DESCRIPTION
Closes the feedback-loop gap surfaced by PR #1514, where a full reviewer run produced zero GitHub reviews/comments because the reviewer summarized internally and never called `gh pr review`.

## What changed
- **Reviewer base prompt** (`seed-agents.ts`) mandates `gh pr review <url> --body-file <file>` + `gh api repos/{owner}/{repo}/pulls/{n}/comments`, with a worked example.
- **CODING_WORKFLOW reviewer slot** must `send_message` to Coding with `data: { pr_url, review_url, comment_urls }` after posting.
- **CODING_WORKFLOW coder slot** (on re-activation) reads `review_url` / `comment_urls` from the incoming message and replies inline via `gh api .../comments/{id}/replies`.
- **REVIEW_ONLY_WORKFLOW reviewer** must post to the PR before calling `report_result`.
- New **`review-posted-gate`** on the Review → Coding channel: a bash script queries `gh pr view --json reviews` and requires a review `submittedAt > NEOKAI_WORKFLOW_START_ISO`, so the runtime refuses to deliver the coder-ping until the review is actually visible on GitHub.
- **Runtime**: `GateScriptContext.workflowStartIso` → `NEOKAI_WORKFLOW_START_ISO` env var, sourced from `workflowRun.createdAt`. Agents cannot spoof it.
- **Multi-round audit trail**: every reviewer write to `review-posted-gate` appends a `workflow_run_artifacts` row (`type=review`, `artifactKey=cycle-N`) carrying `review_url`, `cycle`, `submittedAt`, `comment_urls`.

## Test plan
- [x] `bun test tests/unit/5-space/other/seed-agents.test.ts` — new assertion that the Reviewer prompt requires `gh pr review`
- [x] `bun test tests/unit/5-space/workflow/built-in-workflows.test.ts` — CODING_WORKFLOW now has 2 gates; Review→Coding is gated by `review-posted-gate`; reviewer/coder slots carry the new payload contract
- [x] `bun test tests/unit/5-space/other/gate-script-executor.test.ts` — `NEOKAI_WORKFLOW_START_ISO` injection + anti-spoof
- [x] `bun test tests/unit/5-space/agent/node-agent-tools.test.ts` — 3 rounds → 3 artifacts with cycles 0/1/2 and unique artifact keys; skipped when `review_url` absent or gate id differs
- [x] Full daemon suite: `./scripts/test-daemon.sh` — 11100/11101 pass (one pre-existing skip unrelated)
- [x] `bun run check` — lint + typecheck + knip clean