### PR TITLE
fix(space): split report_result into audit/approve/submit — end reviewer-loop premature completion

### DIFF
--- a/packages/daemon/src/lib/db-query/scope-config.ts
+++ b/packages/daemon/src/lib/db-query/scope-config.ts
@@ -235,6 +235,13 @@ const SPACE_SCOPE_TABLES: ScopeTableConfig[] = [
 			'Tasks within a space with numbering, status, PR tracking, and workflow run associations.',
 	},
 	{
+		tableName: 'space_task_report_results',
+		scopeColumn: 'space_id',
+		blacklistedColumns: [],
+		description:
+			'Append-only audit log of `report_result` tool calls per task. Stores summary, optional evidence, and agent identity for each report.',
+	},
+	{
 		tableName: 'space_worktrees',
 		scopeColumn: 'space_id',
 		blacklistedColumns: [],

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -60,6 +60,7 @@ import { SpaceTaskManager } from '../space/managers/space-task-manager';
 import { SpaceWorkflowManager } from '../space/managers/space-workflow-manager';
 import type { SpaceAgentLookup } from '../space/managers/space-workflow-manager';
 import { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
+import { SpaceTaskReportResultRepository } from '../../storage/repositories/space-task-report-result-repository';
 import { SpaceWorkflowRunRepository } from '../../storage/repositories/space-workflow-run-repository';
 import { GateDataRepository } from '../../storage/repositories/gate-data-repository';
 import { WorkflowRunArtifactRepository } from '../../storage/repositories/workflow-run-artifact-repository';
@@ -369,6 +370,10 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 
 	// Space handlers (spaceManager injected from deps — single instance shared with DaemonAppContext)
 	const spaceTaskRepo = new SpaceTaskRepository(deps.db.getDatabase(), deps.reactiveDb);
+	// Append-only audit of report_result calls from end-node agents (Task #39).
+	// Shared with TaskAgentManager so both the end-node `report_result` and the
+	// task-agent `report_result` handlers append to the same log.
+	const spaceTaskReportResultRepo = new SpaceTaskReportResultRepository(deps.db.getDatabase());
 	const spaceWorkflowRunRepo = new SpaceWorkflowRunRepository(deps.db.getDatabase());
 	const gateDataRepo = new GateDataRepository(deps.db.getDatabase());
 	const artifactRepo = new WorkflowRunArtifactRepository(deps.db.getDatabase(), deps.reactiveDb);
@@ -525,6 +530,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		spaceWorkflowManager,
 		spaceRuntimeService,
 		taskRepo: spaceTaskRepo,
+		taskReportResultRepo: spaceTaskReportResultRepo,
 		workflowRunRepo: spaceWorkflowRunRepo,
 		gateDataRepo,
 		channelCycleRepo,

--- a/packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts
@@ -235,6 +235,10 @@ export function buildWorkflowCreateParams(
 		name,
 		nodes,
 		tags: exported.tags,
+		// Fall back to 3 when the exported bundle predates completionAutonomyLevel.
+		// 3 ("Low Approval") matches the DB column default and is the safest neutral
+		// choice for imports where the exporter didn't specify a level.
+		completionAutonomyLevel: exported.completionAutonomyLevel ?? 3,
 	};
 	if (startNodeId) params.startNodeId = startNodeId;
 	if (endNodeId) params.endNodeId = endNodeId;

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -275,4 +275,93 @@ export function setupSpaceTaskHandlers(
 
 		return task;
 	});
+
+	// ─── spaceTask.approvePendingCompletion ─────────────────────────────────────
+	// Design v2 (Task #39): human approval / rejection for tasks paused at a
+	// `submit_for_approval` checkpoint (`pendingCheckpointType === 'task_completion'`).
+	//
+	// - `approved: true`  → transitions the task review → done, stamps approval
+	//   metadata, clears pending-completion fields, and fires `space.task.updated`.
+	// - `approved: false` → transitions the task back to in_progress so the end-node
+	//   agent can revise its output; clears pending-completion fields. The optional
+	//   `reason` is written to `approvalReason` as a rejection rationale.
+	//
+	// The handler refuses to operate on tasks that are not paused at a
+	// `task_completion` checkpoint to avoid accidentally closing in-flight work.
+	messageHub.onRequest('spaceTask.approvePendingCompletion', async (data) => {
+		const params = data as {
+			spaceId: string;
+			taskId: string;
+			approved: boolean;
+			reason?: string | null;
+		};
+
+		if (!params.spaceId) throw new Error('spaceId is required');
+		if (!params.taskId) throw new Error('taskId is required');
+		if (typeof params.approved !== 'boolean') throw new Error('approved must be a boolean');
+
+		const space = await spaceManager.getSpace(params.spaceId);
+		if (!space) {
+			throw new Error(`Space not found: ${params.spaceId}`);
+		}
+
+		const taskManager = taskManagerFactory(params.spaceId);
+		const currentTask = await taskManager.getTask(params.taskId);
+		if (!currentTask) {
+			throw new Error(`Task not found: ${params.taskId}`);
+		}
+
+		if (currentTask.pendingCheckpointType !== 'task_completion') {
+			throw new Error(
+				`Task ${params.taskId} is not awaiting submit_for_approval review ` +
+					`(pendingCheckpointType=${currentTask.pendingCheckpointType ?? 'null'}).`
+			);
+		}
+
+		if (currentTask.status !== 'review') {
+			throw new Error(
+				`Task ${params.taskId} is not in 'review' status ` + `(current: ${currentTask.status}).`
+			);
+		}
+
+		let task;
+		if (params.approved) {
+			// review → done. Stamp human approval metadata and clear pending flags.
+			task = await taskManager.setTaskStatus(params.taskId, 'done', {
+				approvalSource: 'human',
+				approvalReason: params.reason ?? undefined,
+			});
+			// Clear the pending-completion fields. setTaskStatus does not touch them,
+			// so apply them in a follow-up update so the banner/UI stops rendering.
+			task = await taskManager.updateTask(params.taskId, {
+				pendingCheckpointType: null,
+				pendingCompletionSubmittedByNodeId: null,
+				pendingCompletionSubmittedAt: null,
+				pendingCompletionReason: null,
+			});
+		} else {
+			// review → in_progress (reject). Reason captured as approvalReason for audit.
+			task = await taskManager.setTaskStatus(params.taskId, 'in_progress');
+			task = await taskManager.updateTask(params.taskId, {
+				pendingCheckpointType: null,
+				pendingCompletionSubmittedByNodeId: null,
+				pendingCompletionSubmittedAt: null,
+				pendingCompletionReason: null,
+				approvalReason: params.reason ?? null,
+			});
+		}
+
+		daemonHub
+			.emit('space.task.updated', {
+				sessionId: 'global',
+				spaceId: params.spaceId,
+				taskId: params.taskId,
+				task,
+			})
+			.catch((err) => {
+				log.warn('Failed to emit space.task.updated:', err);
+			});
+
+		return task;
+	});
 }

--- a/packages/daemon/src/lib/space/export-format.ts
+++ b/packages/daemon/src/lib/space/export-format.ts
@@ -134,6 +134,10 @@ const exportedWorkflowBaseSchema = z.object({
 	endNode: z.string().optional(),
 	tags: z.array(z.string()),
 	channels: z.array(exportedWorkflowChannelSchema).optional(),
+	// Optional in schema for backward compatibility with v1 exports that predate
+	// the completionAutonomyLevel field. Import code falls back to a sensible
+	// default when the field is absent.
+	completionAutonomyLevel: z.number().int().min(1).max(5).optional(),
 });
 
 const exportBundleBaseSchema = z.object({
@@ -266,6 +270,7 @@ export function exportWorkflow(
 		nodes: exportedNodes,
 		startNode,
 		tags: workflow.tags,
+		completionAutonomyLevel: workflow.completionAutonomyLevel,
 	};
 	if (endNode !== undefined) result.endNode = endNode;
 	if (workflow.description !== undefined) result.description = workflow.description;
@@ -415,7 +420,12 @@ export function validateExportedWorkflow(data: unknown): ValidationResult<Export
 		}
 	}
 
-	return { ok: true, value: { version: 1, ...result.data } };
+	// Zod's `z.number().min(1).max(5)` widens to `number`; at runtime the schema
+	// guarantees 1-5, so we assert to the nominal SpaceAutonomyLevel union.
+	return {
+		ok: true,
+		value: { version: 1, ...result.data } as ExportedSpaceWorkflow,
+	};
 }
 
 /**
@@ -464,7 +474,11 @@ export function validateExportBundle(data: unknown): ValidationResult<SpaceExpor
 			name: result.data.name,
 			...(result.data.description !== undefined ? { description: result.data.description } : {}),
 			agents: result.data.agents.map((a) => ({ version: 1 as const, ...a })),
-			workflows: result.data.workflows.map((w) => ({ version: 1 as const, ...w })),
+			// Zod widens `completionAutonomyLevel` to `number`; the schema enforces 1-5
+			// at runtime, so casting to ExportedSpaceWorkflow is safe here.
+			workflows: result.data.workflows.map(
+				(w) => ({ version: 1 as const, ...w }) as ExportedSpaceWorkflow
+			),
 			exportedAt: result.data.exportedAt,
 			...(result.data.exportedFrom !== undefined ? { exportedFrom: result.data.exportedFrom } : {}),
 		},

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -64,6 +64,7 @@ import type { SpaceAgentManager } from '../managers/space-agent-manager';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import type { SpaceRuntimeService } from './space-runtime-service';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import type { SpaceTaskReportResultRepository } from '../../../storage/repositories/space-task-report-result-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import type { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
 import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
@@ -89,8 +90,13 @@ import {
 import { TERMINAL_NODE_EXECUTION_STATUSES } from '../managers/node-execution-manager';
 import { Logger } from '../../logger';
 import { SpaceTaskManager } from '../managers/space-task-manager';
-import type { ReportResultInput } from '../tools/task-agent-tool-schemas';
+import type {
+	ReportResultInput,
+	ApproveTaskInput,
+	SubmitForApprovalInput,
+} from '../tools/task-agent-tool-schemas';
 import { jsonResult } from '../tools/tool-result';
+import type { ToolResult } from '../tools/tool-result';
 
 const log = new Logger('task-agent-manager');
 
@@ -115,6 +121,14 @@ export interface TaskAgentManagerConfig {
 	spaceRuntimeService: SpaceRuntimeService;
 	/** Task repository — direct DB reads */
 	taskRepo: SpaceTaskRepository;
+	/**
+	 * Append-only audit log for `report_result` tool calls from end-node agents.
+	 * Every `report_result` invocation writes one row here — the table is the
+	 * source of truth for "what did the agent observe", independent of the
+	 * task's reported/terminal status. Task #39: this separation is what keeps
+	 * Coding↔Review loops from closing on review feedback.
+	 */
+	taskReportResultRepo: SpaceTaskReportResultRepository;
 	/** Workflow run repository — reading and updating runs */
 	workflowRunRepo: SpaceWorkflowRunRepository;
 	/** Gate data repository — for reading and writing gate runtime data in node agent tools */
