### PR TITLE
feat(space): server-derived active-turn roster decoupled from compact feed

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -38,8 +38,17 @@ export interface NamedQuery {
 	/**
 	 * Optional hook to extract metadata from raw query results (before mapRow).
 	 * Called once per query evaluation; result is attached to snapshot/delta events.
+	 *
+	 * The bound query parameters are forwarded as a second argument so handlers
+	 * that need to run a sidecar prepared statement (e.g., `spaceTaskMessages.
+	 * byTask.compact`'s active-turn aggregation) can reuse the same param values
+	 * the live query was subscribed with — they aren't otherwise visible to
+	 * `mapResult`.
 	 */
-	mapResult?: (rawRows: Record<string, unknown>[]) => Record<string, unknown> | undefined;
+	mapResult?: (
+		rawRows: Record<string, unknown>[],
+		params: ReadonlyArray<unknown>
+	) => Record<string, unknown> | undefined;
 }
 
 // ============================================================================
@@ -937,6 +946,9 @@ session_turns AS (
       ELSE 0
     END AS isTerminal,
     CASE
+      -- Drop user rows whose content is exclusively tool_result blocks — they
+      -- render as null in the compact UI and would otherwise consume slots
+      -- in the per-turn cap without contributing visible content.
       WHEN j.messageType = 'user'
         AND json_type(j.content, '$.message.content') = 'array'
         AND EXISTS (
@@ -944,6 +956,27 @@ session_turns AS (
         FROM json_each(json_extract(j.content, '$.message.content')) AS je
         WHERE json_extract(je.value, '$.type') = 'tool_result'
       ) THEN 0
+      -- Drop assistant rows that have *no* renderable content — i.e. the
+      -- content array exists but every block is either an empty/whitespace
+      -- text block or has no non-empty thinking/tool_use sibling. These
+      -- show up rarely in practice but bloat the per-turn cap when they
+      -- do; the active-turn summary applies the same filter so server and
+      -- client agree on what counts as visible activity.
+      WHEN j.messageType = 'assistant'
+        AND json_type(j.content, '$.message.content') = 'array'
+        AND NOT EXISTS (
+          SELECT 1
+          FROM json_each(json_extract(j.content, '$.message.content')) AS je
+          WHERE json_extract(je.value, '$.type') = 'tool_use'
+             OR (
+                json_extract(je.value, '$.type') = 'text'
+                AND TRIM(COALESCE(json_extract(je.value, '$.text'), '')) != ''
+             )
+             OR (
+                json_extract(je.value, '$.type') = 'thinking'
+                AND TRIM(COALESCE(json_extract(je.value, '$.thinking'), '')) != ''
+             )
+        ) THEN 0
       ELSE 1
     END AS isRenderable,
     COALESCE(
@@ -1049,6 +1082,329 @@ SELECT
 FROM selected
 ORDER BY createdAt ASC, id ASC
 `.trim();
+
+/**
+ * SQL for the active-turn activity summary that ships alongside the compact
+ * feed.
+ *
+ * Per the design in task #131: the running roster on the Space task view is
+ * supposed to summarise the *currently active* turn — every tool_use, text,
+ * thinking block, plus user-row activity (real human input + synthetic
+ * agent→agent handoffs). The compact feed query keeps only the last 5
+ * non-terminal renderable rows per `(session, turn)`, which is right for the
+ * feed but too narrow for the roster.
+ *
+ * Strategy:
+ *   1. Reuse the base CTE chain to identify per-session turns (turnIndex is
+ *      the cumulative count of `result` rows preceding each row, plus one).
+ *   2. For each session, find the highest turnIndex with no terminal row yet —
+ *      that's the *active* turn. Closed turns are intentionally excluded.
+ *   3. Walk every row of the active turn (NOT the compacted slice). For
+ *      assistant rows, explode the SDK content blocks via `json_each` and
+ *      classify each one (`tool_use` / `text` / `thinking`). For user rows,
+ *      emit a single entry tagged either `__user_message` (human input) or
+ *      `__user_replay` (synthetic handoff) per `isReplay`. Empty/whitespace
+ *      `text` and `thinking` blocks are filtered out — they're noise. User
+ *      rows whose content is exclusively `tool_result` blocks are dropped
+ *      (mirrors the compact-feed transmission filter).
+ *   4. Order the union deterministically: `(sessionId, ts, rowId, blockIdx)`
+ *      so chronological sequence is preserved across rows AND across
+ *      multiple content blocks within a single row.
+ *
+ * The JS-side `mapResult` hook for `spaceTaskMessages.byTask.compact` runs
+ * this SQL with the same `?1 = task_id` param the compact subscription was
+ * bound with, then aggregates the per-entry rows by sessionId into the
+ * `ActiveTurnSummary[]` shape consumers expect. Closed turns produce zero
+ * rows here and so simply don't appear in the metadata payload.
+ */
+export const SPACE_TASK_ACTIVE_TURN_ENTRIES_BY_TASK_SQL = `
+${SPACE_TASK_MESSAGES_BASE_CTE},
+session_turns AS (
+  SELECT
+    j.id,
+    j.sessionId,
+    j.kind,
+    j.role,
+    j.label,
+    j.taskId,
+    j.taskTitle,
+    j.messageType,
+    j.content,
+    j.createdAt,
+    j.iteration,
+    j.parentToolUseId,
+    COALESCE(
+      SUM(CASE WHEN j.messageType = 'result' THEN 1 ELSE 0 END) OVER (
+        PARTITION BY j.sessionId
+        ORDER BY j.createdAt ASC, j.id ASC
+        ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+      ),
+      0
+    ) + 1 AS turnIndex
+  FROM joined j
+),
+session_max_turn AS (
+  SELECT sessionId, MAX(turnIndex) AS maxTurnIndex
+  FROM session_turns
+  GROUP BY sessionId
+),
+active_turn AS (
+  -- The latest turn per session that has not yet seen a terminal result row.
+  SELECT
+    smt.sessionId AS sessionId,
+    smt.maxTurnIndex AS turnIndex
+  FROM session_max_turn smt
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM session_turns st
+    WHERE st.sessionId = smt.sessionId
+      AND st.turnIndex = smt.maxTurnIndex
+      AND st.messageType = 'result'
+  )
+),
+active_rows AS (
+  SELECT st.*
+  FROM session_turns st
+  JOIN active_turn at
+    ON at.sessionId = st.sessionId
+   AND at.turnIndex = st.turnIndex
+),
+-- One row per assistant content block (tool_use / non-empty text / thinking).
+assistant_entries AS (
+  SELECT
+    ar.sessionId AS sessionId,
+    ar.turnIndex AS turnIndex,
+    ar.createdAt AS ts,
+    ar.id AS rowId,
+    CAST(je.key AS INTEGER) AS blockIdx,
+    json_extract(ar.content, '$.uuid') AS uuid,
+    json_extract(je.value, '$.type') AS blockType,
+    json_extract(je.value, '$.name') AS toolName,
+    json_extract(je.value, '$.input') AS toolInput,
+    json_extract(je.value, '$.text') AS textValue,
+    json_extract(je.value, '$.thinking') AS thinkingValue
+  FROM active_rows ar,
+       json_each(json_extract(ar.content, '$.message.content')) je
+  WHERE ar.messageType = 'assistant'
+    AND json_type(ar.content, '$.message.content') = 'array'
+    AND (
+      json_extract(je.value, '$.type') = 'tool_use'
+      OR (
+        json_extract(je.value, '$.type') = 'text'
+        AND TRIM(COALESCE(json_extract(je.value, '$.text'), '')) != ''
+      )
+      OR (
+        json_extract(je.value, '$.type') = 'thinking'
+        AND TRIM(COALESCE(json_extract(je.value, '$.thinking'), '')) != ''
+      )
+    )
+),
+-- One row per user-typed message row (real human or synthetic replay).
+user_entries AS (
+  SELECT
+    ar.sessionId AS sessionId,
+    ar.turnIndex AS turnIndex,
+    ar.createdAt AS ts,
+    ar.id AS rowId,
+    -1 AS blockIdx,
+    json_extract(ar.content, '$.uuid') AS uuid,
+    CASE
+      WHEN COALESCE(CAST(json_extract(ar.content, '$.isReplay') AS INTEGER), 0) = 1
+        THEN '__user_replay'
+      ELSE '__user_message'
+    END AS blockType,
+    NULL AS toolName,
+    NULL AS toolInput,
+    -- Extract the plain-text body of the message.
+    -- - String content → use directly.
+    -- - Array content → concatenate text blocks.
+    -- - Otherwise → empty string.
+    CASE
+      WHEN json_type(ar.content, '$.message.content') = 'text'
+        THEN json_extract(ar.content, '$.message.content')
+      WHEN json_type(ar.content, '$.message.content') = 'array' THEN (
+        SELECT GROUP_CONCAT(json_extract(je.value, '$.text'), ' ')
+        FROM json_each(json_extract(ar.content, '$.message.content')) je
+        WHERE json_extract(je.value, '$.type') = 'text'
+          AND COALESCE(json_extract(je.value, '$.text'), '') != ''
+      )
+      ELSE ''
+    END AS textValue,
+    NULL AS thinkingValue
+  FROM active_rows ar
+  WHERE ar.messageType = 'user'
+    -- Skip user rows whose content is exclusively tool_result blocks. Such
+    -- rows render as null in the compact feed and don't represent activity.
+    AND NOT (
+      json_type(ar.content, '$.message.content') = 'array'
+      AND EXISTS (
+        SELECT 1
+        FROM json_each(json_extract(ar.content, '$.message.content')) je
+        WHERE json_extract(je.value, '$.type') = 'tool_result'
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM json_each(json_extract(ar.content, '$.message.content')) je
+        WHERE json_extract(je.value, '$.type') = 'text'
+      )
+    )
+)
+SELECT
+  sessionId,
+  turnIndex,
+  ts,
+  rowId,
+  blockIdx,
+  uuid,
+  blockType,
+  toolName,
+  toolInput,
+  textValue,
+  thinkingValue
+FROM assistant_entries
+UNION ALL
+SELECT
+  sessionId,
+  turnIndex,
+  ts,
+  rowId,
+  blockIdx,
+  uuid,
+  blockType,
+  toolName,
+  toolInput,
+  textValue,
+  thinkingValue
+FROM user_entries
+ORDER BY sessionId ASC, ts ASC, rowId ASC, blockIdx ASC
+`.trim();
+
+// ============================================================================
+// Active-turn entry aggregation
+// ============================================================================
+
+const ACTIVITY_PREVIEW_MAX_LEN = 200;
+
+/**
+ * Collapse arbitrary text into a single line and cap its length so the
+ * server-side preview matches what the rail can render without further work.
+ * Mirrors the client-side `oneLine` shape so trailing ellipses and whitespace
+ * collapsing line up byte-for-byte across server and client.
+ */
+function activityOneLine(value: string, max = ACTIVITY_PREVIEW_MAX_LEN): string {
+	const collapsed = value.replace(/\s+/g, ' ').trim();
+	if (collapsed.length === 0) return '';
+	return collapsed.length > max ? `${collapsed.slice(0, max - 1)}…` : collapsed;
+}
+
+/**
+ * Pick a human-friendly preview from a tool_use input object. Falls back
+ * through the most common Claude tool-input shapes (Bash command, file path,
+ * grep pattern, URL, description) before settling for a `key: value` pair so
+ * even tools we don't recognise produce a non-empty preview line.
+ *
+ * Server-side equivalent of the existing client-side `previewFromInput`.
+ */
+function activityPreviewFromInput(input: Record<string, unknown>): string {
+	const command = typeof input.command === 'string' ? input.command : '';
+	if (command) return activityOneLine(command);
+	const filePath = typeof input.file_path === 'string' ? input.file_path : '';
+	if (filePath) return activityOneLine(filePath);
+	const path = typeof input.path === 'string' ? input.path : '';
+	if (path) return activityOneLine(path);
+	const pattern = typeof input.pattern === 'string' ? input.pattern : '';
+	if (pattern) return activityOneLine(pattern);
+	const url = typeof input.url === 'string' ? input.url : '';
+	if (url) return activityOneLine(url);
+	const description = typeof input.description === 'string' ? input.description : '';
+	if (description) return activityOneLine(description);
+	const keys = Object.keys(input);
+	if (keys.length === 0) return '';
+	const firstKey = keys[0];
+	const firstVal = input[firstKey];
+	if (typeof firstVal === 'string') return activityOneLine(`${firstKey}: ${firstVal}`);
+	return `${firstKey}: …`;
+}
+
+/**
+ * Aggregate the per-entry rows produced by `SPACE_TASK_ACTIVE_TURN_ENTRIES_BY_TASK_SQL`
+ * into the `ActiveTurnSummary[]` payload the client consumes.
+ *
+ * Each row corresponds to a single activity entry (one assistant content
+ * block, or one user-row entry). Rows are already chronologically sorted by
+ * the SQL — we only need to group by sessionId and translate the raw
+ * `blockType` discriminator into the public `ActivityEntry.kind` shape, while
+ * computing previews / unwrapping `tool_use.input` JSON server-side.
+ *
+ * Exported for unit-test coverage.
+ */
+export function buildActiveTurnSummariesFromRows(
+	rows: Record<string, unknown>[]
+): Array<{ sessionId: string; turnIndex: number; entries: Record<string, unknown>[] }> {
+	const bySession = new Map<
+		string,
+		{ sessionId: string; turnIndex: number; entries: Record<string, unknown>[] }
+	>();
+
+	for (const row of rows) {
+		const sessionId = typeof row.sessionId === 'string' ? row.sessionId : null;
+		if (!sessionId) continue;
+		const turnIndex = Number(row.turnIndex ?? 0);
+		const ts = Number(row.ts ?? 0);
+		const uuid = typeof row.uuid === 'string' ? row.uuid : '';
+		const blockType = typeof row.blockType === 'string' ? row.blockType : '';
+
+		let entry: Record<string, unknown> | null = null;
+		if (blockType === 'tool_use') {
+			const toolName = typeof row.toolName === 'string' ? row.toolName : '';
+			const rawInput = row.toolInput;
+			let parsedInput: Record<string, unknown> = {};
+			if (typeof rawInput === 'string') {
+				try {
+					const maybe = JSON.parse(rawInput);
+					if (maybe && typeof maybe === 'object') {
+						parsedInput = maybe as Record<string, unknown>;
+					}
+				} catch {
+					// Leave parsedInput empty — preview falls through to `tool_name: …`.
+				}
+			} else if (rawInput && typeof rawInput === 'object') {
+				parsedInput = rawInput as Record<string, unknown>;
+			}
+			entry = {
+				kind: 'tool_use',
+				toolName,
+				preview: activityPreviewFromInput(parsedInput),
+				ts,
+				uuid,
+			};
+		} else if (blockType === 'text') {
+			const text = typeof row.textValue === 'string' ? row.textValue : '';
+			if (text.trim().length === 0) continue;
+			entry = { kind: 'text', text: activityOneLine(text), ts, uuid };
+		} else if (blockType === 'thinking') {
+			const thinking = typeof row.thinkingValue === 'string' ? row.thinkingValue : '';
+			if (thinking.trim().length === 0) continue;
+			entry = { kind: 'thinking', preview: activityOneLine(thinking), ts, uuid };
+		} else if (blockType === '__user_message') {
+			const text = typeof row.textValue === 'string' ? row.textValue : '';
+			entry = { kind: 'user_message', text: activityOneLine(text), ts, uuid };
+		} else if (blockType === '__user_replay') {
+			const text = typeof row.textValue === 'string' ? row.textValue : '';
+			entry = { kind: 'agent_handoff', text: activityOneLine(text), ts, uuid };
+		}
+		if (!entry) continue;
+
+		let summary = bySession.get(sessionId);
+		if (!summary) {
+			summary = { sessionId, turnIndex, entries: [] };
+			bySession.set(sessionId, summary);
+		}
+		summary.entries.push(entry);
+	}
+
+	return Array.from(bySession.values());
+}
 
 // ============================================================================
 // Registry
@@ -1506,8 +1862,45 @@ export function setupLiveQueryHandlers(
 	// visible session list is empty (e.g. all sessions are archived, showArchived=false).
 	const stmtSessionsTotalCount = db.prepare(SESSIONS_TOTAL_COUNT_SQL);
 	const stmtSessionsArchivedCount = db.prepare(SESSIONS_ARCHIVED_COUNT_SQL);
+
+	// Sidecar prepared statement for the compact-thread mapResult: emits one
+	// row per activity entry in each session's currently-active turn. The
+	// compact thread query itself caps rows per turn at 5; this sidecar is
+	// the uncapped feed used to drive the running roster on the task view.
+	//
+	// Prepared lazily on first use so daemon startup doesn't depend on every
+	// table referenced by the CTE chain (e.g. `node_executions`) being live
+	// yet. Preparing eagerly here regressed test setups whose minimal schema
+	// hadn't run the migration that creates that table.
+	let _stmtActiveTurnEntries: ReturnType<BunDatabase['prepare']> | null = null;
+	const getStmtActiveTurnEntries = () => {
+		if (!_stmtActiveTurnEntries) {
+			_stmtActiveTurnEntries = db.prepare(SPACE_TASK_ACTIVE_TURN_ENTRIES_BY_TASK_SQL);
+		}
+		return _stmtActiveTurnEntries;
+	};
+
 	const sessionsListBase = NAMED_QUERY_REGISTRY.get('sessions.list')!;
 	const activeRegistry = new Map(NAMED_QUERY_REGISTRY);
+
+	// Override the compact-thread query so each evaluation also computes the
+	// active-turn activity summary alongside the compact rows. Wired through
+	// the metadata channel so existing snapshot/delta plumbing carries it
+	// without a parallel subscription.
+	const compactThreadBase = NAMED_QUERY_REGISTRY.get('spaceTaskMessages.byTask.compact')!;
+	activeRegistry.set('spaceTaskMessages.byTask.compact', {
+		...compactThreadBase,
+		mapResult: (_rawRows, params) => {
+			const taskId = params[0];
+			if (typeof taskId !== 'string' || taskId.length === 0) return undefined;
+			const entryRows = getStmtActiveTurnEntries().all(taskId) as Record<string, unknown>[];
+			const summaries = buildActiveTurnSummariesFromRows(entryRows);
+			// Always emit the field so the client sees an authoritative empty
+			// list rather than a stale value from a prior snapshot.
+			return { activeTurnSummaries: summaries };
+		},
+	});
+
 	activeRegistry.set('sessions.list', {
 		...sessionsListBase,
 		mapResult: (rawRows) => {
@@ -1696,8 +2089,10 @@ export function setupLiveQueryHandlers(
 					return;
 				}
 
-				// Extract metadata from raw rows (before mapRow strips internal columns)
-				const metadata = namedQuery.mapResult?.(diff.rows as Record<string, unknown>[]);
+				// Extract metadata from raw rows (before mapRow strips internal columns).
+				// Params are forwarded so handlers like the compact-thread mapResult can
+				// run a sidecar prepared statement bound to the same task id.
+				const metadata = namedQuery.mapResult?.(diff.rows as Record<string, unknown>[], params);
 
 				let message: ReturnType<typeof createEventMessage>;
 

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -1233,8 +1233,14 @@ user_entries AS (
     NULL AS thinkingValue
   FROM active_rows ar
   WHERE ar.messageType = 'user'
-    -- Skip user rows whose content is exclusively tool_result blocks. Such
-    -- rows render as null in the compact feed and don't represent activity.
+    -- Skip user rows whose content is exclusively tool_result blocks (or
+    -- mixes tool_result with empty/whitespace-only text blocks). Such rows
+    -- render as null in the compact feed and would otherwise produce a
+    -- blank rail entry — the GROUP_CONCAT above already filters empty text,
+    -- so the row would survive the filter with textValue = NULL.
+    --
+    -- Mirrors the assistant-entries filter on lines above, which also
+    -- excludes empty-text blocks from contributing to the roster.
     AND NOT (
       json_type(ar.content, '$.message.content') = 'array'
       AND EXISTS (
@@ -1246,6 +1252,7 @@ user_entries AS (
         SELECT 1
         FROM json_each(json_extract(ar.content, '$.message.content')) je
         WHERE json_extract(je.value, '$.type') = 'text'
+          AND TRIM(COALESCE(json_extract(je.value, '$.text'), '')) != ''
       )
     )
 )

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
@@ -1015,6 +1015,119 @@ describe('NAMED_QUERY_REGISTRY', () => {
 				expect(nodeEntries.map((e) => e.text)).toContain('node active');
 			});
 		});
+
+		// ---------------------------------------------------------------------
+		// Integration: the central decoupling claim of the PR — a long active
+		// turn yields ≤5 rows in the compact feed (server cap unchanged) AND
+		// every entry in `activeTurnSummaries` (no cap on the summary side).
+		// ---------------------------------------------------------------------
+
+		describe('compact-feed cap and active-turn-summary decoupling', () => {
+			function insertSdkMessageAt(
+				id: string,
+				sessionIdValue: string,
+				timestampMs: number,
+				sdkMessage?: Record<string, unknown>,
+				messageType = 'assistant'
+			): void {
+				const iso = new Date(timestampMs).toISOString();
+				const payload =
+					sdkMessage ??
+					({
+						type: 'assistant',
+						uuid: id,
+						message: { role: 'assistant', content: [{ type: 'text', text: id }] },
+					} as Record<string, unknown>);
+				db.exec(`
+					INSERT INTO sdk_messages (
+						id, session_id, message_type, message_subtype, sdk_message, timestamp, send_status, origin
+					) VALUES (
+						'${id}', '${sessionIdValue}', '${messageType}', NULL, '${JSON.stringify(payload).replace(/'/g, "''")}',
+						'${iso}', 'consumed', 'system'
+					)
+				`);
+			}
+
+			function queryCompact(taskId: string): Record<string, unknown>[] {
+				const entry = NAMED_QUERY_REGISTRY.get('spaceTaskMessages.byTask.compact')!;
+				const rows = db.prepare(entry.sql).all(taskId) as Record<string, unknown>[];
+				return entry.mapRow ? rows.map(entry.mapRow) : rows;
+			}
+
+			async function runEntries(taskId: string): Promise<Record<string, unknown>[]> {
+				const mod = await import('../../../../src/lib/rpc-handlers/live-query-handlers');
+				const sql = mod.SPACE_TASK_ACTIVE_TURN_ENTRIES_BY_TASK_SQL;
+				return db.prepare(sql).all(taskId) as Record<string, unknown>[];
+			}
+
+			async function buildSummaries(taskId: string): Promise<
+				Array<{
+					sessionId: string;
+					turnIndex: number;
+					entries: Record<string, unknown>[];
+				}>
+			> {
+				const mod = await import('../../../../src/lib/rpc-handlers/live-query-handlers');
+				const rows = await runEntries(taskId);
+				return mod.buildActiveTurnSummariesFromRows(rows);
+			}
+
+			test('long active turn: compact feed ≤5 non-terminal rows AND summary carries every entry', async () => {
+				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
+				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
+
+				// Insert 8 distinct assistant tool_use rows in the same active turn.
+				// Each emits one ActivityEntry (one tool_use block per row), so the
+				// summary should carry exactly 8 entries while the compact feed
+				// caps at 5.
+				const turnSize = 8;
+				const toolNames = [
+					'Bash',
+					'Read',
+					'Grep',
+					'Glob',
+					'Edit',
+					'Write',
+					'WebFetch',
+					'WebSearch',
+				];
+				for (let i = 0; i < turnSize; i += 1) {
+					insertSdkMessageAt(`a${i}`, sessionId, now + (i + 1) * 1000, {
+						type: 'assistant',
+						uuid: `a${i}`,
+						message: {
+							content: [
+								{
+									type: 'tool_use',
+									id: `tu-a${i}`,
+									name: toolNames[i],
+									input: { foo: i },
+								},
+							],
+						},
+					});
+				}
+				// Active turn: no terminal `result` row inserted.
+
+				// Compact feed: capped at the per-turn non-terminal limit (5).
+				const compactRows = queryCompact(taskId);
+				expect(compactRows.length).toBeLessThanOrEqual(
+					5 // SPACE_TASK_MESSAGES_COMPACT_NON_TERMINAL_PER_TURN_LIMIT
+				);
+				// Sanity: cap was actually exercised — we inserted more than the cap.
+				expect(turnSize).toBeGreaterThan(compactRows.length);
+
+				// Active-turn summary: uncapped, full chronological activity.
+				const summaries = await buildSummaries(taskId);
+				expect(summaries).toHaveLength(1);
+				const entries = summaries[0].entries as Array<Record<string, unknown>>;
+				expect(entries).toHaveLength(turnSize);
+				expect(entries.map((e) => e.toolName)).toEqual(toolNames);
+				// Confirms entries are not subject to the compact cap that limits
+				// the row stream — this is the decoupling the PR establishes.
+				expect(entries.length).toBeGreaterThan(compactRows.length);
+			});
+		});
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
@@ -705,6 +705,316 @@ describe('NAMED_QUERY_REGISTRY', () => {
 				}
 			});
 		});
+
+		// -----------------------------------------------------------------------
+		// SPACE_TASK_ACTIVE_TURN_ENTRIES_BY_TASK_SQL — server-derived running
+		// roster source. Drives `metadata.activeTurnSummaries` on the compact
+		// LiveQuery; the client renders this directly without re-deriving from
+		// the (potentially truncated) compact rows.
+		// -----------------------------------------------------------------------
+
+		describe('active-turn entries SQL', () => {
+			function insertSdkMessageAt(
+				id: string,
+				sessionIdValue: string,
+				timestampMs: number,
+				sdkMessage?: Record<string, unknown>,
+				messageType = 'assistant'
+			): void {
+				const iso = new Date(timestampMs).toISOString();
+				const payload =
+					sdkMessage ??
+					({
+						type: 'assistant',
+						uuid: id,
+						message: { role: 'assistant', content: [{ type: 'text', text: id }] },
+					} as Record<string, unknown>);
+				db.exec(`
+					INSERT INTO sdk_messages (
+						id, session_id, message_type, message_subtype, sdk_message, timestamp, send_status, origin
+					) VALUES (
+						'${id}', '${sessionIdValue}', '${messageType}', NULL, '${JSON.stringify(payload).replace(/'/g, "''")}',
+						'${iso}', 'consumed', 'system'
+					)
+				`);
+			}
+
+			function insertResultAt(
+				id: string,
+				sessionIdValue: string,
+				timestampMs: number,
+				subtype: 'success' | 'error_during_execution' = 'success'
+			): void {
+				insertSdkMessageAt(
+					id,
+					sessionIdValue,
+					timestampMs,
+					{
+						type: 'result',
+						uuid: id,
+						subtype,
+						duration_ms: 1,
+						duration_api_ms: 1,
+						is_error: subtype !== 'success',
+						total_cost_usd: 0,
+						usage: {
+							input_tokens: 1,
+							cached_input_tokens: 0,
+							output_tokens: 1,
+							reasoning_output_tokens: 0,
+							total_tokens: 2,
+						},
+					},
+					'result'
+				);
+			}
+
+			async function runEntries(taskId: string): Promise<unknown[]> {
+				const mod = await import('../../../../src/lib/rpc-handlers/live-query-handlers');
+				const sql = mod.SPACE_TASK_ACTIVE_TURN_ENTRIES_BY_TASK_SQL;
+				return db.prepare(sql).all(taskId);
+			}
+
+			async function buildSummaries(taskId: string): Promise<
+				Array<{
+					sessionId: string;
+					turnIndex: number;
+					entries: Record<string, unknown>[];
+				}>
+			> {
+				const mod = await import('../../../../src/lib/rpc-handlers/live-query-handlers');
+				const rows = (await runEntries(taskId)) as Record<string, unknown>[];
+				return mod.buildActiveTurnSummariesFromRows(rows);
+			}
+
+			test('emits a summary only for the active (non-terminal) turn per session', async () => {
+				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
+				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
+
+				// Closed turn: assistant text → result.
+				insertSdkMessageAt('t1-a1', sessionId, now + 1000, {
+					type: 'assistant',
+					uuid: 't1-a1',
+					message: { content: [{ type: 'text', text: 'closed-text' }] },
+				});
+				insertResultAt('t1-r', sessionId, now + 2000, 'success');
+
+				// Active turn: tool_use only, NO result row yet.
+				insertSdkMessageAt('t2-a1', sessionId, now + 3000, {
+					type: 'assistant',
+					uuid: 't2-a1',
+					message: {
+						content: [
+							{ type: 'tool_use', id: 'tu-1', name: 'Bash', input: { command: 'bun test' } },
+						],
+					},
+				});
+
+				const summaries = await buildSummaries(taskId);
+				expect(summaries).toHaveLength(1);
+				expect(summaries[0].sessionId).toBe(sessionId);
+				expect(summaries[0].turnIndex).toBe(2);
+				const entries = summaries[0].entries as Array<Record<string, unknown>>;
+				expect(entries).toHaveLength(1);
+				expect(entries[0].kind).toBe('tool_use');
+				expect(entries[0].toolName).toBe('Bash');
+				expect(entries[0].preview).toBe('bun test');
+				// No closed-turn entries leak through.
+				const previews = entries.map((e) => String(e.preview ?? e.text ?? ''));
+				expect(previews).not.toContain('closed-text');
+			});
+
+			test('emits no summary when the latest turn is closed', async () => {
+				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
+				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
+
+				insertSdkMessageAt('a1', sessionId, now + 1000);
+				insertResultAt('r1', sessionId, now + 2000, 'success');
+
+				const summaries = await buildSummaries(taskId);
+				expect(summaries).toHaveLength(0);
+			});
+
+			test('explodes assistant blocks into per-block entries (tool_use, text, thinking)', async () => {
+				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
+				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
+
+				insertSdkMessageAt('a1', sessionId, now + 1000, {
+					type: 'assistant',
+					uuid: 'a1',
+					message: {
+						content: [
+							{ type: 'thinking', thinking: 'Considering options' },
+							{ type: 'text', text: 'Investigating the failing test' },
+							{ type: 'tool_use', id: 'tu-1', name: 'Bash', input: { command: 'ls' } },
+							{ type: 'text', text: '   ' }, // whitespace-only — server should drop
+						],
+					},
+				});
+
+				const summaries = await buildSummaries(taskId);
+				expect(summaries).toHaveLength(1);
+				const entries = summaries[0].entries as Array<Record<string, unknown>>;
+				const kinds = entries.map((e) => e.kind);
+				expect(kinds).toEqual(['thinking', 'text', 'tool_use']);
+				expect(entries[0].preview).toBe('Considering options');
+				expect(entries[1].text).toBe('Investigating the failing test');
+				expect(entries[2].toolName).toBe('Bash');
+				expect(entries[2].preview).toBe('ls');
+			});
+
+			test('distinguishes real human input from synthetic agent handoffs via isReplay', async () => {
+				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
+				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
+
+				// Real human input — isReplay falsy.
+				insertSdkMessageAt(
+					'u1',
+					sessionId,
+					now + 1000,
+					{
+						type: 'user',
+						uuid: 'u1',
+						message: { role: 'user', content: 'please retry' },
+					},
+					'user'
+				);
+				// Synthetic handoff — isReplay = true.
+				insertSdkMessageAt(
+					'u2',
+					sessionId,
+					now + 2000,
+					{
+						type: 'user',
+						uuid: 'u2',
+						isReplay: true,
+						message: {
+							role: 'user',
+							content: [{ type: 'text', text: 'Reviewer Agent: take over' }],
+						},
+					},
+					'user'
+				);
+				// Active turn open with a tool_use to anchor the active-turn detection.
+				insertSdkMessageAt('a1', sessionId, now + 3000, {
+					type: 'assistant',
+					uuid: 'a1',
+					message: {
+						content: [{ type: 'tool_use', id: 'tu-1', name: 'Bash', input: { command: 'ls' } }],
+					},
+				});
+
+				const summaries = await buildSummaries(taskId);
+				expect(summaries).toHaveLength(1);
+				const entries = summaries[0].entries as Array<Record<string, unknown>>;
+				const kinds = entries.map((e) => e.kind);
+				// Server distinguishes the two user-row variants on the wire.
+				expect(kinds).toContain('user_message');
+				expect(kinds).toContain('agent_handoff');
+				const userEntry = entries.find((e) => e.kind === 'user_message') as Record<string, unknown>;
+				const handoffEntry = entries.find((e) => e.kind === 'agent_handoff') as Record<
+					string,
+					unknown
+				>;
+				expect(userEntry.text).toBe('please retry');
+				expect(handoffEntry.text).toBe('Reviewer Agent: take over');
+			});
+
+			test('skips user rows whose content is exclusively tool_result blocks', async () => {
+				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
+				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
+
+				// User row with only a tool_result block — should be dropped.
+				insertSdkMessageAt(
+					'u1',
+					sessionId,
+					now + 1000,
+					{
+						type: 'user',
+						uuid: 'u1',
+						message: {
+							role: 'user',
+							content: [
+								{
+									type: 'tool_result',
+									tool_use_id: 'tu-x',
+									content: [{ type: 'text', text: 'tool output' }],
+								},
+							],
+						},
+					},
+					'user'
+				);
+				// Anchor the active turn with an assistant block.
+				insertSdkMessageAt('a1', sessionId, now + 2000, {
+					type: 'assistant',
+					uuid: 'a1',
+					message: {
+						content: [{ type: 'tool_use', id: 'tu-1', name: 'Bash', input: { command: 'ls' } }],
+					},
+				});
+
+				const summaries = await buildSummaries(taskId);
+				expect(summaries).toHaveLength(1);
+				const entries = summaries[0].entries as Array<Record<string, unknown>>;
+				const kinds = entries.map((e) => e.kind);
+				// No user_message / agent_handoff entry from the tool_result row.
+				expect(kinds).not.toContain('user_message');
+				expect(kinds).not.toContain('agent_handoff');
+				// The assistant tool_use survives.
+				expect(kinds).toContain('tool_use');
+			});
+
+			test('produces independent summaries per session when multiple sessions are active', async () => {
+				const orchestrationSessionId = 'space:test:task:ates-orch';
+				const nodeSessionId = 'space:test:task:atea-node';
+				const workflowRunId = 'wr-active-turn-multi';
+				const workflowNodeId = 'node-multi';
+				const taskId = insertSpaceTask({
+					taskAgentSessionId: orchestrationSessionId,
+					workflowRunId,
+				});
+
+				insertSession(orchestrationSessionId, 'space_task_agent', '{"status":"processing"}');
+				insertSession(nodeSessionId, 'space_task_agent', '{"status":"processing"}');
+
+				db.exec(`
+					INSERT INTO node_executions (
+						id, workflow_run_id, workflow_node_id, agent_name, agent_id,
+						agent_session_id, status, result, created_at, started_at,
+						completed_at, updated_at
+					) VALUES (
+						'ne-multi', '${workflowRunId}', '${workflowNodeId}', 'coder', NULL,
+						'${nodeSessionId}', 'in_progress', NULL, ${now}, ${now},
+						NULL, ${now}
+					)
+				`);
+
+				// Both sessions have an active turn (no result row yet) — both
+				// should appear in the summaries.
+				insertSdkMessageAt('orch-a1', orchestrationSessionId, now + 1000, {
+					type: 'assistant',
+					uuid: 'orch-a1',
+					message: { content: [{ type: 'text', text: 'orch active' }] },
+				});
+				insertSdkMessageAt('node-a1', nodeSessionId, now + 1000, {
+					type: 'assistant',
+					uuid: 'node-a1',
+					message: { content: [{ type: 'text', text: 'node active' }] },
+				});
+
+				const summaries = await buildSummaries(taskId);
+				const bySession = new Map(summaries.map((s) => [s.sessionId, s]));
+				expect(bySession.has(orchestrationSessionId)).toBe(true);
+				expect(bySession.has(nodeSessionId)).toBe(true);
+				const orchEntries = bySession.get(orchestrationSessionId)!.entries as Array<
+					Record<string, unknown>
+				>;
+				const nodeEntries = bySession.get(nodeSessionId)!.entries as Array<Record<string, unknown>>;
+				expect(orchEntries.map((e) => e.text)).toContain('orch active');
+				expect(nodeEntries.map((e) => e.text)).toContain('node active');
+			});
+		});
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -1606,3 +1606,46 @@ export interface ApprovalRecord {
 	/** True if the human chose to skip this action instead of approving */
 	skipped?: boolean;
 }
+
+// ── Active-turn activity summary ──────────────────────────────────────────────
+//
+// The Space task view's running roster ("what is the agent doing right now?")
+// summarises the *currently active* turn for each agent session. Historically
+// the client derived the roster from the same compacted feed rows used by the
+// minimal thread renderer — capped at the last 5 non-terminal renderable rows
+// per turn — so long turns under-reported their activity. The server now
+// computes the full chronological activity list per active turn alongside the
+// compact feed and ships it as `activeTurnSummaries` on the LiveQuery
+// metadata channel; the client display cap is applied at render time.
+
+/** A single chronological activity entry within an active turn. */
+export type ActivityEntry =
+	/** Assistant `tool_use` block — surfaces tool name + an input preview. */
+	| { kind: 'tool_use'; toolName: string; preview: string; ts: number; uuid: string }
+	/** Assistant `text` block (non-empty) — surfaces the assistant's text. */
+	| { kind: 'text'; text: string; ts: number; uuid: string }
+	/** Assistant `thinking` block (non-empty) — surfaces a thinking preview. */
+	| { kind: 'thinking'; preview: string; ts: number; uuid: string }
+	/** Real human user input (`type: 'user'`, `isReplay` falsy). */
+	| { kind: 'user_message'; text: string; ts: number; uuid: string }
+	/** Synthetic agent→agent / system handoff (`type: 'user'`, `isReplay: true`). */
+	| { kind: 'agent_handoff'; text: string; ts: number; uuid: string };
+
+/**
+ * Per-(session, turn) summary of activity entries within an active (incomplete)
+ * turn. Emitted on the `liveQuery.snapshot`/`liveQuery.delta` `metadata` field
+ * for the `spaceTaskMessages.byTask.compact` query under
+ * `metadata.activeTurnSummaries`.
+ *
+ * The server only emits a summary for the highest turnIndex per session that
+ * has not yet seen a terminal `result` row. Closed turns are excluded —
+ * they are not "active" for the purposes of the running roster.
+ */
+export interface ActiveTurnSummary {
+	/** Agent session id whose active turn this summary describes. */
+	sessionId: string;
+	/** Server-computed turn index (1-based, mirrors compact feed `turnIndex`). */
+	turnIndex: number;
+	/** All activity entries in the active turn, chronological order preserved. */
+	entries: ActivityEntry[];
+}

--- a/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
+++ b/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
@@ -29,7 +29,10 @@ export function SpaceTaskUnifiedThread({
 	topInsetClass = '',
 	activeAgentLabels,
 }: SpaceTaskUnifiedThreadProps) {
-	const { rows, isLoading, isReconnecting } = useSpaceTaskMessages(taskId, 'compact');
+	const { rows, activeTurnSummaries, isLoading, isReconnecting } = useSpaceTaskMessages(
+		taskId,
+		'compact'
+	);
 	const containerRef = useRef<HTMLDivElement>(null);
 	const didInitialScrollRef = useRef<string | null>(null);
 
@@ -79,7 +82,11 @@ export function SpaceTaskUnifiedThread({
 		<div class="h-full min-h-0 flex flex-col relative" data-testid="space-task-unified-thread">
 			<div ref={containerRef} class={`flex-1 overflow-y-auto ${topInsetClass} ${bottomInsetClass}`}>
 				<div class="min-h-[calc(100%+1px)]">
-					<MinimalThreadFeed parsedRows={parsedRows} activeAgentLabels={activeAgentLabels} />
+					<MinimalThreadFeed
+						parsedRows={parsedRows}
+						activeAgentLabels={activeAgentLabels}
+						activeTurnSummaries={activeTurnSummaries}
+					/>
 				</div>
 			</div>
 		</div>

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
@@ -1,7 +1,6 @@
-// @ts-nocheck
-
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ActiveTurnSummary } from '@neokai/shared';
 import { parseThreadRow } from '../space-task-thread-events';
 import { MinimalThreadFeed } from './MinimalThreadFeed';
 
@@ -316,7 +315,7 @@ describe('MinimalThreadFeed', () => {
 		// Server-derived summary: same activity as the parsed rows would produce
 		// under the old client-side derivation, but expressed as the wire shape
 		// (`ActivityEntry[]`) the renderer now consumes.
-		const summary = {
+		const summary: ActiveTurnSummary = {
 			sessionId: 'space:s:task:t',
 			turnIndex: 1,
 			entries: [
@@ -381,7 +380,7 @@ describe('MinimalThreadFeed', () => {
 		];
 
 		// 6 tool entries in the active-turn summary — only the last 4 should render.
-		const summary = {
+		const summary: ActiveTurnSummary = {
 			sessionId: 'space:s:task:t',
 			turnIndex: 1,
 			entries: [
@@ -701,7 +700,7 @@ describe('MinimalThreadFeed', () => {
 
 		// Sequence: text → tool → text → tool. All four entries should appear
 		// in the roster in order, with kinds tagged on the data attribute.
-		const summary = {
+		const summary: ActiveTurnSummary = {
 			sessionId: 'space:s:task:t',
 			turnIndex: 1,
 			entries: [
@@ -746,7 +745,7 @@ describe('MinimalThreadFeed', () => {
 		// Server is the canonical filter — but the renderer also defensively
 		// drops empty text/thinking entries so a future relaxation upstream
 		// can't bleed whitespace into the rail.
-		const summary = {
+		const summary: ActiveTurnSummary = {
 			sessionId: 'space:s:task:t',
 			turnIndex: 1,
 			entries: [
@@ -929,7 +928,7 @@ describe('MinimalThreadFeed', () => {
 		];
 
 		// 6 mixed entries — only the last 4 should render.
-		const summary = {
+		const summary: ActiveTurnSummary = {
 			sessionId: 'space:s:task:t',
 			turnIndex: 1,
 			entries: [
@@ -1149,7 +1148,7 @@ describe('MinimalThreadFeed', () => {
 			}),
 		];
 
-		const summary = {
+		const summary: ActiveTurnSummary = {
 			sessionId: 'space:s:task:t',
 			turnIndex: 1,
 			entries: [
@@ -1188,7 +1187,7 @@ describe('MinimalThreadFeed', () => {
 			}),
 		];
 
-		const summary = {
+		const summary: ActiveTurnSummary = {
 			sessionId: 'space:s:task:t',
 			turnIndex: 1,
 			entries: [
@@ -1243,7 +1242,7 @@ describe('MinimalThreadFeed', () => {
 		// Summary keyed on a different session id — the trailing block's
 		// session id has no match, so the rail renders empty rather than
 		// surfacing stale activity from another session.
-		const summary = {
+		const summary: ActiveTurnSummary = {
 			sessionId: 'space:s:other-task:o',
 			turnIndex: 1,
 			entries: [

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
@@ -313,7 +313,39 @@ describe('MinimalThreadFeed', () => {
 			}),
 		];
 
-		render(<MinimalThreadFeed parsedRows={rows} activeAgentLabels={new Set(['Coder Agent'])} />);
+		// Server-derived summary: same activity as the parsed rows would produce
+		// under the old client-side derivation, but expressed as the wire shape
+		// (`ActivityEntry[]`) the renderer now consumes.
+		const summary = {
+			sessionId: 'space:s:task:t',
+			turnIndex: 1,
+			entries: [
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'bun run typecheck', ts: t, uuid: 'a1' },
+				{
+					kind: 'tool_use',
+					toolName: 'Read',
+					preview: 'packages/web/src/foo.ts',
+					ts: t,
+					uuid: 'a1',
+				},
+				{
+					kind: 'tool_use',
+					toolName: 'Grep',
+					preview: 'provisionExistingSpaces',
+					ts: t + 1000,
+					uuid: 'a2',
+				},
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'git status', ts: t + 1000, uuid: 'a2' },
+			],
+		};
+
+		render(
+			<MinimalThreadFeed
+				parsedRows={rows}
+				activeAgentLabels={new Set(['Coder Agent'])}
+				activeTurnSummaries={[summary]}
+			/>
+		);
 
 		const turn = screen.getByTestId('minimal-thread-turn');
 		expect(turn.dataset.turnState).toBe('active');
@@ -339,25 +371,36 @@ describe('MinimalThreadFeed', () => {
 
 	it('caps the active roster at 4 most-recent tool calls', () => {
 		const t = Date.now();
-		// 6 tool calls in one block — only the last 4 should render.
-		const tools = [
-			{ name: 'Bash', input: { command: 'echo 1' } },
-			{ name: 'Bash', input: { command: 'echo 2' } },
-			{ name: 'Bash', input: { command: 'echo 3' } },
-			{ name: 'Bash', input: { command: 'echo 4' } },
-			{ name: 'Bash', input: { command: 'echo 5' } },
-			{ name: 'Bash', input: { command: 'echo 6' } },
-		];
 		const rows = [
 			makeRow({
 				id: 'a1',
 				label: 'Coder Agent',
 				createdAt: t,
-				message: assistantToolUse('a1', tools),
+				message: assistantToolUse('a1', [{ name: 'Bash', input: { command: 'placeholder' } }]),
 			}),
 		];
 
-		render(<MinimalThreadFeed parsedRows={rows} activeAgentLabels={new Set(['Coder Agent'])} />);
+		// 6 tool entries in the active-turn summary — only the last 4 should render.
+		const summary = {
+			sessionId: 'space:s:task:t',
+			turnIndex: 1,
+			entries: [
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'echo 1', ts: t + 1, uuid: 'a1' },
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'echo 2', ts: t + 2, uuid: 'a1' },
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'echo 3', ts: t + 3, uuid: 'a1' },
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'echo 4', ts: t + 4, uuid: 'a1' },
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'echo 5', ts: t + 5, uuid: 'a1' },
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'echo 6', ts: t + 6, uuid: 'a1' },
+			],
+		};
+
+		render(
+			<MinimalThreadFeed
+				parsedRows={rows}
+				activeAgentLabels={new Set(['Coder Agent'])}
+				activeTurnSummaries={[summary]}
+			/>
+		);
 		const entries = screen.getAllByTestId('minimal-thread-roster-entry');
 		expect(entries.length).toBe(4);
 		expect(entries[0].textContent).toContain('echo 3');
@@ -647,42 +690,35 @@ describe('MinimalThreadFeed', () => {
 
 	it('includes assistant text messages in the active roster alongside tool calls', () => {
 		const t = Date.now();
-		// Sequence: text → tool → text → tool. All four entries should appear
-		// in the roster in order, with kinds tagged on the data attribute.
 		const rows = [
 			makeRow({
 				id: 'a1',
 				label: 'Coder Agent',
 				createdAt: t,
-				message: {
-					type: 'assistant',
-					uuid: 'a1',
-					message: {
-						content: [
-							{ type: 'text', text: 'Investigating the failing test' },
-							{ type: 'tool_use', id: 'tu-1', name: 'Bash', input: { command: 'ls' } },
-						],
-					},
-				},
-			}),
-			makeRow({
-				id: 'a2',
-				label: 'Coder Agent',
-				createdAt: t + 1000,
-				message: {
-					type: 'assistant',
-					uuid: 'a2',
-					message: {
-						content: [
-							{ type: 'text', text: 'Now editing the broken assertion' },
-							{ type: 'tool_use', id: 'tu-2', name: 'Edit', input: { file_path: 'foo.ts' } },
-						],
-					},
-				},
+				message: assistantToolUse('a1', [{ name: 'Bash', input: { command: 'ls' } }]),
 			}),
 		];
 
-		render(<MinimalThreadFeed parsedRows={rows} activeAgentLabels={new Set(['Coder Agent'])} />);
+		// Sequence: text → tool → text → tool. All four entries should appear
+		// in the roster in order, with kinds tagged on the data attribute.
+		const summary = {
+			sessionId: 'space:s:task:t',
+			turnIndex: 1,
+			entries: [
+				{ kind: 'text', text: 'Investigating the failing test', ts: t, uuid: 'a1' },
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'ls', ts: t, uuid: 'a1' },
+				{ kind: 'text', text: 'Now editing the broken assertion', ts: t + 1000, uuid: 'a2' },
+				{ kind: 'tool_use', toolName: 'Edit', preview: 'foo.ts', ts: t + 1000, uuid: 'a2' },
+			],
+		};
+
+		render(
+			<MinimalThreadFeed
+				parsedRows={rows}
+				activeAgentLabels={new Set(['Coder Agent'])}
+				activeTurnSummaries={[summary]}
+			/>
+		);
 
 		const entries = screen.getAllByTestId('minimal-thread-roster-entry');
 		expect(entries.length).toBe(4);
@@ -696,31 +732,39 @@ describe('MinimalThreadFeed', () => {
 		expect(entries[3].textContent).toContain('Edit');
 	});
 
-	it('skips empty/whitespace assistant text blocks when building the roster', () => {
+	it('skips empty/whitespace assistant text entries when building the roster', () => {
 		const t = Date.now();
 		const rows = [
 			makeRow({
 				id: 'a1',
 				label: 'Coder Agent',
 				createdAt: t,
-				message: {
-					type: 'assistant',
-					uuid: 'a1',
-					message: {
-						content: [
-							{ type: 'text', text: '   ' }, // whitespace-only
-							{ type: 'text', text: '' }, // empty string
-							{ type: 'tool_use', id: 'tu-1', name: 'Bash', input: { command: 'ls' } },
-						],
-					},
-				},
+				message: assistantToolUse('a1', [{ name: 'Bash', input: { command: 'ls' } }]),
 			}),
 		];
 
-		render(<MinimalThreadFeed parsedRows={rows} activeAgentLabels={new Set(['Coder Agent'])} />);
+		// Server is the canonical filter — but the renderer also defensively
+		// drops empty text/thinking entries so a future relaxation upstream
+		// can't bleed whitespace into the rail.
+		const summary = {
+			sessionId: 'space:s:task:t',
+			turnIndex: 1,
+			entries: [
+				{ kind: 'text', text: '   ', ts: t, uuid: 'a1' }, // whitespace-only
+				{ kind: 'text', text: '', ts: t, uuid: 'a1' }, // empty string
+				{ kind: 'thinking', preview: '', ts: t, uuid: 'a1' }, // empty thinking
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'ls', ts: t, uuid: 'a1' },
+			],
+		};
+
+		render(
+			<MinimalThreadFeed
+				parsedRows={rows}
+				activeAgentLabels={new Set(['Coder Agent'])}
+				activeTurnSummaries={[summary]}
+			/>
+		);
 		const entries = screen.getAllByTestId('minimal-thread-roster-entry');
-		// Only the tool entry survives — the empty/whitespace text blocks
-		// are filtered out so they don't pollute the rail.
 		expect(entries.length).toBe(1);
 		expect(entries[0].dataset.rosterKind).toBe('tool');
 	});
@@ -875,30 +919,36 @@ describe('MinimalThreadFeed', () => {
 
 	it('caps the active roster at 4 most-recent entries even with mixed kinds', () => {
 		const t = Date.now();
-		// 6 mixed entries — only the last 4 should render.
 		const rows = [
 			makeRow({
 				id: 'a1',
 				label: 'Coder Agent',
 				createdAt: t,
-				message: {
-					type: 'assistant',
-					uuid: 'a1',
-					message: {
-						content: [
-							{ type: 'text', text: 'msg-1' },
-							{ type: 'tool_use', id: 'tu-1', name: 'Bash', input: { command: 'echo 1' } },
-							{ type: 'text', text: 'msg-2' },
-							{ type: 'tool_use', id: 'tu-2', name: 'Bash', input: { command: 'echo 2' } },
-							{ type: 'text', text: 'msg-3' },
-							{ type: 'tool_use', id: 'tu-3', name: 'Bash', input: { command: 'echo 3' } },
-						],
-					},
-				},
+				message: assistantToolUse('a1', [{ name: 'Bash', input: { command: 'echo 3' } }]),
 			}),
 		];
 
-		render(<MinimalThreadFeed parsedRows={rows} activeAgentLabels={new Set(['Coder Agent'])} />);
+		// 6 mixed entries — only the last 4 should render.
+		const summary = {
+			sessionId: 'space:s:task:t',
+			turnIndex: 1,
+			entries: [
+				{ kind: 'text', text: 'msg-1', ts: t + 1, uuid: 'a1' },
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'echo 1', ts: t + 2, uuid: 'a1' },
+				{ kind: 'text', text: 'msg-2', ts: t + 3, uuid: 'a1' },
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'echo 2', ts: t + 4, uuid: 'a1' },
+				{ kind: 'text', text: 'msg-3', ts: t + 5, uuid: 'a1' },
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'echo 3', ts: t + 6, uuid: 'a1' },
+			],
+		};
+
+		render(
+			<MinimalThreadFeed
+				parsedRows={rows}
+				activeAgentLabels={new Set(['Coder Agent'])}
+				activeTurnSummaries={[summary]}
+			/>
+		);
 		const entries = screen.getAllByTestId('minimal-thread-roster-entry');
 		expect(entries.length).toBe(4);
 		const allText = entries.map((e) => e.textContent).join('\n');
@@ -1086,5 +1136,131 @@ describe('MinimalThreadFeed', () => {
 			const turn = screen.getByTestId('minimal-thread-turn');
 			expect(turn.dataset.turnState).toBe('active');
 		});
+	});
+
+	it('renders thinking-block entries with a distinct visual treatment', () => {
+		const t = Date.now();
+		const rows = [
+			makeRow({
+				id: 'a1',
+				label: 'Coder Agent',
+				createdAt: t,
+				message: assistantToolUse('a1', [{ name: 'Bash', input: { command: 'ls' } }]),
+			}),
+		];
+
+		const summary = {
+			sessionId: 'space:s:task:t',
+			turnIndex: 1,
+			entries: [
+				{
+					kind: 'thinking',
+					preview: 'Considering the edge case where the cache is cold',
+					ts: t,
+					uuid: 'a1',
+				},
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'ls', ts: t, uuid: 'a1' },
+			],
+		};
+
+		render(
+			<MinimalThreadFeed
+				parsedRows={rows}
+				activeAgentLabels={new Set(['Coder Agent'])}
+				activeTurnSummaries={[summary]}
+			/>
+		);
+		const entries = screen.getAllByTestId('minimal-thread-roster-entry');
+		expect(entries.length).toBe(2);
+		expect(entries[0].dataset.rosterKind).toBe('thinking');
+		expect(entries[0].textContent).toContain('Considering the edge case');
+		expect(entries[1].dataset.rosterKind).toBe('tool');
+	});
+
+	it('renders synthetic agent-handoff entries distinctly from real human messages', () => {
+		const t = Date.now();
+		const rows = [
+			makeRow({
+				id: 'a1',
+				label: 'Coder Agent',
+				createdAt: t,
+				message: assistantToolUse('a1', [{ name: 'Bash', input: { command: 'ls' } }]),
+			}),
+		];
+
+		const summary = {
+			sessionId: 'space:s:task:t',
+			turnIndex: 1,
+			entries: [
+				{ kind: 'user_message', text: 'please retry that step', ts: t, uuid: 'u1' },
+				{
+					kind: 'agent_handoff',
+					text: 'Reviewer Agent: please verify the fix',
+					ts: t + 1,
+					uuid: 'h1',
+				},
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'ls', ts: t + 2, uuid: 'a1' },
+			],
+		};
+
+		render(
+			<MinimalThreadFeed
+				parsedRows={rows}
+				activeAgentLabels={new Set(['Coder Agent'])}
+				activeTurnSummaries={[summary]}
+			/>
+		);
+
+		const entries = screen.getAllByTestId('minimal-thread-roster-entry');
+		expect(entries.length).toBe(3);
+
+		// First entry: real human user input — distinct kind data attribute.
+		expect(entries[0].dataset.rosterKind).toBe('user');
+		expect(entries[0].textContent).toContain('please retry that step');
+
+		// Second entry: synthetic agent→agent handoff — uses its own kind, NOT
+		// the same `user` kind, so the rail can render the visual distinction.
+		expect(entries[1].dataset.rosterKind).toBe('handoff');
+		expect(entries[1].textContent).toContain('Reviewer Agent');
+
+		// Third entry: tool — confirms the handoff/user entries don't displace
+		// or break the existing tool rendering.
+		expect(entries[2].dataset.rosterKind).toBe('tool');
+	});
+
+	it('falls back to an empty roster when no summary covers the active session', () => {
+		const t = Date.now();
+		const rows = [
+			makeRow({
+				id: 'a1',
+				label: 'Coder Agent',
+				createdAt: t,
+				message: assistantToolUse('a1', [{ name: 'Bash', input: { command: 'ls' } }]),
+				sessionId: 'space:s:task:t',
+			}),
+		];
+
+		// Summary keyed on a different session id — the trailing block's
+		// session id has no match, so the rail renders empty rather than
+		// surfacing stale activity from another session.
+		const summary = {
+			sessionId: 'space:s:other-task:o',
+			turnIndex: 1,
+			entries: [
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'should not show', ts: t, uuid: 'x1' },
+			],
+		};
+
+		render(
+			<MinimalThreadFeed
+				parsedRows={rows}
+				activeAgentLabels={new Set(['Coder Agent'])}
+				activeTurnSummaries={[summary]}
+			/>
+		);
+		expect(screen.queryByTestId('minimal-thread-roster-entry')).toBeNull();
+		// Active rail is still present (the block IS active) — it just has
+		// no entries.
+		expect(screen.getByTestId('minimal-thread-active-rail')).toBeTruthy();
 	});
 });

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -249,24 +249,45 @@ function rosterEntriesFromSummary(
 	return out.slice(-maxEntries);
 }
 
+/**
+ * Defensive string coercion for fields that the typed `ActivityEntry` shape
+ * declares as `string`. `parseActiveTurnSummaries` validates the wrapper but
+ * intentionally trusts entry-level fields (the daemon already normalises
+ * them), so we coerce here as a belt-and-braces guard against a malformed
+ * entry crashing the renderer with a `TypeError` on `.trim()`.
+ */
+function asTrimmedString(value: unknown): string {
+	return typeof value === 'string' ? value.trim() : '';
+}
+
 function mapActivityEntry(entry: ActivityEntry): ActiveRosterEntry | null {
 	switch (entry.kind) {
 		case 'tool_use':
-			return { kind: 'tool', tool: entry.toolName, preview: entry.preview };
+			return {
+				kind: 'tool',
+				tool: typeof entry.toolName === 'string' ? entry.toolName : '',
+				preview: typeof entry.preview === 'string' ? entry.preview : '',
+			};
 		case 'text': {
-			const text = entry.text.trim();
+			const text = asTrimmedString(entry.text);
 			if (!text) return null;
 			return { kind: 'message', text };
 		}
 		case 'thinking': {
-			const preview = entry.preview.trim();
+			const preview = asTrimmedString(entry.preview);
 			if (!preview) return null;
 			return { kind: 'thinking', preview };
 		}
-		case 'user_message':
-			return { kind: 'user', text: entry.text };
-		case 'agent_handoff':
-			return { kind: 'handoff', text: entry.text };
+		case 'user_message': {
+			const text = asTrimmedString(entry.text);
+			if (!text) return null;
+			return { kind: 'user', text };
+		}
+		case 'agent_handoff': {
+			const text = asTrimmedString(entry.text);
+			if (!text) return null;
+			return { kind: 'handoff', text };
+		}
 		default:
 			return null;
 	}

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -23,6 +23,7 @@
  */
 
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
+import type { ActiveTurnSummary, ActivityEntry } from '@neokai/shared';
 import {
 	isSDKAssistantMessage,
 	isSDKResultMessage,
@@ -74,16 +75,37 @@ interface MinimalThreadFeedProps {
 	 * labels (e.g. "coder agent" → "Coder Agent").
 	 */
 	activeAgentLabels?: ReadonlySet<string>;
+	/**
+	 * Server-derived activity summaries — one per session with an active
+	 * (non-terminal) turn. The roster on each active feed turn is built from
+	 * the matching summary's full entry list, so the rail stays accurate even
+	 * when the compact feed has dropped older non-terminal rows from the
+	 * trailing turn. Empty array when no session is mid-turn.
+	 *
+	 * Optional for backwards-compatibility with tests / call sites that
+	 * haven't been updated; an absent payload silently falls back to no
+	 * roster (rather than the previous client-side derivation, which is now
+	 * gone).
+	 */
+	activeTurnSummaries?: ActiveTurnSummary[];
 }
 
 /**
  * Active-turn roster entry. The roster surfaces what the agent is "doing right
- * now" — historically just tool invocations, now also the assistant's own text
- * messages so the user can see the model thinking aloud between tool calls.
+ * now" — tool invocations interleaved with the assistant's own outputs and the
+ * user-side rows (real human input or synthetic agent→agent handoff) that are
+ * sitting inside the active turn.
  *
- * Tagged on `kind` so the renderer can switch between two distinct visuals:
- *   - `tool` : `BashCmd: bun run typecheck`     (colored TOOL prefix + preview)
- *   - `message` : `💬 Investigating the failing test…`  (chat glyph + italic body)
+ * Tagged on `kind` so the renderer can switch between distinct visuals:
+ *   - `tool`     : `BashCmd: bun run typecheck`             (colored TOOL: + preview)
+ *   - `message`  : `💬 Investigating the failing test…`     (chat glyph + italic body)
+ *   - `thinking` : `✦ Considering edge cases…`              (sparkle + dim italic body)
+ *   - `user`     : `👤 You: please retry`                   (user glyph + body)
+ *   - `handoff`  : `↪ Reviewer Agent: please verify`        (handoff glyph + body)
+ *
+ * Server-derived: shapes mirror `ActivityEntry` from `@neokai/shared` 1:1. The
+ * mapping happens in `rosterEntriesFromSummary` so the renderer stays decoupled
+ * from the wire format.
  */
 interface RosterToolEntry {
 	kind: 'tool';
@@ -94,10 +116,27 @@ interface RosterMessageEntry {
 	kind: 'message';
 	text: string;
 }
+interface RosterThinkingEntry {
+	kind: 'thinking';
+	preview: string;
+}
+interface RosterUserEntry {
+	kind: 'user';
+	text: string;
+}
+interface RosterHandoffEntry {
+	kind: 'handoff';
+	text: string;
+}
+type ActiveRosterEntry =
+	| RosterToolEntry
+	| RosterMessageEntry
+	| RosterThinkingEntry
+	| RosterUserEntry
+	| RosterHandoffEntry;
 
 const TASK_THREAD_MESSAGE_BUBBLE_WIDTH_CLASS = 'max-w-[85%] md:max-w-[86%]';
 const TASK_THREAD_AGENT_BUBBLE_WIDTH_CLASS = 'max-w-full md:max-w-[86%]';
-type ActiveRosterEntry = RosterToolEntry | RosterMessageEntry;
 
 interface CompletedFeedTurn {
 	state: 'completed';
@@ -174,14 +213,7 @@ interface MessageFeedTurn {
 
 type FeedTurn = CompletedFeedTurn | ActiveFeedTurn | MessageFeedTurn;
 
-const PREVIEW_MAX_LEN = 80;
 const ROSTER_MAX_ENTRIES = 4;
-
-function oneLine(value: string, max = PREVIEW_MAX_LEN): string {
-	const collapsed = value.replace(/\s+/g, ' ').trim();
-	if (!collapsed) return '';
-	return collapsed.length > max ? `${collapsed.slice(0, max - 1)}…` : collapsed;
-}
 
 function getToolUseContentBlocks(row: ParsedThreadRow) {
 	if (!row.message || !isSDKAssistantMessage(row.message)) return [];
@@ -192,62 +224,75 @@ function getToolUseContentBlocks(row: ParsedThreadRow) {
 	);
 }
 
-function previewFromInput(input: Record<string, unknown>): string {
-	const command = typeof input.command === 'string' ? input.command : '';
-	if (command) return oneLine(command);
-	const filePath = typeof input.file_path === 'string' ? input.file_path : '';
-	if (filePath) return oneLine(filePath);
-	const path = typeof input.path === 'string' ? input.path : '';
-	if (path) return oneLine(path);
-	const pattern = typeof input.pattern === 'string' ? input.pattern : '';
-	if (pattern) return oneLine(pattern);
-	const url = typeof input.url === 'string' ? input.url : '';
-	if (url) return oneLine(url);
-	const description = typeof input.description === 'string' ? input.description : '';
-	if (description) return oneLine(description);
-	const keys = Object.keys(input);
-	if (keys.length === 0) return '';
-	// Fallback: show first key=value summary so the entry isn't blank.
-	const firstKey = keys[0];
-	const firstVal = input[firstKey];
-	if (typeof firstVal === 'string') return oneLine(`${firstKey}: ${firstVal}`);
-	return `${firstKey}: …`;
+/**
+ * Translate the server-derived `ActivityEntry` union into the renderer's
+ * tagged `ActiveRosterEntry` shape and apply the display cap (most-recent
+ * wins). Server entries are already chronologically sorted and have their
+ * previews/text collapsed onto a single line; the cap is the last piece of
+ * presentation policy that lives client-side.
+ *
+ * Empty `text` entries (e.g. a model response containing only whitespace)
+ * are still defensively dropped here even though the server already filters
+ * them — defence in depth lets renderer-level invariants hold even if a
+ * future server change relaxes the filter.
+ */
+function rosterEntriesFromSummary(
+	summary: ActiveTurnSummary | undefined,
+	maxEntries: number
+): ActiveRosterEntry[] {
+	if (!summary) return [];
+	const out: ActiveRosterEntry[] = [];
+	for (const entry of summary.entries) {
+		const mapped = mapActivityEntry(entry);
+		if (mapped) out.push(mapped);
+	}
+	return out.slice(-maxEntries);
+}
+
+function mapActivityEntry(entry: ActivityEntry): ActiveRosterEntry | null {
+	switch (entry.kind) {
+		case 'tool_use':
+			return { kind: 'tool', tool: entry.toolName, preview: entry.preview };
+		case 'text': {
+			const text = entry.text.trim();
+			if (!text) return null;
+			return { kind: 'message', text };
+		}
+		case 'thinking': {
+			const preview = entry.preview.trim();
+			if (!preview) return null;
+			return { kind: 'thinking', preview };
+		}
+		case 'user_message':
+			return { kind: 'user', text: entry.text };
+		case 'agent_handoff':
+			return { kind: 'handoff', text: entry.text };
+		default:
+			return null;
+	}
 }
 
 /**
- * Walk the active block's content blocks in chronological order and emit one
- * roster entry per `tool_use` or non-empty `text` block. Capped at `maxEntries`
- * (most-recent wins) so the rail stays compact even on long-running turns.
- *
- * Mixing tool calls with the agent's own text messages reproduces the cadence
- * a developer would see watching the live SDK stream: "Reading…", "I think
- * this is the bug.", "Editing…", "Confirmed it now passes." — much more
- * informative than four anonymous tool names.
+ * Count tool calls within the active turn from the server-derived summary
+ * (preferred — covers the *full* turn, not the truncated compact slice) or
+ * fall back to the parsed rows when no summary is available.
  */
-function extractRosterEntries(rows: ParsedThreadRow[], maxEntries: number): ActiveRosterEntry[] {
-	const entries: ActiveRosterEntry[] = [];
-	for (const row of rows) {
-		if (!row.message || !isSDKAssistantMessage(row.message)) continue;
-		const content = (row.message as { message?: { content?: unknown } }).message?.content;
-		if (!Array.isArray(content)) continue;
-		for (const block of content) {
-			if (isToolUseBlock(block as never)) {
-				const tu = block as { name: string; input?: unknown };
-				const input =
-					typeof tu.input === 'object' && tu.input !== null
-						? (tu.input as Record<string, unknown>)
-						: {};
-				entries.push({ kind: 'tool', tool: tu.name, preview: previewFromInput(input) });
-				continue;
-			}
-			const b = block as { type?: unknown; text?: unknown };
-			if (b.type === 'text' && typeof b.text === 'string') {
-				const text = b.text.trim();
-				if (text.length > 0) entries.push({ kind: 'message', text: oneLine(text) });
-			}
+function countToolCallsForActive(
+	rows: ParsedThreadRow[],
+	summary: ActiveTurnSummary | undefined
+): number {
+	if (summary) {
+		let n = 0;
+		for (const e of summary.entries) {
+			if (e.kind === 'tool_use') n += 1;
 		}
+		return n;
 	}
-	return entries.slice(-maxEntries);
+	let n = 0;
+	for (const row of rows) {
+		n += getToolUseContentBlocks(row).length;
+	}
+	return n;
 }
 
 function countToolCalls(rows: ParsedThreadRow[]): number {
@@ -371,7 +416,8 @@ function buildCompletedTurn(
 function buildActiveTurn(
 	block: AgentTurnBlock,
 	rows: ParsedThreadRow[],
-	turnId: string
+	turnId: string,
+	summary: ActiveTurnSummary | undefined
 ): ActiveFeedTurn {
 	return {
 		state: 'active',
@@ -379,8 +425,8 @@ function buildActiveTurn(
 		agent: block.agentLabel,
 		startedAt: rows[0].createdAt,
 		status: 'Running…',
-		toolCalls: countToolCalls(rows),
-		roster: extractRosterEntries(rows, ROSTER_MAX_ENTRIES),
+		toolCalls: countToolCallsForActive(rows, summary),
+		roster: rosterEntriesFromSummary(summary, ROSTER_MAX_ENTRIES),
 		sessionId: latestSessionId(rows),
 	};
 }
@@ -533,10 +579,19 @@ function extractBlockEnvelopes(rows: ParsedThreadRow[]): {
  */
 function buildFeedTurns(
 	parsedRows: ParsedThreadRow[],
-	activeAgentLabels: ReadonlySet<string>
+	activeAgentLabels: ReadonlySet<string>,
+	activeTurnSummaries: ActiveTurnSummary[]
 ): FeedTurn[] {
 	const blocks = buildAgentTurns(parsedRows);
 	if (blocks.length === 0) return [];
+
+	// Index summaries by sessionId so the trailing-block upgrade can pick the
+	// right summary in O(1) rather than scanning the (small but not bounded)
+	// list once per render. The server emits at most one summary per session.
+	const summariesBySession = new Map<string, ActiveTurnSummary>();
+	for (const summary of activeTurnSummaries) {
+		summariesBySession.set(summary.sessionId, summary);
+	}
 
 	const turns: FeedTurn[] = [];
 	// Per-agent trailing completed-turn pointer. Keyed by the normalised agent
@@ -590,7 +645,11 @@ function buildFeedTurns(
 	// whose trailing block is non-terminal, swap that agent's last completed
 	// turn for an active turn. Independent across agents — a Reviewer terminal
 	// block landing after Coder's last row can no longer suppress the Coder
-	// rail because Coder has its own entry in `perAgentTrailing`.
+	// rail because Coder has its own entry in `perAgentTrailing`. The roster
+	// is built from the server-derived summary keyed on the trailing rows'
+	// session id; missing summary → empty roster (e.g. server hasn't shipped
+	// metadata yet, or the active turn lives on a different session than the
+	// trailing fragment).
 	if (activeAgentLabels.size > 0) {
 		const normalisedActive = new Set<string>();
 		for (const label of activeAgentLabels) {
@@ -600,7 +659,14 @@ function buildFeedTurns(
 			if (!normalisedActive.has(key)) continue;
 			if (trailing.block.isTerminal) continue;
 			const completed = turns[trailing.turnIdx] as CompletedFeedTurn;
-			turns[trailing.turnIdx] = buildActiveTurn(trailing.block, trailing.rows, completed.id);
+			const sessionId = completed.sessionId;
+			const summary = sessionId ? summariesBySession.get(sessionId) : undefined;
+			turns[trailing.turnIdx] = buildActiveTurn(
+				trailing.block,
+				trailing.rows,
+				completed.id,
+				summary
+			);
 		}
 	}
 
@@ -664,6 +730,60 @@ function RosterEntry({ entry, isLatest }: { entry: ActiveRosterEntry; isLatest: 
 			>
 				<span class={`${toolColor} font-semibold shrink-0`}>{entry.tool}:</span>
 				<span class={bodyClass}>{entry.preview}</span>
+			</div>
+		);
+	}
+
+	if (entry.kind === 'thinking') {
+		// Thinking block — sparkle glyph + dim italic preview. Visually
+		// closer to "the model is reasoning" than "the model said this", so
+		// the body is one shade dimmer than the message branch even when
+		// it's the latest entry.
+		const thinkBody = `truncate italic ${isLatest ? 'text-gray-300' : 'text-gray-500'}`;
+		return (
+			<div
+				class={`flex items-baseline gap-2 text-xs leading-5 ${fadeClass}`}
+				data-testid="minimal-thread-roster-entry"
+				data-roster-kind="thinking"
+			>
+				<span class="shrink-0 text-gray-500" aria-hidden="true">
+					✦
+				</span>
+				<span class={thinkBody}>{entry.preview}</span>
+			</div>
+		);
+	}
+
+	if (entry.kind === 'user') {
+		// Real human input that landed inside the active turn — surface it
+		// distinctly from agent text so a user reading the rail can tell at
+		// a glance which line is theirs.
+		return (
+			<div
+				class={`flex items-baseline gap-2 text-xs leading-5 ${fadeClass}`}
+				data-testid="minimal-thread-roster-entry"
+				data-roster-kind="user"
+			>
+				<span class="shrink-0 text-blue-400" aria-hidden="true">
+					👤
+				</span>
+				<span class={bodyClass}>{entry.text}</span>
+			</div>
+		);
+	}
+
+	if (entry.kind === 'handoff') {
+		// Synthetic agent→agent / system handoff — arrow glyph + body.
+		return (
+			<div
+				class={`flex items-baseline gap-2 text-xs leading-5 ${fadeClass}`}
+				data-testid="minimal-thread-roster-entry"
+				data-roster-kind="handoff"
+			>
+				<span class="shrink-0 text-gray-500" aria-hidden="true">
+					↪
+				</span>
+				<span class={bodyClass}>{entry.text}</span>
 			</div>
 		);
 	}
@@ -989,8 +1109,9 @@ const EMPTY_ACTIVE_AGENT_LABELS: ReadonlySet<string> = new Set();
 export function MinimalThreadFeed({
 	parsedRows,
 	activeAgentLabels = EMPTY_ACTIVE_AGENT_LABELS,
+	activeTurnSummaries = [],
 }: MinimalThreadFeedProps) {
-	const turns = buildFeedTurns(parsedRows, activeAgentLabels);
+	const turns = buildFeedTurns(parsedRows, activeAgentLabels, activeTurnSummaries);
 	if (turns.length === 0) return null;
 
 	return (

--- a/packages/web/src/hooks/useSpaceTaskMessages.ts
+++ b/packages/web/src/hooks/useSpaceTaskMessages.ts
@@ -1,5 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
-import type { LiveQueryDeltaEvent, LiveQuerySnapshotEvent } from '@neokai/shared';
+import type {
+	ActiveTurnSummary,
+	LiveQueryDeltaEvent,
+	LiveQuerySnapshotEvent,
+} from '@neokai/shared';
 import { useMessageHub } from './useMessageHub';
 
 export interface SpaceTaskThreadMessageRow {
@@ -38,8 +42,48 @@ export type SpaceTaskMessagesQueryVariant = 'compact' | 'full';
 
 export interface UseSpaceTaskMessagesResult {
 	rows: SpaceTaskThreadMessageRow[];
+	/**
+	 * Server-computed activity summary for the currently-active turn of each
+	 * session in the task. Empty array when no session has an open turn.
+	 *
+	 * Populated only by the `compact` query variant — the daemon ships this
+	 * alongside the compacted rows on the LiveQuery `metadata` channel so the
+	 * running roster on the task view can surface activity from the *full*
+	 * active turn (not the compacted slice). Closed turns are intentionally
+	 * absent.
+	 */
+	activeTurnSummaries: ActiveTurnSummary[];
 	isLoading: boolean;
 	isReconnecting: boolean;
+}
+
+/**
+ * Coerce a raw `metadata.activeTurnSummaries` payload into the typed
+ * `ActiveTurnSummary[]` shape. The daemon already produces well-formed entries,
+ * but defensive parsing here means a malformed snapshot can never crash the
+ * thread renderer — it just falls back to an empty roster.
+ */
+function parseActiveTurnSummaries(value: unknown): ActiveTurnSummary[] {
+	if (!Array.isArray(value)) return [];
+	const out: ActiveTurnSummary[] = [];
+	for (const raw of value) {
+		if (!raw || typeof raw !== 'object') continue;
+		const r = raw as Record<string, unknown>;
+		const sessionId = typeof r.sessionId === 'string' ? r.sessionId : null;
+		if (!sessionId) continue;
+		const turnIndex = typeof r.turnIndex === 'number' ? r.turnIndex : 0;
+		const entries = Array.isArray(r.entries)
+			? (r.entries as Record<string, unknown>[]).filter(
+					(e): e is Record<string, unknown> => !!e && typeof e === 'object'
+				)
+			: [];
+		out.push({
+			sessionId,
+			turnIndex,
+			entries: entries as ActiveTurnSummary['entries'],
+		});
+	}
+	return out;
 }
 
 let _taskMessageSubCounter = 0;
@@ -78,6 +122,7 @@ export function useSpaceTaskMessages(
 ): UseSpaceTaskMessagesResult {
 	const { request, onEvent, isConnected } = useMessageHub();
 	const [rows, setRows] = useState<SpaceTaskThreadMessageRow[]>([]);
+	const [activeTurnSummaries, setActiveTurnSummaries] = useState<ActiveTurnSummary[]>([]);
 	/**
 	 * The task id whose LiveQuery snapshot has been applied to `rows`.
 	 * `null` means either no subscription is active or we are still waiting
@@ -96,6 +141,7 @@ export function useSpaceTaskMessages(
 	useEffect(() => {
 		if (!taskId || !isConnected) {
 			setRows([]);
+			setActiveTurnSummaries([]);
 			setLoadedForTaskId(null);
 			activeSubIdRef.current = null;
 			return;
@@ -107,17 +153,24 @@ export function useSpaceTaskMessages(
 		// empty-state UI is still suppressed because `loadedForTaskId` is now
 		// out of sync with `taskId`, so consumers see the loading state.
 		setRows([]);
+		setActiveTurnSummaries([]);
 		setLoadedForTaskId(null);
 
 		const unsubSnapshot = onEvent<LiveQuerySnapshotEvent>('liveQuery.snapshot', (event) => {
 			if (event.subscriptionId !== activeSubIdRef.current) return;
 			setRows(sortRows((event.rows as SpaceTaskThreadMessageRow[]) ?? []));
+			setActiveTurnSummaries(parseActiveTurnSummaries(event.metadata?.activeTurnSummaries));
 			setLoadedForTaskId(taskId);
 		});
 
 		const unsubDelta = onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
 			if (event.subscriptionId !== activeSubIdRef.current) return;
 			setRows((prev) => applyDelta(prev, event));
+			// `metadata` is recomputed every evaluation, so a delta carries the
+			// current active-turn summary for the task — overwrite, don't merge.
+			if (event.metadata && 'activeTurnSummaries' in event.metadata) {
+				setActiveTurnSummaries(parseActiveTurnSummaries(event.metadata.activeTurnSummaries));
+			}
 		});
 
 		request('liveQuery.subscribe', {
@@ -152,6 +205,7 @@ export function useSpaceTaskMessages(
 
 	return {
 		rows: sortedRows,
+		activeTurnSummaries,
 		isLoading,
 		isReconnecting: !isConnected && taskId !== null,
 	};


### PR DESCRIPTION
## Summary
- Compact feed previously truncated each turn to the last 5 non-terminal rows; the client running roster then capped at 4 entries — so the on-screen roster could never reflect more than 4 distinct activities for the active turn.
- Daemon now aggregates activity entries (tool_use, text, thinking, user, handoff) directly from `node_executions` for each active (non-terminal) turn and ships them as `activeTurnSummaries` on LiveQuery `metadata`. The compact row cap is preserved.
- Web replaces row-walking `extractRosterEntries` with summary consumption; new visual kinds (`thinking`, `user`, `handoff`) render distinctly.

## Test plan
- [x] `bun run test` (web) — 7309 passing, includes 3 new MinimalThreadFeed tests for thinking/handoff/empty-summary fallback
- [x] daemon rpc-handlers tests — 1044 passing, includes 6 new active-turn-entries SQL tests
- [x] Lint, format, typecheck, knip via pre-commit hooks