### PR TITLE
feat(space): move task status actions from inline bar to dropdown menu

### DIFF
--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -12,7 +12,7 @@ import { cn } from '../../lib/utils';
 import { borderColors } from '../../lib/design-tokens';
 import { SpaceTaskUnifiedThread } from './SpaceTaskUnifiedThread';
 import { TaskArtifactsPanel } from './TaskArtifactsPanel';
-import { getTransitionActions, TaskStatusActions } from './TaskStatusActions';
+import { getTransitionActions } from './TaskStatusActions';
 import { TaskBlockedBanner } from './TaskBlockedBanner';
 import { PendingGateBanner } from './PendingGateBanner';
 import { PendingCompletionActionBanner } from './PendingCompletionActionBanner';
@@ -163,7 +163,6 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	const canShowCanvasTab = !!task.workflowRunId && !!canvasWorkflowId;
 	const canShowArtifactsTab = !!task.workflowRunId;
 	const activitySummary = STATUS_LABELS[task.status];
-	const transitionActions = getTransitionActions(task.status);
 	const agentActionLabel =
 		task.activeSession === 'leader'
 			? 'View Leader Session'
@@ -246,6 +245,14 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 		}
 	};
 
+	const allTransitionActions = getTransitionActions(task.status);
+	const filteredTransitionActions =
+		task.pendingCheckpointType === 'completion_action' ||
+		task.pendingCheckpointType === 'task_completion' ||
+		task.pendingCheckpointType === 'gate'
+			? allTransitionActions.filter(({ target }) => target !== 'done' && target !== 'cancelled')
+			: allTransitionActions;
+
 	const taskActionItems: DropdownMenuItem[] = [];
 	if (activityMembers.length > 0) {
 		taskActionItems.push(
@@ -257,8 +264,21 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 			}))
 		);
 	}
-	// Status transition actions are rendered inline (TaskStatusActions) rather
-	// than in the dropdown, so they're always visible without an extra click.
+	if (filteredTransitionActions.length > 0) {
+		if (taskActionItems.length > 0) {
+			taskActionItems.push({ type: 'divider' as const });
+		}
+		taskActionItems.push(
+			...filteredTransitionActions.map(({ target, label }) => ({
+				label,
+				onClick: () => {
+					handleStatusTransition(target);
+				},
+				disabled: statusTransitioning,
+				danger: target === 'cancelled' || target === 'archived',
+			}))
+		);
+	}
 
 	return (
 		<div class="flex flex-col h-full overflow-hidden bg-dark-900">
@@ -316,17 +336,6 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 					)}
 				</div>
 			</div>
-
-			{transitionActions.length > 0 && (
-				<div class="px-4 pb-2 flex-shrink-0">
-					<TaskStatusActions
-						status={task.status}
-						onTransition={handleStatusTransition}
-						disabled={statusTransitioning}
-						pendingCheckpointType={task.pendingCheckpointType}
-					/>
-				</div>
-			)}
 
 			<div class="px-4 pb-2 flex-shrink-0 flex justify-center">
 				<div class="flex items-center gap-1 rounded-3xl border border-dark-700 bg-dark-800/60 p-1 backdrop-blur-sm">

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -782,12 +782,70 @@ describe('SpaceTaskPane — activity members actions', () => {
 		cleanup();
 	});
 
