### PR TITLE
fix(web): keep last chat message visible above floating composer

### DIFF
--- a/packages/web/src/hooks/__tests__/useAutoScroll.test.ts
+++ b/packages/web/src/hooks/__tests__/useAutoScroll.test.ts
@@ -111,7 +111,7 @@ describe('useAutoScroll', () => {
 	});
 
 	describe('scrollToBottom', () => {
-		it('should call scrollIntoView with instant behavior by default', () => {
+		it('should call scrollIntoView with instant behavior and block: end by default', () => {
 			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
 
 			const { result } = renderHook(() =>
@@ -127,10 +127,12 @@ describe('useAutoScroll', () => {
 				result.current.scrollToBottom();
 			});
 
-			expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'instant' });
+			// block: 'end' combined with the container's scroll-padding-bottom keeps
+			// the last message above the floating composer rather than behind it.
+			expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'instant', block: 'end' });
 		});
 
-		it('should call scrollIntoView with smooth behavior when specified', () => {
+		it('should call scrollIntoView with smooth behavior and block: end when specified', () => {
 			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
 
 			const { result } = renderHook(() =>
@@ -146,7 +148,7 @@ describe('useAutoScroll', () => {
 				result.current.scrollToBottom(true);
 			});
 
-			expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth' });
+			expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth', block: 'end' });
 		});
 
 		it('should handle null endRef gracefully', () => {

--- a/packages/web/src/hooks/useAutoScroll.ts
+++ b/packages/web/src/hooks/useAutoScroll.ts
@@ -66,11 +66,15 @@ export function useAutoScroll({
 	const prevMessageCountRef = useRef<number>(0);
 	const hasScrolledOnInitialLoad = useRef(false);
 
-	// Scroll to bottom function - instant by default during streaming, smooth when user clicks
+	// Scroll to bottom function - instant by default during streaming, smooth when user clicks.
+	// Uses `block: 'end'` so the end sentinel is aligned to the container's bottom edge,
+	// which — combined with `scroll-padding-bottom` on the scroll container — parks the last
+	// message just above the floating composer instead of underneath it.
 	const scrollToBottom = useCallback(
 		(smooth = false) => {
 			endRef.current?.scrollIntoView({
 				behavior: smooth ? 'smooth' : 'instant',
+				block: 'end',
 			});
 		},
 		[endRef]

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -951,6 +951,10 @@ export default function ChatContainer({
 					style={{
 						WebkitOverflowScrolling: 'touch',
 						paddingBottom: `var(--messages-bottom-padding, ${MIN_MESSAGES_BOTTOM_PADDING_PX}px)`,
+						// Mirror paddingBottom so browser-driven scrolls (scrollIntoView,
+						// focus/anchor scroll) stop short of the floating composer instead
+						// of parking the last message behind it.
+						scrollPaddingBottom: `var(--messages-bottom-padding, ${MIN_MESSAGES_BOTTOM_PADDING_PX}px)`,
 					}}
 				>
 					{/* Worktree Choice Inline */}

--- a/packages/web/src/lib/__tests__/layout-metrics.test.ts
+++ b/packages/web/src/lib/__tests__/layout-metrics.test.ts
@@ -6,22 +6,26 @@ import {
 } from '../layout-metrics';
 
 describe('layout-metrics', () => {
-	it('allows the last message to reach the floating composer for normal footer heights', () => {
+	it('clamps to the floor when the footer is shorter than the baseline clearance', () => {
+		// Padding must always be at least MIN so the last message clears a
+		// normally-sized composer even before the live measurement has landed.
 		expect(getMessagesBottomPaddingPx(48)).toBe(MIN_MESSAGES_BOTTOM_PADDING_PX);
 		expect(getMessagesBottomPaddingPx(110)).toBe(MIN_MESSAGES_BOTTOM_PADDING_PX);
 	});
 
-	it('grows padding when the composer expands to multiple lines', () => {
-		expect(getMessagesBottomPaddingPx(134)).toBe(118);
-		expect(getMessagesBottomPaddingPx(158)).toBe(142);
+	it('keeps the last message fully above the composer when it grows', () => {
+		// Padding tracks the live footer height plus a small clearance buffer so
+		// no part of the newest message can sit behind the composer.
+		expect(getMessagesBottomPaddingPx(134)).toBe(150);
+		expect(getMessagesBottomPaddingPx(158)).toBe(174);
 	});
 
 	it('adds queue-overlay headroom rows', () => {
-		expect(getMessagesBottomPaddingPx(158, 3)).toBe(154);
+		expect(getMessagesBottomPaddingPx(158, 3)).toBe(186);
 	});
 
 	it('caps queue-overlay headroom rows', () => {
-		expect(getMessagesBottomPaddingPx(158, 99)).toBe(174);
+		expect(getMessagesBottomPaddingPx(158, 99)).toBe(206);
 	});
 
 	it('caps very tall footer padding at the hard maximum', () => {

--- a/packages/web/src/lib/layout-metrics.ts
+++ b/packages/web/src/lib/layout-metrics.ts
@@ -1,10 +1,23 @@
-// Allow the last message to slide under the floating input pill instead of
-// stopping above the whole footer stack. The footer still expands the padding
-// when it grows tall (multiline composer, queue overlays, etc.).
-export const MIN_MESSAGES_BOTTOM_PADDING_PX = 96;
-export const MAX_MESSAGES_BOTTOM_PADDING_PX = 256;
-const FLOATING_FOOTER_BASELINE_HEIGHT_PX = 112;
-const FOOTER_GROWTH_TO_PADDING_RATIO = 1;
+// The chat scroll container extends behind the floating composer so the
+// glassmorphism effect reads correctly. For auto-scroll (and any browser-driven
+// scrollIntoView) to leave the last message fully visible *above* the composer
+// — not hidden behind it — we must:
+//
+//   1. Keep enough `padding-bottom` at the end of the messages list that the
+//      last message can be pushed above the composer without the scroller
+//      running out of content room.
+//   2. Mirror the same value as `scroll-padding-bottom` on the container so
+//      `scrollIntoView({ block: 'end' })` aligns below the composer instead of
+//      under it.
+//
+// Bottom padding is derived from the live footer height plus a small clearance
+// buffer, so both multiline composer growth and queue overlay rows keep the
+// newest message visible. `MIN` / `MAX` clamp the result to reasonable values.
+
+export const MIN_MESSAGES_BOTTOM_PADDING_PX = 128;
+export const MAX_MESSAGES_BOTTOM_PADDING_PX = 320;
+/** Breathing room between the bottom edge of the last message and the composer. */
+const COMPOSER_CLEARANCE_PX = 16;
 const QUEUE_OVERLAY_ROW_HEADROOM_PX = 4;
 const MAX_QUEUE_OVERLAY_ROWS = 8;
 
@@ -23,11 +36,9 @@ export function getMessagesBottomPaddingPx(
 	const queueHeadroomPx = normalizedQueueRows * QUEUE_OVERLAY_ROW_HEADROOM_PX;
 
 	const normalizedFooterHeightPx = Math.ceil(footerHeightPx);
-	const footerGrowthPx = Math.max(0, normalizedFooterHeightPx - FLOATING_FOOTER_BASELINE_HEIGHT_PX);
-	const computedPaddingPx =
-		MIN_MESSAGES_BOTTOM_PADDING_PX +
-		Math.ceil(footerGrowthPx * FOOTER_GROWTH_TO_PADDING_RATIO) +
-		queueHeadroomPx;
+	// Ensure the last message fully clears the composer: padding must cover the
+	// composer's height plus a small clearance buffer. Below the MIN, clamp up.
+	const computedPaddingPx = normalizedFooterHeightPx + COMPOSER_CLEARANCE_PX + queueHeadroomPx;
 	return Math.min(
 		MAX_MESSAGES_BOTTOM_PADDING_PX,
 		Math.max(MIN_MESSAGES_BOTTOM_PADDING_PX, computedPaddingPx)


### PR DESCRIPTION
## Summary
- Auto-scroll was landing at the true bottom of the scroll container, which is extended beneath the floating composer for the glassmorphism effect — so the newest message sat behind the input rather than above it.
- `getMessagesBottomPaddingPx` now tracks `footerHeight + 16px` (clamped 128–320) so padding always exceeds the composer. Previously `min=96` with a `baseline=112` left a ~16px clip on every message.
- Add `scroll-padding-bottom` mirroring `--messages-bottom-padding` on the messages container so browser-driven scrolls (scrollIntoView, focus/anchor) stop short of the composer.
- `useAutoScroll` now calls `scrollIntoView({ block: 'end' })` so the end sentinel respects `scroll-padding-bottom`.

## Test plan
- [x] `bunx vitest run src/lib/__tests__/layout-metrics.test.ts src/hooks/__tests__/useAutoScroll.test.ts` passes (24/24).
- [x] `bun run check` (lint + typecheck + knip + session-guards) passes.
- [ ] Manual: send a new message — newest message is fully visible above composer (not clipped).
- [ ] Manual: expand composer to multiline — padding updates, last message still clears composer.
- [ ] Manual: scroll up, new messages arrive — auto-scroll stays disabled, no forced scroll.
- [ ] CI e2e smoke (trigger manually since this is a UI change).