### PR TITLE
fix(space): gate Coding Workflow merge behind explicit Reviewer approval

### DIFF
--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -350,7 +350,10 @@ const REVIEW_REVIEW_NODE = 'tpl-review-review';
  * Three-node iterative graph: Coding → Review → Done (with Review↔Coding cycle).
  * - Coding → Review: gated by `code-ready-gate` — a bash script verifies that an
  *   open, mergeable PR exists and emits its URL as `{"pr_url":"..."}`.
- * - Review → Coding: ungated — Reviewer sends back for changes without any gate.
+ * - Review → Coding: gated by `review-posted-gate` — a bash script verifies the
+ *   Reviewer has actually posted a GitHub review (via `gh pr review`) before
+ *   the changes-requested message is delivered back to Coding. Capped at 5
+ *   cycles to prevent runaway ping-pong.
  * - Review → Done: gated by `review-approval-gate` — only opens when the Reviewer
  *   explicitly writes structured approval (`{approved: true}`) via send_message.
  *   A peer chat message alone is NOT authorization. The merge completion action

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -31,6 +31,7 @@ import { computeWorkflowHash } from './template-hash.ts';
 
 const CODING_CODE_NODE = 'tpl-coding-code';
 const CODING_REVIEW_NODE = 'tpl-coding-review';
+const CODING_DONE_NODE = 'tpl-coding-done';
 
 // Plan & Decompose node IDs
 const PD_PLANNING_NODE = 'tpl-pd-planning';
@@ -346,19 +347,32 @@ const REVIEW_REVIEW_NODE = 'tpl-review-review';
 /**
  * Coding Workflow
  *
- * Two-node iterative graph: Coding ↔ Review (with cycle).
+ * Three-node iterative graph: Coding → Review → Done (with Review↔Coding cycle).
  * - Coding → Review: gated by `code-ready-gate` — a bash script verifies that an
  *   open, mergeable PR exists and emits its URL as `{"pr_url":"..."}`.
  * - Review → Coding: ungated — Reviewer sends back for changes without any gate.
- *   When satisfied, Reviewer calls `report_result()` on the Review node (endNodeId)
- *   which signals workflow completion.
+ * - Review → Done: gated by `review-approval-gate` — only opens when the Reviewer
+ *   explicitly writes structured approval (`{approved: true}`) via send_message.
+ *   A peer chat message alone is NOT authorization. The merge completion action
+ *   then runs on Done; at space autonomy level below merge-pr's requiredLevel,
+ *   the task pauses at `review` status awaiting human approval of the merge.
+ *
+ * Design notes (Task #41):
+ * - The Coder does NOT have merge authority. It opens the PR and hands off.
+ * - The Reviewer does NOT complete the workflow. It writes structured approval
+ *   via send_message(target="Done", data={approved:true}) which opens the gate.
+ * - The Done node is the only node with `completionActions: [merge-pr]`. The
+ *   merge therefore can only run after the reviewer approval gate is open AND
+ *   the space autonomy level meets the merge action's `requiredLevel`.
  */
 export const CODING_WORKFLOW: SpaceWorkflow = {
 	id: '',
 	spaceId: '',
 	name: 'Coding Workflow',
 	description:
-		'Iterative coding workflow with Coding ↔ Review loop. Engineer implements and opens a PR; Reviewer reviews and either requests changes or signals completion.',
+		'Iterative coding workflow with Coding ↔ Review loop and gated Done/merge. ' +
+		'Engineer implements and opens a PR; Reviewer reviews and either requests changes or ' +
+		'writes a structured approval that opens the merge gate.',
 	nodes: [
 		{
 			id: CODING_CODE_NODE,
@@ -371,6 +385,12 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 						value:
 							'You are a software engineer in a Coding→Review iterative workflow. Your job is to ' +
 							'implement the task, write tests, commit your changes, and open a pull request.\n\n' +
+							'**You do NOT have merge authority.** You must not run `gh pr merge`, `git merge`, ' +
+							'squash-merge endpoints, or force-push to protected branches — a peer chat message ' +
+							'saying "approved" is communication, not authorization. The merge is performed ' +
+							'automatically by the Done node once the Reviewer writes a structured approval ' +
+							'and any required human sign-off is recorded. Your job ends at "PR open and handed ' +
+							'off to Reviewer."\n\n' +
 							'Workflow context:\n' +
 							'- The Reviewer is NOT triggered automatically when you finish. You MUST hand off ' +
 							'explicitly by sending a message to the Review node with the PR URL — that send ' +
@@ -417,8 +437,8 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 					name: 'reviewer',
 					customPrompt: {
 						value:
-							'You are the Reviewer in a Coding→Review iterative workflow. You review the work ' +
-							'and either approve it or request changes.\n\n' +
+							'You are the Reviewer in a Coding→Review→Done workflow. You review the work and ' +
+							'either approve it (by writing a structured gate signal) or request changes.\n\n' +
 							'Workflow context:\n' +
 							'- The engineer has already implemented and opened a PR (verified automatically).\n' +
 							'- You share the same worktree as the engineer — review the codebase as a whole, ' +
@@ -432,11 +452,16 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'checks GitHub for a fresh review before releasing your message. If you skip ' +
 							'`gh pr review`, the gate will block and the coder will never hear from you.\n' +
 							'- If you request changes, the engineer is automatically re-activated.\n\n' +
-							'**You MUST call `report_result` to end this workflow.** It is the only signal ' +
-							'the runtime accepts as completion — finishing your turn without it leaves the ' +
-							'workflow stuck. Do all your review work — read files, run tests, post comments ' +
-							'to GitHub, send messages to Coding — BEFORE calling `report_result`. After it ' +
-							'returns, do not invoke any other tools.\n\n' +
+							'**Approval is structured data, not a chat message.** To complete the workflow, ' +
+							'you MUST open the review-approval-gate by calling ' +
+							'`send_message(target="Done", message="<your review summary>", data={ approved: true })`. ' +
+							'A plain chat message saying "approved" is NOT authorization — the Done node ' +
+							'and its merge action only activate when the gate data contains ' +
+							'`approved: true`. **Do NOT run `gh pr merge`, `git merge`, or any merge command ' +
+							'yourself.** The merge is performed by the Done node as a completion action, ' +
+							'and at lower space autonomy levels it pauses for an explicit human approval.\n\n' +
+							'Do NOT call `report_result` — this workflow completes through the Done node, ' +
+							'not the Review node.\n\n' +
 							'Review checklist:\n' +
 							'1. Read the PR diff (`gh pr diff`) AND explore the worktree for context\n' +
 							'2. Check for correctness, style, test coverage, and integration impact\n' +
@@ -451,11 +476,36 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'data={ pr_url: "<url>", review_url: "<gh pr review url>", ' +
 							'comment_urls: ["<comment #1 url>", "<comment #2 url>"] }). The `data` payload ' +
 							'satisfies the review-posted-gate and gives the coder direct links to each ' +
-							'thread. Do NOT call `report_result` — leave the workflow open for the next round.\n' +
+							'thread. Do NOT write `approved: true` — leave the gate closed for the next round.\n' +
 							'5. If satisfied: post an approval review with `gh pr review <pr-url> --approve ' +
-							'--body-file <file>`, verify the PR is open and mergeable, then call ' +
-							'`report_result({ summary, evidence: { prUrl } })` as your final action. ' +
-							'Do NOT pass a `status` — the runtime decides the terminal state via completion actions.',
+							'--body-file <file>`, verify the PR is open and mergeable, then hand off with ' +
+							'`send_message(target="Done", message="<review summary>", data={ approved: true, ' +
+							'pr_url: "<url>" })` as your final action.',
+					},
+				},
+			],
+		},
+		{
+			id: CODING_DONE_NODE,
+			name: 'Done',
+			agents: [
+				{
+					agentId: 'Coder',
+					name: 'coder',
+					customPrompt: {
+						value:
+							'You are the Finalizer on the Done node of the Coding Workflow. You are only ' +
+							'reached after the Reviewer writes a structured approval (`approved: true`) on ' +
+							'the review-approval-gate — that gate is the sole authorization pathway.\n\n' +
+							'**Your ONLY job is to call `report_result(summary=...)` immediately.** Do not run ' +
+							'`gh pr merge`, `git merge`, `git push`, or any other tool. Do NOT pass a ' +
+							'`status` — the runtime decides the terminal state via completion actions. The ' +
+							"merge is performed by this node's `merge-pr` completion action after you report; " +
+							'at lower space autonomy levels it pauses for explicit human approval before ' +
+							'executing. Any merge you attempt yourself bypasses that checkpoint and will be ' +
+							'treated as an unauthorized merge.\n\n' +
+							'Summary format: a single short sentence acknowledging reviewer approval (e.g. ' +
+							'"Reviewer approved; handing off to merge-pr completion action.").',
 					},
 				},
 			],
@@ -463,7 +513,7 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 		},
 	],
 	startNodeId: CODING_CODE_NODE,
