### PR TITLE
fix: usage.input_tokens crash on bridge providers + upgrade copilot-sdk

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "packages/cli": {
       "name": "@neokai/cli",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "bin": {
         "kai": "./main.ts",
       },
@@ -32,10 +32,10 @@
     },
     "packages/daemon": {
       "name": "@neokai/daemon",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.112",
-        "@github/copilot-sdk": "0.2.2",
+        "@github/copilot-sdk": "0.3.0",
         "@neokai/shared": "workspace:*",
         "@openai/codex": "0.125.0",
         "croner": "10.0.1",
@@ -52,7 +52,7 @@
     },
     "packages/e2e": {
       "name": "@neokai/e2e",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "devDependencies": {
         "@playwright/test": "1.59.1",
         "@types/node": "25.6.0",
@@ -61,14 +61,14 @@
     },
     "packages/shared": {
       "name": "@neokai/shared",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "devDependencies": {
         "@types/bun": "1.3.13",
       },
     },
     "packages/ui": {
       "name": "@neokai/ui",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "dependencies": {
         "@floating-ui/dom": "1.7.6",
         "preact": "10.29.1",
@@ -88,7 +88,7 @@
     },
     "packages/web": {
       "name": "@neokai/web",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "dependencies": {
         "@preact/signals": "2.9.0",
         "clsx": "2.1.1",
@@ -202,7 +202,7 @@
 
     "@github/copilot-linux-x64": ["@github/copilot-linux-x64@1.0.36", "", { "os": "linux", "cpu": "x64", "bin": { "copilot-linux-x64": "copilot" } }, "sha512-wBtCdR3ITZcq07BJbkwHfwI6ayiwbH5pF1ex+Ycl4UI+Lf1vP9eQD6wJppPgsrjwFcdeWRThaYTPCRTkSGHv5g=="],
 
-    "@github/copilot-sdk": ["@github/copilot-sdk@0.2.2", "", { "dependencies": { "@github/copilot": "^1.0.21", "vscode-jsonrpc": "^8.2.1", "zod": "^4.3.6" } }, "sha512-VZCqS08YlUM90bUKJ7VLeIxgTTEHtfXBo84T1IUMNvXRREX2csjPH6Z+CPw3S2468RcCLvzBXcc9LtJJTLIWFw=="],
+    "@github/copilot-sdk": ["@github/copilot-sdk@0.3.0", "", { "dependencies": { "@github/copilot": "^1.0.36-0", "vscode-jsonrpc": "^8.2.1", "zod": "^4.3.6" } }, "sha512-SUo35k56pzzgYgwmDPHcu7kZxPrzXbH66IWXaEf6pmb94DlA709F82HrrDeja087TL4djJ9OuvRFWWOKCosAsg=="],
 
     "@github/copilot-win32-arm64": ["@github/copilot-win32-arm64@1.0.36", "", { "os": "win32", "cpu": "arm64", "bin": { "copilot-win32-arm64": "copilot.exe" } }, "sha512-0GzZUZQn07alI8BgbzK0NlR5+ta/Rd0sWmd8kbRCns7oybAIkSALy6BKVwJmVHtXUi6h4iUE8oiFhkn0spymvw=="],
 

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -23,7 +23,7 @@
 	},
 	"dependencies": {
 		"@anthropic-ai/claude-agent-sdk": "0.2.112",
-		"@github/copilot-sdk": "0.2.2",
+		"@github/copilot-sdk": "0.3.0",
 		"@neokai/shared": "workspace:*",
 		"@openai/codex": "0.125.0",
 		"croner": "10.0.1",

--- a/packages/daemon/src/lib/providers/anthropic-copilot/conversation.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/conversation.ts
@@ -168,7 +168,7 @@ export class ConversationManager {
 			...(systemMessage
 				? { systemMessage: { mode: 'replace' as const, content: systemMessage } }
 				: {}),
-			onPermissionRequest: () => Promise.resolve({ kind: 'approved' as const }),
+			onPermissionRequest: () => Promise.resolve({ kind: 'approve-once' as const }),
 			onUserInputRequest: () =>
 				Promise.resolve({ answer: 'User input is not available in API mode.', wasFreeform: true }),
 			hooks: {

--- a/packages/daemon/src/lib/providers/anthropic-copilot/server.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/server.ts
@@ -129,7 +129,7 @@ function buildPlainSessionConfig(
 		...(systemMessage
 			? { systemMessage: { mode: 'replace' as const, content: systemMessage } }
 			: {}),
-		onPermissionRequest: () => Promise.resolve({ kind: 'approved' as const }),
+		onPermissionRequest: () => Promise.resolve({ kind: 'approve-once' as const }),
 		onUserInputRequest: () =>
 			Promise.resolve({
 				answer: 'User input is not available. Ask your question in your response instead.',

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts
@@ -309,6 +309,12 @@ export type MessageDeltaUsage = {
 	 * The `outputTokens > 0` guard in `drainToSSE` selects between the two.
 	 */
 	outputTokens: number;
+	/** Input token count for this message (from Codex usage events when available). */
+	inputTokens?: number | null;
+	/** Cache creation input token count (from Codex usage events when available). */
+	cacheCreationInputTokens?: number | null;
+	/** Cache read input token count (from Codex usage events when available). */
+	cacheReadInputTokens?: number | null;
 };
 
 export function messageDeltaSSE(
@@ -318,7 +324,12 @@ export function messageDeltaSSE(
 	return sseEvent('message_delta', {
 		type: 'message_delta',
 		delta: { stop_reason: stopReason, stop_sequence: null },
-		usage: { output_tokens: usage.outputTokens },
+		usage: {
+			input_tokens: usage.inputTokens ?? null,
+			output_tokens: usage.outputTokens,
+			cache_creation_input_tokens: usage.cacheCreationInputTokens ?? null,
+			cache_read_input_tokens: usage.cacheReadInputTokens ?? null,
+		},
 	});
 }
 

--- a/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/translator.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/translator.test.ts
@@ -411,6 +411,30 @@ describe('SSE builders', () => {
 		expect((data as { usage: { output_tokens: number } }).usage.output_tokens).toBe(10);
 	});
 
+	it('messageDeltaSSE includes optional usage fields when provided', () => {
+		const { data } = parseSSE(
+			messageDeltaSSE('end_turn', {
+				outputTokens: 42,
+				inputTokens: 100,
+				cacheCreationInputTokens: 50,
+				cacheReadInputTokens: 25,
+			})
+		);
+		const usage = (data as { usage: Record<string, unknown> }).usage;
+		expect(usage.input_tokens).toBe(100);
+		expect(usage.output_tokens).toBe(42);
+		expect(usage.cache_creation_input_tokens).toBe(50);
+		expect(usage.cache_read_input_tokens).toBe(25);
+	});
+
+	it('messageDeltaSSE null-coalesces missing optional usage fields', () => {
+		const { data } = parseSSE(messageDeltaSSE('end_turn', { outputTokens: 42 }));
+		const usage = (data as { usage: Record<string, unknown> }).usage;
+		expect(usage.input_tokens).toBeNull();
+		expect(usage.cache_creation_input_tokens).toBeNull();
+		expect(usage.cache_read_input_tokens).toBeNull();
+	});
+
 	it('messageStopSSE emits message_stop', () => {
 		const { event, data } = parseSSE(messageStopSSE());
 		expect(event).toBe('message_stop');

--- a/packages/web/src/components/sdk/SDKResultMessage.tsx
+++ b/packages/web/src/components/sdk/SDKResultMessage.tsx
@@ -26,6 +26,14 @@ export function SDKResultMessage({ message }: Props) {
 	const isSuccess = isSDKResultSuccess(message);
 	const isError = isSDKResultError(message);
 
+	// Defense in depth: bridge providers (Copilot / Codex) may omit usage at runtime
+	// despite TypeScript declaring it as NonNullableUsage. Guard all accesses.
+	const usage = (message as { usage?: Record<string, number | undefined> }).usage ?? {};
+	const inputTokens = (usage.input_tokens as number | undefined) ?? 0;
+	const outputTokens = (usage.output_tokens as number | undefined) ?? 0;
+	const cacheReadTokens = (usage.cache_read_input_tokens as number | undefined) ?? 0;
+	const cacheCreationTokens = (usage.cache_creation_input_tokens as number | undefined) ?? 0;
+
 	return (
 		<div
 			class={`rounded border mb-4 ${
@@ -70,7 +78,7 @@ export function SDKResultMessage({ message }: Props) {
 						</svg>
 					)}
 					<span class="font-medium text-green-900 dark:text-green-100">
-						{message.usage.input_tokens}→{message.usage.output_tokens} tokens
+						{inputTokens}→{outputTokens} tokens
 					</span>
 					<span class="text-green-700 dark:text-green-300">•</span>
 					<span class="font-mono text-green-700 dark:text-green-300">
@@ -98,7 +106,7 @@ export function SDKResultMessage({ message }: Props) {
 					<div class="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
 						<StatCard
 							label="Input Tokens"
-							value={message.usage.input_tokens.toLocaleString()}
+							value={inputTokens.toLocaleString()}
 							icon={
 								<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path
@@ -112,7 +120,7 @@ export function SDKResultMessage({ message }: Props) {
 						/>
 						<StatCard
 							label="Output Tokens"
-							value={message.usage.output_tokens.toLocaleString()}
+							value={outputTokens.toLocaleString()}
 							icon={
 								<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path
@@ -156,8 +164,7 @@ export function SDKResultMessage({ message }: Props) {
 					</div>
 
 					{/* Cache Stats (if any) */}
-					{(message.usage.cache_read_input_tokens > 0 ||
-						message.usage.cache_creation_input_tokens > 0) && (
+					{(cacheReadTokens > 0 || cacheCreationTokens > 0) && (
 						<div class="pt-2 border-t border-green-200 dark:border-green-800">
 							<div class="flex items-center gap-4 text-xs text-green-700 dark:text-green-300">
 								<div class="flex items-center gap-1">
@@ -169,11 +176,9 @@ export function SDKResultMessage({ message }: Props) {
 											d="M5 13l4 4L19 7"
 										/>
 									</svg>
-									<span>
-										Cache Read: {message.usage.cache_read_input_tokens.toLocaleString()} tokens
-									</span>
+									<span>Cache Read: {cacheReadTokens.toLocaleString()} tokens</span>
 								</div>
-								{message.usage.cache_creation_input_tokens > 0 && (
+								{cacheCreationTokens > 0 && (
 									<div class="flex items-center gap-1">
 										<svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 											<path
@@ -183,10 +188,7 @@ export function SDKResultMessage({ message }: Props) {
 												d="M12 4v16m8-8H4"
 											/>
 										</svg>
-										<span>
-											Cache Created: {message.usage.cache_creation_input_tokens.toLocaleString()}{' '}
-											tokens
-										</span>
+										<span>Cache Created: {cacheCreationTokens.toLocaleString()} tokens</span>
 									</div>
 								)}
 							</div>

--- a/packages/web/src/components/sdk/__tests__/SDKResultMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKResultMessage.test.tsx
@@ -122,6 +122,13 @@ describe('SDKResultMessage', () => {
 			expect(container.textContent).toContain('tokens');
 		});
 
+		it('should handle missing usage gracefully', () => {
+			const message = createSuccessResult({ usage: undefined as unknown });
+			const { container } = render(<SDKResultMessage message={message} />);
+
+			expect(container.textContent).toContain('0→0 tokens');
+		});
+
 		it('should show cost', () => {
 			const message = createSuccessResult();
 			const { container } = render(<SDKResultMessage message={message} />);

--- a/packages/web/src/components/space/__tests__/space-task-thread-events.test.ts
+++ b/packages/web/src/components/space/__tests__/space-task-thread-events.test.ts
@@ -294,6 +294,45 @@ describe('buildThreadEvents — multi-agent ordering and label preservation', ()
 		expect(events[0].title).toBe('Sub-agent');
 	});
 
+	it('produces result event with token summary from usage', () => {
+		const row = makeRow({
+			id: 'success-result',
+			label: 'Task Agent',
+			messageType: 'result',
+			content: JSON.stringify({
+				type: 'result',
+				subtype: 'success',
+				uuid: 'r1',
+				session_id: 'session-1',
+				usage: { input_tokens: 100, output_tokens: 50 },
+			}),
+			createdAt: 1_000,
+		});
+		const events = buildThreadEvents([parseThreadRow(row)]);
+		expect(events).toHaveLength(1);
+		expect(events[0].kind).toBe('result');
+		expect(events[0].summary).toContain('100→50 tokens');
+	});
+
+	it('produces result event with dash summary when usage is missing', () => {
+		const row = makeRow({
+			id: 'no-usage-result',
+			label: 'Task Agent',
+			messageType: 'result',
+			content: JSON.stringify({
+				type: 'result',
+				subtype: 'success',
+				uuid: 'r2',
+				session_id: 'session-1',
+			}),
+			createdAt: 1_000,
+		});
+		const events = buildThreadEvents([parseThreadRow(row)]);
+		expect(events).toHaveLength(1);
+		expect(events[0].kind).toBe('result');
+		expect(events[0].summary).toBe('— tokens');
+	});
+
 	it('produces result event with error flag for non-success result', () => {
 		const row = makeRow({
 			id: 'err-result',

--- a/packages/web/src/components/space/thread/space-task-thread-events.ts
+++ b/packages/web/src/components/space/thread/space-task-thread-events.ts
@@ -422,6 +422,10 @@ export function buildThreadEvents(parsedRows: ParsedThreadRow[]): SpaceTaskThrea
 		}
 
 		if (isSDKResultMessage(row.message)) {
+			const usage = (row.message as { usage?: Record<string, number | undefined> }).usage;
+			const tokenSummary = usage
+				? `${usage.input_tokens ?? 0}→${usage.output_tokens ?? 0} tokens`
+				: '— tokens';
 			events.push({
 				id: `${String(row.id)}-result`,
 				label: row.label,
@@ -431,7 +435,7 @@ export function buildThreadEvents(parsedRows: ParsedThreadRow[]): SpaceTaskThrea
 				createdAt: row.createdAt,
 				kind: 'result',
 				title: row.message.subtype === 'success' ? 'Completed' : 'Error',
-				summary: `${row.message.usage.input_tokens}→${row.message.usage.output_tokens} tokens`,
+				summary: tokenSummary,
 				message: row.message,
 				resultSubtype: row.message.subtype,
 				isError: row.message.subtype !== 'success',


### PR DESCRIPTION
## Summary
- Guard `message.usage` with optional chaining in `SDKResultMessage` and `space-task-thread-events` — bridge providers (Copilot/Codex) can omit usage at runtime, causing a WebKit crash (`undefined is not an object (evaluating 'K.input_tokens')`)
- Emit complete usage shape (all four fields) in codex bridge `message_delta` SSE events
- Upgrade `@github/copilot-sdk` 0.2.2 → 0.3.0; adapt permission approval kind (`"approved"` → `"approve-once"`)

## Test plan
- [x] 7341 web tests pass (256 files)
- [x] 11406 daemon unit tests pass (382 files)
- [x] TypeScript compilation clean for both packages
- [ ] Manual test with bridge provider to confirm no crash on result messages
- [ ] Manual test Copilot provider end-to-end after SDK upgrade