### PR TITLE
fix(space): lazy-activate stranded executions and clickable not-started entries (Task #139)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -728,7 +728,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		channelCycleRepo,
 		async (runId, nodeId) => {
 			await spaceRuntimeService.activateWorkflowNode(runId, nodeId);
-		}
+		},
+		pendingMessageRepo
 	);
 
 	// Space export/import handlers

--- a/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
@@ -81,6 +81,54 @@ export interface TaskAgentManagerInterface {
 	 * Required for @mention routing to specific agents.
 	 */
 	injectSubSessionMessage?(subSessionId: string, message: string): Promise<void>;
+	/**
+	 * Optional: lazy-activate a workflow-declared node agent for a given task.
+	 *
+	 * Used by `space.task.activateNodeAgent` so the web UI can spawn a
+	 * not-started workflow peer (e.g. clicking "Reviewer (Not started)" in
+	 * the agent dropdown) without going through the Task Agent first.
+	 *
+	 * Returns true when the agent's workflow node was activated (or already
+	 * active), false otherwise (unknown agent, missing workflow, etc.).
+	 */
+	ensureWorkflowNodeActivationForAgent?(
+		taskId: string,
+		agentName: string,
+		options?: { reopenReason?: string; reopenBy?: string }
+	): Promise<boolean>;
+	/**
+	 * Optional: list all workflow-declared agent names for a task. Used to
+	 * validate `space.task.activateNodeAgent` requests before invoking
+	 * `ensureWorkflowNodeActivationForAgent`.
+	 */
+	getWorkflowDeclaredAgentNamesForTask?(taskId: string): string[];
+	/**
+	 * Optional: look up a live sub-session by agent name within a task. Used
+	 * by `space.task.activateNodeAgent` to short-circuit when the target is
+	 * already spawned and to return its sessionId to the caller.
+	 */
+	getSubSessionByAgentName?(
+		taskId: string,
+		agentName: string
+	): Promise<{ session: { id: string } } | null>;
+}
+
+/**
+ * Minimal interface for the pending-message queue used by
+ * `space.task.activateNodeAgent` to persist a first-message payload from the
+ * web client until the lazily-spawned target session drains the queue.
+ */
+export interface PendingAgentMessageQueue {
+	enqueue(input: {
+		workflowRunId: string;
+		spaceId: string;
+		taskId: string;
+		sourceAgentName?: string;
+		targetKind: 'node_agent' | 'space_agent';
+		targetAgentName: string;
+		message: string;
+		idempotencyKey?: string | null;
+	}): { record: { id: string }; deduped: boolean };
 }
 
 type SpaceTaskMessageTarget =
@@ -104,7 +152,8 @@ export function setupSpaceTaskMessageHandlers(
 	daemonHub: DaemonHub,
 	nodeExecutionRepo?: NodeExecutionLookup,
 	channelCycleResetter?: ChannelCycleResetter,
-	activateNode?: (runId: string, nodeId: string) => Promise<void>
+	activateNode?: (runId: string, nodeId: string) => Promise<void>,
+	pendingMessageQueue?: PendingAgentMessageQueue
 ): void {
 	const taskRepo = new SpaceTaskRepository(db.getDatabase());
 
@@ -385,6 +434,148 @@ export function setupSpaceTaskMessageHandlers(
 		await resetChannelCyclesOnHumanTouch(task.workflowRunId, params.taskId);
 
 		return { ok: true };
+	});
+
+	// ─── space.task.activateNodeAgent ───────────────────────────────────────────
+	// Lazy-activate a workflow-declared node agent on demand. Used by the web UI
+	// when the user clicks a "(Not started)" peer in the task agent dropdown:
+	// the click triggers this RPC, which creates the underlying node_execution
+	// row (if missing), spawns the sub-session via the SpaceRuntime tick loop,
+	// and (optionally) queues a first message so the spawned session receives
+	// the user's prompt as soon as it comes online.
+	//
+	// Returns the live session ID when one already exists, otherwise indicates
+	// that activation has been kicked off — the web client can then watch
+	// `space.task.activity` for the new session via the existing live-query
+	// subscription.
+	messageHub.onRequest('space.task.activateNodeAgent', async (data) => {
+		const params = data as {
+			spaceId: string;
+			taskId: string;
+			agentName: string;
+			message?: string;
+		};
+
+		if (!params.spaceId) throw new Error('spaceId is required');
+		if (!params.taskId) throw new Error('taskId is required');
+		if (!params.agentName || params.agentName.trim() === '') {
+			throw new Error('agentName is required');
+		}
+		if (params.message !== undefined) {
+			if (typeof params.message !== 'string') {
+				throw new Error('message must be a string');
+			}
+			if (params.message.length > 10_000) {
+				throw new Error('Message is too long (max 10,000 characters)');
+			}
+		}
+
+		const task = taskRepo.getTask(params.taskId);
+		if (!task) {
+			throw new Error(`Task not found: ${params.taskId}`);
+		}
+		if (task.spaceId !== params.spaceId) {
+			throw new Error(`Task not found: ${params.taskId}`);
+		}
+		if (!task.workflowRunId) {
+			throw new Error(`Task ${params.taskId} has no associated workflow run`);
+		}
+
+		const workflowRunId = task.workflowRunId;
+
+		// Validate the requested agent is actually declared by the workflow.
+		// Without this guard, a typo would silently no-op (the helper returns
+		// `false` for unknown names) and the user would never see an error.
+		const declaredNames =
+			taskAgentManager.getWorkflowDeclaredAgentNamesForTask?.(params.taskId) ?? [];
+		if (!declaredNames.includes(params.agentName)) {
+			throw new Error(
+				`Agent "${params.agentName}" is not declared in this task's workflow. ` +
+					(declaredNames.length > 0
+						? `Declared agents: ${declaredNames.join(', ')}.`
+						: 'No agents are declared for this task.')
+			);
+		}
+
+		// Short-circuit when the target is already spawned: skip activation,
+		// inject the message directly into the live session (if any), and
+		// return its sessionId so the caller hydrates the overlay immediately.
+		const liveSession = taskAgentManager.getSubSessionByAgentName
+			? await taskAgentManager.getSubSessionByAgentName(params.taskId, params.agentName)
+			: null;
+
+		if (liveSession && params.message && taskAgentManager.injectSubSessionMessage) {
+			const prefixed = `[Message from human]: ${params.message}`;
+			await taskAgentManager.injectSubSessionMessage(liveSession.session.id, prefixed);
+			log.info(
+				`space.task.activateNodeAgent: delivered message to live session ${liveSession.session.id} ` +
+					`(agent=${params.agentName}, task=${params.taskId})`
+			);
+			await resetChannelCyclesOnHumanTouch(workflowRunId, params.taskId);
+			return {
+				ok: true,
+				agentName: params.agentName,
+				sessionId: liveSession.session.id,
+				activated: false,
+				queued: false,
+			};
+		}
+
+		if (liveSession) {
+			// Live session, no message — just acknowledge.
+			return {
+				ok: true,
+				agentName: params.agentName,
+				sessionId: liveSession.session.id,
+				activated: false,
+				queued: false,
+			};
+		}
+
+		// No live session. Optionally queue the message so the future spawn
+		// drains it via `flushPendingMessagesForTarget`.
+		let queuedMessageId: string | null = null;
+		if (params.message && pendingMessageQueue) {
+			const { record } = pendingMessageQueue.enqueue({
+				workflowRunId,
+				spaceId: params.spaceId,
+				taskId: params.taskId,
+				sourceAgentName: 'human',
+				targetKind: 'node_agent',
+				targetAgentName: params.agentName,
+				message: params.message,
+			});
+			queuedMessageId = record.id;
+		}
+
+		// Fire the activation kick. Idempotent — `channelRouter.activateNode`
+		// returns existing tasks early if the node already has active executions.
+		const activated = taskAgentManager.ensureWorkflowNodeActivationForAgent
+			? await taskAgentManager.ensureWorkflowNodeActivationForAgent(
+					params.taskId,
+					params.agentName,
+					{
+						reopenReason: `web client lazy activation of "${params.agentName}"`,
+						reopenBy: 'web-client',
+					}
+				)
+			: false;
+
+		log.info(
+			`space.task.activateNodeAgent: agent=${params.agentName} task=${params.taskId} ` +
+				`activated=${activated} queuedMessageId=${queuedMessageId ?? 'none'}`
+		);
+
+		await resetChannelCyclesOnHumanTouch(workflowRunId, params.taskId);
+
+		return {
+			ok: true,
+			agentName: params.agentName,
+			sessionId: null,
+			activated,
+			queued: queuedMessageId !== null,
+			...(queuedMessageId !== null ? { queuedMessageId } : {}),
+		};
 	});
 
 	// ─── space.task.getMessages ─────────────────────────────────────────────────

