### PR TITLE
feat(web): compact approval banners into one-line + modal

### DIFF
--- a/packages/web/src/components/space/PendingCompletionActionBanner.tsx
+++ b/packages/web/src/components/space/PendingCompletionActionBanner.tsx
@@ -11,9 +11,8 @@
  * `status: 'cancelled'` — we treat rejection as cancelling the task, which is
  * the transition the daemon already permits out of `review`.
  *
- * For `type: 'script'` actions the bash source is shown under a `<details>`
- * disclosure, collapsed by default — so risky shell commands are visible to
- * reviewers but don't dominate the banner.
+ * Compact design: shows a single status line inline; full action details and
+ * confirmation are shown in modals opened by the Approve / Reject buttons.
  *
  * Distinct from `PendingGateBanner` (workflow-level gates) and
  * `TaskBlockedBanner` (blocked-status tasks). The three can, in principle, be
@@ -25,7 +24,7 @@ import { useCallback, useMemo, useState } from 'preact/hooks';
 import type { CompletionAction, SpaceAutonomyLevel, SpaceTask } from '@neokai/shared';
 import { spaceStore } from '../../lib/space-store';
 import { AUTONOMY_LABELS } from '../../lib/space-constants';
-import { ConfirmModal } from '../ui/ConfirmModal';
+import { Modal } from '../ui/Modal.tsx';
 
 interface PendingCompletionActionBannerProps {
 	task: SpaceTask;
@@ -75,7 +74,8 @@ export function PendingCompletionActionBanner({
 
 	const [busy, setBusy] = useState(false);
 	const [error, setError] = useState<string | null>(null);
-	const [showRejectConfirm, setShowRejectConfirm] = useState(false);
+	const [showApproveModal, setShowApproveModal] = useState(false);
+	const [showRejectModal, setShowRejectModal] = useState(false);
 	const [rejectReason, setRejectReason] = useState('');
 
 	const onApprove = useCallback(async () => {
@@ -87,6 +87,7 @@ export function PendingCompletionActionBanner({
 			// recomputes the resulting status (done / review / blocked) based on
 			// the action outcome + remaining actions, so we don't need to guess.
 			await spaceStore.updateTask(task.id, { status: 'done' });
+			setShowApproveModal(false);
 		} catch (err: unknown) {
 			setError(err instanceof Error ? err.message : 'Failed to approve');
 		} finally {
@@ -111,7 +112,7 @@ export function PendingCompletionActionBanner({
 				pendingCheckpointType: null,
 				...(reason ? { result: reason } : {}),
 			});
-			setShowRejectConfirm(false);
+			setShowRejectModal(false);
 			setRejectReason('');
 		} catch (err: unknown) {
 			setError(err instanceof Error ? err.message : 'Failed to reject');
@@ -135,89 +136,173 @@ export function PendingCompletionActionBanner({
 
 	return (
 		<>
+			{/* Compact one-line banner */}
 			<div
-				class="mx-4 mt-2 mb-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 space-y-2"
+				class="mx-4 mt-2 mb-2 flex items-center gap-2 px-2 py-1 rounded text-xs text-amber-400/90"
 				data-testid="pending-completion-action-banner"
 				data-action-type={action.type}
 			>
-				<div class="flex items-start justify-between gap-2">
-					<div class="flex-1 min-w-0">
-						<p class="text-xs font-medium text-amber-300">
-							⏸ Completion Action Awaiting Approval — {action.name}
-						</p>
-						<p
-							class="mt-0.5 text-xs text-amber-400/70"
-							data-testid="pending-completion-action-type"
-						>
-							{typeLabel} · requires {requiredLabel} (Level {action.requiredLevel}); space is{' '}
-							<span data-testid="pending-completion-action-current-level">
-								{currentLabel} (Level {currentLevel})
-							</span>
-						</p>
+				<span class="shrink-0">⏸</span>
+				<span class="flex-1 min-w-0 truncate">
+					Completion action: <span class="font-medium">{action.name}</span>
+					<span class="text-amber-400/60 ml-1">· {typeLabel}</span>
+					<span class="text-amber-400/60 ml-1">· requires Level {action.requiredLevel}</span>
+				</span>
+
+				<div class="flex items-center gap-1 flex-shrink-0">
+					<button
+						type="button"
+						onClick={() => {
+							setError(null);
+							setShowApproveModal(true);
+						}}
+						disabled={busy}
+						data-testid="pending-completion-action-approve-btn"
+						class="px-2 py-0.5 text-xs font-medium rounded bg-green-900/40 text-green-300 border border-green-700/50 hover:bg-green-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+					>
+						Approve
+					</button>
+					<button
+						type="button"
+						onClick={() => {
+							setError(null);
+							setShowRejectModal(true);
+						}}
+						disabled={busy}
+						data-testid="pending-completion-action-reject-btn"
+						class="px-2 py-0.5 text-xs font-medium rounded bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+					>
+						Reject
+					</button>
+				</div>
+			</div>
+
+			{/* Approve modal */}
+			<Modal
+				isOpen={showApproveModal}
+				onClose={() => {
+					if (!busy) {
+						setShowApproveModal(false);
+						setError(null);
+					}
+				}}
+				title={`Approve "${action.name}"?`}
+				size="md"
+				data-testid="pending-completion-action-approve-modal"
+			>
+				<div class="space-y-4" data-testid="pending-completion-action-approve-modal-content">
+					<div class="text-xs text-amber-400/80" data-testid="pending-completion-action-type">
+						{typeLabel} · requires {requiredLabel} (Level {action.requiredLevel}); space is{' '}
+						<span data-testid="pending-completion-action-current-level">
+							{currentLabel} (Level {currentLevel})
+						</span>
 					</div>
 
-					<div class="flex items-center gap-1.5 flex-shrink-0">
+					<CompletionActionDetails action={action} />
+
+					{error && (
+						<p class="text-xs text-red-400" data-testid="pending-completion-action-error">
+							{error}
+						</p>
+					)}
+
+					<div class="flex items-center justify-end gap-3 pt-1">
+						<button
+							type="button"
+							onClick={() => {
+								if (!busy) {
+									setShowApproveModal(false);
+									setError(null);
+								}
+							}}
+							disabled={busy}
+							class="px-4 py-2 text-sm font-medium text-gray-300 hover:text-white bg-dark-800 hover:bg-dark-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							Cancel
+						</button>
 						<button
 							type="button"
 							onClick={() => void onApprove()}
 							disabled={busy}
-							data-testid="pending-completion-action-approve-btn"
-							class="px-2 py-1 text-xs font-medium rounded bg-green-900/40 text-green-300 border border-green-700/50 hover:bg-green-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+							data-testid="pending-completion-action-approve-confirm"
+							class="px-4 py-2 text-sm font-medium rounded-lg transition-colors bg-green-600 hover:bg-green-700 text-white disabled:bg-green-600/50 disabled:cursor-not-allowed"
 						>
-							Approve
-						</button>
-						<button
-							type="button"
-							onClick={() => setShowRejectConfirm(true)}
-							disabled={busy}
-							data-testid="pending-completion-action-reject-btn"
-							class="px-2 py-1 text-xs font-medium rounded bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-						>
-							Reject
+							{busy ? 'Processing...' : 'Approve'}
 						</button>
 					</div>
 				</div>
+			</Modal>
 
-				<CompletionActionDetails action={action} />
-
-				{error && (
-					<p class="text-xs text-red-400" data-testid="pending-completion-action-error">
-						{error}
-					</p>
-				)}
-			</div>
-
-			<ConfirmModal
-				isOpen={showRejectConfirm}
+			{/* Reject modal */}
+			<Modal
+				isOpen={showRejectModal}
 				onClose={() => {
 					if (!busy) {
-						setShowRejectConfirm(false);
+						setShowRejectModal(false);
 						setRejectReason('');
+						setError(null);
 					}
 				}}
-				onConfirm={() => void onRejectConfirm()}
 				title={`Reject "${action.name}"?`}
-				message={`The task will be cancelled and the ${typeLabel.toLowerCase()} will not run. This can't be undone by the banner — to retry, reopen the task.`}
-				confirmText="Reject and Cancel Task"
-				cancelText="Keep Pending"
-				confirmButtonVariant="danger"
-				isLoading={busy}
-				error={error}
-				confirmTestId="pending-completion-action-reject-confirm"
+				size="md"
+				data-testid="pending-completion-action-reject-modal"
 			>
-				<label class="block text-xs text-gray-400 mb-1" for="reject-reason-input">
-					Reason (optional — recorded on the task)
-				</label>
-				<textarea
-					id="reject-reason-input"
-					data-testid="pending-completion-action-reject-reason"
-					value={rejectReason}
-					onInput={(e) => setRejectReason((e.target as HTMLTextAreaElement).value)}
-					class="w-full rounded border border-dark-600 bg-dark-800 px-2 py-1 text-sm text-gray-200 focus:border-red-500 focus:outline-none"
-					rows={2}
-					disabled={busy}
-				/>
-			</ConfirmModal>
+				<div class="space-y-4" data-testid="pending-completion-action-reject-modal-content">
+					<p class="text-gray-300 text-sm leading-relaxed">
+						The task will be cancelled and the {typeLabel.toLowerCase()} will not run. This can't be
+						undone by the banner — to retry, reopen the task.
+					</p>
+
+					<CompletionActionDetails action={action} />
+
+					<div>
+						<label class="block text-xs text-gray-400 mb-1" for="reject-reason-input">
+							Reason (optional — recorded on the task)
+						</label>
+						<textarea
+							id="reject-reason-input"
+							data-testid="pending-completion-action-reject-reason"
+							value={rejectReason}
+							onInput={(e) => setRejectReason((e.target as HTMLTextAreaElement).value)}
+							class="w-full rounded border border-dark-600 bg-dark-800 px-2 py-1 text-sm text-gray-200 focus:border-red-500 focus:outline-none"
+							rows={2}
+							disabled={busy}
+						/>
+					</div>
+
+					{error && (
+						<p class="text-xs text-red-400" data-testid="pending-completion-action-error">
+							{error}
+						</p>
+					)}
+
+					<div class="flex items-center justify-end gap-3 pt-1">
+						<button
+							type="button"
+							onClick={() => {
+								if (!busy) {
+									setShowRejectModal(false);
+									setRejectReason('');
+									setError(null);
+								}
+							}}
+							disabled={busy}
+							class="px-4 py-2 text-sm font-medium text-gray-300 hover:text-white bg-dark-800 hover:bg-dark-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							Keep Pending
+						</button>
+						<button
+							type="button"
+							onClick={() => void onRejectConfirm()}
+							disabled={busy}
+							data-testid="pending-completion-action-reject-confirm"
+							class="px-4 py-2 text-sm font-medium rounded-lg transition-colors bg-red-600 hover:bg-red-700 text-white disabled:bg-red-600/50 disabled:cursor-not-allowed"
+						>
+							{busy ? 'Processing...' : 'Reject and Cancel Task'}
+						</button>
+					</div>
+				</div>
+			</Modal>
 		</>
 	);
 }

--- a/packages/web/src/components/space/PendingTaskCompletionBanner.tsx
+++ b/packages/web/src/components/space/PendingTaskCompletionBanner.tsx
@@ -12,6 +12,9 @@
  *   which transitions review → in_progress so the end-node agent can revise
  *   its output; clears the pending-completion fields.
  *
+ * Compact design: shows a single status line inline; full details and
+ * confirmation are shown in modals opened by the Approve / Send back buttons.
+ *
  * Distinct from `PendingCompletionActionBanner` (completion-action checkpoints,
  * `pendingCheckpointType === 'completion_action'`) which runs a configured
  * script/instruction/mcp_call on approval.
@@ -20,7 +23,7 @@
 import { useCallback, useState } from 'preact/hooks';
 import type { SpaceTask } from '@neokai/shared';
 import { spaceStore } from '../../lib/space-store';
-import { ConfirmModal } from '../ui/ConfirmModal';
+import { Modal } from '../ui/Modal.tsx';
 
 interface PendingTaskCompletionBannerProps {
 	task: SpaceTask;
@@ -47,7 +50,8 @@ export function PendingTaskCompletionBanner({
 }: PendingTaskCompletionBannerProps) {
 	const [busy, setBusy] = useState(false);
 	const [error, setError] = useState<string | null>(null);
-	const [showRejectConfirm, setShowRejectConfirm] = useState(false);
+	const [showApproveModal, setShowApproveModal] = useState(false);
+	const [showRejectModal, setShowRejectModal] = useState(false);
 	const [rejectReason, setRejectReason] = useState('');
 	const [approveReason, setApproveReason] = useState('');
 
@@ -58,6 +62,7 @@ export function PendingTaskCompletionBanner({
 			const reason = approveReason.trim();
 			await spaceStore.approvePendingCompletion(task.id, true, reason ? reason : null);
 			setApproveReason('');
+			setShowApproveModal(false);
 		} catch (err: unknown) {
 			setError(err instanceof Error ? err.message : 'Failed to approve');
 		} finally {
@@ -71,7 +76,7 @@ export function PendingTaskCompletionBanner({
 		try {
 			const reason = rejectReason.trim();
 			await spaceStore.approvePendingCompletion(task.id, false, reason ? reason : null);
-			setShowRejectConfirm(false);
+			setShowRejectModal(false);
 			setRejectReason('');
 		} catch (err: unknown) {
 			setError(err instanceof Error ? err.message : 'Failed to reject');
@@ -84,120 +89,220 @@ export function PendingTaskCompletionBanner({
 
 	const agentReason = task.pendingCompletionReason?.trim();
 	const reportedSummary = task.reportedSummary?.trim();
-	const submittedBy = task.pendingCompletionSubmittedByNodeId;
 	const submittedAgo = formatPendingSince(task.pendingCompletionSubmittedAt ?? null);
 
 	return (
 		<>
+			{/* Compact one-line banner */}
 			<div
-				class="mx-4 mt-2 mb-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 space-y-2"
+				class="mx-4 mt-2 mb-2 flex items-center gap-2 px-2 py-1 rounded text-xs text-amber-400/90"
 				data-testid="pending-task-completion-banner"
 			>
-				<div class="flex items-start justify-between gap-2">
-					<div class="flex-1 min-w-0">
-						<p class="text-xs font-medium text-amber-300">
-							Awaiting Human Approval — Submit for Review
-						</p>
-						<p class="mt-0.5 text-xs text-amber-400/70">
-							An end-node agent requested human sign-off
-							{submittedBy ? ` (node: ${submittedBy})` : ''}
-							{submittedAgo ? ` · ${submittedAgo}` : ''}.
-						</p>
+				<span class="shrink-0">⏸</span>
+				<span class="flex-1 min-w-0 truncate">
+					Awaiting approval
+					{submittedAgo ? <span class="text-amber-400/60 ml-1">· {submittedAgo}</span> : null}
+				</span>
+
+				<div class="flex items-center gap-1 flex-shrink-0">
+					<button
+						type="button"
+						onClick={() => {
+							setError(null);
+							setShowApproveModal(true);
+						}}
+						disabled={busy}
+						data-testid="pending-task-completion-approve-btn"
+						class="px-2 py-0.5 text-xs font-medium rounded bg-green-900/40 text-green-300 border border-green-700/50 hover:bg-green-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+					>
+						Approve
+					</button>
+					<button
+						type="button"
+						onClick={() => {
+							setError(null);
+							setShowRejectModal(true);
+						}}
+						disabled={busy}
+						data-testid="pending-task-completion-reject-btn"
+						class="px-2 py-0.5 text-xs font-medium rounded bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+					>
+						Send back
+					</button>
+				</div>
+			</div>
+
+			{/* Approve modal */}
+			<Modal
+				isOpen={showApproveModal}
+				onClose={() => {
+					if (!busy) {
+						setShowApproveModal(false);
+						setApproveReason('');
+						setError(null);
+					}
+				}}
+				title="Approve task completion?"
+				size="md"
+				data-testid="pending-task-completion-approve-modal"
+			>
+				<div class="space-y-4" data-testid="pending-task-completion-approve-modal-content">
+					{reportedSummary && (
+						<div class="text-xs" data-testid="pending-task-completion-reported-summary">
+							<p class="text-gray-400 mb-1">Agent's reported outcome:</p>
+							<p class="p-2 bg-dark-900/60 border border-dark-700 rounded text-[11px] text-gray-300 whitespace-pre-wrap">
+								{reportedSummary}
+							</p>
+						</div>
+					)}
+
+					{agentReason && (
+						<div class="text-xs" data-testid="pending-task-completion-agent-reason">
+							<p class="text-gray-400 mb-1">Agent rationale:</p>
+							<p class="p-2 bg-dark-900/60 border border-dark-700 rounded text-[11px] text-gray-300 whitespace-pre-wrap">
+								{agentReason}
+							</p>
+						</div>
+					)}
+
+					<div>
+						<label class="block text-[11px] text-gray-400 mb-1" for="approve-reason-input">
+							Approval note (optional — recorded on the task)
+						</label>
+						<textarea
+							id="approve-reason-input"
+							data-testid="pending-task-completion-approve-reason"
+							value={approveReason}
+							onInput={(e) => setApproveReason((e.target as HTMLTextAreaElement).value)}
+							class="w-full rounded border border-dark-600 bg-dark-800 px-2 py-1 text-[11px] text-gray-200 focus:border-amber-500 focus:outline-none"
+							rows={2}
+							disabled={busy}
+						/>
 					</div>
 
-					<div class="flex items-center gap-1.5 flex-shrink-0">
+					{error && (
+						<p class="text-xs text-red-400" data-testid="pending-task-completion-error">
+							{error}
+						</p>
+					)}
+
+					<div class="flex items-center justify-end gap-3 pt-1">
+						<button
+							type="button"
+							onClick={() => {
+								if (!busy) {
+									setShowApproveModal(false);
+									setApproveReason('');
+									setError(null);
+								}
+							}}
+							disabled={busy}
+							class="px-4 py-2 text-sm font-medium text-gray-300 hover:text-white bg-dark-800 hover:bg-dark-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							Cancel
+						</button>
 						<button
 							type="button"
 							onClick={() => void onApprove()}
 							disabled={busy}
-							data-testid="pending-task-completion-approve-btn"
-							class="px-2 py-1 text-xs font-medium rounded bg-green-900/40 text-green-300 border border-green-700/50 hover:bg-green-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+							data-testid="pending-task-completion-approve-confirm"
+							class="px-4 py-2 text-sm font-medium rounded-lg transition-colors bg-green-600 hover:bg-green-700 text-white disabled:bg-green-600/50 disabled:cursor-not-allowed"
 						>
-							Approve
+							{busy ? 'Processing...' : 'Approve'}
+						</button>
+					</div>
+				</div>
+			</Modal>
+
+			{/* Reject / Send back modal */}
+			<Modal
+				isOpen={showRejectModal}
+				onClose={() => {
+					if (!busy) {
+						setShowRejectModal(false);
+						setRejectReason('');
+						setError(null);
+					}
+				}}
+				title="Send task back for revision?"
+				size="md"
+				data-testid="pending-task-completion-reject-modal"
+			>
+				<div class="space-y-4" data-testid="pending-task-completion-reject-modal-content">
+					<p class="text-gray-300 text-sm leading-relaxed">
+						The task will be reopened (status: in_progress) so the end-node agent can revise and
+						re-submit. The pending-completion request will be cleared.
+					</p>
+
+					{reportedSummary && (
+						<div class="text-xs">
+							<p class="text-gray-400 mb-1">Agent's reported outcome:</p>
+							<p class="p-2 bg-dark-900/60 border border-dark-700 rounded text-[11px] text-gray-300 whitespace-pre-wrap">
+								{reportedSummary}
+							</p>
+						</div>
+					)}
+
+					{agentReason && (
+						<div class="text-xs">
+							<p class="text-gray-400 mb-1">Agent rationale:</p>
+							<p class="p-2 bg-dark-900/60 border border-dark-700 rounded text-[11px] text-gray-300 whitespace-pre-wrap">
+								{agentReason}
+							</p>
+						</div>
+					)}
+
+					<div>
+						<label
+							class="block text-xs text-gray-400 mb-1"
+							for="task-completion-reject-reason-input"
+						>
+							Reason (optional — shared with the agent as feedback)
+						</label>
+						<textarea
+							id="task-completion-reject-reason-input"
+							data-testid="pending-task-completion-reject-reason"
+							value={rejectReason}
+							onInput={(e) => setRejectReason((e.target as HTMLTextAreaElement).value)}
+							class="w-full rounded border border-dark-600 bg-dark-800 px-2 py-1 text-sm text-gray-200 focus:border-red-500 focus:outline-none"
+							rows={3}
+							disabled={busy}
+						/>
+					</div>
+
+					{error && (
+						<p class="text-xs text-red-400" data-testid="pending-task-completion-error">
+							{error}
+						</p>
+					)}
+
+					<div class="flex items-center justify-end gap-3 pt-1">
+						<button
+							type="button"
+							onClick={() => {
+								if (!busy) {
+									setShowRejectModal(false);
+									setRejectReason('');
+									setError(null);
+								}
+							}}
+							disabled={busy}
+							class="px-4 py-2 text-sm font-medium text-gray-300 hover:text-white bg-dark-800 hover:bg-dark-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							Keep Pending
 						</button>
 						<button
 							type="button"
-							onClick={() => setShowRejectConfirm(true)}
+							onClick={() => void onRejectConfirm()}
 							disabled={busy}
-							data-testid="pending-task-completion-reject-btn"
-							class="px-2 py-1 text-xs font-medium rounded bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+							data-testid="pending-task-completion-reject-confirm"
+							class="px-4 py-2 text-sm font-medium rounded-lg transition-colors bg-red-600 hover:bg-red-700 text-white disabled:bg-red-600/50 disabled:cursor-not-allowed"
 						>
-							Send back
+							{busy ? 'Processing...' : 'Send back to agent'}
 						</button>
 					</div>
 				</div>
-
-				{reportedSummary && (
-					<div class="text-xs" data-testid="pending-task-completion-reported-summary">
-						<p class="text-amber-400/80">Agent's reported outcome:</p>
-						<p class="mt-0.5 p-2 bg-dark-900/60 border border-dark-700 rounded text-[11px] text-gray-300 whitespace-pre-wrap">
-							{reportedSummary}
-						</p>
-					</div>
-				)}
-
-				{agentReason && (
-					<div class="text-xs" data-testid="pending-task-completion-agent-reason">
-						<p class="text-amber-400/80">Agent rationale:</p>
-						<p class="mt-0.5 p-2 bg-dark-900/60 border border-dark-700 rounded text-[11px] text-gray-300 whitespace-pre-wrap">
-							{agentReason}
-						</p>
-					</div>
-				)}
-
-				<div>
-					<label class="block text-[11px] text-gray-400 mb-1" for="approve-reason-input">
-						Approval note (optional — recorded on the task)
-					</label>
-					<textarea
-						id="approve-reason-input"
-						data-testid="pending-task-completion-approve-reason"
-						value={approveReason}
-						onInput={(e) => setApproveReason((e.target as HTMLTextAreaElement).value)}
-						class="w-full rounded border border-dark-600 bg-dark-800 px-2 py-1 text-[11px] text-gray-200 focus:border-amber-500 focus:outline-none"
-						rows={2}
-						disabled={busy}
-					/>
-				</div>
-
-				{error && (
-					<p class="text-xs text-red-400" data-testid="pending-task-completion-error">
-						{error}
-					</p>
-				)}
-			</div>
-
-			<ConfirmModal
-				isOpen={showRejectConfirm}
-				onClose={() => {
-					if (!busy) {
-						setShowRejectConfirm(false);
-						setRejectReason('');
-					}
-				}}
-				onConfirm={() => void onRejectConfirm()}
-				title="Send task back for revision?"
-				message="The task will be reopened (status: in_progress) so the end-node agent can revise and re-submit. The pending-completion request will be cleared."
-				confirmText="Send back to agent"
-				cancelText="Keep Pending"
-				confirmButtonVariant="danger"
-				isLoading={busy}
-				error={error}
-				confirmTestId="pending-task-completion-reject-confirm"
-			>
-				<label class="block text-xs text-gray-400 mb-1" for="task-completion-reject-reason-input">
-					Reason (optional — shared with the agent as feedback)
-				</label>
-				<textarea
-					id="task-completion-reject-reason-input"
-					data-testid="pending-task-completion-reject-reason"
-					value={rejectReason}
-					onInput={(e) => setRejectReason((e.target as HTMLTextAreaElement).value)}
-					class="w-full rounded border border-dark-600 bg-dark-800 px-2 py-1 text-sm text-gray-200 focus:border-red-500 focus:outline-none"
-					rows={3}
-					disabled={busy}
-				/>
-			</ConfirmModal>
+			</Modal>
 		</>
 	);
 }

--- a/packages/web/src/components/space/__tests__/PendingCompletionActionBanner.test.tsx
+++ b/packages/web/src/components/space/__tests__/PendingCompletionActionBanner.test.tsx
@@ -3,9 +3,9 @@
  *
  * Covers the Done criteria from the task:
  *   - renders name + description (type line) + required level vs space level
- *   - Approve calls spaceStore.updateTask with status='done'
- *   - Reject opens a confirmation modal; confirm cancels the task
- *   - Script details collapsed by default (<details>)
+ *   - Approve opens a modal; confirming calls spaceStore.updateTask with status='done'
+ *   - Reject opens a modal; confirming cancels the task
+ *   - Script details collapsed by default (<details>) inside the approve modal
  *   - Hidden when pendingCheckpointType !== 'completion_action'
  *
  * Plus regressions:
@@ -136,14 +136,26 @@ describe('PendingCompletionActionBanner', () => {
 		cleanup();
 	});
 
-	it('renders with action name, type, and required / current level', () => {
+	it('renders with action name in the compact banner', () => {
 		const task = makeTask();
 		const { getByTestId } = render(
 			<PendingCompletionActionBanner task={task} spaceId="space-1" spaceAutonomyLevel={1} />
 		);
 		const banner = getByTestId('pending-completion-action-banner');
 		expect(banner.textContent).toContain('merge-pr');
-		const typeLine = getByTestId('pending-completion-action-type').textContent ?? '';
+	});
+
+	it('approve modal shows action type, required level, and current space level', async () => {
+		const task = makeTask();
+		const { getByTestId } = render(
+			<PendingCompletionActionBanner task={task} spaceId="space-1" spaceAutonomyLevel={1} />
+		);
+		// Open the approve modal
+		fireEvent.click(getByTestId('pending-completion-action-approve-btn'));
+		// Modal is now open — type/level info is visible
+		const typeLine = await waitFor(
+			() => getByTestId('pending-completion-action-type').textContent ?? ''
+		);
 		expect(typeLine).toContain('Bash script');
 		expect(typeLine).toContain('Level 3');
 		const current = getByTestId('pending-completion-action-current-level').textContent ?? '';
@@ -183,10 +195,14 @@ describe('PendingCompletionActionBanner', () => {
 		expect(queryByTestId('pending-completion-action-banner')).toBeNull();
 	});
 
-	it('script details are collapsed by default', () => {
+	it('script details are collapsed by default inside the approve modal', async () => {
 		const task = makeTask();
 		const { getByTestId } = render(<PendingCompletionActionBanner task={task} spaceId="space-1" />);
-		const details = getByTestId('pending-completion-action-details') as HTMLDetailsElement;
+		// Open approve modal to access action details
+		fireEvent.click(getByTestId('pending-completion-action-approve-btn'));
+		const details = await waitFor(
+			() => getByTestId('pending-completion-action-details') as HTMLDetailsElement
+		);
 		expect(details.tagName.toLowerCase()).toBe('details');
 		expect(details.open).toBe(false);
 		// But the script source is in the DOM (ready to reveal).
@@ -194,20 +210,26 @@ describe('PendingCompletionActionBanner', () => {
 		expect(source).toContain('gh pr merge');
 	});
 
-	it('Approve calls spaceStore.updateTask with status="done"', async () => {
+	it('Approve opens modal; confirming calls spaceStore.updateTask with status="done"', async () => {
 		const task = makeTask();
 		const { getByTestId } = render(<PendingCompletionActionBanner task={task} spaceId="space-1" />);
+		// Click the inline Approve button → opens modal
 		fireEvent.click(getByTestId('pending-completion-action-approve-btn'));
+		// Click the confirm button inside the modal
+		const confirmBtn = await waitFor(() =>
+			getByTestId('pending-completion-action-approve-confirm')
+		);
+		fireEvent.click(confirmBtn);
 		await waitFor(() => expect(updateTaskMock).toHaveBeenCalledTimes(1));
 		expect(updateTaskMock).toHaveBeenCalledWith(task.id, { status: 'done' });
 	});
 
-	it('Reject opens confirmation modal; confirm cancels task and clears pending fields', async () => {
+	it('Reject opens modal; confirm cancels task and clears pending fields', async () => {
 		const task = makeTask();
 		const { getByTestId, queryByTestId } = render(
 			<PendingCompletionActionBanner task={task} spaceId="space-1" />
 		);
-		// Modal is not open by default
+		// Reject modal is not open by default
 		expect(queryByTestId('pending-completion-action-reject-confirm')).toBeNull();
 
 		fireEvent.click(getByTestId('pending-completion-action-reject-btn'));
@@ -241,16 +263,21 @@ describe('PendingCompletionActionBanner', () => {
 		expect(payload.result).toBeUndefined();
 	});
 
-	it('surfaces approval errors inline without throwing', async () => {
+	it('surfaces approval errors inside the modal without throwing', async () => {
 		updateTaskMock.mockRejectedValueOnce(new Error('network down'));
 		const task = makeTask();
 		const { getByTestId } = render(<PendingCompletionActionBanner task={task} spaceId="space-1" />);
+		// Open approve modal and confirm
 		fireEvent.click(getByTestId('pending-completion-action-approve-btn'));
+		const confirmBtn = await waitFor(() =>
+			getByTestId('pending-completion-action-approve-confirm')
+		);
+		fireEvent.click(confirmBtn);
 		const err = await waitFor(() => getByTestId('pending-completion-action-error'));
 		expect(err.textContent).toContain('network down');
 	});
 
-	it('renders instruction details for instruction actions', () => {
+	it('renders instruction details for instruction actions inside the approve modal', async () => {
 		workflowsSignal.value = [
 			makeWorkflow({
 				id: 'a2',
@@ -263,14 +290,16 @@ describe('PendingCompletionActionBanner', () => {
 		];
 		const task = makeTask();
 		const { getByTestId } = render(<PendingCompletionActionBanner task={task} spaceId="space-1" />);
-		const details = getByTestId('pending-completion-action-details');
+		// Open approve modal to see action details
+		fireEvent.click(getByTestId('pending-completion-action-approve-btn'));
+		const details = await waitFor(() => getByTestId('pending-completion-action-details'));
 		expect(details.getAttribute('data-action-type')).toBe('instruction');
 		expect(getByTestId('pending-completion-action-instruction').textContent).toContain(
 			'Post a summary'
 		);
 	});
 
-	it('renders MCP details for mcp_call actions', () => {
+	it('renders MCP details for mcp_call actions inside the approve modal', async () => {
 		workflowsSignal.value = [
 			makeWorkflow({
 				id: 'a3',
@@ -284,7 +313,9 @@ describe('PendingCompletionActionBanner', () => {
 		];
 		const task = makeTask();
 		const { getByTestId } = render(<PendingCompletionActionBanner task={task} spaceId="space-1" />);
-		const details = getByTestId('pending-completion-action-details');
+		// Open approve modal to see action details
+		fireEvent.click(getByTestId('pending-completion-action-approve-btn'));
+		const details = await waitFor(() => getByTestId('pending-completion-action-details'));
 		expect(details.getAttribute('data-action-type')).toBe('mcp_call');
 		const args = getByTestId('pending-completion-action-mcp-args').textContent ?? '';
 		expect(args).toContain('title');


### PR DESCRIPTION
Redesign `PendingTaskCompletionBanner` and `PendingCompletionActionBanner` from large inline cards into compact one-line status indicators with detail modals.

**What changed:**
- Both banners now render as a single line: icon + brief label + Approve/Reject buttons
- Clicking Approve or Reject opens a `Modal` with the full details (rationale, reported summary, action script/instruction/MCP args) and a confirmation flow
- All existing `data-testid` attributes preserved; modal content gets new testids (`*-approve-modal`, `*-reject-modal`, `*-approve-confirm`)
- No backend/store changes; all approve/reject API calls unchanged

**Tests:** Updated `PendingCompletionActionBanner` tests to match the new modal-based flow (clicking Approve/Reject now requires confirming inside the modal).