### PR TITLE
fix(daemon): rehydrate sub-session MCP servers across daemon restart

### DIFF
--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1956,20 +1956,22 @@ export class TaskAgentManager {
 	/**
 	 * Rehydrate Task Agent sessions after a daemon restart.
 	 *
-	 * Queries `space_tasks` for tasks with status `in_progress`, `blocked`, or
-	 * `approved` that have a non-null `taskAgentSessionId`. For each such task
-	 * that has a `space_task_agent` session type in the DB, restores the Task
-	 * Agent session via `AgentSession.restore()`, re-attaches the MCP server
-	 * and system prompt, restarts the streaming query, and injects a
-	 * re-orientation message so the agent resumes from where it left off.
-	 * `'approved'` is included because the Task Agent session can still be
-	 * live while the post-approval sub-session runs — see
-	 * `SpaceTaskRepository.listActiveWithTaskAgentSession`.
+	 * Queries `space_tasks` for tasks with status `in_progress`, `review`,
+	 * `blocked`, or `approved` that have a non-null `taskAgentSessionId`. For
+	 * each such task that has a `space_task_agent` session type in the DB,
+	 * restores the Task Agent session via `AgentSession.restore()`, re-attaches
+	 * the MCP server and system prompt, restarts the streaming query, and
+	 * injects a re-orientation message so the agent resumes from where it left
+	 * off. See `SpaceTaskRepository.listActiveWithTaskAgentSession` for the
+	 * full justification of which statuses are included.
 	 *
-	 * Sub-sessions are NOT fully rehydrated — the Task Agent will re-spawn them
-	 * via its MCP tools after receiving the re-orientation message. The in-memory
-	 * `subSessions` map is rebuilt from sub-session tasks found in the DB (so
-	 * cleanup works correctly), but their streaming queries are not restarted.
+	 * After each Task Agent is restored, `rehydrateTaskAgent` also eagerly
+	 * rehydrates every workflow sub-session attached to its workflow run via
+	 * `rehydrateSubSessionsForRun` — see that method for the full rationale.
+	 * Without that step, sub-sessions whose `node-agent` and `space-agent-tools`
+	 * MCP servers are in-process-only would silently sit without those servers
+	 * after a restart, breaking gate writes / peer messaging the moment a UI
+	 * overlay or peer message reached them (task #126 failure mode).
 	 *
 	 * This method is called from `SpaceRuntime.rehydrateExecutors()` after
 	 * WorkflowExecutors are loaded, so executors are ready when Task Agents run.
@@ -2650,7 +2652,10 @@ export class TaskAgentManager {
 	 * 5. Restarts the streaming query so the SDK resumes from conversation history.
 	 * 6. Injects a re-orientation message so the agent checks its current state and
 	 *    continues from where it left off.
-	 * 7. Rebuilds the `subSessions` map from node tasks in the same workflow run.
+	 * 7. Eagerly rehydrates every workflow sub-session attached to the workflow
+	 *    run via `rehydrateSubSessionsForRun`, so the in-process `node-agent`
+	 *    and `space-agent-tools` MCP servers are re-attached BEFORE any UI
+	 *    overlay or peer message can reach a sub-session (task #126 fix).
 	 */
 	private async rehydrateTaskAgent(task: SpaceTask, sessionId: string): Promise<void> {
 		const taskId = task.id;
@@ -2861,9 +2866,77 @@ export class TaskAgentManager {
 				'Please check the current task status and continue from where you left off.';
 		await this.injectMessageIntoSession(agentSession, reorientMessage);
 
+		// --- Eagerly rehydrate every workflow sub-session for this task.
+		//
+		// Without this, sub-sessions (coder/reviewer/etc.) that the workflow had
+		// already spawned before the daemon restart sit out-of-memory until
+		// `injectSubSessionMessage` is invoked. That lazy path is fine for the
+		// "Task Agent calls a tool that injects a message" flow, but it has two
+		// gaps that bite us in the wild (task #126):
+		//
+		//   1. UI/RPC paths that resolve a sub-session via
+		//      `SessionManager.getSessionAsync` short-circuit on
+		//      `AgentSession.restore()` and never reach `rehydrateSubSession` —
+		//      the bare restored session has neither `node-agent` nor
+		//      `space-agent-tools` attached, so `write_gate` / `read_gate` /
+		//      `send_message` calls die silently with "No such tool available".
+		//   2. A sub-session sitting idle at a gate has no incoming message to
+		//      trigger lazy rehydration, so the in-process MCP servers stay
+		//      missing for as long as the workflow waits.
+		//
+		// Eager rehydration here closes both gaps: every sub-session whose
+		// NodeExecution still has an `agentSessionId` (i.e. was spawned before
+		// the restart) is restored, registered in the in-memory maps + the
+		// SessionManager cache, and re-attached with `node-agent` +
+		// `space-agent-tools` BEFORE any UI/RPC consumer can ask for it.
+		await this.rehydrateSubSessionsForRun(workflowRun?.id ?? null);
+
 		log.info(
 			`TaskAgentManager.rehydrate: rehydrated task agent for task ${taskId} (session ${sessionId})`
 		);
+	}
+
+	/**
+	 * Eagerly rehydrate every workflow sub-session attached to a workflow run,
+	 * so the in-process `node-agent` and `space-agent-tools` MCP servers are
+	 * re-attached to each sub-session before any external consumer
+	 * (UI overlay, peer message, gate write) reaches them.
+	 *
+	 * Iterates `node_executions` for the run, finds rows that already have an
+	 * `agentSessionId` assigned (i.e. a sub-session was spawned before the
+	 * daemon restart), and calls `rehydrateSubSession` for each that is not
+	 * yet in the in-memory `agentSessionIndex`. `rehydrateSubSession` is
+	 * idempotent w.r.t. the maps (see its comments) — calling it for an entry
+	 * that is somehow already in memory would re-restore from DB, which is
+	 * wasteful but not harmful; the explicit `agentSessionIndex` guard avoids
+	 * that wasted work.
+	 *
+	 * Failures are isolated per sub-session and logged at warn level — one
+	 * broken sub-session must not block rehydration of its siblings.
+	 *
+	 * No-op when `workflowRunId` is null (standalone task with no workflow).
+	 */
+	private async rehydrateSubSessionsForRun(workflowRunId: string | null): Promise<void> {
+		if (!workflowRunId) return;
+
+		const executions = this.config.nodeExecutionRepo.listByWorkflowRun(workflowRunId);
+		for (const execution of executions) {
+			const subSessionId = execution.agentSessionId;
+			if (!subSessionId) continue;
+
+			// Skip if already in memory (e.g. lazily rehydrated by an earlier
+			// inbound message during this same restart, or never torn down).
+			if (this.agentSessionIndex.has(subSessionId)) continue;
+
+			try {
+				await this.rehydrateSubSession(subSessionId);
+			} catch (err) {
+				log.warn(
+					`TaskAgentManager.rehydrateSubSessionsForRun: failed to rehydrate sub-session ${subSessionId} ` +
+						`(run=${workflowRunId}, exec=${execution.id}, agent=${execution.agentName}): ${err instanceof Error ? err.message : String(err)}`
+				);
+			}
+		}
 	}
 
 	/**

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -2904,12 +2904,29 @@ export class TaskAgentManager {
 	 *
 	 * Iterates `node_executions` for the run, finds rows that already have an
 	 * `agentSessionId` assigned (i.e. a sub-session was spawned before the
-	 * daemon restart), and calls `rehydrateSubSession` for each that is not
-	 * yet in the in-memory `agentSessionIndex`. `rehydrateSubSession` is
-	 * idempotent w.r.t. the maps (see its comments) — calling it for an entry
-	 * that is somehow already in memory would re-restore from DB, which is
-	 * wasteful but not harmful; the explicit `agentSessionIndex` guard avoids
-	 * that wasted work.
+	 * daemon restart) AND whose execution status indicates the agent is still
+	 * active (`'in_progress'` or `'blocked'`), and calls `rehydrateSubSession`
+	 * for each that is not yet in the in-memory `agentSessionIndex`.
+	 * `rehydrateSubSession` is idempotent w.r.t. the maps (see its comments) —
+	 * calling it for an entry that is somehow already in memory would re-restore
+	 * from DB, which is wasteful but not harmful; the explicit
+	 * `agentSessionIndex` guard avoids that wasted work.
+	 *
+	 * Status filter rationale (`NodeExecutionStatus` is
+	 * `'pending' | 'in_progress' | 'idle' | 'blocked' | 'cancelled'`):
+	 * - `'in_progress'` — agent actively working; must come back.
+	 * - `'blocked'` — agent sitting at a gate awaiting input; must come back.
+	 *   This is the original Task #126 scenario.
+	 * - `'pending'` — declared but never spawned, so `agentSessionId` is null
+	 *   and the row is already filtered by the `if (!subSessionId)` guard
+	 *   above. Listed here for completeness.
+	 * - `'idle'` — the agent finished its turn; `handleSubSessionComplete`
+	 *   already auto-transitioned the execution and fired the completion
+	 *   callback. Restoring would attach MCP servers, register a new
+	 *   completion callback, and restart the streaming query for an agent
+	 *   that has no remaining work — pure overhead.
+	 * - `'cancelled'` — the execution was explicitly stopped; same reasoning
+	 *   as `'idle'`.
 	 *
 	 * Failures are isolated per sub-session and logged at warn level — one
 	 * broken sub-session must not block rehydration of its siblings.
@@ -2923,6 +2940,13 @@ export class TaskAgentManager {
 		for (const execution of executions) {
 			const subSessionId = execution.agentSessionId;
 			if (!subSessionId) continue;
+
+			// Only rehydrate active executions. `idle` / `cancelled` agents have
+			// already finished their turn (or been explicitly stopped) and will
+			// not receive any new messages — restoring them would attach MCP
+			// servers, register a new completion callback, and restart the
+			// streaming query for nothing.
+			if (execution.status !== 'in_progress' && execution.status !== 'blocked') continue;
 
 			// Skip if already in memory (e.g. lazily rehydrated by an earlier
 			// inbound message during this same restart, or never torn down).

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -367,21 +367,36 @@ export class SpaceTaskRepository {
 	/**
 	 * List all tasks that have an active Task Agent session.
 	 *
-	 * Returns tasks with status `in_progress`, `blocked`, or `approved` that
-	 * have a non-null `task_agent_session_id`. Used by
+	 * Returns tasks with status `in_progress`, `review`, `blocked`, or `approved`
+	 * that have a non-null `task_agent_session_id`. Used by
 	 * `TaskAgentManager.rehydrate()` on daemon restart to find Task Agent
 	 * sessions that need to be restarted.
 	 *
-	 * `'approved'` is included because the Task Agent session can still be live
-	 * while the post-approval sub-session runs — mark_complete may transition
-	 * the task back to `in_progress` or to `done`, and the UI's
-	 * `spaceTaskActivity.byTask` LiveQuery depends on the session being
-	 * rehydrated in-memory. Tasks in `'done'`/`'cancelled'`/`'archived'` are
-	 * terminal and their sessions are torn down.
+	 * Status inclusions:
+	 * - `'in_progress'` — actively being worked on; obvious rehydrate target.
+	 * - `'review'` — workflow agents finished but a human/auto reviewer must
+	 *   approve. The Task Agent session is still live: it owns the sub-session
+	 *   map (coder/reviewer/etc.) and is the only path that can re-attach the
+	 *   in-process `node-agent` / `space-agent-tools` MCP servers to those
+	 *   sub-sessions after a daemon restart. Excluding `'review'` here was the
+	 *   root cause of task #126: a coder/reviewer sub-session sitting at a gate
+	 *   while the parent task waited in `'review'` lost both MCP servers across
+	 *   a daemon restart, so `write_gate` / `read_gate` / `send_message` all
+	 *   silently failed with "No such tool available".
+	 * - `'blocked'` — task awaits human input but the Task Agent session must
+	 *   stay live so unblocking messages reach it.
+	 * - `'approved'` — the Task Agent can still be live while the post-approval
+	 *   sub-session runs; `mark_complete` may transition the task back to
+	 *   `in_progress` or to `done`, and the UI's `spaceTaskActivity.byTask`
+	 *   LiveQuery depends on the session being rehydrated in-memory.
+	 *
+	 * Tasks in `'done'`/`'cancelled'`/`'archived'`/`'open'` are excluded:
+	 * terminal states have their sessions torn down, and `'open'` tasks have
+	 * no Task Agent yet.
 	 */
 	listActiveWithTaskAgentSession(): SpaceTask[] {
 		const stmt = this.db.prepare(
-			`SELECT * FROM space_tasks WHERE status IN ('in_progress', 'blocked', 'approved') AND task_agent_session_id IS NOT NULL`
+			`SELECT * FROM space_tasks WHERE status IN ('in_progress', 'review', 'blocked', 'approved') AND task_agent_session_id IS NOT NULL`
 		);
 		const rows = stmt.all() as Record<string, unknown>[];
 		return rows.map((r) => this.rowToSpaceTask(r));

--- a/packages/daemon/tests/unit/4-space-storage/storage/space-task-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/space-task-repository.test.ts
@@ -561,8 +561,15 @@ describe('SpaceTaskRepository', () => {
 			return task.id;
 		}
 
-		it("includes 'in_progress', 'blocked', and 'approved' tasks with a non-null session id", () => {
+		it("includes 'in_progress', 'review', 'blocked', and 'approved' tasks with a non-null session id", () => {
+			// 'review' was added to the active set as part of the Task #126 fix:
+			// a coder/reviewer sub-session sitting at a code-ready-gate while the
+			// parent task waited in 'review' was previously excluded from rehydration,
+			// so the task agent's in-process MCP servers were never restored after a
+			// daemon restart. See `listActiveWithTaskAgentSession` docstring for the
+			// per-status justification.
 			const inProgress = seed('in_progress', 'sess-in-progress');
+			const review = seed('review', 'sess-review');
 			const blocked = seed('blocked', 'sess-blocked');
 			const approved = seed('approved', 'sess-approved');
 
@@ -570,9 +577,10 @@ describe('SpaceTaskRepository', () => {
 			const ids = new Set(active.map((t) => t.id));
 
 			expect(ids.has(inProgress)).toBe(true);
+			expect(ids.has(review)).toBe(true);
 			expect(ids.has(blocked)).toBe(true);
 			expect(ids.has(approved)).toBe(true);
-			expect(active.length).toBe(3);
+			expect(active.length).toBe(4);
 		});
 
 		it('excludes tasks without a task_agent_session_id', () => {
@@ -585,8 +593,12 @@ describe('SpaceTaskRepository', () => {
 		});
 
 		it('excludes terminal and open statuses even when a session id is present', () => {
+			// 'review' is intentionally NOT in this exclusion list — it is an
+			// active state where the Task Agent (and any sub-sessions sitting at
+			// the review gate) must come back after a daemon restart so their
+			// in-process MCP servers (`node-agent`, `space-agent-tools`) are
+			// re-attached. See the inclusion test above for the rationale.
 			seed('open', 'sess-open');
-			seed('review', 'sess-review');
 			seed('done', 'sess-done');
 			seed('cancelled', 'sess-cancelled');
 			seed('archived', 'sess-archived');

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
@@ -948,3 +948,336 @@ describe('TaskAgentManager.tryResumeNodeAgentSession', () => {
 		expect(fastPathMsg).toBeDefined();
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Tests: TaskAgentManager.rehydrate() eager sub-session rehydration (Task #126)
+// ---------------------------------------------------------------------------
+
+/**
+ * Regression coverage for Task #126: after a daemon restart, every workflow
+ * sub-session whose NodeExecution still has an `agentSessionId` must come back
+ * with both `node-agent` and `space-agent-tools` MCP servers attached. Without
+ * the eager rehydration step inside `rehydrateTaskAgent`, sub-sessions sitting
+ * idle at a gate (or first reached via a UI overlay path that resolves them
+ * through `SessionManager.getSessionAsync` rather than `injectSubSessionMessage`)
+ * would silently lose those in-process MCP servers and `write_gate` /
+ * `read_gate` / `send_message` calls would die with "No such tool available".
+ *
+ * These tests simulate the daemon-restart entry point by:
+ *   1. Seeding a parent task with a `space_task_agent` session row in the DB.
+ *   2. Seeding a workflow run + node execution whose `agentSessionId` points
+ *      at a sub-session row of type `'worker'`.
+ *   3. Calling `manager.rehydrate()` (NOT `injectSubSessionMessage`) — the
+ *      same path SpaceRuntime invokes during daemon startup.
+ *   4. Asserting the sub-session is present in the in-memory map AND has both
+ *      `node-agent` and `space-agent-tools` in its MCP server map.
+ */
+describe('TaskAgentManager.rehydrate (eager sub-session rehydration — Task #126)', () => {
+	let ctx: TestCtx;
+	let restoreSpy: ReturnType<typeof spyOn<typeof AgentSession, 'restore'>>;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+		restoreSpy = spyOn(AgentSession, 'restore').mockImplementation((sessionId: string) => {
+			if (!ctx.mockDb.getSession(sessionId)) return null;
+			const existing = ctx.createdSessions.get(sessionId);
+			if (existing) return existing as unknown as AgentSession;
+			const mockSession = makeMockSession(sessionId);
+			ctx.createdSessions.set(sessionId, mockSession);
+			return mockSession as unknown as AgentSession;
+		});
+	});
+
+	afterEach(() => {
+		ctx.fromInitSpy.mockRestore();
+		restoreSpy.mockRestore();
+	});
+
+	test('rehydrate() restores sub-sessions with both node-agent and space-agent-tools MCP servers attached (in_progress task)', async () => {
+		const wfRunId = 'run-eager-inprogress';
+		const wfId = 'wf-eager-inprogress';
+		const nodeId = 'node-eager-inprogress';
+		seedWorkflowRun(ctx, wfRunId, wfId, nodeId);
+
+		// Parent task in 'in_progress' with a persisted Task Agent session
+		const parentTask = await ctx.taskManager.createTask({
+			title: 'Parent task — eager rehydration (in_progress)',
+			description: '',
+			taskType: 'coding',
+			status: 'in_progress',
+			workflowRunId: wfRunId,
+		});
+		const taskAgentSessionId = `space:${ctx.spaceId}:task:${parentTask.id}`;
+		ctx.taskRepo.updateTask(parentTask.id, {
+			taskAgentSessionId,
+			status: 'in_progress',
+		});
+		ctx.mockDb.createSession({ id: taskAgentSessionId, type: 'space_task_agent' });
+
+		// Sub-session created before the restart — represented by a NodeExecution
+		// row that has an `agentSessionId` plus a `'worker'` session row in DB.
+		const subSessionId = `space:${ctx.spaceId}:task:${parentTask.id}:exec:eager-sub-coder`;
+		const execution = ctx.nodeExecutionRepo.create({
+			workflowRunId: wfRunId,
+			workflowNodeId: nodeId,
+			agentName: 'coder',
+			agentId: null,
+			status: 'in_progress',
+		});
+		ctx.nodeExecutionRepo.updateSessionId(execution.id, subSessionId);
+		ctx.mockDb.createSession({ id: subSessionId, type: 'worker' });
+
+		// Daemon restart entry point: in-memory maps start empty.
+		expect(ctx.manager.getSubSession(subSessionId)).toBeUndefined();
+
+		await ctx.manager.rehydrate();
+
+		// Sub-session is in the in-memory index after rehydrate (no message injection
+		// was needed — this is the gap the fix closes).
+		const rehydrated = ctx.manager.getSubSession(subSessionId);
+		expect(rehydrated).toBeDefined();
+
+		// Both runtime-only MCP servers must be re-attached. Without these, the
+		// sub-session would silently fail any `write_gate` / `read_gate` /
+		// `send_message` call (the original Task #126 failure mode).
+		const session = ctx.createdSessions.get(subSessionId)!;
+		expect(session).toBeDefined();
+		const attachedNames = Object.keys(session._mcpServers);
+		expect(attachedNames).toContain('node-agent');
+		expect(attachedNames).toContain('space-agent-tools');
+
+		// Sub-session also gets registered in the SessionManager cache so the
+		// UI's `getSessionAsync` path resolves to the live (MCP-attached) instance
+		// instead of constructing a bare `AgentSession` from DB.
+		expect(ctx.registeredSessions).toContain(subSessionId);
+	});
+
+	test("rehydrate() includes 'review' status tasks and re-attaches sub-session MCP servers", async () => {
+		// 'review' is the original Task #126 failure mode: a coder/reviewer
+		// sub-session sat idle at a gate while the parent task waited in 'review'
+		// status, and the parent was excluded from `listActiveWithTaskAgentSession`
+		// (so no rehydration happened, so the sub-session never got node-agent /
+		// space-agent-tools re-attached).
+		const wfRunId = 'run-eager-review';
+		const wfId = 'wf-eager-review';
+		const nodeId = 'node-eager-review';
+		seedWorkflowRun(ctx, wfRunId, wfId, nodeId);
+
+		const parentTask = await ctx.taskManager.createTask({
+			title: 'Parent task — eager rehydration (review)',
+			description: '',
+			taskType: 'coding',
+			status: 'in_progress',
+			workflowRunId: wfRunId,
+		});
+		const taskAgentSessionId = `space:${ctx.spaceId}:task:${parentTask.id}`;
+		// Move the task into 'review' AFTER creation — this is the state a task
+		// is in when it has reached a `code-ready-gate` and is waiting for a
+		// reviewer node to evaluate.
+		ctx.taskRepo.updateTask(parentTask.id, {
+			taskAgentSessionId,
+			status: 'review',
+		});
+		ctx.mockDb.createSession({ id: taskAgentSessionId, type: 'space_task_agent' });
+
+		const subSessionId = `space:${ctx.spaceId}:task:${parentTask.id}:exec:eager-sub-reviewer`;
+		const execution = ctx.nodeExecutionRepo.create({
+			workflowRunId: wfRunId,
+			workflowNodeId: nodeId,
+			agentName: 'reviewer',
+			agentId: null,
+			status: 'in_progress',
+		});
+		ctx.nodeExecutionRepo.updateSessionId(execution.id, subSessionId);
+		ctx.mockDb.createSession({ id: subSessionId, type: 'worker' });
+
+		await ctx.manager.rehydrate();
+
+		// The parent Task Agent must come back...
+		expect(ctx.manager.getTaskAgent(parentTask.id)).toBeDefined();
+
+		// ...and so must the sub-session, with both MCP servers attached.
+		expect(ctx.manager.getSubSession(subSessionId)).toBeDefined();
+		const session = ctx.createdSessions.get(subSessionId)!;
+		const attachedNames = Object.keys(session._mcpServers);
+		expect(attachedNames).toContain('node-agent');
+		expect(attachedNames).toContain('space-agent-tools');
+	});
+
+	test('rehydrate() restores multiple sub-sessions per workflow run', async () => {
+		// A workflow run can have multiple node executions (e.g. coder + reviewer
+		// running in parallel, or multiple sequential nodes). All of them must
+		// come back with their MCP servers attached.
+		const wfRunId = 'run-eager-multi';
+		const wfId = 'wf-eager-multi';
+		const nodeId = 'node-eager-multi';
+		seedWorkflowRun(ctx, wfRunId, wfId, nodeId);
+
+		const parentTask = await ctx.taskManager.createTask({
+			title: 'Parent task — multi sub-session rehydration',
+			description: '',
+			taskType: 'coding',
+			status: 'in_progress',
+			workflowRunId: wfRunId,
+		});
+		const taskAgentSessionId = `space:${ctx.spaceId}:task:${parentTask.id}`;
+		ctx.taskRepo.updateTask(parentTask.id, {
+			taskAgentSessionId,
+			status: 'in_progress',
+		});
+		ctx.mockDb.createSession({ id: taskAgentSessionId, type: 'space_task_agent' });
+
+		const subSessionIds = [
+			`space:${ctx.spaceId}:task:${parentTask.id}:exec:eager-multi-coder`,
+			`space:${ctx.spaceId}:task:${parentTask.id}:exec:eager-multi-reviewer`,
+		];
+		const agentNames = ['coder', 'reviewer'];
+		for (let i = 0; i < subSessionIds.length; i++) {
+			const exec = ctx.nodeExecutionRepo.create({
+				workflowRunId: wfRunId,
+				workflowNodeId: nodeId,
+				agentName: agentNames[i]!,
+				agentId: null,
+				status: 'in_progress',
+			});
+			ctx.nodeExecutionRepo.updateSessionId(exec.id, subSessionIds[i]!);
+			ctx.mockDb.createSession({ id: subSessionIds[i]!, type: 'worker' });
+		}
+
+		await ctx.manager.rehydrate();
+
+		for (const id of subSessionIds) {
+			expect(ctx.manager.getSubSession(id)).toBeDefined();
+			const session = ctx.createdSessions.get(id)!;
+			expect(session).toBeDefined();
+			const attached = Object.keys(session._mcpServers);
+			expect(attached).toContain('node-agent');
+			expect(attached).toContain('space-agent-tools');
+		}
+	});
+
+	test('rehydrate() skips NodeExecutions that have no agentSessionId (never spawned)', async () => {
+		// An execution row with a null `agentSessionId` represents a node-agent
+		// that was declared in the workflow but never spawned (e.g. the workflow
+		// is paused before that node). It must NOT trigger any restore call —
+		// there is nothing to restore.
+		const wfRunId = 'run-eager-noagent';
+		const wfId = 'wf-eager-noagent';
+		const nodeId = 'node-eager-noagent';
+		seedWorkflowRun(ctx, wfRunId, wfId, nodeId);
+
+		const parentTask = await ctx.taskManager.createTask({
+			title: 'Parent task — execution with no agentSessionId',
+			description: '',
+			taskType: 'coding',
+			status: 'in_progress',
+			workflowRunId: wfRunId,
+		});
+		const taskAgentSessionId = `space:${ctx.spaceId}:task:${parentTask.id}`;
+		ctx.taskRepo.updateTask(parentTask.id, {
+			taskAgentSessionId,
+			status: 'in_progress',
+		});
+		ctx.mockDb.createSession({ id: taskAgentSessionId, type: 'space_task_agent' });
+
+		// Create an execution but DO NOT call updateSessionId — no agentSessionId.
+		ctx.nodeExecutionRepo.create({
+			workflowRunId: wfRunId,
+			workflowNodeId: nodeId,
+			agentName: 'coder',
+			agentId: null,
+			status: 'pending',
+		});
+
+		// Track restore calls strictly for sub-session-shaped IDs.
+		const subSessionRestoreCalls: string[] = [];
+		const trackingSpy = spyOn(AgentSession, 'restore').mockImplementation((sessionId: string) => {
+			if (sessionId.includes(':exec:')) {
+				subSessionRestoreCalls.push(sessionId);
+			}
+			if (!ctx.mockDb.getSession(sessionId)) return null;
+			const existing = ctx.createdSessions.get(sessionId);
+			if (existing) return existing as unknown as AgentSession;
+			const mockSession = makeMockSession(sessionId);
+			ctx.createdSessions.set(sessionId, mockSession);
+			return mockSession as unknown as AgentSession;
+		});
+
+		try {
+			await ctx.manager.rehydrate();
+		} finally {
+			trackingSpy.mockRestore();
+		}
+
+		// Parent task agent restored, but no sub-session restore attempt was made.
+		expect(ctx.manager.getTaskAgent(parentTask.id)).toBeDefined();
+		expect(subSessionRestoreCalls).toEqual([]);
+	});
+
+	test("SpaceTaskRepository.listActiveWithTaskAgentSession includes 'review' status (Task #126)", async () => {
+		// Direct repository-level guard: if this regresses, the daemon-restart
+		// rehydration loop will silently skip every task waiting at a review
+		// gate, and the sub-session MCP attachment fix above becomes unreachable.
+		const inProgress = await ctx.taskManager.createTask({
+			title: 'in_progress task',
+			description: '',
+			taskType: 'coding',
+			status: 'in_progress',
+		});
+		ctx.taskRepo.updateTask(inProgress.id, {
+			taskAgentSessionId: `space:${ctx.spaceId}:task:${inProgress.id}`,
+		});
+
+		const review = await ctx.taskManager.createTask({
+			title: 'review task',
+			description: '',
+			taskType: 'coding',
+			status: 'in_progress',
+		});
+		ctx.taskRepo.updateTask(review.id, {
+			taskAgentSessionId: `space:${ctx.spaceId}:task:${review.id}`,
+			status: 'review',
+		});
+
+		const blocked = await ctx.taskManager.createTask({
+			title: 'blocked task',
+			description: '',
+			taskType: 'coding',
+			status: 'in_progress',
+		});
+		ctx.taskRepo.updateTask(blocked.id, {
+			taskAgentSessionId: `space:${ctx.spaceId}:task:${blocked.id}`,
+			status: 'blocked',
+		});
+
+		const approved = await ctx.taskManager.createTask({
+			title: 'approved task',
+			description: '',
+			taskType: 'coding',
+			status: 'in_progress',
+		});
+		ctx.taskRepo.updateTask(approved.id, {
+			taskAgentSessionId: `space:${ctx.spaceId}:task:${approved.id}`,
+			status: 'approved',
+		});
+
+		// Excluded statuses — terminal or not-yet-spawned.
+		const done = await ctx.taskManager.createTask({
+			title: 'done task',
+			description: '',
+			taskType: 'coding',
+			status: 'in_progress',
+		});
+		ctx.taskRepo.updateTask(done.id, {
+			taskAgentSessionId: `space:${ctx.spaceId}:task:${done.id}`,
+			status: 'done',
+		});
+
+		const ids = ctx.taskRepo.listActiveWithTaskAgentSession().map((t) => t.id);
+		expect(ids).toContain(inProgress.id);
+		expect(ids).toContain(review.id);
+		expect(ids).toContain(blocked.id);
+		expect(ids).toContain(approved.id);
+		expect(ids).not.toContain(done.id);
+	});
+});

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
@@ -1214,6 +1214,113 @@ describe('TaskAgentManager.rehydrate (eager sub-session rehydration — Task #12
 		expect(subSessionRestoreCalls).toEqual([]);
 	});
 
+	test("rehydrate() skips terminal NodeExecutions ('idle' / 'cancelled') even when agentSessionId is set", async () => {
+		// `handleSubSessionComplete` auto-transitions an execution to 'idle' the
+		// moment a sub-session finishes its turn (and fires the completion
+		// callback). The `agentSessionId` is intentionally retained on the row
+		// so post-mortem tooling and the workflow-completion `terminalResult`
+		// scan can still attribute output back to the agent. Eagerly rehydrating
+		// such an execution on the next daemon restart would attach MCP servers
+		// + restart the streaming query for an agent that has already finished
+		// — pure overhead.
+		//
+		// `'cancelled'` is the same shape: the execution was explicitly stopped
+		// but the row keeps `agentSessionId` for audit. Must also be skipped.
+		const wfRunId = 'run-eager-terminal';
+		const wfId = 'wf-eager-terminal';
+		const nodeId = 'node-eager-terminal';
+		seedWorkflowRun(ctx, wfRunId, wfId, nodeId);
+
+		const parentTask = await ctx.taskManager.createTask({
+			title: 'Parent task — terminal sub-sessions must not rehydrate',
+			description: '',
+			taskType: 'coding',
+			status: 'in_progress',
+			workflowRunId: wfRunId,
+		});
+		const taskAgentSessionId = `space:${ctx.spaceId}:task:${parentTask.id}`;
+		ctx.taskRepo.updateTask(parentTask.id, {
+			taskAgentSessionId,
+			status: 'in_progress',
+		});
+		ctx.mockDb.createSession({ id: taskAgentSessionId, type: 'space_task_agent' });
+
+		// One idle execution (finished its turn — completion callback already fired)
+		const idleSubSessionId = `space:${ctx.spaceId}:task:${parentTask.id}:exec:terminal-idle`;
+		const idleExec = ctx.nodeExecutionRepo.create({
+			workflowRunId: wfRunId,
+			workflowNodeId: nodeId,
+			agentName: 'coder',
+			agentId: null,
+			status: 'in_progress',
+		});
+		ctx.nodeExecutionRepo.updateSessionId(idleExec.id, idleSubSessionId);
+		// Transition to 'idle' (matches handleSubSessionComplete's behaviour at TAM:2316).
+		ctx.nodeExecutionRepo.update(idleExec.id, { status: 'idle' });
+		ctx.mockDb.createSession({ id: idleSubSessionId, type: 'worker' });
+
+		// One cancelled execution (explicitly stopped — same skip rationale)
+		const cancelledSubSessionId = `space:${ctx.spaceId}:task:${parentTask.id}:exec:terminal-cancelled`;
+		const cancelledExec = ctx.nodeExecutionRepo.create({
+			workflowRunId: wfRunId,
+			workflowNodeId: nodeId,
+			agentName: 'reviewer',
+			agentId: null,
+			status: 'in_progress',
+		});
+		ctx.nodeExecutionRepo.updateSessionId(cancelledExec.id, cancelledSubSessionId);
+		ctx.nodeExecutionRepo.update(cancelledExec.id, { status: 'cancelled' });
+		ctx.mockDb.createSession({ id: cancelledSubSessionId, type: 'worker' });
+
+		// One in_progress execution (must rehydrate as control). Distinct
+		// `agentName` because the schema enforces UNIQUE
+		// (workflow_run_id, workflow_node_id, agent_name).
+		const activeSubSessionId = `space:${ctx.spaceId}:task:${parentTask.id}:exec:terminal-active`;
+		const activeExec = ctx.nodeExecutionRepo.create({
+			workflowRunId: wfRunId,
+			workflowNodeId: nodeId,
+			agentName: 'tester',
+			agentId: null,
+			status: 'in_progress',
+		});
+		ctx.nodeExecutionRepo.updateSessionId(activeExec.id, activeSubSessionId);
+		ctx.mockDb.createSession({ id: activeSubSessionId, type: 'worker' });
+
+		// Track every restore call observed during rehydrate().
+		const restoredSessionIds: string[] = [];
+		const trackingSpy = spyOn(AgentSession, 'restore').mockImplementation((sessionId: string) => {
+			restoredSessionIds.push(sessionId);
+			if (!ctx.mockDb.getSession(sessionId)) return null;
+			const existing = ctx.createdSessions.get(sessionId);
+			if (existing) return existing as unknown as AgentSession;
+			const mockSession = makeMockSession(sessionId);
+			ctx.createdSessions.set(sessionId, mockSession);
+			return mockSession as unknown as AgentSession;
+		});
+
+		try {
+			await ctx.manager.rehydrate();
+		} finally {
+			trackingSpy.mockRestore();
+		}
+
+		// AgentSession.restore must NOT have been called for the idle or cancelled sub-sessions.
+		expect(restoredSessionIds).not.toContain(idleSubSessionId);
+		expect(restoredSessionIds).not.toContain(cancelledSubSessionId);
+		// And the in-memory sub-session map must not contain them either.
+		expect(ctx.manager.getSubSession(idleSubSessionId)).toBeUndefined();
+		expect(ctx.manager.getSubSession(cancelledSubSessionId)).toBeUndefined();
+
+		// The active sub-session is the control: it MUST come back, with both MCP
+		// servers attached. If this fails the status filter is over-aggressive.
+		expect(restoredSessionIds).toContain(activeSubSessionId);
+		expect(ctx.manager.getSubSession(activeSubSessionId)).toBeDefined();
+		const activeSession = ctx.createdSessions.get(activeSubSessionId)!;
+		const attached = Object.keys(activeSession._mcpServers);
+		expect(attached).toContain('node-agent');
+		expect(attached).toContain('space-agent-tools');
+	});
+
 	test("SpaceTaskRepository.listActiveWithTaskAgentSession includes 'review' status (Task #126)", async () => {
 		// Direct repository-level guard: if this regresses, the daemon-restart
 		// rehydration loop will silently skip every task waiting at a review


### PR DESCRIPTION
After a daemon restart, coder/reviewer sub-sessions sitting at a `code-ready-gate` silently lost their `node-agent` and `space-agent-tools` MCP servers, so any `write_gate` / `read_gate` / `send_message` call died with "No such tool available" (Task #126).

Two gaps caused this:

1. `SpaceTaskRepository.listActiveWithTaskAgentSession` excluded `'review'`, so the parent task agent was never rehydrated while the workflow waited at the review gate.
2. `TaskAgentManager.rehydrateTaskAgent` did not eagerly rehydrate workflow sub-sessions. They only came back via the lazy `injectSubSessionMessage` path, but UI/RPC paths that resolve sub-sessions through `SessionManager.getSessionAsync` short-circuit on `AgentSession.restore()` and never reach `rehydrateSubSession`, leaving the session with no in-process MCP servers attached.

This PR:

- Adds `'review'` to the active set in `listActiveWithTaskAgentSession` (with per-status justification in the docstring).
- Adds a private `rehydrateSubSessionsForRun` invoked at the end of `rehydrateTaskAgent` that eagerly rehydrates every sub-session whose `NodeExecution` still carries an `agentSessionId`. Failures are isolated per sub-session.
- Removes a misleading docstring claim that the `subSessions` map was "rebuilt from sub-session tasks" — there was no such code.
- Adds focused tests covering the eager rehydration path for `in_progress` and `'review'` statuses, multi-sub-session runs, and executions with no `agentSessionId`. Updates the repository test to assert `'review'` is in the active set.

## Test plan
- [x] `bun test packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts` — 17 pass, 0 fail
- [x] `bun test packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts` — 77 pass, 0 fail
- [x] `bun test packages/daemon/tests/unit/5-space/agent/task-agent-manager-mcp.test.ts` — 31 pass, 0 fail
- [x] `bun test packages/daemon/tests/unit/4-space-storage/storage/space-task-repository.test.ts` — 50 pass, 0 fail
- [x] `bun run lint` / `bun run typecheck` / `bun run format:check` / `bun run check:session-guards` — clean