### PR TITLE
fix(space): auto-resume idle node-agent session when a message is queued for it

### DIFF
--- a/packages/daemon/src/lib/space/runtime/agent-message-router.ts
+++ b/packages/daemon/src/lib/space/runtime/agent-message-router.ts
@@ -63,6 +63,16 @@ export interface AgentMessageRouterConfig {
 	 * Optional; defaults to null.
 	 */
 	taskId?: string;
+	/**
+	 * Optional callback fired after a message is persisted to `pendingMessageRepo`
+	 * for a declared-but-inactive target. Callers can use this to immediately
+	 * attempt to resume the target session if one is known (e.g. a session from a
+	 * previous execution that is currently idle/completed), so the queued message
+	 * is delivered without waiting for the next external activation trigger.
+	 *
+	 * Fires only for non-deduped enqueues (deduped = message already in queue).
+	 */
+	onMessageQueued?: (agentName: string) => void;
 }
 
 export interface AgentMessageParams {
@@ -147,6 +157,7 @@ export class AgentMessageRouter {
 			pendingMessageRepo,
 			spaceId,
 			taskId,
+			onMessageQueued,
 		} = this.config;
 
 		// --- Build channel resolver + slot-to-node translation map ---
@@ -402,7 +413,7 @@ export class AgentMessageRouter {
 					// adds it at delivery time so the source name is always accurate).
 					const rawMessage = `${message}${dataAppendix}`;
 					try {
-						const { record } = pendingMessageRepo.enqueue({
+						const { record, deduped } = pendingMessageRepo.enqueue({
 							workflowRunId,
 							spaceId,
 							taskId: taskId ?? null,
@@ -416,6 +427,11 @@ export class AgentMessageRouter {
 							`[AgentMessageRouter] queued message ${record.id} for agent "${agentName}" ` +
 								`(run=${workflowRunId}, from=${fromAgentName})`
 						);
+						// Best-effort auto-resume: if the target already has a known session
+						// (e.g. a previous execution that is now idle/completed), trigger an
+						// immediate resume so the queue is drained without waiting for the
+						// next activation cycle.
+						if (!deduped) onMessageQueued?.(agentName);
 					} catch (err) {
 						const errMsg = err instanceof Error ? err.message : String(err);
 						log.warn(

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -835,6 +835,17 @@ export class TaskAgentManager {
 
 			const actualSessionId = await this.createSubSession(taskId, sessionId, init, {
 				agentId: slot.agentId,
+				// agentName + nodeId enable two critical behaviours inside createSubSession:
+				//   1. Session reuse — if this agent already ran (agentSessionId set on an
+				//      older NodeExecution), the existing session is reused rather than spawning
+				//      a redundant second session. Each named agent lives in one session per
+				//      task lifetime; subsequent activations inject a new message into it.
+				//   2. Pending message flush — after the session is created/reused, any
+				//      messages queued via PendingAgentMessageRepository (e.g. from a Task
+				//      Agent send_message call that raced ahead of this spawn) are drained
+				//      into the session. Without agentName this flush is skipped entirely.
+				agentName: execution.agentName,
+				nodeId: execution.workflowNodeId,
 			});
 			spawnedSessionId = actualSessionId;
 
@@ -1130,6 +1141,44 @@ export class TaskAgentManager {
 				repo.markAttemptFailed(row.id, errMsg);
 				// Keep going — a single per-row failure must not block the rest of the queue.
 			}
+		}
+	}
+
+	/**
+	 * Best-effort attempt to resume a node-agent session and drain its pending
+	 * message queue immediately after a message has been queued for it.
+	 *
+	 * Called by send_message (task-agent-tools) right after `pendingMessageRepo.enqueue()`
+	 * so that if the target already has a known session (e.g. it ran before and is now
+	 * idle/completed), the queued message is delivered without waiting for the next
+	 * activation trigger.
+	 *
+	 * Flow:
+	 *  1. Look for the most recent NodeExecution for this agent that has an `agentSessionId`.
+	 *  2. If found, look up the session in memory (fast path) or lazily rehydrate it from DB.
+	 *  3. If the session is live, call `flushPendingMessagesForTarget` to drain the queue.
+	 *
+	 * Idempotent and non-fatal — if the session cannot be found or restored the queue
+	 * is left intact for the next activation (e.g. when `createSubSession` spawns/reuses
+	 * the session and calls `flushPendingMessagesForTarget`).
+	 */
+	async tryResumeNodeAgentSession(workflowRunId: string, agentName: string): Promise<void> {
+		const repo = this.config.pendingMessageRepo;
+		if (!repo) return;
+
+		const executions = this.config.nodeExecutionRepo.listByWorkflowRun(workflowRunId);
+		const exec = executions.filter((e) => e.agentName === agentName && e.agentSessionId).at(-1);
+		if (!exec?.agentSessionId) return; // No known session for this agent — wait for spawn.
+
+		const sessionId = exec.agentSessionId;
+
+		if (this.agentSessionIndex.has(sessionId)) {
+			// Fast path: session is already live in memory — flush pending messages directly.
+			await this.flushPendingMessagesForTarget(workflowRunId, agentName, sessionId);
+		} else {
+			// Slow path: session is not in memory (e.g. after daemon restart).
+			// rehydrateSubSession restores it AND calls flushPendingMessagesForTarget internally.
+			await this.rehydrateSubSession(sessionId);
 		}
 	}
 
@@ -2668,6 +2717,16 @@ export class TaskAgentManager {
 			pendingMessageRepo: this.config.pendingMessageRepo,
 			spaceId,
 			taskId,
+			// Auto-resume callback: when a message is queued for an inactive peer,
+			// immediately attempt to resume that peer's last known session so the
+			// message is delivered without waiting for external activation.
+			onMessageQueued: (targetAgentName) => {
+				void this.tryResumeNodeAgentSession(workflowRunId, targetAgentName).catch((err) => {
+					log.warn(
+						`AgentMessageRouter.onMessageQueued: tryResumeNodeAgentSession failed for "${targetAgentName}": ${err instanceof Error ? err.message : String(err)}`
+					);
+				});
+			},
 		});
 
 		const agentNameAliases = execution

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -657,6 +657,21 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 							deduped,
 						});
 						if (!deduped) emitQueued(record);
+						// Best-effort auto-resume: if the target already has a known session
+						// (e.g. it ran in a previous execution and is now idle/completed),
+						// try to resume it immediately so the queued message is delivered
+						// without waiting for the next external activation trigger.
+						if (!deduped && taskAgentManager) {
+							void taskAgentManager
+								.tryResumeNodeAgentSession(workflowRunId, targetAgentName)
+								.catch((err) => {
+									// Non-fatal — the message stays queued and will be
+									// delivered when the session next activates normally.
+									log.warn(
+										`send_message: tryResumeNodeAgentSession failed for "${targetAgentName}": ${err instanceof Error ? err.message : String(err)}`
+									);
+								});
+						}
 						continue;
 					}
 					notFound.push(targetAgentName);

--- a/packages/daemon/tests/unit/5-space/agent/agent-message-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-message-router.test.ts
@@ -1155,3 +1155,155 @@ describe('AgentMessageRouter: pure topology target (no execution, no nodeGroups)
 		expect(pending[0].message).toContain('activate and review');
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Tests: onMessageQueued callback — auto-resume hook (Task #70)
+// ---------------------------------------------------------------------------
+
+describe('AgentMessageRouter: onMessageQueued callback fires for non-deduped enqueues', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('calls onMessageQueued with agent name when message is newly queued', async () => {
+		const { runId: workflowRunId } = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeChannel('coder', 'reviewer'),
+		]);
+
+		seedPeerTask(ctx.db, ctx.spaceId, workflowRunId, ctx.nodeId, 'coder', ctx.coderSessionId);
+		// reviewer declared but no session
+		ctx.nodeExecutionRepo.createOrIgnore({
+			workflowRunId,
+			workflowNodeId: ctx.nodeId,
+			agentName: 'reviewer',
+			status: 'pending',
+		});
+
+		const pendingMessageRepo = new PendingAgentMessageRepository(ctx.db);
+		const resumedAgents: string[] = [];
+
+		const router = new AgentMessageRouter({
+			nodeExecutionRepo: ctx.nodeExecutionRepo,
+			workflowRunId,
+			workflowChannels: [makeChannel('coder', 'reviewer')],
+			messageInjector: async () => {},
+			pendingMessageRepo,
+			spaceId: ctx.spaceId,
+			taskId: null,
+			onMessageQueued: (agentName) => resumedAgents.push(agentName),
+		});
+
+		await router.deliverMessage({
+			fromAgentName: 'coder',
+			fromSessionId: ctx.coderSessionId,
+			target: 'reviewer',
+			message: 'activate and review',
+		});
+
+		expect(resumedAgents).toHaveLength(1);
+		expect(resumedAgents[0]).toBe('reviewer');
+	});
+
+	test('does NOT call onMessageQueued when pendingMessageRepo returns deduped=true', async () => {
+		const { runId: workflowRunId } = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeChannel('coder', 'reviewer'),
+		]);
+
+		seedPeerTask(ctx.db, ctx.spaceId, workflowRunId, ctx.nodeId, 'coder', ctx.coderSessionId);
+		ctx.nodeExecutionRepo.createOrIgnore({
+			workflowRunId,
+			workflowNodeId: ctx.nodeId,
+			agentName: 'reviewer',
+			status: 'pending',
+		});
+
+		// Mock repo that always reports deduped=true (simulating an already-queued message)
+		const existingRecord = {
+			id: 'existing-msg-id',
+			workflowRunId,
+			spaceId: ctx.spaceId,
+			taskId: null,
+			sourceAgentName: 'coder',
+			targetAgentName: 'reviewer',
+			targetKind: 'node_agent',
+			message: 'already queued',
+			status: 'pending',
+			attempts: 0,
+			maxAttempts: 3,
+			idempotencyKey: null,
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+			expiresAt: Date.now() + 600_000,
+			lastAttemptAt: null,
+			lastError: null,
+		};
+		const dedupedRepo = {
+			enqueue: () => ({ record: existingRecord, deduped: true }),
+			listPendingForTarget: () => [existingRecord],
+		} as unknown as PendingAgentMessageRepository;
+
+		const resumedAgents: string[] = [];
+
+		const router = new AgentMessageRouter({
+			nodeExecutionRepo: ctx.nodeExecutionRepo,
+			workflowRunId,
+			workflowChannels: [makeChannel('coder', 'reviewer')],
+			messageInjector: async () => {},
+			pendingMessageRepo: dedupedRepo,
+			spaceId: ctx.spaceId,
+			taskId: null,
+			onMessageQueued: (agentName) => resumedAgents.push(agentName),
+		});
+
+		await router.deliverMessage({
+			fromAgentName: 'coder',
+			fromSessionId: ctx.coderSessionId,
+			target: 'reviewer',
+			message: 'review please again',
+		});
+
+		// Deduped → callback must NOT fire
+		expect(resumedAgents).toHaveLength(0);
+	});
+
+	test('does NOT call onMessageQueued when message is delivered directly (live session)', async () => {
+		const { runId: workflowRunId } = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeChannel('coder', 'reviewer'),
+		]);
+
+		seedPeerTask(ctx.db, ctx.spaceId, workflowRunId, ctx.nodeId, 'coder', ctx.coderSessionId);
+		// reviewer has a live session
+		seedPeerTask(ctx.db, ctx.spaceId, workflowRunId, ctx.nodeId, 'reviewer', ctx.reviewerSessionId);
+
+		const pendingMessageRepo = new PendingAgentMessageRepository(ctx.db);
+		const resumedAgents: string[] = [];
+
+		const router = new AgentMessageRouter({
+			nodeExecutionRepo: ctx.nodeExecutionRepo,
+			workflowRunId,
+			workflowChannels: [makeChannel('coder', 'reviewer')],
+			messageInjector: async () => {},
+			pendingMessageRepo,
+			spaceId: ctx.spaceId,
+			taskId: null,
+			onMessageQueued: (agentName) => resumedAgents.push(agentName),
+		});
+
+		await router.deliverMessage({
+			fromAgentName: 'coder',
+			fromSessionId: ctx.coderSessionId,
+			target: 'reviewer',
+			message: 'review ready',
+		});
+
+		// Message delivered directly — callback must not have fired
+		expect(resumedAgents).toHaveLength(0);
+	});
+});

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
@@ -16,6 +16,7 @@ import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
 import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
 import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
