### PR TITLE
fix(web): surface runtime state in Tools modal and MCP Servers settings

### DIFF
--- a/packages/web/src/components/ToolsModal.tsx
+++ b/packages/web/src/components/ToolsModal.tsx
@@ -62,7 +62,7 @@ const RUNTIME_MCP_LABELS: Record<string, { title: string; description: string }>
 		description: 'Room-scoped coordination between co-located agents',
 	},
 };
-import { computeSkillGroupState } from './ToolsModal.utils.ts';
+import { computeMcpSkillRuntimeState, computeSkillGroupState } from './ToolsModal.utils.ts';
 
 interface ToolsModalProps {
 	isOpen: boolean;
@@ -173,6 +173,12 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 	const sessionMcpEntries = useSignal<SessionMcpServerEntry[]>([]);
 	const sessionMcpToggling = useSignal<Set<string>>(new Set());
 	const sessionMcpSearch = useSignal('');
+	// Tracks whether the per-session MCP list has been fetched at least once.
+	// We can't use `sessionMcpEntries.length > 0` as a proxy because an empty
+	// registry is a legitimate stable state — without this flag, runtime
+	// indicators on `mcp_server` skills would flicker as "unknown" → "missing"
+	// during the initial load.
+	const sessionMcpLoaded = useSignal(false);
 
 	// Search filter for App Skills section
 	const appSkillSearch = useSignal('');
@@ -229,6 +235,7 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 	const loadSessionMcpEntries = async () => {
 		if (!session) {
 			sessionMcpEntries.value = [];
+			sessionMcpLoaded.value = false;
 			return;
 		}
 		try {
@@ -237,10 +244,16 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 				sessionId: session.id,
 			});
 			sessionMcpEntries.value = response.entries ?? [];
+			sessionMcpLoaded.value = true;
 		} catch {
 			// Typically means the daemon rejected the session id; show nothing
 			// rather than an error banner — the empty state is self-explanatory.
 			sessionMcpEntries.value = [];
+			// Keep sessionMcpLoaded=false: we genuinely don't know the effective
+			// MCP state, so per-skill runtime indicators stay hidden ("unknown")
+			// rather than risk showing a misleading "server missing" when the
+			// backing data just wasn't retrieved.
+			sessionMcpLoaded.value = false;
 		}
 	};
 
@@ -651,7 +664,11 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 											class="w-full text-xs bg-dark-900 border border-dark-700 rounded px-2.5 py-1.5 text-gray-300 placeholder-gray-600 focus:outline-none focus:border-blue-500/50"
 										/>
 									)}
