### PR TITLE
fix(daemon): wrap builtin skills as SDK plugins so /playwright works

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -243,6 +243,21 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	const skillsManager = new SkillsManager(db.skills, db.appMcpServers, jobQueue);
 	skillsManager.initializeBuiltins();
 
+	// Materialise SDK-plugin wrappers for every builtin skill so the SDK
+	// recognises them as plugins and exposes `/<commandName>` slash commands.
+	// Without this, `plugins: [{ type: 'local', path: '~/.neokai/skills/playwright' }]`
+	// is silently dropped because the directory has no `.claude-plugin/plugin.json`
+	// (it follows the agent-skills layout, not the plugin layout). See
+	// `lib/agent/builtin-skill-plugin-wrapper.ts` for the full rationale.
+	//
+	// Errors are non-fatal: if a wrapper can't be created the slash command
+	// just won't appear, but the daemon must still come up.
+	try {
+		await skillsManager.ensureBuiltinPluginWrappers();
+	} catch (err) {
+		logError('[Daemon] Failed to ensure builtin skill plugin wrappers (non-fatal):', err);
+	}
+
 	// Initialize session manager (with EventBus, SettingsManager, no StateManager dependency!)
 	// Use reactiveDb.db so sdk_messages writes emitted by AgentSession pipelines
 	// trigger LiveQuery invalidation immediately.