@@ -540,6 +554,7 @@ export class TaskAgentManager {
 				space,
 				workflowRunId,
 				taskRepo: this.config.taskRepo,
+				taskReportResultRepo: this.config.taskReportResultRepo,
 				nodeExecutionRepo: this.config.nodeExecutionRepo,
 				taskManager,
 				messageInjector: (subSessionId, message) =>
@@ -2070,6 +2085,7 @@ export class TaskAgentManager {
 			space,
 			workflowRunId: rehydrateWorkflowRunId,
 			taskRepo: this.config.taskRepo,
+			taskReportResultRepo: this.config.taskReportResultRepo,
 			nodeExecutionRepo: this.config.nodeExecutionRepo,
 			taskManager,
 			messageInjector: (subSessionId, message) =>
@@ -2621,53 +2637,85 @@ export class TaskAgentManager {
 			? this.buildAgentNameAliasesForExecution(workflow, execution)
 			: this.agentNameVariants(agentName);
 
-		// Build onReportResult callback for end-node agents so they can close the workflow run.
+		// Design v2 tool contract (Task #39):
+		//   `report_result`      — append-only audit. Does NOT close the task.
+		//   `approve_task`       — closes the task as done (self-approval). Gated
+		//                          by `space.autonomyLevel >= workflow.completionAutonomyLevel`.
+		//   `submit_for_approval` — request human review of completion.
 		//
-		// Records the agent's reported intent (status + summary) into
-		// `space_tasks.reported_status` / `reported_summary`, but does NOT directly
-		// transition `space_tasks.status`. The runtime resolves the final task status
-		// on the next tick via `resolveCompletionWithActions`, which honors the
-		// supervised-mode review gate. See `CompletionDetector.isComplete`.
+		// The previous behaviour where `report_result` set `reportedStatus='done'`
+		// caused cycle-graphs like Coding↔Review to close the moment the Reviewer
+		// reported feedback. Splitting audit from closure restores the intended
+		// iterative semantics.
 		const isEndNode = !!workflow?.endNodeId && workflowNodeId === workflow.endNodeId;
-		let onReportResult:
-			| ((args: ReportResultInput) => Promise<ReturnType<typeof jsonResult>>)
-			| undefined;
+		let onReportResult: ((args: ReportResultInput) => Promise<ToolResult>) | undefined;
+		let onApproveTask: ((args: ApproveTaskInput) => Promise<ToolResult>) | undefined;
+		let onSubmitForApproval: ((args: SubmitForApprovalInput) => Promise<ToolResult>) | undefined;
+
 		if (isEndNode) {
 			const capturedTaskId = taskId;
 			const capturedSpaceId = spaceId;
+			const capturedWorkflow = workflow;
+
+			// report_result — append-only audit. Records what the agent observed
+			// without touching `reportedStatus`. Every call is a new row, including
+			// repeat calls across review cycles; no de-duplication.
 			onReportResult = async (args: ReportResultInput) => {
 				const task = this.config.taskRepo.getTask(capturedTaskId);
 				if (!task)
 					return jsonResult({ success: false, error: `Task not found: ${capturedTaskId}` });
 
-				// Serialize optional evidence into the summary so completion-action
-				// verifiers and downstream consumers can inspect it. The agent
-				// does NOT pass a status — the runtime always records `done` and
-				// lets the completion-action pipeline decide the terminal state.
-				const serializedSummary = args.evidence
-					? `${args.summary}\n\n<!-- evidence -->\n${JSON.stringify(args.evidence, null, 2)}`
-					: args.summary;
-
-				// Idempotency: if the agent re-invokes report_result with the same outcome
-				// (retry, double-call, etc.), skip the DB write and the broadcast — they
-				// would be no-ops that still wake every subscriber.
-				const successPayload = jsonResult({
-					success: true,
-					taskId: capturedTaskId,
-					summary: args.summary,
-					message:
-						'Result recorded. The completion-action pipeline will determine the final task status (supervised mode may pause for human approval).',
-				});
-				if (task.reportedStatus === 'done' && task.reportedSummary === serializedSummary) {
-					return successPayload;
+				try {
+					this.config.taskReportResultRepo.append({
+						taskId: capturedTaskId,
+						spaceId: capturedSpaceId,
+						workflowNodeId,
+						agentName,
+						summary: args.summary,
+						evidence: args.evidence ?? null,
+					});
+					return jsonResult({
+						success: true,
+						taskId: capturedTaskId,
+						summary: args.summary,
+						message:
+							'Result recorded to audit log. This does NOT close the task — call approve_task (if available) or submit_for_approval to finalize.',
+					});
+				} catch (err) {
+					return jsonResult({
+						success: false,
+						error: err instanceof Error ? err.message : String(err),
+					});
 				}
+			};
+
+			// approve_task — agent self-closes. Gated by autonomy level. Registration
+			// is conditional on the same check, but we also re-check here as
+			// defense-in-depth against a buggy/malicious client bypassing it.
+			onApproveTask = async (_args: ApproveTaskInput) => {
+				const space = await this.config.spaceManager.getSpace(capturedSpaceId);
+				const currentLevel = space?.autonomyLevel ?? 1;
+				const required = capturedWorkflow?.completionAutonomyLevel ?? 5;
+				if (currentLevel < required) {
+					return jsonResult({
+						success: false,
+						error: `approve_task not permitted: space autonomy level ${currentLevel} < workflow completionAutonomyLevel ${required}. Use submit_for_approval to request human review.`,
+					});
+				}
+				const task = this.config.taskRepo.getTask(capturedTaskId);
+				if (!task)
+					return jsonResult({ success: false, error: `Task not found: ${capturedTaskId}` });
 
 				try {
 					const updated = this.config.taskRepo.updateTask(capturedTaskId, {
 						reportedStatus: 'done',
-						reportedSummary: serializedSummary,
+						// Clear any pending-completion state in case a prior submit_for_approval
+						// set it; approval supersedes the pending request.
+						pendingCheckpointType: null,
+						pendingCompletionSubmittedByNodeId: null,
+						pendingCompletionSubmittedAt: null,
+						pendingCompletionReason: null,
 					});
-
 					if (this.config.daemonHub && updated) {
 						void this.config.daemonHub
 							.emit('space.task.updated', {
@@ -2682,11 +2730,59 @@ export class TaskAgentManager {
 								);
 							});
 					}
-
-					return successPayload;
+					return jsonResult({
+						success: true,
+						taskId: capturedTaskId,
+						message:
+							'Task approved for completion. The completion-action pipeline will now resolve terminal status.',
+					});
 				} catch (err) {
-					const message = err instanceof Error ? err.message : String(err);
-					return jsonResult({ success: false, error: message });
+					return jsonResult({
+						success: false,
+						error: err instanceof Error ? err.message : String(err),
+					});
+				}
+			};
+
+			// submit_for_approval — always available to end nodes. Marks the task
+			// awaiting human review; the runtime resumes on approveTaskCompletion RPC.
+			onSubmitForApproval = async (args: SubmitForApprovalInput) => {
+				const task = this.config.taskRepo.getTask(capturedTaskId);
+				if (!task)
+					return jsonResult({ success: false, error: `Task not found: ${capturedTaskId}` });
+
+				try {
+					const updated = this.config.taskRepo.updateTask(capturedTaskId, {
+						status: 'review',
+						pendingCheckpointType: 'task_completion',
+						pendingCompletionSubmittedByNodeId: workflowNodeId,
+						pendingCompletionSubmittedAt: Date.now(),
+						pendingCompletionReason: args.reason ?? null,
+					});
+					if (this.config.daemonHub && updated) {
+						void this.config.daemonHub
+							.emit('space.task.updated', {
+								sessionId: 'global',
+								spaceId: capturedSpaceId,
+								taskId: capturedTaskId,
+								task: updated,
+							})
+							.catch((err) => {
+								log.warn(
+									`Failed to emit space.task.updated for task ${capturedTaskId}: ${err instanceof Error ? err.message : String(err)}`
+								);
+							});
+					}
+					return jsonResult({
+						success: true,
+						taskId: capturedTaskId,
+						message: `Task submitted for human review${args.reason ? ` (reason: ${args.reason})` : ''}. A human must approve or reject via the UI before the workflow continues.`,
+					});
+				} catch (err) {
+					return jsonResult({
+						success: false,
+						error: err instanceof Error ? err.message : String(err),
+					});
 				}
 			};
 		}
@@ -2754,6 +2850,8 @@ export class TaskAgentManager {
 				workflowStartIso: run ? new Date(run.createdAt).toISOString() : undefined,
 			},
 			onReportResult,
+			onApproveTask,
+			onSubmitForApproval,
 			artifactRepo: this.config.artifactRepo,
 			getSpaceAutonomyLevel: async (sid) => {
 				const s = await spaceManager.getSpace(sid);

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -74,6 +74,7 @@ import type { SpaceWorktreeManager } from '../managers/space-worktree-manager';
 import type { SubSessionMemberInfo } from '../tools/task-agent-tools';
 import { createTaskAgentMcpServer } from '../tools/task-agent-tools';
 import { createNodeAgentMcpServer } from '../tools/node-agent-tools';
+import { createEndNodeHandlers } from '../tools/end-node-handlers';
 import { createSpaceAgentMcpServer } from '../tools/space-agent-tools';
 import { createDbQueryMcpServer, type DbQueryMcpServer } from '../../db-query/tools';
 import { ChannelResolver } from './channel-resolver';
@@ -90,13 +91,6 @@ import {
 import { TERMINAL_NODE_EXECUTION_STATUSES } from '../managers/node-execution-manager';
 import { Logger } from '../../logger';
 import { SpaceTaskManager } from '../managers/space-task-manager';
-import type {
-	ReportResultInput,
-	ApproveTaskInput,
-	SubmitForApprovalInput,
-} from '../tools/task-agent-tool-schemas';
-import { jsonResult } from '../tools/tool-result';
-import type { ToolResult } from '../tools/tool-result';
 
 const log = new Logger('task-agent-manager');
 
@@ -893,7 +887,7 @@ export class TaskAgentManager {
 					agentSlotName: execution.agentName,
 					gateData: gateDataSnapshot,
 				});
-				const runtimeContract = this.buildNodeExecutionRuntimeContract(workflow, execution);
+				const runtimeContract = this.buildNodeExecutionRuntimeContract(workflow, execution, space);
 				const kickoffMessage = runtimeContract
 					? `${initialMessage}\n\n${runtimeContract}`
 					: initialMessage;
@@ -1769,12 +1763,53 @@ export class TaskAgentManager {
 	/**
 	 * Build a runtime contract for a specific node execution from the current
 	 * workflow graph, including gate requirements derived from outbound channels.
+	 *
+	 * The `space` argument is used to determine whether `approve_task` is
+	 * currently unlocked by the space's autonomy level. When unlocked, the
+	 * prompt tells the agent it can self-close; otherwise the prompt tells the
+	 * agent that `submit_for_approval` is the only way to finalize. This keeps
+	 * the system prompt aligned with what the MCP handler actually enforces at
+	 * call time.
 	 */
 	private buildNodeExecutionRuntimeContract(
 		workflow: SpaceWorkflow | null,
-		execution: NodeExecution
+		execution: NodeExecution,
+		space: Space | null
 	): string {
 		const isEndNode = !!workflow?.endNodeId && execution.workflowNodeId === workflow.endNodeId;
+
+		// Compute whether approve_task is currently unlocked for this space.
+		// The MCP handler re-checks at call time, so this is purely for prompt
+		// accuracy — the tool is registered unconditionally on end-node sessions.
+		const spaceLevel = space?.autonomyLevel ?? 1;
+		const requiredLevel = workflow?.completionAutonomyLevel ?? 5;
+		const approveUnlocked = spaceLevel >= requiredLevel;
+
+		// Design v2 end-node tool contract (Task #39):
+		//   - report_result: append-only audit — does NOT close the task.
+		//   - approve_task : self-close (autonomy-gated).
+		//   - submit_for_approval: human sign-off (always available).
+		// Keep these strings in sync with `node-agent-tools.ts` and
+		// `task-agent-manager.ts` where the handlers live.
+		const endNodeContractLines = (indent: string): string[] => {
+			if (!isEndNode) return [];
+			const lines = [
+				`${indent}- report_result({ summary, evidence? }) — APPEND-ONLY AUDIT. Records what you observed; does NOT close the task. Every call is a new entry.`,
+			];
+			if (approveUnlocked) {
+				lines.push(
+					`${indent}- approve_task({}) — Close this task as done (self-approval). Unlocked for this space (autonomy ${spaceLevel} >= required ${requiredLevel}). Use as your FINAL action when you are satisfied the work is complete.`
+				);
+			} else {
+				lines.push(
+					`${indent}- approve_task({}) — NOT AVAILABLE: space autonomy ${spaceLevel} < workflow completionAutonomyLevel ${requiredLevel}. Do NOT call this tool; use submit_for_approval instead.`
+				);
+			}
+			lines.push(
+				`${indent}- submit_for_approval({ reason? }) — Request human sign-off. Always available to end-node agents. Use when autonomy blocks self-close OR the outcome is risky enough to escalate.`
+			);
+			return lines;
+		};
 
 		const fallback = [
 			'## Runtime Execution Contract',
@@ -1782,14 +1817,10 @@ export class TaskAgentManager {
 			'Tools available:',
 			'  - send_message({ target, message, data? }) — communicate with peers; data is automatically written to the gate when the channel is gated',
 			'  - save({ summary?, data? }) — persist your output at any time (call multiple times as needed)',
-			isEndNode
-				? '  - report_result({ summary, evidence? }) — YOU ARE THE END NODE: call this when the workflow is complete to close the run. Do NOT pass a status; the runtime decides the terminal state via completion actions.'
-				: null,
+			...endNodeContractLines('  '),
 			'  - restore_node_agent({ reason? }) — self-heal fallback: if a previous mcp__node-agent__* call returned "No such tool available", call this once and then retry the original tool',
 			'Only contact the task-agent via send_message if you are blocked or need human input.',
-		]
-			.filter(Boolean)
-			.join('\n');
+		].join('\n');
 
 		if (!workflow) {
 			return fallback;
@@ -1818,18 +1849,10 @@ export class TaskAgentManager {
 			'Tools available:',
 			'  - send_message({ target, message, data? }) — communicate with peers; when a channel is gated, `data` is automatically merged into the gate',
 			'  - save({ summary?, data? }) — persist your output (summary text and/or structured data like pr_url)',
-		];
-
-		if (isEndNode) {
-			lines.push(
-				'  - report_result({ summary, evidence? }) — YOU ARE THE END NODE: call this when the workflow is complete. Do NOT pass a status; the runtime decides the terminal state via completion actions. `evidence` is an optional object (prUrl, commitSha, testOutput, …) supporting your summary.'
-			);
-		}
-
-		lines.push(
+			...endNodeContractLines('  '),
 			'  - list_peers / list_reachable_agents / list_channels / list_gates / read_gate — discovery',
-			'  - restore_node_agent({ reason? }) — self-heal fallback: if a previous mcp__node-agent__* call ever returned "No such tool available", call this once and then retry the original tool'
-		);
+			'  - restore_node_agent({ reason? }) — self-heal fallback: if a previous mcp__node-agent__* call ever returned "No such tool available", call this once and then retry the original tool',
+		];
 
 		if (outboundGatedChannels.length === 0) {
 			lines.push('No outbound gated channels are currently mapped from this agent/node.');
@@ -1874,9 +1897,18 @@ export class TaskAgentManager {
 			'Only contact the task-agent via send_message if you are blocked or need human input.'
 		);
 		if (isEndNode) {
-			lines.push(
-				'When your work is complete, call report_result({ summary: "...", evidence: { prUrl?: "...", commitSha?: "...", testOutput?: "...", ... } }) to close the workflow run. Do NOT pass a `status` — the runtime runs completion actions to decide the terminal state.'
-			);
+			// Closure guidance: record audit first (report_result), then finalize
+			// via the appropriate tool. This replaces the old (incorrect) guidance
+			// that said report_result closes the run.
+			if (approveUnlocked) {
+				lines.push(
+					'When your work is complete: (1) call report_result({ summary, evidence? }) to record the outcome, then (2) call approve_task({}) as your FINAL action to close the task. The runtime — not your report — decides the terminal status via completion actions.'
+				);
+			} else {
+				lines.push(
+					'When your work is complete: (1) call report_result({ summary, evidence? }) to record the outcome, then (2) call submit_for_approval({ reason: "..." }) as your FINAL action. approve_task is NOT available at this autonomy level; only a human can finalize.'
+				);
+			}
 		}
 		return lines.join('\n');
 	}
@@ -2648,144 +2680,22 @@ export class TaskAgentManager {
 		// reported feedback. Splitting audit from closure restores the intended
 		// iterative semantics.
 		const isEndNode = !!workflow?.endNodeId && workflowNodeId === workflow.endNodeId;
-		let onReportResult: ((args: ReportResultInput) => Promise<ToolResult>) | undefined;
-		let onApproveTask: ((args: ApproveTaskInput) => Promise<ToolResult>) | undefined;
-		let onSubmitForApproval: ((args: SubmitForApprovalInput) => Promise<ToolResult>) | undefined;
-
-		if (isEndNode) {
-			const capturedTaskId = taskId;
-			const capturedSpaceId = spaceId;
-			const capturedWorkflow = workflow;
-
-			// report_result — append-only audit. Records what the agent observed
-			// without touching `reportedStatus`. Every call is a new row, including
-			// repeat calls across review cycles; no de-duplication.
-			onReportResult = async (args: ReportResultInput) => {
-				const task = this.config.taskRepo.getTask(capturedTaskId);
-				if (!task)
-					return jsonResult({ success: false, error: `Task not found: ${capturedTaskId}` });
-
-				try {
-					this.config.taskReportResultRepo.append({
-						taskId: capturedTaskId,
-						spaceId: capturedSpaceId,
-						workflowNodeId,
-						agentName,
-						summary: args.summary,
-						evidence: args.evidence ?? null,
-					});
-					return jsonResult({
-						success: true,
-						taskId: capturedTaskId,
-						summary: args.summary,
-						message:
-							'Result recorded to audit log. This does NOT close the task — call approve_task (if available) or submit_for_approval to finalize.',
-					});
-				} catch (err) {
-					return jsonResult({
-						success: false,
-						error: err instanceof Error ? err.message : String(err),
-					});
-				}
-			};
-
-			// approve_task — agent self-closes. Gated by autonomy level. Registration
-			// is conditional on the same check, but we also re-check here as
-			// defense-in-depth against a buggy/malicious client bypassing it.
-			onApproveTask = async (_args: ApproveTaskInput) => {
-				const space = await this.config.spaceManager.getSpace(capturedSpaceId);
-				const currentLevel = space?.autonomyLevel ?? 1;
-				const required = capturedWorkflow?.completionAutonomyLevel ?? 5;
-				if (currentLevel < required) {
-					return jsonResult({
-						success: false,
-						error: `approve_task not permitted: space autonomy level ${currentLevel} < workflow completionAutonomyLevel ${required}. Use submit_for_approval to request human review.`,
-					});
-				}
-				const task = this.config.taskRepo.getTask(capturedTaskId);
-				if (!task)
-					return jsonResult({ success: false, error: `Task not found: ${capturedTaskId}` });
-
-				try {
-					const updated = this.config.taskRepo.updateTask(capturedTaskId, {
-						reportedStatus: 'done',
-						// Clear any pending-completion state in case a prior submit_for_approval
-						// set it; approval supersedes the pending request.
-						pendingCheckpointType: null,
-						pendingCompletionSubmittedByNodeId: null,
-						pendingCompletionSubmittedAt: null,
-						pendingCompletionReason: null,
-					});
-					if (this.config.daemonHub && updated) {
-						void this.config.daemonHub
-							.emit('space.task.updated', {
-								sessionId: 'global',
-								spaceId: capturedSpaceId,
-								taskId: capturedTaskId,
-								task: updated,
-							})
-							.catch((err) => {
-								log.warn(
-									`Failed to emit space.task.updated for task ${capturedTaskId}: ${err instanceof Error ? err.message : String(err)}`
-								);
-							});
-					}
-					return jsonResult({
-						success: true,
-						taskId: capturedTaskId,
-						message:
-							'Task approved for completion. The completion-action pipeline will now resolve terminal status.',
-					});
-				} catch (err) {
-					return jsonResult({
-						success: false,
-						error: err instanceof Error ? err.message : String(err),
-					});
-				}
-			};
-
-			// submit_for_approval — always available to end nodes. Marks the task
-			// awaiting human review; the runtime resumes on approveTaskCompletion RPC.
-			onSubmitForApproval = async (args: SubmitForApprovalInput) => {
-				const task = this.config.taskRepo.getTask(capturedTaskId);
-				if (!task)
-					return jsonResult({ success: false, error: `Task not found: ${capturedTaskId}` });
-
-				try {
-					const updated = this.config.taskRepo.updateTask(capturedTaskId, {
-						status: 'review',
-						pendingCheckpointType: 'task_completion',
-						pendingCompletionSubmittedByNodeId: workflowNodeId,
-						pendingCompletionSubmittedAt: Date.now(),
-						pendingCompletionReason: args.reason ?? null,
-					});
-					if (this.config.daemonHub && updated) {
-						void this.config.daemonHub
-							.emit('space.task.updated', {
-								sessionId: 'global',
-								spaceId: capturedSpaceId,
-								taskId: capturedTaskId,
-								task: updated,
-							})
-							.catch((err) => {
-								log.warn(
-									`Failed to emit space.task.updated for task ${capturedTaskId}: ${err instanceof Error ? err.message : String(err)}`
-								);
-							});
-					}
-					return jsonResult({
-						success: true,
-						taskId: capturedTaskId,
-						message: `Task submitted for human review${args.reason ? ` (reason: ${args.reason})` : ''}. A human must approve or reject via the UI before the workflow continues.`,
-					});
-				} catch (err) {
-					return jsonResult({
-						success: false,
-						error: err instanceof Error ? err.message : String(err),
-					});
-				}
-			};
-		}
+		const endNodeHandlers = isEndNode
+			? createEndNodeHandlers({
+					taskId,
+					spaceId,
+					workflow,
+					workflowNodeId,
+					agentName,
+					taskRepo: this.config.taskRepo,
+					taskReportResultRepo: this.config.taskReportResultRepo,
+					spaceManager: this.config.spaceManager,
+					daemonHub: this.config.daemonHub,
+				})
+			: undefined;
+		const onReportResult = endNodeHandlers?.onReportResult;
+		const onApproveTask = endNodeHandlers?.onApproveTask;
+		const onSubmitForApproval = endNodeHandlers?.onSubmitForApproval;
 
 		// Self-heal callback for the agent-callable `restore_node_agent` tool.
 		// Looks up the live AgentSession by the enclosing-scope subSessionId, then

--- a/packages/daemon/src/lib/space/tools/end-node-handlers.ts
+++ b/packages/daemon/src/lib/space/tools/end-node-handlers.ts
@@ -1,0 +1,207 @@
+/**
+ * End-node tool handlers (Design v2 — Task #39).
+ *
+ * Factory for the three "terminal" MCP tool handlers exposed to end-node agents:
+ *   - report_result       — APPEND-ONLY audit. Does NOT mutate task state.
+ *   - approve_task        — Agent self-close. Gated by space.autonomyLevel >=
+ *                           workflow.completionAutonomyLevel.
+ *   - submit_for_approval — Request human sign-off. Always available.
+ *
+ * These were previously inline closures inside
+ * `SpaceTaskAgentManager.buildNodeAgentMcpServer`. Extracting them here lets
+ * them be unit-tested directly (see `end-node-handlers.test.ts`) and keeps the
+ * manager focused on orchestration.
+ *
+ * Contract notes:
+ *   - All three handlers return a `ToolResult` (never throw).
+ *   - `onReportResult` never touches `reportedStatus`; splitting audit from
+ *     closure is the whole point of the refactor.
+ *   - `onApproveTask` re-checks autonomy at call time as defense-in-depth;
+ *     tool registration already gates the surface, but a racing autonomy-level
+ *     downgrade between registration and invocation would otherwise slip
+ *     through.
+ *   - `onSubmitForApproval` sets `status='review'` plus pending-completion
+ *     fields so the UI banner can route a human to approve/reject.
+ */
+
+import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import type { SpaceTaskReportResultRepository } from '../../../storage/repositories/space-task-report-result-repository';
+import type { SpaceManager } from '../managers/space-manager';
+import type { DaemonHub } from '../../daemon-hub';
+import type { SpaceTask, SpaceWorkflow } from '@neokai/shared';
+import type { ToolResult } from './tool-result';
+import { jsonResult } from './tool-result';
+import type {
+	ApproveTaskInput,
+	ReportResultInput,
+	SubmitForApprovalInput,
+} from './task-agent-tool-schemas';
+import { Logger } from '../../logger';
+
+const log = new Logger('end-node-handlers');
+
+/**
+ * Dependencies for building end-node handlers. All fields are required EXCEPT
+ * `daemonHub` — when absent the handlers still succeed, they just do not emit
+ * lifecycle events (used in unit tests).
+ */
+export interface EndNodeHandlerDeps {
+	/** Task being finalized. */
+	taskId: string;
+	/** Space the task belongs to. Needed for autonomy lookup + event payloads. */
+	spaceId: string;
+	/** Workflow the task was executed under. Needed for completionAutonomyLevel. */
+	workflow: SpaceWorkflow | null;
+	/** Workflow node ID of the calling agent — stored for audit + pending fields. */
+	workflowNodeId: string;
+	/** Agent name calling the tool — written to the audit log. */
+	agentName: string;
+	/** Task repository. */
+	taskRepo: SpaceTaskRepository;
+	/** Append-only report result repository (used by report_result). */
+	taskReportResultRepo: SpaceTaskReportResultRepository;
+	/** Space manager — used to look up current autonomy level for approve_task. */
+	spaceManager: Pick<SpaceManager, 'getSpace'>;
+	/** Optional hub for emitting `space.task.updated` events after state changes. */
+	daemonHub?: Pick<DaemonHub, 'emit'>;
+}
+
+export interface EndNodeHandlers {
+	onReportResult: (args: ReportResultInput) => Promise<ToolResult>;
+	onApproveTask: (args: ApproveTaskInput) => Promise<ToolResult>;
+	onSubmitForApproval: (args: SubmitForApprovalInput) => Promise<ToolResult>;
+}
+
+/**
+ * Create the three end-node tool handlers bound to a specific task/workflow/
+ * agent context. The returned handlers are pure closures — repeated calls
+ * with the same `deps` return independent instances.
+ */
+export function createEndNodeHandlers(deps: EndNodeHandlerDeps): EndNodeHandlers {
+	const {
+		taskId,
+		spaceId,
+		workflow,
+		workflowNodeId,
+		agentName,
+		taskRepo,
+		taskReportResultRepo,
+		spaceManager,
+		daemonHub,
+	} = deps;
+
+	const emitTaskUpdated = (task: SpaceTask): void => {
+		if (!daemonHub) return;
+		void daemonHub
+			.emit('space.task.updated', { sessionId: 'global', spaceId, taskId, task })
+			.catch((err: unknown) => {
+				log.warn(
+					`Failed to emit space.task.updated for task ${taskId}: ${err instanceof Error ? err.message : String(err)}`
+				);
+			});
+	};
+
+	return {
+		// -------------------------------------------------------------------
+		// report_result — APPEND-ONLY. Never mutates task state.
+		// -------------------------------------------------------------------
+		onReportResult: async (args: ReportResultInput) => {
+			const task = taskRepo.getTask(taskId);
+			if (!task) return jsonResult({ success: false, error: `Task not found: ${taskId}` });
+
+			try {
+				taskReportResultRepo.append({
+					taskId,
+					spaceId,
+					workflowNodeId,
+					agentName,
+					summary: args.summary,
+					evidence: args.evidence ?? null,
+				});
+				return jsonResult({
+					success: true,
+					taskId,
+					summary: args.summary,
+					message:
+						'Result recorded to audit log. This does NOT close the task — call approve_task (if available) or submit_for_approval to finalize.',
+				});
+			} catch (err) {
+				return jsonResult({
+					success: false,
+					error: err instanceof Error ? err.message : String(err),
+				});
+			}
+		},
+
+		// -------------------------------------------------------------------
+		// approve_task — self-close. Re-checks autonomy at call time.
+		// -------------------------------------------------------------------
+		onApproveTask: async (_args: ApproveTaskInput) => {
+			const space = await spaceManager.getSpace(spaceId);
+			const currentLevel = space?.autonomyLevel ?? 1;
+			const required = workflow?.completionAutonomyLevel ?? 5;
+			if (currentLevel < required) {
+				return jsonResult({
+					success: false,
+					error: `approve_task not permitted: space autonomy level ${currentLevel} < workflow completionAutonomyLevel ${required}. Use submit_for_approval to request human review.`,
+				});
+			}
+
+			const task = taskRepo.getTask(taskId);
+			if (!task) return jsonResult({ success: false, error: `Task not found: ${taskId}` });
+
+			try {
+				const updated = taskRepo.updateTask(taskId, {
+					reportedStatus: 'done',
+					// Clear any pending-completion state in case a prior submit_for_approval
+					// set it; approval supersedes the pending request.
+					pendingCheckpointType: null,
+					pendingCompletionSubmittedByNodeId: null,
+					pendingCompletionSubmittedAt: null,
+					pendingCompletionReason: null,
+				});
+				if (updated) emitTaskUpdated(updated);
+				return jsonResult({
+					success: true,
+					taskId,
+					message:
+						'Task approved for completion. The completion-action pipeline will now resolve terminal status.',
+				});
+			} catch (err) {
+				return jsonResult({
+					success: false,
+					error: err instanceof Error ? err.message : String(err),
+				});
+			}
+		},
+
+		// -------------------------------------------------------------------
+		// submit_for_approval — human sign-off. Always available to end nodes.
+		// -------------------------------------------------------------------
+		onSubmitForApproval: async (args: SubmitForApprovalInput) => {
+			const task = taskRepo.getTask(taskId);
+			if (!task) return jsonResult({ success: false, error: `Task not found: ${taskId}` });
+
+			try {
+				const updated = taskRepo.updateTask(taskId, {
+					status: 'review',
+					pendingCheckpointType: 'task_completion',
+					pendingCompletionSubmittedByNodeId: workflowNodeId,
+					pendingCompletionSubmittedAt: Date.now(),
+					pendingCompletionReason: args.reason ?? null,
+				});
+				if (updated) emitTaskUpdated(updated);
+				return jsonResult({
+					success: true,
+					taskId,
+					message: `Task submitted for human review${args.reason ? ` (reason: ${args.reason})` : ''}. A human must approve or reject via the UI before the workflow continues.`,
+				});
+			} catch (err) {
+				return jsonResult({
+					success: false,
+					error: err instanceof Error ? err.message : String(err),
+				});
+			}
+		},
+	};
+}

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -27,8 +27,16 @@
 
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import type { DaemonHub } from '../../daemon-hub';
-import { ReportResultSchema } from './task-agent-tool-schemas';
-import type { ReportResultInput } from './task-agent-tool-schemas';
+import {
+	ReportResultSchema,
+	ApproveTaskSchema,
+	SubmitForApprovalSchema,
+} from './task-agent-tool-schemas';
+import type {
+	ReportResultInput,
+	ApproveTaskInput,
+	SubmitForApprovalInput,
+} from './task-agent-tool-schemas';
 import { Logger } from '../../logger';
 import type { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
 import { ChannelResolver } from '../runtime/channel-resolver';
@@ -159,10 +167,26 @@ export interface NodeAgentToolsConfig {
 	/**
 	 * Optional callback for the `report_result` tool.
 	 * When provided, a `report_result` tool is added to the MCP server —
-	 * intended for the end node of a workflow so it can close the workflow run.
+	 * intended for the end node of a workflow so it can append an audit record
+	 * of what it observed. Design v2: this call does NOT close the task.
 	 * When absent, `report_result` is not available to this node agent.
 	 */
 	onReportResult?: (args: ReportResultInput) => Promise<ToolResult>;
+	/**
+	 * Optional callback for the `approve_task` tool. When provided, `approve_task`
+	 * is added to the MCP server. Intended for the end node when
+	 * `space.autonomyLevel >= workflow.completionAutonomyLevel`. The handler
+	 * also runtime-checks as defense-in-depth against a buggy/malicious client
+	 * bypassing registration gating.
+	 */
+	onApproveTask?: (args: ApproveTaskInput) => Promise<ToolResult>;
+	/**
+	 * Optional callback for the `submit_for_approval` tool. When provided, the
+	 * tool is added to the MCP server. Always present for end nodes regardless
+	 * of autonomy level — agents may voluntarily escalate risky outcomes for
+	 * human review even when they could self-close.
+	 */
+	onSubmitForApproval?: (args: SubmitForApprovalInput) => Promise<ToolResult>;
 	/**
 	 * Resolves the space's current autonomy level.
 	 * When provided, agent gate writes via send_message are blocked when
@@ -989,12 +1013,40 @@ export function createNodeAgentMcpServer(config: NodeAgentToolsConfig) {
 			? [
 					tool(
 						'report_result',
-						'Record the final result of the workflow — the runtime decides the terminal status via completion actions. ' +
-							'Only available to the end node of the workflow. ' +
-							'Provide a human-readable summary and optional structured evidence (prUrl, commitSha, testOutput, …). ' +
-							'Do NOT pass a `status` — the completion-action pipeline is the sole arbiter of success/failure.',
+						"Append an audit record of what you observed to the task's report log. " +
+							'This does NOT close the task — it is append-only. To finalize the task, ' +
+							'call `approve_task` (if available) for self-close, or `submit_for_approval` ' +
+							'to request human review. Provide a human-readable summary and optional ' +
+							'structured evidence (prUrl, commitSha, testOutput, …).',
 						ReportResultSchema.shape,
 						(args) => onReportResult(args)
+					),
+				]
+			: []),
+		...(config.onApproveTask
+			? [
+					tool(
+						'approve_task',
+						'Close this task as done (self-approval). Only available when the space autonomy level ' +
+							"meets the workflow's completionAutonomyLevel threshold. Takes no arguments — the task " +
+							'is inferred from your session context. After calling, the completion-action pipeline ' +
+							'runs and resolves the terminal status. Use this as your final action when you are ' +
+							'authorized to self-close; otherwise use submit_for_approval.',
+						ApproveTaskSchema.shape,
+						(args) => config.onApproveTask!(args)
+					),
+				]
+			: []),
+		...(config.onSubmitForApproval
+			? [
+					tool(
+						'submit_for_approval',
+						"Request human review of this task's completion. Always available to end-node agents. " +
+							'Use this when you want to escalate for human sign-off — either because autonomy rules ' +
+							'require it, or because the outcome is risky enough to warrant attention. Pass an ' +
+							'optional `reason` explaining why you are escalating; it is shown in the approval UI.',
+						SubmitForApprovalSchema.shape,
+						(args) => config.onSubmitForApproval!(args)
 					),
 				]
 			: []),

--- a/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
@@ -81,6 +81,56 @@ export const ReportResultSchema = z
 export type ReportResultInput = z.infer<typeof ReportResultSchema>;
 
 // ---------------------------------------------------------------------------
+// approve_task
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `approve_task` input.
+ *
+ * Agent-self-close tool for end-node agents. Conditionally registered on the
+ * MCP server only when `space.autonomyLevel >= workflow.completionAutonomyLevel`.
+ * Calling this tool sets `space_tasks.reportedStatus = 'done'`, triggering the
+ * completion-action pipeline on the next runtime tick.
+ *
+ * Takes no arguments — the task, workflow, and node are implicit from the
+ * calling session's context. Strict schema so future fields fail fast until
+ * explicitly added.
+ */
+export const ApproveTaskSchema = z.object({}).strict();
+
+export type ApproveTaskInput = z.infer<typeof ApproveTaskSchema>;
+
+// ---------------------------------------------------------------------------
+// submit_for_approval
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `submit_for_approval` input.
+ *
+ * Always available to end-node agents (independent of autonomy level). Marks
+ * the task as awaiting human sign-off: sets `task.status = 'review'` and
+ * populates the pending-completion fields so the UI can route a human to
+ * approve or reject. Even at high autonomy levels this remains available —
+ * agents may want to escalate a risky result for attention.
+ */
+export const SubmitForApprovalSchema = z
+	.object({
+		/**
+		 * Optional human-readable reason for requesting review. Surfaces in the
+		 * approval UI so the human reviewer knows why the agent escalated.
+		 */
+		reason: z
+			.string()
+			.describe(
+				'Optional note explaining why you are requesting human review (visible in the approval UI)'
+			)
+			.optional(),
+	})
+	.strict();
+
+export type SubmitForApprovalInput = z.infer<typeof SubmitForApprovalSchema>;
+
+// ---------------------------------------------------------------------------
 // request_human_input
 // ---------------------------------------------------------------------------
 
@@ -123,6 +173,8 @@ export type ListGroupMembersInput = z.infer<typeof ListGroupMembersSchema>;
  */
 export const TASK_AGENT_TOOL_SCHEMAS = {
 	report_result: ReportResultSchema,
+	approve_task: ApproveTaskSchema,
+	submit_for_approval: SubmitForApprovalSchema,
 	request_human_input: RequestHumanInputSchema,
 	list_group_members: ListGroupMembersSchema,
 } as const;

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -23,6 +23,7 @@ import type { DaemonHub } from '../../daemon-hub';
 import { Logger } from '../../logger';
 import type { SpaceTaskManager } from '../managers/space-task-manager';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import type { SpaceTaskReportResultRepository } from '../../../storage/repositories/space-task-report-result-repository';
 import type { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
 import type { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
@@ -86,6 +87,12 @@ export interface TaskAgentToolsConfig {
 	workflowRunId: string;
 	/** Task repository for direct DB reads. */
 	taskRepo: SpaceTaskRepository;
+	/**
+	 * Append-only audit log for `report_result` tool calls. Design v2 (Task #39):
+	 * the task-agent `report_result` is purely audit — it does not mutate task
+	 * state or emit `space.task.done`. Each call appends one row here.
+	 */
+	taskReportResultRepo: SpaceTaskReportResultRepository;
 	/** Node execution repository for querying execution state in list_group_members. */
 	nodeExecutionRepo: NodeExecutionRepository;
 	/** Task manager for validated status transitions. */
@@ -171,6 +178,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		space,
 		workflowRunId,
 		taskRepo,
+		taskReportResultRepo,
 		nodeExecutionRepo,
 		taskManager,
 		messageInjector,
@@ -221,13 +229,18 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 
 	return {
 		/**
-		 * Report the final outcome of the task and close the task lifecycle.
+		 * Record a progress report (Design v2 — Task #39, append-only audit).
 		 *
-		 * The agent supplies only a summary + optional evidence. The runtime —
-		 * not this tool — decides the final task status via the completion-
-		 * action pipeline. Internally we mark the task as `done` so the
-		 * CompletionDetector picks it up; the pipeline may flip it to
-		 * `needs_attention` / `blocked` / etc. based on its actions.
+		 * Post Stage-2, `report_result` is NOT a terminal tool. It simply appends
+		 * one row to `space_task_report_results` so the full history of reports
+		 * issued during a task is preserved. It never mutates task status, never
+		 * emits `space.task.done`, and never triggers the completion-action
+		 * pipeline.
+		 *
+		 * Terminal state is decided by:
+		 *   - End-node agents: via `approve_task` (auto-close when autonomy
+		 *     permits) or `submit_for_approval` (human review).
+		 *   - Human operators: via `spaceTask.approvePendingCompletion` RPC.
 		 */
 		async report_result(args: ReportResultInput): Promise<ToolResult> {
 			const { summary, evidence } = args;
@@ -237,43 +250,23 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				return jsonResult({ success: false, error: `Task not found: ${taskId}` });
 			}
 
-			// Serialize evidence into the summary so downstream consumers (PR
-			// reviewers, verification actions) can inspect it. The dedicated
-			// structured column is a Stage-3 concern.
-			const serializedSummary = evidence
-				? `${summary}\n\n<!-- evidence -->\n${JSON.stringify(evidence, null, 2)}`
-				: summary;
-
 			try {
-				await taskManager.setTaskStatus(taskId, 'done', {
-					result: serializedSummary,
+				const record = taskReportResultRepo.append({
+					taskId,
+					spaceId: space.id,
+					workflowNodeId: null,
+					agentName: 'task-agent',
+					summary,
+					evidence: evidence ?? null,
 				});
-
-				// Emit DaemonHub event so the Space Agent is notified of task completion.
-				// Completion-action pipeline may later downgrade to `space.task.failed`.
-				if (daemonHub) {
-					const eventPayload = {
-						sessionId: 'global',
-						taskId,
-						spaceId: space.id,
-						status: 'done' as const,
-						summary: summary ?? '',
-						workflowRunId,
-						taskTitle: mainTask.title,
-					};
-					void daemonHub.emit('space.task.done', eventPayload).catch((err) => {
-						log.warn(
-							`Failed to emit space.task.done for task ${taskId}: ${err instanceof Error ? err.message : String(err)}`
-						);
-					});
-				}
 
 				return jsonResult({
 					success: true,
 					taskId,
-					summary,
+					reportId: record.id,
 					message:
-						'Result recorded. The completion-action pipeline will determine the final task status.',
+						'Report recorded (audit-only). This does not close the task. ' +
+						'Use approve_task or submit_for_approval on an end node to finalize.',
 				});
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
@@ -803,8 +796,12 @@ export function createTaskAgentMcpServer(config: TaskAgentToolsConfig) {
 	const tools = [
 		tool(
 			'report_result',
-			'Mark the task as completed, failed, or cancelled and record the result summary. ' +
-				'Call this when the workflow reaches a terminal node or an unrecoverable error occurs.',
+			'Record a progress report for this task as an append-only audit entry. ' +
+				'This does NOT close the task — it only appends a summary (and optional evidence) ' +
+				'to the task report history. Terminal completion is handled by `approve_task` ' +
+				'(end-node, self-close when autonomy permits) or `submit_for_approval` (end-node, ' +
+				'human review). Use `report_result` to share intermediate outcomes, status updates, ' +
+				'or findings without ending the workflow run.',
 			ReportResultSchema.shape,
 			(args) => handlers.report_result(args)
 		),

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -297,9 +297,13 @@ const PD_TASK_DISPATCHER_PROMPT =
 	'You are the Task Dispatcher in a Plan & Decompose Workflow. You are the end node. ' +
 	'All four Plan Reviewers have approved the plan — your job is to fan the plan out into ' +
 	'standalone follow-up tasks using the `create_standalone_task` MCP tool.\n\n' +
-	'**You MUST call `report_result` as your final action.** It is the only signal the runtime ' +
-	'accepts as completion — finishing without it leaves the workflow stuck. Do all task ' +
-	'creation BEFORE calling `report_result`.\n\n' +
+	'TOOL CONTRACT (Design v2):\n' +
+	'- `report_result({ summary, evidence? })` — append-only audit. Records the dispatch ' +
+	'outcome. Does NOT close the task.\n' +
+	'- `approve_task()` — closes this task as done. Call after every required downstream task ' +
+	'has been created.\n' +
+	'- `submit_for_approval({ reason? })` — request human sign-off instead of self-closing. ' +
+	'Use when autonomy blocks self-close.\n\n' +
 	'Steps:\n' +
 	'1. Read the approved plan from the plan PR (`gh pr diff` or `gh pr view --json files`). ' +
 	'Identify each actionable work item.\n' +
@@ -307,28 +311,40 @@ const PD_TASK_DISPATCHER_PROMPT =
 	'clear, imperative title and a description that gives the downstream worker everything they ' +
 	'need (context, acceptance criteria, references to the plan).\n' +
 	'3. Collect the returned task IDs.\n' +
-	'4. Call `report_result(status="done", summary="Created N tasks from plan: <short list>", ' +
-	'evidence={ created_task_ids: [<ids>] })` as your last tool call.\n\n' +
+	'4. Call `report_result({ summary: "Created N tasks from plan: <short list>", ' +
+	'evidence: { created_task_ids: [<ids>] } })` to record the dispatch audit entry.\n' +
+	'5. Call `approve_task()` as your final action. If autonomy blocks self-close, call ' +
+	'`submit_for_approval({ reason: "..." })` instead.\n\n' +
 	'Do NOT implement the work items yourself. Do NOT create fewer tasks than the plan requires. ' +
-	'If the plan is empty or ambiguous, send feedback to Planning before calling report_result.';
+	'If the plan is empty or ambiguous, send feedback to Planning before closing the task.';
 
 const FULLSTACK_CODING_PROMPT =
 	'You are the Coder in a Fullstack QA Loop workflow. You implement backend + frontend changes, ' +
 	'write tests, and keep one PR updated across review and QA cycles.\n\n' +
-	'When implementation is ready, ensure the PR is open and mergeable, write code-pr-gate with ' +
-	'field pr_url, then call report_result() to mark Coding complete.';
+	'When implementation is ready, ensure the PR is open and mergeable and write code-pr-gate with ' +
+	'field pr_url so Review can activate. Coding is not the end node — the task-completion tools ' +
+	'(`approve_task`, `submit_for_approval`) are not available to you.';
 
 const FULLSTACK_REVIEW_PROMPT =
 	'You are the Reviewer in a Fullstack QA Loop workflow. Review the PR for correctness, ' +
 	'maintainability, and coverage before QA.\n\n' +
 	'If the change is ready for QA, write to review-approval-gate (field: approved = true). ' +
-	'If changes are needed, send actionable feedback to Coding.';
+	'If changes are needed, send actionable feedback to Coding. Review is not the end node, ' +
+	'so the task-completion tools are not available to you.';
 
 const FULLSTACK_QA_PROMPT =
 	'You are the QA node in a Fullstack QA Loop workflow. Run thorough validation, including backend tests, ' +
 	'frontend tests, and browser-based checks for critical flows.\n\n' +
-	'If everything passes, call report_result() with the QA evidence summary. ' +
-	'If issues are found, send a detailed fix list to Coding.';
+	'TOOL CONTRACT (Design v2):\n' +
+	'- `report_result({ summary, evidence? })` — append-only audit. Records what you observed ' +
+	'during this cycle. Does NOT close the task.\n' +
+	'- `approve_task()` — closes this task as done. Only call after the PR is actually merged ' +
+	'and the workspace is synced.\n' +
+	'- `submit_for_approval({ reason? })` — request human sign-off instead of self-closing. ' +
+	'Use when autonomy blocks self-close.\n\n' +
+	'If everything passes, merge the PR, sync the worktree, then call `report_result` followed by ' +
+	'`approve_task`. If issues are found, send a detailed fix list to Coding and record a ' +
+	'`report_result({ summary: "QA failed: ..." })` audit entry; do NOT call `approve_task`.';
 
 const RESEARCH_RESEARCH_NODE = 'tpl-research-research';
 const RESEARCH_REVIEW_NODE = 'tpl-research-review';
@@ -416,16 +432,20 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'- The Review → Coding channel is gated by `review-posted-gate` — the runtime ' +
 							'checks GitHub for a fresh review before releasing your message. If you skip ' +
 							'`gh pr review`, the gate will block and the coder will never hear from you.\n\n' +
-							'**You MUST call `report_result` to end this workflow.** It is the only signal ' +
-							'the runtime accepts as completion — finishing your turn without it leaves the ' +
-							'workflow stuck. Do all your review work — read files, run tests, post comments ' +
-							'to GitHub, send messages to Coding — BEFORE calling `report_result`. After it ' +
-							'returns, do not invoke any other tools.\n\n' +
+							'TOOL CONTRACT (Design v2):\n' +
+							'- `report_result({ summary, evidence? })` — append-only audit. Records what you ' +
+							'observed. Does NOT close the task. Call it every cycle (changes-requested AND ' +
+							'approval) so the audit log has a clear trail of each decision.\n' +
+							'- `approve_task()` — closes this task as done. Call this ONLY when you are ' +
+							'satisfied the work is shippable. It is gated by autonomy level; the runtime ' +
+							'will tell you if the level is too low.\n' +
+							'- `submit_for_approval({ reason? })` — request human sign-off instead of self- ' +
+							'closing. Use when the change is risky or the autonomy rules block self-close.\n\n' +
 							'Review checklist:\n' +
 							'1. Read the PR diff (`gh pr diff`) AND explore the worktree for context\n' +
 							'2. Check for correctness, style, test coverage, and integration impact\n' +
 							'3. Run the relevant tests yourself if uncertain\n' +
-							'4. If changes needed:\n' +
+							'4. If changes are needed:\n' +
 							'   a. Post a summary review: `gh pr review <pr-url> --request-changes ' +
 							'--body-file /tmp/review.md`. Capture the returned review URL.\n' +
 							'   b. For each issue, post a line-level comment: `gh api ' +
@@ -435,11 +455,15 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'data={ pr_url: "<url>", review_url: "<gh pr review url>", ' +
 							'comment_urls: ["<comment #1 url>", "<comment #2 url>"] }). The `data` payload ' +
 							'satisfies the review-posted-gate and gives the coder direct links to each ' +
-							'thread. Do NOT call `report_result` — leave the workflow open for the next round.\n' +
+							'thread.\n' +
+							'   d. Call `report_result({ summary: "Requested changes: ...", evidence: { ' +
+							'prUrl, reviewUrl } })` so the cycle is recorded. Do NOT call `approve_task` — ' +
+							'the workflow must stay open for the next cycle.\n' +
 							'5. If satisfied: post an approval review with `gh pr review <pr-url> --approve ' +
 							'--body-file <file>`, verify the PR is open and mergeable, then call ' +
-							'`report_result({ summary, evidence: { prUrl } })` as your final action. ' +
-							'Do NOT pass a `status` — the runtime decides the terminal state via completion actions.',
+							'`report_result({ summary, evidence: { prUrl } })` to record the audit entry, ' +
+							'and finally call `approve_task()` to close the task. If autonomy blocks ' +
+							'self-close, call `submit_for_approval({ reason: "..." })` instead.',
 					},
 				},
 			],
@@ -451,6 +475,9 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 	tags: ['coding', 'default'],
 	createdAt: 0,
 	updatedAt: 0,
+	// Default coding loop — reviewer may auto-close when space runs at the
+	// standard "trusted but supervised" tier (3).
+	completionAutonomyLevel: 3,
 	gates: [
 		{
 			id: 'code-ready-gate',
@@ -564,21 +591,24 @@ export const RESEARCH_WORKFLOW: SpaceWorkflow = {
 						value:
 							'You are the Reviewer in a Research→Reviewer iterative workflow. You review the ' +
 							'research findings for completeness, accuracy, and quality.\n\n' +
-							'**You MUST call `report_result` to end this workflow.** It is the only signal the ' +
-							'runtime accepts as completion — finishing your turn without it leaves the workflow ' +
-							'stuck. Do all your review work BEFORE calling `report_result`; it must be your last ' +
-							'tool call. Do not call it when requesting more research — leave the workflow open ' +
-							'for the next round in that case.\n\n' +
+							'TOOL CONTRACT (Design v2):\n' +
+							'- `report_result({ summary, evidence? })` — append-only audit. Records what you ' +
+							'observed during this cycle. Does NOT close the task.\n' +
+							'- `approve_task()` — closes the task as done. Call only when satisfied.\n' +
+							'- `submit_for_approval({ reason? })` — request human sign-off instead of self- ' +
+							'closing. Use when autonomy rules block self-close or the finding is sensitive.\n\n' +
 							'Review checklist:\n' +
 							'1. Read all research documents in the PR (`gh pr diff`)\n' +
 							'2. Check completeness: does the research answer the original question?\n' +
 							'3. Check accuracy: are claims supported by evidence or sources?\n' +
 							'4. Check clarity: are findings well-organized and easy to follow?\n' +
-							'5. If more research needed: send_message back to Research with specific areas to ' +
-							'investigate (do NOT call `report_result`)\n' +
-							'6. If satisfied: verify the PR is still open and mergeable, then call ' +
-							'`report_result({ summary, evidence: { prUrl } })` as your final action. ' +
-							'Do NOT pass a `status` — the runtime decides the terminal state via completion actions.',
+							'5. If more research is needed: send_message back to Research with specific areas ' +
+							'to investigate, then `report_result({ summary: "Requested more research: ..." })` ' +
+							'to record the cycle. Do NOT call `approve_task` — leave the workflow open.\n' +
+							'6. If satisfied: verify the PR is still open and mergeable, call ' +
+							'`report_result({ summary, evidence: { prUrl } })` to record the final audit ' +
+							'entry, then `approve_task()` to close. If autonomy blocks self-close, call ' +
+							'`submit_for_approval({ reason: "..." })` instead.',
 					},
 				},
 			],
@@ -590,6 +620,9 @@ export const RESEARCH_WORKFLOW: SpaceWorkflow = {
 	tags: ['research'],
 	createdAt: 0,
 	updatedAt: 0,
+	// Research is low-risk (read-only investigation + PR of findings) — permit
+	// auto-close at a more conservative autonomy tier than coding loops.
+	completionAutonomyLevel: 2,
 	gates: [
 		{
 			id: 'research-ready-gate',
@@ -654,13 +687,16 @@ export const REVIEW_ONLY_WORKFLOW: SpaceWorkflow = {
 						value:
 							'You are the sole Reviewer in a single-node Review-Only workflow. There is no planning ' +
 							'or coding phase — you are reviewing an existing PR or codebase directly.\n\n' +
-							'**You MUST call `report_result` to end this workflow.** It is the only signal the ' +
-							'runtime accepts as completion — finishing your turn without it leaves the workflow ' +
-							'stuck. Do all review work BEFORE calling `report_result`; it must be your last tool ' +
-							'call.\n\n' +
+							'TOOL CONTRACT (Design v2):\n' +
+							'- `report_result({ summary, evidence? })` — append-only audit. Records what you ' +
+							'observed. Does NOT close the task.\n' +
+							'- `approve_task()` — closes the task as done. Call only after you have posted ' +
+							'your review to the PR via `gh pr review`.\n' +
+							'- `submit_for_approval({ reason? })` — request human sign-off instead of self- ' +
+							'closing. Use when autonomy blocks self-close.\n\n' +
 							'**You MUST post your review to the PR via `gh pr review` BEFORE calling ' +
-							'`report_result`.** An internal summary is not enough — the author must be able to see ' +
-							'your feedback on GitHub. Use:\n' +
+							'`approve_task` or `submit_for_approval`.** An internal summary is not enough — the ' +
+							'author must be able to see your feedback on GitHub. Use:\n' +
 							'- `gh pr review <pr-url> --body-file <file>` with `--approve`, `--request-changes`, or ' +
 							'`--comment`.\n' +
 							'- `gh api repos/{owner}/{repo}/pulls/{n}/comments` for line-level comments anchored to ' +
@@ -670,11 +706,11 @@ export const REVIEW_ONLY_WORKFLOW: SpaceWorkflow = {
 							'2. Check for correctness, security, performance, and style issues\n' +
 							'3. Verify test coverage is adequate\n' +
 							'4. Post your review to the PR via `gh pr review` (+ inline comments via `gh api` ' +
-							'where relevant) — this is required, not optional, and the runtime verifies at ' +
-							'least one review/comment exists before accepting completion\n' +
-							'5. Summarize your findings clearly for the task record\n' +
-							'6. Call `report_result({ summary, evidence: { prUrl } })` as your final action. ' +
-							'Do NOT pass a `status` — the runtime decides the terminal state via completion actions.',
+							'where relevant) — this is required, not optional; the runtime verifies at least one ' +
+							'review/comment exists before accepting completion\n' +
+							'5. Call `report_result({ summary, evidence: { prUrl } })` to record the audit entry\n' +
+							'6. Call `approve_task()` as your final action. If autonomy blocks self-close, call ' +
+							'`submit_for_approval({ reason: "..." })` instead.',
 					},
 				},
 			],
@@ -686,6 +722,9 @@ export const REVIEW_ONLY_WORKFLOW: SpaceWorkflow = {
 	tags: ['review'],
 	createdAt: 0,
 	updatedAt: 0,
+	// Review-only is low-risk (no code changes, only feedback posting) — permit
+	// auto-close at the same conservative tier as Research.
+	completionAutonomyLevel: 2,
 };
 
 /**
@@ -886,6 +925,10 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
 	tags: ['planning', 'decomposition'],
 	createdAt: 0,
 	updatedAt: 0,
+	// Plan & Decompose ends by creating follow-up tasks (no merges, no
+	// destructive actions) but does alter the task graph — match the default
+	// Coding Workflow tier.
+	completionAutonomyLevel: 3,
 	gates: [
 		{
 			id: 'plan-pr-gate',
@@ -982,8 +1025,7 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
 							'2. Add/update unit, integration, and UI tests as needed\n' +
 							'3. Open or update the PR and ensure it remains mergeable\n' +
 							'4. Write code-pr-gate with field pr_url so Review can activate\n' +
-							'5. Call report_result() with a concise coding handoff summary\n' +
-							'6. Share blockers clearly with Reviewer/QA when needed',
+							'5. Share blockers clearly with Reviewer/QA when needed',
 					},
 				},
 			],
@@ -1020,23 +1062,21 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
 						value:
 							FULLSTACK_QA_PROMPT +
 							'\n\n' +
-							'**You MUST call `report_result` to end this workflow.** It is the only signal the ' +
-							'runtime accepts as completion — finishing your turn without it leaves the workflow ' +
-							'stuck. `report_result` must be your last tool call. Do not call it when sending ' +
-							'feedback to Coding — leave the workflow open for the next round in that case.\n\n' +
 							'Expected inputs: Reviewer-approved PR.\n' +
 							'Expected outputs: PR merged and worktree synced, or QA feedback to Coding.\n\n' +
 							'Steps:\n' +
 							'1. Run backend and frontend test suites\n' +
 							'2. Run browser-based critical-path validation\n' +
 							'3. Validate CI and mergeability\n' +
-							'4. If fail: send detailed failures and repro steps to Coding (do NOT call ' +
-							'`report_result`)\n' +
+							'4. If fail: send detailed failures and repro steps to Coding, then call ' +
+							'`report_result({ summary: "QA failed: ..." })` to record the audit entry. Do ' +
+							'NOT call `approve_task` — leave the workflow open for the next Coding cycle.\n' +
 							'5. If all green: merge the PR with `gh pr merge <URL> --squash`\n' +
 							'6. Sync worktree: `git checkout <base-branch> && git pull --ff-only`\n' +
-							'7. Call `report_result({ summary, evidence: { prUrl, testOutput } })` confirming ' +
-							'merge and sync. Do NOT pass a `status` — the runtime verifies the PR is actually ' +
-							'merged before accepting completion.',
+							'7. Call `report_result({ summary, evidence: { prUrl, testOutput } })` to record ' +
+							'the audit entry, then `approve_task()` as your final action. If autonomy blocks ' +
+							'self-close, call `submit_for_approval({ reason: "..." })` instead. The runtime ' +
+							'also verifies the PR is actually merged before accepting completion.',
 					},
 				},
 			],
@@ -1048,6 +1088,9 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
 	tags: ['fullstack', 'qa', 'browser-testing'],
 	createdAt: 0,
 	updatedAt: 0,
+	// QA loop ends with the QA node actually merging the PR — permit auto-close
+	// only at the highest "autonomous with safety nets" tier.
+	completionAutonomyLevel: 4,
 	gates: [
 		{
 			id: 'code-pr-gate',
@@ -1264,6 +1307,7 @@ export function seedBuiltInWorkflows(
 					? template.channels.map((ch) => ({ ...ch, id: ch.id ?? generateUUID() }))
 					: undefined,
 				gates: template.gates ? [...template.gates] : undefined,
+				completionAutonomyLevel: template.completionAutonomyLevel,
 				templateName: template.name,
 				templateHash: computeWorkflowHash(template),
 			});

--- a/packages/daemon/src/lib/space/workflows/template-hash.ts
+++ b/packages/daemon/src/lib/space/workflows/template-hash.ts
@@ -27,6 +27,12 @@ interface WorkflowFingerprint {
 	 * gate internals (not just gate additions/removals).
 	 */
 	gates: string[];
+	// NOTE: `completionAutonomyLevel` is intentionally NOT part of the
+	// fingerprint. Including it would invalidate historical template hashes
+	// computed by Migration 94 and make every existing Space's workflow appear
+	// drifted on upgrade. The field is persisted and enforced at runtime, but
+	// structural drift detection continues to track only the node/channel/gate
+	// topology as before.
 }
 
 /**

--- a/packages/daemon/src/storage/repositories/space-task-report-result-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-report-result-repository.ts
@@ -1,0 +1,130 @@
+/**
+ * Space Task Report Result Repository
+ *
+ * Append-only repository for `space_task_report_results` rows.
+ *
+ * Each `report_result` tool call creates one row. Never updated; deleted only
+ * via ON DELETE CASCADE when the task or space is removed.
+ *
+ * This table exists so the `report_result` tool can audit what an end-node
+ * agent observed without mutating `space_tasks.reported_status` — that field
+ * is still the source of truth for whether the task is considered closed,
+ * and is only written by `approve_task` (agent self-close) or by the runtime
+ * after a human approves a `submit_for_approval` request.
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+import { generateUUID } from '@neokai/shared';
+import type { SpaceTaskReportResult } from '@neokai/shared';
+
+/** Input for `append()` — the repo generates `id` and `recordedAt`. */
+export type AppendSpaceTaskReportResultInput = Omit<SpaceTaskReportResult, 'id' | 'recordedAt'>;
+
+interface ReportResultRow {
+	id: string;
+	task_id: string;
+	space_id: string;
+	workflow_node_id: string | null;
+	agent_name: string | null;
+	summary: string;
+	evidence: string | null;
+	recorded_at: number;
+}
+
+export class SpaceTaskReportResultRepository {
+	constructor(private db: BunDatabase) {}
+
+	/**
+	 * Append a new `report_result` audit row.
+	 *
+	 * Evidence is stored as a JSON string; null round-trips as SQL NULL.
+	 */
+	append(input: AppendSpaceTaskReportResultInput): SpaceTaskReportResult {
+		const id = generateUUID();
+		const recordedAt = Date.now();
+		const evidenceJson = input.evidence === null ? null : JSON.stringify(input.evidence);
+
+		this.db
+			.prepare(
+				`INSERT INTO space_task_report_results
+					(id, task_id, space_id, workflow_node_id, agent_name, summary, evidence, recorded_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+			)
+			.run(
+				id,
+				input.taskId,
+				input.spaceId,
+				input.workflowNodeId,
+				input.agentName,
+				input.summary,
+				evidenceJson,
+				recordedAt
+			);
+
+		return {
+			id,
+			taskId: input.taskId,
+			spaceId: input.spaceId,
+			workflowNodeId: input.workflowNodeId,
+			agentName: input.agentName,
+			summary: input.summary,
+			evidence: input.evidence,
+			recordedAt,
+		};
+	}
+
+	/**
+	 * List all report results for a task in ascending `recordedAt` order.
+	 *
+	 * Ordering by `recorded_at ASC, rowid ASC` guarantees that two rows written
+	 * in the same millisecond stay in insert order (monotonic rowid tiebreak).
+	 */
+	listByTask(taskId: string): SpaceTaskReportResult[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM space_task_report_results
+				 WHERE task_id = ?
+				 ORDER BY recorded_at ASC, rowid ASC`
+			)
+			.all(taskId) as ReportResultRow[];
+		return rows.map((r) => this.rowToRecord(r));
+	}
+
+	/**
+	 * Return the most recently recorded result for a task, or null if none.
+	 */
+	getLatestByTask(taskId: string): SpaceTaskReportResult | null {
+		const row = this.db
+			.prepare(
+				`SELECT * FROM space_task_report_results
+				 WHERE task_id = ?
+				 ORDER BY recorded_at DESC, rowid DESC
+				 LIMIT 1`
+			)
+			.get(taskId) as ReportResultRow | undefined;
+		return row ? this.rowToRecord(row) : null;
+	}
+
+	private rowToRecord(row: ReportResultRow): SpaceTaskReportResult {
+		let evidence: Record<string, unknown> | null = null;
+		if (row.evidence !== null) {
+			try {
+				evidence = JSON.parse(row.evidence) as Record<string, unknown>;
+			} catch {
+				// Corrupt JSON — surface as null rather than throwing, matching the
+				// forgiving pattern used by gate-data-repository.
+				evidence = null;
+			}
+		}
+		return {
+			id: row.id,
+			taskId: row.task_id,
+			spaceId: row.space_id,
+			workflowNodeId: row.workflow_node_id,
+			agentName: row.agent_name,
+			summary: row.summary,
+			evidence,
+			recordedAt: row.recorded_at,
+		};
+	}
+}

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -272,6 +272,18 @@ export class SpaceTaskRepository {
 			fields.push('pending_checkpoint_type = ?');
 			values.push(params.pendingCheckpointType ?? null);
 		}
+		if (params.pendingCompletionSubmittedByNodeId !== undefined) {
+			fields.push('pending_completion_submitted_by_node_id = ?');
+			values.push(params.pendingCompletionSubmittedByNodeId ?? null);
+		}
+		if (params.pendingCompletionSubmittedAt !== undefined) {
+			fields.push('pending_completion_submitted_at = ?');
+			values.push(params.pendingCompletionSubmittedAt ?? null);
+		}
+		if (params.pendingCompletionReason !== undefined) {
+			fields.push('pending_completion_reason = ?');
+			values.push(params.pendingCompletionReason ?? null);
+		}
 		if (params.reportedStatus !== undefined) {
 			fields.push('reported_status = ?');
 			values.push(params.reportedStatus ?? null);
@@ -420,6 +432,10 @@ export class SpaceTaskRepository {
 			pendingActionIndex: (row.pending_action_index as number | null) ?? null,
 			pendingCheckpointType:
 				(row.pending_checkpoint_type as SpaceTask['pendingCheckpointType']) ?? null,
+			pendingCompletionSubmittedByNodeId:
+				(row.pending_completion_submitted_by_node_id as string | null) ?? null,
+			pendingCompletionSubmittedAt: (row.pending_completion_submitted_at as number | null) ?? null,
+			pendingCompletionReason: (row.pending_completion_reason as string | null) ?? null,
 			reportedStatus: (row.reported_status as SpaceTask['reportedStatus']) ?? null,
 			reportedSummary: (row.reported_summary as string | null) ?? null,
 			createdAt: row.created_at as number,

--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -17,6 +17,7 @@ import type { Database as BunDatabase } from 'bun:sqlite';
 import { generateUUID } from '@neokai/shared';
 import type {
 	SpaceWorkflow,
+	SpaceAutonomyLevel,
 	WorkflowNode,
 	WorkflowNodeInput,
 	WorkflowNodeAgent,
@@ -45,6 +46,7 @@ interface WorkflowRow {
 	template_name: string | null;
 	template_hash: string | null;
 	instructions: string | null;
+	completion_autonomy_level: number;
 	created_at: number;
 	updated_at: number;
 }
@@ -117,6 +119,7 @@ function rowToWorkflow(row: WorkflowRow, nodes: WorkflowNode[]): SpaceWorkflow {
 		nodes,
 		startNodeId,
 		tags,
+		completionAutonomyLevel: row.completion_autonomy_level as SpaceAutonomyLevel,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
 	};
@@ -145,6 +148,16 @@ export class SpaceWorkflowRepository {
 		const workflowId = generateUUID();
 		const now = Date.now();
 
+		if (params.completionAutonomyLevel === undefined || params.completionAutonomyLevel === null) {
+			// completion_autonomy_level is required — the runtime (MCP tool handlers,
+			// workflow builder, template seeder) must supply an explicit value. We
+			// never silently default here; the DB column has a NOT NULL default only
+			// to satisfy SQLite's ADD COLUMN backfill rules.
+			throw new Error(
+				`createWorkflow: completionAutonomyLevel is required (workflow name="${params.name}")`
+			);
+		}
+
 		// Pre-resolve node IDs so channels can reference them
 		const nodeInputs = params.nodes ?? [];
 		const resolvedNodes: Array<{ id: string; input: WorkflowNodeInput }> = nodeInputs.map(
@@ -164,8 +177,8 @@ export class SpaceWorkflowRepository {
 
 		this.db
 			.prepare(
-				`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, end_node_id, tags, channels, gates, layout, template_name, template_hash, instructions, created_at, updated_at)
-	         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+				`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, end_node_id, tags, channels, gates, layout, template_name, template_hash, instructions, completion_autonomy_level, created_at, updated_at)
+	         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			)
 			.run(
 				workflowId,
@@ -181,6 +194,7 @@ export class SpaceWorkflowRepository {
 				params.templateName ?? null,
 				params.templateHash ?? null,
 				params.instructions ?? null,
+				params.completionAutonomyLevel,
 				now,
 				now
 			);
@@ -279,6 +293,10 @@ export class SpaceWorkflowRepository {
 		if (params.instructions !== undefined) {
 			fields.push('instructions = ?');
 			values.push(params.instructions ?? null);
+		}
+		if (params.completionAutonomyLevel !== undefined) {
+			fields.push('completion_autonomy_level = ?');
+			values.push(params.completionAutonomyLevel);
 		}
 
 		const hasNodeReplacement = params.nodes !== undefined;

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -55,6 +55,8 @@ export { runMigration96 } from './migrations';
 export { runMigration97 } from './migrations';
 // knip-ignore-next-line
 export { runMigration98 } from './migrations';
+// knip-ignore-next-line
+export { runMigration99 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -436,6 +436,12 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	//   call; those are now enqueued to the job queue and the cached result is served
 	//   synchronously from this table on subsequent opens.
 	runMigration98(db);
+
+	// Migration 99: Tool-contract refactor for Task #39 — adds the
+	//   `space_workflows.completion_autonomy_level` column, three pending-completion
+	//   columns on `space_tasks`, and the `space_task_report_results` append-only
+	//   audit table used by the new `report_result` tool.
+	runMigration99(db);
 }
 
 /**
@@ -6306,4 +6312,112 @@ export function runMigration98(db: BunDatabase): void {
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_wrac_run_task_key ON workflow_run_artifact_cache(run_id, task_id, cache_key)`
 	);
+}
+
+/**
+ * Migration 99 — Tool-contract refactor for Task #39.
+ *
+ * Adds:
+ *   1. `space_workflows.completion_autonomy_level` (INTEGER, NOT NULL) — the
+ *      minimum autonomy level at which `approve_task` (agent self-close) is
+ *      registered on end-node agents.
+ *   2. `space_tasks.pending_completion_submitted_by_node_id` (TEXT, nullable)
+ *      `space_tasks.pending_completion_submitted_at` (INTEGER, nullable)
+ *      `space_tasks.pending_completion_reason` (TEXT, nullable)
+ *      Populated when an end-node agent calls `submit_for_approval`; cleared on
+ *      approve or reject.
+ *   3. `space_task_report_results` table — append-only audit of each
+ *      `report_result` call. Does NOT replace `space_tasks.reported_summary`
+ *      (which the UI caches as the latest); it adds history.
+ *
+ * Backfill policy for the new NOT NULL column on `space_workflows`:
+ *   - Rows whose `name` matches a built-in template get a per-template level:
+ *       Coding Workflow               → 3
+ *       Research Workflow             → 2
+ *       Review-Only Workflow          → 2
+ *       Coding with QA Workflow       → 4
+ *       Plan & Decompose Workflow     → 3
+ *   - Any other row (user-created) gets level 3 as a reasonable default.
+ *   These are picked to reflect the risk profile of each workflow's
+ *   terminal action — merging a PR (Coding) is higher-risk than posting a
+ *   review (Review-Only); Coding with QA's end step runs `gh pr merge`
+ *   itself, so it requires the highest autonomy (4).
+ *
+ * SQLite does not allow an `ADD COLUMN ... NOT NULL` on a table that already
+ * has rows without also supplying a DEFAULT. We add the column with
+ * `NOT NULL DEFAULT 3`, then `UPDATE` per-name to apply the per-template
+ * overrides. The default remains on the column (SQLite can't drop a default
+ * without rebuilding the table); future inserts from the runtime layer will
+ * always supply an explicit value, so the default only matters for any future
+ * migration that inserts a row without specifying this column.
+ */
+export function runMigration99(db: BunDatabase): void {
+	// 1. space_workflows.completion_autonomy_level ---------------------------
+	if (
+		tableExists(db, 'space_workflows') &&
+		!tableHasColumn(db, 'space_workflows', 'completion_autonomy_level')
+	) {
+		db.exec(
+			`ALTER TABLE space_workflows ADD COLUMN completion_autonomy_level INTEGER NOT NULL DEFAULT 3`
+		);
+		// Per-template backfill — override the default for built-in workflows
+		// whose risk profile differs from the generic default of 3.
+		const perTemplateLevels: Array<[string, number]> = [
+			['Coding Workflow', 3],
+			['Research Workflow', 2],
+			['Review-Only Workflow', 2],
+			['Coding with QA Workflow', 4],
+			['Plan & Decompose Workflow', 3],
+		];
+		const update = db.prepare(
+			`UPDATE space_workflows SET completion_autonomy_level = ? WHERE name = ?`
+		);
+		for (const [name, level] of perTemplateLevels) {
+			update.run(level, name);
+		}
+	}
+
+	// 2. space_tasks pending_completion_* columns ----------------------------
+	if (tableExists(db, 'space_tasks')) {
+		if (!tableHasColumn(db, 'space_tasks', 'pending_completion_submitted_by_node_id')) {
+			db.exec(
+				`ALTER TABLE space_tasks ADD COLUMN pending_completion_submitted_by_node_id TEXT DEFAULT NULL`
+			);
+		}
+		if (!tableHasColumn(db, 'space_tasks', 'pending_completion_submitted_at')) {
+			db.exec(
+				`ALTER TABLE space_tasks ADD COLUMN pending_completion_submitted_at INTEGER DEFAULT NULL`
+			);
+		}
+		if (!tableHasColumn(db, 'space_tasks', 'pending_completion_reason')) {
+			db.exec(`ALTER TABLE space_tasks ADD COLUMN pending_completion_reason TEXT DEFAULT NULL`);
+		}
+	}
+
+	// 3. space_task_report_results table -------------------------------------
+	// Only create if the parent tables exist; otherwise this is a very fresh
+	// DB that pre-dates the Space system, and the table will be (re)created
+	// automatically once spaces tables come online via earlier migrations.
+	if (tableExists(db, 'space_tasks') && tableExists(db, 'spaces')) {
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS space_task_report_results (
+				id TEXT PRIMARY KEY,
+				task_id TEXT NOT NULL,
+				space_id TEXT NOT NULL,
+				workflow_node_id TEXT,
+				agent_name TEXT,
+				summary TEXT NOT NULL,
+				evidence TEXT,
+				recorded_at INTEGER NOT NULL,
+				FOREIGN KEY (task_id) REFERENCES space_tasks(id) ON DELETE CASCADE,
+				FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+			)
+		`);
+		db.exec(
+			`CREATE INDEX IF NOT EXISTS idx_space_task_report_results_task ON space_task_report_results(task_id, recorded_at)`
+		);
+		db.exec(
+			`CREATE INDEX IF NOT EXISTS idx_space_task_report_results_space ON space_task_report_results(space_id, recorded_at)`
+		);
+	}
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -6420,4 +6420,153 @@ export function runMigration99(db: BunDatabase): void {
 			`CREATE INDEX IF NOT EXISTS idx_space_task_report_results_space ON space_task_report_results(space_id, recorded_at)`
 		);
 	}
+
+	// 4. Widen `pending_checkpoint_type` CHECK constraint ---------------------
+	// Migration 86 added this column with CHECK(... IN ('completion_action', 'gate')).
+	// Task #39's new `submit_for_approval` tool writes 'task_completion', which
+	// the old constraint blocks at SQLite level. SQLite cannot ALTER a CHECK
+	// constraint, so rebuild the table with the widened enum. Detection: if the
+	// raw CREATE TABLE sql lacks 'task_completion' we need to rebuild.
+	if (tableExists(db, 'space_tasks')) {
+		const master = db
+			.prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='space_tasks'`)
+			.get() as { sql?: string } | undefined;
+		const currentSql = master?.sql ?? '';
+		if (
+			currentSql &&
+			!currentSql.includes("'task_completion'") &&
+			tableHasColumn(db, 'space_tasks', 'pending_checkpoint_type')
+		) {
+			// Build the INSERT/SELECT column list from the intersection of the
+			// full post-M98 schema and the columns the existing table actually
+			// has. This makes the rebuild safe when M98 is invoked against an
+			// older/minimal schema (e.g. isolated migration tests that construct
+			// a bare-bones space_tasks and then call runMigration98 directly).
+			// In production every prior migration has already run so the source
+			// table has all of these columns and the list is exhaustive.
+			const fullColumnList = [
+				'id',
+				'space_id',
+				'task_number',
+				'title',
+				'description',
+				'status',
+				'priority',
+				'labels',
+				'workflow_run_id',
+				'preferred_workflow_id',
+				'created_by_task_id',
+				'result',
+				'depends_on',
+				'active_session',
+				'task_agent_session_id',
+				'approval_source',
+				'approval_reason',
+				'approved_at',
+				'block_reason',
+				'archived_at',
+				'created_at',
+				'started_at',
+				'completed_at',
+				'updated_at',
+				'pending_action_index',
+				'pending_checkpoint_type',
+				'reported_status',
+				'reported_summary',
+				'pending_completion_submitted_by_node_id',
+				'pending_completion_submitted_at',
+				'pending_completion_reason',
+			];
+			const existingColumns = new Set(
+				(db.prepare(`PRAGMA table_info('space_tasks')`).all() as Array<{ name: string }>).map(
+					(r) => r.name
+				)
+			);
+			const copyColumns = fullColumnList.filter((c) => existingColumns.has(c));
+			const copyColsSql = copyColumns.join(', ');
+
+			// Capture existing non-autoindex DDL so we can re-create exactly the
+			// indexes the table had — no more, no less. Some earlier migrations
+			// intentionally dropped indexes (e.g. M71 removed idx_space_tasks_status
+			// when its column semantics changed); we must not silently re-add them.
+			const existingIndexDdl = (
+				db
+					.prepare(
+						`SELECT sql FROM sqlite_master
+						 WHERE type='index' AND tbl_name='space_tasks' AND sql IS NOT NULL`
+					)
+					.all() as Array<{ sql: string }>
+			)
+				.map((r) => r.sql)
+				.filter((sql) => !!sql);
+
+			db.exec('PRAGMA foreign_keys = OFF');
+			db.exec('BEGIN');
+			try {
+				db.exec(`
+					CREATE TABLE space_tasks_m98_new (
+						id TEXT PRIMARY KEY,
+						space_id TEXT NOT NULL,
+						task_number INTEGER NOT NULL,
+						title TEXT NOT NULL,
+						description TEXT NOT NULL DEFAULT '',
+						status TEXT NOT NULL DEFAULT 'open'
+							CHECK(status IN ('open', 'in_progress', 'review', 'done', 'blocked', 'cancelled', 'archived')),
+						priority TEXT NOT NULL DEFAULT 'normal'
+							CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+						labels TEXT NOT NULL DEFAULT '[]',
+						workflow_run_id TEXT,
+						preferred_workflow_id TEXT,
+						created_by_task_id TEXT,
+						result TEXT,
+						depends_on TEXT NOT NULL DEFAULT '[]',
+						active_session TEXT
+							CHECK(active_session IN ('worker', 'leader')),
+						task_agent_session_id TEXT,
+						approval_source TEXT,
+						approval_reason TEXT,
+						approved_at INTEGER,
+						block_reason TEXT,
+						archived_at INTEGER,
+						created_at INTEGER NOT NULL,
+						started_at INTEGER,
+						completed_at INTEGER,
+						updated_at INTEGER NOT NULL,
+						pending_action_index INTEGER DEFAULT NULL,
+						pending_checkpoint_type TEXT DEFAULT NULL
+							CHECK(pending_checkpoint_type IN ('completion_action', 'gate', 'task_completion')),
+						reported_status TEXT DEFAULT NULL
+							CHECK(reported_status IS NULL OR reported_status IN ('done', 'blocked', 'cancelled')),
+						reported_summary TEXT DEFAULT NULL,
+						pending_completion_submitted_by_node_id TEXT DEFAULT NULL,
+						pending_completion_submitted_at INTEGER DEFAULT NULL,
+						pending_completion_reason TEXT DEFAULT NULL,
+						FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+						FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL
+					)
+				`);
+				db.exec(
+					`INSERT INTO space_tasks_m98_new (${copyColsSql}) SELECT ${copyColsSql} FROM space_tasks`
+				);
+				db.exec(`DROP TABLE space_tasks`);
+				db.exec(`ALTER TABLE space_tasks_m98_new RENAME TO space_tasks`);
+				// Re-create exactly the indexes that existed before the rebuild.
+				// Using IF NOT EXISTS on each so a DDL that happens to use the
+				// non-IF-EXISTS form still applies cleanly.
+				for (const ddl of existingIndexDdl) {
+					const normalized = ddl.replace(
+						/^CREATE (UNIQUE )?INDEX /i,
+						(_m, unique) => `CREATE ${unique ?? ''}INDEX IF NOT EXISTS `
+					);
+					db.exec(normalized);
+				}
+				db.exec('COMMIT');
+			} catch (err) {
+				db.exec('ROLLBACK');
+				throw err;
+			} finally {
+				db.exec('PRAGMA foreign_keys = ON');
+			}
+		}
+	}
 }

--- a/packages/daemon/tests/online/space/helpers/space-test-helpers.ts
+++ b/packages/daemon/tests/online/space/helpers/space-test-helpers.ts
@@ -462,6 +462,9 @@ export async function createTestSpace(daemon: DaemonServerContext): Promise<Test
 				label: 'QA → Coding (fix loop)',
 			},
 		],
+		// Test fixture: supervised tier (level 3) — matches the production CODING_WORKFLOW
+		// default so tests exercise the autonomy-gated end-node tool path realistically.
+		completionAutonomyLevel: 3,
 		tags: ['v2', 'test'],
 	})) as { workflow: SpaceWorkflow };
 

--- a/packages/daemon/tests/online/space/task-agent-lifecycle.test.ts
+++ b/packages/daemon/tests/online/space/task-agent-lifecycle.test.ts
@@ -105,6 +105,7 @@ async function createTestFixtures(daemon: DaemonServerContext): Promise<TestFixt
 		nodes: [{ id: STEP_CODE_ID, name: 'Code Implementation', agentId: coderAgent.id }],
 		transitions: [],
 		startNodeId: STEP_CODE_ID,
+		completionAutonomyLevel: 3,
 	})) as { workflow: SpaceWorkflow };
 
 	return {

--- a/packages/daemon/tests/online/space/task-agent-skills.test.ts
+++ b/packages/daemon/tests/online/space/task-agent-skills.test.ts
@@ -78,6 +78,7 @@ async function createTestFixtures(daemon: DaemonServerContext): Promise<TestFixt
 		nodes: [{ id: 'step-skills-001', name: 'Code Implementation', agentId: coderAgent.id }],
 		transitions: [],
 		startNodeId: 'step-skills-001',
+		completionAutonomyLevel: 3,
 	})) as { workflow: SpaceWorkflow };
 
 	return { space, coderAgent, workflow: workflowResult.workflow };

--- a/packages/daemon/tests/unit/1-core/lib/space-workflow-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-workflow-manager.test.ts
@@ -36,6 +36,7 @@ describe('SpaceWorkflowManager', () => {
 					{ id: 'node-1', name: 'Step One', agents: [{ agentId: 'agent-1', name: 'coder' }] },
 					{ id: 'node-2', name: 'Step Two', agents: [{ agentId: 'agent-1', name: 'coder' }] },
 				],
+				completionAutonomyLevel: 3,
 			});
 
 			expect(result.startNodeId).toBe('node-1');
@@ -52,6 +53,7 @@ describe('SpaceWorkflowManager', () => {
 				],
 				startNodeId: null as unknown as string,
 				endNodeId: null as unknown as string,
+				completionAutonomyLevel: 3,
 			});
 
 			expect(result.startNodeId).toBe('node-1');
@@ -68,6 +70,7 @@ describe('SpaceWorkflowManager', () => {
 				],
 				startNodeId: 'node-2',
 				endNodeId: 'node-1',
+				completionAutonomyLevel: 3,
 			});
 
 			expect(result.startNodeId).toBe('node-2');
@@ -83,6 +86,7 @@ describe('SpaceWorkflowManager', () => {
 						{ id: 'node-1', name: 'Step One', agents: [{ agentId: 'agent-1', name: 'coder' }] },
 					],
 					startNodeId: '  ',
+					completionAutonomyLevel: 3,
 				})
 			).toThrow('startNodeId must be a non-empty string');
 		});
@@ -96,6 +100,7 @@ describe('SpaceWorkflowManager', () => {
 						{ id: 'node-1', name: 'Step One', agents: [{ agentId: 'agent-1', name: 'coder' }] },
 					],
 					endNodeId: '   ',
+					completionAutonomyLevel: 3,
 				})
 			).toThrow('endNodeId must be a non-empty string');
 		});
@@ -109,6 +114,7 @@ describe('SpaceWorkflowManager', () => {
 						{ id: 'node-1', name: 'Step One', agents: [{ agentId: 'agent-1', name: 'coder' }] },
 					],
 					startNodeId: 'nonexistent-node',
+					completionAutonomyLevel: 3,
 				})
 			).toThrow('startNodeId "nonexistent-node" does not match any node in this workflow');
 		});
