### PR TITLE
fix(space): @mention routing includes idle agents; fix error badge overlap

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
@@ -159,10 +159,11 @@ export function setupSpaceTaskMessageHandlers(
 			taskAgentManager.injectSubSessionMessage
 		) {
 			const executions = nodeExecutionRepo.listByWorkflowRun(task.workflowRunId);
-			// Only route to agents that are actively running — exclude done/cancelled/blocked
-			// to avoid injecting into sessions that will never process the message.
+			// Exclude only cancelled agents — they are truly terminal and will never process
+			// messages. Idle agents (waiting for input), blocked agents (waiting on dependencies),
+			// and pending agents are all reachable and should receive @mention messages.
 			const activeAgents = executions.filter(
-				(e) => e.agentSessionId !== null && (e.status === 'in_progress' || e.status === 'pending')
+				(e) => e.agentSessionId !== null && e.status !== 'cancelled'
 			);
 
 			const routedTo: string[] = [];

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-message-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-message-handlers.test.ts
@@ -798,10 +798,33 @@ describe('setupSpaceTaskMessageHandlers', () => {
 			expect(taskAgentManager.injectTaskAgentMessage).toHaveBeenCalled();
 		});
 
-		it('does not route to done/cancelled/blocked agents — excludes completed sessions', async () => {
+		it('routes @mention to idle agents — core fix for the reported bug', async () => {
+			// Idle agents (waiting for input) should receive @mention messages.
+			// Previously this was broken: only 'in_progress' and 'pending' passed the filter,
+			// so @Reviewer returned "Available agents: none" when the agent was idle.
 			const { injectSubSession } = setupWithMention([
-				{ agentName: 'Coder', agentSessionId: 'session-coder-done', status: 'done' },
+				{ agentName: 'Reviewer', agentSessionId: 'session-reviewer-idle', status: 'idle' },
+			]);
+
+			const result = await call('space.task.sendMessage', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				message: '@Reviewer please review',
+			});
+
+			expect(result).toMatchObject({ ok: true, routedTo: ['Reviewer'] });
+			expect(injectSubSession).toHaveBeenCalledWith(
+				'session-reviewer-idle',
+				'@Reviewer please review'
+			);
+		});
+
+		it('only excludes cancelled agents — idle, blocked, and pending are all routable', async () => {
+			// Only 'cancelled' is truly terminal. All other statuses (idle, blocked, pending,
+			// in_progress) can still receive and process messages.
+			const { injectSubSession } = setupWithMention([
 				{ agentName: 'Coder', agentSessionId: 'session-coder-cancelled', status: 'cancelled' },
+				{ agentName: 'Coder', agentSessionId: 'session-coder-idle', status: 'idle' },
 				{ agentName: 'Coder', agentSessionId: 'session-coder-blocked', status: 'blocked' },
 				{ agentName: 'Coder', agentSessionId: 'session-coder-active', status: 'in_progress' },
 			]);
@@ -812,19 +835,24 @@ describe('setupSpaceTaskMessageHandlers', () => {
 				message: '@Coder please check',
 			});
 
-			// Only the in_progress session should receive the message
+			// All non-cancelled sessions should receive the message
 			expect(result).toMatchObject({ ok: true, routedTo: ['Coder'] });
-			expect(injectSubSession).toHaveBeenCalledTimes(1);
+			expect(injectSubSession).toHaveBeenCalledTimes(3); // idle + blocked + in_progress
+			expect(injectSubSession).not.toHaveBeenCalledWith(
+				'session-coder-cancelled',
+				expect.anything()
+			);
+			expect(injectSubSession).toHaveBeenCalledWith('session-coder-idle', '@Coder please check');
+			expect(injectSubSession).toHaveBeenCalledWith('session-coder-blocked', '@Coder please check');
 			expect(injectSubSession).toHaveBeenCalledWith('session-coder-active', '@Coder please check');
-			expect(injectSubSession).not.toHaveBeenCalledWith('session-coder-done', expect.anything());
 		});
 
-		it('@mention throws when all matching agents are in terminal status', async () => {
+		it('@mention throws when all matching agents are cancelled', async () => {
 			setupWithMention([
-				{ agentName: 'Coder', agentSessionId: 'session-coder-done', status: 'done' },
+				{ agentName: 'Coder', agentSessionId: 'session-coder-cancelled', status: 'cancelled' },
 			]);
 
-			// Coder exists but is done — should be treated as unavailable
+			// Coder exists but is cancelled — should be treated as unavailable
 			await expect(
 				call('space.task.sendMessage', {
 					spaceId: 'space-1',

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -449,7 +449,9 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 							{hasUnifiedWorkflowThread ? (
 								<SpaceTaskUnifiedThread
 									taskId={task.id}
-									bottomInsetClass={showInlineComposer ? 'pb-16' : 'pb-3'}
+									bottomInsetClass={
+										showInlineComposer ? (threadSendError ? 'pb-24' : 'pb-16') : 'pb-3'
+									}
 									isAgentActive={isAgentActive}
 								/>
 							) : (


### PR DESCRIPTION
When a user tries to @mention an idle agent (e.g. `@Reviewer` while the Reviewer is waiting for input), they got `@mention not found: Reviewer. Available agents: none`.

**Root cause:** The filter in `space.task.sendMessage` used an allowlist `(status === 'in_progress' || status === 'pending')`, excluding `idle` agents — which is incorrect because idle agents are fully active and can process messages.

**Changes:**
- `space-task-message-handlers.ts`: Change filter to denylist `status !== 'cancelled'`. Only cancelled agents are truly terminal; idle, blocked, and pending agents all remain reachable.
- `SpaceTaskPane.tsx`: Expand `bottomInsetClass` from `pb-16` to `pb-24` when a send error is displayed, preventing the error badge from overlapping thread content.
- Tests: Replace the imprecise `done/cancelled/blocked` exclusion test with targeted tests that verify idle agents route correctly and only cancelled is excluded.