### PR TITLE
feat(space): add Task Agent merge_pr MCP tool (behind feature flag)

### DIFF
--- a/packages/daemon/src/lib/space/tools/pr-merge-script.ts
+++ b/packages/daemon/src/lib/space/tools/pr-merge-script.ts
@@ -1,0 +1,62 @@
+/**
+ * PR merge bash script.
+ *
+ * Hoisted out of `built-in-workflows.ts` so it can be reused by the
+ * Task Agent `merge_pr` MCP tool handler (`task-agent-merge-handler.ts`).
+ *
+ * Security contract:
+ *   - Input is exposed to the script **only** via the environment variable
+ *     `NEOKAI_ARTIFACT_DATA_JSON`, parsed inside the script via `jq -r`.
+ *     Callers MUST NOT interpolate `pr_url` (or any other untrusted value)
+ *     into the script source — doing so would enable command injection.
+ *   - `pr_url` itself is regex-validated upstream in
+ *     `task-agent-merge-handler.ts` before the script runs.
+ *
+ * Environment variables read by the script:
+ *   NEOKAI_ARTIFACT_DATA_JSON — JSON payload containing `{ pr_url }`
+ *   NEOKAI_WORKSPACE_PATH    — workspace root (parent process sets as cwd)
+ *
+ * Behaviour:
+ *   - Resolves PR URL from `NEOKAI_ARTIFACT_DATA_JSON` (via `jq`), falling
+ *     back to `gh pr view --json url` for the current branch.
+ *   - Skips the merge if `gh pr view` reports `state = MERGED` (idempotent
+ *     re-entry from the script's perspective — complements the handler's
+ *     artifact-store idempotency check).
+ *   - Squash-merges via `gh pr merge --squash`, then syncs the worktree.
+ *   - Emits a JSON summary on stdout: `{"merged_pr_url":"…","status":"merged"|"already_merged"}`.
+ *   - Exits non-zero on failure with the error on stderr.
+ */
+
+export const PR_MERGE_BASH_SCRIPT = [
+	'# Resolve PR URL from artifact data (parsed via jq — never eval/$()-expanded) or current branch',
+	'PR_URL=$(jq -r \'.pr_url // .url // empty\' <<< "${NEOKAI_ARTIFACT_DATA_JSON:-{}}" 2>/dev/null || true)',
+	'if [ -z "$PR_URL" ]; then',
+	'  PR_URL=$(gh pr view --json url -q .url 2>/dev/null || true)',
+	'fi',
+	'if [ -z "$PR_URL" ]; then',
+	'  echo "No PR URL found — cannot merge" >&2',
+	'  exit 1',
+	'fi',
+	'# Idempotency guard: skip merge if PR is already merged',
+	'PR_STATE=$(gh pr view "$PR_URL" --json state -q .state 2>/dev/null || true)',
+	'if [ "$PR_STATE" = "MERGED" ]; then',
+	'  echo "PR already merged: $PR_URL"',
+	'  BASE_BRANCH=$(gh pr view "$PR_URL" --json baseRefName -q .baseRefName 2>/dev/null || echo "main")',
+	'  git checkout "$BASE_BRANCH" 2>/dev/null && git pull --ff-only 2>/dev/null || true',
+	'  jq -n --arg url "$PR_URL" \'{"merged_pr_url":$url,"status":"already_merged"}\'',
+	'  exit 0',
+	'fi',
+	'echo "Merging PR: $PR_URL"',
+	'if ! gh pr merge "$PR_URL" --squash; then',
+	'  echo "Failed to merge PR: $PR_URL" >&2',
+	'  exit 1',
+	'fi',
+	'# Sync worktree with base branch after merge',
+	'BASE_BRANCH=$(gh pr view "$PR_URL" --json baseRefName -q .baseRefName 2>/dev/null || echo "main")',
+	'git checkout "$BASE_BRANCH" 2>/dev/null && git pull --ff-only 2>/dev/null || true',
+	'echo "PR merged and worktree synced"',
+	'jq -n --arg url "$PR_URL" \'{"merged_pr_url":$url,"status":"merged"}\'',
+].join('\n');
+
+/** Default timeout (ms) for the PR merge script. Matches the legacy completion-action timeout. */
+export const PR_MERGE_SCRIPT_TIMEOUT_MS = 120_000;

