### PR TITLE
fix(space): forbid Reviewer terminal actions while P0–P3 findings are open

### DIFF
--- a/packages/daemon/src/lib/space/agents/seed-agents.ts
+++ b/packages/daemon/src/lib/space/agents/seed-agents.ts
@@ -178,6 +178,17 @@ Only skip delegation for trivially small, self-contained changes (a single obvio
 - Request changes (\`REQUEST_CHANGES\`) if ANY finding exists at P0, P1, P2, **or P3**. Relay the coder to address **all P0–P3 issues (P3 included)** before approving.
 - Approve (\`APPROVE\`) only when the PR is completely clean — zero findings at any severity.
 
+## Terminal Action Pre-Conditions
+
+The task-completion tools \`approve_task\` and \`submit_for_approval\` are **TERMINAL** — they close the review/QA loop and hand the task off. Call them ONLY when BOTH conditions hold:
+
+1. Your most recent posted review's verdict is \`APPROVE\` — zero findings at any severity P0–P3.
+2. Any prior rounds' P0–P3 findings have been addressed in the latest commits you reviewed.
+
+If your verdict on this round is \`REQUEST_CHANGES\` (ANY P0–P3 finding exists), you MUST post the review, send actionable feedback to the upstream coding/implementation agent, and **STOP**. Do NOT call \`approve_task\`. Do NOT call \`submit_for_approval\`. The workflow MUST stay open for the next cycle.
+
+\`submit_for_approval\` is **NOT** "ask a human to decide for me while findings are open." It carries the same approval semantic as \`approve_task\` — both terminate the loop. Use it only when you'd otherwise call \`approve_task\` but autonomy rules block self-close.
+
 ## Posting the Review
 
 Determine the event deterministically (own-PR detection), then post via the REST API so the response includes the review URL:

--- a/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tool-schemas.ts
@@ -39,8 +39,20 @@ import { z } from 'zod';
  * Takes no arguments — the task, workflow, and node are implicit from the
  * calling session's context. Strict schema so future fields fail fast until
  * explicitly added.
+ *
+ * Pre-conditions (enforced by the agent's prompt, not the schema):
+ *   - For review-style end-node agents: your verdict on the current round MUST
+ *     be APPROVE (zero P0–P3 findings) AND any prior-round P0–P3 findings must
+ *     be resolved in the commits you've reviewed.
+ *   - This tool is a TERMINAL ACTION: it closes the review loop. Do NOT call
+ *     it while findings are open — request changes and continue the loop instead.
  */
-export const ApproveTaskSchema = z.object({}).strict();
+export const ApproveTaskSchema = z
+	.object({})
+	.strict()
+	.describe(
+		'Self-close the task as approved. TERMINAL: closes the review/QA loop. Pre-condition: your current-round verdict MUST be APPROVE (zero P0–P3 findings) AND any prior-round P0–P3 findings must be addressed in the latest commits you reviewed. While findings are open, request changes and continue the loop instead — do NOT call this tool.'
+	);
 
 export type ApproveTaskInput = z.infer<typeof ApproveTaskSchema>;
 
@@ -56,6 +68,17 @@ export type ApproveTaskInput = z.infer<typeof ApproveTaskSchema>;
  * `task.status = 'review'` and populates the pending-completion fields so the
  * UI can route a human to approve or reject. Even at high autonomy levels this
  * remains available — agents may want to escalate a risky result for attention.
+ *
+ * IMPORTANT: This tool is TERMINAL — it closes the review loop. It carries the
+ * same approval semantic as `approve_task` ("the work is approved by me, but
+ * autonomy rules block me from self-closing, so a human must rubber-stamp the
+ * final close"). It is NOT a way to defer judgment while findings are open.
+ *
+ * Pre-conditions (enforced by the agent's prompt, not the schema):
+ *   - Your current-round verdict MUST be APPROVE (zero P0–P3 findings) AND any
+ *     prior-round P0–P3 findings must be resolved in the commits you've reviewed.
+ *   - Do NOT use `submit_for_approval` to defer judgment while findings are
+ *     open — request changes and continue the loop instead.
  */
 export const SubmitForApprovalSchema = z
 	.object({
@@ -70,7 +93,10 @@ export const SubmitForApprovalSchema = z
 			)
 			.optional(),
 	})
-	.strict();
+	.strict()
+	.describe(
+		'Request human sign-off as the final close action. TERMINAL: closes the review/QA loop, equivalent in semantic to `approve_task` (both signal "the work is approved by me"). Pre-condition: your current-round verdict MUST be APPROVE (zero P0–P3 findings) AND any prior-round P0–P3 findings must be resolved in the commits you reviewed. Do NOT use this to defer judgment while findings are open — request changes and continue the loop instead.'
+	);
 
 export type SubmitForApprovalInput = z.infer<typeof SubmitForApprovalSchema>;
 

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -142,6 +142,49 @@ const REVIEW_POSTED_BASH_SCRIPT = [
 	'jq -n --arg url "$PR_URL" --argjson n "$COMMENT_COUNT" \'{"pr_url":$url,"review_count":$n}\'',
 ].join('\n');
 
+/**
+ * Reviewer Terminal Action Pre-conditions block.
+ *
+ * Prepended to every review-style end-node prompt that exposes the terminal
+ * task-completion tools (`approve_task`, `submit_for_approval`). Establishes a
+ * hard pre-condition: terminal actions are valid ONLY when the review verdict
+ * is APPROVE with zero P0–P3 findings. While findings are open, the cycle MUST
+ * continue via `send_message(target="<upstream>", ...)` — the reviewer must not
+ * close the loop or hand off to a human until the work is actually clean.
+ *
+ * The wording deliberately equates `submit_for_approval` with `approve_task`
+ * (both close the review loop) so the model cannot interpret it as "let a
+ * human decide while findings are still open".
+ *
+ * @param upstreamNodeName - The peer node the reviewer must send feedback to
+ *   when posting REQUEST_CHANGES (e.g. "Coding", "Research", "Planning").
+ */
+function reviewerTerminalActionPreconditions(upstreamNodeName: string): string {
+	return (
+		'TERMINAL ACTION PRE-CONDITIONS (read before considering `approve_task` or ' +
+		'`submit_for_approval`):\n\n' +
+		'**Terminal actions (`approve_task`, `submit_for_approval`) close the review ' +
+		'loop and hand the task off.** You may call them ONLY when BOTH conditions hold:\n' +
+		"1. Your most recent posted review's verdict is `APPROVE` — zero findings at " +
+		'any severity P0–P3.\n' +
+		"2. Any prior rounds' P0–P3 findings have been addressed in the latest commits " +
+		'you reviewed.\n\n' +
+		'If your verdict on this round is `REQUEST_CHANGES` (ANY finding exists at P0, ' +
+		'P1, P2, or P3), you MUST:\n' +
+		`- Post the review with \`--request-changes\` (or \`--comment\` for own-PR).\n` +
+		`- \`send_message(target="${upstreamNodeName}", ...)\` with the feedback summary ` +
+		'plus the review URL and inline-comment URLs.\n' +
+		'- `save_artifact({ type: "result", append: true, summary: "Requested ' +
+		'changes: ..." })` to record the cycle.\n' +
+		'- **STOP. Do NOT call `approve_task`. Do NOT call `submit_for_approval`.** ' +
+		'The workflow MUST stay open for the next cycle.\n\n' +
+		'`submit_for_approval` is **NOT** "ask a human to decide for me while findings ' +
+		'are open." It is "the work is approved by me, but autonomy rules block me ' +
+		'from self-closing, so a human must rubber-stamp the final close." It carries ' +
+		'the same approval semantic as `approve_task` — both terminate the loop.\n\n'
+	);
+}
+
 const PD_PLANNING_PROMPT =
 	'You are the Planning node in a Plan & Decompose Workflow. Your role is to turn the user goal ' +
 	'into a concrete, decomposable plan that a Task Dispatcher can fan out into standalone tasks.\n\n' +
