### PR TITLE
refactor(space): unify Submit-for-Review UI and agent submit_for_approval (#123)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -8,13 +8,12 @@
  * - spaceTask.update - Update task fields (metadata and status with transition validation)
  */
 
-import type { MessageHub } from '@neokai/shared';
-import type { CreateSpaceTaskParams, UpdateSpaceTaskParams } from '@neokai/shared';
+import type { CreateSpaceTaskParams, MessageHub, UpdateSpaceTaskParams } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
+import { Logger } from '../logger';
 import type { SpaceManager } from '../space/managers/space-manager';
 import type { SpaceTaskManager } from '../space/managers/space-task-manager';
 import type { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
-import { Logger } from '../logger';
 
 const log = new Logger('space-task-handlers');
 
@@ -164,6 +163,26 @@ export function setupSpaceTaskHandlers(
 						`spaceTask.update cannot transition a task into 'review' directly. ` +
 							`Use spaceTask.submitForReview (or the agent submit_for_approval tool) ` +
 							`so the pending-completion fields get stamped and the approval banner renders.`
+					);
+				}
+				// Reject bare transitions into `approved`. The `approved` status
+				// is owned by the post-approval pipeline:
+				//   - human approvals → `spaceTask.approvePendingCompletion`,
+				//     which dispatches `PostApprovalRouter` (it calls
+				//     `setTaskStatus(approved)` with the right metadata).
+				//   - agent approvals → the runtime's reactive
+				//     `reportedStatus='done'` handler, again routing through
+				//     `PostApprovalRouter`.
+				// A bare `update({status:'approved'})` would skip the awareness
+				// event, the post-approval dispatch, and the approval-source
+				// stamping — the same kind of gap the `→ review` guard above
+				// closes on the entry side.
+				if (updateParams.status === 'approved') {
+					throw new Error(
+						`spaceTask.update cannot transition a task into 'approved' directly. ` +
+							`Use spaceTask.approvePendingCompletion (UI Approve banner) or let the ` +
+							`runtime's post-approval router handle the transition — both stamp the ` +
+							`approval metadata and dispatch the configured post-approval step.`
 					);
 				}
 				// Status is changing — validate via setTaskStatus (enforces transitions).
@@ -348,29 +367,26 @@ export function setupSpaceTaskHandlers(
 			// dispatches the configured post-approval step (no-route → done,
 			// inline Task Agent, or spawn fresh node-agent).
 			//
-			// Clear the pending-completion fields up front so the UI banner stops
-			// rendering immediately on approval. The router handles the status
-			// transition itself.
-			task = await taskManager.updateTask(params.taskId, {
-				pendingCheckpointType: null,
-				pendingCompletionSubmittedByNodeId: null,
-				pendingCompletionSubmittedAt: null,
-				pendingCompletionReason: null,
-				approvalReason: params.reason ?? null,
-			});
+			// The router's review→approved `setTaskStatus` call carries both
+			// concerns in a single SQL UPDATE: it stamps `approvalReason`
+			// (from `contextExtras`) and the centralised "exit review" cleanup
+			// nulls the pending-completion fields. No pre-call cleanup is
+			// needed — what used to be a 3-write sequence (clear + flip + ack)
+			// collapses into one atomic write inside the router.
 			await spaceRuntimeService.dispatchPostApproval(params.spaceId, params.taskId, 'human', {
 				approvalReason: params.reason ?? null,
 			});
 			// Re-read the task so the caller sees the post-router state.
-			task = (await taskManager.getTask(params.taskId)) ?? task;
+			const refreshed = await taskManager.getTask(params.taskId);
+			if (!refreshed) throw new Error(`Task not found: ${params.taskId}`);
+			task = refreshed;
 		} else {
-			// review → in_progress (reject). Reason captured as approvalReason for audit.
+			// review → in_progress (reject). Reason captured as `approvalReason`
+			// for audit. `setTaskStatus` nulls the pending-completion fields in
+			// the same UPDATE (centralised "exit review" cleanup), so the
+			// follow-up `updateTask` only stamps the rejection reason.
 			task = await taskManager.setTaskStatus(params.taskId, 'in_progress');
 			task = await taskManager.updateTask(params.taskId, {
-				pendingCheckpointType: null,
-				pendingCompletionSubmittedByNodeId: null,
-				pendingCompletionSubmittedAt: null,
-				pendingCompletionReason: null,
 				approvalReason: params.reason ?? null,
 			});
 		}

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -151,6 +151,21 @@ export function setupSpaceTaskHandlers(
 			}
 
 			if (updateParams.status !== currentTask.status) {
+				// Reject bare transitions into `review`. Every task that lands in
+				// `review` MUST carry the pending-completion fields so
+				// `PendingTaskCompletionBanner` renders and approvals route through
+				// `PostApprovalRouter`. Callers must use `spaceTask.submitForReview`
+				// (UI) or the agent `submit_for_approval` tool — both go through
+				// `SpaceTaskManager.submitTaskForReview` which writes the metadata
+				// atomically. Without this guard a stray `update({status:'review'})`
+				// would re-introduce the banner-less generic-button flow.
+				if (updateParams.status === 'review') {
+					throw new Error(
+						`spaceTask.update cannot transition a task into 'review' directly. ` +
+							`Use spaceTask.submitForReview (or the agent submit_for_approval tool) ` +
+							`so the pending-completion fields get stamped and the approval banner renders.`
+					);
+				}
 				// Status is changing — validate via setTaskStatus (enforces transitions).
 				// `approvalReason` is stamped on review→done; `cancelReason` is
 				// persisted into the same underlying column for review→cancelled
@@ -215,6 +230,55 @@ export function setupSpaceTaskHandlers(
 				sessionId: 'global',
 				spaceId,
 				taskId,
+				task,
+			})
+			.catch((err) => {
+				log.warn('Failed to emit space.task.updated:', err);
+			});
+
+		return task;
+	});
+
+	// ─── spaceTask.submitForReview ──────────────────────────────────────────────
+	// User-initiated counterpart to the agent `submit_for_approval` tool. Both
+	// paths converge on `SpaceTaskManager.submitTaskForReview`, which atomically
+	// transitions the task into `review` and stamps the pending-completion
+	// fields that drive `PendingTaskCompletionBanner`. Without this RPC the UI
+	// "Submit for Review" button degraded to a bare status update — landing the
+	// task in `review` with no banner, no metadata, and a generic Approve button
+	// that bypassed `PostApprovalRouter`. After unification, every task in
+	// `review` is banner-eligible regardless of who submitted it.
+	//
+	// `pendingCompletionSubmittedByNodeId` is set to `null` for user-initiated
+	// submissions — same semantics as a Task Agent self-submit. The post-
+	// approval router treats both identically (no waiting end-node session to
+	// resume; awareness events are best-effort).
+	messageHub.onRequest('spaceTask.submitForReview', async (data) => {
+		const params = data as {
+			spaceId: string;
+			taskId: string;
+			reason?: string | null;
+		};
+
+		if (!params.spaceId) throw new Error('spaceId is required');
+		if (!params.taskId) throw new Error('taskId is required');
+
+		const space = await spaceManager.getSpace(params.spaceId);
+		if (!space) {
+			throw new Error(`Space not found: ${params.spaceId}`);
+		}
+
+		const taskManager = taskManagerFactory(params.spaceId);
+		const task = await taskManager.submitTaskForReview(params.taskId, {
+			submittedByNodeId: null,
+			reason: params.reason ?? null,
+		});
+
+		daemonHub
+			.emit('space.task.updated', {
+				sessionId: 'global',
+				spaceId: params.spaceId,
+				taskId: params.taskId,
 				task,
 			})
 			.catch((err) => {

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -217,6 +217,56 @@ export class SpaceTaskManager {
 	}
 
 	/**
+	 * Submit a task for human review.
+	 *
+	 * Single entry point for both the agent `submit_for_approval` tool and the
+	 * UI "Submit for Review" button. Atomically transitions a task into `review`
+	 * and stamps the pending-completion metadata that drives the
+	 * `PendingTaskCompletionBanner` — meaning every task that lands in `review`
+	 * is guaranteed to carry the banner-eligible fields.
+	 *
+	 * Three callers, one set of writes:
+	 *   - End-node `submit_for_approval` (passes a real `submittedByNodeId`)
+	 *   - Task Agent `submit_for_approval` (passes `null` — orchestrator has no
+	 *     workflow node)
+	 *   - UI "Submit for Review" RPC (passes `null` — user-initiated)
+	 *
+	 * Validates the transition through `setTaskStatus` first so an illegal
+	 * source status (e.g. `done`, `archived`) fails with a clear error before
+	 * any pending-* fields get written. The follow-up `updateTask` call then
+	 * stamps the metadata in a single repository write.
+	 */
+	async submitTaskForReview(
+		taskId: string,
+		opts: {
+			/**
+			 * Workflow node ID of the submitting agent, or `null` when there is no
+			 * waiting end-node session (Task Agent self-submit, UI submit). Used by
+			 * `PostApprovalRouter` to distinguish agent-initiated vs user-initiated
+			 * approvals when emitting awareness events.
+			 */
+			submittedByNodeId: string | null;
+			/** Optional human-readable reason; surfaces in the approval banner. */
+			reason: string | null;
+		}
+	): Promise<SpaceTask> {
+		// Run the centralised transition validator first so that illegal source
+		// statuses fail before we write any pending-* fields.
+		await this.setTaskStatus(taskId, 'review');
+
+		const updated = this.taskRepo.updateTask(taskId, {
+			pendingCheckpointType: 'task_completion',
+			pendingCompletionSubmittedByNodeId: opts.submittedByNodeId,
+			pendingCompletionSubmittedAt: Date.now(),
+			pendingCompletionReason: opts.reason,
+		});
+		if (!updated) {
+			throw new Error(`Failed to submit task for review: ${taskId}`);
+		}
+		return updated;
+	}
+
+	/**
 	 * Complete a task
 	 */
 	async completeTask(taskId: string, result: string): Promise<SpaceTask> {

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -231,10 +231,14 @@ export class SpaceTaskManager {
 	 *     workflow node)
 	 *   - UI "Submit for Review" RPC (passes `null` — user-initiated)
 	 *
-	 * Validates the transition through `setTaskStatus` first so an illegal
-	 * source status (e.g. `done`, `archived`) fails with a clear error before
-	 * any pending-* fields get written. The follow-up `updateTask` call then
-	 * stamps the metadata in a single repository write.
+	 * Atomicity is load-bearing: the entire write — `status='review'` plus the
+	 * pending-completion fields — is issued as a single `taskRepo.updateTask`
+	 * call (one SQL UPDATE). A two-step write (`setTaskStatus` + a follow-up
+	 * pending-* update) would expose the exact banner-less in-between state
+	 * this PR is meant to eliminate: any concurrent reader landing between the
+	 * two writes would see `status='review' / pendingCheckpointType=null`. The
+	 * transition is validated inline against `isValidSpaceTaskTransition` so an
+	 * illegal source status (`done`, `archived`, …) throws before the write.
 	 */
 	async submitTaskForReview(
 		taskId: string,
@@ -250,11 +254,26 @@ export class SpaceTaskManager {
 			reason: string | null;
 		}
 	): Promise<SpaceTask> {
-		// Run the centralised transition validator first so that illegal source
-		// statuses fail before we write any pending-* fields.
-		await this.setTaskStatus(taskId, 'review');
+		const task = await this.getTask(taskId);
+		if (!task) {
+			throw new Error(`Task not found: ${taskId}`);
+		}
 
+		// Inline transition validation. Mirrors the check in `setTaskStatus` —
+		// kept here (rather than delegating) so the status flip and the pending-*
+		// stamp can happen in a single SQL UPDATE.
+		if (!isValidSpaceTaskTransition(task.status, 'review')) {
+			throw new Error(
+				`Invalid status transition from '${task.status}' to 'review'. ` +
+					`Allowed: ${VALID_SPACE_TASK_TRANSITIONS[task.status].join(', ') || 'none'}`
+			);
+		}
+
+		// Single atomic write: status flip + pending-completion stamp in one
+		// repository UPDATE. No reader can observe `status='review'` without the
+		// pending-* fields populated, which is the whole point of this helper.
 		const updated = this.taskRepo.updateTask(taskId, {
+			status: 'review',
 			pendingCheckpointType: 'task_completion',
 			pendingCompletionSubmittedByNodeId: opts.submittedByNodeId,
 			pendingCompletionSubmittedAt: Date.now(),

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -8,16 +8,16 @@
  */
 
 import type { Database as BunDatabase } from 'bun:sqlite';
-import { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
-import type { ReactiveDatabase } from '../../../storage/reactive-database';
 import type {
+	CreateSpaceTaskParams,
+	SpaceApprovalSource,
+	SpaceBlockReason,
 	SpaceTask,
 	SpaceTaskStatus,
-	SpaceBlockReason,
-	SpaceApprovalSource,
-	CreateSpaceTaskParams,
 	UpdateSpaceTaskParams,
 } from '@neokai/shared';
+import type { ReactiveDatabase } from '../../../storage/reactive-database';
+import { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
 
 /**
  * Valid task status transitions for space tasks
@@ -197,6 +197,39 @@ export class SpaceTaskManager {
 			updates.approvalSource = null;
 			updates.approvalReason = null;
 			updates.approvedAt = null;
+		}
+
+		// Clear pending-completion fields on any transition out of `review`.
+		//
+		// Mirrors (and replaces) the explicit follow-up `updateTask` cleanups
+		// formerly issued by `approvePendingCompletion` (both branches) and the
+		// agent `approve_task` tool. Centralising here closes the exit-side
+		// counterpart of the unified `submitTaskForReview` entry: every task
+		// landing in `review` carries the pending-* fields, and every task
+		// leaving `review` (for any reason — Approve via banner, Reopen, Archive,
+		// review→done by RPC) gets those fields nulled in the same SQL UPDATE
+		// that flips the status. No banner-on-non-review state can persist.
+		if (task.status === 'review' && newStatus !== 'review') {
+			updates.pendingCheckpointType = null;
+			updates.pendingCompletionSubmittedByNodeId = null;
+			updates.pendingCompletionSubmittedAt = null;
+			updates.pendingCompletionReason = null;
+		}
+
+		// Clear post-approval tracking fields on any transition out of `approved`.
+		//
+		// Mirrors (and replaces) the follow-up `updateTask` formerly issued by
+		// the agent `mark_complete` tool. After this change, the `approved →
+		// done` transition writes status='done' and nulls the post-approval
+		// fields in a single repository UPDATE — closing the race window where
+		// a reader could observe `status='done'` with stale
+		// `postApprovalSessionId`/`postApprovalStartedAt`/`postApprovalBlockedReason`.
+		// Also covers UI-driven escape hatches (`approved → in_progress`,
+		// `approved → archived`) which previously left these fields lingering.
+		if (task.status === 'approved' && newStatus !== 'approved') {
+			updates.postApprovalSessionId = null;
+			updates.postApprovalStartedAt = null;
+			updates.postApprovalBlockedReason = null;
 		}
 
 		const updated = this.taskRepo.updateTask(taskId, updates);

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -3577,6 +3577,14 @@ export class TaskAgentManager {
 		//   `submit_for_approval` — request human review of completion.
 		//                           Only available to end-node agents.
 		const isEndNode = !!workflow?.endNodeId && workflowNodeId === workflow.endNodeId;
+		// Bound SpaceTaskManager shared by the `submit_for_approval` and
+		// `mark_complete` tool handlers — both rely on the centralised transition
+		// validator so any illegal source status fails before fields get written.
+		const boundTaskManager = new SpaceTaskManager(
+			this.config.db.getDatabase(),
+			spaceId,
+			this.config.reactiveDb
+		);
 		const endNodeHandlers = isEndNode
 			? createEndNodeHandlers({
 					taskId,
@@ -3585,6 +3593,7 @@ export class TaskAgentManager {
 					workflowNodeId,
 					agentName,
 					taskRepo: this.config.taskRepo,
+					taskManager: boundTaskManager,
 					spaceManager: this.config.spaceManager,
 					daemonHub: this.config.daemonHub,
 				})
@@ -3596,18 +3605,12 @@ export class TaskAgentManager {
 		// post-approval sub-sessions can close the task via `approved → done`.
 		// The handler self-validates status (rejects non-approved) — a spawned
 		// agent that happens not to be running a post-approval step simply sees
-		// the tool reject with a clear error. Each session gets its own bound
-		// SpaceTaskManager so the centralised transition validator runs.
-		const markCompleteTaskManager = new SpaceTaskManager(
-			this.config.db.getDatabase(),
-			spaceId,
-			this.config.reactiveDb
-		);
+		// the tool reject with a clear error.
 		const onMarkComplete = createMarkCompleteHandler({
 			taskId,
 			spaceId,
 			taskRepo: this.config.taskRepo,
-			taskManager: markCompleteTaskManager,
+			taskManager: boundTaskManager,
 			daemonHub: this.config.daemonHub,
 		});
 

--- a/packages/daemon/src/lib/space/tools/end-node-handlers.ts
+++ b/packages/daemon/src/lib/space/tools/end-node-handlers.ts
@@ -58,6 +58,13 @@ export interface EndNodeHandlerDeps {
 	agentName: string;
 	/** Task repository. */
 	taskRepo: SpaceTaskRepository;
+	/**
+	 * Task manager bound to `spaceId`. Used by `submit_for_approval` so the
+	 * agent path and the UI "Submit for Review" RPC share `submitTaskForReview`,
+	 * which runs the centralised transition validator before stamping the
+	 * pending-completion fields.
+	 */
+	taskManager: Pick<SpaceTaskManager, 'submitTaskForReview'>;
 	/** Space manager — used to look up current autonomy level for approve_task. */
 	spaceManager: Pick<SpaceManager, 'getSpace'>;
 	/** Optional hub for emitting `space.task.updated` events after state changes. */
@@ -157,7 +164,16 @@ export function createMarkCompleteHandler(
  * with the same `deps` return independent instances.
  */
 export function createEndNodeHandlers(deps: EndNodeHandlerDeps): EndNodeHandlers {
-	const { taskId, spaceId, workflow, workflowNodeId, taskRepo, spaceManager, daemonHub } = deps;
+	const {
+		taskId,
+		spaceId,
+		workflow,
+		workflowNodeId,
+		taskRepo,
+		taskManager,
+		spaceManager,
+		daemonHub,
+	} = deps;
 
 	const emitTaskUpdated = (task: SpaceTask): void => {
 		if (!daemonHub) return;
@@ -215,20 +231,22 @@ export function createEndNodeHandlers(deps: EndNodeHandlerDeps): EndNodeHandlers
 
 		// -------------------------------------------------------------------
 		// submit_for_approval — human sign-off. Always available to end nodes.
+		//
+		// Delegates to `SpaceTaskManager.submitTaskForReview` — the same helper
+		// used by the UI "Submit for Review" RPC and the Task Agent's
+		// `submit_for_approval` tool — so all three callers write identical
+		// fields and the resulting `review` task is always banner-eligible.
 		// -------------------------------------------------------------------
 		onSubmitForApproval: async (args: SubmitForApprovalInput) => {
 			const task = taskRepo.getTask(taskId);
 			if (!task) return jsonResult({ success: false, error: `Task not found: ${taskId}` });
 
 			try {
-				const updated = taskRepo.updateTask(taskId, {
-					status: 'review',
-					pendingCheckpointType: 'task_completion',
-					pendingCompletionSubmittedByNodeId: workflowNodeId,
-					pendingCompletionSubmittedAt: Date.now(),
-					pendingCompletionReason: args.reason ?? null,
+				const updated = await taskManager.submitTaskForReview(taskId, {
+					submittedByNodeId: workflowNodeId,
+					reason: args.reason ?? null,
 				});
-				if (updated) emitTaskUpdated(updated);
+				emitTaskUpdated(updated);
 				return jsonResult({
 					success: true,
 					taskId,

--- a/packages/daemon/src/lib/space/tools/end-node-handlers.ts
+++ b/packages/daemon/src/lib/space/tools/end-node-handlers.ts
@@ -24,19 +24,19 @@
  * `save_artifact({ type: 'result', append: true, ... })` instead.
  */
 
+import type { SpaceTask, SpaceWorkflow } from '@neokai/shared';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import type { DaemonHub } from '../../daemon-hub';
+import { Logger } from '../../logger';
 import type { SpaceManager } from '../managers/space-manager';
 import type { SpaceTaskManager } from '../managers/space-task-manager';
-import type { DaemonHub } from '../../daemon-hub';
-import type { SpaceTask, SpaceWorkflow } from '@neokai/shared';
-import type { ToolResult } from './tool-result';
-import { jsonResult } from './tool-result';
 import type {
 	ApproveTaskInput,
-	SubmitForApprovalInput,
 	MarkCompleteInput,
+	SubmitForApprovalInput,
 } from './task-agent-tool-schemas';
-import { Logger } from '../../logger';
+import type { ToolResult } from './tool-result';
+import { jsonResult } from './tool-result';
 
 const log = new Logger('end-node-handlers');
 
@@ -132,13 +132,12 @@ export function createMarkCompleteHandler(
 		}
 
 		try {
-			await taskManager.setTaskStatus(taskId, 'done', {
+			// Single atomic write: status flip + post-approval-* cleanup. The
+			// "exit approved" branch in `SpaceTaskManager.setTaskStatus` nulls
+			// `postApprovalSessionId`, `postApprovalStartedAt`, and
+			// `postApprovalBlockedReason` in the same UPDATE.
+			const updated = await taskManager.setTaskStatus(taskId, 'done', {
 				approvalSource: task.approvalSource ?? 'agent',
-			});
-			const updated = await taskManager.updateTask(taskId, {
-				postApprovalSessionId: null,
-				postApprovalStartedAt: null,
-				postApprovalBlockedReason: null,
 			});
 			emitTaskUpdated(updated);
 			log.info(

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -479,24 +479,23 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		/**
 		 * Request human sign-off for task completion.
 		 *
-		 * Always available regardless of autonomy level. Sets task.status = 'review'
-		 * and populates pending-completion fields so the UI can route a human to
-		 * approve or reject. Even at high autonomy levels agents may want to escalate
-		 * risky outcomes.
+		 * Always available regardless of autonomy level. Delegates to
+		 * `SpaceTaskManager.submitTaskForReview` — the same helper used by the
+		 * end-node `submit_for_approval` tool and the UI "Submit for Review" RPC
+		 * — so all three callers write identical fields and the resulting
+		 * `review` task is always banner-eligible. Even at high autonomy levels
+		 * agents may want to escalate risky outcomes.
 		 */
 		async submit_for_approval(args: SubmitForApprovalInput): Promise<ToolResult> {
 			const task = taskRepo.getTask(taskId);
 			if (!task) return jsonResult({ success: false, error: `Task not found: ${taskId}` });
 
 			try {
-				const updated = taskRepo.updateTask(taskId, {
-					status: 'review',
-					pendingCheckpointType: 'task_completion',
-					pendingCompletionSubmittedByNodeId: null, // Task Agent has no workflow node
-					pendingCompletionSubmittedAt: Date.now(),
-					pendingCompletionReason: args.reason ?? null,
+				const updated = await taskManager.submitTaskForReview(taskId, {
+					submittedByNodeId: null, // Task Agent has no workflow node
+					reason: args.reason ?? null,
 				});
-				if (updated) emitTaskUpdated(updated);
+				emitTaskUpdated(updated);
 				return jsonResult({
 					success: true,
 					taskId,

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -23,46 +23,46 @@
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import type { Space, SpaceTask } from '@neokai/shared';
 import { z } from 'zod';
+import type { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
+import type { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
+import type {
+	PendingAgentMessageRecord,
+	PendingAgentMessageRepository,
+} from '../../../storage/repositories/pending-agent-message-repository';
+import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
+import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
 import type { DaemonHub } from '../../daemon-hub';
 import { Logger } from '../../logger';
 import type { SpaceTaskManager } from '../managers/space-task-manager';
-import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
-import type { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
-import type { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
-import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
-import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
-import type {
-	PendingAgentMessageRepository,
-	PendingAgentMessageRecord,
-} from '../../../storage/repositories/pending-agent-message-repository';
 import type { TaskAgentManager } from '../runtime/task-agent-manager';
-import { jsonResult } from './tool-result';
-import type { ToolResult } from './tool-result';
+import type {
+	ListArtifactsInput,
+	SaveArtifactInput,
+	SendMessageInput,
+} from './node-agent-tool-schemas';
 import {
-	ApproveTaskSchema,
-	SubmitForApprovalSchema,
-	MarkCompleteSchema,
-	RequestHumanInputSchema,
-	ListGroupMembersSchema,
-} from './task-agent-tool-schemas';
-import {
-	SendMessageSchema,
-	SaveArtifactSchema,
 	ListArtifactsSchema,
+	SaveArtifactSchema,
+	SendMessageSchema,
 } from './node-agent-tool-schemas';
 import type {
 	ApproveTaskInput,
-	SubmitForApprovalInput,
+	ListGroupMembersInput,
 	MarkCompleteInput,
 	RequestHumanInputInput,
-	ListGroupMembersInput,
+	SubmitForApprovalInput,
 } from './task-agent-tool-schemas';
-import type {
-	SendMessageInput,
-	SaveArtifactInput,
-	ListArtifactsInput,
-} from './node-agent-tool-schemas';
+import {
+	ApproveTaskSchema,
+	ListGroupMembersSchema,
+	MarkCompleteSchema,
+	RequestHumanInputSchema,
+	SubmitForApprovalSchema,
+} from './task-agent-tool-schemas';
+import type { ToolResult } from './tool-result';
+import { jsonResult } from './tool-result';
 
 // Re-export for consumers that want the shared type
 export type { ToolResult };
@@ -429,10 +429,15 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 		 * Agent itself when `workflow.postApproval.targetAgent === 'task-agent'`,
 		 * or the spawned space-task-node-agent sub-session otherwise.
 		 *
-		 * Transitions the task `approved → done`, clears
-		 * `post_approval_session_id` and `post_approval_started_at`, and emits a
-		 * `space.task.updated` event. Rejects on any non-`approved` status with a
-		 * message that points the caller at the correct tool.
+		 * Transitions the task `approved → done` via `setTaskStatus`, which now
+		 * atomically clears `postApprovalSessionId`, `postApprovalStartedAt`,
+		 * and `postApprovalBlockedReason` in the same SQL UPDATE — the
+		 * centralised "exit `approved`" cleanup. No follow-up write is needed,
+		 * which closes the previous race window where a reader could observe
+		 * `status='done'` alongside stale post-approval fields.
+		 *
+		 * Rejects on any non-`approved` status with a message that points the
+		 * caller at the correct tool.
 		 */
 		async mark_complete(_args: MarkCompleteInput): Promise<ToolResult> {
 			const task = taskRepo.getTask(taskId);
@@ -448,16 +453,12 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 			}
 
 			try {
-				// Use taskManager.setTaskStatus so the approved → done edge runs
-				// through the centralised transition validator.
-				let updated = await taskManager.setTaskStatus(taskId, 'done', {
+				// Single atomic write: status flip + post-approval-* cleanup. The
+				// "exit approved" branch in `setTaskStatus` nulls
+				// `postApprovalSessionId`, `postApprovalStartedAt`, and
+				// `postApprovalBlockedReason` in the same UPDATE.
+				const updated = await taskManager.setTaskStatus(taskId, 'done', {
 					approvalSource: task.approvalSource ?? 'agent',
-				});
-				// Clear post-approval tracking fields.
-				updated = await taskManager.updateTask(taskId, {
-					postApprovalSessionId: null,
-					postApprovalStartedAt: null,
-					postApprovalBlockedReason: null,
 				});
 				emitTaskUpdated(updated);
 				log.info(

--- a/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
@@ -938,4 +938,71 @@ describe('SpaceTaskManager', () => {
 			expect(Math.max(...numbers)).toBe(20);
 		});
 	});
+
+	// ─── submitTaskForReview ────────────────────────────────────────────────
+	//
+	// Single entry point for the agent `submit_for_approval` tool, the Task Agent
+	// self-submit path, and the UI "Submit for Review" RPC. The contract: any task
+	// landing in `review` MUST carry the pending-completion fields so
+	// `PendingTaskCompletionBanner` renders and approvals route through
+	// `PostApprovalRouter`. These tests pin that atomic write contract end-to-end
+	// against a real SQLite database.
+	describe('submitTaskForReview', () => {
+		it('transitions in_progress→review and stamps pending-completion fields atomically', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+
+			const reviewing = await manager.submitTaskForReview(task.id, {
+				submittedByNodeId: 'node-A',
+				reason: 'ready for human review',
+			});
+
+			expect(reviewing.status).toBe('review');
+			expect(reviewing.pendingCheckpointType).toBe('task_completion');
+			expect(reviewing.pendingCompletionSubmittedByNodeId).toBe('node-A');
+			expect(reviewing.pendingCompletionReason).toBe('ready for human review');
+			expect(typeof reviewing.pendingCompletionSubmittedAt).toBe('number');
+		});
+
+		it('accepts null submittedByNodeId for Task Agent / UI submissions', async () => {
+			// Task Agent self-submit and UI "Submit for Review" both pass null —
+			// no waiting end-node session to resume. The PostApprovalRouter
+			// distinguishes these cases via `pendingCompletionSubmittedByNodeId`.
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+
+			const reviewing = await manager.submitTaskForReview(task.id, {
+				submittedByNodeId: null,
+				reason: null,
+			});
+
+			expect(reviewing.status).toBe('review');
+			expect(reviewing.pendingCheckpointType).toBe('task_completion');
+			expect(reviewing.pendingCompletionSubmittedByNodeId).toBeNull();
+			expect(reviewing.pendingCompletionReason).toBeNull();
+		});
+
+		it('rejects illegal source statuses before any pending-* fields get written', async () => {
+			// `done → review` is not in VALID_SPACE_TASK_TRANSITIONS — the helper
+			// must surface the transition error from `setTaskStatus` *before*
+			// touching the pending-completion columns. Otherwise a banner would
+			// render on top of an already-completed task.
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			await manager.completeTask(task.id, 'done');
+
+			await expect(
+				manager.submitTaskForReview(task.id, {
+					submittedByNodeId: null,
+					reason: null,
+				})
+			).rejects.toThrow(/Invalid status transition/);
+
+			// Confirm no partial write — task is still `done` with no pending fields.
+			const after = await manager.getTask(task.id);
+			expect(after?.status).toBe('done');
+			expect(after?.pendingCheckpointType).toBeFalsy();
+			expect(after?.pendingCompletionSubmittedAt).toBeFalsy();
+		});
+	});
 });

--- a/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
@@ -1004,5 +1004,53 @@ describe('SpaceTaskManager', () => {
 			expect(after?.pendingCheckpointType).toBeFalsy();
 			expect(after?.pendingCompletionSubmittedAt).toBeFalsy();
 		});
+
+		it('writes status and pending-completion fields in a single UPDATE (atomicity)', async () => {
+			// Atomicity regression guard. The earlier two-step implementation
+			// (setTaskStatus + follow-up updateTask) exposed a window where
+			// `status='review'` was visible without `pendingCheckpointType` set —
+			// the exact banner-less state this PR was supposed to eliminate. We
+			// pin the contract by spying on the underlying repository: on a
+			// successful submit, exactly ONE write must reach the DB and that
+			// write must carry both the status flip and the pending-* fields
+			// together.
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+
+			// Wrap the live repo's `updateTask` so we can count calls without
+			// breaking real DB writes. (Using bun:sqlite directly keeps the
+			// downstream pendingCheckpointType read in this test honest.)
+			// biome-ignore lint/suspicious/noExplicitAny: spy needs to reach into private repo
+			const repo: any = (manager as any).taskRepo;
+			const originalUpdate = repo.updateTask.bind(repo);
+			const calls: Array<{ id: string; params: Record<string, unknown> }> = [];
+			repo.updateTask = (id: string, params: Record<string, unknown>) => {
+				calls.push({ id, params });
+				return originalUpdate(id, params);
+			};
+
+			try {
+				const result = await manager.submitTaskForReview(task.id, {
+					submittedByNodeId: 'node-A',
+					reason: 'ready',
+				});
+
+				expect(result.status).toBe('review');
+				expect(result.pendingCheckpointType).toBe('task_completion');
+
+				// Exactly one repo.updateTask call — no two-write race window.
+				expect(calls).toHaveLength(1);
+				const onlyCall = calls[0];
+				expect(onlyCall.id).toBe(task.id);
+				// Both the status flip AND the pending-* fields ride the same UPDATE.
+				expect(onlyCall.params.status).toBe('review');
+				expect(onlyCall.params.pendingCheckpointType).toBe('task_completion');
+				expect(onlyCall.params.pendingCompletionSubmittedByNodeId).toBe('node-A');
+				expect(onlyCall.params.pendingCompletionReason).toBe('ready');
+				expect(typeof onlyCall.params.pendingCompletionSubmittedAt).toBe('number');
+			} finally {
+				repo.updateTask = originalUpdate;
+			}
+		});
 	});
 });

--- a/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
@@ -4,14 +4,14 @@
  * Tests task lifecycle, status transitions, and dependency validation.
  */
 
-import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
 import { Database } from 'bun:sqlite';
-import { SpaceRepository } from '../../../../src/storage/repositories/space-repository';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import {
+	isValidSpaceTaskTransition,
 	SpaceTaskManager,
 	VALID_SPACE_TASK_TRANSITIONS,
-	isValidSpaceTaskTransition,
 } from '../../../../src/lib/space/managers/space-task-manager';
+import { SpaceRepository } from '../../../../src/storage/repositories/space-repository';
 import { createSpaceTables } from '../../helpers/space-test-db';
 
 describe('SpaceTaskManager', () => {
@@ -1051,6 +1051,232 @@ describe('SpaceTaskManager', () => {
 			} finally {
 				repo.updateTask = originalUpdate;
 			}
+		});
+	});
+
+	// ─── Exit-status cleanup (review-out, approved-out) ─────────────────────
+	//
+	// Counterpart to the entry-side `submitTaskForReview` atomic write. The
+	// `setTaskStatus` helper now nulls the pending-completion fields on any
+	// transition out of `review`, and nulls the post-approval tracking
+	// fields on any transition out of `approved`, in the SAME SQL UPDATE
+	// that flips the status. These tests pin that contract end-to-end so:
+	//   - UI generic transitions (Reopen/Archive a `review` task, Mark
+	//     Done/Reopen/Archive an `approved` task) get the cleanup for free —
+	//     no banner-on-non-review state, no stale post-approval fields on
+	//     terminal tasks.
+	//   - The agent-tool simplifications (`mark_complete` no longer does a
+	//     follow-up `updateTask`) stay correct.
+	describe('exit-status cleanup', () => {
+		// --- review-exit -----------------------------------------------------
+
+		it('clears pending-* fields on review → in_progress (Reopen)', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			await manager.submitTaskForReview(task.id, {
+				submittedByNodeId: 'node-A',
+				reason: 'please review',
+			});
+
+			const reopened = await manager.setTaskStatus(task.id, 'in_progress');
+			expect(reopened.status).toBe('in_progress');
+			expect(reopened.pendingCheckpointType).toBeNull();
+			expect(reopened.pendingCompletionSubmittedByNodeId).toBeNull();
+			expect(reopened.pendingCompletionSubmittedAt).toBeNull();
+			expect(reopened.pendingCompletionReason).toBeNull();
+		});
+
+		it('clears pending-* fields on review → archived', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			await manager.submitTaskForReview(task.id, {
+				submittedByNodeId: null,
+				reason: 'go',
+			});
+
+			const archived = await manager.setTaskStatus(task.id, 'archived');
+			expect(archived.status).toBe('archived');
+			expect(archived.pendingCheckpointType).toBeNull();
+			expect(archived.pendingCompletionSubmittedByNodeId).toBeNull();
+			expect(archived.pendingCompletionSubmittedAt).toBeNull();
+			expect(archived.pendingCompletionReason).toBeNull();
+		});
+
+		it('clears pending-* fields on review → cancelled', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			await manager.submitTaskForReview(task.id, {
+				submittedByNodeId: 'node-Z',
+				reason: 'risky',
+			});
+
+			const cancelled = await manager.setTaskStatus(task.id, 'cancelled');
+			expect(cancelled.status).toBe('cancelled');
+			expect(cancelled.pendingCheckpointType).toBeNull();
+			expect(cancelled.pendingCompletionReason).toBeNull();
+		});
+
+		it('clears pending-* fields on review → done (human approval terminal write)', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			await manager.submitTaskForReview(task.id, {
+				submittedByNodeId: null,
+				reason: null,
+			});
+
+			const done = await manager.setTaskStatus(task.id, 'done', {
+				approvalSource: 'human',
+			});
+			expect(done.status).toBe('done');
+			expect(done.pendingCheckpointType).toBeNull();
+			expect(done.pendingCompletionSubmittedAt).toBeNull();
+		});
+
+		it('writes status flip and pending-* cleanup in a single UPDATE on review-exit (atomicity)', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			await manager.submitTaskForReview(task.id, {
+				submittedByNodeId: 'node-A',
+				reason: 'r',
+			});
+
+			// biome-ignore lint/suspicious/noExplicitAny: spy needs to reach into private repo
+			const repo: any = (manager as any).taskRepo;
+			const originalUpdate = repo.updateTask.bind(repo);
+			const calls: Array<{ id: string; params: Record<string, unknown> }> = [];
+			repo.updateTask = (id: string, params: Record<string, unknown>) => {
+				calls.push({ id, params });
+				return originalUpdate(id, params);
+			};
+
+			try {
+				await manager.setTaskStatus(task.id, 'in_progress');
+				expect(calls).toHaveLength(1);
+				const onlyCall = calls[0];
+				expect(onlyCall.params.status).toBe('in_progress');
+				// Cleanup rides the same UPDATE — no separate write.
+				expect(onlyCall.params.pendingCheckpointType).toBeNull();
+				expect(onlyCall.params.pendingCompletionSubmittedByNodeId).toBeNull();
+				expect(onlyCall.params.pendingCompletionSubmittedAt).toBeNull();
+				expect(onlyCall.params.pendingCompletionReason).toBeNull();
+			} finally {
+				repo.updateTask = originalUpdate;
+			}
+		});
+
+		// --- approved-exit ---------------------------------------------------
+
+		it('clears post-approval-* fields on approved → done (mark_complete)', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			await manager.setTaskStatus(task.id, 'approved', { approvalSource: 'agent' });
+			await manager.updateTask(task.id, {
+				postApprovalSessionId: 'sess-1',
+				postApprovalStartedAt: Date.now(),
+				postApprovalBlockedReason: null,
+			});
+
+			const done = await manager.setTaskStatus(task.id, 'done');
+			expect(done.status).toBe('done');
+			expect(done.postApprovalSessionId).toBeNull();
+			expect(done.postApprovalStartedAt).toBeNull();
+			expect(done.postApprovalBlockedReason).toBeNull();
+		});
+
+		it('clears post-approval-* fields on approved → in_progress (Reopen escape hatch)', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			await manager.setTaskStatus(task.id, 'approved', { approvalSource: 'human' });
+			await manager.updateTask(task.id, {
+				postApprovalSessionId: 'sess-2',
+				postApprovalStartedAt: 999,
+				postApprovalBlockedReason: 'router unavailable',
+			});
+
+			const reopened = await manager.setTaskStatus(task.id, 'in_progress');
+			expect(reopened.status).toBe('in_progress');
+			expect(reopened.postApprovalSessionId).toBeNull();
+			expect(reopened.postApprovalStartedAt).toBeNull();
+			expect(reopened.postApprovalBlockedReason).toBeNull();
+		});
+
+		it('clears post-approval-* fields on approved → archived', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			await manager.setTaskStatus(task.id, 'approved', { approvalSource: 'human' });
+			await manager.updateTask(task.id, {
+				postApprovalSessionId: 'sess-3',
+				postApprovalStartedAt: 1,
+				postApprovalBlockedReason: null,
+			});
+
+			const archived = await manager.setTaskStatus(task.id, 'archived');
+			expect(archived.status).toBe('archived');
+			expect(archived.postApprovalSessionId).toBeNull();
+			expect(archived.postApprovalStartedAt).toBeNull();
+		});
+
+		it('writes status flip and post-approval-* cleanup in a single UPDATE on approved → done (atomicity)', async () => {
+			// Atomicity regression guard for the centralised "exit approved"
+			// cleanup. The earlier two-step `mark_complete` implementation
+			// (setTaskStatus → updateTask) exposed a window where status='done'
+			// was visible alongside stale post-approval fields. This test pins
+			// the contract that the new single-UPDATE form holds.
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			await manager.setTaskStatus(task.id, 'approved', { approvalSource: 'agent' });
+			await manager.updateTask(task.id, {
+				postApprovalSessionId: 'sess-X',
+				postApprovalStartedAt: 5,
+				postApprovalBlockedReason: 'blocked-prior',
+			});
+
+			// biome-ignore lint/suspicious/noExplicitAny: spy needs to reach into private repo
+			const repo: any = (manager as any).taskRepo;
+			const originalUpdate = repo.updateTask.bind(repo);
+			const calls: Array<{ id: string; params: Record<string, unknown> }> = [];
+			repo.updateTask = (id: string, params: Record<string, unknown>) => {
+				calls.push({ id, params });
+				return originalUpdate(id, params);
+			};
+
+			try {
+				await manager.setTaskStatus(task.id, 'done');
+				expect(calls).toHaveLength(1);
+				const onlyCall = calls[0];
+				expect(onlyCall.params.status).toBe('done');
+				// All three post-approval-* fields cleared in the same UPDATE.
+				expect(onlyCall.params.postApprovalSessionId).toBeNull();
+				expect(onlyCall.params.postApprovalStartedAt).toBeNull();
+				expect(onlyCall.params.postApprovalBlockedReason).toBeNull();
+			} finally {
+				repo.updateTask = originalUpdate;
+			}
+		});
+
+		// --- guard: same-status writes don't trigger the cleanup -------------
+
+		it('does not clear pending-* fields on same-status writes (review → review noop guard)', async () => {
+			// `setTaskStatus` rejects same-status writes (no entry in the
+			// transition table). The cleanup branch keys off `task.status !==
+			// newStatus`, so even if a future caller tries to flip review→review
+			// it would never reach the cleanup. Pinned defensively so this stays
+			// safe even if the transition table is widened.
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			await manager.submitTaskForReview(task.id, {
+				submittedByNodeId: 'node-A',
+				reason: 'r',
+			});
+
+			await expect(manager.setTaskStatus(task.id, 'review')).rejects.toThrow(
+				'Invalid status transition'
+			);
+
+			// Pending fields untouched.
+			const after = await manager.getTask(task.id);
+			expect(after?.pendingCheckpointType).toBe('task_completion');
+			expect(after?.pendingCompletionReason).toBe('r');
 		});
 	});
 });

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
@@ -107,6 +107,18 @@ function createMockTaskManager(task: SpaceTask | null = mockTask): SpaceTaskMana
 		setTaskStatus: mock(async () => ({ ...task!, status: 'in_progress' as const })),
 		updateTask: mock(async () => ({ ...task!, title: 'Updated' })),
 		updateTaskProgress: mock(async () => ({ ...task!, progress: 50 })),
+		// Unified entry point used by both `spaceTask.submitForReview` (UI) and
+		// the agent `submit_for_approval` tool. Returns a task in `review` with
+		// the pending-completion fields stamped — mirrors the real manager's
+		// output shape so handler-level assertions stay accurate.
+		submitTaskForReview: mock(async (_taskId: string, opts: { reason: string | null }) => ({
+			...task!,
+			status: 'review' as const,
+			pendingCheckpointType: 'task_completion' as const,
+			pendingCompletionSubmittedByNodeId: null,
+			pendingCompletionSubmittedAt: NOW,
+			pendingCompletionReason: opts.reason,
+		})),
 	} as unknown as SpaceTaskManager;
 }
 
@@ -653,8 +665,29 @@ describe('space-task-handlers', () => {
 			setup(mockSpace, doneTask);
 
 			(taskManager.setTaskStatus as ReturnType<typeof mock>).mockRejectedValue(
-				new Error("Invalid status transition from 'done' to 'review'. Allowed: none")
+				new Error("Invalid status transition from 'done' to 'in_progress'. Allowed: none")
 			);
+
+			await expect(
+				call('spaceTask.update', {
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					status: 'in_progress',
+				})
+			).rejects.toThrow('Invalid status transition');
+		});
+
+		it('rejects bare in_progress→review transitions and points at spaceTask.submitForReview', async () => {
+			// Unification (Task #123): every task that lands in `review` must
+			// carry the pending-completion fields so `PendingTaskCompletionBanner`
+			// renders and approvals route through `PostApprovalRouter`. The
+			// `spaceTask.update` path can't stamp those fields, so the handler
+			// must reject `status: 'review'` requests and direct callers to
+			// `spaceTask.submitForReview` (or the agent `submit_for_approval`
+			// tool). Without this guard the legacy bare-status flow would slip
+			// back in and produce banner-less `review` tasks.
+			const inProgressTask = { ...mockTask, status: 'in_progress' as const };
+			setup(mockSpace, inProgressTask);
 
 			await expect(
 				call('spaceTask.update', {
@@ -662,7 +695,11 @@ describe('space-task-handlers', () => {
 					taskId: 'task-1',
 					status: 'review',
 				})
-			).rejects.toThrow('Invalid status transition');
+			).rejects.toThrow(/spaceTask\.submitForReview/);
+			// The handler must short-circuit before hitting the manager so a
+			// bad caller never gets a partial write.
+			expect(taskManager.setTaskStatus).not.toHaveBeenCalled();
+			expect(taskManager.updateTask).not.toHaveBeenCalled();
 		});
 
 		it('propagates errors from updateTask', async () => {
@@ -685,4 +722,102 @@ describe('space-task-handlers', () => {
 	// proceeds through the plain `taskManager.setTaskStatus` path for any task
 	// without a `task_completion` checkpoint; tasks with `task_completion` are
 	// routed through `approvePendingCompletion` (tested in its own file).
+
+	// ─── spaceTask.submitForReview ────────────────────────────────────────────
+	//
+	// User-initiated counterpart to the agent `submit_for_approval` tool. The
+	// handler must funnel the request through `SpaceTaskManager.submitTaskForReview`
+	// (the unified entry point) so the resulting task always carries the
+	// pending-completion fields that drive `PendingTaskCompletionBanner`. These
+	// tests pin the handler-level contract: argument shape, validation, event
+	// emission, and error propagation.
+	describe('spaceTask.submitForReview', () => {
+		beforeEach(() => setup());
+
+		it('delegates to taskManager.submitTaskForReview with submittedByNodeId=null and the reason', async () => {
+			// `submittedByNodeId: null` is load-bearing — it tells the
+			// PostApprovalRouter that no end-node session is waiting to be
+			// resumed (same semantics as a Task Agent self-submit).
+			const result = await call('spaceTask.submitForReview', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				reason: 'ready for human eyes',
+			});
+
+			expect(taskManager.submitTaskForReview).toHaveBeenCalledWith('task-1', {
+				submittedByNodeId: null,
+				reason: 'ready for human eyes',
+			});
+			expect((result as SpaceTask).status).toBe('review');
+			expect((result as SpaceTask).pendingCheckpointType).toBe('task_completion');
+			expect((result as SpaceTask).pendingCompletionReason).toBe('ready for human eyes');
+		});
+
+		it('coerces missing reason to null so the manager always receives an explicit value', async () => {
+			// Defensive: the manager treats `undefined` and `null` differently for
+			// its DB writer (only `null` clears the column). The handler must
+			// normalize so callers can omit the field without ambiguity.
+			await call('spaceTask.submitForReview', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+			});
+
+			expect(taskManager.submitTaskForReview).toHaveBeenCalledWith('task-1', {
+				submittedByNodeId: null,
+				reason: null,
+			});
+		});
+
+		it('emits space.task.updated with the post-submit task', async () => {
+			await call('spaceTask.submitForReview', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				reason: 'ready',
+			});
+
+			expect(daemonHub.emit).toHaveBeenCalledWith('space.task.updated', {
+				sessionId: 'global',
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				task: expect.objectContaining({
+					status: 'review',
+					pendingCheckpointType: 'task_completion',
+				}),
+			});
+		});
+
+		it('throws when spaceId is missing', async () => {
+			await expect(call('spaceTask.submitForReview', { taskId: 'task-1' })).rejects.toThrow(
+				'spaceId is required'
+			);
+			expect(taskManager.submitTaskForReview).not.toHaveBeenCalled();
+		});
+
+		it('throws when taskId is missing', async () => {
+			await expect(call('spaceTask.submitForReview', { spaceId: 'space-1' })).rejects.toThrow(
+				'taskId is required'
+			);
+			expect(taskManager.submitTaskForReview).not.toHaveBeenCalled();
+		});
+
+		it('throws Space not found when space does not exist', async () => {
+			setup(null);
+			await expect(
+				call('spaceTask.submitForReview', { spaceId: 'ghost', taskId: 'task-1' })
+			).rejects.toThrow('Space not found: ghost');
+			expect(taskManager.submitTaskForReview).not.toHaveBeenCalled();
+		});
+
+		it('propagates manager errors (e.g. invalid status transition)', async () => {
+			// E.g. attempting to submit an `archived` task — the manager's
+			// `setTaskStatus(taskId, 'review')` step rejects the transition.
+			(taskManager.submitTaskForReview as ReturnType<typeof mock>).mockRejectedValue(
+				new Error("Invalid status transition from 'archived' to 'review'. Allowed: none")
+			);
+
+			await expect(
+				call('spaceTask.submitForReview', { spaceId: 'space-1', taskId: 'task-1' })
+			).rejects.toThrow('Invalid status transition');
+		});
+	});
 });

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
@@ -11,14 +11,13 @@
  * - DaemonHub events emitted on mutations
  */
 
-import { describe, expect, it, mock, beforeEach } from 'bun:test';
-import { MessageHub } from '@neokai/shared';
-import type { Space, SpaceTask } from '@neokai/shared';
-import { setupSpaceTaskHandlers } from '../../../../src/lib/rpc-handlers/space-task-handlers';
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { MessageHub, Space, SpaceTask } from '@neokai/shared';
+import type { DaemonHub } from '../../../../src/lib/daemon-hub';
 import type { SpaceTaskManagerFactory } from '../../../../src/lib/rpc-handlers/space-task-handlers';
+import { setupSpaceTaskHandlers } from '../../../../src/lib/rpc-handlers/space-task-handlers';
 import type { SpaceManager } from '../../../../src/lib/space/managers/space-manager';
 import type { SpaceTaskManager } from '../../../../src/lib/space/managers/space-task-manager';
-import type { DaemonHub } from '../../../../src/lib/daemon-hub';
 import type { SpaceRuntimeService } from '../../../../src/lib/space/runtime/space-runtime-service';
 
 type RequestHandler = (data: unknown) => Promise<unknown>;
@@ -700,6 +699,58 @@ describe('space-task-handlers', () => {
 			// bad caller never gets a partial write.
 			expect(taskManager.setTaskStatus).not.toHaveBeenCalled();
 			expect(taskManager.updateTask).not.toHaveBeenCalled();
+		});
+
+		it('rejects bare → approved transitions and points at the post-approval router', async () => {
+			// Exit-side counterpart to the `→ review` guard. The `approved`
+			// status is owned by the post-approval pipeline:
+			//   - human approvals route through `spaceTask.approvePendingCompletion`
+			//     which dispatches `PostApprovalRouter` (the router calls
+			//     `setTaskStatus(approved)` with the right metadata).
+			//   - agent approvals route through the runtime's reactive
+			//     `reportedStatus='done'` handler — also via the router.
+			// A bare `update({status:'approved'})` would skip the awareness
+			// event, the dispatch, and the approval-source stamping. The
+			// handler must short-circuit so neither manager method is called.
+			const inProgressTask = { ...mockTask, status: 'in_progress' as const };
+			setup(mockSpace, inProgressTask);
+
+			await expect(
+				call('spaceTask.update', {
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					status: 'approved',
+				})
+			).rejects.toThrow(/approvePendingCompletion|post-approval/);
+			expect(taskManager.setTaskStatus).not.toHaveBeenCalled();
+			expect(taskManager.updateTask).not.toHaveBeenCalled();
+		});
+
+		it('allows approved → done via spaceTask.update — relies on setTaskStatus to clear post-approval-* atomically', async () => {
+			// Counterpart fact: the `→ approved` guard does NOT block exits
+			// FROM `approved`. UI escape hatches (Mark Done / Reopen / Archive
+			// from approved) flow through `spaceTask.update`, which delegates
+			// to `setTaskStatus`. The manager's centralised "exit approved"
+			// cleanup nulls postApprovalSessionId/StartedAt/BlockedReason in
+			// the same SQL UPDATE — see the manager-level atomicity test.
+			const approvedTask = { ...mockTask, status: 'approved' as const };
+			setup(mockSpace, approvedTask);
+			(taskManager.setTaskStatus as ReturnType<typeof mock>).mockResolvedValue({
+				...approvedTask,
+				status: 'done' as const,
+				postApprovalSessionId: null,
+				postApprovalStartedAt: null,
+				postApprovalBlockedReason: null,
+			});
+
+			const result = await call('spaceTask.update', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				status: 'done',
+			});
+
+			expect(taskManager.setTaskStatus).toHaveBeenCalledWith('task-1', 'done', expect.any(Object));
+			expect((result as SpaceTask).status).toBe('done');
 		});
 
 		it('propagates errors from updateTask', async () => {

--- a/packages/daemon/tests/unit/5-space/agent/end-node-handlers.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/end-node-handlers.test.ts
@@ -17,6 +17,7 @@ import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../src/storage/schema/index.ts';
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceTaskManager } from '../../../../src/lib/space/managers/space-task-manager.ts';
 import { createEndNodeHandlers } from '../../../../src/lib/space/tools/end-node-handlers.ts';
 import type { EndNodeHandlerDeps } from '../../../../src/lib/space/tools/end-node-handlers.ts';
 import type { Space, SpaceWorkflow } from '@neokai/shared';
@@ -97,6 +98,7 @@ interface TestCtx {
 	db: BunDatabase;
 	spaceId: string;
 	taskRepo: SpaceTaskRepository;
+	taskManager: SpaceTaskManager;
 }
 
 function makeCtx(autonomyLevel = 1): TestCtx {
@@ -107,6 +109,10 @@ function makeCtx(autonomyLevel = 1): TestCtx {
 		db,
 		spaceId,
 		taskRepo: new SpaceTaskRepository(db),
+		// Real SpaceTaskManager so the centralised transition validator runs
+		// inside `submitTaskForReview` — exercises the same code path that the
+		// production wiring takes from `task-agent-manager.ts`.
+		taskManager: new SpaceTaskManager(db, spaceId),
 	};
 }
 
@@ -121,7 +127,9 @@ function makeDeps(
 		spaceId: ctx.spaceId,
 		workflow: makeWorkflow(3),
 		workflowNodeId: 'end-node',
+		agentName: 'test-agent',
 		taskRepo: ctx.taskRepo,
+		taskManager: ctx.taskManager,
 		spaceManager: {
 			getSpace: async () => makeSpace(ctx.spaceId, 3),
 		},

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -22,6 +22,7 @@ import { resolveActiveTaskBanner } from '../../lib/task-banner.ts';
 import { TaskSessionChatComposer } from './TaskSessionChatComposer';
 import { ReadOnlyWorkflowCanvas } from './ReadOnlyWorkflowCanvas';
 import { Dropdown, type DropdownMenuItem } from '../ui/Dropdown';
+import { SubmitForReviewModal } from './SubmitForReviewModal';
 
 interface SpaceTaskPaneProps {
 	taskId: string | null;
@@ -91,6 +92,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	const [threadSendError, setThreadSendError] = useState<string | null>(null);
 	const [sendingThread, setSendingThread] = useState(false);
 	const [statusTransitioning, setStatusTransitioning] = useState(false);
+	const [showSubmitForReviewModal, setShowSubmitForReviewModal] = useState(false);
 	const activeView = currentSpaceTaskViewTabSignal.value;
 	const _spaceId = currentSpaceIdSignal.value ?? '';
 
@@ -249,6 +251,16 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	};
 
 	const handleStatusTransition = async (newStatus: SpaceTaskStatus) => {
+		// Submitting for review is the human counterpart of the agent
+		// `submit_for_approval` tool — it must stamp pending-completion metadata
+		// so `PendingTaskCompletionBanner` renders. Open the optional-reason
+		// modal instead of issuing a bare status update; the modal calls
+		// `spaceStore.submitForReview` on confirm.
+		if (newStatus === 'review') {
+			setThreadSendError(null);
+			setShowSubmitForReviewModal(true);
+			return;
+		}
 		try {
 			setStatusTransitioning(true);
 			setThreadSendError(null);
@@ -260,9 +272,29 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 		}
 	};
 
+	const handleSubmitForReviewConfirm = async (reason: string | null) => {
+		try {
+			setStatusTransitioning(true);
+			setThreadSendError(null);
+			await spaceStore.submitForReview(task.id, reason);
+			setShowSubmitForReviewModal(false);
+		} catch (err) {
+			setThreadSendError(formatTaskThreadError(err));
+		} finally {
+			setStatusTransitioning(false);
+		}
+	};
+
 	const allTransitionActions = getTransitionActions(task.status);
+	// Mirrors the filter in `TaskStatusActions`: any task in `review` is
+	// "awaiting human approval via a dedicated banner" — the bare review→done /
+	// review→cancelled buttons would bypass `PostApprovalRouter` and the
+	// approval metadata stamping. Hide them so the only Approve / Cancel path
+	// is the banner. Non-approval escape hatches (Reopen, Archive) stay.
 	const filteredTransitionActions =
-		task.pendingCheckpointType === 'task_completion' || task.pendingCheckpointType === 'gate'
+		task.status === 'review' ||
+		task.pendingCheckpointType === 'task_completion' ||
+		task.pendingCheckpointType === 'gate'
 			? allTransitionActions.filter(({ target }) => target !== 'done' && target !== 'cancelled')
 			: allTransitionActions;
 
@@ -518,6 +550,14 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 					</div>
 				)}
 			</div>
+			<SubmitForReviewModal
+				isOpen={showSubmitForReviewModal}
+				busy={statusTransitioning}
+				onCancel={() => {
+					if (!statusTransitioning) setShowSubmitForReviewModal(false);
+				}}
+				onConfirm={handleSubmitForReviewConfirm}
+			/>
 		</div>
 	);
 }

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -1,28 +1,28 @@
-import { useEffect, useState } from 'preact/hooks';
-import { spaceStore } from '../../lib/space-store';
-import { pushOverlayHistory, navigateToSpaceTask } from '../../lib/router';
-import { currentSpaceTaskViewTabSignal, currentSpaceIdSignal } from '../../lib/signals';
 import type {
 	SpaceTaskActivityMember,
 	SpaceTaskActivityState,
 	SpaceTaskPriority,
 	SpaceTaskStatus,
 } from '@neokai/shared';
-import { cn } from '../../lib/utils';
+import { useEffect, useState } from 'preact/hooks';
 import { borderColors } from '../../lib/design-tokens';
-import { SpaceTaskUnifiedThread } from './SpaceTaskUnifiedThread';
-import { TaskArtifactsPanel } from './TaskArtifactsPanel';
-import { getTransitionActions } from './TaskStatusActions';
-import { TaskBlockedBanner } from './TaskBlockedBanner';
-import { PendingGateBanner } from './PendingGateBanner';
-import { PendingTaskCompletionBanner } from './PendingTaskCompletionBanner';
-import { PendingPostApprovalBanner } from './PendingPostApprovalBanner';
-import { useRunGateSummaries } from './use-run-gate-summaries.ts';
+import { navigateToSpaceTask, pushOverlayHistory } from '../../lib/router';
+import { currentSpaceIdSignal, currentSpaceTaskViewTabSignal } from '../../lib/signals';
+import { spaceStore } from '../../lib/space-store';
 import { resolveActiveTaskBanner } from '../../lib/task-banner.ts';
-import { TaskSessionChatComposer } from './TaskSessionChatComposer';
-import { ReadOnlyWorkflowCanvas } from './ReadOnlyWorkflowCanvas';
+import { cn } from '../../lib/utils';
 import { Dropdown, type DropdownMenuItem } from '../ui/Dropdown';
+import { PendingGateBanner } from './PendingGateBanner';
+import { PendingPostApprovalBanner } from './PendingPostApprovalBanner';
+import { PendingTaskCompletionBanner } from './PendingTaskCompletionBanner';
+import { ReadOnlyWorkflowCanvas } from './ReadOnlyWorkflowCanvas';
+import { SpaceTaskUnifiedThread } from './SpaceTaskUnifiedThread';
 import { SubmitForReviewModal } from './SubmitForReviewModal';
+import { TaskArtifactsPanel } from './TaskArtifactsPanel';
+import { TaskBlockedBanner } from './TaskBlockedBanner';
+import { TaskSessionChatComposer } from './TaskSessionChatComposer';
+import { getTransitionActions } from './TaskStatusActions';
+import { useRunGateSummaries } from './use-run-gate-summaries.ts';
 
 interface SpaceTaskPaneProps {
 	taskId: string | null;
@@ -93,6 +93,12 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	const [sendingThread, setSendingThread] = useState(false);
 	const [statusTransitioning, setStatusTransitioning] = useState(false);
 	const [showSubmitForReviewModal, setShowSubmitForReviewModal] = useState(false);
+	// Modal-local error feedback. Separate from `threadSendError` because
+	// `threadSendError` is rendered inside `TaskSessionChatComposer`, which is
+	// only mounted when the inline composer is visible. A failed submit-for-
+	// review RPC needs to surface inside the modal regardless of composer
+	// visibility — see `SubmitForReviewModalProps.error`.
+	const [submitForReviewError, setSubmitForReviewError] = useState<string | null>(null);
 	const activeView = currentSpaceTaskViewTabSignal.value;
 	const _spaceId = currentSpaceIdSignal.value ?? '';
 
@@ -258,6 +264,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 		// `spaceStore.submitForReview` on confirm.
 		if (newStatus === 'review') {
 			setThreadSendError(null);
+			setSubmitForReviewError(null);
 			setShowSubmitForReviewModal(true);
 			return;
 		}
@@ -275,11 +282,14 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	const handleSubmitForReviewConfirm = async (reason: string | null) => {
 		try {
 			setStatusTransitioning(true);
-			setThreadSendError(null);
+			setSubmitForReviewError(null);
 			await spaceStore.submitForReview(task.id, reason);
 			setShowSubmitForReviewModal(false);
 		} catch (err) {
-			setThreadSendError(formatTaskThreadError(err));
+			// Render the error inside the modal — `threadSendError` is invisible
+			// when the inline composer is hidden, which would leave the modal
+			// frozen with no feedback after a failed submit.
+			setSubmitForReviewError(formatTaskThreadError(err));
 		} finally {
 			setStatusTransitioning(false);
 		}
@@ -557,6 +567,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 					if (!statusTransitioning) setShowSubmitForReviewModal(false);
 				}}
 				onConfirm={handleSubmitForReviewConfirm}
+				error={submitForReviewError}
 			/>
 		</div>
 	);

--- a/packages/web/src/components/space/SubmitForReviewModal.tsx
+++ b/packages/web/src/components/space/SubmitForReviewModal.tsx
@@ -1,0 +1,100 @@
+/**
+ * SubmitForReviewModal — UI counterpart to the agent `submit_for_approval` tool.
+ *
+ * Opens when a user clicks the "Submit for Review" button on an
+ * `in_progress` task. Captures an optional reason (mirrors the agent tool's
+ * `reason` parameter) and calls `spaceStore.submitForReview` on confirm,
+ * which routes through the unified `spaceTask.submitForReview` RPC.
+ *
+ * After unification, this is the only path by which a UI user can land a
+ * task in `review`. The bare `updateTask({status:'review'})` path is
+ * rejected by the daemon so callers can't accidentally bypass the
+ * pending-completion metadata that drives `PendingTaskCompletionBanner`.
+ */
+
+import { useEffect, useState } from 'preact/hooks';
+import { Modal } from '../ui/Modal.tsx';
+
+interface SubmitForReviewModalProps {
+	isOpen: boolean;
+	busy: boolean;
+	onCancel: () => void;
+	onConfirm: (reason: string | null) => void | Promise<void>;
+}
+
+export function SubmitForReviewModal({
+	isOpen,
+	busy,
+	onCancel,
+	onConfirm,
+}: SubmitForReviewModalProps) {
+	const [reason, setReason] = useState('');
+
+	// Reset the reason field whenever the modal closes so a follow-up open
+	// doesn't surface stale text from a prior submission attempt.
+	useEffect(() => {
+		if (!isOpen) setReason('');
+	}, [isOpen]);
+
+	const handleConfirm = (): void => {
+		const trimmed = reason.trim();
+		void onConfirm(trimmed ? trimmed : null);
+	};
+
+	return (
+		<Modal
+			isOpen={isOpen}
+			onClose={() => {
+				if (!busy) onCancel();
+			}}
+			title="Submit task for human review?"
+			size="md"
+		>
+			<div class="space-y-4" data-testid="submit-for-review-modal-content">
+				<p class="text-gray-300 text-sm leading-relaxed">
+					The task will be moved to <span class="font-mono">review</span>. A reviewer will approve
+					or send it back via the pending-approval banner — the same flow used by the agent{' '}
+					<span class="font-mono">submit_for_approval</span> tool.
+				</p>
+
+				<div>
+					<label class="block text-[11px] text-gray-400 mb-1" for="submit-for-review-reason-input">
+						Reason (optional — visible in the approval banner)
+					</label>
+					<textarea
+						id="submit-for-review-reason-input"
+						data-testid="submit-for-review-reason"
+						value={reason}
+						onInput={(e) => setReason((e.target as HTMLTextAreaElement).value)}
+						class="w-full rounded border border-dark-600 bg-dark-800 px-2 py-1 text-[11px] text-gray-200 focus:border-amber-500 focus:outline-none"
+						rows={3}
+						disabled={busy}
+						placeholder="What should the reviewer look at?"
+					/>
+				</div>
+
+				<div class="flex items-center justify-end gap-3 pt-1">
+					<button
+						type="button"
+						onClick={() => {
+							if (!busy) onCancel();
+						}}
+						disabled={busy}
+						class="px-4 py-2 text-sm font-medium text-gray-300 hover:text-white bg-dark-800 hover:bg-dark-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						onClick={handleConfirm}
+						disabled={busy}
+						data-testid="submit-for-review-confirm"
+						class="px-4 py-2 text-sm font-medium rounded-lg transition-colors bg-amber-600 hover:bg-amber-700 text-white disabled:bg-amber-600/50 disabled:cursor-not-allowed"
+					>
+						{busy ? 'Submitting...' : 'Submit for Review'}
+					</button>
+				</div>
+			</div>
+		</Modal>
+	);
+}

--- a/packages/web/src/components/space/SubmitForReviewModal.tsx
+++ b/packages/web/src/components/space/SubmitForReviewModal.tsx
@@ -20,6 +20,19 @@ interface SubmitForReviewModalProps {
 	busy: boolean;
 	onCancel: () => void;
 	onConfirm: (reason: string | null) => void | Promise<void>;
+	/**
+	 * Inline error message rendered inside the modal when the submit RPC
+	 * fails. Owned by the parent so it can re-trigger by clearing/setting the
+	 * value across submit attempts.
+	 *
+	 * Why this lives in the modal rather than relying on `threadSendError`:
+	 * `threadSendError` is only painted inside `TaskSessionChatComposer`, which
+	 * is mounted only when the inline composer is visible. If a user submits
+	 * for review while the composer is hidden, an RPC failure leaves the modal
+	 * frozen with no feedback. Rendering the error here makes the failure
+	 * visible regardless of composer visibility.
+	 */
+	error?: string | null;
 }
 
 export function SubmitForReviewModal({
@@ -27,6 +40,7 @@ export function SubmitForReviewModal({
 	busy,
 	onCancel,
 	onConfirm,
+	error,
 }: SubmitForReviewModalProps) {
 	const [reason, setReason] = useState('');
 
@@ -72,6 +86,12 @@ export function SubmitForReviewModal({
 						placeholder="What should the reviewer look at?"
 					/>
 				</div>
+
+				{error && (
+					<p class="text-xs text-red-400" role="alert" data-testid="submit-for-review-error">
+						{error}
+					</p>
+				)}
 
 				<div class="flex items-center justify-end gap-3 pt-1">
 					<button

--- a/packages/web/src/components/space/TaskStatusActions.tsx
+++ b/packages/web/src/components/space/TaskStatusActions.tsx
@@ -99,15 +99,28 @@ export function TaskStatusActions({
 	pendingCheckpointType,
 }: TaskStatusActionsProps) {
 	const allActions = getTransitionActions(status);
-	// When a task is paused at a submit_for_approval checkpoint or a channel
-	// gate awaiting human approval, hide the generic Approve (review → done)
-	// and Cancel (review → cancelled) buttons. The dedicated banner owns those
-	// transitions. For gate-pending tasks the PendingGateBanner provides the
-	// Approve/Reject UX; bypassing it via the generic button would mark the task
-	// done without opening the gate. Non-checkpoint transitions (e.g. Reopen →
-	// in_progress, Archive) stay visible.
+	// `review` is always "awaiting human approval via a dedicated banner":
+	//
+	//   - `task_completion` checkpoint → `PendingTaskCompletionBanner` owns
+	//     Approve / Send back, routed through `approvePendingCompletion` so the
+	//     PostApprovalRouter runs and approval metadata is stamped.
+	//   - `gate` checkpoint            → `PendingGateBanner` owns Approve /
+	//     Reject; bypassing it via the generic button would mark the task done
+	//     without opening the gate.
+	//
+	// After unification, every fresh `review` task carries
+	// `pendingCheckpointType === 'task_completion'` (set by the unified
+	// `submitTaskForReview` helper) — so the banner is always present and the
+	// generic Approve / Cancel buttons would never be the right answer. We hide
+	// them whenever the task is in `review`, regardless of `pendingCheckpointType`,
+	// so legacy data (older tasks that landed in `review` before unification with
+	// a null checkpoint type) still routes through the banner once they're
+	// approved through other means. Non-approval transitions (Reopen → in_progress,
+	// Archive) stay visible as escape hatches.
 	const actions =
-		pendingCheckpointType === 'task_completion' || pendingCheckpointType === 'gate'
+		status === 'review' ||
+		pendingCheckpointType === 'task_completion' ||
+		pendingCheckpointType === 'gate'
 			? allActions.filter(({ target }) => target !== 'done' && target !== 'cancelled')
 			: allActions;
 

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -1,7 +1,5 @@
 // @ts-nocheck
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { cleanup, fireEvent, render, waitFor } from '@testing-library/preact';
-import { signal } from '@preact/signals';
+
 import type {
 	SpaceAgent,
 	SpaceTask,
@@ -9,6 +7,9 @@ import type {
 	SpaceWorkflow,
 	SpaceWorkflowRun,
 } from '@neokai/shared';
+import { signal } from '@preact/signals';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/preact';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Bridge objects: created in vi.hoisted so mock factories can reference them.
 // Real Preact signals are assigned to .signal after module init so that mock
@@ -85,6 +86,7 @@ let mockTaskActivity: ReturnType<typeof signal<Map<string, SpaceTaskActivityMemb
 let mockNodeExecutionsByNodeId: ReturnType<typeof signal<Map<string, unknown[]>>>;
 
 const mockUpdateTask = vi.fn().mockResolvedValue(undefined);
+const mockSubmitForReview = vi.fn().mockResolvedValue(undefined);
 const mockEnsureTaskAgentSession = vi.fn();
 const mockSendTaskMessage = vi.fn().mockResolvedValue(undefined);
 const mockSubscribeTaskActivity = vi.fn().mockResolvedValue(undefined);
@@ -100,6 +102,7 @@ vi.mock('../../../lib/space-store', () => ({
 			taskActivity: mockTaskActivity,
 			nodeExecutionsByNodeId: mockNodeExecutionsByNodeId,
 			updateTask: mockUpdateTask,
+			submitForReview: mockSubmitForReview,
 			ensureTaskAgentSession: mockEnsureTaskAgentSession,
 			sendTaskMessage: mockSendTaskMessage,
 			subscribeTaskActivity: mockSubscribeTaskActivity,
@@ -1060,5 +1063,91 @@ describe('SpaceTaskPane — floating tab pill layout', () => {
 		const { queryByTestId } = render(<SpaceTaskPane taskId="task-1" spaceId="space-1" />);
 
 		expect(queryByTestId('task-pane-banner')).toBeNull();
+	});
+});
+
+// Submit-for-Review unification: the "Submit for Review" dropdown action must
+// open the optional-reason modal and route through `spaceStore.submitForReview`
+// (the unified RPC). It must NOT issue a bare `updateTask({status:'review'})`
+// — that path is rejected by the daemon because it would skip stamping
+// `pendingCheckpointType` / `pendingCompletionSubmittedByNodeId` /
+// `pendingCompletionReason`, leaving `PendingTaskCompletionBanner` invisible.
+describe('SpaceTaskPane — submit for review modal', () => {
+	beforeEach(() => {
+		cleanup();
+		mockTasks.value = [];
+		mockUpdateTask.mockClear();
+		mockSubmitForReview.mockReset();
+		mockSubmitForReview.mockResolvedValue(undefined);
+		mockEnsureTaskAgentSession.mockReset();
+		mockEnsureTaskAgentSession.mockImplementation(async () =>
+			makeTask({ status: 'in_progress', taskAgentSessionId: 'session-ensured' })
+		);
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('clicking "Submit for Review" opens the modal and does NOT call updateTask', () => {
+		mockTasks.value = [makeTask({ status: 'in_progress', taskAgentSessionId: 'session-abc' })];
+		const { getByTestId, getByText } = render(<SpaceTaskPane taskId="task-1" />);
+		fireEvent.click(getByTestId('task-actions-menu-trigger'));
+		fireEvent.click(getByText('Submit for Review'));
+
+		// Modal is open
+		expect(getByTestId('submit-for-review-modal-content')).toBeTruthy();
+		// Critical: the bare `→review` path must NOT have been used.
+		expect(mockUpdateTask).not.toHaveBeenCalled();
+		expect(mockSubmitForReview).not.toHaveBeenCalled();
+	});
+
+	it('confirming the modal calls spaceStore.submitForReview with the trimmed reason', async () => {
+		mockTasks.value = [makeTask({ status: 'in_progress', taskAgentSessionId: 'session-abc' })];
+		const { getByTestId, getByText, queryByTestId } = render(<SpaceTaskPane taskId="task-1" />);
+		fireEvent.click(getByTestId('task-actions-menu-trigger'));
+		fireEvent.click(getByText('Submit for Review'));
+
+		fireEvent.input(getByTestId('submit-for-review-reason'), {
+			target: { value: '  please verify the migration  ' },
+		});
+		fireEvent.click(getByTestId('submit-for-review-confirm'));
+
+		await waitFor(() =>
+			expect(mockSubmitForReview).toHaveBeenCalledWith('task-1', 'please verify the migration')
+		);
+		// updateTask must not be touched even on success.
+		expect(mockUpdateTask).not.toHaveBeenCalled();
+		// Modal closes after a successful confirm.
+		await waitFor(() => expect(queryByTestId('submit-for-review-modal-content')).toBeNull());
+	});
+
+	it('confirming with empty reason passes null (matches the agent tool contract)', async () => {
+		mockTasks.value = [makeTask({ status: 'in_progress', taskAgentSessionId: 'session-abc' })];
+		const { getByTestId, getByText } = render(<SpaceTaskPane taskId="task-1" />);
+		fireEvent.click(getByTestId('task-actions-menu-trigger'));
+		fireEvent.click(getByText('Submit for Review'));
+
+		fireEvent.click(getByTestId('submit-for-review-confirm'));
+
+		await waitFor(() => expect(mockSubmitForReview).toHaveBeenCalledWith('task-1', null));
+	});
+
+	it('renders RPC error inside the modal so the user gets feedback even when the inline composer is hidden', async () => {
+		mockSubmitForReview.mockRejectedValueOnce(new Error('Network down'));
+		mockTasks.value = [makeTask({ status: 'in_progress', taskAgentSessionId: 'session-abc' })];
+		const { getByTestId, getByText, findByTestId, queryByTestId } = render(
+			<SpaceTaskPane taskId="task-1" />
+		);
+		fireEvent.click(getByTestId('task-actions-menu-trigger'));
+		fireEvent.click(getByText('Submit for Review'));
+		fireEvent.click(getByTestId('submit-for-review-confirm'));
+
+		// Error surfaces inside the modal — not via threadSendError, which is
+		// invisible when the inline composer isn't mounted.
+		const errEl = await findByTestId('submit-for-review-error');
+		expect(errEl.textContent).toContain('Network down');
+		// Modal stays open so the user can retry.
+		expect(queryByTestId('submit-for-review-modal-content')).toBeTruthy();
 	});
 });

--- a/packages/web/src/components/space/__tests__/SubmitForReviewModal.test.tsx
+++ b/packages/web/src/components/space/__tests__/SubmitForReviewModal.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for SubmitForReviewModal — the UI counterpart to the agent
+ * `submit_for_approval` tool. The modal owns the optional reason input, the
+ * confirm/cancel buttons, the busy state, and the inline error.
+ *
+ * These tests pin the contract that:
+ *   - it only renders when `isOpen` is true
+ *   - confirm forwards the trimmed reason (or null for empty/whitespace)
+ *   - cancel fires `onCancel` and respects `busy`
+ *   - `busy` disables both buttons and the textarea
+ *   - the reason field resets between opens (no stale text leak)
+ *   - the `error` prop renders inline so RPC failures are visible even when
+ *     the inline composer (which owns `threadSendError`) isn't mounted
+ */
+
+import { cleanup, fireEvent, render } from '@testing-library/preact';
+// @ts-nocheck
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SubmitForReviewModal } from '../SubmitForReviewModal';
+
+describe('SubmitForReviewModal', () => {
+	beforeEach(() => {
+		cleanup();
+	});
+	afterEach(() => {
+		cleanup();
+	});
+
+	function renderModal(overrides: Partial<Parameters<typeof SubmitForReviewModal>[0]> = {}) {
+		const onCancel = vi.fn();
+		const onConfirm = vi.fn();
+		const utils = render(
+			<SubmitForReviewModal
+				isOpen={true}
+				busy={false}
+				onCancel={onCancel}
+				onConfirm={onConfirm}
+				{...overrides}
+			/>
+		);
+		return { ...utils, onCancel, onConfirm };
+	}
+
+	it('does not render when isOpen is false', () => {
+		const { queryByTestId } = render(
+			<SubmitForReviewModal isOpen={false} busy={false} onCancel={vi.fn()} onConfirm={vi.fn()} />
+		);
+		expect(queryByTestId('submit-for-review-modal-content')).toBeNull();
+	});
+
+	it('renders the body, reason textarea, and confirm/cancel buttons when open', () => {
+		const { getByTestId, getByText } = renderModal();
+		expect(getByTestId('submit-for-review-modal-content')).toBeTruthy();
+		expect(getByTestId('submit-for-review-reason')).toBeTruthy();
+		expect(getByTestId('submit-for-review-confirm')).toBeTruthy();
+		expect(getByText('Cancel')).toBeTruthy();
+	});
+
+	it('confirm forwards the trimmed reason', () => {
+		const { getByTestId, onConfirm } = renderModal();
+		fireEvent.input(getByTestId('submit-for-review-reason'), {
+			target: { value: '  please review the migration  ' },
+		});
+		fireEvent.click(getByTestId('submit-for-review-confirm'));
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+		expect(onConfirm).toHaveBeenCalledWith('please review the migration');
+	});
+
+	it('confirm passes null when the reason is empty or whitespace-only', () => {
+		const { getByTestId, onConfirm } = renderModal();
+		// Empty.
+		fireEvent.click(getByTestId('submit-for-review-confirm'));
+		expect(onConfirm).toHaveBeenLastCalledWith(null);
+
+		// Whitespace-only — must still normalize to null so the daemon's
+		// `pendingCompletionReason` field stays null rather than holding "   ".
+		fireEvent.input(getByTestId('submit-for-review-reason'), {
+			target: { value: '     ' },
+		});
+		fireEvent.click(getByTestId('submit-for-review-confirm'));
+		expect(onConfirm).toHaveBeenLastCalledWith(null);
+	});
+
+	it('cancel button fires onCancel', () => {
+		const { getByText, onCancel } = renderModal();
+		fireEvent.click(getByText('Cancel'));
+		expect(onCancel).toHaveBeenCalledTimes(1);
+	});
+
+	it('busy=true disables the confirm button, cancel button, and reason textarea', () => {
+		const { getByTestId, getByText } = renderModal({ busy: true });
+		const confirm = getByTestId('submit-for-review-confirm') as HTMLButtonElement;
+		const cancel = getByText('Cancel') as HTMLButtonElement;
+		const reason = getByTestId('submit-for-review-reason') as HTMLTextAreaElement;
+		expect(confirm.disabled).toBe(true);
+		expect(cancel.disabled).toBe(true);
+		expect(reason.disabled).toBe(true);
+		// Confirm label flips to a busy indicator so the user knows the click
+		// registered.
+		expect(confirm.textContent).toContain('Submitting');
+	});
+
+	it('busy=true does not call onCancel when cancel is clicked (button is inert)', () => {
+		const { getByText, onCancel } = renderModal({ busy: true });
+		fireEvent.click(getByText('Cancel'));
+		expect(onCancel).not.toHaveBeenCalled();
+	});
+
+	it('resets the reason field between opens so prior text does not leak', () => {
+		const onCancel = vi.fn();
+		const onConfirm = vi.fn();
+		const { rerender, getByTestId } = render(
+			<SubmitForReviewModal isOpen={true} busy={false} onCancel={onCancel} onConfirm={onConfirm} />
+		);
+		fireEvent.input(getByTestId('submit-for-review-reason'), {
+			target: { value: 'leftover text' },
+		});
+
+		// Close — modal unmounts, but the `reason` state in the closed-modal
+		// instance must reset so the next open starts blank.
+		rerender(
+			<SubmitForReviewModal isOpen={false} busy={false} onCancel={onCancel} onConfirm={onConfirm} />
+		);
+		// Reopen.
+		rerender(
+			<SubmitForReviewModal isOpen={true} busy={false} onCancel={onCancel} onConfirm={onConfirm} />
+		);
+		const reason = getByTestId('submit-for-review-reason') as HTMLTextAreaElement;
+		expect(reason.value).toBe('');
+	});
+
+	it('renders the inline error when the `error` prop is set', () => {
+		const { getByTestId } = renderModal({ error: 'Network down — please retry' });
+		const errEl = getByTestId('submit-for-review-error');
+		expect(errEl.textContent).toContain('Network down — please retry');
+		// Uses role="alert" so screen readers announce the failure when it
+		// appears mid-flow.
+		expect(errEl.getAttribute('role')).toBe('alert');
+	});
+
+	it('does not render the inline error region when `error` is null/undefined', () => {
+		const { queryByTestId } = renderModal({ error: null });
+		expect(queryByTestId('submit-for-review-error')).toBeNull();
+	});
+});

--- a/packages/web/src/components/space/__tests__/TaskStatusActions.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskStatusActions.test.tsx
@@ -211,17 +211,28 @@ describe('TaskStatusActions component', () => {
 			expect(getByTestId('task-action-archived')).toBeTruthy();
 		});
 
-		it('keeps Approve / Cancel visible when pendingCheckpointType is null', () => {
+		it('hides Approve / Cancel for any review task even when pendingCheckpointType is null', () => {
+			// After unification (Task #123) every fresh `review` task carries
+			// `pendingCheckpointType === 'task_completion'` because the unified
+			// `submitTaskForReview` helper stamps it on transition. Legacy data
+			// from before unification (null checkpoint type, status=review) must
+			// still route through the banner — the bare review→done button would
+			// bypass `PostApprovalRouter` and the approval-metadata stamp. So
+			// we hide the generic Approve/Cancel buttons whenever status==='review'
+			// regardless of `pendingCheckpointType`.
 			const onTransition = vi.fn();
-			const { getByTestId } = render(
+			const { queryByTestId, getByTestId } = render(
 				<TaskStatusActions
 					status="review"
 					onTransition={onTransition}
 					pendingCheckpointType={null}
 				/>
 			);
-			expect(getByTestId('task-action-done')).toBeTruthy();
-			expect(getByTestId('task-action-cancelled')).toBeTruthy();
+			expect(queryByTestId('task-action-done')).toBeNull();
+			expect(queryByTestId('task-action-cancelled')).toBeNull();
+			// Non-approval escape hatches stay visible.
+			expect(getByTestId('task-action-in_progress')).toBeTruthy();
+			expect(getByTestId('task-action-archived')).toBeTruthy();
 		});
 
 		it('hides Approve (done) and Cancel (cancelled) when paused at gate approval', () => {

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -1573,6 +1573,29 @@ class SpaceStore {
 	}
 
 	/**
+	 * Submit a task for human review (UI counterpart to the agent
+	 * `submit_for_approval` tool). Routes to the `spaceTask.submitForReview` RPC
+	 * which sets `status='review'`, `pendingCheckpointType='task_completion'`,
+	 * and the pending-completion metadata so `PendingTaskCompletionBanner`
+	 * renders. After unification, every task in `review` carries the banner —
+	 * the bare `updateTask({status:'review'})` path is rejected by the daemon.
+	 */
+	async submitForReview(taskId: string, reason?: string | null): Promise<SpaceTask> {
+		const spaceId = this.spaceId.value;
+		if (!spaceId) throw new Error('No space selected');
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		const task = await hub.request<SpaceTask>('spaceTask.submitForReview', {
+			taskId,
+			spaceId,
+			reason: reason ?? null,
+		});
+		return task;
+	}
+
+	/**
 	 * Approve or reject a task awaiting human sign-off at a `submit_for_approval`
 	 * checkpoint (`pendingCheckpointType === 'task_completion'`). Routes to the
 	 * `spaceTask.approvePendingCompletion` RPC which handles status transition,


### PR DESCRIPTION
Both paths now converge on `SpaceTaskManager.submitTaskForReview`, which atomically transitions a task into `review` and stamps the pending-completion fields that drive `PendingTaskCompletionBanner`. Closes the hole where the UI button shipped a bare status update — landing tasks in `review` with no banner and a generic Approve button that bypassed `PostApprovalRouter` and approval-metadata stamping.

## Daemon

- New `SpaceTaskManager.submitTaskForReview()` is the single entry point for all three callers (agent `submit_for_approval`, Task Agent self-submit, UI). It validates the transition via `setTaskStatus` first, then writes the pending-completion metadata in one repository call.
- New `spaceTask.submitForReview` RPC routes the UI button through the same helper.
- `spaceTask.update` now rejects bare `→review` transitions with an error pointing at the dedicated RPC, so banner-less review tasks can't sneak back in via legacy callers.

## Web

- "Submit for Review" opens a `SubmitForReviewModal` that captures an optional reason (mirrors the agent tool's `reason` parameter) and calls `spaceStore.submitForReview`.
- `TaskStatusActions` and `SpaceTaskPane` filter out the bare `review→done` / `review→cancelled` buttons whenever a task is in `review`, regardless of `pendingCheckpointType`. The banner is the sole approve/reject path; non-approval transitions (Reopen, Archive) stay as escape hatches.

## Test plan

- [x] Daemon: `tests/unit/1-core/lib/space-task-manager.test.ts` (98 pass — 3 new tests for `submitTaskForReview`)
- [x] Daemon: `tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts` (45 pass — new `spaceTask.submitForReview` describe block + bare-`→review` rejection test)
- [x] Daemon: `tests/unit/5-space/agent/end-node-handlers.test.ts` (15 pass — refactored to wire the shared `SpaceTaskManager` through `EndNodeHandlerDeps`)
- [x] Web: `packages/web/src/components/space/__tests__/TaskStatusActions.test.tsx` (29 pass — updated to assert that `review→done` / `review→cancelled` are hidden whenever `status === 'review'`, regardless of `pendingCheckpointType`)
- [x] `bun run lint`, `bun run typecheck`, `bun run knip` all clean