@@ -122,6 +128,7 @@ describe('SpaceWorkflowManager', () => {
 						{ id: 'node-1', name: 'Step One', agents: [{ agentId: 'agent-1', name: 'coder' }] },
 					],
 					endNodeId: 'nonexistent-node',
+					completionAutonomyLevel: 3,
 				})
 			).toThrow('endNodeId "nonexistent-node" does not match any node in this workflow');
 		});
@@ -138,6 +145,7 @@ describe('SpaceWorkflowManager', () => {
 				],
 				startNodeId: 'node-1',
 				endNodeId: 'node-2',
+				completionAutonomyLevel: 3,
 			});
 
 			const updated = manager.updateWorkflow(created.id, {});
@@ -155,6 +163,7 @@ describe('SpaceWorkflowManager', () => {
 				],
 				startNodeId: 'node-2',
 				endNodeId: 'node-1',
+				completionAutonomyLevel: 3,
 			});
 
 			const updated = manager.updateWorkflow(created.id, { startNodeId: null, endNodeId: null });
@@ -170,6 +179,7 @@ describe('SpaceWorkflowManager', () => {
 					{ id: 'node-1', name: 'Step One', agents: [{ agentId: 'agent-1', name: 'coder' }] },
 					{ id: 'node-2', name: 'Step Two', agents: [{ agentId: 'agent-1', name: 'coder' }] },
 				],
+				completionAutonomyLevel: 3,
 			});
 
 			const updated = manager.updateWorkflow(created.id, {
@@ -187,6 +197,7 @@ describe('SpaceWorkflowManager', () => {
 				nodes: [
 					{ id: 'node-1', name: 'Step One', agents: [{ agentId: 'agent-1', name: 'coder' }] },
 				],
+				completionAutonomyLevel: 3,
 			});
 
 			expect(() => manager.updateWorkflow(created.id, { startNodeId: 'nonexistent' })).toThrow(
@@ -201,6 +212,7 @@ describe('SpaceWorkflowManager', () => {
 				nodes: [
 					{ id: 'node-1', name: 'Step One', agents: [{ agentId: 'agent-1', name: 'coder' }] },
 				],
+				completionAutonomyLevel: 3,
 			});
 
 			expect(() => manager.updateWorkflow(created.id, { endNodeId: 'nonexistent' })).toThrow(
@@ -215,6 +227,7 @@ describe('SpaceWorkflowManager', () => {
 				nodes: [
 					{ id: 'node-old', name: 'Old Step', agents: [{ agentId: 'agent-1', name: 'coder' }] },
 				],
+				completionAutonomyLevel: 3,
 			});
 
 			const updated = manager.updateWorkflow(created.id, {
@@ -237,6 +250,7 @@ describe('SpaceWorkflowManager', () => {
 				nodes: [
 					{ id: 'node-old', name: 'Old Step', agents: [{ agentId: 'agent-1', name: 'coder' }] },
 				],
+				completionAutonomyLevel: 3,
 			});
 
 			expect(() =>
@@ -267,6 +281,7 @@ describe('SpaceWorkflowManager', () => {
 					{ id: 'node-1', name: 'Step One', agents: [{ agentId: 'agent-1', name: 'coder' }] },
 					{ id: 'node-2', name: 'Step Two', agents: [{ agentId: 'agent-1', name: 'coder' }] },
 				],
+				completionAutonomyLevel: 3,
 			});
 
 			expect(() => manager.updateWorkflow(created.id, { startNodeId: '  ' })).toThrow(

--- a/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
@@ -64,6 +64,7 @@ describe('scope-config', () => {
 				'space_workflow_nodes',
 				'space_workflow_runs',
 				'space_tasks',
+				'space_task_report_results',
 				'space_worktrees',
 				'gate_data',
 				'channel_cycles',

--- a/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
@@ -71,7 +71,7 @@ describe('scope-config', () => {
 				'workflow_run_artifacts',
 				'workflow_run_artifact_cache',
 			]);
-			expect(names).toHaveLength(10);
+			expect(names).toHaveLength(11);
 		});
 
 		it('all table configs have a description', () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-export-import-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-export-import-handlers.test.ts
@@ -82,6 +82,7 @@ function createSchema(db: Database): void {
 			template_name TEXT DEFAULT NULL,
 			template_hash TEXT DEFAULT NULL,
 			instructions TEXT DEFAULT NULL,
+			completion_autonomy_level INTEGER NOT NULL DEFAULT 3,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
@@ -373,6 +374,7 @@ describe('Space Export/Import RPC Handlers', () => {
 				name: 'Pipeline',
 				nodes: [{ name: 'Code', agentId: agent.id }],
 				transitions: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { bundle } = await call<{ bundle: any }>(handlers, 'spaceExport.workflows', {
@@ -394,6 +396,7 @@ describe('Space Export/Import RPC Handlers', () => {
 				name: 'Pipeline',
 				nodes: [{ name: 'Code', agentId: coder.id }],
 				transitions: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { bundle } = await call<{ bundle: any }>(handlers, 'spaceExport.workflows', {
@@ -412,12 +415,14 @@ describe('Space Export/Import RPC Handlers', () => {
 				name: 'WF1',
 				nodes: [{ name: 'S1', agentId: agent.id }],
 				transitions: [],
+				completionAutonomyLevel: 3,
 			});
 			workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
 				name: 'WF2',
 				nodes: [{ name: 'S2', agentId: agent.id }],
 				transitions: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { bundle } = await call<{ bundle: any }>(handlers, 'spaceExport.workflows', {
@@ -440,6 +445,7 @@ describe('Space Export/Import RPC Handlers', () => {
 				name: 'W',
 				nodes: [{ name: 'S', agentId: agent.id }],
 				transitions: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { bundle } = await call<{ bundle: any }>(handlers, 'spaceExport.bundle', {
@@ -459,12 +465,14 @@ describe('Space Export/Import RPC Handlers', () => {
 				name: 'W1',
 				nodes: [{ name: 'S', agentId: a1.id }],
 				transitions: [],
+				completionAutonomyLevel: 3,
 			});
 			workflowManager.createWorkflow({
 				spaceId: SPACE_ID,
 				name: 'W2',
 				nodes: [{ name: 'S', agentId: a1.id }],
 				transitions: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { bundle } = await call<{ bundle: any }>(handlers, 'spaceExport.bundle', {
@@ -530,6 +538,7 @@ describe('Space Export/Import RPC Handlers', () => {
 				name: 'Pipeline',
 				nodes: [{ name: 'S', agentId: agent.id }],
 				transitions: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const bundle = makeBundle(
@@ -662,6 +671,7 @@ describe('Space Export/Import RPC Handlers', () => {
 					name: 'Pipeline',
 					nodes: [{ name: 'S', agentId: agent.id }],
 					transitions: [],
+					completionAutonomyLevel: 3,
 				});
 
 				const bundle = makeBundle(
@@ -715,6 +725,7 @@ describe('Space Export/Import RPC Handlers', () => {
 					name: 'Pipeline',
 					nodes: [{ name: 'S', agentId: agent.id }],
 					transitions: [],
+					completionAutonomyLevel: 3,
 				});
 
 				const bundle = makeBundle(
@@ -765,6 +776,7 @@ describe('Space Export/Import RPC Handlers', () => {
 					name: 'Pipeline',
 					nodes: [{ name: 'OldStep', agentId: agent.id }],
 					transitions: [],
+					completionAutonomyLevel: 3,
 				});
 
 				const bundle = makeBundle(
@@ -963,6 +975,7 @@ describe('Space Export/Import RPC Handlers', () => {
 					name: 'ToReplace',
 					nodes: [{ name: 'S', agentId: existingAgent.id }],
 					transitions: [],
+					completionAutonomyLevel: 3,
 				});
 
 				// Bundle: replace "ToReplace" but the replacement references a ghost agent
@@ -1125,6 +1138,7 @@ describe('Space Export/Import RPC Handlers', () => {
 				name: 'Pipe',
 				nodes: [{ name: 's1', agentId: existingAgentId }],
 				transitions: [],
+				completionAutonomyLevel: 3,
 			});
 			const oldWorkflowId = existingWf.id;
 

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-53_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-53_test.ts
@@ -134,6 +134,7 @@ describe('Migration 53: channels column on space_workflows', () => {
 				{ id: 'ch-1', from: 'node-a', to: 'node-b', label: 'alpha to beta' },
 				{ id: 'ch-2', from: 'node-b', to: 'node-a' },
 			],
+			completionAutonomyLevel: 3,
 		});
 
 		// Verify the channels column is written at the DB level
@@ -172,6 +173,7 @@ describe('Migration 53: channels column on space_workflows', () => {
 		const wf = repo.createWorkflow({
 			spaceId: 'sp-cfg',
 			name: 'Config Check',
+			completionAutonomyLevel: 3,
 		});
 
 		// After M74, config column is dropped. Verify tags column exists and has default.
@@ -196,6 +198,7 @@ describe('Migration 53: channels column on space_workflows', () => {
 		const wf = repo.createWorkflow({
 			spaceId: 'sp-upd',
 			name: 'Update Test',
+			completionAutonomyLevel: 3,
 		});
 
 		repo.updateWorkflow(wf.id, {
@@ -223,6 +226,7 @@ describe('Migration 53: channels column on space_workflows', () => {
 		const wf = repo.createWorkflow({
 			spaceId: 'sp-clr',
 			name: 'Clear Test',
+			completionAutonomyLevel: 3,
 		});
 
 		repo.updateWorkflow(wf.id, { channels: null });

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-99_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-99_test.ts
@@ -1,0 +1,294 @@
+/**
+ * Migration 99 Tests — Tool-contract refactor for Task #39.
+ *
+ * Migration 99:
+ *   - Adds `space_workflows.completion_autonomy_level` (INTEGER NOT NULL,
+ *     default 3). Built-in workflow rows get per-template overrides; user
+ *     rows get the default.
+ *   - Adds three nullable `pending_completion_*` columns to `space_tasks`.
+ *   - Creates the append-only `space_task_report_results` audit table plus
+ *     its two lookup indexes.
+ *
+ * Covers:
+ *   - Fresh DB has the column, the NOT NULL default is 3, and the new table exists.
+ *   - Pre-existing rows get per-template values via backfill.
+ *   - Custom (non-built-in) workflows get the generic default.
+ *   - `space_task_report_results.task_id NOT NULL` is enforced.
+ *   - Idempotent — running the migration twice is a no-op.
+ *   - `space_tasks.pending_completion_submitted_by_node_id` column exists.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../../src/storage/schema/index.ts';
+import { runMigration99 } from '../../../../../src/storage/schema/migrations.ts';
+
+function insertSpace(db: BunDatabase, id: string): void {
+	const now = Date.now();
+	db.prepare(
+		`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`
+	).run(id, id, `/ws/${id}`, id, now, now);
+}
+
+function insertWorkflow(
+	db: BunDatabase,
+	opts: {
+		id: string;
+		spaceId: string;
+		name: string;
+	}
+): void {
+	const now = Date.now();
+	// Pre-migration column set — do NOT include completion_autonomy_level so we
+	// exercise the backfill path (M99 must add the column and populate it).
+	db.prepare(
+		`INSERT INTO space_workflows (
+			id, space_id, name, description, tags, created_at, updated_at
+		) VALUES (?, ?, ?, '', '[]', ?, ?)`
+	).run(opts.id, opts.spaceId, opts.name, now, now);
+}
+
+function getLevel(db: BunDatabase, id: string): number | null {
+	const row = db
+		.prepare(`SELECT completion_autonomy_level FROM space_workflows WHERE id = ?`)
+		.get(id) as { completion_autonomy_level: number } | undefined;
+	return row?.completion_autonomy_level ?? null;
+}
+
+function columnNames(db: BunDatabase, table: string): string[] {
+	const rows = db.prepare(`PRAGMA table_info('${table}')`).all() as Array<{ name: string }>;
+	return rows.map((r) => r.name);
+}
+
+function columnInfo(
+	db: BunDatabase,
+	table: string,
+	column: string
+): { notnull: number; dflt_value: string | null } | null {
+	const rows = db.prepare(`PRAGMA table_info('${table}')`).all() as Array<{
+		name: string;
+		notnull: number;
+		dflt_value: string | null;
+	}>;
+	const found = rows.find((r) => r.name === column);
+	return found ? { notnull: found.notnull, dflt_value: found.dflt_value } : null;
+}
+
+describe('Migration 99: tool-contract refactor (Task #39)', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(
+			process.cwd(),
+			'tmp',
+			'test-migration-99',
+			`test-${Date.now()}-${Math.random()}`
+		);
+		mkdirSync(testDir, { recursive: true });
+		db = new BunDatabase(join(testDir, 'test.db'));
+		db.exec('PRAGMA foreign_keys = ON');
+		runMigrations(db, () => {});
+		insertSpace(db, 'sp-1');
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	describe('space_workflows.completion_autonomy_level', () => {
+		test('column exists after migration with NOT NULL DEFAULT 3', () => {
+			const info = columnInfo(db, 'space_workflows', 'completion_autonomy_level');
+			expect(info).not.toBeNull();
+			expect(info!.notnull).toBe(1);
+			// SQLite stores defaults as strings in PRAGMA output.
+			expect(info!.dflt_value).toBe('3');
+		});
+
+		test('built-in workflows get their per-template level via backfill on a pre-M99 DB', () => {
+			// To exercise the backfill UPDATE path, recreate a pre-M99 schema on a
+			// fresh DB (the one from `beforeEach` already has M99 applied). We
+			// simulate the pre-migration state by dropping the column and recreating
+			// the table without it, then seed rows, then run M99 directly.
+			const freshDir = join(
+				process.cwd(),
+				'tmp',
+				'test-migration-99-backfill',
+				`test-${Date.now()}-${Math.random()}`
+			);
+			mkdirSync(freshDir, { recursive: true });
+			const freshDb = new BunDatabase(join(freshDir, 'fresh.db'));
+			try {
+				freshDb.exec('PRAGMA foreign_keys = ON');
+				// Pre-M99 minimal schema. Only the tables M99 touches matter.
+				freshDb.exec(
+					`CREATE TABLE spaces (
+						id TEXT PRIMARY KEY, slug TEXT, workspace_path TEXT, name TEXT,
+						created_at INTEGER, updated_at INTEGER
+					)`
+				);
+				freshDb.exec(
+					`CREATE TABLE space_workflows (
+						id TEXT PRIMARY KEY, space_id TEXT NOT NULL, name TEXT NOT NULL,
+						description TEXT NOT NULL DEFAULT '', tags TEXT NOT NULL DEFAULT '[]',
+						created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+					)`
+				);
+				freshDb.exec(
+					`CREATE TABLE space_tasks (
+						id TEXT PRIMARY KEY, space_id TEXT NOT NULL, task_number INTEGER,
+						title TEXT, description TEXT, status TEXT, priority TEXT, labels TEXT,
+						depends_on TEXT, created_at INTEGER, updated_at INTEGER
+					)`
+				);
+				const now = Date.now();
+				freshDb
+					.prepare(
+						`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+					)
+					.run('sp-x', 'sp-x', '/ws/x', 'Space X', now, now);
+
+				const builtIns: Array<[string, number]> = [
+					['Coding Workflow', 3],
+					['Research Workflow', 2],
+					['Review-Only Workflow', 2],
+					['Coding with QA Workflow', 4],
+					['Plan & Decompose Workflow', 3],
+				];
+				for (const [i, [name]] of builtIns.entries()) {
+					freshDb
+						.prepare(
+							`INSERT INTO space_workflows (id, space_id, name, description, tags, created_at, updated_at)
+							 VALUES (?, ?, ?, '', '[]', ?, ?)`
+						)
+						.run(`wf-builtin-${i}`, 'sp-x', name, now, now);
+				}
+
+				runMigration99(freshDb);
+
+				for (const [i, [, expectedLevel]] of builtIns.entries()) {
+					const level = freshDb
+						.prepare(`SELECT completion_autonomy_level FROM space_workflows WHERE id = ?`)
+						.get(`wf-builtin-${i}`) as { completion_autonomy_level: number };
+					expect(level.completion_autonomy_level).toBe(expectedLevel);
+				}
+			} finally {
+				try {
+					freshDb.close();
+				} catch {
+					// ignore
+				}
+				try {
+					rmSync(freshDir, { recursive: true, force: true });
+				} catch {
+					// ignore
+				}
+			}
+		});
+
+		test('custom (non-built-in) workflows get level 3 default', () => {
+			insertWorkflow(db, {
+				id: 'wf-custom',
+				spaceId: 'sp-1',
+				name: 'My Custom Workflow',
+			});
+			// The column default fires on INSERT — verify without rerunning M99.
+			expect(getLevel(db, 'wf-custom')).toBe(3);
+		});
+
+		test('migration is idempotent — second run is a no-op', () => {
+			insertWorkflow(db, {
+				id: 'wf-coding',
+				spaceId: 'sp-1',
+				name: 'Coding Workflow',
+			});
+
+			runMigration99(db);
+			const after1 = getLevel(db, 'wf-coding');
+
+			runMigration99(db);
+			const after2 = getLevel(db, 'wf-coding');
+
+			expect(after1).toBe(3);
+			expect(after2).toBe(3);
+		});
+	});
+
+	describe('space_tasks pending_completion_* columns', () => {
+		test('pending_completion_submitted_by_node_id column exists', () => {
+			const cols = columnNames(db, 'space_tasks');
+			expect(cols).toContain('pending_completion_submitted_by_node_id');
+			expect(cols).toContain('pending_completion_submitted_at');
+			expect(cols).toContain('pending_completion_reason');
+		});
+
+		test('new columns are nullable (insert without values succeeds)', () => {
+			const now = Date.now();
+			db.prepare(
+				`INSERT INTO space_tasks (
+					id, space_id, task_number, title, description, status, priority,
+					labels, depends_on, created_at, updated_at
+				) VALUES (?, ?, ?, ?, '', 'open', 'normal', '[]', '[]', ?, ?)`
+			).run('t-1', 'sp-1', 1, 'Task A', now, now);
+			const row = db
+				.prepare(
+					`SELECT pending_completion_submitted_by_node_id, pending_completion_submitted_at,
+						pending_completion_reason FROM space_tasks WHERE id = ?`
+				)
+				.get('t-1') as Record<string, unknown>;
+			expect(row.pending_completion_submitted_by_node_id).toBeNull();
+			expect(row.pending_completion_submitted_at).toBeNull();
+			expect(row.pending_completion_reason).toBeNull();
+		});
+	});
+
+	describe('space_task_report_results table', () => {
+		test('table exists and has the expected columns', () => {
+			const cols = columnNames(db, 'space_task_report_results');
+			expect(cols.sort()).toEqual(
+				[
+					'id',
+					'task_id',
+					'space_id',
+					'workflow_node_id',
+					'agent_name',
+					'summary',
+					'evidence',
+					'recorded_at',
+				].sort()
+			);
+		});
+
+		test('task_id NOT NULL is enforced', () => {
+			expect(() => {
+				db.prepare(
+					`INSERT INTO space_task_report_results (id, task_id, space_id, summary, recorded_at)
+					 VALUES ('rr-1', NULL, 'sp-1', 'hi', ?)`
+				).run(Date.now());
+			}).toThrow();
+		});
+
+		test('indexes exist for task_id and space_id lookups', () => {
+			const indexes = db
+				.prepare(
+					`SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'space_task_report_results'`
+				)
+				.all() as Array<{ name: string }>;
+			const names = indexes.map((r) => r.name);
+			expect(names).toContain('idx_space_task_report_results_task');
+			expect(names).toContain('idx_space_task_report_results_space');
+		});
+	});
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/space-task-report-result-repository_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/space-task-report-result-repository_test.ts
@@ -1,0 +1,259 @@
+/**
+ * SpaceTaskReportResultRepository Unit Tests
+ *
+ * Covers:
+ *   - append() creates a row with a generated id and recordedAt ~= Date.now().
+ *   - listByTask() returns rows in ascending recordedAt order.
+ *   - getLatestByTask() returns the most recent row, or null when empty.
+ *   - Evidence round-trips through JSON; null evidence stays null.
+ *   - FK cascade: deleting the parent task removes associated result rows.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SpaceTaskReportResultRepository } from '../../../../src/storage/repositories/space-task-report-result-repository.ts';
+import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceRepository } from '../../../../src/storage/repositories/space-repository.ts';
+import { createSpaceTables } from '../../helpers/space-test-db.ts';
+
+describe('SpaceTaskReportResultRepository', () => {
+	let db: Database;
+	let spaceRepo: SpaceRepository;
+	let taskRepo: SpaceTaskRepository;
+	let repo: SpaceTaskReportResultRepository;
+	let spaceId: string;
+	let taskId: string;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		spaceRepo = new SpaceRepository(db as any);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		taskRepo = new SpaceTaskRepository(db as any);
+		repo = new SpaceTaskReportResultRepository(db);
+
+		const space = spaceRepo.createSpace({
+			workspacePath: '/workspace/test',
+			slug: 'test',
+			name: 'Test',
+		});
+		spaceId = space.id;
+		const task = taskRepo.createTask({ spaceId, title: 'T', description: '' });
+		taskId = task.id;
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	describe('append', () => {
+		test('creates a row with a generated id and recordedAt ~= Date.now()', () => {
+			const before = Date.now();
+			const result = repo.append({
+				taskId,
+				spaceId,
+				workflowNodeId: 'node-1',
+				agentName: 'coder',
+				summary: 'Built the thing',
+				evidence: { files: ['a.ts'] },
+			});
+			const after = Date.now();
+
+			expect(result.id).toBeTruthy();
+			expect(result.id.length).toBeGreaterThan(8);
+			expect(result.recordedAt).toBeGreaterThanOrEqual(before);
+			expect(result.recordedAt).toBeLessThanOrEqual(after);
+			expect(result.taskId).toBe(taskId);
+			expect(result.summary).toBe('Built the thing');
+			expect(result.evidence).toEqual({ files: ['a.ts'] });
+		});
+
+		test('null evidence round-trips as null', () => {
+			const result = repo.append({
+				taskId,
+				spaceId,
+				workflowNodeId: null,
+				agentName: null,
+				summary: 'quick note',
+				evidence: null,
+			});
+			expect(result.evidence).toBeNull();
+
+			const fetched = repo.getLatestByTask(taskId);
+			expect(fetched?.evidence).toBeNull();
+		});
+
+		test('workflowNodeId and agentName can be null', () => {
+			const result = repo.append({
+				taskId,
+				spaceId,
+				workflowNodeId: null,
+				agentName: null,
+				summary: 's',
+				evidence: null,
+			});
+			expect(result.workflowNodeId).toBeNull();
+			expect(result.agentName).toBeNull();
+		});
+	});
+
+	describe('listByTask', () => {
+		test('returns all rows for the task in ascending recordedAt order', async () => {
+			const r1 = repo.append({
+				taskId,
+				spaceId,
+				workflowNodeId: 'n',
+				agentName: 'a',
+				summary: 'first',
+				evidence: null,
+			});
+			// Ensure a distinct timestamp for deterministic ordering.
+			await new Promise((r) => setTimeout(r, 2));
+			const r2 = repo.append({
+				taskId,
+				spaceId,
+				workflowNodeId: 'n',
+				agentName: 'a',
+				summary: 'second',
+				evidence: null,
+			});
+			await new Promise((r) => setTimeout(r, 2));
+			const r3 = repo.append({
+				taskId,
+				spaceId,
+				workflowNodeId: 'n',
+				agentName: 'a',
+				summary: 'third',
+				evidence: null,
+			});
+
+			const rows = repo.listByTask(taskId);
+			expect(rows.map((r) => r.id)).toEqual([r1.id, r2.id, r3.id]);
+			expect(rows.map((r) => r.summary)).toEqual(['first', 'second', 'third']);
+		});
+
+		test('only returns rows for the requested task', () => {
+			const otherTask = taskRepo.createTask({ spaceId, title: 'Other', description: '' });
+			repo.append({
+				taskId,
+				spaceId,
+				workflowNodeId: null,
+				agentName: null,
+				summary: 'mine',
+				evidence: null,
+			});
+			repo.append({
+				taskId: otherTask.id,
+				spaceId,
+				workflowNodeId: null,
+				agentName: null,
+				summary: 'theirs',
+				evidence: null,
+			});
+			const rows = repo.listByTask(taskId);
+			expect(rows).toHaveLength(1);
+			expect(rows[0].summary).toBe('mine');
+		});
+
+		test('returns empty array when task has no results', () => {
+			expect(repo.listByTask(taskId)).toEqual([]);
+		});
+
+		test('two appends with different evidence payloads round-trip', () => {
+			repo.append({
+				taskId,
+				spaceId,
+				workflowNodeId: null,
+				agentName: null,
+				summary: 'a',
+				evidence: { kind: 'pr', url: 'https://example.com/pr/1' },
+			});
+			repo.append({
+				taskId,
+				spaceId,
+				workflowNodeId: null,
+				agentName: null,
+				summary: 'b',
+				evidence: { kind: 'commit', sha: 'abc123' },
+			});
+			const rows = repo.listByTask(taskId);
+			expect(rows).toHaveLength(2);
+			expect(rows[0].evidence).toEqual({ kind: 'pr', url: 'https://example.com/pr/1' });
+			expect(rows[1].evidence).toEqual({ kind: 'commit', sha: 'abc123' });
+		});
+	});
+
+	describe('getLatestByTask', () => {
+		test('returns the most recent row', async () => {
+			repo.append({
+				taskId,
+				spaceId,
+				workflowNodeId: null,
+				agentName: null,
+				summary: 'first',
+				evidence: null,
+			});
+			await new Promise((r) => setTimeout(r, 2));
+			const r2 = repo.append({
+				taskId,
+				spaceId,
+				workflowNodeId: null,
+				agentName: null,
+				summary: 'second',
+				evidence: null,
+			});
+
+			const latest = repo.getLatestByTask(taskId);
+			expect(latest?.id).toBe(r2.id);
+			expect(latest?.summary).toBe('second');
+		});
+
+		test('returns null when task has no results', () => {
+			expect(repo.getLatestByTask(taskId)).toBeNull();
+		});
+	});
+
+	describe('FK cascade', () => {
+		test('deleting the parent task removes associated result rows', () => {
+			repo.append({
+				taskId,
+				spaceId,
+				workflowNodeId: null,
+				agentName: null,
+				summary: 'x',
+				evidence: null,
+			});
+			repo.append({
+				taskId,
+				spaceId,
+				workflowNodeId: null,
+				agentName: null,
+				summary: 'y',
+				evidence: null,
+			});
+			expect(repo.listByTask(taskId)).toHaveLength(2);
+
+			taskRepo.deleteTask(taskId);
+
+			expect(repo.listByTask(taskId)).toHaveLength(0);
+		});
+
+		test('deleting the parent space removes associated result rows', () => {
+			repo.append({
+				taskId,
+				spaceId,
+				workflowNodeId: null,
+				agentName: null,
+				summary: 'x',
+				evidence: null,
+			});
+			expect(repo.listByTask(taskId)).toHaveLength(1);
+
+			spaceRepo.deleteSpace(spaceId);
+
+			// Task cascaded from space, and results cascaded from task (or space).
+			expect(repo.listByTask(taskId)).toHaveLength(0);
+		});
+	});
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/space-task-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/space-task-repository.test.ts
@@ -218,6 +218,39 @@ describe('SpaceTaskRepository', () => {
 			const updated = repo.updateTask(task.id, { taskAgentSessionId: null });
 			expect(updated!.taskAgentSessionId).toBeUndefined();
 		});
+
+		it('round-trips pendingCompletion* fields (set then clear)', () => {
+			const task = repo.createTask({ spaceId, title: 'T', description: '' });
+			// On create, all three fields should be null.
+			expect(task.pendingCompletionSubmittedByNodeId).toBeNull();
+			expect(task.pendingCompletionSubmittedAt).toBeNull();
+			expect(task.pendingCompletionReason).toBeNull();
+
+			// Set via update.
+			const ts = Date.now();
+			const updated = repo.updateTask(task.id, {
+				pendingCheckpointType: 'task_completion',
+				pendingCompletionSubmittedByNodeId: 'node-end',
+				pendingCompletionSubmittedAt: ts,
+				pendingCompletionReason: 'ready for review',
+			});
+			expect(updated!.pendingCheckpointType).toBe('task_completion');
+			expect(updated!.pendingCompletionSubmittedByNodeId).toBe('node-end');
+			expect(updated!.pendingCompletionSubmittedAt).toBe(ts);
+			expect(updated!.pendingCompletionReason).toBe('ready for review');
+
+			// Clear via update with nulls.
+			const cleared = repo.updateTask(task.id, {
+				pendingCheckpointType: null,
+				pendingCompletionSubmittedByNodeId: null,
+				pendingCompletionSubmittedAt: null,
+				pendingCompletionReason: null,
+			});
+			expect(cleared!.pendingCheckpointType).toBeNull();
+			expect(cleared!.pendingCompletionSubmittedByNodeId).toBeNull();
+			expect(cleared!.pendingCompletionSubmittedAt).toBeNull();
+			expect(cleared!.pendingCompletionReason).toBeNull();
+		});
 	});
 
 	describe('getTaskBySessionId', () => {

--- a/packages/daemon/tests/unit/4-space-storage/storage/space-workflow-repository-completion-autonomy.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/space-workflow-repository-completion-autonomy.test.ts
@@ -1,0 +1,104 @@
+/**
+ * SpaceWorkflowRepository — completionAutonomyLevel round-trip tests (Task #39).
+ *
+ * Covers:
+ *   - createWorkflow throws when `completionAutonomyLevel` is omitted.
+ *   - createWorkflow stores the provided value; getWorkflow reads it back.
+ *   - updateWorkflow can raise or lower the value, preserving other fields.
+ *   - listWorkflows returns the value for every row.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
+import { createSpaceTables } from '../../helpers/space-test-db.ts';
+
+describe('SpaceWorkflowRepository — completionAutonomyLevel', () => {
+	let db: Database;
+	let repo: SpaceWorkflowRepository;
+	const spaceId = 'sp-1';
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?)`
+		).run(spaceId, spaceId, '/ws/x', 'Test Space', now, now);
+		repo = new SpaceWorkflowRepository(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	test('createWorkflow throws when completionAutonomyLevel is missing', () => {
+		expect(() => {
+			repo.createWorkflow({
+				spaceId,
+				name: 'Missing Level',
+				nodes: [{ name: 'Only', agentId: 'agent-1' }],
+			});
+		}).toThrow(/completionAutonomyLevel/);
+	});
+
+	test('createWorkflow stores and reads back completionAutonomyLevel', () => {
+		const wf = repo.createWorkflow({
+			spaceId,
+			name: 'WF',
+			nodes: [{ name: 'Only', agentId: 'agent-1' }],
+			completionAutonomyLevel: 4,
+		});
+		expect(wf.completionAutonomyLevel).toBe(4);
+
+		const fetched = repo.getWorkflow(wf.id);
+		expect(fetched?.completionAutonomyLevel).toBe(4);
+	});
+
+	test('updateWorkflow raises/lowers completionAutonomyLevel', () => {
+		const wf = repo.createWorkflow({
+			spaceId,
+			name: 'WF',
+			nodes: [{ name: 'Only', agentId: 'agent-1' }],
+			completionAutonomyLevel: 2,
+		});
+
+		const raised = repo.updateWorkflow(wf.id, { completionAutonomyLevel: 5 });
+		expect(raised?.completionAutonomyLevel).toBe(5);
+
+		const lowered = repo.updateWorkflow(wf.id, { completionAutonomyLevel: 1 });
+		expect(lowered?.completionAutonomyLevel).toBe(1);
+	});
+
+	test('updateWorkflow leaves completionAutonomyLevel alone when not provided', () => {
+		const wf = repo.createWorkflow({
+			spaceId,
+			name: 'WF',
+			nodes: [{ name: 'Only', agentId: 'agent-1' }],
+			completionAutonomyLevel: 3,
+		});
+
+		const updated = repo.updateWorkflow(wf.id, { name: 'Renamed' });
+		expect(updated?.name).toBe('Renamed');
+		expect(updated?.completionAutonomyLevel).toBe(3);
+	});
+
+	test('listWorkflows returns completionAutonomyLevel for every row', () => {
+		repo.createWorkflow({
+			spaceId,
+			name: 'A',
+			nodes: [{ name: 'Only', agentId: 'agent-1' }],
+			completionAutonomyLevel: 1,
+		});
+		repo.createWorkflow({
+			spaceId,
+			name: 'B',
+			nodes: [{ name: 'Only', agentId: 'agent-1' }],
+			completionAutonomyLevel: 5,
+		});
+		const all = repo.listWorkflows(spaceId);
+		const byName = Object.fromEntries(all.map((w) => [w.name, w.completionAutonomyLevel]));
+		expect(byName).toEqual({ A: 1, B: 5 });
+	});
+});

--- a/packages/daemon/tests/unit/5-space/agent/agent-completion.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-completion.test.ts
@@ -118,6 +118,7 @@ function seedWorkflowRun(db: BunDatabase, spaceId: string): string {
 		transitions: [],
 		startNodeId: '',
 		rules: [],
+		completionAutonomyLevel: 3,
 	});
 	const runRepo = new SpaceWorkflowRunRepository(db);
 	const run = runRepo.createRun({

--- a/packages/daemon/tests/unit/5-space/agent/agent-message-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-message-router.test.ts
@@ -65,6 +65,7 @@ function seedWorkflowRunWithChannels(
 		transitions: [],
 		startNodeId: '',
 		rules: [],
+		completionAutonomyLevel: 3,
 	});
 
 	const runRepo = new SpaceWorkflowRunRepository(db);

--- a/packages/daemon/tests/unit/5-space/agent/end-node-handlers.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/end-node-handlers.test.ts
@@ -1,0 +1,603 @@
+/**
+ * Unit tests for createEndNodeHandlers() — the Design v2 three-tool contract
+ * for end-node agents (Task #39).
+ *
+ * Covers:
+ *   - report_result       — append-only audit; never mutates task state
+ *   - approve_task        — autonomy-gated self-close
+ *   - submit_for_approval — always-available human sign-off request
+ *
+ * These handlers were extracted from task-agent-manager.ts so they can be
+ * unit-tested directly with a real SQLite DB and no live agent sessions.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceTaskReportResultRepository } from '../../../../src/storage/repositories/space-task-report-result-repository.ts';
+import { createEndNodeHandlers } from '../../../../src/lib/space/tools/end-node-handlers.ts';
+import type { EndNodeHandlerDeps } from '../../../../src/lib/space/tools/end-node-handlers.ts';
+import type { Space, SpaceWorkflow } from '@neokai/shared';
+import type { DaemonHub } from '../../../../src/lib/daemon-hub.ts';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeDb(): { db: BunDatabase; dir: string } {
+	const dir = join(
+		process.cwd(),
+		'tmp',
+		'test-end-node-handlers',
+		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
+	);
+	mkdirSync(dir, { recursive: true });
+	const db = new BunDatabase(join(dir, 'test.db'));
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	return { db, dir };
+}
+
+function seedSpaceRow(db: BunDatabase, spaceId: string, autonomyLevel = 1): void {
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, slug, status, autonomy_level, created_at, updated_at)
+     VALUES (?, '/tmp', ?, '', '', '', '[]', '[]', ?, 'active', ?, ?, ?)`
+	).run(spaceId, `Space ${spaceId}`, spaceId, autonomyLevel, Date.now(), Date.now());
+}
+
+function makeSpace(spaceId: string, autonomyLevel?: number): Space {
+	return {
+		id: spaceId,
+		workspacePath: '/tmp',
+		name: `Space ${spaceId}`,
+		description: '',
+		backgroundContext: '',
+		instructions: '',
+		sessionIds: [],
+		status: 'active',
+		autonomyLevel,
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	};
+}
+
+function makeWorkflow(completionAutonomyLevel: number, endNodeId = 'end-node'): SpaceWorkflow {
+	return {
+		id: 'wf-test',
+		spaceId: 'space-test',
+		name: 'Test WF',
+		description: '',
+		nodes: [{ id: endNodeId, name: 'end', agents: [] }],
+		channels: [],
+		gates: [],
+		startNodeId: endNodeId,
+		endNodeId,
+		completionAutonomyLevel,
+		tags: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	} as unknown as SpaceWorkflow;
+}
+
+interface MockHubCtx {
+	hub: Pick<DaemonHub, 'emit'>;
+	emitted: Array<{ name: string; payload: Record<string, unknown> }>;
+}
+
+function makeMockHub(): MockHubCtx {
+	const emitted: Array<{ name: string; payload: Record<string, unknown> }> = [];
+	const hub = {
+		emit: mock((name: string, payload: Record<string, unknown>) => {
+			emitted.push({ name, payload });
+			return Promise.resolve();
+		}),
+	} as unknown as Pick<DaemonHub, 'emit'>;
+	return { hub, emitted };
+}
+
+interface TestCtx {
+	db: BunDatabase;
+	dir: string;
+	spaceId: string;
+	taskRepo: SpaceTaskRepository;
+	reportRepo: SpaceTaskReportResultRepository;
+}
+
+function makeCtx(autonomyLevel = 1): TestCtx {
+	const { db, dir } = makeDb();
+	const spaceId = 'space-end-node-test';
+	seedSpaceRow(db, spaceId, autonomyLevel);
+	return {
+		db,
+		dir,
+		spaceId,
+		taskRepo: new SpaceTaskRepository(db),
+		reportRepo: new SpaceTaskReportResultRepository(db),
+	};
+}
+
+/** Build deps with sensible defaults + overrides. */
+function makeDeps(
+	ctx: TestCtx,
+	taskId: string,
+	overrides: Partial<EndNodeHandlerDeps> = {}
+): EndNodeHandlerDeps {
+	return {
+		taskId,
+		spaceId: ctx.spaceId,
+		workflow: makeWorkflow(3),
+		workflowNodeId: 'end-node',
+		agentName: 'reviewer',
+		taskRepo: ctx.taskRepo,
+		taskReportResultRepo: ctx.reportRepo,
+		spaceManager: {
+			getSpace: async () => makeSpace(ctx.spaceId, 3),
+		},
+		...overrides,
+	};
+}
+
+// ===========================================================================
+// report_result — APPEND-ONLY
+// ===========================================================================
+
+describe('createEndNodeHandlers — report_result', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('appends an audit row and does NOT mutate task state', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T1',
+			description: '',
+			status: 'in_progress',
+		});
+		const { onReportResult } = createEndNodeHandlers(makeDeps(ctx, task.id));
+
+		const out = await onReportResult({ summary: 'PR opened' });
+		const parsed = JSON.parse(out.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.taskId).toBe(task.id);
+		expect(parsed.message).toContain('does NOT close the task');
+
+		// task unchanged
+		const t = ctx.taskRepo.getTask(task.id);
+		expect(t?.status).toBe('in_progress');
+		expect(t?.reportedStatus).toBeFalsy();
+
+		// audit row written
+		const audit = ctx.reportRepo.listByTask(task.id);
+		expect(audit).toHaveLength(1);
+		expect(audit[0].summary).toBe('PR opened');
+		expect(audit[0].agentName).toBe('reviewer');
+	});
+
+	test('records optional evidence payload', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		const { onReportResult } = createEndNodeHandlers(makeDeps(ctx, task.id));
+
+		const out = await onReportResult({
+			summary: 'Done',
+			evidence: { prUrl: 'https://example.com/pr/1', commitSha: 'abc123' },
+		});
+		expect(JSON.parse(out.content[0].text).success).toBe(true);
+
+		const audit = ctx.reportRepo.listByTask(task.id);
+		expect(audit[0].evidence).toEqual({
+			prUrl: 'https://example.com/pr/1',
+			commitSha: 'abc123',
+		});
+	});
+
+	test('returns error when task does not exist', async () => {
+		const { onReportResult } = createEndNodeHandlers(makeDeps(ctx, 'no-such-task'));
+		const out = await onReportResult({ summary: 'x' });
+		const parsed = JSON.parse(out.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('no-such-task');
+	});
+
+	test('does NOT emit space.task.updated (audit-only)', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		const { hub, emitted } = makeMockHub();
+		const { onReportResult } = createEndNodeHandlers(makeDeps(ctx, task.id, { daemonHub: hub }));
+
+		await onReportResult({ summary: 'x' });
+		expect(emitted.filter((e) => e.name.startsWith('space.task.'))).toHaveLength(0);
+	});
+});
+
+// ===========================================================================
+// approve_task — autonomy-gated self-close
+// ===========================================================================
+
+describe('createEndNodeHandlers — approve_task', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('returns error when space.autonomyLevel < workflow.completionAutonomyLevel', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		const { onApproveTask } = createEndNodeHandlers(
+			makeDeps(ctx, task.id, {
+				workflow: makeWorkflow(3),
+				spaceManager: { getSpace: async () => makeSpace(ctx.spaceId, 1) },
+			})
+		);
+
+		const out = await onApproveTask({});
+		const parsed = JSON.parse(out.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('approve_task not permitted');
+		expect(parsed.error).toContain('space autonomy level 1');
+		expect(parsed.error).toContain('completionAutonomyLevel 3');
+
+		// task unchanged
+		const t = ctx.taskRepo.getTask(task.id);
+		expect(t?.reportedStatus).toBeFalsy();
+	});
+
+	test('defaults to level 1 when space has no autonomy set', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		const { onApproveTask } = createEndNodeHandlers(
+			makeDeps(ctx, task.id, {
+				workflow: makeWorkflow(3),
+				spaceManager: { getSpace: async () => makeSpace(ctx.spaceId, undefined) },
+			})
+		);
+
+		const out = await onApproveTask({});
+		const parsed = JSON.parse(out.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('space autonomy level 1');
+	});
+
+	test('defaults to required level 5 when workflow is null (blocks approval)', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		const { onApproveTask } = createEndNodeHandlers(
+			makeDeps(ctx, task.id, {
+				workflow: null,
+				spaceManager: { getSpace: async () => makeSpace(ctx.spaceId, 4) },
+			})
+		);
+
+		const out = await onApproveTask({});
+		const parsed = JSON.parse(out.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('completionAutonomyLevel 5');
+	});
+
+	test('sets reportedStatus=done when autonomy is sufficient', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		const { onApproveTask } = createEndNodeHandlers(
+			makeDeps(ctx, task.id, {
+				workflow: makeWorkflow(3),
+				spaceManager: { getSpace: async () => makeSpace(ctx.spaceId, 3) },
+			})
+		);
+
+		const out = await onApproveTask({});
+		const parsed = JSON.parse(out.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.taskId).toBe(task.id);
+		expect(parsed.message).toContain('completion-action pipeline');
+
+		const t = ctx.taskRepo.getTask(task.id);
+		expect(t?.reportedStatus).toBe('done');
+	});
+
+	test('clears pending-completion fields that were set by a prior submit_for_approval', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'review',
+		});
+		// Prime the pending-completion fields as if submit_for_approval ran first.
+		ctx.taskRepo.updateTask(task.id, {
+			pendingCheckpointType: 'task_completion',
+			pendingCompletionSubmittedByNodeId: 'end-node',
+			pendingCompletionSubmittedAt: Date.now() - 1000,
+			pendingCompletionReason: 'prior reason',
+		});
+
+		const { onApproveTask } = createEndNodeHandlers(
+			makeDeps(ctx, task.id, {
+				workflow: makeWorkflow(2),
+				spaceManager: { getSpace: async () => makeSpace(ctx.spaceId, 3) },
+			})
+		);
+
+		const out = await onApproveTask({});
+		expect(JSON.parse(out.content[0].text).success).toBe(true);
+
+		const t = ctx.taskRepo.getTask(task.id);
+		expect(t?.reportedStatus).toBe('done');
+		expect(t?.pendingCheckpointType).toBeNull();
+		expect(t?.pendingCompletionSubmittedByNodeId).toBeNull();
+		expect(t?.pendingCompletionSubmittedAt).toBeNull();
+		expect(t?.pendingCompletionReason).toBeNull();
+	});
+
+	test('emits space.task.updated with the updated task on success', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		const { hub, emitted } = makeMockHub();
+		const { onApproveTask } = createEndNodeHandlers(
+			makeDeps(ctx, task.id, {
+				workflow: makeWorkflow(3),
+				spaceManager: { getSpace: async () => makeSpace(ctx.spaceId, 3) },
+				daemonHub: hub,
+			})
+		);
+
+		await onApproveTask({});
+
+		const updateEvents = emitted.filter((e) => e.name === 'space.task.updated');
+		expect(updateEvents).toHaveLength(1);
+		expect(updateEvents[0].payload.taskId).toBe(task.id);
+		expect(updateEvents[0].payload.spaceId).toBe(ctx.spaceId);
+		const emittedTask = updateEvents[0].payload.task as { id: string; reportedStatus: string };
+		expect(emittedTask.id).toBe(task.id);
+		expect(emittedTask.reportedStatus).toBe('done');
+	});
+
+	test('does NOT emit space.task.updated when permission check fails', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		const { hub, emitted } = makeMockHub();
+		const { onApproveTask } = createEndNodeHandlers(
+			makeDeps(ctx, task.id, {
+				workflow: makeWorkflow(5),
+				spaceManager: { getSpace: async () => makeSpace(ctx.spaceId, 1) },
+				daemonHub: hub,
+			})
+		);
+
+		await onApproveTask({});
+		expect(emitted).toHaveLength(0);
+	});
+
+	test('returns error when task does not exist (even at sufficient autonomy)', async () => {
+		const { onApproveTask } = createEndNodeHandlers(
+			makeDeps(ctx, 'ghost-task', {
+				workflow: makeWorkflow(3),
+				spaceManager: { getSpace: async () => makeSpace(ctx.spaceId, 5) },
+			})
+		);
+		const out = await onApproveTask({});
+		const parsed = JSON.parse(out.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('ghost-task');
+	});
+});
+
+// ===========================================================================
+// submit_for_approval — always available
+// ===========================================================================
+
+describe('createEndNodeHandlers — submit_for_approval', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('sets status=review and populates pending-completion fields', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		const { onSubmitForApproval } = createEndNodeHandlers(
+			makeDeps(ctx, task.id, { workflowNodeId: 'end-node-xyz' })
+		);
+
+		const before = Date.now();
+		const out = await onSubmitForApproval({ reason: 'needs review' });
+		const after = Date.now();
+
+		const parsed = JSON.parse(out.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.message).toContain('submitted for human review');
+		expect(parsed.message).toContain('needs review');
+
+		const t = ctx.taskRepo.getTask(task.id);
+		expect(t?.status).toBe('review');
+		expect(t?.pendingCheckpointType).toBe('task_completion');
+		expect(t?.pendingCompletionSubmittedByNodeId).toBe('end-node-xyz');
+		expect(t?.pendingCompletionReason).toBe('needs review');
+		expect(t?.pendingCompletionSubmittedAt).toBeGreaterThanOrEqual(before);
+		expect(t?.pendingCompletionSubmittedAt).toBeLessThanOrEqual(after);
+	});
+
+	test('handles missing reason (optional field)', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		const { onSubmitForApproval } = createEndNodeHandlers(makeDeps(ctx, task.id));
+
+		const out = await onSubmitForApproval({});
+		const parsed = JSON.parse(out.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		// Message omits the "(reason: ...)" suffix when reason is missing.
+		expect(parsed.message).not.toContain('(reason:');
+
+		const t = ctx.taskRepo.getTask(task.id);
+		expect(t?.status).toBe('review');
+		expect(t?.pendingCompletionReason).toBeNull();
+	});
+
+	test('succeeds regardless of space autonomy level', async () => {
+		// submit_for_approval must work even at level 1 (the most restrictive).
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		const { onSubmitForApproval } = createEndNodeHandlers(
+			makeDeps(ctx, task.id, {
+				workflow: makeWorkflow(5),
+				spaceManager: { getSpace: async () => makeSpace(ctx.spaceId, 1) },
+			})
+		);
+
+		const out = await onSubmitForApproval({ reason: 'low-autonomy submit' });
+		const parsed = JSON.parse(out.content[0].text);
+		expect(parsed.success).toBe(true);
+
+		const t = ctx.taskRepo.getTask(task.id);
+		expect(t?.status).toBe('review');
+	});
+
+	test('emits space.task.updated with the updated task', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		const { hub, emitted } = makeMockHub();
+		const { onSubmitForApproval } = createEndNodeHandlers(
+			makeDeps(ctx, task.id, { daemonHub: hub })
+		);
+
+		await onSubmitForApproval({ reason: 'escalate' });
+
+		const updateEvents = emitted.filter((e) => e.name === 'space.task.updated');
+		expect(updateEvents).toHaveLength(1);
+		expect(updateEvents[0].payload.taskId).toBe(task.id);
+		const emittedTask = updateEvents[0].payload.task as {
+			id: string;
+			status: string;
+			pendingCheckpointType: string;
+		};
+		expect(emittedTask.id).toBe(task.id);
+		expect(emittedTask.status).toBe('review');
+		expect(emittedTask.pendingCheckpointType).toBe('task_completion');
+	});
+
+	test('returns error when task does not exist', async () => {
+		const { onSubmitForApproval } = createEndNodeHandlers(makeDeps(ctx, 'ghost'));
+		const out = await onSubmitForApproval({ reason: 'x' });
+		const parsed = JSON.parse(out.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('ghost');
+	});
+});
+
+// ===========================================================================
+// daemonHub is optional
+// ===========================================================================
+
+describe('createEndNodeHandlers — daemonHub is optional', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('approve_task succeeds without a daemonHub', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		const { onApproveTask } = createEndNodeHandlers(
+			makeDeps(ctx, task.id, {
+				workflow: makeWorkflow(1),
+				spaceManager: { getSpace: async () => makeSpace(ctx.spaceId, 5) },
+				daemonHub: undefined,
+			})
+		);
+
+		const out = await onApproveTask({});
+		expect(JSON.parse(out.content[0].text).success).toBe(true);
+		expect(ctx.taskRepo.getTask(task.id)?.reportedStatus).toBe('done');
+	});
+
+	test('submit_for_approval succeeds without a daemonHub', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		const { onSubmitForApproval } = createEndNodeHandlers(
+			makeDeps(ctx, task.id, { daemonHub: undefined })
+		);
+
+		const out = await onSubmitForApproval({});
+		expect(JSON.parse(out.content[0].text).success).toBe(true);
+		expect(ctx.taskRepo.getTask(task.id)?.status).toBe('review');
+	});
+});

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-collaboration.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-collaboration.test.ts
@@ -194,6 +194,7 @@ function buildTwoNodeWorkflow(ctx: TestCtx): SpaceWorkflow {
 		transitions: [],
 		startNodeId: node1Id,
 		rules: [],
+		completionAutonomyLevel: 3,
 	});
 }
 
@@ -219,6 +220,7 @@ function buildHumanGateWorkflow(ctx: TestCtx): SpaceWorkflow {
 				gate: { type: 'human', description: 'Human must approve before reviewer is notified' },
 			},
 		],
+		completionAutonomyLevel: 3,
 	});
 }
 
@@ -323,6 +325,7 @@ describe('Task Agent — multi-agent node collaboration', () => {
 			],
 			startNodeId: node1Id,
 			channels: [{ id: 'ch-1', from: 'Code', to: 'Review' }],
+			completionAutonomyLevel: 3,
 		});
 
 		const loadedWf = ctx.workflowManager.getWorkflow(wf.id);
@@ -345,6 +348,7 @@ describe('Task Agent — multi-agent node collaboration', () => {
 			startNodeId: 'only-node',
 			rules: [],
 			channels: [],
+			completionAutonomyLevel: 3,
 		});
 
 		const { run, mainTask } = await startRun(ctx, wf);

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-mcp.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-mcp.test.ts
@@ -533,6 +533,7 @@ function seedWorkflowRunWithChannels(
 		transitions: [],
 		startNodeId: '',
 		rules: [],
+		completionAutonomyLevel: 3,
 	});
 	const runRepo = new SpaceWorkflowRunRepository(bunDb);
 	const run = runRepo.createRun({

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
@@ -362,6 +362,7 @@ function seedWorkflowRun(ctx: TestCtx, wfRunId: string, _wfId: string, wfNodeId:
 		],
 		startNodeId: wfNodeId,
 		tags: [],
+		completionAutonomyLevel: 3,
 	});
 	const now = Date.now();
 	ctx.bunDb

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
@@ -464,6 +464,7 @@ describe('TaskAgentManager', () => {
 				],
 				startNodeId: fallbackStepId,
 				tags: ['default'],
+				completionAutonomyLevel: 3,
 			});
 
 			const task = await makeTask(ctx.taskManager);

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-session-lifecycle.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-session-lifecycle.test.ts
@@ -1266,6 +1266,7 @@ describe('Task Agent Session Lifecycle', () => {
 					},
 				],
 				startNodeId: 'step-code',
+				completionAutonomyLevel: 3,
 			});
 
 			const task = await makeTask(ctx.taskManager, {

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-tool-schemas.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-tool-schemas.test.ts
@@ -193,12 +193,14 @@ describe('RequestHumanInputSchema', () => {
 // ---------------------------------------------------------------------------
 
 describe('TASK_AGENT_TOOL_SCHEMAS', () => {
-	test('contains all 3 tool schemas', () => {
+	test('contains all 5 tool schemas', () => {
 		const keys = Object.keys(TASK_AGENT_TOOL_SCHEMAS);
 		expect(keys).toContain('report_result');
+		expect(keys).toContain('approve_task');
+		expect(keys).toContain('submit_for_approval');
 		expect(keys).toContain('request_human_input');
 		expect(keys).toContain('list_group_members');
-		expect(keys).toHaveLength(3);
+		expect(keys).toHaveLength(5);
 	});
 
 	test('each schema value is a valid Zod schema with safeParse', () => {

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-tools.test.ts
@@ -71,6 +71,7 @@ import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
 import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository.ts';
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceTaskReportResultRepository } from '../../../../src/storage/repositories/space-task-report-result-repository.ts';
 import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
 import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
@@ -166,6 +167,7 @@ function buildTwoStepWorkflow(
 			},
 		],
 		startNodeId: step1Id,
+		completionAutonomyLevel: 3,
 	});
 }
 
@@ -181,6 +183,7 @@ function buildSingleStepWorkflow(
 		name,
 		nodes: [{ id: stepId, name: 'Only Step', agents: [{ agentId, name: 'only-step' }] }],
 		startNodeId: stepId,
+		completionAutonomyLevel: 3,
 	});
 }
 
@@ -199,6 +202,7 @@ function buildHumanGateWorkflow(
 			{ id: step2Id, name: 'After Gate', agents: [{ agentId, name: 'after-gate' }] },
 		],
 		startNodeId: step1Id,
+		completionAutonomyLevel: 3,
 	});
 }
 
@@ -218,6 +222,7 @@ function buildTaskResultWorkflow(
 			{ id: step2Id, name: 'Next Step', agents: [{ agentId, name: 'next-step' }] },
 		],
 		startNodeId: step1Id,
+		completionAutonomyLevel: 3,
 	});
 }
 
@@ -234,6 +239,7 @@ interface TestCtx {
 	workflowManager: SpaceWorkflowManager;
 	workflowRunRepo: SpaceWorkflowRunRepository;
 	taskRepo: SpaceTaskRepository;
+	taskReportResultRepo: SpaceTaskReportResultRepository;
 	nodeExecutionRepo: NodeExecutionRepository;
 	taskManager: SpaceTaskManager;
 	runtime: SpaceRuntime;
@@ -257,6 +263,7 @@ function makeCtx(): TestCtx {
 
 	const workflowRunRepo = new SpaceWorkflowRunRepository(db);
 	const taskRepo = new SpaceTaskRepository(db);
+	const taskReportResultRepo = new SpaceTaskReportResultRepository(db);
 	const nodeExecutionRepo = new NodeExecutionRepository(db);
 	const spaceManager = new SpaceManager(db);
 	const taskManager = new SpaceTaskManager(db, spaceId);
@@ -282,6 +289,7 @@ function makeCtx(): TestCtx {
 		workflowManager,
 		workflowRunRepo,
 		taskRepo,
+		taskReportResultRepo,
 		nodeExecutionRepo,
 		taskManager,
 		runtime,
@@ -301,6 +309,7 @@ function makeConfig(
 		space: ctx.space,
 		workflowRunId,
 		taskRepo: ctx.taskRepo,
+		taskReportResultRepo: ctx.taskReportResultRepo,
 		nodeExecutionRepo: ctx.nodeExecutionRepo,
 		taskManager: ctx.taskManager,
 		messageInjector: options?.messageInjector ?? (async () => {}),
@@ -379,7 +388,7 @@ async function startRun(
 // report_result tests
 // ===========================================================================
 
-describe('createTaskAgentToolHandlers — report_result', () => {
+describe('createTaskAgentToolHandlers — report_result (Design v2 append-only audit)', () => {
 	let ctx: TestCtx;
 	beforeEach(() => {
 		ctx = makeCtx();
@@ -389,7 +398,7 @@ describe('createTaskAgentToolHandlers — report_result', () => {
 		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
-	test('records summary and marks task done (runtime pipeline decides terminal status)', async () => {
+	test('records summary as an audit row and does NOT mutate task state', async () => {
 		const mainTask = ctx.taskRepo.createTask({
 			spaceId: ctx.spaceId,
 			title: 'Main task',
@@ -405,17 +414,24 @@ describe('createTaskAgentToolHandlers — report_result', () => {
 		const parsed = JSON.parse(result.content[0].text);
 
 		expect(parsed.success).toBe(true);
-		expect(parsed.summary).toBe('All steps completed successfully.');
-		// `status` is intentionally NOT echoed — the agent does not control it.
+		expect(parsed.taskId).toBe(mainTask.id);
+		expect(parsed.reportId).toBeDefined();
+		// `status` is intentionally NOT echoed — report_result is audit-only.
 		expect(parsed.status).toBeUndefined();
 
+		// The task's status must remain unchanged (report_result is append-only).
 		const updated = ctx.taskRepo.getTask(mainTask.id);
-		// The tool always records `done`; the completion-action pipeline may
-		// later downgrade it. Downstream tests cover that.
-		expect(updated?.status).toBe('done');
+		expect(updated?.status).toBe('in_progress');
+
+		// Exactly one audit row is written.
+		const audit = ctx.taskReportResultRepo.listByTask(mainTask.id);
+		expect(audit).toHaveLength(1);
+		expect(audit[0].summary).toBe('All steps completed successfully.');
+		expect(audit[0].evidence).toBeNull();
+		expect(audit[0].agentName).toBe('task-agent');
 	});
 
-	test('records evidence alongside the summary', async () => {
+	test('records evidence alongside the summary in the audit row', async () => {
 		const mainTask = ctx.taskRepo.createTask({
 			spaceId: ctx.spaceId,
 			title: 'Main task',
@@ -435,11 +451,17 @@ describe('createTaskAgentToolHandlers — report_result', () => {
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(true);
 
+		// Task state unchanged (audit-only).
 		const updated = ctx.taskRepo.getTask(mainTask.id);
-		expect(updated?.status).toBe('done');
-		expect(updated?.result).toContain('PR opened.');
-		expect(updated?.result).toContain('https://github.com/example/repo/pull/42');
-		expect(updated?.result).toContain('abc1234');
+		expect(updated?.status).toBe('in_progress');
+
+		const audit = ctx.taskReportResultRepo.listByTask(mainTask.id);
+		expect(audit).toHaveLength(1);
+		expect(audit[0].summary).toBe('PR opened.');
+		expect(audit[0].evidence).toEqual({
+			prUrl: 'https://github.com/example/repo/pull/42',
+			commitSha: 'abc1234',
+		});
 	});
 
 	test('returns error when task not found', async () => {
@@ -454,32 +476,40 @@ describe('createTaskAgentToolHandlers — report_result', () => {
 		expect(parsed.error).toContain('task-does-not-exist');
 	});
 
-	test('returns error when status transition is invalid', async () => {
-		// done → done is not a valid transition
+	test('accepts multiple report_result calls on the same task (append-only, no transition errors)', async () => {
+		// Design v2: the agent can report many times during a task's lifetime.
+		// Unlike the legacy contract, there is no transition error for repeat calls.
 		const mainTask = ctx.taskRepo.createTask({
 			spaceId: ctx.spaceId,
-			title: 'Already done',
+			title: 'Ongoing',
 			description: '',
-			status: 'done',
+			status: 'in_progress',
 		});
 
 		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, 'run-id'));
 
-		const result = await handlers.report_result({
-			summary: 'Done again?',
-		});
-		const parsed = JSON.parse(result.content[0].text);
+		const first = await handlers.report_result({ summary: 'First report.' });
+		const second = await handlers.report_result({ summary: 'Second report.' });
 
-		expect(parsed.success).toBe(false);
-		expect(parsed.error).toContain('transition');
+		expect(JSON.parse(first.content[0].text).success).toBe(true);
+		expect(JSON.parse(second.content[0].text).success).toBe(true);
+
+		const audit = ctx.taskReportResultRepo.listByTask(mainTask.id);
+		expect(audit).toHaveLength(2);
+		expect(audit[0].summary).toBe('First report.');
+		expect(audit[1].summary).toBe('Second report.');
+
+		// Task is still in_progress — reports never close it.
+		const updated = ctx.taskRepo.getTask(mainTask.id);
+		expect(updated?.status).toBe('in_progress');
 	});
 });
 
 // ===========================================================================
-// report_result — DaemonHub event emission tests
+// report_result — DaemonHub event emission tests (Design v2)
 // ===========================================================================
 
-describe('createTaskAgentToolHandlers — report_result DaemonHub events', () => {
+describe('createTaskAgentToolHandlers — report_result does not emit task lifecycle events', () => {
 	let ctx: TestCtx;
 	beforeEach(() => {
 		ctx = makeCtx();
@@ -489,7 +519,7 @@ describe('createTaskAgentToolHandlers — report_result DaemonHub events', () =>
 		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
-	test('emits space.task.done event with summary', async () => {
+	test('does NOT emit space.task.done (report_result is audit-only; approve_task owns terminal events)', async () => {
 		const mainTask = ctx.taskRepo.createTask({
 			spaceId: ctx.spaceId,
 			title: 'Test Task',
@@ -505,44 +535,11 @@ describe('createTaskAgentToolHandlers — report_result DaemonHub events', () =>
 
 		await handlers.report_result({ summary: 'All done.' });
 
-		// The mock emit is synchronous (records events before returning Promise.resolve()),
-		// so no async flush is needed — assertions can run immediately.
-		expect(emittedEvents).toHaveLength(1);
-		expect(emittedEvents[0].name).toBe('space.task.done');
-		expect(emittedEvents[0].payload.taskId).toBe(mainTask.id);
-		expect(emittedEvents[0].payload.spaceId).toBe(ctx.spaceId);
-		expect(emittedEvents[0].payload.status).toBe('done');
-		expect(emittedEvents[0].payload.summary).toBe('All done.');
-		expect(emittedEvents[0].payload.workflowRunId).toBe('run-123');
-		expect(emittedEvents[0].payload.taskTitle).toBe('Test Task');
-	});
-
-	test('always emits space.task.done (runtime pipeline decides final status)', async () => {
-		const mainTask = ctx.taskRepo.createTask({
-			spaceId: ctx.spaceId,
-			title: 'Failing Task',
-			description: '',
-			status: 'in_progress',
-		});
-		const { hub, emittedEvents } = makeMockDaemonHub();
-
-		const handlers = createTaskAgentToolHandlers({
-			...makeConfig(ctx, mainTask.id, 'run-456'),
-			daemonHub: hub,
-		});
-
-		// The agent can no longer self-certify "blocked" — it always reports a
-		// summary and the completion-action pipeline decides if the task should
-		// end up blocked/needs_attention.
-		await handlers.report_result({
-			summary: 'Tests failed — summary only; pipeline may flip to needs_attention.',
-		});
-
-		expect(emittedEvents).toHaveLength(1);
-		expect(emittedEvents[0].name).toBe('space.task.done');
-		expect(emittedEvents[0].payload.taskId).toBe(mainTask.id);
-		expect(emittedEvents[0].payload.status).toBe('done');
-		expect(emittedEvents[0].payload.taskTitle).toBe('Failing Task');
+		// Design v2: report_result must not emit any task lifecycle events.
+		// Terminal events (space.task.done) are the responsibility of approve_task
+		// and the completion-action pipeline that handles submit_for_approval.
+		const taskLifecycleEvents = emittedEvents.filter((e) => e.name.startsWith('space.task.'));
+		expect(taskLifecycleEvents).toHaveLength(0);
 	});
 
 	test('does not emit events when daemonHub is not provided', async () => {
@@ -561,25 +558,6 @@ describe('createTaskAgentToolHandlers — report_result DaemonHub events', () =>
 
 		// Should still succeed — hub is optional
 		expect(parsed.success).toBe(true);
-	});
-
-	test('event payload includes sessionId: global', async () => {
-		const mainTask = ctx.taskRepo.createTask({
-			spaceId: ctx.spaceId,
-			title: 'Hub Test Task',
-			description: '',
-			status: 'in_progress',
-		});
-		const { hub, emittedEvents } = makeMockDaemonHub();
-
-		const handlers = createTaskAgentToolHandlers({
-			...makeConfig(ctx, mainTask.id, 'run-id'),
-			daemonHub: hub,
-		});
-
-		await handlers.report_result({ summary: 'Done.' });
-
-		expect(emittedEvents[0].payload.sessionId).toBe('global');
 	});
 
 	test('does not emit event when task is not found', async () => {
@@ -777,7 +755,9 @@ describe('createTaskAgentMcpServer', () => {
 		const { server } = await makeServerCtx();
 		const entry = server.instance._registeredTools['report_result'];
 		expect(entry).toBeDefined();
-		expect(entry.description).toContain('Mark the task as completed, failed, or cancelled');
+		// Design v2: report_result is append-only audit.
+		expect(entry.description).toContain('append-only audit');
+		expect(entry.description).toContain('does NOT close the task');
 	});
 
 	test('request_human_input has correct description', async () => {

--- a/packages/daemon/tests/unit/5-space/other/channel-router-async.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/channel-router-async.test.ts
@@ -101,6 +101,7 @@ function buildWorkflowWithGates(
 		tags: [],
 		channels,
 		gates,
+		completionAutonomyLevel: 3,
 	});
 }
 

--- a/packages/daemon/tests/unit/5-space/other/channel-router-auto-approval.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/channel-router-auto-approval.test.ts
@@ -86,6 +86,7 @@ function buildWorkflowWithGates(
 		tags: [],
 		channels,
 		gates,
+		completionAutonomyLevel: 3,
 	});
 }
 

--- a/packages/daemon/tests/unit/5-space/other/channel-router-reopen.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/channel-router-reopen.test.ts
@@ -120,6 +120,7 @@ function buildSimpleWorkflow(
 		tags: [],
 		channels,
 		gates,
+		completionAutonomyLevel: 3,
 	});
 }
 

--- a/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
@@ -145,6 +145,7 @@ function buildWorkflow(
 		rules: [],
 		tags: [],
 		channels: channels ?? [],
+		completionAutonomyLevel: 3,
 	});
 }
 
@@ -182,6 +183,7 @@ function buildWorkflowWithGates(
 		tags: [],
 		channels,
 		gates,
+		completionAutonomyLevel: 3,
 	});
 }
 

--- a/packages/daemon/tests/unit/5-space/other/cross-agent-messaging-integration.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/cross-agent-messaging-integration.test.ts
@@ -131,6 +131,7 @@ function seedWorkflowRunWithChannels(
 		spaceId,
 		name: `Integration Test Workflow ${Math.random().toString(36).slice(2)}`,
 		nodes: [{ name: 'step', agents: [{ agentId: 'agent-1', name: 'agent' }] }],
+		completionAutonomyLevel: 3,
 	});
 
 	const runRepo = new SpaceWorkflowRunRepository(db);
@@ -173,6 +174,7 @@ function makeTestDb(): TestDb {
 		spaceId,
 		name: 'Integration Test Workflow',
 		nodes: [{ name: 'step', agents: [{ agentId: 'agent-1', name: 'agent' }] }],
+		completionAutonomyLevel: 3,
 	});
 	const run = workflowRunRepo.createRun({
 		spaceId,

--- a/packages/daemon/tests/unit/5-space/other/cross-agent-messaging.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/cross-agent-messaging.test.ts
@@ -222,6 +222,7 @@ function makeStepCtx(
 		transitions: [],
 		startNodeId: '',
 		rules: [],
+		completionAutonomyLevel: 3,
 	});
 	const workflowRunRepo = new SpaceWorkflowRunRepository(db);
 	const run = workflowRunRepo.createRun({
@@ -471,6 +472,7 @@ function buildSingleStepWf(ctx: TaskCtx) {
 		transitions: [],
 		startNodeId: stepId,
 		rules: [],
+		completionAutonomyLevel: 3,
 	});
 }
 

--- a/packages/daemon/tests/unit/5-space/other/gate-types-and-schema.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/gate-types-and-schema.test.ts
@@ -178,6 +178,7 @@ describe('SpaceWorkflowRepository — gates round-trip', () => {
 			spaceId: SPACE_ID,
 			name: 'Test Workflow',
 			gates,
+			completionAutonomyLevel: 3,
 		});
 
 		expect(workflow.gates).toBeDefined();
@@ -194,6 +195,7 @@ describe('SpaceWorkflowRepository — gates round-trip', () => {
 		const workflow = workflowRepo.createWorkflow({
 			spaceId: SPACE_ID,
 			name: 'No Gates Workflow',
+			completionAutonomyLevel: 3,
 		});
 		expect(workflow.gates).toBeUndefined();
 	});
@@ -203,6 +205,7 @@ describe('SpaceWorkflowRepository — gates round-trip', () => {
 		const workflow = workflowRepo.createWorkflow({
 			spaceId: SPACE_ID,
 			name: 'Update Gates Test',
+			completionAutonomyLevel: 3,
 		});
 
 		// Set gates
@@ -254,6 +257,7 @@ describe('SpaceWorkflowRepository — gates with label and color round-trip', ()
 			spaceId: SPACE_ID,
 			name: 'Label Color Workflow',
 			gates,
+			completionAutonomyLevel: 3,
 		});
 
 		expect(workflow.gates).toBeDefined();
@@ -285,6 +289,7 @@ describe('SpaceWorkflowRepository — gates with label and color round-trip', ()
 					resetOnCycle: false,
 				},
 			],
+			completionAutonomyLevel: 3,
 		});
 
 		// Update with label and color added
@@ -364,6 +369,7 @@ describe('SpaceWorkflowRepository — gates with label and color round-trip', ()
 			spaceId: SPACE_ID,
 			name: 'Multi Label Color',
 			gates,
+			completionAutonomyLevel: 3,
 		});
 
 		expect(workflow.gates).toHaveLength(3);
@@ -398,6 +404,7 @@ describe('SpaceWorkflowRepository — gates with label and color round-trip', ()
 			spaceId: SPACE_ID,
 			name: 'Label Only Workflow',
 			gates,
+			completionAutonomyLevel: 3,
 		});
 
 		expect(workflow.gates![0].label).toBe('Manual Check');
@@ -427,6 +434,7 @@ describe('SpaceWorkflowRepository — gates with label and color round-trip', ()
 			spaceId: SPACE_ID,
 			name: 'Color Only Workflow',
 			gates,
+			completionAutonomyLevel: 3,
 		});
 
 		expect(workflow.gates![0].color).toBe('#8b5cf6');
@@ -458,6 +466,7 @@ describe('SpaceWorkflowRepository — gates with script round-trip', () => {
 			spaceId: SPACE_ID,
 			name: 'Bash Script Workflow',
 			gates,
+			completionAutonomyLevel: 3,
 		});
 
 		expect(workflow.gates).toBeDefined();
@@ -486,6 +495,7 @@ describe('SpaceWorkflowRepository — gates with script round-trip', () => {
 			spaceId: SPACE_ID,
 			name: 'Node Script Workflow',
 			gates,
+			completionAutonomyLevel: 3,
 		});
 
 		expect(workflow.gates![0].script!.interpreter).toBe('node');
@@ -512,6 +522,7 @@ describe('SpaceWorkflowRepository — gates with script round-trip', () => {
 			spaceId: SPACE_ID,
 			name: 'Python Script Workflow',
 			gates,
+			completionAutonomyLevel: 3,
 		});
 
 		expect(workflow.gates![0].script!.interpreter).toBe('python3');
@@ -554,6 +565,7 @@ describe('SpaceWorkflowRepository — gates with script round-trip', () => {
 			spaceId: SPACE_ID,
 			name: 'Combined Gate Workflow',
 			gates,
+			completionAutonomyLevel: 3,
 		});
 
 		const gate = workflow.gates![0];
@@ -588,6 +600,7 @@ describe('SpaceWorkflowRepository — gates with script round-trip', () => {
 					resetOnCycle: false,
 				},
 			],
+			completionAutonomyLevel: 3,
 		});
 
 		// Update: replace fields-only gate with script gate
@@ -633,6 +646,7 @@ describe('SpaceWorkflowRepository — script-only gate round-trip', () => {
 			spaceId: SPACE_ID,
 			name: 'Script Only Workflow',
 			gates,
+			completionAutonomyLevel: 3,
 		});
 
 		expect(workflow.gates).toBeDefined();
@@ -664,6 +678,7 @@ describe('SpaceWorkflowRepository — script-only gate round-trip', () => {
 			spaceId: SPACE_ID,
 			name: 'Script Only Round-Trip',
 			gates,
+			completionAutonomyLevel: 3,
 		});
 
 		// Fetch fresh from DB
@@ -706,6 +721,7 @@ describe('SpaceWorkflowRepository — script-only gate round-trip', () => {
 			spaceId: SPACE_ID,
 			name: 'Multi Script Gates',
 			gates,
+			completionAutonomyLevel: 3,
 		});
 
 		expect(workflow.gates).toHaveLength(3);
@@ -731,6 +747,7 @@ describe('SpaceWorkflowRepository — script-only gate round-trip', () => {
 					resetOnCycle: false,
 				},
 			],
+			completionAutonomyLevel: 3,
 		});
 
 		// Update: add fields alongside script
@@ -768,6 +785,7 @@ describe('SpaceWorkflowRunRepository — failureReason', () => {
 		const workflow = workflowRepo.createWorkflow({
 			spaceId: SPACE_ID,
 			name: 'FR Test Workflow',
+			completionAutonomyLevel: 3,
 		});
 
 		const runRepo = new SpaceWorkflowRunRepository(db);
@@ -784,6 +802,7 @@ describe('SpaceWorkflowRunRepository — failureReason', () => {
 		const workflow = workflowRepo.createWorkflow({
 			spaceId: SPACE_ID,
 			name: 'FR Persist Test',
+			completionAutonomyLevel: 3,
 		});
 
 		const runRepo = new SpaceWorkflowRunRepository(db);
@@ -811,6 +830,7 @@ describe('SpaceWorkflowRunRepository — failureReason', () => {
 		const workflow = workflowRepo.createWorkflow({
 			spaceId: SPACE_ID,
 			name: 'FR Clear Test',
+			completionAutonomyLevel: 3,
 		});
 
 		const runRepo = new SpaceWorkflowRunRepository(db);
@@ -831,6 +851,7 @@ describe('SpaceWorkflowRunRepository — failureReason', () => {
 		const workflow = workflowRepo.createWorkflow({
 			spaceId: SPACE_ID,
 			name: 'FR All Values',
+			completionAutonomyLevel: 3,
 		});
 		const runRepo = new SpaceWorkflowRunRepository(db);
 
@@ -867,6 +888,7 @@ describe('gate_data table — schema and CRUD', () => {
 		const workflow = workflowRepo.createWorkflow({
 			spaceId: SPACE_ID,
 			name: 'GD Test Workflow',
+			completionAutonomyLevel: 3,
 		});
 		const runRepo = new SpaceWorkflowRunRepository(db);
 		const run = runRepo.createRun({
@@ -895,6 +917,7 @@ describe('gate_data table — schema and CRUD', () => {
 		const workflow = workflowRepo.createWorkflow({
 			spaceId: SPACE_ID,
 			name: 'Cascade Test',
+			completionAutonomyLevel: 3,
 		});
 		const runRepo = new SpaceWorkflowRunRepository(db);
 		const run = runRepo.createRun({
@@ -1256,6 +1279,7 @@ describe('Backward compatibility — gates without new fields round-trip', () =>
 			spaceId: SPACE_ID,
 			name: 'Legacy Fields Gate',
 			gates,
+			completionAutonomyLevel: 3,
 		});
 
 		expect(workflow.gates).toHaveLength(1);
@@ -1290,6 +1314,7 @@ describe('Backward compatibility — gates without new fields round-trip', () =>
 			spaceId: SPACE_ID,
 			name: 'Legacy Desc Gate',
 			gates,
+			completionAutonomyLevel: 3,
 		});
 
 		expect(workflow.gates![0].id).toBe('gate-desc');
@@ -1334,6 +1359,7 @@ describe('Backward compatibility — gates without new fields round-trip', () =>
 			spaceId: SPACE_ID,
 			name: 'Multi Legacy Gates',
 			gates,
+			completionAutonomyLevel: 3,
 		});
 
 		expect(workflow.gates).toHaveLength(2);
@@ -1366,6 +1392,7 @@ describe('Backward compatibility — gates without new fields round-trip', () =>
 			spaceId: SPACE_ID,
 			name: 'Legacy Round-Trip',
 			gates,
+			completionAutonomyLevel: 3,
 		});
 
 		// Fetch fresh from DB

--- a/packages/daemon/tests/unit/5-space/other/send-message-unified.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/send-message-unified.test.ts
@@ -70,6 +70,7 @@ function seedWorkflowRunWithChannels(
 		description: '',
 		nodes: [],
 		startNodeId: '',
+		completionAutonomyLevel: 3,
 	});
 
 	const runRepo = new SpaceWorkflowRunRepository(db);

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-task-creation-flow.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-task-creation-flow.test.ts
@@ -79,6 +79,7 @@ function buildSingleStepWorkflow(
 		startNodeId: stepId,
 		rules: [],
 		tags,
+		completionAutonomyLevel: 3,
 	});
 }
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -86,6 +86,7 @@ function buildSingleStepWorkflow(
 		startNodeId: stepId,
 		rules: [],
 		tags,
+		completionAutonomyLevel: 3,
 	});
 }
 
@@ -1187,6 +1188,7 @@ describe('createSpaceAgentToolHandlers — task creation and planning node activ
 			startNodeId: stepId,
 			rules: [],
 			tags: ['coding', 'v2'],
+			completionAutonomyLevel: 3,
 		});
 
 		const result = await startWorkflowRun(ctx, {
@@ -1215,6 +1217,7 @@ describe('createSpaceAgentToolHandlers — task creation and planning node activ
 			startNodeId: stepId,
 			rules: [],
 			tags: ['planning', 'decomposition'],
+			completionAutonomyLevel: 3,
 		});
 
 		await startWorkflowRun(ctx, {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
@@ -185,6 +185,7 @@ function buildWorkflowWithActions(
 		endNodeId,
 		rules: [],
 		tags: [],
+		completionAutonomyLevel: 3,
 	});
 }
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
@@ -106,6 +106,7 @@ function buildLinearWorkflow(
 		rules: [],
 		tags: [],
 		channels,
+		completionAutonomyLevel: 3,
 	});
 }
 
@@ -642,6 +643,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 				],
 				startNodeId: 'chan-plan',
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -676,6 +678,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 				rules: [],
 				tags: [],
 				transitions: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -744,6 +747,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 				rules: [],
 				tags: [],
 				transitions: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -789,6 +793,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 				rules: [],
 				tags: [],
 				transitions: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -832,6 +837,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 				rules: [],
 				tags: [],
 				transitions: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -871,6 +877,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 				rules: [],
 				tags: [],
 				transitions: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -917,6 +924,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 				rules: [],
 				tags: [],
 				transitions: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -1028,6 +1036,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 				startNodeId: 'en-start',
 				endNodeId: 'en-end',
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 			expect(workflow.endNodeId).toBe('en-end');
 
@@ -1078,6 +1087,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 				startNodeId: 'ec-sibling',
 				endNodeId: 'ec-end',
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -1143,6 +1153,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 				startNodeId: 'coder-node',
 				endNodeId: 'reviewer-node',
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -1193,6 +1204,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 				],
 				startNodeId: 'no-en-1',
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			// Simulate a legacy workflow row persisted before end_node_id existed.
@@ -1221,6 +1233,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 				startNodeId: 'rs-start',
 				endNodeId: 'rs-end',
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -1253,6 +1266,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 				startNodeId: 'enc-start',
 				endNodeId: 'enc-end',
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
@@ -142,6 +142,7 @@ function buildLinearWorkflow(
 		startNodeId: nodes[0].id,
 		rules: [],
 		tags: [],
+		completionAutonomyLevel: 3,
 	});
 }
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-llm-workflow-selection.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-llm-workflow-selection.test.ts
@@ -82,6 +82,7 @@ function buildWorkflow(
 		startNodeId: stepId,
 		rules: [],
 		tags,
+		completionAutonomyLevel: 3,
 	});
 }
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-notifications.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-notifications.test.ts
@@ -172,6 +172,7 @@ function buildLinearWorkflow(
 		nodes: workflowNodes,
 		startNodeId: nodes[0].id,
 		tags: [],
+		completionAutonomyLevel: 3,
 	});
 }
 
@@ -1107,6 +1108,7 @@ describe('SpaceRuntime — notification events', () => {
 				endNodeId: SYNTHETIC_END_NODE_ID,
 				rules: [],
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -1141,6 +1143,7 @@ describe('SpaceRuntime — notification events', () => {
 				endNodeId: SYNTHETIC_END_NODE_ID,
 				rules: [],
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -1193,6 +1196,7 @@ describe('SpaceRuntime — notification events', () => {
 				endNodeId: SYNTHETIC_END_NODE_ID,
 				rules: [],
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -1333,6 +1337,7 @@ describe('SpaceRuntime — notification events', () => {
 				endNodeId: SYNTHETIC_END_NODE_ID,
 				rules: [],
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -1372,6 +1377,7 @@ describe('SpaceRuntime — notification events', () => {
 				endNodeId: SYNTHETIC_END_NODE_ID,
 				rules: [],
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -1469,6 +1475,7 @@ describe('SpaceRuntime — notification events', () => {
 				endNodeId: SYNTHETIC_END_NODE_ID,
 				rules: [],
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -1512,6 +1519,7 @@ describe('SpaceRuntime — notification events', () => {
 				startNodeId: 'step-coder-sum',
 				rules: [],
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			// startWorkflowRun creates the task for the start (Coder) node
@@ -1559,6 +1567,7 @@ describe('SpaceRuntime — notification events', () => {
 				startNodeId: 'step-nosummary',
 				rules: [],
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			// startWorkflowRun creates the task for the start node
@@ -1599,6 +1608,7 @@ describe('SpaceRuntime — notification events', () => {
 				startNodeId: 'step-upstream-prio',
 				rules: [],
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			// startWorkflowRun creates the task for the start (Coder/upstream) node
@@ -1665,6 +1675,7 @@ describe('SpaceRuntime — notification events', () => {
 				startNodeId: 'step-nt-a',
 				rules: [],
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -1722,6 +1733,7 @@ describe('SpaceRuntime — notification events', () => {
 				startNodeId: 'step-mt-start',
 				rules: [],
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -1788,6 +1800,7 @@ describe('SpaceRuntime — notification events', () => {
 				startNodeId: 'step-mtnr-start',
 				rules: [],
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -1837,6 +1850,7 @@ describe('SpaceRuntime — notification events', () => {
 				startNodeId: 'step-empty-res',
 				rules: [],
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -1874,6 +1888,7 @@ describe('SpaceRuntime — notification events', () => {
 				startNodeId: 'step-bidi-a',
 				rules: [],
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -1933,6 +1948,7 @@ describe('SpaceRuntime — notification events', () => {
 				startNodeId: 'step-slot-parallel',
 				rules: [],
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-rehydration.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-rehydration.test.ts
@@ -82,6 +82,7 @@ function buildLinearWorkflow(
 		startNodeId: nodes[0].id,
 		rules: [],
 		tags: [],
+		completionAutonomyLevel: 3,
 	});
 }
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -699,6 +699,7 @@ describe('activateWorkflowNode() — notification forwarding', () => {
 				tags: [],
 				channels: [],
 				gates: [],
+				completionAutonomyLevel: 3,
 			});
 
 			// Create a run + canonical task, then mark the run as `done`.

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
@@ -88,6 +88,7 @@ function buildLinearWorkflow(
 		startNodeId: nodes[0].id,
 		rules: [],
 		tags: [],
+		completionAutonomyLevel: 3,
 	});
 }
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
@@ -88,6 +88,7 @@ function buildLinearWorkflow(
 		startNodeId: nodes[0].id,
 		rules: [],
 		tags: [],
+		completionAutonomyLevel: 3,
 	});
 }
 
@@ -293,6 +294,7 @@ describe('SpaceRuntime', () => {
 					endNodeId: 'step-bad',
 					rules: [],
 					tags: [],
+					completionAutonomyLevel: 3,
 				});
 			} finally {
 				db.exec('PRAGMA foreign_keys = ON');
@@ -389,6 +391,7 @@ describe('SpaceRuntime', () => {
 				endNodeId,
 				rules: [],
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Multi Run');
@@ -419,6 +422,7 @@ describe('SpaceRuntime', () => {
 				endNodeId,
 				rules: [],
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Custom Multi Run');
@@ -445,6 +449,7 @@ describe('SpaceRuntime', () => {
 					startNodeId: STEP_A,
 					rules: [],
 					tags: [],
+					completionAutonomyLevel: 3,
 				});
 			} finally {
 				db.exec('PRAGMA foreign_keys = ON');
@@ -1104,6 +1109,7 @@ describe('SpaceRuntime', () => {
 				endNodeId,
 				rules: [],
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -1147,6 +1153,7 @@ describe('SpaceRuntime', () => {
 				endNodeId,
 				rules: [],
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -1176,6 +1183,7 @@ describe('SpaceRuntime', () => {
 				startNodeId: STEP_A,
 				rules: [],
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -1211,6 +1219,7 @@ describe('SpaceRuntime', () => {
 				endNodeId,
 				rules: [],
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -1245,6 +1254,7 @@ describe('SpaceRuntime', () => {
 				endNodeId,
 				rules: [],
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -1284,6 +1294,7 @@ describe('SpaceRuntime', () => {
 				channels: [{ id: 'ch-1', from: 'Code', to: 'Review', label: 'submit' }],
 				startNodeId: STEP_A,
 				tags: [],
+				completionAutonomyLevel: 3,
 			});
 
 			const { run } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -1328,6 +1339,7 @@ describe('SpaceRuntime', () => {
 				nodes,
 				startNodeId: stepId,
 				endNodeId,
+				completionAutonomyLevel: 3,
 			});
 
 			const { run } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');

--- a/packages/daemon/tests/unit/5-space/runtime/space-workflow.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-workflow.test.ts
@@ -104,6 +104,7 @@ describe('SpaceWorkflowRepository', () => {
 			spaceId: 'space-1',
 			name: 'My Workflow',
 			nodes: [coderNode, plannerNode],
+			completionAutonomyLevel: 3,
 		});
 
 		expect(wf.id).toBeTruthy();
@@ -122,6 +123,7 @@ describe('SpaceWorkflowRepository', () => {
 			name: 'Tagged',
 			nodes: [coderNode],
 			tags: ['ci', 'deploy'],
+			completionAutonomyLevel: 3,
 		});
 		expect(wf.tags).toEqual(['ci', 'deploy']);
 	});
@@ -131,6 +133,7 @@ describe('SpaceWorkflowRepository', () => {
 			spaceId: 'space-1',
 			name: 'Auto Start',
 			nodes: [coderNode, plannerNode],
+			completionAutonomyLevel: 3,
 		});
 		expect(wf.startNodeId).toBe(coderNode.id);
 	});
@@ -141,6 +144,7 @@ describe('SpaceWorkflowRepository', () => {
 			name: 'Explicit Start',
 			nodes: [coderNode, plannerNode],
 			startNodeId: plannerNode.id,
+			completionAutonomyLevel: 3,
 		});
 		expect(wf.startNodeId).toBe(plannerNode.id);
 	});
@@ -157,6 +161,7 @@ describe('SpaceWorkflowRepository', () => {
 			nodes: [coderNode, plannerNode],
 			startNodeId: coderNode.id,
 			tags: ['a', 'b'],
+			completionAutonomyLevel: 3,
 		});
 
 		const fetched = repo.getWorkflow(created.id)!;
@@ -167,14 +172,25 @@ describe('SpaceWorkflowRepository', () => {
 	});
 
 	test('listWorkflows returns all workflows for a space', () => {
-		repo.createWorkflow({ spaceId: 'space-1', name: 'WF1', nodes: [coderNode] });
-		repo.createWorkflow({ spaceId: 'space-1', name: 'WF2', nodes: [plannerNode] });
+		repo.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF1',
+			nodes: [coderNode],
+			completionAutonomyLevel: 3,
+		});
+		repo.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF2',
+			nodes: [plannerNode],
+			completionAutonomyLevel: 3,
+		});
 		// Another space — should not appear; use anonymous step (no fixed id) to avoid PK collision
 		seedSpace(db, 'space-2');
 		repo.createWorkflow({
 			spaceId: 'space-2',
 			name: 'WF3',
 			nodes: [{ name: 'Code', agentId: 'agent-coder' }],
+			completionAutonomyLevel: 3,
 		});
 
 		const wfs = repo.listWorkflows('space-1');
@@ -183,14 +199,24 @@ describe('SpaceWorkflowRepository', () => {
 	});
 
 	test('updateWorkflow updates name and description', () => {
-		const wf = repo.createWorkflow({ spaceId: 'space-1', name: 'Old Name', nodes: [coderNode] });
+		const wf = repo.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Old Name',
+			nodes: [coderNode],
+			completionAutonomyLevel: 3,
+		});
 		const updated = repo.updateWorkflow(wf.id, { name: 'New Name', description: 'Updated desc' });
 		expect(updated?.name).toBe('New Name');
 		expect(updated?.description).toBe('Updated desc');
 	});
 
 	test('updateWorkflow bumps updatedAt on step-only update', async () => {
-		const wf = repo.createWorkflow({ spaceId: 'space-1', name: 'WF', nodes: [coderNode] });
+		const wf = repo.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF',
+			nodes: [coderNode],
+			completionAutonomyLevel: 3,
+		});
 		const before = wf.updatedAt;
 		// Small delay to ensure timestamp difference
 		await new Promise((r) => setTimeout(r, 2));
@@ -205,6 +231,7 @@ describe('SpaceWorkflowRepository', () => {
 			spaceId: 'space-1',
 			name: 'WF',
 			nodes: [coderNode, plannerNode],
+			completionAutonomyLevel: 3,
 		});
 		expect(wf.nodes).toHaveLength(2);
 
@@ -220,7 +247,12 @@ describe('SpaceWorkflowRepository', () => {
 	});
 
 	test('deleteWorkflow removes the workflow and its steps', () => {
-		const wf = repo.createWorkflow({ spaceId: 'space-1', name: 'WF', nodes: [coderNode] });
+		const wf = repo.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF',
+			nodes: [coderNode],
+			completionAutonomyLevel: 3,
+		});
 		expect(repo.deleteWorkflow(wf.id)).toBe(true);
 		expect(repo.getWorkflow(wf.id)).toBeNull();
 
@@ -243,6 +275,7 @@ describe('SpaceWorkflowRepository', () => {
 			spaceId: 'space-1',
 			name: 'WF With Agent',
 			nodes: [{ id: 'step-1', name: 'Step', agentId: 'agent-1' }],
+			completionAutonomyLevel: 3,
 		});
 		const results = repo.getWorkflowsReferencingAgent('agent-1');
 		expect(results).toHaveLength(1);
@@ -254,6 +287,7 @@ describe('SpaceWorkflowRepository', () => {
 			spaceId: 'space-1',
 			name: 'WF',
 			nodes: [coderNode],
+			completionAutonomyLevel: 3,
 		});
 		expect(repo.getWorkflowsReferencingAgent('no-such-agent')).toHaveLength(0);
 	});
@@ -276,6 +310,7 @@ describe('SpaceWorkflowRepository', () => {
 					],
 				},
 			],
+			completionAutonomyLevel: 3,
 		});
 		// Both agents must be found via the config LIKE path (agent_id is NULL in DB)
 		const refs1 = repo.getWorkflowsReferencingAgent('agent-multi-1');
@@ -315,6 +350,7 @@ describe('SpaceWorkflowRepository', () => {
 					// node-level instructions removed
 				},
 			],
+			completionAutonomyLevel: 3,
 		});
 
 		const read = repo.getWorkflow(wf.id);
@@ -355,6 +391,7 @@ describe('SpaceWorkflowRepository', () => {
 				{ id: 'ch-1', from: 'Channels Step', to: 'multi-2', label: 'feedback' },
 				{ id: 'ch-2', from: 'multi-2', to: ['Channels Step', 'Channels Step'] },
 			],
+			completionAutonomyLevel: 3,
 		});
 
 		const read = repo.getWorkflow(wf.id);
@@ -384,6 +421,7 @@ describe('SpaceWorkflowRepository', () => {
 					agentId: 'agent-1',
 				} as unknown as import('@neokai/shared').WorkflowNodeInput,
 			],
+			completionAutonomyLevel: 3,
 		});
 
 		const read = repo.getWorkflow(wf.id);
@@ -404,6 +442,7 @@ describe('SpaceWorkflowRepository', () => {
 			name: 'WF',
 			nodes: [coderNode],
 			tags: ['ci', 'deploy'],
+			completionAutonomyLevel: 3,
 		});
 		const fetched = repo.getWorkflow(wf.id)!;
 		expect(fetched.tags).toEqual(['ci', 'deploy']);
@@ -421,6 +460,7 @@ describe('SpaceWorkflowRepository', () => {
 					agentId: 'agent-99',
 				} as unknown as import('@neokai/shared').WorkflowNodeInput,
 			],
+			completionAutonomyLevel: 3,
 		});
 		const fetched = repo.getWorkflow(wf.id)!;
 		// Legacy agentId shorthand is normalised to agents[] during insertNode
@@ -441,6 +481,7 @@ describe('SpaceWorkflowRepository', () => {
 			name: 'Layout WF',
 			nodes: [coderNode, plannerNode],
 			layout,
+			completionAutonomyLevel: 3,
 		});
 		expect(wf.layout).toEqual(layout);
 
@@ -453,6 +494,7 @@ describe('SpaceWorkflowRepository', () => {
 			spaceId: 'space-1',
 			name: 'No Layout WF',
 			nodes: [coderNode],
+			completionAutonomyLevel: 3,
 		});
 		expect(wf.layout).toBeUndefined();
 
@@ -465,6 +507,7 @@ describe('SpaceWorkflowRepository', () => {
 			spaceId: 'space-1',
 			name: 'WF',
 			nodes: [coderNode],
+			completionAutonomyLevel: 3,
 		});
 		expect(wf.layout).toBeUndefined();
 
@@ -483,6 +526,7 @@ describe('SpaceWorkflowRepository', () => {
 			name: 'WF',
 			nodes: [coderNode],
 			layout,
+			completionAutonomyLevel: 3,
 		});
 		expect(wf.layout).toEqual(layout);
 
@@ -500,6 +544,7 @@ describe('SpaceWorkflowRepository', () => {
 			name: 'WF Raw',
 			nodes: [coderNode],
 			layout,
+			completionAutonomyLevel: 3,
 		});
 		const row = db.prepare('SELECT layout FROM space_workflows WHERE id = ?').get(wf.id) as {
 			layout: string;
@@ -543,42 +588,83 @@ describe('SpaceWorkflowManager', () => {
 	// -------------------------------------------------------------------------
 
 	test('createWorkflow throws if name already exists in space', () => {
-		manager.createWorkflow({ spaceId: 'space-1', name: 'Dup', nodes: [coderNode] });
+		manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Dup',
+			nodes: [coderNode],
+			completionAutonomyLevel: 3,
+		});
 		expect(() =>
-			manager.createWorkflow({ spaceId: 'space-1', name: 'Dup', nodes: [plannerNode] })
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Dup',
+				nodes: [plannerNode],
+				completionAutonomyLevel: 3,
+			})
 		).toThrow(WorkflowValidationError);
 	});
 
 	test('createWorkflow allows same name in different spaces', () => {
 		seedSpace(db, 'space-2');
-		manager.createWorkflow({ spaceId: 'space-1', name: 'Same', nodes: [coderNode] });
+		manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Same',
+			nodes: [coderNode],
+			completionAutonomyLevel: 3,
+		});
 		// Use anonymous step (no fixed id) to avoid PK collision across spaces in the same DB
 		const wf2 = manager.createWorkflow({
 			spaceId: 'space-2',
 			name: 'Same',
 			nodes: [{ name: 'Code', agentId: 'agent-coder' }],
+			completionAutonomyLevel: 3,
 		});
 		expect(wf2.name).toBe('Same');
 	});
 
 	test('updateWorkflow throws if new name conflicts with another workflow', () => {
-		manager.createWorkflow({ spaceId: 'space-1', name: 'Existing', nodes: [coderNode] });
-		const wf = manager.createWorkflow({ spaceId: 'space-1', name: 'WF2', nodes: [plannerNode] });
+		manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Existing',
+			nodes: [coderNode],
+			completionAutonomyLevel: 3,
+		});
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF2',
+			nodes: [plannerNode],
+			completionAutonomyLevel: 3,
+		});
 		expect(() => manager.updateWorkflow(wf.id, { name: 'Existing' })).toThrow(
 			WorkflowValidationError
 		);
 	});
 
 	test('updateWorkflow allows keeping the same name', () => {
-		const wf = manager.createWorkflow({ spaceId: 'space-1', name: 'WF', nodes: [coderNode] });
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF',
+			nodes: [coderNode],
+			completionAutonomyLevel: 3,
+		});
 		const updated = manager.updateWorkflow(wf.id, { name: 'WF' });
 		expect(updated?.name).toBe('WF');
 	});
 
 	test('name is trimmed before storage — whitespace variants collide', () => {
-		manager.createWorkflow({ spaceId: 'space-1', name: 'Foo', nodes: [coderNode] });
+		manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'Foo',
+			nodes: [coderNode],
+			completionAutonomyLevel: 3,
+		});
 		expect(() =>
-			manager.createWorkflow({ spaceId: 'space-1', name: '  Foo  ', nodes: [plannerNode] })
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: '  Foo  ',
+				nodes: [plannerNode],
+				completionAutonomyLevel: 3,
+			})
 		).toThrow(WorkflowValidationError);
 	});
 
@@ -587,6 +673,7 @@ describe('SpaceWorkflowManager', () => {
 			spaceId: 'space-1',
 			name: '  Trimmed  ',
 			nodes: [coderNode],
+			completionAutonomyLevel: 3,
 		});
 		expect(wf.name).toBe('Trimmed');
 	});
@@ -596,24 +683,39 @@ describe('SpaceWorkflowManager', () => {
 	// -------------------------------------------------------------------------
 
 	test('createWorkflow throws when steps is empty', () => {
-		expect(() => manager.createWorkflow({ spaceId: 'space-1', name: 'Empty', nodes: [] })).toThrow(
-			WorkflowValidationError
-		);
+		expect(() =>
+			manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Empty',
+				nodes: [],
+				completionAutonomyLevel: 3,
+			})
+		).toThrow(WorkflowValidationError);
 	});
 
 	test('createWorkflow throws when steps is not provided (defaults to empty)', () => {
-		expect(() => manager.createWorkflow({ spaceId: 'space-1', name: 'NoNodes' })).toThrow(
-			WorkflowValidationError
-		);
+		expect(() =>
+			manager.createWorkflow({ spaceId: 'space-1', name: 'NoNodes', completionAutonomyLevel: 3 })
+		).toThrow(WorkflowValidationError);
 	});
 
 	test('updateWorkflow throws when replacing with empty steps', () => {
-		const wf = manager.createWorkflow({ spaceId: 'space-1', name: 'WF', nodes: [coderNode] });
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF',
+			nodes: [coderNode],
+			completionAutonomyLevel: 3,
+		});
 		expect(() => manager.updateWorkflow(wf.id, { nodes: [] })).toThrow(WorkflowValidationError);
 	});
 
 	test('updateWorkflow throws when steps is null (treated as empty replacement)', () => {
-		const wf = manager.createWorkflow({ spaceId: 'space-1', name: 'WF', nodes: [coderNode] });
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF',
+			nodes: [coderNode],
+			completionAutonomyLevel: 3,
+		});
 		expect(() => manager.updateWorkflow(wf.id, { nodes: null as unknown as [] })).toThrow(
 			WorkflowValidationError
 		);
@@ -628,6 +730,7 @@ describe('SpaceWorkflowManager', () => {
 			spaceId: 'space-1',
 			name: 'WF',
 			nodes: [{ name: 'Step', agents: [{ agentId: 'some-uuid', name: 'agent' }] }],
+			completionAutonomyLevel: 3,
 		});
 		expect(wf.nodes[0].agents[0].agentId).toBe('some-uuid');
 	});
@@ -638,6 +741,7 @@ describe('SpaceWorkflowManager', () => {
 				spaceId: 'space-1',
 				name: 'Bad AgentId',
 				nodes: [{ name: 'Step', agentId: '' }],
+				completionAutonomyLevel: 3,
 			})
 		).toThrow(WorkflowValidationError);
 	});
@@ -648,6 +752,7 @@ describe('SpaceWorkflowManager', () => {
 				spaceId: 'space-1',
 				name: 'Whitespace AgentId',
 				nodes: [{ name: 'Step', agentId: '   ' }],
+				completionAutonomyLevel: 3,
 			})
 		).toThrow(WorkflowValidationError);
 	});
@@ -663,6 +768,7 @@ describe('SpaceWorkflowManager', () => {
 			spaceId: 'space-1',
 			name: 'Custom WF',
 			nodes: [{ name: 'Step', agents: [{ agentId: 'agent-1', name: 'main' }] }],
+			completionAutonomyLevel: 3,
 		});
 		expect(wf.nodes[0].agents[0].agentId).toBe('agent-1');
 	});
@@ -677,6 +783,7 @@ describe('SpaceWorkflowManager', () => {
 				spaceId: 'space-1',
 				name: 'Bad Agent',
 				nodes: [{ name: 'Step', agentId: 'non-existent-uuid' }],
+				completionAutonomyLevel: 3,
 			})
 		).toThrow(WorkflowValidationError);
 	});
@@ -686,12 +793,18 @@ describe('SpaceWorkflowManager', () => {
 			spaceId: 'space-1',
 			name: 'No-Lookup WF',
 			nodes: [{ name: 'Step', agents: [{ agentId: 'anything', name: 'main' }] }],
+			completionAutonomyLevel: 3,
 		});
 		expect(wf.nodes[0].agents[0].agentId).toBe('anything');
 	});
 
 	test('updateWorkflow rejects invalid agentId via lookup', () => {
-		const wf = manager.createWorkflow({ spaceId: 'space-1', name: 'WF', nodes: [coderNode] });
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF',
+			nodes: [coderNode],
+			completionAutonomyLevel: 3,
+		});
 		const lookup: SpaceAgentLookup = { getAgentById: () => null };
 		const mgr = new SpaceWorkflowManager(repo, lookup);
 		expect(() =>
@@ -706,7 +819,12 @@ describe('SpaceWorkflowManager', () => {
 	// -------------------------------------------------------------------------
 
 	test('deleteWorkflow removes an existing workflow', () => {
-		const wf = manager.createWorkflow({ spaceId: 'space-1', name: 'WF', nodes: [coderNode] });
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF',
+			nodes: [coderNode],
+			completionAutonomyLevel: 3,
+		});
 		expect(manager.deleteWorkflow(wf.id)).toBe(true);
 		expect(manager.getWorkflow(wf.id)).toBeNull();
 	});
@@ -724,6 +842,7 @@ describe('SpaceWorkflowManager', () => {
 			spaceId: 'space-1',
 			name: 'Ordered',
 			nodes: [plannerNode, coderNode, generalNode],
+			completionAutonomyLevel: 3,
 		});
 		expect(wf.nodes[0].name).toBe('Plan');
 		expect(wf.nodes[1].name).toBe('Code');
@@ -740,11 +859,13 @@ describe('SpaceWorkflowManager', () => {
 			spaceId: 'space-1',
 			name: 'Uses Alpha',
 			nodes: [{ id: 'step-1', name: 'Step', agentId: 'agent-1' }],
+			completionAutonomyLevel: 3,
 		});
 		manager.createWorkflow({
 			spaceId: 'space-1',
 			name: 'Uses Other',
 			nodes: [coderNode],
+			completionAutonomyLevel: 3,
 		});
 		const refs = manager.getWorkflowsReferencingAgent('agent-1');
 		expect(refs).toHaveLength(1);
@@ -766,6 +887,7 @@ describe('SpaceWorkflowManager', () => {
 						agents: [{ agentId: '' }],
 					},
 				],
+				completionAutonomyLevel: 3,
 			})
 		).toThrow(WorkflowValidationError);
 	});
@@ -781,6 +903,7 @@ describe('SpaceWorkflowManager', () => {
 						agents: [{ agentId: '   ' }],
 					},
 				],
+				completionAutonomyLevel: 3,
 			})
 		).toThrow(WorkflowValidationError);
 	});
@@ -800,12 +923,18 @@ describe('SpaceWorkflowManager', () => {
 				// Synthetic single-agent end node — multi-agent end nodes are forbidden.
 				{ name: 'End', agentId: 'agent-a' },
 			],
+			completionAutonomyLevel: 3,
 		});
 		expect(wf.nodes[0].agents).toHaveLength(2);
 	});
 
 	test('updateWorkflow rejects agents[] entry with empty agentId (no lookup)', () => {
-		const wf = manager.createWorkflow({ spaceId: 'space-1', name: 'WF', nodes: [coderNode] });
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF',
+			nodes: [coderNode],
+			completionAutonomyLevel: 3,
+		});
 		expect(() =>
 			manager.updateWorkflow(wf.id, {
 				nodes: [{ id: 'step-x', name: 'Step', agents: [{ agentId: '' }] }],
@@ -824,6 +953,7 @@ describe('SpaceWorkflowManager', () => {
 				name: 'Empty From',
 				nodes: [{ name: 'Step', agents: [{ agentId: 'agent-a', name: 'a' }] }],
 				channels: [{ id: 'ch-1', from: '', to: 'Step' }],
+				completionAutonomyLevel: 3,
 			})
 		).toThrow(WorkflowValidationError);
 	});
@@ -835,6 +965,7 @@ describe('SpaceWorkflowManager', () => {
 				name: 'Empty To',
 				nodes: [{ name: 'Step', agents: [{ agentId: 'agent-a', name: 'a' }] }],
 				channels: [{ id: 'ch-1', from: 'Step', to: '' }],
+				completionAutonomyLevel: 3,
 			})
 		).toThrow(WorkflowValidationError);
 	});
