### PR TITLE
feat(space): runtime post-approval routing + mark_complete tool (PR 2/5)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -14,6 +14,7 @@ import type { DaemonHub } from '../daemon-hub';
 import type { SpaceManager } from '../space/managers/space-manager';
 import type { SpaceTaskManager } from '../space/managers/space-task-manager';
 import type { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
+import { isPostApprovalRoutingEnabled } from '../space/runtime/post-approval-router';
 import { Logger } from '../logger';
 
 const log = new Logger('space-task-handlers');
@@ -326,19 +327,43 @@ export function setupSpaceTaskHandlers(
 
 		let task;
 		if (params.approved) {
-			// review → done. Stamp human approval metadata and clear pending flags.
-			task = await taskManager.setTaskStatus(params.taskId, 'done', {
-				approvalSource: 'human',
-				approvalReason: params.reason ?? undefined,
-			});
-			// Clear the pending-completion fields. setTaskStatus does not touch them,
-			// so apply them in a follow-up update so the banner/UI stops rendering.
-			task = await taskManager.updateTask(params.taskId, {
-				pendingCheckpointType: null,
-				pendingCompletionSubmittedByNodeId: null,
-				pendingCompletionSubmittedAt: null,
-				pendingCompletionReason: null,
-			});
+			if (isPostApprovalRoutingEnabled() && spaceRuntimeService) {
+				// Post-approval routing ON: delegate to the router. It transitions
+				// review → approved (via SpaceTaskManager.setTaskStatus), emits
+				// [TASK_APPROVED], and dispatches the configured post-approval step
+				// (no-route → done, inline Task Agent, or spawn fresh node-agent).
+				//
+				// Clear the pending-completion fields up front so the UI banner
+				// stops rendering immediately on approval. The router handles the
+				// status transition itself.
+				task = await taskManager.updateTask(params.taskId, {
+					pendingCheckpointType: null,
+					pendingCompletionSubmittedByNodeId: null,
+					pendingCompletionSubmittedAt: null,
+					pendingCompletionReason: null,
+					approvalReason: params.reason ?? null,
+				});
+				await spaceRuntimeService.dispatchPostApproval(params.spaceId, params.taskId, 'human', {
+					approvalReason: params.reason ?? null,
+				});
+				// Re-read the task so the caller sees the post-router state.
+				task = (await taskManager.getTask(params.taskId)) ?? task;
+			} else {
+				// Legacy path (flag OFF or runtime service unavailable): direct
+				// review → done, stamp human approval metadata and clear pending flags.
+				task = await taskManager.setTaskStatus(params.taskId, 'done', {
+					approvalSource: 'human',
+					approvalReason: params.reason ?? undefined,
+				});
+				// Clear the pending-completion fields. setTaskStatus does not touch them,
+				// so apply them in a follow-up update so the banner/UI stops rendering.
+				task = await taskManager.updateTask(params.taskId, {
+					pendingCheckpointType: null,
+					pendingCompletionSubmittedByNodeId: null,
+					pendingCompletionSubmittedAt: null,
+					pendingCompletionReason: null,
+				});
+			}
 		} else {
 			// review → in_progress (reject). Reason captured as approvalReason for audit.
 			task = await taskManager.setTaskStatus(params.taskId, 'in_progress');

--- a/packages/daemon/src/lib/space/agents/task-agent.ts
+++ b/packages/daemon/src/lib/space/agents/task-agent.ts
@@ -272,6 +272,36 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 			`you must wait for explicit human approval before continuing.`
 	);
 
+	// ---- Post-approval -------------------------------------------------------
+	sections.push(`\n## Post-Approval\n`);
+	sections.push(
+		`When a task reaches the \`approved\` status (either via end-node \`approve_task\` or ` +
+			`human approval of a \`submit_for_approval\` request), the runtime emits a ` +
+			`\`[TASK_APPROVED]\` awareness event into your session. This event is informational — ` +
+			`it tells you that the task has cleared approval but is **not yet done**.\n` +
+			`\n` +
+			`Depending on the workflow's \`postApproval\` configuration, one of three things happens next:\n` +
+			`1. **No post-approval declared** — the runtime auto-transitions the task \`approved → done\`. ` +
+			`You do nothing.\n` +
+			`2. **\`targetAgent: 'task-agent'\`** — the runtime injects a \`[POST_APPROVAL_INSTRUCTIONS]\` ` +
+			`message into your session containing the workflow's post-approval instructions. ` +
+			`Execute them to completion using your tools, then call \`mark_complete\` to transition the ` +
+			`task \`approved → done\`. You must call \`mark_complete\` exactly once when the work is finished.\n` +
+			`3. **\`targetAgent\` pointing at a node agent** — the runtime spawns a fresh node-agent ` +
+			`sub-session to handle the post-approval work. You do nothing; that sub-session will call ` +
+			`\`mark_complete\` itself when finished.\n` +
+			`\n` +
+			`**Key rules:**\n` +
+			`- \`mark_complete\` is the ONLY way to transition \`approved → done\`. It fails with a clear ` +
+			`error if the task is not in \`approved\` status.\n` +
+			`- Do not call \`approve_task\` on a task that is already \`approved\` — that would be a no-op ` +
+			`error. If you want to move an approved task to done, call \`mark_complete\`.\n` +
+			`- \`[POST_APPROVAL_INSTRUCTIONS]\` arrive as a user-turn message. Treat them as authoritative ` +
+			`work to execute; do not ask for human approval before starting.\n` +
+			`- If the post-approval work fails, call \`submit_for_approval\` (or surface the error via ` +
+			`\`request_human_input\`) rather than swallowing it.`
+	);
+
 	// ---- Behavioral rules ---------------------------------------------------
 	sections.push(`\n## Behavioral Rules\n`);
 	sections.push(

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -25,15 +25,20 @@ import type {
  */
 export const VALID_SPACE_TASK_TRANSITIONS: Record<SpaceTaskStatus, SpaceTaskStatus[]> = {
 	open: ['in_progress', 'blocked', 'done', 'cancelled'],
-	in_progress: ['open', 'review', 'done', 'blocked', 'cancelled'],
-	review: ['done', 'in_progress', 'cancelled', 'archived'], // Approve, reopen, cancel, or archive
-	// `approved` is the post-approval staging status added in PR 1/5 of the
-	// task-agent-as-post-approval-executor refactor. No runtime consumer
-	// transitions tasks INTO `approved` in PR 1 (intentionally: the enter
-	// edges belong to PR 2 which wires the post-approval router). The set
-	// below is conservative — enough for a manually-set `approved` row to be
-	// moved on, and enough for the `Record<SpaceTaskStatus, …>` type to
-	// accept every union member.
+	// `in_progress → approved` is the end-node `approve_task` path (PR 2/5 of
+	// the task-agent-as-post-approval-executor refactor). It replaces the
+	// `in_progress → done` shortcut that the completion-action pipeline used
+	// to take.
+	in_progress: ['open', 'review', 'approved', 'done', 'blocked', 'cancelled'],
+	// `review → approved` is the human-approves-the-work path — the
+	// `approvePendingCompletion` RPC handler takes a task out of `review`
+	// into `approved` so the post-approval router can dispatch.
+	review: ['done', 'approved', 'in_progress', 'cancelled', 'archived'],
+	// `approved → done` is driven by `mark_complete` (post-approval agent)
+	// or the runtime fallback on session termination. `approved → blocked`
+	// is intentionally absent in Stage 2: a failing post-approval session
+	// leaves the task in `approved` with `postApprovalBlockedReason` set
+	// and surfaces via `PendingPostApprovalBanner`.
 	approved: ['done', 'in_progress', 'archived'],
 	done: ['in_progress', 'archived'], // Reactivate or archive
 	blocked: ['open', 'in_progress', 'archived'], // Restart allowed + archive
@@ -151,6 +156,28 @@ export class SpaceTaskManager {
 			updates.approvalSource = options?.approvalSource ?? null;
 			updates.approvalReason = options?.approvalReason ?? null;
 			updates.approvedAt = Date.now();
+		}
+
+		// Stamp approval metadata when transitioning into the `approved` status
+		// (in_progress → approved, review → approved). Post-approval routing uses
+		// this as the canonical mid-lifecycle stamp before the Task Agent / spawned
+		// sub-session transitions the task forward to `done` via `mark_complete`.
+		if (newStatus === 'approved') {
+			updates.approvalSource = options?.approvalSource ?? null;
+			updates.approvalReason = options?.approvalReason ?? null;
+			updates.approvedAt = Date.now();
+		}
+
+		// Mirror the approval stamp on approved → done (via `mark_complete`),
+		// carrying through the original approvalSource so the audit trail is
+		// preserved once the task reaches its terminal state.
+		if (task.status === 'approved' && newStatus === 'done') {
+			if (options?.approvalSource !== undefined) {
+				updates.approvalSource = options.approvalSource;
+			}
+			if (options?.approvalReason !== undefined) {
+				updates.approvalReason = options.approvalReason;
+			}
 		}
 
 		// Clear result when restarting or deprioritizing.

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -125,7 +125,10 @@ export class SpaceTaskManager {
 			result?: string;
 			blockReason?: SpaceBlockReason;
 			approvalSource?: SpaceApprovalSource;
-			approvalReason?: string;
+			// `null` explicitly clears a prior value; `undefined` leaves any
+			// existing approvalReason untouched on transitions that carry the
+			// stamp forward (see the approved → done mirror below).
+			approvalReason?: string | null;
 		}
 	): Promise<SpaceTask> {
 		const task = await this.getTask(taskId);

--- a/packages/daemon/src/lib/space/runtime/post-approval-router.ts
+++ b/packages/daemon/src/lib/space/runtime/post-approval-router.ts
@@ -1,0 +1,412 @@
+/**
+ * PostApprovalRouter — deterministic dispatch for workflow post-approval routes.
+ *
+ * PR 2/5 of the task-agent-as-post-approval-executor refactor. See
+ * `docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md`
+ * §1.4 for the runtime-driven routing mechanics and §2.3 for the event shapes.
+ *
+ * ## What it does
+ *
+ * When a task transitions into `approved` (from the end-node `approve_task`
+ * path in `space-runtime.ts`, or from the human `approvePendingCompletion`
+ * RPC handler in `space-task-handlers.ts`), this router consults
+ * `workflow.postApproval` and performs one of three deterministic actions:
+ *
+ *   1. **No route declared** → runtime transitions `approved → done` directly
+ *      and emits `task.status-transition: approved → done source=no-post-approval`.
+ *   2. **`targetAgent === 'task-agent'`** → inject a `[POST_APPROVAL_INSTRUCTIONS]`
+ *      user turn into the existing Task Agent session. No new session spawn,
+ *      no `post_approval_session_id` stamped.
+ *   3. **Any other `targetAgent`** (a *space task node agent* — see terminology
+ *      below) → spawn a fresh sub-session for that agent with the interpolated
+ *      kickoff message, and stamp `post_approval_session_id` +
+ *      `post_approval_started_at` on the task.
+ *
+ * In all cases the router also emits a `[TASK_APPROVED]` awareness event into
+ * the Task Agent session (see §2.3). This is informational only — the Task
+ * Agent never *acts* on it; it only acts on the `[POST_APPROVAL_INSTRUCTIONS]`
+ * event that accompanies the `'task-agent'` route.
+ *
+ * ## Terminology — "space task node agent"
+ *
+ * Throughout this plan, "space task node agent" refers to an agent session
+ * spawned for a node in a space workflow run — distinct from the Task Agent
+ * (the orchestrator) and from ad-hoc chat sessions. In the current codebase
+ * this is the `'node_agent'` kind in
+ * `packages/shared/src/types/space.ts` (`SpaceMemberSession.kind`). See
+ * `PostApprovalRoute.targetAgent` in the same file: the validator in
+ * `post-approval-validator.ts` restricts valid targets to either the literal
+ * `'task-agent'` or the `name` of a declared `WorkflowNodeAgent`.
+ *
+ * ## Double-fire guard (§3.4)
+ *
+ * The router is idempotent against double-invocation for the node-agent-spawn
+ * case: if a task already has `postApprovalSessionId` set AND the referenced
+ * session is alive (not terminal), the router returns a no-op result with
+ * `mode: 'already-routed'`. For the inline `'task-agent'` and no-route cases
+ * the dispatch is cheap (message inject / status update) so we re-run without
+ * guarding; double-delivery of `[POST_APPROVAL_INSTRUCTIONS]` would be visible
+ * to the operator as conversation noise, not a failure.
+ *
+ * ## Feature flag
+ *
+ * This router is only invoked when the caller has confirmed the
+ * `NEOKAI_TASK_AGENT_POST_APPROVAL_ROUTING` feature flag is ON. The router
+ * itself performs no flag check — it trusts the caller. The flag is flipped
+ * ON in PR 3; for PR 2 the default is OFF so production runs continue to flow
+ * through `resolveCompletionWithActions` unchanged.
+ */
+
+import type {
+	SpaceTask,
+	SpaceWorkflow,
+	SpaceApprovalSource,
+	UpdateSpaceTaskParams,
+} from '@neokai/shared';
+import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import {
+	interpolatePostApprovalTemplate,
+	type PostApprovalTemplateContext,
+} from '../workflows/post-approval-template';
+import { POST_APPROVAL_TASK_AGENT_TARGET } from '../workflows/post-approval-validator';
+import { Logger } from '../../logger';
+
+const log = new Logger('post-approval-router');
+
+/**
+ * Feature-flag env var. Call-sites read this and only invoke the router when
+ * it is truthy (`'1'` or `'true'`). Exported so tests can assert on it and
+ * so the RPC handler + space-runtime share a single key.
+ */
+export const POST_APPROVAL_ROUTING_FLAG_ENV = 'NEOKAI_TASK_AGENT_POST_APPROVAL_ROUTING';
+
+/**
+ * Returns true when the feature flag is enabled via environment.
+ */
+export function isPostApprovalRoutingEnabled(
+	env: Readonly<Record<string, string | undefined>> = process.env
+): boolean {
+	const raw = env[POST_APPROVAL_ROUTING_FLAG_ENV];
+	if (!raw) return false;
+	const v = raw.trim().toLowerCase();
+	return v === '1' || v === 'true' || v === 'yes' || v === 'on';
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch delegates
+// ---------------------------------------------------------------------------
+
+/**
+ * Abstracts the Task Agent session as far as the router is concerned. The
+ * router only needs to inject two kinds of messages (awareness + post-approval
+ * instructions) — no other Task Agent surface is touched.
+ */
+export interface TaskAgentInjector {
+	/**
+	 * Inject a user-turn message into the Task Agent session for this task.
+	 *
+	 *   - Returns `{ injected: true, sessionId }` when the Task Agent was live
+	 *     and the message was enqueued.
+	 *   - Returns `{ injected: false }` when no Task Agent session exists for
+	 *     the task (e.g. the task was approved before any workflow ran).
+	 *     Callers log a warning but continue — awareness events are best-effort.
+	 */
+	injectIntoTaskAgent(
+		taskId: string,
+		message: string
+	): Promise<{ injected: boolean; sessionId?: string }>;
+}
+
+/**
+ * Delegate for spawning the post-approval sub-session on the
+ * space-task-node-agent path. Production wires this to
+ * `TaskAgentManager.spawnPostApprovalSubSession`; tests pass a stub.
+ *
+ * The delegate is responsible for everything that differs between a regular
+ * node activation and a post-approval activation:
+ *   - Creating a `NodeExecution` row (or reusing the agent's existing session).
+ *   - Attaching the same MCP server set that the target node would have.
+ *   - Injecting the `kickoffMessage` as the first user turn.
+ *   - Returning the spawned session ID so the router can stamp it on the task.
+ */
+export interface PostApprovalSubSessionSpawner {
+	spawnPostApprovalSubSession(args: {
+		task: SpaceTask;
+		workflow: SpaceWorkflow;
+		targetAgent: string;
+		kickoffMessage: string;
+	}): Promise<{ sessionId: string }>;
+}
+
+/**
+ * Optional delegate used to confirm that a previously-recorded
+ * `postApprovalSessionId` still points at a live session. When omitted the
+ * router treats any non-null `postApprovalSessionId` as live (conservative:
+ * it skips the second spawn). Production wires this to
+ * `TaskAgentManager.isSessionAlive`.
+ */
+export interface SessionLivenessProbe {
+	isSessionAlive(sessionId: string): boolean;
+}
+
+export interface PostApprovalRouterDeps {
+	taskRepo: Pick<SpaceTaskRepository, 'updateTask' | 'getTask'>;
+	taskAgent: TaskAgentInjector;
+	spawner: PostApprovalSubSessionSpawner;
+	livenessProbe?: SessionLivenessProbe;
+}
+
+// ---------------------------------------------------------------------------
+// Route inputs + outputs
+// ---------------------------------------------------------------------------
+
+/**
+ * Runtime context assembled by the caller. Includes every key that the
+ * template interpolator recognises (see
+ * `post-approval-template.ts:POST_APPROVAL_TEMPLATE_KEYS`) plus arbitrary
+ * extra keys signalled by the end-node agent (e.g. `pr_url`).
+ */
+export interface PostApprovalRouteContext extends PostApprovalTemplateContext {
+	/** How the task reached `approved`. Drives `[TASK_APPROVED]` payload shape. */
+	approvalSource: SpaceApprovalSource;
+	/** Slot/name of the agent that approved the task. */
+	reviewerName?: string;
+	/** Owning space ID. */
+	spaceId?: string;
+	/** Workspace path for the space's worktree. */
+	workspacePath?: string;
+	/** Space's autonomy level at routing time. */
+	autonomyLevel?: number;
+}
+
+/**
+ * Discriminated union describing which branch the router took.
+ *
+ *   - `mode: 'no-route'`        — no `postApproval` declared; task transitioned
+ *                                 directly `approved → done`.
+ *   - `mode: 'inline'`          — `targetAgent === 'task-agent'`; instructions
+ *                                 were injected into the Task Agent session.
+ *   - `mode: 'spawn'`           — a node-agent sub-session was spawned; its
+ *                                 ID was stamped on the task.
+ *   - `mode: 'already-routed'`  — idempotency guard: a prior spawn's session
+ *                                 is still alive, so this call is a no-op.
+ *   - `mode: 'skipped'`         — router precondition failed (e.g. missing
+ *                                 workflow, empty instructions for inline path).
+ *                                 Not a failure — caller may choose to surface.
+ */
+export type PostApprovalRouteResult =
+	| { mode: 'no-route'; taskStatus: 'done' }
+	| { mode: 'inline'; taskAgentSessionId?: string; missingKeys: string[] }
+	| {
+			mode: 'spawn';
+			postApprovalSessionId: string;
+			postApprovalStartedAt: number;
+			missingKeys: string[];
+	  }
+	| { mode: 'already-routed'; postApprovalSessionId: string }
+	| { mode: 'skipped'; reason: string };
+
+// ---------------------------------------------------------------------------
+// Event shapes (§2.3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the `[TASK_APPROVED]` awareness event body. Emitted on both the
+ * end-node and human-review paths, regardless of which mode the router
+ * eventually takes. See §2.3 of the plan for the exact shape.
+ */
+export function buildTaskApprovedEvent(args: {
+	task: SpaceTask;
+	workflow: SpaceWorkflow | null;
+	approvalSource: SpaceApprovalSource;
+	mode: 'spawning' | 'self' | 'none';
+}): string {
+	const workflowName = args.workflow?.name ?? 'none';
+	const targetAgent = args.workflow?.postApproval?.targetAgent ?? 'none';
+	const title = args.task.title ?? '(untitled)';
+	return (
+		`[TASK_APPROVED] Task ${args.task.id} ("${title}") was approved.\n\n` +
+		`Post-approval routing:\n` +
+		`  workflow: ${workflowName}\n` +
+		`  target_agent: ${targetAgent}\n` +
+		`  approval_source: ${args.approvalSource}\n` +
+		`  session_status: ${args.mode}\n\n` +
+		`No action required from you — this is informational. The runtime will\n` +
+		`spawn the post-approval session (if target_agent is a space task node\n` +
+		`agent) or deliver the instructions to you directly (if target_agent is\n` +
+		`"task-agent") or close the task immediately (if no target).`
+	);
+}
+
+/**
+ * Build the `[POST_APPROVAL_INSTRUCTIONS]` follow-up event. Only sent when
+ * `targetAgent === 'task-agent'`. See §2.3.
+ */
+export function buildPostApprovalInstructionsEvent(args: {
+	task: SpaceTask;
+	interpolatedInstructions: string;
+}): string {
+	return (
+		`[POST_APPROVAL_INSTRUCTIONS] Task ${args.task.id} post-approval work begins now.\n\n` +
+		`${args.interpolatedInstructions}\n\n` +
+		`When you finish (or need to abort), call mark_complete to transition the\n` +
+		`task from \`approved\` to \`done\`. If you need human input mid-work, call\n` +
+		`request_human_input as usual.`
+	);
+}
+
+// ---------------------------------------------------------------------------
+// PostApprovalRouter
+// ---------------------------------------------------------------------------
+
+/**
+ * Deterministic dispatcher for the post-approval step. Instantiated once by
+ * the runtime layer (see `space-runtime.ts`), reused for every approval.
+ */
+export class PostApprovalRouter {
+	constructor(private readonly deps: PostApprovalRouterDeps) {}
+
+	/**
+	 * Route a just-`approved` task. Must be called AFTER the caller has
+	 * transitioned the task into `approved` — the router inspects the
+	 * current task state but never performs the `in_progress → approved`
+	 * or `review → approved` hop itself (those live at the call sites so
+	 * their emit + liveness semantics stay local).
+	 */
+	async route(
+		task: SpaceTask,
+		workflow: SpaceWorkflow | null,
+		context: PostApprovalRouteContext
+	): Promise<PostApprovalRouteResult> {
+		// -------------------------------------------------------------------
+		// 0. Sanity: task MUST currently be in `approved`. If it isn't, the
+		//    caller misordered things — log loudly and skip.
+		// -------------------------------------------------------------------
+		if (task.status !== 'approved') {
+			const reason = `task ${task.id} is not in 'approved' (status=${task.status}); router will not dispatch`;
+			log.warn(`PostApprovalRouter.route: ${reason}`);
+			return { mode: 'skipped', reason };
+		}
+
+		const route = workflow?.postApproval;
+
+		// -------------------------------------------------------------------
+		// 1. No postApproval declared → close the task directly.
+		// -------------------------------------------------------------------
+		if (!route || !route.targetAgent) {
+			const updates: UpdateSpaceTaskParams = {
+				status: 'done',
+				completedAt: Date.now(),
+				postApprovalSessionId: null,
+				postApprovalStartedAt: null,
+				postApprovalBlockedReason: null,
+			};
+			this.deps.taskRepo.updateTask(task.id, updates);
+			log.info(
+				`post-approval.route: spaceId=${task.spaceId} taskId=${task.id} targetAgent=none mode=none autonomyLevel=${context.autonomyLevel ?? 'unknown'}`
+			);
+			log.info(
+				`task.status-transition: taskId=${task.id} from=approved to=done source=no-post-approval`
+			);
+			return { mode: 'no-route', taskStatus: 'done' };
+		}
+
+		const { targetAgent, instructions } = route;
+
+		// -------------------------------------------------------------------
+		// 2. Inline route — deliver instructions to the Task Agent.
+		// -------------------------------------------------------------------
+		if (targetAgent === POST_APPROVAL_TASK_AGENT_TARGET) {
+			const { text, missingKeys } = interpolatePostApprovalTemplate(instructions ?? '', context);
+			if (!text.trim()) {
+				const reason = `task ${task.id}: inline post-approval has empty instructions template`;
+				log.warn(`PostApprovalRouter.route: ${reason}`);
+				return { mode: 'skipped', reason };
+			}
+			const body = buildPostApprovalInstructionsEvent({
+				task,
+				interpolatedInstructions: text,
+			});
+			const { injected, sessionId } = await this.deps.taskAgent.injectIntoTaskAgent(task.id, body);
+			if (!injected) {
+				log.warn(
+					`PostApprovalRouter.route: no Task Agent session for task ${task.id} — [POST_APPROVAL_INSTRUCTIONS] not delivered`
+				);
+			}
+			if (missingKeys.length > 0) {
+				log.warn(
+					`PostApprovalRouter.route: task ${task.id} instructions referenced unknown keys: ${missingKeys.join(', ')}`
+				);
+			}
+			log.info(
+				`post-approval.route: spaceId=${task.spaceId} taskId=${task.id} targetAgent=${targetAgent} mode=inline autonomyLevel=${context.autonomyLevel ?? 'unknown'}`
+			);
+			return { mode: 'inline', taskAgentSessionId: sessionId, missingKeys };
+		}
+
+		// -------------------------------------------------------------------
+		// 3. Node-agent spawn route.
+		// -------------------------------------------------------------------
+
+		// Double-fire guard (§3.4): skip when an existing session is alive.
+		if (task.postApprovalSessionId) {
+			const alive = this.deps.livenessProbe
+				? this.deps.livenessProbe.isSessionAlive(task.postApprovalSessionId)
+				: true;
+			if (alive) {
+				log.info(
+					`PostApprovalRouter.route: task ${task.id} already has live post-approval session ${task.postApprovalSessionId}; skipping re-spawn`
+				);
+				return {
+					mode: 'already-routed',
+					postApprovalSessionId: task.postApprovalSessionId,
+				};
+			}
+		}
+
+		// Interpolate the kickoff from the workflow template.
+		const { text: kickoffMessage, missingKeys } = interpolatePostApprovalTemplate(
+			instructions ?? '',
+			context
+		);
+		if (!kickoffMessage.trim()) {
+			const reason = `task ${task.id}: node-agent post-approval has empty instructions template`;
+			log.warn(`PostApprovalRouter.route: ${reason}`);
+			return { mode: 'skipped', reason };
+		}
+		if (missingKeys.length > 0) {
+			log.warn(
+				`PostApprovalRouter.route: task ${task.id} kickoff referenced unknown keys: ${missingKeys.join(', ')}`
+			);
+		}
+		if (!workflow) {
+			const reason = `task ${task.id}: cannot spawn post-approval sub-session without workflow`;
+			log.warn(`PostApprovalRouter.route: ${reason}`);
+			return { mode: 'skipped', reason };
+		}
+
+		const startedAt = Date.now();
+		const { sessionId } = await this.deps.spawner.spawnPostApprovalSubSession({
+			task,
+			workflow,
+			targetAgent,
+			kickoffMessage,
+		});
+
+		this.deps.taskRepo.updateTask(task.id, {
+			postApprovalSessionId: sessionId,
+			postApprovalStartedAt: startedAt,
+			postApprovalBlockedReason: null,
+		});
+
+		log.info(
+			`post-approval.route: spaceId=${task.spaceId} taskId=${task.id} targetAgent=${targetAgent} mode=spawn autonomyLevel=${context.autonomyLevel ?? 'unknown'} sessionId=${sessionId}`
+		);
+		return {
+			mode: 'spawn',
+			postApprovalSessionId: sessionId,
+			postApprovalStartedAt: startedAt,
+			missingKeys,
+		};
+	}
+}

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -807,4 +807,30 @@ export class SpaceRuntimeService {
 	): Promise<SpaceTask | null> {
 		return this.runtime.resumeCompletionActions(spaceId, taskId, options);
 	}
+
+	/**
+	 * Dispatch post-approval routing for a task. Delegates to
+	 * `SpaceRuntime.dispatchPostApproval`, which:
+	 *   1. Transitions the task into `approved` (via `SpaceTaskManager.setTaskStatus`).
+	 *   2. Emits `[TASK_APPROVED]` into the Task Agent session (best-effort).
+	 *   3. Calls `PostApprovalRouter.route()` to dispatch the configured
+	 *      post-approval step (no-route, inline Task Agent, or spawn fresh
+	 *      node-agent sub-session).
+	 *
+	 * Called from the `spaceTask.approvePendingCompletion` RPC handler when a
+	 * human approves a task paused at a `task_completion` checkpoint AND the
+	 * `NEOKAI_TASK_AGENT_POST_APPROVAL_ROUTING` feature flag is ON.
+	 *
+	 * The `spaceId` argument is only used for logging at this layer — the
+	 * underlying runtime looks up the task's actual spaceId from the repository.
+	 */
+	async dispatchPostApproval(
+		spaceId: string,
+		taskId: string,
+		approvalSource: 'human' | 'agent',
+		contextExtras?: { reviewerName?: string; approvalReason?: string | null }
+	): Promise<void> {
+		log.info(`dispatchPostApproval: spaceId=${spaceId} taskId=${taskId} source=${approvalSource}`);
+		await this.runtime.dispatchPostApproval(taskId, approvalSource, contextExtras ?? {});
+	}
 }

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -49,6 +49,14 @@ import { buildRestrictedEnv, collectWithMaxBuffer, MAX_BUFFER_BYTES } from './ga
 import { CompletionDetector } from './completion-detector';
 import type { SelectWorkflowWithLlm } from './llm-workflow-selector';
 import {
+	PostApprovalRouter,
+	buildTaskApprovedEvent,
+	isPostApprovalRoutingEnabled,
+	type PostApprovalRouteContext,
+	type PostApprovalRouteResult,
+} from './post-approval-router';
+import type { SpaceApprovalSource } from '@neokai/shared';
+import {
 	type CompletionActionExecutionResult,
 	type InstructionActionExecutor,
 	type McpToolExecutor,
@@ -398,6 +406,146 @@ export class SpaceRuntime {
 	}
 
 	/**
+	 * Cached `PostApprovalRouter` instance (PR 2/5 of the
+	 * task-agent-as-post-approval-executor refactor). Built lazily on first use
+	 * because it depends on `taskAgentManager`, which is injected after
+	 * `SpaceRuntime` is constructed.
+	 */
+	private postApprovalRouter: PostApprovalRouter | null = null;
+
+	/**
+	 * Lazy-construct the `PostApprovalRouter` once `taskAgentManager` is
+	 * available. Returns `null` when the manager has not yet been injected —
+	 * the only expected scenario is very early startup before the daemon has
+	 * finished wiring, in which case we fall through to the legacy path.
+	 */
+	private getPostApprovalRouter(): PostApprovalRouter | null {
+		if (this.postApprovalRouter) return this.postApprovalRouter;
+		const manager = this.config.taskAgentManager;
+		if (!manager) return null;
+		this.postApprovalRouter = new PostApprovalRouter({
+			taskRepo: this.config.taskRepo,
+			taskAgent: {
+				injectIntoTaskAgent: (taskId, message) => manager.injectIntoTaskAgent(taskId, message),
+			},
+			spawner: {
+				spawnPostApprovalSubSession: (args) => manager.spawnPostApprovalSubSession(args),
+			},
+			livenessProbe: {
+				isSessionAlive: (sessionId) => manager.isSessionAlive(sessionId),
+			},
+		});
+		return this.postApprovalRouter;
+	}
+
+	/**
+	 * Public entry point — transition a task into `approved` and dispatch the
+	 * post-approval step via `PostApprovalRouter`.
+	 *
+	 * Called by:
+	 *   - The `space-runtime.ts` tick loop once an end-node `approve_task` has
+	 *     flagged the task ready to approve (via `reportedStatus='done'`), when
+	 *     `NEOKAI_TASK_AGENT_POST_APPROVAL_ROUTING` is ON. In PR 2/5 the flag
+	 *     defaults OFF so production runs continue through
+	 *     `resolveCompletionWithActions`.
+	 *   - `SpaceRuntimeService.dispatchPostApproval`, invoked from the
+	 *     `spaceTask.approvePendingCompletion` RPC handler when a human approves
+	 *     a task paused at a `task_completion` checkpoint.
+	 *
+	 * Contract:
+	 *   1. If the task is not already `approved`, transition it there via
+	 *      `SpaceTaskManager.setTaskStatus` (so the centralised transition
+	 *      validator runs).
+	 *   2. Emit a `[TASK_APPROVED]` awareness event into the Task Agent session
+	 *      on a best-effort basis (missing session → log + continue).
+	 *   3. Call `PostApprovalRouter.route()` — which handles the no-route,
+	 *      inline (Task Agent), spawn, already-routed, and skip branches.
+	 *
+	 * Returns the `PostApprovalRouteResult` from the router (or a `skipped`
+	 * result when the router is not yet wired / the task is missing).
+	 */
+	async dispatchPostApproval(
+		taskId: string,
+		approvalSource: SpaceApprovalSource,
+		contextExtras: Omit<PostApprovalRouteContext, 'approvalSource'> = {}
+	): Promise<PostApprovalRouteResult> {
+		const router = this.getPostApprovalRouter();
+		if (!router) {
+			const reason = `PostApprovalRouter not wired yet (taskAgentManager missing); task=${taskId}`;
+			log.warn(`dispatchPostApproval: ${reason}`);
+			return { mode: 'skipped', reason };
+		}
+
+		const current = this.config.taskRepo.getTask(taskId);
+		if (!current) {
+			const reason = `task ${taskId} not found`;
+			log.warn(`dispatchPostApproval: ${reason}`);
+			return { mode: 'skipped', reason };
+		}
+
+		const spaceId = current.spaceId;
+		const space = await this.config.spaceManager.getSpace(spaceId);
+		// Workflow lookup goes via the run (tasks reference workflowRunId, runs
+		// reference workflowId). Standalone tasks have no run → no workflow → the
+		// router takes the no-route branch.
+		const run = current.workflowRunId
+			? this.config.workflowRunRepo.getRun(current.workflowRunId)
+			: null;
+		const workflow = run
+			? (this.config.spaceWorkflowManager.getWorkflow(run.workflowId) ?? null)
+			: null;
+
+		// 1. Ensure the task is in `approved` before routing. Uses the space's
+		//    task manager so the transition validator runs (rejects illegal
+		//    transitions with a structured error).
+		let approvedTask: SpaceTask = current;
+		if (current.status !== 'approved') {
+			const taskManager = this.getOrCreateTaskManager(spaceId);
+			approvedTask = await taskManager.setTaskStatus(taskId, 'approved', {
+				approvalSource,
+			});
+			await this.safeOnTaskUpdated(spaceId, approvedTask);
+			log.info(
+				`task.status-transition: taskId=${taskId} from=${current.status} to=approved source=${approvalSource}`
+			);
+		}
+
+		// 2. Emit [TASK_APPROVED] awareness event (informational; best-effort).
+		const routeTarget = workflow?.postApproval?.targetAgent ?? null;
+		const mode: 'spawning' | 'self' | 'none' =
+			routeTarget === null || routeTarget === undefined
+				? 'none'
+				: routeTarget === 'task-agent'
+					? 'self'
+					: 'spawning';
+		const awarenessBody = buildTaskApprovedEvent({
+			task: approvedTask,
+			workflow,
+			approvalSource,
+			mode,
+		});
+		const manager = this.config.taskAgentManager;
+		if (manager) {
+			const injected = await manager.injectIntoTaskAgent(taskId, awarenessBody);
+			if (!injected.injected) {
+				log.warn(
+					`dispatchPostApproval: no Task Agent session for task ${taskId} — [TASK_APPROVED] not delivered`
+				);
+			}
+		}
+
+		// 3. Dispatch the actual post-approval step.
+		const routeContext: PostApprovalRouteContext = {
+			...contextExtras,
+			approvalSource,
+			spaceId,
+			autonomyLevel: space?.autonomyLevel,
+			workspacePath: space?.workspacePath,
+		};
+		return router.route(approvedTask, workflow, routeContext);
+	}
+
+	/**
 	 * Safely calls notificationSink.notify(), catching and logging any errors.
 	 *
 	 * By interface contract, NotificationSink implementations should handle their
@@ -626,19 +774,34 @@ export class SpaceRuntime {
 			if (
 				canonicalTask.status !== 'done' &&
 				canonicalTask.status !== 'review' &&
-				canonicalTask.status !== 'cancelled'
+				canonicalTask.status !== 'cancelled' &&
+				canonicalTask.status !== 'approved'
 			) {
-				// The completion-action pipeline is the sole arbiter of terminal
-				// status — we no longer read `reportedStatus` from the agent.
-				const params = await this.resolveCompletionWithActions(
-					run.spaceId,
-					run.id,
-					workflow,
-					nextResult,
-					spaceLevel,
-					canonicalTask.id
-				);
-				await this.updateTaskAndEmit(run.spaceId, canonicalTask.id, params);
+				// PR 2/5 (flag-gated): when NEOKAI_TASK_AGENT_POST_APPROVAL_ROUTING
+				// is ON, skip the legacy completion-action pipeline and dispatch
+				// through PostApprovalRouter (transition → approved → route). When
+				// the flag is OFF (default), keep the legacy completion-action path
+				// intact so production behaviour is unchanged.
+				if (isPostApprovalRoutingEnabled()) {
+					// Preserve the computed result on the task before routing —
+					// dispatchPostApproval handles the status transition itself.
+					if (nextResult && canonicalTask.result !== nextResult) {
+						await this.updateTaskAndEmit(run.spaceId, canonicalTask.id, { result: nextResult });
+					}
+					await this.dispatchPostApproval(canonicalTask.id, 'agent');
+				} else {
+					// The completion-action pipeline is the sole arbiter of terminal
+					// status — we no longer read `reportedStatus` from the agent.
+					const params = await this.resolveCompletionWithActions(
+						run.spaceId,
+						run.id,
+						workflow,
+						nextResult,
+						spaceLevel,
+						canonicalTask.id
+					);
+					await this.updateTaskAndEmit(run.spaceId, canonicalTask.id, params);
+				}
 			} else if (
 				nextResult &&
 				canonicalTask.result !== nextResult &&
@@ -1561,11 +1724,13 @@ export class SpaceRuntime {
 
 				// Skip re-resolution when the task is already at a non-`open`/non-`in_progress`
 				// status — `done`/`cancelled` are terminal; `review` means we've already paused
-				// at a completion-action gate and are awaiting human approval.
+				// at a completion-action gate and are awaiting human approval; `approved`
+				// means PostApprovalRouter already ran once (PR 2/5).
 				const taskAlreadyResolved =
 					canonicalTask.status === 'done' ||
 					canonicalTask.status === 'review' ||
-					canonicalTask.status === 'cancelled';
+					canonicalTask.status === 'cancelled' ||
+					canonicalTask.status === 'approved';
 
 				// Final status drives sibling cancellation. We only kill siblings when
 				// the task reached a true terminal state (`done`/`cancelled`); `review`
@@ -1574,20 +1739,41 @@ export class SpaceRuntime {
 				let finalTaskStatus: SpaceTask['status'] = canonicalTask.status;
 
 				if (!taskAlreadyResolved) {
-					// The completion-action pipeline is the sole arbiter of terminal
-					// status. The agent's `report_result` only records a summary +
-					// optional evidence on `reportedSummary`; terminal status is
-					// decided entirely by the outcome of the actions below.
-					const params = await this.resolveCompletionWithActions(
-						meta.spaceId,
-						runId,
-						meta.workflow,
-						nextTaskResult,
-						spaceLevel,
-						canonicalTask.id
-					);
-					await this.updateTaskAndEmit(meta.spaceId, canonicalTask.id, params);
-					finalTaskStatus = params.status ?? canonicalTask.status;
+					// PR 2/5 (flag-gated): when NEOKAI_TASK_AGENT_POST_APPROVAL_ROUTING
+					// is ON, dispatch through PostApprovalRouter; otherwise fall back
+					// to the legacy completion-action pipeline (unchanged).
+					if (isPostApprovalRoutingEnabled()) {
+						if (nextTaskResult && canonicalTask.result !== nextTaskResult) {
+							await this.updateTaskAndEmit(meta.spaceId, canonicalTask.id, {
+								result: nextTaskResult,
+							});
+						}
+						const result = await this.dispatchPostApproval(canonicalTask.id, 'agent');
+						// Resolve the final status from the router result. 'no-route'
+						// moved directly to done; 'inline' / 'spawn' / 'already-routed'
+						// parked at approved awaiting mark_complete.
+						finalTaskStatus =
+							result.mode === 'no-route'
+								? 'done'
+								: result.mode === 'skipped'
+									? canonicalTask.status
+									: 'approved';
+					} else {
+						// The completion-action pipeline is the sole arbiter of terminal
+						// status. The agent's `report_result` only records a summary +
+						// optional evidence on `reportedSummary`; terminal status is
+						// decided entirely by the outcome of the actions below.
+						const params = await this.resolveCompletionWithActions(
+							meta.spaceId,
+							runId,
+							meta.workflow,
+							nextTaskResult,
+							spaceLevel,
+							canonicalTask.id
+						);
+						await this.updateTaskAndEmit(meta.spaceId, canonicalTask.id, params);
+						finalTaskStatus = params.status ?? canonicalTask.status;
+					}
 				} else if (summary && canonicalTask.result !== summary) {
 					await this.updateTaskAndEmit(meta.spaceId, canonicalTask.id, { result: summary });
 				}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -498,11 +498,25 @@ export class SpaceRuntime {
 		// 1. Ensure the task is in `approved` before routing. Uses the space's
 		//    task manager so the transition validator runs (rejects illegal
 		//    transitions with a structured error).
+		//
+		//    `approvalReason` must be forwarded from `contextExtras` (the RPC
+		//    handler passes the operator's rejection/approval note) — otherwise
+		//    `SpaceTaskManager.setTaskStatus` would stamp `null` and overwrite
+		//    the value the caller may have already written via `updateTask`.
+		//    We distinguish missing (undefined) from explicit null so an
+		//    explicit clear still wins.
+		const resolvedApprovalReason =
+			typeof contextExtras.approvalReason === 'string'
+				? contextExtras.approvalReason
+				: contextExtras.approvalReason === null
+					? null
+					: undefined;
 		let approvedTask: SpaceTask = current;
 		if (current.status !== 'approved') {
 			const taskManager = this.getOrCreateTaskManager(spaceId);
 			approvedTask = await taskManager.setTaskStatus(taskId, 'approved', {
 				approvalSource,
+				approvalReason: resolvedApprovalReason,
 			});
 			await this.safeOnTaskUpdated(spaceId, approvedTask);
 			log.info(
@@ -542,7 +556,20 @@ export class SpaceRuntime {
 			autonomyLevel: space?.autonomyLevel,
 			workspacePath: space?.workspacePath,
 		};
-		return router.route(approvedTask, workflow, routeContext);
+		const routeResult = await router.route(approvedTask, workflow, routeContext);
+
+		// 4. Re-read and emit so UI listeners see the post-dispatch task state
+		//    (no-route → `done`, inline → `approvalReason` stamped, spawn →
+		//    `postApprovalSessionId` stamped). The router performs its own
+		//    `taskRepo.updateTask` writes without emitting; without this the
+		//    end-node tick path would leave the UI waiting until the next poll.
+		//    The RPC path also emits via `daemonHub` after this returns — the
+		//    double emit is benign (idempotent UI refresh).
+		if (routeResult.mode !== 'skipped') {
+			const final = this.config.taskRepo.getTask(taskId);
+			if (final) await this.safeOnTaskUpdated(spaceId, final);
+		}
+		return routeResult;
 	}
 
 	/**

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -74,7 +74,7 @@ import type { SpaceWorktreeManager } from '../managers/space-worktree-manager';
 import type { SubSessionMemberInfo } from '../tools/task-agent-tools';
 import { createTaskAgentMcpServer } from '../tools/task-agent-tools';
 import { createNodeAgentMcpServer } from '../tools/node-agent-tools';
-import { createEndNodeHandlers } from '../tools/end-node-handlers';
+import { createEndNodeHandlers, createMarkCompleteHandler } from '../tools/end-node-handlers';
 import { createSpaceAgentMcpServer } from '../tools/space-agent-tools';
 import { createDbQueryMcpServer, type DbQueryMcpServer } from '../../db-query/tools';
 import { ChannelResolver } from './channel-resolver';
@@ -3589,6 +3589,25 @@ export class TaskAgentManager {
 		const onApproveTask = endNodeHandlers?.onApproveTask;
 		const onSubmitForApproval = endNodeHandlers?.onSubmitForApproval;
 
+		// `mark_complete` (PR 2/5) is mirrored onto every spawned node-agent so
+		// post-approval sub-sessions can close the task via `approved → done`.
+		// The handler self-validates status (rejects non-approved) — a spawned
+		// agent that happens not to be running a post-approval step simply sees
+		// the tool reject with a clear error. Each session gets its own bound
+		// SpaceTaskManager so the centralised transition validator runs.
+		const markCompleteTaskManager = new SpaceTaskManager(
+			this.config.db.getDatabase(),
+			spaceId,
+			this.config.reactiveDb
+		);
+		const onMarkComplete = createMarkCompleteHandler({
+			taskId,
+			spaceId,
+			taskRepo: this.config.taskRepo,
+			taskManager: markCompleteTaskManager,
+			daemonHub: this.config.daemonHub,
+		});
+
 		// Self-heal callback for the agent-callable `restore_node_agent` tool.
 		// Looks up the live AgentSession by the enclosing-scope subSessionId, then
 		// calls reinjectNodeAgentMcpServer to (re)attach node-agent and restart the query
@@ -3654,6 +3673,7 @@ export class TaskAgentManager {
 			},
 			onApproveTask,
 			onSubmitForApproval,
+			onMarkComplete,
 			artifactRepo: this.config.artifactRepo,
 			getSpaceAutonomyLevel: async (sid) => {
 				const s = await spaceManager.getSpace(sid);
@@ -3661,5 +3681,197 @@ export class TaskAgentManager {
 			},
 			onRestoreNodeAgent,
 		});
+	}
+
+	// -------------------------------------------------------------------------
+	// Public — post-approval routing delegates (PR 2/5)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Inject a user-turn message into the Task Agent session for a task.
+	 *
+	 * Thin wrapper around `injectTaskAgentMessage` that matches the
+	 * `TaskAgentInjector` shape consumed by `PostApprovalRouter`: returns
+	 * `{ injected, sessionId }` instead of throwing when no Task Agent session
+	 * exists for the task. Callers treat `injected: false` as a best-effort miss
+	 * (log + continue) rather than a hard error.
+	 */
+	async injectIntoTaskAgent(
+		taskId: string,
+		message: string
+	): Promise<{ injected: boolean; sessionId?: string }> {
+		const existing = this.taskAgentSessions.get(taskId);
+		const persisted = existing ? null : this.config.taskRepo.getTask(taskId);
+		if (!existing && !persisted?.taskAgentSessionId) {
+			return { injected: false };
+		}
+		try {
+			await this.injectTaskAgentMessage(taskId, message);
+		} catch (err) {
+			log.warn(
+				`TaskAgentManager.injectIntoTaskAgent: failed for task ${taskId}: ${err instanceof Error ? err.message : String(err)}`
+			);
+			return { injected: false };
+		}
+		const session = this.taskAgentSessions.get(taskId);
+		return { injected: true, sessionId: session?.session.id };
+	}
+
+	/**
+	 * Spawn a fresh sub-session for a post-approval node-agent handoff (PR 2/5).
+	 *
+	 * Called by `PostApprovalRouter` when the workflow declares a
+	 * `postApproval.targetAgent` that is NOT `'task-agent'`. The flow:
+	 *
+	 *   1. Look up the agent slot in the workflow by name (matches against both
+	 *      slot.name and agent display name).
+	 *   2. Build an `AgentSessionInit` using the same resolver the regular node
+	 *      activation path uses (so tool registry + system prompt line up).
+	 *   3. Attach the same MCP server surface as a normal node-agent spawn —
+	 *      `node-agent` (with `mark_complete` mirrored) and `space-agent-tools`.
+	 *   4. Kick off the session with the interpolated post-approval instructions
+	 *      as the first user turn.
+	 *
+	 * Returns `{ sessionId }`. The caller (router) stamps this onto
+	 * `space_tasks.post_approval_session_id` so the UI banner can render a
+	 * link + human operators have a jump-off point for manual abort.
+	 *
+	 * Failures throw; the router logs and surfaces `mode: 'skipped'` upstream.
+	 */
+	async spawnPostApprovalSubSession(args: {
+		task: SpaceTask;
+		workflow: SpaceWorkflow;
+		targetAgent: string;
+		kickoffMessage: string;
+	}): Promise<{ sessionId: string }> {
+		const { task, workflow, targetAgent, kickoffMessage } = args;
+		const taskId = task.id;
+		const spaceId = task.spaceId;
+
+		const space = await this.config.spaceManager.getSpace(spaceId);
+		if (!space) {
+			throw new Error(`spawnPostApprovalSubSession: space ${spaceId} not found for task ${taskId}`);
+		}
+
+		// Locate the declared agent slot across all nodes. `targetAgent` is validated
+		// at workflow-save time to match a WorkflowNodeAgent.name; we also accept the
+		// underlying agent's display name / id as a fallback for extra robustness.
+		let matchedSlot: ReturnType<typeof resolveNodeAgents>[number] | null = null;
+		let matchedNodeId: string | null = null;
+		for (const node of workflow.nodes) {
+			for (const slot of resolveNodeAgents(node)) {
+				if (slot.name === targetAgent || slot.agentId === targetAgent) {
+					matchedSlot = slot;
+					matchedNodeId = node.id;
+					break;
+				}
+			}
+			if (matchedSlot) break;
+		}
+		if (!matchedSlot?.agentId || !matchedNodeId) {
+			throw new Error(
+				`spawnPostApprovalSubSession: no agent slot "${targetAgent}" declared in workflow ${workflow.id}`
+			);
+		}
+
+		const workflowRunId = task.workflowRunId;
+		const workflowRun = workflowRunId ? this.config.workflowRunRepo.getRun(workflowRunId) : null;
+
+		const workspacePath = this.taskWorktreePaths.get(taskId) ?? space.workspacePath;
+
+		// Build slot overrides + init in the same shape as spawnWorkflowNodeAgentForExecution.
+		let slotCustomPrompt: string | undefined = matchedSlot.customPrompt?.value;
+		if (!slotCustomPrompt) {
+			const legacySlot = matchedSlot as {
+				systemPrompt?: { value: string };
+				instructions?: { value: string };
+			};
+			const legacySp = legacySlot.systemPrompt?.value?.trim() ?? '';
+			const legacyInstr = legacySlot.instructions?.value?.trim() ?? '';
+			if (legacySp && legacyInstr) {
+				slotCustomPrompt = `${legacySp}\n\n${legacyInstr}`;
+			} else {
+				slotCustomPrompt = legacySp || legacyInstr || undefined;
+			}
+		}
+		const slotOverrides: SlotOverrides = {
+			model: matchedSlot.model,
+			customPrompt: slotCustomPrompt,
+			disabledSkillIds: matchedSlot.disabledSkillIds,
+			extraMcpServers: matchedSlot.extraMcpServers,
+		};
+
+		const baseSessionId = `space:${spaceId}:task:${taskId}:post-approval:${this.sanitizeAgentNameForId(matchedSlot.name)}`;
+		const sessionId = this.resolveSessionId(baseSessionId);
+
+		let init = resolveAgentInit({
+			task,
+			space,
+			agentManager: this.config.spaceAgentManager,
+			sessionId,
+			workspacePath,
+			workflowRun: workflowRun ?? undefined,
+			workflow,
+			slotOverrides,
+			agentId: matchedSlot.agentId,
+		});
+
+		const nodeAgentMcpServer = this.buildNodeAgentMcpServerForSession(
+			taskId,
+			sessionId,
+			matchedSlot.name,
+			spaceId,
+			workflowRunId ?? '',
+			workspacePath,
+			matchedNodeId
+		);
+		const subSessionSpaceAgentMcpServer = this.buildSpaceAgentToolsMcpServerForSubSession({
+			taskId,
+			subSessionId: sessionId,
+			agentName: matchedSlot.name,
+			spaceId,
+			workflowRunId: workflowRunId ?? '',
+			workspacePath,
+			workflowNodeId: matchedNodeId,
+		});
+		init = {
+			...init,
+			mcpServers: {
+				...init.mcpServers,
+				'node-agent': nodeAgentMcpServer as unknown as McpServerConfig,
+				'space-agent-tools': subSessionSpaceAgentMcpServer as unknown as McpServerConfig,
+			},
+		};
+
+		const actualSessionId = await this.createSubSession(taskId, sessionId, init, {
+			agentId: matchedSlot.agentId,
+			agentName: matchedSlot.name,
+			nodeId: matchedNodeId,
+		});
+
+		const spawned = this.getSubSession(actualSessionId);
+		if (!spawned) {
+			throw new Error(
+				`spawnPostApprovalSubSession: spawned session ${actualSessionId} not registered in memory`
+			);
+		}
+
+		await this.ensureNodeAgentAttached(spawned, {
+			taskId,
+			subSessionId: actualSessionId,
+			agentName: matchedSlot.name,
+			spaceId,
+			workflowRunId: workflowRunId ?? '',
+			workspacePath,
+			workflowNodeId: matchedNodeId,
+			phase: 'spawn',
+		});
+
+		await this.injectMessageIntoSession(spawned, kickoffMessage);
+
+		log.info(
+			`TaskAgentManager.spawnPostApprovalSubSession: spawned session ${actualSessionId} for agent "${matchedSlot.name}" (task ${taskId}, node ${matchedNodeId})`
+		);
+		return { sessionId: actualSessionId };
 	}
 }

--- a/packages/daemon/src/lib/space/tools/end-node-handlers.ts
+++ b/packages/daemon/src/lib/space/tools/end-node-handlers.ts
@@ -26,11 +26,16 @@
 
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 import type { SpaceManager } from '../managers/space-manager';
+import type { SpaceTaskManager } from '../managers/space-task-manager';
 import type { DaemonHub } from '../../daemon-hub';
 import type { SpaceTask, SpaceWorkflow } from '@neokai/shared';
 import type { ToolResult } from './tool-result';
 import { jsonResult } from './tool-result';
-import type { ApproveTaskInput, SubmitForApprovalInput } from './task-agent-tool-schemas';
+import type {
+	ApproveTaskInput,
+	SubmitForApprovalInput,
+	MarkCompleteInput,
+} from './task-agent-tool-schemas';
 import { Logger } from '../../logger';
 
 const log = new Logger('end-node-handlers');
@@ -62,6 +67,88 @@ export interface EndNodeHandlerDeps {
 export interface EndNodeHandlers {
 	onApproveTask: (args: ApproveTaskInput) => Promise<ToolResult>;
 	onSubmitForApproval: (args: SubmitForApprovalInput) => Promise<ToolResult>;
+}
+
+/**
+ * Standalone factory for the `mark_complete` handler (PR 2/5). Separate from
+ * `createEndNodeHandlers` because `mark_complete` is mirrored onto
+ * post-approval sub-sessions — which are NOT necessarily end-node sessions —
+ * and also onto the orchestration Task Agent's MCP surface directly.
+ *
+ * Transitions the task `approved → done` via `SpaceTaskManager.setTaskStatus`
+ * (so the centralised transition validator runs), clears the post-approval
+ * tracking fields, and emits a `space.task.updated` DaemonHub event.
+ */
+export interface MarkCompleteHandlerDeps {
+	taskId: string;
+	spaceId: string;
+	/** Task repository — used to read the current status before transitioning. */
+	taskRepo: Pick<SpaceTaskRepository, 'getTask'>;
+	/** Task manager — used to transition and update the task atomically. */
+	taskManager: Pick<SpaceTaskManager, 'setTaskStatus' | 'updateTask'>;
+	/** Optional hub for emitting `space.task.updated` events. */
+	daemonHub?: Pick<DaemonHub, 'emit'>;
+}
+
+/**
+ * Create a bound `mark_complete` handler. See the type-level doc on the
+ * `mark_complete` tool registration in `task-agent-tools.ts` /
+ * `node-agent-tools.ts` for the wider contract.
+ */
+export function createMarkCompleteHandler(
+	deps: MarkCompleteHandlerDeps
+): (args: MarkCompleteInput) => Promise<ToolResult> {
+	const { taskId, spaceId, taskRepo, taskManager, daemonHub } = deps;
+
+	const emitTaskUpdated = (task: SpaceTask): void => {
+		if (!daemonHub) return;
+		void daemonHub
+			.emit('space.task.updated', { sessionId: 'global', spaceId, taskId, task })
+			.catch((err: unknown) => {
+				log.warn(
+					`Failed to emit space.task.updated for task ${taskId}: ${err instanceof Error ? err.message : String(err)}`
+				);
+			});
+	};
+
+	return async (_args: MarkCompleteInput): Promise<ToolResult> => {
+		const task = taskRepo.getTask(taskId);
+		if (!task) return jsonResult({ success: false, error: `Task not found: ${taskId}` });
+
+		if (task.status !== 'approved') {
+			return jsonResult({
+				success: false,
+				error:
+					`task is not in \`approved\` status (current: \`${task.status}\`); did you mean \`approve_task\`? ` +
+					`mark_complete only transitions an already-approved task from 'approved' to 'done'.`,
+			});
+		}
+
+		try {
+			await taskManager.setTaskStatus(taskId, 'done', {
+				approvalSource: task.approvalSource ?? 'agent',
+			});
+			const updated = await taskManager.updateTask(taskId, {
+				postApprovalSessionId: null,
+				postApprovalStartedAt: null,
+				postApprovalBlockedReason: null,
+			});
+			emitTaskUpdated(updated);
+			log.info(
+				`post-approval.complete: spaceId=${spaceId} taskId=${taskId} outcome=done mode=${task.postApprovalSessionId ? 'spawn' : 'inline'}`
+			);
+			return jsonResult({
+				success: true,
+				taskId,
+				message: 'Post-approval work finished. Task transitioned to done.',
+			});
+		} catch (err) {
+			return jsonResult({
+				success: false,
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+	};
 }
 
 /**

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -29,8 +29,16 @@
 
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import type { DaemonHub } from '../../daemon-hub';
-import { ApproveTaskSchema, SubmitForApprovalSchema } from './task-agent-tool-schemas';
-import type { ApproveTaskInput, SubmitForApprovalInput } from './task-agent-tool-schemas';
+import {
+	ApproveTaskSchema,
+	SubmitForApprovalSchema,
+	MarkCompleteSchema,
+} from './task-agent-tool-schemas';
+import type {
+	ApproveTaskInput,
+	SubmitForApprovalInput,
+	MarkCompleteInput,
+} from './task-agent-tool-schemas';
 import { Logger } from '../../logger';
 import type { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
 import { ChannelResolver } from '../runtime/channel-resolver';
@@ -171,6 +179,15 @@ export interface NodeAgentToolsConfig {
 	 * human review even when they could self-close.
 	 */
 	onSubmitForApproval?: (args: SubmitForApprovalInput) => Promise<ToolResult>;
+	/**
+	 * Optional callback for the `mark_complete` tool (PR 2/5 of the
+	 * task-agent-as-post-approval-executor refactor). When provided, the tool
+	 * is mirrored onto this node-agent's MCP surface so a spawned post-approval
+	 * sub-session can close its task directly via `approved → done`. Routed
+	 * through the same `mark_complete` handler the Task Agent uses — the
+	 * autonomy / status validation is centralised on the task side.
+	 */
+	onMarkComplete?: (args: MarkCompleteInput) => Promise<ToolResult>;
 	/**
 	 * Resolves the space's current autonomy level.
 	 * When provided, agent gate writes via send_message are blocked when
@@ -1161,6 +1178,21 @@ export function createNodeAgentMcpServer(config: NodeAgentToolsConfig) {
 							'optional `reason` explaining why you are escalating; it is shown in the approval UI.',
 						SubmitForApprovalSchema.shape,
 						(args) => config.onSubmitForApproval!(args)
+					),
+				]
+			: []),
+		...(config.onMarkComplete
+			? [
+					tool(
+						'mark_complete',
+						'Finish post-approval work and transition the task from `approved` to `done`. ' +
+							'Call this after the post-approval instructions (e.g. merging a PR, ' +
+							'publishing a release) have been carried out. Takes no arguments — the ' +
+							'task is inferred from your session context. Distinct from `approve_task`: ' +
+							'`approve_task` handles `in_progress → approved`; `mark_complete` handles ' +
+							'`approved → done`. Rejected if the task is not currently in `approved`.',
+						MarkCompleteSchema.shape,
+						(args) => config.onMarkComplete!(args)
 					),
 				]
 			: []),

--- a/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
@@ -6,6 +6,7 @@
  * Tools (defined in this file):
  *   approve_task          — self-close the task (gated by autonomy level)
  *   submit_for_approval   — request human sign-off
+ *   mark_complete         — finish post-approval work (`approved → done`)
  *   request_human_input   — pause execution and surface a question to the human user
  *   list_group_members    — list all members of the current task's session group
  *
@@ -74,6 +75,30 @@ export const SubmitForApprovalSchema = z
 export type SubmitForApprovalInput = z.infer<typeof SubmitForApprovalSchema>;
 
 // ---------------------------------------------------------------------------
+// mark_complete
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `mark_complete` input.
+ *
+ * Post-approval completion tool. Added in PR 2/5 of the
+ * task-agent-as-post-approval-executor refactor. Transitions the task from
+ * `approved → done` once the post-approval agent (the Task Agent itself when
+ * the workflow's `postApproval.targetAgent === 'task-agent'`, or a spawned
+ * space-task-node-agent sub-session otherwise) has finished its work.
+ *
+ * Distinct from `approve_task`:
+ *   - `approve_task`  covers `in_progress → approved` (work is good).
+ *   - `mark_complete` covers `approved → done`       (post-approval finished).
+ *
+ * Takes no arguments — the task is implicit from the calling session's
+ * context. Strict schema so future fields fail fast until explicitly added.
+ */
+export const MarkCompleteSchema = z.object({}).strict();
+
+export type MarkCompleteInput = z.infer<typeof MarkCompleteSchema>;
+
+// ---------------------------------------------------------------------------
 // request_human_input
 // ---------------------------------------------------------------------------
 
@@ -117,6 +142,7 @@ export type ListGroupMembersInput = z.infer<typeof ListGroupMembersSchema>;
 export const TASK_AGENT_TOOL_SCHEMAS = {
 	approve_task: ApproveTaskSchema,
 	submit_for_approval: SubmitForApprovalSchema,
+	mark_complete: MarkCompleteSchema,
 	request_human_input: RequestHumanInputSchema,
 	list_group_members: ListGroupMembersSchema,
 } as const;

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -6,6 +6,7 @@
  *   list_artifacts        — List artifacts for the current workflow run
  *   approve_task          — Self-close the task (gated by autonomy level)
  *   submit_for_approval   — Request human sign-off (always available)
+ *   mark_complete         — Transition `approved → done` after post-approval work finishes
  *   request_human_input   — Pause execution and surface a question to the human user
  *   list_group_members    — List all members of the current task's session group
  *   send_message          — Send a message to peer node agents via channel topology
@@ -41,6 +42,7 @@ import type { ToolResult } from './tool-result';
 import {
 	ApproveTaskSchema,
 	SubmitForApprovalSchema,
+	MarkCompleteSchema,
 	RequestHumanInputSchema,
 	ListGroupMembersSchema,
 } from './task-agent-tool-schemas';
@@ -52,6 +54,7 @@ import {
 import type {
 	ApproveTaskInput,
 	SubmitForApprovalInput,
+	MarkCompleteInput,
 	RequestHumanInputInput,
 	ListGroupMembersInput,
 } from './task-agent-tool-schemas';
@@ -343,11 +346,19 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		},
 
 		/**
-		 * Self-close this task as done.
+		 * Self-close this task as done (PR 2/5 behaviour unchanged).
 		 *
 		 * Gated by space.autonomyLevel >= workflow.completionAutonomyLevel.
 		 * For standalone tasks (no workflow), always requires human review (blocked at level 1-4).
-		 * Sets reportedStatus='done' which triggers the completion-action pipeline.
+		 * Sets reportedStatus='done' which triggers the completion-action pipeline
+		 * (or, when NEOKAI_TASK_AGENT_POST_APPROVAL_ROUTING is enabled, the new
+		 * runtime path that transitions `in_progress → approved` and hands off to
+		 * PostApprovalRouter).
+		 *
+		 * This tool only handles the `in_progress → approved` hop. For the
+		 * subsequent `approved → done` transition after post-approval work is
+		 * finished, use `mark_complete`. Calling `approve_task` on a task that
+		 * is already `approved` is rejected as a guardrail.
 		 */
 		async approve_task(_args: ApproveTaskInput): Promise<ToolResult> {
 			const currentLevel = space.autonomyLevel ?? 1;
@@ -374,6 +385,19 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 			const task = taskRepo.getTask(taskId);
 			if (!task) return jsonResult({ success: false, error: `Task not found: ${taskId}` });
 
+			// Guardrail (§3.2): approve_task only handles `in_progress → approved`.
+			// Calling it on a task already in `approved` is a protocol error —
+			// the caller probably meant `mark_complete`.
+			if (task.status === 'approved') {
+				return jsonResult({
+					success: false,
+					error:
+						`approve_task cannot re-approve a task already in 'approved' status. ` +
+						`Did you mean mark_complete? approve_task handles 'in_progress → approved'; ` +
+						`mark_complete handles 'approved → done' once post-approval work finishes.`,
+				});
+			}
+
 			try {
 				const updated = taskRepo.updateTask(taskId, {
 					reportedStatus: 'done',
@@ -388,6 +412,61 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 					taskId,
 					message:
 						'Task approved for completion. The completion-action pipeline will now resolve terminal status.',
+				});
+			} catch (err) {
+				return jsonResult({
+					success: false,
+					error: err instanceof Error ? err.message : String(err),
+				});
+			}
+		},
+
+		/**
+		 * Finish post-approval work — transition `approved → done`.
+		 *
+		 * Added in PR 2/5 of the task-agent-as-post-approval-executor refactor.
+		 * Called by whichever agent performs the post-approval step: the Task
+		 * Agent itself when `workflow.postApproval.targetAgent === 'task-agent'`,
+		 * or the spawned space-task-node-agent sub-session otherwise.
+		 *
+		 * Transitions the task `approved → done`, clears
+		 * `post_approval_session_id` and `post_approval_started_at`, and emits a
+		 * `space.task.updated` event. Rejects on any non-`approved` status with a
+		 * message that points the caller at the correct tool.
+		 */
+		async mark_complete(_args: MarkCompleteInput): Promise<ToolResult> {
+			const task = taskRepo.getTask(taskId);
+			if (!task) return jsonResult({ success: false, error: `Task not found: ${taskId}` });
+
+			if (task.status !== 'approved') {
+				return jsonResult({
+					success: false,
+					error:
+						`task is not in \`approved\` status (current: \`${task.status}\`); did you mean \`approve_task\`? ` +
+						`mark_complete only transitions an already-approved task from 'approved' to 'done'.`,
+				});
+			}
+
+			try {
+				// Use taskManager.setTaskStatus so the approved → done edge runs
+				// through the centralised transition validator.
+				let updated = await taskManager.setTaskStatus(taskId, 'done', {
+					approvalSource: task.approvalSource ?? 'agent',
+				});
+				// Clear post-approval tracking fields.
+				updated = await taskManager.updateTask(taskId, {
+					postApprovalSessionId: null,
+					postApprovalStartedAt: null,
+					postApprovalBlockedReason: null,
+				});
+				emitTaskUpdated(updated);
+				log.info(
+					`post-approval.complete: spaceId=${space.id} taskId=${taskId} outcome=done mode=${task.postApprovalSessionId ? 'spawn' : 'inline'}`
+				);
+				return jsonResult({
+					success: true,
+					taskId,
+					message: 'Post-approval work finished. Task transitioned to done.',
 				});
 			} catch (err) {
 				return jsonResult({
@@ -1054,6 +1133,18 @@ export function createTaskAgentMcpServer(config: TaskAgentToolsConfig) {
 				'optional `reason` explaining why you are escalating; it is shown in the approval UI.',
 			SubmitForApprovalSchema.shape,
 			(args) => handlers.submit_for_approval(args)
+		),
+		tool(
+			'mark_complete',
+			'Finish post-approval work and transition the task from `approved` to `done`. ' +
+				'Call this after you (or the spawned post-approval sub-session) have completed ' +
+				"the workflow's post-approval instructions (e.g. merging a PR, publishing a release). " +
+				'Takes no arguments — the task is inferred from your session context. ' +
+				'Distinct from `approve_task`: `approve_task` handles `in_progress → approved` ' +
+				'(the work is good), whereas `mark_complete` handles `approved → done` ' +
+				'(post-approval work finished). Rejected if the task is not currently in `approved`.',
+			MarkCompleteSchema.shape,
+			(args) => handlers.mark_complete(args)
 		),
 	];
 

--- a/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
@@ -592,10 +592,14 @@ describe('SpaceTaskManager', () => {
 			]);
 		});
 
-		it('in_progress allows open, review, done, blocked, and cancelled', () => {
+		it('in_progress allows open, review, approved, done, blocked, and cancelled', () => {
+			// `approved` was added in PR 2/5 of the task-agent-as-post-approval
+			// executor refactor; end-node `approve_task` transitions `in_progress →
+			// approved` so the post-approval router can dispatch.
 			expect(VALID_SPACE_TASK_TRANSITIONS.in_progress).toEqual([
 				'open',
 				'review',
+				'approved',
 				'done',
 				'blocked',
 				'cancelled',

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-mark-complete.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-mark-complete.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Unit tests for the `mark_complete` Task Agent tool (PR 2/5).
+ *
+ * Contract:
+ *   - Happy path: task in `approved` → transitions `approved → done`, clears
+ *     post-approval tracking fields, emits `space.task.updated`.
+ *   - Wrong status: returns a structured error suggesting `approve_task`.
+ *   - `approve_task` on already-approved: returns a guardrail error.
+ */
+
+import { mock } from 'bun:test';
+
+// Mirror the SDK mock used elsewhere so tests can reflect on tool metadata.
+mock.module('@anthropic-ai/claude-agent-sdk', () => {
+	class MockMcpServer {
+		readonly _registeredTools: Record<string, object> = {};
+		connect(): void {}
+		disconnect(): void {}
+	}
+	let _toolBatch: Array<{ name: string; def: object }> = [];
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	function tool(name: string, description: string, inputSchema: any, handler: unknown): object {
+		const def = { name, description, inputSchema, handler };
+		_toolBatch.push({ name, def });
+		return def;
+	}
+	return {
+		query: mock(async () => ({ interrupt: () => {} })),
+		interrupt: mock(async () => {}),
+		supportedModels: mock(async () => {
+			throw new Error('SDK unavailable');
+		}),
+		createSdkMcpServer: mock((_opts: { name: string; version?: string; tools?: unknown[] }) => {
+			const server = new MockMcpServer();
+			for (const { name, def } of _toolBatch) {
+				server._registeredTools[name] = def;
+			}
+			if (Object.keys(server._registeredTools).length === 0 && Array.isArray(_opts.tools)) {
+				for (const t of _opts.tools) {
+					const td = t as { name?: string };
+					if (td.name) server._registeredTools[td.name] = t;
+				}
+			}
+			_toolBatch = [];
+			return {
+				type: 'sdk' as const,
+				name: _opts.name,
+				version: _opts.version ?? '1.0.0',
+				tools: _opts.tools ?? [],
+				instance: server,
+			};
+		}),
+		tool,
+	};
+});
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
+import { WorkflowRunArtifactRepository } from '../../../../src/storage/repositories/workflow-run-artifact-repository.ts';
+import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
+import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
+import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
+import { SpaceTaskManager } from '../../../../src/lib/space/managers/space-task-manager.ts';
+import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
+import { createTaskAgentToolHandlers } from '../../../../src/lib/space/tools/task-agent-tools.ts';
+import type { Space } from '@neokai/shared';
+
+function makeDb(): BunDatabase {
+	const db = new BunDatabase(':memory:');
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	return db;
+}
+
+function seedSpaceRow(db: BunDatabase, spaceId: string): void {
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, slug, status, autonomy_level, created_at, updated_at)
+     VALUES (?, '/tmp/ws', ?, '', '', '', '[]', '[]', ?, 'active', ?, ?, ?)`
+	).run(spaceId, `Space ${spaceId}`, spaceId, 5, Date.now(), Date.now());
+}
+
+function seedAgentRow(db: BunDatabase, agentId: string, spaceId: string): void {
+	db.prepare(
+		`INSERT INTO space_agents (id, space_id, name, description, model, tools, system_prompt, created_at, updated_at)
+     VALUES (?, ?, 'Coder', '', null, '[]', '', ?, ?)`
+	).run(agentId, spaceId, Date.now(), Date.now());
+}
+
+function makeSpace(spaceId: string): Space {
+	return {
+		id: spaceId,
+		workspacePath: '/tmp/ws',
+		name: `Space ${spaceId}`,
+		description: '',
+		backgroundContext: '',
+		instructions: '',
+		sessionIds: [],
+		status: 'active',
+		autonomyLevel: 5,
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+	};
+}
+
+interface Ctx {
+	db: BunDatabase;
+	spaceId: string;
+	space: Space;
+	taskRepo: SpaceTaskRepository;
+	artifactRepo: WorkflowRunArtifactRepository;
+	nodeExecutionRepo: NodeExecutionRepository;
+	workflowRunRepo: SpaceWorkflowRunRepository;
+	workflowManager: SpaceWorkflowManager;
+	taskManager: SpaceTaskManager;
+}
+
+function makeCtx(): Ctx {
+	const db = makeDb();
+	const spaceId = 'space-mc-test';
+	seedSpaceRow(db, spaceId);
+	seedAgentRow(db, 'agent-1', spaceId);
+
+	const agentRepo = new SpaceAgentRepository(db);
+	void new SpaceAgentManager(agentRepo);
+	const workflowRepo = new SpaceWorkflowRepository(db);
+	const workflowManager = new SpaceWorkflowManager(workflowRepo);
+	const workflowRunRepo = new SpaceWorkflowRunRepository(db);
+	const taskRepo = new SpaceTaskRepository(db);
+	const artifactRepo = new WorkflowRunArtifactRepository(db);
+	const nodeExecutionRepo = new NodeExecutionRepository(db);
+	void new SpaceManager(db);
+	const taskManager = new SpaceTaskManager(db, spaceId);
+
+	return {
+		db,
+		spaceId,
+		space: makeSpace(spaceId),
+		taskRepo,
+		artifactRepo,
+		nodeExecutionRepo,
+		workflowRunRepo,
+		workflowManager,
+		taskManager,
+	};
+}
+
+describe('task-agent mark_complete', () => {
+	let ctx: Ctx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+	});
+
+	test('transitions approved → done and clears post-approval fields', async () => {
+		// Arrange: create a task in `approved` with post-approval tracking stamped.
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		// Move through in_progress → approved (direct valid transition).
+		await ctx.taskManager.setTaskStatus(task.id, 'approved', { approvalSource: 'agent' });
+		ctx.taskRepo.updateTask(task.id, {
+			postApprovalSessionId: 'session-xyz',
+			postApprovalStartedAt: Date.now(),
+			postApprovalBlockedReason: null,
+		});
+
+		const handlers = createTaskAgentToolHandlers({
+			taskId: task.id,
+			space: ctx.space,
+			workflowRunId: 'no-run',
+			taskRepo: ctx.taskRepo,
+			artifactRepo: ctx.artifactRepo,
+			nodeExecutionRepo: ctx.nodeExecutionRepo,
+			taskManager: ctx.taskManager,
+			messageInjector: async () => {},
+		});
+
+		// Act.
+		const result = await handlers.mark_complete({});
+		const parsed = JSON.parse(result.content[0].text);
+
+		// Assert handler response.
+		expect(parsed.success).toBe(true);
+		expect(parsed.taskId).toBe(task.id);
+		expect(parsed.message).toContain('done');
+
+		// Assert task state.
+		const final = ctx.taskRepo.getTask(task.id);
+		expect(final?.status).toBe('done');
+		expect(final?.postApprovalSessionId).toBeNull();
+		expect(final?.postApprovalStartedAt).toBeNull();
+		expect(final?.postApprovalBlockedReason).toBeNull();
+	});
+
+	test('rejects when task is not approved — suggests approve_task', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		const handlers = createTaskAgentToolHandlers({
+			taskId: task.id,
+			space: ctx.space,
+			workflowRunId: 'no-run',
+			taskRepo: ctx.taskRepo,
+			artifactRepo: ctx.artifactRepo,
+			nodeExecutionRepo: ctx.nodeExecutionRepo,
+			taskManager: ctx.taskManager,
+			messageInjector: async () => {},
+		});
+
+		const result = await handlers.mark_complete({});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('approved');
+		expect(parsed.error).toContain('approve_task');
+
+		// Task state must be unchanged.
+		const final = ctx.taskRepo.getTask(task.id);
+		expect(final?.status).toBe('in_progress');
+	});
+
+	test('rejects when task not found', async () => {
+		const handlers = createTaskAgentToolHandlers({
+			taskId: 'no-such-task',
+			space: ctx.space,
+			workflowRunId: 'no-run',
+			taskRepo: ctx.taskRepo,
+			artifactRepo: ctx.artifactRepo,
+			nodeExecutionRepo: ctx.nodeExecutionRepo,
+			taskManager: ctx.taskManager,
+			messageInjector: async () => {},
+		});
+		const result = await handlers.mark_complete({});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('no-such-task');
+	});
+});
+
+describe('task-agent approve_task guardrail (already-approved)', () => {
+	let ctx: Ctx;
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+	afterEach(() => {
+		ctx.db.close();
+	});
+
+	test('rejects approve_task when task is already approved', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		await ctx.taskManager.setTaskStatus(task.id, 'approved', { approvalSource: 'agent' });
+
+		const handlers = createTaskAgentToolHandlers({
+			taskId: task.id,
+			space: ctx.space,
+			workflowRunId: 'no-run',
+			taskRepo: ctx.taskRepo,
+			artifactRepo: ctx.artifactRepo,
+			nodeExecutionRepo: ctx.nodeExecutionRepo,
+			taskManager: ctx.taskManager,
+			messageInjector: async () => {},
+		});
+		const result = await handlers.approve_task({});
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('mark_complete');
+		expect(parsed.error).toContain("'approved'");
+	});
+});

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-tool-schemas.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-tool-schemas.test.ts
@@ -13,6 +13,7 @@ import {
 	RequestHumanInputSchema,
 	TASK_AGENT_TOOL_SCHEMAS,
 	ListGroupMembersSchema,
+	MarkCompleteSchema,
 } from '../../../../src/lib/space/tools/task-agent-tool-schemas.ts';
 
 // ---------------------------------------------------------------------------
@@ -116,13 +117,14 @@ describe('RequestHumanInputSchema', () => {
 // ---------------------------------------------------------------------------
 
 describe('TASK_AGENT_TOOL_SCHEMAS', () => {
-	test('contains all 4 tool schemas', () => {
+	test('contains all 5 tool schemas', () => {
 		const keys = Object.keys(TASK_AGENT_TOOL_SCHEMAS);
 		expect(keys).toContain('approve_task');
 		expect(keys).toContain('submit_for_approval');
 		expect(keys).toContain('request_human_input');
 		expect(keys).toContain('list_group_members');
-		expect(keys).toHaveLength(4);
+		expect(keys).toContain('mark_complete');
+		expect(keys).toHaveLength(5);
 	});
 
 	test('each schema value is a valid Zod schema with safeParse', () => {
@@ -137,6 +139,27 @@ describe('TASK_AGENT_TOOL_SCHEMAS', () => {
 		expect(keys).not.toContain('spawn_node_agent');
 		expect(keys).not.toContain('check_node_status');
 		expect(keys).not.toContain('advance_workflow');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// MarkCompleteSchema (PR 2/5)
+// ---------------------------------------------------------------------------
+
+describe('MarkCompleteSchema', () => {
+	test('accepts empty object', () => {
+		const result = MarkCompleteSchema.safeParse({});
+		expect(result.success).toBe(true);
+	});
+
+	test('rejects extra fields (strict schema)', () => {
+		const result = MarkCompleteSchema.safeParse({ reason: 'done' });
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects non-object input', () => {
+		const result = MarkCompleteSchema.safeParse('done');
+		expect(result.success).toBe(false);
 	});
 });
 

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-tools.test.ts
@@ -851,7 +851,7 @@ describe('createTaskAgentMcpServer', () => {
 		expect(server.name).toBe('task-agent');
 	});
 
-	test('registers the 8 externally exposed task-agent tools (with artifactRepo)', async () => {
+	test('registers the 9 externally exposed task-agent tools (with artifactRepo)', async () => {
 		const { server } = await makeServerCtx();
 		const registered = Object.keys(server.instance._registeredTools).sort();
 		expect(registered).toEqual([
@@ -859,6 +859,7 @@ describe('createTaskAgentMcpServer', () => {
 			'approve_task',
 			'list_artifacts',
 			'list_group_members',
+			'mark_complete',
 			'request_human_input',
 			'save_artifact',
 			'send_message',
@@ -975,9 +976,9 @@ describe('createTaskAgentMcpServer', () => {
 
 		// Each call returns a distinct server instance
 		expect(server1.instance).not.toBe(server2.instance);
-		// Both register the same 8 externally exposed tools (with artifactRepo)
-		expect(Object.keys(server1.instance._registeredTools)).toHaveLength(8);
-		expect(Object.keys(server2.instance._registeredTools)).toHaveLength(8);
+		// Both register the same 9 externally exposed tools (with artifactRepo)
+		expect(Object.keys(server1.instance._registeredTools)).toHaveLength(9);
+		expect(Object.keys(server2.instance._registeredTools)).toHaveLength(9);
 	});
 });
 

--- a/packages/daemon/tests/unit/5-space/runtime/post-approval-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/post-approval-router.test.ts
@@ -1,0 +1,433 @@
+/**
+ * Unit tests for the PostApprovalRouter (PR 2/5).
+ *
+ * The router is pure plumbing: it reads `workflow.postApproval` and dispatches
+ * via three injected delegates. These tests use in-memory SQLite for the task
+ * repository and stub the delegates, so we can assert exactly which branch
+ * fired for each workflow configuration.
+ *
+ * Coverage matrix (§4.6 of the plan):
+ *   - No postApproval → no-route; task flipped approved → done.
+ *   - targetAgent === 'task-agent' → inline; injector called, no spawn.
+ *   - targetAgent pointing at a node agent → spawn; session id stamped.
+ *   - postApprovalSessionId already set + live → already-routed (no spawn).
+ *   - postApprovalSessionId set but dead → re-spawn.
+ *   - Empty instructions on inline / spawn path → skipped.
+ *   - buildTaskApprovedEvent: contains task id, title, targetAgent, mode.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
+import {
+	PostApprovalRouter,
+	buildTaskApprovedEvent,
+	buildPostApprovalInstructionsEvent,
+	isPostApprovalRoutingEnabled,
+	POST_APPROVAL_ROUTING_FLAG_ENV,
+} from '../../../../src/lib/space/runtime/post-approval-router.ts';
+import type { SpaceTask, SpaceWorkflow } from '@neokai/shared';
+
+const SPACE_ID = 'space-par-test';
+
+function makeDb(): BunDatabase {
+	const db = new BunDatabase(':memory:');
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, '/tmp/ws', ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(SPACE_ID, `Space ${SPACE_ID}`, SPACE_ID, Date.now(), Date.now());
+	return db;
+}
+
+function makeApprovedTask(taskRepo: SpaceTaskRepository): SpaceTask {
+	const task = taskRepo.createTask({
+		spaceId: SPACE_ID,
+		title: 'Ship it',
+		description: 'Do the thing',
+		status: 'in_progress',
+	});
+	// The router expects callers to have already transitioned the task into `approved`.
+	const approved = taskRepo.updateTask(task.id, {
+		status: 'approved',
+		approvalSource: 'agent',
+		approvedAt: Date.now(),
+	});
+	if (!approved) throw new Error('failed to seed approved task');
+	return approved;
+}
+
+function stubWorkflow(overrides: Partial<SpaceWorkflow> = {}): SpaceWorkflow {
+	return {
+		id: 'wf-1',
+		spaceId: SPACE_ID,
+		name: 'Test WF',
+		description: '',
+		version: 1,
+		completionAutonomyLevel: 3,
+		startNodeId: 'n1',
+		endNodeId: 'n1',
+		nodes: [],
+		channels: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	} as SpaceWorkflow;
+}
+
+interface Delegates {
+	injected: Array<{ taskId: string; message: string }>;
+	spawned: Array<{ taskId: string; targetAgent: string; kickoffMessage: string }>;
+	injector: {
+		injectIntoTaskAgent: (
+			taskId: string,
+			message: string
+		) => Promise<{ injected: boolean; sessionId?: string }>;
+	};
+	spawner: {
+		spawnPostApprovalSubSession: (args: {
+			task: SpaceTask;
+			workflow: SpaceWorkflow;
+			targetAgent: string;
+			kickoffMessage: string;
+		}) => Promise<{ sessionId: string }>;
+	};
+	liveness: { isSessionAlive: (id: string) => boolean };
+	aliveSessions: Set<string>;
+}
+
+function makeDelegates(): Delegates {
+	const d: Delegates = {
+		injected: [],
+		spawned: [],
+		aliveSessions: new Set(),
+		injector: {
+			async injectIntoTaskAgent(taskId: string, message: string) {
+				d.injected.push({ taskId, message });
+				return { injected: true, sessionId: `ta-session-${taskId}` };
+			},
+		},
+		spawner: {
+			async spawnPostApprovalSubSession(args) {
+				const sessionId = `spawned-session-${d.spawned.length + 1}`;
+				d.spawned.push({
+					taskId: args.task.id,
+					targetAgent: args.targetAgent,
+					kickoffMessage: args.kickoffMessage,
+				});
+				d.aliveSessions.add(sessionId);
+				return { sessionId };
+			},
+		},
+		liveness: {
+			isSessionAlive(id: string) {
+				return d.aliveSessions.has(id);
+			},
+		},
+	};
+	return d;
+}
+
+describe('isPostApprovalRoutingEnabled', () => {
+	test('returns false when env var unset', () => {
+		expect(isPostApprovalRoutingEnabled({})).toBe(false);
+	});
+	test('returns true for "1", "true", "yes", "on" (case-insensitive)', () => {
+		for (const v of ['1', 'true', 'TRUE', 'yes', 'ON']) {
+			expect(isPostApprovalRoutingEnabled({ [POST_APPROVAL_ROUTING_FLAG_ENV]: v })).toBe(true);
+		}
+	});
+	test('returns false for arbitrary strings', () => {
+		expect(isPostApprovalRoutingEnabled({ [POST_APPROVAL_ROUTING_FLAG_ENV]: 'maybe' })).toBe(false);
+		expect(isPostApprovalRoutingEnabled({ [POST_APPROVAL_ROUTING_FLAG_ENV]: '0' })).toBe(false);
+	});
+});
+
+describe('PostApprovalRouter.route', () => {
+	let db: BunDatabase;
+	let taskRepo: SpaceTaskRepository;
+
+	beforeEach(() => {
+		db = makeDb();
+		taskRepo = new SpaceTaskRepository(db);
+	});
+	afterEach(() => {
+		db.close();
+	});
+
+	test('no postApproval → closes task directly (done)', async () => {
+		const task = makeApprovedTask(taskRepo);
+		const delegates = makeDelegates();
+		const router = new PostApprovalRouter({
+			taskRepo,
+			taskAgent: delegates.injector,
+			spawner: delegates.spawner,
+			livenessProbe: delegates.liveness,
+		});
+
+		const result = await router.route(task, stubWorkflow(), {
+			approvalSource: 'agent',
+			spaceId: SPACE_ID,
+		});
+
+		expect(result.mode).toBe('no-route');
+		if (result.mode === 'no-route') {
+			expect(result.taskStatus).toBe('done');
+		}
+		const final = taskRepo.getTask(task.id);
+		expect(final?.status).toBe('done');
+		expect(delegates.injected).toHaveLength(0);
+		expect(delegates.spawned).toHaveLength(0);
+	});
+
+	test("targetAgent === 'task-agent' → inline inject, no spawn", async () => {
+		const task = makeApprovedTask(taskRepo);
+		const delegates = makeDelegates();
+		const router = new PostApprovalRouter({
+			taskRepo,
+			taskAgent: delegates.injector,
+			spawner: delegates.spawner,
+			livenessProbe: delegates.liveness,
+		});
+
+		const workflow = stubWorkflow({
+			postApproval: {
+				targetAgent: 'task-agent',
+				instructions: 'Deploy task {{task_id}} to production.',
+			},
+		});
+		const result = await router.route(task, workflow, {
+			approvalSource: 'agent',
+			spaceId: SPACE_ID,
+			autonomyLevel: 4,
+			task_id: task.id,
+		});
+
+		expect(result.mode).toBe('inline');
+		expect(delegates.injected).toHaveLength(1);
+		expect(delegates.injected[0].taskId).toBe(task.id);
+		expect(delegates.injected[0].message).toContain('[POST_APPROVAL_INSTRUCTIONS]');
+		expect(delegates.injected[0].message).toContain(`Deploy task ${task.id}`);
+		expect(delegates.spawned).toHaveLength(0);
+		// Task stays in approved — router does NOT close on inline path.
+		expect(taskRepo.getTask(task.id)?.status).toBe('approved');
+	});
+
+	test('targetAgent pointing at node agent → spawn sub-session + stamp', async () => {
+		const task = makeApprovedTask(taskRepo);
+		const delegates = makeDelegates();
+		const router = new PostApprovalRouter({
+			taskRepo,
+			taskAgent: delegates.injector,
+			spawner: delegates.spawner,
+			livenessProbe: delegates.liveness,
+		});
+
+		const workflow = stubWorkflow({
+			postApproval: {
+				targetAgent: 'deployer',
+				instructions: 'Deploy {{task_title}} now.',
+			},
+		});
+		const before = Date.now();
+		const result = await router.route(task, workflow, {
+			approvalSource: 'agent',
+			task_title: task.title,
+		});
+		const after = Date.now();
+
+		expect(result.mode).toBe('spawn');
+		expect(delegates.spawned).toHaveLength(1);
+		expect(delegates.spawned[0].targetAgent).toBe('deployer');
+		expect(delegates.spawned[0].kickoffMessage).toContain(task.title ?? '');
+		expect(delegates.injected).toHaveLength(0);
+
+		const final = taskRepo.getTask(task.id);
+		expect(final?.postApprovalSessionId).toBe('spawned-session-1');
+		expect(final?.postApprovalStartedAt).toBeGreaterThanOrEqual(before);
+		expect(final?.postApprovalStartedAt).toBeLessThanOrEqual(after);
+		expect(final?.status).toBe('approved');
+	});
+
+	test('already-routed (live session) → no re-spawn', async () => {
+		const task = makeApprovedTask(taskRepo);
+		// Stamp a live session id.
+		taskRepo.updateTask(task.id, {
+			postApprovalSessionId: 'session-alive-1',
+		});
+		const updated = taskRepo.getTask(task.id);
+		expect(updated?.postApprovalSessionId).toBe('session-alive-1');
+
+		const delegates = makeDelegates();
+		delegates.aliveSessions.add('session-alive-1');
+
+		const router = new PostApprovalRouter({
+			taskRepo,
+			taskAgent: delegates.injector,
+			spawner: delegates.spawner,
+			livenessProbe: delegates.liveness,
+		});
+
+		const workflow = stubWorkflow({
+			postApproval: { targetAgent: 'deployer', instructions: 'deploy it' },
+		});
+
+		const result = await router.route({ ...updated! }, workflow, { approvalSource: 'agent' });
+
+		expect(result.mode).toBe('already-routed');
+		if (result.mode === 'already-routed') {
+			expect(result.postApprovalSessionId).toBe('session-alive-1');
+		}
+		expect(delegates.spawned).toHaveLength(0);
+	});
+
+	test('stale postApprovalSessionId (dead session) → re-spawns', async () => {
+		const task = makeApprovedTask(taskRepo);
+		taskRepo.updateTask(task.id, { postApprovalSessionId: 'session-dead-1' });
+		const updated = taskRepo.getTask(task.id)!;
+
+		const delegates = makeDelegates();
+		// aliveSessions intentionally empty → liveness probe returns false.
+
+		const router = new PostApprovalRouter({
+			taskRepo,
+			taskAgent: delegates.injector,
+			spawner: delegates.spawner,
+			livenessProbe: delegates.liveness,
+		});
+
+		const workflow = stubWorkflow({
+			postApproval: { targetAgent: 'deployer', instructions: 'retry deploy' },
+		});
+
+		const result = await router.route({ ...updated }, workflow, { approvalSource: 'agent' });
+		expect(result.mode).toBe('spawn');
+		expect(delegates.spawned).toHaveLength(1);
+	});
+
+	test('empty instructions on inline path → skipped', async () => {
+		const task = makeApprovedTask(taskRepo);
+		const delegates = makeDelegates();
+		const router = new PostApprovalRouter({
+			taskRepo,
+			taskAgent: delegates.injector,
+			spawner: delegates.spawner,
+			livenessProbe: delegates.liveness,
+		});
+
+		const result = await router.route(
+			task,
+			stubWorkflow({ postApproval: { targetAgent: 'task-agent', instructions: '   ' } }),
+			{ approvalSource: 'agent' }
+		);
+		expect(result.mode).toBe('skipped');
+		expect(delegates.injected).toHaveLength(0);
+	});
+
+	test('empty instructions on spawn path → skipped', async () => {
+		const task = makeApprovedTask(taskRepo);
+		const delegates = makeDelegates();
+		const router = new PostApprovalRouter({
+			taskRepo,
+			taskAgent: delegates.injector,
+			spawner: delegates.spawner,
+			livenessProbe: delegates.liveness,
+		});
+
+		const result = await router.route(
+			task,
+			stubWorkflow({ postApproval: { targetAgent: 'deployer', instructions: '' } }),
+			{ approvalSource: 'agent' }
+		);
+		expect(result.mode).toBe('skipped');
+		expect(delegates.spawned).toHaveLength(0);
+	});
+
+	test('task not in approved → skipped', async () => {
+		const task = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		const delegates = makeDelegates();
+		const router = new PostApprovalRouter({
+			taskRepo,
+			taskAgent: delegates.injector,
+			spawner: delegates.spawner,
+			livenessProbe: delegates.liveness,
+		});
+		const result = await router.route(task, stubWorkflow(), { approvalSource: 'agent' });
+		expect(result.mode).toBe('skipped');
+	});
+});
+
+describe('buildTaskApprovedEvent', () => {
+	test('contains task id, title, workflow name, target agent, mode', () => {
+		const db = makeDb();
+		try {
+			const taskRepo = new SpaceTaskRepository(db);
+			const task = makeApprovedTask(taskRepo);
+			const workflow = stubWorkflow({
+				name: 'Release WF',
+				postApproval: { targetAgent: 'task-agent', instructions: 'do it' },
+			});
+			const body = buildTaskApprovedEvent({
+				task,
+				workflow,
+				approvalSource: 'human',
+				mode: 'self',
+			});
+			expect(body).toContain('[TASK_APPROVED]');
+			expect(body).toContain(task.id);
+			expect(body).toContain(task.title ?? '');
+			expect(body).toContain('Release WF');
+			expect(body).toContain('task-agent');
+			expect(body).toContain('human');
+			expect(body).toContain('self');
+		} finally {
+			db.close();
+		}
+	});
+
+	test('marks mode=none when no postApproval route', () => {
+		const db = makeDb();
+		try {
+			const taskRepo = new SpaceTaskRepository(db);
+			const task = makeApprovedTask(taskRepo);
+			const body = buildTaskApprovedEvent({
+				task,
+				workflow: stubWorkflow(),
+				approvalSource: 'agent',
+				mode: 'none',
+			});
+			expect(body).toContain('target_agent: none');
+			expect(body).toContain('session_status: none');
+		} finally {
+			db.close();
+		}
+	});
+});
+
+describe('buildPostApprovalInstructionsEvent', () => {
+	test('includes interpolated instructions and mark_complete hint', () => {
+		const db = makeDb();
+		try {
+			const taskRepo = new SpaceTaskRepository(db);
+			const task = makeApprovedTask(taskRepo);
+			const body = buildPostApprovalInstructionsEvent({
+				task,
+				interpolatedInstructions: 'Run `bun ship` and tweet about it.',
+			});
+			expect(body).toContain('[POST_APPROVAL_INSTRUCTIONS]');
+			expect(body).toContain(task.id);
+			expect(body).toContain('bun ship');
+			expect(body).toContain('mark_complete');
+		} finally {
+			db.close();
+		}
+	});
+});

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-dispatch-post-approval.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-dispatch-post-approval.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Regression coverage for SpaceRuntime.dispatchPostApproval (PR 2/5 review fixes).
+ *
+ * Drives the **full flow** through `dispatchPostApproval` (not just
+ * `setTaskStatus`) to pin down two bugs the initial implementation had:
+ *
+ *   Bug 1 — `approvalReason` from `contextExtras` was silently dropped on the
+ *   `review → approved` transition. `SpaceTaskManager.setTaskStatus` would then
+ *   stamp `approvalReason: null`, overwriting whatever the caller had already
+ *   written via `updateTask`.
+ *
+ *   Bug 2 — The no-route branch (`workflow.postApproval` absent → direct
+ *   `approved → done`) bypassed `safeOnTaskUpdated`, leaving UI listeners in
+ *   the dark until the next poll. Only the RPC path emitted (because
+ *   `approvePendingCompletion` re-reads + emits after dispatch); the end-node
+ *   tick path did not.
+ *
+ * These tests guard the fixes by:
+ *   - Asserting `approvalReason` is persisted after `dispatchPostApproval`
+ *     on the review → approved transition with a reason in `contextExtras`.
+ *   - Asserting `onTaskUpdated` is invoked with a task in status `done` after
+ *     a no-route dispatch (covers the end-node tick path that has no follow-up).
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
+import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
+import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
+import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
+import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
+import { SpaceRuntime } from '../../../../src/lib/space/runtime/space-runtime.ts';
+import type { SpaceRuntimeConfig } from '../../../../src/lib/space/runtime/space-runtime.ts';
+import type { SpaceTask } from '@neokai/shared';
+
+const SPACE_ID = 'space-dispatch-pa';
+
+function makeDb(): BunDatabase {
+	const db = new BunDatabase(':memory:');
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, '/tmp/ws', ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(SPACE_ID, `Space ${SPACE_ID}`, SPACE_ID, Date.now(), Date.now());
+	return db;
+}
+
+interface Ctx {
+	db: BunDatabase;
+	runtime: SpaceRuntime;
+	taskRepo: SpaceTaskRepository;
+	emitted: Array<{ spaceId: string; task: SpaceTask }>;
+}
+
+function buildRuntime(): Ctx {
+	const db = makeDb();
+	const workflowRunRepo = new SpaceWorkflowRunRepository(db);
+	const taskRepo = new SpaceTaskRepository(db);
+	const nodeExecutionRepo = new NodeExecutionRepository(db);
+	const agentRepo = new SpaceAgentRepository(db);
+	const agentManager = new SpaceAgentManager(agentRepo);
+	const workflowRepo = new SpaceWorkflowRepository(db);
+	const workflowManager = new SpaceWorkflowManager(workflowRepo);
+	const spaceManager = new SpaceManager(db);
+
+	const emitted: Array<{ spaceId: string; task: SpaceTask }> = [];
+	const config: SpaceRuntimeConfig = {
+		db,
+		spaceManager,
+		spaceAgentManager: agentManager,
+		spaceWorkflowManager: workflowManager,
+		workflowRunRepo,
+		taskRepo,
+		nodeExecutionRepo,
+		onTaskUpdated: async ({ spaceId, task }) => {
+			emitted.push({ spaceId, task });
+		},
+		// Minimal Task Agent stub — the router only needs injectIntoTaskAgent
+		// for the [TASK_APPROVED] awareness fan-out. Return `injected: false`
+		// (no live session) so the runtime logs and continues.
+		taskAgentManager: {
+			injectIntoTaskAgent: async () => ({ injected: false }),
+			spawnPostApprovalSubSession: async () => ({ sessionId: 'stub-session' }),
+			isSessionAlive: () => false,
+		} as unknown as NonNullable<SpaceRuntimeConfig['taskAgentManager']>,
+	};
+
+	const runtime = new SpaceRuntime(config);
+	return { db, runtime, taskRepo, emitted };
+}
+
+function seedReviewTask(taskRepo: SpaceTaskRepository): SpaceTask {
+	// Start in 'in_progress' then transition to 'review' via the repo (setting
+	// status directly bypasses the transition validator, which is fine for a
+	// fixture — the runtime does NOT look at transition history).
+	const t = taskRepo.createTask({
+		spaceId: SPACE_ID,
+		title: 'Ship it',
+		description: '',
+		status: 'in_progress',
+	});
+	const updated = taskRepo.updateTask(t.id, { status: 'review' });
+	if (!updated) throw new Error('failed to seed review task');
+	return updated;
+}
+
+describe('SpaceRuntime.dispatchPostApproval — end-to-end', () => {
+	let ctx: Ctx;
+
+	beforeEach(() => {
+		ctx = buildRuntime();
+	});
+	afterEach(() => {
+		try {
+			ctx.db.close();
+		} catch {
+			/* ignore */
+		}
+	});
+
+	// ---------------------------------------------------------------------------
+	// Bug 1 regression
+	// ---------------------------------------------------------------------------
+
+	test('forwards approvalReason from contextExtras to setTaskStatus (review → approved)', async () => {
+		const task = seedReviewTask(ctx.taskRepo);
+
+		await ctx.runtime.dispatchPostApproval(task.id, 'human', {
+			approvalReason: 'LGTM — ship it',
+		});
+
+		const final = ctx.taskRepo.getTask(task.id);
+		expect(final?.status).toBe('done'); // no-route → closed
+		expect(final?.approvalSource).toBe('human');
+		// The critical assertion: reason survives the round-trip. Prior to the
+		// fix it would be null because dispatchPostApproval silently dropped it.
+		expect(final?.approvalReason).toBe('LGTM — ship it');
+		expect(final?.approvedAt).toBeTypeOf('number');
+	});
+
+	test('undefined approvalReason leaves it null (no spurious stamp)', async () => {
+		const task = seedReviewTask(ctx.taskRepo);
+
+		await ctx.runtime.dispatchPostApproval(task.id, 'human', {});
+
+		const final = ctx.taskRepo.getTask(task.id);
+		expect(final?.approvalReason).toBeNull();
+		expect(final?.approvalSource).toBe('human');
+	});
+
+	// ---------------------------------------------------------------------------
+	// Bug 2 regression
+	// ---------------------------------------------------------------------------
+
+	test('emits onTaskUpdated with status=done after no-route dispatch', async () => {
+		const task = seedReviewTask(ctx.taskRepo);
+
+		await ctx.runtime.dispatchPostApproval(task.id, 'agent');
+
+		// At least two emits expected: one for review → approved (step 1), one
+		// for the post-router state (approved → done). The end-of-dispatch emit
+		// is the critical one — without it the UI would not learn about the
+		// closure until the next poll.
+		const doneEmits = ctx.emitted.filter((e) => e.task.status === 'done');
+		expect(doneEmits.length).toBeGreaterThanOrEqual(1);
+		expect(doneEmits[doneEmits.length - 1].task.id).toBe(task.id);
+	});
+
+	test('already-approved task still fires post-dispatch emit on no-route', async () => {
+		const t = ctx.taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Already approved',
+			description: '',
+			status: 'in_progress',
+		});
+		ctx.taskRepo.updateTask(t.id, {
+			status: 'approved',
+			approvalSource: 'agent',
+			approvedAt: Date.now(),
+		});
+
+		await ctx.runtime.dispatchPostApproval(t.id, 'agent');
+
+		const final = ctx.taskRepo.getTask(t.id);
+		expect(final?.status).toBe('done');
+		// Should still emit even though the transition step was skipped.
+		expect(ctx.emitted.some((e) => e.task.id === t.id && e.task.status === 'done')).toBe(true);
+	});
+});

--- a/packages/daemon/tests/unit/5-space/runtime/task-status-transitions.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/task-status-transitions.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for SpaceTask status-transition rules added in PR 2/5:
+ *   - `in_progress → approved`  (end-node `approve_task` path)
+ *   - `review → approved`       (human approves via approvePendingCompletion)
+ *   - `approved → done`         (mark_complete)
+ *   - `approved → in_progress`  (revive for revision)
+ *   - `approved → blocked` is intentionally NOT a valid transition
+ *
+ * The tests drive `SpaceTaskManager.setTaskStatus` so the centralised
+ * transition validator runs, and assert both the edge-level behaviour
+ * (accept/reject) and the stamping side-effects (approvalSource, approvedAt).
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
+import {
+	SpaceTaskManager,
+	VALID_SPACE_TASK_TRANSITIONS,
+	isValidSpaceTaskTransition,
+} from '../../../../src/lib/space/managers/space-task-manager.ts';
+
+const SPACE_ID = 'space-trans-test';
+
+function makeDb(): BunDatabase {
+	const db = new BunDatabase(':memory:');
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, '/tmp/ws', ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(SPACE_ID, `Space ${SPACE_ID}`, SPACE_ID, Date.now(), Date.now());
+	return db;
+}
+
+describe('VALID_SPACE_TASK_TRANSITIONS (PR 2/5 rules)', () => {
+	test('in_progress can go to approved', () => {
+		expect(VALID_SPACE_TASK_TRANSITIONS.in_progress).toContain('approved');
+	});
+
+	test('review can go to approved', () => {
+		expect(VALID_SPACE_TASK_TRANSITIONS.review).toContain('approved');
+	});
+
+	test('approved can go to done', () => {
+		expect(VALID_SPACE_TASK_TRANSITIONS.approved).toContain('done');
+	});
+
+	test('approved can go to in_progress (revive)', () => {
+		expect(VALID_SPACE_TASK_TRANSITIONS.approved).toContain('in_progress');
+	});
+
+	test('approved CANNOT go to blocked (Stage 2 rule)', () => {
+		expect(VALID_SPACE_TASK_TRANSITIONS.approved).not.toContain('blocked');
+		expect(isValidSpaceTaskTransition('approved', 'blocked')).toBe(false);
+	});
+});
+
+describe('SpaceTaskManager.setTaskStatus — approval-path transitions', () => {
+	let db: BunDatabase;
+	let taskRepo: SpaceTaskRepository;
+	let taskManager: SpaceTaskManager;
+
+	beforeEach(() => {
+		db = makeDb();
+		taskRepo = new SpaceTaskRepository(db);
+		taskManager = new SpaceTaskManager(db, SPACE_ID);
+	});
+	afterEach(() => {
+		db.close();
+	});
+
+	test('in_progress → approved stamps approvalSource + approvedAt', async () => {
+		const task = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		const before = Date.now();
+		const updated = await taskManager.setTaskStatus(task.id, 'approved', {
+			approvalSource: 'agent',
+		});
+		expect(updated.status).toBe('approved');
+		expect(updated.approvalSource).toBe('agent');
+		expect(updated.approvedAt).toBeGreaterThanOrEqual(before);
+	});
+
+	test('review → approved stamps approvalSource=human + approvedAt', async () => {
+		const task = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		// in_progress → review
+		await taskManager.setTaskStatus(task.id, 'review');
+		// review → approved
+		const updated = await taskManager.setTaskStatus(task.id, 'approved', {
+			approvalSource: 'human',
+			approvalReason: 'LGTM',
+		});
+		expect(updated.status).toBe('approved');
+		expect(updated.approvalSource).toBe('human');
+		expect(updated.approvalReason).toBe('LGTM');
+	});
+
+	test('approved → done via mark_complete carries approvalSource through', async () => {
+		const task = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		await taskManager.setTaskStatus(task.id, 'approved', {
+			approvalSource: 'human',
+			approvalReason: 'approved by alice',
+		});
+		// Now transition approved → done, passing approvalSource explicitly (as mark_complete does).
+		const done = await taskManager.setTaskStatus(task.id, 'done', {
+			approvalSource: 'human',
+		});
+		expect(done.status).toBe('done');
+		// approvalReason preserved (setTaskStatus does not clear it on approved→done).
+		expect(done.approvalSource).toBe('human');
+		expect(done.approvalReason).toBe('approved by alice');
+	});
+
+	test('approved → blocked is rejected by the transition validator', async () => {
+		const task = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		await taskManager.setTaskStatus(task.id, 'approved', { approvalSource: 'agent' });
+		await expect(taskManager.setTaskStatus(task.id, 'blocked')).rejects.toThrow(
+			/Invalid status transition from 'approved' to 'blocked'/
+		);
+	});
+
+	test('approved → in_progress (revive) clears approval stamps', async () => {
+		const task = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'T',
+			description: '',
+			status: 'in_progress',
+		});
+		// in_progress → review → approved
+		await taskManager.setTaskStatus(task.id, 'review');
+		await taskManager.setTaskStatus(task.id, 'approved', {
+			approvalSource: 'human',
+			approvalReason: 'ok',
+		});
+		// approved → in_progress — revive path
+		const back = await taskManager.setTaskStatus(task.id, 'in_progress');
+		expect(back.status).toBe('in_progress');
+	});
+});

--- a/packages/web/src/components/space/InlineStatusBanner.tsx
+++ b/packages/web/src/components/space/InlineStatusBanner.tsx
@@ -1,0 +1,158 @@
+/**
+ * InlineStatusBanner — shared thin-banner primitive for task-pane status lines.
+ *
+ * Prior to this primitive, `PendingCompletionActionBanner`,
+ * `PendingTaskCompletionBanner`, and (in this PR) `PendingPostApprovalBanner`
+ * each rolled their own one-line banner markup. Extracting the shape lets new
+ * banners stay consistent and lets tests assert structure instead of class
+ * strings.
+ *
+ * Tone palette matches existing banners:
+ *   - `amber`  — awaiting approval / blocked on human
+ *   - `blue`   — informational, in-progress
+ *   - `green`  — success / positive
+ *   - `purple` — gate / policy
+ *   - `red`    — failure / error
+ *   - `gray`   — inert
+ *
+ * Keep this primitive narrow: icon + label + optional meta + up to 3 actions.
+ * Multi-line bodies, modals, and expandable sections belong in the caller.
+ */
+
+import type { ComponentChildren, JSX } from 'preact';
+
+export type InlineStatusBannerTone = 'amber' | 'blue' | 'green' | 'purple' | 'red' | 'gray';
+
+export interface InlineStatusBannerAction {
+	/** Visible label. */
+	label: string;
+	/** Click handler. */
+	onClick: () => void;
+	/** Optional button variant. Defaults to `'secondary'`. */
+	variant?: 'primary' | 'secondary' | 'danger';
+	/** Optional test id. */
+	testId?: string;
+	/** Disabled state — e.g. while a request is in flight. */
+	disabled?: boolean;
+}
+
+export interface InlineStatusBannerProps {
+	/** Colour accent. */
+	tone: InlineStatusBannerTone;
+	/** Small leading icon — plain text/emoji (kept as ComponentChildren so
+	 *  consumers can pass JSX if needed). */
+	icon?: ComponentChildren;
+	/** Primary label. */
+	label: ComponentChildren;
+	/** Optional right-of-label meta (e.g. `"· 3m ago"`). */
+	meta?: ComponentChildren;
+	/** Up to 3 actions. Callers are responsible for truncating. */
+	actions?: InlineStatusBannerAction[];
+	/** Test id applied to the root. */
+	testId?: string;
+	/** Optional data-* attribute for test introspection. */
+	dataAttrs?: Record<string, string>;
+}
+
+interface ToneClasses {
+	text: string;
+	meta: string;
+}
+
+const TONE_CLASSES: Record<InlineStatusBannerTone, ToneClasses> = {
+	amber: { text: 'text-amber-400/90', meta: 'text-amber-400/60' },
+	blue: { text: 'text-sky-300', meta: 'text-sky-300/60' },
+	green: { text: 'text-green-300', meta: 'text-green-400/60' },
+	purple: { text: 'text-purple-300', meta: 'text-purple-400/60' },
+	red: { text: 'text-red-300', meta: 'text-red-400/60' },
+	gray: { text: 'text-gray-300', meta: 'text-gray-400/60' },
+};
+
+const ACTION_VARIANT_CLASSES: Record<
+	NonNullable<InlineStatusBannerAction['variant']>,
+	Record<InlineStatusBannerTone, string>
+> = {
+	primary: {
+		amber: 'bg-amber-900/40 text-amber-200 border border-amber-700/50 hover:bg-amber-800/50',
+		blue: 'bg-sky-900/40 text-sky-200 border border-sky-700/50 hover:bg-sky-800/50',
+		green: 'bg-green-900/40 text-green-200 border border-green-700/50 hover:bg-green-800/50',
+		purple: 'bg-purple-900/40 text-purple-200 border border-purple-700/50 hover:bg-purple-800/50',
+		red: 'bg-red-900/40 text-red-200 border border-red-700/50 hover:bg-red-800/50',
+		gray: 'bg-gray-800/60 text-gray-200 border border-gray-700/50 hover:bg-gray-800/80',
+	},
+	secondary: {
+		amber: 'bg-dark-700 text-amber-300 hover:bg-dark-600',
+		blue: 'bg-dark-700 text-sky-300 hover:bg-dark-600',
+		green: 'bg-dark-700 text-green-300 hover:bg-dark-600',
+		purple: 'bg-dark-700 text-purple-300 hover:bg-dark-600',
+		red: 'bg-dark-700 text-red-300 hover:bg-dark-600',
+		gray: 'bg-dark-700 text-gray-300 hover:bg-dark-600',
+	},
+	danger: {
+		amber: 'bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50',
+		blue: 'bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50',
+		green: 'bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50',
+		purple: 'bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50',
+		red: 'bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50',
+		gray: 'bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/50',
+	},
+};
+
+/**
+ * Render the one-line banner. Callers should cap `actions.length` at 3; this
+ * component does not truncate silently.
+ */
+export function InlineStatusBanner({
+	tone,
+	icon,
+	label,
+	meta,
+	actions,
+	testId,
+	dataAttrs,
+}: InlineStatusBannerProps): JSX.Element {
+	const tc = TONE_CLASSES[tone];
+	const actionList = actions ?? [];
+	return (
+		<div
+			class={`mx-4 mt-2 mb-2 flex items-center gap-2 px-2 py-1 rounded text-xs ${tc.text}`}
+			data-testid={testId}
+			data-tone={tone}
+			{...(dataAttrs ?? {})}
+		>
+			{icon !== undefined && icon !== null ? (
+				<span class="shrink-0" data-testid={testId ? `${testId}-icon` : undefined}>
+					{icon}
+				</span>
+			) : null}
+			<span class="flex-1 min-w-0 truncate" data-testid={testId ? `${testId}-label` : undefined}>
+				{label}
+				{meta !== undefined && meta !== null ? (
+					<span class={`${tc.meta} ml-1`} data-testid={testId ? `${testId}-meta` : undefined}>
+						{meta}
+					</span>
+				) : null}
+			</span>
+			{actionList.length > 0 ? (
+				<div class="flex items-center gap-1 flex-shrink-0">
+					{actionList.map((action, idx) => {
+						const variant = action.variant ?? 'secondary';
+						const variantClasses = ACTION_VARIANT_CLASSES[variant][tone];
+						return (
+							<button
+								key={action.testId ?? `${action.label}-${idx}`}
+								type="button"
+								onClick={action.onClick}
+								disabled={action.disabled}
+								data-testid={action.testId}
+								class={`px-2 py-0.5 text-xs font-medium rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${variantClasses}`}
+							>
+								{action.label}
+							</button>
+						);
+					})}
+				</div>
+			) : null}
+		</div>
+	);
+}

--- a/packages/web/src/components/space/PendingPostApprovalBanner.tsx
+++ b/packages/web/src/components/space/PendingPostApprovalBanner.tsx
@@ -63,10 +63,12 @@ export function PendingPostApprovalBanner({
 	}, [task.id]);
 
 	const onRetry = useCallback(async () => {
-		// Retry is surfaced as a placeholder for now — wiring a dedicated
-		// `spaceTask.retryPostApproval` RPC is tracked separately. For the
-		// moment, nudging the task back to `in_progress` lets the runtime tick
-		// re-dispatch on the next reconciliation pass.
+		// Returns the task to `in_progress` so the operator can restart the
+		// work and re-approve when ready. The reconciliation pass does NOT
+		// automatically re-trigger post-approval routing on this transition —
+		// the operator has to redo the work and call `approve_task` again. A
+		// dedicated `retryPostApproval` RPC that re-runs the router directly
+		// is tracked separately.
 		setBusy(true);
 		setError(null);
 		try {

--- a/packages/web/src/components/space/PendingPostApprovalBanner.tsx
+++ b/packages/web/src/components/space/PendingPostApprovalBanner.tsx
@@ -1,0 +1,130 @@
+/**
+ * PendingPostApprovalBanner — surfaces tasks stuck mid-post-approval.
+ *
+ * Renders when a task is in the `approved` status (i.e. the runtime routed
+ * post-approval work) AND the router recorded a reason it could not complete
+ * (`postApprovalBlockedReason` is set). This is a signal to the human that a
+ * spawned post-approval sub-session failed — e.g. the sub-session died before
+ * calling `mark_complete`, or the configured target agent could not be found.
+ *
+ * The banner offers three actions:
+ *   - **Retry** — re-run the approval dispatch (not implemented yet; surfaces
+ *     a disabled placeholder with a future hook).
+ *   - **Mark done** — manually transition `approved → done` via
+ *     `spaceTask.update`. Equivalent to the end-node calling `mark_complete`
+ *     itself; use when the work is provably finished but the sub-session
+ *     failed to self-close.
+ *   - **View session** — navigates to the spawned sub-session if we have a
+ *     session id on `task.postApprovalSessionId`.
+ *
+ * Not shown when `task.status !== 'approved'` — `approved` with no
+ * `postApprovalBlockedReason` is the healthy mid-flight state and does not
+ * warrant a banner.
+ */
+
+import { useCallback, useState } from 'preact/hooks';
+import type { SpaceTask } from '@neokai/shared';
+import { spaceStore } from '../../lib/space-store';
+import { InlineStatusBanner, type InlineStatusBannerAction } from './InlineStatusBanner';
+
+export interface PendingPostApprovalBannerProps {
+	task: SpaceTask;
+	spaceId: string;
+	/** Optional navigation hook for the "View session" action. */
+	onViewSession?: (sessionId: string) => void;
+}
+
+export function PendingPostApprovalBanner({
+	task,
+	spaceId: _spaceId,
+	onViewSession,
+}: PendingPostApprovalBannerProps) {
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const reason = task.postApprovalBlockedReason?.trim();
+	const sessionId = task.postApprovalSessionId?.trim() || null;
+
+	const onMarkDone = useCallback(async () => {
+		setBusy(true);
+		setError(null);
+		try {
+			await spaceStore.updateTask(task.id, {
+				status: 'done',
+				postApprovalSessionId: null,
+				postApprovalStartedAt: null,
+				postApprovalBlockedReason: null,
+			});
+		} catch (err: unknown) {
+			setError(err instanceof Error ? err.message : 'Failed to mark done');
+		} finally {
+			setBusy(false);
+		}
+	}, [task.id]);
+
+	const onRetry = useCallback(async () => {
+		// Retry is surfaced as a placeholder for now — wiring a dedicated
+		// `spaceTask.retryPostApproval` RPC is tracked separately. For the
+		// moment, nudging the task back to `in_progress` lets the runtime tick
+		// re-dispatch on the next reconciliation pass.
+		setBusy(true);
+		setError(null);
+		try {
+			await spaceStore.updateTask(task.id, {
+				status: 'in_progress',
+				postApprovalBlockedReason: null,
+			});
+		} catch (err: unknown) {
+			setError(err instanceof Error ? err.message : 'Failed to retry');
+		} finally {
+			setBusy(false);
+		}
+	}, [task.id]);
+
+	if (task.status !== 'approved') return null;
+	if (!reason) return null;
+
+	const actions: InlineStatusBannerAction[] = [
+		{
+			label: 'Retry',
+			onClick: () => void onRetry(),
+			variant: 'secondary',
+			disabled: busy,
+			testId: 'pending-post-approval-retry-btn',
+		},
+		{
+			label: 'Mark done',
+			onClick: () => void onMarkDone(),
+			variant: 'primary',
+			disabled: busy,
+			testId: 'pending-post-approval-mark-done-btn',
+		},
+	];
+	if (sessionId && onViewSession) {
+		actions.push({
+			label: 'View session',
+			onClick: () => onViewSession(sessionId),
+			variant: 'secondary',
+			disabled: busy,
+			testId: 'pending-post-approval-view-session-btn',
+		});
+	}
+
+	return (
+		<>
+			<InlineStatusBanner
+				tone="amber"
+				icon={<span aria-hidden="true">⏳</span>}
+				label={`Post-approval blocked: ${reason}`}
+				actions={actions}
+				testId="pending-post-approval-banner"
+				dataAttrs={{ 'data-task-id': task.id }}
+			/>
+			{error ? (
+				<p class="mx-4 -mt-1 mb-2 text-xs text-red-400" data-testid="pending-post-approval-error">
+					{error}
+				</p>
+			) : null}
+		</>
+	);
+}

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -17,6 +17,7 @@ import { TaskBlockedBanner } from './TaskBlockedBanner';
 import { PendingGateBanner } from './PendingGateBanner';
 import { PendingCompletionActionBanner } from './PendingCompletionActionBanner';
 import { PendingTaskCompletionBanner } from './PendingTaskCompletionBanner';
+import { PendingPostApprovalBanner } from './PendingPostApprovalBanner';
 import { TaskSessionChatComposer } from './TaskSessionChatComposer';
 import { ReadOnlyWorkflowCanvas } from './ReadOnlyWorkflowCanvas';
 import { Dropdown, type DropdownMenuItem } from '../ui/Dropdown';
@@ -439,6 +440,9 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 								)}
 								{task.pendingCheckpointType === 'task_completion' && (
 									<PendingTaskCompletionBanner task={task} spaceId={runtimeSpaceId} />
+								)}
+								{task.status === 'approved' && task.postApprovalBlockedReason && (
+									<PendingPostApprovalBanner task={task} spaceId={runtimeSpaceId} />
 								)}
 								{task.workflowRunId && (
 									<PendingGateBanner

--- a/packages/web/src/components/space/__tests__/InlineStatusBanner.test.tsx
+++ b/packages/web/src/components/space/__tests__/InlineStatusBanner.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for InlineStatusBanner — the shared one-line banner primitive.
+ *
+ * Covers:
+ *   - Renders tone class via data-tone attribute
+ *   - Icon + label + meta rendering
+ *   - Up to 3 actions fire callbacks on click
+ *   - Actions respect disabled state
+ */
+
+// @ts-nocheck
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/preact';
+import { InlineStatusBanner } from '../InlineStatusBanner';
+
+describe('InlineStatusBanner', () => {
+	beforeEach(() => {
+		cleanup();
+	});
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders with tone, icon, label, and meta', () => {
+		const { getByTestId } = render(
+			<InlineStatusBanner
+				tone="amber"
+				icon="⏳"
+				label="Waiting on something"
+				meta="· 3m ago"
+				testId="demo-banner"
+			/>
+		);
+		const root = getByTestId('demo-banner');
+		expect(root.getAttribute('data-tone')).toBe('amber');
+		expect(getByTestId('demo-banner-icon').textContent).toBe('⏳');
+		expect(getByTestId('demo-banner-label').textContent).toContain('Waiting on something');
+		expect(getByTestId('demo-banner-meta').textContent).toContain('3m ago');
+	});
+
+	it('renders actions and fires their callbacks', () => {
+		const onRetry: Mock = vi.fn();
+		const onClose: Mock = vi.fn();
+		const { getByTestId } = render(
+			<InlineStatusBanner
+				tone="blue"
+				label="Needs attention"
+				actions={[
+					{ label: 'Retry', onClick: onRetry, testId: 'retry-btn', variant: 'primary' },
+					{ label: 'Close', onClick: onClose, testId: 'close-btn' },
+				]}
+				testId="demo-banner"
+			/>
+		);
+		fireEvent.click(getByTestId('retry-btn'));
+		fireEvent.click(getByTestId('close-btn'));
+		expect(onRetry).toHaveBeenCalledTimes(1);
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('disables action buttons when disabled=true', () => {
+		const onClick: Mock = vi.fn();
+		const { getByTestId } = render(
+			<InlineStatusBanner
+				tone="red"
+				label="Error"
+				actions={[{ label: 'Retry', onClick, testId: 'retry-btn', disabled: true }]}
+				testId="err-banner"
+			/>
+		);
+		const btn = getByTestId('retry-btn') as HTMLButtonElement;
+		expect(btn.disabled).toBe(true);
+		fireEvent.click(btn);
+		// Disabled buttons don't fire click events in the DOM.
+		expect(onClick).not.toHaveBeenCalled();
+	});
+
+	it('applies dataAttrs to the root node', () => {
+		const { getByTestId } = render(
+			<InlineStatusBanner
+				tone="green"
+				label="ok"
+				testId="banner"
+				dataAttrs={{ 'data-task-id': 'task-42' }}
+			/>
+		);
+		const root = getByTestId('banner');
+		expect(root.getAttribute('data-task-id')).toBe('task-42');
+	});
+
+	it('does not render icon when icon prop omitted', () => {
+		const { queryByTestId } = render(
+			<InlineStatusBanner tone="gray" label="no icon" testId="banner" />
+		);
+		expect(queryByTestId('banner-icon')).toBeNull();
+	});
+
+	it('does not render meta when meta prop omitted', () => {
+		const { queryByTestId } = render(
+			<InlineStatusBanner tone="purple" label="no meta" testId="banner" />
+		);
+		expect(queryByTestId('banner-meta')).toBeNull();
+	});
+});

--- a/packages/web/src/components/space/__tests__/PendingPostApprovalBanner.test.tsx
+++ b/packages/web/src/components/space/__tests__/PendingPostApprovalBanner.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for PendingPostApprovalBanner.
+ *
+ * Covers:
+ *   - Hidden when task.status !== 'approved'
+ *   - Hidden when status==='approved' but no postApprovalBlockedReason
+ *   - Renders reason + Retry + Mark done actions when blocked reason is set
+ *   - Retry triggers spaceStore.updateTask with status='in_progress'
+ *   - Mark done triggers spaceStore.updateTask with status='done'
+ *   - View session action appears only when session id + handler both present
+ */
+
+// @ts-nocheck
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/preact';
+import type { SpaceTask } from '@neokai/shared';
+
+const updateTaskMock: Mock = vi.fn();
+vi.mock('../../../lib/space-store', () => ({
+	spaceStore: {
+		updateTask: (...args: unknown[]) => updateTaskMock(...args),
+	},
+}));
+
+import { PendingPostApprovalBanner } from '../PendingPostApprovalBanner';
+
+function makeTask(overrides: Partial<SpaceTask> = {}): SpaceTask {
+	return {
+		id: 'task-1',
+		spaceId: 'space-1',
+		title: 'T',
+		description: '',
+		status: 'approved',
+		dependsOn: [],
+		assignedToSessionId: null,
+		reportedByAgentName: null,
+		result: null,
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		...overrides,
+	} as SpaceTask;
+}
+
+describe('PendingPostApprovalBanner', () => {
+	beforeEach(() => {
+		cleanup();
+		updateTaskMock.mockReset();
+		updateTaskMock.mockResolvedValue(undefined);
+	});
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('hidden when task status is not approved', () => {
+		const task = makeTask({ status: 'in_progress', postApprovalBlockedReason: 'failure' });
+		const { queryByTestId } = render(<PendingPostApprovalBanner task={task} spaceId="space-1" />);
+		expect(queryByTestId('pending-post-approval-banner')).toBeNull();
+	});
+
+	it('hidden when approved but no blocked reason', () => {
+		const task = makeTask({ status: 'approved', postApprovalBlockedReason: null });
+		const { queryByTestId } = render(<PendingPostApprovalBanner task={task} spaceId="space-1" />);
+		expect(queryByTestId('pending-post-approval-banner')).toBeNull();
+	});
+
+	it('renders reason + Retry + Mark done when blocked', () => {
+		const task = makeTask({
+			status: 'approved',
+			postApprovalBlockedReason: 'deploy session crashed',
+		});
+		const { getByTestId, queryByTestId } = render(
+			<PendingPostApprovalBanner task={task} spaceId="space-1" />
+		);
+		const banner = getByTestId('pending-post-approval-banner');
+		expect(banner.textContent).toContain('deploy session crashed');
+		expect(queryByTestId('pending-post-approval-retry-btn')).not.toBeNull();
+		expect(queryByTestId('pending-post-approval-mark-done-btn')).not.toBeNull();
+		expect(queryByTestId('pending-post-approval-view-session-btn')).toBeNull();
+	});
+
+	it('Retry calls updateTask with status=in_progress', async () => {
+		const task = makeTask({
+			status: 'approved',
+			postApprovalBlockedReason: 'spawn failed',
+		});
+		const { getByTestId } = render(<PendingPostApprovalBanner task={task} spaceId="space-1" />);
+		fireEvent.click(getByTestId('pending-post-approval-retry-btn'));
+		await waitFor(() => {
+			expect(updateTaskMock).toHaveBeenCalledTimes(1);
+		});
+		expect(updateTaskMock).toHaveBeenCalledWith(
+			'task-1',
+			expect.objectContaining({ status: 'in_progress', postApprovalBlockedReason: null })
+		);
+	});
+
+	it('Mark done calls updateTask with status=done and clears post-approval fields', async () => {
+		const task = makeTask({
+			status: 'approved',
+			postApprovalBlockedReason: 'stuck',
+		});
+		const { getByTestId } = render(<PendingPostApprovalBanner task={task} spaceId="space-1" />);
+		fireEvent.click(getByTestId('pending-post-approval-mark-done-btn'));
+		await waitFor(() => {
+			expect(updateTaskMock).toHaveBeenCalledTimes(1);
+		});
+		expect(updateTaskMock).toHaveBeenCalledWith(
+			'task-1',
+			expect.objectContaining({
+				status: 'done',
+				postApprovalSessionId: null,
+				postApprovalStartedAt: null,
+				postApprovalBlockedReason: null,
+			})
+		);
+	});
+
+	it('View session appears when sessionId + handler present', () => {
+		const task = makeTask({
+			status: 'approved',
+			postApprovalBlockedReason: 'stuck',
+			postApprovalSessionId: 'session-xyz',
+		});
+		const onViewSession: Mock = vi.fn();
+		const { getByTestId } = render(
+			<PendingPostApprovalBanner task={task} spaceId="space-1" onViewSession={onViewSession} />
+		);
+		const btn = getByTestId('pending-post-approval-view-session-btn');
+		fireEvent.click(btn);
+		expect(onViewSession).toHaveBeenCalledWith('session-xyz');
+	});
+
+	it('surfaces error when updateTask rejects', async () => {
+		updateTaskMock.mockRejectedValueOnce(new Error('rpc exploded'));
+		const task = makeTask({
+			status: 'approved',
+			postApprovalBlockedReason: 'stuck',
+		});
+		const { getByTestId } = render(<PendingPostApprovalBanner task={task} spaceId="space-1" />);
+		fireEvent.click(getByTestId('pending-post-approval-mark-done-btn'));
+		await waitFor(() => {
+			expect(getByTestId('pending-post-approval-error').textContent).toContain('rpc exploded');
+		});
+	});
+});


### PR DESCRIPTION
Implements PR 2/5 of `docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md`.

- `PostApprovalRouter.route(task, workflow, context)` deterministically dispatches on `approved` transitions: no route → direct `approved → done`; `targetAgent === 'task-agent'` → inject `[POST_APPROVAL_INSTRUCTIONS]`; else spawn fresh node-agent sub-session.
- New `mark_complete` MCP tool on Task Agent + mirrored on spawned node-agent MCP surfaces so post-approval executors finalize `approved → done`.
- Wired into `space-runtime.ts` end-node `approve_task` path and `space-task-handlers.ts` `approvePendingCompletion` RPC behind `NEOKAI_TASK_AGENT_POST_APPROVAL_ROUTING` (OFF by default).
- `approve_task` behavior unchanged (`in_progress → approved`, rejects on already-approved); `[TASK_APPROVED]` emitted on every approved transition; `[POST_APPROVAL_INSTRUCTIONS]` only for task-agent target.
- `## Post-Approval` appended to Task Agent system prompt.
- New `InlineStatusBanner` primitive + `PendingPostApprovalBanner` wired into `SpaceTaskPane`.

## Test plan
- [x] `bun run check`
- [x] Full daemon suite
- [x] Full web suite
- [ ] Manual smoke with flag ON