### PR TITLE
docs: plan revision — post-approval routing (runtime dispatch + mark_complete tool)

### DIFF
--- a/docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md
+++ b/docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md
@@ -29,17 +29,19 @@ That approach was reconsidered after initial review:
   contract and makes future requests ("can Task Agent also deploy?") harder
   to refuse.
 
-**The revised approach is workflow-declared post-approval agent routing.** In
-one sentence: a workflow template declares `postApproval.targetAgent` (an
-agent role that is part of the same workflow, or `task-agent`) and
-`postApproval.instructions` (a templated prompt). After the end node signals
-completion, the Task Agent transitions the task to a new `approved` status,
-spawns a fresh session for the target agent with the interpolated
-instructions, and moves the task to `done` once that session completes. The
-target agent is a normal workflow-agent session with its normal toolkit
-(Bash, file ops, MCP servers, everything), so it can handle merge complexity
-the same way any other node handles its work — with LLM judgement, retries,
-and escalation.
+**The revised approach is workflow-declared, runtime-dispatched post-approval
+agent routing.** In one sentence: a workflow template declares
+`postApproval.targetAgent` (an agent role that is part of the same workflow,
+or `task-agent`) and `postApproval.instructions` (a templated prompt). After
+the end node signals completion, the **runtime** transitions the task to a
+new `approved` status and dispatches deterministically — spawning a fresh
+session for the target agent with interpolated instructions, or (when the
+target is `task-agent`) injecting an instruction turn into the existing Task
+Agent conversation. When post-approval completes, the task transitions to
+`done`. The target agent is a normal workflow-agent session with its normal
+toolkit (Bash, file ops, MCP servers, everything), so it can handle merge
+complexity the same way any other node handles its work — with LLM
+judgement, retries, and escalation.
 
 Concretely:
 
@@ -55,22 +57,35 @@ Concretely:
    template's data source — `{{pr_url}}` comes from there.
 3. New task status value **`approved`**. Lifecycle becomes
    `open → in_progress → review? → approved → done` (the `review` branch is
-   unchanged from today). The Task Agent transitions the task to `approved`
+   unchanged from today). The runtime transitions the task to `approved`
    when an end node closes it; it transitions to `done` once post-approval
    completes.
-4. Task Agent, on seeing `approved`, looks up `workflow.postApproval`:
+4. A new runtime module, `PostApprovalRouter`, performs the dispatch on the
+   `approved` boundary — *not* the Task Agent LLM. The dispatch is a
+   deterministic lookup against `workflow.postApproval`:
    - If the workflow has no `postApproval` → immediately transition to `done`
      (single-step workflows, documentation missions).
-   - Otherwise → spawn a new session for `targetAgent` with the interpolated
-     `instructions` as the kickoff user message. Wait for the session to
-     complete.
+   - If `targetAgent` is a workflow-agent role → spawn a new session for that
+     role with the interpolated `instructions` as kickoff. The session's
+     completion triggers `approved → done` via existing sub-session event
+     plumbing.
+   - If `targetAgent === 'task-agent'` → inject
+     `[POST_APPROVAL_INSTRUCTIONS]` as a user turn into the existing Task
+     Agent session. The Task Agent performs the work with its orchestrator
+     toolset and calls its existing (now idempotent) `approve_task` to
+     close — no new tools.
 5. The spawned post-approval session is a normal workflow-agent session: it
    has the agent's full system prompt, tool surface, and MCP servers. For a
    PR merge, the instructions direct it to run the appropriate shell
    commands (`gh pr view`, `gh pr merge`, worktree sync). For a different
    workflow's post-approval it could be publishing a release, notifying
    slack, etc. — all determined by the workflow author's instruction string.
-6. The entire `CompletionAction` type, its runtime pipeline, its RPC
+6. **No new MCP tools on the Task Agent server.** Routing is deterministic
+   runtime code; there is no decision for an LLM to mediate. The Task Agent
+   receives `[TASK_APPROVED]` as awareness only, and acts only when
+   `targetAgent === 'task-agent'` (handled via the existing `approve_task`
+   tool in its idempotent-completion mode).
+7. The entire `CompletionAction` type, its runtime pipeline, its RPC
    intercepts, its MCP tool (`approve_completion_action`), its DB columns,
    and its UI surface are deleted. The per-workflow knob
    `completionAutonomyLevel` **stays** (it controls `approve_task` vs
@@ -87,7 +102,7 @@ Task Agent or daemon.
 | Stage | PR | Scope | Dependency |
 |------|----|-------|------------|
 | 1 | Task state `approved` + workflow schema | Add `TaskStatus='approved'` (shared types + DB migration), add `WorkflowDefinition.postApproval` shape + validator, no behaviour change yet (nothing reads `approved` or `postApproval` beyond load/save). Unit-tested. | — |
-| 2 | Task Agent post-approval routing | Task Agent reads `workflow.postApproval` on task-closed event; transitions task to `approved`; spawns target-agent session with templated instructions; waits for that session to complete; transitions task to `done`. Behind a feature flag so callers continue seeing completion-actions behaviour until workflow templates migrate. | Stage 1 deployed |
+| 2 | Runtime post-approval routing | New `PostApprovalRouter` module dispatches on the `approved` boundary: no-target → direct `done`; workflow-agent target → spawn session; `task-agent` target → inject `[POST_APPROVAL_INSTRUCTIONS]` turn. `approve_task` tool becomes idempotent for `approved → done`. Runtime emits `[TASK_APPROVED]` as an awareness-only event. No new MCP tools. Behind a feature flag so callers continue seeing completion-actions behaviour until workflow templates migrate. | Stage 1 deployed |
 | 3 | End-node handoff + built-in workflow `postApproval` entries | Update built-in workflow prompts to `send_message` to `task-agent` with `{ pr_url, post_approval_action }` before `approve_task`. Populate `postApproval` on all 5 built-in workflows. Update Task Agent system prompt + kickoff. Flip the feature flag. | Stage 2 deployed |
 | 4 | Remove completion-action runtime pipeline | Delete `resolveCompletionWithActions` / `resumeCompletionActions` / `executeCompletionAction`; delete the `spaceTask.update` intercept for `completion_action`; delete `approve_completion_action` MCP tool; delete `PendingCompletionActionBanner`. Task/run completion now flows through the new `approved → done` path. | Stage 3 deployed |
 | 5 | Schema cleanup + docs | Drop `pending_action_index`, `pending_checkpoint_type='completion_action'` value, `completion_actions_fired_at`, `MERGE_PR_COMPLETION_ACTION` etc. from DB & shared types. Docs refresh. Changelog. | Stage 4 merged |
@@ -212,7 +227,7 @@ Semantics:
 |--------|---------|
 | `in_progress` | A workflow node is actively working. |
 | `review` | The end node returned `submit_for_approval`; a human must approve (or reject) before the task can close. Unchanged. |
-| **`approved` (new)** | The work has been accepted (by the end node via `approve_task`, or by a human via `approvePendingCompletion`). **Post-approval is now pending.** The Task Agent reads `workflow.postApproval` and routes. |
+| **`approved` (new)** | The work has been accepted (by the end node via `approve_task`, or by a human via `approvePendingCompletion`). **Post-approval is now pending.** The runtime (`PostApprovalRouter`) reads `workflow.postApproval` and dispatches. |
 | `done` | Terminal success. Reached from `approved` once the post-approval session completes (or immediately if the workflow has no `postApproval`). |
 | `blocked` | Terminal failure or human intervention required. |
 | `cancelled` | User cancelled. |
@@ -243,60 +258,85 @@ approved --postApproval session failed after retries--> blocked
 No backfill required: existing tasks are all in terminal or in-flight
 statuses that don't include `approved`.
 
-### 1.4 Task Agent routing mechanics
+### 1.4 Runtime-driven routing mechanics
 
-Three event sites interact:
+**Design decision (2026-04-23 revision):** routing is a deterministic
+runtime step, not an LLM decision. The Task Agent is *not* in the critical
+path for spawning the post-approval session — it only observes the
+transitions for conversational awareness. No new MCP tools are added to
+the Task Agent server.
+
+Four event sites interact:
 
 1. **End-node `approve_task` completes.** Today this flows through the
    completion-action pipeline. New behaviour:
    - `SpaceRuntime` transitions the task from `in_progress → approved`
      (instead of the current `in_progress → pending_completion_action → done`).
-   - Emits a `[TASK_APPROVED]` runtime event to the Task Agent session
-     carrying the end-node's structured-data payload verbatim (for template
-     interpolation).
+   - Calls a new helper `PostApprovalRouter.route(task, workflow, context)`
+     which performs the steps in (3) below.
+   - Emits a `[TASK_APPROVED]` runtime event to the Task Agent session for
+     conversational awareness only (so the orchestrator can answer user
+     questions like "what happened to task 12?"). The Task Agent takes no
+     action in response to this event.
 
 2. **`approvePendingCompletion` (the human-approves-the-work path).**
    Transitions the task `review → approved` instead of today's `review → done`
-   (or the completion-action branch). Emits `[TASK_APPROVED]` the same way.
+   (or the completion-action branch). Calls `PostApprovalRouter.route` the
+   same way.
 
-3. **Task Agent receives `[TASK_APPROVED]`.** It looks up
-   `workflow.postApproval` for the current workflow:
+3. **`PostApprovalRouter.route` — the deterministic dispatch.** Looks up
+   `workflow.postApproval` and branches:
 
-   - **If no `postApproval`:** Task Agent calls a new internal RPC
-     `spaceTask.completePostApproval({ taskId })` which transitions
-     `approved → done`. Done.
+   - **If no `postApproval`:** runtime transitions `approved → done`
+     directly via the task repository. Emits
+     `task.status-transition: approved → done source=no-post-approval`.
+     Done.
 
-   - **If `postApproval.targetAgent === 'task-agent'`:** Task Agent
-     interpolates `instructions` and acts on them within its own session.
-     This is the narrow case where the orchestrator itself is the target
-     — used when the post-approval work is small enough to fit within
-     the Task Agent's orchestrator tool surface (e.g. sending a notification
-     via `send_message`, writing a final artifact, no-op workflows). On
-     completion, calls `spaceTask.completePostApproval` to close.
+   - **If `postApproval.targetAgent === 'task-agent'`:** runtime injects
+     the interpolated `instructions` as a user-message turn into the
+     existing Task Agent session (same channel the runtime already uses
+     for `[TASK_APPROVED]` and `[NODE_COMPLETE]` events; see
+     `task-agent-manager.ts` ≈ line 2878). No session spawn; no new tools.
+     The Task Agent acts on the instructions using the tools already on
+     its MCP server (`send_message`, `request_human_input`,
+     `save_artifact`, etc.). Completion is signalled when the Task Agent
+     calls its existing `approve_task` tool again — that tool becomes
+     idempotent for `approved` tasks and transitions `approved → done`
+     (see §3.2).
 
-   - **Otherwise (targetAgent is a workflow-agent role):** Task Agent
-     spawns a new session for that role:
-     - Session kind: `space_task_post_approval` (new session type) or reuse
-       the existing `space_task_agent` sub-session model. Decision deferred
-       to §7.1.
-     - Same worktree, same MCP server config as the corresponding
+   - **Otherwise (targetAgent is a workflow-agent role):** runtime spawns
+     a fresh session for that role:
+     - Session kind: reuses the existing `space_task_agent` sub-session
+       model with an `isPostApproval: true` flag (confirmed decision —
+       §7.1).
+     - Same worktree and MCP server config as the corresponding
        workflow-node session would have.
      - Kickoff user message = interpolated `instructions`.
-     - Records `post_approval_session_id` on the task.
-     - Awaits session completion.
+     - Records `post_approval_session_id` + `post_approval_started_at` on
+       the task.
+     - Awaits session completion via the existing sub-session event
+       plumbing (same path that handles `[NODE_COMPLETE]` today).
 
-4. **Post-approval session completes.** The spawned session terminates
-   normally (its agent calls `approve_task`, or simply exits). Task Agent
-   observes the `[NODE_COMPLETE]`-equivalent event and calls
-   `spaceTask.completePostApproval({ taskId })` to move `approved → done`.
+4. **Post-approval session completes (non-task-agent path).** The spawned
+   session terminates normally (its agent calls `approve_task` or simply
+   reaches end-of-turn). Runtime observes the session-terminated event and
+   transitions `approved → done`. No Task Agent tool-call needed.
 
 5. **Post-approval session fails.** If the session exits with an error, or
    the spawned agent calls `submit_for_approval` on its post-approval work
    (escalating to a human), the task stays in `approved` with a
