### PR TITLE
fix(space): resolve gate scripts from live templates; log drift warnings at startup

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -54,7 +54,10 @@ import { setupSpaceTaskMessageHandlers } from './space-task-message-handlers';
 import { NodeExecutionRepository } from '../../storage/repositories/node-execution-repository';
 import { TaskAgentManager } from '../space/runtime/task-agent-manager';
 import { SpaceWorktreeManager } from '../space/managers/space-worktree-manager';
-import { setupSpaceWorkflowHandlers } from './space-workflow-handlers';
+import {
+	setupSpaceWorkflowHandlers,
+	checkBuiltInWorkflowDriftOnStartup,
+} from './space-workflow-handlers';
 import type { SpaceManager } from '../space/managers/space-manager';
 import { SpaceTaskManager } from '../space/managers/space-task-manager';
 import { SpaceWorkflowManager } from '../space/managers/space-workflow-manager';
@@ -437,6 +440,10 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		deps.spaceAgentManager,
 		spaceWorkflowRunRepo
 	);
+
+	// Proactive drift detection — fire-and-forget; logs warnings for any workflows
+	// that have drifted from their built-in templates since the last sync.
+	void checkBuiltInWorkflowDriftOnStartup(spaceWorkflowManager, deps.spaceManager);
 
 	// Space Runtime Service — wraps SpaceRuntime with per-space lifecycle API.
 	// Not started yet: TaskAgentManager is created next and injected before start().

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
@@ -110,6 +110,73 @@ function buildTemplateUpdateParams(
 	};
 }
 
