### PR TITLE
fix(space): attach space-agent-tools to ad-hoc Space member sessions

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -391,30 +391,29 @@ export class SpaceRuntimeService {
 		// covers the remaining cases: worker/coder/general/room_chat sessions
 		// that live inside a Space and need to send/receive messages via
 		// `send_message_to_agent`, inspect tasks, etc.
-		const unsubSessionCreated = daemonHub.on(
-			'session.created',
-			(event) => {
-				void this.attachSpaceToolsToMemberSession(event.session).catch((err) => {
-					log.error(
-						`Failed to attach space tools to session ${event.sessionId} (space ${event.session.context?.spaceId ?? '?'}):`,
-						err
-					);
-				});
-			},
-			{ sessionId: 'global' }
-		);
+		//
+		// NOTE: no `{ sessionId: 'global' }` filter here — `session.created` is
+		// emitted with `data.sessionId = <new session UUID>`, so a `'global'`
+		// filter would never match. We want every session.created event, so we
+		// subscribe globally (TypedHub's default).
+		const unsubSessionCreated = daemonHub.on('session.created', (event) => {
+			void this.attachSpaceToolsToMemberSession(event.session).catch((err) => {
+				log.error(
+					`Failed to attach space tools to session ${event.sessionId} (space ${event.session.context?.spaceId ?? '?'}):`,
+					err
+				);
+			});
+		});
 		this.unsubscribers.push(unsubSessionCreated);
 
 		// When a session is deleted, release any per-session db-query server we
 		// spun up for it so read-only SQLite handles don't accumulate on a
 		// long-lived daemon serving many short-lived worker sessions.
-		const unsubSessionDeleted = daemonHub.on(
-			'session.deleted',
-			(event) => {
-				this.releaseMemberSessionDbQuery(event.sessionId);
-			},
-			{ sessionId: 'global' }
-		);
+		// (Same reasoning as above: `session.deleted` is emitted with the
+		// deleted session's UUID as `sessionId`, not `'global'`.)
+		const unsubSessionDeleted = daemonHub.on('session.deleted', (event) => {
+			this.releaseMemberSessionDbQuery(event.sessionId);
+		});
 		this.unsubscribers.push(unsubSessionDeleted);
 	}
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -38,6 +38,7 @@ import { SpaceAgentRepository } from '../../../../src/storage/repositories/space
 import { SpaceAgentManager as AgentMgr } from '../../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager as WorkflowMgr } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
 import { SpaceManager as SpaceMgr } from '../../../../src/lib/space/managers/space-manager.ts';
