### PR TITLE
[codex] Target workflow agents from task composer

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -725,7 +725,10 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		deps.db,
 		deps.daemonHub,
 		nodeExecutionRepo,
-		channelCycleRepo
+		channelCycleRepo,
+		async (runId, nodeId) => {
+			await spaceRuntimeService.activateWorkflowNode(runId, nodeId);
+		}
 	);
 
 	// Space export/import handlers

--- a/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
@@ -56,9 +56,13 @@ export function parseMentions(text: string): string[] {
  * Allows the handler to resolve @mention targets without depending on the concrete repository class.
  */
 export interface NodeExecutionLookup {
-	listByWorkflowRun(
-		workflowRunId: string
-	): Array<{ agentName: string; agentSessionId: string | null; status: string }>;
+	listByWorkflowRun(workflowRunId: string): Array<{
+		id?: string;
+		workflowNodeId?: string;
+		agentName: string;
+		agentSessionId: string | null;
+		status: string;
+	}>;
 }
 
 /**
@@ -79,6 +83,10 @@ export interface TaskAgentManagerInterface {
 	injectSubSessionMessage?(subSessionId: string, message: string): Promise<void>;
 }
 
+type SpaceTaskMessageTarget =
+	| { kind: 'task_agent' }
+	| { kind: 'node_agent'; agentName?: string; nodeExecutionId?: string };
+
 /**
  * Register RPC handlers for human ↔ Task Agent message routing.
  *
@@ -95,7 +103,8 @@ export function setupSpaceTaskMessageHandlers(
 	db: Database,
 	daemonHub: DaemonHub,
 	nodeExecutionRepo?: NodeExecutionLookup,
-	channelCycleResetter?: ChannelCycleResetter
+	channelCycleResetter?: ChannelCycleResetter,
+	activateNode?: (runId: string, nodeId: string) => Promise<void>
 ): void {
 	const taskRepo = new SpaceTaskRepository(db.getDatabase());
 
@@ -131,6 +140,82 @@ export function setupSpaceTaskMessageHandlers(
 				}`
 			);
 		}
+	}
+
+	async function routeToNodeAgents(
+		task: ReturnType<SpaceTaskRepository['getTask']>,
+		taskId: string,
+		message: string,
+		target: { agentName?: string; nodeExecutionId?: string }
+	): Promise<{ ok: true; routedTo: string[]; delivered?: false; activated?: true }> {
+		if (!task?.workflowRunId) {
+			throw new Error(`Task ${taskId} has no workflow run — cannot target workflow agents.`);
+		}
+		if (!nodeExecutionRepo || !taskAgentManager.injectSubSessionMessage) {
+			throw new Error('Workflow agent targeting is unavailable on this daemon.');
+		}
+
+		const executions = nodeExecutionRepo
+			.listByWorkflowRun(task.workflowRunId)
+			.filter((e) => e.status !== 'cancelled');
+		const matches = executions.filter((e) => {
+			if (target.nodeExecutionId && e.id === target.nodeExecutionId) return true;
+			return !!target.agentName && e.agentName.toLowerCase() === target.agentName.toLowerCase();
+		});
+
+		if (matches.length === 0) {
+			const available = [...new Set(executions.map((e) => e.agentName))].sort();
+			throw new Error(
+				`Workflow agent not found: ${target.agentName ?? target.nodeExecutionId ?? 'unknown'}. ` +
+					`Available agents: ${available.length > 0 ? available.join(', ') : 'none'}`
+			);
+		}
+
+		let activated = false;
+		let deliverable = matches.filter((e) => e.agentSessionId);
+		const missingSessionNodeIds = [
+			...new Set(
+				matches
+					.filter((e) => !e.agentSessionId && e.workflowNodeId)
+					.map((e) => e.workflowNodeId as string)
+			),
+		];
+
+		if (deliverable.length === 0 && missingSessionNodeIds.length > 0 && activateNode) {
+			await Promise.all(
+				missingSessionNodeIds.map((nodeId) => activateNode(task.workflowRunId!, nodeId))
+			);
+			activated = true;
+			const refreshed = nodeExecutionRepo
+				.listByWorkflowRun(task.workflowRunId)
+				.filter((e) => e.status !== 'cancelled');
+			const refreshedMatches = refreshed.filter((e) => {
+				if (target.nodeExecutionId && e.id === target.nodeExecutionId) return true;
+				return !!target.agentName && e.agentName.toLowerCase() === target.agentName.toLowerCase();
+			});
+			deliverable = refreshedMatches.filter((e) => e.agentSessionId);
+		}
+
+		if (deliverable.length === 0) {
+			return {
+				ok: true,
+				routedTo: [...new Set(matches.map((e) => e.agentName))],
+				...(activated ? { activated: true as const } : {}),
+				delivered: false,
+			};
+		}
+
+		await Promise.all(
+			deliverable.map((exec) =>
+				taskAgentManager.injectSubSessionMessage!(exec.agentSessionId!, message)
+			)
+		);
+
+		return {
+			ok: true,
+			routedTo: [...new Set(deliverable.map((e) => e.agentName))],
+			...(activated ? { activated: true as const } : {}),
+		};
 	}
 
 	// ─── space.task.ensureAgentSession ──────────────────────────────────────────
@@ -173,7 +258,12 @@ export function setupSpaceTaskMessageHandlers(
 
 	// ─── space.task.sendMessage ─────────────────────────────────────────────────
 	messageHub.onRequest('space.task.sendMessage', async (data) => {
-		const params = data as { spaceId: string; taskId: string; message: string };
+		const params = data as {
+			spaceId: string;
+			taskId: string;
+			message: string;
+			target?: SpaceTaskMessageTarget | null;
+		};
 
 		if (!params.spaceId) {
 			throw new Error('spaceId is required');
@@ -195,6 +285,15 @@ export function setupSpaceTaskMessageHandlers(
 		}
 		if (task.spaceId !== params.spaceId) {
 			throw new Error(`Task not found: ${params.taskId}`);
+		}
+
+		if (params.target?.kind === 'node_agent') {
+			const result = await routeToNodeAgents(task, params.taskId, params.message, params.target);
+			log.info(
+				`space.task.sendMessage: explicit target routing to [${result.routedTo.join(', ')}] for task ${params.taskId}`
+			);
+			await resetChannelCyclesOnHumanTouch(task.workflowRunId, params.taskId);
+			return result;
 		}
 
 		// ── @mention routing ──────────────────────────────────────────────────────

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-message-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-message-handlers.test.ts
@@ -615,7 +615,13 @@ describe('setupSpaceTaskMessageHandlers', () => {
 	describe('@mention routing in space.task.sendMessage', () => {
 		// Mock NodeExecutionLookup — includes status field (required by NodeExecutionLookup interface)
 		function makeNodeExecutionRepo(
-			agents: Array<{ agentName: string; agentSessionId: string | null; status?: string }>
+			agents: Array<{
+				id?: string;
+				workflowNodeId?: string;
+				agentName: string;
+				agentSessionId: string | null;
+				status?: string;
+			}>
 		): NodeExecutionLookup {
 			return {
 				listByWorkflowRun: mock(() =>
@@ -781,6 +787,39 @@ describe('setupSpaceTaskMessageHandlers', () => {
 				'task-1',
 				'Please continue the work'
 			);
+		});
+
+		it('explicit node-agent target routes by node execution id without @mention text', async () => {
+			const { injectSubSession } = setupWithMention([
+				{
+					id: 'exec-coder',
+					workflowNodeId: 'node-1',
+					agentName: 'Coder',
+					agentSessionId: 'session-coder-1',
+				},
+				{
+					id: 'exec-reviewer',
+					workflowNodeId: 'node-1',
+					agentName: 'Reviewer',
+					agentSessionId: 'session-reviewer-1',
+				},
+			]);
+
+			const result = await call('space.task.sendMessage', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				message: 'Please review this',
+				target: {
+					kind: 'node_agent',
+					agentName: 'Reviewer',
+					nodeExecutionId: 'exec-reviewer',
+				},
+			});
+
+			expect(result).toMatchObject({ ok: true, routedTo: ['Reviewer'] });
+			expect(injectSubSession).toHaveBeenCalledTimes(1);
+			expect(injectSubSession).toHaveBeenCalledWith('session-reviewer-1', 'Please review this');
+			expect(taskAgentManager.injectTaskAgentMessage).not.toHaveBeenCalled();
 		});
 
 		it('@mention falls back to Task Agent when task has no workflowRunId', async () => {

--- a/packages/web/src/components/ChatComposer.tsx
+++ b/packages/web/src/components/ChatComposer.tsx
@@ -7,6 +7,7 @@ import type {
 	SessionType,
 	ThinkingLevel,
 } from '@neokai/shared';
+import type { ComponentChildren } from 'preact';
 import MessageInput from './MessageInput.tsx';
 import SessionStatusBar from './SessionStatusBar.tsx';
 import { borderColors } from '../lib/design-tokens.ts';
@@ -51,6 +52,9 @@ export interface ChatComposerProps {
 	agentMentionCandidates?: Array<{ id: string; name: string }>;
 	/** Override the default placeholder text in the message input */
 	inputPlaceholder?: string;
+	inputLeadingElement?: ComponentChildren;
+	inputLeadingPaddingClass?: string;
+	onDraftActiveChange?: (hasDraft: boolean) => void;
 	/** Optional inline error message rendered above the status bar (used by task sessions) */
 	errorMessage?: string | null;
 }
