### PR TITLE
feat(mcp): per-session MCP override toggles (MCP M6)

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -238,6 +238,19 @@ export class AgentSession
 	settingsManager: SettingsManager;
 	readonly logger: Logger;
 
+	/**
+	 * Unified per-scope MCP enablement repo — exposed on the context so the
+	 * QueryOptionsBuilder can resolve the session > room > space > registry
+	 * precedence for skill-wrapped MCP servers (MCP M6).
+	 *
+	 * Exposed as a getter because every AgentSession already owns a Database
+	 * reference; this avoids threading a new constructor arg through every
+	 * spawn call site just to re-wrap something that's already reachable.
+	 */
+	get mcpEnablementRepo(): import('../../storage/repositories/mcp-enablement-repository').McpEnablementRepository {
+		return this.db.mcpEnablement;
+	}
+
 	constructor(
 		readonly session: Session,
 		readonly db: Database,

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -35,7 +35,9 @@ import type { AppMcpServerSourceType } from '@neokai/shared';
 import type { SettingsManager } from '../settings-manager';
 import type { SkillsManager } from '../skills-manager';
 import type { AppMcpServerRepository } from '../../storage/repositories/app-mcp-server-repository';
+import type { McpEnablementRepository } from '../../storage/repositories/mcp-enablement-repository';
 import type { RoomSkillOverride } from '@neokai/shared';
+import { resolveMcpServers, scopeChainForSession } from '../mcp/resolve-mcp-servers';
 import { getProviderContextManager } from '../providers/factory.js';
 import { resolveSDKCliPath, isRunningUnderBun } from './sdk-cli-resolver.js';
 import { homedir } from 'os';
@@ -52,6 +54,14 @@ export interface QueryOptionsBuilderContext {
 	readonly skillsManager?: SkillsManager;
 	/** App MCP server repo for resolving mcp_server skill configs. Optional for backwards compatibility. */
 	readonly appMcpServerRepo?: AppMcpServerRepository;
+	/**
+	 * Unified per-scope MCP enablement repo. When provided, the builder resolves
+	 * skill-wrapped MCP servers against the session > room > space > registry
+	 * precedence chain so explicit per-scope overrides (including MCP M6
+	 * per-session toggles) filter the skill bridge too — not just the spawn
+	 * path's direct `config.mcpServers` injection.
+	 */
+	readonly mcpEnablementRepo?: McpEnablementRepository;
 	/**
 	 * Room-level skill overrides. When provided, a skill with `enabled: false` in this list
 	 * is excluded from injection even if it is globally enabled in the skills registry.
@@ -911,12 +921,20 @@ CRITICAL RULES:
 	 *
 	 * Skill-injected MCP servers: must appear in mcpServers map for
 	 * strictMcpConfig sessions to accept them.
+	 *
+	 * MCP M6: when `mcpEnablementRepo` is available, the skill bridge also respects
+	 * explicit overrides in the `mcp_enablement` table along the session's scope
+	 * chain (session > room > space > registry). Without this, a user disabling a
+	 * skill-wrapped MCP server via the session Tools modal would not actually take
+	 * effect, because the skill bridge bypasses `config.mcpServers` (which the
+	 * spawn path resolves upstream).
 	 */
 	private getMcpServersFromSkills(): Record<string, McpServerConfig> {
 		if (!this.ctx.skillsManager || !this.ctx.appMcpServerRepo) return {};
 
 		const skills = this.ctx.skillsManager.getEnabledSkills();
 		const roomDisabled = this.getRoomDisabledSkillIds();
+		const effectivelyEnabled = this.getEffectivelyEnabledAppServerIds();
 		const servers: Record<string, McpServerConfig> = {};
 
 		for (const skill of skills) {
@@ -926,13 +944,39 @@ CRITICAL RULES:
 			const appServer = this.ctx.appMcpServerRepo.get(skill.config.appMcpServerId);
 			// Skip silently if the referenced app_mcp_servers entry was deleted or no longer exists
 			if (!appServer) continue;
-			// Skip if the AppMcpServer itself is disabled, even if the wrapping skill is enabled
-			if (!appServer.enabled) continue;
+
+			if (effectivelyEnabled !== null) {
+				// Resolver result covers the full session > room > space > registry chain,
+				// so an explicit session override to enable a globally-disabled server wins
+				// here just as the spec calls for. Missing from the set ⇒ skip.
+				if (!effectivelyEnabled.has(appServer.id)) continue;
+			} else if (!appServer.enabled) {
+				// Fallback for contexts that do not plumb mcpEnablementRepo (legacy unit
+				// tests, ad-hoc builder usage): preserve the pre-M6 behaviour of only
+				// honouring the registry default.
+				continue;
+			}
 
 			servers[skill.name] = this.appMcpServerToSdkConfig(appServer);
 		}
 
 		return servers;
+	}
+
+	/**
+	 * Compute the set of AppMcpServer IDs that are effectively enabled for this
+	 * session given the session > room > space > registry precedence. Returns
+	 * `null` when the enablement repo isn't wired (legacy contexts), so callers
+	 * can fall back to the registry default.
+	 */
+	private getEffectivelyEnabledAppServerIds(): Set<string> | null {
+		if (!this.ctx.appMcpServerRepo || !this.ctx.mcpEnablementRepo) return null;
+
+		const registry = this.ctx.appMcpServerRepo.list();
+		const chain = scopeChainForSession(this.ctx.session);
+		const overrides = this.ctx.mcpEnablementRepo.listForScopes(chain);
+		const effective = resolveMcpServers(this.ctx.session, registry, overrides);
+		return new Set(effective.map((s) => s.id));
 	}
 
 	/**

--- a/packages/daemon/src/lib/rpc-handlers/app-mcp-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/app-mcp-handlers.ts
@@ -29,6 +29,11 @@ import type { MessageHub } from '@neokai/shared';
 import type {
 	AppMcpServer,
 	CreateAppMcpServerRequest,
+	McpEffectiveEnablementSource,
+	McpEnablementOverride,
+	SessionMcpListRequest,
+	SessionMcpListResponse,
+	SessionMcpServerEntry,
 	UpdateAppMcpServerRequest,
 } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
@@ -50,6 +55,7 @@ import type {
 	McpRoomResetToGlobalRequest,
 	McpRoomResetToGlobalResponse,
 } from '@neokai/shared';
+import { scopeChainForSession } from '../mcp/resolve-mcp-servers';
 import { Logger } from '../logger';
 
 const log = new Logger('app-mcp-handlers');
@@ -311,5 +317,89 @@ export function setupAppMcpHandlers(
 				.catch((err) => log.warn('Failed to emit mcp.registry.changed:', err));
 		}
 		return { deleted } satisfies McpEnablementClearScopeResponse;
+	});
+
+	// -------------------------------------------------------------------------
+	// Session-scope convenience RPC (MCP M6)
+	//
+	// The Tools modal needs to render every registry entry with its effective
+	// enablement for the currently-open session, annotated with the scope that
+	// owns that decision. Doing the resolution here means the UI never has to
+	// re-implement session > room > space > registry precedence.
+	// -------------------------------------------------------------------------
+
+	messageHub.onRequest('session.mcp.list', (data) => {
+		const { sessionId } = data as SessionMcpListRequest;
+		if (!sessionId) throw new Error('sessionId is required');
+
+		const session = db.getSession(sessionId);
+		if (!session) {
+			throw new Error(`Session not found: ${sessionId}`);
+		}
+
+		const registry = db.appMcpServers.list();
+		const chain = scopeChainForSession(session);
+		// Only overrides along this session's chain can influence the decision,
+		// so filter in SQL instead of walking every row.
+		const overrides = db.mcpEnablement.listForScopes(chain);
+
+		// Bucket overrides by scope for O(1) precedence lookup.
+		const sessionOverrides = new Map<string, McpEnablementOverride>();
+		const roomOverrides = new Map<string, McpEnablementOverride>();
+		const spaceOverrides = new Map<string, McpEnablementOverride>();
+		for (const ov of overrides) {
+			if (ov.scopeType === 'session' && ov.scopeId === sessionId) {
+				sessionOverrides.set(ov.serverId, ov);
+			} else if (
+				ov.scopeType === 'room' &&
+				session.context?.roomId &&
+				ov.scopeId === session.context.roomId
+			) {
+				roomOverrides.set(ov.serverId, ov);
+			} else if (
+				ov.scopeType === 'space' &&
+				session.context?.spaceId &&
+				ov.scopeId === session.context.spaceId
+			) {
+				spaceOverrides.set(ov.serverId, ov);
+			}
+		}
+
+		const entries: SessionMcpServerEntry[] = registry.map((server) => {
+			const sessionOv = sessionOverrides.get(server.id);
+			if (sessionOv) {
+				return {
+					server,
+					enabled: sessionOv.enabled,
+					source: 'session' as McpEffectiveEnablementSource,
+					override: sessionOv,
+				};
+			}
+			const roomOv = roomOverrides.get(server.id);
+			if (roomOv) {
+				return {
+					server,
+					enabled: roomOv.enabled,
+					source: 'room' as McpEffectiveEnablementSource,
+					override: roomOv,
+				};
+			}
+			const spaceOv = spaceOverrides.get(server.id);
+			if (spaceOv) {
+				return {
+					server,
+					enabled: spaceOv.enabled,
+					source: 'space' as McpEffectiveEnablementSource,
+					override: spaceOv,
+				};
+			}
+			return {
+				server,
+				enabled: server.enabled,
+				source: 'registry' as McpEffectiveEnablementSource,
+			};
+		});
+
+		return { entries } satisfies SessionMcpListResponse;
 	});
 }

--- a/packages/daemon/src/storage/repositories/session-repository.ts
+++ b/packages/daemon/src/storage/repositories/session-repository.ts
@@ -221,11 +221,30 @@ export class SessionRepository {
 	}
 
 	/**
-	 * Delete a session by ID
+	 * Delete a session by ID.
+	 *
+	 * Also drops any `mcp_enablement` rows targeting this session (scope_type =
+	 * 'session', scope_id = id) in the same transaction. Per-session MCP
+	 * overrides from MCP M6 would otherwise become orphan rows on hard-delete:
+	 * harmless (no code reads overrides for a non-existent session), but they
+	 * accumulate forever on workloads with many short-lived sessions. Doing
+	 * this here — rather than in session-lifecycle.ts — keeps the invariant
+	 * "no session row ⇒ no session-scope override rows" true regardless of
+	 * which delete path (UI, tests, explicit RPC, …) is used.
+	 *
+	 * Note: `mcp_enablement` has no FK on `sessions.id` (the column is generic
+	 * `scope_id TEXT`), so cascade must be done explicitly.
 	 */
 	deleteSession(id: string): void {
-		const stmt = this.db.prepare(`DELETE FROM sessions WHERE id = ?`);
-		stmt.run(id);
+		const deleteOverrides = this.db.prepare(
+			`DELETE FROM mcp_enablement WHERE scope_type = 'session' AND scope_id = ?`
+		);
+		const deleteSession = this.db.prepare(`DELETE FROM sessions WHERE id = ?`);
+		const tx = this.db.transaction((sessionId: string) => {
+			deleteOverrides.run(sessionId);
+			deleteSession.run(sessionId);
+		});
+		tx(id);
 	}
 
 	/**

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -1324,6 +1324,180 @@ describe('QueryOptionsBuilder', () => {
 				url: 'http://localhost:3002/mcp',
 			});
 		});
+
+		// ------------------------------------------------------------------
+		// MCP M6: per-session `mcp_enablement` overrides must filter the
+		// skill bridge too, not just the spawn path's direct `config.mcpServers`
+		// injection. Without this wiring a user disabling a skill-wrapped MCP
+		// server via the Tools modal would see the toggle persist but the
+		// server would still be injected (because the skill bridge bypasses
+		// config.mcpServers).
+		// ------------------------------------------------------------------
+		describe('mcp_enablement override filtering (MCP M6)', () => {
+			const targetAppServer = {
+				id: 'mcp-server-uuid',
+				name: 'brave-search-server',
+				description: 'Brave Search MCP',
+				sourceType: 'stdio' as const,
+				command: 'npx',
+				args: ['-y', 'brave-mcp'],
+				env: { BRAVE_API_KEY: 'test-key' },
+				enabled: true,
+			};
+			const mcpSkill = {
+				id: 'skill-mcp-1',
+				name: 'brave-search',
+				displayName: 'Brave Search',
+				description: 'Web search via Brave',
+				sourceType: 'mcp_server' as const,
+				config: { type: 'mcp_server' as const, appMcpServerId: 'mcp-server-uuid' },
+				enabled: true,
+				builtIn: false,
+				validationStatus: 'valid' as const,
+				createdAt: Date.now(),
+			};
+
+			function buildContext(
+				overrides: {
+					scopeType: 'session' | 'room' | 'space';
+					scopeId: string;
+					serverId: string;
+					enabled: boolean;
+				}[]
+			): QueryOptionsBuilderContext {
+				const mockAppMcpServerRepo = {
+					get: mock(() => targetAppServer),
+					list: mock(() => [targetAppServer]),
+				};
+				const mockEnablementRepo = {
+					listForScopes: mock(() =>
+						overrides.map((ov) => ({
+							scopeType: ov.scopeType,
+							scopeId: ov.scopeId,
+							serverId: ov.serverId,
+							enabled: ov.enabled,
+						}))
+					),
+				};
+				const mockSkillsManager = {
+					getEnabledSkills: mock(() => [mcpSkill]),
+				};
+				return {
+					session: mockSession,
+					settingsManager: mockSettingsManager,
+					skillsManager:
+						mockSkillsManager as unknown as import('../../../../src/lib/skills-manager').SkillsManager,
+					appMcpServerRepo:
+						mockAppMcpServerRepo as unknown as import('../../../../src/storage/repositories/app-mcp-server-repository').AppMcpServerRepository,
+					mcpEnablementRepo:
+						mockEnablementRepo as unknown as import('../../../../src/storage/repositories/mcp-enablement-repository').McpEnablementRepository,
+				};
+			}
+
+			it('excludes a skill-wrapped MCP server disabled by a session override', async () => {
+				const ctx = buildContext([
+					{
+						scopeType: 'session',
+						scopeId: mockSession.id,
+						serverId: 'mcp-server-uuid',
+						enabled: false,
+					},
+				]);
+				const builder = new QueryOptionsBuilder(ctx);
+				const options = await builder.build();
+
+				// Skill-wrapped server must not be injected despite the skill itself
+				// and the registry row both being enabled.
+				expect(options.mcpServers?.['brave-search']).toBeUndefined();
+			});
+
+			it('includes the server when the session override explicitly enables a globally-disabled registry row', async () => {
+				// Start from a disabled registry row so we can verify the session
+				// override can override-in (not just override-out).
+				const disabledAppServer = { ...targetAppServer, enabled: false };
+				const mockAppMcpServerRepo = {
+					get: mock(() => disabledAppServer),
+					list: mock(() => [disabledAppServer]),
+				};
+				const mockEnablementRepo = {
+					listForScopes: mock(() => [
+						{
+							scopeType: 'session' as const,
+							scopeId: mockSession.id,
+							serverId: 'mcp-server-uuid',
+							enabled: true,
+						},
+					]),
+				};
+				const mockSkillsManager = { getEnabledSkills: mock(() => [mcpSkill]) };
+				const ctx: QueryOptionsBuilderContext = {
+					session: mockSession,
+					settingsManager: mockSettingsManager,
+					skillsManager:
+						mockSkillsManager as unknown as import('../../../../src/lib/skills-manager').SkillsManager,
+					appMcpServerRepo:
+						mockAppMcpServerRepo as unknown as import('../../../../src/storage/repositories/app-mcp-server-repository').AppMcpServerRepository,
+					mcpEnablementRepo:
+						mockEnablementRepo as unknown as import('../../../../src/storage/repositories/mcp-enablement-repository').McpEnablementRepository,
+				};
+				const builder = new QueryOptionsBuilder(ctx);
+				const options = await builder.build();
+
+				expect(options.mcpServers?.['brave-search']).toEqual({
+					command: 'npx',
+					args: ['-y', 'brave-mcp'],
+					env: { BRAVE_API_KEY: 'test-key' },
+				});
+			});
+
+			it('honours the session > room > space > registry precedence chain', async () => {
+				// room disables; session does NOT override — server must be hidden.
+				mockSession.context = { roomId: 'room-1', spaceId: 'space-1' };
+				const ctxRoomDisables = buildContext([
+					{ scopeType: 'room', scopeId: 'room-1', serverId: 'mcp-server-uuid', enabled: false },
+				]);
+				const builder1 = new QueryOptionsBuilder(ctxRoomDisables);
+				const options1 = await builder1.build();
+				expect(options1.mcpServers?.['brave-search']).toBeUndefined();
+
+				// Same room-level disable, but now a session-scope override re-enables —
+				// more specific scope wins.
+				const ctxSessionReenables = buildContext([
+					{ scopeType: 'room', scopeId: 'room-1', serverId: 'mcp-server-uuid', enabled: false },
+					{
+						scopeType: 'session',
+						scopeId: mockSession.id,
+						serverId: 'mcp-server-uuid',
+						enabled: true,
+					},
+				]);
+				const builder2 = new QueryOptionsBuilder(ctxSessionReenables);
+				const options2 = await builder2.build();
+				expect(options2.mcpServers?.['brave-search']).toBeDefined();
+			});
+
+			it('falls back to the registry default when no enablement repo is provided', async () => {
+				// No mcpEnablementRepo — pre-M6 behaviour preserved: registry row's
+				// enabled flag is the only signal.
+				const disabledAppServer = { ...targetAppServer, enabled: false };
+				const mockAppMcpServerRepo = {
+					get: mock(() => disabledAppServer),
+					list: mock(() => [disabledAppServer]),
+				};
+				const mockSkillsManager = { getEnabledSkills: mock(() => [mcpSkill]) };
+				const ctx: QueryOptionsBuilderContext = {
+					session: mockSession,
+					settingsManager: mockSettingsManager,
+					skillsManager:
+						mockSkillsManager as unknown as import('../../../../src/lib/skills-manager').SkillsManager,
+					appMcpServerRepo:
+						mockAppMcpServerRepo as unknown as import('../../../../src/storage/repositories/app-mcp-server-repository').AppMcpServerRepository,
+				};
+				const builder = new QueryOptionsBuilder(ctx);
+				const options = await builder.build();
+				expect(options.mcpServers?.['brave-search']).toBeUndefined();
+			});
+		});
 	});
 
 	describe('room skill overrides', () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc/app-mcp-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc/app-mcp-handlers.test.ts
@@ -28,14 +28,16 @@ import { createTables } from '../../../../src/storage/schema';
 import { createReactiveDatabase } from '../../../../src/storage/reactive-database';
 import { AppMcpServerRepository } from '../../../../src/storage/repositories/app-mcp-server-repository';
 import { RoomMcpEnablementRepository } from '../../../../src/storage/repositories/room-mcp-enablement-repository';
-import type { MessageHub } from '@neokai/shared';
+import { McpEnablementRepository } from '../../../../src/storage/repositories/mcp-enablement-repository';
+import { SessionRepository } from '../../../../src/storage/repositories/session-repository';
+import type { MessageHub, Session } from '@neokai/shared';
 import {
 	registerAppMcpHandlers,
 	setupAppMcpHandlers,
 	type AppMcpHandlerContext,
 } from '../../../../src/lib/rpc-handlers/app-mcp-handlers';
 import type { DaemonHub } from '../../../../src/lib/daemon-hub';
-import type { AppMcpServer } from '@neokai/shared';
+import type { AppMcpServer, SessionMcpListResponse } from '@neokai/shared';
 import type { ReactiveDatabase } from '../../../../src/storage/reactive-database';
 import type { Database } from '../../../../src/storage/database';
 
@@ -440,6 +442,8 @@ describe('setupAppMcpHandlers', () => {
 	let reactiveDb: ReactiveDatabase;
 	let appMcpRepo: AppMcpServerRepository;
 	let roomMcpRepo: RoomMcpEnablementRepository;
+	let mcpEnablementRepo: McpEnablementRepository;
+	let sessionRepo: SessionRepository;
 	let handlers: Map<string, RequestHandler>;
 	let emitSpy: ReturnType<typeof mock>;
 
@@ -461,11 +465,17 @@ describe('setupAppMcpHandlers', () => {
 
 		appMcpRepo = new AppMcpServerRepository(bunDb, reactiveDb);
 		roomMcpRepo = new RoomMcpEnablementRepository(bunDb, reactiveDb);
+		mcpEnablementRepo = new McpEnablementRepository(bunDb, reactiveDb);
+		sessionRepo = new SessionRepository(bunDb);
 
-		// Build a minimal Database stub that exposes what the handlers need
+		// Build a minimal Database stub that exposes what the handlers need.
+		// `session.mcp.list` needs `mcpEnablement` and `getSession`; the unified
+		// `mcp.enablement.*` handlers only need `mcpEnablement`.
 		const db = {
 			appMcpServers: appMcpRepo,
 			roomMcpEnablement: roomMcpRepo,
+			mcpEnablement: mcpEnablementRepo,
+			getSession: (id: string) => sessionRepo.getSession(id),
 		} as unknown as Database;
 
 		const { hub, handlers: h } = createMockMessageHub();
@@ -580,6 +590,262 @@ describe('setupAppMcpHandlers', () => {
 			const handler = handlers.get('mcp.room.resetToGlobal')!;
 			const result = handler({ roomId: 'empty-room' }) as { ok: boolean };
 			expect(result.ok).toBe(true);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// session.mcp.list  (MCP M6)
+	//
+	// Resolves every registry entry to {server, enabled, source, override?} for a
+	// single session, applying session > room > space > registry precedence.
+	// ---------------------------------------------------------------------------
+
+	describe('session.mcp.list', () => {
+		const SPACE_ID = 'space-m6-123';
+		const SESSION_ID = 'session-m6-abc';
+
+		function createSession(opts: { roomId?: string; spaceId?: string } = {}): Session {
+			const session: Session = {
+				id: SESSION_ID,
+				title: 'test-session',
+				workspacePath: '/tmp/ws',
+				createdAt: new Date().toISOString(),
+				lastActiveAt: new Date().toISOString(),
+				status: 'active',
+				config: {} as Session['config'],
+				metadata: {} as Session['metadata'],
+				type: 'worker',
+				context: opts.roomId || opts.spaceId ? opts : undefined,
+			};
+			sessionRepo.createSession(session);
+			return session;
+		}
+
+		test('throws when sessionId is missing', () => {
+			const handler = handlers.get('session.mcp.list')!;
+			expect(() => handler({})).toThrow('sessionId is required');
+		});
+
+		test('throws when session does not exist', () => {
+			const handler = handlers.get('session.mcp.list')!;
+			expect(() => handler({ sessionId: 'does-not-exist' })).toThrow('Session not found');
+		});
+
+		test('returns registry source when no overrides exist', () => {
+			createSession();
+			const srv = appMcpRepo.create({ name: 'reg-only', sourceType: 'stdio', command: 'npx' });
+
+			const handler = handlers.get('session.mcp.list')!;
+			const result = handler({ sessionId: SESSION_ID }) as SessionMcpListResponse;
+
+			const entry = result.entries.find((e) => e.server.id === srv.id);
+			expect(entry).toBeDefined();
+			expect(entry!.enabled).toBe(true); // default registry flag
+			expect(entry!.source).toBe('registry');
+			expect(entry!.override).toBeUndefined();
+		});
+
+		test('registry source still reports when globally disabled', () => {
+			createSession();
+			const srv = appMcpRepo.create({ name: 'reg-disabled', sourceType: 'stdio', command: 'npx' });
+			appMcpRepo.update(srv.id, { enabled: false });
+
+			const handler = handlers.get('session.mcp.list')!;
+			const result = handler({ sessionId: SESSION_ID }) as SessionMcpListResponse;
+
+			const entry = result.entries.find((e) => e.server.id === srv.id)!;
+			expect(entry.enabled).toBe(false);
+			expect(entry.source).toBe('registry');
+		});
+
+		test('session-scope override wins over room/space', () => {
+			// Note: mcp_enablement.scope_id is a generic TEXT column with no FK,
+			// so we don't need a real `spaces` row — the override just needs to
+			// match the session's context.spaceId.
+			createSession({ roomId: ROOM_ID, spaceId: SPACE_ID });
+			const srv = appMcpRepo.create({ name: 'srv-cascade', sourceType: 'stdio', command: 'npx' });
+
+			// space disables, room enables, session disables — session wins.
+			mcpEnablementRepo.setOverride('space', SPACE_ID, srv.id, false);
+			mcpEnablementRepo.setOverride('room', ROOM_ID, srv.id, true);
+			mcpEnablementRepo.setOverride('session', SESSION_ID, srv.id, false);
+
+			const handler = handlers.get('session.mcp.list')!;
+			const result = handler({ sessionId: SESSION_ID }) as SessionMcpListResponse;
+
+			const entry = result.entries.find((e) => e.server.id === srv.id)!;
+			expect(entry.enabled).toBe(false);
+			expect(entry.source).toBe('session');
+			expect(entry.override).toEqual({
+				scopeType: 'session',
+				scopeId: SESSION_ID,
+				serverId: srv.id,
+				enabled: false,
+			});
+		});
+
+		test('room-scope override wins over space when no session override', () => {
+			createSession({ roomId: ROOM_ID, spaceId: SPACE_ID });
+			const srv = appMcpRepo.create({ name: 'srv-room-wins', sourceType: 'stdio', command: 'npx' });
+
+			mcpEnablementRepo.setOverride('space', SPACE_ID, srv.id, true);
+			mcpEnablementRepo.setOverride('room', ROOM_ID, srv.id, false);
+
+			const handler = handlers.get('session.mcp.list')!;
+			const result = handler({ sessionId: SESSION_ID }) as SessionMcpListResponse;
+
+			const entry = result.entries.find((e) => e.server.id === srv.id)!;
+			expect(entry.enabled).toBe(false);
+			expect(entry.source).toBe('room');
+			expect(entry.override?.scopeType).toBe('room');
+		});
+
+		test('space-scope override used when room/session absent', () => {
+			createSession({ spaceId: SPACE_ID });
+			const srv = appMcpRepo.create({
+				name: 'srv-space-only',
+				sourceType: 'stdio',
+				command: 'npx',
+			});
+			mcpEnablementRepo.setOverride('space', SPACE_ID, srv.id, false);
+
+			const handler = handlers.get('session.mcp.list')!;
+			const result = handler({ sessionId: SESSION_ID }) as SessionMcpListResponse;
+
+			const entry = result.entries.find((e) => e.server.id === srv.id)!;
+			expect(entry.enabled).toBe(false);
+			expect(entry.source).toBe('space');
+			expect(entry.override?.scopeType).toBe('space');
+		});
+
+		test('ignores overrides targeting unrelated scopes', () => {
+			createSession(); // no room, no space
+			const srv = appMcpRepo.create({ name: 'srv-isolated', sourceType: 'stdio', command: 'npx' });
+
+			// Override targets a different session — must not influence this session.
+			mcpEnablementRepo.setOverride('session', 'other-session', srv.id, false);
+
+			const handler = handlers.get('session.mcp.list')!;
+			const result = handler({ sessionId: SESSION_ID }) as SessionMcpListResponse;
+
+			const entry = result.entries.find((e) => e.server.id === srv.id)!;
+			expect(entry.enabled).toBe(true);
+			expect(entry.source).toBe('registry');
+		});
+
+		test('returns an entry per registry row, preserving registry order', () => {
+			createSession();
+			const a = appMcpRepo.create({ name: 'srv-a', sourceType: 'stdio', command: 'npx' });
+			const b = appMcpRepo.create({ name: 'srv-b', sourceType: 'stdio', command: 'npx' });
+			const c = appMcpRepo.create({ name: 'srv-c', sourceType: 'stdio', command: 'npx' });
+
+			const handler = handlers.get('session.mcp.list')!;
+			const result = handler({ sessionId: SESSION_ID }) as SessionMcpListResponse;
+
+			const ids = result.entries.map((e) => e.server.id);
+			const registryOrder = appMcpRepo.list().map((s) => s.id);
+			expect(ids).toEqual(registryOrder);
+			// All three registry servers must appear.
+			expect(ids).toContain(a.id);
+			expect(ids).toContain(b.id);
+			expect(ids).toContain(c.id);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// mcp.enablement.*  (scope-aware override CRUD)
+	//
+	// These handlers share the same `mcp_enablement` table as session.mcp.list,
+	// but expose raw override CRUD rather than resolved enablement.
+	// ---------------------------------------------------------------------------
+
+	describe('mcp.enablement.setOverride', () => {
+		test('upserts a session-scope override and emits changed', async () => {
+			const srv = appMcpRepo.create({
+				name: 'enablement-set',
+				sourceType: 'stdio',
+				command: 'npx',
+			});
+			const handler = handlers.get('mcp.enablement.setOverride')!;
+			emitSpy.mockClear();
+
+			const result = handler({
+				scopeType: 'session',
+				scopeId: 'sess-1',
+				serverId: srv.id,
+				enabled: false,
+			}) as { override: { enabled: boolean } };
+
+			expect(result.override.enabled).toBe(false);
+			expect(mcpEnablementRepo.getOverride('session', 'sess-1', srv.id)?.enabled).toBe(false);
+
+			await new Promise<void>((resolve) => setTimeout(resolve, 10));
+			expect(emitSpy).toHaveBeenCalledWith('mcp.registry.changed', { sessionId: 'global' });
+		});
+
+		test('rejects unknown server IDs', () => {
+			const handler = handlers.get('mcp.enablement.setOverride')!;
+			expect(() =>
+				handler({
+					scopeType: 'session',
+					scopeId: 'sess-1',
+					serverId: 'no-such-server',
+					enabled: true,
+				})
+			).toThrow('MCP server not found');
+		});
+
+		test('rejects non-boolean enabled', () => {
+			const srv = appMcpRepo.create({
+				name: 'enablement-bad',
+				sourceType: 'stdio',
+				command: 'npx',
+			});
+			const handler = handlers.get('mcp.enablement.setOverride')!;
+			expect(() =>
+				handler({
+					scopeType: 'session',
+					scopeId: 'sess-1',
+					serverId: srv.id,
+					enabled: 'yes',
+				})
+			).toThrow('enabled must be a boolean');
+		});
+	});
+
+	describe('mcp.enablement.clearOverride', () => {
+		test('deletes an existing override and returns deleted:true', () => {
+			const srv = appMcpRepo.create({
+				name: 'enablement-clear',
+				sourceType: 'stdio',
+				command: 'npx',
+			});
+			mcpEnablementRepo.setOverride('session', 'sess-1', srv.id, true);
+
+			const handler = handlers.get('mcp.enablement.clearOverride')!;
+			const result = handler({
+				scopeType: 'session',
+				scopeId: 'sess-1',
+				serverId: srv.id,
+			}) as { deleted: boolean };
+
+			expect(result.deleted).toBe(true);
+			expect(mcpEnablementRepo.getOverride('session', 'sess-1', srv.id)).toBeNull();
+		});
+
+		test('returns deleted:false when no override exists', () => {
+			const srv = appMcpRepo.create({
+				name: 'enablement-clear-miss',
+				sourceType: 'stdio',
+				command: 'npx',
+			});
+			const handler = handlers.get('mcp.enablement.clearOverride')!;
+			const result = handler({
+				scopeType: 'session',
+				scopeId: 'ghost',
+				serverId: srv.id,
+			}) as { deleted: boolean };
+			expect(result.deleted).toBe(false);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/session-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/session-repository.test.ts
@@ -69,6 +69,16 @@ describe('SessionRepository', () => {
 			);
 
 			CREATE INDEX idx_sessions_last_active ON sessions(last_active_at);
+
+			-- deleteSession() drops session-scope overrides in the same transaction
+			-- so the table must exist even in tests that don't otherwise touch it.
+			CREATE TABLE mcp_enablement (
+				server_id TEXT NOT NULL,
+				scope_type TEXT NOT NULL CHECK(scope_type IN ('space', 'room', 'session')),
+				scope_id TEXT NOT NULL,
+				enabled INTEGER NOT NULL,
+				PRIMARY KEY (server_id, scope_type, scope_id)
+			);
 		`);
 		repository = new SessionRepository(db as any);
 	});
@@ -532,6 +542,45 @@ describe('SessionRepository', () => {
 
 		it('should not throw when deleting non-existent session', () => {
 			expect(() => repository.deleteSession('non-existent')).not.toThrow();
+		});
+
+		it('should cascade-delete session-scope mcp_enablement overrides (MCP M6)', () => {
+			repository.createSession(createDefaultSession({ id: 'session-1' }));
+			repository.createSession(createDefaultSession({ id: 'session-2' }));
+
+			// Seed overrides at every scope targeting the deleted session's id across
+			// tables. Only rows with (scope_type='session', scope_id='session-1')
+			// should be removed — room/space rows sharing the same scope_id string
+			// must survive (they belong to a different scope namespace).
+			const insert = db.prepare(
+				`INSERT INTO mcp_enablement (server_id, scope_type, scope_id, enabled) VALUES (?, ?, ?, ?)`
+			);
+			insert.run('srv-a', 'session', 'session-1', 1);
+			insert.run('srv-b', 'session', 'session-1', 0);
+			insert.run('srv-a', 'session', 'session-2', 1);
+			insert.run('srv-a', 'room', 'session-1', 1); // same id, different scope
+			insert.run('srv-a', 'space', 'session-1', 1); // same id, different scope
+
+			repository.deleteSession('session-1');
+
+			const rows = db.prepare('SELECT * FROM mcp_enablement ORDER BY scope_type, server_id').all();
+			expect(rows).toEqual([
+				{ server_id: 'srv-a', scope_type: 'room', scope_id: 'session-1', enabled: 1 },
+				{ server_id: 'srv-a', scope_type: 'session', scope_id: 'session-2', enabled: 1 },
+				{ server_id: 'srv-a', scope_type: 'space', scope_id: 'session-1', enabled: 1 },
+			]);
+		});
+
+		it('should leave mcp_enablement untouched when deleting a session with no overrides', () => {
+			repository.createSession(createDefaultSession());
+			db.prepare(
+				`INSERT INTO mcp_enablement (server_id, scope_type, scope_id, enabled) VALUES (?, ?, ?, ?)`
+			).run('srv-x', 'session', 'other-session', 1);
+
+			repository.deleteSession('session-1');
+
+			const rows = db.prepare('SELECT COUNT(*) as c FROM mcp_enablement').get() as { c: number };
+			expect(rows.c).toBe(1);
 		});
 	});
 

--- a/packages/shared/src/types/mcp-enablement.ts
+++ b/packages/shared/src/types/mcp-enablement.ts
@@ -86,3 +86,55 @@ export interface McpEnablementClearScopeRequest {
 export interface McpEnablementClearScopeResponse {
 	deleted: number;
 }
+
+// ---------------------------------------------------------------------------
+// Session-scope convenience RPCs (MCP M6)
+//
+// The generic `mcp.enablement.*` handlers already support session scope, but
+// the session Tools modal needs a single call that returns, for every registry
+// entry, the effective enablement plus which scope owns that decision. Doing
+// this resolution on the daemon side means the UI never has to re-implement
+// session > room > space > registry precedence.
+// ---------------------------------------------------------------------------
+
+/**
+ * Source of the effective enablement decision for a single (session, server)
+ * pair.
+ *
+ *   - `session` — an explicit `mcp_enablement` row at scope=`session` decides.
+ *   - `room`    — an explicit `mcp_enablement` row at scope=`room` decides
+ *                 (only reached when no session-scope override exists).
+ *   - `space`   — same as `room`, but at scope=`space`.
+ *   - `registry` — no override along the chain; the registry row's `enabled`
+ *                  flag is used.
+ */
+export type McpEffectiveEnablementSource = 'session' | 'room' | 'space' | 'registry';
+
+/**
+ * One entry in the `session.mcp.list` response: the registry row, the
+ * effective enablement for this session, and where that decision came from.
+ */
+export interface SessionMcpServerEntry {
+	/** The underlying registry entry — everything the UI needs to render. */
+	server: import('./app-mcp-server.ts').AppMcpServer;
+	/** Whether this server is effectively enabled for the given session. */
+	enabled: boolean;
+	/** Which level of the scope chain decided `enabled`. */
+	source: McpEffectiveEnablementSource;
+	/**
+	 * When `source` is `session`/`room`/`space`, this holds the explicit override
+	 * row that made the decision (so the UI can tell the user "disabled at the
+	 * room level" vs. "this session explicitly enabled it"). Missing when the
+	 * decision is `registry`.
+	 */
+	override?: McpEnablementOverride;
+}
+
+/** `session.mcp.list` — per-server effective state for a single session. */
+export interface SessionMcpListRequest {
+	sessionId: string;
+}
+
+export interface SessionMcpListResponse {
+	entries: SessionMcpServerEntry[];
+}

--- a/packages/web/src/components/ToolsModal.tsx
+++ b/packages/web/src/components/ToolsModal.tsx
@@ -4,14 +4,13 @@
  * Unified view of MCP servers and tools for a session:
  * - Agent Runtime Tools: in-process MCPs attached at session-spawn time
  *   (space-agent-tools, db-query, task-agent, node-agent, etc.) — read-only.
+ * - Session MCP Servers: per-session overrides of registry servers. Toggles
+ *   write an `mcp_enablement` row at scope='session' so the override is
+ *   applied on top of any room/space/registry defaults. Takes effect on the
+ *   next session respawn (M6 of `unify-mcp-config-model`).
  * - App Skills & MCP Servers: from the unified skills registry, toggled
  *   globally (changes affect all sessions).
  * - Advanced: Claude Code preset toggle.
- *
- * Per-session "disable this MCP" overrides moved out of session config and
- * into the `mcp_enablement` table (M5 of `unify-mcp-config-model`). The Tools
- * Modal therefore no longer renders a session-scope MCP enable/disable list;
- * any per-session override UI will land in M6 against the new registry.
  */
 
 import { useSignal, useComputed } from '@preact/signals';
@@ -20,7 +19,16 @@ import { connectionManager } from '../lib/connection-manager.ts';
 import { toast } from '../lib/toast.ts';
 import { Modal } from './ui/Modal.tsx';
 import { borderColors } from '../lib/design-tokens.ts';
-import type { Session, ToolsConfig, GlobalToolsConfig, AppSkill } from '@neokai/shared';
+import type {
+	Session,
+	ToolsConfig,
+	GlobalToolsConfig,
+	AppSkill,
+	SessionMcpListResponse,
+	SessionMcpServerEntry,
+	McpEnablementSetOverrideResponse,
+	McpEnablementClearOverrideResponse,
+} from '@neokai/shared';
 import { listRuntimeMcpServers } from '../lib/api-helpers.ts';
 import { skillsStore } from '../lib/skills-store.ts';
 
@@ -154,6 +162,18 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 	// space-agent-tools, db-query, task-agent, node-agent, etc.
 	const runtimeMcpServers = useSignal<string[]>([]);
 
+	// Per-session MCP registry state (MCP M6).
+	//
+	// The daemon resolves session > room > space > registry precedence and
+	// returns, for each registry entry, its effective enabled flag and which
+	// scope owns that decision. Toggles write an `mcp_enablement` row at
+	// scope='session' so it always wins over less-specific scopes; clearing
+	// reverts to inheritance.
+	const sessionMcpGroupOpen = useSignal(true);
+	const sessionMcpEntries = useSignal<SessionMcpServerEntry[]>([]);
+	const sessionMcpToggling = useSignal<Set<string>>(new Set());
+	const sessionMcpSearch = useSignal('');
+
 	// Search filter for App Skills section
 	const appSkillSearch = useSignal('');
 
@@ -169,6 +189,7 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 			loadConfig();
 			loadGlobalConfig();
 			loadRuntimeMcpServers();
+			void loadSessionMcpEntries();
 			void skillsStore.subscribe().catch(() => {
 				toast.error('Failed to load App MCP Servers');
 			});
@@ -205,6 +226,89 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 		}
 	};
 
