### PR TITLE
feat(space): add 'approved' task status + workflow postApproval schema (PR 1/5)

### DIFF
--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -27,6 +27,14 @@ export const VALID_SPACE_TASK_TRANSITIONS: Record<SpaceTaskStatus, SpaceTaskStat
 	open: ['in_progress', 'blocked', 'done', 'cancelled'],
 	in_progress: ['open', 'review', 'done', 'blocked', 'cancelled'],
 	review: ['done', 'in_progress', 'cancelled', 'archived'], // Approve, reopen, cancel, or archive
+	// `approved` is the post-approval staging status added in PR 1/5 of the
+	// task-agent-as-post-approval-executor refactor. No runtime consumer
+	// transitions tasks INTO `approved` in PR 1 (intentionally: the enter
+	// edges belong to PR 2 which wires the post-approval router). The set
+	// below is conservative — enough for a manually-set `approved` row to be
+	// moved on, and enough for the `Record<SpaceTaskStatus, …>` type to
+	// accept every union member.
+	approved: ['done', 'in_progress', 'archived'],
 	done: ['in_progress', 'archived'], // Reactivate or archive
 	blocked: ['open', 'in_progress', 'archived'], // Restart allowed + archive
 	cancelled: ['open', 'in_progress', 'done', 'archived'], // Restart, complete, or archive

--- a/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
@@ -21,6 +21,10 @@ import type {
 } from '@neokai/shared';
 import { generateUUID } from '@neokai/shared';
 import type { SpaceWorkflowRepository } from '../../../storage/repositories/space-workflow-repository';
+import { Logger } from '../../logger';
+import { validatePostApproval } from '../workflows/post-approval-validator';
+
+const logger = new Logger('SpaceWorkflowManager');
 
 // ---------------------------------------------------------------------------
 // Dependency interfaces