--- a/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
@@ -480,6 +480,14 @@ export function setupSpaceTaskMessageHandlers(
 		if (!task.workflowRunId) {
 			throw new Error(`Task ${params.taskId} has no associated workflow run`);
 		}
+		if (task.status === 'archived') {
+			throw new Error(`Task ${params.taskId} is archived and cannot activate agents`);
+		}
+		if (task.status === 'done' || task.status === 'cancelled') {
+			throw new Error(
+				`Task ${params.taskId} is ${task.status} — activateNodeAgent requires an active task`
+			);
+		}
 
 		const workflowRunId = task.workflowRunId;
 

--- a/packages/daemon/src/lib/space/runtime/agent-message-router.ts
+++ b/packages/daemon/src/lib/space/runtime/agent-message-router.ts
@@ -424,6 +424,9 @@ export class AgentMessageRouter {
 						);
 
 				if (isDeclaredOrActivated && pendingMessageRepo && spaceId) {
+					// Audited (Task #139): onMessageQueued below covers all
+					// queuing paths. No independent activation gap exists —
+					// every branch that enqueues also fires the callback.
 					// Queue the message (without the "[Message from X]:" prefix — flushPendingMessages
 					// adds it at delivery time so the source name is always accurate).
 					const rawMessage = `${message}${dataAppendix}`;

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -3772,15 +3772,39 @@ export class TaskAgentManager {
 			pendingMessageRepo: this.config.pendingMessageRepo,
 			spaceId,
 			taskId,
-			// Auto-resume callback: when a message is queued for an inactive peer,
-			// immediately attempt to resume that peer's last known session so the
-			// message is delivered without waiting for external activation.
+			// Auto-resume + lazy-activation callback fired when a message is queued
+			// for an inactive peer:
+			//
+			//   1. `tryResumeNodeAgentSession` — fast path that rehydrates a known
+			//      idle/completed session so the queue is drained immediately.
+			//   2. `ensureWorkflowNodeActivationForAgent` — explicit activation kick
+			//      for workflow-declared peers that have no live session. Mirrors the
+			//      Task Agent send-path fix in #139: relying on `channelRouter`'s
+			//      activation-on-deliverMessage step is not enough because that step
+			//      only fires when the target node has zero active executions; a
+			//      workflow node stranded in `pending` state would otherwise queue
+			//      forever. `activateNode` is idempotent so this is safe regardless
+			//      of the existing row's status.
 			onMessageQueued: (targetAgentName) => {
 				void this.tryResumeNodeAgentSession(workflowRunId, targetAgentName).catch((err) => {
 					log.warn(
 						`AgentMessageRouter.onMessageQueued: tryResumeNodeAgentSession failed for "${targetAgentName}": ${err instanceof Error ? err.message : String(err)}`
 					);
 				});
+				const declaredAgentNames = this.getWorkflowDeclaredAgentNamesForTask(taskId);
+				if (declaredAgentNames.includes(targetAgentName)) {
+					log.info(
+						`agent-message-router.onMessageQueued: lazy-activated peer ${targetAgentName} for task ${taskId}`
+					);
+					void this.ensureWorkflowNodeActivationForAgent(taskId, targetAgentName, {
+						reopenReason: `node-agent send_message to lazily activate "${targetAgentName}"`,
+						reopenBy: `agent:${agentName}`,
+					}).catch((err) => {
+						log.warn(
+							`AgentMessageRouter.onMessageQueued: ensureWorkflowNodeActivationForAgent failed for "${targetAgentName}": ${err instanceof Error ? err.message : String(err)}`
+						);
+					});
+				}
 			},
 		});
 

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -735,15 +735,16 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 					// Agent is declared but hasn't been spawned yet (pre-first-execution).
 					// Queue the message if we have the pending-message repo, else fall back to notFound.
 					const isDeclaredInRun = declaredAgentNames.has(targetAgentName);
-					// Workflow-declared but never activated: no node_execution row exists,
-					// so `tryResumeNodeAgentSession` would be a no-op. We also need to
-					// trigger lazy activation of the owning workflow node so the tick
-					// loop can spawn the session and `flushPendingMessagesForTarget`
-					// drains the queue we are about to populate.
-					const needsLazyActivation =
-						isDeclaredInRun &&
-						workflowDeclaredAgentNames.has(targetAgentName) &&
-						!executionDeclaredAgentNames.has(targetAgentName);
+					// Whether the agent is declared in the workflow definition (and therefore
+					// has a workflow node we can lazily activate). The earlier #133 implementation
+					// gated the activation kick on `!executionDeclaredAgentNames.has(...)` so
+					// activation only fired when no node_execution row existed yet. That left a
+					// hole: a workflow-declared peer with a `pending` row stranded by a missed
+					// tick (e.g. the run was idle when the message arrived) would queue forever
+					// because `tryResumeNodeAgentSession` only resumes existing sessions.
+					// `channelRouter.activateNode` is idempotent, so it is safe to call even
+					// when a row already exists — it returns early without flapping state.
+					const isWorkflowDeclared = workflowDeclaredAgentNames.has(targetAgentName);
 					if (isDeclaredInRun && pendingMessageRepo) {
 						const { record, deduped } = pendingMessageRepo.enqueue({
 							workflowRunId,
@@ -776,13 +777,19 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 									);
 								});
 						}
-						// Trigger workflow-node activation for never-spawned, workflow-declared
-						// peers so the tick loop creates node_execution rows and spawns the
-						// session. Without this hop the message would queue forever for an
-						// agent that has no spawn pathway.
-						if (!deduped && needsLazyActivation) {
+						// Always trigger workflow-node activation when queuing for a
+						// workflow-declared peer that has no live session — even when a
+						// `node_execution` row already exists. `channelRouter.activateNode`
+						// is idempotent on existing active executions and resets terminal
+						// rows back to pending for re-spawn. Without this kick the queued
+						// message would wait forever on a stranded run that never receives
+						// an external activation signal (Task #139, Symptom 2).
+						if (!deduped && isWorkflowDeclared && taskAgentManager) {
+							log.info(
+								`task-agent.send: lazy-activated peer ${targetAgentName} for task ${taskId}`
+							);
 							void taskAgentManager
-								?.ensureWorkflowNodeActivationForAgent(taskId, targetAgentName, {
+								.ensureWorkflowNodeActivationForAgent(taskId, targetAgentName, {
 									reopenReason: `task-agent send_message to lazily activate "${targetAgentName}"`,
 									reopenBy: 'task-agent',
 								})

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-message-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-message-handlers.test.ts
@@ -1496,6 +1496,45 @@ describe('setupSpaceTaskMessageHandlers', () => {
 				})
 			).rejects.toThrow('Task not found');
 		});
+
+		it('throws when task is archived', async () => {
+			const { handlers: h } = setupActivate({
+				task: { ...mockTaskWithRun, status: 'archived' },
+			});
+			await expect(
+				(h.get('space.task.activateNodeAgent') as RequestHandler)({
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					agentName: 'reviewer',
+				})
+			).rejects.toThrow('archived');
+		});
+
+		it('throws when task is done', async () => {
+			const { handlers: h } = setupActivate({
+				task: { ...mockTaskWithRun, status: 'done' },
+			});
+			await expect(
+				(h.get('space.task.activateNodeAgent') as RequestHandler)({
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					agentName: 'reviewer',
+				})
+			).rejects.toThrow(/done.*active task/);
+		});
+
+		it('throws when task is cancelled', async () => {
+			const { handlers: h } = setupActivate({
+				task: { ...mockTaskWithRun, status: 'cancelled' },
+			});
+			await expect(
+				(h.get('space.task.activateNodeAgent') as RequestHandler)({
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					agentName: 'reviewer',
+				})
+			).rejects.toThrow(/cancelled.*active task/);
+		});
 	});
 });
 

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-message-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-message-handlers.test.ts
@@ -1258,6 +1258,245 @@ describe('setupSpaceTaskMessageHandlers', () => {
 			expect(emitCalls.some((c) => c[0] === 'space.workflowRun.cyclesReset')).toBe(false);
 		});
 	});
