### PR TITLE
fix(space): emit session.created on daemonHub so ad-hoc space sessions get space-agent-tools MCP

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -95,6 +95,15 @@ export function setupSessionHandlers(
 		const agentSession = sessionManager.getSession(sessionId);
 		const session = agentSession?.getSessionData();
 
+		// Bridge to daemonHub so subscribers like SpaceRuntimeService can react.
+		// session-lifecycle.ts emits 'session.created' only on eventBus; nothing
+		// forwards it to daemonHub, so SpaceRuntimeService.attachSpaceToolsToMemberSession
+		// never fires for RPC-created sessions (e.g. ad-hoc Space sessions). This
+		// matches the pattern used by space-handlers.ts for 'space.created'.
+		if (session) {
+			daemonHub.emit('session.created', { sessionId, session }).catch(() => {});
+		}
+
 		return { sessionId, session };
 	});
 

--- a/packages/daemon/tests/unit/2-handlers/rpc/session-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc/session-handlers.test.ts
@@ -328,6 +328,66 @@ describe('Session RPC Handlers', () => {
 
 			expect(roomManager.assignSession).toHaveBeenCalledWith('room-123', 'session-456');
 		});
+
+		it('emits session.created on daemonHub after session creation', async () => {
+			const handler = messageHubData.handlers.get('session.create');
+			expect(handler).toBeDefined();
+
+			const { agentSession, mocks } = createMockAgentSession();
+			sessionManagerData.mocks.createSession.mockResolvedValueOnce('new-session-789');
+			sessionManagerData.mocks.getSession.mockReturnValueOnce(agentSession);
+
+			await handler!({ workspacePath: '/workspace/test' }, {});
+
+			expect(daemonHubData.emit).toHaveBeenCalledWith(
+				'session.created',
+				expect.objectContaining({
+					sessionId: 'new-session-789',
+					session: mocks.getSessionData(),
+				})
+			);
+		});
+
+		it('emits session.created on daemonHub for space sessions', async () => {
+			const handler = messageHubData.handlers.get('session.create');
+			expect(handler).toBeDefined();
+
+			const spaceSession = createMockAgentSession({
+				context: { spaceId: 'space-abc' },
+			} as Partial<AgentSession>);
+			sessionManagerData.mocks.createSession.mockResolvedValueOnce('space-session-1');
+			sessionManagerData.mocks.getSession.mockReturnValueOnce(spaceSession.agentSession);
+
+			await handler!({ workspacePath: '/workspace/test', spaceId: 'space-abc' }, {});
+
+			expect(daemonHubData.emit).toHaveBeenCalledWith(
+				'session.created',
+				expect.objectContaining({
+					sessionId: 'space-session-1',
+				})
+			);
+		});
+
+		it('does not emit session.created on daemonHub when session is not found', async () => {
+			const handler = messageHubData.handlers.get('session.create');
+			expect(handler).toBeDefined();
+
+			sessionManagerData.mocks.createSession.mockResolvedValueOnce('orphan-session');
+			// getSession returns null — session was just created but not yet loaded
+			sessionManagerData.mocks.getSession.mockReturnValueOnce(null);
+
+			const emitCallsBefore = (daemonHubData.emit as ReturnType<typeof mock>).mock.calls.filter(
+				(c) => c[0] === 'session.created'
+			).length;
+
+			await handler!({ workspacePath: '/workspace/test' }, {});
+
+			const emitCallsAfter = (daemonHubData.emit as ReturnType<typeof mock>).mock.calls.filter(
+				(c) => c[0] === 'session.created'
+			).length;
+
+			expect(emitCallsAfter - emitCallsBefore).toBe(0);
+		});
 	});
 
 	describe('session.setWorktreeMode', () => {


### PR DESCRIPTION
## Problem

Ad-hoc sessions created via "New Session" in the Space UI did not get `space-agent-tools` MCP attached. The agent couldn't call `list_tasks`, `create_standalone_task`, etc.

## Root cause

`session-lifecycle.ts` emits `session.created` only on the internal `eventBus`. `state-manager.ts` bridges that to `messageHub` (client-facing WebSocket) but strips the `session` payload. `SpaceRuntimeService` subscribes on `daemonHub` expecting `{ sessionId, session }` — which never arrived for RPC-created sessions.

## Fix

In `session-handlers.ts`, after the session object is retrieved, emit `session.created` on `daemonHub` with the full `{ sessionId, session }` payload. This mirrors the pattern already used by `space-handlers.ts` for `space.created`.

The `SpaceRuntimeService` subscriber already guards against `space_chat` and `space_task_agent` types, so no double-attach risk.

## Tests

3 new unit tests in `session-handlers.test.ts`:
- Verifies `daemonHub.emit('session.created', …)` is called after session creation
- Verifies it fires for sessions with a `spaceId` context (the primary bug scenario)
- Verifies it is skipped when the session object cannot be retrieved