+/**
+ * Proactive drift check run once at daemon startup.
+ *
+ * Scans every space for workflows that were seeded from a built-in template but
+ * have since drifted (i.e. the stored `templateHash` no longer matches the
+ * current template's hash). Detected drifts are logged as warnings so operators
+ * and developers see them in the daemon log even when no user has opened the
+ * Workflow List UI.
+ *
+ * This function is intentionally non-blocking: failures (e.g. DB errors) are
+ * caught and logged rather than propagated, so startup is never blocked by drift
+ * detection.
+ */
+export async function checkBuiltInWorkflowDriftOnStartup(
+	workflowManager: SpaceWorkflowManager,
+	spaceManager: SpaceManager
+): Promise<void> {
+	try {
+		const spaces = await spaceManager.listSpaces();
+		if (spaces.length === 0) return;
+
+		const templates = getBuiltInWorkflows();
+		const templateMap = new Map(templates.map((t) => [t.name, t]));
+
+		const driftedWorkflows: Array<{
+			spaceName: string;
+			workflowName: string;
+			templateName: string;
+		}> = [];
+
+		for (const space of spaces) {
+			const workflows = workflowManager.listWorkflows(space.id);
+			for (const workflow of workflows) {
+				if (!workflow.templateName) continue;
+				const template = templateMap.get(workflow.templateName);
+				if (!template) continue;
+
+				const currentTemplateHash = computeWorkflowHash(template);
+				const storedHash = workflow.templateHash ?? null;
+
+				if (currentTemplateHash !== storedHash) {
+					driftedWorkflows.push({
+						spaceName: space.name,
+						workflowName: workflow.name,
+						templateName: workflow.templateName,
+					});
+				}
+			}
+		}
+
+		if (driftedWorkflows.length === 0) return;
+
+		log.warn(
+			`[startup] ${driftedWorkflows.length} workflow(s) have drifted from their built-in templates. ` +
+				`Open the Workflow List in the UI and click "Sync" to update them.`
+		);
+		for (const { spaceName, workflowName, templateName } of driftedWorkflows) {
+			log.warn(
+				`  • Space "${spaceName}" / Workflow "${workflowName}" (template: "${templateName}") is outdated`
+			);
+		}
+	} catch (err) {
+		// Non-fatal: drift detection errors must never break daemon startup.
+		log.warn('[startup] Workflow drift check failed (non-fatal):', err);
+	}
+}
+
 export function setupSpaceWorkflowHandlers(
 	messageHub: MessageHub,
 	spaceManager: SpaceManager,

--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -52,6 +52,7 @@ import { TERMINAL_NODE_EXECUTION_STATUSES } from '../managers/node-execution-man
 import { evaluateGate, type GateEvalResult, type GateScriptExecutorFn } from './gate-evaluator';
 import type { GateScriptContext } from './gate-script-executor';
 import { executeGateScript } from './gate-script-executor';
+import { getBuiltInGateScript } from '../workflows/built-in-workflows';
 import type { NotificationSink, SpaceNotificationEvent } from './notification-sink';
 import { Logger } from '../../logger';
 
@@ -818,12 +819,25 @@ export class ChannelRouter {
 		gateId: string,
 		workflow: SpaceWorkflow
 	): Promise<GateEvalResult> {
-		const gateDef = (workflow.gates ?? []).find((g) => g.id === gateId);
-		if (!gateDef) {
+		const storedGateDef = (workflow.gates ?? []).find((g) => g.id === gateId);
+		if (!storedGateDef) {
 			return {
 				open: false,
 				reason: `Gate "${gateId}" not found in workflow "${workflow.id}" — channel is closed (misconfiguration)`,
 			};
+		}
+
+		// When this workflow was seeded from a built-in template, always resolve the
+		// gate script from the *current* template definition rather than the copy that
+		// was baked in at seed time. This ensures that template script updates (bug
+		// fixes, new fallback logic, etc.) take immediate effect for all running
+		// workflow instances without requiring a resync.
+		let gateDef = storedGateDef;
+		if (workflow.templateName && storedGateDef.script) {
+			const liveScript = getBuiltInGateScript(workflow.templateName, gateId);
+			if (liveScript) {
+				gateDef = { ...storedGateDef, script: liveScript };
+			}
 		}
 
 		// Load runtime data from DB; fall back to computed defaults from fields

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -22,6 +22,7 @@
 
 import { generateUUID } from '@neokai/shared';
 import type { SpaceWorkflow, CompletionAction } from '@neokai/shared';
+import type { GateScript } from '@neokai/shared';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import { computeWorkflowHash } from './template-hash.ts';
 
@@ -1201,6 +1202,26 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
+
+/**
+ * Returns the current gate script for a given built-in template name and gate ID.
+ *
+ * Gate scripts are stored in the `space_workflows.gates` JSON column at seed time.
+ * When a template script is updated, existing workflow instances still carry the old
+ * script from when they were seeded. Callers that need the **live** script (e.g. the
+ * gate evaluator) should use this function to resolve the script at call time instead
+ * of relying on the stored copy.
+ *
+ * Returns `undefined` when the template or gate is not found, or when the gate has
+ * no script (field-only gate). Callers should fall back to the stored gate definition
+ * in that case.
+ */
+export function getBuiltInGateScript(templateName: string, gateId: string): GateScript | undefined {
+	const template = getBuiltInWorkflows().find((t) => t.name === templateName);
+	if (!template) return undefined;
+	const gate = (template.gates ?? []).find((g) => g.id === gateId);
+	return gate?.script;
+}
 
 /**
  * Returns all built-in workflow templates.

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-workflow-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-workflow-handlers.test.ts
@@ -23,7 +23,10 @@
 import { describe, expect, it, mock, beforeEach } from 'bun:test';
 import { MessageHub } from '@neokai/shared';
 import type { Space, SpaceWorkflow } from '@neokai/shared';
-import { setupSpaceWorkflowHandlers } from '../../../../src/lib/rpc-handlers/space-workflow-handlers';
+import {
+	setupSpaceWorkflowHandlers,
+	checkBuiltInWorkflowDriftOnStartup,
+} from '../../../../src/lib/rpc-handlers/space-workflow-handlers';
 import type { SpaceManager } from '../../../../src/lib/space/managers/space-manager';
 import type { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager';
 import { WorkflowValidationError } from '../../../../src/lib/space/managers/space-workflow-manager';
@@ -1153,5 +1156,151 @@ describe('space-workflow-handlers', () => {
 			expect(workflowRunRepo.deleteByWorkflowId).toHaveBeenCalledWith('wf-older-2');
 			expect(workflowRunRepo.deleteByWorkflowId).not.toHaveBeenCalledWith('wf-newer');
 		});
+	});
+});
+
+// ─── checkBuiltInWorkflowDriftOnStartup ──────────────────────────────────────
+
+describe('checkBuiltInWorkflowDriftOnStartup', () => {
+	function makeSpaceManager(spaces: Space[]): SpaceManager {
+		return {
+			listSpaces: mock(async () => spaces),
+		} as unknown as SpaceManager;
+	}
+
+	function makeWorkflowManager(
+		workflowsBySpaceId: Record<string, SpaceWorkflow[]>
+	): SpaceWorkflowManager {
+		return {
+			listWorkflows: mock((spaceId: string) => workflowsBySpaceId[spaceId] ?? []),
+		} as unknown as SpaceWorkflowManager;
+	}
+
+	it('returns without logging when there are no spaces', async () => {
+		const sm = makeSpaceManager([]);
+		const wm = makeWorkflowManager({});
+		// Should complete without throwing
+		await expect(checkBuiltInWorkflowDriftOnStartup(wm, sm)).resolves.toBeUndefined();
+	});
+
+	it('returns without logging when all workflows are up-to-date', async () => {
+		const [template] = getBuiltInWorkflows();
+		const currentHash = computeWorkflowHash(template);
+		const space: Space = { ...mockSpace, id: 'sp-1', name: 'My Space' };
+		const workflow: SpaceWorkflow = {
+			...mockWorkflow,
+			id: 'wf-fresh',
+			spaceId: 'sp-1',
+			templateName: template.name,
+			templateHash: currentHash,
+		};
+		const sm = makeSpaceManager([space]);
+		const wm = makeWorkflowManager({ 'sp-1': [workflow] });
+
+		await expect(checkBuiltInWorkflowDriftOnStartup(wm, sm)).resolves.toBeUndefined();
+		// listWorkflows was called for the one space
+		expect(wm.listWorkflows).toHaveBeenCalledWith('sp-1');
+	});
+
+	it('returns without logging when workflows have no templateName', async () => {
+		const space: Space = { ...mockSpace, id: 'sp-1', name: 'My Space' };
+		const workflow: SpaceWorkflow = {
+			...mockWorkflow,
+			id: 'wf-custom',
+			spaceId: 'sp-1',
+			templateName: undefined,
+		};
+		const sm = makeSpaceManager([space]);
+		const wm = makeWorkflowManager({ 'sp-1': [workflow] });
+
+		await expect(checkBuiltInWorkflowDriftOnStartup(wm, sm)).resolves.toBeUndefined();
+	});
+
+	it('returns without logging when templateName does not match any built-in', async () => {
+		const space: Space = { ...mockSpace, id: 'sp-1', name: 'My Space' };
+		const workflow: SpaceWorkflow = {
+			...mockWorkflow,
+			id: 'wf-orphan',
+			spaceId: 'sp-1',
+			templateName: 'Nonexistent Template',
+			templateHash: 'some-hash',
+		};
+		const sm = makeSpaceManager([space]);
+		const wm = makeWorkflowManager({ 'sp-1': [workflow] });
+
+		// No drift for unknown template names — they are skipped
+		await expect(checkBuiltInWorkflowDriftOnStartup(wm, sm)).resolves.toBeUndefined();
+	});
+
+	it('resolves without throwing when drift is detected (stale templateHash)', async () => {
+		const [template] = getBuiltInWorkflows();
+		const space: Space = { ...mockSpace, id: 'sp-1', name: 'My Space' };
+		const staleWorkflow: SpaceWorkflow = {
+			...mockWorkflow,
+			id: 'wf-stale',
+			spaceId: 'sp-1',
+			templateName: template.name,
+			templateHash: 'stale-hash-from-old-version',
+		};
+		const sm = makeSpaceManager([space]);
+		const wm = makeWorkflowManager({ 'sp-1': [staleWorkflow] });
+
+		// Must resolve (not throw) even when drift is present
+		await expect(checkBuiltInWorkflowDriftOnStartup(wm, sm)).resolves.toBeUndefined();
+	});
+
+	it('resolves without throwing when templateHash is absent (null → drifted)', async () => {
+		const [template] = getBuiltInWorkflows();
+		const space: Space = { ...mockSpace, id: 'sp-1', name: 'My Space' };
+		const workflow: SpaceWorkflow = {
+			...mockWorkflow,
+			id: 'wf-no-hash',
+			spaceId: 'sp-1',
+			templateName: template.name,
+			templateHash: undefined,
+		};
+		const sm = makeSpaceManager([space]);
+		const wm = makeWorkflowManager({ 'sp-1': [workflow] });
+
+		await expect(checkBuiltInWorkflowDriftOnStartup(wm, sm)).resolves.toBeUndefined();
+	});
+
+	it('scans workflows across multiple spaces', async () => {
+		const [template] = getBuiltInWorkflows();
+		const currentHash = computeWorkflowHash(template);
+		const spaceA: Space = { ...mockSpace, id: 'sp-a', name: 'Space A' };
+		const spaceB: Space = { ...mockSpace, id: 'sp-b', name: 'Space B' };
+		const freshWf: SpaceWorkflow = {
+			...mockWorkflow,
+			id: 'wf-fresh',
+			spaceId: 'sp-a',
+			templateName: template.name,
+			templateHash: currentHash,
+		};
+		const staleWf: SpaceWorkflow = {
+			...mockWorkflow,
+			id: 'wf-stale',
+			spaceId: 'sp-b',
+			templateName: template.name,
+			templateHash: 'stale',
+		};
+		const sm = makeSpaceManager([spaceA, spaceB]);
+		const wm = makeWorkflowManager({ 'sp-a': [freshWf], 'sp-b': [staleWf] });
+
+		await expect(checkBuiltInWorkflowDriftOnStartup(wm, sm)).resolves.toBeUndefined();
+		expect(wm.listWorkflows).toHaveBeenCalledWith('sp-a');
+		expect(wm.listWorkflows).toHaveBeenCalledWith('sp-b');
+	});
+
+	it('resolves without throwing when spaceManager.listSpaces rejects (non-fatal)', async () => {
+		const sm = {
+			listSpaces: mock(async () => {
+				throw new Error('DB connection lost');
+			}),
+		} as unknown as SpaceManager;
+		const wm = makeWorkflowManager({});
+
+		// Errors must be swallowed — startup must never be blocked
+		await expect(checkBuiltInWorkflowDriftOnStartup(wm, sm)).resolves.toBeUndefined();
 	});
 });

--- a/packages/daemon/tests/unit/5-space/other/channel-router-async.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/channel-router-async.test.ts
@@ -29,6 +29,7 @@ import {
 	ChannelGateBlockedError,
 } from '../../../../src/lib/space/runtime/channel-router.ts';
 import type { Gate, WorkflowChannel } from '@neokai/shared';
+import { CODING_WORKFLOW } from '../../../../src/lib/space/workflows/built-in-workflows.ts';
 
 // ---------------------------------------------------------------------------
 // DB helpers (shared with channel-router.test.ts)
@@ -1479,6 +1480,237 @@ describe('ChannelRouter async gate evaluation', () => {
 
 			const router = makeRouter({ workspacePath: '/tmp' });
 			const result = await router.canDeliver(run.id, 'coder', 'planner');
+			expect(result.allowed).toBe(true);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Live gate script resolution (Issue 1 fix)
+	// ---------------------------------------------------------------------------
+	// When a workflow has a `templateName`, the gate evaluator must use the
+	// *current* template's gate script rather than the version stored in the DB
+	// at seed time. This ensures that script updates (bug fixes, new fallback
+	// logic, etc.) take effect for all running workflow instances immediately.
+
+	describe('live gate script resolution for template-based workflows', () => {
+		/**
+		 * Builds a two-node workflow that mimics a seeded Coding Workflow:
+		 * - Uses node/agent names from CODING_WORKFLOW
+		 * - Carries a STALE script in the stored code-ready-gate
+		 * - Has templateName set to CODING_WORKFLOW.name
+		 *
+		 * The stale script exits non-zero (which would block delivery if it ran).
+		 * The live template script exits 0 immediately (for testability).
+		 */
+		function buildStaleTemplateWorkflow(staleScript: string, liveGate: Gate) {
+			const staleGate: Gate = {
+				...liveGate,
+				script: {
+					interpreter: 'bash',
+					source: staleScript,
+					timeoutMs: 5000,
+				},
+			};
+
+			const wf = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Stale Template Workflow ${Date.now()}`,
+				description: '',
+				nodes: [
+					{
+						id: NODE_A,
+						name: 'Coder Node',
+						agents: [{ agentId: AGENT_CODER, name: 'coder' }],
+					},
+					{
+						id: NODE_B,
+						name: 'Planner Node',
+						agents: [{ agentId: AGENT_PLANNER, name: 'planner' }],
+					},
+				],
+				startNodeId: NODE_A,
+				endNodeId: NODE_B,
+				tags: [],
+				channels: [
+					{
+						from: 'coder',
+						to: 'planner',
+						gateId: staleGate.id,
+					},
+				],
+				gates: [staleGate],
+				completionAutonomyLevel: 3,
+				// Mark as seeded from Coding Workflow template
+				templateName: CODING_WORKFLOW.name,
+				templateHash: 'stale-hash',
+			});
+
+			return wf;
+		}
+
+		test('uses the live template script instead of the stale stored script when templateName matches', async () => {
+			// A script that always fails — simulates a stale script with an old bug
+			const STALE_FAILING_SCRIPT = 'exit 1 # stale script that has a bug';
+
+			// The gate we are patching: code-ready-gate from the CODING_WORKFLOW template
+			// For this test we stub it with a simple passing script to avoid real `gh` calls
+			const LIVE_PASSING_SCRIPT = 'echo \'{"pr_url":"https://github.com/test/pr/1"}\'';
+
+			// Build a gate that matches code-ready-gate's field schema but with a stale script.
+			// The router will swap in the live template script at evaluation time.
+			const gateId = 'code-ready-gate';
+			const gateWithStaleScript: Gate = {
+				id: gateId,
+				fields: [
+					{
+						name: 'pr_url',
+						type: 'string',
+						writers: ['Coding'],
+						check: { op: 'exists' },
+					},
+				],
+				script: {
+					interpreter: 'bash',
+					source: STALE_FAILING_SCRIPT,
+					timeoutMs: 5000,
+				},
+				resetOnCycle: true,
+			};
+
+			// Patch: replace the live template's gate script so we can control it in tests
+			// without invoking real `gh` commands. We do this by temporarily overriding
+			// the gate in CODING_WORKFLOW's gates array.
+			const originalGate = CODING_WORKFLOW.gates!.find((g) => g.id === gateId)!;
+			const originalScript = originalGate.script;
+			// biome-ignore lint/suspicious/noExplicitAny: test-only mutation of template
+			(originalGate as any).script = {
+				interpreter: 'bash',
+				source: LIVE_PASSING_SCRIPT,
+				timeoutMs: 5000,
+			};
+
+			try {
+				const wf = buildStaleTemplateWorkflow(STALE_FAILING_SCRIPT, gateWithStaleScript);
+				const run = createActiveRun(wf);
+				// Seed pr_url in gate data so the pr_url field check passes after script runs
+				gateDataRepo.set(run.id, gateId, { pr_url: 'https://github.com/test/pr/1' });
+
+				const router = makeRouter({ workspacePath: '/tmp' });
+				// If the stale script ran, canDeliver would return { allowed: false }
+				// because exit 1 blocks the gate. The live script exits 0 with a pr_url
+				// JSON object → gate opens.
+				const result = await router.canDeliver(run.id, 'coder', 'planner');
+				expect(result.allowed).toBe(true);
+			} finally {
+				// Restore original script
+				// biome-ignore lint/suspicious/noExplicitAny: test-only restoration
+				(originalGate as any).script = originalScript;
+			}
+		});
+
+		test('stale stored script would block delivery without live resolution', async () => {
+			// Control test: without templateName set, the router uses the stored (stale) script
+			const STALE_FAILING_SCRIPT = 'exit 1 # stale script that has a bug';
+
+			const gateId = 'some-custom-gate';
+			const gateWithFailingScript: Gate = {
+				id: gateId,
+				fields: [
+					{
+						name: 'pr_url',
+						type: 'string',
+						writers: ['*'],
+						check: { op: 'exists' },
+					},
+				],
+				script: {
+					interpreter: 'bash',
+					source: STALE_FAILING_SCRIPT,
+					timeoutMs: 5000,
+				},
+				resetOnCycle: false,
+			};
+
+			// Build workflow WITHOUT templateName — uses the stored script directly
+			const wf = buildWorkflowWithGates(
+				SPACE_ID,
+				workflowManager,
+				[
+					{
+						id: NODE_A,
+						name: 'Coder Node',
+						agents: [{ agentId: AGENT_CODER, name: 'coder' }],
+					},
+					{
+						id: NODE_B,
+						name: 'Planner Node',
+						agents: [{ agentId: AGENT_PLANNER, name: 'planner' }],
+					},
+				],
+				[{ from: 'coder', to: 'planner', gateId }],
+				[gateWithFailingScript]
+			);
+			const run = createActiveRun(wf);
+
+			const router = makeRouter({ workspacePath: '/tmp' });
+			const result = await router.canDeliver(run.id, 'coder', 'planner');
+			// Without templateName, the failing stored script blocks the gate
+			expect(result.allowed).toBe(false);
+		});
+
+		test('falls back to stored script when templateName does not match any built-in', async () => {
+			// A script that passes immediately
+			const PASSING_STORED_SCRIPT = 'echo \'{"pr_url":"https://github.com/x/1"}\'';
+
+			const gateId = 'gate-with-unknown-template';
+			const gate: Gate = {
+				id: gateId,
+				fields: [
+					{
+						name: 'pr_url',
+						type: 'string',
+						writers: ['*'],
+						check: { op: 'exists' },
+					},
+				],
+				script: {
+					interpreter: 'bash',
+					source: PASSING_STORED_SCRIPT,
+					timeoutMs: 5000,
+				},
+				resetOnCycle: false,
+			};
+
+			// Workflow with a non-existent templateName → no live script to resolve
+			const wf = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Unknown Template Workflow ${Date.now()}`,
+				description: '',
+				nodes: [
+					{
+						id: NODE_A,
+						name: 'Coder Node',
+						agents: [{ agentId: AGENT_CODER, name: 'coder' }],
+					},
+					{
+						id: NODE_B,
+						name: 'Planner Node',
+						agents: [{ agentId: AGENT_PLANNER, name: 'planner' }],
+					},
+				],
+				startNodeId: NODE_A,
+				endNodeId: NODE_B,
+				tags: [],
+				channels: [{ from: 'coder', to: 'planner', gateId }],
+				gates: [gate],
+				completionAutonomyLevel: 3,
+				templateName: 'Unknown Template That Does Not Exist',
+			});
+			const run = createActiveRun(wf);
+
+			const router = makeRouter({ workspacePath: '/tmp' });
+			const result = await router.canDeliver(run.id, 'coder', 'planner');
+			// Stored script exits 0 → gate opens (fallback to stored script works)
 			expect(result.allowed).toBe(true);
 		});
 	});

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -29,6 +29,7 @@ import {
 	RESEARCH_WORKFLOW,
 	REVIEW_ONLY_WORKFLOW,
 	getBuiltInWorkflows,
+	getBuiltInGateScript,
 	seedBuiltInWorkflows,
 } from '../../../../src/lib/space/workflows/built-in-workflows.ts';
 import type { SpaceAgent, SpaceWorkflow } from '@neokai/shared';
