### PR TITLE
chore(release): bump version to 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to NeoKai will be documented in this file.
 
+## [0.14.0] - 2026-04-24
+
+A release introducing the Tauri desktop wrapper, server-derived active-turn tracking, and workflow definition improvements. 10 commits since v0.13.0.
+
+### Added
+
+- **`@neokai/desktop` Tauri wrapper**: Bundles daemon as sidecar for native desktop app
+- **Server-derived active-turn roster**: Decoupled from compact feed for accurate per-agent turn tracking
+- **Lazy workflow agent activation**: Agents activate on first message instead of at workflow start
+
+### Changed
+
+- Per-node timeouts moved from runtime constants into workflow definitions
+- Removed all `report_result` references
+
+### Fixed
+
+- Space migrations made idempotent with foreign keys
+- Reviewer terminal actions forbidden while P0–P3 findings are open
+- Active-turn rail tracked per agent label
+- Space task view polished (Codex)
+
+### Dependencies
+
+- Patch + minor bumps across the monorepo
+
 ## [0.13.0] - 2026-04-23
 
 A major release replacing the completion-actions pipeline with workflow-declared post-approval routing, unifying the MCP/Tools modal, and hardening daemon restart resilience. 38 commits since v0.12.0.

--- a/npm/neokai/package.json
+++ b/npm/neokai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neokai",
-	"version": "0.13.0",
+	"version": "0.14.0",
 	"description": "NeoKai - Claude Agent SDK Web Interface",
 	"bin": {
 		"kai": "bin/kai.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/cli",
-	"version": "0.13.0",
+	"version": "0.14.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"bin": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/daemon",
-	"version": "0.13.0",
+	"version": "0.14.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "main.ts",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/e2e",
-	"version": "0.13.0",
+	"version": "0.14.0",
 	"private": true,
 	"license": "Apache-2.0",
 	"type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/shared",
-	"version": "0.13.0",
+	"version": "0.14.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "src/mod.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/ui",
-	"version": "0.13.0",
+	"version": "0.14.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "src/mod.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/web",
-	"version": "0.13.0",
+	"version": "0.14.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"scripts": {


### PR DESCRIPTION
Tauri desktop wrapper, server-derived active-turn tracking, and workflow definition improvements.