### PR TITLE
fix(web): track active-turn rail per agent label

### DIFF
--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -173,12 +173,26 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	const isTerminalTask =
 		task.status === 'done' || task.status === 'cancelled' || task.status === 'archived';
 
-	// True when at least one activity member is actively executing (not idle /
-	// completed / failed / interrupted). Used to gate the running-border animation
-	// in the compact thread feed.
-	const isAgentActive = activityMembers.some(
-		(m) => m.state === 'active' || m.state === 'queued' || m.state === 'waiting_for_input'
-	);
+	// Per-agent activity. Each member that's currently executing (not idle /
+	// completed / failed / interrupted) contributes its label to the active set.
+	// The thread feed keys the live rail off this set so that, in multi-session
+	// workflows, every still-running agent's trailing non-terminal block renders
+	// its own active rail — a single boolean would collapse incorrectly when one
+	// agent's terminal result row lands after another agent's last visible row.
+	//
+	// Aggregate boolean is still useful for UI bits that ask "is anything
+	// running?" (the chat composer's processing indicator), so derive it from
+	// the set rather than recomputing from `activityMembers`.
+	const activeAgentLabels = (() => {
+		const labels = new Set<string>();
+		for (const m of activityMembers) {
+			if (m.state === 'active' || m.state === 'queued' || m.state === 'waiting_for_input') {
+				labels.add(m.label);
+			}
+		}
+		return labels;
+	})();
+	const isAgentActive = activeAgentLabels.size > 0;
 	const hasUnifiedWorkflowThread =
 		!!task.workflowRunId || !!agentSessionId || activityMembers.length > 0;
 	const showInlineComposer = !isTerminalTask;
@@ -525,7 +539,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 									bottomInsetClass={
 										showInlineComposer ? (threadSendError ? 'pb-24' : 'pb-16') : 'pb-3'
 									}