-	it('does not show activity member actions when no activity members exist', () => {
-		mockTasks.value = [makeTask({ taskAgentSessionId: 'session-abc' })];
+	it('does not show dropdown when task is archived and has no activity members', () => {
+		mockTasks.value = [makeTask({ status: 'archived', taskAgentSessionId: 'session-abc' })];
 		const { queryByTestId, queryByText } = render(<SpaceTaskPane taskId="task-1" />);
-		// No activity members → dropdown trigger is not rendered
+		// archived has no valid transitions and no activity members → dropdown trigger is not rendered
 		expect(queryByTestId('task-actions-menu-trigger')).toBeNull();
 		expect(queryByText('Open Task Agent (Active)')).toBeNull();
+	});
+
+	it('shows dropdown trigger when no activity members but task has valid transitions', () => {
+		mockTasks.value = [makeTask({ status: 'open', taskAgentSessionId: 'session-abc' })];
+		const { getByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+		// open has transitions → dropdown is visible even with no activity members
+		expect(getByTestId('task-actions-menu-trigger')).toBeTruthy();
+	});
+
+	it('shows status transition actions in dropdown', () => {
+		mockTasks.value = [makeTask({ status: 'done', taskAgentSessionId: 'session-abc' })];
+		const { getByTestId, getByText } = render(<SpaceTaskPane taskId="task-1" />);
+		fireEvent.click(getByTestId('task-actions-menu-trigger'));
+		// done → in_progress = 'Reopen', done → archived = 'Archive'
+		expect(getByText('Reopen')).toBeTruthy();
+		expect(getByText('Archive')).toBeTruthy();
+	});
+
+	it('calls updateTask when a transition action is clicked in the dropdown', async () => {
+		mockTasks.value = [makeTask({ status: 'done', taskAgentSessionId: 'session-abc' })];
+		const { getByTestId, getByText } = render(<SpaceTaskPane taskId="task-1" />);
+		fireEvent.click(getByTestId('task-actions-menu-trigger'));
+		fireEvent.click(getByText('Reopen'));
+		await waitFor(() =>
+			expect(mockUpdateTask).toHaveBeenCalledWith('task-1', { status: 'in_progress' })
+		);
+	});
+
+	it('shows divider between activity members and transition actions', () => {
+		mockTasks.value = [makeTask({ status: 'done', taskAgentSessionId: 'session-abc' })];
+		mockTaskActivity.value = new Map([
+			['task-1', [makeActivityMember({ id: 'm1', label: 'Task Agent', state: 'active' })]],
+		]);
+		const { getByTestId, container } = render(<SpaceTaskPane taskId="task-1" />);
+		fireEvent.click(getByTestId('task-actions-menu-trigger'));
+		const dividers = container.querySelectorAll('.h-px.bg-dark-700');
+		expect(dividers.length).toBeGreaterThan(0);
+	});
+
+	it('hides done and cancelled transitions when pendingCheckpointType is task_completion', () => {
+		mockTasks.value = [
+			makeTask({
+				status: 'review',
+				pendingCheckpointType: 'task_completion',
+				taskAgentSessionId: 'session-abc',
+			}),
+		];
+		const { getByTestId, getByRole } = render(<SpaceTaskPane taskId="task-1" />);
+		fireEvent.click(getByTestId('task-actions-menu-trigger'));
+		// Scope assertions to the dropdown menu to avoid false positives from the
+		// PendingTaskCompletionBanner which also renders an "Approve" button.
+		const menu = getByRole('menu');
+		// done (Approve) and cancelled (Cancel) are owned by the banner when pendingCheckpointType is set
+		expect(menu.textContent).not.toContain('Approve');
+		expect(menu.textContent).not.toContain('Cancel');
+		// non-approval transitions stay visible in the dropdown
+		expect(menu.textContent).toContain('Reopen');
+		expect(menu.textContent).toContain('Archive');
 	});
 
 	it('shows activity members as task action menu items with state', () => {


### PR DESCRIPTION
Status transition buttons (Reopen, Archive, Cancel, etc.) now appear in the ⋯ dropdown instead of an inline bar under the task pane header.

**Changes:**
- Removed the inline `TaskStatusActions` bar that appeared between the header and the tab bar
- Status transitions are now appended to the ⋯ dropdown, separated from activity member links by a divider when both are present
- Destructive actions (Cancel → `cancelled`, Archive → `archived`) use `danger: true` red styling
- The `done`/`cancelled` filtering when `pendingCheckpointType` is set is preserved — approval banners still own those flows
- Dropdown is shown whenever there are activity members OR valid transitions; hidden only when both are empty (e.g. archived tasks with no activity)

Tests updated to cover the new dropdown behavior.