### PR TITLE
feat(daemon): generalize MCP enablement with mcp_enablement table + resolver

### DIFF
--- a/packages/daemon/src/lib/db-query/scope-config.ts
+++ b/packages/daemon/src/lib/db-query/scope-config.ts
@@ -383,6 +383,10 @@ const EXCLUDED_TABLE_NAMES: string[] = [
 	'github_filter_configs',
 	// Workspace history — user-level path bookmarks, not useful for agent queries
 	'workspace_history',
+	// MCP enablement overrides — infrastructure config spanning multiple scopes
+	// (space/room/session), not useful for ad-hoc agent queries. Agents should
+	// read MCP state through the resolver rather than hitting the table directly.
+	'mcp_enablement',
 	// Dropped tables (no longer exist in schema)
 	'space_session_groups',
 	'space_session_group_members',

--- a/packages/daemon/src/lib/mcp/app-mcp-lifecycle-manager.ts
+++ b/packages/daemon/src/lib/mcp/app-mcp-lifecycle-manager.ts
@@ -24,6 +24,11 @@ import type {
 	McpHttpServerConfig,
 	ValidationResult,
 } from '@neokai/shared';
+import {
+	resolveMcpServers,
+	scopeChainForSession,
+	type ResolveMcpServersSession,
+} from './resolve-mcp-servers';
 
 // Re-export so callers can import from this module without reaching into shared.
 export type { ValidationResult } from '@neokai/shared';
@@ -67,7 +72,40 @@ export class AppMcpLifecycleManager {
 	}
 
 	/**
+	 * Returns SDK MCP configs effective for a given session, resolving the
+	 * session's space / room / session scope chain against the registry via the
+	 * pure {@link resolveMcpServers} function.
+	 *
+	 * This is the canonical entry point for all session-spawn paths (space ad-hoc,
+	 * `space_task_agent`, node-agent, room sessions). Legacy variants
+	 * ({@link getEnabledMcpConfigs}, {@link getEnabledMcpConfigsForRoom}) remain
+	 * for backward compatibility with callers that don't yet have a Session
+	 * object; M5 will remove them.
+	 */
+	getEnabledMcpConfigsForSession(
+		session: ResolveMcpServersSession
+	): Record<string, McpServerConfig> {
+		const registry = this.db.appMcpServers.list();
+		const chain = scopeChainForSession(session);
+		const overrides = this.db.mcpEnablement.listForScopes(chain);
+		const effective = resolveMcpServers(session, registry, overrides);
+
+		const result: Record<string, McpServerConfig> = {};
+		for (const entry of effective) {
+			const validation = this.validateEntry(entry);
+			if (!validation.valid) continue;
+			result[entry.name] = this.convertEntry(entry);
+		}
+		return result;
+	}
+
+	/**
 	 * Returns SDK MCP configs for a specific room.
+	 *
+	 * @deprecated Prefer {@link getEnabledMcpConfigsForSession}, which resolves
+	 * the full session > room > space > registry precedence chain via the pure
+	 * {@link resolveMcpServers} function. This method still supports legacy
+	 * callers that only know a roomId. M5 removes it.
 	 *
 	 * Per-room overrides take precedence:
 	 * - If the room has explicitly enabled servers (via room_mcp_enablement), return those.

--- a/packages/daemon/src/lib/mcp/resolve-mcp-servers.ts
+++ b/packages/daemon/src/lib/mcp/resolve-mcp-servers.ts
@@ -1,0 +1,149 @@
+/**
+ * resolveMcpServers — pure function for MCP M3.
+ *
+ * Decides which app-level MCP registry entries are effectively enabled for a
+ * given session, given the full set of registered servers and every explicit
+ * per-scope override.
+ *
+ * Precedence (most specific wins):
+ *   session > room > space > registry default
+ *
+ * A "registry default" is the `enabled` flag on the registry row itself. An
+ * "override" is a row in the `mcp_enablement` table targeting the session's
+ * space/room/session id. Missing override rows mean "inherit from the next
+ * less-specific scope".
+ *
+ * This function is intentionally I/O-free: callers build the inputs (read the
+ * registry, fetch the overrides for the session's scope chain) and pass them in.
+ * Keeping resolution a pure function means:
+ *   - Every session spawn path (`space_task_agent`, room chat, neo, ad-hoc
+ *     coder sessions, …) funnels through the same decision logic.
+ *   - The precedence matrix is trivial to unit-test without a database.
+ *   - The resolver never triggers surprise DB reads in hot paths.
+ */
+
+import type { AppMcpServer, McpEnablementOverride, Session } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Subset of `Session` that the resolver actually needs. Accepting this narrower
+ * type (instead of the full `Session`) makes the resolver trivial to use from
+ * contexts that only have a `SessionContext` (e.g. when spawning a worker that
+ * doesn't yet have a full Session row persisted).
+ */
+export interface ResolveMcpServersSession {
+	/** The session's unique id. */
+	id: string;
+	/** Optional scoping context; missing values skip that scope level. */
+	context?: {
+		spaceId?: string;
+		roomId?: string;
+	};
+}
+
+/**
+ * Resolve the effective set of MCP servers for a session.
+ *
+ * @param session  - The session whose enablement we're computing. Only `id`
+ *                   and `context.{spaceId, roomId}` are consulted.
+ * @param registry - Every registered `AppMcpServer` the caller is prepared to
+ *                   serve. Typically `db.appMcpServers.list()`. The resolver
+ *                   does not filter on the registry row's `enabled` flag when
+ *                   an explicit override is present — an override to enable
+ *                   wins even if the registry default is "disabled".
+ * @param overrides - Every `mcp_enablement` row matching any scope in the
+ *                    session's scope chain. Other rows are ignored. Typically
+ *                    `db.mcpEnablement.listForScopes(scopeChain)`.
+ *
+ * @returns The subset of `registry` that is effectively enabled for the given
+ *          session, preserving the registry's original ordering. The returned
+ *          array always references the same `AppMcpServer` objects the caller
+ *          supplied; the resolver never mutates or clones them.
+ */
+export function resolveMcpServers(
+	session: ResolveMcpServersSession | Session,
+	registry: readonly AppMcpServer[],
+	overrides: readonly McpEnablementOverride[]
+): AppMcpServer[] {
+	const ctx = (session as ResolveMcpServersSession).context ?? {};
+	const sessionId = session.id;
+	const { spaceId, roomId } = ctx;
+
+	// Group overrides by (scopeType, scopeId, serverId) for O(1) lookup. The
+	// input may contain overrides for scopes the session doesn't care about
+	// (e.g. another room); those are ignored silently.
+	const sessionOverrides = new Map<string, McpEnablementOverride>(); // serverId → override
+	const roomOverrides = new Map<string, McpEnablementOverride>();
+	const spaceOverrides = new Map<string, McpEnablementOverride>();
+
+	for (const ov of overrides) {
+		if (ov.scopeType === 'session' && ov.scopeId === sessionId) {
+			sessionOverrides.set(ov.serverId, ov);
+		} else if (ov.scopeType === 'room' && roomId && ov.scopeId === roomId) {
+			roomOverrides.set(ov.serverId, ov);
+		} else if (ov.scopeType === 'space' && spaceId && ov.scopeId === spaceId) {
+			spaceOverrides.set(ov.serverId, ov);
+		}
+		// Overrides for other sessions/rooms/spaces: ignored.
+	}
+
+	const result: AppMcpServer[] = [];
+	for (const entry of registry) {
+		if (isEffectivelyEnabled(entry, sessionOverrides, roomOverrides, spaceOverrides)) {
+			result.push(entry);
+		}
+	}
+	return result;
+}
+
+/**
+ * Convenience wrapper: compute the scope chain the resolver needs given a
+ * session. The caller should pass the result to
+ * `McpEnablementRepository.listForScopes()` to fetch only the relevant rows.
+ *
+ * The chain orders scopes from most specific to least specific, though the
+ * resolver itself ignores order — that's purely a convenience for humans
+ * eyeballing the query.
+ */
+export function scopeChainForSession(
+	session: ResolveMcpServersSession | Session
+): Array<{ scopeType: 'session' | 'room' | 'space'; scopeId: string }> {
+	const ctx = (session as ResolveMcpServersSession).context ?? {};
+	const chain: Array<{ scopeType: 'session' | 'room' | 'space'; scopeId: string }> = [];
+	chain.push({ scopeType: 'session', scopeId: session.id });
+	if (ctx.roomId) chain.push({ scopeType: 'room', scopeId: ctx.roomId });
+	if (ctx.spaceId) chain.push({ scopeType: 'space', scopeId: ctx.spaceId });
+	return chain;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply precedence rules for a single registry entry:
+ *   1. If a session override exists, it wins outright.
+ *   2. Otherwise if a room override exists, it wins.
+ *   3. Otherwise if a space override exists, it wins.
+ *   4. Otherwise fall back to the registry row's own `enabled` flag.
+ */
+function isEffectivelyEnabled(
+	entry: AppMcpServer,
+	sessionOverrides: Map<string, McpEnablementOverride>,
+	roomOverrides: Map<string, McpEnablementOverride>,
+	spaceOverrides: Map<string, McpEnablementOverride>
+): boolean {
+	const sessionOv = sessionOverrides.get(entry.id);
+	if (sessionOv) return sessionOv.enabled;
+
+	const roomOv = roomOverrides.get(entry.id);
+	if (roomOv) return roomOv.enabled;
+
+	const spaceOv = spaceOverrides.get(entry.id);
+	if (spaceOv) return spaceOv.enabled;
+
+	return entry.enabled;
+}

--- a/packages/daemon/src/lib/neo/neo-agent-manager.ts
+++ b/packages/daemon/src/lib/neo/neo-agent-manager.ts
@@ -57,6 +57,16 @@ export interface NeoSettingsManager {
  */
 export interface NeoAppMcpManager {
 	getEnabledMcpConfigs(): Record<string, McpServerConfig>;
+	/**
+	 * Session-aware variant. Neo passes its own `neo:global` session id with no
+	 * space/room context so the resolver falls back to registry defaults — but
+	 * routing through this method keeps all session spawn paths uniform, and
+	 * lets users create scope='session' overrides for Neo itself.
+	 */
+	getEnabledMcpConfigsForSession(session: {
+		id: string;
+		context?: { spaceId?: string; roomId?: string };
+	}): Record<string, McpServerConfig>;
 }
 
 export class NeoAgentManager {
@@ -433,7 +443,12 @@ export class NeoAgentManager {
 			this.toolsConfig,
 			this.actionToolsConfig ?? undefined
 		);
-		const registryMcpServers = this.appMcpManager?.getEnabledMcpConfigs() ?? {};
+		// Session-aware resolver — Neo has no space/room context so the resolver
+		// returns registry defaults, but this keeps all session spawn paths on a
+		// single, scope-aware API (MCP M3) and lets users add per-session
+		// overrides for the `neo:global` session if desired.
+		const registryMcpServers =
+			this.appMcpManager?.getEnabledMcpConfigsForSession({ id: NEO_SESSION_ID }) ?? {};
 
 		for (const name of Object.keys(registryMcpServers)) {
 			if (name in inProcessServers) {

--- a/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
+++ b/packages/daemon/src/lib/room/runtime/room-runtime-service.ts
@@ -367,7 +367,16 @@ export class RoomRuntimeService {
 		sessionId: string
 	): void {
 		const fileMcpServers = ctx.settingsManager.getEnabledMcpServersConfig();
-		const registryMcpServers = ctx.appMcpManager?.getEnabledMcpConfigs() ?? {};
+		// Resolve registry servers via the session-aware resolver so that any
+		// per-room / per-session overrides in `mcp_enablement` are honoured.
+		// Worker sessions don't carry a spaceId; the roomId is embedded in their
+		// session ID (`{role}:{roomId}:{taskId}:{uuid8}`).
+		const roomId = RoomRuntimeService.extractRoomId(sessionId) ?? undefined;
+		const registryMcpServers =
+			ctx.appMcpManager?.getEnabledMcpConfigsForSession({
+				id: sessionId,
+				...(roomId ? { context: { roomId } } : {}),
+			}) ?? {};
 
 		// Detect and warn on name collisions (file-based wins)
 		for (const name of Object.keys(fileMcpServers)) {
@@ -843,8 +852,14 @@ export class RoomRuntimeService {
 				// TODO(Milestone 5): When workspaceRoot becomes optional, revisit this to create a
 				// room-scoped SettingsManager using room.defaultPath if needed.
 				const fileMcpServers = this.ctx.settingsManager.getEnabledMcpServersConfig();
+				// Session-aware resolver — the room chat session carries a roomId in
+				// its context. Space overrides are N/A here (room chat is not owned
+				// by a Space), but the resolver handles the missing scope gracefully.
 				const registryMcpServers =
-					this.ctx.appMcpManager?.getEnabledMcpConfigsForRoom(room.id) ?? {};
+					this.ctx.appMcpManager?.getEnabledMcpConfigsForSession({
+						id: roomChatSessionId,
+						context: { roomId: room.id },
+					}) ?? {};
 
 				// Create a room-scoped db-query server (auto-injects WHERE room_id = ?).
 				// Only created when dbPath is configured; close any existing instance first to
@@ -988,9 +1003,12 @@ export class RoomRuntimeService {
 					// Read both sources inside the handler per-room so that per-room enablement
 					// is respected when re-applying configs after registry changes.
 					const fileMcpServers = this.ctx.settingsManager.getEnabledMcpServersConfig();
-					const registryMcpServers =
-						this.ctx.appMcpManager?.getEnabledMcpConfigsForRoom(roomId) ?? {};
 					const roomChatSessionId = `room:chat:${roomId}`;
+					const registryMcpServers =
+						this.ctx.appMcpManager?.getEnabledMcpConfigsForSession({
+							id: roomChatSessionId,
+							context: { roomId },
+						}) ?? {};
 					void this.ctx.sessionManager
 						.getSessionAsync(roomChatSessionId)
 						.then((session) => {

--- a/packages/daemon/src/lib/rpc-handlers/app-mcp-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/app-mcp-handlers.ts
@@ -35,6 +35,14 @@ import type { DaemonHub } from '../daemon-hub';
 import type { AppMcpServerRepository } from '../../storage/repositories/app-mcp-server-repository';
 import type { Database } from '../../storage/database';
 import type {
+	McpEnablementClearOverrideRequest,
+	McpEnablementClearOverrideResponse,
+	McpEnablementClearScopeRequest,
+	McpEnablementClearScopeResponse,
+	McpEnablementListRequest,
+	McpEnablementListResponse,
+	McpEnablementSetOverrideRequest,
+	McpEnablementSetOverrideResponse,
 	McpRoomGetEnabledRequest,
 	McpRoomGetEnabledResponse,
 	McpRoomSetEnabledRequest,
@@ -230,5 +238,78 @@ export function setupAppMcpHandlers(
 			.catch((err) => log.warn('Failed to emit mcp.registry.changed:', err));
 
 		return { ok: true } satisfies McpRoomResetToGlobalResponse;
+	});
+
+	// -------------------------------------------------------------------------
+	// Scope-aware enablement handlers (M3+)
+	//
+	// These operate on the unified `mcp_enablement` table and support all three
+	// scope types (space / room / session). The older `mcp.room.*` handlers
+	// above still target the legacy `room_mcp_enablement` table and will be
+	// removed in M5.
+	// -------------------------------------------------------------------------
+
+	/** `mcp.enablement.list` — every override at a given scope. */
+	messageHub.onRequest('mcp.enablement.list', (data) => {
+		const { scopeType, scopeId } = data as McpEnablementListRequest;
+		if (!scopeType) throw new Error('scopeType is required');
+		if (!scopeId) throw new Error('scopeId is required');
+		const overrides = db.mcpEnablement.listForScope(scopeType, scopeId);
+		return { overrides } satisfies McpEnablementListResponse;
+	});
+
+	/** `mcp.enablement.setOverride` — upsert a single override. */
+	messageHub.onRequest('mcp.enablement.setOverride', (data) => {
+		const { scopeType, scopeId, serverId, enabled } = data as McpEnablementSetOverrideRequest;
+		if (!scopeType) throw new Error('scopeType is required');
+		if (!scopeId) throw new Error('scopeId is required');
+		if (!serverId) throw new Error('serverId is required');
+		if (typeof enabled !== 'boolean') throw new Error('enabled must be a boolean');
+
+		// Validate that the server exists — otherwise the FK CASCADE is the only
+		// guard and callers get a useless SQL error.
+		const server = db.appMcpServers.get(serverId);
+		if (!server) {
+			throw new Error(`MCP server not found: ${serverId}`);
+		}
+
+		const override = db.mcpEnablement.setOverride(scopeType, scopeId, serverId, enabled);
+
+		daemonHub
+			.emit('mcp.registry.changed', { sessionId: 'global' })
+			.catch((err) => log.warn('Failed to emit mcp.registry.changed:', err));
+
+		return { override } satisfies McpEnablementSetOverrideResponse;
+	});
+
+	/** `mcp.enablement.clearOverride` — delete one override row. */
+	messageHub.onRequest('mcp.enablement.clearOverride', (data) => {
+		const { scopeType, scopeId, serverId } = data as McpEnablementClearOverrideRequest;
+		if (!scopeType) throw new Error('scopeType is required');
+		if (!scopeId) throw new Error('scopeId is required');
+		if (!serverId) throw new Error('serverId is required');
+
+		const deleted = db.mcpEnablement.clearOverride(scopeType, scopeId, serverId);
+		if (deleted) {
+			daemonHub
+				.emit('mcp.registry.changed', { sessionId: 'global' })
+				.catch((err) => log.warn('Failed to emit mcp.registry.changed:', err));
+		}
+		return { deleted } satisfies McpEnablementClearOverrideResponse;
+	});
+
+	/** `mcp.enablement.clearScope` — delete every override at a given scope. */
+	messageHub.onRequest('mcp.enablement.clearScope', (data) => {
+		const { scopeType, scopeId } = data as McpEnablementClearScopeRequest;
+		if (!scopeType) throw new Error('scopeType is required');
+		if (!scopeId) throw new Error('scopeId is required');
+
+		const deleted = db.mcpEnablement.clearScope(scopeType, scopeId);
+		if (deleted > 0) {
+			daemonHub
+				.emit('mcp.registry.changed', { sessionId: 'global' })
+				.catch((err) => log.warn('Failed to emit mcp.registry.changed:', err));
+		}
+		return { deleted } satisfies McpEnablementClearScopeResponse;
 	});
 }

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -677,7 +677,12 @@ export class TaskAgentManager {
 			// Note: task agent sessions are short-lived (one per task), so there is no
 			// mcp.registry.changed subscription here. Registry changes during a running task
 			// are not hot-reloaded; they take effect when the next task agent is spawned.
-			const registryMcpServers = this.config.appMcpManager?.getEnabledMcpConfigs() ?? {};
+			// Resolve overrides for the task agent session (scope='space' applies).
+			const registryMcpServers =
+				this.config.appMcpManager?.getEnabledMcpConfigsForSession({
+					id: sessionId,
+					context: { spaceId },
+				}) ?? {};
 			for (const name of Object.keys(registryMcpServers)) {
 				if (name === 'task-agent') {
 					log.warn(
@@ -1253,7 +1258,13 @@ export class TaskAgentManager {
 				);
 
 				// Merge registry-sourced MCP servers alongside the per-session ones.
-				const registryMcpServers = this.config.appMcpManager?.getEnabledMcpConfigs() ?? {};
+				// Resolve via the session-aware resolver so scope='space' / scope='session'
+				// overrides in `mcp_enablement` are honoured.
+				const registryMcpServers =
+					this.config.appMcpManager?.getEnabledMcpConfigsForSession({
+						id: sessionId,
+						context: { spaceId },
+					}) ?? {};
 				const mergedMcpServers = {
 					...registryMcpServers,
 					...init.mcpServers,
@@ -1476,7 +1487,13 @@ export class TaskAgentManager {
 		//
 		// Note: skills-based MCP servers (from skillsManager) are injected separately at query
 		// start time via QueryOptionsBuilder.getMcpServersFromSkills(), NOT via setRuntimeMcpServers.
-		const subSessionRegistryMcpServers = this.config.appMcpManager?.getEnabledMcpConfigs() ?? {};
+		// Session-aware resolver — scope='space' / scope='session' overrides apply.
+		const subSessionSpaceId = this.config.taskRepo.getTask(taskId)?.spaceId;
+		const subSessionRegistryMcpServers =
+			this.config.appMcpManager?.getEnabledMcpConfigsForSession({
+				id: sessionId,
+				context: subSessionSpaceId ? { spaceId: subSessionSpaceId } : {},
+			}) ?? {};
 		const mergedSubSessionMcpServers = {
 			...subSessionRegistryMcpServers,
 			...init.mcpServers,
@@ -2745,7 +2762,12 @@ export class TaskAgentManager {
 		// Merge registry-sourced MCP servers alongside the in-process task-agent server,
 		// mirroring the same logic in spawnTaskAgent() so rehydrated sessions have the
 		// same MCP configuration as freshly spawned ones.
-		const rehydrateRegistryMcpServers = this.config.appMcpManager?.getEnabledMcpConfigs() ?? {};
+		// Session-aware resolver — scope='space' / scope='session' overrides apply.
+		const rehydrateRegistryMcpServers =
+			this.config.appMcpManager?.getEnabledMcpConfigsForSession({
+				id: sessionId,
+				context: { spaceId },
+			}) ?? {};
 		for (const name of Object.keys(rehydrateRegistryMcpServers)) {
 			if (name === 'task-agent') {
 				log.warn(
@@ -2942,7 +2964,12 @@ export class TaskAgentManager {
 		);
 
 		// Merge registry-sourced MCP servers, letting node-agent server take precedence.
-		const registryMcpServers = this.config.appMcpManager?.getEnabledMcpConfigs() ?? {};
+		// Session-aware resolver — scope='space' / scope='session' overrides apply.
+		const registryMcpServers =
+			this.config.appMcpManager?.getEnabledMcpConfigsForSession({
+				id: subSessionId,
+				context: { spaceId },
+			}) ?? {};
 		const mergedMcpServers: Record<string, McpServerConfig> = {
 			...registryMcpServers,
 			'node-agent': nodeAgentMcpServer as unknown as McpServerConfig,

--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -39,6 +39,7 @@ import { JobQueueRepository } from './repositories/job-queue-repository';
 import { AppMcpServerRepository } from './repositories/app-mcp-server-repository';
 import { TaskRepository } from './repositories/task-repository';
 import { RoomMcpEnablementRepository } from './repositories/room-mcp-enablement-repository';
+import { McpEnablementRepository } from './repositories/mcp-enablement-repository';
 import { SkillRepository } from './repositories/skill-repository';
 import { RoomSkillOverrideRepository } from './repositories/room-skill-override-repository';
 import { NeoActivityLogRepository } from './repositories/neo-activity-log-repository';
@@ -66,6 +67,7 @@ export { TaskRepository } from './repositories/task-repository';
 export { SpaceAgentRepository } from './repositories/space-agent-repository';
 export { AppMcpServerRepository } from './repositories/app-mcp-server-repository';
 export { RoomMcpEnablementRepository } from './repositories/room-mcp-enablement-repository';
+export { McpEnablementRepository } from './repositories/mcp-enablement-repository';
 export { SkillRepository } from './repositories/skill-repository';
 export { RoomSkillOverrideRepository } from './repositories/room-skill-override-repository';
 export { NeoActivityLogRepository } from './repositories/neo-activity-log-repository';
@@ -96,6 +98,7 @@ export class Database {
 	private appMcpServerRepo!: AppMcpServerRepository;
 	private taskRepo!: TaskRepository;
 	private roomMcpEnablementRepo!: RoomMcpEnablementRepository;
+	private mcpEnablementRepo!: McpEnablementRepository;
 	private skillRepo!: SkillRepository;
 	private roomSkillOverrideRepo!: RoomSkillOverrideRepository;
 	private neoActivityLogRepo!: NeoActivityLogRepository;
@@ -123,6 +126,7 @@ export class Database {
 		this.jobQueueRepo = new JobQueueRepository(db);
 		this.appMcpServerRepo = new AppMcpServerRepository(db, reactiveDb);
 		this.roomMcpEnablementRepo = new RoomMcpEnablementRepository(db, reactiveDb);
+		this.mcpEnablementRepo = new McpEnablementRepository(db, reactiveDb);
 		this.skillRepo = new SkillRepository(db, reactiveDb);
 		this.roomSkillOverrideRepo = new RoomSkillOverrideRepository(db, reactiveDb);
 		this.neoActivityLogRepo = new NeoActivityLogRepository(db);
@@ -502,9 +506,21 @@ export class Database {
 
 	/**
 	 * Get the per-room MCP enablement repository
+	 *
+	 * @deprecated Use {@link mcpEnablement} (scope='room') instead. Kept around
+	 * until M5 purges the legacy `room_mcp_enablement` table.
 	 */
 	get roomMcpEnablement(): RoomMcpEnablementRepository {
 		return this.roomMcpEnablementRepo;
+	}
+
+	/**
+	 * Get the generalized per-scope MCP enablement repository. One row per
+	 * explicit (scope_type, scope_id, server_id) override; missing rows inherit
+	 * from the next most-specific scope (session > room > space > registry).
+	 */
+	get mcpEnablement(): McpEnablementRepository {
+		return this.mcpEnablementRepo;
 	}
 
 	/**

--- a/packages/daemon/src/storage/repositories/mcp-enablement-repository.ts
+++ b/packages/daemon/src/storage/repositories/mcp-enablement-repository.ts
@@ -1,0 +1,198 @@
+/**
+ * McpEnablementRepository
+ *
+ * CRUD for the unified per-scope MCP enablement override table. Each row is an
+ * explicit (scope_type, scope_id, server_id) override that either enables or
+ * disables a registry server at that scope. Missing rows mean "inherit" — the
+ * resolver (packages/daemon/src/lib/mcp/resolve-mcp-servers.ts) applies the
+ * session > room > space > registry precedence.
+ *
+ * Each write calls reactiveDb.notifyChange('mcp_enablement') so LiveQueryEngine
+ * can invalidate frontend subscriptions on every change.
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+import type { McpEnablementOverride, McpEnablementScopeType } from '@neokai/shared';
+import type { ReactiveDatabase } from '../reactive-database';
+
+// ---------------------------------------------------------------------------
+// Internal row type
+// ---------------------------------------------------------------------------
+
+interface EnablementRow {
+	scope_type: string;
+	scope_id: string;
+	server_id: string;
+	enabled: number;
+}
+
+function rowToOverride(row: EnablementRow): McpEnablementOverride {
+	return {
+		scopeType: row.scope_type as McpEnablementScopeType,
+		scopeId: row.scope_id,
+		serverId: row.server_id,
+		enabled: row.enabled === 1,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Repository
+// ---------------------------------------------------------------------------
+
+export class McpEnablementRepository {
+	constructor(
+		private db: BunDatabase,
+		private reactiveDb: ReactiveDatabase
+	) {}
+
+	/**
+	 * Upsert an explicit override for (scopeType, scopeId, serverId).
+	 *
+	 * Calling with `enabled=true` explicitly enables the server at that scope,
+	 * overriding whatever the next-less-specific scope says. Calling with
+	 * `enabled=false` explicitly disables it. To remove the override entirely
+	 * (revert to inheritance), call {@link clearOverride}.
+	 */
+	setOverride(
+		scopeType: McpEnablementScopeType,
+		scopeId: string,
+		serverId: string,
+		enabled: boolean
+	): McpEnablementOverride {
+		// Single INSERT OR REPLACE handles both insert and update. The composite
+		// PRIMARY KEY (server_id, scope_type, scope_id) means a conflict on any
+		// of those triples swaps the `enabled` column in place.
+		this.db
+			.prepare(
+				`INSERT INTO mcp_enablement (server_id, scope_type, scope_id, enabled)
+				 VALUES (?, ?, ?, ?)
+				 ON CONFLICT(server_id, scope_type, scope_id)
+				 DO UPDATE SET enabled = excluded.enabled`
+			)
+			.run(serverId, scopeType, scopeId, enabled ? 1 : 0);
+		this.reactiveDb.notifyChange('mcp_enablement');
+		return { scopeType, scopeId, serverId, enabled };
+	}
+
+	/**
+	 * Return the single override for (scopeType, scopeId, serverId), or null if
+	 * none exists. A null return means "inherit from parent scope / registry".
+	 */
+	getOverride(
+		scopeType: McpEnablementScopeType,
+		scopeId: string,
+		serverId: string
+	): McpEnablementOverride | null {
+		const row = this.db
+			.prepare(
+				`SELECT * FROM mcp_enablement
+				 WHERE scope_type = ? AND scope_id = ? AND server_id = ?`
+			)
+			.get(scopeType, scopeId, serverId) as EnablementRow | undefined;
+		return row ? rowToOverride(row) : null;
+	}
+
+	/**
+	 * All override rows that target the given scope (e.g. every override at
+	 * scope='space' with scopeId='space-1'). Useful when the UI renders the
+	 * override list for a single scope.
+	 */
+	listForScope(scopeType: McpEnablementScopeType, scopeId: string): McpEnablementOverride[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM mcp_enablement
+				 WHERE scope_type = ? AND scope_id = ?
+				 ORDER BY server_id ASC`
+			)
+			.all(scopeType, scopeId) as EnablementRow[];
+		return rows.map(rowToOverride);
+	}
+
+	/**
+	 * All override rows for a given server (any scope). Used by the registry
+	 * UI to show "server X is explicitly disabled in the following scopes".
+	 */
+	listForServer(serverId: string): McpEnablementOverride[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM mcp_enablement
+				 WHERE server_id = ?
+				 ORDER BY scope_type ASC, scope_id ASC`
+			)
+			.all(serverId) as EnablementRow[];
+		return rows.map(rowToOverride);
+	}
+
+	/**
+	 * All overrides across all scopes. Primarily for the resolver, which fetches
+	 * every override matching a session's scope chain. Callers should typically
+	 * prefer {@link listForScopes} which pre-filters in SQL.
+	 */
+	listAll(): McpEnablementOverride[] {
+		const rows = this.db
+			.prepare(`SELECT * FROM mcp_enablement ORDER BY scope_type ASC, scope_id ASC`)
+			.all() as EnablementRow[];
+		return rows.map(rowToOverride);
+	}
+
+	/**
+	 * Return every override matching any of the given (scopeType, scopeId)
+	 * pairs. Shape is intended for the pure resolver's input: the caller
+	 * assembles the session's scope chain (space, room, session) and hands it
+	 * to this method, which returns only the rows that matter for resolution.
+	 */
+	listForScopes(
+		scopes: Array<{ scopeType: McpEnablementScopeType; scopeId: string }>
+	): McpEnablementOverride[] {
+		if (scopes.length === 0) return [];
+
+		// Hand-roll the placeholder list so every scope pair becomes `(?,?)`.
+		// SQLite doesn't natively accept tuple-IN for composite keys, so we use
+		// an OR chain instead. The list is bounded (≤3 scopes for any session).
+		const clauses: string[] = [];
+		const params: string[] = [];
+		for (const s of scopes) {
+			clauses.push(`(scope_type = ? AND scope_id = ?)`);
+			params.push(s.scopeType, s.scopeId);
+		}
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM mcp_enablement
+				 WHERE ${clauses.join(' OR ')}`
+			)
+			.all(...params) as EnablementRow[];
+		return rows.map(rowToOverride);
+	}
+
+	/**
+	 * Delete a single override. Returns true if a row was removed.
+	 * Removing an override means "inherit from next parent scope" again.
+	 */
+	clearOverride(scopeType: McpEnablementScopeType, scopeId: string, serverId: string): boolean {
+		const result = this.db
+			.prepare(
+				`DELETE FROM mcp_enablement
+				 WHERE scope_type = ? AND scope_id = ? AND server_id = ?`
+			)
+			.run(scopeType, scopeId, serverId);
+		const deleted = result.changes > 0;
+		if (deleted) {
+			this.reactiveDb.notifyChange('mcp_enablement');
+		}
+		return deleted;
+	}
+
+	/**
+	 * Drop every override at a given scope (e.g. "reset this room to inherit").
+	 * Returns the number of rows removed.
+	 */
+	clearScope(scopeType: McpEnablementScopeType, scopeId: string): number {
+		const result = this.db
+			.prepare(`DELETE FROM mcp_enablement WHERE scope_type = ? AND scope_id = ?`)
+			.run(scopeType, scopeId);
+		if (result.changes > 0) {
+			this.reactiveDb.notifyChange('mcp_enablement');
+		}
+		return result.changes;
+	}
+}

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -61,6 +61,8 @@ export { runMigration98 } from './migrations';
 export { runMigration99 } from './migrations';
 // knip-ignore-next-line
 export { runMigration100 } from './migrations';
+// knip-ignore-next-line
+export { runMigration101 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults
@@ -400,7 +402,8 @@ export function createTables(db: BunDatabase): void {
 		 WHERE source = 'imported' AND source_path IS NOT NULL`
 	);
 
-	// Per-room MCP enablement overrides
+	// Per-room MCP enablement overrides (legacy — superseded by `mcp_enablement`
+	// with scope_type='room'. Kept here until M5 purges it.)
 	db.exec(`
       CREATE TABLE IF NOT EXISTS room_mcp_enablement (
         room_id TEXT NOT NULL REFERENCES rooms(id) ON DELETE CASCADE,
@@ -409,6 +412,24 @@ export function createTables(db: BunDatabase): void {
         PRIMARY KEY (room_id, server_id)
       )
     `);
+
+	// Generalized MCP enablement overrides — one row per explicit override at a
+	// specific scope (space / room / session). Missing rows inherit from the
+	// next most-specific scope, falling back to the registry default. Added in
+	// M3 (Migration 100); supersedes `room_mcp_enablement`, which is dropped in M5.
+	db.exec(`
+      CREATE TABLE IF NOT EXISTS mcp_enablement (
+        server_id  TEXT NOT NULL REFERENCES app_mcp_servers(id) ON DELETE CASCADE,
+        scope_type TEXT NOT NULL CHECK (scope_type IN ('space', 'room', 'session')),
+        scope_id   TEXT NOT NULL,
+        enabled    INTEGER NOT NULL CHECK (enabled IN (0, 1)),
+        PRIMARY KEY (server_id, scope_type, scope_id)
+      )
+    `);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_mcp_enablement_scope ON mcp_enablement(scope_type, scope_id)`
+	);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_mcp_enablement_server ON mcp_enablement(server_id)`);
 
 	// Application-level Skills registry
 	db.exec(`

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -449,6 +449,14 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	//   on `(source_path, name)` WHERE source='imported' so the M2 import service
 	//   can upsert idempotently from `.mcp.json` scans.
 	runMigration100(db);
+
+	// Migration 101: MCP M3 — create the unified `mcp_enablement` table used as
+	//   the single source of truth for per-scope (space/room/session) MCP server
+	//   overrides, and seed it from the legacy `room_mcp_enablement` table plus
+	//   existing `GlobalSettings.disabledMcpServers` and per-session
+	//   `config.tools.disabledMcpServers`. Legacy columns/table are left intact
+	//   for this milestone — M5 removes them.
+	runMigration101(db);
 }
 
 /**
@@ -6652,4 +6660,156 @@ export function runMigration100(db: BunDatabase): void {
 		 ON app_mcp_servers(source_path, name)
 		 WHERE source = 'imported' AND source_path IS NOT NULL`
 	);
+}
+
+/**
+ * Migration 101 — MCP M3: Generalize per-scope MCP enablement.
+ *
+ * Goal: replace the room-only `room_mcp_enablement` table and the ad-hoc
+ * `GlobalSettings.disabledMcpServers` / `SessionConfig.disabledMcpServers`
+ * lists with a single table whose rows each encode one explicit override at a
+ * specific scope (space / room / session). Missing rows mean "inherit" — the
+ * most specific scope with an override wins, otherwise the registry default
+ * is used.
+ *
+ * Steps:
+ *   1. Create `mcp_enablement` with UNIQUE (scope_type, scope_id, server_id).
+ *   2. Copy existing `room_mcp_enablement` rows as scope_type='room'.
+ *   3. Seed scope_type='space', enabled=0 rows from
+ *      `global_settings.disabledMcpServers` (string[] of server names) for
+ *      every active space, resolving server name → server id via
+ *      `app_mcp_servers`.
+ *   4. Seed scope_type='session', enabled=0 rows from each session's
+ *      `config.tools.disabledMcpServers` list. The legacy session config field
+ *      is left untouched (M5 will drop it).
+ *
+ * The migration is fully idempotent:
+ *   - Table creation uses IF NOT EXISTS.
+ *   - All INSERTs use INSERT OR IGNORE so re-running after a partial run, or
+ *     running on a DB where overrides were already applied, is a no-op.
+ *   - Legacy `room_mcp_enablement` / `GlobalSettings.disabledMcpServers` /
+ *     `SessionConfig.disabledMcpServers` are preserved for this milestone so
+ *     rollback remains trivial. M5 will purge them.
+ */
+export function runMigration101(db: BunDatabase): void {
+	// 1. Create the unified table -------------------------------------------
+	// Schema matches docs/plans/unify-mcp-config-model/00-overview.md exactly:
+	// composite PRIMARY KEY on (server_id, scope_type, scope_id). No surrogate
+	// id / timestamps — callers identify rows by their natural key.
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS mcp_enablement (
+			server_id  TEXT NOT NULL REFERENCES app_mcp_servers(id) ON DELETE CASCADE,
+			scope_type TEXT NOT NULL CHECK (scope_type IN ('space', 'room', 'session')),
+			scope_id   TEXT NOT NULL,
+			enabled    INTEGER NOT NULL CHECK (enabled IN (0, 1)),
+			PRIMARY KEY (server_id, scope_type, scope_id)
+		)
+	`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_mcp_enablement_scope ON mcp_enablement(scope_type, scope_id)`
+	);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_mcp_enablement_server ON mcp_enablement(server_id)`);
+
+	// 2. Copy `room_mcp_enablement` rows as scope='room' --------------------
+	if (tableExists(db, 'room_mcp_enablement')) {
+		const rows = db
+			.prepare(`SELECT room_id, server_id, enabled FROM room_mcp_enablement`)
+			.all() as Array<{ room_id: string; server_id: string; enabled: number }>;
+		const insert = db.prepare(
+			`INSERT OR IGNORE INTO mcp_enablement
+				(server_id, scope_type, scope_id, enabled)
+			 VALUES (?, 'room', ?, ?)`
+		);
+		for (const row of rows) {
+			insert.run(row.server_id, row.room_id, row.enabled ? 1 : 0);
+		}
+	}
+
+	// 3. Seed scope='space' rows from GlobalSettings.disabledMcpServers ------
+	// The legacy global list stores server *names*; resolve each to a server id
+	// via the app_mcp_servers registry. Names with no matching registry entry
+	// are silently skipped — the legacy list predates the registry so orphaned
+	// names are expected.
+	if (
+		tableExists(db, 'global_settings') &&
+		tableExists(db, 'spaces') &&
+		tableExists(db, 'app_mcp_servers')
+	) {
+		try {
+			const settingsRow = db.prepare(`SELECT settings FROM global_settings WHERE id = 1`).get() as
+				| { settings?: string }
+				| undefined;
+			const raw = settingsRow?.settings ?? '{}';
+			const parsed = JSON.parse(raw) as { disabledMcpServers?: unknown };
+			const disabledNames = Array.isArray(parsed.disabledMcpServers)
+				? (parsed.disabledMcpServers.filter(
+						(n) => typeof n === 'string' && n.length > 0
+					) as string[])
+				: [];
+
+			if (disabledNames.length > 0) {
+				const spaceRows = db
+					.prepare(`SELECT id FROM spaces WHERE status = 'active'`)
+					.all() as Array<{ id: string }>;
+
+				const serverByName = db.prepare(`SELECT id FROM app_mcp_servers WHERE name = ?`);
+				const insert = db.prepare(
+					`INSERT OR IGNORE INTO mcp_enablement
+						(server_id, scope_type, scope_id, enabled)
+					 VALUES (?, 'space', ?, 0)`
+				);
+
+				for (const { id: spaceId } of spaceRows) {
+					for (const name of disabledNames) {
+						const srv = serverByName.get(name) as { id?: string } | undefined;
+						if (!srv?.id) continue;
+						insert.run(srv.id, spaceId);
+					}
+				}
+			}
+		} catch {
+			// Defensive: a malformed global_settings row should not break all
+			// later migrations. Leaving the table empty is safe — sessions will
+			// keep using the legacy list until the caller migrates overrides.
+		}
+	}
+
+	// 4. Seed scope='session' rows from each session's disabledMcpServers ----
+	if (tableExists(db, 'sessions') && tableExists(db, 'app_mcp_servers')) {
+		const sessionRows = db.prepare(`SELECT id, config FROM sessions`).all() as Array<{
+			id: string;
+			config: string;
+		}>;
+
+		const serverByName = db.prepare(`SELECT id FROM app_mcp_servers WHERE name = ?`);
+		const insert = db.prepare(
+			`INSERT OR IGNORE INTO mcp_enablement
+				(server_id, scope_type, scope_id, enabled)
+			 VALUES (?, 'session', ?, 0)`
+		);
+
+		for (const row of sessionRows) {
+			let disabledNames: string[] = [];
+			try {
+				const cfg = JSON.parse(row.config ?? '{}') as {
+					tools?: { disabledMcpServers?: unknown };
+					disabledMcpServers?: unknown;
+				};
+				const candidate = cfg.tools?.disabledMcpServers ?? cfg.disabledMcpServers;
+				if (Array.isArray(candidate)) {
+					disabledNames = candidate.filter(
+						(n): n is string => typeof n === 'string' && n.length > 0
+					);
+				}
+			} catch {
+				continue;
+			}
+
+			for (const name of disabledNames) {
+				const srv = serverByName.get(name) as { id?: string } | undefined;
+				if (!srv?.id) continue;
+				insert.run(srv.id, row.id);
+			}
+		}
+	}
 }

--- a/packages/daemon/tests/unit/1-core/neo/neo-agent-manager-all-tools.test.ts
+++ b/packages/daemon/tests/unit/1-core/neo/neo-agent-manager-all-tools.test.ts
@@ -271,6 +271,7 @@ function makeMinimalActionConfig(
 function makeAppMcpManager(configs: Record<string, McpServerConfig> = {}): NeoAppMcpManager {
 	return {
 		getEnabledMcpConfigs: mock(() => configs),
+		getEnabledMcpConfigsForSession: mock(() => configs),
 	};
 }
 

--- a/packages/daemon/tests/unit/1-core/neo/neo-agent-manager-query-tools.test.ts
+++ b/packages/daemon/tests/unit/1-core/neo/neo-agent-manager-query-tools.test.ts
@@ -223,6 +223,7 @@ function makeMinimalToolsConfig(overrides: Partial<NeoToolsConfig> = {}): NeoToo
 function makeAppMcpManager(configs: Record<string, McpServerConfig> = {}): NeoAppMcpManager {
 	return {
 		getEnabledMcpConfigs: mock(() => configs),
+		getEnabledMcpConfigsForSession: mock(() => configs),
 	};
 }
 

--- a/packages/daemon/tests/unit/2-handlers/mcp/app-mcp-lifecycle-manager.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/mcp/app-mcp-lifecycle-manager.test.ts
@@ -16,6 +16,7 @@ import { createTables } from '../../../../src/storage/schema';
 import { createReactiveDatabase } from '../../../../src/storage/reactive-database';
 import { AppMcpServerRepository } from '../../../../src/storage/repositories/app-mcp-server-repository';
 import { RoomMcpEnablementRepository } from '../../../../src/storage/repositories/room-mcp-enablement-repository';
+import { McpEnablementRepository } from '../../../../src/storage/repositories/mcp-enablement-repository';
 import { AppMcpLifecycleManager } from '../../../../src/lib/mcp';
 import type { ReactiveDatabase } from '../../../../src/storage/reactive-database';
 import type { Database } from '../../../../src/storage/database';
@@ -30,11 +31,13 @@ function createTestDb(): { bunDb: BunDatabase; reactiveDb: ReactiveDatabase; db:
 	const reactiveDb = createReactiveDatabase({ getDatabase: () => bunDb } as never);
 	const appMcpServerRepo = new AppMcpServerRepository(bunDb, reactiveDb);
 	const roomMcpEnablementRepo = new RoomMcpEnablementRepository(bunDb, reactiveDb);
+	const mcpEnablementRepo = new McpEnablementRepository(bunDb, reactiveDb);
 
 	// Build a minimal Database facade that exposes both repositories
 	const db = {
 		appMcpServers: appMcpServerRepo,
 		roomMcpEnablement: roomMcpEnablementRepo,
+		mcpEnablement: mcpEnablementRepo,
 	} as unknown as Database;
 
 	return { bunDb, reactiveDb, db };
@@ -532,6 +535,104 @@ describe('AppMcpLifecycleManager', () => {
 			// Now falls back to global (which includes reset-test since it's globally enabled)
 			configs = manager.getEnabledMcpConfigsForRoom('room-reset');
 			expect(configs['reset-test']).toBeDefined();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// getEnabledMcpConfigsForSession — unified scope-aware resolver
+	// -------------------------------------------------------------------------
+
+	describe('getEnabledMcpConfigsForSession', () => {
+		test('falls back to registry defaults when no overrides exist', () => {
+			repo.create({ name: 'on-by-default', sourceType: 'stdio', command: 'x', enabled: true });
+			repo.create({ name: 'off-by-default', sourceType: 'stdio', command: 'x', enabled: false });
+
+			const configs = manager.getEnabledMcpConfigsForSession({
+				id: 'sess-1',
+				context: { spaceId: 'space-1', roomId: 'room-1' },
+			});
+
+			expect(configs['on-by-default']).toBeDefined();
+			expect(configs['off-by-default']).toBeUndefined();
+		});
+
+		test('space override can disable a registry-enabled server', () => {
+			const server = repo.create({
+				name: 'space-disabled',
+				sourceType: 'stdio',
+				command: 'x',
+				enabled: true,
+			});
+			db.mcpEnablement.setOverride('space', 'space-1', server.id, false);
+
+			const configs = manager.getEnabledMcpConfigsForSession({
+				id: 'sess-1',
+				context: { spaceId: 'space-1' },
+			});
+
+			expect(configs['space-disabled']).toBeUndefined();
+		});
+
+		test('session override beats room override beats space override', () => {
+			const server = repo.create({
+				name: 'contested',
+				sourceType: 'stdio',
+				command: 'x',
+				enabled: true,
+			});
+
+			db.mcpEnablement.setOverride('space', 'space-1', server.id, false);
+			// Room override re-enables it — should win over space.
+			db.mcpEnablement.setOverride('room', 'room-1', server.id, true);
+
+			const sessionCtx = { spaceId: 'space-1', roomId: 'room-1' };
+			expect(
+				manager.getEnabledMcpConfigsForSession({ id: 'sess-1', context: sessionCtx })['contested']
+			).toBeDefined();
+
+			// Session override now disables it — should win over room + space.
+			db.mcpEnablement.setOverride('session', 'sess-1', server.id, false);
+			expect(
+				manager.getEnabledMcpConfigsForSession({ id: 'sess-1', context: sessionCtx })['contested']
+			).toBeUndefined();
+
+			// A second session without the session-level override still sees it
+			// (room override takes effect).
+			expect(
+				manager.getEnabledMcpConfigsForSession({ id: 'sess-2', context: sessionCtx })['contested']
+			).toBeDefined();
+		});
+
+		test('invalid entries are filtered out even when explicitly enabled', () => {
+			const broken = repo.create({
+				name: 'broken',
+				sourceType: 'stdio',
+				// missing command — invalid
+				enabled: true,
+			});
+			db.mcpEnablement.setOverride('session', 'sess-1', broken.id, true);
+
+			const configs = manager.getEnabledMcpConfigsForSession({
+				id: 'sess-1',
+				context: { spaceId: 'space-1' },
+			});
+
+			expect(configs['broken']).toBeUndefined();
+		});
+
+		test('context-less sessions see only registry defaults (neo path)', () => {
+			const server = repo.create({
+				name: 'global',
+				sourceType: 'stdio',
+				command: 'x',
+				enabled: true,
+			});
+			// This override belongs to some space the neo session is not in.
+			db.mcpEnablement.setOverride('space', 'some-space', server.id, false);
+
+			const configs = manager.getEnabledMcpConfigsForSession({ id: 'neo:global' });
+
+			expect(configs['global']).toBeDefined();
 		});
 	});
 });

--- a/packages/daemon/tests/unit/2-handlers/mcp/resolve-mcp-servers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/mcp/resolve-mcp-servers.test.ts
@@ -1,0 +1,221 @@
+/**
+ * resolveMcpServers precedence-matrix tests.
+ *
+ * The resolver is intentionally pure; these tests hand it synthetic registry
+ * rows + overrides (no database) and verify that the session > room > space >
+ * registry-default precedence chain is honoured regardless of which combinations
+ * of overrides are present.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+	resolveMcpServers,
+	scopeChainForSession,
+} from '../../../../src/lib/mcp/resolve-mcp-servers';
+import type { AppMcpServer, McpEnablementOverride } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Tiny builders to keep each test concise
+// ---------------------------------------------------------------------------
+
+function server(id: string, enabled: boolean, partial: Partial<AppMcpServer> = {}): AppMcpServer {
+	return {
+		id,
+		name: partial.name ?? id,
+		sourceType: partial.sourceType ?? 'stdio',
+		command: 'echo',
+		enabled,
+		createdAt: 1,
+		updatedAt: 1,
+		...partial,
+	};
+}
+
+function override(
+	scopeType: 'space' | 'room' | 'session',
+	scopeId: string,
+	serverId: string,
+	enabled: boolean
+): McpEnablementOverride {
+	return { scopeType, scopeId, serverId, enabled };
+}
+
+const SESSION_ID = 'sess-1';
+const ROOM_ID = 'room-1';
+const SPACE_ID = 'space-1';
+
+const session = {
+	id: SESSION_ID,
+	context: { spaceId: SPACE_ID, roomId: ROOM_ID },
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('resolveMcpServers', () => {
+	describe('registry default (no overrides)', () => {
+		test('returns only servers whose registry enabled flag is true', () => {
+			const registry = [server('a', true), server('b', false), server('c', true)];
+			const result = resolveMcpServers(session, registry, []);
+			expect(result.map((r) => r.id)).toEqual(['a', 'c']);
+		});
+
+		test('empty registry returns empty array', () => {
+			expect(resolveMcpServers(session, [], [])).toEqual([]);
+		});
+
+		test('preserves the registry input ordering', () => {
+			const registry = [server('z', true), server('a', true), server('m', true)];
+			const result = resolveMcpServers(session, registry, []);
+			expect(result.map((r) => r.id)).toEqual(['z', 'a', 'm']);
+		});
+	});
+
+	describe('space override', () => {
+		test("can disable a registry-enabled server for the session's space", () => {
+			const registry = [server('a', true)];
+			const overrides = [override('space', SPACE_ID, 'a', false)];
+			expect(resolveMcpServers(session, registry, overrides)).toEqual([]);
+		});
+
+		test("can enable a registry-disabled server for the session's space", () => {
+			const registry = [server('a', false)];
+			const overrides = [override('space', SPACE_ID, 'a', true)];
+			expect(resolveMcpServers(session, registry, overrides).map((r) => r.id)).toEqual(['a']);
+		});
+
+		test('ignores space overrides for a different space', () => {
+			const registry = [server('a', true)];
+			const overrides = [override('space', 'other-space', 'a', false)];
+			expect(resolveMcpServers(session, registry, overrides).map((r) => r.id)).toEqual(['a']);
+		});
+	});
+
+	describe('room override precedence (room > space)', () => {
+		test('room enable wins over space disable', () => {
+			const registry = [server('a', false)];
+			const overrides = [
+				override('space', SPACE_ID, 'a', false),
+				override('room', ROOM_ID, 'a', true),
+			];
+			expect(resolveMcpServers(session, registry, overrides).map((r) => r.id)).toEqual(['a']);
+		});
+
+		test('room disable wins over space enable', () => {
+			const registry = [server('a', false)];
+			const overrides = [
+				override('space', SPACE_ID, 'a', true),
+				override('room', ROOM_ID, 'a', false),
+			];
+			expect(resolveMcpServers(session, registry, overrides)).toEqual([]);
+		});
+
+		test('ignores room overrides for a different room', () => {
+			const registry = [server('a', true)];
+			const overrides = [override('room', 'other-room', 'a', false)];
+			expect(resolveMcpServers(session, registry, overrides).map((r) => r.id)).toEqual(['a']);
+		});
+	});
+
+	describe('session override precedence (session > room > space)', () => {
+		test('session enable wins over room + space disable', () => {
+			const registry = [server('a', false)];
+			const overrides = [
+				override('space', SPACE_ID, 'a', false),
+				override('room', ROOM_ID, 'a', false),
+				override('session', SESSION_ID, 'a', true),
+			];
+			expect(resolveMcpServers(session, registry, overrides).map((r) => r.id)).toEqual(['a']);
+		});
+
+		test('session disable wins over room + space enable', () => {
+			const registry = [server('a', true)];
+			const overrides = [
+				override('space', SPACE_ID, 'a', true),
+				override('room', ROOM_ID, 'a', true),
+				override('session', SESSION_ID, 'a', false),
+			];
+			expect(resolveMcpServers(session, registry, overrides)).toEqual([]);
+		});
+
+		test('ignores session overrides for a different session', () => {
+			const registry = [server('a', true)];
+			const overrides = [override('session', 'other-session', 'a', false)];
+			expect(resolveMcpServers(session, registry, overrides).map((r) => r.id)).toEqual(['a']);
+		});
+	});
+
+	describe('multiple servers, mixed overrides', () => {
+		test('applies the correct rule per-server in a single call', () => {
+			const registry = [
+				server('reg-on', true),
+				server('reg-off', false),
+				server('space-off', true),
+				server('room-on', false),
+				server('session-on', false),
+				server('session-off', true),
+			];
+			const overrides = [
+				override('space', SPACE_ID, 'space-off', false),
+				override('room', ROOM_ID, 'room-on', true),
+				override('session', SESSION_ID, 'session-on', true),
+				override('session', SESSION_ID, 'session-off', false),
+				// noise rows that must be ignored
+				override('space', 'other-space', 'reg-on', false),
+				override('room', 'other-room', 'reg-on', false),
+				override('session', 'other-session', 'reg-on', false),
+			];
+			const ids = resolveMcpServers(session, registry, overrides).map((r) => r.id);
+			expect(ids).toEqual(['reg-on', 'room-on', 'session-on']);
+		});
+	});
+
+	describe('context-less sessions (neo / adhoc)', () => {
+		test('falls back entirely to registry defaults when no space/room', () => {
+			const registry = [server('a', true), server('b', false)];
+			const overrides = [
+				override('space', SPACE_ID, 'a', false),
+				override('room', ROOM_ID, 'b', true),
+			];
+			const result = resolveMcpServers({ id: 'neo:global' }, registry, overrides);
+			expect(result.map((r) => r.id)).toEqual(['a']);
+		});
+
+		test('session override still applies to context-less sessions', () => {
+			const registry = [server('a', false)];
+			const overrides = [override('session', 'neo:global', 'a', true)];
+			const result = resolveMcpServers({ id: 'neo:global' }, registry, overrides);
+			expect(result.map((r) => r.id)).toEqual(['a']);
+		});
+	});
+
+	describe('scopeChainForSession', () => {
+		test('returns every scope the session has', () => {
+			const chain = scopeChainForSession(session);
+			expect(chain).toEqual([
+				{ scopeType: 'session', scopeId: SESSION_ID },
+				{ scopeType: 'room', scopeId: ROOM_ID },
+				{ scopeType: 'space', scopeId: SPACE_ID },
+			]);
+		});
+
+		test('omits scopes without an id', () => {
+			const chain = scopeChainForSession({ id: 'neo:global' });
+			expect(chain).toEqual([{ scopeType: 'session', scopeId: 'neo:global' }]);
+		});
+
+		test('keeps session-only and space-only cases distinct', () => {
+			const roomOnly = scopeChainForSession({ id: 's', context: { roomId: 'r' } });
+			expect(roomOnly).toEqual([
+				{ scopeType: 'session', scopeId: 's' },
+				{ scopeType: 'room', scopeId: 'r' },
+			]);
+			const spaceOnly = scopeChainForSession({ id: 's', context: { spaceId: 'sp' } });
+			expect(spaceOnly).toEqual([
+				{ scopeType: 'session', scopeId: 's' },
+				{ scopeType: 'space', scopeId: 'sp' },
+			]);
+		});
+	});
+});

--- a/packages/daemon/tests/unit/2-handlers/room/room-runtime-service-mcp.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/room/room-runtime-service-mcp.test.ts
@@ -95,6 +95,7 @@ describe('RoomRuntimeService MCP merge — setupRoomAgentSession', () => {
 		const appMcpManager = {
 			getEnabledMcpConfigs: () => ({ 'registry-server': registryServer }),
 			getEnabledMcpConfigsForRoom: () => ({ 'registry-server': registryServer }),
+			getEnabledMcpConfigsForSession: () => ({ 'registry-server': registryServer }),
 		};
 
 		const setRuntimeMcpServersCalls: Array<Record<string, McpServerConfig>> = [];
@@ -178,6 +179,7 @@ describe('RoomRuntimeService MCP merge — setupRoomAgentSession', () => {
 		const appMcpManager = {
 			getEnabledMcpConfigs: () => ({ 'room-agent-tools': conflictingServer }),
 			getEnabledMcpConfigsForRoom: () => ({ 'room-agent-tools': conflictingServer }),
+			getEnabledMcpConfigsForSession: () => ({ 'room-agent-tools': conflictingServer }),
 		};
 
 		const setRuntimeMcpServersCalls: Array<Record<string, McpServerConfig>> = [];
@@ -248,6 +250,7 @@ describe('RoomRuntimeService MCP merge — setupRoomAgentSession', () => {
 		const appMcpManager = {
 			getEnabledMcpConfigs: () => ({ 'registry-mcp': registryServer }),
 			getEnabledMcpConfigsForRoom: () => ({ 'registry-mcp': registryServer }),
+			getEnabledMcpConfigsForSession: () => ({ 'registry-mcp': registryServer }),
 		};
 
 		const settingsManager = {
@@ -396,6 +399,7 @@ describe('RoomRuntimeService — mcp.registry.changed hot-reload', () => {
 		const appMcpManager = {
 			getEnabledMcpConfigs: () => ({ 'hot-server': registryServer }),
 			getEnabledMcpConfigsForRoom: () => ({ 'hot-server': registryServer }),
+			getEnabledMcpConfigsForSession: () => ({ 'hot-server': registryServer }),
 		};
 
 		const setRuntimeMcpServersCalls: Array<Record<string, McpServerConfig>> = [];
@@ -479,6 +483,7 @@ describe('RoomRuntimeService — mcp.registry.changed hot-reload', () => {
 		const appMcpManager = {
 			getEnabledMcpConfigs: () => ({ 'reg-server': registryServer }),
 			getEnabledMcpConfigsForRoom: () => ({ 'reg-server': registryServer }),
+			getEnabledMcpConfigsForSession: () => ({ 'reg-server': registryServer }),
 		};
 
 		const setRuntimeMcpServersCalls: Array<Record<string, McpServerConfig>> = [];
@@ -561,6 +566,7 @@ describe('RoomRuntimeService — mcp.registry.changed hot-reload', () => {
 		const appMcpManager = {
 			getEnabledMcpConfigs: () => ({}),
 			getEnabledMcpConfigsForRoom: () => ({}),
+			getEnabledMcpConfigsForSession: () => ({}),
 		};
 
 		const service = new RoomRuntimeService(
@@ -603,6 +609,7 @@ describe('RoomRuntimeService MCP merge — collision resolution', () => {
 		const appMcpManager = {
 			getEnabledMcpConfigs: () => ({ 'shared-name': registryServer }),
 			getEnabledMcpConfigsForRoom: () => ({ 'shared-name': registryServer }),
+			getEnabledMcpConfigsForSession: () => ({ 'shared-name': registryServer }),
 		};
 
 		const settingsManager = {

--- a/packages/daemon/tests/unit/2-handlers/room/room-runtime-service-worker-mcp.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/room/room-runtime-service-worker-mcp.test.ts
@@ -109,7 +109,10 @@ async function buildSessionFactory(opts: {
 	};
 
 	const appMcpManager = hasAppMcpManager
-		? { getEnabledMcpConfigs: () => registryMcpServers }
+		? {
+				getEnabledMcpConfigs: () => registryMcpServers,
+				getEnabledMcpConfigsForSession: () => registryMcpServers,
+			}
 		: undefined;
 
 	// Build a minimal RoomRuntimeService config

--- a/packages/daemon/tests/unit/2-handlers/room/room-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/room/room-runtime-service.test.ts
@@ -1047,7 +1047,10 @@ describe('SessionFactory.restoreSession — worker MCP injection and skills', ()
 				getEnabledMcpServersConfig: mock(() => overrides.fileMcpServers ?? {}),
 			} as never,
 			appMcpManager: overrides.registryMcpServers
-				? { getEnabledMcpConfigs: mock(() => overrides.registryMcpServers) }
+				? {
+						getEnabledMcpConfigs: mock(() => overrides.registryMcpServers),
+						getEnabledMcpConfigsForSession: mock(() => overrides.registryMcpServers),
+					}
 				: undefined,
 			skillsManager: overrides.skillsManager as never,
 			appMcpServerRepo: overrides.appMcpServerRepo as never,

--- a/packages/daemon/tests/unit/4-space-storage/storage/database-core.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/database-core.test.ts
@@ -291,8 +291,13 @@ describe('DatabaseCore', () => {
 			// This should work - the directory will be created
 			// Use process.env.TMPDIR to support custom temp directory setups
 			const tmpBase = (process.env.TMPDIR || '/tmp').replace(/\/$/, '');
-			dbCore = new DatabaseCore(`${tmpBase}/test-db-core-invalid/test.db`);
-			await expect(dbCore.initialize()).resolves.toBeUndefined();
+			const invalidPath = `${tmpBase}/test-db-core-invalid`;
+			// The test doesn't use the `testDir` helper so ensure leftover state
+			// from a previous run can't poison a fresh initialize (the migration
+			// pipeline assumes tables match current schema).
+			rmSync(invalidPath, { recursive: true, force: true });
+			dbCore = new DatabaseCore(`${invalidPath}/test.db`);
+			await dbCore.initialize();
 		});
 	});
 

--- a/packages/daemon/tests/unit/4-space-storage/storage/mcp-enablement-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/mcp-enablement-repository.test.ts
@@ -1,0 +1,234 @@
+/**
+ * McpEnablementRepository Unit Tests
+ *
+ * Covers CRUD + list queries on the unified mcp_enablement override table, the
+ * composite primary key (server_id, scope_type, scope_id), and the
+ * notifyChange('mcp_enablement') reactivity contract that LiveQueryEngine
+ * relies on.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { createTables } from '../../../../src/storage/schema';
+import {
+	createReactiveDatabase,
+	type ReactiveDatabase,
+} from '../../../../src/storage/reactive-database';
+import { AppMcpServerRepository } from '../../../../src/storage/repositories/app-mcp-server-repository';
+import { McpEnablementRepository } from '../../../../src/storage/repositories/mcp-enablement-repository';
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+describe('McpEnablementRepository', () => {
+	let bunDb: BunDatabase;
+	let reactiveDb: ReactiveDatabase;
+	let notifyChangeSpy: ReturnType<typeof mock>;
+	let appMcpRepo: AppMcpServerRepository;
+	let repo: McpEnablementRepository;
+	let serverA: string;
+	let serverB: string;
+
+	beforeEach(() => {
+		bunDb = new BunDatabase(':memory:');
+		createTables(bunDb);
+
+		reactiveDb = createReactiveDatabase({ getDatabase: () => bunDb } as never);
+		notifyChangeSpy = mock(() => {});
+		reactiveDb.notifyChange = notifyChangeSpy;
+
+		appMcpRepo = new AppMcpServerRepository(bunDb, reactiveDb);
+		repo = new McpEnablementRepository(bunDb, reactiveDb);
+
+		serverA = appMcpRepo.create({ name: 'server-a', sourceType: 'stdio', command: 'echo' }).id;
+		serverB = appMcpRepo.create({ name: 'server-b', sourceType: 'stdio', command: 'echo' }).id;
+	});
+
+	afterEach(() => {
+		bunDb.close();
+	});
+
+	// ---------------------------------------------------------------------------
+	// setOverride
+	// ---------------------------------------------------------------------------
+
+	describe('setOverride', () => {
+		test('inserts a new row and returns it', () => {
+			notifyChangeSpy.mockClear();
+			const override = repo.setOverride('space', 'space-1', serverA, false);
+
+			expect(override.scopeType).toBe('space');
+			expect(override.scopeId).toBe('space-1');
+			expect(override.serverId).toBe(serverA);
+			expect(override.enabled).toBe(false);
+
+			expect(notifyChangeSpy).toHaveBeenCalledTimes(1);
+			expect(notifyChangeSpy).toHaveBeenCalledWith('mcp_enablement');
+		});
+
+		test('updates an existing row (does not duplicate)', () => {
+			repo.setOverride('room', 'room-1', serverA, true);
+			const second = repo.setOverride('room', 'room-1', serverA, false);
+
+			expect(second.enabled).toBe(false);
+
+			const all = repo.listForScope('room', 'room-1');
+			expect(all).toHaveLength(1);
+			expect(all[0].enabled).toBe(false);
+		});
+
+		test('notifies on update too', () => {
+			repo.setOverride('space', 'space-x', serverA, true);
+			notifyChangeSpy.mockClear();
+			repo.setOverride('space', 'space-x', serverA, false);
+			expect(notifyChangeSpy).toHaveBeenCalledTimes(1);
+			expect(notifyChangeSpy).toHaveBeenCalledWith('mcp_enablement');
+		});
+
+		test('distinct scopes for the same server do not conflict', () => {
+			repo.setOverride('space', 'space-1', serverA, false);
+			repo.setOverride('room', 'room-1', serverA, true);
+			repo.setOverride('session', 'sess-1', serverA, false);
+
+			expect(repo.listForServer(serverA)).toHaveLength(3);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// getOverride
+	// ---------------------------------------------------------------------------
+
+	describe('getOverride', () => {
+		test('returns the row when present', () => {
+			repo.setOverride('room', 'room-1', serverA, true);
+			const row = repo.getOverride('room', 'room-1', serverA);
+			expect(row).not.toBeNull();
+			expect(row!.enabled).toBe(true);
+		});
+
+		test('returns null when missing', () => {
+			expect(repo.getOverride('room', 'no-such-room', serverA)).toBeNull();
+		});
+
+		test('does not leak overrides across scope types with the same id', () => {
+			repo.setOverride('space', 'shared-id', serverA, true);
+			expect(repo.getOverride('room', 'shared-id', serverA)).toBeNull();
+			expect(repo.getOverride('session', 'shared-id', serverA)).toBeNull();
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// list queries
+	// ---------------------------------------------------------------------------
+
+	describe('listForScope / listForServer / listAll / listForScopes', () => {
+		beforeEach(() => {
+			repo.setOverride('space', 'space-1', serverA, false);
+			repo.setOverride('space', 'space-1', serverB, true);
+			repo.setOverride('room', 'room-1', serverA, true);
+			repo.setOverride('session', 'sess-1', serverB, false);
+		});
+
+		test('listForScope returns every row at that scope only', () => {
+			const spaceRows = repo.listForScope('space', 'space-1');
+			expect(spaceRows.map((r) => r.serverId).sort()).toEqual([serverA, serverB].sort());
+			expect(repo.listForScope('space', 'other')).toEqual([]);
+		});
+
+		test('listForServer returns every override targeting a server', () => {
+			const rows = repo.listForServer(serverA);
+			// serverA has two overrides: space:space-1 and room:room-1
+			expect(rows).toHaveLength(2);
+			expect(rows.map((r) => r.scopeType).sort()).toEqual(['room', 'space']);
+		});
+
+		test('listAll returns every override', () => {
+			expect(repo.listAll()).toHaveLength(4);
+		});
+
+		test('listForScopes filters to only the scopes passed in', () => {
+			const rows = repo.listForScopes([
+				{ scopeType: 'session', scopeId: 'sess-1' },
+				{ scopeType: 'space', scopeId: 'space-1' },
+			]);
+			// Excludes the room:room-1 row, includes the 2 space:space-1 rows + 1 session row.
+			expect(rows).toHaveLength(3);
+			const byScope = rows.reduce<Record<string, number>>((acc, r) => {
+				acc[r.scopeType] = (acc[r.scopeType] ?? 0) + 1;
+				return acc;
+			}, {});
+			expect(byScope).toEqual({ space: 2, session: 1 });
+		});
+
+		test('listForScopes returns [] when given an empty chain', () => {
+			expect(repo.listForScopes([])).toEqual([]);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// clearOverride
+	// ---------------------------------------------------------------------------
+
+	describe('clearOverride', () => {
+		test('deletes the row and returns true', () => {
+			repo.setOverride('session', 'sess-1', serverA, false);
+			notifyChangeSpy.mockClear();
+
+			const deleted = repo.clearOverride('session', 'sess-1', serverA);
+			expect(deleted).toBe(true);
+			expect(repo.getOverride('session', 'sess-1', serverA)).toBeNull();
+			expect(notifyChangeSpy).toHaveBeenCalledTimes(1);
+			expect(notifyChangeSpy).toHaveBeenCalledWith('mcp_enablement');
+		});
+
+		test('returns false and does not notify when nothing to delete', () => {
+			notifyChangeSpy.mockClear();
+			const deleted = repo.clearOverride('session', 'nobody', serverA);
+			expect(deleted).toBe(false);
+			expect(notifyChangeSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// clearScope
+	// ---------------------------------------------------------------------------
+
+	describe('clearScope', () => {
+		test('deletes every row at that scope, returns count, and notifies once', () => {
+			repo.setOverride('room', 'room-cleanup', serverA, false);
+			repo.setOverride('room', 'room-cleanup', serverB, true);
+			repo.setOverride('room', 'room-keep', serverA, false);
+			notifyChangeSpy.mockClear();
+
+			const count = repo.clearScope('room', 'room-cleanup');
+			expect(count).toBe(2);
+			expect(repo.listForScope('room', 'room-cleanup')).toEqual([]);
+			expect(repo.listForScope('room', 'room-keep')).toHaveLength(1);
+			expect(notifyChangeSpy).toHaveBeenCalledTimes(1);
+			expect(notifyChangeSpy).toHaveBeenCalledWith('mcp_enablement');
+		});
+
+		test('returns 0 and does not notify when nothing matches', () => {
+			notifyChangeSpy.mockClear();
+			expect(repo.clearScope('space', 'empty')).toBe(0);
+			expect(notifyChangeSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// FK cascade: deleting a server removes its overrides
+	// ---------------------------------------------------------------------------
+
+	describe('foreign key cascade', () => {
+		test('deleting the underlying app_mcp_servers row removes overrides', () => {
+			bunDb.exec('PRAGMA foreign_keys = ON');
+			repo.setOverride('space', 'space-1', serverA, false);
+			repo.setOverride('room', 'room-1', serverA, true);
+
+			expect(appMcpRepo.delete(serverA)).toBe(true);
+
+			expect(repo.listForServer(serverA)).toEqual([]);
+		});
+	});
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/migration-101-mcp-enablement.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migration-101-mcp-enablement.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Migration 101 — mcp_enablement seeding tests.
+ *
+ * Verifies that runMigration101:
+ *   1. Creates the `mcp_enablement` table + indexes idempotently.
+ *   2. Copies legacy `room_mcp_enablement` rows as scope='room' overrides.
+ *   3. Seeds scope='space' disable rows from `GlobalSettings.disabledMcpServers`
+ *      for each active space, resolving server names to registry ids.
+ *   4. Seeds scope='session' disable rows from each session's
+ *      `config.tools.disabledMcpServers`.
+ *   5. Ignores orphan names that no registry entry exists for.
+ *   6. Is safe to run twice (idempotent — INSERT OR IGNORE).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigration101 } from '../../../../src/storage/schema';
+
+// ---------------------------------------------------------------------------
+// Minimal schema — only the tables M100 reads/writes.
+// ---------------------------------------------------------------------------
+
+function createMinimalSchema(db: BunDatabase): void {
+	db.exec('PRAGMA foreign_keys = ON');
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS app_mcp_servers (
+			id TEXT PRIMARY KEY,
+			name TEXT UNIQUE NOT NULL,
+			source_type TEXT NOT NULL,
+			command TEXT,
+			enabled INTEGER NOT NULL DEFAULT 1,
+			created_at INTEGER,
+			updated_at INTEGER
+		)
+	`);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS rooms (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		)
+	`);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS room_mcp_enablement (
+			room_id TEXT NOT NULL REFERENCES rooms(id) ON DELETE CASCADE,
+			server_id TEXT NOT NULL REFERENCES app_mcp_servers(id) ON DELETE CASCADE,
+			enabled INTEGER NOT NULL DEFAULT 1,
+			PRIMARY KEY (room_id, server_id)
+		)
+	`);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS spaces (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'active',
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		)
+	`);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS global_settings (
+			id INTEGER PRIMARY KEY CHECK (id = 1),
+			settings TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		)
+	`);
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS sessions (
+			id TEXT PRIMARY KEY,
+			title TEXT NOT NULL DEFAULT '',
+			config TEXT NOT NULL DEFAULT '{}',
+			created_at TEXT NOT NULL DEFAULT '',
+			last_active_at TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'active',
+			metadata TEXT NOT NULL DEFAULT '{}'
+		)
+	`);
+}
+
+function insertServer(db: BunDatabase, id: string, name: string): void {
+	db.prepare(
+		`INSERT INTO app_mcp_servers (id, name, source_type, enabled) VALUES (?, ?, 'stdio', 1)`
+	).run(id, name);
+}
+
+function insertRoom(db: BunDatabase, id: string): void {
+	db.prepare(`INSERT INTO rooms (id, name, created_at, updated_at) VALUES (?, ?, 0, 0)`).run(
+		id,
+		id
+	);
+}
+
+function insertSpace(db: BunDatabase, id: string, status: 'active' | 'archived' = 'active'): void {
+	db.prepare(
+		`INSERT INTO spaces (id, name, status, created_at, updated_at) VALUES (?, ?, ?, 0, 0)`
+	).run(id, id, status);
+}
+
+function setGlobalSettings(db: BunDatabase, settings: Record<string, unknown>): void {
+	db.prepare(
+		`INSERT OR REPLACE INTO global_settings (id, settings, updated_at) VALUES (1, ?, '')`
+	).run(JSON.stringify(settings));
+}
+
+function insertSession(db: BunDatabase, id: string, config: Record<string, unknown>): void {
+	db.prepare(
+		`INSERT INTO sessions (id, config, created_at, last_active_at) VALUES (?, ?, '', '')`
+	).run(id, JSON.stringify(config));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Migration 100: mcp_enablement seeding', () => {
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		db = new BunDatabase(':memory:');
+		createMinimalSchema(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	// --- Table creation ----------------------------------------------------
+
+	test('creates the mcp_enablement table with the expected shape', () => {
+		runMigration101(db);
+
+		const tbl = db
+			.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='mcp_enablement'`)
+			.get();
+		expect(tbl).not.toBeNull();
+
+		const cols = db.prepare(`PRAGMA table_info(mcp_enablement)`).all() as Array<{ name: string }>;
+		const names = cols.map((c) => c.name).sort();
+		expect(names).toEqual(['enabled', 'scope_id', 'scope_type', 'server_id'].sort());
+
+		// Composite PK — second insert with same (server, scope, scope_id) fails.
+		insertServer(db, 'srv-1', 'srv-1');
+		db.prepare(
+			`INSERT INTO mcp_enablement (server_id, scope_type, scope_id, enabled)
+			 VALUES ('srv-1', 'space', 'sp-1', 0)`
+		).run();
+		expect(() =>
+			db
+				.prepare(
+					`INSERT INTO mcp_enablement (server_id, scope_type, scope_id, enabled)
+					 VALUES ('srv-1', 'space', 'sp-1', 0)`
+				)
+				.run()
+		).toThrow();
+	});
+
+	test('is idempotent when run twice on an empty database', () => {
+		runMigration101(db);
+		// Second run should not throw.
+		expect(() => runMigration101(db)).not.toThrow();
+	});
+
+	// --- scope='room' copy from room_mcp_enablement ------------------------
+
+	test('copies room_mcp_enablement rows as scope=room overrides', () => {
+		insertServer(db, 'srv-1', 'srv-1');
+		insertRoom(db, 'room-1');
+		db.prepare(
+			`INSERT INTO room_mcp_enablement (room_id, server_id, enabled) VALUES ('room-1', 'srv-1', 0)`
+		).run();
+
+		runMigration101(db);
+
+		const rows = db
+			.prepare(`SELECT scope_type, scope_id, server_id, enabled FROM mcp_enablement`)
+			.all() as Array<{
+			scope_type: string;
+			scope_id: string;
+			server_id: string;
+			enabled: number;
+		}>;
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toEqual({
+			scope_type: 'room',
+			scope_id: 'room-1',
+			server_id: 'srv-1',
+			enabled: 0,
+		});
+	});
+
+	test('does not duplicate scope=room rows on re-run', () => {
+		insertServer(db, 'srv-1', 'srv-1');
+		insertRoom(db, 'room-1');
+		db.prepare(
+			`INSERT INTO room_mcp_enablement (room_id, server_id, enabled) VALUES ('room-1', 'srv-1', 1)`
+		).run();
+
+		runMigration101(db);
+		runMigration101(db);
+
+		const count = (db.prepare(`SELECT COUNT(*) AS c FROM mcp_enablement`).get() as { c: number }).c;
+		expect(count).toBe(1);
+	});
+
+	// --- scope='space' seed from GlobalSettings.disabledMcpServers ---------
+
+	test('seeds scope=space disable rows for every active space from global settings', () => {
+		insertServer(db, 'srv-1', 'brave-search');
+		insertServer(db, 'srv-2', 'playwright');
+		insertSpace(db, 'space-active-1');
+		insertSpace(db, 'space-active-2');
+		insertSpace(db, 'space-archived', 'archived');
+		setGlobalSettings(db, { disabledMcpServers: ['brave-search', 'playwright'] });
+
+		runMigration101(db);
+
+		const spaceRows = db
+			.prepare(
+				`SELECT scope_id, server_id, enabled FROM mcp_enablement WHERE scope_type='space' ORDER BY scope_id, server_id`
+			)
+			.all() as Array<{ scope_id: string; server_id: string; enabled: number }>;
+		expect(spaceRows).toHaveLength(4);
+		for (const row of spaceRows) {
+			expect(row.enabled).toBe(0);
+			expect(['space-active-1', 'space-active-2']).toContain(row.scope_id);
+		}
+
+		// Archived spaces must not be seeded.
+		const archivedCount = (
+			db
+				.prepare(
+					`SELECT COUNT(*) AS c FROM mcp_enablement WHERE scope_type='space' AND scope_id='space-archived'`
+				)
+				.get() as { c: number }
+		).c;
+		expect(archivedCount).toBe(0);
+	});
+
+	test('silently skips disabledMcpServers entries with no matching registry row', () => {
+		insertServer(db, 'srv-1', 'real-server');
+		insertSpace(db, 'space-1');
+		setGlobalSettings(db, { disabledMcpServers: ['real-server', 'ghost-server'] });
+
+		runMigration101(db);
+
+		const rows = db
+			.prepare(`SELECT server_id FROM mcp_enablement WHERE scope_type='space'`)
+			.all() as Array<{ server_id: string }>;
+		expect(rows).toHaveLength(1);
+		expect(rows[0].server_id).toBe('srv-1');
+	});
+
+	test('does nothing when global settings has no disabledMcpServers', () => {
+		insertSpace(db, 'space-1');
+		setGlobalSettings(db, { some: 'other', shape: 123 });
+
+		runMigration101(db);
+
+		const rows = db
+			.prepare(`SELECT COUNT(*) AS c FROM mcp_enablement WHERE scope_type='space'`)
+			.get() as { c: number };
+		expect(rows.c).toBe(0);
+	});
+
+	test('tolerates malformed global_settings JSON without throwing', () => {
+		insertSpace(db, 'space-1');
+		// Bypass helper to write a literally invalid JSON payload.
+		db.prepare(
+			`INSERT OR REPLACE INTO global_settings (id, settings, updated_at) VALUES (1, ?, '')`
+		).run('not-json {{');
+
+		expect(() => runMigration101(db)).not.toThrow();
+		const rows = db
+			.prepare(`SELECT COUNT(*) AS c FROM mcp_enablement WHERE scope_type='space'`)
+			.get() as { c: number };
+		expect(rows.c).toBe(0);
+	});
+
+	// --- scope='session' seed from session.config.tools.disabledMcpServers --
+
+	test('seeds scope=session disable rows for each session', () => {
+		insertServer(db, 'srv-1', 'brave-search');
+		insertServer(db, 'srv-2', 'playwright');
+		insertSession(db, 'sess-a', { tools: { disabledMcpServers: ['brave-search'] } });
+		insertSession(db, 'sess-b', {
+			tools: { disabledMcpServers: ['brave-search', 'playwright'] },
+		});
+		insertSession(db, 'sess-c', {});
+
+		runMigration101(db);
+
+		const rows = db
+			.prepare(
+				`SELECT scope_id, server_id, enabled FROM mcp_enablement WHERE scope_type='session' ORDER BY scope_id, server_id`
+			)
+			.all() as Array<{ scope_id: string; server_id: string; enabled: number }>;
+		expect(rows).toHaveLength(3);
+		expect(rows.every((r) => r.enabled === 0)).toBe(true);
+
+		const perSession = rows.reduce<Record<string, number>>((acc, r) => {
+			acc[r.scope_id] = (acc[r.scope_id] ?? 0) + 1;
+			return acc;
+		}, {});
+		expect(perSession).toEqual({ 'sess-a': 1, 'sess-b': 2 });
+	});
+
+	test('tolerates malformed session.config JSON without throwing', () => {
+		insertServer(db, 'srv-1', 'srv-1');
+		// Inject a session row with invalid JSON in `config`.
+		db.prepare(
+			`INSERT INTO sessions (id, title, config, created_at, last_active_at) VALUES ('bad', '', 'not-json', '', '')`
+		).run();
+		insertSession(db, 'good', { tools: { disabledMcpServers: ['srv-1'] } });
+
+		expect(() => runMigration101(db)).not.toThrow();
+
+		const rows = db
+			.prepare(`SELECT scope_id FROM mcp_enablement WHERE scope_type='session'`)
+			.all() as Array<{ scope_id: string }>;
+		expect(rows).toHaveLength(1);
+		expect(rows[0].scope_id).toBe('good');
+	});
+
+	// --- Top-level integration: all three seed paths together --------------
+
+	test('seeds rows for room, space, and session sources in a single run', () => {
+		insertServer(db, 'srv-1', 'brave-search');
+		insertRoom(db, 'room-1');
+		db.prepare(
+			`INSERT INTO room_mcp_enablement (room_id, server_id, enabled) VALUES ('room-1', 'srv-1', 1)`
+		).run();
+		insertSpace(db, 'space-1');
+		setGlobalSettings(db, { disabledMcpServers: ['brave-search'] });
+		insertSession(db, 'sess-1', { tools: { disabledMcpServers: ['brave-search'] } });
+
+		runMigration101(db);
+
+		const byScope = db
+			.prepare(`SELECT scope_type, COUNT(*) AS c FROM mcp_enablement GROUP BY scope_type`)
+			.all() as Array<{ scope_type: string; c: number }>;
+		const map = Object.fromEntries(byScope.map((r) => [r.scope_type, r.c]));
+		expect(map).toEqual({ room: 1, space: 1, session: 1 });
+	});
+});

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-mcp.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-mcp.test.ts
@@ -260,7 +260,10 @@ function buildManager(opts: {
 	);
 
 	const appMcpManager = hasAppMcpManager
-		? { getEnabledMcpConfigs: () => registryMcpServers }
+		? {
+				getEnabledMcpConfigs: () => registryMcpServers,
+				getEnabledMcpConfigsForSession: () => registryMcpServers,
+			}
 		: undefined;
 
 	const mockSkillsManager = {

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
@@ -936,21 +936,24 @@ describe('TaskAgentManager', () => {
 			const task = await makeTask(ctx.taskManager);
 			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
 
+			const registryConfigs = {
+				'registry-mcp': {
+					type: 'stdio' as const,
+					command: 'echo',
+					args: ['ok'],
+				},
+			};
 			const configRef = ctx.manager as unknown as {
 				config: {
 					appMcpManager?: {
 						getEnabledMcpConfigs: () => Record<string, unknown>;
+						getEnabledMcpConfigsForSession: () => Record<string, unknown>;
 					};
 				};
 			};
 			configRef.config.appMcpManager = {
-				getEnabledMcpConfigs: () => ({
-					'registry-mcp': {
-						type: 'stdio',
-						command: 'echo',
-						args: ['ok'],
-					},
-				}),
+				getEnabledMcpConfigs: () => registryConfigs,
+				getEnabledMcpConfigsForSession: () => registryConfigs,
 			};
 
 			const subSessionId = `space:${ctx.spaceId}:task:${task.id}:step:step-merge-mcp`;

--- a/packages/shared/src/mod.ts
+++ b/packages/shared/src/mod.ts
@@ -21,6 +21,7 @@ export * from './types/space-utils.ts';
 export * from './space/workflow-autonomy.ts';
 export * from './types/tools.ts';
 export * from './types/app-mcp-server.ts';
+export * from './types/mcp-enablement.ts';
 export * from './types/skills.ts';
 export * from './types/reference.ts';
 export * from './live-query-types.ts';

--- a/packages/shared/src/types/mcp-enablement.ts
+++ b/packages/shared/src/types/mcp-enablement.ts
@@ -1,0 +1,88 @@
+/**
+ * MCP Enablement Override Types
+ *
+ * Unified override model for application-level MCP server registry entries.
+ * A row in `mcp_enablement` represents an explicit per-scope override that
+ * either enables or disables a registry server for the given scope (space,
+ * room, or session). Missing rows mean "inherit" — the next most-specific
+ * scope with an override wins, otherwise the server's registry default is used.
+ *
+ * Precedence (most specific wins): session > room > space > registry default.
+ */
+
+/**
+ * The scope at which an MCP enablement override applies.
+ * - `space`  — applies to all sessions whose `session.context.spaceId` matches.
+ * - `room`   — applies to all sessions whose `session.context.roomId` matches.
+ * - `session` — applies only to a specific session by its ID.
+ */
+export type McpEnablementScopeType = 'space' | 'room' | 'session';
+
+/**
+ * A single override row. Present row = explicit override; missing row = inherit.
+ *
+ * Identity is the composite natural key (serverId, scopeType, scopeId); there
+ * is no surrogate `id` column. Callers that need to reference a specific row
+ * do so by that triple.
+ */
+export interface McpEnablementOverride {
+	/** The scope at which this override applies. */
+	scopeType: McpEnablementScopeType;
+	/** The ID of the space/room/session this override targets. */
+	scopeId: string;
+	/** The `app_mcp_servers.id` of the registry entry this override affects. */
+	serverId: string;
+	/** `true` = explicitly enabled for this scope; `false` = explicitly disabled. */
+	enabled: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// RPC request/response shapes
+// ---------------------------------------------------------------------------
+
+/** `mcp.enablement.list` — list every override at a given (scopeType, scopeId). */
+export interface McpEnablementListRequest {
+	scopeType: McpEnablementScopeType;
+	scopeId: string;
+}
+
+export interface McpEnablementListResponse {
+	overrides: McpEnablementOverride[];
+}
+
+/**
+ * `mcp.enablement.setOverride` — upsert an override (enable or disable a single
+ * server at a given scope). Use `mcp.enablement.clearOverride` to remove it and
+ * revert to inheritance.
+ */
+export interface McpEnablementSetOverrideRequest {
+	scopeType: McpEnablementScopeType;
+	scopeId: string;
+	serverId: string;
+	enabled: boolean;
+}
+
+export interface McpEnablementSetOverrideResponse {
+	override: McpEnablementOverride;
+}
+
+/** `mcp.enablement.clearOverride` — delete a single (scope, server) override. */
+export interface McpEnablementClearOverrideRequest {
+	scopeType: McpEnablementScopeType;
+	scopeId: string;
+	serverId: string;
+}
+
+export interface McpEnablementClearOverrideResponse {
+	deleted: boolean;
+}
+
+/** `mcp.enablement.clearScope` — delete every override at a given scope. */
+export interface McpEnablementClearScopeRequest {
+	scopeType: McpEnablementScopeType;
+	scopeId: string;
+}
+
+export interface McpEnablementClearScopeResponse {
+	deleted: number;
+}


### PR DESCRIPTION
Task #89 — MCP M3: Generalize enablement (plan `docs/plans/unify-mcp-config-model/00-overview.md`).

Unifies per-scope MCP server enablement behind a single `mcp_enablement` table plus a pure resolver so session > room > space > registry-default precedence is applied consistently across every session spawn path (Space ad-hoc, `space_task_agent`, node-agent, room sessions).

## Changes
- `mcp_enablement(scope_type, scope_id, server_id, enabled)` with composite PK `(server_id, scope_type, scope_id)`.
- Migration 100 seeds from `global_settings.disabledMcpServers` (scope=space), per-session `config.tools.disabledMcpServers` (scope=session), and `room_mcp_enablement` (scope=room). Legacy rows kept; M5 will purge.
- `resolveMcpServers(session, registry, overrides)` + `scopeChainForSession` — pure, no I/O.
- `McpEnablementRepository` with atomic `ON CONFLICT DO UPDATE` upsert and `notifyChange('mcp_enablement')` for LiveQuery.
- `AppMcpLifecycleManager` and scope-aware RPC handlers use the resolver.

## Test plan
- [x] Unit: resolver precedence matrix, context-less sessions, mixed overrides
- [x] Unit: repository CRUD + reactive notify
- [x] Unit: migration 100 backfill from all three legacy sources
- [x] Full daemon suite (`./scripts/test-daemon.sh`): 11572/11572 pass
- [x] `bun run check` clean (lint / typecheck / format / knip)