### PR TITLE
plan: improve test coverage to 80%

### DIFF
--- a/docs/plans/improve-test-coverage/00-overview.md
+++ b/docs/plans/improve-test-coverage/00-overview.md
@@ -1,0 +1,59 @@
+# Plan: Improve Test Coverage to 80%
+
+## Goal
+
+Raise the Coveralls combined project coverage from the current enforced minimum of 30% to 80%, enforced in CI.
+
+## Current State (April 2026)
+
+- **CI gate**: `MIN_COVERAGE=30` in `.github/workflows/main.yml` — the actual gate is wrong; must be raised to 80 as the final step.
+- **Coverage tracking**: Coveralls receives parallel uploads from 8 daemon unit shards + ~25 online module shards + 1 web upload, then merges them.
+- **Vitest (web)**: `packages/web/vitest.config.ts` has NO `coverage.include` glob. Files never imported by any test are invisible to coverage. This is a structural gap that likely means the real web coverage is lower than it appears.
+- **Bun (daemon/shared/cli)**: Bun has no native `all:true` / `coverage.include`. Files never imported by any test are silently excluded. The workaround is a dedicated `coverage.test.ts` per package that dynamically imports every source file.
+- **UI package**: Has vitest + 34 tests but is NOT wired into CI coverage uploads. Adding it would help the aggregate number.
+- **CLI package**: CI runs `bun test` WITHOUT `--coverage`; coverage is never uploaded to Coveralls.
+
+## High-Level Approach
+
+Coverage increases through two levers:
+
+1. **Expose hidden files** (infrastructure changes) — Fix vitest and add Bun workaround so untested files register as 0% instead of being invisible. This immediately lowers the apparent coverage but gives an honest baseline.
+2. **Write tests** — Systematically cover the high-line-count untested files across web, daemon, shared, and cli packages.
+
+The 80% target is achievable because most of the codebase already has test counterparts; the gap is a mix of invisible files and a handful of large untested modules.
+
+## Milestones
+
+| # | Milestone | Description |
+|---|-----------|-------------|
+| 01 | **Coverage Infrastructure** | Fix vitest `coverage.include`, add Bun all-files workaround per package, verify CI flag-name uniqueness |
+| 02 | **True Baseline Measurement** | Run coverage after infrastructure changes, document actual per-package percentages |
+| 03 | **Web: Lib and Store Tests** | Test `room-store.ts`, `lobby-store.ts`, `parse-group-message.ts`, and other uncovered lib files |
+| 04 | **Web: Component Tests** | Test the top untested components by line count: `RoomAgents`, `AgentTurnBlock`, `RoomSettings`, `FallbackModelsSettings`, `MessageInput`, etc. |
+| 05 | **Web: Hook and Utility Tests** | Test `useChatComposerController`, `useSkills`, and remaining uncovered hooks/utils |
+| 06 | **Daemon: Repository Tests** | Tests for the 4 untested repositories: `space-worktree-repository`, `skill-repository`, `space-task-report-result-repository`, `workspace-history-repository` |
+| 07 | **Daemon: Core Service Tests** | Tests for `rpc-handlers/index.ts`, `daemon-hub.ts`, `github-service.ts`, `providers/registry.ts`, `providers/factory.ts`, coordinator agents |
+| 08 | **Shared and CLI Coverage** | Add Bun coverage workaround for shared; add `--coverage` flag to CLI CI step; fill gaps in shared message-hub and provider modules |
+| 09 | **CI Gate Update** | Raise `MIN_COVERAGE` from 30 to 80 in `.github/workflows/main.yml` after coverage is confirmed passing |
+
+## Cross-Milestone Dependencies
+
+```
+01 (Infrastructure) --> 02 (Baseline) --> 03-08 (Tests) --> 09 (Gate)
+```
+
+- Milestones 03–08 can run in parallel after milestone 02.
+- Milestone 09 must be the last commit — raising the gate before coverage is at 80% would break CI.
+- Milestones 06 and 07 are daemon-focused; they share the same test shard patterns and helpers but can be written by independent coder agents.
+
+## Total Estimated Tasks
+
+Approximately 28 tasks across 9 milestones.
+
+## Key Technical Constraints
+
+1. **Do not write tests for `migrations.ts`** — This file (7,317 lines of raw SQL) is not unit-testable. The existing integration path covers it indirectly.
+2. **Neo-related tests remain disabled** — The `**/neo-*.test.ts` pattern is excluded via `--path-ignore-patterns` in the test runner. Do not re-enable them; the underlying flakiness is unresolved.
+3. **Bun all-files workaround**: Use `Bun.Glob` + dynamic import pattern (see milestone 01). The glob must exclude `.test.ts`, `.d.ts`, `index.ts` barrels, and the schema `migrations.ts`.
+4. **Vitest `coverage.include`** (not `coverage.all`): `coverage.all` was removed in Vitest 4.0. Use `coverage.include: ['src/**/*.{ts,tsx}']` with appropriate excludes.
+5. **Coveralls flag-name uniqueness**: Each parallel upload already uses a unique `flag-name` (e.g., `daemon-0-shared`, `daemon-online-<module>`, `web`). No collision risk currently; verify any new uploads get a new unique flag.