@@ -81,6 +85,17 @@ export class SpaceWorkflowManager {
 		if (params.channels && params.channels.length > 0) {
 			this.validateChannels(params.channels);
 		}
+
+		// Hard-reject invalid `postApproval` routes at create time. Stale routes
+		// (target no longer exists) must be caught before the row lands in the
+		// DB, where they would otherwise trip the load-time warning path below.
+		if (params.postApproval !== undefined) {
+			const result = validatePostApproval({ postApproval: params.postApproval, nodes });
+			if (!result.ok) {
+				throw new WorkflowValidationError(result.error);
+			}
+		}
+
 		return this.repo.createWorkflow({
 			...params,
 			name: trimmedName,
@@ -95,11 +110,38 @@ export class SpaceWorkflowManager {
 	// -------------------------------------------------------------------------
 
 	getWorkflow(id: string): SpaceWorkflow | null {
-		return this.repo.getWorkflow(id);
+		const wf = this.repo.getWorkflow(id);
+		if (!wf) return null;
+		return this.sanitizePostApprovalForLoad(wf);
 	}
 
 	listWorkflows(spaceId: string): SpaceWorkflow[] {
-		return this.repo.listWorkflows(spaceId);
+		return this.repo.listWorkflows(spaceId).map((wf) => this.sanitizePostApprovalForLoad(wf));
+	}
+
+	/**
+	 * Load-time sanitiser for the optional `postApproval` route.
+	 *
+	 * If a persisted `postApproval` no longer resolves to a valid target (e.g.
+	 * the targeted node/agent was removed since the workflow was saved), we do
+	 * NOT fail the load — instead we strip the route from the returned object
+	 * and log a warning. Workflow loading is in the hot path (every run start,
+	 * every RPC list), so a stale route cannot be allowed to break the space.
+	 *
+	 * The DB row is untouched — re-saving the workflow via `updateWorkflow`
+	 * with `postApproval: null` is the documented way to clear a stale route.
+	 */
+	private sanitizePostApprovalForLoad(wf: SpaceWorkflow): SpaceWorkflow {
+		if (!wf.postApproval) return wf;
+		const result = validatePostApproval({ postApproval: wf.postApproval, nodes: wf.nodes });
+		if (result.ok) return wf;
+		logger.warn(
+			`disabling stale postApproval route on workflow ${wf.id} ` +
+				`(space ${wf.spaceId}): ${result.error}`
+		);
+		const sanitized: SpaceWorkflow = { ...wf };
+		delete sanitized.postApproval;
+		return sanitized;
 	}
 
 	// -------------------------------------------------------------------------
@@ -166,6 +208,33 @@ export class SpaceWorkflowManager {
 
 		if (params.channels && params.channels.length > 0) {
 			this.validateChannels(params.channels);
+		}
+
+		// Validate `postApproval` against the effective node set so a node rename
+		// that is submitted in the same update call doesn't invalidate the route
+		// spuriously. `null` clears the route (always valid); `undefined` leaves
+		// the existing route untouched — re-validate it against the new nodes so
+		// a node rename that strands an existing route is caught at update time.
+		if (params.postApproval !== undefined) {
+			if (params.postApproval !== null) {
+				const result = validatePostApproval({
+					postApproval: params.postApproval,
+					nodes: effectiveNodes,
+				});
+				if (!result.ok) {
+					throw new WorkflowValidationError(result.error);
+				}
+			}
+		} else if (existing.postApproval) {
+			const result = validatePostApproval({
+				postApproval: existing.postApproval,
+				nodes: effectiveNodes,
+			});
+			if (!result.ok) {
+				throw new WorkflowValidationError(
+					`existing postApproval route is no longer valid after update: ${result.error}`
+				);
+			}
 		}
 
 		return this.repo.updateWorkflow(id, params);

--- a/packages/daemon/src/lib/space/workflows/post-approval-template.ts
+++ b/packages/daemon/src/lib/space/workflows/post-approval-template.ts
@@ -1,0 +1,135 @@
+/**
+ * Post-approval instruction template interpolator.
+ *
+ * PR 1/5 of the task-agent-as-post-approval-executor refactor. See
+ * `docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md`
+ * §1.6 for the grammar.
+ *
+ * Grammar (intentionally minimal):
+ *   - Tokens look like `{{identifier}}`.
+ *   - `identifier` matches `[A-Za-z_][A-Za-z0-9_]*` (ASCII snake/camel).
+ *   - Substitution is **single-pass**: the replacement text for `{{foo}}` is
+ *     never re-scanned for further tokens. This prevents accidental macro
+ *     expansion (and injection) from signalled payloads.
+ *   - Unknown identifiers render as the literal token (e.g. `{{pr_url}}`)
+ *     AND emit a runtime warning so operators can see which template slot
+ *     failed to bind.
+ *   - There are **no conditionals, iteration, or helper functions** — this is
+ *     a deliberate contract, not a limitation to be expanded. If you find
+ *     yourself wanting logic in the template, the logic belongs in the code
+ *     that builds the context map.
+ *   - Values are rendered verbatim via `String(value)` — no HTML-, shell-, or
+ *     JSON-escaping. Templates are delivered to LLMs as plain text; escaping
+ *     would corrupt URLs, titles, and free-text reviewer summaries.
+ *
+ * Recognised context keys (per §1.6 of the plan — callers may supply any
+ * subset, and they may include arbitrary extra keys forwarded from an
+ * end-node's signalled `data` payload):
+ *
+ *   autonomy_level     — current space autonomy level (number as string)
+ *   task_id            — the SpaceTask UUID
+ *   task_title         — the task's `title`
+ *   reviewer_name      — slot name of the approving reviewer agent
+ *   approval_source    — 'human' | 'auto_policy' | 'agent'
+ *   space_id           — owning Space's UUID
+ *   workspace_path     — absolute workspace path for the space
+ *
+ * Every other key in `context` is made available under its own name so
+ * workflow authors can thread arbitrary payload fields (e.g. `{{pr_url}}`,
+ * `{{merge_sha}}`) through the instruction template.
+ */
+
+/**
+ * Context map passed to {@link interpolatePostApprovalTemplate}. Keys are
+ * identifier-shaped strings; values are stringified via `String(value)`.
+ */
+export type PostApprovalTemplateContext = Readonly<Record<string, unknown>>;
+
+/**
+ * Known context keys the runtime always supplies. Declared as a constant so
+ * callers (and tests) have a single source of truth when asserting coverage.
+ */
+export const POST_APPROVAL_TEMPLATE_KEYS = [
+	'autonomy_level',
+	'task_id',
+	'task_title',
+	'reviewer_name',
+	'approval_source',
+	'space_id',
+	'workspace_path',
+] as const;
+
+export type PostApprovalTemplateKey = (typeof POST_APPROVAL_TEMPLATE_KEYS)[number];
+
+/**
+ * Result of an interpolation call.
+ *
+ *   - `text`           — the rendered string.
+ *   - `missingKeys`    — identifiers that appeared in the template but were
+ *                        not present in the context. De-duplicated, in order
+ *                        of first appearance.
+ *
+ * The runtime caller should surface `missingKeys` via its logger (and, in
+ * dev, via the session so the LLM sees the problem in its conversation).
+ */
+export interface PostApprovalTemplateResult {
+	text: string;
+	missingKeys: string[];
+}
+
+/**
+ * Matches `{{identifier}}` with optional internal whitespace, e.g.
+ *   `{{pr_url}}`     → group 1 = "pr_url"
+ *   `{{ task_id }}`  → group 1 = "task_id"
+ *
+ * The identifier grammar matches the plan: ASCII letters, digits, underscore,
+ * no leading digit. No dotted paths, no brackets, no helpers.
+ */
+const TOKEN_PATTERN = /\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/g;
+
+/**
+ * Interpolate a post-approval instruction template in a single pass.
+ *
+ * See file-level docstring for the full grammar contract.
+ *
+ * @param template Raw instruction text. An empty or whitespace-only string
+ *                 round-trips unchanged with no missing keys.
+ * @param context  Map of identifier → value. Values are rendered via
+ *                 `String(value)`; `null`/`undefined` are treated as "missing"
+ *                 so the token stays literal and the key is reported.
+ */
+export function interpolatePostApprovalTemplate(
+	template: string,
+	context: PostApprovalTemplateContext
+): PostApprovalTemplateResult {
+	if (!template) {
+		return { text: template ?? '', missingKeys: [] };
+	}
+
+	const missingSeen = new Set<string>();
+	const missingKeys: string[] = [];
+
+	// Use the String.prototype.replace callback form — it iterates matches
+	// left-to-right in a single pass and never re-scans the replacement text.
+	const text = template.replace(TOKEN_PATTERN, (match, rawKey: string) => {
+		const key = rawKey;
+		if (Object.prototype.hasOwnProperty.call(context, key)) {
+			const value = (context as Record<string, unknown>)[key];
+			if (value === undefined || value === null) {
+				if (!missingSeen.has(key)) {
+					missingSeen.add(key);
+					missingKeys.push(key);
+				}
+				return match;
+			}
+			return String(value);
+		}
+		if (!missingSeen.has(key)) {
+			missingSeen.add(key);
+			missingKeys.push(key);
+		}
+		return match;
+	});
+
+	return { text, missingKeys };
+}

--- a/packages/daemon/src/lib/space/workflows/post-approval-validator.ts
+++ b/packages/daemon/src/lib/space/workflows/post-approval-validator.ts
@@ -1,0 +1,127 @@
+/**
+ * Post-approval validator
+ *
+ * PR 1/5 of the task-agent-as-post-approval-executor refactor. See
+ * `docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md`
+ * §1.5.
+ *
+ * A workflow's optional `postApproval` route declares which agent should act on
+ * the end-node's approval signal. The route's `targetAgent` must resolve to
+ * either:
+ *   - the literal string `'task-agent'` (the orchestration Task Agent), or
+ *   - the `name` of any `WorkflowNodeAgent` declared in the workflow's nodes.
+ *
+ * Any other value is invalid — typically the result of stale config after a
+ * node rename or deletion. This validator is called from:
+ *   - `SpaceWorkflowManager.createWorkflow` / `.updateWorkflow` — hard-reject on
+ *     an invalid route (surfaced as `WorkflowValidationError`).
+ *   - `SpaceWorkflowManager.getWorkflow` — log a warning and disable the route
+ *     for the returned workflow, so a stale persisted config cannot break
+ *     runtime load.
+ *
+ * No runtime consumer reads `postApproval` in this PR — PR 2 wires up the
+ * `PostApprovalRouter` and the `mark_complete` tool.
+ */
+
+import type { PostApprovalRoute, WorkflowNode, WorkflowNodeInput } from '@neokai/shared';
+
+/**
+ * Literal target name that always resolves to the orchestration Task Agent.
+ * The Task Agent is a virtual node that is never stored in
+ * `space_workflow_nodes` — it is injected at runtime — so it cannot match via
+ * the node-agent-name path.
+ */
+export const POST_APPROVAL_TASK_AGENT_TARGET = 'task-agent';
+
+/**
+ * Input shape accepted by the validator. Both the persisted `WorkflowNode`
+ * shape and the create-time `WorkflowNodeInput` shape are supported so the
+ * validator can be called from both the `create` and `update` code paths of
+ * `SpaceWorkflowManager` without re-normalising.
+ */
+export interface PostApprovalValidationInput {
+	/** Optional route to validate. Missing or `undefined` means "no route" → valid. */
+	postApproval?: PostApprovalRoute;
+	/** Workflow nodes — used to collect eligible node-agent target names. */
+	nodes: Array<WorkflowNode | WorkflowNodeInput>;
+}
+
+/** Discriminated result — cheaper than throwing in hot paths. */
+export type PostApprovalValidationResult =
+	| { ok: true }
+	| { ok: false; error: string; eligibleTargets: string[] };
+
+/**
+ * Collect the set of legal `targetAgent` strings for a workflow, in stable
+ * iteration order:
+ *   1. `'task-agent'` (the virtual Task Agent node), always eligible.
+ *   2. Every `WorkflowNodeAgent.name` in document order.
+ *
+ * Exported because the error reporter (`SpaceWorkflowManager`) and the load-
+ * time warning path may want to surface the list to the user/LLM.
+ */
+export function collectEligiblePostApprovalTargets(
+	nodes: Array<WorkflowNode | WorkflowNodeInput>
+): string[] {
+	const targets: string[] = [POST_APPROVAL_TASK_AGENT_TARGET];
+	const seen = new Set<string>(targets);
+	for (const node of nodes) {
+		const agents = node.agents ?? [];
+		for (const agent of agents) {
+			const name = typeof agent?.name === 'string' ? agent.name.trim() : '';
+			if (!name || seen.has(name)) continue;
+			seen.add(name);
+			targets.push(name);
+		}
+	}
+	return targets;
+}
+
+/**
+ * Validate a workflow's `postApproval` route against its node graph.
+ *
+ *   - `route === undefined` → valid (post-approval is optional).
+ *   - `route.targetAgent === 'task-agent'` → valid.
+ *   - `route.targetAgent` matches some `nodes[*].agents[*].name` → valid.
+ *   - Any other `targetAgent` → invalid; the error message lists every
+ *     eligible target so the caller can surface a helpful repair hint.
+ *
+ * This does NOT validate `route.instructions` — an empty string is a legal
+ * no-op template. Template syntax (`{{identifier}}`) is checked lazily at
+ * interpolation time by `post-approval-template.ts`; we do not pre-validate it
+ * here because unknown tokens are a runtime concern (the runtime context is
+ * not known until an approval signal actually fires).
+ */
+export function validatePostApproval(
+	input: PostApprovalValidationInput
+): PostApprovalValidationResult {
+	const route = input.postApproval;
+	if (!route) {
+		return { ok: true };
+	}
+
+	const targetAgent = typeof route.targetAgent === 'string' ? route.targetAgent.trim() : '';
+	const eligible = collectEligiblePostApprovalTargets(input.nodes);
+
+	if (!targetAgent) {
+		return {
+			ok: false,
+			error:
+				`postApproval.targetAgent must be a non-empty string; ` +
+				`eligible targets: ${eligible.map((t) => `"${t}"`).join(', ')}`,
+			eligibleTargets: eligible,
+		};
+	}
+
+	if (eligible.includes(targetAgent)) {
+		return { ok: true };
+	}
+
+	return {
+		ok: false,
+		error:
+			`postApproval.targetAgent "${targetAgent}" does not match any node agent or the ` +
+			`orchestration Task Agent; eligible targets: ${eligible.map((t) => `"${t}"`).join(', ')}`,
+		eligibleTargets: eligible,
+	};
+}

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -292,6 +292,20 @@ export class SpaceTaskRepository {
 			fields.push('reported_summary = ?');
 			values.push(params.reportedSummary ?? null);
 		}
+		// Post-approval columns (PR 1/5 of the post-approval refactor — no
+		// runtime consumer yet; PR 2 wires them up).
+		if (params.postApprovalSessionId !== undefined) {
+			fields.push('post_approval_session_id = ?');
+			values.push(params.postApprovalSessionId ?? null);
+		}
+		if (params.postApprovalStartedAt !== undefined) {
+			fields.push('post_approval_started_at = ?');
+			values.push(params.postApprovalStartedAt ?? null);
+		}
+		if (params.postApprovalBlockedReason !== undefined) {
+			fields.push('post_approval_blocked_reason = ?');
+			values.push(params.postApprovalBlockedReason ?? null);
+		}
 
 		if (fields.length > 0) {
 			fields.push('updated_at = ?');
@@ -438,6 +452,10 @@ export class SpaceTaskRepository {
 			pendingCompletionReason: (row.pending_completion_reason as string | null) ?? null,
 			reportedStatus: (row.reported_status as SpaceTask['reportedStatus']) ?? null,
 			reportedSummary: (row.reported_summary as string | null) ?? null,
+			// Post-approval columns (PR 1/5 — schema only).
+			postApprovalSessionId: (row.post_approval_session_id as string | null) ?? null,
+			postApprovalStartedAt: (row.post_approval_started_at as number | null) ?? null,
+			postApprovalBlockedReason: (row.post_approval_blocked_reason as string | null) ?? null,
 			createdAt: row.created_at as number,
 			startedAt: (row.started_at as number | null) ?? null,
 			completedAt: (row.completed_at as number | null) ?? null,

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -374,6 +374,13 @@ export class SpaceTaskRepository {
 	 * Returns tasks with status `in_progress` or `blocked` that have a
 	 * non-null `task_agent_session_id`. Used by `TaskAgentManager.rehydrate()` on
 	 * daemon restart to find Task Agent sessions that need to be restarted.
+	 *
+	 * NOTE (PR 2 of post-approval refactor): when the `approved` status starts
+	 * carrying `post_approval_session_id` for in-flight post-approval work, the
+	 * status filter here must widen to include `'approved'` so those sessions
+	 * rehydrate too. This PR (1/5) is schema-only and no task can reach
+	 * `'approved'` yet, so keeping the current filter preserves the
+	 * no-behaviour-change invariant.
 	 */
 	listActiveWithTaskAgentSession(): SpaceTask[] {
 		const stmt = this.db.prepare(

--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -25,6 +25,7 @@ import type {
 	WorkflowChannel,
 	Gate,
 	CreateSpaceWorkflowParams,
+	PostApprovalRoute,
 	UpdateSpaceWorkflowParams,
 } from '@neokai/shared';
 
@@ -47,6 +48,12 @@ interface WorkflowRow {
 	template_hash: string | null;
 	instructions: string | null;
 	completion_autonomy_level: number;
+	/**
+	 * JSON-encoded `PostApprovalRoute` — null when the workflow has no
+	 * post-approval route configured. Added in PR 1/5 of the post-approval
+	 * refactor; no runtime consumer reads this yet.
+	 */
+	post_approval?: string | null;
 	created_at: number;
 	updated_at: number;
 }
@@ -130,6 +137,10 @@ function rowToWorkflow(row: WorkflowRow, nodes: WorkflowNode[]): SpaceWorkflow {
 	if (row.template_name) wf.templateName = row.template_name;
 	if (row.template_hash) wf.templateHash = row.template_hash;
 	if (row.instructions) wf.instructions = row.instructions;
+	const postApproval = parseJson<PostApprovalRoute | null>(row.post_approval ?? null, null);
+	if (postApproval && typeof postApproval === 'object') {
+		wf.postApproval = postApproval;
+	}
 	return wf;
 }
 
@@ -170,11 +181,12 @@ export class SpaceWorkflowRepository {
 			params.channels && params.channels.length > 0 ? JSON.stringify(params.channels) : null;
 		const gatesJson = params.gates && params.gates.length > 0 ? JSON.stringify(params.gates) : null;
 		const layoutJson = params.layout ? JSON.stringify(params.layout) : null;
+		const postApprovalJson = params.postApproval ? JSON.stringify(params.postApproval) : null;
 
 		this.db
 			.prepare(
-				`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, end_node_id, tags, channels, gates, layout, template_name, template_hash, instructions, completion_autonomy_level, created_at, updated_at)
-	         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+				`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, end_node_id, tags, channels, gates, layout, template_name, template_hash, instructions, completion_autonomy_level, post_approval, created_at, updated_at)
+	         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			)
 			.run(
 				workflowId,
@@ -191,6 +203,7 @@ export class SpaceWorkflowRepository {
 				params.templateHash ?? null,
 				params.instructions ?? null,
 				completionAutonomyLevel,
+				postApprovalJson,
 				now,
 				now
 			);
@@ -293,6 +306,11 @@ export class SpaceWorkflowRepository {
 		if (params.completionAutonomyLevel !== undefined) {
 			fields.push('completion_autonomy_level = ?');
 			values.push(params.completionAutonomyLevel);
+		}
+
+		if (params.postApproval !== undefined) {
+			fields.push('post_approval = ?');
+			values.push(params.postApproval ? JSON.stringify(params.postApproval) : null);
 		}
 
 		const hasNodeReplacement = params.nodes !== undefined;

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -6920,8 +6920,12 @@ export function runMigration102(db: BunDatabase): void {
  */
 export function runMigration103(db: BunDatabase): void {
 	if (!tableExists(db, 'space_tasks')) {
-		// Very fresh DB — `createTables` will create the table with the new
-		// schema already in place, so this migration has nothing to do.
+		// No `space_tasks` yet — nothing to rebuild. In the full
+		// `runMigrations` pipeline M29 creates this table long before M103
+		// runs, so this branch only fires when `runMigration103` is invoked
+		// standalone on a DB that has not had M29 applied (tests / dev
+		// tooling). Skipping here is safe: once M29 creates the table any
+		// later M103 invocation will enter the rebuild path below.
 		return;
 	}
 

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -467,6 +467,16 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	//   cleanup. Runs strictly *after* M101 so the seed step still has the
 	//   legacy data to copy.
 	runMigration102(db);
+
+	// Migration 103: PR 1/5 of the task-agent-as-post-approval-executor refactor
+	//   (docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md).
+	//   Schema-only — no runtime consumer yet.
+	//   Step 1: widen the `space_tasks.status` CHECK constraint to include the
+	//     new `'approved'` value.
+	//   Steps 2–4: add three nullable columns on `space_tasks`:
+	//     `post_approval_session_id`, `post_approval_started_at`,
+	//     `post_approval_blocked_reason`.
+	runMigration103(db);
 }
 
 /**
@@ -6878,5 +6888,208 @@ export function runMigration102(db: BunDatabase): void {
 		).run(JSON.stringify(settings));
 	} catch {
 		// Swallow — same policy as runMigration12.
+	}
+}
+
+/**
+ * Migration 103 — PR 1/5 of the task-agent-as-post-approval-executor refactor.
+ *
+ * See `docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md`
+ * (§1.3 status, §4.4 migration). Schema-only — no runtime consumer reads the
+ * `'approved'` value or the three new columns in this PR. PR 2 wires them up.
+ *
+ * Changes:
+ *   1. Widen the `space_tasks.status` CHECK constraint so `'approved'` is a
+ *      legal status value alongside the existing
+ *      `open | in_progress | review | done | blocked | cancelled | archived`.
+ *      SQLite cannot ALTER a CHECK constraint in place, so the full
+ *      table-rebuild pattern used by M99 is reused here.
+ *   2. Add `space_tasks.post_approval_session_id TEXT NULL`.
+ *   3. Add `space_tasks.post_approval_started_at INTEGER NULL`.
+ *   4. Add `space_tasks.post_approval_blocked_reason TEXT NULL`.
+ *   5. Add `space_workflows.post_approval TEXT NULL` — stores the optional
+ *      `PostApprovalRoute` as a JSON blob so workflow CRUD round-trips preserve
+ *      the new field. Shape: `{"targetAgent": "...", "instructions": "..."}`.
+ *
+ * No backfill: at migration time all existing rows have statuses that do not
+ * include `'approved'`, and the three new columns are nullable.
+ *
+ * Idempotent: re-running is a no-op — the rebuild is skipped when the current
+ * CREATE TABLE SQL already advertises `'approved'`, and each ADD COLUMN is
+ * guarded by `tableHasColumn`.
+ */
+export function runMigration103(db: BunDatabase): void {
+	if (!tableExists(db, 'space_tasks')) {
+		// Very fresh DB — `createTables` will create the table with the new
+		// schema already in place, so this migration has nothing to do.
+		return;
+	}
+
+	// ─────────────────────────────────────────────────────────────────────────
+	// Step 1: rebuild `space_tasks` to widen the `status` CHECK constraint.
+	// ─────────────────────────────────────────────────────────────────────────
+	const master = db
+		.prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='space_tasks'`)
+		.get() as { sql?: string } | undefined;
+	const currentSql = master?.sql ?? '';
+
+	// Detection: rebuild needed if the CHECK clause does not already include
+	// `'approved'`. We match on the substring so the migration is robust to
+	// whitespace / ordering differences between older and newer table rebuilds.
+	const hasApprovedInCheck =
+		currentSql.includes('status IN (') && /status\s+IN\s*\([^)]*'approved'/.test(currentSql);
+
+	if (currentSql && !hasApprovedInCheck) {
+		// Copy every column that exists on the current schema — the intersection
+		// of the post-M99 baseline and any extra columns added by later
+		// migrations. This keeps the rebuild safe when the running DB has a
+		// slightly different shape than the one used in tests.
+		const baseColumns = [
+			'id',
+			'space_id',
+			'task_number',
+			'title',
+			'description',
+			'status',
+			'priority',
+			'labels',
+			'workflow_run_id',
+			'preferred_workflow_id',
+			'created_by_task_id',
+			'result',
+			'depends_on',
+			'active_session',
+			'task_agent_session_id',
+			'approval_source',
+			'approval_reason',
+			'approved_at',
+			'block_reason',
+			'archived_at',
+			'created_at',
+			'started_at',
+			'completed_at',
+			'updated_at',
+			'pending_action_index',
+			'pending_checkpoint_type',
+			'reported_status',
+			'reported_summary',
+			'pending_completion_submitted_by_node_id',
+			'pending_completion_submitted_at',
+			'pending_completion_reason',
+		];
+		const existingColumns = new Set(
+			(db.prepare(`PRAGMA table_info('space_tasks')`).all() as Array<{ name: string }>).map(
+				(r) => r.name
+			)
+		);
+		const copyColumns = baseColumns.filter((c) => existingColumns.has(c));
+		const copyColsSql = copyColumns.join(', ');
+
+		// Preserve the indexes that exist on the current table so the rebuild
+		// doesn't silently drop them. Mirrors the M99 rebuild.
+		const existingIndexDdl = (
+			db
+				.prepare(
+					`SELECT sql FROM sqlite_master
+					 WHERE type='index' AND tbl_name='space_tasks' AND sql IS NOT NULL`
+				)
+				.all() as Array<{ sql: string }>
+		)
+			.map((r) => r.sql)
+			.filter((sql) => !!sql);
+
+		db.exec('PRAGMA foreign_keys = OFF');
+		db.exec('BEGIN');
+		try {
+			db.exec(`
+				CREATE TABLE space_tasks_m103_new (
+					id TEXT PRIMARY KEY,
+					space_id TEXT NOT NULL,
+					task_number INTEGER NOT NULL,
+					title TEXT NOT NULL,
+					description TEXT NOT NULL DEFAULT '',
+					status TEXT NOT NULL DEFAULT 'open'
+						CHECK(status IN ('open', 'in_progress', 'review', 'approved', 'done', 'blocked', 'cancelled', 'archived')),
+					priority TEXT NOT NULL DEFAULT 'normal'
+						CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+					labels TEXT NOT NULL DEFAULT '[]',
+					workflow_run_id TEXT,
+					preferred_workflow_id TEXT,
+					created_by_task_id TEXT,
+					result TEXT,
+					depends_on TEXT NOT NULL DEFAULT '[]',
+					active_session TEXT
+						CHECK(active_session IN ('worker', 'leader')),
+					task_agent_session_id TEXT,
+					approval_source TEXT,
+					approval_reason TEXT,
+					approved_at INTEGER,
+					block_reason TEXT,
+					archived_at INTEGER,
+					created_at INTEGER NOT NULL,
+					started_at INTEGER,
+					completed_at INTEGER,
+					updated_at INTEGER NOT NULL,
+					pending_action_index INTEGER DEFAULT NULL,
+					pending_checkpoint_type TEXT DEFAULT NULL
+						CHECK(pending_checkpoint_type IN ('completion_action', 'gate', 'task_completion')),
+					reported_status TEXT DEFAULT NULL
+						CHECK(reported_status IS NULL OR reported_status IN ('done', 'blocked', 'cancelled')),
+					reported_summary TEXT DEFAULT NULL,
+					pending_completion_submitted_by_node_id TEXT DEFAULT NULL,
+					pending_completion_submitted_at INTEGER DEFAULT NULL,
+					pending_completion_reason TEXT DEFAULT NULL,
+					FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+					FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL
+				)
+			`);
+			db.exec(
+				`INSERT INTO space_tasks_m103_new (${copyColsSql}) SELECT ${copyColsSql} FROM space_tasks`
+			);
+			db.exec(`DROP TABLE space_tasks`);
+			db.exec(`ALTER TABLE space_tasks_m103_new RENAME TO space_tasks`);
+			for (const ddl of existingIndexDdl) {
+				const normalized = ddl.replace(
+					/^CREATE (UNIQUE )?INDEX /i,
+					(_m, unique) => `CREATE ${unique ?? ''}INDEX IF NOT EXISTS `
+				);
+				db.exec(normalized);
+			}
+			db.exec('COMMIT');
+		} catch (err) {
+			db.exec('ROLLBACK');
+			throw err;
+		} finally {
+			db.exec('PRAGMA foreign_keys = ON');
+		}
+	}
+
+	// ─────────────────────────────────────────────────────────────────────────
+	// Steps 2–4: add the three post-approval columns. Nullable, no backfill.
+	// ─────────────────────────────────────────────────────────────────────────
+	if (!tableHasColumn(db, 'space_tasks', 'post_approval_session_id')) {
+		db.exec(`ALTER TABLE space_tasks ADD COLUMN post_approval_session_id TEXT DEFAULT NULL`);
+	}
+	if (!tableHasColumn(db, 'space_tasks', 'post_approval_started_at')) {
+		db.exec(`ALTER TABLE space_tasks ADD COLUMN post_approval_started_at INTEGER DEFAULT NULL`);
+	}
+	if (!tableHasColumn(db, 'space_tasks', 'post_approval_blocked_reason')) {
+		db.exec(`ALTER TABLE space_tasks ADD COLUMN post_approval_blocked_reason TEXT DEFAULT NULL`);
+	}
+
+	// ─────────────────────────────────────────────────────────────────────────
+	// Step 5: add `space_workflows.post_approval` JSON column.
+	//
+	// Stores the optional `PostApprovalRoute` object as a JSON string. NULL
+	// (the default) means the workflow has no post-approval route configured.
+	// Guarded so re-runs are no-ops, and skipped when the parent table does
+	// not yet exist (very fresh DB — the later seeders will pick up the new
+	// column once migration 29 has created the table).
+	// ─────────────────────────────────────────────────────────────────────────
+	if (
+		tableExists(db, 'space_workflows') &&
+		!tableHasColumn(db, 'space_workflows', 'post_approval')
+	) {
+		db.exec(`ALTER TABLE space_workflows ADD COLUMN post_approval TEXT DEFAULT NULL`);
 	}
 }

--- a/packages/daemon/tests/unit/1-core/lib/space-workflow-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-workflow-manager.test.ts
@@ -292,4 +292,120 @@ describe('SpaceWorkflowManager', () => {
 			);
 		});
 	});
+
+	describe('postApproval validation', () => {
+		it('accepts a postApproval route targeting "task-agent" on create', () => {
+			const wf = manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'WF',
+				nodes: [{ id: 'node-1', name: 'Step', agents: [{ agentId: 'agent-1', name: 'coder' }] }],
+				completionAutonomyLevel: 3,
+				postApproval: { targetAgent: 'task-agent', instructions: 'merge {{pr_url}}' },
+			});
+			expect(wf.postApproval).toEqual({
+				targetAgent: 'task-agent',
+				instructions: 'merge {{pr_url}}',
+			});
+		});
+
+		it('accepts a postApproval route targeting a node agent name', () => {
+			const wf = manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'WF',
+				nodes: [{ id: 'node-1', name: 'Coding', agents: [{ agentId: 'agent-1', name: 'coder' }] }],
+				completionAutonomyLevel: 3,
+				postApproval: { targetAgent: 'coder', instructions: '' },
+			});
+			expect(wf.postApproval?.targetAgent).toBe('coder');
+		});
+
+		it('rejects a postApproval route whose target does not resolve', () => {
+			expect(() =>
+				manager.createWorkflow({
+					spaceId: 'space-1',
+					name: 'WF',
+					nodes: [
+						{ id: 'node-1', name: 'Coding', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+					],
+					completionAutonomyLevel: 3,
+					postApproval: { targetAgent: 'ghost', instructions: '' },
+				})
+			).toThrow('"ghost"');
+		});
+
+		it('re-validates an existing postApproval route when nodes are replaced', () => {
+			const created = manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'WF',
+				nodes: [
+					{
+						id: 'node-1',
+						name: 'Coding',
+						agents: [{ agentId: 'agent-1', name: 'reviewer' }],
+					},
+				],
+				completionAutonomyLevel: 3,
+				postApproval: { targetAgent: 'reviewer', instructions: '' },
+			});
+
+			// Replace nodes so `reviewer` is no longer a declared agent.
+			expect(() =>
+				manager.updateWorkflow(created.id, {
+					nodes: [
+						{
+							id: 'node-2',
+							name: 'Coding',
+							agents: [{ agentId: 'agent-2', name: 'coder' }],
+						},
+					],
+				})
+			).toThrow('existing postApproval route is no longer valid');
+		});
+
+		it('allows clearing the postApproval route with null', () => {
+			const created = manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'WF',
+				nodes: [{ id: 'node-1', name: 'Coding', agents: [{ agentId: 'agent-1', name: 'coder' }] }],
+				completionAutonomyLevel: 3,
+				postApproval: { targetAgent: 'task-agent', instructions: 'hi' },
+			});
+			expect(created.postApproval).toBeDefined();
+
+			const cleared = manager.updateWorkflow(created.id, { postApproval: null });
+			expect(cleared?.postApproval).toBeUndefined();
+		});
+
+		it('strips a stale postApproval route on read instead of failing', () => {
+			// Persist a route that is valid at create time, then corrupt the DB
+			// to simulate a post-hoc node rename that was never re-validated.
+			const wf = manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'WF',
+				nodes: [
+					{
+						id: 'node-1',
+						name: 'Coding',
+						agents: [{ agentId: 'agent-1', name: 'reviewer' }],
+					},
+				],
+				completionAutonomyLevel: 3,
+				postApproval: { targetAgent: 'reviewer', instructions: '' },
+			});
+
+			// Rename the node agent directly in the config JSON to make the
+			// saved route stale. Manager.getWorkflow should sanitise on read.
+			const staleCfg = JSON.stringify({
+				agents: [{ agentId: 'agent-1', name: 'coder' }],
+			});
+			db.prepare(`UPDATE space_workflow_nodes SET config = ? WHERE workflow_id = ?`).run(
+				staleCfg,
+				wf.id
+			);
+
+			const fetched = manager.getWorkflow(wf.id);
+			expect(fetched).not.toBeNull();
+			expect(fetched?.postApproval).toBeUndefined();
+		});
+	});
 });

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-export-import-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-export-import-handlers.test.ts
@@ -83,6 +83,7 @@ function createSchema(db: Database): void {
 			template_hash TEXT DEFAULT NULL,
 			instructions TEXT DEFAULT NULL,
 			completion_autonomy_level INTEGER NOT NULL DEFAULT 3,
+			post_approval TEXT DEFAULT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-103_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-103_test.ts
@@ -1,0 +1,419 @@
+/**
+ * Migration 103 Tests — PR 1/5 of the task-agent-as-post-approval-executor refactor.
+ *
+ * Migration 103:
+ *   - Rebuilds `space_tasks` to widen the `status` CHECK constraint so it
+ *     accepts the new `'approved'` value.
+ *   - Adds three nullable columns to `space_tasks`:
+ *       `post_approval_session_id`, `post_approval_started_at`,
+ *       `post_approval_blocked_reason`.
+ *   - Adds `space_workflows.post_approval` (nullable JSON text column) that
+ *     stores the optional `PostApprovalRoute`.
+ *
+ * See `docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md`
+ * §1.1–1.2 for the schema contract. This is purely schema — no runtime
+ * consumer reads these columns yet (PR 2 wires them up).
+ *
+ * Covers:
+ *   - Fresh, fully-migrated DB — the widened CHECK accepts `'approved'` and
+ *     the new columns exist on both tables.
+ *   - Pre-M103 schema with existing rows — the table rebuild preserves
+ *     every row unchanged, including all status values.
+ *   - Pre-M103 indexes on `space_tasks` survive the rebuild.
+ *   - Running the migration a second time is a no-op (idempotent).
+ *   - A `space_workflows` row round-trips `post_approval` as NULL by default
+ *     and as JSON when written.
+ *   - Legacy `status='failed'` is still rejected (the widening only adds
+ *     `'approved'`, it does not accept arbitrary strings).
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigration103, runMigrations } from '../../../../../src/storage/schema/migrations.ts';
+
+function columnNames(db: BunDatabase, table: string): string[] {
+	const rows = db.prepare(`PRAGMA table_info('${table}')`).all() as Array<{ name: string }>;
+	return rows.map((r) => r.name);
+}
+
+function indexNames(db: BunDatabase, table: string): string[] {
+	const rows = db
+		.prepare(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name=? AND sql IS NOT NULL`)
+		.all(table) as Array<{ name: string }>;
+	return rows.map((r) => r.name);
+}
+
+function seedPreM103Schema(db: BunDatabase): void {
+	db.exec('PRAGMA foreign_keys = OFF');
+	// Minimal parent tables (only what the FKs need). We create both tables
+	// that `space_tasks` references so post-rebuild inserts work even with
+	// foreign_keys=ON, mirroring production.
+	db.exec(`
+		CREATE TABLE spaces (
+			id TEXT PRIMARY KEY,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		)
+	`);
+	db.exec(`
+		CREATE TABLE space_workflow_runs (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		)
+	`);
+	// Pre-M103 space_tasks — note the CHECK clause does NOT include 'approved'
+	// and none of the three post_approval_* columns exist yet. This is the
+	// shape M103 must rebuild.
+	db.exec(`
+		CREATE TABLE space_tasks (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			task_number INTEGER NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'open'
+				CHECK(status IN ('open', 'in_progress', 'review', 'done', 'blocked', 'cancelled', 'archived')),
+			priority TEXT NOT NULL DEFAULT 'normal'
+				CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+			labels TEXT NOT NULL DEFAULT '[]',
+			workflow_run_id TEXT,
+			preferred_workflow_id TEXT,
+			created_by_task_id TEXT,
+			result TEXT,
+			depends_on TEXT NOT NULL DEFAULT '[]',
+			active_session TEXT
+				CHECK(active_session IN ('worker', 'leader')),
+			task_agent_session_id TEXT,
+			approval_source TEXT,
+			approval_reason TEXT,
+			approved_at INTEGER,
+			block_reason TEXT,
+			archived_at INTEGER,
+			created_at INTEGER NOT NULL,
+			started_at INTEGER,
+			completed_at INTEGER,
+			updated_at INTEGER NOT NULL,
+			pending_action_index INTEGER DEFAULT NULL,
+			pending_checkpoint_type TEXT DEFAULT NULL
+				CHECK(pending_checkpoint_type IN ('completion_action', 'gate', 'task_completion')),
+			pending_completion_submitted_by_node_id TEXT DEFAULT NULL,
+			pending_completion_submitted_at INTEGER DEFAULT NULL,
+			pending_completion_reason TEXT DEFAULT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+		)
+	`);
+	// Two pre-existing indexes — M103 must preserve them across the rebuild.
+	db.exec(
+		`CREATE UNIQUE INDEX idx_space_tasks_space_task_number ON space_tasks(space_id, task_number)`
+	);
+	db.exec(`CREATE INDEX idx_space_tasks_space_id ON space_tasks(space_id)`);
+
+	// Pre-M103 space_workflows — no `post_approval` column.
+	db.exec(`
+		CREATE TABLE space_workflows (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			tags TEXT NOT NULL DEFAULT '[]',
+			completion_autonomy_level INTEGER NOT NULL DEFAULT 3,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+		)
+	`);
+
+	db.exec('PRAGMA foreign_keys = ON');
+}
+
+describe('Migration 103: task status "approved" + post_approval schema', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(
+			process.cwd(),
+			'tmp',
+			'test-migration-103',
+			`test-${Date.now()}-${Math.random()}`
+		);
+		mkdirSync(testDir, { recursive: true });
+		db = new BunDatabase(join(testDir, 'test.db'));
+		db.exec('PRAGMA foreign_keys = ON');
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	describe('fresh DB (all migrations applied)', () => {
+		beforeEach(() => {
+			runMigrations(db, () => {});
+			// Seed a space so FKs work.
+			const now = Date.now();
+			db.prepare(
+				`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?)`
+			).run('sp-1', 'sp-1', '/ws/1', 'Space 1', now, now);
+		});
+
+		test('space_tasks CHECK accepts "approved"', () => {
+			const now = Date.now();
+			expect(() => {
+				db.prepare(
+					`INSERT INTO space_tasks (
+						id, space_id, task_number, title, description, status, priority,
+						labels, depends_on, created_at, updated_at
+					) VALUES (?, ?, ?, ?, '', 'approved', 'normal', '[]', '[]', ?, ?)`
+				).run('t-ok', 'sp-1', 1, 'Approved Task', now, now);
+			}).not.toThrow();
+		});
+
+		test('space_tasks CHECK still rejects unknown statuses (e.g. legacy "failed")', () => {
+			const now = Date.now();
+			expect(() => {
+				db.prepare(
+					`INSERT INTO space_tasks (
+						id, space_id, task_number, title, description, status, priority,
+						labels, depends_on, created_at, updated_at
+					) VALUES (?, ?, ?, ?, '', 'failed', 'normal', '[]', '[]', ?, ?)`
+				).run('t-bad', 'sp-1', 2, 'Bad', now, now);
+			}).toThrow();
+		});
+
+		test('space_tasks has the three new post_approval_* columns', () => {
+			const cols = columnNames(db, 'space_tasks');
+			expect(cols).toContain('post_approval_session_id');
+			expect(cols).toContain('post_approval_started_at');
+			expect(cols).toContain('post_approval_blocked_reason');
+		});
+
+		test('space_workflows has the post_approval column', () => {
+			const cols = columnNames(db, 'space_workflows');
+			expect(cols).toContain('post_approval');
+		});
+
+		test('task row round-trips status="approved" + post_approval_* values', () => {
+			const now = Date.now();
+			db.prepare(
+				`INSERT INTO space_tasks (
+					id, space_id, task_number, title, description, status, priority,
+					labels, depends_on, created_at, updated_at,
+					post_approval_session_id, post_approval_started_at, post_approval_blocked_reason
+				) VALUES (?, ?, ?, ?, '', 'approved', 'normal', '[]', '[]', ?, ?, ?, ?, ?)`
+			).run(
+				't-rt',
+				'sp-1',
+				3,
+				'Round Trip',
+				now,
+				now,
+				'sess-abc',
+				now + 5,
+				'waiting on GitHub token'
+			);
+
+			const row = db
+				.prepare(
+					`SELECT status, post_approval_session_id, post_approval_started_at, post_approval_blocked_reason
+					 FROM space_tasks WHERE id = ?`
+				)
+				.get('t-rt') as {
+				status: string;
+				post_approval_session_id: string | null;
+				post_approval_started_at: number | null;
+				post_approval_blocked_reason: string | null;
+			};
+
+			expect(row.status).toBe('approved');
+			expect(row.post_approval_session_id).toBe('sess-abc');
+			expect(row.post_approval_started_at).toBe(now + 5);
+			expect(row.post_approval_blocked_reason).toBe('waiting on GitHub token');
+		});
+
+		test('workflow row round-trips post_approval as NULL by default and JSON when written', () => {
+			const now = Date.now();
+			db.prepare(
+				`INSERT INTO space_workflows (
+					id, space_id, name, description, tags, completion_autonomy_level,
+					created_at, updated_at
+				) VALUES (?, ?, ?, '', '[]', 3, ?, ?)`
+			).run('wf-null', 'sp-1', 'wf null', now, now);
+
+			const nullRow = db
+				.prepare(`SELECT post_approval FROM space_workflows WHERE id = ?`)
+				.get('wf-null') as { post_approval: string | null };
+			expect(nullRow.post_approval).toBeNull();
+
+			const route = { targetAgent: 'task-agent', instructions: 'merge {{pr_url}}' };
+			db.prepare(
+				`INSERT INTO space_workflows (
+					id, space_id, name, description, tags, completion_autonomy_level,
+					post_approval, created_at, updated_at
+				) VALUES (?, ?, ?, '', '[]', 3, ?, ?, ?)`
+			).run('wf-set', 'sp-1', 'wf set', JSON.stringify(route), now, now);
+
+			const setRow = db
+				.prepare(`SELECT post_approval FROM space_workflows WHERE id = ?`)
+				.get('wf-set') as { post_approval: string };
+			expect(JSON.parse(setRow.post_approval)).toEqual(route);
+		});
+	});
+
+	describe('table rebuild — pre-M103 DB with existing rows', () => {
+		beforeEach(() => {
+			seedPreM103Schema(db);
+			const now = Date.now();
+			db.prepare(`INSERT INTO spaces (id, created_at, updated_at) VALUES (?, ?, ?)`).run(
+				'sp-1',
+				now,
+				now
+			);
+			// Seed one row for every legal pre-M103 status so we verify the
+			// rebuild preserves them verbatim.
+			const seeds: Array<[string, number, string, string]> = [
+				['t-open', 1, 'open', 'Open'],
+				['t-inp', 2, 'in_progress', 'In Progress'],
+				['t-rev', 3, 'review', 'Review'],
+				['t-done', 4, 'done', 'Done'],
+				['t-block', 5, 'blocked', 'Blocked'],
+				['t-cancel', 6, 'cancelled', 'Cancelled'],
+				['t-arch', 7, 'archived', 'Archived'],
+			];
+			for (const [id, n, status, title] of seeds) {
+				db.prepare(
+					`INSERT INTO space_tasks (
+						id, space_id, task_number, title, description, status, priority,
+						labels, depends_on, created_at, updated_at
+					) VALUES (?, ?, ?, ?, 'desc', ?, 'normal', '[]', '[]', ?, ?)`
+				).run(id, 'sp-1', n, title, status, now, now);
+			}
+		});
+
+		test('preserves every pre-existing row unchanged after rebuild', () => {
+			const before = db
+				.prepare(
+					`SELECT id, space_id, task_number, title, description, status, priority,
+							labels, depends_on, created_at, updated_at FROM space_tasks ORDER BY task_number`
+				)
+				.all();
+
+			runMigration103(db);
+
+			const after = db
+				.prepare(
+					`SELECT id, space_id, task_number, title, description, status, priority,
+							labels, depends_on, created_at, updated_at FROM space_tasks ORDER BY task_number`
+				)
+				.all();
+
+			expect(after).toEqual(before);
+			expect(after.length).toBe(7);
+		});
+
+		test('preserves pre-existing indexes across the rebuild', () => {
+			const before = new Set(indexNames(db, 'space_tasks'));
+			expect(before).toContain('idx_space_tasks_space_task_number');
+			expect(before).toContain('idx_space_tasks_space_id');
+
+			runMigration103(db);
+
+			const after = new Set(indexNames(db, 'space_tasks'));
+			for (const name of before) {
+				expect(after.has(name)).toBe(true);
+			}
+		});
+
+		test('widens CHECK to accept "approved" after rebuild', () => {
+			runMigration103(db);
+			const now = Date.now();
+			expect(() => {
+				db.prepare(
+					`INSERT INTO space_tasks (
+						id, space_id, task_number, title, description, status, priority,
+						labels, depends_on, created_at, updated_at
+					) VALUES (?, ?, ?, ?, '', 'approved', 'normal', '[]', '[]', ?, ?)`
+				).run('t-new-approved', 'sp-1', 99, 'Approved', now, now);
+			}).not.toThrow();
+		});
+
+		test('adds post_approval_* columns to space_tasks', () => {
+			expect(columnNames(db, 'space_tasks')).not.toContain('post_approval_session_id');
+			runMigration103(db);
+			const cols = columnNames(db, 'space_tasks');
+			expect(cols).toContain('post_approval_session_id');
+			expect(cols).toContain('post_approval_started_at');
+			expect(cols).toContain('post_approval_blocked_reason');
+		});
+
+		test('adds post_approval column to space_workflows', () => {
+			expect(columnNames(db, 'space_workflows')).not.toContain('post_approval');
+			runMigration103(db);
+			expect(columnNames(db, 'space_workflows')).toContain('post_approval');
+		});
+
+		test('is idempotent — running a second time is a no-op', () => {
+			runMigration103(db);
+			const countAfter1 = (
+				db.prepare(`SELECT COUNT(*) AS n FROM space_tasks`).get() as { n: number }
+			).n;
+			const cols1 = columnNames(db, 'space_tasks').sort();
+
+			expect(() => runMigration103(db)).not.toThrow();
+
+			const countAfter2 = (
+				db.prepare(`SELECT COUNT(*) AS n FROM space_tasks`).get() as { n: number }
+			).n;
+			const cols2 = columnNames(db, 'space_tasks').sort();
+
+			expect(countAfter2).toBe(countAfter1);
+			expect(cols2).toEqual(cols1);
+		});
+	});
+
+	describe('missing tables — no-op guards', () => {
+		test('runMigration103 on an empty DB does not throw', () => {
+			expect(() => runMigration103(db)).not.toThrow();
+		});
+
+		test('runMigration103 skips space_workflows changes when only space_tasks exists', () => {
+			db.exec(`
+				CREATE TABLE space_tasks (
+					id TEXT PRIMARY KEY,
+					space_id TEXT NOT NULL,
+					task_number INTEGER NOT NULL,
+					title TEXT NOT NULL,
+					description TEXT NOT NULL DEFAULT '',
+					status TEXT NOT NULL DEFAULT 'open'
+						CHECK(status IN ('open', 'in_progress', 'review', 'done', 'blocked', 'cancelled', 'archived')),
+					priority TEXT NOT NULL DEFAULT 'normal'
+						CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+					labels TEXT NOT NULL DEFAULT '[]',
+					depends_on TEXT NOT NULL DEFAULT '[]',
+					created_at INTEGER NOT NULL,
+					updated_at INTEGER NOT NULL
+				)
+			`);
+			expect(() => runMigration103(db)).not.toThrow();
+			// space_tasks got the new columns, space_workflows still doesn't exist.
+			expect(columnNames(db, 'space_tasks')).toContain('post_approval_session_id');
+			const wfExists = db
+				.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='space_workflows'`)
+				.get();
+			expect(wfExists).toBeNull();
+		});
+	});
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/space-task-repository-post-approval.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/space-task-repository-post-approval.test.ts
@@ -1,0 +1,124 @@
+/**
+ * SpaceTaskRepository — `approved` status + post_approval_* round-trip tests.
+ *
+ * PR 1/5 of the task-agent-as-post-approval-executor refactor. See
+ * `docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md`
+ * §1.1.
+ *
+ * Covers the acceptance criterion "A task can be written to DB with
+ * `status='approved'` and the new post-approval columns; selecting it back
+ * returns the same data."
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SpaceRepository } from '../../../../src/storage/repositories/space-repository.ts';
+import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
+import { createSpaceTables } from '../../helpers/space-test-db.ts';
+
+describe('SpaceTaskRepository — "approved" status + post-approval columns', () => {
+	let db: Database;
+	let repo: SpaceTaskRepository;
+	let spaceId: string;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		const spaceRepo = new SpaceRepository(db as any);
+		repo = new SpaceTaskRepository(db as any);
+		const space = spaceRepo.createSpace({
+			workspacePath: '/workspace/post-approval',
+			slug: 'post-approval',
+			name: 'PA',
+		});
+		spaceId = space.id;
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	test('updateTask accepts status="approved" and round-trips it', () => {
+		const task = repo.createTask({ spaceId, title: 'T', description: '' });
+		const updated = repo.updateTask(task.id, { status: 'approved' });
+		expect(updated?.status).toBe('approved');
+
+		const fetched = repo.getTask(task.id);
+		expect(fetched?.status).toBe('approved');
+	});
+
+	test('moving into "approved" does not stamp completedAt (it is not a terminal status)', () => {
+		const task = repo.createTask({ spaceId, title: 'T', description: '' });
+		const updated = repo.updateTask(task.id, { status: 'approved' });
+		expect(updated?.completedAt).toBeNull();
+	});
+
+	test('round-trips the three post_approval_* columns through updateTask', () => {
+		const task = repo.createTask({ spaceId, title: 'T', description: '' });
+		expect(task.postApprovalSessionId).toBeNull();
+		expect(task.postApprovalStartedAt).toBeNull();
+		expect(task.postApprovalBlockedReason).toBeNull();
+
+		const ts = Date.now();
+		const updated = repo.updateTask(task.id, {
+			postApprovalSessionId: 'sess-abc',
+			postApprovalStartedAt: ts,
+			postApprovalBlockedReason: 'waiting on token',
+		});
+		expect(updated?.postApprovalSessionId).toBe('sess-abc');
+		expect(updated?.postApprovalStartedAt).toBe(ts);
+		expect(updated?.postApprovalBlockedReason).toBe('waiting on token');
+
+		const fetched = repo.getTask(task.id);
+		expect(fetched?.postApprovalSessionId).toBe('sess-abc');
+		expect(fetched?.postApprovalStartedAt).toBe(ts);
+		expect(fetched?.postApprovalBlockedReason).toBe('waiting on token');
+	});
+
+	test('post_approval_* columns can be cleared back to null', () => {
+		const task = repo.createTask({ spaceId, title: 'T', description: '' });
+		repo.updateTask(task.id, {
+			postApprovalSessionId: 'sess-abc',
+			postApprovalStartedAt: 123,
+			postApprovalBlockedReason: 'r',
+		});
+
+		const cleared = repo.updateTask(task.id, {
+			postApprovalSessionId: null,
+			postApprovalStartedAt: null,
+			postApprovalBlockedReason: null,
+		});
+		expect(cleared?.postApprovalSessionId).toBeNull();
+		expect(cleared?.postApprovalStartedAt).toBeNull();
+		expect(cleared?.postApprovalBlockedReason).toBeNull();
+	});
+
+	test('approved + post_approval columns survive a full save → load → assert round-trip', () => {
+		const task = repo.createTask({ spaceId, title: 'Ship PR', description: '' });
+		const ts = Date.now();
+		repo.updateTask(task.id, {
+			status: 'approved',
+			postApprovalSessionId: 'sess-xyz',
+			postApprovalStartedAt: ts,
+			postApprovalBlockedReason: null,
+		});
+
+		const fetched = repo.getTask(task.id);
+		expect(fetched).not.toBeNull();
+		expect(fetched?.status).toBe('approved');
+		expect(fetched?.postApprovalSessionId).toBe('sess-xyz');
+		expect(fetched?.postApprovalStartedAt).toBe(ts);
+		expect(fetched?.postApprovalBlockedReason).toBeNull();
+	});
+
+	test('listByStatus(space, "approved") returns only approved tasks', () => {
+		const a = repo.createTask({ spaceId, title: 'A', description: '' });
+		const b = repo.createTask({ spaceId, title: 'B', description: '' });
+		repo.updateTask(a.id, { status: 'approved' });
+		repo.updateTask(b.id, { status: 'in_progress' });
+
+		const approved = repo.listByStatus(spaceId, 'approved');
+		expect(approved).toHaveLength(1);
+		expect(approved[0].title).toBe('A');
+	});
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/space-workflow-repository-post-approval.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/space-workflow-repository-post-approval.test.ts
@@ -1,0 +1,162 @@
+/**
+ * SpaceWorkflowRepository — `postApproval` round-trip tests.
+ *
+ * PR 1/5 of the task-agent-as-post-approval-executor refactor. See
+ * `docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md`
+ * §1.2.
+ *
+ * Covers the acceptance criterion "Workflow CRUD round-trips preserve
+ * `postApproval` field (save → load → assert equal)."
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import type { PostApprovalRoute } from '@neokai/shared';
+import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
+import { createSpaceTables } from '../../helpers/space-test-db.ts';
+
+describe('SpaceWorkflowRepository — postApproval', () => {
+	let db: Database;
+	let repo: SpaceWorkflowRepository;
+	const spaceId = 'sp-1';
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?)`
+		).run(spaceId, spaceId, '/ws/x', 'Test Space', now, now);
+		repo = new SpaceWorkflowRepository(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	test('createWorkflow stores and reads back a PostApprovalRoute', () => {
+		const route: PostApprovalRoute = {
+			targetAgent: 'task-agent',
+			instructions: 'Merge {{pr_url}} once CI is green.',
+		};
+		const wf = repo.createWorkflow({
+			spaceId,
+			name: 'WF with route',
+			nodes: [{ name: 'Only', agentId: 'agent-1' }],
+			postApproval: route,
+		});
+		expect(wf.postApproval).toEqual(route);
+
+		const fetched = repo.getWorkflow(wf.id);
+		expect(fetched?.postApproval).toEqual(route);
+	});
+
+	test('createWorkflow without postApproval leaves the field undefined on read', () => {
+		const wf = repo.createWorkflow({
+			spaceId,
+			name: 'WF no route',
+			nodes: [{ name: 'Only', agentId: 'agent-1' }],
+		});
+		expect(wf.postApproval).toBeUndefined();
+
+		const fetched = repo.getWorkflow(wf.id);
+		expect(fetched?.postApproval).toBeUndefined();
+	});
+
+	test('updateWorkflow can add a route to an existing workflow', () => {
+		const wf = repo.createWorkflow({
+			spaceId,
+			name: 'WF',
+			nodes: [{ name: 'Only', agentId: 'agent-1' }],
+		});
+		expect(wf.postApproval).toBeUndefined();
+
+		const route: PostApprovalRoute = {
+			targetAgent: 'reviewer',
+			instructions: 'Final checks on {{pr_url}}.',
+		};
+		const updated = repo.updateWorkflow(wf.id, { postApproval: route });
+		expect(updated?.postApproval).toEqual(route);
+
+		const fetched = repo.getWorkflow(wf.id);
+		expect(fetched?.postApproval).toEqual(route);
+	});
+
+	test('updateWorkflow can replace an existing route', () => {
+		const initial: PostApprovalRoute = {
+			targetAgent: 'task-agent',
+			instructions: 'Initial',
+		};
+		const wf = repo.createWorkflow({
+			spaceId,
+			name: 'WF',
+			nodes: [{ name: 'Only', agentId: 'agent-1' }],
+			postApproval: initial,
+		});
+
+		const replacement: PostApprovalRoute = {
+			targetAgent: 'reviewer',
+			instructions: 'Replaced',
+		};
+		const updated = repo.updateWorkflow(wf.id, { postApproval: replacement });
+		expect(updated?.postApproval).toEqual(replacement);
+	});
+
+	test('updateWorkflow with postApproval: null clears the route', () => {
+		const wf = repo.createWorkflow({
+			spaceId,
+			name: 'WF',
+			nodes: [{ name: 'Only', agentId: 'agent-1' }],
+			postApproval: { targetAgent: 'task-agent', instructions: 'hi' },
+		});
+		expect(wf.postApproval).toBeDefined();
+
+		const cleared = repo.updateWorkflow(wf.id, { postApproval: null });
+		expect(cleared?.postApproval).toBeUndefined();
+
+		const fetched = repo.getWorkflow(wf.id);
+		expect(fetched?.postApproval).toBeUndefined();
+	});
+
+	test('updateWorkflow with postApproval: undefined leaves the existing route alone', () => {
+		const route: PostApprovalRoute = {
+			targetAgent: 'task-agent',
+			instructions: 'Keep me.',
+		};
+		const wf = repo.createWorkflow({
+			spaceId,
+			name: 'WF',
+			nodes: [{ name: 'Only', agentId: 'agent-1' }],
+			postApproval: route,
+		});
+
+		// Update a different field; omit postApproval entirely.
+		const renamed = repo.updateWorkflow(wf.id, { name: 'Renamed' });
+		expect(renamed?.name).toBe('Renamed');
+		expect(renamed?.postApproval).toEqual(route);
+	});
+
+	test('listWorkflows surfaces postApproval on every row where it is set', () => {
+		const withRoute: PostApprovalRoute = {
+			targetAgent: 'reviewer',
+			instructions: 'X',
+		};
+		repo.createWorkflow({
+			spaceId,
+			name: 'A',
+			nodes: [{ name: 'Only', agentId: 'agent-1' }],
+			postApproval: withRoute,
+		});
+		repo.createWorkflow({
+			spaceId,
+			name: 'B',
+			nodes: [{ name: 'Only', agentId: 'agent-1' }],
+		});
+
+		const all = repo.listWorkflows(spaceId);
+		const byName = Object.fromEntries(all.map((w) => [w.name, w.postApproval]));
+		expect(byName.A).toEqual(withRoute);
+		expect(byName.B).toBeUndefined();
+	});
+});

--- a/packages/daemon/tests/unit/5-space/workflow/post-approval-template.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/post-approval-template.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for `post-approval-template.ts`.
+ *
+ * PR 1/5 of the task-agent-as-post-approval-executor refactor. See
+ * `docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md`
+ * §1.6, §4.6.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+	POST_APPROVAL_TEMPLATE_KEYS,
+	interpolatePostApprovalTemplate,
+} from '../../../../src/lib/space/workflows/post-approval-template.ts';
+
+describe('interpolatePostApprovalTemplate — happy path', () => {
+	test('renders all documented context keys', () => {
+		const template =
+			'Task {{task_id}} ({{task_title}}) in space {{space_id}} at {{workspace_path}}\n' +
+			'Reviewer: {{reviewer_name}} via {{approval_source}} (autonomy {{autonomy_level}}).';
+		const context = {
+			autonomy_level: 3,
+			task_id: 't-42',
+			task_title: 'Ship PR',
+			reviewer_name: 'reviewer',
+			approval_source: 'human',
+			space_id: 's-7',
+			workspace_path: '/tmp/ws',
+		};
+		const result = interpolatePostApprovalTemplate(template, context);
+		expect(result.missingKeys).toEqual([]);
+		expect(result.text).toBe(
+			'Task t-42 (Ship PR) in space s-7 at /tmp/ws\n' + 'Reviewer: reviewer via human (autonomy 3).'
+		);
+	});
+
+	test('arbitrary context keys (e.g. end-node payload) are usable', () => {
+		const template = 'merge {{pr_url}} (sha {{merge_sha}})';
+		const result = interpolatePostApprovalTemplate(template, {
+			pr_url: 'https://github.com/a/b/pull/1',
+			merge_sha: 'deadbeef',
+		});
+		expect(result.text).toBe('merge https://github.com/a/b/pull/1 (sha deadbeef)');
+		expect(result.missingKeys).toEqual([]);
+	});
+
+	test('POST_APPROVAL_TEMPLATE_KEYS matches the §1.6 contract', () => {
+		expect([...POST_APPROVAL_TEMPLATE_KEYS]).toEqual([
+			'autonomy_level',
+			'task_id',
+			'task_title',
+			'reviewer_name',
+			'approval_source',
+			'space_id',
+			'workspace_path',
+		]);
+	});
+});
+
+describe('interpolatePostApprovalTemplate — missing keys', () => {
+	test('missing key renders as the literal token and is reported', () => {
+		const result = interpolatePostApprovalTemplate('merge {{pr_url}} now', {});
+		expect(result.text).toBe('merge {{pr_url}} now');
+		expect(result.missingKeys).toEqual(['pr_url']);
+	});
+
+	test('null / undefined values are treated as missing', () => {
+		const result = interpolatePostApprovalTemplate('{{a}} {{b}}', {
+			a: null,
+			b: undefined,
+		});
+		expect(result.text).toBe('{{a}} {{b}}');
+		expect(result.missingKeys).toEqual(['a', 'b']);
+	});
+
+	test('same missing key appearing multiple times reports once', () => {
+		const result = interpolatePostApprovalTemplate('{{pr_url}} / {{pr_url}}', {});
+		expect(result.text).toBe('{{pr_url}} / {{pr_url}}');
+		expect(result.missingKeys).toEqual(['pr_url']);
+	});
+});
+
+describe('interpolatePostApprovalTemplate — grammar guarantees', () => {
+	test('single-pass: replacement text is not re-scanned for tokens', () => {
+		// If the substitution were recursive, `{{inner}}` would be expanded
+		// after replacing {{outer}}. Single-pass means the nested token stays
+		// literal.
+		const result = interpolatePostApprovalTemplate('{{outer}}', {
+			outer: 'prefix-{{inner}}-suffix',
+			inner: 'SHOULD_NOT_EXPAND',
+		});
+		expect(result.text).toBe('prefix-{{inner}}-suffix');
+		// `{{inner}}` was produced by the substitution, not by the source —
+		// so it is NOT counted as a missing key.
+		expect(result.missingKeys).toEqual([]);
+	});
+
+	test('special characters in values pass through unchanged (no escaping)', () => {
+		const template = 'URL: {{pr_url}}; shell: {{cmd}}; html: {{html}}';
+		const result = interpolatePostApprovalTemplate(template, {
+			pr_url: 'https://example.com/a?b=1&c=2',
+			cmd: "rm -rf / && echo 'hi' $VAR",
+			html: '<script>alert(1)</script>',
+		});
+		expect(result.text).toBe(
+			"URL: https://example.com/a?b=1&c=2; shell: rm -rf / && echo 'hi' $VAR; html: <script>alert(1)</script>"
+		);
+	});
+
+	test('identifier-shaped tokens only (no dotted paths, no helpers)', () => {
+		// `{{a.b}}` is NOT a valid token — it stays literal.
+		const result = interpolatePostApprovalTemplate('{{a.b}} {{a b}} {{1foo}}', {
+			'a.b': 'should not substitute',
+			'a b': 'should not substitute',
+			'1foo': 'should not substitute',
+		});
+		// Every one of those templates failed to match the identifier pattern,
+		// so they remain literal and nothing is reported missing.
+		expect(result.text).toBe('{{a.b}} {{a b}} {{1foo}}');
+		expect(result.missingKeys).toEqual([]);
+	});
+
+	test('internal whitespace around the identifier is allowed', () => {
+		const result = interpolatePostApprovalTemplate('{{  task_id  }}', { task_id: 't-42' });
+		expect(result.text).toBe('t-42');
+	});
+
+	test('empty template round-trips', () => {
+		expect(interpolatePostApprovalTemplate('', { any: 1 })).toEqual({
+			text: '',
+			missingKeys: [],
+		});
+	});
+
+	test('values are stringified via String(value) (numbers, booleans)', () => {
+		const result = interpolatePostApprovalTemplate('{{n}}/{{b}}', { n: 42, b: true });
+		expect(result.text).toBe('42/true');
+	});
+});

--- a/packages/daemon/tests/unit/5-space/workflow/post-approval-validator.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/post-approval-validator.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for `post-approval-validator.ts`.
+ *
+ * PR 1/5 of the task-agent-as-post-approval-executor refactor. See
+ * `docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md`
+ * §1.5, §4.6.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { PostApprovalRoute, WorkflowNode } from '@neokai/shared';
+import {
+	POST_APPROVAL_TASK_AGENT_TARGET,
+	collectEligiblePostApprovalTargets,
+	validatePostApproval,
+} from '../../../../src/lib/space/workflows/post-approval-validator.ts';
+
+const node = (
+	id: string,
+	name: string,
+	agents: Array<{ agentId: string; name: string }>
+): WorkflowNode => ({ id, name, agents });
+
+const CODING_NODES: WorkflowNode[] = [
+	node('n1', 'Coding', [{ agentId: 'a1', name: 'coder' }]),
+	node('n2', 'Review', [{ agentId: 'a2', name: 'reviewer' }]),
+];
+
+describe('collectEligiblePostApprovalTargets', () => {
+	test('always lists the Task Agent first', () => {
+		expect(collectEligiblePostApprovalTargets([])).toEqual([POST_APPROVAL_TASK_AGENT_TARGET]);
+	});
+
+	test('appends each node-agent name in document order, without duplicates', () => {
+		const duplicate: WorkflowNode[] = [
+			node('n1', 'A', [
+				{ agentId: 'a1', name: 'coder' },
+				{ agentId: 'a2', name: 'coder' /* dup — should collapse */ },
+			]),
+			node('n2', 'B', [{ agentId: 'a3', name: 'reviewer' }]),
+		];
+		expect(collectEligiblePostApprovalTargets(duplicate)).toEqual([
+			'task-agent',
+			'coder',
+			'reviewer',
+		]);
+	});
+});
+
+describe('validatePostApproval', () => {
+	test('missing postApproval is valid (optional field)', () => {
+		expect(validatePostApproval({ nodes: CODING_NODES })).toEqual({ ok: true });
+	});
+
+	test('targetAgent === "task-agent" is valid', () => {
+		const route: PostApprovalRoute = {
+			targetAgent: 'task-agent',
+			instructions: 'merge {{pr_url}}',
+		};
+		expect(validatePostApproval({ postApproval: route, nodes: CODING_NODES })).toEqual({
+			ok: true,
+		});
+	});
+
+	test('declared node-agent name is valid', () => {
+		const route: PostApprovalRoute = {
+			targetAgent: 'reviewer',
+			instructions: 'post final review on {{pr_url}}',
+		};
+		expect(validatePostApproval({ postApproval: route, nodes: CODING_NODES })).toEqual({
+			ok: true,
+		});
+	});
+
+	test('unknown target is invalid; error lists every eligible target', () => {
+		const route: PostApprovalRoute = {
+			targetAgent: 'ghost-agent',
+			instructions: '',
+		};
+		const result = validatePostApproval({ postApproval: route, nodes: CODING_NODES });
+		expect(result.ok).toBe(false);
+		if (result.ok) return; // type narrow
+		expect(result.eligibleTargets).toEqual(['task-agent', 'coder', 'reviewer']);
+		expect(result.error).toContain('"ghost-agent"');
+		// The error surfaces every eligible target so the operator/LLM can fix
+		// the route without a round-trip to the docs.
+		for (const target of ['task-agent', 'coder', 'reviewer']) {
+			expect(result.error).toContain(`"${target}"`);
+		}
+	});
+
+	test('empty/whitespace targetAgent is invalid', () => {
+		const route: PostApprovalRoute = { targetAgent: '   ', instructions: '' };
+		const result = validatePostApproval({ postApproval: route, nodes: CODING_NODES });
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error).toContain('non-empty');
+	});
+
+	test('target agent name is trimmed before comparison', () => {
+		const route: PostApprovalRoute = { targetAgent: '  coder  ', instructions: '' };
+		const result = validatePostApproval({ postApproval: route, nodes: CODING_NODES });
+		expect(result).toEqual({ ok: true });
+	});
+});

--- a/packages/daemon/tests/unit/helpers/space-agent-schema.ts
+++ b/packages/daemon/tests/unit/helpers/space-agent-schema.ts
@@ -66,6 +66,7 @@ export function createSpaceAgentSchema(db: Database): void {
 			template_hash TEXT DEFAULT NULL,
 			instructions TEXT DEFAULT NULL,
 			completion_autonomy_level INTEGER NOT NULL DEFAULT 3,
+			post_approval TEXT DEFAULT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -74,6 +74,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			template_hash TEXT DEFAULT NULL,
 			instructions TEXT DEFAULT NULL,
 			completion_autonomy_level INTEGER NOT NULL DEFAULT 3,
+			post_approval TEXT DEFAULT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
@@ -195,7 +196,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			title TEXT NOT NULL,
 			description TEXT NOT NULL DEFAULT '',
 			status TEXT NOT NULL DEFAULT 'open'
-				CHECK(status IN ('open', 'in_progress', 'review', 'done', 'blocked', 'cancelled', 'archived')),
+				CHECK(status IN ('open', 'in_progress', 'review', 'approved', 'done', 'blocked', 'cancelled', 'archived')),
 			priority TEXT NOT NULL DEFAULT 'normal'
 				CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
 			labels TEXT NOT NULL DEFAULT '[]',
@@ -217,6 +218,9 @@ export function createSpaceTables(db: BunDatabase): void {
 			pending_completion_submitted_by_node_id TEXT DEFAULT NULL,
 			pending_completion_submitted_at INTEGER DEFAULT NULL,
 			pending_completion_reason TEXT DEFAULT NULL,
+			post_approval_session_id TEXT DEFAULT NULL,
+			post_approval_started_at INTEGER DEFAULT NULL,
+			post_approval_blocked_reason TEXT DEFAULT NULL,
 			archived_at INTEGER,
 			created_at INTEGER NOT NULL,
 			started_at INTEGER,

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -151,18 +151,26 @@ export interface UpdateSpaceParams {
 /**
  * Space task status
  *
- * - `open`       — task is queued and waiting to be picked up
+ * - `open`        — task is queued and waiting to be picked up
  * - `in_progress` — a Task Agent session is actively working on this task
- * - `review`     — workflow agents completed; awaiting human review/approval (supervised mode)
- * - `done`       — task completed successfully
- * - `blocked`    — task requires human attention or intervention
- * - `cancelled`  — task was cancelled and will not be completed
- * - `archived`   — task is archived (soft-delete, `archivedAt` is stamped)
+ * - `review`      — workflow agents completed; awaiting human review/approval (supervised mode)
+ * - `approved`    — work has been approved (human or auto_policy); a post-approval
+ *                   executor (e.g. Task Agent running a `postApproval` route such
+ *                   as a PR merge) may still be executing before the task reaches
+ *                   its terminal `done` state. No runtime consumer exists yet —
+ *                   PR 2 of the task-agent-as-post-approval-executor refactor
+ *                   wires this status in. See
+ *                   `docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md`.
+ * - `done`        — task completed successfully
+ * - `blocked`     — task requires human attention or intervention
+ * - `cancelled`   — task was cancelled and will not be completed
+ * - `archived`    — task is archived (soft-delete, `archivedAt` is stamped)
  */
 export type SpaceTaskStatus =
 	| 'open'
 	| 'in_progress'
 	| 'review'
+	| 'approved'
 	| 'done'
 	| 'blocked'
 	| 'cancelled'
@@ -336,6 +344,30 @@ export interface SpaceTask {
 	 * Summary the end-node agent provided alongside `reportedStatus`. Null until reported.
 	 */
 	reportedSummary: string | null;
+	/**
+	 * Session ID of the post-approval executor (e.g. the Task Agent session running
+	 * the workflow's `postApproval` route) while it is executing. Null when no
+	 * post-approval action is in progress.
+	 *
+	 * Schema only in PR 1 of the task-agent-as-post-approval-executor refactor; no
+	 * runtime consumer yet.
+	 */
+	postApprovalSessionId?: string | null;
+	/**
+	 * Timestamp (ms since epoch) when the post-approval executor started. Null when
+	 * no post-approval action has run for this task.
+	 *
+	 * Schema only in PR 1; no runtime consumer yet.
+	 */
+	postApprovalStartedAt?: number | null;
+	/**
+	 * Free-form reason captured when a post-approval executor cannot proceed (e.g.
+	 * human rejected, target agent unavailable, script failure). Null when not
+	 * blocked.
+	 *
+	 * Schema only in PR 1; no runtime consumer yet.
+	 */
+	postApprovalBlockedReason?: string | null;
 	/** Last update timestamp (milliseconds since epoch) */
 	updatedAt: number;
 }
@@ -479,6 +511,21 @@ export interface UpdateSpaceTaskParams {
 	reportedStatus?: SpaceReportedStatus | null;
 	/** Agent-reported summary from `report_result`; null to clear */
 	reportedSummary?: string | null;
+	/**
+	 * Session ID of the post-approval executor; null to clear.
+	 * Schema only in PR 1 of the post-approval refactor; no runtime consumer yet.
+	 */
+	postApprovalSessionId?: string | null;
+	/**
+	 * Timestamp (ms) when the post-approval executor started; null to clear.
+	 * Schema only in PR 1; no runtime consumer yet.
+	 */
+	postApprovalStartedAt?: number | null;
+	/**
+	 * Reason a post-approval action is blocked; null to clear.
+	 * Schema only in PR 1; no runtime consumer yet.
+	 */
+	postApprovalBlockedReason?: string | null;
 }
 
 /**
@@ -1051,6 +1098,41 @@ export interface WorkflowNodeInput {
 }
 
 /**
+ * Describes a post-approval route — a handoff from an end-node's approval
+ * signal to a downstream executor that continues work **after** the task is
+ * approved (e.g. merging a PR, publishing a release, running a verification
+ * script). The route is declarative and lives on the workflow definition; the
+ * runtime routes the structured signal to `targetAgent` with an `instructions`
+ * string that supports `{{identifier}}` template interpolation.
+ *
+ * Added in PR 1 of the task-agent-as-post-approval-executor refactor. No
+ * runtime consumer reads this field yet — PR 2 wires the
+ * `PostApprovalRouter` and `mark_complete` tool. See
+ * `docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md`
+ * §1.1 / §1.6.
+ */
+export interface PostApprovalRoute {
+	/**
+	 * Name of the agent that should execute the post-approval action.
+	 *
+	 *   - `'task-agent'`                    — deliver to the orchestration Task Agent.
+	 *   - any `WorkflowNodeAgent.name` in  — deliver to the declared workflow
+	 *     this workflow's `nodes[*].agents`.
+	 *
+	 * The validator (`post-approval-validator.ts`) rejects unknown targets at
+	 * workflow create/update time and disables stale routes at load time.
+	 */
+	targetAgent: string;
+	/**
+	 * Instruction template delivered to `targetAgent` when the end node signals
+	 * approval. Supports `{{identifier}}` single-pass substitution against the
+	 * runtime context assembled by the PostApprovalRouter. See
+	 * `post-approval-template.ts` for the template grammar.
+	 */
+	instructions: string;
+}
+
+/**
  * A named, reusable workflow definition within a Space.
  * Workflows are collaboration graphs: nodes are agent groups, channels are communication paths.
  * The SpaceRuntime executes workflows by creating SpaceWorkflowRun instances.
@@ -1135,6 +1217,13 @@ export interface SpaceWorkflow {
 	 * `undefined` when no template tracking is active.
 	 */
 	templateHash?: string;
+	/**
+	 * Optional post-approval route — describes which agent should act on the
+	 * end-node's approval signal, with an instruction template. See
+	 * {@link PostApprovalRoute}. Added in PR 1 of the post-approval refactor;
+	 * no runtime consumer yet (PR 2 wires it up).
+	 */
+	postApproval?: PostApprovalRoute;
 }
 
 /**
@@ -1185,6 +1274,11 @@ export interface CreateSpaceWorkflowParams {
 	 * Stored for future drift detection.
 	 */
 	templateHash?: string;
+	/**
+	 * Optional post-approval route. See {@link PostApprovalRoute}.
+	 * Schema only in PR 1 of the post-approval refactor; no runtime consumer yet.
+	 */
+	postApproval?: PostApprovalRoute;
 }
 
 /**
@@ -1236,6 +1330,11 @@ export interface UpdateSpaceWorkflowParams {
 	/** Update template tracking (used when syncing from a template). */
 	templateName?: string | null;
 	templateHash?: string | null;
+	/**
+	 * Update the workflow's post-approval route. Pass `null` to clear.
+	 * Schema only in PR 1 of the post-approval refactor; no runtime consumer yet.
+	 */
+	postApproval?: PostApprovalRoute | null;
 }
 
 /**

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -31,6 +31,10 @@ const STATUS_LABELS: Record<SpaceTaskStatus, string> = {
 	open: 'Open',
 	in_progress: 'In Progress',
 	review: 'Awaiting Review',
+	// `approved` is a transient post-approval status added in PR 1/5 of the
+	// task-agent-as-post-approval-executor refactor. Not yet written by any
+	// runtime path — PR 2 wires it in.
+	approved: 'Approved',
 	done: 'Done',
 	blocked: 'Blocked',
 	cancelled: 'Cancelled',

--- a/packages/web/src/components/space/TaskStatusActions.tsx
+++ b/packages/web/src/components/space/TaskStatusActions.tsx
@@ -8,6 +8,14 @@ export const VALID_TASK_TRANSITIONS: Record<SpaceTaskStatus, SpaceTaskStatus[]> 
 	open: ['in_progress', 'blocked', 'done', 'cancelled'],
 	in_progress: ['open', 'review', 'done', 'blocked', 'cancelled'],
 	review: ['done', 'in_progress', 'cancelled', 'archived'],
+	// `approved` is the post-approval staging status added in PR 1/5 of the
+	// task-agent-as-post-approval-executor refactor. No runtime consumer
+	// produces this status yet — PR 2 wires it in. Listed here with a
+	// conservative transition set (escape hatches to `done`/`in_progress`/
+	// `archived`) so that manually-set `approved` rows can still be moved
+	// along, and so `Record<SpaceTaskStatus, SpaceTaskStatus[]>` typechecks.
+	// Deliberately NOT reachable from `review` yet — PR 2 adds that edge.
+	approved: ['done', 'in_progress', 'archived'],
 	done: ['in_progress', 'archived'],
 	blocked: ['open', 'in_progress', 'archived'],
 	cancelled: ['open', 'in_progress', 'done', 'archived'],
@@ -31,6 +39,12 @@ export const TRANSITION_LABELS: Record<string, string> = {
 	'review->in_progress': 'Reopen',
 	'review->cancelled': 'Cancel',
 	'review->archived': 'Archive',
+	// PR 1/5 schema-only: `approved` has no user-facing enter edge yet. Labels
+	// for `approved -> X` are defined here so that if the status is manually
+	// set (e.g. tests) the Task pane still renders readable action buttons.
+	'approved->done': 'Mark Done',
+	'approved->in_progress': 'Reopen',
+	'approved->archived': 'Archive',
 	'done->in_progress': 'Reopen',
 	'done->archived': 'Archive',
 	'blocked->open': 'Reopen',
@@ -48,6 +62,7 @@ export const TRANSITION_LABELS: Record<string, string> = {
 const TRANSITION_STYLES: Record<string, string> = {
 	in_progress: 'text-blue-300 hover:text-blue-200',
 	review: 'text-purple-300 hover:text-purple-200',
+	approved: 'text-emerald-300 hover:text-emerald-200',
 	done: 'text-green-300 hover:text-green-200',
 	blocked: 'text-amber-300 hover:text-amber-200',
 	cancelled: 'text-red-300 hover:text-red-200',


### PR DESCRIPTION
## Summary

PR 1 of 5 in the [task-agent-as-post-approval-executor refactor](../blob/dev/docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md). Strictly additive, schema-only — **no runtime behaviour change**. No edge produces the new `approved` status yet, and no consumer reads `postApproval`. PR 2 wires the router and `mark_complete` tool.

- New task status `'approved'` (positioned between `review` and `done`).
- New `PostApprovalRoute { targetAgent, instructions }` + optional `SpaceWorkflow.postApproval`.
- New optional `postApprovalSessionId` / `postApprovalStartedAt` / `postApprovalBlockedReason` on `SpaceTask`.
- Migration 103: widens `space_tasks.status` CHECK (table-rebuild preserving indexes & FKs), adds 3 task columns, adds `post_approval` JSON column on `space_workflows`.
- Repositories persist the new columns; `SpaceWorkflowManager` validates `postApproval` on create/update against node agents (+ `task-agent`) and strips stale routes on load.
- `post-approval-template.ts` single-pass `{{identifier}}` interpolator (used by PR 2).
- Web label/transition maps extended so `Record<SpaceTaskStatus, ...>` typechecks; `review -> approved` is deliberately NOT added yet.

## Test plan

- [x] `./scripts/test-daemon.sh 1-core 2-handlers 4-space-storage 5-space` — all green
- [x] `bun run check` (lint + typecheck + knip + session-guards)
- [x] New unit tests: migration 103 (fresh + legacy rebuild + idempotency), repository round-trips for both new tables, validator (happy/reject/trim/eligible-targets), template (interpolate/missing-keys/single-pass), workflow manager validation (create/update/stale-route strip)