### PR TITLE
refactor(space): move per-node timeouts from runtime into workflow defs

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts
@@ -192,6 +192,7 @@ export function buildWorkflowCreateParams(
 				customPrompt?: import('@neokai/shared').WorkflowNodeAgentOverride;
 				disabledSkillIds?: string[];
 				extraMcpServers?: import('@neokai/shared').WorkflowNodeAgent['extraMcpServers'];
+				timeoutMs?: number;
 			} = {
 				agentId: agentId ?? '',
 				name: a.name,
@@ -213,6 +214,7 @@ export function buildWorkflowCreateParams(
 					string,
 					import('@neokai/shared').McpServerConfig
 				>;
+			if (typeof a.timeoutMs === 'number') entry.timeoutMs = a.timeoutMs;
 			return entry;
 		});
 

--- a/packages/daemon/src/lib/space/export-format.ts
+++ b/packages/daemon/src/lib/space/export-format.ts
@@ -83,6 +83,8 @@ const exportedWorkflowNodeAgentSchema = z.object({
 	 * Validated as a loose record to stay forward-compatible with SDK McpServerConfig shape changes.
 	 */
 	extraMcpServers: z.record(z.string(), z.unknown()).optional(),
+	/** Optional per-slot agent timeout in milliseconds. Positive integer. */
+	timeoutMs: z.number().int().positive().optional(),
 });
 
 /**
@@ -245,6 +247,7 @@ export function exportWorkflow(
 			if (a.customPrompt !== undefined) entry.systemPrompt = a.customPrompt;
 			if (a.disabledSkillIds !== undefined) entry.disabledSkillIds = a.disabledSkillIds;
 			if (a.extraMcpServers !== undefined) entry.extraMcpServers = a.extraMcpServers;
+			if (a.timeoutMs !== undefined) entry.timeoutMs = a.timeoutMs;
 			return entry;
 		});
 

--- a/packages/daemon/src/lib/space/runtime/constants.ts
+++ b/packages/daemon/src/lib/space/runtime/constants.ts
@@ -2,45 +2,26 @@
  * Space Runtime Constants
  *
  * Shared configuration constants for the Space runtime layer.
+ *
+ * Per-node timeout policy lives with the workflow definition, not here. The
+ * runtime knows exactly one timeout default — `DEFAULT_NODE_TIMEOUT_MS`. Any
+ * per-slot override is read from `WorkflowNodeAgent.timeoutMs` at runtime by
+ * `resolveTimeoutForExecution` (see `space-runtime.ts`). Adding a new agent
+ * role no longer requires a runtime change.
  */
 
 // ---------------------------------------------------------------------------
-// Per-node agent name timeout constants (M9.4)
+// Per-node default timeout
 // ---------------------------------------------------------------------------
-
-/** Timeout for coder agent node agents (30 minutes). */
-export const CODER_NODE_TIMEOUT_MS = 30 * 60 * 1000;
-
-/** Timeout for reviewer agent node agents (15 minutes). */
-export const REVIEWER_NODE_TIMEOUT_MS = 15 * 60 * 1000;
-
-/** Timeout for QA agent node agents (15 minutes). */
-export const QA_NODE_TIMEOUT_MS = 15 * 60 * 1000;
-
-/** Timeout for planner agent node agents (20 minutes). */
-export const PLANNER_NODE_TIMEOUT_MS = 20 * 60 * 1000;
-
-/** Default timeout for node agents whose agent name does not match a known preset (30 minutes). */
-export const DEFAULT_NODE_TIMEOUT_MS = 30 * 60 * 1000;
 
 /**
- * Resolve the per-node timeout in milliseconds based on the agent name.
- *
- * Matching is case-insensitive. Known agent names:
- *   - `coder` / `general` → 30 minutes
- *   - `reviewer`          → 15 minutes
- *   - `qa`                → 15 minutes
- *   - `planner`           → 20 minutes
- *   - (anything else)     → 30 minutes (DEFAULT_NODE_TIMEOUT_MS)
+ * Default timeout for node agents whose workflow slot does not declare an
+ * explicit `timeoutMs`. 4 minutes 30 seconds (270_000 ms) — chosen to stay
+ * within the model prompt-cache window so the next interaction can reuse
+ * cached context. Per-node overrides are configured on the agent slot in the
+ * workflow definition.
  */
