### PR TITLE
fix(space): node-agent injection invariant + agent-callable restore (Task #37)

### DIFF
--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -244,9 +244,8 @@ export class QueryRunner {
 			// for workflow sub-sessions) is missing from session config at first turn.
 			// Always logged at info level so production logs preserve the evidence trail.
 			const mcpServerNames = Object.keys(queryOptions.mcpServers ?? {}).sort();
-			const sessionContext = session.context as Record<string, unknown> | undefined;
 			const isWorkflowSubSession = !!(
-				sessionContext?.spaceId &&
+				session.context?.spaceId &&
 				session.id.includes(':task:') &&
 				session.id.includes(':exec:')
 			);

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -239,6 +239,31 @@ export class QueryRunner {
 			let queryOptions = await optionsBuilder.build();
 			queryOptions = optionsBuilder.addSessionStateOptions(queryOptions);
 
+			// Structured log of MCP servers visible to this query. Critical for diagnosing
+			// "No such tool available" issues where an expected MCP server (e.g. node-agent
+			// for workflow sub-sessions) is missing from session config at first turn.
+			// Always logged at info level so production logs preserve the evidence trail.
+			const mcpServerNames = Object.keys(queryOptions.mcpServers ?? {}).sort();
+			const sessionContext = session.context as Record<string, unknown> | undefined;
+			const isWorkflowSubSession = !!(
+				sessionContext?.spaceId &&
+				session.id.includes(':task:') &&
+				session.id.includes(':exec:')
+			);
+			logger.info(
+				`QueryRunner.start(): session ${session.id} mcp servers visible at first turn: ` +
+					`[${mcpServerNames.join(', ')}]` +
+					(isWorkflowSubSession ? ' (workflow sub-session)' : '')
+			);
+			if (isWorkflowSubSession && !mcpServerNames.includes('node-agent')) {
+				logger.error(
+					`QueryRunner.start(): workflow sub-session ${session.id} is MISSING the 'node-agent' MCP server. ` +
+						`Visible servers: [${mcpServerNames.join(', ')}]. ` +
+						`The agent will not be able to call mcp__node-agent__* tools (send_message, save, list_peers, etc). ` +
+						`This is a runtime injection failure — see TaskAgentManager.spawnWorkflowNodeAgentForExecution and createSubSession.`
+				);
+			}
+
 			// Apply provider env vars
 			{
 				const { getProviderService } = await import('../provider-service');

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -806,6 +806,25 @@ export class TaskAgentManager {
 				throw new Error(`Spawned node session ${actualSessionId} is not registered in memory`);
 			}
 
+			// Defensive guarantee: verify the node-agent MCP server is present in the
+			// sub-session's effective config. If a registry collision, race, or refactor
+			// regression ever drops it, self-heal by re-attaching before the first turn
+			// kicks off — and emit a loud warning so the regression surfaces in logs.
+			//
+			// This is a belt-and-braces check to prevent silent recurrence of the
+			// "No such tool available" failure mode where the Coder→Reviewer handoff
+			// died because mcp__node-agent__send_message was unregistered.
+			this.ensureNodeAgentAttached(spawned, {
+				taskId,
+				subSessionId: actualSessionId,
+				agentName: execution.agentName,
+				spaceId: space.id,
+				workflowRunId: workflowRun.id,
+				workspacePath,
+				workflowNodeId: execution.workflowNodeId,
+				phase: 'spawn',
+			});
+
 			this.registerCompletionCallback(actualSessionId, async () => {
 				await this.handleSubSessionComplete(taskId, execution.workflowNodeId, actualSessionId);
 			});
@@ -1713,6 +1732,7 @@ export class TaskAgentManager {
 			isEndNode
 				? '  - report_result({ status, summary }) — YOU ARE THE END NODE: call this when the workflow is complete to close the run'
 				: null,
+			'  - restore_node_agent({ reason? }) — self-heal fallback: if a previous mcp__node-agent__* call returned "No such tool available", call this once and then retry the original tool',
 			'Only contact the task-agent via send_message if you are blocked or need human input.',
 		]
 			.filter(Boolean)
@@ -1754,7 +1774,8 @@ export class TaskAgentManager {
 		}
 
 		lines.push(
-			'  - list_peers / list_reachable_agents / list_channels / list_gates / read_gate — discovery'
+			'  - list_peers / list_reachable_agents / list_channels / list_gates / read_gate — discovery',
+			'  - restore_node_agent({ reason? }) — self-heal fallback: if a previous mcp__node-agent__* call ever returned "No such tool available", call this once and then retry the original tool'
 		);
 
 		if (outboundGatedChannels.length === 0) {
@@ -2206,6 +2227,18 @@ export class TaskAgentManager {
 		};
 		agentSession.setRuntimeMcpServers(mergedMcpServers);
 
+		// Defensive guarantee — see ensureNodeAgentAttached docs.
+		this.ensureNodeAgentAttached(agentSession, {
+			taskId,
+			subSessionId,
+			agentName: execution.agentName,
+			spaceId,
+			workflowRunId,
+			workspacePath,
+			workflowNodeId: execution.workflowNodeId,
+			phase: 'rehydrate',
+		});
+
 		// --- Register in in-memory maps
 		if (!this.subSessions.has(taskId)) {
 			this.subSessions.set(taskId, new Map());
@@ -2357,6 +2390,116 @@ export class TaskAgentManager {
 	}
 
 	/**
+	 * Verify that a workflow node sub-session has the `node-agent` MCP server attached
+	 * to its in-memory config, and self-heal by re-attaching if it's missing.
+	 *
+	 * This is a defensive guard against silent recurrence of the failure mode in
+	 * PR #1535 where a Coder sub-session ran without `node-agent`, causing
+	 * `mcp__node-agent__send_message` to return "No such tool available" and the
+	 * Coder→Reviewer handoff to die silently. The session then idled out at the
+	 * 30-minute timeout with no diagnostic trail.
+	 *
+	 * Called from both spawn and rehydrate paths to guarantee the invariant:
+	 *   "every workflow-node sub-session has `node-agent` attached BEFORE first turn".
+	 *
+	 * If the server is missing (which should never happen given the merge logic in
+	 * createSubSession + rehydrateSubSession), this method:
+	 *   1. Logs a loud error tagged with the spawn/rehydrate phase for diagnosis.
+	 *   2. Re-builds and re-attaches `node-agent` (preserving any registry-sourced
+	 *      MCP servers that may already be present in the config).
+	 *   3. Re-verifies attachment; if still missing, throws — better to fail spawn
+	 *      visibly than to start an unrecoverable session.
+	 */
+	ensureNodeAgentAttached(
+		session: AgentSession,
+		ctx: {
+			taskId: string;
+			subSessionId: string;
+			agentName: string;
+			spaceId: string;
+			workflowRunId: string;
+			workspacePath: string;
+			workflowNodeId: string;
+			phase: 'spawn' | 'rehydrate' | 'restore';
+		}
+	): void {
+		// `session.config` may be absent on restored ghost sessions before the first
+		// query setup, so read defensively — treat as empty servers map.
+		const currentMcpServers =
+			(session.session.config?.mcpServers as Record<string, McpServerConfig> | undefined) ?? {};
+		if (currentMcpServers['node-agent']) {
+			// Invariant holds — log at debug level for traceability.
+			log.debug(
+				`TaskAgentManager.ensureNodeAgentAttached: node-agent present on session ${ctx.subSessionId} (phase=${ctx.phase})`
+			);
+			return;
+		}
+
+		log.error(
+			`TaskAgentManager.ensureNodeAgentAttached: node-agent MCP server MISSING on workflow sub-session ${ctx.subSessionId} ` +
+				`(task=${ctx.taskId}, agent=${ctx.agentName}, phase=${ctx.phase}). ` +
+				`Visible servers: [${Object.keys(currentMcpServers).sort().join(', ')}]. ` +
+				`Self-healing by re-injecting before first turn — but this indicates a regression in the spawn/rehydrate merge logic.`
+		);
+
+		this.reinjectNodeAgentMcpServer(session, ctx);
+
+		const verifyMcpServers =
+			(session.session.config?.mcpServers as Record<string, McpServerConfig> | undefined) ?? {};
+		if (!verifyMcpServers['node-agent']) {
+			throw new Error(
+				`TaskAgentManager.ensureNodeAgentAttached: failed to re-attach node-agent to session ${ctx.subSessionId} after self-heal attempt`
+			);
+		}
+		log.info(
+			`TaskAgentManager.ensureNodeAgentAttached: successfully re-attached node-agent to session ${ctx.subSessionId} (phase=${ctx.phase})`
+		);
+	}
+
+	/**
+	 * Build (or re-build) the per-session node-agent MCP server and merge it into
+	 * the session's runtime MCP map, preserving any other MCP servers already present.
+	 *
+	 * Used by the defensive self-heal path in ensureNodeAgentAttached and as a
+	 * restore primitive callable when a sub-session needs node-agent re-attached
+	 * (e.g., after a refactor regression or registry collision drops it).
+	 *
+	 * Note: `setRuntimeMcpServers` REPLACES the in-memory mcpServers map, so we
+	 * must merge with the current map to avoid dropping registry-sourced servers
+	 * that were attached at session creation.
+	 */
+	reinjectNodeAgentMcpServer(
+		session: AgentSession,
+		ctx: {
+			taskId: string;
+			subSessionId: string;
+			agentName: string;
+			spaceId: string;
+			workflowRunId: string;
+			workspacePath: string;
+			workflowNodeId: string;
+		}
+	): void {
+		const nodeAgentMcpServer = this.buildNodeAgentMcpServerForSession(
+			ctx.taskId,
+			ctx.subSessionId,
+			ctx.agentName,
+			ctx.spaceId,
+			ctx.workflowRunId,
+			ctx.workspacePath,
+			ctx.workflowNodeId
+		);
+
+		const currentMcpServers =
+			(session.session.config?.mcpServers as Record<string, McpServerConfig> | undefined) ?? {};
+		const merged: Record<string, McpServerConfig> = {
+			...currentMcpServers,
+			'node-agent': nodeAgentMcpServer as unknown as McpServerConfig,
+		};
+		session.setRuntimeMcpServers(merged);
+	}
+
+	/**
 	 * Build a node agent MCP server for a newly spawned sub-session.
 	 * Called from the `buildNodeAgentMcpServer` callback passed to createTaskAgentMcpServer().
 	 *
@@ -2498,6 +2641,49 @@ export class TaskAgentManager {
 			};
 		}
 
+		// Self-heal callback for the agent-callable `restore_node_agent` tool.
+		// Looks up the live AgentSession by the session ID we baked into the closure
+		// at server-build time, then calls reinjectNodeAgentMcpServer to (re)attach
+		// node-agent. Belt-and-braces: the tool call itself is proof the server is
+		// already attached, but re-injecting protects against partial/torn registry
+		// state and emits a structured log entry for diagnosis.
+		const capturedTaskId = taskId;
+		const capturedSubSessionId = subSessionId;
+		const capturedAgentName = agentName;
+		const capturedSpaceId = spaceId;
+		const capturedWorkflowRunId = workflowRunId;
+		const capturedWorkspacePath = workspacePath;
+		const capturedWorkflowNodeId = workflowNodeId;
+		const onRestoreNodeAgent = (args: { reason?: string }): void => {
+			const liveSession = this.getSubSession(capturedSubSessionId);
+			if (!liveSession) {
+				log.warn(
+					`TaskAgentManager.onRestoreNodeAgent: no live AgentSession found for sub-session ${capturedSubSessionId} ` +
+						`(task=${capturedTaskId}, agent=${capturedAgentName}). Reason: ${args.reason ?? '<unspecified>'}`
+				);
+				return;
+			}
+			try {
+				this.reinjectNodeAgentMcpServer(liveSession, {
+					taskId: capturedTaskId,
+					subSessionId: capturedSubSessionId,
+					agentName: capturedAgentName,
+					spaceId: capturedSpaceId,
+					workflowRunId: capturedWorkflowRunId,
+					workspacePath: capturedWorkspacePath,
+					workflowNodeId: capturedWorkflowNodeId,
+				});
+				log.info(
+					`TaskAgentManager.onRestoreNodeAgent: re-attached node-agent for sub-session ${capturedSubSessionId} ` +
+						`(task=${capturedTaskId}, agent=${capturedAgentName}, reason=${args.reason ?? '<unspecified>'})`
+				);
+			} catch (err) {
+				log.error(
+					`TaskAgentManager.onRestoreNodeAgent: failed to re-attach node-agent for sub-session ${capturedSubSessionId}: ${err instanceof Error ? err.message : String(err)}`
+				);
+			}
+		};
+
 		return createNodeAgentMcpServer({
 			mySessionId: subSessionId,
 			myAgentName: agentName,
@@ -2522,6 +2708,7 @@ export class TaskAgentManager {
 				const s = await spaceManager.getSpace(sid);
 				return s?.autonomyLevel ?? 1;
 			},
+			onRestoreNodeAgent,
 		});
 	}
 }

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -2448,7 +2448,7 @@ export class TaskAgentManager {
 			workflowRunId: string;
 			workspacePath: string;
 			workflowNodeId: string;
-			phase: 'spawn' | 'rehydrate' | 'restore';
+			phase: 'spawn' | 'rehydrate';
 		}
 	): void {
 		// `session.config` may be absent on restored ghost sessions before the first
@@ -2678,44 +2678,38 @@ export class TaskAgentManager {
 		}
 
 		// Self-heal callback for the agent-callable `restore_node_agent` tool.
-		// Looks up the live AgentSession by the session ID we baked into the closure
-		// at server-build time, then calls reinjectNodeAgentMcpServer to (re)attach
-		// node-agent. Belt-and-braces: the tool call itself is proof the server is
-		// already attached, but re-injecting protects against partial/torn registry
-		// state and emits a structured log entry for diagnosis.
-		const capturedTaskId = taskId;
-		const capturedSubSessionId = subSessionId;
-		const capturedAgentName = agentName;
-		const capturedSpaceId = spaceId;
-		const capturedWorkflowRunId = workflowRunId;
-		const capturedWorkspacePath = workspacePath;
-		const capturedWorkflowNodeId = workflowNodeId;
+		// Looks up the live AgentSession by the enclosing-scope subSessionId, then
+		// calls reinjectNodeAgentMcpServer to (re)attach node-agent. Belt-and-braces:
+		// the tool call itself is proof the server is already attached, but re-injecting
+		// protects against partial/torn registry state and emits a structured log entry
+		// for diagnosis. All identity vars (taskId, subSessionId, etc.) are `const` in
+		// the enclosing scope, so the closure captures them safely without aliasing.
 		const onRestoreNodeAgent = (args: { reason?: string }): void => {
-			const liveSession = this.getSubSession(capturedSubSessionId);
+			const liveSession = this.getSubSession(subSessionId);
 			if (!liveSession) {
 				log.warn(
-					`TaskAgentManager.onRestoreNodeAgent: no live AgentSession found for sub-session ${capturedSubSessionId} ` +
-						`(task=${capturedTaskId}, agent=${capturedAgentName}). Reason: ${args.reason ?? '<unspecified>'}`
+					`TaskAgentManager.onRestoreNodeAgent: no live AgentSession found for sub-session ${subSessionId} ` +
+						`(task=${taskId}, agent=${agentName}). Reason: ${args.reason ?? '<unspecified>'}`
 				);
 				return;
 			}
 			try {
 				this.reinjectNodeAgentMcpServer(liveSession, {
-					taskId: capturedTaskId,
-					subSessionId: capturedSubSessionId,
-					agentName: capturedAgentName,
-					spaceId: capturedSpaceId,
-					workflowRunId: capturedWorkflowRunId,
-					workspacePath: capturedWorkspacePath,
-					workflowNodeId: capturedWorkflowNodeId,
+					taskId,
+					subSessionId,
+					agentName,
+					spaceId,
+					workflowRunId,
+					workspacePath,
+					workflowNodeId,
 				});
 				log.info(
-					`TaskAgentManager.onRestoreNodeAgent: re-attached node-agent for sub-session ${capturedSubSessionId} ` +
-						`(task=${capturedTaskId}, agent=${capturedAgentName}, reason=${args.reason ?? '<unspecified>'})`
+					`TaskAgentManager.onRestoreNodeAgent: re-attached node-agent for sub-session ${subSessionId} ` +
+						`(task=${taskId}, agent=${agentName}, reason=${args.reason ?? '<unspecified>'})`
 				);
 			} catch (err) {
 				log.error(
-					`TaskAgentManager.onRestoreNodeAgent: failed to re-attach node-agent for sub-session ${capturedSubSessionId}: ${err instanceof Error ? err.message : String(err)}`
+					`TaskAgentManager.onRestoreNodeAgent: failed to re-attach node-agent for sub-session ${subSessionId}: ${err instanceof Error ? err.message : String(err)}`
 				);
 			}
 		};

--- a/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
@@ -228,6 +228,38 @@ export const ListArtifactsSchema = z.object({
 export type ListArtifactsInput = z.infer<typeof ListArtifactsSchema>;
 
 // ---------------------------------------------------------------------------
+// restore_node_agent
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `restore_node_agent` input.
+ *
+ * Self-heal primitive — invoked by a sub-session agent when it detects (or
+ * suspects) that node-agent tools are unavailable. The fact that this tool
+ * call succeeds is itself proof that node-agent is registered for the
+ * current session; the handler additionally re-attaches node-agent on the
+ * server side as a belt-and-braces measure and returns the visible MCP
+ * server names so the agent can confirm its environment.
+ *
+ * Use this when:
+ *   - A previous `mcp__node-agent__send_message` (or other node-agent tool)
+ *     unexpectedly returned "No such tool available".
+ *   - You want to verify the node-agent environment before performing a
+ *     critical handoff.
+ */
+export const RestoreNodeAgentSchema = z.object({
+	/** Optional human-readable reason for the restore — recorded in logs. */
+	reason: z
+		.string()
+		.describe(
+			'Optional human-readable reason for invoking restore (recorded in logs for diagnosis)'
+		)
+		.optional(),
+});
+
+export type RestoreNodeAgentInput = z.infer<typeof RestoreNodeAgentSchema>;
+
+// ---------------------------------------------------------------------------
 // Aggregate export
 // ---------------------------------------------------------------------------
 
@@ -244,6 +276,7 @@ export const NODE_AGENT_TOOL_SCHEMAS = {
 	read_gate: ReadGateSchema,
 	write_artifact: WriteArtifactSchema,
 	list_artifacts: ListArtifactsSchema,
+	restore_node_agent: RestoreNodeAgentSchema,
 } as const;
 
 export type NodeAgentToolName = keyof typeof NODE_AGENT_TOOL_SCHEMAS;

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -53,6 +53,7 @@ import {
 	ReadGateSchema,
 	WriteArtifactSchema,
 	ListArtifactsSchema,
+	RestoreNodeAgentSchema,
 } from './node-agent-tool-schemas';
 import type {
 	ListPeersInput,
@@ -64,6 +65,7 @@ import type {
 	ReadGateInput,
 	WriteArtifactInput,
 	ListArtifactsInput,
+	RestoreNodeAgentInput,
 } from './node-agent-tool-schemas';
 import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
 
@@ -172,6 +174,18 @@ export interface NodeAgentToolsConfig {
 	 * Optional — when absent, artifact tools are not registered.
 	 */
 	artifactRepo?: WorkflowRunArtifactRepository;
+	/**
+	 * Optional callback invoked when the agent calls `restore_node_agent`.
+	 *
+	 * Wired by TaskAgentManager to re-attach the per-session node-agent MCP server
+	 * (preserving any other registry-sourced servers) and emit a structured log
+	 * entry for diagnosis. The callback is fire-and-forget from the tool's
+	 * perspective — failures are logged but do not block the tool result.
+	 *
+	 * When omitted (e.g. in unit tests), the tool still succeeds and reports the
+	 * visible MCP server names but performs no server-side reattachment.
+	 */
+	onRestoreNodeAgent?: (args: { reason?: string }) => Promise<void> | void;
 }
 
 // ---------------------------------------------------------------------------
@@ -769,6 +783,50 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 				return jsonResult({ success: false, error: message });
 			}
 		},
+
+		// ── Self-heal ────────────────────────────────────────────────────
+
+		/**
+		 * Self-heal primitive.
+		 *
+		 * Successfully invoking this tool is itself proof that the node-agent
+		 * MCP server is registered for the current session — if the server were
+		 * missing, the SDK would have rejected the call with "No such tool
+		 * available". The handler additionally invokes the optional
+		 * `onRestoreNodeAgent` callback (wired by TaskAgentManager) which
+		 * re-attaches the per-session node-agent server as a belt-and-braces
+		 * measure and writes a structured log entry for diagnosis.
+		 *
+		 * The result reports back the visible MCP server names so the agent can
+		 * confirm its environment before retrying a critical handoff.
+		 */
+		async restore_node_agent(args: RestoreNodeAgentInput): Promise<ToolResult> {
+			const reason = args.reason?.trim();
+			log.info(
+				`node-agent.restore_node_agent invoked by session ${mySessionId} ` +
+					`(agent=${myAgentName}, task=${config.taskId}, reason=${reason ?? '<unspecified>'})`
+			);
+
+			try {
+				if (config.onRestoreNodeAgent) {
+					await config.onRestoreNodeAgent({ reason });
+				}
+			} catch (err) {
+				log.warn(
+					`node-agent.restore_node_agent: server-side reattachment callback failed for session ${mySessionId}: ${err instanceof Error ? err.message : String(err)}`
+				);
+			}
+
+			return jsonResult({
+				success: true,
+				sessionId: mySessionId,
+				agentName: myAgentName,
+				message:
+					'node-agent MCP server is registered for this session — the fact that this tool ' +
+					'call succeeded proves it. If a previous mcp__node-agent__send_message call ' +
+					'returned "No such tool available", retry it now.',
+			});
+		},
 	};
 }
 
@@ -847,6 +905,17 @@ export function createNodeAgentMcpServer(config: NodeAgentToolsConfig) {
 				'Use `data` for machine-readable artifacts like pr_url, commit_sha, test_results.',
 			SaveSchema.shape,
 			(args) => handlers.save(args)
+		),
+		tool(
+			'restore_node_agent',
+			'Self-heal primitive — call when you suspect the node-agent MCP server is unhealthy ' +
+				'(e.g. a previous mcp__node-agent__send_message returned "No such tool available"). ' +
+				'The fact that this call succeeds proves node-agent is registered for your session. ' +
+				'The handler also re-attaches the server on the daemon side as a belt-and-braces ' +
+				'measure and emits a structured log line for diagnosis. After calling, retry the ' +
+				'failed tool once.',
+			RestoreNodeAgentSchema.shape,
+			(args) => handlers.restore_node_agent(args)
 		),
 		...(config.artifactRepo
 			? [

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -2232,3 +2232,87 @@ describe('node-agent-tools: async gate evaluation', () => {
 		expect(data.gateWrite).toBeUndefined();
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Tests: restore_node_agent (self-heal primitive)
+// ---------------------------------------------------------------------------
+
+describe('node-agent-tools: restore_node_agent', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('returns success with session/agent identity even without onRestoreNodeAgent callback', async () => {
+		const config = makeConfig(ctx);
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.restore_node_agent({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.sessionId).toBe(ctx.coderSessionId);
+		expect(data.agentName).toBe('coder');
+		expect(typeof data.message).toBe('string');
+		expect(data.message).toContain('node-agent MCP server is registered');
+	});
+
+	test('invokes onRestoreNodeAgent callback with the supplied reason', async () => {
+		const captured: Array<{ reason?: string }> = [];
+		const config = makeConfig(ctx, {
+			onRestoreNodeAgent: (args) => {
+				captured.push(args);
+			},
+		});
+		const handlers = createNodeAgentToolHandlers(config);
+		await handlers.restore_node_agent({ reason: 'previous send_message returned No such tool' });
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0]!.reason).toBe('previous send_message returned No such tool');
+	});
+
+	test('still returns success when the onRestoreNodeAgent callback throws', async () => {
+		const config = makeConfig(ctx, {
+			onRestoreNodeAgent: () => {
+				throw new Error('reattach failed');
+			},
+		});
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.restore_node_agent({ reason: 'diagnostic' });
+		const data = JSON.parse(result.content[0].text);
+
+		// The tool MUST report success — calling it at all proves node-agent is registered.
+		// Server-side reattach failures are logged but must not block the agent's recovery flow.
+		expect(data.success).toBe(true);
+		expect(data.sessionId).toBe(ctx.coderSessionId);
+	});
+
+	test('awaits async onRestoreNodeAgent callback before returning', async () => {
+		let resolved = false;
+		const config = makeConfig(ctx, {
+			onRestoreNodeAgent: async () => {
+				await new Promise((r) => setTimeout(r, 10));
+				resolved = true;
+			},
+		});
+		const handlers = createNodeAgentToolHandlers(config);
+		await handlers.restore_node_agent({});
+
+		expect(resolved).toBe(true);
+	});
+
+	test('createNodeAgentMcpServer registers restore_node_agent tool', () => {
+		const config = makeConfig(ctx);
+		const server = createNodeAgentMcpServer(config);
+		const registered = Object.keys(
+			(server as unknown as { instance: { _registeredTools: Record<string, unknown> } }).instance
+				._registeredTools
+		);
+		expect(registered).toContain('restore_node_agent');
+	});
+});

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-mcp.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-mcp.test.ts
@@ -71,7 +71,7 @@ class TestDaemonHub {
 // ---------------------------------------------------------------------------
 
 interface MockAgentSession {
-	session: { id: string };
+	session: { id: string; config: { mcpServers?: Record<string, unknown> } };
 	getProcessingState: () => AgentProcessingState;
 	setRuntimeMcpServers: (servers: Record<string, unknown>) => void;
 	setRuntimeSystemPrompt: (sp: unknown) => void;
@@ -85,11 +85,15 @@ interface MockAgentSession {
 
 function makeMockSession(sessionId: string): MockAgentSession {
 	const m: MockAgentSession = {
-		session: { id: sessionId },
+		session: { id: sessionId, config: { mcpServers: {} } },
 		_mcpServers: {},
 		getProcessingState: () => ({ status: 'idle' }) as AgentProcessingState,
 		setRuntimeMcpServers(servers) {
 			m._mcpServers = servers;
+			// Mirror the real AgentSession.setRuntimeMcpServers behaviour so
+			// ensureNodeAgentAttached's `session.config.mcpServers` check sees the
+			// merged map after spawn / self-heal.
+			m.session.config = { ...m.session.config, mcpServers: servers };
 		},
 		setRuntimeSystemPrompt(_sp: unknown) {},
 		async startStreamingQuery() {},
@@ -1083,5 +1087,389 @@ describe('TaskAgentManager.rehydrate — skills injection (G3)', () => {
 		const args = capturedRestoreArgs.get(agentSessionId);
 		expect(args).toBeDefined();
 		expect(args!.appMcpServerRepo).toBe(mockAppMcpServerRepo);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// ensureNodeAgentAttached + reinjectNodeAgentMcpServer (defensive self-heal
+// for workflow sub-sessions — Task #37)
+// ---------------------------------------------------------------------------
+
+describe('TaskAgentManager.ensureNodeAgentAttached — workflow sub-session invariant (Task #37)', () => {
+	const spies: Array<{ mockRestore: () => void }> = [];
+	const dirs: string[] = [];
+
+	afterEach(() => {
+		for (const spy of spies.splice(0)) spy.mockRestore();
+		for (const dir of dirs.splice(0)) {
+			try {
+				rmSync(dir, { recursive: true });
+			} catch {
+				/* best-effort */
+			}
+		}
+	});
+
+	test('does nothing when node-agent is already present in session.config.mcpServers', () => {
+		const { manager, fromInitSpy, dir } = buildManager({});
+		spies.push(fromInitSpy);
+		dirs.push(dir);
+
+		const session = makeMockSession('sub-session-ok');
+		// Pre-populate node-agent in the session config — invariant already holds.
+		session.session.config.mcpServers = { 'node-agent': { name: 'node-agent' } };
+
+		// Fail loudly if reinjectNodeAgentMcpServer is called — it must not be.
+		const mgr = manager as unknown as {
+			reinjectNodeAgentMcpServer: (...args: unknown[]) => void;
+			ensureNodeAgentAttached: (s: unknown, c: unknown) => void;
+		};
+		const originalReinject = mgr.reinjectNodeAgentMcpServer.bind(manager);
+		let reinjectCalled = false;
+		mgr.reinjectNodeAgentMcpServer = (...args) => {
+			reinjectCalled = true;
+			return originalReinject(...args);
+		};
+
+		mgr.ensureNodeAgentAttached(session, {
+			taskId: 'task-1',
+			subSessionId: 'sub-session-ok',
+			agentName: 'coder',
+			spaceId: 'space-1',
+			workflowRunId: 'run-1',
+			workspacePath: '/tmp',
+			workflowNodeId: 'node-1',
+			phase: 'spawn',
+		});
+
+		expect(reinjectCalled).toBe(false);
+		// Server map untouched.
+		expect(session.session.config.mcpServers!['node-agent']).toBeDefined();
+	});
+
+	test('self-heals by re-injecting node-agent when missing', () => {
+		const { manager, fromInitSpy, dir } = buildManager({});
+		spies.push(fromInitSpy);
+		dirs.push(dir);
+
+		const session = makeMockSession('sub-session-broken');
+		// node-agent is missing — registry servers may still be there.
+		session.session.config.mcpServers = { 'registry-mcp': { name: 'registry' } };
+
+		const mgr = manager as unknown as {
+			ensureNodeAgentAttached: (s: unknown, c: unknown) => void;
+			reinjectNodeAgentMcpServer: (s: unknown, c: unknown) => void;
+		};
+
+		// Stub reinject so we don't have to wire a full workflow run; record the call
+		// and simulate the server-side merge that the real implementation would do.
+		const originalReinject = mgr.reinjectNodeAgentMcpServer.bind(manager);
+		let reinjectCallCount = 0;
+		mgr.reinjectNodeAgentMcpServer = (s, _ctx) => {
+			reinjectCallCount++;
+			const sess = s as MockAgentSession;
+			sess.setRuntimeMcpServers({
+				...(sess.session.config.mcpServers ?? {}),
+				'node-agent': { name: 'node-agent', _stub: true },
+			});
+		};
+
+		try {
+			mgr.ensureNodeAgentAttached(session, {
+				taskId: 'task-1',
+				subSessionId: 'sub-session-broken',
+				agentName: 'coder',
+				spaceId: 'space-1',
+				workflowRunId: 'run-1',
+				workspacePath: '/tmp',
+				workflowNodeId: 'node-1',
+				phase: 'spawn',
+			});
+		} finally {
+			mgr.reinjectNodeAgentMcpServer = originalReinject;
+		}
+
+		expect(reinjectCallCount).toBe(1);
+		expect(session.session.config.mcpServers!['node-agent']).toBeDefined();
+		// Pre-existing servers must be preserved during self-heal.
+		expect(session.session.config.mcpServers!['registry-mcp']).toBeDefined();
+	});
+
+	test('throws when re-injection fails to add node-agent', () => {
+		const { manager, fromInitSpy, dir } = buildManager({});
+		spies.push(fromInitSpy);
+		dirs.push(dir);
+
+		const session = makeMockSession('sub-session-broken');
+		session.session.config.mcpServers = {};
+
+		const mgr = manager as unknown as {
+			ensureNodeAgentAttached: (s: unknown, c: unknown) => void;
+			reinjectNodeAgentMcpServer: (s: unknown, c: unknown) => void;
+		};
+		const originalReinject = mgr.reinjectNodeAgentMcpServer.bind(manager);
+		// Simulate a broken reinject that does not add node-agent.
+		mgr.reinjectNodeAgentMcpServer = () => {
+			/* no-op — fails to re-attach */
+		};
+
+		try {
+			expect(() =>
+				mgr.ensureNodeAgentAttached(session, {
+					taskId: 'task-1',
+					subSessionId: 'sub-session-broken',
+					agentName: 'coder',
+					spaceId: 'space-1',
+					workflowRunId: 'run-1',
+					workspacePath: '/tmp',
+					workflowNodeId: 'node-1',
+					phase: 'spawn',
+				})
+			).toThrow(/failed to re-attach node-agent/);
+		} finally {
+			mgr.reinjectNodeAgentMcpServer = originalReinject;
+		}
+	});
+});
+
+describe('TaskAgentManager.reinjectNodeAgentMcpServer — server-side restore primitive (Task #37)', () => {
+	const spies: Array<{ mockRestore: () => void }> = [];
+	const dirs: string[] = [];
+
+	afterEach(() => {
+		for (const spy of spies.splice(0)) spy.mockRestore();
+		for (const dir of dirs.splice(0)) {
+			try {
+				rmSync(dir, { recursive: true });
+			} catch {
+				/* best-effort */
+			}
+		}
+	});
+
+	test('builds and merges node-agent into session config without dropping existing servers', () => {
+		const { manager, fromInitSpy, dir, space } = buildManager({});
+		spies.push(fromInitSpy);
+		dirs.push(dir);
+
+		const session = makeMockSession('sub-session-reinject');
+		session.session.config.mcpServers = { 'registry-mcp': { name: 'registry' } };
+
+		// Stub the underlying server builder so we don't need a fully wired workflow run.
+		const mcpServerSpy = spyOn(nodeAgentToolsModule, 'createNodeAgentMcpServer').mockImplementation(
+			() => {
+				return { name: 'node-agent', _stub: true } as unknown as ReturnType<
+					typeof nodeAgentToolsModule.createNodeAgentMcpServer
+				>;
+			}
+		);
+		spies.push(mcpServerSpy);
+
+		const mgr = manager as unknown as {
+			reinjectNodeAgentMcpServer: (s: unknown, c: unknown) => void;
+		};
+		mgr.reinjectNodeAgentMcpServer(session, {
+			taskId: 'task-1',
+			subSessionId: 'sub-session-reinject',
+			agentName: 'coder',
+			spaceId: space.id,
+			workflowRunId: '',
+			workspacePath: space.workspacePath,
+			workflowNodeId: 'node-1',
+		});
+
+		// Both the registry server and the freshly built node-agent must be present.
+		expect(session._mcpServers['node-agent']).toBeDefined();
+		expect(session._mcpServers['registry-mcp']).toBeDefined();
+		// The mirror on session.config.mcpServers must match.
+		expect(session.session.config.mcpServers!['node-agent']).toBeDefined();
+		expect(session.session.config.mcpServers!['registry-mcp']).toBeDefined();
+	});
+});
+
+describe('TaskAgentManager.buildNodeAgentMcpServerForSession — onRestoreNodeAgent callback wiring (Task #37)', () => {
+	const spies: Array<{ mockRestore: () => void }> = [];
+	const dirs: string[] = [];
+
+	afterEach(() => {
+		for (const spy of spies.splice(0)) spy.mockRestore();
+		for (const dir of dirs.splice(0)) {
+			try {
+				rmSync(dir, { recursive: true });
+			} catch {
+				/* best-effort */
+			}
+		}
+	});
+
+	test('passes an onRestoreNodeAgent callback into createNodeAgentMcpServer', () => {
+		const { manager, fromInitSpy, dir, space, taskManager } = buildManager({});
+		spies.push(fromInitSpy);
+		dirs.push(dir);
+
+		let capturedConfig: Record<string, unknown> | null = null;
+		const mcpServerSpy = spyOn(nodeAgentToolsModule, 'createNodeAgentMcpServer').mockImplementation(
+			(config) => {
+				capturedConfig = config as unknown as Record<string, unknown>;
+				return { server: {}, cleanup: () => {} } as unknown as ReturnType<
+					typeof nodeAgentToolsModule.createNodeAgentMcpServer
+				>;
+			}
+		);
+		spies.push(mcpServerSpy);
+
+		const mgr = manager as unknown as {
+			buildNodeAgentMcpServerForSession(
+				taskId: string,
+				subSessionId: string,
+				agentName: string,
+				spaceId: string,
+				workflowRunId: string,
+				workspacePath: string,
+				workflowNodeIdHint?: string
+			): unknown;
+		};
+		mgr.buildNodeAgentMcpServerForSession(
+			'task-1',
+			'sub-session-restore-test',
+			'coder',
+			space.id,
+			'',
+			space.workspacePath,
+			'node-1'
+		);
+
+		expect(capturedConfig).not.toBeNull();
+		expect(typeof capturedConfig!['onRestoreNodeAgent']).toBe('function');
+
+		// Use taskManager to keep linter happy — exposes the seeded test space wiring.
+		expect(taskManager).toBeDefined();
+	});
+
+	test('onRestoreNodeAgent callback re-injects node-agent on a live sub-session', async () => {
+		const { manager, fromInitSpy, dir, space } = buildManager({});
+		spies.push(fromInitSpy);
+		dirs.push(dir);
+
+		// Step 1: stub the server builder so buildNodeAgentMcpServerForSession can run
+		// without requiring a full workflow definition. The first call (server build)
+		// returns a captured config holding the onRestoreNodeAgent callback. The second
+		// call (triggered by the callback's reinject path) returns a stub server.
+		let capturedConfig: Record<string, unknown> | null = null;
+		const builtServers: unknown[] = [];
+		const mcpServerSpy = spyOn(nodeAgentToolsModule, 'createNodeAgentMcpServer').mockImplementation(
+			(config) => {
+				if (capturedConfig === null) {
+					capturedConfig = config as unknown as Record<string, unknown>;
+				}
+				const stub = { name: 'node-agent', _stub: true } as unknown as ReturnType<
+					typeof nodeAgentToolsModule.createNodeAgentMcpServer
+				>;
+				builtServers.push(stub);
+				return stub;
+			}
+		);
+		spies.push(mcpServerSpy);
+
+		// Step 2: create a sub-session and register it in the subSessions map so
+		// getSubSession() can find it from the callback closure.
+		const subSessionId = 'sub-session-restore-live';
+		const init = {
+			sessionId: subSessionId,
+			sessionType: 'space_task_agent' as const,
+			title: 'Restore live test',
+			workspacePath: '/tmp',
+		};
+		await manager.createSubSession('task-restore', subSessionId, init as never);
+
+		// Step 3: build the node-agent server for the sub-session. The build call
+		// captures the onRestoreNodeAgent callback we want to test.
+		const mgr = manager as unknown as {
+			buildNodeAgentMcpServerForSession(
+				taskId: string,
+				subSessionId: string,
+				agentName: string,
+				spaceId: string,
+				workflowRunId: string,
+				workspacePath: string,
+				workflowNodeIdHint?: string
+			): unknown;
+			getSubSession(id: string): MockAgentSession | undefined;
+		};
+		mgr.buildNodeAgentMcpServerForSession(
+			'task-restore',
+			subSessionId,
+			'coder',
+			space.id,
+			'',
+			space.workspacePath,
+			'node-1'
+		);
+
+		expect(capturedConfig).not.toBeNull();
+		const onRestoreNodeAgent = capturedConfig!['onRestoreNodeAgent'] as (args: {
+			reason?: string;
+		}) => void;
+		expect(typeof onRestoreNodeAgent).toBe('function');
+
+		// Step 4: invoke the callback — it should re-attach node-agent on the live session.
+		const liveSession = mgr.getSubSession(subSessionId);
+		expect(liveSession).toBeDefined();
+		// Pre-condition: node-agent is NOT in the session config (sub-session was
+		// created without injecting it via init.mcpServers in this test path).
+		expect(liveSession!.session.config.mcpServers?.['node-agent']).toBeUndefined();
+
+		onRestoreNodeAgent({ reason: 'test trigger' });
+
+		// Post-condition: node-agent should now be present after the self-heal path.
+		expect(liveSession!.session.config.mcpServers?.['node-agent']).toBeDefined();
+	});
+
+	test('onRestoreNodeAgent is a no-op (logs only) when no live sub-session is found', () => {
+		const { manager, fromInitSpy, dir, space } = buildManager({});
+		spies.push(fromInitSpy);
+		dirs.push(dir);
+
+		let capturedConfig: Record<string, unknown> | null = null;
+		const mcpServerSpy = spyOn(nodeAgentToolsModule, 'createNodeAgentMcpServer').mockImplementation(
+			(config) => {
+				if (capturedConfig === null) {
+					capturedConfig = config as unknown as Record<string, unknown>;
+				}
+				return { name: 'node-agent', _stub: true } as unknown as ReturnType<
+					typeof nodeAgentToolsModule.createNodeAgentMcpServer
+				>;
+			}
+		);
+		spies.push(mcpServerSpy);
+
+		const mgr = manager as unknown as {
+			buildNodeAgentMcpServerForSession(
+				taskId: string,
+				subSessionId: string,
+				agentName: string,
+				spaceId: string,
+				workflowRunId: string,
+				workspacePath: string,
+				workflowNodeIdHint?: string
+			): unknown;
+		};
+		mgr.buildNodeAgentMcpServerForSession(
+			'task-1',
+			'sub-session-not-registered',
+			'coder',
+			space.id,
+			'',
+			space.workspacePath,
+			'node-1'
+		);
+
+		expect(capturedConfig).not.toBeNull();
+		const onRestoreNodeAgent = capturedConfig!['onRestoreNodeAgent'] as (args: {
+			reason?: string;
+		}) => void;
+
+		// Should not throw — just log a warning when the sub-session is missing.
+		expect(() => onRestoreNodeAgent({ reason: 'not-registered' })).not.toThrow();
 	});
 });

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
@@ -67,7 +67,11 @@ class TestDaemonHub {
 // ---------------------------------------------------------------------------
 
 interface MockAgentSession {
-	session: { id: string; context?: Record<string, unknown> };
+	session: {
+		id: string;
+		context?: Record<string, unknown>;
+		config: { mcpServers?: Record<string, unknown> };
+	};
 	getProcessingState: () => AgentProcessingState;
 	getSDKMessageCount: () => number;
 	getSessionData: () => { id: string; context?: Record<string, unknown> };
@@ -89,7 +93,7 @@ interface MockAgentSession {
 
 function makeMockSession(sessionId: string): MockAgentSession {
 	const m: MockAgentSession = {
-		session: { id: sessionId, context: {} },
+		session: { id: sessionId, context: {}, config: { mcpServers: {} } },
 		_processingState: { status: 'idle' } as AgentProcessingState,
 		_sdkMessageCount: 0,
 		_startCalled: false,
@@ -108,6 +112,9 @@ function makeMockSession(sessionId: string): MockAgentSession {
 		},
 		setRuntimeMcpServers(servers) {
 			this._mcpServers = servers;
+			// Mirror the real AgentSession behaviour so ensureNodeAgentAttached's
+			// `session.config.mcpServers` invariant check sees the merged map.
+			this.session.config = { ...this.session.config, mcpServers: servers };
 		},
 		setRuntimeSystemPrompt(_sp: unknown) {},
 		async startStreamingQuery() {


### PR DESCRIPTION
Fixes the silent "No such tool available" failure where workflow sub-sessions (e.g. PR #1535's Coder→Reviewer handoff) idled out at the 30-min timeout because `mcp__node-agent__send_message` was unregistered at first turn.

## Changes

- **Diagnostic log** in `QueryRunner.start()` — every query logs the MCP servers visible at first turn; workflow sub-sessions additionally log an error if `node-agent` is missing.
- **Defensive guarantee** via `TaskAgentManager.ensureNodeAgentAttached()` — called from both spawn and rehydrate paths. Verifies `node-agent` is in `session.config.mcpServers`; if missing, self-heals via `reinjectNodeAgentMcpServer()` (preserves registry servers); throws if the re-attach still fails.
- **Agent-callable restore primitive** — new `restore_node_agent({ reason? })` MCP tool. The fact that the call succeeds is itself proof the server is registered; the handler also triggers a server-side reinject as belt-and-braces and emits a structured log line.
- **Runtime contract update** — `buildNodeExecutionRuntimeContract` documents `restore_node_agent` as the fallback path when an `mcp__node-agent__*` call returns "No such tool available".
- **Tests** — covers `ensureNodeAgentAttached` (hold/self-heal/throw), `reinjectNodeAgentMcpServer` (preserve existing servers), `restore_node_agent` handler (sync/async callback, throwing callback, no live session), and the `onRestoreNodeAgent` wiring inside `buildNodeAgentMcpServerForSession`.

## Test plan

- [x] `bun test tests/unit/5-space/agent/node-agent-tools.test.ts` — 79 pass
- [x] `bun test tests/unit/5-space/agent/task-agent-manager-mcp.test.ts` — 25 pass
- [x] `bun test tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts` — 8 pass
- [x] `./scripts/test-daemon.sh` — 11099 pass / 0 fail
- [x] `bun run check` (lint + typecheck + knip) — clean