### PR TITLE
fix(web): gate chat empty state on first messages snapshot

### DIFF
--- a/packages/web/src/hooks/__tests__/useGroupMessages.test.ts
+++ b/packages/web/src/hooks/__tests__/useGroupMessages.test.ts
@@ -402,6 +402,39 @@ describe('useGroupMessages', () => {
 			expect(result.current.messages).toHaveLength(1);
 			expect(result.current.messages[0].id).toBe(5);
 		});
+
+		// Regression coverage for the empty-state flash: when groupId switches
+		// from an already-loaded group to a new one, the render immediately
+		// following the switch must report isLoading=true. Before the fix,
+		// `isLoading` was flipped back to true from inside useEffect, leaving
+		// one render where rows were empty and isLoading was false — which the
+		// consumer (TaskConversationRenderer) rendered as "No conversation
+		// history found" before the new snapshot arrived.
+		it('reports isLoading=true on the render following a groupId switch', () => {
+			const { result, rerender } = renderHook(
+				({ groupId }: { groupId: string | null }) => useGroupMessages(groupId),
+				{ initialProps: { groupId: 'group-1' as string | null } }
+			);
+
+			// Finish loading group-1.
+			const firstSubId = lastSubscribeSubId();
+			act(() => {
+				fireEvent('liveQuery.snapshot', {
+					subscriptionId: firstSubId,
+					rows: [makeMessage(1)],
+					version: 1,
+				});
+			});
+			expect(result.current.isLoading).toBe(false);
+
+			// Switch to group-2 — isLoading must be true again immediately,
+			// not one render later when the effect fires.
+			rerender({ groupId: 'group-2' });
+			expect(result.current.isLoading).toBe(true);
+			// Existing rows must be cleared so the consumer does not briefly
+			// show group-1's messages under the new group-2 header.
+			expect(result.current.messages).toEqual([]);
+		});
 	});
 
 	describe('reconnect handling', () => {

--- a/packages/web/src/hooks/__tests__/useSpaceTaskMessages.test.ts
+++ b/packages/web/src/hooks/__tests__/useSpaceTaskMessages.test.ts
@@ -14,24 +14,43 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook } from '@testing-library/preact';
+import { act, renderHook } from '@testing-library/preact';
 
 // ---------------------------------------------------------------------------
 // Hoisted mock for useMessageHub
 // ---------------------------------------------------------------------------
 
-const { mockRequest, mockOnEvent } = vi.hoisted(() => ({
+const { mockRequest, mockOnEvent, mockIsConnected } = vi.hoisted(() => ({
 	mockRequest: vi.fn().mockResolvedValue(undefined),
-	mockOnEvent: vi.fn(() => () => {}),
+	mockOnEvent: vi.fn<(method: string, handler: (event: unknown) => void) => () => void>(
+		() => () => {}
+	),
+	mockIsConnected: { value: true },
 }));
 
 vi.mock('../useMessageHub', () => ({
 	useMessageHub: () => ({
 		request: mockRequest,
 		onEvent: mockOnEvent,
-		isConnected: true,
+		get isConnected() {
+			return mockIsConnected.value;
+		},
 	}),
 }));
+
+// Handler registry used by the empty-state flash tests to simulate LiveQuery
+// snapshot delivery.
+type EventHandler = (event: unknown) => void;
+let eventHandlers: Record<string, EventHandler[]> = {};
+
+function fireEvent(method: string, payload: unknown): void {
+	(eventHandlers[method] ?? []).forEach((h) => h(payload));
+}
+
+function lastSubscribeSubId(): string {
+	const subscribeCalls = mockRequest.mock.calls.filter((call) => call[0] === 'liveQuery.subscribe');
+	return subscribeCalls[subscribeCalls.length - 1][1].subscriptionId;
+}
 
 // ---------------------------------------------------------------------------
 // Imports (after mocks)
@@ -41,8 +60,18 @@ import { useSpaceTaskMessages } from '../useSpaceTaskMessages';
 
 describe('useSpaceTaskMessages', () => {
 	beforeEach(() => {
-		mockRequest.mockClear();
-		mockOnEvent.mockClear();
+		mockRequest.mockReset();
+		mockOnEvent.mockReset();
+		mockRequest.mockResolvedValue(undefined);
+		mockIsConnected.value = true;
+		eventHandlers = {};
+		mockOnEvent.mockImplementation((method: string, handler: EventHandler) => {
+			if (!eventHandlers[method]) eventHandlers[method] = [];
+			eventHandlers[method].push(handler);
+			return () => {
+				eventHandlers[method] = (eventHandlers[method] ?? []).filter((h) => h !== handler);
+			};
+		});
 	});
 
 	it('subscribes to the compact query name by default', () => {
@@ -80,5 +109,93 @@ describe('useSpaceTaskMessages', () => {
 
 		const subscribe = mockRequest.mock.calls.find(([method]) => method === 'liveQuery.subscribe');
 		expect(subscribe).toBeUndefined();
+	});
+
+	// Regression coverage for the empty-state flash reported against
+	// SpaceTaskUnifiedThread. The consumer renders "No task-agent activity
+	// yet." when `rows.length === 0 && !isLoading`. On slow networks the old
+	// hook briefly exposed that exact combination on first render and on
+	// task switch, so the empty-state flashed before the LiveQuery snapshot
+	// arrived.
+	describe('isLoading (empty-state flash prevention)', () => {
+		it('reports isLoading=true on the very first render when a taskId is provided', () => {
+			const { result } = renderHook(() => useSpaceTaskMessages('task-1'));
+
+			expect(result.current.isLoading).toBe(true);
+			expect(result.current.rows).toEqual([]);
+		});
+
+		it('reports isLoading=false when no taskId is provided', () => {
+			const { result } = renderHook(() => useSpaceTaskMessages(null));
+
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		it('flips isLoading to false once the LiveQuery snapshot arrives', () => {
+			const { result } = renderHook(() => useSpaceTaskMessages('task-1'));
+
+			const subId = lastSubscribeSubId();
+			expect(result.current.isLoading).toBe(true);
+
+			act(() => {
+				fireEvent('liveQuery.snapshot', {
+					subscriptionId: subId,
+					rows: [],
+					version: 1,
+				});
+			});
+
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		it('stays isLoading=true after switching taskId until the new snapshot arrives', () => {
+			const { result, rerender } = renderHook(
+				({ taskId }: { taskId: string }) => useSpaceTaskMessages(taskId),
+				{ initialProps: { taskId: 'task-1' } }
+			);
+
+			// Finish loading task-1.
+			const firstSubId = lastSubscribeSubId();
+			act(() => {
+				fireEvent('liveQuery.snapshot', {
+					subscriptionId: firstSubId,
+					rows: [],
+					version: 1,
+				});
+			});
+			expect(result.current.isLoading).toBe(false);
+
+			// Switch to task-2 — isLoading must be true again on the very next
+			// render, not one render later after the effect fires.
+			rerender({ taskId: 'task-2' });
+			expect(result.current.isLoading).toBe(true);
+
+			// Snapshot for task-2 closes the gate.
+			const secondSubId = lastSubscribeSubId();
+			expect(secondSubId).not.toBe(firstSubId);
+			act(() => {
+				fireEvent('liveQuery.snapshot', {
+					subscriptionId: secondSubId,
+					rows: [],
+					version: 1,
+				});
+			});
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		it('releases the loading gate on subscribe failure', async () => {
+			mockRequest.mockRejectedValueOnce(new Error('subscribe failed'));
+
+			const { result } = renderHook(() => useSpaceTaskMessages('task-1'));
+
+			expect(result.current.isLoading).toBe(true);
+
+			// Drain the rejection microtask.
+			await act(async () => {
+				await Promise.resolve();
+			});
+
+			expect(result.current.isLoading).toBe(false);
+		});
 	});
 });

--- a/packages/web/src/hooks/useGroupMessages.ts
+++ b/packages/web/src/hooks/useGroupMessages.ts
@@ -315,7 +315,17 @@ export function useGroupMessages(
 		paginationReducer,
 		INITIAL_PAGINATION_STATE
 	);
-	const [isLoading, setIsLoading] = useState(false);
+	/**
+	 * The groupId whose LiveQuery snapshot has been applied to `allMessages`.
+	 * `null` means either no subscription is active or we are still waiting
+	 * for the first snapshot of the current `groupId`. `isLoading` is derived
+	 * from the mismatch between this and the incoming `groupId` so the first
+	 * render (before the subscription effect runs) already reports `true` —
+	 * callers never briefly see an empty message list paired with
+	 * `isLoading=false`, which is what caused the empty-state flash on mount
+	 * and on task switch.
+	 */
+	const [loadedForGroupId, setLoadedForGroupId] = useState<string | null>(null);
 
 	// Track the active subscriptionId to guard against stale events from prior
 	// group subscriptions (e.g., rapid task switching or reconnect cycles).
@@ -324,15 +334,18 @@ export function useGroupMessages(
 	useEffect(() => {
 		if (!groupId || !isConnected) {
 			dispatch({ type: 'reset' });
-			setIsLoading(false);
+			setLoadedForGroupId(null);
 			activeSubIdRef.current = null;
 			return;
 		}
 
 		const subscriptionId = generateGroupMessagesSubId(groupId);
 		activeSubIdRef.current = subscriptionId;
-		setIsLoading(true);
+		// Reset the visible message set + the "loaded" marker for the previous
+		// group so consumers see the loading state (not stale rows or the
+		// empty-state placeholder) while the new snapshot is in flight.
 		dispatch({ type: 'reset' });
+		setLoadedForGroupId(null);
 
 		// Register event listeners BEFORE sending the subscribe request so the
 		// snapshot that is delivered synchronously as part of the subscribe
@@ -344,7 +357,7 @@ export function useGroupMessages(
 				rows: event.rows as SessionGroupMessage[],
 				pageSize: pageSizeRef.current,
 			});
-			setIsLoading(false);
+			setLoadedForGroupId(groupId);
 		});
 
 		const unsubDelta = onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
@@ -382,7 +395,11 @@ export function useGroupMessages(
 					}, RETRY_DELAYS_MS[attempt]);
 				} else {
 					if (activeSubIdRef.current === subscriptionId) {
-						setIsLoading(false);
+						// Release the loading gate after exhausting retries so
+						// consumers can surface whatever terminal UI is
+						// appropriate (empty or error) rather than stalling
+						// on the loading state forever.
+						setLoadedForGroupId(groupId);
 					}
 				}
 			});
@@ -426,6 +443,13 @@ export function useGroupMessages(
 	const loadEarlier = useCallback(() => {
 		dispatch({ type: 'loadEarlier', pageSize: pageSizeRef.current });
 	}, []); // dispatch is stable from useReducer; pageSizeRef is a ref
+
+	// Derived: we are loading whenever we have an active groupId + connection
+	// but have not yet applied a snapshot for that group. Computing this
+	// (instead of tracking it as separate state) means the very first render —
+	// before the subscription effect runs — already returns `isLoading=true`,
+	// which suppresses the empty-state flash on mount and on task switch.
+	const isLoading = groupId !== null && isConnected && loadedForGroupId !== groupId;
 
 	return {
 		messages,

--- a/packages/web/src/hooks/useSpaceTaskMessages.ts
+++ b/packages/web/src/hooks/useSpaceTaskMessages.ts
@@ -78,7 +78,16 @@ export function useSpaceTaskMessages(
 ): UseSpaceTaskMessagesResult {
 	const { request, onEvent, isConnected } = useMessageHub();
 	const [rows, setRows] = useState<SpaceTaskThreadMessageRow[]>([]);
-	const [isLoading, setIsLoading] = useState(false);
+	/**
+	 * The task id whose LiveQuery snapshot has been applied to `rows`.
+	 * `null` means either no subscription is active or we are still waiting
+	 * for the first snapshot of the current `taskId`. `isLoading` is derived
+	 * from the mismatch between this and the incoming `taskId`, which keeps
+	 * the loading state correct from the very first render — no useEffect
+	 * transition is needed to flip it to `true`, so the empty-state branch
+	 * can never flash on mount or on task switch.
+	 */
+	const [loadedForTaskId, setLoadedForTaskId] = useState<string | null>(null);
 	const activeSubIdRef = useRef<string | null>(null);
 
 	const queryName =
@@ -87,20 +96,23 @@ export function useSpaceTaskMessages(
 	useEffect(() => {
 		if (!taskId || !isConnected) {
 			setRows([]);
-			setIsLoading(false);
+			setLoadedForTaskId(null);
 			activeSubIdRef.current = null;
 			return;
 		}
 
 		const subscriptionId = nextTaskMessageSubId(taskId);
 		activeSubIdRef.current = subscriptionId;
+		// Clear stale rows from a previous subscription synchronously. The
+		// empty-state UI is still suppressed because `loadedForTaskId` is now
+		// out of sync with `taskId`, so consumers see the loading state.
 		setRows([]);
-		setIsLoading(true);
+		setLoadedForTaskId(null);
 
 		const unsubSnapshot = onEvent<LiveQuerySnapshotEvent>('liveQuery.snapshot', (event) => {
 			if (event.subscriptionId !== activeSubIdRef.current) return;
 			setRows(sortRows((event.rows as SpaceTaskThreadMessageRow[]) ?? []));
-			setIsLoading(false);
+			setLoadedForTaskId(taskId);
 		});
 
 		const unsubDelta = onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
@@ -113,8 +125,11 @@ export function useSpaceTaskMessages(
 			params: [taskId],
 			subscriptionId,
 		}).catch(() => {
+			// Release the loading gate on subscribe failure so consumers can
+			// surface the empty state (or, more likely, the reconnecting state
+			// once the websocket drops) rather than stalling forever.
 			if (activeSubIdRef.current === subscriptionId) {
-				setIsLoading(false);
+				setLoadedForTaskId(taskId);
 			}
 		});
 
@@ -127,6 +142,13 @@ export function useSpaceTaskMessages(
 	}, [taskId, isConnected, onEvent, request, queryName]);
 
 	const sortedRows = useMemo(() => sortRows(rows), [rows]);
+
+	// Derived: we are loading whenever we have an active taskId but have not
+	// yet applied a snapshot for it. Computing this (instead of tracking it
+	// as separate state) means the very first render — before the effect
+	// runs — already returns `isLoading=true`, which is what suppresses the
+	// empty-state flash on slow networks and on task switch.
+	const isLoading = taskId !== null && isConnected && loadedForTaskId !== taskId;
 
 	return {
 		rows: sortedRows,

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -372,11 +372,16 @@ export default function ChatContainer({
 		setHasMoreMessages(sessionStore.hasMoreMessages.value);
 	});
 
-	// Track initial load state - set to false once session state RPC has returned
+	// Track initial load state — we are done loading only when BOTH the session
+	// state RPC has returned AND the initial messages LiveQuery snapshot has
+	// arrived. The two responses are independent, and on slow networks the
+	// session RPC can land many seconds before the messages snapshot. Flipping
+	// `isInitialLoad` too early is what lets the empty-state placeholder flash
+	// for 20+ seconds while messages are still in flight.
 	useSignalEffect(() => {
-		const hasMessages = sessionStore.sdkMessages.value.length > 0;
 		const sessionStateLoaded = sessionStore.sessionState.value !== null;
-		if (hasMessages || sessionStateLoaded) {
+		const messagesLoaded = sessionStore.messagesLoaded.value;
+		if (sessionStateLoaded && messagesLoaded) {
 			setIsInitialLoad(false);
 			setLoadTimedOut(false);
 		}
@@ -763,10 +768,25 @@ export default function ChatContainer({
 		return [];
 	}, [errorDetails, errorCategory, errorProviderId, availableModels, switchModel]);
 
-	// Derive loading state from sessionStore
-	// sessionState being null means the RPC hasn't returned yet (truly loading)
-	// session (sessionInfo) can be null even after RPC returns for room sessions
-	const loading = sessionStore.sessionState.value === null && !error;
+	// Derive loading state from sessionStore.
+	//
+	// We must wait for BOTH pieces of the session init to land before the chat
+	// area is allowed to render:
+	//   1. `sessionState` (metadata + agent state, via `state.session` RPC)
+	//   2. `messagesLoaded` (first LiveQuery snapshot for `messages.bySession`)
+	//
+	// These are independent responses. On slow networks / large conversations
+	// the LiveQuery snapshot can take 20+ seconds, long after the metadata RPC
+	// has resolved. If we only gated on `sessionState`, the empty-state
+	// placeholder ("No messages yet") would flash during that window for any
+	// session that actually has messages. Gating on `messagesLoaded` as well
+	// keeps the loading skeleton up until the server has confirmed whether the
+	// conversation is genuinely empty.
+	//
+	// Errors short-circuit the loading state so the error UI can render.
+	const sessionStateLoaded = sessionStore.sessionState.value !== null;
+	const messagesLoaded = sessionStore.messagesLoaded.value;
+	const loading = !error && (!sessionStateLoaded || !messagesLoaded);
 
 	// Render loading state
 	if (loading) {

--- a/packages/web/src/lib/__tests__/session-store-comprehensive.test.ts
+++ b/packages/web/src/lib/__tests__/session-store-comprehensive.test.ts
@@ -511,6 +511,108 @@ describe('SessionStore - Comprehensive Coverage', () => {
 
 			expect(sessionStore.sdkMessages.value.some((m) => m.uuid === 'ghost')).toBe(false);
 		});
+
+		describe('messagesLoaded gate', () => {
+			// Regression coverage for the empty-state flash: the ChatContainer
+			// uses `messagesLoaded` together with `sessionState` to decide when
+			// to render the empty-state placeholder. If `messagesLoaded` goes
+			// true before the first LiveQuery snapshot applies, the UI will
+			// flash "No messages yet" for sessions that actually have messages
+			// but are still loading on slow networks.
+
+			it('starts false on construction', () => {
+				// Fresh store state: no session has been selected yet.
+				expect(sessionStore.messagesLoaded.value).toBe(false);
+			});
+
+			it('is reset to false on session switch and stays false before the snapshot arrives', async () => {
+				const hub = installLiveQueryHub();
+				await sessionStore.select('session-1');
+
+				// The `state.session` RPC has already resolved here (the mock
+				// resolves it synchronously), but the LiveQuery snapshot has
+				// not been fired yet — this is the exact window where the
+				// empty-state flash would appear.
+				expect(sessionStore.sessionState.value).not.toBeNull();
+				expect(sessionStore.messagesLoaded.value).toBe(false);
+
+				// Only after the snapshot does the gate open.
+				hub.fire('liveQuery.snapshot', { subscriptionId: hub.subscriptionId!, rows: [] });
+				expect(sessionStore.messagesLoaded.value).toBe(true);
+			});
+
+			it('flips to true when the LiveQuery snapshot applies', async () => {
+				const hub = installLiveQueryHub();
+				await sessionStore.select('session-1');
+
+				expect(sessionStore.messagesLoaded.value).toBe(false);
+
+				hub.fire('liveQuery.snapshot', {
+					subscriptionId: hub.subscriptionId!,
+					rows: [
+						{
+							uuid: 'msg-1',
+							type: 'text',
+							role: 'user',
+							content: [{ type: 'text', text: 'Hi' }],
+						},
+					],
+				});
+
+				expect(sessionStore.messagesLoaded.value).toBe(true);
+			});
+
+			it('resets to false when switching to a different session', async () => {
+				const hub = installLiveQueryHub();
+				await sessionStore.select('session-1');
+				hub.fire('liveQuery.snapshot', { subscriptionId: hub.subscriptionId!, rows: [] });
+				expect(sessionStore.messagesLoaded.value).toBe(true);
+
+				// Switching sessions clears the gate — the UI must stay on the
+				// loading skeleton until the new session's snapshot arrives,
+				// even if the prior session's messages had fully loaded.
+				await sessionStore.select('session-2');
+				expect(sessionStore.messagesLoaded.value).toBe(false);
+			});
+
+			it('opens the gate on subscribe failure so the UI can recover', async () => {
+				// First install the successful handler map for onEvent, then
+				// configure the subscribe RPC to reject. The `state.session`
+				// RPC still resolves so the sessionState path doesn't go into
+				// its own error branch; we're isolating the subscribe failure.
+				const handlers = new Map<string, Array<(data: unknown) => void>>();
+				mockHub.request.mockImplementation((channel: string, _params?: Record<string, unknown>) => {
+					if (channel === 'state.session') {
+						return Promise.resolve({ sessionInfo: { id: 'session-1' } });
+					}
+					if (channel === 'liveQuery.subscribe') {
+						return Promise.reject(new Error('subscribe failed'));
+					}
+					if (channel === 'liveQuery.unsubscribe') {
+						return Promise.resolve({ ok: true });
+					}
+					return Promise.resolve(undefined);
+				});
+				mockHub.onEvent.mockImplementation((channel: string, callback: (data: unknown) => void) => {
+					const list = handlers.get(channel) ?? [];
+					list.push(callback);
+					handlers.set(channel, list);
+					return () => {
+						const l = handlers.get(channel);
+						if (!l) return;
+						const i = l.indexOf(callback);
+						if (i >= 0) l.splice(i, 1);
+					};
+				});
+
+				await sessionStore.select('session-1');
+
+				// Subscribe failed — we never got (and never will get) a
+				// snapshot. The gate must open anyway, otherwise the UI would
+				// sit on the loading skeleton forever.
+				expect(sessionStore.messagesLoaded.value).toBe(true);
+			});
+		});
 	});
 
 	describe('slash commands sync', () => {

--- a/packages/web/src/lib/session-store.ts
+++ b/packages/web/src/lib/session-store.ts
@@ -57,6 +57,24 @@ class SessionStore {
 	/** SDK messages from state.sdkMessages channel */
 	readonly sdkMessages = signal<ChatMessage[]>([]);
 
+	/**
+	 * Whether the initial messages snapshot has arrived for the current session.
+	 *
+	 * The session metadata RPC (`state.session`) and the messages LiveQuery run
+	 * on independent request paths. On slow networks or for long conversations
+	 * the metadata RPC can land many seconds before the messages snapshot. The
+	 * UI uses this flag together with `sessionState` to decide when the chat is
+	 * truly ready — rendering the empty-state placeholder before this is `true`
+	 * would lie to the user about a conversation that still has messages in
+	 * flight.
+	 *
+	 * Reset to `false` on every session switch; set to `true` when the first
+	 * LiveQuery snapshot applies or when the subscribe fails (so the UI can
+	 * surface a genuinely-empty conversation or a failure rather than stalling
+	 * on a loading skeleton forever).
+	 */
+	readonly messagesLoaded = signal<boolean>(false);
+
 	/** API retry attempts (populated from session.retryAttempt events) */
 	readonly retryAttempts = signal<
 		Array<{
@@ -206,6 +224,10 @@ class SessionStore {
 		this._initialMessageCount.value = 0;
 		this._hasMoreMessages.value = false;
 		this._contextInfo.value = null; // Clear context info on session switch
+		// Reset the messages-loaded gate so ChatContainer shows the loading
+		// skeleton (not the empty-state placeholder) until the new session's
+		// LiveQuery snapshot arrives.
+		this.messagesLoaded.value = false;
 		// Invalidate any in-flight LiveQuery events for the previous session.
 		// Events already queued in the event loop will see this guard and be
 		// dropped before touching the fresh sdkMessages signal.
@@ -400,9 +422,16 @@ class SessionStore {
 			});
 		} catch (err) {
 			logger.error('Failed to subscribe to messages LiveQuery:', err);
+			// Release the messages-loaded gate so the UI doesn't stall on the
+			// loading skeleton forever when the subscribe fails (e.g. session
+			// was deleted between select and subscribe). We fall through to
+			// whatever sdkMessages currently holds — either the optimistic
+			// empty state or stale rows from a prior subscription.
+			if (this.activeMessagesSubscriptionId === subscriptionId) {
+				this.messagesLoaded.value = true;
+			}
 			// Don't rethrow — we still want session state to be usable even if
-			// the LiveQuery failed (e.g. session was deleted between select and
-			// subscribe). The UI will render whatever sdkMessages currently holds.
+			// the LiveQuery failed.
 		}
 	}
 
@@ -427,6 +456,9 @@ class SessionStore {
 		this.sdkMessages.value = sorted;
 		this._hasMoreMessages.value = rows.length >= LIVE_QUERY_MESSAGE_LIMIT;
 		this._initialMessageCount.value = rows.length;
+		// Mark the messages as loaded so the UI can transition from the loading
+		// skeleton to either the message list or the empty-state placeholder.
+		this.messagesLoaded.value = true;
 		this._syncCommandsFromSDKMessages(sorted);
 	}
 


### PR DESCRIPTION
## Summary

Chat UI flashed "No messages yet" for 20+ seconds on slow networks / long conversations. Root cause: loading was keyed only on the `state.session` RPC, not on the independent `messages.bySession` LiveQuery snapshot — so once metadata landed the UI flipped out of loading even though rows hadn't arrived.

- `SessionStore` now exposes a `messagesLoaded` signal; `ChatContainer` gates the empty state on **both** session metadata and the first messages snapshot.
- `useSpaceTaskMessages` and `useGroupMessages` derive `isLoading` from `loadedForId !== currentId`, so the very first render — before effects fire — already reports `isLoading=true`, and id-switches flip it back synchronously (no one-frame flash).
- Subscribe-failure paths open the gate so we never stall forever.

Regression tests added for all three paths.

## Test plan

- [x] `bunx vitest run` (web) — 248/250 files pass; the 2 failing files (`ChatContainer.test.ts` Node import issue, `SpaceIsland.test.tsx`) pre-exist on `dev` and are unrelated
- [x] `bun run check` (lint + typecheck + knip)
- [ ] Manual: open a chat in a long-running room on a throttled network; confirm the empty state never flashes before messages render