+	const loadSessionMcpEntries = async () => {
+		if (!session) {
+			sessionMcpEntries.value = [];
+			return;
+		}
+		try {
+			const hub = await connectionManager.getHub();
+			const response = await hub.request<SessionMcpListResponse>('session.mcp.list', {
+				sessionId: session.id,
+			});
+			sessionMcpEntries.value = response.entries ?? [];
+		} catch {
+			// Typically means the daemon rejected the session id; show nothing
+			// rather than an error banner — the empty state is self-explanatory.
+			sessionMcpEntries.value = [];
+		}
+	};
+
+	/**
+	 * Toggle the effective enablement of a single MCP server for this session.
+	 *
+	 * Precedence matters here: we always write an `mcp_enablement` row at
+	 * scope='session' on toggle, because the alternative ("clear the override
+	 * if new state matches the inherited state") leaks inheritance details
+	 * into the UI — users who want a stable on/off for this session shouldn't
+	 * have to care whether the room or space flipped underneath them later.
+	 * The "Clear override" affordance (handleClearSessionMcpOverride) is the
+	 * escape hatch for users who explicitly want to revert to inheritance.
+	 */
+	const toggleSessionMcp = async (entry: SessionMcpServerEntry) => {
+		if (!session) return;
+		const serverId = entry.server.id;
+		const next = !entry.enabled;
+		const toggling = new Set(sessionMcpToggling.value);
+		toggling.add(serverId);
+		sessionMcpToggling.value = toggling;
+		try {
+			const hub = await connectionManager.getHub();
+			await hub.request<McpEnablementSetOverrideResponse>('mcp.enablement.setOverride', {
+				scopeType: 'session',
+				scopeId: session.id,
+				serverId,
+				enabled: next,
+			});
+			await loadSessionMcpEntries();
+		} catch {
+			toast.error(`Failed to toggle ${entry.server.name}`);
+		} finally {
+			const done = new Set(sessionMcpToggling.value);
+			done.delete(serverId);
+			sessionMcpToggling.value = done;
+		}
+	};
+
+	/**
+	 * Delete the session-scope override row for a server, reverting to the
+	 * next most-specific scope (room → space → registry default). No-op when
+	 * the effective decision isn't already a session override.
+	 */
+	const handleClearSessionMcpOverride = async (entry: SessionMcpServerEntry) => {
+		if (!session) return;
+		if (entry.source !== 'session') return;
+		const serverId = entry.server.id;
+		const toggling = new Set(sessionMcpToggling.value);
+		toggling.add(serverId);
+		sessionMcpToggling.value = toggling;
+		try {
+			const hub = await connectionManager.getHub();
+			await hub.request<McpEnablementClearOverrideResponse>('mcp.enablement.clearOverride', {
+				scopeType: 'session',
+				scopeId: session.id,
+				serverId,
+			});
+			await loadSessionMcpEntries();
+		} catch {
+			toast.error(`Failed to clear override for ${entry.server.name}`);
+		} finally {
+			const done = new Set(sessionMcpToggling.value);
+			done.delete(serverId);
+			sessionMcpToggling.value = done;
+		}
+	};
+
 	const isClaudeCodePresetAllowed = useComputed(
 		() => globalConfig.value?.systemPrompt?.claudeCodePreset?.allowed ?? true
 	);