@@ -846,6 +977,7 @@ describe('SpaceWorkflowManager', () => {
 				name: 'Empty Array To',
 				nodes: [{ name: 'Step', agents: [{ agentId: 'agent-a', name: 'a' }] }],
 				channels: [{ id: 'ch-1', from: 'Step', to: [] as string[] }],
+				completionAutonomyLevel: 3,
 			})
 		).toThrow(WorkflowValidationError);
 	});
@@ -857,6 +989,7 @@ describe('SpaceWorkflowManager', () => {
 				name: 'Whitespace From',
 				nodes: [{ name: 'Step', agents: [{ agentId: 'agent-a', name: 'a' }] }],
 				channels: [{ id: 'ch-1', from: '   ', to: 'Step' }],
+				completionAutonomyLevel: 3,
 			})
 		).toThrow(WorkflowValidationError);
 	});
@@ -868,6 +1001,7 @@ describe('SpaceWorkflowManager', () => {
 				name: 'Whitespace To',
 				nodes: [{ name: 'Step', agents: [{ agentId: 'agent-a', name: 'a' }] }],
 				channels: [{ id: 'ch-1', from: 'Step', to: '   ' }],
+				completionAutonomyLevel: 3,
 			})
 		).toThrow(WorkflowValidationError);
 	});