@@ -159,6 +202,16 @@ const PD_PLAN_REVIEW_PROMPT =
 	'You are one of four parallel Reviewers in the Plan Review node of a Plan & Decompose Workflow. ' +
 	'You receive a plan from the Planning node and must evaluate it through your specific lens ' +
 	'before tasks are dispatched. You do not coordinate with other reviewers; vote independently.\n\n' +
+	'TERMINAL ACTION PRE-CONDITIONS:\n' +
+	'Plan Review is NOT the end node in this workflow — the task-completion tools ' +
+	'(`approve_task`, `submit_for_approval`) are not available to you. Your terminal ' +
+	'action is your vote on `plan-approval-gate`. Vote `approved: true` ONLY when your ' +
+	'lens-specific verdict is APPROVE (zero P0–P3 findings under your lens). If ANY ' +
+	'P0–P3 finding exists, you MUST vote `approved: false` AND send_message to the ' +
+	'Planning node describing what to change. Do NOT vote `approved: true` to "let a ' +
+	'human decide" or to defer judgment — that is equivalent to silently passing the ' +
+	'plan through with findings open. The 4-of-4 approval threshold exists precisely ' +
+	'so that no lens can be skipped.\n\n' +
 	'Steps:\n' +
 	'1. Read the plan file in the PR (`gh pr diff` and `gh pr view`).\n' +
 	'2. Evaluate the plan against your lens criteria (described below).\n' +
@@ -176,13 +229,26 @@ const PD_TASK_DISPATCHER_PROMPT =
 	'standalone follow-up tasks using the `create_standalone_task` MCP tool. Each task ' +
 	'description must include stacked PR instructions so the downstream coder knows exactly ' +
 	'which base branch to target, forming a reviewable PR chain across the plan.\n\n' +
+	'TERMINAL ACTION PRE-CONDITIONS (read before considering `approve_task` or ' +
+	'`submit_for_approval`):\n\n' +
+	'**Terminal actions (`approve_task`, `submit_for_approval`) close this task ' +
+	'and the entire Plan & Decompose run.** You may call them ONLY when every ' +
+	'required downstream standalone task has been created via ' +
+	'`create_standalone_task` AND every returned task ID has been recorded in a ' +
+	'`save_artifact` audit entry.\n\n' +
+	'If `create_standalone_task` fails, the plan is empty/ambiguous, or any work ' +
+	'item is missing, you MUST send feedback to Planning and STOP. **Do NOT call ' +
+	'`approve_task`. Do NOT call `submit_for_approval`** while dispatch is ' +
+	'incomplete — both are terminal and would close the run with the plan ' +
+	'unfinished. `submit_for_approval` carries the same approval semantic as ' +
+	'`approve_task`; it is NOT a way to defer judgment while dispatch is open.\n\n' +
 	'TOOL CONTRACT (Design v2):\n' +
 	'- `save_artifact({ type: "result", append: true, summary, ...data? })` — append-only audit. Records the dispatch ' +
 	'outcome. Does NOT close the task.\n' +
 	'- `approve_task()` — closes this task as done. Call after every required downstream task ' +
 	'has been created.\n' +
 	'- `submit_for_approval({ reason? })` — request human sign-off instead of self-closing. ' +
-	'Use when autonomy blocks self-close.\n\n' +
+	'Same pre-conditions as `approve_task` apply — use when autonomy blocks self-close, NOT to skip dispatch.\n\n' +
 	'Steps:\n' +
 	'1. Read the approved plan from the plan PR (`gh pr diff` or `gh pr view --json files`). ' +
 	'Identify each actionable work item in order and record its title, description, priority, ' +
