### PR TITLE
docs: revise plan — workflow-declared post-approval agent routing

### DIFF
--- a/docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md
+++ b/docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md
@@ -1,162 +1,379 @@
-# Plan: Remove `completionActions` — Task Agent as Post-Approval Executor
+# Plan: Remove `completionActions` — Workflow-Defined Post-Approval Agent Routing
 
 **Task:** Space Task #75
 **Source research:** [`docs/research/pr-merging-completion-actions.md`](../research/pr-merging-completion-actions.md)
 **Status:** Planning — no code changes yet
 **Author:** Research node
+**Revision:** 2026-04-23 — approach changed from "Task Agent MCP `merge_pr` tool" to "workflow-declared post-approval agent". See §8 "Revision history" for the full context.
 
 ---
 
 ## 0. Executive summary
 
 The research doc argues (and this plan accepts) that the `completionActions`
-system should be **removed entirely** and replaced by a single, uniform
-post-approval executor: the **Task Agent**. Concretely:
+system should be **removed entirely**. The original revision of this plan
+proposed replacing it with a narrow `merge_pr` MCP tool on the Task Agent.
+That approach was reconsidered after initial review:
 
-1. End nodes signal post-approval intent via a structured `send_message` to
-   `task-agent` (with `data: { pr_url, post_approval_action: 'merge_pr' }`) and
-   **then** call `approve_task()` / `submit_for_approval()` exactly as today.
-2. The Task Agent receives the structured intent, checks space autonomy level:
-   - Level ≥ 4 → auto-executes a narrowly-scoped new MCP tool `merge_pr(pr_url)`.
-   - Level 1–3 → first calls `request_human_input(question, context)` to surface
-     the merge decision to the user; after the human responds, calls
-     `merge_pr(pr_url)` with the human approval recorded on the call.
-3. The entire `CompletionAction` type, its runtime pipeline, its RPC intercepts,
-   its MCP tool (`approve_completion_action`), its DB columns, and its UI
-   surface are deleted. The per-workflow knob `completionAutonomyLevel`
-   **stays** (it controls `approve_task` vs `submit_for_approval` at the
-   *work-is-good* level, orthogonal to the merge-PR level).
+- Real-world post-approval work (merge a PR, deploy, publish a package, …) is
+  rarely a one-shot shell command. It involves waiting on CI, handling
+  conflicts, retrying on transient failures, and deciding when to escalate to
+  a human. A rigid handler cannot do this well; it needs **LLM dynamic
+  processing**.
+- Post-approval actions are **per-workflow**, not per-daemon. The workflow
+  template knows its own domain (coding-with-PRs vs. research-with-docs vs.
+  plan-and-decompose). Hardcoding "merge_pr" as a daemon-level primitive
+  leaks workflow-specific knowledge into the runtime.
+- The Task Agent's "orchestrator, never executor" contract should stay
+  intact. Adding any executor tool to it (narrow or otherwise) erodes the
+  contract and makes future requests ("can Task Agent also deploy?") harder
+  to refuse.
 
-This resolves Gaps #1, #2, #3 from the research doc in one move, eliminates the
-failure modes catalogued in §10 of that doc, and produces a single unified
-approval UX.
+**The revised approach is workflow-declared post-approval agent routing.** In
+one sentence: a workflow template declares `postApproval.targetAgent` (an
+agent role that is part of the same workflow, or `task-agent`) and
+`postApproval.instructions` (a templated prompt). After the end node signals
+completion, the Task Agent transitions the task to a new `approved` status,
+spawns a fresh session for the target agent with the interpolated
+instructions, and moves the task to `done` once that session completes. The
+target agent is a normal workflow-agent session with its normal toolkit
+(Bash, file ops, MCP servers, everything), so it can handle merge complexity
+the same way any other node handles its work — with LLM judgement, retries,
+and escalation.
+
+Concretely:
+
+1. New workflow schema field `postApproval: { targetAgent, instructions }` —
+   `targetAgent` must be either a declared agent role in the same workflow or
+   the literal string `task-agent`. `instructions` is a templated string
+   (`{{pr_url}}`, `{{autonomy_level}}`, `{{reviewer_name}}`, …) evaluated at
+   routing time.
+2. End nodes still signal post-approval intent via a structured `send_message`
+   to `task-agent` (with `data: { pr_url, post_approval_action: 'merge_pr' }`
+   or any other domain-specific key) and **then** call `approve_task()` /
+   `submit_for_approval()` exactly as today. This payload survives as the
+   template's data source — `{{pr_url}}` comes from there.
+3. New task status value **`approved`**. Lifecycle becomes
+   `open → in_progress → review? → approved → done` (the `review` branch is
+   unchanged from today). The Task Agent transitions the task to `approved`
+   when an end node closes it; it transitions to `done` once post-approval
+   completes.
+4. Task Agent, on seeing `approved`, looks up `workflow.postApproval`:
+   - If the workflow has no `postApproval` → immediately transition to `done`
+     (single-step workflows, documentation missions).
+   - Otherwise → spawn a new session for `targetAgent` with the interpolated
+     `instructions` as the kickoff user message. Wait for the session to
+     complete.
+5. The spawned post-approval session is a normal workflow-agent session: it
+   has the agent's full system prompt, tool surface, and MCP servers. For a
+   PR merge, the instructions direct it to run the appropriate shell
+   commands (`gh pr view`, `gh pr merge`, worktree sync). For a different
+   workflow's post-approval it could be publishing a release, notifying
+   slack, etc. — all determined by the workflow author's instruction string.
+6. The entire `CompletionAction` type, its runtime pipeline, its RPC
+   intercepts, its MCP tool (`approve_completion_action`), its DB columns,
+   and its UI surface are deleted. The per-workflow knob
+   `completionAutonomyLevel` **stays** (it controls `approve_task` vs
+   `submit_for_approval` at the *work-is-good* level, orthogonal to the
+   post-approval step).
+
+This resolves Gaps #1, #2, #3 from the research doc in one move, eliminates
+the failure modes catalogued in §10 of that doc, and produces a single
+unified approval UX — without introducing new executor primitives into the
+Task Agent or daemon.
 
 ### Prioritized implementation order
 
 | Stage | PR | Scope | Dependency |
 |------|----|-------|------------|
-| 1 | `merge_pr` tool + wiring | Add the Task Agent `merge_pr` MCP tool (disabled for now via feature flag), unit-tested. No prompt/workflow changes. | — |
-| 2 | End-node handoff | Update built-in workflow prompts to `send_message` to `task-agent` with `{ pr_url, post_approval_action }` before `approve_task`. Update Task Agent system prompt + kickoff to handle the signal. Flip the feature flag. | Stage 1 deployed |
-| 3 | Remove runtime pipeline | Delete `resolveCompletionWithActions` / `resumeCompletionActions` / `executeCompletionAction`; delete the `spaceTask.update` intercept for `completion_action`; delete `approve_completion_action` MCP tool; delete `PendingCompletionActionBanner`. Task/run completion now flows through a simplified path. | Stage 2 deployed |
-| 4 | Schema cleanup | Drop `pending_action_index`, `pending_checkpoint_type='completion_action'` value, `completion_actions_fired_at`, `MERGE_PR_COMPLETION_ACTION` etc. from DB & shared types. | Stage 3 merged |
-| 5 | Docs + tests sweep | Remove stale test coverage, update design docs, add changelog entry. | Stage 4 merged |
+| 1 | Task state `approved` + workflow schema | Add `TaskStatus='approved'` (shared types + DB migration), add `WorkflowDefinition.postApproval` shape + validator, no behaviour change yet (nothing reads `approved` or `postApproval` beyond load/save). Unit-tested. | — |
+| 2 | Task Agent post-approval routing | Task Agent reads `workflow.postApproval` on task-closed event; transitions task to `approved`; spawns target-agent session with templated instructions; waits for that session to complete; transitions task to `done`. Behind a feature flag so callers continue seeing completion-actions behaviour until workflow templates migrate. | Stage 1 deployed |
+| 3 | End-node handoff + built-in workflow `postApproval` entries | Update built-in workflow prompts to `send_message` to `task-agent` with `{ pr_url, post_approval_action }` before `approve_task`. Populate `postApproval` on all 5 built-in workflows. Update Task Agent system prompt + kickoff. Flip the feature flag. | Stage 2 deployed |
+| 4 | Remove completion-action runtime pipeline | Delete `resolveCompletionWithActions` / `resumeCompletionActions` / `executeCompletionAction`; delete the `spaceTask.update` intercept for `completion_action`; delete `approve_completion_action` MCP tool; delete `PendingCompletionActionBanner`. Task/run completion now flows through the new `approved → done` path. | Stage 3 deployed |
+| 5 | Schema cleanup + docs | Drop `pending_action_index`, `pending_checkpoint_type='completion_action'` value, `completion_actions_fired_at`, `MERGE_PR_COMPLETION_ACTION` etc. from DB & shared types. Docs refresh. Changelog. | Stage 4 merged |
 
-Stages 3 + 4 can reasonably ship as one PR if the diff is still reviewable;
+Stages 4 + 5 can reasonably ship as one PR if the diff is still reviewable;
 separating them keeps the migration safer.
 
 ---
 
-## 1. Task Agent merge capability
+## 1. Post-approval agent routing
 
-### 1.1 New MCP tool: `merge_pr`
+### 1.1 Workflow schema: `postApproval`
 
-Add a single new tool on the Task Agent's MCP server, defined alongside the
-existing tools in
-[`packages/daemon/src/lib/space/tools/task-agent-tools.ts`](../../packages/daemon/src/lib/space/tools/task-agent-tools.ts).
+New optional field on `WorkflowDefinition` (shared type):
 
 ```ts
-merge_pr(args: {
-    pr_url: string;             // fully-qualified GitHub PR URL
-    human_approval_reason?: string; // required when autonomy < MERGE_AUTONOMY_THRESHOLD
-}): Promise<ToolResult>;
+interface PostApprovalRoute {
+    /**
+     * Agent role that runs post-approval work. Must be one of:
+     *   - An agent name declared on a node in THIS workflow (e.g. "reviewer",
+     *     "coder", "qa"). Post-approval spawns a fresh session for that role
+     *     with the same config as a workflow-node session (same tool surface,
+     *     same MCP servers, same worktree), independent of any previous
+     *     execution.
+     *   - The literal string "task-agent". Post-approval runs in the Task
+     *     Agent's own session — used only when no workflow agent is
+     *     appropriate and the Task Agent's orchestrator-tool surface is
+     *     sufficient.
+     * Validation runs at workflow save + load time; see §1.5.
+     */
+    targetAgent: string;
+
+    /**
+     * Templated user-message prompt delivered to the target agent's new
+     * session as its kickoff input. Template variables are interpolated from
+     * the signalled data and space state at routing time; see §1.6 for the
+     * template grammar.
+     *
+     * Example:
+     *   "The task has been approved. Merge the PR at {{pr_url}}.
+     *    Space autonomy level: {{autonomy_level}}.
+     *    - If autonomy >= 4, merge directly. Sync your worktree after.
+     *    - Otherwise, call request_human_input to confirm, then merge.
+     *    Verify CI status first (gh pr checks). On conflicts, rebase and
+     *    retry. Escalate to the user via request_human_input if you get
+     *    stuck."
+     */
+    instructions: string;
+}
+
+interface WorkflowDefinition {
+    // ... existing fields
+    postApproval?: PostApprovalRoute;
+}
 ```
 
-**Handler contract** (new file
-`packages/daemon/src/lib/space/tools/task-agent-merge-handler.ts`, wired from
-`createTaskAgentMcpServer`):
+Rules:
 
