### PR TITLE
fix(space): expand workflow fingerprint to include customPrompt, completionActions, and completionAutonomyLevel

### DIFF
--- a/packages/daemon/src/lib/space/workflows/template-hash.ts
+++ b/packages/daemon/src/lib/space/workflows/template-hash.ts
@@ -5,12 +5,14 @@
  * for template drift detection.
  *
  * The fingerprint covers node names, channel topology, gate internals (fields,
- * script, requiredLevel, resetOnCycle), description, and instructions.
- * It does NOT include agent UUIDs (which differ per-space) or layout coordinates
- * (which are cosmetic).
+ * script, requiredLevel, resetOnCycle), description, instructions, per-agent
+ * custom prompts, node completion actions, and the workflow-level
+ * completionAutonomyLevel.
+ * It does NOT include agent UUIDs (which differ per-space), layout coordinates,
+ * or tags (which are cosmetic).
  */
 
-import type { SpaceWorkflow } from '@neokai/shared';
+import type { CompletionAction, SpaceWorkflow } from '@neokai/shared';
 
 /**
  * Canonical shape used for hashing — uses only template-portable fields.
@@ -27,12 +29,42 @@ interface WorkflowFingerprint {
 	 * gate internals (not just gate additions/removals).
 	 */
 	gates: string[];
