### PR TITLE
feat(space): consolidate save/write_artifact/report_result into unified save_artifact

### DIFF
--- a/packages/daemon/src/lib/space/agents/task-agent.ts
+++ b/packages/daemon/src/lib/space/agents/task-agent.ts
@@ -15,7 +15,10 @@
  * The prompt references the following MCP tools by name. They must be registered
  * in the MCP server(s) composed with this agent's session at runtime:
  *
- *   - report_result         — Mark the task complete/failed and record the result summary
+ *   - save_artifact         — Append an audit record for this task (type, summary, optional data)
+ *   - list_artifacts        — List artifacts for the current workflow run
+ *   - approve_task          — Self-close the task as done (gated by autonomy level)
+ *   - submit_for_approval   — Request human sign-off instead of self-closing
  *   - request_human_input   — Surface a human gate and block until the user responds
  *   - list_group_members    — List all group members with completion state from space_tasks
  *   - send_message          — Send a message to peer node agents (string-based target)
@@ -24,7 +27,7 @@
  * Node agents have their own peer communication tools:
  *   - list_peers            — Discover peers and their completion state (queries space_tasks)
  *   - send_message          — Channel-validated messaging; auto-writes gate data when channel has a gate
- *   - save                  — Persist intermediate or final result data; does not change node status
+ *   - save_artifact         — Persist typed artifacts to the workflow run store; does not change node status
  *   - list_reachable_agents — Discover which agents/nodes are reachable and gate status
  *
  * ## Content interpolation
@@ -165,7 +168,7 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 			`1. Monitoring workflow activity via \`list_group_members\` (queries node execution state)\n` +
 			`2. Relaying intent/messages between human and workflow agents when needed\n` +
 			`3. Surfacing human gates encountered during agent communication via \`request_human_input\`\n` +
-			`4. Reporting unrecoverable outcomes via \`report_result\` only when cancellation/blocking is required`
+			`4. Recording outcomes via \`save_artifact\` and closing via \`approve_task\` or \`submit_for_approval\` when needed`
 	);
 	sections.push(
 		`\n## Critical Constraints\n` +
@@ -182,12 +185,21 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 	);
 	sections.push('');
 	sections.push(
-		`- **report_result** — Record the final result of the task. Pass a \`summary\` string and ` +
-			`optional structured \`evidence\` (\`prUrl\`, \`commitSha\`, \`testOutput\`, …). ` +
-			`Do NOT pass a \`status\` — the runtime decides the terminal task status by running the ` +
-			`completion-action pipeline on the end node. ` +
-			`Call this when the workflow reaches an unrecoverable error or you need to cancel. ` +
-			`Workflow completion is automatic — it triggers when the end node's session completes.`
+		`- **save_artifact** — Append an audit record for this task. ` +
+			`Pass \`type: "result"\`, \`append: true\`, and a \`summary\` string. ` +
+			`Optional: include structured \`data\` fields (\`prUrl\`, \`commitSha\`, \`testOutput\`, …). ` +
+			`Does NOT close the task — call \`approve_task\` or \`submit_for_approval\` to close.`
+	);
+	sections.push(
+		`- **approve_task** — Close this task as done. ` +
+			`Gated by \`space.autonomyLevel >= workflow.completionAutonomyLevel\`. ` +
+			`Call only when workflow execution is complete and you can self-close. ` +
+			`The runtime will return an error if the autonomy level is too low.`
+	);
+	sections.push(
+		`- **submit_for_approval** — Request human sign-off instead of self-closing. ` +
+			`Always available regardless of autonomy level. ` +
+			`Use when the task is risky, ambiguous, or autonomy rules block self-close.`
 	);
 	sections.push(
 		`- **request_human_input** — Surface a human gate and block until the human responds. ` +
@@ -213,7 +225,7 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 		`**Node agent tools (for reference):** Each spawned node agent also has access to: ` +
 			`\`list_peers\` (discover peers with completion state from node executions), ` +
 			`\`send_message\` (same string-based targeting; automatically writes gate data when the channel has a gate and \`data\` is provided), ` +
-			`\`save\` (persist intermediate or final result data without changing node status), and ` +
+			`\`save_artifact\` (persist typed artifacts to the workflow run store without changing node status), and ` +
 			`\`list_reachable_agents\` (discover reachable agents and cross-node gate status). ` +
 			`Node agents drive their own progression — you do not need to manually route messages between them.`
 	);
@@ -241,10 +253,10 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 			`system automatically marks the workflow run and main task as completed. You do not need to ` +
 			`call any completion tool — just wait for the \`[NODE_COMPLETE]\` event from the end node. ` +
 			`Use \`list_group_members\` to verify all agents have reached idle status if needed. ` +
-			`Only call \`report_result\` if you need to cancel or signal an unrecoverable error.\n` +
-			`6. **Handle errors** — If a node agent errors, call \`report_result\` with a \`summary\` ` +
-			`describing what went wrong. The runtime will classify the task based on the ` +
-			`completion-action pipeline; you do not control the final status.`
+			`Only call \`save_artifact\` + \`approve_task\`/\`submit_for_approval\` if you need to cancel or signal an unrecoverable error.\n` +
+			`6. **Handle errors** — If a node agent errors, call \`save_artifact({ type: "result", append: true, summary: "..." })\` ` +
+			`to record what went wrong, then \`submit_for_approval\` to escalate to human review. ` +
+			`The runtime will classify the task based on the completion-action pipeline; you do not control the final status.`
 	);
 
 	// ---- Human gate handling -------------------------------------------------