-   `postApprovalBlockedReason` recorded. The user sees a banner similar to
-   today's `PendingCompletionActionBanner` but driven by the session
-   outcome, not by a specific action. They can inspect the session
-   transcript, fix the issue externally, and either retry or manually close.
+   `postApprovalBlockedReason` recorded. The user sees a
+   `PendingPostApprovalBanner` driven by the session outcome (see §3.5).
+   They can inspect the session transcript, fix the issue externally, and
+   either retry or manually close.
+
+**Why runtime-driven, not LLM-driven?** Routing is a fixed lookup against
+`workflow.postApproval` — there is no decision for an LLM to make. Adding
+an MCP tool for the Task Agent to "decide" to spawn would put deterministic
+dispatch behind a non-deterministic gate, risking the Task Agent skipping
+or mis-routing. The LLM's judgement is still fully present in the
+post-approval *work itself* (performed by the target agent reading the
+interpolated instructions); just not in the dispatch trigger.
 
 ### 1.5 Eligible target agents + validation
 
@@ -444,19 +484,27 @@ refuse.
 
 ### 2.3 When does the Task Agent act?
 
-Two signals converge in the Task Agent's existing event loop
-(documented in the Task Agent system prompt at
-[`task-agent.ts:233-260`](../../packages/daemon/src/lib/space/agents/task-agent.ts)):
+The Task Agent is **not** the routing driver — the runtime is (see §1.4).
+The Task Agent observes two events for conversational awareness, but only
+*acts* on one of them:
 
-1. The structured `[Message from reviewer]: ...\n<structured-data>{...}</structured-data>`
-   arrives in the Task Agent's conversation. Task Agent remembers the
-   payload in its context.
-2. The task transitions to `approved` — either via `approve_task()` from the
-   end-node or via the human `approvePendingCompletion` path. A new runtime
-   event `[TASK_APPROVED]` is injected into the Task Agent's session at that
-   moment.
+1. **Passive observation — structured data from the end node.** The
+   `[Message from reviewer]: ...\n<structured-data>{...}</structured-data>`
+   payload (§2.1) arrives in the Task Agent's conversation. No tool call
+   required; it becomes part of context so the orchestrator can answer
+   follow-up questions.
+2. **Passive observation — `[TASK_APPROVED]`.** A runtime event injected
+   when the task transitions to `approved`. Also informational: the Task
+   Agent knows the work was approved and routing is now in flight.
+3. **Active only when `targetAgent === 'task-agent'`.** In that specific
+   case the runtime follows up the `[TASK_APPROVED]` event with a second
+   injected user turn carrying the interpolated `instructions`. The Task
+   Agent then performs the post-approval work using tools it already owns
+   and calls `approve_task` a second time to signal completion. (The
+   `approve_task` tool becomes idempotent for `approved` tasks —
+   `approved → done`; see §3.2.)
 
-**Runtime injection shape:**
+**Runtime injection shape (`[TASK_APPROVED]` — awareness only):**
 
 ```
 [TASK_APPROVED] Task <taskId> ("<task-title>") was approved.
@@ -464,31 +512,30 @@ Two signals converge in the Task Agent's existing event loop
 Post-approval routing:
   workflow: <workflow-name>
   target_agent: <target_agent or "none">
-  interpolation_keys_expected: [pr_url, autonomy_level, ...]
   approval_source: <end_node | human_review>
+  session_status: <spawning | self | none>
 
-If target_agent is declared, route now: spawn the session with the
-interpolated instructions from workflow.postApproval.instructions. If
-target_agent is "task-agent", act on those instructions in this
-session and then call spaceTask.completePostApproval when done. If
-target_agent is "none", call spaceTask.completePostApproval immediately.
+No action required from you — this is informational. The runtime will
+spawn the post-approval session (if target_agent is a workflow agent) or
+deliver the instructions to you directly (if target_agent is "task-agent")
+or close the task immediately (if no target).
 ```
 
-The Task Agent has a new tool `spawn_post_approval_session` (internal to the
-Task Agent MCP server; not exposed to node agents) that accepts
-`{ taskId, targetAgent }` and performs the spawn. `completePostApproval` is
-a no-args status transition (Task Agent already owns the task).
+**Runtime injection shape (post-approval instructions — only when
+target_agent === "task-agent"):**
 
-Alternative considered, rejected: have the runtime do the spawn automatically
-on the `[TASK_APPROVED]` boundary, without the Task Agent's involvement.
-Rejected because:
+```
+[POST_APPROVAL_INSTRUCTIONS] Task <taskId> post-approval work begins now.
 
-- The Task Agent owning the spawn keeps the control plane in one place.
-- LLM judgement may still be useful pre-spawn (e.g. the Task Agent may
-  decide the `instructions` need augmenting with context from artifacts it
-  has seen).
-- Symmetry with the `submit_for_approval` path, which the Task Agent already
-  handles via its conversation loop.
+<interpolated instructions from workflow.postApproval.instructions>
+
+When you finish (or need to abort), call approve_task() to close the task.
+If you need human input mid-work, call request_human_input as usual.
+```
+
+No new MCP tools are added to the Task Agent server. The routing
+decision is deterministic and lives in `PostApprovalRouter.route` in the
+runtime layer (§1.4).
 
 ### 2.4 Prompt changes by node
 
@@ -575,40 +622,50 @@ line:
    we want to (e.g. `gh` + `git` + `cd` but no arbitrary `curl`). Scoping
    decision deferred to §7.2.
 
-### 3.2 Task Agent system prompt addition
+### 3.2 Task Agent system prompt addition + `approve_task` idempotency
 
-Amend [`task-agent.ts:buildTaskAgentSystemPrompt`](../../packages/daemon/src/lib/space/agents/task-agent.ts)
-to add a new `## Post-Approval Routing` section after the existing
+**System prompt addition.** Amend
+[`task-agent.ts:buildTaskAgentSystemPrompt`](../../packages/daemon/src/lib/space/agents/task-agent.ts)
+to add a short new `## Post-Approval` section after the existing
 `## Human Gate Handling` section (~line 273):
 
 ```
-## Post-Approval Routing
+## Post-Approval
 
-When a task reaches `approved` status (either via `approve_task()` from the
-end node, or via human approval of a `submit_for_approval` request), a
-`[TASK_APPROVED]` event is injected into your session. That event tells you:
-- the workflow's `postApproval` routing (target agent + what interpolation
-  keys the instructions template expects),
-- whether the approval source was the end node or a human review.
+When a task is approved (either via `approve_task()` from the end node, or
+via human approval of a `submit_for_approval` request), the runtime
+handles routing automatically. You receive a `[TASK_APPROVED]` event for
+awareness; **no action from you is required** for that event.
 
-Your job is to decide the next step:
+The only case where you act is when the workflow's
+`postApproval.targetAgent` is "task-agent". In that case the runtime
+follows up with a `[POST_APPROVAL_INSTRUCTIONS]` event carrying the
+interpolated prompt. Perform the work using the tools already on this
+MCP server (send_message, request_human_input, save_artifact,
+list_artifacts). Do not attempt shell commands — you are an orchestrator,
+not an executor.
 
-1. If the workflow has no `postApproval` target, call
-   `spaceTask.completePostApproval({ taskId })` to move the task to `done`.
-2. If `target_agent` is a workflow-agent role (e.g. "reviewer", "coder"),
-   call `spawn_post_approval_session({ taskId, targetAgent })`. The runtime
-   interpolates the instructions using the structured-data payload from the
-   end node's signal and delivers it as the new session's kickoff. Wait for
-   the session to complete; then call `completePostApproval`.
-3. If `target_agent` is "task-agent", the post-approval work runs in this
-   conversation. Interpret the interpolated instructions directly. When
-   complete, call `completePostApproval`.
+When you finish the post-approval work, call `approve_task()` again to
+close the task. Calling `approve_task` on an already-`approved` task is
+idempotent and transitions it to `done`.
 
-You do not execute post-approval work yourself via shell or Bash — you
-route. The only exception is `target_agent: "task-agent"`, in which case
-use the tools already on this MCP server (send_message, request_human_input,
-save_artifact, list_artifacts). Do not attempt to run shell commands.
+If you need to abort post-approval (e.g. human rejection via
+`request_human_input`), record the reason via `save_artifact` and still
+call `approve_task()` — abandonment is a legitimate outcome, not a
+failure.
 ```
+
+**`approve_task` tool behaviour change.** The existing tool in
+[`task-agent-tools.ts`](../../packages/daemon/src/lib/space/tools/task-agent-tools.ts)
+becomes status-aware:
+
+| Current task status | Effect of `approve_task()` |
+|---------------------|----------------------------|
+| `in_progress` | Transitions `in_progress → approved`, then runtime routes (§1.4). Unchanged user-visible behaviour except the intermediate state. |
+| `approved` (new idempotent case) | Transitions `approved → done`. Used by the Task Agent to signal post-approval completion when `targetAgent === 'task-agent'`. |
+| Any other status | Rejected with an explanatory error (unchanged). |
+
+No new MCP tools are added.
 
 ### 3.3 `request_human_input` question scaffolding
 
@@ -656,10 +713,14 @@ the PR state and decides: already done → exit success; not done → retry
 from the top. The Task Agent's tracking (`post_approval_session_id` on the
 task row) makes it easy to re-attach.
 
-**Task Agent re-routing.** If the Task Agent LLM decides to re-route (rare —
-would require a conversation rewind), `spawn_post_approval_session` checks
-`post_approval_session_id`; if one is already set and not in a terminal
-state, it returns a no-op success with the existing session ID.
+**Runtime re-routing / double-fire protection.** Since routing is a pure
+function of `(task.status, workflow.postApproval)`, the `PostApprovalRouter`
+guards against double-spawn by checking `post_approval_session_id` before
+spawning: if one is already set and the referenced session is not in a
+terminal state, routing returns a no-op. This covers the crash-and-restart
+case — the router can be invoked safely on startup for any tasks still
+sitting in `approved` with a session ID, and it will re-attach rather than
+re-spawn.
 
 ### 3.5 Human-rejection path
 
@@ -668,8 +729,8 @@ itself, or the template's `request_human_input` response is a rejection):
 
 1. The session records the rejection in an artifact.
 2. The session exits normally (completed, not failed).
-3. Task Agent observes completion, calls `completePostApproval` —
-   task moves to `done`.
+3. Runtime observes session completion and transitions `approved → done`
+   directly (no Task Agent tool-call required).
 4. An audit artifact on the task records "post-approval skipped:
    `human_rejected`".
 
@@ -707,8 +768,8 @@ is removed the same way regardless of what replaces it.)*
 | `packages/daemon/src/lib/space/runtime/pending-action.ts` | Entire file (60 lines). |
 | `packages/daemon/src/lib/space/runtime/space-runtime-service.ts` | `resumeCompletionActions` public API (lines 795-807). |
 | `packages/daemon/src/lib/space/tools/space-agent-tools.ts` | `approve_completion_action` handler (lines 944-1006) and its tool registration (line 1246). |
-| `packages/daemon/src/lib/space/tools/task-agent-tools.ts` | Update `approve_task` tool description string to reference the new routing model. Add new tools: `spawn_post_approval_session`, `completePostApproval` (internal to Task Agent MCP server). |
-| `packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts` | The `pendingCheckpointType === 'completion_action'` intercept in `spaceTask.update` (lines 154-203). `approvePendingCompletion` now transitions `review → approved` (not `review → done`). Add `completePostApproval` RPC. |
+| `packages/daemon/src/lib/space/tools/task-agent-tools.ts` | Update `approve_task` tool description string to reference the new status-aware behaviour (`in_progress → approved` spawns routing; `approved → done` is idempotent post-approval completion). No new tools added. |
+| `packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts` | The `pendingCheckpointType === 'completion_action'` intercept in `spaceTask.update` (lines 154-203). `approvePendingCompletion` now transitions `review → approved` (not `review → done`) and invokes `PostApprovalRouter.route`. No new RPC. |
 | `packages/daemon/src/lib/space/workflows/built-in-workflows.ts` | `MERGE_PR_COMPLETION_ACTION` (lines 187-194). `VERIFY_PR_MERGED_BASH_SCRIPT` + `VERIFY_PR_MERGED_COMPLETION_ACTION` (lines 204-239). `VERIFY_REVIEW_POSTED_BASH_SCRIPT` + `VERIFY_REVIEW_POSTED_COMPLETION_ACTION` (lines 246-282). `PLAN_AND_DECOMPOSE_VERIFY_SCRIPT` + `PLAN_AND_DECOMPOSE_VERIFY_COMPLETION_ACTION` (lines 792-830). Every `completionActions: [...]` entry on a node (lines 518, 664, 766, 972, 1135). **Add** `postApproval` on the 2 workflows that need it (Coding, Research, QA). `PR_MERGE_BASH_SCRIPT` stays but moves to `pr-merge-script.ts` (see §3.4). |
 | `packages/web/src/components/space/PendingCompletionActionBanner.tsx` | Entire file (385 lines). |
 | `packages/web/src/components/space/TaskStatusActions.tsx` | Remove import + render of `PendingCompletionActionBanner`. Add a new, simpler `PendingPostApprovalBanner` that surfaces the post-approval session status when a task is stuck in `approved` (see §3.5). |