--- a/packages/daemon/src/lib/agent/builtin-skill-plugin-wrapper.ts
+++ b/packages/daemon/src/lib/agent/builtin-skill-plugin-wrapper.ts
@@ -1,0 +1,246 @@
+/**
+ * Builtin-skill → SDK-plugin wrapper
+ *
+ * The Claude Agent SDK's `plugins: [{ type: 'local', path }]` option requires
+ * each plugin path to be a proper plugin directory — one containing either
+ * `.claude-plugin/plugin.json` or `.claude-plugin/marketplace.json`, with
+ * slash commands / skills living under `commands/`, `skills/<name>/SKILL.md`,
+ * etc. (When neither manifest exists the SDK logs "No manifest found" and
+ * silently skips the entry, which is why `/playwright` used to return
+ * "Unknown command".)
+ *
+ * Our builtin skills, however, ship in the shape established by Anthropic's
+ * agent-skills repo: `~/.neokai/skills/<commandName>/SKILL.md` plus any
+ * sibling assets. That's a skill directory, not a plugin directory. Pointing
+ * the SDK at it directly fails.
+ *
+ * This module bridges the two conventions by generating a small wrapper
+ * plugin for each builtin skill at a separate location:
+ *
+ *   ~/.neokai/skill-plugins/<commandName>/
+ *   ├── .claude-plugin/plugin.json
+ *   └── skills/<commandName>/    → symlink to ~/.neokai/skills/<commandName>/
+ *
+ * The SDK plugin loader then discovers `skills/<commandName>/SKILL.md` via
+ * the wrapper and exposes `/<commandName>` as a slash command. We keep the
+ * user-visible skill directory (`~/.neokai/skills/<commandName>`) exactly
+ * where it has always been so that manual edits still work.
+ *
+ * Wrapper generation is idempotent: the plugin.json is rewritten on every
+ * call (cheap), and the symlink is only replaced when its target drifts.
+ * When the platform refuses symlinks (e.g. Windows without developer mode)
+ * we fall back to mirroring the skill directory contents by recursive copy
+ * so the wrapper still resolves.
+ */
+
+import {
+	access,
+	copyFile,
+	lstat,
+	mkdir,
+	readdir,
+	readFile,
+	readlink,
+	rm,
+	symlink,
+	unlink,
+	writeFile,
+} from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import { createLogger } from '@neokai/shared';
+
+const log = createLogger('kai:daemon:builtin-skill-plugin-wrapper');
+
+/**
+ * Default root directory where wrapper plugin directories are materialised.
+ * Keeping this separate from `~/.neokai/skills/` means regenerating wrappers
+ * never touches user-edited skill content.
+ */
+export function defaultBuiltinSkillPluginRoot(): string {
+	return join(homedir(), '.neokai', 'skill-plugins');
+}
+
+/**
+ * Resolve the wrapper plugin directory for a builtin skill.
+ * Callers use the returned path as the `plugins[].path` entry passed to the SDK.
+ */
+export function builtinSkillPluginPath(wrappersRoot: string, commandName: string): string {
+	return join(wrappersRoot, commandName);
+}
+
+export interface BuiltinSkillPluginWrapperOptions {
+	/** Optional description — copied into plugin.json.description when provided. */
+	description?: string;
+	/** Optional version string — copied into plugin.json.version when provided. Defaults to "0.0.0". */
+	version?: string;
+}
+
+/**
+ * Ensure a wrapper plugin exists for a single builtin skill and return its
+ * absolute path. Safe to call repeatedly — see module doc for details.
+ *
+ * When the source skill directory does not exist yet, the wrapper is created
+ * as an empty shell (plugin.json + empty `skills/<name>/`) so a later sync
+ * step populating the skill will still resolve via the symlink.
+ */
+export async function ensureBuiltinSkillPluginWrapper(
+	wrappersRoot: string,
+	skillsRoot: string,
+	commandName: string,
+	options: BuiltinSkillPluginWrapperOptions = {}
+): Promise<string> {
+	const wrapperDir = builtinSkillPluginPath(wrappersRoot, commandName);
+	const pluginJsonDir = join(wrapperDir, '.claude-plugin');
+	const pluginJsonPath = join(pluginJsonDir, 'plugin.json');
+	const skillsSubdir = join(wrapperDir, 'skills');
+	const skillLinkPath = join(skillsSubdir, commandName);
+	const skillTarget = join(skillsRoot, commandName);
+
+	await mkdir(pluginJsonDir, { recursive: true });
+	await mkdir(skillsSubdir, { recursive: true });
+
+	const manifest: Record<string, unknown> = {
+		name: commandName,
+		version: options.version ?? '0.0.0',
+	};
+	if (options.description !== undefined && options.description !== '') {
+		manifest.description = options.description;
+	}
+	const manifestJson = JSON.stringify(manifest, null, 2) + '\n';
+	await writeFile(pluginJsonPath, manifestJson, 'utf8');
+
+	await linkSkillDirectory(skillLinkPath, skillTarget);
+
+	return wrapperDir;
+}
+
+/**
+ * Ensure wrappers for a set of builtin skills. Returns a map from commandName
+ * to wrapper directory path. Errors on individual skills are logged but do
+ * not abort the loop, so one bad skill cannot break daemon startup.
+ */
+export async function ensureBuiltinSkillPluginWrappers(
+	wrappersRoot: string,
+	skillsRoot: string,
+	skills: Array<{ commandName: string } & BuiltinSkillPluginWrapperOptions>
+): Promise<Map<string, string>> {
+	const result = new Map<string, string>();
+	for (const skill of skills) {
+		try {
+			const dir = await ensureBuiltinSkillPluginWrapper(
+				wrappersRoot,
+				skillsRoot,
+				skill.commandName,
+				{ description: skill.description, version: skill.version }
+			);
+			result.set(skill.commandName, dir);
+		} catch (err) {
+			log.warn(
+				`Failed to create plugin wrapper for builtin skill "${skill.commandName}": ${
+					err instanceof Error ? err.message : String(err)
+				}`
+			);
+		}
+	}
+	return result;
+}
+
+/**
+ * Make `linkPath` resolve to the skill directory at `target`.
+ *
+ * Preferred strategy: a directory symlink. If the link already exists and
+ * points at the same target, nothing is done. Otherwise any stale entry
+ * (symlink with different target, real directory, or stray file) is removed
+ * first.
+ *
+ * Fallback: when symlink creation fails because the platform disallows them
+ * (EPERM / ENOSYS, seen on Windows without developer mode), we mirror the
+ * target's contents into a regular directory. This is a worst-case path —
+ * macOS and Linux always take the symlink branch.
+ */
+async function linkSkillDirectory(linkPath: string, target: string): Promise<void> {
+	const existing = await tryLstat(linkPath);
+	if (existing) {
+		if (existing.isSymbolicLink()) {
+			const current = await tryReadlink(linkPath);
+			if (current === target) return;
+			await unlink(linkPath);
+		} else if (existing.isDirectory()) {
+			await rm(linkPath, { recursive: true, force: true });
+		} else {
+			await unlink(linkPath);
+		}
+	}
+
+	try {
+		await symlink(target, linkPath, 'dir');
+		return;
+	} catch (err) {
+		const code = (err as NodeJS.ErrnoException).code;
+		if (code === 'EEXIST') {
+			// Another process beat us to it — accept whatever is there.
+			return;
+		}
+		if (code !== 'EPERM' && code !== 'ENOSYS') throw err;
+		log.warn(
+			`symlink not permitted for ${linkPath} (code ${code}), falling back to directory copy`
+		);
+	}
+
+	await mirrorDirectory(target, linkPath);
+}
+
+async function tryLstat(path: string) {
+	try {
+		return await lstat(path);
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+		throw err;
+	}
+}
+
+async function tryReadlink(path: string): Promise<string | null> {
+	try {
+		return await readlink(path);
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+		throw err;
+	}
+}
+
+/**
+ * Recursively mirror `src` into `dest`. Only used as a fallback when symlinks
+ * are unavailable; regular installs never execute this path.
+ */
+async function mirrorDirectory(src: string, dest: string): Promise<void> {
+	await mkdir(dest, { recursive: true });
+	let exists = true;
+	try {
+		await access(src);
+	} catch {
+		exists = false;
+	}
+	if (!exists) return;
+
+	const entries = await readdir(src, { withFileTypes: true });
+	for (const entry of entries) {
+		const srcPath = join(src, entry.name);
+		const destPath = join(dest, entry.name);
+		if (entry.isDirectory()) {
+			await mirrorDirectory(srcPath, destPath);
+		} else if (entry.isFile()) {
+			await mkdir(dirname(destPath), { recursive: true });
+			await copyFile(srcPath, destPath);
+		} else if (entry.isSymbolicLink()) {
+			// Resolve the link and copy its content — safer than re-creating a
+			// symlink that might have been invalid at the source.
+			try {
+				const content = await readFile(srcPath);
+				await writeFile(destPath, content);
+			} catch {
+				// Ignore broken links in the source tree.
+			}
+		}
+	}
+}

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -40,6 +40,10 @@ import type { RoomSkillOverride } from '@neokai/shared';
 import { resolveMcpServers, scopeChainForSession } from '../mcp/resolve-mcp-servers';
 import { getProviderContextManager } from '../providers/factory.js';
 import { resolveSDKCliPath, isRunningUnderBun } from './sdk-cli-resolver.js';