--- a/docs/plans/improve-test-coverage/01-coverage-infrastructure.md
+++ b/docs/plans/improve-test-coverage/01-coverage-infrastructure.md
@@ -1,0 +1,173 @@
+# Milestone 01: Coverage Infrastructure
+
+## Goal
+
+Fix the structural gaps in coverage tooling so that ALL source files are visible in coverage reports — including files that have zero tests. Without this step, the current ~30% gate is measuring a partial picture; many untested files are simply invisible to coverage tools.
+
+## Scope
+
+- `packages/web/vitest.config.ts` — add `coverage.include`
+- `packages/daemon/tests/unit/coverage.test.ts` — new Bun all-files workaround
+- `packages/shared/tests/coverage.test.ts` — new Bun all-files workaround
+- `packages/cli/tests/coverage.test.ts` — new Bun all-files workaround (small)
+- `.github/workflows/main.yml` — add `--coverage` to CLI test step, verify flag-name uniqueness
+
+---
+
+## Task 1.1: Fix Vitest `coverage.include` for web package
+
+**Agent type**: coder
+
+**Description**
+
+The `packages/web/vitest.config.ts` currently has no `coverage.include` glob. In Vitest 4.x, files never imported during a test run are completely invisible to coverage. Adding `coverage.include` forces all source files to be instrumented and show as 0% if untested.
+
+Note: `coverage.all` was removed in Vitest 4.0. The correct option is `coverage.include`.
+
+**Files to modify**
+
+- `packages/web/vitest.config.ts`
+
+**Subtasks**
+
+1. Add `coverage.include: ['src/**/*.{ts,tsx}']` to the `test.coverage` block.
+2. Extend `coverage.exclude` to also exclude test files themselves: `'**/*.test.{ts,tsx}'`, `'**/*.spec.{ts,tsx}'`, `'**/vitest.setup.ts'`.
+3. Confirm the existing excludes for `src/index.ts` and `**/index.ts` remain in place.
+4. Run `bun run coverage` locally (or in CI) and verify the text reporter now shows rows for previously-invisible files.
+
+**Acceptance criteria**
+
+- `packages/web/vitest.config.ts` has a `coverage.include` field.
+- Running `bun run coverage` in `packages/web` reports coverage for files that previously had no tests (they will show 0% statements, 0% lines).
+- No existing tests are broken by the config change.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+## Task 1.2: Add Bun all-files coverage workaround for daemon package
+
+**Agent type**: coder
+
+**Description**
+
+Bun's `bun test --coverage` only instruments files actually imported during the test run. There is no `all:true` or `coverage.include` option. The documented workaround is a dedicated test file that dynamically imports every source file using `Bun.Glob`.
+
+**Files to create**
+
+- `packages/daemon/tests/unit/coverage.test.ts`
+
+**Subtasks**
+
+1. Create `packages/daemon/tests/unit/coverage.test.ts` with the following pattern:
+
+```typescript
+import { test } from 'bun:test';
+
+/**
+ * All-files coverage shim.
+ *
+ * Bun does not support coverage.include / coverage.all.
+ * This test dynamically imports every source file so that
+ * files with zero test coverage show up as 0% (not missing).
+ *
+ * Excludes:
+ *  - *.test.ts and *.d.ts files
+ *  - index.ts barrel files (they only re-export)
+ *  - storage/schema/migrations.ts (7k+ lines of raw SQL, not unit-testable)
+ *  - Files under tests/ directory
+ */
+test('imports all daemon modules for coverage', async () => {
+  const glob = new Bun.Glob('**/*.ts');
+  const srcDir = new URL('../../src', import.meta.url).pathname;
+  const files = [...glob.scanSync(srcDir)].filter(
+    (f) =>
+      !f.endsWith('.test.ts') &&
+      !f.endsWith('.d.ts') &&
+      !f.endsWith('index.ts') &&
+      !f.includes('storage/schema/migrations') &&
+      !f.includes('storage/schema/m94') // backfill migration script
+  );
+  await Promise.allSettled(files.map((f) => import(`${srcDir}/${f}`)));
+  // allSettled: import errors from files with side-effect dependencies
+  // (e.g. files that open DB connections on import) are tolerated.
+});
+```
+
+2. Decide which test shard this file belongs to. Place it in the `1-core` shard (it has no DB dependency so it fits there).
+3. Verify the file doesn't cause test failures by running `./scripts/test-daemon.sh 1-core` locally.
+
+**Acceptance criteria**
+
+- File exists at `packages/daemon/tests/unit/coverage.test.ts` (or a suitable sub-shard path).
+- Running the relevant shard with `--coverage` causes previously-invisible source files to appear in the coverage output.
+- The test itself passes (it only imports; allSettled means import errors don't fail the test).
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+## Task 1.3: Add Bun all-files coverage workaround for shared and cli packages
+
+**Agent type**: coder
+
+**Description**
+
+Apply the same Bun coverage workaround to the `shared` and `cli` packages.
+
+**Files to create**
+
+- `packages/shared/tests/coverage.test.ts`
+- `packages/cli/tests/coverage.test.ts`
+
+**Subtasks**
+
+1. Create `packages/shared/tests/coverage.test.ts` with a glob targeting `packages/shared/src/**/*.ts`, excluding `.test.ts`, `.d.ts`, and `index.ts` barrels.
+2. Create `packages/cli/tests/coverage.test.ts` with a glob targeting `packages/cli/src/**/*.ts`, excluding `.test.ts`, `.d.ts`. CLI has only 6 source files so this is straightforward.
+3. For the `cli` glob, be sure to also exclude `packages/cli/main.ts` (the bun entry point that starts the server) since importing it will attempt to bind ports.
+
+**Acceptance criteria**
+
+- Both files exist and contain a test that uses `Bun.Glob` + dynamic `import()`.
+- The tests pass when run with `bun test --coverage` in their respective packages.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+---
+
+## Task 1.4: Add `--coverage` flag to CLI test step in CI
+
+**Agent type**: coder
+
+**Description**
+
+The CLI test step in `.github/workflows/main.yml` currently runs `bun test` with no `--coverage` flag, so CLI code is never uploaded to Coveralls. Adding coverage + a Coveralls upload step will include CLI in the aggregate.
+
+**Files to modify**
+
+- `.github/workflows/main.yml`
+
+**Subtasks**
+
+1. In the `test-cli` job, change the run command from:
+   ```yaml
+   run: bun test
+   ```
+   to:
+   ```yaml
+   run: bun test --coverage --coverage-reporter=lcov --coverage-dir=coverage
+   ```
+2. Add a "Fix coverage paths for monorepo" step (same pattern as the web step):
+   ```yaml
+   - name: Fix coverage paths for monorepo
+     run: sed -i 's|^SF:src/|SF:packages/cli/src/|g' packages/cli/coverage/lcov.info
+   ```
+3. Add a Coveralls parallel upload step with `flag-name: cli` (unique, not used by any existing upload).
+4. Add `test-cli` to the `needs` list of the `coveralls-finalize` job.
+5. Verify the `coveralls-finalize` job still has all the flag-names it needs to finalize.
+
+**Acceptance criteria**
+
+- The `test-cli` job in CI produces an `lcov.info` and uploads it to Coveralls with flag `cli`.
+- The `coveralls-finalize` job correctly lists `test-cli` as a dependency.
+- No existing CI jobs are broken.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Task 1.3 (CLI coverage test must exist for `bun test --coverage` to produce meaningful output)

--- a/docs/plans/improve-test-coverage/02-baseline-measurement.md
+++ b/docs/plans/improve-test-coverage/02-baseline-measurement.md
@@ -1,0 +1,63 @@
+# Milestone 02: True Baseline Measurement
+
+## Goal
+
+After milestone 01 is merged and CI has run, capture the true per-package and aggregate coverage numbers. This baseline will determine the exact gap to 80% and guide prioritization of the test-writing milestones (03-08).
+
+## Scope
+
+- Run the full test suite locally (or wait for CI to report to Coveralls).
+- Document per-package coverage percentages.
+- Identify which packages/files have the most uncovered lines, to confirm the prioritization in milestones 03–08.
+
+---
+
+## Task 2.1: Run full coverage suite and document baseline
+
+**Agent type**: general
+
+**Description**
+
+After milestone 01 is merged and a CI run completes, query Coveralls for the current coverage figures. Cross-reference with local `coverage/lcov.info` reports if needed.
+
+**Subtasks**
+
+1. Wait for milestone 01 PR to merge and CI to complete.
+2. Check the Coveralls badge / API at `https://coveralls.io/github/lsm/neokai` for the updated `covered_percent`.
+3. Run `bun run coverage` in `packages/web` locally and capture the text summary (statements, branches, functions, lines).
+4. Run `./scripts/test-daemon.sh --coverage` locally and capture the per-shard coverage output.
+5. Produce a simple table in this document (or a separate markdown) listing per-package coverage percentages and the delta to 80%.
+
+**Acceptance criteria**
+
+- A clear table exists showing current coverage% per package and the gap to 80%.
+- The aggregate Coveralls figure after infrastructure changes is documented.
+- This data is used to adjust priorities for milestones 03–08 if necessary (e.g., if one package is already at 75%, less effort is needed there).
+
+**Depends on**: Milestone 01 all tasks merged and CI passing.
+
+---
+
+## Task 2.2: Triage and adjust priorities for milestones 03-08
+
+**Agent type**: general
+
+**Description**
+
+Review the baseline numbers and confirm or adjust the file prioritization in milestones 03-08. Some assumptions in the plan (e.g. which files contribute the most uncovered lines) may shift once all files are visible to coverage tools.
+
+**Subtasks**
+
+1. Sort uncovered files by line count across all packages.
+2. Verify the largest contributors match the files targeted in milestones 03-08.
+3. If any unexpected files show up (e.g. a large file that was previously invisible), add them to the appropriate milestone's task list.
+4. Estimate whether the planned test work in milestones 03-08 is sufficient to reach 80% or if additional files need to be covered.
+5. Document any adjustments as notes at the top of the affected milestone files.
+
+**Acceptance criteria**
+
+- Milestones 03-08 have been reviewed against the actual baseline data.
+- Any high-impact uncovered files not already in the plan have been added to the relevant milestone.
+- A rough projection (e.g., "+15% from web component tests, +8% from daemon repo tests...") confirms the 80% target is achievable with the planned scope.
+
+**Depends on**: Task 2.1

--- a/docs/plans/improve-test-coverage/03-web-lib-store-tests.md
+++ b/docs/plans/improve-test-coverage/03-web-lib-store-tests.md
@@ -1,0 +1,136 @@
+# Milestone 03: Web — Lib and Store Tests
+
+## Goal
+
+Write tests for the major uncovered lib and store files in `packages/web/src/lib/`. These are pure TypeScript modules (no JSX), making them the most straightforward web tests to write. The largest is `room-store.ts` (1,396 lines), which is partially covered by existing tests but has significant uncovered paths.
+
+## Scope
+
+Target files (all in `packages/web/src/lib/`):
+
+| File | Lines | Priority |
+|------|-------|----------|
+| `room-store.ts` | 1,396 | High — but partially covered; focus on gaps |
+| `lobby-store.ts` | 258 | High |
+| `parse-group-message.ts` | 100 | Medium |
+| `errors.ts` | 46 | Low |
+| `role-colors.ts` | 21 | Low |
+| `recent-paths.ts` | 61 | Medium |
+| `task-constants.ts` | 29 | Low |
+| `space-constants.ts` | 17 | Low |
+
+---
+
+## Task 3.1: Audit existing room-store tests and add coverage for uncovered paths
+
+**Agent type**: coder
+
+**Description**
+
+`room-store.ts` (1,396 lines) already has multiple test files under `packages/web/src/lib/__tests__/` (e.g. `room-store-session-events.test.ts`, `room-store-create-session.test.ts`, `room-store-computed-signals.test.ts`, etc.). The goal is to audit coverage gaps and add tests for paths not yet covered.
+
+**Files to read first**
+
+- `packages/web/src/lib/room-store.ts`
+- All existing `room-store-*.test.ts` files in `packages/web/src/lib/__tests__/`
+
+**Files to modify or create**
+
+- Add new test cases to the most appropriate existing `room-store-*.test.ts` file, OR
+- Create `packages/web/src/lib/__tests__/room-store-missing-coverage.test.ts` for new scenarios.
+
+**Subtasks**
+
+1. Read `room-store.ts` to identify exported functions and state machine branches not covered by existing tests.
+2. For each uncovered branch (look for error paths, edge cases in event handling, optional parameter branches), write a focused test.
+3. Follow the existing test patterns: use `createMinimalDb()` from helpers, mock signals with `@preact/signals`, mock the `connection-manager`.
+4. Aim for at least 70% line coverage of `room-store.ts` (from the baseline measurement).
+5. Run `bun run coverage` in `packages/web` and verify coverage of `room-store.ts` has increased.
+
+**Acceptance criteria**
+
+- New tests cover previously-uncovered branches in `room-store.ts`.
+- All new tests pass with `bun run coverage`.
+- No regressions in existing room-store tests.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Milestone 01 (vitest `coverage.include` must be in place to measure accurately), Milestone 02 (baseline data).
+
+---
+
+## Task 3.2: Write tests for lobby-store.ts
+
+**Agent type**: coder
+
+**Description**
+
+`lobby-store.ts` (258 lines) is completely untested. It manages the lobby state, session listing, and connection state for unauthenticated/pre-room views.
+
+**Files to read first**
+
+- `packages/web/src/lib/lobby-store.ts`
+- `packages/web/src/lib/__tests__/global-store.test.ts` (for store testing patterns)
+- `packages/web/vitest.setup.ts`
+
+**Files to create**
+
+- `packages/web/src/lib/__tests__/lobby-store.test.ts`
+
+**Subtasks**
+
+1. Read `lobby-store.ts` to understand its exports, state shape, and side effects.
+2. Mock any external dependencies (e.g., `connection-manager`, `api-helpers`) using `vi.mock()`.
+3. Write tests for: initial state, state transitions, any exported actions/methods.
+4. Aim for at least 70% line coverage of `lobby-store.ts`.
+5. Run `bun run coverage` and verify the new file appears in coverage output.
+
+**Acceptance criteria**
+
+- `packages/web/src/lib/__tests__/lobby-store.test.ts` exists and passes.
+- Coverage of `lobby-store.ts` is at least 70%.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Milestone 01.
+
+---
+
+## Task 3.3: Write tests for parse-group-message.ts, errors.ts, role-colors.ts, recent-paths.ts, and constants files
+
+**Agent type**: coder
+
+**Description**
+
+These are small, mostly-pure utility files that should be quick to test comprehensively.
+
+**Files to read first**
+
+- `packages/web/src/lib/parse-group-message.ts`
+- `packages/web/src/lib/errors.ts`
+- `packages/web/src/lib/role-colors.ts`
+- `packages/web/src/lib/recent-paths.ts`
+- `packages/web/src/lib/task-constants.ts`
+- `packages/web/src/lib/space-constants.ts`
+
+**Files to create**
+
+- `packages/web/src/lib/__tests__/parse-group-message.test.ts`
+- `packages/web/src/lib/__tests__/errors.test.ts` (or add to existing `aaa-errors.test.ts` if appropriate)
+- `packages/web/src/lib/__tests__/role-colors.test.ts`
+- `packages/web/src/lib/__tests__/recent-paths.test.ts`
+
+**Subtasks**
+
+1. For `parse-group-message.ts`: test with various input shapes (empty, single message, grouped messages, edge cases like undefined sender).
+2. For `errors.ts`: test error type guards, error constructors, and any classification helpers.
+3. For `role-colors.ts`: test that each role returns a valid CSS class string; test the default/fallback case.
+4. For `recent-paths.ts`: test path recording, deduplication, and retrieval.
+5. For constants files (`task-constants.ts`, `space-constants.ts`): since these are pure data, a single test that imports and asserts key constant values is sufficient to get them into coverage.
+6. Aim for 90%+ coverage of each file (they are simple enough).
+
+**Acceptance criteria**
+
+- All test files exist and pass.
+- Each target file shows at least 80% line coverage in the vitest report.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Milestone 01.

--- a/docs/plans/improve-test-coverage/04-web-component-tests.md
+++ b/docs/plans/improve-test-coverage/04-web-component-tests.md
@@ -1,0 +1,227 @@
+# Milestone 04: Web — Component Tests
+
+## Goal
+
+Write tests for the highest-impact untested React/Preact components in `packages/web/src/components/`. Prioritized by line count, these components collectively account for thousands of uncovered lines. Tests use `@testing-library/preact` with `happy-dom` environment.
+
+## Scope
+
+Priority components (sorted by line count):
+
+| File | Lines | Sub-area |
+|------|-------|----------|
+| `room/RoomAgents.tsx` | 1,093 | Room |
+| `room/RoomSettings.tsx` | 772 | Room |
+| `settings/FallbackModelsSettings.tsx` | 754 | Settings |
+| `room/AgentTurnBlock.tsx` | 735 | Room |
+| `MessageInput.tsx` | 677 | Top-level (partially covered) |
+| `settings/AddSkillDialog.tsx` | 349 | Settings |
+| `settings/EditSkillDialog.tsx` | 323 | Settings |
+| `WorkspaceSelector.tsx` | 304 | Top-level |
+| `room/TaskViewModelSelector.tsx` | 293 | Room |
+| `room/ReadonlySessionChat.tsx` | 199 | Room |
+| `settings/GeneralSettings.tsx` | 173 | Settings |
+| `room/HeaderReviewBar.tsx` | 126 | Room |
+| `room/RoomAgentContextStrip.tsx` | (small) | Room |
+
+---
+
+## Task 4.1: Write tests for RoomAgents.tsx
+
+**Agent type**: coder
+
+**Description**
+
+`RoomAgents.tsx` (1,093 lines) is the largest untested component. It renders the list of agents active in a room, handles agent invocation UI, and displays agent state. Heavy use of signals and store subscriptions.
+
+**Files to read first**
+
+- `packages/web/src/components/room/RoomAgents.tsx`
+- An existing room component test for patterns (e.g. `packages/web/src/components/room/__tests__/`)
+- `packages/web/vitest.setup.ts`
+
+**Files to create**
+
+- `packages/web/src/components/room/__tests__/RoomAgents.test.tsx`
+
+**Subtasks**
+
+1. Read the component to identify its props interface, signal dependencies, and conditional rendering branches.
+2. Mock all store/signal dependencies using `vi.mock()` or inline mock objects.
+3. Write render tests for: empty agents list, single agent (idle), agent running, agent error state.
+4. Write interaction tests for any click handlers (e.g., selecting an agent, invoking an agent).
+5. Do not attempt to test real database or network interactions — mock them at the signal level.
+6. Aim for at least 60% line coverage of `RoomAgents.tsx` (complex conditional rendering makes 100% impractical).
+
+**Acceptance criteria**
+
+- Test file exists and all tests pass.
+- `RoomAgents.tsx` shows at least 60% line coverage in vitest report.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Milestone 01 (vitest `coverage.include` must be set).
+
+---
+
+## Task 4.2: Write tests for AgentTurnBlock.tsx and RoomSettings.tsx
+
+**Agent type**: coder
+
+**Description**
+
+Two large room components. `AgentTurnBlock.tsx` (735 lines) renders the content of a single agent turn in the chat (tool calls, text output, approval prompts). `RoomSettings.tsx` (772 lines) is the settings panel for a room.
+
+**Files to read first**
+
+- `packages/web/src/components/room/AgentTurnBlock.tsx`
+- `packages/web/src/components/room/RoomSettings.tsx`
+- Existing room component tests for mock patterns
+
+**Files to create**
+
+- `packages/web/src/components/room/__tests__/AgentTurnBlock.test.tsx`
+- `packages/web/src/components/room/__tests__/RoomSettings.test.tsx`
+
+**Subtasks**
+
+1. For `AgentTurnBlock.tsx`:
+   - Write render tests for each turn block type: text, tool_use, tool_result, thinking.
+   - Test the approval prompt rendering (if present).
+   - Mock SDK message types from `@neokai/shared/sdk/type-guards`.
+2. For `RoomSettings.tsx`:
+   - Write render tests for the main settings view.
+   - Test form interactions (e.g. model selector, skill toggles).
+   - Mock room store signals.
+3. Aim for 60%+ line coverage on each file.
+
+**Acceptance criteria**
+
+- Both test files exist and pass.
+- Each component shows at least 60% line coverage.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Milestone 01.
+
+---
+
+## Task 4.3: Write tests for FallbackModelsSettings.tsx and settings dialogs
+
+**Agent type**: coder
+
+**Description**
+
+The settings area has several completely untested components. `FallbackModelsSettings.tsx` (754 lines) is the most complex; `AddSkillDialog.tsx` (349 lines), `EditSkillDialog.tsx` (323 lines), and `GeneralSettings.tsx` (173 lines) are secondary priorities.
+
+**Files to read first**
+
+- `packages/web/src/components/settings/FallbackModelsSettings.tsx`
+- `packages/web/src/components/settings/AddSkillDialog.tsx`
+- `packages/web/src/components/settings/EditSkillDialog.tsx`
+- `packages/web/src/components/settings/GeneralSettings.tsx`
+- Existing settings tests (e.g. any `*.test.tsx` in `components/settings/`)
+
+**Files to create**
+
+- `packages/web/src/components/settings/__tests__/FallbackModelsSettings.test.tsx`
+- `packages/web/src/components/settings/__tests__/AddSkillDialog.test.tsx`
+- `packages/web/src/components/settings/__tests__/EditSkillDialog.test.tsx`
+- `packages/web/src/components/settings/__tests__/GeneralSettings.test.tsx`
+
+**Subtasks**
+
+1. For each component, identify the props and store dependencies.
+2. Mock stores/signals at the top of each test file using `vi.mock()`.
+3. Write render tests covering the main display state and at least one user interaction per component.
+4. For `FallbackModelsSettings.tsx` specifically, test the model ordering/priority logic if it's exposed as a pure function.
+5. Aim for 50%+ line coverage on each file (settings dialogs have many conditional branches).
+
+**Acceptance criteria**
+
+- All four test files exist and pass.
+- Each file shows at least 50% line coverage.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Milestone 01.
+
+---
+
+## Task 4.4: Write tests for MessageInput.tsx, WorkspaceSelector.tsx, and TaskViewModelSelector.tsx
+
+**Agent type**: coder
+
+**Description**
+
+`MessageInput.tsx` (677 lines) is partially covered (there is an existing `MessageInput.queue-mode.test.tsx`) but has significant uncovered paths. `WorkspaceSelector.tsx` (304 lines) and `TaskViewModelSelector.tsx` (293 lines) are fully untested.
+
+**Files to read first**
+
+- `packages/web/src/components/MessageInput.tsx`
+- `packages/web/src/components/MessageInput.queue-mode.test.tsx` (existing test for context)
+- `packages/web/src/components/WorkspaceSelector.tsx`
+- `packages/web/src/components/room/TaskViewModelSelector.tsx`
+
+**Files to create or modify**
+
+- `packages/web/src/components/__tests__/MessageInput.test.tsx` (or extend existing test)
+- `packages/web/src/components/__tests__/WorkspaceSelector.test.tsx`
+- `packages/web/src/components/room/__tests__/TaskViewModelSelector.test.tsx`
+
+**Subtasks**
+
+1. For `MessageInput.tsx`:
+   - Read the existing queue-mode test to understand the mock setup.
+   - Add tests for: standard mode rendering, file attachment input, keyboard shortcuts (Enter to send, Shift+Enter for newline), empty-state disabling.
+2. For `WorkspaceSelector.tsx`:
+   - Test render with no workspaces, with one workspace selected, and with multiple workspaces.
+   - Test the selection change handler.
+3. For `TaskViewModelSelector.tsx`:
+   - Test that the component renders the current model.
+   - Test model change triggers the expected action.
+4. Aim for 65%+ line coverage on `MessageInput.tsx`, 70%+ on the others.
+
+**Acceptance criteria**
+
+- All test files exist and pass.
+- `MessageInput.tsx` shows at least 65% combined line coverage across both test files.
+- `WorkspaceSelector.tsx` and `TaskViewModelSelector.tsx` show at least 70% line coverage.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Milestone 01.
+
+---
+
+## Task 4.5: Write tests for remaining room components and small components
+
+**Agent type**: coder
+
+**Description**
+
+Cover the remaining smaller room components: `ReadonlySessionChat.tsx`, `HeaderReviewBar.tsx`, `RoomAgentContextStrip.tsx`, and `RoomContext.tsx`.
+
+**Files to read first**
+
+- `packages/web/src/components/room/ReadonlySessionChat.tsx`
+- `packages/web/src/components/room/HeaderReviewBar.tsx`
+- `packages/web/src/components/room/RoomAgentContextStrip.tsx`
+- `packages/web/src/components/room/RoomContext.tsx`
+
+**Files to create**
+
+- `packages/web/src/components/room/__tests__/ReadonlySessionChat.test.tsx`
+- `packages/web/src/components/room/__tests__/HeaderReviewBar.test.tsx`
+- `packages/web/src/components/room/__tests__/RoomAgentContextStrip.test.tsx`
+- `packages/web/src/components/room/__tests__/RoomContext.test.tsx`
+
+**Subtasks**
+
+1. For each component, write at minimum: one render test (smoke test), one test for a key conditional branch, and one test for a user interaction if any.
+2. Mock all store/signal dependencies.
+3. These are smaller files so 70%+ line coverage is achievable with 3-5 tests each.
+
+**Acceptance criteria**
+
+- All four test files exist and pass.
+- Each component shows at least 70% line coverage.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Milestone 01.

--- a/docs/plans/improve-test-coverage/05-web-hooks-utils-tests.md
+++ b/docs/plans/improve-test-coverage/05-web-hooks-utils-tests.md
@@ -1,0 +1,142 @@
+# Milestone 05: Web — Hook and Utility Tests
+
+## Goal
+
+Fill gaps in test coverage for hooks, utility modules, and space-area components that are not yet covered. The hooks directory already has good coverage (27 of 29 hooks are tested), so this milestone is primarily about the `useChatComposerController` hook and the `space/` sub-area utilities which have several untested TS files.
+
+## Scope
+
+| File | Lines | Category |
+|------|-------|----------|
+| `hooks/useChatComposerController.ts` | 153 | Hook |
+| `hooks/useSkills.ts` | 62 | Hook |
+| `components/space/visual-editor/semanticWorkflowGraph.ts` | — | Space utility |
+| `components/space/visual-editor/serialization.ts` | — | Space utility |
+| `components/space/visual-editor/layout.ts` | — | Space utility |
+| `components/space/export-import-utils.ts` | — | Space utility |
+| `components/space/gate-status.ts` | — | Space utility |
+| `components/space/workflow-templates.ts` | — | Space utility |
+| `components/sdk/tools/tool-utils.ts` | — | SDK utility |
+| `components/sdk/tools/tool-registry.ts` | — | SDK utility |
+
+---
+
+## Task 5.1: Write tests for useChatComposerController and useSkills hooks
+
+**Agent type**: coder
+
+**Description**
+
+`useChatComposerController.ts` (153 lines) is the largest untested hook. `useSkills.ts` (62 lines) is a smaller gap. All other hooks already have test files under `packages/web/src/hooks/__tests__/`.
+
+**Files to read first**
+
+- `packages/web/src/hooks/useChatComposerController.ts`
+- `packages/web/src/hooks/useSkills.ts`
+- An existing hook test for patterns (e.g. `packages/web/src/hooks/__tests__/useChatBase.test.ts`)
+
+**Files to create**
+
+- `packages/web/src/hooks/__tests__/useChatComposerController.test.ts`
+- `packages/web/src/hooks/__tests__/useSkills.test.ts`
+
+**Subtasks**
+
+1. For `useChatComposerController.ts`:
+   - Identify all external dependencies (stores, signals, other hooks) and mock them.
+   - Test the main composition logic: input handling, command detection, mention detection.
+   - Test state transitions (empty input, input with text, input with @mention).
+2. For `useSkills.ts`:
+   - Test that skills are loaded from the store.
+   - Test that the hook returns the correct shape.
+3. Use `renderHook` from `@testing-library/preact` for both hooks.
+4. Aim for 70%+ line coverage on `useChatComposerController.ts`, 80%+ on `useSkills.ts`.
+
+**Acceptance criteria**
+
+- Both test files exist and pass.
+- Line coverage targets are met.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Milestone 01.
+
+---
+
+## Task 5.2: Write tests for space visual-editor utilities
+
+**Agent type**: coder
+
+**Description**
+
+The `packages/web/src/components/space/visual-editor/` directory has several pure utility TS files with no tests: `semanticWorkflowGraph.ts`, `serialization.ts`, `layout.ts`, `nodeMetrics.ts`. These are algorithmic (graph layout, serialization) and ideal for unit testing without DOM/store mocking.
+
+**Files to read first**
+
+- `packages/web/src/components/space/visual-editor/semanticWorkflowGraph.ts`
+- `packages/web/src/components/space/visual-editor/serialization.ts`
+- `packages/web/src/components/space/visual-editor/layout.ts`
+- `packages/web/src/components/space/visual-editor/nodeMetrics.ts`
+
+**Files to create**
+
+- `packages/web/src/components/space/visual-editor/__tests__/semanticWorkflowGraph.test.ts`
+- `packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts`
+- `packages/web/src/components/space/visual-editor/__tests__/layout.test.ts`
+
+**Subtasks**
+
+1. For `semanticWorkflowGraph.ts`: test graph construction from workflow definition objects, node/edge extraction, cycle detection if present.
+2. For `serialization.ts`: test round-trip serialization (serialize then deserialize and confirm structural equality).
+3. For `layout.ts`: test that the layout function returns valid node positions (e.g., no NaN coordinates, all nodes positioned).
+4. Use fixture data from `packages/web/src/components/space/__tests__/fixtures/` if available (the `builtInTemplateWorkflows.ts` fixture may be useful).
+5. These are pure functions — no mocking required.
+
+**Acceptance criteria**
+
+- All test files exist and pass.
+- Each target file shows at least 70% line coverage.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Milestone 01.
+
+---
+
+## Task 5.3: Write tests for space utility files and SDK tool utilities
+
+**Agent type**: coder
+
+**Description**
+
+Cover the remaining small utility files: `export-import-utils.ts`, `gate-status.ts`, `workflow-templates.ts`, `thread/space-task-thread-events.ts`, and SDK tool utilities `tool-utils.ts` and `tool-registry.ts`.
+
+**Files to read first**
+
+- `packages/web/src/components/space/export-import-utils.ts`
+- `packages/web/src/components/space/gate-status.ts`
+- `packages/web/src/components/space/workflow-templates.ts`
+- `packages/web/src/components/sdk/tools/tool-utils.ts`
+- `packages/web/src/components/sdk/tools/tool-registry.ts`
+
+**Files to create**
+
+- `packages/web/src/components/space/__tests__/export-import-utils.test.ts`
+- `packages/web/src/components/space/__tests__/gate-status.test.ts`
+- `packages/web/src/components/space/__tests__/workflow-templates.test.ts`
+- `packages/web/src/components/sdk/tools/__tests__/tool-utils.test.ts`
+- `packages/web/src/components/sdk/tools/__tests__/tool-registry.test.ts`
+
+**Subtasks**
+
+1. For `export-import-utils.ts`: test export serialization and import parsing with sample space data.
+2. For `gate-status.ts`: test status classification functions with each possible status value.
+3. For `workflow-templates.ts`: test that template generation returns the expected workflow shape.
+4. For `tool-utils.ts` and `tool-registry.ts`: test tool registration, lookup by name, and any type-guard utilities.
+5. These are all pure utility modules — mock minimally.
+
+**Acceptance criteria**
+
+- All test files exist and pass.
+- Each file shows at least 75% line coverage.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Milestone 01.

--- a/docs/plans/improve-test-coverage/06-daemon-repository-tests.md
+++ b/docs/plans/improve-test-coverage/06-daemon-repository-tests.md
@@ -1,0 +1,147 @@
+# Milestone 06: Daemon — Repository Tests
+
+## Goal
+
+Write unit tests for the 4 daemon storage repositories that currently have no test files. These use the established repository testing pattern: create an in-memory SQLite database with `createSpaceTables()` (or the full schema), instantiate the repository, and exercise CRUD methods.
+
+## Background: Repository Testing Pattern
+
+The existing repository tests in `packages/daemon/tests/unit/4-space-storage/storage/` follow this pattern:
+
+```typescript
+import { Database } from 'bun:sqlite';
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { createSpaceTables } from '../../helpers/space-test-db';
+import { SomeRepository } from '../../../../src/storage/repositories/some-repository';
+
+let db: Database;
+let repo: SomeRepository;
+
+beforeEach(() => {
+  db = new Database(':memory:');
+  createSpaceTables(db);
+  repo = new SomeRepository(db);
+});
+```
+
+Note: If `createSpaceTables` doesn't include the required tables for a specific repository, add the missing table DDL inline in the test file rather than modifying `space-test-db.ts` (to avoid side effects on other tests).
+
+## Scope
+
+| File | Lines | Shard |
+|------|-------|-------|
+| `storage/repositories/space-worktree-repository.ts` | 134 | 4-space-storage |
+| `storage/repositories/skill-repository.ts` | 196 | 4-space-storage |
+| `storage/repositories/space-task-report-result-repository.ts` | 130 | 4-space-storage |
+| `storage/repositories/workspace-history-repository.ts` | 71 | 4-space-storage |
+
+---
+
+## Task 6.1: Write tests for space-worktree-repository.ts
+
+**Agent type**: coder
+
+**Description**
+
+`space-worktree-repository.ts` (134 lines) manages workspace-level git worktree records associated with spaces.
+
+**Files to read first**
+
+- `packages/daemon/src/storage/repositories/space-worktree-repository.ts`
+- `packages/daemon/tests/unit/4-space-storage/storage/space-repository.test.ts` (for DB setup patterns)
+- `packages/daemon/tests/unit/helpers/space-test-db.ts` (to check if `space_worktrees` table is defined)
+
+**Files to create**
+
+- `packages/daemon/tests/unit/4-space-storage/storage/space-worktree-repository.test.ts`
+
+**Subtasks**
+
+1. Read the repository to identify all public methods.
+2. Check if `space-test-db.ts` defines the `space_worktrees` table. If not, add the DDL inline in the test's `beforeEach`.
+3. Write tests for: create, findById, findBySpaceId, update, delete (all CRUD methods present).
+4. Test edge cases: not found returns null/undefined, duplicate insert throws, etc.
+5. Run `./scripts/test-daemon.sh 4-space-storage` to confirm tests pass.
+
+**Acceptance criteria**
+
+- Test file exists at `packages/daemon/tests/unit/4-space-storage/storage/space-worktree-repository.test.ts`.
+- All CRUD methods have at least one test each.
+- Repository shows at least 80% line coverage.
+- Tests pass in the shard runner.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Milestone 01 (Bun all-files workaround so the repository appears in coverage).
+
+---
+
+## Task 6.2: Write tests for skill-repository.ts
+
+**Agent type**: coder
+
+**Description**
+
+`skill-repository.ts` (196 lines) manages skill definitions (user-configured agent capabilities).
+
+**Files to read first**
+
+- `packages/daemon/src/storage/repositories/skill-repository.ts`
+- `packages/daemon/tests/unit/4-space-storage/storage/settings-repository.test.ts` (similar shape)
+
+**Files to create**
+
+- `packages/daemon/tests/unit/4-space-storage/storage/skill-repository.test.ts`
+
+**Subtasks**
+
+1. Read the repository to understand the `skills` table schema and all public methods.
+2. Set up the in-memory DB with the skills table DDL (check if `createSpaceTables` includes it; if not, add inline).
+3. Write tests for: create skill, find by id, find all, update, delete.
+4. Test any query methods (e.g., find by room_id, find enabled skills).
+5. Test the uniqueness/constraint behavior if applicable.
+
+**Acceptance criteria**
+
+- Test file exists and passes in the 4-space-storage shard.
+- `skill-repository.ts` shows at least 80% line coverage.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Milestone 01.
+
+---
+
+## Task 6.3: Write tests for space-task-report-result-repository.ts and workspace-history-repository.ts
+
+**Agent type**: coder
+
+**Description**
+
+Two smaller repositories. `space-task-report-result-repository.ts` (130 lines) stores results of automated task report evaluations. `workspace-history-repository.ts` (71 lines) tracks workspace access history.
+
+**Files to read first**
+
+- `packages/daemon/src/storage/repositories/space-task-report-result-repository.ts`
+- `packages/daemon/src/storage/repositories/workspace-history-repository.ts`
+
+**Files to create**
+
+- `packages/daemon/tests/unit/4-space-storage/storage/space-task-report-result-repository.test.ts`
+
+  Note: There is already a `space-task-report-result-repository_test.ts` (with underscore-test suffix, non-standard) — check if it contains tests or is a stub, and either extend it or create the standard-named file.
+
+- `packages/daemon/tests/unit/4-space-storage/storage/workspace-history-repository.test.ts`
+
+**Subtasks**
+
+1. Check the existing `space-task-report-result-repository_test.ts` — if it has meaningful tests, read it for context; if it is empty/stub, create a new properly-named file.
+2. For `space-task-report-result-repository.ts`: test create, findByTaskId, and any aggregation methods.
+3. For `workspace-history-repository.ts`: test adding an entry, retrieving history, and any limit/order behavior.
+4. Both repositories are small — aim for 90%+ coverage.
+
+**Acceptance criteria**
+
+- Both repositories have tests that pass in the shard runner.
+- Each shows at least 85% line coverage.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Milestone 01.

--- a/docs/plans/improve-test-coverage/07-daemon-core-service-tests.md
+++ b/docs/plans/improve-test-coverage/07-daemon-core-service-tests.md
@@ -1,0 +1,209 @@
+# Milestone 07: Daemon — Core Service Tests
+
+## Goal
+
+Write unit tests for the major untested daemon service files. These are more complex than repositories (they have side effects, external dependencies, and rich business logic) and require careful mocking. Focus on the files with the highest line count and broadest business impact.
+
+## Scope
+
+| File | Lines | Complexity | Shard |
+|------|-------|------------|-------|
+| `lib/rpc-handlers/index.ts` | 805 | High | 2-handlers |
+| `lib/daemon-hub.ts` | 633 | High | 1-core |
+| `lib/github/github-service.ts` | 652 | Medium | 2-handlers |
+| `lib/providers/registry.ts` | 268 | Medium | 1-core |
+| `lib/providers/factory.ts` | 108 | Medium | 1-core |
+| `lib/agent/coordinator/*.ts` | ~250 total | Low-Medium | 1-core |
+| `lib/lobby/index.ts` | 20 | Low | 2-handlers |
+| `lib/short-id-allocator.ts` | — | Low | 1-core |
+
+---
+
+## Task 7.1: Write tests for rpc-handlers/index.ts
+
+**Agent type**: coder
+
+**Description**
+
+`lib/rpc-handlers/index.ts` (805 lines) is the main RPC dispatch layer — it maps incoming WebSocket/HTTP messages to handler functions. This file is in shard `2-handlers`. The existing `neo-handlers.test.ts` covers neo-specific handlers; this task covers the non-neo handlers.
+
+**Files to read first**
+
+- `packages/daemon/src/lib/rpc-handlers/index.ts`
+- An existing handler test in `packages/daemon/tests/unit/2-handlers/rpc-handlers/` for patterns
+- `packages/daemon/tests/unit/setup.ts` for the SDK mock setup
+
+**Files to create**
+
+- `packages/daemon/tests/unit/2-handlers/rpc-handlers/rpc-handler-dispatch.test.ts`
+
+**Subtasks**
+
+1. Read `rpc-handlers/index.ts` to identify the handler registration pattern and the set of RPC method names handled.
+2. Mock the dependencies: room manager, session manager, auth, and any DB access.
+3. Write tests for the most frequently called RPC methods (e.g., `createSession`, `sendMessage`, `getRoom`, `updateSettings`).
+4. Test error handling paths: unknown method returns error, malformed payload returns validation error.
+5. Test authentication/authorization checks if present.
+6. Aim for 50%+ line coverage (the file is large; focus on the highest-traffic paths).
+
+**Acceptance criteria**
+
+- Test file exists and passes in the 2-handlers shard.
+- `rpc-handlers/index.ts` shows at least 50% line coverage.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Milestone 01 (Bun all-files workaround so the file is visible in coverage).
+
+---
+
+## Task 7.2: Write tests for daemon-hub.ts
+
+**Agent type**: coder
+
+**Description**
+
+`lib/daemon-hub.ts` (633 lines) is the central hub that coordinates between rooms, sessions, and the agent lifecycle. It has complex lifecycle management. Belongs in shard `1-core`.
+
+**Files to read first**
+
+- `packages/daemon/src/lib/daemon-hub.ts`
+- `packages/daemon/tests/unit/1-core/core/` for existing hub-adjacent tests
+- `packages/daemon/tests/unit/setup.ts`
+
+**Files to create**
+
+- `packages/daemon/tests/unit/1-core/core/daemon-hub.test.ts`
+
+**Subtasks**
+
+1. Read `daemon-hub.ts` to identify the public API surface: initialization, room registration, session routing, event dispatch.
+2. Mock the database, room manager, and agent SDK.
+3. Write tests for: hub initialization, room creation routing, session handoff, cleanup on shutdown.
+4. Test event emission/handling if the hub uses an event bus.
+5. Given the complexity, aim for 40%+ line coverage with focus on the most critical paths.
+
+**Acceptance criteria**
+
+- Test file exists and passes in the 1-core shard.
+- `daemon-hub.ts` shows at least 40% line coverage.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Milestone 01.
+
+---
+
+## Task 7.3: Write tests for github-service.ts
+
+**Agent type**: coder
+
+**Description**
+
+`lib/github/github-service.ts` (652 lines) handles GitHub API interactions: OAuth token management, repo operations, PR creation, and webhook processing. Shard `2-handlers`.
+
+**Files to read first**
+
+- `packages/daemon/src/lib/github/github-service.ts`
+- `packages/daemon/tests/unit/2-handlers/github/` (if any existing github tests)
+
+**Files to create**
+
+- `packages/daemon/tests/unit/2-handlers/github/github-service.test.ts`
+
+**Subtasks**
+
+1. Read `github-service.ts` to identify public methods and the HTTP client it uses.
+2. Mock the HTTP client (fetch or a GitHub SDK) to return fixture responses.
+3. Write tests for: OAuth token exchange, `getRepo`, `createPR`, `listPRs`, `getCommit`.
+4. Test error handling: 401 returns auth error, 404 returns not-found error, rate limit returns retry-able error.
+5. Aim for 60%+ line coverage.
+
+**Acceptance criteria**
+
+- Test file exists and passes.
+- `github-service.ts` shows at least 60% line coverage.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Milestone 01.
+
+---
+
+## Task 7.4: Write tests for providers/registry.ts and providers/factory.ts
+
+**Agent type**: coder
+
+**Description**
+
+`lib/providers/registry.ts` (268 lines) manages the provider registry (LLM provider registrations). `lib/providers/factory.ts` (108 lines) creates provider instances from config. Both belong in shard `1-core`. Note: `setup.ts` already calls `resetProviderRegistry()` before each test run, so the registry is reset between test files.
+
+**Files to read first**
+
+- `packages/daemon/src/lib/providers/registry.ts`
+- `packages/daemon/src/lib/providers/factory.ts`
+- `packages/daemon/tests/unit/1-core/providers/` (check existing provider tests)
+- `packages/daemon/tests/unit/setup.ts` (note the `resetProviderRegistry()` call)
+
+**Files to create**
+
+- `packages/daemon/tests/unit/1-core/providers/registry.test.ts`
+- `packages/daemon/tests/unit/1-core/providers/factory.test.ts`
+
+**Subtasks**
+
+1. For `registry.ts`:
+   - Test provider registration (happy path).
+   - Test duplicate registration behavior.
+   - Test `getProvider` with known and unknown provider names.
+   - Test `resetProviderRegistry` clears all registrations.
+2. For `factory.ts`:
+   - Test that `createProvider` returns the expected provider instance given valid config.
+   - Test that unsupported provider type throws a descriptive error.
+3. Mock the actual provider implementations (just register mock objects).
+
+**Acceptance criteria**
+
+- Both test files exist and pass.
+- `registry.ts` shows at least 75% line coverage; `factory.ts` shows at least 80%.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Milestone 01.
+
+---
+
+## Task 7.5: Write tests for coordinator agent files and short-id-allocator
+
+**Agent type**: coder
+
+**Description**
+
+The `lib/agent/coordinator/` directory contains 7 small files (~30-60 lines each) that define specialized coordinator agent behaviors (coder, reviewer, verifier, debugger, tester, vcs, coordinator). These are small enough to test comprehensively. Also cover `lib/short-id-allocator.ts`.
+
+**Files to read first**
+
+- `packages/daemon/src/lib/agent/coordinator/coordinator.ts`
+- `packages/daemon/src/lib/agent/coordinator/coder.ts`
+- `packages/daemon/src/lib/agent/coordinator/reviewer.ts`
+- `packages/daemon/src/lib/agent/coordinator/verifier.ts`
+- `packages/daemon/src/lib/short-id-allocator.ts`
+- `packages/daemon/tests/unit/1-core/agent/coordinator-agents.test.ts` (existing test — check what is already covered)
+
+**Files to create or modify**
+
+- Extend `packages/daemon/tests/unit/1-core/agent/coordinator-agents.test.ts` OR
+- Create `packages/daemon/tests/unit/1-core/agent/coordinator-agents-extended.test.ts`
+- Create `packages/daemon/tests/unit/1-core/lib/short-id-allocator.test.ts`
+
+**Subtasks**
+
+1. Check the existing `coordinator-agents.test.ts` to see which coordinator types are already covered.
+2. Add tests for any uncovered coordinator types (coder, reviewer, verifier, debugger, tester, vcs).
+3. For `short-id-allocator.ts`: test allocation uniqueness, sequential generation, and reset behavior.
+4. Mock the Claude agent SDK (already mocked by `setup.ts`).
+
+**Acceptance criteria**
+
+- All coordinator files show at least 80% line coverage.
+- `short-id-allocator.ts` shows at least 90% line coverage.
+- All new/modified tests pass in the 1-core shard.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Milestone 01.

--- a/docs/plans/improve-test-coverage/08-shared-cli-ui-coverage.md
+++ b/docs/plans/improve-test-coverage/08-shared-cli-ui-coverage.md
@@ -1,0 +1,161 @@
+# Milestone 08: Shared, CLI, and UI Coverage Expansion
+
+## Goal
+
+Fill coverage gaps in the `shared`, `cli`, and `ui` packages. After the Bun all-files workaround is in place (milestone 01), previously-invisible files will appear at 0%. This milestone targets the most impactful uncovered shared modules and ensures CLI tests upload coverage to Coveralls.
+
+## Scope
+
+| Package | Key uncovered files | Notes |
+|---------|---------------------|-------|
+| shared | `message-hub/router.ts` (431 lines), `api.ts` (951 lines), `provider/types.ts` | Large type/utility files |
+| shared | `message-hub/channel-manager.ts`, `message-hub/types.ts` | Message hub gaps |
+| cli | `src/dev-server.ts`, `src/prod-server.ts`, `src/prod-server-embedded.ts` | Server entry points (hard to unit test) |
+| cli | `src/cli-utils.ts`, `src/skill-utils.ts` | Already tested — verify coverage |
+| ui | (no Coveralls upload currently) | Optional: add vitest coverage + upload |
+
+---
+
+## Task 8.1: Write tests for shared message-hub router and channel-manager
+
+**Agent type**: coder
+
+**Description**
+
+`message-hub/router.ts` (431 lines) and `message-hub/channel-manager.ts` have partial test coverage from existing tests, but the Bun all-files workaround will expose more gaps. This task targets the uncovered paths.
+
+**Files to read first**
+
+- `packages/shared/src/message-hub/router.ts`
+- `packages/shared/src/message-hub/channel-manager.ts`
+- `packages/shared/tests/message-hub-router.test.ts` (existing tests)
+- `packages/shared/tests/message-hub.test.ts`
+
+**Files to create or modify**
+
+- Extend `packages/shared/tests/message-hub-router.test.ts` with additional test cases, OR
+- Create `packages/shared/tests/message-hub-router-extended.test.ts`
+
+**Subtasks**
+
+1. Run `./scripts/test-daemon.sh 0-shared --coverage` to get the current coverage of `router.ts` and `channel-manager.ts` after milestone 01 is merged.
+2. Identify uncovered branches (error paths, edge cases in message routing, unsubscribe paths).
+3. Write focused tests for each uncovered branch.
+4. For `channel-manager.ts`: test channel creation, subscription management, and cleanup on disconnect.
+5. Aim for 75%+ line coverage on both files.
+
+**Acceptance criteria**
+
+- New tests cover previously-uncovered branches.
+- Both files show at least 75% line coverage.
+- All tests pass in the 0-shared shard.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Milestone 01 (Bun workaround for shared package).
+
+---
+
+## Task 8.2: Write tests for shared provider module and API helpers
+
+**Agent type**: coder
+
+**Description**
+
+`packages/shared/src/provider/` contains `index.ts`, `types.ts`, and `auth-types.ts`. The `api.ts` (951 lines) is a large file of type definitions and API schemas. These are mostly type-level files, but the provider logic files have testable behavior.
+
+**Files to read first**
+
+- `packages/shared/src/provider/index.ts`
+- `packages/shared/src/provider/types.ts`
+- `packages/shared/src/provider/auth-types.ts`
+- `packages/shared/src/api.ts`
+
+**Files to create**
+
+- `packages/shared/tests/provider.test.ts`
+
+**Subtasks**
+
+1. For `provider/index.ts`: test any exported factory functions or type guards.
+2. For `provider/types.ts` and `auth-types.ts`: these are primarily type definitions; create tests that import the types and validate any runtime type guard functions.
+3. For `api.ts`: if it contains only type definitions with no runtime code, a single import test gets it into coverage. If it contains validators or parsers, test those.
+4. Note: Pure type declaration files (`.d.ts` files) don't count toward coverage — only `.ts` files with runtime code need testing.
+
+**Acceptance criteria**
+
+- `packages/shared/tests/provider.test.ts` exists and passes.
+- Provider source files show at least 60% line coverage (accounting for type-only files).
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Milestone 01.
+
+---
+
+## Task 8.3: Add coverage for CLI server files
+
+**Agent type**: coder
+
+**Description**
+
+The CLI has 6 source files. `cli-utils.ts` and `skill-utils.ts` already have tests (confirmed in milestone 01 setup). The server files (`dev-server.ts`, `prod-server.ts`, `prod-server-embedded.ts`) start HTTP listeners and are not directly unit-testable, but logic extracted from them (like config validation, route setup) can be tested.
+
+**Files to read first**
+
+- `packages/cli/src/dev-server.ts`
+- `packages/cli/src/prod-server.ts`
+- `packages/cli/src/prod-server-embedded.ts`
+- `packages/cli/tests/cli-utils.test.ts` (for existing test patterns)
+
+**Files to create**
+
+- `packages/cli/tests/server-config.test.ts`
+
+**Subtasks**
+
+1. Read the three server files to identify any pure functions or configurable logic (e.g., middleware setup, port configuration, route handlers without side effects).
+2. If there are extractable pure functions (e.g., `buildServerConfig`, `resolvePort`), test those.
+3. If the server files are purely side-effectful entry points with no testable units, document this and rely on the `coverage.test.ts` workaround (from task 1.3) to at least register them at 0% rather than invisible.
+4. Focus testing effort on any logic that is extractable; do not attempt to spin up real servers.
+
+**Acceptance criteria**
+
+- Either `server-config.test.ts` exists with meaningful tests, OR a documented decision is made that the server files are integration-only (not worth unit testing).
+- CLI source files appear in coverage output (even at 0%) thanks to task 1.3.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Task 1.3 (CLI coverage workaround), Task 1.4 (CLI coverage in CI).
+
+---
+
+## Task 8.4: (Optional) Add UI package to CI coverage uploads
+
+**Agent type**: coder
+
+**Description**
+
+The `ui` package has vitest configured and 34 test files, but its coverage is never uploaded to Coveralls. Adding a Coveralls upload step for the UI package will increase the aggregate coverage figure.
+
+This task is marked optional because the UI package may already have good coverage (34 tests / 64 source files). Evaluate after milestone 02 baseline data is available.
+
+**Files to modify**
+
+- `.github/workflows/main.yml`
+- `packages/ui/vitest.config.ts`
+
+**Subtasks**
+
+1. Check if `packages/ui/vitest.config.ts` already has `coverage.include`. If not, add it.
+2. Add a `test-ui` job to `.github/workflows/main.yml` similar to the `test-web` job:
+   - Run `vitest run --coverage` in `packages/ui`
+   - Fix coverage paths with `sed`
+   - Upload to Coveralls with `flag-name: ui`
+3. Add `test-ui` to the `needs` list of `coveralls-finalize`.
+4. Add `test-ui` to the `success/skipped` check in the final `all-tests-passed` job.
+
+**Acceptance criteria**
+
+- UI coverage is uploaded to Coveralls on each push to `dev`.
+- The `coveralls-finalize` job includes the UI flag.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Milestone 01 (vitest `coverage.include` pattern established), Milestone 02 (confirm UI coverage is worth including).

--- a/docs/plans/improve-test-coverage/09-ci-gate-update.md
+++ b/docs/plans/improve-test-coverage/09-ci-gate-update.md
@@ -1,0 +1,77 @@
+# Milestone 09: CI Gate Update
+
+## Goal
+
+Raise the `MIN_COVERAGE` threshold in `.github/workflows/main.yml` from 30 to 80, enforcing the target permanently in CI. This milestone must be the final step — executed only after aggregate coverage is confirmed to be at or above 80%.
+
+## Prerequisites
+
+Before raising the gate:
+
+1. All milestones 01-08 are merged to `dev`.
+2. A CI run has completed and Coveralls reports aggregate coverage >= 80%.
+3. The Coveralls dashboard at `https://coveralls.io/github/lsm/neokai` shows the current `covered_percent`.
+
+---
+
+## Task 9.1: Verify coverage is at 80% before raising the gate
+
+**Agent type**: general
+
+**Description**
+
+Query the Coveralls API (or dashboard) to confirm the actual coverage is at or above 80% before modifying the CI gate. Raising the gate prematurely would break CI for all PRs.
+
+**Subtasks**
+
+1. Check the Coveralls badge URL: `https://coveralls.io/repos/github/lsm/neokai/badge.svg`
+2. Or query the API: `curl https://coveralls.io/github/lsm/neokai.json | jq .covered_percent`
+3. If coverage is below 80%, identify which milestones are still pending and do not proceed to task 9.2.
+4. If coverage is at or above 80%, document the exact percentage and proceed.
+
+**Acceptance criteria**
+
+- A documented confirmation that Coveralls reports >= 80% aggregate coverage.
+- This confirmation is referenced in the PR description for task 9.2.
+
+**Depends on**: All milestones 01-08 merged and CI passing.
+
+---
+
+## Task 9.2: Raise MIN_COVERAGE gate to 80 in CI
+
+**Agent type**: coder
+
+**Description**
+
+Update the coverage gate threshold and adjust the regression guard if needed.
+
+**Files to modify**
+
+- `.github/workflows/main.yml`
+
+**Subtasks**
+
+1. Change line `MIN_COVERAGE=30` to `MIN_COVERAGE=80` in the `coverage-gate` job.
+2. Review the `MAX_REGRESSION=-2` setting. With 80% as the baseline, a 2% regression allowance (-2%) is reasonable. Keep it at -2 unless the team wants a tighter guard.
+3. Update any inline comments near `MIN_COVERAGE` to reflect the new target.
+4. Optionally: add a comment explaining when this was raised and the rationale.
+
+**Example diff:**
+
+```yaml
+- MIN_COVERAGE=30
++ MIN_COVERAGE=80
+```
+
+5. Commit and create a PR against `dev`.
+6. Wait for CI to confirm the gate passes (it will query Coveralls for the current coverage; as long as coverage is at 80%+, the gate will pass).
+
+**Acceptance criteria**
+
+- `MIN_COVERAGE=80` is set in `.github/workflows/main.yml`.
+- The CI `coverage-gate` job passes on the `dev` branch after this change.
+- No other CI jobs are broken.
+- Changes must be on a feature branch with a GitHub PR created via `gh pr create`.
+
+**Depends on**: Task 9.1 (coverage confirmed at 80%+).


### PR DESCRIPTION
## Summary

- Multi-file plan covering 9 milestones and ~28 tasks to bring aggregate Coveralls coverage from the current 30% enforced gate to 80%
- Addresses two root causes: (1) structural gaps in coverage tooling (vitest missing `coverage.include`, Bun missing all-files workaround) and (2) ~56 daemon and ~38 web component files with no tests
- Sequenced so infrastructure fixes come first, then test writing, then CI gate raise last

## Plan Files

- `docs/plans/improve-test-coverage/00-overview.md` — phases, milestones, dependencies
- `docs/plans/improve-test-coverage/01-coverage-infrastructure.md` — Fix vitest config, add Bun all-files workaround, wire CLI into coverage uploads
- `docs/plans/improve-test-coverage/02-baseline-measurement.md` — Measure true baseline after infra changes
- `docs/plans/improve-test-coverage/03-web-lib-store-tests.md` — Tests for room-store, lobby-store, and utility libs
- `docs/plans/improve-test-coverage/04-web-component-tests.md` — Tests for RoomAgents, AgentTurnBlock, RoomSettings, FallbackModelsSettings, MessageInput, etc.
- `docs/plans/improve-test-coverage/05-web-hooks-utils-tests.md` — Tests for hooks and space/sdk utilities
- `docs/plans/improve-test-coverage/06-daemon-repository-tests.md` — Tests for 4 untested repositories
- `docs/plans/improve-test-coverage/07-daemon-core-service-tests.md` — Tests for rpc-handlers, daemon-hub, github-service, providers
- `docs/plans/improve-test-coverage/08-shared-cli-ui-coverage.md` — Tests for shared message-hub, CLI server logic, optional UI upload
- `docs/plans/improve-test-coverage/09-ci-gate-update.md` — Raise MIN_COVERAGE from 30 to 80

## Test plan

- [ ] Review each milestone file for accuracy against the actual codebase structure
- [ ] Confirm task dependencies are correctly sequenced (01 before 03-08, 09 last)
- [ ] Verify the Bun all-files workaround pattern is correct for each package
- [ ] Confirm `migrations.ts` (7,317 lines) is explicitly excluded from the Bun glob

🤖 Generated with [Claude Code](https://claude.com/claude-code)