### PR TITLE
fix(space): skip redundant merge approval when human already approved

### DIFF
--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -436,7 +436,7 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'You are the Reviewer in a Coding→Review iterative workflow. You review the work ' +
 							'and either approve it or request changes.\n\n' +
 							'You share the same worktree as the engineer — review the codebase as a whole, ' +
-							'not just the PR diff. Read related files, run tests, check for issues the diff ' +
+							'not just the PR diff. Read related files, check for issues the diff ' +
 							'might not surface (e.g. callers of changed functions, integration points).\n' +
 							'- All feedback MUST be posted to the PR on GitHub — not just summarized in your ' +
 							'response. Use `gh pr review <pr-url> --request-changes --body-file <file>` for ' +

--- a/packages/daemon/src/lib/space/workflows/post-approval-merge-template.ts
+++ b/packages/daemon/src/lib/space/workflows/post-approval-merge-template.ts
@@ -15,9 +15,12 @@
  *   - `{{pr_url}}`          — signalled by the end node via
  *                             `send_message(task-agent, …, data:{ pr_url })`.
  *   - `{{autonomy_level}}`  — space autonomy level at routing time.
- *   - `{{approval_source}}` — `'end_node' | 'human_review'` (distinguishes
- *                             reviewer self-close from human-approved review).
- *
+ *   - `{{approval_source}}` — `'human' | 'agent'` (from
+ *                             `SpaceApprovalSource`; `auto_policy` is
+ *                             theoretically possible but no caller produces
+ *                             it for post-approval). Step 2 uses this to
+ *                             skip redundant merge approval when human
+ *                             already approved.
  * NOTE: The `{{reviewer_name}}` token was intentionally replaced with the
  * static string `[end-node reviewer]` in PR 3/5 because nothing in
  * `dispatchPostApproval` currently resolves the approving agent's slot name

--- a/packages/daemon/src/lib/space/workflows/post-approval-merge-template.ts
+++ b/packages/daemon/src/lib/space/workflows/post-approval-merge-template.ts
@@ -53,7 +53,7 @@ export const PR_MERGE_POST_APPROVAL_INSTRUCTIONS: string = [
 	'1. Verify the PR is still open and passes CI:',
 	'     gh pr view {{pr_url}} --json state,mergeStateStatus,statusCheckRollup',
 	'   If state is MERGED, record an audit artifact and exit — the work is done.',
-	'2. If approval_source == "auto" AND autonomy_level < 4:',
+	'2. If approval_source != "human" AND autonomy_level < 4:',
 	'     Call request_human_input with',
 	'       question: "Approve merging PR {{pr_url}}?"',
 	'       context: "Reviewer: [end-node reviewer]. CI: <from step 1>."',

--- a/packages/daemon/src/lib/space/workflows/post-approval-merge-template.ts
+++ b/packages/daemon/src/lib/space/workflows/post-approval-merge-template.ts
@@ -53,7 +53,7 @@ export const PR_MERGE_POST_APPROVAL_INSTRUCTIONS: string = [
 	'1. Verify the PR is still open and passes CI:',
 	'     gh pr view {{pr_url}} --json state,mergeStateStatus,statusCheckRollup',
 	'   If state is MERGED, record an audit artifact and exit — the work is done.',
-	'2. If autonomy_level < 4:',
+	'2. If approval_source == "auto" AND autonomy_level < 4:',
 	'     Call request_human_input with',
 	'       question: "Approve merging PR {{pr_url}}?"',
 	'       context: "Reviewer: [end-node reviewer]. CI: <from step 1>."',

--- a/packages/daemon/tests/unit/5-space/workflow/end-node-handoff.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/end-node-handoff.test.ts
@@ -287,10 +287,12 @@ describe('Shared merge template canonical content', () => {
 		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).toContain('DO NOT call approve_task');
 	});
 
-	test('template gates auto-merge behind autonomy_level >= 4', () => {
+	test('template gates auto-merge behind approval_source == "auto" AND autonomy_level < 4', () => {
 		// Section 2 of the template body is the human-approval fallback for
-		// autonomy < 4. Dropping the fallback would silently auto-merge for
-		// low-autonomy spaces, which is explicitly forbidden by the plan.
+		// auto-approved tasks at autonomy < 4. When approval_source is
+		// "human" (the human already reviewed and approved), step 2 is
+		// skipped to avoid redundant double-approval.
+		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).toContain('approval_source == "auto"');
 		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).toContain('autonomy_level < 4');
 		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).toContain('request_human_input');
 	});

--- a/packages/daemon/tests/unit/5-space/workflow/end-node-handoff.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/end-node-handoff.test.ts
@@ -287,12 +287,13 @@ describe('Shared merge template canonical content', () => {
 		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).toContain('DO NOT call approve_task');
 	});
 
-	test('template gates auto-merge behind approval_source == "auto" AND autonomy_level < 4', () => {
+	test('template gates auto-merge behind approval_source != "human" AND autonomy_level < 4', () => {
 		// Section 2 of the template body is the human-approval fallback for
-		// auto-approved tasks at autonomy < 4. When approval_source is
-		// "human" (the human already reviewed and approved), step 2 is
-		// skipped to avoid redundant double-approval.
-		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).toContain('approval_source == "auto"');
+		// non-human approvals (auto_policy, agent) at autonomy < 4. When
+		// approval_source is "human", step 2 is skipped to avoid redundant
+		// double-approval. Uses != to cover both SpaceApprovalSource
+		// variants ("auto_policy" and "agent").
+		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).toContain('approval_source != "human"');
 		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).toContain('autonomy_level < 4');
 		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).toContain('request_human_input');
 	});


### PR DESCRIPTION
## Summary

- Changed merge template step 2 condition from `autonomy_level < 4` to `approval_source == "auto" AND autonomy_level < 4`, so human-approved tasks skip the redundant "Approve merging PR?" prompt
- Updated the structural test to assert the new combined condition

## Behavior change

| approval_source | autonomy | Before | After |
|---|---|---|---|
| human | any | asks human again | merges directly |
| auto | < 4 | asks human | asks human (unchanged) |
| auto | >= 4 | merges directly | merges directly (unchanged) |