### PR TITLE
feat(space): Plan & Decompose workflow generates stacked PR task chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ A focused release hardening the Space Workflow System for production use — aut
 ### Added
 
 #### Space Workflow System
+- **Stacked PR task chain**: Plan & Decompose Task Dispatcher embeds branch name, base branch, and dependency ordering instructions in each task description so downstream coders automatically produce a reviewable PR chain bottom-up from `dev`
 - **Completion actions pipeline**: `script`, `instruction`, and `mcp_call` completion actions with audit trail, approval reason tracking, pause/resume flow, and `task_awaiting_approval` events
 - **Autonomy-gated approvals**: Supervisor/semi-autonomous enforcement for workflow gates; "X of Y workflows autonomous" selector in SpaceSettings and SpaceOverview
 - **Runtime controls**: Pause/resume lifecycle; Stop/Start runtime on overview page

--- a/packages/daemon/src/lib/space/agents/space-chat-agent.ts
+++ b/packages/daemon/src/lib/space/agents/space-chat-agent.ts
@@ -156,10 +156,14 @@ export function buildSpaceChatSystemPrompt(context: SpaceChatAgentContext = {}):
 			`the change spans multiple services or needs heavier verification than unit tests.\n` +
 			`  - **Plan & Decompose Workflow** — NOT a coding workflow. Produces a plan PR, has ` +
 			`four reviewers (architecture, security, correctness, UX) approve it, then fans the ` +
-			`plan out into individual follow-up tasks via \`create_standalone_task\`. Pick this when ` +
+			`plan out into individual follow-up tasks via \`create_standalone_task\`. Each task ` +
+			`description includes stacked PR instructions (branch name, base branch, dependency ` +
+			`ordering) so downstream coders automatically produce a reviewable PR chain — each PR ` +
+			`targets the branch of the item below it, building bottom-up from dev. Pick this when ` +
 			`the user goal is too broad for one PR — e.g. "build feature X", "migrate system Y", ` +
-			`"overhaul area Z" — and needs to be broken into smaller tasks before any coding starts. ` +
-			`The output is a set of tasks, not a merged change.\n` +
+			`"overhaul area Z" — and needs to be broken into smaller tasks before any coding ` +
+			`starts. The output is a set of dependency-ordered tasks that produce a stacked PR ` +
+			`chain when executed, not a merged change.\n` +
 			`  - **Research Workflow** — read-only investigation that produces a research document PR. ` +
 			`Pick this when the user wants findings or a recommendation, not a code change.\n` +
 			`  - **Review-Only Workflow** — single reviewer against an existing PR or codebase. ` +

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -311,7 +311,9 @@ const PD_PLAN_REVIEW_PROMPT =
 const PD_TASK_DISPATCHER_PROMPT =
 	'You are the Task Dispatcher in a Plan & Decompose Workflow. You are the end node. ' +
 	'All four Plan Reviewers have approved the plan — your job is to fan the plan out into ' +
-	'standalone follow-up tasks using the `create_standalone_task` MCP tool.\n\n' +
+	'standalone follow-up tasks using the `create_standalone_task` MCP tool. Each task ' +
+	'description must include stacked PR instructions so the downstream coder knows exactly ' +
+	'which base branch to target, forming a reviewable PR chain across the plan.\n\n' +
 	'TOOL CONTRACT (Design v2):\n' +
 	'- `report_result({ summary, evidence? })` — append-only audit. Records the dispatch ' +
 	'outcome. Does NOT close the task.\n' +
@@ -321,16 +323,48 @@ const PD_TASK_DISPATCHER_PROMPT =
 	'Use when autonomy blocks self-close.\n\n' +
 	'Steps:\n' +
 	'1. Read the approved plan from the plan PR (`gh pr diff` or `gh pr view --json files`). ' +
