### PR TITLE
fix(daemon): normalize usage on BetaMessages to prevent SDK crash

### DIFF
--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -487,6 +487,25 @@ export class SDKMessageHandler {
 			(message as SDKUserMessage & { isSynthetic: boolean }).isSynthetic = true;
 		}
 
+		// Ensure messages with a nested BetaMessage have a usage object to
+		// prevent SDK crashes. The Claude Agent SDK's internal functions
+		// access message.usage.input_tokens without null-checking. When the
+		// SDK subprocess is restarted and reloads conversation history from
+		// the daemon, messages without usage cause:
+		//   "undefined is not an object (evaluating 'K.input_tokens')"
+		if (
+			'message' in message &&
+			message.message &&
+			!(message.message as Record<string, unknown>).usage
+		) {
+			(message.message as Record<string, unknown>).usage = {
+				input_tokens: 0,
+				output_tokens: 0,
+				cache_creation_input_tokens: 0,
+				cache_read_input_tokens: 0,
+			};
+		}
+
 		// Save to DB FIRST before broadcasting to clients
 		// This ensures we only broadcast messages that are successfully persisted
 		const deferredSuccessfully = db.saveSDKMessage(session.id, message);

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -193,7 +193,7 @@ export async function drainToSSE(
 				send(contentBlockStopSSE(blockIndex));
 				// At tool_call time, thread/tokenUsage/updated has not yet fired (the model
 				// hasn't finished the turn yet), so always use the heuristic count here.
-				send(messageDeltaSSE('tool_use', { outputTokens }));
+				send(messageDeltaSSE('tool_use', { outputTokens, inputTokens: 0 }));
 				send(messageStopSSE());
 
 				// Store the session so the next HTTP request can resume it.
@@ -228,7 +228,12 @@ export async function drainToSSE(
 				// event.outputTokens is populated from thread/tokenUsage/updated (v2 protocol)
 				// or from legacy inline usage. Fall back to heuristic count if both are 0.
 				const endOutputTokens = event.outputTokens > 0 ? event.outputTokens : outputTokens;
-				send(messageDeltaSSE('end_turn', { outputTokens: endOutputTokens }));
+				send(
+					messageDeltaSSE('end_turn', {
+						outputTokens: endOutputTokens,
+						inputTokens: event.inputTokens || 0,
+					})
+				);
 				send(messageStopSSE());
 				onTurnDone();
 				controller.close();
@@ -253,7 +258,7 @@ export async function drainToSSE(
 		if (textBlockOpen) {
 			send(contentBlockStopSSE(blockIndex));
 		}
-		send(messageDeltaSSE('end_turn', { outputTokens: outputTokens }));
+		send(messageDeltaSSE('end_turn', { outputTokens: outputTokens, inputTokens: 0 }));
 		send(messageStopSSE());
 		session.kill();
 		onError?.();

--- a/packages/daemon/tests/unit/1-core/agent/sdk-message-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/sdk-message-handler.test.ts
@@ -208,6 +208,65 @@ describe('SDKMessageHandler', () => {
 			expect(saveSDKMessageSpy).toHaveBeenCalledWith('test-session-id', message);
 		});
 
+		it('should normalize missing usage on messages with BetaMessage (bridge provider crash guard)', async () => {
+			// Bridge providers (Codex, Copilot) may produce messages without a
+			// usage field on the nested BetaMessage. The Claude Agent SDK's
+			// internal functions access message.usage.input_tokens without
+			// null-checking, so we must ensure all persisted messages with a
+			// BetaMessage have a usage object.
+			const message: SDKMessage = {
+				type: 'assistant',
+				uuid: 'test-uuid',
+				message: { role: 'assistant', content: [] },
+			} as unknown as SDKMessage;
+
+			// message.message.usage should be undefined before handling
+			expect(
+				(message as unknown as { message: { usage?: unknown } }).message.usage
+			).toBeUndefined();
+
+			await handler.handleMessage(message);
+
+			// After handling, usage should be normalized with zeroed fields
+			expect(
+				(message as unknown as { message: { usage: Record<string, number> } }).message.usage
+			).toEqual({
+				input_tokens: 0,
+				output_tokens: 0,
+				cache_creation_input_tokens: 0,
+				cache_read_input_tokens: 0,
+			});
+
+			// The normalized message should be saved to DB
+			expect(saveSDKMessageSpy).toHaveBeenCalledWith('test-session-id', message);
+		});
+
+		it('should not overwrite existing usage on messages with BetaMessage', async () => {
+			// When usage is already present (e.g. direct Anthropic provider),
+			// it should be left untouched.
+			const originalUsage = {
+				input_tokens: 500,
+				output_tokens: 200,
+				cache_creation_input_tokens: 100,
+				cache_read_input_tokens: 50,
+			};
+			const message: SDKMessage = {
+				type: 'assistant',
+				uuid: 'test-uuid',
+				message: {
+					role: 'assistant',
+					content: [],
+					usage: originalUsage,
+				},
+			} as unknown as SDKMessage;
+
+			await handler.handleMessage(message);
+
+			expect(
+				(message as unknown as { message: { usage: Record<string, number> } }).message.usage
+			).toBe(originalUsage);
+		});
+
 		it('should publish message delta', async () => {
 			const message: SDKMessage = {
 				type: 'assistant',


### PR DESCRIPTION
## Summary

- Normalize missing `usage` on any persisted message with a `BetaMessage` (before DB save), preventing `K.input_tokens` crash when the SDK subprocess reloads conversation history from bridge providers
- Pass explicit `inputTokens` in Codex bridge `message_delta` SSE events instead of relying on null-coalescing to `null`
- Copilot bridge already emits correct usage shape — no changes needed

## Test plan

- [x] Unit tests: 2 new tests for usage normalization (missing usage → zeroed, existing usage → preserved)
- [x] All 93 existing tests pass (sdk-message-handler + translator)
- [ ] Manual: run dev server with Codex provider, verify multi-turn sessions work without `K.input_tokens` crash
- [ ] Manual: verify conversation summary/context management features work (the SDK's qjz code path)