+import { createTestDaemonHub } from '../../../helpers/database.ts';
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -765,6 +766,240 @@ describe('SpaceRuntimeService', () => {
 			expect(mergeMock).toHaveBeenCalledTimes(2);
 
 			await svc.stop();
+		});
+	});
+
+	// ─── daemonHub session.created subscription regression (Task #137) ───────
+	//
+	// Before this fix, subscribeToSpaceEvents() registered the session.created
+	// and session.deleted handlers with `{ sessionId: 'global' }`. TypedHub
+	// stores that under the literal `'global'` key, NOT under the `'__global__'`
+	// GLOBAL_KEY used for unfiltered subscriptions, AND its cross-transport
+	// hubHandler filters with `if (sessionId && eventData.sessionId !== sessionId)
+	// return`. Both checks reject events emitted with a UUID `sessionId` (which
+	// is what `SessionLifecycle.create()` and `deleteResources()` actually emit),
+	// so the handlers never fired. The visible symptom: ad-hoc Space worker /
+	// coder / room_chat / general sessions silently came up missing
+	// `space-agent-tools` and `db-query`.
+	//
+	// These tests use a real DaemonHub so the bug reproduces end-to-end if the
+	// `{ sessionId: 'global' }` filter is reintroduced.
+
+	describe('daemonHub session.created subscription (Task #137 regression)', () => {
+		function makeMemberAgentSession() {
+			return {
+				mergeRuntimeMcpServers: mock((_: Record<string, McpServerConfig>) => {}),
+				setRuntimeMcpServers: mock(() => {}),
+				setRuntimeSystemPrompt: mock(() => {}),
+			} as unknown as AgentSession;
+		}
+
+		function makeMemberSession(overrides: Partial<Session> = {}): Session {
+			return {
+				id: 'worker-session-uuid-123',
+				title: 'Worker',
+				workspacePath: '/tmp/ws',
+				createdAt: new Date().toISOString(),
+				lastActiveAt: new Date().toISOString(),
+				status: 'active',
+				config: { tools: {} },
+				metadata: {},
+				type: 'worker',
+				context: { spaceId: mockSpace.id },
+				...overrides,
+			} as unknown as Session;
+		}
+
+		test('attaches space-agent-tools when daemonHub emits session.created with a UUID sessionId', async () => {
+			const agent = makeMemberAgentSession();
+			const sessionManager = {
+				getSessionAsync: mock(async () => agent),
+				listSessions: mock(() => [] as Session[]),
+			} as unknown as SessionManager;
+
+			const daemonHub = await createTestDaemonHub('space-rts-test-created');
+			const svc = new SpaceRuntimeService({
+				db: {} as BunDatabase,
+				spaceManager: createMockSpaceManager(mockSpace),
+				spaceAgentManager: { listBySpaceId: mock(() => []) } as unknown as SpaceAgentManager,
+				spaceWorkflowManager: { listWorkflows: mock(() => []) } as unknown as SpaceWorkflowManager,
+				workflowRunRepo: {} as SpaceWorkflowRunRepository,
+				taskRepo: {} as SpaceTaskRepository,
+				tickIntervalMs: 60_000,
+				sessionManager,
+				daemonHub,
+			});
+			svc.start();
+
+			const session = makeMemberSession();
+			// Emit with the actual session UUID — exactly what SessionLifecycle.create
+			// does. With the broken `{ sessionId: 'global' }` filter, neither
+			// dispatchLocally nor the cross-transport hubHandler matches this.
+			await daemonHub.emit('session.created', { sessionId: session.id, session });
+
+			// Allow microtasks to flush (dispatchLocally schedules via queueMicrotask
+			// and does not await the async handler).
+			await new Promise<void>((resolve) => setTimeout(resolve, 10));
+
+			const mergeMock = agent.mergeRuntimeMcpServers as Mock<typeof agent.mergeRuntimeMcpServers>;
+			expect(mergeMock).toHaveBeenCalledTimes(1);
+			const [additional] = mergeMock.mock.calls[0];
+			expect(additional).toHaveProperty('space-agent-tools');
+
+			await svc.stop();
+			await daemonHub.close();
+		});
+
+		test('does NOT attach for sessions without context.spaceId (non-space sessions)', async () => {
+			const agent = makeMemberAgentSession();
+			const sessionManager = {
+				getSessionAsync: mock(async () => agent),
+				listSessions: mock(() => [] as Session[]),
+			} as unknown as SessionManager;
+
+			const daemonHub = await createTestDaemonHub('space-rts-test-non-space');
+			const svc = new SpaceRuntimeService({
+				db: {} as BunDatabase,
+				spaceManager: createMockSpaceManager(mockSpace),
+				spaceAgentManager: { listBySpaceId: mock(() => []) } as unknown as SpaceAgentManager,
+				spaceWorkflowManager: { listWorkflows: mock(() => []) } as unknown as SpaceWorkflowManager,
+				workflowRunRepo: {} as SpaceWorkflowRunRepository,
+				taskRepo: {} as SpaceTaskRepository,
+				tickIntervalMs: 60_000,
+				sessionManager,
+				daemonHub,
+			});
+			svc.start();
+
+			const nonSpaceSession = makeMemberSession({ context: undefined });
+			await daemonHub.emit('session.created', {
+				sessionId: nonSpaceSession.id,
+				session: nonSpaceSession,
+			});
+			await new Promise<void>((resolve) => setTimeout(resolve, 10));
+
+			expect(agent.mergeRuntimeMcpServers).not.toHaveBeenCalled();
+
+			await svc.stop();
+			await daemonHub.close();
+		});
+
+		test('does NOT attach for space_chat sessions (handled by setupSpaceAgentSession)', async () => {
+			const agent = makeMemberAgentSession();
+			const sessionManager = {
+				getSessionAsync: mock(async () => agent),
+				listSessions: mock(() => [] as Session[]),
+			} as unknown as SessionManager;
+
+			const daemonHub = await createTestDaemonHub('space-rts-test-space-chat');
+			const svc = new SpaceRuntimeService({
+				db: {} as BunDatabase,
+				spaceManager: createMockSpaceManager(mockSpace),
+				spaceAgentManager: { listBySpaceId: mock(() => []) } as unknown as SpaceAgentManager,
+				spaceWorkflowManager: { listWorkflows: mock(() => []) } as unknown as SpaceWorkflowManager,
+				workflowRunRepo: {} as SpaceWorkflowRunRepository,
+				taskRepo: {} as SpaceTaskRepository,
+				tickIntervalMs: 60_000,
+				sessionManager,
+				daemonHub,
+			});
+			svc.start();
+
+			const chatSession = makeMemberSession({
+				type: 'space_chat',
+				id: `space:chat:${mockSpace.id}`,
+			});
+			await daemonHub.emit('session.created', {
+				sessionId: chatSession.id,
+				session: chatSession,
+			});
+			await new Promise<void>((resolve) => setTimeout(resolve, 10));
+
+			expect(agent.mergeRuntimeMcpServers).not.toHaveBeenCalled();
+
+			await svc.stop();
+			await daemonHub.close();
+		});
+
+		test('does NOT attach for space_task_agent sessions (handled by TaskAgentManager)', async () => {
+			const agent = makeMemberAgentSession();
+			const sessionManager = {
+				getSessionAsync: mock(async () => agent),
+				listSessions: mock(() => [] as Session[]),
+			} as unknown as SessionManager;
+
+			const daemonHub = await createTestDaemonHub('space-rts-test-task-agent');
+			const svc = new SpaceRuntimeService({
+				db: {} as BunDatabase,
+				spaceManager: createMockSpaceManager(mockSpace),
+				spaceAgentManager: { listBySpaceId: mock(() => []) } as unknown as SpaceAgentManager,
+				spaceWorkflowManager: { listWorkflows: mock(() => []) } as unknown as SpaceWorkflowManager,
+				workflowRunRepo: {} as SpaceWorkflowRunRepository,
+				taskRepo: {} as SpaceTaskRepository,
+				tickIntervalMs: 60_000,
+				sessionManager,
+				daemonHub,
+			});
+			svc.start();
+
+			const taskAgentSession = makeMemberSession({ type: 'space_task_agent' });
+			await daemonHub.emit('session.created', {
+				sessionId: taskAgentSession.id,
+				session: taskAgentSession,
+			});
+			await new Promise<void>((resolve) => setTimeout(resolve, 10));
+
+			expect(agent.mergeRuntimeMcpServers).not.toHaveBeenCalled();
+
+			await svc.stop();
+			await daemonHub.close();
+		});
+
+		test('session.deleted handler runs when daemonHub emits with a UUID sessionId', async () => {
+			// Arrange a service in a state where it has a per-session db-query
+			// server cached for the deleted session, so we can observe whether the
+			// handler ran by checking the cache state after the emit.
+			const sessionManager = {
+				getSessionAsync: mock(async () => null),
+				listSessions: mock(() => [] as Session[]),
+			} as unknown as SessionManager;
+
+			const daemonHub = await createTestDaemonHub('space-rts-test-deleted');
+			const svc = new SpaceRuntimeService({
+				db: {} as BunDatabase,
+				spaceManager: createMockSpaceManager(mockSpace),
+				spaceAgentManager: { listBySpaceId: mock(() => []) } as unknown as SpaceAgentManager,
+				spaceWorkflowManager: { listWorkflows: mock(() => []) } as unknown as SpaceWorkflowManager,
+				workflowRunRepo: {} as SpaceWorkflowRunRepository,
+				taskRepo: {} as SpaceTaskRepository,
+				tickIntervalMs: 60_000,
+				sessionManager,
+				daemonHub,
+			});
+
+			// Stub a db-query server entry so we can observe its removal as proof
+			// the session.deleted handler actually ran. Doing this via internals is
+			// the lightest-weight way; the production code paths that populate this
+			// map are integration-level (require a real db file).
+			const memberDbQueryServers = (
+				svc as unknown as {
+					memberSessionDbQueryServers: Map<string, { close: () => void }>;
+				}
+			).memberSessionDbQueryServers;
+			const closeMock = mock(() => {});
+			memberDbQueryServers.set('worker-session-uuid-456', { close: closeMock });
+
+			svc.start();
+
+			await daemonHub.emit('session.deleted', { sessionId: 'worker-session-uuid-456' });
+			await new Promise<void>((resolve) => setTimeout(resolve, 10));
+
+			// Handler ran → the cached server was closed and removed.
+			expect(closeMock).toHaveBeenCalledTimes(1);
+			expect(memberDbQueryServers.has('worker-session-uuid-456')).toBe(false);
+
+			await svc.stop();
+			await daemonHub.close();
 		});
 	});
 


### PR DESCRIPTION
`SpaceRuntimeService` subscribed to `session.created`/`session.deleted` with `{ sessionId: 'global' }`, but TypedHub stores that under the literal `'global'` key (not `'__global__'`) and its cross-transport hubHandler rejects events whose sessionId isn't `'global'` — and both events emit with the actual session UUID, so the handlers never fired and ad-hoc worker / coder / room_chat sessions inside a Space silently came up without `space-agent-tools` or `db-query`. Drop the filter so the subscriptions land under the GLOBAL_KEY and actually fire.