@@ -809,27 +870,31 @@ Under `packages/daemon/tests/unit/5-space/`:
   - Interpolation is a single pass (no recursive expansion).
   - Special characters in values are passed through unchanged (no HTML
     escaping, no shell escaping — the downstream agent handles that).
-- `runtime/post-approval-routing.test.ts`
-  - `approved` task with no `postApproval` → immediately transitions to
-    `done` via `completePostApproval`.
-  - `approved` task with workflow-agent target → Task Agent invokes
-    `spawn_post_approval_session`; a session is created with the correct
-    interpolated kickoff message.
-  - `approved` task with `target_agent: task-agent` → no spawn; Task Agent
-    executes instructions in its own session.
-  - `post_approval_session_id` is persisted and observable via the
-    repository.
+- `runtime/post-approval-router.test.ts`
+  - `approved` task with no `postApproval` → router transitions directly
+    to `done`; no session spawned; no Task Agent tool-call.
+  - `approved` task with workflow-agent target → router spawns a new
+    sub-session with the interpolated kickoff and records
+    `post_approval_session_id` + `post_approval_started_at`.
+  - `approved` task with `target_agent: 'task-agent'` → router injects a
+    `[POST_APPROVAL_INSTRUCTIONS]` turn into the existing Task Agent
+    session; no new session spawn; no `post_approval_session_id`.
   - `[TASK_APPROVED]` is emitted with the correct payload shape on both
     `approve_task` and `approvePendingCompletion` paths.
+  - Double-fire protection: invoking `route` twice on the same
+    already-routed task is a no-op (returns existing session ID).
 - `runtime/task-status-transitions.test.ts`
-  - `in_progress → approved` via `approve_task`.
-  - `review → approved` via `approvePendingCompletion`.
-  - `approved → done` via `completePostApproval`.
+  - `in_progress → approved` via `approve_task` (end node).
+  - `review → approved` via `approvePendingCompletion` (human).
+  - `approved → done` via idempotent `approve_task` (Task Agent
+    post-approval completion).
+  - `approved → done` via runtime on non-task-agent session completion.
   - `approved → blocked` disallowed in Stage 2 (deferred to §7).
-- `agent/task-agent-post-approval-spawning.test.ts`
-  - Given a mocked `spawn_post_approval_session` tool call, assert the
-    resulting session receives the right system prompt, kickoff message,
-    and tool surface.
+- `agent/task-agent-approve-task-idempotent.test.ts`
+  - `approve_task` called on a task already in `approved` status
+    transitions to `done`; no runtime routing re-fires.
+  - `approve_task` called on a task in any non-`in_progress`/non-`approved`
+    status is rejected.
 - `workflows/end-node-handoff.test.ts`
   - For each of the 5 built-in workflows, snapshot-test the end-node's
     customPrompt to ensure the post-approval signalling instructions are
@@ -939,12 +1004,15 @@ post-approval session layer rather than at the `merge_pr` tool layer.
   validator, template interpolator, `post_approval_session_id` column +
   migration. No behaviour change (nothing reads `approved` in this PR).
   Unit-tested. ~600 LOC; self-contained.
-- **PR 2** — **Task Agent post-approval routing.**
-  Runtime emits `[TASK_APPROVED]`. Task Agent system prompt addition.
-  New tools `spawn_post_approval_session` + `completePostApproval`. State
-  transitions `in_progress/review → approved → done` plumbed through.
-  Behind a feature flag (`NEOKAI_TASK_AGENT_POST_APPROVAL_ROUTING`).
-  ~800 LOC; depends on PR 1.
+- **PR 2** — **Runtime-driven post-approval routing.**
+  New `PostApprovalRouter` module in the runtime layer performs the
+  deterministic dispatch: no-target → direct `approved → done`;
+  task-agent target → inject `[POST_APPROVAL_INSTRUCTIONS]` turn;
+  workflow-agent target → spawn sub-session. `approve_task` tool becomes
+  idempotent for `approved` tasks. Runtime emits `[TASK_APPROVED]` as an
+  awareness-only event. Task Agent system prompt gets a short
+  `## Post-Approval` section. No new MCP tools. Behind a feature flag
+  (`NEOKAI_TASK_AGENT_POST_APPROVAL_ROUTING`). ~700 LOC; depends on PR 1.
 - **PR 3** — **End-node handoff + built-in workflow `postApproval`
   entries.** Update all 5 built-in workflow prompts. Populate `postApproval`
   on Coding, Research, QA. Flip the feature flag. ~500 LOC; depends on PR 2.
@@ -972,9 +1040,9 @@ post-approval session layer rather than at the `merge_pr` tool layer.
 ### 6.4 Observability / rollback
 
 - Add structured daemon log entries:
-  - `task-agent.post-approval.spawn: spaceId=... taskId=... targetAgent=... sessionId=... autonomyLevel=...`
-  - `task-agent.post-approval.complete: spaceId=... taskId=... outcome=done|blocked reason=...`
-  - `task.status-transition: taskId=... from=... to=... source=...`
+  - `post-approval.route: spaceId=... taskId=... targetAgent=... mode=<spawn|inline|none> autonomyLevel=...`
+  - `post-approval.complete: spaceId=... taskId=... outcome=done|blocked reason=... mode=<spawn|inline>`
+  - `task.status-transition: taskId=... from=... to=... source=<approve_task|approvePendingCompletion|post-approval-router|...>`
 - Feature flag (`NEOKAI_TASK_AGENT_POST_APPROVAL_ROUTING`) allows a quick
   disable. When disabled, tasks transition directly to `done` and no
   post-approval session spawns — identical to today's no-completion-actions
@@ -986,16 +1054,11 @@ post-approval session layer rather than at the `merge_pr` tool layer.
 
 ## 7. Open questions / decisions for review
 
-1. **Session kind for post-approval.** Options:
-   - (A) Reuse the existing `space_task_agent` sub-session kind; add a field
-     `isPostApproval: true` to distinguish from a regular node execution.
-   - (B) Introduce a new `space_task_post_approval` sub-session kind with
-     its own repository entries.
-   - (C) Model post-approval as a new ad-hoc node grafted onto the run's
-     node graph.
-   **Recommendation:** **A** for Stage 2 — fewer moving parts, integrates
-   with existing `[NODE_COMPLETE]` event plumbing. Revisit in Stage 5 if
-   the flag becomes load-bearing for queries.
+1. **Session kind for post-approval.** **Decided: A.** Reuse the existing
+   `space_task_agent` sub-session kind; add a field `isPostApproval: true`
+   to distinguish from a regular node execution. Fewer moving parts,
+   integrates with existing `[NODE_COMPLETE]` event plumbing. Revisit in
+   Stage 5 if the flag becomes load-bearing for queries.
 
 2. **Tool-allowlist scoping for post-approval sessions.**
    Can we narrow the tool surface (e.g. drop `curl`, drop file-write
@@ -1040,23 +1103,60 @@ post-approval session layer rather than at the `merge_pr` tool layer.
    **Recommendation:** accept the regression for Stage 4; revisit as a
    follow-up if operator feedback indicates the checks were load-bearing.
 
-7. **Should `spawn_post_approval_session` be exposed to non-Task-Agent
-   sessions?** No. Internal to the Task Agent MCP server.
+7. **Completion signal for `targetAgent === 'task-agent'`.** The chosen
+   mechanism is idempotent `approve_task` (§3.2). Alternative considered:
+   infer completion from turn-end (no pending tool calls). Rejected
+   because turn-end is an ambiguous signal — the Task Agent may pause for
+   `request_human_input`, in which case turn-end does not mean the work
+   is done. An explicit `approve_task` call is unambiguous, matches what
+   end-node agents already do, and requires no new tool.
 
 ---
 
 ## 8. Revision history
 
-**2026-04-23 (this revision):** Approach changed from "narrow `merge_pr`
-MCP tool on Task Agent" to "workflow-declared post-approval agent
-routing", based on review feedback that the MCP-tool approach was too
-rigid for real-world post-approval work. Key changes:
+**2026-04-23 revision 2 (this revision):** Dropped the proposed
+`spawn_post_approval_session` + `completePostApproval` MCP tools on the
+Task Agent server after direct user feedback: routing is deterministic
+(a pure function of `workflow.postApproval`), so putting it behind an LLM
+tool-call gate is wrong. Routing moves to a new runtime module
+(`PostApprovalRouter`). The Task Agent's only new responsibility is
+**conversational awareness** plus, when `targetAgent === 'task-agent'`,
+acting on an injected `[POST_APPROVAL_INSTRUCTIONS]` turn and calling its
+existing (now idempotent) `approve_task` tool to close. Key changes:
+
+- §1.4: renamed "Task Agent routing mechanics" → "Runtime-driven routing
+  mechanics"; routing happens in `PostApprovalRouter.route`, not via Task
+  Agent tool calls.
+- §2.3: reframed as "Task Agent observes (2 events), acts in 1 case".
+  Added `[POST_APPROVAL_INSTRUCTIONS]` event shape.
+- §3.2: renamed to include "approve_task idempotency" — the existing tool
+  becomes status-aware (`in_progress → approved` triggers routing;
+  `approved → done` is idempotent completion). No new tools.
+- §3.4 / §3.5: retired Task Agent re-routing framing; completion and
+  double-fire protection live in the runtime router.
+- §4.1 table: removed the "add new tools" row for `task-agent-tools.ts`;
+  also no new RPC in `space-task-handlers.ts`.
+- §4.6: renamed test files (`post-approval-router.test.ts`,
+  `task-agent-approve-task-idempotent.test.ts`); dropped the
+  spawn-tool-specific test.
+- §6.2 PR 2: no new MCP tools; smaller LOC estimate.
+- §7: removed the "expose `spawn_post_approval_session` to non-Task-Agent
+  sessions?" question (moot); added a new question on the task-agent
+  completion signal (decided: idempotent `approve_task`).
+- Appendix A: removed `spawn_post_approval_session` /
+  `completePostApproval` references; added `post-approval-router.ts`.
+- Appendix B: added row for "Routing trigger: Task Agent LLM vs. runtime".
+
+**2026-04-23 revision 1:** Approach changed from "narrow `merge_pr` MCP
+tool on Task Agent" to "workflow-declared post-approval agent routing",
+based on review feedback that the MCP-tool approach was too rigid for
+real-world post-approval work.
 
 - §0, §1: rewritten around workflow schema `postApproval` field, new task
   status `approved`, agent-spawn routing model. §1.2 replaced ("Why a
   post-approval agent, not a dedicated MCP tool").
-- §2.3: reframed `[TASK_APPROVED]` event as a routing signal (not a
-  tool-call hint).
+- §2.3: reframed `[TASK_APPROVED]` event as a routing signal.
 - §3.1: autonomy enforcement moves from handler-layer to template-layer +
   tool-layer.
 - §5: workflows now declare `postApproval` instead of `completionActions`;
@@ -1078,10 +1178,10 @@ data)`, unchanged sections §2 (signal protocol concepts), §4.1–4.3
 Key files referenced in this plan, grouped by area:
 
 **Task Agent wiring**
-- `packages/daemon/src/lib/space/agents/task-agent.ts` — system prompt + session init (add §3.2 section)
-- `packages/daemon/src/lib/space/runtime/task-agent-manager.ts` — session lifecycle, sub-session events, post-approval spawn plumbing
-- `packages/daemon/src/lib/space/tools/task-agent-tools.ts` — MCP server (add `spawn_post_approval_session`, `completePostApproval`)
-- `packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts` — Zod schemas for new tools
+- `packages/daemon/src/lib/space/agents/task-agent.ts` — system prompt + session init (add short §3.2 `## Post-Approval` section)
+- `packages/daemon/src/lib/space/runtime/task-agent-manager.ts` — session lifecycle, sub-session events, post-approval session spawn plumbing (consumed by `PostApprovalRouter`)
+- `packages/daemon/src/lib/space/tools/task-agent-tools.ts` — `approve_task` handler becomes status-aware (idempotent `approved → done`). No new tools.
+- `packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts` — unchanged
 
 **Workflow schema**
 - `packages/shared/src/types/space.ts` — add `PostApprovalRoute`, `WorkflowDefinition.postApproval`
@@ -1097,7 +1197,7 @@ Key files referenced in this plan, grouped by area:
 - `packages/daemon/src/lib/space/runtime/post-approval-router.ts` — NEW: orchestrates target-agent spawn
 
 **RPC layer**
-- `packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts` — `spaceTask.update` intercept, `approvePendingCompletion` (new target = `approved`), `completePostApproval` (NEW RPC)
+- `packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts` — `spaceTask.update` intercept, `approvePendingCompletion` (new target = `approved`, then calls `PostApprovalRouter.route`). No new RPC.
 
 **Shared types**
 - `packages/shared/src/types/space.ts` — `TaskStatus` (add `approved`), `CompletionAction` (remove), `SpaceTask`, `SpaceWorkflowRun`, `WorkflowDefinition`
@@ -1125,7 +1225,8 @@ Key files referenced in this plan, grouped by area:
 | Eligible `targetAgent` values | (A) Any agent name; (B) Declared workflow agent + `task-agent`; (C) Declared workflow agent only | **B** | Constraining to agents the workflow already declared avoids ad-hoc config. `task-agent` as an explicit second option handles the "no workflow agent fits" escape hatch without needing new agent types. |
 | Task lifecycle addition | (A) Reuse `review` → `done` with a post-approval sub-state; (B) Add new `approved` status; (C) Track post-approval progress on the workflow-run row, not the task | **B** | `approved` is semantically distinct from `review` (work is accepted, not pending) and from `done` (terminal). Making it a first-class status is simpler to reason about in UI and queries. See §1.3. |
 | Template grammar | (A) Simple `{{var}}` substitute; (B) Full Handlebars; (C) JS expressions | **A** | Dumb substitute is sufficient because the LLM reading the prompt handles all the conditional logic. Handlebars + JS are overkill and create testing/security debt. |
-| Merge executor: Task Agent LLM (direct) vs. Task Agent routes to reviewer | Original revision: Task Agent LLM calls `merge_pr` MCP tool directly. This revision: Task Agent routes to reviewer (workflow-declared agent). | **Route to reviewer** | Task Agent stays a pure orchestrator. The reviewer agent (or any target) already has the Bash/git/gh toolkit — reuse rather than duplicate. |
+| Merge executor: Task Agent LLM (direct) vs. Task Agent routes to reviewer | Original revision: Task Agent LLM calls `merge_pr` MCP tool directly. This revision: the runtime routes to reviewer (workflow-declared agent). | **Route to reviewer** | Task Agent stays a pure orchestrator. The reviewer agent (or any target) already has the Bash/git/gh toolkit — reuse rather than duplicate. |
+| Routing trigger: Task Agent LLM tool-call vs. runtime dispatch | (A) New `spawn_post_approval_session` + `completePostApproval` MCP tools on the Task Agent server; LLM decides when to spawn/complete. (B) New `PostApprovalRouter` in the runtime layer; triggered deterministically on the `approved` transition; no new MCP tools. | **B** | Routing is a pure function of `workflow.postApproval` — there is no decision for an LLM to make. Putting dispatch behind an LLM tool call risks skip/mis-route. LLM judgement still fully present in the post-approval *work itself*. See §1.4 for full rationale. Decided by direct user feedback 2026-04-23. |
 | Handoff signal: new gate vs. structured send_message | Unchanged from original revision. | **send_message(task-agent, data)** | Already idiomatic; gates don't fit the task-agent's implicit channels. |
 | `completionAutonomyLevel`: keep, repurpose, or remove | Unchanged. | **Keep** | Independently controls `approve_task` vs `submit_for_approval` — a distinct "is the work any good" decision from post-approval. |
 | Verification completion actions (verify-pr-merged, verify-review-posted, verify-tasks-created): keep, convert, delete | Unchanged. | **Delete** (accept regression) | Lost verifications are soft guardrails; audit artifacts + human review are the primary safety nets. |

--- a/docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md
+++ b/docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md
@@ -806,8 +806,11 @@ is removed the same way regardless of what replaces it.)*
 | `packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts` | The `pendingCheckpointType === 'completion_action'` intercept in `spaceTask.update` (lines 154-203). `approvePendingCompletion` now transitions `review → approved` (not `review → done`) and invokes `PostApprovalRouter.route`. No new RPC. |
 | `packages/daemon/src/lib/space/workflows/built-in-workflows.ts` | `MERGE_PR_COMPLETION_ACTION` (lines 187-194). `VERIFY_PR_MERGED_BASH_SCRIPT` + `VERIFY_PR_MERGED_COMPLETION_ACTION` (lines 204-239). `VERIFY_REVIEW_POSTED_BASH_SCRIPT` + `VERIFY_REVIEW_POSTED_COMPLETION_ACTION` (lines 246-282). `PLAN_AND_DECOMPOSE_VERIFY_SCRIPT` + `PLAN_AND_DECOMPOSE_VERIFY_COMPLETION_ACTION` (lines 792-830). Every `completionActions: [...]` entry on a node (lines 518, 664, 766, 972, 1135). **Add** `postApproval` on the 2 workflows that need it (Coding, Research, QA). `PR_MERGE_BASH_SCRIPT` stays but moves to `pr-merge-script.ts` (see §3.4). |
 | `packages/web/src/components/space/PendingCompletionActionBanner.tsx` | Entire file (385 lines). |