-export function resolveNodeTimeout(agentName: string): number {
-	const r = agentName.toLowerCase();
-	if (r === 'coder' || r === 'general') return CODER_NODE_TIMEOUT_MS;
-	if (r === 'reviewer') return REVIEWER_NODE_TIMEOUT_MS;
-	if (r === 'qa') return QA_NODE_TIMEOUT_MS;
-	if (r === 'planner') return PLANNER_NODE_TIMEOUT_MS;
-	return DEFAULT_NODE_TIMEOUT_MS;
-}
+export const DEFAULT_NODE_TIMEOUT_MS = 4 * 60 * 1000 + 30 * 1000;
 
 // ---------------------------------------------------------------------------
 // Network retry constants (M9.4)

--- a/packages/daemon/src/lib/space/runtime/resolve-node-timeout.ts
+++ b/packages/daemon/src/lib/space/runtime/resolve-node-timeout.ts
@@ -1,0 +1,58 @@
+/**
+ * Per-node timeout resolution.
+ *
+ * The runtime no longer knows the agent role taxonomy. Per-slot timeout
+ * overrides come from the workflow definition itself (`WorkflowNodeAgent.timeoutMs`).
+ * If a slot does not declare one, the caller falls back to
+ * `DEFAULT_NODE_TIMEOUT_MS` from `./constants`.
+ *
+ * This module intentionally stays small and pure — no role tables, no
+ * registry, no string-keyed lookups. The only inputs are the workflow
+ * definition and the running execution.
+ */
+
+import type { SpaceWorkflow } from '@neokai/shared';
+
+/**
+ * Minimal shape needed to resolve a timeout for a running node execution.
+ * Keeping this interface local avoids importing the larger `NodeExecution`
+ * type just to read two fields.
+ */
+export interface TimeoutExecutionRef {
+	workflowNodeId: string;
+	agentName: string | null;
+}
+
+/**
+ * Resolve the timeout (in ms) declared by the workflow definition for the
+ * agent slot matching this execution.
+ *
+ * Returns `undefined` when:
+ *   - the workflow has no node with the execution's `workflowNodeId`, or
+ *   - the matched node has no agent slot whose `name` matches `agentName`, or
+ *   - the matched slot does not declare a `timeoutMs`.
+ *
+ * The caller is expected to fall back to `DEFAULT_NODE_TIMEOUT_MS` when this
+ * returns `undefined`. Returning `undefined` (rather than the default) keeps
+ * this helper free of policy and lets the call site decide how to handle the
+ * "no override" case.
+ */
+export function resolveTimeoutForExecution(
+	execution: TimeoutExecutionRef,
+	workflow: Pick<SpaceWorkflow, 'nodes'>
+): number | undefined {
+	const node = workflow.nodes.find((n) => n.id === execution.workflowNodeId);
+	if (!node) return undefined;
+
+	const agentName = execution.agentName;
+	if (!agentName) return undefined;
+
+	const slot = node.agents.find((a) => a.name === agentName);
+	if (!slot) return undefined;
+
+	const timeoutMs = slot.timeoutMs;
+	if (typeof timeoutMs !== 'number' || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+		return undefined;
+	}
+	return timeoutMs;
+}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -53,10 +53,11 @@ import {
 } from './post-approval-router';
 import type { SpaceApprovalSource } from '@neokai/shared';
 import {
+	DEFAULT_NODE_TIMEOUT_MS,
 	MAX_BLOCKED_RUN_RETRIES,
 	MAX_TASK_AGENT_CRASH_RETRIES,
-	resolveNodeTimeout,
 } from './constants';
+import { resolveTimeoutForExecution } from './resolve-node-timeout';
 
 const log = new Logger('space-runtime');
 
