### PR TITLE
fix(space): thread UI — agent header spacing, system:init card height, empty thinking blocks

### DIFF
--- a/packages/shared/src/sdk/type-guards.ts
+++ b/packages/shared/src/sdk/type-guards.ts
@@ -186,7 +186,19 @@ export function isSDKRateLimitEvent(
 // ============================================================================
 
 /**
- * Type for content blocks from APIAssistantMessage
+ * Type for content blocks from APIAssistantMessage.
+ *
+ * The `thinking` variant carries an optional `signature` field that Anthropic
+ * returns alongside thinking output for multi-turn continuity. When the model
+ * is configured with `thinking.display = 'omitted'` (the Opus 4.7 default in
+ * some paths), the server returns a thinking block with a non-empty signature
+ * and an *empty* `thinking` string. Renderers must treat empty thinking as
+ * "no content to display" rather than rendering an empty card.
+ *
+ * We also accept the `redacted_thinking` variant emitted by the raw Anthropic
+ * API when a thinking block is redacted for safety. The SDK normally maps
+ * these into `thinking` blocks, but we include the type so the union is
+ * exhaustive and renderers can skip them safely if they ever appear.
  */
 export type ContentBlock =
   | { type: "text"; text: string }
@@ -196,7 +208,8 @@ export type ContentBlock =
       name: string;
       input: Record<string, unknown>;
     }
-  | { type: "thinking"; thinking: string };
+  | { type: "thinking"; thinking: string; signature?: string }
+  | { type: "redacted_thinking"; data: string };
 
 /**
  * AskUserQuestion tool input type
@@ -276,12 +289,33 @@ export function isToolUseBlock(
 }
 
 /**
- * Check if content block is a thinking block
+ * Check if content block is a thinking block.
+ *
+ * Note: this guard matches thinking blocks regardless of whether the
+ * `thinking` payload is empty. Empty thinking blocks are emitted by newer
+ * Anthropic models (e.g. Opus 4.7) when `thinking.display = 'omitted'` is in
+ * effect — the server still returns a thinking block carrying a signature for
+ * multi-turn continuity but no textual content. Use
+ * {@link hasRenderableThinking} at render time to decide whether to display
+ * a thinking card.
  */
 export function isThinkingBlock(
   block: ContentBlock,
 ): block is Extract<ContentBlock, { type: "thinking" }> {
   return block.type === "thinking";
+}
+
+/**
+ * Check if a thinking block has content that's worth rendering in the UI.
+ *
+ * Returns `false` for blocks with missing/empty/whitespace-only thinking
+ * strings (e.g. Opus 4.7 omitted-thinking stubs), so renderers can avoid
+ * showing an empty "Thinking · 0 characters" card.
+ */
+export function hasRenderableThinking(
+  block: Extract<ContentBlock, { type: "thinking" }>,
+): boolean {
+  return typeof block.thinking === "string" && block.thinking.trim().length > 0;
 }
 
 // ============================================================================

--- a/packages/shared/tests/type-guards.test.ts
+++ b/packages/shared/tests/type-guards.test.ts
@@ -23,6 +23,7 @@ import {
 	isTextBlock,
 	isToolUseBlock,
 	isThinkingBlock,
+	hasRenderableThinking,
 	getMessageTypeDescription,
 	isUserVisibleMessage,
 	type ContentBlock,
@@ -433,6 +434,51 @@ describe('Content Block Type Guards', () => {
 		test('should return false for text block', () => {
 			const block: ContentBlock = { type: 'text', text: 'Hello' };
 			expect(isThinkingBlock(block)).toBe(false);
+		});
+
+		test('should return true even when thinking payload is empty (Opus 4.7 case)', () => {
+			// Opus 4.7 with `thinking.display = 'omitted'` returns a
+			// structurally-valid thinking block whose `thinking` field is
+			// empty. The type guard stays structural; callers use
+			// `hasRenderableThinking` to decide whether to display.
+			const block: ContentBlock = {
+				type: 'thinking',
+				thinking: '',
+				signature: 'sig_abc',
+			};
+			expect(isThinkingBlock(block)).toBe(true);
+		});
+
+		test('should return false for redacted_thinking block', () => {
+			// redacted_thinking is its own variant — callers that want
+			// "is it a thinking block?" shouldn't match redacted blocks.
+			const block: ContentBlock = {
+				type: 'redacted_thinking',
+				data: 'opaque',
+			};
+			expect(isThinkingBlock(block)).toBe(false);
+		});
+	});
+
+	describe('hasRenderableThinking', () => {
+		test('should return true for non-empty thinking', () => {
+			const block = { type: 'thinking' as const, thinking: 'Real reasoning.' };
+			expect(hasRenderableThinking(block)).toBe(true);
+		});
+
+		test('should return false for empty thinking (Opus 4.7 omitted stub)', () => {
+			const block = { type: 'thinking' as const, thinking: '', signature: 'sig_x' };
+			expect(hasRenderableThinking(block)).toBe(false);
+		});
+
+		test('should return false for whitespace-only thinking', () => {
+			const block = { type: 'thinking' as const, thinking: '   \n\t  ' };
+			expect(hasRenderableThinking(block)).toBe(false);
+		});
+
+		test('should return false when thinking field is missing/non-string', () => {
+			const block = { type: 'thinking' as const, thinking: undefined as unknown as string };
+			expect(hasRenderableThinking(block)).toBe(false);
 		});
 	});
 });