@@ -879,6 +1013,7 @@ describe('SpaceWorkflowManager', () => {
 				name: 'Whitespace Array To Element',
 				nodes: [{ name: 'Step', agents: [{ agentId: 'agent-a', name: 'a' }] }],
 				channels: [{ id: 'ch-1', from: 'Step', to: ['   '] }],
+				completionAutonomyLevel: 3,
 			})
 		).toThrow(WorkflowValidationError);
 	});
@@ -893,6 +1028,7 @@ describe('SpaceWorkflowManager', () => {
 			],
 			channels: [{ id: 'ch-1', from: '*', to: 'Review' }],
 			startNodeId: 'n1',
+			completionAutonomyLevel: 3,
 		});
 		expect(wf.channels).toHaveLength(1);
 		expect(wf.channels![0].from).toBe('*');
@@ -909,6 +1045,7 @@ describe('SpaceWorkflowManager', () => {
 			],
 			channels: [{ id: 'ch-1', from: 'Code', to: ['Review', 'QA'] }],
 			startNodeId: 'n1',
+			completionAutonomyLevel: 3,
 		});
 		expect(wf.channels).toHaveLength(1);
 		expect(wf.channels![0].to).toEqual(['Review', 'QA']);
@@ -930,6 +1067,7 @@ describe('SpaceWorkflowManager', () => {
 			],
 			channels: [{ id: 'ch-1', from: 'Code', to: 'Review' }],
 			startNodeId: 'n1',
+			completionAutonomyLevel: 3,
 		});
 		expect(wf.channels).toHaveLength(1);
 		expect(wf.channels![0].from).toBe('Code');