-	endNodeId: CODING_REVIEW_NODE,
+	endNodeId: CODING_DONE_NODE,
 	tags: ['coding', 'default'],
 	createdAt: 0,
 	updatedAt: 0,
@@ -509,6 +559,26 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 			},
 			resetOnCycle: true,
 		},
+		{
+			id: 'review-approval-gate',
+			label: 'Review Approved',
+			description:
+				'Reviewer has explicitly approved the PR by writing structured gate data ' +
+				'({approved: true}). A peer chat message is never sufficient — the gate opens ' +
+				'only when a `reviewer`-named agent writes the `approved` field. The merge ' +
+				"itself is further gated by the merge-pr completion action's requiredLevel, " +
+				'which pauses at `review` status for human approval at low space autonomy.',
+			fields: [
+				{
+					name: 'approved',
+					type: 'boolean',
+					writers: ['reviewer'],
+					check: { op: '==', value: true },
+				},
+			],
+			requiredLevel: 4,
+			resetOnCycle: true,
+		},
 	],
 	channels: [
 		{
@@ -523,6 +593,12 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 			gateId: 'review-posted-gate',
 			maxCycles: 5,
 			label: 'Review → Coding (changes requested)',
+		},
+		{
+			from: 'Review',
+			to: 'Done',
+			gateId: 'review-approval-gate',
+			label: 'Review → Done (approval)',
 		},
 	],
 };

--- a/packages/daemon/src/storage/schema/m94-backfill-workflow-templates.ts
+++ b/packages/daemon/src/storage/schema/m94-backfill-workflow-templates.ts
@@ -140,6 +140,11 @@ const MERGE_PR_COMPLETION_ACTION: CompletionActionShape = {
 // Coding+QA) and the migration falls back to the row's own hash.
 const PR_READY_SCRIPT_PREFIX = '# Prefer explicit PR URL from gate data JSON when available; fal';
 
+// First 64 chars of `REVIEW_POSTED_BASH_SCRIPT` (joined with \n). Used by the
+// Coding Workflow's review-posted-gate to verify a reviewer has posted a
+// GitHub review before the Review → Coding feedback channel releases.
+const REVIEW_POSTED_SCRIPT_PREFIX = 'PR_URL=$(jq -r \'.pr_url // empty\' <<< "${NEOKAI_GATE_DATA_JSON:-';
+
 /**
  * Known built-in templates and their fingerprints.
  * Order is not significant — matched by `name`.
@@ -148,13 +153,16 @@ const KNOWN_TEMPLATES: TemplateShape[] = [
 	{
 		name: 'Coding Workflow',
 		description:
-			'Iterative coding workflow with Coding ↔ Review loop. Engineer implements and opens a PR; Reviewer reviews and either requests changes or signals completion.',
+			'Iterative coding workflow with Coding ↔ Review loop and gated Done/merge. ' +
+			'Engineer implements and opens a PR; Reviewer reviews and either requests changes or ' +
+			'writes a structured approval that opens the merge gate.',
 		instructions: '',
-		nodeNames: ['Coding', 'Review'],
-		endNodeName: 'Review',
+		nodeNames: ['Coding', 'Review', 'Done'],
+		endNodeName: 'Done',
 		channels: [
 			{ from: 'Coding', to: 'Review' },
 			{ from: 'Review', to: 'Coding' },
+			{ from: 'Review', to: 'Done' },
 		],
 		gates: [
 			{
@@ -162,6 +170,18 @@ const KNOWN_TEMPLATES: TemplateShape[] = [
 				resetOnCycle: true,
 				fields: [{ name: 'pr_url', type: 'string', check: { op: 'exists' } }],
 				scriptSource: PR_READY_SCRIPT_PREFIX,
+			},
+			{
+				id: 'review-posted-gate',
+				resetOnCycle: true,
+				fields: [{ name: 'review_url', type: 'string', check: { op: 'exists' } }],
+				scriptSource: REVIEW_POSTED_SCRIPT_PREFIX,
+			},
+			{
+				id: 'review-approval-gate',
+				requiredLevel: 4,
+				resetOnCycle: true,
+				fields: [{ name: 'approved', type: 'boolean', check: { op: '==', value: true } }],
 			},
 		],
 		endNodeCompletionActions: [MERGE_PR_COMPLETION_ACTION],

--- a/packages/daemon/src/storage/schema/m94-backfill-workflow-templates.ts
+++ b/packages/daemon/src/storage/schema/m94-backfill-workflow-templates.ts
@@ -143,7 +143,8 @@ const PR_READY_SCRIPT_PREFIX = '# Prefer explicit PR URL from gate data JSON whe
 // First 64 chars of `REVIEW_POSTED_BASH_SCRIPT` (joined with \n). Used by the
 // Coding Workflow's review-posted-gate to verify a reviewer has posted a
 // GitHub review before the Review → Coding feedback channel releases.
-const REVIEW_POSTED_SCRIPT_PREFIX = 'PR_URL=$(jq -r \'.pr_url // empty\' <<< "${NEOKAI_GATE_DATA_JSON:-';
+const REVIEW_POSTED_SCRIPT_PREFIX =
+	"PR_URL=$(jq -r '.pr_url // empty' <<< \"${NEOKAI_GATE_DATA_JSON:-";
 
 /**
  * Known built-in templates and their fingerprints.

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-94_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-94_test.ts
@@ -144,15 +144,16 @@ function seedLegacyCodingWorkflow(
 		createdAt?: number;
 		/** Default false — null template_name simulates pre-M90 legacy rows. */
 		withTemplateFields?: boolean;
-		/** Default false — when true, end node has completionActions already. */
+		/** Default false — when true, end (Done) node has completionActions already. */
 		withCompletionActions?: boolean;
 	}
