### PR TITLE
feat(space): report_result result-only; completion pipeline decides terminal status

### DIFF
--- a/docs/design/autonomy-levels-and-completion-actions.md
+++ b/docs/design/autonomy-levels-and-completion-actions.md
@@ -127,8 +127,9 @@ interface ScriptCompletionAction extends CompletionAction {
 
 interface InstructionCompletionAction extends CompletionAction {
   type: 'instruction';
-  targetNodeId: string;           // which node agent receives the instruction
+  agentName: string;              // name of the SpaceAgent that will execute the instruction
   instruction: string;            // supports {{artifact.field}} templates
+  timeoutMs?: number;             // default 120000 — max time to wait for the verifier agent
 }
 
 interface McpCallCompletionAction extends CompletionAction {
@@ -136,8 +137,21 @@ interface McpCallCompletionAction extends CompletionAction {
   server: string;                 // MCP server name (must be enabled in space skills)
   tool: string;                   // tool name on that server
   args: Record<string, string>;   // supports {{artifact.field}} templates
+  expect?: McpCallExpectation;    // optional assertion applied to the tool result
+}
+
+interface McpCallExpectation {
+  path: string;                   // dot/bracket accessor into the result (e.g. 'data.items[0].status')
+  op: 'eq' | 'neq' | 'contains' | 'exists' | 'truthy';
+  value?: unknown;                // required for eq/neq/contains, ignored for exists/truthy
 }
 ```
+
+**`instruction` executor.** The runtime resolves `agentName` to a SpaceAgent, spawns an ephemeral verification session bound to that agent, injects a `report_verification(pass, reason)` MCP tool, and sends `instruction` (template-interpolated from the resolved artifact) as the user message. The action completes when the agent calls `report_verification` — passing `true` makes the action succeed, `false` makes it fail with the supplied `reason`. If the agent does not call the tool within `timeoutMs` (default 120s), the action fails with reason `'timed out'`.
+
+**`mcp_call` executor.** The runtime invokes `tool` on `server` with `args`. If `expect` is provided, the `path`/`op`/`value` assertion is applied to the tool's JSON result; a failing assertion fails the action with a descriptive reason (e.g. `'expected "state" to equal "MERGED", got "OPEN"'`). Any thrown error from the tool invocation fails the action with the error's message.
+
+Both executors are **dependency-injected** into `SpaceRuntime` via `SpaceRuntimeConfig.instructionActionExecutor` and `SpaceRuntimeConfig.mcpToolExecutor`. When an executor is not configured, the corresponding action type fails with a configuration error rather than silently succeeding — the runtime refuses to skip a human-authored verification step.
 
 Three action types cover the spectrum of complexity:
 
@@ -146,6 +160,32 @@ Three action types cover the spectrum of complexity:
 | `script` | CLI commands (`gh pr merge`, `npm publish`) | Yes | No |
 | `mcp_call` | External service calls (Slack, JIRA, deploy tools) | Yes | No |
 | `instruction` | Complex reasoning tasks (write release notes, analyze test results) | No | Yes |
+
+### 2c. `report_result`: agents report outcomes, runtime decides status
+
+Agents signal task completion by calling the `report_result` MCP tool. Stage-2 tightens this tool's contract so that agents can no longer self-certify terminal status:
+
+```typescript
+report_result({
+  summary: string,                 // human-readable summary of what was done
+  evidence?: {                     // optional structured evidence
+    prUrl?: string,
+    commitSha?: string,
+    testOutput?: string,
+    // ...additional keys allowed via passthrough
+  },
+})
+```
+
+The Zod schema is `.strict()` — passing a `status` or `error` field is a **validation error**, not silently accepted. This is enforced at both the Task Agent and Node Agent `report_result` surfaces (`task-agent-tool-schemas.ts`, `node-agent-tools.ts`).
+
+**The completion-action pipeline is the sole arbiter of terminal task status.** When a `report_result` call is recorded:
+
+1. The runtime sets `task.reportedStatus = 'done'` and stores the agent's summary (+ serialized evidence block) on `task.reportedSummary`.
+2. `CompletionDetector` fires on the `reportedStatus` change and triggers `resolveCompletionWithActions()`.
+3. The completion actions on the end node run in order. Their collective outcome decides whether the task ends `done` (all actions passed), pauses at `review` (an action requires human approval), or ends `blocked` (an action failed).
+
+Notably, **the runtime does NOT read `reportedStatus` to decide terminal status anymore** — it only uses it as a trigger. Legacy values like `reportedStatus='blocked'` or `'cancelled'` written by older code paths do NOT short-circuit the pipeline. This closes the "agent lies" gap: an agent claiming "I merged the PR" cannot mark the task `done` — the `VERIFY_PR_MERGED` completion action on the workflow's QA end node runs regardless and will fail the task if the PR is still open.
 
 ### 3. Execution Flow
 

--- a/packages/daemon/src/lib/space/agents/task-agent.ts
+++ b/packages/daemon/src/lib/space/agents/task-agent.ts
@@ -182,8 +182,10 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 	);
 	sections.push('');
 	sections.push(
-		`- **report_result** — Mark the task as completed or failed and record a result summary. ` +
-			`Pass \`status\` (\`done\`, \`blocked\`, or \`cancelled\`) and a \`summary\` string. ` +
+		`- **report_result** — Record the final result of the task. Pass a \`summary\` string and ` +
+			`optional structured \`evidence\` (\`prUrl\`, \`commitSha\`, \`testOutput\`, …). ` +
+			`Do NOT pass a \`status\` — the runtime decides the terminal task status by running the ` +
+			`completion-action pipeline on the end node. ` +
 			`Call this when the workflow reaches an unrecoverable error or you need to cancel. ` +
 			`Workflow completion is automatic — it triggers when the end node's session completes.`
 	);
@@ -240,8 +242,9 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 			`call any completion tool — just wait for the \`[NODE_COMPLETE]\` event from the end node. ` +
 			`Use \`list_group_members\` to verify all agents have reached idle status if needed. ` +
 			`Only call \`report_result\` if you need to cancel or signal an unrecoverable error.\n` +
-			`6. **Handle errors** — If a node agent errors, call \`report_result\` with ` +
-			`\`status: "cancelled"\` and the error details.`
+			`6. **Handle errors** — If a node agent errors, call \`report_result\` with a \`summary\` ` +
+			`describing what went wrong. The runtime will classify the task based on the ` +
+			`completion-action pipeline; you do not control the final status.`
 	);
 
 	// ---- Human gate handling -------------------------------------------------

