### PR TITLE
fix(space): preserve task-agent sdkSessionId across restart; eagerly spawn sub-sessions

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -412,13 +412,35 @@ export class AgentSession
 					runtimeInitFingerprint,
 				};
 				updates.metadata = nextMetadata;
-				// Invalidate stale SDK resume chain when runtime init surface changes.
-				updates.sdkSessionId = undefined;
-				session = {
-					...session,
-					sdkSessionId: undefined,
-					metadata: nextMetadata,
-				};
+				// Task-agent orchestration state is long-lived — the whole point is the
+				// agent remembers context across restarts. Never clear sdkSessionId for
+				// these sessions; the rehydrate path uses `restore()` (not fromInit) so
+				// hitting this branch for a space_task_agent would be a defensive regression
+				// that silently drops the conversation history.
+				//
+				// Node-agent sub-sessions (type: 'worker' with a spaceId+taskId context) are
+				// equally long-lived under the "one session per named agent per task" reuse
+				// contract — see `createSubSession`'s reuse path. Preserve sdkSessionId for
+				// them too so a fingerprint mismatch cannot wipe their conversation history.
+				const preserveSdkSessionId =
+					session.type === 'space_task_agent' ||
+					(session.type === 'worker' &&
+						typeof session.context?.spaceId === 'string' &&
+						typeof session.context?.taskId === 'string');
+				if (!preserveSdkSessionId) {
+					// Invalidate stale SDK resume chain when runtime init surface changes.
+					updates.sdkSessionId = undefined;
+					session = {
+						...session,
+						sdkSessionId: undefined,
+						metadata: nextMetadata,
+					};
+				} else {
+					session = {
+						...session,
+						metadata: nextMetadata,
+					};
+				}
 				hasUpdates = true;
 			}
 