@@ -1655,7 +1656,8 @@ export class SpaceRuntime {
 				if (execution.status !== 'in_progress' || !execution.agentSessionId) continue;
 				if (!tam.isSessionAlive(execution.agentSessionId)) continue;
 
-				const timeoutMs = resolveNodeTimeout(execution.agentName ?? 'general');
+				const timeoutMs =
+					resolveTimeoutForExecution(execution, meta.workflow) ?? DEFAULT_NODE_TIMEOUT_MS;
 				const referenceTime = execution.startedAt ?? execution.createdAt;
 				const elapsedMs = now - referenceTime;
 				if (elapsedMs <= timeoutMs) continue;

--- a/packages/daemon/tests/unit/4-space-storage/storage/space-workflow-repository-agent-timeout.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/space-workflow-repository-agent-timeout.test.ts
@@ -1,0 +1,127 @@
+/**
+ * SpaceWorkflowRepository — `WorkflowNodeAgent.timeoutMs` round-trip tests.
+ *
+ * Per-slot agent timeouts live with the workflow definition (not the runtime),
+ * so they must round-trip through create / get / list / update without loss.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
+import { createSpaceTables } from '../../helpers/space-test-db.ts';
+
+describe('SpaceWorkflowRepository — WorkflowNodeAgent.timeoutMs round-trip', () => {
+	let db: Database;
+	let repo: SpaceWorkflowRepository;
+	const spaceId = 'sp-1';
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?)`
+		).run(spaceId, spaceId, '/ws/x', 'Test Space', now, now);
+		repo = new SpaceWorkflowRepository(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	test('createWorkflow persists per-slot timeoutMs and getWorkflow reads it back', () => {
+		const wf = repo.createWorkflow({
+			spaceId,
+			name: 'WF With Timeout',
+			nodes: [
+				{
+					name: 'Coding',
+					agents: [
+						{ agentId: 'agent-1', name: 'coder', timeoutMs: 600_000 },
+						{ agentId: 'agent-2', name: 'reviewer' /* no override */ },
+					],
+				},
+			],
+		});
+
+		const fetched = repo.getWorkflow(wf.id);
+		expect(fetched).not.toBeNull();
+		const node = fetched!.nodes[0];
+		expect(node.agents).toHaveLength(2);
+		expect(node.agents[0]).toMatchObject({ name: 'coder', timeoutMs: 600_000 });
+		expect(node.agents[1].timeoutMs).toBeUndefined();
+	});
+
+	test('omitted timeoutMs stays undefined (no implicit defaulting at the storage layer)', () => {
+		const wf = repo.createWorkflow({
+			spaceId,
+			name: 'WF Without Timeout',
+			nodes: [
+				{
+					name: 'Coding',
+					agents: [{ agentId: 'agent-1', name: 'coder' }],
+				},
+			],
+		});
+
+		const fetched = repo.getWorkflow(wf.id);
+		expect(fetched?.nodes[0].agents[0].timeoutMs).toBeUndefined();
+	});
+
+	test('updateWorkflow node replacement preserves the new timeoutMs', () => {
+		const wf = repo.createWorkflow({
+			spaceId,
+			name: 'WF',
+			nodes: [
+				{
+					name: 'Coding',
+					agents: [{ agentId: 'agent-1', name: 'coder', timeoutMs: 300_000 }],
+				},
+			],
+		});
+
+		const updated = repo.updateWorkflow(wf.id, {
+			nodes: [
+				{
+					id: wf.nodes[0].id,
+					name: 'Coding',
+					agents: [{ agentId: 'agent-1', name: 'coder', timeoutMs: 900_000 }],
+				},
+			],
+		});
+		expect(updated?.nodes[0].agents[0].timeoutMs).toBe(900_000);
+
+		const refetched = repo.getWorkflow(wf.id);
+		expect(refetched?.nodes[0].agents[0].timeoutMs).toBe(900_000);
+	});
+
+	test('listWorkflows returns timeoutMs for every workflow row', () => {
+		repo.createWorkflow({
+			spaceId,
+			name: 'WF-A',
+			nodes: [
+				{
+					name: 'Coding',
+					agents: [{ agentId: 'agent-1', name: 'coder', timeoutMs: 600_000 }],
+				},
+			],
+		});
+		repo.createWorkflow({
+			spaceId,
+			name: 'WF-B',
+			nodes: [
+				{
+					name: 'Coding',
+					agents: [{ agentId: 'agent-1', name: 'coder' }],
+				},
+			],
+		});
+
+		const list = repo.listWorkflows(spaceId);
+		const wfA = list.find((w) => w.name === 'WF-A');
+		const wfB = list.find((w) => w.name === 'WF-B');
+		expect(wfA?.nodes[0].agents[0].timeoutMs).toBe(600_000);
+		expect(wfB?.nodes[0].agents[0].timeoutMs).toBeUndefined();
+	});
+});