+
+	// ─── space.task.activateNodeAgent ─────────────────────────────────────────────
+
+	describe('space.task.activateNodeAgent', () => {
+		// Web client RPC for Task #139 Fix 2 — lazy-activate a workflow-declared
+		// node agent on first click of a "(Not started)" entry. Validates the
+		// agent name against the workflow declaration, short-circuits to a live
+		// session when present, and otherwise queues the user's first message
+		// while triggering the daemon's activation kick.
+
+		const mockTaskWithRun: SpaceTask = {
+			...mockTaskWithSession,
+			workflowRunId: 'run-act-1',
+		};
+
+		function setupActivate(
+			opts: {
+				task?: SpaceTask | null;
+				declared?: string[];
+				liveSession?: { session: { id: string } } | null;
+				ensureReturns?: boolean;
+				includeQueue?: boolean;
+			} = {}
+		) {
+			const mh = createMockMessageHub();
+			const declared = opts.declared ?? ['reviewer', 'coder'];
+			const liveSession = opts.liveSession ?? null;
+
+			const ensureCalls: Array<{ taskId: string; agentName: string }> = [];
+			const injectCalls: Array<{ sessionId: string; message: string }> = [];
+			const enqueueCalls: Array<{
+				targetAgentName: string;
+				message: string;
+				sourceAgentName?: string | null;
+			}> = [];
+
+			const localTaskAgentManager: TaskAgentManagerInterface = {
+				...createMockTaskAgentManager(null, opts.task ?? mockTaskWithRun),
+				injectSubSessionMessage: mock(async (sid: string, msg: string) => {
+					injectCalls.push({ sessionId: sid, message: msg });
+				}),
+				getSubSessionByAgentName: mock(async (_taskId: string, agentName: string) => {
+					if (liveSession && declared.includes(agentName)) return liveSession;
+					return null;
+				}),
+				getWorkflowDeclaredAgentNamesForTask: mock(() => declared),
+				ensureWorkflowNodeActivationForAgent: mock(async (taskId: string, agentName: string) => {
+					ensureCalls.push({ taskId, agentName });
+					return opts.ensureReturns ?? true;
+				}),
+			};
+
+			const localDb = createMockDatabase(
+				opts.task === null ? null : (opts.task ?? mockTaskWithRun)
+			);
+			const localDaemonHub = { emit: mock(async () => {}) } as unknown as DaemonHub;
+
+			let pendingQueue: ReturnType<typeof mock> | undefined;
+			let pendingMessageQueue: undefined | { enqueue: typeof pendingQueue };
+			if (opts.includeQueue ?? true) {
+				pendingQueue = mock(
+					(input: {
+						targetAgentName: string;
+						message: string;
+						sourceAgentName?: string | null;
+					}) => {
+						enqueueCalls.push({
+							targetAgentName: input.targetAgentName,
+							message: input.message,
+							sourceAgentName: input.sourceAgentName,
+						});
+						return { record: { id: `pending-${enqueueCalls.length}` }, deduped: false };
+					}
+				);
+				pendingMessageQueue = { enqueue: pendingQueue };
+			}
+
+			setupSpaceTaskMessageHandlers(
+				mh.hub,
+				localTaskAgentManager,
+				localDb,
+				localDaemonHub,
+				undefined,
+				undefined,
+				undefined,
+				pendingMessageQueue as Parameters<typeof setupSpaceTaskMessageHandlers>[7]
+			);
+
+			return {
+				handlers: mh.handlers,
+				taskAgentManager: localTaskAgentManager,
+				ensureCalls,
+				injectCalls,
+				enqueueCalls,
+				daemonHub: localDaemonHub,
+			};
+		}
+
+		it('registers space.task.activateNodeAgent', () => {
+			const { handlers: h } = setupActivate();
+			expect(h.has('space.task.activateNodeAgent')).toBe(true);
+		});
+
+		it('throws when spaceId is missing', async () => {
+			const { handlers: h } = setupActivate();
+			await expect(
+				(h.get('space.task.activateNodeAgent') as RequestHandler)({
+					taskId: 'task-1',
+					agentName: 'reviewer',
+				})
+			).rejects.toThrow('spaceId is required');
+		});
+
+		it('throws when taskId is missing', async () => {
+			const { handlers: h } = setupActivate();
+			await expect(
+				(h.get('space.task.activateNodeAgent') as RequestHandler)({
+					spaceId: 'space-1',
+					agentName: 'reviewer',
+				})
+			).rejects.toThrow('taskId is required');
+		});
+
+		it('throws when agentName is missing or empty', async () => {
+			const { handlers: h } = setupActivate();
+			await expect(
+				(h.get('space.task.activateNodeAgent') as RequestHandler)({
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					agentName: '   ',
+				})
+			).rejects.toThrow('agentName is required');
+		});
+
+		it('throws when agent is not workflow-declared', async () => {
+			const { handlers: h } = setupActivate({ declared: ['reviewer'] });
+			await expect(
+				(h.get('space.task.activateNodeAgent') as RequestHandler)({
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					agentName: 'ghost-agent',
+				})
+			).rejects.toThrow(/not declared/);
+		});
+
+		it('throws when message exceeds 10,000 characters', async () => {
+			const { handlers: h } = setupActivate();
+			await expect(
+				(h.get('space.task.activateNodeAgent') as RequestHandler)({
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					agentName: 'reviewer',
+					message: 'x'.repeat(10_001),
+				})
+			).rejects.toThrow(/too long/);
+		});
+
+		it('short-circuits to live session when target is already spawned (returns sessionId)', async () => {
+			const {
+				handlers: h,
+				ensureCalls,
+				injectCalls,
+				enqueueCalls,
+			} = setupActivate({
+				liveSession: { session: { id: 'sess-live-reviewer' } },
+			});
+			const result = (await (h.get('space.task.activateNodeAgent') as RequestHandler)({
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				agentName: 'reviewer',
+				message: 'hi reviewer',
+			})) as Record<string, unknown>;
+
+			expect(result.sessionId).toBe('sess-live-reviewer');
+			expect(result.activated).toBe(false);
+			expect(result.queued).toBe(false);
+			// Direct injection — no queue, no activation kick.
+			expect(injectCalls).toHaveLength(1);
+			expect(injectCalls[0].sessionId).toBe('sess-live-reviewer');
+			expect(injectCalls[0].message).toBe('[Message from human]: hi reviewer');
+			expect(enqueueCalls).toHaveLength(0);
+			expect(ensureCalls).toHaveLength(0);
+		});
+
+		it('queues the message and triggers ensureWorkflowNodeActivationForAgent when no live session exists', async () => {
+			const { handlers: h, ensureCalls, injectCalls, enqueueCalls } = setupActivate();
+			const result = (await (h.get('space.task.activateNodeAgent') as RequestHandler)({
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				agentName: 'reviewer',
+				message: 'wake up reviewer',
+			})) as Record<string, unknown>;
+
+			expect(result.sessionId).toBeNull();
+			expect(result.activated).toBe(true);
+			expect(result.queued).toBe(true);
+			expect(result.queuedMessageId).toBe('pending-1');
+
+			// No direct injection — target had no live session.
+			expect(injectCalls).toHaveLength(0);
+
+			// Message queued for the lazily-spawned target to drain on first activation.
+			expect(enqueueCalls).toHaveLength(1);
+			expect(enqueueCalls[0].targetAgentName).toBe('reviewer');
+			expect(enqueueCalls[0].message).toBe('wake up reviewer');
+			expect(enqueueCalls[0].sourceAgentName).toBe('human');
+
+			// Activation kick fired against the workflow-declared peer.
+			expect(ensureCalls).toHaveLength(1);
+			expect(ensureCalls[0].taskId).toBe('task-1');
+			expect(ensureCalls[0].agentName).toBe('reviewer');
+		});
+
+		it('skips queueing when no message is provided but still triggers activation', async () => {
+			const { handlers: h, ensureCalls, enqueueCalls } = setupActivate();
+			const result = (await (h.get('space.task.activateNodeAgent') as RequestHandler)({
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				agentName: 'reviewer',
+			})) as Record<string, unknown>;
+
+			expect(result.sessionId).toBeNull();
+			expect(result.queued).toBe(false);
+			expect(result.queuedMessageId).toBeUndefined();
+			expect(enqueueCalls).toHaveLength(0);
+			expect(ensureCalls).toHaveLength(1);
+		});
+
+		it('cross-space access throws Task not found', async () => {
+			const { handlers: h } = setupActivate();
+			await expect(
+				(h.get('space.task.activateNodeAgent') as RequestHandler)({
+					spaceId: 'space-other',
+					taskId: 'task-1',
+					agentName: 'reviewer',
+				})
+			).rejects.toThrow('Task not found');
+		});
+	});
 });
 
 // ─── parseMentions unit tests ────────────────────────────────────────────────

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-tools.test.ts
@@ -1328,6 +1328,72 @@ describe('createTaskAgentToolHandlers — send_message queue-until-active', () =
 		expect(ensureCalls).toHaveLength(0);
 	});
 
