### PR TITLE
fix(tests): stabilize flaky CI tests (workspace-history sort, web Suspense, Node imports)

### DIFF
--- a/packages/daemon/src/storage/repositories/workspace-history-repository.ts
+++ b/packages/daemon/src/storage/repositories/workspace-history-repository.ts
@@ -46,11 +46,17 @@ export class WorkspaceHistoryRepository {
 
 	/**
 	 * List all workspace history entries sorted by last_used_at DESC.
+	 *
+	 * Secondary sort by `id DESC` ensures deterministic ordering when two rows
+	 * share the same `last_used_at` (e.g., two inserts in the same millisecond
+	 * on fast hardware). The autoincrement `id` guarantees that the most
+	 * recently inserted row wins the tiebreak, matching the user-visible
+	 * "most recently used first" contract.
 	 */
 	list(limit = 20): WorkspaceHistoryRow[] {
 		return this.db
 			.prepare(
-				'SELECT path, last_used_at, use_count FROM workspace_history ORDER BY last_used_at DESC LIMIT ?'
+				'SELECT path, last_used_at, use_count FROM workspace_history ORDER BY last_used_at DESC, id DESC LIMIT ?'
 			)
 			.all(limit) as WorkspaceHistoryRow[];
 	}

--- a/packages/daemon/tests/unit/2-handlers/rpc/workspace-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc/workspace-handlers.test.ts
@@ -87,11 +87,14 @@ describe('workspace handlers', () => {
 		});
 
 		it('returns entries sorted by last_used_at descending', async () => {
-			// Insert two entries with explicit timestamps by using the repo directly
-			repo.upsert('/workspace/older');
-			// Small delay to ensure different timestamps
-			await Bun.sleep(2);
-			repo.upsert('/workspace/newer');
+			// Insert two entries with explicit timestamps so the ordering is
+			// deterministic regardless of clock resolution or CPU load.
+			db.prepare(
+				'INSERT INTO workspace_history (path, last_used_at, use_count) VALUES (?, ?, 1)'
+			).run('/workspace/older', 1000);
+			db.prepare(
+				'INSERT INTO workspace_history (path, last_used_at, use_count) VALUES (?, ?, 1)'
+			).run('/workspace/newer', 2000);
 
 			const handler = handlers.get('workspace.history')!;
 			const result = (await handler({})) as {
@@ -101,6 +104,29 @@ describe('workspace handlers', () => {
 			expect(result.entries).toHaveLength(2);
 			expect(result.entries[0].path).toBe('/workspace/newer');
 			expect(result.entries[1].path).toBe('/workspace/older');
+		});
+
+		it('breaks ties on identical last_used_at by insertion order (newest first)', async () => {
+			// When two rows share the same last_used_at (possible on fast
+			// machines where Date.now() returns identical values for two
+			// back-to-back inserts), the autoincrement `id` is used as a
+			// deterministic tiebreaker so the most-recently-inserted row wins.
+			const sameTs = 1234;
+			db.prepare(
+				'INSERT INTO workspace_history (path, last_used_at, use_count) VALUES (?, ?, 1)'
+			).run('/workspace/first', sameTs);
+			db.prepare(
+				'INSERT INTO workspace_history (path, last_used_at, use_count) VALUES (?, ?, 1)'
+			).run('/workspace/second', sameTs);
+
+			const handler = handlers.get('workspace.history')!;
+			const result = (await handler({})) as {
+				entries: Array<{ path: string }>;
+			};
+
+			expect(result.entries).toHaveLength(2);
+			expect(result.entries[0].path).toBe('/workspace/second');
+			expect(result.entries[1].path).toBe('/workspace/first');
 		});
 
 		it('maps repository rows to WorkspaceHistoryEntry shape', async () => {

--- a/packages/web/src/islands/__tests__/ChatContainer.test.ts
+++ b/packages/web/src/islands/__tests__/ChatContainer.test.ts
@@ -5,13 +5,11 @@
  * These tests verify the fixes for UI freeze during state transitions.
  */
 
-import { readFileSync } from 'fs';
-import { resolve, dirname } from 'path';
-import { fileURLToPath } from 'url';
-import { describe, it, expect, beforeEach, vi, afterEach, beforeAll } from 'vitest';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+// Vite-native raw import — works in both Node and browser-like test environments
+// (happy-dom) without reaching for Node built-ins like `fs`/`path`/`url`, which
+// are externalized by Vite and unavailable at runtime in the test environment.
+import chatContainerSource from '../ChatContainer.tsx?raw';
 
 // Mock requestAnimationFrame for testing
 const rafCallbacks: Array<() => void> = [];
@@ -357,12 +355,7 @@ describe('ResizeObserver Integration', () => {
  *   consumes height that later disappears, causing the messages area to shift.
  */
 describe('ChatContainer Loading Skeleton CLS Prevention', () => {
-	let source: string;
-
-	beforeAll(() => {
-		const componentPath = resolve(__dirname, '../ChatContainer.tsx');
-		source = readFileSync(componentPath, 'utf-8');
-	});
+	const source = chatContainerSource;
 
 	it('skeleton header uses h-[65px] to match ChatHeader fixed height', () => {
 		// ChatHeader sets `h-[65px]`.  The skeleton must use the same value so

--- a/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
+++ b/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
@@ -8,8 +8,14 @@
  * - content priority for session/task routes
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup, waitFor } from '@testing-library/preact';
+
+// Default waitFor timeout of 1000ms is too tight for lazy-loaded routes under
+// full-suite load (CI parallel workers, Vite transform pipeline). Bumping to
+// 5s for all lazy-module assertions eliminates flakiness without slowing the
+// happy path, since waitFor returns as soon as the assertion passes.
+const LAZY_LOAD_TIMEOUT = 5000;
 import { signal } from '@preact/signals';
 import type { SpaceWorkflow, SpaceAgent, Space } from '@neokai/shared';
 
@@ -147,6 +153,20 @@ vi.mock('../../lib/router', () => ({
 
 import SpaceIsland from '../SpaceIsland';
 
+// Eagerly resolve the lazily-imported modules used by SpaceIsland so that
+// <Suspense> boundaries inside the component tree can resolve on the first
+// microtask in tests. Without this, test assertions race against Vite's
+// module transform pipeline under full-suite load.
+beforeAll(async () => {
+	await Promise.all([
+		import('../../components/space/SpaceConfigurePage'),
+		import('../../components/space/SpaceOverview'),
+		import('../../components/space/SpaceTaskPane'),
+		import('../../components/space/SpaceTasks'),
+		import('../../components/space/SpaceSessionsPage'),
+	]);
+});
+
 function makeSpace(overrides: Partial<Space> = {}): Space {
 	return {
 		id: 'space-1',
@@ -198,9 +218,12 @@ describe('SpaceIsland — route-driven views', () => {
 			<SpaceIsland spaceId="space-1" viewMode="overview" />
 		);
 		// Wait for lazy SpaceOverview to load through Suspense
-		await waitFor(() => {
-			expect(getByTestId('space-dashboard')).toBeTruthy();
-		});
+		await waitFor(
+			() => {
+				expect(getByTestId('space-dashboard')).toBeTruthy();
+			},
+			{ timeout: LAZY_LOAD_TIMEOUT }
+		);
 		// Outer wrapper
 		expect(getByTestId('space-overview-view')).toBeTruthy();
 		// Legacy tab bar is removed from overview
@@ -210,9 +233,12 @@ describe('SpaceIsland — route-driven views', () => {
 	it('renders the configure view when requested', async () => {
 		const { getByTestId } = render(<SpaceIsland spaceId="space-1" viewMode="configure" />);
 		// Wait for lazy SpaceConfigurePage to load through Suspense
-		await waitFor(() => {
-			expect(getByTestId('space-agent-list')).toBeTruthy();
-		});
+		await waitFor(
+			() => {
+				expect(getByTestId('space-agent-list')).toBeTruthy();
+			},
+			{ timeout: LAZY_LOAD_TIMEOUT }
+		);
 		expect(getByTestId('space-configure-view')).toBeTruthy();
 	});
 });
@@ -233,9 +259,12 @@ describe('SpaceIsland — configure workflow editor', () => {
 	async function renderConfigure() {
 		const result = render(<SpaceIsland spaceId="space-1" viewMode="configure" />);
 		// Wait for lazy SpaceConfigurePage to load through Suspense
-		await waitFor(() => {
-			expect(result.getByTestId('space-configure-tab-bar')).toBeTruthy();
-		});
+		await waitFor(
+			() => {
+				expect(result.getByTestId('space-configure-tab-bar')).toBeTruthy();
+			},
+			{ timeout: LAZY_LOAD_TIMEOUT }
+		);
 		return result;
 	}
 


### PR DESCRIPTION
## Summary

- **workspace-history sort** (the dev blocker): `WorkspaceHistoryRepository.list()` now orders by `last_used_at DESC, id DESC`. Same-millisecond inserts were previously undefined; the autoincrement `id` tiebreak matches the "most recently used first" contract. Test switched from a racy 2ms sleep to explicit timestamps, plus a new case covering the identical-timestamp path.
- **ChatContainer.test.ts**: swap `fs`/`path`/`url` for a Vite `?raw` import so the file loads in happy-dom instead of failing with `No such built-in module: node:`.
- **SpaceIsland.test.tsx**: preload lazy route modules in `beforeAll` and raise `waitFor` timeouts to 5s; the default 1s was too tight for lazy `SpaceConfigurePage` under full-suite load.

## Test plan

- [x] `packages/daemon/tests/unit/2-handlers/rpc/workspace-handlers.test.ts` — 18/18 pass (1 new case added)
- [x] Full daemon suite: 11656/11657 pass, 0 fail (`./scripts/test-daemon.sh`)
- [x] Full web suite: 7164/7164 pass across 3 consecutive runs (`bunx vitest run`)
- [x] `bun run check` (lint + typecheck + knip + session-guards) clean