+import { PendingAgentMessageRepository } from '../../../../src/storage/repositories/pending-agent-message-repository.ts';
 import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
 import { SpaceTaskManager } from '../../../../src/lib/space/managers/space-task-manager.ts';
@@ -713,5 +714,225 @@ describe('TaskAgentManager.rehydrateSubSession (lazy rehydration)', () => {
 		// Returns null for unknown session
 		const notFound = ctx.nodeExecutionRepo.getByAgentSessionId('no-such-session');
 		expect(notFound).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: TaskAgentManager.tryResumeNodeAgentSession (Task #70)
+// ---------------------------------------------------------------------------
+
+/**
+ * Helper: build a TaskAgentManager that reuses all mocked dependencies from
+ * `ctx` but also has a PendingAgentMessageRepository wired in.
+ * Uses bracket-notation access to the private `config` field, which is
+ * safe in test code because TypeScript's `private` is compile-time only.
+ */
+function makeManagerWithPendingRepo(
+	ctx: TestCtx,
+	pendingRepo: PendingAgentMessageRepository
+): TaskAgentManager {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const existingConfig = (ctx.manager as any).config as Record<string, unknown>;
+	return new TaskAgentManager({
+		...existingConfig,
+		pendingMessageRepo: pendingRepo,
+	} as unknown as ConstructorParameters<typeof TaskAgentManager>[0]);
+}
+
+describe('TaskAgentManager.tryResumeNodeAgentSession', () => {
+	let ctx: TestCtx;
+	let restoreSpy: ReturnType<typeof spyOn<typeof AgentSession, 'restore'>>;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+		restoreSpy = spyOn(AgentSession, 'restore').mockImplementation((sessionId: string) => {
+			if (!ctx.mockDb.getSession(sessionId)) return null;
+			const existing = ctx.createdSessions.get(sessionId);
+			if (existing) return existing as unknown as AgentSession;
+			const mockSession = makeMockSession(sessionId);
+			ctx.createdSessions.set(sessionId, mockSession);
+			return mockSession as unknown as AgentSession;
+		});
+	});
+
+	afterEach(() => {
+		ctx.fromInitSpy.mockRestore();
+		restoreSpy.mockRestore();
+		try {
+			rmSync(ctx.dir, { recursive: true, force: true });
+		} catch {
+			// ignore cleanup errors
+		}
+	});
+
+	test('is a no-op when pendingMessageRepo is not configured', async () => {
+		// ctx.manager has no pendingMessageRepo — should return immediately without throwing
+		const wfRunId = 'run-resume-noop-1';
+		const wfId = 'wf-resume-noop-1';
+		const nodeId = 'node-resume-noop-1';
+		seedWorkflowRun(ctx, wfRunId, wfId, nodeId);
+
+		await expect(ctx.manager.tryResumeNodeAgentSession(wfRunId, 'coder')).resolves.toBeUndefined();
+
+		// No restore or fromInit should have been called
+		expect(restoreSpy).not.toHaveBeenCalled();
+		expect(ctx.fromInitSpy).not.toHaveBeenCalled();
+	});
+
+	test('is a no-op when no NodeExecution with agentSessionId exists for the agent', async () => {
+		const pendingRepo = new PendingAgentMessageRepository(ctx.bunDb);
+
+		const wfRunId = 'run-resume-nosession-1';
+		const wfId = 'wf-resume-nosession-1';
+		const nodeId = 'node-resume-nosession-1';
+		seedWorkflowRun(ctx, wfRunId, wfId, nodeId);
+
+		// Execution exists but has no agentSessionId (agent was declared but never spawned)
+		ctx.nodeExecutionRepo.create({
+			workflowRunId: wfRunId,
+			workflowNodeId: nodeId,
+			agentName: 'coder',
+			status: 'pending',
+		});
+
+		const manager = makeManagerWithPendingRepo(ctx, pendingRepo);
+		await expect(manager.tryResumeNodeAgentSession(wfRunId, 'coder')).resolves.toBeUndefined();
+
+		// No restore should have been triggered
+		expect(restoreSpy).not.toHaveBeenCalled();
+	});
+
+	test('rehydrates session and flushes pending messages when session is not in memory', async () => {
+		const pendingRepo = new PendingAgentMessageRepository(ctx.bunDb);
+
+		const wfRunId = 'run-resume-rehydrate-1';
+		const wfId = 'wf-resume-rehydrate-1';
+		const nodeId = 'node-resume-rehydrate-1';
+		seedWorkflowRun(ctx, wfRunId, wfId, nodeId);
+
+		const parentTask = await ctx.taskManager.createTask({
+			title: 'Parent task for resume test',
+			description: '',
+			taskType: 'coding',
+			status: 'in_progress',
+			workflowRunId: wfRunId,
+		});
+		const taskAgentSessionId = `space:${ctx.spaceId}:task:${parentTask.id}`;
+		ctx.taskRepo.updateTask(parentTask.id, { taskAgentSessionId, status: 'in_progress' });
+		ctx.mockDb.createSession({ id: taskAgentSessionId, type: 'space_task_agent' });
+
+		const subSessionId = `space:${ctx.spaceId}:task:${parentTask.id}:exec:resume-exec-1`;
+		const execution = ctx.nodeExecutionRepo.create({
+			workflowRunId: wfRunId,
+			workflowNodeId: nodeId,
+			agentName: 'coder',
+			agentId: null,
+			status: 'in_progress',
+		});
+		ctx.nodeExecutionRepo.updateSessionId(execution.id, subSessionId);
+		// Seed session in mock DB so AgentSession.restore() returns a session
+		ctx.mockDb.createSession({ id: subSessionId, type: 'worker' });
+
+		// Queue a pending message for the coder
+		pendingRepo.enqueue({
+			workflowRunId: wfRunId,
+			spaceId: ctx.spaceId,
+			taskId: parentTask.id,
+			sourceAgentName: 'task-agent',
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'resume and continue',
+		});
+
+		const manager = makeManagerWithPendingRepo(ctx, pendingRepo);
+
+		// Session is NOT in memory — tryResumeNodeAgentSession should rehydrate it and flush
+		await manager.tryResumeNodeAgentSession(wfRunId, 'coder');
+
+		// restoreSpy must have been called to rehydrate the session (first arg is sessionId)
+		expect(restoreSpy).toHaveBeenCalled();
+		const restoreCalls = restoreSpy.mock.calls;
+		expect(restoreCalls.some((args) => args[0] === subSessionId)).toBe(true);
+
+		// flushPendingMessagesForTarget is called with `void` (fire-and-forget) inside
+		// rehydrateSubSession. Yield to the event loop so the flush microtask chain completes
+		// before we assert on its side-effects.
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+		// Pending message should have been delivered to the rehydrated session
+		const rehydrated = ctx.createdSessions.get(subSessionId);
+		expect(rehydrated).toBeDefined();
+		const delivered = rehydrated!._enqueuedMessages.find((m) =>
+			m.msg.includes('resume and continue')
+		);
+		expect(delivered).toBeDefined();
+
+		// Queue should now be empty (markDelivered was called)
+		const remaining = pendingRepo.listPendingForTarget(wfRunId, 'coder');
+		expect(remaining).toHaveLength(0);
+	});
+
+	test('flushes pending messages directly (fast path) when session is already in memory', async () => {
+		const pendingRepo = new PendingAgentMessageRepository(ctx.bunDb);
+
+		const wfRunId = 'run-resume-live-1';
+		const wfId = 'wf-resume-live-1';
+		const nodeId = 'node-resume-live-1';
+		seedWorkflowRun(ctx, wfRunId, wfId, nodeId);
+
+		const parentTask = await ctx.taskManager.createTask({
+			title: 'Parent task for live-session resume',
+			description: '',
+			taskType: 'coding',
+			status: 'in_progress',
+			workflowRunId: wfRunId,
+		});
+		const taskAgentSessionId = `space:${ctx.spaceId}:task:${parentTask.id}`;
+		ctx.taskRepo.updateTask(parentTask.id, { taskAgentSessionId, status: 'in_progress' });
+		ctx.mockDb.createSession({ id: taskAgentSessionId, type: 'space_task_agent' });
+
+		const subSessionId = `space:${ctx.spaceId}:task:${parentTask.id}:exec:resume-live-exec`;
+		const execution = ctx.nodeExecutionRepo.create({
+			workflowRunId: wfRunId,
+			workflowNodeId: nodeId,
+			agentName: 'reviewer',
+			agentId: null,
+			status: 'in_progress',
+		});
+		ctx.nodeExecutionRepo.updateSessionId(execution.id, subSessionId);
+		ctx.mockDb.createSession({ id: subSessionId, type: 'worker' });
+
+		const manager = makeManagerWithPendingRepo(ctx, pendingRepo);
+
+		// Prime the session into memory by injecting a message (triggers rehydration)
+		await manager.injectSubSessionMessage(subSessionId, 'initial injection');
+		const rehydrateCallCount = restoreSpy.mock.calls.length;
+
+		// Queue a pending message AFTER the session is in memory
+		pendingRepo.enqueue({
+			workflowRunId: wfRunId,
+			spaceId: ctx.spaceId,
+			taskId: parentTask.id,
+			sourceAgentName: 'task-agent',
+			targetKind: 'node_agent',
+			targetAgentName: 'reviewer',
+			message: 'fast path delivery',
+		});
+
+		// Call tryResumeNodeAgentSession — session IS in memory → fast path (no restore call)
+		await manager.tryResumeNodeAgentSession(wfRunId, 'reviewer');
+
+		// restoreSpy should NOT have been called again (fast path skips rehydration)
+		expect(restoreSpy.mock.calls.length).toBe(rehydrateCallCount);
+
+		// Pending message should have been flushed to the live session
+		const remaining = pendingRepo.listPendingForTarget(wfRunId, 'reviewer');
+		expect(remaining).toHaveLength(0);
+
+		const session = ctx.createdSessions.get(subSessionId);
+		const fastPathMsg = session?._enqueuedMessages.find((m) =>
+			m.msg.includes('fast path delivery')
+		);
+		expect(fastPathMsg).toBeDefined();
 	});
 });

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-tools.test.ts
@@ -1251,6 +1251,7 @@ describe('createTaskAgentToolHandlers — send_message queue-until-active', () =
 				if (agentName === 'coder') return { session: { id: 'session-coder' } };
 				return null;
 			},
+			tryResumeNodeAgentSession: async () => {},
 		} as unknown as TaskAgentToolsConfig['taskAgentManager'];
 
 		const delivered: Array<{ sessionId: string; message: string }> = [];
