### PR TITLE
fix(daemon): don't block review/approved tasks on daemon restart

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1280,16 +1280,42 @@ export class SpaceRuntime {
 		const tasks = this.config.taskRepo.listByWorkflowRun(run.id);
 		const canonicalTask = this.pickCanonicalTaskForRun(run, tasks);
 
+		// A canonical task is "at rest" — i.e. NOT a stalled run that needs
+		// daemon-restart intervention — when it is in any of these states:
+		//
+		//   - `done` / `cancelled`  → terminal; the tick loop's
+		//                             CompletionDetector will pick it up and
+		//                             finalize the run.
+		//   - `review`              → end-node agent finished and the workflow
+		//                             is paused awaiting human approval (e.g.
+		//                             via `submit_for_approval`). All node
+		//                             executions are correctly `idle` while we
+		//                             wait for the human; this is not a stall.
+		//   - `approved`            → human (or auto_policy) approved; a
+		//                             post-approval executor (e.g. PR merge)
+		//                             may still be in flight, leaving prior
+		//                             node executions `idle`.
+		//   - `reportedStatus !== null` → end-node agent reported a result;
+		//                                 the next tick will route through the
+		//                                 completion path.
+		//
+		// In all of these cases a daemon restart must NOT alter task status.
+		// Only when none of these hold is the run genuinely stalled and
+		// eligible to be flagged `blocked`.
 		const completionSignalled =
 			canonicalTask !== null &&
 			(canonicalTask.status === 'done' ||
 				canonicalTask.status === 'cancelled' ||
+				canonicalTask.status === 'review' ||
+				canonicalTask.status === 'approved' ||
 				canonicalTask.reportedStatus !== null);
 
 		if (completionSignalled) {
 			// Tick loop's CompletionDetector + processRunTick will fire on the
 			// next pass and transition the run to `done` (or pick up the
-			// cancelled task). Nothing to do here — the run will finalize.
+			// cancelled task), or the run will remain paused awaiting the
+			// human / post-approval executor that owns it. Nothing to do
+			// here — the run is at rest, not stalled.
 			return 'completion-pending';
 		}
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -375,6 +375,120 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 
 			expect(workflowRunRepo.getRun(run.id)!.status).toBe('in_progress');
 		});
+
+		// -----------------------------------------------------------------------
+		// Regression — task #127
+		//
+		// A task in `review` is paused waiting for human approval (the end-node
+		// agent finished, all sibling executions correctly went `idle`). It is
+		// NOT a stalled run. A daemon restart must leave the task and its run
+		// untouched. Same applies to `approved` (post-approval executor may be
+		// in flight, leaving prior node executions idle).
+		// -----------------------------------------------------------------------
+
+		test('canonical task in `review` → run + task untouched, no blocked notifications (task #127)', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Review-Pending Run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Review-Pending Run',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'review',
+			});
+
+			// All node executions correctly idle while we wait for the human.
+			seedExec(run.id, STEP_A, 'Step A', 'idle');
+
+			const rt = makeRuntime();
+			await rt.recoverStalledRuns();
+
+			// Run + task must be unchanged — `review` is "at rest", not stalled.
+			expect(workflowRunRepo.getRun(run.id)!.status).toBe('in_progress');
+			const after = taskRepo.getTask(task.id)!;
+			expect(after.status).toBe('review');
+			expect(after.blockReason).toBeNull();
+			// And no spurious blocked notifications.
+			expect(notifications.filter((n) => n.kind === 'workflow_run_blocked').length).toBe(0);
+			expect(notifications.filter((n) => n.kind === 'task_blocked').length).toBe(0);
+		});
+
+		test('canonical task in `review` with pendingCheckpointType=task_completion → not blocked', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Submit-For-Approval Run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Submit-For-Approval Run',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'review',
+			});
+			// Mirror the real-world `submit_for_approval` checkpoint shape.
+			taskRepo.updateTask(task.id, { pendingCheckpointType: 'task_completion' });
+
+			seedExec(run.id, STEP_A, 'Step A', 'idle');
+
+			const rt = makeRuntime();
+			await rt.recoverStalledRuns();
+
+			expect(workflowRunRepo.getRun(run.id)!.status).toBe('in_progress');
+			const after = taskRepo.getTask(task.id)!;
+			expect(after.status).toBe('review');
+			expect(after.pendingCheckpointType).toBe('task_completion');
+			expect(notifications.filter((n) => n.kind === 'task_blocked').length).toBe(0);
+		});
+
+		test('canonical task in `approved` → run + task untouched (post-approval may be in flight)', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Approved Run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Approved Run',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'approved',
+			});
+
+			seedExec(run.id, STEP_A, 'Step A', 'idle');
+
+			const rt = makeRuntime();
+			await rt.recoverStalledRuns();
+
+			expect(workflowRunRepo.getRun(run.id)!.status).toBe('in_progress');
+			expect(taskRepo.getTask(task.id)!.status).toBe('approved');
+			expect(notifications.filter((n) => n.kind === 'workflow_run_blocked').length).toBe(0);
+			expect(notifications.filter((n) => n.kind === 'task_blocked').length).toBe(0);
+		});
 	});
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

`SpaceRuntime.recoverSingleRun()` (the daemon-restart safety net for stalled workflow runs) only treated `done`, `cancelled`, and `reportedStatus !== null` as "at rest". A task in `review` (paused awaiting human approval after `submit_for_approval`) has all sibling executions correctly `idle`, so recovery was misclassifying it as "stalled" and forcibly transitioning it to `blocked` with `block_reason = execution_failed` on every daemon restart. Same hazard for `approved` while a post-approval executor is in flight.

## Fix

Add `review` and `approved` to the at-rest set in `recoverSingleRun()`. One-file, surgical change with a documented rationale.

## Tests

Three new regression tests in `space-runtime-stalled-recovery.test.ts`:
1. `review` task with idle execution → run + task untouched, no blocked notifications
2. `review` + `pendingCheckpointType=task_completion` → unchanged (mirrors the real `submit_for_approval` shape)
3. `approved` task → unchanged (post-approval executor may still be running)

Existing "genuinely stalled run → blocked" coverage remains green.

## Test plan
- [x] `bun test packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts` — 15/15 pass
- [x] Full runtime suite — 584/584 pass
- [x] Pre-commit (lint, format, tsc, knip) clean

Fixes #127.