@@ -942,6 +1080,7 @@ describe('SpaceWorkflowManager', () => {
 			name: 'Any Role Channels',
 			nodes: [{ name: 'Step', agents: [{ agentId: 'agent-coder-id', name: 'coder' }] }],
 			channels: [{ id: 'ch-1', from: 'arbitrary-source', to: 'arbitrary-target' }],
+			completionAutonomyLevel: 3,
 		});
 		expect(wf.channels).toHaveLength(1);
 	});
@@ -952,13 +1091,19 @@ describe('SpaceWorkflowManager', () => {
 			name: 'Wildcard Channels 2',
 			nodes: [{ name: 'Step', agents: [{ agentId: 'agent-coder-id', name: 'coder' }] }],
 			channels: [{ id: 'ch-1', from: '*', to: '*' }],
+			completionAutonomyLevel: 3,
 		});
 		expect(wf.channels).toHaveLength(1);
 		expect(wf.channels![0].from).toBe('*');
 	});
 
 	test('updateWorkflow stores channels at workflow level when replacing step', () => {
-		const wf = manager.createWorkflow({ spaceId: 'space-1', name: 'WF', nodes: [coderNode] });
+		const wf = manager.createWorkflow({
+			spaceId: 'space-1',
+			name: 'WF',
+			nodes: [coderNode],
+			completionAutonomyLevel: 3,
+		});
 		const updated = manager.updateWorkflow(wf.id, {
 			nodes: [
 				{ id: 'n1', name: 'Code', agents: [{ agentId: 'agent-coder-id', name: 'coder' }] },
@@ -1000,6 +1145,7 @@ describe('SpaceWorkflowManager', () => {
 			],
 			channels: [{ id: 'ch-1', from: 'Code', to: 'Review', label: 'submit' }],
 			startNodeId: 'step-1',
+			completionAutonomyLevel: 3,
 		});
 
 		const read = manager.getWorkflow(wf.id)!;
@@ -1024,6 +1170,7 @@ describe('SpaceWorkflowManager', () => {
 			spaceId: 'space-1',
 			name: 'Update Multi-Agent',
 			nodes: [coderNode],
+			completionAutonomyLevel: 3,
 		});
 
 		const updated = manager.updateWorkflow(wf.id, {
@@ -1068,6 +1215,7 @@ describe('SpaceWorkflowManager', () => {
 			],
 			startNodeId: 'step-1',
 			endNodeId: 'step-end',
+			completionAutonomyLevel: 3,
 		});
 
 		expect(manager.deleteWorkflow(wf.id)).toBe(true);
@@ -1080,6 +1228,7 @@ describe('SpaceWorkflowManager', () => {
 			spaceId: 'space-1',
 			name: 'Single Agent',
 			nodes: [coderNode],
+			completionAutonomyLevel: 3,
 		});
 		const multi = manager.createWorkflow({
 			spaceId: 'space-1',
@@ -1098,6 +1247,7 @@ describe('SpaceWorkflowManager', () => {
 			],
 			startNodeId: 'step-m',
 			endNodeId: 'step-end',
+			completionAutonomyLevel: 3,
 		});
 
 		const workflows = manager.listWorkflows('space-1');
@@ -1127,6 +1277,7 @@ describe('SpaceWorkflowManager', () => {
 						agents: [{ agentId: 'agent-a', name: '' }],
 					},
 				],
+				completionAutonomyLevel: 3,
 			})
 		).toThrow(WorkflowValidationError);
 	});
@@ -1145,6 +1296,7 @@ describe('SpaceWorkflowManager', () => {
 						],
 					},
 				],