-	'Identify each actionable work item.\n' +
-	'2. For each item, call `create_standalone_task({ title, description, priority })`. Use a ' +
-	'clear, imperative title and a description that gives the downstream worker everything they ' +
-	'need (context, acceptance criteria, references to the plan).\n' +
-	'3. Collect the returned task IDs.\n' +
-	'4. Call `report_result({ summary: "Created N tasks from plan: <short list>", ' +
-	'evidence: { created_task_ids: [<ids>] } })` to record the dispatch audit entry.\n' +
-	'5. Call `approve_task()` as your final action. If autonomy blocks self-close, call ' +
+	'Identify each actionable work item in order and record its title, description, priority, ' +
+	'and acceptance criteria.\n' +
+	'2. Generate a stack prefix from the plan title: a short kebab-case slug derived from the ' +
+	'key words, e.g. "Migrate auth to JWT tokens" → "migrate-auth-jwt", "Add file upload ' +
+	'support" → "add-file-upload". All branches in the stack share this prefix so they are ' +
+	'grouped: `plan/<prefix>/<item-slug>`.\n' +
+	'3. Create standalone tasks in BOTTOM-UP order (item 1 first, then item 2, etc.) by ' +
+	'calling `create_standalone_task({ title, description, priority })` for each. The ' +
+	'description must contain the original plan item content PLUS a ' +
+	'"## Stacked PR Instructions" section appended at the end.\n\n' +
+	'   For the BOTTOM task (item 1 — PR base is `dev`):\n' +
+	'   ```\n' +
+	'   ## Stacked PR Instructions\n' +
+	'   This task is the bottom of a stacked PR chain. When creating your PR:\n' +
+	'   - Branch name: plan/<stack-prefix>/<item-1-slug>\n' +
+	'   - Base branch: dev\n' +
+	'   - PR body must include: "Part of stack: <plan title>. PR 1 of N (bottom)."\n' +
+	'   ```\n\n' +
+	"   For MIDDLE and TOP tasks (item N where N > 1 — PR base is the previous item's branch):\n" +
+	'   ```\n' +
+	'   ## Stacked PR Instructions\n' +
+	'   This task is part of a stacked PR chain. When creating your PR:\n' +
+	'   - Branch name: plan/<stack-prefix>/<item-N-slug>\n' +
+	'   - Base branch: plan/<stack-prefix>/<item-(N-1)-slug>\n' +
+	'   - PR body must include: "Part of stack: <plan title>. PR N of [total]."\n' +
+	'   - IMPORTANT: The task below you in the stack (task #<prev-task-id>) must have an ' +
+	'open or merged PR on branch plan/<stack-prefix>/<item-(N-1)-slug> before you create ' +
+	'yours. Verify with: `gh pr list --head plan/<stack-prefix>/<item-(N-1)-slug>`\n' +
+	'   - This task depends on task #<prev-task-id>. Start implementation only after ' +
+	"that task's branch exists.\n" +
+	'   ```\n\n' +
+	'4. Collect the returned task IDs. Build a stack map: ' +
+	'{ prefix, items: [{ title, taskId, branch, baseBranch, position }] }.\n' +
+	'5. Call `report_result({ summary: "Created N tasks from plan: <short list>", ' +
+	'evidence: { created_task_ids: [<ids>], stack_prefix: "<prefix>", ' +
+	'stack_branches: ["plan/<prefix>/<item-1-slug>", "plan/<prefix>/<item-2-slug>", ...] } ' +
+	'})` to record the dispatch audit entry.\n' +
+	'6. Call `approve_task()` as your final action. If autonomy blocks self-close, call ' +
 	'`submit_for_approval({ reason: "..." })` instead.\n\n' +
-	'Do NOT implement the work items yourself. Do NOT create fewer tasks than the plan requires. ' +
+	'CRITICAL: Do NOT create branches, make commits, push to git, or open PRs yourself — ' +
+	"that is the downstream coder's job. Do NOT implement the work items yourself. " +
+	'Do NOT create fewer tasks than the plan requires. ' +
 	'If the plan is empty or ambiguous, send feedback to Planning before closing the task.';
 
 const FULLSTACK_CODING_PROMPT =
@@ -822,7 +856,10 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
 		'Planning-only workflow that ends by creating follow-up tasks rather than writing code. ' +
 		'A Planner drafts a plan PR, four Reviewers review it through different lenses ' +
 		'(architecture, security, correctness, UX), and a Task Dispatcher fans the approved plan ' +