-1. Validate `pr_url` against `^https://github.com/[^/]+/[^/]+/pull/\d+$`.
-2. Resolve the current autonomy level via the injected
-   `getSpaceAutonomyLevel(config.space.id)` resolver (already present on
-   `TaskAgentToolsConfig`); `level = (await getSpaceAutonomyLevel(space.id)) ?? 1`.
-   This re-reads live state, so a racing autonomy downgrade between tool
-   registration and invocation is caught. The space ID and workspace path are
-   available as `config.space.id` / `config.space.workspacePath`.
-3. `const MERGE_AUTONOMY_THRESHOLD = 4` (constant — matches the current
-   `MERGE_PR_COMPLETION_ACTION.requiredLevel`, so no behavioural change at the
-   autonomy boundary).
-4. If `level < MERGE_AUTONOMY_THRESHOLD` **and** `args.human_approval_reason`
-   is missing or empty → return
-   `{ success: false, error: 'Human approval required: call request_human_input first, then retry with human_approval_reason set to the human\'s response.' }`.
-   This is belt-and-braces: the Task Agent's system prompt also tells it this
-   rule, but an agent that ignores the prompt is caught by the handler.
-5. Idempotency: query artifact store for any existing
-   `{ type: 'result', data.merged_pr_url == pr_url }` — if found, return
-   `{ success: true, alreadyMerged: true }`. (Artifact-based idempotency keeps
-   state local to the workflow run; no new DB column needed.)
-6. Actually invoke the merge. Reuse the existing
-   [`PR_MERGE_BASH_SCRIPT`](../../packages/daemon/src/lib/space/workflows/built-in-workflows.ts)
-   body — move it out of `built-in-workflows.ts` into a new helper
-   `packages/daemon/src/lib/space/tools/pr-merge-script.ts` that exports
-   `PR_MERGE_BASH_SCRIPT` as a string. Execute via the existing gate-script
-   runner pattern (`Bun.spawn` / `child_process.spawn`) with:
-    - `cwd = space.workspacePath`
-    - env: `NEOKAI_ARTIFACT_DATA_JSON = JSON.stringify({ pr_url })`,
-            `NEOKAI_WORKSPACE_PATH = space.workspacePath`
-    - timeout: 120_000 ms (matches current completion-action timeout at
-      `space-runtime.ts:2209`)
-7. On success: `artifactRepo.upsert({ type: 'result', append: true, nodeId: 'task-agent', data: { merged_pr_url: pr_url, status: 'merged', mergedAt: Date.now(), approval: level >= MERGE_AUTONOMY_THRESHOLD ? 'auto_policy' : 'human', approvalReason: args.human_approval_reason ?? null } })`
-   so the audit trail mirrors the pre-removal shape.
-8. On failure: return `{ success: false, error, stderr }` — Task Agent can
-   surface this via its normal human-coordination path (`save_artifact` +
-   `submit_for_approval` if it decides the task cannot close).
+- **Optional.** Workflows without a `postApproval` field transition directly
+  from `approved → done` with no routing. Applies to workflows whose
+  real-world lifecycle has no after-approval step (documentation, research,
+  plan-and-decompose).
+- **Single target per workflow.** No fan-out, no fallback chain. If a
+  workflow needs both "merge PR" and "notify slack" the authors compose them
+  inside `instructions`: the single target agent runs the combined flow
+  step-by-step.
+- **No dedicated tool surface.** The target agent's session is started with
+  the same tool surface as if it were running a workflow node. No
+  post-approval-specific MCP tools or Bash carve-outs.
 
-### 1.2 Why a dedicated tool, not generic Bash
+### 1.2 Why a post-approval agent, not a dedicated MCP tool
 
-The Task Agent's system prompt at
-[`packages/daemon/src/lib/space/agents/task-agent.ts:281-283`](../../packages/daemon/src/lib/space/agents/task-agent.ts)
-declares:
+(This section replaces the original revision's §1.2 "Why a dedicated tool,
+not generic Bash". The argument flipped after the initial review: the
+deterministic handler was too rigid for real-world merges.)
 
-> "Do not execute code directly. You are an orchestrator, not an executor.
-> All code execution, file editing, and git operations happen in workflow
-> node sessions. You have no direct access to the filesystem."
+The Task Agent's system prompt declares it an orchestrator, not an executor.
+Holding that line is valuable for three reasons, all of which push against
+adding even a narrow executor tool like `merge_pr`:
 
-A generic Bash carve-out would force us to unpick this rule (the LLM might
-decide to run arbitrary commands). A single-purpose `merge_pr` tool:
+1. **Merging a PR is not a one-shot shell command.** It requires waiting on
+   CI, resolving conflicts, retrying on transient GitHub 500s, and deciding
+   when to escalate to a human. A `Bun.spawn` handler with a fixed bash
+   script has no decision surface for any of this; it either succeeds in one
+   attempt or returns a stderr blob. LLM-dynamic handling is the natural fit.
 
-- Is a **narrow, well-defined class of action** (merge a specific, validated PR URL)
-- Keeps the "orchestrator only" contract intact for everything else
-- Is unit-testable without spinning up an LLM
-- Has its own autonomy check at the handler level — cannot be bypassed by a
-  hallucinated model call
+2. **Post-approval work is workflow-specific.** A coding workflow merges a
+   PR. A release workflow cuts a tag and publishes. A docs workflow might
+   open a downstream docs-site PR. Encoding any one of these as a daemon
+   primitive leaks the workflow's domain into the runtime and invites
+   `deploy_service`, `publish_package`, `notify_oncall` as follow-up
+   primitives. Workflow authors already write the rest of their workflow in
+   prompts — let them write post-approval the same way.
 
-This is a **deliberate, documented policy exception**, not a silent broadening.
-Add a §"Post-Approval Actions" subsection to the Task Agent system prompt
-(see §3.2) explaining when this tool is available and how to use it.
+3. **The orchestrator contract is a narrow interface worth keeping.** The
+   Task Agent's value is that it is predictable: it tracks tasks, routes
+   messages, requests human input, spawns agents. Every executor tool added
+   to its MCP server enlarges its surface area and makes its behaviour
+   harder to reason about. Routing to a purpose-built agent session keeps
+   the Task Agent thin.
 
-### 1.3 Wiring
+**Tradeoff accepted:** the post-approval agent session has a full toolkit
+(Bash, filesystem, MCP) — much broader than a dedicated `merge_pr` handler.
+This is fine because: (a) workflow-node sessions already have it, so we are
+not granting a new privilege — we are reusing an existing one; (b) the
+session is short-lived and scoped to the task at hand; (c) the autonomy
+level and instruction template bound what the agent does in practice
+(§3).
 
-`createTaskAgentMcpServer` in
-[`packages/daemon/src/lib/space/tools/task-agent-tools.ts:965-1061`](../../packages/daemon/src/lib/space/tools/task-agent-tools.ts)
-already takes a `TaskAgentToolsConfig` whose existing fields cover every
-dependency the new handler needs:
+### 1.3 New task status: `approved`
 
-- `space: Space` — provides `space.id` and `space.workspacePath` (the merge
-  script's `cwd`).
-- `taskId: string` — for logging / audit.
-- `getSpaceAutonomyLevel?: (spaceId: string) => Promise<number>` — live
-  autonomy resolver (required — register the tool only when this is set).
-- `artifactRepo` is reachable through the same path `save_artifact` uses today.
+Add `'approved'` to the `TaskStatus` union (shared type) and to the DB
+`space_tasks.status` CHECK constraint. The full set becomes:
 
-No new field on `TaskAgentToolsConfig` is required. Add:
+```
+open | in_progress | review | approved | done | blocked | cancelled | archived
+```
 
-- `tool definition` in the MCP `tools` list (around line 1044)
-- `handler` registration (around line 975)
+Semantics:
 
-No new manager plumbing is required; `TaskAgentManager.spawnTaskAgent` in
-[`packages/daemon/src/lib/space/runtime/task-agent-manager.ts:429-683`](../../packages/daemon/src/lib/space/runtime/task-agent-manager.ts)
-already composes the MCP server with all these dependencies.
+| Status | Meaning |
+|--------|---------|
+| `in_progress` | A workflow node is actively working. |
+| `review` | The end node returned `submit_for_approval`; a human must approve (or reject) before the task can close. Unchanged. |
+| **`approved` (new)** | The work has been accepted (by the end node via `approve_task`, or by a human via `approvePendingCompletion`). **Post-approval is now pending.** The Task Agent reads `workflow.postApproval` and routes. |
+| `done` | Terminal success. Reached from `approved` once the post-approval session completes (or immediately if the workflow has no `postApproval`). |
+| `blocked` | Terminal failure or human intervention required. |
+| `cancelled` | User cancelled. |
+| `archived` | Moved out of active views. |
 
-### 1.4 Feature flag for staged rollout
+Transitions relevant to this plan:
 
-Gate the tool registration behind a `Space.experimentalFeatures` bit (or a
-`NEOKAI_TASK_AGENT_MERGE_EXECUTOR` env var) during Stage 1 so the tool is
-defined, tested, and wired but not yet visible to agents. Flip the flag in
-Stage 2 after the workflow prompt changes land.
+```
+in_progress --approve_task()--> approved
+in_progress --submit_for_approval()--> review
+review --approve (human)--> approved
+approved --no postApproval--> done
+approved --postApproval session completed--> done
+approved --postApproval session failed after retries--> blocked
+```
+
+**DB migration:**
+
+- Extend the `status` CHECK constraint on `space_tasks` to include
+  `'approved'`. Uses the table-rebuild pattern (SQLite cannot alter a CHECK
+  constraint in place).
+- Add a new column `space_tasks.post_approval_session_id TEXT NULL` that
+  records the sub-session spawned for post-approval. Nullable because many
+  tasks won't have one.
+- Add a new column `space_tasks.post_approval_started_at INTEGER NULL` for
+  audit / observability.
+
+No backfill required: existing tasks are all in terminal or in-flight
+statuses that don't include `approved`.
+
+### 1.4 Task Agent routing mechanics
+
+Three event sites interact:
+
+1. **End-node `approve_task` completes.** Today this flows through the
+   completion-action pipeline. New behaviour:
+   - `SpaceRuntime` transitions the task from `in_progress → approved`
+     (instead of the current `in_progress → pending_completion_action → done`).
+   - Emits a `[TASK_APPROVED]` runtime event to the Task Agent session
+     carrying the end-node's structured-data payload verbatim (for template
+     interpolation).
+
+2. **`approvePendingCompletion` (the human-approves-the-work path).**
+   Transitions the task `review → approved` instead of today's `review → done`
+   (or the completion-action branch). Emits `[TASK_APPROVED]` the same way.
+
+3. **Task Agent receives `[TASK_APPROVED]`.** It looks up
+   `workflow.postApproval` for the current workflow:
+
+   - **If no `postApproval`:** Task Agent calls a new internal RPC
+     `spaceTask.completePostApproval({ taskId })` which transitions
+     `approved → done`. Done.
+
+   - **If `postApproval.targetAgent === 'task-agent'`:** Task Agent
+     interpolates `instructions` and acts on them within its own session.
+     This is the narrow case where the orchestrator itself is the target
+     — used when the post-approval work is small enough to fit within
+     the Task Agent's orchestrator tool surface (e.g. sending a notification
+     via `send_message`, writing a final artifact, no-op workflows). On
+     completion, calls `spaceTask.completePostApproval` to close.
+
+   - **Otherwise (targetAgent is a workflow-agent role):** Task Agent
+     spawns a new session for that role:
+     - Session kind: `space_task_post_approval` (new session type) or reuse
+       the existing `space_task_agent` sub-session model. Decision deferred
+       to §7.1.
+     - Same worktree, same MCP server config as the corresponding
+       workflow-node session would have.
+     - Kickoff user message = interpolated `instructions`.
+     - Records `post_approval_session_id` on the task.
+     - Awaits session completion.
+
+4. **Post-approval session completes.** The spawned session terminates
+   normally (its agent calls `approve_task`, or simply exits). Task Agent
+   observes the `[NODE_COMPLETE]`-equivalent event and calls
+   `spaceTask.completePostApproval({ taskId })` to move `approved → done`.
+
+5. **Post-approval session fails.** If the session exits with an error, or
+   the spawned agent calls `submit_for_approval` on its post-approval work
+   (escalating to a human), the task stays in `approved` with a
+   `postApprovalBlockedReason` recorded. The user sees a banner similar to
+   today's `PendingCompletionActionBanner` but driven by the session
+   outcome, not by a specific action. They can inspect the session
+   transcript, fix the issue externally, and either retry or manually close.
+
+### 1.5 Eligible target agents + validation
+
+`targetAgent` must resolve at workflow save/load time. The validator:
+
+```ts
+function validatePostApproval(
+    wf: WorkflowDefinition
+): PostApprovalValidationResult {
+    if (!wf.postApproval) return { ok: true };
+    const { targetAgent } = wf.postApproval;
+    if (targetAgent === 'task-agent') return { ok: true };
+    const workflowAgents = new Set(
+        wf.nodes.flatMap((n) => n.agents.map((a) => a.name))
+    );
+    if (workflowAgents.has(targetAgent)) return { ok: true };
+    return {
+        ok: false,
+        error: `postApproval.targetAgent "${targetAgent}" is not a declared agent on this workflow and is not "task-agent". Eligible: ${[...workflowAgents, 'task-agent'].join(', ')}.`,
+    };
+}
+```
+
+Runs in `SpaceWorkflowManager.create` and `.update`, and on load from DB in
+`SpaceWorkflowManager.get` (surfaces as a validator warning — workflow loads
+but `postApproval` is disabled for that run until fixed, to protect against
+stale configs after a node removal).
+
+**Why restrict to workflow-declared agents + task-agent?** Any other target
+would require inventing a new agent role with ad-hoc config. The constraint
+keeps the surface narrow: a workflow author can only route to agents they
+already understand (because they already declared them) or the
+orchestrator. If a post-approval step needs a different agent, add it as a
+node in the workflow first.
+
+### 1.6 Template grammar for `instructions`
+
+Minimal, deterministic interpolation — no conditional logic, no expressions,
+no code execution. The template string is split on `{{…}}` tokens and each
+token is looked up against the interpolation context:
+
+```ts
+interface PostApprovalTemplateContext {
+    /** From end-node structured-data: { pr_url: "..." }. */
+    [key: string]: string | number | boolean | undefined;
+
+    // Standard variables always provided by the runtime:
+    autonomy_level: number;      // space.autonomyLevel at routing time (1–5)
+    task_id: string;             // the task being closed
+    task_title: string;          // task title
+    reviewer_name: string;       // agent name of the end node that approved
+    approval_source:             // how the task reached 'approved'
+        'end_node' | 'human_review';
+    space_id: string;
+    workspace_path: string;
+}
+```
+
+- Undefined variables render as the literal token (e.g. `{{pr_url}}` stays
+  as `{{pr_url}}`) and emit a runtime warning. The target agent sees the
+  gap and can ask the user for clarification via `request_human_input`.
+- No escaping for `{`/`}` is needed in practice; the grammar is scoped to
+  `{{identifier}}` where identifier is `[a-zA-Z_][a-zA-Z0-9_]*`.
+- Templating is performed in a single pass in the Task Agent's routing
+  code before the kickoff message is sent.
+
+**Explicitly out of scope for v1:** conditionals (`{{#if}}`), iteration,
+nested variable lookups, helper functions. The goal is a dumb string
+substitute — anything more is delegated to the LLM reading the prompt.
 
 ---
 
 ## 2. End-node handoff protocol