+				completionAutonomyLevel: 3,
 			})
 		).toThrow(WorkflowValidationError);
 	});
@@ -1164,6 +1316,7 @@ describe('SpaceWorkflowManager', () => {
 				// Synthetic single-agent end node — multi-agent end nodes are forbidden.
 				{ name: 'End', agentId: 'agent-a' },
 			],
+			completionAutonomyLevel: 3,
 		});
 		expect(wf.nodes[0].agents).toHaveLength(2);
 		expect(wf.nodes[0].agents![0].name).toBe('strict-reviewer');
@@ -1187,6 +1340,7 @@ describe('SpaceWorkflowManager', () => {
 					agents: [{ agentId: 'agent-old-1' }, { agentId: 'agent-old-2' }],
 				},
 			],
+			completionAutonomyLevel: 3,
 		});
 
 		const read = repo.getWorkflow(wf.id)!;

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -1056,6 +1056,7 @@ describe('seedBuiltInWorkflows()', () => {
 			spaceId: SPACE_ID,
 			name: 'My Custom Workflow',
 			nodes: [{ name: 'Code', agentId: CODER_ID }],
+			completionAutonomyLevel: 3,
 		});
 
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
@@ -1705,6 +1706,7 @@ describe('Coding Workflow export/import round-trip', () => {
 			startNodeId: undefined,
 			tags: exported.tags,
 			channels: exported.channels,
+			completionAutonomyLevel: exported.completionAutonomyLevel ?? 3,
 		});
 
 		// Verify the re-imported workflow

--- a/packages/daemon/tests/unit/5-space/workflow/gate-autonomy-status-consistency.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/gate-autonomy-status-consistency.test.ts
@@ -59,6 +59,7 @@ function createWorkflowAndRun(db: BunDatabase, spaceId: string): { runId: string
 		description: '',
 		nodes: [],
 		startNodeId: '',
+		completionAutonomyLevel: 3,
 	});
 	const runRepo = new SpaceWorkflowRunRepository(db);
 	const run = runRepo.createRun({ spaceId, workflowId: workflow.id, title: 'Gate Test Run' });

--- a/packages/daemon/tests/unit/5-space/workflow/workflow-executor-multi-agent.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/workflow-executor-multi-agent.test.ts
@@ -190,6 +190,7 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 			endNodeId,
 			rules: [],
 			tags: [],
+			completionAutonomyLevel: 3,
 		});
 
 		const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Multi Start Run');
@@ -232,6 +233,7 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 			endNodeId,
 			rules: [],
 			tags: [],
+			completionAutonomyLevel: 3,
 		});
 
 		const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -261,6 +263,7 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 			endNodeId,
 			rules: [],
 			tags: [],
+			completionAutonomyLevel: 3,
 		});
 
 		const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -289,6 +292,7 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 			endNodeId,
 			rules: [],
 			tags: [],
+			completionAutonomyLevel: 3,
 		});
 
 		const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -321,6 +325,7 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 			startNodeId: STEP_A,
 			rules: [],
 			tags: [],
+			completionAutonomyLevel: 3,
 		});
 
 		const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -363,6 +368,7 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 			endNodeId,
 			rules: [],
 			tags: [],
+			completionAutonomyLevel: 3,
 		});
 
 		const { run } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -404,6 +410,7 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 			endNodeId,
 			rules: [],
 			tags: [],
+			completionAutonomyLevel: 3,
 		});
 
 		const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -445,6 +452,7 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 			endNodeId,
 			rules: [],
 			tags: [],
