### PR TITLE
fix(daemon): make AskUserQuestion survive daemon restart and clean up dead sessions

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -658,13 +658,16 @@ export class AgentSession
 	 * idle. Called by reapers (force-completion, rehydrate failure) so the
 	 * UI removes the now-unanswerable question card.
 	 *
-	 * Returns true if a question was actually orphaned, false if the session
-	 * was not in `waiting_for_input`.
+	 * @param telemetryReason Annotates the `question.orphaned` daemonHub event
+	 *   only — the persisted `cancelReason` is hardcoded to
+	 *   `agent_session_terminated` (see `AskUserQuestionHandler.markQuestionOrphaned`).
+	 * @returns true if a question was actually orphaned, false if the session
+	 *   was not in `waiting_for_input`.
 	 */
 	async markPendingQuestionOrphaned(
-		reason: 'agent_session_terminated' | 'rehydrate_failed' = 'agent_session_terminated'
+		telemetryReason: 'agent_session_terminated' | 'rehydrate_failed' = 'agent_session_terminated'
 	): Promise<boolean> {
-		return this.askUserQuestionHandler.markQuestionOrphaned(reason);
+		return this.askUserQuestionHandler.markQuestionOrphaned(telemetryReason);
 	}
 
 	// ============================================================================

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -653,6 +653,20 @@ export class AgentSession
 		await this.askUserQuestionHandler.handleQuestionCancel(toolUseId);
 	}
 
+	/**
+	 * Mark any pending AskUserQuestion as orphaned and reset the session to
+	 * idle. Called by reapers (force-completion, rehydrate failure) so the
+	 * UI removes the now-unanswerable question card.
+	 *
+	 * Returns true if a question was actually orphaned, false if the session
+	 * was not in `waiting_for_input`.
+	 */
+	async markPendingQuestionOrphaned(
+		reason: 'agent_session_terminated' | 'rehydrate_failed' = 'agent_session_terminated'
+	): Promise<boolean> {
+		return this.askUserQuestionHandler.markQuestionOrphaned(reason);
+	}
+
 	// ============================================================================
 	// Model Switching
 	// ============================================================================

--- a/packages/daemon/src/lib/agent/ask-user-question-handler.ts
+++ b/packages/daemon/src/lib/agent/ask-user-question-handler.ts
@@ -13,14 +13,45 @@
  * 4. When user responds via RPC, resolves the Promise with formatted answers
  * 5. The SDK automatically continues with the answers
  *
+ * ## Restart-survival path (task #138)
+ *
+ * The in-memory `pendingResolver` is bound to the live SDK query process. When
+ * the daemon restarts, the SDK process dies and the resolver is gone — but the
+ * persisted `waiting_for_input` state still renders the question card in the
+ * UI. To make Submit/Skip work after a restart we maintain a `queuedAnswers`
+ * map keyed by toolUseId:
+ *
+ * - On user submit/cancel after restart (no resolver): we stash a
+ *   `PermissionResult` in `queuedAnswers`, transition out of
+ *   `waiting_for_input`, inject a synthetic user message containing a
+ *   `tool_result` block referencing the original `tool_use_id`, and trigger
+ *   `ensureQueryStarted()`. The SDK resumes the conversation with the answer
+ *   delivered as a normal `tool_result` user message.
+ * - On the chance the SDK re-issues the AskUserQuestion call after resume,
+ *   `createCanUseToolCallback` consults `queuedAnswers` first and returns the
+ *   queued result immediately without re-prompting the user.
+ *
+ * ## Orphan cleanup
+ *
+ * When a session is force-completed or fails to rehydrate while in
+ * `waiting_for_input`, `markQuestionOrphaned()` flips the question to a
+ * `cancelled` ResolvedQuestion with cancelReason `agent_session_terminated`.
+ * The UI renders these distinctly so the user knows why the card disappeared.
+ *
  * See: https://platform.claude.com/docs/en/agent-sdk/permissions#handling-the-askuserquestion-tool
  */
 
-import type { PendingUserQuestion, QuestionDraftResponse, Session } from '@neokai/shared';
+import type {
+	PendingUserQuestion,
+	QuestionCancelReason,
+	QuestionDraftResponse,
+	Session,
+} from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { Database } from '../../storage/database';
 import type { CanUseTool, PermissionResult } from '@anthropic-ai/claude-agent-sdk';
 import type { ProcessingStateManager } from './processing-state-manager';
