### PR TITLE
chore(release): bump version to 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to NeoKai will be documented in this file.
 
+## [0.11.0] - 2026-04-22
+
+A refinement release improving workflow reliability, artifact display, and communication resilience. 15 commits since v0.10.0.
+
+### Added
+
+**Space Workflow System**
+- **Stacked PR task chain**: Plan & Decompose workflow generates ordered tasks with branch name, base branch, and dependency instructions for bottom-up PR chains
+- **Data-driven artifact rendering**: Worktree commit display for artifacts
+- **Unified save_artifact tool**: Consolidated `save`, `write_artifact`, and `report_result` into one tool
+- **Clickable overview stat cards**: Navigate to tasks page from overview stats
+
+**Frontend & UI**
+- **Compact approval banners**: One-line + modal pattern replaces inline banners
+
+### Fixed
+
+- **Node-agent MCP tools**: Restored in workflow sessions after daemon restart; auto-resume idle sessions when messages are queued
+- **Gate scripts**: Resolved from live templates instead of stale DB rows; startup drift warnings added
+- **Communication**: `list_peers` shows topology peers; `send_message` queues for inactive nodes instead of failing
+- **db-query MCP**: Exposed `space_sessions` and `sdk_messages` in space scope
+
 ## [0.10.0] - 2026-04-21
 
 A focused release hardening the Space Workflow System for production use — autonomy enforcement, completion pipelines, workflow template sync, and significant UI polish. 76 commits since v0.9.0.

--- a/npm/neokai/package.json
+++ b/npm/neokai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neokai",
-	"version": "0.10.0",
+	"version": "0.11.0",
 	"description": "NeoKai - Claude Agent SDK Web Interface",
 	"bin": {
 		"kai": "bin/kai.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/cli",
-	"version": "0.10.0",
+	"version": "0.11.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"bin": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/daemon",
-	"version": "0.10.0",
+	"version": "0.11.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "main.ts",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/e2e",
-	"version": "0.10.0",
+	"version": "0.11.0",
 	"private": true,
 	"license": "Apache-2.0",
 	"type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/shared",
-	"version": "0.10.0",
+	"version": "0.11.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "src/mod.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/ui",
-	"version": "0.10.0",
+	"version": "0.11.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "src/mod.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/web",
-	"version": "0.10.0",
+	"version": "0.11.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"scripts": {


### PR DESCRIPTION
## Summary
- Bump version from 0.10.0 to 0.11.0 across all 7 package.json files
- Add CHANGELOG.md entry for v0.11.0

## Next steps
1. Merge this PR to dev
2. Tag: `git tag v0.11.0` on the merge commit
3. Push tag: `git push origin v0.11.0` to trigger the release pipeline