### PR TITLE
feat(space): show task dependency badges in task list

### DIFF
--- a/packages/web/src/components/space/SpaceTasks.tsx
+++ b/packages/web/src/components/space/SpaceTasks.tsx
@@ -200,18 +200,104 @@ function EmptyTabState({ tab }: { tab: TaskFilterTab }) {
 	);
 }
 
+/** Max dependency badges to render inline before collapsing into a "+N" overflow chip. */
+const MAX_VISIBLE_DEPENDENCY_BADGES = 3;
+
+/**
+ * Inline dependency badges for a task. Each badge is a clickable pill showing
+ * the prerequisite task number, coloured green when the dep is `done` and
+ * gray otherwise. Deps not found in the loaded task list render as a gray
+ * badge with a "task not found" tooltip. Shows at most
+ * `MAX_VISIBLE_DEPENDENCY_BADGES` badges inline; any remainder is folded into
+ * a non-interactive `+N` overflow chip.
+ */
+function TaskDependencyBadges({
+	dependsOnIds,
+	allTasks,
+	onSelectDependency,
+}: {
+	dependsOnIds: string[];
+	allTasks: SpaceTask[];
+	onSelectDependency?: (taskId: string) => void;
+}) {
+	if (dependsOnIds.length === 0) return null;
+
+	const taskById = useMemo(() => {
+		const map = new Map<string, SpaceTask>();
+		for (const t of allTasks) map.set(t.id, t);
+		return map;
+	}, [allTasks]);
+
+	const visible = dependsOnIds.slice(0, MAX_VISIBLE_DEPENDENCY_BADGES);
+	const overflow = dependsOnIds.length - visible.length;
+
+	return (
+		<div class="flex items-center gap-1 flex-wrap mt-1" data-testid="task-dependency-badges">
+			<span class="text-xs text-gray-500 mr-0.5">deps:</span>
+			{visible.map((depId) => {
+				const dep = taskById.get(depId);
+				const isDone = dep?.status === 'done';
+				const isMissing = !dep;
+
+				const label = dep ? `#${dep.taskNumber}` : '#?';
+				const tooltip = dep ? dep.title : 'task not found';
+
+				const colorClasses = isDone
+					? 'text-green-300 bg-green-900/40 border-green-700/60 hover:bg-green-900/60'
+					: 'text-gray-300 bg-dark-700 border-dark-600 hover:bg-dark-600';
+
+				const interactive = !isMissing && !!onSelectDependency;
+
+				return (
+					<button
+						type="button"
+						key={depId}
+						data-testid="task-dependency-badge"
+						data-dep-id={depId}
+						data-dep-status={dep?.status ?? 'missing'}
+						title={tooltip}
+						disabled={!interactive}
+						onClick={(e) => {
+							e.stopPropagation();
+							if (interactive) onSelectDependency(depId);
+						}}
+						class={`inline-flex items-center gap-0.5 text-xs font-mono font-medium px-1.5 py-0.5 rounded border flex-shrink-0 transition-colors ${colorClasses} ${interactive ? 'cursor-pointer' : 'cursor-default'}`}
+					>
+						{isMissing && (
+							<span aria-hidden="true" class="text-amber-400">
+								⚠
+							</span>
+						)}
+						{label}
+					</button>
+				);
+			})}
+			{overflow > 0 && (
+				<span
+					data-testid="task-dependency-overflow"
+					class="inline-flex items-center text-xs font-mono font-medium text-gray-400 bg-dark-700 border border-dark-600 px-1.5 py-0.5 rounded flex-shrink-0"
+				>
+					+{overflow}
+				</span>
+			)}
+		</div>
+	);
+}
+
 /** Task group card with colored header, matching RoomTasks.TaskGroup style */
 function TaskGroup({
 	title,
 	count,
 	variant,
 	tasks,
+	allTasks,
 	onTaskClick,
 }: {
 	title: string;
 	count: number;
 	variant: 'default' | 'yellow' | 'purple' | 'green' | 'red' | 'gray';
 	tasks: SpaceTask[];
+	allTasks: SpaceTask[];
 	onTaskClick?: (taskId: string) => void;
 }) {
 	const headerStyles: Record<string, string> = {
@@ -252,7 +338,7 @@ function TaskGroup({
 			</div>
 			<div class="divide-y divide-dark-700">
 				{tasks.map((task) => (
-					<TaskItem key={task.id} task={task} onClick={onTaskClick} />
+					<TaskItem key={task.id} task={task} allTasks={allTasks} onClick={onTaskClick} />
 				))}
 			</div>
 		</div>
@@ -260,7 +346,15 @@ function TaskGroup({
 }
 
 /** Individual task item with left border, matching RoomTasks.TaskItem style */
-function TaskItem({ task, onClick }: { task: SpaceTask; onClick?: (taskId: string) => void }) {
+function TaskItem({
+	task,
+	allTasks,
+	onClick,
+}: {
+	task: SpaceTask;
+	allTasks: SpaceTask[];
+	onClick?: (taskId: string) => void;
+}) {
 	const isClickable = !!onClick;
 	const borderColor = STATUS_BORDER[task.status] ?? 'border-l-transparent';
 
@@ -283,6 +377,11 @@ function TaskItem({ task, onClick }: { task: SpaceTask; onClick?: (taskId: strin
 							<span class="text-xs text-gray-600">{getRelativeTime(task.updatedAt)}</span>
 						)}
 					</div>
+					<TaskDependencyBadges
+						dependsOnIds={task.dependsOn}
+						allTasks={allTasks}
+						onSelectDependency={onClick}
+					/>
 					{task.status === 'blocked' && task.result && (
 						<p class="mt-1 text-xs text-amber-400/80 truncate" data-testid="task-blocked-reason">
 							{task.result}
@@ -454,7 +553,12 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 				{filteredTasks.length === 0 ? (
 					<EmptyTabState tab={activeTab} />
 				) : (
-					<TaskGroupList tasks={filteredTasks} tab={activeTab} onTaskClick={onSelectTask} />
+					<TaskGroupList
+						tasks={filteredTasks}
+						allTasks={tasks}
+						tab={activeTab}
+						onTaskClick={onSelectTask}
+					/>
 				)}
 			</div>
 		</div>
@@ -464,10 +568,12 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 /** Groups tasks by status within the selected tab, rendering TaskGroup cards */
 function TaskGroupList({
 	tasks,
+	allTasks,
 	tab,
 	onTaskClick,
 }: {
 	tasks: SpaceTask[];
+	allTasks: SpaceTask[];
 	tab: TaskFilterTab;
 	onTaskClick?: (taskId: string) => void;
 }) {
@@ -486,6 +592,7 @@ function TaskGroupList({
 						count={groupTasks.length}
 						variant={group.variant}
 						tasks={groupTasks}
+						allTasks={allTasks}
 						onTaskClick={onTaskClick}
 					/>
 				);

--- a/packages/web/src/components/space/SpaceTasks.tsx
+++ b/packages/web/src/components/space/SpaceTasks.tsx
@@ -210,23 +210,20 @@ const MAX_VISIBLE_DEPENDENCY_BADGES = 3;
  * badge with a "task not found" tooltip. Shows at most
  * `MAX_VISIBLE_DEPENDENCY_BADGES` badges inline; any remainder is folded into
  * a non-interactive `+N` overflow chip.
+ *
+ * The dep lookup (`taskById`) is built once by the parent and passed in, so
+ * the map construction is O(N) per render of the list — not per row.
  */
 function TaskDependencyBadges({
 	dependsOnIds,
-	allTasks,
+	taskById,
 	onSelectDependency,
 }: {
 	dependsOnIds: string[];
-	allTasks: SpaceTask[];
+	taskById: ReadonlyMap<string, SpaceTask>;
 	onSelectDependency?: (taskId: string) => void;
 }) {
 	if (dependsOnIds.length === 0) return null;
-
-	const taskById = useMemo(() => {
-		const map = new Map<string, SpaceTask>();
-		for (const t of allTasks) map.set(t.id, t);
-		return map;
-	}, [allTasks]);
 
 	const visible = dependsOnIds.slice(0, MAX_VISIBLE_DEPENDENCY_BADGES);
 	const overflow = dependsOnIds.length - visible.length;
@@ -242,11 +239,14 @@ function TaskDependencyBadges({
 				const label = dep ? `#${dep.taskNumber}` : '#?';
 				const tooltip = dep ? dep.title : 'task not found';
 
-				const colorClasses = isDone
-					? 'text-green-300 bg-green-900/40 border-green-700/60 hover:bg-green-900/60'
-					: 'text-gray-300 bg-dark-700 border-dark-600 hover:bg-dark-600';
-
 				const interactive = !isMissing && !!onSelectDependency;
+
+				// Hover classes only applied when the badge is interactive —
+				// disabled buttons shouldn't carry hover state, even though
+				// browsers would ignore it.
+				const colorClasses = isDone
+					? `text-green-300 bg-green-900/40 border-green-700/60${interactive ? ' hover:bg-green-900/60' : ''}`
+					: `text-gray-300 bg-dark-700 border-dark-600${interactive ? ' hover:bg-dark-600' : ''}`;
 
 				return (
 					<button
@@ -290,14 +290,14 @@ function TaskGroup({
 	count,
 	variant,
 	tasks,
-	allTasks,
+	taskById,
 	onTaskClick,
 }: {
 	title: string;
 	count: number;
 	variant: 'default' | 'yellow' | 'purple' | 'green' | 'red' | 'gray';
 	tasks: SpaceTask[];
-	allTasks: SpaceTask[];
+	taskById: ReadonlyMap<string, SpaceTask>;
 	onTaskClick?: (taskId: string) => void;
 }) {
 	const headerStyles: Record<string, string> = {
@@ -338,7 +338,7 @@ function TaskGroup({
 			</div>
 			<div class="divide-y divide-dark-700">
 				{tasks.map((task) => (
-					<TaskItem key={task.id} task={task} allTasks={allTasks} onClick={onTaskClick} />
+					<TaskItem key={task.id} task={task} taskById={taskById} onClick={onTaskClick} />
 				))}
 			</div>
 		</div>
@@ -348,11 +348,11 @@ function TaskGroup({
 /** Individual task item with left border, matching RoomTasks.TaskItem style */
 function TaskItem({
 	task,
-	allTasks,
+	taskById,
 	onClick,
 }: {
 	task: SpaceTask;
-	allTasks: SpaceTask[];
+	taskById: ReadonlyMap<string, SpaceTask>;
 	onClick?: (taskId: string) => void;
 }) {
 	const isClickable = !!onClick;
@@ -379,7 +379,7 @@ function TaskItem({
 					</div>
 					<TaskDependencyBadges
 						dependsOnIds={task.dependsOn}
-						allTasks={allTasks}
+						taskById={taskById}
 						onSelectDependency={onClick}
 					/>
 					{task.status === 'blocked' && task.result && (
@@ -458,6 +458,14 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 		}
 		return list.sort((a, b) => b.updatedAt - a.updatedAt);
 	}, [tasks, activeTab, activeFilter]);
+
+	// Build the dep lookup once per render of the list — O(N) total rather
+	// than O(N) per row inside the badge component.
+	const taskById = useMemo(() => {
+		const map = new Map<string, SpaceTask>();
+		for (const t of tasks) map.set(t.id, t);
+		return map;
+	}, [tasks]);
 
 	if (tasks.length === 0) {
 		return (
@@ -555,7 +563,7 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 				) : (
 					<TaskGroupList
 						tasks={filteredTasks}
-						allTasks={tasks}
+						taskById={taskById}
 						tab={activeTab}
 						onTaskClick={onSelectTask}
 					/>
@@ -568,12 +576,12 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 /** Groups tasks by status within the selected tab, rendering TaskGroup cards */
 function TaskGroupList({
 	tasks,
-	allTasks,
+	taskById,
 	tab,
 	onTaskClick,
 }: {
 	tasks: SpaceTask[];
-	allTasks: SpaceTask[];
+	taskById: ReadonlyMap<string, SpaceTask>;
 	tab: TaskFilterTab;
 	onTaskClick?: (taskId: string) => void;
 }) {
@@ -592,7 +600,7 @@ function TaskGroupList({
 						count={groupTasks.length}
 						variant={group.variant}
 						tasks={groupTasks}
-						allTasks={allTasks}
+						taskById={taskById}
 						onTaskClick={onTaskClick}
 					/>
 				);

--- a/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
@@ -282,6 +282,147 @@ describe('SpaceTasks', () => {
 		expect(queryByText(/Open \(/)).toBeNull();
 	});
 
+	describe('Dependency badges', () => {
+		it('renders no badge row when a task has no dependencies', () => {
+			mockTasks.value = [makeTask('t1', 'open')];
+			const { queryByTestId } = render(<SpaceTasks spaceId="space-1" />);
+			expect(queryByTestId('task-dependency-badges')).toBeNull();
+		});
+
+		it('renders a gray badge when the dependency is not done', () => {
+			mockTasks.value = [
+				makeTask('t1', 'open', { taskNumber: 1 }),
+				makeTask('t2', 'open', { taskNumber: 2, dependsOn: ['t1'] }),
+			];
+			const { getAllByTestId } = render(<SpaceTasks spaceId="space-1" />);
+			const badges = getAllByTestId('task-dependency-badge');
+			expect(badges).toHaveLength(1);
+			expect(badges[0].textContent).toContain('#1');
+			expect(badges[0].getAttribute('data-dep-status')).toBe('open');
+			// Gray color classes applied (bg-dark-700 / text-gray-300)
+			expect(badges[0].className).toContain('text-gray-300');
+			expect(badges[0].className).not.toContain('text-green-300');
+		});
+
+		it('renders a green badge when the dependency is done', () => {
+			mockTasks.value = [
+				makeTask('t1', 'done', { taskNumber: 1 }),
+				makeTask('t2', 'open', { taskNumber: 2, dependsOn: ['t1'] }),
+			];
+			const { getAllByTestId } = render(<SpaceTasks spaceId="space-1" />);
+			const badges = getAllByTestId('task-dependency-badge');
+			expect(badges).toHaveLength(1);
+			expect(badges[0].getAttribute('data-dep-status')).toBe('done');
+			expect(badges[0].className).toContain('text-green-300');
+		});
+
+		it('renders a missing-dep badge with ⚠ when the dep id is not found', () => {
+			mockTasks.value = [makeTask('t2', 'open', { taskNumber: 2, dependsOn: ['missing-id'] })];
+			const { getAllByTestId } = render(<SpaceTasks spaceId="space-1" />);
+			const badges = getAllByTestId('task-dependency-badge');
+			expect(badges).toHaveLength(1);
+			expect(badges[0].getAttribute('data-dep-status')).toBe('missing');
+			expect(badges[0].getAttribute('title')).toBe('task not found');
+			expect(badges[0].textContent).toContain('⚠');
+			expect(badges[0].textContent).toContain('#?');
+			expect((badges[0] as HTMLButtonElement).disabled).toBe(true);
+		});
+
+		it('shows the dep task title as the tooltip', () => {
+			mockTasks.value = [
+				makeTask('t1', 'open', { taskNumber: 1, title: 'Set up auth' }),
+				makeTask('t2', 'open', { taskNumber: 2, dependsOn: ['t1'] }),
+			];
+			const { getAllByTestId } = render(<SpaceTasks spaceId="space-1" />);
+			const badges = getAllByTestId('task-dependency-badge');
+			expect(badges[0].getAttribute('title')).toBe('Set up auth');
+		});
+
+		it('navigates to the dependency task when a badge is clicked', () => {
+			mockTasks.value = [
+				makeTask('t1', 'open', { taskNumber: 1 }),
+				makeTask('t2', 'open', { taskNumber: 2, dependsOn: ['t1'] }),
+			];
+			const onSelectTask = vi.fn();
+			const { getAllByTestId } = render(
+				<SpaceTasks spaceId="space-1" onSelectTask={onSelectTask} />
+			);
+			const badges = getAllByTestId('task-dependency-badge');
+			fireEvent.click(badges[0]);
+			expect(onSelectTask).toHaveBeenCalledWith('t1');
+			// Must not also select the parent row (stopPropagation)
+			expect(onSelectTask).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not invoke onSelectTask for a missing dependency', () => {
+			mockTasks.value = [makeTask('t2', 'open', { taskNumber: 2, dependsOn: ['ghost'] })];
+			const onSelectTask = vi.fn();
+			const { getAllByTestId } = render(
+				<SpaceTasks spaceId="space-1" onSelectTask={onSelectTask} />
+			);
+			const badges = getAllByTestId('task-dependency-badge');
+			fireEvent.click(badges[0]);
+			expect(onSelectTask).not.toHaveBeenCalled();
+		});
+
+		it('shows overflow chip when there are more than 3 deps (first 3 + "+N")', () => {
+			mockTasks.value = [
+				makeTask('t1', 'done', { taskNumber: 1 }),
+				makeTask('t2', 'open', { taskNumber: 2 }),
+				makeTask('t3', 'blocked', { taskNumber: 3 }),
+				makeTask('t4', 'done', { taskNumber: 4 }),
+				makeTask('t5', 'open', { taskNumber: 5 }),
+				makeTask('target', 'open', {
+					taskNumber: 99,
+					dependsOn: ['t1', 't2', 't3', 't4', 't5'],
+				}),
+			];
+			const { getAllByTestId, getByTestId } = render(<SpaceTasks spaceId="space-1" />);
+			const badges = getAllByTestId('task-dependency-badge');
+			// Only the first 3 deps render as badges
+			expect(badges).toHaveLength(3);
+			expect(badges.map((b) => b.textContent)).toEqual(['#1', '#2', '#3']);
+			const overflow = getByTestId('task-dependency-overflow');
+			expect(overflow.textContent).toBe('+2');
+		});
+
+		it('does not show an overflow chip when there are exactly 3 deps', () => {
+			mockTasks.value = [
+				makeTask('t1', 'done', { taskNumber: 1 }),
+				makeTask('t2', 'done', { taskNumber: 2 }),
+				makeTask('t3', 'done', { taskNumber: 3 }),
+				makeTask('target', 'open', {
+					taskNumber: 99,
+					dependsOn: ['t1', 't2', 't3'],
+				}),
+			];
+			const { getAllByTestId, queryByTestId } = render(<SpaceTasks spaceId="space-1" />);
+			expect(getAllByTestId('task-dependency-badge')).toHaveLength(3);
+			expect(queryByTestId('task-dependency-overflow')).toBeNull();
+		});
+
+		it('reacts when a dependency transitions to done', () => {
+			mockTasks.value = [
+				makeTask('t1', 'in_progress', { taskNumber: 1 }),
+				makeTask('t2', 'open', { taskNumber: 2, dependsOn: ['t1'] }),
+			];
+			const { getAllByTestId, rerender } = render(<SpaceTasks spaceId="space-1" />);
+			let badges = getAllByTestId('task-dependency-badge');
+			expect(badges[0].getAttribute('data-dep-status')).toBe('in_progress');
+			expect(badges[0].className).toContain('text-gray-300');
+
+			// Dependency completes → the badge should flip to green
+			mockTasks.value = [
+				makeTask('t1', 'done', { taskNumber: 1 }),
+				makeTask('t2', 'open', { taskNumber: 2, dependsOn: ['t1'] }),
+			];
+			rerender(<SpaceTasks spaceId="space-1" />);
+			badges = getAllByTestId('task-dependency-badge');
+			expect(badges[0].getAttribute('data-dep-status')).toBe('done');
+			expect(badges[0].className).toContain('text-green-300');
+		});
+	});
+
 	describe('Awaiting-approval filter chip', () => {
 		it('is hidden when no tasks are paused at a completion action', () => {
 			mockTasks.value = [makeTask('t1', 'review')];

--- a/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
@@ -326,6 +326,8 @@ describe('SpaceTasks', () => {
 			expect(badges[0].textContent).toContain('⚠');
 			expect(badges[0].textContent).toContain('#?');
 			expect((badges[0] as HTMLButtonElement).disabled).toBe(true);
+			// Disabled badges should not carry hover: classes.
+			expect(badges[0].className).not.toMatch(/\bhover:/);
 		});
 
 		it('shows the dep task title as the tooltip', () => {
@@ -352,6 +354,8 @@ describe('SpaceTasks', () => {
 			expect(onSelectTask).toHaveBeenCalledWith('t1');
 			// Must not also select the parent row (stopPropagation)
 			expect(onSelectTask).toHaveBeenCalledTimes(1);
+			// Interactive badges carry hover: classes for feedback.
+			expect(badges[0].className).toMatch(/\bhover:/);
 		});
 
 		it('does not invoke onSelectTask for a missing dependency', () => {


### PR DESCRIPTION
## Summary
- Tasks with `dependsOn` populated now render compact, clickable badges inline under the title row in the Space task list.
- Green badge = dependency is `done`; gray = still pending/blocked/etc; missing deps render a disabled `#?` chip with a ⚠ glyph and "task not found" tooltip.
- Deps are resolved client-side against the already-loaded `spaceStore.tasks` (no API change; reactive via existing LiveQuery — badges flip to green automatically when a dep completes).
- Clicking a badge navigates to that dep via the same `onSelectTask` handler, with `stopPropagation()` so the parent row's click is not also triggered.
- Overflow: 4+ deps shows the first 3 badges plus a `+N` chip so the row stays compact.

## Test plan
- [x] `bunx vitest run src/components/space/__tests__/SpaceTasks.test.tsx` — 31 passed (11 new dependency-badge cases).
- [x] `bun run check` — lint + typecheck + knip + session-guards all clean.
- [ ] Manual smoke: open a space with a task that depends on others; verify colour flips when a dep is marked done; verify clicking a badge jumps to that task.