### PR TITLE
Delete orphan built-in workflow rows + surface template-drift duplicates

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -421,7 +421,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		deps.spaceManager,
 		spaceWorkflowManager,
 		deps.daemonHub,
-		deps.spaceAgentManager
+		deps.spaceAgentManager,
+		spaceWorkflowRunRepo
 	);
 
 	// Space Runtime Service — wraps SpaceRuntime with per-space lifecycle API.

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
@@ -23,6 +23,7 @@ import type {
 	CreateSpaceWorkflowParams,
 	UpdateSpaceWorkflowParams,
 	DuplicateDriftReport,
+	SpaceWorkflow,
 } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { SpaceManager } from '../space/managers/space-manager';
@@ -30,16 +31,92 @@ import type { SpaceWorkflowManager } from '../space/managers/space-workflow-mana
 import type { SpaceAgentManager } from '../space/managers/space-agent-manager';
 import { getBuiltInWorkflows } from '../space/workflows/built-in-workflows';
 import { computeWorkflowHash } from '../space/workflows/template-hash';
+import type { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
 import { Logger } from '../logger';
 
 const log = new Logger('space-workflow-handlers');
+
+/**
+ * Resolve a template (built-in workflow) against a space's agents and produce
+ * the `UpdateSpaceWorkflowParams` that overwrites an existing row with the
+ * template's canonical content.
+ *
+ * Shared by `spaceWorkflow.syncFromTemplate` and `spaceWorkflow.resyncDuplicates`.
+ *
+ * Throws synchronously if any node references an agent name that doesn't exist
+ * in the target space — callers rely on this to validate BEFORE performing any
+ * destructive work (e.g. deleting duplicate rows).
+ *
+ * @param errorVerb   Appears in thrown error messages (e.g. "sync", "resync")
+ *                    so users see "Cannot sync: …" vs. "Cannot resync: …".
+ */
+function buildTemplateUpdateParams(
+	spaceAgentManager: SpaceAgentManager,
+	spaceId: string,
+	template: SpaceWorkflow,
+	errorVerb: 'sync' | 'resync'
+): UpdateSpaceWorkflowParams {
+	const spaceAgents = spaceAgentManager.listBySpaceId(spaceId);
+	function resolveAgentId(roleName: string): string | undefined {
+		return spaceAgents.find((a) => a.name.toLowerCase() === roleName.toLowerCase())?.id;
+	}
+
+	const nodeIdMap = new Map<string, string>();
+	for (const node of template.nodes) {
+		nodeIdMap.set(node.id, generateUUID());
+	}
+
+	const newNodes = template.nodes.map((node) => {
+		const resolvedAgents = node.agents.map((a) => {
+			const resolvedId = resolveAgentId(a.agentId);
+			if (!resolvedId) {
+				throw new Error(
+					`Cannot ${errorVerb}: no SpaceAgent found with name "${a.agentId}" in space "${spaceId}".`
+				);
+			}
+			return { ...a, agentId: resolvedId };
+		});
+		return {
+			id: nodeIdMap.get(node.id)!,
+			name: node.name,
+			agents: resolvedAgents,
+			...(node.completionActions ? { completionActions: node.completionActions } : {}),
+		};
+	});
+
+	const newStartNodeId = nodeIdMap.get(template.startNodeId);
+	if (!newStartNodeId) {
+		throw new Error(`Template "${template.name}" has invalid startNodeId.`);
+	}
+	const newEndNodeId = template.endNodeId ? nodeIdMap.get(template.endNodeId) : undefined;
+	const newChannels = template.channels
+		? template.channels.map((ch) => ({ ...ch, id: ch.id ?? generateUUID() }))
+		: null;
+	const newGates = template.gates ? [...template.gates] : null;
+	const templateHash = computeWorkflowHash(template);
+
+	return {
+		name: template.name,
+		description: template.description ?? null,
+		instructions: template.instructions ?? null,
+		nodes: newNodes,
+		startNodeId: newStartNodeId,
+		endNodeId: newEndNodeId ?? null,
+		channels: newChannels,
+		gates: newGates,
+		tags: [...template.tags],
+		templateName: template.name,
+		templateHash,
+	};
+}
 
 export function setupSpaceWorkflowHandlers(
 	messageHub: MessageHub,
 	spaceManager: SpaceManager,
 	workflowManager: SpaceWorkflowManager,
 	daemonHub: DaemonHub,
-	spaceAgentManager: SpaceAgentManager
+	spaceAgentManager: SpaceAgentManager,
+	workflowRunRepo: SpaceWorkflowRunRepository
 ): void {
 	// ─── spaceWorkflow.create ────────────────────────────────────────────────
 	messageHub.onRequest('spaceWorkflow.create', async (data) => {
@@ -345,66 +422,23 @@ export function setupSpaceWorkflowHandlers(
 			);
 		}
 
-		// Resolve agent role names → space agent UUIDs
-		const spaceAgents = spaceAgentManager.listBySpaceId(params.spaceId);
-		function resolveAgentId(roleName: string): string | undefined {
-			return spaceAgents.find((a) => a.name.toLowerCase() === roleName.toLowerCase())?.id;
-		}
+		// Build the overwrite params. Throws synchronously if any node references
+		// an agent name that doesn't exist in this space — nothing is mutated
+		// in that case.
+		const updateParams = buildTemplateUpdateParams(
+			spaceAgentManager,
+			params.spaceId,
+			template,
+			'sync'
+		);
 
-		// Build new node list from template, assigning fresh UUIDs to node IDs
-		const nodeIdMap = new Map<string, string>();
-		for (const node of template.nodes) {
-			nodeIdMap.set(node.id, generateUUID());
-		}
-
-		const newNodes = template.nodes.map((node) => {
-			const resolvedAgents = node.agents.map((a) => {
-				const resolvedId = resolveAgentId(a.agentId);
-				if (!resolvedId) {
-					throw new Error(
-						`Cannot sync: no SpaceAgent found with name "${a.agentId}" in space "${params.spaceId}".`
-					);
-				}
-				return { ...a, agentId: resolvedId };
-			});
-			return {
-				id: nodeIdMap.get(node.id)!,
-				name: node.name,
-				agents: resolvedAgents,
-				...(node.completionActions ? { completionActions: node.completionActions } : {}),
-			};
-		});
-
-		const newStartNodeId = nodeIdMap.get(template.startNodeId);
-		if (!newStartNodeId) {
-			throw new Error(`Template "${template.name}" has invalid startNodeId.`);
-		}
-
-		const newEndNodeId = template.endNodeId ? nodeIdMap.get(template.endNodeId) : undefined;
-
-		const newChannels = template.channels
-			? template.channels.map((ch) => ({ ...ch, id: ch.id ?? generateUUID() }))
-			: null;
-
-		const newGates = template.gates ? [...template.gates] : null;
-
-		// Compute the template hash for drift tracking
-		const templateHash = computeWorkflowHash(template);
+		// Preserve the existing workflow's templateName rather than adopting the
+		// template's name — they should match already, but this guards against
+		// manual edits to the stored templateName.
+		updateParams.templateName = workflow.templateName;
 
 		// Overwrite the workflow
-		const updated = workflowManager.updateWorkflow(params.id, {
-			name: template.name,
-			description: template.description ?? null,
-			instructions: template.instructions ?? null,
-			nodes: newNodes,
-			startNodeId: newStartNodeId,
-			endNodeId: newEndNodeId ?? null,
-			channels: newChannels,
-			gates: newGates,
-			tags: [...template.tags],
-			templateName: workflow.templateName,
-			templateHash,
-		});
+		const updated = workflowManager.updateWorkflow(params.id, updateParams);
 
 		if (!updated) {
 			throw new Error(`Workflow not found: ${params.id}`);
@@ -485,13 +519,18 @@ export function setupSpaceWorkflowHandlers(
 
 	// ─── spaceWorkflow.resyncDuplicates ──────────────────────────────────────
 	// Resolves a duplicate-drift group by:
-	//   1. Keeping the newest (by createdAt) workflow row for the given
-	//      `templateName` in the space.
-	//   2. Deleting every older row in the group (cascade-removing their
-	//      workflow runs — which is acceptable because this is a user-initiated
-	//      cleanup, gated by a confirmation dialog in the UI).
-	//   3. Overwriting the kept row with the current built-in template via
-	//      the same logic as `spaceWorkflow.syncFromTemplate`.
+	//   1. Building the template overwrite params (validates that every agent
+	//      role in the template resolves to a SpaceAgent in this space — throws
+	//      BEFORE any row is mutated if validation fails).
+	//   2. Overwriting the kept row (newest by createdAt) with the canonical
+	//      built-in template, matching `spaceWorkflow.syncFromTemplate`.
+	//   3. Only after (2) succeeds: deleting every older row in the group and
+	//      their workflow runs. Runs are deleted explicitly because migration
+	//      60 rebuilt `space_workflow_runs` without an ON DELETE CASCADE on
+	//      `workflow_id`, so dropping a workflow alone would leave orphans.
+	//
+	// This ordering is deliberate — if agent resolution fails on step 1 the
+	// duplicates must remain on disk so the user can retry after fixing agents.
 	messageHub.onRequest('spaceWorkflow.resyncDuplicates', async (data) => {
 		const params = data as { spaceId: string; templateName: string };
 
@@ -526,13 +565,35 @@ export function setupSpaceWorkflowHandlers(
 			);
 		}
 
-		// Sort newest-first. Keep the first, delete the rest.
+		// Sort newest-first. Keep the first, the rest are candidates for deletion.
 		group.sort((a, b) => b.createdAt - a.createdAt);
 		const kept = group[0];
 		const toDelete = group.slice(1);
 
+		// Build the overwrite params BEFORE any destructive work. If this throws
+		// (e.g. an agent role is missing), no rows have been touched and the
+		// user can retry after fixing their space agents.
+		const updateParams = buildTemplateUpdateParams(
+			spaceAgentManager,
+			params.spaceId,
+			template,
+			'resync'
+		);
+
+		// Overwrite the kept row first. If the update fails the duplicates stay
+		// on disk.
+		const updated = workflowManager.updateWorkflow(kept.id, updateParams);
+		if (!updated) {
+			throw new Error(`Workflow not found: ${kept.id}`);
+		}
+
+		// Only now — after the kept row is safely resynced — remove the duplicates.
+		// Runs are deleted explicitly because the space_workflow_runs FK is not
+		// ON DELETE CASCADE (migration 60 dropped it). Without this the rows
+		// would orphan and show up in no UI but still consume disk.
 		const deletedIds: string[] = [];
 		for (const wf of toDelete) {
+			workflowRunRepo.deleteByWorkflowId(wf.id);
 			const ok = workflowManager.deleteWorkflow(wf.id);
 			if (ok) {
 				deletedIds.push(wf.id);
@@ -546,67 +607,6 @@ export function setupSpaceWorkflowHandlers(
 						log.warn('Failed to emit spaceWorkflow.deleted:', err);
 					});
 			}
-		}
-
-		// If the kept row is already a verbatim copy of the template there's
-		// no content to overwrite — but we still refresh the stored hash so
-		// drift detection clears immediately. The overwrite below re-derives
-		// everything from the template, so this is safe.
-		const spaceAgents = spaceAgentManager.listBySpaceId(params.spaceId);
-		function resolveAgentId(roleName: string): string | undefined {
-			return spaceAgents.find((a) => a.name.toLowerCase() === roleName.toLowerCase())?.id;
-		}
-
-		const nodeIdMap = new Map<string, string>();
-		for (const node of template.nodes) {
-			nodeIdMap.set(node.id, generateUUID());
-		}
-
-		const newNodes = template.nodes.map((node) => {
-			const resolvedAgents = node.agents.map((a) => {
-				const resolvedId = resolveAgentId(a.agentId);
-				if (!resolvedId) {
-					throw new Error(
-						`Cannot resync: no SpaceAgent found with name "${a.agentId}" in space "${params.spaceId}".`
-					);
-				}
-				return { ...a, agentId: resolvedId };
-			});
-			return {
-				id: nodeIdMap.get(node.id)!,
-				name: node.name,
-				agents: resolvedAgents,
-				...(node.completionActions ? { completionActions: node.completionActions } : {}),
-			};
-		});
-
-		const newStartNodeId = nodeIdMap.get(template.startNodeId);
-		if (!newStartNodeId) {
-			throw new Error(`Template "${template.name}" has invalid startNodeId.`);
-		}
-		const newEndNodeId = template.endNodeId ? nodeIdMap.get(template.endNodeId) : undefined;
-		const newChannels = template.channels
-			? template.channels.map((ch) => ({ ...ch, id: ch.id ?? generateUUID() }))
-			: null;
-		const newGates = template.gates ? [...template.gates] : null;
-		const templateHash = computeWorkflowHash(template);
-
-		const updated = workflowManager.updateWorkflow(kept.id, {
-			name: template.name,
-			description: template.description ?? null,
-			instructions: template.instructions ?? null,
-			nodes: newNodes,
-			startNodeId: newStartNodeId,
-			endNodeId: newEndNodeId ?? null,
-			channels: newChannels,
-			gates: newGates,
-			tags: [...template.tags],
-			templateName: template.name,
-			templateHash,
-		});
-
-		if (!updated) {
-			throw new Error(`Workflow not found: ${kept.id}`);
 		}
 
 		daemonHub

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
@@ -19,7 +19,11 @@
 
 import type { MessageHub } from '@neokai/shared';
 import { generateUUID } from '@neokai/shared';
-import type { CreateSpaceWorkflowParams, UpdateSpaceWorkflowParams } from '@neokai/shared';
+import type {
+	CreateSpaceWorkflowParams,
+	UpdateSpaceWorkflowParams,
+	DuplicateDriftReport,
+} from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { SpaceManager } from '../space/managers/space-manager';
 import type { SpaceWorkflowManager } from '../space/managers/space-workflow-manager';
@@ -417,5 +421,204 @@ export function setupSpaceWorkflowHandlers(
 			});
 
 		return { workflow: updated };
+	});
+
+	// ─── spaceWorkflow.detectDuplicateDrift ──────────────────────────────────
+	// Returns groups of workflows within a space that share a `templateName`
+	// but have diverging `templateHash` values — i.e. template drift between
+	// multiple rows for the same built-in template.
+	//
+	// This is distinct from `spaceWorkflow.detectDrift` which reports per-row
+	// drift against the canonical built-in template. `detectDuplicateDrift`
+	// surfaces the case where two or more rows exist and their stored hashes
+	// disagree, which is the signal for "this space has a stale duplicate
+	// that should be cleaned up".
+	messageHub.onRequest('spaceWorkflow.detectDuplicateDrift', async (data) => {
+		const params = data as { spaceId: string };
+
+		if (!params.spaceId) {
+			throw new Error('spaceId is required');
+		}
+
+		const space = await spaceManager.getSpace(params.spaceId);
+		if (!space) {
+			throw new Error(`Space not found: ${params.spaceId}`);
+		}
+
+		// Only built-in templates are eligible for drift reporting — drift on
+		// a user-named template has no canonical source to resync against.
+		const builtInNames = new Set(getBuiltInWorkflows().map((w) => w.name));
+
+		const workflows = workflowManager.listWorkflows(params.spaceId);
+
+		// Group workflows by templateName.
+		const byTemplate = new Map<string, typeof workflows>();
+		for (const wf of workflows) {
+			if (!wf.templateName) continue;
+			if (!builtInNames.has(wf.templateName)) continue;
+			const bucket = byTemplate.get(wf.templateName);
+			if (bucket) bucket.push(wf);
+			else byTemplate.set(wf.templateName, [wf]);
+		}
+
+		const reports: DuplicateDriftReport[] = [];
+		for (const [templateName, rows] of byTemplate) {
+			if (rows.length < 2) continue;
+			// Drift = hash values diverge across rows. Rows with identical hashes
+			// aren't considered drift (even though they're still technically
+			// duplicates — left for separate cleanup).
+			const distinctHashes = new Set(rows.map((r) => r.templateHash ?? null));
+			if (distinctHashes.size < 2) continue;
+			const sortedRows = [...rows].sort((a, b) => b.createdAt - a.createdAt);
+			reports.push({
+				templateName,
+				rows: sortedRows.map((r) => ({
+					id: r.id,
+					templateHash: r.templateHash ?? null,
+					createdAt: r.createdAt,
+				})),
+			});
+		}
+
+		return { reports };
+	});
+
+	// ─── spaceWorkflow.resyncDuplicates ──────────────────────────────────────
+	// Resolves a duplicate-drift group by:
+	//   1. Keeping the newest (by createdAt) workflow row for the given
+	//      `templateName` in the space.
+	//   2. Deleting every older row in the group (cascade-removing their
+	//      workflow runs — which is acceptable because this is a user-initiated
+	//      cleanup, gated by a confirmation dialog in the UI).
+	//   3. Overwriting the kept row with the current built-in template via
+	//      the same logic as `spaceWorkflow.syncFromTemplate`.
+	messageHub.onRequest('spaceWorkflow.resyncDuplicates', async (data) => {
+		const params = data as { spaceId: string; templateName: string };
+
+		if (!params.spaceId) {
+			throw new Error('spaceId is required');
+		}
+		if (!params.templateName) {
+			throw new Error('templateName is required');
+		}
+
+		const space = await spaceManager.getSpace(params.spaceId);
+		if (!space) {
+			throw new Error(`Space not found: ${params.spaceId}`);
+		}
+
+		// Only built-in templates can be resynced — other templateNames have
+		// no canonical source to pull from.
+		const builtInTemplates = getBuiltInWorkflows();
+		const template = builtInTemplates.find((t) => t.name === params.templateName);
+		if (!template) {
+			throw new Error(
+				`Built-in template "${params.templateName}" not found. Resync is only available for built-in workflows.`
+			);
+		}
+
+		// Find all workflows in the space with this templateName.
+		const all = workflowManager.listWorkflows(params.spaceId);
+		const group = all.filter((w) => w.templateName === params.templateName);
+		if (group.length === 0) {
+			throw new Error(
+				`No workflows found for templateName "${params.templateName}" in space "${params.spaceId}".`
+			);
+		}
+
+		// Sort newest-first. Keep the first, delete the rest.
+		group.sort((a, b) => b.createdAt - a.createdAt);
+		const kept = group[0];
+		const toDelete = group.slice(1);
+
+		const deletedIds: string[] = [];
+		for (const wf of toDelete) {
+			const ok = workflowManager.deleteWorkflow(wf.id);
+			if (ok) {
+				deletedIds.push(wf.id);
+				await daemonHub
+					.emit('spaceWorkflow.deleted', {
+						sessionId: 'global',
+						spaceId: params.spaceId,
+						workflowId: wf.id,
+					})
+					.catch((err) => {
+						log.warn('Failed to emit spaceWorkflow.deleted:', err);
+					});
+			}
+		}
+
+		// If the kept row is already a verbatim copy of the template there's
+		// no content to overwrite — but we still refresh the stored hash so
+		// drift detection clears immediately. The overwrite below re-derives
+		// everything from the template, so this is safe.
+		const spaceAgents = spaceAgentManager.listBySpaceId(params.spaceId);
+		function resolveAgentId(roleName: string): string | undefined {
+			return spaceAgents.find((a) => a.name.toLowerCase() === roleName.toLowerCase())?.id;
+		}
+
+		const nodeIdMap = new Map<string, string>();
+		for (const node of template.nodes) {
+			nodeIdMap.set(node.id, generateUUID());
+		}
+
+		const newNodes = template.nodes.map((node) => {
+			const resolvedAgents = node.agents.map((a) => {
+				const resolvedId = resolveAgentId(a.agentId);
+				if (!resolvedId) {
+					throw new Error(
+						`Cannot resync: no SpaceAgent found with name "${a.agentId}" in space "${params.spaceId}".`
+					);
+				}
+				return { ...a, agentId: resolvedId };
+			});
+			return {
+				id: nodeIdMap.get(node.id)!,
+				name: node.name,
+				agents: resolvedAgents,
+				...(node.completionActions ? { completionActions: node.completionActions } : {}),
+			};
+		});
+
+		const newStartNodeId = nodeIdMap.get(template.startNodeId);
+		if (!newStartNodeId) {
+			throw new Error(`Template "${template.name}" has invalid startNodeId.`);
+		}
+		const newEndNodeId = template.endNodeId ? nodeIdMap.get(template.endNodeId) : undefined;
+		const newChannels = template.channels
+			? template.channels.map((ch) => ({ ...ch, id: ch.id ?? generateUUID() }))
+			: null;
+		const newGates = template.gates ? [...template.gates] : null;
+		const templateHash = computeWorkflowHash(template);
+
+		const updated = workflowManager.updateWorkflow(kept.id, {
+			name: template.name,
+			description: template.description ?? null,
+			instructions: template.instructions ?? null,
+			nodes: newNodes,
+			startNodeId: newStartNodeId,
+			endNodeId: newEndNodeId ?? null,
+			channels: newChannels,
+			gates: newGates,
+			tags: [...template.tags],
+			templateName: template.name,
+			templateHash,
+		});
+
+		if (!updated) {
+			throw new Error(`Workflow not found: ${kept.id}`);
+		}
+
+		daemonHub
+			.emit('spaceWorkflow.updated', {
+				sessionId: 'global',
+				spaceId: params.spaceId,
+				workflow: updated,
+			})
+			.catch((err) => {
+				log.warn('Failed to emit spaceWorkflow.updated:', err);
+			});
+
+		return { workflow: updated, keptWorkflowId: kept.id, deletedIds };
 	});
 }

--- a/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
@@ -210,6 +210,21 @@ export class SpaceWorkflowRunRepository {
 	}
 
 	/**
+	 * Delete every run that belongs to a given workflow.
+	 *
+	 * Needed because migration 60 rebuilt `space_workflow_runs` without an
+	 * `ON DELETE CASCADE` FK on `workflow_id`, so callers that remove a workflow
+	 * must explicitly clean up its runs to avoid orphans.
+	 *
+	 * @returns The number of rows deleted.
+	 */
+	deleteByWorkflowId(workflowId: string): number {
+		const stmt = this.db.prepare(`DELETE FROM space_workflow_runs WHERE workflow_id = ?`);
+		const result = stmt.run(workflowId);
+		return result.changes;
+	}
+
+	/**
 	 * Convert a database row to a SpaceWorkflowRun object
 	 */
 	private rowToRun(row: Record<string, unknown>): SpaceWorkflowRun {

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -51,6 +51,8 @@ export { runMigration94 } from './migrations';
 export { runMigration95 } from './migrations';
 // knip-ignore-next-line
 export { runMigration96 } from './migrations';
+// knip-ignore-next-line
+export { runMigration97 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -421,6 +421,14 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	//   now that it has been replaced by the Plan & Decompose workflow.
 	//   Only deletes rows with no active workflow runs so in-flight work is preserved.
 	runMigration96(db);
+
+	// Migration 97: Delete orphan built-in workflow rows — rows whose `name` matches
+	//   a known built-in template but whose `template_name` column is NULL. These are
+	//   pre-template-tracking duplicates left over when a later seed created a fresh
+	//   row alongside the orphan. Any runs referencing an orphan workflow are deleted
+	//   first (M60 rebuilt space_workflow_runs without an ON DELETE CASCADE FK, so
+	//   the migration handles the cleanup explicitly).
+	runMigration97(db);
 }
 
 /**
@@ -470,6 +478,74 @@ export function runMigration96(db: BunDatabase): void {
 		// Defensive: swallow errors on ancient schemas. The migration's only job
 		// is a cleanup nudge — failing here would block unrelated migrations.
 	}
+}
+
+/**
+ * Migration 97 — Delete orphan built-in workflow rows.
+ *
+ * Clears pre-template-tracking rows that match a known built-in workflow name
+ * but have `template_name IS NULL`. These rows predate the template-tracking
+ * columns (see migration 90) and were typically superseded by a fresh seed row
+ * that already carries `template_name`. Leaving them in place breaks drift
+ * detection and confuses the workflow list UI.
+ *
+ * Idempotent — running the migration twice deletes 0 rows on the second pass.
+ *
+ * Orphaned-run handling: the `space_workflow_runs.workflow_id` FK was dropped
+ * in migration 60, so deleting a workflow does NOT cascade to its runs. To
+ * avoid leaving dangling run rows we first delete any runs that reference an
+ * orphan workflow. This is acceptable because orphan rows have not been used
+ * for new seeding since template tracking shipped — any run referencing one
+ * is stale.
+ *
+ * Complements migration 96 (which deletes Full-Cycle rows without active runs):
+ * M96 targets rows by exact name; this migration targets pre-tracking orphans
+ * across the built-in set (including legacy names like "Coding with QA
+ * Workflow" and "Full-Cycle Coding Workflow" for users upgrading from older
+ * databases).
+ */
+export function runMigration97(db: BunDatabase): void {
+	if (!tableExists(db, 'space_workflows')) return;
+	// Guard on the template_name column existing — if migration 90 hasn't run
+	// yet (shouldn't happen in practice, but defensive) skip silently.
+	if (!tableHasColumn(db, 'space_workflows', 'template_name')) return;
+
+	// Built-in workflow names at the time this migration was authored. Mirrors
+	// `getBuiltInWorkflows()` in built-in-workflows.ts, plus the two legacy
+	// names retired in PR #1539 so orphan rows on upgraded databases are also
+	// cleaned up. Kept inline — migrations must be self-contained and stable
+	// across future template changes.
+	const BUILT_IN_NAMES = [
+		'Coding Workflow',
+		'Coding with QA Workflow',
+		'Full-Cycle Coding Workflow',
+		'Fullstack QA Loop Workflow',
+		'Plan & Decompose Workflow',
+		'Research Workflow',
+		'Review-Only Workflow',
+	];
+
+	const placeholders = BUILT_IN_NAMES.map(() => '?').join(', ');
+
+	// Clean up dangling runs first — there is no FK cascade from
+	// space_workflow_runs.workflow_id anymore (M60 rebuilt the table without
+	// it), so we do it explicitly to avoid leaving orphaned run rows.
+	if (tableExists(db, 'space_workflow_runs')) {
+		db.prepare(
+			`DELETE FROM space_workflow_runs
+			  WHERE workflow_id IN (
+			    SELECT id FROM space_workflows
+			    WHERE template_name IS NULL
+			      AND name IN (${placeholders})
+			  )`
+		).run(...BUILT_IN_NAMES);
+	}
+
+	db.prepare(
+		`DELETE FROM space_workflows
+		  WHERE template_name IS NULL
+		    AND name IN (${placeholders})`
+	).run(...BUILT_IN_NAMES);
 }
 
 /**

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-workflow-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-workflow-handlers.test.ts
@@ -28,6 +28,7 @@ import type { SpaceManager } from '../../../../src/lib/space/managers/space-mana
 import type { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager';
 import { WorkflowValidationError } from '../../../../src/lib/space/managers/space-workflow-manager';
 import type { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager';
+import type { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository';
 import type { DaemonHub } from '../../../../src/lib/daemon-hub';
 import { computeWorkflowHash } from '../../../../src/lib/space/workflows/template-hash';
 import { getBuiltInWorkflows } from '../../../../src/lib/space/workflows/built-in-workflows';
@@ -135,6 +136,12 @@ function createMockSpaceAgentManager(
 	} as unknown as SpaceAgentManager;
 }
 
+function createMockWorkflowRunRepo(): SpaceWorkflowRunRepository {
+	return {
+		deleteByWorkflowId: mock(() => 0),
+	} as unknown as SpaceWorkflowRunRepository;
+}
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('space-workflow-handlers', () => {
@@ -144,6 +151,7 @@ describe('space-workflow-handlers', () => {
 	let spaceManager: SpaceManager;
 	let workflowManager: SpaceWorkflowManager;
 	let spaceAgentManager: SpaceAgentManager;
+	let workflowRunRepo: SpaceWorkflowRunRepository;
 
 	function setup(
 		space: Space | null = mockSpace,
@@ -157,7 +165,15 @@ describe('space-workflow-handlers', () => {
 		spaceManager = createMockSpaceManager(space);
 		workflowManager = createMockWorkflowManager(workflow);
 		spaceAgentManager = createMockSpaceAgentManager(agents);
-		setupSpaceWorkflowHandlers(hub, spaceManager, workflowManager, daemonHub, spaceAgentManager);
+		workflowRunRepo = createMockWorkflowRunRepo();
+		setupSpaceWorkflowHandlers(
+			hub,
+			spaceManager,
+			workflowManager,
+			daemonHub,
+			spaceAgentManager,
+			workflowRunRepo
+		);
 	}
 
 	const call = (method: string, data: unknown) => {
@@ -1059,7 +1075,11 @@ describe('space-workflow-handlers', () => {
 			expect(workflowManager.updateWorkflow).toHaveBeenCalledTimes(1);
 		});
 
-		it('throws when no SpaceAgent resolves a required role (rolls back nothing — same contract as syncFromTemplate)', async () => {
+		it('throws when no SpaceAgent resolves a required role — and does NOT delete any duplicates or mutate the kept row', async () => {
+			// Regression: previously resyncDuplicates deleted the older rows
+			// before validating agent resolution. If agent resolution threw,
+			// duplicates were permanently lost with no resync performed. The
+			// handler must now validate first, update second, delete last.
 			const [template] = getBuiltInWorkflows();
 			const older: SpaceWorkflow = {
 				...mockWorkflow,
@@ -1084,6 +1104,54 @@ describe('space-workflow-handlers', () => {
 					templateName: template.name,
 				})
 			).rejects.toThrow('Cannot resync: no SpaceAgent found with name');
+
+			// Crucially: no destructive work happened.
+			expect(workflowManager.deleteWorkflow).not.toHaveBeenCalled();
+			expect(workflowManager.updateWorkflow).not.toHaveBeenCalled();
+			expect(workflowRunRepo.deleteByWorkflowId).not.toHaveBeenCalled();
+		});
+
+		it('explicitly deletes runs for each removed duplicate workflow', async () => {
+			// Regression: migration 60 rebuilt space_workflow_runs without ON
+			// DELETE CASCADE on workflow_id, so removing a workflow alone leaves
+			// orphan runs. resyncDuplicates must call deleteByWorkflowId for
+			// each deleted row.
+			const [template] = getBuiltInWorkflows();
+			const agents = agentsForTemplate(template);
+			const older1: SpaceWorkflow = {
+				...mockWorkflow,
+				id: 'wf-older-1',
+				templateName: template.name,
+				templateHash: 'old-1',
+				createdAt: 100,
+			};
+			const older2: SpaceWorkflow = {
+				...mockWorkflow,
+				id: 'wf-older-2',
+				templateName: template.name,
+				templateHash: 'old-2',
+				createdAt: 150,
+			};
+			const newer: SpaceWorkflow = {
+				...mockWorkflow,
+				id: 'wf-newer',
+				templateName: template.name,
+				templateHash: 'new',
+				createdAt: 200,
+			};
+			setupWithGroup([older1, older2, newer], agents);
+
+			(workflowManager.updateWorkflow as ReturnType<typeof mock>).mockReturnValue(newer);
+			(workflowManager.deleteWorkflow as ReturnType<typeof mock>).mockReturnValue(true);
+
+			await call('spaceWorkflow.resyncDuplicates', {
+				spaceId: 'space-1',
+				templateName: template.name,
+			});
+
+			expect(workflowRunRepo.deleteByWorkflowId).toHaveBeenCalledWith('wf-older-1');
+			expect(workflowRunRepo.deleteByWorkflowId).toHaveBeenCalledWith('wf-older-2');
+			expect(workflowRunRepo.deleteByWorkflowId).not.toHaveBeenCalledWith('wf-newer');
 		});
 	});
 });

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-workflow-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-workflow-handlers.test.ts
@@ -709,4 +709,381 @@ describe('space-workflow-handlers', () => {
 			).rejects.toThrow('Cannot sync: no SpaceAgent found with name');
 		});
 	});
+
+	// ─── spaceWorkflow.detectDuplicateDrift ───────────────────────────────────
+	//
+	// Surfaces groups of workflows in the same space that share a `templateName`
+	// and a known built-in name, but have diverging `templateHash` values.
+
+	describe('spaceWorkflow.detectDuplicateDrift', () => {
+		function setupWithWorkflows(workflows: SpaceWorkflow[]) {
+			setup(mockSpace, mockWorkflow);
+			(workflowManager.listWorkflows as ReturnType<typeof mock>).mockReturnValue(workflows);
+		}
+
+		it('throws when spaceId is missing', async () => {
+			setup();
+			await expect(call('spaceWorkflow.detectDuplicateDrift', {})).rejects.toThrow(
+				'spaceId is required'
+			);
+		});
+
+		it('throws when space not found', async () => {
+			setup(null, mockWorkflow);
+			await expect(
+				call('spaceWorkflow.detectDuplicateDrift', { spaceId: 'ghost' })
+			).rejects.toThrow('Space not found: ghost');
+		});
+
+		it('returns empty reports when the space has no workflows', async () => {
+			setupWithWorkflows([]);
+			const result = (await call('spaceWorkflow.detectDuplicateDrift', {
+				spaceId: 'space-1',
+			})) as { reports: DuplicateDriftReport[] };
+			expect(result.reports).toEqual([]);
+		});
+
+		it('returns empty reports when no duplicates share a templateName', async () => {
+			const [t1] = getBuiltInWorkflows();
+			setupWithWorkflows([
+				{
+					...mockWorkflow,
+					id: 'wf-a',
+					templateName: t1.name,
+					templateHash: 'hash-1',
+					createdAt: 100,
+				},
+			]);
+			const result = (await call('spaceWorkflow.detectDuplicateDrift', {
+				spaceId: 'space-1',
+			})) as { reports: DuplicateDriftReport[] };
+			expect(result.reports).toEqual([]);
+		});
+
+		it('excludes groups whose rows all share the same hash (duplicates without drift)', async () => {
+			const [t1] = getBuiltInWorkflows();
+			setupWithWorkflows([
+				{
+					...mockWorkflow,
+					id: 'wf-a',
+					templateName: t1.name,
+					templateHash: 'same-hash',
+					createdAt: 100,
+				},
+				{
+					...mockWorkflow,
+					id: 'wf-b',
+					templateName: t1.name,
+					templateHash: 'same-hash',
+					createdAt: 200,
+				},
+			]);
+			const result = (await call('spaceWorkflow.detectDuplicateDrift', {
+				spaceId: 'space-1',
+			})) as { reports: DuplicateDriftReport[] };
+			expect(result.reports).toEqual([]);
+		});
+
+		it('excludes groups keyed on a non-built-in templateName', async () => {
+			setupWithWorkflows([
+				{
+					...mockWorkflow,
+					id: 'wf-a',
+					templateName: 'Custom Template',
+					templateHash: 'h1',
+					createdAt: 100,
+				},
+				{
+					...mockWorkflow,
+					id: 'wf-b',
+					templateName: 'Custom Template',
+					templateHash: 'h2',
+					createdAt: 200,
+				},
+			]);
+			const result = (await call('spaceWorkflow.detectDuplicateDrift', {
+				spaceId: 'space-1',
+			})) as { reports: DuplicateDriftReport[] };
+			expect(result.reports).toEqual([]);
+		});
+
+		it('returns a drift report when rows share a built-in templateName with diverging hashes', async () => {
+			const [t1] = getBuiltInWorkflows();
+			setupWithWorkflows([
+				{
+					...mockWorkflow,
+					id: 'wf-older',
+					templateName: t1.name,
+					templateHash: 'old-hash',
+					createdAt: 100,
+				},
+				{
+					...mockWorkflow,
+					id: 'wf-newer',
+					templateName: t1.name,
+					templateHash: 'new-hash',
+					createdAt: 200,
+				},
+			]);
+			const result = (await call('spaceWorkflow.detectDuplicateDrift', {
+				spaceId: 'space-1',
+			})) as { reports: DuplicateDriftReport[] };
+			expect(result.reports).toHaveLength(1);
+			const report = result.reports[0];
+			expect(report.templateName).toBe(t1.name);
+			expect(report.rows).toHaveLength(2);
+			// Newest-first ordering
+			expect(report.rows[0].id).toBe('wf-newer');
+			expect(report.rows[1].id).toBe('wf-older');
+			expect(report.rows[0].templateHash).toBe('new-hash');
+		});
+
+		it('treats null-vs-non-null hashes as drift', async () => {
+			const [t1] = getBuiltInWorkflows();
+			setupWithWorkflows([
+				{
+					...mockWorkflow,
+					id: 'wf-a',
+					templateName: t1.name,
+					templateHash: undefined,
+					createdAt: 100,
+				},
+				{
+					...mockWorkflow,
+					id: 'wf-b',
+					templateName: t1.name,
+					templateHash: 'h1',
+					createdAt: 200,
+				},
+			]);
+			const result = (await call('spaceWorkflow.detectDuplicateDrift', {
+				spaceId: 'space-1',
+			})) as { reports: DuplicateDriftReport[] };
+			expect(result.reports).toHaveLength(1);
+			expect(result.reports[0].rows).toHaveLength(2);
+		});
+
+		it('returns multiple reports when multiple built-in templates drift', async () => {
+			const [t1, t2] = getBuiltInWorkflows();
+			setupWithWorkflows([
+				{
+					...mockWorkflow,
+					id: 'a1',
+					templateName: t1.name,
+					templateHash: 'a-old',
+					createdAt: 100,
+				},
+				{
+					...mockWorkflow,
+					id: 'a2',
+					templateName: t1.name,
+					templateHash: 'a-new',
+					createdAt: 200,
+				},
+				{
+					...mockWorkflow,
+					id: 'b1',
+					templateName: t2.name,
+					templateHash: 'b-old',
+					createdAt: 50,
+				},
+				{
+					...mockWorkflow,
+					id: 'b2',
+					templateName: t2.name,
+					templateHash: 'b-new',
+					createdAt: 300,
+				},
+			]);
+			const result = (await call('spaceWorkflow.detectDuplicateDrift', {
+				spaceId: 'space-1',
+			})) as { reports: DuplicateDriftReport[] };
+			expect(result.reports).toHaveLength(2);
+			const names = result.reports.map((r) => r.templateName).sort();
+			expect(names).toEqual([t1.name, t2.name].sort());
+		});
+	});
+
+	// ─── spaceWorkflow.resyncDuplicates ───────────────────────────────────────
+
+	describe('spaceWorkflow.resyncDuplicates', () => {
+		function agentsForTemplate(template: SpaceWorkflow): Array<{ id: string; name: string }> {
+			const names = new Set<string>();
+			for (const node of template.nodes) {
+				for (const a of node.agents) {
+					names.add(a.agentId);
+				}
+			}
+			return Array.from(names).map((name, i) => ({ id: `agent-uuid-${i}`, name }));
+		}
+
+		function setupWithGroup(
+			group: SpaceWorkflow[],
+			agents: Array<{ id: string; name: string }> = []
+		) {
+			setup(mockSpace, group[0] ?? null, agents);
+			(workflowManager.listWorkflows as ReturnType<typeof mock>).mockReturnValue(group);
+		}
+
+		it('throws when spaceId is missing', async () => {
+			setup();
+			await expect(
+				call('spaceWorkflow.resyncDuplicates', { templateName: 'Coding Workflow' })
+			).rejects.toThrow('spaceId is required');
+		});
+
+		it('throws when templateName is missing', async () => {
+			setup();
+			await expect(call('spaceWorkflow.resyncDuplicates', { spaceId: 'space-1' })).rejects.toThrow(
+				'templateName is required'
+			);
+		});
+
+		it('throws when space not found', async () => {
+			setup(null, mockWorkflow);
+			await expect(
+				call('spaceWorkflow.resyncDuplicates', {
+					spaceId: 'ghost',
+					templateName: 'Coding Workflow',
+				})
+			).rejects.toThrow('Space not found: ghost');
+		});
+
+		it('throws when templateName is not a built-in', async () => {
+			setup();
+			await expect(
+				call('spaceWorkflow.resyncDuplicates', {
+					spaceId: 'space-1',
+					templateName: 'My Custom Template',
+				})
+			).rejects.toThrow('Built-in template "My Custom Template" not found');
+		});
+
+		it('throws when no rows exist for the given templateName', async () => {
+			const [template] = getBuiltInWorkflows();
+			setupWithGroup([], agentsForTemplate(template));
+			await expect(
+				call('spaceWorkflow.resyncDuplicates', {
+					spaceId: 'space-1',
+					templateName: template.name,
+				})
+			).rejects.toThrow(`No workflows found for templateName "${template.name}"`);
+		});
+
+		it('keeps the newest row, deletes older rows, and overwrites kept row from the template', async () => {
+			const [template] = getBuiltInWorkflows();
+			const agents = agentsForTemplate(template);
+			const older: SpaceWorkflow = {
+				...mockWorkflow,
+				id: 'wf-older',
+				templateName: template.name,
+				templateHash: 'old',
+				createdAt: 100,
+			};
+			const newer: SpaceWorkflow = {
+				...mockWorkflow,
+				id: 'wf-newer',
+				templateName: template.name,
+				templateHash: 'new',
+				createdAt: 200,
+			};
+			setupWithGroup([older, newer], agents);
+
+			const templateHash = computeWorkflowHash(template);
+			const updatedWf: SpaceWorkflow = { ...newer, templateHash };
+			(workflowManager.updateWorkflow as ReturnType<typeof mock>).mockReturnValue(updatedWf);
+			(workflowManager.deleteWorkflow as ReturnType<typeof mock>).mockReturnValue(true);
+
+			const result = (await call('spaceWorkflow.resyncDuplicates', {
+				spaceId: 'space-1',
+				templateName: template.name,
+			})) as { workflow: SpaceWorkflow; keptWorkflowId: string; deletedIds: string[] };
+
+			// Kept the newest row.
+			expect(result.keptWorkflowId).toBe('wf-newer');
+			// Deleted the older row.
+			expect(result.deletedIds).toEqual(['wf-older']);
+			expect(workflowManager.deleteWorkflow).toHaveBeenCalledWith('wf-older');
+			expect(workflowManager.deleteWorkflow).not.toHaveBeenCalledWith('wf-newer');
+
+			// Overwrote kept row with template content.
+			expect(workflowManager.updateWorkflow).toHaveBeenCalledTimes(1);
+			const [calledId, calledParams] = (workflowManager.updateWorkflow as ReturnType<typeof mock>)
+				.mock.calls[0] as [string, Record<string, unknown>];
+			expect(calledId).toBe('wf-newer');
+			expect(calledParams.name).toBe(template.name);
+			expect(calledParams.templateName).toBe(template.name);
+			expect(calledParams.templateHash).toBe(templateHash);
+
+			// Emitted spaceWorkflow.deleted for the older row and spaceWorkflow.updated for the kept row.
+			expect(daemonHub.emit).toHaveBeenCalledWith('spaceWorkflow.deleted', {
+				sessionId: 'global',
+				spaceId: 'space-1',
+				workflowId: 'wf-older',
+			});
+			expect(daemonHub.emit).toHaveBeenCalledWith(
+				'spaceWorkflow.updated',
+				expect.objectContaining({
+					sessionId: 'global',
+					spaceId: 'space-1',
+				})
+			);
+		});
+
+		it('handles a group of one — no deletions, just overwrite the single row', async () => {
+			const [template] = getBuiltInWorkflows();
+			const agents = agentsForTemplate(template);
+			const only: SpaceWorkflow = {
+				...mockWorkflow,
+				id: 'wf-only',
+				templateName: template.name,
+				templateHash: 'whatever',
+				createdAt: 100,
+			};
+			setupWithGroup([only], agents);
+
+			const templateHash = computeWorkflowHash(template);
+			(workflowManager.updateWorkflow as ReturnType<typeof mock>).mockReturnValue({
+				...only,
+				templateHash,
+			});
+
+			const result = (await call('spaceWorkflow.resyncDuplicates', {
+				spaceId: 'space-1',
+				templateName: template.name,
+			})) as { keptWorkflowId: string; deletedIds: string[] };
+
+			expect(result.keptWorkflowId).toBe('wf-only');
+			expect(result.deletedIds).toEqual([]);
+			expect(workflowManager.deleteWorkflow).not.toHaveBeenCalled();
+			expect(workflowManager.updateWorkflow).toHaveBeenCalledTimes(1);
+		});
+
+		it('throws when no SpaceAgent resolves a required role (rolls back nothing — same contract as syncFromTemplate)', async () => {
+			const [template] = getBuiltInWorkflows();
+			const older: SpaceWorkflow = {
+				...mockWorkflow,
+				id: 'wf-older',
+				templateName: template.name,
+				templateHash: 'old',
+				createdAt: 100,
+			};
+			const newer: SpaceWorkflow = {
+				...mockWorkflow,
+				id: 'wf-newer',
+				templateName: template.name,
+				templateHash: 'new',
+				createdAt: 200,
+			};
+			// Empty agents list — required roles won't resolve
+			setupWithGroup([older, newer], []);
+
+			await expect(
+				call('spaceWorkflow.resyncDuplicates', {
+					spaceId: 'space-1',
+					templateName: template.name,
+				})
+			).rejects.toThrow('Cannot resync: no SpaceAgent found with name');
+		});
+	});
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-97_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-97_test.ts
@@ -1,0 +1,281 @@
+/**
+ * Migration 97 Tests — Delete orphan built-in workflow rows.
+ *
+ * Migration 97 removes pre-template-tracking rows that share a name with a
+ * known built-in template but have `template_name IS NULL`. The
+ * `space_workflow_runs.workflow_id` FK no longer cascades (migration 60
+ * rebuilt the table without it), so the migration deletes dependent runs
+ * explicitly before removing the workflow row.
+ *
+ * Covers:
+ *   - Orphan row for each known built-in name is deleted
+ *   - Rows with `template_name` set (even if they share the built-in name) are preserved
+ *   - Idempotency: running the migration twice leaves the DB unchanged
+ *   - Custom workflows with `template_name IS NULL` and a non-built-in name are
+ *     preserved (the migration only targets known built-in names)
+ *   - Sibling rows (nodes, runs) are removed when an orphan is deleted
+ *   - No-op on a DB with no matching rows
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../../src/storage/schema/index.ts';
+import { runMigration97 } from '../../../../../src/storage/schema/migrations.ts';
+
+interface WorkflowRow {
+	id: string;
+	name: string;
+	template_name: string | null;
+}
+
+const BUILT_IN_NAMES = [
+	'Coding Workflow',
+	'Coding with QA Workflow',
+	'Full-Cycle Coding Workflow',
+	'Fullstack QA Loop Workflow',
+	'Plan & Decompose Workflow',
+	'Research Workflow',
+	'Review-Only Workflow',
+];
+
+function insertSpace(db: BunDatabase, id: string): void {
+	const now = Date.now();
+	db.prepare(
+		`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`
+	).run(id, id, '/ws', id, now, now);
+}
+
+function insertWorkflow(
+	db: BunDatabase,
+	opts: {
+		id: string;
+		spaceId: string;
+		name: string;
+		templateName?: string | null;
+		templateHash?: string | null;
+		createdAt?: number;
+	}
+): void {
+	const now = opts.createdAt ?? Date.now();
+	db.prepare(
+		`INSERT INTO space_workflows (
+			id, space_id, name, description, start_node_id, end_node_id,
+			tags, channels, gates, created_at, updated_at, template_name, template_hash
+		 ) VALUES (?, ?, ?, '', NULL, NULL, '[]', '[]', '[]', ?, ?, ?, ?)`
+	).run(
+		opts.id,
+		opts.spaceId,
+		opts.name,
+		now,
+		now,
+		opts.templateName ?? null,
+		opts.templateHash ?? null
+	);
+}
+
+function insertNode(db: BunDatabase, opts: { id: string; workflowId: string; name: string }): void {
+	const now = Date.now();
+	db.prepare(
+		`INSERT INTO space_workflow_nodes (id, workflow_id, name, config, created_at, updated_at)
+		 VALUES (?, ?, ?, '{}', ?, ?)`
+	).run(opts.id, opts.workflowId, opts.name, now, now);
+}
+
+function insertRun(
+	db: BunDatabase,
+	opts: { id: string; spaceId: string; workflowId: string; status: string }
+): void {
+	const now = Date.now();
+	db.prepare(
+		`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at, updated_at)
+		 VALUES (?, ?, ?, 'run', ?, ?, ?)`
+	).run(opts.id, opts.spaceId, opts.workflowId, opts.status, now, now);
+}
+
+function listWorkflows(db: BunDatabase): WorkflowRow[] {
+	return db
+		.prepare(`SELECT id, name, template_name FROM space_workflows ORDER BY name, id`)
+		.all() as WorkflowRow[];
+}
+
+describe('Migration 97: delete orphan built-in workflow rows', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(
+			process.cwd(),
+			'tmp',
+			'test-migration-97',
+			`test-${Date.now()}-${Math.random()}`
+		);
+		mkdirSync(testDir, { recursive: true });
+		db = new BunDatabase(join(testDir, 'test.db'));
+		db.exec('PRAGMA foreign_keys = ON');
+		runMigrations(db, () => {});
+		insertSpace(db, 'sp-1');
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	test('deletes orphan row for each built-in name', () => {
+		// Insert one orphan (template_name IS NULL) for every built-in name,
+		// plus one backfilled sibling sharing the same name to verify the
+		// sibling is preserved.
+		for (const [i, name] of BUILT_IN_NAMES.entries()) {
+			insertWorkflow(db, {
+				id: `wf-orphan-${i}`,
+				spaceId: 'sp-1',
+				name,
+				templateName: null,
+				templateHash: null,
+				createdAt: 1000,
+			});
+			insertWorkflow(db, {
+				id: `wf-keep-${i}`,
+				spaceId: 'sp-1',
+				name,
+				templateName: name,
+				templateHash: 'hash-abc',
+				createdAt: 2000,
+			});
+		}
+
+		runMigration97(db);
+
+		const rows = listWorkflows(db);
+		// Orphans gone, siblings remain.
+		expect(rows.some((r) => r.id.startsWith('wf-orphan-'))).toBe(false);
+		expect(rows.filter((r) => r.id.startsWith('wf-keep-'))).toHaveLength(BUILT_IN_NAMES.length);
+		// Sanity — every remaining built-in row has its template_name set.
+		for (const r of rows) {
+			if (BUILT_IN_NAMES.includes(r.name)) {
+				expect(r.template_name).not.toBeNull();
+			}
+		}
+	});
+
+	test('is idempotent — second run is a no-op', () => {
+		insertWorkflow(db, {
+			id: 'wf-keep-1',
+			spaceId: 'sp-1',
+			name: 'Coding Workflow',
+			templateName: 'Coding Workflow',
+			templateHash: 'h',
+		});
+		insertWorkflow(db, {
+			id: 'wf-orphan-1',
+			spaceId: 'sp-1',
+			name: 'Coding Workflow',
+			templateName: null,
+		});
+
+		runMigration97(db);
+		const after1 = listWorkflows(db);
+
+		runMigration97(db);
+		const after2 = listWorkflows(db);
+
+		expect(after2).toEqual(after1);
+		expect(after1.some((r) => r.id === 'wf-orphan-1')).toBe(false);
+		expect(after1.some((r) => r.id === 'wf-keep-1')).toBe(true);
+	});
+
+	test('preserves custom (non-built-in) workflows with template_name IS NULL', () => {
+		insertWorkflow(db, {
+			id: 'wf-custom',
+			spaceId: 'sp-1',
+			name: 'My Custom Workflow',
+			templateName: null,
+		});
+
+		runMigration97(db);
+
+		const rows = listWorkflows(db);
+		expect(rows.find((r) => r.id === 'wf-custom')).toBeDefined();
+	});
+
+	test('preserves rows that share a built-in name but already have template_name set', () => {
+		// Two rows with the Coding Workflow name; both backfilled. Neither should
+		// be touched.
+		insertWorkflow(db, {
+			id: 'wf-a',
+			spaceId: 'sp-1',
+			name: 'Coding Workflow',
+			templateName: 'Coding Workflow',
+			templateHash: 'aaa',
+			createdAt: 1000,
+		});
+		insertWorkflow(db, {
+			id: 'wf-b',
+			spaceId: 'sp-1',
+			name: 'Coding Workflow',
+			templateName: 'Coding Workflow',
+			templateHash: 'bbb',
+			createdAt: 2000,
+		});
+
+		runMigration97(db);
+
+		const rows = listWorkflows(db);
+		expect(rows.find((r) => r.id === 'wf-a')).toBeDefined();
+		expect(rows.find((r) => r.id === 'wf-b')).toBeDefined();
+	});
+
+	test('cascade-deletes nodes and runs when an orphan is removed', () => {
+		insertWorkflow(db, {
+			id: 'wf-orphan',
+			spaceId: 'sp-1',
+			name: 'Research Workflow',
+			templateName: null,
+		});
+		insertNode(db, { id: 'n-1', workflowId: 'wf-orphan', name: 'Research' });
+		insertRun(db, {
+			id: 'run-1',
+			spaceId: 'sp-1',
+			workflowId: 'wf-orphan',
+			status: 'in_progress',
+		});
+
+		runMigration97(db);
+
+		const nodes = db
+			.prepare(`SELECT id FROM space_workflow_nodes WHERE workflow_id = ?`)
+			.all('wf-orphan');
+		const runs = db
+			.prepare(`SELECT id FROM space_workflow_runs WHERE workflow_id = ?`)
+			.all('wf-orphan');
+		expect(nodes).toHaveLength(0);
+		expect(runs).toHaveLength(0);
+	});
+
+	test('no-op when the DB has no orphan built-in rows', () => {
+		insertWorkflow(db, {
+			id: 'wf-ok',
+			spaceId: 'sp-1',
+			name: 'Coding Workflow',
+			templateName: 'Coding Workflow',
+			templateHash: 'h',
+		});
+
+		const before = listWorkflows(db);
+		runMigration97(db);
+		const after = listWorkflows(db);
+
+		expect(after).toEqual(before);
+	});
+});

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -1163,6 +1163,35 @@ export interface UpdateSpaceWorkflowParams {
 	templateHash?: string | null;
 }
 
+/**
+ * A single workflow row that participates in a duplicate-drift group.
+ * Part of {@link DuplicateDriftReport}.
+ */
+export interface DuplicateDriftRow {
+	/** Workflow UUID. */
+	id: string;
+	/** Canonical content hash at last sync. May be null for legacy rows. */
+	templateHash: string | null;
+	/** Creation timestamp (ms since epoch). Newest-first ordering is used for resync. */
+	createdAt: number;
+}
+
+/**
+ * One drift group surfaced by `spaceWorkflow.detectDuplicateDrift`.
+ *
+ * A drift group is formed by multiple workflow rows in the same space that
+ * share a `templateName` but carry differing `templateHash` values. These
+ * rows represent template drift — either duplicate seed passes left stale
+ * versions behind, or the source built-in template changed after some rows
+ * were seeded but before others were re-synced.
+ */
+export interface DuplicateDriftReport {
+	/** Shared `templateName` for the group. Always non-empty. */
+	templateName: string;
+	/** Workflow rows in the group, newest-first. Always >= 2 entries. */
+	rows: DuplicateDriftRow[];
+}
+
 // ============================================================================
 // Export / Import Format Types (M8)
 // ============================================================================

--- a/packages/web/src/components/space/WorkflowList.tsx
+++ b/packages/web/src/components/space/WorkflowList.tsx
@@ -11,7 +11,7 @@
  */
 
 import { useState, useEffect } from 'preact/hooks';
-import type { SpaceWorkflow, SpaceExportBundle } from '@neokai/shared';
+import type { SpaceWorkflow, SpaceExportBundle, DuplicateDriftReport } from '@neokai/shared';
 import { spaceStore } from '../../lib/space-store';
 
 type WorkflowConditionType = 'always' | 'human' | 'condition' | 'task_result';
@@ -104,14 +104,39 @@ function MiniStepViz({ workflow }: { workflow: SpaceWorkflow }) {
 // Workflow Card
 // ============================================================================
 
+/**
+ * Duplicate-drift info for a single workflow card.
+ *
+ * Computed at the list level (one RPC call per space) and passed down so each
+ * card can render a "Duplicate" badge + a "Resync duplicates" action on the
+ * newest row in a drift group.
+ */
+interface DuplicateDriftInfo {
+	/** Shared `templateName` that formed the drift group. */
+	templateName: string;
+	/** Total rows in the drift group (always >= 2). */
+	groupSize: number;
+	/** True if this workflow is the newest row in the group (becomes the kept row on resync). */
+	isNewest: boolean;
+}
+
 interface WorkflowCardProps {
 	workflow: SpaceWorkflow;
 	spaceId: string;
 	spaceName: string;
 	onEdit: () => void;
+	duplicateDrift?: DuplicateDriftInfo;
+	onResyncDuplicates?: (templateName: string) => Promise<void>;
 }
 
-function WorkflowCard({ workflow, spaceId, spaceName, onEdit }: WorkflowCardProps) {
+function WorkflowCard({
+	workflow,
+	spaceId,
+	spaceName,
+	onEdit,
+	duplicateDrift,
+	onResyncDuplicates,
+}: WorkflowCardProps) {
 	const [confirmDelete, setConfirmDelete] = useState(false);
 	const [deleting, setDeleting] = useState(false);
 	const [deleteError, setDeleteError] = useState<string | null>(null);
@@ -121,6 +146,11 @@ function WorkflowCard({ workflow, spaceId, spaceName, onEdit }: WorkflowCardProp
 	const [syncing, setSyncing] = useState(false);
 	const [syncError, setSyncError] = useState<string | null>(null);
 	const [confirmSync, setConfirmSync] = useState(false);
+
+	// Duplicate-drift resync state
+	const [confirmDupResync, setConfirmDupResync] = useState(false);
+	const [dupResyncing, setDupResyncing] = useState(false);
+	const [dupResyncError, setDupResyncError] = useState<string | null>(null);
 
 	// Check for template drift whenever workflow changes (if it came from a template)
 	useEffect(() => {
@@ -197,6 +227,20 @@ function WorkflowCard({ workflow, spaceId, spaceName, onEdit }: WorkflowCardProp
 		}
 	}
 
+	async function handleResyncDuplicates() {
+		if (!duplicateDrift || !onResyncDuplicates) return;
+		setDupResyncing(true);
+		setDupResyncError(null);
+		try {
+			await onResyncDuplicates(duplicateDrift.templateName);
+			setConfirmDupResync(false);
+		} catch (err) {
+			setDupResyncError(err instanceof Error ? err.message : 'Resync failed');
+		} finally {
+			setDupResyncing(false);
+		}
+	}
+
 	return (
 		<div class="bg-dark-850 border border-dark-700 rounded-lg p-4 hover:border-dark-600 transition-colors group">
 			{deleteError && (
@@ -238,6 +282,22 @@ function WorkflowCard({ workflow, spaceId, spaceName, onEdit }: WorkflowCardProp
 									Outdated
 								</span>
 							)}
+							{duplicateDrift && (
+								<span
+									class="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs bg-orange-900/30 border border-orange-700/50 rounded text-orange-400"
+									title={`${duplicateDrift.groupSize} rows share the "${duplicateDrift.templateName}" template with diverging content. Resync keeps the newest row and removes the rest.`}
+								>
+									<svg class="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width={2}
+											d="M8 7v8a2 2 0 002 2h6M8 7V5a2 2 0 012-2h4.586a1 1 0 01.707.293l4.414 4.414a1 1 0 01.293.707V15a2 2 0 01-2 2h-2M8 7H6a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2v-2"
+										/>
+									</svg>
+									Duplicate ×{duplicateDrift.groupSize}
+								</span>
+							)}
 						</div>
 					)}
 				</div>
@@ -273,6 +333,15 @@ function WorkflowCard({ workflow, spaceId, spaceName, onEdit }: WorkflowCardProp
 									title="Sync from template (overwrites local changes)"
 								>
 									Sync
+								</button>
+							)}
+							{duplicateDrift?.isNewest && (
+								<button
+									onClick={() => setConfirmDupResync(true)}
+									class="px-2.5 py-1 text-xs text-orange-400 hover:text-orange-200 bg-dark-800 hover:bg-dark-700 rounded border border-orange-700/50 hover:border-orange-600/70 transition-colors"
+									title={`Remove ${duplicateDrift.groupSize - 1} older duplicate${duplicateDrift.groupSize - 1 === 1 ? '' : 's'} and resync this workflow from the built-in template`}
+								>
+									Resync duplicates
 								</button>
 							)}
 							<button
@@ -338,6 +407,58 @@ function WorkflowCard({ workflow, spaceId, spaceName, onEdit }: WorkflowCardProp
 					</>
 				)}
 			</div>
+
+			{/* Resync duplicates confirmation modal */}
+			{confirmDupResync && duplicateDrift && (
+				<div class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60">
+					<div class="bg-dark-850 border border-dark-700 rounded-lg p-5 max-w-md w-full shadow-xl">
+						<h3 class="text-sm font-semibold text-gray-100 mb-2">Resync duplicate workflows?</h3>
+						<p class="text-xs text-gray-400 mb-1">
+							This space has{' '}
+							<span class="font-medium text-gray-200">{duplicateDrift.groupSize} rows</span> sharing
+							the <span class="font-medium text-gray-200">"{duplicateDrift.templateName}"</span>{' '}
+							template with diverging content.
+						</p>
+						<p class="text-xs text-gray-400 mb-1">
+							The newest row <span class="font-medium text-gray-200">"{workflow.name}"</span> will
+							be kept and resynced from the built-in template. The remaining{' '}
+							<span class="font-medium text-gray-200">
+								{duplicateDrift.groupSize - 1} older{' '}
+								{duplicateDrift.groupSize - 1 === 1 ? 'row' : 'rows'}
+							</span>{' '}
+							will be deleted.
+						</p>
+						<p class="text-xs text-red-400 mb-4">
+							Local edits to the older rows and any workflow runs attached to them will be
+							permanently lost.
+						</p>
+						{dupResyncError && (
+							<div class="mb-3 px-3 py-1.5 bg-red-900/20 border border-red-800/40 rounded text-xs text-red-300">
+								{dupResyncError}
+							</div>
+						)}
+						<div class="flex items-center gap-2 justify-end">
+							<button
+								onClick={() => {
+									setConfirmDupResync(false);
+									setDupResyncError(null);
+								}}
+								disabled={dupResyncing}
+								class="px-3 py-1.5 text-xs text-gray-400 hover:text-gray-200 transition-colors disabled:opacity-50"
+							>
+								Cancel
+							</button>
+							<button
+								onClick={handleResyncDuplicates}
+								disabled={dupResyncing}
+								class="px-3 py-1.5 text-xs font-medium text-white bg-orange-700 hover:bg-orange-600 rounded transition-colors disabled:opacity-50"
+							>
+								{dupResyncing ? 'Resyncing…' : 'Delete older rows & resync'}
+							</button>
+						</div>
+					</div>
+				</div>
+			)}
 
 			{/* Sync from template confirmation modal */}
 			{confirmSync && (
@@ -407,6 +528,68 @@ export function WorkflowList({
 	const [importBundle, setImportBundle] = useState<SpaceExportBundle | null>(null);
 	const [importPreview, setImportPreview] = useState<ImportPreviewResult | null>(null);
 	const [isExecuting, setIsExecuting] = useState(false);
+
+	// Map of workflow id → duplicate-drift info (only present for workflows in a drift group).
+	const [duplicateDriftMap, setDuplicateDriftMap] = useState<Map<string, DuplicateDriftInfo>>(
+		new Map()
+	);
+
+	// Fetch duplicate-drift reports whenever the set of workflows changes. We
+	// watch the list of (id, updatedAt) tuples so the effect re-runs when a
+	// workflow is added, removed, or edited.
+	const driftKey = workflows
+		.map((w) => `${w.id}:${w.updatedAt}`)
+		.sort()
+		.join('|');
+	useEffect(() => {
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) return;
+
+		let cancelled = false;
+		hub
+			.request<{ reports: DuplicateDriftReport[] }>('spaceWorkflow.detectDuplicateDrift', {
+				spaceId,
+			})
+			.then((result) => {
+				if (cancelled) return;
+				const map = new Map<string, DuplicateDriftInfo>();
+				for (const report of result.reports) {
+					// Rows are newest-first; the first entry becomes the kept row on resync.
+					for (const [i, row] of report.rows.entries()) {
+						map.set(row.id, {
+							templateName: report.templateName,
+							groupSize: report.rows.length,
+							isNewest: i === 0,
+						});
+					}
+				}
+				setDuplicateDriftMap(map);
+			})
+			.catch(() => {
+				// Non-fatal — drift reporting is best-effort.
+			});
+
+		return () => {
+			cancelled = true;
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- driftKey captures the list identity
+	}, [spaceId, driftKey]);
+
+	async function handleResyncDuplicates(templateName: string) {
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) {
+			toast.error('Connection lost.');
+			throw new Error('Not connected');
+		}
+		const result = await hub.request<{ deletedIds: string[] }>('spaceWorkflow.resyncDuplicates', {
+			spaceId,
+			templateName,
+		});
+		const removed = result.deletedIds.length;
+		toast.success(
+			`Resynced "${templateName}"${removed > 0 ? ` — removed ${removed} older ${removed === 1 ? 'duplicate' : 'duplicates'}` : ''}`
+		);
+	}
 
 	// ─── Import/Export helpers ──────────────────────────────────────────────
 
@@ -588,6 +771,8 @@ export function WorkflowList({
 									spaceId={spaceId}
 									spaceName={spaceName}
 									onEdit={() => onEditWorkflow(wf.id)}
+									duplicateDrift={duplicateDriftMap.get(wf.id)}
+									onResyncDuplicates={handleResyncDuplicates}
 								/>
 							))}
 						</div>

--- a/packages/web/src/components/space/__tests__/WorkflowList.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowList.test.tsx
@@ -17,7 +17,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup, waitFor } from '@testing-library/preact';
 import { signal, type Signal } from '@preact/signals';
-import type { SpaceWorkflow } from '@neokai/shared';
+import type { SpaceWorkflow, DuplicateDriftReport } from '@neokai/shared';
 
 // ---- Mocks ----
 // Signals are initialized immediately so vi.mock's lazy getter can reference them safely.
@@ -35,8 +35,12 @@ vi.mock('../../../lib/space-store', () => ({
 	},
 }));
 
+const mockHubRequest = vi.fn();
+
 vi.mock('../../../lib/connection-manager.ts', () => ({
-	connectionManager: { getHubIfConnected: vi.fn() },
+	connectionManager: {
+		getHubIfConnected: () => ({ request: mockHubRequest }),
+	},
 }));
 vi.mock('../../../lib/toast.ts', () => ({
 	toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
@@ -85,6 +89,13 @@ describe('WorkflowList', () => {
 		defaultProps.workflows = [];
 		defaultProps.onCreateWorkflow.mockClear();
 		defaultProps.onEditWorkflow.mockClear();
+		// Default: no duplicates, no per-workflow drift.
+		mockHubRequest.mockReset();
+		mockHubRequest.mockImplementation(async (method: string) => {
+			if (method === 'spaceWorkflow.detectDuplicateDrift') return { reports: [] };
+			if (method === 'spaceWorkflow.detectDrift') return { drifted: false };
+			return undefined;
+		});
 	});
 
 	afterEach(() => {
@@ -255,6 +266,163 @@ describe('WorkflowList', () => {
 			await waitFor(() => {
 				expect(getByText('Delete failed')).toBeTruthy();
 			});
+		});
+	});
+
+	describe('duplicate-drift badge + resync', () => {
+		function driftReport(
+			templateName: string,
+			rows: Array<{ id: string; templateHash: string | null; createdAt: number }>
+		): DuplicateDriftReport {
+			return { templateName, rows };
+		}
+
+		it('renders a Duplicate badge on each workflow in a drift group', async () => {
+			mockHubRequest.mockImplementation(async (method: string) => {
+				if (method === 'spaceWorkflow.detectDuplicateDrift') {
+					return {
+						reports: [
+							driftReport('Coding Workflow', [
+								{ id: 'wf-newer', templateHash: 'new', createdAt: 200 },
+								{ id: 'wf-older', templateHash: 'old', createdAt: 100 },
+							]),
+						],
+					};
+				}
+				if (method === 'spaceWorkflow.detectDrift') return { drifted: false };
+				return undefined;
+			});
+
+			const props = {
+				...defaultProps,
+				workflows: [
+					makeWorkflow({ id: 'wf-newer', name: 'Newer', templateName: 'Coding Workflow' }),
+					makeWorkflow({ id: 'wf-older', name: 'Older', templateName: 'Coding Workflow' }),
+				],
+			};
+			const { findAllByText } = render(<WorkflowList {...props} />);
+			const badges = await findAllByText(/Duplicate ×2/);
+			expect(badges.length).toBe(2);
+		});
+
+		it('shows "Resync duplicates" button only on the newest row', async () => {
+			mockHubRequest.mockImplementation(async (method: string) => {
+				if (method === 'spaceWorkflow.detectDuplicateDrift') {
+					return {
+						reports: [
+							driftReport('Coding Workflow', [
+								{ id: 'wf-newer', templateHash: 'new', createdAt: 200 },
+								{ id: 'wf-older', templateHash: 'old', createdAt: 100 },
+							]),
+						],
+					};
+				}
+				if (method === 'spaceWorkflow.detectDrift') return { drifted: false };
+				return undefined;
+			});
+
+			const props = {
+				...defaultProps,
+				workflows: [
+					makeWorkflow({ id: 'wf-newer', name: 'Newer', templateName: 'Coding Workflow' }),
+					makeWorkflow({ id: 'wf-older', name: 'Older', templateName: 'Coding Workflow' }),
+				],
+			};
+			const { findAllByText } = render(<WorkflowList {...props} />);
+			const buttons = await findAllByText('Resync duplicates');
+			expect(buttons.length).toBe(1);
+		});
+
+		it('opens the resync confirmation dialog when button clicked', async () => {
+			mockHubRequest.mockImplementation(async (method: string) => {
+				if (method === 'spaceWorkflow.detectDuplicateDrift') {
+					return {
+						reports: [
+							driftReport('Coding Workflow', [
+								{ id: 'wf-newer', templateHash: 'new', createdAt: 200 },
+								{ id: 'wf-older', templateHash: 'old', createdAt: 100 },
+							]),
+						],
+					};
+				}
+				if (method === 'spaceWorkflow.detectDrift') return { drifted: false };
+				return undefined;
+			});
+
+			const props = {
+				...defaultProps,
+				workflows: [
+					makeWorkflow({ id: 'wf-newer', name: 'Newer', templateName: 'Coding Workflow' }),
+					makeWorkflow({ id: 'wf-older', name: 'Older', templateName: 'Coding Workflow' }),
+				],
+			};
+			const { findByText, getByText } = render(<WorkflowList {...props} />);
+			const btn = await findByText('Resync duplicates');
+			fireEvent.click(btn);
+			expect(getByText('Resync duplicate workflows?')).toBeTruthy();
+			expect(getByText('Delete older rows & resync')).toBeTruthy();
+		});
+
+		it('calls resyncDuplicates RPC when confirmed', async () => {
+			mockHubRequest.mockImplementation(async (method: string, params: unknown) => {
+				if (method === 'spaceWorkflow.detectDuplicateDrift') {
+					return {
+						reports: [
+							driftReport('Coding Workflow', [
+								{ id: 'wf-newer', templateHash: 'new', createdAt: 200 },
+								{ id: 'wf-older', templateHash: 'old', createdAt: 100 },
+							]),
+						],
+					};
+				}
+				if (method === 'spaceWorkflow.detectDrift') return { drifted: false };
+				if (method === 'spaceWorkflow.resyncDuplicates') {
+					expect(params).toMatchObject({
+						spaceId: 'space-1',
+						templateName: 'Coding Workflow',
+					});
+					return { deletedIds: ['wf-older'] };
+				}
+				return undefined;
+			});
+
+			const props = {
+				...defaultProps,
+				workflows: [
+					makeWorkflow({ id: 'wf-newer', name: 'Newer', templateName: 'Coding Workflow' }),
+					makeWorkflow({ id: 'wf-older', name: 'Older', templateName: 'Coding Workflow' }),
+				],
+			};
+			const { findByText, getByText } = render(<WorkflowList {...props} />);
+			const btn = await findByText('Resync duplicates');
+			fireEvent.click(btn);
+			fireEvent.click(getByText('Delete older rows & resync'));
+			await waitFor(() => {
+				expect(mockHubRequest).toHaveBeenCalledWith(
+					'spaceWorkflow.resyncDuplicates',
+					expect.objectContaining({
+						spaceId: 'space-1',
+						templateName: 'Coding Workflow',
+					})
+				);
+			});
+		});
+
+		it('renders no Duplicate badge when the RPC returns no reports', async () => {
+			// Default mockHubRequest returns { reports: [] }
+			const props = {
+				...defaultProps,
+				workflows: [makeWorkflow({ id: 'wf-a', name: 'Only', templateName: 'Coding Workflow' })],
+			};
+			const { queryByText } = render(<WorkflowList {...props} />);
+			await waitFor(() => {
+				expect(mockHubRequest).toHaveBeenCalledWith(
+					'spaceWorkflow.detectDuplicateDrift',
+					expect.objectContaining({ spaceId: 'space-1' })
+				);
+			});
+			expect(queryByText(/Duplicate ×/)).toBeNull();
+			expect(queryByText('Resync duplicates')).toBeNull();
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Stage-2 Task F. Cleans up duplicate built-in workflow rows left over from pre–template-tracking seeding, and makes remaining duplicates visible + fixable from the Space UI.

- **Migration 95** — Deletes `space_workflows` rows whose `name` matches a known built-in template but whose `template_name IS NULL`. Idempotent. Explicitly removes any runs pointing at those workflows (M60 dropped the FK cascade).
- **`spaceWorkflow.detectDuplicateDrift(spaceId)`** — Groups rows by `templateName`, keeps only groups with ≥2 rows AND ≥2 distinct hashes, returns them newest-first. Only built-in templates are eligible.
- **`spaceWorkflow.resyncDuplicates(spaceId, templateName)`** — Keeps the newest row, deletes older ones, overwrites the kept row from the current built-in template (same logic as `syncFromTemplate`). Emits `spaceWorkflow.deleted` per removed row and `spaceWorkflow.updated` for the kept row.
- **Frontend** — `WorkflowList` now fetches drift reports once per space and renders an orange "Duplicate ×N" badge on each affected card, plus a "Resync duplicates" button (with a confirmation dialog that spells out what gets deleted) on the newest row in each group.

## Test plan
- [x] `migration-95_test.ts` — orphans deleted per built-in name, idempotent, custom workflows preserved, cascade-deletes runs (6 tests)
- [x] `space-workflow-handlers.test.ts` — `detectDuplicateDrift` (8 cases) + `resyncDuplicates` (7 cases) incl. agent-resolution failure (65 tests total in file)
- [x] `WorkflowList.test.tsx` — badge rendering, newest-only button, dialog open/call RPC, no-drift path (24 tests total in file)
- [x] `./scripts/test-daemon.sh` — 11 110 / 11 110 tests pass
- [x] `bun run check` — lint + typecheck + knip clean