--- a/packages/daemon/tests/unit/5-space/runtime/resolve-node-timeout.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/resolve-node-timeout.test.ts
@@ -1,0 +1,145 @@
+/**
+ * resolveTimeoutForExecution — unit tests
+ *
+ * Verifies that per-node timeout resolution is driven entirely by the
+ * workflow definition. The runtime no longer carries a role-name → timeout
+ * lookup table; this helper replaces it.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { SpaceWorkflow } from '@neokai/shared';
+import { resolveTimeoutForExecution } from '../../../../src/lib/space/runtime/resolve-node-timeout.ts';
+
+function makeWorkflow(
+	nodes: Array<{
+		id: string;
+		name: string;
+		agents: Array<{ agentId: string; name: string; timeoutMs?: number }>;
+	}>
+): Pick<SpaceWorkflow, 'nodes'> {
+	return { nodes };
+}
+
+describe('resolveTimeoutForExecution', () => {
+	test('returns the slot timeoutMs when set', () => {
+		const wf = makeWorkflow([
+			{
+				id: 'node-1',
+				name: 'Coding',
+				agents: [{ agentId: 'a-1', name: 'coder', timeoutMs: 600_000 }],
+			},
+		]);
+
+		const result = resolveTimeoutForExecution({ workflowNodeId: 'node-1', agentName: 'coder' }, wf);
+		expect(result).toBe(600_000);
+	});
+
+	test('returns undefined when the slot has no timeoutMs', () => {
+		const wf = makeWorkflow([
+			{
+				id: 'node-1',
+				name: 'Coding',
+				agents: [{ agentId: 'a-1', name: 'coder' }],
+			},
+		]);
+
+		const result = resolveTimeoutForExecution({ workflowNodeId: 'node-1', agentName: 'coder' }, wf);
+		expect(result).toBeUndefined();
+	});
+
+	test('returns undefined when the workflow has no matching node', () => {
+		const wf = makeWorkflow([
+			{
+				id: 'node-1',
+				name: 'Coding',
+				agents: [{ agentId: 'a-1', name: 'coder', timeoutMs: 600_000 }],
+			},
+		]);
+
+		const result = resolveTimeoutForExecution(
+			{ workflowNodeId: 'unknown-node', agentName: 'coder' },
+			wf
+		);
+		expect(result).toBeUndefined();
+	});
+
+	test('returns undefined when the node has no slot with the matching name', () => {
+		const wf = makeWorkflow([
+			{
+				id: 'node-1',
+				name: 'Coding',
+				agents: [{ agentId: 'a-1', name: 'reviewer', timeoutMs: 600_000 }],
+			},
+		]);
+
+		const result = resolveTimeoutForExecution({ workflowNodeId: 'node-1', agentName: 'coder' }, wf);
+		expect(result).toBeUndefined();
+	});
+
+	test('returns undefined when execution.agentName is null', () => {
+		const wf = makeWorkflow([
+			{
+				id: 'node-1',
+				name: 'Coding',
+				agents: [{ agentId: 'a-1', name: 'coder', timeoutMs: 600_000 }],
+			},
+		]);
+
+		const result = resolveTimeoutForExecution({ workflowNodeId: 'node-1', agentName: null }, wf);
+		expect(result).toBeUndefined();
+	});
+
+	test('rejects non-positive timeoutMs values', () => {
+		for (const bad of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+			const wf = makeWorkflow([
+				{
+					id: 'node-1',
+					name: 'Coding',
+					agents: [{ agentId: 'a-1', name: 'coder', timeoutMs: bad }],
+				},
+			]);
+
+			const result = resolveTimeoutForExecution(
+				{ workflowNodeId: 'node-1', agentName: 'coder' },
+				wf
+			);
+			expect(result).toBeUndefined();
+		}
+	});
+
+	test('picks the matching slot when a node has multiple agents', () => {
+		const wf = makeWorkflow([
+			{
+				id: 'node-1',
+				name: 'PlanAndCode',
+				agents: [
+					{ agentId: 'a-1', name: 'planner', timeoutMs: 1_200_000 },
+					{ agentId: 'a-2', name: 'coder', timeoutMs: 1_800_000 },
+				],
+			},
+		]);
+
+		expect(resolveTimeoutForExecution({ workflowNodeId: 'node-1', agentName: 'planner' }, wf)).toBe(
+			1_200_000
+		);
+		expect(resolveTimeoutForExecution({ workflowNodeId: 'node-1', agentName: 'coder' }, wf)).toBe(
+			1_800_000
+		);
+	});
+
+	test('matches agentName by exact slot name (case-sensitive)', () => {
+		// Slot names are derived from the SpaceAgent name and stored verbatim;
+		// agent matching here must be exact, mirroring how the runtime stores
+		// the slot name in `node_executions.agent_name`.
+		const wf = makeWorkflow([
+			{
+				id: 'node-1',
+				name: 'Coding',
+				agents: [{ agentId: 'a-1', name: 'Coder', timeoutMs: 600_000 }],
+			},
+		]);
+
+		const result = resolveTimeoutForExecution({ workflowNodeId: 'node-1', agentName: 'coder' }, wf);
+		expect(result).toBeUndefined();
+	});
+});

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -984,6 +984,20 @@ export interface WorkflowNodeAgent {
 	 * Merged with app-level MCP servers when building session options.
 	 */
 	extraMcpServers?: Record<string, McpServerConfig>;