@@ -243,6 +309,15 @@ const FULLSTACK_CODING_PROMPT =
 const FULLSTACK_REVIEW_PROMPT =
 	'You are the Reviewer in a Fullstack QA Loop workflow. Review the PR for correctness, ' +
 	'maintainability, and coverage before QA.\n\n' +
+	'TERMINAL ACTION PRE-CONDITIONS:\n' +
+	'Review is NOT the end node in this workflow — the task-completion tools ' +
+	'(`approve_task`, `submit_for_approval`) are not available to you. Your terminal ' +
+	'action is writing `approved = true` to the `review-approval-gate`, which hands ' +
+	'the PR to QA. You may write the gate ONLY when your verdict is APPROVE (zero ' +
+	'findings at P0–P3). If ANY P0–P3 finding exists this round, your verdict is ' +
+	'`REQUEST_CHANGES`: send actionable feedback to Coding via `send_message(' +
+	'target="Coding", ...)` — do NOT write the approval gate, and the workflow stays ' +
+	'open for the next cycle.\n\n' +
 	'If the change is ready for QA, write to review-approval-gate (field: approved = true). ' +
 	'If changes are needed, send actionable feedback to Coding. Review is not the end node, ' +
 	'so the task-completion tools are not available to you.';
@@ -250,19 +325,35 @@ const FULLSTACK_REVIEW_PROMPT =
 const FULLSTACK_QA_PROMPT =
 	'You are the QA node in a Fullstack QA Loop workflow. Run thorough validation, including backend tests, ' +
 	'frontend tests, and browser-based checks for critical flows.\n\n' +
+	'TERMINAL ACTION PRE-CONDITIONS (read before considering `approve_task` or ' +
+	'`submit_for_approval`):\n\n' +
+	'**Terminal actions (`approve_task`, `submit_for_approval`) close the QA loop ' +
+	'and hand the task off.** You may call them ONLY when QA passes cleanly — every ' +
+	'required test suite is green AND no P0–P3 issues remain open from this or any ' +
+	'prior cycle.\n\n' +
+	'If QA finds ANY blocking failure or regression, you MUST:\n' +
+	'- `send_message(target="Coding", ...)` with the failure list and repro steps.\n' +
+	'- `save_artifact({ type: "result", append: true, summary: "QA failed: ..." })` ' +
+	'to record the cycle.\n' +
+	'- **STOP. Do NOT call `approve_task`. Do NOT call `submit_for_approval`.** The ' +
+	'workflow MUST stay open for the next Coding cycle.\n\n' +
+	'`submit_for_approval` carries the same approval semantic as `approve_task` — ' +
+	'both terminate the loop. It is NOT a way to defer judgment while issues are ' +
+	'open; it is "QA passes, but autonomy rules block me from self-closing, so a ' +
+	'human must rubber-stamp the final close."\n\n' +
 	'TOOL CONTRACT (Design v2):\n' +
 	'- `save_artifact({ type: "result", append: true, summary, ...data? })` — append-only audit. Records what you observed ' +
 	'during this cycle. Does NOT close the task.\n' +
 	'- `approve_task()` — closes this task as done. Only call after QA passes and the ' +
 	'post-approval handoff to the Task Agent has been sent.\n' +
 	'- `submit_for_approval({ reason? })` — request human sign-off instead of self-closing. ' +
-	'Use when autonomy blocks self-close.\n\n' +
+	'Use when autonomy blocks self-close (and only when QA passes — see pre-conditions above).\n\n' +
 	'If everything passes, signal the Task Agent that a merge is the post-approval action, ' +
 	'then `save_artifact({ type: "result", append: true, summary: "QA passed." })` and ' +
 	'`approve_task`. Do NOT merge the PR yourself — a post-approval reviewer session runs ' +
 	'the merge after the task transitions to `approved`. If issues are found, send a detailed ' +
 	'fix list to Coding and record a `save_artifact({ type: "result", append: true, summary: "QA failed: ..." })` ' +
-	'audit entry; do NOT call `approve_task`.';
+	'audit entry; do NOT call `approve_task` and do NOT call `submit_for_approval`.';
 
 const RESEARCH_RESEARCH_NODE = 'tpl-research-research';
 const RESEARCH_REVIEW_NODE = 'tpl-research-review';
@@ -350,20 +441,23 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'- The Review → Coding channel is gated by `review-posted-gate` — the runtime ' +
 							'checks GitHub for a fresh review before releasing your message. If you skip ' +
 							'`gh pr review`, the gate will block and the coder will never hear from you.\n\n' +
+							reviewerTerminalActionPreconditions('Coding') +
 							'TOOL CONTRACT (Design v2):\n' +
 							'- `save_artifact({ type: "result", append: true, summary, ...data? })` — append-only audit. Records what you ' +
 							'observed. Does NOT close the task. Call it every cycle (changes-requested AND ' +
 							'approval) so the audit log has a clear trail of each decision.\n' +
 							'- `approve_task()` — closes this task as done. Call this ONLY when you are ' +
-							'satisfied the work is shippable. It is gated by autonomy level; the runtime ' +
-							'will tell you if the level is too low.\n' +
+							'satisfied the work is shippable AND the pre-conditions above are met. It is ' +
+							'gated by autonomy level; the runtime will tell you if the level is too low.\n' +
 							'- `submit_for_approval({ reason? })` — request human sign-off instead of self- ' +
-							'closing. Use when the change is risky or the autonomy rules block self-close.\n\n' +
+							'closing. Use when the change is approved by you but autonomy rules block ' +
+							'self-close. Same pre-conditions as `approve_task` apply — do NOT call this ' +
+							'while findings are open.\n\n' +
 							'Review checklist:\n' +
 							'1. Read the PR diff (`gh pr diff`) AND explore the worktree for context\n' +
 							'2. Check for correctness, style, test coverage, and integration impact\n' +
 							'3. Run the relevant tests yourself if uncertain\n' +
