### PR TITLE
fix(db-query): expose space sessions and sdk_messages in space scope

### DIFF
--- a/packages/daemon/src/lib/db-query/scope-config.ts
+++ b/packages/daemon/src/lib/db-query/scope-config.ts
@@ -15,6 +15,31 @@ export interface ScopeJoinConfig {
 	joinPkColumn: string;
 	/** The scope column on the join table (e.g., 'room_id' or 'space_id'). */
 	scopeColumn: string;
+	/**
+	 * When set, uses `LIKE ?` instead of `= ?` for the join's WHERE clause.
+	 * The LIKE parameter is constructed as: `likePrefix + scopeValue + likeSuffix`.
+	 * Example: likePrefix='space:', likeSuffix=':%' → WHERE session_id LIKE 'space:abc:%'
+	 */
+	likePrefix?: string;
+	/** Suffix for the LIKE pattern. Only used when likePrefix is set. Defaults to ''. */
+	likeSuffix?: string;
+}
+
+/**
+ * Configuration for LIKE-based scope filtering on a direct column.
+ *
+ * Used for tables where scope is encoded in a column value via a prefix pattern,
+ * such as session IDs with the format `space:<spaceId>:<rest>`.
+ *
+ * The LIKE parameter is constructed as: `patternPrefix + scopeValue + patternSuffix`.
+ */
+export interface ScopeLikeConfig {
+	/** Column to apply LIKE filter on (e.g., 'id', 'session_id'). */
+	column: string;
+	/** Text before the scope value in the LIKE pattern (e.g., 'space:'). */
+	patternPrefix: string;
+	/** Text after the scope value in the LIKE pattern (e.g., ':%'). */
+	patternSuffix: string;
 }
 
 /** Full configuration for a table within a given scope. */