+	/**
+	 * Optional per-slot timeout (milliseconds) used by the runtime to decide
+	 * when an agent that is still alive but apparently stuck should be
+	 * auto-completed.
+	 *
+	 * When unset, the runtime falls back to its `DEFAULT_NODE_TIMEOUT_MS`
+	 * default. Per-node overrides belong with the workflow definition itself —
+	 * the runtime does not embed a role-name → timeout lookup. To give a
+	 * specific node a longer or shorter timeout than the default, set this on
+	 * the agent slot in the workflow definition.
+	 *
+	 * Must be a positive integer when present.
+	 */
+	timeoutMs?: number;
 }
 
 /**
@@ -1423,6 +1437,14 @@ export interface ExportedWorkflowNodeAgent {
 	 * and the data is cast to `McpServerConfig` only at runtime use.
 	 */
 	extraMcpServers?: Record<string, unknown>;
+	/**
+	 * Optional per-slot timeout (milliseconds) for runtime auto-completion of
+	 * stuck-but-alive agents. Mirrors `WorkflowNodeAgent.timeoutMs`. When unset,
+	 * the runtime applies its `DEFAULT_NODE_TIMEOUT_MS` default.
+	 *
+	 * Must be a positive integer when present.
+	 */
+	timeoutMs?: number;
 }
 
 /**


### PR DESCRIPTION
Per-slot timeout overrides now live with the workflow definition (\`WorkflowNodeAgent.timeoutMs\`). The runtime's only timeout knob is \`DEFAULT_NODE_TIMEOUT_MS = 4m30s\`, sized to stay within the model prompt-cache window. The role-name → timeout lookup (\`resolveNodeTimeout()\`) and the \`general → coder\` alias are gone; adding a new agent role no longer requires a runtime PR.

\`WorkflowNodeAgent.timeoutMs\` round-trips through the existing JSON \`config\` column on \`space_workflow_nodes\` (no DDL change) and through export/import.

## Test plan
- [x] \`bun run lint\`
- [x] \`bun run typecheck\`
- [x] \`bun run knip\`
- [x] \`bun test packages/daemon/tests/unit/5-space/runtime/\` (592 pass)
- [x] \`bun test packages/daemon/tests/unit/4-space-storage/\` (1753 pass; 4 pre-existing Copilot-SDK flaky failures unrelated to this change — verified on dev)
- [x] \`bun test packages/shared\` (493 pass)
- [x] \`bun test packages/daemon/tests/unit/2-handlers/\` (4201 pass)
- [x] Acceptance grep \`CODER_/REVIEWER_/QA_/PLANNER_NODE_TIMEOUT_MS|resolveNodeTimeout\` returns zero matches
- [x] Acceptance grep for \`agentName === 'coder|reviewer|qa|planner|general'\` in \`runtime/\` returns zero matches