### PR TITLE
chore(space): remove completionActions types + schema + docs (PR 5/5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 All notable changes to NeoKai will be documented in this file.
 
+## [Unreleased]
+
+A five-PR refactor that replaces the `completionActions` pipeline with
+workflow-declared post-approval agent routing (#1620, #1621, #1623, #1628, and
+the schema/docs cleanup PR 5/5). See
+[`docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md`](docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md)
+for the full design.
+
+### Added
+
+- **`approved` task status** — new lifecycle stage between `review` and `done`
+  for tasks whose end-node verdict has been accepted but whose post-approval
+  side effect (e.g. PR merge) is still in flight.
+- **`postApproval: { targetAgent, instructions }` workflow schema** — workflows
+  declare an optional post-approval route; the runtime spawns the named
+  in-workflow agent (or injects an instruction turn into the Task Agent) on the
+  `review/done → approved` boundary.
+- **`mark_complete` MCP tool** — the post-approval executor calls this to
+  transition `approved → done` (or back to `blocked` with a reason).
+- **Single-slot post-approval banner** — replaces the previous multi-slot
+  completion-action banner; surfaces `task.postApprovalBlockedReason` when the
+  executor reports it cannot proceed.
+
+### Removed
+
+- **`completionActions` workflow field** — both the type and the schema column.
+  Workflows persisted with the field are silently sanitised at load time and
+  emit a `workflow.migrated` daemon log line so operators can audit drift.
+- **`approve_completion_action` MCP tool**, the `MERGE_PR_COMPLETION_ACTION` /
+  `VERIFY_PR_MERGED_COMPLETION_ACTION` /
+  `VERIFY_REVIEW_POSTED_COMPLETION_ACTION` /
+  `PLAN_AND_DECOMPOSE_VERIFY_COMPLETION_ACTION` constants, and the
+  `CompletionActionExecutor` runtime. PR-merge logic now lives inside the
+  post-approval agent's instructions.
+- **`space_tasks.pending_action_index` column** and
+  **`space_workflow_runs.completion_actions_fired_at` column** — dropped by
+  M104. The `pending_checkpoint_type` CHECK constraint is tightened to
+  `('gate', 'task_completion')`.
+
+### Migrations
+
+- **M104** — defensive rewrite of any in-flight
+  `pending_checkpoint_type='completion_action'` rows to `'task_completion'`,
+  table-rebuild of `space_tasks` to drop `pending_action_index`, and
+  `ALTER TABLE … DROP COLUMN` on `space_workflow_runs.completion_actions_fired_at`.
+  Idempotent and guarded for missing-table cases.
+
 ## [0.12.0] - 2026-04-22
 
 A release improving tool surface area and session resilience. 5 commits since v0.11.1.

--- a/docs/design/autonomy-levels-and-completion-actions.md
+++ b/docs/design/autonomy-levels-and-completion-actions.md
@@ -1,7 +1,7 @@
 # Design: Autonomy Levels & Completion Actions
 
 Date: 2026-04-14
-Status: Draft
+Status: **Superseded** (2026-04-24) — the autonomy-levels half of this doc shipped, but the `completionActions` half was replaced by workflow-declared `postApproval` routing. See [`docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md`](../plans/remove-completion-actions-task-agent-as-post-approval-executor.md) for the replacement design and the five PRs that delivered it (#1620, #1621, #1623, #1628, plus the schema/docs cleanup PR 5/5). The `CompletionAction` interface, `pendingActionIndex` field, and `pending_checkpoint_type='completion_action'` value referenced below no longer exist in the codebase as of PR 5/5; treat §"Completion actions" of this document as historical context only.
 
 ## Problem
 

--- a/docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md
+++ b/docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md
@@ -2,9 +2,23 @@
 
 **Task:** Space Task #75
 **Source research:** [`docs/research/pr-merging-completion-actions.md`](../research/pr-merging-completion-actions.md)
-**Status:** Planning — no code changes yet
+**Status:** ✅ **Shipped** — all five PRs merged.
 **Author:** Research node
 **Revision:** 2026-04-23 — approach changed from "Task Agent MCP `merge_pr` tool" to "workflow-declared post-approval agent". See §8 "Revision history" for the full context.
+
+> **Implementation status (2026-04-24):** the plan landed in five sequenced PRs:
+>
+> | Stage | PR | Scope |
+> | --- | --- | --- |
+> | 1 | [#1620](https://github.com/focusdotcc/neokai/pull/1620) | New `approved` task status + `postApproval` workflow schema (no behaviour change) |
+> | 2 | [#1621](https://github.com/focusdotcc/neokai/pull/1621) | Runtime post-approval routing + `mark_complete` MCP tool |
+> | 3 | [#1623](https://github.com/focusdotcc/neokai/pull/1623) | Built-in workflows declare `postApproval`; feature flag enabled |
+> | 4 | [#1628](https://github.com/focusdotcc/neokai/pull/1628) | Delete `CompletionActionExecutor`, MCP tools, and the legacy banner |
+> | 5 | _this PR_ | Drop `CompletionAction` types + DB columns + tighten the `pending_checkpoint_type` CHECK; refresh docs |
+>
+> The plan document below is preserved as the design record. Wherever the plan
+> says "will" or "we propose", read it as "did" / "we did". Anything still
+> labelled future work in §11 has been deferred to a follow-up.
 
 ---
 

--- a/docs/research/pr-merging-completion-actions.md
+++ b/docs/research/pr-merging-completion-actions.md
@@ -5,6 +5,20 @@
 **Question:** Where are PR merge decisions made, and can a PR be auto-merged when the space is at autonomy **Level 1** (the lowest / most conservative level)?
 **Bottom line:** Yes — there are two concrete code paths that can merge a PR at Level 1 without any human approval step, and one design gap where the documented "merge-pr" completion action for the *Coding* workflow is effectively **dead code at Level 1** (it is never reached through the human-approval path).
 
+> **Status (2026-04-24):** this research drove the plan in
+> [`docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md`](../plans/remove-completion-actions-task-agent-as-post-approval-executor.md),
+> which has now shipped in five PRs:
+> [#1620](https://github.com/focusdotcc/neokai/pull/1620),
+> [#1621](https://github.com/focusdotcc/neokai/pull/1621),
+> [#1623](https://github.com/focusdotcc/neokai/pull/1623),
+> [#1628](https://github.com/focusdotcc/neokai/pull/1628), and the
+> schema/docs cleanup PR (5/5). The `completionActions` pipeline described
+> below has been replaced by workflow-declared `postApproval: { targetAgent,
+> instructions }` routing dispatched by the runtime — the end-node agent no
+> longer carries an action list. The terminology in §1–§7 is preserved as a
+> historical record of the system that motivated the redesign; do not treat
+> any of the described code paths as live.
+
 ---
 
 ## 1. Background — The Three Dials That Govern Merging

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
@@ -80,7 +80,6 @@ function buildTemplateUpdateParams(
 			id: nodeIdMap.get(node.id)!,
 			name: node.name,
 			agents: resolvedAgents,
-			...(node.completionActions ? { completionActions: node.completionActions } : {}),
 		};
 	});
 

--- a/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
@@ -157,10 +157,6 @@ export class SpaceWorkflowManager {
 			this.validateName(existing.spaceId, trimmedName, id);
 			params = { ...params, name: trimmedName };
 		}
-		// IMPORTANT: thread `completionActions` through both branches. The
-		// second branch (existing.nodes rehydration) runs on EVERY update call —
-		// including updates that don't touch nodes — so dropping the field here
-		// silently deletes completionActions from any workflow that had them.
 		const effectiveNodes: WorkflowNodeInput[] =
 			params.nodes !== undefined
 				? (params.nodes ?? []).map(
@@ -168,7 +164,6 @@ export class SpaceWorkflowManager {
 							id: n.id,
 							name: n.name,
 							agents: n.agents,
-							...(n.completionActions ? { completionActions: n.completionActions } : {}),
 						})
 					)
 				: existing.nodes.map(
@@ -176,7 +171,6 @@ export class SpaceWorkflowManager {
 							id: n.id,
 							name: n.name,
 							agents: n.agents,
-							...(n.completionActions ? { completionActions: n.completionActions } : {}),
 						})
 					);
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1956,12 +1956,15 @@ export class TaskAgentManager {
 	/**
 	 * Rehydrate Task Agent sessions after a daemon restart.
 	 *
-	 * Queries `space_tasks` for tasks with status `in_progress` or `blocked`
-	 * that have a non-null `taskAgentSessionId`. For each such task that has a
-	 * `space_task_agent` session type in the DB, restores the Task Agent session via
-	 * `AgentSession.restore()`, re-attaches the MCP server and system prompt,
-	 * restarts the streaming query, and injects a re-orientation message so the
-	 * agent resumes from where it left off.
+	 * Queries `space_tasks` for tasks with status `in_progress`, `blocked`, or
+	 * `approved` that have a non-null `taskAgentSessionId`. For each such task
+	 * that has a `space_task_agent` session type in the DB, restores the Task
+	 * Agent session via `AgentSession.restore()`, re-attaches the MCP server
+	 * and system prompt, restarts the streaming query, and injects a
+	 * re-orientation message so the agent resumes from where it left off.
+	 * `'approved'` is included because the Task Agent session can still be
+	 * live while the post-approval sub-session runs — see
+	 * `SpaceTaskRepository.listActiveWithTaskAgentSession`.
 	 *
 	 * Sub-sessions are NOT fully rehydrated — the Task Agent will re-spawn them
 	 * via its MCP tools after receiving the re-orientation message. The in-memory

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -380,11 +380,11 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'   a. Post an approval review: `gh pr review <pr-url> --approve ' +
 							'--body-file <file>`.\n' +
 							'   b. Verify the PR is still open and mergeable.\n' +
-							'   c. Signal the Task Agent that a merge is the post-approval action:\n' +
+							'   c. Signal the Task Agent that the PR is ready for post-approval:\n' +
 							'      send_message(\n' +
 							'         target: "task-agent",\n' +
 							'         message: "Reviewer approved. PR ready for post-approval.",\n' +
-							'         data: { pr_url: "<url>", post_approval_action: "merge_pr" }\n' +
+							'         data: { pr_url: "<url>" }\n' +
 							'      )\n' +
 							'   d. Call `save_artifact({ type: "result", append: true, summary, data: { prUrl: "<url>" } })` ' +
 							'to record the audit entry. The `prUrl` inside `data` is what ' +
@@ -550,11 +550,11 @@ export const RESEARCH_WORKFLOW: SpaceWorkflow = {
 							'--body-file <file>`. A visible GitHub review is required — an internal ' +
 							'summary is not enough.\n' +
 							'   b. Verify the PR is still open and mergeable.\n' +
-							'   c. Signal the Task Agent that a merge is the post-approval action:\n' +
+							'   c. Signal the Task Agent that the PR is ready for post-approval:\n' +
 							'      send_message(\n' +
 							'         target: "task-agent",\n' +
 							'         message: "Reviewer approved. PR ready for post-approval.",\n' +
-							'         data: { pr_url: "<url>", post_approval_action: "merge_pr" }\n' +
+							'         data: { pr_url: "<url>" }\n' +
 							'      )\n' +
 							'   d. Call `save_artifact({ type: "result", append: true, summary, data: { prUrl: "<url>" } })` ' +
 							'to record the final audit entry. The `prUrl` inside `data` is what ' +
@@ -982,11 +982,11 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
 							'`save_artifact({ type: "result", append: true, summary: "QA failed: ..." })` to record the audit entry. Do ' +
 							'NOT call `approve_task` — leave the workflow open for the next Coding cycle.\n' +
 							'5. If all green:\n' +
-							'   a. Signal the Task Agent that a merge is the post-approval action:\n' +
+							'   a. Signal the Task Agent that the PR is ready for post-approval:\n' +
 							'      send_message(\n' +
 							'         target: "task-agent",\n' +
 							'         message: "QA passed. PR ready for post-approval.",\n' +
-							'         data: { pr_url: "<url>", post_approval_action: "merge_pr" }\n' +
+							'         data: { pr_url: "<url>" }\n' +
 							'      )\n' +
 							'   b. Call `save_artifact({ type: "result", append: true, summary, data: { prUrl: "<url>", testOutput: "<output>" } })` ' +
 							'to record the audit entry. The `prUrl` inside `data` is what ' +

--- a/packages/daemon/src/lib/space/workflows/post-approval-merge-template.ts
+++ b/packages/daemon/src/lib/space/workflows/post-approval-merge-template.ts
@@ -28,9 +28,11 @@
  * for now.
  *
  * Workflow authors referencing this template MUST ensure their end node signals
- * `{ pr_url, post_approval_action: 'merge_pr' }` before `approve_task()` /
- * `submit_for_approval()` — the signalling convention documented in §2.1 of
- * the plan.
+ * `{ pr_url }` (inside the `data` payload of `send_message(target:
+ * 'task-agent', …)` and/or `save_artifact({ type: 'result', data: { prUrl } })`)
+ * before `approve_task()` / `submit_for_approval()`. The earlier §2.1
+ * `post_approval_action` discriminator was removed — post-approval routing is
+ * declarative on the workflow's `postApproval` field, not signalled at runtime.
  *
  * Step 6 MUST instruct the post-approval session to call `mark_complete` (not
  * `approve_task`); this is the hard distinction between the

--- a/packages/daemon/src/lib/space/workflows/template-hash.ts
+++ b/packages/daemon/src/lib/space/workflows/template-hash.ts
@@ -6,13 +6,13 @@
  *
  * The fingerprint covers node names, channel topology, gate internals (fields,
  * script, requiredLevel, resetOnCycle), description, instructions, per-agent
- * custom prompts, node completion actions, and the workflow-level
- * completionAutonomyLevel.
+ * custom prompts, the workflow-level `completionAutonomyLevel`, and the
+ * workflow-level `postApproval` route.
  * It does NOT include agent UUIDs (which differ per-space), layout coordinates,
  * or tags (which are cosmetic).
  */
 
-import type { CompletionAction, SpaceWorkflow } from '@neokai/shared';
+import type { SpaceWorkflow } from '@neokai/shared';
 
 /**
  * Canonical shape used for hashing — uses only template-portable fields.
@@ -36,42 +36,17 @@ interface WorkflowFingerprint {
 	 */
 	nodePrompts: string[];
 	/**
-	 * Per-node completion action entries, sorted. Format:
-	 * `<nodeName>|<actionId>|<type>|<requiredLevel>|<contentKey>`.
-	 * Detects changes to what happens when the workflow finishes.
-	 */
-	completionActions: string[];
-	/**
 	 * Minimum space autonomy level required to auto-close the workflow.
 	 * Affects autonomy gating behavior.
 	 */
 	completionAutonomyLevel: number;
 	/**
-	 * Workflow-level post-approval route (PR 3/5). Empty string when no route
-	 * is declared. Format: `<targetAgent>|<instructions>`. Detects changes to
-	 * the post-approval handoff — so seeder re-stamping triggers when the
-	 * built-in templates gain or modify their `postApproval` entry.
+	 * Workflow-level post-approval route. Empty string when no route is
+	 * declared. Format: `<targetAgent>|<instructions>`. Detects changes to the
+	 * post-approval handoff — so seeder re-stamping triggers when the built-in
+	 * templates gain or modify their `postApproval` entry.
 	 */
 	postApproval: string;
-}
-
-/**
- * Serialize a single completion action into a stable canonical string.
- * Format: `<id>|<type>|<requiredLevel>|<contentKey>`
- * - script:      contentKey = full script source
- * - instruction: contentKey = `<agentName>:<instruction>`
- * - mcp_call:    contentKey = `<server>:<tool>`
- */
-function serializeCompletionAction(action: CompletionAction): string {
-	let contentKey: string;
-	if (action.type === 'script') {
-		contentKey = action.script;
-	} else if (action.type === 'instruction') {
-		contentKey = `${action.agentName}:${action.instruction}`;
-	} else {
-		contentKey = `${action.server}:${action.tool}`;
-	}
-	return `${action.id}|${action.type}|${action.requiredLevel}|${contentKey}`;
 }
 
 /**
@@ -118,14 +93,6 @@ export function buildWorkflowFingerprint(workflow: SpaceWorkflow): WorkflowFinge
 		.flatMap((n) => n.agents.map((a) => `${n.name}|${a.name}|${a.customPrompt?.value ?? ''}`))
 		.sort();
 
-	// Serialize per-node completion actions.
-	// Format: `<nodeName>|<actionId>|<type>|<requiredLevel>|<contentKey>`
-	const completionActions = workflow.nodes
-		.flatMap((n) =>
-			(n.completionActions ?? []).map((action) => `${n.name}|${serializeCompletionAction(action)}`)
-		)
-		.sort();
-
 	// Serialize workflow-level post-approval route.
 	// Format: `<targetAgent>|<instructions>` (empty string when absent).
 	const postApproval = workflow.postApproval
@@ -139,7 +106,6 @@ export function buildWorkflowFingerprint(workflow: SpaceWorkflow): WorkflowFinge
 		channels,
 		gates,
 		nodePrompts,
-		completionActions,
 		completionAutonomyLevel: workflow.completionAutonomyLevel,
 		postApproval,
 	};

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -367,20 +367,21 @@ export class SpaceTaskRepository {
 	/**
 	 * List all tasks that have an active Task Agent session.
 	 *
-	 * Returns tasks with status `in_progress` or `blocked` that have a
-	 * non-null `task_agent_session_id`. Used by `TaskAgentManager.rehydrate()` on
-	 * daemon restart to find Task Agent sessions that need to be restarted.
+	 * Returns tasks with status `in_progress`, `blocked`, or `approved` that
+	 * have a non-null `task_agent_session_id`. Used by
+	 * `TaskAgentManager.rehydrate()` on daemon restart to find Task Agent
+	 * sessions that need to be restarted.
 	 *
-	 * NOTE (PR 2 of post-approval refactor): when the `approved` status starts
-	 * carrying `post_approval_session_id` for in-flight post-approval work, the
-	 * status filter here must widen to include `'approved'` so those sessions
-	 * rehydrate too. This PR (1/5) is schema-only and no task can reach
-	 * `'approved'` yet, so keeping the current filter preserves the
-	 * no-behaviour-change invariant.
+	 * `'approved'` is included because the Task Agent session can still be live
+	 * while the post-approval sub-session runs — mark_complete may transition
+	 * the task back to `in_progress` or to `done`, and the UI's
+	 * `spaceTaskActivity.byTask` LiveQuery depends on the session being
+	 * rehydrated in-memory. Tasks in `'done'`/`'cancelled'`/`'archived'` are
+	 * terminal and their sessions are torn down.
 	 */
 	listActiveWithTaskAgentSession(): SpaceTask[] {
 		const stmt = this.db.prepare(
-			`SELECT * FROM space_tasks WHERE status IN ('in_progress', 'blocked') AND task_agent_session_id IS NOT NULL`
+			`SELECT * FROM space_tasks WHERE status IN ('in_progress', 'blocked', 'approved') AND task_agent_session_id IS NOT NULL`
 		);
 		const rows = stmt.all() as Record<string, unknown>[];
 		return rows.map((r) => this.rowToSpaceTask(r));

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -264,10 +264,6 @@ export class SpaceTaskRepository {
 			fields.push('approved_at = ?');
 			values.push(params.approvedAt ?? null);
 		}
-		if (params.pendingActionIndex !== undefined) {
-			fields.push('pending_action_index = ?');
-			values.push(params.pendingActionIndex ?? null);
-		}
 		if (params.pendingCheckpointType !== undefined) {
 			fields.push('pending_checkpoint_type = ?');
 			values.push(params.pendingCheckpointType ?? null);
@@ -450,7 +446,6 @@ export class SpaceTaskRepository {
 			approvalSource: (row.approval_source as SpaceTask['approvalSource']) ?? null,
 			approvalReason: (row.approval_reason as string | null) ?? null,
 			approvedAt: (row.approved_at as number | null) ?? null,
-			pendingActionIndex: (row.pending_action_index as number | null) ?? null,
 			pendingCheckpointType:
 				(row.pending_checkpoint_type as SpaceTask['pendingCheckpointType']) ?? null,
 			pendingCompletionSubmittedByNodeId:

--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -21,13 +21,15 @@ import type {
 	WorkflowNode,
 	WorkflowNodeInput,
 	WorkflowNodeAgent,
-	CompletionAction,
 	WorkflowChannel,
 	Gate,
 	CreateSpaceWorkflowParams,
 	PostApprovalRoute,
 	UpdateSpaceWorkflowParams,
 } from '@neokai/shared';
+import { Logger } from '../../lib/logger';
+
+const log = new Logger('space-workflow-repository');
 
 // ---------------------------------------------------------------------------
 // Internal DB row shapes
@@ -72,8 +74,16 @@ interface NodeRow {
 interface NodeConfigJson {
 	/** Multi-agent array */
 	agents?: WorkflowNodeAgent[];
-	/** Completion actions for end-node post-completion execution */
-	completionActions?: CompletionAction[];
+	/**
+	 * Forward-compat: rows persisted before PR 5/5 of the
+	 * task-agent-as-post-approval-executor refactor may carry a legacy
+	 * post-approval action list under this key. The runtime no longer reads it;
+	 * `rowToNode` strips it on load and logs a warning so the row can be
+	 * re-saved cleanly the next time the workflow is updated. The field is
+	 * intentionally untyped (`unknown`) because the action union has been
+	 * deleted from `@neokai/shared`.
+	 */
+	completionActions?: unknown;
 }
 
 // ---------------------------------------------------------------------------
@@ -89,7 +99,17 @@ function parseJson<T>(raw: string | null | undefined, fallback: T): T {
 	}
 }
 
-function rowToNode(row: NodeRow): WorkflowNode {
+/**
+ * Per-load migration accumulator. `rowToNode` pushes the names of any
+ * deprecated fields it strips into `strippedFields` so the caller can emit a
+ * single workflow-level `workflow.migrated` structured log line covering every
+ * stripped field across all nodes — instead of a noisy per-node warning.
+ */
+interface NodeMigrationContext {
+	strippedFields: Set<string>;
+}
+
+function rowToNode(row: NodeRow, ctx?: NodeMigrationContext): WorkflowNode {
 	const cfg = parseJson<NodeConfigJson>(row.config, {});
 	// Ensure agents is always a non-empty array
 	const agents: WorkflowNodeAgent[] =
@@ -101,13 +121,21 @@ function rowToNode(row: NodeRow): WorkflowNode {
 				}))
 			: [];
 
+	// Forward-compat: drop the deprecated `completionActions` key without
+	// failing the load. Older rows persisted before PR 5/5 of the
+	// task-agent-as-post-approval-executor refactor still carry it. The
+	// runtime no longer routes through it — the workflow's `postApproval`
+	// route is the supported replacement. We do NOT log here per-node; the
+	// caller aggregates stripped fields and emits a single structured
+	// `workflow.migrated` log line per workflow load. See plan §6.1.
+	if (cfg.completionActions !== undefined && ctx) {
+		ctx.strippedFields.add('completionActions');
+	}
+
 	return {
 		id: row.id,
 		name: row.name,
 		agents,
-		...(cfg.completionActions && cfg.completionActions.length > 0
-			? { completionActions: cfg.completionActions }
-			: {}),
 	};
 }
 
@@ -226,7 +254,9 @@ export class SpaceWorkflowRepository {
 			| WorkflowRow
 			| undefined;
 		if (!row) return null;
-		const nodes = this.fetchNodes(id);
+		const ctx: NodeMigrationContext = { strippedFields: new Set<string>() };
+		const nodes = this.fetchNodes(id, ctx);
+		this.emitMigrationLog(row, ctx);
 		return rowToWorkflow(row, nodes);
 	}
 
@@ -236,7 +266,31 @@ export class SpaceWorkflowRepository {
 				`SELECT * FROM space_workflows WHERE space_id = ? ORDER BY created_at ASC, rowid ASC`
 			)
 			.all(spaceId) as WorkflowRow[];
-		return rows.map((r) => rowToWorkflow(r, this.fetchNodes(r.id)));
+		return rows.map((r) => {
+			const ctx: NodeMigrationContext = { strippedFields: new Set<string>() };
+			const nodes = this.fetchNodes(r.id, ctx);
+			this.emitMigrationLog(r, ctx);
+			return rowToWorkflow(r, nodes);
+		});
+	}
+
+	/**
+	 * Emit the structured `workflow.migrated` log line when a load stripped
+	 * deprecated fields. Format is fixed by plan §6.1 so operators / log
+	 * aggregators can grep / parse it reliably:
+	 *
+	 *   `workflow.migrated: workflowId=<id> workflowName=<name> strippedFields=[<csv>]`
+	 *
+	 * The DB row is intentionally NOT rewritten — re-saving the workflow via
+	 * the editor is the documented way to clear persisted legacy fields.
+	 */
+	private emitMigrationLog(row: WorkflowRow, ctx: NodeMigrationContext): void {
+		if (ctx.strippedFields.size === 0) return;
+		const stripped = [...ctx.strippedFields].sort().join(',');
+		log.warn(
+			`workflow.migrated: workflowId=${row.id} workflowName=${row.name} ` +
+				`strippedFields=[${stripped}]`
+		);
 	}
 
 	// -------------------------------------------------------------------------
@@ -376,11 +430,11 @@ export class SpaceWorkflowRepository {
 	// Private helpers
 	// -------------------------------------------------------------------------
 
-	private fetchNodes(workflowId: string): WorkflowNode[] {
+	private fetchNodes(workflowId: string, ctx?: NodeMigrationContext): WorkflowNode[] {
 		const rows = this.db
 			.prepare(`SELECT * FROM space_workflow_nodes WHERE workflow_id = ? ORDER BY rowid ASC`)
 			.all(workflowId) as NodeRow[];
-		return rows.map(rowToNode);
+		return rows.map((r) => rowToNode(r, ctx));
 	}
 
 	private insertNode(
@@ -403,9 +457,6 @@ export class SpaceWorkflowRepository {
 		}
 		if (resolvedAgents && resolvedAgents.length > 0) {
 			nodeCfg.agents = resolvedAgents;
-		}
-		if (input.completionActions && input.completionActions.length > 0) {
-			nodeCfg.completionActions = input.completionActions;
 		}
 
 		this.db

--- a/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-run-repository.ts
@@ -22,13 +22,6 @@ export interface UpdateWorkflowRunParams {
 	failureReason?: WorkflowRunFailureReason | null;
 	startedAt?: number | null;
 	completedAt?: number | null;
-	/**
-	 * Timestamp at which the run's end-node completion actions have been fired.
-	 * Pass `null` only when explicitly clearing the marker (uncommon). Once set,
-	 * the marker survives reopen transitions so completion actions are never
-	 * re-fired on subsequent completions.
-	 */
-	completionActionsFiredAt?: number | null;
 }
 
 export class SpaceWorkflowRunRepository {
@@ -154,10 +147,6 @@ export class SpaceWorkflowRunRepository {
 			fields.push('completed_at = ?');
 			values.push(params.completedAt ?? null);
 		}
-		if (params.completionActionsFiredAt !== undefined) {
-			fields.push('completion_actions_fired_at = ?');
-			values.push(params.completionActionsFiredAt ?? null);
-		}
 
 		if (fields.length > 0) {
 			fields.push('updated_at = ?');
@@ -240,7 +229,6 @@ export class SpaceWorkflowRunRepository {
 			startedAt: (row.started_at as number | null) ?? null,
 			updatedAt: row.updated_at as number,
 			completedAt: (row.completed_at as number | null) ?? null,
-			completionActionsFiredAt: (row.completion_actions_fired_at as number | null) ?? null,
 		};
 	}
 }

--- a/packages/daemon/src/storage/schema/m94-backfill-workflow-templates.ts
+++ b/packages/daemon/src/storage/schema/m94-backfill-workflow-templates.ts
@@ -1,24 +1,27 @@
 /**
- * Migration 94 — Backfill workflow template tracking & end-node completion actions.
+ * Migration 94 — Backfill workflow template tracking & remove orphan duplicates.
  *
- * Context: two silent field-drop bugs in `seedBuiltInWorkflows()` and
- * `updateWorkflow()` caused existing workflow rows to be persisted without
- * their `completionActions`, and earlier versions of the seed predated the
- * `template_name` / `template_hash` columns. As a result, existing Spaces have
- * workflows that:
- *   - Match a built-in template by name but have `template_name = NULL`
- *     (breaking drift detection and the "Sync from template" UI).
- *   - Have an end node without `MERGE_PR_COMPLETION_ACTION`, so the Reviewer's
- *     `report_result()` completes the run but the PR never merges.
+ * Context: earlier versions of `seedBuiltInWorkflows()` predated the
+ * `template_name` / `template_hash` columns, so existing Spaces ended up with
+ * workflows that match a built-in template by name but have
+ * `template_name = NULL` (which broke drift detection and the "Sync from
+ * template" UI).
  *
  * This migration realigns legacy rows with the current built-in templates:
- *   1. For each `space_workflows` row whose (name, node names) structurally
- *      matches a known built-in, set `template_name` + `template_hash` if
- *      missing, and reattach the template's `completionActions` on the end
- *      node if missing.
+ *   1. For each `space_workflows` row whose (name, node names, fingerprint)
+ *      structurally matches a known built-in, set `template_name` +
+ *      `template_hash` if missing.
  *   2. Delete orphan duplicate workflows — same (space_id, name) as a newer
  *      row, older `created_at`, and no active `space_workflow_runs` references.
  *      Keeps the newer row; drops the earlier superseded seed.
+ *
+ * Historical note: an earlier revision of this migration also reattached an
+ * end-node `completionActions` JSON entry on rows where it was missing. That
+ * pipeline was deleted in PR 4/5 of the
+ * task-agent-as-post-approval-executor refactor and the underlying columns are
+ * dropped in M104, so the backfill is no longer needed. Any residual
+ * `completionActions` JSON on existing node rows is silently ignored at load
+ * time (see `space-workflow-repository.ts#rowToNode`).
  *
  * The migration is idempotent: re-running it on a DB that has already been
  * backfilled is a no-op (template hashes only get rewritten when they differ).
@@ -68,70 +71,11 @@ interface TemplateShape {
 	description: string;
 	instructions: string;
 	nodeNames: string[];
-	/** Name of the end node — used to locate which node-row to backfill. */
+	/** Name of the end node — preserved for symmetry with the historical shape. */
 	endNodeName: string;
 	channels: ChannelShape[];
 	gates: GateShape[];
-	/** Completion action JSON to attach to the end node, if any. */
-	endNodeCompletionActions?: CompletionActionShape[];
 }
-
-interface CompletionActionShape {
-	id: string;
-	name: string;
-	type: 'script' | 'instruction' | 'mcp_call';
-	requiredLevel: number;
-	artifactType?: string;
-	artifactKey?: string;
-	script?: string;
-	targetNodeId?: string;
-	instruction?: string;
-	server?: string;
-	tool?: string;
-	args?: Record<string, string>;
-}
-
-// Inline bash scripts from built-in-workflows.ts — the actual merge script.
-// Kept inline so the migration is self-contained and stable.
-const PR_MERGE_BASH_SCRIPT = [
-	'# Resolve PR URL from artifact data or current branch',
-	'PR_URL=$(jq -r \'.pr_url // .url // empty\' <<< "${NEOKAI_ARTIFACT_DATA_JSON:-{}}" 2>/dev/null || true)',
-	'if [ -z "$PR_URL" ]; then',
-	'  PR_URL=$(gh pr view --json url -q .url 2>/dev/null || true)',
-	'fi',
-	'if [ -z "$PR_URL" ]; then',
-	'  echo "No PR URL found — cannot merge" >&2',
-	'  exit 1',
-	'fi',
-	'# Idempotency guard: skip merge if PR is already merged',
-	'PR_STATE=$(gh pr view "$PR_URL" --json state -q .state 2>/dev/null || true)',
-	'if [ "$PR_STATE" = "MERGED" ]; then',
-	'  echo "PR already merged: $PR_URL"',
-	'  BASE_BRANCH=$(gh pr view "$PR_URL" --json baseRefName -q .baseRefName 2>/dev/null || echo "main")',
-	'  git checkout "$BASE_BRANCH" 2>/dev/null && git pull --ff-only 2>/dev/null || true',
-	'  jq -n --arg url "$PR_URL" \'{"merged_pr_url":$url,"status":"already_merged"}\'',
-	'  exit 0',
-	'fi',
-	'echo "Merging PR: $PR_URL"',
-	'if ! gh pr merge "$PR_URL" --squash; then',
-	'  echo "Failed to merge PR: $PR_URL" >&2',
-	'  exit 1',
-	'fi',
-	'# Sync worktree with base branch after merge',
-	'BASE_BRANCH=$(gh pr view "$PR_URL" --json baseRefName -q .baseRefName 2>/dev/null || echo "main")',
-	'git checkout "$BASE_BRANCH" 2>/dev/null && git pull --ff-only 2>/dev/null || true',
-	'echo "PR merged and worktree synced"',
-	'jq -n --arg url "$PR_URL" \'{"merged_pr_url":$url,"status":"merged"}\'',
-].join('\n');
-
-const MERGE_PR_COMPLETION_ACTION: CompletionActionShape = {
-	id: 'merge-pr',
-	name: 'Merge PR',
-	type: 'script',
-	requiredLevel: 4,
-	artifactType: 'pr',
-	script: PR_MERGE_BASH_SCRIPT,
-};
 
 // First 64 chars of `PR_READY_BASH_SCRIPT` (joined with \n) — matches what
 // `computeWorkflowHash` captures via `g.script.source.slice(0, 64)`. Must be
@@ -164,7 +108,6 @@ const KNOWN_TEMPLATES: TemplateShape[] = [
 				scriptSource: PR_READY_SCRIPT_PREFIX,
 			},
 		],
-		endNodeCompletionActions: [MERGE_PR_COMPLETION_ACTION],
 	},
 	{
 		name: 'Research Workflow',
@@ -185,7 +128,6 @@ const KNOWN_TEMPLATES: TemplateShape[] = [
 				scriptSource: PR_READY_SCRIPT_PREFIX,
 			},
 		],
-		endNodeCompletionActions: [MERGE_PR_COMPLETION_ACTION],
 	},
 	{
 		name: 'Review-Only Workflow',
@@ -196,7 +138,6 @@ const KNOWN_TEMPLATES: TemplateShape[] = [
 		endNodeName: 'Review',
 		channels: [],
 		gates: [],
-		endNodeCompletionActions: undefined,
 	},
 	{
 		name: 'Plan & Decompose Workflow',
@@ -228,9 +169,6 @@ const KNOWN_TEMPLATES: TemplateShape[] = [
 				],
 			},
 		],
-		// Plan & Decompose's end-node completion action verifies ≥1 task was
-		// created — it's injected by the live template, not by the M94 backfill.
-		endNodeCompletionActions: undefined,
 	},
 	{
 		name: 'Coding with QA Workflow',
@@ -259,7 +197,6 @@ const KNOWN_TEMPLATES: TemplateShape[] = [
 				fields: [{ name: 'approved', type: 'boolean', check: { op: '==', value: true } }],
 			},
 		],
-		endNodeCompletionActions: undefined,
 	},
 ];
 
@@ -395,11 +332,6 @@ interface NodeRow {
 	config: string | null;
 }
 
-interface NodeConfigJson {
-	agents?: unknown[];
-	completionActions?: CompletionActionShape[];
-}
-
 function parseJson<T>(raw: string | null | undefined, fallback: T): T {
 	if (!raw) return fallback;
 	try {
@@ -453,7 +385,6 @@ export function runMigration94(db: BunDatabase): void {
 	const updateWorkflow = db.prepare(
 		`UPDATE space_workflows SET template_name = ?, template_hash = ? WHERE id = ?`
 	);
-	const updateNodeConfig = db.prepare(`UPDATE space_workflow_nodes SET config = ? WHERE id = ?`);
 	const deleteWorkflow = db.prepare(`DELETE FROM space_workflows WHERE id = ?`);
 
 	// Track which rows are considered "backfilled built-ins" — used below for
@@ -462,8 +393,7 @@ export function runMigration94(db: BunDatabase): void {
 	const matchedByKey = new Map<string, WorkflowRow[]>(); // key: `${spaceId}|${name}`
 
 	// -----------------------------------------------------------------------
-	// Pass 1 — structural match + backfill template_name/template_hash and
-	// end-node completionActions.
+	// Pass 1 — structural match + backfill template_name/template_hash.
 	// -----------------------------------------------------------------------
 	for (const row of workflowRows) {
 		const known = templatesByName.get(row.name);
@@ -512,27 +442,6 @@ export function runMigration94(db: BunDatabase): void {
 			updateWorkflow.run(nextTemplateName, nextTemplateHash, row.id);
 			row.template_name = nextTemplateName;
 			row.template_hash = nextTemplateHash;
-		}
-
-		// ----- Backfill end-node completionActions -----
-		if (known.tpl.endNodeCompletionActions && known.tpl.endNodeCompletionActions.length > 0) {
-			// Prefer end_node_id when set; otherwise fall back to node matched
-			// by endNodeName.
-			const endNode =
-				nodeRows.find((n) => n.id === row.end_node_id) ??
-				nodeRows.find((n) => n.name === known.tpl.endNodeName);
-			if (endNode) {
-				const cfg = parseJson<NodeConfigJson>(endNode.config, {});
-				const existing = cfg.completionActions ?? [];
-				// Only inject if missing — preserve any custom actions the user
-				// may have added.
-				const hasMergePr = existing.some((a) => a?.id === 'merge-pr');
-				if (!hasMergePr) {
-					const newActions = [...existing, ...known.tpl.endNodeCompletionActions];
-					const newCfg: NodeConfigJson = { ...cfg, completionActions: newActions };
-					updateNodeConfig.run(JSON.stringify(newCfg), endNode.id);
-				}
-			}
 		}
 	}
 

--- a/packages/daemon/src/storage/schema/m94-backfill-workflow-templates.ts
+++ b/packages/daemon/src/storage/schema/m94-backfill-workflow-templates.ts
@@ -201,8 +201,18 @@ const KNOWN_TEMPLATES: TemplateShape[] = [
 ];
 
 // ---------------------------------------------------------------------------
-// Canonical fingerprint / hash — MUST mirror
-// `packages/daemon/src/lib/space/workflows/template-hash.ts`.
+// Canonical fingerprint / hash — frozen historical copy.
+//
+// This mirrors the shape of `template-hash.ts` AS OF the M94 authoring date
+// (commit 6c13c7a7a). The production fingerprint in
+// `packages/daemon/src/lib/space/workflows/template-hash.ts` has since grown
+// additional fields (nodePrompts, completionAutonomyLevel, postApproval).
+//
+// We intentionally do NOT update this migration to track the evolving
+// fingerprint: M94 is a one-shot backfill that runs against pre-M94 DBs, and
+// the seeder re-stamps `template_content_hash` on every daemon start using
+// the live fingerprint. So the only role of this hash is to mark the row as
+// "templated" with a deterministic value — drift is corrected at startup.
 // ---------------------------------------------------------------------------
 
 interface WorkflowFingerprint {

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -477,6 +477,23 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	//     `post_approval_session_id`, `post_approval_started_at`,
 	//     `post_approval_blocked_reason`.
 	runMigration103(db);
+
+	// Migration 104: PR 5/5 of the task-agent-as-post-approval-executor refactor.
+	//   Final cleanup — drops the completion-action schema fields. By this stage
+	//   PR 4/5 has already removed every runtime path that produced these
+	//   values, so the migration is mostly defensive.
+	//   Step 5: rewrite any live tasks paused at `pending_checkpoint_type =
+	//     'completion_action'` to `'task_completion'` and clear
+	//     `pending_action_index`.
+	//   Step 6: drop `space_tasks.pending_action_index` column.
+	//   Step 7: tighten the `pending_checkpoint_type` CHECK constraint from
+	//     `('completion_action', 'gate', 'task_completion')` to
+	//     `('gate', 'task_completion')`.
+	//   Step 8: drop `space_workflow_runs.completion_actions_fired_at`.
+	//   Step 9 (deferred per plan §4.4): `space_task_report_results` stays —
+	//     dropping it is gated on a writer audit and shipped in a later
+	//     cleanup migration.
+	runMigration104(db);
 }
 
 /**
@@ -7095,5 +7112,206 @@ export function runMigration103(db: BunDatabase): void {
 		!tableHasColumn(db, 'space_workflows', 'post_approval')
 	) {
 		db.exec(`ALTER TABLE space_workflows ADD COLUMN post_approval TEXT DEFAULT NULL`);
+	}
+}
+
+/**
+ * Migration 104 — PR 5/5 of the task-agent-as-post-approval-executor refactor.
+ *
+ * Drops the completion-action schema fields. PR 4/5 already removed every
+ * runtime path that wrote `pending_checkpoint_type='completion_action'`, but
+ * we defensively rewrite any leftover rows to `'task_completion'` before
+ * tightening the CHECK constraint. We then drop two now-unused columns:
+ *   - `space_tasks.pending_action_index`
+ *   - `space_workflow_runs.completion_actions_fired_at`
+ *
+ * The optional drop of the legacy `space_task_report_results` table (plan
+ * §4.4 step 9) is intentionally deferred to a later migration — that step is
+ * gated on auditing whether any writer paths still reach the table. Splitting
+ * the audit out of this migration keeps M104 small and easy to roll forward.
+ *
+ * SQLite cannot drop columns or alter CHECK constraints in place, so the
+ * migration uses the table-rebuild pattern (mirrors M99/M103). It is
+ * idempotent: re-running it on a DB that has already been migrated is a no-op
+ * because the rebuild detection checks the live CHECK clause.
+ */
+export function runMigration104(db: BunDatabase): void {
+	// ─────────────────────────────────────────────────────────────────────────
+	// Step 5: rewrite any live tasks paused at 'completion_action' to
+	// 'task_completion'. Clear `pending_action_index` because the field is
+	// about to be dropped and would otherwise survive in the rebuilt table.
+	// ─────────────────────────────────────────────────────────────────────────
+	if (tableExists(db, 'space_tasks')) {
+		const hasCheckpointType = tableHasColumn(db, 'space_tasks', 'pending_checkpoint_type');
+		const hasActionIndex = tableHasColumn(db, 'space_tasks', 'pending_action_index');
+		if (hasCheckpointType && hasActionIndex) {
+			db.prepare(
+				`UPDATE space_tasks
+				    SET pending_checkpoint_type = 'task_completion',
+				        pending_action_index = NULL
+				  WHERE pending_checkpoint_type = 'completion_action'`
+			).run();
+		} else if (hasCheckpointType) {
+			db.prepare(
+				`UPDATE space_tasks
+				    SET pending_checkpoint_type = 'task_completion'
+				  WHERE pending_checkpoint_type = 'completion_action'`
+			).run();
+		}
+	}
+
+	// ─────────────────────────────────────────────────────────────────────────
+	// Steps 6 + 7: rebuild `space_tasks` to drop `pending_action_index` and
+	// tighten the `pending_checkpoint_type` CHECK constraint.
+	// ─────────────────────────────────────────────────────────────────────────
+	if (tableExists(db, 'space_tasks')) {
+		const master = db
+			.prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='space_tasks'`)
+			.get() as { sql?: string } | undefined;
+		const currentSql = master?.sql ?? '';
+
+		const hasLegacyCheckpointCheck =
+			currentSql.includes("pending_checkpoint_type IN ('completion_action'") ||
+			/pending_checkpoint_type\s+IN\s*\([^)]*'completion_action'/.test(currentSql);
+		const hasActionIndexCol = tableHasColumn(db, 'space_tasks', 'pending_action_index');
+		const needsRebuild = !!currentSql && (hasLegacyCheckpointCheck || hasActionIndexCol);
+
+		if (needsRebuild) {
+			// Copy every column the new schema expects, intersected with what the
+			// current row actually has — same defensive approach as M103.
+			const baseColumns = [
+				'id',
+				'space_id',
+				'task_number',
+				'title',
+				'description',
+				'status',
+				'priority',
+				'labels',
+				'workflow_run_id',
+				'preferred_workflow_id',
+				'created_by_task_id',
+				'result',
+				'depends_on',
+				'active_session',
+				'task_agent_session_id',
+				'approval_source',
+				'approval_reason',
+				'approved_at',
+				'block_reason',
+				'archived_at',
+				'created_at',
+				'started_at',
+				'completed_at',
+				'updated_at',
+				'pending_checkpoint_type',
+				'reported_status',
+				'reported_summary',
+				'pending_completion_submitted_by_node_id',
+				'pending_completion_submitted_at',
+				'pending_completion_reason',
+				'post_approval_session_id',
+				'post_approval_started_at',
+				'post_approval_blocked_reason',
+			];
+			const existingColumns = new Set(
+				(db.prepare(`PRAGMA table_info('space_tasks')`).all() as Array<{ name: string }>).map(
+					(r) => r.name
+				)
+			);
+			const copyColumns = baseColumns.filter((c) => existingColumns.has(c));
+			const copyColsSql = copyColumns.join(', ');
+
+			// Preserve indexes — same approach as M103.
+			const existingIndexDdl = (
+				db
+					.prepare(
+						`SELECT sql FROM sqlite_master
+						 WHERE type='index' AND tbl_name='space_tasks' AND sql IS NOT NULL`
+					)
+					.all() as Array<{ sql: string }>
+			)
+				.map((r) => r.sql)
+				.filter((sql) => !!sql);
+
+			db.exec('PRAGMA foreign_keys = OFF');
+			db.exec('BEGIN');
+			try {
+				db.exec(`
+					CREATE TABLE space_tasks_m104_new (
+						id TEXT PRIMARY KEY,
+						space_id TEXT NOT NULL,
+						task_number INTEGER NOT NULL,
+						title TEXT NOT NULL,
+						description TEXT NOT NULL DEFAULT '',
+						status TEXT NOT NULL DEFAULT 'open'
+							CHECK(status IN ('open', 'in_progress', 'review', 'approved', 'done', 'blocked', 'cancelled', 'archived')),
+						priority TEXT NOT NULL DEFAULT 'normal'
+							CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+						labels TEXT NOT NULL DEFAULT '[]',
+						workflow_run_id TEXT,
+						preferred_workflow_id TEXT,
+						created_by_task_id TEXT,
+						result TEXT,
+						depends_on TEXT NOT NULL DEFAULT '[]',
+						active_session TEXT
+							CHECK(active_session IN ('worker', 'leader')),
+						task_agent_session_id TEXT,
+						approval_source TEXT,
+						approval_reason TEXT,
+						approved_at INTEGER,
+						block_reason TEXT,
+						archived_at INTEGER,
+						created_at INTEGER NOT NULL,
+						started_at INTEGER,
+						completed_at INTEGER,
+						updated_at INTEGER NOT NULL,
+						pending_checkpoint_type TEXT DEFAULT NULL
+							CHECK(pending_checkpoint_type IN ('gate', 'task_completion')),
+						reported_status TEXT DEFAULT NULL
+							CHECK(reported_status IS NULL OR reported_status IN ('done', 'blocked', 'cancelled')),
+						reported_summary TEXT DEFAULT NULL,
+						pending_completion_submitted_by_node_id TEXT DEFAULT NULL,
+						pending_completion_submitted_at INTEGER DEFAULT NULL,
+						pending_completion_reason TEXT DEFAULT NULL,
+						post_approval_session_id TEXT DEFAULT NULL,
+						post_approval_started_at INTEGER DEFAULT NULL,
+						post_approval_blocked_reason TEXT DEFAULT NULL,
+						FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+						FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL
+					)
+				`);
+				db.exec(
+					`INSERT INTO space_tasks_m104_new (${copyColsSql}) SELECT ${copyColsSql} FROM space_tasks`
+				);
+				db.exec(`DROP TABLE space_tasks`);
+				db.exec(`ALTER TABLE space_tasks_m104_new RENAME TO space_tasks`);
+				for (const ddl of existingIndexDdl) {
+					const normalized = ddl.replace(
+						/^CREATE (UNIQUE )?INDEX /i,
+						(_m, unique) => `CREATE ${unique ?? ''}INDEX IF NOT EXISTS `
+					);
+					db.exec(normalized);
+				}
+				db.exec('COMMIT');
+			} catch (err) {
+				db.exec('ROLLBACK');
+				throw err;
+			} finally {
+				db.exec('PRAGMA foreign_keys = ON');
+			}
+		}
+	}
+
+	// ─────────────────────────────────────────────────────────────────────────
+	// Step 8: drop `completion_actions_fired_at` from `space_workflow_runs`.
+	// SQLite has supported `ALTER TABLE … DROP COLUMN` since 3.35; Bun ships a
+	// new-enough SQLite. Guarded so re-runs are no-ops.
+	// ─────────────────────────────────────────────────────────────────────────
+	if (
+		tableExists(db, 'space_workflow_runs') &&
+		tableHasColumn(db, 'space_workflow_runs', 'completion_actions_fired_at')
+	) {
+		db.exec(`ALTER TABLE space_workflow_runs DROP COLUMN completion_actions_fired_at`);
 	}
 }

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-104_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-104_test.ts
@@ -1,0 +1,443 @@
+/**
+ * Migration 104 Tests — PR 5/5 of the task-agent-as-post-approval-executor refactor.
+ *
+ * Migration 104 finishes burying the completion-action pipeline:
+ *   1. Defensively rewrites any live `space_tasks` row paused at
+ *      `pending_checkpoint_type='completion_action'` to `'task_completion'`,
+ *      and clears `pending_action_index` so the dropped column does not
+ *      survive in the rebuilt table.
+ *   2. Rebuilds `space_tasks` to drop `pending_action_index` and tighten
+ *      `pending_checkpoint_type IN ('gate', 'task_completion')` (the legacy
+ *      `'completion_action'` value is no longer accepted).
+ *   3. Drops `space_workflow_runs.completion_actions_fired_at` via
+ *      `ALTER TABLE … DROP COLUMN`.
+ *
+ * See `docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md`
+ * §4.4 (steps 5–8) for the schema contract.
+ *
+ * Covers:
+ *   - Fresh, fully-migrated DB — the dropped columns are gone, the CHECK
+ *     constraint rejects `'completion_action'`, and the kept `'gate'` /
+ *     `'task_completion'` values still round-trip.
+ *   - Pre-M104 schema with stuck rows — `'completion_action'` is rewritten to
+ *     `'task_completion'`, `pending_action_index` is cleared, and other rows
+ *     pass through untouched.
+ *   - Pre-existing indexes on `space_tasks` survive the rebuild.
+ *   - `space_workflow_runs.completion_actions_fired_at` is dropped after the
+ *     migration runs.
+ *   - Re-running the migration is a no-op (idempotent).
+ *   - Empty DB / partial-table cases are guarded.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigration104, runMigrations } from '../../../../../src/storage/schema/migrations.ts';
+
+function columnNames(db: BunDatabase, table: string): string[] {
+	const rows = db.prepare(`PRAGMA table_info('${table}')`).all() as Array<{ name: string }>;
+	return rows.map((r) => r.name);
+}
+
+function indexNames(db: BunDatabase, table: string): string[] {
+	const rows = db
+		.prepare(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name=? AND sql IS NOT NULL`)
+		.all(table) as Array<{ name: string }>;
+	return rows.map((r) => r.name);
+}
+
+function tableSql(db: BunDatabase, table: string): string {
+	const row = db
+		.prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name=?`)
+		.get(table) as { sql?: string } | undefined;
+	return row?.sql ?? '';
+}
+
+/**
+ * Builds the post-M103 / pre-M104 shape of `space_tasks`, `space_workflow_runs`,
+ * and the supporting tables. This mirrors what a DB that has run every
+ * migration up to and including M103 would look like — i.e. the
+ * `'completion_action'` checkpoint value is still legal, `pending_action_index`
+ * still exists, and `space_workflow_runs.completion_actions_fired_at` still
+ * exists.
+ */
+function seedPreM104Schema(db: BunDatabase): void {
+	db.exec('PRAGMA foreign_keys = OFF');
+	db.exec(`
+		CREATE TABLE spaces (
+			id TEXT PRIMARY KEY,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		)
+	`);
+	db.exec(`
+		CREATE TABLE space_workflow_runs (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			completion_actions_fired_at INTEGER DEFAULT NULL
+		)
+	`);
+	db.exec(`
+		CREATE TABLE space_tasks (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			task_number INTEGER NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'open'
+				CHECK(status IN ('open', 'in_progress', 'review', 'approved', 'done', 'blocked', 'cancelled', 'archived')),
+			priority TEXT NOT NULL DEFAULT 'normal'
+				CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+			labels TEXT NOT NULL DEFAULT '[]',
+			workflow_run_id TEXT,
+			preferred_workflow_id TEXT,
+			created_by_task_id TEXT,
+			result TEXT,
+			depends_on TEXT NOT NULL DEFAULT '[]',
+			active_session TEXT
+				CHECK(active_session IN ('worker', 'leader')),
+			task_agent_session_id TEXT,
+			approval_source TEXT,
+			approval_reason TEXT,
+			approved_at INTEGER,
+			block_reason TEXT,
+			archived_at INTEGER,
+			created_at INTEGER NOT NULL,
+			started_at INTEGER,
+			completed_at INTEGER,
+			updated_at INTEGER NOT NULL,
+			pending_action_index INTEGER DEFAULT NULL,
+			pending_checkpoint_type TEXT DEFAULT NULL
+				CHECK(pending_checkpoint_type IN ('completion_action', 'gate', 'task_completion')),
+			reported_status TEXT DEFAULT NULL
+				CHECK(reported_status IS NULL OR reported_status IN ('done', 'blocked', 'cancelled')),
+			reported_summary TEXT DEFAULT NULL,
+			pending_completion_submitted_by_node_id TEXT DEFAULT NULL,
+			pending_completion_submitted_at INTEGER DEFAULT NULL,
+			pending_completion_reason TEXT DEFAULT NULL,
+			post_approval_session_id TEXT DEFAULT NULL,
+			post_approval_started_at INTEGER DEFAULT NULL,
+			post_approval_blocked_reason TEXT DEFAULT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+			FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL
+		)
+	`);
+	db.exec(
+		`CREATE UNIQUE INDEX idx_space_tasks_space_task_number ON space_tasks(space_id, task_number)`
+	);
+	db.exec(`CREATE INDEX idx_space_tasks_space_id ON space_tasks(space_id)`);
+	db.exec('PRAGMA foreign_keys = ON');
+}
+
+describe('Migration 104: drop completionActions schema (PR 5/5)', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(
+			process.cwd(),
+			'tmp',
+			'test-migration-104',
+			`test-${Date.now()}-${Math.random()}`
+		);
+		mkdirSync(testDir, { recursive: true });
+		db = new BunDatabase(join(testDir, 'test.db'));
+		db.exec('PRAGMA foreign_keys = ON');
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	describe('fresh DB (all migrations applied)', () => {
+		beforeEach(() => {
+			runMigrations(db, () => {});
+			const now = Date.now();
+			db.prepare(
+				`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?)`
+			).run('sp-1', 'sp-1', '/ws/1', 'Space 1', now, now);
+		});
+
+		test('space_tasks no longer has pending_action_index', () => {
+			expect(columnNames(db, 'space_tasks')).not.toContain('pending_action_index');
+		});
+
+		test('space_workflow_runs no longer has completion_actions_fired_at', () => {
+			expect(columnNames(db, 'space_workflow_runs')).not.toContain('completion_actions_fired_at');
+		});
+
+		test('pending_checkpoint_type CHECK rejects "completion_action"', () => {
+			const now = Date.now();
+			db.prepare(
+				`INSERT INTO space_tasks (
+					id, space_id, task_number, title, description, status, priority,
+					labels, depends_on, created_at, updated_at
+				) VALUES (?, ?, ?, ?, '', 'open', 'normal', '[]', '[]', ?, ?)`
+			).run('t-base', 'sp-1', 1, 'Base', now, now);
+			expect(() => {
+				db.prepare(
+					`UPDATE space_tasks SET pending_checkpoint_type = 'completion_action' WHERE id = ?`
+				).run('t-base');
+			}).toThrow();
+		});
+
+		test('pending_checkpoint_type CHECK still accepts "gate" and "task_completion"', () => {
+			const now = Date.now();
+			db.prepare(
+				`INSERT INTO space_tasks (
+					id, space_id, task_number, title, description, status, priority,
+					labels, depends_on, created_at, updated_at, pending_checkpoint_type
+				) VALUES (?, ?, ?, ?, '', 'open', 'normal', '[]', '[]', ?, ?, 'gate')`
+			).run('t-gate', 'sp-1', 2, 'Gate', now, now);
+
+			db.prepare(
+				`INSERT INTO space_tasks (
+					id, space_id, task_number, title, description, status, priority,
+					labels, depends_on, created_at, updated_at, pending_checkpoint_type
+				) VALUES (?, ?, ?, ?, '', 'open', 'normal', '[]', '[]', ?, ?, 'task_completion')`
+			).run('t-tc', 'sp-1', 3, 'Task Completion', now, now);
+
+			const rows = db
+				.prepare(
+					`SELECT id, pending_checkpoint_type FROM space_tasks WHERE id IN ('t-gate', 't-tc') ORDER BY id`
+				)
+				.all() as Array<{ id: string; pending_checkpoint_type: string }>;
+			expect(rows).toEqual([
+				{ id: 't-gate', pending_checkpoint_type: 'gate' },
+				{ id: 't-tc', pending_checkpoint_type: 'task_completion' },
+			]);
+		});
+
+		test('table SQL no longer mentions "completion_action" or "pending_action_index"', () => {
+			const sql = tableSql(db, 'space_tasks');
+			expect(sql).not.toContain('completion_action');
+			expect(sql).not.toContain('pending_action_index');
+		});
+	});
+
+	describe('table rebuild — pre-M104 DB with stuck rows', () => {
+		beforeEach(() => {
+			seedPreM104Schema(db);
+			const now = Date.now();
+			db.prepare(`INSERT INTO spaces (id, created_at, updated_at) VALUES (?, ?, ?)`).run(
+				'sp-1',
+				now,
+				now
+			);
+			db.prepare(
+				`INSERT INTO space_workflow_runs (id, space_id, created_at, updated_at, completion_actions_fired_at)
+				 VALUES (?, ?, ?, ?, ?)`
+			).run('run-1', 'sp-1', now, now, now);
+			// Stuck row paused at the legacy 'completion_action' checkpoint with a
+			// non-null pending_action_index — what M104 must rewrite.
+			db.prepare(
+				`INSERT INTO space_tasks (
+					id, space_id, task_number, title, description, status, priority,
+					labels, depends_on, created_at, updated_at,
+					pending_checkpoint_type, pending_action_index
+				) VALUES (?, ?, ?, ?, 'desc', 'review', 'normal', '[]', '[]', ?, ?, 'completion_action', 2)`
+			).run('t-stuck', 'sp-1', 1, 'Stuck Task', now, now);
+			// Healthy row with 'task_completion' — must pass through unchanged.
+			db.prepare(
+				`INSERT INTO space_tasks (
+					id, space_id, task_number, title, description, status, priority,
+					labels, depends_on, created_at, updated_at,
+					pending_checkpoint_type, pending_action_index
+				) VALUES (?, ?, ?, ?, 'desc', 'review', 'normal', '[]', '[]', ?, ?, 'task_completion', NULL)`
+			).run('t-healthy', 'sp-1', 2, 'Healthy Task', now, now);
+			// Gate-paused row — must pass through unchanged.
+			db.prepare(
+				`INSERT INTO space_tasks (
+					id, space_id, task_number, title, description, status, priority,
+					labels, depends_on, created_at, updated_at,
+					pending_checkpoint_type, pending_action_index
+				) VALUES (?, ?, ?, ?, 'desc', 'review', 'normal', '[]', '[]', ?, ?, 'gate', NULL)`
+			).run('t-gate', 'sp-1', 3, 'Gate Task', now, now);
+			// Plain row with no checkpoint — must pass through unchanged.
+			db.prepare(
+				`INSERT INTO space_tasks (
+					id, space_id, task_number, title, description, status, priority,
+					labels, depends_on, created_at, updated_at
+				) VALUES (?, ?, ?, ?, 'desc', 'open', 'normal', '[]', '[]', ?, ?)`
+			).run('t-plain', 'sp-1', 4, 'Plain Task', now, now);
+		});
+
+		test('rewrites stuck completion_action rows to task_completion + clears pending_action_index', () => {
+			runMigration104(db);
+			const stuck = db
+				.prepare(`SELECT pending_checkpoint_type FROM space_tasks WHERE id = ?`)
+				.get('t-stuck') as { pending_checkpoint_type: string };
+			expect(stuck.pending_checkpoint_type).toBe('task_completion');
+			// pending_action_index is dropped entirely after rebuild — verify both
+			// the column is gone and the row exists.
+			expect(columnNames(db, 'space_tasks')).not.toContain('pending_action_index');
+			const stuckExists = db.prepare(`SELECT id FROM space_tasks WHERE id = ?`).get('t-stuck') as
+				| { id: string }
+				| undefined;
+			expect(stuckExists?.id).toBe('t-stuck');
+		});
+
+		test('preserves non-completion_action rows verbatim', () => {
+			const before = db
+				.prepare(
+					`SELECT id, status, pending_checkpoint_type
+					   FROM space_tasks
+					  WHERE id IN ('t-healthy', 't-gate', 't-plain')
+					  ORDER BY id`
+				)
+				.all();
+
+			runMigration104(db);
+
+			const after = db
+				.prepare(
+					`SELECT id, status, pending_checkpoint_type
+					   FROM space_tasks
+					  WHERE id IN ('t-healthy', 't-gate', 't-plain')
+					  ORDER BY id`
+				)
+				.all();
+			expect(after).toEqual(before);
+		});
+
+		test('drops pending_action_index column from space_tasks', () => {
+			expect(columnNames(db, 'space_tasks')).toContain('pending_action_index');
+			runMigration104(db);
+			expect(columnNames(db, 'space_tasks')).not.toContain('pending_action_index');
+		});
+
+		test('tightens pending_checkpoint_type CHECK to ("gate", "task_completion")', () => {
+			runMigration104(db);
+			const sql = tableSql(db, 'space_tasks');
+			expect(sql).toMatch(
+				/pending_checkpoint_type\s+IN\s*\(\s*'gate'\s*,\s*'task_completion'\s*\)/
+			);
+			expect(sql).not.toContain("'completion_action'");
+		});
+
+		test('rejects new INSERTs with pending_checkpoint_type="completion_action" after rebuild', () => {
+			runMigration104(db);
+			const now = Date.now();
+			expect(() => {
+				db.prepare(
+					`INSERT INTO space_tasks (
+						id, space_id, task_number, title, description, status, priority,
+						labels, depends_on, created_at, updated_at, pending_checkpoint_type
+					) VALUES (?, ?, ?, ?, '', 'open', 'normal', '[]', '[]', ?, ?, 'completion_action')`
+				).run('t-bad', 'sp-1', 99, 'Bad', now, now);
+			}).toThrow();
+		});
+
+		test('drops completion_actions_fired_at from space_workflow_runs', () => {
+			expect(columnNames(db, 'space_workflow_runs')).toContain('completion_actions_fired_at');
+			runMigration104(db);
+			expect(columnNames(db, 'space_workflow_runs')).not.toContain('completion_actions_fired_at');
+			// Pre-existing rows should still be there — the column drop should not
+			// destroy data.
+			const run = db.prepare(`SELECT id FROM space_workflow_runs WHERE id = ?`).get('run-1') as
+				| { id: string }
+				| undefined;
+			expect(run?.id).toBe('run-1');
+		});
+
+		test('preserves pre-existing indexes across the rebuild', () => {
+			const before = new Set(indexNames(db, 'space_tasks'));
+			expect(before).toContain('idx_space_tasks_space_task_number');
+			expect(before).toContain('idx_space_tasks_space_id');
+
+			runMigration104(db);
+
+			const after = new Set(indexNames(db, 'space_tasks'));
+			for (const name of before) {
+				expect(after.has(name)).toBe(true);
+			}
+		});
+
+		test('is idempotent — running a second time is a no-op', () => {
+			runMigration104(db);
+			const colsAfter1 = columnNames(db, 'space_tasks').sort();
+			const sqlAfter1 = tableSql(db, 'space_tasks');
+			const countAfter1 = (
+				db.prepare(`SELECT COUNT(*) AS n FROM space_tasks`).get() as { n: number }
+			).n;
+
+			expect(() => runMigration104(db)).not.toThrow();
+
+			const colsAfter2 = columnNames(db, 'space_tasks').sort();
+			const sqlAfter2 = tableSql(db, 'space_tasks');
+			const countAfter2 = (
+				db.prepare(`SELECT COUNT(*) AS n FROM space_tasks`).get() as { n: number }
+			).n;
+
+			expect(colsAfter2).toEqual(colsAfter1);
+			expect(sqlAfter2).toEqual(sqlAfter1);
+			expect(countAfter2).toBe(countAfter1);
+		});
+	});
+
+	describe('missing tables — no-op guards', () => {
+		test('runMigration104 on an empty DB does not throw', () => {
+			expect(() => runMigration104(db)).not.toThrow();
+		});
+
+		test('runMigration104 skips space_workflow_runs changes when only space_tasks exists', () => {
+			db.exec(`
+				CREATE TABLE space_tasks (
+					id TEXT PRIMARY KEY,
+					space_id TEXT NOT NULL,
+					task_number INTEGER NOT NULL,
+					title TEXT NOT NULL,
+					description TEXT NOT NULL DEFAULT '',
+					status TEXT NOT NULL DEFAULT 'open'
+						CHECK(status IN ('open', 'in_progress', 'review', 'approved', 'done', 'blocked', 'cancelled', 'archived')),
+					priority TEXT NOT NULL DEFAULT 'normal'
+						CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+					labels TEXT NOT NULL DEFAULT '[]',
+					depends_on TEXT NOT NULL DEFAULT '[]',
+					created_at INTEGER NOT NULL,
+					updated_at INTEGER NOT NULL,
+					pending_action_index INTEGER DEFAULT NULL,
+					pending_checkpoint_type TEXT DEFAULT NULL
+						CHECK(pending_checkpoint_type IN ('completion_action', 'gate', 'task_completion'))
+				)
+			`);
+			expect(() => runMigration104(db)).not.toThrow();
+			expect(columnNames(db, 'space_tasks')).not.toContain('pending_action_index');
+			const runsExists = db
+				.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='space_workflow_runs'`)
+				.get();
+			expect(runsExists).toBeNull();
+		});
+
+		test('runMigration104 skips space_tasks rebuild when only space_workflow_runs exists', () => {
+			db.exec(`
+				CREATE TABLE space_workflow_runs (
+					id TEXT PRIMARY KEY,
+					space_id TEXT NOT NULL,
+					created_at INTEGER NOT NULL,
+					updated_at INTEGER NOT NULL,
+					completion_actions_fired_at INTEGER DEFAULT NULL
+				)
+			`);
+			expect(() => runMigration104(db)).not.toThrow();
+			expect(columnNames(db, 'space_workflow_runs')).not.toContain('completion_actions_fired_at');
+			const tasksExists = db
+				.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='space_tasks'`)
+				.get();
+			expect(tasksExists).toBeNull();
+		});
+	});
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-94_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-94_test.ts
@@ -1,30 +1,31 @@
 /**
- * Migration 94 Tests — Backfill workflow template tracking & end-node
- * completion actions.
+ * Migration 94 Tests — Backfill workflow template tracking & deduplicate seeds.
  *
  * Migration 94 realigns legacy `space_workflows` rows with the current built-in
  * templates by:
  *   - Setting `template_name` + `template_hash` on rows whose node names
  *     structurally match a known template.
- *   - Re-injecting `MERGE_PR_COMPLETION_ACTION` on end nodes that lost it (seed
- *     bug A).
  *   - Deleting orphan duplicate rows that have no active `space_workflow_runs`
  *     references.
  *
+ * Note: an earlier revision of M94 also re-injected end-node `completionActions`
+ * JSON on rows where it was missing. That pipeline was deleted in PR 4/5 of the
+ * task-agent-as-post-approval-executor refactor and the underlying columns are
+ * dropped in M104 (PR 5/5), so the backfill is no longer performed. These tests
+ * therefore only assert template tracking + dedup behaviour.
+ *
  * Covers:
- *   - Legacy Coding Workflow backfill (template_name + canonical template_hash
- *     + merge-pr injected on Review end node)
+ *   - Legacy Coding Workflow backfill (template_name + canonical template_hash)
  *   - Legacy Research Workflow backfill (similar)
- *   - Review-Only workflow backfills template_name but does NOT inject
- *     completionActions (that template has no end-node actions)
+ *   - Review-Only workflow backfills template_name + hash
  *   - Hash self-verification: the hashes my inlined fingerprints produce for
- *     each of the 5 built-in templates must match the canonical
- *     `computeWorkflowHash()` output. This guards against fingerprint drift.
+ *     each of the 5 built-in templates must structurally line up with the
+ *     canonical `computeWorkflowHash()` output. This guards against fingerprint
+ *     drift.
  *   - Idempotency: running twice yields the same result
  *   - Custom workflows (non-template name) are untouched
  *   - Orphan duplicate deletion: older row deleted when no active runs
  *   - Orphan duplicate retention: older row kept when active runs reference it
- *   - Existing completionActions on end node preserved (no duplicate injection)
  *   - Rows with non-matching node structure are not treated as templates
  */
 
@@ -144,8 +145,6 @@ function seedLegacyCodingWorkflow(
 		createdAt?: number;
 		/** Default false — null template_name simulates pre-M90 legacy rows. */
 		withTemplateFields?: boolean;
-		/** Default false — when true, end node has completionActions already. */
-		withCompletionActions?: boolean;
 	}
 ): { workflowId: string; codingNodeId: string; reviewNodeId: string } {
 	const template = getBuiltInWorkflows().find((t) => t.name === 'Coding Workflow');
@@ -175,27 +174,17 @@ function seedLegacyCodingWorkflow(
 		config: { agents: [{ agentId: 'a-coder', name: 'coder' }] },
 	});
 
-	const reviewConfig: Record<string, unknown> = {
-		agents: [{ agentId: 'a-reviewer', name: 'reviewer' }],
-	};
-	if (opts.withCompletionActions) {
-		reviewConfig.completionActions = [
-			{
-				id: 'merge-pr',
-				name: 'Merge PR',
-				type: 'script',
-				requiredLevel: 4,
-				artifactType: 'pr',
-				script: '# existing script',
-			},
-		];
-	}
-	insertNode(db, { id: reviewNodeId, workflowId: opts.id, name: 'Review', config: reviewConfig });
+	insertNode(db, {
+		id: reviewNodeId,
+		workflowId: opts.id,
+		name: 'Review',
+		config: { agents: [{ agentId: 'a-reviewer', name: 'reviewer' }] },
+	});
 
 	return { workflowId: opts.id, codingNodeId, reviewNodeId };
 }
 
-describe('Migration 94: backfill workflow template tracking & completion actions', () => {
+describe('Migration 94: backfill workflow template tracking & dedup orphan duplicates', () => {
 	let testDir: string;
 	let db: BunDatabase;
 
@@ -229,7 +218,7 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 	test('hash self-verification: migration stores narrow hash that diverges from expanded computeWorkflowHash', () => {
 		// Migration 94 uses a frozen narrow fingerprint (description + instructions +
 		// nodeNames + channels + gates only). The live computeWorkflowHash was later
-		// expanded to also include customPrompt per agent, completionActions, and
+		// expanded to also include customPrompt per agent and
 		// completionAutonomyLevel. As a result, the migration's stored hash
 		// intentionally diverges from the current computeWorkflowHash — this is
 		// what causes drift detection to fire for existing spaces on next daemon
@@ -306,11 +295,11 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 		expect(row.template_hash).toBeTruthy();
 	});
 
-	test('legacy Coding Workflow: sets template_name + narrow hash + injects merge-pr', () => {
+	test('legacy Coding Workflow: sets template_name + narrow hash', () => {
 		// Migration 94 stores a narrow hash (pre-expansion). After the fingerprint
-		// was expanded to include customPrompt/completionActions/completionAutonomyLevel,
+		// was expanded to include customPrompt/completionAutonomyLevel,
 		// the stored hash diverges from computeWorkflowHash — enabling drift detection.
-		const { workflowId, reviewNodeId } = seedLegacyCodingWorkflow(db, {
+		const { workflowId } = seedLegacyCodingWorkflow(db, {
 			id: 'wf-1',
 			spaceId: 'sp-1',
 		});
@@ -325,18 +314,9 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 		expect(row.template_hash).not.toBe(
 			computeWorkflowHash(getBuiltInWorkflows().find((t) => t.name === 'Coding Workflow')!)
 		);
-
-		const cfg = readNodeConfig(db, reviewNodeId) as {
-			completionActions?: Array<{ id: string; type: string; artifactType?: string }>;
-		};
-		expect(cfg.completionActions).toBeDefined();
-		expect(cfg.completionActions).toHaveLength(1);
-		expect(cfg.completionActions?.[0]?.id).toBe('merge-pr');
-		expect(cfg.completionActions?.[0]?.type).toBe('script');
-		expect(cfg.completionActions?.[0]?.artifactType).toBe('pr');
 	});
 
-	test('legacy Research Workflow: sets template_name + narrow hash + injects merge-pr', () => {
+	test('legacy Research Workflow: sets template_name + narrow hash', () => {
 		// Migration 94 stores a narrow hash (pre-expansion). After the fingerprint
 		// was expanded, the stored hash diverges from computeWorkflowHash — enabling drift detection.
 		const template = getBuiltInWorkflows().find((t) => t.name === 'Research Workflow')!;
@@ -365,14 +345,9 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 		expect(row.template_hash).toMatch(/^[0-9a-f]{64}$/);
 		// The narrow hash differs from the current expanded hash — drift will be detected
 		expect(row.template_hash).not.toBe(computeWorkflowHash(template));
-
-		const cfg = readNodeConfig(db, reviewNodeId) as {
-			completionActions?: Array<{ id: string }>;
-		};
-		expect(cfg.completionActions?.some((a) => a.id === 'merge-pr')).toBe(true);
 	});
 
-	test('Review-Only Workflow: sets template_name + narrow hash, does not inject completionActions', () => {
+	test('Review-Only Workflow: sets template_name + narrow hash', () => {
 		// Migration 94 stores a narrow hash (pre-expansion). After the fingerprint
 		// was expanded, the stored hash diverges from computeWorkflowHash — enabling drift detection.
 		const template = getBuiltInWorkflows().find((t) => t.name === 'Review-Only Workflow')!;
@@ -399,10 +374,6 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 		expect(row.template_hash).toMatch(/^[0-9a-f]{64}$/);
 		// The narrow hash differs from the current expanded hash — drift will be detected
 		expect(row.template_hash).not.toBe(computeWorkflowHash(template));
-
-		const cfg = readNodeConfig(db, reviewNodeId) as { completionActions?: unknown[] };
-		// Review-Only has no endNodeCompletionActions; migration must not inject.
-		expect(cfg.completionActions).toBeUndefined();
 	});
 
 	test('idempotent — running twice yields the same result', () => {
@@ -421,10 +392,6 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 
 		expect(rowAfter2).toEqual(rowAfter1);
 		expect(cfgAfter2).toEqual(cfgAfter1);
-
-		// And the end-node still has exactly one merge-pr action — no duplication.
-		const actions = (cfgAfter2 as { completionActions?: Array<{ id: string }> }).completionActions!;
-		expect(actions.filter((a) => a.id === 'merge-pr')).toHaveLength(1);
 	});
 
 	test('custom workflow with non-matching name is untouched', () => {
@@ -463,28 +430,6 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 		const row = readWorkflow(db, wfId)!;
 		expect(row.template_name).toBeNull();
 		expect(row.template_hash).toBeNull();
-	});
-
-	test('existing completionActions on end node preserved (no duplicate injection)', () => {
-		const { workflowId, reviewNodeId } = seedLegacyCodingWorkflow(db, {
-			id: 'wf-has-action',
-			spaceId: 'sp-1',
-			withCompletionActions: true, // already has merge-pr
-		});
-
-		runMigration94(db);
-
-		const cfg = readNodeConfig(db, reviewNodeId) as {
-			completionActions?: Array<{ id: string; script?: string }>;
-		};
-		// Must not duplicate — already had a merge-pr with "# existing script".
-		expect(cfg.completionActions).toHaveLength(1);
-		expect(cfg.completionActions?.[0]?.id).toBe('merge-pr');
-		expect(cfg.completionActions?.[0]?.script).toBe('# existing script');
-
-		// template_name + hash still set.
-		const row = readWorkflow(db, workflowId)!;
-		expect(row.template_name).toBe('Coding Workflow');
 	});
 
 	test('orphan duplicate deleted when it has no active runs', () => {
@@ -616,26 +561,21 @@ describe('Migration 94: backfill workflow template tracking & completion actions
 		expect(readWorkflow(db, 'wf-c2')).toBeDefined();
 	});
 
-	test('row already backfilled is left alone (no redundant writes)', () => {
-		const template = getBuiltInWorkflows().find((t) => t.name === 'Coding Workflow')!;
-		const { workflowId, reviewNodeId } = seedLegacyCodingWorkflow(db, {
-			id: 'wf-already-backfilled',
+	test('node config JSON is never rewritten by the migration (template-only backfill)', () => {
+		// PR 5/5 simplified M94: the legacy completionActions injection pass was
+		// removed. The migration must therefore leave node config JSON untouched
+		// — only `template_name` / `template_hash` on `space_workflows` may be
+		// written.
+		const { reviewNodeId } = seedLegacyCodingWorkflow(db, {
+			id: 'wf-config-untouched',
 			spaceId: 'sp-1',
-			withTemplateFields: true,
-			withCompletionActions: true,
 		});
 
-		const beforeRow = readWorkflow(db, workflowId)!;
 		const beforeCfg = readNodeConfig(db, reviewNodeId);
 
 		runMigration94(db);
 
-		const afterRow = readWorkflow(db, workflowId)!;
 		const afterCfg = readNodeConfig(db, reviewNodeId);
-
-		expect(afterRow.template_name).toBe(template.name);
-		expect(afterRow.template_hash).toBe(computeWorkflowHash(template));
 		expect(afterCfg).toEqual(beforeCfg);
-		expect(afterRow).toEqual(beforeRow);
 	});
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-spaces-autonomy-level_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-spaces-autonomy-level_test.ts
@@ -337,9 +337,12 @@ describe('Migration 33: Add autonomy_level to spaces', () => {
 		]);
 	});
 
-	test('migration 86: pending_action_index and pending_checkpoint_type columns exist', () => {
+	test('migration 86: pending_checkpoint_type column exists after full migrate', () => {
 		runMigrations(db, () => {});
-		expect(columnExists(db, 'space_tasks', 'pending_action_index')).toBe(true);
+		// `pending_action_index` was added by M86 but later dropped by M104 (PR
+		// 5/5 of the task-agent-as-post-approval-executor refactor). Only
+		// `pending_checkpoint_type` survives the full pipeline.
+		expect(columnExists(db, 'space_tasks', 'pending_action_index')).toBe(false);
 		expect(columnExists(db, 'space_tasks', 'pending_checkpoint_type')).toBe(true);
 	});
 

--- a/packages/daemon/tests/unit/4-space-storage/storage/space-task-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/space-task-repository.test.ts
@@ -540,4 +540,59 @@ describe('SpaceTaskRepository', () => {
 			expect(Math.max(...numbers)).toBe(20);
 		});
 	});
+
+	describe('listActiveWithTaskAgentSession', () => {
+		/**
+		 * Seed a task at the given status, with an optional task-agent session id.
+		 * Statuses outside the default state-machine are applied directly via UPDATE
+		 * to avoid running the transition validator (the helper here is purely a
+		 * storage-layer fixture).
+		 */
+		function seed(status: string, sessionId: string | null): string {
+			const task = repo.createTask({
+				spaceId,
+				title: `Task ${status}`,
+				description: '',
+				workflowRunId,
+			});
+			(db as any)
+				.prepare(`UPDATE space_tasks SET status = ?, task_agent_session_id = ? WHERE id = ?`)
+				.run(status, sessionId, task.id);
+			return task.id;
+		}
+
+		it("includes 'in_progress', 'blocked', and 'approved' tasks with a non-null session id", () => {
+			const inProgress = seed('in_progress', 'sess-in-progress');
+			const blocked = seed('blocked', 'sess-blocked');
+			const approved = seed('approved', 'sess-approved');
+
+			const active = repo.listActiveWithTaskAgentSession();
+			const ids = new Set(active.map((t) => t.id));
+
+			expect(ids.has(inProgress)).toBe(true);
+			expect(ids.has(blocked)).toBe(true);
+			expect(ids.has(approved)).toBe(true);
+			expect(active.length).toBe(3);
+		});
+
+		it('excludes tasks without a task_agent_session_id', () => {
+			seed('in_progress', null);
+			seed('approved', null);
+			const inProgressWithSession = seed('in_progress', 'sess-1');
+
+			const active = repo.listActiveWithTaskAgentSession();
+			expect(active.map((t) => t.id)).toEqual([inProgressWithSession]);
+		});
+
+		it('excludes terminal and open statuses even when a session id is present', () => {
+			seed('open', 'sess-open');
+			seed('review', 'sess-review');
+			seed('done', 'sess-done');
+			seed('cancelled', 'sess-cancelled');
+			seed('archived', 'sess-archived');
+
+			const active = repo.listActiveWithTaskAgentSession();
+			expect(active).toEqual([]);
+		});
+	});
 });

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -1474,10 +1474,11 @@ describe('createSpaceAgentToolHandlers — list_tasks search/pagination/compact'
 // approve_task — plain review→done / review→approved path
 // ---------------------------------------------------------------------------
 //
-// The `approve_completion_action` MCP tool was deleted in PR 4/5 together with
-// the completion-action runtime pipeline. Residual DB rows that still carry
-// `pendingCheckpointType='completion_action'` are swept into `task_completion`
-// by migration (see PR 5) and do not round-trip through the MCP surface.
+// The completion-action approval MCP tool was deleted in PR 4/5 together with
+// the completion-action runtime pipeline. PR 5/5 (migration M104) further
+// rewrote any residual stuck rows into `task_completion` and tightened the
+// `pendingCheckpointType` CHECK constraint, so the legacy variant no longer
+// round-trips through the MCP surface.
 
 describe('createSpaceAgentToolHandlers — approve_task plain path', () => {
 	let ctx: TestCtx;

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -628,17 +628,6 @@ describe('PLAN_AND_DECOMPOSE_WORKFLOW template', () => {
 		expect(prompt).toContain('downstream coder');
 	});
 
-	test('Task Dispatcher node carries no completionActions (pipeline deleted in PR 4/5)', () => {
-		const dispatcherNode = PLAN_AND_DECOMPOSE_WORKFLOW.nodes.find(
-			(n) => n.name === 'Task Dispatcher'
-		)!;
-		// The completion-action runtime pipeline (including
-		// `verify-tasks-created`) was removed in PR 4/5 — post-approval work is
-		// now handled by `PostApprovalRouter` via the `postApproval` field.
-		// `completionActions` is either undefined or empty.
-		expect(dispatcherNode.completionActions ?? []).toEqual([]);
-	});
-
 	test('workflow description describes stacked PR chain output', () => {
 		// The workflow description must convey that the output is a stacked PR chain
 		expect(PLAN_AND_DECOMPOSE_WORKFLOW.description).toMatch(/stacked PR/i);
@@ -1048,18 +1037,6 @@ describe('seedBuiltInWorkflows()', () => {
 		const names = manager.listWorkflows(SPACE_ID).map((w) => w.name);
 		expect(names).toContain(CODING_WORKFLOW.name);
 		expect(names).toContain(PLAN_AND_DECOMPOSE_WORKFLOW.name);
-	});
-
-	test('PLAN_AND_DECOMPOSE_WORKFLOW seeded Task Dispatcher carries no completionActions', async () => {
-		// Completion actions were deleted in PR 4/5 — the seeded workflow's
-		// nodes must not carry any. Post-approval work runs through
-		// `PostApprovalRouter` on the `approved → done` boundary instead.
-		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
-		const wf = manager
-			.listWorkflows(SPACE_ID)
-			.find((w) => w.name === PLAN_AND_DECOMPOSE_WORKFLOW.name)!;
-		const dispatcherNode = wf.nodes.find((n) => n.name === 'Task Dispatcher')!;
-		expect(dispatcherNode.completionActions ?? []).toEqual([]);
 	});
 
 	test('all seeded workflows have the real spaceId assigned', async () => {

--- a/packages/daemon/tests/unit/5-space/workflow/end-node-handoff.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/end-node-handoff.test.ts
@@ -18,7 +18,7 @@
  *   - Review-Only intentionally does NOT declare `postApproval` (no PR to
  *     merge) and its prompt no longer carries the "runtime verifies" boilerplate.
  *
- *   - Plan & Decompose is unchanged: it closes on its own `completionActions`
+ *   - Plan & Decompose is unchanged: it closes on its own end-node directive
  *     (verify-tasks-created) and has no `postApproval` route.
  *
  * These tests protect against silent regressions where someone edits an end-
@@ -199,8 +199,9 @@ describe('Review-Only end-node prompt loses verification boilerplate', () => {
 		const prompt = endNodePrompt(REVIEW_ONLY_WORKFLOW);
 		// The old trailing "; the runtime verifies at least one review/comment
 		// exists before accepting completion" sentence was removed — the
-		// completionAction (VERIFY_REVIEW_POSTED_COMPLETION_ACTION) still does
-		// that check, but the prompt no longer duplicates the claim.
+		// agent prompt no longer duplicates the claim. PR 4/5 removed the
+		// runtime verification action and PR 5/5 deleted the schema, so the
+		// review check now lives entirely in agent guidance.
 		expect(prompt).not.toContain('runtime verifies');
 		expect(prompt).not.toContain('before accepting completion');
 	});

--- a/packages/daemon/tests/unit/5-space/workflow/end-node-handoff.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/end-node-handoff.test.ts
@@ -1,14 +1,17 @@
 /**
- * End-node handoff prompt tests (PR 3/5)
+ * End-node handoff prompt tests (PR 3/5, updated in PR 5/5)
  *
  * Verifies that every built-in workflow's end-node `customPrompt` agrees with
- * the post-approval routing contract introduced in PR 3/5:
+ * the post-approval routing contract:
  *
  *   - Coding / Research / QA end nodes each signal the Task Agent with
- *     `send_message(task-agent, data:{ pr_url, post_approval_action:"merge_pr" })`
- *     BEFORE calling `approve_task`. These three workflows MUST also declare a
+ *     `send_message(task-agent, data:{ pr_url })` BEFORE calling
+ *     `approve_task`. These three workflows MUST also declare a
  *     `postApproval: { targetAgent: 'reviewer', instructions: <merge template> }`
- *     route so the runtime dispatches the merge.
+ *     route so the runtime dispatches the merge. PR 5/5 removed the legacy
+ *     `post_approval_action: "merge_pr"` discriminator from the data payload —
+ *     post-approval routing is now fully declarative on the workflow's
+ *     `postApproval` field and nothing consumed the runtime discriminator.
  *
  *   - QA no longer embeds `gh pr merge` / worktree-sync instructions — the
  *     reviewer post-approval session runs the merge instead. The QA workflow's
@@ -113,21 +116,29 @@ describe('End-node post-approval declarations', () => {
 
 describe('End-node prompts signal the Task Agent before approve_task', () => {
 	for (const [label, wf] of MERGE_ROUTED_WORKFLOWS) {
-		test(`${label} end-node prompt includes send_message(task-agent, data:{...post_approval_action:"merge_pr"})`, () => {
+		test(`${label} end-node prompt includes send_message(task-agent, data:{ pr_url })`, () => {
 			const prompt = endNodePrompt(wf);
 			// Every merge-routed workflow must instruct its end-node agent to
-			// signal the Task Agent with a structured handoff payload. The
-			// `post_approval_action` key is the convention consumed by the
-			// reviewer post-approval session (see PR_MERGE_POST_APPROVAL_INSTRUCTIONS).
+			// signal the Task Agent with a structured handoff carrying the
+			// PR URL. `dispatchPostApproval` reads `pr_url` from the task's
+			// result artifact when interpolating `{{pr_url}}` into the merge
+			// template.
 			expect(prompt).toContain('send_message');
 			expect(prompt).toContain('target: "task-agent"');
-			expect(prompt).toContain('post_approval_action: "merge_pr"');
 			expect(prompt).toContain('pr_url');
+			// PR 5/5: the legacy `post_approval_action: "merge_pr"`
+			// discriminator was removed — post-approval routing is fully
+			// declarative on `postApproval`. Guard against accidental
+			// reintroduction.
+			expect(prompt).not.toContain('post_approval_action');
 		});
 
 		test(`${label} end-node prompt places the task-agent signal BEFORE the final approve_task call`, () => {
 			const prompt = endNodePrompt(wf);
-			const signalIdx = prompt.indexOf('post_approval_action: "merge_pr"');
+			// Anchor on the `send_message(` call itself — the unique shape of
+			// the handoff. The earlier anchor `post_approval_action: "merge_pr"`
+			// was removed in PR 5/5.
+			const signalIdx = prompt.indexOf('send_message(');
 			// Use lastIndexOf: the first `approve_task()` occurrence in every
 			// prompt lives in the "TOOL CONTRACT" block at the top, which is a
 			// description of the tool — not the operational instruction. The
@@ -217,13 +228,17 @@ describe('Review-Only end-node prompt loses verification boilerplate', () => {
 	});
 });
 
-describe('Plan & Decompose end-node is unchanged by PR 3/5', () => {
-	test('PLAN_AND_DECOMPOSE_WORKFLOW Task Dispatcher prompt does NOT mention post_approval_action', () => {
+describe('Plan & Decompose end-node is unchanged', () => {
+	test('PLAN_AND_DECOMPOSE_WORKFLOW Task Dispatcher prompt does NOT signal the task-agent', () => {
 		const prompt = endNodePrompt(PLAN_AND_DECOMPOSE_WORKFLOW);
 		// Plan & Decompose has no PR to merge; its completion is signalled by
-		// the verify-tasks-created completion action, not by a Task Agent
-		// handoff. The end-node prompt MUST NOT adopt the merge-signalling
-		// convention that is specific to the three PR-producing workflows.
+		// the verify-tasks-created directive, not by a Task Agent handoff. The
+		// end-node prompt MUST NOT adopt the handoff-signalling convention
+		// specific to the three PR-producing workflows.
+		expect(prompt).not.toContain('send_message');
+		// Legacy discriminator is also still absent (PR 5/5 removed it from
+		// the PR-producing workflows; this negative assertion guards against
+		// drift in either direction).
 		expect(prompt).not.toContain('post_approval_action');
 	});
 

--- a/packages/daemon/tests/unit/5-space/workflow/gate-autonomy-status-consistency.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/gate-autonomy-status-consistency.test.ts
@@ -152,17 +152,4 @@ describe('Autonomy level vs review status (SpaceTask concept)', () => {
 		// The run status machine has no 'review' state
 		expect(Object.keys(VALID_TRANSITIONS)).not.toContain(reviewStatus);
 	});
-
-	test('completion action requiredLevel threshold controls review vs immediate execution', () => {
-		// A completion action with requiredLevel=4 requires spaceLevel >= 4 to auto-execute
-		// Otherwise the task pauses at 'review' with pendingCheckpointType='completion_action'
-		const requiredLevel = 4;
-		function wouldAutoExecute(spaceLevel: number): boolean {
-			return spaceLevel >= requiredLevel;
-		}
-		expect(wouldAutoExecute(4)).toBe(true); // at threshold — auto
-		expect(wouldAutoExecute(5)).toBe(true); // above threshold — auto
-		expect(wouldAutoExecute(3)).toBe(false); // below threshold → task goes to review
-		expect(wouldAutoExecute(1)).toBe(false); // supervised → always review
-	});
 });

--- a/packages/daemon/tests/unit/5-space/workflow/template-hash.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/template-hash.test.ts
@@ -152,36 +152,6 @@ describe('buildWorkflowFingerprint', () => {
 		expect(fp.nodePrompts[0]).toBe('Coder|coder|');
 	});
 
-	it('returns sorted completionActions for each node action', () => {
-		const wf = makeWorkflow({
-			nodes: [
-				{
-					id: 'n1',
-					name: 'Coder',
-					agents: [{ agentId: 'a1', name: 'coder' }],
-					completionActions: [
-						{
-							id: 'merge-pr',
-							name: 'Merge PR',
-							type: 'script',
-							requiredLevel: 4,
-							script: 'gh pr merge',
-						},
-					],
-				},
-			],
-		});
-		const fp = buildWorkflowFingerprint(wf);
-		expect(fp.completionActions).toHaveLength(1);
-		expect(fp.completionActions[0]).toBe('Coder|merge-pr|script|4|gh pr merge');
-	});
-
-	it('returns empty completionActions when no node has completion actions', () => {
-		const wf = makeWorkflow();
-		const fp = buildWorkflowFingerprint(wf);
-		expect(fp.completionActions).toEqual([]);
-	});
-
 	it('includes completionAutonomyLevel in fingerprint', () => {
 		const wf = makeWorkflow({ completionAutonomyLevel: 5 });
 		const fp = buildWorkflowFingerprint(wf);
@@ -429,72 +399,6 @@ describe('computeWorkflowHash', () => {
 					id: 'n1',
 					name: 'Coder',
 					agents: [{ agentId: 'a1', name: 'coder', customPrompt: { value: 'New prompt' } }],
-				},
-			],
-		});
-		expect(computeWorkflowHash(wf1)).not.toBe(computeWorkflowHash(wf2));
-	});
-
-	it('DOES change when a node completionAction is added', () => {
-		const wf1 = makeWorkflow({
-			nodes: [{ id: 'n1', name: 'Coder', agents: [{ agentId: 'a1', name: 'coder' }] }],
-		});
-		const wf2 = makeWorkflow({
-			nodes: [
-				{
-					id: 'n1',
-					name: 'Coder',
-					agents: [{ agentId: 'a1', name: 'coder' }],
-					completionActions: [
-						{
-							id: 'merge-pr',
-							name: 'Merge PR',
-							type: 'script',
-							requiredLevel: 4,
-							script: 'gh pr merge',
-						},
-					],
-				},
-			],
-		});
-		expect(computeWorkflowHash(wf1)).not.toBe(computeWorkflowHash(wf2));
-	});
-
-	it('DOES change when a node completionAction script changes', () => {
-		const base = {
-			id: 'n1',
-			name: 'Coder',
-			agents: [{ agentId: 'a1', name: 'coder' }],
-		};
-		const wf1 = makeWorkflow({
-			nodes: [
-				{
-					...base,
-					completionActions: [
-						{
-							id: 'merge-pr',
-							name: 'Merge PR',
-							type: 'script' as const,
-							requiredLevel: 4 as const,
-							script: 'gh pr merge --squash',
-						},
-					],
-				},
-			],
-		});
-		const wf2 = makeWorkflow({
-			nodes: [
-				{
-					...base,
-					completionActions: [
-						{
-							id: 'merge-pr',
-							name: 'Merge PR',
-							type: 'script' as const,
-							requiredLevel: 4 as const,
-							script: 'gh pr merge --merge',
-						},
-					],
 				},
 			],
 		});

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -212,9 +212,8 @@ export function createSpaceTables(db: BunDatabase): void {
 			approval_source TEXT,
 			approval_reason TEXT,
 			approved_at INTEGER,
-			pending_action_index INTEGER DEFAULT NULL,
 			pending_checkpoint_type TEXT DEFAULT NULL
-				CHECK(pending_checkpoint_type IN ('completion_action', 'gate', 'task_completion')),
+				CHECK(pending_checkpoint_type IN ('gate', 'task_completion')),
 			pending_completion_submitted_by_node_id TEXT DEFAULT NULL,
 			pending_completion_submitted_at INTEGER DEFAULT NULL,
 			pending_completion_reason TEXT DEFAULT NULL,

--- a/packages/e2e/tests/features/post-approval-merge-autonomy-high.e2e.ts
+++ b/packages/e2e/tests/features/post-approval-merge-autonomy-high.e2e.ts
@@ -56,8 +56,7 @@ test.describe
 			// 4. Drive the workflow through its gates by short-circuiting the
 			//    Coder + Reviewer agents via the LLM mock: the Reviewer's
 			//    scripted tool calls must include save_artifact({ prUrl }),
-			//    send_message(task-agent, data:{ pr_url, post_approval_action: 'merge_pr' }),
-			//    approve_task().
+			//    send_message(task-agent, data:{ pr_url }), approve_task().
 			// 5. Assert: task transitions `in_progress → approved`.
 			// 6. Assert: PostApprovalRouter spawns a reviewer session; the mock
 			//    `gh pr merge --squash` runs; the session calls `mark_complete`.

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -282,17 +282,11 @@ export interface SpaceTask {
 	/** Timestamp when approval occurred (milliseconds since epoch); null until approved */
 	approvedAt: number | null;
 	/**
-	 * Index into the workflow node's `completionActions[]` for the action currently awaiting
-	 * human approval. Null when not paused at a completion action.
-	 */
-	pendingActionIndex: number | null;
-	/**
 	 * Type of checkpoint the task is currently paused at. Null when not paused.
-	 * - `completion_action`: paused at a node completion action
 	 * - `gate`: paused at a gate requiring human approval
 	 * - `task_completion`: paused awaiting human approval of a submit_for_approval request
 	 */
-	pendingCheckpointType: 'completion_action' | 'gate' | 'task_completion' | null;
+	pendingCheckpointType: 'gate' | 'task_completion' | null;
 	/**
 	 * Node ID of the end-node agent that called `submit_for_approval`. Set when the
 	 * task enters `review` status via that tool; cleared on approve/reject.
@@ -308,36 +302,11 @@ export interface SpaceTask {
 	 */
 	pendingCompletionReason?: string | null;
 	/**
-	 * Metadata for the completion action the task is currently paused at, derived from
-	 * `workflow.endNode.completionActions[pendingActionIndex]` at read time.
-	 *
-	 * Populated by read-path enrichers (e.g. `get_task_detail`, `list_tasks`) so UIs can
-	 * render a review/approval banner without fetching workflow detail. Null when the
-	 * task is not paused at a completion action, or when the workflow can't be resolved.
-	 *
-	 * NOT persisted in the database. NOT included in every `SpaceTask` instance —
-	 * callers that load tasks straight from the repo will see `undefined` here.
-	 * Script bodies, instruction prompts, and MCP tool args are intentionally omitted;
-	 * consumers fetch the workflow definition directly if they need those.
-	 */
-	pendingAction?: {
-		/** Unique identifier within the node's completion actions */
-		id: string;
-		/** Human-readable name (shown in approval UI) */
-		name: string;
-		/** Human-readable description if defined on the action */
-		description?: string;
-		/** Discriminator for the action's execution type */
-		type: 'script' | 'instruction' | 'mcp_call';
-		/** Minimum space autonomy level required to auto-execute this action */
-		requiredLevel: SpaceAutonomyLevel;
-	} | null;
-	/**
 	 * Status the end-node agent reported via `report_result`. Null until the agent
 	 * reports. Recorded separately from `status` so the runtime can resolve the
-	 * final task status through completion-actions review (supervised modes) without
-	 * the agent bypassing the gate. Once recorded, this field is preserved for audit
-	 * even after `status` reaches a terminal value.
+	 * final task status through the `submit_for_approval` review path (supervised
+	 * modes) without the agent bypassing the gate. Once recorded, this field is
+	 * preserved for audit even after `status` reaches a terminal value.
 	 */
 	reportedStatus: SpaceReportedStatus | null;
 	/**
@@ -488,16 +457,14 @@ export interface UpdateSpaceTaskParams {
 	 * Optional cancellation/rejection reason. Stored into the same underlying
 	 * `approval_reason` column as `approvalReason`, but semantically paired with
 	 * transitions that abort work (e.g. review → cancelled, or rejecting a
-	 * paused completion action). When both are provided, the runtime picks the
-	 * one that matches the transition direction.
+	 * `submit_for_approval` request). When both are provided, the runtime picks
+	 * the one that matches the transition direction.
 	 */
 	cancelReason?: string | null;
 	/** Timestamp when approval occurred; null to clear */
 	approvedAt?: number | null;
-	/** Index of the completion action awaiting approval; null to clear */
-	pendingActionIndex?: number | null;
 	/** Type of checkpoint the task is paused at; null to clear */
-	pendingCheckpointType?: 'completion_action' | 'gate' | 'task_completion' | null;
+	pendingCheckpointType?: 'gate' | 'task_completion' | null;
 	/**
 	 * Node ID of the agent that called `submit_for_approval`; null to clear.
 	 * See `SpaceTask.pendingCompletionSubmittedByNodeId`.
@@ -677,15 +644,6 @@ export interface SpaceWorkflowRun {
 	updatedAt: number;
 	/** Completion timestamp (milliseconds since epoch); null until the run reaches a terminal state */
 	completedAt: number | null;
-	/**
-	 * Timestamp (milliseconds since epoch) at which the run's end-node
-	 * `completionActions` have been successfully fired. Used as an idempotency
-	 * marker so that a run which is reopened (done → in_progress) and later
-	 * completes again does not re-fire its completion actions.
-	 *
-	 * Null until the first successful completion. Never cleared on reopen.
-	 */
-	completionActionsFiredAt: number | null;
 }
 
 /**
@@ -1071,12 +1029,6 @@ export interface WorkflowNode {
 	 * Must be non-empty. Each agent runs concurrently; the node completes when all agents complete.
 	 */
 	agents: WorkflowNodeAgent[];
-	/**
-	 * Actions to execute after this node's task is approved (or auto-approved).
-	 * Executed in definition order. Each action has a `requiredLevel` that determines
-	 * whether it auto-executes or pauses for human approval.
-	 */
-	completionActions?: CompletionAction[];
 }
 
 /**
@@ -1093,8 +1045,6 @@ export interface WorkflowNodeInput {
 	 * Agents for parallel execution within this node. Must be non-empty.
 	 */
 	agents: WorkflowNodeAgent[];
-	/** Completion actions to execute after this node's task is approved. */
-	completionActions?: CompletionAction[];
 }
 
 /**
@@ -1567,91 +1517,6 @@ export interface WorkflowRunArtifact {
 	data: Record<string, unknown>;
 	createdAt: number;
 	updatedAt: number;
-}
-
-// ── Completion Actions ────────────────────────────────────────────────────
-
-/**
- * A completion action runs after a workflow node's task is approved.
- * Actions execute in definition order. Each has a `requiredLevel` —
- * if `space.autonomyLevel >= requiredLevel`, it auto-executes;
- * otherwise, the pipeline pauses for human sign-off.
- */
-export type CompletionAction =
-	| ScriptCompletionAction
-	| InstructionCompletionAction
-	| McpCallCompletionAction;
-
-interface CompletionActionBase {
-	/** Unique identifier within the node's completion actions */
-	id: string;
-	/** Human-readable name (shown in approval UI) */
-	name: string;
-	/** Human-readable description of what the action does (shown alongside the name in approval UI) */
-	description?: string;
-	/** Minimum space autonomy level required to auto-execute this action */
-	requiredLevel: SpaceAutonomyLevel;
-	/** Which artifact type to resolve as context for this action */
-	artifactType?: ArtifactType;
-	/** Specific artifact key, or undefined to use all artifacts of the type */
-	artifactKey?: string;
-}
-
-/** Deterministic bash script — artifact data injected as environment variables */
-export interface ScriptCompletionAction extends CompletionActionBase {
-	type: 'script';
-	/** Shell script to execute */
-	script: string;
-}
-
-/** Agent instruction — spawns a short-lived SpaceAgent session to verify an outcome */
-export interface InstructionCompletionAction extends CompletionActionBase {
-	type: 'instruction';
-	/**
-	 * Name of the SpaceAgent that should execute the instruction. The runtime
-	 * spawns an ephemeral session bound to this agent, injects a
-	 * `report_verification` tool, and awaits its response.
-	 */
-	agentName: string;
-	/** Prompt text — supports `{{artifact.field}}` template interpolation */
-	instruction: string;
-	/**
-	 * Maximum time to wait for the spawned agent to call
-	 * `report_verification`. Defaults to 120000ms (2 minutes).
-	 */
-	timeoutMs?: number;
-}
-
-/** Direct MCP tool invocation — no agent reasoning needed */
-export interface McpCallCompletionAction extends CompletionActionBase {
-	type: 'mcp_call';
-	/** MCP server id (must be enabled in the space's skills config) */
-	server: string;
-	/** Tool name on the MCP server */
-	tool: string;
-	/** Tool arguments — values support `{{artifact.field}}` template interpolation */
-	args: Record<string, string>;
-	/**
-	 * Optional assertion applied to the tool result. The runtime extracts the
-	 * value at `path` from the result object and compares it via `op` to
-	 * `value`. If the assertion fails, the action fails.
-	 */
-	expect?: McpCallExpectation;
-}
-
-/**
- * Assertion applied to the JSON result of an `mcp_call` completion action.
- *
- * `path` uses a dot/bracket accessor syntax (e.g. `data.items[0].status`).
- * Empty path matches the whole result.
- */
-export interface McpCallExpectation {
-	/** Dot/bracket accessor path into the tool result (e.g. `status`, `data.items[0].ok`). */
-	path: string;
-	/** Comparison operator. */
-	op: 'eq' | 'neq' | 'contains' | 'exists' | 'truthy';
-	/** Right-hand side. Required for `eq`/`neq`/`contains`, ignored for `exists`/`truthy`. */
-	value?: unknown;
 }
 
 // ── Approval Records ──────────────────────────────────────────────────────

--- a/packages/web/src/components/space/PendingTaskCompletionBanner.tsx
+++ b/packages/web/src/components/space/PendingTaskCompletionBanner.tsx
@@ -15,9 +15,10 @@
  * Compact design: shows a single status line inline; full details and
  * confirmation are shown in modals opened by the Approve / Send back buttons.
  *
- * The legacy `completion_action` checkpoint pipeline (and its dedicated
- * `PendingCompletionActionBanner`) was removed in PR 4/5 — post-approval work
- * now runs through `PostApprovalRouter` instead. See
+ * The legacy completion-action checkpoint pipeline (and its dedicated banner)
+ * was removed in PR 4/5 — post-approval work now runs through
+ * `PostApprovalRouter` instead. PR 5/5 followed up by dropping the
+ * `'completion_action'` value from `pendingCheckpointType` entirely. See
  * `docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md`.
  */
 

--- a/packages/web/src/components/space/SpaceTasks.tsx
+++ b/packages/web/src/components/space/SpaceTasks.tsx
@@ -35,8 +35,14 @@ function isAwaitingTaskCompletion(task: SpaceTask): boolean {
 const ATTENTION_BLOCK_REASONS: SpaceBlockReason[] = ['human_input_requested', 'gate_rejected'];
 
 const TAB_GROUPS: Record<TaskFilterTab, SpaceTaskStatus[]> = {
+	// `approved` is transient (post-approval sub-session runs, then
+	// `mark_complete` transitions `approved → done`). We route it to the
+	// `active` tab so a stuck `approved` task (e.g. with
+	// `postApprovalBlockedReason` set) remains visible to the user rather
+	// than disappearing between tabs. The task-detail pane's
+	// PendingPostApprovalBanner surfaces the actionable failure state.
 	action: ['review', 'blocked'],
-	active: ['open', 'in_progress'],
+	active: ['open', 'in_progress', 'approved'],
 	completed: ['done', 'cancelled'],
 	archived: ['archived'],
 };
@@ -46,6 +52,7 @@ const STATUS_BORDER: Record<string, string> = {
 	in_progress: 'border-l-blue-500',
 	blocked: 'border-l-amber-500',
 	review: 'border-l-purple-500',
+	approved: 'border-l-emerald-500',
 	done: 'border-l-green-500',
 	cancelled: 'border-l-gray-600',
 	archived: 'border-l-gray-700',
@@ -56,6 +63,7 @@ const STATUS_LABEL: Record<string, string> = {
 	in_progress: 'In Progress',
 	blocked: 'Blocked',
 	review: 'Review',
+	approved: 'Approved',
 	done: 'Done',
 	cancelled: 'Cancelled',
 	archived: 'Archived',
@@ -98,6 +106,11 @@ const ACTION_GROUPS: StatusGroupDef[] = [
 
 const ACTIVE_GROUPS: StatusGroupDef[] = [
 	{ status: 'in_progress', title: 'In Progress', variant: 'yellow' },
+	// `approved` is a transient state — the post-approval sub-session runs,
+	// then `mark_complete` transitions the task to `done`. Surface it in
+	// Active so a task stuck in `approved` (post-approval dispatch failed,
+	// `postApprovalBlockedReason` populated) stays visible.
+	{ status: 'approved', title: 'Post-Approval Running', variant: 'green' },
 	{ status: 'open', title: 'Open', variant: 'default' },
 ];
 

--- a/packages/web/src/components/space/__tests__/AutonomyWorkflowSummary.test.tsx
+++ b/packages/web/src/components/space/__tests__/AutonomyWorkflowSummary.test.tsx
@@ -8,9 +8,10 @@
  * - Expands to reveal blocking workflows when the toggle is clicked
  * - Uses the runtime fallback (level 5) for workflows with no `completionAutonomyLevel`
  *
- * Note: `completionActions` on workflow nodes was removed in PR 4/5 — gating is
- * now expressed by a single `completionAutonomyLevel` field on the workflow
- * itself (defaulting to 5 when absent).
+ * Note: per-node action arrays on workflow nodes were removed in PR 4/5 (and
+ * the shared types deleted in PR 5/5) — gating is now expressed by a single
+ * `completionAutonomyLevel` field on the workflow itself (defaulting to 5
+ * when absent).
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';

--- a/packages/web/src/components/space/__tests__/SpaceOverview.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceOverview.test.tsx
@@ -471,11 +471,9 @@ describe('SpaceOverview', () => {
 			mockSpace.value = makeSpace();
 			mockTasks.value = [
 				makeTask('t1', 'review', {
-					pendingActionIndex: 0,
 					pendingCheckpointType: 'task_completion',
 				}),
 				makeTask('t2', 'review', {
-					pendingActionIndex: 1,
 					pendingCheckpointType: 'task_completion',
 				}),
 				// Gate-paused task should not contribute to the count
@@ -493,7 +491,6 @@ describe('SpaceOverview', () => {
 			mockSpace.value = makeSpace();
 			mockTasks.value = [
 				makeTask('t1', 'review', {
-					pendingActionIndex: 0,
 					pendingCheckpointType: 'task_completion',
 				}),
 			];
@@ -505,7 +502,6 @@ describe('SpaceOverview', () => {
 			mockSpace.value = makeSpace();
 			mockTasks.value = [
 				makeTask('t1', 'review', {
-					pendingActionIndex: 0,
 					pendingCheckpointType: 'task_completion',
 				}),
 			];

--- a/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
@@ -438,7 +438,6 @@ describe('SpaceTasks', () => {
 		it('shows chip with count when at least one task is paused at a submit_for_approval checkpoint', () => {
 			mockTasks.value = [
 				makeTask('t1', 'review', {
-					pendingActionIndex: 0,
 					pendingCheckpointType: 'task_completion',
 				}),
 				makeTask('t2', 'review'),
@@ -453,7 +452,6 @@ describe('SpaceTasks', () => {
 		it('filters the list to awaiting-approval tasks only when toggled on', () => {
 			mockTasks.value = [
 				makeTask('t1', 'review', {
-					pendingActionIndex: 0,
 					pendingCheckpointType: 'task_completion',
 				}),
 				makeTask('t2', 'review'),

--- a/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
@@ -162,6 +162,18 @@ describe('SpaceTasks', () => {
 		expect(queryByText('No active tasks')).toBeNull();
 	});
 
+	it("surfaces 'approved' tasks inside the active tab (post-approval running)", () => {
+		// `approved` is a transient state between `approve_task` and
+		// `mark_complete`. When stuck (post-approval dispatch fails and
+		// `postApprovalBlockedReason` is populated), the task must remain
+		// visible — routing it to Active keeps it in sight and the
+		// PendingPostApprovalBanner on the detail pane surfaces the error.
+		mockTasks.value = [makeTask('t1', 'approved')];
+		const { getByText } = render(<SpaceTasks spaceId="space-1" />);
+		expect(getByText('Task t1')).toBeTruthy();
+		expect(getByText(/Post-Approval Running/)).toBeTruthy();
+	});
+
 	it('displays tasks in action tab (blocked + review)', () => {
 		mockTasks.value = [makeTask('t1', 'blocked'), makeTask('t2', 'review')];
 		const { getByText } = render(<SpaceTasks spaceId="space-1" />);

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -74,7 +74,6 @@ function makeTask(id: string, status = 'open', workflowRunId?: string): SpaceTas
 		approvalSource: null,
 		approvalReason: null,
 		approvedAt: null,
-		pendingActionIndex: null,
 		pendingCheckpointType: null,
 		reportedStatus: null,
 		reportedSummary: null,
@@ -93,7 +92,6 @@ function makeRun(id: string, status = 'pending'): SpaceWorkflowRun {
 		status: status as SpaceWorkflowRun['status'],
 		startedAt: null,
 		completedAt: null,
-		completionActionsFiredAt: null,
 		createdAt: Date.now(),
 		updatedAt: Date.now(),
 	};

--- a/packages/web/src/lib/__tests__/task-banner.test.ts
+++ b/packages/web/src/lib/__tests__/task-banner.test.ts
@@ -131,11 +131,12 @@ describe('task_completion_pending branch', () => {
 		}
 	});
 
-	test('completion_action checkpoints (legacy) are ignored — they fall through to gate/null', () => {
-		// `completion_action` was removed from the pipeline in PR 4/5. Residual
-		// rows must NOT render a banner via this helper.
+	test('unknown checkpoint type values are ignored — they fall through to gate/null', () => {
+		// PR 5/5 narrowed `pendingCheckpointType` to `'gate' | 'task_completion' |
+		// null`. If a stale daemon ever ships a different literal, this helper
+		// must NOT render a banner — the unknown value falls through.
 		const task = makeTask({
-			pendingCheckpointType: 'completion_action' as unknown as SpaceTask['pendingCheckpointType'],
+			pendingCheckpointType: 'legacy_unknown' as unknown as SpaceTask['pendingCheckpointType'],
 		});
 		expect(resolveActiveTaskBanner(task, [])).toBeNull();
 	});

--- a/packages/web/src/lib/task-banner.ts
+++ b/packages/web/src/lib/task-banner.ts
@@ -1,12 +1,9 @@
 /**
  * Task-pane banner precedence helper.
  *
- * Before PR 4/5 the task pane stacked four independent banners
- * (`PendingCompletionActionBanner`, `PendingTaskCompletionBanner`,
- * `PendingGateBanner`, `TaskBlockedBanner`) and let CSS stacking decide which
- * the user saw first. That produced ambiguous states — e.g. a blocked task
- * with a pending gate still rendered both bands, and the completion-action
- * banner (now deleted) could sit on top of the gate banner.
+ * Before PR 4/5 the task pane stacked four independent banners and let CSS
+ * stacking decide which the user saw first. That produced ambiguous states —
+ * e.g. a blocked task with a pending gate still rendered both bands.
  *
  * `resolveActiveTaskBanner` collapses that into a single, deterministic
  * decision. Consumers render exactly one banner — the one this function
@@ -21,10 +18,9 @@
  *   4. `task.workflowRunId` AND any gate is `waiting_human`              → `gate_pending`
  *   5. Otherwise                                                         → `null`
  *
- * Completion-action checkpoints (`pendingCheckpointType === 'completion_action'`)
- * are intentionally not in the precedence chain — the completion-action
- * pipeline was removed in this same PR, so any residual row with that value is
- * treated as noise and falls through to `null`.
+ * The legacy `'completion_action'` checkpoint variant was removed in PR 5/5
+ * (schema migration M104 narrowed the column CHECK to `('gate',
+ * 'task_completion')`), so it is no longer reachable here.
  *
  * This file is purely derived from its inputs. No hub calls, no signals, no
  * side effects — safe to call inside render loops and unit tests.

--- a/packages/web/src/lib/task-constants.ts
+++ b/packages/web/src/lib/task-constants.ts
@@ -2,6 +2,7 @@ export const TASK_STATUS_COLORS: Record<string, string> = {
 	// SpaceTaskStatus values
 	open: 'text-gray-400',
 	in_progress: 'text-yellow-400',
+	approved: 'text-emerald-400',
 	done: 'text-green-400',
 	blocked: 'text-red-400',
 	cancelled: 'text-gray-500',


### PR DESCRIPTION
Final stage of the task-agent-as-post-approval-executor refactor (plan: [`docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md`](docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md)). PRs 1–4 (#1620, #1621, #1623, #1628) moved every runtime path off `completionActions`. This PR deletes the types, schema columns, and supporting code so nothing references the dead pipeline.

## Summary
- Drop `CompletionAction` union, `pendingActionIndex`, and `completionActionsFiredAt` from `@neokai/shared`; narrow `pendingCheckpointType` to `'gate' | 'task_completion'`.
- New M104 migration: rewrites stuck `completion_action` rows → `task_completion`, drops `space_tasks.pending_action_index`, tightens the CHECK constraint, and drops `space_workflow_runs.completion_actions_fired_at`. Idempotent and guarded.
- Strip legacy `completionActions` keys from persisted node config at load time and emit a structured `workflow.migrated: workflowId=… workflowName=… strippedFields=[…]` log line per workflow load.
- Refresh CHANGELOG, plan doc banner, research doc, and the autonomy-levels design doc to mark the legacy system superseded.

## Test plan
- [x] `bun run check` (lint, typecheck, knip, session guards)
- [x] `./scripts/test-daemon.sh` — 11 131 / 11 132 pass
- [x] `bun run test` (web, vitest) — 7 231 / 7 231 pass
- [x] `bun test packages/shared/tests` — 474 / 474 pass
- [x] New `migration-104_test.ts` covers fresh-DB / pre-M104 rebuild / idempotency / missing-table guards (16 cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)