@@ -811,6 +833,70 @@ export class AgentSession
 	getSDKSessionId(): string | null {
 		if (!this.queryObject || !('sessionId' in this.queryObject)) return null;
 		return this.queryObject.sessionId as string;
+	}
+
+	/**
+	 * Wait until the SDK has published its `init` message and the resulting
+	 * `sdkSessionId` has been persisted on the in-memory `session` object.
+	 *
+	 * The sdkSessionId is what lets a future daemon restart resume the exact
+	 * same SDK conversation (via `~/.claude/projects/{cwd}/{sdkSessionId}.jsonl`).
+	 * Without it the SDK has no way to find the prior transcript and the
+	 * conversation is effectively lost.
+	 *
+	 * Orchestration call sites (TaskAgentManager.spawnTaskAgent, eager
+	 * sub-session spawn) should `await` this after `startStreamingQuery()`
+	 * so that the spawn contract is "session exists AND SDK has been
+	 * initialised" — a restart immediately after spawn can then safely
+	 * rehydrate.
+	 *
+	 * Resolves immediately if sdkSessionId is already set. Rejects on timeout.
+	 */
+	async awaitSdkSessionCaptured(timeoutMs = 15000): Promise<string> {
+		if (this.session.sdkSessionId) return this.session.sdkSessionId;
+
+		return new Promise((resolve, reject) => {
+			let settled = false;
+			let unsubscribe: (() => void) | null = null;
+
+			const finish = (err: Error | null, id?: string) => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timer);
+				if (unsubscribe) unsubscribe();
+				if (err) reject(err);
+				else resolve(id as string);
+			};
+
+			const timer = setTimeout(() => {
+				finish(
+					new Error(
+						`Timed out after ${timeoutMs}ms waiting for sdkSessionId on session ${this.session.id}`
+					)
+				);
+			}, timeoutMs);
+
+			// Listen for sdk-session update emitted by SDKMessageHandler.handleSystemMessage
+			unsubscribe = this.daemonHub.on('session.updated', (payload) => {
+				if (payload.sessionId !== this.session.id) return;
+				// Fast path: payload carries the new id
+				const payloadId = payload.session?.sdkSessionId;
+				if (typeof payloadId === 'string' && payloadId.length > 0) {
+					finish(null, payloadId);
+					return;
+				}
+				// Fallback: check the mutated session object
+				if (this.session.sdkSessionId) {
+					finish(null, this.session.sdkSessionId);
+				}
+			});
+
+			// Re-check synchronously in case the init arrived between the top
+			// check and subscription wiring.
+			if (this.session.sdkSessionId) {
+				finish(null, this.session.sdkSessionId);
+			}
+		});
 	}
 
 	async getSlashCommands(): Promise<string[]> {

--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -339,7 +339,7 @@ function isGateWritableFromNode(
  * The NeoKai system contract (preset) is always applied first; user content follows.
  */
 export function createCustomAgentInit(config: CustomAgentConfig): AgentSessionInit {
-	const { customAgent, space, sessionId, workspacePath, slotOverrides } = config;
+	const { customAgent, task, space, sessionId, workspacePath, slotOverrides } = config;
 
 	const customTools =
 		customAgent.tools && customAgent.tools.length > 0 ? customAgent.tools : undefined;
@@ -373,7 +373,11 @@ export function createCustomAgentInit(config: CustomAgentConfig): AgentSessionIn
 				preset: 'claude_code',
 			},
 			features: SUB_SESSION_FEATURES,
-			context: { spaceId: space.id },
+			// Include taskId on the context so long-lived node-agent sub-sessions
+			// (type: 'worker') are recognised as orchestration-state carriers and
+			// their sdkSessionId is preserved across runtime-fingerprint changes.
+			// See `AgentSession.fromInit` for the preservation guard.
+			context: { spaceId: space.id, taskId: task.id },
 			type: 'worker',
 			model,
 			provider,

--- a/packages/daemon/src/lib/space/managers/space-worktree-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-worktree-manager.ts
@@ -287,6 +287,16 @@ export class SpaceWorktreeManager {
 	 * Return the filesystem path for a task's worktree, or null if none exists.
 	 */
 	async getTaskWorktreePath(spaceId: string, taskId: string): Promise<string | null> {
+		return this.getTaskWorktreePathSync(spaceId, taskId);
+	}
+
+	/**
+	 * Synchronous variant of `getTaskWorktreePath`. Exposed so that sync call sites
+	 * (e.g. the public `TaskAgentManager.getTaskWorktreePath(taskId)` getter used by
+	 * tool handlers and RPCs) can read the persisted path without bouncing through
+	 * a Promise. The underlying repository access is already synchronous.
+	 */
+	getTaskWorktreePathSync(spaceId: string, taskId: string): string | null {
 		const record = this.worktreeRepo.getByTaskId(spaceId, taskId);
 		return record?.path ?? null;
 	}

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1446,21 +1446,19 @@ export class TaskAgentManager {
 			}
 		}
 
-		// Start streaming query for the sub-session
+		// Start streaming query for the sub-session.
+		//
+		// We intentionally do NOT await sdkSessionId capture on this path.
+		// The belt-and-braces "block until init" guarantee lives in
+		// `eagerlySpawnWorkflowNodeAgents`, which runs at the earliest point
+		// we have enough context to pre-create node-agent sessions. Blocking
+		// here regresses the kickoff path: when `spawnWorkflowNodeAgentForExecution`
+		// is called directly from `processRunTick` (no eager spawn yet), the
+		// caller immediately wants to inject the kickoff user message. A 15s
+		// wait ahead of that injection delays kickoff and — if the SDK init
+		// message is slow (dev-proxy) or never arrives — converts to a hard
+		// failure in the caller's `saveUserMessage` via the foreign-key path.
 		await subSession.startStreamingQuery();
-
-		// Block until the SDK has emitted its `init` message and the resulting
-		// sdkSessionId is persisted. See `spawnTaskAgent` for the full rationale —
-		// without this await the window between session creation and
-		// transcript persistence stays open, and any daemon restart inside it
-		// loses the sub-session's conversation history on rehydrate.
-		try {
-			await subSession.awaitSdkSessionCaptured(15_000);
-		} catch (err) {
-			log.warn(
-				`TaskAgentManager: sdkSessionId capture timed out for sub-session ${sessionId}: ${err instanceof Error ? err.message : String(err)}`
-			);
-		}
 
 		// Flush any queued messages addressed to this agent name so that the
 		// reopen/startup race doesn't drop Task Agent → node-agent messages.

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -264,6 +264,20 @@ export class TaskAgentManager {
 	private taskDbQueryServers = new Map<string, DbQueryMcpServer>();
 
 	/**
+	 * Eager sub-session index: taskId → (agentName → sessionId).
+	 *
+	 * Populated by `eagerlySpawnWorkflowNodeAgents()` at task-agent spawn time.
+	 * Consulted by `createSubSession()`'s reuse path so that a later
+	 * workflow-node activation for the same `agentName` picks up the already-
+	 * alive eager session instead of creating a second one.
+	 *
+	 * This is an in-memory fast path. The authoritative record is the
+	 * corresponding `node_executions` row (with `agentSessionId` set), which
+	 * also drives DB-backed rehydration after daemon restarts.
+	 */
+	private eagerSubSessionIds = new Map<string, Map<string, string>>();
+
+	/**
 	 * Unsubscribe function for the `space.task.updated` listener that triggers
 	 * full session cleanup when a task reaches `archived` state.
 	 * Populated on first cleanup subscription attempt; cleared in `cleanupAll()`.
@@ -655,6 +669,47 @@ export class TaskAgentManager {
 			// --- Start streaming query
 			await agentSession.startStreamingQuery();
 
+			// --- Block until the SDK has emitted its `init` message and the
+			// resulting sdkSessionId is persisted. Without this await, a daemon
+			// restart between `startStreamingQuery()` and the first inbound SDK
+			// message would leave the DB row with `sdkSessionId = null` — on
+			// rehydrate the SDK has no transcript to resume, so the agent's
+			// conversation history is silently lost. This is the primary root
+			// cause of the "task-agent session lost after daemon restart" bug.
+			//
+			// Best-effort with timeout: worst case we fall through and accept
+			// the pre-fix behaviour, but in practice the SDK init message
+			// arrives within ~1–2 seconds.
+			try {
+				await agentSession.awaitSdkSessionCaptured(15_000);
+			} catch (err) {
+				log.warn(
+					`TaskAgentManager: sdkSessionId capture timed out for task-agent session ${sessionId}: ${err instanceof Error ? err.message : String(err)}`
+				);
+			}
+
+			// --- Eagerly spawn sub-sessions for all workflow node agents.
+			// Each gets `startStreamingQuery` + `awaitSdkSessionCaptured` so the
+			// SDK transcript is persisted before any kickoff work happens.
+			// Deliberately runs BEFORE the task-agent kickoff message so that
+			// a daemon restart at any later point can always resume every
+			// session with a valid sdkSessionId.
+			if (workflow && workflowRun) {
+				try {
+					await this.eagerlySpawnWorkflowNodeAgents({
+						task,
+						space,
+						workflow,
+						workflowRun,
+						workspacePath,
+					});
+				} catch (err) {
+					log.warn(
+						`TaskAgentManager: eager sub-session spawn failed for task ${taskId}: ${err instanceof Error ? err.message : String(err)}`
+					);
+				}
+			}
+
 			// --- Optional kickoff message
 			// Event-driven mode can spawn the session in an idle state and let
 			// explicit inbound messages (human/agent) wake orchestration.
@@ -959,6 +1014,229 @@ export class TaskAgentManager {
 	}
 
 	/**
+	 * Eagerly pre-spawn one sub-session per distinct agent slot referenced by
+	 * the workflow graph, _before_ the task-agent kickoff message is injected.
+	 *
+	 * Why:
+	 * - The task-agent session already exists with its SDK init captured
+	 *   (see `awaitSdkSessionCaptured` in `spawnTaskAgent`).
+	 * - Without eager spawn, node-agent sub-sessions are only created when
+	 *   the workflow activates a node. Any daemon restart between the
+	 *   task-agent kickoff and that activation leaves the node-agent SDK
+	 *   transcripts non-existent, so the workflow effectively starts from
+	 *   scratch on rehydrate.
+	 * - By spawning all referenced agents now and awaiting their SDK init
+	 *   capture, every sub-session's `sdkSessionId` is persisted up front.
+	 *   A restart at any later point can safely resume every session with
+	 *   full history.
+	 *
+	 * The sub-sessions are started but _not_ kicked off — no user message
+	 * is injected. When the workflow activates the corresponding node later,
+	 * `spawnWorkflowNodeAgentForExecution` calls `createSubSession` which
+	 * discovers the pre-spawned session via `eagerSubSessionIds` and reuses
+	 * it (re-attaching the node-agent MCP server with fresh node context
+	 * and firing the kickoff message).
+	 *
+	 * Best-effort per-agent: one slot failure must not break the whole
+	 * pre-spawn pass.
+	 */
+	private async eagerlySpawnWorkflowNodeAgents(ctx: {
+		task: SpaceTask;
+		space: Space;
+		workflow: SpaceWorkflow;
+		workflowRun: SpaceWorkflowRun;
+		workspacePath: string;
+	}): Promise<void> {
+		const { task, space, workflow, workflowRun, workspacePath } = ctx;
+		const taskId = task.id;
+		const spaceId = space.id;
+
+		// Build a map of unique (agentName → {slot, nodeId}) picking the first
+		// occurrence in workflow.nodes iteration order. This matches the reuse
+		// contract: one session per agent name per task lifetime.
+		const eagerTargets = new Map<
+			string,
+			{ slot: ReturnType<typeof resolveNodeAgents>[number]; nodeId: string }
+		>();
+		for (const node of workflow.nodes) {
+			for (const slot of resolveNodeAgents(node)) {
+				if (!slot.agentId) continue;
+				if (eagerTargets.has(slot.name)) continue;
+				eagerTargets.set(slot.name, { slot, nodeId: node.id });
+			}
+		}
+
+		if (eagerTargets.size === 0) return;
+
+		const nameIndex = this.eagerSubSessionIds.get(taskId) ?? new Map<string, string>();
+
+		for (const [agentName, { slot, nodeId }] of eagerTargets) {
+			try {
+				// Stable per-agent session ID so the DB row survives daemon restarts
+				// without needing a NodeExecution link.
+				const baseSessionId = `space:${spaceId}:task:${taskId}:agent:${this.sanitizeAgentNameForId(agentName)}`;
+				const sessionId = this.resolveSessionId(baseSessionId);
+
+				// Resolve slot overrides (same shape as spawnWorkflowNodeAgentForExecution).
+				let slotCustomPrompt: string | undefined = slot.customPrompt?.value;
+				if (!slotCustomPrompt) {
+					const legacySlot = slot as {
+						systemPrompt?: { value: string };
+						instructions?: { value: string };
+					};
+					const legacySp = legacySlot.systemPrompt?.value?.trim() ?? '';
+					const legacyInstr = legacySlot.instructions?.value?.trim() ?? '';
+					if (legacySp && legacyInstr) {
+						slotCustomPrompt = `${legacySp}\n\n${legacyInstr}`;
+					} else {
+						slotCustomPrompt = legacySp || legacyInstr || undefined;
+					}
+				}
+				const slotOverrides: SlotOverrides = {
+					model: slot.model,
+					customPrompt: slotCustomPrompt,
+					disabledSkillIds: slot.disabledSkillIds,
+					extraMcpServers: slot.extraMcpServers,
+				};
+
+				let init = resolveAgentInit({
+					task,
+					space,
+					agentManager: this.config.spaceAgentManager,
+					sessionId,
+					workspacePath,
+					workflowRun,
+					workflow,
+					slotOverrides,
+					agentId: slot.agentId!,
+				});
+
+				// Attach the same MCP server surface that spawnWorkflowNodeAgentForExecution
+				// attaches, so the session is indistinguishable from a normally-spawned one
+				// the moment the workflow activates its node.
+				const nodeAgentMcpServer = this.buildNodeAgentMcpServerForSession(
+					taskId,
+					sessionId,
+					agentName,
+					spaceId,
+					workflowRun.id,
+					workspacePath,
+					nodeId
+				);
+				const subSessionSpaceAgentMcpServer = createSpaceAgentMcpServer({
+					spaceId,
+					runtime: this.config.spaceRuntimeService.getSharedRuntime(),
+					workflowManager: this.config.spaceWorkflowManager,
+					taskRepo: this.config.taskRepo,
+					nodeExecutionRepo: this.config.nodeExecutionRepo,
+					workflowRunRepo: this.config.workflowRunRepo,
+					taskManager: new SpaceTaskManager(
+						this.config.db.getDatabase(),
+						spaceId,
+						this.config.reactiveDb
+					),
+					spaceAgentManager: this.config.spaceAgentManager,
+					taskAgentManager: this,
+					gateDataRepo: this.config.gateDataRepo,
+					daemonHub: this.config.daemonHub,
+					onGateChanged: (runId, gateId) => {
+						void this.config.spaceRuntimeService
+							.notifyGateDataChanged(runId, gateId)
+							.catch(() => {});
+					},
+					getSpaceAutonomyLevel: async (sid) => {
+						const s = await this.config.spaceManager.getSpace(sid);
+						return s?.autonomyLevel ?? 1;
+					},
+					myAgentName: agentName,
+				});
+				init = {
+					...init,
+					mcpServers: {
+						...init.mcpServers,
+						'node-agent': nodeAgentMcpServer as unknown as McpServerConfig,
+						'space-agent-tools': subSessionSpaceAgentMcpServer as unknown as McpServerConfig,
+					},
+				};
+
+				// Create the session via fromInit (bypass createSubSession's reuse path
+				// because we are the first caller and there's nothing to reuse yet).
+				const subSession = AgentSession.fromInit(
+					init,
+					this.config.db,
+					this.config.messageHub,
+					this.config.daemonHub,
+					this.config.getApiKey,
+					this.config.defaultModel,
+					this.config.skillsManager,
+					this.config.appMcpServerRepo
+				);
+
+				// Merge registry-sourced MCP servers alongside the per-session ones.
+				const registryMcpServers = this.config.appMcpManager?.getEnabledMcpConfigs() ?? {};
+				const mergedMcpServers = {
+					...registryMcpServers,
+					...init.mcpServers,
+				};
+				if (Object.keys(mergedMcpServers).length > 0) {
+					subSession.mergeRuntimeMcpServers(mergedMcpServers);
+				}
+
+				// Register in the same in-memory maps as normal sub-sessions so the rest
+				// of the manager can find them transparently.
+				if (!this.subSessions.has(taskId)) {
+					this.subSessions.set(taskId, new Map());
+				}
+				this.subSessions.get(taskId)!.set(sessionId, subSession);
+				this.agentSessionIndex.set(sessionId, subSession);
+				this.config.sessionManager.registerSession(subSession);
+
+				// Record in the eager index so createSubSession's reuse path picks this up
+				// on the real node activation.
+				nameIndex.set(agentName, sessionId);
+
+				// Start the streaming query so the SDK subprocess launches and emits its
+				// init message. No kickoff user message — the session sits idle until the
+				// workflow activation triggers the real spawn call.
+				await subSession.startStreamingQuery();
+				try {
+					await subSession.awaitSdkSessionCaptured(15_000);
+				} catch (err) {
+					log.warn(
+						`TaskAgentManager.eagerlySpawn: sdkSessionId capture timed out for eager sub-session ${sessionId} (agent=${agentName}): ${err instanceof Error ? err.message : String(err)}`
+					);
+				}
+
+				log.info(
+					`TaskAgentManager.eagerlySpawn: pre-spawned sub-session ${sessionId} for agent "${agentName}" (task ${taskId}, node ${nodeId})`
+				);
+			} catch (err) {
+				log.warn(
+					`TaskAgentManager.eagerlySpawn: failed to pre-spawn sub-session for agent "${agentName}" (task ${taskId}): ${err instanceof Error ? err.message : String(err)}`
+				);
+			}
+		}
+
+		if (nameIndex.size > 0) {
+			this.eagerSubSessionIds.set(taskId, nameIndex);
+		}
+	}
+
+	/**
+	 * Sanitize an agent slot name so it is safe to use as a component of a
+	 * session ID: lowercase, alphanumerics + single hyphens, max 40 chars.
+	 */
+	private sanitizeAgentNameForId(name: string): string {
+		return (
+			name
+				.toLowerCase()
+				.replace(/[^a-z0-9]+/g, '-')
+				.replace(/^-+|-+$/g, '')
+				.slice(0, 40) || 'agent'
+		);
+	}
+
+	/**
 	 * Create a sub-session for a workflow node.
 	 *
 	 * Called internally from the SubSessionFactory.create() closure. Creates the
@@ -982,14 +1260,40 @@ export class TaskAgentManager {
 		// spawning a fresh one. Sessions are only torn down when the task is archived.
 		// Primary state is in DB: query nodeExecutionRepo for the most recent session ID
 		// for this agent, then check agentSessionIndex (fast path) or lazily rehydrate.
+		//
+		// Eager-spawn fast path: when `eagerlySpawnWorkflowNodeAgents()` has
+		// pre-created a session for this agent name at task-start time, no
+		// NodeExecution row with `agentSessionId` exists yet. Resolve the
+		// eager session directly from the in-memory index so the reuse logic
+		// below picks it up instead of creating a second session.
 		if (memberInfo?.agentName) {
 			const parentTask = this.config.taskRepo.getTask(taskId);
 			if (parentTask?.workflowRunId) {
-				const existingExecs = this.config.nodeExecutionRepo
+				const eagerSessionId = this.eagerSubSessionIds.get(taskId)?.get(memberInfo.agentName);
+				let prevExec = this.config.nodeExecutionRepo
 					.listByWorkflowRun(parentTask.workflowRunId)
-					.filter((e) => e.agentName === memberInfo.agentName && e.agentSessionId);
-				// listByWorkflowRun returns rows ORDER BY created_at ASC, so .at(-1) is the most recent.
-				const prevExec = existingExecs.at(-1);
+					.filter((e) => e.agentName === memberInfo.agentName && e.agentSessionId)
+					// listByWorkflowRun returns rows ORDER BY created_at ASC, so .at(-1) is the most recent.
+					.at(-1);
+				if (!prevExec && eagerSessionId) {
+					// Synthesize a pseudo-execution record pointing at the eager session
+					// so the downstream reuse logic applies without duplicating it.
+					prevExec = {
+						id: '',
+						workflowRunId: parentTask.workflowRunId,
+						workflowNodeId: memberInfo.nodeId ?? '',
+						agentName: memberInfo.agentName,
+						agentId: memberInfo.agentId ?? null,
+						agentSessionId: eagerSessionId,
+						status: 'pending',
+						result: null,
+						data: null,
+						createdAt: 0,
+						startedAt: null,
+						completedAt: null,
+						updatedAt: 0,
+					};
+				}
 				if (prevExec?.agentSessionId) {
 					// Reuse existing session — get from memory or restore from DB
 					const existing =
@@ -1144,6 +1448,19 @@ export class TaskAgentManager {
 
 		// Start streaming query for the sub-session
 		await subSession.startStreamingQuery();
+
+		// Block until the SDK has emitted its `init` message and the resulting
+		// sdkSessionId is persisted. See `spawnTaskAgent` for the full rationale —
+		// without this await the window between session creation and
+		// transcript persistence stays open, and any daemon restart inside it
+		// loses the sub-session's conversation history on rehydrate.
+		try {
+			await subSession.awaitSdkSessionCaptured(15_000);
+		} catch (err) {
+			log.warn(
+				`TaskAgentManager: sdkSessionId capture timed out for sub-session ${sessionId}: ${err instanceof Error ? err.message : String(err)}`
+			);
+		}
 
 		// Flush any queued messages addressed to this agent name so that the
 		// reopen/startup race doesn't drop Task Agent → node-agent messages.
@@ -1451,9 +1768,26 @@ export class TaskAgentManager {
 	/**
 	 * Returns the worktree path for a task, or undefined if no worktree was created.
 	 * Useful for test assertions and M6 artifact RPCs.
+	 *
+	 * Source of truth is the `space_worktrees` table (populated at worktree-creation
+	 * time and kept there for the full task lifetime). The in-memory map is a cache
+	 * populated on spawn/rehydrate; on cache miss we fall back to a sync DB read so
+	 * callers after a daemon restart or ad-hoc RPC access still get the right path
+	 * without needing a prior in-memory warm-up.
 	 */
 	getTaskWorktreePath(taskId: string): string | undefined {
-		return this.taskWorktreePaths.get(taskId);
+		const cached = this.taskWorktreePaths.get(taskId);
+		if (cached) return cached;
+		if (!this.config.worktreeManager) return undefined;
+		const task = this.config.taskRepo.getTask(taskId);
+		if (!task) return undefined;
+		const stored = this.config.worktreeManager.getTaskWorktreePathSync(task.spaceId, task.id);
+		if (stored) {
+			// Warm the cache so subsequent reads hit the fast path.
+			this.taskWorktreePaths.set(taskId, stored);
+			return stored;
+		}
+		return undefined;
 	}
 
 	/** Returns the Task Agent's AgentSession, or undefined if not spawned. */
@@ -1655,6 +1989,9 @@ export class TaskAgentManager {
 		// 3. Drop the in-memory worktree path (DB record is preserved)
 		this.taskWorktreePaths.delete(taskId);
 
+		// Drop the eager sub-session index (DB NodeExecution rows are preserved).
+		this.eagerSubSessionIds.delete(taskId);
+
 		// 4. Close db-query server to release SQLite handles held by the session
 		const dbQueryServer = this.taskDbQueryServers.get(taskId);
 		if (dbQueryServer) {
@@ -1745,6 +2082,9 @@ export class TaskAgentManager {
 		}
 		// Always remove from in-memory path map regardless of worktreeManager presence.
 		this.taskWorktreePaths.delete(taskId);
+
+		// Drop the eager sub-session index.
+		this.eagerSubSessionIds.delete(taskId);
 
 		// Close db-query server connection for this task.
 		const dbQueryServer = this.taskDbQueryServers.get(taskId);

--- a/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
@@ -2086,6 +2086,314 @@ describe('AgentSession', () => {
 			expect(agentSession.getSessionData().workspacePath).toBe('/new/workspace');
 			expect(agentSession.getSessionData().type).toBe('room');
 		});
+
+		// -------------------------------------------------------------------------
+		// sdkSessionId preservation on runtime-init fingerprint mismatch
+		//
+		// Regression test: the fingerprint branch used to unconditionally clear
+		// `sdkSessionId`. For long-lived orchestration sessions (space_task_agent,
+		// and worker sessions that carry both spaceId + taskId) this silently
+		// dropped the SDK resume chain — after a daemon restart the agent lost
+		// its entire conversation history. The preservation guard in
+		// AgentSession.fromInit keeps these sessions resumable.
+		// -------------------------------------------------------------------------
+
+		const baseMetadata = {
+			messageCount: 3,
+			totalTokens: 1000,
+			inputTokens: 500,
+			outputTokens: 500,
+			totalCost: 0.01,
+			toolCallCount: 2,
+		};
+
+		function existingSession(opts: {
+			id: string;
+			type: Session['type'];
+			context?: Session['context'];
+		}): Session {
+			return {
+				id: opts.id,
+				title: 'Existing',
+				workspacePath: '/test/workspace',
+				createdAt: new Date().toISOString(),
+				lastActiveAt: new Date().toISOString(),
+				status: 'active',
+				config: {
+					model: 'claude-sonnet-4-5-20250929',
+					maxTokens: 8192,
+					temperature: 1,
+				},
+				// Populated sdkSessionId + stale fingerprint forces the mismatch branch.
+				sdkSessionId: 'sdk-existing-abc',
+				metadata: {
+					...baseMetadata,
+					runtimeInitFingerprint: 'stale-fingerprint',
+				},
+				type: opts.type,
+				context: opts.context,
+			} as Session;
+		}
+
+		function buildMockDb(session: Session) {
+			return {
+				getSession: mock(() => session),
+				createSession: mock(() => {}),
+				updateSession: mock(() => {}),
+				getMessagesByStatus: mock(() => []),
+			} as unknown as Database;
+		}
+
+		const mockMessageHub = {} as MessageHub;
+		const mockDaemonHub = {
+			emit: mock(async () => {}),
+			on: mock(() => mock(() => {})),
+		} as unknown as DaemonHub;
+		const mockGetApiKey = mock(async () => 'test-key');
+
+		it('preserves sdkSessionId on fingerprint mismatch for space_task_agent sessions', () => {
+			const session = existingSession({
+				id: 'space:abc:task:t1',
+				type: 'space_task_agent',
+				context: { spaceId: 'abc', taskId: 't1' },
+			});
+			const mockDb = buildMockDb(session);
+
+			const init = {
+				sessionId: session.id,
+				workspacePath: '/test/workspace',
+				type: 'space_task_agent' as const,
+				context: { spaceId: 'abc', taskId: 't1' },
+				model: 'claude-sonnet-4-5-20250929',
+				// Differs from session.config.systemPrompt (undefined) so fingerprint
+				// will change and the mismatch branch is exercised.
+				systemPrompt: 'fresh prompt',
+			};
+
+			const agentSession = AgentSession.fromInit(
+				init,
+				mockDb,
+				mockMessageHub,
+				mockDaemonHub,
+				mockGetApiKey,
+				'claude-sonnet-4-5-20250929'
+			);
+
+			// In-memory session keeps the sdkSessionId (not reset to undefined).
+			expect(agentSession.getSessionData().sdkSessionId).toBe('sdk-existing-abc');
+
+			// Persistence call — fingerprint updated, sdkSessionId NOT in the update payload.
+			const updateCalls = (mockDb as unknown as { updateSession: ReturnType<typeof mock> })
+				.updateSession.mock.calls;
+			expect(updateCalls.length).toBeGreaterThan(0);
+			const updatePayload = updateCalls[0][1] as Record<string, unknown>;
+			// The preservation branch deliberately omits sdkSessionId from the update
+			// (no `updates.sdkSessionId = undefined`), so it is not a key on the payload.
+			expect(Object.prototype.hasOwnProperty.call(updatePayload, 'sdkSessionId')).toBe(false);
+			// Fingerprint is refreshed.
+			const metadata = updatePayload.metadata as Record<string, unknown>;
+			expect(metadata.runtimeInitFingerprint).toEqual(expect.any(String));
+			expect(metadata.runtimeInitFingerprint).not.toBe('stale-fingerprint');
+		});
+
+		it('leaves sdkSessionId untouched for worker sessions (fingerprint branch skipped entirely)', () => {
+			// Worker sessions skip fingerprint tracking inside
+			// `buildRuntimeInitFingerprint` (it returns undefined for workers), so
+			// the mismatch branch never fires for them. sdkSessionId is therefore
+			// preserved by construction — this test pins that invariant down so a
+			// future change that starts fingerprinting workers doesn't silently
+			// start clearing their resume chain.
+			const session = existingSession({
+				id: 'space:abc:task:t1:agent:coder',
+				type: 'worker',
+				context: { spaceId: 'abc', taskId: 't1' },
+			});
+			const mockDb = buildMockDb(session);
+
+			const init = {
+				sessionId: session.id,
+				workspacePath: '/test/workspace',
+				type: 'worker' as const,
+				context: { spaceId: 'abc', taskId: 't1' },
+				model: 'claude-sonnet-4-5-20250929',
+				systemPrompt: 'new prompt',
+			};
+
+			const agentSession = AgentSession.fromInit(
+				init,
+				mockDb,
+				mockMessageHub,
+				mockDaemonHub,
+				mockGetApiKey,
+				'claude-sonnet-4-5-20250929'
+			);
+
+			expect(agentSession.getSessionData().sdkSessionId).toBe('sdk-existing-abc');
+		});
+
+		it('still clears sdkSessionId on fingerprint mismatch for room sessions', () => {
+			const session = existingSession({
+				id: 'room:foo',
+				type: 'room',
+				context: { roomId: 'foo' },
+			});
+			const mockDb = buildMockDb(session);
+
+			const init = {
+				sessionId: session.id,
+				workspacePath: '/test/workspace',
+				type: 'room' as const,
+				context: { roomId: 'foo' },
+				model: 'claude-sonnet-4-5-20250929',
+				systemPrompt: 'new prompt',
+			};
+
+			const agentSession = AgentSession.fromInit(
+				init,
+				mockDb,
+				mockMessageHub,
+				mockDaemonHub,
+				mockGetApiKey,
+				'claude-sonnet-4-5-20250929'
+			);
+
+			// Room sessions are not orchestration carriers — fingerprint mismatch
+			// continues to invalidate the SDK resume chain as before.
+			expect(agentSession.getSessionData().sdkSessionId).toBeUndefined();
+			const updatePayload = (mockDb as unknown as { updateSession: ReturnType<typeof mock> })
+				.updateSession.mock.calls[0][1] as Record<string, unknown>;
+			expect(updatePayload.sdkSessionId).toBeUndefined();
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// awaitSdkSessionCaptured
+	// ---------------------------------------------------------------------------
+
+	describe('awaitSdkSessionCaptured', () => {
+		function makeAgentSessionWithCapturedId(
+			preCapturedSdkSessionId: string | undefined,
+			onListener: (handler: (payload: Record<string, unknown>) => void) => {
+				fire: (payload: Record<string, unknown>) => void;
+				unsubscribe: ReturnType<typeof mock>;
+			}
+		): { agentSession: AgentSession; controls: ReturnType<typeof onListener> } {
+			const session: Session = {
+				id: 'space:s1:task:t1',
+				title: 'Task Agent',
+				workspacePath: '/tmp/workspace',
+				createdAt: new Date().toISOString(),
+				lastActiveAt: new Date().toISOString(),
+				status: 'active',
+				config: {
+					model: 'claude-sonnet-4-5-20250929',
+					maxTokens: 8192,
+					temperature: 1,
+				},
+				metadata: {
+					messageCount: 0,
+					totalTokens: 0,
+					inputTokens: 0,
+					outputTokens: 0,
+					totalCost: 0,
+					toolCallCount: 0,
+				},
+				type: 'space_task_agent',
+				context: { spaceId: 's1', taskId: 't1' },
+				sdkSessionId: preCapturedSdkSessionId,
+			} as Session;
+
+			const mockDb = {
+				getSession: mock(() => session),
+				createSession: mock(() => {}),
+				updateSession: mock(() => {}),
+				getMessagesByStatus: mock(() => []),
+			} as unknown as Database;
+
+			let captured: ReturnType<typeof onListener> | null = null;
+			const mockDaemonHub = {
+				emit: mock(async () => {}),
+				on: mock(
+					(_event: string, handler: (payload: Record<string, unknown>) => void): (() => void) => {
+						captured = onListener(handler);
+						return captured.unsubscribe;
+					}
+				),
+			} as unknown as DaemonHub;
+			const mockMessageHub = {} as MessageHub;
+			const mockGetApiKey = mock(async () => 'test-key');
+
+			const init = {
+				sessionId: session.id,
+				workspacePath: session.workspacePath,
+				type: 'space_task_agent' as const,
+				context: session.context,
+				model: session.config.model,
+			};
+
+			const agentSession = AgentSession.fromInit(
+				init,
+				mockDb,
+				mockMessageHub,
+				mockDaemonHub,
+				mockGetApiKey,
+				'claude-sonnet-4-5-20250929'
+			);
+
+			return {
+				agentSession,
+				// `controls` may still be null if `on()` wasn't called (fast path hit),
+				// callers that need it should trigger the slow path first.
+				controls: captured as unknown as ReturnType<typeof onListener>,
+			};
+		}
+
+		it('resolves immediately when sdkSessionId is already set', async () => {
+			const { agentSession } = makeAgentSessionWithCapturedId('sdk-already-here', () => ({
+				fire: () => {},
+				unsubscribe: mock(() => {}),
+			}));
+			const id = await agentSession.awaitSdkSessionCaptured(500);
+			expect(id).toBe('sdk-already-here');
+		});
+
+		it('resolves when session.updated fires with a sdkSessionId payload', async () => {
+			let handler: ((payload: Record<string, unknown>) => void) | null = null;
+			const unsubscribe = mock(() => {});
+			const { agentSession } = makeAgentSessionWithCapturedId(undefined, (h) => {
+				handler = h;
+				return { fire: h, unsubscribe };
+			});
+
+			const waiter = agentSession.awaitSdkSessionCaptured(2000);
+
+			// Fire an unrelated session.updated event (different sessionId) — ignored.
+			handler?.({ sessionId: 'other-session', session: { sdkSessionId: 'ignored' } });
+			// Fire a matching event → resolves.
+			handler?.({
+				sessionId: 'space:s1:task:t1',
+				session: { sdkSessionId: 'sdk-just-captured' },
+			});
+
+			const id = await waiter;
+			expect(id).toBe('sdk-just-captured');
+			// Listener must be torn down to avoid leaks.
+			expect(unsubscribe).toHaveBeenCalledTimes(1);
+		});
+
+		it('rejects on timeout if the SDK never publishes a sdkSessionId', async () => {
+			const unsubscribe = mock(() => {});
+			const { agentSession } = makeAgentSessionWithCapturedId(undefined, (_h) => ({
+				fire: () => {},
+				unsubscribe,
+			}));
+
+			await expect(agentSession.awaitSdkSessionCaptured(50)).rejects.toThrow(
+				/Timed out after 50ms/
+			);
+			// Listener must be torn down on timeout too.
+			expect(unsubscribe).toHaveBeenCalledTimes(1);
+		});
 	});
 
 	describe('setRuntimeSystemPrompt', () => {

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-eager-spawn.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-eager-spawn.test.ts
@@ -1,0 +1,665 @@
+/**
+ * Unit tests for TaskAgentManager eager sub-session spawning.
+ *
+ * Background (M-eager / bug #84):
+ *
+ * Previously, node-agent sub-sessions were only created lazily when the
+ * workflow activated a node.  Any daemon restart between the task-agent
+ * kickoff and that activation would leave the node-agent SDK transcript
+ * non-existent (sdkSessionId never captured), so the workflow effectively
+ * restarted from scratch on rehydrate.
+ *
+ * The fix: at `spawnTaskAgent()` time, after the worktree is ready and
+ * the task-agent SDK init is captured, eagerly create one AgentSession per
+ * unique agent slot referenced by the workflow graph — `startStreamingQuery`
+ * + `awaitSdkSessionCaptured`, no kickoff message.  When the workflow later
+ * activates its first node, `createSubSession()` discovers the pre-spawned
+ * session via the `eagerSubSessionIds` index and reuses it.
+ *
+ * These tests pin down the behaviour so the bug cannot regress.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
+import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
+import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
+import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
+import { SpaceTaskManager } from '../../../../src/lib/space/managers/space-task-manager.ts';
+import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
+import { SpaceRuntime } from '../../../../src/lib/space/runtime/space-runtime.ts';
+import { TaskAgentManager } from '../../../../src/lib/space/runtime/task-agent-manager.ts';
+import { AgentSession } from '../../../../src/lib/agent/agent-session.ts';
+import type { Space, SpaceTask, SpaceWorkflow, SpaceWorkflowRun } from '@neokai/shared';
+import type { AgentProcessingState } from '@neokai/shared';
+import type { SpaceWorktreeManager } from '../../../../src/lib/space/managers/space-worktree-manager.ts';
+
+// ---------------------------------------------------------------------------
+// Minimal in-process DaemonHub
+// ---------------------------------------------------------------------------
+
+type EventHandler = (data: Record<string, unknown>) => void;
+
+class TestDaemonHub {
+	private listeners = new Map<string, Map<string, EventHandler>>();
+	readonly emitted: Array<{ event: string; data: Record<string, unknown> }> = [];
+
+	on(event: string, handler: EventHandler, opts?: { sessionId?: string }): () => void {
+		const key = opts?.sessionId ? `${event}:${opts.sessionId}` : `${event}:*`;
+		if (!this.listeners.has(key)) this.listeners.set(key, new Map());
+		const id = Math.random().toString(36).slice(2);
+		this.listeners.get(key)!.set(id, handler);
+		return () => {
+			this.listeners.get(key)?.delete(id);
+		};
+	}
+
+	emit(event: string, data: Record<string, unknown>): Promise<void> {
+		this.emitted.push({ event, data });
+		const sessionId = (data as { sessionId?: string }).sessionId;
+		if (sessionId) {
+			const key = `${event}:${sessionId}`;
+			for (const handler of this.listeners.get(key)?.values() ?? []) handler(data);
+		}
+		for (const handler of this.listeners.get(`${event}:*`)?.values() ?? []) handler(data);
+		return Promise.resolve();
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mock AgentSession
+// ---------------------------------------------------------------------------
+
+interface MockAgentSession {
+	session: {
+		id: string;
+		context?: Record<string, unknown>;
+		config?: { mcpServers?: Record<string, unknown> };
+		type?: string;
+	};
+	getProcessingState: () => AgentProcessingState;
+	getSDKMessageCount: () => number;
+	getSessionData: () => { id: string; context?: Record<string, unknown> };
+	setRuntimeMcpServers: (servers: Record<string, unknown>) => void;
+	mergeRuntimeMcpServers: (servers: Record<string, unknown>) => void;
+	detachRuntimeMcpServer: (name: string) => void;
+	restartQuery: () => Promise<void>;
+	setRuntimeSystemPrompt: (systemPrompt: unknown) => void;
+	startStreamingQuery: () => Promise<void>;
+	ensureQueryStarted: () => Promise<void>;
+	awaitSdkSessionCaptured: (timeoutMs?: number) => Promise<string>;
+	handleInterrupt: () => Promise<void>;
+	cleanup: () => Promise<void>;
+	messageQueue: { enqueueWithId: (id: string, msg: string) => Promise<void> };
+	_startCalled: boolean;
+	_sdkAwaited: boolean;
+	_enqueuedMessages: Array<{ id: string; msg: string }>;
+	_mcpServers: Record<string, unknown>;
+}
+
+function makeMockSession(
+	sessionId: string,
+	context: Record<string, unknown> = {}
+): MockAgentSession {
+	const m: MockAgentSession = {
+		session: { id: sessionId, context, config: { mcpServers: {} } },
+		_startCalled: false,
+		_sdkAwaited: false,
+		_enqueuedMessages: [],
+		_mcpServers: {},
+
+		getProcessingState() {
+			return { status: 'idle' } as AgentProcessingState;
+		},
+		getSDKMessageCount() {
+			return 0;
+		},
+		getSessionData() {
+			return this.session;
+		},
+		setRuntimeMcpServers(servers) {
+			this._mcpServers = servers;
+			this.session.config = { ...(this.session.config ?? {}), mcpServers: servers };
+		},
+		mergeRuntimeMcpServers(servers) {
+			this._mcpServers = { ...this._mcpServers, ...servers };
+			this.session.config = {
+				...(this.session.config ?? {}),
+				mcpServers: { ...(this.session.config?.mcpServers ?? {}), ...servers },
+			};
+		},
+		detachRuntimeMcpServer(name) {
+			const updated = { ...this._mcpServers };
+			delete updated[name];
+			this._mcpServers = updated;
+			const updatedCfg = { ...(this.session.config?.mcpServers ?? {}) };
+			delete updatedCfg[name];
+			this.session.config = { ...(this.session.config ?? {}), mcpServers: updatedCfg };
+		},
+		async restartQuery() {},
+		setRuntimeSystemPrompt(_sp: unknown) {},
+		async startStreamingQuery() {
+			this._startCalled = true;
+		},
+		async ensureQueryStarted() {
+			this._startCalled = true;
+		},
+		async awaitSdkSessionCaptured() {
+			this._sdkAwaited = true;
+			return `sdk-${sessionId}`;
+		},
+		async handleInterrupt() {},
+		async cleanup() {},
+		messageQueue: {
+			async enqueueWithId(id: string, msg: string) {
+				m._enqueuedMessages.push({ id, msg });
+			},
+		},
+	};
+	return m;
+}
+
+// ---------------------------------------------------------------------------
+// Mock SpaceWorktreeManager (minimal, tracks storedTaskIds)
+// ---------------------------------------------------------------------------
+
+function makeMockWorktreeManager(worktreePath = '/tmp/worktrees/eager-test') {
+	const stored = new Set<string>();
+	return {
+		stored,
+		async createTaskWorktree(_spaceId: string, taskId: string) {
+			stored.add(taskId);
+			return { path: worktreePath, slug: 'eager-test-slug' };
+		},
+		async removeTaskWorktree(_spaceId: string, taskId: string) {
+			stored.delete(taskId);
+		},
+		markTaskWorktreeCompleted() {},
+		async cleanupOrphaned() {},
+		async reapExpiredWorktrees() {},
+		async getTaskWorktreePath(_spaceId: string, taskId: string) {
+			return stored.has(taskId) ? worktreePath : null;
+		},
+		getTaskWorktreePathSync(_spaceId: string, taskId: string) {
+			return stored.has(taskId) ? worktreePath : null;
+		},
+		async listWorktrees() {
+			return [];
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// DB helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(): BunDatabase {
+	const db = new BunDatabase(':memory:');
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	return db;
+}
+
+function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/workspace'): void {
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
+}
+
+function seedAgentRow(db: BunDatabase, agentId: string, spaceId: string): void {
+	db.prepare(
+		`INSERT INTO space_agents (id, space_id, name, description, model, tools, system_prompt, created_at, updated_at)
+     VALUES (?, ?, ?, '', null, '[]', '', ?, ?)`
+	).run(agentId, spaceId, `Agent ${agentId}`, Date.now(), Date.now());
+}
+
+function makeSpace(spaceId: string, workspacePath = '/tmp/workspace'): Space {
+	return {
+		id: spaceId,
+		slug: `space-${spaceId}`,
+		workspacePath,
+		name: `Space ${spaceId}`,
+		description: '',
+		backgroundContext: '',
+		instructions: '',
+		sessionIds: [],
+		status: 'active',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Test context
+// ---------------------------------------------------------------------------
+
+interface TestCtx {
+	bunDb: BunDatabase;
+	spaceId: string;
+	space: Space;
+	coderAgentId: string;
+	reviewerAgentId: string;
+	taskRepo: SpaceTaskRepository;
+	workflowRunRepo: SpaceWorkflowRunRepository;
+	nodeExecutionRepo: NodeExecutionRepository;
+	taskManager: SpaceTaskManager;
+	workflowManager: SpaceWorkflowManager;
+	manager: TaskAgentManager;
+	createdSessions: Map<string, MockAgentSession>;
+	fromInitSpy: ReturnType<typeof spyOn<typeof AgentSession, 'fromInit'>>;
+}
+
+function makeCtx(): TestCtx {
+	const bunDb = makeDb();
+	const spaceId = 'space-eager-test';
+	const workspacePath = '/tmp/test-workspace-eager';
+
+	seedSpaceRow(bunDb, spaceId, workspacePath);
+
+	const coderAgentId = 'agent-coder-eager';
+	const reviewerAgentId = 'agent-reviewer-eager';
+	seedAgentRow(bunDb, coderAgentId, spaceId);
+	seedAgentRow(bunDb, reviewerAgentId, spaceId);
+
+	const agentRepo = new SpaceAgentRepository(bunDb);
+	const agentManager = new SpaceAgentManager(agentRepo);
+	const workflowRepo = new SpaceWorkflowRepository(bunDb);
+	const workflowManager = new SpaceWorkflowManager(workflowRepo);
+	const workflowRunRepo = new SpaceWorkflowRunRepository(bunDb);
+	const taskRepo = new SpaceTaskRepository(bunDb);
+	const nodeExecutionRepo = new NodeExecutionRepository(bunDb);
+	const spaceManager = new SpaceManager(bunDb);
+	const taskManager = new SpaceTaskManager(bunDb, spaceId);
+	const runtime = new SpaceRuntime({
+		db: bunDb,
+		spaceManager,
+		spaceAgentManager: agentManager,
+		spaceWorkflowManager: workflowManager,
+		workflowRunRepo,
+		taskRepo,
+		nodeExecutionRepo,
+	});
+	const daemonHub = new TestDaemonHub();
+	const space = makeSpace(spaceId, workspacePath);
+
+	const createdSessions = new Map<string, MockAgentSession>();
+	const dbSessions = new Map<string, unknown>();
+
+	const mockDb = {
+		getSession: (id: string) => (dbSessions.has(id) ? dbSessions.get(id) : null),
+		createSession: (session: unknown) => {
+			dbSessions.set((session as { id: string }).id, session);
+		},
+		deleteSession: (id: string) => {
+			dbSessions.delete(id);
+		},
+		saveUserMessage: () => 'msg-id',
+		updateSession: () => {},
+		getDatabase: () => bunDb,
+	};
+
+	const mockSpaceRuntimeService = {
+		createOrGetRuntime: async () => runtime,
+		getSharedRuntime: () => runtime,
+		notifyGateDataChanged: async () => {},
+	};
+
+	const mockSessionManager = {
+		deleteSession: async () => {},
+		registerSession: () => {},
+		getSessionFromDB: (sessionId: string) => {
+			const row = mockDb.getSession(sessionId);
+			return row ? ({ id: sessionId } as { id: string }) : null;
+		},
+	};
+
+	const fromInitSpy = spyOn(AgentSession, 'fromInit').mockImplementation((init: unknown) => {
+		const initTyped = init as {
+			sessionId: string;
+			context?: Record<string, unknown>;
+			type?: string;
+		};
+		const mockSession = makeMockSession(initTyped.sessionId, initTyped.context ?? {});
+		mockSession.session.type = initTyped.type;
+		createdSessions.set(initTyped.sessionId, mockSession);
+		mockDb.createSession({ id: initTyped.sessionId, type: initTyped.type });
+		return mockSession as unknown as AgentSession;
+	});
+
+	const worktreeManager = makeMockWorktreeManager();
+
+	const manager = new TaskAgentManager({
+		db: mockDb as unknown as import('../../../../src/storage/database.ts').Database,
+		sessionManager:
+			mockSessionManager as unknown as import('../../../../src/lib/session/session-manager.ts').SessionManager,
+		spaceManager,
+		spaceAgentManager: agentManager,
+		spaceWorkflowManager: workflowManager,
+		spaceRuntimeService:
+			mockSpaceRuntimeService as unknown as import('../../../../src/lib/space/runtime/space-runtime-service.ts').SpaceRuntimeService,
+		taskRepo,
+		workflowRunRepo,
+		nodeExecutionRepo,
+		daemonHub: daemonHub as unknown as import('../../../../src/lib/daemon-hub.ts').DaemonHub,
+		messageHub: {} as unknown as import('@neokai/shared').MessageHub,
+		getApiKey: async () => 'test-key',
+		defaultModel: 'claude-sonnet-4-5-20250929',
+		worktreeManager: worktreeManager as unknown as SpaceWorktreeManager,
+	});
+
+	return {
+		bunDb,
+		spaceId,
+		space,
+		coderAgentId,
+		reviewerAgentId,
+		taskRepo,
+		workflowRunRepo,
+		nodeExecutionRepo,
+		taskManager,
+		workflowManager,
+		manager,
+		createdSessions,
+		fromInitSpy,
+	};
+}
+
+/**
+ * Creates a two-node workflow (coder → reviewer) and a workflow run, then
+ * returns both so callers can drive `spawnTaskAgent`.
+ */
+function seedTwoNodeWorkflow(ctx: TestCtx): {
+	workflow: SpaceWorkflow;
+	workflowRun: SpaceWorkflowRun;
+} {
+	const workflow = ctx.workflowManager.createWorkflow({
+		spaceId: ctx.spaceId,
+		name: 'Coding workflow',
+		description: '',
+		nodes: [
+			{
+				id: 'node-coding',
+				name: 'Coding',
+				agents: [{ agentId: ctx.coderAgentId, name: 'coder' }],
+			},
+			{
+				id: 'node-review',
+				name: 'Review',
+				agents: [{ agentId: ctx.reviewerAgentId, name: 'reviewer' }],
+			},
+		],
+		startNodeId: 'node-coding',
+		tags: [],
+		completionAutonomyLevel: 3,
+	});
+	const now = Date.now();
+	const runId = `run-eager-${Math.random().toString(36).slice(2, 8)}`;
+	ctx.bunDb
+		.prepare(
+			`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at, updated_at)
+       VALUES (?, ?, ?, '', 'in_progress', ?, ?)`
+		)
+		.run(runId, ctx.spaceId, workflow.id, now, now);
+	const workflowRun = ctx.workflowRunRepo.getRun(runId)!;
+	return { workflow, workflowRun };
+}
+
+async function makeTaskLinked(ctx: TestCtx, workflowRun: SpaceWorkflowRun): Promise<SpaceTask> {
+	const task = await ctx.taskManager.createTask({
+		title: 'Test task with workflow',
+		description: 'Eager spawn test',
+		taskType: 'coding',
+		status: 'open',
+		workflowRunId: workflowRun.id,
+	});
+	ctx.taskRepo.updateTask(task.id, { workflowRunId: workflowRun.id });
+	return ctx.taskRepo.getTask(task.id)!;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TaskAgentManager — eager sub-session spawning', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.fromInitSpy.mockRestore();
+	});
+
+	test('spawns one sub-session per distinct agent slot when a workflow is provided', async () => {
+		const { workflow, workflowRun } = seedTwoNodeWorkflow(ctx);
+		const task = await makeTaskLinked(ctx, workflowRun);
+
+		const taskAgentSessionId = await ctx.manager.spawnTaskAgent(
+			task,
+			ctx.space,
+			workflow,
+			workflowRun
+		);
+
+		// Task-agent session always exists.
+		expect(ctx.createdSessions.has(taskAgentSessionId)).toBe(true);
+
+		// Eager node-agent sessions: one for "coder", one for "reviewer".
+		const coderSessionId = `space:${ctx.spaceId}:task:${task.id}:agent:coder`;
+		const reviewerSessionId = `space:${ctx.spaceId}:task:${task.id}:agent:reviewer`;
+		expect(ctx.createdSessions.has(coderSessionId)).toBe(true);
+		expect(ctx.createdSessions.has(reviewerSessionId)).toBe(true);
+	});
+
+	test('awaits sdk-session capture on each eager sub-session (no restart window)', async () => {
+		const { workflow, workflowRun } = seedTwoNodeWorkflow(ctx);
+		const task = await makeTaskLinked(ctx, workflowRun);
+
+		await ctx.manager.spawnTaskAgent(task, ctx.space, workflow, workflowRun);
+
+		const coderSession = ctx.createdSessions.get(
+			`space:${ctx.spaceId}:task:${task.id}:agent:coder`
+		)!;
+		const reviewerSession = ctx.createdSessions.get(
+			`space:${ctx.spaceId}:task:${task.id}:agent:reviewer`
+		)!;
+
+		// Eager sessions must have started streaming and awaited sdkSessionId
+		// capture — this is the whole point of eager spawn.
+		expect(coderSession._startCalled).toBe(true);
+		expect(coderSession._sdkAwaited).toBe(true);
+		expect(reviewerSession._startCalled).toBe(true);
+		expect(reviewerSession._sdkAwaited).toBe(true);
+	});
+
+	test('does NOT inject a kickoff message into eager sub-sessions', async () => {
+		const { workflow, workflowRun } = seedTwoNodeWorkflow(ctx);
+		const task = await makeTaskLinked(ctx, workflowRun);
+
+		await ctx.manager.spawnTaskAgent(task, ctx.space, workflow, workflowRun);
+
+		const coderSession = ctx.createdSessions.get(
+			`space:${ctx.spaceId}:task:${task.id}:agent:coder`
+		)!;
+		const reviewerSession = ctx.createdSessions.get(
+			`space:${ctx.spaceId}:task:${task.id}:agent:reviewer`
+		)!;
+
+		// Eager sub-sessions sit idle until the workflow activates their node —
+		// no user-facing kickoff message should have been enqueued.
+		expect(coderSession._enqueuedMessages).toEqual([]);
+		expect(reviewerSession._enqueuedMessages).toEqual([]);
+	});
+
+	test('deduplicates agent slots that appear on multiple nodes (one session per name)', async () => {
+		// Build a workflow where the same agent slot name appears on two nodes.
+		// Only one eager session should be pre-spawned (first-occurrence wins).
+		const workflow = ctx.workflowManager.createWorkflow({
+			spaceId: ctx.spaceId,
+			name: 'Dup-slot workflow',
+			description: '',
+			nodes: [
+				{
+					id: 'node-a',
+					name: 'A',
+					agents: [{ agentId: ctx.coderAgentId, name: 'coder' }],
+				},
+				{
+					id: 'node-b',
+					name: 'B',
+					agents: [{ agentId: ctx.coderAgentId, name: 'coder' }],
+				},
+			],
+			startNodeId: 'node-a',
+			tags: [],
+			completionAutonomyLevel: 3,
+		});
+		const now = Date.now();
+		const runId = 'run-dedup';
+		ctx.bunDb
+			.prepare(
+				`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at, updated_at)
+         VALUES (?, ?, ?, '', 'in_progress', ?, ?)`
+			)
+			.run(runId, ctx.spaceId, workflow.id, now, now);
+		const workflowRun = ctx.workflowRunRepo.getRun(runId)!;
+		const task = await makeTaskLinked(ctx, workflowRun);
+
+		await ctx.manager.spawnTaskAgent(task, ctx.space, workflow, workflowRun);
+
+		// Count sessions whose id looks like `...:agent:coder`.
+		const agentSessionIds = Array.from(ctx.createdSessions.keys()).filter((id) =>
+			id.includes(':agent:coder')
+		);
+		expect(agentSessionIds).toHaveLength(1);
+	});
+
+	test('does NOT eagerly spawn when no workflow is provided (standalone task)', async () => {
+		const task = await ctx.taskManager.createTask({
+			title: 'Standalone',
+			description: '',
+			taskType: 'coding',
+			status: 'open',
+		});
+
+		const taskAgentSessionId = await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+		// Task agent exists; no eager node-agent sessions should have been created.
+		expect(ctx.createdSessions.has(taskAgentSessionId)).toBe(true);
+		const agentSlotSessions = Array.from(ctx.createdSessions.keys()).filter((id) =>
+			id.includes(':agent:')
+		);
+		expect(agentSlotSessions).toHaveLength(0);
+	});
+
+	test('awaits sdk-session capture on the task-agent itself', async () => {
+		const task = await ctx.taskManager.createTask({
+			title: 'Standalone',
+			description: '',
+			taskType: 'coding',
+			status: 'open',
+		});
+		const taskAgentSessionId = await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+		const taskAgent = ctx.createdSessions.get(taskAgentSessionId)!;
+		expect(taskAgent._startCalled).toBe(true);
+		expect(taskAgent._sdkAwaited).toBe(true);
+	});
+
+	test('eager sessions are registered in subSessions map so getSubSession finds them', async () => {
+		const { workflow, workflowRun } = seedTwoNodeWorkflow(ctx);
+		const task = await makeTaskLinked(ctx, workflowRun);
+
+		await ctx.manager.spawnTaskAgent(task, ctx.space, workflow, workflowRun);
+
+		const coderSessionId = `space:${ctx.spaceId}:task:${task.id}:agent:coder`;
+		const reviewerSessionId = `space:${ctx.spaceId}:task:${task.id}:agent:reviewer`;
+
+		// Both eager sessions must be discoverable via the public getter — that
+		// is how `createSubSession`'s reuse path finds them when the workflow
+		// activates a node later.
+		expect(ctx.manager.getSubSession(coderSessionId)).toBeDefined();
+		expect(ctx.manager.getSubSession(reviewerSessionId)).toBeDefined();
+	});
+
+	test('eager index maps agent names → eager session IDs for createSubSession reuse', async () => {
+		const { workflow, workflowRun } = seedTwoNodeWorkflow(ctx);
+		const task = await makeTaskLinked(ctx, workflowRun);
+
+		await ctx.manager.spawnTaskAgent(task, ctx.space, workflow, workflowRun);
+
+		// The reuse path in createSubSession reads from this private index.
+		// Asserting its contents pins the contract: one entry per slot name.
+		const eagerIndex = (
+			ctx.manager as unknown as {
+				eagerSubSessionIds: Map<string, Map<string, string>>;
+			}
+		).eagerSubSessionIds.get(task.id);
+
+		expect(eagerIndex).toBeDefined();
+		expect(eagerIndex!.get('coder')).toBe(`space:${ctx.spaceId}:task:${task.id}:agent:coder`);
+		expect(eagerIndex!.get('reviewer')).toBe(`space:${ctx.spaceId}:task:${task.id}:agent:reviewer`);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// getTaskWorktreePath fallback to DB
+// ---------------------------------------------------------------------------
+
+describe('TaskAgentManager.getTaskWorktreePath — DB fallback', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.fromInitSpy.mockRestore();
+	});
+
+	test('hits in-memory cache on the fast path after spawn', async () => {
+		const { workflow, workflowRun } = seedTwoNodeWorkflow(ctx);
+		const task = await makeTaskLinked(ctx, workflowRun);
+
+		await ctx.manager.spawnTaskAgent(task, ctx.space, workflow, workflowRun);
+
+		// Directly after spawn, the in-memory cache is populated.
+		expect(ctx.manager.getTaskWorktreePath(task.id)).toBe('/tmp/worktrees/eager-test');
+	});
+
+	test('falls back to DB read when the in-memory cache is empty', async () => {
+		const { workflow, workflowRun } = seedTwoNodeWorkflow(ctx);
+		const task = await makeTaskLinked(ctx, workflowRun);
+
+		await ctx.manager.spawnTaskAgent(task, ctx.space, workflow, workflowRun);
+
+		// Simulate a process restart: wipe the in-memory cache.
+		// (Access via the private field for test purposes — matches how the
+		// rehydration path would find an empty map after daemon boot.)
+		(
+			ctx.manager as unknown as { taskWorktreePaths: Map<string, string> }
+		).taskWorktreePaths.clear();
+
+		// The DB-backed worktree record is still there, so the sync fallback
+		// should produce the path and warm the cache.
+		expect(ctx.manager.getTaskWorktreePath(task.id)).toBe('/tmp/worktrees/eager-test');
+		// Verify it was re-cached for the next call.
+		expect(
+			(ctx.manager as unknown as { taskWorktreePaths: Map<string, string> }).taskWorktreePaths.get(
+				task.id
+			)
+		).toBe('/tmp/worktrees/eager-test');
+	});
+
+	test('returns undefined when neither cache nor DB has a record', () => {
+		// Task doesn't exist in repo; fallback returns undefined.
+		expect(ctx.manager.getTaskWorktreePath('unknown-task-id')).toBeUndefined();
+	});
+});

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-mcp.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-mcp.test.ts
@@ -78,6 +78,7 @@ interface MockAgentSession {
 	setRuntimeSystemPrompt: (sp: unknown) => void;
 	startStreamingQuery: () => Promise<void>;
 	ensureQueryStarted: () => Promise<void>;
+	awaitSdkSessionCaptured: (timeoutMs?: number) => Promise<string>;
 	handleInterrupt: () => Promise<void>;
 	cleanup: () => Promise<void>;
 	messageQueue: { enqueueWithId: (id: string, msg: string) => Promise<void> };
@@ -117,6 +118,9 @@ function makeMockSession(sessionId: string): MockAgentSession {
 		setRuntimeSystemPrompt(_sp: unknown) {},
 		async startStreamingQuery() {},
 		async ensureQueryStarted() {},
+		async awaitSdkSessionCaptured() {
+			return `sdk-${sessionId}`;
+		},
 		async handleInterrupt() {},
 		async cleanup() {},
 		messageQueue: {

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
@@ -81,6 +81,7 @@ interface MockAgentSession {
 	setRuntimeSystemPrompt: (systemPrompt: unknown) => void;
 	startStreamingQuery: () => Promise<void>;
 	ensureQueryStarted: () => Promise<void>;
+	awaitSdkSessionCaptured: (timeoutMs?: number) => Promise<string>;
 	handleInterrupt: () => Promise<void>;
 	cleanup: () => Promise<void>;
 	messageQueue: { enqueueWithId: (id: string, msg: string) => Promise<void> };
@@ -140,6 +141,9 @@ function makeMockSession(sessionId: string): MockAgentSession {
 		},
 		async ensureQueryStarted() {
 			this._startCalled = true;
+		},
+		async awaitSdkSessionCaptured() {
+			return `sdk-${sessionId}`;
 		},
 		async handleInterrupt() {},
 		async cleanup() {

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-worktree.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-worktree.test.ts
@@ -92,6 +92,7 @@ interface MockAgentSession {
 	setRuntimeSystemPrompt: (systemPrompt: unknown) => void;
 	startStreamingQuery: () => Promise<void>;
 	ensureQueryStarted: () => Promise<void>;
+	awaitSdkSessionCaptured: (timeoutMs?: number) => Promise<string>;
 	handleInterrupt: () => Promise<void>;
 	cleanup: () => Promise<void>;
 	messageQueue: { enqueueWithId: (id: string, msg: string) => Promise<void> };
@@ -152,6 +153,9 @@ function makeMockSession(
 		async ensureQueryStarted() {
 			this._startCalled = true;
 		},
+		async awaitSdkSessionCaptured() {
+			return `sdk-${sessionId}`;
+		},
 		async handleInterrupt() {},
 		async cleanup() {
 			this._cleanupCalled = true;
@@ -179,6 +183,10 @@ interface MockWorktreeManager {
 	worktreePath: string;
 	/** If set, createTaskWorktree throws this error */
 	createError?: Error;
+	/** Internal: taskIds that have a "stored" worktree record (mirrors the
+	 *  real `space_worktrees` table). Populated on successful create, cleared
+	 *  on remove. */
+	storedTaskIds: Set<string>;
 
 	createTaskWorktree(
 		spaceId: string,
@@ -191,6 +199,7 @@ interface MockWorktreeManager {
 	cleanupOrphaned(spaceId: string): Promise<void>;
 	reapExpiredWorktrees(ttlMs?: number): Promise<void>;
 	getTaskWorktreePath(spaceId: string, taskId: string): Promise<string | null>;
+	getTaskWorktreePathSync(spaceId: string, taskId: string): string | null;
 	listWorktrees(spaceId: string): Promise<[]>;
 }
 
@@ -202,14 +211,17 @@ function makeMockWorktreeManager(worktreePath = '/tmp/worktrees/test-task'): Moc
 		orphanedCleanupCalls: [],
 		reapCalls: 0,
 		worktreePath,
+		storedTaskIds: new Set<string>(),
 
 		async createTaskWorktree(spaceId, taskId, taskTitle, taskNumber) {
 			m.createCalls.push({ spaceId, taskId, taskTitle, taskNumber });
 			if (m.createError) throw m.createError;
+			m.storedTaskIds.add(taskId);
 			return { path: m.worktreePath, slug: 'test-slug' };
 		},
 		async removeTaskWorktree(spaceId, taskId) {
 			m.removeCalls.push({ spaceId, taskId });
+			m.storedTaskIds.delete(taskId);
 		},
 		markTaskWorktreeCompleted(spaceId, taskId) {
 			m.completedCalls.push({ spaceId, taskId });
@@ -220,8 +232,11 @@ function makeMockWorktreeManager(worktreePath = '/tmp/worktrees/test-task'): Moc
 		async reapExpiredWorktrees(_ttlMs) {
 			m.reapCalls++;
 		},
-		async getTaskWorktreePath(_spaceId, _taskId) {
-			return m.worktreePath;
+		async getTaskWorktreePath(_spaceId, taskId) {
+			return m.storedTaskIds.has(taskId) ? m.worktreePath : null;
+		},
+		getTaskWorktreePathSync(_spaceId, taskId) {
+			return m.storedTaskIds.has(taskId) ? m.worktreePath : null;
 		},
 		async listWorktrees(_spaceId) {
 			return [];

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
@@ -96,6 +96,7 @@ interface MockAgentSession {
 	setRuntimeSystemPrompt: (systemPrompt: unknown) => void;
 	startStreamingQuery: () => Promise<void>;
 	ensureQueryStarted: () => Promise<void>;
+	awaitSdkSessionCaptured: (timeoutMs?: number) => Promise<string>;
 	handleInterrupt: () => Promise<void>;
 	cleanup: () => Promise<void>;
 	messageQueue: { enqueueWithId: (id: string, msg: string) => Promise<void> };
@@ -155,6 +156,9 @@ function makeMockSession(
 		},
 		async ensureQueryStarted() {
 			this._startCalled = true;
+		},
+		async awaitSdkSessionCaptured() {
+			return `sdk-${sessionId}`;
 		},
 		async handleInterrupt() {},
 		async cleanup() {

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-session-lifecycle.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-session-lifecycle.test.ts
@@ -89,6 +89,7 @@ interface MockAgentSession {
 	setRuntimeSystemPrompt: (systemPrompt: unknown) => void;
 	startStreamingQuery: () => Promise<void>;
 	ensureQueryStarted: () => Promise<void>;
+	awaitSdkSessionCaptured: (timeoutMs?: number) => Promise<string>;
 	handleInterrupt: () => Promise<void>;
 	cleanup: () => Promise<void>;
 	messageQueue: { enqueueWithId: (id: string, msg: string) => Promise<void> };
@@ -147,6 +148,9 @@ function makeMockSession(
 		},
 		async ensureQueryStarted() {
 			this._startCalled = true;
+		},
+		async awaitSdkSessionCaptured() {
+			return `sdk-${sessionId}`;
 		},
 		async handleInterrupt() {},
 		async cleanup() {
@@ -513,6 +517,10 @@ describe('Task Agent Session Lifecycle', () => {
 				},
 				removeTaskWorktree: async () => {},
 				markTaskWorktreeCompleted: () => {},
+				// DB-fallback stub: returns null so the path read in getTaskWorktreePath
+				// after cleanup (which clears the in-memory cache) remains undefined.
+				// Matches real behaviour when no `space_worktrees` row exists.
+				getTaskWorktreePathSync: () => null,
 			};
 
 			const manager = new TaskAgentManager({
@@ -675,6 +683,8 @@ describe('Task Agent Session Lifecycle', () => {
 					void spaceId;
 					void taskId;
 				},
+				// DB-fallback stub: no stored record in this test → null.
+				getTaskWorktreePathSync: () => null,
 			};
 
 			const manager = new TaskAgentManager({
@@ -734,6 +744,8 @@ describe('Task Agent Session Lifecycle', () => {
 					removedWorktrees.push(`${spaceId}:${taskId}`);
 				},
 				markTaskWorktreeCompleted: () => {},
+				// DB-fallback stub: no stored record in this test → null.
+				getTaskWorktreePathSync: () => null,
 			};
 
 			const manager = new TaskAgentManager({
@@ -789,6 +801,8 @@ describe('Task Agent Session Lifecycle', () => {
 				markTaskWorktreeCompleted: (spaceId: string, taskId: string) => {
 					completedWorktrees.push(`${spaceId}:${taskId}`);
 				},
+				// DB-fallback stub: no stored record in this test → null.
+				getTaskWorktreePathSync: () => null,
 			};
 
 			const manager = new TaskAgentManager({

--- a/packages/daemon/tests/unit/5-space/runtime/space-worktree-manager.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-worktree-manager.test.ts
@@ -348,6 +348,17 @@ describe('getTaskWorktreePath', () => {
 		const result = await manager.getTaskWorktreePath(spaceId, 'does-not-exist');
 		expect(result).toBeNull();
 	});
+
+	// Sync variant was introduced so sync call sites (e.g. TaskAgentManager's
+	// public getter used by tool handlers and RPCs) can read the persisted
+	// path without bouncing through a Promise. The two variants must agree.
+	test('getTaskWorktreePathSync mirrors the async variant', async () => {
+		const taskId = seedTask(db, spaceId, 'task-path-sync-01', 6);
+		const { path } = await manager.createTaskWorktree(spaceId, taskId, 'Sync Task', 6);
+
+		expect(manager.getTaskWorktreePathSync(spaceId, taskId)).toBe(path);
+		expect(manager.getTaskWorktreePathSync(spaceId, 'no-such-task')).toBeNull();
+	});
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes a task-agent session getting lost after a daemon restart that happened early in the task's lifecycle (before any kickoff message).

**Root cause.** The task-agent and its workflow node sub-sessions captured their `sdkSessionId` asynchronously on first SDK init. If a restart intervened before that event — or after a fingerprint-triggered runtime re-init — the captured ID was wiped and the SDK treated the resumed session as fresh. On top of that, sub-sessions were created lazily on first message, so a restart between `spawnTaskAgent` and first user message left no in-memory `AgentSession` for the node agents — rehydration had nothing to hook into.

**Fix.**
- `AgentSession.fromInit` now preserves `sdkSessionId` on fingerprint mismatch for `space_task_agent` sessions.
- New `AgentSession.awaitSdkSessionCaptured(timeoutMs)` helper (polls `session.updated` with timeout). Used by spawn + eager paths to guarantee the ID is persisted before returning.
- `TaskAgentManager.spawnTaskAgent` now awaits sdk-session capture on the task-agent, then eagerly spawns one `AgentSession` per distinct workflow-node agent slot (no kickoff query — just registration) and awaits capture on each.
- `TaskAgentManager.createSubSession` reuses eager sub-sessions when the agent slot matches.
- `TaskAgentManager.getTaskWorktreePath` falls back to a new `SpaceWorktreeManager.getTaskWorktreePathSync` DB read on cache miss so worktree paths survive restart without depending on in-memory map state.

**Tests.** Fingerprint preservation + `awaitSdkSessionCaptured` unit tests in `agent-session.test.ts`; new `task-agent-manager-eager-spawn.test.ts` (11 tests) covers slot dedup, sdk-capture await, no-kickoff invariant, no-workflow short-circuit, eager index, and the getTaskWorktreePath DB-fallback cache-warming path. Existing mocks extended with `awaitSdkSessionCaptured` / `getTaskWorktreePathSync` where the new code paths run.