-| `packages/web/src/components/space/TaskStatusActions.tsx` | Remove import + render of `PendingCompletionActionBanner`. Add a new, simpler `PendingPostApprovalBanner` that surfaces the post-approval session status when a task is stuck in `approved` (see §3.5). |
-| `packages/web/src/components/space/SpaceTaskPane.tsx` | Remove routing of `'completion_action'` checkpoint to the removed banner. |
+| `packages/web/src/components/space/TaskStatusActions.tsx` | Remove import + render of `PendingCompletionActionBanner`. Replaced by the precedence-driven single-slot renderer introduced in §4.7. |
+| `packages/web/src/components/space/SpaceTaskPane.tsx` | Remove the 3-conditional banner stack (lines 421-446). Render exactly one banner selected by `resolveActiveTaskBanner(task, run, gates)` (§4.7). |
+| `packages/web/src/components/space/InlineStatusBanner.tsx` | **NEW** — shared single-line banner primitive (§4.7.4). |
+| `packages/web/src/components/space/PendingPostApprovalBanner.tsx` | **NEW** — surfaces a task stuck in `approved` after post-approval failed/escalated (§3.5). Ships in PR 2 as a one-liner from day one. |
+| `packages/web/src/lib/task-banner.ts` | **NEW** — `resolveActiveTaskBanner` precedence helper (§4.7.2). |
 | `packages/shared/src/space/workflow-autonomy.ts` | `EMPTY_ACTIONS_AUTONOMY_THRESHOLD`, `isAutonomousWithoutActions`, `BlockingAction`, `BlockingWorkflow`, `AutonomousWorkflowCount`, `isWorkflowAutonomousAtLevel`, `countAutonomousWorkflows`, `collectCompletionActions` — replace with a single `isWorkflowAutoClosingAtLevel(wf, level)` that checks only `level >= (wf.completionAutonomyLevel ?? 5)`. |
 
 ### 4.2 Code to keep / repurpose
@@ -958,6 +961,171 @@ These E2E tests need a mock `gh` CLI. Reuse existing E2E PR-fixture
 infrastructure if present; otherwise add `tests/e2e/helpers/mock-gh.sh`
 injected on the PATH.
 