-									isAgentActive={isAgentActive}
+									activeAgentLabels={activeAgentLabels}
 								/>
 							) : (
 								<div class="h-full overflow-y-auto">

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -4,7 +4,7 @@ import type {
 	SpaceTaskPriority,
 	SpaceTaskStatus,
 } from '@neokai/shared';
-import { useEffect, useState } from 'preact/hooks';
+import { useEffect, useMemo, useState } from 'preact/hooks';
 import { borderColors } from '../../lib/design-tokens';
 import { navigateToSpaceTask, pushOverlayHistory } from '../../lib/router';
 import { currentSpaceIdSignal, currentSpaceTaskViewTabSignal } from '../../lib/signals';
@@ -180,10 +180,15 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	// its own active rail — a single boolean would collapse incorrectly when one
 	// agent's terminal result row lands after another agent's last visible row.
 	//
+	// `useMemo` keeps the `Set` reference stable between renders when the
+	// activity-members snapshot hasn't changed, so descendants that diff
+	// `activeAgentLabels` by identity (or use it as a hook dependency) don't
+	// see spurious churn on every re-render of the pane.
+	//
 	// Aggregate boolean is still useful for UI bits that ask "is anything
 	// running?" (the chat composer's processing indicator), so derive it from
 	// the set rather than recomputing from `activityMembers`.
-	const activeAgentLabels = (() => {
+	const activeAgentLabels = useMemo(() => {
 		const labels = new Set<string>();
 		for (const m of activityMembers) {
 			if (m.state === 'active' || m.state === 'queued' || m.state === 'waiting_for_input') {
@@ -191,7 +196,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 			}
 		}
 		return labels;
-	})();
+	}, [activityMembers]);
 	const isAgentActive = activeAgentLabels.size > 0;
 	const hasUnifiedWorkflowThread =
 		!!task.workflowRunId || !!agentSessionId || activityMembers.length > 0;

--- a/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
+++ b/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
@@ -14,18 +14,20 @@ interface SpaceTaskUnifiedThreadProps {
 	 */
 	topInsetClass?: string;
 	/**
-	 * Whether the agent session is currently active (not idle / completed /
-	 * failed / interrupted). Forwarded to MinimalThreadFeed to gate the live
-	 * rail / coloured running indicator.
+	 * Labels of agents whose underlying sessions are currently active. Forwarded
+	 * to `MinimalThreadFeed` so the trailing non-terminal block of each
+	 * still-running agent renders its own active rail. Per-agent (rather than a
+	 * single boolean) so a Reviewer terminal `result` row landing after Coder's
+	 * last row can't suppress Coder's still-running rail.
 	 */
-	isAgentActive?: boolean;
+	activeAgentLabels?: ReadonlySet<string>;
 }
 
 export function SpaceTaskUnifiedThread({
 	taskId,
 	bottomInsetClass = 'pb-3',
 	topInsetClass = '',
-	isAgentActive = false,
+	activeAgentLabels,
 }: SpaceTaskUnifiedThreadProps) {
 	const { rows, isLoading, isReconnecting } = useSpaceTaskMessages(taskId, 'compact');
 	const containerRef = useRef<HTMLDivElement>(null);
@@ -77,7 +79,7 @@ export function SpaceTaskUnifiedThread({
 		<div class="h-full min-h-0 flex flex-col relative" data-testid="space-task-unified-thread">
 			<div ref={containerRef} class={`flex-1 overflow-y-auto ${topInsetClass} ${bottomInsetClass}`}>
 				<div class="min-h-[calc(100%+1px)]">
-					<MinimalThreadFeed parsedRows={parsedRows} isAgentActive={isAgentActive} />
+					<MinimalThreadFeed parsedRows={parsedRows} activeAgentLabels={activeAgentLabels} />
 				</div>
 			</div>
 		</div>

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
@@ -236,7 +236,7 @@ describe('MinimalThreadFeed', () => {
 		expect(screen.queryByText('preliminary')).toBeNull();
 	});
 
-	it('renders the active rail and tool roster for the live turn when isAgentActive', () => {
+	it('renders the active rail and tool roster for the live turn when activeAgentLabels includes the agent', () => {
 		const t = Date.now();
 		const rows = [
 			makeRow({
@@ -259,7 +259,7 @@ describe('MinimalThreadFeed', () => {
 			}),
 		];
 
-		render(<MinimalThreadFeed parsedRows={rows} isAgentActive={true} />);
+		render(<MinimalThreadFeed parsedRows={rows} activeAgentLabels={new Set(['Coder Agent'])} />);
 
 		const turn = screen.getByTestId('minimal-thread-turn');
 		expect(turn.dataset.turnState).toBe('active');
@@ -303,7 +303,7 @@ describe('MinimalThreadFeed', () => {
 			}),
 		];
 
-		render(<MinimalThreadFeed parsedRows={rows} isAgentActive={true} />);
+		render(<MinimalThreadFeed parsedRows={rows} activeAgentLabels={new Set(['Coder Agent'])} />);
 		const entries = screen.getAllByTestId('minimal-thread-roster-entry');
 		expect(entries.length).toBe(4);
 		expect(entries[0].textContent).toContain('echo 3');
@@ -331,12 +331,12 @@ describe('MinimalThreadFeed', () => {
 			}),
 		];
 
-		render(<MinimalThreadFeed parsedRows={rows} isAgentActive={true} />);
+		render(<MinimalThreadFeed parsedRows={rows} activeAgentLabels={new Set(['Coder Agent'])} />);
 		expect(screen.queryByTestId('minimal-thread-active-rail')).toBeNull();
 		expect(screen.getByTestId('minimal-thread-turn').dataset.turnState).toBe('completed');
 	});
 
-	it('treats the last block as completed when isAgentActive is false', () => {
+	it('treats the last block as completed when activeAgentLabels is empty', () => {
 		const t = Date.now();
 		// No result message — block is non-terminal. Need an assistant text row
 		// alongside the tool-use so the completed turn has surfaceable text and
@@ -356,7 +356,7 @@ describe('MinimalThreadFeed', () => {
 			}),
 		];
 
-		render(<MinimalThreadFeed parsedRows={rows} isAgentActive={false} />);
+		render(<MinimalThreadFeed parsedRows={rows} activeAgentLabels={new Set()} />);
 		const turn = screen.getByTestId('minimal-thread-turn');
 		expect(turn.dataset.turnState).toBe('completed');
 		expect(screen.queryByTestId('minimal-thread-active-rail')).toBeNull();
@@ -538,7 +538,7 @@ describe('MinimalThreadFeed', () => {
 			}),
 		];
 
-		render(<MinimalThreadFeed parsedRows={rows} isAgentActive={true} />);
+		render(<MinimalThreadFeed parsedRows={rows} activeAgentLabels={new Set(['Coder Agent'])} />);
 		const turns = screen.getAllByTestId('minimal-thread-turn');
 		expect(turns[0].dataset.turnState).toBe('message');
 		expect(turns[1].dataset.turnState).toBe('active');
@@ -625,7 +625,7 @@ describe('MinimalThreadFeed', () => {
 			}),
 		];
 
-		render(<MinimalThreadFeed parsedRows={rows} isAgentActive={true} />);
+		render(<MinimalThreadFeed parsedRows={rows} activeAgentLabels={new Set(['Coder Agent'])} />);
 
 		const entries = screen.getAllByTestId('minimal-thread-roster-entry');
 		expect(entries.length).toBe(4);
@@ -660,7 +660,7 @@ describe('MinimalThreadFeed', () => {
 			}),
 		];
 
-		render(<MinimalThreadFeed parsedRows={rows} isAgentActive={true} />);
+		render(<MinimalThreadFeed parsedRows={rows} activeAgentLabels={new Set(['Coder Agent'])} />);
 		const entries = screen.getAllByTestId('minimal-thread-roster-entry');
 		// Only the tool entry survives — the empty/whitespace text blocks
 		// are filtered out so they don't pollute the rail.
@@ -841,7 +841,7 @@ describe('MinimalThreadFeed', () => {
 			}),
 		];
 
-		render(<MinimalThreadFeed parsedRows={rows} isAgentActive={true} />);
+		render(<MinimalThreadFeed parsedRows={rows} activeAgentLabels={new Set(['Coder Agent'])} />);
 		const entries = screen.getAllByTestId('minimal-thread-roster-entry');
 		expect(entries.length).toBe(4);
 		const allText = entries.map((e) => e.textContent).join('\n');
@@ -853,5 +853,181 @@ describe('MinimalThreadFeed', () => {
 		expect(allText).toContain('echo 2');
 		expect(allText).toContain('msg-3');
 		expect(allText).toContain('echo 3');
+	});
+
+	describe('Per-agent active rail (multi-session)', () => {
+		// In a multi-session workflow (e.g. Coder + Reviewer in the Coding
+		// Workflow), agent rows interleave. With the original "globally
+		// trailing block" check, a Reviewer terminal `result` row landing
+		// after Coder's last visible row would suppress Coder's still-
+		// running rail because the global tail is now terminal. The fix
+		// is to track trailing non-terminal blocks per agent label.
+		it('keeps the Coder rail active when Reviewer just emitted a terminal result after Coder', () => {
+			const t = Date.now();
+			const rows = [
+				// Coder is mid-action — assistant rows but no result yet.
+				makeRow({
+					id: 'a-coder-1',
+					label: 'Coder Agent',
+					createdAt: t,
+					message: assistantToolUse('a-coder-1', [
+						{ name: 'Bash', input: { command: 'bun run typecheck' } },
+					]),
+				}),
+				makeRow({
+					id: 'a-coder-2',
+					label: 'Coder Agent',
+					createdAt: t + 1000,
+					message: assistantText('a-coder-2', 'investigating'),
+				}),
+				// Reviewer ran briefly and just finished — its terminal `result`
+				// row lands AFTER Coder's last row. Pre-fix, this is what
+				// suppressed Coder's rail.
+				makeRow({
+					id: 'a-rev',
+					label: 'Reviewer Agent',
+					createdAt: t + 2000,
+					message: assistantText('a-rev', 'looks good so far'),
+				}),
+				makeRow({
+					id: 'r-rev',
+					label: 'Reviewer Agent',
+					createdAt: t + 2500,
+					message: resultMessage('r-rev'),
+				}),
+			];
+
+			render(<MinimalThreadFeed parsedRows={rows} activeAgentLabels={new Set(['Coder Agent'])} />);
+
+			const turns = screen.getAllByTestId('minimal-thread-turn');
+			// Coder turn first, Reviewer turn second.
+			const coderTurn = turns.find((t) => t.dataset.agentLabel === 'Coder Agent');
+			const reviewerTurn = turns.find((t) => t.dataset.agentLabel === 'Reviewer Agent');
+			expect(coderTurn?.dataset.turnState).toBe('active');
+			expect(reviewerTurn?.dataset.turnState).toBe('completed');
+			// Exactly one rail — Coder's.
+			expect(screen.getAllByTestId('minimal-thread-active-rail').length).toBe(1);
+		});
+
+		it('mirrors: keeps the Reviewer rail active when Coder just finished before Reviewer', () => {
+			const t = Date.now();
+			const rows = [
+				// Coder fully ran and emitted a terminal result.
+				makeRow({
+					id: 'a-coder',
+					label: 'Coder Agent',
+					createdAt: t,
+					message: assistantText('a-coder', 'patch sent'),
+				}),
+				makeRow({
+					id: 'r-coder',
+					label: 'Coder Agent',
+					createdAt: t + 500,
+					message: resultMessage('r-coder'),
+				}),
+				// Reviewer is mid-action — assistant rows, no result yet.
+				makeRow({
+					id: 'a-rev-1',
+					label: 'Reviewer Agent',
+					createdAt: t + 1000,
+					message: assistantToolUse('a-rev-1', [{ name: 'Bash', input: { command: 'bun test' } }]),
+				}),
+				makeRow({
+					id: 'a-rev-2',
+					label: 'Reviewer Agent',
+					createdAt: t + 1500,
+					message: assistantText('a-rev-2', 'verifying tests'),
+				}),
+			];
+
+			render(
+				<MinimalThreadFeed parsedRows={rows} activeAgentLabels={new Set(['Reviewer Agent'])} />
+			);
+
+			const turns = screen.getAllByTestId('minimal-thread-turn');
+			const coderTurn = turns.find((t) => t.dataset.agentLabel === 'Coder Agent');
+			const reviewerTurn = turns.find((t) => t.dataset.agentLabel === 'Reviewer Agent');
+			expect(coderTurn?.dataset.turnState).toBe('completed');
+			expect(reviewerTurn?.dataset.turnState).toBe('active');
+			expect(screen.getAllByTestId('minimal-thread-active-rail').length).toBe(1);
+		});
+
+		it('renders one rail per agent when both agents are running concurrently', () => {
+			const t = Date.now();
+			const rows = [
+				// Coder mid-action — non-terminal.
+				makeRow({
+					id: 'a-coder-1',
+					label: 'Coder Agent',
+					createdAt: t,
+					message: assistantToolUse('a-coder-1', [
+						{ name: 'Bash', input: { command: 'bun build' } },
+					]),
+				}),
+				makeRow({
+					id: 'a-coder-2',
+					label: 'Coder Agent',
+					createdAt: t + 1000,
+					message: assistantText('a-coder-2', 'still going'),
+				}),
+				// Reviewer mid-action — also non-terminal.
+				makeRow({
+					id: 'a-rev-1',
+					label: 'Reviewer Agent',
+					createdAt: t + 2000,
+					message: assistantToolUse('a-rev-1', [{ name: 'Read', input: { file_path: 'foo.ts' } }]),
+				}),
+				makeRow({
+					id: 'a-rev-2',
+					label: 'Reviewer Agent',
+					createdAt: t + 3000,
+					message: assistantText('a-rev-2', 'checking'),
+				}),
+			];
+
+			render(
+				<MinimalThreadFeed
+					parsedRows={rows}
+					activeAgentLabels={new Set(['Coder Agent', 'Reviewer Agent'])}
+				/>
+			);
+
+			const turns = screen.getAllByTestId('minimal-thread-turn');
+			const coderTurn = turns.find((t) => t.dataset.agentLabel === 'Coder Agent');
+			const reviewerTurn = turns.find((t) => t.dataset.agentLabel === 'Reviewer Agent');
+			expect(coderTurn?.dataset.turnState).toBe('active');
+			expect(reviewerTurn?.dataset.turnState).toBe('active');
+			// Two rails — one per agent.
+			expect(screen.getAllByTestId('minimal-thread-active-rail').length).toBe(2);
+		});
+
+		it('matches active-agent labels case- and whitespace-insensitively', () => {
+			// Activity members are run through a title-casing helper on the
+			// daemon ("coder agent" → "Coder Agent") while raw row labels
+			// can be either form. The renderer should treat them as the
+			// same agent regardless of casing or extra whitespace.
+			const t = Date.now();
+			const rows = [
+				makeRow({
+					id: 'a1',
+					label: 'coder agent',
+					createdAt: t,
+					message: assistantToolUse('a1', [{ name: 'Bash', input: { command: 'ls' } }]),
+				}),
+				makeRow({
+					id: 'a2',
+					label: 'coder agent',
+					createdAt: t + 1000,
+					message: assistantText('a2', 'running'),
+				}),
+			];
+
+			render(
+				<MinimalThreadFeed parsedRows={rows} activeAgentLabels={new Set(['Coder   Agent'])} />
+			);
+
+			const turn = screen.getByTestId('minimal-thread-turn');
+			expect(turn.dataset.turnState).toBe('active');
+		});
 	});
 });

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -34,7 +34,12 @@ type SystemInitMessage = Extract<SDKMessage, { type: 'system'; subtype: 'init' }
 type ResultMessage = Extract<SDKMessage, { type: 'result' }>;
 import { useEffect, useState } from 'preact/hooks';
 import MarkdownRenderer from '../../../chat/MarkdownRenderer.tsx';
-import { type AgentTurnBlock, buildAgentTurns, isUserRow } from '../space-task-thread-turns';
+import {
+	type AgentTurnBlock,
+	buildAgentTurns,
+	isUserRow,
+	normalizeAgentKey,
+} from '../space-task-thread-turns';
 import { SyntheticMessageBlock } from '../../../sdk/SyntheticMessageBlock';
 import { SpaceTaskThreadMessageActions } from '../SpaceTaskThreadMessageActions';
 import { getAgentColor } from '../space-task-thread-agent-colors';
@@ -51,11 +56,24 @@ import {
 interface MinimalThreadFeedProps {
 	parsedRows: ParsedThreadRow[];
 	/**
-	 * Whether the underlying agent session is currently executing. When true
-	 * AND the last logical block is non-terminal, that block renders as the
-	 * active turn (coloured rail, live tool roster, ticking elapsed clock).
+	 * Labels of agents whose underlying sessions are currently executing.
+	 * The trailing non-terminal block **for each label in this set** renders as
+	 * the active turn (coloured rail, live tool roster, ticking elapsed clock).
+	 *
+	 * Per-agent rather than a single boolean: in multi-session workflows
+	 * (e.g. Coder + Reviewer interleaved), the Reviewer's terminal `result`
+	 * row can land *after* the Coder's last visible row. With a single
+	 * boolean + globally-trailing block check, that suppresses the Coder's
+	 * still-running rail because the global tail is now terminal. Keying
+	 * activity by agent label lets each agent's trailing block be upgraded
+	 * independently of what other agents emitted afterwards.
+	 *
+	 * Labels are matched case-insensitively / whitespace-insensitively against
+	 * each block's `agentLabel` so activity-member labels (which are run
+	 * through a title-casing helper on the daemon) collide with raw row
+	 * labels (e.g. "coder agent" → "Coder Agent").
 	 */
-	isAgentActive?: boolean;
+	activeAgentLabels?: ReadonlySet<string>;
 }
 
 /**
@@ -494,21 +512,32 @@ function extractBlockEnvelopes(rows: ParsedThreadRow[]): {
  * - Each user/synthetic row becomes its own `MessageFeedTurn`, surfaced as a
  *   distinct row showing FROM → TO and the message body.
  * - Consecutive non-user rows (assistant + result) form `CompletedFeedTurn`s.
- * - The very last agent turn upgrades to `ActiveFeedTurn` when the underlying
- *   block is non-terminal AND `isAgentActive` is true.
+ * - For every agent label in `activeAgentLabels`, the trailing non-terminal
+ *   completed turn from that agent upgrades to an `ActiveFeedTurn`. Tracking
+ *   trailing state per agent (rather than a single global "last block") is
+ *   what keeps the Coder rail visible when a Reviewer's terminal `result` row
+ *   lands after Coder's last row in a multi-session workflow.
  */
-function buildFeedTurns(parsedRows: ParsedThreadRow[], isAgentActive: boolean): FeedTurn[] {
+function buildFeedTurns(
+	parsedRows: ParsedThreadRow[],
+	activeAgentLabels: ReadonlySet<string>
+): FeedTurn[] {
 	const blocks = buildAgentTurns(parsedRows);
 	if (blocks.length === 0) return [];
 
 	const turns: FeedTurn[] = [];
-	// Store mutable cross-iteration state in an object so TS doesn't
-	// over-narrow the closure-captured fields to `never` after the loop.
-	const trailing: {
-		idx: number;
+	// Per-agent trailing completed-turn pointer. Keyed by the normalised agent
+	// label so case/whitespace variants between activity-member labels (run
+	// through a title-casing helper on the daemon) and raw row labels collide
+	// on the same entry. Each `flushAgent` call overwrites the entry for
+	// `block.agentLabel`, so after the loop the map points at the *last*
+	// completed turn each agent produced — exactly what we want to upgrade.
+	type AgentTrailing = {
+		turnIdx: number;
 		rows: ParsedThreadRow[];
-		block: AgentTurnBlock | null;
-	} = { idx: -1, rows: [], block: null };
+		block: AgentTurnBlock;
+	};
+	const perAgentTrailing = new Map<string, AgentTrailing>();
 	let previousAgentLabel: string | null = null;
 
 	for (const block of blocks) {
@@ -517,15 +546,18 @@ function buildFeedTurns(parsedRows: ParsedThreadRow[], isAgentActive: boolean): 
 		// envelopes. Cheap — single linear scan over rows we'd already be
 		// walking anyway.
 		const { init: blockInit, result: blockResult } = extractBlockEnvelopes(block.rows);
+		const blockKey = normalizeAgentKey(block.agentLabel);
 
 		let pendingAgentRows: ParsedThreadRow[] = [];
 		const flushAgent = () => {
 			if (pendingAgentRows.length === 0) return;
 			const turnId = `${block.id}:${String(pendingAgentRows[0].id)}`;
 			turns.push(buildCompletedTurn(block, pendingAgentRows, turnId, blockResult));
-			trailing.idx = turns.length - 1;
-			trailing.rows = pendingAgentRows;
-			trailing.block = block;
+			perAgentTrailing.set(blockKey, {
+				turnIdx: turns.length - 1,
+				rows: pendingAgentRows,
+				block,
+			});
 			pendingAgentRows = [];
 		};
 
@@ -541,11 +573,22 @@ function buildFeedTurns(parsedRows: ParsedThreadRow[], isAgentActive: boolean): 
 		previousAgentLabel = block.agentLabel;
 	}
 
-	// Upgrade the last agent turn to active when the trailing block is
-	// non-terminal and the session is reportedly running.
-	if (isAgentActive && trailing.idx >= 0 && trailing.block && !trailing.block.isTerminal) {
-		const completed = turns[trailing.idx] as CompletedFeedTurn;
-		turns[trailing.idx] = buildActiveTurn(trailing.block, trailing.rows, completed.id);
+	// Per-agent active-rail upgrade. For every label in `activeAgentLabels`
+	// whose trailing block is non-terminal, swap that agent's last completed
+	// turn for an active turn. Independent across agents — a Reviewer terminal
+	// block landing after Coder's last row can no longer suppress the Coder
+	// rail because Coder has its own entry in `perAgentTrailing`.
+	if (activeAgentLabels.size > 0) {
+		const normalisedActive = new Set<string>();
+		for (const label of activeAgentLabels) {
+			normalisedActive.add(normalizeAgentKey(label));
+		}
+		for (const [key, trailing] of perAgentTrailing) {
+			if (!normalisedActive.has(key)) continue;
+			if (trailing.block.isTerminal) continue;
+			const completed = turns[trailing.turnIdx] as CompletedFeedTurn;
+			turns[trailing.turnIdx] = buildActiveTurn(trailing.block, trailing.rows, completed.id);
+		}
 	}
 
 	// Drop empty completed turns. With result-message-aware text extraction in
@@ -904,8 +947,13 @@ function MinimalTurnRow({ turn }: { turn: FeedTurn }) {
 
 /* ── public component ────────────────────────────────────────────────────── */
 
-export function MinimalThreadFeed({ parsedRows, isAgentActive = false }: MinimalThreadFeedProps) {
-	const turns = buildFeedTurns(parsedRows, isAgentActive);
+const EMPTY_ACTIVE_AGENT_LABELS: ReadonlySet<string> = new Set();
+
+export function MinimalThreadFeed({
+	parsedRows,
+	activeAgentLabels = EMPTY_ACTIVE_AGENT_LABELS,
+}: MinimalThreadFeedProps) {
+	const turns = buildFeedTurns(parsedRows, activeAgentLabels);
 	if (turns.length === 0) return null;
 
 	return (

--- a/packages/web/src/components/space/thread/space-task-thread-turns.ts
+++ b/packages/web/src/components/space/thread/space-task-thread-turns.ts
@@ -38,7 +38,15 @@ export interface AgentTurnBlock {
 	isTerminal: boolean;
 }
 
-function normalizeAgentKey(label: string): string {
+/**
+ * Lowercase + collapse-whitespace agent label normaliser. Exported so callers
+ * that match block agent labels against external label sources (e.g. activity
+ * members emitted by the daemon, which run their `role` through a separate
+ * title-casing helper before reaching the renderer) can compare against the
+ * same canonical form `buildAgentTurns` uses internally to detect agent
+ * boundaries.
+ */
+export function normalizeAgentKey(label: string): string {
 	return label.trim().toLowerCase().replace(/\s+/g, ' ');
 }
 


### PR DESCRIPTION
## Summary

`MinimalThreadFeed`'s active-turn rail was keyed off the globally trailing block. In multi-session workflows (Coder + Reviewer), a Reviewer terminal `result` row landing after Coder's last visible row collapsed Coder's still-running rail because the global tail was now terminal.

This change replaces `isAgentActive: boolean` with `activeAgentLabels: Set<string>` and tracks trailing non-terminal blocks per normalized agent label so each running agent's trailing block upgrades to the active rail independently.

## Test plan

- [x] Updated existing `MinimalThreadFeed.test.tsx` cases to use the new prop
- [x] Added regression tests: Coder-running + Reviewer-just-finished, mirror, both-running, and case-insensitive label matching
- [x] `bun test` (255 files / 7310 tests) green
- [x] `bun run check` (lint + typecheck + knip + session-guards) green
- [ ] Manual dev verification of Coding Workflow Coder→Reviewer→Coder handoff