@@ -1793,6 +1794,85 @@ describe('Coding Workflow export/import round-trip', () => {
 		const reviewToCode = reimported.channels!.find((c) => c.from === 'Review' && c.to === 'Coding');
 		expect(reviewToCode).toBeDefined();
 		expect(reviewToCode!.maxCycles).toBe(5);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// getBuiltInGateScript()
+// ---------------------------------------------------------------------------
+// Tests for the live gate-script resolution helper. This function returns the
+// *current* script for a given built-in template + gate ID combination so that
+// gate evaluations always use the latest script rather than the version that was
+// baked into the database at seed time.
+
+describe('getBuiltInGateScript()', () => {
+	test('returns the bash script for code-ready-gate in Coding Workflow', () => {
+		const script = getBuiltInGateScript(CODING_WORKFLOW.name, 'code-ready-gate');
+		expect(script).toBeDefined();
+		expect(script?.interpreter).toBe('bash');
+		expect(script?.source.length).toBeGreaterThan(0);
+		// The PR-ready script references gh pr view and checks mergeability
+		expect(script?.source).toContain('gh pr view');
+		expect(script?.source).toContain('MERGEABLE');
+	});
+
+	test('returns the bash script for review-posted-gate in Coding Workflow', () => {
+		const script = getBuiltInGateScript(CODING_WORKFLOW.name, 'review-posted-gate');
+		expect(script).toBeDefined();
+		expect(script?.interpreter).toBe('bash');
+		// The review-posted script should include the PR comment fallback path
+		expect(script?.source).toContain('gh pr view');
+		expect(script?.source).toContain('comments');
+		// Confirm the current fallback message is present (not the stale "No review submitted on…")
+		expect(script?.source).toContain('No review or PR comment found on');
+	});
+
+	test('returns the bash script for plan-pr-gate in Plan & Decompose Workflow', () => {
+		const script = getBuiltInGateScript(PLAN_AND_DECOMPOSE_WORKFLOW.name, 'plan-pr-gate');
+		expect(script).toBeDefined();
+		expect(script?.interpreter).toBe('bash');
+	});
+
+	test('returns undefined for a field-only gate (plan-approval-gate has no script)', () => {
+		const script = getBuiltInGateScript(PLAN_AND_DECOMPOSE_WORKFLOW.name, 'plan-approval-gate');
+		expect(script).toBeUndefined();
+	});
+
+	test('returns undefined when the template name does not match any built-in', () => {
+		const script = getBuiltInGateScript('Unknown Template', 'code-ready-gate');
+		expect(script).toBeUndefined();
+	});
+
+	test('returns undefined when the gate ID does not exist in the template', () => {
+		const script = getBuiltInGateScript(CODING_WORKFLOW.name, 'nonexistent-gate-id');
+		expect(script).toBeUndefined();
+	});
+
+	test('returned script matches the gate definition directly from the template', () => {
+		// Verify the helper returns the exact same object reference as the template defines
+		const templateGate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
+		const script = getBuiltInGateScript(CODING_WORKFLOW.name, 'review-posted-gate');
+		expect(script).toBe(templateGate.script); // same object reference
+	});
+
+	test('returns scripts for all script-based gates in all templates', () => {
+		// Every gate that has a script in any built-in template should be resolvable
+		for (const template of getBuiltInWorkflows()) {
+			for (const gate of template.gates ?? []) {
+				if (!gate.script) continue;
+				const script = getBuiltInGateScript(template.name, gate.id);
+				expect(script).toBeDefined();
+				expect(script?.interpreter).toBe(gate.script.interpreter);
+				expect(script?.source).toBe(gate.script.source);
+			}
+		}
+	});
+
+	test('review-posted-gate script includes NEOKAI_WORKFLOW_START_ISO usage', () => {
+		const script = getBuiltInGateScript(CODING_WORKFLOW.name, 'review-posted-gate');
+		// The review-posted-gate script must use NEOKAI_WORKFLOW_START_ISO to filter
+		// reviews that were posted after the workflow started
+		expect(script?.source).toContain('NEOKAI_WORKFLOW_START_ISO');
 	});
 });
 


### PR DESCRIPTION
Two reliability fixes for running Space workflows.

**Fix 1 — Gate scripts resolve from live template, not stale DB copy**

Gate scripts (e.g. `review-posted-gate`) were baked into `space_workflows.gates` JSON at seed time. Any bug-fix to the script had no effect on already-running workflow instances. `doEvaluateGate` now calls `getBuiltInGateScript(templateName, gateId)` to pull the current script from the in-process built-in template, falling back to the stored copy only when no live script is found. This makes script fixes in `built-in-workflows.ts` take effect immediately — no re-seed required.

**Fix 2 — Proactive drift detection at daemon startup**

Drift detection was purely on-demand (frontend `WorkflowList.tsx` `useEffect`). Added `checkBuiltInWorkflowDriftOnStartup` (called fire-and-forget from `setupRPCHandlers`) that compares each workflow's `templateHash` to the current built-in hash and logs `warn` entries for any drifted workflows. Errors are caught so startup is never blocked.

**Tests added**
- `getBuiltInGateScript` helper (8 cases in `built-in-workflows.test.ts`)
- Live template script resolution in `doEvaluateGate` (3 cases in `channel-router-async.test.ts`)
- `checkBuiltInWorkflowDriftOnStartup` (8 cases in `space-workflow-handlers.test.ts`)