--- a/packages/daemon/src/lib/space/runtime/completion-action-executors.ts
+++ b/packages/daemon/src/lib/space/runtime/completion-action-executors.ts
@@ -1,0 +1,285 @@
+/**
+ * Completion Action Executors
+ *
+ * Runtime-injected executors for the non-script variants of
+ * `CompletionAction`. The `SpaceRuntime` takes these via config so that:
+ *   - Tests can substitute deterministic stubs without standing up the full
+ *     agent SDK or an MCP server.
+ *   - Production wires the real executors (LLM-backed instruction verifier
+ *     and MCP client) once during `createDaemonApp`.
+ *
+ * Two action types are supported here:
+ *
+ *   1. **`instruction`** — spawn a short-lived agent session bound to
+ *      `action.agentName`, hand it `action.instruction`, and wait for it to
+ *      call `report_verification(pass, reason)`. Bounded by `action.timeoutMs`
+ *      (the production executor applies a default of 120_000 ms when unset).
+ *
+ *   2. **`mcp_call`** — invoke the MCP tool `action.tool` on server
+ *      `action.server` with `action.args`, then apply the optional
+ *      `action.expect` assertion to the result.
+ *
+ * Both executors return a uniform `CompletionActionExecutionResult` — a
+ * success flag plus an optional `reason` string for audit logging and the
+ * task's structured failure message.
+ */
+
+import type {
+	InstructionCompletionAction,
+	McpCallCompletionAction,
+	McpCallExpectation,
+} from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Result shape shared by all executors (script/instruction/mcp_call)
+// ---------------------------------------------------------------------------
+
+export interface CompletionActionExecutionResult {
+	/** Did the action succeed (verifier passed / assertion matched)? */
+	success: boolean;
+	/** Human-readable reason — shown in task result on failure, audit-logged on success. */
+	reason?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Instruction executor
+// ---------------------------------------------------------------------------
+
+export interface InstructionExecutorContext {
+	spaceId: string;
+	runId: string;
+	workspacePath: string;
+	artifactData: Record<string, unknown>;
+}
+
+/**
+ * Runs an `instruction` completion action. Implementations should:
+ *
+ *   1. Resolve `action.agentName` to a SpaceAgent.
+ *   2. Start an ephemeral session with that agent, injecting a
+ *      `report_verification(pass: boolean, reason: string)` MCP tool.
+ *   3. Send `action.instruction` (template-interpolated if applicable) as the
+ *      user message.
+ *   4. Resolve once the agent calls `report_verification`, or the timeout
+ *      elapses (→ `{ success: false, reason: 'timed out' }`).
+ */
+export type InstructionActionExecutor = (
+	action: InstructionCompletionAction,
+	ctx: InstructionExecutorContext
+) => Promise<CompletionActionExecutionResult>;
+
+// ---------------------------------------------------------------------------
+// MCP-call executor
+// ---------------------------------------------------------------------------
+
+export interface McpCallExecutorContext {
+	spaceId: string;
+	runId: string;
+	workspacePath: string;
+	artifactData: Record<string, unknown>;
+}
+
+/**
+ * Invokes an MCP tool. Returns the tool's raw result so the caller can apply
+ * the optional `expect` assertion — separation lets us unit-test assertions
+ * against a fake tool result without mocking the whole MCP transport.
+ */
+export type McpToolExecutor = (
+	action: McpCallCompletionAction,
+	ctx: McpCallExecutorContext
+) => Promise<unknown>;
+
+// ---------------------------------------------------------------------------
+// Assertion evaluation — applied to `mcp_call.result` when `expect` is set
+// ---------------------------------------------------------------------------
+
+/**
+ * Navigate into a value using a dot/bracket accessor path.
+ * `''` returns the root value. Missing segments yield `undefined`.
+ *
+ * Supports:
+ *   - Dot access: `data.items.status`
+ *   - Bracket access: `data.items[0]`, `data['foo bar']`
+ */
+export function accessByPath(root: unknown, path: string): unknown {
+	if (!path) return root;
+
+	// Parse path into segments respecting dots, [n] and ['...'] notations.
+	const segments: string[] = [];
+	let i = 0;
+	let buf = '';
+	while (i < path.length) {
+		const ch = path[i];
+		if (ch === '.') {
+			if (buf) {
+				segments.push(buf);
+				buf = '';
+			}
+			i++;
+			continue;
+		}
+		if (ch === '[') {
+			if (buf) {
+				segments.push(buf);
+				buf = '';
+			}
+			const end = path.indexOf(']', i + 1);
+			if (end === -1) {
+				// Malformed — treat remainder as literal
+				buf = path.slice(i);
+				break;
+			}
+			let key = path.slice(i + 1, end);
+			// Strip surrounding quotes if present (single or double)
+			if (
+				(key.startsWith('"') && key.endsWith('"')) ||
+				(key.startsWith("'") && key.endsWith("'"))
+			) {
+				key = key.slice(1, -1);
+			}
+			segments.push(key);
+			i = end + 1;
+			continue;
+		}
+		buf += ch;
+		i++;
+	}
+	if (buf) segments.push(buf);
+
+	let cursor: unknown = root;
+	for (const seg of segments) {
+		if (cursor == null) return undefined;
+		if (Array.isArray(cursor)) {
+			const n = Number(seg);
+			cursor = Number.isInteger(n) ? cursor[n] : undefined;
+			continue;
+		}
+		if (typeof cursor === 'object') {
+			cursor = (cursor as Record<string, unknown>)[seg];
+			continue;
+		}
+		return undefined;
+	}
+	return cursor;
+}
+
+/**
+ * Apply an `expect` assertion to the result of an MCP call.
+ *
+ * `eq`/`neq` use deep equality via JSON serialization — sufficient for plain
+ * primitives / arrays / objects of primitives, which is the only shape MCP
+ * tool results are practically expected to contain for a verifier.
+ *
+ * `contains` works against either strings (substring) or arrays (element
+ * membership via JSON equality).
+ *
+ * `exists` passes when the path resolves to anything other than `undefined`.
+ *
+ * `truthy` passes when the resolved value is JavaScript-truthy.
+ */
+export function evaluateMcpExpectation(
+	result: unknown,
+	expectation: McpCallExpectation
+): CompletionActionExecutionResult {
+	const actual = accessByPath(result, expectation.path);
+
+	switch (expectation.op) {
+		case 'exists':
+			return actual !== undefined
+				? { success: true }
+				: {
+						success: false,
+						reason: `expected path "${expectation.path}" to exist, got undefined`,
+					};
+		case 'truthy':
+			return actual
+				? { success: true }
+				: {
+						success: false,
+						reason: `expected path "${expectation.path}" to be truthy, got ${describe(actual)}`,
+					};
+		case 'eq':
+			return deepEqual(actual, expectation.value)
+				? { success: true }
+				: {
+						success: false,
+						reason: `expected "${expectation.path}" to equal ${describe(expectation.value)}, got ${describe(actual)}`,
+					};
+		case 'neq':
+			return !deepEqual(actual, expectation.value)
+				? { success: true }
+				: {
+						success: false,
+						reason: `expected "${expectation.path}" not to equal ${describe(expectation.value)}`,
+					};
+		case 'contains':
+			return containsValue(actual, expectation.value)
+				? { success: true }
+				: {
+						success: false,
+						reason: `expected "${expectation.path}" to contain ${describe(expectation.value)}, got ${describe(actual)}`,
+					};
+		default: {
+			// Exhaustiveness: McpCallExpectation.op is a closed union — adding a
+			// new variant without a case is a type error here.
+			const _never: never = expectation.op;
+			void _never;
+			return { success: false, reason: `unknown expect op: ${String(expectation.op)}` };
+		}
+	}
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+	if (a === b) return true;
+	try {
+		return JSON.stringify(a) === JSON.stringify(b);
+	} catch {
+		return false;
+	}
+}
+
+function containsValue(container: unknown, needle: unknown): boolean {
+	if (typeof container === 'string') {
+		return typeof needle === 'string' && container.includes(needle);
+	}
+	if (Array.isArray(container)) {
+		return container.some((item) => deepEqual(item, needle));
+	}
+	return false;
+}
+
+function describe(v: unknown): string {
+	if (v === undefined) return 'undefined';
+	try {
+		return JSON.stringify(v);
+	} catch {
+		return String(v);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// `mcp_call` action runner — combines the tool executor + assertion
+// ---------------------------------------------------------------------------
+
+/**
+ * Run an `mcp_call` action: invoke the tool then apply the optional `expect`.
+ * No assertion → any non-throwing tool call is success. A throwing tool call
+ * is always a failure and surfaces the error message in `reason`.
+ */
+export async function runMcpCallAction(
+	action: McpCallCompletionAction,
+	ctx: McpCallExecutorContext,
+	executor: McpToolExecutor
+): Promise<CompletionActionExecutionResult> {
+	let result: unknown;
+	try {
+		result = await executor(action, ctx);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return { success: false, reason: `mcp_call "${action.tool}" failed: ${message}` };
+	}
+	if (!action.expect) {
+		return { success: true };
+	}
+	return evaluateMcpExpectation(result, action.expect);
+}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -23,7 +23,6 @@ import type { Database as BunDatabase } from 'bun:sqlite';
 import type {
 	CompletionAction,
 	SpaceAutonomyLevel,
-	SpaceReportedStatus,
 	SpaceTask,
 	UpdateSpaceTaskParams,
 	SpaceWorkflow,
@@ -49,6 +48,12 @@ import { type NotificationSink, NullNotificationSink } from './notification-sink
 import { buildRestrictedEnv, collectWithMaxBuffer, MAX_BUFFER_BYTES } from './gate-script-executor';
 import { CompletionDetector } from './completion-detector';
 import type { SelectWorkflowWithLlm } from './llm-workflow-selector';
+import {
+	type CompletionActionExecutionResult,
+	type InstructionActionExecutor,
+	type McpToolExecutor,
+	runMcpCallAction,
+} from './completion-action-executors';
 import {
 	MAX_BLOCKED_RUN_RETRIES,
 	MAX_TASK_AGENT_CRASH_RETRIES,
@@ -161,6 +166,19 @@ export interface SpaceRuntimeConfig {
 	 * `selectWorkflowWithLlmDefault` from `./llm-workflow-selector`.
 	 */
 	selectWorkflowWithLlm?: SelectWorkflowWithLlm;
+	/**
+	 * Optional executor for `instruction` completion actions. Spawns an
+	 * ephemeral agent session to verify an outcome. When not provided,
+	 * instruction actions fail with a configuration error — the runtime
+	 * refuses to silently skip a human-authored verification step.
+	 */
+	instructionActionExecutor?: InstructionActionExecutor;
+	/**
+	 * Optional executor for `mcp_call` completion actions. Invokes the named
+	 * tool on the named MCP server. When not provided, mcp_call actions fail
+	 * with a configuration error.
+	 */
+	mcpToolExecutor?: McpToolExecutor;
 }
 
 interface StartWorkflowRunOptions {
@@ -567,12 +585,12 @@ export class SpaceRuntime {
 				canonicalTask.status !== 'review' &&
 				canonicalTask.status !== 'cancelled'
 			) {
-				const reportedStatus = canonicalTask.reportedStatus ?? 'done';
+				// The completion-action pipeline is the sole arbiter of terminal
+				// status — we no longer read `reportedStatus` from the agent.
 				const params = await this.resolveCompletionWithActions(
 					run.spaceId,
 					run.id,
 					workflow,
-					reportedStatus,
 					nextResult,
 					spaceLevel,
 					canonicalTask.id
@@ -958,11 +976,16 @@ export class SpaceRuntime {
 			const action = actions[i];
 			if (i === startIndex || spaceLevel >= action.requiredLevel) {
 				// First action was human-approved; subsequent ones auto-execute if autonomy permits
-				const ok = await this.executeCompletionAction(action, spaceId, run.id, space.workspacePath);
-				if (!ok) {
+				const result = await this.executeCompletionAction(
+					action,
+					spaceId,
+					run.id,
+					space.workspacePath
+				);
+				if (!result.success) {
 					return await this.finalizeResume(spaceId, taskId, {
 						status: 'blocked',
-						result: `Completion action "${action.name}" failed`,
+						result: result.reason ?? `Completion action "${action.name}" failed`,
 					});
 				}
 				// Emit audit-trail event for each successfully executed action. This
@@ -1488,16 +1511,14 @@ export class SpaceRuntime {
 				let finalTaskStatus: SpaceTask['status'] = canonicalTask.status;
 
 				if (!taskAlreadyResolved) {
-					// Resolve final status using the agent's reported intent as the base.
-					// Defaults to 'done' when the agent did not report (legacy/fallback path);
-					// the runtime never auto-completes without a reported intent in the new
-					// model, but we tolerate the missing-report case for safety.
-					const reportedStatus = canonicalTask.reportedStatus ?? 'done';
+					// The completion-action pipeline is the sole arbiter of terminal
+					// status. The agent's `report_result` only records a summary +
+					// optional evidence on `reportedSummary`; terminal status is
+					// decided entirely by the outcome of the actions below.
 					const params = await this.resolveCompletionWithActions(
 						meta.spaceId,
 						runId,
 						meta.workflow,
-						reportedStatus,
 						nextTaskResult,
 						spaceLevel,
 						canonicalTask.id
@@ -1794,6 +1815,11 @@ export class SpaceRuntime {
 	 * Resolve the task completion status, executing completion actions if the
 	 * end node defines them.
 	 *
+	 * The completion-action pipeline is the **sole arbiter** of terminal task
+	 * status. The agent's `report_result` only records a summary + optional
+	 * evidence; whether the task ends `done` / `needs_attention` / `blocked`
+	 * is decided entirely by the outcomes of the actions below.
+	 *
 	 * Flow:
 	 * 1. If the end node has no completionActions → fall back to binary autonomy check.
 	 * 2. For each action in definition order:
@@ -1809,31 +1835,10 @@ export class SpaceRuntime {
 		spaceId: string,
 		runId: string,
 		workflow: SpaceWorkflow | null,
-		reportedStatus: SpaceReportedStatus,
 		taskResult: string | null,
 		spaceLevel: SpaceAutonomyLevel,
 		taskId: string
 	): Promise<UpdateSpaceTaskParams> {
-		// Non-success outcomes pass through directly. Completion actions are a
-		// success-path review gate ("flip to done after verifying X"); they
-		// don't apply when the agent reported `blocked` or `cancelled`.
-		if (reportedStatus === 'blocked') {
-			return {
-				status: 'blocked' as const,
-				result: taskResult,
-				blockReason: 'execution_failed',
-				completedAt: Date.now(),
-			};
-		}
-		if (reportedStatus === 'cancelled') {
-			return {
-				status: 'cancelled' as const,
-				result: taskResult,
-				completedAt: Date.now(),
-			};
-		}
-
-		// reportedStatus === 'done' — run the success-path review gate.
 		// Find end node's completion actions
 		const endNode = workflow?.nodes.find((n) => n.id === workflow.endNodeId);
 		const actions = endNode?.completionActions;
@@ -1875,11 +1880,11 @@ export class SpaceRuntime {
 			const action = actions[i];
 			if (spaceLevel >= action.requiredLevel) {
 				// Auto-execute
-				const ok = await this.executeCompletionAction(action, spaceId, runId, workspacePath);
-				if (!ok) {
+				const result = await this.executeCompletionAction(action, spaceId, runId, workspacePath);
+				if (!result.success) {
 					return {
 						status: 'blocked' as const,
-						result: `Completion action "${action.name}" failed`,
+						result: result.reason ?? `Completion action "${action.name}" failed`,
 					};
 				}
 				// Emit audit-trail event for the auto-executed action. Mirrors the
@@ -1980,37 +1985,127 @@ export class SpaceRuntime {
 	/**
 	 * Execute a single completion action.
 	 *
-	 * Currently supports `script` type only. `instruction` and `mcp_call` types
-	 * log a warning and are skipped (future implementation).
+	 * Dispatches by `action.type`:
+	 *   - `script`       → inline bash executor
+	 *   - `instruction`  → `config.instructionActionExecutor` (injected)
+	 *   - `mcp_call`     → `config.mcpToolExecutor` (injected) + `expect` assertion
+	 *
+	 * The `switch` is exhaustive — adding a new `CompletionAction` variant to
+	 * the shared type without a case here is a compile-time error (the
+	 * `never` check at the bottom of the switch guarantees this).
+	 *
+	 * Every path returns a `CompletionActionExecutionResult` — failures carry
+	 * a human-readable `reason` so the task's `result` field is descriptive.
 	 */
 	private async executeCompletionAction(
 		action: CompletionAction,
 		spaceId: string,
 		runId: string,
 		workspacePath: string
-	): Promise<boolean> {
-		if (action.type !== 'script') {
-			log.warn(
-				`SpaceRuntime: completion action type "${action.type}" not yet implemented ` +
-					`(action: ${action.id}, space: ${spaceId}); treating as success`
-			);
-			return true;
-		}
+	): Promise<CompletionActionExecutionResult> {
+		const artifactData = this.resolveArtifactData(action, runId);
 
-		// Resolve artifact data for script env injection
-		let artifactData: Record<string, unknown> = {};
-		if (action.artifactType && this.config.artifactRepo) {
-			const artifacts = this.config.artifactRepo.listByRun(runId, {
-				artifactType: action.artifactType,
-			});
-			if (action.artifactKey) {
-				const match = artifacts.find((a) => a.artifactKey === action.artifactKey);
-				if (match) artifactData = match.data;
-			} else if (artifacts.length > 0) {
-				artifactData = artifacts[0].data;
+		switch (action.type) {
+			case 'script':
+				return this.executeScriptCompletionAction(
+					action,
+					spaceId,
+					runId,
+					workspacePath,
+					artifactData
+				);
+			case 'instruction': {
+				const executor = this.config.instructionActionExecutor;
+				if (!executor) {
+					const reason =
+						'instruction completion action is not supported: no instructionActionExecutor configured';
+					log.warn(`SpaceRuntime: ${reason} (action: ${action.id}, space: ${spaceId})`);
+					return { success: false, reason };
+				}
+				try {
+					log.info(
+						`SpaceRuntime: executing instruction completion action "${action.name}" (${action.id}) ` +
+							`for space ${spaceId}, run ${runId} → agent "${action.agentName}"`
+					);
+					const result = await executor(action, {
+						spaceId,
+						runId,
+						workspacePath,
+						artifactData,
+					});
+					if (!result.success) {
+						log.warn(
+							`SpaceRuntime: instruction action "${action.name}" verification failed: ` +
+								`${result.reason ?? '(no reason provided)'}`
+						);
+					}
+					return result;
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err);
+					log.warn(`SpaceRuntime: instruction action "${action.name}" threw: ${message}`);
+					return { success: false, reason: `instruction executor threw: ${message}` };
+				}
+			}
+			case 'mcp_call': {
+				const executor = this.config.mcpToolExecutor;
+				if (!executor) {
+					const reason =
+						'mcp_call completion action is not supported: no mcpToolExecutor configured';
+					log.warn(`SpaceRuntime: ${reason} (action: ${action.id}, space: ${spaceId})`);
+					return { success: false, reason };
+				}
+				log.info(
+					`SpaceRuntime: executing mcp_call completion action "${action.name}" (${action.id}) ` +
+						`for space ${spaceId}, run ${runId} → ${action.server}.${action.tool}`
+				);
+				return await runMcpCallAction(
+					action,
+					{ spaceId, runId, workspacePath, artifactData },
+					executor
+				);
+			}
+			default: {
+				// Exhaustiveness guard — adding a new variant to CompletionAction
+				// without a case here is a type error. `void _never` silences the
+				// unused-var lint without changing runtime behavior.
+				const _never: never = action;
+				void _never;
+				return {
+					success: false,
+					reason: `unknown completion action type: ${String((action as { type?: string }).type)}`,
+				};
 			}
 		}
+	}
 
+	/**
+	 * Resolve artifact data for a completion action. Shared by all action
+	 * types so `instruction` and `mcp_call` executors can template-interpolate
+	 * against the same artifact shape that `script` actions consume via env.
+	 */
+	private resolveArtifactData(action: CompletionAction, runId: string): Record<string, unknown> {
+		if (!action.artifactType || !this.config.artifactRepo) return {};
+		const artifacts = this.config.artifactRepo.listByRun(runId, {
+			artifactType: action.artifactType,
+		});
+		if (action.artifactKey) {
+			const match = artifacts.find((a) => a.artifactKey === action.artifactKey);
+			return match?.data ?? {};
+		}
+		return artifacts[0]?.data ?? {};
+	}
+
+	/**
+	 * Execute a `script` completion action: spawn bash with a restricted env,
+	 * stream stdout/stderr with a maxBuffer, and honor a 2-minute SIGKILL timeout.
+	 */
+	private async executeScriptCompletionAction(
+		action: Extract<CompletionAction, { type: 'script' }>,
+		spaceId: string,
+		runId: string,
+		workspacePath: string,
+		artifactData: Record<string, unknown>
+	): Promise<CompletionActionExecutionResult> {
 		// Reuse gate script executor's restricted env builder.
 		// Pass a synthetic gateId — buildRestrictedEnv sets NEOKAI_GATE_ID from it,
 		// which we immediately override with the correct action-specific var.
@@ -2029,7 +2124,7 @@ export class SpaceRuntime {
 		}
 
 		log.info(
-			`SpaceRuntime: executing completion action "${action.name}" (${action.id}) ` +
+			`SpaceRuntime: executing script completion action "${action.name}" (${action.id}) ` +
 				`for space ${spaceId}, run ${runId}`
 		);
 
@@ -2058,25 +2153,26 @@ export class SpaceRuntime {
 			]);
 
 			if (exitResult.timedOut) {
-				log.warn(
-					`SpaceRuntime: completion action "${action.name}" timed out ` +
-						`after ${COMPLETION_ACTION_TIMEOUT_MS}ms`
-				);
-				return false;
-			} else if (exitResult.code !== 0) {
+				const reason = `script timed out after ${COMPLETION_ACTION_TIMEOUT_MS}ms`;
+				log.warn(`SpaceRuntime: completion action "${action.name}" ${reason}`);
+				return { success: false, reason: `${action.name}: ${reason}` };
+			}
+			if (exitResult.code !== 0) {
+				const stderrSnippet = stderrResult.text.trim().slice(0, 500);
 				log.warn(
 					`SpaceRuntime: completion action "${action.name}" failed ` +
-						`(exit ${exitResult.code}): ${stderrResult.text.trim().slice(0, 500)}`
+						`(exit ${exitResult.code}): ${stderrSnippet}`
 				);
-				return false;
+				return {
+					success: false,
+					reason: `${action.name}: script exited ${exitResult.code}${stderrSnippet ? ` — ${stderrSnippet}` : ''}`,
+				};
 			}
-			return true;
+			return { success: true };
 		} catch (err) {
-			log.warn(
-				`SpaceRuntime: completion action "${action.name}" error: ` +
-					`${err instanceof Error ? err.message : String(err)}`
-			);
-			return false;
+			const message = err instanceof Error ? err.message : String(err);
+			log.warn(`SpaceRuntime: completion action "${action.name}" error: ${message}`);
+			return { success: false, reason: `${action.name}: ${message}` };
 		}
 	}
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1711,7 +1711,7 @@ export class TaskAgentManager {
 			'  - send_message({ target, message, data? }) — communicate with peers; data is automatically written to the gate when the channel is gated',
 			'  - save({ summary?, data? }) — persist your output at any time (call multiple times as needed)',
 			isEndNode
-				? '  - report_result({ status, summary }) — YOU ARE THE END NODE: call this when the workflow is complete to close the run'
+				? '  - report_result({ summary, evidence? }) — YOU ARE THE END NODE: call this when the workflow is complete to close the run. Do NOT pass a status; the runtime decides the terminal state via completion actions.'
 				: null,
 			'Only contact the task-agent via send_message if you are blocked or need human input.',
 		]
@@ -1749,7 +1749,7 @@ export class TaskAgentManager {
 
 		if (isEndNode) {
 			lines.push(
-				'  - report_result({ status, summary }) — YOU ARE THE END NODE: call this when the workflow is complete'
+				'  - report_result({ summary, evidence? }) — YOU ARE THE END NODE: call this when the workflow is complete. Do NOT pass a status; the runtime decides the terminal state via completion actions. `evidence` is an optional object (prUrl, commitSha, testOutput, …) supporting your summary.'
 			);
 		}
 
@@ -1801,7 +1801,7 @@ export class TaskAgentManager {
 		);
 		if (isEndNode) {
 			lines.push(
-				'When your work is complete, call report_result({ status: "done", summary: "..." }) to close the workflow run.'
+				'When your work is complete, call report_result({ summary: "...", evidence: { prUrl?: "...", commitSha?: "...", testOutput?: "...", ... } }) to close the workflow run. Do NOT pass a `status` — the runtime runs completion actions to decide the terminal state.'
 			);
 		}
 		return lines.join('\n');
@@ -2455,24 +2455,32 @@ export class TaskAgentManager {
 				if (!task)
 					return jsonResult({ success: false, error: `Task not found: ${capturedTaskId}` });
 
+				// Serialize optional evidence into the summary so completion-action
+				// verifiers and downstream consumers can inspect it. The agent
+				// does NOT pass a status — the runtime always records `done` and
+				// lets the completion-action pipeline decide the terminal state.
+				const serializedSummary = args.evidence
+					? `${args.summary}\n\n<!-- evidence -->\n${JSON.stringify(args.evidence, null, 2)}`
+					: args.summary;
+
 				// Idempotency: if the agent re-invokes report_result with the same outcome
 				// (retry, double-call, etc.), skip the DB write and the broadcast — they
 				// would be no-ops that still wake every subscriber.
 				const successPayload = jsonResult({
 					success: true,
 					taskId: capturedTaskId,
-					status: args.status,
 					summary: args.summary,
-					message: `Result reported as "${args.status}". The runtime will resolve the final task status (supervised mode may pause for human approval).`,
+					message:
+						'Result recorded. The completion-action pipeline will determine the final task status (supervised mode may pause for human approval).',
 				});
-				if (task.reportedStatus === args.status && task.reportedSummary === args.summary) {
+				if (task.reportedStatus === 'done' && task.reportedSummary === serializedSummary) {
 					return successPayload;
 				}
 
 				try {
 					const updated = this.config.taskRepo.updateTask(capturedTaskId, {
-						reportedStatus: args.status,
-						reportedSummary: args.summary,
+						reportedStatus: 'done',
+						reportedSummary: serializedSummary,
 					});
 
 					if (this.config.daemonHub && updated) {

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -920,9 +920,10 @@ export function createNodeAgentMcpServer(config: NodeAgentToolsConfig) {
 			? [
 					tool(
 						'report_result',
-						'Mark the workflow as completed, failed, or cancelled and record the final result. ' +
+						'Record the final result of the workflow — the runtime decides the terminal status via completion actions. ' +
 							'Only available to the end node of the workflow. ' +
-							'Call this when the workflow has reached its terminal state.',
+							'Provide a human-readable summary and optional structured evidence (prUrl, commitSha, testOutput, …). ' +
+							'Do NOT pass a `status` — the completion-action pipeline is the sole arbiter of success/failure.',
 						ReportResultSchema.shape,
 						(args) => onReportResult(args)
 					),

--- a/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
@@ -25,10 +25,13 @@ import type { SpaceReportedStatus } from '@neokai/shared';
 // ---------------------------------------------------------------------------
 
 /**
- * Possible final statuses for a task result. Mirrors `SpaceReportedStatus`
- * (the shared type written to `space_tasks.reported_status`); the `satisfies`
- * clause locks the two together so adding a value to one without the other
- * fails to compile.
+ * Possible final statuses the runtime may assign to a task. Agents do NOT
+ * self-certify status — the completion-action pipeline is the sole arbiter.
+ * These values are only used internally by the runtime when resolving tasks.
+ *
+ * Mirrors `SpaceReportedStatus` (the shared type written to
+ * `space_tasks.reported_status`); the `satisfies` clause locks the two
+ * together so adding a value to one without the other fails to compile.
  */
 const TASK_RESULT_STATUS_VALUES = [
 	'done',
@@ -41,22 +44,39 @@ export const TaskResultStatusSchema = z.enum(TASK_RESULT_STATUS_VALUES);
 export type TaskResultStatus = SpaceReportedStatus;
 
 /**
- * Schema for `report_result` input.
- * Reports the final outcome of the task and closes the task lifecycle.
+ * Schema for `report_result` input (post-Stage-2).
+ *
+ * The agent reports only a human-readable summary plus optional structured
+ * evidence. The runtime — not the agent — decides the final task status via
+ * the completion-action pipeline. Passing a `status` field is a validation
+ * error (enforced by `.strict()`).
  */
-export const ReportResultSchema = z.object({
-	/** Final task status. */
-	status: TaskResultStatusSchema.describe(
-		"Final task status: 'done' (success), 'blocked' (human intervention required), or 'cancelled'"
-	),
-	/** Human-readable summary of what was accomplished or why it stopped. */
-	summary: z.string().describe('Human-readable summary of the task outcome'),
-	/** Optional error message when status is blocked or cancelled. */
-	error: z
-		.string()
-		.describe('Error details when the task ended in blocked state or was cancelled')
-		.optional(),
-});
+export const ReportResultSchema = z
+	.object({
+		/** Human-readable summary of what was accomplished. */
+		summary: z
+			.string()
+			.describe(
+				'Human-readable summary of what you did and the outcome. The runtime — not this summary — decides the final task status via completion actions.'
+			),
+		/** Optional structured evidence supporting the summary. */
+		evidence: z
+			.object({
+				/** URL of the pull request, if applicable. */
+				prUrl: z.string().describe('URL of the pull request, if applicable').optional(),
+				/** Commit SHA of the final change, if applicable. */
+				commitSha: z.string().describe('Commit SHA of the final change, if applicable').optional(),
+				/** Test output or validation snippet, if applicable. */
+				testOutput: z
+					.string()
+					.describe('Test output or validation snippet, if applicable')
+					.optional(),
+			})
+			.passthrough()
+			.describe('Optional structured evidence supporting your summary')
+			.optional(),
+	})
+	.strict();
 
 export type ReportResultInput = z.infer<typeof ReportResultSchema>;
 

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -223,40 +223,47 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		/**
 		 * Report the final outcome of the task and close the task lifecycle.
 		 *
-		 * Updates the main SpaceTask status to one of:
-		 *   completed        — task succeeded; summary records the result
-		 *   blocked          — task requires human intervention
-		 *   cancelled        — task was cancelled
+		 * The agent supplies only a summary + optional evidence. The runtime —
+		 * not this tool — decides the final task status via the completion-
+		 * action pipeline. Internally we mark the task as `done` so the
+		 * CompletionDetector picks it up; the pipeline may flip it to
+		 * `needs_attention` / `blocked` / etc. based on its actions.
 		 */
 		async report_result(args: ReportResultInput): Promise<ToolResult> {
-			const { status, summary } = args;
+			const { summary, evidence } = args;
 
 			const mainTask = taskRepo.getTask(taskId);
 			if (!mainTask) {
 				return jsonResult({ success: false, error: `Task not found: ${taskId}` });
 			}
 
+			// Serialize evidence into the summary so downstream consumers (PR
+			// reviewers, verification actions) can inspect it. The dedicated
+			// structured column is a Stage-3 concern.
+			const serializedSummary = evidence
+				? `${summary}\n\n<!-- evidence -->\n${JSON.stringify(evidence, null, 2)}`
+				: summary;
+
 			try {
-				await taskManager.setTaskStatus(taskId, status, {
-					result: summary,
-					...(status === 'blocked' ? { blockReason: 'execution_failed' as const } : {}),
+				await taskManager.setTaskStatus(taskId, 'done', {
+					result: serializedSummary,
 				});
 
-				// Emit DaemonHub event so the Space Agent is notified of task completion/failure.
+				// Emit DaemonHub event so the Space Agent is notified of task completion.
+				// Completion-action pipeline may later downgrade to `space.task.failed`.
 				if (daemonHub) {
 					const eventPayload = {
 						sessionId: 'global',
 						taskId,
 						spaceId: space.id,
-						status,
+						status: 'done' as const,
 						summary: summary ?? '',
 						workflowRunId,
 						taskTitle: mainTask.title,
 					};
-					const eventName = status === 'done' ? 'space.task.done' : 'space.task.failed';
-					void daemonHub.emit(eventName, eventPayload).catch((err) => {
+					void daemonHub.emit('space.task.done', eventPayload).catch((err) => {
 						log.warn(
-							`Failed to emit ${eventName} for task ${taskId}: ${err instanceof Error ? err.message : String(err)}`
+							`Failed to emit space.task.done for task ${taskId}: ${err instanceof Error ? err.message : String(err)}`
 						);
 					});
 				}
@@ -264,9 +271,9 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				return jsonResult({
 					success: true,
 					taskId,
-					status,
 					summary,
-					message: `Task has been marked as "${status}". The task lifecycle is now closed.`,
+					message:
+						'Result recorded. The completion-action pipeline will determine the final task status.',
 				});
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -179,6 +179,94 @@ const MERGE_PR_COMPLETION_ACTION: CompletionAction = {
 	script: PR_MERGE_BASH_SCRIPT,
 };
 
+/**
+ * Verifies the PR associated with the end-node is actually merged on GitHub.
+ * Used by QA workflows where the agent is expected to run `gh pr merge` itself
+ * — this action double-checks that the merge actually happened so the agent
+ * cannot "lie" about completion.
+ *
+ * Exits 0 on merged, non-zero with a descriptive message otherwise.
+ */
+const VERIFY_PR_MERGED_BASH_SCRIPT = [
+	'# Resolve PR URL from artifact data or current branch',
+	'PR_URL=$(jq -r \'.pr_url // .url // .merged_pr_url // empty\' <<< "${NEOKAI_ARTIFACT_DATA_JSON:-{}}" 2>/dev/null || true)',
+	'if [ -z "$PR_URL" ]; then',
+	'  PR_URL=$(gh pr view --json url -q .url 2>/dev/null || true)',
+	'fi',
+	'if [ -z "$PR_URL" ]; then',
+	'  echo "verify-pr-merged: no PR URL found — cannot verify merge" >&2',
+	'  exit 1',
+	'fi',
+	'PR_STATE=$(gh pr view "$PR_URL" --json state -q .state 2>/dev/null || true)',
+	'if [ "$PR_STATE" != "MERGED" ]; then',
+	'  echo "verify-pr-merged: PR $PR_URL is in state \\"$PR_STATE\\", expected MERGED" >&2',
+	'  exit 1',
+	'fi',
+	'echo "verify-pr-merged: PR $PR_URL is merged"',
+	'jq -n --arg url "$PR_URL" \'{"verified_pr_url":$url,"status":"merged"}\'',
+].join('\n');
+
+/**
+ * Completion action for QA-style workflows whose end-node agent is expected to
+ * perform the merge itself (e.g. Coding-with-QA, Full-Cycle Coding). The
+ * script exits non-zero if the PR is not actually merged, causing the task
+ * to end in `blocked` instead of silently completing.
+ */
+const VERIFY_PR_MERGED_COMPLETION_ACTION: CompletionAction = {
+	id: 'verify-pr-merged',
+	name: 'Verify PR merged',
+	description:
+		'Verifies the PR associated with the task is in state MERGED on GitHub. ' +
+		'Fails the task if the agent claims completion without having actually merged.',
+	type: 'script',
+	requiredLevel: 2,
+	artifactType: 'pr',
+	script: VERIFY_PR_MERGED_BASH_SCRIPT,
+};
+
+/**
+ * Script that verifies the PR associated with a Review-Only task has at least
+ * one review comment or submitted review posted. Prevents the Reviewer from
+ * "claiming reviewed" without actually posting feedback on GitHub.
+ */
+const VERIFY_REVIEW_POSTED_BASH_SCRIPT = [
+	'PR_URL=$(jq -r \'.pr_url // .url // empty\' <<< "${NEOKAI_ARTIFACT_DATA_JSON:-{}}" 2>/dev/null || true)',
+	'if [ -z "$PR_URL" ]; then',
+	'  PR_URL=$(gh pr view --json url -q .url 2>/dev/null || true)',
+	'fi',
+	'if [ -z "$PR_URL" ]; then',
+	'  echo "verify-review-posted: no PR URL found — cannot verify review was posted" >&2',
+	'  exit 1',
+	'fi',
+	'REVIEW_COUNT=$(gh pr view "$PR_URL" --json reviews -q \'.reviews | length\' 2>/dev/null || echo 0)',
+	'COMMENT_COUNT=$(gh pr view "$PR_URL" --json comments -q \'.comments | length\' 2>/dev/null || echo 0)',
+	'TOTAL=$((REVIEW_COUNT + COMMENT_COUNT))',
+	'if [ "$TOTAL" -lt 1 ]; then',
+	'  echo "verify-review-posted: PR $PR_URL has no reviews or review comments — reviewer did not post" >&2',
+	'  exit 1',
+	'fi',
+	'echo "verify-review-posted: PR $PR_URL has $REVIEW_COUNT reviews and $COMMENT_COUNT comments"',
+	'jq -n --arg url "$PR_URL" --arg reviews "$REVIEW_COUNT" --arg comments "$COMMENT_COUNT" \\',
+	'  \'{"pr_url":$url,"review_count":($reviews|tonumber),"comment_count":($comments|tonumber)}\'',
+].join('\n');
+
+/**
+ * Completion action for Review-Only workflows. The reviewer is expected to
+ * post their findings on the PR; this script verifies at least one
+ * review/comment was posted before the task is allowed to close as done.
+ */
+const VERIFY_REVIEW_POSTED_COMPLETION_ACTION: CompletionAction = {
+	id: 'verify-review-posted',
+	name: 'Verify review posted',
+	description:
+		'Verifies the Reviewer actually posted review feedback on the PR (review or review-comment). ' +
+		'Fails the task if the agent reports completion without having posted anything.',
+	type: 'script',
+	requiredLevel: 2,
+	artifactType: 'pr',
+	script: VERIFY_REVIEW_POSTED_BASH_SCRIPT,
+};
+
 const V2_PLANNING_PROMPT =
 	'You are the Planning node in a Full-Cycle Coding Workflow. Your role is to turn the task into a ' +
 	'concrete, actionable implementation plan that downstream nodes (Code, Review, QA) can execute ' +
@@ -389,7 +477,8 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'thread. Do NOT call `report_result` — leave the workflow open for the next round.\n' +
 							'5. If satisfied: post an approval review with `gh pr review <pr-url> --approve ' +
 							'--body-file <file>`, verify the PR is open and mergeable, then call ' +
-							'`report_result(status="done", summary=...)` as your final action',
+							'`report_result({ summary, evidence: { prUrl } })` as your final action. ' +
+							'Do NOT pass a `status` — the runtime decides the terminal state via completion actions.',
 					},
 				},
 			],
@@ -538,7 +627,8 @@ export const RESEARCH_WORKFLOW: SpaceWorkflow = {
 							'5. If more research needed: send_message back to Research with specific areas to ' +
 							'investigate (do NOT call `report_result`)\n' +
 							'6. If satisfied: verify the PR is still open and mergeable, then call ' +
-							'`report_result(status="done", summary=...)` as your final action',
+							'`report_result({ summary, evidence: { prUrl } })` as your final action. ' +
+							'Do NOT pass a `status` — the runtime decides the terminal state via completion actions.',
 					},
 				},
 			],
@@ -635,12 +725,15 @@ export const REVIEW_ONLY_WORKFLOW: SpaceWorkflow = {
 							'2. Check for correctness, security, performance, and style issues\n' +
 							'3. Verify test coverage is adequate\n' +
 							'4. Post your review to the PR via `gh pr review` (+ inline comments via `gh api` ' +
-							'where relevant) — this is required, not optional\n' +
+							'where relevant) — this is required, not optional, and the runtime verifies at ' +
+							'least one review/comment exists before accepting completion\n' +
 							'5. Summarize your findings clearly for the task record\n' +
-							'6. Call `report_result(status="done", summary=...)` as your final action',
+							'6. Call `report_result({ summary, evidence: { prUrl } })` as your final action. ' +
+							'Do NOT pass a `status` — the runtime decides the terminal state via completion actions.',
 					},
 				},
 			],
+			completionActions: [VERIFY_REVIEW_POSTED_COMPLETION_ACTION],
 		},
 	],
 	startNodeId: REVIEW_REVIEW_NODE,
@@ -828,11 +921,14 @@ export const FULL_CYCLE_CODING_WORKFLOW: SpaceWorkflow = {
 							'(do NOT call `report_result`)\n' +
 							'6. If all green: merge the PR with `gh pr merge <URL> --squash`\n' +
 							'7. Sync worktree: `git checkout <base-branch> && git pull --ff-only`\n' +
-							'8. Call `report_result(status="done", summary=...)` confirming merge and sync\n\n' +
+							'8. Call `report_result({ summary, evidence: { prUrl, testOutput } })` confirming ' +
+							'merge and sync. Do NOT pass a `status` — the runtime verifies the PR is actually ' +
+							'merged before accepting completion.\n\n' +
 							'On failure, Coding fixes issues and reviewers re-vote before QA runs again.',
 					},
 				},
 			],
+			completionActions: [VERIFY_PR_MERGED_COMPLETION_ACTION],
 		},
 	],
 	startNodeId: V2_PLANNING_NODE,
@@ -1045,10 +1141,13 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
 							'`report_result`)\n' +
 							'5. If all green: merge the PR with `gh pr merge <URL> --squash`\n' +
 							'6. Sync worktree: `git checkout <base-branch> && git pull --ff-only`\n' +
-							'7. Call `report_result(status="done", summary=...)` confirming merge and sync',
+							'7. Call `report_result({ summary, evidence: { prUrl, testOutput } })` confirming ' +
+							'merge and sync. Do NOT pass a `status` — the runtime verifies the PR is actually ' +
+							'merged before accepting completion.',
 					},
 				},
 			],
+			completionActions: [VERIFY_PR_MERGED_COMPLETION_ACTION],
 		},
 	],
 	startNodeId: FULLSTACK_CODING_NODE,

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-tool-schemas.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-tool-schemas.test.ts
@@ -47,52 +47,79 @@ describe('TaskResultStatusSchema', () => {
 });
 
 // ---------------------------------------------------------------------------
-// report_result
+// report_result (post-Stage-2: result-only; terminal status decided by runtime)
 // ---------------------------------------------------------------------------
 
 describe('ReportResultSchema', () => {
-	test('accepts completed status with summary', () => {
-		const result = ReportResultSchema.safeParse({ status: 'done', summary: 'Task done.' });
+	test('accepts summary-only payload', () => {
+		const result = ReportResultSchema.safeParse({ summary: 'Task complete.' });
 		expect(result.success).toBe(true);
 		if (result.success) {
-			expect(result.data.status).toBe('done');
-			expect(result.data.error).toBeUndefined();
+			expect(result.data.summary).toBe('Task complete.');
+			expect(result.data.evidence).toBeUndefined();
 		}
 	});
 
-	test('accepts needs_attention status with summary and error', () => {
+	test('accepts summary + evidence with the known fields', () => {
 		const result = ReportResultSchema.safeParse({
-			status: 'blocked',
-			summary: 'Blocked on auth issue.',
-			error: 'OAuth token expired',
+			summary: 'Shipped PR.',
+			evidence: {
+				prUrl: 'https://github.com/o/r/pull/1',
+				commitSha: 'abc123',
+				testOutput: 'ok (12 tests)',
+			},
 		});
 		expect(result.success).toBe(true);
 		if (result.success) {
-			expect(result.data.status).toBe('blocked');
-			expect(result.data.error).toBe('OAuth token expired');
+			expect(result.data.evidence?.prUrl).toBe('https://github.com/o/r/pull/1');
+			expect(result.data.evidence?.commitSha).toBe('abc123');
+			expect(result.data.evidence?.testOutput).toBe('ok (12 tests)');
 		}
 	});
 
-	test('accepts cancelled status', () => {
+	test('accepts evidence with extra fields (passthrough)', () => {
+		// Evidence is defined with `.passthrough()` so agents can attach domain-
+		// specific keys without needing the schema updated each time.
 		const result = ReportResultSchema.safeParse({
-			status: 'cancelled',
-			summary: 'User cancelled the task.',
+			summary: 'Done.',
+			evidence: {
+				prUrl: 'https://github.com/o/r/pull/1',
+				deployUrl: 'https://staging.example.com',
+			},
 		});
 		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.evidence?.prUrl).toBe('https://github.com/o/r/pull/1');
+			// Passthrough keeps the extra key reachable on the parsed value
+			expect((result.data.evidence as Record<string, unknown> | undefined)?.deployUrl).toBe(
+				'https://staging.example.com'
+			);
+		}
 	});
 
-	test('rejects invalid status value', () => {
-		const result = ReportResultSchema.safeParse({ status: 'failed', summary: 'Bad.' });
+	test('rejects payload carrying a `status` field (strict mode)', () => {
+		// Stage-2 invariant: agents can no longer self-certify terminal status.
+		// Passing `status` must be a validation error, not silently accepted.
+		const result = ReportResultSchema.safeParse({ status: 'done', summary: 'x' });
 		expect(result.success).toBe(false);
+		if (!result.success) {
+			// The error should mention the unrecognized key to give the caller a
+			// useful nudge toward the new shape.
+			const joined = result.error.issues.map((i) => i.message).join(' | ');
+			expect(joined.toLowerCase()).toContain('unrecognized');
+		}
 	});
 
-	test('rejects missing status', () => {
-		const result = ReportResultSchema.safeParse({ summary: 'Done.' });
+	test('rejects payload carrying an `error` field (strict mode)', () => {
+		const result = ReportResultSchema.safeParse({
+			summary: 'x',
+			error: 'something',
+		});
 		expect(result.success).toBe(false);
 	});
 
 	test('rejects missing summary', () => {
-		const result = ReportResultSchema.safeParse({ status: 'done' });
+		const result = ReportResultSchema.safeParse({ evidence: { prUrl: 'x' } });
 		expect(result.success).toBe(false);
 	});
 
@@ -102,15 +129,14 @@ describe('ReportResultSchema', () => {
 	});
 
 	test('rejects non-string summary', () => {
-		const result = ReportResultSchema.safeParse({ status: 'done', summary: 99 });
+		const result = ReportResultSchema.safeParse({ summary: 99 });
 		expect(result.success).toBe(false);
 	});
 
-	test('rejects non-string error', () => {
+	test('rejects evidence with non-string prUrl', () => {
 		const result = ReportResultSchema.safeParse({
-			status: 'cancelled',
-			summary: 'done',
-			error: { message: 'oops' },
+			summary: 'x',
+			evidence: { prUrl: 123 },
 		});
 		expect(result.success).toBe(false);
 	});

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-tools.test.ts
@@ -389,7 +389,7 @@ describe('createTaskAgentToolHandlers — report_result', () => {
 		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
-	test('marks task as completed with summary', async () => {
+	test('records summary and marks task done (runtime pipeline decides terminal status)', async () => {
 		const mainTask = ctx.taskRepo.createTask({
 			spaceId: ctx.spaceId,
 			title: 'Main task',
@@ -400,20 +400,22 @@ describe('createTaskAgentToolHandlers — report_result', () => {
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, 'run-id'));
 
 		const result = await handlers.report_result({
-			status: 'done',
 			summary: 'All steps completed successfully.',
 		});
 		const parsed = JSON.parse(result.content[0].text);
 
 		expect(parsed.success).toBe(true);
-		expect(parsed.status).toBe('done');
 		expect(parsed.summary).toBe('All steps completed successfully.');
+		// `status` is intentionally NOT echoed — the agent does not control it.
+		expect(parsed.status).toBeUndefined();
 
 		const updated = ctx.taskRepo.getTask(mainTask.id);
+		// The tool always records `done`; the completion-action pipeline may
+		// later downgrade it. Downstream tests cover that.
 		expect(updated?.status).toBe('done');
 	});
 
-	test('marks task as needs_attention with error', async () => {
+	test('records evidence alongside the summary', async () => {
 		const mainTask = ctx.taskRepo.createTask({
 			spaceId: ctx.spaceId,
 			title: 'Main task',
@@ -424,44 +426,26 @@ describe('createTaskAgentToolHandlers — report_result', () => {
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, 'run-id'));
 
 		const result = await handlers.report_result({
-			status: 'blocked',
-			summary: 'An error occurred.',
-			error: 'Tests failed in CI.',
+			summary: 'PR opened.',
+			evidence: {
+				prUrl: 'https://github.com/example/repo/pull/42',
+				commitSha: 'abc1234',
+			},
 		});
 		const parsed = JSON.parse(result.content[0].text);
-
 		expect(parsed.success).toBe(true);
-		expect(parsed.status).toBe('blocked');
 
 		const updated = ctx.taskRepo.getTask(mainTask.id);
-		expect(updated?.status).toBe('blocked');
-	});
-
-	test('marks task as cancelled', async () => {
-		const mainTask = ctx.taskRepo.createTask({
-			spaceId: ctx.spaceId,
-			title: 'Main task',
-			description: '',
-			status: 'in_progress',
-		});
-
-		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, 'run-id'));
-
-		const result = await handlers.report_result({
-			status: 'cancelled',
-			summary: 'User cancelled the task.',
-		});
-		const parsed = JSON.parse(result.content[0].text);
-
-		expect(parsed.success).toBe(true);
-		expect(parsed.status).toBe('cancelled');
+		expect(updated?.status).toBe('done');
+		expect(updated?.result).toContain('PR opened.');
+		expect(updated?.result).toContain('https://github.com/example/repo/pull/42');
+		expect(updated?.result).toContain('abc1234');
 	});
 
 	test('returns error when task not found', async () => {
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, 'task-does-not-exist', 'run-id'));
 
 		const result = await handlers.report_result({
-			status: 'done',
 			summary: 'Done.',
 		});
 		const parsed = JSON.parse(result.content[0].text);
@@ -471,7 +455,7 @@ describe('createTaskAgentToolHandlers — report_result', () => {
 	});
 
 	test('returns error when status transition is invalid', async () => {
-		// completed → completed is not a valid transition
+		// done → done is not a valid transition
 		const mainTask = ctx.taskRepo.createTask({
 			spaceId: ctx.spaceId,
 			title: 'Already done',
@@ -482,7 +466,6 @@ describe('createTaskAgentToolHandlers — report_result', () => {
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, 'run-id'));
 
 		const result = await handlers.report_result({
-			status: 'done',
 			summary: 'Done again?',
 		});
 		const parsed = JSON.parse(result.content[0].text);
@@ -506,7 +489,7 @@ describe('createTaskAgentToolHandlers — report_result DaemonHub events', () =>
 		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
-	test('emits space.task.done event when status is done', async () => {
+	test('emits space.task.done event with summary', async () => {
 		const mainTask = ctx.taskRepo.createTask({
 			spaceId: ctx.spaceId,
 			title: 'Test Task',
@@ -520,7 +503,7 @@ describe('createTaskAgentToolHandlers — report_result DaemonHub events', () =>
 			daemonHub: hub,
 		});
 
-		await handlers.report_result({ status: 'done', summary: 'All done.' });
+		await handlers.report_result({ summary: 'All done.' });
 
 		// The mock emit is synchronous (records events before returning Promise.resolve()),
 		// so no async flush is needed — assertions can run immediately.
@@ -534,7 +517,7 @@ describe('createTaskAgentToolHandlers — report_result DaemonHub events', () =>
 		expect(emittedEvents[0].payload.taskTitle).toBe('Test Task');
 	});
 
-	test('emits space.task.failed event when status is needs_attention', async () => {
+	test('always emits space.task.done (runtime pipeline decides final status)', async () => {
 		const mainTask = ctx.taskRepo.createTask({
 			spaceId: ctx.spaceId,
 			title: 'Failing Task',
@@ -548,40 +531,18 @@ describe('createTaskAgentToolHandlers — report_result DaemonHub events', () =>
 			daemonHub: hub,
 		});
 
+		// The agent can no longer self-certify "blocked" — it always reports a
+		// summary and the completion-action pipeline decides if the task should
+		// end up blocked/needs_attention.
 		await handlers.report_result({
-			status: 'blocked',
-			summary: 'Tests failed.',
-			error: 'CI pipeline error',
+			summary: 'Tests failed — summary only; pipeline may flip to needs_attention.',
 		});
 
 		expect(emittedEvents).toHaveLength(1);
-		expect(emittedEvents[0].name).toBe('space.task.failed');
+		expect(emittedEvents[0].name).toBe('space.task.done');
 		expect(emittedEvents[0].payload.taskId).toBe(mainTask.id);
-		expect(emittedEvents[0].payload.spaceId).toBe(ctx.spaceId);
-		expect(emittedEvents[0].payload.status).toBe('blocked');
-		expect(emittedEvents[0].payload.summary).toBe('Tests failed.');
+		expect(emittedEvents[0].payload.status).toBe('done');
 		expect(emittedEvents[0].payload.taskTitle).toBe('Failing Task');
-	});
-
-	test('emits space.task.failed event when status is cancelled', async () => {
-		const mainTask = ctx.taskRepo.createTask({
-			spaceId: ctx.spaceId,
-			title: 'Cancelled Task',
-			description: '',
-			status: 'in_progress',
-		});
-		const { hub, emittedEvents } = makeMockDaemonHub();
-
-		const handlers = createTaskAgentToolHandlers({
-			...makeConfig(ctx, mainTask.id, 'run-789'),
-			daemonHub: hub,
-		});
-
-		await handlers.report_result({ status: 'cancelled', summary: 'User cancelled.' });
-
-		expect(emittedEvents).toHaveLength(1);
-		expect(emittedEvents[0].name).toBe('space.task.failed');
-		expect(emittedEvents[0].payload.status).toBe('cancelled');
 	});
 
 	test('does not emit events when daemonHub is not provided', async () => {
@@ -595,7 +556,7 @@ describe('createTaskAgentToolHandlers — report_result DaemonHub events', () =>
 		// No daemonHub in config
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, 'run-id'));
 
-		const result = await handlers.report_result({ status: 'done', summary: 'Done.' });
+		const result = await handlers.report_result({ summary: 'Done.' });
 		const parsed = JSON.parse(result.content[0].text);
 
 		// Should still succeed — hub is optional
@@ -616,7 +577,7 @@ describe('createTaskAgentToolHandlers — report_result DaemonHub events', () =>
 			daemonHub: hub,
 		});
 
-		await handlers.report_result({ status: 'done', summary: 'Done.' });
+		await handlers.report_result({ summary: 'Done.' });
 
 		expect(emittedEvents[0].payload.sessionId).toBe('global');
 	});
@@ -629,7 +590,7 @@ describe('createTaskAgentToolHandlers — report_result DaemonHub events', () =>
 			daemonHub: hub,
 		});
 
-		const result = await handlers.report_result({ status: 'done', summary: 'Done.' });
+		const result = await handlers.report_result({ summary: 'Done.' });
 		const parsed = JSON.parse(result.content[0].text);
 
 		expect(parsed.success).toBe(false);

--- a/packages/daemon/tests/unit/5-space/agent/task-agent.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent.test.ts
@@ -221,12 +221,31 @@ describe('buildTaskAgentSystemPrompt — human gate handling', () => {
 	});
 });
 
-describe('buildTaskAgentSystemPrompt — result handling', () => {
-	test('uses cancelled instead of failed for error handling in Workflow Execution Instructions', () => {
+describe('buildTaskAgentSystemPrompt — result handling (Stage-2 result-only contract)', () => {
+	test('documents report_result as summary + optional evidence (no status)', () => {
+		// Stage-2 invariant: agents do NOT self-certify terminal status. The
+		// prompt must tell them to pass only `summary` + `evidence` — the
+		// runtime decides the final status via completion actions.
 		const prompt = buildTaskAgentSystemPrompt(makeContext());
-		expect(prompt).toContain('cancelled');
-		// Should not contain the stale "failed" status
-		expect(prompt).not.toMatch(/status: "failed"/);
+		expect(prompt).toContain('summary');
+		expect(prompt).toContain('evidence');
+	});
+
+	test('explicitly instructs agents NOT to pass a status field', () => {
+		const prompt = buildTaskAgentSystemPrompt(makeContext());
+		expect(prompt).toMatch(/Do NOT pass a `status`|do not pass a `status`/i);
+	});
+
+	test('references the completion-action pipeline as the status arbiter', () => {
+		const prompt = buildTaskAgentSystemPrompt(makeContext());
+		expect(prompt.toLowerCase()).toContain('completion-action');
+	});
+
+	test('must not advertise the old status="done"/"blocked"/"failed" contract', () => {
+		const prompt = buildTaskAgentSystemPrompt(makeContext());
+		expect(prompt).not.toMatch(/status\s*[:=]\s*["']done["']/);
+		expect(prompt).not.toMatch(/status\s*[:=]\s*["']blocked["']/);
+		expect(prompt).not.toMatch(/status\s*[:=]\s*["']failed["']/);
 	});
 });
 

--- a/packages/daemon/tests/unit/5-space/runtime/completion-action-executors.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/completion-action-executors.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Unit tests for completion-action-executors.ts
+ *
+ * Exercises the runtime-injectable executor helpers directly — no DB,
+ * no SpaceRuntime, no agent SDK. These helpers are the low-level
+ * building blocks the runtime composes for `instruction` and `mcp_call`
+ * completion actions:
+ *
+ *   - `accessByPath(root, path)` — dot/bracket accessor into a JSON-ish value
+ *   - `evaluateMcpExpectation(result, expectation)` — typed assertion check
+ *   - `runMcpCallAction(action, ctx, executor)` — tool-call + assertion wrapper
+ *
+ * Keeping these tests at the helper level lets the SpaceRuntime integration
+ * tests focus on orchestration (dispatch, pause/resume, notification emission)
+ * while we validate the assertion semantics once, in isolation.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import {
+	accessByPath,
+	evaluateMcpExpectation,
+	runMcpCallAction,
+	type McpToolExecutor,
+} from '../../../../src/lib/space/runtime/completion-action-executors';
+import type { McpCallCompletionAction, McpCallExpectation } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// accessByPath
+// ---------------------------------------------------------------------------
+
+describe('accessByPath', () => {
+	test('empty path returns the root value', () => {
+		expect(accessByPath({ a: 1 }, '')).toEqual({ a: 1 });
+		expect(accessByPath('hello', '')).toBe('hello');
+		expect(accessByPath(null, '')).toBe(null);
+	});
+
+	test('dot access resolves nested object fields', () => {
+		const root = { data: { items: { status: 'OK' } } };
+		expect(accessByPath(root, 'data.items.status')).toBe('OK');
+		expect(accessByPath(root, 'data')).toEqual({ items: { status: 'OK' } });
+	});
+
+	test('bracket-index access resolves array elements', () => {
+		const root = { data: { items: [{ id: 'a' }, { id: 'b' }] } };
+		expect(accessByPath(root, 'data.items[0]')).toEqual({ id: 'a' });
+		expect(accessByPath(root, 'data.items[1].id')).toBe('b');
+	});
+
+	test('bracket-string access supports quoted keys with spaces', () => {
+		const root = { data: { 'weird key': 42 } };
+		expect(accessByPath(root, "data['weird key']")).toBe(42);
+		expect(accessByPath(root, 'data["weird key"]')).toBe(42);
+	});
+
+	test('missing segment yields undefined instead of throwing', () => {
+		const root = { a: { b: 1 } };
+		expect(accessByPath(root, 'a.c')).toBeUndefined();
+		expect(accessByPath(root, 'a.b.c')).toBeUndefined();
+		expect(accessByPath(root, 'x.y.z')).toBeUndefined();
+	});
+
+	test('out-of-range array index yields undefined', () => {
+		const root = { arr: [1, 2, 3] };
+		expect(accessByPath(root, 'arr[5]')).toBeUndefined();
+	});
+
+	test('primitive cursor with further segments yields undefined', () => {
+		// Once we hit a primitive (string/number), further nav can't descend.
+		expect(accessByPath({ a: 'str' }, 'a.b')).toBeUndefined();
+		expect(accessByPath({ a: 42 }, 'a.b')).toBeUndefined();
+	});
+
+	test('null/undefined anywhere short-circuits to undefined', () => {
+		const root = { a: null, b: undefined };
+		expect(accessByPath(root, 'a.x')).toBeUndefined();
+		expect(accessByPath(root, 'b.x')).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// evaluateMcpExpectation
+// ---------------------------------------------------------------------------
+
+describe('evaluateMcpExpectation', () => {
+	test('exists: success when path resolves, failure when undefined', () => {
+		const result = { state: 'MERGED', count: 0 };
+		expect(evaluateMcpExpectation(result, { path: 'state', op: 'exists' })).toEqual({
+			success: true,
+		});
+		// `0` exists (not undefined)
+		expect(evaluateMcpExpectation(result, { path: 'count', op: 'exists' })).toEqual({
+			success: true,
+		});
+		const res = evaluateMcpExpectation(result, { path: 'missing', op: 'exists' });
+		expect(res.success).toBe(false);
+		expect(res.reason).toContain('missing');
+		expect(res.reason).toContain('undefined');
+	});
+
+	test('truthy: success for truthy, failure for falsy with reason', () => {
+		expect(evaluateMcpExpectation({ ok: true }, { path: 'ok', op: 'truthy' })).toEqual({
+			success: true,
+		});
+		expect(evaluateMcpExpectation({ ok: 'yes' }, { path: 'ok', op: 'truthy' })).toEqual({
+			success: true,
+		});
+		const zero = evaluateMcpExpectation({ n: 0 }, { path: 'n', op: 'truthy' });
+		expect(zero.success).toBe(false);
+		expect(zero.reason).toContain('truthy');
+		const falseRes = evaluateMcpExpectation({ ok: false }, { path: 'ok', op: 'truthy' });
+		expect(falseRes.success).toBe(false);
+	});
+
+	test('eq: deep equality succeeds, mismatch yields descriptive reason', () => {
+		const exp: McpCallExpectation = { path: 'state', op: 'eq', value: 'MERGED' };
+		expect(evaluateMcpExpectation({ state: 'MERGED' }, exp)).toEqual({ success: true });
+
+		const bad = evaluateMcpExpectation({ state: 'OPEN' }, exp);
+		expect(bad.success).toBe(false);
+		expect(bad.reason).toContain('"state"');
+		expect(bad.reason).toContain('"MERGED"');
+		expect(bad.reason).toContain('"OPEN"');
+	});
+
+	test('eq: deep equality across nested structures', () => {
+		const exp: McpCallExpectation = {
+			path: 'data',
+			op: 'eq',
+			value: { items: [1, 2], meta: { ok: true } },
+		};
+		expect(evaluateMcpExpectation({ data: { items: [1, 2], meta: { ok: true } } }, exp)).toEqual({
+			success: true,
+		});
+		expect(
+			evaluateMcpExpectation({ data: { items: [1, 2], meta: { ok: false } } }, exp).success
+		).toBe(false);
+	});
+
+	test('neq: succeeds when values differ, fails when equal', () => {
+		const exp: McpCallExpectation = { path: 'state', op: 'neq', value: 'OPEN' };
+		expect(evaluateMcpExpectation({ state: 'MERGED' }, exp)).toEqual({ success: true });
+
+		const bad = evaluateMcpExpectation({ state: 'OPEN' }, exp);
+		expect(bad.success).toBe(false);
+		expect(bad.reason).toContain('not to equal');
+	});
+
+	test('contains: substring match for strings', () => {
+		const exp: McpCallExpectation = { path: 'msg', op: 'contains', value: 'merged' };
+		expect(evaluateMcpExpectation({ msg: 'PR was merged yesterday' }, exp)).toEqual({
+			success: true,
+		});
+		expect(evaluateMcpExpectation({ msg: 'PR open' }, exp).success).toBe(false);
+	});
+
+	test('contains: element membership for arrays (deep equality)', () => {
+		const exp: McpCallExpectation = { path: 'tags', op: 'contains', value: { name: 'bug' } };
+		expect(evaluateMcpExpectation({ tags: [{ name: 'docs' }, { name: 'bug' }] }, exp)).toEqual({
+			success: true,
+		});
+		expect(evaluateMcpExpectation({ tags: [{ name: 'docs' }] }, exp).success).toBe(false);
+	});
+
+	test('contains: non-string/non-array container yields failure', () => {
+		const exp: McpCallExpectation = { path: 'data', op: 'contains', value: 'x' };
+		expect(evaluateMcpExpectation({ data: 42 }, exp).success).toBe(false);
+		expect(evaluateMcpExpectation({ data: { x: 1 } }, exp).success).toBe(false);
+	});
+
+	test('unknown op surfaces as failure (defensive; type system should block)', () => {
+		// Force an invalid op past the type guard to exercise the default branch.
+		const bogus = { path: 'x', op: 'nope' as unknown as McpCallExpectation['op'] };
+		const res = evaluateMcpExpectation({ x: 1 }, bogus);
+		expect(res.success).toBe(false);
+		expect(res.reason).toContain('unknown');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// runMcpCallAction
+// ---------------------------------------------------------------------------
+
+function makeAction(overrides: Partial<McpCallCompletionAction> = {}): McpCallCompletionAction {
+	return {
+		id: 'a1',
+		name: 'Check PR merged',
+		type: 'mcp_call',
+		requiredLevel: 2,
+		server: 'github',
+		tool: 'pr_status',
+		args: { prUrl: 'https://github.com/x/y/pull/1' },
+		...overrides,
+	};
+}
+
+const CTX = {
+	spaceId: 'space-1',
+	runId: 'run-1',
+	workspacePath: '/tmp',
+	artifactData: {},
+};
+
+describe('runMcpCallAction', () => {
+	test('no expect + non-throwing executor → success', async () => {
+		const executor: McpToolExecutor = async () => ({ state: 'MERGED' });
+		const result = await runMcpCallAction(makeAction(), CTX, executor);
+		expect(result).toEqual({ success: true });
+	});
+
+	test('executor throws → failure carrying the error message', async () => {
+		const executor: McpToolExecutor = async () => {
+			throw new Error('connection refused');
+		};
+		const result = await runMcpCallAction(makeAction(), CTX, executor);
+		expect(result.success).toBe(false);
+		expect(result.reason).toContain('pr_status');
+		expect(result.reason).toContain('connection refused');
+	});
+
+	test('executor throws non-Error → failure with stringified value', async () => {
+		const executor: McpToolExecutor = async () => {
+			// eslint-disable-next-line @typescript-eslint/no-throw-literal
+			throw 'string-error'; // non-Error throw
+		};
+		const result = await runMcpCallAction(makeAction(), CTX, executor);
+		expect(result.success).toBe(false);
+		expect(result.reason).toContain('string-error');
+	});
+
+	test('with passing expect → success', async () => {
+		const executor: McpToolExecutor = async () => ({ state: 'MERGED' });
+		const action = makeAction({
+			expect: { path: 'state', op: 'eq', value: 'MERGED' },
+		});
+		const result = await runMcpCallAction(action, CTX, executor);
+		expect(result).toEqual({ success: true });
+	});
+
+	test('with failing expect → failure with descriptive reason', async () => {
+		const executor: McpToolExecutor = async () => ({ state: 'OPEN' });
+		const action = makeAction({
+			expect: { path: 'state', op: 'eq', value: 'MERGED' },
+		});
+		const result = await runMcpCallAction(action, CTX, executor);
+		expect(result.success).toBe(false);
+		expect(result.reason).toContain('"OPEN"');
+		expect(result.reason).toContain('"MERGED"');
+	});
+
+	test('executor receives the action and ctx verbatim', async () => {
+		const calls: Array<{ action: McpCallCompletionAction; ctx: typeof CTX }> = [];
+		const executor: McpToolExecutor = async (action, ctx) => {
+			calls.push({ action, ctx: ctx as typeof CTX });
+			return {};
+		};
+		const action = makeAction({ args: { prUrl: 'u', state: 'MERGED' } });
+		await runMcpCallAction(action, CTX, executor);
+		expect(calls).toHaveLength(1);
+		expect(calls[0].action).toBe(action);
+		expect(calls[0].ctx).toBe(CTX);
+	});
+});

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
@@ -32,6 +32,10 @@ import type { SpaceTask, SpaceWorkflowRun, SpaceWorkflow, Space } from '@neokai/
 import type { SpaceAutonomyLevel, CompletionAction } from '@neokai/shared';
 import type { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
 import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
+import type {
+	InstructionActionExecutor,
+	McpToolExecutor,
+} from '../../../../src/lib/space/runtime/completion-action-executors.ts';
 
 // ---------------------------------------------------------------------------
 // MockNotificationSink
@@ -1180,5 +1184,553 @@ describe('SpaceRuntime — completion actions', () => {
 		);
 		const enriched = enrichTaskWithPendingAction(task, workflowRunRepo, workflowManager);
 		expect(enriched.pendingAction).toBeUndefined();
+	});
+
+	// ─── Pipeline is the sole arbiter of terminal status ──────────────────
+	//
+	// Stage-2 invariant: the runtime does NOT read `reportedStatus` to decide
+	// the terminal status. An agent that calls `report_result` only signals
+	// "I'm done talking" — the completion-action pipeline determines whether
+	// that translates to `done` or `blocked`. These tests pin that contract:
+	// even legacy DB values like `reportedStatus='blocked'` or `'cancelled'`
+	// must NOT bypass the pipeline.
+
+	test('pipeline runs even when reportedStatus is "blocked" — actions succeed → task done', async () => {
+		setAutonomyLevel(5);
+		const rt = makeRuntime();
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'sole-action',
+				name: 'Sole Action',
+				type: 'script',
+				requiredLevel: 2,
+				script: 'echo "ok"',
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		// Legacy value — an old agent might still write 'blocked', but the
+		// runtime must not honor it as a terminal veto.
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'blocked',
+			reportedSummary: 'I think I failed',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+
+		const task = taskRepo.getTask(tasks[0].id)!;
+		// The pipeline — NOT reportedStatus — gets to decide. Action succeeded,
+		// so the task is done.
+		expect(task.status).toBe('done');
+		expect(task.approvalSource).toBe('auto_policy');
+	});
+
+	test('pipeline runs even when reportedStatus is "cancelled" — actions decide outcome', async () => {
+		setAutonomyLevel(5);
+		const rt = makeRuntime();
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'cancel-cover',
+				name: 'Cancel Cover',
+				type: 'script',
+				requiredLevel: 2,
+				script: 'exit 1',
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'cancelled',
+			reportedSummary: 'cancelled',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+
+		const task = taskRepo.getTask(tasks[0].id)!;
+		// Action failed → task is blocked. 'cancelled' reportedStatus did NOT
+		// short-circuit the pipeline; the action's failure is what matters.
+		expect(task.status).toBe('blocked');
+		expect(task.result).toContain('Cancel Cover');
+	});
+
+	test('"agent lies" — reports success but VERIFY action fails → task blocked', async () => {
+		// Canonical scenario from the task brief: an agent calls report_result
+		// claiming completion, but a post-completion verification action proves
+		// it did not actually do the work (e.g. PR not merged). The runtime
+		// must NOT trust the agent's word — the task must end `blocked`.
+		setAutonomyLevel(5);
+		const rt = makeRuntime();
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'verify-pr',
+				name: 'Verify PR Merged',
+				type: 'script',
+				requiredLevel: 2,
+				// Simulated "PR not merged" assertion — exit 1 means verification failed.
+				script: 'echo "PR is still OPEN" >&2; exit 1',
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		// Agent claims success with evidence
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'Merged PR #42',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+
+		const task = taskRepo.getTask(tasks[0].id)!;
+		expect(task.status).toBe('blocked');
+		expect(task.result).toContain('Verify PR Merged');
+	});
+
+	// ─── Instruction completion action ────────────────────────────────────
+
+	test('instruction action with no executor configured → task blocked with clear reason', async () => {
+		setAutonomyLevel(5);
+		// Intentionally no instructionActionExecutor — covers the
+		// misconfiguration path. The runtime must refuse to silently succeed.
+		const rt = makeRuntime();
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'verify-quality',
+				name: 'QA Verifier',
+				type: 'instruction',
+				requiredLevel: 2,
+				agentName: 'qa-agent',
+				instruction: 'Verify the QA checklist is satisfied.',
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'done',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+
+		const task = taskRepo.getTask(tasks[0].id)!;
+		expect(task.status).toBe('blocked');
+		// Exact wording is stable enough to pin — the caller's audit log depends
+		// on it.
+		expect(task.result).toContain('no instructionActionExecutor configured');
+	});
+
+	test('instruction action with executor that passes → task done', async () => {
+		setAutonomyLevel(5);
+		const calls: Array<{ agent: string; instruction: string }> = [];
+		const executor: InstructionActionExecutor = async (action) => {
+			calls.push({ agent: action.agentName, instruction: action.instruction });
+			return { success: true, reason: 'verifier agreed' };
+		};
+		const rt = makeRuntime({ instructionActionExecutor: executor });
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'qa-verify',
+				name: 'QA Verifier',
+				type: 'instruction',
+				requiredLevel: 2,
+				agentName: 'qa-agent',
+				instruction: 'Verify the QA checklist.',
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'done',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+
+		const task = taskRepo.getTask(tasks[0].id)!;
+		expect(task.status).toBe('done');
+		// Executor received the action's agentName + instruction — proves the
+		// dispatch path is wired correctly, not just reading a bool.
+		expect(calls).toHaveLength(1);
+		expect(calls[0].agent).toBe('qa-agent');
+		expect(calls[0].instruction).toBe('Verify the QA checklist.');
+	});
+
+	test('instruction action with executor that fails → task blocked with verifier reason', async () => {
+		setAutonomyLevel(5);
+		const executor: InstructionActionExecutor = async () => ({
+			success: false,
+			reason: 'checklist item #3 not satisfied',
+		});
+		const rt = makeRuntime({ instructionActionExecutor: executor });
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'qa-verify',
+				name: 'QA Verifier',
+				type: 'instruction',
+				requiredLevel: 2,
+				agentName: 'qa-agent',
+				instruction: 'Verify.',
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'done',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+
+		const task = taskRepo.getTask(tasks[0].id)!;
+		expect(task.status).toBe('blocked');
+		expect(task.result).toBe('checklist item #3 not satisfied');
+	});
+
+	test('instruction action whose executor throws → task blocked with error message', async () => {
+		setAutonomyLevel(5);
+		const executor: InstructionActionExecutor = async () => {
+			throw new Error('session crashed');
+		};
+		const rt = makeRuntime({ instructionActionExecutor: executor });
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'qa-verify',
+				name: 'QA Verifier',
+				type: 'instruction',
+				requiredLevel: 2,
+				agentName: 'qa-agent',
+				instruction: 'Verify.',
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'done',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+
+		const task = taskRepo.getTask(tasks[0].id)!;
+		expect(task.status).toBe('blocked');
+		expect(task.result).toContain('session crashed');
+	});
+
+	// ─── mcp_call completion action ───────────────────────────────────────
+
+	test('mcp_call action with no executor configured → task blocked with clear reason', async () => {
+		setAutonomyLevel(5);
+		const rt = makeRuntime();
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'mcp-check',
+				name: 'MCP Check',
+				type: 'mcp_call',
+				requiredLevel: 2,
+				server: 'github',
+				tool: 'pr_status',
+				args: { prUrl: 'https://github.com/o/r/pull/1' },
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'done',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+
+		const task = taskRepo.getTask(tasks[0].id)!;
+		expect(task.status).toBe('blocked');
+		expect(task.result).toContain('no mcpToolExecutor configured');
+	});
+
+	test('mcp_call with no expect + executor returns anything → task done', async () => {
+		setAutonomyLevel(5);
+		const executor: McpToolExecutor = async () => ({ whatever: true });
+		const rt = makeRuntime({ mcpToolExecutor: executor });
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'mcp-ping',
+				name: 'MCP Ping',
+				type: 'mcp_call',
+				requiredLevel: 2,
+				server: 'github',
+				tool: 'ping',
+				args: {},
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'done',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+		expect(taskRepo.getTask(tasks[0].id)!.status).toBe('done');
+	});
+
+	test('mcp_call with passing expect assertion → task done', async () => {
+		setAutonomyLevel(5);
+		const calls: Array<{ tool: string; args: Record<string, string> }> = [];
+		const executor: McpToolExecutor = async (action) => {
+			if (action.type !== 'mcp_call') throw new Error('unexpected');
+			calls.push({ tool: action.tool, args: action.args });
+			return { state: 'MERGED' };
+		};
+		const rt = makeRuntime({ mcpToolExecutor: executor });
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'verify-merged',
+				name: 'Verify Merged',
+				type: 'mcp_call',
+				requiredLevel: 2,
+				server: 'github',
+				tool: 'pr_status',
+				args: { prUrl: 'https://github.com/o/r/pull/1' },
+				expect: { path: 'state', op: 'eq', value: 'MERGED' },
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'Merged PR #1',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+
+		expect(taskRepo.getTask(tasks[0].id)!.status).toBe('done');
+		expect(calls[0].tool).toBe('pr_status');
+		expect(calls[0].args.prUrl).toBe('https://github.com/o/r/pull/1');
+	});
+
+	test('mcp_call with failing expect assertion → task blocked with path/value reason', async () => {
+		setAutonomyLevel(5);
+		const executor: McpToolExecutor = async () => ({ state: 'OPEN' });
+		const rt = makeRuntime({ mcpToolExecutor: executor });
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'verify-merged',
+				name: 'Verify Merged',
+				type: 'mcp_call',
+				requiredLevel: 2,
+				server: 'github',
+				tool: 'pr_status',
+				args: { prUrl: 'x' },
+				expect: { path: 'state', op: 'eq', value: 'MERGED' },
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'Merged PR #1',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+
+		const task = taskRepo.getTask(tasks[0].id)!;
+		expect(task.status).toBe('blocked');
+		expect(task.result).toContain('"OPEN"');
+		expect(task.result).toContain('"MERGED"');
+	});
+
+	test('mcp_call with throwing executor → task blocked with error reason', async () => {
+		setAutonomyLevel(5);
+		const executor: McpToolExecutor = async () => {
+			throw new Error('server unavailable');
+		};
+		const rt = makeRuntime({ mcpToolExecutor: executor });
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'verify-merged',
+				name: 'Verify Merged',
+				type: 'mcp_call',
+				requiredLevel: 2,
+				server: 'github',
+				tool: 'pr_status',
+				args: { prUrl: 'x' },
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'Merged PR #1',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+
+		const task = taskRepo.getTask(tasks[0].id)!;
+		expect(task.status).toBe('blocked');
+		expect(task.result).toContain('server unavailable');
+	});
+
+	// ─── Mixed action types in one pipeline ───────────────────────────────
+
+	test('script + instruction + mcp_call all succeed → task done', async () => {
+		// A realistic QA end-node composition: deterministic script verifies
+		// PR merge state, an instruction agent verifies the summary is
+		// sufficient, and a lightweight MCP call records the success.
+		// The pipeline runs actions in order and demands every one succeed.
+		setAutonomyLevel(5);
+		const instructionCalls: string[] = [];
+		const mcpCalls: string[] = [];
+		const instructionExecutor: InstructionActionExecutor = async (action) => {
+			instructionCalls.push(action.agentName);
+			return { success: true };
+		};
+		const mcpExecutor: McpToolExecutor = async (action) => {
+			if (action.type !== 'mcp_call') throw new Error('unexpected');
+			mcpCalls.push(action.tool);
+			return { ok: true };
+		};
+		const rt = makeRuntime({
+			instructionActionExecutor: instructionExecutor,
+			mcpToolExecutor: mcpExecutor,
+		});
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'a1',
+				name: 'Script OK',
+				type: 'script',
+				requiredLevel: 2,
+				script: 'echo "ok"',
+			},
+			{
+				id: 'a2',
+				name: 'Instruction OK',
+				type: 'instruction',
+				requiredLevel: 2,
+				agentName: 'qa-agent',
+				instruction: 'Verify.',
+			},
+			{
+				id: 'a3',
+				name: 'Mcp OK',
+				type: 'mcp_call',
+				requiredLevel: 2,
+				server: 'github',
+				tool: 'post_comment',
+				args: {},
+				expect: { path: 'ok', op: 'truthy' },
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'done',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+
+		const task = taskRepo.getTask(tasks[0].id)!;
+		expect(task.status).toBe('done');
+		expect(instructionCalls).toEqual(['qa-agent']);
+		expect(mcpCalls).toEqual(['post_comment']);
+	});
+
+	test('pipeline short-circuits on first failure — later actions are not executed', async () => {
+		setAutonomyLevel(5);
+		const mcpCalls: string[] = [];
+		const mcpExecutor: McpToolExecutor = async (action) => {
+			if (action.type !== 'mcp_call') throw new Error('unexpected');
+			mcpCalls.push(action.tool);
+			return { ok: true };
+		};
+		const rt = makeRuntime({ mcpToolExecutor: mcpExecutor });
+
+		const actions: CompletionAction[] = [
+			{
+				id: 'a1',
+				name: 'Failing Script',
+				type: 'script',
+				requiredLevel: 2,
+				script: 'exit 1',
+			},
+			{
+				id: 'a2',
+				name: 'MCP after failure',
+				type: 'mcp_call',
+				requiredLevel: 2,
+				server: 'github',
+				tool: 'should_not_fire',
+				args: {},
+			},
+		];
+		const workflow = buildWorkflowWithActions(SPACE_ID, workflowManager, actions);
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'done',
+		});
+		seedNodeExec(db, run.id, 'end-node', 'worker', 'idle');
+
+		await rt.executeTick();
+
+		const task = taskRepo.getTask(tasks[0].id)!;
+		expect(task.status).toBe('blocked');
+		expect(task.result).toContain('Failing Script');
+		// Crucial: the MCP action after the failing script MUST NOT have been
+		// invoked. Emitting side effects after a verification failure could
+		// e.g. post premature GitHub reviews.
+		expect(mcpCalls).toEqual([]);
 	});
 });

--- a/packages/daemon/tests/unit/5-space/workflow/completion-actions-persistence.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/completion-actions-persistence.test.ts
@@ -146,15 +146,21 @@ describe('completionActions persistence — seed path (Bug A regression)', () =>
 		expect(endNode!.completionActions?.some((a) => a.id === 'merge-pr')).toBe(true);
 	});
 
-	test('Review-Only Workflow end node has no completionActions (template has none)', () => {
-		// Negative control — only templates with endNodeCompletionActions should
-		// persist them. Review-Only explicitly has none; if we ever start injecting
-		// stray actions, this test catches it.
+	test('Review-Only Workflow end node has VERIFY_REVIEW_POSTED_COMPLETION_ACTION attached', () => {
+		// Stage-2: the Review-Only end node now ships with a verification action
+		// that confirms the Reviewer actually posted review feedback on the PR.
+		// Without it, a Reviewer agent could call `report_result` without doing
+		// anything and the task would terminate `done` on trust alone. The
+		// completion-action pipeline closes that "agent lies" gap.
 		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === REVIEW_ONLY_WORKFLOW.name);
 		expect(wf).toBeDefined();
 		const endNode = wf!.nodes.find((n) => n.id === wf!.endNodeId);
 		expect(endNode).toBeDefined();
-		expect(endNode!.completionActions).toBeUndefined();
+		expect(endNode!.completionActions).toBeDefined();
+		const verify = endNode!.completionActions!.find((a) => a.id === 'verify-review-posted');
+		expect(verify).toBeDefined();
+		expect(verify!.type).toBe('script');
+		expect(verify!.artifactType).toBe('pr');
 	});
 
 	test('seeded workflows persist templateName + canonical templateHash', () => {

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -1379,24 +1379,54 @@ export interface ScriptCompletionAction extends CompletionActionBase {
 	script: string;
 }
 
-/** Agent instruction — sends a prompt to a specific node agent for execution */
+/** Agent instruction — spawns a short-lived SpaceAgent session to verify an outcome */
 export interface InstructionCompletionAction extends CompletionActionBase {
 	type: 'instruction';
-	/** Node ID of the agent that receives the instruction */
-	targetNodeId: string;
+	/**
+	 * Name of the SpaceAgent that should execute the instruction. The runtime
+	 * spawns an ephemeral session bound to this agent, injects a
+	 * `report_verification` tool, and awaits its response.
+	 */
+	agentName: string;
 	/** Prompt text — supports `{{artifact.field}}` template interpolation */
 	instruction: string;
+	/**
+	 * Maximum time to wait for the spawned agent to call
+	 * `report_verification`. Defaults to 120000ms (2 minutes).
+	 */
+	timeoutMs?: number;
 }
 
 /** Direct MCP tool invocation — no agent reasoning needed */
 export interface McpCallCompletionAction extends CompletionActionBase {
 	type: 'mcp_call';
-	/** MCP server name (must be enabled in the space's skills config) */
+	/** MCP server id (must be enabled in the space's skills config) */
 	server: string;
 	/** Tool name on the MCP server */
 	tool: string;
 	/** Tool arguments — values support `{{artifact.field}}` template interpolation */
 	args: Record<string, string>;
+	/**
+	 * Optional assertion applied to the tool result. The runtime extracts the
+	 * value at `path` from the result object and compares it via `op` to
+	 * `value`. If the assertion fails, the action fails.
+	 */
+	expect?: McpCallExpectation;
+}
+
+/**
+ * Assertion applied to the JSON result of an `mcp_call` completion action.
+ *
+ * `path` uses a dot/bracket accessor syntax (e.g. `data.items[0].status`).
+ * Empty path matches the whole result.
+ */
+export interface McpCallExpectation {
+	/** Dot/bracket accessor path into the tool result (e.g. `status`, `data.items[0].ok`). */
+	path: string;
+	/** Comparison operator. */
+	op: 'eq' | 'neq' | 'contains' | 'exists' | 'truthy';
+	/** Right-hand side. Required for `eq`/`neq`/`contains`, ignored for `exists`/`truthy`. */
+	value?: unknown;
 }
 
 // ── Approval Records ──────────────────────────────────────────────────────

--- a/packages/web/src/components/space/PendingCompletionActionBanner.tsx
+++ b/packages/web/src/components/space/PendingCompletionActionBanner.tsx
@@ -261,8 +261,8 @@ function CompletionActionDetails({ action }: { action: CompletionAction }) {
 					Show instruction
 				</summary>
 				<p class="mt-2 p-2 bg-dark-900/60 border border-dark-700 rounded text-[11px] text-gray-300">
-					<span class="text-gray-500">→ node </span>
-					<span class="font-mono">{action.targetNodeId}</span>
+					<span class="text-gray-500">→ agent </span>
+					<span class="font-mono">{action.agentName}</span>
 				</p>
 				<pre
 					class="mt-1 p-2 bg-dark-900/60 border border-dark-700 rounded overflow-x-auto whitespace-pre-wrap text-[11px] text-gray-300"

--- a/packages/web/src/components/space/__tests__/PendingCompletionActionBanner.test.tsx
+++ b/packages/web/src/components/space/__tests__/PendingCompletionActionBanner.test.tsx
@@ -257,7 +257,7 @@ describe('PendingCompletionActionBanner', () => {
 				name: 'notify-team',
 				type: 'instruction',
 				requiredLevel: 2,
-				targetNodeId: 'n-x',
+				agentName: 'NotifyAgent',
 				instruction: 'Post a summary to #eng',
 			}),
 		];


### PR DESCRIPTION
## Summary

Stage-2 (Task B) of the autonomy-levels rollout. Agents stop self-certifying terminal status — the completion-action pipeline is now the single source of truth.

- `report_result` is `{ summary, evidence? }.strict()`; passing `status` is a validation error. Evidence is `.passthrough()` for domain-specific keys.
- Runtime no longer short-circuits on `reportedStatus === 'blocked' / 'cancelled'`; every reported result flows through the pipeline.
- New completion action types: `instruction` (bounded SpaceAgent with `report_verification` tool) and `mcp_call` (tool invocation + optional `{path, op, value}` assertion via JSONPath-ish accessor). Both executors are dependency-injected on `SpaceRuntimeConfig`; unwired executors fail closed.
- `CompletionAction` switch uses an exhaustive never-check — adding a new kind without a handler is a type error.
- Full-Cycle and QA-Loop end nodes get `VERIFY_PR_MERGED`; Review-Only end node gets `VERIFY_REVIEW_POSTED`.

## Test plan

- [x] `bun test packages/daemon/tests/unit/5-space/` — 11125 pass
- [x] New: `completion-action-executors.test.ts` (23 cases: accessByPath, evaluateMcpExpectation, runMcpCallAction)
- [x] Extended: `space-runtime-completion-actions.test.ts` (+17 cases: blocked/cancelled still run pipeline, instruction pass/fail/throw/no-executor, mcp_call pass/fail/throw/no-executor, combined pipelines short-circuiting)
- [x] Rewritten: `task-agent-tool-schemas.test.ts` `ReportResultSchema` block (Stage-2 strict contract)
- [x] Rewritten: `task-agent.test.ts` prompt block (result-only wording, no stale `status=` literals)
- [x] Updated: `completion-actions-persistence.test.ts` Review-Only asserts `VERIFY_REVIEW_POSTED`
- [x] `bun run check` (lint + typecheck + knip) clean