+import {
+	builtinSkillPluginPath,
+	defaultBuiltinSkillPluginRoot,
+} from './builtin-skill-plugin-wrapper';
 import { homedir } from 'os';
 import { join } from 'path';
 
@@ -888,10 +892,20 @@ CRITICAL RULES:
 
 	/**
 	 * Build plugin entries from enabled skills with sourceType === 'builtin'.
-	 * Each builtin skill's commandName resolves to ~/.neokai/skills/{commandName}/
-	 * which is populated at startup (by the prod binary extraction step or the dev
-	 * server sync step). These directories are registered as local SDK plugins so
-	 * the SDK discovers their SKILL.md content as slash commands.
+	 *
+	 * Each builtin skill's commandName has a wrapper plugin materialised at
+	 * `~/.neokai/skill-plugins/{commandName}/` by `SkillsManager.ensureBuiltinPluginWrappers()`
+	 * during daemon startup. The wrapper has the layout the Claude Agent SDK
+	 * requires for `plugins: [{ type: 'local', path }]`:
+	 *
+	 *   <wrapper>/.claude-plugin/plugin.json
+	 *   <wrapper>/skills/<commandName>/   → symlink to ~/.neokai/skills/<commandName>/
+	 *
+	 * Without that wrapper the SDK silently drops the plugin (its loader
+	 * requires `.claude-plugin/plugin.json` at the root) and `/<commandName>`
+	 * never registers as a slash command. Pointing directly at
+	 * `~/.neokai/skills/<commandName>/` was the source of the
+	 * "Unknown command: /playwright" bug.
 	 *
 	 * Room overrides with enabled=false exclude the skill even if globally enabled.
 	 */
@@ -901,12 +915,13 @@ CRITICAL RULES:
 		const skills = this.ctx.skillsManager.getEnabledSkills();
 		const roomDisabled = this.getRoomDisabledSkillIds();
 		const plugins: Array<{ type: 'local'; path: string }> = [];
+		const wrappersRoot = defaultBuiltinSkillPluginRoot();
 
 		for (const skill of skills) {
 			if (roomDisabled.has(skill.id)) continue;
 			if (skill.sourceType === 'builtin' && skill.config.type === 'builtin') {
-				const skillDir = join(homedir(), '.neokai', 'skills', skill.config.commandName);
-				plugins.push({ type: 'local', path: skillDir });
+				const wrapperDir = builtinSkillPluginPath(wrappersRoot, skill.config.commandName);
+				plugins.push({ type: 'local', path: wrapperDir });
 			}
 		}
 

--- a/packages/daemon/src/lib/skills-manager.ts
+++ b/packages/daemon/src/lib/skills-manager.ts
@@ -22,6 +22,10 @@ import type { AppMcpServerRepository } from '../storage/repositories/app-mcp-ser
 import type { JobQueueRepository } from '../storage/repositories/job-queue-repository';
 import { SKILL_VALIDATE } from './job-queue-constants';
 import { BUILTIN_MCP_SERVERS, BUILTIN_SKILLS, type BuiltinSkill } from './builtins';
