### PR TITLE
fix: remove lock file on process exit and checkpoint WAL on close

### DIFF
--- a/packages/daemon/src/storage/database-core.ts
+++ b/packages/daemon/src/storage/database-core.ts
@@ -93,8 +93,18 @@ export class DatabaseCore {
 
 	/**
 	 * Close the database connection and release the lock file.
+	 *
+	 * Runs a WAL checkpoint before closing so all write-ahead log data is flushed
+	 * to the main database file. This prevents potential data loss on abrupt
+	 * termination where the WAL is replayed at next startup but uncommitted frames
+	 * were not yet checkpointed.
 	 */
 	close(): void {
+		try {
+			this.db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+		} catch {
+			// Ignore checkpoint errors — the DB may already be closed or in an error state
+		}
 		this.db.close();
 		this.lock.release();
 	}

--- a/packages/daemon/src/storage/database-lock.ts
+++ b/packages/daemon/src/storage/database-lock.ts
@@ -13,6 +13,8 @@ export class DatabaseLock {
 	private lockPath: string;
 	private logger = new Logger('DatabaseLock');
 	private acquired = false;
+	/** Synchronous exit handler registered after acquire(); removed by release(). */
+	private exitHandler: (() => void) | null = null;
 
 	constructor(private dbPath: string) {
 		this.lockPath = `${dbPath}.lock`;
@@ -48,6 +50,20 @@ export class DatabaseLock {
 
 		writeFileSync(this.lockPath, String(process.pid), 'utf-8');
 		this.acquired = true;
+
+		// Register a synchronous process.on('exit') fallback so the lock file is
+		// removed even when async signal handlers (SIGTERM, SIGHUP) don't fire —
+		// e.g. when Bun kills the child process directly on Ctrl+C during `bun run`.
+		// 'exit' is always synchronous and fires before the process terminates.
+		const lockPath = this.lockPath;
+		this.exitHandler = () => {
+			try {
+				unlinkSync(lockPath);
+			} catch {
+				// Ignore — file may already be gone
+			}
+		};
+		process.on('exit', this.exitHandler);
 	}
 
 	/**
@@ -56,6 +72,14 @@ export class DatabaseLock {
 	 */
 	release(): void {
 		if (!this.acquired) return;
+
+		// Deregister the exit-fallback handler so it doesn't attempt to remove a
+		// lock file that we're about to delete (and won't exist after this call).
+		if (this.exitHandler !== null) {
+			process.removeListener('exit', this.exitHandler);
+			this.exitHandler = null;
+		}
+
 		try {
 			unlinkSync(this.lockPath);
 		} catch {

--- a/packages/daemon/tests/unit/1-core/core/daemon-app-cleanup.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/daemon-app-cleanup.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
-import { existsSync, unlinkSync, mkdirSync } from 'node:fs';
+import { existsSync, unlinkSync, mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createDaemonApp } from '../../../../src/app';
@@ -316,7 +316,6 @@ describe('Daemon App Cleanup', () => {
 
 		afterEach(() => {
 			try {
-				const { rmSync } = require('node:fs');
 				rmSync(tmpDbDir, { recursive: true, force: true });
 			} catch {
 				// Ignore cleanup errors

--- a/packages/daemon/tests/unit/1-core/core/daemon-app-cleanup.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/daemon-app-cleanup.test.ts
@@ -9,6 +9,9 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import { existsSync, unlinkSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { createDaemonApp } from '../../../../src/app';
 import type { Config } from '../../../../src/config';
 
@@ -297,6 +300,79 @@ describe('Daemon App Cleanup', () => {
 
 			// Cleanup
 			await daemonContext.cleanup();
+		});
+	});
+
+	describe('lock file cleanup on graceful shutdown', () => {
+		let tmpDbDir: string;
+
+		beforeEach(() => {
+			tmpDbDir = join(
+				tmpdir(),
+				`neokai-cleanup-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+			);
+			mkdirSync(tmpDbDir, { recursive: true });
+		});
+
+		afterEach(() => {
+			try {
+				const { rmSync } = require('node:fs');
+				rmSync(tmpDbDir, { recursive: true, force: true });
+			} catch {
+				// Ignore cleanup errors
+			}
+		});
+
+		test('should remove the lock file after cleanup() when using a file-based DB', async () => {
+			const tmpDbPath = join(tmpDbDir, 'daemon.db');
+			const lockPath = `${tmpDbPath}.lock`;
+
+			const fileConfig: Config = {
+				...config,
+				dbPath: tmpDbPath,
+			};
+
+			const daemonContext = await createDaemonApp({
+				config: fileConfig,
+				verbose: false,
+				standalone: false,
+			});
+
+			// Lock file must exist while the daemon is running
+			expect(existsSync(lockPath)).toBe(true);
+
+			// Graceful shutdown
+			await daemonContext.cleanup();
+
+			// Lock file must be removed after cleanup
+			expect(existsSync(lockPath)).toBe(false);
+		});
+
+		test('should have process.exit fallback handler registered after startup', async () => {
+			const tmpDbPath = join(tmpDbDir, 'daemon-exit.db');
+			const lockPath = `${tmpDbPath}.lock`;
+
+			const fileConfig: Config = {
+				...config,
+				dbPath: tmpDbPath,
+			};
+
+			const exitListenersBefore = process.listenerCount('exit');
+
+			const daemonContext = await createDaemonApp({
+				config: fileConfig,
+				verbose: false,
+				standalone: false,
+			});
+
+			// At least one 'exit' listener should have been added by DatabaseLock
+			expect(process.listenerCount('exit')).toBeGreaterThan(exitListenersBefore);
+
+			// After cleanup the listener should be removed
+			await daemonContext.cleanup();
+
+			expect(process.listenerCount('exit')).toBe(exitListenersBefore);
+			expect(existsSync(lockPath)).toBe(false);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/database-core.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/database-core.test.ts
@@ -165,6 +165,42 @@ describe('DatabaseCore', () => {
 			// After close, operations should fail
 			expect(() => db.prepare('SELECT 1').get()).toThrow();
 		});
+
+		it('should checkpoint the WAL before closing (WAL file is empty or absent after close)', async () => {
+			dbCore = new DatabaseCore(dbPath);
+			await dbCore.initialize();
+
+			const db = dbCore.getDb();
+			// Write data to ensure WAL frames are created
+			db.exec(`
+				INSERT INTO sessions (id, title, workspace_path, created_at, last_active_at, status, config, metadata)
+				VALUES ('wal-close-test', 'WAL Close Test', '/test', datetime('now'), datetime('now'), 'active', '{}', '{}')
+			`);
+
+			dbCore.close();
+			dbCore = null as unknown as typeof dbCore; // prevent double-close in afterEach
+
+			// After a TRUNCATE checkpoint, the WAL file should be zero bytes or absent
+			const walPath = dbPath + '-wal';
+			if (existsSync(walPath)) {
+				const { size } = statSync(walPath);
+				expect(size).toBe(0);
+			}
+			// Lock file should be released
+			expect(existsSync(dbPath + '.lock')).toBe(false);
+		});
+
+		it('should release the lock file on close', async () => {
+			dbCore = new DatabaseCore(dbPath);
+			await dbCore.initialize();
+
+			expect(existsSync(dbPath + '.lock')).toBe(true);
+
+			dbCore.close();
+			dbCore = null as unknown as typeof dbCore; // prevent double-close in afterEach
+
+			expect(existsSync(dbPath + '.lock')).toBe(false);
+		});
 	});
 
 	describe('backup creation', () => {

--- a/packages/daemon/tests/unit/4-space-storage/storage/database-lock.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/database-lock.test.ts
@@ -1,0 +1,175 @@
+/**
+ * DatabaseLock Unit Tests
+ *
+ * Tests for database lock acquisition, release, and the synchronous
+ * process.on('exit') fallback that removes the lock file when async
+ * signal handlers do not fire (SIGTERM, SIGHUP, Bun Ctrl+C kill).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseLock } from '../../../../src/storage/database-lock';
+
+describe('DatabaseLock', () => {
+	let testDir: string;
+	let dbPath: string;
+	let lockPath: string;
+
+	beforeEach(() => {
+		testDir = join(tmpdir(), `db-lock-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(testDir, { recursive: true });
+		dbPath = join(testDir, 'test.db');
+		lockPath = `${dbPath}.lock`;
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// Ignore cleanup errors
+		}
+	});
+
+	describe('acquire', () => {
+		it('should create a lock file containing the current PID', () => {
+			const lock = new DatabaseLock(dbPath);
+			lock.acquire();
+
+			expect(existsSync(lockPath)).toBe(true);
+			const content = readFileSync(lockPath, 'utf-8');
+			expect(parseInt(content, 10)).toBe(process.pid);
+
+			lock.release();
+		});
+
+		it('should be idempotent when called twice', () => {
+			const lock = new DatabaseLock(dbPath);
+			lock.acquire();
+
+			const countAfterFirst = process.listenerCount('exit');
+			lock.acquire(); // Should not register another listener
+
+			expect(process.listenerCount('exit')).toBe(countAfterFirst);
+			expect(existsSync(lockPath)).toBe(true);
+
+			lock.release();
+		});
+
+		it('should register exactly one process.on("exit") listener', () => {
+			const before = process.listenerCount('exit');
+			const lock = new DatabaseLock(dbPath);
+			lock.acquire();
+
+			expect(process.listenerCount('exit')).toBe(before + 1);
+
+			lock.release();
+		});
+
+		it('should not register an exit listener for in-memory databases', () => {
+			const before = process.listenerCount('exit');
+			const lock = new DatabaseLock(':memory:');
+			lock.acquire();
+
+			expect(process.listenerCount('exit')).toBe(before);
+		});
+
+		it('should remove the lock file when the exit handler is invoked directly', () => {
+			const beforeListeners = process.rawListeners('exit') as (() => void)[];
+			const lock = new DatabaseLock(dbPath);
+			lock.acquire();
+
+			expect(existsSync(lockPath)).toBe(true);
+
+			// Find the handler that was just registered (not present before acquire)
+			const afterListeners = process.rawListeners('exit') as (() => void)[];
+			const newHandler = afterListeners.find((l) => !beforeListeners.includes(l));
+			expect(newHandler).toBeDefined();
+
+			// Invoke it directly to simulate a process.on('exit') fire without
+			// actually exiting — safe because we bypass the event system.
+			newHandler!();
+
+			expect(existsSync(lockPath)).toBe(false);
+
+			// Remove the handler from the process since we bypassed release()
+			process.removeListener('exit', newHandler!);
+		});
+	});
+
+	describe('release', () => {
+		it('should remove the lock file', () => {
+			const lock = new DatabaseLock(dbPath);
+			lock.acquire();
+			expect(existsSync(lockPath)).toBe(true);
+
+			lock.release();
+
+			expect(existsSync(lockPath)).toBe(false);
+		});
+
+		it('should deregister the process.exit listener', () => {
+			const lock = new DatabaseLock(dbPath);
+			lock.acquire();
+			const afterAcquire = process.listenerCount('exit');
+
+			lock.release();
+
+			expect(process.listenerCount('exit')).toBe(afterAcquire - 1);
+		});
+
+		it('should be idempotent when called twice', () => {
+			const lock = new DatabaseLock(dbPath);
+			lock.acquire();
+			lock.release();
+
+			// Second release should be a no-op and not throw
+			expect(() => lock.release()).not.toThrow();
+		});
+
+		it('should be safe to call without a prior acquire', () => {
+			const lock = new DatabaseLock(dbPath);
+			expect(() => lock.release()).not.toThrow();
+		});
+	});
+
+	describe('stale lock detection', () => {
+		it('should take over a stale lock from a dead process', () => {
+			// Write a lock file with a PID that is almost certainly dead
+			writeFileSync(lockPath, '2147483647', 'utf-8'); // Max int32 — no such process
+
+			const lock = new DatabaseLock(dbPath);
+			expect(() => lock.acquire()).not.toThrow();
+
+			// Our PID should now be in the lock file
+			const content = readFileSync(lockPath, 'utf-8');
+			expect(parseInt(content, 10)).toBe(process.pid);
+
+			lock.release();
+		});
+
+		it('should throw when another live process holds the lock', () => {
+			// Write a lock file for the parent process (which is alive)
+			const alivePid = process.ppid ?? 1;
+			writeFileSync(lockPath, String(alivePid), 'utf-8');
+
+			const lock = new DatabaseLock(dbPath);
+			let threw = false;
+			try {
+				lock.acquire();
+				// If ppid isn't alive or equals our PID, acquire succeeds — clean up
+				lock.release();
+			} catch (err) {
+				threw = true;
+				expect(String(err)).toContain('Another NeoKai daemon is already running');
+			}
+
+			// On platforms where ppid is verifiably alive and ≠ process.pid this
+			// should always throw; on edge cases (ppid === pid) we skip the check.
+			if (alivePid !== process.pid) {
+				expect(threw).toBe(true);
+			}
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- **Lock file not cleaned up on SIGTERM/SIGHUP**: `DatabaseLock.acquire()` now registers a synchronous `process.on('exit')` fallback handler that removes the lock file even when async signal handlers don't fire (e.g. Bun kills the process on Ctrl+C during `bun run`). `release()` deregisters the handler via `process.removeListener()` so it doesn't double-fire after graceful shutdown.
- **WAL checkpoint on close**: `DatabaseCore.close()` now runs `PRAGMA wal_checkpoint(TRUNCATE)` before `db.close()` to flush all write-ahead log frames to the main DB file, preventing data loss on abrupt termination.

## Tests

- New `database-lock.test.ts` (11 tests): acquire creates lock + exit listener; release removes both; idempotency; in-memory bypass; exit handler directly removes lock file.
- Extended `database-core.test.ts`: WAL file is empty/absent after `close()`; lock file released on `close()`.
- Extended `daemon-app-cleanup.test.ts`: lock file present during run, absent after `cleanup()`; exit listener count decreases after cleanup.