### PR TITLE
fix(space): unify Active-tab filter between sidebar and tasks view

### DIFF
--- a/packages/web/src/components/space/SpaceTasks.tsx
+++ b/packages/web/src/components/space/SpaceTasks.tsx
@@ -1,7 +1,9 @@
 /**
  * SpaceTasks — tabbed task list for a space.
  *
- * Tabs: Action (review + blocked, grouped by reason), Active (open + in_progress),
+ * Tabs: Action (review + blocked, grouped by reason),
+ *       Active (open + in_progress + approved — see `task-filters.ts` for why
+ *       `approved` belongs here),
  *       Completed (done + cancelled), Archived.
  *
  * Within each tab, tasks are grouped by status/reason in TaskGroup cards,
@@ -42,8 +44,13 @@ const ATTENTION_BLOCK_REASONS: SpaceBlockReason[] = ['human_input_requested', 'g
  * badge, "Active"/"Action" sub-tabs). Both surfaces import from the same
  * helper so the lists and the badge counts cannot drift apart — see the
  * `task-filters.ts` doc comments for why `approved` belongs in Active.
+ *
+ * Exported for tests that assert the tasks-view's `active` predicate
+ * matches the sidebar's `isActiveTask` exactly. Keeping this exported is
+ * a regression guard: if someone later re-inlines the predicate here,
+ * the parity test in `task-filters.test.ts` will fail.
  */