+### 4.7 UI consolidation — one banner slot, one-line rule
+
+The current `SpaceTaskPane` renders approval/warning banners as three
+independent conditionals (see `SpaceTaskPane.tsx:421-446`):
+
+```tsx
+{task.status === 'blocked' ? <TaskBlockedBanner /> : (
+  <>
+    {task.pendingCheckpointType === 'completion_action' && <PendingCompletionActionBanner />}
+    {task.pendingCheckpointType === 'task_completion'  && <PendingTaskCompletionBanner />}
+    {task.workflowRunId                                && <PendingGateBanner />}
+  </>
+)}
+```
+
+This allows two banners to stack (e.g. `PendingGateBanner` next to
+`PendingTaskCompletionBanner`) — **but those states cannot actually coexist
+on the same task**. A gate blocks the workflow run; the end node only runs
+once all gates have cleared; only then can `submit_for_approval` fire. So
+the two banners are mutually exclusive in time, and the independent-render
+code is defensive noise.
+
+This section collapses the approval surface to a single slot and enforces a
+one-line rule across all banners. Anything longer opens a modal.
+
+#### 4.7.1 Principles
+
+1. **One active banner per task.** At most one of the
+   {gate-approval, task-approval, post-approval-blocked, task-blocked}
+   banners renders at any time.
+2. **One line of text, max.** Each banner surfaces: an icon, a short label
+   (≤ ~60 chars), optionally an elapsed-time badge, and one or two action
+   buttons. Nothing else inline.
+3. **More info → modal.** Agent rationale, gate artifact data, diff
+   preview, feedback text area, script source, stack traces — all of these
+   open via a "Details" (or "Review") button into a modal.
+4. **Shared primitive.** A single `<InlineStatusBanner>` component
+   enforces consistent geometry (icon slot, label slot, CTA slot). All
+   specific banners compose it.
+
+#### 4.7.2 Banner precedence
+
+New helper in `packages/web/src/lib/task-banner.ts`:
+
+```ts
+type ActiveBanner =
+  | { kind: 'blocked'; reason: TaskBlockReason }
+  | { kind: 'post_approval_blocked'; reason: string }
+  | { kind: 'gate_pending'; runId: string }
+  | { kind: 'task_completion_pending' }
+  | null;
+
+function resolveActiveTaskBanner(
+    task: SpaceTask,
+    run: SpaceWorkflowRun | undefined,
+    gates: ReadonlyArray<GateState> | undefined
+): ActiveBanner;
+```
+
+Precedence order (first match wins):
+
+1. `task.status === 'blocked'` → `blocked` (includes `gate_rejected`,
+   `execution_failed`, etc. — unchanged variant set; `TaskBlockedBanner`
+   already handles these)
+2. `task.status === 'approved' && task.postApprovalBlockedReason` →
+   `post_approval_blocked` *(new)*
+3. `task.pendingCheckpointType === 'task_completion'` →
+   `task_completion_pending`
+4. `task.workflowRunId` AND any gate in that run is `waiting_human` →
+   `gate_pending`
+5. Otherwise → `null` (no banner)
+
+`SpaceTaskPane.tsx` renders exactly **one** banner selected by this helper.
+The per-checkpoint conditionals are deleted.
+
+`PendingCompletionActionBanner` is removed entirely in PR 4 (§4.1) and is
+absent from the precedence list.
+
+#### 4.7.3 Per-banner redesign
+
+Each banner is trimmed to the one-line rule. Details move into an
+existing-or-new modal.
+
+| Banner | Before | After (inline) | Modal content |
+|--------|--------|----------------|---------------|
+| `PendingGateBanner` | Medium panel; one row per gate; description line + 3 buttons; optional error line | *One* row per gate: icon + gate label + "Awaiting approval" + `[Approve]` `[Reject]` `[Review]` buttons. No description line, no error line inline (truncate + tooltip). If run has multiple waiting gates, render a single consolidated line: "3 gates awaiting approval" + `[Review]` which opens the existing `GateArtifactsView` listing them. | `GateArtifactsView` (existing) — gate data, artifacts, decision controls. Also absorbs the error message that currently renders inline. |
+| `PendingTaskCompletionBanner` | Short banner (already ~1 line) + 2 modals | Inline: icon + "Awaiting approval" + elapsed-time badge + `[Approve]` `[Send back]` `[Details]`. Keep the existing Approve/Reject modals; add a `[Details]` that opens a modal showing agent outcome + rationale (currently inline in the Approve modal — hoist to its own Details modal). | Unchanged Approve / Reject modals; new Details modal. |
+| `PendingCompletionActionBanner` | Inline + modals | **Deleted** in PR 4. | — |
+| `PendingPostApprovalBanner` *(new, PR 2)* | n/a | Icon + "Post-approval blocked: `<short-reason>`" + `[Retry]` `[Mark done]` `[View session]`. No inline transcript or stack. | `[View session]` navigates to the session UI (not a modal). `[Mark done]` confirms in a small modal. `[Retry]` re-spawns the target agent; shows a toast on success. |
+| `TaskBlockedBanner` | Multi-variant: 2–3 lines per variant, different inline content per `blockReason` | One line per variant: icon + short label (e.g. "Blocked: agent crashed", "Blocked: dependency failed") + primary CTA (`[Resume]` / `[Review]` / `[Details]`). Long error messages move into a Details modal. `human_input_requested` stays as the current one-line hint ("Reply via composer") with no CTA — already minimal. | Details modal shows full reason, error message, and any linked run context. |
+
+For the `gate_rejected` variant of `TaskBlockedBanner`, the Details modal
+is `GateArtifactsView` (same as `PendingGateBanner`'s Review) so the user
+has one mental model for "inspect a gate".
+
+#### 4.7.4 Shared primitive
+
+New component `packages/web/src/components/space/InlineStatusBanner.tsx`:
+
+```tsx
+interface InlineStatusBannerProps {
+    icon: ComponentChildren;          // status icon (Pause, Lock, Alert, Clock…)
+    tone: 'info' | 'warn' | 'danger'; // color family
+    label: string;                    // ≤ 60 chars, single line, truncated with ellipsis
+    meta?: string;                    // optional right-aligned badge (e.g. elapsed time)
+    actions?: BannerAction[];         // ordered left-to-right; at most 3
+}
+interface BannerAction {
+    label: string;      // ≤ 14 chars
+    onClick: () => void;
+    variant?: 'primary' | 'secondary';
+}
+```
+
+Fixed height, single-line truncation, consistent tone classes. All specific
+banners (`PendingGateBanner`, `PendingTaskCompletionBanner`,
+`PendingPostApprovalBanner`, `TaskBlockedBanner`) compose this primitive
+and own only their own modals.
+
+#### 4.7.5 Modal conventions
+
+- Modals are rendered outside the banner tree (portal) so the banner row
+  stays compact and predictable.
+- Modals share the existing `Modal` primitive; no new modal shell.
+- Modals may be long-form (full-screen overlay for gate artifacts, medium
+  dialog for approve/reject confirmations) — that's fine, the rule is
+  about *inline* noise, not modal content.
+- Every banner's `[Details]` / `[Review]` button is keyboard-accessible
+  and has a consistent aria-label pattern: `"Show details for <label>"`.
+
+#### 4.7.6 Tests to update / add
+
+- `packages/web/src/lib/__tests__/task-banner.test.ts` (new) — precedence
+  resolver: blocked > post_approval_blocked > task_completion_pending >
+  gate_pending > null. Exhaustive status+checkpoint+gate combinations.
+- `packages/web/src/components/space/__tests__/InlineStatusBanner.test.tsx`
+  (new) — snapshot: 1 line height regardless of label length; truncation
+  at ~60 chars; 3 actions max.
+- Update existing banner tests to assert:
+  - No inline text longer than one line.
+  - Details/Review actions open modals; rationale/feedback text lives only
+    in modals, not inline.
+- Delete `PendingCompletionActionBanner.test.tsx` (component removed).
+- Add E2E: `post-approval-banner-minimal.e2e.ts` — for each approval
+  state, assert the banner container has a computed height equal to a
+  single-line banner (regression guard against future bloat).
+
+#### 4.7.7 Scope and staging
+
+This consolidation lands in **PR 4** (the completion-action pipeline
+removal PR) because:
+
+- PR 4 already deletes `PendingCompletionActionBanner` and touches
+  `SpaceTaskPane.tsx` / `TaskStatusActions.tsx`.
+- Collapsing the three independent conditionals into a single precedence
+  slot is a natural simplification once the `completion_action` branch is
+  gone.
+- Adds ~400 LOC (new primitive + precedence helper + modal extractions)
+  and removes ~200 LOC (inline rationale/error sections), net additional
+  change is modest.
+
+The new `PendingPostApprovalBanner` ships in **PR 2** as a one-liner from
+day one (no pre-refactor stage), so it sets the precedent for the PR 4
+consolidation.
+
 ---
 
 ## 5. Workflow definition changes — summary table
@@ -1058,12 +1226,17 @@ post-approval session layer rather than at the `merge_pr` tool layer.
 - **PR 3** — **End-node handoff + built-in workflow `postApproval`
   entries.** Update all 5 built-in workflow prompts. Populate `postApproval`
   on Coding, Research, QA. Flip the feature flag. ~500 LOC; depends on PR 2.
-- **PR 4** — **Delete completion-action runtime pipeline.** Remove
-  `resolveCompletionWithActions`, `resumeCompletionActions`,
-  `executeCompletionAction`, the RPC intercept, `approve_completion_action`
-  MCP tool, `PendingCompletionActionBanner`. Task/run completion flows
-  through the new `approved → done` path. ~1500 LOC net-negative. Depends
-  on PR 3 being deployed long enough to confirm the new path works.
+- **PR 4** — **Delete completion-action runtime pipeline + UI
+  consolidation.** Remove `resolveCompletionWithActions`,
+  `resumeCompletionActions`, `executeCompletionAction`, the RPC intercept,
+  `approve_completion_action` MCP tool, `PendingCompletionActionBanner`.
+  Task/run completion flows through the new `approved → done` path. Also
+  collapses the approval banner stack into a single-slot precedence
+  (`resolveActiveTaskBanner`) and trims every remaining banner to a
+  one-line inline + modal-for-details pattern (see §4.7). ~1500 LOC
+  net-negative after the UI refactor nets out (~400 added / ~200 removed
+  for the banner work). Depends on PR 3 being deployed long enough to
+  confirm the new path works.
 - **PR 5** — **Schema / shared-types / DB migration + docs.** Drop
   `pending_action_index`, `pending_checkpoint_type='completion_action'`,
   `completion_actions_fired_at`, `MERGE_PR_COMPLETION_ACTION` etc. Docs
@@ -1164,7 +1337,33 @@ post-approval session layer rather than at the `merge_pr` tool layer.
 
 ## 8. Revision history
 
-**2026-04-23 revision 3 (this revision):** Two follow-up refinements after
+**2026-04-23 revision 4 (this revision):** UI consolidation pass triggered
+by direct user feedback on the current banner surface:
+
+1. **Single-slot approval banner.** The current `SpaceTaskPane` renders
+   `PendingGateBanner`, `PendingTaskCompletionBanner`, and
+   `PendingCompletionActionBanner` as three independent conditionals that
+   are allowed to stack. But per-task those states cannot coexist in time
+   (a gate blocks the run, so the end node never reaches
+   `submit_for_approval` until gates clear). Collapse to a single
+   precedence-driven slot (`resolveActiveTaskBanner`) that renders at most
+   one banner at a time.
+2. **One-line rule for all banners.** Each banner surfaces only a short
+   label + one or two action buttons inline. Agent rationale, gate
+   artifacts, error traces, and feedback fields move behind
+   `[Details]` / `[Review]` buttons into modals. A new shared primitive
+   `<InlineStatusBanner>` enforces consistent geometry.
+3. Covers all existing + planned banners: `PendingGateBanner`,
+   `PendingTaskCompletionBanner`, `PendingPostApprovalBanner` (new, ships
+   as a one-liner from PR 2), `TaskBlockedBanner` (all variants).
+   `PendingCompletionActionBanner` is still deleted in PR 4 as planned.
+
+New section: **§4.7 UI consolidation**. Also touches §4.1 (delete-table
+adds three NEW-file rows for the primitive, the new banner, and the
+precedence helper), §6.2 PR 4 scope (adds UI refactor), Appendix B (two
+new decision rows).
+
+**2026-04-23 revision 3:** Two follow-up refinements after
 more direct user feedback:
 
 1. **Drop the `approve_task` overload; introduce `mark_complete`.**
@@ -1274,9 +1473,14 @@ Key files referenced in this plan, grouped by area:
 
 **Web UI**
 - `packages/web/src/components/space/PendingCompletionActionBanner.tsx` — delete
-- `packages/web/src/components/space/PendingPostApprovalBanner.tsx` — NEW: "post-approval in progress" / "post-approval failed" banner
-- `packages/web/src/components/space/TaskStatusActions.tsx` — swap banners
-- `packages/web/src/components/space/SpaceTaskPane.tsx` — remove `'completion_action'` routing
+- `packages/web/src/components/space/PendingPostApprovalBanner.tsx` — NEW: one-line "post-approval in progress" / "post-approval failed" banner (§4.7)
+- `packages/web/src/components/space/InlineStatusBanner.tsx` — NEW: shared single-line banner primitive (§4.7.4)
+- `packages/web/src/lib/task-banner.ts` — NEW: `resolveActiveTaskBanner` precedence helper (§4.7.2)
+- `packages/web/src/components/space/TaskStatusActions.tsx` — swap banners; use precedence helper
+- `packages/web/src/components/space/SpaceTaskPane.tsx` — replace 3-conditional banner stack with single precedence-driven slot (§4.7)
+- `packages/web/src/components/space/PendingGateBanner.tsx` — trim to single-line compose of `InlineStatusBanner`; inline description / error move into the Review modal
+- `packages/web/src/components/space/PendingTaskCompletionBanner.tsx` — trim to single-line compose of `InlineStatusBanner`; agent rationale moves behind new Details modal
+- `packages/web/src/components/space/TaskBlockedBanner.tsx` — trim every variant to a single-line compose; long error messages move into a Details modal (`gate_rejected` variant points at `GateArtifactsView`)
 - `packages/web/src/lib/space-store.ts` — drop completion-action helpers; add `approved` status helpers
 
 ---
@@ -1293,6 +1497,8 @@ Key files referenced in this plan, grouped by area:
 | Routing trigger: Task Agent LLM tool-call vs. runtime dispatch | (A) New `spawn_post_approval_session` + `completePostApproval` MCP tools on the Task Agent server; LLM decides when to spawn/complete. (B) New `PostApprovalRouter` in the runtime layer; triggered deterministically on the `approved` transition. | **B** | Routing is a pure function of `workflow.postApproval` — there is no decision for an LLM to make. Putting dispatch behind an LLM tool call risks skip/mis-route. LLM judgement still fully present in the post-approval *work itself*. See §1.4 for full rationale. Decided by direct user feedback 2026-04-23. |
 | Post-approval completion signal tool | (A) Overload `approve_task` — make it idempotent for `approved → done` when the task is already `approved`. (B) New dedicated `mark_complete` tool, status-restricted to `approved`. | **B** | Same tool with two meanings (work-approval vs. post-approval-done) is a confusing footgun for both prompt authors and LLMs. A separately-named tool makes intent explicit at the call site. `approve_task` stays scoped to `in_progress → approved`. Decided by direct user feedback 2026-04-23. |
 | Terminology for per-node workflow agents | (A) "workflow role" / "workflow-agent role". (B) "space task node agent". | **B** | User preference. The codebase currently uses `'node_agent'` kind in `SpaceMemberSession`; the new `post-approval-router.ts` doc comment introduces the long-form name for prose and cross-references the existing kind enum. |
+| Approval banner composition | (A) Keep the current three independent conditionals in `SpaceTaskPane` (gate, completion-action, task-completion), each allowed to stack. (B) Single precedence-driven slot — at most one banner renders at a time, chosen by `resolveActiveTaskBanner`. | **B** | Per-task, gate-approval and task-approval cannot coexist in time — the gate blocks the run, so `submit_for_approval` only fires once gates have cleared. The independent-render code is defensive noise and produces visual clutter. Single-slot precedence matches the actual state machine. Decided by direct user feedback 2026-04-23. |
+| Banner content density | (A) Multi-line banners with inline rationale / error / artifact summaries. (B) One-line banner + modal for any additional info. | **B** | Banners are status indicators, not control panels. Long-form content (agent rationale, gate artifacts, error traces) belongs behind a `[Details]` / `[Review]` modal, not stacked inline. Enforced by the shared `<InlineStatusBanner>` primitive (§4.7.4). Decided by direct user feedback 2026-04-23. |
 | Handoff signal: new gate vs. structured send_message | Unchanged from original revision. | **send_message(task-agent, data)** | Already idiomatic; gates don't fit the task-agent's implicit channels. |
 | `completionAutonomyLevel`: keep, repurpose, or remove | Unchanged. | **Keep** | Independently controls `approve_task` vs `submit_for_approval` — a distinct "is the work any good" decision from post-approval. |
 | Verification completion actions (verify-pr-merged, verify-review-posted, verify-tasks-created): keep, convert, delete | Unchanged. | **Delete** (accept regression) | Lost verifications are soft guardrails; audit artifacts + human review are the primary safety nets. |

--- a/docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md
+++ b/docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md
@@ -38,7 +38,7 @@ new `approved` status and dispatches deterministically — spawning a fresh
 session for the target agent with interpolated instructions, or (when the
 target is `task-agent`) injecting an instruction turn into the existing Task
 Agent conversation. When post-approval completes, the task transitions to
-`done`. The target agent is a normal workflow-agent session with its normal
+`done`. The target agent is a normal space task node agent session with its normal
 toolkit (Bash, file ops, MCP servers, everything), so it can handle merge
 complexity the same way any other node handles its work — with LLM
 judgement, retries, and escalation.
@@ -65,26 +65,32 @@ Concretely:
    deterministic lookup against `workflow.postApproval`:
    - If the workflow has no `postApproval` → immediately transition to `done`
      (single-step workflows, documentation missions).
-   - If `targetAgent` is a workflow-agent role → spawn a new session for that
-     role with the interpolated `instructions` as kickoff. The session's
-     completion triggers `approved → done` via existing sub-session event
-     plumbing.
+   - If `targetAgent` is a **space task node agent** (an agent role declared
+     on a node in this workflow — see code-comment convention below) →
+     spawn a new session for that agent with the interpolated `instructions`
+     as kickoff. The agent calls a new `mark_complete` tool when finished,
+     transitioning `approved → done`.
    - If `targetAgent === 'task-agent'` → inject
      `[POST_APPROVAL_INSTRUCTIONS]` as a user turn into the existing Task
      Agent session. The Task Agent performs the work with its orchestrator
-     toolset and calls its existing (now idempotent) `approve_task` to
-     close — no new tools.
-5. The spawned post-approval session is a normal workflow-agent session: it
+     toolset and calls `mark_complete` when done — same tool as above.
+5. The spawned post-approval session is a normal space task node agent session: it
    has the agent's full system prompt, tool surface, and MCP servers. For a
    PR merge, the instructions direct it to run the appropriate shell
    commands (`gh pr view`, `gh pr merge`, worktree sync). For a different
    workflow's post-approval it could be publishing a release, notifying
    slack, etc. — all determined by the workflow author's instruction string.
-6. **No new MCP tools on the Task Agent server.** Routing is deterministic
-   runtime code; there is no decision for an LLM to mediate. The Task Agent
-   receives `[TASK_APPROVED]` as awareness only, and acts only when
-   `targetAgent === 'task-agent'` (handled via the existing `approve_task`
-   tool in its idempotent-completion mode).
+6. **One new MCP tool on the Task Agent server: `mark_complete`.** Routing
+   itself is deterministic runtime code — no LLM tool-call gates the
+   dispatch. But the `approved → done` transition needs an explicit signal
+   from the agent doing the post-approval work (whether that's a spawned
+   space task node agent or the Task Agent itself when `targetAgent === 'task-agent'`).
+   `mark_complete` takes no args and only succeeds on an `approved` task;
+   calling it transitions the task to `done`. It's deliberately distinct
+   from `approve_task` — overloading one tool across both the
+   "work-quality approval" transition (`in_progress → approved`) and the
+   "post-approval done" transition (`approved → done`) would confuse
+   callers about what the tool means in context.
 7. The entire `CompletionAction` type, its runtime pipeline, its RPC
    intercepts, its MCP tool (`approve_completion_action`), its DB columns,
    and its UI surface are deleted. The per-workflow knob
@@ -102,7 +108,7 @@ Task Agent or daemon.
 | Stage | PR | Scope | Dependency |
 |------|----|-------|------------|
 | 1 | Task state `approved` + workflow schema | Add `TaskStatus='approved'` (shared types + DB migration), add `WorkflowDefinition.postApproval` shape + validator, no behaviour change yet (nothing reads `approved` or `postApproval` beyond load/save). Unit-tested. | — |
-| 2 | Runtime post-approval routing | New `PostApprovalRouter` module dispatches on the `approved` boundary: no-target → direct `done`; workflow-agent target → spawn session; `task-agent` target → inject `[POST_APPROVAL_INSTRUCTIONS]` turn. `approve_task` tool becomes idempotent for `approved → done`. Runtime emits `[TASK_APPROVED]` as an awareness-only event. No new MCP tools. Behind a feature flag so callers continue seeing completion-actions behaviour until workflow templates migrate. | Stage 1 deployed |
+| 2 | Runtime post-approval routing | New `PostApprovalRouter` module dispatches on the `approved` boundary: no-target → direct `done`; space-task-node-agent target → spawn session; `task-agent` target → inject `[POST_APPROVAL_INSTRUCTIONS]` turn. New `mark_complete` MCP tool (Task Agent + spawned post-approval sessions) gates the `approved → done` transition; `approve_task` stays scoped to `in_progress → approved`. Runtime emits `[TASK_APPROVED]` as an awareness-only event. Behind a feature flag so callers continue seeing completion-actions behaviour until workflow templates migrate. | Stage 1 deployed |
 | 3 | End-node handoff + built-in workflow `postApproval` entries | Update built-in workflow prompts to `send_message` to `task-agent` with `{ pr_url, post_approval_action }` before `approve_task`. Populate `postApproval` on all 5 built-in workflows. Update Task Agent system prompt + kickoff. Flip the feature flag. | Stage 2 deployed |
 | 4 | Remove completion-action runtime pipeline | Delete `resolveCompletionWithActions` / `resumeCompletionActions` / `executeCompletionAction`; delete the `spaceTask.update` intercept for `completion_action`; delete `approve_completion_action` MCP tool; delete `PendingCompletionActionBanner`. Task/run completion now flows through the new `approved → done` path. | Stage 3 deployed |
 | 5 | Schema cleanup + docs | Drop `pending_action_index`, `pending_checkpoint_type='completion_action'` value, `completion_actions_fired_at`, `MERGE_PR_COMPLETION_ACTION` etc. from DB & shared types. Docs refresh. Changelog. | Stage 4 merged |
@@ -128,9 +134,9 @@ interface PostApprovalRoute {
      *     same MCP servers, same worktree), independent of any previous
      *     execution.
      *   - The literal string "task-agent". Post-approval runs in the Task
-     *     Agent's own session — used only when no workflow agent is
-     *     appropriate and the Task Agent's orchestrator-tool surface is
-     *     sufficient.
+     *     Agent's own session — used only when no space task node agent
+     *     is appropriate and the Task Agent's orchestrator-tool surface
+     *     is sufficient.
      * Validation runs at workflow save + load time; see §1.5.
      */
     targetAgent: string;
@@ -263,8 +269,20 @@ statuses that don't include `approved`.
 **Design decision (2026-04-23 revision):** routing is a deterministic
 runtime step, not an LLM decision. The Task Agent is *not* in the critical
 path for spawning the post-approval session — it only observes the
-transitions for conversational awareness. No new MCP tools are added to
-the Task Agent server.
+transitions for conversational awareness. **One** new MCP tool is added:
+`mark_complete`, used by whichever agent performs the post-approval work
+(a spawned space task node agent, or the Task Agent itself when
+`targetAgent === 'task-agent'`) to signal `approved → done`.
+
+> **Terminology — "space task node agent".** Throughout this plan,
+> "space task node agent" refers to an agent session spawned for a node
+> in a space workflow run — distinct from the Task Agent (the
+> orchestrator) and from ad-hoc chat sessions. In the current codebase
+> this is the `'node_agent'` kind in
+> `packages/shared/src/types/space.ts` (`SpaceMemberSession.kind`). When
+> the new `post-approval-router.ts` module is added, its doc comment
+> will introduce the full term and cross-reference the existing
+> `'node_agent'` kind so future readers can follow the vocabulary.
 
 Four event sites interact:
 
@@ -296,31 +314,33 @@ Four event sites interact:
      the interpolated `instructions` as a user-message turn into the
      existing Task Agent session (same channel the runtime already uses
      for `[TASK_APPROVED]` and `[NODE_COMPLETE]` events; see
-     `task-agent-manager.ts` ≈ line 2878). No session spawn; no new tools.
-     The Task Agent acts on the instructions using the tools already on
-     its MCP server (`send_message`, `request_human_input`,
-     `save_artifact`, etc.). Completion is signalled when the Task Agent
-     calls its existing `approve_task` tool again — that tool becomes
-     idempotent for `approved` tasks and transitions `approved → done`
-     (see §3.2).
+     `task-agent-manager.ts` ≈ line 2878). No session spawn. The Task
+     Agent acts on the instructions using the tools already on its MCP
+     server (`send_message`, `request_human_input`, `save_artifact`,
+     etc.) plus the new `mark_complete` tool. Completion is signalled
+     when the Task Agent calls `mark_complete` — which transitions
+     `approved → done` (see §3.2).
 