+	test('still triggers ensureWorkflowNodeActivationForAgent when target is workflow-declared AND already has a stranded node_execution row', async () => {
+		// Regression test for Task #139, Symptom 2: in #133 the activation kick was
+		// gated on `!executionDeclaredAgentNames.has(target)` so a workflow-declared
+		// peer with an existing `pending`/`failed` node_execution row never received
+		// a fresh activation signal. This left a hole — pending rows stranded by an
+		// idle/terminal run could queue messages forever without a spawn ever firing.
+		//
+		// The fix drops that gate: whenever the target is workflow-declared and the
+		// message is queued (no live session), we always call
+		// `ensureWorkflowNodeActivationForAgent`. `channelRouter.activateNode` is
+		// idempotent on existing executions, so this is safe.
+		const wf = buildTwoStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
+		const { run, mainTask } = await startRun(ctx, wf);
+
+		// Pre-existing node_execution row for the workflow-declared peer.
+		ctx.nodeExecutionRepo.create({
+			workflowRunId: run.id,
+			workflowNodeId: 'step-two-node',
+			agentName: 'step-two',
+			status: 'pending',
+		});
+
+		const { PendingAgentMessageRepository } = await import(
+			'../../../../src/storage/repositories/pending-agent-message-repository.ts'
+		);
+		const pendingRepo = new PendingAgentMessageRepository(ctx.db);
+
+		const ensureCalls: Array<{ taskId: string; agentName: string }> = [];
+		const mockTaskAgentManager = {
+			getAgentNamesForTask: async () => [],
+			getSubSessionByAgentName: async () => null,
+			tryResumeNodeAgentSession: async () => {},
+			// Workflow declares step-two as a slot — the key difference from the
+			// previous test which only had step-two in the execution row.
+			getWorkflowDeclaredAgentNamesForTask: (_taskId: string) => ['step-one', 'step-two'],
+			ensureWorkflowNodeActivationForAgent: async (taskId: string, agentName: string) => {
+				ensureCalls.push({ taskId, agentName });
+				return true;
+			},
+		} as unknown as TaskAgentToolsConfig['taskAgentManager'];
+
+		const config: TaskAgentToolsConfig = {
+			...makeConfig(ctx, mainTask.id, run.id),
+			pendingMessageRepo: pendingRepo,
+			taskAgentManager: mockTaskAgentManager,
+		};
+		const handlers = createTaskAgentToolHandlers(config);
+
+		const result = await handlers.send_message({
+			target: 'step-two',
+			message: 'wake up step-two',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.queued).toHaveLength(1);
+		expect(parsed.queued[0].agentName).toBe('step-two');
+
+		// Activation MUST fire even though a node_execution row already exists,
+		// because the agent is workflow-declared and there is no live session.
+		await new Promise((r) => setTimeout(r, 0));
+		expect(ensureCalls).toHaveLength(1);
+		expect(ensureCalls[0].taskId).toBe(mainTask.id);
+		expect(ensureCalls[0].agentName).toBe('step-two');
+	});
+
 	test('delivers to active target while queuing inactive target (partial)', async () => {
 		const wf = buildTwoStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId);
 		const { run, mainTask } = await startRun(ctx, wf);

--- a/packages/web/src/components/space/PendingAgentOverlay.tsx
+++ b/packages/web/src/components/space/PendingAgentOverlay.tsx
@@ -1,0 +1,241 @@
+/**
+ * PendingAgentOverlay — slide-over panel shown when the user opens a workflow
+ * agent that has been declared in the workflow but has not yet spawned a
+ * session. Triggered by `spaceOverlayPendingTaskIdSignal` /
+ * `spaceOverlayPendingAgentNameSignal`.
+ *
+ * Behavior:
+ *   - Renders a "Starting <agentName>…" header and a minimal composer.
+ *   - On first send, calls `spaceStore.activateTaskNodeAgent(taskId, agentName,
+ *     message)` — the daemon either short-circuits to the live session (if the
+ *     agent already spawned) or queues the message and triggers a lazy
+ *     activation kick.
+ *   - The component watches `spaceStore.taskActivity` for a node-agent member
+ *     whose `role === agentName`. When that member appears with a sessionId,
+ *     the overlay hands off to `pushOverlayHistory(sessionId, agentName)`,
+ *     which clears pending signals and switches the renderer to the standard
+ *     `AgentOverlayChat`.
+ *
+ * Note: this composer is intentionally minimal — it does not support file
+ * uploads, model switching, agent mentions, or autocomplete. Once the session
+ * spawns, the overlay hands off to the full ChatContainer composer.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { Portal } from '../ui/Portal';
+import { setupFocusTrap } from '../ui/Modal';
+import { spaceStore } from '../../lib/space-store';
+import { pushOverlayHistory } from '../../lib/router';
+import { cn } from '../../lib/utils';
+import { borderColors } from '../../lib/design-tokens';
+
+export const PENDING_AGENT_OVERLAY_TEST_ID = 'pending-agent-overlay';
+
+interface PendingAgentOverlayProps {
+	taskId: string;
+	agentName: string;
+	onClose: () => void;
+}
+
+export function PendingAgentOverlay({ taskId, agentName, onClose }: PendingAgentOverlayProps) {
+	const panelRef = useRef<HTMLDivElement>(null);
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
+	const [content, setContent] = useState('');
+	const [submitting, setSubmitting] = useState(false);
+	const [waitingForSession, setWaitingForSession] = useState(false);
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+	// Watch taskActivity for the live session matching this agentName.
+	// Once we find one, hand off to the standard session-mode overlay so
+	// ChatContainer can take over with full composer/history.
+	const activityMembers = spaceStore.taskActivity.value.get(taskId) ?? [];
+	const liveMember = useMemo(
+		() => activityMembers.find((m) => m.kind === 'node_agent' && m.role === agentName),
+		[activityMembers, agentName]
+	);
+
+	useEffect(() => {
+		if (liveMember && liveMember.sessionId) {
+			pushOverlayHistory(liveMember.sessionId, liveMember.label || agentName);
+		}
+	}, [liveMember, agentName]);
+
+	// Close on Escape
+	useEffect(() => {
+		const handler = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') onClose();
+		};
+		document.addEventListener('keydown', handler);
+		return () => document.removeEventListener('keydown', handler);
+	}, [onClose]);
+
+	// Focus trap
+	useEffect(() => {
+		if (panelRef.current) {
+			return setupFocusTrap(panelRef.current);
+		}
+	}, []);
+
+	// Autofocus the textarea on mount so the user can start typing immediately
+	useEffect(() => {
+		textareaRef.current?.focus();
+	}, []);
+
+	const handleSend = async () => {
+		const trimmed = content.trim();
+		if (!trimmed || submitting) return;
+		setSubmitting(true);
+		setErrorMessage(null);
+		try {
+			const result = await spaceStore.activateTaskNodeAgent(taskId, agentName, trimmed);
+			setContent('');
+			// If the daemon returned a live session synchronously (already
+			// spawned), pivot immediately. Otherwise, wait for the activity
+			// subscription to surface the new session.
+			if (result.sessionId) {
+				pushOverlayHistory(result.sessionId, agentName);
+			} else {
+				setWaitingForSession(true);
+			}
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			setErrorMessage(`Failed to start ${agentName}: ${msg}`);
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	const handleKeyDown = (e: KeyboardEvent) => {
+		// Cmd/Ctrl + Enter or plain Enter (without shift) sends.
+		if (e.key === 'Enter' && !e.shiftKey) {
+			e.preventDefault();
+			void handleSend();
+		}
+	};
+
+	return (
+		<Portal into="body">
+			<div
+				class="fixed inset-0 z-50 flex justify-end"
+				data-testid={PENDING_AGENT_OVERLAY_TEST_ID}
+				aria-modal="true"
+				role="dialog"
+				aria-label={`${agentName} chat (starting)`}
+			>
+				{/* Backdrop */}
+				<div
+					class="absolute inset-0 bg-black/40 backdrop-blur-[1px] cursor-pointer"
+					onClick={onClose}
+					aria-hidden="true"
+				/>
+
+				{/* Slide-over panel */}
+				<div
+					ref={panelRef}
+					class={cn(
+						'relative flex flex-col h-full w-full max-w-2xl bg-dark-900 shadow-2xl',
+						'border-l border-dark-700',
+						'animate-slideInRight'
+					)}
+				>
+					{/* Header */}
+					<div
+						class={cn(
+							'px-4 min-h-[65px] flex-shrink-0 bg-dark-850 border-b flex items-center gap-3',
+							borderColors.ui.default
+						)}
+					>
+						<button
+							type="button"
+							onClick={onClose}
+							class="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-400 hover:bg-dark-800 hover:text-gray-200 transition-colors flex-shrink-0"
+							aria-label="Back"
+						>
+							<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width={2}
+									d="M15 19l-7-7 7-7"
+								/>
+							</svg>
+						</button>
+						<div class="min-w-0 flex-1">
+							<div class="text-sm font-medium text-gray-100 truncate">{agentName}</div>
+							<div class="text-xs text-gray-500 truncate">
+								{waitingForSession ? 'Starting session…' : 'Not started yet'}
+							</div>
+						</div>
+					</div>
+
+					{/* Body — message-area placeholder */}
+					<div class="flex-1 min-h-0 overflow-auto px-4 py-6">
+						<div
+							class={cn(
+								'mx-auto max-w-md text-center text-sm rounded-lg border bg-dark-850/60 px-4 py-6',
+								borderColors.ui.default
+							)}
+							data-testid="pending-agent-overlay-body"
+						>
+							{waitingForSession ? (
+								<>
+									<div class="mb-3 flex items-center justify-center">
+										<div class="w-5 h-5 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+									</div>
+									<p class="text-gray-200 font-medium mb-1">Starting {agentName}…</p>
+									<p class="text-gray-500">
+										Your message has been queued. The session will open here as soon as the agent is
+										ready.
+									</p>
+								</>
+							) : (
+								<>
+									<p class="text-gray-200 font-medium mb-1">{agentName} hasn't started yet</p>
+									<p class="text-gray-500">
+										Send a message below to start this agent's session. Your first message will be
+										delivered when the session is ready.
+									</p>
+								</>
+							)}
+						</div>
+					</div>
+
+					{/* Composer */}
+					<div class={cn('flex-shrink-0 border-t bg-dark-900 px-3 py-3', borderColors.ui.default)}>
+						{errorMessage && (
+							<p class="mb-2 rounded border border-red-500/30 bg-red-500/10 px-2 py-1 text-xs text-red-300">
+								{errorMessage}
+							</p>
+						)}
+						<div class="flex gap-2">
+							<textarea
+								ref={textareaRef}
+								class="flex-1 min-h-[44px] max-h-40 resize-none rounded-md bg-dark-850 border border-dark-700 text-sm text-gray-100 px-3 py-2 placeholder-gray-500 focus:outline-none focus:border-blue-500"
+								placeholder={`Send first message to ${agentName}…`}
+								value={content}
+								onInput={(e) => setContent((e.target as HTMLTextAreaElement).value)}
+								onKeyDown={handleKeyDown}
+								disabled={submitting || waitingForSession}
+								data-testid="pending-agent-overlay-textarea"
+								rows={2}
+							/>
+							<button
+								type="button"
+								onClick={() => void handleSend()}
+								disabled={!content.trim() || submitting || waitingForSession}
+								class={cn(
+									'inline-flex items-center justify-center rounded-md px-3 text-sm font-medium transition-colors flex-shrink-0',
+									'bg-blue-600 text-white hover:bg-blue-500',
+									'disabled:bg-dark-700 disabled:text-gray-500 disabled:cursor-not-allowed'
+								)}
+								data-testid="pending-agent-overlay-send"
+							>
+								{submitting ? 'Starting…' : 'Send'}
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</Portal>
+	);
+}

--- a/packages/web/src/components/space/PendingAgentOverlay.tsx
+++ b/packages/web/src/components/space/PendingAgentOverlay.tsx
@@ -12,7 +12,7 @@
  *     activation kick.
  *   - The component watches `spaceStore.taskActivity` for a node-agent member
  *     whose `role === agentName`. When that member appears with a sessionId,
- *     the overlay hands off to `pushOverlayHistory(sessionId, agentName)`,
+ *     the overlay hands off to `replaceOverlayHistory(sessionId, agentName)`,
  *     which clears pending signals and switches the renderer to the standard
  *     `AgentOverlayChat`.
  *
@@ -25,7 +25,7 @@ import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { Portal } from '../ui/Portal';
 import { setupFocusTrap } from '../ui/Modal';
 import { spaceStore } from '../../lib/space-store';
-import { pushOverlayHistory } from '../../lib/router';
+import { replaceOverlayHistory } from '../../lib/router';
 import { cn } from '../../lib/utils';
 import { borderColors } from '../../lib/design-tokens';
 