--- a/packages/web/src/components/room/AgentTurnBlock.tsx
+++ b/packages/web/src/components/room/AgentTurnBlock.tsx
@@ -18,6 +18,7 @@ import { borderRadius, messageColors, messageSpacing } from '../../lib/design-to
 import MarkdownRenderer from '../chat/MarkdownRenderer.tsx';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import {
+	hasRenderableThinking,
 	isTextBlock,
 	isToolUseBlock,
 	isThinkingBlock,
@@ -210,7 +211,8 @@ function NestedMessageRenderer({
 
 		const textBlocks = content.filter((block) => isTextBlock(block));
 		const toolBlocks = content.filter((block) => isToolUseBlock(block));
-		const thinkingBlocks = content.filter((block) => isThinkingBlock(block));
+		// Skip empty thinking blocks (Opus 4.7 "omitted thinking" stubs).
+		const thinkingBlocks = content.filter(isThinkingBlock).filter(hasRenderableThinking);
 
 		return (
 			<div class="space-y-2">

--- a/packages/web/src/components/sdk/SDKAssistantMessage.tsx
+++ b/packages/web/src/components/sdk/SDKAssistantMessage.tsx
@@ -18,6 +18,7 @@ import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import type { AgentInput } from '@neokai/shared/sdk/sdk-tools.d.ts';
 import {
 	type ContentBlock,
+	hasRenderableThinking,
 	isTextBlock,
 	isThinkingBlock,
 	isToolUseBlock,
@@ -138,10 +139,14 @@ export function SDKAssistantMessage({
 		return date.toLocaleString();
 	};
 
-	// Separate blocks by type - tool use and thinking blocks get full width, text blocks are constrained
+	// Separate blocks by type - tool use and thinking blocks get full width, text blocks are constrained.
+	//
+	// Thinking blocks with empty/whitespace payloads (emitted by Opus 4.7 and
+	// other models running with `thinking.display = 'omitted'`) are filtered
+	// out here so the UI doesn't show an empty "Thinking · 0 characters" card.
 	const textBlocks = apiMessage.content.filter((block: ContentBlock) => isTextBlock(block));
 	const toolBlocks = apiMessage.content.filter((block: ContentBlock) => isToolUseBlock(block));
-	const thinkingBlocks = apiMessage.content.filter((block: ContentBlock) => isThinkingBlock(block));
+	const thinkingBlocks = apiMessage.content.filter(isThinkingBlock).filter(hasRenderableThinking);
 
 	// Get message metadata for E2E tests
 	const messageWithTimestamp = message as SDKMessage & { timestamp?: number };

--- a/packages/web/src/components/sdk/SubagentBlock.tsx
+++ b/packages/web/src/components/sdk/SubagentBlock.tsx
@@ -16,6 +16,7 @@ import MarkdownRenderer from '../chat/MarkdownRenderer.tsx';
 import type { AgentInput } from '@neokai/shared/sdk/sdk-tools.d.ts';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import {
+	hasRenderableThinking,
 	isTextBlock,
 	isToolUseBlock,
 	isThinkingBlock,
@@ -417,7 +418,14 @@ function NestedMessageRenderer({
 
 		const textBlocks = content.filter((block) => isTextBlock(block));
 		const toolBlocks = content.filter((block) => isToolUseBlock(block));
-		const thinkingBlocks = content.filter((block) => isThinkingBlock(block));
+		// Filter out Opus 4.7 "omitted" thinking stubs (empty `thinking`
+		// payload with only a signature). ThinkingBlock guards internally,
+		// but filtering here keeps the behavior consistent with the
+		// top-level assistant/thread renderers and avoids rendering an
+		// empty wrapper.
+		const thinkingBlocks = content
+			.filter((block) => isThinkingBlock(block))
+			.filter((block) => hasRenderableThinking(block));
 
 		return (
 			<div class="space-y-2">

--- a/packages/web/src/components/sdk/ThinkingBlock.tsx
+++ b/packages/web/src/components/sdk/ThinkingBlock.tsx
@@ -47,6 +47,16 @@ export function ThinkingBlock({
 
 	const previewMaxHeight = PREVIEW_LINE_COUNT * LINE_HEIGHT_PX;
 
+	// Defense in depth: render nothing when there's no thinking content to
+	// show. Opus 4.7 and other models running with `thinking.display = 'omitted'`
+	// emit thinking blocks with an empty string + a signature for multi-turn
+	// continuity — we should not render a stub "Thinking · 0 characters" card.
+	// Upstream callers (SDKAssistantMessage) also filter, but a component that
+	// guards itself is easier to compose safely.
+	if (typeof content !== 'string' || content.trim().length === 0) {
+		return null;
+	}
+
 	// Check if content exceeds preview height
 	useLayoutEffect(() => {
 		if (contentRef.current) {

--- a/packages/web/src/components/sdk/__tests__/SDKAssistantMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKAssistantMessage.test.tsx
@@ -328,6 +328,134 @@ describe('SDKAssistantMessage', () => {
 
 			expect(container.textContent).toContain('Let me think about this carefully');
 		});
+
+		/**
+		 * Opus 4.7 (and other models running with `thinking.display = 'omitted'`)
+		 * emits a thinking block with an empty `thinking` string but a
+		 * signature for multi-turn continuity. The UI should treat that as
+		 * "no thinking to show" and NOT render the amber card — otherwise
+		 * the user sees "Thinking · 0 characters" in the transcript.
+		 */
+		it('should NOT render a thinking card when thinking payload is empty (Opus 4.7 case)', async () => {
+			const message = {
+				type: 'assistant',
+				message: {
+					id: 'msg_test',
+					type: 'message',
+					role: 'assistant',
+					content: [
+						{ type: 'thinking', thinking: '', signature: 'sig_abc123' },
+						{ type: 'text', text: 'Here is my response.' },
+					],
+					model: 'claude-opus-4-7',
+					stop_reason: 'end_turn',
+					stop_sequence: null,
+					usage: { input_tokens: 10, output_tokens: 20 },
+				},
+				parent_tool_use_id: null,
+				uuid: createUUID(),
+				session_id: 'test-session',
+			} as unknown as Extract<SDKMessage, { type: 'assistant' }>;
+
+			const { container } = render(<SDKAssistantMessage message={message} />);
+
+			// No thinking card at all
+			expect(container.querySelector('[data-testid="thinking-block"]')).toBeNull();
+			expect(container.textContent).not.toContain('0 characters');
+			// Text block still renders (async via MarkdownRenderer)
+			await waitFor(() => {
+				expect(container.textContent).toContain('Here is my response');
+			});
+		});
+
+		it('should NOT render a thinking card for whitespace-only thinking payload', async () => {
+			const message = {
+				type: 'assistant',
+				message: {
+					id: 'msg_test',
+					type: 'message',
+					role: 'assistant',
+					content: [
+						{ type: 'thinking', thinking: '   \n\t  ' },
+						{ type: 'text', text: 'Only whitespace thinking.' },
+					],
+					model: 'claude-opus-4-7',
+					stop_reason: 'end_turn',
+					stop_sequence: null,
+					usage: { input_tokens: 10, output_tokens: 20 },
+				},
+				parent_tool_use_id: null,
+				uuid: createUUID(),
+				session_id: 'test-session',
+			} as unknown as Extract<SDKMessage, { type: 'assistant' }>;
+
+			const { container } = render(<SDKAssistantMessage message={message} />);
+
+			expect(container.querySelector('[data-testid="thinking-block"]')).toBeNull();
+			await waitFor(() => {
+				expect(container.textContent).toContain('Only whitespace thinking');
+			});
+		});
+
+		it('should still render valid thinking on same-model messages (no regression)', () => {
+			// A thinking block that *has* content must still render — we only
+			// skip when the payload is empty/whitespace.
+			const message = {
+				type: 'assistant',
+				message: {
+					id: 'msg_test',
+					type: 'message',
+					role: 'assistant',
+					content: [
+						{ type: 'thinking', thinking: 'Real reasoning here.', signature: 'sig_xyz' },
+						{ type: 'text', text: 'And the answer.' },
+					],
+					model: 'claude-opus-4-7',
+					stop_reason: 'end_turn',
+					stop_sequence: null,
+					usage: { input_tokens: 10, output_tokens: 20 },
+				},
+				parent_tool_use_id: null,
+				uuid: createUUID(),
+				session_id: 'test-session',
+			} as unknown as Extract<SDKMessage, { type: 'assistant' }>;
+
+			const { container } = render(<SDKAssistantMessage message={message} />);
+
+			expect(container.querySelector('[data-testid="thinking-block"]')).toBeTruthy();
+			expect(container.textContent).toContain('Real reasoning here');
+		});
+
+		it('should filter empty thinking blocks alongside non-empty ones', () => {
+			// Mixed: one empty thinking, one populated — only the populated
+			// one should render.
+			const message = {
+				type: 'assistant',
+				message: {
+					id: 'msg_test',
+					type: 'message',
+					role: 'assistant',
+					content: [
+						{ type: 'thinking', thinking: '', signature: 'sig_empty' },
+						{ type: 'thinking', thinking: 'Actual reasoning.' },
+						{ type: 'text', text: 'Reply.' },
+					],
+					model: 'claude-opus-4-7',
+					stop_reason: 'end_turn',
+					stop_sequence: null,
+					usage: { input_tokens: 10, output_tokens: 20 },
+				},
+				parent_tool_use_id: null,
+				uuid: createUUID(),
+				session_id: 'test-session',
+			} as unknown as Extract<SDKMessage, { type: 'assistant' }>;
+
+			const { container } = render(<SDKAssistantMessage message={message} />);
+
+			const cards = container.querySelectorAll('[data-testid="thinking-block"]');
+			expect(cards.length).toBe(1);
+			expect(container.textContent).toContain('Actual reasoning');
+		});
 	});
 
 	describe('Error State', () => {

--- a/packages/web/src/components/sdk/__tests__/ThinkingBlock.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/ThinkingBlock.test.tsx
@@ -224,11 +224,24 @@ describe('ThinkingBlock', () => {
 	});
 
 	describe('Edge Cases', () => {
-		it('should handle empty content', () => {
+		it('should render nothing for empty content (Opus 4.7 omitted-thinking stub)', () => {
+			// Opus 4.7 with `thinking.display = 'omitted'` returns a thinking
+			// block whose `thinking` field is an empty string (plus a
+			// signature for multi-turn continuity). The card should not
+			// render in that case — otherwise users see a bogus
+			// "Thinking · 0 characters" card.
 			const { container } = render(<ThinkingBlock content="" />);
 
-			expect(container.querySelector('[data-testid="thinking-block"]')).toBeTruthy();
-			expect(container.textContent).toContain('0 characters');
+			expect(container.querySelector('[data-testid="thinking-block"]')).toBeNull();
+			expect(container.textContent).not.toContain('0 characters');
+		});
+
+		it('should render nothing for whitespace-only content', () => {
+			// JSX attribute strings don't interpret escape sequences — use an
+			// expression so the content is actual whitespace.
+			const { container } = render(<ThinkingBlock content={'   \n\t  '} />);
+
+			expect(container.querySelector('[data-testid="thinking-block"]')).toBeNull();
 		});
 
 		it('should handle very long single line content', () => {

--- a/packages/web/src/components/space/__tests__/space-task-thread-events.test.ts
+++ b/packages/web/src/components/space/__tests__/space-task-thread-events.test.ts
@@ -169,6 +169,55 @@ describe('buildThreadEvents — multi-agent ordering and label preservation', ()
 		expect(events[2].kind).toBe('text');
 	});
 
+	it('skips empty Opus 4.7 "omitted" thinking stubs (empty thinking + signature)', () => {
+		// Opus 4.7 with `thinking.display = 'omitted'` returns a
+		// structurally valid thinking block with empty `thinking` but a
+		// non-empty `signature`. Those stubs must not produce "Thinking"
+		// thread events with an empty summary.
+		const row = makeRow({
+			id: 'opus-47-omitted',
+			label: 'Task Agent',
+			content: JSON.stringify({
+				type: 'assistant',
+				uuid: 'a1',
+				session_id: 'session-1',
+				message: {
+					content: [
+						{ type: 'thinking', thinking: '', signature: 'sig_abc123' },
+						{ type: 'text', text: 'Here is my response.' },
+					],
+				},
+			}),
+			createdAt: 1_000,
+		});
+		const events = buildThreadEvents([parseThreadRow(row)]);
+		expect(events).toHaveLength(1);
+		expect(events[0].kind).toBe('text');
+		// Ensure no thinking event leaked through with an empty summary
+		expect(events.some((e) => e.kind === 'thinking')).toBe(false);
+	});
+
+	it('skips whitespace-only thinking payloads', () => {
+		const row = makeRow({
+			id: 'whitespace-thinking',
+			label: 'Task Agent',
+			content: JSON.stringify({
+				type: 'assistant',
+				uuid: 'a1',
+				session_id: 'session-1',
+				message: {
+					content: [
+						{ type: 'thinking', thinking: '   \n\t  ' },
+						{ type: 'text', text: 'Done.' },
+					],
+				},
+			}),
+			createdAt: 1_000,
+		});
+		const events = buildThreadEvents([parseThreadRow(row)]);
+		expect(events.some((e) => e.kind === 'thinking')).toBe(false);
+	});
+
 	it('all events from a multi-block message share the same label', () => {
 		const row = makeRow({
 			id: 'multi-block-2',

--- a/packages/web/src/components/space/thread/compact/SpaceSystemInitCard.test.tsx
+++ b/packages/web/src/components/space/thread/compact/SpaceSystemInitCard.test.tsx
@@ -1,0 +1,135 @@
+// @ts-nocheck
+/**
+ * SpaceSystemInitCard tests — verify the collapsed card renders at the same
+ * "chrome" as SDKResultMessage so the two cards line up vertically in the
+ * compact task feed.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/preact';
+import { SpaceSystemInitCard } from './SpaceSystemInitCard';
+import { SDKResultMessage } from '../../../sdk/SDKResultMessage';
+import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
+
+function makeInitMessage(overrides: Partial<Record<string, unknown>> = {}): SDKMessage {
+	return {
+		type: 'system',
+		subtype: 'init',
+		model: 'claude-sonnet-4-5-20250929',
+		permissionMode: 'default',
+		cwd: '/workspace',
+		tools: ['Read', 'Write', 'Bash'],
+		mcp_servers: [{ name: 'example', status: 'connected' }],
+		slash_commands: ['init'],
+		agents: ['coder'],
+		apiKeySource: 'env',
+		...overrides,
+	} as unknown as SDKMessage;
+}
+
+function makeSuccessResult() {
+	return {
+		type: 'result',
+		subtype: 'success',
+		uuid: 'result-1',
+		usage: {
+			input_tokens: 100,
+			output_tokens: 50,
+			cache_read_input_tokens: 0,
+			cache_creation_input_tokens: 0,
+		},
+		total_cost_usd: 0.0123,
+		duration_ms: 1500,
+		duration_api_ms: 1200,
+		num_turns: 2,
+		modelUsage: {},
+		permission_denials: [],
+		result: 'done',
+	} as any;
+}
+
+describe('SpaceSystemInitCard', () => {
+	afterEach(() => cleanup());
+
+	describe('collapsed state', () => {
+		it('renders as a single-row toggle with "Session Started" label', () => {
+			const { getByTestId, container } = render(
+				<SpaceSystemInitCard message={makeInitMessage()} />
+			);
+			expect(getByTestId('compact-system-init-card')).toBeTruthy();
+			const toggle = getByTestId('compact-system-init-toggle') as HTMLButtonElement;
+			expect(toggle.textContent).toContain('Session Started');
+			// Collapsed — no details
+			expect(container.querySelector('[data-testid="compact-system-init-details"]')).toBeNull();
+		});
+
+		it('applies the same padding + text-size classes as SDKResultMessage for height parity', () => {
+			// Render both cards and compare the collapsed header button's
+			// utility classes. These are the only classes that affect
+			// collapsed-state row height (padding and text size).
+			const { getByTestId: getInitTestId } = render(
+				<SpaceSystemInitCard message={makeInitMessage()} />
+			);
+			const initButton = getInitTestId('compact-system-init-toggle') as HTMLButtonElement;
+
+			const result = render(<SDKResultMessage message={makeSuccessResult()} />);
+			const resultButton = result.container.querySelector('button') as HTMLButtonElement;
+			expect(resultButton).toBeTruthy();
+
+			// SDKResultMessage's collapsed header uses `px-3 py-2` + a `text-xs`
+			// inner container. SpaceSystemInitCard must match.
+			expect(initButton.className).toContain('px-3');
+			expect(initButton.className).toContain('py-2');
+			expect(resultButton.className).toContain('px-3');
+			expect(resultButton.className).toContain('py-2');
+
+			// Both cards should have a text-xs container with the row
+			// contents so the inner line-height matches.
+			const initInner = initButton.querySelector('.text-xs');
+			const resultInner = resultButton.querySelector('.text-xs');
+			expect(initInner).toBeTruthy();
+			expect(resultInner).toBeTruthy();
+		});
+
+		it('does NOT use the legacy small paddings/text sizes', () => {
+			const { getByTestId } = render(<SpaceSystemInitCard message={makeInitMessage()} />);
+			const toggle = getByTestId('compact-system-init-toggle') as HTMLButtonElement;
+			// Regression guards for the previous hand-tuned sizes that
+			// produced a visibly shorter card than SDKResultMessage.
+			expect(toggle.className).not.toContain('px-2.5');
+			expect(toggle.className).not.toContain('py-1.5');
+			expect(toggle.innerHTML).not.toContain('text-[11px]');
+			expect(toggle.innerHTML).not.toContain('text-[10px]');
+		});
+	});
+
+	describe('expanded state', () => {
+		it('reveals details when toggled', () => {
+			const { getByTestId, container } = render(
+				<SpaceSystemInitCard message={makeInitMessage()} />
+			);
+			const toggle = getByTestId('compact-system-init-toggle');
+			fireEvent.click(toggle);
+			expect(container.querySelector('[data-testid="compact-system-init-details"]')).toBeTruthy();
+			expect(container.textContent).toContain('/workspace');
+		});
+	});
+
+	describe('model/permissionMode rendering', () => {
+		it('strips the claude- prefix and shows permissionMode', () => {
+			const { container } = render(
+				<SpaceSystemInitCard
+					message={makeInitMessage({ model: 'claude-opus-4-7', permissionMode: 'plan' })}
+				/>
+			);
+			expect(container.textContent).toContain('opus-4-7');
+			expect(container.textContent).toContain('plan');
+		});
+
+		it('falls back to "unknown model" when model is missing', () => {
+			const { container } = render(
+				<SpaceSystemInitCard message={makeInitMessage({ model: undefined })} />
+			);
+			expect(container.textContent).toContain('unknown model');
+		});
+	});
+});

--- a/packages/web/src/components/space/thread/compact/SpaceSystemInitCard.tsx
+++ b/packages/web/src/components/space/thread/compact/SpaceSystemInitCard.tsx
@@ -51,18 +51,23 @@ export function SpaceSystemInitCard({ message }: Props) {
 			class="rounded border bg-sky-50 dark:bg-sky-900/20 border-sky-200 dark:border-sky-800"
 			data-testid="compact-system-init-card"
 		>
+			{/*
+			 * Collapsed row uses the same padding (`px-3 py-2`), icon size
+			 * (`w-4 h-4`), and text size (`text-xs`) as `SDKResultMessage` so
+			 * the two render at matching heights in the compact feed.
+			 */}
 			<button
 				type="button"
 				onClick={() => setExpanded((v) => !v)}
-				class="w-full px-2.5 py-1.5 flex items-center justify-between gap-2 hover:bg-sky-100 dark:hover:bg-sky-900/30 transition-colors text-left rounded"
+				class="w-full px-3 py-2 flex items-center justify-between gap-2 hover:bg-sky-100 dark:hover:bg-sky-900/30 transition-colors text-left rounded"
 				aria-expanded={expanded}
 				data-testid="compact-system-init-toggle"
 			>
-				<div class="flex items-center gap-2 min-w-0">
+				<div class="flex items-center gap-2 min-w-0 text-xs">
 					{/* Chevron rotates when expanded */}
 					<svg
 						class={
-							'w-3 h-3 flex-shrink-0 text-sky-600 dark:text-sky-400 transition-transform ' +
+							'w-4 h-4 flex-shrink-0 text-sky-600 dark:text-sky-400 transition-transform ' +
 							(expanded ? 'rotate-90' : '')
 						}
 						viewBox="0 0 24 24"
@@ -75,15 +80,15 @@ export function SpaceSystemInitCard({ message }: Props) {
 					>
 						<polyline points="9 18 15 12 9 6" />
 					</svg>
-					<span class="text-[11px] font-medium text-sky-900 dark:text-sky-100 flex-shrink-0">
+					<span class="font-medium text-sky-900 dark:text-sky-100 flex-shrink-0">
 						Session Started
 					</span>
-					<span class="text-[11px] text-sky-700 dark:text-sky-300 font-mono truncate">
+					<span class="text-sky-700 dark:text-sky-300 font-mono truncate">
 						{shortModel(m.model)}
 						{m.permissionMode ? ` · ${m.permissionMode}` : ''}
 					</span>
 				</div>
-				<div class="flex items-center gap-2 flex-shrink-0 text-[10px] text-sky-600 dark:text-sky-400">
+				<div class="flex items-center gap-2 flex-shrink-0 text-xs text-sky-600 dark:text-sky-400">
 					{toolCount > 0 && <span>{toolCount} tools</span>}
 					{mcpCount > 0 && <span>{mcpCount} MCP</span>}
 				</div>

--- a/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.test.tsx
+++ b/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.test.tsx
@@ -419,6 +419,78 @@ describe('SpaceTaskCardFeed', () => {
 		expect(mockSpaceOverlayAgentNameSignal.value).toBe('Coder Agent');
 	});
 
+	/**
+	 * Regression guard: the agent pill should have consistent breathing room
+	 * above the first body row regardless of which SDK block type is first
+	 * (system:init, text, thinking, tool_use). Previously `pt-0.5` on the
+	 * body wrapper left the `Session Started` card butted up against the
+	 * agent header pill.
+	 */
+	describe('agent header spacing (first block type parity)', () => {
+		const firstBlockScenarios: Array<{
+			name: string;
+			build: () => ParsedThreadRow[];
+		}> = [
+			{
+				name: 'system:init first',
+				build: () => [
+					{
+						id: '1',
+						sessionId: 'sess-coder',
+						label: 'Coder Agent',
+						taskId: 'task-1',
+						taskTitle: 'Task One',
+						createdAt: 1,
+						turnIndex: undefined,
+						turnHiddenMessageCount: undefined,
+						message: {
+							type: 'system',
+							subtype: 'init',
+							model: 'sonnet-4-5',
+							permissionMode: 'default',
+							tools: ['Read', 'Write'],
+							mcp_servers: [],
+						} as any,
+						fallbackText: null,
+					},
+				],
+			},
+			{
+				name: 'text first',
+				build: () => [makeAssistantTextRow('1', 'Coder Agent', 'hello world')],
+			},
+			{
+				name: 'tool_use first',
+				build: () => [makeToolUseRow('1', 'Coder Agent', 'Read')],
+			},
+			{
+				name: 'user message first',
+				build: () => [makeUserRow('1', 'Coder Agent', 'Start coding please')],
+			},
+		];
+
+		for (const scenario of firstBlockScenarios) {
+			it(`applies consistent body top-padding when ${scenario.name}`, () => {
+				const { container } = render(
+					<SpaceTaskCardFeed
+						parsedRows={scenario.build()}
+						taskId="task-1"
+						maps={fakeMaps as any}
+						isAgentActive={false}
+					/>
+				);
+				const body = container.querySelector('[data-testid="compact-block-body"]') as HTMLElement;
+				expect(body).toBeTruthy();
+				// The body wrapper must apply a non-minimal top padding so the
+				// first block does not butt against the agent header pill.
+				// We check the class list rather than the computed style
+				// because jsdom doesn't resolve Tailwind utility classes.
+				expect(body.className).toContain('pt-2');
+				expect(body.className).not.toContain('pt-0.5');
+			});
+		}
+	});
+
 	it('renders subagent result/error rows (no filtering)', () => {
 		const rows = [
 			makeToolUseRow('a1', 'Task Agent', 'Task', 'sess-task'),

--- a/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.tsx
+++ b/packages/web/src/components/space/thread/compact/SpaceTaskCardFeed.tsx
@@ -183,7 +183,11 @@ function renderAgentBlock(
 
 			{renderAgentHeaderPill(block, isClickable, handleOpenAgentOverlay, handleHeaderKeyDown)}
 
-			<div class="pl-4 pt-0.5 space-y-1" data-testid="compact-block-body">
+			{/* Body spacing: pt-2 provides consistent breathing room below the
+			    agent pill regardless of the first block type (system:init,
+			    text, thinking, tool_use). The previous pt-0.5 left system:init
+			    cards butting directly against the pill. */}
+			<div class="pl-4 pt-2 space-y-1" data-testid="compact-block-body">
 				{block.rows.flatMap((row) => {
 					const key = String(row.id);
 					const rowNode = renderRow(row, maps, key === runningRowId);

--- a/packages/web/src/components/space/thread/space-task-thread-events.ts
+++ b/packages/web/src/components/space/thread/space-task-thread-events.ts
@@ -1,6 +1,7 @@
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import {
 	type ContentBlock,
+	hasRenderableThinking,
 	isSDKAssistantMessage,
 	isSDKRateLimitEvent,
 	isSDKResultMessage,
@@ -142,6 +143,12 @@ function extractAssistantEvents(
 		const eventId = `${String(row.id)}-assistant-${idx}`;
 
 		if (isThinkingBlock(block)) {
+			// Skip Opus 4.7 "omitted" thinking stubs — they carry an empty
+			// `thinking` payload (plus a signature for multi-turn continuity)
+			// and would otherwise produce a blank "Thinking" thread event.
+			if (!hasRenderableThinking(block)) {
+				continue;
+			}
 			events.push({
 				id: eventId,
 				label: row.label,


### PR DESCRIPTION
Fixes three compact task-thread UI issues:

1. **Agent header spacing** — bump block-body `pt-0.5 → pt-2` in `SpaceTaskCardFeed` so the "CODER" pill gets consistent breathing room below it regardless of the first block type.
2. **system:init card height parity** — swap `SpaceSystemInitCard`'s hand-tuned `px-2.5 py-1.5` + `text-[11px]/[10px]` chrome for the same `px-3 py-2` + `text-xs` chrome used by `SDKResultMessage`, so the two cards line up pixel-for-pixel.
3. **Opus 4.7 empty thinking blocks** — Anthropic's `thinking.display = 'omitted'` returns a ContentBlock with empty `thinking: ''` (but a non-empty `signature`). Add `hasRenderableThinking()` and filter those out of `SDKAssistantMessage` + `AgentTurnBlock`; `ThinkingBlock` also guards defensively. Added `redacted_thinking` to the ContentBlock union. Sonnet 4.5 / Opus 4.5 / Haiku thinking blocks are unaffected.

## Test plan
- [x] `bunx vitest run` — 4 updated web test files, 92 tests pass
- [x] `bun test packages/shared/tests/type-guards.test.ts` — 65 pass
- [x] `bun run check` — lint + typecheck + knip clean
- [ ] Visually verify in dev UI that Opus 4.7 no longer shows "Thinking · 0 characters"
- [ ] Visually verify collapsed system:init + result cards line up in the thread