### PR TITLE
feat: preset agent drift detection and sync (M105/M106)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
@@ -3,11 +3,13 @@
  *
  * RPC handlers for Space agent CRUD operations:
  * - spaceAgent.listBuiltInTemplates - List built-in agent templates from seeding source
- * - spaceAgent.create  - Create an agent in a Space
- * - spaceAgent.list    - List all agents in a Space
- * - spaceAgent.get     - Get a single agent by ID
- * - spaceAgent.update  - Update an agent's fields
- * - spaceAgent.delete  - Delete an agent (error if referenced by workflows)
+ * - spaceAgent.create           - Create an agent in a Space
+ * - spaceAgent.list             - List all agents in a Space
+ * - spaceAgent.get              - Get a single agent by ID
+ * - spaceAgent.update           - Update an agent's fields
+ * - spaceAgent.delete           - Delete an agent (error if referenced by workflows)
+ * - spaceAgent.getDriftReport   - Compare preset-tracked agents to live preset definitions
+ * - spaceAgent.syncFromTemplate - Reset a preset-tracked agent to the current preset definition
  */
 
 import type { MessageHub } from '@neokai/shared';
@@ -117,6 +119,60 @@ export function setupSpaceAgentHandlers(
 			customPrompt: updateFields.customPrompt,
 		});
 
