### PR TITLE
fix(space): accept depends_on in create_standalone_task MCP tool

### DIFF
--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -368,12 +368,18 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 
 		/**
 		 * Create a standalone task not associated with any workflow run.
+		 *
+		 * Supports structured dependencies via `depends_on`. The underlying
+		 * SpaceTaskManager.createTask() validates that every dependency ID
+		 * exists in the same space and rejects circular references; those
+		 * errors are surfaced here as `{ success: false, error }`.
 		 */
 		async create_standalone_task(args: {
 			title: string;
 			description: string;
 			priority?: SpaceTaskPriority;
 			workflow_id?: string;
+			depends_on?: string[];
 		}): Promise<ToolResult> {
 			try {
 				const task = await taskManager.createTask({
@@ -381,6 +387,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 					description: args.description,
 					priority: args.priority,
 					preferredWorkflowId: args.workflow_id ?? null,
+					dependsOn: args.depends_on,
 				});
 				return jsonResult({ success: true, task });
 			} catch (err) {
@@ -1108,7 +1115,7 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 		),
 		tool(
 			'create_standalone_task',
-			'Create a task request. Runtime may attach and execute a workflow for this task during orchestration.',
+			'Create a task request. Runtime may attach and execute a workflow for this task during orchestration. Supports structured task dependencies via depends_on — the task will be blocked until every listed dependency reaches status=done, and cascade-cancelled if a dependency is cancelled.',
 			{
 				title: z.string().describe('Short title for the task'),
 				description: z.string().describe('Detailed description of the work to be done'),
@@ -1125,6 +1132,12 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 					.optional()
 					.describe(
 						'ID of the workflow to use for this task. When provided, the runtime uses this workflow instead of auto-selecting one. Example: "67b42e04-ae03-425d-b267-40527b042dcc" for Coding with QA Workflow.'
+					),
+				depends_on: z
+					.array(z.string())
+					.optional()
+					.describe(
+						'List of task IDs this task depends on. All must be in the same space. The task will be blocked until every dependency reaches status=done. Cycles and non-existent IDs are rejected.'
 					),
 			},
 			(args) => handlers.create_standalone_task(args)

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -331,8 +331,13 @@ const PD_TASK_DISPATCHER_PROMPT =
 	'support" → "add-file-upload". All branches in the stack share this prefix so they are ' +
 	'grouped: `plan/<prefix>/<item-slug>`.\n' +
 	'3. Create standalone tasks in BOTTOM-UP order (item 1 first, then item 2, etc.) by ' +
-	'calling `create_standalone_task({ title, description, priority })` for each. The ' +
-	'description must contain the original plan item content PLUS a ' +
+	'calling `create_standalone_task({ title, description, priority, depends_on })` for each. ' +
+	'ALWAYS pass `depends_on` as a structured array of prerequisite task IDs so the runtime can ' +
+	'enforce ordering, block dependents until prerequisites are done, and cascade-cancel on ' +
+	'failure. Do NOT rely on prose-only dependency hints — they are informational, not enforced.\n\n' +
+	'   - BOTTOM task (item 1): `depends_on: []` (no prerequisites).\n' +
+	'   - MIDDLE / TOP tasks (item N > 1): `depends_on: [<taskId of item N-1>]`.\n\n' +
+	'The `description` must contain the original plan item content PLUS a ' +
 	'"## Stacked PR Instructions" section appended at the end.\n\n' +
 	'   For the BOTTOM task (item 1 — PR base is `dev`):\n' +
 	'   ```\n' +

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -728,6 +728,125 @@ describe('createSpaceAgentToolHandlers — create_standalone_task', () => {
 		const stored = ctx.taskRepo.getTask(parsed.task.id);
 		expect(stored?.preferredWorkflowId ?? null).toBeNull();
 	});
+
+	test('depends_on: [] succeeds and persists an empty dependency list', async () => {
+		const result = await makeHandlers(ctx).create_standalone_task({
+			title: 'No deps',
+			description: 'Task with no prerequisites',
+			depends_on: [],
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.dependsOn).toEqual([]);
+		const stored = ctx.taskRepo.getTask(parsed.task.id);
+		expect(stored?.dependsOn).toEqual([]);
+	});
+
+	test('depends_on with one valid task ID persists the dependency', async () => {
+		const parentResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Parent task',
+			description: 'Bottom of the stack',
+		});
+		const parentId = JSON.parse(parentResult.content[0].text).task.id;
+
+		const childResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Child task',
+			description: 'Depends on parent',
+			depends_on: [parentId],
+		});
+		const parsed = JSON.parse(childResult.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.dependsOn).toEqual([parentId]);
+
+		const stored = ctx.taskRepo.getTask(parsed.task.id);
+		expect(stored?.dependsOn).toEqual([parentId]);
+	});
+
+	test('depends_on with multiple valid task IDs persists all dependencies', async () => {
+		const depAResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Dep A',
+			description: 'First dep',
+		});
+		const depAId = JSON.parse(depAResult.content[0].text).task.id;
+
+		const depBResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Dep B',
+			description: 'Second dep',
+		});
+		const depBId = JSON.parse(depBResult.content[0].text).task.id;
+
+		const childResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'Child task',
+			description: 'Depends on A and B',
+			depends_on: [depAId, depBId],
+		});
+		const parsed = JSON.parse(childResult.content[0].text);
+		expect(parsed.success).toBe(true);
+		expect(parsed.task.dependsOn).toEqual([depAId, depBId]);
+	});
+
+	test('depends_on with a non-existent task ID fails with a descriptive error', async () => {
+		const result = await makeHandlers(ctx).create_standalone_task({
+			title: 'Orphan child',
+			description: 'References a missing task',
+			depends_on: ['task-does-not-exist'],
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('task-does-not-exist');
+		expect(parsed.error).toMatch(/not found|dependency/i);
+	});
+
+	test('depends_on with a task from a different space fails (cross-space rejected)', async () => {
+		// Seed a second space and create a task there via its own task manager.
+		const otherSpaceId = 'space-other';
+		seedSpaceRow(ctx.db, otherSpaceId, '/tmp/other-workspace');
+		const otherTaskManager = new SpaceTaskManager(ctx.db, otherSpaceId);
+		const otherTask = await otherTaskManager.createTask({
+			title: 'Other-space task',
+			description: 'Belongs to a different space',
+		});
+
+		const result = await makeHandlers(ctx).create_standalone_task({
+			title: 'Cross-space child',
+			description: 'Tries to depend on another space',
+			depends_on: [otherTask.id],
+		});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain(otherTask.id);
+		expect(parsed.error).toMatch(/not found|dependency/i);
+	});
+
+	test('depends_on rejects a cycle when a dependency chain would loop back', async () => {
+		// Create three tasks: A, B, C, linked A → B → C (C depends on B, B depends on A).
+		const aResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'A',
+			description: 'root',
+		});
+		const aId = JSON.parse(aResult.content[0].text).task.id;
+
+		const bResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'B',
+			description: 'depends on A',
+			depends_on: [aId],
+		});
+		const bId = JSON.parse(bResult.content[0].text).task.id;
+
+		const cResult = await makeHandlers(ctx).create_standalone_task({
+			title: 'C',
+			description: 'depends on B',
+			depends_on: [bId],
+		});
+		expect(JSON.parse(cResult.content[0].text).success).toBe(true);
+		const cId = JSON.parse(cResult.content[0].text).task.id;
+
+		// Now attempt to update A to depend on C — this would form a cycle
+		// A → C → B → A. Cycle detection happens on updates via the manager.
+		await expect(ctx.taskManager.updateTask(aId, { dependsOn: [cId] })).rejects.toThrow(
+			/circular|cycle/i
+		);
+	});
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Expose `depends_on: string[]` on the `create_standalone_task` MCP tool so Space Agents can set structured task dependencies at creation time (validated by `SpaceTaskManager` — missing IDs, cross-space, and cycles are rejected).
- Update the Plan & Decompose **Task Dispatcher** prompt to always pass `depends_on` when fanning a plan into stacked tasks, so the stack chain is structurally enforced instead of prose-only.

## Why

`SpaceTaskManager.createTask` already supported `dependsOn`, but the MCP tool surface didn't pass it through. Callers encoded dependencies as prose in the description, which the runtime couldn't act on — breaking dependency-ordered execution, cascade cancellation, and the `areDependenciesMet()` gate.

## Test plan

- [x] `packages/daemon` full unit suite: 11,527/11,527 pass
- [x] New unit tests in `space-agent-tools.test.ts`:
  - `depends_on: []` → success, persisted empty
  - single valid dep → success, dep persisted
  - multiple valid deps → success, all persisted
  - non-existent dep ID → failure with descriptive error
  - cross-space dep → failure (treated as not-in-space)
  - cycle via `updateTask` → failure
- [x] `bun run check` (lint, typecheck, knip, session guards) clean