+			completionAutonomyLevel: 3,
 		});
 
 		const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -476,6 +484,7 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 			startNodeId: STEP_A,
 			rules: [],
 			tags: [],
+			completionAutonomyLevel: 3,
 		});
 
 		const { tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
@@ -637,6 +646,7 @@ describe('Mixed workflows — single-agent, multi-agent, and channels', () => {
 			endNodeId,
 			rules: [],
 			tags: [],
+			completionAutonomyLevel: 3,
 		});
 
 		const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Run');

--- a/packages/daemon/tests/unit/5-space/workflow/workflow-executor-progression.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/workflow-executor-progression.test.ts
@@ -153,6 +153,7 @@ function makeLinearWorkflow(steps: Array<{ id: string; agentId: string }>): {
 			order: 0,
 		})),
 		startNodeId: steps[0].id,
+		completionAutonomyLevel: 3,
 	});
 	const run = runRepo.createRun({ spaceId: SPACE_ID, workflowId: workflow.id, title: 'Test' });
 	return { workflow, run };

--- a/packages/daemon/tests/unit/5-space/workflow/workflow-executor.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/workflow-executor.test.ts
@@ -156,6 +156,7 @@ describe('WorkflowExecutor', () => {
 			nodes,
 			transitions,
 			startNodeId: stepsSpec[0].id,
+			completionAutonomyLevel: 3,
 		});
 
 		const run = runRepo.createRun({

--- a/packages/daemon/tests/unit/5-space/workflow/workflow-run-status-lifecycle.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/workflow-run-status-lifecycle.test.ts
@@ -82,6 +82,7 @@ function createWorkflowAndRun(db: BunDatabase, spaceId: string): { runId: string
 		transitions: [],
 		startNodeId: '',
 		rules: [],
+		completionAutonomyLevel: 3,
 	});
 	const runRepo = new SpaceWorkflowRunRepository(db);
 	const run = runRepo.createRun({ spaceId, workflowId: workflow.id, title: 'Test Run' });

--- a/packages/daemon/tests/unit/helpers/space-agent-schema.ts
+++ b/packages/daemon/tests/unit/helpers/space-agent-schema.ts
@@ -65,6 +65,7 @@ export function createSpaceAgentSchema(db: Database): void {
 			template_name TEXT DEFAULT NULL,
 			template_hash TEXT DEFAULT NULL,
 			instructions TEXT DEFAULT NULL,
+			completion_autonomy_level INTEGER NOT NULL DEFAULT 3,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -73,6 +73,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			template_name TEXT DEFAULT NULL,
 			template_hash TEXT DEFAULT NULL,
 			instructions TEXT DEFAULT NULL,
+			completion_autonomy_level INTEGER NOT NULL DEFAULT 3,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
@@ -198,7 +199,10 @@ export function createSpaceTables(db: BunDatabase): void {
 			approved_at INTEGER,
 			pending_action_index INTEGER DEFAULT NULL,
 			pending_checkpoint_type TEXT DEFAULT NULL
-				CHECK(pending_checkpoint_type IN ('completion_action', 'gate')),
+				CHECK(pending_checkpoint_type IN ('completion_action', 'gate', 'task_completion')),
+			pending_completion_submitted_by_node_id TEXT DEFAULT NULL,
+			pending_completion_submitted_at INTEGER DEFAULT NULL,
+			pending_completion_reason TEXT DEFAULT NULL,
 			archived_at INTEGER,
 			created_at INTEGER NOT NULL,
 			started_at INTEGER,
@@ -208,6 +212,29 @@ export function createSpaceTables(db: BunDatabase): void {
 			FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL
 		)
 	`);
+
+	// Append-only audit log of `report_result` tool calls (Task #39). See
+	// migration 98 for the production schema — mirror here.
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS space_task_report_results (
+			id TEXT PRIMARY KEY,
+			task_id TEXT NOT NULL,
+			space_id TEXT NOT NULL,
+			workflow_node_id TEXT,
+			agent_name TEXT,
+			summary TEXT NOT NULL,
+			evidence TEXT,
+			recorded_at INTEGER NOT NULL,
+			FOREIGN KEY (task_id) REFERENCES space_tasks(id) ON DELETE CASCADE,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+		)
+	`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_task_report_results_task ON space_task_report_results(task_id, recorded_at)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_space_task_report_results_space ON space_task_report_results(space_id, recorded_at)`
+	);
 
 	db.exec(
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_space_tasks_space_task_number ON space_tasks(space_id, task_number)`

--- a/packages/e2e/tests/features/space-completion-action-approval.e2e.ts
+++ b/packages/e2e/tests/features/space-completion-action-approval.e2e.ts
@@ -121,6 +121,7 @@ async function createSpaceWithPausedTask(page: Page): Promise<PausedTaskFixture>
 				],
 				startNodeId: nodeId,
 				endNodeId: nodeId,
+				completionAutonomyLevel: 3,
 			})) as { workflow: { id: string } };
 			const workflowId = wfRes.workflow.id;
 

--- a/packages/e2e/tests/features/space-workflow-rules.e2e.ts
+++ b/packages/e2e/tests/features/space-workflow-rules.e2e.ts
@@ -314,6 +314,7 @@ test.describe('Space Workflow Rules & Navigation Integration', () => {
 						startNodeId: node.id,
 						rules: [],
 						tags: [],
+						completionAutonomyLevel: 3,
 					});
 				},
 				{ sid: spaceId, wname: deletableWorkflowName }

--- a/packages/e2e/tests/features/visual-workflow-editor.e2e.ts
+++ b/packages/e2e/tests/features/visual-workflow-editor.e2e.ts
@@ -196,6 +196,7 @@ test.describe('Visual Workflow Editor', () => {
 					rules: [],
 					tags: [],
 					layout,
+					completionAutonomyLevel: 3,
 				});
 			},
 			{ sid: spaceId, aId: agentId }
@@ -675,6 +676,7 @@ test.describe('Visual Workflow Editor', () => {
 						[step1]: { x: 100, y: 80 },
 						[step2]: { x: 450, y: 80 },
 					},
+					completionAutonomyLevel: 3,
 				});
 			},
 			{ sid: spaceId, aId: agentId, step1: s1, step2: s2, trans1: t1 }

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -282,8 +282,23 @@ export interface SpaceTask {
 	 * Type of checkpoint the task is currently paused at. Null when not paused.
 	 * - `completion_action`: paused at a node completion action
 	 * - `gate`: paused at a gate requiring human approval
+	 * - `task_completion`: paused awaiting human approval of a submit_for_approval request
 	 */
-	pendingCheckpointType: 'completion_action' | 'gate' | null;
+	pendingCheckpointType: 'completion_action' | 'gate' | 'task_completion' | null;
+	/**
+	 * Node ID of the end-node agent that called `submit_for_approval`. Set when the
+	 * task enters `review` status via that tool; cleared on approve/reject.
+	 */
+	pendingCompletionSubmittedByNodeId?: string | null;
+	/**
+	 * Timestamp (ms) when `submit_for_approval` was called. Null when not pending.
+	 */
+	pendingCompletionSubmittedAt?: number | null;
+	/**
+	 * Agent-supplied rationale passed to `submit_for_approval`. Shown to the human
+	 * in the approval banner. Null when the agent did not provide one.
+	 */
+	pendingCompletionReason?: string | null;
 	/**
 	 * Metadata for the completion action the task is currently paused at, derived from
 	 * `workflow.endNode.completionActions[pendingActionIndex]` at read time.
@@ -450,11 +465,48 @@ export interface UpdateSpaceTaskParams {
 	/** Index of the completion action awaiting approval; null to clear */
 	pendingActionIndex?: number | null;
 	/** Type of checkpoint the task is paused at; null to clear */
-	pendingCheckpointType?: 'completion_action' | 'gate' | null;
+	pendingCheckpointType?: 'completion_action' | 'gate' | 'task_completion' | null;
+	/**
+	 * Node ID of the agent that called `submit_for_approval`; null to clear.
+	 * See `SpaceTask.pendingCompletionSubmittedByNodeId`.
+	 */
+	pendingCompletionSubmittedByNodeId?: string | null;
+	/** Timestamp (ms) when `submit_for_approval` was called; null to clear. */
+	pendingCompletionSubmittedAt?: number | null;
+	/** Agent-supplied rationale for `submit_for_approval`; null to clear. */
+	pendingCompletionReason?: string | null;
 	/** Agent-reported terminal status from `report_result`; null to clear */
 	reportedStatus?: SpaceReportedStatus | null;
 	/** Agent-reported summary from `report_result`; null to clear */
 	reportedSummary?: string | null;
+}
+
+/**
+ * Append-only audit record of an end-node agent's `report_result` call.
+ *
+ * `report_result` is pure outcome reporting — each call creates a new row here
+ * rather than overwriting the previous one, so the full history is visible
+ * post-hoc. Writing to this table does NOT touch `task.reportedStatus`; that
+ * is set only by `approve_task` (agent self-close) or by the runtime after a
+ * human approves a `submit_for_approval` request.
+ */
+export interface SpaceTaskReportResult {
+	/** Unique identifier */
+	id: string;
+	/** Task this result belongs to */
+	taskId: string;
+	/** Space this task belongs to (denormalized for fast per-space queries) */
+	spaceId: string;
+	/** Workflow node ID of the reporting agent */
+	workflowNodeId: string | null;
+	/** Agent name (slot) that reported */
+	agentName: string | null;
+	/** Human-readable summary */
+	summary: string;
+	/** Structured evidence, if supplied; stored as JSON blob */
+	evidence: Record<string, unknown> | null;
+	/** Record creation timestamp (milliseconds since epoch) */
+	recordedAt: number;
 }
 
 // ============================================================================
@@ -1062,6 +1114,16 @@ export interface SpaceWorkflow {
 	/** Last update timestamp (milliseconds since epoch) */
 	updatedAt: number;
 	/**
+	 * Minimum space autonomy level at which `approve_task` (agent-self-close) is
+	 * available to end-node agents. When `space.autonomyLevel < completionAutonomyLevel`,
+	 * end-node agents only see `submit_for_approval` (human review required).
+	 *
+	 * This is the workflow's threshold for auto-closing; it is independent of the
+	 * `requiredLevel` on individual gates and completion actions, which gate their
+	 * own execution steps. Required (no default) — set explicitly per workflow.
+	 */
+	completionAutonomyLevel: SpaceAutonomyLevel;
+	/**
 	 * Name of the built-in template this workflow was created from or last synced to.
 	 * `undefined` for user-created workflows not based on any template.
 	 */
@@ -1106,6 +1168,13 @@ export interface CreateSpaceWorkflowParams {
 	tags?: string[];
 	/** Visual editor node positions: maps node ID to {x, y} canvas coordinates */
 	layout?: Record<string, { x: number; y: number }>;
+	/**
+	 * Minimum space autonomy level at which `approve_task` is offered to end-node
+	 * agents. See `SpaceWorkflow.completionAutonomyLevel`. Optional here so the
+	 * caller (builder, importer, template seeder) can omit it when the repository
+	 * layer supplies an explicit value.
+	 */
+	completionAutonomyLevel?: SpaceAutonomyLevel;
 	/**
 	 * Name of the built-in template this workflow is being created from.
 	 * When set, `templateHash` must also be provided.
@@ -1158,6 +1227,12 @@ export interface UpdateSpaceWorkflowParams {
 	tags?: string[] | null;
 	/** Visual editor node positions. Pass `null` to clear. */
 	layout?: Record<string, { x: number; y: number }> | null;
+	/**
+	 * Updates the workflow's `completionAutonomyLevel` (minimum space autonomy
+	 * level at which `approve_task` is offered on end-node agents). See
+	 * `SpaceWorkflow.completionAutonomyLevel`.
+	 */
+	completionAutonomyLevel?: SpaceAutonomyLevel;
 	/** Update template tracking (used when syncing from a template). */
 	templateName?: string | null;
 	templateHash?: string | null;
@@ -1340,6 +1415,13 @@ export interface ExportedSpaceWorkflow {
 	 * Directed messaging channels. `from`/`to` use node names. Channel `id` is stripped.
 	 */
 	channels?: ExportedWorkflowChannel[];
+	/**
+	 * Minimum autonomy level (1-5) required for end-node agents to self-close
+	 * the task via `approve_task`. Below this threshold, `approve_task` becomes
+	 * a no-op and the agent must use `submit_for_approval` to request human
+	 * review. Optional for backward compat with pre-Design-v2 exports.
+	 */
+	completionAutonomyLevel?: SpaceAutonomyLevel;
 }
 
 /**

--- a/packages/shared/tests/space-utils.test.ts
+++ b/packages/shared/tests/space-utils.test.ts
@@ -57,6 +57,7 @@ function makeWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
 		tags: [],
 		createdAt: 0,
 		updatedAt: 0,
+		completionAutonomyLevel: 3,
 		...overrides,
 	};
 }

--- a/packages/shared/tests/workflow-autonomy.test.ts
+++ b/packages/shared/tests/workflow-autonomy.test.ts
@@ -48,6 +48,7 @@ function makeWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
 		tags: [],
 		createdAt: 0,
 		updatedAt: 0,
+		completionAutonomyLevel: 3,
 		...overrides,
 	};
 }

--- a/packages/web/src/components/space/PendingTaskCompletionBanner.tsx
+++ b/packages/web/src/components/space/PendingTaskCompletionBanner.tsx
@@ -1,0 +1,193 @@
+/**
+ * PendingTaskCompletionBanner — thread-view CTA for `submit_for_approval` pauses.
+ *
+ * Renders when the task is paused at a `submit_for_approval` checkpoint — i.e.
+ * `task.pendingCheckpointType === 'task_completion'`. Provides Approve and
+ * Reject controls.
+ *
+ * - Approve → `spaceTask.approvePendingCompletion({ approved: true, reason? })`
+ *   which transitions review → done, stamps human approval metadata, clears
+ *   the pending-completion fields, and fires `space.task.updated`.
+ * - Reject  → `spaceTask.approvePendingCompletion({ approved: false, reason? })`
+ *   which transitions review → in_progress so the end-node agent can revise
+ *   its output; clears the pending-completion fields.
+ *
+ * Distinct from `PendingCompletionActionBanner` (completion-action checkpoints,
+ * `pendingCheckpointType === 'completion_action'`) which runs a configured
+ * script/instruction/mcp_call on approval.
+ */
+
+import { useCallback, useState } from 'preact/hooks';
+import type { SpaceTask } from '@neokai/shared';
+import { spaceStore } from '../../lib/space-store';
+import { ConfirmModal } from '../ui/ConfirmModal';
+
+interface PendingTaskCompletionBannerProps {
+	task: SpaceTask;
+	spaceId: string;
+}
+
+function formatPendingSince(submittedAt: number | null | undefined): string | null {
+	if (!submittedAt) return null;
+	const delta = Date.now() - submittedAt;
+	if (delta < 0) return null;
+	const seconds = Math.floor(delta / 1000);
+	if (seconds < 60) return `${seconds}s ago`;
+	const minutes = Math.floor(seconds / 60);
+	if (minutes < 60) return `${minutes}m ago`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return `${hours}h ago`;
+	const days = Math.floor(hours / 24);
+	return `${days}d ago`;
+}
+
+export function PendingTaskCompletionBanner({
+	task,
+	spaceId: _spaceId,
+}: PendingTaskCompletionBannerProps) {
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [showRejectConfirm, setShowRejectConfirm] = useState(false);
+	const [rejectReason, setRejectReason] = useState('');
+	const [approveReason, setApproveReason] = useState('');
+
+	const onApprove = useCallback(async () => {
+		setBusy(true);
+		setError(null);
+		try {
+			const reason = approveReason.trim();
+			await spaceStore.approvePendingCompletion(task.id, true, reason ? reason : null);
+			setApproveReason('');
+		} catch (err: unknown) {
+			setError(err instanceof Error ? err.message : 'Failed to approve');
+		} finally {
+			setBusy(false);
+		}
+	}, [task.id, approveReason]);
+
+	const onRejectConfirm = useCallback(async () => {
+		setBusy(true);
+		setError(null);
+		try {
+			const reason = rejectReason.trim();
+			await spaceStore.approvePendingCompletion(task.id, false, reason ? reason : null);
+			setShowRejectConfirm(false);
+			setRejectReason('');
+		} catch (err: unknown) {
+			setError(err instanceof Error ? err.message : 'Failed to reject');
+		} finally {
+			setBusy(false);
+		}
+	}, [task.id, rejectReason]);
+
+	if (task.pendingCheckpointType !== 'task_completion') return null;
+
+	const agentReason = task.pendingCompletionReason?.trim();
+	const submittedBy = task.pendingCompletionSubmittedByNodeId;
+	const submittedAgo = formatPendingSince(task.pendingCompletionSubmittedAt ?? null);
+
+	return (
+		<>
+			<div
+				class="mx-4 mt-2 mb-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 space-y-2"
+				data-testid="pending-task-completion-banner"
+			>
+				<div class="flex items-start justify-between gap-2">
+					<div class="flex-1 min-w-0">
+						<p class="text-xs font-medium text-amber-300">
+							Awaiting Human Approval — Submit for Review
+						</p>
+						<p class="mt-0.5 text-xs text-amber-400/70">
+							An end-node agent requested human sign-off
+							{submittedBy ? ` (node: ${submittedBy})` : ''}
+							{submittedAgo ? ` · ${submittedAgo}` : ''}.
+						</p>
+					</div>
+
+					<div class="flex items-center gap-1.5 flex-shrink-0">
+						<button
+							type="button"
+							onClick={() => void onApprove()}
+							disabled={busy}
+							data-testid="pending-task-completion-approve-btn"
+							class="px-2 py-1 text-xs font-medium rounded bg-green-900/40 text-green-300 border border-green-700/50 hover:bg-green-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+						>
+							Approve
+						</button>
+						<button
+							type="button"
+							onClick={() => setShowRejectConfirm(true)}
+							disabled={busy}
+							data-testid="pending-task-completion-reject-btn"
+							class="px-2 py-1 text-xs font-medium rounded bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+						>
+							Send back
+						</button>
+					</div>
+				</div>
+
+				{agentReason && (
+					<div class="text-xs" data-testid="pending-task-completion-agent-reason">
+						<p class="text-amber-400/80">Agent rationale:</p>
+						<p class="mt-0.5 p-2 bg-dark-900/60 border border-dark-700 rounded text-[11px] text-gray-300 whitespace-pre-wrap">
+							{agentReason}
+						</p>
+					</div>
+				)}
+
+				<div>
+					<label class="block text-[11px] text-gray-400 mb-1" for="approve-reason-input">
+						Approval note (optional — recorded on the task)
+					</label>
+					<textarea
+						id="approve-reason-input"
+						data-testid="pending-task-completion-approve-reason"
+						value={approveReason}
+						onInput={(e) => setApproveReason((e.target as HTMLTextAreaElement).value)}
+						class="w-full rounded border border-dark-600 bg-dark-800 px-2 py-1 text-[11px] text-gray-200 focus:border-amber-500 focus:outline-none"
+						rows={2}
+						disabled={busy}
+					/>
+				</div>
+
+				{error && (
+					<p class="text-xs text-red-400" data-testid="pending-task-completion-error">
+						{error}
+					</p>
+				)}
+			</div>
+
+			<ConfirmModal
+				isOpen={showRejectConfirm}
+				onClose={() => {
+					if (!busy) {
+						setShowRejectConfirm(false);
+						setRejectReason('');
+					}
+				}}
+				onConfirm={() => void onRejectConfirm()}
+				title="Send task back for revision?"
+				message="The task will be reopened (status: in_progress) so the end-node agent can revise and re-submit. The pending-completion request will be cleared."
+				confirmText="Send back to agent"
+				cancelText="Keep Pending"
+				confirmButtonVariant="danger"
+				isLoading={busy}
+				error={error}
+				confirmTestId="pending-task-completion-reject-confirm"
+			>
+				<label class="block text-xs text-gray-400 mb-1" for="task-completion-reject-reason-input">
+					Reason (optional — shared with the agent as feedback)
+				</label>
+				<textarea
+					id="task-completion-reject-reason-input"
+					data-testid="pending-task-completion-reject-reason"
+					value={rejectReason}
+					onInput={(e) => setRejectReason((e.target as HTMLTextAreaElement).value)}
+					class="w-full rounded border border-dark-600 bg-dark-800 px-2 py-1 text-sm text-gray-200 focus:border-red-500 focus:outline-none"
+					rows={3}
+					disabled={busy}
+				/>
+			</ConfirmModal>
+		</>
+	);
+}

--- a/packages/web/src/components/space/PendingTaskCompletionBanner.tsx
+++ b/packages/web/src/components/space/PendingTaskCompletionBanner.tsx
@@ -83,6 +83,7 @@ export function PendingTaskCompletionBanner({
 	if (task.pendingCheckpointType !== 'task_completion') return null;
 
 	const agentReason = task.pendingCompletionReason?.trim();
+	const reportedSummary = task.reportedSummary?.trim();
 	const submittedBy = task.pendingCompletionSubmittedByNodeId;
 	const submittedAgo = formatPendingSince(task.pendingCompletionSubmittedAt ?? null);
 
@@ -125,6 +126,15 @@ export function PendingTaskCompletionBanner({
 						</button>
 					</div>
 				</div>
+
+				{reportedSummary && (
+					<div class="text-xs" data-testid="pending-task-completion-reported-summary">
+						<p class="text-amber-400/80">Agent's reported outcome:</p>
+						<p class="mt-0.5 p-2 bg-dark-900/60 border border-dark-700 rounded text-[11px] text-gray-300 whitespace-pre-wrap">
+							{reportedSummary}
+						</p>
+					</div>
+				)}
 
 				{agentReason && (
 					<div class="text-xs" data-testid="pending-task-completion-agent-reason">

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -15,6 +15,7 @@ import { getTransitionActions, TaskStatusActions } from './TaskStatusActions';
 import { TaskBlockedBanner } from './TaskBlockedBanner';
 import { PendingGateBanner } from './PendingGateBanner';
 import { PendingCompletionActionBanner } from './PendingCompletionActionBanner';
+import { PendingTaskCompletionBanner } from './PendingTaskCompletionBanner';
 import { ThreadedChatComposer } from './ThreadedChatComposer';
 import { ReadOnlyWorkflowCanvas } from './ReadOnlyWorkflowCanvas';
 import { Dropdown, type DropdownMenuItem } from '../ui/Dropdown';
@@ -431,6 +432,9 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 										spaceId={runtimeSpaceId}
 										spaceAutonomyLevel={spaceStore.space.value?.autonomyLevel}
 									/>
+								)}
+								{task.pendingCheckpointType === 'task_completion' && (
+									<PendingTaskCompletionBanner task={task} spaceId={runtimeSpaceId} />
 								)}
 								{task.workflowRunId && (
 									<PendingGateBanner

--- a/packages/web/src/components/space/TaskStatusActions.tsx
+++ b/packages/web/src/components/space/TaskStatusActions.tsx
@@ -74,11 +74,13 @@ interface TaskStatusActionsProps {
 	disabled?: boolean;
 	/**
 	 * Type of checkpoint the task is paused at, if any. When set to
-	 * `completion_action`, the generic Approve/Reject transitions are hidden
-	 * and routed through `PendingCompletionActionBanner` instead — the banner
-	 * shows what would actually run on approval, which the generic button can't.
+	 * `completion_action` or `task_completion`, the generic Approve/Reject
+	 * transitions are hidden and routed through the matching banner
+	 * (`PendingCompletionActionBanner` / `PendingTaskCompletionBanner`) instead —
+	 * those banners show what the approval actually does, which the generic
+	 * buttons can't.
 	 */
-	pendingCheckpointType?: 'completion_action' | 'gate' | null;
+	pendingCheckpointType?: 'completion_action' | 'gate' | 'task_completion' | null;
 }
 
 export function TaskStatusActions({
@@ -88,12 +90,13 @@ export function TaskStatusActions({
 	pendingCheckpointType,
 }: TaskStatusActionsProps) {
 	const allActions = getTransitionActions(status);
-	// When a task is paused at a completion action, hide the generic Approve
-	// (review → done) and Cancel (review → cancelled) buttons. The banner owns
-	// those transitions so it can disclose what the approval will actually run.
-	// Non-checkpoint transitions (e.g. Reopen → in_progress, Archive) stay visible.
+	// When a task is paused at a completion action or a submit_for_approval
+	// checkpoint, hide the generic Approve (review → done) and Cancel (review →
+	// cancelled) buttons. The dedicated banner owns those transitions so it can
+	// disclose what the approval will actually run / send. Non-checkpoint
+	// transitions (e.g. Reopen → in_progress, Archive) stay visible.
 	const actions =
-		pendingCheckpointType === 'completion_action'
+		pendingCheckpointType === 'completion_action' || pendingCheckpointType === 'task_completion'
 			? allActions.filter(({ target }) => target !== 'done' && target !== 'cancelled')
 			: allActions;
 

--- a/packages/web/src/components/space/__tests__/WorkflowEditor.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowEditor.test.tsx
@@ -97,6 +97,7 @@ function makeWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
 		tags: [],
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
+		completionAutonomyLevel: 3,
 		...overrides,
 	};
 }

--- a/packages/web/src/components/space/__tests__/WorkflowList.test.tsx
+++ b/packages/web/src/components/space/__tests__/WorkflowList.test.tsx
@@ -69,6 +69,7 @@ function makeWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
 		tags: [],
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
+		completionAutonomyLevel: 3,
 		...overrides,
 	};
 }

--- a/packages/web/src/components/space/__tests__/fixtures/builtInTemplateWorkflows.ts
+++ b/packages/web/src/components/space/__tests__/fixtures/builtInTemplateWorkflows.ts
@@ -48,6 +48,7 @@ export function makeBuiltInTemplateWorkflows(
 			tags: [],
 			createdAt: 0,
 			updatedAt: 0,
+			completionAutonomyLevel: 3,
 		},
 		{
 			id: 'tpl-research',
@@ -70,6 +71,7 @@ export function makeBuiltInTemplateWorkflows(
 			tags: [],
 			createdAt: 0,
 			updatedAt: 0,
+			completionAutonomyLevel: 2,
 		},
 		{
 			id: 'tpl-review-only',
@@ -87,6 +89,7 @@ export function makeBuiltInTemplateWorkflows(
 			tags: [],
 			createdAt: 0,
 			updatedAt: 0,
+			completionAutonomyLevel: 2,
 		},
 		{
 			id: 'tpl-plan-decompose',
@@ -119,6 +122,7 @@ export function makeBuiltInTemplateWorkflows(
 			tags: ['planning', 'decomposition'],
 			createdAt: 0,
 			updatedAt: 0,
+			completionAutonomyLevel: 3,
 			channels: [
 				{
 					from: 'Planning',
@@ -195,6 +199,7 @@ export function makeBuiltInTemplateWorkflows(
 			tags: [],
 			createdAt: 0,
 			updatedAt: 0,
+			completionAutonomyLevel: 4,
 			channels: [
 				{
 					from: 'Coding',

--- a/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
@@ -147,6 +147,7 @@ function makeWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
 		tags: [],
 		createdAt: 0,
 		updatedAt: 0,
+		completionAutonomyLevel: 3,
 		...overrides,
 	};
 }

--- a/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.transitionGuard.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.transitionGuard.test.tsx
@@ -83,6 +83,7 @@ function makeWorkflow(): SpaceWorkflow {
 		tags: [],
 		createdAt: 0,
 		updatedAt: 0,
+		completionAutonomyLevel: 3,
 	};
 }
 

--- a/packages/web/src/components/space/visual-editor/__tests__/performance.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/performance.test.tsx
@@ -107,6 +107,7 @@ function buildLargeWorkflow(): SpaceWorkflow {
 		tags: [],
 		createdAt: 0,
 		updatedAt: 0,
+		completionAutonomyLevel: 3,
 	};
 }
 

--- a/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
+++ b/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
@@ -52,6 +52,7 @@ function makeWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
 		tags: [],
 		createdAt: 0,
 		updatedAt: 0,
+		completionAutonomyLevel: 3,
 		...overrides,
 	};
 }

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -120,6 +120,7 @@ function makeWorkflow(id: string): SpaceWorkflow {
 		tags: [],
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
+		completionAutonomyLevel: 3,
 	};
 }
 

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -1696,6 +1696,32 @@ class SpaceStore {
 	}
 
 	/**
+	 * Approve or reject a task awaiting human sign-off at a `submit_for_approval`
+	 * checkpoint (`pendingCheckpointType === 'task_completion'`). Routes to the
+	 * `spaceTask.approvePendingCompletion` RPC which handles status transition,
+	 * pending-field cleanup, and reason capture atomically.
+	 */
+	async approvePendingCompletion(
+		taskId: string,
+		approved: boolean,
+		reason?: string | null
+	): Promise<SpaceTask> {
+		const spaceId = this.spaceId.value;
+		if (!spaceId) throw new Error('No space selected');
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		const task = await hub.request<SpaceTask>('spaceTask.approvePendingCompletion', {
+			taskId,
+			spaceId,
+			approved,
+			reason: reason ?? null,
+		});
+		return task;
+	}
+
+	/**
 	 * Ensure a Task Agent session exists for a task and return latest task state.
 	 */
 	async ensureTaskAgentSession(taskId: string): Promise<SpaceTask> {


### PR DESCRIPTION
The coder/reviewer cycle workflow (Coding → Review → Coding …) closed the instant the Reviewer posted feedback because `report_result` was a terminal tool that set `reportedStatus='done'`. Any end-node call — including a routine "here's what I saw" from the Reviewer — slammed the task into the completion-action pipeline.

Design v2 splits the one overloaded tool into three distinct intents:

- `report_result` — append-only audit. Writes one row per call to the new `space_task_report_results` table. Never mutates task state, never emits `space.task.done`. Safe to call repeatedly across review cycles.
- `approve_task` — end-node self-close. Conditionally registered only when `space.autonomyLevel >= workflow.completionAutonomyLevel`. Handler re-checks the gate as defense-in-depth.
- `submit_for_approval` — always available on end nodes. Moves the task to `status='review'` with `pendingCheckpointType='task_completion'`. Humans resolve via the new `spaceTask.approvePendingCompletion` RPC.

Migration 98 adds `space_workflows.completion_autonomy_level` (with per-template backfill), three `pending_completion_*` columns on `space_tasks`, and the `space_task_report_results` audit table. Export/import round-trips the new autonomy level with a default of 3 for older bundles.

## Test plan
- [x] `./scripts/test-daemon.sh` — 11,255 tests pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] New tests: migration-98, report-result repo, workflow completion-autonomy, task-agent report/approve/submit contract