@@ -56,7 +56,7 @@ export function PendingAgentOverlay({ taskId, agentName, onClose }: PendingAgent
 
 	useEffect(() => {
 		if (liveMember && liveMember.sessionId) {
-			pushOverlayHistory(liveMember.sessionId, liveMember.label || agentName);
+			replaceOverlayHistory(liveMember.sessionId, liveMember.label || agentName);
 		}
 	}, [liveMember, agentName]);
 
@@ -93,7 +93,7 @@ export function PendingAgentOverlay({ taskId, agentName, onClose }: PendingAgent
 			// spawned), pivot immediately. Otherwise, wait for the activity
 			// subscription to surface the new session.
 			if (result.sessionId) {
-				pushOverlayHistory(result.sessionId, agentName);
+				replaceOverlayHistory(result.sessionId, agentName);
 			} else {
 				setWaitingForSession(true);
 			}
@@ -211,7 +211,11 @@ export function PendingAgentOverlay({ taskId, agentName, onClose }: PendingAgent
 							<textarea
 								ref={textareaRef}
 								class="flex-1 min-h-[44px] max-h-40 resize-none rounded-md bg-dark-850 border border-dark-700 text-sm text-gray-100 px-3 py-2 placeholder-gray-500 focus:outline-none focus:border-blue-500"
-								placeholder={`Send first message to ${agentName}…`}
+								placeholder={
+									waitingForSession
+										? `Send another message to ${agentName}…`
+										: `Send first message to ${agentName}…`
+								}
 								value={content}
 								onInput={(e) => setContent((e.target as HTMLTextAreaElement).value)}
 								onKeyDown={handleKeyDown}
@@ -222,7 +226,7 @@ export function PendingAgentOverlay({ taskId, agentName, onClose }: PendingAgent
 							<button
 								type="button"
 								onClick={() => void handleSend()}
-								disabled={!content.trim() || submitting || waitingForSession}
+								disabled={!content.trim() || submitting}
 								class={cn(
 									'inline-flex items-center justify-center rounded-md px-3 text-sm font-medium transition-colors flex-shrink-0',
 									'bg-blue-600 text-white hover:bg-blue-500',

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -7,7 +7,11 @@ import type {
 import type { ComponentChildren } from 'preact';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { borderColors } from '../../lib/design-tokens';
-import { navigateToSpaceTask, pushOverlayHistory } from '../../lib/router';
+import {
+	navigateToSpaceTask,
+	pushOverlayHistory,
+	pushOverlayHistoryForPendingAgent,
+} from '../../lib/router';
 import { currentSpaceIdSignal, currentSpaceTaskViewTabSignal } from '../../lib/signals';
 import { spaceStore } from '../../lib/space-store';
 import { resolveActiveTaskBanner } from '../../lib/task-banner.ts';
@@ -587,19 +591,20 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 		);
 	}
 	// Workflow-declared agents that have never spawned a session yet. We surface
-	// them in the dropdown so users see every reachable peer, but render them as
-	// disabled — there is no session to open, and routing the click to the Task
-	// Agent's session under the peer's label was misleading (the overlay would
-	// say "reviewer" but render the Task Agent thread). Once the daemon lazily
-	// activates the node (e.g. after Task Agent send_message), the activity
-	// member appears via the live store and replaces this entry naturally.
+	// them as clickable entries that open a "pending" overlay routed by agent
+	// name; the first message the user sends from that overlay invokes
+	// `space.task.activateNodeAgent`, which lazily spawns the workflow node.
+	// Once `taskActivity` reflects the new session, the overlay hydrates to a
+	// normal session-mode chat and this entry is replaced by the live member
+	// from `activityMembers` above.
 	if (declaredAgentSlots.length > 0) {
 		taskActionItems.push(
 			...declaredAgentSlots.map((slot) => ({
 				label: `Open ${slot.name} (Not started)`,
-				onClick: () => {},
-				disabled: true,
-				title: `${slot.name} hasn't been activated yet. Send a message from the Task Agent thread to start its session.`,
+				onClick: () => {
+					pushOverlayHistoryForPendingAgent(task.id, slot.name);
+				},
+				title: `${slot.name} hasn't been activated yet. Sending the first message will start its session.`,
 			}))
 		);
 	}

--- a/packages/web/src/components/space/__tests__/PendingAgentOverlay.test.tsx
+++ b/packages/web/src/components/space/__tests__/PendingAgentOverlay.test.tsx
@@ -1,0 +1,237 @@
+// @ts-nocheck
+/**
+ * Unit tests for PendingAgentOverlay (Task #139, Symptom 2 fix).
+ *
+ * The overlay is opened when the user clicks a "(Not started)" entry for a
+ * workflow-declared peer that has not yet spawned a session. It renders a
+ * minimal composer; on first send it invokes
+ * `spaceStore.activateTaskNodeAgent(taskId, agentName, message)` which
+ * triggers a lazy daemon-side activation. Once the live session appears in
+ * `spaceStore.taskActivity`, the overlay hands off to the standard
+ * session-mode overlay via `pushOverlayHistory(sessionId, agentName)`.
+ *
+ * These tests verify:
+ *   - The overlay renders a composer with starting copy and aria-label.
+ *   - Clicking Send invokes spaceStore.activateTaskNodeAgent with the right
+ *     (taskId, agentName, message) tuple.
+ *   - When the daemon returns a live sessionId synchronously, the overlay
+ *     hands off via pushOverlayHistory.
+ *   - When the daemon returns no sessionId yet, the overlay enters a
+ *     waiting state. When taskActivity later surfaces a node_agent member
+ *     whose role matches the agentName, the overlay hands off as soon as
+ *     that member's sessionId is set.
+ *   - Escape and backdrop clicks invoke onClose.
+ *   - Submit error path surfaces an error message and re-enables the input.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { signal } from '@preact/signals';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/preact';
+
+// Hoisted bridges — mock factories are evaluated before module init, so
+// module-level variables referenced inside the factory body fail with TDZ
+// errors. Hoist plain objects here and assign real Preact signals to
+// `taskActivityBridge.signal` after import so reactivity works inside the
+// component.
+const { taskActivityBridge, mockActivateTaskNodeAgent, mockPushOverlayHistory } = vi.hoisted(
+	() => ({
+		taskActivityBridge: {
+			signal: null as ReturnType<typeof signal<Map<string, unknown[]>>> | null,
+		},
+		mockActivateTaskNodeAgent: vi.fn(),
+		mockPushOverlayHistory: vi.fn(),
+	})
+);
+
+vi.mock('../../../lib/space-store', () => ({
+	get spaceStore() {
+		return {
+			get taskActivity() {
+				return taskActivityBridge.signal!;
+			},
+			activateTaskNodeAgent: mockActivateTaskNodeAgent,
+		};
+	},
+}));
+
+vi.mock('../../../lib/router', () => ({
+	pushOverlayHistory: mockPushOverlayHistory,
+}));
+
+vi.mock('../../../lib/utils', () => ({
+	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+// Assign the real signal after the hoist so the bridge resolves to a live
+// Preact signal at test-runtime.
+taskActivityBridge.signal = signal(new Map<string, unknown[]>());
+
+import { PendingAgentOverlay, PENDING_AGENT_OVERLAY_TEST_ID } from '../PendingAgentOverlay';
+
+const TASK_ID = 'task-123';
+const AGENT_NAME = 'reviewer';
+
+describe('PendingAgentOverlay', () => {
+	let onClose: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		cleanup();
+		onClose = vi.fn();
+		taskActivityBridge.signal!.value = new Map();
+		mockActivateTaskNodeAgent.mockReset();
+		mockPushOverlayHistory.mockClear();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders the overlay with the agent name in copy and aria-label', () => {
+		const { getByTestId, getByText } = render(
+			<PendingAgentOverlay taskId={TASK_ID} agentName={AGENT_NAME} onClose={onClose} />
+		);
+		const overlay = getByTestId(PENDING_AGENT_OVERLAY_TEST_ID);
+		expect(overlay).toBeTruthy();
+		expect(overlay.getAttribute('aria-label')).toBe(`${AGENT_NAME} chat (starting)`);
+		// Body explains the pending state and the path forward.
+		expect(getByText(`${AGENT_NAME} hasn't started yet`)).toBeTruthy();
+	});
+
+	it('disables the Send button until the user types a non-empty message', () => {
+		const { getByTestId } = render(
+			<PendingAgentOverlay taskId={TASK_ID} agentName={AGENT_NAME} onClose={onClose} />
+		);
+		const send = getByTestId('pending-agent-overlay-send') as HTMLButtonElement;
+		expect(send.disabled).toBe(true);
+
+		const textarea = getByTestId('pending-agent-overlay-textarea') as HTMLTextAreaElement;
+		fireEvent.input(textarea, { target: { value: 'kick off' } });
+		expect(send.disabled).toBe(false);
+	});
+
+	it('calls activateTaskNodeAgent on send and hands off when the daemon returns a sessionId synchronously', async () => {
+		mockActivateTaskNodeAgent.mockResolvedValue({
+			sessionId: 'sess-live-1',
+			activated: true,
+			queued: false,
+		});
+
+		const { getByTestId } = render(
+			<PendingAgentOverlay taskId={TASK_ID} agentName={AGENT_NAME} onClose={onClose} />
+		);
+
+		const textarea = getByTestId('pending-agent-overlay-textarea') as HTMLTextAreaElement;
+		fireEvent.input(textarea, { target: { value: 'wake up reviewer' } });
+		fireEvent.click(getByTestId('pending-agent-overlay-send'));
+
+		await waitFor(() => expect(mockActivateTaskNodeAgent).toHaveBeenCalledTimes(1));
+		expect(mockActivateTaskNodeAgent).toHaveBeenCalledWith(TASK_ID, AGENT_NAME, 'wake up reviewer');
+		await waitFor(() =>
+			expect(mockPushOverlayHistory).toHaveBeenCalledWith('sess-live-1', AGENT_NAME)
+		);
+	});
+
+	it('enters a waiting state when the daemon defers activation, then hands off when taskActivity surfaces the live session', async () => {
+		mockActivateTaskNodeAgent.mockResolvedValue({
+			sessionId: null,
+			activated: true,
+			queued: true,
+			queuedMessageId: 'msg-1',
+		});
+
+		const { getByTestId, getByText } = render(
+			<PendingAgentOverlay taskId={TASK_ID} agentName={AGENT_NAME} onClose={onClose} />
+		);
+
+		const textarea = getByTestId('pending-agent-overlay-textarea') as HTMLTextAreaElement;
+		fireEvent.input(textarea, { target: { value: 'queue please' } });
+		fireEvent.click(getByTestId('pending-agent-overlay-send'));
+
+		// After send, the overlay is waiting for the activity subscription to
+		// surface the new session.
+		await waitFor(() => expect(getByText(`Starting ${AGENT_NAME}…`)).toBeTruthy());
+		expect(mockPushOverlayHistory).not.toHaveBeenCalled();
+
+		// Simulate the live-query subscription delivering the new session.
+		taskActivityBridge.signal!.value = new Map([
+			[
+				TASK_ID,
+				[
+					{
+						id: 'm1',
+						sessionId: 'sess-spawned-2',
+						kind: 'node_agent',
+						role: AGENT_NAME,
+						label: 'Reviewer',
+						state: 'active',
+						messageCount: 0,
+					},
+				],
+			],
+		]);
+
+		await waitFor(() =>
+			expect(mockPushOverlayHistory).toHaveBeenCalledWith('sess-spawned-2', 'Reviewer')
+		);
+	});
+
+	it('surfaces an error and re-enables the input when activateTaskNodeAgent rejects', async () => {
+		mockActivateTaskNodeAgent.mockRejectedValue(new Error('hub disconnected'));
+
+		const { getByTestId, getByText } = render(
+			<PendingAgentOverlay taskId={TASK_ID} agentName={AGENT_NAME} onClose={onClose} />
+		);
+
+		const textarea = getByTestId('pending-agent-overlay-textarea') as HTMLTextAreaElement;
+		fireEvent.input(textarea, { target: { value: 'try' } });
+		fireEvent.click(getByTestId('pending-agent-overlay-send'));
+
+		await waitFor(() =>
+			expect(getByText(/Failed to start reviewer: hub disconnected/)).toBeTruthy()
+		);
+		// Input is re-enabled so the user can retry.
+		expect((textarea as HTMLTextAreaElement).disabled).toBe(false);
+		expect(mockPushOverlayHistory).not.toHaveBeenCalled();
+	});
+
+	it('calls onClose when the Escape key is pressed', () => {
+		render(<PendingAgentOverlay taskId={TASK_ID} agentName={AGENT_NAME} onClose={onClose} />);
+		fireEvent.keyDown(document, { key: 'Escape' });
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('calls onClose when the backdrop is clicked', () => {
+		const { getByTestId } = render(
+			<PendingAgentOverlay taskId={TASK_ID} agentName={AGENT_NAME} onClose={onClose} />
+		);
+		const overlay = getByTestId(PENDING_AGENT_OVERLAY_TEST_ID);
+		const backdrop = overlay.querySelector('[aria-hidden="true"]');
+		expect(backdrop).toBeTruthy();
+		fireEvent.click(backdrop!);
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('hands off immediately when the matching activity member is already present on mount (already spawned)', () => {
+		// If the user clicks a "(Not started)" entry while a race makes the
+		// session show up before the overlay mounts, hand off without waiting
+		// for a send. This keeps the overlay in lock-step with the live store.
+		taskActivityBridge.signal!.value = new Map([
+			[
+				TASK_ID,
+				[
+					{
+						id: 'm1',
+						sessionId: 'sess-pre-existing-3',
+						kind: 'node_agent',
+						role: AGENT_NAME,
+						label: 'Reviewer',
+						state: 'active',
+						messageCount: 0,
+					},
+				],
+			],
+		]);
+		render(<PendingAgentOverlay taskId={TASK_ID} agentName={AGENT_NAME} onClose={onClose} />);
+		expect(mockPushOverlayHistory).toHaveBeenCalledWith('sess-pre-existing-3', 'Reviewer');
+	});
+});

--- a/packages/web/src/components/space/__tests__/PendingAgentOverlay.test.tsx
+++ b/packages/web/src/components/space/__tests__/PendingAgentOverlay.test.tsx
@@ -33,13 +33,13 @@ import { render, fireEvent, cleanup, waitFor } from '@testing-library/preact';
 // errors. Hoist plain objects here and assign real Preact signals to
 // `taskActivityBridge.signal` after import so reactivity works inside the
 // component.
-const { taskActivityBridge, mockActivateTaskNodeAgent, mockPushOverlayHistory } = vi.hoisted(
+const { taskActivityBridge, mockActivateTaskNodeAgent, mockReplaceOverlayHistory } = vi.hoisted(
 	() => ({
 		taskActivityBridge: {
 			signal: null as ReturnType<typeof signal<Map<string, unknown[]>>> | null,
 		},
 		mockActivateTaskNodeAgent: vi.fn(),
-		mockPushOverlayHistory: vi.fn(),
+		mockReplaceOverlayHistory: vi.fn(),
 	})
 );
 
@@ -55,7 +55,7 @@ vi.mock('../../../lib/space-store', () => ({
 }));
 
 vi.mock('../../../lib/router', () => ({
-	pushOverlayHistory: mockPushOverlayHistory,
+	replaceOverlayHistory: mockReplaceOverlayHistory,
 }));
 
 vi.mock('../../../lib/utils', () => ({
@@ -79,7 +79,7 @@ describe('PendingAgentOverlay', () => {
 		onClose = vi.fn();
 		taskActivityBridge.signal!.value = new Map();
 		mockActivateTaskNodeAgent.mockReset();
-		mockPushOverlayHistory.mockClear();
+		mockReplaceOverlayHistory.mockClear();
 	});
 
 	afterEach(() => {
@@ -127,7 +127,7 @@ describe('PendingAgentOverlay', () => {
 		await waitFor(() => expect(mockActivateTaskNodeAgent).toHaveBeenCalledTimes(1));
 		expect(mockActivateTaskNodeAgent).toHaveBeenCalledWith(TASK_ID, AGENT_NAME, 'wake up reviewer');
 		await waitFor(() =>
-			expect(mockPushOverlayHistory).toHaveBeenCalledWith('sess-live-1', AGENT_NAME)
+			expect(mockReplaceOverlayHistory).toHaveBeenCalledWith('sess-live-1', AGENT_NAME)
 		);
 	});
 
@@ -150,7 +150,7 @@ describe('PendingAgentOverlay', () => {
 		// After send, the overlay is waiting for the activity subscription to
 		// surface the new session.
 		await waitFor(() => expect(getByText(`Starting ${AGENT_NAME}…`)).toBeTruthy());
-		expect(mockPushOverlayHistory).not.toHaveBeenCalled();
+		expect(mockReplaceOverlayHistory).not.toHaveBeenCalled();
 
 		// Simulate the live-query subscription delivering the new session.
 		taskActivityBridge.signal!.value = new Map([
@@ -171,7 +171,7 @@ describe('PendingAgentOverlay', () => {
 		]);
 
 		await waitFor(() =>
-			expect(mockPushOverlayHistory).toHaveBeenCalledWith('sess-spawned-2', 'Reviewer')
+			expect(mockReplaceOverlayHistory).toHaveBeenCalledWith('sess-spawned-2', 'Reviewer')
 		);
 	});
 
@@ -191,7 +191,7 @@ describe('PendingAgentOverlay', () => {
 		);
 		// Input is re-enabled so the user can retry.
 		expect((textarea as HTMLTextAreaElement).disabled).toBe(false);
-		expect(mockPushOverlayHistory).not.toHaveBeenCalled();
+		expect(mockReplaceOverlayHistory).not.toHaveBeenCalled();
 	});
 
 	it('calls onClose when the Escape key is pressed', () => {
@@ -232,6 +232,6 @@ describe('PendingAgentOverlay', () => {
 			],
 		]);
 		render(<PendingAgentOverlay taskId={TASK_ID} agentName={AGENT_NAME} onClose={onClose} />);
-		expect(mockPushOverlayHistory).toHaveBeenCalledWith('sess-pre-existing-3', 'Reviewer');
+		expect(mockReplaceOverlayHistory).toHaveBeenCalledWith('sess-pre-existing-3', 'Reviewer');
 	});
 });

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -28,23 +28,27 @@ const {
 	idBridge: { signal: null as ReturnType<typeof signal<string | null>> | null },
 }));
 
-const { mockNavigateToSpaceAgent, mockPushOverlayHistory, mockNavigateToSpaceTask } = vi.hoisted(
-	() => ({
-		mockNavigateToSpaceAgent: vi.fn(),
-		mockPushOverlayHistory: vi.fn((sessionId: string, agentName?: string) => {
-			mockSpaceOverlaySessionIdSignal.value = sessionId;
-			mockSpaceOverlayAgentNameSignal.value = agentName ?? null;
-		}),
-		mockNavigateToSpaceTask: vi.fn((_spaceId: string, _taskId: string, view: string) => {
-			if (viewTabBridge.signal) {
-				viewTabBridge.signal.value = view ?? 'thread';
-			}
-			if (idBridge.signal) {
-				idBridge.signal.value = _spaceId;
-			}
-		}),
-	})
-);
+const {
+	mockNavigateToSpaceAgent,
+	mockPushOverlayHistory,
+	mockPushOverlayHistoryForPendingAgent,
+	mockNavigateToSpaceTask,
+} = vi.hoisted(() => ({
+	mockNavigateToSpaceAgent: vi.fn(),
+	mockPushOverlayHistory: vi.fn((sessionId: string, agentName?: string) => {
+		mockSpaceOverlaySessionIdSignal.value = sessionId;
+		mockSpaceOverlayAgentNameSignal.value = agentName ?? null;
+	}),
+	mockPushOverlayHistoryForPendingAgent: vi.fn(),
+	mockNavigateToSpaceTask: vi.fn((_spaceId: string, _taskId: string, view: string) => {
+		if (viewTabBridge.signal) {
+			viewTabBridge.signal.value = view ?? 'thread';
+		}
+		if (idBridge.signal) {
+			idBridge.signal.value = _spaceId;
+		}
+	}),
+}));
 
 // Real Preact signals — these enable reactivity for values read during render
 const mockCurrentSpaceTaskViewTabSignal = signal<string>('thread');
@@ -57,6 +61,7 @@ idBridge.signal = mockCurrentSpaceIdSignal;
 vi.mock('../../../lib/router', () => ({
 	navigateToSpaceAgent: mockNavigateToSpaceAgent,
 	pushOverlayHistory: mockPushOverlayHistory,
+	pushOverlayHistoryForPendingAgent: mockPushOverlayHistoryForPendingAgent,
 	navigateToSpaceTask: mockNavigateToSpaceTask,
 }));
 
@@ -976,6 +981,7 @@ describe('SpaceTaskPane — workflow-declared agents in dropdown', () => {
 			makeTask({ status: 'in_progress', taskAgentSessionId: 'session-ensured' })
 		);
 		mockPushOverlayHistory.mockClear();
+		mockPushOverlayHistoryForPendingAgent.mockClear();
 		mockSpaceOverlaySessionIdSignal.value = null;
 		mockSpaceOverlayAgentNameSignal.value = null;
 	});
@@ -1027,11 +1033,14 @@ describe('SpaceTaskPane — workflow-declared agents in dropdown', () => {
 		expect(getByText('Open reviewer (Not started)')).toBeTruthy();
 	});
 
-	it('renders workflow-declared (Not started) agents as disabled with an explanatory tooltip', () => {
-		// Clicking the entry must NOT open the Task Agent session under the
-		// peer's label — that was misleading (overlay said "reviewer" but
-		// rendered the Task Agent thread). The peer becomes openable only when
-		// the daemon lazily activates it and an activity member appears.
+	it('renders workflow-declared (Not started) agents as clickable and routes to a pending-agent overlay', () => {
+		// Task #139 regression fix: in #133 these entries were rendered as
+		// disabled — that violated #133's own AC #4 ("clicking a declared-but-
+		// not-spawned agent opens the chat overlay; the first message activates
+		// the session"). The fix re-enables the click and routes it to the
+		// pending-agent overlay variant (`pushOverlayHistoryForPendingAgent`)
+		// which carries (taskId, agentName) instead of a sessionId — so the
+		// overlay header reads "reviewer" and not the Task Agent thread.
 		mockTasks.value = [
 			makeTask({
 				workflowRunId: 'run-1',
@@ -1060,13 +1069,18 @@ describe('SpaceTaskPane — workflow-declared agents in dropdown', () => {
 
 		const reviewerItem = getByText('Open reviewer (Not started)').closest('button');
 		expect(reviewerItem).toBeTruthy();
-		expect(reviewerItem?.disabled).toBe(true);
+		// No longer disabled — the click is routed to the pending-agent overlay.
+		expect(reviewerItem?.disabled).toBeFalsy();
 		expect(reviewerItem?.title).toContain('reviewer');
-		expect(reviewerItem?.title).toContain('Task Agent');
 
 		fireEvent.click(getByText('Open reviewer (Not started)'));
-		// Disabled entries do not push overlay history under any session id —
-		// no misleading reuse of the Task Agent session under the peer's label.
+		// Click routes through pushOverlayHistoryForPendingAgent so the overlay
+		// renders the pending-agent variant scoped to (taskId, agentName).
+		// Crucially, pushOverlayHistory (session-mode) MUST NOT be invoked —
+		// that would have surfaced the Task Agent's session under the peer's
+		// label, which was the very bug #133 first introduced.
+		expect(mockPushOverlayHistoryForPendingAgent).toHaveBeenCalledTimes(1);
+		expect(mockPushOverlayHistoryForPendingAgent).toHaveBeenCalledWith('task-1', 'reviewer');
 		expect(mockPushOverlayHistory).not.toHaveBeenCalled();
 	});
 

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -17,9 +17,12 @@ import {
 	spaceOverlaySessionIdSignal,
 	spaceOverlayAgentNameSignal,
 	spaceOverlayHighlightMessageIdSignal,
+	spaceOverlayPendingTaskIdSignal,
+	spaceOverlayPendingAgentNameSignal,
 } from '../lib/signals';
 import { SpacePageHeader } from '../components/space/SpacePageHeader';
 import { AgentOverlayChat } from '../components/space/AgentOverlayChat';
+import { PendingAgentOverlay } from '../components/space/PendingAgentOverlay';
 import { spaceStore } from '../lib/space-store';
 import {
 	navigateToSpace,
@@ -69,9 +72,35 @@ export default function SpaceIsland({
 	const overlaySessionId = spaceOverlaySessionIdSignal.value;
 	const overlayAgentName = spaceOverlayAgentNameSignal.value;
 	const overlayHighlightMessageId = spaceOverlayHighlightMessageIdSignal.value;
+	// Pending-agent overlay — workflow-declared peer that hasn't spawned yet.
+	// When set, renders PendingAgentOverlay; once the daemon spawns the session
+	// (via taskActivity), the overlay hands off to spaceOverlaySessionIdSignal
+	// and the standard AgentOverlayChat takes over.
+	const overlayPendingTaskId = spaceOverlayPendingTaskIdSignal.value;
+	const overlayPendingAgentName = spaceOverlayPendingAgentNameSignal.value;
 	const handleOverlayClose = useCallback(() => {
 		closeOverlayHistory();
 	}, []);
+
+	// Single overlay element shared across every rendering branch below — keeps
+	// the overlay/pending precedence in one place. Pending takes precedence over
+	// session because pending is cleared as part of pushOverlayHistory, so the
+	// two are never both set at the same time in practice.
+	const overlay =
+		overlayPendingTaskId && overlayPendingAgentName ? (
+			<PendingAgentOverlay
+				taskId={overlayPendingTaskId}
+				agentName={overlayPendingAgentName}
+				onClose={handleOverlayClose}
+			/>
+		) : overlaySessionId ? (
+			<AgentOverlayChat
+				sessionId={overlaySessionId}
+				agentName={overlayAgentName ?? undefined}
+				highlightMessageId={overlayHighlightMessageId ?? undefined}
+				onClose={handleOverlayClose}
+			/>
+		) : null;
 
 	// Test hook: expose overlay controls on window.__neokai_space_overlay so E2E
 	// tests can trigger the overlay programmatically. Opening is purely
@@ -111,14 +140,7 @@ export default function SpaceIsland({
 		return (
 			<>
 				<ChatContainer key={sessionViewId} sessionId={sessionViewId} />
-				{overlaySessionId && (
-					<AgentOverlayChat
-						sessionId={overlaySessionId}
-						agentName={overlayAgentName ?? undefined}
-						highlightMessageId={overlayHighlightMessageId ?? undefined}
-						onClose={handleOverlayClose}
-					/>
-				)}
+				{overlay}
 			</>
 		);
 	}
@@ -154,14 +176,7 @@ export default function SpaceIsland({
 						<SpaceTaskPane taskId={taskViewId} spaceId={spaceId} onClose={handleTaskPaneClose} />
 					</Suspense>
 				</div>
-				{overlaySessionId && (
-					<AgentOverlayChat
-						sessionId={overlaySessionId}
-						agentName={overlayAgentName ?? undefined}
-						highlightMessageId={overlayHighlightMessageId ?? undefined}
-						onClose={handleOverlayClose}
-					/>
-				)}
+				{overlay}
 			</>
 		);
 	}
@@ -183,14 +198,7 @@ export default function SpaceIsland({
 						</Suspense>
 					</div>
 				</div>
-				{overlaySessionId && (
-					<AgentOverlayChat
-						sessionId={overlaySessionId}
-						agentName={overlayAgentName ?? undefined}
-						highlightMessageId={overlayHighlightMessageId ?? undefined}
-						onClose={handleOverlayClose}
-					/>
-				)}
+				{overlay}
 			</>
 		);
 	}
@@ -209,14 +217,7 @@ export default function SpaceIsland({
 						</Suspense>
 					</div>
 				</div>
-				{overlaySessionId && (
-					<AgentOverlayChat
-						sessionId={overlaySessionId}
-						agentName={overlayAgentName ?? undefined}
-						highlightMessageId={overlayHighlightMessageId ?? undefined}
-						onClose={handleOverlayClose}
-					/>
-				)}
+				{overlay}
 			</>
 		);
 	}
@@ -235,27 +236,14 @@ export default function SpaceIsland({
 						</Suspense>
 					</div>
 				</div>
-				{overlaySessionId && (
-					<AgentOverlayChat
-						sessionId={overlaySessionId}
-						agentName={overlayAgentName ?? undefined}
-						highlightMessageId={overlayHighlightMessageId ?? undefined}
-						onClose={handleOverlayClose}
-					/>
-				)}
+				{overlay}
 			</>
 		);
 	}
 
 	return (
 		<>
-			{overlaySessionId && (
-				<AgentOverlayChat
-					sessionId={overlaySessionId}
-					agentName={overlayAgentName ?? undefined}
-					onClose={handleOverlayClose}
-				/>
-			)}
+			{overlay}
 			<div
 				class="flex-1 flex flex-col overflow-hidden bg-dark-900"
 				data-testid="space-overview-view"

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -34,6 +34,8 @@ import {
 	spaceOverlaySessionIdSignal,
 	spaceOverlayAgentNameSignal,
 	spaceOverlayHighlightMessageIdSignal,
+	spaceOverlayPendingTaskIdSignal,
+	spaceOverlayPendingAgentNameSignal,
 } from './signals.ts';
 
 /** Route patterns */
@@ -1562,10 +1564,13 @@ function handlePopState(_event: PopStateEvent): void {
 
 	// If the overlay is open and the user pressed back, close the overlay
 	// instead of navigating away from the current view.
-	if (spaceOverlaySessionIdSignal.value && !window.history.state?.overlaySessionId) {
+	const overlayOpen = spaceOverlaySessionIdSignal.value || spaceOverlayPendingAgentNameSignal.value;
+	if (overlayOpen && !window.history.state?.overlaySessionId) {
 		spaceOverlaySessionIdSignal.value = null;
 		spaceOverlayAgentNameSignal.value = null;
 		spaceOverlayHighlightMessageIdSignal.value = null;
+		spaceOverlayPendingTaskIdSignal.value = null;
+		spaceOverlayPendingAgentNameSignal.value = null;
 		return;
 	}
 
@@ -2164,6 +2169,35 @@ export function pushOverlayHistory(
 	spaceOverlaySessionIdSignal.value = sessionId;
 	spaceOverlayAgentNameSignal.value = agentName ?? null;
 	spaceOverlayHighlightMessageIdSignal.value = highlightMessageId ?? null;
+	// Clear any pending-agent overlay state — opening a real session takes
+	// precedence and the overlay can only display one mode at a time.
+	spaceOverlayPendingTaskIdSignal.value = null;
+	spaceOverlayPendingAgentNameSignal.value = null;
+}
+
+/**
+ * Push an overlay entry for a workflow-declared peer that has not been spawned
+ * yet. The overlay renders a "Starting…" composer scoped to (taskId, agentName);
+ * on first send the daemon spawns the sub-session and the overlay hydrates to
+ * the live session via the `taskActivity` subscription.
+ *
+ * Use this in place of `pushOverlayHistory` when the user clicks a
+ * "(Not started)" entry in the task agent dropdown.
+ */
+export function pushOverlayHistoryForPendingAgent(taskId: string, agentName: string): void {
+	const currentPath = getCurrentPath();
+	window.history.pushState(
+		{ ...window.history.state, overlaySessionId: `pending:${taskId}:${agentName}` },
+		'',
+		currentPath
+	);
+	spaceOverlayPendingTaskIdSignal.value = taskId;
+	spaceOverlayPendingAgentNameSignal.value = agentName;
+	// Clear any session-mode overlay state so the renderer picks up the
+	// pending-agent variant unambiguously.
+	spaceOverlaySessionIdSignal.value = null;
+	spaceOverlayAgentNameSignal.value = agentName;
+	spaceOverlayHighlightMessageIdSignal.value = null;
 }
 
 /**
@@ -2174,12 +2208,16 @@ export function closeOverlayHistory(): void {
 		spaceOverlaySessionIdSignal.value = null;
 		spaceOverlayAgentNameSignal.value = null;
 		spaceOverlayHighlightMessageIdSignal.value = null;
+		spaceOverlayPendingTaskIdSignal.value = null;
+		spaceOverlayPendingAgentNameSignal.value = null;
 		window.history.back();
 	} else {
 		// No overlay history entry — just close the overlay signal
 		spaceOverlaySessionIdSignal.value = null;
 		spaceOverlayAgentNameSignal.value = null;
 		spaceOverlayHighlightMessageIdSignal.value = null;
+		spaceOverlayPendingTaskIdSignal.value = null;
+		spaceOverlayPendingAgentNameSignal.value = null;
 	}
 }
 

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -2201,6 +2201,33 @@ export function pushOverlayHistoryForPendingAgent(taskId: string, agentName: str
 }
 
 /**
+ * Replace the current overlay history entry instead of pushing a new one.
+ *
+ * Use this for "handoff" transitions where a pending-agent entry is being
+ * replaced by the live session entry (e.g. `PendingAgentOverlay` →
+ * `AgentOverlayChat`). Using `replaceState` avoids pushing a second history
+ * entry, so pressing Back from the live session overlay closes it cleanly
+ * instead of restoring a stale `pending:…` ghost state.
+ */
+export function replaceOverlayHistory(
+	sessionId: string,
+	agentName?: string,
+	highlightMessageId?: string
+): void {
+	const currentPath = getCurrentPath();
+	window.history.replaceState(
+		{ ...window.history.state, overlaySessionId: sessionId },
+		'',
+		currentPath
+	);
+	spaceOverlaySessionIdSignal.value = sessionId;
+	spaceOverlayAgentNameSignal.value = agentName ?? null;
+	spaceOverlayHighlightMessageIdSignal.value = highlightMessageId ?? null;
+	spaceOverlayPendingTaskIdSignal.value = null;
+	spaceOverlayPendingAgentNameSignal.value = null;
+}
+
+/**
  * Close the overlay and go back in history to the pre-overlay entry.
  */
 export function closeOverlayHistory(): void {

--- a/packages/web/src/lib/signals.ts
+++ b/packages/web/src/lib/signals.ts
@@ -76,6 +76,14 @@ export const spaceOverlayAgentNameSignal = signal<string | null>(null);
 // minimal thread feed so they land on the message they clicked instead of the
 // session's tail. Cleared along with the other overlay signals on close.
 export const spaceOverlayHighlightMessageIdSignal = signal<string | null>(null);
+// Pending-agent overlay routing — set when the user opens a not-started peer
+// from the task agent dropdown. The overlay renders a "Starting…" composer
+// against the agent name; on first send it invokes
+// `space.task.activateNodeAgent` to lazily spawn the workflow node, and
+// hydrates to a normal chat overlay as soon as the live session appears in
+// `taskActivity`. Both signals are cleared together on close.
+export const spaceOverlayPendingTaskIdSignal = signal<string | null>(null);
+export const spaceOverlayPendingAgentNameSignal = signal<string | null>(null);
 
 // Mobile drawer signals
 export const contextPanelOpenSignal = signal<boolean>(false);

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -1668,6 +1668,54 @@ class SpaceStore {
 		});
 	}
 
+	/**
+	 * Lazy-activate a workflow-declared node agent for a task.
+	 *
+	 * Used by the agent dropdown when the user clicks a "(Not started)" peer:
+	 * triggers the daemon to spawn the corresponding sub-session and
+	 * (optionally) queues a first message that will be delivered as soon as
+	 * the spawn completes.
+	 *
+	 * Returns the live sessionId when the agent is already spawned, otherwise
+	 * `null` — callers should watch `taskActivity` for the new session to
+	 * appear via the existing live-query subscription.
+	 */
+	async activateTaskNodeAgent(
+		taskId: string,
+		agentName: string,
+		message?: string
+	): Promise<{
+		sessionId: string | null;
+		activated: boolean;
+		queued: boolean;
+		queuedMessageId?: string;
+	}> {
+		const spaceId = this.spaceId.value;
+		if (!spaceId) throw new Error('No space selected');
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		const response = await hub.request<{
+			sessionId: string | null;
+			activated: boolean;
+			queued: boolean;
+			queuedMessageId?: string;
+		}>('space.task.activateNodeAgent', {
+			taskId,
+			spaceId,
+			agentName,
+			...(message !== undefined ? { message } : {}),
+		});
+
+		return {
+			sessionId: response?.sessionId ?? null,
+			activated: response?.activated ?? false,
+			queued: response?.queued ?? false,
+			...(response?.queuedMessageId ? { queuedMessageId: response.queuedMessageId } : {}),
+		};
+	}
+
 	// ========================================
 	// Gate Methods
 	// ========================================


### PR DESCRIPTION
## Summary

Fixes two regressions from Task #133's lazy-activation work:

1. **Daemon** — drop the `executionDeclaredAgentNames` gate on the activation kick. Task agents now always fire `ensureWorkflowNodeActivationForAgent` when queuing for a workflow-declared peer with no live session, including the case where a stranded `node_executions` row already exists. New RPC `space.task.activateNodeAgent` lets the web UI drive the same path on first send. New log line: `task-agent.send: lazy-activated peer <agentName> for task <taskId>`.

2. **Web** — workflow-declared "(Not started)" dropdown entries are now clickable. Clicking opens a new `PendingAgentOverlay` keyed on (taskId, agentName). The overlay's minimal composer calls `spaceStore.activateTaskNodeAgent` on send; once `taskActivity` surfaces a matching `node_agent` member, it hands off to the standard `AgentOverlayChat`.

## Test plan

- [x] New daemon unit tests for `space.task.activateNodeAgent` (10 cases) and stranded-execution activation kick
- [x] New web unit tests for `PendingAgentOverlay` (8 cases)
- [x] Updated `SpaceTaskPane` test asserts not-started entry is clickable and routes to pending overlay
- [x] `bun test` — daemon unit tests green
- [x] `vitest` — web unit tests green
- [x] `tsc --build --noEmit` clean
- [ ] Manual: click "(Not started)" → send first message → session spawns → overlay hands off