+import {
+	defaultBuiltinSkillPluginRoot,
+	ensureBuiltinSkillPluginWrappers,
+} from './agent/builtin-skill-plugin-wrapper';
 
 /**
  * Convert a GitHub tree/blob URL to a raw content URL.
@@ -343,6 +347,15 @@ export class SkillsManager {
 			createdAt: Date.now(),
 		};
 		this.repo.insert(skill);
+
+		// Materialise the SDK plugin wrapper for the new skill so the next
+		// session that resolves it as a plugin sees a valid plugin directory.
+		// Without this the slash command would not register until the daemon
+		// restarted and re-ran ensureBuiltinPluginWrappers().
+		await this.ensureBuiltinPluginWrappers().catch(() => {
+			// Already logged inside the helper; non-fatal.
+		});
+
 		return this.repo.get(skill.id)!;
 	}
 
@@ -550,6 +563,41 @@ export class SkillsManager {
 			enabled: serverDef.enabled,
 			source: 'builtin',
 		});
+	}
+
+	/**
+	 * Materialise SDK-plugin wrappers for every registered `sourceType: 'builtin'`
+	 * skill so the SDK exposes each skill as a `/<commandName>` slash command.
+	 *
+	 * The Claude Agent SDK silently drops plugin paths that are not valid plugin
+	 * directories (i.e. have no `.claude-plugin/plugin.json`). Our skill
+	 * directories at `~/.neokai/skills/<commandName>/` follow the agent-skills
+	 * layout (SKILL.md at root) rather than the plugin layout, so the SDK needs
+	 * a wrapper that bridges the two. See `builtin-skill-plugin-wrapper.ts` for
+	 * the full rationale.
+	 *
+	 * Called once during daemon startup after `initializeBuiltins()`. Errors on
+	 * individual skills are logged and swallowed — a broken wrapper must never
+	 * block daemon startup.
+	 */
+	async ensureBuiltinPluginWrappers(
+		wrappersRoot: string = defaultBuiltinSkillPluginRoot(),
+		skillsRoot: string = join(homedir(), '.neokai', 'skills')
+	): Promise<Map<string, string>> {
+		const builtinSkills = this.repo.findAll().filter((s) => {
+			return s.sourceType === 'builtin' && s.config.type === 'builtin';
+		});
+		return ensureBuiltinSkillPluginWrappers(
+			wrappersRoot,
+			skillsRoot,
+			builtinSkills.map((s) => {
+				const config = s.config as { type: 'builtin'; commandName: string };
+				return {
+					commandName: config.commandName,
+					description: s.description,
+				};
+			})
+		);
 	}
 
 	// ---------------------------------------------------------------------------