-									{/* 2-column grid */}
+									{/* 2-column grid.
+									    Note: the checkbox reflects the registry toggle (global, all
+									    sessions). For MCP-backed skills we also surface the runtime
+									    effective state below each name so users can tell when an
+									    "enabled" skill actually reaches this session. */}
 									{visibleAppSkills.length === 0 ? (
 										<div class="text-xs text-gray-600 py-1">
 											No skills match &ldquo;{appSkillSearch.value}&rdquo;.
@@ -660,6 +677,23 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 										<div class="grid grid-cols-2 gap-1">
 											{visibleAppSkills.map((skill) => {
 												const isToggling = skillToggling.value.has(skill.id);
+												const runtime = computeMcpSkillRuntimeState(
+													skill,
+													sessionMcpEntries.value,
+													sessionMcpLoaded.value
+												);
+												const runtimeDotClass =
+													runtime.status === 'active'
+														? 'bg-emerald-400'
+														: runtime.status === 'server-missing'
+															? 'bg-red-400'
+															: 'bg-gray-500';
+												const runtimeTextClass =
+													runtime.status === 'active'
+														? 'text-emerald-500/70'
+														: runtime.status === 'server-missing'
+															? 'text-red-400'
+															: 'text-gray-500';
 												return (
 													<label
 														key={skill.id}
@@ -698,6 +732,19 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 														)}
 														<div class="flex-1 min-w-0">
 															<div class="text-xs text-gray-200 truncate">{skill.displayName}</div>
+															{runtime.status !== 'unknown' && runtime.label && (
+																<div
+																	class={`text-[10px] truncate flex items-center gap-1 ${runtimeTextClass}`}
+																	title={runtime.label}
+																	data-testid={`skill-runtime-${skill.name}`}
+																	data-status={runtime.status}
+																>
+																	<span
+																		class={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${runtimeDotClass}`}
+																	/>
+																	<span class="truncate">{runtime.label}</span>
+																</div>
+															)}
 														</div>
 														<div class="flex items-center gap-1 flex-shrink-0">
 															{isToggling && (

--- a/packages/web/src/components/ToolsModal.tsx
+++ b/packages/web/src/components/ToolsModal.tsx
@@ -62,7 +62,11 @@ const RUNTIME_MCP_LABELS: Record<string, { title: string; description: string }>
 		description: 'Room-scoped coordination between co-located agents',
 	},
 };
-import { computeMcpSkillRuntimeState, computeSkillGroupState } from './ToolsModal.utils.ts';
+import {
+	computeMcpSkillRuntimeState,
+	computeSkillGroupState,
+	getMcpSkillRuntimeClasses,
+} from './ToolsModal.utils.ts';
 
 interface ToolsModalProps {
 	isOpen: boolean;
@@ -682,18 +686,11 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 													sessionMcpEntries.value,
 													sessionMcpLoaded.value
 												);
-												const runtimeDotClass =
-													runtime.status === 'active'
-														? 'bg-emerald-400'
-														: runtime.status === 'server-missing'
-															? 'bg-red-400'
-															: 'bg-gray-500';
-												const runtimeTextClass =
-													runtime.status === 'active'
-														? 'text-emerald-500/70'
-														: runtime.status === 'server-missing'
-															? 'text-red-400'
-															: 'text-gray-500';
+												// Colour pair is derived from a pure util so the mapping is
+												// unit-tested and stays consistent with the amber orphan-
+												// warning in AppMcpServersSettings (see getMcpSkillRuntimeClasses).
+												const { dot: runtimeDotClass, text: runtimeTextClass } =
+													getMcpSkillRuntimeClasses(runtime.status);
 												return (
 													<label
 														key={skill.id}

--- a/packages/web/src/components/ToolsModal.utils.ts
+++ b/packages/web/src/components/ToolsModal.utils.ts
@@ -12,6 +12,8 @@
  * the SDK is locked to `settingSources: []`.
  */
 
+import type { AppSkill, SessionMcpServerEntry } from '@neokai/shared';
+
 /**
  * Compute group-level toggle state for a list of app-level skills.
  * Returns `allEnabled: false` and `someEnabled: false` when the list is empty
@@ -28,4 +30,155 @@ export function computeSkillGroupState(skills: { enabled: boolean }[]): {
 	const allEnabled = skills.every((s) => s.enabled);
 	const someEnabled = skills.some((s) => s.enabled);
 	return { allEnabled, someEnabled, isIndeterminate: someEnabled && !allEnabled };
+}
+
+/**
+ * The runtime state of an mcp_server-backed skill with respect to a specific
+ * session. Used by the Tools modal to explain *why* a skill the user sees as
+ * "enabled" may not actually be injected into the current query.
+ *
+ *   - `active`           — the backing MCP server is effectively enabled for
+ *                          this session and the skill's enablement chain does
+ *                          not block it. The SDK will see the tools at the
+ *                          next `build()`.
+ *   - `skill-disabled`   — the skill itself is off in the app-level registry,
+ *                          so the skill bridge skips it regardless of MCP
+ *                          overrides.
+ *   - `server-off`       — the backing `app_mcp_servers` entry is disabled
+ *                          (either by its registry default or by an explicit
+ *                          `mcp_enablement` override along this session's
+ *                          scope chain). `overrideSource` pinpoints which
+ *                          scope owns the decision.
+ *   - `server-missing`   — the skill's `appMcpServerId` points at an
+ *                          `app_mcp_servers` row that no longer exists.
+ *                          Orphaned skill — never reaches any session.
+ *   - `unknown`          — we could not determine runtime state (e.g. the
+ *                          session-MCP list hasn't loaded yet). Treated as
+ *                          "no indicator shown" by callers.
+ */
+export type McpSkillRuntimeStatus =
+	| 'active'
+	| 'skill-disabled'
+	| 'server-off'
+	| 'server-missing'
+	| 'unknown';
+
+export interface McpSkillRuntimeState {
+	status: McpSkillRuntimeStatus;
+	/** The `app_mcp_servers.id` the skill points at, when known. */
+	appMcpServerId?: string;
+	/**
+	 * Which level of the scope chain owns the `server-off` decision. Present
+	 * only when `status === 'server-off'`; omitted for other statuses.
+	 */
+	overrideSource?: SessionMcpServerEntry['source'];
+	/** Short label suitable for rendering under the skill name. */
+	label: string;
+}
+
+/**
+ * Compute the runtime state of a single skill relative to a session.
+ *
+ * For non-`mcp_server` skills (builtin / plugin) we return `status: 'unknown'`
+ * because there is no analogous session-scope override path; the component
+ * should render no indicator.
+ *
+ * @param skill            The app-level skill whose runtime state to compute.
+ * @param sessionMcpList   The `SessionMcpListResponse.entries` payload for
+ *                         the current session. When empty (not yet loaded or
+ *                         no registry entries), we return `unknown` even for
+ *                         `mcp_server` skills so the UI stays calm.
+ * @param sessionMcpLoaded Explicit flag from the caller saying the list has
+ *                         been populated at least once. Without this we can't
+ *                         distinguish "no entries" (stable) from "not loaded
+ *                         yet" (loading).
+ */
+export function computeMcpSkillRuntimeState(
+	skill: AppSkill,
+	sessionMcpList: SessionMcpServerEntry[],
+	sessionMcpLoaded: boolean
+): McpSkillRuntimeState {
+	if (skill.sourceType !== 'mcp_server' || skill.config.type !== 'mcp_server') {
+		return { status: 'unknown', label: '' };
+	}
+
+	const appMcpServerId = skill.config.appMcpServerId;
+
+	if (!sessionMcpLoaded) {
+		return { status: 'unknown', appMcpServerId, label: '' };
+	}
+
+	// If the skill itself is off, the skill bridge never injects it regardless
+	// of the backing server's enablement. Surface that first so users aren't
+	// misled by a green "active" indicator when their own checkbox is off.
+	if (!skill.enabled) {
+		const entry = sessionMcpList.find((e) => e.server.id === appMcpServerId);
+		if (!entry) {
+			return {
+				status: 'server-missing',
+				appMcpServerId,
+				label: 'No backing MCP server',
+			};
+		}
+		return {
+			status: 'skill-disabled',
+			appMcpServerId,
+			label: 'Skill off — not injected',
+		};
+	}
+
+	const entry = sessionMcpList.find((e) => e.server.id === appMcpServerId);
+	if (!entry) {
+		return {
+			status: 'server-missing',
+			appMcpServerId,
+			label: 'No backing MCP server',
+		};
+	}
+
+	if (!entry.enabled) {
+		const where =
+			entry.source === 'session'
+				? 'this session'
+				: entry.source === 'room'
+					? 'room'
+					: entry.source === 'space'
+						? 'space'
+						: 'registry';
+		return {
+			status: 'server-off',
+			appMcpServerId,
+			overrideSource: entry.source,
+			label: `MCP server disabled at ${where}`,
+		};
+	}
+
+	return {
+		status: 'active',
+		appMcpServerId,
+		label: 'Active in this session',
+	};
+}
+
+/**
+ * For each `app_mcp_servers` entry, look up the (single) skill that wraps it.
+ * Skills are stored with `sourceType === 'mcp_server'` and
+ * `config.appMcpServerId` pointing at an `app_mcp_servers.id`. Returns a map
+ * keyed by server ID so the Global Settings MCP Servers page can render "this
+ * server is exposed as skill X" in O(1) per row.
+ *
+ * When multiple skills point at the same server ID (pathological — seed +
+ * user clone) we keep the first; the UI shouldn't encourage that topology.
+ */
+export function computeMcpServerSkillLinkage(skills: AppSkill[]): Map<string, AppSkill> {
+	const map = new Map<string, AppSkill>();
+	for (const skill of skills) {
+		if (skill.sourceType !== 'mcp_server' || skill.config.type !== 'mcp_server') continue;
+		const serverId = skill.config.appMcpServerId;
+		if (!serverId) continue;
+		if (!map.has(serverId)) {
+			map.set(serverId, skill);
+		}
+	}
+	return map;
 }

--- a/packages/web/src/components/ToolsModal.utils.ts
+++ b/packages/web/src/components/ToolsModal.utils.ts
@@ -161,6 +161,39 @@ export function computeMcpSkillRuntimeState(
 }
 
 /**
+ * Tailwind class pair for the runtime-state indicator (dot + label text).
+ *
+ * Colour semantics:
+ *   - active          → emerald (all good)
+ *   - server-off      → amber   (a scope override the user may not have set)
+ *   - server-missing  → red     (data-integrity problem)
+ *   - skill-disabled  → gray    (the user's own choice)
+ *   - unknown         → gray    (no indicator — caller should suppress render)
+ *
+ * Amber for `server-off` is deliberately aligned with the amber orphan-warning
+ * in `AppMcpServersSettings`: both signal "this doesn't do what you think it
+ * does", and sharing the colour makes that signal consistent across views.
+ */
+export interface McpSkillRuntimeClasses {
+	dot: string;
+	text: string;
+}
+
+export function getMcpSkillRuntimeClasses(status: McpSkillRuntimeStatus): McpSkillRuntimeClasses {
+	switch (status) {
+		case 'active':
+			return { dot: 'bg-emerald-400', text: 'text-emerald-500/70' };
+		case 'server-off':
+			return { dot: 'bg-amber-400', text: 'text-amber-500/70' };
+		case 'server-missing':
+			return { dot: 'bg-red-400', text: 'text-red-400' };
+		case 'skill-disabled':
+		case 'unknown':
+			return { dot: 'bg-gray-500', text: 'text-gray-500' };
+	}
+}
+
+/**
  * For each `app_mcp_servers` entry, look up the (single) skill that wraps it.
  * Skills are stored with `sourceType === 'mcp_server'` and
  * `config.appMcpServerId` pointing at an `app_mcp_servers.id`. Returns a map

--- a/packages/web/src/components/__tests__/ToolsModal.test.tsx
+++ b/packages/web/src/components/__tests__/ToolsModal.test.tsx
@@ -13,6 +13,7 @@ import {
 	computeMcpServerSkillLinkage,
 	computeMcpSkillRuntimeState,
 	computeSkillGroupState,
+	getMcpSkillRuntimeClasses,
 } from '../ToolsModal.utils.ts';
 
 describe('computeSkillGroupState', () => {
@@ -243,5 +244,52 @@ describe('computeMcpServerSkillLinkage', () => {
 			config: { type: 'mcp_server', appMcpServerId: '' },
 		});
 		expect(computeMcpServerSkillLinkage([skill]).size).toBe(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// getMcpSkillRuntimeClasses
+// ---------------------------------------------------------------------------
+
+describe('getMcpSkillRuntimeClasses', () => {
+	it('maps active → emerald', () => {
+		expect(getMcpSkillRuntimeClasses('active')).toEqual({
+			dot: 'bg-emerald-400',
+			text: 'text-emerald-500/70',
+		});
+	});
+
+	it('maps server-off → amber (distinct from skill-disabled gray)', () => {
+		// Regression guard: `server-off` used to share gray with `skill-disabled`,
+		// which hid a meaningful distinction — "a scope override the user may
+		// not have set" vs "the user turned it off themselves." Amber also
+		// matches the orphan-warning colour in AppMcpServersSettings so the
+		// "this doesn't do what you think it does" signal reads the same in
+		// both places.
+		expect(getMcpSkillRuntimeClasses('server-off')).toEqual({
+			dot: 'bg-amber-400',
+			text: 'text-amber-500/70',
+		});
+	});
+
+	it('maps server-missing → red', () => {
+		expect(getMcpSkillRuntimeClasses('server-missing')).toEqual({
+			dot: 'bg-red-400',
+			text: 'text-red-400',
+		});
+	});
+
+	it('maps skill-disabled → gray (user-owned state)', () => {
+		expect(getMcpSkillRuntimeClasses('skill-disabled')).toEqual({
+			dot: 'bg-gray-500',
+			text: 'text-gray-500',
+		});
+	});
+
+	it('maps unknown → gray (caller should suppress render)', () => {
+		expect(getMcpSkillRuntimeClasses('unknown')).toEqual({
+			dot: 'bg-gray-500',
+			text: 'text-gray-500',
+		});
 	});
 });

--- a/packages/web/src/components/__tests__/ToolsModal.test.tsx
+++ b/packages/web/src/components/__tests__/ToolsModal.test.tsx
@@ -8,7 +8,12 @@
  * were removed in M5 of `unify-mcp-config-model`; their tests went with them.
  */
 import { describe, it, expect } from 'vitest';
-import { computeSkillGroupState } from '../ToolsModal.utils.ts';
+import type { AppMcpServer, AppSkill, SessionMcpServerEntry } from '@neokai/shared';
+import {
+	computeMcpServerSkillLinkage,
+	computeMcpSkillRuntimeState,
+	computeSkillGroupState,
+} from '../ToolsModal.utils.ts';
 
 describe('computeSkillGroupState', () => {
 	it('returns all-false for empty skills list (no vacuous truth)', () => {
@@ -37,5 +42,206 @@ describe('computeSkillGroupState', () => {
 		expect(state.allEnabled).toBe(false);
 		expect(state.someEnabled).toBe(true);
 		expect(state.isIndeterminate).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeMcpSkill(overrides: Partial<AppSkill> = {}): AppSkill {
+	return {
+		id: 'skill-1',
+		name: 'chrome-devtools-mcp',
+		displayName: 'Chrome DevTools (MCP)',
+		description: '',
+		sourceType: 'mcp_server',
+		config: { type: 'mcp_server', appMcpServerId: 'server-1' },
+		enabled: true,
+		builtIn: false,
+		validationStatus: 'valid',
+		createdAt: 0,
+		...overrides,
+	};
+}
+
+function makeBuiltinSkill(overrides: Partial<AppSkill> = {}): AppSkill {
+	return {
+		id: 'skill-builtin',
+		name: 'playwright',
+		displayName: 'Playwright',
+		description: '',
+		sourceType: 'builtin',
+		config: { type: 'builtin', commandName: 'playwright' },
+		enabled: true,
+		builtIn: true,
+		validationStatus: 'valid',
+		createdAt: 0,
+		...overrides,
+	};
+}
+
+function makeAppMcpServer(overrides: Partial<AppMcpServer> = {}): AppMcpServer {
+	return {
+		id: 'server-1',
+		name: 'chrome-devtools',
+		sourceType: 'stdio',
+		command: 'bunx',
+		args: ['chrome-devtools-mcp@latest'],
+		env: {},
+		enabled: true,
+		source: 'builtin',
+		...overrides,
+	};
+}
+
+function makeEntry(overrides: Partial<SessionMcpServerEntry> = {}): SessionMcpServerEntry {
+	return {
+		server: makeAppMcpServer(),
+		enabled: true,
+		source: 'registry',
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// computeMcpSkillRuntimeState
+// ---------------------------------------------------------------------------
+
+describe('computeMcpSkillRuntimeState', () => {
+	it('returns "unknown" for builtin skills (no runtime linkage path)', () => {
+		const skill = makeBuiltinSkill();
+		const state = computeMcpSkillRuntimeState(skill, [], true);
+		expect(state.status).toBe('unknown');
+		expect(state.label).toBe('');
+	});
+
+	it('returns "unknown" while session MCP list is still loading', () => {
+		const skill = makeMcpSkill();
+		const state = computeMcpSkillRuntimeState(skill, [], false);
+		expect(state.status).toBe('unknown');
+	});
+
+	it('returns "active" when the backing server is effectively enabled', () => {
+		const skill = makeMcpSkill();
+		const entries = [makeEntry({ enabled: true, source: 'registry' })];
+		const state = computeMcpSkillRuntimeState(skill, entries, true);
+		expect(state.status).toBe('active');
+		expect(state.label).toMatch(/active/i);
+	});
+
+	it('returns "server-off" with registry source when registry default is false', () => {
+		const skill = makeMcpSkill();
+		const entries = [makeEntry({ enabled: false, source: 'registry' })];
+		const state = computeMcpSkillRuntimeState(skill, entries, true);
+		expect(state.status).toBe('server-off');
+		expect(state.overrideSource).toBe('registry');
+		expect(state.label).toMatch(/registry/i);
+	});
+
+	it('returns "server-off" with session source when session override disables', () => {
+		const skill = makeMcpSkill();
+		const entries = [makeEntry({ enabled: false, source: 'session' })];
+		const state = computeMcpSkillRuntimeState(skill, entries, true);
+		expect(state.status).toBe('server-off');
+		expect(state.overrideSource).toBe('session');
+		expect(state.label).toMatch(/this session/);
+	});
+
+	it('returns "server-off" with room source when room override disables', () => {
+		const skill = makeMcpSkill();
+		const entries = [makeEntry({ enabled: false, source: 'room' })];
+		const state = computeMcpSkillRuntimeState(skill, entries, true);
+		expect(state.status).toBe('server-off');
+		expect(state.overrideSource).toBe('room');
+		expect(state.label).toMatch(/room/);
+	});
+
+	it('returns "server-off" with space source when space override disables', () => {
+		const skill = makeMcpSkill();
+		const entries = [makeEntry({ enabled: false, source: 'space' })];
+		const state = computeMcpSkillRuntimeState(skill, entries, true);
+		expect(state.status).toBe('server-off');
+		expect(state.overrideSource).toBe('space');
+		expect(state.label).toMatch(/space/);
+	});
+
+	it('returns "server-missing" when backing app_mcp_servers entry is absent', () => {
+		const skill = makeMcpSkill({
+			config: { type: 'mcp_server', appMcpServerId: 'ghost-id' },
+		});
+		// Entries exist but none match the orphan skill's appMcpServerId.
+		const entries = [makeEntry()];
+		const state = computeMcpSkillRuntimeState(skill, entries, true);
+		expect(state.status).toBe('server-missing');
+		expect(state.label).toMatch(/missing|no backing/i);
+	});
+
+	it('returns "skill-disabled" when the skill itself is off but server exists', () => {
+		const skill = makeMcpSkill({ enabled: false });
+		const entries = [makeEntry({ enabled: true })];
+		const state = computeMcpSkillRuntimeState(skill, entries, true);
+		// Skill is off, so it's never injected regardless of server state — surface
+		// that distinct reason instead of implying the server is broken.
+		expect(state.status).toBe('skill-disabled');
+	});
+
+	it('prefers "server-missing" over "skill-disabled" when both apply', () => {
+		// Orphaned skill that is also disabled. We prioritise "server-missing"
+		// because that's a persistent data-integrity problem, whereas
+		// "skill-disabled" is the user's own toggle — the former is actionable
+		// regardless of what the user wants to do next.
+		const skill = makeMcpSkill({
+			enabled: false,
+			config: { type: 'mcp_server', appMcpServerId: 'ghost-id' },
+		});
+		const entries = [makeEntry()];
+		const state = computeMcpSkillRuntimeState(skill, entries, true);
+		expect(state.status).toBe('server-missing');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// computeMcpServerSkillLinkage
+// ---------------------------------------------------------------------------
+
+describe('computeMcpServerSkillLinkage', () => {
+	it('returns empty map for empty skills list', () => {
+		expect(computeMcpServerSkillLinkage([])).toEqual(new Map());
+	});
+
+	it('ignores builtin and plugin skills', () => {
+		const skills = [
+			makeBuiltinSkill({ id: 'a' }),
+			makeBuiltinSkill({ id: 'b', sourceType: 'builtin' }),
+		];
+		expect(computeMcpServerSkillLinkage(skills).size).toBe(0);
+	});
+
+	it('maps mcp_server skills by appMcpServerId', () => {
+		const skill = makeMcpSkill({
+			id: 'wrap-1',
+			config: { type: 'mcp_server', appMcpServerId: 'server-1' },
+		});
+		const map = computeMcpServerSkillLinkage([skill]);
+		expect(map.get('server-1')).toBe(skill);
+	});
+
+	it('keeps the first wrapper when multiple skills point at the same server', () => {
+		const first = makeMcpSkill({ id: 'first', displayName: 'First' });
+		const second = makeMcpSkill({ id: 'second', displayName: 'Second' });
+		const map = computeMcpServerSkillLinkage([first, second]);
+		// Defensive behaviour: the UI should never render two annotations for
+		// one server row, so we de-dup rather than surfacing the last-seen.
+		expect(map.get('server-1')).toBe(first);
+	});
+
+	it('skips skills with empty appMcpServerId', () => {
+		const skill = makeMcpSkill({
+			// Deliberately construct a malformed config; the guard in the util
+			// keeps the map consistent even if a bad row sneaks through the DB.
+			config: { type: 'mcp_server', appMcpServerId: '' },
+		});
+		expect(computeMcpServerSkillLinkage([skill]).size).toBe(0);
 	});
 });

--- a/packages/web/src/components/settings/AppMcpServersSettings.tsx
+++ b/packages/web/src/components/settings/AppMcpServersSettings.tsx
@@ -64,6 +64,11 @@ export function AppMcpServersSettings() {
 	// is exposed via skill X" (or warn when a server has no wrapper and is
 	// therefore never injected into any session).
 	const skills = skillsStore.skills.value;
+	// Explicit "first snapshot arrived" flag from the skills store. We need this
+	// (not `skills.length > 0`) to correctly distinguish "subscription still
+	// loading" from "there genuinely are zero skills" — otherwise a space with
+	// MCP servers but zero wrapper skills would never show orphan warnings.
+	const skillsLoaded = skillsStore.loaded.value;
 
 	const [showForm, setShowForm] = useState(false);
 	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -352,12 +357,11 @@ export function AppMcpServersSettings() {
 				) : (
 					<div class="space-y-2">
 						{servers.map((server) => {
-							// Show linkage info only after the skills subscription has loaded
-							// at least one row. Before that, we genuinely don't know whether a
-							// wrapper exists, so suppressing the annotation prevents a
-							// misleading "⚠️ Not exposed" flash during initial mount.
+							// Show linkage info only after the skills subscription has delivered
+							// its first snapshot (`skillsLoaded`). Before that, we genuinely
+							// don't know whether a wrapper exists, so suppressing the annotation
+							// prevents a misleading "⚠️ Not exposed" flash during initial mount.
 							const linkedSkill = skillLinkage.get(server.id);
-							const skillsLoaded = skills.length > 0;
 							return (
 								<div
 									key={server.id}

--- a/packages/web/src/components/settings/AppMcpServersSettings.tsx
+++ b/packages/web/src/components/settings/AppMcpServersSettings.tsx
@@ -5,7 +5,7 @@
  * Allows users to add, edit, delete, and enable/disable MCP servers.
  */
 
-import { useEffect, useState } from 'preact/hooks';
+import { useEffect, useMemo, useState } from 'preact/hooks';
 import type { AppMcpServer, AppMcpServerSourceType } from '@neokai/shared';
 import {
 	createAppMcpServer,
@@ -14,12 +14,14 @@ import {
 	setAppMcpServerEnabled,
 } from '../../lib/api-helpers.ts';
 import { appMcpStore } from '../../lib/app-mcp-store.ts';
+import { skillsStore } from '../../lib/skills-store.ts';
 import { toast } from '../../lib/toast.ts';
 import { SettingsSection, SettingsToggle } from './SettingsSection.tsx';
 import { Modal } from '../ui/Modal.tsx';
 import { ConfirmModal } from '../ui/ConfirmModal.tsx';
 import { Button } from '../ui/Button.tsx';
 import { cn } from '../../lib/utils.ts';
+import { computeMcpServerSkillLinkage } from '../ToolsModal.utils.ts';
 
 interface FormData {
 	name: string;
@@ -57,6 +59,11 @@ export function AppMcpServersSettings() {
 	const servers = appMcpStore.appMcpServers.value;
 	const loading = appMcpStore.loading.value;
 	const error = appMcpStore.error.value;
+	// Read the skills signal so the component re-renders when wrappers are added
+	// or removed. We cross-reference skills against servers to show "this server
+	// is exposed via skill X" (or warn when a server has no wrapper and is
+	// therefore never injected into any session).
+	const skills = skillsStore.skills.value;
 
 	const [showForm, setShowForm] = useState(false);
 	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -67,18 +74,38 @@ export function AppMcpServersSettings() {
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [togglingId, setTogglingId] = useState<string | null>(null);
 
-	// Subscribe to the store on mount
+	// Subscribe to both stores on mount.
+	// - appMcpStore drives the server list shown in this panel.
+	// - skillsStore drives the cross-linkage: each server row needs to know
+	//   whether a skill wraps it so we can render "Exposed via skill X" vs the
+	//   "⚠️ Not exposed to sessions" warning. Missing either subscription hides
+	//   a real and actionable state from the user.
 	useEffect(() => {
 		appMcpStore.subscribe().catch((err) => {
 			toast.error(
 				'Failed to load MCP servers: ' + (err instanceof Error ? err.message : 'Unknown error')
 			);
 		});
+		skillsStore.subscribe().catch((err) => {
+			// Non-fatal: the panel still works without linkage info; we just lose
+			// the "Exposed via skill …" / "No skill wrapper" annotations. Use a
+			// softer warning rather than a blocking error toast.
+			// eslint-disable-next-line no-console
+			console.warn(
+				'Failed to load skills for MCP linkage:',
+				err instanceof Error ? err.message : err
+			);
+		});
 
 		return () => {
 			appMcpStore.unsubscribe();
+			skillsStore.unsubscribe();
 		};
 	}, []);
+
+	// Memoise the (serverId → wrapping skill) map so the O(n) scan runs once per
+	// skills-array change rather than once per server row.
+	const skillLinkage = useMemo(() => computeMcpServerSkillLinkage(skills), [skills]);
 
 	const validateForm = (): boolean => {
 		const errors: FormErrors = {};
@@ -324,79 +351,106 @@ export function AppMcpServersSettings() {
 					</div>
 				) : (
 					<div class="space-y-2">
-						{servers.map((server) => (
-							<div
-								key={server.id}
-								class={cn(
-									'flex items-center justify-between gap-3 py-3 px-3',
-									'bg-dark-800/50 rounded-lg border border-dark-700'
-								)}
-							>
-								<div class="flex-1 min-w-0">
-									<div class="text-sm text-gray-200 truncate font-medium">{server.name}</div>
-									<div class="text-xs text-gray-500 mt-0.5 flex items-center gap-2 flex-wrap">
-										<span
-											class={cn(
-												'px-1.5 py-0.5 rounded text-[10px] uppercase font-medium',
-												server.sourceType === 'stdio' && 'bg-green-500/20 text-green-400',
-												server.sourceType === 'sse' && 'bg-blue-500/20 text-blue-400',
-												server.sourceType === 'http' && 'bg-purple-500/20 text-purple-400'
+						{servers.map((server) => {
+							// Show linkage info only after the skills subscription has loaded
+							// at least one row. Before that, we genuinely don't know whether a
+							// wrapper exists, so suppressing the annotation prevents a
+							// misleading "⚠️ Not exposed" flash during initial mount.
+							const linkedSkill = skillLinkage.get(server.id);
+							const skillsLoaded = skills.length > 0;
+							return (
+								<div
+									key={server.id}
+									class={cn(
+										'flex items-center justify-between gap-3 py-3 px-3',
+										'bg-dark-800/50 rounded-lg border border-dark-700'
+									)}
+								>
+									<div class="flex-1 min-w-0">
+										<div class="text-sm text-gray-200 truncate font-medium">{server.name}</div>
+										<div class="text-xs text-gray-500 mt-0.5 flex items-center gap-2 flex-wrap">
+											<span
+												class={cn(
+													'px-1.5 py-0.5 rounded text-[10px] uppercase font-medium',
+													server.sourceType === 'stdio' && 'bg-green-500/20 text-green-400',
+													server.sourceType === 'sse' && 'bg-blue-500/20 text-blue-400',
+													server.sourceType === 'http' && 'bg-purple-500/20 text-purple-400'
+												)}
+											>
+												{server.sourceType}
+											</span>
+											{server.sourceType === 'stdio' && server.command && (
+												<span class="font-mono truncate max-w-[200px]">{server.command}</span>
 											)}
-										>
-											{server.sourceType}
-										</span>
-										{server.sourceType === 'stdio' && server.command && (
-											<span class="font-mono truncate max-w-[200px]">{server.command}</span>
+											{server.sourceType !== 'stdio' && server.url && (
+												<span class="truncate max-w-[200px]">{server.url}</span>
+											)}
+										</div>
+										{server.description && (
+											<div class="text-xs text-gray-500 mt-1 truncate">{server.description}</div>
 										)}
-										{server.sourceType !== 'stdio' && server.url && (
-											<span class="truncate max-w-[200px]">{server.url}</span>
+										{skillsLoaded && linkedSkill && (
+											<div
+												class="text-[11px] text-sky-400/80 mt-1 truncate"
+												data-testid={`skill-link-${server.name}`}
+											>
+												Exposed to sessions via the{' '}
+												<span class="font-medium">{linkedSkill.displayName}</span> skill
+												{!linkedSkill.enabled && ' (skill is off)'}
+											</div>
+										)}
+										{skillsLoaded && !linkedSkill && (
+											<div
+												class="text-[11px] text-amber-400/90 mt-1"
+												data-testid={`skill-orphan-${server.name}`}
+											>
+												⚠️ No skill wrapper — this server is not injected into any session. Toggling
+												it here has no runtime effect.
+											</div>
 										)}
 									</div>
-									{server.description && (
-										<div class="text-xs text-gray-500 mt-1 truncate">{server.description}</div>
-									)}
-								</div>
 
-								<div class="flex items-center gap-2 flex-shrink-0">
-									<button
-										onClick={() => openEditForm(server)}
-										class="p-1.5 text-gray-400 hover:text-gray-200 hover:bg-dark-700 rounded transition-colors"
-										title="Edit"
-									>
-										<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-											<path
-												stroke-linecap="round"
-												stroke-linejoin="round"
-												stroke-width={2}
-												d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-											/>
-										</svg>
-									</button>
-									<button
-										onClick={() => {
-											setDeletingServer(server);
-											setShowDeleteConfirm(true);
-										}}
-										class="p-1.5 text-gray-400 hover:text-red-400 hover:bg-dark-700 rounded transition-colors"
-										title="Delete"
-									>
-										<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-											<path
-												stroke-linecap="round"
-												stroke-linejoin="round"
-												stroke-width={2}
-												d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-											/>
-										</svg>
-									</button>
-									<SettingsToggle
-										checked={server.enabled}
-										onChange={(enabled) => handleToggle(server, enabled)}
-										disabled={togglingId === server.id}
-									/>
+									<div class="flex items-center gap-2 flex-shrink-0">
+										<button
+											onClick={() => openEditForm(server)}
+											class="p-1.5 text-gray-400 hover:text-gray-200 hover:bg-dark-700 rounded transition-colors"
+											title="Edit"
+										>
+											<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+												<path
+													stroke-linecap="round"
+													stroke-linejoin="round"
+													stroke-width={2}
+													d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+												/>
+											</svg>
+										</button>
+										<button
+											onClick={() => {
+												setDeletingServer(server);
+												setShowDeleteConfirm(true);
+											}}
+											class="p-1.5 text-gray-400 hover:text-red-400 hover:bg-dark-700 rounded transition-colors"
+											title="Delete"
+										>
+											<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+												<path
+													stroke-linecap="round"
+													stroke-linejoin="round"
+													stroke-width={2}
+													d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+												/>
+											</svg>
+										</button>
+										<SettingsToggle
+											checked={server.enabled}
+											onChange={(enabled) => handleToggle(server, enabled)}
+											disabled={togglingId === server.id}
+										/>
+									</div>
 								</div>
-							</div>
-						))}
+							);
+						})}
 					</div>
 				)}
 			</SettingsSection>

--- a/packages/web/src/components/settings/__tests__/AppMcpServersSettings.test.tsx
+++ b/packages/web/src/components/settings/__tests__/AppMcpServersSettings.test.tsx
@@ -11,7 +11,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup, screen, waitFor, fireEvent } from '@testing-library/preact';
-import type { AppMcpServer } from '@neokai/shared';
+import type { AppMcpServer, AppSkill } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
 // Mocks - must use vi.hoisted for proper hoisting with vi.mock
@@ -26,6 +26,8 @@ const {
 	mockToastSuccess,
 	mockSubscribe,
 	mockUnsubscribe,
+	mockSkillsSubscribe,
+	mockSkillsUnsubscribe,
 } = vi.hoisted(() => ({
 	mockCreateAppMcpServer: vi.fn(),
 	mockUpdateAppMcpServer: vi.fn(),
@@ -35,6 +37,8 @@ const {
 	mockToastSuccess: vi.fn(),
 	mockSubscribe: vi.fn().mockResolvedValue(undefined),
 	mockUnsubscribe: vi.fn(),
+	mockSkillsSubscribe: vi.fn().mockResolvedValue(undefined),
+	mockSkillsUnsubscribe: vi.fn(),
 }));
 
 // Mock the appMcpStore
@@ -45,6 +49,18 @@ vi.mock('../../../lib/app-mcp-store.ts', () => ({
 		error: { value: null },
 		subscribe: mockSubscribe,
 		unsubscribe: mockUnsubscribe,
+	},
+}));
+
+// Mock the skillsStore — AppMcpServersSettings subscribes to it so it can
+// annotate each server row with its wrapping skill (or warn about orphans).
+vi.mock('../../../lib/skills-store.ts', () => ({
+	skillsStore: {
+		skills: { value: [] },
+		isLoading: { value: false },
+		error: { value: null },
+		subscribe: mockSkillsSubscribe,
+		unsubscribe: mockSkillsUnsubscribe,
 	},
 }));
 
@@ -192,6 +208,7 @@ vi.mock('../../ui/Button.tsx', () => ({
 // Import the component after mocks are set up
 import { AppMcpServersSettings } from '../AppMcpServersSettings.tsx';
 import { appMcpStore } from '../../../lib/app-mcp-store.ts';
+import { skillsStore } from '../../../lib/skills-store.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -211,6 +228,22 @@ function makeServer(id: string, overrides: Partial<AppMcpServer> = {}): AppMcpSe
 	};
 }
 
+function makeMcpSkill(id: string, serverId: string, overrides: Partial<AppSkill> = {}): AppSkill {
+	return {
+		id,
+		name: `skill-${id}`,
+		displayName: `Skill ${id}`,
+		description: '',
+		sourceType: 'mcp_server',
+		config: { type: 'mcp_server', appMcpServerId: serverId },
+		enabled: true,
+		builtIn: false,
+		validationStatus: 'valid',
+		createdAt: 0,
+		...overrides,
+	};
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -224,6 +257,7 @@ describe('AppMcpServersSettings', () => {
 		appMcpStore.appMcpServers.value = [];
 		appMcpStore.loading.value = false;
 		appMcpStore.error.value = null;
+		skillsStore.skills.value = [];
 
 		// Default mock implementations
 		mockCreateAppMcpServer.mockResolvedValue({
@@ -326,6 +360,81 @@ describe('AppMcpServersSettings', () => {
 			render(<AppMcpServersSettings />);
 
 			expect(mockSubscribe).toHaveBeenCalled();
+		});
+
+		it('should subscribe to the skills store too (for wrapper linkage)', () => {
+			// The linkage annotations depend on the skills list — if we don't
+			// subscribe here, users see orphan warnings on every server while the
+			// skills subscription sits idle elsewhere.
+			render(<AppMcpServersSettings />);
+
+			expect(mockSkillsSubscribe).toHaveBeenCalled();
+		});
+
+		it('should unsubscribe from both stores on unmount', () => {
+			const { unmount } = render(<AppMcpServersSettings />);
+			unmount();
+
+			expect(mockUnsubscribe).toHaveBeenCalled();
+			expect(mockSkillsUnsubscribe).toHaveBeenCalled();
+		});
+	});
+
+	describe('Skill wrapper linkage', () => {
+		it('shows "Exposed via skill X" when a wrapper skill exists', () => {
+			const server = makeServer('s1', { name: 'chrome-devtools' });
+			const skill = makeMcpSkill('w1', server.id, {
+				displayName: 'Chrome DevTools (MCP)',
+			});
+			appMcpStore.appMcpServers.value = [server];
+			skillsStore.skills.value = [skill];
+
+			render(<AppMcpServersSettings />);
+
+			const link = screen.getByTestId('skill-link-chrome-devtools');
+			expect(link).toBeTruthy();
+			expect(link.textContent).toContain('Chrome DevTools (MCP)');
+		});
+
+		it('notes "(skill is off)" when the wrapper skill is disabled', () => {
+			const server = makeServer('s1', { name: 'chrome-devtools' });
+			const skill = makeMcpSkill('w1', server.id, {
+				displayName: 'Chrome DevTools (MCP)',
+				enabled: false,
+			});
+			appMcpStore.appMcpServers.value = [server];
+			skillsStore.skills.value = [skill];
+
+			render(<AppMcpServersSettings />);
+
+			const link = screen.getByTestId('skill-link-chrome-devtools');
+			expect(link.textContent).toMatch(/skill is off/i);
+		});
+
+		it('shows the orphan warning when no skill wrapper exists', () => {
+			const server = makeServer('s1', { name: 'fetch-mcp' });
+			appMcpStore.appMcpServers.value = [server];
+			// A different skill wraps a different server — fetch-mcp is still orphan.
+			skillsStore.skills.value = [makeMcpSkill('w1', 'some-other-server')];
+
+			render(<AppMcpServersSettings />);
+
+			const warn = screen.getByTestId('skill-orphan-fetch-mcp');
+			expect(warn).toBeTruthy();
+			expect(warn.textContent).toMatch(/no skill wrapper/i);
+		});
+
+		it('suppresses annotations while skills are still loading', () => {
+			// Skills subscription hasn't populated any rows yet — we should not
+			// flash "no skill wrapper" warnings before we know the truth.
+			const server = makeServer('s1', { name: 'chrome-devtools' });
+			appMcpStore.appMcpServers.value = [server];
+			skillsStore.skills.value = [];
+
+			render(<AppMcpServersSettings />);
+
+			expect(screen.queryByTestId('skill-link-chrome-devtools')).toBeNull();
+			expect(screen.queryByTestId('skill-orphan-chrome-devtools')).toBeNull();
 		});
 	});
 

--- a/packages/web/src/components/settings/__tests__/AppMcpServersSettings.test.tsx
+++ b/packages/web/src/components/settings/__tests__/AppMcpServersSettings.test.tsx
@@ -54,10 +54,14 @@ vi.mock('../../../lib/app-mcp-store.ts', () => ({
 
 // Mock the skillsStore — AppMcpServersSettings subscribes to it so it can
 // annotate each server row with its wrapping skill (or warn about orphans).
+// `loaded` is the explicit "first snapshot delivered" signal the component
+// reads (distinct from `skills.length > 0`, which would mis-report the
+// "subscription delivered but zero rows" state as still-loading).
 vi.mock('../../../lib/skills-store.ts', () => ({
 	skillsStore: {
 		skills: { value: [] },
 		isLoading: { value: false },
+		loaded: { value: false },
 		error: { value: null },
 		subscribe: mockSkillsSubscribe,
 		unsubscribe: mockSkillsUnsubscribe,
@@ -258,6 +262,9 @@ describe('AppMcpServersSettings', () => {
 		appMcpStore.loading.value = false;
 		appMcpStore.error.value = null;
 		skillsStore.skills.value = [];
+		// Default to loaded=true so the linkage annotations render in the
+		// steady-state tests below. Loading-specific tests flip it to false.
+		skillsStore.loaded.value = true;
 
 		// Default mock implementations
 		mockCreateAppMcpServer.mockResolvedValue({
@@ -424,17 +431,35 @@ describe('AppMcpServersSettings', () => {
 			expect(warn.textContent).toMatch(/no skill wrapper/i);
 		});
 
-		it('suppresses annotations while skills are still loading', () => {
-			// Skills subscription hasn't populated any rows yet — we should not
-			// flash "no skill wrapper" warnings before we know the truth.
+		it('suppresses annotations while the skills subscription has not yet delivered a snapshot', () => {
+			// The skills LiveQuery hasn't fired its first snapshot yet — we should
+			// not flash "no skill wrapper" warnings before we know the truth. This
+			// is the `loaded === false` branch and is distinct from the
+			// "subscription delivered, zero skills exist" case below.
 			const server = makeServer('s1', { name: 'chrome-devtools' });
 			appMcpStore.appMcpServers.value = [server];
 			skillsStore.skills.value = [];
+			skillsStore.loaded.value = false;
 
 			render(<AppMcpServersSettings />);
 
 			expect(screen.queryByTestId('skill-link-chrome-devtools')).toBeNull();
 			expect(screen.queryByTestId('skill-orphan-chrome-devtools')).toBeNull();
+		});
+
+		it('shows orphan warning once the subscription has loaded even if there are zero skills', () => {
+			// Regression guard: previously the component used `skills.length > 0`
+			// as a proxy for "loaded", which mis-classified this perfectly valid
+			// steady state (MCP servers configured, no skill wrappers yet) as
+			// "still loading" and silently hid the actionable warning.
+			const server = makeServer('s1', { name: 'fetch-mcp' });
+			appMcpStore.appMcpServers.value = [server];
+			skillsStore.skills.value = [];
+			skillsStore.loaded.value = true;
+
+			render(<AppMcpServersSettings />);
+
+			expect(screen.getByTestId('skill-orphan-fetch-mcp')).toBeTruthy();
 		});
 	});
 

--- a/packages/web/src/lib/skills-store.test.ts
+++ b/packages/web/src/lib/skills-store.test.ts
@@ -112,6 +112,7 @@ describe('SkillsStore', () => {
 		// Reset store signals
 		skillsStore.skills.value = [];
 		skillsStore.isLoading.value = false;
+		skillsStore.loaded.value = false;
 		skillsStore.error.value = null;
 
 		vi.mocked(connectionManager.getHub).mockResolvedValue(mockHub as never);
@@ -173,6 +174,49 @@ describe('SkillsStore', () => {
 			expect(skillsStore.isLoading.value).toBe(false);
 
 			unsub();
+		});
+
+		it('should start with loaded=false and flip to true on first snapshot', async () => {
+			// Consumers (e.g. AppMcpServersSettings) rely on `loaded` to tell
+			// "subscription still in flight" from "subscription delivered zero
+			// rows." Using skills.length > 0 would conflate them.
+			expect(skillsStore.loaded.value).toBe(false);
+
+			await skillsStore.subscribe();
+			expect(skillsStore.loaded.value).toBe(false); // request sent, snapshot not yet
+
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: SUBSCRIPTION_ID,
+				rows: [],
+				version: 1,
+			});
+			expect(skillsStore.loaded.value).toBe(true);
+		});
+
+		it('should flip loaded=true even when the snapshot delivers zero rows', async () => {
+			// Regression guard for the AppMcpServersSettings orphan-warning bug:
+			// "zero skills" is a valid steady state, not a stuck-loading state.
+			await skillsStore.subscribe();
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: SUBSCRIPTION_ID,
+				rows: [],
+				version: 1,
+			});
+			expect(skillsStore.loaded.value).toBe(true);
+			expect(skillsStore.skills.value).toHaveLength(0);
+		});
+
+		it('should reset loaded=false on unsubscribe so the next mount re-arms the gate', async () => {
+			await skillsStore.subscribe();
+			mockHub.fire<LiveQuerySnapshotEvent>('liveQuery.snapshot', {
+				subscriptionId: SUBSCRIPTION_ID,
+				rows: [makeSkill('1')],
+				version: 1,
+			});
+			expect(skillsStore.loaded.value).toBe(true);
+
+			skillsStore.unsubscribe();
+			expect(skillsStore.loaded.value).toBe(false);
 		});
 
 		it('should populate skills from snapshot rows', async () => {

--- a/packages/web/src/lib/skills-store.ts
+++ b/packages/web/src/lib/skills-store.ts
@@ -34,6 +34,15 @@ class SkillsStore {
 	/** Loading state */
 	readonly isLoading = signal<boolean>(false);
 
+	/**
+	 * Flips to `true` the first time the LiveQuery snapshot handler fires and
+	 * stays true until unsubscribe. Use this (not `skills.length > 0`) when you
+	 * need to distinguish "the subscription has returned" from "there happen to
+	 * be zero skills" — e.g. to suppress UI annotations during the initial
+	 * mount while showing them correctly in the zero-skills steady state.
+	 */
+	readonly loaded = signal<boolean>(false);
+
 	/** Error state — set when subscribe() fails */
 	readonly error = signal<string | null>(null);
 
@@ -82,6 +91,10 @@ class SkillsStore {
 				if (!this.activeSubscriptionIds.has(SUBSCRIPTION_ID)) return; // stale-event guard
 				this.skills.value = event.rows as AppSkill[];
 				this.isLoading.value = false;
+				// Flip loaded=true on the first snapshot so consumers can tell
+				// "we've heard back from the server, there genuinely are zero
+				// skills" apart from "we haven't heard back yet."
+				this.loaded.value = true;
 			});
 			this.cleanups.push(unsubSnapshot);
 			this.cleanups.push(() => this.activeSubscriptionIds.delete(SUBSCRIPTION_ID));
@@ -164,6 +177,7 @@ class SkillsStore {
 		}
 		this.cleanups = [];
 		this.isLoading.value = false;
+		this.loaded.value = false;
 		this.error.value = null;
 	}
 


### PR DESCRIPTION
Tools modal now shows a per-skill runtime indicator derived from the session MCP list (active / server-off with scope source / server-missing / skill-disabled / unknown-while-loading), so users can tell when a "checked" skill is not actually being injected.

MCP Servers settings links each `app_mcp_servers` row to its skill wrapper; orphan rows render an amber warning that toggling them has no runtime effect.

Runtime-state and linkage logic live in `ToolsModal.utils.ts` so tests exercise the same code the UI uses.

Addresses Task #114.