### PR TITLE
feat(space): data-driven artifact rendering with worktree commit display

### DIFF
--- a/packages/daemon/src/lib/job-handlers/space-workflow-run-artifact.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/space-workflow-run-artifact.handler.ts
@@ -30,6 +30,8 @@ import {
 	parseCommitLog,
 	countDiffLines,
 	getDiffBaseRef,
+	getGitRemoteUrl,
+	normalizeGithubUrl,
 	CACHE_KEY_GATE_ARTIFACTS,
 	CACHE_KEY_COMMITS,
 	COMMIT_LOG_FORMAT,
@@ -233,7 +235,7 @@ async function handleSyncCommits(
 			taskId,
 			cacheKey: CACHE_KEY_COMMITS,
 			status: 'ok',
-			data: { commits: [], baseRef: null, isGitRepo: false },
+			data: { commits: [], baseRef: null, isGitRepo: false, repoUrl: null },
 		});
 		emitCacheUpdated(deps.daemonHub, {
 			spaceId,
@@ -245,7 +247,11 @@ async function handleSyncCommits(
 		return { ok: true, isGitRepo: false };
 	}
 
-	const baseRef = await getDiffBaseRef(worktreePath);
+	const [baseRef, rawRemoteUrl] = await Promise.all([
+		getDiffBaseRef(worktreePath),
+		getGitRemoteUrl(worktreePath),
+	]);
+	const repoUrl = rawRemoteUrl ? normalizeGithubUrl(rawRemoteUrl) : null;
 	const range = baseRef ? `${baseRef}..HEAD` : '';
 
 	let logOutput = '';
@@ -260,7 +266,7 @@ async function handleSyncCommits(
 			taskId,
 			cacheKey: CACHE_KEY_COMMITS,
 			status: 'error',
-			data: { commits: [], baseRef: baseRef || null, isGitRepo: true },
+			data: { commits: [], baseRef: baseRef || null, isGitRepo: true, repoUrl },
 			error: err instanceof Error ? err.message : String(err),
 		});
 		emitCacheUpdated(deps.daemonHub, {
@@ -279,7 +285,7 @@ async function handleSyncCommits(
 		taskId,
 		cacheKey: CACHE_KEY_COMMITS,
 		status: 'ok',
-		data: { commits, baseRef: baseRef || null, isGitRepo: true },
+		data: { commits, baseRef: baseRef || null, isGitRepo: true, repoUrl },
 	});
 	emitCacheUpdated(deps.daemonHub, {
 		spaceId,

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
@@ -44,6 +44,8 @@ import {
 	parseCommitLog,
 	countDiffLines,
 	getDiffBaseRef,
+	getGitRemoteUrl,
+	normalizeGithubUrl,
 	CACHE_KEY_GATE_ARTIFACTS,
 	CACHE_KEY_COMMITS,
 	COMMIT_LOG_FORMAT,
@@ -822,10 +824,14 @@ export function setupSpaceWorkflowRunHandlers(
 		if (!worktreePath) throw new Error(`No workspace path found for run: ${params.runId}`);
 
 		if (!(await isGitRepo(worktreePath))) {
-			return { commits: [], baseRef: null, isGitRepo: false };
+			return { commits: [], baseRef: null, isGitRepo: false, repoUrl: null };
 		}
 
-		const baseRef = await getDiffBaseRef(worktreePath);
+		const [baseRef, rawRemoteUrl] = await Promise.all([
+			getDiffBaseRef(worktreePath),
+			getGitRemoteUrl(worktreePath),
+		]);
+		const repoUrl = rawRemoteUrl ? normalizeGithubUrl(rawRemoteUrl) : null;
 		const range = baseRef ? `${baseRef}..HEAD` : '';
 
 		let logOutput = '';
@@ -838,7 +844,7 @@ export function setupSpaceWorkflowRunHandlers(
 		}
 
 		const commits = parseCommitLog(logOutput);
-		return { commits, baseRef: baseRef || null, isGitRepo: true };
+		return { commits, baseRef: baseRef || null, isGitRepo: true, repoUrl };
 	});
 
 	// ─── spaceWorkflowRun.getCommitFiles ─────────────────────────────────────

--- a/packages/daemon/src/lib/space/artifact-git-ops.ts
+++ b/packages/daemon/src/lib/space/artifact-git-ops.ts
@@ -242,3 +242,39 @@ export function commitFileDiffCacheKey(commitSha: string, filePath: string): str
 
 /** Size cap (in bytes) for full diff payloads served from the cache. */
 export const FILE_DIFF_SIZE_LIMIT_BYTES = 100 * 1024;
+
+/**
+ * Returns the push URL for the `origin` remote, or `null` when git is
+ * unavailable, the path is not a repo, or no origin remote is configured.
+ */
+export async function getGitRemoteUrl(worktreePath: string): Promise<string | null> {
+	try {
+		const url = await execGit(['remote', 'get-url', 'origin'], worktreePath, 5_000);
+		return url.trim() || null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Converts a git remote URL (SSH or HTTPS) for a GitHub repo into a clean
+ * `https://github.com/{owner}/{repo}` URL.
+ *
+ * Returns `null` when the remote is not a GitHub URL.
+ *
+ * Examples:
+ *   `git@github.com:owner/repo.git`       → `https://github.com/owner/repo`
+ *   `https://github.com/owner/repo.git`   → `https://github.com/owner/repo`
+ *   `https://github.com/owner/repo`       → `https://github.com/owner/repo`
+ */
+export function normalizeGithubUrl(remoteUrl: string): string | null {
+	// SSH format: git@github.com:owner/repo.git or git@github.com:owner/repo
+	const sshMatch = remoteUrl.match(/^git@github\.com:([^/]+\/[^.]+?)(?:\.git)?$/);
+	if (sshMatch) return `https://github.com/${sshMatch[1]}`;
+
+	// HTTPS format: https://github.com/owner/repo.git or https://github.com/owner/repo
+	const httpsMatch = remoteUrl.match(/^https?:\/\/github\.com\/([^/]+\/[^.]+?)(?:\.git)?$/);
+	if (httpsMatch) return `https://github.com/${httpsMatch[1]}`;
+
+	return null;
+}

--- a/packages/daemon/tests/unit/5-space/other/artifact-git-ops.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/artifact-git-ops.test.ts
@@ -22,6 +22,8 @@ import {
 	CACHE_KEY_COMMITS,
 	FILE_DIFF_SIZE_LIMIT_BYTES,
 	MERGE_BASE_TTL_MS,
+	normalizeGithubUrl,
+	getGitRemoteUrl,
 } from '../../../../src/lib/space/artifact-git-ops';
 
 describe('parseNumstat', () => {
@@ -216,5 +218,59 @@ describe('getDiffBaseRef / merge-base cache', () => {
 
 	it('defaults the TTL to MERGE_BASE_TTL_MS', () => {
 		expect(MERGE_BASE_TTL_MS).toBe(60_000);
+	});
+});
+
+describe('normalizeGithubUrl', () => {
+	it('converts SSH remote to HTTPS GitHub URL (with .git)', () => {
+		expect(normalizeGithubUrl('git@github.com:owner/repo.git')).toBe(
+			'https://github.com/owner/repo'
+		);
+	});
+
+	it('converts SSH remote to HTTPS GitHub URL (without .git)', () => {
+		expect(normalizeGithubUrl('git@github.com:owner/repo')).toBe('https://github.com/owner/repo');
+	});
+
+	it('normalises HTTPS GitHub URL with .git suffix', () => {
+		expect(normalizeGithubUrl('https://github.com/owner/repo.git')).toBe(
+			'https://github.com/owner/repo'
+		);
+	});
+
+	it('passes through HTTPS GitHub URL without .git suffix unchanged', () => {
+		expect(normalizeGithubUrl('https://github.com/owner/repo')).toBe(
+			'https://github.com/owner/repo'
+		);
+	});
+
+	it('returns null for non-GitHub remotes', () => {
+		expect(normalizeGithubUrl('https://gitlab.com/owner/repo.git')).toBeNull();
+		expect(normalizeGithubUrl('git@bitbucket.org:owner/repo.git')).toBeNull();
+		expect(normalizeGithubUrl('https://example.com/repo')).toBeNull();
+	});
+
+	it('returns null for arbitrary strings', () => {
+		expect(normalizeGithubUrl('not-a-url')).toBeNull();
+		expect(normalizeGithubUrl('')).toBeNull();
+	});
+});
+
+describe('getGitRemoteUrl', () => {
+	it('returns null for a non-existent directory (git command fails)', async () => {
+		const result = await getGitRemoteUrl('/tmp/nonexistent-dir-for-remote-url-test');
+		expect(result).toBeNull();
+	});
+
+	it('returns null for a directory with no git repo', async () => {
+		const { mkdtempSync, rmdirSync } = await import('node:fs');
+		const { tmpdir } = await import('node:os');
+		const dir = mkdtempSync(`${tmpdir()}/neokai-no-git-`);
+		try {
+			const result = await getGitRemoteUrl(dir);
+			expect(result).toBeNull();
+		} finally {
+			rmdirSync(dir);
+		}
 	});
 });

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -1449,8 +1449,14 @@ export interface SpaceExportBundle {
 
 // ── Workflow Run Artifacts ──────────────────────────────────────────────────
 
-/** Artifact types that node agents can produce. Extensible union. */
-export type ArtifactType = 'pr' | 'commit_set' | 'test_result' | 'deployment';
+/**
+ * Artifact type label — a generic string tag agents use to categorise their
+ * output (e.g. 'pr', 'result', 'progress', 'review').  The UI renders
+ * artifacts based on the **shape of `data`**, not this string, so no fixed
+ * enum is needed.  The type is still displayed as a badge on each artifact
+ * card for human scanning.
+ */
+export type ArtifactType = string;
 
 /** A typed artifact produced by a workflow node execution. */
 export interface WorkflowRunArtifact {

--- a/packages/web/src/components/space/ArtifactCard.tsx
+++ b/packages/web/src/components/space/ArtifactCard.tsx
@@ -1,21 +1,78 @@
 /**
- * ArtifactCard — renders a typed workflow run artifact.
+ * ArtifactCard — data-driven renderer for workflow run artifacts.
  *
- * Dispatches on artifactType to render specialized cards:
- *   - pr: PR card with link, number, state badge
- *   - (default): generic JSON card with collapsible data
+ * Rendering is determined entirely by inspecting the shape of `artifact.data`,
+ * NOT by the `artifactType` string.  The type is shown as a small badge/chip
+ * on every card for human scanning, but never drives rendering logic.
+ *
+ * Renderer selection (first match wins):
+ *   1. data.url matches a GitHub PR URL           → PrCard
+ *   2. data.url matches a GitHub commit URL       → CommitRefCard
+ *   3. data.url is any URL                        → LinkCard
+ *   4. data has test_output / stdout / stderr     → TerminalOutputCard
+ *   5. data has ONLY a `summary` string key       → MarkdownCard
+ *   6. all data values are JSON primitives        → StructuredTableCard
+ *   7. (default)                                  → GenericCard
  */
 
 import type { WorkflowRunArtifact } from '@neokai/shared';
 
-interface ArtifactCardProps {
-	artifact: WorkflowRunArtifact;
+// ── URL pattern helpers ──────────────────────────────────────────────────────
+
+const GITHUB_PR_RE = /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/;
+const GITHUB_COMMIT_RE = /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/commit\/([0-9a-f]{7,40})/;
+
+function isUrl(val: unknown): val is string {
+	return typeof val === 'string' && /^https?:\/\//.test(val);
 }
 
-function PrArtifactCard({ artifact }: ArtifactCardProps) {
+// ── Renderer detector ────────────────────────────────────────────────────────
+
+type RendererKind = 'pr' | 'commit-ref' | 'link' | 'terminal' | 'markdown' | 'table' | 'generic';
+
+function detectRenderer(data: Record<string, unknown>): RendererKind {
+	const url = typeof data.url === 'string' ? data.url : null;
+
+	if (url && GITHUB_PR_RE.test(url)) return 'pr';
+	if (url && GITHUB_COMMIT_RE.test(url)) return 'commit-ref';
+	if (url && isUrl(url)) return 'link';
+	if ('test_output' in data || 'stdout' in data || 'stderr' in data) return 'terminal';
+
+	const keys = Object.keys(data);
+	if (keys.length === 1 && keys[0] === 'summary' && typeof data.summary === 'string')
+		return 'markdown';
+	if (keys.length > 0 && keys.every((k) => isPrimitive(data[k]))) return 'table';
+
+	return 'generic';
+}
+
+function isPrimitive(v: unknown): boolean {
+	return v === null || typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean';
+}
+
+// ── Shared sub-components ────────────────────────────────────────────────────
+
+/** Small badge showing the artifact type label. */
+function TypeBadge({ type }: { type: string }) {
+	if (!type) return null;
+	return (
+		<span class="flex-shrink-0 px-1.5 py-0.5 rounded text-[10px] font-medium bg-dark-600 text-gray-400 uppercase tracking-wide">
+			{type}
+		</span>
+	);
+}
+
+const cardBase =
+	'flex items-start gap-2 px-3 py-2 rounded bg-dark-700/50 border border-dark-600 w-full';
+
+// ── Individual renderers ─────────────────────────────────────────────────────
+
+function PrCard({ artifact }: { artifact: WorkflowRunArtifact }) {
 	const { data } = artifact;
 	const url = typeof data.url === 'string' ? data.url : null;
-	const number = typeof data.number === 'number' ? data.number : null;
+	const match = url ? GITHUB_PR_RE.exec(url) : null;
+	const prNumber =
+		typeof data.number === 'number' ? data.number : match ? parseInt(match[3], 10) : null;
 	const title = typeof data.title === 'string' ? data.title : null;
 	const state = typeof data.state === 'string' ? data.state : null;
 	const headBranch = typeof data.headBranch === 'string' ? data.headBranch : null;
@@ -30,12 +87,10 @@ function PrArtifactCard({ artifact }: ArtifactCardProps) {
 					: 'text-gray-400';
 
 	return (
-		<div
-			class="flex items-center gap-2 px-3 py-2 rounded bg-dark-700/50 border border-dark-600"
-			data-testid="artifact-card-pr"
-		>
+		<div class={cardBase} data-testid="artifact-card-pr">
+			{/* PR icon */}
 			<svg
-				class="w-4 h-4 text-purple-400 flex-shrink-0"
+				class="w-4 h-4 text-purple-400 flex-shrink-0 mt-0.5"
 				fill="none"
 				viewBox="0 0 24 24"
 				stroke="currentColor"
@@ -55,45 +110,247 @@ function PrArtifactCard({ artifact }: ArtifactCardProps) {
 						rel="noopener noreferrer"
 						class="text-xs text-blue-400 hover:text-blue-300 truncate block"
 					>
-						{number != null ? `PR #${number}` : 'Pull Request'}
+						{prNumber != null ? `PR #${prNumber}` : 'Pull Request'}
 						{title && <span class="text-gray-400 ml-1.5">— {title}</span>}
 					</a>
 				) : (
 					<span class="text-xs text-gray-300">
-						{number != null ? `PR #${number}` : 'Pull Request'}
+						{prNumber != null ? `PR #${prNumber}` : 'Pull Request'}
 						{title && <span class="text-gray-400 ml-1.5">— {title}</span>}
 					</span>
 				)}
 				{headBranch && <p class="text-xs text-gray-600 font-mono mt-0.5 truncate">{headBranch}</p>}
 			</div>
 			{state && <span class={`text-xs font-medium ${stateColor} flex-shrink-0`}>{state}</span>}
+			<TypeBadge type={artifact.artifactType} />
 		</div>
 	);
 }
 
-function GenericArtifactCard({ artifact }: ArtifactCardProps) {
-	const keyCount = Object.keys(artifact.data).length;
+function CommitRefCard({ artifact }: { artifact: WorkflowRunArtifact }) {
+	const { data } = artifact;
+	const url = typeof data.url === 'string' ? data.url : null;
+	const match = url ? GITHUB_COMMIT_RE.exec(url) : null;
+	const sha = typeof data.sha === 'string' ? data.sha : match ? match[3] : null;
+	const shortSha = sha ? sha.slice(0, 7) : null;
+	const message = typeof data.message === 'string' ? data.message : null;
+	const author = typeof data.author === 'string' ? data.author : null;
+
 	return (
-		<div
-			class="flex items-center gap-2 px-3 py-2 rounded bg-dark-700/50 border border-dark-600"
-			data-testid="artifact-card-generic"
-		>
-			<span class="text-xs text-gray-500 font-mono flex-shrink-0">{artifact.artifactType}</span>
-			{artifact.artifactKey && (
-				<span class="text-xs text-gray-600 truncate">({artifact.artifactKey})</span>
-			)}
-			<span class="text-xs text-gray-500 ml-auto flex-shrink-0">
-				{keyCount} field{keyCount === 1 ? '' : 's'}
-			</span>
+		<div class={cardBase} data-testid="artifact-card-commit-ref">
+			{/* Commit icon */}
+			<svg
+				class="w-3.5 h-3.5 text-gray-500 flex-shrink-0 mt-0.5"
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+			>
+				<circle cx="12" cy="12" r="3" stroke-width={2} />
+				<path stroke-linecap="round" stroke-width={2} d="M12 3v6m0 6v6M3 12h6m6 0h6" />
+			</svg>
+			<div class="flex-1 min-w-0">
+				{url ? (
+					<a
+						href={url}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="text-xs font-mono text-blue-400 hover:text-blue-300"
+					>
+						{shortSha ?? 'commit'}
+					</a>
+				) : (
+					<span class="text-xs font-mono text-gray-400">{shortSha ?? 'commit'}</span>
+				)}
+				{message && <p class="text-xs text-gray-300 truncate mt-0.5">{message}</p>}
+				{author && <p class="text-xs text-gray-600 mt-0.5">{author}</p>}
+			</div>
+			<TypeBadge type={artifact.artifactType} />
 		</div>
 	);
+}
+
+function LinkCard({ artifact }: { artifact: WorkflowRunArtifact }) {
+	const { data } = artifact;
+	const url = typeof data.url === 'string' ? data.url : '';
+	const title = typeof data.title === 'string' ? data.title : url;
+
+	let hostname = '';
+	try {
+		hostname = new URL(url).hostname;
+	} catch {
+		hostname = url;
+	}
+
+	return (
+		<div class={cardBase} data-testid="artifact-card-link">
+			<svg
+				class="w-3.5 h-3.5 text-blue-400 flex-shrink-0 mt-0.5"
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width={2}
+					d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+				/>
+			</svg>
+			<div class="flex-1 min-w-0">
+				<a
+					href={url}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="text-xs text-blue-400 hover:text-blue-300 truncate block"
+				>
+					{title}
+				</a>
+				<p class="text-xs text-gray-600 font-mono mt-0.5 truncate">{hostname}</p>
+			</div>
+			<TypeBadge type={artifact.artifactType} />
+		</div>
+	);
+}
+
+function TerminalOutputCard({ artifact }: { artifact: WorkflowRunArtifact }) {
+	const { data } = artifact;
+	const output =
+		(typeof data.test_output === 'string' && data.test_output) ||
+		(typeof data.stdout === 'string' && data.stdout) ||
+		(typeof data.stderr === 'string' && data.stderr) ||
+		'';
+
+	const preview = output.split('\n').slice(0, 5).join('\n');
+	const truncated = output.split('\n').length > 5;
+
+	return (
+		<div
+			class="rounded border border-dark-600 bg-dark-800 overflow-hidden w-full"
+			data-testid="artifact-card-terminal"
+		>
+			<div class="flex items-center justify-between px-3 py-1.5 border-b border-dark-700 bg-dark-700/50">
+				<div class="flex items-center gap-1.5">
+					<svg
+						class="w-3.5 h-3.5 text-gray-500"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width={2}
+							d="M8 9l3 3-3 3m5 0h3"
+						/>
+					</svg>
+					<span class="text-xs text-gray-400">
+						{'test_output' in data ? 'Test output' : 'stdout' in data ? 'stdout' : 'stderr'}
+					</span>
+				</div>
+				<TypeBadge type={artifact.artifactType} />
+			</div>
+			<pre class="px-3 py-2 text-xs font-mono text-gray-300 overflow-x-auto whitespace-pre-wrap break-words">
+				{preview}
+				{truncated && <span class="text-gray-600">{'\n…'}</span>}
+			</pre>
+		</div>
+	);
+}
+
+function MarkdownCard({ artifact }: { artifact: WorkflowRunArtifact }) {
+	const summary = typeof artifact.data.summary === 'string' ? artifact.data.summary : '';
+
+	return (
+		<div
+			class="rounded border border-dark-600 bg-dark-700/50 px-3 py-2 w-full"
+			data-testid="artifact-card-markdown"
+		>
+			<div class="flex items-start justify-between gap-2 mb-1">
+				<TypeBadge type={artifact.artifactType} />
+			</div>
+			<p class="text-xs text-gray-300 whitespace-pre-wrap leading-relaxed">{summary}</p>
+		</div>
+	);
+}
+
+function StructuredTableCard({ artifact }: { artifact: WorkflowRunArtifact }) {
+	const entries = Object.entries(artifact.data);
+
+	return (
+		<div
+			class="rounded border border-dark-600 bg-dark-700/50 overflow-hidden w-full"
+			data-testid="artifact-card-table"
+		>
+			<div class="flex items-center justify-between px-3 py-1.5 border-b border-dark-700">
+				<span class="text-xs text-gray-500">
+					{entries.length} field{entries.length === 1 ? '' : 's'}
+				</span>
+				<TypeBadge type={artifact.artifactType} />
+			</div>
+			<table class="w-full text-xs">
+				<tbody>
+					{entries.map(([key, value]) => (
+						<tr key={key} class="border-b border-dark-700/50 last:border-0">
+							<td class="px-3 py-1.5 text-gray-500 font-mono align-top whitespace-nowrap w-1/3">
+								{key}
+							</td>
+							<td class="px-3 py-1.5 text-gray-300 break-all">
+								{value === null ? (
+									<span class="text-gray-600 italic">null</span>
+								) : typeof value === 'boolean' ? (
+									<span class={value ? 'text-green-400' : 'text-red-400'}>{String(value)}</span>
+								) : (
+									String(value)
+								)}
+							</td>
+						</tr>
+					))}
+				</tbody>
+			</table>
+		</div>
+	);
+}
+
+function GenericCard({ artifact }: { artifact: WorkflowRunArtifact }) {
+	const keyCount = Object.keys(artifact.data).length;
+	return (
+		<div class={cardBase} data-testid="artifact-card-generic">
+			<div class="flex-1 min-w-0">
+				{artifact.artifactKey && (
+					<p class="text-xs text-gray-500 font-mono truncate">{artifact.artifactKey}</p>
+				)}
+				<p class="text-xs text-gray-600">
+					{keyCount} field{keyCount === 1 ? '' : 's'}
+				</p>
+			</div>
+			<TypeBadge type={artifact.artifactType} />
+		</div>
+	);
+}
+
+// ── Public component ─────────────────────────────────────────────────────────
+
+interface ArtifactCardProps {
+	artifact: WorkflowRunArtifact;
 }
 
 export function ArtifactCard({ artifact }: ArtifactCardProps) {
-	switch (artifact.artifactType) {
+	const renderer = detectRenderer(artifact.data);
+
+	switch (renderer) {
 		case 'pr':
-			return <PrArtifactCard artifact={artifact} />;
+			return <PrCard artifact={artifact} />;
+		case 'commit-ref':
+			return <CommitRefCard artifact={artifact} />;
+		case 'link':
+			return <LinkCard artifact={artifact} />;
+		case 'terminal':
+			return <TerminalOutputCard artifact={artifact} />;
+		case 'markdown':
+			return <MarkdownCard artifact={artifact} />;
+		case 'table':
+			return <StructuredTableCard artifact={artifact} />;
 		default:
-			return <GenericArtifactCard artifact={artifact} />;
+			return <GenericCard artifact={artifact} />;
 	}
 }

--- a/packages/web/src/components/space/TaskArtifactsPanel.tsx
+++ b/packages/web/src/components/space/TaskArtifactsPanel.tsx
@@ -25,6 +25,26 @@ import {
 } from './thread/space-task-thread-events';
 
 // ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Returns a human-readable relative time string (e.g. "3m ago", "2h ago").
+ * Intentionally simple — no i18n dependency.
+ */
+function relativeTime(timestampMs: number): string {
+	const diffMs = Date.now() - timestampMs;
+	const diffSec = Math.floor(diffMs / 1_000);
+	if (diffSec < 60) return `${diffSec}s ago`;
+	const diffMin = Math.floor(diffSec / 60);
+	if (diffMin < 60) return `${diffMin}m ago`;
+	const diffHr = Math.floor(diffMin / 60);
+	if (diffHr < 24) return `${diffHr}h ago`;
+	const diffDays = Math.floor(diffHr / 24);
+	return `${diffDays}d ago`;
+}
+
+// ============================================================================
 // Types
 // ============================================================================
 
@@ -63,6 +83,7 @@ interface CommitsResult {
 	commits: CommitInfo[];
 	baseRef: string | null;
 	isGitRepo: boolean;
+	repoUrl?: string | null;
 }
 
 type PanelView =
@@ -615,65 +636,101 @@ export function TaskArtifactsPanel({
 										{!commitsData?.commits.length ? (
 											<p class="px-2 py-3 text-sm text-gray-500">No commits yet</p>
 										) : (
-											commitsData.commits.map((commit) => (
-												<button
-													key={commit.sha}
-													onClick={() => setView({ mode: 'commitFiles', commit })}
-													class={cn(
-														'w-full flex items-start gap-3 px-3 py-2 rounded text-left',
-														'hover:bg-dark-700 transition-colors group'
-													)}
-													data-testid="artifacts-commit-row"
-												>
-													<svg
-														class="w-3.5 h-3.5 text-gray-500 flex-shrink-0 mt-0.5"
-														fill="none"
-														viewBox="0 0 24 24"
-														stroke="currentColor"
+											commitsData.commits.map((commit) => {
+												const ghCommitUrl = commitsData.repoUrl
+													? `${commitsData.repoUrl}/commit/${commit.sha}`
+													: null;
+												const shortSha = commit.sha.slice(0, 7);
+												return (
+													<button
+														key={commit.sha}
+														onClick={() => setView({ mode: 'commitFiles', commit })}
+														class={cn(
+															'w-full flex items-start gap-3 px-3 py-2 rounded text-left',
+															'hover:bg-dark-700 transition-colors group'
+														)}
+														data-testid="artifacts-commit-row"
 													>
-														<circle cx="12" cy="12" r="3" stroke-width={2} />
-														<path
-															stroke-linecap="round"
-															stroke-width={2}
-															d="M12 3v6m0 6v6M3 12h6m6 0h6"
-														/>
-													</svg>
-													<div class="flex-1 min-w-0">
-														<p class="text-xs text-gray-300 truncate group-hover:text-gray-100">
-															{commit.message}
-														</p>
-														<p class="text-xs text-gray-600 font-mono mt-0.5">
-															{commit.sha.slice(0, 7)}
-															{commit.fileCount > 0 && (
-																<span class="ml-2 font-sans">
-																	{commit.fileCount} file{commit.fileCount === 1 ? '' : 's'}
-																</span>
+														<svg
+															class="w-3.5 h-3.5 text-gray-500 flex-shrink-0 mt-0.5"
+															fill="none"
+															viewBox="0 0 24 24"
+															stroke="currentColor"
+														>
+															<circle cx="12" cy="12" r="3" stroke-width={2} />
+															<path
+																stroke-linecap="round"
+																stroke-width={2}
+																d="M12 3v6m0 6v6M3 12h6m6 0h6"
+															/>
+														</svg>
+														<div class="flex-1 min-w-0">
+															<p class="text-xs text-gray-300 truncate group-hover:text-gray-100">
+																{commit.message}
+															</p>
+															<p class="text-xs text-gray-600 font-mono mt-0.5 flex items-center gap-1.5 flex-wrap">
+																{/* SHA — links to GitHub when repoUrl is available */}
+																{ghCommitUrl ? (
+																	<a
+																		href={ghCommitUrl}
+																		target="_blank"
+																		rel="noopener noreferrer"
+																		class="hover:text-blue-400 transition-colors"
+																		onClick={(e) => e.stopPropagation()}
+																		data-testid="artifacts-commit-sha-link"
+																	>
+																		{shortSha}
+																	</a>
+																) : (
+																	<span>{shortSha}</span>
+																)}
+																{commit.author && (
+																	<span
+																		class="font-sans text-gray-600 truncate"
+																		data-testid="artifacts-commit-author"
+																	>
+																		{commit.author}
+																	</span>
+																)}
+																{commit.timestamp > 0 && (
+																	<span
+																		class="font-sans text-gray-700"
+																		data-testid="artifacts-commit-time"
+																	>
+																		{relativeTime(commit.timestamp)}
+																	</span>
+																)}
+																{commit.fileCount > 0 && (
+																	<span class="font-sans">
+																		{commit.fileCount} file{commit.fileCount === 1 ? '' : 's'}
+																	</span>
+																)}
+															</p>
+														</div>
+														<span class="flex-shrink-0 flex items-center gap-1 text-xs font-mono">
+															{commit.additions > 0 && (
+																<span class="text-green-400">+{commit.additions}</span>
 															)}
-														</p>
-													</div>
-													<span class="flex-shrink-0 flex items-center gap-1 text-xs font-mono">
-														{commit.additions > 0 && (
-															<span class="text-green-400">+{commit.additions}</span>
-														)}
-														{commit.deletions > 0 && (
-															<span class="text-red-400">-{commit.deletions}</span>
-														)}
-													</span>
-													<svg
-														class="w-3 h-3 text-gray-600 flex-shrink-0 group-hover:text-gray-400 mt-0.5"
-														fill="none"
-														viewBox="0 0 24 24"
-														stroke="currentColor"
-													>
-														<path
-															stroke-linecap="round"
-															stroke-linejoin="round"
-															stroke-width={2}
-															d="M9 5l7 7-7 7"
-														/>
-													</svg>
-												</button>
-											))
+															{commit.deletions > 0 && (
+																<span class="text-red-400">-{commit.deletions}</span>
+															)}
+														</span>
+														<svg
+															class="w-3 h-3 text-gray-600 flex-shrink-0 group-hover:text-gray-400 mt-0.5"
+															fill="none"
+															viewBox="0 0 24 24"
+															stroke="currentColor"
+														>
+															<path
+																stroke-linecap="round"
+																stroke-linejoin="round"
+																stroke-width={2}
+																d="M9 5l7 7-7 7"
+															/>
+														</svg>
+													</button>
+												);
+											})
 										)}
 									</div>
 								)}

--- a/packages/web/src/components/space/__tests__/ArtifactCard.test.tsx
+++ b/packages/web/src/components/space/__tests__/ArtifactCard.test.tsx
@@ -1,0 +1,328 @@
+/**
+ * ArtifactCard — data-driven renderer tests.
+ *
+ * Verifies that the correct renderer is selected based on the shape of
+ * artifact.data, NOT the artifactType string.  Also checks that artifactType
+ * always appears as a badge regardless of which renderer is active.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/preact';
+import { ArtifactCard } from '../ArtifactCard';
+import type { WorkflowRunArtifact } from '@neokai/shared';
+
+function makeArtifact(
+	overrides: Partial<WorkflowRunArtifact> & { data: Record<string, unknown> }
+): WorkflowRunArtifact {
+	return {
+		id: 'art-1',
+		runId: 'run-1',
+		nodeId: 'node-1',
+		artifactType: 'result',
+		artifactKey: 'key',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	};
+}
+
+// ── PR card ──────────────────────────────────────────────────────────────────
+
+describe('ArtifactCard — PR renderer', () => {
+	it('renders artifact-card-pr when data.url is a GitHub PR URL', () => {
+		const artifact = makeArtifact({
+			data: { url: 'https://github.com/owner/repo/pull/42', number: 42, title: 'My PR' },
+		});
+		const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+		expect(getByTestId('artifact-card-pr')).toBeTruthy();
+	});
+
+	it('shows PR number and title from data fields', () => {
+		const artifact = makeArtifact({
+			data: { url: 'https://github.com/owner/repo/pull/7', number: 7, title: 'Fix bug' },
+		});
+		const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+		const card = getByTestId('artifact-card-pr');
+		expect(card.textContent).toContain('PR #7');
+		expect(card.textContent).toContain('Fix bug');
+	});
+
+	it('shows state badge when data.state is provided', () => {
+		const artifact = makeArtifact({
+			data: { url: 'https://github.com/owner/repo/pull/1', state: 'merged' },
+		});
+		const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+		expect(getByTestId('artifact-card-pr').textContent).toContain('merged');
+	});
+
+	it('shows artifactType badge on the PR card', () => {
+		const artifact = makeArtifact({
+			artifactType: 'pr',
+			data: { url: 'https://github.com/owner/repo/pull/1' },
+		});
+		const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+		expect(getByTestId('artifact-card-pr').textContent).toContain('pr');
+	});
+});
+
+// ── Commit reference card ─────────────────────────────────────────────────────
+
+describe('ArtifactCard — commit-ref renderer', () => {
+	it('renders artifact-card-commit-ref when data.url is a GitHub commit URL', () => {
+		const artifact = makeArtifact({
+			data: { url: 'https://github.com/owner/repo/commit/abc1234def5678' },
+		});
+		const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+		expect(getByTestId('artifact-card-commit-ref')).toBeTruthy();
+	});
+
+	it('shows short SHA from the URL', () => {
+		const artifact = makeArtifact({
+			data: { url: 'https://github.com/owner/repo/commit/abc1234def5678' },
+		});
+		const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+		expect(getByTestId('artifact-card-commit-ref').textContent).toContain('abc1234');
+	});
+
+	it('shows commit message and author when provided in data', () => {
+		const artifact = makeArtifact({
+			data: {
+				url: 'https://github.com/owner/repo/commit/abc1234def5678',
+				message: 'feat: do thing',
+				author: 'Alice',
+			},
+		});
+		const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+		const card = getByTestId('artifact-card-commit-ref');
+		expect(card.textContent).toContain('feat: do thing');
+		expect(card.textContent).toContain('Alice');
+	});
+
+	it('does NOT use commit-ref renderer for GitHub PR URLs (PR wins)', () => {
+		const artifact = makeArtifact({
+			data: { url: 'https://github.com/owner/repo/pull/99' },
+		});
+		const { getByTestId, queryByTestId } = render(<ArtifactCard artifact={artifact} />);
+		expect(getByTestId('artifact-card-pr')).toBeTruthy();
+		expect(queryByTestId('artifact-card-commit-ref')).toBeNull();
+	});
+});
+
+// ── Link card ─────────────────────────────────────────────────────────────────
+
+describe('ArtifactCard — link renderer', () => {
+	it('renders artifact-card-link for a non-GitHub URL', () => {
+		const artifact = makeArtifact({
+			data: { url: 'https://example.com/report' },
+		});
+		const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+		expect(getByTestId('artifact-card-link')).toBeTruthy();
+	});
+
+	it('shows custom title when provided', () => {
+		const artifact = makeArtifact({
+			data: { url: 'https://example.com/report', title: 'Full report' },
+		});
+		const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+		expect(getByTestId('artifact-card-link').textContent).toContain('Full report');
+	});
+
+	it('falls back to URL as title when title is absent', () => {
+		const artifact = makeArtifact({
+			data: { url: 'https://example.com/no-title' },
+		});
+		const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+		expect(getByTestId('artifact-card-link').textContent).toContain('example.com');
+	});
+
+	it('shows hostname in the card', () => {
+		const artifact = makeArtifact({
+			data: { url: 'https://docs.example.com/api' },
+		});
+		const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+		expect(getByTestId('artifact-card-link').textContent).toContain('docs.example.com');
+	});
+});
+
+// ── Terminal output card ──────────────────────────────────────────────────────
+
+describe('ArtifactCard — terminal renderer', () => {
+	it('renders artifact-card-terminal when data.stdout is present', () => {
+		const artifact = makeArtifact({
+			data: { stdout: 'hello world\n' },
+		});
+		const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+		expect(getByTestId('artifact-card-terminal')).toBeTruthy();
+	});
+
+	it('renders artifact-card-terminal when data.stderr is present', () => {
+		const artifact = makeArtifact({
+			data: { stderr: 'error: something failed\n' },
+		});
+		const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+		expect(getByTestId('artifact-card-terminal')).toBeTruthy();
+	});
+
+	it('renders artifact-card-terminal when data.test_output is present', () => {
+		const artifact = makeArtifact({
+			data: { test_output: 'PASS src/foo.test.ts\n' },
+		});
+		const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+		expect(getByTestId('artifact-card-terminal')).toBeTruthy();
+	});
+
+	it('shows first 5 lines of output as preview', () => {
+		const lines = ['line1', 'line2', 'line3', 'line4', 'line5', 'line6'];
+		const artifact = makeArtifact({
+			data: { stdout: lines.join('\n') },
+		});
+		const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+		const card = getByTestId('artifact-card-terminal');
+		expect(card.textContent).toContain('line1');
+		expect(card.textContent).toContain('line5');
+		// line6 is cut off; the truncation indicator appears
+		expect(card.textContent).toContain('…');
+	});
+});
+
+// ── Markdown card ─────────────────────────────────────────────────────────────
+
+describe('ArtifactCard — markdown renderer', () => {
+	it('renders artifact-card-markdown when data only has a summary string key', () => {
+		const artifact = makeArtifact({
+			data: { summary: 'This PR implements feature X, Y, Z.' },
+		});
+		const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+		expect(getByTestId('artifact-card-markdown')).toBeTruthy();
+	});
+
+	it('shows the summary text', () => {
+		const artifact = makeArtifact({
+			data: { summary: 'Deployment succeeded on prod.' },
+		});
+		const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+		expect(getByTestId('artifact-card-markdown').textContent).toContain(
+			'Deployment succeeded on prod.'
+		);
+	});
+
+	it('does NOT use markdown renderer when summary is one of several keys', () => {
+		// summary + another key → table renderer (all primitives)
+		const artifact = makeArtifact({
+			data: { summary: 'text', status: 'ok' },
+		});
+		const { getByTestId, queryByTestId } = render(<ArtifactCard artifact={artifact} />);
+		expect(queryByTestId('artifact-card-markdown')).toBeNull();
+		expect(getByTestId('artifact-card-table')).toBeTruthy();
+	});
+});
+
+// ── Structured table card ─────────────────────────────────────────────────────
+
+describe('ArtifactCard — table renderer', () => {
+	it('renders artifact-card-table when data has flat primitive key-value pairs', () => {
+		const artifact = makeArtifact({
+			data: { status: 'ok', count: 42, flag: true },
+		});
+		const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+		expect(getByTestId('artifact-card-table')).toBeTruthy();
+	});
+
+	it('shows all key-value pairs in the table', () => {
+		const artifact = makeArtifact({
+			data: { environment: 'production', version: '1.2.3' },
+		});
+		const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+		const card = getByTestId('artifact-card-table');
+		expect(card.textContent).toContain('environment');
+		expect(card.textContent).toContain('production');
+		expect(card.textContent).toContain('version');
+		expect(card.textContent).toContain('1.2.3');
+	});
+
+	it('renders boolean values', () => {
+		const artifact = makeArtifact({
+			data: { success: true, failed: false },
+		});
+		const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+		const card = getByTestId('artifact-card-table');
+		expect(card.textContent).toContain('true');
+		expect(card.textContent).toContain('false');
+	});
+
+	it('shows null values as "null"', () => {
+		const artifact = makeArtifact({
+			data: { missing: null },
+		});
+		const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+		expect(getByTestId('artifact-card-table').textContent).toContain('null');
+	});
+
+	it('does NOT use table renderer when data has nested objects', () => {
+		const artifact = makeArtifact({
+			data: { nested: { key: 'value' } },
+		});
+		const { getByTestId, queryByTestId } = render(<ArtifactCard artifact={artifact} />);
+		expect(queryByTestId('artifact-card-table')).toBeNull();
+		// Falls through to generic
+		expect(getByTestId('artifact-card-generic')).toBeTruthy();
+	});
+});
+
+// ── Generic fallback ──────────────────────────────────────────────────────────
+
+describe('ArtifactCard — generic renderer', () => {
+	it('renders artifact-card-generic for unrecognised data shapes', () => {
+		const artifact = makeArtifact({
+			data: { nested: { deep: 'value' }, arr: [1, 2, 3] },
+		});
+		const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+		expect(getByTestId('artifact-card-generic')).toBeTruthy();
+	});
+
+	it('shows artifactType badge on the generic card', () => {
+		const artifact = makeArtifact({
+			artifactType: 'custom_event',
+			data: { nested: { x: 1 } },
+		});
+		const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+		expect(getByTestId('artifact-card-generic').textContent).toContain('custom_event');
+	});
+});
+
+// ── Type badge visible on all renderers ──────────────────────────────────────
+
+describe('ArtifactCard — type badge always visible', () => {
+	const cases: Array<{ desc: string; data: Record<string, unknown>; testId: string }> = [
+		{
+			desc: 'PR renderer',
+			data: { url: 'https://github.com/o/r/pull/1' },
+			testId: 'artifact-card-pr',
+		},
+		{
+			desc: 'commit-ref renderer',
+			data: { url: 'https://github.com/o/r/commit/abc1234' },
+			testId: 'artifact-card-commit-ref',
+		},
+		{
+			desc: 'link renderer',
+			data: { url: 'https://example.com' },
+			testId: 'artifact-card-link',
+		},
+		{
+			desc: 'terminal renderer',
+			data: { stdout: 'output' },
+			testId: 'artifact-card-terminal',
+		},
+		{ desc: 'markdown renderer', data: { summary: 'text' }, testId: 'artifact-card-markdown' },
+		{ desc: 'table renderer', data: { k: 'v' }, testId: 'artifact-card-table' },
+	];
+
+	for (const { desc, data, testId } of cases) {
+		it(`shows artifactType badge on the ${desc}`, () => {
+			const artifact = makeArtifact({ artifactType: 'my_type', data });
+			const { getByTestId } = render(<ArtifactCard artifact={artifact} />);
+			expect(getByTestId(testId).textContent).toContain('my_type');
+		});
+	}
+});

--- a/packages/web/src/components/space/__tests__/TaskArtifactsPanel.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskArtifactsPanel.test.tsx
@@ -53,6 +53,7 @@ const COMMITS_RESULT = {
 	commits: [],
 	baseRef: null,
 	isGitRepo: true,
+	repoUrl: null,
 };
 
 function setupDefaultMocks() {
@@ -212,6 +213,7 @@ describe('TaskArtifactsPanel', () => {
 					],
 					baseRef: 'origin/dev',
 					isGitRepo: true,
+					repoUrl: null,
 				});
 			return Promise.resolve({});
 		});
@@ -221,6 +223,153 @@ describe('TaskArtifactsPanel', () => {
 			expect(getByTestId('artifacts-commits-list').textContent).toContain('feat: add feature')
 		);
 		expect(getByTestId('artifacts-commits-list').textContent).toContain('abc1234');
+	});
+
+	it('shows commit author in each commit row', async () => {
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'spaceWorkflowRun.getGateArtifacts')
+				return Promise.resolve(UNCOMMITTED_RESULT);
+			if (method === 'spaceWorkflowRun.getCommits')
+				return Promise.resolve({
+					commits: [
+						{
+							sha: 'abc1234',
+							message: 'feat: add feature',
+							author: 'Alice',
+							timestamp: Date.now(),
+							additions: 10,
+							deletions: 2,
+							fileCount: 3,
+						},
+					],
+					baseRef: 'origin/dev',
+					isGitRepo: true,
+					repoUrl: null,
+				});
+			return Promise.resolve({});
+		});
+
+		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />);
+		await waitFor(() =>
+			expect(getByTestId('artifacts-commits-list').textContent).toContain('Alice')
+		);
+		expect(
+			getByTestId('artifacts-commits-list').querySelector('[data-testid="artifacts-commit-author"]')
+				?.textContent
+		).toBe('Alice');
+	});
+
+	it('shows relative time in each commit row', async () => {
+		const recentTimestamp = Date.now() - 5 * 60 * 1000; // 5 minutes ago
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'spaceWorkflowRun.getGateArtifacts')
+				return Promise.resolve(UNCOMMITTED_RESULT);
+			if (method === 'spaceWorkflowRun.getCommits')
+				return Promise.resolve({
+					commits: [
+						{
+							sha: 'abc1234',
+							message: 'feat: add feature',
+							author: 'Alice',
+							timestamp: recentTimestamp,
+							additions: 0,
+							deletions: 0,
+							fileCount: 0,
+						},
+					],
+					baseRef: 'origin/dev',
+					isGitRepo: true,
+					repoUrl: null,
+				});
+			return Promise.resolve({});
+		});
+
+		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />);
+		await waitFor(() =>
+			expect(
+				getByTestId('artifacts-commits-list').querySelector('[data-testid="artifacts-commit-time"]')
+			).toBeTruthy()
+		);
+		const timeEl = getByTestId('artifacts-commits-list').querySelector(
+			'[data-testid="artifacts-commit-time"]'
+		);
+		// Should show something like "5m ago"
+		expect(timeEl?.textContent).toMatch(/\d+[smhd] ago/);
+	});
+
+	it('shows GitHub commit link when repoUrl is available', async () => {
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'spaceWorkflowRun.getGateArtifacts')
+				return Promise.resolve(UNCOMMITTED_RESULT);
+			if (method === 'spaceWorkflowRun.getCommits')
+				return Promise.resolve({
+					commits: [
+						{
+							sha: 'abc1234def5678',
+							message: 'feat: add feature',
+							author: 'Alice',
+							timestamp: Date.now(),
+							additions: 0,
+							deletions: 0,
+							fileCount: 0,
+						},
+					],
+					baseRef: 'origin/dev',
+					isGitRepo: true,
+					repoUrl: 'https://github.com/owner/repo',
+				});
+			return Promise.resolve({});
+		});
+
+		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />);
+		await waitFor(() =>
+			expect(
+				getByTestId('artifacts-commits-list').querySelector(
+					'[data-testid="artifacts-commit-sha-link"]'
+				)
+			).toBeTruthy()
+		);
+		const link = getByTestId('artifacts-commits-list').querySelector(
+			'[data-testid="artifacts-commit-sha-link"]'
+		) as HTMLAnchorElement;
+		expect(link.href).toContain('https://github.com/owner/repo/commit/abc1234def5678');
+		expect(link.textContent).toBe('abc1234');
+	});
+
+	it('does not show GitHub link when repoUrl is null', async () => {
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'spaceWorkflowRun.getGateArtifacts')
+				return Promise.resolve(UNCOMMITTED_RESULT);
+			if (method === 'spaceWorkflowRun.getCommits')
+				return Promise.resolve({
+					commits: [
+						{
+							sha: 'abc1234',
+							message: 'feat: add feature',
+							author: 'Alice',
+							timestamp: Date.now(),
+							additions: 0,
+							deletions: 0,
+							fileCount: 0,
+						},
+					],
+					baseRef: 'origin/dev',
+					isGitRepo: true,
+					repoUrl: null,
+				});
+			return Promise.resolve({});
+		});
+
+		const { getByTestId } = render(<TaskArtifactsPanel runId="run-1" onClose={vi.fn()} />);
+		await waitFor(() =>
+			expect(getByTestId('artifacts-commits-list').textContent).toContain('abc1234')
+		);
+		// No link element
+		expect(
+			getByTestId('artifacts-commits-list').querySelector(
+				'[data-testid="artifacts-commit-sha-link"]'
+			)
+		).toBeNull();
 	});
 
 	it('shows Files Touched section (not Commits) when isGitRepo is false', async () => {


### PR DESCRIPTION
## Summary

- **Data-driven ArtifactCard**: Rendering now dispatches on the shape of `artifact.data`, not the `artifactType` string. Seven renderers: PR card (GitHub PR URL), commit-ref (GitHub commit URL), link card (any URL), terminal output (`stdout`/`stderr`/`test_output` fields), markdown block (single `summary` key), structured table (flat key-value data), generic fallback. The `artifactType` string is shown as a small badge on every card.
- **`ArtifactType` → `string`**: Removes the narrow enum so any agent-chosen label is accepted without code changes.
- **Worktree commit display**: The `getCommits` RPC and background sync job now also run `git remote get-url origin` and return a `repoUrl` field. Commit rows in `TaskArtifactsPanel` show author name, relative time, and clickable SHA links to GitHub when `repoUrl` is available.
- **New helpers**: `getGitRemoteUrl` + `normalizeGithubUrl` in `artifact-git-ops.ts` handle both SSH and HTTPS GitHub remotes.
- **Tests**: 32 new `ArtifactCard` tests (every renderer + type badge), 4 new `TaskArtifactsPanel` tests (author, relative time, GitHub link, no-link fallback), extended `artifact-git-ops` tests for the new functions. All pass; two pre-existing unrelated failures in `ChatContainer.test.ts` and `SpaceIsland.test.tsx` (only when run together in full suite) are not caused by this PR.