### PR TITLE
chore(release): bump version to 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to NeoKai will be documented in this file.
 
+## [0.12.0] - 2026-04-22
+
+A release improving tool surface area and session resilience. 5 commits since v0.11.1.
+
+### Added
+
+- **Runtime MCP surface**: Sync-attach space tools to all member sessions; surface runtime MCP servers in Tool Modal
+- **Standalone task dependencies**: `depends_on` parameter in `create_standalone_task` MCP tool
+
+### Changed
+
+- Remove global MCP Servers page; plan MCP unification
+
+### Fixed
+
+- Sessions only deleted/archived from UI actions (not agent)
+- Task-agent `sdkSessionId` preserved across restart; sub-sessions eagerly spawned
+
 ## [0.11.1] - 2026-04-22
 
 A patch release fixing session persistence and workflow fingerprint accuracy. 8 commits since v0.11.0.

--- a/npm/neokai/package.json
+++ b/npm/neokai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neokai",
-	"version": "0.11.1",
+	"version": "0.12.0",
 	"description": "NeoKai - Claude Agent SDK Web Interface",
 	"bin": {
 		"kai": "bin/kai.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/cli",
-	"version": "0.11.1",
+	"version": "0.12.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"bin": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/daemon",
-	"version": "0.11.1",
+	"version": "0.12.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "main.ts",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/e2e",
-	"version": "0.11.1",
+	"version": "0.12.0",
 	"private": true,
 	"license": "Apache-2.0",
 	"type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/shared",
-	"version": "0.11.1",
+	"version": "0.12.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "src/mod.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/ui",
-	"version": "0.11.1",
+	"version": "0.12.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "src/mod.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/web",
-	"version": "0.11.1",
+	"version": "0.12.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"scripts": {


### PR DESCRIPTION
Tool surface improvements and session resilience fixes.