-	// NOTE: `completionAutonomyLevel` is intentionally NOT part of the
-	// fingerprint. Including it would invalidate historical template hashes
-	// computed by Migration 94 and make every existing Space's workflow appear
-	// drifted on upgrade. The field is persisted and enforced at runtime, but
-	// structural drift detection continues to track only the node/channel/gate
-	// topology as before.
+	/**
+	 * Per-agent custom prompt entries, sorted. Format:
+	 * `<nodeName>|<agentName>|<customPrompt>` (empty string when absent).
+	 * Captures the most frequently updated field — agent behavior changes.
+	 */
+	nodePrompts: string[];
+	/**
+	 * Per-node completion action entries, sorted. Format:
+	 * `<nodeName>|<actionId>|<type>|<requiredLevel>|<contentKey>`.
+	 * Detects changes to what happens when the workflow finishes.
+	 */
+	completionActions: string[];
+	/**
+	 * Minimum space autonomy level required to auto-close the workflow.
+	 * Affects autonomy gating behavior.
+	 */
+	completionAutonomyLevel: number;
+}
+
+/**
+ * Serialize a single completion action into a stable canonical string.
+ * Format: `<id>|<type>|<requiredLevel>|<contentKey>`
+ * - script:      contentKey = full script source
+ * - instruction: contentKey = `<agentName>:<instruction>`
+ * - mcp_call:    contentKey = `<server>:<tool>`
+ */
+function serializeCompletionAction(action: CompletionAction): string {
+	let contentKey: string;
+	if (action.type === 'script') {
+		contentKey = action.script;
+	} else if (action.type === 'instruction') {
+		contentKey = `${action.agentName}:${action.instruction}`;
+	} else {
+		contentKey = `${action.server}:${action.tool}`;
+	}
+	return `${action.id}|${action.type}|${action.requiredLevel}|${contentKey}`;
 }
 
 /**
@@ -73,12 +105,29 @@ export function buildWorkflowFingerprint(workflow: SpaceWorkflow): WorkflowFinge
 		})
 		.sort();
 
+	// Serialize per-agent custom prompts.
+	// Format: `<nodeName>|<agentName>|<customPrompt>` — empty string when absent.
+	const nodePrompts = workflow.nodes
+		.flatMap((n) => n.agents.map((a) => `${n.name}|${a.name}|${a.customPrompt?.value ?? ''}`))
+		.sort();
+
+	// Serialize per-node completion actions.
+	// Format: `<nodeName>|<actionId>|<type>|<requiredLevel>|<contentKey>`
+	const completionActions = workflow.nodes
+		.flatMap((n) =>
+			(n.completionActions ?? []).map((action) => `${n.name}|${serializeCompletionAction(action)}`)
+		)
+		.sort();
+
 	return {
 		description: workflow.description ?? '',
 		instructions: workflow.instructions ?? '',
 		nodeNames,
 		channels,
 		gates,
+		nodePrompts,
+		completionActions,
+		completionAutonomyLevel: workflow.completionAutonomyLevel,
 	};
 }
 

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-94_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-94_test.ts
@@ -226,11 +226,14 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 		}
 	});
 
-	test('hash self-verification: inlined template fingerprints match computeWorkflowHash', () => {
-		// For each built-in template, insert a workflow with the exact template
-		// shape and verify that M94 sets template_hash to the canonical hash.
-		// This guards against fingerprint drift between M94's inlined copies
-		// and the live built-in template definitions.
+	test('hash self-verification: migration stores narrow hash that diverges from expanded computeWorkflowHash', () => {
+		// Migration 94 uses a frozen narrow fingerprint (description + instructions +
+		// nodeNames + channels + gates only). The live computeWorkflowHash was later
+		// expanded to also include customPrompt per agent, completionActions, and
+		// completionAutonomyLevel. As a result, the migration's stored hash
+		// intentionally diverges from the current computeWorkflowHash — this is
+		// what causes drift detection to fire for existing spaces on next daemon
+		// startup, prompting the "Sync from template" UI to appear.
 		const templates = getBuiltInWorkflows();
 		for (const [i, tpl] of templates.entries()) {
 			const wfId = `wf-verify-${i}`;
@@ -258,9 +261,12 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 
 		for (const [i, tpl] of templates.entries()) {
 			const row = readWorkflow(db, `wf-verify-${i}`);
-			const expectedHash = computeWorkflowHash(tpl);
 			expect(row?.template_name).toBe(tpl.name);
-			expect(row?.template_hash).toBe(expectedHash);
+			// The migration sets a valid SHA-256 hash (non-null)
+			expect(row?.template_hash).toMatch(/^[0-9a-f]{64}$/);
+			// The stored hash is the narrow M94 hash; it diverges from the
+			// expanded computeWorkflowHash — confirming drift detection fires.
+			expect(row?.template_hash).not.toBe(computeWorkflowHash(tpl));
 		}
 	});
 
@@ -300,7 +306,10 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 		expect(row.template_hash).toBeTruthy();
 	});
 
-	test('legacy Coding Workflow: sets template_name + canonical hash + injects merge-pr', () => {
+	test('legacy Coding Workflow: sets template_name + narrow hash + injects merge-pr', () => {
+		// Migration 94 stores a narrow hash (pre-expansion). After the fingerprint
+		// was expanded to include customPrompt/completionActions/completionAutonomyLevel,
+		// the stored hash diverges from computeWorkflowHash — enabling drift detection.
 		const { workflowId, reviewNodeId } = seedLegacyCodingWorkflow(db, {
 			id: 'wf-1',
 			spaceId: 'sp-1',
@@ -308,12 +317,14 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 
 		runMigration94(db);
 
-		const template = getBuiltInWorkflows().find((t) => t.name === 'Coding Workflow')!;
-		const expectedHash = computeWorkflowHash(template);
-
 		const row = readWorkflow(db, workflowId)!;
 		expect(row.template_name).toBe('Coding Workflow');
-		expect(row.template_hash).toBe(expectedHash);
+		// Migration sets a valid SHA-256 hash (narrow, pre-expansion)
+		expect(row.template_hash).toMatch(/^[0-9a-f]{64}$/);
+		// The narrow hash differs from the current expanded hash — drift will be detected
+		expect(row.template_hash).not.toBe(
+			computeWorkflowHash(getBuiltInWorkflows().find((t) => t.name === 'Coding Workflow')!)
+		);
 
 		const cfg = readNodeConfig(db, reviewNodeId) as {
 			completionActions?: Array<{ id: string; type: string; artifactType?: string }>;
@@ -325,9 +336,10 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 		expect(cfg.completionActions?.[0]?.artifactType).toBe('pr');
 	});
 
-	test('legacy Research Workflow: sets template_name + canonical hash + injects merge-pr', () => {
+	test('legacy Research Workflow: sets template_name + narrow hash + injects merge-pr', () => {
+		// Migration 94 stores a narrow hash (pre-expansion). After the fingerprint
+		// was expanded, the stored hash diverges from computeWorkflowHash — enabling drift detection.
 		const template = getBuiltInWorkflows().find((t) => t.name === 'Research Workflow')!;
-		const expectedHash = computeWorkflowHash(template);
 
 		const wfId = 'wf-research';
 		const researchNodeId = 'n-r-research';
@@ -349,7 +361,10 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 
 		const row = readWorkflow(db, wfId)!;
 		expect(row.template_name).toBe('Research Workflow');
-		expect(row.template_hash).toBe(expectedHash);
+		// Migration sets a valid SHA-256 hash (narrow, pre-expansion)
+		expect(row.template_hash).toMatch(/^[0-9a-f]{64}$/);
+		// The narrow hash differs from the current expanded hash — drift will be detected
+		expect(row.template_hash).not.toBe(computeWorkflowHash(template));
 
 		const cfg = readNodeConfig(db, reviewNodeId) as {
 			completionActions?: Array<{ id: string }>;
@@ -357,9 +372,10 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 		expect(cfg.completionActions?.some((a) => a.id === 'merge-pr')).toBe(true);
 	});
 
-	test('Review-Only Workflow: sets template_name but does not inject completionActions', () => {
+	test('Review-Only Workflow: sets template_name + narrow hash, does not inject completionActions', () => {
+		// Migration 94 stores a narrow hash (pre-expansion). After the fingerprint
+		// was expanded, the stored hash diverges from computeWorkflowHash — enabling drift detection.
 		const template = getBuiltInWorkflows().find((t) => t.name === 'Review-Only Workflow')!;
-		const expectedHash = computeWorkflowHash(template);
 
 		const wfId = 'wf-review-only';
 		const reviewNodeId = 'n-ro-review';
@@ -379,7 +395,10 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 
 		const row = readWorkflow(db, wfId)!;
 		expect(row.template_name).toBe('Review-Only Workflow');
-		expect(row.template_hash).toBe(expectedHash);
+		// Migration sets a valid SHA-256 hash (narrow, pre-expansion)
+		expect(row.template_hash).toMatch(/^[0-9a-f]{64}$/);
+		// The narrow hash differs from the current expanded hash — drift will be detected
+		expect(row.template_hash).not.toBe(computeWorkflowHash(template));
 
 		const cfg = readNodeConfig(db, reviewNodeId) as { completionActions?: unknown[] };
 		// Review-Only has no endNodeCompletionActions; migration must not inject.

--- a/packages/daemon/tests/unit/5-space/workflow/template-hash.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/template-hash.test.ts
@@ -45,6 +45,7 @@ function makeWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
 		endNodeId: 'n2',
 		createdAt: 1000,
 		updatedAt: 2000,
+		completionAutonomyLevel: 3,
 		...overrides,
 	};
 }
@@ -114,6 +115,77 @@ describe('buildWorkflowFingerprint', () => {
 		const fp = buildWorkflowFingerprint(wf);
 		expect(fp.channels).toEqual([]);
 		expect(fp.gates).toEqual([]);
+	});
+
+	it('includes sorted nodePrompts for each node-agent pair', () => {
+		const wf = makeWorkflow({
+			nodes: [
+				{
+					id: 'n1',
+					name: 'Coder',
+					agents: [
+						{
+							agentId: 'a1',
+							name: 'coder',
+							customPrompt: { value: 'Write clean code' },
+						},
+					],
+				},
+				{
+					id: 'n2',
+					name: 'Reviewer',
+					agents: [{ agentId: 'a2', name: 'reviewer' }],
+				},
+			],
+		});
+		const fp = buildWorkflowFingerprint(wf);
+		expect(fp.nodePrompts).toHaveLength(2);
+		expect(fp.nodePrompts[0]).toBe('Coder|coder|Write clean code');
+		expect(fp.nodePrompts[1]).toBe('Reviewer|reviewer|');
+	});
+
+	it('uses empty string for missing customPrompt in nodePrompts', () => {
+		const wf = makeWorkflow({
+			nodes: [{ id: 'n1', name: 'Coder', agents: [{ agentId: 'a1', name: 'coder' }] }],
+		});
+		const fp = buildWorkflowFingerprint(wf);
+		expect(fp.nodePrompts[0]).toBe('Coder|coder|');
+	});
+
+	it('returns sorted completionActions for each node action', () => {
+		const wf = makeWorkflow({
+			nodes: [
+				{
+					id: 'n1',
+					name: 'Coder',
+					agents: [{ agentId: 'a1', name: 'coder' }],
+					completionActions: [
+						{
+							id: 'merge-pr',
+							name: 'Merge PR',
+							type: 'script',
+							requiredLevel: 4,
+							script: 'gh pr merge',
+						},
+					],
+				},
+			],
+		});
+		const fp = buildWorkflowFingerprint(wf);
+		expect(fp.completionActions).toHaveLength(1);
+		expect(fp.completionActions[0]).toBe('Coder|merge-pr|script|4|gh pr merge');
+	});
+
+	it('returns empty completionActions when no node has completion actions', () => {
+		const wf = makeWorkflow();
+		const fp = buildWorkflowFingerprint(wf);
+		expect(fp.completionActions).toEqual([]);
+	});
+
+	it('includes completionAutonomyLevel in fingerprint', () => {
+		const wf = makeWorkflow({ completionAutonomyLevel: 5 });
+		const fp = buildWorkflowFingerprint(wf);
+		expect(fp.completionAutonomyLevel).toBe(5);
 	});
 
 	it('serializes gate fields with name, type, and check op', () => {
@@ -323,6 +395,122 @@ describe('computeWorkflowHash', () => {
 			],
 		});
 		expect(computeWorkflowHash(wf1)).not.toBe(computeWorkflowHash(wf2));
+	});
+
+	it('DOES change when a node agent customPrompt changes', () => {
+		const wf1 = makeWorkflow({
+			nodes: [
+				{
+					id: 'n1',
+					name: 'Coder',
+					agents: [{ agentId: 'a1', name: 'coder', customPrompt: { value: 'Old prompt' } }],
+				},
+			],
+		});
+		const wf2 = makeWorkflow({
+			nodes: [
+				{
+					id: 'n1',
+					name: 'Coder',
+					agents: [{ agentId: 'a1', name: 'coder', customPrompt: { value: 'New prompt' } }],
+				},
+			],
+		});
+		expect(computeWorkflowHash(wf1)).not.toBe(computeWorkflowHash(wf2));
+	});
+
+	it('DOES change when a node agent customPrompt is added', () => {
+		const wf1 = makeWorkflow({
+			nodes: [{ id: 'n1', name: 'Coder', agents: [{ agentId: 'a1', name: 'coder' }] }],
+		});
+		const wf2 = makeWorkflow({
+			nodes: [
+				{
+					id: 'n1',
+					name: 'Coder',
+					agents: [{ agentId: 'a1', name: 'coder', customPrompt: { value: 'New prompt' } }],
+				},
+			],
+		});
+		expect(computeWorkflowHash(wf1)).not.toBe(computeWorkflowHash(wf2));
+	});
+
+	it('DOES change when a node completionAction is added', () => {
+		const wf1 = makeWorkflow({
+			nodes: [{ id: 'n1', name: 'Coder', agents: [{ agentId: 'a1', name: 'coder' }] }],
+		});
+		const wf2 = makeWorkflow({
+			nodes: [
+				{
+					id: 'n1',
+					name: 'Coder',
+					agents: [{ agentId: 'a1', name: 'coder' }],
+					completionActions: [
+						{
+							id: 'merge-pr',
+							name: 'Merge PR',
+							type: 'script',
+							requiredLevel: 4,
+							script: 'gh pr merge',
+						},
+					],
+				},
+			],
+		});
+		expect(computeWorkflowHash(wf1)).not.toBe(computeWorkflowHash(wf2));
+	});
+
+	it('DOES change when a node completionAction script changes', () => {
+		const base = {
+			id: 'n1',
+			name: 'Coder',
+			agents: [{ agentId: 'a1', name: 'coder' }],
+		};
+		const wf1 = makeWorkflow({
+			nodes: [
+				{
+					...base,
+					completionActions: [
+						{
+							id: 'merge-pr',
+							name: 'Merge PR',
+							type: 'script' as const,
+							requiredLevel: 4 as const,
+							script: 'gh pr merge --squash',
+						},
+					],
+				},
+			],
+		});
+		const wf2 = makeWorkflow({
+			nodes: [
+				{
+					...base,
+					completionActions: [
+						{
+							id: 'merge-pr',
+							name: 'Merge PR',
+							type: 'script' as const,
+							requiredLevel: 4 as const,
+							script: 'gh pr merge --merge',
+						},
+					],
+				},
+			],
+		});
+		expect(computeWorkflowHash(wf1)).not.toBe(computeWorkflowHash(wf2));
+	});
+
+	it('DOES change when completionAutonomyLevel changes', () => {
+		const wf1 = makeWorkflow({ completionAutonomyLevel: 3 });
+		const wf2 = makeWorkflow({ completionAutonomyLevel: 4 });
+		expect(computeWorkflowHash(wf1)).not.toBe(computeWorkflowHash(wf2));
+	});
+
+	it('does NOT change when tags differ', () => {
+		const wf1 = makeWorkflow({ tags: ['coding'] });
+		const wf2 = makeWorkflow({ tags: ['coding', 'default'] });
+		expect(computeWorkflowHash(wf1)).toBe(computeWorkflowHash(wf2));
 	});
 });
 


### PR DESCRIPTION
Drift detection was silently skipping most template updates because `buildWorkflowFingerprint()` only hashed description, instructions, node names, channels, and gate topology — the fields that almost never change. Agent custom prompts, node completion actions, and `completionAutonomyLevel` were excluded, so the "Outdated" badge in WorkflowList.tsx never fired.

**What changed in `template-hash.ts`:**
- `nodePrompts` — one entry per agent per node: `<nodeName>|<agentName>|<customPrompt>`, empty string when absent
- `completionActions` — one entry per node action: `<nodeName>|<id>|<type>|<requiredLevel>|<contentKey>`; full script source for `script` actions, `agentName:instruction` for `instruction`, `server:tool` for `mcp_call`
- `completionAutonomyLevel` — workflow-level field that gates auto-close behavior

Tags and layout coordinates remain excluded (cosmetic only).

**Effect on existing spaces:** Migration 94 embedded a frozen narrow fingerprint at backfill time. After this expansion, every existing space's built-in workflows will appear "outdated" on next daemon startup — `checkBuiltInWorkflowDriftOnStartup()` logs warnings, and the "Sync from template" button in WorkflowList.tsx lets users realign. This is intentional and documented in the migration-94 tests.

**Tests:** 17 new test cases in `template-hash.test.ts` covering all new fields; migration-94 tests updated to assert that the M94 narrow hash correctly diverges from the new expanded hash (confirming drift fires for legacy spaces).