+import type { MessageQueue } from './message-queue';
 import { Logger } from '../logger';
 
 /**
@@ -32,6 +63,14 @@ export interface AskUserQuestionHandlerContext {
 	readonly db: Database;
 	readonly stateManager: ProcessingStateManager;
 	readonly daemonHub: DaemonHub;
+	readonly messageQueue: MessageQueue;
+	/**
+	 * Ensure the SDK query is running so a queued tool_result can flow through
+	 * the streaming input pipeline. Implemented by AgentSession via
+	 * QueryLifecycleManager. Optional because legacy tests/contexts may not
+	 * provide it; callers must handle the absent case.
+	 */
+	ensureQueryStarted?(): Promise<void>;
 }
 
 /**
@@ -60,9 +99,23 @@ interface PendingQuestionResolver {
 	reject: (error: Error) => void;
 }
 
+/**
+ * Cancellation message delivered to the agent when the user clicks Skip.
+ * Exported so tests and other layers can assert on the exact wording.
+ */
+export const QUESTION_CANCEL_MESSAGE =
+	'User cancelled: The user chose not to answer this question. Please proceed accordingly or ask a different question if needed.';
+
 export class AskUserQuestionHandler {
 	private logger: Logger;
 	private pendingResolver: PendingQuestionResolver | null = null;
+	/**
+	 * Answers received via RPC after the in-memory resolver was lost (e.g.
+	 * daemon restart). Keyed by toolUseId. If the SDK re-issues the same
+	 * AskUserQuestion call after resume, `createCanUseToolCallback` consumes
+	 * the queued answer instead of re-prompting the user.
+	 */
+	private queuedAnswers: Map<string, PermissionResult> = new Map();
 
 	constructor(private ctx: AskUserQuestionHandlerContext) {
 		this.logger = new Logger(`AskUserQuestionHandler ${ctx.session.id}`);
@@ -93,6 +146,34 @@ export class AskUserQuestionHandler {
 			if (toolName !== 'AskUserQuestion') {
 				// Allow all other tools (they go through permission mode settings)
 				return { behavior: 'allow', updatedInput: input };
+			}
+
+			// Restart-survival fast path: if a queued answer is waiting for this
+			// toolUseId, resolve immediately and skip the user prompt entirely.
+			const queued = this.queuedAnswers.get(options.toolUseID);
+			if (queued) {
+				this.queuedAnswers.delete(options.toolUseID);
+				// If the queued PermissionResult was an `allow`, the SDK expects
+				// updatedInput to include the original input fields plus answers.
+				// Patch in any missing fields from the live `input` so we don't
+				// drop required schema fields just because the resolver was lost.
+				const merged: PermissionResult =
+					queued.behavior === 'allow'
+						? {
+								behavior: 'allow',
+								updatedInput: { ...input, ...queued.updatedInput },
+							}
+						: queued;
+				this.logger.info(
+					`AskUserQuestion ${options.toolUseID}: consuming queued answer (behavior=${queued.behavior})`
+				);
+				await daemonHub.emit('question.injected_as_tool_result', {
+					sessionId: session.id,
+					toolUseId: options.toolUseID,
+					mode: queued.behavior === 'allow' ? 'submitted' : 'cancelled',
+					viaCanUseTool: true,
+				});
+				return merged;
 			}
 
 			const askInput = input as unknown as AskUserQuestionInput;
@@ -159,12 +240,7 @@ export class AskUserQuestionHandler {
 			);
 		}
 
-		// Verify we have a pending resolver
-		if (!this.pendingResolver) {
-			throw new Error('No pending question to respond to');
-		}
-
-		// Verify the toolUseId matches (uses SDK's toolUseID)
+		// Verify the toolUseId matches the persisted question
 		if (currentState.pendingQuestion.toolUseId !== toolUseId) {
 			throw new Error(
 				`Tool use ID mismatch: expected ${currentState.pendingQuestion.toolUseId}, got ${toolUseId}`
@@ -176,38 +252,36 @@ export class AskUserQuestionHandler {
 
 		// Format the answers as expected by the SDK
 		// Maps question text to selected option label(s)
-		const answers: Record<string, string> = {};
-		for (const response of responses) {
-			const question = pendingQuestion.questions[response.questionIndex];
-			if (!question) continue;
+		const answers = this.buildAnswers(pendingQuestion, responses);
 
-			if (response.customText) {
-				// User provided custom text via "Other" option
-				answers[question.question] = response.customText;
-			} else if (response.selectedLabels.length > 0) {
-				// User selected one or more predefined options
-				// Multi-select answers are comma-separated
-				answers[question.question] = response.selectedLabels.join(', ');
-			}
-		}
-
-		// Transition back to processing state
-		await stateManager.setProcessing(toolUseId, 'streaming');
-
-		// Track resolved question in session metadata
+		// Track resolved question in session metadata. We do this BEFORE the
+		// state transition so the metadata is durable even if the deliver step
+		// throws midway.
 		this.trackResolvedQuestion(toolUseId, pendingQuestion, 'submitted', responses);
 
-		// Resolve the pending Promise with the answers
-		// This allows the SDK to continue with the user's input
-		const resolver = this.pendingResolver;
-		this.pendingResolver = null;
+		// Happy path: a live SDK query is awaiting our resolver — resolve in-memory.
+		if (this.pendingResolver && this.pendingResolver.toolUseId === toolUseId) {
+			// Transition back to processing state
+			await stateManager.setProcessing(toolUseId, 'streaming');
+			const resolver = this.pendingResolver;
+			this.pendingResolver = null;
+			resolver.resolve({
+				behavior: 'allow',
+				updatedInput: {
+					...resolver.input,
+					answers,
+				},
+			});
+			return;
+		}
 
-		resolver.resolve({
+		// Restart-survival path: the original resolver is gone (daemon restart,
+		// session cleanup, etc.). Queue the answer for the resumed SDK and
+		// inject a synthetic tool_result user message to drive the conversation
+		// forward.
+		await this.deliverQueuedAnswer(toolUseId, pendingQuestion, {
 			behavior: 'allow',
-			updatedInput: {
-				...resolver.input,
-				answers,
-			},
+			updatedInput: { answers },
 		});
 	}
 
@@ -228,11 +302,6 @@ export class AskUserQuestionHandler {
 			);
 		}
 
-		// Verify we have a pending resolver
-		if (!this.pendingResolver) {
-			throw new Error('No pending question to cancel');
-		}
-
 		// Verify the toolUseId matches
 		if (currentState.pendingQuestion.toolUseId !== toolUseId) {
 			throw new Error(
@@ -243,22 +312,208 @@ export class AskUserQuestionHandler {
 		// Capture the pending question before transitioning state
 		const pendingQuestion = currentState.pendingQuestion;
 
-		// Transition back to processing state
-		await stateManager.setProcessing(toolUseId, 'streaming');
+		// Track cancelled question in session metadata (user-initiated cancel)
+		this.trackResolvedQuestion(toolUseId, pendingQuestion, 'cancelled', [], 'user_cancelled');
 
-		// Track cancelled question in session metadata
-		this.trackResolvedQuestion(toolUseId, pendingQuestion, 'cancelled', []);
+		// Happy path: a live SDK query is awaiting our resolver.
+		if (this.pendingResolver && this.pendingResolver.toolUseId === toolUseId) {
+			await stateManager.setProcessing(toolUseId, 'streaming');
+			const resolver = this.pendingResolver;
+			this.pendingResolver = null;
+			resolver.resolve({
+				behavior: 'deny',
+				message: QUESTION_CANCEL_MESSAGE,
+			});
+			return;
+		}
 
-		// Resolve with a deny behavior
-		// This tells Claude the user declined to answer
-		const resolver = this.pendingResolver;
-		this.pendingResolver = null;
-
-		resolver.resolve({
+		// Restart-survival path: queue a deny + inject the cancellation message.
+		await this.deliverQueuedAnswer(toolUseId, pendingQuestion, {
 			behavior: 'deny',
-			message:
-				'User cancelled: The user chose not to answer this question. Please proceed accordingly or ask a different question if needed.',
+			message: QUESTION_CANCEL_MESSAGE,
 		});
+	}
+
+	/**
+	 * Mark a pending question as orphaned because the owning session is no
+	 * longer alive (force-completion, rehydrate failure, daemon shutdown, etc.).
+	 *
+	 * Idempotent: safe to call when the session is not in `waiting_for_input`
+	 * (returns false). The persisted question is flipped to a `cancelled`
+	 * ResolvedQuestion with cancelReason `agent_session_terminated` and the
+	 * processing state is reset to `idle` so the UI removes the dead-end card.
+	 *
+	 * @returns true if a question was actually orphaned, false if there was
+	 *   nothing to clean up.
+	 */
+	async markQuestionOrphaned(
+		reason: 'agent_session_terminated' | 'rehydrate_failed' = 'agent_session_terminated'
+	): Promise<boolean> {
+		const { stateManager, daemonHub, session } = this.ctx;
+		const currentState = stateManager.getState();
+		if (currentState.status !== 'waiting_for_input') {
+			return false;
+		}
+
+		const pendingQuestion = currentState.pendingQuestion;
+
+		// Track as cancelled with the orphan reason so the UI can render
+		// distinctly ("Question cancelled — agent session ended").
+		this.trackResolvedQuestion(
+			pendingQuestion.toolUseId,
+			pendingQuestion,
+			'cancelled',
+			[],
+			'agent_session_terminated'
+		);
+
+		// Reject any pending in-memory resolver so an awaiting SDK query (rare
+		// but possible) doesn't leak a hanging Promise.
+		if (this.pendingResolver) {
+			try {
+				this.pendingResolver.reject(new Error('Question orphaned: agent session ended'));
+			} catch {
+				// Ignore — best-effort cleanup
+			}
+			this.pendingResolver = null;
+		}
+		// Drop any queued answer for this question; nothing left to deliver to.
+		this.queuedAnswers.delete(pendingQuestion.toolUseId);
+
+		// Drop waiting_for_input state so the UI removes the live card. The
+		// resolved-question record persisted above is what the UI renders going
+		// forward.
+		await stateManager.setIdle();
+
+		await daemonHub.emit('question.orphaned', {
+			sessionId: session.id,
+			toolUseId: pendingQuestion.toolUseId,
+			reason,
+		});
+
+		this.logger.info(
+			`AskUserQuestion ${pendingQuestion.toolUseId} orphaned (reason=${reason}); UI card cleaned up`
+		);
+		return true;
+	}
+
+	/**
+	 * Build the answers map from the user's responses.
+	 * Maps question text → selected option label(s) or custom text.
+	 */
+	private buildAnswers(
+		pendingQuestion: PendingUserQuestion,
+		responses: QuestionDraftResponse[]
+	): Record<string, string> {
+		const answers: Record<string, string> = {};
+		for (const response of responses) {
+			const question = pendingQuestion.questions[response.questionIndex];
+			if (!question) continue;
+
+			if (response.customText) {
+				// User provided custom text via "Other" option
+				answers[question.question] = response.customText;
+			} else if (response.selectedLabels.length > 0) {
+				// User selected one or more predefined options
+				// Multi-select answers are comma-separated
+				answers[question.question] = response.selectedLabels.join(', ');
+			}
+		}
+		return answers;
+	}
+
+	/**
+	 * Restart-survival delivery: queue the answer for the resumed SDK and
+	 * inject a synthetic tool_result user message into the streaming queue so
+	 * the conversation moves forward even if the SDK does not re-issue the
+	 * canUseTool call.
+	 *
+	 * Both halves are intentionally redundant:
+	 * 1. `queuedAnswers` covers the case where the SDK re-plays the
+	 *    AskUserQuestion call (canUseTool consumes the queued answer).
+	 * 2. The injected `tool_result` user message covers the case where the SDK
+	 *    treats the prior tool_use as already-resolved and just needs the
+	 *    matching tool_result to continue the conversation cleanly.
+	 */
+	private async deliverQueuedAnswer(
+		toolUseId: string,
+		pendingQuestion: PendingUserQuestion,
+		result: PermissionResult
+	): Promise<void> {
+		const { stateManager, daemonHub, session, messageQueue, ensureQueryStarted } = this.ctx;
+
+		this.queuedAnswers.set(toolUseId, result);
+
+		// Drop waiting_for_input state — the question is resolved from the user's
+		// perspective. Going to idle (rather than processing) lets the SDK
+		// query restart cleanly via ensureQueryStarted().
+		await stateManager.setIdle();
+
+		// Build the tool_result content text. For `allow`, serialize the answers
+		// as JSON so the agent can parse them. For `deny`, use the cancellation
+		// message as the tool_result content (matches what the SDK would have
+		// produced in the live-resolver path).
+		const toolResultText =
+			result.behavior === 'allow'
+				? JSON.stringify({
+						answers:
+							(result.updatedInput as { answers?: Record<string, string> } | undefined)?.answers ??
+							{},
+					})
+				: result.message;
+
+		const mode: 'submitted' | 'cancelled' = result.behavior === 'allow' ? 'submitted' : 'cancelled';
+
+		await daemonHub.emit('question.injected_as_tool_result', {
+			sessionId: session.id,
+			toolUseId,
+			mode,
+			viaCanUseTool: false,
+		});
+
+		// Best-effort: start the SDK query and enqueue the tool_result. If the
+		// agent session has no ensureQueryStarted (e.g. a unit-test context),
+		// we still queue the answer for whenever the SDK eventually resumes.
+		if (!ensureQueryStarted) {
+			this.logger.warn(
+				`AskUserQuestion ${toolUseId}: no ensureQueryStarted on context; answer queued only`
+			);
+			return;
+		}
+
+		try {
+			await ensureQueryStarted();
+			// Inject as a tool_result content block. MessageQueue extracts
+			// `tool_use_id` from the block and forwards it as
+			// `parent_tool_use_id` on the SDK user message — that's the wire
+			// format the Anthropic API expects for a user→assistant tool reply.
+			//
+			// If the SDK has already moved past this tool_use (because the
+			// queued answer was consumed by canUseTool above), this message
+			// becomes a no-op text from the SDK's perspective.
+			await messageQueue.enqueueWithId(`question-${toolUseId}-${Date.now()}`, [
+				{
+					type: 'tool_result',
+					tool_use_id: toolUseId,
+					content: toolResultText,
+				},
+			]);
+		} catch (error) {
+			this.logger.error(
+				`AskUserQuestion ${toolUseId}: failed to inject tool_result after restart`,
+				error
+			);
+			// Leave the queued answer in place — a future canUseTool fire can
+			// still consume it. Do not rethrow; the user's RPC already
+			// succeeded from their perspective (the question is marked
+			// resolved and removed from the UI).
+		}
+
+		// Mention the toolUseId in the closing log so production traces can
+		// follow a single question end-to-end through restart.
+		this.logger.info(
+			`AskUserQuestion ${toolUseId}: queued ${result.behavior} answer + injected tool_result for ${pendingQuestion.questions.length} question(s)`
+		);
 	}
 
 	/**
@@ -270,7 +525,8 @@ export class AskUserQuestionHandler {
 		toolUseId: string,
 		pendingQuestion: PendingUserQuestion,
 		state: 'submitted' | 'cancelled',
-		responses: QuestionDraftResponse[]
+		responses: QuestionDraftResponse[],
+		cancelReason?: QuestionCancelReason
 	): void {
 		const { session, db } = this.ctx;
 
@@ -281,6 +537,7 @@ export class AskUserQuestionHandler {
 			state,
 			responses,
 			resolvedAt: Date.now(),
+			...(state === 'cancelled' && cancelReason ? { cancelReason } : {}),
 		};
 
 		// Update session metadata
@@ -301,12 +558,25 @@ export class AskUserQuestionHandler {
 	}
 
 	/**
-	 * Cleanup any pending resolvers (called during session cleanup)
+	 * Cleanup any pending resolvers (called during session cleanup).
+	 *
+	 * Note: this does NOT mark the persisted question as cancelled — callers
+	 * that want the UI card to update should invoke `markQuestionOrphaned`
+	 * first. `cleanup()` only releases in-memory references.
 	 */
 	cleanup(): void {
 		if (this.pendingResolver) {
 			this.pendingResolver.reject(new Error('Session cleanup'));
 			this.pendingResolver = null;
 		}
+		this.queuedAnswers.clear();
+	}
+
+	/**
+	 * Test-only: inspect the current queued-answer map.
+	 * Returns a shallow copy so callers cannot mutate handler internals.
+	 */
+	getQueuedAnswersForTesting(): Map<string, PermissionResult> {
+		return new Map(this.queuedAnswers);
 	}
 }

--- a/packages/daemon/src/lib/agent/ask-user-question-handler.ts
+++ b/packages/daemon/src/lib/agent/ask-user-question-handler.ts
@@ -340,14 +340,20 @@ export class AskUserQuestionHandler {
 	 *
 	 * Idempotent: safe to call when the session is not in `waiting_for_input`
 	 * (returns false). The persisted question is flipped to a `cancelled`
-	 * ResolvedQuestion with cancelReason `agent_session_terminated` and the
+	 * ResolvedQuestion with cancelReason `agent_session_terminated` (always —
+	 * the UI only renders one orphan-cancelled state today) and the
 	 * processing state is reset to `idle` so the UI removes the dead-end card.
 	 *
+	 * @param telemetryReason Annotates the `question.orphaned` daemonHub event
+	 *   only. Does NOT affect the persisted `cancelReason` on the resolved
+	 *   record — that's hardcoded to `agent_session_terminated` because the UI
+	 *   has no separate rendering for `rehydrate_failed`. If a future UX
+	 *   distinguishes the two, plumb this param through to `trackResolvedQuestion`.
 	 * @returns true if a question was actually orphaned, false if there was
 	 *   nothing to clean up.
 	 */
 	async markQuestionOrphaned(
-		reason: 'agent_session_terminated' | 'rehydrate_failed' = 'agent_session_terminated'
+		telemetryReason: 'agent_session_terminated' | 'rehydrate_failed' = 'agent_session_terminated'
 	): Promise<boolean> {
 		const { stateManager, daemonHub, session } = this.ctx;
 		const currentState = stateManager.getState();
@@ -357,8 +363,9 @@ export class AskUserQuestionHandler {
 
 		const pendingQuestion = currentState.pendingQuestion;
 
-		// Track as cancelled with the orphan reason so the UI can render
-		// distinctly ("Question cancelled — agent session ended").
+		// Track as cancelled. The persisted `cancelReason` is intentionally
+		// always `agent_session_terminated` — see JSDoc on `telemetryReason`
+		// for why we don't pass `telemetryReason` through here.
 		this.trackResolvedQuestion(
 			pendingQuestion.toolUseId,
 			pendingQuestion,
@@ -388,11 +395,11 @@ export class AskUserQuestionHandler {
 		await daemonHub.emit('question.orphaned', {
 			sessionId: session.id,
 			toolUseId: pendingQuestion.toolUseId,
-			reason,
+			reason: telemetryReason,
 		});
 
 		this.logger.info(
-			`AskUserQuestion ${pendingQuestion.toolUseId} orphaned (reason=${reason}); UI card cleaned up`
+			`AskUserQuestion ${pendingQuestion.toolUseId} orphaned (telemetryReason=${telemetryReason}); UI card cleaned up`
 		);
 		return true;
 	}
@@ -488,9 +495,14 @@ export class AskUserQuestionHandler {
 			// `parent_tool_use_id` on the SDK user message — that's the wire
 			// format the Anthropic API expects for a user→assistant tool reply.
 			//
-			// If the SDK has already moved past this tool_use (because the
-			// queued answer was consumed by canUseTool above), this message
-			// becomes a no-op text from the SDK's perspective.
+			// Redundancy note: if the resumed SDK query *also* re-fires
+			// canUseTool for the same `tool_use_id` (path A — queuedAnswers
+			// consumed), the SDK will see two responses for that tool_use:
+			// the canUseTool return and this enqueued tool_result. In
+			// practice the SDK we use treats the canUseTool response as
+			// authoritative and forwards the tool_result as a regular user
+			// message. We tolerate the duplicate rather than try to detect
+			// which path the SDK will pick before it picks one.
 			await messageQueue.enqueueWithId(`question-${toolUseId}-${Date.now()}`, [
 				{
 					type: 'tool_result',
@@ -573,8 +585,13 @@ export class AskUserQuestionHandler {
 	}
 
 	/**
-	 * Test-only: inspect the current queued-answer map.
-	 * Returns a shallow copy so callers cannot mutate handler internals.
+	 * Inspect the current queued-answer map.
+	 *
+	 * @internal Test-only inspector. Production code MUST NOT depend on this
+	 * — it bypasses the canUseTool delivery contract and is exposed solely so
+	 * unit tests can assert side-effects of `submitQuestionResponse` and
+	 * `cancelQuestion` along the post-restart path. Returns a shallow copy
+	 * so callers cannot mutate handler internals.
 	 */
 	getQueuedAnswersForTesting(): Map<string, PermissionResult> {
 		return new Map(this.queuedAnswers);

--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -114,6 +114,29 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 		sessionId: string;
 		pendingQuestion: PendingUserQuestion;
 	};
+	/**
+	 * Emitted when a pending question is cleaned up because its owning session
+	 * ended (force-completion, rehydrate failure, daemon shutdown). The card
+	 * is flipped to a `cancelled` ResolvedQuestion with cancelReason
+	 * `agent_session_terminated` so the UI can render it distinctly.
+	 */
+	'question.orphaned': {
+		sessionId: string;
+		toolUseId: string;
+		reason: 'agent_session_terminated' | 'rehydrate_failed';
+	};
+	/**
+	 * Emitted when an AskUserQuestion answer is delivered after the original
+	 * canUseTool resolver was lost (e.g. daemon restart). Helps verify the
+	 * restart-survival path works in production.
+	 */
+	'question.injected_as_tool_result': {
+		sessionId: string;
+		toolUseId: string;
+		mode: 'submitted' | 'cancelled';
+		/** True when the queued answer was consumed by a re-played canUseTool call. */
+		viaCanUseTool: boolean;
+	};
 
 	// User message processing events (3-layer communication pattern)
 	'userMessage.persisted': {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1581,6 +1581,24 @@ export class SpaceRuntime {
 				const crashCount = (this.taskCrashCounts.get(crashKey) ?? 0) + 1;
 				this.taskCrashCounts.set(crashKey, crashCount);
 
+				// Part C (task #138): if the dead session was sitting in
+				// `waiting_for_input`, the persisted AskUserQuestion card is now
+				// unanswerable. Try to flip it to `cancelled` (cancelReason
+				// `agent_session_terminated`) so the UI removes the dead-end
+				// rather than rendering a permanently-frozen card. Best-effort:
+				// the AgentSession instance may already be gone from every map.
+				try {
+					const liveSession = tam.getAgentSessionById(execution.agentSessionId);
+					if (liveSession) {
+						await liveSession.markPendingQuestionOrphaned('agent_session_terminated');
+					}
+				} catch (err) {
+					log.warn(
+						`SpaceRuntime: failed to clean up pending question for crashed session ${execution.agentSessionId}:`,
+						err
+					);
+				}
+
 				if (crashCount <= MAX_TASK_AGENT_CRASH_RETRIES) {
 					log.warn(
 						`SpaceRuntime: workflow node agent crashed for execution ${execution.id} ` +
@@ -1650,7 +1668,14 @@ export class SpaceRuntime {
 
 			// Step 1.5: Auto-complete alive agents that have exceeded their timeout.
 			// Transitions to 'idle' — the same state as a naturally completing session.
+			//
+			// Part D (task #138): a session in `waiting_for_input` is *legitimately*
+			// blocked on a human, not stuck. Force-completing it here turns the
+			// pending AskUserQuestion card into a dead-end (Submit/Skip have no
+			// resolver to wake) and confuses the user. Skip those sessions; the
+			// long-term fix (Tier 0) removes Step 1.5 entirely.
 			let autoCompleted = 0;
+			let skippedWaitingForInput = 0;
 			const now = Date.now();
 			for (const execution of nodeExecutions) {
 				if (execution.status !== 'in_progress' || !execution.agentSessionId) continue;
@@ -1662,7 +1687,32 @@ export class SpaceRuntime {
 				const elapsedMs = now - referenceTime;
 				if (elapsedMs <= timeoutMs) continue;
 
+				// Part D guard: spare sessions waiting for user input. The agent is
+				// not stuck — a human is.
+				const liveSession = tam.getAgentSessionById(execution.agentSessionId);
+				if (liveSession?.getProcessingState().status === 'waiting_for_input') {
+					skippedWaitingForInput++;
+					continue;
+				}
+
 				const timeoutMinutes = Math.round(timeoutMs / 60_000);
+
+				// Part C: if (somehow) we're force-completing a session that *is*
+				// in waiting_for_input despite the guard above (e.g. state changed
+				// between checks), clear the orphaned question first so the UI
+				// doesn't render a card whose resolver no longer exists. Best-
+				// effort — never let cleanup failure block the auto-complete.
+				if (liveSession) {
+					try {
+						await liveSession.markPendingQuestionOrphaned('agent_session_terminated');
+					} catch (err) {
+						log.warn(
+							`SpaceRuntime: failed to clean up pending question for session ${execution.agentSessionId}:`,
+							err
+						);
+					}
+				}
+
 				this.config.nodeExecutionRepo.update(execution.id, {
 					status: 'idle',
 					result: `Auto-completed: agent timed out after ${timeoutMinutes} minutes`,
@@ -1679,6 +1729,11 @@ export class SpaceRuntime {
 			if (autoCompleted > 0) {
 				log.warn(
 					`SpaceRuntime: auto-completed ${autoCompleted} stuck node agent(s) for run ${runId}`
+				);
+			}
+			if (skippedWaitingForInput > 0) {
+				log.info(
+					`SpaceRuntime: spared ${skippedWaitingForInput} node agent(s) blocked on waiting_for_input for run ${runId}`
 				);
 			}
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1697,11 +1697,14 @@ export class SpaceRuntime {
 
 				const timeoutMinutes = Math.round(timeoutMs / 60_000);
 
-				// Part C: if (somehow) we're force-completing a session that *is*
-				// in waiting_for_input despite the guard above (e.g. state changed
-				// between checks), clear the orphaned question first so the UI
-				// doesn't render a card whose resolver no longer exists. Best-
-				// effort — never let cleanup failure block the auto-complete.
+				// Defensive Part C call: the Part D guard above already skips
+				// `waiting_for_input` sessions, so by construction this code only
+				// runs for sessions that are NOT in `waiting_for_input` — and
+				// `markPendingQuestionOrphaned` is a no-op (returns false) for
+				// those. We keep the call as belt-and-braces against a future
+				// refactor that loosens the guard or introduces an `await`
+				// between the guard and this point. Best-effort: never let
+				// cleanup failure block the auto-complete.
 				if (liveSession) {
 					try {
 						await liveSession.markPendingQuestionOrphaned('agent_session_terminated');

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -2013,6 +2013,29 @@ export class TaskAgentManager {
 		return undefined;
 	}
 
+	/**
+	 * Look up an AgentSession by its session ID across every in-memory map this
+	 * manager owns. Used by reapers (e.g. SpaceRuntime force-completion) that
+	 * have only the session ID and need to inspect/mutate the session before
+	 * reaping it (e.g. clear an orphaned AskUserQuestion card).
+	 *
+	 * Mirrors the lookup order in `isSessionAlive`: reverse index first, then
+	 * task agent map, then SessionManager. Returns undefined for ghost
+	 * session IDs that have no live AgentSession instance.
+	 */
+	getAgentSessionById(sessionId: string): AgentSession | undefined {
+		const indexed = this.agentSessionIndex.get(sessionId);
+		if (indexed) return indexed;
+
+		for (const taskAgent of this.taskAgentSessions.values()) {
+			if (taskAgent.session.id === sessionId) return taskAgent;
+		}
+
+		// SessionManager returns null for unknown sessions; normalize to undefined
+		// so the return contract stays uniform.
+		return this.config.sessionManager.getSession(sessionId) ?? undefined;
+	}
+
 	// -------------------------------------------------------------------------
 	// Public — cleanup
 	// -------------------------------------------------------------------------

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -2019,9 +2019,32 @@ export class TaskAgentManager {
 	 * have only the session ID and need to inspect/mutate the session before
 	 * reaping it (e.g. clear an orphaned AskUserQuestion card).
 	 *
-	 * Mirrors the lookup order in `isSessionAlive`: reverse index first, then
-	 * task agent map, then SessionManager. Returns undefined for ghost
-	 * session IDs that have no live AgentSession instance.
+	 * Lookup order (mirrors `isSessionAlive`):
+	 *  1. `agentSessionIndex` (fast reverse index for sub-sessions)
+	 *  2. `taskAgentSessions` map (Task Agents)
+	 *  3. `SessionManager.getSession()` (general session cache)
+	 *
+	 * Step 3 may **lazy-hydrate** an AgentSession from the database if it's
+	 * not currently in any in-memory map — this is intentional, because:
+	 *
+	 *  - The hydrated `AgentSession` constructor calls
+	 *    `ProcessingStateManager.restoreFromDatabase()`, which preserves
+	 *    `waiting_for_input` state across daemon restarts (see
+	 *    `processing-state-manager.ts:62-65`). So `getProcessingState()`
+	 *    on a hydrated session returns the *persisted* status, not `idle`.
+	 *  - The Step 1.5 "spare waiting_for_input" guard relies on this
+	 *    lazy hydration: after a daemon restart, before any explicit
+	 *    rehydrate path runs, this lookup is what the runtime uses to
+	 *    detect that a session is still waiting on the user.
+	 *
+	 * Caveat: hydration *does* have side effects (event subscriptions,
+	 * orphaned-message recovery, cache insertion). In practice this is
+	 * fine because callers reach this method only after `isSessionAlive`
+	 * has already triggered the same lookup, so hydration happens at most
+	 * once per session per tick.
+	 *
+	 * Returns undefined when the session is not in memory and either does
+	 * not exist in the DB or fails to load.
 	 */
 	getAgentSessionById(sessionId: string): AgentSession | undefined {
 		const indexed = this.agentSessionIndex.get(sessionId);
@@ -2031,7 +2054,8 @@ export class TaskAgentManager {
 			if (taskAgent.session.id === sessionId) return taskAgent;
 		}
 
-		// SessionManager returns null for unknown sessions; normalize to undefined
+		// SessionManager.getSession may hydrate a fresh AgentSession from DB;
+		// that's intentional — see method JSDoc for why. Normalize null → undefined
 		// so the return contract stays uniform.
 		return this.config.sessionManager.getSession(sessionId) ?? undefined;
 	}

--- a/packages/daemon/tests/unit/1-core/agent/ask-user-question-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/ask-user-question-handler.test.ts
@@ -283,6 +283,49 @@ describe('AskUserQuestionHandler', () => {
 			);
 		});
 
+		it('queues the answer but does NOT call enqueueWithId when ensureQueryStarted is missing', async () => {
+			// Some unit-test contexts (and a few legacy code paths) construct the
+			// handler without an `ensureQueryStarted` on the context. Verify the
+			// post-restart delivery path falls back to queue-only without calling
+			// MessageQueue.enqueueWithId — a future canUseTool fire can still
+			// consume the queued answer.
+			const handlerNoStart = new AskUserQuestionHandler({
+				...mockContext,
+				ensureQueryStarted: undefined,
+			});
+
+			const pendingQuestion: PendingUserQuestion = {
+				toolUseId: 'tool-no-start',
+				questions: [
+					{
+						question: 'Pick?',
+						header: 'P',
+						options: [{ label: 'A', description: 'A' }],
+						multiSelect: false,
+					},
+				],
+				askedAt: Date.now(),
+			};
+			currentState = { status: 'waiting_for_input', pendingQuestion };
+
+			await handlerNoStart.handleQuestionResponse('tool-no-start', [
+				{ questionIndex: 0, selectedLabels: ['A'] },
+			]);
+
+			// Answer is queued for a future canUseTool fire
+			const queued = handlerNoStart.getQueuedAnswersForTesting();
+			expect(queued.has('tool-no-start')).toBe(true);
+			expect(queued.get('tool-no-start')!.behavior).toBe('allow');
+
+			// State dropped from waiting_for_input
+			expect(setIdleSpy).toHaveBeenCalled();
+
+			// But: no SDK injection — the warn path returns before
+			// enqueueWithId / ensureQueryStarted are touched.
+			expect(enqueueWithIdSpy).not.toHaveBeenCalled();
+			expect(ensureQueryStartedSpy).not.toHaveBeenCalled();
+		});
+
 		it('should throw on toolUseId mismatch', async () => {
 			const callback = handler.createCanUseToolCallback();
 

--- a/packages/daemon/tests/unit/1-core/agent/ask-user-question-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/ask-user-question-handler.test.ts
@@ -12,6 +12,7 @@ import {
 import type { ProcessingStateManager } from '../../../../src/lib/agent/processing-state-manager';
 import type { DaemonHub } from '../../../../src/lib/daemon-hub';
 import type { Database } from '../../../../src/storage/database';
+import type { MessageQueue } from '../../../../src/lib/agent/message-queue';
 import type { PendingUserQuestion, AgentProcessingState, Session } from '@neokai/shared';
 import { generateUUID } from '@neokai/shared';
 
@@ -20,16 +21,21 @@ describe('AskUserQuestionHandler', () => {
 	let mockStateManager: ProcessingStateManager;
 	let mockDaemonHub: DaemonHub;
 	let mockDb: Database;
+	let mockMessageQueue: MessageQueue;
 	let mockContext: AskUserQuestionHandlerContext;
 	let emitSpy: ReturnType<typeof mock>;
 	let setWaitingForInputSpy: ReturnType<typeof mock>;
 	let setProcessingSpy: ReturnType<typeof mock>;
+	let setIdleSpy: ReturnType<typeof mock>;
 	let getStateSpy: ReturnType<typeof mock>;
 	let updateQuestionDraftSpy: ReturnType<typeof mock>;
 	let updateSessionSpy: ReturnType<typeof mock>;
+	let enqueueWithIdSpy: ReturnType<typeof mock>;
+	let ensureQueryStartedSpy: ReturnType<typeof mock>;
 	const testSessionId = generateUUID();
 
 	let currentState: AgentProcessingState;
+	let mockSession: Session;
 
 	beforeEach(() => {
 		currentState = { status: 'idle' };
@@ -51,12 +57,16 @@ describe('AskUserQuestionHandler', () => {
 				phase: 'streaming',
 			};
 		});
+		setIdleSpy = mock(async () => {
+			currentState = { status: 'idle' };
+		});
 		getStateSpy = mock(() => currentState);
 		updateQuestionDraftSpy = mock(async () => {});
 
 		mockStateManager = {
 			setWaitingForInput: setWaitingForInputSpy,
 			setProcessing: setProcessingSpy,
+			setIdle: setIdleSpy,
 			getState: getStateSpy,
 			updateQuestionDraft: updateQuestionDraftSpy,
 		} as unknown as ProcessingStateManager;
@@ -67,8 +77,14 @@ describe('AskUserQuestionHandler', () => {
 			updateSession: updateSessionSpy,
 		} as unknown as Database;
 
+		// Create mock MessageQueue
+		enqueueWithIdSpy = mock(async () => {});
+		mockMessageQueue = {
+			enqueueWithId: enqueueWithIdSpy,
+		} as unknown as MessageQueue;
+
 		// Create mock session
-		const mockSession: Session = {
+		mockSession = {
 			id: testSessionId,
 			title: 'Test Session',
 			workspacePath: '/test/workspace',
@@ -79,12 +95,16 @@ describe('AskUserQuestionHandler', () => {
 			metadata: {},
 		};
 
+		ensureQueryStartedSpy = mock(async () => {});
+
 		// Create context
 		mockContext = {
 			session: mockSession,
 			db: mockDb,
 			stateManager: mockStateManager,
 			daemonHub: mockDaemonHub,
+			messageQueue: mockMessageQueue,
+			ensureQueryStarted: ensureQueryStartedSpy,
 		};
 
 		handler = new AskUserQuestionHandler(mockContext);
@@ -198,14 +218,19 @@ describe('AskUserQuestionHandler', () => {
 			).rejects.toThrow('agent is not waiting for input');
 		});
 
-		it('should throw when no pending resolver', async () => {
+		it('should queue answer + inject tool_result when no pending resolver (post-restart)', async () => {
+			// Simulate persisted waiting_for_input state with no in-memory resolver
+			// (this is the post-restart scenario — task #138).
 			const pendingQuestion: PendingUserQuestion = {
 				toolUseId: 'tool-123',
 				questions: [
 					{
-						question: 'Test?',
-						header: 'Test',
-						options: [{ label: 'A', description: 'A' }],
+						question: 'What do you want?',
+						header: 'Choice',
+						options: [
+							{ label: 'A', description: 'A' },
+							{ label: 'B', description: 'B' },
+						],
 						multiSelect: false,
 					},
 				],
@@ -213,9 +238,49 @@ describe('AskUserQuestionHandler', () => {
 			};
 			currentState = { status: 'waiting_for_input', pendingQuestion };
 
-			await expect(
-				handler.handleQuestionResponse('tool-123', [{ questionIndex: 0, selectedLabels: ['A'] }])
-			).rejects.toThrow('No pending question');
+			await handler.handleQuestionResponse('tool-123', [
+				{ questionIndex: 0, selectedLabels: ['A'] },
+			]);
+
+			// Should mark resolved-question metadata (submitted)
+			expect(updateSessionSpy).toHaveBeenCalled();
+			const updateCall = updateSessionSpy.mock.calls[0];
+			expect(updateCall[1].metadata.resolvedQuestions['tool-123'].state).toBe('submitted');
+
+			// Should drop waiting_for_input via setIdle (NOT setProcessing — let
+			// ensureQueryStarted resume cleanly).
+			expect(setIdleSpy).toHaveBeenCalled();
+			expect(setProcessingSpy).not.toHaveBeenCalled();
+
+			// Should queue the answer for canUseTool re-fire
+			const queued = handler.getQueuedAnswersForTesting();
+			expect(queued.has('tool-123')).toBe(true);
+			expect(queued.get('tool-123')!.behavior).toBe('allow');
+
+			// Should inject tool_result into the message queue
+			expect(enqueueWithIdSpy).toHaveBeenCalled();
+			const enqueueCall = enqueueWithIdSpy.mock.calls[0];
+			expect(enqueueCall[1]).toEqual([
+				expect.objectContaining({
+					type: 'tool_result',
+					tool_use_id: 'tool-123',
+					content: expect.stringContaining('A'),
+				}),
+			]);
+
+			// Should restart the query
+			expect(ensureQueryStartedSpy).toHaveBeenCalled();
+
+			// Should emit injected_as_tool_result telemetry
+			expect(emitSpy).toHaveBeenCalledWith(
+				'question.injected_as_tool_result',
+				expect.objectContaining({
+					sessionId: testSessionId,
+					toolUseId: 'tool-123',
+					mode: 'submitted',
+					viaCanUseTool: false,
+				})
+			);
 		});
 
 		it('should throw on toolUseId mismatch', async () => {
@@ -484,7 +549,9 @@ describe('AskUserQuestionHandler', () => {
 			);
 		});
 
-		it('should throw when no pending resolver', async () => {
+		it('should queue deny + inject cancellation tool_result when no pending resolver', async () => {
+			// Same post-restart scenario as the response test, but for the cancel
+			// (Skip) path.
 			const pendingQuestion: PendingUserQuestion = {
 				toolUseId: 'tool-123',
 				questions: [
@@ -499,8 +566,29 @@ describe('AskUserQuestionHandler', () => {
 			};
 			currentState = { status: 'waiting_for_input', pendingQuestion };
 
-			await expect(handler.handleQuestionCancel('tool-123')).rejects.toThrow(
-				'No pending question to cancel'
+			await handler.handleQuestionCancel('tool-123');
+
+			expect(updateSessionSpy).toHaveBeenCalled();
+			const updateCall = updateSessionSpy.mock.calls[0];
+			expect(updateCall[1].metadata.resolvedQuestions['tool-123'].state).toBe('cancelled');
+			expect(updateCall[1].metadata.resolvedQuestions['tool-123'].cancelReason).toBe(
+				'user_cancelled'
+			);
+
+			expect(setIdleSpy).toHaveBeenCalled();
+
+			const queued = handler.getQueuedAnswersForTesting();
+			expect(queued.has('tool-123')).toBe(true);
+			expect(queued.get('tool-123')!.behavior).toBe('deny');
+
+			expect(enqueueWithIdSpy).toHaveBeenCalled();
+			expect(ensureQueryStartedSpy).toHaveBeenCalled();
+			expect(emitSpy).toHaveBeenCalledWith(
+				'question.injected_as_tool_result',
+				expect.objectContaining({
+					mode: 'cancelled',
+					viaCanUseTool: false,
+				})
 			);
 		});
 
@@ -679,6 +767,206 @@ describe('AskUserQuestionHandler', () => {
 		it('should be safe to call cleanup when no pending resolver', () => {
 			// Should not throw
 			expect(() => handler.cleanup()).not.toThrow();
+		});
+	});
+
+	describe('markQuestionOrphaned', () => {
+		it('returns false when no question is pending', async () => {
+			currentState = { status: 'idle' };
+			const result = await handler.markQuestionOrphaned();
+			expect(result).toBe(false);
+			expect(emitSpy).not.toHaveBeenCalledWith('question.orphaned', expect.any(Object));
+		});
+
+		it('flips waiting_for_input to cancelled with agent_session_terminated reason', async () => {
+			const pendingQuestion: PendingUserQuestion = {
+				toolUseId: 'orphan-tool-1',
+				questions: [
+					{
+						question: 'Pending?',
+						header: 'Pending',
+						options: [{ label: 'A', description: 'A' }],
+						multiSelect: false,
+					},
+				],
+				askedAt: Date.now(),
+			};
+			currentState = { status: 'waiting_for_input', pendingQuestion };
+
+			const result = await handler.markQuestionOrphaned('agent_session_terminated');
+			expect(result).toBe(true);
+
+			// Persisted as cancelled with the right reason
+			expect(updateSessionSpy).toHaveBeenCalled();
+			const updateCall = updateSessionSpy.mock.calls[0];
+			expect(updateCall[1].metadata.resolvedQuestions['orphan-tool-1'].state).toBe('cancelled');
+			expect(updateCall[1].metadata.resolvedQuestions['orphan-tool-1'].cancelReason).toBe(
+				'agent_session_terminated'
+			);
+
+			// Drops waiting_for_input
+			expect(setIdleSpy).toHaveBeenCalled();
+
+			// Telemetry
+			expect(emitSpy).toHaveBeenCalledWith(
+				'question.orphaned',
+				expect.objectContaining({
+					sessionId: testSessionId,
+					toolUseId: 'orphan-tool-1',
+					reason: 'agent_session_terminated',
+				})
+			);
+		});
+
+		it('records rehydrate_failed reason when passed', async () => {
+			const pendingQuestion: PendingUserQuestion = {
+				toolUseId: 'orphan-tool-2',
+				questions: [
+					{
+						question: '?',
+						header: 'X',
+						options: [{ label: 'A', description: 'A' }],
+						multiSelect: false,
+					},
+				],
+				askedAt: Date.now(),
+			};
+			currentState = { status: 'waiting_for_input', pendingQuestion };
+
+			await handler.markQuestionOrphaned('rehydrate_failed');
+
+			const updateCall = updateSessionSpy.mock.calls[0];
+			expect(updateCall[1].metadata.resolvedQuestions['orphan-tool-2'].cancelReason).toBe(
+				'agent_session_terminated'
+			);
+			// Note: persisted reason is always agent_session_terminated for the UI;
+			// the telemetry event carries the more granular reason.
+			expect(emitSpy).toHaveBeenCalledWith(
+				'question.orphaned',
+				expect.objectContaining({ reason: 'rehydrate_failed' })
+			);
+		});
+
+		it('clears any queued answers and rejects in-memory resolvers', async () => {
+			const callback = handler.createCanUseToolCallback();
+			const input = {
+				questions: [
+					{
+						question: 'Test?',
+						header: 'T',
+						options: [
+							{ label: 'A', description: 'A' },
+							{ label: 'B', description: 'B' },
+						],
+						multiSelect: false,
+					},
+				],
+			};
+			const resultPromise = callback('AskUserQuestion', input, {
+				signal: new AbortController().signal,
+				toolUseID: 'orphan-with-resolver',
+			});
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			// Force-orphan while resolver is live
+			await handler.markQuestionOrphaned('agent_session_terminated');
+
+			// Live SDK promise should reject
+			await expect(resultPromise).rejects.toThrow(/orphaned/i);
+
+			// queuedAnswers map should be empty for that toolUseId
+			expect(handler.getQueuedAnswersForTesting().has('orphan-with-resolver')).toBe(false);
+		});
+	});
+
+	describe('createCanUseToolCallback queued-answer fast path', () => {
+		it('consumes a queued allow without re-prompting and emits viaCanUseTool=true', async () => {
+			// Pre-populate the queued-answer map by simulating a post-restart
+			// handleQuestionResponse that ran before the SDK re-issued the
+			// AskUserQuestion call.
+			const pendingQuestion: PendingUserQuestion = {
+				toolUseId: 'replay-tool',
+				questions: [
+					{
+						question: 'Pick?',
+						header: 'P',
+						options: [{ label: 'A', description: 'A' }],
+						multiSelect: false,
+					},
+				],
+				askedAt: Date.now(),
+			};
+			currentState = { status: 'waiting_for_input', pendingQuestion };
+
+			await handler.handleQuestionResponse('replay-tool', [
+				{ questionIndex: 0, selectedLabels: ['A'] },
+			]);
+
+			// SDK now re-issues the canUseTool call (post-restart replay).
+			currentState = { status: 'idle' };
+			emitSpy.mockClear();
+			setWaitingForInputSpy.mockClear();
+
+			const callback = handler.createCanUseToolCallback();
+			const result = await callback(
+				'AskUserQuestion',
+				{ questions: pendingQuestion.questions },
+				{ signal: new AbortController().signal, toolUseID: 'replay-tool' }
+			);
+
+			// Should not re-transition to waiting_for_input
+			expect(setWaitingForInputSpy).not.toHaveBeenCalled();
+
+			// Should resolve immediately with the queued allow result
+			expect(result.behavior).toBe('allow');
+			expect(
+				(result as { updatedInput: { answers: Record<string, string> } }).updatedInput.answers
+			).toEqual({ 'Pick?': 'A' });
+
+			// Telemetry should record viaCanUseTool=true on consume
+			expect(emitSpy).toHaveBeenCalledWith(
+				'question.injected_as_tool_result',
+				expect.objectContaining({
+					toolUseId: 'replay-tool',
+					mode: 'submitted',
+					viaCanUseTool: true,
+				})
+			);
+
+			// Queue should now be empty for that toolUseId
+			expect(handler.getQueuedAnswersForTesting().has('replay-tool')).toBe(false);
+		});
+
+		it('consumes a queued deny without re-prompting', async () => {
+			const pendingQuestion: PendingUserQuestion = {
+				toolUseId: 'replay-cancel',
+				questions: [
+					{
+						question: 'Skip?',
+						header: 'S',
+						options: [{ label: 'A', description: 'A' }],
+						multiSelect: false,
+					},
+				],
+				askedAt: Date.now(),
+			};
+			currentState = { status: 'waiting_for_input', pendingQuestion };
+
+			await handler.handleQuestionCancel('replay-cancel');
+
+			currentState = { status: 'idle' };
+			setWaitingForInputSpy.mockClear();
+
+			const callback = handler.createCanUseToolCallback();
+			const result = await callback(
+				'AskUserQuestion',
+				{ questions: pendingQuestion.questions },
+				{ signal: new AbortController().signal, toolUseID: 'replay-cancel' }
+			);
+
+			expect(setWaitingForInputSpy).not.toHaveBeenCalled();
+			expect(result.behavior).toBe('deny');
+			expect((result as { message: string }).message).toMatch(/cancel/i);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-orphan-question.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-orphan-question.test.ts
@@ -1,0 +1,321 @@
+/**
+ * SpaceRuntime — Orphaned-question cleanup tests (Task #138)
+ *
+ * Covers two related guarantees that protect users from a "dead-end" question
+ * card after the runtime force-completes or blocks a session that was sitting
+ * in `waiting_for_input`:
+ *
+ *   1. Step 1.5 force-idle SPARES sessions in `waiting_for_input` — the
+ *      session is not stuck (a human is), so we leave it alone. (Part D)
+ *
+ *   2. When Step 1 (liveness check) decides to reset/block a node-execution,
+ *      we call `markPendingQuestionOrphaned('agent_session_terminated')` on
+ *      the live AgentSession before tearing it down. (Part C)
+ *
+ * The tests exercise the runtime through `processRunTick`-style flows with a
+ * mock TaskAgentManager whose `getAgentSessionById` returns a stub that
+ * tracks calls to `getProcessingState` / `markPendingQuestionOrphaned`.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
+import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
+import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
+import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
+import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
+import { SpaceRuntime } from '../../../../src/lib/space/runtime/space-runtime.ts';
+import type { SpaceRuntimeConfig } from '../../../../src/lib/space/runtime/space-runtime.ts';
+import type { SpaceWorkflow, AgentProcessingState } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// DB / seed helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(): BunDatabase {
+	const db = new BunDatabase(':memory:');
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	return db;
+}
+
+function seedSpaceRow(db: BunDatabase, spaceId: string, workspacePath = '/tmp/ws'): void {
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+     allowed_models, session_ids, slug, status, created_at, updated_at)
+     VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, workspacePath, `Space ${spaceId}`, spaceId, Date.now(), Date.now());
+}
+
+function seedAgentRow(db: BunDatabase, agentId: string, spaceId: string): void {
+	db.prepare(
+		`INSERT INTO space_agents (id, space_id, name, description, model, tools, system_prompt, created_at, updated_at)
+     VALUES (?, ?, ?, '', null, '[]', '', ?, ?)`
+	).run(agentId, spaceId, `Agent ${agentId}`, Date.now(), Date.now());
+}
+
+function buildLinearWorkflow(
+	spaceId: string,
+	workflowManager: SpaceWorkflowManager,
+	nodes: Array<{ id: string; name: string; agentId: string }>
+): SpaceWorkflow {
+	const transitions = nodes.slice(0, -1).map((step, i) => ({
+		from: step.id,
+		to: nodes[i + 1].id,
+		condition: { type: 'always' as const },
+		order: 0,
+	}));
+	return workflowManager.createWorkflow({
+		spaceId,
+		name: `Workflow-${Date.now()}-${Math.random()}`,
+		description: 'Test',
+		nodes,
+		transitions,
+		startNodeId: nodes[0].id,
+		rules: [],
+		tags: [],
+		completionAutonomyLevel: 3,
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Mock AgentSession stub
+// ---------------------------------------------------------------------------
+
+interface AgentSessionStub {
+	getProcessingState(): AgentProcessingState;
+	markPendingQuestionOrphaned: (
+		reason: 'agent_session_terminated' | 'rehydrate_failed'
+	) => Promise<boolean>;
+	_orphanCalls: Array<'agent_session_terminated' | 'rehydrate_failed'>;
+}
+
+function makeAgentSessionStub(state: AgentProcessingState): AgentSessionStub {
+	const orphanCalls: Array<'agent_session_terminated' | 'rehydrate_failed'> = [];
+	return {
+		getProcessingState: () => state,
+		markPendingQuestionOrphaned: async (reason) => {
+			orphanCalls.push(reason);
+			return true;
+		},
+		_orphanCalls: orphanCalls,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Mock TaskAgentManager
+// ---------------------------------------------------------------------------
+
+function makeMockTaskAgentManager(opts: {
+	aliveSessions?: Set<string>;
+	sessionStubs?: Map<string, AgentSessionStub>;
+}) {
+	return {
+		isSpawning: () => false,
+		isTaskAgentAlive: () => false,
+		isExecutionSpawning: () => false,
+		isSessionAlive: (sessionId: string) => opts.aliveSessions?.has(sessionId) ?? false,
+		spawnWorkflowNodeAgent: async () => 'unused',
+		spawnWorkflowNodeAgentForExecution: async () => 'unused',
+		rehydrate: async () => {},
+		cancelBySessionId: () => {},
+		interruptBySessionId: async () => {},
+		getAgentSessionById: (sessionId: string) => opts.sessionStubs?.get(sessionId) ?? null,
+		injectIntoTaskAgent: async () => ({ injected: false, reason: 'no-session' }),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SpaceRuntime — orphaned-question cleanup (Task #138)', () => {
+	let db: BunDatabase;
+	let workflowRunRepo: SpaceWorkflowRunRepository;
+	let taskRepo: SpaceTaskRepository;
+	let agentManager: SpaceAgentManager;
+	let workflowManager: SpaceWorkflowManager;
+	let spaceManager: SpaceManager;
+	let nodeExecutionRepo: NodeExecutionRepository;
+
+	const SPACE_ID = 'space-orphan-1';
+	const AGENT = 'agent-orphan-1';
+	const STEP_A = 'step-a';
+
+	function buildConfig(tam: ReturnType<typeof makeMockTaskAgentManager>): SpaceRuntimeConfig {
+		return {
+			db,
+			spaceManager,
+			spaceAgentManager: agentManager,
+			spaceWorkflowManager: workflowManager,
+			workflowRunRepo,
+			taskRepo,
+			nodeExecutionRepo,
+			taskAgentManager: tam as never,
+		};
+	}
+
+	beforeEach(() => {
+		db = makeDb();
+		seedSpaceRow(db, SPACE_ID);
+		seedAgentRow(db, AGENT, SPACE_ID);
+
+		workflowRunRepo = new SpaceWorkflowRunRepository(db);
+		taskRepo = new SpaceTaskRepository(db);
+		const agentRepo = new SpaceAgentRepository(db);
+		agentManager = new SpaceAgentManager(agentRepo);
+		const workflowRepo = new SpaceWorkflowRepository(db);
+		workflowManager = new SpaceWorkflowManager(workflowRepo);
+		spaceManager = new SpaceManager(db);
+		nodeExecutionRepo = new NodeExecutionRepository(db);
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			/* ignore */
+		}
+	});
+
+	// --------------------------------------------------------------------
+	// Part D: Step 1.5 spares waiting_for_input sessions
+	// --------------------------------------------------------------------
+
+	describe('Step 1.5 (force-idle) spares waiting_for_input sessions', () => {
+		test('does NOT auto-complete or orphan a session that is waiting_for_input past timeout', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Pending-question run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Pending-question run',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+
+			// Seed an in_progress execution whose startedAt is far in the past so
+			// elapsedMs > timeout. The Step 1.5 path would normally auto-complete
+			// this — Part D guard should spare it because the session is
+			// waiting_for_input.
+			const sessionId = 'session-waiting';
+			const created = nodeExecutionRepo.createOrIgnore({
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				agentName: 'Step A',
+				agentId: AGENT,
+				status: 'pending',
+			});
+			nodeExecutionRepo.update(created.id, {
+				status: 'in_progress',
+				agentSessionId: sessionId,
+			});
+			// Force startedAt into the deep past (-1 day)
+			db.prepare('UPDATE node_executions SET started_at = ? WHERE id = ?').run(
+				Date.now() - 24 * 60 * 60 * 1000,
+				created.id
+			);
+
+			const stub = makeAgentSessionStub({
+				status: 'waiting_for_input',
+				pendingQuestion: {
+					toolUseId: 'tool-spared',
+					questions: [
+						{
+							question: '?',
+							header: 'X',
+							options: [{ label: 'A', description: 'A' }],
+							multiSelect: false,
+						},
+					],
+					askedAt: Date.now(),
+				},
+			});
+
+			const tam = makeMockTaskAgentManager({
+				aliveSessions: new Set([sessionId]),
+				sessionStubs: new Map([[sessionId, stub]]),
+			});
+			const rt = new SpaceRuntime(buildConfig(tam));
+
+			await rt.executeTick();
+
+			// Execution still in_progress — not auto-completed
+			const after = nodeExecutionRepo.listByNode(run.id, STEP_A)[0]!;
+			expect(after.status).toBe('in_progress');
+			expect(after.result).toBeFalsy();
+
+			// Orphan cleanup must NOT have been called for the spared session
+			expect(stub._orphanCalls).toEqual([]);
+		});
+
+		test('DOES auto-complete a stuck (processing, not waiting) session past timeout', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Stuck run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Stuck run',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+
+			const sessionId = 'session-stuck';
+			const created = nodeExecutionRepo.createOrIgnore({
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				agentName: 'Step A',
+				agentId: AGENT,
+				status: 'pending',
+			});
+			nodeExecutionRepo.update(created.id, {
+				status: 'in_progress',
+				agentSessionId: sessionId,
+			});
+			db.prepare('UPDATE node_executions SET started_at = ? WHERE id = ?').run(
+				Date.now() - 24 * 60 * 60 * 1000,
+				created.id
+			);
+
+			// Session reports it is *processing* (not waiting_for_input) — Step 1.5
+			// should still force-idle it.
+			const stub = makeAgentSessionStub({
+				status: 'processing',
+				messageId: 'm1',
+				phase: 'streaming',
+			});
+			const tam = makeMockTaskAgentManager({
+				aliveSessions: new Set([sessionId]),
+				sessionStubs: new Map([[sessionId, stub]]),
+			});
+			const rt = new SpaceRuntime(buildConfig(tam));
+
+			await rt.executeTick();
+
+			const after = nodeExecutionRepo.listByNode(run.id, STEP_A)[0]!;
+			expect(after.status).toBe('idle');
+			expect(after.result).toMatch(/Auto-completed.*timed out/);
+		});
+	});
+});

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-orphan-question.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-orphan-question.test.ts
@@ -318,4 +318,136 @@ describe('SpaceRuntime — orphaned-question cleanup (Task #138)', () => {
 			expect(after.result).toMatch(/Auto-completed.*timed out/);
 		});
 	});
+
+	// --------------------------------------------------------------------
+	// Part C: Step 1 (liveness) marks the orphan question on dead sessions
+	// --------------------------------------------------------------------
+	//
+	// Defense-in-depth path. In production today, `isSessionAlive` lazily
+	// rehydrates a session from DB on first lookup, so for sessions whose row
+	// still exists this branch isn't hit — Part D handles them in Step 1.5.
+	// The Part C path covers the case where a session has been evicted and
+	// cannot be revived (e.g. SessionManager reports dead) but a stub still
+	// exposes the in-memory question state via `getAgentSessionById`. We
+	// exercise it here so a future refactor that decouples isSessionAlive
+	// from auto-rehydration can't silently regress the orphan cleanup.
+
+	describe('Step 1 (liveness) orphans pending questions on dead sessions', () => {
+		test('calls markPendingQuestionOrphaned with agent_session_terminated on a dead waiting_for_input session', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Crashed-question run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Crashed-question run',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+
+			const sessionId = 'session-crashed';
+			const created = nodeExecutionRepo.createOrIgnore({
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				agentName: 'Step A',
+				agentId: AGENT,
+				status: 'pending',
+			});
+			nodeExecutionRepo.update(created.id, {
+				status: 'in_progress',
+				agentSessionId: sessionId,
+			});
+
+			// Stub reports waiting_for_input, but the session is NOT in the alive
+			// set — Step 1's liveness check sees it as dead and falls into the
+			// crash path, where Part C should call markPendingQuestionOrphaned
+			// before the execution is reset/blocked.
+			const stub = makeAgentSessionStub({
+				status: 'waiting_for_input',
+				pendingQuestion: {
+					toolUseId: 'tool-orphaned',
+					questions: [
+						{
+							question: '?',
+							header: 'X',
+							options: [{ label: 'A', description: 'A' }],
+							multiSelect: false,
+						},
+					],
+					askedAt: Date.now(),
+				},
+			});
+
+			const tam = makeMockTaskAgentManager({
+				// aliveSessions intentionally empty — isSessionAlive returns false
+				aliveSessions: new Set(),
+				sessionStubs: new Map([[sessionId, stub]]),
+			});
+			const rt = new SpaceRuntime(buildConfig(tam));
+
+			await rt.executeTick();
+
+			// Crash path fired: orphan cleanup was invoked with the expected reason
+			// before the execution was reset/blocked. The downstream execution state
+			// (re-spawned, blocked, etc.) is owned by the runtime's lifecycle logic
+			// and out of scope for this assertion — we only care that the question
+			// card was flipped to cancelled.
+			expect(stub._orphanCalls).toEqual(['agent_session_terminated']);
+		});
+
+		test('orphan cleanup is best-effort: if the session has no stub, the crash path still resets the execution', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Vanished-session run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Vanished-session run',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+
+			const sessionId = 'session-vanished';
+			const created = nodeExecutionRepo.createOrIgnore({
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				agentName: 'Step A',
+				agentId: AGENT,
+				status: 'pending',
+			});
+			nodeExecutionRepo.update(created.id, {
+				status: 'in_progress',
+				agentSessionId: sessionId,
+			});
+
+			// No stub registered — getAgentSessionById returns null. Crash path
+			// must still proceed to reset the execution; orphan cleanup is a
+			// best-effort no-op when there's nothing to clean up.
+			const tam = makeMockTaskAgentManager({
+				aliveSessions: new Set(),
+				sessionStubs: new Map(),
+			});
+			const rt = new SpaceRuntime(buildConfig(tam));
+
+			await rt.executeTick();
+
+			// Tick completed without throwing despite no stub — the orphan cleanup
+			// is a try/catch best-effort, so a missing live session doesn't break
+			// the crash path. (The downstream execution lifecycle is out of scope.)
+		});
+	});
 });

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
@@ -107,6 +107,7 @@ function makeMockTaskAgentManager(
 		rehydrate?: () => Promise<void>;
 		cancelBySessionId?: (sessionId: string) => void;
 		interruptBySessionId?: (sessionId: string) => Promise<void>;
+		getAgentSessionById?: (sessionId: string) => unknown;
 	} = {}
 ) {
 	const spawned: string[] = [];
@@ -161,6 +162,7 @@ function makeMockTaskAgentManager(
 		rehydrate: overrides.rehydrate ?? (async () => {}),
 		cancelBySessionId: overrides.cancelBySessionId ?? (() => {}),
 		interruptBySessionId: overrides.interruptBySessionId ?? (async () => {}),
+		getAgentSessionById: overrides.getAgentSessionById ?? (() => null),
 		// PR 3/5 added a post-approval awareness injection via
 		// `injectIntoTaskAgent`. The tick-loop mock is not exercising delivery,
 		// so return a trivial "not injected" result — production treats this as

--- a/packages/shared/src/state-types.ts
+++ b/packages/shared/src/state-types.ts
@@ -119,6 +119,15 @@ export interface QuestionDraftResponse {
 }
 
 /**
+ * Reason a question was cancelled.
+ * - `user_cancelled`: user clicked Skip in the UI
+ * - `agent_session_terminated`: agent session ended before the user answered
+ *   (force-completion, rehydrate failure, daemon shutdown). UI should render
+ *   the card distinctly so the user understands why the question went away.
+ */
+export type QuestionCancelReason = 'user_cancelled' | 'agent_session_terminated';
+
+/**
  * Resolved question - saved after user submits or cancels
  * Used to persist question UI state across page refreshes
  */
@@ -131,6 +140,11 @@ export interface ResolvedQuestion {
 	responses: QuestionDraftResponse[];
 	/** When the question was resolved */
 	resolvedAt: number;
+	/**
+	 * When state === 'cancelled', explains who/what cancelled the question.
+	 * Defaults to 'user_cancelled' for back-compat when missing.
+	 */
+	cancelReason?: QuestionCancelReason;
 }
 
 /**

--- a/packages/shared/src/state-types.ts
+++ b/packages/shared/src/state-types.ts
@@ -141,8 +141,14 @@ export interface ResolvedQuestion {
 	/** When the question was resolved */
 	resolvedAt: number;
 	/**
-	 * When state === 'cancelled', explains who/what cancelled the question.
-	 * Defaults to 'user_cancelled' for back-compat when missing.
+	 * When `state === 'cancelled'`, explains who/what cancelled the question.
+	 *
+	 * Optional and unset on records persisted before this field was added —
+	 * the field has no runtime default. Renderers that need a fallback
+	 * (e.g. `QuestionPrompt`) must handle `undefined` explicitly; the
+	 * current UI displays a generic "Question skipped" header for missing
+	 * `cancelReason` and a specific "agent session ended" header for
+	 * `cancelReason === 'agent_session_terminated'`.
 	 */
 	cancelReason?: QuestionCancelReason;
 }

--- a/packages/web/src/components/QuestionPrompt.tsx
+++ b/packages/web/src/components/QuestionPrompt.tsx
@@ -14,7 +14,11 @@
  */
 
 import { useState, useCallback, useEffect } from 'preact/hooks';
-import type { PendingUserQuestion, QuestionDraftResponse } from '@neokai/shared';
+import type {
+	PendingUserQuestion,
+	QuestionCancelReason,
+	QuestionDraftResponse,
+} from '@neokai/shared';
 import { useMessageHub } from '../hooks/useMessageHub.ts';
 import { Button } from './ui/Button.tsx';
 import { cn } from '../lib/utils.ts';
@@ -57,6 +61,14 @@ interface QuestionPromptProps {
 	resolvedState?: ResolvedState;
 	/** Final responses when resolved (for display) */
 	finalResponses?: QuestionDraftResponse[];
+	/**
+	 * When `resolvedState === 'cancelled'`, explains who cancelled the question.
+	 * - `user_cancelled` (default): user clicked Skip
+	 * - `agent_session_terminated`: session ended before the user answered, so
+	 *   the card is rendered as an orphan note rather than a "Question skipped"
+	 *   pretending the user dismissed it.
+	 */
+	cancelReason?: QuestionCancelReason;
 	/** Callback when the question is resolved (submitted or cancelled) */
 	onResolved?: (state: 'submitted' | 'cancelled', responses: QuestionDraftResponse[]) => void;
 }
@@ -66,6 +78,7 @@ export function QuestionPrompt({
 	pendingQuestion,
 	resolvedState = null,
 	finalResponses,
+	cancelReason,
 	onResolved,
 }: QuestionPromptProps) {
 	const { questions, toolUseId, draftResponses } = pendingQuestion;
@@ -334,7 +347,15 @@ export function QuestionPrompt({
 	// Get header title based on state
 	const getHeaderTitle = () => {
 		if (resolvedState === 'submitted') return 'Response submitted';
-		if (resolvedState === 'cancelled') return 'Question skipped';
+		if (resolvedState === 'cancelled') {
+			// `agent_session_terminated`: the session ended before the user
+			// answered, so the question card is being cleaned up by the
+			// runtime rather than dismissed by the user.
+			if (cancelReason === 'agent_session_terminated') {
+				return 'Question cancelled — agent session ended';
+			}
+			return 'Question skipped';
+		}
 		return 'Claude needs your input';
 	};
 

--- a/packages/web/src/components/__tests__/QuestionPrompt.test.tsx
+++ b/packages/web/src/components/__tests__/QuestionPrompt.test.tsx
@@ -332,6 +332,40 @@ describe('QuestionPrompt', () => {
 			expect(container.textContent).toContain('Question skipped');
 		});
 
+		it('should show "agent session ended" header when cancelReason=agent_session_terminated', () => {
+			// Task #138: orphaned questions (session died before user answered)
+			// must render distinctly from a user-initiated Skip so users know
+			// the card was cleaned up by the runtime, not by them.
+			const { container } = render(
+				<QuestionPrompt
+					sessionId="session-1"
+					pendingQuestion={mockPendingQuestion}
+					resolvedState="cancelled"
+					finalResponses={[]}
+					cancelReason="agent_session_terminated"
+				/>
+			);
+
+			expect(container.textContent).toContain('Question cancelled — agent session ended');
+			// And does NOT collapse to the generic Skip wording
+			expect(container.textContent).not.toContain('Question skipped');
+		});
+
+		it('should show generic "Question skipped" when cancelReason=user_cancelled', () => {
+			const { container } = render(
+				<QuestionPrompt
+					sessionId="session-1"
+					pendingQuestion={mockPendingQuestion}
+					resolvedState="cancelled"
+					finalResponses={[]}
+					cancelReason="user_cancelled"
+				/>
+			);
+
+			expect(container.textContent).toContain('Question skipped');
+			expect(container.textContent).not.toContain('agent session ended');
+		});
+
 		it('should hide action buttons when resolved', () => {
 			const { container } = render(
 				<QuestionPrompt

--- a/packages/web/src/components/sdk/SDKAssistantMessage.tsx
+++ b/packages/web/src/components/sdk/SDKAssistantMessage.tsx
@@ -506,6 +506,7 @@ function ToolUseBlock({
 						pendingQuestion={resolved.question}
 						resolvedState={resolved.state}
 						finalResponses={resolved.responses}
+						cancelReason={resolved.cancelReason}
 					/>
 				) : isPending ? (
 					<QuestionPrompt


### PR DESCRIPTION
## Summary

Fixes Task #138. Three coordinated changes so a daemon restart while a session is in `waiting_for_input` no longer leaves a dead-end question card.

- **Restart-survival** in `AskUserQuestionHandler`: a `queuedAnswers` map + injected `tool_result` user message let Submit/Skip work after the in-memory resolver is gone. Redundant on purpose — `createCanUseToolCallback` consumes the queued answer if the SDK re-issues the call; the injected `tool_result` covers the case where the SDK considers the prior `tool_use` already-resolved.
- **Orphan cleanup** via new `markQuestionOrphaned()` — wired into SpaceRuntime Step 1 (force-completion/block) and Step 1.5 (auto-complete). The persisted question becomes a `cancelled` ResolvedQuestion with `cancelReason='agent_session_terminated'` and `QuestionPrompt` renders "Question cancelled — agent session ended" instead of the generic Skip wording.
- **Step 1.5 guard** spares sessions whose ProcessingState is `waiting_for_input` — the agent is not stuck, a human is. Interim until Step 1.5 is removed entirely.

New telemetry events: `question.orphaned`, `question.injected_as_tool_result`.

## Test plan

- [x] Daemon unit suite: 11394 pass / 0 fail
- [x] Web vitest suite: 7325 pass / 0 fail
- [x] Shared suite: 493 pass / 0 fail
- [x] Typecheck clean across workspace
- [x] New handler tests cover queued-answer fast path, orphan flows, post-restart submit/cancel
- [x] New `space-runtime-orphan-question.test.ts` covers Step 1.5 spare + still-stuck paths
- [x] New QuestionPrompt UI test covers `cancelReason='agent_session_terminated'` header
- [ ] Manual: restart daemon during a pending question, verify Submit and Skip both work
- [ ] Manual: force-complete a `waiting_for_input` session, verify the card flips to "agent session ended"

🤖 Generated with [Claude Code](https://claude.com/claude-code)