+		if (!result.ok) throw new Error(result.error);
+
+		daemonHub
+			.emit('spaceAgent.updated', {
+				sessionId: `space:${result.value.spaceId}`,
+				spaceId: result.value.spaceId,
+				agent: result.value,
+			})
+			.catch((err) => {
+				log.warn('Failed to emit spaceAgent.updated:', err);
+			});
+
+		return { agent: result.value };
+	});
+
+	// spaceAgent.getDriftReport — list preset-tracked agents and whether each
+	// has drifted from the source preset definition in code.
+	messageHub.onRequest('spaceAgent.getDriftReport', async (data) => {
+		const params = data as { spaceId: string };
+		if (!params.spaceId) throw new Error('spaceId is required');
+
+		// Validate space ownership for consistency with the rest of the
+		// spaceAgent.* handlers — keeps unauthenticated drift queries from
+		// leaking the existence of preset-tracked agents.
+		const space = await spaceManager.getSpace(params.spaceId);
+		if (!space) throw new Error(`Space not found: ${params.spaceId}`);
+
+		const report = spaceAgentManager.getAgentDriftReport(params.spaceId);
+		return { report };
+	});
+
+	// spaceAgent.syncFromTemplate — reset a preset-tracked agent to the
+	// current preset definition (description, tools, customPrompt) and
+	// re-stamp its template_hash. Throws if the agent has no template_name
+	// or the named preset no longer exists in code.
+	messageHub.onRequest('spaceAgent.syncFromTemplate', async (data) => {
+		const params = data as { spaceId: string; agentId: string };
+		if (!params.spaceId) throw new Error('spaceId is required');
+		if (!params.agentId) throw new Error('agentId is required');
+
+		const space = await spaceManager.getSpace(params.spaceId);
+		if (!space) throw new Error(`Space not found: ${params.spaceId}`);
+
+		// Defensive: verify the agent actually belongs to this space before
+		// running the sync. SpaceAgentManager.syncFromTemplate operates on the
+		// agent ID alone, so this check prevents one space from rewriting
+		// another space's agent via a forged spaceId.
+		const existing = spaceAgentManager.getById(params.agentId);
+		if (!existing) throw new Error(`Agent not found: ${params.agentId}`);
+		if (existing.spaceId !== params.spaceId) {
+			throw new Error(`Agent not found: ${params.agentId}`);
+		}
+
+		const result = await spaceAgentManager.syncFromTemplate(params.agentId);
 		if (!result.ok) throw new Error(result.error);
 
 		daemonHub

--- a/packages/daemon/src/lib/space/agents/agent-template-hash.ts
+++ b/packages/daemon/src/lib/space/agents/agent-template-hash.ts
@@ -1,0 +1,77 @@
+/**
+ * Agent Template Hash Utility
+ *
+ * Computes a deterministic canonical hash of a preset agent's template
+ * fingerprint for drift detection. Mirrors the workflow `template-hash.ts`
+ * utility, but for the small handful of fields that are seeded onto preset
+ * `SpaceAgent` rows by `seedPresetAgents()`.
+ *
+ * The fingerprint covers `name` (lowercased, trimmed), `description`, the
+ * `tools` array (sorted), and `customPrompt`. Runtime/identity fields like
+ * `id`, `spaceId`, `model`, `provider`, `createdAt`, `updatedAt` are NOT
+ * included — they vary per-space (or per-row) and have nothing to do with
+ * what the preset definition says the agent should look like.
+ */
+
+/**
+ * The shape of a preset agent that participates in fingerprinting.
+ *
+ * `tools` is required (use `[]` for an empty list) so the hash is stable
+ * across callers that pass an empty array vs. omitting the field.
+ */
+export interface AgentTemplateInput {
+	name: string;
+	description: string;
+	tools: string[];
+	customPrompt: string;
+}
+
+/**
+ * Canonical shape used for hashing — uses only template-portable fields.
+ *
+ * Field order matters because we hash a `JSON.stringify(...)` of this
+ * object. Keep the keys in this fixed order; do NOT sort them.
+ */
+export interface AgentTemplateFingerprint {
+	/** Lowercased + trimmed agent name. */
+	name: string;
+	/** Description as-supplied (already canonical text). */
+	description: string;
+	/** Tools sorted alphabetically for stability across array orderings. */
+	tools: string[];
+	/** Custom prompt verbatim — case + whitespace are part of the identity. */
+	customPrompt: string;
+}
+
+/**
+ * Build the canonical fingerprint of a preset agent. Useful for tests that
+ * want to assert the shape *before* hashing.
+ */
+export function buildAgentTemplateFingerprint(agent: AgentTemplateInput): AgentTemplateFingerprint {
+	return {
+		name: (agent.name ?? '').trim().toLowerCase(),
+		description: agent.description ?? '',
+		tools: [...(agent.tools ?? [])].sort(),
+		customPrompt: agent.customPrompt ?? '',
+	};
+}
+
+/**
+ * Compute the SHA-256 hex hash of a preset agent's canonical fingerprint.
+ * Used to track template versions and detect drift between the preset
+ * definition in code and what was persisted on a space's `space_agents` row.
+ */
+export function computeAgentTemplateHash(agent: AgentTemplateInput): string {
+	const fp = buildAgentTemplateFingerprint(agent);
+	const json = JSON.stringify(fp);
+	const hasher = new Bun.CryptoHasher('sha256');
+	hasher.update(json);
+	return hasher.digest('hex');
+}
+
+/**
+ * Returns true when two preset agent definitions hash to the same value.
+ */
+export function agentTemplatesMatch(a: AgentTemplateInput, b: AgentTemplateInput): boolean {
+	return computeAgentTemplateHash(a) === computeAgentTemplateHash(b);
+}

--- a/packages/daemon/src/lib/space/agents/seed-agents.ts
+++ b/packages/daemon/src/lib/space/agents/seed-agents.ts
@@ -19,6 +19,7 @@
 import type { SpaceAgent } from '@neokai/shared';
 import { KNOWN_TOOLS } from '@neokai/shared';
 import type { SpaceAgentManager, SpaceAgentResult } from '../managers/space-agent-manager';
+import { computeAgentTemplateHash } from './agent-template-hash';
 
 // ---------------------------------------------------------------------------
 // Sub-session features
@@ -326,12 +327,18 @@ export async function seedPresetAgents(
 	const errors: Array<{ name: string; error: string }> = [];
 
 	for (const preset of PRESET_AGENTS) {
+		// Stamp template tracking so the row participates in drift detection /
+		// sync from day one. Hash is computed from the same canonical
+		// fingerprint that drift detection re-derives later.
+		const templateHash = computeAgentTemplateHash(preset);
 		const result: SpaceAgentResult<SpaceAgent> = await agentManager.create({
 			spaceId,
 			name: preset.name,
 			description: preset.description,
 			tools: preset.tools,
 			customPrompt: preset.customPrompt,
+			templateName: preset.name,
+			templateHash,
 		});
 
 		if (result.ok) {

--- a/packages/daemon/src/lib/space/managers/space-agent-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-agent-manager.ts
@@ -10,10 +10,18 @@
  *   - Deletion blocked when agent is referenced by workflow nodes
  */
 
-import type { SpaceAgent, CreateSpaceAgentParams, UpdateSpaceAgentParams } from '@neokai/shared';
+import type {
+	SpaceAgent,
+	CreateSpaceAgentParams,
+	UpdateSpaceAgentParams,
+	AgentDriftEntry,
+	AgentDriftReport,
+} from '@neokai/shared';
 import { KNOWN_TOOLS } from '@neokai/shared';
 import type { SpaceAgentRepository } from '../../../storage/repositories/space-agent-repository';
 import { isValidModel, getAvailableModels, getModelInfoUnfiltered } from '../../model-service';
+import { getPresetAgentTemplates } from '../agents/seed-agents';
+import { computeAgentTemplateHash } from '../agents/agent-template-hash';
 
 const KNOWN_TOOLS_SET = new Set<string>(KNOWN_TOOLS);
 
@@ -132,6 +140,82 @@ export class SpaceAgentManager {
 	 */
 	getAgentsByIds(ids: string[]): SpaceAgent[] {
 		return this.repo.getAgentsByIds(ids);
+	}
+
+	/**
+	 * Build a drift report for every preset-tracked agent in a space.
+	 *
+	 * For each `SpaceAgent` row that has a non-null `templateName`, this
+	 * recomputes the current preset's hash from `getPresetAgentTemplates()`
+	 * and compares it to the stored `templateHash`. Rows whose `templateName`
+	 * doesn't match any current preset (e.g. a preset was deleted in code) are
+	 * silently skipped — there's nothing to sync against.
+	 *
+	 * User-created agents (`templateName === null`) are NOT included in the
+	 * report at all; the UI relies on this to decide which cards get a badge.
+	 */
+	getAgentDriftReport(spaceId: string): AgentDriftReport {
+		const agents = this.repo.getBySpaceId(spaceId);
+		const presetByName = new Map(getPresetAgentTemplates().map((p) => [p.name.toLowerCase(), p]));
+
+		const entries: AgentDriftEntry[] = [];
+		for (const agent of agents) {
+			if (!agent.templateName) continue;
+			const preset = presetByName.get(agent.templateName.toLowerCase());
+			if (!preset) continue;
+
+			const currentHash = computeAgentTemplateHash(preset);
+			const storedHash = agent.templateHash ?? null;
+			entries.push({
+				agentId: agent.id,
+				agentName: agent.name,
+				templateName: agent.templateName,
+				storedHash,
+				currentHash,
+				drifted: storedHash !== currentHash,
+			});
+		}
+
+		return { spaceId, agents: entries };
+	}
+
+	/**
+	 * Reset a preset-tracked agent's `description`, `tools`, and
+	 * `customPrompt` to the current preset definition, then re-stamp the
+	 * stored `templateHash`. Throws when the agent is not preset-tracked or
+	 * when the preset can no longer be found in code.
+	 *
+	 * The agent's `id`, `spaceId`, `name`, `model`, and `provider` are
+	 * preserved — only the fields that participate in the fingerprint are
+	 * overwritten.
+	 */
+	async syncFromTemplate(agentId: string): Promise<SpaceAgentResult<SpaceAgent>> {
+		const existing = this.repo.getById(agentId);
+		if (!existing) return { ok: false, error: `Agent not found: ${agentId}` };
+		if (!existing.templateName) {
+			return {
+				ok: false,
+				error: `Agent "${existing.name}" is not linked to a preset template and cannot be synced.`,
+			};
+		}
+
+		const presetByName = new Map(getPresetAgentTemplates().map((p) => [p.name.toLowerCase(), p]));
+		const preset = presetByName.get(existing.templateName.toLowerCase());
+		if (!preset) {
+			return {
+				ok: false,
+				error: `Preset template "${existing.templateName}" not found. It may have been removed from the code.`,
+			};
+		}
+
+		const updated = this.repo.update(agentId, {
+			description: preset.description,
+			tools: preset.tools,
+			customPrompt: preset.customPrompt,
+			templateHash: computeAgentTemplateHash(preset),
+		});
+		if (!updated) return { ok: false, error: `Agent not found after sync: ${agentId}` };
+		return { ok: true, value: updated };
 	}
 
 	// ---------------------------------------------------------------------------

--- a/packages/daemon/src/storage/repositories/space-agent-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-agent-repository.ts
@@ -4,8 +4,10 @@
  * CRUD operations for space_agents table.
  *
  * Column mapping:
- *   SpaceAgent.customPrompt  ↔  custom_prompt column (nullable text)
- *   SpaceAgent.tools         ↔  tools column (JSON string array; '[]' or null → undefined)
+ *   SpaceAgent.customPrompt   ↔  custom_prompt column (nullable text)
+ *   SpaceAgent.tools          ↔  tools column (JSON string array; '[]' or null → undefined)
+ *   SpaceAgent.templateName   ↔  template_name column (nullable text; null for user-created agents)
+ *   SpaceAgent.templateHash   ↔  template_hash column (nullable text; null for user-created agents)
  */
 
 import type { Database as BunDatabase } from 'bun:sqlite';
@@ -26,8 +28,9 @@ export class SpaceAgentRepository {
 		this.db
 			.prepare(
 				`INSERT INTO space_agents
-					(id, space_id, name, description, model, provider, tools, custom_prompt, created_at, updated_at)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+					(id, space_id, name, description, model, provider, tools, custom_prompt,
+					 template_name, template_hash, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			)
 			.run(
 				id,
@@ -38,6 +41,8 @@ export class SpaceAgentRepository {
 				params.provider ?? null,
 				params.tools && params.tools.length > 0 ? JSON.stringify(params.tools) : '[]',
 				params.customPrompt ?? null,
+				params.templateName ?? null,
+				params.templateHash ?? null,
 				now,
 				now
 			);
@@ -128,6 +133,14 @@ export class SpaceAgentRepository {
 			fields.push('tools = ?');
 			values.push(params.tools && params.tools.length > 0 ? JSON.stringify(params.tools) : '[]');
 		}
+		if (params.templateName !== undefined) {
+			fields.push('template_name = ?');
+			values.push(params.templateName ?? null);
+		}
+		if (params.templateHash !== undefined) {
+			fields.push('template_hash = ?');
+			values.push(params.templateHash ?? null);
+		}
 
 		if (fields.length === 0) return this.getById(id);
 
@@ -183,6 +196,11 @@ export class SpaceAgentRepository {
 			provider: (row.provider as string | null) ?? undefined,
 			customPrompt: (row.custom_prompt as string | null) ?? null,
 			tools,
+			// `template_name` / `template_hash` may be missing entirely on
+			// schemas that predate M105 — guard with `??` so older test DBs
+			// (and any pre-migration call paths) don't return `undefined`.
+			templateName: (row.template_name as string | null | undefined) ?? null,
+			templateHash: (row.template_hash as string | null | undefined) ?? null,
 			createdAt: row.created_at as number,
 			updatedAt: row.updated_at as number,
 		};

--- a/packages/daemon/src/storage/schema/m106-backfill-agent-templates.ts
+++ b/packages/daemon/src/storage/schema/m106-backfill-agent-templates.ts
@@ -1,0 +1,160 @@
+/**
+ * Migration 106 — Backfill preset agent template tracking.
+ *
+ * Context: M105 added `template_name` / `template_hash` columns to
+ * `space_agents`, but every row seeded before M105 has those columns
+ * NULL. Drift detection silently skips rows with `template_name = NULL`,
+ * so without a backfill the new "Sync from template" button would never
+ * appear on existing spaces — even though those spaces clearly seeded
+ * preset agents.
+ *
+ * What this migration does:
+ *   For each `space_agents` row with `template_name = NULL` whose
+ *   normalized name matches a known preset name (case-insensitive),
+ *   set `template_name` to the canonical preset name and `template_hash`
+ *   to the SHA-256 fingerprint of the row's CURRENT field values
+ *   (description, tools, customPrompt). Hashing the row — not the live
+ *   preset — preserves any user customisations: drift detection then
+ *   surfaces those rows as "out of sync" and the user can opt into the
+ *   sync via the UI button.
+ *
+ * Self-contained by design — migrations must not depend on runtime app
+ * logic that may drift over time. The preset name list and the hashing
+ * logic are inlined here so the migration's behaviour is frozen at the
+ * time it was authored.
+ *
+ * Idempotent: re-running on a DB whose rows already have `template_name`
+ * is a no-op (we only touch rows where `template_name IS NULL`).
+ *
+ * Mirrors the pattern used by `m94-backfill-workflow-templates.ts`.
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+
+// ---------------------------------------------------------------------------
+// Frozen preset name set — the six built-in presets seeded by
+// `seedPresetAgents()` at the time M106 was authored. Matched
+// case-insensitively against the row's `name` column.
+// ---------------------------------------------------------------------------
+
+const KNOWN_PRESET_NAMES = ['Coder', 'General', 'Planner', 'Research', 'Reviewer', 'QA'] as const;
+
+// ---------------------------------------------------------------------------
+// Canonical fingerprint / hash — frozen historical copy. Mirrors the live
+// `agent-template-hash.ts` AS OF the M106 authoring date. We deliberately
+// inline this rather than importing the runtime utility so that the
+// migration's behaviour is stable across future template format changes.
+// ---------------------------------------------------------------------------
+
+interface AgentFingerprintInput {
+	name: string;
+	description: string;
+	tools: string[];
+	customPrompt: string;
+}
+
+function buildAgentFingerprint(input: AgentFingerprintInput): {
+	name: string;
+	description: string;
+	tools: string[];
+	customPrompt: string;
+} {
+	return {
+		name: (input.name ?? '').trim().toLowerCase(),
+		description: input.description ?? '',
+		tools: [...(input.tools ?? [])].sort(),
+		customPrompt: input.customPrompt ?? '',
+	};
+}
+
+function hashAgentFingerprint(input: AgentFingerprintInput): string {
+	const fp = buildAgentFingerprint(input);
+	const json = JSON.stringify(fp);
+	const hasher = new Bun.CryptoHasher('sha256');
+	hasher.update(json);
+	return hasher.digest('hex');
+}
+
+// ---------------------------------------------------------------------------
+// DB row shape
+// ---------------------------------------------------------------------------
+
+interface AgentRow {
+	id: string;
+	name: string;
+	description: string | null;
+	tools: string | null;
+	custom_prompt: string | null;
+	template_name: string | null;
+	template_hash: string | null;
+}
+
+function tableExists(db: BunDatabase, tableName: string): boolean {
+	const result = db
+		.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`)
+		.get(tableName);
+	return !!result;
+}
+
+function tableHasColumn(db: BunDatabase, tableName: string, columnName: string): boolean {
+	const result = db
+		.prepare(`SELECT name FROM pragma_table_info('${tableName}') WHERE name = ?`)
+		.get(columnName);
+	return !!result;
+}
+
+function parseTools(raw: string | null): string[] {
+	if (!raw) return [];
+	try {
+		const parsed = JSON.parse(raw);
+		return Array.isArray(parsed) ? (parsed.filter((t) => typeof t === 'string') as string[]) : [];
+	} catch {
+		return [];
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Migration entrypoint
+// ---------------------------------------------------------------------------
+
+export function runMigration106(db: BunDatabase): void {
+	if (!tableExists(db, 'space_agents')) return;
+	// Guard on the template columns existing — if M105 hasn't run yet (in
+	// practice it always does, runMigrations runs them in order), skip.
+	if (!tableHasColumn(db, 'space_agents', 'template_name')) return;
+	if (!tableHasColumn(db, 'space_agents', 'template_hash')) return;
+
+	// Lower-case lookup map: normalized name → canonical preset name.
+	const presetByLowerName = new Map<string, string>(
+		KNOWN_PRESET_NAMES.map((n) => [n.toLowerCase(), n])
+	);
+
+	const rows = db
+		.prepare(
+			`SELECT id, name, description, tools, custom_prompt, template_name, template_hash
+			   FROM space_agents
+			  WHERE template_name IS NULL`
+		)
+		.all() as AgentRow[];
+
+	if (rows.length === 0) return;
+
+	const update = db.prepare(
+		`UPDATE space_agents SET template_name = ?, template_hash = ? WHERE id = ?`
+	);
+
+	for (const row of rows) {
+		const normalized = (row.name ?? '').trim().toLowerCase();
+		const canonicalName = presetByLowerName.get(normalized);
+		if (!canonicalName) continue; // user-created agent — leave alone
+
+		const hash = hashAgentFingerprint({
+			name: canonicalName,
+			description: row.description ?? '',
+			tools: parseTools(row.tools),
+			customPrompt: row.custom_prompt ?? '',
+		});
+
+		update.run(canonicalName, hash, row.id);
+	}
+}

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -11,6 +11,7 @@
 
 import type { Database as BunDatabase } from 'bun:sqlite';
 import { runMigration94 as runMigration94External } from './m94-backfill-workflow-templates';
+import { runMigration106 as runMigration106External } from './m106-backfill-agent-templates';
 
 /**
  * Run all database migrations
@@ -494,6 +495,19 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	//     dropping it is gated on a writer audit and shipped in a later
 	//     cleanup migration.
 	runMigration104(db);
+
+	// Migration 105: Add template_name and template_hash to space_agents for
+	//   preset-agent drift detection. Mirrors the workflow template-tracking
+	//   columns added in M90 so preset-seeded agents can detect when the source
+	//   definitions in seed-agents.ts have moved on, and the UI can offer a
+	//   one-click "Sync from template" action.
+	runMigration105(db);
+
+	// Migration 106: Backfill template_name + template_hash on existing
+	//   space_agents rows that match a preset agent by name but predate M105.
+	//   Self-contained (frozen preset fingerprints inlined) — same pattern as
+	//   M94 for workflow templates.
+	runMigration106(db);
 }
 
 /**
@@ -7314,4 +7328,37 @@ export function runMigration104(db: BunDatabase): void {
 	) {
 		db.exec(`ALTER TABLE space_workflow_runs DROP COLUMN completion_actions_fired_at`);
 	}
+}
+
+/**
+ * Migration 105: Add `template_name` and `template_hash` columns to
+ * `space_agents` for preset-agent drift detection. Mirrors the workflow
+ * template-tracking columns added in M90 — preset-seeded agents now carry
+ * these fields so the daemon can detect when the source preset definition
+ * has changed and the UI can surface a "Sync from template" action.
+ *
+ * Both columns are nullable: user-created agents always have NULL for both,
+ * which is the marker the drift-detection RPC uses to ignore them.
+ *
+ * Idempotent: re-running on a DB that already has the columns is a no-op.
+ */
+export function runMigration105(db: BunDatabase): void {
+	if (!tableExists(db, 'space_agents')) return;
+
+	if (!tableHasColumn(db, 'space_agents', 'template_name')) {
+		db.exec(`ALTER TABLE space_agents ADD COLUMN template_name TEXT DEFAULT NULL`);
+	}
+	if (!tableHasColumn(db, 'space_agents', 'template_hash')) {
+		db.exec(`ALTER TABLE space_agents ADD COLUMN template_hash TEXT DEFAULT NULL`);
+	}
+}
+
+/**
+ * Migration 106 — delegated to m106-backfill-agent-templates.ts so the
+ * frozen preset definitions don't bloat this file. Runs strictly *after*
+ * M105 so the columns exist. The behaviour is documented in that module.
+ * Exported for direct invocation from tests.
+ */
+export function runMigration106(db: BunDatabase): void {
+	runMigration106External(db);
 }

--- a/packages/daemon/tests/unit/1-core/lib/space-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-agent-manager.test.ts
@@ -388,4 +388,209 @@ describe('SpaceAgentManager', () => {
 			if (result.ok) expect(result.value.tools).toBeUndefined();
 		});
 	});
+
+	// -------------------------------------------------------------------------
+	// drift detection — getAgentDriftReport / syncFromTemplate
+	// -------------------------------------------------------------------------
+
+	describe('getAgentDriftReport', () => {
+		it('returns an empty report when the space has no agents', () => {
+			const report = manager.getAgentDriftReport('space-1');
+			expect(report.spaceId).toBe('space-1');
+			expect(report.agents).toEqual([]);
+		});
+
+		it('omits user-created agents (no templateName) entirely from the report', async () => {
+			await manager.create({ spaceId: 'space-1', name: 'CustomBot' });
+			const report = manager.getAgentDriftReport('space-1');
+			expect(report.agents).toEqual([]);
+		});
+
+		it('reports drifted=false when stored hash matches the current preset hash', async () => {
+			// Use a known preset name ("Coder") so the manager can find a live
+			// preset to compare against. We seed it with the real preset's hash.
+			const { getPresetAgentTemplates } = await import(
+				'../../../../src/lib/space/agents/seed-agents'
+			);
+			const { computeAgentTemplateHash } = await import(
+				'../../../../src/lib/space/agents/agent-template-hash'
+			);
+			const coder = getPresetAgentTemplates().find((p) => p.name === 'Coder');
+			if (!coder) throw new Error('Coder preset missing');
+			const hash = computeAgentTemplateHash(coder);
+
+			await manager.create({
+				spaceId: 'space-1',
+				name: 'Coder',
+				description: coder.description,
+				tools: coder.tools,
+				customPrompt: coder.customPrompt,
+				templateName: 'Coder',
+				templateHash: hash,
+			});
+
+			const report = manager.getAgentDriftReport('space-1');
+			expect(report.agents).toHaveLength(1);
+			expect(report.agents[0].agentName).toBe('Coder');
+			expect(report.agents[0].templateName).toBe('Coder');
+			expect(report.agents[0].drifted).toBe(false);
+			expect(report.agents[0].storedHash).toBe(hash);
+			expect(report.agents[0].currentHash).toBe(hash);
+		});
+
+		it('reports drifted=true when stored hash differs from the current preset hash', async () => {
+			await manager.create({
+				spaceId: 'space-1',
+				name: 'Coder',
+				description: 'Old description',
+				tools: ['Read'],
+				customPrompt: 'old prompt',
+				templateName: 'Coder',
+				templateHash: 'stale-hash-value',
+			});
+
+			const report = manager.getAgentDriftReport('space-1');
+			expect(report.agents).toHaveLength(1);
+			expect(report.agents[0].drifted).toBe(true);
+			expect(report.agents[0].storedHash).toBe('stale-hash-value');
+			expect(report.agents[0].currentHash).not.toBe('stale-hash-value');
+		});
+
+		it('reports drifted=true when storedHash is null (post-backfill unmatchable rows)', async () => {
+			await manager.create({
+				spaceId: 'space-1',
+				name: 'Coder',
+				templateName: 'Coder',
+				// Intentionally omit templateHash — exercises the null-hash branch.
+			});
+
+			const report = manager.getAgentDriftReport('space-1');
+			expect(report.agents).toHaveLength(1);
+			expect(report.agents[0].storedHash).toBeNull();
+			expect(report.agents[0].drifted).toBe(true);
+		});
+
+		it('skips rows whose templateName no longer matches any preset', async () => {
+			await manager.create({
+				spaceId: 'space-1',
+				name: 'Ghost',
+				templateName: 'NonExistentPreset',
+				templateHash: 'whatever',
+			});
+
+			const report = manager.getAgentDriftReport('space-1');
+			expect(report.agents).toEqual([]);
+		});
+	});
+
+	describe('syncFromTemplate', () => {
+		it('rejects user-created (non-preset) agents', async () => {
+			const created = await manager.create({ spaceId: 'space-1', name: 'CustomBot' });
+			if (!created.ok) throw new Error('create failed');
+
+			const result = await manager.syncFromTemplate(created.value.id);
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.error).toMatch(/not linked to a preset/i);
+		});
+
+		it('rejects when the agent ID does not exist', async () => {
+			const result = await manager.syncFromTemplate('does-not-exist');
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.error).toMatch(/not found/i);
+		});
+
+		it('rejects when the templateName references a preset that no longer exists', async () => {
+			const created = await manager.create({
+				spaceId: 'space-1',
+				name: 'Ghost',
+				templateName: 'NonExistentPreset',
+				templateHash: 'whatever',
+			});
+			if (!created.ok) throw new Error('create failed');
+
+			const result = await manager.syncFromTemplate(created.value.id);
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.error).toMatch(/not found/i);
+		});
+
+		it('overwrites description, tools, and customPrompt with current preset values', async () => {
+			const { getPresetAgentTemplates } = await import(
+				'../../../../src/lib/space/agents/seed-agents'
+			);
+			const coder = getPresetAgentTemplates().find((p) => p.name === 'Coder');
+			if (!coder) throw new Error('Coder preset missing');
+
+			const created = await manager.create({
+				spaceId: 'space-1',
+				name: 'Coder',
+				description: 'User-edited description',
+				tools: ['Read'],
+				customPrompt: 'User-edited prompt',
+				templateName: 'Coder',
+				templateHash: 'stale-hash',
+			});
+			if (!created.ok) throw new Error('create failed');
+
+			const result = await manager.syncFromTemplate(created.value.id);
+			expect(result.ok).toBe(true);
+			if (!result.ok) throw new Error('expected ok');
+
+			expect(result.value.description).toBe(coder.description);
+			expect(result.value.tools).toEqual(coder.tools);
+			expect(result.value.customPrompt).toBe(coder.customPrompt);
+		});
+
+		it('preserves id, spaceId, name, model, and provider', async () => {
+			const created = await manager.create({
+				spaceId: 'space-1',
+				name: 'Coder',
+				description: 'old',
+				tools: ['Read'],
+				customPrompt: 'old',
+				templateName: 'Coder',
+				templateHash: 'stale',
+			});
+			if (!created.ok) throw new Error('create failed');
+
+			// Force a model + provider after create (to verify they survive sync).
+			const updated = await manager.update(created.value.id, {
+				model: 'sonnet',
+				provider: 'anthropic',
+			});
+			if (!updated.ok) throw new Error('update failed');
+
+			const result = await manager.syncFromTemplate(created.value.id);
+			expect(result.ok).toBe(true);
+			if (!result.ok) throw new Error('expected ok');
+
+			expect(result.value.id).toBe(created.value.id);
+			expect(result.value.spaceId).toBe(created.value.spaceId);
+			expect(result.value.name).toBe('Coder');
+			expect(result.value.model).toBe('sonnet');
+			expect(result.value.provider).toBe('anthropic');
+		});
+
+		it('re-stamps templateHash so a follow-up drift report shows drifted=false', async () => {
+			const created = await manager.create({
+				spaceId: 'space-1',
+				name: 'Coder',
+				description: 'old',
+				tools: ['Read'],
+				customPrompt: 'old',
+				templateName: 'Coder',
+				templateHash: 'stale-hash',
+			});
+			if (!created.ok) throw new Error('create failed');
+
+			const before = manager.getAgentDriftReport('space-1');
+			expect(before.agents[0].drifted).toBe(true);
+
+			const sync = await manager.syncFromTemplate(created.value.id);
+			expect(sync.ok).toBe(true);
+
+			const after = manager.getAgentDriftReport('space-1');
+			expect(after.agents[0].drifted).toBe(false);
+			expect(after.agents[0].storedHash).toBe(after.agents[0].currentHash);
+		});
+	});
 });

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-agent-handlers.test.ts
@@ -509,4 +509,155 @@ describe('Space Agent RPC Handlers', () => {
 			expect(result.success).toBe(true);
 		});
 	});
