### PR TITLE
feat(space): remove edit/write tools from Space chat agent

### DIFF
--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -287,6 +287,66 @@ export class QueryOptionsBuilder {
 			queryOptions.settingSources = [];
 		}
 
+		// ============ Space Chat Session Restrictions ============
+		// Space chat sessions are read-only coordinators — they can read files and run
+		// diagnostics but must not create or modify files.  File editing tools
+		// (Write/Edit/NotebookEdit) are excluded; the agent uses its space-agent-tools
+		// MCP server for all coordination operations.
+		if (this.ctx.session.type === 'space_chat') {
+			const spaceAllowedBuiltinTools = [
+				'Read',
+				'Glob',
+				'Grep',
+				'Bash',
+				'WebFetch',
+				'WebSearch',
+				'ToolSearch',
+				'AskUserQuestion',
+			];
+			const spaceRestrictedBuiltinTools = [
+				'Task',
+				'TaskOutput',
+				'TaskStop',
+				'Edit',
+				'Write',
+				'NotebookEdit',
+			];
+
+			// Space chat must not use Claude Code preset prompt.
+			const systemPrompt = queryOptions.systemPrompt;
+			if (
+				typeof systemPrompt === 'object' &&
+				systemPrompt !== null &&
+				(systemPrompt as ClaudeCodePreset).type === 'preset' &&
+				(systemPrompt as ClaudeCodePreset).preset === 'claude_code'
+			) {
+				queryOptions.systemPrompt = undefined;
+			}
+
+			// Restrict space chat to coordinator-appropriate built-in tool set.
+			queryOptions.tools = spaceAllowedBuiltinTools;
+
+			// Auto-allow all explicitly configured MCP server tools (space-agent-tools + db-query).
+			const mcpServerWildcards = Object.keys(queryOptions.mcpServers ?? {}).map(
+				(name) => `${name}__*`
+			);
+			queryOptions.allowedTools = [
+				...new Set([
+					...(queryOptions.allowedTools ?? []),
+					...spaceAllowedBuiltinTools,
+					...mcpServerWildcards,
+				]),
+			];
+
+			queryOptions.disallowedTools = [
+				...new Set([...(queryOptions.disallowedTools ?? []), ...spaceRestrictedBuiltinTools]),
+			];
+			// Prevent user-configured MCP servers from being merged in (only runtime-injected servers allowed).
+			queryOptions.strictMcpConfig = true;
+			// Skip settings file loading so user's settings.json doesn't inject extra tools.
+			queryOptions.settingSources = [];
+		}
+
 		// ============ Coordinator Mode ============
 		// When coordinator mode is enabled, apply the coordinator agent to the main thread
 		// and merge specialist agents with any user-defined agents

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -439,6 +439,95 @@ describe('QueryOptionsBuilder', () => {
 		});
 	});
 
+	describe('space chat session restrictions', () => {
+		it('should preserve space MCP servers while enforcing strict MCP config', async () => {
+			mockSession.type = 'space_chat';
+			mockSession.config.mcpServers = {
+				'space-agent-tools': { command: 'space-cmd' },
+			};
+
+			const options = await builder.build();
+			expect(options.mcpServers).toEqual({
+				'space-agent-tools': { command: 'space-cmd' },
+			});
+			expect(options.strictMcpConfig).toBe(true);
+			expect(options.settingSources).toEqual([]);
+		});
+
+		it('should enforce space built-in tool allowlist including Bash', async () => {
+			mockSession.type = 'space_chat';
+			const options = await builder.build();
+			expect(options.tools).toEqual([
+				'Read',
+				'Glob',
+				'Grep',
+				'Bash',
+				'WebFetch',
+				'WebSearch',
+				'ToolSearch',
+				'AskUserQuestion',
+			]);
+			expect(options.allowedTools).toEqual(
+				expect.arrayContaining([
+					'Read',
+					'Glob',
+					'Grep',
+					'Bash',
+					'WebFetch',
+					'WebSearch',
+					'ToolSearch',
+					'AskUserQuestion',
+				])
+			);
+		});
+
+		it('should not include Write/Edit/NotebookEdit in space chat tool allowlist', async () => {
+			mockSession.type = 'space_chat';
+			const options = await builder.build();
+			expect(options.disallowedTools).toEqual(
+				expect.arrayContaining(['Edit', 'Write', 'NotebookEdit'])
+			);
+			expect(options.tools).not.toContain('Edit');
+			expect(options.tools).not.toContain('Write');
+			expect(options.tools).not.toContain('NotebookEdit');
+		});
+
+		it('should auto-allow wildcards for all configured space MCP servers', async () => {
+			mockSession.type = 'space_chat';
+			mockSession.config.mcpServers = {
+				'space-agent-tools': { command: 'space-cmd' },
+				'db-query': { command: 'db-cmd' },
+			};
+
+			const options = await builder.build();
+			expect(options.allowedTools).toEqual(
+				expect.arrayContaining(['space-agent-tools__*', 'db-query__*'])
+			);
+		});
+
+		it('should disable Claude Code preset system prompt for space chat sessions', async () => {
+			mockSession.type = 'space_chat';
+			const options = await builder.build();
+			expect(options.systemPrompt).toBeUndefined();
+		});
+
+		it('should preserve a custom string system prompt for space chat sessions', async () => {
+			mockSession.type = 'space_chat';
+			mockSession.config.systemPrompt = 'You are the Space coordinator.';
+			const options = await builder.build();
+			expect(options.systemPrompt).toBe('You are the Space coordinator.');
+		});
+
+		it('should not affect worker sessions (coder/reviewer tool access unchanged)', async () => {
+			// Worker sessions (type: 'worker') must not be affected by space_chat restrictions
+			mockSession.type = 'worker';
+			const options = await builder.build();
+			// Worker sessions use the default claude_code preset — no restrictions imposed
+			expect(options.strictMcpConfig).toBeUndefined();
+			expect(options.tools).toBeUndefined();
+		});
+	});
+
 	describe('additional directories configuration', () => {
 		it('should allow temp directories for shell operations when worktree exists', async () => {
 			mockSession.worktree = {


### PR DESCRIPTION
Space chat sessions (`space_chat`) are read-only coordinators — they should not be able to create or modify files.

Mirrors the existing `room_chat` restriction pattern in `QueryOptionsBuilder.build()`:
- Allowed built-in tools: `Read`, `Glob`, `Grep`, `Bash`, `WebFetch`, `WebSearch`, `ToolSearch`, `AskUserQuestion`
- Disallowed: `Edit`, `Write`, `NotebookEdit`, `Task`, `TaskOutput`, `TaskStop`
- `strictMcpConfig: true` (only runtime-injected MCP servers: `space-agent-tools`, `db-query`)
- `settingSources: []` (user settings.json cannot inject extra tools)

Worker sessions (coder/reviewer node agents) are unaffected.

7 new tests added covering the restriction behavior.