@@ -91,6 +95,9 @@ export function ChatComposer({
 	onExitRewindMode,
 	agentMentionCandidates,
 	inputPlaceholder,
+	inputLeadingElement,
+	inputLeadingPaddingClass,
+	onDraftActiveChange,
 	errorMessage,
 }: ChatComposerProps) {
 	return (
@@ -175,6 +182,9 @@ export function ChatComposer({
 							onExitRewindMode={onExitRewindMode}
 							agentMentionCandidates={agentMentionCandidates}
 							placeholder={inputPlaceholder}
+							leadingElement={inputLeadingElement}
+							leadingPaddingClass={inputLeadingPaddingClass}
+							onDraftActiveChange={onDraftActiveChange}
 						/>
 					)
 				)}

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import type { ComponentChildren } from 'preact';
 import type {
 	MessageDeliveryMode,
 	MessageImage,
@@ -81,6 +82,12 @@ interface MessageInputProps {
 	agentMentionCandidates?: Array<{ id: string; name: string }>;
 	/** Override the default placeholder derived from sessionType */
 	placeholder?: string;
+	/** Optional control rendered inside the input, on the left side */
+	leadingElement?: ComponentChildren;
+	/** Left padding class used when leadingElement is present */
+	leadingPaddingClass?: string;
+	/** Emits whether the current draft has non-whitespace content */
+	onDraftActiveChange?: (hasDraft: boolean) => void;
 }
 
 interface QueuedOverlayMessage {
@@ -104,6 +111,9 @@ export default function MessageInput({
 	onExitRewindMode,
 	agentMentionCandidates,
 	placeholder: placeholderProp,
+	leadingElement,
+	leadingPaddingClass,
+	onDraftActiveChange,
 }: MessageInputProps) {
 	// Cache touch device detection — computed once on first render, stable thereafter.
 	// Using useRef (not a module constant) so tests can mock matchMedia before render.
@@ -141,6 +151,10 @@ export default function MessageInput({
 		handlePaste,
 	} = useFileAttachments();
 	const { handleInterrupt } = useInterrupt({ sessionId });
+
+	useEffect(() => {
+		onDraftActiveChange?.(content.trim().length > 0);
+	}, [content, onDraftActiveChange]);
 
 	// Command autocomplete
 	const handleCommandSelect = useCallback(
@@ -667,6 +681,8 @@ export default function MessageInput({
 							onPaste={disabled ? undefined : handlePaste}
 							textareaRef={textareaInputRef}
 							transparent={true}
+							leadingElement={leadingElement}
+							leadingPaddingClass={leadingPaddingClass}
 							onHeightChange={handleTextareaHeightChange}
 						/>
 					</div>

--- a/packages/web/src/components/room/TaskView.test.tsx
+++ b/packages/web/src/components/room/TaskView.test.tsx
@@ -114,11 +114,18 @@ vi.mock('../ScrollToBottomButton.tsx', () => ({
 	ScrollToBottomButton: ({
 		onClick,
 		bottomClass,
+		autoScroll,
 	}: {
 		onClick: () => void;
 		bottomClass?: string;
+		autoScroll?: boolean;
 	}) => (
-		<button data-testid="scroll-to-bottom" data-bottom-class={bottomClass} onClick={onClick}>
+		<button
+			data-testid="scroll-to-bottom"
+			data-bottom-class={bottomClass}
+			data-auto-scroll={String(autoScroll)}
+			onClick={onClick}
+		>
 			↓
 		</button>
 	),
@@ -1105,6 +1112,7 @@ describe('TaskView — ScrollToBottomButton bottomClass', () => {
 		});
 
 		expect(getByTestId('scroll-to-bottom').getAttribute('data-bottom-class')).toBe('bottom-0');
+		expect(getByTestId('scroll-to-bottom').getAttribute('data-auto-scroll')).toBe('true');
 	});
 });
 

--- a/packages/web/src/components/room/TaskView.tsx
+++ b/packages/web/src/components/room/TaskView.tsx
@@ -387,7 +387,11 @@ export function TaskView({ roomId, taskId, viewVersion }: TaskViewProps) {
 						</svg>
 					</button>
 					{showScrollButton && (
-						<ScrollToBottomButton onClick={handleScrollToBottom} bottomClass="bottom-0" />
+						<ScrollToBottomButton
+							onClick={handleScrollToBottom}
+							bottomClass="bottom-0"
+							autoScroll={autoScrollEnabled}
+						/>
 					)}
 				</div>
 			</div>

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -353,7 +353,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 			root.querySelector<HTMLElement>('[data-testid="space-task-unified-thread"] > div') ?? root;
 
 		let frame = 0;
-		const updateVisibleTarget = () => {
+		const updateVisibleTarget = (options?: { unlockManualTarget?: boolean }) => {
 			cancelAnimationFrame(frame);
 			frame = requestAnimationFrame(() => {
 				const rootRect = scroller.getBoundingClientRect();
@@ -382,20 +382,24 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 					}
 				}
 				setVisibleTargetName(best?.targetName ?? null);
+				if (options?.unlockManualTarget && targetLocked && !hasComposerDraft && !sendingThread) {
+					setTargetLocked(false);
+				}
 			});
 		};
 
-		const observer = new MutationObserver(updateVisibleTarget);
+		const handleScroll = () => updateVisibleTarget({ unlockManualTarget: true });
+		const observer = new MutationObserver(() => updateVisibleTarget());
 		observer.observe(root, { childList: true, subtree: true });
-		scroller.addEventListener('scroll', updateVisibleTarget, { passive: true });
+		scroller.addEventListener('scroll', handleScroll, { passive: true });
 		updateVisibleTarget();
 
 		return () => {
 			cancelAnimationFrame(frame);
 			observer.disconnect();
-			scroller.removeEventListener('scroll', updateVisibleTarget);
+			scroller.removeEventListener('scroll', handleScroll);
 		};
-	}, [activeView, showInlineComposer]);
+	}, [activeView, hasComposerDraft, sendingThread, showInlineComposer, targetLocked]);
 
 	useEffect(() => {
 		if (activeView === 'canvas' && !canShowCanvasTab) {

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -153,6 +153,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	const [visibleTargetName, setVisibleTargetName] = useState<string | null>(null);
 	const [autoScrollEnabled, setAutoScrollEnabled] = useState(true);
 	const [showScrollButton, setShowScrollButton] = useState(false);
+	const [threadScroller, setThreadScroller] = useState<HTMLDivElement | null>(null);
 	const threadPanelRef = useRef<HTMLDivElement>(null);
 	const scrollToBottomRef = useRef<((smooth?: boolean) => void) | null>(null);
 	const draftWasActiveRef = useRef(false);
@@ -172,6 +173,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 		setVisibleTargetName(null);
 		setAutoScrollEnabled(true);
 		setShowScrollButton(false);
+		setThreadScroller(null);
 		scrollToBottomRef.current = null;
 		draftWasActiveRef.current = false;
 	}, [taskId]);
@@ -357,7 +359,9 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 		const root = threadPanelRef.current;
 		if (!root) return;
 		const scroller =
-			root.querySelector<HTMLElement>('[data-testid="space-task-unified-thread"] > div') ?? root;
+			threadScroller ??
+			root.querySelector<HTMLElement>('[data-testid="space-task-unified-thread"] > div');
+		if (!scroller) return;
 
 		let frame = 0;
 		const updateVisibleTarget = (options?: { unlockManualTarget?: boolean }) => {
@@ -406,7 +410,14 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 			observer.disconnect();
 			scroller.removeEventListener('scroll', handleScroll);
 		};
-	}, [activeView, hasComposerDraft, sendingThread, showInlineComposer, targetLocked]);
+	}, [
+		activeView,
+		hasComposerDraft,
+		sendingThread,
+		showInlineComposer,
+		targetLocked,
+		threadScroller,
+	]);
 
 	useEffect(() => {
 		if (activeView === 'canvas' && !canShowCanvasTab) {
@@ -822,6 +833,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 									onScrollToBottomChange={(scrollToBottom) => {
 										scrollToBottomRef.current = scrollToBottom;
 									}}
+									onScrollerChange={setThreadScroller}
 								/>
 							) : (
 								<div class="h-full overflow-y-auto">

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -5,7 +5,7 @@ import type {
 	SpaceTaskStatus,
 } from '@neokai/shared';
 import type { ComponentChildren } from 'preact';
-import { useEffect, useMemo, useState } from 'preact/hooks';
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { borderColors } from '../../lib/design-tokens';
 import { navigateToSpaceTask, pushOverlayHistory } from '../../lib/router';
 import { currentSpaceIdSignal, currentSpaceTaskViewTabSignal } from '../../lib/signals';
@@ -21,7 +21,7 @@ import { SpaceTaskUnifiedThread } from './SpaceTaskUnifiedThread';
 import { SubmitForReviewModal } from './SubmitForReviewModal';
 import { TaskArtifactsPanel } from './TaskArtifactsPanel';
 import { TaskBlockedBanner } from './TaskBlockedBanner';
-import { TaskSessionChatComposer } from './TaskSessionChatComposer';
+import { TaskSessionChatComposer, type TaskComposerTarget } from './TaskSessionChatComposer';
 import { getTransitionActions } from './TaskStatusActions';
 import { useRunGateSummaries } from './use-run-gate-summaries.ts';
 
@@ -80,6 +80,21 @@ const PRIORITY_BADGE_CLASSES: Record<SpaceTaskPriority, string> = {
 	urgent: 'border-red-500/30 bg-red-500/10 text-red-300',
 };
 
+function formatAgentSlotLabel(name: string): string {
+	return name
+		.split(/[\s_-]+/)
+		.filter(Boolean)
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(' ');
+}
+
+function normalizeTargetName(name: string | null | undefined): string {
+	return (name ?? '')
+		.toLowerCase()
+		.replace(/(?:\s+agent)+$/, '')
+		.replace(/[\s_-]+/g, '');
+}
+
 function TaskMetaBadge({
 	children,
 	class: className,
@@ -131,6 +146,12 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	const [sendingThread, setSendingThread] = useState(false);
 	const [statusTransitioning, setStatusTransitioning] = useState(false);
 	const [showSubmitForReviewModal, setShowSubmitForReviewModal] = useState(false);
+	const [selectedTargetId, setSelectedTargetId] = useState<string | null>(null);
+	const [targetLocked, setTargetLocked] = useState(false);
+	const [hasComposerDraft, setHasComposerDraft] = useState(false);
+	const [visibleTargetName, setVisibleTargetName] = useState<string | null>(null);
+	const threadPanelRef = useRef<HTMLDivElement>(null);
+	const draftWasActiveRef = useRef(false);
 	// Modal-local error feedback. Separate from `threadSendError` because
 	// `threadSendError` is rendered inside `TaskSessionChatComposer`, which is
 	// only mounted when the inline composer is visible. A failed submit-for-
@@ -141,6 +162,11 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 
 	useEffect(() => {
 		setThreadSendError(null);
+		setSelectedTargetId(null);
+		setTargetLocked(false);
+		setHasComposerDraft(false);
+		setVisibleTargetName(null);
+		draftWasActiveRef.current = false;
 	}, [taskId]);
 
 	useEffect(() => {
@@ -200,13 +226,55 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	const workflow = canvasWorkflowId
 		? (spaceStore.workflows.value.find((w) => w.id === canvasWorkflowId) ?? null)
 		: null;
-	const workflowAgentIds = workflow
-		? new Set(workflow.nodes.flatMap((n) => n.agents.map((a) => a.agentId)))
-		: null;
-	const mentionCandidates =
-		workflowAgentIds !== null
-			? spaceStore.agents.value.filter((a) => workflowAgentIds.has(a.id))
-			: [];
+	const spaceAgents = spaceStore.agents.value;
+	const nodeExecutions = spaceStore.nodeExecutions.value;
+	const taskAgentMember = activityMembers.find((m) => m.kind === 'task_agent') ?? null;
+	const composerTargets: TaskComposerTarget[] = useMemo(() => {
+		const nodeTargets =
+			workflow?.nodes.flatMap((node) =>
+				node.agents.map((agent) => {
+					const member =
+						activityMembers.find(
+							(m) =>
+								m.kind === 'node_agent' &&
+								(normalizeTargetName(m.role) === normalizeTargetName(agent.name) ||
+									normalizeTargetName(m.nodeExecution?.agentName) ===
+										normalizeTargetName(agent.name))
+						) ?? null;
+					const nodeExecution =
+						task.workflowRunId && node.id
+							? (nodeExecutions.find(
+									(execution) =>
+										execution.workflowRunId === task.workflowRunId &&
+										execution.workflowNodeId === node.id &&
+										normalizeTargetName(execution.agentName) === normalizeTargetName(agent.name)
+								) ?? null)
+							: null;
+					const spaceAgent = spaceAgents.find((a) => a.id === agent.agentId) ?? null;
+					return {
+						id: `node:${node.id}:${agent.name}`,
+						kind: 'node_agent' as const,
+						label: member?.label ?? spaceAgent?.name ?? formatAgentSlotLabel(agent.name),
+						agentName: agent.name,
+						nodeExecutionId: nodeExecution?.id,
+						nodeName: node.name,
+						state: member ? ACTIVITY_STATE_LABELS[member.state] : 'Not started',
+					};
+				})
+			) ?? [];
+
+		const taskAgentTarget: TaskComposerTarget = {
+			id: 'task-agent',
+			kind: 'task_agent',
+			label: 'Task Agent',
+			state: taskAgentMember ? ACTIVITY_STATE_LABELS[taskAgentMember.state] : undefined,
+		};
+
+		return nodeTargets.length > 0 ? [...nodeTargets, taskAgentTarget] : [taskAgentTarget];
+	}, [workflow, activityMembers, task.workflowRunId, taskAgentMember, nodeExecutions, spaceAgents]);
+	const mentionCandidates = composerTargets
+		.filter((target) => target.kind === 'node_agent' && target.agentName)
+		.map((target) => ({ id: target.id, name: target.agentName as string }));
 
 	const isTerminalTask =
 		task.status === 'done' || task.status === 'cancelled' || task.status === 'archived';
@@ -252,6 +320,82 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 				: agentSessionId
 					? 'View Agent Session'
 					: 'Open Space Agent';
+	const visibleTarget = visibleTargetName
+		? composerTargets.find(
+				(target) =>
+					normalizeTargetName(target.label) === normalizeTargetName(visibleTargetName) ||
+					normalizeTargetName(target.agentName) === normalizeTargetName(visibleTargetName)
+			)
+		: null;
+	const defaultTarget =
+		visibleTarget ?? composerTargets.find((t) => t.kind === 'node_agent') ?? null;
+	const selectedTarget =
+		composerTargets.find((target) => target.id === selectedTargetId) ?? defaultTarget;
+
+	useEffect(() => {
+		if (selectedTargetId && composerTargets.some((target) => target.id === selectedTargetId)) {
+			return;
+		}
+		setSelectedTargetId(defaultTarget?.id ?? null);
+	}, [composerTargets, defaultTarget?.id, selectedTargetId]);
+
+	useEffect(() => {
+		if (targetLocked || hasComposerDraft || !defaultTarget) return;
+		if (selectedTargetId === defaultTarget.id) return;
+		setSelectedTargetId(defaultTarget.id);
+	}, [defaultTarget, hasComposerDraft, selectedTargetId, targetLocked]);
+
+	useEffect(() => {
+		if (activeView !== 'thread' || !showInlineComposer) return;
+		const root = threadPanelRef.current;
+		if (!root) return;
+		const scroller =
+			root.querySelector<HTMLElement>('[data-testid="space-task-unified-thread"] > div') ?? root;
+
+		let frame = 0;
+		const updateVisibleTarget = () => {
+			cancelAnimationFrame(frame);
+			frame = requestAnimationFrame(() => {
+				const rootRect = scroller.getBoundingClientRect();
+				const targetAnchorY = rootRect.top + rootRect.height * 0.72;
+				const turns = Array.from(
+					root.querySelectorAll<HTMLElement>('[data-testid="minimal-thread-turn"]')
+				);
+				let best: { targetName: string; distance: number; visibleHeight: number } | null = null;
+				for (const turn of turns) {
+					const rect = turn.getBoundingClientRect();
+					const visibleTop = Math.max(rect.top, rootRect.top);
+					const visibleBottom = Math.min(rect.bottom, rootRect.bottom);
+					const visibleHeight = visibleBottom - visibleTop;
+					if (visibleHeight < 8) continue;
+					const targetName =
+						turn.dataset.toLabel || turn.dataset.agentLabel || turn.dataset.fromLabel || null;
+					if (!targetName) continue;
+					const visibleCenter = visibleTop + visibleHeight / 2;
+					const distance = Math.abs(visibleCenter - targetAnchorY);
+					if (
+						!best ||
+						distance < best.distance ||
+						(distance === best.distance && visibleHeight >= best.visibleHeight)
+					) {
+						best = { targetName, distance, visibleHeight };
+					}
+				}
+				setVisibleTargetName(best?.targetName ?? null);
+			});
+		};
+
+		const observer = new MutationObserver(updateVisibleTarget);
+		observer.observe(root, { childList: true, subtree: true });
+		scroller.addEventListener('scroll', updateVisibleTarget, { passive: true });
+		updateVisibleTarget();
+
+		return () => {
+			cancelAnimationFrame(frame);
+			observer.disconnect();
+			scroller.removeEventListener('scroll', updateVisibleTarget);
+		};
+	}, [activeView, showInlineComposer]);
 
 	useEffect(() => {
 		if (activeView === 'canvas' && !canShowCanvasTab) {
@@ -288,7 +432,10 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 		}
 	};
 
-	const sendThreadMessage = async (nextMessage: string): Promise<boolean> => {
+	const sendThreadMessage = async (
+		nextMessage: string,
+		target: TaskComposerTarget | null
+	): Promise<boolean> => {
 		if (!nextMessage) return false;
 		if (!runtimeSpaceId || !task) return false;
 
@@ -296,14 +443,27 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 			setSendingThread(true);
 			setThreadSendError(null);
 
-			if (!agentSessionId) {
+			if (target?.kind !== 'node_agent' && !agentSessionId) {
 				setEnsuringThread(true);
 				const ensured = await spaceStore.ensureTaskAgentSession(task.id);
 				setThreadSessionId(ensured.taskAgentSessionId ?? null);
 				setEnsuringThread(false);
 			}
 
-			await spaceStore.sendTaskMessage(task.id, nextMessage);
+			await spaceStore.sendTaskMessage(
+				task.id,
+				nextMessage,
+				target?.kind === 'node_agent' && target.agentName
+					? {
+							kind: 'node_agent',
+							agentName: target.agentName,
+							...(target.nodeExecutionId ? { nodeExecutionId: target.nodeExecutionId } : {}),
+						}
+					: { kind: 'task_agent' }
+			);
+			setTargetLocked(false);
+			setHasComposerDraft(false);
+			draftWasActiveRef.current = false;
 			return true;
 		} catch (err) {
 			setThreadSendError(formatTaskThreadError(err));
@@ -628,7 +788,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 					/>
 				) : (
 					<div class="h-full flex flex-col relative">
-						<div class="flex-1 min-h-0" data-testid="task-thread-panel">
+						<div ref={threadPanelRef} class="flex-1 min-h-0" data-testid="task-thread-panel">
 							{hasUnifiedWorkflowThread ? (
 								<SpaceTaskUnifiedThread
 									taskId={task.id}
@@ -664,11 +824,22 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 							<TaskSessionChatComposer
 								sessionId={agentSessionId ?? ''}
 								mentionCandidates={mentionCandidates}
+								targets={composerTargets}
+								selectedTargetId={selectedTarget?.id ?? null}
 								hasTaskAgentSession={!!agentSessionId}
 								canSend={canSendThreadMessage}
 								isSending={sendingThread}
 								isProcessing={isAgentActive}
 								errorMessage={threadSendError}
+								onTargetSelect={(targetId) => {
+									setSelectedTargetId(targetId);
+									setTargetLocked(true);
+								}}
+								onDraftActiveChange={(hasDraft) => {
+									setHasComposerDraft(hasDraft);
+									if (draftWasActiveRef.current && !hasDraft) setTargetLocked(false);
+									draftWasActiveRef.current = hasDraft;
+								}}
 								onSend={sendThreadMessage}
 							/>
 						)}

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -5,7 +5,7 @@ import type {
 	SpaceTaskStatus,
 } from '@neokai/shared';
 import type { ComponentChildren } from 'preact';
-import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { borderColors } from '../../lib/design-tokens';
 import { navigateToSpaceTask, pushOverlayHistory } from '../../lib/router';
 import { currentSpaceIdSignal, currentSpaceTaskViewTabSignal } from '../../lib/signals';
@@ -13,6 +13,7 @@ import { spaceStore } from '../../lib/space-store';
 import { resolveActiveTaskBanner } from '../../lib/task-banner.ts';
 import { cn } from '../../lib/utils';
 import { Dropdown, type DropdownMenuItem } from '../ui/Dropdown';
+import { ScrollToBottomButton } from '../ScrollToBottomButton';
 import { PendingGateBanner } from './PendingGateBanner';
 import { PendingPostApprovalBanner } from './PendingPostApprovalBanner';
 import { PendingTaskCompletionBanner } from './PendingTaskCompletionBanner';
@@ -150,7 +151,10 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	const [targetLocked, setTargetLocked] = useState(false);
 	const [hasComposerDraft, setHasComposerDraft] = useState(false);
 	const [visibleTargetName, setVisibleTargetName] = useState<string | null>(null);
+	const [autoScrollEnabled, setAutoScrollEnabled] = useState(true);
+	const [showScrollButton, setShowScrollButton] = useState(false);
 	const threadPanelRef = useRef<HTMLDivElement>(null);
+	const scrollToBottomRef = useRef<((smooth?: boolean) => void) | null>(null);
 	const draftWasActiveRef = useRef(false);
 	// Modal-local error feedback. Separate from `threadSendError` because
 	// `threadSendError` is rendered inside `TaskSessionChatComposer`, which is
@@ -166,6 +170,9 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 		setTargetLocked(false);
 		setHasComposerDraft(false);
 		setVisibleTargetName(null);
+		setAutoScrollEnabled(true);
+		setShowScrollButton(false);
+		scrollToBottomRef.current = null;
 		draftWasActiveRef.current = false;
 	}, [taskId]);
 
@@ -477,6 +484,11 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 			setSendingThread(false);
 		}
 	};
+
+	const handleScrollToBottom = useCallback(() => {
+		scrollToBottomRef.current?.(true);
+		setAutoScrollEnabled(true);
+	}, []);
 
 	const handleStatusTransition = async (newStatus: SpaceTaskStatus) => {
 		// Submitting for review is the human counterpart of the agent
@@ -805,6 +817,11 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 											: 'pb-3'
 									}
 									activeAgentLabels={activeAgentLabels}
+									autoScrollEnabled={autoScrollEnabled}
+									onShowScrollButtonChange={setShowScrollButton}
+									onScrollToBottomChange={(scrollToBottom) => {
+										scrollToBottomRef.current = scrollToBottom;
+									}}
 								/>
 							) : (
 								<div class="h-full overflow-y-auto">
@@ -824,6 +841,14 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 							)}
 						</div>
 
+						{showScrollButton && (
+							<ScrollToBottomButton
+								onClick={handleScrollToBottom}
+								bottomClass={threadSendError ? 'bottom-52 sm:bottom-44' : 'bottom-44 sm:bottom-36'}
+								autoScroll={autoScrollEnabled}
+							/>
+						)}
+
 						{showInlineComposer && (
 							<TaskSessionChatComposer
 								sessionId={agentSessionId ?? ''}
@@ -834,7 +859,9 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 								canSend={canSendThreadMessage}
 								isSending={sendingThread}
 								isProcessing={isAgentActive}
+								autoScroll={autoScrollEnabled}
 								errorMessage={threadSendError}
+								onAutoScrollChange={setAutoScrollEnabled}
 								onTargetSelect={(targetId) => {
 									setSelectedTargetId(targetId);
 									setTargetLocked(true);

--- a/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
+++ b/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
@@ -25,6 +25,7 @@ interface SpaceTaskUnifiedThreadProps {
 	autoScrollEnabled?: boolean;
 	onShowScrollButtonChange?: (showScrollButton: boolean) => void;
 	onScrollToBottomChange?: (scrollToBottom: ((smooth?: boolean) => void) | null) => void;
+	onScrollerChange?: (scroller: HTMLDivElement | null) => void;
 }
 
 export function SpaceTaskUnifiedThread({
@@ -35,6 +36,7 @@ export function SpaceTaskUnifiedThread({
 	autoScrollEnabled = true,
 	onShowScrollButtonChange,
 	onScrollToBottomChange,
+	onScrollerChange,
 }: SpaceTaskUnifiedThreadProps) {
 	const { rows, activeTurnSummaries, isLoading, isReconnecting } = useSpaceTaskMessages(
 		taskId,
@@ -59,6 +61,11 @@ export function SpaceTaskUnifiedThread({
 		onScrollToBottomChange?.(scrollToBottom);
 		return () => onScrollToBottomChange?.(null);
 	}, [onScrollToBottomChange, scrollToBottom]);
+
+	useEffect(() => {
+		onScrollerChange?.(containerRef.current);
+		return () => onScrollerChange?.(null);
+	}, [onScrollerChange, parsedRows.length, isLoading, isReconnecting]);
 
 	if (isReconnecting) {
 		return (

--- a/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
+++ b/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef } from 'preact/hooks';
 import { useSpaceTaskMessages } from '../../hooks/useSpaceTaskMessages';
+import { useAutoScroll } from '../../hooks/useAutoScroll';
 import { MinimalThreadFeed } from './thread/minimal/MinimalThreadFeed';
 import { parseThreadRow } from './thread/space-task-thread-events';
 
@@ -21,6 +22,9 @@ interface SpaceTaskUnifiedThreadProps {
 	 * last row can't suppress Coder's still-running rail.
 	 */
 	activeAgentLabels?: ReadonlySet<string>;
+	autoScrollEnabled?: boolean;
+	onShowScrollButtonChange?: (showScrollButton: boolean) => void;
+	onScrollToBottomChange?: (scrollToBottom: ((smooth?: boolean) => void) | null) => void;
 }
 
 export function SpaceTaskUnifiedThread({
@@ -28,25 +32,33 @@ export function SpaceTaskUnifiedThread({
 	bottomInsetClass = 'pb-3',
 	topInsetClass = '',
 	activeAgentLabels,
+	autoScrollEnabled = true,
+	onShowScrollButtonChange,
+	onScrollToBottomChange,
 }: SpaceTaskUnifiedThreadProps) {
 	const { rows, activeTurnSummaries, isLoading, isReconnecting } = useSpaceTaskMessages(
 		taskId,
 		'compact'
 	);
 	const containerRef = useRef<HTMLDivElement>(null);
-	const didInitialScrollRef = useRef<string | null>(null);
+	const messagesEndRef = useRef<HTMLDivElement>(null);
 
 	const parsedRows = useMemo(() => rows.map(parseThreadRow), [rows]);
+	const { showScrollButton, scrollToBottom } = useAutoScroll({
+		containerRef,
+		endRef: messagesEndRef,
+		enabled: autoScrollEnabled,
+		messageCount: rows.length,
+	});
 
 	useEffect(() => {
-		if (!containerRef.current) return;
-		// MinimalThreadFeed is a summary view — the entry point is the start
-		// of the conversation, not the latest event.
-		if (didInitialScrollRef.current !== taskId) {
-			containerRef.current.scrollTop = 0;
-			didInitialScrollRef.current = taskId;
-		}
-	}, [taskId, parsedRows.length]);
+		onShowScrollButtonChange?.(showScrollButton);
+	}, [onShowScrollButtonChange, showScrollButton]);
+
+	useEffect(() => {
+		onScrollToBottomChange?.(scrollToBottom);
+		return () => onScrollToBottomChange?.(null);
+	}, [onScrollToBottomChange, scrollToBottom]);
 
 	if (isReconnecting) {
 		return (
@@ -87,6 +99,7 @@ export function SpaceTaskUnifiedThread({
 						activeAgentLabels={activeAgentLabels}
 						activeTurnSummaries={activeTurnSummaries}
 					/>
+					<div ref={messagesEndRef} />
 				</div>
 			</div>
 		</div>

--- a/packages/web/src/components/space/TaskSessionChatComposer.tsx
+++ b/packages/web/src/components/space/TaskSessionChatComposer.tsx
@@ -25,7 +25,9 @@ interface TaskSessionChatComposerProps {
 	canSend: boolean;
 	isSending: boolean;
 	isProcessing: boolean;
+	autoScroll: boolean;
 	errorMessage?: string | null;
+	onAutoScrollChange: (enabled: boolean) => void;
 	onTargetSelect: (targetId: string) => void;
 	onDraftActiveChange?: (hasDraft: boolean) => void;
 	onSend: (message: string, target: TaskComposerTarget | null) => Promise<boolean>;
@@ -40,7 +42,9 @@ export function TaskSessionChatComposer({
 	canSend,
 	isSending,
 	isProcessing,
+	autoScroll,
 	errorMessage,
+	onAutoScrollChange,
 	onTargetSelect,
 	onDraftActiveChange,
 	onSend,
@@ -146,7 +150,7 @@ export function TaskSessionChatComposer({
 				availableModels={availableModels}
 				modelSwitching={modelSwitching}
 				modelLoading={modelLoading}
-				autoScroll={false}
+				autoScroll={autoScroll}
 				coordinatorMode={false}
 				coordinatorSwitching={false}
 				sandboxEnabled={false}
@@ -155,7 +159,7 @@ export function TaskSessionChatComposer({
 				isConnected={true}
 				rewindMode={false}
 				onModelSwitch={switchModel}
-				onAutoScrollChange={() => {}}
+				onAutoScrollChange={onAutoScrollChange}
 				onCoordinatorModeChange={() => {}}
 				onSandboxModeChange={() => {}}
 				onSend={handleSend}

--- a/packages/web/src/components/space/TaskSessionChatComposer.tsx
+++ b/packages/web/src/components/space/TaskSessionChatComposer.tsx
@@ -1,26 +1,48 @@
 import type { MessageDeliveryMode, MessageImage } from '@neokai/shared';
+import { useMemo, useState } from 'preact/hooks';
 import { ChatComposer } from '../ChatComposer.tsx';
 import { useModelSwitcher } from '../../hooks';
+import { cn } from '../../lib/utils.ts';
+import { getAgentColor } from './thread/space-task-thread-agent-colors';
+import { agentInitial } from './thread/minimal/minimal-mock-data';
+
+export interface TaskComposerTarget {
+	id: string;
+	kind: 'task_agent' | 'node_agent';
+	label: string;
+	agentName?: string;
+	nodeExecutionId?: string;
+	nodeName?: string;
+	state?: string;
+}
 
 interface TaskSessionChatComposerProps {
 	sessionId: string;
 	mentionCandidates: Array<{ id: string; name: string }>;
+	targets: TaskComposerTarget[];
+	selectedTargetId: string | null;
 	hasTaskAgentSession: boolean;
 	canSend: boolean;
 	isSending: boolean;
 	isProcessing: boolean;
 	errorMessage?: string | null;
-	onSend: (message: string) => Promise<boolean>;
+	onTargetSelect: (targetId: string) => void;
+	onDraftActiveChange?: (hasDraft: boolean) => void;
+	onSend: (message: string, target: TaskComposerTarget | null) => Promise<boolean>;
 }
 
 export function TaskSessionChatComposer({
 	sessionId,
 	mentionCandidates,
+	targets,
+	selectedTargetId,
 	hasTaskAgentSession,
 	canSend,
 	isSending,
 	isProcessing,
 	errorMessage,
+	onTargetSelect,
+	onDraftActiveChange,
 	onSend,
 }: TaskSessionChatComposerProps) {
 	const {
@@ -31,6 +53,13 @@ export function TaskSessionChatComposer({
 		loading: modelLoading,
 		switchModel,
 	} = useModelSwitcher(sessionId);
+	const [targetMenuOpen, setTargetMenuOpen] = useState(false);
+	const selectedTarget = useMemo(
+		() => targets.find((target) => target.id === selectedTargetId) ?? targets[0] ?? null,
+		[targets, selectedTargetId]
+	);
+	const selectedTargetColor = selectedTarget ? getAgentColor(selectedTarget.label) : '#66A7FF';
+	const selectedTargetInitial = selectedTarget ? agentInitial(selectedTarget.label) : 'A';
 
 	// Return the boolean so MessageInput can restore the draft when sending fails
 	const handleSend = async (
@@ -38,8 +67,66 @@ export function TaskSessionChatComposer({
 		_images?: MessageImage[],
 		_deliveryMode?: MessageDeliveryMode
 	): Promise<boolean> => {
-		return onSend(content);
+		return onSend(content, selectedTarget);
 	};
+
+	const targetPicker =
+		targets.length > 0 ? (
+			<div class="relative">
+				<button
+					type="button"
+					class="group inline-flex h-9 w-9 items-center justify-center rounded-full border border-dark-900/30 text-sm font-bold text-dark-950 shadow-sm ring-1 ring-white/10 transition-transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-400/70 active:scale-95"
+					style={{ backgroundColor: selectedTargetColor }}
+					onClick={() => setTargetMenuOpen((open) => !open)}
+					data-testid="task-composer-target-trigger"
+					aria-label="Select message recipient"
+					aria-haspopup="menu"
+					aria-expanded={targetMenuOpen}
+					title={selectedTarget ? `Send to ${selectedTarget.label}` : 'Select recipient'}
+				>
+					<span>{selectedTargetInitial}</span>
+				</button>
+				{targetMenuOpen && (
+					<div
+						class="absolute bottom-full left-0 z-50 mb-2 w-64 overflow-hidden rounded-lg border border-dark-700 bg-dark-850 shadow-xl shadow-black/30"
+						data-testid="task-composer-target-menu"
+					>
+						<div class="border-b border-dark-700 px-3 py-2 text-[11px] font-medium uppercase tracking-wide text-gray-500">
+							Send Message To
+						</div>
+						<div class="max-h-72 overflow-y-auto py-1">
+							{targets.map((target) => (
+								<button
+									key={target.id}
+									type="button"
+									class={cn(
+										'flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm transition-colors hover:bg-dark-700/70',
+										target.id === selectedTarget?.id && 'bg-blue-500/15 text-blue-100'
+									)}
+									onClick={() => {
+										onTargetSelect(target.id);
+										setTargetMenuOpen(false);
+									}}
+									data-testid="task-composer-target-option"
+								>
+									<span class="min-w-0">
+										<span class="block truncate text-gray-100">{target.label}</span>
+										<span class="block truncate text-xs text-gray-500">
+											{target.kind === 'task_agent'
+												? 'Fallback coordinator'
+												: `${target.nodeName ?? 'Workflow'}${target.state ? ` · ${target.state}` : ''}`}
+										</span>
+									</span>
+									{target.id === selectedTarget?.id && (
+										<span class="text-xs font-medium text-blue-300">Selected</span>
+									)}
+								</button>
+							))}
+						</div>
+					</div>
+				)}
+			</div>
+		) : null;
 
 	return (
 		<div class="relative z-10" data-testid="task-session-chat-composer">
@@ -77,8 +164,19 @@ export function TaskSessionChatComposer({
 				onExitRewindMode={() => {}}
 				agentMentionCandidates={mentionCandidates}
 				inputPlaceholder={
-					hasTaskAgentSession ? 'Message task agent...' : 'Message task agent (auto-start)...'
+					selectedTarget?.kind === 'task_agent'
+						? hasTaskAgentSession
+							? 'Message task agent...'
+							: 'Message task agent (auto-start)...'
+						: selectedTarget
+							? `Message ${selectedTarget.label}...`
+							: hasTaskAgentSession
+								? 'Message task agent...'
+								: 'Message task agent (auto-start)...'
 				}
+				inputLeadingElement={targetPicker}
+				inputLeadingPaddingClass="pl-12"
+				onDraftActiveChange={onDraftActiveChange}
 				errorMessage={errorMessage}
 			/>
 		</div>

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.mention.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.mention.test.tsx
@@ -370,6 +370,45 @@ describe('SpaceTaskPane — @mention autocomplete', () => {
 		rectSpy.mockRestore();
 	});
 
+	it('releases a manual empty-composer target lock when the thread scrolls', async () => {
+		mockTasks.value = [makeWorkflowTask()];
+		mockThreadTurns.push({ fromLabel: 'Reviewer Agent', toLabel: 'Coder Agent' });
+		const rectSpy = vi
+			.spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+			.mockImplementation(function () {
+				if ((this as HTMLElement).getAttribute('data-testid') === 'minimal-thread-turn') {
+					return { top: 20, bottom: 80, left: 0, right: 100, width: 100, height: 60 } as DOMRect;
+				}
+				return { top: 0, bottom: 100, left: 0, right: 100, width: 100, height: 100 } as DOMRect;
+			});
+
+		const container = render(<SpaceTaskPane taskId="task-1" />);
+
+		await waitFor(() =>
+			expect(container.getByTestId('task-composer-target-trigger').getAttribute('title')).toBe(
+				'Send to Coder'
+			)
+		);
+
+		fireEvent.click(container.getByTestId('task-composer-target-trigger'));
+		const options = container.getAllByTestId('task-composer-target-option');
+		fireEvent.click(options[1]);
+		expect(container.getByTestId('task-composer-target-trigger').getAttribute('title')).toBe(
+			'Send to Reviewer'
+		);
+
+		const scroller = container.getByTestId('space-task-unified-thread').firstElementChild;
+		expect(scroller).toBeTruthy();
+		fireEvent.scroll(scroller as Element);
+
+		await waitFor(() =>
+			expect(container.getByTestId('task-composer-target-trigger').getAttribute('title')).toBe(
+				'Send to Coder'
+			)
+		);
+		rectSpy.mockRestore();
+	});
+
 	it('filters agents when @partial is typed', async () => {
 		mockTasks.value = [makeWorkflowTask()];
 		const container = render(<SpaceTaskPane taskId="task-1" />);

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.mention.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.mention.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, render, waitFor } from '@testing-library/preact';
 import { signal } from '@preact/signals';
 import type {
 	SpaceAgent,
+	NodeExecution,
 	SpaceTask,
 	SpaceTaskActivityMember,
 	SpaceWorkflow,
@@ -14,10 +15,16 @@ vi.mock('../../../lib/router', () => ({
 	navigateToSpaceAgent: vi.fn(),
 }));
 
-const { mockSpaceOverlaySessionIdSignal, mockSpaceOverlayAgentNameSignal } = vi.hoisted(() => ({
-	mockSpaceOverlaySessionIdSignal: { value: null as string | null },
-	mockSpaceOverlayAgentNameSignal: { value: null as string | null },
-}));
+const { mockSpaceOverlaySessionIdSignal, mockSpaceOverlayAgentNameSignal, mockThreadTurns } =
+	vi.hoisted(() => ({
+		mockSpaceOverlaySessionIdSignal: { value: null as string | null },
+		mockSpaceOverlayAgentNameSignal: { value: null as string | null },
+		mockThreadTurns: [] as Array<{
+			agentLabel?: string;
+			fromLabel?: string;
+			toLabel?: string;
+		}>,
+	}));
 vi.mock('../../../lib/signals', async (importOriginal) => {
 	const actual = await importOriginal();
 	return {
@@ -35,6 +42,7 @@ let mockTasks: ReturnType<typeof signal<SpaceTask[]>>;
 let mockAgents: ReturnType<typeof signal<SpaceAgent[]>>;
 let mockWorkflows: ReturnType<typeof signal<SpaceWorkflow[]>>;
 let mockWorkflowRuns: ReturnType<typeof signal<SpaceWorkflowRun[]>>;
+let mockNodeExecutions: ReturnType<typeof signal<NodeExecution[]>>;
 let mockTaskActivity: ReturnType<typeof signal<Map<string, SpaceTaskActivityMember[]>>>;
 
 const mockUpdateTask = vi.fn().mockResolvedValue(undefined);
@@ -50,6 +58,7 @@ vi.mock('../../../lib/space-store', () => ({
 			agents: mockAgents,
 			workflows: mockWorkflows,
 			workflowRuns: mockWorkflowRuns,
+			nodeExecutions: mockNodeExecutions,
 			taskActivity: mockTaskActivity,
 			updateTask: mockUpdateTask,
 			ensureTaskAgentSession: mockEnsureTaskAgentSession,
@@ -64,7 +73,19 @@ vi.mock('../../../lib/space-store', () => ({
 
 vi.mock('../SpaceTaskUnifiedThread', () => ({
 	SpaceTaskUnifiedThread: ({ taskId }: { taskId: string }) => (
-		<div data-testid="space-task-unified-thread" data-task-id={taskId} />
+		<div data-testid="space-task-unified-thread" data-task-id={taskId}>
+			<div>
+				{mockThreadTurns.map((turn, index) => (
+					<div
+						key={index}
+						data-testid="minimal-thread-turn"
+						data-agent-label={turn.agentLabel}
+						data-from-label={turn.fromLabel}
+						data-to-label={turn.toLabel}
+					/>
+				))}
+			</div>
+		</div>
 	),
 }));
 
@@ -82,6 +103,7 @@ mockTasks = signal<SpaceTask[]>([]);
 mockAgents = signal<SpaceAgent[]>([]);
 mockWorkflows = signal<SpaceWorkflow[]>([]);
 mockWorkflowRuns = signal<SpaceWorkflowRun[]>([]);
+mockNodeExecutions = signal<NodeExecution[]>([]);
 mockTaskActivity = signal<Map<string, SpaceTaskActivityMember[]>>(new Map());
 
 import { SpaceTaskPane } from '../SpaceTaskPane';
@@ -160,6 +182,31 @@ describe('SpaceTaskPane — @mention autocomplete', () => {
 				updatedAt: 0,
 			},
 		];
+		mockThreadTurns.length = 0;
+		mockNodeExecutions.value = [
+			{
+				id: 'exec-coder',
+				workflowRunId: 'run-1',
+				workflowNodeId: 'node-1',
+				agentName: 'Coder',
+				status: 'idle',
+				agentSessionId: 'session-coder',
+				result: null,
+				createdAt: 0,
+				updatedAt: 0,
+			},
+			{
+				id: 'exec-reviewer',
+				workflowRunId: 'run-1',
+				workflowNodeId: 'node-1',
+				agentName: 'Reviewer',
+				status: 'idle',
+				agentSessionId: 'session-reviewer',
+				result: null,
+				createdAt: 0,
+				updatedAt: 0,
+			},
+		];
 		mockTaskActivity.value = new Map();
 		mockEnsureTaskAgentSession.mockReset();
 		mockEnsureTaskAgentSession.mockImplementation(async () =>
@@ -177,7 +224,7 @@ describe('SpaceTaskPane — @mention autocomplete', () => {
 	});
 
 	function getTextarea(container: ReturnType<typeof render>) {
-		return container.getByPlaceholderText('Message task agent...') as HTMLTextAreaElement;
+		return container.getByPlaceholderText(/^Message /) as HTMLTextAreaElement;
 	}
 
 	function typeIntoTextarea(textarea: HTMLTextAreaElement, value: string) {
@@ -214,6 +261,113 @@ describe('SpaceTaskPane — @mention autocomplete', () => {
 			expect(items[0].textContent).toContain('@Coder');
 			expect(items[1].textContent).toContain('@Reviewer');
 		});
+	});
+
+	it('targets the first workflow agent by default when sending from a workflow task', async () => {
+		mockTasks.value = [makeWorkflowTask()];
+		const container = render(<SpaceTaskPane taskId="task-1" />);
+		const textarea = getTextarea(container);
+
+		expect(container.getByTestId('task-composer-target-trigger').getAttribute('title')).toBe(
+			'Send to Coder'
+		);
+		typeIntoTextarea(textarea, 'Can you check this?');
+		fireEvent.click(container.getByTestId('send-button'));
+
+		await waitFor(() =>
+			expect(mockSendTaskMessage).toHaveBeenCalledWith('task-1', 'Can you check this?', {
+				kind: 'node_agent',
+				agentName: 'Coder',
+				nodeExecutionId: 'exec-coder',
+			})
+		);
+	});
+
+	it('sends to the manually selected workflow agent', async () => {
+		mockTasks.value = [makeWorkflowTask()];
+		const container = render(<SpaceTaskPane taskId="task-1" />);
+
+		fireEvent.click(container.getByTestId('task-composer-target-trigger'));
+		const options = container.getAllByTestId('task-composer-target-option');
+		fireEvent.click(options[1]);
+
+		const textarea = getTextarea(container);
+		expect(container.getByTestId('task-composer-target-trigger').getAttribute('title')).toBe(
+			'Send to Reviewer'
+		);
+		typeIntoTextarea(textarea, 'Please review again');
+		fireEvent.click(container.getByTestId('send-button'));
+
+		await waitFor(() =>
+			expect(mockSendTaskMessage).toHaveBeenCalledWith('task-1', 'Please review again', {
+				kind: 'node_agent',
+				agentName: 'Reviewer',
+				nodeExecutionId: 'exec-reviewer',
+			})
+		);
+		await waitFor(() =>
+			expect(container.getByTestId('task-composer-target-trigger').getAttribute('title')).toBe(
+				'Send to Coder'
+			)
+		);
+	});
+
+	it('auto-targets the task agent when the visible turn is addressed to task agent', async () => {
+		mockTasks.value = [makeWorkflowTask()];
+		mockThreadTurns.push({ fromLabel: 'Coder Agent', toLabel: 'Task Agent agent' });
+		const rectSpy = vi
+			.spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+			.mockImplementation(function () {
+				if ((this as HTMLElement).getAttribute('data-testid') === 'minimal-thread-turn') {
+					return { top: 20, bottom: 80, left: 0, right: 100, width: 100, height: 60 } as DOMRect;
+				}
+				return { top: 0, bottom: 100, left: 0, right: 100, width: 100, height: 100 } as DOMRect;
+			});
+
+		const container = render(<SpaceTaskPane taskId="task-1" />);
+
+		await waitFor(() =>
+			expect(container.getByTestId('task-composer-target-trigger').getAttribute('title')).toBe(
+				'Send to Task Agent'
+			)
+		);
+		rectSpy.mockRestore();
+	});
+
+	it('auto-targets the lowest visible turn instead of a tall row extending below the viewport', async () => {
+		mockTasks.value = [makeWorkflowTask()];
+		mockThreadTurns.push(
+			{ fromLabel: 'Agent', toLabel: 'Coder Agent' },
+			{ fromLabel: 'Coder Agent', toLabel: 'Reviewer Agent' }
+		);
+		const rectSpy = vi
+			.spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+			.mockImplementation(function () {
+				if ((this as HTMLElement).getAttribute('data-testid') === 'minimal-thread-turn') {
+					const toLabel = (this as HTMLElement).dataset.toLabel;
+					if (toLabel === 'Coder Agent') {
+						return {
+							top: 0,
+							bottom: 1000,
+							left: 0,
+							right: 100,
+							width: 100,
+							height: 1000,
+						} as DOMRect;
+					}
+					return { top: 80, bottom: 120, left: 0, right: 100, width: 100, height: 40 } as DOMRect;
+				}
+				return { top: 0, bottom: 100, left: 0, right: 100, width: 100, height: 100 } as DOMRect;
+			});
+
+		const container = render(<SpaceTaskPane taskId="task-1" />);
+
+		await waitFor(() =>
+			expect(container.getByTestId('task-composer-target-trigger').getAttribute('title')).toBe(
+				'Send to Reviewer'
+			)
+		);
+		rectSpy.mockRestore();
 	});
 
 	it('filters agents when @partial is typed', async () => {

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -1,6 +1,7 @@
 // @ts-nocheck
 
 import type {
+	NodeExecution,
 	SpaceAgent,
 	SpaceTask,
 	SpaceTaskActivityMember,
@@ -83,6 +84,7 @@ let mockAgents: ReturnType<typeof signal<SpaceAgent[]>>;
 let mockWorkflows: ReturnType<typeof signal<SpaceWorkflow[]>>;
 let mockWorkflowRuns: ReturnType<typeof signal<SpaceWorkflowRun[]>>;
 let mockTaskActivity: ReturnType<typeof signal<Map<string, SpaceTaskActivityMember[]>>>;
+let mockNodeExecutions: ReturnType<typeof signal<NodeExecution[]>>;
 let mockNodeExecutionsByNodeId: ReturnType<typeof signal<Map<string, unknown[]>>>;
 
 const mockUpdateTask = vi.fn().mockResolvedValue(undefined);
@@ -100,6 +102,7 @@ vi.mock('../../../lib/space-store', () => ({
 			workflows: mockWorkflows,
 			workflowRuns: mockWorkflowRuns,
 			taskActivity: mockTaskActivity,
+			nodeExecutions: mockNodeExecutions,
 			nodeExecutionsByNodeId: mockNodeExecutionsByNodeId,
 			updateTask: mockUpdateTask,
 			submitForReview: mockSubmitForReview,
@@ -189,6 +192,7 @@ mockAgents = signal<SpaceAgent[]>([]);
 mockWorkflows = signal<SpaceWorkflow[]>([]);
 mockWorkflowRuns = signal<SpaceWorkflowRun[]>([]);
 mockTaskActivity = signal<Map<string, SpaceTaskActivityMember[]>>(new Map());
+mockNodeExecutions = signal<NodeExecution[]>([]);
 mockNodeExecutionsByNodeId = signal<Map<string, unknown[]>>(new Map());
 
 import { SpaceTaskPane } from '../SpaceTaskPane';
@@ -216,6 +220,7 @@ describe('SpaceTaskPane', () => {
 		mockWorkflows.value = [];
 		mockWorkflowRuns.value = [];
 		mockTaskActivity.value = new Map();
+		mockNodeExecutions.value = [];
 		mockUpdateTask.mockClear();
 		mockEnsureTaskAgentSession.mockReset();
 		mockEnsureTaskAgentSession.mockImplementation(async () =>
@@ -310,7 +315,9 @@ describe('SpaceTaskPane — composer', () => {
 		fireEvent.click(getByTestId('send-button'));
 
 		await waitFor(() =>
-			expect(mockSendTaskMessage).toHaveBeenCalledWith('task-1', 'Looks good to me')
+			expect(mockSendTaskMessage).toHaveBeenCalledWith('task-1', 'Looks good to me', {
+				kind: 'task_agent',
+			})
 		);
 		expect(mockEnsureTaskAgentSession).not.toHaveBeenCalled();
 	});
@@ -367,7 +374,9 @@ describe('SpaceTaskPane — composer', () => {
 		fireEvent.submit(textarea.form!);
 
 		await waitFor(() =>
-			expect(mockSendTaskMessage).toHaveBeenCalledWith('task-1', 'Approve the PR')
+			expect(mockSendTaskMessage).toHaveBeenCalledWith('task-1', 'Approve the PR', {
+				kind: 'task_agent',
+			})
 		);
 		await waitFor(() => expect(textarea.value).toBe(''));
 	});
@@ -381,7 +390,9 @@ describe('SpaceTaskPane — composer', () => {
 		fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
 
 		await waitFor(() =>
-			expect(mockSendTaskMessage).toHaveBeenCalledWith('task-1', 'Quick approve')
+			expect(mockSendTaskMessage).toHaveBeenCalledWith('task-1', 'Quick approve', {
+				kind: 'task_agent',
+			})
 		);
 	});
 

--- a/packages/web/src/components/space/__tests__/SpaceTaskUnifiedThread.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskUnifiedThread.test.tsx
@@ -89,6 +89,15 @@ describe('SpaceTaskUnifiedThread', () => {
 		expect(screen.getAllByTestId('minimal-thread-turn').length).toBeGreaterThan(0);
 	});
 
+	it('reports the actual scroll container to the parent', () => {
+		const onScrollerChange = vi.fn();
+		render(<SpaceTaskUnifiedThread taskId="task-1" onScrollerChange={onScrollerChange} />);
+
+		const scroller = screen.getByTestId('space-task-unified-thread').firstElementChild;
+		expect(scroller).toBeInstanceOf(HTMLDivElement);
+		expect(onScrollerChange).toHaveBeenCalledWith(scroller);
+	});
+
 	it('does not render the legacy floating agent-name tag', () => {
 		// The compact-mode-only sticky agent label has been removed; minimal
 		// rows carry their own per-row header so the floating tag is redundant.

--- a/packages/web/src/components/space/__tests__/TaskArtifactsPanel.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskArtifactsPanel.test.tsx
@@ -442,6 +442,7 @@ describe('SpaceTaskPane — artifacts toggle', () => {
 					agents: signal([]),
 					workflows: signal([]),
 					workflowRuns: signal([]),
+					nodeExecutions: signal([]),
 					updateTask: vi.fn().mockResolvedValue(undefined),
 					ensureTaskAgentSession: vi.fn().mockResolvedValue({
 						id: 'task-1',
@@ -521,6 +522,7 @@ describe('SpaceTaskPane — artifacts toggle', () => {
 					agents: signal([]),
 					workflows: signal([]),
 					workflowRuns: signal([]),
+					nodeExecutions: signal([]),
 					updateTask: vi.fn().mockResolvedValue(undefined),
 					ensureTaskAgentSession: vi.fn().mockResolvedValue({ id: 'task-2' }),
 					sendTaskMessage: vi.fn().mockResolvedValue(undefined),
@@ -595,6 +597,7 @@ describe('SpaceTaskPane — artifacts toggle', () => {
 					agents: signal([]),
 					workflows: signal([]),
 					workflowRuns: signal([]),
+					nodeExecutions: signal([]),
 					updateTask: vi.fn().mockResolvedValue(undefined),
 					ensureTaskAgentSession: vi.fn().mockResolvedValue({
 						id: 'task-3',

--- a/packages/web/src/components/space/__tests__/TaskSessionChatComposer.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskSessionChatComposer.test.tsx
@@ -65,7 +65,9 @@ function renderComposer(overrides: Partial<Parameters<typeof TaskSessionChatComp
 			canSend={true}
 			isSending={false}
 			isProcessing={false}
+			autoScroll={true}
 			errorMessage={null}
+			onAutoScrollChange={vi.fn()}
 			onTargetSelect={onTargetSelect}
 			onSend={onSend}
 			{...overrides}
@@ -148,6 +150,13 @@ describe('TaskSessionChatComposer', () => {
 	it('forwards isProcessing to ChatComposer', () => {
 		renderComposer({ isProcessing: true });
 		expect(lastChatComposerProps?.isProcessing).toBe(true);
+	});
+
+	it('forwards auto-scroll state to ChatComposer', () => {
+		const onAutoScrollChange = vi.fn();
+		renderComposer({ autoScroll: false, onAutoScrollChange });
+		expect(lastChatComposerProps?.autoScroll).toBe(false);
+		expect(lastChatComposerProps?.onAutoScrollChange).toBe(onAutoScrollChange);
 	});
 
 	it('renders a recipient picker in the input leading slot', () => {

--- a/packages/web/src/components/space/__tests__/TaskSessionChatComposer.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskSessionChatComposer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { cleanup, render } from '@testing-library/preact';
+import { cleanup, fireEvent, render } from '@testing-library/preact';
 import type { ChatComposerProps } from '../../ChatComposer';
 
 // Mock useModelSwitcher — avoids real WebSocket/RPC calls in unit tests
@@ -27,7 +27,9 @@ vi.mock('../../ChatComposer', () => ({
 				data-session-id={props.sessionId}
 				data-is-waiting={String(props.isWaitingForInput)}
 				data-placeholder={props.inputPlaceholder}
-			/>
+			>
+				{props.inputLeadingElement}
+			</div>
 		);
 	},
 }));
@@ -38,23 +40,38 @@ const mentionCandidates = [
 	{ id: 'a1', name: 'Coder' },
 	{ id: 'a2', name: 'Reviewer' },
 ];
+const targets = [
+	{
+		id: 'node:n1:coder',
+		kind: 'node_agent' as const,
+		label: 'Coder',
+		agentName: 'coder',
+		nodeName: 'Coding',
+		state: 'Active',
+	},
+	{ id: 'task-agent', kind: 'task_agent' as const, label: 'Task Agent' },
+];
 
 function renderComposer(overrides: Partial<Parameters<typeof TaskSessionChatComposer>[0]> = {}) {
 	const onSend = vi.fn().mockResolvedValue(true);
+	const onTargetSelect = vi.fn();
 	const view = render(
 		<TaskSessionChatComposer
 			sessionId="task-session-id"
 			mentionCandidates={mentionCandidates}
+			targets={targets}
+			selectedTargetId="node:n1:coder"
 			hasTaskAgentSession={true}
 			canSend={true}
 			isSending={false}
 			isProcessing={false}
 			errorMessage={null}
+			onTargetSelect={onTargetSelect}
 			onSend={onSend}
 			{...overrides}
 		/>
 	);
-	return { ...view, onSend };
+	return { ...view, onSend, onTargetSelect };
 }
 
 describe('TaskSessionChatComposer', () => {
@@ -120,16 +137,33 @@ describe('TaskSessionChatComposer', () => {
 
 	it('uses task agent session placeholder when hasTaskAgentSession is true', () => {
 		renderComposer({ hasTaskAgentSession: true });
-		expect(lastChatComposerProps?.inputPlaceholder).toBe('Message task agent...');
+		expect(lastChatComposerProps?.inputPlaceholder).toBe('Message Coder...');
 	});
 
 	it('uses auto-start placeholder when hasTaskAgentSession is false', () => {
-		renderComposer({ hasTaskAgentSession: false });
+		renderComposer({ hasTaskAgentSession: false, targets: [], selectedTargetId: null });
 		expect(lastChatComposerProps?.inputPlaceholder).toBe('Message task agent (auto-start)...');
 	});
 
 	it('forwards isProcessing to ChatComposer', () => {
 		renderComposer({ isProcessing: true });
 		expect(lastChatComposerProps?.isProcessing).toBe(true);
+	});
+
+	it('renders a recipient picker in the input leading slot', () => {
+		const { getByTestId } = renderComposer();
+		const trigger = getByTestId('task-composer-target-trigger');
+		expect(trigger.textContent).toBe('C');
+		expect(trigger.getAttribute('title')).toBe('Send to Coder');
+		expect(trigger.getAttribute('aria-haspopup')).toBe('menu');
+		expect(lastChatComposerProps?.inputLeadingPaddingClass).toBe('pl-12');
+		expect(lastChatComposerProps?.inputLeadingElement).toBeTruthy();
+	});
+
+	it('calls onTargetSelect when a recipient is selected', () => {
+		const { getByTestId, getAllByTestId, onTargetSelect } = renderComposer();
+		fireEvent.click(getByTestId('task-composer-target-trigger'));
+		fireEvent.click(getAllByTestId('task-composer-target-option')[1]);
+		expect(onTargetSelect).toHaveBeenCalledWith('task-agent');
 	});
 });

--- a/packages/web/src/hooks/__tests__/useInputDraft.test.ts
+++ b/packages/web/src/hooks/__tests__/useInputDraft.test.ts
@@ -351,10 +351,10 @@ describe('useInputDraft', () => {
 				result.current.setContent('');
 			});
 
-			// Should save immediately with undefined (no debounce for clearing)
+			// Should save immediately with null (undefined is dropped by JSON-RPC serialization)
 			expect(mockHub.request).toHaveBeenCalledWith('session.update', {
 				sessionId: 'session-1',
-				metadata: { inputDraft: undefined },
+				metadata: { inputDraft: null },
 			});
 		});
 
@@ -511,7 +511,7 @@ describe('useInputDraft', () => {
 			// Should clear immediately
 			expect(mockHub.request).toHaveBeenCalledWith('session.update', {
 				sessionId: 'session-1',
-				metadata: { inputDraft: undefined },
+				metadata: { inputDraft: null },
 			});
 		});
 

--- a/packages/web/src/hooks/useInputDraft.ts
+++ b/packages/web/src/hooks/useInputDraft.ts
@@ -106,7 +106,7 @@ export function useInputDraft(sessionId: string, debounceMs = 250): UseInputDraf
 					.request('session.update', {
 						sessionId: prevSessionId,
 						metadata: {
-							inputDraft: trimmedContent || undefined,
+							inputDraft: trimmedContent || null,
 						},
 					})
 					.catch(() => {
@@ -126,7 +126,7 @@ export function useInputDraft(sessionId: string, debounceMs = 250): UseInputDraf
 					.request('session.update', {
 						sessionId,
 						metadata: {
-							inputDraft: undefined,
+							inputDraft: null,
 						},
 					})
 					.catch(() => {

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -1105,7 +1105,9 @@ export default function ChatContainer({
 				</div>
 
 				{/* Scroll Button - positioned relative to container, not scrollable content */}
-				{showScrollButton && <ScrollToBottomButton onClick={() => scrollToBottom(true)} />}
+				{showScrollButton && (
+					<ScrollToBottomButton onClick={() => scrollToBottom(true)} autoScroll={autoScroll} />
+				)}
 			</div>
 
 			{/* Footer - Floating Status Bar */}

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -1647,7 +1647,13 @@ class SpaceStore {
 	/**
 	 * Send a human message into a task's agent thread.
 	 */
-	async sendTaskMessage(taskId: string, message: string): Promise<void> {
+	async sendTaskMessage(
+		taskId: string,
+		message: string,
+		target?:
+			| { kind: 'task_agent' }
+			| { kind: 'node_agent'; agentName: string; nodeExecutionId?: string }
+	): Promise<void> {
 		const spaceId = this.spaceId.value;
 		if (!spaceId) throw new Error('No space selected');
 
@@ -1658,6 +1664,7 @@ class SpaceStore {
 			taskId,
 			spaceId,
 			message,
+			...(target ? { target } : {}),
 		});
 	}
 


### PR DESCRIPTION
## Summary

- Add explicit task composer targeting for workflow node agents and the task agent fallback.
- Route `space.task.sendMessage` to selected workflow node-agent sessions, activating node sessions when needed.
- Auto-select the composer target from the visible task thread content, with manual selection released on empty-composer scroll.
- Fix task composer draft cleanup so sent text does not return after refresh.

## Impact

Users can message the relevant workflow agent directly from the task view instead of routing everything through the task agent. The compact avatar target picker keeps the composer usable on mobile, while the selected target follows the visible thread context when the composer is empty.

## Validation

- `bun run test -- src/components/space/__tests__/SpaceTaskPane.mention.test.tsx`
- `bun run typecheck`
- `bun run lint`
- pre-commit checks: lint, format, typecheck, knip

E2E was intentionally skipped per request.