### PR TITLE
refactor(web): float SpaceTaskPane tab pill inside content area

### DIFF
--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -350,68 +350,76 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 				</div>
 			</div>
 
-			<div class="px-4 pb-2 flex-shrink-0 flex justify-center">
-				<div class="flex items-center gap-1 rounded-3xl border border-dark-700 bg-dark-800/60 p-1 backdrop-blur-sm">
-					<button
-						type="button"
-						onClick={() => navigateToSpaceTask(_spaceId, taskId, 'thread')}
-						class={cn(
-							'px-2.5 py-1 text-xs font-medium rounded-2xl transition-all',
-							activeView === 'thread'
-								? 'text-gray-100 bg-dark-700/70 shadow-sm'
-								: 'text-gray-300/80 hover:text-gray-100 hover:bg-dark-700/40'
+			<div class="flex-1 min-h-0 overflow-hidden relative" data-testid="task-pane-content">
+				{/* Wrapper spans the full content width so the pill can center
+				    horizontally — but that span would otherwise eat clicks meant
+				    for the canvas / thread / artifacts beneath it. Disabling
+				    pointer-events on the wrapper and re-enabling them on the pill
+				    itself keeps only the pill interactive. */}
+				<div
+					class="pointer-events-none absolute top-2 left-0 right-0 z-10 flex justify-center px-4"
+					data-testid="task-view-tab-pill"
+				>
+					<div class="pointer-events-auto flex items-center gap-1 rounded-3xl border border-dark-700 bg-dark-800/80 p-1 shadow-lg backdrop-blur-sm">
+						<button
+							type="button"
+							onClick={() => navigateToSpaceTask(_spaceId, taskId, 'thread')}
+							class={cn(
+								'px-2.5 py-1 text-xs font-medium rounded-2xl transition-all',
+								activeView === 'thread'
+									? 'text-gray-100 bg-dark-700/70 shadow-sm'
+									: 'text-gray-300/80 hover:text-gray-100 hover:bg-dark-700/40'
+							)}
+							data-testid="thread-toggle"
+							aria-pressed={activeView === 'thread'}
+						>
+							Thread
+						</button>
+						{canShowCanvasTab && (
+							<button
+								type="button"
+								onClick={() => {
+									if (activeView === 'canvas') {
+										navigateToSpaceTask(_spaceId, taskId, 'thread');
+										return;
+									}
+									spaceStore.ensureNodeExecutions().catch(() => {});
+									navigateToSpaceTask(_spaceId, taskId, 'canvas');
+								}}
+								class={cn(
+									'px-2.5 py-1 text-xs font-medium rounded-2xl transition-all',
+									activeView === 'canvas'
+										? 'text-gray-100 bg-dark-700/70 shadow-sm'
+										: 'text-gray-300/80 hover:text-gray-100 hover:bg-dark-700/40'
+								)}
+								data-testid="canvas-toggle"
+								aria-pressed={activeView === 'canvas'}
+							>
+								Canvas
+							</button>
 						)}
-						data-testid="thread-toggle"
-						aria-pressed={activeView === 'thread'}
-					>
-						Thread
-					</button>
-					{canShowCanvasTab && (
-						<button
-							type="button"
-							onClick={() => {
-								if (activeView === 'canvas') {
-									navigateToSpaceTask(_spaceId, taskId, 'thread');
-									return;
+						{canShowArtifactsTab && (
+							<button
+								type="button"
+								onClick={() =>
+									currentSpaceTaskViewTabSignal.value === 'artifacts'
+										? navigateToSpaceTask(_spaceId, taskId, 'thread')
+										: navigateToSpaceTask(_spaceId, taskId, 'artifacts')
 								}
-								spaceStore.ensureNodeExecutions().catch(() => {});
-								navigateToSpaceTask(_spaceId, taskId, 'canvas');
-							}}
-							class={cn(
-								'px-2.5 py-1 text-xs font-medium rounded-2xl transition-all',
-								activeView === 'canvas'
-									? 'text-gray-100 bg-dark-700/70 shadow-sm'
-									: 'text-gray-300/80 hover:text-gray-100 hover:bg-dark-700/40'
-							)}
-							data-testid="canvas-toggle"
-							aria-pressed={activeView === 'canvas'}
-						>
-							Canvas
-						</button>
-					)}
-					{canShowArtifactsTab && (
-						<button
-							type="button"
-							onClick={() =>
-								currentSpaceTaskViewTabSignal.value === 'artifacts'
-									? navigateToSpaceTask(_spaceId, taskId, 'thread')
-									: navigateToSpaceTask(_spaceId, taskId, 'artifacts')
-							}
-							class={cn(
-								'px-2.5 py-1 text-xs font-medium rounded-2xl transition-all',
-								activeView === 'artifacts'
-									? 'text-gray-100 bg-dark-700/70 shadow-sm'
-									: 'text-gray-300/80 hover:text-gray-100 hover:bg-dark-700/40'
-							)}
-							data-testid="artifacts-toggle"
-							aria-pressed={activeView === 'artifacts'}
-						>
-							Artifacts
-						</button>
-					)}
+								class={cn(
+									'px-2.5 py-1 text-xs font-medium rounded-2xl transition-all',
+									activeView === 'artifacts'
+										? 'text-gray-100 bg-dark-700/70 shadow-sm'
+										: 'text-gray-300/80 hover:text-gray-100 hover:bg-dark-700/40'
+								)}
+								data-testid="artifacts-toggle"
+								aria-pressed={activeView === 'artifacts'}
+							>
+								Artifacts
+							</button>
+						)}
+					</div>
 				</div>
-			</div>
-			<div class="flex-1 min-h-0 overflow-hidden">
 				{activeView === 'canvas' && task.workflowRunId && canvasWorkflowId ? (
 					<div class="h-full" data-testid="canvas-view">
 						<ReadOnlyWorkflowCanvas

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -350,6 +350,46 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 				</div>
 			</div>
 
+			{/* Banner block lives outside the tab content so blocked / pending
+			    banners stay visible regardless of which tab the user is on.
+			    `resolveActiveTaskBanner` returns null when no banner applies —
+			    the wrapping fragment then renders nothing and the block takes
+			    zero height. */}
+			{(() => {
+				// Single-slot precedence renderer — at most one banner is ever
+				// shown. Precedence (high → low):
+				//   blocked > post_approval_blocked > task_completion_pending > gate_pending
+				// The helper captures the rule so it can be unit-tested
+				// independently of the render tree.
+				const banner = resolveActiveTaskBanner(task, gateSummaries);
+				if (!banner) return null;
+				const child =
+					banner.kind === 'blocked' ? (
+						<TaskBlockedBanner
+							task={task}
+							spaceId={runtimeSpaceId}
+							onStatusTransition={handleStatusTransition}
+						/>
+					) : banner.kind === 'post_approval_blocked' ? (
+						<PendingPostApprovalBanner task={task} spaceId={runtimeSpaceId} />
+					) : banner.kind === 'task_completion_pending' ? (
+						<PendingTaskCompletionBanner task={task} spaceId={runtimeSpaceId} />
+					) : (
+						// gate_pending — PendingGateBanner renders rows for every
+						// waiting gate on the run.
+						<PendingGateBanner
+							runId={banner.runId}
+							spaceId={runtimeSpaceId}
+							workflowId={canvasWorkflowId}
+						/>
+					);
+				return (
+					<div class="flex-shrink-0" data-testid="task-pane-banner">
+						{child}
+					</div>
+				);
+			})()}
+
 			<div class="flex-1 min-h-0 overflow-hidden relative" data-testid="task-pane-content">
 				{/* Wrapper spans the full content width so the pill can center
 				    horizontally — but that span would otherwise eat clicks meant
@@ -357,7 +397,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 				    pointer-events on the wrapper and re-enabling them on the pill
 				    itself keeps only the pill interactive. */}
 				<div
-					class="pointer-events-none absolute top-2 left-0 right-0 z-10 flex justify-center px-4"
+					class="pointer-events-none absolute top-3 left-0 right-0 z-10 flex justify-center px-4"
 					data-testid="task-view-tab-pill"
 				>
 					<div class="pointer-events-auto flex items-center gap-1 rounded-3xl border border-dark-700 bg-dark-800/80 p-1 shadow-lg backdrop-blur-sm">
@@ -439,43 +479,11 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 					/>
 				) : (
 					<div class="h-full flex flex-col relative">
-						{(() => {
-							// Single-slot precedence renderer — at most one banner is
-							// ever shown. Precedence (high → low):
-							//   blocked > post_approval_blocked > task_completion_pending > gate_pending
-							// The helper captures the rule so it can be unit-tested
-							// independently of the render tree.
-							const banner = resolveActiveTaskBanner(task, gateSummaries);
-							if (!banner) return null;
-							if (banner.kind === 'blocked') {
-								return (
-									<TaskBlockedBanner
-										task={task}
-										spaceId={runtimeSpaceId}
-										onStatusTransition={handleStatusTransition}
-									/>
-								);
-							}
-							if (banner.kind === 'post_approval_blocked') {
-								return <PendingPostApprovalBanner task={task} spaceId={runtimeSpaceId} />;
-							}
-							if (banner.kind === 'task_completion_pending') {
-								return <PendingTaskCompletionBanner task={task} spaceId={runtimeSpaceId} />;
-							}
-							// gate_pending — PendingGateBanner renders rows for every
-							// waiting gate on the run.
-							return (
-								<PendingGateBanner
-									runId={banner.runId}
-									spaceId={runtimeSpaceId}
-									workflowId={canvasWorkflowId}
-								/>
-							);
-						})()}
 						<div class="flex-1 min-h-0" data-testid="task-thread-panel">
 							{hasUnifiedWorkflowThread ? (
 								<SpaceTaskUnifiedThread
 									taskId={task.id}
+									topInsetClass="pt-12"
 									bottomInsetClass={
 										showInlineComposer ? (threadSendError ? 'pb-24' : 'pb-16') : 'pb-3'
 									}

--- a/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
+++ b/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
@@ -56,6 +56,13 @@ interface SpaceTaskUnifiedThreadProps {
 	taskId: string;
 	bottomInsetClass?: string;
 	/**
+	 * Top padding applied to the scroll container so the first message clears
+	 * any floating overlay (e.g. SpaceTaskPane's tab pill) at scroll-top. Older
+	 * messages still scroll under the overlay's frosted-glass background; only
+	 * the resting position is adjusted.
+	 */
+	topInsetClass?: string;
+	/**
 	 * Whether the agent session is currently active (not idle / completed /
 	 * failed / interrupted). Forwarded to the compact feed to gate the running
 	 * border animation.
@@ -66,6 +73,7 @@ interface SpaceTaskUnifiedThreadProps {
 export function SpaceTaskUnifiedThread({
 	taskId,
 	bottomInsetClass = 'pb-3',
+	topInsetClass = '',
 	isAgentActive = false,
 }: SpaceTaskUnifiedThreadProps) {
 	// Read render style on every render so that the value stays fresh after a
@@ -172,7 +180,7 @@ export function SpaceTaskUnifiedThread({
 					</span>
 				</div>
 			)}
-			<div ref={containerRef} class={`flex-1 overflow-y-auto ${bottomInsetClass}`}>
+			<div ref={containerRef} class={`flex-1 overflow-y-auto ${topInsetClass} ${bottomInsetClass}`}>
 				<div class="min-h-[calc(100%+1px)]">
 					{renderStyle === 'compact' ? (
 						<SpaceTaskCardFeed

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -923,3 +923,81 @@ describe('SpaceTaskPane — activity members actions', () => {
 		expect(mockUnsubscribeTaskActivity).toHaveBeenCalledWith('task-1');
 	});
 });
+
+describe('SpaceTaskPane — floating tab pill layout', () => {
+	beforeEach(() => {
+		cleanup();
+		mockTasks.value = [];
+		mockWorkflowRuns.value = [];
+		mockWorkflows.value = [];
+		mockEnsureTaskAgentSession.mockReset();
+		mockEnsureTaskAgentSession.mockImplementation(async () =>
+			makeTask({ status: 'in_progress', taskAgentSessionId: 'session-ensured' })
+		);
+		mockNavigateToSpaceTask.mockClear();
+		mockCurrentSpaceTaskViewTabSignal.value = 'thread';
+		mockCurrentSpaceIdSignal.value = null;
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders the tab pill as a floating overlay inside the content area', () => {
+		mockTasks.value = [makeTask({ workflowRunId: 'run-1', taskAgentSessionId: 'session-abc' })];
+		mockWorkflowRuns.value = [makeWorkflowRun({ id: 'run-1', workflowId: 'workflow-1' })];
+		const { getByTestId } = render(<SpaceTaskPane taskId="task-1" spaceId="space-1" />);
+
+		const pill = getByTestId('task-view-tab-pill');
+		// Floating overlay: absolute-positioned, full-width wrapper, high z-index,
+		// and pointer-events disabled on the wrapper so empty space around the
+		// pill never blocks underlying canvas / thread interactions. (CSS class
+		// strings are asserted directly because Tailwind utilities aren't
+		// loaded in jsdom — getComputedStyle would return defaults.)
+		expect(pill.className).toContain('absolute');
+		expect(pill.className).toContain('pointer-events-none');
+		expect(pill.className).toContain('z-10');
+
+		// The pill is a direct child of the content wrapper, not nested inside
+		// the rendered view, so it overlays rather than displaces content.
+		const contentWrapper = getByTestId('task-pane-content');
+		expect(pill.parentElement).toBe(contentWrapper);
+		expect(pill.contains(getByTestId('task-thread-panel'))).toBe(false);
+	});
+
+	it('floating pill remains visible across thread, canvas, and artifacts views', () => {
+		mockTasks.value = [makeTask({ workflowRunId: 'run-1', taskAgentSessionId: 'session-abc' })];
+		mockWorkflowRuns.value = [makeWorkflowRun({ id: 'run-1', workflowId: 'workflow-1' })];
+		const { getByTestId, queryByTestId } = render(
+			<SpaceTaskPane taskId="task-1" spaceId="space-1" />
+		);
+
+		// Thread view (default)
+		expect(queryByTestId('task-view-tab-pill')).toBeTruthy();
+
+		// Canvas view
+		fireEvent.click(getByTestId('canvas-toggle'));
+		expect(queryByTestId('task-view-tab-pill')).toBeTruthy();
+		expect(getByTestId('canvas-view')).toBeTruthy();
+
+		// Artifacts view
+		fireEvent.click(getByTestId('artifacts-toggle'));
+		expect(queryByTestId('task-view-tab-pill')).toBeTruthy();
+	});
+
+	it('pill buttons remain clickable through the pointer-events-none wrapper', () => {
+		mockCurrentSpaceIdSignal.value = 'space-1';
+		mockTasks.value = [makeTask({ workflowRunId: 'run-1', taskAgentSessionId: 'session-abc' })];
+		mockWorkflowRuns.value = [makeWorkflowRun({ id: 'run-1', workflowId: 'workflow-1' })];
+		const { getByTestId } = render(<SpaceTaskPane taskId="task-1" spaceId="space-1" />);
+
+		// Direct child of the floating wrapper must restore pointer-events so
+		// the buttons inside it are still interactive.
+		const pill = getByTestId('task-view-tab-pill');
+		const innerPill = pill.firstElementChild as HTMLElement;
+		expect(innerPill.className).toContain('pointer-events-auto');
+
+		fireEvent.click(getByTestId('canvas-toggle'));
+		expect(mockNavigateToSpaceTask).toHaveBeenCalledWith('space-1', 'task-1', 'canvas');
+	});
+});

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -127,8 +127,21 @@ function makeWorkflowRun(overrides: Partial<SpaceWorkflowRun> = {}): SpaceWorkfl
 }
 
 vi.mock('../SpaceTaskUnifiedThread', () => ({
-	SpaceTaskUnifiedThread: ({ taskId }: { taskId: string }) => (
-		<div data-testid="space-task-unified-thread" data-task-id={taskId} />
+	SpaceTaskUnifiedThread: ({
+		taskId,
+		topInsetClass,
+		bottomInsetClass,
+	}: {
+		taskId: string;
+		topInsetClass?: string;
+		bottomInsetClass?: string;
+	}) => (
+		<div
+			data-testid="space-task-unified-thread"
+			data-task-id={taskId}
+			data-top-inset={topInsetClass ?? ''}
+			data-bottom-inset={bottomInsetClass ?? ''}
+		/>
 	),
 }));
 
@@ -980,7 +993,9 @@ describe('SpaceTaskPane — floating tab pill layout', () => {
 		expect(queryByTestId('task-view-tab-pill')).toBeTruthy();
 		expect(getByTestId('canvas-view')).toBeTruthy();
 
-		// Artifacts view
+		// Return to thread, then activate Artifacts — exercising a clean
+		// thread→artifacts transition rather than canvas→artifacts.
+		fireEvent.click(getByTestId('thread-toggle'));
 		fireEvent.click(getByTestId('artifacts-toggle'));
 		expect(queryByTestId('task-view-tab-pill')).toBeTruthy();
 	});
@@ -999,5 +1014,54 @@ describe('SpaceTaskPane — floating tab pill layout', () => {
 
 		fireEvent.click(getByTestId('canvas-toggle'));
 		expect(mockNavigateToSpaceTask).toHaveBeenCalledWith('space-1', 'task-1', 'canvas');
+	});
+
+	it('passes topInsetClass to SpaceTaskUnifiedThread so messages clear the floating pill', () => {
+		mockTasks.value = [makeTask({ taskAgentSessionId: 'session-abc' })];
+		const { getByTestId } = render(<SpaceTaskPane taskId="task-1" spaceId="space-1" />);
+
+		const thread = getByTestId('space-task-unified-thread');
+		expect(thread.getAttribute('data-top-inset')).toBe('pt-12');
+	});
+
+	it('renders the active banner outside task-pane-content so it is visible across tabs', () => {
+		mockTasks.value = [
+			makeTask({
+				status: 'blocked',
+				result: 'Waiting for API key',
+				workflowRunId: 'run-1',
+				taskAgentSessionId: 'session-abc',
+			}),
+		];
+		mockWorkflowRuns.value = [makeWorkflowRun({ id: 'run-1', workflowId: 'workflow-1' })];
+		const { getByTestId } = render(<SpaceTaskPane taskId="task-1" spaceId="space-1" />);
+
+		// The banner block sits between the header and the content wrapper —
+		// its parent is the top-level pane container, NOT the content wrapper —
+		// so it stays visible regardless of which tab is active.
+		const banner = getByTestId('task-pane-banner');
+		const contentWrapper = getByTestId('task-pane-content');
+		expect(contentWrapper.contains(banner)).toBe(false);
+		expect(banner.parentElement).toBe(contentWrapper.parentElement);
+
+		// Banner content (the underlying TaskBlockedBanner) renders inside.
+		expect(getByTestId('task-blocked-banner')).toBeTruthy();
+
+		// Switching to Canvas / Artifacts must not unmount the banner.
+		fireEvent.click(getByTestId('canvas-toggle'));
+		expect(getByTestId('task-pane-banner')).toBeTruthy();
+		expect(getByTestId('task-blocked-banner')).toBeTruthy();
+
+		fireEvent.click(getByTestId('thread-toggle'));
+		fireEvent.click(getByTestId('artifacts-toggle'));
+		expect(getByTestId('task-pane-banner')).toBeTruthy();
+		expect(getByTestId('task-blocked-banner')).toBeTruthy();
+	});
+
+	it('does not render the banner block when no banner applies', () => {
+		mockTasks.value = [makeTask({ status: 'in_progress', taskAgentSessionId: 'session-abc' })];
+		const { queryByTestId } = render(<SpaceTaskPane taskId="task-1" spaceId="space-1" />);
+
+		expect(queryByTestId('task-pane-banner')).toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary

- Move the Thread / Canvas / Artifacts tab pill out of its own row and reposition it as an absolute-positioned, frosted-glass overlay inside the content area — reclaims a row of vertical space; pill stays visible across all three views.
- Disable pointer-events on the centering wrapper and restore them on the pill itself so empty space around the pill doesn't block clicks on the canvas / thread / artifacts beneath.
- Tightened the pill's background opacity (`/60` → `/80`) and added `shadow-lg` so it reads as elevated.
- Added `task-pane-content` testid + 3 new tests covering overlay structure, cross-view persistence, and click-through.

## Test plan

- [x] `bun run test src/components/space/__tests__/SpaceTaskPane.test.tsx` — 46 pass (43 existing + 3 new)
- [x] `bun run test src/components/space/__tests__/SpaceTaskPane.mention.test.tsx` — 15 pass
- [x] `bun run typecheck` — clean
- [x] Pre-commit hooks pass (oxlint, biome format, tsc, knip)
- [ ] Visual: the pill floats over thread/canvas/artifacts with frosted-glass effect; thread scroll content passes under it; clicking around the pill (not on it) reaches the content beneath.