-							'4. If changes are needed:\n' +
+							'4. If changes are needed (verdict = REQUEST_CHANGES, any P0–P3 finding):\n' +
 							'   a. Post a summary review: `gh pr review <pr-url> --request-changes ' +
 							'--body-file /tmp/review.md`. Capture the returned review URL.\n' +
 							'   b. For each issue, post a line-level comment: `gh api ' +
@@ -374,9 +468,13 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'comment_urls: ["<comment #1 url>", "<comment #2 url>"] }). The `data` payload ' +
 							'satisfies the review-posted-gate and gives the coder direct links to each ' +
 							'thread.\n' +
-							'   d. Call `save_artifact({ type: "result", append: true, summary: "Requested changes: ...", data: { prUrl: "<url>", reviewUrl: "<gh pr review url>" } })` so the cycle is recorded. Do NOT call `approve_task` — ' +
-							'the workflow must stay open for the next cycle.\n' +
-							'5. If satisfied:\n' +
+							'   d. Call `save_artifact({ type: "result", append: true, summary: "Requested changes: ...", data: { prUrl: "<url>", reviewUrl: "<gh pr review url>" } })` so the cycle is recorded.\n' +
+							'   e. **STOP. Do NOT call `approve_task`. Do NOT call `submit_for_approval`.** ' +
+							'Both are terminal actions that close the review loop — calling either while ' +
+							'P0–P3 findings are open hands the task off before Coding can address them. ' +
+							'The workflow MUST stay open for the next cycle.\n' +
+							'5. If satisfied (verdict = APPROVE, zero findings at any severity AND any ' +
+							'prior-round P0–P3 findings have been addressed in the latest commits):\n' +
 							'   a. Post an approval review: `gh pr review <pr-url> --approve ' +
 							'--body-file <file>`.\n' +
 							'   b. Verify the PR is still open and mergeable.\n' +
@@ -531,21 +629,26 @@ export const RESEARCH_WORKFLOW: SpaceWorkflow = {
 						value:
 							'You are the Reviewer in a Research→Reviewer iterative workflow. You review the ' +
 							'research findings for completeness, accuracy, and quality.\n\n' +
+							reviewerTerminalActionPreconditions('Research') +
 							'TOOL CONTRACT (Design v2):\n' +
 							'- `save_artifact({ type: "result", append: true, summary, ...data? })` — append-only audit. Records what you ' +
 							'observed during this cycle. Does NOT close the task.\n' +
-							'- `approve_task()` — closes the task as done. Call only when satisfied.\n' +
+							'- `approve_task()` — closes the task as done. Call only when satisfied AND the ' +
+							'pre-conditions above are met.\n' +
 							'- `submit_for_approval({ reason? })` — request human sign-off instead of self- ' +
-							'closing. Use when autonomy rules block self-close or the finding is sensitive.\n\n' +
+							'closing. Use when autonomy rules block self-close. Same pre-conditions as ' +
+							'`approve_task` apply — do NOT call this while findings are open.\n\n' +
 							'Review checklist:\n' +
 							'1. Read all research documents in the PR (`gh pr diff`)\n' +
 							'2. Check completeness: does the research answer the original question?\n' +
 							'3. Check accuracy: are claims supported by evidence or sources?\n' +
 							'4. Check clarity: are findings well-organized and easy to follow?\n' +
-							'5. If more research is needed: send_message back to Research with specific areas ' +
-							'to investigate, then `save_artifact({ type: "result", append: true, summary: "Requested more research: ..." })` ' +
-							'to record the cycle. Do NOT call `approve_task` — leave the workflow open.\n' +
-							'6. If satisfied:\n' +
+							'5. If more research is needed (verdict = REQUEST_CHANGES, any P0–P3 finding): ' +
+							'send_message back to Research with specific areas to investigate, then ' +
+							'`save_artifact({ type: "result", append: true, summary: "Requested more research: ..." })` ' +
+							'to record the cycle. **Do NOT call `approve_task`. Do NOT call ' +
+							'`submit_for_approval`.** Both terminate the loop. Leave the workflow open.\n' +
+							'6. If satisfied (verdict = APPROVE, zero findings at any severity):\n' +
 							'   a. Post an approval review: `gh pr review <pr-url> --approve ' +
 							'--body-file <file>`. A visible GitHub review is required — an internal ' +
 							'summary is not enough.\n' +
@@ -649,13 +752,30 @@ export const REVIEW_ONLY_WORKFLOW: SpaceWorkflow = {
 						value:
 							'You are the sole Reviewer in a single-node Review-Only workflow. There is no planning ' +
 							'or coding phase — you are reviewing an existing PR or codebase directly.\n\n' +
+							'TERMINAL ACTION PRE-CONDITIONS (read before considering `approve_task` or ' +
+							'`submit_for_approval`):\n\n' +
+							'**Terminal actions (`approve_task`, `submit_for_approval`) close this task.** ' +
+							'Because Review-Only is a single-node workflow there is no upstream coder to ' +
+							'send back to — but the loop-closing semantic is still strict:\n' +
+							'1. You MUST post your review to GitHub via `gh pr review` (and inline comments ' +
+							'where relevant) BEFORE calling either terminal tool. An internal summary is ' +
+							'not enough.\n' +
+							'2. If your verdict on the PR is `REQUEST_CHANGES` (any P0–P3 finding), call ' +
+							'`save_artifact({ type: "result", append: true, summary: "Requested ' +
+							'changes: ..." })` and STOP — return control to the caller. **Do NOT call ' +
+							'`approve_task`. Do NOT call `submit_for_approval`.** They both signal "the ' +
+							'work is approved by me" and would close the task with findings still open.\n' +
+							'3. Only when your verdict is `APPROVE` (zero findings at any severity) may you ' +
+							'call `approve_task` (or `submit_for_approval` when autonomy blocks self-close, ' +
+							'which carries the same approval semantic).\n\n' +
 							'TOOL CONTRACT (Design v2):\n' +
 							'- `save_artifact({ type: "result", append: true, summary, ...data? })` — append-only audit. Records what you ' +
 							'observed. Does NOT close the task.\n' +
-							'- `approve_task()` — closes the task as done. Call only after you have posted ' +
-							'your review to the PR via `gh pr review`.\n' +
+							'- `approve_task()` — closes the task as done. Call only when verdict is APPROVE ' +
+							'AND you have posted your review to the PR via `gh pr review`.\n' +
 							'- `submit_for_approval({ reason? })` — request human sign-off instead of self- ' +
-							'closing. Use when autonomy blocks self-close.\n\n' +
+							'closing. Same pre-conditions as `approve_task` apply — do NOT call this while ' +
+							'findings are open.\n\n' +
 							'**You MUST post your review to the PR via `gh pr review` BEFORE calling ' +
 							'`approve_task` or `submit_for_approval`.** An internal summary is not enough — the ' +
 							'author must be able to see your feedback on GitHub. Use:\n' +
@@ -670,8 +790,10 @@ export const REVIEW_ONLY_WORKFLOW: SpaceWorkflow = {
 							'4. Post your review to the PR via `gh pr review` (+ inline comments via `gh api` ' +
 							'where relevant) — this is required, not optional\n' +
 							'5. Call `save_artifact({ type: "result", append: true, summary, data: { prUrl: "<url>" } })` to record the audit entry. Nest `prUrl` inside `data`; top-level keys outside `data` are stripped by the tool schema\n' +
-							'6. Call `approve_task()` as your final action. If autonomy blocks self-close, call ' +
-							'`submit_for_approval({ reason: "..." })` instead.',
+							'6. If your verdict is APPROVE: call `approve_task()` as your final action. If ' +
+							'autonomy blocks self-close, call `submit_for_approval({ reason: "..." })` ' +
+							'instead. If your verdict is REQUEST_CHANGES: stop after step 5 — do NOT call ' +
+							'either terminal tool.',
 					},
 				},
 			],

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -20,13 +20,12 @@
  *   `resolveChannels()` matches node names via the `nodeNameToAgents` lookup.
  */
 