@@ -224,6 +328,17 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 			(s) =>
 				s.displayName.toLowerCase().includes(q) ||
 				(s.description?.toLowerCase().includes(q) ?? false)
+		);
+	});
+
+	// Filtered session MCP entries (MCP M6).
+	const filteredSessionMcpEntries = useComputed(() => {
+		const q = sessionMcpSearch.value.trim().toLowerCase();
+		if (!q) return sessionMcpEntries.value;
+		return sessionMcpEntries.value.filter(
+			(e) =>
+				e.server.name.toLowerCase().includes(q) ||
+				(e.server.description?.toLowerCase().includes(q) ?? false)
 		);
 	});
 
@@ -373,6 +488,131 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 											</div>
 										);
 									})}
+								</div>
+							)}
+						</div>
+						<div class={`border-t ${borderColors.ui.secondary}`} />
+					</>
+				)}
+
+				{/* Session MCP Servers (MCP M6) —
+				    Per-session overrides of the app-level registry. Hidden when the
+				    registry is empty so users aren't presented with a blank section
+				    during initial setup. */}
+				{sessionMcpEntries.value.length > 0 && (
+					<>
+						<div>
+							<div class="flex items-center justify-between py-2 cursor-pointer select-none group">
+								<button
+									type="button"
+									class="flex items-center gap-2 flex-1 text-left hover:text-gray-200 transition-colors"
+									onClick={() => {
+										sessionMcpGroupOpen.value = !sessionMcpGroupOpen.value;
+									}}
+									aria-expanded={sessionMcpGroupOpen.value}
+								>
+									<svg
+										class={`w-3.5 h-3.5 text-gray-500 transition-transform ${sessionMcpGroupOpen.value ? 'rotate-90' : ''}`}
+										fill="none"
+										viewBox="0 0 24 24"
+										stroke="currentColor"
+									>
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width={2}
+											d="M9 5l7 7-7 7"
+										/>
+									</svg>
+									<span class="text-sm font-medium text-gray-300">Session MCP Servers</span>
+									<span class="text-xs text-gray-600">({sessionMcpEntries.value.length})</span>
+								</button>
+								<ScopeBadge scope="session" />
+							</div>
+							{sessionMcpGroupOpen.value && (
+								<div class="mt-2 ml-5 space-y-2">
+									<div class="text-xs text-gray-500">
+										Overrides apply to this session only. Changes take effect on the next respawn.
+									</div>
+									{sessionMcpEntries.value.length > 4 && (
+										<input
+											type="search"
+											placeholder="Filter MCP servers…"
+											value={sessionMcpSearch.value}
+											onInput={(e) => {
+												sessionMcpSearch.value = (e.target as HTMLInputElement).value;
+											}}
+											class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2.5 py-1.5 text-gray-300 placeholder-gray-600 focus:outline-none focus:border-blue-500/50"
+										/>
+									)}
+									{filteredSessionMcpEntries.value.length === 0 ? (
+										<div class="text-xs text-gray-600 py-1">
+											No servers match &ldquo;{sessionMcpSearch.value}&rdquo;.
+										</div>
+									) : (
+										<div class="space-y-1">
+											{filteredSessionMcpEntries.value.map((entry) => {
+												const isToggling = sessionMcpToggling.value.has(entry.server.id);
+												const sourceLabel =
+													entry.source === 'session'
+														? 'Session override'
+														: entry.source === 'room'
+															? 'Inherited from room'
+															: entry.source === 'space'
+																? 'Inherited from space'
+																: 'Registry default';
+												return (
+													<div
+														key={`session-mcp-${entry.server.id}`}
+														class={`flex items-center gap-2 p-2 rounded-lg bg-dark-800/50 min-w-0 ${
+															isToggling ? 'opacity-60' : ''
+														}`}
+													>
+														<svg
+															class="w-3.5 h-3.5 text-amber-400 flex-shrink-0"
+															fill="none"
+															viewBox="0 0 24 24"
+															stroke="currentColor"
+														>
+															<path
+																stroke-linecap="round"
+																stroke-linejoin="round"
+																stroke-width={2}
+																d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2"
+															/>
+														</svg>
+														<div class="flex-1 min-w-0">
+															<div class="text-xs text-gray-200 truncate">{entry.server.name}</div>
+															<div class="text-[10px] text-gray-500 truncate">{sourceLabel}</div>
+														</div>
+														<div class="flex items-center gap-2 flex-shrink-0">
+															{entry.source === 'session' && (
+																<button
+																	type="button"
+																	class="text-[10px] text-gray-500 hover:text-gray-300 transition-colors"
+																	title="Revert this session back to the inherited value"
+																	onClick={() => void handleClearSessionMcpOverride(entry)}
+																	disabled={isToggling}
+																>
+																	Clear
+																</button>
+															)}
+															{isToggling && (
+																<div class="w-2.5 h-2.5 border-2 border-gray-500 border-t-transparent rounded-full animate-spin" />
+															)}
+															<input
+																type="checkbox"
+																checked={entry.enabled}
+																onChange={() => void toggleSessionMcp(entry)}
+																disabled={isToggling}
+																class="w-3.5 h-3.5 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
+															/>
+														</div>
+													</div>
+												);
+											})}
+										</div>
+									)}
 								</div>
 							)}
 						</div>


### PR DESCRIPTION
## Summary
- Wires `mcp_enablement` into the skill bridge (`QueryOptionsBuilder.getMcpServersFromSkills`) so skill-wrapped MCP servers honor session > room > space > registry precedence via the shared resolver — previously only the registry flag was checked.
- Adds `session.mcp.list` RPC that returns every registry entry resolved to `{server, enabled, source, override?}` for a single session, so the UI never re-implements precedence.
- Tools modal now has a "MCP servers for this session" group with per-server toggles (write session-scope overrides), scope labels ("Session override", "Inherited from room", …), and an explicit "Clear" affordance on session-owned rows.
- Cascade-deletes session-scope `mcp_enablement` rows inside `SessionRepository.deleteSession()` so orphans don't accumulate. Reviewer's non-blocking note from the prior round.

## Test plan
- [x] `app-mcp-handlers.test.ts`: 11 new tests covering `session.mcp.list` precedence/isolation/errors + `mcp.enablement.{setOverride,clearOverride}` CRUD error paths.
- [x] `query-options-builder.test.ts`: 4 new tests for the skill bridge's effective-enablement filter.
- [x] `session-repository.test.ts`: 2 new tests for cascade-delete on session delete.
- [x] `./scripts/test-daemon.sh` — 11630/11630 pass.
- [x] `bun run lint` / `typecheck` / `format` clean.