### PR TITLE
fix(space): restore node-agent MCP tools in workflow sessions after restart

### DIFF
--- a/packages/daemon/.env.example
+++ b/packages/daemon/.env.example
@@ -96,6 +96,16 @@ MAX_SESSIONS=10
 # NEOKAI_ENABLE_NEO_AGENT=1
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Debugging
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#
+# Throw a hard error when a workflow session is missing expected MCP servers
+# (node-agent or space-agent-tools) at query start. Useful for reproducing
+# "No such tool available" failures during local development. In production
+# the daemon emits a structured warning event instead.
+# NEOKAI_DEBUG_MCP_INVARIANTS=1
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Test Configuration
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 #

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -673,7 +673,10 @@ export class AgentSession
 	 * attached servers (e.g. `space-agent-tools`, `db-query`) silently drops those
 	 * attachments, causing "No such tool available" failures during workflow execution.
 	 *
-	 * Remaining callers are being migrated; do not add new call sites.
+	 * Remaining callers to migrate (do not add new call sites):
+	 *   - room-runtime-service.ts × 4  (room-tools, room-chat, workflow-chat injection)
+	 *   - neo-agent-manager.ts × 1     (neo session bootstrap)
+	 *   - space-runtime-service.ts × 1 (space_chat session attachment)
 	 */
 	setRuntimeMcpServers(mcpServers: Record<string, McpServerConfig>): void {
 		this.session.config = {

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -666,6 +666,14 @@ export class AgentSession
 	/**
 	 * Apply runtime MCP servers to in-memory session config only.
 	 * These servers may contain non-serializable instances and must not be persisted.
+	 *
+	 * @deprecated Prefer `mergeRuntimeMcpServers` (which preserves existing entries)
+	 * plus `detachRuntimeMcpServer` (which removes a single named entry) over this
+	 * replace-all API. Using `setRuntimeMcpServers` when other subsystems have already
+	 * attached servers (e.g. `space-agent-tools`, `db-query`) silently drops those
+	 * attachments, causing "No such tool available" failures during workflow execution.
+	 *
+	 * Remaining callers are being migrated; do not add new call sites.
 	 */
 	setRuntimeMcpServers(mcpServers: Record<string, McpServerConfig>): void {
 		this.session.config = {
@@ -693,6 +701,39 @@ export class AgentSession
 				...additional,
 			},
 		};
+	}
+
+	/**
+	 * Remove a single named runtime MCP server from the in-memory session config.
+	 *
+	 * Use this alongside `mergeRuntimeMcpServers` when you need to rotate a server
+	 * (e.g. rebuild `node-agent` with a fresh closure for a new node activation).
+	 * Removing a name that is not present is a no-op.
+	 */
+	detachRuntimeMcpServer(name: string): void {
+		const existing = this.session.config?.mcpServers;
+		if (!existing || !(name in existing)) return;
+		const updated = { ...existing };
+		delete updated[name];
+		this.session.config = {
+			...this.session.config,
+			mcpServers: updated,
+		};
+	}
+
+	/**
+	 * Update only the user-managed (subprocess) MCP servers in the session config,
+	 * preserving all in-process (SDK-type) servers such as `node-agent`, `task-agent`,
+	 * `space-agent-tools`, and `db-query`.
+	 *
+	 * Call this instead of `updateConfig({ mcpServers })` from RPC handlers that handle
+	 * user-facing MCP configuration (config.mcp.update, config.mcp.addServer,
+	 * config.mcp.removeServer). Using `updateConfig` directly would replace the whole
+	 * `mcpServers` key, dropping runtime-injected in-process servers and causing
+	 * "No such tool available" failures on the next query start.
+	 */
+	async updateUserMcpServers(servers: Record<string, McpServerConfig>): Promise<void> {
+		await this.sessionConfigHandler.updateUserMcpServers(servers);
 	}
 
 	/**

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -254,13 +254,40 @@ export class QueryRunner {
 					`[${mcpServerNames.join(', ')}]` +
 					(isWorkflowSubSession ? ' (workflow sub-session)' : '')
 			);
-			if (isWorkflowSubSession && !mcpServerNames.includes('node-agent')) {
-				logger.error(
-					`QueryRunner.start(): workflow sub-session ${session.id} is MISSING the 'node-agent' MCP server. ` +
-						`Visible servers: [${mcpServerNames.join(', ')}]. ` +
-						`The agent will not be able to call mcp__node-agent__* tools (send_message, save, list_peers, etc). ` +
-						`This is a runtime injection failure — see TaskAgentManager.spawnWorkflowNodeAgentForExecution and createSubSession.`
-				);
+			// P2-6: Structured metric — detect missing required MCP servers for workflow sub-sessions.
+			// Required servers: node-agent (peer comms) and space-agent-tools (space tool surface).
+			// Emit a structured error log with joinable fields (sessionId, spaceId, context) so
+			// production monitoring can detect and alert on MCP injection failures without requiring
+			// grep-based log analysis.
+			if (isWorkflowSubSession) {
+				const requiredServers = ['node-agent', 'space-agent-tools'];
+				const missingServers = requiredServers.filter((name) => !mcpServerNames.includes(name));
+				if (missingServers.length > 0) {
+					const diagnosticPayload = {
+						event: 'workflow.mcp.missing',
+						sessionId: session.id,
+						spaceId: session.context?.spaceId,
+						sessionType: session.type,
+						missingServers,
+						presentServers: mcpServerNames,
+					};
+					logger.error(
+						`QueryRunner.start(): workflow sub-session ${session.id} is MISSING required MCP servers. ` +
+							`Missing: [${missingServers.join(', ')}]. ` +
+							`Present: [${mcpServerNames.join(', ')}]. ` +
+							`The agent will not be able to call the corresponding tools. ` +
+							`This is a runtime injection failure — see TaskAgentManager.spawnWorkflowNodeAgentForExecution, createSubSession, and rehydrateSubSession. ` +
+							`Diagnostic: ${JSON.stringify(diagnosticPayload)}`
+					);
+					// P2-7: Debug-build invariant assertion — throws in test/dev environments
+					// to surface injection regressions immediately rather than letting them
+					// silently produce "No such tool available" failures at runtime.
+					if (process.env.NODE_ENV === 'test' || process.env.NEOKAI_DEBUG_MCP_INVARIANTS === '1') {
+						throw new Error(
+							`[MCP invariant] Workflow sub-session ${session.id} is missing required MCP servers: [${missingServers.join(', ')}]`
+						);
+					}
+				}
 			}
 
 			// Apply provider env vars

--- a/packages/daemon/src/lib/agent/session-config-handler.ts
+++ b/packages/daemon/src/lib/agent/session-config-handler.ts
@@ -10,7 +10,7 @@
  * - SettingsManager recreation when workspace changes
  */
 
-import type { Session } from '@neokai/shared';
+import type { Session, McpServerConfig } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { Database } from '../../storage/database';
 import { SettingsManager } from '../settings-manager';
@@ -41,11 +41,53 @@ export class SessionConfigHandler {
 	 *
 	 * Merges the provided config updates with existing config,
 	 * persists to database, and broadcasts the update event.
+	 *
+	 * **Warning:** If `configUpdates.mcpServers` is set, the entire `mcpServers`
+	 * key is replaced — this will drop any runtime-injected in-process servers
+	 * (`node-agent`, `task-agent`, `space-agent-tools`, `db-query`).
+	 * For user-facing MCP configuration changes use `updateUserMcpServers` instead.
 	 */
 	async updateConfig(configUpdates: Partial<Session['config']>): Promise<void> {
 		const { session, db, daemonHub } = this.ctx;
 
 		session.config = { ...session.config, ...configUpdates };
+		db.updateSession(session.id, { config: session.config });
+
+		await daemonHub.emit('session.updated', {
+			sessionId: session.id,
+			source: 'config-update',
+			session: { config: session.config },
+		});
+	}
+
+	/**
+	 * Update only the user-managed (subprocess) MCP servers, preserving all
+	 * in-process (SDK-type) servers already present in the session config.
+	 *
+	 * In-process servers (`node-agent`, `task-agent`, `space-agent-tools`, `db-query`)
+	 * are identified by `server.type === 'sdk'` and are never overwritten here.
+	 * User-managed subprocess servers (`type: 'stdio' | 'sse' | 'http'`) are replaced
+	 * wholesale with the provided `servers` map.
+	 *
+	 * Persists to DB and emits a `session.updated` event like `updateConfig`.
+	 */
+	async updateUserMcpServers(servers: Record<string, McpServerConfig>): Promise<void> {
+		const { session, db, daemonHub } = this.ctx;
+
+		// Collect in-process (SDK-type) servers that must be preserved.
+		const existing = (session.config?.mcpServers ?? {}) as Record<string, McpServerConfig>;
+		const runtimeServers: Record<string, McpServerConfig> = {};
+		for (const [name, cfg] of Object.entries(existing)) {
+			// In-process servers are McpSdkServerConfigWithInstance with type === 'sdk'.
+			if ((cfg as { type?: string }).type === 'sdk') {
+				runtimeServers[name] = cfg;
+			}
+		}
+
+		// Merge: runtime servers take precedence, then user-provided subprocess servers.
+		const merged: Record<string, McpServerConfig> = { ...servers, ...runtimeServers };
+
+		session.config = { ...session.config, mcpServers: merged };
 		db.updateSession(session.id, { config: session.config });
 
 		await daemonHub.emit('session.updated', {

--- a/packages/daemon/src/lib/rpc-handlers/config-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/config-handlers.ts
@@ -391,12 +391,15 @@ export function setupConfigHandlers(
 			}
 		}
 
-		// Persist
-		const configUpdate: Partial<Session['config']> = {};
-		if (mcpServers !== undefined) configUpdate.mcpServers = mcpServers;
-		if (strictMcpConfig !== undefined) configUpdate.strictMcpConfig = strictMcpConfig;
-
-		await agentSession.updateConfig(configUpdate);
+		// Persist user-managed MCP servers via the safe merge API that preserves
+		// in-process runtime servers (node-agent, task-agent, space-agent-tools, db-query).
+		// Other config fields (strictMcpConfig) go through updateConfig as before.
+		if (mcpServers !== undefined) {
+			await agentSession.updateUserMcpServers(mcpServers);
+		}
+		if (strictMcpConfig !== undefined) {
+			await agentSession.updateConfig({ strictMcpConfig });
+		}
 
 		// Restart query if requested
 		if (restartQuery) {
@@ -430,15 +433,19 @@ export function setupConfigHandlers(
 			return { success: false, applied: false, error: validation.error };
 		}
 
-		// Merge with existing servers
+		// Merge with existing user-managed servers (subprocess/external only).
+		// Reading only the persisted (non-SDK) subset via the current in-memory config;
+		// updateUserMcpServers will preserve in-process servers on the way back in.
 		const currentConfig = agentSession.getSessionData().config;
-		const updatedServers = {
-			...currentConfig.mcpServers,
-			[name]: config,
-		};
+		const currentSubprocessServers = Object.fromEntries(
+			Object.entries(currentConfig.mcpServers ?? {}).filter(
+				([, cfg]) => (cfg as { type?: string }).type !== 'sdk'
+			)
+		);
+		const updatedServers = { ...currentSubprocessServers, [name]: config };
 
-		// Persist
-		await agentSession.updateConfig({ mcpServers: updatedServers });
+		// Persist via the safe merge API that preserves in-process runtime servers.
+		await agentSession.updateUserMcpServers(updatedServers);
 
 		// Restart if requested
 		if (restartQuery) {
@@ -466,12 +473,17 @@ export function setupConfigHandlers(
 		const agentSession = await sessionManager.getSessionAsync(sessionId);
 		if (!agentSession) throw new Error('Session not found');
 
+		// Build updated subprocess-only server map without the removed entry.
 		const currentConfig = agentSession.getSessionData().config;
-		const updatedServers = { ...currentConfig.mcpServers };
-		delete updatedServers[name];
+		const currentSubprocessServers = Object.fromEntries(
+			Object.entries(currentConfig.mcpServers ?? {}).filter(
+				([, cfg]) => (cfg as { type?: string }).type !== 'sdk'
+			)
+		);
+		delete currentSubprocessServers[name];
 
-		// Persist
-		await agentSession.updateConfig({ mcpServers: updatedServers });
+		// Persist via the safe merge API that preserves in-process runtime servers.
+		await agentSession.updateUserMcpServers(currentSubprocessServers);
 
 		// Restart if requested
 		if (restartQuery) {

--- a/packages/daemon/src/lib/rpc-handlers/config-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/config-handlers.ts
@@ -475,10 +475,19 @@ export function setupConfigHandlers(
 
 		// Build updated subprocess-only server map without the removed entry.
 		const currentConfig = agentSession.getSessionData().config;
+		const allServers = currentConfig.mcpServers ?? {};
+
+		// Reject attempts to remove in-process (SDK-type) runtime servers —
+		// they are managed by the daemon, not user configuration.
+		const targetServer = allServers[name] as { type?: string } | undefined;
+		if (targetServer && targetServer.type === 'sdk') {
+			throw new Error(
+				`Cannot remove "${name}": it is a runtime-managed in-process server and cannot be removed via config`
+			);
+		}
+
 		const currentSubprocessServers = Object.fromEntries(
-			Object.entries(currentConfig.mcpServers ?? {}).filter(
-				([, cfg]) => (cfg as { type?: string }).type !== 'sdk'
-			)
+			Object.entries(allServers).filter(([, cfg]) => (cfg as { type?: string }).type !== 'sdk')
 		);
 		delete currentSubprocessServers[name];
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -634,7 +634,11 @@ export class TaskAgentManager {
 			});
 			taskMcpServers['space-agent-tools'] = spaceAgentMcpServer as unknown as McpServerConfig;
 
-			agentSession.setRuntimeMcpServers(taskMcpServers);
+			// Use merge semantics so any servers already present (e.g. injected by a
+			// concurrent subsystem before this path runs) are preserved. In practice the
+			// session is freshly created and the map is empty, but merge is safer than
+			// the deprecated replace-all setRuntimeMcpServers.
+			agentSession.mergeRuntimeMcpServers(taskMcpServers);
 
 			// --- Persist taskAgentSessionId on the SpaceTask
 			this.config.taskRepo.updateTask(taskId, { taskAgentSessionId: sessionId });
@@ -825,11 +829,48 @@ export class TaskAgentManager {
 				workspacePath,
 				execution.workflowNodeId
 			);
+
+			// Build space-agent-tools for this sub-session so it has the same Space
+			// tool surface as the task-agent (list_peers, approve_gate, etc.). This server
+			// is NOT re-attached by SpaceRuntimeService because workflow sub-sessions are
+			// created via AgentSession.fromInit + registerSession (not SessionLifecycle
+			// which fires the `session.created` event that drives attachSpaceToolsToMemberSession).
+			//
+			// Note: onRestoreNodeAgent is not wired here because the final session ID
+			// may differ from `sessionId` in the reuse path — the callback would target
+			// the wrong session. The rehydrate path wires it correctly where the ID is known.
+			const subSessionSpaceAgentMcpServer = createSpaceAgentMcpServer({
+				spaceId: space.id,
+				runtime: this.config.spaceRuntimeService.getSharedRuntime(),
+				workflowManager: this.config.spaceWorkflowManager,
+				taskRepo: this.config.taskRepo,
+				nodeExecutionRepo: this.config.nodeExecutionRepo,
+				workflowRunRepo: this.config.workflowRunRepo,
+				taskManager: new SpaceTaskManager(
+					this.config.db.getDatabase(),
+					space.id,
+					this.config.reactiveDb
+				),
+				spaceAgentManager: this.config.spaceAgentManager,
+				taskAgentManager: this,
+				gateDataRepo: this.config.gateDataRepo,
+				daemonHub: this.config.daemonHub,
+				onGateChanged: (runId, gateId) => {
+					void this.config.spaceRuntimeService.notifyGateDataChanged(runId, gateId).catch(() => {});
+				},
+				getSpaceAutonomyLevel: async (sid) => {
+					const s = await this.config.spaceManager.getSpace(sid);
+					return s?.autonomyLevel ?? 1;
+				},
+				myAgentName: execution.agentName,
+			});
+
 			init = {
 				...init,
 				mcpServers: {
 					...init.mcpServers,
 					'node-agent': nodeAgentMcpServer as unknown as McpServerConfig,
+					'space-agent-tools': subSessionSpaceAgentMcpServer as unknown as McpServerConfig,
 				},
 			};
 
@@ -862,7 +903,7 @@ export class TaskAgentManager {
 			// This is a belt-and-braces check to prevent silent recurrence of the
 			// "No such tool available" failure mode where the Coder→Reviewer handoff
 			// died because mcp__node-agent__send_message was unregistered.
-			this.ensureNodeAgentAttached(spawned, {
+			await this.ensureNodeAgentAttached(spawned, {
 				taskId,
 				subSessionId: actualSessionId,
 				agentName: execution.agentName,
@@ -974,6 +1015,29 @@ export class TaskAgentManager {
 							}
 						}
 
+						// P1-4: Rebuild the node-agent MCP server with the new node context.
+						//
+						// When a session is reused across workflow node activations (e.g. a Coder
+						// that processes multiple review cycles), its previous `node-agent` closure
+						// captures the OLD workflowNodeId, workspaceRunId, and channel resolver.
+						// `send_message` uses workflowNodeId to resolve the "from" node — if stale,
+						// the topology check fails or routes incorrectly ("message never arrived").
+						//
+						// Re-merging with a fresh node-agent and restarting the query ensures the
+						// session's tool surface reflects the new node activation context.
+						if (memberInfo.nodeId) {
+							const reuseWorkspacePath = this.taskWorktreePaths.get(taskId) ?? init.workspacePath;
+							await this.reinjectNodeAgentMcpServer(existing, {
+								taskId,
+								subSessionId: existingSessionId,
+								agentName: memberInfo.agentName,
+								spaceId: parentTask.spaceId,
+								workflowRunId: parentTask.workflowRunId,
+								workspacePath: reuseWorkspacePath,
+								workflowNodeId: memberInfo.nodeId,
+							});
+						}
+
 						// Register a fresh completion callback for this execution turn.
 						// Clear any stale callback registered by a previous execution (e.g. from
 						// rehydrateSubSession, which registers with the old nodeId). Without this,
@@ -1034,7 +1098,11 @@ export class TaskAgentManager {
 			...init.mcpServers,
 		};
 		if (Object.keys(mergedSubSessionMcpServers).length > 0) {
-			subSession.setRuntimeMcpServers(mergedSubSessionMcpServers);
+			// Use merge semantics: the session is freshly created here so the map is
+			// empty in practice, but mergeRuntimeMcpServers is safer than the deprecated
+			// replace-all setRuntimeMcpServers because it won't clobber servers injected
+			// by a concurrent subsystem before this path runs.
+			subSession.mergeRuntimeMcpServers(mergedSubSessionMcpServers);
 		}
 
 		// Determine node ID from session convention or task context.
@@ -2224,7 +2292,40 @@ export class TaskAgentManager {
 			rehydrateMcpServers['db-query'] = rehydrateDbQueryServer as unknown as McpServerConfig;
 		}
 
-		agentSession.setRuntimeMcpServers(rehydrateMcpServers);
+		// Re-attach `space-agent-tools` so the rehydrated task agent has the same
+		// tool surface as a freshly spawned task agent. This server is not persisted to
+		// DB (see session-repository.ts) and is not re-attached by SpaceRuntimeService
+		// because rehydrated sessions do not fire the `session.created` event that the
+		// service subscribes to. Without this, the task agent cannot call list_peers /
+		// send_message / read_gate / etc. after a daemon restart.
+		const rehydrateSpaceAgentMcpServer = createSpaceAgentMcpServer({
+			spaceId,
+			runtime: this.config.spaceRuntimeService.getSharedRuntime(),
+			workflowManager: this.config.spaceWorkflowManager,
+			taskRepo: this.config.taskRepo,
+			nodeExecutionRepo: this.config.nodeExecutionRepo,
+			workflowRunRepo: this.config.workflowRunRepo,
+			taskManager,
+			spaceAgentManager: this.config.spaceAgentManager,
+			taskAgentManager: this,
+			gateDataRepo: this.config.gateDataRepo,
+			daemonHub: this.config.daemonHub,
+			onGateChanged: (runId, gateId) => {
+				void this.config.spaceRuntimeService.notifyGateDataChanged(runId, gateId).catch(() => {});
+			},
+			getSpaceAutonomyLevel: async (sid) => {
+				const s = await this.config.spaceManager.getSpace(sid);
+				return s?.autonomyLevel ?? 1;
+			},
+			myAgentName: 'task-agent',
+		});
+		rehydrateMcpServers['space-agent-tools'] =
+			rehydrateSpaceAgentMcpServer as unknown as McpServerConfig;
+
+		// Use merge semantics: the restored session has no in-memory MCP servers
+		// (they are stripped from DB persistence) so this is effectively a full set,
+		// but mergeRuntimeMcpServers is safer than the deprecated replace-all API.
+		agentSession.mergeRuntimeMcpServers(rehydrateMcpServers);
 
 		// Re-attach system prompt (runtime-only, not persisted).
 		// Generated fresh from createTaskAgentInit() so it reflects the current task/workflow state.
@@ -2357,10 +2458,70 @@ export class TaskAgentManager {
 			...registryMcpServers,
 			'node-agent': nodeAgentMcpServer as unknown as McpServerConfig,
 		};
-		agentSession.setRuntimeMcpServers(mergedMcpServers);
+
+		// Re-attach `space-agent-tools` so the rehydrated sub-session has the same
+		// tool surface as a freshly spawned one. This server is stripped from DB
+		// persistence and is NOT re-attached by SpaceRuntimeService for rehydrated
+		// sessions (which do not fire `session.created`). Without this, the sub-session
+		// loses access to read_gate / write_gate / approve_gate / etc. after a daemon
+		// restart mid-workflow.
+		const subSessionTaskManager = new SpaceTaskManager(
+			this.config.db.getDatabase(),
+			spaceId,
+			this.config.reactiveDb
+		);
+		const subSessionSpaceAgentMcpServer = createSpaceAgentMcpServer({
+			spaceId,
+			runtime: this.config.spaceRuntimeService.getSharedRuntime(),
+			workflowManager: this.config.spaceWorkflowManager,
+			taskRepo: this.config.taskRepo,
+			nodeExecutionRepo: this.config.nodeExecutionRepo,
+			workflowRunRepo: this.config.workflowRunRepo,
+			taskManager: subSessionTaskManager,
+			spaceAgentManager: this.config.spaceAgentManager,
+			taskAgentManager: this,
+			gateDataRepo: this.config.gateDataRepo,
+			daemonHub: this.config.daemonHub,
+			onGateChanged: (runId, gateId) => {
+				void this.config.spaceRuntimeService.notifyGateDataChanged(runId, gateId).catch(() => {});
+			},
+			getSpaceAutonomyLevel: async (sid) => {
+				const s = await this.config.spaceManager.getSpace(sid);
+				return s?.autonomyLevel ?? 1;
+			},
+			myAgentName: execution.agentName,
+			// P3-8: wire restore_node_agent into space-agent-tools so it is callable even
+			// when node-agent is missing. Closures capture the rehydrate-time values of
+			// taskId, subSessionId, agentName, etc. which are stable for this session.
+			onRestoreNodeAgent: async (_args) => {
+				const liveSession = this.getSubSession(subSessionId);
+				if (!liveSession) {
+					log.warn(
+						`space-agent-tools.restore_node_agent: no live session found for sub-session ${subSessionId}`
+					);
+					return;
+				}
+				await this.reinjectNodeAgentMcpServer(liveSession, {
+					taskId,
+					subSessionId,
+					agentName: execution.agentName,
+					spaceId,
+					workflowRunId,
+					workspacePath,
+					workflowNodeId: execution.workflowNodeId,
+				});
+			},
+		});
+		mergedMcpServers['space-agent-tools'] =
+			subSessionSpaceAgentMcpServer as unknown as McpServerConfig;
+
+		// Use merge semantics: the restored session has no in-memory MCP servers
+		// (stripped from DB) so this is effectively a full set, but mergeRuntimeMcpServers
+		// is safer than the deprecated replace-all setRuntimeMcpServers.
+		agentSession.mergeRuntimeMcpServers(mergedMcpServers);
 
 		// Defensive guarantee — see ensureNodeAgentAttached docs.
-		this.ensureNodeAgentAttached(agentSession, {
+		await this.ensureNodeAgentAttached(agentSession, {
 			taskId,
 			subSessionId,
 			agentName: execution.agentName,
@@ -2542,7 +2703,7 @@ export class TaskAgentManager {
 	 *   3. Re-verifies attachment; if still missing, throws — better to fail spawn
 	 *      visibly than to start an unrecoverable session.
 	 */
-	ensureNodeAgentAttached(
+	async ensureNodeAgentAttached(
 		session: AgentSession,
 		ctx: {
 			taskId: string;
@@ -2554,7 +2715,7 @@ export class TaskAgentManager {
 			workflowNodeId: string;
 			phase: 'spawn' | 'rehydrate';
 		}
-	): void {
+	): Promise<void> {
 		// `session.config` may be absent on restored ghost sessions before the first
 		// query setup, so read defensively — treat as empty servers map.
 		const currentMcpServers =
@@ -2574,7 +2735,7 @@ export class TaskAgentManager {
 				`Self-healing by re-injecting before first turn — but this indicates a regression in the spawn/rehydrate merge logic.`
 		);
 
-		this.reinjectNodeAgentMcpServer(session, ctx);
+		await this.reinjectNodeAgentMcpServer(session, ctx);
 
 		const verifyMcpServers =
 			(session.session.config?.mcpServers as Record<string, McpServerConfig> | undefined) ?? {};
@@ -2596,11 +2757,16 @@ export class TaskAgentManager {
 	 * restore primitive callable when a sub-session needs node-agent re-attached
 	 * (e.g., after a refactor regression or registry collision drops it).
 	 *
-	 * Note: `setRuntimeMcpServers` REPLACES the in-memory mcpServers map, so we
-	 * must merge with the current map to avoid dropping registry-sourced servers
-	 * that were attached at session creation.
+	 * After merging the new server, if a query is currently running the method calls
+	 * `restartQuery()` so the SDK picks up the fresh tool registry. Without the restart
+	 * the running turn keeps the old (pre-merge) tool surface and the self-heal has no
+	 * visible effect until the next turn boundary.
+	 *
+	 * `restartQuery()` is safe to call even when no query is running — it is a no-op
+	 * in that case — so calling it from `ensureNodeAgentAttached` (before `startStreamingQuery`)
+	 * is harmless.
 	 */
-	reinjectNodeAgentMcpServer(
+	async reinjectNodeAgentMcpServer(
 		session: AgentSession,
 		ctx: {
 			taskId: string;
@@ -2611,7 +2777,7 @@ export class TaskAgentManager {
 			workspacePath: string;
 			workflowNodeId: string;
 		}
-	): void {
+	): Promise<void> {
 		const nodeAgentMcpServer = this.buildNodeAgentMcpServerForSession(
 			ctx.taskId,
 			ctx.subSessionId,
@@ -2622,13 +2788,16 @@ export class TaskAgentManager {
 			ctx.workflowNodeId
 		);
 
-		const currentMcpServers =
-			(session.session.config?.mcpServers as Record<string, McpServerConfig> | undefined) ?? {};
-		const merged: Record<string, McpServerConfig> = {
-			...currentMcpServers,
+		// Use merge semantics so other runtime servers (space-agent-tools, db-query, etc.)
+		// are preserved. The deprecated setRuntimeMcpServers would clobber them.
+		session.mergeRuntimeMcpServers({
 			'node-agent': nodeAgentMcpServer as unknown as McpServerConfig,
-		};
-		session.setRuntimeMcpServers(merged);
+		});
+
+		// Restart the running query so the SDK mounts the fresh node-agent server.
+		// If no query is running this is a no-op (restartQuery returns early when
+		// messageQueue.isRunning() is false).
+		await session.restartQuery();
 	}
 
 	/**
@@ -2758,12 +2927,13 @@ export class TaskAgentManager {
 
 		// Self-heal callback for the agent-callable `restore_node_agent` tool.
 		// Looks up the live AgentSession by the enclosing-scope subSessionId, then
-		// calls reinjectNodeAgentMcpServer to (re)attach node-agent. Belt-and-braces:
+		// calls reinjectNodeAgentMcpServer to (re)attach node-agent and restart the query
+		// so the SDK mounts the fresh tool registry for the next turn. Belt-and-braces:
 		// the tool call itself is proof the server is already attached, but re-injecting
 		// protects against partial/torn registry state and emits a structured log entry
 		// for diagnosis. All identity vars (taskId, subSessionId, etc.) are `const` in
 		// the enclosing scope, so the closure captures them safely without aliasing.
-		const onRestoreNodeAgent = (args: { reason?: string }): void => {
+		const onRestoreNodeAgent = async (args: { reason?: string }): Promise<void> => {
 			const liveSession = this.getSubSession(subSessionId);
 			if (!liveSession) {
 				log.warn(
@@ -2773,7 +2943,7 @@ export class TaskAgentManager {
 				return;
 			}
 			try {
-				this.reinjectNodeAgentMcpServer(liveSession, {
+				await this.reinjectNodeAgentMcpServer(liveSession, {
 					taskId,
 					subSessionId,
 					agentName,

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -21,6 +21,7 @@
  */
 
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
+import type { SdkMcpToolDefinition } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
 import type { NodeExecution, SpaceTask, SpaceTaskStatus, SpaceTaskPriority } from '@neokai/shared';
 import type { SpaceRuntime } from '../runtime/space-runtime';
@@ -132,6 +133,18 @@ export interface SpaceAgentToolsConfig {
 	 * writer authorization.
 	 */
 	myAgentNameAliases?: string[];
+
+	/**
+	 * Optional self-heal callback exposed as the `restore_node_agent` tool.
+	 *
+	 * When provided, the tool is added to this MCP server so it remains callable
+	 * even if the `node-agent` MCP server is missing — breaking the namespace paradox
+	 * where the self-heal tool lived in the same namespace as the server it repairs.
+	 *
+	 * Wired by TaskAgentManager when building space-agent-tools for workflow sub-sessions.
+	 * Not set for task-agent or space-chat sessions (they have no node-agent to restore).
+	 */
+	onRestoreNodeAgent?: (args: { reason?: string }) => Promise<void> | void;
 }
 
 // ---------------------------------------------------------------------------
@@ -1005,7 +1018,8 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 	const handlers = createSpaceAgentToolHandlers(config);
 
-	const tools = [
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const tools: SdkMcpToolDefinition<any>[] = [
 		tool(
 			'list_workflows',
 			'Show all workflows in this space with their descriptions and steps. Call this first to understand available options before creating a task.',
@@ -1243,6 +1257,52 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 			(args) => handlers.approve_completion_action(args)
 		),
 	];
+
+	// P3-8: expose restore_node_agent in the space-agent-tools namespace so it remains
+	// callable even when the node-agent MCP server is missing. The node-agent namespace
+	// has a self-referential paradox: if node-agent is gone, restore_node_agent (which
+	// lives inside that namespace) is also gone and cannot be called. Placing a copy here
+	// breaks the dependency — space-agent-tools is always present for workflow sub-sessions
+	// (attached both at spawn and rehydrate, independent of node-agent health).
+	if (config.onRestoreNodeAgent) {
+		const restoreCallback = config.onRestoreNodeAgent;
+		tools.push(
+			tool(
+				'restore_node_agent',
+				'Self-heal tool: re-attaches the node-agent MCP server for this session and restarts ' +
+					'the query so the new tool surface takes effect. Call this if a previous ' +
+					'mcp__node-agent__send_message or similar call returned "No such tool available". ' +
+					'The tool restarts your current turn — retry the failed tool call afterwards.',
+				{
+					reason: z
+						.string()
+						.optional()
+						.describe('Brief explanation of why you are calling this tool'),
+				},
+				async (args) => {
+					try {
+						await restoreCallback({ reason: args.reason });
+					} catch {
+						// Log but don't surface the error to the agent — the query restart
+						// may interrupt this response before we can return anyway.
+					}
+					return {
+						content: [
+							{
+								type: 'text' as const,
+								text: JSON.stringify({
+									success: true,
+									message:
+										'node-agent MCP server re-attached and query restarted. ' +
+										'Your current turn will be interrupted — retry the failed tool call in the next turn.',
+								}),
+							},
+						],
+					};
+				}
+			)
+		);
+	}
 
 	return createSdkMcpServer({ name: 'space-agent', tools });
 }

--- a/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
@@ -2349,6 +2349,161 @@ describe('AgentSession', () => {
 		});
 	});
 
+	describe('detachRuntimeMcpServer', () => {
+		const makeMockSession = (existingServers?: Record<string, unknown>): Session => ({
+			id: 'space:worker:test',
+			title: 'Space Worker',
+			workspacePath: '/test/workspace',
+			createdAt: new Date().toISOString(),
+			lastActiveAt: new Date().toISOString(),
+			status: 'active',
+			config: {
+				model: 'claude-sonnet-4-5-20250929',
+				maxTokens: 8192,
+				temperature: 1.0,
+				mcpServers: existingServers as Record<string, McpServerConfig> | undefined,
+			},
+			metadata: {
+				messageCount: 0,
+				totalTokens: 0,
+				inputTokens: 0,
+				outputTokens: 0,
+				totalCost: 0,
+				toolCallCount: 0,
+			},
+			type: 'general',
+		});
+
+		const makeMocks = () => {
+			const mockDb = {
+				getSession: mock(() => null),
+				createSession: mock(() => {}),
+				updateSession: mock(() => {}),
+				getMessagesByStatus: mock(() => []),
+			} as unknown as Database;
+			const mockMessageHub = {} as MessageHub;
+			const mockDaemonHub = {
+				emit: mock(async () => {}),
+				on: mock(() => mock(() => {})),
+			} as unknown as DaemonHub;
+			const mockGetApiKey = mock(async () => 'test-api-key');
+			return { mockDb, mockMessageHub, mockDaemonHub, mockGetApiKey };
+		};
+
+		it('should remove the named server from mcpServers', () => {
+			const existing = {
+				'node-agent': { type: 'sdk' } as unknown as McpServerConfig,
+				'space-agent-tools': { type: 'sdk' } as unknown as McpServerConfig,
+			};
+			const mockSession = makeMockSession(existing);
+			const { mockDb, mockMessageHub, mockDaemonHub, mockGetApiKey } = makeMocks();
+
+			const agentSession = new AgentSession(
+				mockSession,
+				mockDb,
+				mockMessageHub,
+				mockDaemonHub,
+				mockGetApiKey
+			);
+
+			agentSession.detachRuntimeMcpServer('node-agent');
+
+			const servers = agentSession.getSessionData().config.mcpServers;
+			expect(servers?.['node-agent']).toBeUndefined();
+			// Other server must survive
+			expect(servers?.['space-agent-tools']).toBe(existing['space-agent-tools']);
+		});
+
+		it('should be a no-op when name is not present', () => {
+			const existing = {
+				'space-agent-tools': { type: 'sdk' } as unknown as McpServerConfig,
+			};
+			const mockSession = makeMockSession(existing);
+			const { mockDb, mockMessageHub, mockDaemonHub, mockGetApiKey } = makeMocks();
+
+			const agentSession = new AgentSession(
+				mockSession,
+				mockDb,
+				mockMessageHub,
+				mockDaemonHub,
+				mockGetApiKey
+			);
+
+			// Should not throw
+			agentSession.detachRuntimeMcpServer('node-agent');
+
+			const servers = agentSession.getSessionData().config.mcpServers;
+			expect(servers?.['space-agent-tools']).toBe(existing['space-agent-tools']);
+		});
+
+		it('should be a no-op when mcpServers is not defined', () => {
+			const mockSession = makeMockSession(); // no existing servers
+			const { mockDb, mockMessageHub, mockDaemonHub, mockGetApiKey } = makeMocks();
+
+			const agentSession = new AgentSession(
+				mockSession,
+				mockDb,
+				mockMessageHub,
+				mockDaemonHub,
+				mockGetApiKey
+			);
+
+			// Should not throw even with no mcpServers key at all
+			expect(() => agentSession.detachRuntimeMcpServer('node-agent')).not.toThrow();
+		});
+
+		it('should not persist the removal to the database', () => {
+			const existing = {
+				'node-agent': { type: 'sdk' } as unknown as McpServerConfig,
+			};
+			const mockSession = makeMockSession(existing);
+			const { mockDb, mockMessageHub, mockDaemonHub, mockGetApiKey } = makeMocks();
+
+			const agentSession = new AgentSession(
+				mockSession,
+				mockDb,
+				mockMessageHub,
+				mockDaemonHub,
+				mockGetApiKey
+			);
+
+			agentSession.detachRuntimeMcpServer('node-agent');
+
+			const updateSessionCalls = (mockDb as unknown as { updateSession: ReturnType<typeof mock> })
+				.updateSession.mock.calls;
+			expect(updateSessionCalls.length).toBe(0);
+		});
+
+		it('supports rotate pattern: detach then merge a replacement', () => {
+			const staleNodeAgent = { type: 'sdk', tag: 'stale' } as unknown as McpServerConfig;
+			const existing = {
+				'node-agent': staleNodeAgent,
+				'space-agent-tools': { type: 'sdk' } as unknown as McpServerConfig,
+			};
+			const mockSession = makeMockSession(existing);
+			const { mockDb, mockMessageHub, mockDaemonHub, mockGetApiKey } = makeMocks();
+
+			const agentSession = new AgentSession(
+				mockSession,
+				mockDb,
+				mockMessageHub,
+				mockDaemonHub,
+				mockGetApiKey
+			);
+
+			const freshNodeAgent = { type: 'sdk', tag: 'fresh' } as unknown as McpServerConfig;
+			agentSession.detachRuntimeMcpServer('node-agent');
+			agentSession.mergeRuntimeMcpServers({ 'node-agent': freshNodeAgent });
+
+			const servers = agentSession.getSessionData().config.mcpServers;
+			// Fresh server replaces stale one
+			expect(servers?.['node-agent']).toBe(freshNodeAgent);
+			expect(servers?.['node-agent']).not.toBe(staleNodeAgent);
+			// Unrelated server is untouched
+			expect(servers?.['space-agent-tools']).toBe(existing['space-agent-tools']);
+		});
+	});
+
 	describe('startupTimeoutTimer', () => {
 		let mockSession: Session;
 		let mockDb: Database;

--- a/packages/daemon/tests/unit/1-core/agent/session-config-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/session-config-handler.test.ts
@@ -200,4 +200,101 @@ describe('SessionConfigHandler', () => {
 			expect(ctx.ctx.settingsManager).toBeInstanceOf(SettingsManager);
 		});
 	});
+
+	describe('updateUserMcpServers', () => {
+		it('should replace subprocess servers with new map', async () => {
+			mockSession.config = {
+				model: 'default',
+				mcpServers: {
+					'my-tool': { type: 'stdio', command: 'old', args: [] },
+				},
+			} as unknown as Session['config'];
+
+			await handler.updateUserMcpServers({
+				'my-tool': { type: 'stdio', command: 'new', args: [] },
+			});
+
+			expect((mockSession.config.mcpServers as Record<string, unknown>)['my-tool']).toMatchObject({
+				command: 'new',
+			});
+		});
+
+		it('should preserve in-process (SDK-type) servers from existing config', async () => {
+			mockSession.config = {
+				model: 'default',
+				mcpServers: {
+					'node-agent': { type: 'sdk' } as unknown,
+					'space-agent-tools': { type: 'sdk' } as unknown,
+					'my-user-tool': { type: 'stdio', command: 'some-cmd', args: [] },
+				},
+			} as unknown as Session['config'];
+
+			// Provide only the subprocess server; SDK servers must survive.
+			await handler.updateUserMcpServers({
+				'my-user-tool': { type: 'stdio', command: 'some-cmd', args: [] },
+			});
+
+			const servers = mockSession.config.mcpServers as Record<string, unknown>;
+			expect(servers['node-agent']).toEqual({ type: 'sdk' });
+			expect(servers['space-agent-tools']).toEqual({ type: 'sdk' });
+			expect(servers['my-user-tool']).toMatchObject({ command: 'some-cmd' });
+		});
+
+		it('should not allow user-provided servers to overwrite SDK-type servers', async () => {
+			mockSession.config = {
+				model: 'default',
+				mcpServers: {
+					'node-agent': { type: 'sdk', secret: 'closure-value' } as unknown,
+				},
+			} as unknown as Session['config'];
+
+			// Attacker tries to overwrite the runtime node-agent with a subprocess.
+			await handler.updateUserMcpServers({
+				'node-agent': { type: 'stdio', command: 'evil', args: [] },
+			});
+
+			const servers = mockSession.config.mcpServers as Record<string, unknown>;
+			// Runtime SDK server must win.
+			expect((servers['node-agent'] as { type: string }).type).toBe('sdk');
+		});
+
+		it('should persist merged config to database', async () => {
+			mockSession.config = {
+				model: 'default',
+				mcpServers: { 'sdk-server': { type: 'sdk' } as unknown },
+			} as unknown as Session['config'];
+
+			await handler.updateUserMcpServers({
+				'user-server': { type: 'stdio', command: 'cmd', args: [] },
+			});
+
+			expect(updateSessionSpy).toHaveBeenCalledTimes(1);
+			const [, patch] = updateSessionSpy.mock.calls[0] as [string, { config: unknown }];
+			const servers = (patch.config as { mcpServers: Record<string, unknown> }).mcpServers;
+			expect(servers['sdk-server']).toBeDefined();
+			expect(servers['user-server']).toBeDefined();
+		});
+
+		it('should emit session.updated event after persisting', async () => {
+			await handler.updateUserMcpServers({
+				'user-server': { type: 'stdio', command: 'cmd', args: [] },
+			});
+
+			expect(emitSpy).toHaveBeenCalledTimes(1);
+			const [event, payload] = emitSpy.mock.calls[0] as [string, { source: string }];
+			expect(event).toBe('session.updated');
+			expect(payload.source).toBe('config-update');
+		});
+
+		it('should work when session has no existing mcpServers', async () => {
+			mockSession.config = { model: 'default' } as Session['config'];
+
+			await handler.updateUserMcpServers({
+				'my-tool': { type: 'stdio', command: 'cmd', args: [] },
+			});
+
+			const servers = mockSession.config.mcpServers as Record<string, unknown>;
+			expect(servers['my-tool']).toBeDefined();
+		});
+	});
 });

--- a/packages/daemon/tests/unit/2-handlers/rpc/config-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc/config-handlers.test.ts
@@ -116,6 +116,7 @@ function createMockAgentSession(configOverrides: Partial<Session['config']> = {}
 		setMaxThinkingTokens: ReturnType<typeof mock>;
 		setPermissionMode: ReturnType<typeof mock>;
 		updateConfig: ReturnType<typeof mock>;
+		updateUserMcpServers: ReturnType<typeof mock>;
 		resetQuery: ReturnType<typeof mock>;
 		getMcpServerStatus: ReturnType<typeof mock>;
 	};
@@ -128,6 +129,7 @@ function createMockAgentSession(configOverrides: Partial<Session['config']> = {}
 		setMaxThinkingTokens: mock(async () => ({ success: true })),
 		setPermissionMode: mock(async () => ({ success: true })),
 		updateConfig: mock(async () => {}),
+		updateUserMcpServers: mock(async () => {}),
 		resetQuery: mock(async () => ({ success: true })),
 		getMcpServerStatus: mock(async () => ({})),
 	};

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-mcp.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-mcp.test.ts
@@ -4,7 +4,7 @@
  *
  * Verifies that:
  * 1. Task agent sessions receive registry-sourced MCP servers merged into their
- *    setRuntimeMcpServers() call alongside the in-process task-agent server.
+ *    mergeRuntimeMcpServers() call alongside the in-process task-agent server.
  * 2. The in-process task-agent server always takes precedence over registry entries
  *    on name collision.
  * 3. The merged map is complete — registry entries are not dropped.
@@ -72,6 +72,9 @@ interface MockAgentSession {
 	session: { id: string; config: { mcpServers?: Record<string, unknown> } };
 	getProcessingState: () => AgentProcessingState;
 	setRuntimeMcpServers: (servers: Record<string, unknown>) => void;
+	mergeRuntimeMcpServers: (servers: Record<string, unknown>) => void;
+	detachRuntimeMcpServer: (name: string) => void;
+	restartQuery: () => Promise<void>;
 	setRuntimeSystemPrompt: (sp: unknown) => void;
 	startStreamingQuery: () => Promise<void>;
 	ensureQueryStarted: () => Promise<void>;
@@ -93,6 +96,24 @@ function makeMockSession(sessionId: string): MockAgentSession {
 			// merged map after spawn / self-heal.
 			m.session.config = { ...m.session.config, mcpServers: servers };
 		},
+		mergeRuntimeMcpServers(servers) {
+			// Merge into existing map (additive, not replace).
+			// Use config.mcpServers as the source of truth so that servers set directly
+			// on session.config (e.g. by test setup) are not lost.
+			const existing = m.session.config.mcpServers ?? {};
+			const merged = { ...existing, ...servers };
+			m._mcpServers = merged;
+			m.session.config = { ...m.session.config, mcpServers: merged };
+		},
+		detachRuntimeMcpServer(name) {
+			const updated = { ...m._mcpServers };
+			delete updated[name];
+			m._mcpServers = updated;
+			const updatedCfg = { ...(m.session.config.mcpServers ?? {}) };
+			delete updatedCfg[name];
+			m.session.config = { ...m.session.config, mcpServers: updatedCfg };
+		},
+		async restartQuery() {},
 		setRuntimeSystemPrompt(_sp: unknown) {},
 		async startStreamingQuery() {},
 		async ensureQueryStarted() {},
@@ -832,7 +853,7 @@ describe('TaskAgentManager — skills injection into sub-sessions (G2)', () => {
 		expect(args!.appMcpServerRepo).toBe(mockAppMcpServerRepo);
 	});
 
-	test('sub-session receives registry MCPs via setRuntimeMcpServers()', async () => {
+	test('sub-session receives registry MCPs via mergeRuntimeMcpServers()', async () => {
 		const registryServer: McpServerConfig = { type: 'stdio', command: 'registry-cmd' };
 		const { manager, fromInitSpy, createdSessions } = buildManager({
 			registryMcpServers: { 'registry-mcp': registryServer },
@@ -871,7 +892,7 @@ describe('TaskAgentManager — skills injection into sub-sessions (G2)', () => {
 
 		const subSession = createdSessions.get(subSessionId);
 		expect(subSession).toBeDefined();
-		// No registry MCPs — _mcpServers should be empty (no setRuntimeMcpServers called with entries)
+		// No registry MCPs — _mcpServers should be empty (no mergeRuntimeMcpServers called with entries)
 		expect(Object.keys(subSession!._mcpServers)).toHaveLength(0);
 	});
 });

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
@@ -75,6 +75,9 @@ interface MockAgentSession {
 	getSDKMessageCount: () => number;
 	getSessionData: () => { id: string; context?: Record<string, unknown> };
 	setRuntimeMcpServers: (servers: Record<string, unknown>) => void;
+	mergeRuntimeMcpServers: (servers: Record<string, unknown>) => void;
+	detachRuntimeMcpServer: (name: string) => void;
+	restartQuery: () => Promise<void>;
 	setRuntimeSystemPrompt: (systemPrompt: unknown) => void;
 	startStreamingQuery: () => Promise<void>;
 	ensureQueryStarted: () => Promise<void>;
@@ -115,6 +118,22 @@ function makeMockSession(sessionId: string): MockAgentSession {
 			// `session.config.mcpServers` invariant check sees the merged map.
 			this.session.config = { ...this.session.config, mcpServers: servers };
 		},
+		mergeRuntimeMcpServers(servers) {
+			this._mcpServers = { ...this._mcpServers, ...servers };
+			this.session.config = {
+				...this.session.config,
+				mcpServers: { ...(this.session.config.mcpServers ?? {}), ...servers },
+			};
+		},
+		detachRuntimeMcpServer(name) {
+			const updated = { ...this._mcpServers };
+			delete updated[name];
+			this._mcpServers = updated;
+			const updatedCfg = { ...(this.session.config.mcpServers ?? {}) };
+			delete updatedCfg[name];
+			this.session.config = { ...this.session.config, mcpServers: updatedCfg };
+		},
+		async restartQuery() {},
 		setRuntimeSystemPrompt(_sp: unknown) {},
 		async startStreamingQuery() {
 			this._startCalled = true;

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-worktree.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-worktree.test.ts
@@ -77,11 +77,18 @@ class TestDaemonHub {
 // ---------------------------------------------------------------------------
 
 interface MockAgentSession {
-	session: { id: string; context?: Record<string, unknown> };
+	session: {
+		id: string;
+		context?: Record<string, unknown>;
+		config?: { mcpServers?: Record<string, unknown> };
+	};
 	getProcessingState: () => AgentProcessingState;
 	getSDKMessageCount: () => number;
 	getSessionData: () => { id: string; context?: Record<string, unknown> };
 	setRuntimeMcpServers: (servers: Record<string, unknown>) => void;
+	mergeRuntimeMcpServers: (servers: Record<string, unknown>) => void;
+	detachRuntimeMcpServer: (name: string) => void;
+	restartQuery: () => Promise<void>;
 	setRuntimeSystemPrompt: (systemPrompt: unknown) => void;
 	startStreamingQuery: () => Promise<void>;
 	ensureQueryStarted: () => Promise<void>;
@@ -122,6 +129,22 @@ function makeMockSession(
 		setRuntimeMcpServers(servers) {
 			this._mcpServers = servers;
 		},
+		mergeRuntimeMcpServers(servers) {
+			this._mcpServers = { ...this._mcpServers, ...servers };
+			this.session.config = {
+				...(this.session.config ?? {}),
+				mcpServers: { ...(this.session.config?.mcpServers ?? {}), ...servers },
+			};
+		},
+		detachRuntimeMcpServer(name) {
+			const updated = { ...this._mcpServers };
+			delete updated[name];
+			this._mcpServers = updated;
+			const updatedCfg = { ...(this.session.config?.mcpServers ?? {}) };
+			delete updatedCfg[name];
+			this.session.config = { ...(this.session.config ?? {}), mcpServers: updatedCfg };
+		},
+		async restartQuery() {},
 		setRuntimeSystemPrompt(_systemPrompt: unknown) {},
 		async startStreamingQuery() {
 			this._startCalled = true;

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
@@ -1068,10 +1068,17 @@ describe('TaskAgentManager', () => {
 			const stepId = 'step-complete-1';
 			ctx.bunDb
 				.prepare(
-					`INSERT INTO space_workflow_nodes (id, workflow_id, name, description, created_at, updated_at)
-           VALUES (?, ?, ?, '', ?, ?)`
+					`INSERT INTO space_workflow_nodes (id, workflow_id, name, description, config, created_at, updated_at)
+           VALUES (?, ?, ?, '', ?, ?, ?)`
 				)
-				.run(stepId, wfId, 'Step 1', now, now);
+				.run(
+					stepId,
+					wfId,
+					'Step 1',
+					JSON.stringify({ agents: [{ agentId: ctx.agentId, name: 'coder' }] }),
+					now,
+					now
+				);
 			ctx.bunDb
 				.prepare(
 					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at, updated_at)

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
@@ -81,11 +81,18 @@ class TestDaemonHub {
 // ---------------------------------------------------------------------------
 
 interface MockAgentSession {
-	session: { id: string; context?: Record<string, unknown> };
+	session: {
+		id: string;
+		context?: Record<string, unknown>;
+		config?: { mcpServers?: Record<string, unknown> };
+	};
 	getProcessingState: () => AgentProcessingState;
 	getSDKMessageCount: () => number;
 	getSessionData: () => { id: string; context?: Record<string, unknown> };
 	setRuntimeMcpServers: (servers: Record<string, unknown>) => void;
+	mergeRuntimeMcpServers: (servers: Record<string, unknown>) => void;
+	detachRuntimeMcpServer: (name: string) => void;
+	restartQuery: () => Promise<void>;
 	setRuntimeSystemPrompt: (systemPrompt: unknown) => void;
 	startStreamingQuery: () => Promise<void>;
 	ensureQueryStarted: () => Promise<void>;
@@ -126,6 +133,22 @@ function makeMockSession(
 		setRuntimeMcpServers(servers) {
 			this._mcpServers = servers;
 		},
+		mergeRuntimeMcpServers(servers) {
+			this._mcpServers = { ...this._mcpServers, ...servers };
+			this.session.config = {
+				...(this.session.config ?? {}),
+				mcpServers: { ...(this.session.config?.mcpServers ?? {}), ...servers },
+			};
+		},
+		detachRuntimeMcpServer(name) {
+			const updated = { ...this._mcpServers };
+			delete updated[name];
+			this._mcpServers = updated;
+			const updatedCfg = { ...(this.session.config?.mcpServers ?? {}) };
+			delete updatedCfg[name];
+			this.session.config = { ...(this.session.config ?? {}), mcpServers: updatedCfg };
+		},
+		async restartQuery() {},
 		setRuntimeSystemPrompt(_systemPrompt: unknown) {},
 		async startStreamingQuery() {
 			this._startCalled = true;
@@ -697,10 +720,17 @@ describe('TaskAgentManager', () => {
 			const stepId = 'step-reuse-1';
 			ctx.bunDb
 				.prepare(
-					`INSERT INTO space_workflow_nodes (id, workflow_id, name, description, created_at, updated_at)
-         VALUES (?, ?, ?, '', ?, ?)`
+					`INSERT INTO space_workflow_nodes (id, workflow_id, name, description, config, created_at, updated_at)
+         VALUES (?, ?, ?, '', ?, ?, ?)`
 				)
-				.run(stepId, wfId, 'Step 1', now, now);
+				.run(
+					stepId,
+					wfId,
+					'Step 1',
+					JSON.stringify({ agents: [{ agentId: ctx.agentId, name: 'coder' }] }),
+					now,
+					now
+				);
 			ctx.bunDb
 				.prepare(
 					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at, updated_at)
@@ -777,10 +807,17 @@ describe('TaskAgentManager', () => {
 			const stepId = 'step-cb-clear';
 			ctx.bunDb
 				.prepare(
-					`INSERT INTO space_workflow_nodes (id, workflow_id, name, description, created_at, updated_at)
-         VALUES (?, ?, ?, '', ?, ?)`
+					`INSERT INTO space_workflow_nodes (id, workflow_id, name, description, config, created_at, updated_at)
+         VALUES (?, ?, ?, '', ?, ?, ?)`
 				)
-				.run(stepId, wfId, 'Step CB', now, now);
+				.run(
+					stepId,
+					wfId,
+					'Step CB',
+					JSON.stringify({ agents: [{ agentId: ctx.agentId, name: 'coder' }] }),
+					now,
+					now
+				);
 			ctx.bunDb
 				.prepare(
 					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at, updated_at)

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-session-lifecycle.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-session-lifecycle.test.ts
@@ -74,11 +74,18 @@ class TestDaemonHub {
 // ---------------------------------------------------------------------------
 
 interface MockAgentSession {
-	session: { id: string; context?: Record<string, unknown> };
+	session: {
+		id: string;
+		context?: Record<string, unknown>;
+		config?: { mcpServers?: Record<string, unknown> };
+	};
 	getProcessingState: () => AgentProcessingState;
 	getSDKMessageCount: () => number;
 	getSessionData: () => { id: string; context?: Record<string, unknown> };
 	setRuntimeMcpServers: (servers: Record<string, unknown>) => void;
+	mergeRuntimeMcpServers: (servers: Record<string, unknown>) => void;
+	detachRuntimeMcpServer: (name: string) => void;
+	restartQuery: () => Promise<void>;
 	setRuntimeSystemPrompt: (systemPrompt: unknown) => void;
 	startStreamingQuery: () => Promise<void>;
 	ensureQueryStarted: () => Promise<void>;
@@ -118,6 +125,22 @@ function makeMockSession(
 		setRuntimeMcpServers(servers) {
 			this._mcpServers = servers;
 		},
+		mergeRuntimeMcpServers(servers) {
+			this._mcpServers = { ...this._mcpServers, ...servers };
+			this.session.config = {
+				...(this.session.config ?? {}),
+				mcpServers: { ...(this.session.config?.mcpServers ?? {}), ...servers },
+			};
+		},
+		detachRuntimeMcpServer(name) {
+			const updated = { ...this._mcpServers };
+			delete updated[name];
+			this._mcpServers = updated;
+			const updatedCfg = { ...(this.session.config?.mcpServers ?? {}) };
+			delete updatedCfg[name];
+			this.session.config = { ...(this.session.config ?? {}), mcpServers: updatedCfg };
+		},
+		async restartQuery() {},
 		setRuntimeSystemPrompt(_systemPrompt: unknown) {},
 		async startStreamingQuery() {
 			this._startCalled = true;


### PR DESCRIPTION
Adds `mergeRuntimeMcpServers`, `detachRuntimeMcpServer`, and `restartQuery` to `AgentSession` so `TaskAgentManager` can attach/refresh MCP tools additively without clobbering other runtime servers (space-agent-tools, db-query, etc.).

- `reinjectNodeAgentMcpServer` now uses `mergeRuntimeMcpServers` + `restartQuery` so the SDK picks up the fresh node-agent tool registry on self-heal
- Updates 5 task-agent-manager test files to implement the new mock interface methods
- Fixes 2 raw SQL workflow-node seeds that were missing agents config (causing `resolveNodeAgents` to throw on reinject)