### PR TITLE
test(daemon): switch 5-space unit test SQLite to in-memory

### DIFF
--- a/packages/daemon/tests/unit/1-core/lib/node-execution-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/node-execution-manager.test.ts
@@ -40,8 +40,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { NodeExecutionManager } from '../../../../src/lib/space/managers/node-execution-manager.ts';
@@ -57,18 +55,13 @@ import type { NodeExecutionStatus } from '@neokai/shared';
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-node-exec-mgr',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	runMigrations(db, () => {});
 	db.exec('PRAGMA foreign_keys = OFF');
-	return { db, dir };
+	return db;
 }
 
 function seedExecution(
@@ -106,17 +99,15 @@ function seedExecution(
 // ---------------------------------------------------------------------------
 
 let db: BunDatabase;
-let dir: string;
 let manager: NodeExecutionManager;
 
 beforeEach(() => {
-	({ db, dir } = makeDb());
+	db = makeDb();
 	manager = new NodeExecutionManager(db);
 });
 
 afterEach(() => {
 	db.close();
-	rmSync(dir, { recursive: true, force: true });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/2-handlers/room/room-repository.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/room/room-repository.test.ts
@@ -12,27 +12,18 @@ import type { CreateRoomParams, WorkspacePath } from '@neokai/shared';
 
 describe('RoomRepository', () => {
 	let db: Database;
-	let tempDir: string;
 	let repository: RoomRepository;
 
 	beforeEach(() => {
-		// Create temp directory and file-based database
-		// Use process.env.TMPDIR to support custom temp directory setups
-		const tmpBase = (process.env.TMPDIR || '/tmp').replace(/\/$/, '');
-		tempDir = `${tmpBase}/neokai-test-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-		require('fs').mkdirSync(tempDir, { recursive: true });
-		db = new Database(`${tempDir}/test.db`);
+		// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+		// I/O contention that caused beforeEach hook timeouts in CI.
+		db = new Database(':memory:');
 		createTables(db);
 		repository = new RoomRepository(db);
 	});
 
 	afterEach(() => {
 		db.close();
-		try {
-			require('fs').rmSync(tempDir, { recursive: true, force: true });
-		} catch {
-			// Ignore cleanup errors
-		}
 	});
 
 	describe('createRoom', () => {

--- a/packages/daemon/tests/unit/4-space-storage/skills-manager.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/skills-manager.test.ts
@@ -298,7 +298,7 @@ describe('SkillRepository', () => {
 
 		// Clean up temp file
 		unlinkSync(tmpPath);
-	});
+	}, 30_000);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/5-space/agent/agent-completion.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-completion.test.ts
@@ -8,8 +8,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
@@ -39,18 +37,13 @@ import type { Space } from '@neokai/shared';
 // DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-agent-completion',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string): void {
@@ -168,17 +161,13 @@ function makeMockSessionFactory(): SubSessionFactory {
 
 describe('Migration 51 — rename slot_role → agent_name, add completion_summary', () => {
 	let db: BunDatabase;
-	let dir: string;
 
 	beforeEach(() => {
-		const result = makeDb();
-		db = result.db;
-		dir = result.dir;
+		db = makeDb();
 	});
 
 	afterEach(() => {
 		db.close();
-		rmSync(dir, { recursive: true, force: true });
 	});
 
 	test('space_tasks has labels column after migration', () => {
@@ -230,7 +219,6 @@ describe('Migration 51 — rename slot_role → agent_name, add completion_summa
 
 describe('list_peers — completion state via SpaceTaskRepository', () => {
 	let db: BunDatabase;
-	let dir: string;
 	let spaceId: string;
 	let spaceTaskRepo: SpaceTaskRepository;
 	let nodeExecutionRepo: NodeExecutionRepository;
@@ -238,9 +226,7 @@ describe('list_peers — completion state via SpaceTaskRepository', () => {
 	const coderSessionId = 'session-coder-cs';
 
 	beforeEach(() => {
-		const result = makeDb();
-		db = result.db;
-		dir = result.dir;
+		db = makeDb();
 		spaceId = 'space-lp-cs-test';
 		seedSpaceRow(db, spaceId);
 
@@ -251,7 +237,6 @@ describe('list_peers — completion state via SpaceTaskRepository', () => {
 
 	afterEach(() => {
 		db.close();
-		rmSync(dir, { recursive: true, force: true });
 	});
 
 	function makeConfig(overrides: Partial<NodeAgentToolsConfig> = {}): NodeAgentToolsConfig {
@@ -372,7 +357,6 @@ describe('list_peers — completion state via SpaceTaskRepository', () => {
 
 describe('list_group_members — completion state via SpaceTaskRepository', () => {
 	let db: BunDatabase;
-	let dir: string;
 	let spaceId: string;
 	let taskRepo: SpaceTaskRepository;
 	let nodeExecutionRepo: NodeExecutionRepository;
@@ -380,9 +364,7 @@ describe('list_group_members — completion state via SpaceTaskRepository', () =
 	const mainTaskId = 'main-task-lgm';
 
 	beforeEach(() => {
-		const result = makeDb();
-		db = result.db;
-		dir = result.dir;
+		db = makeDb();
 		spaceId = 'space-lgm-cs-test';
 		seedSpaceRow(db, spaceId);
 
@@ -393,7 +375,6 @@ describe('list_group_members — completion state via SpaceTaskRepository', () =
 
 	afterEach(() => {
 		db.close();
-		rmSync(dir, { recursive: true, force: true });
 	});
 
 	function makeConfig(

--- a/packages/daemon/tests/unit/5-space/agent/agent-liveness.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-liveness.test.ts
@@ -15,8 +15,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
@@ -39,18 +37,13 @@ import type { TaskAgentManager } from '../../../../src/lib/space/runtime/task-ag
 // Test helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-agent-liveness',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string): void {
@@ -123,23 +116,17 @@ function makeNotifySpy(): {
 
 describe('autoCompleteStuckAgents', () => {
 	let db: BunDatabase;
-	let dir: string;
 	let taskRepo: SpaceTaskRepository;
 	const spaceId = 'space-test-liveness';
 
 	beforeEach(() => {
-		({ db, dir } = makeDb());
+		db = makeDb();
 		taskRepo = new SpaceTaskRepository(db);
 		seedSpaceRow(db, spaceId);
 	});
 
 	afterEach(() => {
 		db.close();
-		try {
-			rmSync(dir, { recursive: true, force: true });
-		} catch {
-			// ignore cleanup failures
-		}
 	});
 
 	test('returns empty array when no tasks are provided', async () => {

--- a/packages/daemon/tests/unit/5-space/agent/agent-message-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-message-router.test.ts
@@ -1143,7 +1143,6 @@ describe('AgentMessageRouter: onMessageQueued callback fires for non-deduped enq
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('calls onMessageQueued with agent name when message is newly queued', async () => {

--- a/packages/daemon/tests/unit/5-space/agent/agent-message-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-message-router.test.ts
@@ -14,8 +14,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { PendingAgentMessageRepository } from '../../../../src/storage/repositories/pending-agent-message-repository.ts';
@@ -30,18 +28,13 @@ import type { WorkflowChannel } from '@neokai/shared';
 // DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-channel-router',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string): void {
@@ -101,7 +94,6 @@ function makeResolvedChannel(
 
 interface TestCtx {
 	db: BunDatabase;
-	dir: string;
 	spaceId: string;
 	nodeExecutionRepo: NodeExecutionRepository;
 	workflowRunRepo: SpaceWorkflowRunRepository;
@@ -141,7 +133,7 @@ function seedPeerTask(
 }
 
 function makeCtx(): TestCtx {
-	const { db, dir } = makeDb();
+	const db = makeDb();
 	const spaceId = 'space-channel-router-test';
 
 	seedSpaceRow(db, spaceId);
@@ -156,7 +148,6 @@ function makeCtx(): TestCtx {
 
 	return {
 		db,
-		dir,
 		spaceId,
 		nodeExecutionRepo,
 		workflowRunRepo,
@@ -198,7 +189,6 @@ describe('AgentMessageRouter: agent name (role) target → DM', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('delivers message to single session with matching role', async () => {
@@ -240,7 +230,6 @@ describe('AgentMessageRouter: single agent per role (task-centric model)', () =>
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('delivers to the single session with the target role', async () => {
@@ -277,7 +266,6 @@ describe('AgentMessageRouter: broadcast * → all permitted targets', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('delivers to all topology-permitted targets', async () => {
@@ -343,7 +331,6 @@ describe('AgentMessageRouter: unknown target → clear error', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns error with "no agent or node found" when target unknown', async () => {
@@ -399,7 +386,6 @@ describe('AgentMessageRouter: unauthorized target → error with permitted targe
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns error when channel topology forbids the send', async () => {
@@ -435,7 +421,6 @@ describe('AgentMessageRouter: unauthorized target → error with structured fiel
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('populates unauthorizedAgentNames and permittedTargets structured fields on auth failure', async () => {
@@ -474,7 +459,6 @@ describe('AgentMessageRouter: empty topology → error', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns error when no channel topology is declared', async () => {
@@ -522,7 +506,6 @@ describe('AgentMessageRouter: partial delivery failure → partial success', () 
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns false success when the single session fails', async () => {
@@ -564,7 +547,6 @@ describe('AgentMessageRouter: all deliveries fail → false success', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns success: false when all injections fail', async () => {
@@ -603,7 +585,6 @@ describe('AgentMessageRouter: node name target with nodeGroups → fan-out', () 
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('delivers to all roles mapped to a node name', async () => {
@@ -651,7 +632,6 @@ describe('AgentMessageRouter: node name target without nodeGroups → unknown ta
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns unknown target error when nodeGroups not configured', async () => {
@@ -690,7 +670,6 @@ describe('AgentMessageRouter: fromNodeName resolution edge cases', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('isTopologyDeclared is false when slot name differs from node-name-addressed channel source (no nodeGroups)', async () => {
@@ -763,7 +742,6 @@ describe('AgentMessageRouter: notFoundAgentNames structured field', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('populates notFoundAgentNames on broadcast when some permitted roles have no active sessions', async () => {
@@ -811,7 +789,6 @@ describe('AgentMessageRouter: queue message for declared-but-inactive target', (
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('queues message when target has a pending execution but no active session', async () => {
@@ -997,7 +974,6 @@ describe('AgentMessageRouter: broadcast * with mixed active/inactive targets', (
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('delivers to active targets and queues for inactive declared targets', async () => {
@@ -1064,7 +1040,6 @@ describe('AgentMessageRouter: queue enqueue failure graceful degradation', () =>
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('falls back to notFound when pendingMessageRepo.enqueue throws', async () => {
@@ -1118,7 +1093,6 @@ describe('AgentMessageRouter: pure topology target (no execution, no nodeGroups)
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('queues message when target is topology-declared but has no execution record', async () => {

--- a/packages/daemon/tests/unit/5-space/agent/end-node-handlers.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/end-node-handlers.test.ts
@@ -14,8 +14,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
@@ -28,18 +26,13 @@ import type { DaemonHub } from '../../../../src/lib/daemon-hub.ts';
 // Fixtures
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-end-node-handlers',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string, autonomyLevel = 1): void {
@@ -102,18 +95,16 @@ function makeMockHub(): MockHubCtx {
 
 interface TestCtx {
 	db: BunDatabase;
-	dir: string;
 	spaceId: string;
 	taskRepo: SpaceTaskRepository;
 }
 
 function makeCtx(autonomyLevel = 1): TestCtx {
-	const { db, dir } = makeDb();
+	const db = makeDb();
 	const spaceId = 'space-end-node-test';
 	seedSpaceRow(db, spaceId, autonomyLevel);
 	return {
 		db,
-		dir,
 		spaceId,
 		taskRepo: new SpaceTaskRepository(db),
 	};
@@ -149,7 +140,6 @@ describe('createEndNodeHandlers — approve_task', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns error when space.autonomyLevel < workflow.completionAutonomyLevel', async () => {
@@ -349,7 +339,6 @@ describe('createEndNodeHandlers — submit_for_approval', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('sets status=review and populates pending-completion fields', async () => {
@@ -472,7 +461,6 @@ describe('createEndNodeHandlers — daemonHub is optional', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('approve_task succeeds without a daemonHub', async () => {

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -14,8 +14,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
@@ -37,18 +35,13 @@ import type { SpaceWorkflow, Gate, WorkflowChannel } from '@neokai/shared';
 // DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-node-agent-tools',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string): void {
@@ -170,7 +163,6 @@ function makeResolvedChannel(
 
 interface TestCtx {
 	db: BunDatabase;
-	dir: string;
 	spaceId: string;
 	taskRepo: SpaceTaskRepository;
 	taskManager: SpaceTaskManager;
@@ -191,7 +183,7 @@ interface TestCtx {
 }
 
 function makeCtx(): TestCtx {
-	const { db, dir } = makeDb();
+	const db = makeDb();
 	const spaceId = 'space-node-tools-test';
 
 	seedSpaceRow(db, spaceId);
@@ -243,7 +235,6 @@ function makeCtx(): TestCtx {
 
 	return {
 		db,
-		dir,
 		spaceId,
 		taskRepo,
 		taskManager,
@@ -317,7 +308,6 @@ describe('node-agent-tools: list_peers', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns peers excluding self and task-agent', async () => {
@@ -449,7 +439,6 @@ describe('node-agent-tools: send_message', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('point-to-point succeeds when channel declared', async () => {
@@ -841,7 +830,6 @@ describe('node-agent-tools: save_artifact', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('save_artifact({ type, summary }) writes to artifact store and does NOT mutate task status', async () => {
@@ -962,7 +950,6 @@ describe('node-agent-tools: list_channels', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns empty channels when workflow is null', async () => {
@@ -1069,7 +1056,6 @@ describe('node-agent-tools: list_gates', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns empty gates when workflow is null', async () => {
@@ -1201,7 +1187,6 @@ describe('node-agent-tools: read_gate', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns error for non-existent gateId', async () => {
@@ -1310,7 +1295,6 @@ describe('node-agent-tools: send_message (gate-write)', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	/** Build a workflow with a gated channel from coder → reviewer. */
@@ -1539,7 +1523,6 @@ describe('node-agent-tools: list_reachable_agents', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns within-node peers excluding self and task-agent', async () => {
@@ -1790,7 +1773,6 @@ describe('node-agent-tools: createNodeAgentMcpServer', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('creates an MCP server with expected tools', () => {
@@ -1835,7 +1817,6 @@ describe('list_peers — completion state', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('list_peers includes completionState for each peer based on space_tasks', async () => {
@@ -1953,7 +1934,6 @@ describe('node-agent-tools: async gate evaluation', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	/**
@@ -2260,7 +2240,6 @@ describe('node-agent-tools: restore_node_agent', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns success with session/agent identity even without onRestoreNodeAgent callback', async () => {
@@ -2344,7 +2323,6 @@ describe('node-agent-tools: review-posted-gate multi-round artifact history', ()
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	/**
@@ -2573,7 +2551,6 @@ describe('node-agent-tools: list_peers — cross-node peer discovery', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('shows cross-node peer as not_started when node has not been activated yet', async () => {
@@ -2933,7 +2910,6 @@ describe('node-agent-tools: send_message — queue-when-inactive', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('queues message for declared-but-inactive agent when pendingMessageRepo provided', async () => {

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-collaboration.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-collaboration.test.ts
@@ -12,8 +12,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -37,18 +35,13 @@ import type { DaemonHub } from '../../../../src/lib/daemon-hub.ts';
 // DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-task-agent-collaboration',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
@@ -89,7 +82,6 @@ function makeSpace(spaceId: string, workspacePath = '/tmp/workspace'): Space {
 
 interface TestCtx {
 	db: BunDatabase;
-	dir: string;
 	spaceId: string;
 	coderAgentId: string;
 	reviewerAgentId: string;
@@ -103,7 +95,7 @@ interface TestCtx {
 }
 
 function makeCtx(): TestCtx {
-	const { db, dir } = makeDb();
+	const db = makeDb();
 	const spaceId = 'space-collab-test';
 	const workspacePath = '/tmp/test-workspace';
 
@@ -140,7 +132,6 @@ function makeCtx(): TestCtx {
 
 	return {
 		db,
-		dir,
 		spaceId,
 		coderAgentId,
 		reviewerAgentId,
@@ -274,7 +265,6 @@ describe('Task Agent — gate-blocked flow with escalation', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('escalation context is recorded on task error field', async () => {
@@ -309,7 +299,6 @@ describe('Task Agent — multi-agent node collaboration', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('collaboration workflow with channels: channel map in workflow is persisted and accessible', async () => {

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-mcp.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-mcp.test.ts
@@ -16,8 +16,6 @@
  */
 
 import { describe, test, expect, afterEach, spyOn, beforeEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -111,18 +109,13 @@ function makeMockSession(sessionId: string): MockAgentSession {
 // DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-tam-mcp',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
@@ -167,7 +160,6 @@ function buildManager(opts: {
 	fromInitSpy: ReturnType<typeof spyOn<typeof AgentSession, 'fromInit'>>;
 	capturedFromInitArgs: Map<string, CapturedSessionArgs>;
 	bunDb: BunDatabase;
-	dir: string;
 	taskRepo: SpaceTaskRepository;
 	taskManager: SpaceTaskManager;
 	space: Space;
@@ -177,7 +169,7 @@ function buildManager(opts: {
 	seedSession: (id: string, type: string) => void;
 } {
 	const { registryMcpServers = {}, hasAppMcpManager = true } = opts;
-	const { db: bunDb, dir } = makeDb();
+	const bunDb = makeDb();
 	const spaceId = 'space-mcp-test';
 	seedSpaceRow(bunDb, spaceId);
 
@@ -287,7 +279,6 @@ function buildManager(opts: {
 		capturedFromInitArgs,
 		fromInitSpy,
 		bunDb,
-		dir,
 		taskRepo,
 		taskManager,
 		space,
@@ -305,26 +296,17 @@ function buildManager(opts: {
 
 describe('TaskAgentManager — registry MCP merge (Task 3.4)', () => {
 	const spies: Array<{ mockRestore: () => void }> = [];
-	const dirs: string[] = [];
 
 	afterEach(() => {
 		for (const spy of spies.splice(0)) spy.mockRestore();
-		for (const dir of dirs.splice(0)) {
-			try {
-				rmSync(dir, { recursive: true });
-			} catch {
-				// best-effort cleanup
-			}
-		}
 	});
 
 	test('task agent session receives registry MCP servers merged with task-agent server', async () => {
 		const registryServer: McpServerConfig = { type: 'stdio', command: 'registry-cmd' };
-		const { manager, createdSessions, fromInitSpy, dir, taskManager, space } = buildManager({
+		const { manager, createdSessions, fromInitSpy, taskManager, space } = buildManager({
 			registryMcpServers: { 'registry-mcp': registryServer },
 		});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		const task = await taskManager.createTask({
 			title: 'Test task',
@@ -349,11 +331,10 @@ describe('TaskAgentManager — registry MCP merge (Task 3.4)', () => {
 	test('in-process task-agent server takes precedence over registry entry with same name', async () => {
 		// A registry entry named 'task-agent' should NOT override the in-process server.
 		const impostor: McpServerConfig = { type: 'stdio', command: 'impostor-cmd' };
-		const { manager, createdSessions, fromInitSpy, dir, taskManager, space } = buildManager({
+		const { manager, createdSessions, fromInitSpy, taskManager, space } = buildManager({
 			registryMcpServers: { 'task-agent': impostor },
 		});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		const task = await taskManager.createTask({
 			title: 'Collision task',
@@ -375,11 +356,10 @@ describe('TaskAgentManager — registry MCP merge (Task 3.4)', () => {
 	test('merged map contains all registry servers — none are dropped', async () => {
 		const serverA: McpServerConfig = { type: 'stdio', command: 'server-a' };
 		const serverB: McpServerConfig = { type: 'stdio', command: 'server-b' };
-		const { manager, createdSessions, fromInitSpy, dir, taskManager, space } = buildManager({
+		const { manager, createdSessions, fromInitSpy, taskManager, space } = buildManager({
 			registryMcpServers: { 'mcp-a': serverA, 'mcp-b': serverB },
 		});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		const task = await taskManager.createTask({
 			title: 'Multi-registry task',
@@ -398,11 +378,10 @@ describe('TaskAgentManager — registry MCP merge (Task 3.4)', () => {
 	});
 
 	test('works without appMcpManager — task-agent server is still injected', async () => {
-		const { manager, createdSessions, fromInitSpy, dir, taskManager, space } = buildManager({
+		const { manager, createdSessions, fromInitSpy, taskManager, space } = buildManager({
 			hasAppMcpManager: false,
 		});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		const task = await taskManager.createTask({
 			title: 'No registry task',
@@ -420,11 +399,10 @@ describe('TaskAgentManager — registry MCP merge (Task 3.4)', () => {
 	});
 
 	test('works with empty registry — task-agent server is still injected', async () => {
-		const { manager, createdSessions, fromInitSpy, dir, taskManager, space } = buildManager({
+		const { manager, createdSessions, fromInitSpy, taskManager, space } = buildManager({
 			registryMcpServers: {},
 		});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		const task = await taskManager.createTask({
 			title: 'Empty registry task',
@@ -453,25 +431,16 @@ describe('TaskAgentManager — registry MCP merge (Task 3.4)', () => {
 
 describe('TaskAgentManager.rehydrate — registry MCP merge (Task 3.4)', () => {
 	const spies: Array<{ mockRestore: () => void }> = [];
-	const dirs: string[] = [];
 
 	afterEach(() => {
 		for (const spy of spies.splice(0)) spy.mockRestore();
-		for (const dir of dirs.splice(0)) {
-			try {
-				rmSync(dir, { recursive: true });
-			} catch {
-				/* best-effort */
-			}
-		}
 	});
 
 	test('rehydrated task agent session receives registry MCP servers alongside task-agent server', async () => {
 		const registryServer: McpServerConfig = { type: 'stdio', command: 'registry-cmd' };
-		const { manager, createdSessions, fromInitSpy, bunDb, dir, taskManager, space, seedSession } =
+		const { manager, createdSessions, fromInitSpy, bunDb, taskManager, space, seedSession } =
 			buildManager({ registryMcpServers: { 'registry-mcp': registryServer } });
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		// Create a task that was in progress before the daemon restart
 		const task = await taskManager.createTask({
@@ -562,17 +531,9 @@ function makeResolvedChannel(
 
 describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 	const spies: Array<{ mockRestore: () => void }> = [];
-	const dirs: string[] = [];
 
 	afterEach(() => {
 		for (const spy of spies.splice(0)) spy.mockRestore();
-		for (const dir of dirs.splice(0)) {
-			try {
-				rmSync(dir, { recursive: true });
-			} catch {
-				/* best-effort */
-			}
-		}
 	});
 
 	test('buildNodeAgentMcpServerForSession injects ChannelResolver (empty after M71 run.config removal)', () => {
@@ -580,9 +541,8 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 		// buildNodeAgentMcpServerForSession now creates an empty ChannelResolver via
 		// ChannelResolver.fromRunConfig(undefined). This test verifies the resolver is
 		// created and injected (though it has no channels since they're in-memory only).
-		const { manager, fromInitSpy, bunDb, dir, space, taskManager } = buildManager({});
+		const { manager, fromInitSpy, bunDb, space, taskManager } = buildManager({});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		// Seed a workflow run (channels param ignored since run.config no longer stores them)
 		const workflowRunId = seedWorkflowRunWithChannels(bunDb, space.id, [
@@ -634,9 +594,8 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 	});
 
 	test('buildNodeAgentMcpServerForSession injects empty ChannelResolver when run has no channels', () => {
-		const { manager, fromInitSpy, bunDb, dir, space, taskManager } = buildManager({});
+		const { manager, fromInitSpy, bunDb, space, taskManager } = buildManager({});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		// Seed a workflow run with NO channels
 		const workflowRunId = seedWorkflowRunWithChannels(bunDb, space.id, []);
@@ -681,9 +640,8 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 	});
 
 	test('buildNodeAgentMcpServerForSession injects empty ChannelResolver when workflowRunId is empty', () => {
-		const { manager, fromInitSpy, dir, space, taskManager } = buildManager({});
+		const { manager, fromInitSpy, space, taskManager } = buildManager({});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		let capturedConfig: Record<string, unknown> | null = null;
 		const mcpServerSpy = spyOn(nodeAgentToolsModule, 'createNodeAgentMcpServer').mockImplementation(
@@ -726,9 +684,8 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 	});
 
 	test('buildNodeAgentMcpServerForSession passes correct mySessionId, myAgentName, and taskId', () => {
-		const { manager, fromInitSpy, bunDb, dir, space, taskManager, taskRepo } = buildManager({});
+		const { manager, fromInitSpy, bunDb, space, taskManager, taskRepo } = buildManager({});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		// Seed a step task — workflowNodeId was removed in M71, buildNodeAgentMcpServerForSession
 		// now uses task.id as the workflowNodeId value
@@ -786,31 +743,15 @@ describe('TaskAgentManager — ChannelResolver injection (Task 3.3)', () => {
 
 describe('TaskAgentManager — skills injection into fresh task agent sessions (G1)', () => {
 	const spies: Array<{ mockRestore: () => void }> = [];
-	const dirs: string[] = [];
 
 	afterEach(() => {
 		for (const spy of spies.splice(0)) spy.mockRestore();
-		for (const dir of dirs.splice(0)) {
-			try {
-				rmSync(dir, { recursive: true });
-			} catch {
-				// best-effort
-			}
-		}
 	});
 
 	test('AgentSession.fromInit receives skillsManager when spawning task agent', async () => {
-		const {
-			manager,
-			fromInitSpy,
-			capturedFromInitArgs,
-			dir,
-			taskManager,
-			space,
-			mockSkillsManager,
-		} = buildManager({});
+		const { manager, fromInitSpy, capturedFromInitArgs, taskManager, space, mockSkillsManager } =
+			buildManager({});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		const task = await taskManager.createTask({
 			title: 'Skills injection task',
@@ -828,17 +769,9 @@ describe('TaskAgentManager — skills injection into fresh task agent sessions (
 	});
 
 	test('AgentSession.fromInit receives appMcpServerRepo when spawning task agent', async () => {
-		const {
-			manager,
-			fromInitSpy,
-			capturedFromInitArgs,
-			dir,
-			taskManager,
-			space,
-			mockAppMcpServerRepo,
-		} = buildManager({});
+		const { manager, fromInitSpy, capturedFromInitArgs, taskManager, space, mockAppMcpServerRepo } =
+			buildManager({});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		const task = await taskManager.createTask({
 			title: 'AppMcpServerRepo injection task',
@@ -857,23 +790,14 @@ describe('TaskAgentManager — skills injection into fresh task agent sessions (
 
 describe('TaskAgentManager — skills injection into sub-sessions (G2)', () => {
 	const spies: Array<{ mockRestore: () => void }> = [];
-	const dirs: string[] = [];
 
 	afterEach(() => {
 		for (const spy of spies.splice(0)) spy.mockRestore();
-		for (const dir of dirs.splice(0)) {
-			try {
-				rmSync(dir, { recursive: true });
-			} catch {
-				// best-effort
-			}
-		}
 	});
 
 	test('AgentSession.fromInit receives skillsManager when creating sub-session', async () => {
-		const { manager, fromInitSpy, capturedFromInitArgs, dir, mockSkillsManager } = buildManager({});
+		const { manager, fromInitSpy, capturedFromInitArgs, mockSkillsManager } = buildManager({});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		// Create sub-session directly via public createSubSession()
 		const subSessionId = 'sub-session-skills-test';
@@ -891,11 +815,8 @@ describe('TaskAgentManager — skills injection into sub-sessions (G2)', () => {
 	});
 
 	test('AgentSession.fromInit receives appMcpServerRepo when creating sub-session', async () => {
-		const { manager, fromInitSpy, capturedFromInitArgs, dir, mockAppMcpServerRepo } = buildManager(
-			{}
-		);
+		const { manager, fromInitSpy, capturedFromInitArgs, mockAppMcpServerRepo } = buildManager({});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		const subSessionId = 'sub-session-appmcp-test';
 		const init = {
@@ -913,11 +834,10 @@ describe('TaskAgentManager — skills injection into sub-sessions (G2)', () => {
 
 	test('sub-session receives registry MCPs via setRuntimeMcpServers()', async () => {
 		const registryServer: McpServerConfig = { type: 'stdio', command: 'registry-cmd' };
-		const { manager, fromInitSpy, createdSessions, dir } = buildManager({
+		const { manager, fromInitSpy, createdSessions } = buildManager({
 			registryMcpServers: { 'registry-mcp': registryServer },
 		});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		const subSessionId = 'sub-session-registry-mcp-test';
 		const init = {
@@ -935,11 +855,10 @@ describe('TaskAgentManager — skills injection into sub-sessions (G2)', () => {
 	});
 
 	test('sub-session receives no registry MCPs when appMcpManager is absent', async () => {
-		const { manager, fromInitSpy, createdSessions, dir } = buildManager({
+		const { manager, fromInitSpy, createdSessions } = buildManager({
 			hasAppMcpManager: false,
 		});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		const subSessionId = 'sub-session-no-registry-test';
 		const init = {
@@ -959,17 +878,9 @@ describe('TaskAgentManager — skills injection into sub-sessions (G2)', () => {
 
 describe('TaskAgentManager.rehydrate — skills injection (G3)', () => {
 	const spies: Array<{ mockRestore: () => void }> = [];
-	const dirs: string[] = [];
 
 	afterEach(() => {
 		for (const spy of spies.splice(0)) spy.mockRestore();
-		for (const dir of dirs.splice(0)) {
-			try {
-				rmSync(dir, { recursive: true });
-			} catch {
-				/* best-effort */
-			}
-		}
 	});
 
 	test('AgentSession.restore receives skillsManager when rehydrating task agent', async () => {
@@ -978,14 +889,12 @@ describe('TaskAgentManager.rehydrate — skills injection (G3)', () => {
 			fromInitSpy,
 			createdSessions,
 			bunDb,
-			dir,
 			taskManager,
 			space,
 			seedSession,
 			mockSkillsManager,
 		} = buildManager({});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		const task = await taskManager.createTask({
 			title: 'Rehydration skills task',
@@ -1040,14 +949,12 @@ describe('TaskAgentManager.rehydrate — skills injection (G3)', () => {
 			fromInitSpy,
 			createdSessions,
 			bunDb,
-			dir,
 			taskManager,
 			space,
 			seedSession,
 			mockAppMcpServerRepo,
 		} = buildManager({});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		const task = await taskManager.createTask({
 			title: 'Rehydration appMcpServerRepo task',
@@ -1104,23 +1011,14 @@ describe('TaskAgentManager.rehydrate — skills injection (G3)', () => {
 
 describe('TaskAgentManager.ensureNodeAgentAttached — workflow sub-session invariant (Task #37)', () => {
 	const spies: Array<{ mockRestore: () => void }> = [];
-	const dirs: string[] = [];
 
 	afterEach(() => {
 		for (const spy of spies.splice(0)) spy.mockRestore();
-		for (const dir of dirs.splice(0)) {
-			try {
-				rmSync(dir, { recursive: true });
-			} catch {
-				/* best-effort */
-			}
-		}
 	});
 
 	test('does nothing when node-agent is already present in session.config.mcpServers', () => {
-		const { manager, fromInitSpy, dir } = buildManager({});
+		const { manager, fromInitSpy } = buildManager({});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		const session = makeMockSession('sub-session-ok');
 		// Pre-populate node-agent in the session config — invariant already holds.
@@ -1155,9 +1053,8 @@ describe('TaskAgentManager.ensureNodeAgentAttached — workflow sub-session inva
 	});
 
 	test('self-heals by re-injecting node-agent when missing', () => {
-		const { manager, fromInitSpy, dir } = buildManager({});
+		const { manager, fromInitSpy } = buildManager({});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		const session = makeMockSession('sub-session-broken');
 		// node-agent is missing — registry servers may still be there.
@@ -1203,9 +1100,8 @@ describe('TaskAgentManager.ensureNodeAgentAttached — workflow sub-session inva
 	});
 
 	test('throws when re-injection fails to add node-agent', () => {
-		const { manager, fromInitSpy, dir } = buildManager({});
+		const { manager, fromInitSpy } = buildManager({});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		const session = makeMockSession('sub-session-broken');
 		session.session.config.mcpServers = {};
@@ -1241,23 +1137,14 @@ describe('TaskAgentManager.ensureNodeAgentAttached — workflow sub-session inva
 
 describe('TaskAgentManager.reinjectNodeAgentMcpServer — server-side restore primitive (Task #37)', () => {
 	const spies: Array<{ mockRestore: () => void }> = [];
-	const dirs: string[] = [];
 
 	afterEach(() => {
 		for (const spy of spies.splice(0)) spy.mockRestore();
-		for (const dir of dirs.splice(0)) {
-			try {
-				rmSync(dir, { recursive: true });
-			} catch {
-				/* best-effort */
-			}
-		}
 	});
 
 	test('builds and merges node-agent into session config without dropping existing servers', () => {
-		const { manager, fromInitSpy, dir, space } = buildManager({});
+		const { manager, fromInitSpy, space } = buildManager({});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		const session = makeMockSession('sub-session-reinject');
 		session.session.config.mcpServers = { 'registry-mcp': { name: 'registry' } };
@@ -1296,23 +1183,14 @@ describe('TaskAgentManager.reinjectNodeAgentMcpServer — server-side restore pr
 
 describe('TaskAgentManager.buildNodeAgentMcpServerForSession — onRestoreNodeAgent callback wiring (Task #37)', () => {
 	const spies: Array<{ mockRestore: () => void }> = [];
-	const dirs: string[] = [];
 
 	afterEach(() => {
 		for (const spy of spies.splice(0)) spy.mockRestore();
-		for (const dir of dirs.splice(0)) {
-			try {
-				rmSync(dir, { recursive: true });
-			} catch {
-				/* best-effort */
-			}
-		}
 	});
 
 	test('passes an onRestoreNodeAgent callback into createNodeAgentMcpServer', () => {
-		const { manager, fromInitSpy, dir, space, taskManager } = buildManager({});
+		const { manager, fromInitSpy, space, taskManager } = buildManager({});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		let capturedConfig: Record<string, unknown> | null = null;
 		const mcpServerSpy = spyOn(nodeAgentToolsModule, 'createNodeAgentMcpServer').mockImplementation(
@@ -1354,9 +1232,8 @@ describe('TaskAgentManager.buildNodeAgentMcpServerForSession — onRestoreNodeAg
 	});
 
 	test('onRestoreNodeAgent callback re-injects node-agent on a live sub-session', async () => {
-		const { manager, fromInitSpy, dir, space } = buildManager({});
+		const { manager, fromInitSpy, space } = buildManager({});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		// Step 1: stub the server builder so buildNodeAgentMcpServerForSession can run
 		// without requiring a full workflow definition. The first call (server build)
@@ -1433,9 +1310,8 @@ describe('TaskAgentManager.buildNodeAgentMcpServerForSession — onRestoreNodeAg
 	});
 
 	test('onRestoreNodeAgent is a no-op (logs only) when no live sub-session is found', () => {
-		const { manager, fromInitSpy, dir, space } = buildManager({});
+		const { manager, fromInitSpy, space } = buildManager({});
 		spies.push(fromInitSpy);
-		dirs.push(dir);
 
 		let capturedConfig: Record<string, unknown> | null = null;
 		const mcpServerSpy = spyOn(nodeAgentToolsModule, 'createNodeAgentMcpServer').mockImplementation(

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
@@ -744,11 +744,6 @@ describe('TaskAgentManager.tryResumeNodeAgentSession', () => {
 	afterEach(() => {
 		ctx.fromInitSpy.mockRestore();
 		restoreSpy.mockRestore();
-		try {
-			rmSync(ctx.dir, { recursive: true, force: true });
-		} catch {
-			// ignore cleanup errors
-		}
 	});
 
 	test('is a no-op when pendingMessageRepo is not configured', async () => {

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
@@ -7,8 +7,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -141,18 +139,13 @@ function makeMockSession(sessionId: string): MockAgentSession {
 // DB + test context helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-task-agent-rehydration',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
@@ -188,7 +181,6 @@ function makeSpace(spaceId: string, workspacePath = '/tmp/workspace'): Space {
 
 interface TestCtx {
 	bunDb: BunDatabase;
-	dir: string;
 	spaceId: string;
 	space: Space;
 	agentId: string;
@@ -214,7 +206,7 @@ interface TestCtx {
 }
 
 function makeCtx(): TestCtx {
-	const { db: bunDb, dir } = makeDb();
+	const bunDb = makeDb();
 	const spaceId = 'space-rehydration-test';
 	const workspacePath = '/tmp/test-workspace';
 
@@ -319,7 +311,6 @@ function makeCtx(): TestCtx {
 
 	return {
 		bunDb,
-		dir,
 		spaceId,
 		space,
 		agentId,
@@ -398,11 +389,6 @@ describe('TaskAgentManager.rehydrateSubSession (lazy rehydration)', () => {
 	afterEach(() => {
 		ctx.fromInitSpy.mockRestore();
 		restoreSpy.mockRestore();
-		try {
-			rmSync(ctx.dir, { recursive: true, force: true });
-		} catch {
-			// ignore cleanup errors
-		}
 	});
 
 	test('injectSubSessionMessage rehydrates a ghost sub-session and delivers the message', async () => {

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-worktree.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-worktree.test.ts
@@ -17,8 +17,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach, spyOn, mock } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -213,18 +211,13 @@ function makeMockWorktreeManager(worktreePath = '/tmp/worktrees/test-task'): Moc
 // DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-tam-worktree',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
@@ -273,7 +266,6 @@ async function makeTask(taskManager: SpaceTaskManager): Promise<SpaceTask> {
 
 interface TestCtx {
 	bunDb: BunDatabase;
-	dir: string;
 	spaceId: string;
 	space: Space;
 	taskRepo: SpaceTaskRepository;
@@ -290,7 +282,7 @@ interface TestCtx {
 }
 
 function makeCtx(worktreePath = '/tmp/worktrees/test-task'): TestCtx {
-	const { db: bunDb, dir } = makeDb();
+	const bunDb = makeDb();
 	const spaceId = 'space-wt-test';
 	const workspacePath = '/tmp/test-workspace';
 
@@ -393,7 +385,6 @@ function makeCtx(worktreePath = '/tmp/worktrees/test-task'): TestCtx {
 
 	return {
 		bunDb,
-		dir,
 		spaceId,
 		space,
 		taskRepo,
@@ -424,11 +415,6 @@ describe('TaskAgentManager × SpaceWorktreeManager (M4.3)', () => {
 
 	afterEach(() => {
 		ctx.fromInitSpy.mockRestore();
-		try {
-			rmSync(ctx.dir, { recursive: true, force: true });
-		} catch {
-			// ignore cleanup errors
-		}
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
@@ -17,8 +17,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach, spyOn, mock } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -152,18 +150,13 @@ function makeMockSession(
 // DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-task-agent-manager',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
@@ -212,7 +205,6 @@ async function makeTask(taskManager: SpaceTaskManager): Promise<SpaceTask> {
 
 interface TestCtx {
 	bunDb: BunDatabase;
-	dir: string;
 	spaceId: string;
 	space: Space;
 	agentId: string;
@@ -240,7 +232,7 @@ interface TestCtx {
 }
 
 function makeCtx(): TestCtx {
-	const { db: bunDb, dir } = makeDb();
+	const bunDb = makeDb();
 	const spaceId = 'space-tam-test';
 	const workspacePath = '/tmp/test-workspace';
 
@@ -348,7 +340,6 @@ function makeCtx(): TestCtx {
 
 	return {
 		bunDb,
-		dir,
 		spaceId,
 		space,
 		agentId,
@@ -382,11 +373,6 @@ describe('TaskAgentManager', () => {
 
 	afterEach(() => {
 		ctx.fromInitSpy.mockRestore();
-		try {
-			rmSync(ctx.dir, { recursive: true, force: true });
-		} catch {
-			// ignore cleanup errors
-		}
 	});
 
 	// -----------------------------------------------------------------------
@@ -1898,7 +1884,7 @@ describe('TaskAgentManager', () => {
 
 	describe('flushPendingMessagesForSpaceAgent', () => {
 		test('delivers queued Space Agent message via spaceAgentInjector', async () => {
-			const { db: testDb, dir: testDir } = makeDb();
+			const testDb = makeDb();
 			const testSpaceId = 'space-flush-sa';
 			const testRunId = 'run-flush-sa';
 			const testWfId = 'wf-flush-sa';
@@ -1962,11 +1948,7 @@ describe('TaskAgentManager', () => {
 			expect(rows).toHaveLength(1);
 			expect(rows[0].status).toBe('delivered');
 
-			try {
-				rmSync(testDir, { recursive: true, force: true });
-			} catch {
-				// ignore
-			}
+			testDb.close();
 		});
 
 		test('no-op when pendingMessageRepo is absent', async () => {
@@ -1977,7 +1959,7 @@ describe('TaskAgentManager', () => {
 		});
 
 		test('no-op when there are no pending Space Agent messages', async () => {
-			const { db: testDb, dir: testDir } = makeDb();
+			const testDb = makeDb();
 			const testSpaceId = 'space-flush-empty';
 			const testRunId = 'run-flush-empty';
 			const testWfId = 'wf-flush-empty';
@@ -2027,11 +2009,7 @@ describe('TaskAgentManager', () => {
 			await emptyManager.flushPendingMessagesForSpaceAgent(testSpaceId, testRunId);
 			expect(injectorCalled).toBe(false);
 
-			try {
-				rmSync(testDir, { recursive: true, force: true });
-			} catch {
-				// ignore
-			}
+			testDb.close();
 		});
 	});
 });

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-session-lifecycle.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-session-lifecycle.test.ts
@@ -15,8 +15,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -144,18 +142,13 @@ function makeMockSession(
 // DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-task-agent-lifecycle',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
@@ -208,7 +201,6 @@ async function makeTask(
 
 interface TestCtx {
 	bunDb: BunDatabase;
-	dir: string;
 	spaceId: string;
 	space: Space;
 	agentId: string;
@@ -236,7 +228,7 @@ interface TestCtx {
 }
 
 function makeCtx(): TestCtx {
-	const { db: bunDb, dir } = makeDb();
+	const bunDb = makeDb();
 	const spaceId = 'space-tal-test';
 	const workspacePath = '/tmp/test-workspace';
 
@@ -353,7 +345,6 @@ function makeCtx(): TestCtx {
 
 	return {
 		bunDb,
-		dir,
 		spaceId,
 		space,
 		agentId,
@@ -387,11 +378,6 @@ describe('Task Agent Session Lifecycle', () => {
 
 	afterEach(() => {
 		ctx.fromInitSpy.mockRestore();
-		try {
-			rmSync(ctx.dir, { recursive: true, force: true });
-		} catch {
-			// ignore cleanup errors
-		}
 	});
 
 	// =======================================================================

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-tools.test.ts
@@ -66,8 +66,6 @@ mock.module('@anthropic-ai/claude-agent-sdk', () => {
 });
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -93,18 +91,13 @@ import type { DaemonHub } from '../../../../src/lib/daemon-hub.ts';
 // DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-task-agent-tools',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
@@ -234,7 +227,6 @@ function buildTaskResultWorkflow(
 
 interface TestCtx {
 	db: BunDatabase;
-	dir: string;
 	spaceId: string;
 	agentId: string;
 	space: Space;
@@ -248,7 +240,7 @@ interface TestCtx {
 }
 
 function makeCtx(): TestCtx {
-	const { db, dir } = makeDb();
+	const db = makeDb();
 	const spaceId = 'space-tat-test';
 	const workspacePath = '/tmp/test-workspace';
 
@@ -284,7 +276,6 @@ function makeCtx(): TestCtx {
 
 	return {
 		db,
-		dir,
 		spaceId,
 		agentId,
 		space,
@@ -397,7 +388,6 @@ describe('createTaskAgentToolHandlers — save_artifact', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('saves artifact with summary and does NOT mutate task state', async () => {
@@ -509,7 +499,7 @@ describe('createTaskAgentToolHandlers — approve_task', () => {
 	let ctx: TestCtx;
 	beforeEach(() => {
 		// Seed space with autonomy level 5 so approve_task works by default
-		const { db, dir } = makeDb();
+		const db = makeDb();
 		const spaceId = 'space-tat-test';
 		db.prepare(
 			`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
@@ -548,7 +538,6 @@ describe('createTaskAgentToolHandlers — approve_task', () => {
 
 		ctx = {
 			db,
-			dir,
 			spaceId,
 			agentId,
 			space,
@@ -563,7 +552,6 @@ describe('createTaskAgentToolHandlers — approve_task', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('sets reportedStatus=done when space autonomy sufficient (no workflow run repo)', async () => {
@@ -631,7 +619,6 @@ describe('createTaskAgentToolHandlers — submit_for_approval', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('sets status=review and pending-completion fields', async () => {
@@ -726,7 +713,6 @@ describe('createTaskAgentToolHandlers — request_human_input', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('marks task as blocked and returns the question in the response', async () => {
@@ -841,7 +827,6 @@ describe('createTaskAgentMcpServer', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	// ---------------------------------------------------------------------------
@@ -1007,7 +992,6 @@ describe('createTaskAgentToolHandlers — list_group_members', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns empty member list when no tasks have taskAgentSessionId', async () => {
@@ -1134,7 +1118,6 @@ describe('createTaskAgentToolHandlers — send_message queue-until-active', () =
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('queues message when target is declared but inactive', async () => {

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-tools.test.ts
@@ -1483,7 +1483,6 @@ describe('createTaskAgentToolHandlers — send_message auto-resume on queue', ()
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('calls tryResumeNodeAgentSession after queuing a non-deduped message', async () => {

--- a/packages/daemon/tests/unit/5-space/other/autonomy-gated-approvals.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/autonomy-gated-approvals.test.ts
@@ -22,8 +22,6 @@
  */
 
 import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { GateDataRepository } from '../../../../src/storage/repositories/gate-data-repository.ts';
@@ -56,18 +54,13 @@ import type {
 // DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-autonomy-gated',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(
@@ -231,7 +224,6 @@ function buildGatedWorkflowMixed(opts: {
 
 describe('ChannelRouter.onGateDataChanged — requiredLevel enforcement', () => {
 	let db: BunDatabase;
-	let dir: string;
 	let gateDataRepo: GateDataRepository;
 	let nodeExecutionRepo: NodeExecutionRepository;
 
@@ -240,9 +232,7 @@ describe('ChannelRouter.onGateDataChanged — requiredLevel enforcement', () => 
 	const gateId = 'code-ready-gate';
 
 	beforeEach(() => {
-		const result = makeDb();
-		db = result.db;
-		dir = result.dir;
+		db = makeDb();
 		gateDataRepo = new GateDataRepository(db);
 		nodeExecutionRepo = new NodeExecutionRepository(db);
 		seedSpaceRow(db, spaceId);
@@ -251,7 +241,6 @@ describe('ChannelRouter.onGateDataChanged — requiredLevel enforcement', () => 
 
 	afterEach(() => {
 		db.close();
-		rmSync(dir, { recursive: true, force: true });
 	});
 
 	function makeRouter(spaceAutonomyLevel: number, workflow: SpaceWorkflow) {
@@ -934,7 +923,6 @@ describe('task-agent-tools approve_gate — autonomy enforcement', () => {
 
 describe('node-agent-tools send_message gate write — autonomy enforcement', () => {
 	let db: BunDatabase;
-	let dir: string;
 	let gateDataRepo: GateDataRepository;
 	let nodeExecutionRepo: NodeExecutionRepository;
 
@@ -945,9 +933,7 @@ describe('node-agent-tools send_message gate write — autonomy enforcement', ()
 	const reviewerNodeId = 'node-reviewer';
 
 	beforeEach(() => {
-		const result = makeDb();
-		db = result.db;
-		dir = result.dir;
+		db = makeDb();
 		gateDataRepo = new GateDataRepository(db);
 		nodeExecutionRepo = new NodeExecutionRepository(db);
 		seedSpaceRow(db, spaceId);
@@ -956,7 +942,6 @@ describe('node-agent-tools send_message gate write — autonomy enforcement', ()
 
 	afterEach(() => {
 		db.close();
-		rmSync(dir, { recursive: true, force: true });
 	});
 
 	function makeHandlers(opts: {

--- a/packages/daemon/tests/unit/5-space/other/channel-router-async.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/channel-router-async.test.ts
@@ -11,8 +11,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -35,18 +33,13 @@ import { CODING_WORKFLOW } from '../../../../src/lib/space/workflows/built-in-wo
 // DB helpers (shared with channel-router.test.ts)
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-channel-router-async',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpace(db: BunDatabase, spaceId: string): void {
@@ -112,7 +105,6 @@ function buildWorkflowWithGates(
 
 describe('ChannelRouter async gate evaluation', () => {
 	let db: BunDatabase;
-	let dir: string;
 
 	let taskRepo: SpaceTaskRepository;
 	let workflowRunRepo: SpaceWorkflowRunRepository;
@@ -128,9 +120,7 @@ describe('ChannelRouter async gate evaluation', () => {
 	const NODE_B = 'node-async-b';
 
 	beforeEach(() => {
-		const dbResult = makeDb();
-		db = dbResult.db;
-		dir = dbResult.dir;
+		db = makeDb();
 
 		seedSpace(db, SPACE_ID);
 		seedAgent(db, AGENT_CODER, SPACE_ID, 'coder');
@@ -150,7 +140,6 @@ describe('ChannelRouter async gate evaluation', () => {
 
 	afterEach(() => {
 		db.close();
-		rmSync(dir, { recursive: true, force: true });
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/5-space/other/channel-router-auto-approval.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/channel-router-auto-approval.test.ts
@@ -10,8 +10,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -31,18 +29,13 @@ import { computeGateDefaults } from '@neokai/shared';
 // DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-channel-router-auto-approval',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpace(db: BunDatabase, spaceId: string, autonomyLevel: SpaceAutonomyLevel = 1): void {
@@ -96,7 +89,6 @@ function buildWorkflowWithGates(
 
 describe('ChannelRouter — gate auto-approval via requiredLevel', () => {
 	let db: BunDatabase;
-	let dir: string;
 
 	let taskRepo: SpaceTaskRepository;
 	let workflowRunRepo: SpaceWorkflowRunRepository;
@@ -142,7 +134,7 @@ describe('ChannelRouter — gate auto-approval via requiredLevel', () => {
 	}
 
 	beforeEach(() => {
-		({ db, dir } = makeDb());
+		db = makeDb();
 		seedSpace(db, SPACE_ID, 1);
 		seedAgent(db, AGENT_A, SPACE_ID);
 		seedAgent(db, AGENT_B, SPACE_ID);
@@ -177,11 +169,6 @@ describe('ChannelRouter — gate auto-approval via requiredLevel', () => {
 	afterEach(() => {
 		try {
 			db?.close();
-		} catch {
-			/* ignore */
-		}
-		try {
-			rmSync(dir, { recursive: true, force: true });
 		} catch {
 			/* ignore */
 		}

--- a/packages/daemon/tests/unit/5-space/other/channel-router-reopen.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/channel-router-reopen.test.ts
@@ -23,8 +23,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -52,18 +50,13 @@ import type { Gate, SpaceWorkflow, WorkflowChannel } from '@neokai/shared';
 // DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-channel-router-reopen',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpace(db: BunDatabase, spaceId: string): void {
@@ -130,7 +123,6 @@ function buildSimpleWorkflow(
 
 describe('ChannelRouter — reopen on inbound activity (archive tombstone)', () => {
 	let db: BunDatabase;
-	let dir: string;
 
 	let taskRepo: SpaceTaskRepository;
 	let workflowRunRepo: SpaceWorkflowRunRepository;
@@ -148,7 +140,7 @@ describe('ChannelRouter — reopen on inbound activity (archive tombstone)', () 
 	const NODE_B = 'node-b';
 
 	beforeEach(() => {
-		({ db, dir } = makeDb());
+		db = makeDb();
 		seedSpace(db, SPACE_ID);
 		seedAgent(db, AGENT_A, SPACE_ID);
 		seedAgent(db, AGENT_B, SPACE_ID);
@@ -193,7 +185,6 @@ describe('ChannelRouter — reopen on inbound activity (archive tombstone)', () 
 
 	afterEach(() => {
 		db.close();
-		rmSync(dir, { recursive: true, force: true });
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
@@ -29,8 +29,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -54,18 +52,13 @@ import { computeGateDefaults } from '@neokai/shared';
 // DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-channel-router',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpace(db: BunDatabase, spaceId: string): void {
@@ -189,7 +182,6 @@ function buildWorkflowWithGates(
 
 describe('ChannelRouter', () => {
 	let db: BunDatabase;
-	let dir: string;
 
 	let taskRepo: SpaceTaskRepository;
 	let workflowRunRepo: SpaceWorkflowRunRepository;
@@ -208,7 +200,7 @@ describe('ChannelRouter', () => {
 	const NODE_B = 'node-b';
 
 	beforeEach(() => {
-		({ db, dir } = makeDb());
+		db = makeDb();
 
 		seedSpace(db, SPACE_ID);
 		seedAgent(db, AGENT_CODER, SPACE_ID);
@@ -258,7 +250,6 @@ describe('ChannelRouter', () => {
 
 	afterEach(() => {
 		db.close();
-		rmSync(dir, { recursive: true, force: true });
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/5-space/other/cross-agent-messaging-integration.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/cross-agent-messaging-integration.test.ts
@@ -40,8 +40,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
@@ -66,18 +64,13 @@ const STEP_NODE_ID = 'node-integration-step';
 // DB / seed helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-cross-agent-integration',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string): void {
@@ -154,7 +147,6 @@ function makeResolvedChannel(from: string, to: string | string[]): WorkflowChann
 
 interface TestDb {
 	db: BunDatabase;
-	dir: string;
 	spaceId: string;
 	nodeExecutionRepo: NodeExecutionRepository;
 	workflowRunRepo: SpaceWorkflowRunRepository;
@@ -162,7 +154,7 @@ interface TestDb {
 }
 
 function makeTestDb(): TestDb {
-	const { db, dir } = makeDb();
+	const db = makeDb();
 	const spaceId = `space-${Math.random().toString(36).slice(2)}`;
 	seedSpaceRow(db, spaceId);
 	const nodeExecutionRepo = new NodeExecutionRepository(db);
@@ -184,7 +176,6 @@ function makeTestDb(): TestDb {
 
 	return {
 		db,
-		dir,
 		spaceId,
 		nodeExecutionRepo,
 		workflowRunRepo,
@@ -253,7 +244,6 @@ describe('cross-group isolation', () => {
 
 	afterEach(() => {
 		tdb.db.close();
-		rmSync(tdb.dir, { recursive: true, force: true });
 	});
 
 	test('send_message never reaches group B members (group scoping)', async () => {
@@ -293,9 +283,7 @@ describe('cross-group isolation', () => {
 			expect(deliveredIds).not.toContain('session-coder-e');
 		} finally {
 			tdbA.db.close();
-			rmSync(tdbA.dir, { recursive: true, force: true });
 			tdbB.db.close();
-			rmSync(tdbB.dir, { recursive: true, force: true });
 		}
 	});
 });
@@ -313,7 +301,6 @@ describe('channel direction enforcement', () => {
 
 	afterEach(() => {
 		tdb.db.close();
-		rmSync(tdb.dir, { recursive: true, force: true });
 	});
 
 	test('send on declared one-way channel succeeds', async () => {
@@ -390,7 +377,6 @@ describe('bidirectional point-to-point A↔B', () => {
 
 	afterEach(() => {
 		tdb.db.close();
-		rmSync(tdb.dir, { recursive: true, force: true });
 	});
 
 	test('both directions of bidirectional channel deliver correctly', async () => {
@@ -489,7 +475,6 @@ describe('fan-out one-way A→[B,C,D]', () => {
 
 	afterEach(() => {
 		tdb.db.close();
-		rmSync(tdb.dir, { recursive: true, force: true });
 	});
 
 	function setupFanOutTasks(tdb: TestDb) {
@@ -626,7 +611,6 @@ describe('hub-spoke bidirectional A↔[B,C,D]', () => {
 
 	afterEach(() => {
 		tdb.db.close();
-		rmSync(tdb.dir, { recursive: true, force: true });
 	});
 
 	function setupHubSpokeTasks(tdb: TestDb) {
@@ -807,7 +791,6 @@ describe('concurrent message injection — both messages delivered', () => {
 
 	afterEach(() => {
 		tdb.db.close();
-		rmSync(tdb.dir, { recursive: true, force: true });
 	});
 
 	test('two agents injecting to same target simultaneously delivers both messages', async () => {
@@ -896,7 +879,6 @@ describe('data reload and DB-based validation', () => {
 
 	afterEach(() => {
 		tdb.db.close();
-		rmSync(tdb.dir, { recursive: true, force: true });
 	});
 
 	test('channel topology resolves correctly after workflow run re-fetch', async () => {
@@ -997,7 +979,6 @@ describe('error paths — missing workflowRunId', () => {
 
 	afterEach(() => {
 		tdb.db.close();
-		rmSync(tdb.dir, { recursive: true, force: true });
 	});
 
 	test('send_message fails with no-active-sessions when workflowRunId is empty', async () => {
@@ -1083,7 +1064,6 @@ describe('Task Agent channel participation', () => {
 
 	afterEach(() => {
 		tdb.db.close();
-		rmSync(tdb.dir, { recursive: true, force: true });
 	});
 
 	test('ChannelResolver: canSend returns true when coder→task-agent channel declared', async () => {

--- a/packages/daemon/tests/unit/5-space/other/cross-agent-messaging.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/cross-agent-messaging.test.ts
@@ -26,8 +26,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -59,18 +57,13 @@ import type { WorkflowChannel, Space, SpaceWorkflow } from '@neokai/shared';
 // DB / seed helpers
 // ===========================================================================
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-cross-agent-messaging',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpace(db: BunDatabase, spaceId: string): void {
@@ -141,7 +134,6 @@ const STEP_NODE_ID = 'node-cam-step';
 
 interface StepCtx {
 	db: BunDatabase;
-	dir: string;
 	spaceId: string;
 	nodeExecutionRepo: NodeExecutionRepository;
 	workflowRunId: string;
@@ -207,7 +199,7 @@ function seedStepTask(
 function makeStepCtx(
 	members: Array<{ sessionId: string; agentName: string; status?: string }>
 ): StepCtx {
-	const { db, dir } = makeDb();
+	const db = makeDb();
 	// Each DB is isolated; using a fixed spaceId within the DB is safe.
 	const spaceId = 'space-cam-step';
 	seedSpace(db, spaceId);
@@ -239,7 +231,6 @@ function makeStepCtx(
 
 	return {
 		db,
-		dir,
 		spaceId,
 		nodeExecutionRepo,
 		workflowRunId: run.id,
@@ -302,7 +293,6 @@ function makeStepConfig(
 
 interface TaskCtx {
 	db: BunDatabase;
-	dir: string;
 	spaceId: string;
 	agentId: string;
 	space: Space;
@@ -316,7 +306,7 @@ interface TaskCtx {
 }
 
 function makeTaskCtx(): TaskCtx {
-	const { db, dir } = makeDb();
+	const db = makeDb();
 	// Each DB is isolated; using a fixed spaceId within the DB is safe.
 	const spaceId = 'space-cam-task';
 	seedSpace(db, spaceId);
@@ -361,7 +351,6 @@ function makeTaskCtx(): TaskCtx {
 
 	return {
 		db,
-		dir,
 		spaceId,
 		agentId,
 		space,
@@ -492,7 +481,6 @@ describe('send_message — point-to-point (target: role)', () => {
 	let ctx: StepCtx;
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('succeeds when channel is declared', async () => {
@@ -535,7 +523,6 @@ describe('send_message — broadcast (target: "*")', () => {
 	let ctx: StepCtx;
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('delivers to all permitted targets', async () => {
@@ -576,7 +563,6 @@ describe('send_message — multicast (target: [role1, role2])', () => {
 	let ctx: StepCtx;
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('delivers to all listed roles when all are permitted', async () => {
@@ -655,7 +641,6 @@ describe('send_message — no channels declared', () => {
 	let ctx: StepCtx;
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('all send_message calls fail when no channels declared', async () => {
@@ -682,7 +667,6 @@ describe('send_message — fan-out one-way: hub → spokes, spokes cannot reply'
 	let ctx: StepCtx;
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	beforeEach(() => {
@@ -737,7 +721,6 @@ describe('send_message — hub-spoke bidirectional: hub broadcasts, spokes reply
 	let ctx: StepCtx;
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	beforeEach(() => {
@@ -805,7 +788,6 @@ describe('list_peers — peer discovery with channel info', () => {
 	let ctx: StepCtx;
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns peers excluding self (task-agent is included when active)', async () => {
@@ -876,7 +858,6 @@ describe('list_group_members — Task Agent group view', () => {
 	let ctx: TaskCtx;
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns all members with session IDs, roles, statuses, and permitted targets', async () => {
@@ -961,7 +942,6 @@ describe('Task Agent in channel topology — via list_group_members', () => {
 	let ctx: TaskCtx;
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('coder permittedTargets includes task-agent when channel coder→task-agent is declared', async () => {
@@ -1126,9 +1106,7 @@ describe('Group scoping — messages cannot leak between task groups', () => {
 			expect(cfgB.injectedMessages).toHaveLength(0);
 		} finally {
 			ctxA.db.close();
-			rmSync(ctxA.dir, { recursive: true, force: true });
 			ctxB.db.close();
-			rmSync(ctxB.dir, { recursive: true, force: true });
 		}
 	});
 });
@@ -1141,7 +1119,6 @@ describe('Error cases — non-existent targets and injection failures', () => {
 	let ctx: StepCtx;
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('send_message to topology-declared but missing role fails with no-active-sessions', async () => {
@@ -1188,7 +1165,6 @@ describe('Step with no channels declared', () => {
 	let ctx: StepCtx;
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('send_message fails when no channels declared', async () => {
@@ -1230,7 +1206,6 @@ describe('send_message — sender attribution prefix', () => {
 	let ctx: StepCtx;
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('injected message includes [Message from <role>] prefix', async () => {
@@ -1257,7 +1232,6 @@ describe('Task Agent send_message — point-to-point (target: role)', () => {
 	let ctx: TaskCtx;
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('succeeds when channel is declared', async () => {
@@ -1319,7 +1293,6 @@ describe('Task Agent send_message — broadcast (target: "*")', () => {
 	let ctx: TaskCtx;
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('delivers to all permitted targets', async () => {
@@ -1367,7 +1340,6 @@ describe('Task Agent send_message — default task-agent channels', () => {
 	let ctx: TaskCtx;
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('task-agent has default bidirectional channels to all node agents', async () => {
@@ -1421,7 +1393,6 @@ describe('Task Agent send_message — error cases', () => {
 	let ctx: TaskCtx;
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns error when no active sessions found for target', async () => {

--- a/packages/daemon/tests/unit/5-space/other/export-import-round-trip.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/export-import-round-trip.test.ts
@@ -12,8 +12,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -30,18 +28,13 @@ import type { SpaceAgent, SpaceWorkflow, ExportedSpaceWorkflow } from '@neokai/s
 // DB setup helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-export-import-round-trip',
-		`t-${Date.now()}-${Math.random()}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpace(db: BunDatabase, spaceId: string): void {
@@ -551,14 +544,13 @@ test('mix of plain strings and { value } objects in the same node normalize to c
 
 describe('full round-trip: export → import → DB read-back', () => {
 	let db: BunDatabase;
-	let dir: string;
 	let repo: SpaceWorkflowRepository;
 	let manager: SpaceWorkflowManager;
 
 	const SPACE_ID = 'space-rt';
 
 	beforeEach(() => {
-		({ db, dir } = makeDb());
+		db = makeDb();
 		seedSpace(db, SPACE_ID);
 		seedAgent(db, 'agent-1', SPACE_ID, 'Coder Agent');
 		seedAgent(db, 'agent-2', SPACE_ID, 'Reviewer Agent');
@@ -568,7 +560,6 @@ describe('full round-trip: export → import → DB read-back', () => {
 
 	afterEach(() => {
 		db.close();
-		rmSync(dir, { recursive: true, force: true });
 	});
 
 	test('per-slot systemPrompt override persists after import', () => {

--- a/packages/daemon/tests/unit/5-space/other/send-message-unified.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/send-message-unified.test.ts
@@ -17,8 +17,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -36,18 +34,13 @@ import type { WorkflowChannel } from '@neokai/shared';
 // DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-send-message-unified',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string): void {
@@ -97,7 +90,6 @@ const NODE_ID = 'node-review';
 
 interface TestCtx {
 	db: BunDatabase;
-	dir: string;
 	spaceId: string;
 	nodeExecutionRepo: NodeExecutionRepository;
 	coderSessionId: string;
@@ -125,7 +117,7 @@ function seedPeerTask(
 }
 
 function makeCtx(): TestCtx {
-	const { db, dir } = makeDb();
+	const db = makeDb();
 	const spaceId = 'space-send-msg-unified-test';
 
 	seedSpaceRow(db, spaceId);
@@ -137,7 +129,6 @@ function makeCtx(): TestCtx {
 
 	return {
 		db,
-		dir,
 		spaceId,
 		nodeExecutionRepo,
 		coderSessionId,
@@ -190,7 +181,6 @@ describe('send_message with ChannelRouter injected', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('agent name target → DM delivery via ChannelRouter', async () => {
@@ -303,7 +293,6 @@ describe('send_message without ChannelRouter (legacy path)', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('role target → DM via legacy path', async () => {
@@ -365,7 +354,6 @@ describe('both paths produce same behavior for role-based DM', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('success result structure matches between legacy and ChannelRouter paths', async () => {
@@ -432,7 +420,6 @@ describe('send_message: node name→fan-out via AgentMessageRouter', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('node name target fans out to all agents mapped to that node', async () => {
@@ -524,7 +511,6 @@ describe('send_message: cross-node delivery', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('coder in Node A can send to reviewer in Node B via agent name', async () => {
@@ -603,7 +589,6 @@ describe('send_message: gate blocked via topology', () => {
 
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('send is blocked when no channel is declared from sender to target', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-autonomy.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-autonomy.test.ts
@@ -11,8 +11,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 
 import { buildSpaceChatSystemPrompt } from '../../../../src/lib/space/agents/space-chat-agent';
@@ -35,18 +33,13 @@ import type { SpaceAutonomyLevel } from '@neokai/shared/types/space';
 // DB + space setup helpers (mirrors space-agent-tools.test.ts patterns)
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-space-agent-autonomy',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
@@ -66,7 +59,6 @@ function seedAgentRow(db: BunDatabase, agentId: string, spaceId: string, name: s
 
 interface TestCtx {
 	db: BunDatabase;
-	dir: string;
 	spaceId: string;
 	agentId: string;
 	workflowManager: SpaceWorkflowManager;
@@ -78,7 +70,7 @@ interface TestCtx {
 }
 
 function makeCtx(): TestCtx {
-	const { db, dir } = makeDb();
+	const db = makeDb();
 	const spaceId = 'space-autonomy-test';
 	const workspacePath = '/tmp/test-workspace';
 
@@ -110,7 +102,6 @@ function makeCtx(): TestCtx {
 
 	return {
 		db,
-		dir,
 		spaceId,
 		agentId,
 		workflowManager,
@@ -376,7 +367,6 @@ describe('retry_task tool — autonomy level does not affect tool behavior', () 
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	function createNeedsAttentionTask(ctx: TestCtx): string {

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-task-creation-flow.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-task-creation-flow.test.ts
@@ -11,8 +11,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -32,18 +30,13 @@ import type { SpaceWorkflow } from '@neokai/shared';
 // DB + space setup helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-agent-task-flow',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
@@ -89,7 +82,6 @@ function buildSingleStepWorkflow(
 
 interface TestCtx {
 	db: BunDatabase;
-	dir: string;
 	spaceId: string;
 	agentId: string;
 	workflowManager: SpaceWorkflowManager;
@@ -102,7 +94,7 @@ interface TestCtx {
 }
 
 function makeCtx(): TestCtx {
-	const { db, dir } = makeDb();
+	const db = makeDb();
 	const spaceId = 'space-flow-test';
 	const workspacePath = '/tmp/test-workspace';
 
@@ -136,7 +128,6 @@ function makeCtx(): TestCtx {
 
 	return {
 		db,
-		dir,
 		spaceId,
 		agentId,
 		workflowManager,
@@ -178,7 +169,6 @@ describe('Agent-to-task creation flow — field completeness', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('create_standalone_task returns task with all expected SpaceTask fields', async () => {
@@ -300,7 +290,6 @@ describe('Agent-to-task creation flow — task appears in list_tasks', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('standalone task created by agent appears in list_tasks with no filters', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -10,8 +10,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -35,18 +33,13 @@ import type { TaskAgentManager } from '../../../../src/lib/space/runtime/task-ag
 // DB + space setup helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-space-agent-tools',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
@@ -96,7 +89,6 @@ function buildSingleStepWorkflow(
 
 interface TestCtx {
 	db: BunDatabase;
-	dir: string;
 	spaceId: string;
 	agentId: string;
 	workflowManager: SpaceWorkflowManager;
@@ -109,7 +101,7 @@ interface TestCtx {
 }
 
 function makeCtx(): TestCtx {
-	const { db, dir } = makeDb();
+	const db = makeDb();
 	const spaceId = 'space-tools-test';
 	const workspacePath = '/tmp/test-workspace';
 
@@ -143,7 +135,6 @@ function makeCtx(): TestCtx {
 
 	return {
 		db,
-		dir,
 		spaceId,
 		agentId,
 		workflowManager,
@@ -201,7 +192,6 @@ describe('createSpaceAgentMcpServer — tool registration', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('does not register start_workflow_run for Space Agent sessions', () => {
@@ -233,7 +223,6 @@ describe('createSpaceAgentToolHandlers — list_workflows', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns empty list when no workflows exist', async () => {
@@ -265,7 +254,6 @@ describe('createSpaceAgentToolHandlers — get_workflow_run', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns run with executions', async () => {
@@ -321,7 +309,6 @@ describe('createSpaceAgentToolHandlers — change_plan', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('updates description of an in-progress run', async () => {
@@ -445,7 +432,6 @@ describe('createSpaceAgentToolHandlers — list_tasks', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns all tasks when no filter applied', async () => {
@@ -511,7 +497,6 @@ describe('createSpaceAgentToolHandlers — get_workflow_detail', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns full workflow definition including steps and rules', async () => {
@@ -572,7 +557,6 @@ describe('createSpaceAgentToolHandlers — suggest_workflow', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns empty list with message when no workflows exist', async () => {
@@ -670,7 +654,6 @@ describe('createSpaceAgentToolHandlers — create_standalone_task', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('creates a task with required fields only', async () => {
@@ -758,7 +741,6 @@ describe('createSpaceAgentToolHandlers — get_task_detail', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns full task record by ID', async () => {
@@ -812,7 +794,6 @@ describe('createSpaceAgentToolHandlers — retry_task', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('resets a needs_attention task to pending', async () => {
@@ -896,7 +877,6 @@ describe('createSpaceAgentToolHandlers — cancel_task', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('cancels a pending task', async () => {
@@ -1008,7 +988,6 @@ describe('createSpaceAgentToolHandlers — reassign_task', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('reassigns a pending task (custom_agent_id is accepted, field removed in M71)', async () => {
@@ -1148,7 +1127,6 @@ describe('createSpaceAgentToolHandlers — task creation and planning node activ
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('create_standalone_task creates task with pending status (clear request)', async () => {
@@ -1279,7 +1257,6 @@ describe('createSpaceAgentToolHandlers — list_tasks search/pagination/compact'
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('returns total count in response', async () => {
@@ -1385,7 +1362,6 @@ describe('createSpaceAgentToolHandlers — approve_completion_action', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('rejects tasks that are not at a completion-action checkpoint', async () => {
@@ -1484,7 +1460,6 @@ describe('createSpaceAgentToolHandlers — approve_task guard', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	test('rejects tasks paused at a completion-action checkpoint', async () => {
@@ -1589,7 +1564,6 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 	});
 	afterEach(() => {
 		ctx.db.close();
-		rmSync(ctx.dir, { recursive: true, force: true });
 	});
 
 	async function createTask(title = 'Test Task'): Promise<SpaceTask> {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts
@@ -11,8 +11,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { createTables, runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -102,21 +100,16 @@ class MockTaskAgentManager {
 // DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-completion-actions',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	// createTables provisions the base schema (notably sdk_messages, needed by
 	// the thread-event emission path); runMigrations applies schema evolution.
 	createTables(db);
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(
@@ -195,7 +188,6 @@ function buildWorkflowWithActions(
 
 describe('SpaceRuntime — completion actions', () => {
 	let db: BunDatabase;
-	let dir: string;
 
 	let workflowRunRepo: SpaceWorkflowRunRepository;
 	let taskRepo: SpaceTaskRepository;
@@ -228,8 +220,8 @@ describe('SpaceRuntime — completion actions', () => {
 	}
 
 	beforeEach(() => {
-		({ db, dir } = makeDb());
-		seedSpaceRow(db, SPACE_ID, dir, 1); // use test dir as workspace so scripts can run
+		db = makeDb();
+		seedSpaceRow(db, SPACE_ID, '/tmp', 1); // use /tmp as workspace so scripts can run
 		seedAgentRow(db, AGENT_A, SPACE_ID);
 
 		workflowRunRepo = new SpaceWorkflowRunRepository(db);
@@ -248,11 +240,6 @@ describe('SpaceRuntime — completion actions', () => {
 	afterEach(() => {
 		try {
 			db?.close();
-		} catch {
-			/* ignore */
-		}
-		try {
-			rmSync(dir, { recursive: true, force: true });
 		} catch {
 			/* ignore */
 		}
@@ -1159,7 +1146,7 @@ describe('SpaceRuntime — completion actions', () => {
 		const rt = makeRuntime();
 
 		// A marker file we'd expect to be touched if the script actually ran.
-		const markerPath = join(dir, 'completion-marker.txt');
+		const markerPath = `/tmp/neokai-test-marker-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`;
 		const actions: CompletionAction[] = [
 			{
 				id: 'touch-marker',

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
@@ -10,8 +10,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -61,18 +59,13 @@ class MockNotificationSink implements NotificationSink {
 // DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-space-runtime-completion',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
@@ -222,7 +215,6 @@ class MockTaskAgentManager {
 
 describe('SpaceRuntime — completion detection & status transitions', () => {
 	let db: BunDatabase;
-	let dir: string;
 
 	let workflowRunRepo: SpaceWorkflowRunRepository;
 	let taskRepo: SpaceTaskRepository;
@@ -257,7 +249,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 	}
 
 	beforeEach(() => {
-		({ db, dir } = makeDb());
+		db = makeDb();
 
 		seedSpaceRow(db, SPACE_ID, WORKSPACE);
 		seedAgentRow(db, AGENT_A, SPACE_ID);
@@ -285,7 +277,6 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			/* ignore */
 		}
 		try {
-			rmSync(dir, { recursive: true, force: true });
 		} catch {
 			/* ignore */
 		}

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-edge-cases.test.ts
@@ -13,8 +13,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -84,18 +82,13 @@ class FlakyNotificationSink implements NotificationSink {
 // DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-space-runtime-edge',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/ws'): void {
@@ -187,7 +180,6 @@ function makeMockSessionFactory(opts?: {
 
 describe('SpaceRuntime — edge cases and resilience', () => {
 	let db: BunDatabase;
-	let dir: string;
 
 	let workflowRunRepo: SpaceWorkflowRunRepository;
 	let taskRepo: SpaceTaskRepository;
@@ -228,7 +220,7 @@ describe('SpaceRuntime — edge cases and resilience', () => {
 	}
 
 	beforeEach(() => {
-		({ db, dir } = makeDb());
+		db = makeDb();
 
 		seedSpaceRow(db, SPACE_ID, WORKSPACE);
 		seedAgentRow(db, AGENT, SPACE_ID);
@@ -255,7 +247,6 @@ describe('SpaceRuntime — edge cases and resilience', () => {
 			/* ignore */
 		}
 		try {
-			rmSync(dir, { recursive: true, force: true });
 		} catch {
 			/* ignore */
 		}

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-llm-workflow-selection.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-llm-workflow-selection.test.ts
@@ -15,8 +15,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -36,18 +34,13 @@ import type { SpaceWorkflow } from '@neokai/shared';
 // Fixtures — mirrors helpers in space-runtime.test.ts but scoped local
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-space-runtime-llm',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string): void {
@@ -95,7 +88,6 @@ describe('SpaceRuntime — LLM workflow selection', () => {
 	const AGENT_ID = 'agent-llm-worker';
 
 	let db: BunDatabase;
-	let dir: string;
 	let workflowRunRepo: SpaceWorkflowRunRepository;
 	let taskRepo: SpaceTaskRepository;
 	let nodeExecutionRepo: NodeExecutionRepository;
@@ -104,7 +96,7 @@ describe('SpaceRuntime — LLM workflow selection', () => {
 	let spaceManager: SpaceManager;
 
 	beforeEach(() => {
-		({ db, dir } = makeDb());
+		db = makeDb();
 		seedSpaceRow(db, SPACE_ID);
 		seedAgentRow(db, AGENT_ID, SPACE_ID, 'LLM Worker');
 
@@ -123,7 +115,6 @@ describe('SpaceRuntime — LLM workflow selection', () => {
 			/* ignore */
 		}
 		try {
-			rmSync(dir, { recursive: true, force: true });
 		} catch {
 			/* ignore */
 		}

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-notifications.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-notifications.test.ts
@@ -15,8 +15,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -66,18 +64,13 @@ class MockNotificationSink implements NotificationSink {
 // DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-space-runtime-notif',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
@@ -199,7 +192,6 @@ function withSyntheticEnd(endAgentId: string): {
 
 describe('SpaceRuntime — notification events', () => {
 	let db: BunDatabase;
-	let dir: string;
 
 	let workflowRunRepo: SpaceWorkflowRunRepository;
 	let taskRepo: SpaceTaskRepository;
@@ -232,7 +224,7 @@ describe('SpaceRuntime — notification events', () => {
 	}
 
 	beforeEach(() => {
-		({ db, dir } = makeDb());
+		db = makeDb();
 
 		seedSpaceRow(db, SPACE_ID, WORKSPACE);
 		seedAgentRow(db, AGENT_CODER, SPACE_ID);
@@ -258,7 +250,6 @@ describe('SpaceRuntime — notification events', () => {
 			/* ignore */
 		}
 		try {
-			rmSync(dir, { recursive: true, force: true });
 		} catch {
 			/* ignore */
 		}

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-rehydration.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-rehydration.test.ts
@@ -13,8 +13,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -33,18 +31,13 @@ import type { SpaceWorkflow } from '@neokai/shared';
 // DB / seed helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-space-runtime-rehydration',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/ws'): void {
@@ -92,7 +85,6 @@ function buildLinearWorkflow(
 
 describe('SpaceRuntime — crash recovery and rehydration', () => {
 	let db: BunDatabase;
-	let dir: string;
 
 	let workflowRunRepo: SpaceWorkflowRunRepository;
 	let taskRepo: SpaceTaskRepository;
@@ -119,7 +111,7 @@ describe('SpaceRuntime — crash recovery and rehydration', () => {
 	}
 
 	beforeEach(() => {
-		({ db, dir } = makeDb());
+		db = makeDb();
 		seedSpaceRow(db, SPACE_ID);
 		seedAgentRow(db, AGENT, SPACE_ID);
 
@@ -139,7 +131,6 @@ describe('SpaceRuntime — crash recovery and rehydration', () => {
 			/* ignore */
 		}
 		try {
-			rmSync(dir, { recursive: true, force: true });
 		} catch {
 			/* ignore */
 		}

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach, mock, type Mock } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
+import { mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { SpaceRuntimeService } from '../../../../src/lib/space/runtime/space-runtime-service.ts';
@@ -624,18 +624,13 @@ class MockSink implements NotificationSink {
 	}
 }
 
-function makeTestDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-srs-notif',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeTestDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 // ─── activateWorkflowNode — notification sink forwarding ─────────────────────
@@ -648,7 +643,7 @@ function makeTestDb(): { db: BunDatabase; dir: string } {
 
 describe('activateWorkflowNode() — notification forwarding', () => {
 	test('forwards workflow_run_reopened to the current NotificationSink when reopening a done run', async () => {
-		const { db, dir } = makeTestDb();
+		const db = makeTestDb();
 		try {
 			const SPACE_ID = 'space-act-sink-1';
 			const AGENT_ID = 'agent-act-sink-1';
@@ -752,7 +747,6 @@ describe('activateWorkflowNode() — notification forwarding', () => {
 			} catch {
 				/* ignore */
 			}
-			rmSync(dir, { recursive: true, force: true });
 		}
 	});
 });

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
@@ -13,8 +13,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -33,18 +31,13 @@ import type { SpaceWorkflow } from '@neokai/shared';
 // DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-space-runtime-tick',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
@@ -178,7 +171,6 @@ function makeMockTaskAgentManager(
 
 describe('SpaceRuntime — tick loop correctness', () => {
 	let db: BunDatabase;
-	let dir: string;
 
 	let workflowRunRepo: SpaceWorkflowRunRepository;
 	let taskRepo: SpaceTaskRepository;
@@ -198,7 +190,7 @@ describe('SpaceRuntime — tick loop correctness', () => {
 	const STEP_B = 'step-b';
 
 	beforeEach(() => {
-		({ db, dir } = makeDb());
+		db = makeDb();
 
 		seedSpaceRow(db, SPACE_ID, WORKSPACE);
 		seedSpaceRow(db, SPACE_ID_2, '/tmp/tick-ws-2');
@@ -228,7 +220,6 @@ describe('SpaceRuntime — tick loop correctness', () => {
 			/* ignore */
 		}
 		try {
-			rmSync(dir, { recursive: true, force: true });
 		} catch {
 			/* ignore */
 		}

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
@@ -12,8 +12,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -32,18 +30,13 @@ import type { SpaceWorkflow, SpaceWorkflowRun } from '@neokai/shared';
 // DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-space-runtime',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
@@ -123,7 +116,6 @@ function appendSyntheticEnd<T extends { id: string; agents?: unknown[] }>(
 
 describe('SpaceRuntime', () => {
 	let db: BunDatabase;
-	let dir: string;
 
 	let workflowRunRepo: SpaceWorkflowRunRepository;
 	let taskRepo: SpaceTaskRepository;
@@ -148,7 +140,7 @@ describe('SpaceRuntime', () => {
 	const STEP_C = 'step-c';
 
 	beforeEach(() => {
-		({ db, dir } = makeDb());
+		db = makeDb();
 
 		// Seed space
 		seedSpaceRow(db, SPACE_ID, WORKSPACE);
@@ -191,7 +183,6 @@ describe('SpaceRuntime', () => {
 			/* ignore */
 		}
 		try {
-			rmSync(dir, { recursive: true, force: true });
 		} catch {
 			/* ignore */
 		}

--- a/packages/daemon/tests/unit/5-space/runtime/space-workflow.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-workflow.test.ts
@@ -14,8 +14,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -30,13 +28,13 @@ import type { WorkflowNodeInput } from '@neokai/shared';
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(process.cwd(), 'tmp', 'test-space-workflow', `t-${Date.now()}-${Math.random()}`);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpace(db: BunDatabase, spaceId = 'space-1'): void {
@@ -73,11 +71,10 @@ const generalNode: WorkflowNodeInput = {
 
 describe('SpaceWorkflowRepository', () => {
 	let db: BunDatabase;
-	let dir: string;
 	let repo: SpaceWorkflowRepository;
 
 	beforeEach(() => {
-		({ db, dir } = makeDb());
+		db = makeDb();
 		seedSpace(db);
 		repo = new SpaceWorkflowRepository(db);
 	});
@@ -85,11 +82,6 @@ describe('SpaceWorkflowRepository', () => {
 	afterEach(() => {
 		try {
 			db.close();
-		} catch {
-			/* ignore */
-		}
-		try {
-			rmSync(dir, { recursive: true, force: true });
 		} catch {
 			/* ignore */
 		}
@@ -559,12 +551,11 @@ describe('SpaceWorkflowRepository', () => {
 
 describe('SpaceWorkflowManager', () => {
 	let db: BunDatabase;
-	let dir: string;
 	let repo: SpaceWorkflowRepository;
 	let manager: SpaceWorkflowManager;
 
 	beforeEach(() => {
-		({ db, dir } = makeDb());
+		db = makeDb();
 		seedSpace(db);
 		repo = new SpaceWorkflowRepository(db);
 		manager = new SpaceWorkflowManager(repo, null);
@@ -573,11 +564,6 @@ describe('SpaceWorkflowManager', () => {
 	afterEach(() => {
 		try {
 			db.close();
-		} catch {
-			/* ignore */
-		}
-		try {
-			rmSync(dir, { recursive: true, force: true });
 		} catch {
 			/* ignore */
 		}

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -16,8 +16,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -42,18 +40,13 @@ import {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-built-in-workflows',
-		`t-${Date.now()}-${Math.random()}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpace(db: BunDatabase, spaceId: string): void {
@@ -771,7 +764,6 @@ describe('getBuiltInWorkflows()', () => {
 
 describe('seedBuiltInWorkflows()', () => {
 	let db: BunDatabase;
-	let dir: string;
 	let manager: SpaceWorkflowManager;
 	const SPACE_ID = 'seed-test-space';
 
@@ -795,7 +787,7 @@ describe('seedBuiltInWorkflows()', () => {
 	const resolveAgentId = (role: string): string | undefined => roleMap[role.toLowerCase()];
 
 	beforeEach(() => {
-		({ db, dir } = makeDb());
+		db = makeDb();
 		seedSpace(db, SPACE_ID);
 		// Seed preset agents so the manager's agentLookup (when wired) would find them
 		seedAgent(db, PLANNER_ID, SPACE_ID, 'Planner');
@@ -813,11 +805,6 @@ describe('seedBuiltInWorkflows()', () => {
 	afterEach(() => {
 		try {
 			db.close();
-		} catch {
-			/* ignore */
-		}
-		try {
-			rmSync(dir, { recursive: true, force: true });
 		} catch {
 			/* ignore */
 		}
@@ -1635,7 +1622,6 @@ describe('seedBuiltInWorkflows()', () => {
 
 describe('Coding Workflow export/import round-trip', () => {
 	let db: BunDatabase;
-	let dir: string;
 	let manager: SpaceWorkflowManager;
 	const SPACE_ID = 'roundtrip-test-space';
 
@@ -1685,7 +1671,7 @@ describe('Coding Workflow export/import round-trip', () => {
 	];
 
 	beforeEach(() => {
-		({ db, dir } = makeDb());
+		db = makeDb();
 		seedSpace(db, SPACE_ID);
 		seedAgent(db, PLANNER_ID, SPACE_ID, 'Planner');
 		seedAgent(db, CODER_ID, SPACE_ID, 'Coder');
@@ -1699,11 +1685,6 @@ describe('Coding Workflow export/import round-trip', () => {
 	afterEach(() => {
 		try {
 			db.close();
-		} catch {
-			/* ignore */
-		}
-		try {
-			rmSync(dir, { recursive: true, force: true });
 		} catch {
 			/* ignore */
 		}

--- a/packages/daemon/tests/unit/5-space/workflow/completion-actions-persistence.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/completion-actions-persistence.test.ts
@@ -20,8 +20,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -38,18 +36,13 @@ import { computeWorkflowHash } from '../../../../src/lib/space/workflows/templat
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-completion-actions-persistence',
-		`t-${Date.now()}-${Math.random()}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpace(db: BunDatabase, spaceId: string): void {
@@ -102,11 +95,10 @@ function seedWithAllAgents(db: BunDatabase): void {
 
 describe('completionActions persistence — seed path (Bug A regression)', () => {
 	let db: BunDatabase;
-	let dir: string;
 	let manager: SpaceWorkflowManager;
 
 	beforeEach(() => {
-		({ db, dir } = makeDb());
+		db = makeDb();
 		seedWithAllAgents(db);
 		manager = new SpaceWorkflowManager(new SpaceWorkflowRepository(db));
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
@@ -115,11 +107,6 @@ describe('completionActions persistence — seed path (Bug A regression)', () =>
 	afterEach(() => {
 		try {
 			db.close();
-		} catch {
-			/* ignore */
-		}
-		try {
-			rmSync(dir, { recursive: true, force: true });
 		} catch {
 			/* ignore */
 		}
@@ -173,11 +160,10 @@ describe('completionActions persistence — seed path (Bug A regression)', () =>
 
 describe('completionActions persistence — updateWorkflow round-trip (Bug B regression)', () => {
 	let db: BunDatabase;
-	let dir: string;
 	let manager: SpaceWorkflowManager;
 
 	beforeEach(() => {
-		({ db, dir } = makeDb());
+		db = makeDb();
 		seedWithAllAgents(db);
 		manager = new SpaceWorkflowManager(new SpaceWorkflowRepository(db));
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
@@ -186,11 +172,6 @@ describe('completionActions persistence — updateWorkflow round-trip (Bug B reg
 	afterEach(() => {
 		try {
 			db.close();
-		} catch {
-			/* ignore */
-		}
-		try {
-			rmSync(dir, { recursive: true, force: true });
 		} catch {
 			/* ignore */
 		}

--- a/packages/daemon/tests/unit/5-space/workflow/completion-detector.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/completion-detector.test.ts
@@ -10,8 +10,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
@@ -21,36 +19,29 @@ import { CompletionDetector } from '../../../../src/lib/space/runtime/completion
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-completion-detector',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	runMigrations(db, () => {});
 	// Disable FK so we can insert tasks with synthetic workflow_run_id values
 	// without seeding a parent row.
 	db.exec('PRAGMA foreign_keys = OFF');
-	return { db, dir };
+	return db;
 }
 
 let db: BunDatabase;
-let dir: string;
 let taskRepo: SpaceTaskRepository;
 let detector: CompletionDetector;
 
 beforeEach(() => {
-	({ db, dir } = makeDb());
+	db = makeDb();
 	taskRepo = new SpaceTaskRepository(db);
 	detector = new CompletionDetector(taskRepo);
 });
 
 afterEach(() => {
 	db.close();
-	rmSync(dir, { recursive: true, force: true });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/5-space/workflow/gate-autonomy-status-consistency.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/gate-autonomy-status-consistency.test.ts
@@ -15,8 +15,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository.ts';
@@ -29,18 +27,13 @@ import type { WorkflowRunStatus } from '@neokai/shared';
 
 // --- DB helpers ---
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-gate-autonomy-status',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	runMigrations(db, () => {});
 	db.exec('PRAGMA foreign_keys = OFF');
-	return { db, dir };
+	return db;
 }
 
 function seedSpace(db: BunDatabase, spaceId: string): void {
@@ -70,18 +63,16 @@ function createWorkflowAndRun(db: BunDatabase, spaceId: string): { runId: string
 
 const SPACE = 'space-gate-autonomy-1';
 let db: BunDatabase;
-let dir: string;
 let runRepo: SpaceWorkflowRunRepository;
 
 beforeEach(() => {
-	({ db, dir } = makeDb());
+	db = makeDb();
 	seedSpace(db, SPACE);
 	runRepo = new SpaceWorkflowRunRepository(db);
 });
 
 afterEach(() => {
 	db.close();
-	rmSync(dir, { recursive: true, force: true });
 });
 
 describe('Gate rejection and recovery (WorkflowRunStatus)', () => {

--- a/packages/daemon/tests/unit/5-space/workflow/workflow-executor-multi-agent.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/workflow-executor-multi-agent.test.ts
@@ -11,8 +11,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -36,18 +34,13 @@ import type { SpaceAgent, WorkflowNode } from '@neokai/shared';
 // DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-wf-multi-agent',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpace(db: BunDatabase, spaceId: string, workspacePath = '/tmp/ws'): void {
@@ -109,7 +102,6 @@ function appendSyntheticEnd<T extends { id: string; agents?: unknown[] }>(
 
 describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 	let db: BunDatabase;
-	let dir: string;
 	let workflowRunRepo: SpaceWorkflowRunRepository;
 	let taskRepo: SpaceTaskRepository;
 	let nodeExecutionRepo: NodeExecutionRepository;
@@ -125,7 +117,7 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 	const STEP_B = 'step-rt-b';
 
 	beforeEach(() => {
-		({ db, dir } = makeDb());
+		db = makeDb();
 		seedSpace(db, SPACE_ID, WORKSPACE);
 		seedAgent(db, AGENT_CODER, SPACE_ID, 'Coder');
 		seedAgent(db, AGENT_PLANNER, SPACE_ID, 'Planner');
@@ -157,11 +149,6 @@ describe('SpaceRuntime — startWorkflowRun() multi-agent start step', () => {
 	afterEach(() => {
 		try {
 			db.close();
-		} catch {
-			/* ignore */
-		}
-		try {
-			rmSync(dir, { recursive: true, force: true });
 		} catch {
 			/* ignore */
 		}
@@ -570,7 +557,6 @@ describe('resolveNodeAgents()', () => {
 
 describe('Mixed workflows — single-agent, multi-agent, and channels', () => {
 	let db: BunDatabase;
-	let dir: string;
 	let workflowRunRepo: SpaceWorkflowRunRepository;
 	let taskRepo: SpaceTaskRepository;
 	let workflowManager: SpaceWorkflowManager;
@@ -586,7 +572,7 @@ describe('Mixed workflows — single-agent, multi-agent, and channels', () => {
 	const STEP_C = 'step-mx-c';
 
 	beforeEach(() => {
-		({ db, dir } = makeDb());
+		db = makeDb();
 		seedSpace(db, SPACE_ID, WORKSPACE);
 		seedAgent(db, AGENT_CODER, SPACE_ID, 'Coder');
 		seedAgent(db, AGENT_PLANNER, SPACE_ID, 'Planner');
@@ -616,11 +602,6 @@ describe('Mixed workflows — single-agent, multi-agent, and channels', () => {
 	afterEach(() => {
 		try {
 			db.close();
-		} catch {
-			/* ignore */
-		}
-		try {
-			rmSync(dir, { recursive: true, force: true });
 		} catch {
 			/* ignore */
 		}

--- a/packages/daemon/tests/unit/5-space/workflow/workflow-executor-progression.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/workflow-executor-progression.test.ts
@@ -34,8 +34,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -57,18 +55,13 @@ import type { SpaceWorkflow, SpaceWorkflowRun, Gate, GateField, Channel } from '
 // DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-wf-progression',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpace(db: BunDatabase, spaceId = 'space-1', workspacePath = '/tmp/ws-1'): void {
@@ -109,7 +102,6 @@ function makeThrowingRunner(message: string): CommandRunner {
 // ---------------------------------------------------------------------------
 
 let db: BunDatabase;
-let dir: string;
 let workflowRepo: SpaceWorkflowRepository;
 let runRepo: SpaceWorkflowRunRepository;
 
@@ -117,7 +109,7 @@ const SPACE_ID = 'space-1';
 const WORKSPACE = '/tmp/ws-1';
 
 beforeEach(() => {
-	({ db, dir } = makeDb());
+	db = makeDb();
 	seedSpace(db, SPACE_ID, WORKSPACE);
 	seedAgent(db, 'agent-a', SPACE_ID, 'Agent A');
 	seedAgent(db, 'agent-b', SPACE_ID, 'Agent B');
@@ -129,11 +121,6 @@ beforeEach(() => {
 afterEach(() => {
 	try {
 		db.close();
-	} catch {
-		/* ignore */
-	}
-	try {
-		rmSync(dir, { recursive: true, force: true });
 	} catch {
 		/* ignore */
 	}

--- a/packages/daemon/tests/unit/5-space/workflow/workflow-executor.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/workflow-executor.test.ts
@@ -7,8 +7,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
@@ -24,18 +22,13 @@ import type { SpaceWorkflow, SpaceWorkflowRun, WorkflowCondition } from '@neokai
 // Test DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-workflow-executor',
-		`t-${Date.now()}-${Math.random()}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
-	return { db, dir };
+	return db;
 }
 
 function seedSpace(db: BunDatabase, spaceId = 'space-1', workspacePath = '/tmp/ws-1'): void {
@@ -75,7 +68,6 @@ function makeTimeoutRunner(): CommandRunner {
 
 describe('WorkflowExecutor', () => {
 	let db: BunDatabase;
-	let dir: string;
 	let workflowRepo: SpaceWorkflowRepository;
 	let runRepo: SpaceWorkflowRunRepository;
 
@@ -89,7 +81,7 @@ describe('WorkflowExecutor', () => {
 	const STEP_B = 'step-b';
 
 	beforeEach(() => {
-		({ db, dir } = makeDb());
+		db = makeDb();
 		seedSpace(db, SPACE_ID, WORKSPACE);
 		seedAgent(db, AGENT_A, SPACE_ID, 'Agent A');
 		seedAgent(db, AGENT_B, SPACE_ID, 'Agent B');
@@ -101,11 +93,6 @@ describe('WorkflowExecutor', () => {
 	afterEach(() => {
 		try {
 			db.close();
-		} catch {
-			/* ignore */
-		}
-		try {
-			rmSync(dir, { recursive: true, force: true });
 		} catch {
 			/* ignore */
 		}

--- a/packages/daemon/tests/unit/5-space/workflow/workflow-run-status-lifecycle.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/workflow-run-status-lifecycle.test.ts
@@ -33,8 +33,6 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { rmSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository.ts';
@@ -50,18 +48,13 @@ import type { WorkflowRunStatus } from '@neokai/shared';
 // DB helpers
 // ---------------------------------------------------------------------------
 
-function makeDb(): { db: BunDatabase; dir: string } {
-	const dir = join(
-		process.cwd(),
-		'tmp',
-		'test-run-status-lifecycle',
-		`t-${Date.now()}-${Math.random().toString(36).slice(2)}`
-	);
-	mkdirSync(dir, { recursive: true });
-	const db = new BunDatabase(join(dir, 'test.db'));
+function makeDb(): BunDatabase {
+	// Use in-memory SQLite — faster than file-based DB and avoids filesystem
+	// I/O contention that caused beforeEach hook timeouts in CI.
+	const db = new BunDatabase(':memory:');
 	runMigrations(db, () => {});
 	db.exec('PRAGMA foreign_keys = OFF');
-	return { db, dir };
+	return db;
 }
 
 function seedSpace(db: BunDatabase, spaceId: string): void {
@@ -95,18 +88,16 @@ function createWorkflowAndRun(db: BunDatabase, spaceId: string): { runId: string
 
 const SPACE = 'space-lifecycle-1';
 let db: BunDatabase;
-let dir: string;
 let runRepo: SpaceWorkflowRunRepository;
 
 beforeEach(() => {
-	({ db, dir } = makeDb());
+	db = makeDb();
 	seedSpace(db, SPACE);
 	runRepo = new SpaceWorkflowRunRepository(db);
 });
 
 afterEach(() => {
 	db.close();
-	rmSync(dir, { recursive: true, force: true });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -184,19 +184,11 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	}, [activeView, canShowCanvasTab, canShowArtifactsTab]);
 
 	const handleNodeClick = (_nodeId: string, _nodeName: string, _agentSlotNames: string[]) => {
-		// Resolve agent display names from the store using the workflow node’s agent IDs.
-		// nodeExecution is often absent; resolve via the agent store instead.
-		const workflowNode = workflow?.nodes.find((n) => n.id === _nodeId);
-		const agentDisplayNames = workflowNode
-			? workflowNode.agents
-					.map((sa) => spaceStore.agents.value.find((a) => a.id === sa.agentId)?.name)
-					.filter((n): n is string => !!n)
-			: [];
-
-		// Exact-match against activity member labels (same data source as the “Agents” buttons).
+		// Match against activity member roles (slot names like “reviewer”, “coder”).
+		// m.role is the agent slot name stored in the DB and directly corresponds to _agentSlotNames.
 		// For multi-agent nodes, returns the first matching member.
 		const nodeMember = activityMembers.find(
-			(m) => m.kind === 'node_agent' && agentDisplayNames.includes(m.label)
+			(m) => m.kind === 'node_agent' && _agentSlotNames.includes(m.role)
 		);
 		if (nodeMember) {
 			pushOverlayHistory(nodeMember.sessionId, nodeMember.label);

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -617,6 +617,53 @@ describe('SpaceTaskPane — canvas toggle', () => {
 		expect(mockSpaceOverlayAgentNameSignal.value).toBe('Coder Node');
 	});
 
+	it('canvas node click matches by role (slot name), not by label — regression for Review node bug', () => {
+		// This test reproduces the bug where clicking a "Review" node opened the Task Agent
+		// session instead of the Reviewer session. The root cause was matching m.label against
+		// agentDisplayNames rather than m.role against _agentSlotNames.
+		// Here the activity member label ('Code Reviewer') differs from _agentSlotNames (['reviewer']),
+		// but m.role === 'reviewer' matches correctly.
+		mockTasks.value = [
+			makeTask({
+				id: 'task-1',
+				workflowRunId: 'run-1',
+				taskAgentSessionId: 'session-task',
+				activeSession: null,
+			}),
+		];
+		mockWorkflowRuns.value = [makeWorkflowRun({ id: 'run-1', workflowId: 'workflow-1' })];
+		// No agents in the store — ensures no accidental label-based fallback works
+		mockAgents.value = [];
+		mockTaskActivity.value = new Map([
+			[
+				'task-1',
+				[
+					{
+						id: 'session-reviewer',
+						sessionId: 'session-reviewer',
+						kind: 'node_agent' as const,
+						// label differs from slot name — this is what broke the old code
+						label: 'Code Reviewer',
+						role: 'reviewer',
+						state: 'active' as const,
+						messageCount: 2,
+					},
+				],
+			],
+		]);
+		const { getByTestId } = render(<SpaceTaskPane taskId="task-1" spaceId="space-1" />);
+
+		fireEvent.click(getByTestId('canvas-toggle'));
+		expect(getByTestId('workflow-canvas')).toBeTruthy();
+
+		// Click the "Review" node — slot name is 'reviewer'
+		mockWorkflowCanvasOnNodeClick('node-review', 'Review', ['reviewer']);
+
+		// Must open the reviewer's session, NOT the task agent's session
+		expect(mockSpaceOverlaySessionIdSignal.value).toBe('session-reviewer');
+		expect(mockSpaceOverlayAgentNameSignal.value).toBe('Code Reviewer');
+	});
+
 	it('switching to canvas view closes the artifacts panel', () => {
 		mockTasks.value = [makeTask({ workflowRunId: 'run-1' })];
 		mockWorkflowRuns.value = [makeWorkflowRun({ id: 'run-1', workflowId: 'workflow-1' })];

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -147,7 +147,7 @@ vi.mock('../ReadOnlyWorkflowCanvas', () => ({
 		workflowId: string;
 		runId?: string | null;
 		spaceId: string;
-		onNodeClick?: (nodeId: string) => void;
+		onNodeClick?: (nodeId: string, nodeName: string, agentNames: string[]) => void;
 		class?: string;
 	}) => {
 		// Expose the onNodeClick for testing


### PR DESCRIPTION
Switch all file-based SQLite test helpers in `packages/daemon/tests/unit/5-space/` to in-memory databases (`new BunDatabase(':memory:')`). This removes the root cause of CI flakiness where `beforeEach`/`afterEach` hooks exceed the 10-second bun timeout when multiple shards run filesystem I/O in parallel.

Changes: 40 test files across `5-space/agent/`, `5-space/runtime/`, and `5-space/workflow/` directories. The `space-worktree-manager.test.ts` and `space-runtime-service.test.ts` retain their filesystem usage (real git worktree operations and db-query MCP integration test, respectively).