+
+*(Largely unchanged from the previous revision — the signalling mechanism
+still fits the new design. Only §2.3 is rewritten to reflect the new
+routing semantics.)*
 
 ### 2.1 Signalling mechanism — `send_message` to `task-agent` with structured `data`
 
@@ -179,8 +396,8 @@ When `data` is non-empty the router formats the delivered message as:
 </structured-data>
 ```
 
-So the Task Agent can parse `pr_url` out of its conversation context with zero
-new infrastructure.
+So the Task Agent can parse `pr_url` out of its conversation context with
+zero new infrastructure.
 
 **New convention:** end-node agents send, as a required step before calling
 `approve_task()` / `submit_for_approval()`:
@@ -188,12 +405,19 @@ new infrastructure.
 ```ts
 send_message({
     target: 'task-agent',
-    message: 'Work complete. PR ready for post-approval action: merge_pr.',
+    message: 'Work complete. Post-approval data attached.',
     data: { pr_url: '<url>', post_approval_action: 'merge_pr' }
 });
 ```
 
-This gives the Task Agent the `pr_url` and a typed intent (`post_approval_action: 'merge_pr'`) in its context, so when the task completes it can act.
+The `data` keys are **arbitrary** from the runtime's perspective — the Task
+Agent uses them as the template interpolation context in §1.6. A workflow
+whose `instructions` references `{{release_tag}}` would have its end node
+signal `data: { release_tag: '...', post_approval_action: 'publish_release' }`
+instead. The `post_approval_action` key is a **convention for the operator
+reading the conversation**, not a runtime dispatch key — the runtime
+dispatches on `workflow.postApproval.targetAgent`, not on the signalled
+action.
 
 ### 2.2 Why not a gate write?
 
@@ -212,9 +436,11 @@ supplied. But:
   this way).
 
 If we decide later that stronger enforcement is needed (e.g. "end-node must
-have signalled an action before its `approve_task` is accepted"), we can add a
-runtime check: refuse `approve_task` when `reportedStatus === 'done'` is set
-but no `{ post_approval_action }` artifact / inbound task-agent message exists.
+have signalled data matching its workflow's expected template variables
+before its `approve_task` is accepted"), add a runtime check in Stage 3: on
+`approve_task`, if the workflow has a `postApproval` referencing template
+variables not present in any signalled `data`, log a warning and optionally
+refuse.
 
 ### 2.3 When does the Task Agent act?
 
@@ -222,49 +448,53 @@ Two signals converge in the Task Agent's existing event loop
 (documented in the Task Agent system prompt at
 [`task-agent.ts:233-260`](../../packages/daemon/src/lib/space/agents/task-agent.ts)):
 
-1. The structured `[Message from reviewer]: ...\n<structured-data>{pr_url, post_approval_action}</structured-data>`
-   arrives in the Task Agent's conversation.
-2. A `[NODE_COMPLETE] Node "...-Review" sub-session (...) has completed`
-   injection arrives once the end-node session ends
-   ([`task-agent-manager.ts:1822-1834`](../../packages/daemon/src/lib/space/runtime/task-agent-manager.ts)).
+1. The structured `[Message from reviewer]: ...\n<structured-data>{...}</structured-data>`
+   arrives in the Task Agent's conversation. Task Agent remembers the
+   payload in its context.
+2. The task transitions to `approved` — either via `approve_task()` from the
+   end-node or via the human `approvePendingCompletion` path. A new runtime
+   event `[TASK_APPROVED]` is injected into the Task Agent's session at that
+   moment.
 
-**New runtime injection** — in addition to the existing `[NODE_COMPLETE]`,
-when the canonical task transitions to `status = 'done'` AND
-`reportedStatus = 'done'` AND an end-node message declared
-`post_approval_action`, inject a `[TASK_APPROVED]` event:
+**Runtime injection shape:**
 
 ```