-): { workflowId: string; codingNodeId: string; reviewNodeId: string } {
+): { workflowId: string; codingNodeId: string; reviewNodeId: string; doneNodeId: string } {
 	const template = getBuiltInWorkflows().find((t) => t.name === 'Coding Workflow');
 	if (!template) throw new Error('Coding Workflow template missing');
 
 	const codingNodeId = `${opts.id}-n-coding`;
 	const reviewNodeId = `${opts.id}-n-review`;
+	const doneNodeId = `${opts.id}-n-done`;
 
 	insertWorkflow(db, {
 		id: opts.id,
@@ -162,7 +163,7 @@ function seedLegacyCodingWorkflow(
 		channels: template.channels ?? [],
 		gates: template.gates ?? [],
 		startNodeId: codingNodeId,
-		endNodeId: reviewNodeId,
+		endNodeId: doneNodeId,
 		templateName: opts.withTemplateFields ? template.name : null,
 		templateHash: opts.withTemplateFields ? computeWorkflowHash(template) : null,
 		createdAt: opts.createdAt,
@@ -175,11 +176,18 @@ function seedLegacyCodingWorkflow(
 		config: { agents: [{ agentId: 'a-coder', name: 'coder' }] },
 	});
 
-	const reviewConfig: Record<string, unknown> = {
-		agents: [{ agentId: 'a-reviewer', name: 'reviewer' }],
+	insertNode(db, {
+		id: reviewNodeId,
+		workflowId: opts.id,
+		name: 'Review',
+		config: { agents: [{ agentId: 'a-reviewer', name: 'reviewer' }] },
+	});
+
+	const doneConfig: Record<string, unknown> = {
+		agents: [{ agentId: 'a-coder', name: 'coder' }],
 	};
 	if (opts.withCompletionActions) {
-		reviewConfig.completionActions = [
+		doneConfig.completionActions = [
 			{
 				id: 'merge-pr',
 				name: 'Merge PR',
@@ -190,9 +198,9 @@ function seedLegacyCodingWorkflow(
 			},
 		];
 	}
-	insertNode(db, { id: reviewNodeId, workflowId: opts.id, name: 'Review', config: reviewConfig });
+	insertNode(db, { id: doneNodeId, workflowId: opts.id, name: 'Done', config: doneConfig });
 
-	return { workflowId: opts.id, codingNodeId, reviewNodeId };
+	return { workflowId: opts.id, codingNodeId, reviewNodeId, doneNodeId };
 }
 
 describe('Migration 94: backfill workflow template tracking & completion actions', () => {
@@ -276,6 +284,7 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 		const wfId = 'wf-diverged';
 		const codingId = 'n-d-coding';
 		const reviewId = 'n-d-review';
+		const doneId = 'n-d-done';
 		insertWorkflow(db, {
 			id: wfId,
 			spaceId: 'sp-1',
@@ -283,10 +292,11 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 			description: template.description + ' — user edited',
 			channels: template.channels ?? [],
 			gates: template.gates ?? [],
-			endNodeId: reviewId,
+			endNodeId: doneId,
 		});
 		insertNode(db, { id: codingId, workflowId: wfId, name: 'Coding' });
 		insertNode(db, { id: reviewId, workflowId: wfId, name: 'Review' });
+		insertNode(db, { id: doneId, workflowId: wfId, name: 'Done' });
 
 		runMigration94(db);
 
@@ -301,7 +311,7 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 	});
 
 	test('legacy Coding Workflow: sets template_name + canonical hash + injects merge-pr', () => {
-		const { workflowId, reviewNodeId } = seedLegacyCodingWorkflow(db, {
+		const { workflowId, doneNodeId } = seedLegacyCodingWorkflow(db, {
 			id: 'wf-1',
 			spaceId: 'sp-1',
 		});
@@ -315,7 +325,7 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 		expect(row.template_name).toBe('Coding Workflow');
 		expect(row.template_hash).toBe(expectedHash);
 
-		const cfg = readNodeConfig(db, reviewNodeId) as {
+		const cfg = readNodeConfig(db, doneNodeId) as {
 			completionActions?: Array<{ id: string; type: string; artifactType?: string }>;
 		};
 		expect(cfg.completionActions).toBeDefined();
@@ -387,18 +397,18 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 	});
 
 	test('idempotent — running twice yields the same result', () => {
-		const { workflowId, reviewNodeId } = seedLegacyCodingWorkflow(db, {
+		const { workflowId, doneNodeId } = seedLegacyCodingWorkflow(db, {
 			id: 'wf-idem',
 			spaceId: 'sp-1',
 		});
 
 		runMigration94(db);
 		const rowAfter1 = readWorkflow(db, workflowId)!;
-		const cfgAfter1 = readNodeConfig(db, reviewNodeId);
+		const cfgAfter1 = readNodeConfig(db, doneNodeId);
 
 		runMigration94(db);
 		const rowAfter2 = readWorkflow(db, workflowId)!;
-		const cfgAfter2 = readNodeConfig(db, reviewNodeId);
+		const cfgAfter2 = readNodeConfig(db, doneNodeId);
 
 		expect(rowAfter2).toEqual(rowAfter1);
 		expect(cfgAfter2).toEqual(cfgAfter1);
@@ -447,7 +457,7 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 	});
 
 	test('existing completionActions on end node preserved (no duplicate injection)', () => {
-		const { workflowId, reviewNodeId } = seedLegacyCodingWorkflow(db, {
+		const { workflowId, doneNodeId } = seedLegacyCodingWorkflow(db, {
 			id: 'wf-has-action',
 			spaceId: 'sp-1',
 			withCompletionActions: true, // already has merge-pr
@@ -455,7 +465,7 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 
 		runMigration94(db);
 
-		const cfg = readNodeConfig(db, reviewNodeId) as {
+		const cfg = readNodeConfig(db, doneNodeId) as {
 			completionActions?: Array<{ id: string; script?: string }>;
 		};
 		// Must not duplicate — already had a merge-pr with "# existing script".
@@ -599,7 +609,7 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 
 	test('row already backfilled is left alone (no redundant writes)', () => {
 		const template = getBuiltInWorkflows().find((t) => t.name === 'Coding Workflow')!;
-		const { workflowId, reviewNodeId } = seedLegacyCodingWorkflow(db, {
+		const { workflowId, doneNodeId } = seedLegacyCodingWorkflow(db, {
 			id: 'wf-already-backfilled',
 			spaceId: 'sp-1',
 			withTemplateFields: true,
@@ -607,12 +617,12 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 		});
 
 		const beforeRow = readWorkflow(db, workflowId)!;
-		const beforeCfg = readNodeConfig(db, reviewNodeId);
+		const beforeCfg = readNodeConfig(db, doneNodeId);
 
 		runMigration94(db);
 
 		const afterRow = readWorkflow(db, workflowId)!;
-		const afterCfg = readNodeConfig(db, reviewNodeId);
+		const afterCfg = readNodeConfig(db, doneNodeId);
 
 		expect(afterRow.template_name).toBe(template.name);
 		expect(afterRow.template_hash).toBe(computeWorkflowHash(template));

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -96,18 +96,21 @@ function hasLeaderAgentId(wf: SpaceWorkflow): boolean {
 // ---------------------------------------------------------------------------
 
 describe('CODING_WORKFLOW template', () => {
-	test('has two nodes: Coding, Review', () => {
-		expect(CODING_WORKFLOW.nodes).toHaveLength(2);
-		expect(CODING_WORKFLOW.nodes.map((s) => s.name)).toEqual(['Coding', 'Review']);
+	test('has three nodes: Coding, Review, Done', () => {
+		expect(CODING_WORKFLOW.nodes).toHaveLength(3);
+		expect(CODING_WORKFLOW.nodes.map((s) => s.name)).toEqual(['Coding', 'Review', 'Done']);
 	});
 
 	test('step agentId placeholders are correct', () => {
 		expect(CODING_WORKFLOW.nodes[0].agents[0]?.name).toBe('coder');
 		expect(CODING_WORKFLOW.nodes[1].agents[0]?.name).toBe('reviewer');
+		// Done node reuses the Coder preset as a finalizer — its prompt allows
+		// only `report_result`; the merge itself runs as a completion action.
+		expect(CODING_WORKFLOW.nodes[2].agents[0]?.name).toBe('coder');
 	});
 
-	test('has two channels', () => {
-		expect(CODING_WORKFLOW.channels).toHaveLength(2);
+	test('has three channels: Coding→Review (gated), Review→Coding (cycle), Review→Done (gated)', () => {
+		expect(CODING_WORKFLOW.channels).toHaveLength(3);
 	});
 
 	test('Coding → Review channel is gated by code-ready-gate', () => {
@@ -128,6 +131,14 @@ describe('CODING_WORKFLOW template', () => {
 		expect(ch!.maxCycles).toBe(5);
 	});
 
+	test('Review → Done channel is gated by review-approval-gate', () => {
+		const ch = CODING_WORKFLOW.channels!.find((c) => c.from === 'Review' && c.to === 'Done');
+		expect(ch).toBeDefined();
+		expect(ch!.gateId).toBe('review-approval-gate');
+		// One-shot approval handoff, not a cycle.
+		expect(ch!.maxCycles).toBeUndefined();
+	});
+
 	test('all channels have direction one-way', () => {
 		for (const ch of CODING_WORKFLOW.channels!) {
 			expect('direction' in ch).toBe(false); // direction field removed
@@ -142,10 +153,10 @@ describe('CODING_WORKFLOW template', () => {
 		}
 	});
 
-	test('has two gates: code-ready-gate and review-posted-gate', () => {
-		expect(CODING_WORKFLOW.gates).toHaveLength(2);
+	test('has three gates: code-ready-gate, review-posted-gate and review-approval-gate', () => {
+		expect(CODING_WORKFLOW.gates).toHaveLength(3);
 		const gateIds = CODING_WORKFLOW.gates!.map((g) => g.id).sort();
-		expect(gateIds).toEqual(['code-ready-gate', 'review-posted-gate']);
+		expect(gateIds).toEqual(['code-ready-gate', 'review-approval-gate', 'review-posted-gate']);
 		for (const gate of CODING_WORKFLOW.gates!) {
 			expect(gate.fields).toHaveLength(1);
 		}
@@ -183,7 +194,7 @@ describe('CODING_WORKFLOW template', () => {
 
 	test('code-ready-gate has pr_url field writable only by Coding', () => {
 		const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'code-ready-gate')!;
-		const prField = gate.fields.find((f) => f.name === 'pr_url')!;
+		const prField = gate.fields!.find((f) => f.name === 'pr_url')!;
 		expect(prField.type).toBe('string');
 		expect(prField.writers).toEqual(['Coding']);
 		expect(prField.check.op).toBe('exists');
@@ -213,19 +224,96 @@ describe('CODING_WORKFLOW template', () => {
 		expect(gate.resetOnCycle).toBe(true);
 	});
 
+	test('review-approval-gate has approved:boolean field writable only by reviewer', () => {
+		const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-approval-gate')!;
+		expect(gate.fields).toHaveLength(1);
+		const approvedField = gate.fields!.find((f) => f.name === 'approved')!;
+		expect(approvedField.type).toBe('boolean');
+		expect(approvedField.writers).toEqual(['reviewer']);
+		expect(approvedField.check.op).toBe('==');
+		if (approvedField.check.op === '==') {
+			expect(approvedField.check.value).toBe(true);
+		}
+	});
+
+	test('review-approval-gate has requiredLevel >= 4 so low-autonomy spaces cannot auto-approve', () => {
+		const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-approval-gate')!;
+		// At space autonomy level 3, reviewer must explicitly write; autonomy-based
+		// auto-approval requires level >= 4.
+		expect(gate.requiredLevel).toBeGreaterThanOrEqual(4);
+	});
+
+	test('review-approval-gate resets on cycle so reviewer must re-approve each round', () => {
+		const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-approval-gate')!;
+		expect(gate.resetOnCycle).toBe(true);
+	});
+
 	test('startNodeId points to the Coding step', () => {
 		const codeStep = CODING_WORKFLOW.nodes.find((s) => s.agents[0]?.name === 'coder');
 		expect(CODING_WORKFLOW.startNodeId).toBe(codeStep?.id);
 	});
 
-	test('endNodeId points to the Review step', () => {
-		const reviewStep = CODING_WORKFLOW.nodes.find((s) => s.name === 'Review');
-		expect(CODING_WORKFLOW.endNodeId).toBe(reviewStep?.id);
+	test('endNodeId points to the Done step', () => {
+		const doneStep = CODING_WORKFLOW.nodes.find((s) => s.name === 'Done');
+		expect(CODING_WORKFLOW.endNodeId).toBe(doneStep?.id);
 	});
 
 	test('endNodeId references a valid node in the graph', () => {
 		const nodeIds = new Set(CODING_WORKFLOW.nodes.map((n) => n.id));
 		expect(nodeIds.has(CODING_WORKFLOW.endNodeId!)).toBe(true);
+	});
+
+	test('merge-pr completion action is attached to Done node only', () => {
+		const coding = CODING_WORKFLOW.nodes.find((n) => n.name === 'Coding')!;
+		const review = CODING_WORKFLOW.nodes.find((n) => n.name === 'Review')!;
+		const done = CODING_WORKFLOW.nodes.find((n) => n.name === 'Done')!;
+
+		expect(coding.completionActions ?? []).toHaveLength(0);
+		// Review must NOT carry the merge action — otherwise Reviewer could
+		// trigger the merge by calling report_result directly.
+		expect(review.completionActions ?? []).toHaveLength(0);
+
+		expect(done.completionActions).toBeDefined();
+		expect(done.completionActions).toHaveLength(1);
+		const mergeAction = done.completionActions![0];
+		expect(mergeAction.id).toBe('merge-pr');
+		expect(mergeAction.type).toBe('script');
+		// Merge must not auto-execute at space autonomy level 3 — requiredLevel >= 4
+		// guarantees a human-approval pause via the completion-action checkpoint.
+		expect(mergeAction.requiredLevel).toBeGreaterThanOrEqual(4);
+	});
+
+	test('Coder prompt forbids merge commands (no self-merge)', () => {
+		const coder = CODING_WORKFLOW.nodes.find((n) => n.name === 'Coding')!.agents[0];
+		const prompt = coder.customPrompt?.value ?? '';
+		// Must explicitly deny merge authority rather than implicitly rely on prompt silence.
+		expect(prompt).toMatch(/do NOT have merge authority/i);
+		// Must explicitly prohibit the merge commands by name, not just implicitly.
+		expect(prompt).toMatch(/must not run `gh pr merge`/);
+		expect(prompt).toContain('git merge');
+		// Must explain WHY — the merge is done by the Done node, not the coder.
+		expect(prompt).toMatch(/merge is performed automatically by the Done node/i);
+	});
+
+	test('Reviewer prompt approves via structured gate data, not report_result', () => {
+		const reviewer = CODING_WORKFLOW.nodes.find((n) => n.name === 'Review')!.agents[0];
+		const prompt = reviewer.customPrompt?.value ?? '';
+		// Reviewer must open the gate via send_message data, not via chat or report_result.
+		expect(prompt).toContain('review-approval-gate');
+		expect(prompt).toMatch(/approved:\s*true/);
+		expect(prompt).toMatch(/send_message\(target="Done"/);
+		// Reviewer must be explicitly told NOT to call report_result.
+		expect(prompt).toMatch(/Do NOT call `report_result`/);
+		// Reviewer must be told NOT to run merge commands herself.
+		expect(prompt).toMatch(/Do NOT run `gh pr merge`/);
+	});
+
+	test('Done node agent prompt only calls report_result (no merge tools)', () => {
+		const done = CODING_WORKFLOW.nodes.find((n) => n.name === 'Done')!.agents[0];
+		const prompt = done.customPrompt?.value ?? '';
+		expect(prompt).toMatch(/report_result/);
+		// Done must NOT run merge itself — it delegates to the completion action.
+		expect(prompt).toMatch(/merge is performed by this node'?s `merge-pr`/i);
 	});
 
 	test('does not reference leader', () => {
@@ -808,19 +896,21 @@ describe('seedBuiltInWorkflows()', () => {
 		}
 	});
 
-	test('CODING_WORKFLOW seeded correctly — two nodes with real agent IDs', async () => {
+	test('CODING_WORKFLOW seeded correctly — three nodes with real agent IDs', async () => {
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name);
 		expect(wf).toBeDefined();
-		expect(wf!.nodes).toHaveLength(2);
+		expect(wf!.nodes).toHaveLength(3);
 		expect(wf!.nodes[0].agents[0]?.agentId).toBe(CODER_ID);
 		expect(wf!.nodes[1].agents[0]?.agentId).toBe(roleMap.reviewer);
+		// Done node reuses Coder as finalizer.
+		expect(wf!.nodes[2].agents[0]?.agentId).toBe(CODER_ID);
 	});
 
-	test('CODING_WORKFLOW seeded with two channels (gated Coding→Review, gated Review→Coding)', async () => {
+	test('CODING_WORKFLOW seeded with three channels (Coding→Review gated, Review→Coding gated, Review→Done gated)', async () => {
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
-		expect(wf.channels).toHaveLength(2);
+		expect(wf.channels).toHaveLength(3);
 
 		const codeToReview = wf.channels!.find((c) => c.from === 'Coding' && c.to === 'Review');
 		expect(codeToReview).toBeDefined();
@@ -832,14 +922,36 @@ describe('seedBuiltInWorkflows()', () => {
 		// message cannot be delivered until a GitHub review is visible.
 		expect(reviewToCode!.gateId).toBe('review-posted-gate');
 		expect(reviewToCode!.maxCycles).toBe(5);
+
+		const reviewToDone = wf.channels!.find((c) => c.from === 'Review' && c.to === 'Done');
+		expect(reviewToDone).toBeDefined();
+		expect(reviewToDone!.gateId).toBe('review-approval-gate');
 	});
 
-	test('CODING_WORKFLOW seeded with two gates (code-ready-gate + review-posted-gate)', async () => {
+	test('CODING_WORKFLOW seeded with three gates (code-ready-gate, review-posted-gate, review-approval-gate)', async () => {
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
-		expect(wf.gates).toHaveLength(2);
+		expect(wf.gates).toHaveLength(3);
 		const gateIds = wf.gates!.map((g) => g.id).sort();
-		expect(gateIds).toEqual(['code-ready-gate', 'review-posted-gate']);
+		expect(gateIds).toEqual(['code-ready-gate', 'review-approval-gate', 'review-posted-gate']);
+	});
+
+	test('CODING_WORKFLOW seeded with merge-pr completion action on Done node only', async () => {
+		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
+		const coding = wf.nodes.find((n) => n.name === 'Coding')!;
+		const review = wf.nodes.find((n) => n.name === 'Review')!;
+		const done = wf.nodes.find((n) => n.name === 'Done')!;
+
+		expect(coding.completionActions ?? []).toHaveLength(0);
+		expect(review.completionActions ?? []).toHaveLength(0);
+		expect(done.completionActions).toBeDefined();
+		expect(done.completionActions).toHaveLength(1);
+		expect(done.completionActions![0].id).toBe('merge-pr');
+		expect(done.completionActions![0].requiredLevel).toBeGreaterThanOrEqual(4);
+
+		// endNodeId points to Done node.
+		expect(wf.endNodeId).toBe(done.id);
 	});
 
 	test('CODING_WORKFLOW seeded channels all have direction one-way', async () => {
@@ -1262,7 +1374,10 @@ describe('seedBuiltInWorkflows()', () => {
 		const codeNode = wf.nodes.find((n) => n.name === 'Coding');
 		expect(codeNode?.agents[0].customPrompt?.value).toContain('gh pr create');
 		const reviewNode = wf.nodes.find((n) => n.name === 'Review');
-		expect(reviewNode?.agents[0].customPrompt?.value).toContain('report_result(');
+		// Reviewer approves via structured gate data, not report_result.
+		expect(reviewNode?.agents[0].customPrompt?.value).toContain('review-approval-gate');
+		const doneNode = wf.nodes.find((n) => n.name === 'Done');
+		expect(doneNode?.agents[0].customPrompt?.value).toContain('report_result');
 	});
 
 	test('PLAN_AND_DECOMPOSE_WORKFLOW seeded nodes preserve customPrompt content', () => {
@@ -1301,6 +1416,22 @@ describe('seedBuiltInWorkflows()', () => {
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === REVIEW_ONLY_WORKFLOW.name)!;
 		expect(wf.gates ?? []).toHaveLength(0);
+	});
+
+	test('CODING_WORKFLOW seeded review-approval-gate has reviewer writers + requiredLevel', () => {
+		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
+		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
+		const gate = wf.gates!.find((g) => g.id === 'review-approval-gate');
+		expect(gate).toBeDefined();
+		expect(gate!.fields).toHaveLength(1);
+		const approved = gate!.fields!.find((f) => f.name === 'approved')!;
+		expect(approved.type).toBe('boolean');
+		expect(approved.writers).toEqual(['reviewer']);
+		if (approved.check.op === '==') {
+			expect(approved.check.value).toBe(true);
+		}
+		expect(gate!.requiredLevel).toBeGreaterThanOrEqual(4);
+		expect(gate!.resetOnCycle).toBe(true);
 	});
 
 	test('CODING_WORKFLOW gate fields are preserved during seeding', () => {
@@ -1649,18 +1780,21 @@ describe('Coding Workflow export/import round-trip', () => {
 		expect(result.ok).toBe(true);
 	});
 
-	test('exported Coding Workflow preserves two channels and Review→Coding cycle', () => {
+	test('exported Coding Workflow preserves three channels and Review→Coding cycle', () => {
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const wf = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
 
 		const exported = exportWorkflow(wf, mockAgents);
 		expect(exported.channels).toBeDefined();
 		// gateId is stripped during export (gates are separate entities)
-		expect(exported.channels).toHaveLength(2);
+		expect(exported.channels).toHaveLength(3);
 
 		const reviewToCode = exported.channels!.find((c) => c.from === 'Review' && c.to === 'Coding');
 		expect(reviewToCode).toBeDefined();
 		expect(reviewToCode!.maxCycles).toBe(5);
+
+		const reviewToDone = exported.channels!.find((c) => c.from === 'Review' && c.to === 'Done');
+		expect(reviewToDone).toBeDefined();
 	});
 
 	test('exported Coding Workflow channels do not include gate field (gates are separate entities)', () => {
@@ -1712,8 +1846,11 @@ describe('Coding Workflow export/import round-trip', () => {
 			.listWorkflows(SPACE_ID)
 			.find((w) => w.name === CODING_WORKFLOW.name)!;
 		expect(reimported).toBeDefined();
-		expect(reimported.nodes).toHaveLength(2);
-		expect(reimported.channels).toHaveLength(2);
+		// Three nodes: Coding, Review, Done (merge-authority separation).
+		expect(reimported.nodes).toHaveLength(3);
+		expect(reimported.nodes.map((n) => n.name)).toEqual(['Coding', 'Review', 'Done']);
+		// Three channels: Coding→Review (gated), Review→Coding (cycle), Review→Done (gated).
+		expect(reimported.channels).toHaveLength(3);
 
 		// Coding → Review channel preserved
 		const codeToReview = reimported.channels!.find((c) => c.from === 'Coding' && c.to === 'Review');
@@ -1723,6 +1860,10 @@ describe('Coding Workflow export/import round-trip', () => {
 		const reviewToCode = reimported.channels!.find((c) => c.from === 'Review' && c.to === 'Coding');
 		expect(reviewToCode).toBeDefined();
 		expect(reviewToCode!.maxCycles).toBe(5);
+
+		// Review → Done channel preserved (approval handoff)
+		const reviewToDone = reimported.channels!.find((c) => c.from === 'Review' && c.to === 'Done');
+		expect(reviewToDone).toBeDefined();
 	});
 });
 
@@ -1783,11 +1924,23 @@ describe('CODING_WORKFLOW agent slot customPrompt', () => {
 		expect(prompt).toContain('/replies');
 	});
 
-	test('Review node reviewer has non-empty customPrompt', () => {
+	test('Review node reviewer has non-empty customPrompt that hands off via approval gate', () => {
 		const reviewNode = CODING_WORKFLOW.nodes.find((n) => n.name === 'Review')!;
 		const reviewer = reviewNode.agents[0];
 		expect(reviewer.customPrompt?.value).toBeDefined();
-		expect(reviewer.customPrompt?.value).toContain('report_result');
+		expect(reviewer.customPrompt?.value.trim().length).toBeGreaterThan(0);
+		// Reviewer completes the workflow by writing the approval gate, not by
+		// calling report_result. The Done node is the only node that reports done.
+		expect(reviewer.customPrompt?.value).toContain('review-approval-gate');
+		expect(reviewer.customPrompt?.value).toMatch(/approved:\s*true/);
+	});
+
+	test('Done node agent has non-empty customPrompt that ends with report_result', () => {
+		const doneNode = CODING_WORKFLOW.nodes.find((n) => n.name === 'Done')!;
+		const done = doneNode.agents[0];
+		expect(done.customPrompt?.value).toBeDefined();
+		expect(done.customPrompt?.value.trim().length).toBeGreaterThan(0);
+		expect(done.customPrompt?.value).toContain('report_result');
 	});
 
 	test('Review node reviewer customPrompt requires posting to GitHub and echoing review_url', () => {

--- a/packages/daemon/tests/unit/5-space/workflow/coding-workflow-merge-authority.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/coding-workflow-merge-authority.test.ts
@@ -290,7 +290,46 @@ describe('CODING_WORKFLOW Done node — merge-pr completion action (Task #41 Bug
 	test('at autonomy 4, Done node task proceeds — merge action auto-executes (exits review)', async () => {
 		setAutonomyLevel(4);
 		const rt = makeRuntime();
-		const workflow = buildWorkflowWithMergeAction();
+
+		// Build a workflow whose end-node carries a stand-in completion action with
+		// the same `requiredLevel` as the real merge-pr action. We intentionally do
+		// NOT use the real merge-pr script here — its `gh pr merge` fallback can
+		// reach outside the sandbox (e.g. pick up the CWD's git remote) and tries
+		// to merge an actual PR. The lifecycle invariant under test is pure: at
+		// autonomy >= requiredLevel, the action must auto-execute and the task
+		// must NOT park at `pendingCheckpointType === 'completion_action'`.
+		const endNodeId = 'done-node';
+		const workflow = workflowManager.createWorkflow({
+			spaceId: SPACE_ID,
+			name: `Merge Authority Auto ${Date.now()}`,
+			description: '',
+			nodes: [
+				{
+					id: endNodeId,
+					name: 'Done',
+					agents: [{ agentId: AGENT_ID, name: 'coder' }],
+					completionActions: [
+						{
+							id: 'merge-pr',
+							type: 'script',
+							requiredLevel: extractMergePrAction().requiredLevel,
+							label: 'Merge PR (test stand-in)',
+							description: 'No-op stand-in used to avoid real `gh pr merge` in tests.',
+							script: {
+								interpreter: 'bash',
+								source: 'echo "stand-in merge ok"',
+								timeoutMs: 2000,
+							},
+						},
+					],
+				},
+			],
+			transitions: [],
+			startNodeId: endNodeId,
+			endNodeId,
+			rules: [],
+			tags: [],
+		});
 
 		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
 		taskRepo.updateTask(tasks[0].id, {
@@ -303,10 +342,9 @@ describe('CODING_WORKFLOW Done node — merge-pr completion action (Task #41 Bug
 		await rt.executeTick();
 
 		const task = taskRepo.getTask(tasks[0].id)!;
-		// At autonomy >= requiredLevel the action auto-executes. It may succeed or
-		// fail (depending on whether gh/jq are available in this sandbox), but it
-		// MUST NOT leave the task parked at `review` with pendingCheckpointType set
-		// — that would mean the pause logic ignored the autonomy level.
+		// At autonomy >= requiredLevel the action auto-executes. It MUST NOT leave
+		// the task parked at `review` with pendingCheckpointType set — that would
+		// mean the pause logic ignored the autonomy level.
 		expect(task.pendingCheckpointType).not.toBe('completion_action');
 	});
 });

--- a/packages/daemon/tests/unit/5-space/workflow/coding-workflow-merge-authority.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/coding-workflow-merge-authority.test.ts
@@ -1,0 +1,600 @@
+/**
+ * CODING_WORKFLOW — Merge-Authority Separation Tests (Task #41)
+ *
+ * End-to-end wiring tests that prove the two Task #41 bug fixes actually
+ * plug into the runtime mechanisms:
+ *
+ * Bug A (unauthorized merge): A peer chat `send_message` with no `data`
+ *   payload must NOT open the review-approval-gate. Only a structured
+ *   `data: { approved: true }` write (by the `reviewer` agent) opens it.
+ *   We exercise this against the real CODING_WORKFLOW gate + channel.
+ *
+ * Bug B (task lifecycle): When the Reviewer's approval gate opens and the
+ *   Done node's `merge-pr` completion action has requiredLevel > space
+ *   autonomy, the task must transition to `status: 'review'` with
+ *   `pendingCheckpointType: 'completion_action'`. We assert this with the
+ *   real MERGE_PR_COMPLETION_ACTION extracted from CODING_WORKFLOW's Done
+ *   node.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { createTables, runMigrations } from '../../../../src/storage/schema/index.ts';
+import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
+import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
+import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
+import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
+import { SpaceRuntime } from '../../../../src/lib/space/runtime/space-runtime.ts';
+import type { SpaceRuntimeConfig } from '../../../../src/lib/space/runtime/space-runtime.ts';
+import type {
+	NotificationSink,
+	SpaceNotificationEvent,
+} from '../../../../src/lib/space/runtime/notification-sink.ts';
+import type {
+	SpaceTask,
+	SpaceWorkflowRun,
+	SpaceWorkflow,
+	Space,
+	SpaceAutonomyLevel,
+	CompletionAction,
+	Gate,
+} from '@neokai/shared';
+import type { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
+import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
+import { GateDataRepository } from '../../../../src/storage/repositories/gate-data-repository.ts';
+import { createNodeAgentToolHandlers } from '../../../../src/lib/space/tools/node-agent-tools.ts';
+import { AgentMessageRouter } from '../../../../src/lib/space/runtime/agent-message-router.ts';
+import { ChannelResolver } from '../../../../src/lib/space/runtime/channel-resolver.ts';
+import { CODING_WORKFLOW } from '../../../../src/lib/space/workflows/built-in-workflows.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers (trimmed copies of the patterns used by space-runtime-completion-actions.test.ts
+// and node-agent-tools.test.ts — kept local so the two test suites stay independent).
+// ---------------------------------------------------------------------------
+
+class MockNotificationSink implements NotificationSink {
+	readonly events: SpaceNotificationEvent[] = [];
+	notify(event: SpaceNotificationEvent): Promise<void> {
+		this.events.push(event);
+		return Promise.resolve();
+	}
+}
+
+class MockTaskAgentManager {
+	isTaskAgentAlive(_taskId: string): boolean {
+		return false;
+	}
+	isSpawning(_taskId: string): boolean {
+		return false;
+	}
+	isExecutionSpawning(_executionId: string): boolean {
+		return false;
+	}
+	isSessionAlive(_sessionId: string): boolean {
+		return false;
+	}
+	async spawnWorkflowNodeAgent(
+		_task: SpaceTask,
+		_space: Space,
+		_workflow: SpaceWorkflow | null,
+		_run: SpaceWorkflowRun | null
+	): Promise<string> {
+		return 'mock-session';
+	}
+	async spawnWorkflowNodeAgentForExecution(
+		_task: SpaceTask,
+		_space: Space,
+		_workflow: SpaceWorkflow,
+		_run: SpaceWorkflowRun,
+		execution: { id: string }
+	): Promise<string> {
+		return `mock-session:${execution.id}`;
+	}
+	async rehydrate(): Promise<void> {}
+	cancelBySessionId(_agentSessionId: string): void {}
+	async interruptBySessionId(_agentSessionId: string): Promise<void> {}
+}
+
+function makeDb(prefix: string): { db: BunDatabase; dir: string } {
+	const dir = join(
+		process.cwd(),
+		'tmp',
+		prefix,
+		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
+	);
+	mkdirSync(dir, { recursive: true });
+	const db = new BunDatabase(join(dir, 'test.db'));
+	db.exec('PRAGMA foreign_keys = ON');
+	createTables(db);
+	runMigrations(db, () => {});
+	return { db, dir };
+}
+
+function seedSpaceRow(
+	db: BunDatabase,
+	spaceId: string,
+	workspacePath = '/tmp/workspace',
+	autonomyLevel: SpaceAutonomyLevel = 1
+): void {
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, slug, status, autonomy_level, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, spaceId, autonomyLevel, Date.now(), Date.now());
+}
+
+function seedAgentRow(db: BunDatabase, agentId: string, spaceId: string, name: string): void {
+	db.prepare(
+		`INSERT INTO space_agents (id, space_id, name, description, model, tools, system_prompt, created_at, updated_at)
+     VALUES (?, ?, ?, '', null, '[]', '', ?, ?)`
+	).run(agentId, spaceId, name, Date.now(), Date.now());
+}
+
+function seedNodeExec(
+	db: BunDatabase,
+	workflowRunId: string,
+	workflowNodeId: string,
+	agentName: string,
+	status: string
+): void {
+	const id = `exec-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+	const now = Date.now();
+	db.prepare(
+		`INSERT OR REPLACE INTO node_executions
+       (id, workflow_run_id, workflow_node_id, agent_name, agent_id,
+        agent_session_id, status, result, created_at, started_at,
+        completed_at, updated_at)
+       VALUES (?, ?, ?, ?, NULL, NULL, ?, NULL, ?, NULL, NULL, ?)`
+	).run(id, workflowRunId, workflowNodeId, agentName, status, now, now);
+}
+
+// ---------------------------------------------------------------------------
+// Bug B — Task pauses at `review` when merge-pr requiredLevel > space level
+// ---------------------------------------------------------------------------
+
+describe('CODING_WORKFLOW Done node — merge-pr completion action (Task #41 Bug B)', () => {
+	let db: BunDatabase;
+	let dir: string;
+	let workflowRunRepo: SpaceWorkflowRunRepository;
+	let taskRepo: SpaceTaskRepository;
+	let agentManager: SpaceAgentManager;
+	let workflowManager: SpaceWorkflowManager;
+	let spaceManager: SpaceManager;
+	let sink: MockNotificationSink;
+
+	const SPACE_ID = 'space-ca-merge';
+	const AGENT_ID = 'agent-coder';
+
+	function makeRuntime(extraConfig?: Partial<SpaceRuntimeConfig>): SpaceRuntime {
+		const config: SpaceRuntimeConfig = {
+			db,
+			spaceManager,
+			spaceAgentManager: agentManager,
+			spaceWorkflowManager: workflowManager,
+			workflowRunRepo,
+			taskRepo,
+			nodeExecutionRepo: new NodeExecutionRepository(db),
+			notificationSink: sink,
+			taskAgentManager: new MockTaskAgentManager() as unknown as TaskAgentManager,
+			...extraConfig,
+		};
+		return new SpaceRuntime(config);
+	}
+
+	function setAutonomyLevel(level: SpaceAutonomyLevel): void {
+		db.prepare(`UPDATE spaces SET autonomy_level = ? WHERE id = ?`).run(level, SPACE_ID);
+	}
+
+	beforeEach(() => {
+		({ db, dir } = makeDb('test-coding-workflow-merge-authority'));
+		seedSpaceRow(db, SPACE_ID, dir, 1);
+		seedAgentRow(db, AGENT_ID, SPACE_ID, 'Coder');
+
+		workflowRunRepo = new SpaceWorkflowRunRepository(db);
+		taskRepo = new SpaceTaskRepository(db);
+
+		const agentRepo = new SpaceAgentRepository(db);
+		agentManager = new SpaceAgentManager(agentRepo);
+
+		const workflowRepo = new SpaceWorkflowRepository(db);
+		workflowManager = new SpaceWorkflowManager(workflowRepo);
+
+		spaceManager = new SpaceManager(db);
+		sink = new MockNotificationSink();
+	});
+
+	afterEach(() => {
+		try {
+			db?.close();
+		} catch {
+			/* ignore */
+		}
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	/** Extract the real merge-pr completion action from the CODING_WORKFLOW template. */
+	function extractMergePrAction(): CompletionAction {
+		const doneNode = CODING_WORKFLOW.nodes.find((n) => n.name === 'Done');
+		expect(doneNode).toBeDefined();
+		expect(doneNode!.completionActions).toBeDefined();
+		expect(doneNode!.completionActions).toHaveLength(1);
+		return doneNode!.completionActions![0];
+	}
+
+	/** Build a minimal workflow with a single end-node carrying the merge-pr action. */
+	function buildWorkflowWithMergeAction(): SpaceWorkflow {
+		const endNodeId = 'done-node';
+		return workflowManager.createWorkflow({
+			spaceId: SPACE_ID,
+			name: `Merge Authority ${Date.now()}`,
+			description: '',
+			nodes: [
+				{
+					id: endNodeId,
+					name: 'Done',
+					agents: [{ agentId: AGENT_ID, name: 'coder' }],
+					completionActions: [extractMergePrAction()],
+				},
+			],
+			transitions: [],
+			startNodeId: endNodeId,
+			endNodeId,
+			rules: [],
+			tags: [],
+		});
+	}
+
+	test('merge-pr completion action in CODING_WORKFLOW has requiredLevel 4', () => {
+		const action = extractMergePrAction();
+		expect(action.id).toBe('merge-pr');
+		// Below 4 means auto-execute at autonomy 3 (too permissive); 4+ forces pause.
+		expect(action.requiredLevel).toBe(4);
+		expect(action.type).toBe('script');
+	});
+
+	test('at autonomy 3, Done node task pauses at `review` awaiting human merge approval', async () => {
+		setAutonomyLevel(3);
+		const rt = makeRuntime();
+		const workflow = buildWorkflowWithMergeAction();
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		// Simulate the Done node agent reporting done.
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'Reviewer approved; handing off to merge-pr completion action.',
+		});
+		seedNodeExec(db, run.id, 'done-node', 'coder', 'idle');
+
+		await rt.executeTick();
+
+		const task = taskRepo.getTask(tasks[0].id)!;
+		// Core Bug B contract: task moves to `review`, not directly to `done`.
+		expect(task.status).toBe('review');
+		// The pause reason is a pending completion action, not (e.g.) a leveled gate.
+		expect(task.pendingCheckpointType).toBe('completion_action');
+		expect(task.pendingActionIndex).toBe(0);
+		// Must not have flipped to `done` — the merge hasn't run.
+		expect(task.completedAt).toBeNull();
+	});
+
+	test('at autonomy 4, Done node task proceeds — merge action auto-executes (exits review)', async () => {
+		setAutonomyLevel(4);
+		const rt = makeRuntime();
+		const workflow = buildWorkflowWithMergeAction();
+
+		const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+		taskRepo.updateTask(tasks[0].id, {
+			status: 'in_progress',
+			reportedStatus: 'done',
+			reportedSummary: 'Reviewer approved.',
+		});
+		seedNodeExec(db, run.id, 'done-node', 'coder', 'idle');
+
+		await rt.executeTick();
+
+		const task = taskRepo.getTask(tasks[0].id)!;
+		// At autonomy >= requiredLevel the action auto-executes. It may succeed or
+		// fail (depending on whether gh/jq are available in this sandbox), but it
+		// MUST NOT leave the task parked at `review` with pendingCheckpointType set
+		// — that would mean the pause logic ignored the autonomy level.
+		expect(task.pendingCheckpointType).not.toBe('completion_action');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Bug A — send_message with chat only must NOT open review-approval-gate
+// ---------------------------------------------------------------------------
+
+describe('CODING_WORKFLOW review-approval-gate — send_message authorization (Task #41 Bug A)', () => {
+	const spaceId = 'space-approval-gate';
+	const workflowRunId = 'run-approval-gate';
+	const nodeId = 'node-review';
+	const reviewerSessionId = 'session-reviewer';
+	const doneSessionId = 'session-done';
+
+	let db: BunDatabase;
+	let dir: string;
+	let gateDataRepo: GateDataRepository;
+	let nodeExecutionRepo: NodeExecutionRepository;
+	let taskRepo: SpaceTaskRepository;
+
+	function extractReviewApprovalGate(): Gate {
+		const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-approval-gate');
+		expect(gate).toBeDefined();
+		return gate!;
+	}
+
+	function buildReviewToDoneWorkflow(): SpaceWorkflow {
+		const approvalGate = extractReviewApprovalGate();
+		return {
+			id: 'wf-review-to-done',
+			spaceId,
+			name: 'Coding Workflow fragment',
+			description: '',
+			nodes: [],
+			startNodeId: '',
+			rules: [],
+			tags: [],
+			channels: [
+				{
+					id: 'ch-review-done',
+					from: 'reviewer',
+					to: 'Done',
+					gateId: approvalGate.id,
+				},
+			],
+			gates: [approvalGate],
+		};
+	}
+
+	function seedSpaceAndPeers(): void {
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+       allowed_models, session_ids, slug, status, created_at, updated_at)
+       VALUES (?, '/tmp', ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+		).run(spaceId, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
+
+		db.prepare(
+			`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at, updated_at)
+         VALUES (?, ?, 'wf-review-to-done', '', 'pending', ?, ?)`
+		).run(workflowRunId, spaceId, Date.now(), Date.now());
+
+		// Seed peer tasks: reviewer (self) and Done.
+		const seedTask = (agentName: string, sessionId: string): void => {
+			const taskId = `task-${agentName}-${Math.random().toString(36).slice(2)}`;
+			const now = Date.now();
+			db.exec('PRAGMA foreign_keys = OFF');
+			db.prepare(
+				`INSERT INTO space_tasks
+           (id, space_id, task_number, title, description, status, priority, result,
+            workflow_run_id, depends_on, task_agent_session_id, created_at, updated_at)
+           VALUES (?, ?,
+             (SELECT COALESCE(MAX(task_number), 0) + 1 FROM space_tasks WHERE space_id = ?),
+             ?, '', 'in_progress', 'normal', NULL, ?, '[]', ?, ?, ?)`
+			).run(taskId, spaceId, spaceId, agentName, workflowRunId, sessionId, now, now);
+			db.exec('PRAGMA foreign_keys = ON');
+			nodeExecutionRepo.createOrIgnore({
+				workflowRunId,
+				workflowNodeId: nodeId,
+				agentName,
+				agentSessionId: sessionId,
+				status: 'in_progress',
+			});
+		};
+
+		seedTask('reviewer', reviewerSessionId);
+		seedTask('Done', doneSessionId);
+	}
+
+	beforeEach(() => {
+		({ db, dir } = makeDb('test-coding-workflow-approval-gate'));
+		gateDataRepo = new GateDataRepository(db);
+		nodeExecutionRepo = new NodeExecutionRepository(db);
+		taskRepo = new SpaceTaskRepository(db);
+		seedSpaceAndPeers();
+	});
+
+	afterEach(() => {
+		try {
+			db?.close();
+		} catch {
+			/* ignore */
+		}
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	test('review-approval-gate exists and has reviewer-only writers (sanity check)', () => {
+		const gate = extractReviewApprovalGate();
+		const approved = gate.fields!.find((f) => f.name === 'approved')!;
+		expect(approved.writers).toEqual(['reviewer']);
+		expect(gate.requiredLevel).toBeGreaterThanOrEqual(4);
+	});
+
+	test('reviewer sending chat-only send_message does NOT open review-approval-gate', async () => {
+		const workflow = buildReviewToDoneWorkflow();
+		const channelResolver = new ChannelResolver(workflow.channels ?? []);
+		const agentMessageRouter = new AgentMessageRouter({
+			nodeExecutionRepo,
+			workflowRunId,
+			workflowChannels: channelResolver.getChannels(),
+			messageInjector: async () => {},
+		});
+		// Create a parent task so send_message has context.
+		const parentTask = taskRepo.createTask({
+			spaceId,
+			title: 'Parent',
+			description: '',
+			status: 'in_progress',
+		});
+		const handlers = createNodeAgentToolHandlers({
+			mySessionId: reviewerSessionId,
+			myAgentName: 'reviewer',
+			taskId: parentTask.id,
+			spaceId,
+			channelResolver,
+			workflowRunId,
+			workflowNodeId: nodeId,
+			nodeExecutionRepo,
+			agentMessageRouter,
+			workflow,
+			gateDataRepo,
+		});
+
+		// Reviewer sends a pure chat message — "approved" is just text, not data.
+		const result = await handlers.send_message({
+			target: 'Done',
+			message: 'looks good to me, approved',
+		});
+		const data = JSON.parse(result.content[0].text);
+
+		// No gateWrite in the response — the gate was not touched.
+		expect(data.gateWrite).toBeUndefined();
+		// And the gate data row is empty (no `approved` field set).
+		const record = gateDataRepo.get(workflowRunId, 'review-approval-gate');
+		expect(record?.data?.approved).toBeUndefined();
+	});
+
+	test('reviewer sending send_message with data={approved:true} opens review-approval-gate', async () => {
+		const workflow = buildReviewToDoneWorkflow();
+		const channelResolver = new ChannelResolver(workflow.channels ?? []);
+		const agentMessageRouter = new AgentMessageRouter({
+			nodeExecutionRepo,
+			workflowRunId,
+			workflowChannels: channelResolver.getChannels(),
+			messageInjector: async () => {},
+		});
+		const parentTask = taskRepo.createTask({
+			spaceId,
+			title: 'Parent',
+			description: '',
+			status: 'in_progress',
+		});
+		const handlers = createNodeAgentToolHandlers({
+			mySessionId: reviewerSessionId,
+			myAgentName: 'reviewer',
+			taskId: parentTask.id,
+			spaceId,
+			channelResolver,
+			workflowRunId,
+			workflowNodeId: nodeId,
+			nodeExecutionRepo,
+			agentMessageRouter,
+			workflow,
+			gateDataRepo,
+		});
+
+		const result = await handlers.send_message({
+			target: 'Done',
+			message: 'approving via structured data',
+			data: { approved: true },
+		});
+		const data = JSON.parse(result.content[0].text);
+
+		// Gate was written — the approval is recorded as structured data.
+		expect(data.gateWrite).toBeDefined();
+		expect(data.gateWrite.gateId).toBe('review-approval-gate');
+		expect(data.gateWrite.gateOpen).toBe(true);
+		const record = gateDataRepo.get(workflowRunId, 'review-approval-gate');
+		expect(record?.data?.approved).toBe(true);
+	});
+
+	test('non-reviewer agent cannot open review-approval-gate even with data={approved:true}', async () => {
+		// Simulate a coder trying to self-approve by impersonating a write. The
+		// gate's `writers: ['reviewer']` must reject the write silently (the gate
+		// tool authorizes writes by agent name, not by target channel).
+		const workflow = buildReviewToDoneWorkflow();
+		// coder → Done channel (bypasses reviewer role entirely)
+		workflow.channels = [
+			{
+				id: 'ch-coder-done',
+				from: 'coder',
+				to: 'Done',
+				gateId: 'review-approval-gate',
+			},
+		];
+		const channelResolver = new ChannelResolver(workflow.channels ?? []);
+		const agentMessageRouter = new AgentMessageRouter({
+			nodeExecutionRepo,
+			workflowRunId,
+			workflowChannels: channelResolver.getChannels(),
+			messageInjector: async () => {},
+		});
+		const parentTask = taskRepo.createTask({
+			spaceId,
+			title: 'Parent',
+			description: '',
+			status: 'in_progress',
+		});
+		// Seed a coder peer task + executions.
+		const coderSessionId = 'session-coder-for-auth-test';
+		db.exec('PRAGMA foreign_keys = OFF');
+		db.prepare(
+			`INSERT INTO space_tasks
+         (id, space_id, task_number, title, description, status, priority, result,
+          workflow_run_id, depends_on, task_agent_session_id, created_at, updated_at)
+         VALUES (?, ?,
+           (SELECT COALESCE(MAX(task_number), 0) + 1 FROM space_tasks WHERE space_id = ?),
+           'coder', '', 'in_progress', 'normal', NULL, ?, '[]', ?, ?, ?)`
+		).run(
+			'task-coder-auth',
+			spaceId,
+			spaceId,
+			workflowRunId,
+			coderSessionId,
+			Date.now(),
+			Date.now()
+		);
+		db.exec('PRAGMA foreign_keys = ON');
+		nodeExecutionRepo.createOrIgnore({
+			workflowRunId,
+			workflowNodeId: nodeId,
+			agentName: 'coder',
+			agentSessionId: coderSessionId,
+			status: 'in_progress',
+		});
+
+		const handlers = createNodeAgentToolHandlers({
+			mySessionId: coderSessionId,
+			myAgentName: 'coder',
+			taskId: parentTask.id,
+			spaceId,
+			channelResolver,
+			workflowRunId,
+			workflowNodeId: nodeId,
+			nodeExecutionRepo,
+			agentMessageRouter,
+			workflow,
+			gateDataRepo,
+		});
+
+		const result = await handlers.send_message({
+			target: 'Done',
+			message: 'self-approving',
+			data: { approved: true },
+		});
+		const body = JSON.parse(result.content[0].text);
+
+		// The gate filter drops unauthorized fields — `approved` must not land in gate data.
+		const record = gateDataRepo.get(workflowRunId, 'review-approval-gate');
+		expect(record?.data?.approved).toBeUndefined();
+		// Even if a gateWrite row is emitted, the gate must remain closed because
+		// no authorized writer has supplied the required field.
+		if (body.gateWrite) {
+			expect(body.gateWrite.gateOpen).toBe(false);
+		}
+	});
+});

--- a/packages/daemon/tests/unit/5-space/workflow/completion-actions-persistence.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/completion-actions-persistence.test.ts
@@ -232,10 +232,13 @@ describe('completionActions persistence — updateWorkflow round-trip (Bug B reg
 		// Caller sends nodes without specifying completionActions → manager should
 		// not silently clobber existing completionActions on other nodes. This is
 		// a defensive test for a class of bugs in the update path.
+		// Note: in the new 3-node CODING_WORKFLOW (Task #41), merge-pr lives on the
+		// Done node, not the Review node — merge authority is separated from review.
 		const before = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
 		const codingNode = before.nodes.find((n) => n.name === 'Coding')!;
 		const reviewNode = before.nodes.find((n) => n.name === 'Review')!;
-		expect(reviewNode.completionActions?.some((a) => a.id === 'merge-pr')).toBe(true);
+		const doneNode = before.nodes.find((n) => n.name === 'Done')!;
+		expect(doneNode.completionActions?.some((a) => a.id === 'merge-pr')).toBe(true);
 
 		// Pass nodes back as-is (mimicking a UI that re-emits the full node list
 		// on every save, preserving each node's completionActions).
@@ -250,14 +253,19 @@ describe('completionActions persistence — updateWorkflow round-trip (Bug B reg
 					id: reviewNode.id,
 					name: reviewNode.name,
 					agents: reviewNode.agents,
-					completionActions: reviewNode.completionActions,
+				},
+				{
+					id: doneNode.id,
+					name: doneNode.name,
+					agents: doneNode.agents,
+					completionActions: doneNode.completionActions,
 				},
 			],
 		});
 
 		const after = manager.getWorkflow(before.id)!;
-		const afterReview = after.nodes.find((n) => n.name === 'Review')!;
-		expect(afterReview.completionActions?.some((a) => a.id === 'merge-pr')).toBe(true);
+		const afterDone = after.nodes.find((n) => n.name === 'Done')!;
+		expect(afterDone.completionActions?.some((a) => a.id === 'merge-pr')).toBe(true);
 	});
 
 	test('update with explicit completionActions=[] on a node clears them (caller intent honored)', () => {
@@ -266,6 +274,7 @@ describe('completionActions persistence — updateWorkflow round-trip (Bug B reg
 		const before = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
 		const reviewNode = before.nodes.find((n) => n.name === 'Review')!;
 		const codingNode = before.nodes.find((n) => n.name === 'Coding')!;
+		const doneNode = before.nodes.find((n) => n.name === 'Done')!;
 
 		manager.updateWorkflow(before.id, {
 			nodes: [
@@ -278,16 +287,21 @@ describe('completionActions persistence — updateWorkflow round-trip (Bug B reg
 					id: reviewNode.id,
 					name: reviewNode.name,
 					agents: reviewNode.agents,
+				},
+				{
+					id: doneNode.id,
+					name: doneNode.name,
+					agents: doneNode.agents,
 					completionActions: [],
 				},
 			],
 		});
 
 		const after = manager.getWorkflow(before.id)!;
-		const afterReview = after.nodes.find((n) => n.name === 'Review')!;
+		const afterDone = after.nodes.find((n) => n.name === 'Done')!;
 		// Empty array → end node has no actions (repo stores `undefined` when
 		// empty array). Either empty array or undefined is acceptable; assert
 		// that no action is present.
-		expect(afterReview.completionActions?.length ?? 0).toBe(0);
+		expect(afterDone.completionActions?.length ?? 0).toBe(0);
 	});
 });


### PR DESCRIPTION
Splits the Coding Workflow into three nodes (Coding → Review → Done) so merge authority no longer rests with the Coder. The new `review-approval-gate` (requiredLevel: 4, writers: [`reviewer`], approved: true) is the only path to the Done node, whose `merge-pr` completion action performs the squash-merge. At autonomy below 4 the task pauses at `review` status awaiting explicit human approval.

**Bug A (unauthorized merge)** — Coder no longer has merge authority. Its prompt explicitly forbids `gh pr merge`, `git merge`, squash endpoints, and force-push. A peer chat message saying "approved" is never authorization — only a `reviewer`-named agent writing structured `approved: true` via `send_message` opens the gate.

**Bug B (task lifecycle)** — At autonomy below `merge-pr.requiredLevel`, the task transitions to `review` status with `pendingCheckpointType: 'completion_action'` while awaiting human sign-off. Tasks no longer go directly to `done` when a merge is pending.

## Changes

- `built-in-workflows.ts`: CODING_WORKFLOW now has Coding/Review/Done nodes, 3 channels, code-ready-gate + review-approval-gate.
- `m94-backfill-workflow-templates.ts`: inlined fingerprint updated to match the new 3-node shape so M94's hash self-verification still passes.
- New `coding-workflow-merge-authority.test.ts`: 7 integration tests covering peer-chat non-opens-gate, structured data opens gate, and low-autonomy task-status transition.

## Test plan
- [x] `./scripts/test-daemon.sh` — 11,105 tests pass
- [x] Migration 94 tests — 15 pass
- [x] New merge-authority integration tests — 7 pass