### PR TITLE
fix(codex-bridge): add stub endpoints to prevent SDK model not found error

### DIFF
--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -38,6 +38,47 @@ import { Logger } from '../../logger.js';
 
 const logger = new Logger('codex-bridge-server');
 
+// ---------------------------------------------------------------------------
+// Model catalogue for GET /v1/models stub
+// ---------------------------------------------------------------------------
+// The bridge server is model-agnostic (it receives the model in each request
+// body), but the Claude Agent SDK calls GET /v1/models during initialisation
+// for capability caching.  Returning 404 for this endpoint triggers a misleading
+// "model not found" error in the SDK's CLI error handler.  We therefore expose
+// a minimal Anthropic-compatible model listing that covers the models offered
+// by the parent AnthropicToCodexBridgeProvider.
+
+const BRIDGE_MODELS = [
+	{
+		id: 'gpt-5.3-codex',
+		display_name: 'GPT-5.3 Codex',
+		created_at: '2025-12-01T00:00:00Z',
+		max_input_tokens: 200000,
+		max_tokens: 16384,
+	},
+	{
+		id: 'gpt-5.4',
+		display_name: 'GPT-5.4',
+		created_at: '2026-01-01T00:00:00Z',
+		max_input_tokens: 200000,
+		max_tokens: 16384,
+	},
+	{
+		id: 'gpt-5.1-codex-mini',
+		display_name: 'GPT-5.1 Codex Mini',
+		created_at: '2026-01-01T00:00:00Z',
+		max_input_tokens: 128000,
+		max_tokens: 16384,
+	},
+] as const;
+
+const MODELS_LIST_RESPONSE = {
+	data: BRIDGE_MODELS.map((m) => ({ ...m, type: 'model' as const })),
+	has_more: false,
+	first_id: BRIDGE_MODELS[0].id,
+	last_id: BRIDGE_MODELS[BRIDGE_MODELS.length - 1].id,
+};
+
 function isClosedControllerError(error: unknown): boolean {
 	if (!(error instanceof Error)) {
 		return false;
@@ -334,8 +375,30 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 				return new Response('ok');
 			}
 
+			// Model listing — the Claude Agent SDK calls this during init for
+			// capability caching.  A 404 here would trigger a misleading "model
+			// not found" error in the SDK's CLI error handler.
+			if (url.pathname === '/v1/models' && req.method === 'GET') {
+				return new Response(JSON.stringify(MODELS_LIST_RESPONSE), {
+					headers: { 'Content-Type': 'application/json' },
+				});
+			}
+
+			// Token counting stub — the SDK calls this for context/token
+			// estimation.  It already catches errors, but returning a proper
+			// response avoids unnecessary error noise.
+			if (url.pathname === '/v1/messages/count_tokens' && req.method === 'POST') {
+				return new Response(JSON.stringify({ input_tokens: 0 }), {
+					headers: { 'Content-Type': 'application/json' },
+				});
+			}
+
+			// Catch-all: return 501 instead of 404.  The SDK specifically maps
+			// HTTP 404 to a user-facing "model not found" message regardless of
+			// which endpoint returned it.  501 falls through to the generic
+			// error handler which does not produce that misleading message.
 			if (url.pathname !== '/v1/messages' || req.method !== 'POST') {
-				return createAnthropicError(404, 'not_found_error', 'Not found');
+				return createAnthropicError(501, 'not_implemented_error', 'Not implemented');
 			}
 
 			let body: AnthropicRequest;

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts
@@ -342,6 +342,7 @@ export type AnthropicErrorType =
 	| 'invalid_request_error'
 	| 'authentication_error'
 	| 'not_found_error'
+	| 'not_implemented_error'
 	| 'api_error'
 	| 'overloaded_error';
 

--- a/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/server.test.ts
@@ -1097,15 +1097,76 @@ describe('Bridge HTTP server — Anthropic JSON error envelopes', () => {
 		realServer.stop();
 	});
 
-	it('returns 404 JSON envelope for unknown URL paths', async () => {
+	it('returns 501 JSON envelope for unknown URL paths', async () => {
 		const resp = await fetch(`http://127.0.0.1:${realServer.port}/unknown/path`, {
 			method: 'GET',
 		});
-		expect(resp.status).toBe(404);
+		expect(resp.status).toBe(501);
 		expect(resp.headers.get('content-type')).toContain('application/json');
 		const body = (await resp.json()) as { type: string; error: { type: string; message: string } };
 		expect(body.type).toBe('error');
-		expect(body.error.type).toBe('not_found_error');
+		expect(body.error.type).toBe('not_implemented_error');
+	});
+
+	it('returns 200 with model listing for GET /v1/models', async () => {
+		const resp = await fetch(`http://127.0.0.1:${realServer.port}/v1/models`, {
+			method: 'GET',
+		});
+		expect(resp.ok).toBe(true);
+		expect(resp.headers.get('content-type')).toContain('application/json');
+		const body = (await resp.json()) as {
+			data: Array<{ id: string; type: string; display_name: string }>;
+			has_more: boolean;
+			first_id: string;
+			last_id: string;
+		};
+		expect(body.data.length).toBeGreaterThanOrEqual(3);
+		expect(body.has_more).toBe(false);
+		// All entries must have type 'model'
+		for (const m of body.data) {
+			expect(m.type).toBe('model');
+			expect(m.id).toBeTruthy();
+			expect(m.display_name).toBeTruthy();
+		}
+		// Known models should be present
+		const ids = body.data.map((m) => m.id);
+		expect(ids).toContain('gpt-5.3-codex');
+		expect(ids).toContain('gpt-5.4');
+		expect(ids).toContain('gpt-5.1-codex-mini');
+		expect(body.first_id).toBe(ids[0]);
+		expect(body.last_id).toBe(ids[ids.length - 1]);
+	});
+
+	it('returns dummy token count for POST /v1/messages/count_tokens', async () => {
+		const resp = await fetch(`http://127.0.0.1:${realServer.port}/v1/messages/count_tokens`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				messages: [{ role: 'user', content: 'hello' }],
+			}),
+		});
+		expect(resp.ok).toBe(true);
+		expect(resp.headers.get('content-type')).toContain('application/json');
+		const body = (await resp.json()) as { input_tokens: number };
+		expect(typeof body.input_tokens).toBe('number');
+	});
+
+	it('returns dummy token count for POST /v1/messages/count_tokens?beta=true', async () => {
+		const resp = await fetch(
+			`http://127.0.0.1:${realServer.port}/v1/messages/count_tokens?beta=true`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					model: 'gpt-5.3-codex',
+					messages: [{ role: 'user', content: 'hello' }],
+				}),
+			}
+		);
+		expect(resp.ok).toBe(true);
+		const body = (await resp.json()) as { input_tokens: number };
+		expect(typeof body.input_tokens).toBe('number');
 	});
 
 	it('returns 400 JSON envelope for invalid JSON body', async () => {


### PR DESCRIPTION
## Summary

- Add `GET /v1/models` endpoint returning Anthropic-compatible model listing (gpt-5.3-codex, gpt-5.4, gpt-5.1-codex-mini) so the SDK's capability caching doesn't trigger a 404
- Add `POST /v1/messages/count_tokens` stub returning `{ input_tokens: 0 }` to satisfy the SDK's token estimation call
- Change catch-all response from 404 to 501 — the Claude Agent SDK maps any HTTP 404 to a misleading "model not found" error regardless of which endpoint returned it; 501 falls through to the generic error handler
- Add `not_implemented_error` to `AnthropicErrorType` union

The `@openai/codex` package is already at 0.125.0 (latest) and `findCodexCli()` correctly resolves the built-in binary from `node_modules/.bun/`.

## Test plan

- [x] All 84 codex-bridge tests pass (server, process-manager, translator)
- [x] All 38 provider tests pass
- [x] New tests: GET /v1/models returns correct listing, POST /v1/messages/count_tokens returns dummy token count, unknown paths return 501
- [ ] Manual: start dev server with Codex provider, verify no "model not found" error mid-session