### PR TITLE
feat(mcp): per-space override UI + import scanner (M4)

### DIFF
--- a/packages/daemon/src/lib/mcp/import-scanner.ts
+++ b/packages/daemon/src/lib/mcp/import-scanner.ts
@@ -1,0 +1,267 @@
+/**
+ * MCP Import Scanner
+ *
+ * Scans on-disk `.mcp.json` files and upserts/removes rows in the
+ * `app_mcp_servers` registry tagged with `source = 'imported'`. This is
+ * the minimum implementation for M2 — it gives the M4 space settings UI
+ * a "Refresh imports" button that keeps the imported registry set in
+ * sync with whatever Claude Code picked up from the project.
+ *
+ * A successful scan is idempotent:
+ *   - Existing imported rows with a matching `(name, sourcePath)` are
+ *     updated in place (command/args/env/url/headers).
+ *   - New imported entries are inserted with `enabled=true` so they
+ *     show up immediately in the space settings UI.
+ *   - Imported rows whose `sourcePath` was scanned but no longer appears
+ *     in any scanned file are deleted.
+ *
+ * Non-imported rows (builtin/user) are never touched.
+ */
+
+import { readFile, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import type {
+	AppMcpServer,
+	AppMcpServerSourceType,
+	CreateAppMcpServerRequest,
+	UpdateAppMcpServerRequest,
+} from '@neokai/shared';
+import type { AppMcpServerRepository } from '../../storage/repositories/app-mcp-server-repository';
+import { Logger } from '../logger';
+
+const log = new Logger('mcp-import-scanner');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface McpJsonStdioEntry {
+	command: string;
+	args?: string[];
+	env?: Record<string, string>;
+}
+
+interface McpJsonUrlEntry {
+	type?: 'sse' | 'http' | 'stdio';
+	url?: string;
+	headers?: Record<string, string>;
+	command?: string;
+	args?: string[];
+	env?: Record<string, string>;
+}
+
+type McpJsonEntry = McpJsonStdioEntry | McpJsonUrlEntry;
+
+interface McpJsonFile {
+	mcpServers?: Record<string, McpJsonEntry>;
+}
+
+export interface ImportScanResult {
+	/** Number of imported rows inserted or updated. */
+	imported: number;
+	/** Number of imported rows removed because the scanned source no longer lists them. */
+	removed: number;
+	/** Human-readable notes (e.g. files not found, parse errors). */
+	notes: string[];
+}
+
+export interface ImportScanOptions {
+	/** Paths of `.mcp.json` files to scan. Missing files are quietly skipped. */
+	mcpJsonPaths: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function inferSourceType(entry: McpJsonEntry): AppMcpServerSourceType | null {
+	if ('type' in entry && entry.type) {
+		if (entry.type === 'stdio' || entry.type === 'sse' || entry.type === 'http') {
+			return entry.type;
+		}
+	}
+	if ('command' in entry && entry.command) return 'stdio';
+	if ('url' in entry && entry.url) return 'http';
+	return null;
+}
+
+function entryShallowEqual(a: AppMcpServer, b: CreateAppMcpServerRequest): boolean {
+	if (a.sourceType !== b.sourceType) return false;
+	if ((a.command ?? null) !== (b.command ?? null)) return false;
+	if ((a.url ?? null) !== (b.url ?? null)) return false;
+	const aArgs = JSON.stringify(a.args ?? []);
+	const bArgs = JSON.stringify(b.args ?? []);
+	if (aArgs !== bArgs) return false;
+	const aEnv = JSON.stringify(a.env ?? {});
+	const bEnv = JSON.stringify(b.env ?? {});
+	if (aEnv !== bEnv) return false;
+	const aHeaders = JSON.stringify(a.headers ?? {});
+	const bHeaders = JSON.stringify(b.headers ?? {});
+	if (aHeaders !== bHeaders) return false;
+	return true;
+}
+
+async function readMcpJsonSafe(
+	path: string,
+	notes: string[]
+): Promise<Record<string, McpJsonEntry> | null> {
+	try {
+		await stat(path);
+	} catch {
+		// File missing — quietly skip; not every workspace has a .mcp.json.
+		return null;
+	}
+	try {
+		const raw = await readFile(path, 'utf-8');
+		const parsed = JSON.parse(raw) as McpJsonFile;
+		return parsed.mcpServers ?? {};
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		notes.push(`${path}: parse error — ${msg}`);
+		log.warn(`readMcpJsonSafe: parse error for ${path}: ${msg}`);
+		return null;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scanner
+// ---------------------------------------------------------------------------
+
+/**
+ * Scan each `.mcp.json` path and reconcile imported rows in the registry.
+ * Returns a summary of how many rows were inserted/updated vs. removed.
+ *
+ * Only imported rows are touched: user-authored or builtin rows are
+ * preserved untouched, and any `source='imported'` row whose sourcePath
+ * was scanned but whose name is missing from the file gets deleted.
+ */
+export async function scanMcpImports(
+	repo: AppMcpServerRepository,
+	options: ImportScanOptions
+): Promise<ImportScanResult> {
+	const notes: string[] = [];
+	let imported = 0;
+	let removed = 0;
+
+	// Map by (sourcePath, name) for quick lookup of existing rows.
+	const existingImported = repo.listImported();
+	const existingByKey = new Map<string, AppMcpServer>();
+	for (const row of existingImported) {
+		if (row.sourcePath) {
+			existingByKey.set(`${row.sourcePath}::${row.name}`, row);
+		}
+	}
+
+	// Track which (sourcePath, name) keys appear in the scanned files so we
+	// can delete imported rows whose source file was scanned but no longer
+	// lists them. Files that fail to read (parse errors, missing) are NOT
+	// marked scanned — rows tied to them are left alone.
+	const scannedPaths = new Set<string>();
+	const seenKeys = new Set<string>();
+
+	for (const mcpJsonPath of options.mcpJsonPaths) {
+		const servers = await readMcpJsonSafe(mcpJsonPath, notes);
+		if (servers === null) continue;
+		scannedPaths.add(mcpJsonPath);
+
+		for (const [name, entry] of Object.entries(servers)) {
+			const sourceType = inferSourceType(entry);
+			if (!sourceType) {
+				notes.push(`${mcpJsonPath}: server "${name}" has unknown shape — skipped`);
+				continue;
+			}
+
+			const req: CreateAppMcpServerRequest = {
+				name,
+				sourceType,
+				enabled: true,
+				source: 'imported',
+				sourcePath: mcpJsonPath,
+				...('command' in entry && entry.command ? { command: entry.command } : {}),
+				...('args' in entry && entry.args ? { args: entry.args } : {}),
+				...('env' in entry && entry.env ? { env: entry.env } : {}),
+				...('url' in entry && entry.url ? { url: entry.url } : {}),
+				...('headers' in entry && entry.headers ? { headers: entry.headers } : {}),
+			};
+
+			const key = `${mcpJsonPath}::${name}`;
+			seenKeys.add(key);
+
+			const existing = existingByKey.get(key);
+			if (existing) {
+				if (!entryShallowEqual(existing, req)) {
+					const updates: Omit<UpdateAppMcpServerRequest, 'id'> = {
+						sourceType: req.sourceType,
+						command: req.command,
+						args: req.args,
+						env: req.env,
+						url: req.url,
+						headers: req.headers,
+					};
+					repo.update(existing.id, updates);
+					imported += 1;
+				}
+				continue;
+			}
+
+			// Insert if no row exists. Check for a name collision with a non-imported
+			// entry — if one exists, skip with a note so user/builtin rows aren't
+			// clobbered.
+			const collision = repo.getByName(name);
+			if (collision) {
+				notes.push(
+					`${mcpJsonPath}: server "${name}" already exists as "${collision.source}" — import skipped`
+				);
+				continue;
+			}
+			repo.create(req);
+			imported += 1;
+		}
+	}
+
+	// Delete imported rows whose source file was scanned but which no longer
+	// appears in that file.
+	for (const row of existingImported) {
+		if (!row.sourcePath) continue;
+		if (!scannedPaths.has(row.sourcePath)) continue;
+		const key = `${row.sourcePath}::${row.name}`;
+		if (!seenKeys.has(key)) {
+			repo.delete(row.id);
+			removed += 1;
+		}
+	}
+
+	return { imported, removed, notes };
+}
+
+/**
+ * Build a de-duplicated list of `.mcp.json` paths to scan:
+ *   - The user-level `~/.claude/.mcp.json` (if HOME is set).
+ *   - Every unique `workspacePath` provided, with `.mcp.json` joined.
+ *   - Optional additional explicit paths (e.g. from a test harness).
+ */
+export function buildMcpJsonPaths(opts: {
+	workspacePaths: string[];
+	homeDir?: string;
+	additional?: string[];
+}): string[] {
+	const seen = new Set<string>();
+	const out: string[] = [];
+	const push = (p: string) => {
+		if (!seen.has(p)) {
+			seen.add(p);
+			out.push(p);
+		}
+	};
+
+	if (opts.homeDir) {
+		push(join(opts.homeDir, '.claude', '.mcp.json'));
+	}
+	for (const wp of opts.workspacePaths) {
+		if (wp) push(join(wp, '.mcp.json'));
+	}
+	for (const extra of opts.additional ?? []) {
+		if (extra) push(extra);
+	}
+	return out;
+}

--- a/packages/daemon/src/lib/mcp/seed-defaults.ts
+++ b/packages/daemon/src/lib/mcp/seed-defaults.ts
@@ -16,7 +16,8 @@ import type { Database } from '../../storage/database';
 export function seedDefaultMcpEntries(db: Database): void {
 	const repo = db.appMcpServers;
 
-	if (!repo.getByName('fetch-mcp')) {
+	const existingFetch = repo.getByName('fetch-mcp');
+	if (!existingFetch) {
 		repo.create({
 			name: 'fetch-mcp',
 			description: 'Fetch web pages and convert to Markdown for reading documentation and articles',
@@ -27,9 +28,13 @@ export function seedDefaultMcpEntries(db: Database): void {
 			enabled: true,
 			source: 'builtin',
 		});
+	} else if (existingFetch.source !== 'builtin') {
+		// Upgrade provenance for legacy rows seeded before the `source` column existed.
+		repo.update(existingFetch.id, { source: 'builtin' });
 	}
 
-	if (!repo.getByName('chrome-devtools')) {
+	const existingChrome = repo.getByName('chrome-devtools');
+	if (!existingChrome) {
 		repo.create({
 			name: 'chrome-devtools',
 			description:
@@ -41,5 +46,7 @@ export function seedDefaultMcpEntries(db: Database): void {
 			enabled: false,
 			source: 'builtin',
 		});
+	} else if (existingChrome.source !== 'builtin') {
+		repo.update(existingChrome.id, { source: 'builtin' });
 	}
 }

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -94,6 +94,7 @@ import { FileIndex } from '../file-index';
 import { LiveQueryEngine } from '../../storage/live-query';
 import type { AppMcpLifecycleManager, McpImportService } from '../mcp';
 import { registerAppMcpHandlers, setupAppMcpHandlers } from './app-mcp-handlers';
+import { setupSpaceMcpHandlers } from './space-mcp-handlers';
 import { registerSkillHandlers } from './skill-handlers';
 import type { SkillsManager } from '../skills-manager';
 import { setupNeoHandlers } from './neo-handlers';
@@ -359,6 +360,9 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 
 	// Per-room MCP enablement RPC handlers
 	setupAppMcpHandlers(deps.messageHub, deps.daemonHub, deps.db);
+
+	// Per-space MCP enablement RPC handlers + `.mcp.json` import refresh.
+	setupSpaceMcpHandlers(deps.messageHub, deps.daemonHub, deps.db, deps.spaceManager);
 
 	// Skills registry RPC handlers
 	registerSkillHandlers(deps.messageHub, deps.skillsManager, deps.daemonHub, undefined);

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -417,6 +417,54 @@ function mapMcpEnablementRow(row: Record<string, unknown>): Record<string, unkno
 	};
 }
 
+/**
+ * SQL for `mcpEnablement.bySpace`. Returns a row per registry entry, with the
+ * per-space override (if any) applied. Columns match SpaceMcpEntry so the
+ * frontend can use the LiveQuery result without a separate RPC roundtrip.
+ *
+ * `overridden` is 1 when the entry has an explicit `mcp_enablement` row for
+ * this (space, server) pair, else 0. `enabled` is the effective state:
+ * override if present, else the registry's global `enabled` flag.
+ */
+const MCP_ENABLEMENT_BY_SPACE_SQL = `
+SELECT
+  ams.id                                                       AS serverId,
+  ams.name                                                     AS name,
+  ams.description                                              AS description,
+  ams.source_type                                              AS sourceType,
+  ams.source                                                   AS source,
+  ams.source_path                                              AS sourcePath,
+  ams.enabled                                                  AS globallyEnabled,
+  CASE WHEN me.enabled IS NOT NULL THEN 1 ELSE 0 END           AS overridden,
+  COALESCE(me.enabled, ams.enabled)                            AS enabled
+FROM app_mcp_servers ams
+LEFT JOIN mcp_enablement me
+  ON me.server_id = ams.id
+ AND me.scope_type = 'space'
+ AND me.scope_id = ?
+ORDER BY ams.source ASC, ams.created_at IS NULL, ams.created_at ASC, ams.id ASC
+`.trim();
+
+function mapMcpEnablementBySpaceRow(row: Record<string, unknown>): Record<string, unknown> {
+	const sourceRaw = typeof row.source === 'string' ? row.source : null;
+	const normalisedSource =
+		sourceRaw === 'builtin' || sourceRaw === 'imported' || sourceRaw === 'user'
+			? sourceRaw
+			: 'user';
+	const out: Record<string, unknown> = {
+		serverId: row.serverId,
+		name: row.name,
+		sourceType: row.sourceType,
+		source: normalisedSource,
+		globallyEnabled: row.globallyEnabled === 1,
+		overridden: row.overridden === 1,
+		enabled: row.enabled === 1,
+	};
+	if (row.description != null) out.description = row.description;
+	if (row.sourcePath != null) out.sourcePath = row.sourcePath;
+	return out;
+}
+
 const SKILLS_BY_ROOM_SQL = `
 SELECT
   s.id,
@@ -1355,6 +1403,14 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 		},
 	],
 	[
+		'mcpEnablement.bySpace',
+		{
+			sql: MCP_ENABLEMENT_BY_SPACE_SQL,
+			paramCount: 1,
+			mapRow: mapMcpEnablementBySpaceRow,
+		},
+	],
+	[
 		'skills.byRoom',
 		{
 			sql: SKILLS_BY_ROOM_SQL,
@@ -1570,7 +1626,7 @@ export function setupLiveQueryHandlers(
 			if (!spaceTask) {
 				throw new Error(`Unauthorized: space task "${taskId}" not found`);
 			}
-		} else if (queryName === 'spaceSessions.bySpace') {
+		} else if (queryName === 'spaceSessions.bySpace' || queryName === 'mcpEnablement.bySpace') {
 			const spaceId = params[0] as string;
 			if (!stmtSpace.get(spaceId)) {
 				throw new Error(`Unauthorized: space "${spaceId}" not found`);

--- a/packages/daemon/src/lib/rpc-handlers/space-mcp-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-mcp-handlers.ts
@@ -1,0 +1,196 @@
+/**
+ * Space MCP RPC Handlers
+ *
+ * Per-space MCP enablement surface backed by the generalized `mcp_enablement`
+ * table (scope_type='space'). Exposes:
+ *   - space.mcp.list(spaceId)               → Array<SpaceMcpEntry>
+ *   - space.mcp.setEnabled(...)             → upsert override row
+ *   - space.mcp.clearOverride(...)          → delete override row (inherit default)
+ *
+ * Takes effect on **newly-created** sessions: `AppMcpLifecycleManager`
+ * provides `getEnabledMcpConfigsForSpace(spaceId)` and `TaskAgentManager`
+ * uses it at spawn time. Existing live sessions keep their previously-
+ * resolved MCP set and are NOT hot-swapped — a fresh task run picks up the
+ * change.
+ *
+ * Each mutation emits `mcp.registry.changed` so any daemon-internal
+ * subscribers (e.g. neo bootstrap) refresh, and relies on the
+ * `McpEnablementRepository` to `reactiveDb.notifyChange('mcp_enablement')`
+ * which drives the `mcpEnablement.bySpace` LiveQuery.
+ */
+
+import type {
+	MessageHub,
+	SpaceMcpEntry,
+	SpaceMcpListRequest,
+	SpaceMcpListResponse,
+	SpaceMcpSetEnabledRequest,
+	SpaceMcpSetEnabledResponse,
+	SpaceMcpClearOverrideRequest,
+	SpaceMcpClearOverrideResponse,
+	McpImportsRefreshRequest,
+	McpImportsRefreshResponse,
+} from '@neokai/shared';
+import { homedir } from 'node:os';
+import type { DaemonHub } from '../daemon-hub';
+import type { Database } from '../../storage/database';
+import type { SpaceManager } from '../space/managers/space-manager';
+import { buildMcpJsonPaths, scanMcpImports } from '../mcp/import-scanner';
+import { Logger } from '../logger';
+
+const log = new Logger('space-mcp-handlers');
+
+function emitChanged(daemonHub: DaemonHub): void {
+	daemonHub.emit('mcp.registry.changed', { sessionId: 'global' }).catch((err) => {
+		log.warn('Failed to emit mcp.registry.changed:', err);
+	});
+}
+
+async function assertSpaceExists(spaceManager: SpaceManager, spaceId: string): Promise<void> {
+	const space = await spaceManager.getSpace(spaceId);
+	if (!space) {
+		throw new Error(`Space not found: ${spaceId}`);
+	}
+}
+
+export function setupSpaceMcpHandlers(
+	messageHub: MessageHub,
+	daemonHub: DaemonHub,
+	db: Database,
+	spaceManager: SpaceManager
+): void {
+	/**
+	 * List every registry entry with its resolved per-space enabled state so
+	 * the space settings UI can render the toggle list in a single round-trip.
+	 *
+	 * The resolution is: `enabled = override row if present, else registry default`.
+	 */
+	messageHub.onRequest('space.mcp.list', async (data) => {
+		const { spaceId } = data as SpaceMcpListRequest;
+		if (!spaceId || typeof spaceId !== 'string') {
+			throw new Error('spaceId is required');
+		}
+		await assertSpaceExists(spaceManager, spaceId);
+
+		const servers = db.appMcpServers.list();
+		const overrides = db.mcpEnablement.listForScope('space', spaceId);
+		const overrideMap = new Map(overrides.map((o) => [o.serverId, o.enabled]));
+
+		const entries: SpaceMcpEntry[] = servers.map((server) => {
+			const override = overrideMap.get(server.id);
+			const overridden = override !== undefined;
+			const enabled = overridden ? override! : server.enabled;
+			return {
+				serverId: server.id,
+				name: server.name,
+				...(server.description !== undefined ? { description: server.description } : {}),
+				sourceType: server.sourceType,
+				source: server.source,
+				...(server.sourcePath !== undefined ? { sourcePath: server.sourcePath } : {}),
+				globallyEnabled: server.enabled,
+				overridden,
+				enabled,
+			};
+		});
+
+		return { entries } satisfies SpaceMcpListResponse;
+	});
+
+	/**
+	 * Upsert an explicit enabled/disabled override for one (space, server) pair.
+	 */
+	messageHub.onRequest('space.mcp.setEnabled', async (data) => {
+		const { spaceId, serverId, enabled } = data as SpaceMcpSetEnabledRequest;
+		if (!spaceId || typeof spaceId !== 'string') {
+			throw new Error('spaceId is required');
+		}
+		if (!serverId || typeof serverId !== 'string') {
+			throw new Error('serverId is required');
+		}
+		if (typeof enabled !== 'boolean') {
+			throw new Error('enabled must be a boolean');
+		}
+		await assertSpaceExists(spaceManager, spaceId);
+
+		const server = db.appMcpServers.get(serverId);
+		if (!server) {
+			throw new Error(`MCP server not found: ${serverId}`);
+		}
+
+		db.mcpEnablement.setOverride('space', spaceId, serverId, enabled);
+		emitChanged(daemonHub);
+		log.info(
+			`space.mcp.setEnabled: space=${spaceId} server=${serverId} (${server.name}) enabled=${enabled}`
+		);
+		return { ok: true } satisfies SpaceMcpSetEnabledResponse;
+	});
+
+	/**
+	 * Remove an explicit override so the server inherits the registry default
+	 * again for this space. No-op (still returns ok:true) when no override
+	 * row exists, so the UI can call this idempotently from a "reset" button.
+	 */
+	messageHub.onRequest('space.mcp.clearOverride', async (data) => {
+		const { spaceId, serverId } = data as SpaceMcpClearOverrideRequest;
+		if (!spaceId || typeof spaceId !== 'string') {
+			throw new Error('spaceId is required');
+		}
+		if (!serverId || typeof serverId !== 'string') {
+			throw new Error('serverId is required');
+		}
+		await assertSpaceExists(spaceManager, spaceId);
+
+		const cleared = db.mcpEnablement.clearOverride('space', spaceId, serverId);
+		if (cleared) {
+			emitChanged(daemonHub);
+			log.info(`space.mcp.clearOverride: space=${spaceId} server=${serverId}`);
+		}
+		return { ok: true } satisfies SpaceMcpClearOverrideResponse;
+	});
+
+	/**
+	 * Rescan on-disk `.mcp.json` files and reconcile imported registry rows.
+	 *
+	 * Scans (in order):
+	 *   - `~/.claude/.mcp.json`
+	 *   - `<space.workspacePath>/.mcp.json` for every Space
+	 *   - `<workspacePath>/.mcp.json` when the request narrows to one workspace
+	 *
+	 * Emits `mcp.registry.changed` when any import rows change, so the UI
+	 * picks up the new set on its next `mcp.registry.list` call.
+	 */
+	messageHub.onRequest('mcp.imports.refresh', async (data) => {
+		const { workspacePath } = (data ?? {}) as McpImportsRefreshRequest;
+
+		const workspacePaths: string[] = [];
+		if (workspacePath && typeof workspacePath === 'string') {
+			workspacePaths.push(workspacePath);
+		} else {
+			const spaces = await spaceManager.listSpaces(true);
+			for (const s of spaces) {
+				if (s.workspacePath) workspacePaths.push(s.workspacePath);
+			}
+		}
+
+		const mcpJsonPaths = buildMcpJsonPaths({
+			workspacePaths,
+			homeDir: homedir(),
+		});
+
+		const result = await scanMcpImports(db.appMcpServers, { mcpJsonPaths });
+
+		if (result.imported > 0 || result.removed > 0) {
+			emitChanged(daemonHub);
+		}
+		log.info(
+			`mcp.imports.refresh: imported=${result.imported} removed=${result.removed} notes=${result.notes.length}`
+		);
+
+		return {
+			ok: true,
+			imported: result.imported,
+			removed: result.removed,
+			notes: result.notes,
+		} satisfies McpImportsRefreshResponse;
+	});
+}

--- a/packages/daemon/src/lib/skills-manager.ts
+++ b/packages/daemon/src/lib/skills-manager.ts
@@ -478,6 +478,7 @@ export class SkillsManager {
 				args: ['chrome-devtools-mcp@latest', '--isolated'],
 				env: {},
 				enabled: false,
+				source: 'builtin',
 			});
 
 		// Step 2: upsert the skill referencing the app MCP entry

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -677,7 +677,10 @@ export class TaskAgentManager {
 			// Note: task agent sessions are short-lived (one per task), so there is no
 			// mcp.registry.changed subscription here. Registry changes during a running task
 			// are not hot-reloaded; they take effect when the next task agent is spawned.
-			// Resolve overrides for the task agent session (scope='space' applies).
+			//
+			// Resolves the session's space > room > session scope chain against
+			// mcp_enablement so per-space overrides from the space settings UI
+			// are honored.
 			const registryMcpServers =
 				this.config.appMcpManager?.getEnabledMcpConfigsForSession({
 					id: sessionId,
@@ -2761,8 +2764,8 @@ export class TaskAgentManager {
 
 		// Merge registry-sourced MCP servers alongside the in-process task-agent server,
 		// mirroring the same logic in spawnTaskAgent() so rehydrated sessions have the
-		// same MCP configuration as freshly spawned ones.
-		// Session-aware resolver — scope='space' / scope='session' overrides apply.
+		// same MCP configuration as freshly spawned ones. Session-aware resolver
+		// — scope='space' / scope='session' overrides survive restarts.
 		const rehydrateRegistryMcpServers =
 			this.config.appMcpManager?.getEnabledMcpConfigsForSession({
 				id: sessionId,

--- a/packages/daemon/tests/unit/2-handlers/mcp/import-scanner.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/mcp/import-scanner.test.ts
@@ -1,0 +1,285 @@
+/**
+ * MCP Import Scanner Unit Tests
+ *
+ * Covers:
+ *   - scanMcpImports: idempotent updates, inserts, removals, name-collision with
+ *     non-imported rows, unknown-shape notes, missing and malformed files.
+ *   - buildMcpJsonPaths: dedupe, home/.claude injection, additional paths.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createTables } from '../../../../src/storage/schema';
+import { createReactiveDatabase } from '../../../../src/storage/reactive-database';
+import { AppMcpServerRepository } from '../../../../src/storage/repositories/app-mcp-server-repository';
+import type { ReactiveDatabase } from '../../../../src/storage/reactive-database';
+import { scanMcpImports, buildMcpJsonPaths } from '../../../../src/lib/mcp/import-scanner';
+
+describe('import-scanner', () => {
+	let bunDb: BunDatabase;
+	let reactiveDb: ReactiveDatabase;
+	let repo: AppMcpServerRepository;
+	let tmpRoot: string;
+
+	beforeEach(() => {
+		bunDb = new BunDatabase(':memory:');
+		createTables(bunDb);
+		reactiveDb = createReactiveDatabase({ getDatabase: () => bunDb } as never);
+		repo = new AppMcpServerRepository(bunDb, reactiveDb);
+		tmpRoot = mkdtempSync(join(tmpdir(), 'mcp-import-scanner-'));
+	});
+
+	afterEach(() => {
+		bunDb.close();
+		rmSync(tmpRoot, { recursive: true, force: true });
+	});
+
+	function writeMcpJson(relPath: string, body: object): string {
+		const fullPath = join(tmpRoot, relPath);
+		mkdirSync(join(fullPath, '..'), { recursive: true });
+		writeFileSync(fullPath, JSON.stringify(body, null, 2), 'utf-8');
+		return fullPath;
+	}
+
+	// ---------------------------------------------------------------------------
+	// scanMcpImports
+	// ---------------------------------------------------------------------------
+
+	describe('scanMcpImports', () => {
+		test('inserts imported rows for stdio entries', async () => {
+			const p = writeMcpJson('repo/.mcp.json', {
+				mcpServers: {
+					fetch: { command: 'npx', args: ['-y', '@mcp/fetch'] },
+				},
+			});
+
+			const result = await scanMcpImports(repo, { mcpJsonPaths: [p] });
+
+			expect(result.imported).toBe(1);
+			expect(result.removed).toBe(0);
+			const row = repo.getByName('fetch');
+			expect(row).toBeTruthy();
+			expect(row!.source).toBe('imported');
+			expect(row!.sourcePath).toBe(p);
+			expect(row!.sourceType).toBe('stdio');
+			expect(row!.command).toBe('npx');
+			expect(row!.args).toEqual(['-y', '@mcp/fetch']);
+			expect(row!.enabled).toBe(true);
+		});
+
+		test('infers http sourceType when url is set but no type', async () => {
+			const p = writeMcpJson('repo/.mcp.json', {
+				mcpServers: {
+					remote: { url: 'https://example.com/mcp' },
+				},
+			});
+
+			await scanMcpImports(repo, { mcpJsonPaths: [p] });
+			const row = repo.getByName('remote');
+			expect(row?.sourceType).toBe('http');
+			expect(row?.url).toBe('https://example.com/mcp');
+		});
+
+		test('honors explicit type sse', async () => {
+			const p = writeMcpJson('repo/.mcp.json', {
+				mcpServers: {
+					sseServer: { type: 'sse', url: 'https://sse.example.com' },
+				},
+			});
+
+			await scanMcpImports(repo, { mcpJsonPaths: [p] });
+			expect(repo.getByName('sseServer')?.sourceType).toBe('sse');
+		});
+
+		test('is idempotent — rescanning unchanged file does not produce updates', async () => {
+			const p = writeMcpJson('repo/.mcp.json', {
+				mcpServers: { fetch: { command: 'npx', args: ['-y', '@mcp/fetch'] } },
+			});
+
+			const first = await scanMcpImports(repo, { mcpJsonPaths: [p] });
+			expect(first.imported).toBe(1);
+
+			const second = await scanMcpImports(repo, { mcpJsonPaths: [p] });
+			expect(second.imported).toBe(0);
+			expect(second.removed).toBe(0);
+		});
+
+		test('updates existing imported row when command/args change', async () => {
+			const p = writeMcpJson('repo/.mcp.json', {
+				mcpServers: { changer: { command: 'old', args: ['v1'] } },
+			});
+			await scanMcpImports(repo, { mcpJsonPaths: [p] });
+
+			writeFileSync(
+				p,
+				JSON.stringify({ mcpServers: { changer: { command: 'new', args: ['v2'] } } })
+			);
+			const second = await scanMcpImports(repo, { mcpJsonPaths: [p] });
+
+			expect(second.imported).toBe(1);
+			const row = repo.getByName('changer');
+			expect(row?.command).toBe('new');
+			expect(row?.args).toEqual(['v2']);
+		});
+
+		test('removes imported rows whose source file was scanned but no longer lists them', async () => {
+			const p = writeMcpJson('repo/.mcp.json', {
+				mcpServers: { alpha: { command: 'a' }, beta: { command: 'b' } },
+			});
+			await scanMcpImports(repo, { mcpJsonPaths: [p] });
+			expect(repo.getByName('alpha')).toBeTruthy();
+			expect(repo.getByName('beta')).toBeTruthy();
+
+			// Rewrite the file without `alpha`.
+			writeFileSync(p, JSON.stringify({ mcpServers: { beta: { command: 'b' } } }));
+			const result = await scanMcpImports(repo, { mcpJsonPaths: [p] });
+
+			expect(result.removed).toBe(1);
+			expect(repo.getByName('alpha')).toBeNull();
+			expect(repo.getByName('beta')).toBeTruthy();
+		});
+
+		test('does not remove imported rows whose sourcePath was NOT scanned', async () => {
+			// Seed: two imported rows from different sourcePaths.
+			const p1 = writeMcpJson('repo1/.mcp.json', {
+				mcpServers: { one: { command: 'x' } },
+			});
+			const p2 = writeMcpJson('repo2/.mcp.json', {
+				mcpServers: { two: { command: 'y' } },
+			});
+			await scanMcpImports(repo, { mcpJsonPaths: [p1, p2] });
+
+			// Scan only p1 this time, with no entries — should only touch p1's row.
+			writeFileSync(p1, JSON.stringify({ mcpServers: {} }));
+			const result = await scanMcpImports(repo, { mcpJsonPaths: [p1] });
+
+			expect(result.removed).toBe(1);
+			expect(repo.getByName('one')).toBeNull();
+			expect(repo.getByName('two')).toBeTruthy();
+		});
+
+		test('does not touch user or builtin rows', async () => {
+			repo.create({ name: 'user-entry', sourceType: 'stdio', command: 'ok', source: 'user' });
+			repo.create({
+				name: 'builtin-entry',
+				sourceType: 'stdio',
+				command: 'ok',
+				source: 'builtin',
+			});
+
+			const p = writeMcpJson('repo/.mcp.json', { mcpServers: {} });
+			const result = await scanMcpImports(repo, { mcpJsonPaths: [p] });
+
+			expect(result.removed).toBe(0);
+			expect(repo.getByName('user-entry')).toBeTruthy();
+			expect(repo.getByName('builtin-entry')).toBeTruthy();
+		});
+
+		test('name collision with a user row is skipped and noted', async () => {
+			repo.create({
+				name: 'shared-name',
+				sourceType: 'stdio',
+				command: 'user-cmd',
+				source: 'user',
+			});
+
+			const p = writeMcpJson('repo/.mcp.json', {
+				mcpServers: { 'shared-name': { command: 'imported-cmd' } },
+			});
+			const result = await scanMcpImports(repo, { mcpJsonPaths: [p] });
+
+			// The user row is preserved.
+			expect(repo.getByName('shared-name')?.source).toBe('user');
+			expect(repo.getByName('shared-name')?.command).toBe('user-cmd');
+			expect(result.imported).toBe(0);
+			expect(result.notes.some((n) => n.includes('shared-name'))).toBe(true);
+		});
+
+		test('quietly skips missing files (no error, no note)', async () => {
+			const missing = join(tmpRoot, 'does-not-exist/.mcp.json');
+			const result = await scanMcpImports(repo, { mcpJsonPaths: [missing] });
+			expect(result.imported).toBe(0);
+			expect(result.removed).toBe(0);
+			expect(result.notes).toEqual([]);
+		});
+
+		test('records a parse-error note for malformed JSON', async () => {
+			const p = join(tmpRoot, 'bad.mcp.json');
+			writeFileSync(p, '{ not valid json ', 'utf-8');
+
+			const result = await scanMcpImports(repo, { mcpJsonPaths: [p] });
+			expect(result.imported).toBe(0);
+			expect(result.notes.some((n) => n.includes('parse error'))).toBe(true);
+		});
+
+		test('notes unknown-shape entries without inserting', async () => {
+			const p = writeMcpJson('repo/.mcp.json', {
+				mcpServers: { weird: { notes: 'no command or url' } },
+			});
+			const result = await scanMcpImports(repo, { mcpJsonPaths: [p] });
+			expect(result.imported).toBe(0);
+			expect(result.notes.some((n) => n.includes('unknown shape'))).toBe(true);
+		});
+
+		test('returns zero when the file has no mcpServers block', async () => {
+			const p = writeMcpJson('repo/.mcp.json', {});
+			const result = await scanMcpImports(repo, { mcpJsonPaths: [p] });
+			expect(result.imported).toBe(0);
+			expect(result.removed).toBe(0);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// buildMcpJsonPaths
+	// ---------------------------------------------------------------------------
+
+	describe('buildMcpJsonPaths', () => {
+		test('includes ~/.claude/.mcp.json when homeDir is set', () => {
+			const paths = buildMcpJsonPaths({
+				workspacePaths: [],
+				homeDir: '/home/user',
+			});
+			expect(paths).toContain('/home/user/.claude/.mcp.json');
+		});
+
+		test('joins .mcp.json onto each unique workspace path', () => {
+			const paths = buildMcpJsonPaths({
+				workspacePaths: ['/ws/a', '/ws/b'],
+			});
+			expect(paths).toContain('/ws/a/.mcp.json');
+			expect(paths).toContain('/ws/b/.mcp.json');
+		});
+
+		test('dedupes duplicate paths', () => {
+			const paths = buildMcpJsonPaths({
+				workspacePaths: ['/ws/a', '/ws/a'],
+				additional: ['/ws/a/.mcp.json'],
+			});
+			const count = paths.filter((p) => p === '/ws/a/.mcp.json').length;
+			expect(count).toBe(1);
+		});
+
+		test('skips empty workspace strings', () => {
+			const paths = buildMcpJsonPaths({
+				workspacePaths: ['', '/ws/b'],
+			});
+			expect(paths).toEqual(['/ws/b/.mcp.json']);
+		});
+
+		test('includes additional explicit paths', () => {
+			const paths = buildMcpJsonPaths({
+				workspacePaths: [],
+				additional: ['/custom/file.json'],
+			});
+			expect(paths).toContain('/custom/file.json');
+		});
+
+		test('omits home entry when homeDir is not supplied', () => {
+			const paths = buildMcpJsonPaths({ workspacePaths: ['/ws'] });
+			expect(paths).toEqual(['/ws/.mcp.json']);
+		});
+	});
+});

--- a/packages/daemon/tests/unit/2-handlers/rpc/space-mcp-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc/space-mcp-handlers.test.ts
@@ -1,0 +1,473 @@
+/**
+ * Unit tests for Space MCP RPC handlers (space-mcp-handlers.ts)
+ *
+ * Covers:
+ *   - space.mcp.list           — resolves override + global and builds entries[]
+ *   - space.mcp.setEnabled     — writes upsert override + emits changed event
+ *   - space.mcp.clearOverride  — deletes override + emits when a row changed
+ *   - mcp.imports.refresh      — builds scan paths, runs scanner, emits on diff
+ *
+ * Uses an in-memory SQLite DB for real repository interactions and mocks
+ * MessageHub/DaemonHub/SpaceManager at the edges.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type {
+	MessageHub,
+	Space,
+	SpaceMcpListResponse,
+	McpImportsRefreshResponse,
+} from '@neokai/shared';
+import { createTables } from '../../../../src/storage/schema';
+import { createReactiveDatabase } from '../../../../src/storage/reactive-database';
+import { AppMcpServerRepository } from '../../../../src/storage/repositories/app-mcp-server-repository';
+import { McpEnablementRepository } from '../../../../src/storage/repositories/mcp-enablement-repository';
+import { setupSpaceMcpHandlers } from '../../../../src/lib/rpc-handlers/space-mcp-handlers';
+import type { Database } from '../../../../src/storage/database';
+import type { DaemonHub } from '../../../../src/lib/daemon-hub';
+import type { SpaceManager } from '../../../../src/lib/space/managers/space-manager';
+import type { ReactiveDatabase } from '../../../../src/storage/reactive-database';
+
+type RequestHandler = (data: unknown, context?: unknown) => unknown;
+
+function createMockHub(): { hub: MessageHub; handlers: Map<string, RequestHandler> } {
+	const handlers = new Map<string, RequestHandler>();
+	const hub = {
+		onRequest: mock((method: string, handler: RequestHandler) => {
+			handlers.set(method, handler);
+			return () => handlers.delete(method);
+		}),
+		onEvent: mock(() => () => {}),
+		onClientDisconnect: mock(() => () => {}),
+		request: mock(async () => {}),
+		event: mock(() => {}),
+		joinChannel: mock(async () => {}),
+		leaveChannel: mock(async () => {}),
+		isConnected: mock(() => true),
+		getState: mock(() => 'connected' as const),
+		onConnection: mock(() => () => {}),
+		onMessage: mock(() => () => {}),
+		cleanup: mock(() => {}),
+		registerTransport: mock(() => () => {}),
+		registerRouter: mock(() => {}),
+		getRouter: mock(() => null),
+		getPendingCallCount: mock(() => 0),
+	} as unknown as MessageHub;
+	return { hub, handlers };
+}
+
+function createMockDaemonHub(): { daemonHub: DaemonHub; emit: ReturnType<typeof mock> } {
+	const emit = mock(async () => {});
+	const daemonHub = {
+		emit,
+		on: mock(() => () => {}),
+		off: mock(() => {}),
+		once: mock(async () => {}),
+	} as unknown as DaemonHub;
+	return { daemonHub, emit };
+}
+
+function fakeSpace(id: string, workspacePath?: string): Space {
+	return {
+		id,
+		name: id,
+		slug: id,
+		workspacePath: workspacePath ?? `/tmp/${id}`,
+		archivedAt: null,
+		createdAt: 0,
+		updatedAt: 0,
+	} as unknown as Space;
+}
+
+function createSpaceManagerMock(spaces: Space[]): SpaceManager {
+	return {
+		getSpace: mock(async (id: string) => spaces.find((s) => s.id === id) ?? null),
+		listSpaces: mock(async () => spaces),
+	} as unknown as SpaceManager;
+}
+
+describe('space-mcp-handlers', () => {
+	let bunDb: BunDatabase;
+	let reactiveDb: ReactiveDatabase;
+	let db: Database;
+	let appMcpRepo: AppMcpServerRepository;
+	let enablementRepo: McpEnablementRepository;
+	let tmpRoot: string;
+
+	beforeEach(() => {
+		bunDb = new BunDatabase(':memory:');
+		bunDb.exec('PRAGMA foreign_keys = ON');
+		createTables(bunDb);
+		reactiveDb = createReactiveDatabase({ getDatabase: () => bunDb } as never);
+
+		appMcpRepo = new AppMcpServerRepository(bunDb, reactiveDb);
+		enablementRepo = new McpEnablementRepository(bunDb, reactiveDb);
+
+		db = {
+			appMcpServers: appMcpRepo,
+			mcpEnablement: enablementRepo,
+		} as unknown as Database;
+
+		tmpRoot = mkdtempSync(join(tmpdir(), 'space-mcp-handlers-'));
+	});
+
+	afterEach(() => {
+		bunDb.close();
+		rmSync(tmpRoot, { recursive: true, force: true });
+	});
+
+	// ---------------------------------------------------------------------------
+	// space.mcp.list
+	// ---------------------------------------------------------------------------
+
+	describe('space.mcp.list', () => {
+		test('returns one entry per registry row with resolved enabled state', async () => {
+			const globalOn = appMcpRepo.create({
+				name: 'global-on',
+				sourceType: 'stdio',
+				command: 'on',
+				enabled: true,
+				source: 'user',
+			});
+			const globalOff = appMcpRepo.create({
+				name: 'global-off',
+				sourceType: 'stdio',
+				command: 'off',
+				enabled: false,
+				source: 'user',
+			});
+
+			// Override: disable global-on for space-A
+			enablementRepo.setOverride('space', 'space-A', globalOn.id, false);
+
+			const { hub, handlers } = createMockHub();
+			const { daemonHub } = createMockDaemonHub();
+			const spaceManager = createSpaceManagerMock([fakeSpace('space-A')]);
+			setupSpaceMcpHandlers(hub, daemonHub, db, spaceManager);
+
+			const handler = handlers.get('space.mcp.list')!;
+			const result = (await handler({ spaceId: 'space-A' })) as SpaceMcpListResponse;
+
+			expect(result.entries).toHaveLength(2);
+			const on = result.entries.find((e) => e.serverId === globalOn.id)!;
+			expect(on.globallyEnabled).toBe(true);
+			expect(on.overridden).toBe(true);
+			expect(on.enabled).toBe(false);
+
+			const off = result.entries.find((e) => e.serverId === globalOff.id)!;
+			expect(off.globallyEnabled).toBe(false);
+			expect(off.overridden).toBe(false);
+			expect(off.enabled).toBe(false);
+		});
+
+		test('surfaces imported source + sourcePath on entries', async () => {
+			appMcpRepo.create({
+				name: 'imp',
+				sourceType: 'stdio',
+				command: 'x',
+				source: 'imported',
+				sourcePath: '/repo/.mcp.json',
+				enabled: true,
+			});
+
+			const { hub, handlers } = createMockHub();
+			const { daemonHub } = createMockDaemonHub();
+			const spaceManager = createSpaceManagerMock([fakeSpace('space-A')]);
+			setupSpaceMcpHandlers(hub, daemonHub, db, spaceManager);
+
+			const handler = handlers.get('space.mcp.list')!;
+			const result = (await handler({ spaceId: 'space-A' })) as SpaceMcpListResponse;
+			const entry = result.entries.find((e) => e.name === 'imp')!;
+			expect(entry.source).toBe('imported');
+			expect(entry.sourcePath).toBe('/repo/.mcp.json');
+		});
+
+		test('throws when spaceId is missing', async () => {
+			const { hub, handlers } = createMockHub();
+			const { daemonHub } = createMockDaemonHub();
+			const spaceManager = createSpaceManagerMock([]);
+			setupSpaceMcpHandlers(hub, daemonHub, db, spaceManager);
+
+			const handler = handlers.get('space.mcp.list')!;
+			await expect(handler({})).rejects.toThrow('spaceId is required');
+		});
+
+		test('throws when space does not exist', async () => {
+			const { hub, handlers } = createMockHub();
+			const { daemonHub } = createMockDaemonHub();
+			const spaceManager = createSpaceManagerMock([fakeSpace('space-A')]);
+			setupSpaceMcpHandlers(hub, daemonHub, db, spaceManager);
+
+			const handler = handlers.get('space.mcp.list')!;
+			await expect(handler({ spaceId: 'nope' })).rejects.toThrow('Space not found');
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// space.mcp.setEnabled
+	// ---------------------------------------------------------------------------
+
+	describe('space.mcp.setEnabled', () => {
+		test('upserts an override row and emits mcp.registry.changed', async () => {
+			const srv = appMcpRepo.create({
+				name: 's1',
+				sourceType: 'stdio',
+				command: 'x',
+				enabled: true,
+			});
+
+			const { hub, handlers } = createMockHub();
+			const { daemonHub, emit } = createMockDaemonHub();
+			const spaceManager = createSpaceManagerMock([fakeSpace('space-A')]);
+			setupSpaceMcpHandlers(hub, daemonHub, db, spaceManager);
+
+			const handler = handlers.get('space.mcp.setEnabled')!;
+			const result = (await handler({
+				spaceId: 'space-A',
+				serverId: srv.id,
+				enabled: false,
+			})) as { ok: boolean };
+
+			expect(result.ok).toBe(true);
+			expect(enablementRepo.getOverride('space', 'space-A', srv.id)).toEqual({
+				scopeType: 'space',
+				scopeId: 'space-A',
+				serverId: srv.id,
+				enabled: false,
+			});
+			expect(emit).toHaveBeenCalledWith('mcp.registry.changed', { sessionId: 'global' });
+		});
+
+		test('flip — second call replaces the prior override', async () => {
+			const srv = appMcpRepo.create({
+				name: 'flipper',
+				sourceType: 'stdio',
+				command: 'x',
+				enabled: true,
+			});
+
+			const { hub, handlers } = createMockHub();
+			const { daemonHub } = createMockDaemonHub();
+			const spaceManager = createSpaceManagerMock([fakeSpace('space-A')]);
+			setupSpaceMcpHandlers(hub, daemonHub, db, spaceManager);
+
+			const handler = handlers.get('space.mcp.setEnabled')!;
+			await handler({ spaceId: 'space-A', serverId: srv.id, enabled: false });
+			await handler({ spaceId: 'space-A', serverId: srv.id, enabled: true });
+
+			expect(enablementRepo.getOverride('space', 'space-A', srv.id)).toEqual({
+				scopeType: 'space',
+				scopeId: 'space-A',
+				serverId: srv.id,
+				enabled: true,
+			});
+		});
+
+		test('throws when serverId does not exist', async () => {
+			const { hub, handlers } = createMockHub();
+			const { daemonHub } = createMockDaemonHub();
+			const spaceManager = createSpaceManagerMock([fakeSpace('space-A')]);
+			setupSpaceMcpHandlers(hub, daemonHub, db, spaceManager);
+
+			const handler = handlers.get('space.mcp.setEnabled')!;
+			await expect(
+				handler({ spaceId: 'space-A', serverId: 'ghost', enabled: true })
+			).rejects.toThrow('MCP server not found');
+		});
+
+		test('throws on missing required fields', async () => {
+			const { hub, handlers } = createMockHub();
+			const { daemonHub } = createMockDaemonHub();
+			const spaceManager = createSpaceManagerMock([fakeSpace('space-A')]);
+			setupSpaceMcpHandlers(hub, daemonHub, db, spaceManager);
+
+			const handler = handlers.get('space.mcp.setEnabled')!;
+			await expect(handler({ serverId: 'x', enabled: true })).rejects.toThrow(
+				'spaceId is required'
+			);
+			await expect(handler({ spaceId: 'space-A', enabled: true })).rejects.toThrow(
+				'serverId is required'
+			);
+			await expect(
+				handler({ spaceId: 'space-A', serverId: 'x', enabled: 'nope' as never })
+			).rejects.toThrow('enabled must be a boolean');
+		});
+
+		test('throws when space does not exist', async () => {
+			const { hub, handlers } = createMockHub();
+			const { daemonHub } = createMockDaemonHub();
+			const spaceManager = createSpaceManagerMock([fakeSpace('space-A')]);
+			setupSpaceMcpHandlers(hub, daemonHub, db, spaceManager);
+
+			const handler = handlers.get('space.mcp.setEnabled')!;
+			await expect(handler({ spaceId: 'missing', serverId: 'x', enabled: true })).rejects.toThrow(
+				'Space not found'
+			);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// space.mcp.clearOverride
+	// ---------------------------------------------------------------------------
+
+	describe('space.mcp.clearOverride', () => {
+		test('removes the override row and emits changed', async () => {
+			const srv = appMcpRepo.create({
+				name: 'c1',
+				sourceType: 'stdio',
+				command: 'x',
+				enabled: true,
+			});
+			enablementRepo.setOverride('space', 'space-A', srv.id, false);
+
+			const { hub, handlers } = createMockHub();
+			const { daemonHub, emit } = createMockDaemonHub();
+			const spaceManager = createSpaceManagerMock([fakeSpace('space-A')]);
+			setupSpaceMcpHandlers(hub, daemonHub, db, spaceManager);
+
+			const handler = handlers.get('space.mcp.clearOverride')!;
+			const result = (await handler({ spaceId: 'space-A', serverId: srv.id })) as {
+				ok: boolean;
+			};
+
+			expect(result.ok).toBe(true);
+			expect(enablementRepo.getOverride('space', 'space-A', srv.id)).toBeNull();
+			expect(emit).toHaveBeenCalledWith('mcp.registry.changed', { sessionId: 'global' });
+		});
+
+		test('idempotent — no override row still returns ok:true and no emit', async () => {
+			const srv = appMcpRepo.create({
+				name: 'noop',
+				sourceType: 'stdio',
+				command: 'x',
+				enabled: true,
+			});
+
+			const { hub, handlers } = createMockHub();
+			const { daemonHub, emit } = createMockDaemonHub();
+			const spaceManager = createSpaceManagerMock([fakeSpace('space-A')]);
+			setupSpaceMcpHandlers(hub, daemonHub, db, spaceManager);
+
+			const handler = handlers.get('space.mcp.clearOverride')!;
+			const result = (await handler({ spaceId: 'space-A', serverId: srv.id })) as {
+				ok: boolean;
+			};
+			expect(result.ok).toBe(true);
+			expect(emit).not.toHaveBeenCalled();
+		});
+
+		test('throws on missing ids', async () => {
+			const { hub, handlers } = createMockHub();
+			const { daemonHub } = createMockDaemonHub();
+			const spaceManager = createSpaceManagerMock([fakeSpace('space-A')]);
+			setupSpaceMcpHandlers(hub, daemonHub, db, spaceManager);
+
+			const handler = handlers.get('space.mcp.clearOverride')!;
+			await expect(handler({ serverId: 'x' })).rejects.toThrow('spaceId is required');
+			await expect(handler({ spaceId: 'space-A' })).rejects.toThrow('serverId is required');
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// mcp.imports.refresh
+	// ---------------------------------------------------------------------------
+
+	describe('mcp.imports.refresh', () => {
+		test('scans the given workspace and imports new rows', async () => {
+			const wsPath = join(tmpRoot, 'ws');
+			writeFileSync(
+				join(tmpRoot, 'mcp.json'),
+				JSON.stringify({ mcpServers: { foo: { command: 'x' } } })
+			);
+			// put .mcp.json inside wsPath
+			const fs = await import('node:fs');
+			fs.mkdirSync(wsPath, { recursive: true });
+			writeFileSync(
+				join(wsPath, '.mcp.json'),
+				JSON.stringify({ mcpServers: { foo: { command: 'x' } } })
+			);
+
+			const { hub, handlers } = createMockHub();
+			const { daemonHub, emit } = createMockDaemonHub();
+			const spaceManager = createSpaceManagerMock([fakeSpace('space-A', wsPath)]);
+			setupSpaceMcpHandlers(hub, daemonHub, db, spaceManager);
+
+			const handler = handlers.get('mcp.imports.refresh')!;
+			const result = (await handler({ workspacePath: wsPath })) as McpImportsRefreshResponse;
+
+			expect(result.ok).toBe(true);
+			expect(result.imported).toBe(1);
+			expect(result.removed).toBe(0);
+			expect(appMcpRepo.getByName('foo')?.source).toBe('imported');
+			expect(emit).toHaveBeenCalledWith('mcp.registry.changed', { sessionId: 'global' });
+		});
+
+		test('scans every space when no workspacePath narrow is given', async () => {
+			const ws1 = join(tmpRoot, 'ws1');
+			const ws2 = join(tmpRoot, 'ws2');
+			const fs = await import('node:fs');
+			fs.mkdirSync(ws1, { recursive: true });
+			fs.mkdirSync(ws2, { recursive: true });
+			writeFileSync(
+				join(ws1, '.mcp.json'),
+				JSON.stringify({ mcpServers: { one: { command: 'x' } } })
+			);
+			writeFileSync(
+				join(ws2, '.mcp.json'),
+				JSON.stringify({ mcpServers: { two: { command: 'y' } } })
+			);
+
+			const { hub, handlers } = createMockHub();
+			const { daemonHub } = createMockDaemonHub();
+			const spaceManager = createSpaceManagerMock([fakeSpace('sA', ws1), fakeSpace('sB', ws2)]);
+			setupSpaceMcpHandlers(hub, daemonHub, db, spaceManager);
+
+			const handler = handlers.get('mcp.imports.refresh')!;
+			const result = (await handler({})) as McpImportsRefreshResponse;
+
+			expect(result.imported).toBe(2);
+			expect(appMcpRepo.getByName('one')).toBeTruthy();
+			expect(appMcpRepo.getByName('two')).toBeTruthy();
+		});
+
+		test('does not emit when no import rows changed', async () => {
+			const wsPath = join(tmpRoot, 'empty-ws');
+			const fs = await import('node:fs');
+			fs.mkdirSync(wsPath, { recursive: true });
+			// No .mcp.json at all — scanner should return zero changes.
+
+			const { hub, handlers } = createMockHub();
+			const { daemonHub, emit } = createMockDaemonHub();
+			const spaceManager = createSpaceManagerMock([fakeSpace('space-A', wsPath)]);
+			setupSpaceMcpHandlers(hub, daemonHub, db, spaceManager);
+
+			const handler = handlers.get('mcp.imports.refresh')!;
+			const result = (await handler({ workspacePath: wsPath })) as McpImportsRefreshResponse;
+
+			expect(result.imported).toBe(0);
+			expect(result.removed).toBe(0);
+			expect(emit).not.toHaveBeenCalled();
+		});
+
+		test('surfaces parse-error notes from the scanner', async () => {
+			const wsPath = join(tmpRoot, 'bad-ws');
+			const fs = await import('node:fs');
+			fs.mkdirSync(wsPath, { recursive: true });
+			writeFileSync(join(wsPath, '.mcp.json'), '{ not valid json');
+
+			const { hub, handlers } = createMockHub();
+			const { daemonHub } = createMockDaemonHub();
+			const spaceManager = createSpaceManagerMock([fakeSpace('space-A', wsPath)]);
+			setupSpaceMcpHandlers(hub, daemonHub, db, spaceManager);
+
+			const handler = handlers.get('mcp.imports.refresh')!;
+			const result = (await handler({ workspacePath: wsPath })) as McpImportsRefreshResponse;
+
+			expect(result.notes.some((n) => n.includes('parse error'))).toBe(true);
+		});
+	});
+});

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -456,6 +456,80 @@ export interface McpRoomResetToGlobalResponse {
 	ok: boolean;
 }
 
+// --- Per-Space MCP Enablement (M4) ---
+
+/**
+ * One entry in the resolved per-space MCP list. Combines the registry row
+ * with the resolved enabled-for-this-space state so the UI can render the
+ * toggle without making a second call.
+ */
+export interface SpaceMcpEntry {
+	serverId: string;
+	name: string;
+	description?: string;
+	sourceType: 'stdio' | 'sse' | 'http';
+	/** Provenance of the registry row (builtin / user / imported). */
+	source: 'builtin' | 'user' | 'imported';
+	/** Populated only when `source === 'imported'`. */
+	sourcePath?: string;
+	/** Whether this server is enabled globally in the registry. */
+	globallyEnabled: boolean;
+	/**
+	 * True when there is an explicit `mcp_enablement` row for this
+	 * (server, space) pair. When false, `enabled` equals `globallyEnabled`.
+	 */
+	overridden: boolean;
+	/** Effective enabled state for this space (override if present, else global). */
+	enabled: boolean;
+}
+
+export interface SpaceMcpListRequest {
+	spaceId: string;
+}
+
+export interface SpaceMcpListResponse {
+	entries: SpaceMcpEntry[];
+}
+
+export interface SpaceMcpSetEnabledRequest {
+	spaceId: string;
+	serverId: string;
+	enabled: boolean;
+}
+
+export interface SpaceMcpSetEnabledResponse {
+	ok: boolean;
+}
+
+export interface SpaceMcpClearOverrideRequest {
+	spaceId: string;
+	serverId: string;
+}
+
+export interface SpaceMcpClearOverrideResponse {
+	ok: boolean;
+}
+
+// --- MCP Imports (explicit refresh trigger for .mcp.json discovery) ---
+
+export interface McpImportsRefreshRequest {
+	/**
+	 * Optional: limit the refresh scan to a single workspace path. When
+	 * omitted, scans every registered workspace + `~/.claude/.mcp.json`.
+	 */
+	workspacePath?: string;
+}
+
+export interface McpImportsRefreshResponse {
+	ok: boolean;
+	/** Number of imported rows inserted or updated by this refresh. */
+	imported: number;
+	/** Number of imported rows removed because their source file no longer lists them. */
+	removed: number;
+	/** Human-readable notes (e.g. files not found, parse errors). */
+	notes: string[];
+}
+
 // --- Per-Room Skill Enablement ---
 
 export interface SkillRoomGetOverridesRequest {

--- a/packages/web/src/components/space/SpaceMcpSettings.tsx
+++ b/packages/web/src/components/space/SpaceMcpSettings.tsx
@@ -1,0 +1,305 @@
+/**
+ * SpaceMcpSettings — per-space MCP enablement panel.
+ *
+ * Lists every entry in the application-level MCP registry (`app_mcp_servers`)
+ * grouped by provenance (builtin / user / imported) and renders a toggle
+ * whose state reflects the per-space override, or the registry default when
+ * no override exists.
+ *
+ * Toggling writes via `space.mcp.setEnabled`. A per-row "Reset" appears when
+ * an override exists, issuing `space.mcp.clearOverride` so the space falls
+ * back to the registry default again. A section-level "Refresh imports"
+ * button triggers `mcp.imports.refresh` to rescan on-disk `.mcp.json` files.
+ *
+ * Per-space overrides take effect on **new** sessions only — already-running
+ * task/coder sessions keep the MCP set they started with. The copy surfaces
+ * this explicitly so toggles are never mistaken for a live-reload.
+ */
+
+import { useSignalEffect } from '@preact/signals';
+import { useMemo, useState } from 'preact/hooks';
+import type { McpImportsRefreshResponse, SpaceMcpEntry } from '@neokai/shared';
+import { spaceMcpStore } from '../../lib/space-mcp-store.ts';
+import { connectionManager } from '../../lib/connection-manager.ts';
+import { toast } from '../../lib/toast.ts';
+import { cn } from '../../lib/utils.ts';
+import { Spinner } from '../ui/Spinner.tsx';
+import { Button } from '../ui/Button.tsx';
+
+interface SpaceMcpSettingsProps {
+	spaceId: string;
+	disabled?: boolean;
+}
+
+type GroupKey = 'builtin' | 'user' | 'imported';
+
+const GROUP_LABELS: Record<GroupKey, string> = {
+	builtin: 'Built-in',
+	user: 'Added in NeoKai',
+	imported: 'Imported from .mcp.json',
+};
+
+const GROUP_ORDER: GroupKey[] = ['builtin', 'user', 'imported'];
+
+function sourceTypeLabel(sourceType: string): string {
+	switch (sourceType) {
+		case 'stdio':
+			return 'stdio';
+		case 'sse':
+			return 'SSE';
+		case 'http':
+			return 'HTTP';
+		default:
+			return sourceType;
+	}
+}
+
+export function SpaceMcpSettings({ spaceId, disabled = false }: SpaceMcpSettingsProps) {
+	const [refreshing, setRefreshing] = useState(false);
+
+	useSignalEffect(() => {
+		// spaceMcpStore is a singleton, so `subscribe(spaceId)` is idempotent per
+		// spaceId and swaps subscriptions automatically if spaceId changes.
+		spaceMcpStore.subscribe(spaceId).catch((err) => {
+			// Error surface is already stored in spaceMcpStore.error
+			// eslint-disable-next-line no-console
+			toast.error(
+				`Failed to load MCP servers: ${err instanceof Error ? err.message : String(err)}`
+			);
+		});
+		return () => {
+			spaceMcpStore.unsubscribe();
+		};
+	});
+
+	const entriesMap = spaceMcpStore.entries.value;
+	const loading = spaceMcpStore.loading.value;
+
+	const grouped = useMemo(() => {
+		const out: Record<GroupKey, SpaceMcpEntry[]> = {
+			builtin: [],
+			user: [],
+			imported: [],
+		};
+		for (const entry of entriesMap.values()) {
+			const key: GroupKey =
+				entry.source === 'builtin' ? 'builtin' : entry.source === 'imported' ? 'imported' : 'user';
+			out[key].push(entry);
+		}
+		for (const key of GROUP_ORDER) {
+			out[key].sort((a, b) => a.name.localeCompare(b.name));
+		}
+		return out;
+	}, [entriesMap]);
+
+	const totalEntries = entriesMap.size;
+
+	async function handleToggle(entry: SpaceMcpEntry, nextEnabled: boolean): Promise<void> {
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) {
+			toast.error('Not connected to server');
+			return;
+		}
+		try {
+			await hub.request('space.mcp.setEnabled', {
+				spaceId,
+				serverId: entry.serverId,
+				enabled: nextEnabled,
+			});
+		} catch (err) {
+			toast.error(
+				`Failed to ${nextEnabled ? 'enable' : 'disable'} ${entry.name}: ${
+					err instanceof Error ? err.message : String(err)
+				}`
+			);
+		}
+	}
+
+	async function handleClearOverride(entry: SpaceMcpEntry): Promise<void> {
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) {
+			toast.error('Not connected to server');
+			return;
+		}
+		try {
+			await hub.request('space.mcp.clearOverride', {
+				spaceId,
+				serverId: entry.serverId,
+			});
+			toast.success(`${entry.name} now follows the global default`);
+		} catch (err) {
+			toast.error(
+				`Failed to reset ${entry.name}: ${err instanceof Error ? err.message : String(err)}`
+			);
+		}
+	}
+
+	async function handleRefreshImports(): Promise<void> {
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) {
+			toast.error('Not connected to server');
+			return;
+		}
+		try {
+			setRefreshing(true);
+			const result = await hub.request<McpImportsRefreshResponse>('mcp.imports.refresh', {});
+			const summary =
+				result.imported > 0 || result.removed > 0
+					? `Refreshed: ${result.imported} imported, ${result.removed} removed`
+					: 'No changes from .mcp.json scan';
+			toast.success(summary);
+			for (const note of result.notes) {
+				// Parser warnings / name collisions surface here for visibility.
+				toast.info(note);
+			}
+		} catch (err) {
+			toast.error(`Refresh failed: ${err instanceof Error ? err.message : String(err)}`);
+		} finally {
+			setRefreshing(false);
+		}
+	}
+
+	return (
+		<section class="space-y-3" data-testid="space-mcp-settings">
+			<div class="flex items-center justify-between">
+				<h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider">MCP Servers</h3>
+				<Button
+					type="button"
+					variant="secondary"
+					size="sm"
+					loading={refreshing}
+					disabled={disabled || refreshing}
+					onClick={handleRefreshImports}
+					data-testid="space-mcp-refresh-imports"
+				>
+					Refresh imports
+				</Button>
+			</div>
+			<p class="text-xs text-gray-500">
+				Enable or disable MCP servers for tasks spawned in this space. Each toggle overrides the
+				global default. Changes apply to <strong>new</strong> sessions; already-running tasks keep
+				the MCP set they started with.
+			</p>
+
+			{loading && totalEntries === 0 ? (
+				<div class="flex items-center gap-2 py-2">
+					<Spinner size="sm" />
+					<span class="text-xs text-gray-500">Loading MCP servers…</span>
+				</div>
+			) : totalEntries === 0 ? (
+				<div class="text-sm text-gray-500 bg-dark-800 border border-dark-700 rounded-lg px-3 py-3">
+					No MCP servers configured. Add one in global MCP settings, or drop a
+					<span class="font-mono mx-1">.mcp.json</span>
+					into the space workspace and press <strong>Refresh imports</strong>.
+				</div>
+			) : (
+				<div class="space-y-4">
+					{GROUP_ORDER.map((groupKey) => {
+						const group = grouped[groupKey];
+						if (group.length === 0) return null;
+						return (
+							<div key={groupKey} class="space-y-2">
+								<div class="text-[11px] uppercase tracking-wider text-gray-500">
+									{GROUP_LABELS[groupKey]}
+								</div>
+								<div class="space-y-2">
+									{group.map((entry) => (
+										<SpaceMcpEntryRow
+											key={entry.serverId}
+											entry={entry}
+											disabled={disabled}
+											onToggle={(next) => handleToggle(entry, next)}
+											onClearOverride={() => handleClearOverride(entry)}
+										/>
+									))}
+								</div>
+							</div>
+						);
+					})}
+				</div>
+			)}
+		</section>
+	);
+}
+
+interface SpaceMcpEntryRowProps {
+	entry: SpaceMcpEntry;
+	disabled: boolean;
+	onToggle: (next: boolean) => Promise<void>;
+	onClearOverride: () => Promise<void>;
+}
+
+function SpaceMcpEntryRow({ entry, disabled, onToggle, onClearOverride }: SpaceMcpEntryRowProps) {
+	const badges: Array<{ label: string; tone: 'override' | 'muted' | 'info' }> = [];
+	if (entry.overridden) {
+		badges.push({ label: 'space override', tone: 'override' });
+	}
+	if (!entry.overridden && !entry.globallyEnabled) {
+		badges.push({ label: 'disabled globally', tone: 'muted' });
+	}
+	if (entry.source === 'imported') {
+		badges.push({ label: 'imported', tone: 'info' });
+	}
+
+	return (
+		<label
+			class={cn(
+				'flex items-start gap-3 bg-dark-800 border border-dark-600 rounded-lg px-3 py-2.5 cursor-pointer hover:border-dark-500 transition-colors',
+				disabled && 'opacity-60 cursor-not-allowed'
+			)}
+			data-testid={`space-mcp-entry-${entry.name}`}
+		>
+			<input
+				type="checkbox"
+				checked={entry.enabled}
+				disabled={disabled}
+				onChange={async () => {
+					await onToggle(!entry.enabled);
+				}}
+				class="w-4 h-4 mt-0.5 rounded border-dark-500 bg-dark-700 text-blue-500
+				focus:ring-blue-500 focus:ring-offset-dark-900 cursor-pointer"
+				data-testid={`space-mcp-toggle-${entry.name}`}
+			/>
+			<div class="flex-1 min-w-0">
+				<div class="flex items-center gap-2 flex-wrap">
+					<span class="text-sm font-medium text-gray-200">{entry.name}</span>
+					{badges.map((b) => (
+						<span
+							key={b.label}
+							class={cn(
+								'text-xs px-1.5 py-0.5 rounded',
+								b.tone === 'override' && 'bg-blue-900/40 text-blue-400',
+								b.tone === 'muted' && 'bg-dark-700 text-gray-500',
+								b.tone === 'info' && 'bg-purple-900/40 text-purple-300'
+							)}
+						>
+							{b.label}
+						</span>
+					))}
+				</div>
+				{entry.description && (
+					<p class="text-xs text-gray-500 mt-0.5 truncate">{entry.description}</p>
+				)}
+				<p class="text-xs text-gray-600 mt-0.5 font-mono">
+					{sourceTypeLabel(entry.sourceType)}
+					{entry.source === 'imported' && entry.sourcePath ? ` — ${entry.sourcePath}` : ''}
+				</p>
+				{entry.overridden && (
+					<button
+						type="button"
+						class="text-xs text-gray-400 hover:text-gray-200 mt-1 disabled:opacity-40"
+						onClick={async (e) => {
+							e.preventDefault();
+							e.stopPropagation();
+							await onClearOverride();
+						}}
+						disabled={disabled}
+						data-testid={`space-mcp-reset-${entry.name}`}
+					>
+						Reset to global default
+					</button>
+				)}
+			</div>
+		</label>
+	);
+}

--- a/packages/web/src/components/space/SpaceSettings.tsx
+++ b/packages/web/src/components/space/SpaceSettings.tsx
@@ -18,6 +18,7 @@ import { navigateToSpaces } from '../../lib/router.ts';
 import { Button } from '../ui/Button.tsx';
 import { AUTONOMY_LEVELS } from '../../lib/space-constants.ts';
 import { AutonomyWorkflowSummary } from './AutonomyWorkflowSummary.tsx';
+import { SpaceMcpSettings } from './SpaceMcpSettings.tsx';
 
 interface SpaceSettingsProps {
 	space: Space;
@@ -316,6 +317,9 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 						<p class="text-xs text-gray-500 font-mono break-all">{space.workspacePath}</p>
 					</div>
 				</section>
+
+				{/* MCP Servers — per-space overrides for the application MCP registry. */}
+				<SpaceMcpSettings spaceId={space.id} disabled={saving} />
 
 				{/* Export section */}
 				<section class="space-y-3">

--- a/packages/web/src/components/space/__tests__/SpaceMcpSettings.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceMcpSettings.test.tsx
@@ -1,0 +1,242 @@
+/**
+ * Tests for SpaceMcpSettings component
+ *
+ * Covers:
+ * - Subscribes to spaceMcpStore on mount and unsubscribes on unmount
+ * - Renders entries grouped by source (builtin/user/imported)
+ * - Clicking a toggle calls space.mcp.setEnabled RPC with the new value
+ * - Clicking reset calls space.mcp.clearOverride
+ * - Clicking "Refresh imports" calls mcp.imports.refresh
+ * - Shows override badge when entry is overridden
+ * - Shows "disabled globally" badge when appropriate
+ * - Handles empty state + loading spinner
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, waitFor } from '@testing-library/preact';
+import type { SpaceMcpEntry } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const mockEntriesMap = vi.hoisted(() => new Map<string, SpaceMcpEntry>());
+const mockSubscribe = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockUnsubscribe = vi.hoisted(() => vi.fn());
+
+const mockHubRequest = vi.hoisted(() => vi.fn().mockResolvedValue({ ok: true }));
+const mockGetHubIfConnected = vi.hoisted(() =>
+	vi.fn(() => ({
+		request: mockHubRequest,
+	}))
+);
+
+const mockToastSuccess = vi.hoisted(() => vi.fn());
+const mockToastError = vi.hoisted(() => vi.fn());
+const mockToastInfo = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../lib/space-mcp-store.ts', () => ({
+	spaceMcpStore: {
+		entries: { value: mockEntriesMap, subscribe: vi.fn() },
+		loading: { value: false, subscribe: vi.fn() },
+		error: { value: null, subscribe: vi.fn() },
+		subscribe: mockSubscribe,
+		unsubscribe: mockUnsubscribe,
+	},
+}));
+
+vi.mock('../../../lib/connection-manager.ts', () => ({
+	connectionManager: {
+		getHubIfConnected: mockGetHubIfConnected,
+	},
+}));
+
+vi.mock('../../../lib/toast.ts', () => ({
+	toast: {
+		success: mockToastSuccess,
+		error: mockToastError,
+		info: mockToastInfo,
+	},
+}));
+
+import { SpaceMcpSettings } from '../SpaceMcpSettings';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEntry(name: string, overrides: Partial<SpaceMcpEntry> = {}): SpaceMcpEntry {
+	return {
+		serverId: `srv-${name}`,
+		name,
+		sourceType: 'stdio',
+		source: 'user',
+		globallyEnabled: true,
+		overridden: false,
+		enabled: true,
+		...overrides,
+	};
+}
+
+function setEntries(entries: SpaceMcpEntry[]): void {
+	mockEntriesMap.clear();
+	for (const e of entries) mockEntriesMap.set(e.serverId, e);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SpaceMcpSettings', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockEntriesMap.clear();
+		mockHubRequest.mockResolvedValue({ ok: true });
+		mockGetHubIfConnected.mockReturnValue({ request: mockHubRequest });
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('subscribes to the store on mount with the given spaceId', () => {
+		render(<SpaceMcpSettings spaceId="space-1" />);
+		expect(mockSubscribe).toHaveBeenCalledWith('space-1');
+	});
+
+	it('renders grouped entries with group labels', () => {
+		setEntries([
+			makeEntry('alpha', { source: 'user' }),
+			makeEntry('bravo', { source: 'builtin' }),
+			makeEntry('charlie', {
+				source: 'imported',
+				sourcePath: '/repo/.mcp.json',
+			}),
+		]);
+
+		const { container } = render(<SpaceMcpSettings spaceId="space-1" />);
+
+		expect(container.textContent).toContain('Built-in');
+		expect(container.textContent).toContain('Added in NeoKai');
+		expect(container.textContent).toContain('Imported from .mcp.json');
+		expect(container.textContent).toContain('alpha');
+		expect(container.textContent).toContain('bravo');
+		expect(container.textContent).toContain('charlie');
+	});
+
+	it('shows sourcePath text for imported entries', () => {
+		setEntries([
+			makeEntry('imp', {
+				source: 'imported',
+				sourcePath: '/repo/.mcp.json',
+			}),
+		]);
+		const { container } = render(<SpaceMcpSettings spaceId="space-1" />);
+		expect(container.textContent).toContain('/repo/.mcp.json');
+	});
+
+	it('renders the "space override" badge only for overridden entries', () => {
+		setEntries([makeEntry('plain'), makeEntry('overridden', { overridden: true, enabled: false })]);
+		const { container } = render(<SpaceMcpSettings spaceId="space-1" />);
+		const text = container.textContent ?? '';
+		// Only one occurrence of "space override"
+		expect((text.match(/space override/g) ?? []).length).toBe(1);
+	});
+
+	it('shows "disabled globally" when global is false and no override', () => {
+		setEntries([makeEntry('off', { globallyEnabled: false, enabled: false })]);
+		const { container } = render(<SpaceMcpSettings spaceId="space-1" />);
+		expect(container.textContent).toContain('disabled globally');
+	});
+
+	it('toggles a server — calls space.mcp.setEnabled with inverse value', async () => {
+		setEntries([makeEntry('alpha', { enabled: true })]);
+		const { getByTestId } = render(<SpaceMcpSettings spaceId="space-1" />);
+		const toggle = getByTestId('space-mcp-toggle-alpha') as HTMLInputElement;
+
+		fireEvent.change(toggle);
+
+		await waitFor(() => {
+			expect(mockHubRequest).toHaveBeenCalledWith('space.mcp.setEnabled', {
+				spaceId: 'space-1',
+				serverId: 'srv-alpha',
+				enabled: false,
+			});
+		});
+	});
+
+	it('reset button calls space.mcp.clearOverride for overridden entry', async () => {
+		setEntries([makeEntry('reset-me', { overridden: true, enabled: false })]);
+		const { getByTestId } = render(<SpaceMcpSettings spaceId="space-1" />);
+		const btn = getByTestId('space-mcp-reset-reset-me') as HTMLButtonElement;
+
+		fireEvent.click(btn);
+
+		await waitFor(() => {
+			expect(mockHubRequest).toHaveBeenCalledWith('space.mcp.clearOverride', {
+				spaceId: 'space-1',
+				serverId: 'srv-reset-me',
+			});
+		});
+		expect(mockToastSuccess).toHaveBeenCalled();
+	});
+
+	it('refresh imports calls mcp.imports.refresh and toasts a summary', async () => {
+		mockHubRequest.mockResolvedValueOnce({ ok: true, imported: 2, removed: 0, notes: [] });
+		const { getByTestId } = render(<SpaceMcpSettings spaceId="space-1" />);
+		const btn = getByTestId('space-mcp-refresh-imports') as HTMLButtonElement;
+
+		fireEvent.click(btn);
+
+		await waitFor(() => {
+			expect(mockHubRequest).toHaveBeenCalledWith('mcp.imports.refresh', {});
+		});
+		await waitFor(() => {
+			expect(mockToastSuccess).toHaveBeenCalledWith(expect.stringContaining('2 imported'));
+		});
+	});
+
+	it('surfaces scanner notes via toast.info', async () => {
+		mockHubRequest.mockResolvedValueOnce({
+			ok: true,
+			imported: 0,
+			removed: 0,
+			notes: ['/tmp/foo: parse error — oops'],
+		});
+		const { getByTestId } = render(<SpaceMcpSettings spaceId="space-1" />);
+		fireEvent.click(getByTestId('space-mcp-refresh-imports') as HTMLButtonElement);
+
+		await waitFor(() => {
+			expect(mockToastInfo).toHaveBeenCalledWith('/tmp/foo: parse error — oops');
+		});
+	});
+
+	it('shows empty state when there are no entries', () => {
+		setEntries([]);
+		const { container } = render(<SpaceMcpSettings spaceId="space-1" />);
+		expect(container.textContent).toContain('No MCP servers configured');
+	});
+
+	it('toasts an error when toggle call rejects', async () => {
+		setEntries([makeEntry('fail-srv')]);
+		mockHubRequest.mockRejectedValueOnce(new Error('nope'));
+		const { getByTestId } = render(<SpaceMcpSettings spaceId="space-1" />);
+		fireEvent.change(getByTestId('space-mcp-toggle-fail-srv') as HTMLInputElement);
+
+		await waitFor(() => {
+			expect(mockToastError).toHaveBeenCalled();
+			expect(mockToastError.mock.calls[0][0]).toMatch(/nope/);
+		});
+	});
+
+	it('toasts error when not connected', async () => {
+		mockGetHubIfConnected.mockReturnValue(null as never);
+		setEntries([makeEntry('offline-srv')]);
+		const { getByTestId } = render(<SpaceMcpSettings spaceId="space-1" />);
+		fireEvent.change(getByTestId('space-mcp-toggle-offline-srv') as HTMLInputElement);
+
+		await waitFor(() => {
+			expect(mockToastError).toHaveBeenCalledWith('Not connected to server');
+		});
+	});
+});

--- a/packages/web/src/lib/__tests__/space-mcp-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-mcp-store.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Tests for SpaceMcpStore
+ *
+ * Covers:
+ * - subscribe/unsubscribe wiring and idempotency
+ * - snapshot populates entries signal
+ * - delta applies added/updated/removed to the signal
+ * - stale-event guard discards events after unsubscribe
+ * - WebSocket reconnect re-subscribes automatically
+ * - swapping spaceId tears down the old subscription
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { LiveQuerySnapshotEvent, LiveQueryDeltaEvent, SpaceMcpEntry } from '@neokai/shared';
+
+type EventHandler<T = unknown> = (data: T) => void;
+
+interface MockHub {
+	_handlers: Map<string, EventHandler[]>;
+	_connectionHandlers: EventHandler[];
+	onEvent: <T>(method: string, handler: EventHandler<T>) => () => void;
+	onConnection: (handler: EventHandler<string>) => () => void;
+	request: ReturnType<typeof vi.fn>;
+	fire: <T>(method: string, data: T) => void;
+	fireConnection: (state: string) => void;
+}
+
+function createMockHub(): MockHub {
+	const _handlers = new Map<string, EventHandler[]>();
+	const _connectionHandlers: EventHandler[] = [];
+	return {
+		_handlers,
+		_connectionHandlers,
+		onEvent: <T>(method: string, handler: EventHandler<T>) => {
+			if (!_handlers.has(method)) _handlers.set(method, []);
+			_handlers.get(method)!.push(handler as EventHandler);
+			return () => {
+				const list = _handlers.get(method);
+				if (list) {
+					const i = list.indexOf(handler as EventHandler);
+					if (i >= 0) list.splice(i, 1);
+				}
+			};
+		},
+		onConnection: (handler: EventHandler<string>) => {
+			_connectionHandlers.push(handler as EventHandler);
+			return () => {
+				const i = _connectionHandlers.indexOf(handler as EventHandler);
+				if (i >= 0) _connectionHandlers.splice(i, 1);
+			};
+		},
+		request: vi.fn(),
+		fire: <T>(method: string, data: T) => {
+			for (const h of _handlers.get(method) ?? []) h(data);
+		},
+		fireConnection: (state: string) => {
+			for (const h of _connectionHandlers) h(state);
+		},
+	};
+}
+
+vi.mock('../connection-manager.ts', () => ({
+	connectionManager: {
+		getHub: vi.fn(),
+		getHubIfConnected: vi.fn(),
+	},
+}));
+
+import { connectionManager } from '../connection-manager.js';
+import { spaceMcpStore } from '../space-mcp-store.js';
+
+function makeEntry(serverId: string, overrides: Partial<SpaceMcpEntry> = {}): SpaceMcpEntry {
+	return {
+		serverId,
+		name: `Server ${serverId}`,
+		sourceType: 'stdio',
+		source: 'user',
+		globallyEnabled: true,
+		overridden: false,
+		enabled: true,
+		...overrides,
+	};
+}
+
+const SPACE_ID = 'space-1';
+const SUBSCRIPTION_ID = `spaceMcp-${SPACE_ID}`;
+
+describe('SpaceMcpStore', () => {
+	let mockHub: MockHub;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockHub = createMockHub();
+
+		spaceMcpStore.entries.value = new Map();
+		spaceMcpStore.loading.value = false;
+		spaceMcpStore.error.value = null;
+
+		vi.mocked(connectionManager.getHub).mockResolvedValue(mockHub as never);
+		vi.mocked(connectionManager.getHubIfConnected).mockReturnValue(mockHub as never);
+		vi.mocked(mockHub.request).mockResolvedValue({ ok: true });
+	});
+
+	afterEach(() => {
+		spaceMcpStore.unsubscribe();
+	});
+
+	// ---------------------------------------------------------------------------
+	// subscribe()
+	// ---------------------------------------------------------------------------
+
+	describe('subscribe()', () => {
+		it('sends liveQuery.subscribe with mcpEnablement.bySpace', async () => {
+			await spaceMcpStore.subscribe(SPACE_ID);
+			expect(mockHub.request).toHaveBeenCalledWith('liveQuery.subscribe', {
+				queryName: 'mcpEnablement.bySpace',
+				params: [SPACE_ID],
+				subscriptionId: SUBSCRIPTION_ID,
+			});
+		});
+
+		it('populates entries from the snapshot', async () => {
+			await spaceMcpStore.subscribe(SPACE_ID);
+			const rows = [makeEntry('srv-1'), makeEntry('srv-2', { enabled: false, overridden: true })];
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: SUBSCRIPTION_ID,
+				rows,
+				version: 1,
+			});
+
+			expect(spaceMcpStore.entries.value.size).toBe(2);
+			expect(spaceMcpStore.entries.value.get('srv-1')?.enabled).toBe(true);
+			expect(spaceMcpStore.entries.value.get('srv-2')?.overridden).toBe(true);
+			expect(spaceMcpStore.loading.value).toBe(false);
+		});
+
+		it('is idempotent — second subscribe with same spaceId is a no-op', async () => {
+			await spaceMcpStore.subscribe(SPACE_ID);
+			mockHub.request.mockClear();
+			await spaceMcpStore.subscribe(SPACE_ID);
+			expect(mockHub.request).not.toHaveBeenCalled();
+		});
+
+		it('swaps subscriptions when spaceId changes', async () => {
+			await spaceMcpStore.subscribe(SPACE_ID);
+			const newSpaceId = 'space-2';
+			const newSub = `spaceMcp-${newSpaceId}`;
+			await spaceMcpStore.subscribe(newSpaceId);
+
+			expect(mockHub.request).toHaveBeenCalledWith('liveQuery.unsubscribe', {
+				subscriptionId: SUBSCRIPTION_ID,
+			});
+			expect(mockHub.request).toHaveBeenCalledWith('liveQuery.subscribe', {
+				queryName: 'mcpEnablement.bySpace',
+				params: [newSpaceId],
+				subscriptionId: newSub,
+			});
+		});
+
+		it('surfaces subscription errors via error signal', async () => {
+			vi.mocked(mockHub.request).mockRejectedValue(new Error('boom'));
+			await expect(spaceMcpStore.subscribe(SPACE_ID)).rejects.toThrow('boom');
+			expect(spaceMcpStore.error.value).toBe('boom');
+			expect(spaceMcpStore.loading.value).toBe(false);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// delta handling
+	// ---------------------------------------------------------------------------
+
+	describe('delta handling', () => {
+		beforeEach(async () => {
+			await spaceMcpStore.subscribe(SPACE_ID);
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: SUBSCRIPTION_ID,
+				rows: [makeEntry('srv-1'), makeEntry('srv-2')],
+				version: 1,
+			});
+		});
+
+		it('applies added rows', () => {
+			mockHub.fire<LiveQueryDeltaEvent>('liveQuery.delta', {
+				subscriptionId: SUBSCRIPTION_ID,
+				added: [makeEntry('srv-3')],
+				version: 2,
+			});
+			expect(spaceMcpStore.entries.value.has('srv-3')).toBe(true);
+			expect(spaceMcpStore.entries.value.size).toBe(3);
+		});
+
+		it('applies updated rows in-place', () => {
+			mockHub.fire<LiveQueryDeltaEvent>('liveQuery.delta', {
+				subscriptionId: SUBSCRIPTION_ID,
+				updated: [makeEntry('srv-1', { enabled: false, overridden: true })],
+				version: 2,
+			});
+			expect(spaceMcpStore.entries.value.get('srv-1')?.enabled).toBe(false);
+			expect(spaceMcpStore.entries.value.get('srv-1')?.overridden).toBe(true);
+		});
+
+		it('applies removed rows', () => {
+			mockHub.fire<LiveQueryDeltaEvent>('liveQuery.delta', {
+				subscriptionId: SUBSCRIPTION_ID,
+				removed: [makeEntry('srv-2')],
+				version: 2,
+			});
+			expect(spaceMcpStore.entries.value.has('srv-2')).toBe(false);
+			expect(spaceMcpStore.entries.value.size).toBe(1);
+		});
+
+		it('ignores deltas with a different subscriptionId', () => {
+			mockHub.fire<LiveQueryDeltaEvent>('liveQuery.delta', {
+				subscriptionId: 'other',
+				added: [makeEntry('srv-99')],
+				version: 2,
+			});
+			expect(spaceMcpStore.entries.value.has('srv-99')).toBe(false);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Stale-event guard
+	// ---------------------------------------------------------------------------
+
+	describe('stale-event guard', () => {
+		it('discards snapshot events fired after unsubscribe', async () => {
+			await spaceMcpStore.subscribe(SPACE_ID);
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: SUBSCRIPTION_ID,
+				rows: [makeEntry('srv-1')],
+				version: 1,
+			});
+			expect(spaceMcpStore.entries.value.size).toBe(1);
+
+			spaceMcpStore.unsubscribe();
+
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: SUBSCRIPTION_ID,
+				rows: [makeEntry('stale')],
+				version: 2,
+			});
+			expect(spaceMcpStore.entries.value.size).toBe(0);
+		});
+
+		it('discards delta events fired after unsubscribe', async () => {
+			await spaceMcpStore.subscribe(SPACE_ID);
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: SUBSCRIPTION_ID,
+				rows: [makeEntry('srv-1')],
+				version: 1,
+			});
+			spaceMcpStore.unsubscribe();
+
+			mockHub.fire<LiveQueryDeltaEvent>('liveQuery.delta', {
+				subscriptionId: SUBSCRIPTION_ID,
+				added: [makeEntry('stale')],
+				version: 2,
+			});
+			expect(spaceMcpStore.entries.value.size).toBe(0);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Reconnect
+	// ---------------------------------------------------------------------------
+
+	describe('WebSocket reconnect', () => {
+		it('re-subscribes when the socket reconnects', async () => {
+			await spaceMcpStore.subscribe(SPACE_ID);
+			mockHub.request.mockClear();
+
+			mockHub.fireConnection('connected');
+
+			expect(mockHub.request).toHaveBeenCalledWith('liveQuery.subscribe', {
+				queryName: 'mcpEnablement.bySpace',
+				params: [SPACE_ID],
+				subscriptionId: SUBSCRIPTION_ID,
+			});
+		});
+
+		it('sets loading=true during re-subscribe', async () => {
+			await spaceMcpStore.subscribe(SPACE_ID);
+
+			const values: boolean[] = [];
+			const unsub = spaceMcpStore.loading.subscribe((v) => values.push(v));
+			mockHub.fireConnection('connected');
+			expect(values).toContain(true);
+			unsub();
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// unsubscribe()
+	// ---------------------------------------------------------------------------
+
+	describe('unsubscribe()', () => {
+		it('calls liveQuery.unsubscribe and clears entries', async () => {
+			await spaceMcpStore.subscribe(SPACE_ID);
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: SUBSCRIPTION_ID,
+				rows: [makeEntry('srv-1')],
+				version: 1,
+			});
+			mockHub.request.mockClear();
+
+			spaceMcpStore.unsubscribe();
+
+			expect(mockHub.request).toHaveBeenCalledWith('liveQuery.unsubscribe', {
+				subscriptionId: SUBSCRIPTION_ID,
+			});
+			expect(spaceMcpStore.entries.value.size).toBe(0);
+		});
+
+		it('is safe to call before subscribe()', () => {
+			expect(() => spaceMcpStore.unsubscribe()).not.toThrow();
+		});
+
+		it('is idempotent across repeated unsubscribe calls', async () => {
+			await spaceMcpStore.subscribe(SPACE_ID);
+			spaceMcpStore.unsubscribe();
+			mockHub.request.mockClear();
+			spaceMcpStore.unsubscribe();
+			expect(mockHub.request).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/web/src/lib/space-mcp-store.ts
+++ b/packages/web/src/lib/space-mcp-store.ts
@@ -1,0 +1,176 @@
+/**
+ * SpaceMcpStore — per-space MCP enablement state with LiveQuery subscriptions.
+ *
+ * Subscribes to the `mcpEnablement.bySpace` named query which returns one row
+ * per registry entry with the per-space override already applied. This drives
+ * the space settings MCP panel without a separate RPC/polling loop.
+ *
+ * Signal: `entries` — Map<serverId, SpaceMcpEntry>
+ *
+ * Mirrors `RoomMcpStore` but resolves the effective enabled state server-side
+ * (the SQL's COALESCE) so the UI can render straight from the Map without
+ * re-computing overrides + globals.
+ */
+
+import { signal } from '@preact/signals';
+import type { LiveQuerySnapshotEvent, LiveQueryDeltaEvent, SpaceMcpEntry } from '@neokai/shared';
+import { Logger } from '@neokai/shared';
+import { connectionManager } from './connection-manager';
+
+const logger = new Logger('kai:web:space-mcp-store');
+
+class SpaceMcpStore {
+	/** Per-space registry entries keyed by serverId, with resolved `enabled` state. */
+	readonly entries = signal<Map<string, SpaceMcpEntry>>(new Map());
+
+	readonly loading = signal<boolean>(false);
+	readonly error = signal<string | null>(null);
+
+	private spaceId: string | null = null;
+	private cleanups: Array<() => void> = [];
+	private activeSubscriptionIds = new Set<string>();
+	private subscribed = false;
+
+	/**
+	 * Subscribe to the per-space MCP LiveQuery. Idempotent per spaceId;
+	 * switching spaces automatically tears down the old subscription.
+	 */
+	async subscribe(spaceId: string): Promise<void> {
+		if (this.subscribed && this.spaceId === spaceId) return;
+
+		if (this.subscribed && this.spaceId !== spaceId) {
+			this.unsubscribe();
+		}
+
+		this.spaceId = spaceId;
+		this.subscribed = true;
+
+		const subscriptionId = `spaceMcp-${spaceId}`;
+
+		try {
+			const hub = await connectionManager.getHub();
+
+			if (!this.subscribed) return;
+
+			this.loading.value = true;
+			this.activeSubscriptionIds.add(subscriptionId);
+
+			const unsubSnapshot = hub.onEvent<LiveQuerySnapshotEvent>('liveQuery.snapshot', (event) => {
+				if (event.subscriptionId !== subscriptionId) return;
+				if (!this.activeSubscriptionIds.has(subscriptionId)) return;
+				const newMap = new Map<string, SpaceMcpEntry>();
+				for (const row of event.rows as SpaceMcpEntry[]) {
+					newMap.set(row.serverId, row);
+				}
+				this.entries.value = newMap;
+				this.loading.value = false;
+			});
+			this.cleanups.push(unsubSnapshot);
+			this.cleanups.push(() => this.activeSubscriptionIds.delete(subscriptionId));
+
+			const unsubDelta = hub.onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
+				if (event.subscriptionId !== subscriptionId) return;
+				if (!this.activeSubscriptionIds.has(subscriptionId)) return;
+				const current = new Map(this.entries.value);
+
+				if (event.removed?.length) {
+					for (const row of event.removed as SpaceMcpEntry[]) {
+						current.delete(row.serverId);
+					}
+				}
+				if (event.updated?.length) {
+					for (const row of event.updated as SpaceMcpEntry[]) {
+						current.set(row.serverId, row);
+					}
+				}
+				if (event.added?.length) {
+					for (const row of event.added as SpaceMcpEntry[]) {
+						current.set(row.serverId, row);
+					}
+				}
+				this.entries.value = current;
+			});
+			this.cleanups.push(unsubDelta);
+
+			const unsubReconnect = hub.onConnection((state) => {
+				if (state !== 'connected') return;
+				if (!this.activeSubscriptionIds.has(subscriptionId)) return;
+				this.loading.value = true;
+				hub
+					.request('liveQuery.subscribe', {
+						queryName: 'mcpEnablement.bySpace',
+						params: [spaceId],
+						subscriptionId,
+					})
+					.catch((err) => {
+						logger.warn('SpaceMcpStore LiveQuery re-subscribe failed:', err);
+						this.loading.value = false;
+					});
+			});
+			this.cleanups.push(unsubReconnect);
+
+			await hub.request('liveQuery.subscribe', {
+				queryName: 'mcpEnablement.bySpace',
+				params: [spaceId],
+				subscriptionId,
+			});
+
+			if (!this.subscribed) {
+				this.teardownCleanly();
+				return;
+			}
+		} catch (err) {
+			this.subscribed = false;
+			this.spaceId = null;
+			this.teardownCleanly();
+			this.error.value =
+				err instanceof Error ? err.message : 'Failed to subscribe to space MCP enablement';
+			logger.error('Failed to subscribe SpaceMcpStore LiveQuery:', err);
+			throw err;
+		}
+	}
+
+	private teardownCleanly(): void {
+		for (const fn of this.cleanups) {
+			try {
+				fn();
+			} catch {
+				/* ignore */
+			}
+		}
+		this.cleanups = [];
+		this.loading.value = false;
+		this.error.value = null;
+	}
+
+	unsubscribe(): void {
+		if (!this.subscribed) {
+			this.error.value = null;
+			return;
+		}
+		this.subscribed = false;
+
+		const subscriptionId = this.spaceId ? `spaceMcp-${this.spaceId}` : null;
+		if (subscriptionId) {
+			this.activeSubscriptionIds.delete(subscriptionId);
+		}
+
+		this.teardownCleanly();
+
+		if (subscriptionId) {
+			const hub = connectionManager.getHubIfConnected();
+			if (hub) {
+				hub.request('liveQuery.unsubscribe', { subscriptionId }).catch(() => {});
+			}
+		}
+
+		this.entries.value = new Map();
+		this.spaceId = null;
+	}
+}
+
+/**
+ * Singleton store. Supports one active space at a time; re-calling subscribe()
+ * with a different spaceId swaps the subscription automatically.
+ */
+export const spaceMcpStore = new SpaceMcpStore();


### PR DESCRIPTION
## Summary

- Adds Space settings UI that lists every registered MCP server grouped by source (builtin / user / imported) with per-space enable/disable toggles. Toggles persist into the generalised `mcp_enablement` table at `scope_type='space'`, overlayed on registry defaults.
- Adds **Refresh imports** action: rescans `.mcp.json` across known workspaces, inserts/updates/removes `imported`-source registry rows, and surfaces parse-error notes via `toast.info`.
- Per-space overrides only affect **new** sessions spawned in the space; live sessions retain the MCP set they started with (no hot-swap).

## What's new

- RPCs: `space.mcp.list`, `space.mcp.setEnabled`, `space.mcp.clearOverride`, `mcp.imports.refresh`
- LiveQuery: `mcpEnablement.bySpace` with snapshot + delta streaming
- `McpEnablementRepository` (generalised over `scope_type`, `scope_id`) + `getEffectiveEnabledServers`
- `AppMcpLifecycleManager.getEnabledMcpConfigsForSpace(spaceId)` — resolves registry × per-space override
- `TaskAgentManager` now resolves registry servers via the space-aware call
- Import scanner: discovers + imports `.mcp.json` files, idempotent rescans, reports scan notes

## Test plan

- [x] `./scripts/test-daemon.sh` — 11,591 pass / 0 fail across all shards
- [x] `bunx vitest run` for SpaceMcpSettings, space-mcp-store, app-mcp-store — 57 pass
- [x] `bun run check` (lint + typecheck + knip + session-guard) — clean
- [ ] Manual smoke: open Space settings → MCP tab, toggle a server, verify override badge and persistence
- [ ] Manual smoke: click "Refresh imports" with a `.mcp.json` in a worktree, confirm imported entries appear