-		'out into standalone tasks via create_standalone_task. Use for multi-task goals that ' +
+		'out into standalone tasks via create_standalone_task. Each task description includes ' +
+		'stacked PR instructions — branch name, base branch, and dependency ordering — so ' +
+		'downstream coders automatically produce a reviewable PR chain (each PR targets the ' +
+		'branch of the item below it, bottom-up from dev). Use for multi-task goals that ' +
 		'should be broken down before any coding starts.',
 	nodes: [
 		{

--- a/packages/daemon/tests/unit/5-space/runtime/space-chat-agent.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-chat-agent.test.ts
@@ -212,6 +212,14 @@ describe('buildSpaceChatSystemPrompt — workflow vs task guidance', () => {
 		const prompt = buildSpaceChatSystemPrompt(makeContext());
 		expect(prompt).toContain('Never create tasks immediately');
 	});
+
+	test('Plan & Decompose guidance mentions stacked PR chain output', () => {
+		const prompt = buildSpaceChatSystemPrompt(makeContext());
+		// Must explain that the output produces a stacked PR chain
+		expect(prompt).toMatch(/stacked PR/i);
+		// Must clarify it is not a coding workflow
+		expect(prompt).toContain('NOT a coding workflow');
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -588,6 +588,51 @@ describe('PLAN_AND_DECOMPOSE_WORKFLOW template', () => {
 		expect(prompt).toContain('created_task_ids');
 	});
 
+	test('Task Dispatcher prompt embeds Stacked PR Instructions in task descriptions', () => {
+		const dispatcherNode = PLAN_AND_DECOMPOSE_WORKFLOW.nodes.find(
+			(n) => n.name === 'Task Dispatcher'
+		)!;
+		const prompt = dispatcherNode.agents[0].customPrompt?.value ?? '';
+		// Must embed stacked PR instructions in each task description
+		expect(prompt).toContain('Stacked PR Instructions');
+		// Must specify branch naming convention using plan/ prefix
+		expect(prompt).toContain('plan/');
+		// Evidence must include stack metadata
+		expect(prompt).toContain('stack_prefix');
+		expect(prompt).toContain('stack_branches');
+	});
+
+	test('Task Dispatcher prompt uses dev (not main) as the base branch for the bottom PR', () => {
+		const dispatcherNode = PLAN_AND_DECOMPOSE_WORKFLOW.nodes.find(
+			(n) => n.name === 'Task Dispatcher'
+		)!;
+		const prompt = dispatcherNode.agents[0].customPrompt?.value ?? '';
+		// Bottom item must target dev as base branch
+		expect(prompt).toContain('Base branch: dev');
+		// Must never reference main as the trunk
+		expect(prompt).not.toContain('Base branch: main');
+	});
+
+	test('Task Dispatcher prompt instructs building stacked PR chain bottom-up', () => {
+		const dispatcherNode = PLAN_AND_DECOMPOSE_WORKFLOW.nodes.find(
+			(n) => n.name === 'Task Dispatcher'
+		)!;
+		const prompt = dispatcherNode.agents[0].customPrompt?.value ?? '';
+		// Must instruct bottom-up ordering (item 1 first)
+		expect(prompt).toMatch(/BOTTOM.UP order|bottom.up/i);
+		// Subsequent items must reference the previous item's branch as base
+		expect(prompt).toContain('item-(N-1)-slug');
+	});
+
+	test('Task Dispatcher prompt instructs Task Dispatcher NOT to create branches or PRs itself', () => {
+		const dispatcherNode = PLAN_AND_DECOMPOSE_WORKFLOW.nodes.find(
+			(n) => n.name === 'Task Dispatcher'
+		)!;
+		const prompt = dispatcherNode.agents[0].customPrompt?.value ?? '';
+		// The dispatcher delegates branch/PR creation to downstream coders
+		expect(prompt).toContain('downstream coder');
+	});
+
 	test('Task Dispatcher node carries a verify-tasks-created completion action', () => {
 		const dispatcherNode = PLAN_AND_DECOMPOSE_WORKFLOW.nodes.find(
 			(n) => n.name === 'Task Dispatcher'
@@ -607,6 +652,13 @@ describe('PLAN_AND_DECOMPOSE_WORKFLOW template', () => {
 			expect(action.script).toContain('NEOKAI_WORKFLOW_START_ISO');
 			expect(action.script).toContain('space_tasks');
 		}
+	});
+
+	test('workflow description describes stacked PR chain output', () => {
+		// The workflow description must convey that the output is a stacked PR chain
+		expect(PLAN_AND_DECOMPOSE_WORKFLOW.description).toMatch(/stacked PR/i);
+		// Must mention that PRs are built bottom-up from dev
+		expect(PLAN_AND_DECOMPOSE_WORKFLOW.description).toContain('dev');
 	});
 
 	test('does not reference leader', () => {


### PR DESCRIPTION
Rewrites the Task Dispatcher node in the Plan & Decompose workflow to produce a bottom-up stacked PR structure alongside the existing standalone tasks.

**What changed:**
- `PD_TASK_DISPATCHER_PROMPT` — Task Dispatcher now embeds `## Stacked PR Instructions` in each task description, specifying the branch name (`plan/<prefix>/<item-slug>`), base branch (`dev` for the bottom item, `plan/<prefix>/<prev-item-slug>` for subsequent items), and dependency ordering. Downstream coders receive all the information they need to create a reviewable PR chain — no git ops in the dispatcher itself.
- `PLAN_AND_DECOMPOSE_WORKFLOW.description` — updated to describe the stacked PR chain output.
- `space-chat-agent.ts` — workflow picking guide for Plan & Decompose updated to mention the stacked PR chain.
- Tests — new assertions in `built-in-workflows.test.ts` and `space-chat-agent.test.ts` covering stacked PR instruction embedding, branch naming, `dev` as base for bottom PR, and bottom-up ordering.

**Design note:** The dispatcher does not run `gh stack` or any git commands itself. Instead it encodes the stacking topology in each task description so the implementation is fully decoupled from whether `gh stack` is installed.