### PR TITLE
ci: fix workflow table to show web tests run on PR/push to dev

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,8 @@
 #
 # | Trigger                              | Tests Run                                                    | Rationale                               |
 # |--------------------------------------|--------------------------------------------------------------|-----------------------------------------|
-# | PR to dev                            | check + unit + online                                        | Fast feedback for PRs                   |
-# | Push to dev                          | check + unit + online                                        | Same checks as PR for merge safety     |
+# | PR to dev                            | check + unit + online + web                                  | Fast feedback for PRs                   |
+# | Push to dev                          | check + unit + online + web                                  | Same checks as PR for merge safety      |
 # | PR to main                           | check + unit + online + web + CLI + build (no E2E)           | Full gate for main (E2E is manual)      |
 # | Push to main                         | check + unit + online + web + CLI + build (no E2E)           | Full gate for main (E2E is manual)      |
 # | workflow_dispatch (default)          | all tests including E2E                                      | Manual full run including E2E           |


### PR DESCRIPTION
Corrects the top-level trigger table in `main.yml` to include `web` for the PR-to-dev and push-to-dev rows.

The `test-web` job condition explicitly covers both of those triggers, but the table previously listed only `check + unit + online`, making it misleading to readers.

No behaviour change — purely a comment accuracy fix.