-   - **Otherwise (targetAgent is a workflow-agent role):** runtime spawns
-     a fresh session for that role:
+   - **Otherwise (targetAgent is a space task node agent):** runtime
+     spawns a fresh session for that agent:
      - Session kind: reuses the existing `space_task_agent` sub-session
-       model with an `isPostApproval: true` flag (confirmed decision —
-       §7.1).
+       model (DB row with `kind = 'node_agent'`) with an
+       `isPostApproval: true` flag (confirmed decision — §7.1).
      - Same worktree and MCP server config as the corresponding
        workflow-node session would have.
      - Kickoff user message = interpolated `instructions`.
      - Records `post_approval_session_id` + `post_approval_started_at` on
        the task.
-     - Awaits session completion via the existing sub-session event
-       plumbing (same path that handles `[NODE_COMPLETE]` today).
+     - The `mark_complete` tool is also available on this session's MCP
+       surface (mirrored from the Task Agent's), so the agent can close
+       the task directly when its work is done.
 
 4. **Post-approval session completes (non-task-agent path).** The spawned
-   session terminates normally (its agent calls `approve_task` or simply
-   reaches end-of-turn). Runtime observes the session-terminated event and
-   transitions `approved → done`. No Task Agent tool-call needed.
+   space task node agent either calls `mark_complete` explicitly
+   (preferred), or the runtime falls back to observing session termination
+   as an implicit completion signal and transitions `approved → done`
+   itself. Either way, no confusion between "approve the work" and "mark
+   the post-approval complete" — the tool names are distinct.
 
 5. **Post-approval session fails.** If the session exits with an error, or
    the spawned agent calls `submit_for_approval` on its post-approval work
@@ -365,12 +385,13 @@ Runs in `SpaceWorkflowManager.create` and `.update`, and on load from DB in
 but `postApproval` is disabled for that run until fixed, to protect against
 stale configs after a node removal).
 
-**Why restrict to workflow-declared agents + task-agent?** Any other target
-would require inventing a new agent role with ad-hoc config. The constraint
-keeps the surface narrow: a workflow author can only route to agents they
-already understand (because they already declared them) or the
-orchestrator. If a post-approval step needs a different agent, add it as a
-node in the workflow first.
+**Why restrict to declared space task node agents + task-agent?** Any
+other target would require inventing a new agent role with ad-hoc config.
+The constraint keeps the surface narrow: a workflow author can only route
+to agents they already understand (because they already declared them as
+space task node agents on nodes in this workflow) or the orchestrator. If
+a post-approval step needs a different agent, add it as a node in the
+workflow first.
 
 ### 1.6 Template grammar for `instructions`
 
@@ -499,10 +520,9 @@ The Task Agent observes two events for conversational awareness, but only
 3. **Active only when `targetAgent === 'task-agent'`.** In that specific
    case the runtime follows up the `[TASK_APPROVED]` event with a second
    injected user turn carrying the interpolated `instructions`. The Task
-   Agent then performs the post-approval work using tools it already owns
-   and calls `approve_task` a second time to signal completion. (The
-   `approve_task` tool becomes idempotent for `approved` tasks —
-   `approved → done`; see §3.2.)
+   Agent then performs the post-approval work using tools it already
+   owns plus the new `mark_complete` tool, which it calls when done to
+   transition the task from `approved → done` (see §3.2).
 
 **Runtime injection shape (`[TASK_APPROVED]` — awareness only):**
 
@@ -516,9 +536,9 @@ Post-approval routing:
   session_status: <spawning | self | none>
 
 No action required from you — this is informational. The runtime will