+import type { GateScript, SpaceWorkflow, WorkflowNode } from '@neokai/shared';
 import { generateUUID } from '@neokai/shared';
-import type { SpaceWorkflow, WorkflowNode } from '@neokai/shared';
-import type { GateScript } from '@neokai/shared';
-import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import { Logger } from '../../logger';
-import { computeWorkflowHash } from './template-hash.ts';
+import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import { PR_MERGE_POST_APPROVAL_INSTRUCTIONS } from './post-approval-merge-template.ts';
+import { computeWorkflowHash } from './template-hash.ts';
 
 const builtInSeederLog = new Logger('seed-built-in-workflows');
 
@@ -318,9 +317,14 @@ const FULLSTACK_REVIEW_PROMPT =
 	'`REQUEST_CHANGES`: send actionable feedback to Coding via `send_message(' +
 	'target="Coding", ...)` — do NOT write the approval gate, and the workflow stays ' +
 	'open for the next cycle.\n\n' +
+	'Note: writing `approved = true` to `review-approval-gate` carries the **same ' +
+	'approval semantic** as `approve_task` / `submit_for_approval` would on an end ' +
+	'node — it is a terminal hand-off. Treat it with the same care: never flip the ' +
+	'gate while P0–P3 findings are open.\n\n' +
 	'If the change is ready for QA, write to review-approval-gate (field: approved = true). ' +
-	'If changes are needed, send actionable feedback to Coding. Review is not the end node, ' +
-	'so the task-completion tools are not available to you.';
+	'If changes are needed, send actionable feedback to Coding via ' +
+	'`send_message(target="Coding", ...)`. Review is not the end node, so the ' +
+	'task-completion tools are not available to you.';
 
 const FULLSTACK_QA_PROMPT =
 	'You are the QA node in a Fullstack QA Loop workflow. Run thorough validation, including backend tests, ' +
@@ -1102,7 +1106,9 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
 							'3. Validate CI and mergeability\n' +
 							'4. If fail: send detailed failures and repro steps to Coding, then call ' +
 							'`save_artifact({ type: "result", append: true, summary: "QA failed: ..." })` to record the audit entry. Do ' +
-							'NOT call `approve_task` — leave the workflow open for the next Coding cycle.\n' +
+							'NOT call `approve_task` or `submit_for_approval` — both are TERMINAL and ' +
+							'carry the same approval semantic. Leave the workflow open for the next ' +
+							'Coding cycle.\n' +
 							'5. If all green:\n' +
 							'   a. Signal the Task Agent that the PR is ready for post-approval:\n' +
 							'      send_message(\n' +

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-tool-schemas.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-tool-schemas.test.ts
@@ -30,6 +30,17 @@ describe('ApproveTaskSchema', () => {
 		const result = ApproveTaskSchema.safeParse({ reason: 'done' });
 		expect(result.success).toBe(false);
 	});
