### PR TITLE
ChatContainer → LiveQuery migration + widen space-agent-tools to all Space sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,6 +294,23 @@ make self-test TEST=tests/core/navigation-3-column.e2e.ts
 - Always run a single E2E test file at a time — too slow to run all together
 - If a test scenario can't be triggered through the UI (e.g., token expiry, malformed server responses), it belongs in daemon integration tests, not E2E
 
+## Space Runtime
+
+### Space tool surface
+
+Every session whose `session.context.spaceId` is set — **not just** the Space chat agent — is attached to the `space-agent-tools` MCP server at startup. This means worker sessions, coder sessions, room_chat sessions opened in a Space, and any ad-hoc sessions created with a Space as their context can all query Space state, read/write gate data, signal tasks, etc.
+
+- **Wiring:** `SpaceRuntimeService.attachSpaceToolsToMemberSession(session)` runs for each member session (from `session.created` event + startup backfill). It uses `AgentSession.mergeRuntimeMcpServers({ 'space-agent-tools': … })` so other runtime-attached MCP servers (room tools, db-query, task-agent glue) are preserved.
+- **Not re-attached here:** `space_chat` sessions (`setupSpaceAgentSession` already attaches) and `space_task_agent` sessions (TaskAgentManager attaches them during config build — attaching again afterwards would race with its `setRuntimeMcpServers`).
+- **Permissions:** All gating (writer auth, autonomy level) happens inside the tool handlers themselves, so widening the surface is safe.
+- **No `myAgentName` for ordinary members:** gate writer-authorization for member sessions falls through to the autonomy path, matching the existing contract.
+
+### LiveQuery: `messages.bySession`
+
+SDK messages for a session are published as a LiveQuery under the name `messages.bySession` in `packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts`. The frontend `SessionStore` subscribes via `hub.request('liveQuery.subscribe', { queryName: 'messages.bySession', params: [sessionId, limit], subscriptionId })` and applies the resulting snapshot + delta stream — no per-message RPC fetch and no `state.sdkMessages.delta` event listening. Optimistic user echo is preserved via `pendingLocalMessageUuids` until the snapshot/delta includes the user's message.
+
+---
+
 ## Mission System
 
 The Mission System (Goal V2) extends the room's goal tracking with structured, automated workflows. Use the following terminology consistently across code, tests, and documentation.

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -685,6 +685,27 @@ export class AgentSession
 	}
 
 	/**
+	 * Merge additional runtime MCP servers into the in-memory session config.
+	 *
+	 * Unlike `setRuntimeMcpServers`, this preserves existing entries and only
+	 * overwrites the keys present in `additional`. Used when a cross-cutting
+	 * subsystem (e.g., `SpaceRuntimeService`) wants to attach a shared MCP
+	 * server (like `space-agent-tools`) to a session without disturbing other
+	 * runtime-attached servers (e.g., `task-agent`, `db-query`, `room-tools`)
+	 * that may have been added by other owners.
+	 */
+	mergeRuntimeMcpServers(additional: Record<string, McpServerConfig>): void {
+		const existing = this.session.config?.mcpServers ?? {};
+		this.session.config = {
+			...this.session.config,
+			mcpServers: {
+				...existing,
+				...additional,
+			},
+		};
+	}
+
+	/**
 	 * Apply a runtime system prompt to in-memory session config only.
 	 * Used to inject context-specific instructions (e.g. room workflow guidance)
 	 * without persisting them to the database.

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -1160,6 +1160,119 @@ WHERE j.value = s.id AND s.status != 'archived' AND s.type != 'space_chat'
 ORDER BY s.last_active_at DESC, s.id DESC
 `.trim();
 
+/**
+ * SQL for `messages.bySession` LiveQuery.
+ *
+ * Returns SDK messages for a session in the same shape that
+ * `SDKMessageRepository.getSDKMessages()` produces:
+ *   - Top-level messages (no `parent_tool_use_id`), limited to the most recent
+ *     N rows (by timestamp DESC).
+ *   - Plus subagent messages (rows whose `parent_tool_use_id` is a tool_use id
+ *     emitted by one of those top-level assistant rows).
+ *   - User messages with `send_status = 'deferred'` or `'enqueued'` are
+ *     excluded, matching the RPC behavior.
+ *
+ * Parameters (positional, via `?1` / `?2`):
+ *   ?1 — session_id (used twice because the CTE references sdk_messages twice)
+ *   ?2 — top-level row limit (default 100 from the client)
+ *
+ * Mapping: the raw row carries the JSON-serialised SDK message in `content`,
+ * plus `timestamp` (epoch ms), `sendStatus`, and `origin`.  `mapMessageRow`
+ * inflates the JSON and merges the extras to produce a ChatMessage-shaped
+ * object.
+ */
+const MESSAGES_BY_SESSION_SQL = `
+WITH top_level AS (
+  SELECT
+    id,
+    sdk_message,
+    timestamp,
+    send_status,
+    origin
+  FROM sdk_messages
+  WHERE session_id = ?1
+    AND json_extract(sdk_message, '$.parent_tool_use_id') IS NULL
+    AND (message_type != 'user' OR COALESCE(send_status, 'consumed') IN ('consumed', 'failed'))
+  ORDER BY timestamp DESC, id DESC
+  LIMIT ?2
+),
+tool_use_ids AS (
+  SELECT DISTINCT json_extract(je.value, '$.id') AS id
+  FROM top_level,
+       json_each(json_extract(top_level.sdk_message, '$.message.content')) AS je
+  WHERE json_extract(top_level.sdk_message, '$.type') = 'assistant'
+    AND json_extract(je.value, '$.type') = 'tool_use'
+    AND json_extract(je.value, '$.id') IS NOT NULL
+),
+subagent AS (
+  SELECT
+    sm.id AS id,
+    sm.sdk_message AS sdk_message,
+    sm.timestamp AS timestamp,
+    sm.send_status AS send_status,
+    sm.origin AS origin
+  FROM sdk_messages sm
+  WHERE sm.session_id = ?1
+    AND json_extract(sm.sdk_message, '$.parent_tool_use_id') IN (SELECT id FROM tool_use_ids)
+    AND (sm.message_type != 'user' OR COALESCE(sm.send_status, 'consumed') IN ('consumed', 'failed'))
+)
+SELECT
+  id,
+  sdk_message                                                       AS content,
+  CAST((julianday(timestamp) - 2440587.5) * 86400000 AS INTEGER)    AS timestamp,
+  send_status                                                       AS sendStatus,
+  origin                                                            AS origin
+FROM top_level
+UNION ALL
+SELECT
+  id,
+  sdk_message                                                       AS content,
+  CAST((julianday(timestamp) - 2440587.5) * 86400000 AS INTEGER)    AS timestamp,
+  send_status                                                       AS sendStatus,
+  origin                                                            AS origin
+FROM subagent
+ORDER BY timestamp ASC, id ASC
+`.trim();
+
+/**
+ * Map a raw `messages.bySession` row into a ChatMessage-shaped object.
+ *
+ * Mirrors the behaviour of `SDKMessageRepository.getSDKMessages()`:
+ *   - Parse the `sdk_message` JSON blob and spread its fields onto the output.
+ *   - Override `origin` with the DB column value — explicit `undefined` is
+ *     preserved so any SDK-level `origin?: SDKMessageOrigin` object gets
+ *     stripped in favour of NeoKai's `MessageOrigin` string.
+ *   - Attach `timestamp` (epoch ms, computed SQL-side).
+ *   - Attach `sendStatus` only when the DB column equals `'failed'`, so the UI
+ *     can render the retry affordance without carrying 'consumed' through the
+ *     message stream.
+ *   - Attach `id` so client-side LiveQuery diffing is stable even when the
+ *     SDK message lacks a `uuid`.
+ */
+function mapMessageRow(row: Record<string, unknown>): Record<string, unknown> {
+	const contentRaw = row.content;
+	let parsed: Record<string, unknown> = {};
+	if (typeof contentRaw === 'string') {
+		try {
+			parsed = JSON.parse(contentRaw) as Record<string, unknown>;
+		} catch {
+			// Corrupted JSON — return a sentinel object so the client doesn't crash.
+			parsed = { type: 'unknown', rawContent: contentRaw };
+		}
+	}
+
+	const extras: Record<string, unknown> = {
+		id: row.id,
+		timestamp: typeof row.timestamp === 'number' ? row.timestamp : Number(row.timestamp ?? 0),
+		origin: row.origin != null ? row.origin : undefined,
+	};
+	if (row.sendStatus === 'failed') {
+		extras.sendStatus = 'failed';
+	}
+
+	return { ...parsed, ...extras };
+}
+
 export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 	[
 		'tasks.byRoom',
@@ -1294,6 +1407,14 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 		},
 	],
 	[
+		'messages.bySession',
+		{
+			sql: MESSAGES_BY_SESSION_SQL,
+			paramCount: 2,
+			mapRow: mapMessageRow,
+		},
+	],
+	[
 		'sessions.list',
 		{
 			sql: SESSIONS_LIST_SQL,
@@ -1370,6 +1491,7 @@ export function setupLiveQueryHandlers(
 	const stmtGroup = db.prepare('SELECT ref_id, group_type FROM session_groups WHERE id = ?');
 	const stmtTask = db.prepare('SELECT room_id FROM tasks WHERE id = ?');
 	const stmtSpace = db.prepare('SELECT id FROM spaces WHERE id = ?');
+	const stmtSession = db.prepare('SELECT id FROM sessions WHERE id = ?');
 
 	// -------------------------------------------------------------------------
 	// liveQuery.subscribe
@@ -1452,6 +1574,27 @@ export function setupLiveQueryHandlers(
 			const spaceId = params[0] as string;
 			if (!stmtSpace.get(spaceId)) {
 				throw new Error(`Unauthorized: space "${spaceId}" not found`);
+			}
+		} else if (queryName === 'messages.bySession') {
+			// Verify the session exists. We intentionally do not restrict by
+			// session type (users can view their own worker, room_chat, space_chat,
+			// task_agent, etc. sessions), and the WebSocket clientId check above
+			// already requires an active connection.
+			const targetSessionId = params[0] as string;
+			if (typeof targetSessionId !== 'string' || targetSessionId.length === 0) {
+				throw new Error('Unauthorized: messages.bySession requires a non-empty sessionId');
+			}
+			if (!stmtSession.get(targetSessionId)) {
+				throw new Error(`Unauthorized: session "${targetSessionId}" not found`);
+			}
+			// Validate the limit parameter is a positive integer so bad input
+			// (e.g. NaN, negative numbers) doesn't silently produce an empty result
+			// set that the client would interpret as "no messages".
+			const limit = params[1];
+			if (typeof limit !== 'number' || !Number.isInteger(limit) || limit <= 0 || limit > 10000) {
+				throw new Error(
+					`Unauthorized: messages.bySession limit must be an integer in [1, 10000], got ${String(limit)}`
+				);
 			}
 		}
 

--- a/packages/daemon/src/lib/space/agents/space-chat-agent.ts
+++ b/packages/daemon/src/lib/space/agents/space-chat-agent.ts
@@ -303,6 +303,17 @@ export function buildSpaceChatSystemPrompt(context: SpaceChatAgentContext = {}):
 			`node is stuck or to read intermediate outputs from individual agents.`
 	);
 
+	// Multi-session coordination note
+	sections.push(`\n## Multi-Session Coordination\n`);
+	sections.push(
+		`Other sessions in this Space — task agents, worker/coder sessions, and any ad-hoc sessions created ` +
+			`with this Space as their context — now share the same \`space-agent-tools\` MCP surface you use. ` +
+			`That means:\n` +
+			`  - Task agents can send messages back to you directly via \`send_message_to_agent\`/\`send_message_to_task\`.\n` +
+			`  - Coordination is bidirectional: you are not the only agent that can inspect tasks, approve gates, or message peers.\n` +
+			`  - When you receive a message from another session, verify the sender context (task id, workflow run id) before acting.`
+	);
+
 	// Operator-supplied context appended last — after all contract sections —
 	// so the NeoKai system contract cannot be overridden by user content.
 	if (context.background) {

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -10,7 +10,7 @@
  */
 
 import type { Database as BunDatabase } from 'bun:sqlite';
-import type { McpServerConfig, Space, SpaceTask } from '@neokai/shared';
+import type { McpServerConfig, Session, Space, SpaceTask } from '@neokai/shared';
 import type { SpaceManager } from '../managers/space-manager';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
@@ -104,6 +104,13 @@ export class SpaceRuntimeService {
 	private readonly nodeExecutionRepo: NodeExecutionRepository;
 	/** Stores db-query server instances per space for cleanup on stop. */
 	private readonly spaceDbQueryServers = new Map<string, DbQueryMcpServer>();
+	/**
+	 * Stores db-query server instances attached to member sessions of a space
+	 * (non-space-chat sessions with `context.spaceId`). Keyed by `sessionId`.
+	 * Each entry holds the server instance so it can be closed when the daemon
+	 * stops, mirroring `spaceDbQueryServers` for the space-chat session.
+	 */
+	private readonly memberSessionDbQueryServers = new Map<string, DbQueryMcpServer>();
 
 	constructor(private readonly config: SpaceRuntimeServiceConfig) {
 		// Ensure nodeExecutionRepo is available — create from db if not provided.
@@ -234,12 +241,25 @@ export class SpaceRuntimeService {
 		}
 		this.spaceDbQueryServers.clear();
 
+		// Close all member-session db-query servers as well.
+		for (const [sessionId, server] of this.memberSessionDbQueryServers) {
+			try {
+				server.close();
+			} catch (error) {
+				log.warn(`Failed to close db-query server for member session ${sessionId}:`, error);
+			}
+		}
+		this.memberSessionDbQueryServers.clear();
+
 		log.info('SpaceRuntimeService stopped');
 	}
 
 	/**
-	 * Subscribe to space.created events so newly created spaces get their chat
-	 * sessions provisioned with MCP tools and system prompt.
+	 * Subscribe to space.created and session.created events so newly created
+	 * spaces get their chat sessions provisioned with MCP tools + system
+	 * prompt, and every new session with a `context.spaceId` gets
+	 * `space-agent-tools` (and `db-query`) attached so it can coordinate with
+	 * the rest of the Space.
 	 *
 	 * Called once during start(). No-op when sessionManager or daemonHub are absent.
 	 */
@@ -257,10 +277,34 @@ export class SpaceRuntimeService {
 			{ sessionId: 'global' }
 		);
 		this.unsubscribers.push(unsubCreated);
+
+		// When any new session is created with `context.spaceId`, attach the
+		// shared Space coordination tools. The space-chat session itself is
+		// handled by `setupSpaceAgentSession` (it also sets the system prompt);
+		// the space_task_agent sessions are handled by `TaskAgentManager`
+		// (which merges `space-agent-tools` into its MCP set). This subscription
+		// covers the remaining cases: worker/coder/general/room_chat sessions
+		// that live inside a Space and need to send/receive messages via
+		// `send_message_to_agent`, inspect tasks, etc.
+		const unsubSessionCreated = daemonHub.on(
+			'session.created',
+			(event) => {
+				void this.attachSpaceToolsToMemberSession(event.session).catch((err) => {
+					log.error(
+						`Failed to attach space tools to session ${event.sessionId} (space ${event.session.context?.spaceId ?? '?'}):`,
+						err
+					);
+				});
+			},
+			{ sessionId: 'global' }
+		);
+		this.unsubscribers.push(unsubSessionCreated);
 	}
 
 	/**
-	 * Provision space:chat:${spaceId} sessions for all existing spaces.
+	 * Provision space:chat:${spaceId} sessions for all existing spaces, and
+	 * attach `space-agent-tools` to every other existing session whose
+	 * `context.spaceId` is set.
 	 *
 	 * Called during start() to re-attach MCP tools and system prompts to existing
 	 * space chat sessions after a daemon restart. The sessions already exist in DB;
@@ -286,6 +330,131 @@ export class SpaceRuntimeService {
 			.catch((err) => {
 				log.error('Failed to list spaces for session provisioning:', err);
 			});
+
+		// Attach `space-agent-tools` (and, if configured, `db-query`) to every
+		// other session that already lives inside a Space. We do this on startup
+		// so a daemon restart doesn't leave pre-existing member sessions without
+		// coordination tools.
+		try {
+			const all = sessionManager.listSessions({ includeArchived: false });
+			for (const session of all) {
+				if (!session.context?.spaceId) continue;
+				void this.attachSpaceToolsToMemberSession(session).catch((err) => {
+					log.error(
+						`Failed to attach space tools to existing session ${session.id} (space ${session.context?.spaceId}):`,
+						err
+					);
+				});
+			}
+		} catch (err) {
+			log.error('Failed to iterate existing sessions for space-tool attachment:', err);
+		}
+	}
+
+	/**
+	 * Attach the shared `space-agent-tools` MCP server (and, when configured,
+	 * a space-scoped `db-query` server) to a session that lives inside a Space
+	 * but is not the Space-chat session itself.
+	 *
+	 * This widens the tool surface from "space chat session only" to "every
+	 * session in the space", so worker/coder/general/room_chat sessions
+	 * spawned inside a Space can coordinate with the rest of the Space
+	 * (e.g., `send_message_to_agent`, `list_task_members`). Permission gating
+	 * inside each tool handler (autonomyLevel checks, writer checks, etc.)
+	 * ensures widening the surface does not bypass access control.
+	 *
+	 * Explicitly skipped for:
+	 *   - `space_chat` sessions — handled by `setupSpaceAgentSession`, which
+	 *     also sets the system prompt.
+	 *   - `space_task_agent` sessions — handled by `TaskAgentManager`, which
+	 *     merges `space-agent-tools` into its own MCP map.
+	 *
+	 * Uses `mergeRuntimeMcpServers` so any previously-attached MCP servers on
+	 * the session (e.g., room tools) are preserved. The session's system
+	 * prompt is **not** touched.
+	 */
+	async attachSpaceToolsToMemberSession(session: Session): Promise<void> {
+		const { sessionManager } = this.config;
+		if (!sessionManager) return;
+		const spaceId = session.context?.spaceId;
+		if (!spaceId) return;
+
+		// Skip sessions that other owners already manage.
+		if (session.type === 'space_chat') return;
+		if (session.type === 'space_task_agent') return;
+
+		const space = await this.config.spaceManager.getSpace(spaceId);
+		if (!space) {
+			log.warn(
+				`attachSpaceToolsToMemberSession: space "${spaceId}" not found (session ${session.id})`
+			);
+			return;
+		}
+
+		const agentSession = await sessionManager.getSessionAsync(session.id);
+		if (!agentSession) {
+			log.warn(`attachSpaceToolsToMemberSession: agent session not found for ${session.id}`);
+			return;
+		}
+
+		const spaceManagerForApproval = this.config.spaceManager;
+		const mcpServer = createSpaceAgentMcpServer({
+			spaceId: space.id,
+			runtime: this.runtime,
+			workflowManager: this.config.spaceWorkflowManager,
+			taskRepo: this.config.taskRepo,
+			nodeExecutionRepo: this.nodeExecutionRepo,
+			workflowRunRepo: this.config.workflowRunRepo,
+			taskManager: new SpaceTaskManager(this.config.db, space.id, this.config.reactiveDb),
+			spaceAgentManager: this.config.spaceAgentManager,
+			taskAgentManager: this.taskAgentManager ?? undefined,
+			gateDataRepo: this.config.gateDataRepo,
+			daemonHub: this.config.daemonHub,
+			onGateChanged: (runId, gateId) => {
+				void this.notifyGateDataChanged(runId, gateId).catch(() => {});
+			},
+			getSpaceAutonomyLevel: async (sid) => {
+				const s = await spaceManagerForApproval.getSpace(sid);
+				return s?.autonomyLevel ?? 1;
+			},
+			// Member sessions don't declare themselves as "space-agent"; they are
+			// ordinary participants in the Space. Leaving myAgentName undefined
+			// means gate writer-authorization paths that rely on matching the
+			// writer name fall through to the autonomy path, which is the
+			// correct gating behavior for non-space-agent callers.
+		});
+
+		const additional: Record<string, McpServerConfig> = {
+			'space-agent-tools': mcpServer as unknown as McpServerConfig,
+		};
+
+		if (this.config.dbPath) {
+			// Close any stale instance for this session (e.g., on re-provision
+			// after daemon restart) to avoid leaking read-only SQLite handles.
+			const existing = this.memberSessionDbQueryServers.get(session.id);
+			if (existing) {
+				try {
+					existing.close();
+				} catch (err) {
+					log.warn(`Failed to close stale db-query server for session ${session.id}:`, err);
+				}
+			}
+			const dbQueryServer = createDbQueryMcpServer({
+				dbPath: this.config.dbPath,
+				scopeType: 'space',
+				scopeValue: space.id,
+			});
+			this.memberSessionDbQueryServers.set(session.id, dbQueryServer);
+			additional['db-query'] = dbQueryServer as unknown as McpServerConfig;
+		}
+
+		// Merge rather than replace — other subsystems (e.g., room tools) may
+		// have already attached their own MCP servers on this session.
+		agentSession.mergeRuntimeMcpServers(additional);
+
+		log.info(
+			`Attached space-agent-tools to member session ${session.id} (space ${space.id}, type ${session.type ?? 'worker'})`
+		);
 	}
 
 	/**

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -299,6 +299,33 @@ export class SpaceRuntimeService {
 			{ sessionId: 'global' }
 		);
 		this.unsubscribers.push(unsubSessionCreated);
+
+		// When a session is deleted, release any per-session db-query server we
+		// spun up for it so read-only SQLite handles don't accumulate on a
+		// long-lived daemon serving many short-lived worker sessions.
+		const unsubSessionDeleted = daemonHub.on(
+			'session.deleted',
+			(event) => {
+				this.releaseMemberSessionDbQuery(event.sessionId);
+			},
+			{ sessionId: 'global' }
+		);
+		this.unsubscribers.push(unsubSessionDeleted);
+	}
+
+	/**
+	 * Close and evict the db-query server instance (if any) we attached to the
+	 * given member session. Safe to call for sessions that never had one.
+	 */
+	private releaseMemberSessionDbQuery(sessionId: string): void {
+		const server = this.memberSessionDbQueryServers.get(sessionId);
+		if (!server) return;
+		try {
+			server.close();
+		} catch (err) {
+			log.warn(`Failed to close db-query server for member session ${sessionId}:`, err);
+		}
+		this.memberSessionDbQueryServers.delete(sessionId);
 	}
 
 	/**
@@ -335,20 +362,30 @@ export class SpaceRuntimeService {
 		// other session that already lives inside a Space. We do this on startup
 		// so a daemon restart doesn't leave pre-existing member sessions without
 		// coordination tools.
-		try {
-			const all = sessionManager.listSessions({ includeArchived: false });
-			for (const session of all) {
-				if (!session.context?.spaceId) continue;
-				void this.attachSpaceToolsToMemberSession(session).catch((err) => {
-					log.error(
-						`Failed to attach space tools to existing session ${session.id} (space ${session.context?.spaceId}):`,
-						err
-					);
-				});
+		//
+		// Run sequentially rather than in parallel: each attach performs a space
+		// lookup and a session lookup (both hit SQLite), and a daemon restarting
+		// with many Space member sessions would otherwise issue a thundering
+		// herd of reads. Sequential is fast enough — the work is small per
+		// session and happens once at startup — and avoids the burst.
+		void (async () => {
+			try {
+				const all = sessionManager.listSessions({ includeArchived: false });
+				for (const session of all) {
+					if (!session.context?.spaceId) continue;
+					try {
+						await this.attachSpaceToolsToMemberSession(session);
+					} catch (err) {
+						log.error(
+							`Failed to attach space tools to existing session ${session.id} (space ${session.context?.spaceId}):`,
+							err
+						);
+					}
+				}
+			} catch (err) {
+				log.error('Failed to iterate existing sessions for space-tool attachment:', err);
 			}
-		} catch (err) {
-			log.error('Failed to iterate existing sessions for space-tool attachment:', err);
-		}
+		})();
 	}
 
 	/**
@@ -431,14 +468,7 @@ export class SpaceRuntimeService {
 		if (this.config.dbPath) {
 			// Close any stale instance for this session (e.g., on re-provision
 			// after daemon restart) to avoid leaking read-only SQLite handles.
-			const existing = this.memberSessionDbQueryServers.get(session.id);
-			if (existing) {
-				try {
-					existing.close();
-				} catch (err) {
-					log.warn(`Failed to close stale db-query server for session ${session.id}:`, err);
-				}
-			}
+			this.releaseMemberSessionDbQuery(session.id);
 			const dbQueryServer = createDbQueryMcpServer({
 				dbPath: this.config.dbPath,
 				scopeType: 'space',

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -73,6 +73,7 @@ import type { SpaceWorktreeManager } from '../managers/space-worktree-manager';
 import type { SubSessionMemberInfo } from '../tools/task-agent-tools';
 import { createTaskAgentMcpServer } from '../tools/task-agent-tools';
 import { createNodeAgentMcpServer } from '../tools/node-agent-tools';
+import { createSpaceAgentMcpServer } from '../tools/space-agent-tools';
 import { createDbQueryMcpServer, type DbQueryMcpServer } from '../../db-query/tools';
 import { ChannelResolver } from './channel-resolver';
 import { ChannelRouter } from './channel-router';
@@ -596,6 +597,33 @@ export class TaskAgentManager {
 				this.taskDbQueryServers.set(taskId, dbQueryServer);
 				taskMcpServers['db-query'] = dbQueryServer as unknown as McpServerConfig;
 			}
+
+			// Attach `space-agent-tools` alongside `task-agent` so the task agent
+			// can coordinate directly with the rest of the Space (e.g., via
+			// `send_message_to_agent`) in the same way the Space chat session
+			// can. Safe because tool handlers gate on autonomy + writer checks.
+			const spaceAgentMcpServer = createSpaceAgentMcpServer({
+				spaceId,
+				runtime: this.config.spaceRuntimeService.getSharedRuntime(),
+				workflowManager: this.config.spaceWorkflowManager,
+				taskRepo: this.config.taskRepo,
+				nodeExecutionRepo: this.config.nodeExecutionRepo,
+				workflowRunRepo: this.config.workflowRunRepo,
+				taskManager,
+				spaceAgentManager: this.config.spaceAgentManager,
+				taskAgentManager: this,
+				gateDataRepo: this.config.gateDataRepo,
+				daemonHub: this.config.daemonHub,
+				onGateChanged: (runId, gateId) => {
+					void this.config.spaceRuntimeService.notifyGateDataChanged(runId, gateId).catch(() => {});
+				},
+				getSpaceAutonomyLevel: async (sid) => {
+					const s = await this.config.spaceManager.getSpace(sid);
+					return s?.autonomyLevel ?? 1;
+				},
+				myAgentName: 'task-agent',
+			});
+			taskMcpServers['space-agent-tools'] = spaceAgentMcpServer as unknown as McpServerConfig;
 
 			agentSession.setRuntimeMcpServers(taskMcpServers);
 

--- a/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
@@ -13,6 +13,7 @@ import type {
 	AgentProcessingState,
 	SelectiveRewindResult,
 	RewindMode,
+	McpServerConfig,
 } from '@neokai/shared';
 import { AgentSession } from '../../../../src/lib/agent/agent-session';
 import type { Database } from '../../../../src/storage/database';
@@ -2199,6 +2200,152 @@ describe('AgentSession', () => {
 			agentSession.setRuntimeSystemPrompt('new prompt');
 
 			expect(agentSession.getSessionData().config.systemPrompt).toBe('new prompt');
+		});
+	});
+
+	describe('mergeRuntimeMcpServers', () => {
+		const makeMockSession = (existingServers?: Record<string, unknown>): Session => ({
+			id: 'space:worker:test',
+			title: 'Space Worker',
+			workspacePath: '/test/workspace',
+			createdAt: new Date().toISOString(),
+			lastActiveAt: new Date().toISOString(),
+			status: 'active',
+			config: {
+				model: 'claude-sonnet-4-5-20250929',
+				maxTokens: 8192,
+				temperature: 1.0,
+				mcpServers: existingServers as Record<string, McpServerConfig> | undefined,
+			},
+			metadata: {
+				messageCount: 0,
+				totalTokens: 0,
+				inputTokens: 0,
+				outputTokens: 0,
+				totalCost: 0,
+				toolCallCount: 0,
+			},
+			type: 'general',
+		});
+
+		const makeMocks = () => {
+			const mockDb = {
+				getSession: mock(() => null),
+				createSession: mock(() => {}),
+				updateSession: mock(() => {}),
+				getMessagesByStatus: mock(() => []),
+			} as unknown as Database;
+			const mockMessageHub = {} as MessageHub;
+			const mockDaemonHub = {
+				emit: mock(async () => {}),
+				on: mock(() => mock(() => {})),
+			} as unknown as DaemonHub;
+			const mockGetApiKey = mock(async () => 'test-api-key');
+			return { mockDb, mockMessageHub, mockDaemonHub, mockGetApiKey };
+		};
+
+		it('should merge new servers into empty mcpServers config without persisting', () => {
+			const mockSession = makeMockSession();
+			const { mockDb, mockMessageHub, mockDaemonHub, mockGetApiKey } = makeMocks();
+
+			const agentSession = new AgentSession(
+				mockSession,
+				mockDb,
+				mockMessageHub,
+				mockDaemonHub,
+				mockGetApiKey
+			);
+
+			expect(agentSession.getSessionData().config.mcpServers).toBeUndefined();
+
+			const newServer = { type: 'sdk', name: 'space-agent-tools' } as unknown as McpServerConfig;
+			agentSession.mergeRuntimeMcpServers({ 'space-agent-tools': newServer });
+
+			const merged = agentSession.getSessionData().config.mcpServers;
+			expect(merged).toBeDefined();
+			expect(merged?.['space-agent-tools']).toBe(newServer);
+
+			// Runtime-only: DB update should NOT be called
+			const updateSessionCalls = (mockDb as unknown as { updateSession: ReturnType<typeof mock> })
+				.updateSession.mock.calls;
+			expect(updateSessionCalls.length).toBe(0);
+		});
+
+		it('should preserve existing mcpServers while adding new entries', () => {
+			const existing = {
+				'task-agent': { type: 'sdk', name: 'task-agent' } as unknown as McpServerConfig,
+				'db-query': { type: 'sdk', name: 'db-query' } as unknown as McpServerConfig,
+			};
+			const mockSession = makeMockSession(existing);
+			const { mockDb, mockMessageHub, mockDaemonHub, mockGetApiKey } = makeMocks();
+
+			const agentSession = new AgentSession(
+				mockSession,
+				mockDb,
+				mockMessageHub,
+				mockDaemonHub,
+				mockGetApiKey
+			);
+
+			const spaceAgent = {
+				type: 'sdk',
+				name: 'space-agent-tools',
+			} as unknown as McpServerConfig;
+			agentSession.mergeRuntimeMcpServers({ 'space-agent-tools': spaceAgent });
+
+			const merged = agentSession.getSessionData().config.mcpServers;
+			expect(merged).toBeDefined();
+			// Existing entries preserved
+			expect(merged?.['task-agent']).toBe(existing['task-agent']);
+			expect(merged?.['db-query']).toBe(existing['db-query']);
+			// New entry added
+			expect(merged?.['space-agent-tools']).toBe(spaceAgent);
+			expect(Object.keys(merged ?? {}).sort()).toEqual([
+				'db-query',
+				'space-agent-tools',
+				'task-agent',
+			]);
+		});
+
+		it('should overwrite only overlapping keys, leaving others untouched', () => {
+			const originalDbQuery = {
+				type: 'sdk',
+				name: 'db-query',
+				mark: 'original',
+			} as unknown as McpServerConfig;
+			const existing = {
+				'task-agent': { type: 'sdk', name: 'task-agent' } as unknown as McpServerConfig,
+				'db-query': originalDbQuery,
+			};
+			const mockSession = makeMockSession(existing);
+			const { mockDb, mockMessageHub, mockDaemonHub, mockGetApiKey } = makeMocks();
+
+			const agentSession = new AgentSession(
+				mockSession,
+				mockDb,
+				mockMessageHub,
+				mockDaemonHub,
+				mockGetApiKey
+			);
+
+			const replacementDbQuery = {
+				type: 'sdk',
+				name: 'db-query',
+				mark: 'replacement',
+			} as unknown as McpServerConfig;
+			agentSession.mergeRuntimeMcpServers({ 'db-query': replacementDbQuery });
+
+			const merged = agentSession.getSessionData().config.mcpServers;
+			// Overlapping key was overwritten
+			expect(merged?.['db-query']).toBe(replacementDbQuery);
+			expect(merged?.['db-query']).not.toBe(originalDbQuery);
+			// Non-overlapping key preserved
+			expect(merged?.['task-agent']).toBe(existing['task-agent']);
+
+			// Runtime-only: DB update should NOT be called
+			const updateSessionCalls = (mockDb as unknown as { updateSession: ReturnType<typeof mock> })
+				.updateSession.mock.calls;
+			expect(updateSessionCalls.length).toBe(0);
 		});
 	});
 

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-messages.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-messages.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Unit tests for the `messages.bySession` named query in NAMED_QUERY_REGISTRY.
+ *
+ * Covers:
+ *  - Registry entry exists with the expected paramCount.
+ *  - Ordering (timestamp ASC, id ASC).
+ *  - LIMIT applied to top-level rows only, with subagent rows included
+ *    regardless of whether their parent was inside the limit.
+ *  - Filtering of user messages by send_status (deferred/enqueued excluded).
+ *  - `mapMessageRow` parses the JSON blob, injects id / timestamp / origin,
+ *    and forwards `sendStatus` only when the DB row is 'failed'.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { createTables } from '../../../../src/storage/schema';
+import { NAMED_QUERY_REGISTRY } from '../../../../src/lib/rpc-handlers/live-query-handlers';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(): BunDatabase {
+	const db = new BunDatabase(':memory:');
+	createTables(db);
+	return db;
+}
+
+interface InsertSessionArgs {
+	id: string;
+	title?: string;
+}
+
+function insertSession(db: BunDatabase, args: InsertSessionArgs): void {
+	db.prepare(
+		`INSERT INTO sessions (id, title, created_at, last_active_at, status, config, metadata)
+		 VALUES (?, ?, datetime('now'), datetime('now'), 'active', '{}', '{}')`
+	).run(args.id, args.title ?? 'Test Session');
+}
+
+interface InsertSdkMessageArgs {
+	id: string;
+	sessionId: string;
+	messageType: string;
+	sdkMessage: Record<string, unknown>;
+	/** ISO timestamp (stored TEXT). Default is a fixed known value. */
+	timestamp?: string;
+	sendStatus?: 'deferred' | 'enqueued' | 'consumed' | 'failed';
+	origin?: 'human' | 'neo' | 'system' | null;
+}
+
+function insertSdkMessage(db: BunDatabase, args: InsertSdkMessageArgs): void {
+	db.prepare(
+		`INSERT INTO sdk_messages
+		 (id, session_id, message_type, sdk_message, timestamp, send_status, origin)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`
+	).run(
+		args.id,
+		args.sessionId,
+		args.messageType,
+		JSON.stringify(args.sdkMessage),
+		args.timestamp ?? '2024-01-01 00:00:00',
+		args.sendStatus ?? 'consumed',
+		args.origin ?? null
+	);
+}
+
+function query(db: BunDatabase, sessionId: string, limit: number): Record<string, unknown>[] {
+	const entry = NAMED_QUERY_REGISTRY.get('messages.bySession')!;
+	const rows = db.prepare(entry.sql).all(sessionId, limit) as Record<string, unknown>[];
+	return entry.mapRow ? rows.map(entry.mapRow) : rows;
+}
+
+// ---------------------------------------------------------------------------
+// Registry metadata
+// ---------------------------------------------------------------------------
+
+describe('messages.bySession — registry metadata', () => {
+	test('registry contains messages.bySession entry', () => {
+		expect(NAMED_QUERY_REGISTRY.has('messages.bySession')).toBe(true);
+	});
+
+	test('messages.bySession paramCount is 2', () => {
+		expect(NAMED_QUERY_REGISTRY.get('messages.bySession')!.paramCount).toBe(2);
+	});
+
+	test('messages.bySession has a mapRow function', () => {
+		expect(typeof NAMED_QUERY_REGISTRY.get('messages.bySession')!.mapRow).toBe('function');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// SQL behavior
+// ---------------------------------------------------------------------------
+
+describe('messages.bySession — SQL behavior', () => {
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		db = makeDb();
+		insertSession(db, { id: 's1' });
+		insertSession(db, { id: 's2' });
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	test('returns empty array on fresh session', () => {
+		expect(query(db, 's1', 100)).toEqual([]);
+	});
+
+	test('returns only messages for the requested session', () => {
+		insertSdkMessage(db, {
+			id: 'm1',
+			sessionId: 's1',
+			messageType: 'assistant',
+			sdkMessage: { type: 'assistant', uuid: 'u1', message: { content: [] } },
+			timestamp: '2024-01-01 00:00:01',
+		});
+		insertSdkMessage(db, {
+			id: 'm2',
+			sessionId: 's2',
+			messageType: 'assistant',
+			sdkMessage: { type: 'assistant', uuid: 'u2', message: { content: [] } },
+			timestamp: '2024-01-01 00:00:02',
+		});
+
+		const rows = query(db, 's1', 100);
+		expect(rows).toHaveLength(1);
+		expect(rows[0].uuid).toBe('u1');
+	});
+
+	test('excludes user messages with send_status deferred or enqueued', () => {
+		insertSdkMessage(db, {
+			id: 'm-consumed',
+			sessionId: 's1',
+			messageType: 'user',
+			sdkMessage: { type: 'user', uuid: 'u1', message: { content: 'ok' } },
+			timestamp: '2024-01-01 00:00:01',
+			sendStatus: 'consumed',
+		});
+		insertSdkMessage(db, {
+			id: 'm-deferred',
+			sessionId: 's1',
+			messageType: 'user',
+			sdkMessage: { type: 'user', uuid: 'u2', message: { content: 'deferred' } },
+			timestamp: '2024-01-01 00:00:02',
+			sendStatus: 'deferred',
+		});
+		insertSdkMessage(db, {
+			id: 'm-enqueued',
+			sessionId: 's1',
+			messageType: 'user',
+			sdkMessage: { type: 'user', uuid: 'u3', message: { content: 'enqueued' } },
+			timestamp: '2024-01-01 00:00:03',
+			sendStatus: 'enqueued',
+		});
+		insertSdkMessage(db, {
+			id: 'm-failed',
+			sessionId: 's1',
+			messageType: 'user',
+			sdkMessage: { type: 'user', uuid: 'u4', message: { content: 'failed' } },
+			timestamp: '2024-01-01 00:00:04',
+			sendStatus: 'failed',
+		});
+
+		const rows = query(db, 's1', 100);
+		const uuids = rows.map((r) => r.uuid as string).sort();
+		// consumed and failed are kept; deferred and enqueued are dropped.
+		expect(uuids).toEqual(['u1', 'u4']);
+	});
+
+	test('orders by timestamp ASC, id ASC', () => {
+		insertSdkMessage(db, {
+			id: 'b',
+			sessionId: 's1',
+			messageType: 'assistant',
+			sdkMessage: { type: 'assistant', uuid: 'u-b', message: { content: [] } },
+			timestamp: '2024-01-01 00:00:02',
+		});
+		insertSdkMessage(db, {
+			id: 'a',
+			sessionId: 's1',
+			messageType: 'assistant',
+			sdkMessage: { type: 'assistant', uuid: 'u-a', message: { content: [] } },
+			timestamp: '2024-01-01 00:00:01',
+		});
+		insertSdkMessage(db, {
+			id: 'c',
+			sessionId: 's1',
+			messageType: 'assistant',
+			sdkMessage: { type: 'assistant', uuid: 'u-c', message: { content: [] } },
+			timestamp: '2024-01-01 00:00:02', // same timestamp as 'b'
+		});
+
+		const rows = query(db, 's1', 100);
+		const ids = rows.map((r) => r.id);
+		// 'a' comes first (earliest timestamp); 'b' and 'c' share a timestamp
+		// and must order by id ASC.
+		expect(ids).toEqual(['a', 'b', 'c']);
+	});
+
+	test('limit applies to top-level rows only; keeps most recent N', () => {
+		// Insert 5 top-level assistant messages; set limit to 3.
+		for (let i = 1; i <= 5; i++) {
+			insertSdkMessage(db, {
+				id: `t${i}`,
+				sessionId: 's1',
+				messageType: 'assistant',
+				sdkMessage: { type: 'assistant', uuid: `u${i}`, message: { content: [] } },
+				timestamp: `2024-01-01 00:00:0${i}`,
+			});
+		}
+
+		const rows = query(db, 's1', 3);
+		const ids = rows.map((r) => r.id);
+		// With LIMIT=3, only the 3 most recent top-level rows should be included,
+		// and returned in ascending order (t3, t4, t5).
+		expect(ids).toEqual(['t3', 't4', 't5']);
+	});
+
+	test('includes subagent messages whose parent_tool_use_id matches a top-level tool_use', () => {
+		// Top-level assistant row with a tool_use in its content.
+		insertSdkMessage(db, {
+			id: 'parent',
+			sessionId: 's1',
+			messageType: 'assistant',
+			sdkMessage: {
+				type: 'assistant',
+				uuid: 'u-parent',
+				message: {
+					content: [
+						{ type: 'text', text: 'calling tool' },
+						{ type: 'tool_use', id: 'tool-use-1', name: 'sub', input: {} },
+					],
+				},
+			},
+			timestamp: '2024-01-01 00:00:01',
+		});
+
+		// Subagent row keyed by parent_tool_use_id matching that tool_use.id.
+		insertSdkMessage(db, {
+			id: 'child',
+			sessionId: 's1',
+			messageType: 'assistant',
+			sdkMessage: {
+				type: 'assistant',
+				uuid: 'u-child',
+				parent_tool_use_id: 'tool-use-1',
+				message: { content: [{ type: 'text', text: 'sub result' }] },
+			},
+			timestamp: '2024-01-01 00:00:02',
+		});
+
+		// Unrelated subagent row whose parent_tool_use_id does NOT match.
+		insertSdkMessage(db, {
+			id: 'stranger',
+			sessionId: 's1',
+			messageType: 'assistant',
+			sdkMessage: {
+				type: 'assistant',
+				uuid: 'u-stranger',
+				parent_tool_use_id: 'not-a-real-tool-use',
+				message: { content: [] },
+			},
+			timestamp: '2024-01-01 00:00:03',
+		});
+
+		const rows = query(db, 's1', 100);
+		const uuids = rows.map((r) => r.uuid as string).sort();
+		expect(uuids).toEqual(['u-child', 'u-parent']);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// mapRow — inflation + field extraction
+// ---------------------------------------------------------------------------
+
+describe('messages.bySession — mapRow', () => {
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		db = makeDb();
+		insertSession(db, { id: 's1' });
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	test('parses the sdk_message JSON blob and spreads its fields', () => {
+		insertSdkMessage(db, {
+			id: 'm1',
+			sessionId: 's1',
+			messageType: 'assistant',
+			sdkMessage: {
+				type: 'assistant',
+				uuid: 'u1',
+				message: { content: [{ type: 'text', text: 'hello' }] },
+			},
+			timestamp: '2024-01-01 00:00:01',
+		});
+
+		const [row] = query(db, 's1', 10);
+		expect(row.type).toBe('assistant');
+		expect(row.uuid).toBe('u1');
+		expect(row.message).toEqual({ content: [{ type: 'text', text: 'hello' }] });
+	});
+
+	test('attaches DB id for stable diffing', () => {
+		insertSdkMessage(db, {
+			id: 'stable-id-42',
+			sessionId: 's1',
+			messageType: 'assistant',
+			sdkMessage: { type: 'assistant', message: { content: [] } }, // no uuid
+			timestamp: '2024-01-01 00:00:01',
+		});
+
+		const [row] = query(db, 's1', 10);
+		expect(row.id).toBe('stable-id-42');
+	});
+
+	test('computes timestamp as epoch millis from TEXT column', () => {
+		insertSdkMessage(db, {
+			id: 'm1',
+			sessionId: 's1',
+			messageType: 'assistant',
+			sdkMessage: { type: 'assistant', uuid: 'u1', message: { content: [] } },
+			timestamp: '2024-01-01 00:00:00',
+		});
+
+		const [row] = query(db, 's1', 10);
+		expect(typeof row.timestamp).toBe('number');
+		// `2024-01-01 00:00:00` UTC → epoch ms
+		expect(row.timestamp).toBe(new Date('2024-01-01T00:00:00Z').getTime());
+	});
+
+	test('overrides origin with DB column (string) — stripping nested SDK-level origin', () => {
+		insertSdkMessage(db, {
+			id: 'm1',
+			sessionId: 's1',
+			messageType: 'user',
+			sdkMessage: {
+				type: 'user',
+				uuid: 'u1',
+				origin: { kind: 'sdk-something' },
+				message: { content: 'hi' },
+			},
+			timestamp: '2024-01-01 00:00:01',
+			origin: 'human',
+		});
+
+		const [row] = query(db, 's1', 10);
+		expect(row.origin).toBe('human');
+	});
+
+	test('sets origin to undefined when DB column is NULL', () => {
+		insertSdkMessage(db, {
+			id: 'm1',
+			sessionId: 's1',
+			messageType: 'assistant',
+			sdkMessage: {
+				type: 'assistant',
+				uuid: 'u1',
+				origin: { kind: 'sdk-something' },
+				message: { content: [] },
+			},
+			timestamp: '2024-01-01 00:00:01',
+			origin: null,
+		});
+
+		const [row] = query(db, 's1', 10);
+		expect(row.origin).toBeUndefined();
+	});
+
+	test('attaches sendStatus only when DB column is "failed"', () => {
+		insertSdkMessage(db, {
+			id: 'm-ok',
+			sessionId: 's1',
+			messageType: 'user',
+			sdkMessage: { type: 'user', uuid: 'u-ok', message: { content: 'ok' } },
+			timestamp: '2024-01-01 00:00:01',
+			sendStatus: 'consumed',
+		});
+		insertSdkMessage(db, {
+			id: 'm-fail',
+			sessionId: 's1',
+			messageType: 'user',
+			sdkMessage: { type: 'user', uuid: 'u-fail', message: { content: 'fail' } },
+			timestamp: '2024-01-01 00:00:02',
+			sendStatus: 'failed',
+		});
+
+		const rows = query(db, 's1', 10);
+		const okRow = rows.find((r) => r.uuid === 'u-ok')!;
+		const failRow = rows.find((r) => r.uuid === 'u-fail')!;
+		expect('sendStatus' in okRow).toBe(false);
+		expect(failRow.sendStatus).toBe('failed');
+	});
+});

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-mcp.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-mcp.test.ts
@@ -261,6 +261,8 @@ function buildManager(opts: {
 		spaceWorkflowManager: workflowManager,
 		spaceRuntimeService: {
 			createOrGetRuntime: async (_spaceId: string) => runtime,
+			getSharedRuntime: () => runtime,
+			notifyGateDataChanged: async (_runId: string, _gateId: string) => {},
 		} as unknown as import('../../../../src/lib/space/runtime/space-runtime-service.ts').SpaceRuntimeService,
 		taskRepo,
 		workflowRunRepo,
@@ -432,8 +434,12 @@ describe('TaskAgentManager — registry MCP merge (Task 3.4)', () => {
 		const session = [...createdSessions.values()][0]!;
 		const mcpServers = session._mcpServers;
 		expect(mcpServers['task-agent']).toBeDefined();
-		// Only the task-agent server should be present
-		expect(Object.keys(mcpServers)).toEqual(['task-agent']);
+		// `space-agent-tools` is now always attached to space-scoped sessions so
+		// task agents can coordinate with the rest of the Space (list tasks,
+		// send messages, etc.). When the registry is empty, only these two
+		// built-in servers should be present.
+		expect(mcpServers['space-agent-tools']).toBeDefined();
+		expect(Object.keys(mcpServers).sort()).toEqual(['space-agent-tools', 'task-agent']);
 	});
 });
 

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
@@ -256,6 +256,8 @@ function makeCtx(): TestCtx {
 
 	const mockSpaceRuntimeService = {
 		createOrGetRuntime: async (_spaceId: string) => runtime,
+		getSharedRuntime: () => runtime,
+		notifyGateDataChanged: async (_runId: string, _gateId: string) => {},
 	};
 
 	const mockSessionManager = {

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-worktree.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-worktree.test.ts
@@ -337,6 +337,8 @@ function makeCtx(worktreePath = '/tmp/worktrees/test-task'): TestCtx {
 
 	const mockSpaceRuntimeService = {
 		createOrGetRuntime: async (_spaceId: string) => runtime,
+		getSharedRuntime: () => runtime,
+		notifyGateDataChanged: async (_runId: string, _gateId: string) => {},
 	};
 
 	const mockSessionManager = {

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
@@ -292,6 +292,8 @@ function makeCtx(): TestCtx {
 
 	const mockSpaceRuntimeService = {
 		createOrGetRuntime: async (_spaceId: string) => runtime,
+		getSharedRuntime: () => runtime,
+		notifyGateDataChanged: async (_runId: string, _gateId: string) => {},
 	};
 
 	const mockSessionManager = {

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-session-lifecycle.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-session-lifecycle.test.ts
@@ -286,6 +286,8 @@ function makeCtx(): TestCtx {
 
 	const mockSpaceRuntimeService = {
 		createOrGetRuntime: async (_spaceId: string) => runtime,
+		getSharedRuntime: () => runtime,
+		notifyGateDataChanged: async (_runId: string, _gateId: string) => {},
 	};
 
 	const mockSessionManager = {
@@ -450,6 +452,8 @@ describe('Task Agent Session Lifecycle', () => {
 				spaceWorkflowManager: ctx.workflowManager,
 				spaceRuntimeService: {
 					createOrGetRuntime: async () => ctx.runtime,
+					getSharedRuntime: () => ctx.runtime,
+					notifyGateDataChanged: async () => {},
 				} as unknown as import('../../../../src/lib/space/runtime/space-runtime-service.ts').SpaceRuntimeService,
 				taskRepo: ctx.taskRepo,
 				workflowRunRepo: ctx.workflowRunRepo,
@@ -514,6 +518,8 @@ describe('Task Agent Session Lifecycle', () => {
 				spaceWorkflowManager: ctx.workflowManager,
 				spaceRuntimeService: {
 					createOrGetRuntime: async () => ctx.runtime,
+					getSharedRuntime: () => ctx.runtime,
+					notifyGateDataChanged: async () => {},
 				} as unknown as import('../../../../src/lib/space/runtime/space-runtime-service.ts').SpaceRuntimeService,
 				taskRepo: ctx.taskRepo,
 				workflowRunRepo: ctx.workflowRunRepo,
@@ -584,6 +590,8 @@ describe('Task Agent Session Lifecycle', () => {
 				spaceWorkflowManager: ctx.workflowManager,
 				spaceRuntimeService: {
 					createOrGetRuntime: async () => ctx.runtime,
+					getSharedRuntime: () => ctx.runtime,
+					notifyGateDataChanged: async () => {},
 				} as unknown as import('../../../../src/lib/space/runtime/space-runtime-service.ts').SpaceRuntimeService,
 				taskRepo: ctx.taskRepo,
 				workflowRunRepo: ctx.workflowRunRepo,
@@ -672,6 +680,8 @@ describe('Task Agent Session Lifecycle', () => {
 				spaceWorkflowManager: ctx.workflowManager,
 				spaceRuntimeService: {
 					createOrGetRuntime: async () => ctx.runtime,
+					getSharedRuntime: () => ctx.runtime,
+					notifyGateDataChanged: async () => {},
 				} as unknown as import('../../../../src/lib/space/runtime/space-runtime-service.ts').SpaceRuntimeService,
 				taskRepo: ctx.taskRepo,
 				workflowRunRepo: ctx.workflowRunRepo,
@@ -729,6 +739,8 @@ describe('Task Agent Session Lifecycle', () => {
 				spaceWorkflowManager: ctx.workflowManager,
 				spaceRuntimeService: {
 					createOrGetRuntime: async () => ctx.runtime,
+					getSharedRuntime: () => ctx.runtime,
+					notifyGateDataChanged: async () => {},
 				} as unknown as import('../../../../src/lib/space/runtime/space-runtime-service.ts').SpaceRuntimeService,
 				taskRepo: ctx.taskRepo,
 				workflowRunRepo: ctx.workflowRunRepo,
@@ -782,6 +794,8 @@ describe('Task Agent Session Lifecycle', () => {
 				spaceWorkflowManager: ctx.workflowManager,
 				spaceRuntimeService: {
 					createOrGetRuntime: async () => ctx.runtime,
+					getSharedRuntime: () => ctx.runtime,
+					notifyGateDataChanged: async () => {},
 				} as unknown as import('../../../../src/lib/space/runtime/space-runtime-service.ts').SpaceRuntimeService,
 				taskRepo: ctx.taskRepo,
 				workflowRunRepo: ctx.workflowRunRepo,

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -265,6 +265,10 @@ describe('SpaceRuntimeService', () => {
 			return {
 				getSessionAsync: mock(async () => session),
 				createSession: mock(async () => 'space:chat:space-1'),
+				// Startup backfill calls listSessions() for the non-space-chat
+				// member-session sweep. Default to empty — tests that care
+				// override this mock.
+				listSessions: mock(() => [] as Session[]),
 			} as unknown as SessionManager;
 		}
 
@@ -425,8 +429,9 @@ describe('SpaceRuntimeService', () => {
 			svc.start();
 			await svc.stop();
 
-			// Two subscriptions are registered: space.created and session.created.
-			expect(unsubFn).toHaveBeenCalledTimes(2);
+			// Three subscriptions are registered: space.created, session.created,
+			// and session.deleted (which releases per-session db-query servers).
+			expect(unsubFn).toHaveBeenCalledTimes(3);
 		});
 	});
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -29,7 +29,7 @@ import type {
 import type { SessionManager } from '../../../../src/lib/session-manager.ts';
 import type { AgentSession } from '../../../../src/lib/agent/agent-session.ts';
 import type { DaemonHub } from '../../../../src/lib/daemon-hub.ts';
-import type { Space } from '@neokai/shared';
+import type { McpServerConfig, Session, Space } from '@neokai/shared';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
 import { SpaceWorkflowRunRepository as SpaceWorkflowRunRepo } from '../../../../src/storage/repositories/space-workflow-run-repository.ts';
@@ -425,7 +425,184 @@ describe('SpaceRuntimeService', () => {
 			svc.start();
 			await svc.stop();
 
-			expect(unsubFn).toHaveBeenCalledTimes(1);
+			// Two subscriptions are registered: space.created and session.created.
+			expect(unsubFn).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	// ─── attachSpaceToolsToMemberSession ─────────────────────────────────────
+	//
+	// These tests cover the wider scope introduced for Task #31 Part B:
+	// every session whose `context.spaceId` is set (other than space_chat,
+	// which has its own full-prompt setup, and space_task_agent, which is
+	// managed by TaskAgentManager) should get `space-agent-tools` merged
+	// into its runtime MCP map — without touching its system prompt.
+
+	describe('attachSpaceToolsToMemberSession()', () => {
+		function makeMemberAgentSession() {
+			return {
+				mergeRuntimeMcpServers: mock((_: Record<string, McpServerConfig>) => {}),
+				setRuntimeMcpServers: mock(() => {}),
+				setRuntimeSystemPrompt: mock(() => {}),
+			} as unknown as AgentSession;
+		}
+
+		function makeSessionManager(agent: AgentSession | null): SessionManager {
+			return {
+				getSessionAsync: mock(async () => agent),
+				listSessions: mock(() => [] as Session[]),
+			} as unknown as SessionManager;
+		}
+
+		function buildMemberConfig(opts: {
+			sessionManager: SessionManager;
+			listSessionsResult?: Session[];
+			dbPath?: string;
+		}): SpaceRuntimeServiceConfig {
+			if (opts.listSessionsResult) {
+				(opts.sessionManager as unknown as { listSessions: Mock<() => Session[]> }).listSessions =
+					mock(() => opts.listSessionsResult as Session[]);
+			}
+			return {
+				db: {} as BunDatabase,
+				dbPath: opts.dbPath,
+				spaceManager: createMockSpaceManager(mockSpace),
+				spaceAgentManager: {
+					listBySpaceId: mock(() => []),
+				} as unknown as SpaceAgentManager,
+				spaceWorkflowManager: {
+					listWorkflows: mock(() => []),
+				} as unknown as SpaceWorkflowManager,
+				workflowRunRepo: {} as SpaceWorkflowRunRepository,
+				taskRepo: {} as SpaceTaskRepository,
+				tickIntervalMs: 60_000,
+				sessionManager: opts.sessionManager,
+			};
+		}
+
+		function makeMemberSession(overrides: Partial<Session> = {}): Session {
+			return {
+				id: 'worker-session-1',
+				title: 'Worker',
+				workspacePath: '/tmp/ws',
+				createdAt: new Date().toISOString(),
+				lastActiveAt: new Date().toISOString(),
+				status: 'active',
+				config: { tools: {} },
+				metadata: {},
+				type: 'worker',
+				context: { spaceId: mockSpace.id },
+				...overrides,
+			} as unknown as Session;
+		}
+
+		test('attaches space-agent-tools to a worker session with context.spaceId', async () => {
+			const agent = makeMemberAgentSession();
+			const sessionManager = makeSessionManager(agent);
+			const svc = new SpaceRuntimeService(buildMemberConfig({ sessionManager }));
+
+			await svc.attachSpaceToolsToMemberSession(makeMemberSession());
+
+			const mergeMock = agent.mergeRuntimeMcpServers as Mock<typeof agent.mergeRuntimeMcpServers>;
+			expect(mergeMock).toHaveBeenCalledTimes(1);
+			const [additional] = mergeMock.mock.calls[0];
+			expect(additional).toHaveProperty('space-agent-tools');
+			// No db-query attached when dbPath is not configured.
+			expect(additional).not.toHaveProperty('db-query');
+			// System prompt must NOT be touched on member sessions.
+			expect(agent.setRuntimeSystemPrompt).not.toHaveBeenCalled();
+		});
+
+		test('also attaches db-query when dbPath is configured', async () => {
+			const agent = makeMemberAgentSession();
+			const sessionManager = makeSessionManager(agent);
+
+			// db-query opens a real read-only connection, so the file must exist.
+			const dir = join(
+				process.cwd(),
+				'tmp',
+				'test-space-tools',
+				`db-${Date.now()}-${Math.random().toString(36).slice(2)}`
+			);
+			mkdirSync(dir, { recursive: true });
+			const dbPath = join(dir, 'test.db');
+			const tmpDb = new BunDatabase(dbPath);
+			tmpDb.close();
+
+			try {
+				const svc = new SpaceRuntimeService(buildMemberConfig({ sessionManager, dbPath }));
+
+				await svc.attachSpaceToolsToMemberSession(makeMemberSession());
+
+				const mergeMock = agent.mergeRuntimeMcpServers as Mock<typeof agent.mergeRuntimeMcpServers>;
+				expect(mergeMock).toHaveBeenCalledTimes(1);
+				const [additional] = mergeMock.mock.calls[0];
+				expect(additional).toHaveProperty('space-agent-tools');
+				expect(additional).toHaveProperty('db-query');
+
+				await svc.stop();
+			} finally {
+				rmSync(dir, { recursive: true, force: true });
+			}
+		});
+
+		test('skips sessions without context.spaceId', async () => {
+			const agent = makeMemberAgentSession();
+			const sessionManager = makeSessionManager(agent);
+			const svc = new SpaceRuntimeService(buildMemberConfig({ sessionManager }));
+
+			await svc.attachSpaceToolsToMemberSession(
+				makeMemberSession({ context: { roomId: 'room-1' } })
+			);
+
+			expect(agent.mergeRuntimeMcpServers).not.toHaveBeenCalled();
+		});
+
+		test('skips space_chat sessions (handled by setupSpaceAgentSession)', async () => {
+			const agent = makeMemberAgentSession();
+			const sessionManager = makeSessionManager(agent);
+			const svc = new SpaceRuntimeService(buildMemberConfig({ sessionManager }));
+
+			await svc.attachSpaceToolsToMemberSession(
+				makeMemberSession({ type: 'space_chat', id: `space:chat:${mockSpace.id}` })
+			);
+
+			expect(agent.mergeRuntimeMcpServers).not.toHaveBeenCalled();
+		});
+
+		test('skips space_task_agent sessions (handled by TaskAgentManager)', async () => {
+			const agent = makeMemberAgentSession();
+			const sessionManager = makeSessionManager(agent);
+			const svc = new SpaceRuntimeService(buildMemberConfig({ sessionManager }));
+
+			await svc.attachSpaceToolsToMemberSession(makeMemberSession({ type: 'space_task_agent' }));
+
+			expect(agent.mergeRuntimeMcpServers).not.toHaveBeenCalled();
+		});
+
+		test('start() attaches tools to existing member sessions listed by sessionManager', async () => {
+			const agent = makeMemberAgentSession();
+			const sessionManager = makeSessionManager(agent);
+			const listed: Session[] = [
+				makeMemberSession({ id: 'member-1' }),
+				makeMemberSession({ id: 'member-2' }),
+				// A session without spaceId — should be skipped.
+				makeMemberSession({ id: 'no-space', context: {} }),
+			];
+			const svc = new SpaceRuntimeService(
+				buildMemberConfig({ sessionManager, listSessionsResult: listed })
+			);
+
+			svc.start();
+			// Allow the provisioning microtasks to resolve.
+			await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+			const mergeMock = agent.mergeRuntimeMcpServers as Mock<typeof agent.mergeRuntimeMcpServers>;
+			// Exactly 2 attaches (one per member-N session). The no-space session
+			// is filtered out before getSessionAsync is consulted.
+			expect(mergeMock).toHaveBeenCalledTimes(2);
+
+			await svc.stop();
 		});
 	});
 });

--- a/packages/web/src/lib/__tests__/session-store-comprehensive.test.ts
+++ b/packages/web/src/lib/__tests__/session-store-comprehensive.test.ts
@@ -14,6 +14,7 @@ import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 const mockHub = {
 	request: vi.fn().mockResolvedValue({ acknowledged: true }),
 	onEvent: vi.fn(() => vi.fn()),
+	onConnection: vi.fn(() => vi.fn()),
 	joinChannel: vi.fn(),
 	leaveChannel: vi.fn(),
 	isConnected: vi.fn(() => true),
@@ -181,68 +182,12 @@ describe('SessionStore - Comprehensive Coverage', () => {
 			expect(sessionStore.sessionState.value).toEqual(mockSessionState);
 		});
 
-		it('should fetch and set SDK messages', async () => {
-			const mockMessages: SDKMessage[] = [
-				{ uuid: 'msg-1', type: 'text', role: 'user', content: [{ type: 'text', text: 'Hello' }] },
-				{ uuid: 'msg-2', type: 'text', role: 'assistant', content: [{ type: 'text', text: 'Hi' }] },
-			];
-
-			mockHub.request.mockImplementation((channel) => {
-				if (channel === 'state.session') {
-					return Promise.resolve({ sessionInfo: { id: 'session-1' } });
-				}
-				return Promise.resolve({ sdkMessages: mockMessages, timestamp: 1000 });
-			});
-			mockHub.onEvent.mockReturnValue(vi.fn());
-
-			await sessionStore.select('session-1');
-
-			expect(sessionStore.sdkMessages.value).toEqual(mockMessages);
-		});
-
-		it('should merge messages with newer delta messages', async () => {
-			const mockMessages: SDKMessage[] = [
-				{
-					uuid: 'msg-1',
-					type: 'text',
-					role: 'user',
-					content: [{ type: 'text', text: 'Old' }],
-				} as SDKMessage & { timestamp: number },
-			];
-
-			const newerMessage: SDKMessage = {
-				uuid: 'msg-2',
-				type: 'text',
-				role: 'assistant',
-				content: [{ type: 'text', text: 'Newer' }],
-			} as SDKMessage & { timestamp: number };
-			(newerMessage as SDKMessage & { timestamp: number }).timestamp = 2000;
-
-			// Simulate newer message arriving via delta before fetch completes
-			mockHub.onEvent.mockImplementation((channel, callback) => {
-				if (channel === 'state.sdkMessages.delta') {
-					// Simulate delta arriving immediately
-					setTimeout(() => {
-						callback({ added: [newerMessage] });
-					}, 0);
-				}
-				return vi.fn();
-			});
-
-			mockHub.request.mockImplementation((channel) => {
-				if (channel === 'state.session') {
-					return Promise.resolve({ sessionInfo: { id: 'session-1' } });
-				}
-				// Snapshot has timestamp 1000, newer message has timestamp 2000
-				return Promise.resolve({ sdkMessages: mockMessages, timestamp: 1000 });
-			});
-
-			await sessionStore.select('session-1');
-			await new Promise((resolve) => setTimeout(resolve, 10));
-
-			// Should have both messages, sorted by timestamp
-			expect(sessionStore.sdkMessages.value.length).toBeGreaterThanOrEqual(1);
-		});
+		// NOTE: messages are now streamed through the `messages.bySession`
+		// LiveQuery instead of being pulled via an RPC during
+		// `fetchInitialSessionState`. The delivery path is covered by the
+		// "LiveQuery messages.bySession subscription" describe block below and
+		// by the daemon-side test at
+		// `packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-messages.test.ts`.
 
 		it('should handle fetch errors gracefully', async () => {
 			mockHub.request.mockRejectedValue(new Error('Fetch failed'));
@@ -443,131 +388,128 @@ describe('SessionStore - Comprehensive Coverage', () => {
 		});
 	});
 
-	describe('SDK message delta subscription', () => {
-		it('should add messages from delta subscription', async () => {
-			const newMessages: SDKMessage[] = [
-				{ uuid: 'msg-1', type: 'text', role: 'user', content: [{ type: 'text', text: 'Hello' }] },
-				{ uuid: 'msg-2', type: 'text', role: 'assistant', content: [{ type: 'text', text: 'Hi' }] },
+	describe('LiveQuery messages.bySession subscription', () => {
+		/**
+		 * Helper to drive the LiveQuery path from a test.
+		 *
+		 * `fire('liveQuery.snapshot' | 'liveQuery.delta', event)` invokes every
+		 * handler that `hub.onEvent()` has registered — the snapshot/delta
+		 * handlers installed by sessionStore.select() filter on
+		 * `event.subscriptionId`, so tests can target a specific subscription.
+		 */
+		interface LqMockHub {
+			request: ReturnType<typeof vi.fn>;
+			onEvent: (channel: string, callback: (data: unknown) => void) => () => void;
+			fire: (channel: string, data: unknown) => void;
+			readonly subscriptionId: string | null;
+		}
+
+		function installLiveQueryHub(): LqMockHub {
+			const handlers = new Map<string, Array<(data: unknown) => void>>();
+			let capturedSubscriptionId: string | null = null;
+
+			mockHub.request.mockImplementation((channel: string, params?: Record<string, unknown>) => {
+				if (channel === 'state.session') {
+					return Promise.resolve({ sessionInfo: { id: 'session-1' } });
+				}
+				if (channel === 'liveQuery.subscribe') {
+					capturedSubscriptionId = String(params?.subscriptionId ?? '');
+					return Promise.resolve({ subscriptionId: capturedSubscriptionId });
+				}
+				if (channel === 'liveQuery.unsubscribe') {
+					return Promise.resolve({ ok: true });
+				}
+				return Promise.resolve(undefined);
+			});
+
+			mockHub.onEvent.mockImplementation((channel: string, callback: (data: unknown) => void) => {
+				const list = handlers.get(channel) ?? [];
+				list.push(callback);
+				handlers.set(channel, list);
+				return () => {
+					const l = handlers.get(channel);
+					if (!l) return;
+					const i = l.indexOf(callback);
+					if (i >= 0) l.splice(i, 1);
+				};
+			});
+
+			return {
+				request: mockHub.request,
+				onEvent: mockHub.onEvent,
+				fire: (channel, data) => {
+					for (const h of handlers.get(channel) ?? []) h(data);
+				},
+				get subscriptionId() {
+					return capturedSubscriptionId;
+				},
+			};
+		}
+
+		it('applies a LiveQuery snapshot to sdkMessages', async () => {
+			const hub = installLiveQueryHub();
+			await sessionStore.select('session-1');
+			const subId = hub.subscriptionId!;
+			expect(subId).toBeTruthy();
+
+			const rows: SDKMessage[] = [
+				{ uuid: 'msg-1', type: 'text', role: 'user', content: [{ type: 'text', text: 'Hi' }] },
+				{
+					uuid: 'msg-2',
+					type: 'text',
+					role: 'assistant',
+					content: [{ type: 'text', text: 'Hello' }],
+				},
 			];
+			hub.fire('liveQuery.snapshot', { subscriptionId: subId, rows });
 
-			mockHub.request.mockResolvedValue({
-				sessionInfo: { id: 'session-1' },
-				sdkMessages: [],
-			});
-
-			let deltaCallback: ((delta: { added?: SDKMessage[] }) => void) | null = null;
-			mockHub.onEvent.mockImplementation((channel, callback) => {
-				if (channel === 'state.sdkMessages.delta') {
-					deltaCallback = callback;
-				}
-				return vi.fn();
-			});
-
-			await sessionStore.select('session-1');
-
-			// Simulate delta messages arriving
-			if (deltaCallback) {
-				deltaCallback({ added: newMessages });
-			}
-
-			expect(sessionStore.sdkMessages.value).toEqual(newMessages);
+			expect(sessionStore.sdkMessages.value.map((m) => m.uuid)).toEqual(['msg-1', 'msg-2']);
 		});
 
-		it('should deduplicate messages by uuid', async () => {
-			const existingMessage: SDKMessage = {
-				uuid: 'msg-1',
-				type: 'text',
-				role: 'user',
-				content: [{ type: 'text', text: 'Original' }],
-			};
-
-			const updatedMessage: SDKMessage = {
-				uuid: 'msg-1',
-				type: 'text',
-				role: 'user',
-				content: [{ type: 'text', text: 'Updated' }],
-			};
-
-			mockHub.request.mockResolvedValue({
-				sessionInfo: { id: 'session-1' },
-				sdkMessages: [],
-			});
-
-			let deltaCallback: ((delta: { added?: SDKMessage[] }) => void) | null = null;
-			mockHub.onEvent.mockImplementation((channel, callback) => {
-				if (channel === 'state.sdkMessages.delta') {
-					deltaCallback = callback;
-				}
-				return vi.fn();
-			});
-
+		it('applies LiveQuery delta added rows to sdkMessages', async () => {
+			const hub = installLiveQueryHub();
 			await sessionStore.select('session-1');
+			const subId = hub.subscriptionId!;
 
-			// Add original message
-			if (deltaCallback) {
-				deltaCallback({ added: [existingMessage] });
-			}
+			// Start from empty snapshot so the delta add is the only change.
+			hub.fire('liveQuery.snapshot', { subscriptionId: subId, rows: [] });
 
-			// Try to add same uuid again (should be filtered out)
-			if (deltaCallback) {
-				deltaCallback({ added: [updatedMessage] });
-			}
+			const added: SDKMessage[] = [
+				{ uuid: 'msg-added', type: 'text', role: 'user', content: [{ type: 'text', text: 'A' }] },
+			];
+			hub.fire('liveQuery.delta', {
+				subscriptionId: subId,
+				added,
+				updated: [],
+				removed: [],
+			});
 
-			// Should only have one message (deduplicated)
-			const msgCount = sessionStore.sdkMessages.value.filter((m) => m.uuid === 'msg-1').length;
-			expect(msgCount).toBe(1);
+			expect(sessionStore.sdkMessages.value.some((m) => m.uuid === 'msg-added')).toBe(true);
 		});
 
-		it('should not add messages when delta has no added array', async () => {
-			mockHub.request.mockResolvedValue({
-				sessionInfo: { id: 'session-1' },
-				sdkMessages: [],
-			});
-
-			let deltaCallback: ((delta: { added?: SDKMessage[] }) => void) | null = null;
-			mockHub.onEvent.mockImplementation((channel, callback) => {
-				if (channel === 'state.sdkMessages.delta') {
-					deltaCallback = callback;
-				}
-				return vi.fn();
-			});
-
+		it('ignores snapshot/delta events for a different subscriptionId', async () => {
+			const hub = installLiveQueryHub();
 			await sessionStore.select('session-1');
+			const subId = hub.subscriptionId!;
 
-			const initialCount = sessionStore.sdkMessages.value.length;
+			hub.fire('liveQuery.snapshot', { subscriptionId: subId, rows: [] });
 
-			// Call with empty delta
-			if (deltaCallback) {
-				deltaCallback({});
-			}
-
-			expect(sessionStore.sdkMessages.value.length).toBe(initialCount);
-		});
-
-		it('should not add messages when delta has empty added array', async () => {
-			mockHub.request.mockResolvedValue({
-				sessionInfo: { id: 'session-1' },
-				sdkMessages: [],
+			// Fire a delta for an unrelated subscription — should be ignored.
+			hub.fire('liveQuery.delta', {
+				subscriptionId: 'some-other-id',
+				added: [
+					{
+						uuid: 'ghost',
+						type: 'text',
+						role: 'user',
+						content: [{ type: 'text', text: 'x' }],
+					},
+				],
+				updated: [],
+				removed: [],
 			});
 
-			let deltaCallback: ((delta: { added?: SDKMessage[] }) => void) | null = null;
-			mockHub.onEvent.mockImplementation((channel, callback) => {
-				if (channel === 'state.sdkMessages.delta') {
-					deltaCallback = callback;
-				}
-				return vi.fn();
-			});
-
-			await sessionStore.select('session-1');
-
-			const initialCount = sessionStore.sdkMessages.value.length;
-
-			// Call with empty added array
-			if (deltaCallback) {
-				deltaCallback({ added: [] });
-			}
-
-			expect(sessionStore.sdkMessages.value.length).toBe(initialCount);
+			expect(sessionStore.sdkMessages.value.some((m) => m.uuid === 'ghost')).toBe(false);
 		});
 	});
 
@@ -725,18 +667,66 @@ describe('SessionStore - Comprehensive Coverage', () => {
 	});
 
 	describe('hasMoreMessages (pagination inference)', () => {
+		// `hasMoreMessages` is now set from the `messages.bySession` LiveQuery
+		// snapshot: it becomes true when the snapshot returns the full limit of
+		// rows (and therefore might be truncating older messages) and false
+		// otherwise. We drive it through the same hub mock the store sees.
+
+		const LIMIT = 200; // matches LIVE_QUERY_MESSAGE_LIMIT
+
 		beforeEach(async () => {
-			// Clear session state to ensure each test starts fresh
 			await sessionStore.select(null);
 		});
 
 		afterEach(async () => {
-			// Clear session state to avoid interference
 			await sessionStore.select(null);
 		});
 
-		it('should return false when initial load returns less than 100 messages', async () => {
-			const messages: SDKMessage[] = Array(50)
+		function installLiveQueryHubCapturing(): {
+			fire: (channel: string, data: unknown) => void;
+			readonly subscriptionId: string | null;
+		} {
+			const handlers = new Map<string, Array<(data: unknown) => void>>();
+			let subId: string | null = null;
+
+			mockHub.request.mockImplementation((channel: string, params?: Record<string, unknown>) => {
+				if (channel === 'state.session') {
+					return Promise.resolve({ sessionInfo: { id: 'session-1' } });
+				}
+				if (channel === 'liveQuery.subscribe') {
+					subId = String(params?.subscriptionId ?? '');
+					return Promise.resolve({ subscriptionId: subId });
+				}
+				return Promise.resolve(undefined);
+			});
+			mockHub.onEvent.mockImplementation((ch: string, cb: (data: unknown) => void) => {
+				const list = handlers.get(ch) ?? [];
+				list.push(cb);
+				handlers.set(ch, list);
+				return () => {
+					const l = handlers.get(ch);
+					if (!l) return;
+					const i = l.indexOf(cb);
+					if (i >= 0) l.splice(i, 1);
+				};
+			});
+
+			return {
+				fire: (ch, data) => {
+					for (const h of handlers.get(ch) ?? []) h(data);
+				},
+				get subscriptionId() {
+					return subId;
+				},
+			};
+		}
+
+		it('is false when the snapshot is shorter than the limit', async () => {
+			const hub = installLiveQueryHubCapturing();
+			await sessionStore.select('session-1');
+			const subId = hub.subscriptionId!;
+
+			const rows: SDKMessage[] = Array(50)
 				.fill(null)
 				.map((_, i) => ({
 					uuid: `msg-${i}`,
@@ -744,24 +734,17 @@ describe('SessionStore - Comprehensive Coverage', () => {
 					role: 'user',
 					content: [{ type: 'text', text: `Message ${i}` }],
 				}));
-
-			mockHub.request.mockImplementation((method: string) => {
-				if (method === 'state.session') {
-					return Promise.resolve({ sessionInfo: { id: 'session-1' } });
-				}
-				if (method === 'state.sdkMessages') {
-					return Promise.resolve({ sdkMessages: messages });
-				}
-				return Promise.resolve(undefined);
-			});
-
-			await sessionStore.select('session-1');
+			hub.fire('liveQuery.snapshot', { subscriptionId: subId, rows });
 
 			expect(sessionStore.hasMoreMessages.value).toBe(false);
 		});
 
-		it('should return true when initial load returns exactly 100 messages', async () => {
-			const messages: SDKMessage[] = Array(100)
+		it('is true when the snapshot fills the limit exactly', async () => {
+			const hub = installLiveQueryHubCapturing();
+			await sessionStore.select('session-1');
+			const subId = hub.subscriptionId!;
+
+			const rows: SDKMessage[] = Array(LIMIT)
 				.fill(null)
 				.map((_, i) => ({
 					uuid: `msg-${i}`,
@@ -769,61 +752,18 @@ describe('SessionStore - Comprehensive Coverage', () => {
 					role: 'user',
 					content: [{ type: 'text', text: `Message ${i}` }],
 				}));
+			hub.fire('liveQuery.snapshot', { subscriptionId: subId, rows });
 
-			mockHub.request.mockImplementation((method: string) => {
-				if (method === 'state.session') {
-					return Promise.resolve({ sessionInfo: { id: 'session-1' } });
-				}
-				if (method === 'state.sdkMessages') {
-					return Promise.resolve({ sdkMessages: messages, hasMore: true });
-				}
-				return Promise.resolve(undefined);
-			});
-
-			await sessionStore.select('session-1');
-
-			// Verify messages were loaded and hasMoreMessages is true
-			expect(sessionStore.sdkMessages.value).toHaveLength(100);
+			expect(sessionStore.sdkMessages.value).toHaveLength(LIMIT);
 			expect(sessionStore.hasMoreMessages.value).toBe(true);
 		});
 
-		it('should return false when initial load returns less than 100 messages', async () => {
-			const messages: SDKMessage[] = Array(50)
-				.fill(null)
-				.map((_, i) => ({
-					uuid: `msg-${i}`,
-					type: 'text',
-					role: 'user',
-					content: [{ type: 'text', text: `Message ${i}` }],
-				}));
-
-			mockHub.request.mockImplementation((method: string) => {
-				if (method === 'state.session') {
-					return Promise.resolve({ sessionInfo: { id: 'session-1' } });
-				}
-				if (method === 'state.sdkMessages') {
-					return Promise.resolve({ sdkMessages: messages });
-				}
-				return Promise.resolve(undefined);
-			});
-
+		it('is false when the snapshot is empty', async () => {
+			const hub = installLiveQueryHubCapturing();
 			await sessionStore.select('session-1');
+			const subId = hub.subscriptionId!;
 
-			expect(sessionStore.hasMoreMessages.value).toBe(false);
-		});
-
-		it('should return false when no messages loaded', async () => {
-			mockHub.request.mockImplementation((method: string) => {
-				if (method === 'state.session') {
-					return Promise.resolve({ sessionInfo: { id: 'session-1' } });
-				}
-				if (method === 'state.sdkMessages') {
-					return Promise.resolve({ sdkMessages: [] });
-				}
-				return Promise.resolve(undefined);
-			});
-
-			await sessionStore.select('session-1');
+			hub.fire('liveQuery.snapshot', { subscriptionId: subId, rows: [] });
 
 			expect(sessionStore.hasMoreMessages.value).toBe(false);
 		});
@@ -1038,582 +978,6 @@ describe('SessionStore - Comprehensive Coverage', () => {
 			await sessionStore.select('error-session');
 
 			expect(toast.error).toHaveBeenCalledWith('Failed to connect to daemon');
-		});
-	});
-
-	describe('fetchInitialState message merge with timestamps', () => {
-		it('should merge messages preserving newer delta messages', async () => {
-			// Snapshot messages (from server)
-			const snapshotMessages: SDKMessage[] = [
-				{ uuid: 'msg-1', type: 'text', role: 'user', content: [{ type: 'text', text: 'First' }] },
-			];
-			(snapshotMessages[0] as SDKMessage & { timestamp: number }).timestamp = 1000;
-
-			// Delta message (newer)
-			const deltaMessage: SDKMessage = {
-				uuid: 'msg-2',
-				type: 'text',
-				role: 'assistant',
-				content: [{ type: 'text', text: 'Second' }],
-			};
-			(deltaMessage as SDKMessage & { timestamp: number }).timestamp = 2000;
-
-			let deltaCallback: ((delta: { added?: SDKMessage[] }) => void) | null = null;
-			mockHub.onEvent.mockImplementation((channel, callback) => {
-				if (channel === 'state.sdkMessages.delta') {
-					deltaCallback = callback;
-				}
-				return vi.fn();
-			});
-
-			mockHub.request.mockImplementation((channel) => {
-				if (channel === 'state.session') {
-					return Promise.resolve({ sessionInfo: { id: 'session-1' } });
-				}
-				// Add delay to simulate network latency
-				return new Promise((resolve) => {
-					setTimeout(() => {
-						resolve({ sdkMessages: snapshotMessages, timestamp: 1500 });
-					}, 20);
-				});
-			});
-
-			await sessionStore.select('session-1');
-
-			// Simulate delta arriving while fetch is in progress (but after subscription setup)
-			if (deltaCallback) {
-				deltaCallback({ added: [deltaMessage] });
-			}
-
-			// Wait for fetch to complete and merge
-			await new Promise((resolve) => setTimeout(resolve, 50));
-
-			// Should have merged both messages
-			const messages = sessionStore.sdkMessages.value;
-			expect(messages.length).toBe(2);
-		});
-
-		it('should use snapshot directly when no timestamp in response', async () => {
-			const snapshotMessages: SDKMessage[] = [
-				{ uuid: 'msg-1', type: 'text', role: 'user', content: [{ type: 'text', text: 'Test' }] },
-			];
-
-			mockHub.request.mockImplementation((channel) => {
-				if (channel === 'state.session') {
-					return Promise.resolve({ sessionInfo: { id: 'session-1' } });
-				}
-				// No timestamp in response
-				return Promise.resolve({ sdkMessages: snapshotMessages });
-			});
-			mockHub.onEvent.mockReturnValue(vi.fn());
-
-			await sessionStore.select('session-1');
-
-			expect(sessionStore.sdkMessages.value).toEqual(snapshotMessages);
-		});
-
-		it('should use snapshot directly when current messages are empty', async () => {
-			const snapshotMessages: SDKMessage[] = [
-				{ uuid: 'msg-1', type: 'text', role: 'user', content: [{ type: 'text', text: 'Test' }] },
-			];
-
-			mockHub.request.mockImplementation((channel) => {
-				if (channel === 'state.session') {
-					return Promise.resolve({ sessionInfo: { id: 'session-1' } });
-				}
-				return Promise.resolve({ sdkMessages: snapshotMessages, timestamp: 1000 });
-			});
-			mockHub.onEvent.mockReturnValue(vi.fn());
-
-			// Clear messages before select
-			sessionStore.sdkMessages.value = [];
-
-			await sessionStore.select('session-1');
-
-			// Should have snapshot messages directly (no merge needed)
-			expect(sessionStore.sdkMessages.value).toEqual(snapshotMessages);
-		});
-
-		it('should merge messages from both sources', async () => {
-			const snapshotMessages: SDKMessage[] = [
-				{ uuid: 'msg-1', type: 'text', role: 'user', content: [{ type: 'text', text: 'First' }] },
-			];
-			(snapshotMessages[0] as SDKMessage & { timestamp: number }).timestamp = 1000;
-
-			const deltaMessage: SDKMessage = {
-				uuid: 'msg-2',
-				type: 'text',
-				role: 'assistant',
-				content: [{ type: 'text', text: 'Second' }],
-			};
-			(deltaMessage as SDKMessage & { timestamp: number }).timestamp = 2000;
-
-			// Set up delta callback
-			let deltaCallback: ((delta: { added?: SDKMessage[] }) => void) | null = null;
-			mockHub.onEvent.mockImplementation((channel, callback) => {
-				if (channel === 'state.sdkMessages.delta') {
-					deltaCallback = callback;
-				}
-				return vi.fn();
-			});
-
-			mockHub.request.mockImplementation((channel) => {
-				if (channel === 'state.session') {
-					return Promise.resolve({ sessionInfo: { id: 'session-1' } });
-				}
-				return new Promise((resolve) => {
-					setTimeout(() => {
-						resolve({ sdkMessages: snapshotMessages, timestamp: 1500 });
-					}, 20);
-				});
-			});
-
-			await sessionStore.select('session-1');
-
-			// Add delta with newer timestamp
-			if (deltaCallback) {
-				deltaCallback({ added: [deltaMessage] });
-			}
-
-			await new Promise((resolve) => setTimeout(resolve, 50));
-
-			// Should have merged both messages
-			const messages = sessionStore.sdkMessages.value;
-			expect(messages.length).toBeGreaterThanOrEqual(1);
-		});
-
-		it('should filter and merge only newer messages by timestamp', async () => {
-			// Snapshot messages from server
-			const snapshotMsg1: SDKMessage = {
-				uuid: 'msg-1',
-				type: 'text',
-				role: 'user',
-				content: [{ type: 'text', text: 'Snapshot 1' }],
-			};
-			(snapshotMsg1 as SDKMessage & { timestamp: number }).timestamp = 1000;
-
-			const snapshotMsg2: SDKMessage = {
-				uuid: 'msg-2',
-				type: 'text',
-				role: 'assistant',
-				content: [{ type: 'text', text: 'Snapshot 2' }],
-			};
-			(snapshotMsg2 as SDKMessage & { timestamp: number }).timestamp = 1200;
-
-			// Delta messages - one older, one newer than snapshot timestamp
-			const olderDeltaMsg: SDKMessage = {
-				uuid: 'delta-old',
-				type: 'text',
-				role: 'user',
-				content: [{ type: 'text', text: 'Old delta' }],
-			};
-			(olderDeltaMsg as SDKMessage & { timestamp: number }).timestamp = 1400; // Before snapshotTimestamp
-
-			const newerDeltaMsg: SDKMessage = {
-				uuid: 'delta-new',
-				type: 'text',
-				role: 'assistant',
-				content: [{ type: 'text', text: 'New delta' }],
-			};
-			(newerDeltaMsg as SDKMessage & { timestamp: number }).timestamp = 1600; // After snapshotTimestamp
-
-			// Trigger delta IMMEDIATELY when subscription is set up (before fetch completes)
-			mockHub.onEvent.mockImplementation((channel, callback) => {
-				if (channel === 'state.sdkMessages.delta') {
-					// Trigger delta immediately when subscription starts
-					setTimeout(() => {
-						callback({ added: [olderDeltaMsg, newerDeltaMsg] });
-					}, 5);
-				}
-				return vi.fn();
-			});
-
-			mockHub.request.mockImplementation((channel) => {
-				if (channel === 'state.session') {
-					return Promise.resolve({ sessionInfo: { id: 'session-1' } });
-				}
-				// Delay to allow delta to arrive first
-				return new Promise((resolve) => {
-					setTimeout(() => {
-						resolve({
-							sdkMessages: [snapshotMsg1, snapshotMsg2],
-							timestamp: 1500, // Newer than olderDeltaMsg, older than newerDeltaMsg
-						});
-					}, 50);
-				});
-			});
-
-			await sessionStore.select('session-1');
-			await new Promise((resolve) => setTimeout(resolve, 20));
-
-			// Should have merged messages: snapshot + newer delta (filtered)
-			const messages = sessionStore.sdkMessages.value;
-			const uuids = messages.map((m) => m.uuid);
-
-			// Should have snapshot messages and the newer delta
-			expect(uuids).toContain('msg-1');
-			expect(uuids).toContain('msg-2');
-			expect(uuids).toContain('delta-new');
-		});
-
-		it('should use snapshot when no newer messages exist (lines 294-296)', async () => {
-			// Delta message with older timestamp
-			const olderDeltaMsg: SDKMessage = {
-				uuid: 'delta-old',
-				type: 'text',
-				role: 'user',
-				content: [{ type: 'text', text: 'Old delta' }],
-			};
-			(olderDeltaMsg as SDKMessage & { timestamp: number }).timestamp = 1000; // Before snapshotTimestamp
-
-			// Snapshot message
-			const snapshotMsg: SDKMessage = {
-				uuid: 'snapshot-1',
-				type: 'text',
-				role: 'assistant',
-				content: [{ type: 'text', text: 'Snapshot' }],
-			};
-			(snapshotMsg as SDKMessage & { timestamp: number }).timestamp = 1200;
-
-			// Trigger delta IMMEDIATELY when subscription is set up (before fetch completes)
-			mockHub.onEvent.mockImplementation((channel, callback) => {
-				if (channel === 'state.sdkMessages.delta') {
-					// Trigger delta immediately when subscription starts
-					setTimeout(() => {
-						callback({ added: [olderDeltaMsg] });
-					}, 5);
-				}
-				return vi.fn();
-			});
-
-			mockHub.request.mockImplementation((channel) => {
-				if (channel === 'state.session') {
-					return Promise.resolve({ sessionInfo: { id: 'session-1' } });
-				}
-				// Delay fetch longer than delta arrival
-				return new Promise((resolve) => {
-					setTimeout(() => {
-						resolve({
-							sdkMessages: [snapshotMsg],
-							timestamp: 1500, // After all delta messages (1000 < 1500)
-						});
-					}, 50);
-				});
-			});
-
-			await sessionStore.select('session-1');
-			await new Promise((resolve) => setTimeout(resolve, 20));
-
-			// Should use snapshot directly since delta timestamp (1000) < snapshotTimestamp (1500)
-			const messages = sessionStore.sdkMessages.value;
-			expect(messages.length).toBe(1);
-			expect(messages[0].uuid).toBe('snapshot-1');
-		});
-
-		it('should handle messages without uuid during merge', async () => {
-			// Snapshot message without uuid
-			const snapshotMsg: SDKMessage = {
-				type: 'text',
-				role: 'user',
-				content: [{ type: 'text', text: 'No UUID' }],
-			} as SDKMessage;
-			(snapshotMsg as SDKMessage & { timestamp: number }).timestamp = 1000;
-
-			// Delta message with uuid and newer timestamp
-			const deltaMsg: SDKMessage = {
-				uuid: 'delta-1',
-				type: 'text',
-				role: 'assistant',
-				content: [{ type: 'text', text: 'With UUID' }],
-			};
-			(deltaMsg as SDKMessage & { timestamp: number }).timestamp = 1600;
-
-			// Trigger delta IMMEDIATELY when subscription is set up (before fetch completes)
-			mockHub.onEvent.mockImplementation((channel, callback) => {
-				if (channel === 'state.sdkMessages.delta') {
-					setTimeout(() => {
-						callback({ added: [deltaMsg] });
-					}, 5);
-				}
-				return vi.fn();
-			});
-
-			mockHub.request.mockImplementation((channel) => {
-				if (channel === 'state.session') {
-					return Promise.resolve({ sessionInfo: { id: 'session-1' } });
-				}
-				return new Promise((resolve) => {
-					setTimeout(() => {
-						resolve({
-							sdkMessages: [snapshotMsg],
-							timestamp: 1500,
-						});
-					}, 50);
-				});
-			});
-
-			await sessionStore.select('session-1');
-			await new Promise((resolve) => setTimeout(resolve, 20));
-
-			// Should have only the delta message with uuid
-			const messages = sessionStore.sdkMessages.value;
-			expect(messages.some((m) => m.uuid === 'delta-1')).toBe(true);
-		});
-
-		it('should handle newer message without uuid in merge', async () => {
-			// Snapshot message with uuid
-			const snapshotMsg: SDKMessage = {
-				uuid: 'snapshot-1',
-				type: 'text',
-				role: 'user',
-				content: [{ type: 'text', text: 'Snapshot' }],
-			};
-			(snapshotMsg as SDKMessage & { timestamp: number }).timestamp = 1000;
-
-			// Newer delta message WITHOUT uuid - tests the `if (msg.uuid)` branch in newerMessages loop
-			const newerMsgNoUuid: SDKMessage = {
-				type: 'text',
-				role: 'assistant',
-				content: [{ type: 'text', text: 'No UUID newer' }],
-			} as SDKMessage;
-			(newerMsgNoUuid as SDKMessage & { timestamp: number }).timestamp = 1600;
-
-			// Also add one with uuid to ensure merge happens
-			const newerMsgWithUuid: SDKMessage = {
-				uuid: 'newer-1',
-				type: 'text',
-				role: 'assistant',
-				content: [{ type: 'text', text: 'With UUID newer' }],
-			};
-			(newerMsgWithUuid as SDKMessage & { timestamp: number }).timestamp = 1700;
-
-			mockHub.onEvent.mockImplementation((channel, callback) => {
-				if (channel === 'state.sdkMessages.delta') {
-					setTimeout(() => {
-						callback({ added: [newerMsgNoUuid, newerMsgWithUuid] });
-					}, 5);
-				}
-				return vi.fn();
-			});
-
-			mockHub.request.mockImplementation((channel) => {
-				if (channel === 'state.session') {
-					return Promise.resolve({ sessionInfo: { id: 'session-1' } });
-				}
-				return new Promise((resolve) => {
-					setTimeout(() => {
-						resolve({
-							sdkMessages: [snapshotMsg],
-							timestamp: 1500,
-						});
-					}, 50);
-				});
-			});
-
-			await sessionStore.select('session-1');
-			await new Promise((resolve) => setTimeout(resolve, 20));
-
-			const messages = sessionStore.sdkMessages.value;
-			// Should have messages with uuids (snapshot-1 and newer-1)
-			expect(messages.some((m) => m.uuid === 'snapshot-1')).toBe(true);
-			expect(messages.some((m) => m.uuid === 'newer-1')).toBe(true);
-		});
-
-		it('should handle delta message without timestamp using fallback 0', async () => {
-			// Snapshot message
-			const snapshotMsg: SDKMessage = {
-				uuid: 'snapshot-1',
-				type: 'text',
-				role: 'user',
-				content: [{ type: 'text', text: 'Snapshot' }],
-			};
-			(snapshotMsg as SDKMessage & { timestamp: number }).timestamp = 1000;
-
-			// Delta message WITHOUT timestamp - tests `|| 0` fallback in filter
-			const deltaMsgNoTimestamp: SDKMessage = {
-				uuid: 'delta-no-ts',
-				type: 'text',
-				role: 'assistant',
-				content: [{ type: 'text', text: 'No timestamp' }],
-			};
-			// Intentionally not setting timestamp
-
-			// Newer delta message with timestamp
-			const newerMsg: SDKMessage = {
-				uuid: 'newer-1',
-				type: 'text',
-				role: 'assistant',
-				content: [{ type: 'text', text: 'Newer' }],
-			};
-			(newerMsg as SDKMessage & { timestamp: number }).timestamp = 1600;
-
-			mockHub.onEvent.mockImplementation((channel, callback) => {
-				if (channel === 'state.sdkMessages.delta') {
-					setTimeout(() => {
-						// Add both - one without timestamp, one with
-						callback({ added: [deltaMsgNoTimestamp, newerMsg] });
-					}, 5);
-				}
-				return vi.fn();
-			});
-
-			mockHub.request.mockImplementation((channel) => {
-				if (channel === 'state.session') {
-					return Promise.resolve({ sessionInfo: { id: 'session-1' } });
-				}
-				return new Promise((resolve) => {
-					setTimeout(() => {
-						resolve({
-							sdkMessages: [snapshotMsg],
-							timestamp: 1500,
-						});
-					}, 50);
-				});
-			});
-
-			await sessionStore.select('session-1');
-			await new Promise((resolve) => setTimeout(resolve, 20));
-
-			const messages = sessionStore.sdkMessages.value;
-			// The message without timestamp (0 < 1500) should be filtered out
-			// Only snapshot-1 and newer-1 should remain
-			const uuids = messages.map((m) => m.uuid);
-			expect(uuids).toContain('snapshot-1');
-			expect(uuids).toContain('newer-1');
-		});
-
-		it('should sort merged messages by timestamp', async () => {
-			// Create messages with different timestamps
-			const msg1: SDKMessage = {
-				uuid: 'msg-1',
-				type: 'text',
-				role: 'user',
-				content: [{ type: 'text', text: 'First' }],
-			};
-			(msg1 as SDKMessage & { timestamp: number }).timestamp = 1000;
-
-			const msg2: SDKMessage = {
-				uuid: 'msg-2',
-				type: 'text',
-				role: 'assistant',
-				content: [{ type: 'text', text: 'Second' }],
-			};
-			(msg2 as SDKMessage & { timestamp: number }).timestamp = 1100;
-
-			const newerMsg: SDKMessage = {
-				uuid: 'msg-3',
-				type: 'text',
-				role: 'user',
-				content: [{ type: 'text', text: 'Third' }],
-			};
-			(newerMsg as SDKMessage & { timestamp: number }).timestamp = 1600;
-
-			// Trigger delta IMMEDIATELY when subscription is set up (before fetch completes)
-			mockHub.onEvent.mockImplementation((channel, callback) => {
-				if (channel === 'state.sdkMessages.delta') {
-					setTimeout(() => {
-						callback({ added: [newerMsg] });
-					}, 5);
-				}
-				return vi.fn();
-			});
-
-			mockHub.request.mockImplementation((channel) => {
-				if (channel === 'state.session') {
-					return Promise.resolve({ sessionInfo: { id: 'session-1' } });
-				}
-				return new Promise((resolve) => {
-					setTimeout(() => {
-						// Snapshot at timestamp 1500, so msg-3 (1600) is newer
-						resolve({
-							sdkMessages: [msg1, msg2],
-							timestamp: 1500,
-						});
-					}, 50);
-				});
-			});
-
-			await sessionStore.select('session-1');
-			await new Promise((resolve) => setTimeout(resolve, 20));
-
-			// Messages should be sorted by timestamp
-			const messages = sessionStore.sdkMessages.value;
-			expect(messages.length).toBe(3);
-
-			// Verify order by checking timestamps are ascending
-			for (let i = 1; i < messages.length; i++) {
-				const prevTimestamp =
-					(messages[i - 1] as SDKMessage & { timestamp?: number }).timestamp || 0;
-				const currTimestamp = (messages[i] as SDKMessage & { timestamp?: number }).timestamp || 0;
-				expect(currTimestamp).toBeGreaterThanOrEqual(prevTimestamp);
-			}
-		});
-
-		it('should handle sorting messages without timestamp using fallback 0', async () => {
-			// Snapshot message with uuid but NO timestamp - tests || 0 in sort
-			const snapshotNoTs: SDKMessage = {
-				uuid: 'snapshot-no-ts',
-				type: 'text',
-				role: 'user',
-				content: [{ type: 'text', text: 'Snapshot no timestamp' }],
-			};
-			// Intentionally not setting timestamp
-
-			// Snapshot message with timestamp
-			const snapshotWithTs: SDKMessage = {
-				uuid: 'snapshot-with-ts',
-				type: 'text',
-				role: 'assistant',
-				content: [{ type: 'text', text: 'Snapshot with timestamp' }],
-			};
-			(snapshotWithTs as SDKMessage & { timestamp: number }).timestamp = 1000;
-
-			// Newer delta message with timestamp (to trigger merge)
-			const newerMsg: SDKMessage = {
-				uuid: 'newer-1',
-				type: 'text',
-				role: 'user',
-				content: [{ type: 'text', text: 'Newer' }],
-			};
-			(newerMsg as SDKMessage & { timestamp: number }).timestamp = 1600;
-
-			mockHub.onEvent.mockImplementation((channel, callback) => {
-				if (channel === 'state.sdkMessages.delta') {
-					setTimeout(() => {
-						callback({ added: [newerMsg] });
-					}, 5);
-				}
-				return vi.fn();
-			});
-
-			mockHub.request.mockImplementation((channel) => {
-				if (channel === 'state.session') {
-					return Promise.resolve({ sessionInfo: { id: 'session-1' } });
-				}
-				return new Promise((resolve) => {
-					setTimeout(() => {
-						resolve({
-							// Include message without timestamp in snapshot
-							sdkMessages: [snapshotNoTs, snapshotWithTs],
-							timestamp: 1500,
-						});
-					}, 50);
-				});
-			});
-
-			await sessionStore.select('session-1');
-			await new Promise((resolve) => setTimeout(resolve, 20));
-
-			// All messages with uuid should be present
-			const messages = sessionStore.sdkMessages.value;
-			const uuids = messages.map((m) => m.uuid);
-			expect(uuids).toContain('snapshot-no-ts');
-			expect(uuids).toContain('snapshot-with-ts');
-			expect(uuids).toContain('newer-1');
-
-			// Message without timestamp should be sorted first (timestamp || 0 = 0)
-			const firstMsg = messages[0];
-			expect(firstMsg.uuid).toBe('snapshot-no-ts');
 		});
 	});
 

--- a/packages/web/src/lib/session-store.ts
+++ b/packages/web/src/lib/session-store.ts
@@ -1,32 +1,45 @@
 /**
  * SessionStore - Unified session state management with pure WebSocket architecture
  *
- * ARCHITECTURE: Pure WebSocket (no REST API)
- * - Initial state: Fetched via RPC over WebSocket on session select
- * - Updates: Real-time via state channel subscriptions
- * - Pagination: Loaded via RPC over WebSocket
- * - Single subscription source (replaces StateChannel + useSessionSubscriptions)
- * - Promise-chain lock for atomic session switching
- * - 2 subscriptions per session (state.session + state.sdkMessages.delta)
- * - 6 operations per switch (reduced from 50+)
+ * ARCHITECTURE: Pure WebSocket + LiveQuery
+ * - Session-scoped realtime messages: LiveQuery subscription on `messages.bySession`
+ *   (snapshot on subscribe, delta on subsequent row changes, automatic resubscribe
+ *   on reconnect through connectionManager's hub instance)
+ * - Session metadata / agent state / errors: `state.session` channel subscription
+ * - Pagination for older messages: RPC (`message.sdkMessages`) — LiveQuery returns
+ *   the most recent window; older rows are loaded on demand and prepended client-side.
  *
  * Signals (reactive state):
  * - activeSessionId: Current session ID
  * - sessionState: Unified session state (sessionInfo, agentState, commandsData, contextInfo, error)
- * - sdkMessages: SDK message array
+ * - sdkMessages: SDK message array (LiveQuery-driven)
  *
  * Computed accessors (derived state):
  * - sessionInfo, agentState, contextInfo, commandsData, error, isCompacting, isWorking
  */
 
 import { signal, computed } from '@preact/signals';
-import type { Session, ContextInfo, AgentProcessingState, SessionState } from '@neokai/shared';
+import type {
+	Session,
+	ContextInfo,
+	AgentProcessingState,
+	SessionState,
+	LiveQuerySnapshotEvent,
+	LiveQueryDeltaEvent,
+} from '@neokai/shared';
 import type { ChatMessage } from '@neokai/shared';
 import { Logger } from '@neokai/shared';
 import { connectionManager } from './connection-manager';
 import { slashCommandsSignal } from './signals';
 import { toast } from './toast';
 import type { StructuredError } from '../types/error';
+
+/**
+ * Maximum number of top-level messages the LiveQuery window keeps in memory.
+ * Matches the default page size used by the `message.sdkMessages` RPC so
+ * behaviour matches the previous non-LiveQuery path on first load.
+ */
+const LIVE_QUERY_MESSAGE_LIMIT = 200;
 
 const logger = new Logger('kai:web:sessionstore');
 
@@ -135,6 +148,26 @@ class SessionStore {
 	 */
 	private readonly _contextInfo = signal<ContextInfo | null>(null);
 
+	/**
+	 * Current LiveQuery subscription ID for `messages.bySession`.
+	 *
+	 * Tracked so stale events arriving after a session switch (queued in the
+	 * JS event loop between the unsubscribe and the handler teardown, or
+	 * received after the server ack but before the client knows about the
+	 * switch) are discarded rather than applied to the new session's state.
+	 */
+	private activeMessagesSubscriptionId: string | null = null;
+
+	/**
+	 * Messages that were locally appended (optimistic UI) for the current
+	 * session but have not yet been reflected in the LiveQuery snapshot.
+	 *
+	 * Keyed by uuid. On LiveQuery snapshot/delta, entries whose uuid matches
+	 * a canonical row are cleared; entries that never match are preserved
+	 * until the session switches (at which point they're cleared wholesale).
+	 */
+	private pendingLocalMessageUuids: Set<string> = new Set();
+
 	// ========================================
 	// Session Selection (with Promise-Chain Lock)
 	// ========================================
@@ -183,6 +216,11 @@ class SessionStore {
 		this._initialMessageCount.value = 0;
 		this._hasMoreMessages.value = false;
 		this._contextInfo.value = null; // Clear context info on session switch
+		this.pendingLocalMessageUuids.clear();
+		// Invalidate any in-flight LiveQuery events for the previous session.
+		// Events already queued in the event loop will see this guard and be
+		// dropped before touching the fresh sdkMessages signal.
+		this.activeMessagesSubscriptionId = null;
 		// Record session switch time to only show errors that occur AFTER this point
 		// This prevents showing stale errors that were already in the session state
 		this.sessionSwitchTime = Date.now();
@@ -201,17 +239,20 @@ class SessionStore {
 	// ========================================
 
 	/**
-	 * Start subscriptions for a session
-	 * Only 3 subscriptions: state.session, state.sdkMessages, state.sdkMessages.delta
+	 * Start subscriptions for a session.
 	 *
-	 * NOTE: sdk.message subscription removed - the SDK's query() with AsyncGenerator
-	 * yields complete messages, not stream_event tokens. Messages arrive via
-	 * state.sdkMessages and state.sdkMessages.delta channels.
+	 * Subscriptions:
+	 *   1. `state.session` — session metadata + agent state + commands + error
+	 *   2. `context.updated` — fast-path context info updates
+	 *   3. `session.retryAttempt` — SDK retry events
+	 *   4. LiveQuery `messages.bySession` — realtime SDK message stream
+	 *      (snapshot on subscribe, deltas on subsequent row changes)
 	 *
-	 * ARCHITECTURE: Pure WebSocket
-	 * - Subscriptions set up handlers for future events
-	 * - Initial state fetched via RPC calls (over same WebSocket)
-	 * - No REST API calls needed
+	 * ARCHITECTURE: LiveQuery supersedes the previous
+	 * `state.sdkMessages` RPC + `state.sdkMessages.delta` event pair. The
+	 * daemon's ReactiveDatabase notifies table-change for every write to
+	 * `sdk_messages`, which drives the LiveQuery re-evaluation; the client
+	 * never needs a separate "fetch initial + listen to deltas" coordination.
 	 */
 	private async startSubscriptions(sessionId: string): Promise<void> {
 		try {
@@ -255,65 +296,10 @@ class SessionStore {
 			this.cleanupFunctions.push(unsubSessionState);
 
 			// 2. Context updates (fast path - bypasses full state.session round-trip)
-			// The daemon also sends context via state.session, but subscribing directly here
-			// ensures the UI updates as soon as context.updated fires on the session channel.
-			// FIX: Use direct signal to avoid race condition where events are dropped
-			// when sessionState.value is null (during initial load)
 			const unsubContextUpdated = hub.onEvent<ContextInfo>('context.updated', (contextInfo) => {
 				this._contextInfo.value = contextInfo;
 			});
 			this.cleanupFunctions.push(unsubContextUpdated);
-
-			// 3. SDK messages delta (for incremental updates)
-			// Set up BEFORE fetching initial state to avoid race conditions
-			// FIX: Add deduplication to prevent double messages after Safari reconnection
-			// This can happen when events are queued during reconnection and replayed,
-			// while the server also resends them after subscription re-establishment.
-			const unsubSDKMessagesDelta = hub.onEvent<{
-				added?: ChatMessage[];
-			}>('state.sdkMessages.delta', (delta) => {
-				if (delta.added?.length) {
-					// Upsert by uuid: new messages are appended, but if a message with the
-					// same uuid already exists (e.g. a neokai_action being resolved), it is
-					// replaced in-place so the UI reflects the updated state.
-					const messageMap = new Map(
-						this.sdkMessages.value
-							.filter((m) => (m as ChatMessage & { uuid?: string }).uuid)
-							.map((m) => [(m as ChatMessage & { uuid?: string }).uuid!, m])
-					);
-					// Preserve existing messages that have no uuid (can't be keyed in the map)
-					const existingNoUuid = this.sdkMessages.value.filter(
-						(m) => !(m as ChatMessage & { uuid?: string }).uuid
-					);
-					let changed = false;
-					const trulyNew: ChatMessage[] = [];
-					for (const msg of delta.added) {
-						const uuid = (msg as ChatMessage & { uuid?: string }).uuid;
-						if (uuid && messageMap.has(uuid)) {
-							// Update in-place (handles resolved neokai_action messages)
-							messageMap.set(uuid, msg);
-							changed = true;
-						} else {
-							trulyNew.push(msg);
-							changed = true;
-						}
-					}
-					if (changed) {
-						const updated = [
-							...existingNoUuid,
-							...Array.from(messageMap.values()),
-							...trulyNew,
-						].sort(
-							(a, b) =>
-								((a as ChatMessage & { timestamp?: number }).timestamp || 0) -
-								((b as ChatMessage & { timestamp?: number }).timestamp || 0)
-						);
-						this.sdkMessages.value = updated;
-						this._syncCommandsFromSDKMessages(trulyNew);
-					}
-				}
-			});
-			this.cleanupFunctions.push(unsubSDKMessagesDelta);
 
 			// 3. API retry attempt events (from SDK retry handling)
 			const unsubRetryAttempt = hub.onEvent<{
@@ -341,9 +327,18 @@ class SessionStore {
 			});
 			this.cleanupFunctions.push(unsubRetryAttempt);
 
-			// 4. Fetch initial state via RPC (pure WebSocket - no REST API)
-			// This replaces the old REST API calls and state.sdkMessages subscription
-			await this.fetchInitialState(hub, sessionId);
+			// 4. Fetch session-scoped state (metadata + agent state + commands) via RPC.
+			//    Messages are NOT fetched here — they arrive via the LiveQuery snapshot
+			//    below.  We still need the session RPC because session state is
+			//    push-based (server decides when to broadcast) and there is no
+			//    LiveQuery yet for the `sessions` row.
+			await this.fetchInitialSessionState(hub, sessionId);
+
+			// 5. Subscribe to the messages LiveQuery for this session.
+			//    Errors here are intentionally non-fatal — session state can still
+			//    be useful to display (e.g. to show the error banner), and the
+			//    LiveQuery will re-subscribe automatically on reconnect.
+			await this.subscribeToMessagesLiveQuery(hub, sessionId);
 		} catch (err) {
 			logger.error('Failed to start subscriptions:', err);
 			toast.error('Failed to connect to daemon');
@@ -351,23 +346,222 @@ class SessionStore {
 	}
 
 	/**
-	 * Fetch initial state via RPC calls (pure WebSocket)
-	 * Replaces REST API calls for session data and messages
+	 * Subscribe to the `messages.bySession` LiveQuery for a session.
+	 *
+	 * On snapshot, replaces `sdkMessages` with the canonical server row set
+	 * while preserving any optimistic local messages that don't yet have a
+	 * canonical counterpart (matched by uuid).
+	 *
+	 * On delta, applies added/removed/updated rows incrementally.
+	 *
+	 * Stale events arriving after a session switch are filtered out by
+	 * comparing against `activeMessagesSubscriptionId`.
 	 */
-	private async fetchInitialState(
+	private async subscribeToMessagesLiveQuery(
+		hub: Awaited<ReturnType<typeof connectionManager.getHub>>,
+		sessionId: string
+	): Promise<void> {
+		const subscriptionId = `messages:${sessionId}:${Date.now()}`;
+		this.activeMessagesSubscriptionId = subscriptionId;
+
+		// Snapshot handler
+		const unsubSnapshot = hub.onEvent<LiveQuerySnapshotEvent>('liveQuery.snapshot', (event) => {
+			if (event.subscriptionId !== subscriptionId) return;
+			if (this.activeMessagesSubscriptionId !== subscriptionId) return;
+			this._applyMessagesSnapshot(event.rows as ChatMessage[]);
+		});
+		this.cleanupFunctions.push(unsubSnapshot);
+
+		// Delta handler
+		const unsubDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
+			if (event.subscriptionId !== subscriptionId) return;
+			if (this.activeMessagesSubscriptionId !== subscriptionId) return;
+			this._applyMessagesDelta(event);
+		});
+		this.cleanupFunctions.push(unsubDelta);
+
+		// Reconnect handler — re-subscribe with the same subscriptionId on reconnect.
+		const unsubReconnect = hub.onConnection((state) => {
+			if (state !== 'connected') return;
+			if (this.activeMessagesSubscriptionId !== subscriptionId) return;
+			hub
+				.request('liveQuery.subscribe', {
+					queryName: 'messages.bySession',
+					params: [sessionId, LIVE_QUERY_MESSAGE_LIMIT],
+					subscriptionId,
+				})
+				.catch((err) => {
+					logger.warn('Messages LiveQuery re-subscribe failed:', err);
+				});
+		});
+		this.cleanupFunctions.push(unsubReconnect);
+
+		// Also push a cleanup that tells the server to drop the subscription.
+		this.cleanupFunctions.push(() => {
+			const activeHub = connectionManager.getHubIfConnected();
+			if (activeHub) {
+				activeHub.request('liveQuery.unsubscribe', { subscriptionId }).catch(() => {
+					/* best-effort — server will clean up on disconnect anyway */
+				});
+			}
+		});
+
+		try {
+			await hub.request('liveQuery.subscribe', {
+				queryName: 'messages.bySession',
+				params: [sessionId, LIVE_QUERY_MESSAGE_LIMIT],
+				subscriptionId,
+			});
+		} catch (err) {
+			logger.error('Failed to subscribe to messages LiveQuery:', err);
+			// Don't rethrow — we still want session state to be usable even if
+			// the LiveQuery failed (e.g. session was deleted between select and
+			// subscribe). The UI will render whatever sdkMessages currently holds.
+		}
+	}
+
+	/**
+	 * Apply a LiveQuery snapshot to the sdkMessages signal.
+	 *
+	 * Replaces the canonical messages wholesale, but preserves any optimistic
+	 * local messages (those tracked in `pendingLocalMessageUuids`) that the
+	 * server snapshot doesn't yet include. This avoids flicker when the user
+	 * has just sent a message: their local echo stays visible until the
+	 * server delta overwrites it.
+	 */
+	private _applyMessagesSnapshot(rows: ChatMessage[]): void {
+		const incomingUuids = new Set(
+			rows
+				.map((m) => (m as ChatMessage & { uuid?: string }).uuid)
+				.filter((u): u is string => typeof u === 'string' && u.length > 0)
+		);
+
+		// Preserve any optimistic local messages not yet reflected in the snapshot.
+		const preservedLocals = this.sdkMessages.value.filter((m) => {
+			const uuid = (m as ChatMessage & { uuid?: string }).uuid;
+			return uuid && this.pendingLocalMessageUuids.has(uuid) && !incomingUuids.has(uuid);
+		});
+
+		// Any pending local whose uuid IS in the snapshot is now canonical — drop it
+		// from the pending set so it doesn't keep getting "preserved" forever.
+		for (const uuid of Array.from(this.pendingLocalMessageUuids)) {
+			if (incomingUuids.has(uuid)) {
+				this.pendingLocalMessageUuids.delete(uuid);
+			}
+		}
+
+		const merged = [...rows, ...preservedLocals].sort(
+			(a, b) =>
+				((a as ChatMessage & { timestamp?: number }).timestamp || 0) -
+				((b as ChatMessage & { timestamp?: number }).timestamp || 0)
+		);
+
+		this.sdkMessages.value = merged;
+		this._hasMoreMessages.value = rows.length >= LIVE_QUERY_MESSAGE_LIMIT;
+		this._initialMessageCount.value = rows.length;
+		this._syncCommandsFromSDKMessages(merged);
+	}
+
+	/**
+	 * Apply a LiveQuery delta to the sdkMessages signal.
+	 *
+	 * - added: appended (deduped by uuid against existing rows)
+	 * - removed: filtered out by id
+	 * - updated: replaced in-place by id
+	 *
+	 * Messages keyed by `id` (the DB row id we surfaced in `messages.bySession`)
+	 * give stable diffing even when the SDK message itself lacks a uuid.
+	 */
+	private _applyMessagesDelta(event: LiveQueryDeltaEvent): void {
+		let next = this.sdkMessages.value.slice();
+
+		if (event.removed?.length) {
+			const removedIds = new Set(
+				(event.removed as Array<{ id?: unknown }>).map((r) => r.id).filter((id) => id != null)
+			);
+			const removedUuids = new Set(
+				(event.removed as Array<ChatMessage & { uuid?: string }>)
+					.map((r) => r.uuid)
+					.filter((u): u is string => typeof u === 'string' && u.length > 0)
+			);
+			next = next.filter((m) => {
+				const id = (m as ChatMessage & { id?: unknown }).id;
+				const uuid = (m as ChatMessage & { uuid?: string }).uuid;
+				if (id != null && removedIds.has(id)) return false;
+				if (uuid && removedUuids.has(uuid)) return false;
+				return true;
+			});
+		}
+
+		if (event.updated?.length) {
+			const updatedById = new Map<unknown, ChatMessage>();
+			const updatedByUuid = new Map<string, ChatMessage>();
+			for (const row of event.updated as ChatMessage[]) {
+				const id = (row as ChatMessage & { id?: unknown }).id;
+				const uuid = (row as ChatMessage & { uuid?: string }).uuid;
+				if (id != null) updatedById.set(id, row);
+				if (uuid) updatedByUuid.set(uuid, row);
+			}
+			next = next.map((m) => {
+				const id = (m as ChatMessage & { id?: unknown }).id;
+				const uuid = (m as ChatMessage & { uuid?: string }).uuid;
+				if (id != null && updatedById.has(id)) return updatedById.get(id)!;
+				if (uuid && updatedByUuid.has(uuid)) return updatedByUuid.get(uuid)!;
+				return m;
+			});
+		}
+
+		if (event.added?.length) {
+			const existingIds = new Set(
+				next.map((m) => (m as ChatMessage & { id?: unknown }).id).filter((id) => id != null)
+			);
+			const existingUuids = new Set(
+				next
+					.map((m) => (m as ChatMessage & { uuid?: string }).uuid)
+					.filter((u): u is string => typeof u === 'string' && u.length > 0)
+			);
+			const trulyNew: ChatMessage[] = [];
+			for (const row of event.added as ChatMessage[]) {
+				const id = (row as ChatMessage & { id?: unknown }).id;
+				const uuid = (row as ChatMessage & { uuid?: string }).uuid;
+				if (id != null && existingIds.has(id)) continue;
+				if (uuid && existingUuids.has(uuid)) {
+					// Optimistic echo being replaced by the canonical row — swap in place
+					next = next.map((m) => ((m as ChatMessage & { uuid?: string }).uuid === uuid ? row : m));
+					this.pendingLocalMessageUuids.delete(uuid);
+					continue;
+				}
+				trulyNew.push(row);
+			}
+			if (trulyNew.length) {
+				next = [...next, ...trulyNew].sort(
+					(a, b) =>
+						((a as ChatMessage & { timestamp?: number }).timestamp || 0) -
+						((b as ChatMessage & { timestamp?: number }).timestamp || 0)
+				);
+			}
+			this._syncCommandsFromSDKMessages(trulyNew);
+		}
+
+		this.sdkMessages.value = next;
+	}
+
+	/**
+	 * Fetch initial session state via RPC.
+	 *
+	 * Messages are NOT fetched here — they arrive via the LiveQuery
+	 * `messages.bySession` snapshot pushed on subscribe. Keeping the message
+	 * and session fetches separate is what unlocks the reactive message
+	 * stream: the client no longer has to coordinate a "first RPC then delta"
+	 * handoff, so there's no window where messages could be dropped.
+	 */
+	private async fetchInitialSessionState(
 		hub: Awaited<ReturnType<typeof connectionManager.getHub>>,
 		sessionId: string
 	): Promise<void> {
 		try {
-			// Fetch session state and messages in parallel
-			const [sessionState, messagesState] = await Promise.all([
-				hub.request<SessionState>('state.session', { sessionId }),
-				hub.request<{ sdkMessages: ChatMessage[]; hasMore: boolean }>('state.sdkMessages', {
-					sessionId,
-				}),
-			]);
+			const sessionState = await hub.request<SessionState>('state.session', { sessionId });
 
-			// Update signals with initial state
 			if (sessionState) {
 				this.sessionState.value = sessionState;
 
@@ -396,79 +590,9 @@ class SessionStore {
 					},
 					timestamp: Date.now(),
 				};
-				return;
-			}
-
-			if (messagesState?.sdkMessages) {
-				// CRITICAL FIX: Merge instead of replace to preserve newer messages
-				// that arrived via delta subscription during reconnection
-				//
-				// Root cause: When client reconnects, delta subscription becomes active
-				// immediately (subscribeOptimistic), and fetchInitialState runs in parallel.
-				// If newer messages arrive via delta BEFORE fetchInitialState completes,
-				// a simple replace would lose those newer messages.
-				//
-				// Solution: Use the server's timestamp as the synchronization point.
-				// Keep any existing messages that are newer than the server's snapshot,
-				// then merge and deduplicate by UUID.
-
-				const snapshotTimestamp = (messagesState as unknown as { timestamp?: number }).timestamp;
-				const currentMessages = this.sdkMessages.value;
-				const initialSnapshot = messagesState.sdkMessages;
-
-				// Track initial message count and hasMore from server response
-				this._initialMessageCount.value = initialSnapshot.length;
-				this._hasMoreMessages.value = messagesState.hasMore ?? false;
-
-				if (snapshotTimestamp && currentMessages.length > 0) {
-					// Preserve newer messages that arrived via delta during reconnection
-					// Messages from DB have timestamp added, so we filter by it
-					const newerMessages = currentMessages.filter(
-						(m) => ((m as unknown as { timestamp?: number }).timestamp || 0) >= snapshotTimestamp
-					);
-
-					if (newerMessages.length > 0) {
-						// Merge: server snapshot + newer delta messages
-						const messageMap = new Map<string, ChatMessage>();
-
-						// Add snapshot messages
-						for (const msg of initialSnapshot) {
-							const uuid = (msg as ChatMessage & { uuid?: string }).uuid;
-							if (uuid) {
-								messageMap.set(uuid, msg);
-							}
-						}
-
-						// Newer messages override (they're more recent)
-						for (const msg of newerMessages) {
-							const uuid = (msg as ChatMessage & { uuid?: string }).uuid;
-							if (uuid) {
-								messageMap.set(uuid, msg);
-							}
-						}
-
-						// Convert back to array, sorted by timestamp
-						// Messages from DB have timestamp added, so we can sort by it
-						this.sdkMessages.value = Array.from(messageMap.values()).sort(
-							(a, b) =>
-								((a as unknown as { timestamp?: number }).timestamp || 0) -
-								((b as unknown as { timestamp?: number }).timestamp || 0)
-						);
-					} else {
-						// No newer messages, use snapshot directly
-						this.sdkMessages.value = initialSnapshot;
-					}
-				} else {
-					// No timestamp in response or first load, use snapshot directly
-					this.sdkMessages.value = initialSnapshot;
-				}
-
-				// Sync slash commands from system:init message in initial load.
-				// Handles sessions that already have messages (e.g., after page reload).
-				this._syncCommandsFromSDKMessages(this.sdkMessages.value);
 			}
 		} catch (err) {
-			logger.error('Failed to fetch initial state:', err);
+			logger.error('Failed to fetch initial session state:', err);
 			// Set error state so UI shows error instead of infinite loading
 			this.sessionState.value = {
 				sessionInfo: null,
@@ -546,7 +670,11 @@ class SessionStore {
 
 		try {
 			const hub = await connectionManager.getHub();
-			await this.fetchInitialState(hub, sessionId);
+			// Refresh session state only; the LiveQuery already re-subscribes on
+			// reconnect (via the onConnection handler wired in
+			// subscribeToMessagesLiveQuery), so messages do not need a separate
+			// refresh path.
+			await this.fetchInitialSessionState(hub, sessionId);
 		} catch (err) {
 			logger.error('Failed to refresh state:', err);
 			// Don't throw - subscriptions will still receive updates

--- a/packages/web/src/lib/session-store.ts
+++ b/packages/web/src/lib/session-store.ts
@@ -158,16 +158,6 @@ class SessionStore {
 	 */
 	private activeMessagesSubscriptionId: string | null = null;
 
-	/**
-	 * Messages that were locally appended (optimistic UI) for the current
-	 * session but have not yet been reflected in the LiveQuery snapshot.
-	 *
-	 * Keyed by uuid. On LiveQuery snapshot/delta, entries whose uuid matches
-	 * a canonical row are cleared; entries that never match are preserved
-	 * until the session switches (at which point they're cleared wholesale).
-	 */
-	private pendingLocalMessageUuids: Set<string> = new Set();
-
 	// ========================================
 	// Session Selection (with Promise-Chain Lock)
 	// ========================================
@@ -216,7 +206,6 @@ class SessionStore {
 		this._initialMessageCount.value = 0;
 		this._hasMoreMessages.value = false;
 		this._contextInfo.value = null; // Clear context info on session switch
-		this.pendingLocalMessageUuids.clear();
 		// Invalidate any in-flight LiveQuery events for the previous session.
 		// Events already queued in the event loop will see this guard and be
 		// dropped before touching the fresh sdkMessages signal.
@@ -348,10 +337,7 @@ class SessionStore {
 	/**
 	 * Subscribe to the `messages.bySession` LiveQuery for a session.
 	 *
-	 * On snapshot, replaces `sdkMessages` with the canonical server row set
-	 * while preserving any optimistic local messages that don't yet have a
-	 * canonical counterpart (matched by uuid).
-	 *
+	 * On snapshot, replaces `sdkMessages` with the canonical server row set.
 	 * On delta, applies added/removed/updated rows incrementally.
 	 *
 	 * Stale events arriving after a session switch are filtered out by
@@ -423,49 +409,31 @@ class SessionStore {
 	/**
 	 * Apply a LiveQuery snapshot to the sdkMessages signal.
 	 *
-	 * Replaces the canonical messages wholesale, but preserves any optimistic
-	 * local messages (those tracked in `pendingLocalMessageUuids`) that the
-	 * server snapshot doesn't yet include. This avoids flicker when the user
-	 * has just sent a message: their local echo stays visible until the
-	 * server delta overwrites it.
+	 * Replaces the canonical messages wholesale. The daemon persists every
+	 * user message to `sdk_messages` before acking `message.send`, and the
+	 * LiveQuery delta fires within a single event-loop tick, so no
+	 * client-side optimistic echo is required to show a freshly-sent message
+	 * — it appears on the next delta.
 	 */
 	private _applyMessagesSnapshot(rows: ChatMessage[]): void {
-		const incomingUuids = new Set(
-			rows
-				.map((m) => (m as ChatMessage & { uuid?: string }).uuid)
-				.filter((u): u is string => typeof u === 'string' && u.length > 0)
-		);
+		const sorted = rows
+			.slice()
+			.sort(
+				(a, b) =>
+					((a as ChatMessage & { timestamp?: number }).timestamp || 0) -
+					((b as ChatMessage & { timestamp?: number }).timestamp || 0)
+			);
 
-		// Preserve any optimistic local messages not yet reflected in the snapshot.
-		const preservedLocals = this.sdkMessages.value.filter((m) => {
-			const uuid = (m as ChatMessage & { uuid?: string }).uuid;
-			return uuid && this.pendingLocalMessageUuids.has(uuid) && !incomingUuids.has(uuid);
-		});
-
-		// Any pending local whose uuid IS in the snapshot is now canonical — drop it
-		// from the pending set so it doesn't keep getting "preserved" forever.
-		for (const uuid of Array.from(this.pendingLocalMessageUuids)) {
-			if (incomingUuids.has(uuid)) {
-				this.pendingLocalMessageUuids.delete(uuid);
-			}
-		}
-
-		const merged = [...rows, ...preservedLocals].sort(
-			(a, b) =>
-				((a as ChatMessage & { timestamp?: number }).timestamp || 0) -
-				((b as ChatMessage & { timestamp?: number }).timestamp || 0)
-		);
-
-		this.sdkMessages.value = merged;
+		this.sdkMessages.value = sorted;
 		this._hasMoreMessages.value = rows.length >= LIVE_QUERY_MESSAGE_LIMIT;
 		this._initialMessageCount.value = rows.length;
-		this._syncCommandsFromSDKMessages(merged);
+		this._syncCommandsFromSDKMessages(sorted);
 	}
 
 	/**
 	 * Apply a LiveQuery delta to the sdkMessages signal.
 	 *
-	 * - added: appended (deduped by uuid against existing rows)
+	 * - added: appended (deduped by id — the LiveQuery engine diffs rows by `id`)
 	 * - removed: filtered out by id
 	 * - updated: replaced in-place by id
 	 *
@@ -479,34 +447,21 @@ class SessionStore {
 			const removedIds = new Set(
 				(event.removed as Array<{ id?: unknown }>).map((r) => r.id).filter((id) => id != null)
 			);
-			const removedUuids = new Set(
-				(event.removed as Array<ChatMessage & { uuid?: string }>)
-					.map((r) => r.uuid)
-					.filter((u): u is string => typeof u === 'string' && u.length > 0)
-			);
 			next = next.filter((m) => {
 				const id = (m as ChatMessage & { id?: unknown }).id;
-				const uuid = (m as ChatMessage & { uuid?: string }).uuid;
-				if (id != null && removedIds.has(id)) return false;
-				if (uuid && removedUuids.has(uuid)) return false;
-				return true;
+				return !(id != null && removedIds.has(id));
 			});
 		}
 
 		if (event.updated?.length) {
 			const updatedById = new Map<unknown, ChatMessage>();
-			const updatedByUuid = new Map<string, ChatMessage>();
 			for (const row of event.updated as ChatMessage[]) {
 				const id = (row as ChatMessage & { id?: unknown }).id;
-				const uuid = (row as ChatMessage & { uuid?: string }).uuid;
 				if (id != null) updatedById.set(id, row);
-				if (uuid) updatedByUuid.set(uuid, row);
 			}
 			next = next.map((m) => {
 				const id = (m as ChatMessage & { id?: unknown }).id;
-				const uuid = (m as ChatMessage & { uuid?: string }).uuid;
 				if (id != null && updatedById.has(id)) return updatedById.get(id)!;
-				if (uuid && updatedByUuid.has(uuid)) return updatedByUuid.get(uuid)!;
 				return m;
 			});
 		}
@@ -515,22 +470,10 @@ class SessionStore {
 			const existingIds = new Set(
 				next.map((m) => (m as ChatMessage & { id?: unknown }).id).filter((id) => id != null)
 			);
-			const existingUuids = new Set(
-				next
-					.map((m) => (m as ChatMessage & { uuid?: string }).uuid)
-					.filter((u): u is string => typeof u === 'string' && u.length > 0)
-			);
 			const trulyNew: ChatMessage[] = [];
 			for (const row of event.added as ChatMessage[]) {
 				const id = (row as ChatMessage & { id?: unknown }).id;
-				const uuid = (row as ChatMessage & { uuid?: string }).uuid;
 				if (id != null && existingIds.has(id)) continue;
-				if (uuid && existingUuids.has(uuid)) {
-					// Optimistic echo being replaced by the canonical row — swap in place
-					next = next.map((m) => ((m as ChatMessage & { uuid?: string }).uuid === uuid ? row : m));
-					this.pendingLocalMessageUuids.delete(uuid);
-					continue;
-				}
 				trulyNew.push(row);
 			}
 			if (trulyNew.length) {


### PR DESCRIPTION
## Summary

- **Web:** Migrate `SessionStore` away from the RPC-fetch + `state.sdkMessages.delta` pub/sub path to a single `messages.bySession` LiveQuery (same pattern as `skills.list`/`skills.byRoom`). Optimistic user echo preserved until the server snapshot/delta overwrites it.
- **Daemon:** Add `messages.bySession` named LiveQuery — returns top-level rows plus subagent rows whose `parent_tool_use_id` matches an included `tool_use`, excludes deferred/enqueued user rows, maps to `ChatMessage` with DB-forced `id`/`timestamp`/`origin`.
- **Space:** Attach `space-agent-tools` to every session whose `session.context.spaceId` is set (worker/coder/room_chat/ad-hoc), not just the Space chat session. Permission checks live inside the tool handlers, so widening the MCP surface is safe. Adds `AgentSession.mergeRuntimeMcpServers` so other subsystems' servers are preserved.
- **Docs:** CLAUDE.md "Space Runtime" section covering both pieces.

## Test plan

- [x] `bun run check` (lint + typecheck + knip)
- [x] `make test-daemon` — 11111 pass / 0 fail
- [x] `make test-web` — 7099 pass / 0 fail