### PR TITLE
refactor(web): drop artifacts header, align tab pill with agent name tag

### DIFF
--- a/packages/e2e/tests/features/space-artifacts-panel.e2e.ts
+++ b/packages/e2e/tests/features/space-artifacts-panel.e2e.ts
@@ -297,9 +297,9 @@ test.describe('Artifacts Side Panel', () => {
 		await expect(page.getByTestId('artifacts-file-list')).toBeVisible({ timeout: 5000 });
 	});
 
-	// ─── Test 4: Close button dismisses the panel ────────────────────────────
+	// ─── Test 4: Toggling the pill dismisses the panel ──────────────────────
 
-	test('close button dismisses the artifacts panel and restores the thread view', async ({
+	test('clicking the artifacts toggle while open dismisses the panel and restores the thread view', async ({
 		page,
 	}) => {
 		await page.goto(`/space/${spaceId}/task/${taskId}`);
@@ -310,8 +310,9 @@ test.describe('Artifacts Side Panel', () => {
 		await page.getByTestId('artifacts-toggle').click();
 		await expect(page.getByTestId('artifacts-panel')).toBeVisible({ timeout: 10000 });
 
-		// Close the panel via the X button.
-		await page.getByTestId('artifacts-panel-close').click();
+		// The header (with its X button) was removed — clicking the artifacts
+		// pill toggle a second time is now the canonical way to close the panel.
+		await page.getByTestId('artifacts-toggle').click();
 
 		// Panel must be gone and the task thread panel must be back.
 		await expect(page.getByTestId('artifacts-panel')).toBeHidden({ timeout: 5000 });

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -391,74 +391,70 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 			})()}
 
 			<div class="flex-1 min-h-0 overflow-hidden relative" data-testid="task-pane-content">
-				{/* Wrapper spans the full content width so the pill can center
-				    horizontally — but that span would otherwise eat clicks meant
-				    for the canvas / thread / artifacts beneath it. Disabling
-				    pointer-events on the wrapper and re-enabling them on the pill
-				    itself keeps only the pill interactive. */}
+				{/* Pill is right-aligned at top-2 to mirror the agent name tag at
+				    top-2 left-4 inside SpaceTaskUnifiedThread, so both pills sit
+				    on the same horizontal row. */}
 				<div
-					class="pointer-events-none absolute top-3 left-0 right-0 z-10 flex justify-center px-4"
+					class="absolute top-2 right-4 z-20 flex items-center gap-1 rounded-3xl border border-dark-700 bg-dark-800/60 p-1 backdrop-blur-sm"
 					data-testid="task-view-tab-pill"
 				>
-					<div class="pointer-events-auto flex items-center gap-1 rounded-3xl border border-dark-700 bg-dark-800/80 p-1 shadow-lg backdrop-blur-sm">
+					<button
+						type="button"
+						onClick={() => navigateToSpaceTask(_spaceId, taskId, 'thread')}
+						class={cn(
+							'px-2.5 py-1 text-xs font-medium rounded-2xl transition-all',
+							activeView === 'thread'
+								? 'text-gray-100 bg-dark-700/70 shadow-sm'
+								: 'text-gray-300/80 hover:text-gray-100 hover:bg-dark-700/40'
+						)}
+						data-testid="thread-toggle"
+						aria-pressed={activeView === 'thread'}
+					>
+						Thread
+					</button>
+					{canShowCanvasTab && (
 						<button
 							type="button"
-							onClick={() => navigateToSpaceTask(_spaceId, taskId, 'thread')}
+							onClick={() => {
+								if (activeView === 'canvas') {
+									navigateToSpaceTask(_spaceId, taskId, 'thread');
+									return;
+								}
+								spaceStore.ensureNodeExecutions().catch(() => {});
+								navigateToSpaceTask(_spaceId, taskId, 'canvas');
+							}}
 							class={cn(
 								'px-2.5 py-1 text-xs font-medium rounded-2xl transition-all',
-								activeView === 'thread'
+								activeView === 'canvas'
 									? 'text-gray-100 bg-dark-700/70 shadow-sm'
 									: 'text-gray-300/80 hover:text-gray-100 hover:bg-dark-700/40'
 							)}
-							data-testid="thread-toggle"
-							aria-pressed={activeView === 'thread'}
+							data-testid="canvas-toggle"
+							aria-pressed={activeView === 'canvas'}
 						>
-							Thread
+							Canvas
 						</button>
-						{canShowCanvasTab && (
-							<button
-								type="button"
-								onClick={() => {
-									if (activeView === 'canvas') {
-										navigateToSpaceTask(_spaceId, taskId, 'thread');
-										return;
-									}
-									spaceStore.ensureNodeExecutions().catch(() => {});
-									navigateToSpaceTask(_spaceId, taskId, 'canvas');
-								}}
-								class={cn(
-									'px-2.5 py-1 text-xs font-medium rounded-2xl transition-all',
-									activeView === 'canvas'
-										? 'text-gray-100 bg-dark-700/70 shadow-sm'
-										: 'text-gray-300/80 hover:text-gray-100 hover:bg-dark-700/40'
-								)}
-								data-testid="canvas-toggle"
-								aria-pressed={activeView === 'canvas'}
-							>
-								Canvas
-							</button>
-						)}
-						{canShowArtifactsTab && (
-							<button
-								type="button"
-								onClick={() =>
-									currentSpaceTaskViewTabSignal.value === 'artifacts'
-										? navigateToSpaceTask(_spaceId, taskId, 'thread')
-										: navigateToSpaceTask(_spaceId, taskId, 'artifacts')
-								}
-								class={cn(
-									'px-2.5 py-1 text-xs font-medium rounded-2xl transition-all',
-									activeView === 'artifacts'
-										? 'text-gray-100 bg-dark-700/70 shadow-sm'
-										: 'text-gray-300/80 hover:text-gray-100 hover:bg-dark-700/40'
-								)}
-								data-testid="artifacts-toggle"
-								aria-pressed={activeView === 'artifacts'}
-							>
-								Artifacts
-							</button>
-						)}
-					</div>
+					)}
+					{canShowArtifactsTab && (
+						<button
+							type="button"
+							onClick={() =>
+								currentSpaceTaskViewTabSignal.value === 'artifacts'
+									? navigateToSpaceTask(_spaceId, taskId, 'thread')
+									: navigateToSpaceTask(_spaceId, taskId, 'artifacts')
+							}
+							class={cn(
+								'px-2.5 py-1 text-xs font-medium rounded-2xl transition-all',
+								activeView === 'artifacts'
+									? 'text-gray-100 bg-dark-700/70 shadow-sm'
+									: 'text-gray-300/80 hover:text-gray-100 hover:bg-dark-700/40'
+							)}
+							data-testid="artifacts-toggle"
+							aria-pressed={activeView === 'artifacts'}
+						>
+							Artifacts
+						</button>
+					)}
 				</div>
 				{activeView === 'canvas' && task.workflowRunId && canvasWorkflowId ? (
 					<div class="h-full" data-testid="canvas-view">
@@ -483,7 +479,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 							{hasUnifiedWorkflowThread ? (
 								<SpaceTaskUnifiedThread
 									taskId={task.id}
-									topInsetClass="pt-12"
+									topInsetClass="pt-10"
 									bottomInsetClass={
 										showInlineComposer ? (threadSendError ? 'pb-24' : 'pb-16') : 'pb-3'
 									}

--- a/packages/web/src/components/space/TaskArtifactsPanel.tsx
+++ b/packages/web/src/components/space/TaskArtifactsPanel.tsx
@@ -52,7 +52,7 @@ export interface TaskArtifactsPanelProps {
 	runId: string;
 	taskId?: string;
 	/** Called when the panel should close (kept for API compatibility) */
-	onClose: () => void;
+	onClose?: () => void;
 	class?: string;
 }
 
@@ -308,12 +308,7 @@ function CommitFilesView({
 // Main component
 // ============================================================================
 
-export function TaskArtifactsPanel({
-	runId,
-	taskId,
-	onClose,
-	class: className,
-}: TaskArtifactsPanelProps) {
+export function TaskArtifactsPanel({ runId, taskId, class: className }: TaskArtifactsPanelProps) {
 	const [view, setView] = useState<PanelView>({ mode: 'list' });
 
 	// ── Uncommitted changes ──────────────────────────────────────────────────
@@ -539,24 +534,6 @@ export function TaskArtifactsPanel({
 			class={cn('flex flex-col h-full overflow-hidden', className)}
 			data-testid="artifacts-panel"
 		>
-			<div class="flex items-center justify-between px-4 py-2 border-b border-dark-800 flex-shrink-0">
-				<span class="text-xs font-medium text-gray-400 uppercase tracking-wider">Artifacts</span>
-				<button
-					onClick={onClose}
-					data-testid="artifacts-panel-close"
-					class="text-gray-500 hover:text-gray-200 transition-colors"
-					aria-label="Close artifacts panel"
-				>
-					<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-						<path
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							stroke-width={2}
-							d="M6 18L18 6M6 6l12 12"
-						/>
-					</svg>
-				</button>
-			</div>
 			<div class="flex-1 overflow-y-auto min-h-0">
 				<div class="min-h-[calc(100%+1px)]">
 					{/* ── Todos ───────────────────────────────────────────── */}

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -962,14 +962,15 @@ describe('SpaceTaskPane — floating tab pill layout', () => {
 		const { getByTestId } = render(<SpaceTaskPane taskId="task-1" spaceId="space-1" />);
 
 		const pill = getByTestId('task-view-tab-pill');
-		// Floating overlay: absolute-positioned, full-width wrapper, high z-index,
-		// and pointer-events disabled on the wrapper so empty space around the
-		// pill never blocks underlying canvas / thread interactions. (CSS class
-		// strings are asserted directly because Tailwind utilities aren't
+		// Floating overlay: absolute-positioned at top-2 right-4 to mirror the
+		// agent name tag at top-2 left-4 inside SpaceTaskUnifiedThread, with a
+		// high z-index so the pill always sits above the rendered view. (CSS
+		// class strings are asserted directly because Tailwind utilities aren't
 		// loaded in jsdom — getComputedStyle would return defaults.)
 		expect(pill.className).toContain('absolute');
-		expect(pill.className).toContain('pointer-events-none');
-		expect(pill.className).toContain('z-10');
+		expect(pill.className).toContain('top-2');
+		expect(pill.className).toContain('right-4');
+		expect(pill.className).toContain('z-20');
 
 		// The pill is a direct child of the content wrapper, not nested inside
 		// the rendered view, so it overlays rather than displaces content.
@@ -1000,18 +1001,14 @@ describe('SpaceTaskPane — floating tab pill layout', () => {
 		expect(queryByTestId('task-view-tab-pill')).toBeTruthy();
 	});
 
-	it('pill buttons remain clickable through the pointer-events-none wrapper', () => {
+	it('pill buttons are interactive', () => {
 		mockCurrentSpaceIdSignal.value = 'space-1';
 		mockTasks.value = [makeTask({ workflowRunId: 'run-1', taskAgentSessionId: 'session-abc' })];
 		mockWorkflowRuns.value = [makeWorkflowRun({ id: 'run-1', workflowId: 'workflow-1' })];
 		const { getByTestId } = render(<SpaceTaskPane taskId="task-1" spaceId="space-1" />);
 
-		// Direct child of the floating wrapper must restore pointer-events so
-		// the buttons inside it are still interactive.
-		const pill = getByTestId('task-view-tab-pill');
-		const innerPill = pill.firstElementChild as HTMLElement;
-		expect(innerPill.className).toContain('pointer-events-auto');
-
+		// The pill sits at top-2 right-4 with no pointer-events wrapper, so its
+		// buttons receive clicks directly.
 		fireEvent.click(getByTestId('canvas-toggle'));
 		expect(mockNavigateToSpaceTask).toHaveBeenCalledWith('space-1', 'task-1', 'canvas');
 	});
@@ -1021,7 +1018,7 @@ describe('SpaceTaskPane — floating tab pill layout', () => {
 		const { getByTestId } = render(<SpaceTaskPane taskId="task-1" spaceId="space-1" />);
 
 		const thread = getByTestId('space-task-unified-thread');
-		expect(thread.getAttribute('data-top-inset')).toBe('pt-12');
+		expect(thread.getAttribute('data-top-inset')).toBe('pt-10');
 	});
 
 	it('renders the active banner outside task-pane-content so it is visible across tabs', () => {

--- a/packages/web/src/components/space/__tests__/TaskArtifactsPanel.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskArtifactsPanel.test.tsx
@@ -614,12 +614,8 @@ describe('SpaceTaskPane — artifacts toggle', () => {
 			PendingGateBanner: () => null,
 		}));
 		vi.doMock('../TaskArtifactsPanel', () => ({
-			TaskArtifactsPanel: ({ runId, onClose }: { runId: string; onClose: () => void }) => (
-				<div data-testid="artifacts-panel" data-run-id={runId}>
-					<button data-testid="artifacts-panel-close" onClick={onClose}>
-						Close
-					</button>
-				</div>
+			TaskArtifactsPanel: ({ runId }: { runId: string; onClose?: () => void }) => (
+				<div data-testid="artifacts-panel" data-run-id={runId} />
 			),
 		}));
 		vi.doMock('../../../lib/router', () => ({
@@ -658,8 +654,8 @@ describe('SpaceTaskPane — artifacts toggle', () => {
 		expect(getByTestId('artifacts-panel')).toBeTruthy();
 		expect(getByTestId('artifacts-panel').getAttribute('data-run-id')).toBe('run-toggle');
 
-		// Click close → panel disappears
-		fireEvent.click(getByTestId('artifacts-panel-close'));
+		// Click toggle again → panel disappears (the pill is the only way to close)
+		fireEvent.click(getByTestId('artifacts-toggle'));
 		expect(queryByTestId('artifacts-panel')).toBeNull();
 	});
 });


### PR DESCRIPTION
- Remove the `ARTIFACTS` header bar (label + X close button) from `TaskArtifactsPanel` — the tab pill already labels the active view, and toggling the pill is the canonical close gesture. `onClose` is kept as an optional prop for API compatibility but no longer renders.
- Reposition the Thread/Canvas/Artifacts pill to `absolute top-2 right-4 z-20` inside the content area so it mirrors the agent name tag at `top-2 left-4` inside `SpaceTaskUnifiedThread`. The pointer-events wrapper is gone since the pill no longer spans the full width.
- Trim `topInsetClass` for the unified thread from `pt-12` to `pt-10` to match the new pill height.

## Test plan
- [x] `bun run test` (web): 7238 passed
- [x] `bun run typecheck`, `bun run lint`
- [ ] Manual check that artifacts panel content starts immediately and pill sits on the same row as the agent name tag