--- a/packages/daemon/src/lib/space/tools/task-agent-merge-handler.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-merge-handler.ts
@@ -1,0 +1,667 @@
+/**
+ * Task Agent `merge_pr` MCP tool handler.
+ *
+ * Single-purpose post-approval executor for end nodes that signalled
+ * `post_approval_action: 'merge_pr'` via `send_message(target: 'task-agent')`.
+ *
+ * Contract (see
+ *   `docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md`
+ * for the full plan):
+ *
+ *   1. Validate `pr_url` against the GitHub PR URL regex.
+ *   2. Cross-check `pr_url` against the URL signalled by the end node for the
+ *      current task. A prompt-injected or hallucinated URL cannot be merged
+ *      even at autonomy >= 4.
+ *   3. Read the live space autonomy level via the injected resolver.
+ *      Threshold: `MERGE_AUTONOMY_THRESHOLD = 4`.
+ *   4. At `level < MERGE_AUTONOMY_THRESHOLD`:
+ *      - `human_approval_reason` is required.
+ *      - A recent `request_human_input` artifact for this task must exist
+ *        with a non-rejecting human response. This protects against a
+ *        hallucinating agent inventing a reason string without a real human
+ *        approval.
+ *   5. Idempotency: scan existing `task-agent` `result` artifacts for a row
+ *      whose `data.merged_pr_url === pr_url`. If found → short-circuit with
+ *      `alreadyMerged: true` (no script execution).
+ *   6. Execute `PR_MERGE_BASH_SCRIPT` via `bash -c` with `cwd = space.workspacePath`,
+ *      env `NEOKAI_ARTIFACT_DATA_JSON` / `NEOKAI_WORKSPACE_PATH`, and a 120 s
+ *      timeout. The script never sees interpolated inputs — `pr_url` is
+ *      passed only via env + parsed inside the script with `jq -r`.
+ *   7. On success: write a `task-agent` `result` artifact recording
+ *      `{ merged_pr_url, status: 'merged', mergedAt, approval, approvalReason }`.
+ *   8. On failure: return `{ success: false, error, stderr }` so the Task
+ *      Agent can surface the issue to the human via its normal coordination
+ *      path.
+ *
+ * Security:
+ *   - `pr_url` is regex-validated before use.
+ *   - The bash script parses `NEOKAI_ARTIFACT_DATA_JSON` via `jq -r` — no
+ *     `eval` or `$()` expansion of untrusted input.
+ *   - The audit log line is emitted via a key-value logger call (not a
+ *     format-string concatenation) so `approvalReason` cannot forge
+ *     additional log lines even if it contains newlines or ANSI escapes.
+ *
+ * This handler is registered as the `merge_pr` MCP tool on the Task Agent's
+ * MCP server only when the `NEOKAI_TASK_AGENT_MERGE_EXECUTOR` feature flag
+ * (env var or `Space.experimentalFeatures['taskAgentMergeExecutor']`) is set.
+ * During Stage 1 rollout the flag is off — the tool is defined + tested but
+ * not visible to agents.
+ */
+
+import type { Space } from '@neokai/shared';
+import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
+import { Logger } from '../../logger';
+import { jsonResult } from './tool-result';
+import type { ToolResult } from './tool-result';
+import type { MergePrInput } from './task-agent-tool-schemas';
+import { PR_MERGE_BASH_SCRIPT, PR_MERGE_SCRIPT_TIMEOUT_MS } from './pr-merge-script';
+
+const log = new Logger('task-agent-merge');
+
+/** Autonomy threshold at which `merge_pr` may auto-approve without a human reason. */
+export const MERGE_AUTONOMY_THRESHOLD = 4;
+
+/** Strict GitHub PR URL validation. Matches `https://github.com/<owner>/<repo>/pull/<n>`. */
+export const GITHUB_PR_URL_REGEX = /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+$/;
+
+/**
+ * Canonical `request_human_input` question for a post-approval merge.
+ *
+ * The Task Agent system prompt (updated in Work Item 2) instructs the agent
+ * to use this exact question string when asking the human to approve a
+ * merge at `autonomyLevel < MERGE_AUTONOMY_THRESHOLD`. Pinning the format
+ * here keeps snapshot tests authoritative — if the string drifts, the
+ * snapshot test in `task-agent-merge-handler.test.ts` will fail.
+ */
+export function buildMergeApprovalQuestion(prUrl: string): string {
+	return `Approve merging PR ${prUrl}?`;
+}
+
+/**
+ * Canonical context hint the Task Agent passes to `request_human_input`
+ * alongside the question above. Intentionally terse — the Task Agent is
+ * expected to append reviewer / CI detail from its existing context.
+ */
+export function buildMergeApprovalContextHint(prUrl: string): string {
+	return (
+		`The end node of this workflow signalled a post-approval action:\n` +
+		`  action: merge_pr\n` +
+		`  pr_url: ${prUrl}\n` +
+		`Space autonomy level is below the auto-merge threshold (${MERGE_AUTONOMY_THRESHOLD}), ` +
+		`so a human must confirm before the Task Agent runs the merge.`
+	);
+}
+
+/** Signalled post-approval action payload persisted by an end node. */
+export interface PostApprovalSignal {
+	/** The action type the end node requested (currently only `merge_pr`). */
+	action: string;
+	/** Fully-qualified PR URL the end node wants the Task Agent to merge. */
+	pr_url: string;
+}
+
+/** A human-input response, surfaced by a preceding `request_human_input` call. */
+export interface HumanInputResponse {
+	/** Verbatim human response text. */
+	response: string;
+	/**
+	 * Whether the response represents a rejection. Implementations may classify
+	 * this upstream (e.g. a dedicated reject button, or simple substring match
+	 * on "reject" / "decline" / "no"). The handler refuses the merge when true.
+	 */
+	rejected: boolean;
+	/** Unix-ms timestamp when the response was recorded. */
+	createdAt: number;
+}
+
+/** Result of running the PR merge script. Shape matches the test harness's spawn mock. */
+export interface MergeScriptResult {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+	/** True when the process was killed by the timeout watchdog. */
+	timedOut: boolean;
+}
+
+/** Executor abstraction — lets tests stub spawn without touching the real shell. */
+export type MergeScriptExecutor = (args: {
+	script: string;
+	env: Record<string, string>;
+	cwd: string;
+	timeoutMs: number;
+}) => Promise<MergeScriptResult>;
+
+/**
+ * Dependencies for `createMergePrHandler`.
+ *
+ * Resolvers are declared as required function-shape fields so callers can't
+ * forget them: the tool is feature-flagged at registration time, but if it
+ * IS registered, all resolvers must be wired. Tests pass in-memory stubs.
+ */
+export interface MergePrHandlerDeps {
+	/** Task this handler is bound to. */
+	taskId: string;
+	/** Space the task belongs to — `workspacePath` is the script's `cwd`. */
+	space: Space;
+	/** Active workflow run ID — used for artifact idempotency scans and audit writes. */
+	workflowRunId: string;
+	/** Artifact repo — used for both the idempotency scan and the audit write. */
+	artifactRepo: WorkflowRunArtifactRepository;
+	/** Returns the live space autonomy level. Re-read at every call. */
+	getSpaceAutonomyLevel: (spaceId: string) => Promise<number>;
+	/**
+	 * Resolve the most recent post-approval signal persisted for this task
+	 * (from `send_message(target: 'task-agent', data: { pr_url, post_approval_action })`).
+	 * Returns `null` when no signal has been stored.
+	 *
+	 * In Stage 1 (Work Item 1) this resolver is plumbed through for tests; in
+	 * Stage 2 (Work Item 2) it reads `SpaceTask.pendingPostApprovalAction`.
+	 */
+	getSignalledPostApprovalAction: (taskId: string) => Promise<PostApprovalSignal | null>;
+	/**
+	 * Resolve the most recent `request_human_input` response artifact for this
+	 * task. Returns `null` when no human has responded to a pending question.
+	 *
+	 * Only consulted at `autonomyLevel < MERGE_AUTONOMY_THRESHOLD`. In Stage 1
+	 * this resolver is plumbed through for tests; in Stage 2 it reads the
+	 * artifact written by the updated `request_human_input` handler.
+	 */
+	getRecentHumanInputResponse: (taskId: string) => Promise<HumanInputResponse | null>;
+	/**
+	 * Merge-script executor. Defaults to a `Bun.spawn`-backed implementation.
+	 * Tests supply a stub so no real `bash`/`gh` is invoked.
+	 */
+	runScript?: MergeScriptExecutor;
+}
+
+// ---------------------------------------------------------------------------
+// Default spawn-based executor — used in production; tests override.
+// ---------------------------------------------------------------------------
+
+/**
+ * Default merge-script executor. Streams stdout/stderr with a buffer cap and
+ * enforces the configured timeout by SIGKILL.
+ *
+ * Exposed so other daemon callers can reuse the same semantics if needed; not
+ * re-exported from the package index.
+ */
+export async function defaultMergeScriptExecutor(args: {
+	script: string;
+	env: Record<string, string>;
+	cwd: string;
+	timeoutMs: number;
+}): Promise<MergeScriptResult> {
+	const proc = Bun.spawn(['bash', '-c', args.script], {
+		cwd: args.cwd,
+		env: args.env,
+		stdout: 'pipe',
+		stderr: 'pipe',
+	});
+
+	let timedOut = false;
+	const killTimer = setTimeout(() => {
+		timedOut = true;
+		proc.kill('SIGKILL');
+	}, args.timeoutMs);
+
+	try {
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+			proc.exited,
+		]);
+		return { exitCode, stdout, stderr, timedOut };
+	} finally {
+		clearTimeout(killTimer);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Feature-flag helper — exported so tool-registration can share the logic.
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns `true` when the `NEOKAI_TASK_AGENT_MERGE_EXECUTOR` feature flag is
+ * enabled — either via the env var or via the space's
+ * `experimentalFeatures['taskAgentMergeExecutor']` bit.
+ *
+ * The env var accepts `1`, `true`, or `yes` (case-insensitive). Anything else
+ * is treated as disabled. The space-level bit wins over the env var only when
+ * explicitly `true`.
+ *
+ * The space argument is typed loosely on purpose — the shared `Space` type
+ * does not yet carry `experimentalFeatures`; Stage-2 (Work Item 2) wiring
+ * will add it. Until then, the env var is the production gate and the
+ * space-bit branch lies dormant but ready.
+ */
+export function isMergeExecutorFeatureEnabled(space?: unknown): boolean {
+	const envRaw = process.env.NEOKAI_TASK_AGENT_MERGE_EXECUTOR;
+	if (envRaw !== undefined) {
+		const normalized = envRaw.trim().toLowerCase();
+		if (normalized === '1' || normalized === 'true' || normalized === 'yes') return true;
+	}
+	if (space && typeof space === 'object') {
+		const features = (space as { experimentalFeatures?: unknown }).experimentalFeatures;
+		if (features && typeof features === 'object') {
+			const bit = (features as Record<string, unknown>).taskAgentMergeExecutor;
+			if (bit === true) return true;
+		}
+	}
+	return false;
+}
+
+// ---------------------------------------------------------------------------
+// Handler factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the `merge_pr` handler closure bound to the given dependencies.
+ *
+ * The returned function matches the MCP handler signature used across the
+ * Task Agent tool surface (`(input) => Promise<ToolResult>`), making it a
+ * drop-in for `tool('merge_pr', desc, MergePrSchema.shape, handler)`.
+ */
+export function createMergePrHandler(deps: MergePrHandlerDeps) {
+	const {
+		taskId,
+		space,
+		workflowRunId,
+		artifactRepo,
+		getSpaceAutonomyLevel,
+		getSignalledPostApprovalAction,
+		getRecentHumanInputResponse,
+		runScript = defaultMergeScriptExecutor,
+	} = deps;
+
+	return async function merge_pr(args: MergePrInput): Promise<ToolResult> {
+		const prUrl = args.pr_url.trim();
+		const humanApprovalReason = args.human_approval_reason?.trim();
+
+		// ---- 1. Validate URL shape --------------------------------------------
+		if (!GITHUB_PR_URL_REGEX.test(prUrl)) {
+			auditLog({
+				outcome: 'refused-invalid-url',
+				spaceId: space.id,
+				taskId,
+				prUrl,
+				level: null,
+				autoApproved: null,
+				reason: 'pr_url failed GitHub PR URL validation',
+			});
+			return jsonResult({
+				success: false,
+				error:
+					'Invalid pr_url: expected a fully-qualified GitHub PR URL matching ' +
+					'https://github.com/<owner>/<repo>/pull/<n>.',
+			});
+		}
+
+		// ---- 2. Cross-check against the end-node's signalled URL ---------------
+		// Prevents a prompt-injected or hallucinated URL from being merged even
+		// at autonomy >= 4. The end node persists this signal via Work Item 2's
+		// pendingPostApprovalAction plumbing; the resolver abstracts the source
+		// so Stage 1 can unit-test the gate without that wiring.
+		let signal: PostApprovalSignal | null = null;
+		try {
+			signal = await getSignalledPostApprovalAction(taskId);
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			auditLog({
+				outcome: 'refused-signal-resolver-error',
+				spaceId: space.id,
+				taskId,
+				prUrl,
+				level: null,
+				autoApproved: null,
+				reason: message,
+			});
+			return jsonResult({
+				success: false,
+				error: `Failed to resolve end-node post-approval signal: ${message}`,
+			});
+		}
+
+		if (!signal) {
+			auditLog({
+				outcome: 'refused-no-signal',
+				spaceId: space.id,
+				taskId,
+				prUrl,
+				level: null,
+				autoApproved: null,
+				reason: 'no end-node signal for this task',
+			});
+			return jsonResult({
+				success: false,
+				error:
+					'No post-approval signal recorded for this task. ' +
+					'An end node must first emit send_message(target: "task-agent", data: { pr_url, post_approval_action: "merge_pr" }) ' +
+					'before merge_pr is callable.',
+			});
+		}
+
+		if (signal.action !== 'merge_pr') {
+			auditLog({
+				outcome: 'refused-signal-action-mismatch',
+				spaceId: space.id,
+				taskId,
+				prUrl,
+				level: null,
+				autoApproved: null,
+				reason: `signalled action is '${signal.action}', not 'merge_pr'`,
+			});
+			return jsonResult({
+				success: false,
+				error: `Signalled post-approval action is '${signal.action}', not 'merge_pr'. merge_pr is not a valid executor for this signal.`,
+			});
+		}
+
+		if (signal.pr_url !== prUrl) {
+			auditLog({
+				outcome: 'refused-url-mismatch',
+				spaceId: space.id,
+				taskId,
+				prUrl,
+				level: null,
+				autoApproved: null,
+				reason: `signalled pr_url=${signal.pr_url}`,
+			});
+			return jsonResult({
+				success: false,
+				error:
+					`Refused: args.pr_url does not match the PR URL signalled by the end node. ` +
+					`Signalled URL: ${signal.pr_url}. Provided URL: ${prUrl}.`,
+			});
+		}
+
+		// ---- 3. Read live autonomy level --------------------------------------
+		let level: number;
+		try {
+			level = (await getSpaceAutonomyLevel(space.id)) ?? 1;
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			auditLog({
+				outcome: 'refused-autonomy-resolver-error',
+				spaceId: space.id,
+				taskId,
+				prUrl,
+				level: null,
+				autoApproved: null,
+				reason: message,
+			});
+			return jsonResult({
+				success: false,
+				error: `Failed to resolve space autonomy level: ${message}`,
+			});
+		}
+
+		const autoApproved = level >= MERGE_AUTONOMY_THRESHOLD;
+
+		// ---- 4. At level < threshold: require human_approval_reason AND a
+		//         matching request_human_input artifact with a non-rejecting
+		//         response. The reason alone is model-attestable, so we verify
+		//         a real response was recorded before running the merge.
+		if (!autoApproved) {
+			if (!humanApprovalReason) {
+				auditLog({
+					outcome: 'refused-missing-reason',
+					spaceId: space.id,
+					taskId,
+					prUrl,
+					level,
+					autoApproved,
+					reason: 'human_approval_reason missing at level < 4',
+				});
+				return jsonResult({
+					success: false,
+					error:
+						`Human approval required: space autonomy level is ${level} (< ${MERGE_AUTONOMY_THRESHOLD}). ` +
+						`Call request_human_input({ question: ${JSON.stringify(buildMergeApprovalQuestion(prUrl))}, context: "<reviewer + CI context>" }) ` +
+						"first, wait for the human's reply, then retry merge_pr with human_approval_reason set to the human's verbatim response.",
+					canonicalQuestion: buildMergeApprovalQuestion(prUrl),
+					canonicalContextHint: buildMergeApprovalContextHint(prUrl),
+				});
+			}
+
+			let humanResponse: HumanInputResponse | null = null;
+			try {
+				humanResponse = await getRecentHumanInputResponse(taskId);
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				auditLog({
+					outcome: 'refused-human-response-resolver-error',
+					spaceId: space.id,
+					taskId,
+					prUrl,
+					level,
+					autoApproved,
+					reason: message,
+				});
+				return jsonResult({
+					success: false,
+					error: `Failed to look up human-input response: ${message}`,
+				});
+			}
+
+			if (!humanResponse) {
+				auditLog({
+					outcome: 'refused-no-human-response',
+					spaceId: space.id,
+					taskId,
+					prUrl,
+					level,
+					autoApproved,
+					reason: 'no request_human_input response artifact found',
+				});
+				return jsonResult({
+					success: false,
+					error:
+						'No human-input response found for this task. ' +
+						'Call request_human_input to ask the human, wait for their reply, then retry ' +
+						'merge_pr with their verbatim response as human_approval_reason.',
+				});
+			}
+
+			if (humanResponse.rejected) {
+				auditLog({
+					outcome: 'refused-human-rejected',
+					spaceId: space.id,
+					taskId,
+					prUrl,
+					level,
+					autoApproved,
+					reason: humanResponse.response,
+				});
+				return jsonResult({
+					success: false,
+					error:
+						'The human rejected the merge in their response to request_human_input. ' +
+						'merge_pr will not run. Save an audit artifact describing the rejection and continue.',
+				});
+			}
+		}
+
+		// ---- 5. Idempotency — scan task-agent result artifacts for a row
+		//         with the same merged_pr_url. In-memory scan (no SQL
+		//         json_extract) to keep the artifact-store API simple.
+		const existingArtifacts = artifactRepo.listByRun(workflowRunId, {
+			nodeId: 'task-agent',
+			artifactType: 'result',
+		});
+		const alreadyMergedRow = existingArtifacts.find(
+			(a) => typeof a.data?.merged_pr_url === 'string' && a.data.merged_pr_url === prUrl
+		);
+		if (alreadyMergedRow) {
+			auditLog({
+				outcome: 'already-merged',
+				spaceId: space.id,
+				taskId,
+				prUrl,
+				level,
+				autoApproved,
+				reason: 'artifact store already records a merge for this URL',
+			});
+			return jsonResult({
+				success: true,
+				alreadyMerged: true,
+				merged_pr_url: prUrl,
+				artifactId: alreadyMergedRow.id,
+				message: `PR ${prUrl} was already merged in this workflow run (artifact ${alreadyMergedRow.id}).`,
+			});
+		}
+
+		// ---- 6. Execute the merge script --------------------------------------
+		const scriptEnv: Record<string, string> = {
+			...buildMergeEnv(space.workspacePath),
+			NEOKAI_ARTIFACT_DATA_JSON: JSON.stringify({ pr_url: prUrl }),
+			NEOKAI_WORKSPACE_PATH: space.workspacePath,
+		};
+
+		let result: MergeScriptResult;
+		try {
+			result = await runScript({
+				script: PR_MERGE_BASH_SCRIPT,
+				env: scriptEnv,
+				cwd: space.workspacePath,
+				timeoutMs: PR_MERGE_SCRIPT_TIMEOUT_MS,
+			});
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			auditLog({
+				outcome: 'failed-spawn',
+				spaceId: space.id,
+				taskId,
+				prUrl,
+				level,
+				autoApproved,
+				reason: message,
+			});
+			return jsonResult({
+				success: false,
+				error: `Failed to spawn merge script: ${message}`,
+			});
+		}
+
+		if (result.timedOut) {
+			auditLog({
+				outcome: 'failed-timeout',
+				spaceId: space.id,
+				taskId,
+				prUrl,
+				level,
+				autoApproved,
+				reason: `timed out after ${PR_MERGE_SCRIPT_TIMEOUT_MS}ms`,
+			});
+			return jsonResult({
+				success: false,
+				error: `PR merge script timed out after ${PR_MERGE_SCRIPT_TIMEOUT_MS}ms.`,
+				stderr: result.stderr,
+			});
+		}
+
+		if (result.exitCode !== 0) {
+			auditLog({
+				outcome: 'failed-script',
+				spaceId: space.id,
+				taskId,
+				prUrl,
+				level,
+				autoApproved,
+				reason: `exit ${result.exitCode}`,
+			});
+			return jsonResult({
+				success: false,
+				error: `PR merge script exited with code ${result.exitCode}.`,
+				stderr: result.stderr,
+				stdout: result.stdout,
+			});
+		}
+
+		// ---- 7. Record the audit artifact on success --------------------------
+		const approval: 'auto_policy' | 'human' = autoApproved ? 'auto_policy' : 'human';
+		const mergedAt = Date.now();
+		const artifact = artifactRepo.upsert({
+			id: crypto.randomUUID(),
+			runId: workflowRunId,
+			nodeId: 'task-agent',
+			artifactType: 'result',
+			// Unique key per merge so repeated merges (should never happen after
+			// the idempotency check, but be defensive) stay append-only in practice.
+			artifactKey: `merge_pr:${mergedAt}:${Math.random().toString(36).slice(2, 8)}`,
+			data: {
+				merged_pr_url: prUrl,
+				status: 'merged',
+				mergedAt,
+				approval,
+				approvalReason: humanApprovalReason ?? null,
+				taskId,
+			},
+		});
+
+		auditLog({
+			outcome: 'merged',
+			spaceId: space.id,
+			taskId,
+			prUrl,
+			level,
+			autoApproved,
+			reason: humanApprovalReason ?? null,
+		});
+
+		return jsonResult({
+			success: true,
+			merged_pr_url: prUrl,
+			approval,
+			artifactId: artifact.id,
+			stdout: result.stdout,
+			message: `PR ${prUrl} merged (${approval === 'auto_policy' ? 'auto-approved' : 'human-approved'}).`,
+		});
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the environment the merge script inherits.
+ *
+ * Starts from the current process env (needed so `gh`/`git` can find the
+ * user's auth + PATH), then overrides the NeoKai-specific variables. Callers
+ * merge `NEOKAI_ARTIFACT_DATA_JSON` / `NEOKAI_WORKSPACE_PATH` on top.
+ */
+function buildMergeEnv(workspacePath: string): Record<string, string> {
+	const env: Record<string, string> = {};
+	for (const [key, value] of Object.entries(process.env)) {
+		if (typeof value === 'string') env[key] = value;
+	}
+	env['NEOKAI_WORKSPACE_PATH'] = workspacePath;
+	return env;
+}
+
+/**
+ * Emit a single structured audit line for every merge_pr invocation.
+ *
+ * Uses the key-value form `logger.info('event', fields)` so that
+ * agent-provided strings (`approvalReason`) cannot forge adjacent log lines
+ * — even if the string contains newlines, ANSI escapes, or control chars.
+ */
+function auditLog(fields: {
+	outcome: string;
+	spaceId: string;
+	taskId: string;
+	prUrl: string;
+	level: number | null;
+	autoApproved: boolean | null;
+	reason: string | null;
+}): void {
+	log.info('task-agent.merge_pr', {
+		outcome: fields.outcome,
+		spaceId: fields.spaceId,
+		taskId: fields.taskId,
+		prUrl: fields.prUrl,
+		level: fields.level,
+		autoApproved: fields.autoApproved,
+		reason: fields.reason,
+	});
+}

--- a/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
@@ -8,6 +8,7 @@
  *   submit_for_approval   — request human sign-off
  *   request_human_input   — pause execution and surface a question to the human user
  *   list_group_members    — list all members of the current task's session group
+ *   merge_pr              — execute a post-approval PR merge (feature-flagged)
  *
  * This file is consumed by the MCP server factory. It intentionally
  * contains only schema definitions — no runtime logic or side effects.
@@ -107,6 +108,54 @@ export const ListGroupMembersSchema = z.object({});
 export type ListGroupMembersInput = z.infer<typeof ListGroupMembersSchema>;
 
 // ---------------------------------------------------------------------------
+// merge_pr
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `merge_pr` input.
+ *
+ * Single-purpose post-approval executor: runs a GitHub PR squash-merge on
+ * behalf of an end node that signalled `post_approval_action: 'merge_pr'`.
+ *
+ * Authorisation is enforced inside the handler based on the live
+ * `space.autonomyLevel`:
+ *   - level >= 4 → auto-approved, `human_approval_reason` ignored.
+ *   - level  < 4 → `human_approval_reason` is **required**; the handler
+ *     additionally verifies that a real `request_human_input` artifact exists
+ *     for this task and has a non-rejecting human response.
+ *
+ * Registration is gated behind the `NEOKAI_TASK_AGENT_MERGE_EXECUTOR`
+ * feature flag during Stage 1 rollout — see `task-agent-tools.ts`.
+ */
+export const MergePrSchema = z
+	.object({
+		/** Fully-qualified GitHub PR URL that was signalled by the end node. */
+		pr_url: z
+			.string()
+			.min(1)
+			.describe(
+				'Fully-qualified GitHub PR URL (https://github.com/<owner>/<repo>/pull/<n>). ' +
+					'Must match the URL the end node signalled via send_message(target: "task-agent", data: { pr_url, post_approval_action: "merge_pr" }).'
+			),
+		/**
+		 * Human-provided approval reason — required when space autonomy level is
+		 * below MERGE_AUTONOMY_THRESHOLD. Recorded verbatim on the merge audit
+		 * artifact so operators can later reconstruct who approved what.
+		 */
+		human_approval_reason: z
+			.string()
+			.min(1)
+			.describe(
+				"Human's verbatim approval text from a preceding request_human_input response. " +
+					'Required when space autonomy is below the merge threshold (level < 4). Ignored at level >= 4.'
+			)
+			.optional(),
+	})
+	.strict();
+
+export type MergePrInput = z.infer<typeof MergePrSchema>;
+
+// ---------------------------------------------------------------------------
 // Aggregate export for MCP server factory
 // ---------------------------------------------------------------------------
 
@@ -119,6 +168,7 @@ export const TASK_AGENT_TOOL_SCHEMAS = {
 	submit_for_approval: SubmitForApprovalSchema,
 	request_human_input: RequestHumanInputSchema,
 	list_group_members: ListGroupMembersSchema,
+	merge_pr: MergePrSchema,
 } as const;
 
 export type TaskAgentToolName = keyof typeof TASK_AGENT_TOOL_SCHEMAS;

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -43,6 +43,7 @@ import {
 	SubmitForApprovalSchema,
 	RequestHumanInputSchema,
 	ListGroupMembersSchema,
+	MergePrSchema,
 } from './task-agent-tool-schemas';
 import {
 	SendMessageSchema,
@@ -60,6 +61,13 @@ import type {
 	SaveArtifactInput,
 	ListArtifactsInput,
 } from './node-agent-tool-schemas';
+import {
+	createMergePrHandler,
+	isMergeExecutorFeatureEnabled,
+	type HumanInputResponse,
+	type MergeScriptExecutor,
+	type PostApprovalSignal,
+} from './task-agent-merge-handler';
 
 // Re-export for consumers that want the shared type
 export type { ToolResult };
@@ -174,6 +182,31 @@ export interface TaskAgentToolsConfig {
 	 * Optional — when absent, artifact tools are not registered.
 	 */
 	artifactRepo?: WorkflowRunArtifactRepository;
+	/**
+	 * Resolve the most recent post-approval signal persisted for this task
+	 * (from an end node's `send_message(target: 'task-agent', data: { pr_url, post_approval_action })`).
+	 * Required for `merge_pr` registration — when absent, the tool stays
+	 * unregistered even if the feature flag is on.
+	 */
+	getSignalledPostApprovalAction?: (taskId: string) => Promise<PostApprovalSignal | null>;
+	/**
+	 * Resolve the most recent `request_human_input` response artifact for
+	 * this task. Consulted by `merge_pr` at autonomy < 4. Required for
+	 * `merge_pr` registration — when absent, the tool stays unregistered.
+	 */
+	getRecentHumanInputResponse?: (taskId: string) => Promise<HumanInputResponse | null>;
+	/**
+	 * Optional merge-script executor override — only used by tests to stub
+	 * out the real `bash -c` spawn. Production leaves this undefined so the
+	 * handler's default `Bun.spawn`-backed executor runs.
+	 */
+	mergeScriptExecutor?: MergeScriptExecutor;
+	/**
+	 * Force-enable / force-disable the `merge_pr` feature flag. Tests set
+	 * this explicitly; production leaves it undefined so the handler reads
+	 * `NEOKAI_TASK_AGENT_MERGE_EXECUTOR` + `space.experimentalFeatures`.
+	 */
+	mergeExecutorFeatureEnabled?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -250,7 +283,29 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 			});
 	}
 
+	// `merge_pr` handler is constructed only when all its resolvers are wired
+	// AND the artifact repo is available. Unwired callers see `merge_pr:
+	// undefined` on the returned handlers map so tests can assert gating.
+	const mergePrHandler =
+		config.artifactRepo &&
+		getSpaceAutonomyLevel &&
+		config.getSignalledPostApprovalAction &&
+		config.getRecentHumanInputResponse
+			? createMergePrHandler({
+					taskId,
+					space,
+					workflowRunId,
+					artifactRepo: config.artifactRepo,
+					getSpaceAutonomyLevel,
+					getSignalledPostApprovalAction: config.getSignalledPostApprovalAction,
+					getRecentHumanInputResponse: config.getRecentHumanInputResponse,
+					runScript: config.mergeScriptExecutor,
+				})
+			: undefined;
+
 	return {
+		/** The `merge_pr` handler — `undefined` when its resolvers aren't wired. */
+		merge_pr: mergePrHandler,
 		/**
 		 * Persist data to the workflow run artifact store.
 		 *
@@ -965,6 +1020,17 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 export function createTaskAgentMcpServer(config: TaskAgentToolsConfig) {
 	const handlers = createTaskAgentToolHandlers(config);
 
+	// `merge_pr` registration is gated three ways:
+	//   1. The feature flag must be enabled (env var or space experimental bit).
+	//   2. All resolvers must be wired (enforced via mergePrHandler being defined).
+	//   3. Caller can force-disable via `config.mergeExecutorFeatureEnabled = false`.
+	// During Stage 1 rollout (Work Item 1) the flag is off by default, so the
+	// tool is defined + tested but not visible to agents in production.
+	const mergeFlagOn =
+		config.mergeExecutorFeatureEnabled ?? isMergeExecutorFeatureEnabled(config.space);
+	const mergePrHandler = handlers.merge_pr;
+	const mergePrEnabled = mergeFlagOn && mergePrHandler !== undefined;
+
 	const tools = [
 		tool(
 			'request_human_input',
@@ -1055,6 +1121,22 @@ export function createTaskAgentMcpServer(config: TaskAgentToolsConfig) {
 			SubmitForApprovalSchema.shape,
 			(args) => handlers.submit_for_approval(args)
 		),
+		...(mergePrEnabled && mergePrHandler
+			? [
+					tool(
+						'merge_pr',
+						'Execute a post-approval PR squash-merge for an end node that signalled ' +
+							'`post_approval_action: "merge_pr"`. The `pr_url` MUST equal the URL the end node ' +
+							'signalled — cross-checked against the stored post-approval signal. ' +
+							'At space.autonomyLevel >= 4 the merge runs automatically. Below level 4 the ' +
+							'handler requires `human_approval_reason` AND a preceding request_human_input ' +
+							'artifact with a non-rejecting human response. Idempotent: re-running with the ' +
+							'same URL after a successful merge returns `{ success: true, alreadyMerged: true }`.',
+						MergePrSchema.shape,
+						(args) => mergePrHandler(args)
+					),
+				]
+			: []),
 	];
 
 	return createSdkMcpServer({ name: 'task-agent', tools });

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -25,6 +25,7 @@ import type { SpaceWorkflow, CompletionAction } from '@neokai/shared';
 import type { GateScript } from '@neokai/shared';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import { computeWorkflowHash } from './template-hash.ts';
+import { PR_MERGE_BASH_SCRIPT } from '../tools/pr-merge-script.ts';
 
 // ---------------------------------------------------------------------------
 // Template node ID constants (used as stable IDs for workflow nodes and startNodeId)
@@ -139,50 +140,13 @@ const REVIEW_POSTED_BASH_SCRIPT = [
 ].join('\n');
 
 /**
- * Merge PR completion action script.
- *
- * Used as a `script` completion action on short workflows (Coding, Research).
- * Resolves the PR URL from the artifact env var or the current branch,
- * then squash-merges with branch deletion. Exits non-zero on failure.
- *
- * Environment variables injected by the completion action executor:
- *   NEOKAI_ARTIFACT_DATA_JSON — artifact data (contains pr_url for 'pr' artifacts)
- *   NEOKAI_WORKSPACE_PATH — workspace root (used as cwd)
- */
-const PR_MERGE_BASH_SCRIPT = [
-	'# Resolve PR URL from artifact data or current branch',
-	'PR_URL=$(jq -r \'.pr_url // .url // empty\' <<< "${NEOKAI_ARTIFACT_DATA_JSON:-{}}" 2>/dev/null || true)',
-	'if [ -z "$PR_URL" ]; then',
-	'  PR_URL=$(gh pr view --json url -q .url 2>/dev/null || true)',
-	'fi',
-	'if [ -z "$PR_URL" ]; then',
-	'  echo "No PR URL found — cannot merge" >&2',
-	'  exit 1',
-	'fi',
-	'# Idempotency guard: skip merge if PR is already merged',
-	'PR_STATE=$(gh pr view "$PR_URL" --json state -q .state 2>/dev/null || true)',
-	'if [ "$PR_STATE" = "MERGED" ]; then',
-	'  echo "PR already merged: $PR_URL"',
-	'  BASE_BRANCH=$(gh pr view "$PR_URL" --json baseRefName -q .baseRefName 2>/dev/null || echo "main")',
-	'  git checkout "$BASE_BRANCH" 2>/dev/null && git pull --ff-only 2>/dev/null || true',
-	'  jq -n --arg url "$PR_URL" \'{"merged_pr_url":$url,"status":"already_merged"}\'',
-	'  exit 0',
-	'fi',
-	'echo "Merging PR: $PR_URL"',
-	'if ! gh pr merge "$PR_URL" --squash; then',
-	'  echo "Failed to merge PR: $PR_URL" >&2',
-	'  exit 1',
-	'fi',
-	'# Sync worktree with base branch after merge',
-	'BASE_BRANCH=$(gh pr view "$PR_URL" --json baseRefName -q .baseRefName 2>/dev/null || echo "main")',
-	'git checkout "$BASE_BRANCH" 2>/dev/null && git pull --ff-only 2>/dev/null || true',
-	'echo "PR merged and worktree synced"',
-	'jq -n --arg url "$PR_URL" \'{"merged_pr_url":$url,"status":"merged"}\'',
-].join('\n');
-
-/**
  * Standard "Merge PR" completion action for short workflows.
  * Attached to the end node's completionActions[].
+ *
+ * The underlying bash script `PR_MERGE_BASH_SCRIPT` has been hoisted to
+ * `packages/daemon/src/lib/space/tools/pr-merge-script.ts` so it can be
+ * reused by the Task Agent `merge_pr` MCP tool. The completion-action
+ * wiring that consumes it here stays unchanged for Stage 1 rollout.
  */
 const MERGE_PR_COMPLETION_ACTION: CompletionAction = {
 	id: 'merge-pr',

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-merge-handler.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-merge-handler.test.ts
@@ -1,0 +1,664 @@
+/**
+ * Unit tests for the Task Agent `merge_pr` MCP tool handler.
+ *
+ * Covers the contract described in
+ *   `docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md`
+ * §§1.1 & 1.3, plus the security caveats from the plan review:
+ *   - URL validation
+ *   - Cross-check against the end-node signal (pr_url and action)
+ *   - Autonomy threshold (>= 4 auto-approves, < 4 requires human)
+ *   - Human-input response artifact enforcement at level < 4
+ *   - Idempotency via artifact-store scan (in-memory, no SQL json_extract)
+ *   - Script failure / timeout / spawn error surfacing
+ *   - Audit log emission via structured logger
+ *   - Snapshot of the canonical `request_human_input` question format
+ *   - Feature-flag gating of tool registration on the MCP server
+ *
+ * No live `bash` is invoked — the `runScript` dependency is stubbed so each
+ * test is fully deterministic.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+import { WorkflowRunArtifactRepository } from '../../../../src/storage/repositories/workflow-run-artifact-repository.ts';
+import {
+	createMergePrHandler,
+	defaultMergeScriptExecutor,
+	buildMergeApprovalQuestion,
+	buildMergeApprovalContextHint,
+	isMergeExecutorFeatureEnabled,
+	MERGE_AUTONOMY_THRESHOLD,
+	GITHUB_PR_URL_REGEX,
+	type HumanInputResponse,
+	type MergeScriptExecutor,
+	type MergeScriptResult,
+	type PostApprovalSignal,
+} from '../../../../src/lib/space/tools/task-agent-merge-handler.ts';
+import {
+	PR_MERGE_BASH_SCRIPT,
+	PR_MERGE_SCRIPT_TIMEOUT_MS,
+} from '../../../../src/lib/space/tools/pr-merge-script.ts';
+import type { Space } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(): BunDatabase {
+	const db = new BunDatabase(':memory:');
+	runMigrations(db, () => {});
+	// NOTE: FK constraints are explicitly disabled AFTER migrations because
+	// some migrations internally re-enable them. The artifact repository has
+	// a FK from `workflow_run_artifacts.run_id` → `space_workflow_runs(id)`;
+	// enforcing it would require seeding a full workflow-run graph in every
+	// test, which is outside the scope of these handler-level unit tests.
+	// The FK is exercised in repository tests.
+	db.exec('PRAGMA foreign_keys = OFF');
+	return db;
+}
+
+function makeSpace(): Space {
+	return {
+		id: 'space-merge-test',
+		slug: 'space-merge-test',
+		workspacePath: '/tmp/merge-test',
+		name: 'Merge Test Space',
+		description: '',
+		backgroundContext: '',
+		instructions: '',
+		sessionIds: [],
+		status: 'active',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	};
+}
+
+interface HandlerCtx {
+	db: BunDatabase;
+	space: Space;
+	workflowRunId: string;
+	taskId: string;
+	artifactRepo: WorkflowRunArtifactRepository;
+	scriptCalls: Array<Parameters<MergeScriptExecutor>[0]>;
+	signal: PostApprovalSignal | null;
+	humanResponse: HumanInputResponse | null;
+	autonomyLevel: number;
+	scriptResult: MergeScriptResult;
+	runScriptOverride?: MergeScriptExecutor;
+}
+
+function makeCtx(overrides: Partial<HandlerCtx> = {}): HandlerCtx {
+	const db = overrides.db ?? makeDb();
+	// Exercise a realistic GitHub PR URL — also re-used by default signal below.
+	const defaultPrUrl = 'https://github.com/neokai/neokai/pull/123';
+	return {
+		db,
+		space: overrides.space ?? makeSpace(),
+		workflowRunId: overrides.workflowRunId ?? 'run-merge-test',
+		taskId: overrides.taskId ?? 'task-merge-test',
+		artifactRepo: overrides.artifactRepo ?? new WorkflowRunArtifactRepository(db),
+		scriptCalls: overrides.scriptCalls ?? [],
+		signal:
+			overrides.signal === undefined
+				? { action: 'merge_pr', pr_url: defaultPrUrl }
+				: overrides.signal,
+		humanResponse: overrides.humanResponse ?? null,
+		autonomyLevel: overrides.autonomyLevel ?? 4,
+		scriptResult:
+			overrides.scriptResult ??
+			({
+				exitCode: 0,
+				stdout: JSON.stringify({ merged_pr_url: defaultPrUrl, status: 'merged' }),
+				stderr: '',
+				timedOut: false,
+			} satisfies MergeScriptResult),
+		runScriptOverride: overrides.runScriptOverride,
+	};
+}
+
+function buildHandler(ctx: HandlerCtx) {
+	return createMergePrHandler({
+		taskId: ctx.taskId,
+		space: ctx.space,
+		workflowRunId: ctx.workflowRunId,
+		artifactRepo: ctx.artifactRepo,
+		getSpaceAutonomyLevel: async () => ctx.autonomyLevel,
+		getSignalledPostApprovalAction: async () => ctx.signal,
+		getRecentHumanInputResponse: async () => ctx.humanResponse,
+		runScript:
+			ctx.runScriptOverride ??
+			(async (args) => {
+				ctx.scriptCalls.push(args);
+				return ctx.scriptResult;
+			}),
+	});
+}
+
+function parseToolResult<T = Record<string, unknown>>(res: {
+	content: Array<{ text: string }>;
+}): T {
+	return JSON.parse(res.content[0].text) as T;
+}
+
+const DEFAULT_PR_URL = 'https://github.com/neokai/neokai/pull/123';
+
+// ---------------------------------------------------------------------------
+// URL validation
+// ---------------------------------------------------------------------------
+
+describe('merge_pr — URL validation', () => {
+	let ctx: HandlerCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+	});
+
+	test('accepts a canonical GitHub PR URL', () => {
+		expect(GITHUB_PR_URL_REGEX.test('https://github.com/owner/repo/pull/42')).toBe(true);
+	});
+
+	test('rejects non-GitHub URLs', async () => {
+		const handler = buildHandler(ctx);
+		const res = await handler({ pr_url: 'https://gitlab.com/owner/repo/merge_requests/1' });
+		const parsed = parseToolResult<{ success: false; error: string }>(res);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('Invalid pr_url');
+		expect(ctx.scriptCalls).toHaveLength(0);
+	});
+
+	test('rejects URLs missing the PR number', async () => {
+		const handler = buildHandler(ctx);
+		const res = await handler({ pr_url: 'https://github.com/owner/repo/pull/' });
+		expect(parseToolResult<{ success: false }>(res).success).toBe(false);
+		expect(ctx.scriptCalls).toHaveLength(0);
+	});
+
+	test('rejects URLs with an http (non-TLS) scheme', async () => {
+		const handler = buildHandler(ctx);
+		const res = await handler({ pr_url: 'http://github.com/owner/repo/pull/1' });
+		expect(parseToolResult<{ success: false }>(res).success).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Happy path — level >= 4 auto-approves
+// ---------------------------------------------------------------------------
+
+describe('merge_pr — level >= 4 happy path', () => {
+	let ctx: HandlerCtx;
+	beforeEach(() => {
+		ctx = makeCtx({ autonomyLevel: MERGE_AUTONOMY_THRESHOLD });
+	});
+	afterEach(() => {
+		ctx.db.close();
+	});
+
+	test('runs the merge script, writes a result artifact, reports success', async () => {
+		const handler = buildHandler(ctx);
+		const res = await handler({ pr_url: DEFAULT_PR_URL });
+		const parsed = parseToolResult<{
+			success: boolean;
+			merged_pr_url: string;
+			approval: string;
+			artifactId: string;
+		}>(res);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.merged_pr_url).toBe(DEFAULT_PR_URL);
+		expect(parsed.approval).toBe('auto_policy');
+
+		// The script was invoked once with the canonical env + cwd.
+		expect(ctx.scriptCalls).toHaveLength(1);
+		const call = ctx.scriptCalls[0];
+		expect(call.script).toBe(PR_MERGE_BASH_SCRIPT);
+		expect(call.cwd).toBe(ctx.space.workspacePath);
+		expect(call.timeoutMs).toBe(PR_MERGE_SCRIPT_TIMEOUT_MS);
+		expect(call.env.NEOKAI_WORKSPACE_PATH).toBe(ctx.space.workspacePath);
+		expect(JSON.parse(call.env.NEOKAI_ARTIFACT_DATA_JSON)).toEqual({ pr_url: DEFAULT_PR_URL });
+
+		// Audit artifact written with approval='auto_policy', approvalReason=null.
+		const artifacts = ctx.artifactRepo.listByRun(ctx.workflowRunId, {
+			nodeId: 'task-agent',
+			artifactType: 'result',
+		});
+		expect(artifacts).toHaveLength(1);
+		expect(artifacts[0].data.merged_pr_url).toBe(DEFAULT_PR_URL);
+		expect(artifacts[0].data.status).toBe('merged');
+		expect(artifacts[0].data.approval).toBe('auto_policy');
+		expect(artifacts[0].data.approvalReason).toBeNull();
+	});
+
+	test('human_approval_reason is ignored at level >= 4 (recorded verbatim)', async () => {
+		const handler = buildHandler(ctx);
+		const res = await handler({
+			pr_url: DEFAULT_PR_URL,
+			human_approval_reason: 'ignored at high level',
+		});
+		expect(parseToolResult<{ success: true }>(res).success).toBe(true);
+		const artifacts = ctx.artifactRepo.listByRun(ctx.workflowRunId, {
+			nodeId: 'task-agent',
+			artifactType: 'result',
+		});
+		// Reason is still recorded for audit, but approval stays auto_policy.
+		expect(artifacts[0].data.approval).toBe('auto_policy');
+		expect(artifacts[0].data.approvalReason).toBe('ignored at high level');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Level < 4 refusal / approval paths
+// ---------------------------------------------------------------------------
+
+describe('merge_pr — level < 4 enforcement', () => {
+	let ctx: HandlerCtx;
+	beforeEach(() => {
+		ctx = makeCtx({ autonomyLevel: 3 });
+	});
+	afterEach(() => {
+		ctx.db.close();
+	});
+
+	test('refuses when human_approval_reason is missing', async () => {
+		const handler = buildHandler(ctx);
+		const res = await handler({ pr_url: DEFAULT_PR_URL });
+		const parsed = parseToolResult<{ success: false; error: string }>(res);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('Human approval required');
+		expect(ctx.scriptCalls).toHaveLength(0);
+		// No artifact written on refusal.
+		expect(ctx.artifactRepo.listByRun(ctx.workflowRunId, { nodeId: 'task-agent' })).toHaveLength(0);
+	});
+
+	test('refuses with fabricated reason when no human_input artifact exists', async () => {
+		// Defaults: humanResponse = null → no artifact recorded.
+		const handler = buildHandler(ctx);
+		const res = await handler({
+			pr_url: DEFAULT_PR_URL,
+			human_approval_reason: 'hallucinated: user said yes',
+		});
+		const parsed = parseToolResult<{ success: false; error: string }>(res);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('No human-input response');
+		expect(ctx.scriptCalls).toHaveLength(0);
+	});
+
+	test('refuses when human rejected in the recorded response', async () => {
+		ctx.humanResponse = {
+			response: 'No — needs security review first',
+			rejected: true,
+			createdAt: Date.now(),
+		};
+		const handler = buildHandler(ctx);
+		const res = await handler({
+			pr_url: DEFAULT_PR_URL,
+			human_approval_reason: 'No — needs security review first',
+		});
+		const parsed = parseToolResult<{ success: false; error: string }>(res);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('human rejected');
+		expect(ctx.scriptCalls).toHaveLength(0);
+	});
+
+	test('runs when human approved via a non-rejecting response', async () => {
+		ctx.humanResponse = {
+			response: 'yes, go ahead',
+			rejected: false,
+			createdAt: Date.now(),
+		};
+		const handler = buildHandler(ctx);
+		const res = await handler({
+			pr_url: DEFAULT_PR_URL,
+			human_approval_reason: 'yes, go ahead',
+		});
+		const parsed = parseToolResult<{ success: boolean; approval: string }>(res);
+		expect(parsed.success).toBe(true);
+		expect(parsed.approval).toBe('human');
+		expect(ctx.scriptCalls).toHaveLength(1);
+
+		// Artifact records the approval source + verbatim reason.
+		const artifacts = ctx.artifactRepo.listByRun(ctx.workflowRunId, {
+			nodeId: 'task-agent',
+			artifactType: 'result',
+		});
+		expect(artifacts[0].data.approval).toBe('human');
+		expect(artifacts[0].data.approvalReason).toBe('yes, go ahead');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Cross-check against end-node signal
+// ---------------------------------------------------------------------------
+
+describe('merge_pr — signal cross-check', () => {
+	let ctx: HandlerCtx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+	});
+
+	test('refuses when no end-node signal recorded', async () => {
+		ctx.signal = null;
+		const handler = buildHandler(ctx);
+		const res = await handler({ pr_url: DEFAULT_PR_URL });
+		const parsed = parseToolResult<{ success: false; error: string }>(res);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('No post-approval signal');
+		expect(ctx.scriptCalls).toHaveLength(0);
+	});
+
+	test('refuses when pr_url does not match the signalled URL', async () => {
+		ctx.signal = {
+			action: 'merge_pr',
+			pr_url: 'https://github.com/neokai/neokai/pull/999',
+		};
+		const handler = buildHandler(ctx);
+		const res = await handler({ pr_url: DEFAULT_PR_URL });
+		const parsed = parseToolResult<{ success: false; error: string }>(res);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('does not match');
+		expect(parsed.error).toContain('/pull/999');
+		expect(ctx.scriptCalls).toHaveLength(0);
+	});
+
+	test('refuses when signalled action is not merge_pr', async () => {
+		ctx.signal = {
+			action: 'close_pr',
+			pr_url: DEFAULT_PR_URL,
+		};
+		const handler = buildHandler(ctx);
+		const res = await handler({ pr_url: DEFAULT_PR_URL });
+		const parsed = parseToolResult<{ success: false; error: string }>(res);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain("action is 'close_pr'");
+		expect(ctx.scriptCalls).toHaveLength(0);
+	});
+
+	test('surfaces resolver errors instead of running the merge', async () => {
+		const ctxErr = makeCtx();
+		const handler = createMergePrHandler({
+			taskId: ctxErr.taskId,
+			space: ctxErr.space,
+			workflowRunId: ctxErr.workflowRunId,
+			artifactRepo: ctxErr.artifactRepo,
+			getSpaceAutonomyLevel: async () => 5,
+			getSignalledPostApprovalAction: async () => {
+				throw new Error('db unavailable');
+			},
+			getRecentHumanInputResponse: async () => null,
+			runScript: async (args) => {
+				ctxErr.scriptCalls.push(args);
+				return ctxErr.scriptResult;
+			},
+		});
+		const res = await handler({ pr_url: DEFAULT_PR_URL });
+		const parsed = parseToolResult<{ success: false; error: string }>(res);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('db unavailable');
+		expect(ctxErr.scriptCalls).toHaveLength(0);
+		ctxErr.db.close();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Idempotency — artifact-store in-memory scan
+// ---------------------------------------------------------------------------
+
+describe('merge_pr — idempotency', () => {
+	let ctx: HandlerCtx;
+	beforeEach(() => {
+		ctx = makeCtx({ autonomyLevel: 5 });
+	});
+	afterEach(() => {
+		ctx.db.close();
+	});
+
+	test('short-circuits when artifact store already has a merged_pr_url match', async () => {
+		// Seed a prior merge artifact with the matching URL.
+		ctx.artifactRepo.upsert({
+			id: 'prior-artifact',
+			runId: ctx.workflowRunId,
+			nodeId: 'task-agent',
+			artifactType: 'result',
+			artifactKey: 'merge_pr:1234:abcdef',
+			data: {
+				merged_pr_url: DEFAULT_PR_URL,
+				status: 'merged',
+				approval: 'auto_policy',
+			},
+		});
+
+		const handler = buildHandler(ctx);
+		const res = await handler({ pr_url: DEFAULT_PR_URL });
+		const parsed = parseToolResult<{
+			success: boolean;
+			alreadyMerged: boolean;
+			artifactId: string;
+		}>(res);
+		expect(parsed.success).toBe(true);
+		expect(parsed.alreadyMerged).toBe(true);
+		expect(parsed.artifactId).toBe('prior-artifact');
+
+		// Script NOT invoked on short-circuit.
+		expect(ctx.scriptCalls).toHaveLength(0);
+		// No duplicate artifact created.
+		const artifacts = ctx.artifactRepo.listByRun(ctx.workflowRunId, {
+			nodeId: 'task-agent',
+			artifactType: 'result',
+		});
+		expect(artifacts).toHaveLength(1);
+	});
+
+	test('does NOT short-circuit for a different PR URL', async () => {
+		ctx.artifactRepo.upsert({
+			id: 'prior-other-pr',
+			runId: ctx.workflowRunId,
+			nodeId: 'task-agent',
+			artifactType: 'result',
+			artifactKey: 'merge_pr:other',
+			data: { merged_pr_url: 'https://github.com/neokai/neokai/pull/9999', status: 'merged' },
+		});
+		const handler = buildHandler(ctx);
+		const res = await handler({ pr_url: DEFAULT_PR_URL });
+		expect(parseToolResult<{ success: true; alreadyMerged?: boolean }>(res).success).toBe(true);
+		expect(parseToolResult<{ alreadyMerged?: boolean }>(res).alreadyMerged).toBeUndefined();
+		expect(ctx.scriptCalls).toHaveLength(1);
+	});
+
+	test('relies only on listByRun — no json_extract SQL filter', async () => {
+		// Sanity check: the artifact repo's listByRun filters by nodeId + type
+		// and we scan in-memory. Inject an artifact on a different node to
+		// verify that a scan-by-nodeId prevents cross-node false positives.
+		ctx.artifactRepo.upsert({
+			id: 'other-node-artifact',
+			runId: ctx.workflowRunId,
+			nodeId: 'some-end-node',
+			artifactType: 'result',
+			artifactKey: 'noise',
+			data: { merged_pr_url: DEFAULT_PR_URL },
+		});
+		const handler = buildHandler(ctx);
+		const res = await handler({ pr_url: DEFAULT_PR_URL });
+		// The other-node artifact must NOT be treated as idempotent evidence.
+		expect(parseToolResult<{ alreadyMerged?: boolean }>(res).alreadyMerged).toBeUndefined();
+		expect(ctx.scriptCalls).toHaveLength(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Script failure / timeout / spawn errors
+// ---------------------------------------------------------------------------
+
+describe('merge_pr — script failure surfacing', () => {
+	let ctx: HandlerCtx;
+	beforeEach(() => {
+		ctx = makeCtx({ autonomyLevel: 5 });
+	});
+	afterEach(() => {
+		ctx.db.close();
+	});
+
+	test('non-zero exit → failure with stderr + stdout', async () => {
+		ctx.scriptResult = {
+			exitCode: 1,
+			stdout: '',
+			stderr: 'gh: could not authenticate',
+			timedOut: false,
+		};
+		const handler = buildHandler(ctx);
+		const res = await handler({ pr_url: DEFAULT_PR_URL });
+		const parsed = parseToolResult<{ success: false; error: string; stderr?: string }>(res);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('exited with code 1');
+		expect(parsed.stderr).toContain('could not authenticate');
+
+		// No artifact written on failure.
+		expect(ctx.artifactRepo.listByRun(ctx.workflowRunId, { nodeId: 'task-agent' })).toHaveLength(0);
+	});
+
+	test('timeout → failure carrying the timeoutMs constant', async () => {
+		ctx.scriptResult = { exitCode: -1, stdout: '', stderr: '', timedOut: true };
+		const handler = buildHandler(ctx);
+		const res = await handler({ pr_url: DEFAULT_PR_URL });
+		const parsed = parseToolResult<{ success: false; error: string }>(res);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain(`${PR_MERGE_SCRIPT_TIMEOUT_MS}ms`);
+	});
+
+	test('spawn throw → failure surfaced in error', async () => {
+		ctx.runScriptOverride = async () => {
+			throw new Error('bash: command not found');
+		};
+		const handler = buildHandler(ctx);
+		const res = await handler({ pr_url: DEFAULT_PR_URL });
+		const parsed = parseToolResult<{ success: false; error: string }>(res);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('Failed to spawn');
+		expect(parsed.error).toContain('bash: command not found');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Snapshot — canonical request_human_input question format
+// ---------------------------------------------------------------------------
+
+describe('merge_pr — canonical human-input question snapshot', () => {
+	test('question format is stable across prompt drift', () => {
+		expect(buildMergeApprovalQuestion('https://github.com/owner/repo/pull/42')).toBe(
+			'Approve merging PR https://github.com/owner/repo/pull/42?'
+		);
+	});
+
+	test('context hint format is stable across prompt drift', () => {
+		expect(buildMergeApprovalContextHint('https://github.com/owner/repo/pull/42')).toBe(
+			[
+				'The end node of this workflow signalled a post-approval action:',
+				'  action: merge_pr',
+				'  pr_url: https://github.com/owner/repo/pull/42',
+				`Space autonomy level is below the auto-merge threshold (${MERGE_AUTONOMY_THRESHOLD}), so a human must confirm before the Task Agent runs the merge.`,
+			].join('\n')
+		);
+	});
+
+	test('refusal error at level < 4 includes the canonical question verbatim', async () => {
+		const ctx = makeCtx({ autonomyLevel: 2 });
+		const handler = buildHandler(ctx);
+		const res = await handler({ pr_url: DEFAULT_PR_URL });
+		const parsed = parseToolResult<{
+			success: false;
+			error: string;
+			canonicalQuestion: string;
+			canonicalContextHint: string;
+		}>(res);
+		expect(parsed.canonicalQuestion).toBe(buildMergeApprovalQuestion(DEFAULT_PR_URL));
+		expect(parsed.canonicalContextHint).toBe(buildMergeApprovalContextHint(DEFAULT_PR_URL));
+		// Also present in the human-readable error so the LLM picks it up.
+		expect(parsed.error).toContain(`"${buildMergeApprovalQuestion(DEFAULT_PR_URL)}"`);
+		ctx.db.close();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Feature-flag detection
+// ---------------------------------------------------------------------------
+
+describe('isMergeExecutorFeatureEnabled', () => {
+	const envKey = 'NEOKAI_TASK_AGENT_MERGE_EXECUTOR';
+	const originalEnv = process.env[envKey];
+	afterEach(() => {
+		if (originalEnv === undefined) delete process.env[envKey];
+		else process.env[envKey] = originalEnv;
+	});
+
+	test('returns false when env var is unset and no space bit is set', () => {
+		delete process.env[envKey];
+		expect(isMergeExecutorFeatureEnabled()).toBe(false);
+		expect(isMergeExecutorFeatureEnabled({})).toBe(false);
+	});
+
+	test('env var accepts 1 / true / yes (case-insensitive)', () => {
+		for (const v of ['1', 'true', 'True', 'YES', 'yes']) {
+			process.env[envKey] = v;
+			expect(isMergeExecutorFeatureEnabled()).toBe(true);
+		}
+	});
+
+	test('env var rejects other values', () => {
+		for (const v of ['0', 'false', 'off', '', 'maybe']) {
+			process.env[envKey] = v;
+			expect(isMergeExecutorFeatureEnabled()).toBe(false);
+		}
+	});
+
+	test('space.experimentalFeatures.taskAgentMergeExecutor === true enables', () => {
+		delete process.env[envKey];
+		expect(
+			isMergeExecutorFeatureEnabled({
+				experimentalFeatures: { taskAgentMergeExecutor: true },
+			})
+		).toBe(true);
+	});
+
+	test('space.experimentalFeatures.taskAgentMergeExecutor falsy does not enable', () => {
+		delete process.env[envKey];
+		expect(
+			isMergeExecutorFeatureEnabled({
+				experimentalFeatures: { taskAgentMergeExecutor: false },
+			})
+		).toBe(false);
+		expect(isMergeExecutorFeatureEnabled({ experimentalFeatures: {} })).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// defaultMergeScriptExecutor — smoke test with a trivial in-process script
+// ---------------------------------------------------------------------------
+
+describe('defaultMergeScriptExecutor', () => {
+	test('spawns bash -c and captures stdout/stderr/exit', async () => {
+		const result = await defaultMergeScriptExecutor({
+			script: 'echo "hi stdout"; echo "hi stderr" >&2; exit 0',
+			env: { ...process.env } as Record<string, string>,
+			cwd: process.cwd(),
+			timeoutMs: 5_000,
+		});
+		expect(result.exitCode).toBe(0);
+		expect(result.timedOut).toBe(false);
+		expect(result.stdout).toContain('hi stdout');
+		expect(result.stderr).toContain('hi stderr');
+	});
+
+	test('returns non-zero exit for failing scripts', async () => {
+		const result = await defaultMergeScriptExecutor({
+			script: 'exit 7',
+			env: { ...process.env } as Record<string, string>,
+			cwd: process.cwd(),
+			timeoutMs: 5_000,
+		});
+		expect(result.exitCode).toBe(7);
+	});
+});

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-tool-schemas.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-tool-schemas.test.ts
@@ -116,13 +116,14 @@ describe('RequestHumanInputSchema', () => {
 // ---------------------------------------------------------------------------
 
 describe('TASK_AGENT_TOOL_SCHEMAS', () => {
-	test('contains all 4 tool schemas', () => {
+	test('contains all 5 tool schemas', () => {
 		const keys = Object.keys(TASK_AGENT_TOOL_SCHEMAS);
 		expect(keys).toContain('approve_task');
 		expect(keys).toContain('submit_for_approval');
 		expect(keys).toContain('request_human_input');
 		expect(keys).toContain('list_group_members');
-		expect(keys).toHaveLength(4);
+		expect(keys).toContain('merge_pr');
+		expect(keys).toHaveLength(5);
 	});
 
 	test('each schema value is a valid Zod schema with safeParse', () => {


### PR DESCRIPTION
Work Item 1 of 5 for the completion-actions removal refactor (`docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md`).

## Summary

- Hoists `PR_MERGE_BASH_SCRIPT` + timeout from `built-in-workflows.ts` into reusable `pr-merge-script.ts` (script now reads agent JSON via `jq -r`, not eval).
- Adds `merge_pr({ pr_url, human_approval_reason? })` MCP tool on the Task Agent server — registered only when `NEOKAI_TASK_AGENT_MERGE_EXECUTOR` or `Space.experimentalFeatures.taskAgentMergeExecutor` is set, so this is a no-op in production until Work Item 2 lands.
- Handler enforces: GitHub-PR URL regex, cross-check against the end-node `post_approval_action` signal, autonomy threshold (>=4 auto, <4 requires both `human_approval_reason` arg AND a non-rejecting `request_human_input` response artifact), idempotency via in-memory artifact scan, structured audit logging, result-artifact write.
- Canonical `buildMergeApprovalQuestion` / `buildMergeApprovalContextHint` helpers pin the level-<4 refusal wording for snapshot regression tests.
- 47 unit tests: URL validation, both autonomy paths, signal cross-check (4 cases), idempotency (3 cases), script failure / timeout / spawn-throw surfacing, snapshot pinning, feature-flag gating, `bash -c` smoke test for the default executor.

The in-tree `MERGE_PR_COMPLETION_ACTION` still works unchanged — Work Item 5 removes it.

## Test plan

- [x] `bun test tests/unit/5-space/agent/task-agent-merge-handler.test.ts` — 30 tests pass
- [x] `bun test tests/unit/5-space/agent/task-agent-tool-schemas.test.ts` — updated aggregate test passes
- [x] Full 5-space/agent shard: 622/622 pass
- [x] Full 5-space/workflow shard: 346/346 pass
- [x] `bun run check` (lint + typecheck + knip) clean