### PR TITLE
fix(daemon): kill .mcp.json auto-load leak (MCP M1)

### DIFF
--- a/packages/daemon/.env.example
+++ b/packages/daemon/.env.example
@@ -96,6 +96,27 @@ MAX_SESSIONS=10
 # NEOKAI_ENABLE_NEO_AGENT=1
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# MCP Configuration
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#
+# Kill switch for M1 of the MCP unification plan
+# (docs/plans/unify-mcp-config-model/00-overview.md).
+#
+# As of M1, every session type spawns with `strictMcpConfig: true` and
+# `settingSources: []`, which stops the Claude Agent SDK from auto-loading
+# project `.mcp.json` and `.claude/settings.local.json`. Those MCP servers
+# must now flow through the NeoKai registry (app_mcp_servers).
+#
+# Set NEOKAI_LEGACY_MCP_AUTOLOAD=1 to restore the pre-M1 asymmetry: room_chat
+# and space_chat coordinators stay strict, but workers, task agents and Space
+# ad-hoc sessions retain `settingSources: ['project', 'local']` and the SDK
+# will auto-load `.mcp.json` as before.
+#
+# This flag is a single-release escape hatch and will be REMOVED in M5.
+# Only the exact string "1" activates it — anything else is treated as unset.
+# NEOKAI_LEGACY_MCP_AUTOLOAD=1
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Debugging
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 #

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -82,12 +82,35 @@ export class QueryOptionsBuilder {
 	}
 
 	/**
+	 * M1: Kill the `.mcp.json` auto-load leak.
+	 *
+	 * Default (flag unset): every session type spawns with `strictMcpConfig: true`
+	 * and `settingSources: []`. This stops the Claude Agent SDK from auto-loading
+	 * project `.mcp.json` and `.claude/settings.local.json`, which previously
+	 * bypassed NeoKai's UI toggles for non-coordinator sessions (Space ad-hoc,
+	 * `space_task_agent`, and node-agent workers).
+	 *
+	 * Kill switch (`NEOKAI_LEGACY_MCP_AUTOLOAD=1`): preserves the pre-M1
+	 * asymmetry for exactly one release, then removed in M5. Coordinators
+	 * (`room_chat`, `space_chat`) still force strict config in their per-type
+	 * blocks below. Workers / task agents / ad-hoc sessions retain
+	 * `settingSources: ['project', 'local']` and whatever `strictMcpConfig`
+	 * came from their session config (i.e. the pre-M1 SDK auto-load path).
+	 *
+	 * See `docs/plans/unify-mcp-config-model/00-overview.md` milestone M1.
+	 */
+	private static isLegacyMcpAutoloadEnabled(): boolean {
+		return process.env.NEOKAI_LEGACY_MCP_AUTOLOAD === '1';
+	}
+
+	/**
 	 * Build complete SDK query options
 	 *
 	 * Maps all SessionConfig (which extends SDKConfig) options to SDK Options
 	 */
 	async build(): Promise<Options> {
 		const config = this.ctx.session.config;
+		const legacyMcpAutoload = QueryOptionsBuilder.isLegacyMcpAutoloadEnabled();
 
 		// Get settings-derived options (from global settings)
 		const sdkSettingsOptions = await this.getSettingsOptions();
@@ -187,7 +210,12 @@ export class QueryOptionsBuilder {
 			// are always available regardless of strictMcpConfig setting.
 			// Disabled servers are already filtered out by filterDisabledMcpServers above.
 			mcpServers: mergedMcpServers as Options['mcpServers'],
-			strictMcpConfig: config.strictMcpConfig,
+			// M1: force strictMcpConfig: true on every session type by default.
+			// With NEOKAI_LEGACY_MCP_AUTOLOAD=1, fall back to the session config's
+			// value (undefined/false for workers) to preserve pre-M1 behavior.
+			// Coordinators (room_chat / space_chat) override back to `true` in
+			// their own blocks below so the legacy flag cannot regress them.
+			strictMcpConfig: legacyMcpAutoload ? config.strictMcpConfig : true,
 
 			// ============ Output Format ============
 			outputFormat: config.outputFormat,
@@ -211,7 +239,13 @@ export class QueryOptionsBuilder {
 			pathToClaudeCodeExecutable: sdkCliPath,
 
 			// ============ Settings ============
-			settingSources,
+			// M1: default to `settingSources: []` on every session type so the SDK
+			// does NOT auto-load project `.mcp.json` or `.claude/settings.local.json`.
+			// With NEOKAI_LEGACY_MCP_AUTOLOAD=1, fall back to the previously-derived
+			// value (['project', 'local'] by default) to preserve pre-M1 behavior.
+			// Coordinators (room_chat / space_chat) override back to [] in their own
+			// blocks below so the legacy flag cannot regress them.
+			settingSources: legacyMcpAutoload ? settingSources : [],
 
 			// ============ Streaming ============
 			includePartialMessages: config.includePartialMessages,

--- a/packages/daemon/tests/online/providers/anthropic-to-copilot-bridge-provider.test.ts
+++ b/packages/daemon/tests/online/providers/anthropic-to-copilot-bridge-provider.test.ts
@@ -22,10 +22,13 @@
  *                            the Agent SDK sends tool definitions → Copilot model calls a
  *                            tool → bridge emits a tool_use SSE block → SDK executes the
  *                            tool locally → sends tool_result → suspended session resumes.
- *   3. custom-mcp          — tools registered via .mcp.json in the workspace are loaded by
- *                            the Agent SDK and included in the tools array sent to the Copilot
+ *   3. custom-mcp          — tools registered via `config.mcpServers` on the session are loaded
+ *                            by the Agent SDK and included in the tools array sent to the Copilot
  *                            HTTP server.  Assertion: the MCP server subprocess receives a
  *                            tools/list call, proving get_answer was registered in the bridge.
+ *                            (Pre-M1 this exercised `.mcp.json` auto-load; post-M1 sessions
+ *                            default to `strictMcpConfig: true` + `settingSources: []`, so MCP
+ *                            servers flow through programmatic registration instead.)
  *   4. models-list         — the anthropic-copilot provider exposes its models when authenticated.
  *   5. provider-session    — session.create with explicit config.provider:'anthropic-copilot'
  *                            routes to the copilot backend.
@@ -393,7 +396,7 @@ describe('AnthropicToCopilotBridgeProvider (Online)', () => {
 	// -------------------------------------------------------------------------
 
 	test(
-		'custom MCP: tool from .mcp.json is discovered and exposed to the model',
+		'custom MCP: programmatically registered server is discovered and exposed to the model',
 		async () => {
 			const workspacePath = join(TMP_DIR, `copilot-anthropic-mcp-${Date.now()}`);
 			mkdirSync(workspacePath, { recursive: true });
@@ -401,35 +404,35 @@ describe('AnthropicToCopilotBridgeProvider (Online)', () => {
 			const uniqueToken = `tok-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 
 			// Flag file written by the MCP server when the Agent SDK calls tools/list.
-			// Its existence is the primary assertion: it proves the SDK discovered
-			// .mcp.json, spawned the MCP server subprocess, and fetched the tool list —
+			// Its existence is the primary assertion: it proves the SDK registered
+			// the MCP server, spawned the subprocess, and fetched the tool list —
 			// meaning get_answer was included in the tools array sent to the Copilot
 			// HTTP server (i.e. the MCP bridge is wired up correctly).
 			const toolsListedFlag = join(workspacePath, '.mcp-tools-listed');
 
-			// Write the minimal MCP server and register it via .mcp.json.
+			// Write the minimal MCP server to disk. Pre-M1 this would be registered
+			// by dropping a `.mcp.json` alongside it, but M1
+			// (docs/plans/unify-mcp-config-model/00-overview.md) forces
+			// `settingSources: []` and `strictMcpConfig: true` on every session so
+			// the SDK no longer auto-loads project `.mcp.json`. Instead we pass
+			// the server programmatically via `config.mcpServers`, which is what
+			// the registry/resolver will do once M3 lands.
 			const mcpServerPath = join(workspacePath, 'test-mcp-server.js');
 			writeFileSync(mcpServerPath, makeMcpServerScript(uniqueToken, toolsListedFlag));
-			writeFileSync(
-				join(workspacePath, '.mcp.json'),
-				JSON.stringify(
-					{
-						mcpServers: {
-							'test-answer-server': {
-								command: 'node',
-								args: [mcpServerPath],
-							},
-						},
-					},
-					null,
-					2
-				)
-			);
 
 			const { sessionId } = (await daemon.messageHub.request('session.create', {
 				workspacePath,
 				title: 'Copilot Anthropic MCP Test',
-				config: { model: testModelId, permissionMode: 'acceptEdits' },
+				config: {
+					model: testModelId,
+					permissionMode: 'acceptEdits',
+					mcpServers: {
+						'test-answer-server': {
+							command: 'node',
+							args: [mcpServerPath],
+						},
+					},
+				},
 			})) as { sessionId: string };
 			daemon.trackSession(sessionId);
 

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -345,15 +345,19 @@ describe('QueryOptionsBuilder', () => {
 	});
 
 	describe('setting sources configuration', () => {
-		it('should include project and local sources by default', async () => {
+		// M1: by default every session type gets `settingSources: []` so the SDK
+		// cannot auto-load project `.mcp.json` or `.claude/settings.local.json`.
+		// The pre-M1 `['project', 'local']` default is only restored when
+		// `NEOKAI_LEGACY_MCP_AUTOLOAD=1` — covered in the M1 kill-switch suite below.
+		it('should default to empty settingSources (M1: no SDK auto-load)', async () => {
 			const options = await builder.build();
-			expect(options.settingSources).toEqual(['project', 'local']);
+			expect(options.settingSources).toEqual([]);
 		});
 
-		it('should use local only when loadSettingSources is false', async () => {
+		it('should still force empty settingSources even when loadSettingSources is false', async () => {
 			mockSession.config.tools = { loadSettingSources: false };
 			const options = await builder.build();
-			expect(options.settingSources).toEqual(['local']);
+			expect(options.settingSources).toEqual([]);
 		});
 	});
 
@@ -518,13 +522,118 @@ describe('QueryOptionsBuilder', () => {
 			expect(options.systemPrompt).toBe('You are the Space coordinator.');
 		});
 
-		it('should not affect worker sessions (coder/reviewer tool access unchanged)', async () => {
+		it('should not affect worker sessions tool allowlist (coder/reviewer tool access unchanged)', async () => {
 			// Worker sessions (type: 'worker') must not be affected by space_chat restrictions
 			mockSession.type = 'worker';
 			const options = await builder.build();
-			// Worker sessions use the default claude_code preset — no restrictions imposed
-			expect(options.strictMcpConfig).toBeUndefined();
+			// Worker sessions use the default claude_code preset — no tool restrictions imposed.
+			// (M1 still forces `strictMcpConfig: true`, asserted separately below.)
 			expect(options.tools).toBeUndefined();
+		});
+	});
+
+	// ============================================================================
+	// M1: Kill the `.mcp.json` auto-load leak
+	// docs/plans/unify-mcp-config-model/00-overview.md milestone M1
+	// ============================================================================
+	describe('M1: strict MCP + empty settingSources default', () => {
+		const sessionTypes: Array<'worker' | 'space_task_agent' | 'general' | 'coder' | 'planner'> = [
+			'worker',
+			'space_task_agent',
+			'general',
+			'coder',
+			'planner',
+		];
+
+		beforeEach(() => {
+			delete process.env.NEOKAI_LEGACY_MCP_AUTOLOAD;
+		});
+
+		afterEach(() => {
+			delete process.env.NEOKAI_LEGACY_MCP_AUTOLOAD;
+		});
+
+		for (const type of sessionTypes) {
+			it(`forces strictMcpConfig=true and settingSources=[] on ${type} sessions`, async () => {
+				mockSession.type = type;
+				const options = await builder.build();
+				expect(options.strictMcpConfig).toBe(true);
+				expect(options.settingSources).toEqual([]);
+			});
+		}
+
+		it('does not inject project .mcp.json servers into the mcpServers map (regression)', async () => {
+			// Pre-M1 behavior: SDK auto-loads any `.mcp.json` at the workspace root
+			// because `settingSources` defaults to `['project', 'local']`. Post-M1
+			// `settingSources: []` means the SDK never looks at `.mcp.json` at all,
+			// and an ad-hoc worker session with no programmatic mcpServers emits an
+			// `undefined` mcpServers option — i.e. nothing to inject.
+			mockSession.type = 'worker';
+			mockSession.config.mcpServers = undefined;
+			const options = await builder.build();
+			expect(options.mcpServers).toBeUndefined();
+			expect(options.strictMcpConfig).toBe(true);
+			expect(options.settingSources).toEqual([]);
+		});
+
+		it('preserves explicit mcpServers from session config under strict mode', async () => {
+			mockSession.type = 'space_task_agent';
+			mockSession.config.mcpServers = {
+				'task-agent': { command: 'task-cmd' },
+			};
+			const options = await builder.build();
+			expect(options.strictMcpConfig).toBe(true);
+			expect(options.settingSources).toEqual([]);
+			expect(options.mcpServers).toEqual({ 'task-agent': { command: 'task-cmd' } });
+		});
+
+		describe('kill switch: NEOKAI_LEGACY_MCP_AUTOLOAD=1', () => {
+			it('restores pre-M1 defaults for worker sessions', async () => {
+				process.env.NEOKAI_LEGACY_MCP_AUTOLOAD = '1';
+				mockSession.type = 'worker';
+				const options = await builder.build();
+				// Pre-M1: strictMcpConfig falls through to session config (undefined here)
+				expect(options.strictMcpConfig).toBeUndefined();
+				// Pre-M1: settingSources defaults to ['project', 'local']
+				expect(options.settingSources).toEqual(['project', 'local']);
+			});
+
+			it('restores pre-M1 defaults for space_task_agent sessions', async () => {
+				process.env.NEOKAI_LEGACY_MCP_AUTOLOAD = '1';
+				mockSession.type = 'space_task_agent';
+				const options = await builder.build();
+				expect(options.strictMcpConfig).toBeUndefined();
+				expect(options.settingSources).toEqual(['project', 'local']);
+			});
+
+			it('keeps room_chat strict even with the kill switch enabled', async () => {
+				process.env.NEOKAI_LEGACY_MCP_AUTOLOAD = '1';
+				mockSession.type = 'room_chat';
+				const options = await builder.build();
+				// Coordinator blocks override back to strict; the kill switch must not
+				// regress coordinator hardening.
+				expect(options.strictMcpConfig).toBe(true);
+				expect(options.settingSources).toEqual([]);
+			});
+
+			it('keeps space_chat strict even with the kill switch enabled', async () => {
+				process.env.NEOKAI_LEGACY_MCP_AUTOLOAD = '1';
+				mockSession.type = 'space_chat';
+				const options = await builder.build();
+				expect(options.strictMcpConfig).toBe(true);
+				expect(options.settingSources).toEqual([]);
+			});
+
+			it('is only triggered by the exact string "1"', async () => {
+				// `true`, `yes`, `TRUE`, etc. must NOT re-enable legacy auto-load.
+				for (const val of ['true', 'yes', 'TRUE', '0', '', 'on']) {
+					process.env.NEOKAI_LEGACY_MCP_AUTOLOAD = val;
+					mockSession.type = 'worker';
+					const options = await builder.build();
+					expect(options.strictMcpConfig).toBe(true);
+					expect(options.settingSources).toEqual([]);
+				}
+			});
 		});
 	});
 

--- a/packages/daemon/tests/unit/1-core/agent/query-options-m1-mcp-leak.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-m1-mcp-leak.test.ts
@@ -1,0 +1,261 @@
+/**
+ * M1 regression suite — "Kill the `.mcp.json` auto-load leak".
+ *
+ * This test exercises the three session spawn paths called out in the M1
+ * task (docs/plans/unify-mcp-config-model/00-overview.md): Space ad-hoc
+ * (`worker` type in a Space context), `space_task_agent`, and the workflow
+ * node-agent sub-session (also `worker` type). For each we:
+ *
+ *   1. Build a representative `AgentSessionInit` using the real factory
+ *      (`createTaskAgentInit` / `createCustomAgentInit`) or a bare Space
+ *      worker shape, then synthesize a `Session` from it.
+ *   2. Run it through `QueryOptionsBuilder.build()` with no other mocks.
+ *   3. Assert the resulting SDK options force `strictMcpConfig: true` and
+ *      `settingSources: []`, so the Claude Agent SDK has no path to
+ *      auto-load a project-level `.mcp.json` or `.claude/settings.local.json`.
+ *
+ * We also verify the `NEOKAI_LEGACY_MCP_AUTOLOAD=1` escape hatch restores
+ * pre-M1 behavior for these non-coordinator session types.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { QueryOptionsBuilder } from '../../../../src/lib/agent/query-options-builder';
+import { createTaskAgentInit } from '../../../../src/lib/space/agents/task-agent';
+import { createCustomAgentInit } from '../../../../src/lib/space/agents/custom-agent';
+import type { SettingsManager } from '../../../../src/lib/settings-manager';
+import type { AgentSessionInit, Session, Space, SpaceAgent, SpaceTask } from '@neokai/shared';
+
+function mockSettingsManager(): SettingsManager {
+	return {
+		getGlobalSettings: mock(() => ({})),
+		prepareSDKOptions: mock(async () => ({})),
+	} as unknown as SettingsManager;
+}
+
+function makeSpace(overrides?: Partial<Space>): Space {
+	return {
+		id: 'space-m1',
+		workspacePath: '/workspace',
+		name: 'M1 Space',
+		description: '',
+		backgroundContext: '',
+		instructions: '',
+		sessionIds: [],
+		status: 'active',
+		createdAt: 1,
+		updatedAt: 2,
+		...overrides,
+	};
+}
+
+function makeTask(overrides?: Partial<SpaceTask>): SpaceTask {
+	return {
+		id: 'task-m1',
+		spaceId: 'space-m1',
+		taskNumber: 42,
+		title: 'M1 task',
+		description: 'Test that `.mcp.json` does not leak.',
+		status: 'in_progress',
+		priority: 'high',
+		dependsOn: [],
+		createdAt: 1,
+		updatedAt: 2,
+		...overrides,
+	};
+}
+
+function makeCustomAgent(overrides?: Partial<SpaceAgent>): SpaceAgent {
+	return {
+		id: 'agent-m1',
+		spaceId: 'space-m1',
+		name: 'coder',
+		description: 'Implementation worker.',
+		model: 'claude-sonnet-4-6',
+		customPrompt: 'You write code.',
+		createdAt: 1,
+		updatedAt: 2,
+		...overrides,
+	} as SpaceAgent;
+}
+
+/**
+ * Translate an `AgentSessionInit` into a minimal `Session` suitable for the
+ * `QueryOptionsBuilder`. Only the fields the builder consults matter for
+ * these assertions.
+ */
+function sessionFromInit(init: AgentSessionInit): Session {
+	return {
+		id: init.sessionId,
+		title: 'M1 test session',
+		workspacePath: init.workspacePath,
+		type: init.type,
+		context: init.context,
+		createdAt: new Date().toISOString(),
+		lastActiveAt: new Date().toISOString(),
+		status: 'active',
+		config: {
+			model: init.model ?? 'claude-sonnet-4-6',
+			provider: (init.provider as Session['config']['provider']) ?? 'anthropic',
+			systemPrompt: init.systemPrompt,
+			mcpServers: init.mcpServers,
+			maxTokens: 8192,
+			temperature: 1,
+		},
+		metadata: {
+			messageCount: 0,
+			totalTokens: 0,
+			inputTokens: 0,
+			outputTokens: 0,
+			totalCost: 0,
+			toolCallCount: 0,
+		},
+	} as Session;
+}
+
+describe('M1 leak regression: strictMcpConfig + empty settingSources per spawn path', () => {
+	beforeEach(() => {
+		delete process.env.NEOKAI_LEGACY_MCP_AUTOLOAD;
+	});
+
+	afterEach(() => {
+		delete process.env.NEOKAI_LEGACY_MCP_AUTOLOAD;
+	});
+
+	describe('space_task_agent (createTaskAgentInit)', () => {
+		it('emits SDK options with strictMcpConfig=true and empty settingSources', async () => {
+			const init = createTaskAgentInit({
+				task: makeTask(),
+				space: makeSpace(),
+				sessionId: 'space:space-m1:task:task-m1',
+				workspacePath: '/workspace/task',
+			});
+			expect(init.type).toBe('space_task_agent');
+
+			const session = sessionFromInit(init);
+			const builder = new QueryOptionsBuilder({
+				session,
+				settingsManager: mockSettingsManager(),
+			});
+			const options = await builder.build();
+
+			expect(options.strictMcpConfig).toBe(true);
+			expect(options.settingSources).toEqual([]);
+			// No programmatic mcpServers were passed → map is absent, so nothing
+			// from a project `.mcp.json` can possibly surface here.
+			expect(options.mcpServers).toBeUndefined();
+		});
+
+		it('restores pre-M1 asymmetry when NEOKAI_LEGACY_MCP_AUTOLOAD=1', async () => {
+			process.env.NEOKAI_LEGACY_MCP_AUTOLOAD = '1';
+			const init = createTaskAgentInit({
+				task: makeTask(),
+				space: makeSpace(),
+				sessionId: 'space:space-m1:task:task-m1',
+				workspacePath: '/workspace/task',
+			});
+			const session = sessionFromInit(init);
+			const builder = new QueryOptionsBuilder({
+				session,
+				settingsManager: mockSettingsManager(),
+			});
+			const options = await builder.build();
+
+			expect(options.strictMcpConfig).toBeUndefined();
+			expect(options.settingSources).toEqual(['project', 'local']);
+		});
+	});
+
+	describe('node-agent workflow sub-session (createCustomAgentInit)', () => {
+		it('emits SDK options with strictMcpConfig=true and empty settingSources', async () => {
+			const init = createCustomAgentInit({
+				customAgent: makeCustomAgent(),
+				task: makeTask(),
+				workflowRun: null,
+				workflow: null,
+				space: makeSpace(),
+				sessionId: 'space:space-m1:task:task-m1:exec:e1',
+				workspacePath: '/workspace/task',
+			});
+			expect(init.type).toBe('worker');
+
+			const session = sessionFromInit(init);
+			const builder = new QueryOptionsBuilder({
+				session,
+				settingsManager: mockSettingsManager(),
+			});
+			const options = await builder.build();
+
+			expect(options.strictMcpConfig).toBe(true);
+			expect(options.settingSources).toEqual([]);
+			// A workflow node-agent's `node-agent` MCP server is attached at runtime
+			// via `mergeRuntimeMcpServers` after session creation, not by the init
+			// factory. Without that runtime merge, no ambient `.mcp.json` servers
+			// must appear here either.
+			expect(options.mcpServers).toBeUndefined();
+		});
+
+		it('restores pre-M1 asymmetry when NEOKAI_LEGACY_MCP_AUTOLOAD=1', async () => {
+			process.env.NEOKAI_LEGACY_MCP_AUTOLOAD = '1';
+			const init = createCustomAgentInit({
+				customAgent: makeCustomAgent(),
+				task: makeTask(),
+				workflowRun: null,
+				workflow: null,
+				space: makeSpace(),
+				sessionId: 'space:space-m1:task:task-m1:exec:e1',
+				workspacePath: '/workspace/task',
+			});
+			const session = sessionFromInit(init);
+			const builder = new QueryOptionsBuilder({
+				session,
+				settingsManager: mockSettingsManager(),
+			});
+			const options = await builder.build();
+
+			expect(options.strictMcpConfig).toBeUndefined();
+			expect(options.settingSources).toEqual(['project', 'local']);
+		});
+	});
+
+	describe('Space ad-hoc (worker session attached to a space by context)', () => {
+		it('emits SDK options with strictMcpConfig=true and empty settingSources', async () => {
+			// Space ad-hoc = any session opened in a Space that is neither the
+			// coordinator (`space_chat`) nor a task-agent. The runtime model uses
+			// `type: 'worker'` with a `spaceId` on the context.
+			const session: Session = {
+				id: 'adhoc-1',
+				title: 'Space ad-hoc session',
+				workspacePath: '/workspace/adhoc',
+				type: 'worker',
+				context: { spaceId: 'space-m1' },
+				createdAt: new Date().toISOString(),
+				lastActiveAt: new Date().toISOString(),
+				status: 'active',
+				config: {
+					model: 'claude-sonnet-4-6',
+					provider: 'anthropic',
+					maxTokens: 8192,
+					temperature: 1,
+				},
+				metadata: {
+					messageCount: 0,
+					totalTokens: 0,
+					inputTokens: 0,
+					outputTokens: 0,
+					totalCost: 0,
+					toolCallCount: 0,
+				},
+			} as Session;
+
+			const builder = new QueryOptionsBuilder({
+				session,
+				settingsManager: mockSettingsManager(),
+			});
+			const options = await builder.build();
+
+			expect(options.strictMcpConfig).toBe(true);
+			expect(options.settingSources).toEqual([]);
+			expect(options.mcpServers).toBeUndefined();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Force `strictMcpConfig: true` + `settingSources: []` on every session type in `QueryOptionsBuilder.build()` so the Claude Agent SDK no longer auto-loads project `.mcp.json` or `.claude/settings.local.json` for Space ad-hoc / `space_task_agent` / workflow node-agent sessions. Coordinators (`room_chat`, `space_chat`) were already strict.
- Add `NEOKAI_LEGACY_MCP_AUTOLOAD=1` kill switch that restores the pre-M1 asymmetry for exactly one release. Coordinators stay strict even with the flag on; removed in M5.
- Plan: `docs/plans/unify-mcp-config-model/00-overview.md` (M1).

## Test plan

- [x] Unit: `tests/unit/1-core/agent/query-options-builder.test.ts` — updated default `settingSources` assertions and added full M1 kill-switch suite.
- [x] Unit: new `tests/unit/1-core/agent/query-options-m1-mcp-leak.test.ts` — runs the real `createTaskAgentInit` / `createCustomAgentInit` spawn-path factories through the builder and asserts `strictMcpConfig: true` + `settingSources: []`, plus pre-M1 restore behaviour when the kill switch is set.
- [x] Daemon test suite: all 11538 tests pass (`./scripts/test-daemon.sh`).
- [x] `bun run check` (lint + typecheck + knip + session-deletion guards) passes.
- [x] `bun run format:check` passes.
- [ ] Online Copilot bridge test (`tests/online/providers/anthropic-to-copilot-bridge-provider.test.ts`) switched from `.mcp.json` auto-load to programmatic `config.mcpServers`; requires Copilot credentials to run in CI.