+
+	// ── spaceAgent.getDriftReport ────────────────────────────────────────────
+
+	describe('spaceAgent.getDriftReport', () => {
+		it('registers the handler', () => {
+			expect(hubData.handlers.has('spaceAgent.getDriftReport')).toBe(true);
+		});
+
+		it('returns an empty agents array for a space with no preset-tracked agents', async () => {
+			const result = await call<{
+				report: { spaceId: string; agents: Array<{ drifted: boolean }> };
+			}>(hubData.handlers, 'spaceAgent.getDriftReport', { spaceId: 'space-1' });
+
+			expect(result.report.spaceId).toBe('space-1');
+			expect(result.report.agents).toEqual([]);
+		});
+
+		it('reports a drifted=true entry when stored hash differs from current preset', async () => {
+			// Insert a preset-tracked agent directly via the manager so we can
+			// supply a stale hash without relying on the seeding pipeline.
+			await manager.create({
+				spaceId: 'space-1',
+				name: 'Coder',
+				description: 'old',
+				tools: ['Read'],
+				customPrompt: 'old',
+				templateName: 'Coder',
+				templateHash: 'stale-hash',
+			});
+
+			const result = await call<{
+				report: {
+					spaceId: string;
+					agents: Array<{ agentName: string; drifted: boolean; storedHash: string | null }>;
+				};
+			}>(hubData.handlers, 'spaceAgent.getDriftReport', { spaceId: 'space-1' });
+
+			expect(result.report.agents).toHaveLength(1);
+			expect(result.report.agents[0].agentName).toBe('Coder');
+			expect(result.report.agents[0].drifted).toBe(true);
+			expect(result.report.agents[0].storedHash).toBe('stale-hash');
+		});
+
+		it('throws when spaceId is missing', async () => {
+			await expect(call(hubData.handlers, 'spaceAgent.getDriftReport', {})).rejects.toThrow(
+				'spaceId is required'
+			);
+		});
+
+		it('throws when space does not exist', async () => {
+			await expect(
+				call(hubData.handlers, 'spaceAgent.getDriftReport', { spaceId: 'ghost' })
+			).rejects.toThrow('Space not found');
+		});
+	});
+
+	// ── spaceAgent.syncFromTemplate ──────────────────────────────────────────
+
+	describe('spaceAgent.syncFromTemplate', () => {
+		it('registers the handler', () => {
+			expect(hubData.handlers.has('spaceAgent.syncFromTemplate')).toBe(true);
+		});
+
+		it('throws when spaceId is missing', async () => {
+			await expect(
+				call(hubData.handlers, 'spaceAgent.syncFromTemplate', { agentId: 'a-1' })
+			).rejects.toThrow('spaceId is required');
+		});
+
+		it('throws when agentId is missing', async () => {
+			await expect(
+				call(hubData.handlers, 'spaceAgent.syncFromTemplate', { spaceId: 'space-1' })
+			).rejects.toThrow('agentId is required');
+		});
+
+		it('throws when space does not exist', async () => {
+			await expect(
+				call(hubData.handlers, 'spaceAgent.syncFromTemplate', {
+					spaceId: 'ghost',
+					agentId: 'a-1',
+				})
+			).rejects.toThrow('Space not found');
+		});
+
+		it('throws when agent does not exist', async () => {
+			await expect(
+				call(hubData.handlers, 'spaceAgent.syncFromTemplate', {
+					spaceId: 'space-1',
+					agentId: 'ghost-agent',
+				})
+			).rejects.toThrow('Agent not found');
+		});
+
+		it('throws when agent belongs to a different space (cross-space attack)', async () => {
+			// Create a second space and an agent in it. Then attempt to "sync" that
+			// agent while claiming spaceId of the *other* space.
+			insertSpace(db, 'space-2');
+			spaceManagerData.getSpaceMock.mockImplementation(async (id: string) => {
+				if (id === 'space-1' || id === 'space-2') return { id } as never;
+				return null;
+			});
+			const created = await manager.create({
+				spaceId: 'space-2',
+				name: 'Coder',
+				templateName: 'Coder',
+				templateHash: 'h',
+			});
+			if (!created.ok) throw new Error('create failed');
+
+			await expect(
+				call(hubData.handlers, 'spaceAgent.syncFromTemplate', {
+					spaceId: 'space-1',
+					agentId: created.value.id,
+				})
+			).rejects.toThrow('Agent not found');
+		});
+
+		it('returns the updated agent and emits spaceAgent.updated', async () => {
+			const created = await manager.create({
+				spaceId: 'space-1',
+				name: 'Coder',
+				description: 'old',
+				tools: ['Read'],
+				customPrompt: 'old',
+				templateName: 'Coder',
+				templateHash: 'stale',
+			});
+			if (!created.ok) throw new Error('create failed');
+
+			daemonData.emitMock.mockClear();
+
+			const result = await call<{ agent: { id: string; templateName: string | null } }>(
+				hubData.handlers,
+				'spaceAgent.syncFromTemplate',
+				{ spaceId: 'space-1', agentId: created.value.id }
+			);
+
+			expect(result.agent.id).toBe(created.value.id);
+			expect(result.agent.templateName).toBe('Coder');
+
+			await new Promise((r) => setTimeout(r, 0));
+			expect(daemonData.emitMock).toHaveBeenCalled();
+			const [eventName, payload] = daemonData.emitMock.mock.calls[0] as [
+				string,
+				{ spaceId: string; agent: { id: string } },
+			];
+			expect(eventName).toBe('spaceAgent.updated');
+			expect(payload.spaceId).toBe('space-1');
+			expect(payload.agent.id).toBe(created.value.id);
+		});
+	});
 });

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-export-import-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-export-import-handlers.test.ts
@@ -61,6 +61,8 @@ function createSchema(db: Database): void {
 			provider TEXT,
 			tools TEXT NOT NULL DEFAULT '[]',
 			custom_prompt TEXT,
+			template_name TEXT DEFAULT NULL,
+			template_hash TEXT DEFAULT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-106_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-106_test.ts
@@ -1,0 +1,254 @@
+/**
+ * Migration 106 Tests — Backfill preset agent template tracking.
+ *
+ * Migration 106 walks every `space_agents` row whose `template_name IS NULL`
+ * and, when the row's normalized name matches a known preset (case-insensitive),
+ * stamps:
+ *   - `template_name` = canonical preset name ("Coder", "Reviewer", ...)
+ *   - `template_hash` = SHA-256 of the row's CURRENT field values
+ *
+ * Hashing the row (not the live preset) preserves user customisations: the
+ * row's stored hash differs from the live preset's hash, so drift detection
+ * surfaces the row as "out of sync" rather than silently overwriting local
+ * edits.
+ *
+ * Covers:
+ *   - Canonical preset name (exact match) → backfilled
+ *   - Lowercase / surrounding whitespace → matched + canonicalised
+ *   - User-created agent (no preset name match) → untouched
+ *   - Hash captures the row's current state (preserves customisation)
+ *   - Idempotency: running twice is a no-op
+ *   - Pre-existing template_name on a row → not overwritten
+ *   - Empty `space_agents` table → safe
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../../src/storage/schema/index.ts';
+import { runMigration106 } from '../../../../../src/storage/schema/migrations.ts';
+
+interface AgentRow {
+	id: string;
+	name: string;
+	template_name: string | null;
+	template_hash: string | null;
+	description: string | null;
+	tools: string | null;
+	custom_prompt: string | null;
+}
+
+function insertSpace(db: BunDatabase, id: string): void {
+	const now = Date.now();
+	db.prepare(
+		`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`
+	).run(id, id, `/ws/${id}`, id, now, now);
+}
+
+function insertAgent(
+	db: BunDatabase,
+	opts: {
+		id: string;
+		spaceId: string;
+		name: string;
+		description?: string;
+		tools?: string[];
+		customPrompt?: string | null;
+		templateName?: string | null;
+		templateHash?: string | null;
+	}
+): void {
+	const now = Date.now();
+	db.prepare(
+		`INSERT INTO space_agents (
+			id, space_id, name, description, tools, custom_prompt, template_name, template_hash, created_at, updated_at
+		 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	).run(
+		opts.id,
+		opts.spaceId,
+		opts.name,
+		opts.description ?? '',
+		JSON.stringify(opts.tools ?? []),
+		opts.customPrompt ?? null,
+		opts.templateName ?? null,
+		opts.templateHash ?? null,
+		now,
+		now
+	);
+}
+
+function readAgent(db: BunDatabase, id: string): AgentRow | undefined {
+	return db
+		.prepare(
+			`SELECT id, name, template_name, template_hash, description, tools, custom_prompt
+			   FROM space_agents WHERE id = ?`
+		)
+		.get(id) as AgentRow | undefined;
+}
+
+describe('Migration 106: backfill preset agent template tracking', () => {
+	let testDir: string;
+	let db: BunDatabase;
+
+	beforeEach(() => {
+		testDir = join(
+			process.cwd(),
+			'tmp',
+			'test-migration-106',
+			`test-${Date.now()}-${Math.random()}`
+		);
+		mkdirSync(testDir, { recursive: true });
+		db = new BunDatabase(join(testDir, 'test.db'));
+		db.exec('PRAGMA foreign_keys = ON');
+		runMigrations(db, () => {});
+		insertSpace(db, 'sp-1');
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	test('canonical preset name → template_name + template_hash backfilled', () => {
+		insertAgent(db, {
+			id: 'a-1',
+			spaceId: 'sp-1',
+			name: 'Coder',
+			description: 'whatever',
+			tools: ['Read'],
+			customPrompt: 'old prompt',
+		});
+
+		runMigration106(db);
+
+		const row = readAgent(db, 'a-1')!;
+		expect(row.template_name).toBe('Coder');
+		expect(row.template_hash).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	test('lowercase / whitespace name → matched and canonicalised to "Coder"', () => {
+		insertAgent(db, { id: 'a-1', spaceId: 'sp-1', name: '  coder  ' });
+		runMigration106(db);
+
+		const row = readAgent(db, 'a-1')!;
+		expect(row.template_name).toBe('Coder');
+	});
+
+	test('user-created agent (non-preset name) → untouched', () => {
+		insertAgent(db, { id: 'a-custom', spaceId: 'sp-1', name: 'CustomBot' });
+		runMigration106(db);
+
+		const row = readAgent(db, 'a-custom')!;
+		expect(row.template_name).toBeNull();
+		expect(row.template_hash).toBeNull();
+	});
+
+	test('all six known presets are matched', () => {
+		const presetNames = ['Coder', 'General', 'Planner', 'Research', 'Reviewer', 'QA'];
+		presetNames.forEach((name, i) => {
+			insertAgent(db, { id: `a-${i}`, spaceId: 'sp-1', name });
+		});
+
+		runMigration106(db);
+
+		presetNames.forEach((name, i) => {
+			const row = readAgent(db, `a-${i}`)!;
+			expect(row.template_name).toBe(name);
+			expect(row.template_hash).toMatch(/^[0-9a-f]{64}$/);
+		});
+	});
+
+	test('hash captures the row\u2019s current state — two identical rows hash equal', () => {
+		insertAgent(db, {
+			id: 'a-1',
+			spaceId: 'sp-1',
+			name: 'Coder',
+			description: 'd',
+			tools: ['Read', 'Write'],
+			customPrompt: 'p',
+		});
+		insertAgent(db, {
+			id: 'a-2',
+			spaceId: 'sp-1',
+			name: 'Coder',
+			description: 'd',
+			tools: ['Write', 'Read'], // different ordering — hash should still match
+			customPrompt: 'p',
+		});
+
+		runMigration106(db);
+
+		const r1 = readAgent(db, 'a-1')!;
+		const r2 = readAgent(db, 'a-2')!;
+		expect(r1.template_hash).toBe(r2.template_hash);
+	});
+
+	test('rows that differ in description hash to different values (drift surface)', () => {
+		insertAgent(db, {
+			id: 'a-stock',
+			spaceId: 'sp-1',
+			name: 'Coder',
+			description: 'stock description',
+			tools: ['Read'],
+			customPrompt: 'stock',
+		});
+		insertAgent(db, {
+			id: 'a-edited',
+			spaceId: 'sp-1',
+			name: 'Coder',
+			description: 'user-edited description',
+			tools: ['Read'],
+			customPrompt: 'stock',
+		});
+
+		runMigration106(db);
+
+		const stock = readAgent(db, 'a-stock')!;
+		const edited = readAgent(db, 'a-edited')!;
+		expect(stock.template_hash).not.toBe(edited.template_hash);
+	});
+
+	test('idempotent — second run does not change rows', () => {
+		insertAgent(db, { id: 'a-1', spaceId: 'sp-1', name: 'Coder' });
+
+		runMigration106(db);
+		const after1 = readAgent(db, 'a-1')!;
+
+		runMigration106(db);
+		const after2 = readAgent(db, 'a-1')!;
+
+		expect(after2).toEqual(after1);
+	});
+
+	test('pre-existing template_name is NOT overwritten (only NULL rows are touched)', () => {
+		insertAgent(db, {
+			id: 'a-1',
+			spaceId: 'sp-1',
+			name: 'Coder',
+			templateName: 'Coder',
+			templateHash: 'preexisting-hash',
+		});
+
+		runMigration106(db);
+
+		const row = readAgent(db, 'a-1')!;
+		expect(row.template_name).toBe('Coder');
+		expect(row.template_hash).toBe('preexisting-hash');
+	});
+
+	test('empty space_agents table → migration is safe (no-op)', () => {
+		expect(() => runMigration106(db)).not.toThrow();
+		const count = (db.prepare(`SELECT COUNT(*) AS c FROM space_agents`).get() as { c: number }).c;
+		expect(count).toBe(0);
+	});
+});

--- a/packages/daemon/tests/unit/5-space/agent/agent-template-hash.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-template-hash.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Unit tests for agent-template-hash utility.
+ *
+ * Verifies that:
+ * - buildAgentTemplateFingerprint normalises the name (trim + lowercase),
+ *   sorts the tools array, and preserves description / customPrompt verbatim
+ * - computeAgentTemplateHash returns a deterministic 64-char SHA-256 hex
+ * - Hash is stable across input orderings (tool array order, identity-only
+ *   variations) and changes for any meaningful field difference
+ * - agentTemplatesMatch reflects hash equality
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+	buildAgentTemplateFingerprint,
+	computeAgentTemplateHash,
+	agentTemplatesMatch,
+	type AgentTemplateInput,
+} from '../../../../src/lib/space/agents/agent-template-hash';
+
+function makeAgent(overrides: Partial<AgentTemplateInput> = {}): AgentTemplateInput {
+	return {
+		name: 'Coder',
+		description: 'Implementation worker',
+		tools: ['Read', 'Write', 'Bash'],
+		customPrompt: 'You are an expert coder.',
+		...overrides,
+	};
+}
+
+describe('buildAgentTemplateFingerprint', () => {
+	it('lowercases and trims the agent name', () => {
+		const fp = buildAgentTemplateFingerprint(makeAgent({ name: '  CODER  ' }));
+		expect(fp.name).toBe('coder');
+	});
+
+	it('sorts the tools array alphabetically', () => {
+		const fp = buildAgentTemplateFingerprint(makeAgent({ tools: ['Write', 'Read', 'Bash'] }));
+		expect(fp.tools).toEqual(['Bash', 'Read', 'Write']);
+	});
+
+	it('returns an empty tools array when none supplied', () => {
+		const fp = buildAgentTemplateFingerprint(makeAgent({ tools: [] }));
+		expect(fp.tools).toEqual([]);
+	});
+
+	it('preserves description and customPrompt verbatim', () => {
+		const fp = buildAgentTemplateFingerprint(
+			makeAgent({ description: 'Hello\nWorld', customPrompt: '  Pad  ' })
+		);
+		expect(fp.description).toBe('Hello\nWorld');
+		expect(fp.customPrompt).toBe('  Pad  ');
+	});
+
+	it('coerces undefined fields to safe defaults', () => {
+		const fp = buildAgentTemplateFingerprint({
+			name: undefined as unknown as string,
+			description: undefined as unknown as string,
+			tools: undefined as unknown as string[],
+			customPrompt: undefined as unknown as string,
+		});
+		expect(fp).toEqual({ name: '', description: '', tools: [], customPrompt: '' });
+	});
+
+	it('does not mutate the caller-supplied tools array', () => {
+		const tools = ['Write', 'Read', 'Bash'];
+		buildAgentTemplateFingerprint(makeAgent({ tools }));
+		expect(tools).toEqual(['Write', 'Read', 'Bash']);
+	});
+});
+
+describe('computeAgentTemplateHash', () => {
+	it('returns a 64-character lower-case hex string', () => {
+		const hash = computeAgentTemplateHash(makeAgent());
+		expect(hash).toHaveLength(64);
+		expect(hash).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it('is deterministic for identical input', () => {
+		const a = makeAgent();
+		expect(computeAgentTemplateHash(a)).toBe(computeAgentTemplateHash(a));
+	});
+
+	it('is stable regardless of tool ordering', () => {
+		const a = makeAgent({ tools: ['Write', 'Read', 'Bash'] });
+		const b = makeAgent({ tools: ['Bash', 'Write', 'Read'] });
+		expect(computeAgentTemplateHash(a)).toBe(computeAgentTemplateHash(b));
+	});
+
+	it('is stable regardless of name casing or surrounding whitespace', () => {
+		const a = makeAgent({ name: 'Coder' });
+		const b = makeAgent({ name: '  CODER  ' });
+		expect(computeAgentTemplateHash(a)).toBe(computeAgentTemplateHash(b));
+	});
+
+	it('changes when description changes', () => {
+		const a = makeAgent({ description: 'A' });
+		const b = makeAgent({ description: 'B' });
+		expect(computeAgentTemplateHash(a)).not.toBe(computeAgentTemplateHash(b));
+	});
+
+	it('changes when customPrompt changes', () => {
+		const a = makeAgent({ customPrompt: 'old' });
+		const b = makeAgent({ customPrompt: 'new' });
+		expect(computeAgentTemplateHash(a)).not.toBe(computeAgentTemplateHash(b));
+	});
+
+	it('changes when tools list contents change (addition)', () => {
+		const a = makeAgent({ tools: ['Read'] });
+		const b = makeAgent({ tools: ['Read', 'Write'] });
+		expect(computeAgentTemplateHash(a)).not.toBe(computeAgentTemplateHash(b));
+	});
+
+	it('changes when tools list contents change (removal)', () => {
+		const a = makeAgent({ tools: ['Read', 'Write'] });
+		const b = makeAgent({ tools: ['Read'] });
+		expect(computeAgentTemplateHash(a)).not.toBe(computeAgentTemplateHash(b));
+	});
+
+	it('changes when name changes meaningfully (not just casing)', () => {
+		const a = makeAgent({ name: 'Coder' });
+		const b = makeAgent({ name: 'Reviewer' });
+		expect(computeAgentTemplateHash(a)).not.toBe(computeAgentTemplateHash(b));
+	});
+
+	it('treats whitespace-only customPrompt difference as a real change', () => {
+		const a = makeAgent({ customPrompt: 'a' });
+		const b = makeAgent({ customPrompt: 'a ' });
+		expect(computeAgentTemplateHash(a)).not.toBe(computeAgentTemplateHash(b));
+	});
+});
+
+describe('agentTemplatesMatch', () => {
+	it('returns true for templates with identical fingerprints', () => {
+		expect(agentTemplatesMatch(makeAgent(), makeAgent())).toBe(true);
+	});
+
+	it('returns true for templates differing only in tool ordering', () => {
+		const a = makeAgent({ tools: ['Read', 'Write'] });
+		const b = makeAgent({ tools: ['Write', 'Read'] });
+		expect(agentTemplatesMatch(a, b)).toBe(true);
+	});
+
+	it('returns false for templates with any meaningful difference', () => {
+		const a = makeAgent({ description: 'old' });
+		const b = makeAgent({ description: 'new' });
+		expect(agentTemplatesMatch(a, b)).toBe(false);
+	});
+});

--- a/packages/daemon/tests/unit/helpers/space-agent-schema.ts
+++ b/packages/daemon/tests/unit/helpers/space-agent-schema.ts
@@ -32,7 +32,8 @@ export function createSpaceAgentSchema(db: Database): void {
 	`);
 	db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_spaces_slug ON spaces(slug)`);
 
-	// Keep in sync with space-test-db.ts (post-M74 schema).
+	// Keep in sync with space-test-db.ts (post-M105 schema — template_name /
+	// template_hash columns added for preset-agent drift detection).
 	db.exec(`
 		CREATE TABLE space_agents (
 			id TEXT PRIMARY KEY,
@@ -43,6 +44,8 @@ export function createSpaceAgentSchema(db: Database): void {
 			tools TEXT NOT NULL DEFAULT '[]',
 			custom_prompt TEXT,
 			provider TEXT,
+			template_name TEXT DEFAULT NULL,
+			template_hash TEXT DEFAULT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -52,6 +52,8 @@ export function createSpaceTables(db: BunDatabase): void {
 			system_prompt TEXT NOT NULL DEFAULT '',
 			instructions TEXT,
 			provider TEXT,
+			template_name TEXT DEFAULT NULL,
+			template_hash TEXT DEFAULT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -689,6 +689,18 @@ export interface SpaceAgent {
 	 * When unset, role-based defaults apply.
 	 */
 	tools?: string[];
+	/**
+	 * When this agent was seeded from a preset, the canonical preset name
+	 * (e.g. "Reviewer", "Coder"). Null/undefined for user-created agents and
+	 * for any preset row that predates template tracking.
+	 */
+	templateName?: string | null;
+	/**
+	 * SHA-256 fingerprint of the preset definition at the time it was last
+	 * seeded or synced. Compared against the live preset hash to detect drift.
+	 * Null/undefined when {@link templateName} is null.
+	 */
+	templateHash?: string | null;
 	/** Creation timestamp (milliseconds since epoch) */
 	createdAt: number;
 	/** Last update timestamp (milliseconds since epoch) */
@@ -708,6 +720,17 @@ export interface CreateSpaceAgentParams {
 	customPrompt?: string | null;
 	/** Tool list override — any entry must be a name from KNOWN_TOOLS */
 	tools?: string[];
+	/**
+	 * Optional preset template name. Set by `seedPresetAgents()` when seeding
+	 * built-in presets; left undefined for user-created agents.
+	 * When set, `templateHash` should also be supplied.
+	 */
+	templateName?: string | null;
+	/**
+	 * Optional template fingerprint hash captured at seed time. Used by
+	 * drift-detection to spot when the source preset definition has changed.
+	 */
+	templateHash?: string | null;
 }
 
 /**
@@ -722,6 +745,56 @@ export interface UpdateSpaceAgentParams {
 	customPrompt?: string | null;
 	/** Tool list override — null clears (reverts to role defaults) */
 	tools?: string[] | null;
+	/**
+	 * Update the preset template name. Pass `null` to clear template tracking
+	 * (e.g. when a user converts a preset agent into a fully custom one).
+	 */
+	templateName?: string | null;
+	/**
+	 * Update the stored template fingerprint hash. Used by the
+	 * `spaceAgent.syncFromTemplate` RPC after re-stamping a preset row to
+	 * the current definition.
+	 */
+	templateHash?: string | null;
+}
+
+/**
+ * Single entry in an {@link AgentDriftReport}.
+ *
+ * Each entry corresponds to one preset-seeded `SpaceAgent` row in a space.
+ * Rows for user-created agents (no `templateName`) are not included in the
+ * report at all.
+ */
+export interface AgentDriftEntry {
+	/** Agent UUID. */
+	agentId: string;
+	/** Human-readable agent name (matches `SpaceAgent.name`). */
+	agentName: string;
+	/** Preset template name this agent was seeded from. */
+	templateName: string;
+	/**
+	 * Hash captured the last time this row was seeded or synced.
+	 * Null when the row predates template tracking and the backfill
+	 * migration could not match the row to a preset.
+	 */
+	storedHash: string | null;
+	/** Hash of the current preset definition in code. */
+	currentHash: string;
+	/** True when {@link storedHash} differs from {@link currentHash}. */
+	drifted: boolean;
+}
+
+/**
+ * Returned by `spaceAgent.getDriftReport`. Lists all preset-seeded agents in
+ * a space with the comparison between their stored fingerprint and the
+ * current preset definition. Callers typically filter by `drifted === true`
+ * to surface a UI badge / sync button.
+ */
+export interface AgentDriftReport {
+	/** Space the report was generated for. */
+	spaceId: string;
+	/** Per-agent drift entries — one row per preset-tracked SpaceAgent. */
+	agents: AgentDriftEntry[];
 }
 
 // ============================================================================