-spawn the post-approval session (if target_agent is a workflow agent) or
-deliver the instructions to you directly (if target_agent is "task-agent")
-or close the task immediately (if no target).
+spawn the post-approval session (if target_agent is a space task node
+agent) or deliver the instructions to you directly (if target_agent is
+"task-agent") or close the task immediately (if no target).
 ```
 
 **Runtime injection shape (post-approval instructions — only when
@@ -529,13 +549,15 @@ target_agent === "task-agent"):**
 
 <interpolated instructions from workflow.postApproval.instructions>
 
-When you finish (or need to abort), call approve_task() to close the task.
-If you need human input mid-work, call request_human_input as usual.
+When you finish (or need to abort), call mark_complete to transition the
+task from `approved` to `done`. If you need human input mid-work, call
+request_human_input as usual.
 ```
 
-No new MCP tools are added to the Task Agent server. The routing
-decision is deterministic and lives in `PostApprovalRouter.route` in the
-runtime layer (§1.4).
+One new MCP tool is added (`mark_complete`, §3.2). The routing decision
+itself stays deterministic and lives in `PostApprovalRouter.route` in the
+runtime layer (§1.4) — `mark_complete` only gates the final
+`approved → done` transition, not the dispatch.
 
 ### 2.4 Prompt changes by node
 
@@ -622,7 +644,7 @@ line:
    we want to (e.g. `gh` + `git` + `cd` but no arbitrary `curl`). Scoping
    decision deferred to §7.2.
 
-### 3.2 Task Agent system prompt addition + `approve_task` idempotency
+### 3.2 Task Agent system prompt addition + new `mark_complete` tool
 
 **System prompt addition.** Amend
 [`task-agent.ts:buildTaskAgentSystemPrompt`](../../packages/daemon/src/lib/space/agents/task-agent.ts)
@@ -645,27 +667,36 @@ MCP server (send_message, request_human_input, save_artifact,
 list_artifacts). Do not attempt shell commands — you are an orchestrator,
 not an executor.
 
-When you finish the post-approval work, call `approve_task()` again to
-close the task. Calling `approve_task` on an already-`approved` task is
-idempotent and transitions it to `done`.
+When you finish the post-approval work, call `mark_complete` to
+transition the task from `approved` to `done`. Note: `mark_complete` is
+distinct from `approve_task`. `approve_task` means "the work is good"
+(transitions `in_progress → approved`); `mark_complete` means
+"post-approval is finished" (transitions `approved → done`). Never call
+`approve_task` to close a task that's already `approved` — use
+`mark_complete`.
 
 If you need to abort post-approval (e.g. human rejection via
 `request_human_input`), record the reason via `save_artifact` and still
-call `approve_task()` — abandonment is a legitimate outcome, not a
-failure.
+call `mark_complete` — abandonment is a legitimate outcome of
+post-approval, not a failure.
 ```
 
-**`approve_task` tool behaviour change.** The existing tool in
-[`task-agent-tools.ts`](../../packages/daemon/src/lib/space/tools/task-agent-tools.ts)
-becomes status-aware:
+**New tool `mark_complete` in
+[`task-agent-tools.ts`](../../packages/daemon/src/lib/space/tools/task-agent-tools.ts).**
+Also mirrored onto the post-approval session's MCP surface so spawned
+space task node agents can use the same tool.
 
-| Current task status | Effect of `approve_task()` |
-|---------------------|----------------------------|
-| `in_progress` | Transitions `in_progress → approved`, then runtime routes (§1.4). Unchanged user-visible behaviour except the intermediate state. |
-| `approved` (new idempotent case) | Transitions `approved → done`. Used by the Task Agent to signal post-approval completion when `targetAgent === 'task-agent'`. |
-| Any other status | Rejected with an explanatory error (unchanged). |
+| Caller's current task status | Effect of `mark_complete()` |
+|------------------------------|----------------------------|
+| `approved` | Transitions `approved → done`. Clears `post_approval_session_id`. Emits observability log. |
+| Any other status | Rejected with an explanatory error (e.g. "task is not in `approved` status; did you mean `approve_task`?"). |
 
-No new MCP tools are added.
+Schema: `{ /* empty object — no args */ }`.
+
+**`approve_task` tool behaviour — unchanged.** It still only accepts
+`in_progress` and still transitions to `approved`. Rejecting it on an
+`approved` task is the guardrail that forces callers to use the correct
+signal for the correct transition.
 
 ### 3.3 `request_human_input` question scaffolding
 
@@ -728,9 +759,12 @@ If the target-agent session escalates (calls `submit_for_approval` on
 itself, or the template's `request_human_input` response is a rejection):
 
 1. The session records the rejection in an artifact.
-2. The session exits normally (completed, not failed).
-3. Runtime observes session completion and transitions `approved → done`
-   directly (no Task Agent tool-call required).
+2. The session calls `mark_complete` (rejection is a legitimate completion
+   outcome for post-approval, not a failure — the work itself was already
+   approved upstream). Task transitions `approved → done`.
+3. If the session exits without calling `mark_complete` (crashed,
+   timed out, etc.), the runtime falls back to observing session
+   termination and transitions `approved → done` with an audit note.
 4. An audit artifact on the task records "post-approval skipped:
    `human_rejected`".
 
@@ -768,7 +802,7 @@ is removed the same way regardless of what replaces it.)*
 | `packages/daemon/src/lib/space/runtime/pending-action.ts` | Entire file (60 lines). |
 | `packages/daemon/src/lib/space/runtime/space-runtime-service.ts` | `resumeCompletionActions` public API (lines 795-807). |
 | `packages/daemon/src/lib/space/tools/space-agent-tools.ts` | `approve_completion_action` handler (lines 944-1006) and its tool registration (line 1246). |
-| `packages/daemon/src/lib/space/tools/task-agent-tools.ts` | Update `approve_task` tool description string to reference the new status-aware behaviour (`in_progress → approved` spawns routing; `approved → done` is idempotent post-approval completion). No new tools added. |
+| `packages/daemon/src/lib/space/tools/task-agent-tools.ts` | Add new tool `mark_complete` (takes no args; rejects unless task status is `approved`). Update `approve_task` description to clarify it only handles `in_progress → approved` — with a pointer to `mark_complete` for the other transition. `mark_complete` is also registered on the space-task-node-agent MCP surface (spawned post-approval sessions). |
 | `packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts` | The `pendingCheckpointType === 'completion_action'` intercept in `spaceTask.update` (lines 154-203). `approvePendingCompletion` now transitions `review → approved` (not `review → done`) and invokes `PostApprovalRouter.route`. No new RPC. |
 | `packages/daemon/src/lib/space/workflows/built-in-workflows.ts` | `MERGE_PR_COMPLETION_ACTION` (lines 187-194). `VERIFY_PR_MERGED_BASH_SCRIPT` + `VERIFY_PR_MERGED_COMPLETION_ACTION` (lines 204-239). `VERIFY_REVIEW_POSTED_BASH_SCRIPT` + `VERIFY_REVIEW_POSTED_COMPLETION_ACTION` (lines 246-282). `PLAN_AND_DECOMPOSE_VERIFY_SCRIPT` + `PLAN_AND_DECOMPOSE_VERIFY_COMPLETION_ACTION` (lines 792-830). Every `completionActions: [...]` entry on a node (lines 518, 664, 766, 972, 1135). **Add** `postApproval` on the 2 workflows that need it (Coding, Research, QA). `PR_MERGE_BASH_SCRIPT` stays but moves to `pr-merge-script.ts` (see §3.4). |
 | `packages/web/src/components/space/PendingCompletionActionBanner.tsx` | Entire file (385 lines). |
@@ -860,7 +894,7 @@ WHERE pending_checkpoint_type = 'completion_action';
 Under `packages/daemon/tests/unit/5-space/`:
 
 - `workflow/post-approval-validator.test.ts`
-  - `targetAgent` = declared workflow agent → valid.
+  - `targetAgent` = declared space task node agent → valid.
   - `targetAgent` = `task-agent` → valid.
   - `targetAgent` = unknown → invalid + error lists eligible targets.
   - Missing `postApproval` → valid (optional).
@@ -872,9 +906,9 @@ Under `packages/daemon/tests/unit/5-space/`:
     escaping, no shell escaping — the downstream agent handles that).
 - `runtime/post-approval-router.test.ts`
   - `approved` task with no `postApproval` → router transitions directly
-    to `done`; no session spawned; no Task Agent tool-call.
-  - `approved` task with workflow-agent target → router spawns a new
-    sub-session with the interpolated kickoff and records
+    to `done`; no session spawned; no tool-call required.
+  - `approved` task with space-task-node-agent target → router spawns a
+    new sub-session with the interpolated kickoff and records
     `post_approval_session_id` + `post_approval_started_at`.
   - `approved` task with `target_agent: 'task-agent'` → router injects a
     `[POST_APPROVAL_INSTRUCTIONS]` turn into the existing Task Agent
@@ -886,15 +920,18 @@ Under `packages/daemon/tests/unit/5-space/`:
 - `runtime/task-status-transitions.test.ts`
   - `in_progress → approved` via `approve_task` (end node).
   - `review → approved` via `approvePendingCompletion` (human).
-  - `approved → done` via idempotent `approve_task` (Task Agent
-    post-approval completion).
-  - `approved → done` via runtime on non-task-agent session completion.
+  - `approved → done` via `mark_complete` (post-approval agent — spawned
+    node agent OR Task Agent for `'task-agent'` target).
+  - `approved → done` via runtime fallback on session termination
+    without `mark_complete`.
   - `approved → blocked` disallowed in Stage 2 (deferred to §7).
-- `agent/task-agent-approve-task-idempotent.test.ts`
-  - `approve_task` called on a task already in `approved` status
-    transitions to `done`; no runtime routing re-fires.
-  - `approve_task` called on a task in any non-`in_progress`/non-`approved`
-    status is rejected.
+- `agent/task-agent-mark-complete.test.ts`
+  - `mark_complete` called on a task in `approved` status transitions to
+    `done` and clears `post_approval_session_id`.
+  - `mark_complete` called on a task in any other status is rejected with
+    an explanatory error that points callers at `approve_task`.
+  - `approve_task` called on a task already in `approved` status is
+    rejected (the guardrail preventing accidental overload).
 - `workflows/end-node-handoff.test.ts`
   - For each of the 5 built-in workflows, snapshot-test the end-node's
     customPrompt to ensure the post-approval signalling instructions are
@@ -960,7 +997,10 @@ Steps:
 5. Save an audit artifact:
      save_artifact({ type: "result", append: true,
                      data: { merged_pr_url, mergedAt, approval: "auto"|"human" } })
-6. Call approve_task() to signal post-approval complete.
+6. Call mark_complete() to signal post-approval finished
+   (transitions the task from `approved` to `done`).
+   DO NOT call approve_task — that's for the initial "work is good"
+   transition (in_progress → approved), which already happened upstream.
 ```
 
 The QA-workflow `completionAutonomyLevel` drop from 4 → 3 is a behavioural
@@ -1008,11 +1048,13 @@ post-approval session layer rather than at the `merge_pr` tool layer.
   New `PostApprovalRouter` module in the runtime layer performs the
   deterministic dispatch: no-target → direct `approved → done`;
   task-agent target → inject `[POST_APPROVAL_INSTRUCTIONS]` turn;
-  workflow-agent target → spawn sub-session. `approve_task` tool becomes
-  idempotent for `approved` tasks. Runtime emits `[TASK_APPROVED]` as an
+  space-task-node-agent target → spawn sub-session. New `mark_complete`
+  MCP tool (Task Agent + spawned post-approval sessions) gates the
+  `approved → done` transition; `approve_task` stays scoped to
+  `in_progress → approved`. Runtime emits `[TASK_APPROVED]` as an
   awareness-only event. Task Agent system prompt gets a short
-  `## Post-Approval` section. No new MCP tools. Behind a feature flag
-  (`NEOKAI_TASK_AGENT_POST_APPROVAL_ROUTING`). ~700 LOC; depends on PR 1.
+  `## Post-Approval` section. Behind a feature flag
+  (`NEOKAI_TASK_AGENT_POST_APPROVAL_ROUTING`). ~750 LOC; depends on PR 1.
 - **PR 3** — **End-node handoff + built-in workflow `postApproval`
   entries.** Update all 5 built-in workflow prompts. Populate `postApproval`
   on Coding, Research, QA. Flip the feature flag. ~500 LOC; depends on PR 2.