+
+	test('schema description encodes Terminal Action pre-conditions (Task #136)', () => {
+		// The description is what surfaces to the LLM at tool-call time. It
+		// must restate the gating that the workflow node prompt also enforces
+		// so the model cannot interpret approve_task as valid mid-loop.
+		const description = (ApproveTaskSchema as unknown as { description?: string }).description;
+		expect(description).toBeDefined();
+		expect(description).toMatch(/TERMINAL/i);
+		expect(description).toMatch(/APPROVE/);
+		expect(description).toContain('P0–P3');
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -63,6 +74,22 @@ describe('SubmitForApprovalSchema', () => {
 	test('rejects extra fields (strict schema)', () => {
 		const result = SubmitForApprovalSchema.safeParse({ reason: 'ok', extra: 'bad' });
 		expect(result.success).toBe(false);
+	});
+
+	test('schema description equates submit_for_approval with approve_task (Task #136)', () => {
+		// Reviewer agents were treating submit_for_approval as "let a human
+		// decide for me" while findings were still open. The description must
+		// explicitly call out that it carries the same approval semantic as
+		// approve_task — both close the review loop.
+		const description = (SubmitForApprovalSchema as unknown as { description?: string })
+			.description;
+		expect(description).toBeDefined();
+		expect(description).toMatch(/TERMINAL/i);
+		expect(description).toMatch(/approve_task/);
+		expect(description).toContain('P0–P3');
+		expect(description).toMatch(/APPROVE/);
+		// Must explicitly reject the "defer judgment" interpretation.
+		expect(description).toMatch(/defer judgment|request changes/i);
 	});
 });
 

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-tool-schemas.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-tool-schemas.test.ts
@@ -6,14 +6,14 @@
  * - Rejects invalid inputs with a ZodError
  */
 
-import { describe, test, expect } from 'bun:test';
+import { describe, expect, test } from 'bun:test';
 import {
 	ApproveTaskSchema,
-	SubmitForApprovalSchema,
-	RequestHumanInputSchema,
-	TASK_AGENT_TOOL_SCHEMAS,
 	ListGroupMembersSchema,
 	MarkCompleteSchema,
+	RequestHumanInputSchema,
+	SubmitForApprovalSchema,
+	TASK_AGENT_TOOL_SCHEMAS,
 } from '../../../../src/lib/space/tools/task-agent-tool-schemas.ts';
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/5-space/other/seed-agents.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/seed-agents.test.ts
@@ -6,18 +6,18 @@
  * on name collision are captured but do not abort remaining seeds).
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { Database } from 'bun:sqlite';
-import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository';
-import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager';
-import {
-	seedPresetAgents,
-	PRESET_AGENT_TOOLS,
-	SUB_SESSION_FEATURES,
-	getPresetAgentTemplates,
-} from '../../../../src/lib/space/agents/seed-agents';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { KNOWN_TOOLS } from '@neokai/shared';
 import { setModelsCache } from '../../../../src/lib/model-service';
+import {
+	getPresetAgentTemplates,
+	PRESET_AGENT_TOOLS,
+	SUB_SESSION_FEATURES,
+	seedPresetAgents,
+} from '../../../../src/lib/space/agents/seed-agents';
+import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager';
+import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository';
 import { createSpaceAgentSchema, insertSpace } from '../../helpers/space-agent-schema';
 
 describe('seedPresetAgents', () => {
@@ -264,6 +264,24 @@ describe('seedPresetAgents', () => {
 		// Decision rule: request changes when any P0–P3 finding exists (P3 included).
 		expect(reviewer?.customPrompt).toContain('P0–P3');
 		expect(reviewer?.customPrompt).toMatch(/P3 included/i);
+	});
+
+	it('Reviewer custom prompt fences terminal actions while findings are open (Task #136 regression)', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const reviewer = seeded.find((a) => a.name === 'Reviewer');
+
+		// Preset-level fence must apply to ALL Reviewer instances, even when
+		// the workflow template forgets to add a customPrompt overlay. The
+		// section header, both terminal tools, the P0–P3 gate, and the
+		// "same approval semantic" clarifier must be present so future
+		// workflows inherit the gating by default.
+		expect(reviewer?.customPrompt).toContain('Terminal Action Pre-Conditions');
+		expect(reviewer?.customPrompt).toContain('`approve_task`');
+		expect(reviewer?.customPrompt).toContain('`submit_for_approval`');
+		expect(reviewer?.customPrompt).toContain('P0–P3');
+		expect(reviewer?.customPrompt).toMatch(/Do NOT call `approve_task`/);
+		expect(reviewer?.customPrompt).toMatch(/Do NOT call `submit_for_approval`/);
+		expect(reviewer?.customPrompt).toMatch(/same approval semantic/i);
 	});
 
 	it('Reviewer custom prompt includes own-PR detection', async () => {

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -2168,3 +2168,155 @@ describe('PLAN_AND_DECOMPOSE_WORKFLOW agent slot customPrompt', () => {
 		expect(agent.customPrompt?.value).toContain('save_artifact');
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Reviewer Terminal Action Pre-conditions
+//
+// Regression coverage for Task #136: Reviewer agents were calling
+// `submit_for_approval` / `approve_task` mid-loop while their own posted review
+// still contained pending P0–P3 findings, prematurely closing the iterative
+// Coding ↔ Review loop. Every Reviewer / review-style end-node prompt must now
+// contain an explicit Terminal Action Pre-conditions block establishing the
+// hard gate: zero pending P0–P3 findings AND verdict = APPROVE.
+// ---------------------------------------------------------------------------
+
+describe('Reviewer Terminal Action Pre-conditions (Task #136 regression)', () => {
+	/**
+	 * Asserts that a review-style prompt contains the canonical pre-conditions
+	 * block. The check is content-based rather than token-exact so the prompt
+	 * can evolve without breaking the test, but every load-bearing phrase from
+	 * the design spec (severity range, both terminal tools, REQUEST_CHANGES
+	 * branch instructions, "same approval semantic") must be present.
+	 */
+	function assertTerminalActionPreconditions(prompt: string, opts: { upstream: string }): void {
+		// Header-style phrase identifying the block.
+		expect(prompt).toContain('TERMINAL ACTION PRE-CONDITIONS');
+		// Both terminal tools must be named explicitly so the model cannot
+		// interpret "approve_task only" or "submit_for_approval only".
+		expect(prompt).toContain('`approve_task`');
+		expect(prompt).toContain('`submit_for_approval`');
+		// Severity envelope must reference P0–P3 (covers the full classification
+		// rule from REVIEWER_CUSTOM_PROMPT in seed-agents.ts).
+		expect(prompt).toContain('P0–P3');
+		// Verdict gate — APPROVE must be the only path to a terminal call.
+		expect(prompt).toMatch(/verdict.*APPROVE|APPROVE.*verdict/i);
+		// REQUEST_CHANGES path must explicitly forbid both terminal calls.
+		expect(prompt).toContain('REQUEST_CHANGES');
+		expect(prompt).toMatch(/Do NOT call `approve_task`/);
+		expect(prompt).toMatch(/Do NOT call `submit_for_approval`/);
+		// The upstream node name must appear in the send_message instruction so
+		// the reviewer knows where to route feedback when continuing the loop.
+		expect(prompt).toContain(`send_message(target="${opts.upstream}"`);
+		// Equivalence statement: submit_for_approval is NOT a "let a human
+		// decide" escape hatch — it carries the same approval semantic as
+		// approve_task. This prevents the original bug recurring.
+		expect(prompt).toMatch(/same approval semantic|same.*semantic/i);
+	}
+
+	test('CODING_WORKFLOW Review node prompt contains Terminal Action Pre-conditions block', () => {
+		const reviewNode = CODING_WORKFLOW.nodes.find((n) => n.name === 'Review')!;
+		const prompt = reviewNode.agents[0].customPrompt!.value;
+		assertTerminalActionPreconditions(prompt, { upstream: 'Coding' });
+	});
+
+	test('CODING_WORKFLOW Review node REQUEST_CHANGES branch forbids both terminal tools', () => {
+		const reviewNode = CODING_WORKFLOW.nodes.find((n) => n.name === 'Review')!;
+		const prompt = reviewNode.agents[0].customPrompt!.value;
+		// Step 4 ("If changes are needed") must explicitly forbid both terminal
+		// calls, not just `approve_task`. Pre-Task #136 it only mentioned
+		// approve_task, leaving submit_for_approval as an unintended escape.
+		const stepFour = prompt.split('5. If satisfied')[0];
+		expect(stepFour).toMatch(/Do NOT call `approve_task`/);
+		expect(stepFour).toMatch(/Do NOT call `submit_for_approval`/);
+	});
+
+	test('RESEARCH_WORKFLOW Review node prompt contains Terminal Action Pre-conditions block', () => {
+		const reviewNode = RESEARCH_WORKFLOW.nodes.find((n) => n.name === 'Review')!;
+		const prompt = reviewNode.agents[0].customPrompt!.value;
+		assertTerminalActionPreconditions(prompt, { upstream: 'Research' });
+	});
+
+	test('RESEARCH_WORKFLOW Review node REQUEST_CHANGES branch forbids both terminal tools', () => {
+		const reviewNode = RESEARCH_WORKFLOW.nodes.find((n) => n.name === 'Review')!;
+		const prompt = reviewNode.agents[0].customPrompt!.value;
+		// "more research is needed" branch must forbid both terminal tools.
+		const requestBranch = prompt.split('6. If satisfied')[0];
+		expect(requestBranch).toMatch(/Do NOT call `approve_task`/);
+		expect(requestBranch).toMatch(/Do NOT call `submit_for_approval`/);
+	});
+
+	test('REVIEW_ONLY_WORKFLOW prompt forbids terminal calls when verdict is REQUEST_CHANGES', () => {
+		const prompt = REVIEW_ONLY_WORKFLOW.nodes[0].agents[0].customPrompt!.value;
+		// Header & severity coverage.
+		expect(prompt).toContain('TERMINAL ACTION PRE-CONDITIONS');
+		expect(prompt).toContain('P0–P3');
+		expect(prompt).toContain('`approve_task`');
+		expect(prompt).toContain('`submit_for_approval`');
+		// Both terminal tools must be forbidden on the REQUEST_CHANGES branch.
+		expect(prompt).toMatch(/Do NOT call `approve_task`/);
+		expect(prompt).toMatch(/Do NOT call `submit_for_approval`/);
+		// Same approval semantic clarifier so submit_for_approval is not
+		// treated as an escape hatch in the single-node case either.
+		expect(prompt).toMatch(/same approval semantic/i);
+	});
+
+	test('FULLSTACK_QA_LOOP_WORKFLOW Review node forbids gate-write while findings are open', () => {
+		const reviewNode = FULLSTACK_QA_LOOP_WORKFLOW.nodes.find((n) => n.name === 'Review')!;
+		const prompt = reviewNode.agents[0].customPrompt!.value;
+		// Review is mid-graph in this workflow — terminal tools are unavailable
+		// to it — but the pre-conditions block must still be present so the
+		// reviewer does not silently flip review-approval-gate while findings
+		// are open.
+		expect(prompt).toContain('TERMINAL ACTION PRE-CONDITIONS');
+		expect(prompt).toContain('P0–P3');
+		expect(prompt).toContain('REQUEST_CHANGES');
+		expect(prompt).toContain('review-approval-gate');
+	});
+
+	test('FULLSTACK_QA_LOOP_WORKFLOW QA node prompt contains Terminal Action Pre-conditions block', () => {
+		const qaNode = FULLSTACK_QA_LOOP_WORKFLOW.nodes.find((n) => n.name === 'QA')!;
+		const prompt = qaNode.agents[0].customPrompt!.value;
+		// QA is the end node for the fullstack loop — both terminal tools must
+		// be guarded the same way as a code reviewer.
+		expect(prompt).toContain('TERMINAL ACTION PRE-CONDITIONS');
+		expect(prompt).toContain('`approve_task`');
+		expect(prompt).toContain('`submit_for_approval`');
+		expect(prompt).toContain('P0–P3');
+		// Failure branch must forbid both calls.
+		expect(prompt).toMatch(/Do NOT call `approve_task`/);
+		expect(prompt).toMatch(/Do NOT call `submit_for_approval`/);
+		// Same approval semantic clarifier so submit_for_approval is not used
+		// as an "escalate this failing QA" escape hatch.
+		expect(prompt).toMatch(/same approval semantic/i);
+	});
+
+	test('PLAN_AND_DECOMPOSE_WORKFLOW Plan Review reviewers carry Terminal Action Pre-conditions', () => {
+		const reviewNode = PLAN_AND_DECOMPOSE_WORKFLOW.nodes.find((n) => n.name === 'Plan Review')!;
+		expect(reviewNode.agents).toHaveLength(4);
+		for (const agent of reviewNode.agents) {
+			const prompt = agent.customPrompt!.value;
+			// Plan reviewers are not end-node agents but the same gating
+			// principle applies — voting `approved: true` while P0–P3 findings
+			// are open is the gate-write equivalent of `approve_task`.
+			expect(prompt).toContain('TERMINAL ACTION PRE-CONDITIONS');
+			expect(prompt).toContain('P0–P3');
+			expect(prompt).toContain('`approve_task`');
+			expect(prompt).toContain('`submit_for_approval`');
+		}
+	});
+
+	test('PLAN_AND_DECOMPOSE_WORKFLOW Task Dispatcher prompt forbids terminal calls while dispatch incomplete', () => {
+		const dispatcherNode = PLAN_AND_DECOMPOSE_WORKFLOW.nodes.find(
+			(n) => n.name === 'Task Dispatcher'
+		)!;
+		const prompt = dispatcherNode.agents[0].customPrompt!.value;
+		expect(prompt).toContain('TERMINAL ACTION PRE-CONDITIONS');
+		expect(prompt).toContain('`approve_task`');
+		expect(prompt).toContain('`submit_for_approval`');
+		// Dispatcher's REQUEST_CHANGES analogue: dispatch incomplete.
+		expect(prompt).toMatch(/Do NOT call `approve_task`/);
+		expect(prompt).toMatch(/Do NOT call `submit_for_approval`/);
+		// Same approval semantic clarifier.
+		expect(prompt).toMatch(/same approval semantic/i);
+	});
+});

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -15,27 +15,27 @@
  * - Export/import round-trip: isCyclic and task_result conditions are preserved
  */
 
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { Database as BunDatabase } from 'bun:sqlite';
-import { runMigrations } from '../../../../src/storage/schema/index.ts';
-import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
-import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
-import {
-	CODING_WORKFLOW,
-	PLAN_AND_DECOMPOSE_WORKFLOW,
-	FULLSTACK_QA_LOOP_WORKFLOW,
-	RESEARCH_WORKFLOW,
-	REVIEW_ONLY_WORKFLOW,
-	getBuiltInWorkflows,
-	getBuiltInGateScript,
-	seedBuiltInWorkflows,
-} from '../../../../src/lib/space/workflows/built-in-workflows.ts';
-import { computeWorkflowHash } from '../../../../src/lib/space/workflows/template-hash.ts';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import type { SpaceAgent, SpaceWorkflow } from '@neokai/shared';
 import {
 	exportWorkflow,
 	validateExportedWorkflow,
 } from '../../../../src/lib/space/export-format.ts';
+import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
+import {
+	CODING_WORKFLOW,
+	FULLSTACK_QA_LOOP_WORKFLOW,
+	getBuiltInGateScript,
+	getBuiltInWorkflows,
+	PLAN_AND_DECOMPOSE_WORKFLOW,
+	RESEARCH_WORKFLOW,
+	REVIEW_ONLY_WORKFLOW,
+	seedBuiltInWorkflows,
+} from '../../../../src/lib/space/workflows/built-in-workflows.ts';
+import { computeWorkflowHash } from '../../../../src/lib/space/workflows/template-hash.ts';
+import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -2271,6 +2271,16 @@ describe('Reviewer Terminal Action Pre-conditions (Task #136 regression)', () =>
 		expect(prompt).toContain('P0–P3');
 		expect(prompt).toContain('REQUEST_CHANGES');
 		expect(prompt).toContain('review-approval-gate');
+		// Failure-path routing: the prompt must explicitly tell the reviewer to
+		// send feedback back to Coding via send_message rather than silently
+		// stalling. Asserting this catches future drift in the routing wording.
+		expect(prompt).toContain('send_message(target="Coding", ...)');
+		// Same approval semantic clarifier: even though approve_task /
+		// submit_for_approval are unavailable on this mid-graph node, writing
+		// the approval gate is the equivalent terminal hand-off and the prompt
+		// must call out the parallel so a future split (where the tools become
+		// available) does not accidentally remove the gating.
+		expect(prompt).toMatch(/same approval semantic/i);
 	});
 
 	test('FULLSTACK_QA_LOOP_WORKFLOW QA node prompt contains Terminal Action Pre-conditions block', () => {


### PR DESCRIPTION
## Summary

- Reviewers were calling `submit_for_approval` / `approve_task` at the end of round 1 with pending P0–P3 findings, closing the Coding ↔ Review loop before the coder could address the issues. Add an explicit "Terminal Action Pre-conditions" block to every review-style end-node prompt and tighten the tool descriptions so the gate is enforced both at workflow level and at tool-call time.
- The pre-conditions block equates `submit_for_approval` with `approve_task` (both terminate the loop) so the model can't interpret the former as "let a human decide while findings are open." On the REQUEST_CHANGES branch, both tools are now explicitly forbidden — previously only `approve_task` was called out.

## Test plan

- [x] `bun test tests/unit/5-space` — 2473 pass, 0 fail
- [x] New tests assert each affected workflow's prompt contains the pre-conditions block, REQUEST_CHANGES branches forbid both terminal tools, and tool-schema descriptions encode the constraint
- [ ] Manual dev verification: kick off a Coding Workflow task that triggers P0–P3 findings on round 1; confirm Reviewer posts REQUEST_CHANGES and does NOT call `approve_task` / `submit_for_approval`. Once Coding addresses the findings and Round 2 produces verdict APPROVE, confirm the terminal action fires.