### PR TITLE
fix(daemon): reset channel cycle counters on human touch

### DIFF
--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -504,6 +504,21 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 		data: Record<string, unknown>;
 	};
 	/**
+	 * Emitted when channel cycle counters for a workflow run are reset to 0.
+	 *
+	 * Currently fired when a human sends a message to a task in the run via
+	 * `space.task.sendMessage` ("human touch"). `rowsReset` is the number of
+	 * `channel_cycles` rows actually zeroed — it may be 0 if no cyclic channels
+	 * had traversed yet at the time of the reset.
+	 */
+	'space.workflowRun.cyclesReset': {
+		sessionId: string;
+		runId: string;
+		reason: 'human_touch';
+		taskId?: string;
+		rowsReset: number;
+	};
+	/**
 	 * Emitted when a workflow_run_artifact_cache row has been written by a
 	 * background sync job (spaceWorkflowRun.syncGateArtifacts, syncCommits,
 	 * syncFileDiff). The frontend TaskArtifactsPanel subscribes and refetches

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -693,13 +693,16 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	deps.neoAgentManager.setActionToolsConfig(neoActionToolsConfig);
 	deps.neoAgentManager.setActivityLogger(neoActivityLogger);
 
-	// Human ↔ Task Agent message routing handlers (require taskAgentManager)
+	// Human ↔ Task Agent message routing handlers (require taskAgentManager).
+	// `channelCycleRepo` is passed so `space.task.sendMessage` can reset the
+	// per-channel cycle counters on human touch — see Task #101.
 	setupSpaceTaskMessageHandlers(
 		deps.messageHub,
 		taskAgentManager,
 		deps.db,
 		deps.daemonHub,
-		nodeExecutionRepo
+		nodeExecutionRepo,
+		channelCycleRepo
 	);
 
 	// Space export/import handlers

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -695,7 +695,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 
 	// Human ↔ Task Agent message routing handlers (require taskAgentManager).
 	// `channelCycleRepo` is passed so `space.task.sendMessage` can reset the
-	// per-channel cycle counters on human touch — see Task #101.
+	// per-channel cycle counters on human touch.
 	setupSpaceTaskMessageHandlers(
 		deps.messageHub,
 		taskAgentManager,

--- a/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
@@ -16,6 +16,21 @@ import { Logger } from '../logger';
 const log = new Logger('space-task-message-handlers');
 
 /**
+ * Minimal interface for resetting per-channel cycle counters on a workflow run.
+ * Implemented by `ChannelCycleRepository.resetAllForRun`.
+ *
+ * Extracted so the RPC handler stays decoupled from the concrete repository
+ * class and can be unit-tested with a lightweight mock.
+ */
+export interface ChannelCycleResetter {
+	/**
+	 * Zero out `count` for every `channel_cycles` row belonging to `runId`.
+	 * Returns the number of rows updated.
+	 */
+	resetAllForRun(runId: string): number;
+}
+
+/**
  * Extract @AgentName mentions from message text.
  * Matches patterns like @Coder, @code-reviewer, @planner_1
  * Returns a deduplicated list of mentioned agent names (preserving first occurrence order).
@@ -79,9 +94,45 @@ export function setupSpaceTaskMessageHandlers(
 	taskAgentManager: TaskAgentManagerInterface,
 	db: Database,
 	daemonHub: DaemonHub,
-	nodeExecutionRepo?: NodeExecutionLookup
+	nodeExecutionRepo?: NodeExecutionLookup,
+	channelCycleResetter?: ChannelCycleResetter
 ): void {
 	const taskRepo = new SpaceTaskRepository(db.getDatabase());
+
+	/**
+	 * Reset all channel cycle counters for a workflow run and announce it via
+	 * both a structured log entry and a `space.workflowRun.cyclesReset` daemonHub
+	 * event — the dual signal makes human-touch events observable in post-mortems
+	 * (log) and real-time (hub subscribers) without DB inspection.
+	 *
+	 * Best-effort: any failure is logged and swallowed so the RPC's success
+	 * is not held hostage by an observability side-effect.
+	 */
+	async function resetChannelCyclesOnHumanTouch(
+		workflowRunId: string | null | undefined,
+		taskId: string
+	): Promise<void> {
+		if (!channelCycleResetter || !workflowRunId) return;
+		try {
+			const rowsReset = channelCycleResetter.resetAllForRun(workflowRunId);
+			log.info(
+				`workflow.cycles.reset: runId=${workflowRunId} reason=human_touch taskId=${taskId} rowsReset=${rowsReset}`
+			);
+			await daemonHub.emit('space.workflowRun.cyclesReset', {
+				sessionId: 'global',
+				runId: workflowRunId,
+				reason: 'human_touch',
+				taskId,
+				rowsReset,
+			});
+		} catch (err) {
+			log.warn(
+				`workflow.cycles.reset: failed to reset cycles for task ${taskId}: ${
+					err instanceof Error ? err.message : String(err)
+				}`
+			);
+		}
+	}
 
 	// ─── space.task.ensureAgentSession ──────────────────────────────────────────
 	messageHub.onRequest('space.task.ensureAgentSession', async (data) => {
@@ -198,6 +249,8 @@ export function setupSpaceTaskMessageHandlers(
 				`space.task.sendMessage: @mention routing to [${routedTo.join(', ')}] for task ${params.taskId}`
 			);
 
+			await resetChannelCyclesOnHumanTouch(task.workflowRunId, params.taskId);
+
 			return {
 				ok: true,
 				routedTo,
@@ -225,6 +278,13 @@ export function setupSpaceTaskMessageHandlers(
 
 		await taskAgentManager.injectTaskAgentMessage(params.taskId, params.message);
 		log.info(`space.task.sendMessage: injected message into task ${params.taskId}`);
+
+		// Human touch: `space.task.sendMessage` is the sole RPC boundary for
+		// human→task messages, so every successful call here resets the
+		// autonomous-cycle safety cap. Agent-to-agent paths (send_message tool
+		// → flushPendingMessagesForTarget → injectSubSessionMessage) bypass this
+		// RPC and are therefore correctly excluded from the reset.
+		await resetChannelCyclesOnHumanTouch(task.workflowRunId, params.taskId);
 
 		return { ok: true };
 	});

--- a/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
@@ -100,13 +100,10 @@ export function setupSpaceTaskMessageHandlers(
 	const taskRepo = new SpaceTaskRepository(db.getDatabase());
 
 	/**
-	 * Reset all channel cycle counters for a workflow run and announce it via
-	 * both a structured log entry and a `space.workflowRun.cyclesReset` daemonHub
-	 * event — the dual signal makes human-touch events observable in post-mortems
-	 * (log) and real-time (hub subscribers) without DB inspection.
-	 *
-	 * Best-effort: any failure is logged and swallowed so the RPC's success
-	 * is not held hostage by an observability side-effect.
+	 * Best-effort: failure to reset must not fail the RPC, since the reset is an
+	 * observability/safety-cap side-effect rather than part of the message delivery
+	 * contract. The emit is suppressed when no rows changed to avoid waking
+	 * subscribers for a no-op.
 	 */
 	async function resetChannelCyclesOnHumanTouch(
 		workflowRunId: string | null | undefined,
@@ -118,13 +115,15 @@ export function setupSpaceTaskMessageHandlers(
 			log.info(
 				`workflow.cycles.reset: runId=${workflowRunId} reason=human_touch taskId=${taskId} rowsReset=${rowsReset}`
 			);
-			await daemonHub.emit('space.workflowRun.cyclesReset', {
-				sessionId: 'global',
-				runId: workflowRunId,
-				reason: 'human_touch',
-				taskId,
-				rowsReset,
-			});
+			if (rowsReset > 0) {
+				await daemonHub.emit('space.workflowRun.cyclesReset', {
+					sessionId: 'global',
+					runId: workflowRunId,
+					reason: 'human_touch',
+					taskId,
+					rowsReset,
+				});
+			}
 		} catch (err) {
 			log.warn(
 				`workflow.cycles.reset: failed to reset cycles for task ${taskId}: ${

--- a/packages/daemon/src/storage/repositories/channel-cycle-repository.ts
+++ b/packages/daemon/src/storage/repositories/channel-cycle-repository.ts
@@ -78,16 +78,12 @@ export class ChannelCycleRepository {
 	}
 
 	/**
-	 * Resets ALL channel cycle counters for a given workflow run back to 0.
+	 * Zeros every channel cycle counter for a run in a single statement.
 	 *
-	 * Used on "human touch" events (e.g. a human sends a message into a task via
-	 * `space.task.sendMessage`) so that the autonomous-cycle safety cap tracks
-	 * "consecutive autonomous cycles without human oversight" rather than
-	 * "total cycles ever". All channels in the run reset together — if a human is
-	 * engaged, the whole loop gets a fresh budget.
+	 * The cap measures "consecutive autonomous cycles without human oversight", so
+	 * all channels reset together whenever the run regains human attention.
 	 *
-	 * @returns The number of channel cycle rows that were reset. Zero is a valid
-	 *          outcome (e.g. no cyclic channels have run yet).
+	 * @returns Number of rows updated (0 is valid — no cyclic channels yet).
 	 */
 	resetAllForRun(runId: string): number {
 		const result = this.db

--- a/packages/daemon/src/storage/repositories/channel-cycle-repository.ts
+++ b/packages/daemon/src/storage/repositories/channel-cycle-repository.ts
@@ -76,6 +76,25 @@ export class ChannelCycleRepository {
 			)
 			.run(Date.now(), runId, channelIndex);
 	}
+
+	/**
+	 * Resets ALL channel cycle counters for a given workflow run back to 0.
+	 *
+	 * Used on "human touch" events (e.g. a human sends a message into a task via
+	 * `space.task.sendMessage`) so that the autonomous-cycle safety cap tracks
+	 * "consecutive autonomous cycles without human oversight" rather than
+	 * "total cycles ever". All channels in the run reset together — if a human is
+	 * engaged, the whole loop gets a fresh budget.
+	 *
+	 * @returns The number of channel cycle rows that were reset. Zero is a valid
+	 *          outcome (e.g. no cyclic channels have run yet).
+	 */
+	resetAllForRun(runId: string): number {
+		const result = this.db
+			.prepare('UPDATE channel_cycles SET count = 0, updated_at = ? WHERE run_id = ?')
+			.run(Date.now(), runId);
+		return result.changes;
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-message-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-message-handlers.test.ts
@@ -1000,6 +1000,29 @@ describe('setupSpaceTaskMessageHandlers', () => {
 			expect(emitCalls.some((c) => c[0] === 'space.workflowRun.cyclesReset')).toBe(true);
 		});
 
+		it('does NOT emit cyclesReset when rowsReset is 0 (no subscriber wakeups for no-op)', async () => {
+			const {
+				handlers: h,
+				resetter,
+				daemonHub: dh,
+			} = setupForReset(mockTaskWithRun, {
+				resetRows: 0,
+			});
+
+			const result = await (h.get('space.task.sendMessage') as RequestHandler)({
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				message: 'Please continue',
+			});
+
+			expect(result).toEqual({ ok: true });
+			// The reset statement still runs (it's cheap and idempotent)...
+			expect(resetter.resetAllForRun).toHaveBeenCalledTimes(1);
+			// ...but no event is emitted because nothing actually changed.
+			const emitCalls = (dh.emit as ReturnType<typeof mock>).mock.calls;
+			expect(emitCalls.some((c) => c[0] === 'space.workflowRun.cyclesReset')).toBe(false);
+		});
+
 		it('does NOT reset when the task has no workflowRunId', async () => {
 			const { handlers: h, resetter, daemonHub: dh } = setupForReset(mockTaskNoRun);
 

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-message-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-message-handlers.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { describe, expect, it, mock, beforeEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
 import { MessageHub } from '@neokai/shared';
 import type { SpaceTask } from '@neokai/shared';
 import type { SDKMessage } from '@neokai/shared/sdk';
@@ -19,10 +20,13 @@ import {
 	parseMentions,
 	type TaskAgentManagerInterface,
 	type NodeExecutionLookup,
+	type ChannelCycleResetter,
 } from '../../../../src/lib/rpc-handlers/space-task-message-handlers';
 import type { Database } from '../../../../src/storage/database';
 import type { AgentSession } from '../../../../src/lib/agent/agent-session';
 import type { DaemonHub } from '../../../../src/lib/daemon-hub';
+import { ChannelCycleRepository } from '../../../../src/storage/repositories/channel-cycle-repository';
+import { createSpaceTables } from '../../helpers/space-test-db';
 
 type RequestHandler = (data: unknown) => Promise<unknown>;
 
@@ -887,6 +891,309 @@ describe('setupSpaceTaskMessageHandlers', () => {
 					message: '@Coder please help',
 				})
 			).rejects.toThrow('Sub-session not found: session-coder-1');
+		});
+	});
+
+	// ─── channel-cycle reset on human touch ───────────────────────────────────────
+
+	describe('channel-cycle reset on human touch in space.task.sendMessage', () => {
+		const mockTaskWithRun: SpaceTask = {
+			...mockTaskWithSession,
+			workflowRunId: 'run-cyc-1',
+		};
+
+		const mockTaskNoRun: SpaceTask = {
+			...mockTaskWithSession,
+			workflowRunId: undefined,
+		};
+
+		function setupForReset(
+			task: SpaceTask,
+			opts: { withNodeExec?: boolean; resetRows?: number } = {}
+		) {
+			const mh = createMockMessageHub();
+			const localHub = mh.hub;
+			const localHandlers = mh.handlers;
+			const injectSubSession = mock(async (_sid: string, _msg: string) => {});
+			const localTaskAgentManager: TaskAgentManagerInterface = {
+				...createMockTaskAgentManager(null, task),
+				injectSubSessionMessage: injectSubSession,
+			};
+			const localDb = createMockDatabase(task);
+			const localDaemonHub = { emit: mock(async () => {}) } as unknown as DaemonHub;
+			const resetter: ChannelCycleResetter = {
+				resetAllForRun: mock((_runId: string) => opts.resetRows ?? 2),
+			};
+			const nodeExec: NodeExecutionLookup | undefined = opts.withNodeExec
+				? {
+						listByWorkflowRun: mock(() => [
+							{ agentName: 'Coder', agentSessionId: 'sess-coder', status: 'in_progress' },
+						]),
+					}
+				: undefined;
+
+			setupSpaceTaskMessageHandlers(
+				localHub,
+				localTaskAgentManager,
+				localDb,
+				localDaemonHub,
+				nodeExec,
+				resetter
+			);
+
+			return {
+				handlers: localHandlers,
+				taskAgentManager: localTaskAgentManager,
+				injectSubSession,
+				daemonHub: localDaemonHub,
+				resetter,
+			};
+		}
+
+		it('resets cycle counters after a successful direct task-agent injection (no @mention)', async () => {
+			const { handlers: h, resetter, daemonHub: dh } = setupForReset(mockTaskWithRun);
+
+			const result = await (h.get('space.task.sendMessage') as RequestHandler)({
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				message: 'Please continue the work',
+			});
+
+			expect(result).toEqual({ ok: true });
+			expect(resetter.resetAllForRun).toHaveBeenCalledTimes(1);
+			expect(resetter.resetAllForRun).toHaveBeenCalledWith('run-cyc-1');
+
+			// daemonHub.emit should have been called with 'space.workflowRun.cyclesReset'
+			const emitCalls = (dh.emit as ReturnType<typeof mock>).mock.calls;
+			const cyclesResetCall = emitCalls.find((c) => c[0] === 'space.workflowRun.cyclesReset') as
+				| [string, Record<string, unknown>]
+				| undefined;
+			expect(cyclesResetCall).toBeDefined();
+			expect(cyclesResetCall![1]).toMatchObject({
+				runId: 'run-cyc-1',
+				reason: 'human_touch',
+				taskId: 'task-1',
+				rowsReset: 2,
+			});
+		});
+
+		it('resets cycle counters after a successful @mention injection', async () => {
+			const {
+				handlers: h,
+				injectSubSession,
+				resetter,
+				daemonHub: dh,
+			} = setupForReset(mockTaskWithRun, { withNodeExec: true });
+
+			const result = await (h.get('space.task.sendMessage') as RequestHandler)({
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				message: '@Coder please fix',
+			});
+
+			expect(result).toMatchObject({ ok: true, routedTo: ['Coder'] });
+			expect(injectSubSession).toHaveBeenCalledTimes(1);
+			expect(resetter.resetAllForRun).toHaveBeenCalledTimes(1);
+			expect(resetter.resetAllForRun).toHaveBeenCalledWith('run-cyc-1');
+
+			const emitCalls = (dh.emit as ReturnType<typeof mock>).mock.calls;
+			expect(emitCalls.some((c) => c[0] === 'space.workflowRun.cyclesReset')).toBe(true);
+		});
+
+		it('does NOT reset when the task has no workflowRunId', async () => {
+			const { handlers: h, resetter, daemonHub: dh } = setupForReset(mockTaskNoRun);
+
+			await (h.get('space.task.sendMessage') as RequestHandler)({
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				message: 'Please continue',
+			});
+
+			expect(resetter.resetAllForRun).not.toHaveBeenCalled();
+			const emitCalls = (dh.emit as ReturnType<typeof mock>).mock.calls;
+			expect(emitCalls.some((c) => c[0] === 'space.workflowRun.cyclesReset')).toBe(false);
+		});
+
+		it('does NOT reset when injectTaskAgentMessage fails (error path, no reset)', async () => {
+			const { handlers: h, taskAgentManager: tm, resetter } = setupForReset(mockTaskWithRun);
+			(tm.injectTaskAgentMessage as ReturnType<typeof mock>).mockRejectedValue(
+				new Error('inject failed')
+			);
+
+			await expect(
+				(h.get('space.task.sendMessage') as RequestHandler)({
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					message: 'Please continue',
+				})
+			).rejects.toThrow('inject failed');
+
+			// Reset must not fire when injection fails.
+			expect(resetter.resetAllForRun).not.toHaveBeenCalled();
+		});
+
+		it('does NOT reset when @mention routing fails (all mentions unresolved)', async () => {
+			const { handlers: h, resetter } = setupForReset(mockTaskWithRun, { withNodeExec: true });
+
+			await expect(
+				(h.get('space.task.sendMessage') as RequestHandler)({
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					message: '@Ghost please fix',
+				})
+			).rejects.toThrow('@mention not found: Ghost');
+
+			expect(resetter.resetAllForRun).not.toHaveBeenCalled();
+		});
+
+		it('swallows resetter errors and still returns success (best-effort side-effect)', async () => {
+			const { handlers: h, resetter } = setupForReset(mockTaskWithRun);
+			(resetter.resetAllForRun as ReturnType<typeof mock>).mockImplementation(() => {
+				throw new Error('DB connection lost');
+			});
+
+			const result = await (h.get('space.task.sendMessage') as RequestHandler)({
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				message: 'Please continue',
+			});
+
+			// RPC success is not impacted by a failed side-effect.
+			expect(result).toEqual({ ok: true });
+			expect(resetter.resetAllForRun).toHaveBeenCalledTimes(1);
+		});
+
+		it('acceptance: 4 autonomous cycles + human message -> cycles reset -> 5th cycle allowed', async () => {
+			// Integration test per Task #101 acceptance criteria:
+			//   "simulate 4 autonomous Review→Coding cycles, inject a human message,
+			//    verify cycle count is 0, verify a 5th autonomous cycle is allowed."
+			//
+			// Uses the real ChannelCycleRepository (not a mock) to exercise the full
+			// SQL path that production hits.
+			const sqlite = new BunDatabase(':memory:');
+			createSpaceTables(sqlite);
+			const now = Date.now();
+			sqlite.exec(
+				`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at) VALUES ('sp1', 'sp1', '/tmp/ws-acc', 'Space', ${now}, ${now})`
+			);
+			sqlite.exec(
+				`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at) VALUES ('wf1', 'sp1', 'WF', ${now}, ${now})`
+			);
+			sqlite.exec(
+				`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at, updated_at) VALUES ('run-cyc-1', 'sp1', 'wf1', 'Run', 'in_progress', ${now}, ${now})`
+			);
+			const cycleRepo = new ChannelCycleRepository(sqlite);
+
+			// Simulate 4 autonomous Review→Coding cycles against the backward channel
+			// (channel index 1, maxCycles = 5). At this point the cap is 4/5 — one
+			// more cycle would hit the cap on the next call.
+			const MAX_CYCLES = 5;
+			const CHANNEL_INDEX = 1;
+			for (let i = 0; i < 4; i++) {
+				const ok = cycleRepo.incrementCycleCount('run-cyc-1', CHANNEL_INDEX, MAX_CYCLES);
+				expect(ok).toBe(true);
+			}
+			expect(cycleRepo.get('run-cyc-1', CHANNEL_INDEX)!.count).toBe(4);
+
+			// Wire handlers with the real repo as the ChannelCycleResetter.
+			const mh = createMockMessageHub();
+			const taskAgent = createMockTaskAgentManager(null, {
+				...mockTaskWithSession,
+				workflowRunId: 'run-cyc-1',
+			});
+			const localDb = createMockDatabase({ ...mockTaskWithSession, workflowRunId: 'run-cyc-1' });
+			const localDaemonHub = { emit: mock(async () => {}) } as unknown as DaemonHub;
+			setupSpaceTaskMessageHandlers(
+				mh.hub,
+				taskAgent,
+				localDb,
+				localDaemonHub,
+				undefined,
+				cycleRepo
+			);
+
+			// Human sends a message via the RPC — this must reset cycle counters.
+			const result = await (mh.handlers.get('space.task.sendMessage') as RequestHandler)({
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				message: 'Hold on, I have feedback',
+			});
+			expect(result).toEqual({ ok: true });
+
+			// Cycle count must now be 0.
+			expect(cycleRepo.get('run-cyc-1', CHANNEL_INDEX)!.count).toBe(0);
+
+			// A 5th autonomous cycle is now allowed — the cap guard succeeds again.
+			const fifth = cycleRepo.incrementCycleCount('run-cyc-1', CHANNEL_INDEX, MAX_CYCLES);
+			expect(fifth).toBe(true);
+			expect(cycleRepo.get('run-cyc-1', CHANNEL_INDEX)!.count).toBe(1);
+
+			sqlite.close();
+		});
+
+		it('NOT human touch: agent-to-agent delivery via injectSubSessionMessage does NOT reset', async () => {
+			// Agent `send_message` tool → pending_agent_messages →
+			// flushPendingMessagesForTarget → TaskAgentManager.injectSubSessionMessage
+			// calls `injectSubSessionMessage` directly on the manager, NOT through the
+			// RPC. This test verifies that such a direct call path has no way to
+			// trigger the reset: only the RPC handler holds the resetter.
+			const sqlite = new BunDatabase(':memory:');
+			createSpaceTables(sqlite);
+			const now = Date.now();
+			sqlite.exec(
+				`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at) VALUES ('sp1', 'sp1', '/tmp/ws-a2a', 'Space', ${now}, ${now})`
+			);
+			sqlite.exec(
+				`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at) VALUES ('wf1', 'sp1', 'WF', ${now}, ${now})`
+			);
+			sqlite.exec(
+				`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at, updated_at) VALUES ('run-a2a', 'sp1', 'wf1', 'Run', 'in_progress', ${now}, ${now})`
+			);
+			const cycleRepo = new ChannelCycleRepository(sqlite);
+			cycleRepo.incrementCycleCount('run-a2a', 0, 5);
+			cycleRepo.incrementCycleCount('run-a2a', 0, 5);
+			const before = cycleRepo.get('run-a2a', 0)!.count;
+			expect(before).toBe(2);
+
+			// Simulate the agent-to-agent path: the TaskAgentManager's
+			// injectSubSessionMessage is called directly, not via the RPC.
+			const injectSubSession = mock(async (_sid: string, _msg: string) => {});
+			const taskAgent: TaskAgentManagerInterface = {
+				ensureTaskAgentSession: mock(async () => mockTaskWithSession),
+				injectTaskAgentMessage: mock(async () => {}),
+				getTaskAgent: mock(() => undefined),
+				injectSubSessionMessage: injectSubSession,
+			};
+
+			// Call injectSubSessionMessage directly — this is what
+			// flushPendingMessagesForTarget / the send_message tool dispatcher do.
+			await taskAgent.injectSubSessionMessage!('sess-some-agent', 'hello from an agent');
+
+			// The counter must be UNCHANGED — the RPC reset path was never invoked.
+			expect(cycleRepo.get('run-a2a', 0)!.count).toBe(before);
+
+			sqlite.close();
+		});
+
+		it('is a no-op (no error) when channelCycleResetter is not provided', async () => {
+			// Setup a handler WITHOUT the resetter argument — simulates older wiring
+			// or callers that opt out of reset-on-human-touch.
+			const mh = createMockMessageHub();
+			const taskAgent = createMockTaskAgentManager(null, mockTaskWithRun);
+			const localDb = createMockDatabase(mockTaskWithRun);
+			const localDaemonHub = { emit: mock(async () => {}) } as unknown as DaemonHub;
+			setupSpaceTaskMessageHandlers(mh.hub, taskAgent, localDb, localDaemonHub);
+
+			const result = await (mh.handlers.get('space.task.sendMessage') as RequestHandler)({
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				message: 'Please continue',
+			});
+
+			expect(result).toEqual({ ok: true });
+			// Without a resetter, no cyclesReset event should be emitted.
+			const emitCalls = (localDaemonHub.emit as ReturnType<typeof mock>).mock.calls;
+			expect(emitCalls.some((c) => c[0] === 'space.workflowRun.cyclesReset')).toBe(false);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/channel-cycle-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/channel-cycle-repository.test.ts
@@ -1,0 +1,147 @@
+/**
+ * ChannelCycleRepository Unit Tests
+ *
+ * Covers:
+ *   - incrementCycleCount: insert, update, cap-guard (existing behavior)
+ *   - reset: per-channel reset (existing behavior)
+ *   - resetAllForRun: new human-touch reset that zeroes every channel counter
+ *     for a workflow run in a single statement (Task #101)
+ *
+ * Uses an in-memory SQLite DB seeded with the full migration chain so FK
+ * constraints (channel_cycles.run_id → space_workflow_runs.id) match production.
+ */
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { ChannelCycleRepository } from '../../../../src/storage/repositories/channel-cycle-repository.ts';
+import { createSpaceTables } from '../../helpers/space-test-db.ts';
+
+let db: Database;
+let repo: ChannelCycleRepository;
+
+const RUN_ID_A = 'run-cyc-A';
+const RUN_ID_B = 'run-cyc-B';
+
+function freshDb(): Database {
+	const d = new Database(':memory:');
+	createSpaceTables(d);
+	const now = Date.now();
+	d.exec(
+		`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at) VALUES ('sp1', 'sp1', '/tmp/test', 'Test Space', ${now}, ${now})`
+	);
+	d.exec(
+		`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at) VALUES ('wf1', 'sp1', 'Test Workflow', ${now}, ${now})`
+	);
+	d.exec(
+		`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, started_at, completed_at, created_at, updated_at) VALUES ('${RUN_ID_A}', 'sp1', 'wf1', 'Run A', 'in_progress', NULL, NULL, ${now}, ${now})`
+	);
+	d.exec(
+		`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, started_at, completed_at, created_at, updated_at) VALUES ('${RUN_ID_B}', 'sp1', 'wf1', 'Run B', 'in_progress', NULL, NULL, ${now}, ${now})`
+	);
+	return d;
+}
+
+beforeEach(() => {
+	db = freshDb();
+	repo = new ChannelCycleRepository(db);
+});
+
+describe('ChannelCycleRepository — incrementCycleCount', () => {
+	test('inserts a new row with count=1 on first call', () => {
+		const ok = repo.incrementCycleCount(RUN_ID_A, 0, 5);
+		expect(ok).toBe(true);
+		const rec = repo.get(RUN_ID_A, 0);
+		expect(rec).not.toBeNull();
+		expect(rec!.count).toBe(1);
+		expect(rec!.maxCycles).toBe(5);
+	});
+
+	test('increments existing row while under cap', () => {
+		repo.incrementCycleCount(RUN_ID_A, 0, 5);
+		repo.incrementCycleCount(RUN_ID_A, 0, 5);
+		expect(repo.get(RUN_ID_A, 0)!.count).toBe(2);
+	});
+
+	test('returns false and does not increment when cap is reached', () => {
+		repo.incrementCycleCount(RUN_ID_A, 0, 2);
+		repo.incrementCycleCount(RUN_ID_A, 0, 2);
+		const third = repo.incrementCycleCount(RUN_ID_A, 0, 2);
+		expect(third).toBe(false);
+		expect(repo.get(RUN_ID_A, 0)!.count).toBe(2);
+	});
+});
+
+describe('ChannelCycleRepository — reset (single channel)', () => {
+	test('zeros count for a specific (run, channel) pair only', () => {
+		repo.incrementCycleCount(RUN_ID_A, 0, 5);
+		repo.incrementCycleCount(RUN_ID_A, 0, 5);
+		repo.incrementCycleCount(RUN_ID_A, 1, 5);
+
+		repo.reset(RUN_ID_A, 0);
+
+		expect(repo.get(RUN_ID_A, 0)!.count).toBe(0);
+		expect(repo.get(RUN_ID_A, 1)!.count).toBe(1); // untouched
+	});
+});
+
+describe('ChannelCycleRepository — resetAllForRun (human touch)', () => {
+	test('zeros count for every channel in the given run', () => {
+		repo.incrementCycleCount(RUN_ID_A, 0, 5);
+		repo.incrementCycleCount(RUN_ID_A, 0, 5);
+		repo.incrementCycleCount(RUN_ID_A, 1, 5);
+		repo.incrementCycleCount(RUN_ID_A, 2, 5);
+
+		const rowsReset = repo.resetAllForRun(RUN_ID_A);
+
+		expect(rowsReset).toBe(3);
+		expect(repo.get(RUN_ID_A, 0)!.count).toBe(0);
+		expect(repo.get(RUN_ID_A, 1)!.count).toBe(0);
+		expect(repo.get(RUN_ID_A, 2)!.count).toBe(0);
+	});
+
+	test('allows subsequent increments after reset (budget is refreshed)', () => {
+		repo.incrementCycleCount(RUN_ID_A, 0, 2);
+		repo.incrementCycleCount(RUN_ID_A, 0, 2);
+		// Cap reached — next increment would return false.
+		expect(repo.incrementCycleCount(RUN_ID_A, 0, 2)).toBe(false);
+
+		repo.resetAllForRun(RUN_ID_A);
+
+		// After reset, the cap guard allows more increments.
+		expect(repo.incrementCycleCount(RUN_ID_A, 0, 2)).toBe(true);
+		expect(repo.incrementCycleCount(RUN_ID_A, 0, 2)).toBe(true);
+		expect(repo.get(RUN_ID_A, 0)!.count).toBe(2);
+	});
+
+	test('does not affect other workflow runs', () => {
+		repo.incrementCycleCount(RUN_ID_A, 0, 5);
+		repo.incrementCycleCount(RUN_ID_B, 0, 5);
+		repo.incrementCycleCount(RUN_ID_B, 0, 5);
+
+		repo.resetAllForRun(RUN_ID_A);
+
+		expect(repo.get(RUN_ID_A, 0)!.count).toBe(0);
+		expect(repo.get(RUN_ID_B, 0)!.count).toBe(2); // untouched
+	});
+
+	test('returns 0 when no channel rows exist for the run (human touch before any cyclic traversal)', () => {
+		const rowsReset = repo.resetAllForRun(RUN_ID_A);
+		expect(rowsReset).toBe(0);
+	});
+
+	test('updates updated_at when a row is reset', () => {
+		repo.incrementCycleCount(RUN_ID_A, 0, 5);
+		const before = repo.get(RUN_ID_A, 0)!.updatedAt;
+
+		// Wait at least 1ms so Date.now() is guaranteed to advance.
+		const start = Date.now();
+		while (Date.now() === start) {
+			// spin
+		}
+
+		repo.resetAllForRun(RUN_ID_A);
+
+		const after = repo.get(RUN_ID_A, 0)!.updatedAt;
+		expect(after).toBeGreaterThan(before);
+	});
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/channel-cycle-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/channel-cycle-repository.test.ts
@@ -129,15 +129,12 @@ describe('ChannelCycleRepository — resetAllForRun (human touch)', () => {
 		expect(rowsReset).toBe(0);
 	});
 
-	test('updates updated_at when a row is reset', () => {
+	test('updates updated_at when a row is reset', async () => {
 		repo.incrementCycleCount(RUN_ID_A, 0, 5);
 		const before = repo.get(RUN_ID_A, 0)!.updatedAt;
 
-		// Wait at least 1ms so Date.now() is guaranteed to advance.
-		const start = Date.now();
-		while (Date.now() === start) {
-			// spin
-		}
+		// Yield so Date.now() has a chance to advance (1ms resolution on most platforms).
+		await new Promise((resolve) => setTimeout(resolve, 2));
 
 		repo.resetAllForRun(RUN_ID_A);
 

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -148,6 +148,20 @@ export function createSpaceTables(db: BunDatabase): void {
 	`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_gate_data_run ON gate_data(run_id)`);
 
+	// Per-channel cycle counters (migration 69). Tracks how many times each
+	// backward (cyclic) channel has been traversed in a workflow run.
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS channel_cycles (
+			run_id TEXT NOT NULL,
+			channel_index INTEGER NOT NULL,
+			count INTEGER NOT NULL DEFAULT 0,
+			max_cycles INTEGER NOT NULL DEFAULT 5,
+			updated_at INTEGER NOT NULL,
+			PRIMARY KEY (run_id, channel_index),
+			FOREIGN KEY (run_id) REFERENCES space_workflow_runs(id) ON DELETE CASCADE
+		)
+	`);
+
 	db.exec(`
 		CREATE TABLE IF NOT EXISTS node_executions (
 			id TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary

- `maxCycles` is meant to bound **consecutive autonomous cycles without human oversight**, not total cycles ever. Today, a human message mid-run leaves the counter intact, so the safety cap can fire right after a human asked the agents to continue.
- When `space.task.sendMessage` succeeds (the sole RPC boundary for human→task messages), zero every `channel_cycles` row for the task's workflow run. Both the direct task-agent path and the `@mention` sub-session path reset; agent-to-agent delivery via `flushPendingMessagesForTarget` / `injectSubSessionMessage` bypasses this RPC and is correctly unaffected.
- New bulk `ChannelCycleRepository.resetAllForRun(runId)`, new `space.workflowRun.cyclesReset` daemonHub event + structured log for observability, best-effort side-effect (does not fail the RPC on error).

## Test plan

- [x] `channel-cycle-repository.test.ts`: new unit tests for `resetAllForRun` (bulk reset, per-run isolation, cap-refresh, updated_at bump, empty-run).
- [x] `space-task-message-handlers.test.ts`: reset fires on direct + @mention paths; no reset when task has no workflow run, when injection fails, when @mentions are all unresolved, or when no resetter is wired; resetter errors are swallowed; acceptance integration test (4 autonomous cycles → human message → count is 0 → 5th cycle allowed); negative test that agent-to-agent `injectSubSessionMessage` leaves the counter unchanged.
- [x] `bun run check` (lint + typecheck + knip + session guards) passes.
- [x] Full daemon shard suite passes (11628 tests).