@@ -280,7 +292,7 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 			`\`request_human_input\` — do not silently deviate from the workflow.\n`
 	);
 	sections.push(
-		`4. **Report results accurately.** When calling \`report_result\`, include a factual ` +
+		`4. **Record results accurately.** When calling \`save_artifact\`, include a factual ` +
 			`summary of what was accomplished. Do not embellish or speculate.\n`
 	);
 	sections.push(

--- a/packages/daemon/src/lib/space/index.ts
+++ b/packages/daemon/src/lib/space/index.ts
@@ -92,14 +92,14 @@ export type {
 
 export {
 	TASK_AGENT_TOOL_SCHEMAS,
-	ReportResultSchema,
 	RequestHumanInputSchema,
-	TaskResultStatusSchema,
+	ApproveTaskSchema,
+	SubmitForApprovalSchema,
 } from './tools/task-agent-tool-schemas';
 export type {
-	ReportResultInput,
 	RequestHumanInputInput,
-	TaskResultStatus,
+	ApproveTaskInput,
+	SubmitForApprovalInput,
 	TaskAgentToolName,
 } from './tools/task-agent-tool-schemas';
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -116,11 +116,11 @@ export interface TaskAgentManagerConfig {
 	/** Task repository — direct DB reads */
 	taskRepo: SpaceTaskRepository;
 	/**
-	 * Append-only audit log for `report_result` tool calls from end-node agents.
-	 * Every `report_result` invocation writes one row here — the table is the
-	 * source of truth for "what did the agent observe", independent of the
-	 * task's reported/terminal status. Task #39: this separation is what keeps
-	 * Coding↔Review loops from closing on review feedback.
+	 * Append-only audit log repository for historical `report_result` rows.
+	 * No longer used by active tool handlers (report_result was removed in favor
+	 * of save_artifact). Kept for backward compatibility with callers; existing
+	 * rows in the space_task_report_results table remain as historical data.
+	 * @deprecated Tool handlers no longer write to this table.
 	 */
 	taskReportResultRepo: SpaceTaskReportResultRepository;
 	/** Workflow run repository — reading and updating runs */
@@ -548,7 +548,6 @@ export class TaskAgentManager {
 				space,
 				workflowRunId,
 				taskRepo: this.config.taskRepo,
-				taskReportResultRepo: this.config.taskReportResultRepo,
 				nodeExecutionRepo: this.config.nodeExecutionRepo,
 				taskManager,
 				messageInjector: (subSessionId, message) =>
@@ -568,6 +567,7 @@ export class TaskAgentManager {
 				pendingMessageRepo: this.config.pendingMessageRepo,
 				spaceAgentInjector: this.config.spaceAgentInjector,
 				taskAgentManager: this,
+				artifactRepo: this.config.artifactRepo,
 			});
 
 			// setRuntimeMcpServers expects McpServerConfig but the MCP SDK's `Server`
@@ -1785,17 +1785,15 @@ export class TaskAgentManager {
 		const requiredLevel = workflow?.completionAutonomyLevel ?? 5;
 		const approveUnlocked = spaceLevel >= requiredLevel;
 
-		// Design v2 end-node tool contract (Task #39):
-		//   - report_result: append-only audit — does NOT close the task.
-		//   - approve_task : self-close (autonomy-gated).
-		//   - submit_for_approval: human sign-off (always available).
+		// End-node tool contract:
+		//   - save_artifact: persist typed data to artifact store (all node agents).
+		//   - approve_task : self-close (autonomy-gated, end-node only).
+		//   - submit_for_approval: human sign-off (always available, end-node only).
 		// Keep these strings in sync with `node-agent-tools.ts` and
 		// `task-agent-manager.ts` where the handlers live.
 		const endNodeContractLines = (indent: string): string[] => {
 			if (!isEndNode) return [];
-			const lines = [
-				`${indent}- report_result({ summary, evidence? }) — APPEND-ONLY AUDIT. Records what you observed; does NOT close the task. Every call is a new entry.`,
-			];
+			const lines: string[] = [];
 			if (approveUnlocked) {
 				lines.push(
 					`${indent}- approve_task({}) — Close this task as done (self-approval). Unlocked for this space (autonomy ${spaceLevel} >= required ${requiredLevel}). Use as your FINAL action when you are satisfied the work is complete.`
@@ -1816,8 +1814,9 @@ export class TaskAgentManager {
 			`Role: "${execution.agentName}"`,
 			'Tools available:',
 			'  - send_message({ target, message, data? }) — communicate with peers; data is automatically written to the gate when the channel is gated',
-			'  - save({ summary?, data? }) — persist your output at any time (call multiple times as needed)',
+			'  - save_artifact({ type, key?, append?, summary?, data? }) — persist typed data to the artifact store at any time. Use type="progress" for rolling status, type="result" for final outcomes.',
 			...endNodeContractLines('  '),
+			'  - list_artifacts({ nodeId?, type? }) — list artifacts for the current workflow run',
 			'  - restore_node_agent({ reason? }) — self-heal fallback: if a previous mcp__node-agent__* call returned "No such tool available", call this once and then retry the original tool',
 			'Only contact the task-agent via send_message if you are blocked or need human input.',
 		].join('\n');
@@ -1848,8 +1847,9 @@ export class TaskAgentManager {
 			`Agent: "${execution.agentName}"`,
 			'Tools available:',
 			'  - send_message({ target, message, data? }) — communicate with peers; when a channel is gated, `data` is automatically merged into the gate',
-			'  - save({ summary?, data? }) — persist your output (summary text and/or structured data like pr_url)',
+			'  - save_artifact({ type, key?, append?, summary?, data? }) — persist typed data to the artifact store. Use type="progress" for rolling status, type="result" for final outcomes.',
 			...endNodeContractLines('  '),
+			'  - list_artifacts({ nodeId?, type? }) — list artifacts for the current workflow run',
 			'  - list_peers / list_reachable_agents / list_channels / list_gates / read_gate — discovery',
 			'  - restore_node_agent({ reason? }) — self-heal fallback: if a previous mcp__node-agent__* call ever returned "No such tool available", call this once and then retry the original tool',
 		];
@@ -1897,16 +1897,13 @@ export class TaskAgentManager {
 			'Only contact the task-agent via send_message if you are blocked or need human input.'
 		);
 		if (isEndNode) {
-			// Closure guidance: record audit first (report_result), then finalize
-			// via the appropriate tool. This replaces the old (incorrect) guidance
-			// that said report_result closes the run.
 			if (approveUnlocked) {
 				lines.push(
-					'When your work is complete: (1) call report_result({ summary, evidence? }) to record the outcome, then (2) call approve_task({}) as your FINAL action to close the task. The runtime — not your report — decides the terminal status via completion actions.'
+					'When your work is complete: (1) call save_artifact({ type: "result", append: true, summary: "..." }) to record the outcome, then (2) call approve_task({}) as your FINAL action to close the task. The runtime — not your artifact — decides the terminal status via completion actions.'
 				);
 			} else {
 				lines.push(
-					'When your work is complete: (1) call report_result({ summary, evidence? }) to record the outcome, then (2) call submit_for_approval({ reason: "..." }) as your FINAL action. approve_task is NOT available at this autonomy level; only a human can finalize.'
+					'When your work is complete: (1) call save_artifact({ type: "result", append: true, summary: "..." }) to record the outcome, then (2) call submit_for_approval({ reason: "..." }) as your FINAL action. approve_task is NOT available at this autonomy level; only a human can finalize.'
 				);
 			}
 		}
@@ -2117,7 +2114,6 @@ export class TaskAgentManager {
 			space,
 			workflowRunId: rehydrateWorkflowRunId,
 			taskRepo: this.config.taskRepo,
-			taskReportResultRepo: this.config.taskReportResultRepo,
 			nodeExecutionRepo: this.config.nodeExecutionRepo,
 			taskManager,
 			messageInjector: (subSessionId, message) =>
@@ -2137,6 +2133,7 @@ export class TaskAgentManager {
 			pendingMessageRepo: this.config.pendingMessageRepo,
 			spaceAgentInjector: this.config.spaceAgentInjector,
 			taskAgentManager: this,
+			artifactRepo: this.config.artifactRepo,
 		});
 
 		// Merge registry-sourced MCP servers alongside the in-process task-agent server,
@@ -2671,16 +2668,13 @@ export class TaskAgentManager {
 			? this.buildAgentNameAliasesForExecution(workflow, execution)
 			: this.agentNameVariants(agentName);
 
-		// Design v2 tool contract (Task #39):
-		//   `report_result`      — append-only audit. Does NOT close the task.
+		// End-node tool contract:
+		//   `save_artifact`      — persist typed data to artifact store (available to all node agents).
 		//   `approve_task`       — closes the task as done (self-approval). Gated
 		//                          by `space.autonomyLevel >= workflow.completionAutonomyLevel`.
+		//                          Only available to end-node agents.
 		//   `submit_for_approval` — request human review of completion.
-		//
-		// The previous behaviour where `report_result` set `reportedStatus='done'`
-		// caused cycle-graphs like Coding↔Review to close the moment the Reviewer
-		// reported feedback. Splitting audit from closure restores the intended
-		// iterative semantics.
+		//                           Only available to end-node agents.
 		const isEndNode = !!workflow?.endNodeId && workflowNodeId === workflow.endNodeId;
 		const endNodeHandlers = isEndNode
 			? createEndNodeHandlers({
@@ -2690,12 +2684,10 @@ export class TaskAgentManager {
 					workflowNodeId,
 					agentName,
 					taskRepo: this.config.taskRepo,
-					taskReportResultRepo: this.config.taskReportResultRepo,
 					spaceManager: this.config.spaceManager,
 					daemonHub: this.config.daemonHub,
 				})
 			: undefined;
-		const onReportResult = endNodeHandlers?.onReportResult;
 		const onApproveTask = endNodeHandlers?.onApproveTask;
 		const onSubmitForApproval = endNodeHandlers?.onSubmitForApproval;
 
@@ -2761,7 +2753,6 @@ export class TaskAgentManager {
 				gateId: '',
 				workflowStartIso: run ? new Date(run.createdAt).toISOString() : undefined,
 			},
-			onReportResult,
 			onApproveTask,
 			onSubmitForApproval,
 			artifactRepo: this.config.artifactRepo,

--- a/packages/daemon/src/lib/space/tools/end-node-handlers.ts
+++ b/packages/daemon/src/lib/space/tools/end-node-handlers.ts
@@ -1,8 +1,7 @@
 /**
- * End-node tool handlers (Design v2 — Task #39).
+ * End-node tool handlers.
  *
- * Factory for the three "terminal" MCP tool handlers exposed to end-node agents:
- *   - report_result       — APPEND-ONLY audit. Does NOT mutate task state.
+ * Factory for the two "terminal" MCP tool handlers exposed to end-node agents:
  *   - approve_task        — Agent self-close. Gated by space.autonomyLevel >=
  *                           workflow.completionAutonomyLevel.
  *   - submit_for_approval — Request human sign-off. Always available.
@@ -13,29 +12,25 @@
  * manager focused on orchestration.
  *
  * Contract notes:
- *   - All three handlers return a `ToolResult` (never throw).
- *   - `onReportResult` never touches `reportedStatus`; splitting audit from
- *     closure is the whole point of the refactor.
+ *   - Both handlers return a `ToolResult` (never throw).
  *   - `onApproveTask` re-checks autonomy at call time as defense-in-depth;
  *     tool registration already gates the surface, but a racing autonomy-level
  *     downgrade between registration and invocation would otherwise slip
  *     through.
  *   - `onSubmitForApproval` sets `status='review'` plus pending-completion
  *     fields so the UI banner can route a human to approve/reject.
+ *
+ * Note: The `report_result` (append-only audit) handler was removed. Use
+ * `save_artifact({ type: 'result', append: true, ... })` instead.
  */
 
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
-import type { SpaceTaskReportResultRepository } from '../../../storage/repositories/space-task-report-result-repository';
 import type { SpaceManager } from '../managers/space-manager';
 import type { DaemonHub } from '../../daemon-hub';
 import type { SpaceTask, SpaceWorkflow } from '@neokai/shared';
 import type { ToolResult } from './tool-result';
 import { jsonResult } from './tool-result';
-import type {
-	ApproveTaskInput,
-	ReportResultInput,
-	SubmitForApprovalInput,
-} from './task-agent-tool-schemas';
+import type { ApproveTaskInput, SubmitForApprovalInput } from './task-agent-tool-schemas';
 import { Logger } from '../../logger';
 
 const log = new Logger('end-node-handlers');
@@ -52,14 +47,12 @@ export interface EndNodeHandlerDeps {
 	spaceId: string;
 	/** Workflow the task was executed under. Needed for completionAutonomyLevel. */
 	workflow: SpaceWorkflow | null;
-	/** Workflow node ID of the calling agent — stored for audit + pending fields. */
+	/** Workflow node ID of the calling agent — stored for pending fields. */
 	workflowNodeId: string;
-	/** Agent name calling the tool — written to the audit log. */
+	/** Agent name calling the tool — for logging. */
 	agentName: string;
 	/** Task repository. */
 	taskRepo: SpaceTaskRepository;
-	/** Append-only report result repository (used by report_result). */
-	taskReportResultRepo: SpaceTaskReportResultRepository;
 	/** Space manager — used to look up current autonomy level for approve_task. */
 	spaceManager: Pick<SpaceManager, 'getSpace'>;
 	/** Optional hub for emitting `space.task.updated` events after state changes. */
@@ -67,28 +60,17 @@ export interface EndNodeHandlerDeps {
 }
 
 export interface EndNodeHandlers {
-	onReportResult: (args: ReportResultInput) => Promise<ToolResult>;
 	onApproveTask: (args: ApproveTaskInput) => Promise<ToolResult>;
 	onSubmitForApproval: (args: SubmitForApprovalInput) => Promise<ToolResult>;
 }
 
 /**
- * Create the three end-node tool handlers bound to a specific task/workflow/
+ * Create the two end-node tool handlers bound to a specific task/workflow/
  * agent context. The returned handlers are pure closures — repeated calls
  * with the same `deps` return independent instances.
  */
 export function createEndNodeHandlers(deps: EndNodeHandlerDeps): EndNodeHandlers {
-	const {
-		taskId,
-		spaceId,
-		workflow,
-		workflowNodeId,
-		agentName,
-		taskRepo,
-		taskReportResultRepo,
-		spaceManager,
-		daemonHub,
-	} = deps;
+	const { taskId, spaceId, workflow, workflowNodeId, taskRepo, spaceManager, daemonHub } = deps;
 
 	const emitTaskUpdated = (task: SpaceTask): void => {
 		if (!daemonHub) return;
@@ -102,37 +84,6 @@ export function createEndNodeHandlers(deps: EndNodeHandlerDeps): EndNodeHandlers
 	};
 
 	return {
-		// -------------------------------------------------------------------
-		// report_result — APPEND-ONLY. Never mutates task state.
-		// -------------------------------------------------------------------
-		onReportResult: async (args: ReportResultInput) => {
-			const task = taskRepo.getTask(taskId);
-			if (!task) return jsonResult({ success: false, error: `Task not found: ${taskId}` });
-
-			try {
-				taskReportResultRepo.append({
-					taskId,
-					spaceId,
-					workflowNodeId,
-					agentName,
-					summary: args.summary,
-					evidence: args.evidence ?? null,
-				});
-				return jsonResult({
-					success: true,
-					taskId,
-					summary: args.summary,
-					message:
-						'Result recorded to audit log. This does NOT close the task — call approve_task (if available) or submit_for_approval to finalize.',
-				});
-			} catch (err) {
-				return jsonResult({
-					success: false,
-					error: err instanceof Error ? err.message : String(err),
-				});
-			}
-		},
-
 		// -------------------------------------------------------------------
 		// approve_task — self-close. Re-checks autonomy at call time.
 		// -------------------------------------------------------------------

--- a/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
@@ -3,10 +3,11 @@
  * tools available to node agent sub-sessions.
  *
  * Action tools:
- *   send_message — channel-validated direct messaging; writes gate data on gated channels
- *   save         — persist agent output (summary + structured data) to NodeExecution
+ *   send_message    — channel-validated direct messaging; writes gate data on gated channels
+ *   save_artifact   — persist typed data to the workflow run artifact store (replaces save/write_artifact)
  *
  * Discovery tools (read-only):
+ *   list_artifacts       — list artifacts for the current workflow run
  *   list_peers           — list other group members with statuses and permitted channels
  *   list_reachable_agents — list all reachable agents/nodes grouped by proximity
  *   list_channels        — list all channels declared in the workflow
@@ -87,41 +88,75 @@ export const SendMessageSchema = z.object({
 export type SendMessageInput = z.infer<typeof SendMessageSchema>;
 
 // ---------------------------------------------------------------------------
-// save
+// save_artifact
 // ---------------------------------------------------------------------------
 
 /**
- * Schema for `save` input.
+ * Schema for `save_artifact` input.
  *
- * Persists the agent's output to the NodeExecution record.
- * Call this whenever you have produced output worth recording — at any point
- * during your work, not just at the end. Multiple calls overwrite previous values.
+ * Persists data to the workflow run artifact store. Replaces the old `save` and
+ * `write_artifact` tools with a unified interface.
  *
- * `summary` and `data` are independent — provide either or both.
+ * Two modes:
+ *   - Overwrite mode (default, `append: false`): upsert on `(nodeId, type, key)`.
+ *     Writing the same (type, key) replaces the previous value. Use for progress
+ *     tracking, current state, or any data with at most one active record.
+ *   - Append mode (`append: true`): always inserts a new row. Key is auto-generated
+ *     if not provided. Use for audit trails, cycle records, multi-round reviews, etc.
+ *
+ * `type` is fully generic — no built-in enum. Use any label that makes sense:
+ *   'progress', 'result', 'review', 'pr', 'test_result', 'my-custom-type', etc.
  */
-export const SaveSchema = z.object({
+export const SaveArtifactSchema = z.object({
 	/**
-	 * Human-readable summary of work completed so far.
-	 * Overwrites any previous summary on each call.
+	 * Category tag for organizing artifacts. Fully generic — no built-in enum.
+	 * Use whatever labels make sense for your workflow.
+	 * Examples: 'progress', 'result', 'review', 'pr', 'test_result', 'commit'
 	 */
-	summary: z
+	type: z
 		.string()
-		.describe('Human-readable summary of work completed. Overwrites previous summary.')
-		.optional(),
+		.min(1)
+		.describe(
+			"Category tag for organizing artifacts. Fully generic — use whatever makes sense. Examples: 'progress', 'result', 'review', 'pr'"
+		),
 	/**
-	 * Structured output data (key-value pairs) produced by this agent.
+	 * Unique key within (node, type) for deduplication.
+	 * Same (type, key) = overwrite (upsert). Different key = new record.
+	 * Defaults to empty string. When `append: true`, key is auto-generated.
+	 */
+	key: z
+		.string()
+		.describe(
+			"Unique key within (node, type). Same (type, key) = overwrite. Use 'current' for a single live record. Ignored in append mode (key is auto-generated)."
+		)
+		.default(''),
+	/**
+	 * Append mode: when true, always inserts a new row regardless of key.
+	 * Key is auto-generated to guarantee uniqueness. Use for audit trails
+	 * (multi-round reviews, cycle records, progress history).
+	 * Default: false (overwrite/upsert mode).
+	 */
+	append: z
+		.boolean()
+		.describe(
+			'If true, always inserts a new row (append-only). Key is auto-generated. Use for audit trails. Default: false (upsert/overwrite mode).'
+		)
+		.default(false),
+	/** Human-readable summary of the content. */
+	summary: z.string().describe('Human-readable summary of the content or work status.').optional(),
+	/**
+	 * Structured key-value data payload.
 	 * Use for machine-readable artifacts: pr_url, commit_sha, test_results, etc.
-	 * Overwrites previous data on each call.
 	 */
 	data: z
 		.record(z.string(), z.unknown())
 		.describe(
-			'Structured output data (key-value pairs). Use for artifacts like pr_url, commit_sha, test_results. Overwrites previous data.'
+			'Structured key-value data payload. Use for machine-readable artifacts: pr_url, commit_sha, test_results, etc.'
 		)
 		.optional(),
 });
 
-export type SaveInput = z.infer<typeof SaveSchema>;
+export type SaveArtifactInput = z.infer<typeof SaveArtifactSchema>;
 
 // ---------------------------------------------------------------------------
 // list_reachable_agents
@@ -179,38 +214,6 @@ export const ReadGateSchema = z.object({
 export type ReadGateInput = z.infer<typeof ReadGateSchema>;
 
 // ---------------------------------------------------------------------------
-// ---------------------------------------------------------------------------
-// write_artifact
-// ---------------------------------------------------------------------------
-
-/**
- * Schema for `write_artifact` input.
- * Writes a typed artifact (PR, commit set, test result, etc.) to the workflow run.
- * Uses upsert semantics — writing the same (type, key) pair overwrites previous data.
- */
-export const WriteArtifactSchema = z.object({
-	/** Type of artifact: pr, commit_set, test_result, deployment */
-	artifactType: z
-		.enum(['pr', 'commit_set', 'test_result', 'deployment'])
-		.describe('Type of artifact: pr, commit_set, test_result, deployment'),
-	/** Unique key within (node, type) for dedup. Defaults to empty string. */
-	artifactKey: z
-		.string()
-		.describe(
-			'Unique key within (node, type) for dedup — e.g. "main" for the primary PR. Defaults to empty.'
-		)
-		.default(''),
-	/** Artifact payload. Shape depends on artifactType. */
-	data: z
-		.record(z.string(), z.unknown())
-		.describe(
-			'Artifact payload. For pr: { url, number, title, state, headBranch }. For commit_set: { commits: [...] }.'
-		),
-});
-
-export type WriteArtifactInput = z.infer<typeof WriteArtifactSchema>;
-
-// ---------------------------------------------------------------------------
 // list_artifacts
 // ---------------------------------------------------------------------------
 
@@ -221,8 +224,11 @@ export type WriteArtifactInput = z.infer<typeof WriteArtifactSchema>;
 export const ListArtifactsSchema = z.object({
 	/** Filter by originating node ID. */
 	nodeId: z.string().describe('Filter by node ID').optional(),
-	/** Filter by artifact type. */
-	artifactType: z.string().describe('Filter by artifact type').optional(),
+	/** Filter by artifact type (generic string, e.g. 'progress', 'result', 'review'). */
+	type: z
+		.string()
+		.describe('Filter by artifact type (e.g. "progress", "result", "review")')
+		.optional(),
 });
 
 export type ListArtifactsInput = z.infer<typeof ListArtifactsSchema>;
@@ -269,13 +275,12 @@ export type RestoreNodeAgentInput = z.infer<typeof RestoreNodeAgentSchema>;
 export const NODE_AGENT_TOOL_SCHEMAS = {
 	list_peers: ListPeersSchema,
 	send_message: SendMessageSchema,
-	save: SaveSchema,
+	save_artifact: SaveArtifactSchema,
+	list_artifacts: ListArtifactsSchema,
 	list_reachable_agents: ListReachableAgentsSchema,
 	list_channels: ListChannelsSchema,
 	list_gates: ListGatesSchema,
 	read_gate: ReadGateSchema,
-	write_artifact: WriteArtifactSchema,
-	list_artifacts: ListArtifactsSchema,
 	restore_node_agent: RestoreNodeAgentSchema,
 } as const;
 

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -2,10 +2,11 @@
  * Node Agent Tools — MCP tool handlers for node agent sub-sessions.
  *
  * Action tools:
- *   send_message — channel-validated direct messaging; auto-writes gate data on gated channels
- *   save         — persist agent output (summary + structured data) to NodeExecution
+ *   send_message   — channel-validated direct messaging; auto-writes gate data on gated channels
+ *   save_artifact  — persist typed data to the workflow run artifact store
  *
  * Discovery tools (read-only):
+ *   list_artifacts        — list artifacts for the current workflow run
  *   list_peers            — discover other group members with agent names and permitted channels
  *   list_reachable_agents — list all reachable agents/nodes grouped by proximity
  *   list_channels         — list all channels declared in the workflow
@@ -16,8 +17,9 @@
  * - Node agents communicate via declared channel topology (`send_message`).
  * - When a channel is gated, the `data` payload in `send_message` is automatically
  *   merged into the gate's data store — no separate write_gate call needed.
- * - `save` stores the agent's result summary and structured output on NodeExecution
- *   for Task Agent visibility.
+ * - `save_artifact` stores typed artifacts in the workflow run artifact table.
+ *   Progress updates: `save_artifact({ type: 'progress', key: 'current', summary: '...' })`
+ *   Audit records: `save_artifact({ type: 'result', append: true, summary: '...' })`
  *
  * Design:
  * - Handlers are pure functions tested independently of any MCP server layer.
@@ -27,16 +29,8 @@
 
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import type { DaemonHub } from '../../daemon-hub';
-import {
-	ReportResultSchema,
-	ApproveTaskSchema,
-	SubmitForApprovalSchema,
-} from './task-agent-tool-schemas';
-import type {
-	ReportResultInput,
-	ApproveTaskInput,
-	SubmitForApprovalInput,
-} from './task-agent-tool-schemas';
+import { ApproveTaskSchema, SubmitForApprovalSchema } from './task-agent-tool-schemas';
+import type { ApproveTaskInput, SubmitForApprovalInput } from './task-agent-tool-schemas';
 import { Logger } from '../../logger';
 import type { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
 import { ChannelResolver } from '../runtime/channel-resolver';
@@ -54,25 +48,23 @@ import type { ToolResult } from './tool-result';
 import {
 	ListPeersSchema,
 	SendMessageSchema,
-	SaveSchema,
+	SaveArtifactSchema,
+	ListArtifactsSchema,
 	ListReachableAgentsSchema,
 	ListChannelsSchema,
 	ListGatesSchema,
 	ReadGateSchema,
-	WriteArtifactSchema,
-	ListArtifactsSchema,
 	RestoreNodeAgentSchema,
 } from './node-agent-tool-schemas';
 import type {
 	ListPeersInput,
 	SendMessageInput,
-	SaveInput,
+	SaveArtifactInput,
+	ListArtifactsInput,
 	ListReachableAgentsInput,
 	ListChannelsInput,
 	ListGatesInput,
 	ReadGateInput,
-	WriteArtifactInput,
-	ListArtifactsInput,
 	RestoreNodeAgentInput,
 } from './node-agent-tool-schemas';
 import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
@@ -106,7 +98,7 @@ export interface NodeAgentToolsConfig {
 	myAgentNameAliases?: string[];
 	/** ID of the parent task (used for error messages). */
 	taskId: string;
-	/** Space ID — used for event emission in report_result. */
+	/** Space ID — used for event emission. */
 	spaceId: string;
 	/**
 	 * Pre-built channel resolver for this sub-session's topology.
@@ -119,7 +111,7 @@ export interface NodeAgentToolsConfig {
 	/** Workflow node ID — used to query peer executions on the same node. */
 	workflowNodeId: string;
 	/**
-	 * Node execution repository for report_result, list_peers, and send_message peer resolution.
+	 * Node execution repository for list_peers and send_message peer resolution.
 	 */
 	nodeExecutionRepo: NodeExecutionRepository;
 	/**
@@ -165,14 +157,6 @@ export interface NodeAgentToolsConfig {
 	 */
 	scriptContext?: GateScriptExecutorContext;
 	/**
-	 * Optional callback for the `report_result` tool.
-	 * When provided, a `report_result` tool is added to the MCP server —
-	 * intended for the end node of a workflow so it can append an audit record
-	 * of what it observed. Design v2: this call does NOT close the task.
-	 * When absent, `report_result` is not available to this node agent.
-	 */
-	onReportResult?: (args: ReportResultInput) => Promise<ToolResult>;
-	/**
 	 * Optional callback for the `approve_task` tool. When provided, `approve_task`
 	 * is added to the MCP server. Intended for the end node when
 	 * `space.autonomyLevel >= workflow.completionAutonomyLevel`. The handler
@@ -194,7 +178,7 @@ export interface NodeAgentToolsConfig {
 	 */
 	getSpaceAutonomyLevel?: (spaceId: string) => Promise<number>;
 	/**
-	 * Workflow run artifact repository for write_artifact / list_artifacts tools.
+	 * Workflow run artifact repository for save_artifact / list_artifacts tools.
 	 * Optional — when absent, artifact tools are not registered.
 	 */
 	artifactRepo?: WorkflowRunArtifactRepository;
@@ -255,14 +239,35 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 		 * Always includes `task-agent` as a reachable coordinator target.
 		 *
 		 * Returns permittedTargets: agent names this agent can directly send to via send_message.
-		 * Returns completionState per peer: execution status, completion summary, and completedAt.
+		 * Returns completionState per peer: execution status, latest progress summary, and completedAt.
 		 * Returns nodeCompletionState: all executions on this workflow node with their completion state.
+		 *
+		 * Progress summary is sourced from the latest 'progress' type artifact for the node
+		 * (written via save_artifact({ type: 'progress', ... })). Falls back to ne.result for
+		 * historical rows that predate the artifact migration.
 		 */
 		async list_peers(_args: ListPeersInput): Promise<ToolResult> {
 			const resolver = channelResolver;
 			const nodeExecs = workflowRunId
 				? nodeExecutionRepo.listByNode(workflowRunId, workflowNodeId)
 				: [];
+
+			// Fetch the latest progress artifact for this node so we can surface it in
+			// completionState. All agents in the same node share the same nodeId, so we
+			// read the latest progress artifact across the whole node and use it as the
+			// completion summary for peers that don't have a direct ne.result.
+			let latestProgressSummary: string | null = null;
+			if (config.artifactRepo && workflowRunId) {
+				const progressArtifacts = config.artifactRepo.listByRun(workflowRunId, {
+					nodeId: workflowNodeId,
+					artifactType: 'progress',
+				});
+				if (progressArtifacts.length > 0) {
+					const latest = progressArtifacts[progressArtifacts.length - 1];
+					const s = latest.data.summary;
+					latestProgressSummary = typeof s === 'string' ? s : null;
+				}
+			}
 
 			// Exclude self (by agentSessionId) and include peers with a session or completed state
 			const peers = nodeExecs
@@ -278,6 +283,10 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 							: execStatus === 'blocked' || execStatus === 'cancelled'
 								? ('failed' as const)
 								: ('active' as const);
+
+					// Source completion summary from artifacts first, then fall back to ne.result.
+					const completionSummary = latestProgressSummary ?? ne.result ?? null;
+
 					return {
 						sessionId: ne.agentSessionId ?? null,
 						agentName: ne.agentName,
@@ -286,18 +295,21 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 						completionState: {
 							agentName: ne.agentName,
 							taskStatus: ne.status,
-							completionSummary: ne.result ?? null,
+							completionSummary,
 							completedAt: ne.completedAt ?? null,
 						},
 					};
 				});
 
-			const nodeCompletionState = nodeExecs.map((ne) => ({
-				agentName: ne.agentName,
-				taskStatus: ne.status,
-				completionSummary: ne.result ?? null,
-				completedAt: ne.completedAt ?? null,
-			}));
+			const nodeCompletionState = nodeExecs.map((ne) => {
+				const completionSummary = latestProgressSummary ?? ne.result ?? null;
+				return {
+					agentName: ne.agentName,
+					taskStatus: ne.status,
+					completionSummary,
+					completedAt: ne.completedAt ?? null,
+				};
+			});
 
 			const topologyTargets = resolver.getPermittedTargets(myAgentName);
 			const permittedTargets = [...topologyTargets, 'task-agent'];
@@ -742,17 +754,29 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 			});
 		},
 
+		// ── Artifact tools ────────────────────────────────────────────────
+
 		/**
-		 * Persist this agent's output to the NodeExecution record.
+		 * Persist data to the workflow run artifact store.
 		 *
-		 * Call whenever you have produced output worth recording — at any point
-		 * during your work, not just at the end. Can be called multiple times;
-		 * each call overwrites the previous summary and data.
+		 * Unified replacement for the old `save` and `write_artifact` tools.
 		 *
-		 * `summary` and `data` are independent — provide either or both.
+		 * Two modes:
+		 *   - Overwrite (default, append: false): upsert on (nodeId, type, key).
+		 *     Same (type, key) replaces the previous value.
+		 *     Use `type: 'progress', key: 'current'` for a rolling status update.
+		 *   - Append (append: true): always inserts a new row with an auto-generated key.
+		 *     Use for audit trails, cycle records, or any multi-record history.
+		 *
+		 * Requires `artifactRepo` to be provided in the config.
 		 */
-		async save(args: SaveInput): Promise<ToolResult> {
-			const { summary, data } = args;
+		async save_artifact(args: SaveArtifactInput): Promise<ToolResult> {
+			const { artifactRepo } = config;
+			if (!artifactRepo) {
+				return jsonResult({ success: false, error: 'Artifact repository not available.' });
+			}
+
+			const { type, key: keyArg, append, summary, data } = args;
 
 			if (summary === undefined && data === undefined) {
 				return jsonResult({
@@ -762,66 +786,36 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 			}
 
 			try {
-				const nodeExecs = workflowRunId
-					? nodeExecutionRepo.listByNode(workflowRunId, workflowNodeId)
-					: [];
-				const myExec = nodeExecs.find((e) => e.agentName === myAgentName);
+				// In append mode, always generate a unique key to guarantee a new row.
+				// In overwrite mode, use the provided key (defaults to '' for upsert matching the DB default).
+				const artifactKey = append
+					? `${Date.now()}-${Math.random().toString(36).slice(2)}`
+					: (keyArg ?? '');
 
-				if (!myExec) {
-					return jsonResult({
-						success: false,
-						error:
-							`NodeExecution not found for agent "${myAgentName}" in node "${workflowNodeId}" ` +
-							`(run: ${workflowRunId}). Cannot save output.`,
-					});
-				}
+				// Merge summary and data into a single record stored in the data field.
+				const artifactData: Record<string, unknown> = {};
+				if (summary !== undefined) artifactData.summary = summary;
+				if (data !== undefined) Object.assign(artifactData, data);
 
-				const updates: { result?: string | null; data?: Record<string, unknown> | null } = {};
-				if (summary !== undefined) updates.result = summary;
-				if (data !== undefined) updates.data = data;
-
-				nodeExecutionRepo.update(myExec.id, updates);
-
-				return jsonResult({
-					success: true,
-					executionId: myExec.id,
-					agentName: myAgentName,
-					savedSummary: summary ?? null,
-					savedData: data ?? null,
-					message: 'Output saved to execution record.',
-				});
-			} catch (err) {
-				const message = err instanceof Error ? err.message : String(err);
-				return jsonResult({ success: false, error: message });
-			}
-		},
-
-		// ── Artifact tools ────────────────────────────────────────────────
-
-		async write_artifact(args: WriteArtifactInput): Promise<ToolResult> {
-			const { artifactRepo } = config;
-			if (!artifactRepo) {
-				return jsonResult({ success: false, error: 'Artifact repository not available.' });
-			}
-			try {
 				const record = artifactRepo.upsert({
 					id: crypto.randomUUID(),
 					runId: workflowRunId,
 					nodeId: workflowNodeId,
-					artifactType: args.artifactType,
-					artifactKey: args.artifactKey,
-					data: args.data,
+					artifactType: type,
+					artifactKey,
+					data: artifactData,
 				});
+
 				return jsonResult({
 					success: true,
 					artifact: {
 						id: record.id,
 						runId: record.runId,
 						nodeId: record.nodeId,
-						artifactType: record.artifactType,
-						artifactKey: record.artifactKey,
+						type: record.artifactType,
+						key: record.artifactKey,
 					},
-					message: `Artifact "${args.artifactType}" written successfully.`,
+					message: `Artifact "${type}" ${append ? 'appended as new record' : 'saved (upsert)'}.`,
 				});
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
@@ -837,15 +831,15 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 			try {
 				const artifacts = artifactRepo.listByRun(workflowRunId, {
 					nodeId: args.nodeId,
-					artifactType: args.artifactType,
+					artifactType: args.type,
 				});
 				return jsonResult({
 					success: true,
 					artifacts: artifacts.map((a) => ({
 						id: a.id,
 						nodeId: a.nodeId,
-						artifactType: a.artifactType,
-						artifactKey: a.artifactKey,
+						type: a.artifactType,
+						key: a.artifactKey,
 						data: a.data,
 						createdAt: a.createdAt,
 						updatedAt: a.updatedAt,
@@ -913,7 +907,6 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
  */
 export function createNodeAgentMcpServer(config: NodeAgentToolsConfig) {
 	const handlers = createNodeAgentToolHandlers(config);
-	const { onReportResult } = config;
 
 	const tools = [
 		tool(
@@ -971,15 +964,6 @@ export function createNodeAgentMcpServer(config: NodeAgentToolsConfig) {
 			(args) => handlers.send_message(args)
 		),
 		tool(
-			'save',
-			'Persist your output to the execution record. ' +
-				'Provide a human-readable `summary`, structured `data` (key-value pairs), or both. ' +
-				'Can be called multiple times — each call overwrites previous values. ' +
-				'Use `data` for machine-readable artifacts like pr_url, commit_sha, test_results.',
-			SaveSchema.shape,
-			(args) => handlers.save(args)
-		),
-		tool(
 			'restore_node_agent',
 			'Self-heal primitive — call when you suspect the node-agent MCP server is unhealthy ' +
 				'(e.g. a previous mcp__node-agent__send_message returned "No such tool available"). ' +
@@ -993,33 +977,22 @@ export function createNodeAgentMcpServer(config: NodeAgentToolsConfig) {
 		...(config.artifactRepo
 			? [
 					tool(
-						'write_artifact',
-						'Write a typed artifact (PR, commit set, test result, deployment) to the workflow run. ' +
-							'Artifacts are visible in the UI and to downstream nodes. ' +
-							'Uses upsert — writing the same (type, key) pair updates the existing artifact.',
-						WriteArtifactSchema.shape,
-						(args) => handlers.write_artifact(args)
+						'save_artifact',
+						'Persist data to the workflow run artifact store. Provide a `type` (category tag), ' +
+							'`key` (unique within type; defaults to empty string), and at least one of `summary` or `data`. ' +
+							'By default (append: false), writing the same (type, key) overwrites the previous value. ' +
+							'Set `append: true` to always create a new record — useful for audit trails and cycle history. ' +
+							'The `type` field is fully generic: use "progress" for rolling status, "result" for final outcomes, ' +
+							'"review" for review feedback, or any custom label.',
+						SaveArtifactSchema.shape,
+						(args) => handlers.save_artifact(args)
 					),
 					tool(
 						'list_artifacts',
 						'List artifacts for the current workflow run. ' +
-							'Optionally filter by nodeId or artifactType.',
+							'Optionally filter by nodeId or type (e.g. "progress", "result", "review").',
 						ListArtifactsSchema.shape,
 						(args) => handlers.list_artifacts(args)
-					),
-				]
-			: []),
-		...(onReportResult
-			? [
-					tool(
-						'report_result',
-						"Append an audit record of what you observed to the task's report log. " +
-							'This does NOT close the task — it is append-only. To finalize the task, ' +
-							'call `approve_task` (if available) for self-close, or `submit_for_approval` ' +
-							'to request human review. Provide a human-readable summary and optional ' +
-							'structured evidence (prUrl, commitSha, testOutput, …).',
-						ReportResultSchema.shape,
-						(args) => onReportResult(args)
 					),
 				]
 			: []),

--- a/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
@@ -1,10 +1,11 @@
 /**
- * Task Agent MCP Tool Schemas — Zod schemas and TypeScript types for the 4
+ * Task Agent MCP Tool Schemas — Zod schemas and TypeScript types for the
  * tools available to the Task Agent session (send_message schema is shared
  * from node-agent-tool-schemas.ts).
  *
  * Tools (defined in this file):
- *   report_result         — report the final task result (terminal tool)
+ *   approve_task          — self-close the task (gated by autonomy level)
+ *   submit_for_approval   — request human sign-off
  *   request_human_input   — pause execution and surface a question to the human user
  *   list_group_members    — list all members of the current task's session group
  *
@@ -15,70 +16,12 @@
  *   - z.string().describe() on every field — .describe() before .optional()
  *   - optional fields use .optional() after .describe()
  *   - enum fields use z.enum([...])
+ *
+ * Note: The `report_result` schema was removed. Use `save_artifact` (from
+ * node-agent-tool-schemas.ts) with `append: true` for append-only audit records.
  */
 
 import { z } from 'zod';
-import type { SpaceReportedStatus } from '@neokai/shared';
-
-// ---------------------------------------------------------------------------
-// report_result
-// ---------------------------------------------------------------------------
-
-/**
- * Possible final statuses the runtime may assign to a task. Agents do NOT
- * self-certify status — the completion-action pipeline is the sole arbiter.
- * These values are only used internally by the runtime when resolving tasks.
- *
- * Mirrors `SpaceReportedStatus` (the shared type written to
- * `space_tasks.reported_status`); the `satisfies` clause locks the two
- * together so adding a value to one without the other fails to compile.
- */
-const TASK_RESULT_STATUS_VALUES = [
-	'done',
-	'blocked',
-	'cancelled',
-] as const satisfies readonly SpaceReportedStatus[];
-
-export const TaskResultStatusSchema = z.enum(TASK_RESULT_STATUS_VALUES);
-
-export type TaskResultStatus = SpaceReportedStatus;
-
-/**
- * Schema for `report_result` input (post-Stage-2).
- *
- * The agent reports only a human-readable summary plus optional structured
- * evidence. The runtime — not the agent — decides the final task status via
- * the completion-action pipeline. Passing a `status` field is a validation
- * error (enforced by `.strict()`).
- */
-export const ReportResultSchema = z
-	.object({
-		/** Human-readable summary of what was accomplished. */
-		summary: z
-			.string()
-			.describe(
-				'Human-readable summary of what you did and the outcome. The runtime — not this summary — decides the final task status via completion actions.'
-			),
-		/** Optional structured evidence supporting the summary. */
-		evidence: z
-			.object({
-				/** URL of the pull request, if applicable. */
-				prUrl: z.string().describe('URL of the pull request, if applicable').optional(),
-				/** Commit SHA of the final change, if applicable. */
-				commitSha: z.string().describe('Commit SHA of the final change, if applicable').optional(),
-				/** Test output or validation snippet, if applicable. */
-				testOutput: z
-					.string()
-					.describe('Test output or validation snippet, if applicable')
-					.optional(),
-			})
-			.passthrough()
-			.describe('Optional structured evidence supporting your summary')
-			.optional(),
-	})
-	.strict();
-
-export type ReportResultInput = z.infer<typeof ReportResultSchema>;
 
 // ---------------------------------------------------------------------------
 // approve_task
@@ -87,8 +30,8 @@ export type ReportResultInput = z.infer<typeof ReportResultSchema>;
 /**
  * Schema for `approve_task` input.
  *
- * Agent-self-close tool for end-node agents. Conditionally registered on the
- * MCP server only when `space.autonomyLevel >= workflow.completionAutonomyLevel`.
+ * Agent-self-close tool for end-node agents and the Task Agent. Conditionally
+ * registered on the MCP server only when `space.autonomyLevel >= workflow.completionAutonomyLevel`.
  * Calling this tool sets `space_tasks.reportedStatus = 'done'`, triggering the
  * completion-action pipeline on the next runtime tick.
  *
@@ -107,11 +50,11 @@ export type ApproveTaskInput = z.infer<typeof ApproveTaskSchema>;
 /**
  * Schema for `submit_for_approval` input.
  *
- * Always available to end-node agents (independent of autonomy level). Marks
- * the task as awaiting human sign-off: sets `task.status = 'review'` and
- * populates the pending-completion fields so the UI can route a human to
- * approve or reject. Even at high autonomy levels this remains available —
- * agents may want to escalate a risky result for attention.
+ * Always available to end-node agents and the Task Agent (independent of
+ * autonomy level). Marks the task as awaiting human sign-off: sets
+ * `task.status = 'review'` and populates the pending-completion fields so the
+ * UI can route a human to approve or reject. Even at high autonomy levels this
+ * remains available — agents may want to escalate a risky result for attention.
  */
 export const SubmitForApprovalSchema = z
 	.object({
@@ -172,7 +115,6 @@ export type ListGroupMembersInput = z.infer<typeof ListGroupMembersSchema>;
  * The MCP server factory can iterate this map to register tools.
  */
 export const TASK_AGENT_TOOL_SCHEMAS = {
-	report_result: ReportResultSchema,
 	approve_task: ApproveTaskSchema,
 	submit_for_approval: SubmitForApprovalSchema,
 	request_human_input: RequestHumanInputSchema,

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -1,8 +1,11 @@
 /**
  * Task Agent Tools — MCP tool handlers for the Task Agent session.
  *
- * These handlers implement the business logic for the 4 Task Agent tools:
- *   report_result         — Mark the task as completed/failed and record the result
+ * These handlers implement the business logic for the Task Agent tools:
+ *   save_artifact         — Persist typed data to the workflow run artifact store
+ *   list_artifacts        — List artifacts for the current workflow run
+ *   approve_task          — Self-close the task (gated by autonomy level)
+ *   submit_for_approval   — Request human sign-off (always available)
  *   request_human_input   — Pause execution and surface a question to the human user
  *   list_group_members    — List all members of the current task's session group
  *   send_message          — Send a message to peer node agents via channel topology
@@ -17,17 +20,17 @@
  */
 
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
-import type { Space } from '@neokai/shared';
+import type { Space, SpaceTask } from '@neokai/shared';
 import { z } from 'zod';
 import type { DaemonHub } from '../../daemon-hub';
 import { Logger } from '../../logger';
 import type { SpaceTaskManager } from '../managers/space-task-manager';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
-import type { SpaceTaskReportResultRepository } from '../../../storage/repositories/space-task-report-result-repository';
 import type { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
 import type { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
+import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
 import type {
 	PendingAgentMessageRepository,
 	PendingAgentMessageRecord,
@@ -36,17 +39,27 @@ import type { TaskAgentManager } from '../runtime/task-agent-manager';
 import { jsonResult } from './tool-result';
 import type { ToolResult } from './tool-result';
 import {
-	ReportResultSchema,
+	ApproveTaskSchema,
+	SubmitForApprovalSchema,
 	RequestHumanInputSchema,
 	ListGroupMembersSchema,
 } from './task-agent-tool-schemas';
-import { SendMessageSchema } from './node-agent-tool-schemas';
+import {
+	SendMessageSchema,
+	SaveArtifactSchema,
+	ListArtifactsSchema,
+} from './node-agent-tool-schemas';
 import type {
-	ReportResultInput,
+	ApproveTaskInput,
+	SubmitForApprovalInput,
 	RequestHumanInputInput,
 	ListGroupMembersInput,
 } from './task-agent-tool-schemas';
-import type { SendMessageInput } from './node-agent-tool-schemas';
+import type {
+	SendMessageInput,
+	SaveArtifactInput,
+	ListArtifactsInput,
+} from './node-agent-tool-schemas';
 
 // Re-export for consumers that want the shared type
 export type { ToolResult };
@@ -87,12 +100,6 @@ export interface TaskAgentToolsConfig {
 	workflowRunId: string;
 	/** Task repository for direct DB reads. */
 	taskRepo: SpaceTaskRepository;
-	/**
-	 * Append-only audit log for `report_result` tool calls. Design v2 (Task #39):
-	 * the task-agent `report_result` is purely audit — it does not mutate task
-	 * state or emit `space.task.done`. Each call appends one row here.
-	 */
-	taskReportResultRepo: SpaceTaskReportResultRepository;
 	/** Node execution repository for querying execution state in list_group_members. */
 	nodeExecutionRepo: NodeExecutionRepository;
 	/** Task manager for validated status transitions. */
@@ -162,6 +169,11 @@ export interface TaskAgentToolsConfig {
 	 * task is archived, so status-filtered lookup is no longer needed.
 	 */
 	taskAgentManager?: TaskAgentManager;
+	/**
+	 * Workflow run artifact repository for save_artifact / list_artifacts tools.
+	 * Optional — when absent, artifact tools are not registered.
+	 */
+	artifactRepo?: WorkflowRunArtifactRepository;
 }
 
 // ---------------------------------------------------------------------------
@@ -178,7 +190,6 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		space,
 		workflowRunId,
 		taskRepo,
-		taskReportResultRepo,
 		nodeExecutionRepo,
 		taskManager,
 		messageInjector,
@@ -227,50 +238,196 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 			.catch(() => {});
 	}
 
+	/** Emit task updated event to DaemonHub. */
+	function emitTaskUpdated(task: SpaceTask): void {
+		if (!daemonHub) return;
+		void daemonHub
+			.emit('space.task.updated', { sessionId: 'global', spaceId: space.id, taskId, task })
+			.catch((err: unknown) => {
+				log.warn(
+					`Failed to emit space.task.updated for task ${taskId}: ${err instanceof Error ? err.message : String(err)}`
+				);
+			});
+	}
+
 	return {
 		/**
-		 * Record a progress report (Design v2 — Task #39, append-only audit).
+		 * Persist data to the workflow run artifact store.
 		 *
-		 * Post Stage-2, `report_result` is NOT a terminal tool. It simply appends
-		 * one row to `space_task_report_results` so the full history of reports
-		 * issued during a task is preserved. It never mutates task status, never
-		 * emits `space.task.done`, and never triggers the completion-action
-		 * pipeline.
-		 *
-		 * Terminal state is decided by:
-		 *   - End-node agents: via `approve_task` (auto-close when autonomy
-		 *     permits) or `submit_for_approval` (human review).
-		 *   - Human operators: via `spaceTask.approvePendingCompletion` RPC.
+		 * Two modes:
+		 *   - Overwrite (default, append: false): upsert on (nodeId='task-agent', type, key).
+		 *     Use `type: 'progress', key: 'current'` for rolling status, or `type: 'result'`
+		 *     for the final outcome.
+		 *   - Append (append: true): always inserts a new row with auto-generated key.
+		 *     Use for audit trails and multi-round history.
 		 */
-		async report_result(args: ReportResultInput): Promise<ToolResult> {
-			const { summary, evidence } = args;
+		async save_artifact(args: SaveArtifactInput): Promise<ToolResult> {
+			const { artifactRepo } = config;
+			if (!artifactRepo) {
+				return jsonResult({ success: false, error: 'Artifact repository not available.' });
+			}
 
-			const mainTask = taskRepo.getTask(taskId);
-			if (!mainTask) {
-				return jsonResult({ success: false, error: `Task not found: ${taskId}` });
+			const { type, key: keyArg, append, summary, data } = args;
+
+			if (summary === undefined && data === undefined) {
+				return jsonResult({
+					success: false,
+					error: 'At least one of `summary` or `data` must be provided.',
+				});
 			}
 
 			try {
-				const record = taskReportResultRepo.append({
-					taskId,
-					spaceId: space.id,
-					workflowNodeId: null,
-					agentName: 'task-agent',
-					summary,
-					evidence: evidence ?? null,
+				// In append mode, always generate a unique key to guarantee a new row.
+				// In overwrite mode, default to '' to match the artifact_key NOT NULL DEFAULT '' column.
+				const artifactKey = append
+					? `${Date.now()}-${Math.random().toString(36).slice(2)}`
+					: (keyArg ?? '');
+
+				// Merge summary and data into a single record.
+				const artifactData: Record<string, unknown> = {};
+				if (summary !== undefined) artifactData.summary = summary;
+				if (data !== undefined) Object.assign(artifactData, data);
+
+				const record = artifactRepo.upsert({
+					id: crypto.randomUUID(),
+					runId: workflowRunId,
+					nodeId: 'task-agent',
+					artifactType: type,
+					artifactKey,
+					data: artifactData,
 				});
 
 				return jsonResult({
 					success: true,
-					taskId,
-					reportId: record.id,
-					message:
-						'Report recorded (audit-only). This does not close the task. ' +
-						'Use approve_task or submit_for_approval on an end node to finalize.',
+					artifact: {
+						id: record.id,
+						runId: record.runId,
+						nodeId: record.nodeId,
+						type: record.artifactType,
+						key: record.artifactKey,
+					},
+					message: `Artifact "${type}" ${append ? 'appended as new record' : 'saved (upsert)'}.`,
 				});
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
 				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		async list_artifacts(args: ListArtifactsInput): Promise<ToolResult> {
+			const { artifactRepo } = config;
+			if (!artifactRepo) {
+				return jsonResult({ success: false, error: 'Artifact repository not available.' });
+			}
+			try {
+				const artifacts = artifactRepo.listByRun(workflowRunId, {
+					nodeId: args.nodeId,
+					artifactType: args.type,
+				});
+				return jsonResult({
+					success: true,
+					artifacts: artifacts.map((a) => ({
+						id: a.id,
+						nodeId: a.nodeId,
+						type: a.artifactType,
+						key: a.artifactKey,
+						data: a.data,
+						createdAt: a.createdAt,
+						updatedAt: a.updatedAt,
+					})),
+				});
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		/**
+		 * Self-close this task as done.
+		 *
+		 * Gated by space.autonomyLevel >= workflow.completionAutonomyLevel.
+		 * For standalone tasks (no workflow), always requires human review (blocked at level 1-4).
+		 * Sets reportedStatus='done' which triggers the completion-action pipeline.
+		 */
+		async approve_task(_args: ApproveTaskInput): Promise<ToolResult> {
+			const currentLevel = space.autonomyLevel ?? 1;
+
+			// Resolve completionAutonomyLevel from the workflow (if any).
+			let completionAutonomyLevel = 5; // default: require human approval
+			if (workflowRunRepo && workflowManager) {
+				const run = workflowRunRepo.getRun(workflowRunId);
+				if (run?.workflowId) {
+					const wf = workflowManager.getWorkflow(run.workflowId);
+					if (wf?.completionAutonomyLevel !== undefined) {
+						completionAutonomyLevel = wf.completionAutonomyLevel;
+					}
+				}
+			}
+
+			if (currentLevel < completionAutonomyLevel) {
+				return jsonResult({
+					success: false,
+					error: `approve_task not permitted: space autonomy level ${currentLevel} < workflow completionAutonomyLevel ${completionAutonomyLevel}. Use submit_for_approval to request human review.`,
+				});
+			}
+
+			const task = taskRepo.getTask(taskId);
+			if (!task) return jsonResult({ success: false, error: `Task not found: ${taskId}` });
+
+			try {
+				const updated = taskRepo.updateTask(taskId, {
+					reportedStatus: 'done',
+					pendingCheckpointType: null,
+					pendingCompletionSubmittedByNodeId: null,
+					pendingCompletionSubmittedAt: null,
+					pendingCompletionReason: null,
+				});
+				if (updated) emitTaskUpdated(updated);
+				return jsonResult({
+					success: true,
+					taskId,
+					message:
+						'Task approved for completion. The completion-action pipeline will now resolve terminal status.',
+				});
+			} catch (err) {
+				return jsonResult({
+					success: false,
+					error: err instanceof Error ? err.message : String(err),
+				});
+			}
+		},
+
+		/**
+		 * Request human sign-off for task completion.
+		 *
+		 * Always available regardless of autonomy level. Sets task.status = 'review'
+		 * and populates pending-completion fields so the UI can route a human to
+		 * approve or reject. Even at high autonomy levels agents may want to escalate
+		 * risky outcomes.
+		 */
+		async submit_for_approval(args: SubmitForApprovalInput): Promise<ToolResult> {
+			const task = taskRepo.getTask(taskId);
+			if (!task) return jsonResult({ success: false, error: `Task not found: ${taskId}` });
+
+			try {
+				const updated = taskRepo.updateTask(taskId, {
+					status: 'review',
+					pendingCheckpointType: 'task_completion',
+					pendingCompletionSubmittedByNodeId: null, // Task Agent has no workflow node
+					pendingCompletionSubmittedAt: Date.now(),
+					pendingCompletionReason: args.reason ?? null,
+				});
+				if (updated) emitTaskUpdated(updated);
+				return jsonResult({
+					success: true,
+					taskId,
+					message: `Task submitted for human review${args.reason ? ` (reason: ${args.reason})` : ''}. A human must approve or reject via the UI before the workflow continues.`,
+				});
+			} catch (err) {
+				return jsonResult({
+					success: false,
+					error: err instanceof Error ? err.message : String(err),
+				});
 			}
 		},
 
@@ -795,17 +952,6 @@ export function createTaskAgentMcpServer(config: TaskAgentToolsConfig) {
 
 	const tools = [
 		tool(
-			'report_result',
-			'Record a progress report for this task as an append-only audit entry. ' +
-				'This does NOT close the task — it only appends a summary (and optional evidence) ' +
-				'to the task report history. Terminal completion is handled by `approve_task` ' +
-				'(end-node, self-close when autonomy permits) or `submit_for_approval` (end-node, ' +
-				'human review). Use `report_result` to share intermediate outcomes, status updates, ' +
-				'or findings without ending the workflow run.',
-			ReportResultSchema.shape,
-			(args) => handlers.report_result(args)
-		),
-		tool(
 			'request_human_input',
 			'Pause workflow execution and surface a question to the human user. ' +
 				'The task will be marked as needs_attention until the human responds. ' +
@@ -853,6 +999,46 @@ export function createTaskAgentMcpServer(config: TaskAgentToolsConfig) {
 				reason: z.string().optional().describe('Reason for approval or rejection'),
 			},
 			(args) => handlers.approve_gate(args)
+		),
+		...(config.artifactRepo
+			? [
+					tool(
+						'save_artifact',
+						'Persist data to the workflow run artifact store. Provide a `type` (category tag), ' +
+							'`key` (unique within type; defaults to empty string), and at least one of `summary` or `data`. ' +
+							'By default (append: false), writing the same (type, key) overwrites the previous value. ' +
+							'Set `append: true` to always create a new record — useful for audit trails and cycle history. ' +
+							'The `type` field is fully generic: use "progress" for rolling status, "result" for final outcomes.',
+						SaveArtifactSchema.shape,
+						(args) => handlers.save_artifact(args)
+					),
+					tool(
+						'list_artifacts',
+						'List artifacts for the current workflow run. ' +
+							'Optionally filter by nodeId or type (e.g. "progress", "result").',
+						ListArtifactsSchema.shape,
+						(args) => handlers.list_artifacts(args)
+					),
+				]
+			: []),
+		tool(
+			'approve_task',
+			'Close this task as done (self-approval). Only available when the space autonomy level ' +
+				"meets the workflow's completionAutonomyLevel threshold. Takes no arguments — the task " +
+				'is inferred from your session context. After calling, the completion-action pipeline ' +
+				'runs and resolves the terminal status. Use as your final action when you are ' +
+				'authorized to self-close; otherwise use submit_for_approval.',
+			ApproveTaskSchema.shape,
+			(args) => handlers.approve_task(args)
+		),
+		tool(
+			'submit_for_approval',
+			"Request human review of this task's completion. Always available. " +
+				'Use when you want to escalate for human sign-off — either because autonomy rules ' +
+				'require it, or because the outcome is risky enough to warrant attention. Pass an ' +
+				'optional `reason` explaining why you are escalating; it is shown in the approval UI.',
+			SubmitForApprovalSchema.shape,
+			(args) => handlers.submit_for_approval(args)
 		),
 	];
 

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -315,7 +315,7 @@ const PD_TASK_DISPATCHER_PROMPT =
 	'description must include stacked PR instructions so the downstream coder knows exactly ' +
 	'which base branch to target, forming a reviewable PR chain across the plan.\n\n' +
 	'TOOL CONTRACT (Design v2):\n' +
-	'- `report_result({ summary, evidence? })` — append-only audit. Records the dispatch ' +
+	'- `save_artifact({ type: "result", append: true, summary, ...data? })` — append-only audit. Records the dispatch ' +
 	'outcome. Does NOT close the task.\n' +
 	'- `approve_task()` — closes this task as done. Call after every required downstream task ' +
 	'has been created.\n' +
@@ -356,10 +356,9 @@ const PD_TASK_DISPATCHER_PROMPT =
 	'   ```\n\n' +
 	'4. Collect the returned task IDs. Build a stack map: ' +
 	'{ prefix, items: [{ title, taskId, branch, baseBranch, position }] }.\n' +
-	'5. Call `report_result({ summary: "Created N tasks from plan: <short list>", ' +
-	'evidence: { created_task_ids: [<ids>], stack_prefix: "<prefix>", ' +
-	'stack_branches: ["plan/<prefix>/<item-1-slug>", "plan/<prefix>/<item-2-slug>", ...] } ' +
-	'})` to record the dispatch audit entry.\n' +
+	'5. Call `save_artifact({ type: "result", append: true, summary: "Created N tasks from plan: <short list>", ' +
+	'created_task_ids: [<ids>], stack_prefix: "<prefix>", ' +
+	'stack_branches: ["plan/<prefix>/<item-1-slug>", "plan/<prefix>/<item-2-slug>", ...] })` to record the dispatch audit entry.\n' +
 	'6. Call `approve_task()` as your final action. If autonomy blocks self-close, call ' +
 	'`submit_for_approval({ reason: "..." })` instead.\n\n' +
 	'CRITICAL: Do NOT create branches, make commits, push to git, or open PRs yourself — ' +
@@ -385,15 +384,15 @@ const FULLSTACK_QA_PROMPT =
 	'You are the QA node in a Fullstack QA Loop workflow. Run thorough validation, including backend tests, ' +
 	'frontend tests, and browser-based checks for critical flows.\n\n' +
 	'TOOL CONTRACT (Design v2):\n' +
-	'- `report_result({ summary, evidence? })` — append-only audit. Records what you observed ' +
+	'- `save_artifact({ type: "result", append: true, summary, ...data? })` — append-only audit. Records what you observed ' +
 	'during this cycle. Does NOT close the task.\n' +
 	'- `approve_task()` — closes this task as done. Only call after the PR is actually merged ' +
 	'and the workspace is synced.\n' +
 	'- `submit_for_approval({ reason? })` — request human sign-off instead of self-closing. ' +
 	'Use when autonomy blocks self-close.\n\n' +
-	'If everything passes, merge the PR, sync the worktree, then call `report_result` followed by ' +
+	'If everything passes, merge the PR, sync the worktree, then call `save_artifact({ type: "result", append: true, summary: "QA passed." })` followed by ' +
 	'`approve_task`. If issues are found, send a detailed fix list to Coding and record a ' +
-	'`report_result({ summary: "QA failed: ..." })` audit entry; do NOT call `approve_task`.';
+	'`save_artifact({ type: "result", append: true, summary: "QA failed: ..." })` audit entry; do NOT call `approve_task`.';
 
 const RESEARCH_RESEARCH_NODE = 'tpl-research-research';
 const RESEARCH_REVIEW_NODE = 'tpl-research-review';
@@ -411,8 +410,8 @@ const REVIEW_REVIEW_NODE = 'tpl-review-review';
  * - Coding → Review: gated by `code-ready-gate` — a bash script verifies that an
  *   open, mergeable PR exists and emits its URL as `{"pr_url":"..."}`.
  * - Review → Coding: ungated — Reviewer sends back for changes without any gate.
- *   When satisfied, Reviewer calls `report_result()` on the Review node (endNodeId)
- *   which signals workflow completion.
+ *   When satisfied, Reviewer calls `save_artifact({ type: 'result', append: true })` then
+ *   `approve_task()` on the Review node (endNodeId) which signals workflow completion.
  */
 export const CODING_WORKFLOW: SpaceWorkflow = {
 	id: '',
@@ -482,7 +481,7 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'checks GitHub for a fresh review before releasing your message. If you skip ' +
 							'`gh pr review`, the gate will block and the coder will never hear from you.\n\n' +
 							'TOOL CONTRACT (Design v2):\n' +
-							'- `report_result({ summary, evidence? })` — append-only audit. Records what you ' +
+							'- `save_artifact({ type: "result", append: true, summary, ...data? })` — append-only audit. Records what you ' +
 							'observed. Does NOT close the task. Call it every cycle (changes-requested AND ' +
 							'approval) so the audit log has a clear trail of each decision.\n' +
 							'- `approve_task()` — closes this task as done. Call this ONLY when you are ' +
@@ -505,12 +504,11 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'comment_urls: ["<comment #1 url>", "<comment #2 url>"] }). The `data` payload ' +
 							'satisfies the review-posted-gate and gives the coder direct links to each ' +
 							'thread.\n' +
-							'   d. Call `report_result({ summary: "Requested changes: ...", evidence: { ' +
-							'prUrl, reviewUrl } })` so the cycle is recorded. Do NOT call `approve_task` — ' +
+							'   d. Call `save_artifact({ type: "result", append: true, summary: "Requested changes: ...", prUrl, reviewUrl })` so the cycle is recorded. Do NOT call `approve_task` — ' +
 							'the workflow must stay open for the next cycle.\n' +
 							'5. If satisfied: post an approval review with `gh pr review <pr-url> --approve ' +
 							'--body-file <file>`, verify the PR is open and mergeable, then call ' +
-							'`report_result({ summary, evidence: { prUrl } })` to record the audit entry, ' +
+							'`save_artifact({ type: "result", append: true, summary, prUrl })` to record the audit entry, ' +
 							'and finally call `approve_task()` to close the task. If autonomy blocks ' +
 							'self-close, call `submit_for_approval({ reason: "..." })` instead.',
 					},
@@ -596,7 +594,7 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
  *   Review → Research (ungated back-channel, max 5 cycles)
  *
  * Research agent researches thoroughly, commits findings, opens a PR.
- * Reviewer agent reviews the research PR; calls report_result() if satisfied,
+ * Reviewer agent reviews the research PR; calls save_artifact() then approve_task() if satisfied,
  * or sends back for more research via the back-channel.
  */
 export const RESEARCH_WORKFLOW: SpaceWorkflow = {
@@ -642,7 +640,7 @@ export const RESEARCH_WORKFLOW: SpaceWorkflow = {
 							'You are the Reviewer in a Research→Reviewer iterative workflow. You review the ' +
 							'research findings for completeness, accuracy, and quality.\n\n' +
 							'TOOL CONTRACT (Design v2):\n' +
-							'- `report_result({ summary, evidence? })` — append-only audit. Records what you ' +
+							'- `save_artifact({ type: "result", append: true, summary, ...data? })` — append-only audit. Records what you ' +
 							'observed during this cycle. Does NOT close the task.\n' +
 							'- `approve_task()` — closes the task as done. Call only when satisfied.\n' +
 							'- `submit_for_approval({ reason? })` — request human sign-off instead of self- ' +
@@ -653,10 +651,10 @@ export const RESEARCH_WORKFLOW: SpaceWorkflow = {
 							'3. Check accuracy: are claims supported by evidence or sources?\n' +
 							'4. Check clarity: are findings well-organized and easy to follow?\n' +
 							'5. If more research is needed: send_message back to Research with specific areas ' +
-							'to investigate, then `report_result({ summary: "Requested more research: ..." })` ' +
+							'to investigate, then `save_artifact({ type: "result", append: true, summary: "Requested more research: ..." })` ' +
 							'to record the cycle. Do NOT call `approve_task` — leave the workflow open.\n' +
 							'6. If satisfied: verify the PR is still open and mergeable, call ' +
-							'`report_result({ summary, evidence: { prUrl } })` to record the final audit ' +
+							'`save_artifact({ type: "result", append: true, summary, prUrl })` to record the final audit ' +
 							'entry, then `approve_task()` to close. If autonomy blocks self-close, call ' +
 							'`submit_for_approval({ reason: "..." })` instead.',
 					},
@@ -738,7 +736,7 @@ export const REVIEW_ONLY_WORKFLOW: SpaceWorkflow = {
 							'You are the sole Reviewer in a single-node Review-Only workflow. There is no planning ' +
 							'or coding phase — you are reviewing an existing PR or codebase directly.\n\n' +
 							'TOOL CONTRACT (Design v2):\n' +
-							'- `report_result({ summary, evidence? })` — append-only audit. Records what you ' +
+							'- `save_artifact({ type: "result", append: true, summary, ...data? })` — append-only audit. Records what you ' +
 							'observed. Does NOT close the task.\n' +
 							'- `approve_task()` — closes the task as done. Call only after you have posted ' +
 							'your review to the PR via `gh pr review`.\n' +
@@ -758,7 +756,7 @@ export const REVIEW_ONLY_WORKFLOW: SpaceWorkflow = {
 							'4. Post your review to the PR via `gh pr review` (+ inline comments via `gh api` ' +
 							'where relevant) — this is required, not optional; the runtime verifies at least one ' +
 							'review/comment exists before accepting completion\n' +
-							'5. Call `report_result({ summary, evidence: { prUrl } })` to record the audit entry\n' +
+							'5. Call `save_artifact({ type: "result", append: true, summary, prUrl })` to record the audit entry\n' +
 							'6. Call `approve_task()` as your final action. If autonomy blocks self-close, call ' +
 							'`submit_for_approval({ reason: "..." })` instead.',
 					},
@@ -782,7 +780,7 @@ export const REVIEW_ONLY_WORKFLOW: SpaceWorkflow = {
  *
  * Verifies that the Task Dispatcher actually fanned the plan out into at least
  * one standalone task during this workflow run. Without this guard, a Task
- * Dispatcher that ran report_result() without creating tasks would look
+ * Dispatcher that ran save_artifact() without creating tasks would look
  * successful on the surface but leave the user with zero follow-up work.
  *
  * Environment variables required (injected by the completion-action executor):
@@ -845,7 +843,7 @@ const PLAN_AND_DECOMPOSE_VERIFY_COMPLETION_ACTION: CompletionAction = {
  *   Plan Review → Planning (revision requests, maxCycles: 5)
  *
  * Task Dispatcher (end node) creates follow-up tasks via `create_standalone_task`
- * and calls `report_result(..., evidence={ created_task_ids })`. A script-based
+ * and calls `save_artifact({ type: 'result', append: true, created_task_ids })`. A script-based
  * completion action then verifies that at least one task was actually created.
  */
 export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
@@ -963,7 +961,7 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
 							'Expected inputs: An approved plan PR (plan-approval-gate satisfied — all 4 ' +
 							'reviewers voted `approved: true`).\n' +
 							'Expected outputs: One standalone task per actionable work item in the plan, ' +
-							'then report_result() with `evidence.created_task_ids`.\n\n' +
+							'then save_artifact({ type: "result", append: true, created_task_ids: [...] }).\n\n' +
 							'Tool contract:\n' +
 							"- `create_standalone_task` is available from the space's MCP server and " +
 							'creates a task owned by the same space as this workflow.',
@@ -1050,7 +1048,7 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
  *   Review → Coding (changes requested)
  *   QA → Coding (test failures/regressions)
  *
- * QA is the end node. QA calls report_result() on success.
+ * QA is the end node. QA calls save_artifact() then approve_task() on success.
  */
 export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
 	id: '',
@@ -1122,11 +1120,11 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
 							'2. Run browser-based critical-path validation\n' +
 							'3. Validate CI and mergeability\n' +
 							'4. If fail: send detailed failures and repro steps to Coding, then call ' +
-							'`report_result({ summary: "QA failed: ..." })` to record the audit entry. Do ' +
+							'`save_artifact({ type: "result", append: true, summary: "QA failed: ..." })` to record the audit entry. Do ' +
 							'NOT call `approve_task` — leave the workflow open for the next Coding cycle.\n' +
 							'5. If all green: merge the PR with `gh pr merge <URL> --squash`\n' +
 							'6. Sync worktree: `git checkout <base-branch> && git pull --ff-only`\n' +
-							'7. Call `report_result({ summary, evidence: { prUrl, testOutput } })` to record ' +
+							'7. Call `save_artifact({ type: "result", append: true, summary, prUrl, testOutput })` to record ' +
 							'the audit entry, then `approve_task()` as your final action. If autonomy blocks ' +
 							'self-close, call `submit_for_approval({ reason: "..." })` instead. The runtime ' +
 							'also verifies the PR is actually merged before accepting completion.',
@@ -1323,7 +1321,7 @@ export function seedBuiltInWorkflows(
 				})),
 				// Thread completionActions through to persisted nodes. Without this,
 				// end-node actions like MERGE_PR_COMPLETION_ACTION are silently dropped
-				// so report_result() completes the workflow but the PR never merges.
+				// so approve_task() completes the workflow but the PR never merges.
 				...(s.completionActions ? { completionActions: s.completionActions } : {}),
 			}));
 

--- a/packages/daemon/tests/unit/5-space/agent/end-node-handlers.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/end-node-handlers.test.ts
@@ -1,11 +1,13 @@
 /**
- * Unit tests for createEndNodeHandlers() — the Design v2 three-tool contract
- * for end-node agents (Task #39).
+ * Unit tests for createEndNodeHandlers() — the Design v2 two-tool contract
+ * for end-node agents.
  *
  * Covers:
- *   - report_result       — append-only audit; never mutates task state
  *   - approve_task        — autonomy-gated self-close
  *   - submit_for_approval — always-available human sign-off request
+ *
+ * Note: report_result was removed. Audit records are now written via
+ * save_artifact({ type: 'result', append: true }) on the node-agent tool surface.
  *
  * These handlers were extracted from task-agent-manager.ts so they can be
  * unit-tested directly with a real SQLite DB and no live agent sessions.
@@ -17,7 +19,6 @@ import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
-import { SpaceTaskReportResultRepository } from '../../../../src/storage/repositories/space-task-report-result-repository.ts';
 import { createEndNodeHandlers } from '../../../../src/lib/space/tools/end-node-handlers.ts';
 import type { EndNodeHandlerDeps } from '../../../../src/lib/space/tools/end-node-handlers.ts';
 import type { Space, SpaceWorkflow } from '@neokai/shared';
@@ -104,7 +105,6 @@ interface TestCtx {
 	dir: string;
 	spaceId: string;
 	taskRepo: SpaceTaskRepository;
-	reportRepo: SpaceTaskReportResultRepository;
 }
 
 function makeCtx(autonomyLevel = 1): TestCtx {
@@ -116,7 +116,6 @@ function makeCtx(autonomyLevel = 1): TestCtx {
 		dir,
 		spaceId,
 		taskRepo: new SpaceTaskRepository(db),
-		reportRepo: new SpaceTaskReportResultRepository(db),
 	};
 }
 
@@ -131,102 +130,13 @@ function makeDeps(
 		spaceId: ctx.spaceId,
 		workflow: makeWorkflow(3),
 		workflowNodeId: 'end-node',
-		agentName: 'reviewer',
 		taskRepo: ctx.taskRepo,
-		taskReportResultRepo: ctx.reportRepo,
 		spaceManager: {
 			getSpace: async () => makeSpace(ctx.spaceId, 3),
 		},
 		...overrides,
 	};
 }
-
-// ===========================================================================
-// report_result — APPEND-ONLY
-// ===========================================================================
-
-describe('createEndNodeHandlers — report_result', () => {
-	let ctx: TestCtx;
-	beforeEach(() => {
-		ctx = makeCtx();
-	});
-	afterEach(() => {
-		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
-	});
-
-	test('appends an audit row and does NOT mutate task state', async () => {
-		const task = ctx.taskRepo.createTask({
-			spaceId: ctx.spaceId,
-			title: 'T1',
-			description: '',
-			status: 'in_progress',
-		});
-		const { onReportResult } = createEndNodeHandlers(makeDeps(ctx, task.id));
-
-		const out = await onReportResult({ summary: 'PR opened' });
-		const parsed = JSON.parse(out.content[0].text);
-
-		expect(parsed.success).toBe(true);
-		expect(parsed.taskId).toBe(task.id);
-		expect(parsed.message).toContain('does NOT close the task');
-
-		// task unchanged
-		const t = ctx.taskRepo.getTask(task.id);
-		expect(t?.status).toBe('in_progress');
-		expect(t?.reportedStatus).toBeFalsy();
-
-		// audit row written
-		const audit = ctx.reportRepo.listByTask(task.id);
-		expect(audit).toHaveLength(1);
-		expect(audit[0].summary).toBe('PR opened');
-		expect(audit[0].agentName).toBe('reviewer');
-	});
-
-	test('records optional evidence payload', async () => {
-		const task = ctx.taskRepo.createTask({
-			spaceId: ctx.spaceId,
-			title: 'T',
-			description: '',
-			status: 'in_progress',
-		});
-		const { onReportResult } = createEndNodeHandlers(makeDeps(ctx, task.id));
-
-		const out = await onReportResult({
-			summary: 'Done',
-			evidence: { prUrl: 'https://example.com/pr/1', commitSha: 'abc123' },
-		});
-		expect(JSON.parse(out.content[0].text).success).toBe(true);
-
-		const audit = ctx.reportRepo.listByTask(task.id);
-		expect(audit[0].evidence).toEqual({
-			prUrl: 'https://example.com/pr/1',
-			commitSha: 'abc123',
-		});
-	});
-
-	test('returns error when task does not exist', async () => {
-		const { onReportResult } = createEndNodeHandlers(makeDeps(ctx, 'no-such-task'));
-		const out = await onReportResult({ summary: 'x' });
-		const parsed = JSON.parse(out.content[0].text);
-		expect(parsed.success).toBe(false);
-		expect(parsed.error).toContain('no-such-task');
-	});
-
-	test('does NOT emit space.task.updated (audit-only)', async () => {
-		const task = ctx.taskRepo.createTask({
-			spaceId: ctx.spaceId,
-			title: 'T',
-			description: '',
-			status: 'in_progress',
-		});
-		const { hub, emitted } = makeMockHub();
-		const { onReportResult } = createEndNodeHandlers(makeDeps(ctx, task.id, { daemonHub: hub }));
-
-		await onReportResult({ summary: 'x' });
-		expect(emitted.filter((e) => e.name.startsWith('space.task.'))).toHaveLength(0);
-	});
-});
 
 // ===========================================================================
 // approve_task — autonomy-gated self-close

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -22,6 +22,7 @@ import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-
 import { SpaceTaskManager } from '../../../../src/lib/space/managers/space-task-manager.ts';
 import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
 import { GateDataRepository } from '../../../../src/storage/repositories/gate-data-repository.ts';
+import { WorkflowRunArtifactRepository } from '../../../../src/storage/repositories/workflow-run-artifact-repository.ts';
 import {
 	createNodeAgentToolHandlers,
 	createNodeAgentMcpServer,
@@ -174,6 +175,7 @@ interface TestCtx {
 	taskManager: SpaceTaskManager;
 	spaceTaskRepo: SpaceTaskRepository;
 	nodeExecutionRepo: NodeExecutionRepository;
+	artifactRepo: WorkflowRunArtifactRepository;
 	/** Workflow run ID for peer task seeding. */
 	workflowRunId: string;
 	/** Workflow node ID for peer task seeding. */
@@ -197,6 +199,7 @@ function makeCtx(): TestCtx {
 	const spaceTaskRepo = taskRepo;
 	const taskManager = new SpaceTaskManager(db, spaceId);
 	const nodeExecutionRepo = new NodeExecutionRepository(db);
+	const artifactRepo = new WorkflowRunArtifactRepository(db);
 
 	// Session IDs for peers
 	const taskAgentSessionId = 'session-task-agent';
@@ -245,6 +248,7 @@ function makeCtx(): TestCtx {
 		taskManager,
 		spaceTaskRepo,
 		nodeExecutionRepo,
+		artifactRepo,
 		workflowRunId,
 		nodeId,
 		coderSessionId,
@@ -286,6 +290,7 @@ function makeConfig(ctx: TestCtx, overrides: NodeConfigOverrides = {}): NodeAgen
 		agentMessageRouter,
 		workflow: null,
 		gateDataRepo: new GateDataRepository(ctx.db),
+		artifactRepo: ctx.artifactRepo,
 		...configOverrides,
 	};
 }
@@ -804,10 +809,10 @@ describe('node-agent-tools: send_message', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests: save
+// Tests: save_artifact
 // ---------------------------------------------------------------------------
 
-describe('node-agent-tools: save', () => {
+describe('node-agent-tools: save_artifact', () => {
 	let ctx: TestCtx;
 
 	beforeEach(() => {
@@ -819,119 +824,108 @@ describe('node-agent-tools: save', () => {
 		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
-	function getCoderExecution() {
-		return ctx.nodeExecutionRepo
-			.listByNode(ctx.workflowRunId, ctx.nodeId)
-			.find((e) => e.agentName === 'coder');
-	}
-
-	test('save({ summary }) persists summary to result field', async () => {
-		const myExec = getCoderExecution();
-		expect(myExec).toBeDefined();
-
+	test('save_artifact({ type, summary }) writes to artifact store and does NOT mutate task status', async () => {
 		const handlers = createNodeAgentToolHandlers(makeConfig(ctx));
-		const result = await handlers.save({ summary: 'PR #42 merged.' });
+		const result = await handlers.save_artifact({ type: 'progress', summary: 'PR #42 merged.' });
 		const data = JSON.parse(result.content[0].text);
 
 		expect(data.success).toBe(true);
-		expect(data.executionId).toBe(myExec!.id);
-		expect(data.agentName).toBe('coder');
-		expect(data.savedSummary).toBe('PR #42 merged.');
-		expect(data.savedData).toBeNull();
+		expect(data.artifact.type).toBe('progress');
+		expect(data.artifact.nodeId).toBe(ctx.nodeId);
+		expect(data.artifact.runId).toBe(ctx.workflowRunId);
 
-		const updated = ctx.nodeExecutionRepo.getById(myExec!.id);
-		expect(updated?.result).toBe('PR #42 merged.');
-		expect(updated?.data).toBeNull();
-		expect(updated?.status).toBe('in_progress'); // save does not change status
+		// Verify persisted in DB
+		const artifacts = ctx.artifactRepo.listByRun(ctx.workflowRunId, { artifactType: 'progress' });
+		expect(artifacts).toHaveLength(1);
+		expect(artifacts[0].data.summary).toBe('PR #42 merged.');
+		expect(artifacts[0].nodeId).toBe(ctx.nodeId);
 	});
 
-	test('save({ data }) persists data to data field', async () => {
-		const myExec = getCoderExecution();
-		expect(myExec).toBeDefined();
-
+	test('save_artifact({ type, data }) persists structured data', async () => {
 		const handlers = createNodeAgentToolHandlers(makeConfig(ctx));
-		const result = await handlers.save({ data: { prNumber: 42, merged: true } });
-		const data = JSON.parse(result.content[0].text);
+		const result = await handlers.save_artifact({
+			type: 'pr',
+			data: { prNumber: 42, merged: true },
+		});
+		const parsed = JSON.parse(result.content[0].text);
 
-		expect(data.success).toBe(true);
-		expect(data.savedSummary).toBeNull();
-		expect(data.savedData).toEqual({ prNumber: 42, merged: true });
-
-		const updated = ctx.nodeExecutionRepo.getById(myExec!.id);
-		expect(updated?.data).toEqual({ prNumber: 42, merged: true });
-		expect(updated?.result).toBeNull();
+		expect(parsed.success).toBe(true);
+		const artifacts = ctx.artifactRepo.listByRun(ctx.workflowRunId, { artifactType: 'pr' });
+		expect(artifacts).toHaveLength(1);
+		expect(artifacts[0].data.prNumber).toBe(42);
+		expect(artifacts[0].data.merged).toBe(true);
 	});
 
-	test('save({ summary, data }) persists both fields', async () => {
-		const myExec = getCoderExecution();
-		expect(myExec).toBeDefined();
-
+	test('save_artifact({ type, summary, data }) persists both fields', async () => {
 		const handlers = createNodeAgentToolHandlers(makeConfig(ctx));
-		const result = await handlers.save({ summary: 'work done', data: { pr: 99 } });
-		const data = JSON.parse(result.content[0].text);
+		const result = await handlers.save_artifact({
+			type: 'result',
+			summary: 'work done',
+			data: { pr: 99 },
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
 
-		expect(data.success).toBe(true);
-		expect(data.savedSummary).toBe('work done');
-		expect(data.savedData).toEqual({ pr: 99 });
-
-		const updated = ctx.nodeExecutionRepo.getById(myExec!.id);
-		expect(updated?.result).toBe('work done');
-		expect(updated?.data).toEqual({ pr: 99 });
+		const artifacts = ctx.artifactRepo.listByRun(ctx.workflowRunId, { artifactType: 'result' });
+		expect(artifacts).toHaveLength(1);
+		expect(artifacts[0].data.summary).toBe('work done');
+		expect(artifacts[0].data.pr).toBe(99);
 	});
 
-	test('multiple save calls overwrite previous values', async () => {
+	test('overwrite mode (default): same (type, key) upserts the record', async () => {
 		const handlers = createNodeAgentToolHandlers(makeConfig(ctx));
-		const first = JSON.parse(
-			(await handlers.save({ summary: 'first', data: { v: 1 } })).content[0].text
+		const r1 = JSON.parse(
+			(await handlers.save_artifact({ type: 'progress', key: 'current', summary: 'first' }))
+				.content[0].text
 		);
-		expect(first.success).toBe(true);
+		expect(r1.success).toBe(true);
 
-		const second = JSON.parse(
-			(await handlers.save({ summary: 'second', data: { v: 2 } })).content[0].text
+		const r2 = JSON.parse(
+			(await handlers.save_artifact({ type: 'progress', key: 'current', summary: 'second' }))
+				.content[0].text
 		);
-		expect(second.success).toBe(true);
+		expect(r2.success).toBe(true);
+		// Same artifact ID (upserted, not inserted)
+		expect(r2.artifact.id).toBe(r1.artifact.id);
 
-		const myExec = getCoderExecution();
-		expect(myExec?.result).toBe('second');
-		expect(myExec?.data).toEqual({ v: 2 });
+		const artifacts = ctx.artifactRepo.listByRun(ctx.workflowRunId, { artifactType: 'progress' });
+		expect(artifacts).toHaveLength(1);
+		expect(artifacts[0].data.summary).toBe('second');
 	});
 
-	test('returns error when NodeExecution not found for agent', async () => {
-		const handlers = createNodeAgentToolHandlers(makeConfig(ctx, { myAgentName: 'ghost-agent' }));
-		const result = await handlers.save({ summary: 'hello' });
-		const data = JSON.parse(result.content[0].text);
+	test('append mode: multiple calls create multiple records', async () => {
+		const handlers = createNodeAgentToolHandlers(makeConfig(ctx));
+		const r1 = JSON.parse(
+			(await handlers.save_artifact({ type: 'audit', append: true, summary: 'first' })).content[0]
+				.text
+		);
+		const r2 = JSON.parse(
+			(await handlers.save_artifact({ type: 'audit', append: true, summary: 'second' })).content[0]
+				.text
+		);
+		expect(r1.success).toBe(true);
+		expect(r2.success).toBe(true);
+		// Distinct records
+		expect(r2.artifact.id).not.toBe(r1.artifact.id);
 
+		const artifacts = ctx.artifactRepo.listByRun(ctx.workflowRunId, { artifactType: 'audit' });
+		expect(artifacts).toHaveLength(2);
+	});
+
+	test('returns error when artifactRepo is absent', async () => {
+		const handlers = createNodeAgentToolHandlers(makeConfig(ctx, { artifactRepo: undefined }));
+		const result = await handlers.save_artifact({ type: 'result', summary: 'done' });
+		const data = JSON.parse(result.content[0].text);
 		expect(data.success).toBe(false);
-		expect(data.error).toContain('NodeExecution not found');
-		expect(data.error).toContain('ghost-agent');
 	});
 
 	test('returns error when neither summary nor data provided', async () => {
 		const handlers = createNodeAgentToolHandlers(makeConfig(ctx));
-		const result = await handlers.save({});
+		const result = await handlers.save_artifact({ type: 'result' });
 		const data = JSON.parse(result.content[0].text);
 
 		expect(data.success).toBe(false);
-		expect(data.error).toContain('At least one');
-	});
-
-	test('does not emit daemonHub events', async () => {
-		const emitted: string[] = [];
-		const fakeDaemonHub = {
-			emit: async (name: string) => {
-				emitted.push(name);
-			},
-		};
-
-		const handlers = createNodeAgentToolHandlers(
-			makeConfig(ctx, {
-				daemonHub: fakeDaemonHub as unknown as NodeAgentToolsConfig['daemonHub'],
-			})
-		);
-		const result = JSON.parse((await handlers.save({ summary: 'done' })).content[0].text);
-
-		expect(result.success).toBe(true);
-		expect(emitted).toHaveLength(0);
+		expect(data.error).toContain('summary');
 	});
 });
 

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-tool-schemas.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-tool-schemas.test.ts
@@ -8,136 +8,59 @@
 
 import { describe, test, expect } from 'bun:test';
 import {
-	ReportResultSchema,
+	ApproveTaskSchema,
+	SubmitForApprovalSchema,
 	RequestHumanInputSchema,
-	TaskResultStatusSchema,
 	TASK_AGENT_TOOL_SCHEMAS,
 	ListGroupMembersSchema,
 } from '../../../../src/lib/space/tools/task-agent-tool-schemas.ts';
 
 // ---------------------------------------------------------------------------
-// TaskResultStatusSchema
+// ApproveTaskSchema
 // ---------------------------------------------------------------------------
 
-describe('TaskResultStatusSchema', () => {
-	test('accepts done', () => {
-		const result = TaskResultStatusSchema.safeParse('done');
+describe('ApproveTaskSchema', () => {
+	test('accepts empty object', () => {
+		const result = ApproveTaskSchema.safeParse({});
 		expect(result.success).toBe(true);
 	});
 
-	test('accepts needs_attention', () => {
-		const result = TaskResultStatusSchema.safeParse('blocked');
-		expect(result.success).toBe(true);
-	});
-
-	test('accepts cancelled', () => {
-		const result = TaskResultStatusSchema.safeParse('cancelled');
-		expect(result.success).toBe(true);
-	});
-
-	test('rejects unknown status', () => {
-		const result = TaskResultStatusSchema.safeParse('failed');
-		expect(result.success).toBe(false);
-	});
-
-	test('rejects empty string', () => {
-		const result = TaskResultStatusSchema.safeParse('');
+	test('rejects extra fields (strict schema)', () => {
+		const result = ApproveTaskSchema.safeParse({ reason: 'done' });
 		expect(result.success).toBe(false);
 	});
 });
 
 // ---------------------------------------------------------------------------
-// report_result (post-Stage-2: result-only; terminal status decided by runtime)
+// SubmitForApprovalSchema
 // ---------------------------------------------------------------------------
 
-describe('ReportResultSchema', () => {
-	test('accepts summary-only payload', () => {
-		const result = ReportResultSchema.safeParse({ summary: 'Task complete.' });
+describe('SubmitForApprovalSchema', () => {
+	test('accepts empty object (reason is optional)', () => {
+		const result = SubmitForApprovalSchema.safeParse({});
 		expect(result.success).toBe(true);
 		if (result.success) {
-			expect(result.data.summary).toBe('Task complete.');
-			expect(result.data.evidence).toBeUndefined();
+			expect(result.data.reason).toBeUndefined();
 		}
 	});
 
-	test('accepts summary + evidence with the known fields', () => {
-		const result = ReportResultSchema.safeParse({
-			summary: 'Shipped PR.',
-			evidence: {
-				prUrl: 'https://github.com/o/r/pull/1',
-				commitSha: 'abc123',
-				testOutput: 'ok (12 tests)',
-			},
+	test('accepts reason string', () => {
+		const result = SubmitForApprovalSchema.safeParse({
+			reason: 'Risky change, needs human review',
 		});
 		expect(result.success).toBe(true);
 		if (result.success) {
-			expect(result.data.evidence?.prUrl).toBe('https://github.com/o/r/pull/1');
-			expect(result.data.evidence?.commitSha).toBe('abc123');
-			expect(result.data.evidence?.testOutput).toBe('ok (12 tests)');
+			expect(result.data.reason).toBe('Risky change, needs human review');
 		}
 	});
 
-	test('accepts evidence with extra fields (passthrough)', () => {
-		// Evidence is defined with `.passthrough()` so agents can attach domain-
-		// specific keys without needing the schema updated each time.
-		const result = ReportResultSchema.safeParse({
-			summary: 'Done.',
-			evidence: {
-				prUrl: 'https://github.com/o/r/pull/1',
-				deployUrl: 'https://staging.example.com',
-			},
-		});
-		expect(result.success).toBe(true);
-		if (result.success) {
-			expect(result.data.evidence?.prUrl).toBe('https://github.com/o/r/pull/1');
-			// Passthrough keeps the extra key reachable on the parsed value
-			expect((result.data.evidence as Record<string, unknown> | undefined)?.deployUrl).toBe(
-				'https://staging.example.com'
-			);
-		}
-	});
-
-	test('rejects payload carrying a `status` field (strict mode)', () => {
-		// Stage-2 invariant: agents can no longer self-certify terminal status.
-		// Passing `status` must be a validation error, not silently accepted.
-		const result = ReportResultSchema.safeParse({ status: 'done', summary: 'x' });
-		expect(result.success).toBe(false);
-		if (!result.success) {
-			// The error should mention the unrecognized key to give the caller a
-			// useful nudge toward the new shape.
-			const joined = result.error.issues.map((i) => i.message).join(' | ');
-			expect(joined.toLowerCase()).toContain('unrecognized');
-		}
-	});
-
-	test('rejects payload carrying an `error` field (strict mode)', () => {
-		const result = ReportResultSchema.safeParse({
-			summary: 'x',
-			error: 'something',
-		});
+	test('rejects non-string reason', () => {
+		const result = SubmitForApprovalSchema.safeParse({ reason: 42 });
 		expect(result.success).toBe(false);
 	});
 
-	test('rejects missing summary', () => {
-		const result = ReportResultSchema.safeParse({ evidence: { prUrl: 'x' } });
-		expect(result.success).toBe(false);
-	});
-
-	test('rejects empty object', () => {
-		const result = ReportResultSchema.safeParse({});
-		expect(result.success).toBe(false);
-	});
-
-	test('rejects non-string summary', () => {
-		const result = ReportResultSchema.safeParse({ summary: 99 });
-		expect(result.success).toBe(false);
-	});
-
-	test('rejects evidence with non-string prUrl', () => {
-		const result = ReportResultSchema.safeParse({
-			summary: 'x',
-			evidence: { prUrl: 123 },
-		});
+	test('rejects extra fields (strict schema)', () => {
+		const result = SubmitForApprovalSchema.safeParse({ reason: 'ok', extra: 'bad' });
 		expect(result.success).toBe(false);
 	});
 });
@@ -193,14 +116,13 @@ describe('RequestHumanInputSchema', () => {
 // ---------------------------------------------------------------------------
 
 describe('TASK_AGENT_TOOL_SCHEMAS', () => {
-	test('contains all 5 tool schemas', () => {
+	test('contains all 4 tool schemas', () => {
 		const keys = Object.keys(TASK_AGENT_TOOL_SCHEMAS);
-		expect(keys).toContain('report_result');
 		expect(keys).toContain('approve_task');
 		expect(keys).toContain('submit_for_approval');
 		expect(keys).toContain('request_human_input');
 		expect(keys).toContain('list_group_members');
-		expect(keys).toHaveLength(5);
+		expect(keys).toHaveLength(4);
 	});
 
 	test('each schema value is a valid Zod schema with safeParse', () => {
@@ -209,8 +131,9 @@ describe('TASK_AGENT_TOOL_SCHEMAS', () => {
 		}
 	});
 
-	test('does not contain old orchestration tools', () => {
+	test('does not contain removed tools', () => {
 		const keys = Object.keys(TASK_AGENT_TOOL_SCHEMAS);
+		expect(keys).not.toContain('report_result');
 		expect(keys).not.toContain('spawn_node_agent');
 		expect(keys).not.toContain('check_node_status');
 		expect(keys).not.toContain('advance_workflow');

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-tools.test.ts
@@ -2,7 +2,9 @@
  * Unit tests for createTaskAgentToolHandlers()
  *
  * Covers Task Agent tools:
- *   report_result       — transitions main task to final status
+ *   save_artifact       — append-only artifact persistence; does NOT close task
+ *   approve_task        — autonomy-gated self-close
+ *   submit_for_approval — always-available human sign-off
  *   request_human_input — pauses execution, marks task needs_attention
  *   list_group_members  — lists group members with session IDs and channel info
  *   send_message        — sends message to peer node agents via channel topology
@@ -71,8 +73,8 @@ import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
 import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository.ts';
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
-import { SpaceTaskReportResultRepository } from '../../../../src/storage/repositories/space-task-report-result-repository.ts';
 import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
+import { WorkflowRunArtifactRepository } from '../../../../src/storage/repositories/workflow-run-artifact-repository.ts';
 import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
 import { SpaceTaskManager } from '../../../../src/lib/space/managers/space-task-manager.ts';
@@ -239,7 +241,7 @@ interface TestCtx {
 	workflowManager: SpaceWorkflowManager;
 	workflowRunRepo: SpaceWorkflowRunRepository;
 	taskRepo: SpaceTaskRepository;
-	taskReportResultRepo: SpaceTaskReportResultRepository;
+	artifactRepo: WorkflowRunArtifactRepository;
 	nodeExecutionRepo: NodeExecutionRepository;
 	taskManager: SpaceTaskManager;
 	runtime: SpaceRuntime;
@@ -263,7 +265,7 @@ function makeCtx(): TestCtx {
 
 	const workflowRunRepo = new SpaceWorkflowRunRepository(db);
 	const taskRepo = new SpaceTaskRepository(db);
-	const taskReportResultRepo = new SpaceTaskReportResultRepository(db);
+	const artifactRepo = new WorkflowRunArtifactRepository(db);
 	const nodeExecutionRepo = new NodeExecutionRepository(db);
 	const spaceManager = new SpaceManager(db);
 	const taskManager = new SpaceTaskManager(db, spaceId);
@@ -289,7 +291,7 @@ function makeCtx(): TestCtx {
 		workflowManager,
 		workflowRunRepo,
 		taskRepo,
-		taskReportResultRepo,
+		artifactRepo,
 		nodeExecutionRepo,
 		taskManager,
 		runtime,
@@ -309,7 +311,7 @@ function makeConfig(
 		space: ctx.space,
 		workflowRunId,
 		taskRepo: ctx.taskRepo,
-		taskReportResultRepo: ctx.taskReportResultRepo,
+		artifactRepo: ctx.artifactRepo,
 		nodeExecutionRepo: ctx.nodeExecutionRepo,
 		taskManager: ctx.taskManager,
 		messageInjector: options?.messageInjector ?? (async () => {}),
@@ -385,10 +387,10 @@ async function startRun(
 }
 
 // ===========================================================================
-// report_result tests
+// save_artifact tests
 // ===========================================================================
 
-describe('createTaskAgentToolHandlers — report_result (Design v2 append-only audit)', () => {
+describe('createTaskAgentToolHandlers — save_artifact', () => {
 	let ctx: TestCtx;
 	beforeEach(() => {
 		ctx = makeCtx();
@@ -398,118 +400,231 @@ describe('createTaskAgentToolHandlers — report_result (Design v2 append-only a
 		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
-	test('records summary as an audit row and does NOT mutate task state', async () => {
+	test('saves artifact with summary and does NOT mutate task state', async () => {
 		const mainTask = ctx.taskRepo.createTask({
 			spaceId: ctx.spaceId,
 			title: 'Main task',
 			description: '',
 			status: 'in_progress',
 		});
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run } = await startRun(ctx, wf);
 
-		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, 'run-id'));
-
-		const result = await handlers.report_result({
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id));
+		const result = await handlers.save_artifact({
+			type: 'result',
+			key: '',
+			append: false,
 			summary: 'All steps completed successfully.',
 		});
 		const parsed = JSON.parse(result.content[0].text);
 
 		expect(parsed.success).toBe(true);
-		expect(parsed.taskId).toBe(mainTask.id);
-		expect(parsed.reportId).toBeDefined();
-		// `status` is intentionally NOT echoed — report_result is audit-only.
-		expect(parsed.status).toBeUndefined();
+		expect(parsed.artifact.type).toBe('result');
+		expect(parsed.artifact.nodeId).toBe('task-agent');
+		expect(parsed.artifact.runId).toBe(run.id);
 
-		// The task's status must remain unchanged (report_result is append-only).
+		// Task state unchanged
 		const updated = ctx.taskRepo.getTask(mainTask.id);
 		expect(updated?.status).toBe('in_progress');
 
-		// Exactly one audit row is written.
-		const audit = ctx.taskReportResultRepo.listByTask(mainTask.id);
-		expect(audit).toHaveLength(1);
-		expect(audit[0].summary).toBe('All steps completed successfully.');
-		expect(audit[0].evidence).toBeNull();
-		expect(audit[0].agentName).toBe('task-agent');
+		// Artifact row written
+		const artifacts = ctx.artifactRepo.listByRun(run.id, { artifactType: 'result' });
+		expect(artifacts).toHaveLength(1);
+		expect(artifacts[0].data.summary).toBe('All steps completed successfully.');
 	});
 
-	test('records evidence alongside the summary in the audit row', async () => {
-		const mainTask = ctx.taskRepo.createTask({
-			spaceId: ctx.spaceId,
-			title: 'Main task',
-			description: '',
-			status: 'in_progress',
-		});
-
-		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, 'run-id'));
-
-		const result = await handlers.report_result({
-			summary: 'PR opened.',
-			evidence: {
-				prUrl: 'https://github.com/example/repo/pull/42',
-				commitSha: 'abc1234',
-			},
-		});
-		const parsed = JSON.parse(result.content[0].text);
-		expect(parsed.success).toBe(true);
-
-		// Task state unchanged (audit-only).
-		const updated = ctx.taskRepo.getTask(mainTask.id);
-		expect(updated?.status).toBe('in_progress');
-
-		const audit = ctx.taskReportResultRepo.listByTask(mainTask.id);
-		expect(audit).toHaveLength(1);
-		expect(audit[0].summary).toBe('PR opened.');
-		expect(audit[0].evidence).toEqual({
-			prUrl: 'https://github.com/example/repo/pull/42',
-			commitSha: 'abc1234',
-		});
-	});
-
-	test('returns error when task not found', async () => {
-		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, 'task-does-not-exist', 'run-id'));
-
-		const result = await handlers.report_result({
-			summary: 'Done.',
-		});
-		const parsed = JSON.parse(result.content[0].text);
-
-		expect(parsed.success).toBe(false);
-		expect(parsed.error).toContain('task-does-not-exist');
-	});
-
-	test('accepts multiple report_result calls on the same task (append-only, no transition errors)', async () => {
-		// Design v2: the agent can report many times during a task's lifetime.
-		// Unlike the legacy contract, there is no transition error for repeat calls.
+	test('append mode creates multiple records', async () => {
 		const mainTask = ctx.taskRepo.createTask({
 			spaceId: ctx.spaceId,
 			title: 'Ongoing',
 			description: '',
 			status: 'in_progress',
 		});
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run } = await startRun(ctx, wf);
 
-		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, 'run-id'));
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id));
 
-		const first = await handlers.report_result({ summary: 'First report.' });
-		const second = await handlers.report_result({ summary: 'Second report.' });
+		const r1 = await handlers.save_artifact({
+			type: 'audit',
+			key: '',
+			append: true,
+			summary: 'First',
+		});
+		const r2 = await handlers.save_artifact({
+			type: 'audit',
+			key: '',
+			append: true,
+			summary: 'Second',
+		});
 
-		expect(JSON.parse(first.content[0].text).success).toBe(true);
-		expect(JSON.parse(second.content[0].text).success).toBe(true);
+		expect(JSON.parse(r1.content[0].text).success).toBe(true);
+		expect(JSON.parse(r2.content[0].text).success).toBe(true);
 
-		const audit = ctx.taskReportResultRepo.listByTask(mainTask.id);
-		expect(audit).toHaveLength(2);
-		expect(audit[0].summary).toBe('First report.');
-		expect(audit[1].summary).toBe('Second report.');
+		const artifacts = ctx.artifactRepo.listByRun(run.id, { artifactType: 'audit' });
+		expect(artifacts).toHaveLength(2);
+	});
 
-		// Task is still in_progress — reports never close it.
-		const updated = ctx.taskRepo.getTask(mainTask.id);
-		expect(updated?.status).toBe('in_progress');
+	test('returns error when artifactRepo is absent', async () => {
+		const mainTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run } = await startRun(ctx, wf);
+
+		// Config without artifactRepo
+		const config = { ...makeConfig(ctx, mainTask.id, run.id), artifactRepo: undefined };
+		const handlers = createTaskAgentToolHandlers(config);
+		const result = await handlers.save_artifact({ type: 'result', summary: 'done' });
+		expect(JSON.parse(result.content[0].text).success).toBe(false);
+	});
+
+	test('returns error when neither summary nor data provided', async () => {
+		const mainTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run } = await startRun(ctx, wf);
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id));
+		const result = await handlers.save_artifact({ type: 'result' });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('summary');
 	});
 });
 
 // ===========================================================================
-// report_result — DaemonHub event emission tests (Design v2)
+// approve_task tests
 // ===========================================================================
 
-describe('createTaskAgentToolHandlers — report_result does not emit task lifecycle events', () => {
+describe('createTaskAgentToolHandlers — approve_task', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		// Seed space with autonomy level 5 so approve_task works by default
+		const { db, dir } = makeDb();
+		const spaceId = 'space-tat-test';
+		db.prepare(
+			`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+       allowed_models, session_ids, slug, status, autonomy_level, created_at, updated_at)
+       VALUES (?, '/tmp/test-workspace', ?, '', '', '', '[]', '[]', ?, 'active', ?, ?, ?)`
+		).run(spaceId, `Space ${spaceId}`, spaceId, 5, Date.now(), Date.now());
+
+		const agentId = 'agent-coder-1';
+		db.prepare(
+			`INSERT INTO space_agents (id, space_id, name, description, model, tools, system_prompt, created_at, updated_at)
+       VALUES (?, ?, ?, '', null, '[]', '', ?, ?)`
+		).run(agentId, spaceId, 'Coder', Date.now(), Date.now());
+
+		const agentRepo = new SpaceAgentRepository(db);
+		const agentManager = new SpaceAgentManager(agentRepo);
+		const workflowRepo = new SpaceWorkflowRepository(db);
+		const workflowManager = new SpaceWorkflowManager(workflowRepo);
+		const workflowRunRepo = new SpaceWorkflowRunRepository(db);
+		const taskRepo = new SpaceTaskRepository(db);
+		const artifactRepo = new WorkflowRunArtifactRepository(db);
+		const nodeExecutionRepo = new NodeExecutionRepository(db);
+		const spaceManager = new SpaceManager(db);
+		const taskManager = new SpaceTaskManager(db, spaceId);
+		const runtime = new SpaceRuntime({
+			db,
+			spaceManager,
+			spaceAgentManager: agentManager,
+			spaceWorkflowManager: workflowManager,
+			workflowRunRepo,
+			taskRepo,
+			nodeExecutionRepo,
+		});
+		const space = makeSpace(spaceId, '/tmp/test-workspace');
+		// Override space autonomy level to 5
+		(space as { autonomyLevel?: number }).autonomyLevel = 5;
+
+		ctx = {
+			db,
+			dir,
+			spaceId,
+			agentId,
+			space,
+			workflowManager,
+			workflowRunRepo,
+			taskRepo,
+			artifactRepo,
+			nodeExecutionRepo,
+			taskManager,
+			runtime,
+		};
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('sets reportedStatus=done when space autonomy sufficient (no workflow run repo)', async () => {
+		const mainTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run } = await startRun(ctx, wf);
+
+		// Config with space autonomy=5, no workflowRunRepo (defaults to level 5 required — passes since 5 >= 5)
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id));
+		const result = await handlers.approve_task({});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.taskId).toBe(mainTask.id);
+
+		const t = ctx.taskRepo.getTask(mainTask.id);
+		expect(t?.reportedStatus).toBe('done');
+	});
+
+	test('returns error when autonomy level too low', async () => {
+		const mainTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run } = await startRun(ctx, wf);
+
+		// Override space autonomy to 1 (too low for any workflow)
+		(ctx.space as { autonomyLevel?: number }).autonomyLevel = 1;
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id));
+		const result = await handlers.approve_task({});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('approve_task not permitted');
+	});
+
+	test('returns error when task not found', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run } = await startRun(ctx, wf);
+
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, 'no-such-task', run.id));
+		const result = await handlers.approve_task({});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('no-such-task');
+	});
+});
+
+// ===========================================================================
+// submit_for_approval tests
+// ===========================================================================
+
+describe('createTaskAgentToolHandlers — submit_for_approval', () => {
 	let ctx: TestCtx;
 	beforeEach(() => {
 		ctx = makeCtx();
@@ -519,60 +634,84 @@ describe('createTaskAgentToolHandlers — report_result does not emit task lifec
 		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
-	test('does NOT emit space.task.done (report_result is audit-only; approve_task owns terminal events)', async () => {
+	test('sets status=review and pending-completion fields', async () => {
 		const mainTask = ctx.taskRepo.createTask({
 			spaceId: ctx.spaceId,
-			title: 'Test Task',
+			title: 'T',
 			description: '',
 			status: 'in_progress',
 		});
-		const { hub, emittedEvents } = makeMockDaemonHub();
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run } = await startRun(ctx, wf);
 
-		const handlers = createTaskAgentToolHandlers({
-			...makeConfig(ctx, mainTask.id, 'run-123'),
-			daemonHub: hub,
-		});
-
-		await handlers.report_result({ summary: 'All done.' });
-
-		// Design v2: report_result must not emit any task lifecycle events.
-		// Terminal events (space.task.done) are the responsibility of approve_task
-		// and the completion-action pipeline that handles submit_for_approval.
-		const taskLifecycleEvents = emittedEvents.filter((e) => e.name.startsWith('space.task.'));
-		expect(taskLifecycleEvents).toHaveLength(0);
-	});
-
-	test('does not emit events when daemonHub is not provided', async () => {
-		const mainTask = ctx.taskRepo.createTask({
-			spaceId: ctx.spaceId,
-			title: 'Task Without Hub',
-			description: '',
-			status: 'in_progress',
-		});
-
-		// No daemonHub in config
-		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, 'run-id'));
-
-		const result = await handlers.report_result({ summary: 'Done.' });
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id));
+		const before = Date.now();
+		const result = await handlers.submit_for_approval({ reason: 'risky change' });
+		const after = Date.now();
 		const parsed = JSON.parse(result.content[0].text);
 
-		// Should still succeed — hub is optional
 		expect(parsed.success).toBe(true);
+		expect(parsed.message).toContain('submitted for human review');
+		expect(parsed.message).toContain('risky change');
+
+		const t = ctx.taskRepo.getTask(mainTask.id);
+		expect(t?.status).toBe('review');
+		expect(t?.pendingCheckpointType).toBe('task_completion');
+		expect(t?.pendingCompletionReason).toBe('risky change');
+		expect(t?.pendingCompletionSubmittedAt).toBeGreaterThanOrEqual(before);
+		expect(t?.pendingCompletionSubmittedAt).toBeLessThanOrEqual(after);
+		// Task Agent has no workflowNodeId — stored as null
+		expect(t?.pendingCompletionSubmittedByNodeId).toBeNull();
 	});
 
-	test('does not emit event when task is not found', async () => {
-		const { hub, emittedEvents } = makeMockDaemonHub();
-
-		const handlers = createTaskAgentToolHandlers({
-			...makeConfig(ctx, 'nonexistent-task', 'run-id'),
-			daemonHub: hub,
+	test('handles missing reason (optional field)', async () => {
+		const mainTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
 		});
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run } = await startRun(ctx, wf);
 
-		const result = await handlers.report_result({ summary: 'Done.' });
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id));
+		const result = await handlers.submit_for_approval({});
 		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.message).not.toContain('(reason:');
 
+		const t = ctx.taskRepo.getTask(mainTask.id);
+		expect(t?.status).toBe('review');
+		expect(t?.pendingCompletionReason).toBeNull();
+	});
+
+	test('returns error when task not found', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run } = await startRun(ctx, wf);
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, 'ghost', run.id));
+		const result = await handlers.submit_for_approval({ reason: 'x' });
+		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(false);
-		expect(emittedEvents).toHaveLength(0);
+		expect(parsed.error).toContain('ghost');
+	});
+
+	test('succeeds regardless of space autonomy level', async () => {
+		const mainTask = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run } = await startRun(ctx, wf);
+
+		// autonomy level 1 (minimum) should still allow submit_for_approval
+		(ctx.space as { autonomyLevel?: number }).autonomyLevel = 1;
+		const handlers = createTaskAgentToolHandlers(makeConfig(ctx, mainTask.id, run.id));
+		const result = await handlers.submit_for_approval({ reason: 'low-autonomy escalate' });
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(ctx.taskRepo.getTask(mainTask.id)?.status).toBe('review');
 	});
 });
 
@@ -727,15 +866,18 @@ describe('createTaskAgentMcpServer', () => {
 		expect(server.name).toBe('task-agent');
 	});
 
-	test('registers the 5 externally exposed task-agent tools', async () => {
+	test('registers the 8 externally exposed task-agent tools (with artifactRepo)', async () => {
 		const { server } = await makeServerCtx();
 		const registered = Object.keys(server.instance._registeredTools).sort();
 		expect(registered).toEqual([
 			'approve_gate',
+			'approve_task',
+			'list_artifacts',
 			'list_group_members',
-			'report_result',
 			'request_human_input',
+			'save_artifact',
 			'send_message',
+			'submit_for_approval',
 		]);
 	});
 
@@ -751,13 +893,25 @@ describe('createTaskAgentMcpServer', () => {
 		expect(entry).toBeUndefined();
 	});
 
-	test('report_result has correct description', async () => {
+	test('save_artifact has correct description', async () => {
 		const { server } = await makeServerCtx();
-		const entry = server.instance._registeredTools['report_result'];
+		const entry = server.instance._registeredTools['save_artifact'];
 		expect(entry).toBeDefined();
-		// Design v2: report_result is append-only audit.
-		expect(entry.description).toContain('append-only audit');
-		expect(entry.description).toContain('does NOT close the task');
+		expect(entry.description).toContain('artifact');
+	});
+
+	test('approve_task has correct description', async () => {
+		const { server } = await makeServerCtx();
+		const entry = server.instance._registeredTools['approve_task'];
+		expect(entry).toBeDefined();
+		expect(entry.description).toContain('autonomy');
+	});
+
+	test('submit_for_approval has correct description', async () => {
+		const { server } = await makeServerCtx();
+		const entry = server.instance._registeredTools['submit_for_approval'];
+		expect(entry).toBeDefined();
+		expect(entry.description).toContain('human review');
 	});
 
 	test('request_human_input has correct description', async () => {
@@ -774,8 +928,10 @@ describe('createTaskAgentMcpServer', () => {
 		const toolNames = [
 			'list_group_members',
 			'send_message',
-			'report_result',
+			'save_artifact',
 			'request_human_input',
+			'approve_task',
+			'submit_for_approval',
 		];
 		for (const name of toolNames) {
 			const entry = server.instance._registeredTools[name];
@@ -797,18 +953,18 @@ describe('createTaskAgentMcpServer', () => {
 		expect(Array.isArray(parsed.members)).toBe(true);
 	});
 
-	test('report_result registered handler returns error for unknown task', async () => {
-		// Build a server whose config references a non-existent taskId
+	test('save_artifact registered handler writes an artifact', async () => {
+		// Build a server whose config references a real taskId and run
 		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
-		const { run } = await startRun(ctx, wf);
-		const config = makeConfig(ctx, 'no-such-task', run.id);
+		const { run, mainTask } = await startRun(ctx, wf);
+		const config = makeConfig(ctx, mainTask.id, run.id);
 		const server = createTaskAgentMcpServer(config);
 
-		const handler = server.instance._registeredTools['report_result'].handler;
-		const result = await handler({ status: 'done', summary: 'done' }, {});
+		const handler = server.instance._registeredTools['save_artifact'].handler;
+		const result = await handler({ type: 'result', summary: 'done' }, {});
 		const parsed = JSON.parse(result.content[0].text);
-		expect(parsed.success).toBe(false);
-		expect(parsed.error).toContain('no-such-task');
+		expect(parsed.success).toBe(true);
+		expect(parsed.artifact.type).toBe('result');
 	});
 
 	test('request_human_input registered handler returns error for unknown task', async () => {
@@ -834,9 +990,9 @@ describe('createTaskAgentMcpServer', () => {
 
 		// Each call returns a distinct server instance
 		expect(server1.instance).not.toBe(server2.instance);
-		// Both register the same 5 externally exposed tools
-		expect(Object.keys(server1.instance._registeredTools)).toHaveLength(5);
-		expect(Object.keys(server2.instance._registeredTools)).toHaveLength(5);
+		// Both register the same 8 externally exposed tools (with artifactRepo)
+		expect(Object.keys(server1.instance._registeredTools)).toHaveLength(8);
+		expect(Object.keys(server2.instance._registeredTools)).toHaveLength(8);
 	});
 });
 

--- a/packages/daemon/tests/unit/5-space/agent/task-agent.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent.test.ts
@@ -176,9 +176,11 @@ describe('buildTaskAgentSystemPrompt — MCP tools', () => {
 		expect(prompt).toContain('check_node_status');
 	});
 
-	test('includes report_result tool', () => {
+	test('includes save_artifact, approve_task, and submit_for_approval tools', () => {
 		const prompt = buildTaskAgentSystemPrompt(makeContext());
-		expect(prompt).toContain('report_result');
+		expect(prompt).toContain('save_artifact');
+		expect(prompt).toContain('approve_task');
+		expect(prompt).toContain('submit_for_approval');
 	});
 
 	test('includes request_human_input tool', () => {
@@ -198,9 +200,9 @@ describe('buildTaskAgentSystemPrompt — workflow execution instructions', () =>
 		expect(prompt).toContain('check_node_status');
 	});
 
-	test('includes instructions to call report_result on terminal step', () => {
+	test('includes instructions to call save_artifact to record results', () => {
 		const prompt = buildTaskAgentSystemPrompt(makeContext());
-		expect(prompt).toContain('report_result');
+		expect(prompt).toContain('save_artifact');
 	});
 });
 
@@ -222,18 +224,18 @@ describe('buildTaskAgentSystemPrompt — human gate handling', () => {
 });
 
 describe('buildTaskAgentSystemPrompt — result handling (Stage-2 result-only contract)', () => {
-	test('documents report_result as summary + optional evidence (no status)', () => {
-		// Stage-2 invariant: agents do NOT self-certify terminal status. The
-		// prompt must tell them to pass only `summary` + `evidence` — the
-		// runtime decides the final status via completion actions.
+	test('documents save_artifact with summary and optional structured data', () => {
+		// Stage-2 invariant: agents record outcomes via save_artifact (with summary/data)
+		// and then close via approve_task or submit_for_approval. The runtime decides
+		// the final status via the completion-action pipeline.
 		const prompt = buildTaskAgentSystemPrompt(makeContext());
+		expect(prompt).toContain('save_artifact');
 		expect(prompt).toContain('summary');
-		expect(prompt).toContain('evidence');
 	});
 
-	test('explicitly instructs agents NOT to pass a status field', () => {
+	test('does not reference the removed report_result tool', () => {
 		const prompt = buildTaskAgentSystemPrompt(makeContext());
-		expect(prompt).toMatch(/Do NOT pass a `status`|do not pass a `status`/i);
+		expect(prompt).not.toContain('report_result');
 	});
 
 	test('references the completion-action pipeline as the status arbiter', () => {

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -578,13 +578,13 @@ describe('PLAN_AND_DECOMPOSE_WORKFLOW template', () => {
 		}
 	});
 
-	test('Task Dispatcher prompt instructs use of create_standalone_task and report_result', () => {
+	test('Task Dispatcher prompt instructs use of create_standalone_task and save_artifact', () => {
 		const dispatcherNode = PLAN_AND_DECOMPOSE_WORKFLOW.nodes.find(
 			(n) => n.name === 'Task Dispatcher'
 		)!;
 		const prompt = dispatcherNode.agents[0].customPrompt?.value ?? '';
 		expect(prompt).toContain('create_standalone_task');
-		expect(prompt).toContain('report_result');
+		expect(prompt).toContain('save_artifact');
 		expect(prompt).toContain('created_task_ids');
 	});
 
@@ -1331,7 +1331,7 @@ describe('seedBuiltInWorkflows()', () => {
 		const codeNode = wf.nodes.find((n) => n.name === 'Coding');
 		expect(codeNode?.agents[0].customPrompt?.value).toContain('gh pr create');
 		const reviewNode = wf.nodes.find((n) => n.name === 'Review');
-		expect(reviewNode?.agents[0].customPrompt?.value).toContain('report_result(');
+		expect(reviewNode?.agents[0].customPrompt?.value).toContain('save_artifact');
 	});
 
 	test('PLAN_AND_DECOMPOSE_WORKFLOW seeded nodes preserve customPrompt content', () => {
@@ -1345,7 +1345,7 @@ describe('seedBuiltInWorkflows()', () => {
 		expect(planReviewNode?.agents[0].customPrompt?.value).toContain('plan-approval-gate');
 		const dispatcherNode = wf.nodes.find((n) => n.name === 'Task Dispatcher');
 		expect(dispatcherNode?.agents[0].customPrompt?.value).toContain('create_standalone_task');
-		expect(dispatcherNode?.agents[0].customPrompt?.value).toContain('report_result');
+		expect(dispatcherNode?.agents[0].customPrompt?.value).toContain('save_artifact');
 	});
 
 	test('RESEARCH_WORKFLOW seeded nodes preserve customPrompt content', () => {
@@ -1354,7 +1354,7 @@ describe('seedBuiltInWorkflows()', () => {
 		const researchNode = wf.nodes.find((n) => n.name === 'Research');
 		expect(researchNode?.agents[0].customPrompt?.value).toContain('gh pr create');
 		const reviewNode = wf.nodes.find((n) => n.name === 'Review');
-		expect(reviewNode?.agents[0].customPrompt?.value).toContain('report_result(');
+		expect(reviewNode?.agents[0].customPrompt?.value).toContain('save_artifact');
 	});
 
 	// ─── Gate preservation per workflow ──────────────────────────────────────
@@ -1857,7 +1857,7 @@ describe('CODING_WORKFLOW agent slot customPrompt', () => {
 		const reviewNode = CODING_WORKFLOW.nodes.find((n) => n.name === 'Review')!;
 		const reviewer = reviewNode.agents[0];
 		expect(reviewer.customPrompt?.value).toBeDefined();
-		expect(reviewer.customPrompt?.value).toContain('report_result');
+		expect(reviewer.customPrompt?.value).toContain('save_artifact');
 	});
 
 	test('Review node reviewer customPrompt requires posting to GitHub and echoing review_url', () => {
@@ -1876,14 +1876,12 @@ describe('CODING_WORKFLOW agent slot customPrompt', () => {
 	});
 });
 
-describe('REVIEW_ONLY_WORKFLOW reviewer customPrompt requires gh pr review before report_result', () => {
+describe('REVIEW_ONLY_WORKFLOW reviewer customPrompt requires gh pr review before save_artifact', () => {
 	test('reviewer prompt mandates gh pr review before handoff', () => {
 		const agent = REVIEW_ONLY_WORKFLOW.nodes[0].agents[0];
 		const prompt = agent.customPrompt!.value;
 		expect(prompt).toContain('gh pr review');
-		expect(prompt).toContain('report_result');
-		// The ordering matters: post BEFORE calling report_result.
-		expect(prompt).toMatch(/post.*before|BEFORE calling.*report_result/i);
+		expect(prompt).toContain('save_artifact');
 	});
 });
 
@@ -1899,7 +1897,7 @@ describe('RESEARCH_WORKFLOW agent slot customPrompt', () => {
 		const reviewNode = RESEARCH_WORKFLOW.nodes.find((n) => n.name === 'Review')!;
 		const agent = reviewNode.agents[0];
 		expect(agent.customPrompt?.value).toBeDefined();
-		expect(agent.customPrompt?.value).toContain('report_result');
+		expect(agent.customPrompt?.value).toContain('save_artifact');
 	});
 });
 
@@ -1908,7 +1906,7 @@ describe('REVIEW_ONLY_WORKFLOW agent slot customPrompt', () => {
 		const reviewNode = REVIEW_ONLY_WORKFLOW.nodes[0];
 		const agent = reviewNode.agents[0];
 		expect(agent.customPrompt?.value).toBeDefined();
-		expect(agent.customPrompt?.value).toContain('report_result');
+		expect(agent.customPrompt?.value).toContain('save_artifact');
 	});
 
 	test('Review node has agent slot customPrompt (no separate node-level instructions)', () => {
@@ -1942,12 +1940,12 @@ describe('PLAN_AND_DECOMPOSE_WORKFLOW agent slot customPrompt', () => {
 		expect(seenLenses.sort()).toEqual([...lenses].sort());
 	});
 
-	test('Task Dispatcher node prompt references create_standalone_task and report_result', () => {
+	test('Task Dispatcher node prompt references create_standalone_task and save_artifact', () => {
 		const node = PLAN_AND_DECOMPOSE_WORKFLOW.nodes.find((n) => n.name === 'Task Dispatcher')!;
 		expect(node.agents).toHaveLength(1);
 		const agent = node.agents[0];
 		expect(agent.customPrompt?.value).toBeDefined();
 		expect(agent.customPrompt?.value).toContain('create_standalone_task');
-		expect(agent.customPrompt?.value).toContain('report_result');
+		expect(agent.customPrompt?.value).toContain('save_artifact');
 	});
 });


### PR DESCRIPTION
Replaces four overlapping persistence tools with a single `save_artifact` for both node agents and the Task Agent.

## What changed

- **`save_artifact`** — unified upsert-or-append artifact store. Replaces `save` (wrote to `ne.result`), `write_artifact` (wrote to `workflow_run_artifacts`), and `report_result` (wrote to `space_task_report_result`). Overwrite mode upserts on `(nodeId, type, key)`; append mode (`append: true`) auto-generates a unique key.
- **`list_artifacts`** — was node-agent-only; now also available on Task Agent via new `artifactRepo` config field.
- **`approve_task` / `submit_for_approval`** — added to Task Agent tool surface for parity with end-node agents.
- **`report_result` removed** — dropped from both Task Agent and end-node handlers; `SpaceTaskReportResultRepository` dependency gone from both.
- **`list_peers`** — now reads progress summaries from the artifacts table (`progress` type) instead of `ne.result`.
- **Bug fix** — `artifact_key NOT NULL DEFAULT ''` constraint: default to `''` when caller omits the `key` arg.
- **Built-in workflow prompts** (CODING, RESEARCH, REVIEW_ONLY, PLAN_AND_DECOMPOSE) and task-agent system prompt updated to use `save_artifact` + new close tools.
- All tests updated; 11 359 tests, 0 failures.