--- a/packages/web/src/components/space/SpaceAgentList.tsx
+++ b/packages/web/src/components/space/SpaceAgentList.tsx
@@ -11,21 +11,26 @@
  *   with a clear message. When unreferenced, a standard confirm dialog is shown.
  */
 
-import { useState } from 'preact/hooks';
+import { useState, useEffect } from 'preact/hooks';
 import { spaceStore } from '../../lib/space-store';
 import { Button } from '../ui/Button';
 import { ConfirmModal } from '../ui/ConfirmModal';
 import { Modal } from '../ui/Modal';
-import type { SpaceAgent } from '@neokai/shared';
+import type { SpaceAgent, AgentDriftReport } from '@neokai/shared';
 import { SpaceAgentEditor } from './SpaceAgentEditor';
+import { connectionManager } from '../../lib/connection-manager';
+import { toast } from '../../lib/toast';
 
 interface AgentCardProps {
 	agent: SpaceAgent;
+	drifted: boolean;
+	syncing: boolean;
 	onEdit: (agent: SpaceAgent) => void;
 	onDelete: (agent: SpaceAgent) => void;
+	onSync: (agent: SpaceAgent) => void;
 }
 
-function AgentCard({ agent, onEdit, onDelete }: AgentCardProps) {
+function AgentCard({ agent, drifted, syncing, onEdit, onDelete, onSync }: AgentCardProps) {
 	return (
 		<div class="bg-dark-850 border border-dark-700 rounded-lg p-4 hover:border-dark-600 transition-colors">
 			<div class="flex items-start justify-between gap-3">
@@ -33,6 +38,22 @@ function AgentCard({ agent, onEdit, onDelete }: AgentCardProps) {
 					<div class="flex items-center gap-2 flex-wrap">
 						<span class="text-sm font-medium text-gray-100">{agent.name}</span>
 						{agent.model && <span class="text-xs text-gray-500 font-mono">{agent.model}</span>}
+						{drifted && (
+							<span
+								class="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs bg-amber-900/30 border border-amber-700/50 rounded text-amber-400"
+								title={`This agent was seeded from the "${agent.templateName}" preset and has drifted from the current definition.`}
+							>
+								<svg class="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width={2}
+										d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+									/>
+								</svg>
+								Out of sync
+							</span>
+						)}
 					</div>
 					{agent.description && (
 						<p class="text-xs text-gray-500 mt-1.5 line-clamp-2">{agent.description}</p>
@@ -54,6 +75,17 @@ function AgentCard({ agent, onEdit, onDelete }: AgentCardProps) {
 					)}
 				</div>
 				<div class="flex items-center gap-1 flex-shrink-0">
+					{drifted && (
+						<button
+							type="button"
+							onClick={() => onSync(agent)}
+							disabled={syncing}
+							class="px-2.5 py-1 text-xs text-amber-400 hover:text-amber-200 bg-dark-800 hover:bg-dark-700 rounded border border-amber-700/50 hover:border-amber-600/70 transition-colors disabled:opacity-50"
+							title="Sync from template (overwrites description, tools, and prompt)"
+						>
+							{syncing ? 'Syncing…' : 'Sync from template'}
+						</button>
+					)}
 					<button
 						type="button"
 						onClick={() => onEdit(agent)}
@@ -115,12 +147,84 @@ export function SpaceAgentList() {
 	const agents = spaceStore.agents.value;
 	const loading = spaceStore.loading.value;
 	const workflows = spaceStore.workflows.value;
+	const spaceId = spaceStore.spaceId.value;
 
 	const [editorOpen, setEditorOpen] = useState(false);
 	const [editingAgent, setEditingAgent] = useState<SpaceAgent | null>(null);
 	const [deletingAgent, setDeletingAgent] = useState<SpaceAgent | null>(null);
 	const [deleteError, setDeleteError] = useState<string | null>(null);
 	const [deleting, setDeleting] = useState(false);
+
+	// Drift detection: set of agent IDs that have drifted from their preset.
+	// Empty until the first successful drift report fetch — agents not in the
+	// set render without the badge or sync button (the safe default when the
+	// daemon hasn't responded yet).
+	const [driftedAgentIds, setDriftedAgentIds] = useState<Set<string>>(new Set());
+	const [syncingAgentId, setSyncingAgentId] = useState<string | null>(null);
+
+	// Re-fetch drift report whenever the agent set changes. We watch a
+	// concatenated key of (id, updatedAt) so the effect fires for adds,
+	// removes, and edits — but not for unrelated re-renders.
+	const driftKey = agents
+		.map((a) => `${a.id}:${a.updatedAt}`)
+		.sort()
+		.join('|');
+
+	useEffect(() => {
+		if (!spaceId) return;
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) return;
+
+		let cancelled = false;
+		hub
+			.request<{ report: AgentDriftReport }>('spaceAgent.getDriftReport', { spaceId })
+			.then((result) => {
+				if (cancelled) return;
+				const ids = new Set<string>();
+				for (const entry of result.report.agents) {
+					if (entry.drifted) ids.add(entry.agentId);
+				}
+				setDriftedAgentIds(ids);
+			})
+			.catch(() => {
+				// Drift detection is best-effort — silently swallow errors so
+				// list rendering never depends on the report succeeding.
+			});
+
+		return () => {
+			cancelled = true;
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- driftKey captures the list identity
+	}, [spaceId, driftKey]);
+
+	const handleSync = async (agent: SpaceAgent) => {
+		if (!spaceId) return;
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) {
+			toast.error('Connection lost.');
+			return;
+		}
+		setSyncingAgentId(agent.id);
+		try {
+			await hub.request('spaceAgent.syncFromTemplate', {
+				spaceId,
+				agentId: agent.id,
+			});
+			// Clear drift state for this agent eagerly so the badge disappears
+			// before the next refresh cycle. The spaceAgent.updated event will
+			// re-trigger the effect and reconcile authoritatively.
+			setDriftedAgentIds((prev) => {
+				const next = new Set(prev);
+				next.delete(agent.id);
+				return next;
+			});
+			toast.success(`"${agent.name}" synced from template`);
+		} catch (err) {
+			toast.error(`Sync failed: ${err instanceof Error ? err.message : String(err)}`);
+		} finally {
+			setSyncingAgentId((current) => (current === agent.id ? null : current));
+		}
+	};
 
 	function getWorkflowNamesReferencingAgent(agentId: string): string[] {
 		return workflows
@@ -209,8 +313,11 @@ export function SpaceAgentList() {
 							<AgentCard
 								key={agent.id}
 								agent={agent}
+								drifted={driftedAgentIds.has(agent.id)}
+								syncing={syncingAgentId === agent.id}
 								onEdit={handleEdit}
 								onDelete={handleDeleteClick}
+								onSync={handleSync}
 							/>
 						))}
 					</div>

--- a/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
@@ -26,6 +26,7 @@ import type { SpaceAgent, SpaceWorkflow } from '@neokai/shared';
 let mockAgents: ReturnType<typeof signal<SpaceAgent[]>>;
 let mockWorkflows: ReturnType<typeof signal<SpaceWorkflow[]>>;
 let mockLoading: ReturnType<typeof signal<boolean>>;
+let mockSpaceId: ReturnType<typeof signal<string | null>>;
 
 const mockDeleteAgent = vi.fn();
 const mockCreateAgent = vi.fn();
@@ -37,10 +38,27 @@ vi.mock('../../../lib/space-store', () => ({
 			agents: mockAgents,
 			workflows: mockWorkflows,
 			loading: mockLoading,
+			spaceId: mockSpaceId,
 			deleteAgent: mockDeleteAgent,
 			createAgent: mockCreateAgent,
 			updateAgent: mockUpdateAgent,
 		};
+	},
+}));
+
+const mockHubRequest = vi.fn();
+vi.mock('../../../lib/connection-manager', () => ({
+	connectionManager: {
+		getHubIfConnected: () => ({ request: mockHubRequest }),
+	},
+}));
+
+vi.mock('../../../lib/toast', () => ({
+	toast: {
+		success: vi.fn(),
+		error: vi.fn(),
+		warning: vi.fn(),
+		info: vi.fn(),
 	},
 }));
 
@@ -159,6 +177,7 @@ vi.mock('../../ui/Modal', () => ({
 mockAgents = signal<SpaceAgent[]>([]);
 mockWorkflows = signal<SpaceWorkflow[]>([]);
 mockLoading = signal(false);
+mockSpaceId = signal<string | null>('space-1');
 
 import { SpaceAgentList } from '../SpaceAgentList';
 
@@ -201,9 +220,15 @@ describe('SpaceAgentList', () => {
 		mockAgents.value = [];
 		mockWorkflows.value = [];
 		mockLoading.value = false;
+		mockSpaceId.value = 'space-1';
 		mockDeleteAgent.mockReset();
 		mockCreateAgent.mockReset();
 		mockUpdateAgent.mockReset();
+		mockHubRequest.mockReset();
+		// Default: drift report returns no drifted agents so the list renders cleanly.
+		mockHubRequest.mockResolvedValue({
+			report: { spaceId: 'space-1', agents: [] },
+		});
 	});
 
 	afterEach(() => {
@@ -460,6 +485,117 @@ describe('SpaceAgentList', () => {
 		expect(getByTestId('block-modal')).toBeTruthy();
 		fireEvent.click(getByTestId('block-modal-close'));
 		expect(queryByTestId('block-modal')).toBeNull();
+	});
+
+	// ── Drift detection & sync ────────────────────────────────────────────────
+
+	it('renders "Out of sync" badge for drifted preset agents', async () => {
+		const agent = makeAgent({ id: 'agent-1', name: 'Coder', templateName: 'Coder' });
+		mockAgents.value = [agent];
+		mockHubRequest.mockResolvedValue({
+			report: {
+				spaceId: 'space-1',
+				agents: [
+					{
+						agentId: 'agent-1',
+						agentName: 'Coder',
+						templateName: 'Coder',
+						storedHash: 'a',
+						currentHash: 'b',
+						drifted: true,
+					},
+				],
+			},
+		});
+
+		const { findByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
+		expect(await findByText('Out of sync')).toBeTruthy();
+	});
+
+	it('does NOT render "Out of sync" badge for non-drifted preset agents', async () => {
+		const agent = makeAgent({ id: 'agent-1', name: 'Coder', templateName: 'Coder' });
+		mockAgents.value = [agent];
+		mockHubRequest.mockResolvedValue({
+			report: {
+				spaceId: 'space-1',
+				agents: [
+					{
+						agentId: 'agent-1',
+						agentName: 'Coder',
+						templateName: 'Coder',
+						storedHash: 'a',
+						currentHash: 'a',
+						drifted: false,
+					},
+				],
+			},
+		});
+
+		const { queryByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
+		// Allow the drift effect to settle.
+		await waitFor(() => {
+			expect(mockHubRequest).toHaveBeenCalledWith('spaceAgent.getDriftReport', {
+				spaceId: 'space-1',
+			});
+		});
+		expect(queryByText('Out of sync')).toBeNull();
+	});
+
+	it('clicking "Sync from template" calls spaceAgent.syncFromTemplate and clears badge', async () => {
+		const agent = makeAgent({ id: 'agent-1', name: 'Coder', templateName: 'Coder' });
+		mockAgents.value = [agent];
+
+		// First call: getDriftReport (drifted). Subsequent: syncFromTemplate (success).
+		mockHubRequest.mockImplementation(async (method: string) => {
+			if (method === 'spaceAgent.getDriftReport') {
+				return {
+					report: {
+						spaceId: 'space-1',
+						agents: [
+							{
+								agentId: 'agent-1',
+								agentName: 'Coder',
+								templateName: 'Coder',
+								storedHash: 'a',
+								currentHash: 'b',
+								drifted: true,
+							},
+						],
+					},
+				};
+			}
+			if (method === 'spaceAgent.syncFromTemplate') {
+				return { agent };
+			}
+			return {};
+		});
+
+		const { findByText, queryByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
+		const syncButton = await findByText('Sync from template');
+
+		fireEvent.click(syncButton);
+
+		await waitFor(() => {
+			expect(mockHubRequest).toHaveBeenCalledWith('spaceAgent.syncFromTemplate', {
+				spaceId: 'space-1',
+				agentId: 'agent-1',
+			});
+		});
+
+		// Optimistic clear: the badge should disappear after a successful sync.
+		await waitFor(() => {
+			expect(queryByText('Out of sync')).toBeNull();
+		});
+	});
+
+	it('does not crash when drift report request fails', async () => {
+		const agent = makeAgent({ id: 'agent-1', name: 'Coder', templateName: 'Coder' });
+		mockAgents.value = [agent];
+		mockHubRequest.mockRejectedValue(new Error('hub error'));
+
+		const { getByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
+		// The agent card still renders normally even when drift detection fails.
+		expect(getByText('Coder')).toBeTruthy();
 	});
 
 	// ── Existing agent names passed to editor ──────────────────────────────────


### PR DESCRIPTION
Adds parity with the workflow drift-detection flow for preset-seeded `SpaceAgent` rows.

- M105 adds nullable `template_name` / `template_hash` columns; M106 backfills existing rows whose name matches a known preset (case-insensitive), hashing the row's CURRENT field values so user customisations surface as drift instead of being silently overwritten.
- `SpaceAgentManager.getAgentDriftReport` and `syncFromTemplate` expose drift status and a one-click reset; both are reachable via new RPC handlers `spaceAgent.getDriftReport` and `spaceAgent.syncFromTemplate`.
- `SpaceAgentList` shows an amber "Out of sync" badge on drifted preset cards and a "Sync from template" button, mirroring the workflow UI.

Closes Task #125.