@@ -25,6 +50,8 @@ export interface ScopeTableConfig {
 	scopeColumn?: string;
 	/** Indirect scope resolution via a join table. */
 	scopeJoin?: ScopeJoinConfig;
+	/** LIKE-based scope filter for prefix-encoded IDs (e.g., session ID prefix). */
+	scopeLike?: ScopeLikeConfig;
 	/** Columns to exclude from `db_describe_table` and `SELECT *`. */
 	blacklistedColumns: string[];
 	/** Human-readable description for the agent. */
@@ -293,22 +320,59 @@ const SPACE_SCOPE_TABLES: ScopeTableConfig[] = [
 		description:
 			'JSON-serialised cache of git-derived artifact data (gate diffs, commit log, per-file diffs) populated by background sync jobs and served to the TaskArtifactsPanel.',
 	},
+	// ── Main-DB tables exposed with space-scoped filtering via session ID prefix ──
+	{
+		tableName: 'sessions',
+		scopeLike: { column: 'id', patternPrefix: 'space:', patternSuffix: ':%' },
+		blacklistedColumns: COLUMN_BLACKLISTS.sessions,
+		description:
+			'Agent sessions belonging to this space — task agents, node agents, and sub-sessions. Filtered by session ID prefix (space:<space_id>:*). Includes status, type, workspace path, and timestamps.',
+	},
+	{
+		tableName: 'sdk_messages',
+		scopeLike: { column: 'session_id', patternPrefix: 'space:', patternSuffix: ':%' },
+		blacklistedColumns: [],
+		description:
+			'SDK conversation messages for sessions belonging to this space. Filtered by session_id prefix (space:<space_id>:*). Includes message type, subtype, content, timestamp, and send status.',
+	},
+	{
+		tableName: 'session_groups',
+		scopeJoin: {
+			localColumn: 'id',
+			joinTable: 'session_group_members',
+			joinPkColumn: 'group_id',
+			scopeColumn: 'session_id',
+			likePrefix: 'space:',
+			likeSuffix: ':%',
+		},
+		blacklistedColumns: [],
+		description:
+			'Session groups (multi-agent collaborations) whose members include sessions belonging to this space. Scoped via session_group_members.session_id prefix.',
+	},
+	{
+		tableName: 'session_group_members',
+		scopeLike: { column: 'session_id', patternPrefix: 'space:', patternSuffix: ':%' },
+		blacklistedColumns: [],
+		description:
+			'Session group memberships for sessions belonging to this space. Filtered by session_id prefix (space:<space_id>:*).',
+	},
 ];
 
 /**
  * Tables that are intentionally excluded from ALL scopes.
- * These include sensitive config tables, raw message stores, and internal infrastructure.
+ * These include sensitive config tables and internal infrastructure.
+ *
+ * Note: `sdk_messages`, `session_groups`, and `session_group_members` are now
+ * accessible in the **space** scope (with session ID prefix filtering) and are
+ * therefore NOT in this list. They remain inaccessible in global and room scopes.
  */
 const EXCLUDED_TABLE_NAMES: string[] = [
 	// Sensitive configuration (contains auth tokens, API keys)
 	'auth_config',
 	'global_tools_config',
 	'global_settings',
-	// Raw SDK message store (too large, not useful for ad-hoc queries)
-	'sdk_messages',
-	// Internal session group infrastructure
-	'session_groups',
-	'session_group_members',
+	// session_groups, session_group_members, and sdk_messages are now in SPACE_SCOPE_TABLES.
+	// task_group_events remains excluded — internal event log, not useful for ad-hoc queries.
 	'task_group_events',
 	// Node execution tracking — transient per-run agent state, not useful for ad-hoc queries
 	'node_executions',
@@ -390,16 +454,18 @@ export function getExcludedTableNames(): string[] {
 /**
  * Builds a parameterized WHERE clause for a scoped table configuration.
  *
- * Direct scope:  `room_id = ?`  (one param)
- * Indirect scope: `goal_id IN (SELECT id FROM goals WHERE room_id = ?)`  (one param)
- * Global scope:  returns empty clause (no filtering)
+ * Direct scope:       `room_id = ?`  (one param)
+ * LIKE direct scope:  `id LIKE ?`    (one param — pattern is prefix+scopeValue+suffix)
+ * Indirect scope:     `goal_id IN (SELECT id FROM goals WHERE room_id = ?)`  (one param)
+ * LIKE indirect scope:`id IN (SELECT group_id FROM members WHERE session_id LIKE ?)`
+ * Global scope:       returns empty clause (no filtering)
  */
 export function buildScopeFilter(
 	tableConfig: ScopeTableConfig,
 	scopeValue: string
 ): ScopeFilterResult {
-	// Global tables have no scope column or join — no filter needed
-	if (!tableConfig.scopeColumn && !tableConfig.scopeJoin) {
+	// Global tables have no scope column, join, or like — no filter needed
+	if (!tableConfig.scopeColumn && !tableConfig.scopeJoin && !tableConfig.scopeLike) {
 		return { whereClause: '', params: [] };
 	}
 
@@ -411,9 +477,25 @@ export function buildScopeFilter(
 		};
 	}
 
+	// LIKE-based direct scope filter (e.g., session ID prefix matching)
+	if (tableConfig.scopeLike) {
+		const { column, patternPrefix, patternSuffix } = tableConfig.scopeLike;
+		return {
+			whereClause: `${column} LIKE ?`,
+			params: [`${patternPrefix}${scopeValue}${patternSuffix}`],
+		};
+	}
+
 	// Indirect scope filter via join table
 	if (tableConfig.scopeJoin) {
 		const join = tableConfig.scopeJoin;
+		if (join.likePrefix !== undefined) {
+			// LIKE-based join: e.g., session_groups scoped via session_group_members.session_id
+			return {
+				whereClause: `${join.localColumn} IN (SELECT ${join.joinPkColumn} FROM ${join.joinTable} WHERE ${join.scopeColumn} LIKE ?)`,
+				params: [`${join.likePrefix}${scopeValue}${join.likeSuffix ?? ''}`],
+			};
+		}
 		return {
 			whereClause: `${join.localColumn} IN (SELECT ${join.joinPkColumn} FROM ${join.joinTable} WHERE ${join.scopeColumn} = ?)`,
 			params: [scopeValue],

--- a/packages/daemon/src/lib/db-query/tools.ts
+++ b/packages/daemon/src/lib/db-query/tools.ts
@@ -509,8 +509,8 @@ function buildPrefixedScopeFilter(
 	config: ScopeTableConfig,
 	scopeValue: string
 ): { whereClause: string; params: unknown[] } {
-	// No scope column or join — no filter needed (global tables)
-	if (!config.scopeColumn && !config.scopeJoin) {
+	// No scope column, join, or like — no filter needed (global tables)
+	if (!config.scopeColumn && !config.scopeJoin && !config.scopeLike) {
 		return { whereClause: '', params: [] };
 	}
 
@@ -522,9 +522,25 @@ function buildPrefixedScopeFilter(
 		};
 	}
 
+	// LIKE-based direct scope filter (e.g., session ID prefix matching)
+	if (config.scopeLike) {
+		const { column, patternPrefix, patternSuffix } = config.scopeLike;
+		return {
+			whereClause: `_dbq.${column} LIKE ?`,
+			params: [`${patternPrefix}${scopeValue}${patternSuffix}`],
+		};
+	}
+
 	// Indirect scope filter via join table
 	if (config.scopeJoin) {
 		const join = config.scopeJoin;
+		if (join.likePrefix !== undefined) {
+			// LIKE-based join: e.g., session_groups scoped via session_group_members.session_id
+			return {
+				whereClause: `_dbq.${join.localColumn} IN (SELECT ${join.joinPkColumn} FROM ${join.joinTable} WHERE ${join.scopeColumn} LIKE ?)`,
+				params: [`${join.likePrefix}${scopeValue}${join.likeSuffix ?? ''}`],
+			};
+		}
 		return {
 			whereClause: `_dbq.${join.localColumn} IN (SELECT ${join.joinPkColumn} FROM ${join.joinTable} WHERE ${join.scopeColumn} = ?)`,
 			params: [scopeValue],
@@ -606,11 +622,25 @@ function rewriteScopedQuery(
 					directFilters.set(clause, [scopeValue]);
 				}
 			}
+			if (config.scopeLike) {
+				const { column, patternPrefix, patternSuffix } = config.scopeLike;
+				const clause = `${column} LIKE ?`;
+				if (!directFilters.has(clause)) {
+					directFilters.set(clause, [`${patternPrefix}${scopeValue}${patternSuffix}`]);
+				}
+			}
 			if (config.scopeJoin) {
 				const join = config.scopeJoin;
-				const clause = `${join.localColumn} IN (SELECT ${join.joinPkColumn} FROM ${join.joinTable} WHERE ${join.scopeColumn} = ?)`;
-				if (!directFilters.has(clause)) {
-					directFilters.set(clause, [scopeValue]);
+				if (join.likePrefix !== undefined) {
+					const clause = `${join.localColumn} IN (SELECT ${join.joinPkColumn} FROM ${join.joinTable} WHERE ${join.scopeColumn} LIKE ?)`;
+					if (!directFilters.has(clause)) {
+						directFilters.set(clause, [`${join.likePrefix}${scopeValue}${join.likeSuffix ?? ''}`]);
+					}
+				} else {
+					const clause = `${join.localColumn} IN (SELECT ${join.joinPkColumn} FROM ${join.joinTable} WHERE ${join.scopeColumn} = ?)`;
+					if (!directFilters.has(clause)) {
+						directFilters.set(clause, [scopeValue]);
+					}
 				}
 			}
 		}

--- a/packages/daemon/src/lib/db-query/tools.ts
+++ b/packages/daemon/src/lib/db-query/tools.ts
@@ -522,7 +522,10 @@ function buildPrefixedScopeFilter(
 		};
 	}
 
-	// LIKE-based direct scope filter (e.g., session ID prefix matching)
+	// LIKE-based direct scope filter (e.g., session ID prefix matching).
+	// No LIKE-escaping of scopeValue is needed: it is always a server-side
+	// crypto.randomUUID() string set in the MCP server closure before any agent
+	// interaction, so it can never contain the LIKE special chars '%' or '_'.
 	if (config.scopeLike) {
 		const { column, patternPrefix, patternSuffix } = config.scopeLike;
 		return {

--- a/packages/daemon/tests/unit/2-handlers/db-query/db-query-integration.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/db-query/db-query-integration.test.ts
@@ -674,6 +674,319 @@ describe('db-query integration', () => {
 			expect(result.isError).toBe(true);
 			expect(parseResult(result).raw).toContain('not accessible in space scope');
 		});
+
+		// ── Space scope: sessions, sdk_messages, session_groups, session_group_members ──
+
+		it('can query sessions belonging to this space (session ID prefix filtering)', async () => {
+			// Insert sessions for space-int-1, space-int-2, and an unrelated session
+			db.exec(
+				"INSERT OR IGNORE INTO sessions (id, title, created_at, last_active_at, status, config, metadata) VALUES ('space:space-int-1:task:task-1', 'Task Agent 1', datetime('now'), datetime('now'), 'active', '{}', '{}')"
+			);
+			db.exec(
+				"INSERT OR IGNORE INTO sessions (id, title, created_at, last_active_at, status, config, metadata) VALUES ('space:space-int-1:task:task-1:node:n1', 'Node 1', datetime('now'), datetime('now'), 'ended', '{}', '{}')"
+			);
+			db.exec(
+				"INSERT OR IGNORE INTO sessions (id, title, created_at, last_active_at, status, config, metadata) VALUES ('space:space-int-2:task:task-9', 'Other Space Task', datetime('now'), datetime('now'), 'active', '{}', '{}')"
+			);
+			db.exec(
+				"INSERT OR IGNORE INTO sessions (id, title, created_at, last_active_at, status, config, metadata) VALUES ('regular-session-xyz', 'Regular', datetime('now'), datetime('now'), 'active', '{}', '{}')"
+			);
+
+			const handlers = createDbQueryToolHandlers(
+				{ dbPath: ':memory:', scopeType: 'space', scopeValue: 'space-int-1' },
+				db
+			);
+			const result = await handlers.db_query({ sql: 'SELECT id, title FROM sessions' });
+			const parsed = parseResult(result);
+
+			expect(parsed.isError).toBeFalsy();
+			// Only space-int-1 sessions should appear
+			expect(parsed.rows).toHaveLength(2);
+			const ids = parsed.rows.map((r: Record<string, unknown>) => r.id).sort();
+			expect(ids).toEqual([
+				'space:space-int-1:task:task-1',
+				'space:space-int-1:task:task-1:node:n1',
+			]);
+		});
+
+		it('sessions from other spaces are excluded (space isolation)', async () => {
+			db.exec(
+				"INSERT OR IGNORE INTO sessions (id, title, created_at, last_active_at, status, config, metadata) VALUES ('space:space-int-1:task:task-A', 'Space 1 Task', datetime('now'), datetime('now'), 'active', '{}', '{}')"
+			);
+			db.exec(
+				"INSERT OR IGNORE INTO sessions (id, title, created_at, last_active_at, status, config, metadata) VALUES ('space:space-int-2:task:task-B', 'Space 2 Task', datetime('now'), datetime('now'), 'active', '{}', '{}')"
+			);
+
+			const handlers = createDbQueryToolHandlers(
+				{ dbPath: ':memory:', scopeType: 'space', scopeValue: 'space-int-2' },
+				db
+			);
+			const result = await handlers.db_query({ sql: 'SELECT id FROM sessions' });
+			const parsed = parseResult(result);
+
+			expect(parsed.isError).toBeFalsy();
+			expect(parsed.rows).toHaveLength(1);
+			expect(parsed.rows[0].id).toBe('space:space-int-2:task:task-B');
+		});
+
+		it('sessions rows exclude blacklisted columns (config, session_context)', async () => {
+			db.exec(
+				"INSERT OR IGNORE INTO sessions (id, title, created_at, last_active_at, status, config, metadata, session_context) VALUES ('space:space-int-1:task:task-X', 'Sensitive Test', datetime('now'), datetime('now'), 'active', '{\"secret\":true}', '{}', '{\"spaceId\":\"space-int-1\"}')"
+			);
+
+			const handlers = createDbQueryToolHandlers(
+				{ dbPath: ':memory:', scopeType: 'space', scopeValue: 'space-int-1' },
+				db
+			);
+			const result = await handlers.db_query({ sql: 'SELECT * FROM sessions' });
+			const parsed = parseResult(result);
+
+			expect(parsed.isError).toBeFalsy();
+			for (const row of parsed.rows) {
+				expect(row).not.toHaveProperty('config');
+				expect(row).not.toHaveProperty('session_context');
+				expect(row).toHaveProperty('id');
+				expect(row).toHaveProperty('title');
+				expect(row).toHaveProperty('status');
+			}
+		});
+
+		it('can query sdk_messages for sessions in this space', async () => {
+			// Create sessions first (sdk_messages FK requires session exists)
+			db.exec(
+				"INSERT OR IGNORE INTO sessions (id, title, created_at, last_active_at, status, config, metadata) VALUES ('space:space-int-1:task:msg-task', 'Msg Task', datetime('now'), datetime('now'), 'active', '{}', '{}')"
+			);
+			db.exec(
+				"INSERT OR IGNORE INTO sessions (id, title, created_at, last_active_at, status, config, metadata) VALUES ('space:space-int-2:task:msg-task2', 'Other Msg Task', datetime('now'), datetime('now'), 'active', '{}', '{}')"
+			);
+
+			db.exec(
+				"INSERT OR IGNORE INTO sdk_messages (id, session_id, message_type, sdk_message, timestamp) VALUES ('msg-1', 'space:space-int-1:task:msg-task', 'user', '{\"role\":\"user\"}', '2024-01-01T00:00:00Z')"
+			);
+			db.exec(
+				"INSERT OR IGNORE INTO sdk_messages (id, session_id, message_type, sdk_message, timestamp) VALUES ('msg-2', 'space:space-int-1:task:msg-task', 'assistant', '{\"role\":\"assistant\"}', '2024-01-01T00:00:01Z')"
+			);
+			db.exec(
+				"INSERT OR IGNORE INTO sdk_messages (id, session_id, message_type, sdk_message, timestamp) VALUES ('msg-3', 'space:space-int-2:task:msg-task2', 'user', '{\"role\":\"user\"}', '2024-01-01T00:00:02Z')"
+			);
+
+			const handlers = createDbQueryToolHandlers(
+				{ dbPath: ':memory:', scopeType: 'space', scopeValue: 'space-int-1' },
+				db
+			);
+			const result = await handlers.db_query({
+				sql: 'SELECT id, session_id, message_type FROM sdk_messages',
+			});
+			const parsed = parseResult(result);
+
+			expect(parsed.isError).toBeFalsy();
+			// Only msg-1 and msg-2 belong to space-int-1
+			expect(parsed.rows).toHaveLength(2);
+			const ids = parsed.rows.map((r: Record<string, unknown>) => r.id).sort();
+			expect(ids).toEqual(['msg-1', 'msg-2']);
+			// All rows belong to the correct session
+			for (const row of parsed.rows) {
+				expect(row.session_id).toBe('space:space-int-1:task:msg-task');
+			}
+		});
+
+		it('sdk_messages from other spaces are excluded', async () => {
+			db.exec(
+				"INSERT OR IGNORE INTO sessions (id, title, created_at, last_active_at, status, config, metadata) VALUES ('space:space-int-1:task:iso-1', 'Iso1', datetime('now'), datetime('now'), 'active', '{}', '{}')"
+			);
+			db.exec(
+				"INSERT OR IGNORE INTO sessions (id, title, created_at, last_active_at, status, config, metadata) VALUES ('space:space-int-2:task:iso-2', 'Iso2', datetime('now'), datetime('now'), 'active', '{}', '{}')"
+			);
+			db.exec(
+				"INSERT OR IGNORE INTO sdk_messages (id, session_id, message_type, sdk_message, timestamp) VALUES ('iso-msg-1', 'space:space-int-1:task:iso-1', 'user', '{}', '2024-01-01T00:00:00Z')"
+			);
+			db.exec(
+				"INSERT OR IGNORE INTO sdk_messages (id, session_id, message_type, sdk_message, timestamp) VALUES ('iso-msg-2', 'space:space-int-2:task:iso-2', 'user', '{}', '2024-01-01T00:00:01Z')"
+			);
+
+			const handlers = createDbQueryToolHandlers(
+				{ dbPath: ':memory:', scopeType: 'space', scopeValue: 'space-int-2' },
+				db
+			);
+			const result = await handlers.db_query({ sql: 'SELECT id FROM sdk_messages' });
+			const parsed = parseResult(result);
+
+			expect(parsed.isError).toBeFalsy();
+			expect(parsed.rows).toHaveLength(1);
+			expect(parsed.rows[0].id).toBe('iso-msg-2');
+		});
+
+		it('can query session_group_members filtered by space session ID prefix', async () => {
+			db.exec(
+				"INSERT OR IGNORE INTO sessions (id, title, created_at, last_active_at, status, config, metadata) VALUES ('space:space-int-1:task:sg-task', 'SG Task', datetime('now'), datetime('now'), 'active', '{}', '{}')"
+			);
+			db.exec(
+				"INSERT OR IGNORE INTO sessions (id, title, created_at, last_active_at, status, config, metadata) VALUES ('space:space-int-2:task:sg-task2', 'SG Task2', datetime('now'), datetime('now'), 'active', '{}', '{}')"
+			);
+			db.exec(
+				"INSERT OR IGNORE INTO session_groups (id, group_type, ref_id, created_at) VALUES ('grp-s1', 'task', 'ref-1', 1000)"
+			);
+			db.exec(
+				"INSERT OR IGNORE INTO session_groups (id, group_type, ref_id, created_at) VALUES ('grp-s2', 'task', 'ref-2', 2000)"
+			);
+			db.exec(
+				"INSERT OR IGNORE INTO session_group_members (group_id, session_id, role, joined_at) VALUES ('grp-s1', 'space:space-int-1:task:sg-task', 'coder', 1000)"
+			);
+			db.exec(
+				"INSERT OR IGNORE INTO session_group_members (group_id, session_id, role, joined_at) VALUES ('grp-s2', 'space:space-int-2:task:sg-task2', 'coder', 2000)"
+			);
+
+			const handlers = createDbQueryToolHandlers(
+				{ dbPath: ':memory:', scopeType: 'space', scopeValue: 'space-int-1' },
+				db
+			);
+			const result = await handlers.db_query({
+				sql: 'SELECT group_id, session_id FROM session_group_members',
+			});
+			const parsed = parseResult(result);
+
+			expect(parsed.isError).toBeFalsy();
+			expect(parsed.rows).toHaveLength(1);
+			expect(parsed.rows[0].group_id).toBe('grp-s1');
+			expect(parsed.rows[0].session_id).toBe('space:space-int-1:task:sg-task');
+		});
+
+		it('can query session_groups scoped via session_group_members', async () => {
+			db.exec(
+				"INSERT OR IGNORE INTO sessions (id, title, created_at, last_active_at, status, config, metadata) VALUES ('space:space-int-1:task:sgg-task', 'SGG Task', datetime('now'), datetime('now'), 'active', '{}', '{}')"
+			);
+			db.exec(
+				"INSERT OR IGNORE INTO sessions (id, title, created_at, last_active_at, status, config, metadata) VALUES ('space:space-int-2:task:sgg-task2', 'SGG Task2', datetime('now'), datetime('now'), 'active', '{}', '{}')"
+			);
+			db.exec(
+				"INSERT OR IGNORE INTO session_groups (id, group_type, ref_id, created_at) VALUES ('sgg-grp-1', 'task', 'ref-A', 1000)"
+			);
+			db.exec(
+				"INSERT OR IGNORE INTO session_groups (id, group_type, ref_id, created_at) VALUES ('sgg-grp-2', 'task', 'ref-B', 2000)"
+			);
+			db.exec(
+				"INSERT OR IGNORE INTO session_group_members (group_id, session_id, role, joined_at) VALUES ('sgg-grp-1', 'space:space-int-1:task:sgg-task', 'coder', 1000)"
+			);
+			db.exec(
+				"INSERT OR IGNORE INTO session_group_members (group_id, session_id, role, joined_at) VALUES ('sgg-grp-2', 'space:space-int-2:task:sgg-task2', 'coder', 2000)"
+			);
+
+			const handlers = createDbQueryToolHandlers(
+				{ dbPath: ':memory:', scopeType: 'space', scopeValue: 'space-int-1' },
+				db
+			);
+			const result = await handlers.db_query({ sql: 'SELECT id, group_type FROM session_groups' });
+			const parsed = parseResult(result);
+
+			expect(parsed.isError).toBeFalsy();
+			// Only sgg-grp-1 has members from space-int-1
+			expect(parsed.rows).toHaveLength(1);
+			expect(parsed.rows[0].id).toBe('sgg-grp-1');
+		});
+
+		it('db_list_tables includes sessions, sdk_messages, session_groups, session_group_members in space scope', async () => {
+			const handlers = createDbQueryToolHandlers(
+				{ dbPath: ':memory:', scopeType: 'space', scopeValue: 'space-int-1' },
+				db
+			);
+			const result = await handlers.db_list_tables();
+			const parsed = parseResult(result);
+
+			expect(parsed.isError).toBeFalsy();
+			expect(parsed.tables).toContain('sessions');
+			expect(parsed.tables).toContain('sdk_messages');
+			expect(parsed.tables).toContain('session_groups');
+			expect(parsed.tables).toContain('session_group_members');
+			// Still includes original space tables
+			expect(parsed.tables).toContain('space_tasks');
+			expect(parsed.tables).toContain('gate_data');
+			// Room/global tables still excluded from space scope
+			expect(parsed.tables).not.toContain('tasks');
+			expect(parsed.tables).not.toContain('rooms');
+		});
+
+		it('db_describe_table works for sessions in space scope', async () => {
+			const handlers = createDbQueryToolHandlers(
+				{ dbPath: ':memory:', scopeType: 'space', scopeValue: 'space-int-1' },
+				db
+			);
+			const result = await handlers.db_describe_table({ table_name: 'sessions' });
+			const parsed = parseResult(result);
+
+			expect(parsed.isError).toBeFalsy();
+			expect(parsed.description).toContain('sessions');
+			// Blacklisted columns should not appear as data columns
+			expect(parsed.description).not.toContain('| config |');
+			expect(parsed.description).not.toContain('| session_context |');
+			// Non-blacklisted columns should appear
+			expect(parsed.description).toContain('id');
+			expect(parsed.description).toContain('title');
+			expect(parsed.description).toContain('status');
+		});
+
+		it('db_describe_table works for sdk_messages in space scope', async () => {
+			const handlers = createDbQueryToolHandlers(
+				{ dbPath: ':memory:', scopeType: 'space', scopeValue: 'space-int-1' },
+				db
+			);
+			const result = await handlers.db_describe_table({ table_name: 'sdk_messages' });
+			const parsed = parseResult(result);
+
+			expect(parsed.isError).toBeFalsy();
+			expect(parsed.description).toContain('sdk_messages');
+			expect(parsed.description).toContain('session_id');
+			expect(parsed.description).toContain('message_type');
+		});
+
+		it('COUNT aggregate on sessions in space scope counts only space sessions', async () => {
+			db.exec(
+				"INSERT OR IGNORE INTO sessions (id, title, created_at, last_active_at, status, config, metadata) VALUES ('space:space-int-1:task:cnt-1', 'Count 1', datetime('now'), datetime('now'), 'active', '{}', '{}')"
+			);
+			db.exec(
+				"INSERT OR IGNORE INTO sessions (id, title, created_at, last_active_at, status, config, metadata) VALUES ('space:space-int-1:task:cnt-2', 'Count 2', datetime('now'), datetime('now'), 'ended', '{}', '{}')"
+			);
+			db.exec(
+				"INSERT OR IGNORE INTO sessions (id, title, created_at, last_active_at, status, config, metadata) VALUES ('space:space-int-2:task:cnt-3', 'Other', datetime('now'), datetime('now'), 'active', '{}', '{}')"
+			);
+			db.exec(
+				"INSERT OR IGNORE INTO sessions (id, title, created_at, last_active_at, status, config, metadata) VALUES ('unrelated-session', 'Unrelated', datetime('now'), datetime('now'), 'active', '{}', '{}')"
+			);
+
+			const handlers = createDbQueryToolHandlers(
+				{ dbPath: ':memory:', scopeType: 'space', scopeValue: 'space-int-1' },
+				db
+			);
+			const result = await handlers.db_query({
+				sql: 'SELECT COUNT(*) AS cnt FROM sessions',
+			});
+			const parsed = parseResult(result);
+
+			expect(parsed.isError).toBeFalsy();
+			// Only space-int-1 sessions (cnt-1, cnt-2) should be counted
+			expect(parsed.rows[0].cnt).toBe(2);
+		});
+
+		it('cannot access sessions from room scope (sessions not in room scope)', async () => {
+			const handlers = createDbQueryToolHandlers(
+				{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-int-1' },
+				db
+			);
+			const result = await handlers.db_query({ sql: 'SELECT * FROM sessions' });
+
+			expect(result.isError).toBe(true);
+			expect(parseResult(result).raw).toContain('not accessible in room scope');
+		});
+
+		it('cannot access sdk_messages from room scope', async () => {
+			const handlers = createDbQueryToolHandlers(
+				{ dbPath: ':memory:', scopeType: 'room', scopeValue: 'room-int-1' },
+				db
+			);
+			const result = await handlers.db_query({ sql: 'SELECT * FROM sdk_messages' });
+
+			expect(result.isError).toBe(true);
+			expect(parseResult(result).raw).toContain('not accessible in room scope');
+		});
 	});
 
 	// ── Global scope ─────────────────────────────────────────────────────────────

--- a/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
@@ -70,8 +70,13 @@ describe('scope-config', () => {
 				'channel_cycles',
 				'workflow_run_artifacts',
 				'workflow_run_artifact_cache',
+				// Main-DB tables exposed with space-scoped filtering via session ID prefix:
+				'sessions',
+				'sdk_messages',
+				'session_groups',
+				'session_group_members',
 			]);
-			expect(names).toHaveLength(11);
+			expect(names).toHaveLength(15);
 		});
 
 		it('all table configs have a description', () => {
@@ -192,19 +197,28 @@ describe('scope-config', () => {
 			}
 		});
 
-		it('sdk_messages is not in any scope', () => {
-			for (const scopeType of ['global', 'room', 'space'] as const) {
-				expect(getAccessibleTableNames(scopeType)).not.toContain('sdk_messages');
-			}
+		it('sdk_messages is accessible in space scope (with session ID prefix filtering)', () => {
+			// sdk_messages is now exposed in space scope (filtered by session_id LIKE 'space:<id>:%')
+			expect(getAccessibleTableNames('space')).toContain('sdk_messages');
+			// But NOT in global or room scope
+			expect(getAccessibleTableNames('global')).not.toContain('sdk_messages');
+			expect(getAccessibleTableNames('room')).not.toContain('sdk_messages');
 		});
 
-		it('internal infrastructure tables are not in any scope', () => {
-			const internalTables = ['session_groups', 'session_group_members', 'task_group_events'];
+		it('session_groups and session_group_members are accessible in space scope only', () => {
+			// Now exposed in space scope via session ID prefix filtering
+			expect(getAccessibleTableNames('space')).toContain('session_groups');
+			expect(getAccessibleTableNames('space')).toContain('session_group_members');
+			// But NOT in global or room scope
+			expect(getAccessibleTableNames('global')).not.toContain('session_groups');
+			expect(getAccessibleTableNames('global')).not.toContain('session_group_members');
+			expect(getAccessibleTableNames('room')).not.toContain('session_groups');
+			expect(getAccessibleTableNames('room')).not.toContain('session_group_members');
+		});
+
+		it('task_group_events is not in any scope', () => {
 			for (const scopeType of ['global', 'room', 'space'] as const) {
-				const names = getAccessibleTableNames(scopeType);
-				for (const table of internalTables) {
-					expect(names).not.toContain(table);
-				}
+				expect(getAccessibleTableNames(scopeType)).not.toContain('task_group_events');
 			}
 		});
 
@@ -251,14 +265,20 @@ describe('scope-config', () => {
 			expect(excluded).toContain('global_settings');
 		});
 
-		it('includes sdk_messages', () => {
-			expect(getExcludedTableNames()).toContain('sdk_messages');
+		it('does not include sdk_messages (now in space scope)', () => {
+			// sdk_messages is no longer globally excluded — it's accessible in space scope
+			// with session ID prefix filtering. It remains inaccessible in global/room scopes.
+			expect(getExcludedTableNames()).not.toContain('sdk_messages');
 		});
 
-		it('includes internal infrastructure tables', () => {
+		it('does not include session_groups or session_group_members (now in space scope)', () => {
+			// These tables are now accessible in space scope with session ID prefix filtering.
+			expect(getExcludedTableNames()).not.toContain('session_groups');
+			expect(getExcludedTableNames()).not.toContain('session_group_members');
+		});
+
+		it('includes remaining internal infrastructure tables', () => {
 			const excluded = getExcludedTableNames();
-			expect(excluded).toContain('session_groups');
-			expect(excluded).toContain('session_group_members');
 			expect(excluded).toContain('task_group_events');
 			expect(excluded).toContain('node_executions');
 		});
@@ -386,6 +406,66 @@ describe('scope-config', () => {
 			expect(result.params).toEqual(['space-gamma']);
 		});
 
+		it('produces LIKE filter for sessions in space scope (scopeLike)', () => {
+			const sessions = getScopeConfig('space').find((t) => t.tableName === 'sessions')!;
+			expect(sessions.scopeLike).toBeDefined();
+			expect(sessions.scopeLike!.column).toBe('id');
+			expect(sessions.scopeLike!.patternPrefix).toBe('space:');
+			expect(sessions.scopeLike!.patternSuffix).toBe(':%');
+
+			const result = buildScopeFilter(sessions, 'abc123');
+			expect(result.whereClause).toBe('id LIKE ?');
+			expect(result.params).toEqual(['space:abc123:%']);
+		});
+
+		it('produces LIKE filter for sdk_messages in space scope', () => {
+			const msgs = getScopeConfig('space').find((t) => t.tableName === 'sdk_messages')!;
+			expect(msgs.scopeLike).toBeDefined();
+			expect(msgs.scopeLike!.column).toBe('session_id');
+
+			const result = buildScopeFilter(msgs, 'space-xyz');
+			expect(result.whereClause).toBe('session_id LIKE ?');
+			expect(result.params).toEqual(['space:space-xyz:%']);
+		});
+
+		it('produces LIKE filter for session_group_members in space scope', () => {
+			const sgm = getScopeConfig('space').find((t) => t.tableName === 'session_group_members')!;
+			expect(sgm.scopeLike).toBeDefined();
+
+			const result = buildScopeFilter(sgm, 'sid-42');
+			expect(result.whereClause).toBe('session_id LIKE ?');
+			expect(result.params).toEqual(['space:sid-42:%']);
+		});
+
+		it('produces LIKE-based join filter for session_groups in space scope', () => {
+			const sg = getScopeConfig('space').find((t) => t.tableName === 'session_groups')!;
+			expect(sg.scopeJoin).toBeDefined();
+			expect(sg.scopeJoin!.likePrefix).toBe('space:');
+			expect(sg.scopeJoin!.likeSuffix).toBe(':%');
+			expect(sg.scopeJoin!.localColumn).toBe('id');
+			expect(sg.scopeJoin!.joinTable).toBe('session_group_members');
+			expect(sg.scopeJoin!.joinPkColumn).toBe('group_id');
+			expect(sg.scopeJoin!.scopeColumn).toBe('session_id');
+
+			const result = buildScopeFilter(sg, 'sp99');
+			expect(result.whereClause).toBe(
+				'id IN (SELECT group_id FROM session_group_members WHERE session_id LIKE ?)'
+			);
+			expect(result.params).toEqual(['space:sp99:%']);
+		});
+
+		it('all LIKE-based scope filters produce the correct pattern', () => {
+			const likeConfigs = getScopeConfig('space').filter((c) => c.scopeLike);
+			expect(likeConfigs.length).toBeGreaterThan(0);
+
+			for (const cfg of likeConfigs) {
+				const result = buildScopeFilter(cfg, 'my-space-id');
+				expect(result.whereClause).toContain('LIKE ?');
+				expect(result.params).toHaveLength(1);
+				expect(result.params[0] as string).toContain('my-space-id');
+			}
+		});
+
 		it('all indirect scope filters produce valid SQL with one parameter', () => {
 			// Collect all indirect configs across all scopes
 			const indirectConfigs: ScopeTableConfig[] = [];
@@ -408,7 +488,12 @@ describe('scope-config', () => {
 				expect(result.whereClause).toContain('?');
 				// Exactly one parameter
 				expect(result.params).toHaveLength(1);
-				expect(result.params[0]).toBe('test-scope-value');
+				// Standard join: param is the scope value. LIKE-based join: param is the full LIKE pattern.
+				if (cfg.scopeJoin?.likePrefix !== undefined) {
+					expect(result.params[0] as string).toContain('test-scope-value');
+				} else {
+					expect(result.params[0]).toBe('test-scope-value');
+				}
 			}
 		});
 
@@ -446,10 +531,11 @@ describe('scope-config', () => {
 			expect(unfiltered).toEqual([]);
 		});
 
-		it('every space-scoped table has scopeColumn or scopeJoin', () => {
+		it('every space-scoped table has scopeColumn, scopeJoin, or scopeLike', () => {
+			// Tables using scopeLike filter by session ID prefix (e.g., 'space:<id>:%').
 			const unfiltered: string[] = [];
 			for (const table of getScopeConfig('space')) {
-				if (!table.scopeColumn && !table.scopeJoin) {
+				if (!table.scopeColumn && !table.scopeJoin && !table.scopeLike) {
 					unfiltered.push(table.tableName);
 				}
 			}
@@ -457,10 +543,22 @@ describe('scope-config', () => {
 		});
 	});
 
-	// ── Cross-cutting: no duplicate table names across scopes ─────────────────
+	// ── Cross-cutting: intentional multi-scope tables and uniqueness ──────────
 
 	describe('table name uniqueness', () => {
-		it('no table appears in more than one scope', () => {
+		it('sessions intentionally appears in both global and space scope', () => {
+			// `sessions` is in global scope (no filter — Neo agent full access) AND
+			// in space scope (filtered by session ID prefix — space agent access).
+			// This is an intentional design: the two scopes apply different filtering.
+			expect(getAccessibleTableNames('global')).toContain('sessions');
+			expect(getAccessibleTableNames('space')).toContain('sessions');
+			expect(getAccessibleTableNames('room')).not.toContain('sessions');
+		});
+
+		it('no table other than sessions appears in more than one scope', () => {
+			// `sessions` is the only intentional cross-scope table (global + space).
+			const INTENTIONAL_MULTI_SCOPE = new Set(['sessions']);
+
 			const allTables = new Map<string, string[]>();
 			for (const scopeType of ['global', 'room', 'space'] as const) {
 				for (const name of getAccessibleTableNames(scopeType)) {
@@ -470,13 +568,13 @@ describe('scope-config', () => {
 				}
 			}
 
-			const duplicates: string[] = [];
+			const unexpectedDuplicates: string[] = [];
 			for (const [name, scopes] of allTables) {
-				if (scopes.length > 1) {
-					duplicates.push(`${name}: ${scopes.join(', ')}`);
+				if (scopes.length > 1 && !INTENTIONAL_MULTI_SCOPE.has(name)) {
+					unexpectedDuplicates.push(`${name}: ${scopes.join(', ')}`);
 				}
 			}
-			expect(duplicates).toEqual([]);
+			expect(unexpectedDuplicates).toEqual([]);
 		});
 	});
 


### PR DESCRIPTION
## Summary

- Adds `sessions`, `sdk_messages`, `session_groups`, and `session_group_members` to the `space` scope in the db-query MCP tool, so task agents can query their own space's session data
- Introduces `ScopeLikeConfig` and LIKE-based join patterns to support session ID prefix filtering (`space:<space_id>:%`)
- Sensitive columns (`config`, `session_context`) remain blacklisted for `sessions` in space scope
- `sessions` intentionally appears in both global scope (unfiltered, for Neo agent) and space scope (prefix-filtered)

## How filtering works

| Table | Space scope filter |
|---|---|
| `sessions` | `id LIKE 'space:<id>:%'` |
| `sdk_messages` | `session_id LIKE 'space:<id>:%'` |
| `session_group_members` | `session_id LIKE 'space:<id>:%'` |
| `session_groups` | `id IN (SELECT group_id FROM session_group_members WHERE session_id LIKE ?)` |

## Test plan

- 315 db-query unit tests pass (18 new tests added)
- Full daemon suite passes (11407 tests)
- All pre-commit checks pass (lint, format, typecheck, knip)