@@ -1485,5 +1486,157 @@ describe('createTaskAgentToolHandlers — send_message queue-until-active', () =
 		);
 		const parsed2 = JSON.parse(out2.content[0].text);
 		expect(parsed2.queued[0].deduped).toBe(true);
+	});
+});
+
+// ===========================================================================
+// send_message auto-resume (Task #70)
+// ===========================================================================
+
+describe('createTaskAgentToolHandlers — send_message auto-resume on queue', () => {
+	let ctx: TestCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+		rmSync(ctx.dir, { recursive: true, force: true });
+	});
+
+	test('calls tryResumeNodeAgentSession after queuing a non-deduped message', async () => {
+		const wf = buildTwoStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		// Declare "reviewer" as pending (no session yet)
+		ctx.nodeExecutionRepo.create({
+			workflowRunId: run.id,
+			workflowNodeId: 'declared-node',
+			agentName: 'reviewer',
+			status: 'pending',
+		});
+
+		const { PendingAgentMessageRepository } = await import(
+			'../../../../src/storage/repositories/pending-agent-message-repository.ts'
+		);
+		const pendingRepo = new PendingAgentMessageRepository(ctx.db);
+
+		const resumeAttempts: Array<{ workflowRunId: string; agentName: string }> = [];
+
+		// Mock taskAgentManager with tryResumeNodeAgentSession spy
+		const mockTaskAgentManager = {
+			getAgentNamesForTask: async (_taskId: string) => [],
+			getSubSessionByAgentName: async (_taskId: string, _agentName: string) => null,
+			tryResumeNodeAgentSession: async (workflowRunId: string, agentName: string) => {
+				resumeAttempts.push({ workflowRunId, agentName });
+			},
+		} as unknown as TaskAgentToolsConfig['taskAgentManager'];
+
+		const config: TaskAgentToolsConfig = {
+			...makeConfig(ctx, mainTask.id, run.id),
+			pendingMessageRepo: pendingRepo,
+			taskAgentManager: mockTaskAgentManager,
+		};
+		const handlers = createTaskAgentToolHandlers(config);
+
+		const result = await handlers.send_message({
+			target: 'reviewer',
+			message: 'ping',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.queued).toHaveLength(1);
+
+		// Auto-resume must have been attempted
+		expect(resumeAttempts).toHaveLength(1);
+		expect(resumeAttempts[0].agentName).toBe('reviewer');
+		expect(resumeAttempts[0].workflowRunId).toBe(run.id);
+	});
+
+	test('does NOT call tryResumeNodeAgentSession for deduped (already-queued) messages', async () => {
+		const wf = buildTwoStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		ctx.nodeExecutionRepo.create({
+			workflowRunId: run.id,
+			workflowNodeId: 'declared-node',
+			agentName: 'reviewer',
+			status: 'pending',
+		});
+
+		const { PendingAgentMessageRepository } = await import(
+			'../../../../src/storage/repositories/pending-agent-message-repository.ts'
+		);
+		const pendingRepo = new PendingAgentMessageRepository(ctx.db);
+
+		const resumeAttempts: string[] = [];
+
+		const mockTaskAgentManager = {
+			getAgentNamesForTask: async (_taskId: string) => [],
+			getSubSessionByAgentName: async (_taskId: string, _agentName: string) => null,
+			tryResumeNodeAgentSession: async (_workflowRunId: string, agentName: string) => {
+				resumeAttempts.push(agentName);
+			},
+		} as unknown as TaskAgentToolsConfig['taskAgentManager'];
+
+		const config: TaskAgentToolsConfig = {
+			...makeConfig(ctx, mainTask.id, run.id),
+			pendingMessageRepo: pendingRepo,
+			taskAgentManager: mockTaskAgentManager,
+		};
+		const handlers = createTaskAgentToolHandlers(config);
+
+		// First call — new enqueue → auto-resume triggered
+		await handlers.send_message({
+			target: 'reviewer',
+			message: 'ping',
+			idempotency_key: 'auto-resume-dedup-1',
+		});
+		expect(resumeAttempts).toHaveLength(1);
+
+		// Second call with same key — deduped → auto-resume NOT triggered again
+		resumeAttempts.length = 0;
+		await handlers.send_message({
+			target: 'reviewer',
+			message: 'ping (retry)',
+			idempotency_key: 'auto-resume-dedup-1',
+		});
+		expect(resumeAttempts).toHaveLength(0);
+	});
+
+	test('does NOT call tryResumeNodeAgentSession when taskAgentManager is absent', async () => {
+		// Regression guard: the code path must not throw when taskAgentManager is unset
+		const wf = buildTwoStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		ctx.nodeExecutionRepo.create({
+			workflowRunId: run.id,
+			workflowNodeId: 'declared-node',
+			agentName: 'reviewer',
+			status: 'pending',
+		});
+
+		const { PendingAgentMessageRepository } = await import(
+			'../../../../src/storage/repositories/pending-agent-message-repository.ts'
+		);
+		const pendingRepo = new PendingAgentMessageRepository(ctx.db);
+
+		// No taskAgentManager — should not throw
+		const config: TaskAgentToolsConfig = {
+			...makeConfig(ctx, mainTask.id, run.id),
+			pendingMessageRepo: pendingRepo,
+			// taskAgentManager deliberately absent
+		};
+		const handlers = createTaskAgentToolHandlers(config);
+
+		const result = await handlers.send_message({
+			target: 'reviewer',
+			message: 'ping',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		// Still queues successfully; just no auto-resume
+		expect(parsed.success).toBe(true);
+		expect(parsed.queued).toHaveLength(1);
 	});
 });


### PR DESCRIPTION
When a Task Agent called `send_message` targeting a node agent whose session had completed/gone idle, the message persisted in the pending queue but was never delivered — it sat there until the 10-minute TTL expired.

**Root cause:** `spawnWorkflowNodeAgentForExecution` called `createSubSession` without `agentName`/`nodeId`, so neither session reuse nor pending message flush triggered.

**Fix — three coordinated changes:**

- `spawnWorkflowNodeAgentForExecution` now passes `agentName` + `nodeId` into `createSubSession`, enabling (a) session reuse per named agent per task lifetime and (b) automatic queue flush on session create/reuse
- New `TaskAgentManager.tryResumeNodeAgentSession(workflowRunId, agentName)`: looks up the latest NodeExecution with a known `agentSessionId`, then flushes the pending queue — directly if the session is in memory (fast path) or via `rehydrateSubSession` if not (slow path)
- `send_message` in `task-agent-tools` and `AgentMessageRouter.deliverMessage` both call `tryResumeNodeAgentSession` best-effort after a non-deduped enqueue, closing the send→queue→resume→drain loop without an external activation trigger

Tests added: `onMessageQueued` callback behavior in `AgentMessageRouter`, auto-resume in `send_message`, and `tryResumeNodeAgentSession` (no-op cases, rehydrate+flush, fast-path flush).