--- a/packages/daemon/src/lib/skills-manager.ts
+++ b/packages/daemon/src/lib/skills-manager.ts
@@ -8,7 +8,7 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { access, mkdir, writeFile } from 'node:fs/promises';
-import { generateUUID } from '@neokai/shared';
+import { generateUUID, isBuiltinSkillConfig } from '@neokai/shared';
 import type {
 	AppSkill,
 	AppSkillConfig,
@@ -584,20 +584,20 @@ export class SkillsManager {
 		wrappersRoot: string = defaultBuiltinSkillPluginRoot(),
 		skillsRoot: string = join(homedir(), '.neokai', 'skills')
 	): Promise<Map<string, string>> {
-		const builtinSkills = this.repo.findAll().filter((s) => {
-			return s.sourceType === 'builtin' && s.config.type === 'builtin';
-		});
-		return ensureBuiltinSkillPluginWrappers(
-			wrappersRoot,
-			skillsRoot,
-			builtinSkills.map((s) => {
-				const config = s.config as { type: 'builtin'; commandName: string };
-				return {
-					commandName: config.commandName,
-					description: s.description,
-				};
-			})
-		);
+		// Narrow via the shared type guard so `skill.config.commandName` is a
+		// proper typed access rather than a manual cast. The guard also pairs
+		// with `sourceType === 'builtin'` to defend against any hypothetical
+		// data-shape drift between `sourceType` and `config.type`.
+		const entries: Array<{ commandName: string; description: string }> = [];
+		for (const skill of this.repo.findAll()) {
+			if (skill.sourceType !== 'builtin') continue;
+			if (!isBuiltinSkillConfig(skill.config)) continue;
+			entries.push({
+				commandName: skill.config.commandName,
+				description: skill.description,
+			});
+		}
+		return ensureBuiltinSkillPluginWrappers(wrappersRoot, skillsRoot, entries);
 	}
 
 	// ---------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/1-core/agent/builtin-skill-plugin-wrapper.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/builtin-skill-plugin-wrapper.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Tests for the builtin-skill → SDK-plugin wrapper generator.
+ *
+ * The unit under test materialises a small plugin directory at
+ * `<wrappersRoot>/<commandName>/` that bridges the agent-skills layout used by
+ * NeoKai (`SKILL.md` at the root of the skill dir) to the plugin layout the
+ * Claude Agent SDK requires (`.claude-plugin/plugin.json` at the root, skills
+ * under `skills/<name>/`). The real bug these tests guard against is the SDK
+ * silently dropping plugin entries whose directories lack that manifest — the
+ * root cause of `/playwright` returning "Unknown command".
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { mkdir, mkdtemp, readFile, rm, writeFile, stat, lstat, readlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+	builtinSkillPluginPath,
+	defaultBuiltinSkillPluginRoot,
+	ensureBuiltinSkillPluginWrapper,
+	ensureBuiltinSkillPluginWrappers,
+} from '../../../../src/lib/agent/builtin-skill-plugin-wrapper';
+
+async function pathExists(p: string): Promise<boolean> {
+	try {
+		await stat(p);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+describe('builtin-skill-plugin-wrapper', () => {
+	let tmpRoot: string;
+	let wrappersRoot: string;
+	let skillsRoot: string;
+
+	beforeEach(async () => {
+		tmpRoot = await mkdtemp(join(tmpdir(), 'kai-skill-wrapper-'));
+		wrappersRoot = join(tmpRoot, 'skill-plugins');
+		skillsRoot = join(tmpRoot, 'skills');
+		await mkdir(wrappersRoot, { recursive: true });
+		await mkdir(skillsRoot, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(tmpRoot, { recursive: true, force: true });
+	});
+
+	describe('defaultBuiltinSkillPluginRoot', () => {
+		it('resolves under ~/.neokai/skill-plugins', () => {
+			const root = defaultBuiltinSkillPluginRoot();
+			// Must live beside ~/.neokai/skills (not inside it) so regenerating
+			// wrappers never clobbers user-editable skill content.
+			expect(root.endsWith(join('.neokai', 'skill-plugins'))).toBe(true);
+		});
+	});
+
+	describe('builtinSkillPluginPath', () => {
+		it('joins commandName under the wrappers root', () => {
+			const p = builtinSkillPluginPath('/tmp/wrappers', 'playwright');
+			expect(p).toBe(join('/tmp/wrappers', 'playwright'));
+		});
+	});
+
+	describe('ensureBuiltinSkillPluginWrapper', () => {
+		it('creates .claude-plugin/plugin.json with the expected manifest shape', async () => {
+			// The manifest at this exact location is what the SDK scans for to
+			// treat a directory as a plugin. Without it the SDK logs
+			// "No manifest found" and silently skips the plugin entry.
+			const skillDir = join(skillsRoot, 'playwright');
+			await mkdir(skillDir, { recursive: true });
+			await writeFile(join(skillDir, 'SKILL.md'), '# playwright\n');
+
+			const wrapperDir = await ensureBuiltinSkillPluginWrapper(
+				wrappersRoot,
+				skillsRoot,
+				'playwright',
+				{ description: 'Browser automation', version: '1.2.3' }
+			);
+
+			expect(wrapperDir).toBe(join(wrappersRoot, 'playwright'));
+
+			const manifestPath = join(wrapperDir, '.claude-plugin', 'plugin.json');
+			const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+			expect(manifest).toEqual({
+				name: 'playwright',
+				version: '1.2.3',
+				description: 'Browser automation',
+			});
+		});
+
+		it('omits description from manifest when not provided', async () => {
+			const wrapperDir = await ensureBuiltinSkillPluginWrapper(
+				wrappersRoot,
+				skillsRoot,
+				'some-skill'
+			);
+
+			const manifest = JSON.parse(
+				await readFile(join(wrapperDir, '.claude-plugin', 'plugin.json'), 'utf8')
+			);
+			expect(manifest.name).toBe('some-skill');
+			expect(manifest.version).toBe('0.0.0');
+			expect('description' in manifest).toBe(false);
+		});
+
+		it('omits description when explicitly empty string', async () => {
+			// Empty description would otherwise pollute plugin UI with a blank field.
+			await ensureBuiltinSkillPluginWrapper(wrappersRoot, skillsRoot, 'x', { description: '' });
+			const manifest = JSON.parse(
+				await readFile(join(wrappersRoot, 'x', '.claude-plugin', 'plugin.json'), 'utf8')
+			);
+			expect('description' in manifest).toBe(false);
+		});
+
+		it('creates skills/<commandName>/ that resolves to the source skill directory', async () => {
+			// This is the actual mechanism that lets the SDK find SKILL.md —
+			// the wrapper's skills/<name>/SKILL.md must resolve to content, whether
+			// via a symlink (preferred) or a copied mirror (fallback).
+			const skillDir = join(skillsRoot, 'playwright');
+			await mkdir(skillDir, { recursive: true });
+			await writeFile(join(skillDir, 'SKILL.md'), '# playwright body\n');
+
+			const wrapperDir = await ensureBuiltinSkillPluginWrapper(
+				wrappersRoot,
+				skillsRoot,
+				'playwright'
+			);
+
+			const resolvedSkillFile = join(wrapperDir, 'skills', 'playwright', 'SKILL.md');
+			const body = await readFile(resolvedSkillFile, 'utf8');
+			expect(body).toBe('# playwright body\n');
+		});
+
+		it('uses a symlink when the platform permits', async () => {
+			// macOS/Linux always hit this branch — confirms we aren't silently
+			// doing an expensive recursive copy on every startup.
+			if (process.platform === 'win32') return; // skip where symlinks are unreliable
+			const skillDir = join(skillsRoot, 'playwright');
+			await mkdir(skillDir, { recursive: true });
+
+			const wrapperDir = await ensureBuiltinSkillPluginWrapper(
+				wrappersRoot,
+				skillsRoot,
+				'playwright'
+			);
+
+			const linkPath = join(wrapperDir, 'skills', 'playwright');
+			const lst = await lstat(linkPath);
+			expect(lst.isSymbolicLink()).toBe(true);
+			const target = await readlink(linkPath);
+			expect(target).toBe(skillDir);
+		});
+
+		it('is idempotent — repeated calls keep the same symlink', async () => {
+			// Daemon startup calls this on every boot; installSkillFromGit calls it
+			// whenever a skill is added. It MUST NOT explode or rebuild unnecessarily.
+			if (process.platform === 'win32') return;
+			const skillDir = join(skillsRoot, 'playwright');
+			await mkdir(skillDir, { recursive: true });
+
+			await ensureBuiltinSkillPluginWrapper(wrappersRoot, skillsRoot, 'playwright');
+			const firstLst = await lstat(join(wrappersRoot, 'playwright', 'skills', 'playwright'));
+
+			await ensureBuiltinSkillPluginWrapper(wrappersRoot, skillsRoot, 'playwright');
+			await ensureBuiltinSkillPluginWrapper(wrappersRoot, skillsRoot, 'playwright');
+			const lastLst = await lstat(join(wrappersRoot, 'playwright', 'skills', 'playwright'));
+
+			expect(lastLst.isSymbolicLink()).toBe(true);
+			// ino stability is a decent proxy for "we didn't delete+recreate pointlessly"
+			expect(lastLst.ino).toBe(firstLst.ino);
+		});
+
+		it('replaces a stale symlink whose target has drifted', async () => {
+			// If the skills root moves (e.g. migration), the wrapper must re-point.
+			if (process.platform === 'win32') return;
+			const oldSkillsRoot = join(tmpRoot, 'old-skills');
+			const newSkillsRoot = join(tmpRoot, 'new-skills');
+			await mkdir(join(oldSkillsRoot, 'playwright'), { recursive: true });
+			await mkdir(join(newSkillsRoot, 'playwright'), { recursive: true });
+
+			await ensureBuiltinSkillPluginWrapper(wrappersRoot, oldSkillsRoot, 'playwright');
+			await ensureBuiltinSkillPluginWrapper(wrappersRoot, newSkillsRoot, 'playwright');
+
+			const target = await readlink(join(wrappersRoot, 'playwright', 'skills', 'playwright'));
+			expect(target).toBe(join(newSkillsRoot, 'playwright'));
+		});
+
+		it('replaces a pre-existing regular directory at the skill link path', async () => {
+			// Guards a worst-case recovery: a stale mirror-copy directory left over
+			// from a previous Windows-style fallback run should be cleaned up so
+			// the preferred symlink can take over.
+			if (process.platform === 'win32') return;
+			const skillDir = join(skillsRoot, 'playwright');
+			await mkdir(skillDir, { recursive: true });
+			await writeFile(join(skillDir, 'SKILL.md'), '# real\n');
+
+			// Seed the wrapper with a stale real directory in place of the link.
+			const stalePath = join(wrappersRoot, 'playwright', 'skills', 'playwright');
+			await mkdir(stalePath, { recursive: true });
+			await writeFile(join(stalePath, 'stale.txt'), 'leftover');
+
+			await ensureBuiltinSkillPluginWrapper(wrappersRoot, skillsRoot, 'playwright');
+
+			const lst = await lstat(stalePath);
+			expect(lst.isSymbolicLink()).toBe(true);
+			// Stale contents are gone because the real dir was removed first.
+			expect(await pathExists(join(stalePath, 'stale.txt'))).toBe(false);
+			// Real content now reachable through the fresh link.
+			expect(await readFile(join(stalePath, 'SKILL.md'), 'utf8')).toBe('# real\n');
+		});
+
+		it('creates the wrapper even if the source skill directory does not yet exist', async () => {
+			// Startup order isn't strictly guaranteed — a later sync step may
+			// populate the skill dir. The wrapper should still materialise so the
+			// link resolves once the target appears.
+			if (process.platform === 'win32') return;
+			const wrapperDir = await ensureBuiltinSkillPluginWrapper(
+				wrappersRoot,
+				skillsRoot,
+				'not-yet-synced'
+			);
+			expect(await pathExists(join(wrapperDir, '.claude-plugin', 'plugin.json'))).toBe(true);
+			const linkPath = join(wrapperDir, 'skills', 'not-yet-synced');
+			const lst = await lstat(linkPath);
+			expect(lst.isSymbolicLink()).toBe(true);
+		});
+	});
+
+	describe('ensureBuiltinSkillPluginWrappers (batch)', () => {
+		it('returns a map of commandName → wrapper directory', async () => {
+			await mkdir(join(skillsRoot, 'playwright'), { recursive: true });
+			await mkdir(join(skillsRoot, 'playwright-interactive'), { recursive: true });
+
+			const result = await ensureBuiltinSkillPluginWrappers(wrappersRoot, skillsRoot, [
+				{ commandName: 'playwright', description: 'Browser automation' },
+				{ commandName: 'playwright-interactive' },
+			]);
+
+			expect(result.size).toBe(2);
+			expect(result.get('playwright')).toBe(join(wrappersRoot, 'playwright'));
+			expect(result.get('playwright-interactive')).toBe(
+				join(wrappersRoot, 'playwright-interactive')
+			);
+		});
+
+		it('continues when a single skill fails', async () => {
+			// One broken skill must never prevent the daemon from coming up.
+			// We force a failure by making the wrappers root a plain file so
+			// mkdir on the first skill will fail, then assert the second skill
+			// still succeeds when given a usable root.
+			await mkdir(join(skillsRoot, 'ok-skill'), { recursive: true });
+
+			const brokenRoot = join(tmpRoot, 'broken-root');
+			await writeFile(brokenRoot, 'not a directory');
+
+			// First call targets broken root → should log and skip.
+			const partial = await ensureBuiltinSkillPluginWrappers(brokenRoot, skillsRoot, [
+				{ commandName: 'ok-skill' },
+			]);
+			expect(partial.size).toBe(0);
+
+			// A subsequent call with the good root still works.
+			const full = await ensureBuiltinSkillPluginWrappers(wrappersRoot, skillsRoot, [
+				{ commandName: 'ok-skill' },
+			]);
+			expect(full.get('ok-skill')).toBe(join(wrappersRoot, 'ok-skill'));
+		});
+	});
+});

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -1170,7 +1170,7 @@ describe('QueryOptionsBuilder', () => {
 			expect(options.allowedTools).toContain('test-search__*');
 		});
 
-		it('should inject builtin skills as local plugins pointing to ~/.neokai/skills/{commandName}', async () => {
+		it('should inject builtin skills as local plugins pointing at the wrapper plugin directory', async () => {
 			const builtinSkill = {
 				id: 'skill-builtin-1',
 				name: 'playwright',
@@ -1195,13 +1195,19 @@ describe('QueryOptionsBuilder', () => {
 			const builder = new QueryOptionsBuilder(context);
 			const options = await builder.build();
 
-			// Builtin skills are injected as local plugins so the SDK discovers their SKILL.md
+			// Builtin skills are injected as local plugins so the SDK discovers their SKILL.md.
+			// The path must point at the *wrapper* plugin directory
+			// (~/.neokai/skill-plugins/<commandName>), not the raw skill directory
+			// (~/.neokai/skills/<commandName>), because only the wrapper has the
+			// .claude-plugin/plugin.json manifest the SDK requires — otherwise the
+			// SDK silently drops the plugin entry and `/<commandName>` never registers.
 			expect(options.plugins).toBeDefined();
 			expect(options.plugins).toHaveLength(1);
 			expect(options.plugins![0]).toMatchObject({ type: 'local' });
-			expect((options.plugins![0] as { type: string; path: string }).path).toContain(
-				'.neokai/skills/playwright'
-			);
+			const pluginPath = (options.plugins![0] as { type: string; path: string }).path;
+			expect(pluginPath).toContain('.neokai/skill-plugins/playwright');
+			// Must NOT point at the raw skill directory — that path lacks the plugin manifest.
+			expect(pluginPath).not.toMatch(/\.neokai\/skills\/playwright(?:$|\/)/);
 			// Builtin skills do not contribute to mcpServers
 			expect(options.mcpServers).toBeUndefined();
 		});

--- a/packages/daemon/tests/unit/4-space-storage/skills-manager.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/skills-manager.test.ts
@@ -968,6 +968,67 @@ describe('SkillsManager', () => {
 		expect(names).toContain('playwright');
 		expect(names).toContain('playwright-interactive');
 	});
+
+	// --- ensureBuiltinPluginWrappers ---
+	//
+	// These tests cover the thin wiring layer that feeds the registered builtin
+	// skills into the plugin-wrapper generator. The generator itself has its own
+	// unit tests in agent/builtin-skill-plugin-wrapper.test.ts — here we only
+	// verify that the manager passes the right set of skills (sourceType ===
+	// 'builtin' only) and does not crash on edge cases.
+
+	test('ensureBuiltinPluginWrappers materialises a wrapper for each builtin-typed skill', async () => {
+		const { mkdtemp, rm, readFile, stat } = await import('node:fs/promises');
+		const { tmpdir } = await import('node:os');
+		const tmpRoot = await mkdtemp(join(tmpdir(), 'kai-skills-mgr-wrap-'));
+		try {
+			const wrappersRoot = join(tmpRoot, 'skill-plugins');
+			const skillsRoot = join(tmpRoot, 'skills');
+
+			mgr.initializeBuiltins();
+			const result = await mgr.ensureBuiltinPluginWrappers(wrappersRoot, skillsRoot);
+
+			// Only the two `sourceType: 'builtin'` skills (playwright,
+			// playwright-interactive) should get wrappers — fetch-mcp and
+			// chrome-devtools-mcp are mcp_server-typed and must be skipped
+			// (they're loaded via mcpServers, not the SDK plugin loader).
+			expect(result.size).toBe(2);
+			expect(result.has('playwright')).toBe(true);
+			expect(result.has('playwright-interactive')).toBe(true);
+			expect(result.has('fetch-mcp')).toBe(false);
+			expect(result.has('chrome-devtools-mcp')).toBe(false);
+			expect(result.has('chrome-devtools')).toBe(false);
+
+			// plugin.json must exist at the wrapper root — this is the marker
+			// the SDK actually scans for.
+			const manifest = JSON.parse(
+				await readFile(join(wrappersRoot, 'playwright', '.claude-plugin', 'plugin.json'), 'utf8')
+			);
+			expect(manifest.name).toBe('playwright');
+
+			// The wrappers directory must be a real directory, not a symlink into
+			// the skills root, so regenerating never touches user content.
+			const wst = await stat(wrappersRoot);
+			expect(wst.isDirectory()).toBe(true);
+		} finally {
+			await rm(tmpRoot, { recursive: true, force: true });
+		}
+	});
+
+	test('ensureBuiltinPluginWrappers is safe when no builtin skills are registered', async () => {
+		const { mkdtemp, rm } = await import('node:fs/promises');
+		const { tmpdir } = await import('node:os');
+		const tmpRoot = await mkdtemp(join(tmpdir(), 'kai-skills-mgr-empty-'));
+		try {
+			// Don't call initializeBuiltins — manager has zero skills.
+			const wrappersRoot = join(tmpRoot, 'skill-plugins');
+			const skillsRoot = join(tmpRoot, 'skills');
+			const result = await mgr.ensureBuiltinPluginWrappers(wrappersRoot, skillsRoot);
+			expect(result.size).toBe(0);
+		} finally {
+			await rm(tmpRoot, { recursive: true, force: true });
+		}
+	});
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The SDK's `plugins[]` loader silently drops any path without `.claude-plugin/plugin.json`, so pointing directly at `~/.neokai/skills/<name>/` (agent-skills layout) caused `/playwright` to return "Unknown command".
- Materialise a wrapper plugin at `~/.neokai/skill-plugins/<name>/` with a minimal manifest plus `skills/<name>/` symlinked back to the real skill dir; point `buildPluginsFromBuiltinSkills()` at the wrapper.
- Wrapper generation runs at daemon startup and after `installSkillFromGit`; user-visible `~/.neokai/skills/<name>/` is never mutated.

## Test plan
- [x] `bun test tests/unit/1-core/agent/builtin-skill-plugin-wrapper.test.ts` — 13 new tests (manifest shape, symlink, idempotency, drift replacement, stale-dir cleanup, missing-source case, batch, per-skill error isolation)
- [x] `bun test tests/unit/1-core/agent/query-options-builder.test.ts` — existing builtin-skill assertion updated to require the wrapper path and forbid the raw skill path
- [x] `bun test tests/unit/4-space-storage/skills-manager.test.ts` — adds coverage for `ensureBuiltinPluginWrappers` (only wraps `sourceType: 'builtin'`, safe on empty manager)
- [x] `bun run typecheck`, `bun run lint`, `bun run format:check` all clean
- [ ] Manual: launch daemon, open a space/coder session, invoke `/playwright`