@@ -1103,49 +1145,70 @@ post-approval session layer rather than at the `merge_pr` tool layer.
    **Recommendation:** accept the regression for Stage 4; revisit as a
    follow-up if operator feedback indicates the checks were load-bearing.
 
-7. **Completion signal for `targetAgent === 'task-agent'`.** The chosen
-   mechanism is idempotent `approve_task` (§3.2). Alternative considered:
-   infer completion from turn-end (no pending tool calls). Rejected
-   because turn-end is an ambiguous signal — the Task Agent may pause for
-   `request_human_input`, in which case turn-end does not mean the work
-   is done. An explicit `approve_task` call is unambiguous, matches what
-   end-node agents already do, and requires no new tool.
+7. **Completion signal for post-approval work.** ✅ Decided: a new
+   dedicated tool `mark_complete` (§3.2). Same tool is used by both
+   spawned space task node agents and the Task Agent (in the
+   `'task-agent'` target case). Alternatives considered and rejected:
+   - *Infer completion from turn-end (no pending tool calls).* Ambiguous —
+     a `request_human_input` pause looks the same as end-of-work.
+   - *Overload `approve_task`* (make it idempotent for `approved → done`).
+     Rejected by reviewer/user feedback: the same tool name would mean
+     two different things depending on caller status (work-approval vs.
+     post-approval-done), which is a surprising footgun for both humans
+     reading the prompts and LLMs picking the right call.
+   An explicit separately-named tool is unambiguous: `approve_task` =
+   "work is good" (`in_progress → approved`); `mark_complete` =
+   "post-approval finished" (`approved → done`).
 
 ---
 
 ## 8. Revision history
 
-**2026-04-23 revision 2 (this revision):** Dropped the proposed
+**2026-04-23 revision 3 (this revision):** Two follow-up refinements after
+more direct user feedback:
+
+1. **Drop the `approve_task` overload; introduce `mark_complete`.**
+   Rev 2 made `approve_task` idempotent so calling it on an already-
+   `approved` task would flip `approved → done`. User pushed back: same
+   tool name with two meanings is confusing. Introduce a new dedicated
+   tool `mark_complete` (no args, status-restricted to `approved`) used
+   by spawned space task node agents and by the Task Agent (for the
+   `'task-agent'` target case) to signal post-approval completion.
+   `approve_task` stays scoped to `in_progress → approved`.
+2. **Terminology: "space task node agent" replaces "workflow-agent
+   role".** Consistent label for agent sessions spawned per workflow
+   node. The term is not yet used in the codebase; the new
+   `post-approval-router.ts` module will introduce it in a doc comment
+   cross-referencing the existing `'node_agent'` kind in
+   `packages/shared/src/types/space.ts`.
+
+Key sections touched: §0 items 4+6 (new tool, new term), §1.4, §2.3
+(POST_APPROVAL_INSTRUCTIONS shape), §3.2 (rewritten around
+`mark_complete`), §3.5 (human-rejection signals via `mark_complete`),
+§4.1 (new tool registered), §4.6 (test renamed to
+`task-agent-mark-complete.test.ts`), §5 (merge template step 6 updated
+with explicit DO-NOT-call-approve_task note), §6.2 PR 2, §7.7 (decision
+locked in), §8, Appendix A, Appendix B (new row).
+
+**2026-04-23 revision 2:** Dropped the proposed
 `spawn_post_approval_session` + `completePostApproval` MCP tools on the
 Task Agent server after direct user feedback: routing is deterministic
 (a pure function of `workflow.postApproval`), so putting it behind an LLM
-tool-call gate is wrong. Routing moves to a new runtime module
-(`PostApprovalRouter`). The Task Agent's only new responsibility is
-**conversational awareness** plus, when `targetAgent === 'task-agent'`,
-acting on an injected `[POST_APPROVAL_INSTRUCTIONS]` turn and calling its
-existing (now idempotent) `approve_task` tool to close. Key changes:
+tool-call gate is wrong. Routing moved to a new runtime module
+(`PostApprovalRouter`). Task Agent's only new responsibility: receive
+`[TASK_APPROVED]` for awareness; when `targetAgent === 'task-agent'`,
+also act on an injected `[POST_APPROVAL_INSTRUCTIONS]` turn. Completion
+was signalled via idempotent `approve_task` — subsequently revised to
+`mark_complete` (see rev 3 above).
 
 - §1.4: renamed "Task Agent routing mechanics" → "Runtime-driven routing
   mechanics"; routing happens in `PostApprovalRouter.route`, not via Task
   Agent tool calls.
 - §2.3: reframed as "Task Agent observes (2 events), acts in 1 case".
   Added `[POST_APPROVAL_INSTRUCTIONS]` event shape.
-- §3.2: renamed to include "approve_task idempotency" — the existing tool
-  becomes status-aware (`in_progress → approved` triggers routing;
-  `approved → done` is idempotent completion). No new tools.
 - §3.4 / §3.5: retired Task Agent re-routing framing; completion and
   double-fire protection live in the runtime router.
-- §4.1 table: removed the "add new tools" row for `task-agent-tools.ts`;
-  also no new RPC in `space-task-handlers.ts`.
-- §4.6: renamed test files (`post-approval-router.test.ts`,
-  `task-agent-approve-task-idempotent.test.ts`); dropped the
-  spawn-tool-specific test.
-- §6.2 PR 2: no new MCP tools; smaller LOC estimate.
-- §7: removed the "expose `spawn_post_approval_session` to non-Task-Agent
-  sessions?" question (moot); added a new question on the task-agent
-  completion signal (decided: idempotent `approve_task`).
-- Appendix A: removed `spawn_post_approval_session` /
-  `completePostApproval` references; added `post-approval-router.ts`.
+- §4.1 table: removed the "add new tools" row for the two rev-1 tools.
 - Appendix B: added row for "Routing trigger: Task Agent LLM vs. runtime".
 
 **2026-04-23 revision 1:** Approach changed from "narrow `merge_pr` MCP
@@ -1180,8 +1243,9 @@ Key files referenced in this plan, grouped by area:
 **Task Agent wiring**
 - `packages/daemon/src/lib/space/agents/task-agent.ts` — system prompt + session init (add short §3.2 `## Post-Approval` section)
 - `packages/daemon/src/lib/space/runtime/task-agent-manager.ts` — session lifecycle, sub-session events, post-approval session spawn plumbing (consumed by `PostApprovalRouter`)
-- `packages/daemon/src/lib/space/tools/task-agent-tools.ts` — `approve_task` handler becomes status-aware (idempotent `approved → done`). No new tools.
-- `packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts` — unchanged
+- `packages/daemon/src/lib/space/tools/task-agent-tools.ts` — add new `mark_complete` tool (no-arg; accepts only `approved` status); `approve_task` description clarified to scope it to `in_progress → approved` (does not accept `approved`)
+- `packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts` — add `MarkCompleteSchema` (empty object) + export in `TASK_AGENT_TOOL_SCHEMAS`
+- `packages/daemon/src/lib/space/tools/space-task-node-agent-tools.ts` (or equivalent wiring site) — mirror the `mark_complete` tool onto spawned post-approval sessions' MCP surface so the spawned agent can close the task
 
 **Workflow schema**
 - `packages/shared/src/types/space.ts` — add `PostApprovalRoute`, `WorkflowDefinition.postApproval`
@@ -1226,7 +1290,9 @@ Key files referenced in this plan, grouped by area:
 | Task lifecycle addition | (A) Reuse `review` → `done` with a post-approval sub-state; (B) Add new `approved` status; (C) Track post-approval progress on the workflow-run row, not the task | **B** | `approved` is semantically distinct from `review` (work is accepted, not pending) and from `done` (terminal). Making it a first-class status is simpler to reason about in UI and queries. See §1.3. |
 | Template grammar | (A) Simple `{{var}}` substitute; (B) Full Handlebars; (C) JS expressions | **A** | Dumb substitute is sufficient because the LLM reading the prompt handles all the conditional logic. Handlebars + JS are overkill and create testing/security debt. |
 | Merge executor: Task Agent LLM (direct) vs. Task Agent routes to reviewer | Original revision: Task Agent LLM calls `merge_pr` MCP tool directly. This revision: the runtime routes to reviewer (workflow-declared agent). | **Route to reviewer** | Task Agent stays a pure orchestrator. The reviewer agent (or any target) already has the Bash/git/gh toolkit — reuse rather than duplicate. |
-| Routing trigger: Task Agent LLM tool-call vs. runtime dispatch | (A) New `spawn_post_approval_session` + `completePostApproval` MCP tools on the Task Agent server; LLM decides when to spawn/complete. (B) New `PostApprovalRouter` in the runtime layer; triggered deterministically on the `approved` transition; no new MCP tools. | **B** | Routing is a pure function of `workflow.postApproval` — there is no decision for an LLM to make. Putting dispatch behind an LLM tool call risks skip/mis-route. LLM judgement still fully present in the post-approval *work itself*. See §1.4 for full rationale. Decided by direct user feedback 2026-04-23. |
+| Routing trigger: Task Agent LLM tool-call vs. runtime dispatch | (A) New `spawn_post_approval_session` + `completePostApproval` MCP tools on the Task Agent server; LLM decides when to spawn/complete. (B) New `PostApprovalRouter` in the runtime layer; triggered deterministically on the `approved` transition. | **B** | Routing is a pure function of `workflow.postApproval` — there is no decision for an LLM to make. Putting dispatch behind an LLM tool call risks skip/mis-route. LLM judgement still fully present in the post-approval *work itself*. See §1.4 for full rationale. Decided by direct user feedback 2026-04-23. |
+| Post-approval completion signal tool | (A) Overload `approve_task` — make it idempotent for `approved → done` when the task is already `approved`. (B) New dedicated `mark_complete` tool, status-restricted to `approved`. | **B** | Same tool with two meanings (work-approval vs. post-approval-done) is a confusing footgun for both prompt authors and LLMs. A separately-named tool makes intent explicit at the call site. `approve_task` stays scoped to `in_progress → approved`. Decided by direct user feedback 2026-04-23. |
+| Terminology for per-node workflow agents | (A) "workflow role" / "workflow-agent role". (B) "space task node agent". | **B** | User preference. The codebase currently uses `'node_agent'` kind in `SpaceMemberSession`; the new `post-approval-router.ts` doc comment introduces the long-form name for prose and cross-references the existing kind enum. |
 | Handoff signal: new gate vs. structured send_message | Unchanged from original revision. | **send_message(task-agent, data)** | Already idiomatic; gates don't fit the task-agent's implicit channels. |
 | `completionAutonomyLevel`: keep, repurpose, or remove | Unchanged. | **Keep** | Independently controls `approve_task` vs `submit_for_approval` — a distinct "is the work any good" decision from post-approval. |
 | Verification completion actions (verify-pr-merged, verify-review-posted, verify-tasks-created): keep, convert, delete | Unchanged. | **Delete** (accept regression) | Lost verifications are soft guardrails; audit artifacts + human review are the primary safety nets. |


### PR DESCRIPTION
## Summary

Revised plan for removing `completionActions` in favour of workflow-declared post-approval routing. Incorporates two rounds of direct user feedback on top of the original PR #1612 design.

**Revision 2** (force-pushed earlier): Dropped the `spawn_post_approval_session` + `completePostApproval` MCP tools. Routing is a deterministic function of `workflow.postApproval` — no LLM decision — so it belongs in runtime code (`PostApprovalRouter`), not behind tool-call gates.

**Revision 3** (this commit): Two further refinements:
- **New dedicated `mark_complete` MCP tool** replaces the "idempotent `approve_task`" idea from rev 2. Overloading one name across `in_progress → approved` and `approved → done` was a confusing footgun. `approve_task` stays scoped to "work is good"; `mark_complete` signals "post-approval finished".
- **"Space task node agent"** replaces "workflow role" / "workflow-agent role" in prose. New `post-approval-router.ts` module's doc comment will introduce the term and cross-reference the existing `'node_agent'` kind in `SpaceMemberSession`.

## Key decisions locked

| Question | Chosen |
|---|---|
| Routing trigger | Runtime `PostApprovalRouter` (deterministic) |
| `approved → done` signal | New `mark_complete` tool (not `approve_task` overload) |
| Terminology | "space task node agent" (not "workflow role") |
| `targetAgent === 'task-agent'` injection | `[POST_APPROVAL_INSTRUCTIONS]` user turn |

## Context

Plan-only PR — no code yet. Please approve before Work Item 1 implementation starts.

## Test plan
- [ ] Plan direction reviewed by Review peer