### PR TITLE
chore(release): bump version to 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,52 +2,55 @@
 
 All notable changes to NeoKai will be documented in this file.
 
-## [Unreleased]
+## [0.13.0] - 2026-04-23
 
-A five-PR refactor that replaces the `completionActions` pipeline with
-workflow-declared post-approval agent routing (#1620, #1621, #1623, #1628, and
-the schema/docs cleanup PR 5/5). See
-[`docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md`](docs/plans/remove-completion-actions-task-agent-as-post-approval-executor.md)
-for the full design.
+A major release replacing the completion-actions pipeline with workflow-declared post-approval routing, unifying the MCP/Tools modal, and hardening daemon restart resilience. 38 commits since v0.12.0.
 
 ### Added
 
-- **`approved` task status** — new lifecycle stage between `review` and `done`
-  for tasks whose end-node verdict has been accepted but whose post-approval
-  side effect (e.g. PR merge) is still in flight.
-- **`postApproval: { targetAgent, instructions }` workflow schema** — workflows
-  declare an optional post-approval route; the runtime spawns the named
-  in-workflow agent (or injects an instruction turn into the Task Agent) on the
-  `review/done → approved` boundary.
-- **`mark_complete` MCP tool** — the post-approval executor calls this to
-  transition `approved → done` (or back to `blocked` with a reason).
-- **Single-slot post-approval banner** — replaces the previous multi-slot
-  completion-action banner; surfaces `task.postApprovalBlockedReason` when the
-  executor reports it cannot proceed.
+#### Post-Approval Routing
+- **`approved` task status**: New lifecycle stage between `review` and `done` for tasks whose end-node verdict is accepted but post-approval side effects are still in flight
+- **`postApproval` workflow schema**: Workflows declare an optional post-approval route; runtime spawns the named agent on the `review/done → approved` boundary
+- **`mark_complete` MCP tool**: Post-approval executor calls this to transition `approved → done` (or back to `blocked`)
+- **Post-approval populated on built-in workflows** with enable flag
+
+#### MCP & Tools
+- **Per-session MCP override toggles** in Tool Modal
+- **Unified session Tools modal**: Session-scoped with deferred toggles
+- **Per-space MCP override UI** + import scanner for `.mcp.json`
+- **Generalized MCP enablement** with `mcp_enablement` table + resolver
+- **`.mcp.json` import** into `app_mcp_servers` (source + sourcePath tracking)
+- **Runtime state in Tools modal** and MCP Servers settings
+- **Preset agent drift detection and sync**
+
+#### Frontend & UI
+- **Minimal thread style exploration page**
+- **Autocompact buffer visualization** on context usage indicator
+- **Task dependency badges** in task list
+- **Submit-for-Review UI unified** with agent `submit_for_approval`
+- **Floating task pane tab pill** inside content area
 
 ### Removed
 
-- **`completionActions` workflow field** — both the type and the schema column.
-  Workflows persisted with the field are silently sanitised at load time and
-  emit a `workflow.migrated` daemon log line so operators can audit drift.
-- **`approve_completion_action` MCP tool**, the `MERGE_PR_COMPLETION_ACTION` /
-  `VERIFY_PR_MERGED_COMPLETION_ACTION` /
-  `VERIFY_REVIEW_POSTED_COMPLETION_ACTION` /
-  `PLAN_AND_DECOMPOSE_VERIFY_COMPLETION_ACTION` constants, and the
-  `CompletionActionExecutor` runtime. PR-merge logic now lives inside the
-  post-approval agent's instructions.
-- **`space_tasks.pending_action_index` column** and
-  **`space_workflow_runs.completion_actions_fired_at` column** — dropped by
-  M104. The `pending_checkpoint_type` CHECK constraint is tightened to
-  `('gate', 'task_completion')`.
+- **`completionActions` pipeline**: Types, schema column, `CompletionActionExecutor`, `approve_completion_action` tool, and completion-action constants removed (M104 migration)
+- **Global MCP Servers page**: Removed; MCP config unified into per-space overrides
+- **Legacy thread render mode** from `SpaceTaskUnifiedThread`
+- **Artifacts header** and legacy MCP config code paths
 
-### Migrations
+### Changed
 
-- **M104** — defensive rewrite of any in-flight
-  `pending_checkpoint_type='completion_action'` rows to `'task_completion'`,
-  table-rebuild of `space_tasks` to drop `pending_action_index`, and
-  `ALTER TABLE … DROP COLUMN` on `space_workflow_runs.completion_actions_fired_at`.
-  Idempotent and guarded for missing-table cases.
+- Drop `completionActions` types, schema, and docs
+- Delete completion-action pipeline + consolidate approval banners
+- Remove legacy thread render mode; float SpaceTaskPane tab pill
+
+### Fixed
+
+- **Daemon restart**: Rehydrate sub-session MCP servers; recover stalled workflow runs; close restart race + stop wiping MCP on space_chat
+- **Tasks in review/approved**: Treated as at-rest in `recoverSingleRun`
+- **MCP servers**: Built-in skills wrapped as SDK plugins (`/playwright`, `fetch-mcp`); kill `.mcp.json` auto-load leak
+- **Chat UX**: Scroll to bottom on cached-session re-mount; keep last message visible above floating composer; gate chat empty state on first messages snapshot
+- **Channel cycles**: Reset counters on human touch
+- **CI**: Stabilize flaky tests (workspace-history sort, web Suspense, Node imports)
 
 ## [0.12.0] - 2026-04-22
 

--- a/npm/neokai/package.json
+++ b/npm/neokai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neokai",
-	"version": "0.12.0",
+	"version": "0.13.0",
 	"description": "NeoKai - Claude Agent SDK Web Interface",
 	"bin": {
 		"kai": "bin/kai.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/cli",
-	"version": "0.12.0",
+	"version": "0.13.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"bin": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/daemon",
-	"version": "0.12.0",
+	"version": "0.13.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "main.ts",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/e2e",
-	"version": "0.12.0",
+	"version": "0.13.0",
 	"private": true,
 	"license": "Apache-2.0",
 	"type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/shared",
-	"version": "0.12.0",
+	"version": "0.13.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "src/mod.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/ui",
-	"version": "0.12.0",
+	"version": "0.13.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "src/mod.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/web",
-	"version": "0.12.0",
+	"version": "0.13.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"scripts": {


### PR DESCRIPTION
Post-approval routing, unified MCP/Tools modal, and daemon restart hardening.