### PR TITLE
chore(release): bump version to 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to NeoKai will be documented in this file.
 
+## [0.11.1] - 2026-04-22
+
+A patch release fixing session persistence and workflow fingerprint accuracy. 8 commits since v0.11.0.
+
+### Changed
+
+- Default `completionAutonomyLevel` set to 3; legacy `WorkflowEditor` removed
+- Task status actions moved from inline bar to dropdown menu
+
+### Fixed
+
+- Ad-hoc space sessions now get `space-agent-tools` MCP via `session.created` event
+- Task agent sessions preserved across daemon restart
+- Workflow fingerprint expanded to include customPrompt, completionActions, and completionAutonomyLevel
+- Lock file removed on process exit; WAL checkpointed on DB close
+
 ## [0.11.0] - 2026-04-22
 
 A refinement release improving workflow reliability, artifact display, and communication resilience. 15 commits since v0.10.0.

--- a/npm/neokai/package.json
+++ b/npm/neokai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neokai",
-	"version": "0.11.0",
+	"version": "0.11.1",
 	"description": "NeoKai - Claude Agent SDK Web Interface",
 	"bin": {
 		"kai": "bin/kai.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/cli",
-	"version": "0.11.0",
+	"version": "0.11.1",
 	"type": "module",
 	"license": "Apache-2.0",
 	"bin": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/daemon",
-	"version": "0.11.0",
+	"version": "0.11.1",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "main.ts",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/e2e",
-	"version": "0.11.0",
+	"version": "0.11.1",
 	"private": true,
 	"license": "Apache-2.0",
 	"type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/shared",
-	"version": "0.11.0",
+	"version": "0.11.1",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "src/mod.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/ui",
-	"version": "0.11.0",
+	"version": "0.11.1",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "src/mod.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/web",
-	"version": "0.11.0",
+	"version": "0.11.1",
 	"type": "module",
 	"license": "Apache-2.0",
 	"scripts": {


### PR DESCRIPTION
Patch release with session persistence and workflow fingerprint fixes.