-const TAB_PREDICATES: Record<TaskFilterTab, (task: SpaceTask) => boolean> = {
+export const TAB_PREDICATES: Record<TaskFilterTab, (task: SpaceTask) => boolean> = {
 	action: isActionRequired,
 	active: isActiveTask,
 	completed: (t) => t.status === 'done' || t.status === 'cancelled',

--- a/packages/web/src/components/space/SpaceTasks.tsx
+++ b/packages/web/src/components/space/SpaceTasks.tsx
@@ -8,17 +8,17 @@
  * matching the RoomTasks component style.
  */
 
-import { useEffect, useMemo, useState } from 'preact/hooks';
-import { spaceStore } from '../../lib/space-store';
 import type { SpaceBlockReason, SpaceTask, SpaceTaskStatus } from '@neokai/shared';
-import { isActionRequired } from '../../lib/task-filters';
-import { getRelativeTime } from '../../lib/utils';
+import { useEffect, useMemo, useState } from 'preact/hooks';
+import { navigateToSpaceTasks } from '../../lib/router';
 import {
+	currentSpaceIdSignal,
 	currentSpaceTasksFilterSignal,
 	currentSpaceTasksFilterTabSignal,
-	currentSpaceIdSignal,
 } from '../../lib/signals';
-import { navigateToSpaceTasks } from '../../lib/router';
+import { spaceStore } from '../../lib/space-store';
+import { isActionRequired, isActiveTask } from '../../lib/task-filters';
+import { getRelativeTime } from '../../lib/utils';
 
 type TaskFilterTab = 'action' | 'active' | 'completed' | 'archived';
 
@@ -36,21 +36,16 @@ function isAwaitingTaskCompletion(task: SpaceTask): boolean {
 const ATTENTION_BLOCK_REASONS: SpaceBlockReason[] = ['human_input_requested', 'gate_rejected'];
 
 /**
- * Per-tab membership predicates. The `action` predicate is the shared
- * `isActionRequired` from `task-filters.ts`, which is the single source of
- * truth used by the Tasks-nav badge in `SpaceDetailPanel` — the badge and
- * this tab list cannot drift.
- *
- * `approved` is transient (post-approval sub-session runs, then
- * `mark_complete` transitions `approved → done`). We route it to the
- * `active` tab so a stuck `approved` task (e.g. with
- * `postApprovalBlockedReason` set) remains visible to the user rather
- * than disappearing between tabs. The task-detail pane's
- * PendingPostApprovalBanner surfaces the actionable failure state.
+ * Per-tab membership predicates. The `action` and `active` predicates are
+ * the shared helpers from `task-filters.ts`, which are the single source
+ * of truth also used by the sidebar in `SpaceDetailPanel` (Tasks-nav
+ * badge, "Active"/"Action" sub-tabs). Both surfaces import from the same
+ * helper so the lists and the badge counts cannot drift apart — see the
+ * `task-filters.ts` doc comments for why `approved` belongs in Active.
  */
 const TAB_PREDICATES: Record<TaskFilterTab, (task: SpaceTask) => boolean> = {
 	action: isActionRequired,
-	active: (t) => t.status === 'open' || t.status === 'in_progress' || t.status === 'approved',
+	active: isActiveTask,
 	completed: (t) => t.status === 'done' || t.status === 'cancelled',
 	archived: (t) => t.status === 'archived',
 };

--- a/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
@@ -74,7 +74,8 @@ vi.mock('../../../lib/utils', () => ({
 
 mockTasks = signal<SpaceTask[]>([]);
 
-import { SpaceTasks } from '../SpaceTasks';
+import { isActiveTask } from '../../../lib/task-filters';
+import { SpaceTasks, TAB_PREDICATES } from '../SpaceTasks';
 
 function makeTask(
 	id: string,
@@ -479,6 +480,66 @@ describe('SpaceTasks', () => {
 			// Toggle off via Clear filter
 			fireEvent.click(getByTestId('tasks-filter-clear'));
 			expect(getByText('Task t2')).toBeTruthy();
+		});
+	});
+
+	describe("Active-tab parity with sidebar's isActiveTask", () => {
+		// The sidebar in `SpaceDetailPanel` calls `isActiveTask` directly;
+		// the tasks-view here goes through `TAB_PREDICATES.active`. This
+		// suite asserts those two paths agree across every `SpaceTaskStatus`,
+		// so a future re-inlining of the predicate in `SpaceTasks.tsx` (the
+		// shape the original bug took) would fail loudly here rather than
+		// silently shipping diverging Active lists.
+		const ALL_STATUSES: SpaceTask['status'][] = [
+			'open',
+			'in_progress',
+			'review',
+			'approved',
+			'done',
+			'blocked',
+			'cancelled',
+			'archived',
+		];
+
+		it('TAB_PREDICATES.active and isActiveTask classify every status identically', () => {
+			for (const status of ALL_STATUSES) {
+				const task = makeTask(`t-${status}`, status);
+				expect({ status, value: TAB_PREDICATES.active(task) }).toEqual({
+					status,
+					value: isActiveTask(task),
+				});
+			}
+		});
+
+		it('produces the same set of task IDs as the sidebar over a heterogeneous fixture', () => {
+			// Mirrors the bug scenario: a mixed list including approved
+			// rows. Both consumers must select the exact same IDs.
+			const fixture: SpaceTask[] = [
+				makeTask('t-open-1', 'open'),
+				makeTask('t-open-2', 'open'),
+				makeTask('t-inprog', 'in_progress'),
+				makeTask('t-review', 'review'),
+				makeTask('t-approved-1', 'approved'),
+				makeTask('t-approved-2', 'approved'),
+				makeTask('t-done', 'done'),
+				makeTask('t-blocked', 'blocked'),
+				makeTask('t-cancelled', 'cancelled'),
+				makeTask('t-archived', 'archived'),
+			];
+
+			const sidebarIds = fixture
+				.filter(isActiveTask)
+				.map((t) => t.id)
+				.sort();
+			const tasksViewIds = fixture
+				.filter(TAB_PREDICATES.active)
+				.map((t) => t.id)
+				.sort();
+
+			expect(tasksViewIds).toEqual(sidebarIds);
+			expect(sidebarIds).toEqual(
+				['t-approved-1', 't-approved-2', 't-inprog', 't-open-1', 't-open-2'].sort()
+			);
 		});
 	});
 });

--- a/packages/web/src/islands/SpaceDetailPanel.tsx
+++ b/packages/web/src/islands/SpaceDetailPanel.tsx
@@ -39,6 +39,10 @@ const taskStatusColors: Record<string, string> = {
 	in_progress: 'bg-blue-500',
 	blocked: 'bg-amber-500',
 	review: 'bg-purple-500',
+	// `approved` tasks now appear in the sidebar Active tab — match the
+	// emerald accent used by `SpaceTasks.tsx` (`STATUS_BORDER`) so the dot
+	// colour reads consistently across both surfaces.
+	approved: 'bg-emerald-500',
 	done: 'bg-green-500',
 	cancelled: 'bg-gray-600',
 	archived: 'bg-gray-700',

--- a/packages/web/src/islands/__tests__/SpaceDetailPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/SpaceDetailPanel.test.tsx
@@ -4,10 +4,10 @@
  * Covers overview/agent navigation, task tab defaults, counters, and sessions behavior.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, fireEvent, cleanup, screen, within } from '@testing-library/preact';
-import { signal, type Signal } from '@preact/signals';
-import type { SpaceTask, Space } from '@neokai/shared';
+import type { Space, SpaceTask } from '@neokai/shared';
+import { type Signal, signal } from '@preact/signals';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/preact';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
 	mockNavigateToSpace,
@@ -420,6 +420,29 @@ describe('SpaceDetailPanel', () => {
 			// would come from the badge, which renders only when count > 0.
 			expect(within(tasksNav).queryByText('2')).toBeNull();
 			expect(within(tasksNav).queryByText('1')).toBeNull();
+		});
+
+		it('shows approved (post-approval running) tasks under the Active tab', () => {
+			// Regression: the sidebar "Active" tab and the main-pane Tasks
+			// "Active" tab disagreed about `approved` tasks — the sidebar
+			// hid them while the tasks-view surfaced them. Both now share
+			// `isActiveTask` from `task-filters.ts`, which includes
+			// `approved` so a stuck post-approval task stays visible.
+			mockTasksSignal.value = [
+				makeTask('t1', 'Approved Task', 'approved'),
+				makeTask('t2', 'Open Task', 'open'),
+				makeTask('t3', 'Blocked Task', 'blocked'),
+			];
+			render(<SpaceDetailPanel spaceId="space-1" />);
+
+			fireEvent.click(screen.getByRole('button', { name: /Active/i }));
+			expect(screen.getByText('Approved Task')).toBeTruthy();
+			expect(screen.getByText('Open Task')).toBeTruthy();
+			expect(screen.queryByText('Blocked Task')).toBeNull();
+
+			// Active count should include the approved task (2 = open + approved)
+			const activeTab = screen.getByRole('button', { name: /Active/i });
+			expect(within(activeTab).getByText('2')).toBeTruthy();
 		});
 
 		it('multiple tasks created via different paths all appear in panel', () => {

--- a/packages/web/src/lib/__tests__/task-filters.test.ts
+++ b/packages/web/src/lib/__tests__/task-filters.test.ts
@@ -82,16 +82,14 @@ describe('isActionRequired and isActiveTask are mutually exclusive', () => {
 /**
  * Regression test for the bug where the sidebar "Active" tab and the
  * main-pane Tasks "Active" tab disagreed about whether `approved` tasks
- * belong in Active. Both surfaces now import the same `isActiveTask`
- * predicate; this test verifies the predicate's output across the
- * complete status surface so any future drift would fail loudly.
- *
- * The fixture mirrors how both consumers compute their lists: filter a
- * heterogeneous task set with the predicate and compare the resulting
- * task IDs. If both consumers go through the same helper, the resulting
- * sets must be identical.
+ * belong in Active. The fixture covers every `SpaceTaskStatus` and asserts
+ * the predicate's output over a heterogeneous list. The companion check
+ * that the tasks-view's `TAB_PREDICATES.active` resolves to the same
+ * function lives in `SpaceTasks.test.tsx` (where the necessary signal /
+ * store mocks are already configured), keeping this file focused on the
+ * pure-function predicate behaviour.
  */
-describe('Active filter parity across consumers', () => {
+describe('Active filter — fixture coverage', () => {
 	type Row = { id: string; status: SpaceTaskStatus };
 
 	const fixture: Row[] = [
@@ -107,23 +105,11 @@ describe('Active filter parity across consumers', () => {
 		{ id: 'archived-1', status: 'archived' },
 	];
 
-	// Both consumers reduce to: `tasks.filter(isActiveTask).map(t => t.id)`.
-	// Modeling each path independently makes the parity assertion explicit
-	// rather than relying on a shared import alone.
-	const sidebarActiveIds = (rows: Row[]): string[] =>
-		rows.filter((r) => isActiveTask({ status: r.status })).map((r) => r.id);
-
-	const tasksViewActiveIds = (rows: Row[]): string[] =>
-		rows.filter((r) => isActiveTask({ status: r.status })).map((r) => r.id);
-
-	it('sidebar and tasks-view produce the same set of task IDs', () => {
-		const sidebarSet = new Set(sidebarActiveIds(fixture));
-		const tasksViewSet = new Set(tasksViewActiveIds(fixture));
-		expect([...sidebarSet].sort()).toEqual([...tasksViewSet].sort());
-	});
-
 	it('selects exactly the open / in_progress / approved rows', () => {
-		const ids = sidebarActiveIds(fixture).sort();
+		const ids = fixture
+			.filter((r) => isActiveTask({ status: r.status }))
+			.map((r) => r.id)
+			.sort();
 		expect(ids).toEqual(['approved-1', 'approved-2', 'in_progress-1', 'open-1', 'open-2'].sort());
 	});
 

--- a/packages/web/src/lib/__tests__/task-filters.test.ts
+++ b/packages/web/src/lib/__tests__/task-filters.test.ts
@@ -3,8 +3,8 @@
  * the sidebar Tasks badge in `SpaceDetailPanel`.
  */
 
-import { describe, expect, it } from 'vitest';
 import type { SpaceTask, SpaceTaskStatus } from '@neokai/shared';
+import { describe, expect, it } from 'vitest';
 import { isActionRequired, isActiveTask } from '../task-filters';
 
 const ALL_STATUSES: SpaceTaskStatus[] = [
@@ -49,19 +49,23 @@ describe('isActionRequired', () => {
 });
 
 describe('isActiveTask', () => {
-	it.each(['open', 'in_progress'] as const)('returns true for %s status', (status) => {
+	it.each(['open', 'in_progress', 'approved'] as const)('returns true for %s status', (status) => {
 		expect(isActiveTask(makeTask(status))).toBe(true);
 	});
 
 	it.each([
 		'review',
 		'blocked',
-		'approved',
 		'done',
 		'cancelled',
 		'archived',
 	] as const)('returns false for %s status', (status) => {
 		expect(isActiveTask(makeTask(status))).toBe(false);
+	});
+
+	it('classifies the full status set deterministically', () => {
+		const matching = ALL_STATUSES.filter((s) => isActiveTask(makeTask(s)));
+		expect(matching.sort()).toEqual(['approved', 'in_progress', 'open']);
 	});
 });
 
@@ -71,6 +75,73 @@ describe('isActionRequired and isActiveTask are mutually exclusive', () => {
 			const task = makeTask(status);
 			const both = isActionRequired(task) && isActiveTask(task);
 			expect(both).toBe(false);
+		}
+	});
+});
+
+/**
+ * Regression test for the bug where the sidebar "Active" tab and the
+ * main-pane Tasks "Active" tab disagreed about whether `approved` tasks
+ * belong in Active. Both surfaces now import the same `isActiveTask`
+ * predicate; this test verifies the predicate's output across the
+ * complete status surface so any future drift would fail loudly.
+ *
+ * The fixture mirrors how both consumers compute their lists: filter a
+ * heterogeneous task set with the predicate and compare the resulting
+ * task IDs. If both consumers go through the same helper, the resulting
+ * sets must be identical.
+ */
+describe('Active filter parity across consumers', () => {
+	type Row = { id: string; status: SpaceTaskStatus };
+
+	const fixture: Row[] = [
+		{ id: 'open-1', status: 'open' },
+		{ id: 'open-2', status: 'open' },
+		{ id: 'in_progress-1', status: 'in_progress' },
+		{ id: 'review-1', status: 'review' },
+		{ id: 'approved-1', status: 'approved' },
+		{ id: 'approved-2', status: 'approved' },
+		{ id: 'done-1', status: 'done' },
+		{ id: 'blocked-1', status: 'blocked' },
+		{ id: 'cancelled-1', status: 'cancelled' },
+		{ id: 'archived-1', status: 'archived' },
+	];
+
+	// Both consumers reduce to: `tasks.filter(isActiveTask).map(t => t.id)`.
+	// Modeling each path independently makes the parity assertion explicit
+	// rather than relying on a shared import alone.
+	const sidebarActiveIds = (rows: Row[]): string[] =>
+		rows.filter((r) => isActiveTask({ status: r.status })).map((r) => r.id);
+
+	const tasksViewActiveIds = (rows: Row[]): string[] =>
+		rows.filter((r) => isActiveTask({ status: r.status })).map((r) => r.id);
+
+	it('sidebar and tasks-view produce the same set of task IDs', () => {
+		const sidebarSet = new Set(sidebarActiveIds(fixture));
+		const tasksViewSet = new Set(tasksViewActiveIds(fixture));
+		expect([...sidebarSet].sort()).toEqual([...tasksViewSet].sort());
+	});
+
+	it('selects exactly the open / in_progress / approved rows', () => {
+		const ids = sidebarActiveIds(fixture).sort();
+		expect(ids).toEqual(['approved-1', 'approved-2', 'in_progress-1', 'open-1', 'open-2'].sort());
+	});
+
+	it('every status is covered by exactly one of action / active / completed / archived (no orphan)', () => {
+		// Mirrors the 4-tab partition in SpaceTasks. `review` and `blocked`
+		// land in action; `open`/`in_progress`/`approved` land in active;
+		// `done`/`cancelled` land in completed; `archived` lands in archived.
+		const completedStatuses: SpaceTaskStatus[] = ['done', 'cancelled'];
+		const archivedStatuses: SpaceTaskStatus[] = ['archived'];
+
+		for (const status of ALL_STATUSES) {
+			const task = makeTask(status);
+			const inAction = isActionRequired(task);
+			const inActive = isActiveTask(task);
+			const inCompleted = completedStatuses.includes(status);
+			const inArchived = archivedStatuses.includes(status);
+			const memberships = [inAction, inActive, inCompleted, inArchived].filter(Boolean).length;
+			expect({ status, memberships }).toEqual({ status, memberships: 1 });
 		}
 	});
 });

--- a/packages/web/src/lib/task-filters.ts
+++ b/packages/web/src/lib/task-filters.ts
@@ -33,9 +33,23 @@ export function isActionRequired(task: ActionRequiredTaskInput): boolean {
 
 /**
  * Returns true when a task is actively progressing — not yet awaiting
- * human action and not yet in a terminal state. Used by the "Active"
- * tab in `SpaceDetailPanel`.
+ * human action and not yet in a terminal state.
+ *
+ * Single source of truth for the "Active" tab — used by BOTH the sidebar
+ * `SpaceDetailPanel` and the main-pane `SpaceTasks` view, so the two
+ * surfaces cannot disagree about which tasks are Active.
+ *
+ * Includes:
+ * - `open`, `in_progress`: the obvious cases — work has started or is
+ *   ready to start, no human gate.
+ * - `approved`: a transient post-approval state. After `approve_task`,
+ *   the task sits in `approved` while the post-approval sub-session
+ *   runs; `mark_complete` then transitions `approved → done`. Routing
+ *   `approved` to Active keeps a task stuck in this state (e.g. with
+ *   `postApprovalBlockedReason` populated because dispatch failed)
+ *   visible to the user. The task-detail pane's
+ *   `PendingPostApprovalBanner` surfaces the actionable failure.
  */
 export function isActiveTask(task: ActionRequiredTaskInput): boolean {
-	return task.status === 'open' || task.status === 'in_progress';
+	return task.status === 'open' || task.status === 'in_progress' || task.status === 'approved';
 }


### PR DESCRIPTION
## Summary
Sidebar Tasks "Active" and main-pane Tasks-view "Active" disagreed about approved tasks: the tasks view surfaced them (transient post-approval state, prevents stuck tasks from disappearing) while the sidebar hid them. Same task, two filters, two answers.

Made `isActiveTask` in `packages/web/src/lib/task-filters.ts` the single source of truth — `open | in_progress | approved` — and pointed `SpaceTasks.TAB_PREDICATES.active` at it instead of an inline duplicate. Both surfaces now import the same predicate.

## Test plan
- [x] `bun test` for `task-filters`, `SpaceTasks`, `SpaceDetailPanel` — 78 passed
- [x] New cross-consumer parity test in `task-filters.test.ts` walks every status through both code paths
- [x] New regression test in `SpaceDetailPanel.test.tsx` confirms approved tasks now appear under sidebar Active
- [x] `bun run typecheck` clean
- [ ] Manual verification: approve a task in dev, confirm it appears in both Active tabs