-[TASK_APPROVED] Task has been approved for completion. Pending post-approval action:
-  action: merge_pr
-  pr_url: <url>
-  autonomy_level: <level>
-  merge_autonomy_threshold: 4
-Next step:
-  - If autonomy_level >= merge_autonomy_threshold, call merge_pr({ pr_url }) directly.
-  - Otherwise, call request_human_input({ question: "Approve merging PR <url>?", context: "..." })
-    first, then call merge_pr({ pr_url, human_approval_reason: <human's response> }).
+[TASK_APPROVED] Task <taskId> ("<task-title>") was approved.
+
+Post-approval routing:
+  workflow: <workflow-name>
+  target_agent: <target_agent or "none">
+  interpolation_keys_expected: [pr_url, autonomy_level, ...]
+  approval_source: <end_node | human_review>
+
+If target_agent is declared, route now: spawn the session with the
+interpolated instructions from workflow.postApproval.instructions. If
+target_agent is "task-agent", act on those instructions in this
+session and then call spaceTask.completePostApproval when done. If
+target_agent is "none", call spaceTask.completePostApproval immediately.
 ```
 
-This injection happens from `SpaceRuntime` at the same site where the task
-currently transitions to `done` ([`space-runtime.ts:611-621`](../../packages/daemon/src/lib/space/runtime/space-runtime.ts)
-and [`space-runtime.ts:1561-1569`](../../packages/daemon/src/lib/space/runtime/space-runtime.ts)).
+The Task Agent has a new tool `spawn_post_approval_session` (internal to the
+Task Agent MCP server; not exposed to node agents) that accepts
+`{ taskId, targetAgent }` and performs the spawn. `completePostApproval` is
+a no-args status transition (Task Agent already owns the task).
 
-The equivalent injection also fires after the `submit_for_approval` path: when
-`spaceTask.approvePendingCompletion` transitions the task from `review → done`
-([`space-task-handlers.ts:328-333`](../../packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts)),
-emit `[TASK_APPROVED]` into the task's Task Agent session before returning.
+Alternative considered, rejected: have the runtime do the spawn automatically
+on the `[TASK_APPROVED]` boundary, without the Task Agent's involvement.
+Rejected because:
 
-**How the Task Agent knows the pr_url / action:** from the structured message
-it already received in its own conversation. The `[TASK_APPROVED]` injection
-does not re-deliver the data — it just tells the agent to act.
-
-Alternative design (considered, rejected): have the runtime look up the
-artifact store for a `{ post_approval_action }` record and include it in the
-`[TASK_APPROVED]` injection. Rejected because it duplicates state (agent
-already has the data in context) and couples runtime to a specific artifact
-schema.
+- The Task Agent owning the spawn keeps the control plane in one place.
+- LLM judgement may still be useful pre-spawn (e.g. the Task Agent may
+  decide the `instructions` need augmenting with context from artifacts it
+  has seen).
+- Symmetry with the `submit_for_approval` path, which the Task Agent already
+  handles via its conversation loop.
 
 ### 2.4 Prompt changes by node
+
+*(Unchanged from the previous revision — all five built-in workflows still
+need to emit the `send_message(task-agent, …)` step before `approve_task`.
+The full list is identical to the previous §2.4.)*
 
 All four built-in workflows' end-node prompts live in
 [`built-in-workflows.ts`](../../packages/daemon/src/lib/space/workflows/built-in-workflows.ts).
@@ -282,189 +512,183 @@ with:
    c. Signal the Task Agent that a merge is the post-approval action:
       send_message(
          target: "task-agent",
-         message: "Reviewer approved. PR ready for merge.",
+         message: "Reviewer approved. PR ready for post-approval.",
          data: { pr_url: "<url>", post_approval_action: "merge_pr" }
       )
    d. Call `save_artifact({ type: "result", append: true, summary, prUrl })` to record the audit entry.
    e. Call `approve_task()` to close the task. If autonomy blocks self-close,
-      call `submit_for_approval({ reason: "…" })` instead — the Task Agent will
-      still receive the post-approval signal.
+      call `submit_for_approval({ reason: "…" })` instead — the Task Agent
+      will still route post-approval once the human approves.
 ```
-
-The Coding node (`CODING_CODE_NODE`) prompt is unchanged — Coder never merges.
 
 #### 2.4.2 Research Workflow — `RESEARCH_WORKFLOW` Review node
-File: `built-in-workflows.ts:633-662`.
-Replace step 6 identically:
-
-```
-6. If satisfied:
-   a. Verify the PR is still open and mergeable.
-   b. Signal the Task Agent that a merge is the post-approval action:
-      send_message(target: "task-agent", message: "Research approved. PR ready for merge.",
-                   data: { pr_url: "<url>", post_approval_action: "merge_pr" })
-   c. Call `save_artifact({ type: "result", append: true, summary, prUrl })` to record the audit entry.
-   d. Call `approve_task()` (or `submit_for_approval({ reason })` if autonomy blocks self-close).
-```
+File: `built-in-workflows.ts:633-662`. Analogous change to step 6.
 
 #### 2.4.3 Coding with QA Workflow — `FULLSTACK_QA_LOOP_WORKFLOW` QA node
 File: `built-in-workflows.ts:1107-1135`.
 **Remove** steps 5–6 ("merge the PR with `gh pr merge … --squash`" and "sync
-worktree") entirely. The QA agent no longer merges. Replace with:
-
-```
-5. If all green:
-   a. Signal the Task Agent that a merge is the post-approval action:
-      send_message(target: "task-agent", message: "QA passed. PR ready for merge.",
-                   data: { pr_url: "<url>", post_approval_action: "merge_pr" })
-   b. Call `save_artifact({ type: "result", append: true, summary, prUrl, testOutput })`
-      to record the audit entry.
-   c. Call `approve_task()` (or `submit_for_approval({ reason })` if autonomy blocks self-close).
-      The Task Agent will perform the merge and sync under the autonomy check.
-```
-
-Also remove the trailing sentence "The runtime also verifies the PR is actually
-merged before accepting completion." — that verification goes away with
-`VERIFY_PR_MERGED_COMPLETION_ACTION`.
-
-The `FULLSTACK_QA_PROMPT` constant at `built-in-workflows.ts:384-396` contains
-the duplicate "merge the PR" instruction and must be updated the same way (the
-QA custom prompt concatenates onto it).
+worktree") entirely. QA no longer merges; a post-approval reviewer session
+does. Replace with the same `send_message(task-agent, …)` + `approve_task`
+sequence.
 
 #### 2.4.4 Review-Only Workflow — `REVIEW_ONLY_WORKFLOW`
 File: `built-in-workflows.ts:721-777`.
-
-No merge to perform. The post-approval step is a no-op. Prompt change:
+No merge to perform. No `postApproval` declared on the workflow. The
+post-approval routing skips to `done` immediately. Prompt change:
 remove the trailing paragraph about "the runtime verifies at least one
-review/comment exists before accepting completion" (step 4) — that ran via
+review/comment exists before accepting completion" — that ran via
 `VERIFY_REVIEW_POSTED_COMPLETION_ACTION` which is being deleted.
 
-Known regression: at present, if the Reviewer lies about posting a review,
-the runtime catches it via the completion action. After this change, the lie
-goes through at Level 1 only when a human approves `submit_for_approval`.
-(A human who approves completion without verifying the PR is the same failure
-mode as today for every other workflow.) At Level ≥ 2 where `approve_task` is
-unlocked, there is no gate. This is an acceptable regression for the
-simplification; **mitigation** is documented in §4.3.
+Known regression (unchanged from previous revision): at Level 1 this is
+still protected by human review; at Level ≥ 2 the lie slips through. See
+§4.3 for mitigation options.
 
 #### 2.4.5 Plan & Decompose Workflow — `PLAN_AND_DECOMPOSE_WORKFLOW`
 File: `built-in-workflows.ts:952-972`.
-
-No merge. `PLAN_AND_DECOMPOSE_VERIFY_COMPLETION_ACTION` (the "at least one
-task was created" script) goes away. Prompt change: none required — the
-Dispatcher already calls `save_artifact({ created_task_ids })` as its evidence.
-Regression is identical to Review-Only — the verify script caught agents who
-lied about dispatching; we trust the audit artifact instead.
-
-**Mitigation option:** post-merge / Stage 5, add a `SpaceRuntime` sanity check
-that refuses to mark a Plan-and-Decompose task `done` unless at least one
-`created_task_ids` artifact is present on the run. This is a workflow-specific
-post-approval check that can live in Task Agent as a follow-up tool call
-(`verify_tasks_created`) if we decide it's worth the complexity.
+No `postApproval` declared. Dispatcher prompt is unchanged.
 
 ---
 
-## 3. Autonomy-level enforcement in Task Agent
+## 3. Autonomy-level enforcement
 
-### 3.1 Where the autonomy check lives
+### 3.1 Where the autonomy check lives (post-revision)
 
-Two-layer enforcement:
+In the revised design, autonomy enforcement is **not a dedicated handler
+check** (there is no dedicated handler). Instead, three layers hold the
+line:
 
-1. **Handler-layer (authoritative):** `merge_pr` handler in
-   `task-agent-merge-handler.ts` (new file) reads `space.autonomyLevel` via
-   `config.getSpaceAutonomyLevel(spaceId)` at every call and rejects
-   `level < 4` calls that lack `human_approval_reason`. This is the
-   **single source of truth** and cannot be prompt-injected around.
-2. **Prompt-layer (guidance):** the Task Agent system prompt and the
-   `[TASK_APPROVED]` injection tell the LLM the rule (`level < 4 → call
-   request_human_input first`) so the expected path succeeds without a tool
-   bounce.
+1. **Template-layer (guidance for the LLM):** the `postApproval.instructions`
+   string for each workflow references `{{autonomy_level}}` and spells out
+   the rule. A merge-PR instructions template, for example:
+   > "Space autonomy level: {{autonomy_level}}. If autonomy >= 4, merge
+   > directly. Otherwise, call `request_human_input` with a clear question
+   > ('Approve merging PR {{pr_url}}?') before running any merge command.
+   > Record the human's response as the merge justification."
+2. **Tool-layer (authoritative — unchanged from today):** the
+   post-approval session inherits the standard space autonomy enforcement
+   applied to every tool call. Bash calls, file-write calls, and
+   MCP-tool calls all run through the existing autonomy filter; a
+   level-2 session cannot just `gh pr merge` if the space policy forbids
+   destructive Bash at level 2. No new enforcement plumbing is needed.
+3. **Session-kind-layer:** post-approval sessions can be given a narrower
+   tool allowlist than the workflow-node session they correspond to, if
+   we want to (e.g. `gh` + `git` + `cd` but no arbitrary `curl`). Scoping
+   decision deferred to §7.2.
 
 ### 3.2 Task Agent system prompt addition
 
 Amend [`task-agent.ts:buildTaskAgentSystemPrompt`](../../packages/daemon/src/lib/space/agents/task-agent.ts)
-to add a new `## Post-Approval Actions` section after the existing
+to add a new `## Post-Approval Routing` section after the existing
 `## Human Gate Handling` section (~line 273):
 
 ```
-## Post-Approval Actions
+## Post-Approval Routing
 
-When a workflow end node signals a post-approval action via send_message —
-e.g. { pr_url: "...", post_approval_action: "merge_pr" } — wait for the
-`[TASK_APPROVED]` event. Then:
+When a task reaches `approved` status (either via `approve_task()` from the
+end node, or via human approval of a `submit_for_approval` request), a
+`[TASK_APPROVED]` event is injected into your session. That event tells you:
+- the workflow's `postApproval` routing (target agent + what interpolation
+  keys the instructions template expects),
+- whether the approval source was the end node or a human review.
 
-- If space.autonomyLevel >= 4 (MERGE autonomy threshold):
-  - Call merge_pr({ pr_url }) directly.
-- If space.autonomyLevel < 4:
-  - First call request_human_input with a clear question
-    (e.g. "Approve merging PR <pr_url>?") and the relevant context
-    (diff summary, reviewer name, CI status if known).
-  - Wait for the human's response. It arrives as a normal conversation
-    message.
-  - If the human approves, call merge_pr({ pr_url, human_approval_reason: "<exact human response>" }).
-  - If the human rejects, save an artifact describing the rejection and
-    call submit_for_approval if the task is not already closed.
+Your job is to decide the next step:
 
-The `merge_pr` tool is the ONLY direct-execution tool you may call. Do not
-attempt to run other shell commands. If a post-approval action other than
-`merge_pr` is signalled, treat it as an unsupported action and escalate via
-request_human_input.
+1. If the workflow has no `postApproval` target, call
+   `spaceTask.completePostApproval({ taskId })` to move the task to `done`.
+2. If `target_agent` is a workflow-agent role (e.g. "reviewer", "coder"),
+   call `spawn_post_approval_session({ taskId, targetAgent })`. The runtime
+   interpolates the instructions using the structured-data payload from the
+   end node's signal and delivers it as the new session's kickoff. Wait for
+   the session to complete; then call `completePostApproval`.
+3. If `target_agent` is "task-agent", the post-approval work runs in this
+   conversation. Interpret the interpolated instructions directly. When
+   complete, call `completePostApproval`.
+
+You do not execute post-approval work yourself via shell or Bash — you
+route. The only exception is `target_agent: "task-agent"`, in which case
+use the tools already on this MCP server (send_message, request_human_input,
+save_artifact, list_artifacts). Do not attempt to run shell commands.
 ```
 
 ### 3.3 `request_human_input` question scaffolding
 
-The existing `request_human_input` handler at
-[`task-agent-tools.ts:759-801`](../../packages/daemon/src/lib/space/tools/task-agent-tools.ts)
-sets `task.status = 'blocked'`, stores the question (+ optional context) in
-`task.result`, and pauses the Task Agent's SDK session. The existing banner
-[`TaskBlockedBanner.tsx`](../../packages/web/src/components/space/TaskBlockedBanner.tsx)
-renders this. No code changes needed here — the Task Agent simply writes a
-more specific question string.
+When a target-agent session decides it needs human approval (the template
+said `if autonomy < 4 → request_human_input first`), it calls the Task
+Agent's existing `request_human_input` handler at
+[`task-agent-tools.ts:759-801`](../../packages/daemon/src/lib/space/tools/task-agent-tools.ts).
+This is the same path used by any workflow-node session that needs to pause
+for a human — no changes here.
 
-Suggested question template (enforced by prompt, not schema):
+The template's guidance block steers the agent toward a consistent question
+format (e.g. `"Approve merging PR {{pr_url}}?"`). Unlike the previous
+revision, we do not snapshot-pin the exact string: the target agent's LLM
+chooses the wording based on the instructions. If consistency is desired,
+workflow authors can hardcode the question string inside the instructions
+template:
 
 ```
-question: "Approve merging PR <pr_url>?"
-context:  "Reviewer: <agent name>
-           PR title: <title>
-           Commits: <n>
-           CI status: <CLEAN | HAS_HOOKS | ...>
-           Last review: <agent summary>"
+If autonomy < 4, first call request_human_input with exactly
+question="Approve merging PR {{pr_url}}?" and context="..." and wait for
+the response before merging.
 ```
-
-The Task Agent can populate `context` by reading artifacts from the run
-(`list_artifacts({ type: 'result' })` is already wired) and by running
-`gh pr view <url> --json title,commits,mergeStateStatus` **— wait, Task Agent
-has no Bash**. It does not. We'll rely on the data the end node already passed
-through `send_message` + artifact, plus the PR URL itself.
 
 ### 3.4 Idempotency / retry
 
-`merge_pr` is idempotent by two mechanisms:
+Idempotency lives in two places:
 
-- The underlying script `PR_MERGE_BASH_SCRIPT` already skips the merge when
-  `gh pr view` reports `state == MERGED` (built-in-workflows.ts:163-170 today).
-- The handler pre-checks the artifact store for a matching `merged_pr_url`.
+1. **The target-agent session's own logic.** The session's LLM is told (via
+   instructions) to check the current state before acting — e.g. "first run
+   `gh pr view <url> --json state,mergedAt` — if the PR is already merged,
+   record that and exit successfully."
+2. **The underlying bash script used by merge templates.** The existing
+   [`PR_MERGE_BASH_SCRIPT`](../../packages/daemon/src/lib/space/workflows/built-in-workflows.ts)
+   has a merged-state short-circuit. We keep the script body available as a
+   reusable helper that merge-style `postApproval.instructions` can
+   reference (e.g. "`bash /path/to/merge-helper.sh`"). Hoisting it to a
+   standalone module (`packages/daemon/src/lib/space/tools/pr-merge-script.ts`)
+   remains useful purely as a reusable helper for the built-in Coding
+   workflow's instructions string; not as a runtime-executed primitive.
 
-This covers: daemon restart mid-merge, the Task Agent LLM re-calling the tool
-after a conversation rewind, and the post-approval banner being clicked twice.
+**Daemon restart mid-session.** The post-approval session is a regular
+sub-session; the same restart-restore plumbing that covers workflow-node
+sessions covers post-approval sessions. When the session restarts it re-reads
+the PR state and decides: already done → exit success; not done → retry
+from the top. The Task Agent's tracking (`post_approval_session_id` on the
+task row) makes it easy to re-attach.
+
+**Task Agent re-routing.** If the Task Agent LLM decides to re-route (rare —
+would require a conversation rewind), `spawn_post_approval_session` checks
+`post_approval_session_id`; if one is already set and not in a terminal
+state, it returns a no-op success with the existing session ID.
 
 ### 3.5 Human-rejection path
 
-If the human rejects via `request_human_input` (responds "no" / "do not merge"):
+If the target-agent session escalates (calls `submit_for_approval` on
+itself, or the template's `request_human_input` response is a rejection):
 
-1. Task Agent observes the response in its conversation.
-2. Prompt tells it NOT to call `merge_pr`.
-3. Task Agent calls `save_artifact({ type: 'result', append: true, summary: 'Human declined merge', data: { pr_url, rejectionReason: '...' } })`.
-4. The task is already `done` at this point (merge was the post-approval step,
-   not the completion step) — no further status transition needed.
-5. Operator intervenes on GitHub manually or escalates.
+1. The session records the rejection in an artifact.
+2. The session exits normally (completed, not failed).
+3. Task Agent observes completion, calls `completePostApproval` —
+   task moves to `done`.
+4. An audit artifact on the task records "post-approval skipped:
+   `human_rejected`".
 
-This is a **minor design choice** — one could argue the task should revert to
-`review` on human rejection, but: (a) the work was already approved as good,
-(b) merging is an infrastructure step, not the work itself, (c) reverting
-would require re-plumbing the `done → review` transition which doesn't exist
-today. Keep it simple: task stays `done`, merge skipped, audit recorded.
+If the session itself errors out irrecoverably (crashed, hit timeout, ran
+out of retries):
+
+1. Task stays in `approved`.
+2. `postApprovalBlockedReason` is set.
+3. A UI banner similar to today's PendingCompletionActionBanner shows
+   "Post-approval failed: <reason>. [Retry | Mark done | View session]".
+4. Operator can retry (re-spawn the same target agent with same
+   instructions), manually advance, or inspect the session transcript.
+
+This is a **minor design change from the previous revision.** Previously,
+rejection always moved to `done`. In the revised design, *agent-initiated*
+rejection (via the agent's own `submit_for_approval` or
+`request_human_input(no)`) still moves to `done` (human decision), but
+*session errors* stay in `approved` with a retry option (not a human
+decision — a technical failure).
 
 ---
 
@@ -472,78 +696,87 @@ today. Keep it simple: task stays `done`, merge skipped, audit recorded.
 
 ### 4.1 Code to delete outright
 
-File paths from the completion-action inventory:
+*(Unchanged from the previous revision; the old completion-action pipeline
+is removed the same way regardless of what replaces it.)*
 
 | Path | What to delete |
 |------|----------------|
 | `packages/shared/src/types/space.ts` | `CompletionAction` union, `ScriptCompletionAction`, `InstructionCompletionAction`, `McpCallCompletionAction`, `CompletionActionBase`, `McpCallExpectation` (lines 1481-1556). `WorkflowNode.completionActions` field (line 1032). `SpaceTask.pendingActionIndex`, `SpaceTask.pendingAction` (lines 280, 315-326). `'completion_action'` variant of `SpaceTask.pendingCheckpointType` (line 287). `SpaceWorkflowRun.completionActionsFiredAt` (line 641). |
-| `packages/daemon/src/lib/space/runtime/space-runtime.ts` | `resolveCompletionWithActions` (lines 1881-2015). `resumeCompletionActions` (lines 932-1104). `executeCompletionAction` (lines 2067-2146). `resolveArtifactData` (lines 2153-2163). `buildAwaitingApprovalReason` (lines 71-76). `emitTaskAwaitingApproval` (lines 2028-2050). The two call sites at 613 and 1561 collapse to a direct call of a new small helper `resolveTaskCompletion(workflow, spaceLevel)` that only handles the "no actions" binary-autonomy case (which is now **all** cases). |
+| `packages/daemon/src/lib/space/runtime/space-runtime.ts` | `resolveCompletionWithActions` (lines 1881-2015). `resumeCompletionActions` (lines 932-1104). `executeCompletionAction` (lines 2067-2146). `resolveArtifactData` (lines 2153-2163). `buildAwaitingApprovalReason` (lines 71-76). `emitTaskAwaitingApproval` (lines 2028-2050). The two call sites at 613 and 1561 now call a new small helper `resolveTaskApproval(task, workflow)` that transitions to `approved` and emits `[TASK_APPROVED]`. |
 | `packages/daemon/src/lib/space/runtime/completion-action-executors.ts` | Entire file (285 lines). |
 | `packages/daemon/src/lib/space/runtime/pending-action.ts` | Entire file (60 lines). |
 | `packages/daemon/src/lib/space/runtime/space-runtime-service.ts` | `resumeCompletionActions` public API (lines 795-807). |
 | `packages/daemon/src/lib/space/tools/space-agent-tools.ts` | `approve_completion_action` handler (lines 944-1006) and its tool registration (line 1246). |
-| `packages/daemon/src/lib/space/tools/task-agent-tools.ts` | Update the `approve_task` tool **description string** at [line 1043](../../packages/daemon/src/lib/space/tools/task-agent-tools.ts): replace `"… the completion-action pipeline runs and resolves the terminal status. …"` with `"… the task closes directly; if a post-approval action (e.g. PR merge) was signalled by the end node via send_message, call merge_pr after approve_task. …"` so the tool surface stops lying about a removed pipeline. |
-| `packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts` | The `pendingCheckpointType === 'completion_action'` intercept in `spaceTask.update` (lines 154-203). |
-| `packages/daemon/src/lib/space/workflows/built-in-workflows.ts` | `PR_MERGE_BASH_SCRIPT` (move to new `pr-merge-script.ts` instead of deleting — see §1.1 step 6). `MERGE_PR_COMPLETION_ACTION` (lines 187-194). `VERIFY_PR_MERGED_BASH_SCRIPT` + `VERIFY_PR_MERGED_COMPLETION_ACTION` (lines 204-239). `VERIFY_REVIEW_POSTED_BASH_SCRIPT` + `VERIFY_REVIEW_POSTED_COMPLETION_ACTION` (lines 246-282). `PLAN_AND_DECOMPOSE_VERIFY_SCRIPT` + `PLAN_AND_DECOMPOSE_VERIFY_COMPLETION_ACTION` (lines 792-830). Every `completionActions: [...]` entry on a node (lines 518, 664, 766, 972, 1135). |
+| `packages/daemon/src/lib/space/tools/task-agent-tools.ts` | Update `approve_task` tool description string to reference the new routing model. Add new tools: `spawn_post_approval_session`, `completePostApproval` (internal to Task Agent MCP server). |
+| `packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts` | The `pendingCheckpointType === 'completion_action'` intercept in `spaceTask.update` (lines 154-203). `approvePendingCompletion` now transitions `review → approved` (not `review → done`). Add `completePostApproval` RPC. |
+| `packages/daemon/src/lib/space/workflows/built-in-workflows.ts` | `MERGE_PR_COMPLETION_ACTION` (lines 187-194). `VERIFY_PR_MERGED_BASH_SCRIPT` + `VERIFY_PR_MERGED_COMPLETION_ACTION` (lines 204-239). `VERIFY_REVIEW_POSTED_BASH_SCRIPT` + `VERIFY_REVIEW_POSTED_COMPLETION_ACTION` (lines 246-282). `PLAN_AND_DECOMPOSE_VERIFY_SCRIPT` + `PLAN_AND_DECOMPOSE_VERIFY_COMPLETION_ACTION` (lines 792-830). Every `completionActions: [...]` entry on a node (lines 518, 664, 766, 972, 1135). **Add** `postApproval` on the 2 workflows that need it (Coding, Research, QA). `PR_MERGE_BASH_SCRIPT` stays but moves to `pr-merge-script.ts` (see §3.4). |
 | `packages/web/src/components/space/PendingCompletionActionBanner.tsx` | Entire file (385 lines). |
-| `packages/web/src/components/space/TaskStatusActions.tsx` | Remove import + render of `PendingCompletionActionBanner`. |
+| `packages/web/src/components/space/TaskStatusActions.tsx` | Remove import + render of `PendingCompletionActionBanner`. Add a new, simpler `PendingPostApprovalBanner` that surfaces the post-approval session status when a task is stuck in `approved` (see §3.5). |
 | `packages/web/src/components/space/SpaceTaskPane.tsx` | Remove routing of `'completion_action'` checkpoint to the removed banner. |
-| `packages/shared/src/space/workflow-autonomy.ts` | `EMPTY_ACTIONS_AUTONOMY_THRESHOLD`, `isAutonomousWithoutActions`, `BlockingAction`, `BlockingWorkflow`, `AutonomousWorkflowCount`, `isWorkflowAutonomousAtLevel`, `countAutonomousWorkflows`, `collectCompletionActions` — replace with a single `isWorkflowAutoClosingAtLevel(wf, level)` that checks only `level >= (wf.completionAutonomyLevel ?? 5)`. The UI's "N of M workflows autonomous at level X" summary becomes "N of M auto-close at level X" — simpler and more accurate post-removal. |
+| `packages/shared/src/space/workflow-autonomy.ts` | `EMPTY_ACTIONS_AUTONOMY_THRESHOLD`, `isAutonomousWithoutActions`, `BlockingAction`, `BlockingWorkflow`, `AutonomousWorkflowCount`, `isWorkflowAutonomousAtLevel`, `countAutonomousWorkflows`, `collectCompletionActions` — replace with a single `isWorkflowAutoClosingAtLevel(wf, level)` that checks only `level >= (wf.completionAutonomyLevel ?? 5)`. |
 
 ### 4.2 Code to keep / repurpose
 
 | Item | Decision |
 |------|----------|
-| `completionAutonomyLevel` on `SpaceWorkflow` | **Keep.** It still controls whether the end-node agent's `approve_task` is unlocked vs. forced onto `submit_for_approval` — orthogonal to the merge-PR level. The values (Coding=3, QA=4, Research=2, Review-Only=2, Plan-and-Decompose=3) remain valid. |
-| `submit_for_approval` + `approvePendingCompletion` RPC + `PendingTaskCompletionBanner` | **Keep.** This is the human-approves-the-work path; it is NOT a completion-action path. No changes. |
+| `completionAutonomyLevel` on `SpaceWorkflow` | **Keep.** It still controls whether the end-node agent's `approve_task` is unlocked vs. forced onto `submit_for_approval` — orthogonal to the post-approval step. |
+| `submit_for_approval` + `approvePendingCompletion` RPC + `PendingTaskCompletionBanner` | **Keep.** This is the human-approves-the-work path; the transition target changes from `review → done` to `review → approved` but the user-visible UX is unchanged. |
 | `pendingCheckpointType = 'task_completion'` variant | **Keep.** Still used by `submit_for_approval`. |
-| `pendingCompletionSubmittedByNodeId`, `pendingCompletionSubmittedAt`, `pendingCompletionReason` | **Keep.** Still needed by the task-completion banner. |
-| `space_task_report_results` table (migration 99) | **Keep.** The `report_result` handler has been removed, but the table itself persists audit rows. Check if any callers still write to it — if no, drop it in a later cleanup migration. Appears orphaned; verify with a full-repo grep before removing. |
-| `PR_MERGE_BASH_SCRIPT` string body | **Move and keep.** Hoist to `packages/daemon/src/lib/space/tools/pr-merge-script.ts` so the new `merge_pr` tool handler imports it. |
+| `pendingCompletionSubmittedByNodeId`, `pendingCompletionSubmittedAt`, `pendingCompletionReason` | **Keep.** |
+| `space_task_report_results` table (migration 99) | **Keep.** Audit table; orphaned writers can be dropped in a later cleanup. |
+| `PR_MERGE_BASH_SCRIPT` string body | **Move and keep.** Hoist to `packages/daemon/src/lib/space/tools/pr-merge-script.ts` as a reusable helper. The built-in Coding workflow's `postApproval.instructions` string can reference this path directly; user workflows can ignore it. |
 
 ### 4.3 Lost functionality & mitigations
 
+*(Unchanged from the previous revision — removing the completion-action
+pipeline has the same cost either way.)*
+
 | Lost check | Provided by | Mitigation |
 |-----------|-------------|------------|
-| `verify-pr-merged` (QA-loop) | double-check that QA agent actually merged | No longer needed — Task Agent is the merger, not the QA agent. |
-| `verify-review-posted` (Review-Only) | catches reviewer lying about posting review | Rely on the agent's contract; the operator can inspect the PR. Optional future follow-up: a pre-`approve_task` runtime check that requires at least one `save_artifact` with `reviewUrl`. |
-| `verify-tasks-created` (Plan-and-Decompose) | catches dispatcher lying about creating tasks | Same pattern — optional future `verify_tasks_created` Task Agent tool if the regression proves painful. |
+| `verify-pr-merged` (QA-loop) | double-check that QA agent actually merged | No longer needed — post-approval reviewer session is the merger, not the QA agent. |
+| `verify-review-posted` (Review-Only) | catches reviewer lying about posting review | Rely on the agent's contract; operator can inspect the PR. Optional follow-up: require a saved `reviewUrl` artifact before allowing `approve_task`. |
+| `verify-tasks-created` (Plan-and-Decompose) | catches dispatcher lying about creating tasks | Same pattern — optional follow-up tool if the regression proves painful. |
 | `'blocked'` status on post-hoc verification failure | escalated silently to a blocked task | Task Agent's `submit_for_approval` path produces the same end state via a different trigger. |
-| `Awaiting Human Approval` banner (`PendingCompletionActionBanner`) | per-action modal UI | `request_human_input` → `TaskBlockedBanner` + plain conversation input now covers this. Operators answer the Task Agent's question in free text instead of clicking Approve/Reject on a specific action. Simpler, more uniform UX. |
+| `Awaiting Human Approval` banner (`PendingCompletionActionBanner`) | per-action modal UI | `request_human_input` → `TaskBlockedBanner` + plain conversation input now covers this. Operators answer the Task Agent's (or post-approval session's) question in free text. |
 
 ### 4.4 DB migration
 
 New migration (number = next after current tip):
 
 ```sql
--- Drop the completion_action checkpoint value and associated columns.
--- Step 1: transition any live tasks paused at 'completion_action'.
--- At Stage 4 time, Stage 3 will have already rewritten runtime paths to
--- never produce this value. Still, convert any in-flight rows defensively.
+-- Stage 1 migration (adds 'approved' status + post_approval_session_id column).
+-- Step 1: extend space_tasks.status CHECK constraint to include 'approved'.
+-- SQLite requires table-rebuild pattern (see migration 99 for template).
+-- New allowed values: open, in_progress, review, approved, done, blocked,
+-- cancelled, archived.
+
+-- Step 2: add post_approval_session_id TEXT NULL column.
+-- Step 3: add post_approval_started_at INTEGER NULL column.
+-- Step 4: add post_approval_blocked_reason TEXT NULL column.
+
+-- Stage 5 migration (removes completion-action columns).
+-- Step 5: rewrite any live tasks paused at 'completion_action'.
+-- At Stage 5 time, Stages 3 + 4 will have rewritten runtime paths to never
+-- produce this value. Defensively rewrite:
 UPDATE space_tasks
 SET pending_checkpoint_type = 'task_completion',
     pending_action_index = NULL
 WHERE pending_checkpoint_type = 'completion_action';
 
--- Step 2: drop pending_action_index column.
--- SQLite requires the table-rebuild pattern used by migration 99.
--- (Full rebuild sql omitted here; see migration 99 for template.)
-
--- Step 3: tighten the CHECK constraint on pending_checkpoint_type:
---     from: CHECK (pending_checkpoint_type IN ('completion_action', 'gate', 'task_completion'))
---     to:   CHECK (pending_checkpoint_type IN ('gate', 'task_completion'))
-
--- Step 4: drop completion_actions_fired_at from space_workflow_runs.
-
--- Step 5: (optional) drop space_task_report_results if audit confirms no
--- writer remains. Defer to a later cleanup migration to keep this PR small.
+-- Step 6: drop pending_action_index column.
+-- Step 7: tighten CHECK constraint on pending_checkpoint_type:
+--   from: CHECK (pending_checkpoint_type IN ('completion_action', 'gate', 'task_completion'))
+--   to:   CHECK (pending_checkpoint_type IN ('gate', 'task_completion'))
+-- Step 8: drop completion_actions_fired_at from space_workflow_runs.
+-- Step 9: (optional) drop space_task_report_results if audit confirms no
+-- writer remains. Defer to a later cleanup migration.
 ```
 
-No data migration is needed for `completionAutonomyLevel` since it stays.
+`completionAutonomyLevel` stays — no data migration needed for it.
 
 ### 4.5 Tests to delete / update
 
-Files enumerated in the completion-action inventory (§9):
+*(Updated from the previous revision to reflect the new test additions.)*
 
 - Delete outright:
   - `packages/daemon/tests/unit/5-space/runtime/space-runtime-completion-actions.test.ts`
@@ -558,31 +791,45 @@ Files enumerated in the completion-action inventory (§9):
   - `packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts`
   - `packages/shared/tests/workflow-autonomy.test.ts`
   - `packages/web/src/lib/__tests__/space-store.test.ts`
-- Update (reflect new workflow prompts):
-  - Any test that asserts specific prompt text from the five built-in workflows
-    (e.g. asserting the QA prompt contains `gh pr merge` — it will not any more).
+- Update (reflect new workflow prompts + `postApproval` entries):
+  - Any test that asserts specific prompt text from the five built-in workflows.
 
 ### 4.6 New tests to add
 
 Under `packages/daemon/tests/unit/5-space/`:
 
-- `tools/task-agent-merge-handler.test.ts`
-  - Level ≥ 4, valid URL → script runs, artifact written, success.
-  - Level < 4, no `human_approval_reason` → refused.
-  - Level < 4, valid `human_approval_reason` → script runs.
-  - Invalid URL → refused.
-  - Already-merged idempotency → returns success without running script.
-  - Script failure → returns failure with stderr.
-  - Timeout → surfaces timeout error.
-
-- `runtime/post-approval-signalling.test.ts`
-  - Simulated end-node emits `send_message` to task-agent with
-    `{pr_url, post_approval_action}`; verify the structured-data appendix is
-    delivered to the Task Agent session in the expected format.
-  - Verify `[TASK_APPROVED]` is injected into the Task Agent session on
-    `done` transition.
-  - Verify NOT injected when no `post_approval_action` was signalled.
-
+- `workflow/post-approval-validator.test.ts`
+  - `targetAgent` = declared workflow agent → valid.
+  - `targetAgent` = `task-agent` → valid.
+  - `targetAgent` = unknown → invalid + error lists eligible targets.
+  - Missing `postApproval` → valid (optional).
+- `workflow/post-approval-template.test.ts`
+  - Happy-path interpolation with all keys provided.
+  - Missing key renders as `{{key}}` literal + warning.
+  - Interpolation is a single pass (no recursive expansion).
+  - Special characters in values are passed through unchanged (no HTML
+    escaping, no shell escaping — the downstream agent handles that).
+- `runtime/post-approval-routing.test.ts`
+  - `approved` task with no `postApproval` → immediately transitions to
+    `done` via `completePostApproval`.
+  - `approved` task with workflow-agent target → Task Agent invokes
+    `spawn_post_approval_session`; a session is created with the correct
+    interpolated kickoff message.
+  - `approved` task with `target_agent: task-agent` → no spawn; Task Agent
+    executes instructions in its own session.
+  - `post_approval_session_id` is persisted and observable via the
+    repository.
+  - `[TASK_APPROVED]` is emitted with the correct payload shape on both
+    `approve_task` and `approvePendingCompletion` paths.
+- `runtime/task-status-transitions.test.ts`
+  - `in_progress → approved` via `approve_task`.
+  - `review → approved` via `approvePendingCompletion`.
+  - `approved → done` via `completePostApproval`.
+  - `approved → blocked` disallowed in Stage 2 (deferred to §7).
+- `agent/task-agent-post-approval-spawning.test.ts`
+  - Given a mocked `spawn_post_approval_session` tool call, assert the
+    resulting session receives the right system prompt, kickoff message,
+    and tool surface.
 - `workflows/end-node-handoff.test.ts`
   - For each of the 5 built-in workflows, snapshot-test the end-node's
     customPrompt to ensure the post-approval signalling instructions are
@@ -591,40 +838,73 @@ Under `packages/daemon/tests/unit/5-space/`:
 
 E2E test additions (`packages/e2e/tests/features/`):
 
-- `task-agent-merge-autonomy-high.e2e.ts` — Level 4 space, run the Coding
-  workflow against a fake PR, assert the PR is merged without a human
-  interaction.
-- `task-agent-merge-autonomy-low.e2e.ts` — Level 1 space, run the Coding
-  workflow, assert the Task Agent blocks at `human_input_requested`, then
-  simulate the human approving via the conversation input, and assert the
-  merge happens afterward.
-- `task-agent-merge-human-rejects.e2e.ts` — Level 1 space, human rejects via
-  request_human_input response, assert PR is not merged, task remains `done`,
-  audit artifact is written.
+- `post-approval-merge-autonomy-high.e2e.ts` — Level 4 space, run the Coding
+  workflow against a fake PR; assert the task reaches `approved`, the
+  post-approval reviewer session spawns, merges, and the task reaches
+  `done` without human interaction.
+- `post-approval-merge-autonomy-low.e2e.ts` — Level 1 space, run the Coding
+  workflow; assert the post-approval session pauses at
+  `human_input_requested`; simulate the human approving via the
+  conversation input; assert merge happens afterward.
+- `post-approval-merge-human-rejects.e2e.ts` — Level 1 space, human rejects
+  via `request_human_input`; assert PR is not merged, task reaches `done`,
+  audit artifact records the rejection.
+- `post-approval-no-route.e2e.ts` — Research workflow with no `postApproval`
+  declared; assert task goes straight from `approved → done`.
 
-These E2E tests need a mock `gh` CLI (or dev-proxy style shim) — reuse the
-existing E2E PR-fixture infrastructure if present; otherwise add a tiny
-`tests/e2e/helpers/mock-gh.sh` shim that `make run-e2e` injects onto the PATH.
+These E2E tests need a mock `gh` CLI. Reuse existing E2E PR-fixture
+infrastructure if present; otherwise add `tests/e2e/helpers/mock-gh.sh`
+injected on the PATH.
 
 ---
 
 ## 5. Workflow definition changes — summary table
 
-| Workflow | `completionActions` removed | `completionAutonomyLevel` | Prompt change |
-|---------|-------|--------------------------|---------------|
-| CODING_WORKFLOW | `[MERGE_PR_COMPLETION_ACTION]` | keep at 3 | Reviewer step 5 — add `send_message(task-agent)` before `approve_task` |
-| RESEARCH_WORKFLOW | `[MERGE_PR_COMPLETION_ACTION]` | keep at 2 | Review step 6 — add `send_message(task-agent)` before `approve_task` |
-| FULLSTACK_QA_LOOP_WORKFLOW | `[VERIFY_PR_MERGED_COMPLETION_ACTION]` | **lower from 4 to 3** — QA no longer merges, so the high-level threshold is no longer needed | QA steps 5–6 — remove `gh pr merge` + worktree sync; replace with `send_message(task-agent)` |
-| REVIEW_ONLY_WORKFLOW | `[VERIFY_REVIEW_POSTED_COMPLETION_ACTION]` | keep at 2 | Review step 6 — trim verification boilerplate, no post-approval signalling (no merge) |
-| PLAN_AND_DECOMPOSE_WORKFLOW | `[PLAN_AND_DECOMPOSE_VERIFY_COMPLETION_ACTION]` | keep at 3 | Dispatcher — no change |
+| Workflow | `completionActions` removed | `completionAutonomyLevel` | `postApproval` added | Prompt change |
+|---------|-------|--------------------------|----------------------|---------------|
+| CODING_WORKFLOW | `[MERGE_PR_COMPLETION_ACTION]` | keep at 3 | `{ targetAgent: 'reviewer', instructions: <merge template> }` | Reviewer step 5 — add `send_message(task-agent)` before `approve_task` |
+| RESEARCH_WORKFLOW | `[MERGE_PR_COMPLETION_ACTION]` | keep at 2 | `{ targetAgent: 'reviewer', instructions: <merge template> }` | Review step 6 — add `send_message(task-agent)` before `approve_task` |
+| FULLSTACK_QA_LOOP_WORKFLOW | `[VERIFY_PR_MERGED_COMPLETION_ACTION]` | **lower from 4 to 3** | `{ targetAgent: 'reviewer', instructions: <merge template> }` | QA steps 5–6 — remove `gh pr merge` + worktree sync; replace with `send_message(task-agent)` |
+| REVIEW_ONLY_WORKFLOW | `[VERIFY_REVIEW_POSTED_COMPLETION_ACTION]` | keep at 2 | (none — no post-approval work) | Review step 6 — trim verification boilerplate |
+| PLAN_AND_DECOMPOSE_WORKFLOW | `[PLAN_AND_DECOMPOSE_VERIFY_COMPLETION_ACTION]` | keep at 3 | (none — no post-approval work) | Dispatcher — no change |
 
-The QA-workflow `completionAutonomyLevel` drop from 4 → 3 is a **behavioural
-intent change** worth calling out in the PR description: today, Coding-with-QA
-requires Level 4 to self-close because the QA agent is the merger. After this
-change, the QA agent no longer merges, so Level 3 is the natural threshold
-(aligned with Coding). The operator still needs Level 4 to **auto-merge**,
-because that check is now enforced by the `merge_pr` tool handler, not the
-workflow.
+**Merge-template `instructions` string (shared across Coding, Research, QA):**
+
+```
+The task has been approved. Your job is to merge PR {{pr_url}}.
+
+Space autonomy level: {{autonomy_level}} (threshold for auto-merge: 4).
+Reviewer: {{reviewer_name}}.
+Approval source: {{approval_source}}.
+
+Steps:
+1. Verify the PR is still open and passes CI:
+     gh pr view {{pr_url}} --json state,mergeStateStatus,statusCheckRollup
+   If state is MERGED, record an audit artifact and exit — the work is done.
+2. If autonomy_level < 4:
+     Call request_human_input with
+       question: "Approve merging PR {{pr_url}}?"
+       context: "Reviewer: {{reviewer_name}}. CI: <from step 1>."
+     Wait for the response before proceeding.
+3. Merge:
+     gh pr merge {{pr_url}} --squash --delete-branch
+   On a merge conflict, do NOT force — exit, call request_human_input with
+   a clear summary of the conflict, and let the human resolve.
+4. Sync your worktree with main/dev:
+     git fetch origin && git checkout dev && git pull --ff-only
+5. Save an audit artifact:
+     save_artifact({ type: "result", append: true,
+                     data: { merged_pr_url, mergedAt, approval: "auto"|"human" } })
+6. Call approve_task() to signal post-approval complete.
+```
+
+The QA-workflow `completionAutonomyLevel` drop from 4 → 3 is a behavioural
+intent change worth calling out in the PR description: today,
+Coding-with-QA requires Level 4 to self-close because the QA agent is the
+merger. After this change, the QA agent no longer merges, so Level 3 is the
+natural threshold (aligned with Coding). Auto-merge remains a separate
+autonomy dimension, now enforced by the template's conditional at the
+post-approval session layer rather than at the `merge_pr` tool layer.
 
 ---
 
@@ -632,104 +912,164 @@ workflow.
 
 ### 6.1 Breaking change assessment
 
-- **Workflow schema (shared types)**: removing `completionActions`,
+- **Workflow schema (shared types):** removing `completionActions`,
   `CompletionAction`, `completionActionsFiredAt`, `pendingActionIndex`,
   `pendingCheckpointType: 'completion_action'` is a breaking change to
   `@neokai/shared`. NeoKai ships as a single repo; no external consumers.
-- **Built-in workflows (DB rows)**: the existing `seedBuiltInWorkflows` code
-  stamps template rows into SQLite. On startup after migration, the seeder
-  re-runs with the new template (computed via `computeWorkflowHash`) and
-  replaces the row. Existing user workflows that copied a built-in and still
-  reference `completionActions[…]` in the JSON column will surface as dead
-  fields that the schema validator rejects — a soft migration at load time
-  strips unknown fields (validate this assumption against the `Gate` parser
-  at `space-workflow-manager.ts`). Otherwise add a one-shot data migration in
-  Stage 4.
-- **In-flight runs at migration time**: a daemon upgrade mid-run where the
-  task is paused at `pendingCheckpointType='completion_action'`. Migration
-  step 1 above rewrites these to `task_completion` so the task appears in the
-  "submit for approval" banner instead, where the operator can click through.
-  Downside: the specific *action* context is lost. This is acceptable for the
-  upgrade window.
-- **User workflows that declare `completionActions`**: the workflow validator
-  at `space-workflow-manager.ts` must learn to reject (or strip with warning)
-  unknown fields so users don't hit a hard error on load. Emit a
-  `workflow.migrated` notification in that case.
+  Adding `postApproval` is an additive, non-breaking change.
+- **Task status `approved`:** additive; existing status values unchanged.
+  No existing caller queries for `approved` tasks (it didn't exist). UI
+  lists and filters need to be taught about it (Stage 1).
+- **Built-in workflows (DB rows):** the `seedBuiltInWorkflows` seeder
+  re-stamps template rows via `computeWorkflowHash`. Seeder must rebuild
+  built-in rows in Stage 3 to pick up the new `postApproval` fields.
+- **In-flight runs at migration time:** a daemon upgrade mid-run where the
+  task is paused at `pendingCheckpointType='completion_action'`. Stage 5
+  migration rewrites these to `task_completion` so the task surfaces in the
+  submit-for-approval banner; the operator can click through.
+- **User workflows that declare `completionActions`:** the workflow
+  validator must learn to strip unknown fields with a warning so users
+  don't hit a hard error on load. Emit a `workflow.migrated` notification
+  in that case. (Same as the previous revision.)
 
 ### 6.2 Suggested PR breakdown (5 PRs)
 
-See §0 — restated with rough size estimates:
-
-- **PR 1**: add `merge_pr` tool + handler + pr-merge-script module behind a feature flag, with unit tests. ~400 LOC; self-contained; safe to merge without downstream changes.
-- **PR 2**: end-node prompt changes in all 5 workflows + Task Agent prompt addition (§3.2) + runtime injection of `[TASK_APPROVED]` + feature-flag flip. ~600 LOC; depends on PR 1.
-- **PR 3**: delete runtime pipeline, RPC intercept, MCP tool, UI banner. ~1500 LOC net-negative; largest PR; depends on PR 2 being deployed long enough to confirm the new path works.
-- **PR 4**: schema / shared-types / DB migration. ~500 LOC; depends on PR 3. Can be squashed into PR 3 if the diff is still reviewable.
-- **PR 5**: docs refresh — update `docs/research/pr-merging-completion-actions.md` with a closing section pointing to this plan; update `docs/design/autonomy-levels-and-completion-actions.md`; changelog entry; remove any other stale references. ~200 LOC; trivial.
+- **PR 1** — **Task state `approved` + workflow schema.**
+  Adds `TaskStatus='approved'`, `WorkflowDefinition.postApproval` type,
+  validator, template interpolator, `post_approval_session_id` column +
+  migration. No behaviour change (nothing reads `approved` in this PR).
+  Unit-tested. ~600 LOC; self-contained.
+- **PR 2** — **Task Agent post-approval routing.**
+  Runtime emits `[TASK_APPROVED]`. Task Agent system prompt addition.
+  New tools `spawn_post_approval_session` + `completePostApproval`. State
+  transitions `in_progress/review → approved → done` plumbed through.
+  Behind a feature flag (`NEOKAI_TASK_AGENT_POST_APPROVAL_ROUTING`).
+  ~800 LOC; depends on PR 1.
+- **PR 3** — **End-node handoff + built-in workflow `postApproval`
+  entries.** Update all 5 built-in workflow prompts. Populate `postApproval`
+  on Coding, Research, QA. Flip the feature flag. ~500 LOC; depends on PR 2.
+- **PR 4** — **Delete completion-action runtime pipeline.** Remove
+  `resolveCompletionWithActions`, `resumeCompletionActions`,
+  `executeCompletionAction`, the RPC intercept, `approve_completion_action`
+  MCP tool, `PendingCompletionActionBanner`. Task/run completion flows
+  through the new `approved → done` path. ~1500 LOC net-negative. Depends
+  on PR 3 being deployed long enough to confirm the new path works.
+- **PR 5** — **Schema / shared-types / DB migration + docs.** Drop
+  `pending_action_index`, `pending_checkpoint_type='completion_action'`,
+  `completion_actions_fired_at`, `MERGE_PR_COMPLETION_ACTION` etc. Docs
+  refresh, changelog entry. ~700 LOC. Depends on PR 4.
 
 ### 6.3 Test strategy summary
 
 | Layer | Scope | Files |
 |-------|-------|-------|
-| Unit — daemon | `merge_pr` handler, post-approval signalling, runtime injection, built-in workflow snapshot | §4.6 list |
-| Unit — shared | Workflow-autonomy helper simplification | `packages/shared/tests/workflow-autonomy.test.ts` (rewrite) |
-| Integration — daemon online tests | Simulate full Coding/Research/QA runs with dev-proxy; assert task closes correctly at each autonomy level | `packages/daemon/tests/online/space/` (new files) |
-| E2E | End-to-end from UI input through Task Agent merge decision, with mock `gh` | §4.6 list |
-| Manual | Spin up a dev space at each autonomy level 1–5; kick a Coding workflow against a real GitHub PR; observe behaviour | Pre-merge of PR 2 + 3 |
+| Unit — daemon | Validator, template interpolator, routing, state transitions, spawning, end-node handoff, workflow snapshots | §4.6 list |
+| Unit — shared | `TaskStatus` enum tests, workflow-autonomy helper simplification | `packages/shared/tests/workflow-autonomy.test.ts` (rewrite) |
+| Integration — daemon online tests | Simulate full Coding/Research/QA runs with dev-proxy; assert `approved → done` works at each autonomy level | `packages/daemon/tests/online/space/` (new files) |
+| E2E | End-to-end from UI input through post-approval session, with mock `gh` | §4.6 list |
+| Manual | Spin up a dev space at each autonomy level 1–5; kick a Coding workflow against a real GitHub PR; observe behaviour | Pre-merge of PR 3 + 4 |
 
 ### 6.4 Observability / rollback
 
-- Add a structured daemon log entry for every `merge_pr` tool invocation:
-  `task-agent.merge_pr: spaceId=... taskId=... prUrl=... level=... autoApproved=bool outcome=merged|already_merged|failed|refused-autonomy reason=...`
-- Feature-flag (`NEOKAI_TASK_AGENT_MERGE_EXECUTOR`) allows a quick disable if
-  the tool misbehaves in the wild. When disabled, the tool is not registered
-  and the Task Agent's prompt gracefully reports to humans that the action is
-  unsupported (humans merge manually on GitHub).
-- PRs 3 and 4 are effectively one-way doors once merged (code + DB). If a
-  regression is found after they ship, the fix is forward-only.
+- Add structured daemon log entries:
+  - `task-agent.post-approval.spawn: spaceId=... taskId=... targetAgent=... sessionId=... autonomyLevel=...`
+  - `task-agent.post-approval.complete: spaceId=... taskId=... outcome=done|blocked reason=...`
+  - `task.status-transition: taskId=... from=... to=... source=...`
+- Feature flag (`NEOKAI_TASK_AGENT_POST_APPROVAL_ROUTING`) allows a quick
+  disable. When disabled, tasks transition directly to `done` and no
+  post-approval session spawns — identical to today's no-completion-actions
+  behaviour for workflows without `postApproval`.
+- PRs 4 and 5 are effectively one-way doors once merged. If a regression is
+  found after they ship, the fix is forward-only.
 
 ---
 
 ## 7. Open questions / decisions for review
 
-1. **Artifact-based idempotency vs. a new `space_task_merges` table.**
-   The plan uses the artifact store (`type: 'result', data.merged_pr_url`) for
-   idempotency. Pro: no schema changes, matches existing audit pattern.
-   Con: artifact store is not strictly type-safe; a malformed custom agent
-   could write a similar shape. Decision: accept — the risk is low and the
-   simplicity wins.
+1. **Session kind for post-approval.** Options:
+   - (A) Reuse the existing `space_task_agent` sub-session kind; add a field
+     `isPostApproval: true` to distinguish from a regular node execution.
+   - (B) Introduce a new `space_task_post_approval` sub-session kind with
+     its own repository entries.
+   - (C) Model post-approval as a new ad-hoc node grafted onto the run's
+     node graph.
+   **Recommendation:** **A** for Stage 2 — fewer moving parts, integrates
+   with existing `[NODE_COMPLETE]` event plumbing. Revisit in Stage 5 if
+   the flag becomes load-bearing for queries.
 
-2. **Should `merge_pr` also write to the same artifact store as the end node,
-   or its own namespace (`nodeId: 'task-agent'`)?**
-   Using `nodeId: 'task-agent'` (already the convention in
-   `task-agent-tools.ts:294`) keeps provenance clear and avoids colliding with
-   reviewer-written artifacts. Decision: `nodeId: 'task-agent'`.
+2. **Tool-allowlist scoping for post-approval sessions.**
+   Can we narrow the tool surface (e.g. drop `curl`, drop file-write
+   outside the worktree)? The target agent's default surface may be broader
+   than the post-approval step needs.
+   **Recommendation:** **No restriction in v1.** Keeping the surface
+   identical to the node-session makes the template instructions
+   transferable. Narrowing is a follow-up hardening pass if operators find
+   a specific abuse pattern.
 
-3. **Should the QA workflow `completionAutonomyLevel` drop to 3, or lower?**
-   §5 suggests 3 (matches Coding). Argument for keeping it at 4: QA gates
-   *all* of backend + frontend + browser tests, which is a higher-risk signal
-   than Reviewer approval alone. Argument for 3: after the refactor the
-   self-close is purely "is the work good"; merging is a separate question now
-   handled by `merge_pr` autonomy. Decision: **3**, with a comment in the
-   workflow definition explaining the rationale.
+3. **Task stuck in `approved` with failed post-approval session — UX.**
+   The `PendingPostApprovalBanner` surfaces a stuck task. What actions
+   should it offer?
+   - Retry (re-spawn same target agent with same instructions).
+   - Mark done manually (record an audit artifact, advance to `done`).
+   - View session transcript (routes to the session UI).
+   - Escalate (convert to `blocked` with a reason).
+   **Recommendation:** include all four in v1; escalation is the
+   out-of-band option when retry doesn't work.
 
-4. **Review-Only and Plan-and-Decompose verification regressions.**
+4. **Template interpolation: escape hatches.**
+   Should `{{` be escapable? Should the grammar support literal `{{…}}`
+   in output? Relevant when an `instructions` string wants to embed example
+   template syntax for the LLM to learn from.
+   **Recommendation:** no escaping in v1. If a template ever needs to
+   output a literal `{{foo}}`, the author can use `{ {foo}}` as an escape
+   hatch.
+
+5. **Post-approval on multi-task missions.**
+   Missions (workflow runs spanning several tasks) reach `done` when their
+   last task reaches `done`. Does post-approval run per-task or once per
+   mission? The current design is **per-task** (each task has its own
+   `approved → done` with its own post-approval). A mission-level
+   `postApproval` could be added later as a separate `MissionDefinition`
+   field; not in scope here.
+
+6. **Review-Only and Plan-and-Decompose verification regressions.**
    Do we accept losing the verify-review-posted / verify-tasks-created
-   checks, or do we reintroduce them as optional post-approval actions
-   (requiring a `post_approval_action: 'verify_review_posted'` variant)?
-   **Recommendation:** accept the regression for Stage 3; revisit as a
+   checks, or reintroduce them as optional post-approval templates (e.g.
+   `targetAgent: 'task-agent'` + instructions "before closing, verify the
+   reviewer posted an actual review")?
+   **Recommendation:** accept the regression for Stage 4; revisit as a
    follow-up if operator feedback indicates the checks were load-bearing.
 
-5. **Task Agent context for `request_human_input`.**
-   Should the runtime enrich the structured-data payload with the PR title /
-   CI status / commit count before delivery, so the Task Agent can produce a
-   richer `context` string? Current design: no — let the Task Agent use the
-   `pr_url` the end node supplied and the artifact trail. Re-evaluate if the
-   human-facing question text is too thin in practice.
+7. **Should `spawn_post_approval_session` be exposed to non-Task-Agent
+   sessions?** No. Internal to the Task Agent MCP server.
 
-6. **Should `merge_pr` ever be exposed to non-Task-Agent sessions?**
-   No. It is registered solely on the Task Agent's MCP server (via
-   `createTaskAgentMcpServer`). Do not add it to `createNodeAgentMcpServer`
-   or `createSpaceAgentMcpServer`.
+---
+
+## 8. Revision history
+
+**2026-04-23 (this revision):** Approach changed from "narrow `merge_pr`
+MCP tool on Task Agent" to "workflow-declared post-approval agent
+routing", based on review feedback that the MCP-tool approach was too
+rigid for real-world post-approval work. Key changes:
+
+- §0, §1: rewritten around workflow schema `postApproval` field, new task
+  status `approved`, agent-spawn routing model. §1.2 replaced ("Why a
+  post-approval agent, not a dedicated MCP tool").
+- §2.3: reframed `[TASK_APPROVED]` event as a routing signal (not a
+  tool-call hint).
+- §3.1: autonomy enforcement moves from handler-layer to template-layer +
+  tool-layer.
+- §5: workflows now declare `postApproval` instead of `completionActions`;
+  added the shared merge-template `instructions` string.
+- §6.2: five-PR breakdown reorganised around the new stages.
+- §7: open questions rewritten for the new design.
+
+Original revision (PR #1611) preserved in git history on branch
+`space/task-agent-merge-pr-mcp-tool-handler-script-module-behind`.
+Reusable carry-overs: `PR_MERGE_BASH_SCRIPT` hoist to
+`pr-merge-script.ts`, end-node signalling via `send_message(task-agent,
+data)`, unchanged sections §2 (signal protocol concepts), §4.1–4.3
+(completion-action removal scope), §6.1 (breaking-change assessment).
 
 ---
 
@@ -738,42 +1078,42 @@ See §0 — restated with rough size estimates:
 Key files referenced in this plan, grouped by area:
 
 **Task Agent wiring**
-- `packages/daemon/src/lib/space/agents/task-agent.ts` — system prompt + session init
-- `packages/daemon/src/lib/space/runtime/task-agent-manager.ts` — session lifecycle, sub-session events, prompt building
-- `packages/daemon/src/lib/space/tools/task-agent-tools.ts` — MCP server (add `merge_pr` here)
-- `packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts` — Zod schemas (add `MergePrInputSchema`)
+- `packages/daemon/src/lib/space/agents/task-agent.ts` — system prompt + session init (add §3.2 section)
+- `packages/daemon/src/lib/space/runtime/task-agent-manager.ts` — session lifecycle, sub-session events, post-approval spawn plumbing
+- `packages/daemon/src/lib/space/tools/task-agent-tools.ts` — MCP server (add `spawn_post_approval_session`, `completePostApproval`)
+- `packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts` — Zod schemas for new tools
 
-**End-node wiring**
-- `packages/daemon/src/lib/space/tools/end-node-handlers.ts` — `onApproveTask` / `onSubmitForApproval` (no change)
-- `packages/daemon/src/lib/space/runtime/agent-message-router.ts` — `task-agent` routing (already works)
+**Workflow schema**
+- `packages/shared/src/types/space.ts` — add `PostApprovalRoute`, `WorkflowDefinition.postApproval`
+- `packages/daemon/src/lib/space/workflows/post-approval-validator.ts` — NEW: `targetAgent` validator
+- `packages/daemon/src/lib/space/workflows/post-approval-template.ts` — NEW: `instructions` interpolator
+- `packages/daemon/src/lib/space/workflows/built-in-workflows.ts` — populate `postApproval` on Coding, Research, QA
 
 **Runtime completion-resolution (to delete / simplify)**
-- `packages/daemon/src/lib/space/runtime/space-runtime.ts` — `resolveCompletionWithActions`, `resumeCompletionActions`
+- `packages/daemon/src/lib/space/runtime/space-runtime.ts` — replace `resolveCompletionWithActions` with `resolveTaskApproval`
 - `packages/daemon/src/lib/space/runtime/completion-action-executors.ts` — full file
 - `packages/daemon/src/lib/space/runtime/pending-action.ts` — full file
 - `packages/daemon/src/lib/space/runtime/space-runtime-service.ts` — `resumeCompletionActions`
+- `packages/daemon/src/lib/space/runtime/post-approval-router.ts` — NEW: orchestrates target-agent spawn
 
 **RPC layer**
-- `packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts` — `spaceTask.update` intercept + `approvePendingCompletion`
-
-**Workflow definitions**
-- `packages/daemon/src/lib/space/workflows/built-in-workflows.ts` — all 5 built-in workflows + action constants + scripts
-- `packages/daemon/src/lib/space/workflows/template-hash.ts` — hash changes when templates change (auto)
+- `packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts` — `spaceTask.update` intercept, `approvePendingCompletion` (new target = `approved`), `completePostApproval` (NEW RPC)
 
 **Shared types**
-- `packages/shared/src/types/space.ts` — `CompletionAction`, `SpaceTask`, `SpaceWorkflowRun`, `WorkflowNode`
+- `packages/shared/src/types/space.ts` — `TaskStatus` (add `approved`), `CompletionAction` (remove), `SpaceTask`, `SpaceWorkflowRun`, `WorkflowDefinition`
 - `packages/shared/src/space/workflow-autonomy.ts` — autonomy helpers
 
 **Storage**
-- `packages/daemon/src/storage/schema/migrations.ts` — add new migration (§4.4)
-- `packages/daemon/src/storage/repositories/space-task-repository.ts` — drop completion-action columns from mapper
+- `packages/daemon/src/storage/schema/migrations.ts` — add migrations (§4.4)
+- `packages/daemon/src/storage/repositories/space-task-repository.ts` — `postApprovalSessionId`, `postApprovalStartedAt`, `postApprovalBlockedReason` columns
 - `packages/daemon/src/storage/repositories/space-workflow-run-repository.ts` — drop `completionActionsFiredAt`
 
 **Web UI**
 - `packages/web/src/components/space/PendingCompletionActionBanner.tsx` — delete
-- `packages/web/src/components/space/TaskStatusActions.tsx` — remove banner mount
+- `packages/web/src/components/space/PendingPostApprovalBanner.tsx` — NEW: "post-approval in progress" / "post-approval failed" banner
+- `packages/web/src/components/space/TaskStatusActions.tsx` — swap banners
 - `packages/web/src/components/space/SpaceTaskPane.tsx` — remove `'completion_action'` routing
-- `packages/web/src/lib/space-store.ts` — drop completion-action state helpers
+- `packages/web/src/lib/space-store.ts` — drop completion-action helpers; add `approved` status helpers
 
 ---
 
@@ -781,12 +1121,16 @@ Key files referenced in this plan, grouped by area:
 
 | Decision | Options considered | Chosen | Why |
 |----------|--------------------|--------|-----|
-| Merge executor: Task Agent LLM vs. deterministic daemon method | (A) TaskAgentManager method invoked from runtime completion hook; (B) New MCP tool the Task Agent LLM calls | **B** | Task description explicitly names `request_human_input` (an LLM-session tool) as the approval surface. Deterministic daemon method can't pause for human input the same way. Future post-approval actions reuse the same pattern. |
-| Handoff signal: new gate vs. structured send_message | (A) New `merge-ready-gate` on an `End → TaskAgent` channel; (B) `send_message(task-agent, data)` with structured-data appendix; (C) Artifact written by end-node, runtime passes to Task Agent | **B** | `task-agent` is not a workflow node, so gate semantics don't fit. The structured-data appendix is already the idiomatic pattern for node→Task-Agent data transfer. Artifacts are used as the durable audit trail in addition. |
-| `completionAutonomyLevel`: keep, repurpose, or remove | (A) Remove (merge-PR autonomy is the only thing that ever mattered); (B) Keep — separate from merge level; (C) Rename to `workApprovalAutonomyLevel` | **B** | It independently controls `approve_task` vs `submit_for_approval` — a distinct "is the work any good" decision. Removing would force every workflow into the same `approve_task` discipline. Rename is a nice-to-have but costs a schema migration; defer. |
-| Verification completion actions (verify-pr-merged, verify-review-posted, verify-tasks-created): keep, convert, delete | (A) Keep as a separate "post-approval verification" hook (violates §11 of research doc); (B) Convert each to a Task Agent tool; (C) Delete (accept regression) | **C** | §11 of the research doc explicitly argues for wholesale removal. The lost verifications are soft guardrails; agents lying is a broader problem addressed by audit artifacts and human review, not completion actions. (B) remains available as a follow-up if the regression bites. |
-| Feature-flag the new tool | (A) Ship registered from day 1; (B) Behind flag for Stages 1–2, flip in Stage 2 | **B** | Allows the tool to exist and be tested without any workflow prompt depending on it. De-risks the staged rollout. |
-| QA workflow `completionAutonomyLevel` | Keep 4 vs. drop to 3 | **Drop to 3** | QA no longer merges. Self-close decision is now equivalent to Coding — same threshold. Auto-merge is a separate autonomy dimension enforced at the `merge_pr` tool layer. |
+| Post-approval executor: narrow MCP tool vs. workflow-declared target agent | (A) New `merge_pr` MCP tool on Task Agent; (B) Workflow declares `postApproval.targetAgent` + `instructions`, Task Agent spawns the target | **B** | Real-world post-approval (merge, deploy, publish) needs LLM-dynamic handling — CI waits, conflict resolution, retry logic. A narrow handler cannot do this. Agent-spawn model reuses workflow-agent session infrastructure for free. See §1.2 for full argument. |
+| Eligible `targetAgent` values | (A) Any agent name; (B) Declared workflow agent + `task-agent`; (C) Declared workflow agent only | **B** | Constraining to agents the workflow already declared avoids ad-hoc config. `task-agent` as an explicit second option handles the "no workflow agent fits" escape hatch without needing new agent types. |
+| Task lifecycle addition | (A) Reuse `review` → `done` with a post-approval sub-state; (B) Add new `approved` status; (C) Track post-approval progress on the workflow-run row, not the task | **B** | `approved` is semantically distinct from `review` (work is accepted, not pending) and from `done` (terminal). Making it a first-class status is simpler to reason about in UI and queries. See §1.3. |
+| Template grammar | (A) Simple `{{var}}` substitute; (B) Full Handlebars; (C) JS expressions | **A** | Dumb substitute is sufficient because the LLM reading the prompt handles all the conditional logic. Handlebars + JS are overkill and create testing/security debt. |
+| Merge executor: Task Agent LLM (direct) vs. Task Agent routes to reviewer | Original revision: Task Agent LLM calls `merge_pr` MCP tool directly. This revision: Task Agent routes to reviewer (workflow-declared agent). | **Route to reviewer** | Task Agent stays a pure orchestrator. The reviewer agent (or any target) already has the Bash/git/gh toolkit — reuse rather than duplicate. |
+| Handoff signal: new gate vs. structured send_message | Unchanged from original revision. | **send_message(task-agent, data)** | Already idiomatic; gates don't fit the task-agent's implicit channels. |
+| `completionAutonomyLevel`: keep, repurpose, or remove | Unchanged. | **Keep** | Independently controls `approve_task` vs `submit_for_approval` — a distinct "is the work any good" decision from post-approval. |
+| Verification completion actions (verify-pr-merged, verify-review-posted, verify-tasks-created): keep, convert, delete | Unchanged. | **Delete** (accept regression) | Lost verifications are soft guardrails; audit artifacts + human review are the primary safety nets. |
+| Feature-flag the new routing | (A) Ship enabled by default; (B) Behind flag during PR 2, flip in PR 3 | **B** | Allows the runtime code to exist and be tested without any workflow template depending on it. De-risks the staged rollout. |
+| QA workflow `completionAutonomyLevel` | Keep 4 vs. drop to 3 | **Drop to 3** | QA no longer merges. Auto-merge autonomy is a separate dimension enforced via the post-approval session's own autonomy-aware template. |
 
 ---
 


### PR DESCRIPTION
## Summary

Revises the completion-actions removal plan to pivot from the narrow `merge_pr` MCP-tool-on-Task-Agent approach to a workflow-declared post-approval agent routing model, per reviewer direction.

- Workflow templates declare `postApproval: { targetAgent, instructions }`; Task Agent spawns that agent with interpolated kickoff after human approval
- Eligible targets restricted to workflow-declared agents + `task-agent`
- New task status `approved` added (lifecycle: `in_progress → approved → done`)
- 5-PR breakdown rewritten; §§2–4 concepts preserved where still applicable
- Revision history captured in §8

## Context

Supersedes PR #1611 (MCP-tool approach, now closed). Plan-only PR — no code yet. Please approve the revised plan before any implementation begins.

## Test plan
- [ ] Plan reviewed by Review peer
- [ ] Direction confirmed before starting Work Item 1 code