### PR TITLE
fix(space): preserve task agent sessions across daemon restart

### DIFF
--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1613,9 +1613,10 @@ export class TaskAgentManager {
 	 *
 	 * Steps per task:
 	 * 1. Interrupt and cleanup the in-memory AgentSession (stops SDK query & subprocesses).
-	 * 2. Unsubscribe session.updated listeners and drop completion callbacks.
-	 * 3. Close db-query MCP server file handles.
-	 * 4. Clear in-memory maps so a subsequent rehydrate starts from a clean slate.
+	 *    `stopSessionPreserveDb` also unsubscribes session.updated listeners and
+	 *    drops completion callbacks for each session ID.
+	 * 2. Close db-query MCP server file handles.
+	 * 3. Clear in-memory maps so a subsequent rehydrate starts from a clean slate.
 	 */
 	async cleanupAll(): Promise<void> {
 		if (this.taskArchiveListenerUnsub) {
@@ -1632,44 +1633,29 @@ export class TaskAgentManager {
 	 * Used by shutdown only — for task completion / cancellation use `cleanup()`.
 	 */
 	private async shutdownTask(taskId: string): Promise<void> {
-		const sessionIdsTouched = new Set<string>();
-
-		// 1. Stop sub-sessions (interrupt + cleanup, no DB delete)
+		// 1. Stop sub-sessions (interrupt + cleanup, no DB delete).
+		// stopSessionPreserveDb unsubscribes listeners and drops completion
+		// callbacks for each session ID as part of its teardown.
 		const nodeMap = this.subSessions.get(taskId);
 		if (nodeMap) {
 			for (const [subSessionId, session] of nodeMap) {
-				sessionIdsTouched.add(subSessionId);
 				await this.stopSessionPreserveDb(subSessionId, session);
+				this.agentSessionIndex.delete(subSessionId);
 			}
 			this.subSessions.delete(taskId);
-			for (const sid of sessionIdsTouched) {
-				this.agentSessionIndex.delete(sid);
-			}
 		}
 
 		// 2. Stop Task Agent session
 		const taskAgentSession = this.taskAgentSessions.get(taskId);
 		if (taskAgentSession) {
-			const agentSessionId = taskAgentSession.session.id;
-			sessionIdsTouched.add(agentSessionId);
-			await this.stopSessionPreserveDb(agentSessionId, taskAgentSession);
+			await this.stopSessionPreserveDb(taskAgentSession.session.id, taskAgentSession);
 			this.taskAgentSessions.delete(taskId);
 		}
 
-		// 3. Remove completion callbacks and session listeners for the exact session IDs
-		for (const sessionId of sessionIdsTouched) {
-			this.completionCallbacks.delete(sessionId);
-			const unsub = this.sessionListeners.get(sessionId);
-			if (unsub) {
-				unsub();
-				this.sessionListeners.delete(sessionId);
-			}
-		}
-
-		// 4. Drop the in-memory worktree path (DB record is preserved)
+		// 3. Drop the in-memory worktree path (DB record is preserved)
 		this.taskWorktreePaths.delete(taskId);
 
-		// 5. Close db-query server to release SQLite handles held by the session
+		// 4. Close db-query server to release SQLite handles held by the session
 		const dbQueryServer = this.taskDbQueryServers.get(taskId);
 		if (dbQueryServer) {
 			try {

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1551,6 +1551,7 @@ export class TaskAgentManager {
 
 		let attempted = 0;
 		let failed = 0;
+		let selfHealed = 0;
 
 		for (const task of activeTasks) {
 			const sessionId = task.taskAgentSessionId;
@@ -1560,8 +1561,26 @@ export class TaskAgentManager {
 			if (this.taskAgentSessions.has(task.id)) continue;
 
 			const dbSession = this.config.db.getSession(sessionId);
-			if (!dbSession) continue;
-			if (dbSession.type !== 'space_task_agent') continue;
+			if (!dbSession || dbSession.type !== 'space_task_agent') {
+				// Dangling FK: task still references a session that no longer exists
+				// in the DB (or was replaced by another type). Clear the reference so
+				// the UI's `spaceTaskActivity.byTask` LiveQuery stops inner-joining on
+				// a ghost row (which hides the task agent and canvas) and so the task
+				// becomes eligible to spawn a fresh Task Agent on its next run.
+				log.warn(
+					`TaskAgentManager.rehydrate: task ${task.id} references missing session ${sessionId} — clearing dangling task_agent_session_id`
+				);
+				try {
+					this.config.taskRepo.updateTask(task.id, { taskAgentSessionId: null });
+					selfHealed++;
+				} catch (err) {
+					log.warn(
+						`TaskAgentManager.rehydrate: failed to clear dangling task_agent_session_id for task ${task.id}:`,
+						err
+					);
+				}
+				continue;
+			}
 
 			attempted++;
 			try {
@@ -1577,13 +1596,26 @@ export class TaskAgentManager {
 
 		const succeeded = attempted - failed;
 		log.info(
-			`TaskAgentManager.rehydrate: attempted=${attempted} succeeded=${succeeded} failed=${failed}`
+			`TaskAgentManager.rehydrate: attempted=${attempted} succeeded=${succeeded} failed=${failed} selfHealed=${selfHealed}`
 		);
 	}
 
 	/**
-	 * Stop and clean up all active Task Agent sessions and their sub-sessions.
-	 * Called on daemon shutdown to release all resources.
+	 * Stop all active Task Agent sessions and their sub-sessions for daemon shutdown.
+	 *
+	 * **Preserves DB state** so that `rehydrate()` can restore every task on the next
+	 * daemon start. Specifically:
+	 * - Does NOT delete the session DB row (would orphan `space_tasks.task_agent_session_id`
+	 *   and break the `spaceTaskActivity.byTask` LiveQuery that feeds the Task Agent /
+	 *   reviewer dropdown and canvas).
+	 * - Does NOT mark worktrees completed (the task is still in progress; marking it
+	 *   completed starts the 7-day TTL reaper clock).
+	 *
+	 * Steps per task:
+	 * 1. Interrupt and cleanup the in-memory AgentSession (stops SDK query & subprocesses).
+	 * 2. Unsubscribe session.updated listeners and drop completion callbacks.
+	 * 3. Close db-query MCP server file handles.
+	 * 4. Clear in-memory maps so a subsequent rehydrate starts from a clean slate.
 	 */
 	async cleanupAll(): Promise<void> {
 		if (this.taskArchiveListenerUnsub) {
@@ -1591,8 +1623,64 @@ export class TaskAgentManager {
 			this.taskArchiveListenerUnsub = null;
 		}
 		const taskIds = Array.from(this.taskAgentSessions.keys());
-		await Promise.allSettled(taskIds.map((taskId) => this.cleanup(taskId)));
-		log.info(`TaskAgentManager: cleanupAll complete (${taskIds.length} tasks cleaned up)`);
+		await Promise.allSettled(taskIds.map((taskId) => this.shutdownTask(taskId)));
+		log.info(`TaskAgentManager: cleanupAll complete (${taskIds.length} tasks shut down)`);
+	}
+
+	/**
+	 * Stop all in-memory resources for a task without touching DB state.
+	 * Used by shutdown only — for task completion / cancellation use `cleanup()`.
+	 */
+	private async shutdownTask(taskId: string): Promise<void> {
+		const sessionIdsTouched = new Set<string>();
+
+		// 1. Stop sub-sessions (interrupt + cleanup, no DB delete)
+		const nodeMap = this.subSessions.get(taskId);
+		if (nodeMap) {
+			for (const [subSessionId, session] of nodeMap) {
+				sessionIdsTouched.add(subSessionId);
+				await this.stopSessionPreserveDb(subSessionId, session);
+			}
+			this.subSessions.delete(taskId);
+			for (const sid of sessionIdsTouched) {
+				this.agentSessionIndex.delete(sid);
+			}
+		}
+
+		// 2. Stop Task Agent session
+		const taskAgentSession = this.taskAgentSessions.get(taskId);
+		if (taskAgentSession) {
+			const agentSessionId = taskAgentSession.session.id;
+			sessionIdsTouched.add(agentSessionId);
+			await this.stopSessionPreserveDb(agentSessionId, taskAgentSession);
+			this.taskAgentSessions.delete(taskId);
+		}
+
+		// 3. Remove completion callbacks and session listeners for the exact session IDs
+		for (const sessionId of sessionIdsTouched) {
+			this.completionCallbacks.delete(sessionId);
+			const unsub = this.sessionListeners.get(sessionId);
+			if (unsub) {
+				unsub();
+				this.sessionListeners.delete(sessionId);
+			}
+		}
+
+		// 4. Drop the in-memory worktree path (DB record is preserved)
+		this.taskWorktreePaths.delete(taskId);
+
+		// 5. Close db-query server to release SQLite handles held by the session
+		const dbQueryServer = this.taskDbQueryServers.get(taskId);
+		if (dbQueryServer) {
+			try {
+				dbQueryServer.close();
+			} catch (err) {
+				log.warn(`TaskAgentManager: failed to close db-query server for task ${taskId}:`, err);
+			}
+			this.taskDbQueryServers.delete(taskId);
+		}
+
+		log.info(`TaskAgentManager: shutdown complete for task ${taskId} (DB state preserved)`);
 	}
 
 	/**
@@ -2627,6 +2715,34 @@ export class TaskAgentManager {
 	// -------------------------------------------------------------------------
 	// Private — session cleanup helpers
 	// -------------------------------------------------------------------------
+
+	/**
+	 * Interrupt and clean up a session's in-memory state, **preserving its DB row**.
+	 *
+	 * Used by the daemon-shutdown path (`shutdownTask`) so that `rehydrate()` can
+	 * restore the session when the daemon restarts. The reverse is
+	 * `stopAndDeleteSession`, which is used for task completion / cancellation.
+	 */
+	private async stopSessionPreserveDb(sessionId: string, session: AgentSession): Promise<void> {
+		const unsub = this.sessionListeners.get(sessionId);
+		if (unsub) {
+			unsub();
+			this.sessionListeners.delete(sessionId);
+		}
+		this.completionCallbacks.delete(sessionId);
+
+		try {
+			await session.handleInterrupt();
+		} catch (err) {
+			log.warn(`TaskAgentManager: failed to interrupt session ${sessionId}:`, err);
+		}
+
+		try {
+			await session.cleanup();
+		} catch (err) {
+			log.warn(`TaskAgentManager: failed to cleanup session ${sessionId}:`, err);
+		}
+	}
 
 	/**
 	 * Interrupt and clean up a session, then delete its DB record.

--- a/packages/daemon/src/lib/state-manager.ts
+++ b/packages/daemon/src/lib/state-manager.ts
@@ -698,6 +698,14 @@ export class StateManager {
 	 * FIX: Uses per-channel versioning
 	 */
 	async broadcastSessionStateChange(sessionId: string): Promise<void> {
+		// Guard: an empty sessionId indicates an upstream event emitted without a
+		// valid session (e.g. a provider error surfacing before session binding).
+		// Broadcasting to `session:` with no ID is meaningless and throws inside
+		// getSessionState() producing noisy "Session not found" warnings.
+		if (!sessionId) {
+			return;
+		}
+
 		const version = this.incrementVersion(`${STATE_CHANNELS.SESSION}:${sessionId}`);
 
 		try {

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
@@ -1556,6 +1556,25 @@ describe('TaskAgentManager', () => {
 			expect(ctx.manager.isTaskAgentAlive(task2.id)).toBe(false);
 		});
 
+		test('cleanupAll preserves DB state for rehydration after daemon restart', async () => {
+			const task1 = await makeTask(ctx.taskManager);
+			const task2 = await makeTask(ctx.taskManager);
+			const session1Id = await ctx.manager.spawnTaskAgent(task1, ctx.space, null, null);
+			const session2Id = await ctx.manager.spawnTaskAgent(task2, ctx.space, null, null);
+
+			await ctx.manager.cleanupAll();
+
+			// Must NOT delete session DB rows — rehydrate depends on them
+			expect(ctx.sessionManagerDeleteCalls).not.toContain(session1Id);
+			expect(ctx.sessionManagerDeleteCalls).not.toContain(session2Id);
+
+			// The task_agent_session_id in space_tasks must still point at the live session
+			const reloaded1 = ctx.taskRepo.getTask(task1.id);
+			const reloaded2 = ctx.taskRepo.getTask(task2.id);
+			expect(reloaded1?.taskAgentSessionId).toBe(session1Id);
+			expect(reloaded2?.taskAgentSessionId).toBe(session2Id);
+		});
+
 		test('cleanupAll is a no-op when no sessions are active', async () => {
 			// Should not throw
 			await expect(ctx.manager.cleanupAll()).resolves.toBeUndefined();

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
@@ -1575,6 +1575,35 @@ describe('TaskAgentManager', () => {
 			expect(reloaded2?.taskAgentSessionId).toBe(session2Id);
 		});
 
+		test('cleanupAll preserves sub-session DB rows and stops their in-memory queries', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			const subSessionId = `space:${ctx.spaceId}:task:${task.id}:step:shutdown-sub`;
+			await ctx.manager.createSubSession(task.id, subSessionId, {
+				sessionId: subSessionId,
+				workspacePath: '/tmp/ws',
+			} as unknown as import('../../../../src/lib/agent/agent-session.ts').AgentSessionInit);
+
+			const subSession = ctx.createdSessions.get(subSessionId);
+			expect(subSession).toBeDefined();
+			// Sub-session is registered in memory and backed by a DB row
+			expect(ctx.manager.getSubSession(subSessionId)).toBeDefined();
+			expect(ctx.mockDb.getSession(subSessionId)).not.toBeNull();
+
+			await ctx.manager.cleanupAll();
+
+			// The in-memory sub-session is cleared so rehydrate can restore cleanly
+			expect(ctx.manager.getSubSession(subSessionId)).toBeUndefined();
+
+			// But the DB row is preserved (rehydrateSubSession looks it up by ID on next run)
+			expect(ctx.sessionManagerDeleteCalls).not.toContain(subSessionId);
+			expect(ctx.mockDb.getSession(subSessionId)).not.toBeNull();
+
+			// The sub-session's streaming query was stopped via AgentSession.cleanup()
+			expect(subSession?._cleanupCalled).toBe(true);
+		});
+
 		test('cleanupAll is a no-op when no sessions are active', async () => {
 			// Should not throw
 			await expect(ctx.manager.cleanupAll()).resolves.toBeUndefined();
@@ -1938,6 +1967,50 @@ describe('TaskAgentManager', () => {
 			}
 
 			restoreSpy.mockRestore();
+		});
+
+		test('self-heals dangling task_agent_session_id when session row is missing', async () => {
+			// Simulate post-bad-shutdown state: task still marks itself in_progress
+			// with a taskAgentSessionId, but the session row was deleted.
+			const task = await ctx.taskManager.createTask({
+				title: 'Dangling FK task',
+				description: '',
+				taskType: 'coding',
+				status: 'in_progress',
+			});
+			const danglingSessionId = `space:${ctx.spaceId}:task:${task.id}`;
+			ctx.taskRepo.updateTask(task.id, { taskAgentSessionId: danglingSessionId });
+			// NOTE: no mockDb.createSession — session row is intentionally absent
+
+			await ctx.manager.rehydrate();
+
+			// No task agent added to the map
+			expect(ctx.manager.getTaskAgent(task.id)).toBeUndefined();
+
+			// The dangling FK on space_tasks was cleared so the UI LiveQuery
+			// (spaceTaskActivity.byTask) stops inner-joining on a ghost session.
+			const reloaded = ctx.taskRepo.getTask(task.id);
+			expect(reloaded?.taskAgentSessionId).toBeUndefined();
+		});
+
+		test('self-heals when session exists but is the wrong type', async () => {
+			// The session row exists but is a worker (sub-session), not a
+			// space_task_agent. The FK is still logically dangling — clear it.
+			const task = await ctx.taskManager.createTask({
+				title: 'Wrong-type FK task',
+				description: '',
+				taskType: 'coding',
+				status: 'in_progress',
+			});
+			const wrongTypeSessionId = `space:${ctx.spaceId}:task:${task.id}:wrong`;
+			ctx.taskRepo.updateTask(task.id, { taskAgentSessionId: wrongTypeSessionId });
+			ctx.mockDb.createSession({ id: wrongTypeSessionId, type: 'worker' });
+
+			await ctx.manager.rehydrate();
+
+			expect(ctx.manager.getTaskAgent(task.id)).toBeUndefined();
+			const reloaded = ctx.taskRepo.getTask(task.id);
+			expect(reloaded?.taskAgentSessionId).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
## Summary

On SIGINT, `TaskAgentManager.cleanupAll()` treated shutdown as task completion: it hard-deleted session DB rows and marked worktrees completed, leaving `space_tasks.task_agent_session_id` pointing at rows that no longer existed. `rehydrate()` silently skipped those dangling FKs, so after restart the Task Agent + reviewer vanished from the dropdown and the canvas went blank.

- Split `cleanupAll` into a shutdown path (`shutdownTask` + `stopSessionPreserveDb`) that stops the SDK query / releases MCP but leaves DB + worktree state intact so `rehydrate()` can restore every task.
- Self-heal dangling `task_agent_session_id` on rehydrate so existing bad-shutdown state no longer breaks the UI.
- Guard `broadcastSessionStateChange('')` to silence the cascading "Session not found" warnings.

## Test plan

- [x] New unit test: `cleanupAll preserves DB state for rehydration after daemon restart`
- [x] `task-agent-manager`, `task-agent-manager-rehydration`, `task-agent-session-lifecycle`, `task-agent-manager-worktree` — 128 tests pass
- [x] `bun run typecheck` clean
- [ ] Smoke test: start daemon with active Space task, Ctrl+C, restart, confirm canvas + dropdown populate