### PR TITLE
fix(migration): M86 early-return skips pending_checkpoint_type on pre-migrated DBs

### DIFF
--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -44,6 +44,8 @@ export { runMigration74 } from './migrations';
 // knip-ignore-next-line
 export { runMigration78 } from './migrations';
 // knip-ignore-next-line
+export { runMigration86 } from './migrations';
+// knip-ignore-next-line
 export { runMigration93 } from './migrations';
 // knip-ignore-next-line
 export { runMigration94 } from './migrations';

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -5941,94 +5941,104 @@ function runMigration85(db: BunDatabase): void {
  * 2. Add `pending_action_index` and `pending_checkpoint_type` to `space_tasks`.
  * 3. Migrate `approval_source` values: collapse agent sub-types → 'agent',
  *    'semi_auto' → 'auto_policy'.
+ *
+ * IMPORTANT — idempotency design:
+ * Parts 1 (spaces rebuild) and 2+3 (space_tasks columns) are checked independently.
+ * An older version of this migration only did Part 1; databases upgraded from that
+ * version already have INTEGER autonomy_level but may be missing pending_checkpoint_type.
+ * Using a single early-return on the spaces check would silently skip Parts 2+3 for
+ * those databases. Instead: skip Part 1 if already done, but always run Parts 2+3.
  */
-function runMigration86(db: BunDatabase): void {
+export function runMigration86(db: BunDatabase): void {
 	if (!tableExists(db, 'spaces')) return;
 
-	// Check if already migrated: try reading autonomy_level as integer
+	// ── Part 1: Rebuild spaces with numeric autonomy_level (if still needed) ──
+	let spacesAlreadyNumeric = false;
 	try {
 		const row = db.prepare(`SELECT typeof(autonomy_level) as t FROM spaces LIMIT 1`).get() as
 			| { t: string }
 			| undefined;
-		if (row && row.t === 'integer') return; // already numeric
+		if (row && row.t === 'integer') spacesAlreadyNumeric = true;
 	} catch {
-		// table might be empty, proceed with migration
+		// Column might not exist yet — proceed with full spaces rebuild.
 	}
 
-	db.exec('PRAGMA foreign_keys = OFF');
-	db.exec('BEGIN');
-	try {
-		// ── 1. Rebuild spaces with numeric autonomy_level ──
-		db.exec(`
-			CREATE TABLE spaces_m86_new (
-				id TEXT PRIMARY KEY,
-				slug TEXT NOT NULL,
-				workspace_path TEXT NOT NULL UNIQUE,
-				name TEXT NOT NULL,
-				description TEXT NOT NULL DEFAULT '',
-				background_context TEXT NOT NULL DEFAULT '',
-				instructions TEXT NOT NULL DEFAULT '',
-				default_model TEXT,
-				allowed_models TEXT NOT NULL DEFAULT '[]',
-				session_ids TEXT NOT NULL DEFAULT '[]',
-				status TEXT NOT NULL DEFAULT 'active'
-					CHECK(status IN ('active', 'archived')),
-				autonomy_level INTEGER NOT NULL DEFAULT 1
-					CHECK(autonomy_level BETWEEN 1 AND 5),
-				config TEXT,
-				paused INTEGER NOT NULL DEFAULT 0,
-				created_at INTEGER NOT NULL,
-				updated_at INTEGER NOT NULL
-			)
-		`);
-		db.exec(`
-			INSERT INTO spaces_m86_new (id, slug, workspace_path, name, description,
-				background_context, instructions, default_model, allowed_models,
-				session_ids, status, autonomy_level, config, paused, created_at, updated_at)
-			SELECT id, slug, workspace_path, name, description,
-				background_context, instructions, default_model, allowed_models,
-				session_ids, status,
-				CASE autonomy_level
-					WHEN 'semi_autonomous' THEN 3
-					ELSE 1
-				END,
-				config, paused, created_at, updated_at
-			FROM spaces
-		`);
-		db.exec(`DROP TABLE spaces`);
-		db.exec(`ALTER TABLE spaces_m86_new RENAME TO spaces`);
-		db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_spaces_slug ON spaces(slug)`);
-		db.exec(`CREATE INDEX IF NOT EXISTS idx_spaces_status ON spaces(status)`);
-
-		// ── 2. Add pending checkpoint columns to space_tasks ──
-		if (tableExists(db, 'space_tasks')) {
-			if (!tableHasColumn(db, 'space_tasks', 'pending_action_index')) {
-				db.exec(`ALTER TABLE space_tasks ADD COLUMN pending_action_index INTEGER DEFAULT NULL`);
-			}
-			if (!tableHasColumn(db, 'space_tasks', 'pending_checkpoint_type')) {
-				db.exec(
-					`ALTER TABLE space_tasks ADD COLUMN pending_checkpoint_type TEXT DEFAULT NULL` +
-						` CHECK(pending_checkpoint_type IN ('completion_action', 'gate'))`
-				);
-			}
-
-			// ── 3. Migrate approval_source values ──
+	if (!spacesAlreadyNumeric) {
+		db.exec('PRAGMA foreign_keys = OFF');
+		db.exec('BEGIN');
+		try {
 			db.exec(`
-				UPDATE space_tasks SET approval_source = 'agent'
-				WHERE approval_source IN ('neo_agent', 'space_agent', 'task_agent', 'node_agent')
+				CREATE TABLE spaces_m86_new (
+					id TEXT PRIMARY KEY,
+					slug TEXT NOT NULL,
+					workspace_path TEXT NOT NULL UNIQUE,
+					name TEXT NOT NULL,
+					description TEXT NOT NULL DEFAULT '',
+					background_context TEXT NOT NULL DEFAULT '',
+					instructions TEXT NOT NULL DEFAULT '',
+					default_model TEXT,
+					allowed_models TEXT NOT NULL DEFAULT '[]',
+					session_ids TEXT NOT NULL DEFAULT '[]',
+					status TEXT NOT NULL DEFAULT 'active'
+						CHECK(status IN ('active', 'archived')),
+					autonomy_level INTEGER NOT NULL DEFAULT 1
+						CHECK(autonomy_level BETWEEN 1 AND 5),
+					config TEXT,
+					paused INTEGER NOT NULL DEFAULT 0,
+					created_at INTEGER NOT NULL,
+					updated_at INTEGER NOT NULL
+				)
 			`);
 			db.exec(`
-				UPDATE space_tasks SET approval_source = 'auto_policy'
-				WHERE approval_source = 'semi_auto'
+				INSERT INTO spaces_m86_new (id, slug, workspace_path, name, description,
+					background_context, instructions, default_model, allowed_models,
+					session_ids, status, autonomy_level, config, paused, created_at, updated_at)
+				SELECT id, slug, workspace_path, name, description,
+					background_context, instructions, default_model, allowed_models,
+					session_ids, status,
+					CASE autonomy_level
+						WHEN 'semi_autonomous' THEN 3
+						ELSE 1
+					END,
+					config, paused, created_at, updated_at
+				FROM spaces
 			`);
+			db.exec(`DROP TABLE spaces`);
+			db.exec(`ALTER TABLE spaces_m86_new RENAME TO spaces`);
+			db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_spaces_slug ON spaces(slug)`);
+			db.exec(`CREATE INDEX IF NOT EXISTS idx_spaces_status ON spaces(status)`);
+			db.exec('COMMIT');
+		} catch (err) {
+			db.exec('ROLLBACK');
+			throw err;
+		} finally {
+			db.exec('PRAGMA foreign_keys = ON');
+		}
+	}
+
+	// ── Parts 2+3: space_tasks columns and approval_source migration ──
+	// These run unconditionally (each guarded by its own tableHasColumn check) so
+	// that databases where Part 1 already ran but Parts 2+3 did not are caught up.
+	if (tableExists(db, 'space_tasks')) {
+		if (!tableHasColumn(db, 'space_tasks', 'pending_action_index')) {
+			db.exec(`ALTER TABLE space_tasks ADD COLUMN pending_action_index INTEGER DEFAULT NULL`);
+		}
+		if (!tableHasColumn(db, 'space_tasks', 'pending_checkpoint_type')) {
+			db.exec(
+				`ALTER TABLE space_tasks ADD COLUMN pending_checkpoint_type TEXT DEFAULT NULL` +
+					` CHECK(pending_checkpoint_type IN ('completion_action', 'gate'))`
+			);
 		}
 
-		db.exec('COMMIT');
-	} catch (err) {
-		db.exec('ROLLBACK');
-		throw err;
-	} finally {
-		db.exec('PRAGMA foreign_keys = ON');
+		// ── 3. Migrate approval_source values ──
+		db.exec(`
+			UPDATE space_tasks SET approval_source = 'agent'
+			WHERE approval_source IN ('neo_agent', 'space_agent', 'task_agent', 'node_agent')
+		`);
+		db.exec(`
+			UPDATE space_tasks SET approval_source = 'auto_policy'
+			WHERE approval_source = 'semi_auto'
+		`);
 	}
 }
 

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-spaces-autonomy-level_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-spaces-autonomy-level_test.ts
@@ -14,7 +14,7 @@ import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { rmSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
-import { runMigrations } from '../../../../../src/storage/schema/index.ts';
+import { runMigrations, runMigration86 } from '../../../../../src/storage/schema/index.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -359,5 +359,162 @@ describe('Migration 33: Add autonomy_level to spaces', () => {
 
 		const rows = db.prepare(`SELECT id FROM spaces`).all();
 		expect(rows).toHaveLength(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Regression: M86 partial-migration — spaces already numeric, tasks missing column
+// ---------------------------------------------------------------------------
+// This tests the specific bug where an older version of migration 86 only rebuilt
+// the `spaces` table (converting autonomy_level TEXT → INTEGER) but did NOT yet add
+// `pending_checkpoint_type` to `space_tasks`. On subsequent daemon startups the
+// early-return check (`autonomy_level` is already integer) would fire and skip the
+// column addition, leaving `space_tasks` without `pending_checkpoint_type`.
+// After the fix, Parts 2+3 of M86 run unconditionally so the column is always added.
+
+describe('Migration 86 regression: partial migration (spaces numeric, tasks column missing)', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(
+			process.cwd(),
+			'tmp',
+			'test-migration-86-regression',
+			`test-${Date.now()}-${Math.random()}`
+		);
+		mkdirSync(testDir, { recursive: true });
+		db = new BunDatabase(join(testDir, 'test.db'));
+		db.exec('PRAGMA foreign_keys = ON');
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	test('adds pending_checkpoint_type when spaces.autonomy_level is already INTEGER but column is missing', () => {
+		// Simulate a database that was partially upgraded by an old version of M86:
+		// `spaces.autonomy_level` is already INTEGER (Part 1 done) but
+		// `space_tasks.pending_checkpoint_type` was never added (Parts 2+3 not done).
+		db.exec(`
+			CREATE TABLE spaces (
+				id TEXT PRIMARY KEY,
+				slug TEXT NOT NULL,
+				workspace_path TEXT NOT NULL UNIQUE,
+				name TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				background_context TEXT NOT NULL DEFAULT '',
+				instructions TEXT NOT NULL DEFAULT '',
+				default_model TEXT,
+				allowed_models TEXT NOT NULL DEFAULT '[]',
+				session_ids TEXT NOT NULL DEFAULT '[]',
+				status TEXT NOT NULL DEFAULT 'active'
+					CHECK(status IN ('active', 'archived')),
+				autonomy_level INTEGER NOT NULL DEFAULT 1
+					CHECK(autonomy_level BETWEEN 1 AND 5),
+				config TEXT,
+				paused INTEGER NOT NULL DEFAULT 0,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+		db.exec(`CREATE UNIQUE INDEX idx_spaces_slug ON spaces(slug)`);
+
+		db.exec(`
+			CREATE TABLE space_tasks (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				task_number INTEGER NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				status TEXT NOT NULL DEFAULT 'open',
+				priority TEXT NOT NULL DEFAULT 'normal',
+				labels TEXT NOT NULL DEFAULT '[]',
+				depends_on TEXT NOT NULL DEFAULT '[]',
+				approval_source TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+
+		// Seed a space so the `typeof(autonomy_level)` check returns 'integer',
+		// which is the exact condition that triggered the premature early-return.
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?)`
+		).run('sp-1', 'sp-1', '/ws/1', 'Space 1', now, now);
+
+		// Before the fix: runMigration86 would early-return here and skip the column.
+		runMigration86(db);
+
+		expect(columnExists(db, 'space_tasks', 'pending_checkpoint_type')).toBe(true);
+		expect(columnExists(db, 'space_tasks', 'pending_action_index')).toBe(true);
+	});
+
+	test('pending_checkpoint_type column is writable after M86 fixes it up', () => {
+		// Same partial-migration setup as above.
+		db.exec(`
+			CREATE TABLE spaces (
+				id TEXT PRIMARY KEY,
+				slug TEXT NOT NULL,
+				workspace_path TEXT NOT NULL UNIQUE,
+				name TEXT NOT NULL,
+				autonomy_level INTEGER NOT NULL DEFAULT 1
+					CHECK(autonomy_level BETWEEN 1 AND 5),
+				paused INTEGER NOT NULL DEFAULT 0,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+		db.exec(`
+			CREATE TABLE space_tasks (
+				id TEXT PRIMARY KEY,
+				space_id TEXT NOT NULL,
+				task_number INTEGER NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT NOT NULL DEFAULT '',
+				status TEXT NOT NULL DEFAULT 'open',
+				priority TEXT NOT NULL DEFAULT 'normal',
+				labels TEXT NOT NULL DEFAULT '[]',
+				depends_on TEXT NOT NULL DEFAULT '[]',
+				approval_source TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			)
+		`);
+
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?)`
+		).run('sp-2', 'sp-2', '/ws/2', 'Space 2', now, now);
+		db.prepare(
+			`INSERT INTO space_tasks (id, space_id, task_number, title, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?)`
+		).run('t-1', 'sp-2', 1, 'Test Task', now, now);
+
+		runMigration86(db);
+
+		// Verify the column can be written — the root production error was
+		// "no such column: pending_checkpoint_type" on an UPDATE that set this field.
+		// M86's CHECK constraint allows 'gate'; 'task_completion' is widened by M98.
+		expect(() => {
+			db.prepare(`UPDATE space_tasks SET pending_checkpoint_type = 'gate' WHERE id = ?`).run('t-1');
+		}).not.toThrow();
+
+		const row = db
+			.prepare(`SELECT pending_checkpoint_type FROM space_tasks WHERE id = ?`)
+			.get('t-1') as { pending_checkpoint_type: string } | undefined;
+		expect(row?.pending_checkpoint_type).toBe('gate');
 	});
 });


### PR DESCRIPTION
## Problem

`submit_for_approval` returned `{"success":false,"error":"no such column: pending_checkpoint_type"}` because `space_tasks` was missing the column added by migration 86.

## Root cause

Migration 86 has two responsibilities:
1. **Part 1** — rebuild `spaces` table, converting `autonomy_level` TEXT → INTEGER
2. **Parts 2+3** — add `pending_action_index` / `pending_checkpoint_type` to `space_tasks`; migrate `approval_source` values

The idempotency check was a single early-return:
```ts
if (row && row.t === 'integer') return; // already numeric
```

This fired whenever `spaces.autonomy_level` was already INTEGER — but that also skipped Parts 2+3. Users whose databases were upgraded by an **older version** of M86 (one that only did Part 1) had INTEGER `autonomy_level` but never got `pending_checkpoint_type` in `space_tasks`. Every subsequent daemon startup hit the early-return and silently skipped the column addition.

## Fix

Separate the checks: Part 1 is conditional on `autonomy_level` being TEXT; Parts 2+3 always run, each guarded by its own `tableHasColumn` check. This catches up any database that was partially migrated by an older code version.

Also exports `runMigration86` for direct testing.

## Tests

Two new regression tests in `migration-spaces-autonomy-level_test.ts`:
- Verifies `pending_checkpoint_type` is added when `spaces.autonomy_level` is already INTEGER but the column is missing
- Verifies the column is writable after the fix (simulating the production error path)