### PR TITLE
fix(space): prevent silent message drop + tighten matcher in task-composer target picker (Task #143)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
@@ -133,7 +133,8 @@ export interface PendingAgentMessageQueue {
 
 type SpaceTaskMessageTarget =
 	| { kind: 'task_agent' }
-	| { kind: 'node_agent'; agentName?: string; nodeExecutionId?: string };
+	| { kind: 'node_agent'; agentName: string; nodeExecutionId?: string }
+	| { kind: 'node_agent'; nodeExecutionId: string; agentName?: string };
 
 /**
  * Register RPC handlers for human ↔ Task Agent message routing.
@@ -196,7 +197,13 @@ export function setupSpaceTaskMessageHandlers(
 		taskId: string,
 		message: string,
 		target: { agentName?: string; nodeExecutionId?: string }
-	): Promise<{ ok: true; routedTo: string[]; delivered?: false; activated?: true }> {
+	): Promise<{
+		ok: true;
+		routedTo: string[];
+		delivered?: false;
+		activated?: true;
+		queued?: true;
+	}> {
 		if (!task?.workflowRunId) {
 			throw new Error(`Task ${taskId} has no workflow run — cannot target workflow agents.`);
 		}
@@ -207,10 +214,16 @@ export function setupSpaceTaskMessageHandlers(
 		const executions = nodeExecutionRepo
 			.listByWorkflowRun(task.workflowRunId)
 			.filter((e) => e.status !== 'cancelled');
-		const matches = executions.filter((e) => {
-			if (target.nodeExecutionId && e.id === target.nodeExecutionId) return true;
-			return !!target.agentName && e.agentName.toLowerCase() === target.agentName.toLowerCase();
-		});
+
+		// When nodeExecutionId is provided, require an exact match — the user
+		// disambiguated by execution, so falling back to agentName broadens the
+		// match to every execution sharing the same name across all nodes.
+		// agentName-only matching is only used when nodeExecutionId is absent.
+		const matches = target.nodeExecutionId
+			? executions.filter((e) => e.id === target.nodeExecutionId)
+			: executions.filter(
+					(e) => !!target.agentName && e.agentName.toLowerCase() === target.agentName!.toLowerCase()
+				);
 
 		if (matches.length === 0) {
 			const available = [...new Set(executions.map((e) => e.agentName))].sort();
@@ -238,32 +251,64 @@ export function setupSpaceTaskMessageHandlers(
 			const refreshed = nodeExecutionRepo
 				.listByWorkflowRun(task.workflowRunId)
 				.filter((e) => e.status !== 'cancelled');
-			const refreshedMatches = refreshed.filter((e) => {
-				if (target.nodeExecutionId && e.id === target.nodeExecutionId) return true;
-				return !!target.agentName && e.agentName.toLowerCase() === target.agentName.toLowerCase();
-			});
+			// Re-apply the same strict matching logic used above (exact
+			// nodeExecutionId match when provided, agentName otherwise).
+			const refreshedMatches = target.nodeExecutionId
+				? refreshed.filter((e) => e.id === target.nodeExecutionId)
+				: refreshed.filter(
+						(e) =>
+							!!target.agentName && e.agentName.toLowerCase() === target.agentName!.toLowerCase()
+					);
 			deliverable = refreshedMatches.filter((e) => e.agentSessionId);
 		}
 
-		if (deliverable.length === 0) {
+		// Direct delivery: at least one target has a live session.
+		if (deliverable.length > 0) {
+			await Promise.all(
+				deliverable.map((exec) =>
+					taskAgentManager.injectSubSessionMessage!(exec.agentSessionId!, message)
+				)
+			);
 			return {
 				ok: true,
-				routedTo: [...new Set(matches.map((e) => e.agentName))],
+				routedTo: [...new Set(deliverable.map((e) => e.agentName))],
 				...(activated ? { activated: true as const } : {}),
-				delivered: false,
 			};
 		}
 
-		await Promise.all(
-			deliverable.map((exec) =>
-				taskAgentManager.injectSubSessionMessage!(exec.agentSessionId!, message)
-			)
-		);
+		// No live session after activation — persist the message to the
+		// pending-message queue so it is delivered when the session spawns.
+		// This prevents the user's message from being silently dropped.
+		if (pendingMessageQueue) {
+			const queuedNames: string[] = [];
+			for (const exec of matches) {
+				const { record } = pendingMessageQueue.enqueue({
+					workflowRunId: task.workflowRunId!,
+					spaceId: task.spaceId,
+					taskId,
+					sourceAgentName: 'human',
+					targetKind: 'node_agent',
+					targetAgentName: exec.agentName,
+					message,
+				});
+				if (record) queuedNames.push(exec.agentName);
+			}
+			return {
+				ok: true,
+				routedTo: [...new Set(queuedNames)],
+				...(activated ? { activated: true as const } : {}),
+				delivered: false,
+				queued: true,
+			};
+		}
 
+		// No queue available — signal that the message could not be delivered.
+		// The client is responsible for surfacing this to the user.
 		return {
 			ok: true,
-			routedTo: [...new Set(deliverable.map((e) => e.agentName))],
+			routedTo: [...new Set(matches.map((e) => e.agentName))],
 			...(activated ? { activated: true as const } : {}),
+			delivered: false,
 		};
 	}
 

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -190,7 +190,7 @@ export class SessionManager {
 				// STEP 2: Clear draft if it matches the sent message content
 				if (hasDraftToClear) {
 					await this.sessionLifecycle.update(sessionId, {
-						metadata: { inputDraft: undefined },
+						metadata: { inputDraft: null },
 					} as Partial<Session>);
 				}
 			} catch (error) {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-message-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-message-handlers.test.ts
@@ -195,6 +195,23 @@ describe('setupSpaceTaskMessageHandlers', () => {
 		return handler(data);
 	};
 
+	// Mock NodeExecutionLookup — includes status field (required by NodeExecutionLookup interface)
+	function makeNodeExecutionRepo(
+		agents: Array<{
+			id?: string;
+			workflowNodeId?: string;
+			agentName: string;
+			agentSessionId: string | null;
+			status?: string;
+		}>
+	): NodeExecutionLookup {
+		return {
+			listByWorkflowRun: mock(() =>
+				agents.map((a) => ({ ...a, status: a.status ?? 'in_progress' }))
+			),
+		};
+	}
+
 	// ─── Registration ──────────────────────────────────────────────────────────
 
 	describe('handler registration', () => {
@@ -613,23 +630,6 @@ describe('setupSpaceTaskMessageHandlers', () => {
 	// ─── @mention routing ─────────────────────────────────────────────────────────
 
 	describe('@mention routing in space.task.sendMessage', () => {
-		// Mock NodeExecutionLookup — includes status field (required by NodeExecutionLookup interface)
-		function makeNodeExecutionRepo(
-			agents: Array<{
-				id?: string;
-				workflowNodeId?: string;
-				agentName: string;
-				agentSessionId: string | null;
-				status?: string;
-			}>
-		): NodeExecutionLookup {
-			return {
-				listByWorkflowRun: mock(() =>
-					agents.map((a) => ({ ...a, status: a.status ?? 'in_progress' }))
-				),
-			};
-		}
-
 		// Task with a workflowRunId set
 		const mockTaskWithWorkflowRun: SpaceTask = {
 			...mockTaskWithSession,
@@ -930,6 +930,446 @@ describe('setupSpaceTaskMessageHandlers', () => {
 					message: '@Coder please help',
 				})
 			).rejects.toThrow('Sub-session not found: session-coder-1');
+		});
+	});
+
+	// ─── P2: Matcher correctness + activation path (PR #1660 review) ──────────
+
+	describe('explicit target: matcher correctness (PR #1660 review)', () => {
+		const mockTaskWithRun: SpaceTask = {
+			...mockTaskWithSession,
+			workflowRunId: 'run-match-1',
+		};
+
+		/**
+		 * Sets up handlers with activateNode + pendingMessageQueue for
+		 * activation-path tests.
+		 */
+		function setupWithActivation(opts: {
+			nodeExecAgents: Array<{
+				id?: string;
+				workflowNodeId?: string;
+				agentName: string;
+				agentSessionId: string | null;
+				status?: string;
+			}>;
+			activateNode?: (runId: string, nodeId: string) => Promise<void>;
+			includeQueue?: boolean;
+		}) {
+			const mh = createMockMessageHub();
+			hub = mh.hub;
+			handlers = mh.handlers;
+			const injectSubSession = mock(async (_sid: string, _msg: string) => {});
+			taskAgentManager = {
+				...createMockTaskAgentManager(null, mockTaskWithRun),
+				injectSubSessionMessage: injectSubSession,
+			};
+			db = createMockDatabase(mockTaskWithRun);
+			daemonHub = { emit: mock(async () => {}) } as unknown as DaemonHub;
+
+			const nodeExecCalls: Array<{ runId: string; nodeId: string }> = [];
+			const mockActivateNode = opts.activateNode
+				? mock(async (runId: string, nodeId: string) => {
+						nodeExecCalls.push({ runId, nodeId });
+						await opts.activateNode!(runId, nodeId);
+					})
+				: undefined;
+
+			const enqueueCalls: Array<{
+				targetAgentName: string;
+				message: string;
+				sourceAgentName?: string | null;
+			}> = [];
+			let pendingQueue: { enqueue: ReturnType<typeof mock> } | undefined;
+			if (opts.includeQueue ?? true) {
+				pendingQueue = {
+					enqueue: mock(
+						(input: {
+							targetAgentName: string;
+							message: string;
+							sourceAgentName?: string | null;
+						}) => {
+							enqueueCalls.push({
+								targetAgentName: input.targetAgentName,
+								message: input.message,
+								sourceAgentName: input.sourceAgentName,
+							});
+							return { record: { id: `pending-\${enqueueCalls.length}` }, deduped: false };
+						}
+					),
+				};
+			}
+
+			const nodeExecutionRepo = makeNodeExecutionRepo(opts.nodeExecAgents);
+
+			setupSpaceTaskMessageHandlers(
+				mh.hub,
+				taskAgentManager,
+				db,
+				daemonHub,
+				nodeExecutionRepo,
+				undefined,
+				mockActivateNode,
+				pendingQueue as Parameters<typeof setupSpaceTaskMessageHandlers>[7]
+			);
+
+			return {
+				injectSubSession,
+				nodeExecCalls,
+				enqueueCalls,
+				activateNode: mockActivateNode,
+			};
+		}
+
+		it('nodeExecutionId mismatch with valid agentName throws (does not broaden)', async () => {
+			// Two nodes both declare a "Coder" agent. The user picked
+			// exec-coder-A by nodeExecutionId, but that ID no longer exists.
+			// The handler must NOT fall back to agentName and deliver to
+			// exec-coder-B instead.
+			const { injectSubSession } = setupWithActivation({
+				nodeExecAgents: [
+					{
+						id: 'exec-coder-B',
+						workflowNodeId: 'node-2',
+						agentName: 'Coder',
+						agentSessionId: 'session-coder-b',
+					},
+				],
+			});
+
+			await expect(
+				call('space.task.sendMessage', {
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					message: 'Please fix',
+					target: {
+						kind: 'node_agent',
+						agentName: 'Coder',
+						nodeExecutionId: 'exec-coder-A', // wrong ID
+					},
+				})
+			).rejects.toThrow('Workflow agent not found');
+			expect(injectSubSession).not.toHaveBeenCalled();
+		});
+
+		it('agentName-only target fans out to all same-named executions', async () => {
+			// Two nodes both declare "Coder". No nodeExecutionId provided.
+			// Both should receive the message.
+			const { injectSubSession } = setupWithActivation({
+				nodeExecAgents: [
+					{
+						id: 'exec-coder-A',
+						workflowNodeId: 'node-1',
+						agentName: 'Coder',
+						agentSessionId: 'session-coder-a',
+					},
+					{
+						id: 'exec-coder-B',
+						workflowNodeId: 'node-2',
+						agentName: 'Coder',
+						agentSessionId: 'session-coder-b',
+					},
+				],
+			});
+
+			const result = await call('space.task.sendMessage', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				message: 'Please check both',
+				target: {
+					kind: 'node_agent',
+					agentName: 'Coder',
+					// no nodeExecutionId — should fan out
+				},
+			});
+
+			expect(result).toMatchObject({ ok: true, routedTo: ['Coder'] });
+			expect(injectSubSession).toHaveBeenCalledTimes(2);
+			expect(injectSubSession).toHaveBeenCalledWith('session-coder-a', 'Please check both');
+			expect(injectSubSession).toHaveBeenCalledWith('session-coder-b', 'Please check both');
+		});
+
+		it('activateNode invoked once per unique missing workflowNodeId (deduped)', async () => {
+			const { nodeExecCalls, injectSubSession } = setupWithActivation({
+				nodeExecAgents: [
+					{
+						id: 'exec-coder-1',
+						workflowNodeId: 'node-1',
+						agentName: 'Coder',
+						agentSessionId: null, // no session yet
+					},
+					{
+						id: 'exec-coder-2',
+						workflowNodeId: 'node-1', // same nodeId — deduped
+						agentName: 'Coder',
+						agentSessionId: null,
+					},
+				],
+				activateNode: async () => {
+					// No-op: session stays null after activation
+				},
+			});
+
+			const result = await call('space.task.sendMessage', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				message: 'Wake up Coder',
+				target: { kind: 'node_agent', agentName: 'Coder' },
+			});
+
+			// activateNode called exactly once (deduped by workflowNodeId)
+			expect(nodeExecCalls).toHaveLength(1);
+			expect(nodeExecCalls[0].nodeId).toBe('node-1');
+			// No injection (no sessions)
+			expect(injectSubSession).not.toHaveBeenCalled();
+			// Message queued for delivery when session comes online
+			expect(result).toMatchObject({
+				ok: true,
+				delivered: false,
+				queued: true,
+			});
+		});
+
+		it('activateNode + re-query delivers when session becomes available', async () => {
+			// Mutable repo that returns null session initially, then
+			// returns a live session after activateNode is called.
+			const mutableRepo = {
+				listByWorkflowRun: mock(() => [
+					{
+						id: 'exec-reviewer',
+						workflowNodeId: 'node-rev',
+						agentName: 'Reviewer',
+						agentSessionId: null as string | null,
+						status: 'in_progress',
+					},
+				]),
+			};
+
+			const mh = createMockMessageHub();
+			hub = mh.hub;
+			handlers = mh.handlers;
+			const injectSub = mock(async (_sid: string, _msg: string) => {});
+			taskAgentManager = {
+				...createMockTaskAgentManager(null, mockTaskWithRun),
+				injectSubSessionMessage: injectSub,
+			};
+			db = createMockDatabase(mockTaskWithRun);
+			daemonHub = { emit: mock(async () => {}) } as unknown as DaemonHub;
+
+			const activateCalls: string[] = [];
+			const mockActivate = mock(async (_runId: string, nodeId: string) => {
+				activateCalls.push(nodeId);
+				// Simulate session available after activation
+				mutableRepo.listByWorkflowRun = mock(() => [
+					{
+						id: 'exec-reviewer',
+						workflowNodeId: 'node-rev',
+						agentName: 'Reviewer',
+						agentSessionId: 'session-reviewer-live',
+						status: 'in_progress',
+					},
+				]);
+			});
+
+			setupSpaceTaskMessageHandlers(
+				mh.hub,
+				taskAgentManager,
+				db,
+				daemonHub,
+				mutableRepo,
+				undefined,
+				mockActivate,
+				undefined
+			);
+
+			const result = await call('space.task.sendMessage', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				message: 'Please review',
+				target: {
+					kind: 'node_agent',
+					agentName: 'Reviewer',
+					nodeExecutionId: 'exec-reviewer',
+				},
+			});
+
+			expect(activateCalls).toEqual(['node-rev']);
+			expect(injectSub).toHaveBeenCalledTimes(1);
+			expect(injectSub).toHaveBeenCalledWith('session-reviewer-live', 'Please review');
+			expect(result).toMatchObject({
+				ok: true,
+				routedTo: ['Reviewer'],
+				activated: true,
+			});
+			// No delivered:false — message was actually delivered
+			expect((result as { delivered?: boolean }).delivered).toBeUndefined();
+		});
+
+		it('activateNode throws -> handler surfaces error (no ok:true)', async () => {
+			const { injectSubSession } = setupWithActivation({
+				nodeExecAgents: [
+					{
+						id: 'exec-coder',
+						workflowNodeId: 'node-1',
+						agentName: 'Coder',
+						agentSessionId: null,
+					},
+				],
+				activateNode: async () => {
+					throw new Error('Activation failed: node not found');
+				},
+			});
+
+			await expect(
+				call('space.task.sendMessage', {
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					message: 'Wake up',
+					target: { kind: 'node_agent', agentName: 'Coder' },
+				})
+			).rejects.toThrow('Activation failed: node not found');
+			expect(injectSubSession).not.toHaveBeenCalled();
+		});
+
+		it('delivered:false + queued:true when session not available and queue is present', async () => {
+			const { enqueueCalls, injectSubSession } = setupWithActivation({
+				nodeExecAgents: [
+					{
+						id: 'exec-reviewer',
+						workflowNodeId: 'node-rev',
+						agentName: 'Reviewer',
+						agentSessionId: null,
+					},
+				],
+				activateNode: async () => {
+					// No-op: session stays null
+				},
+			});
+
+			const result = await call('space.task.sendMessage', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				message: 'Queue this',
+				target: { kind: 'node_agent', agentName: 'Reviewer' },
+			});
+
+			expect(result).toMatchObject({
+				ok: true,
+				routedTo: ['Reviewer'],
+				delivered: false,
+				queued: true,
+				activated: true,
+			});
+			// Message persisted to queue
+			expect(enqueueCalls).toHaveLength(1);
+			expect(enqueueCalls[0].targetAgentName).toBe('Reviewer');
+			expect(enqueueCalls[0].message).toBe('Queue this');
+			expect(enqueueCalls[0].sourceAgentName).toBe('human');
+			// No injection (no sessions)
+			expect(injectSubSession).not.toHaveBeenCalled();
+		});
+
+		it('delivered:false without queued when no pendingMessageQueue', async () => {
+			const mh = createMockMessageHub();
+			hub = mh.hub;
+			handlers = mh.handlers;
+			const injectSubSession = mock(async (_sid: string, _msg: string) => {});
+			taskAgentManager = {
+				...createMockTaskAgentManager(null, mockTaskWithRun),
+				injectSubSessionMessage: injectSubSession,
+			};
+			db = createMockDatabase(mockTaskWithRun);
+			daemonHub = { emit: mock(async () => {}) } as unknown as DaemonHub;
+
+			const mockActivate = mock(async () => {});
+			const nodeExecutionRepo = makeNodeExecutionRepo([
+				{
+					id: 'exec-coder',
+					workflowNodeId: 'node-1',
+					agentName: 'Coder',
+					agentSessionId: null,
+				},
+			]);
+
+			// No pendingMessageQueue (7th arg = undefined)
+			setupSpaceTaskMessageHandlers(
+				mh.hub,
+				taskAgentManager,
+				db,
+				daemonHub,
+				nodeExecutionRepo,
+				undefined,
+				mockActivate,
+				undefined
+			);
+
+			const result = await call('space.task.sendMessage', {
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				message: 'Orphaned',
+				target: { kind: 'node_agent', agentName: 'Coder' },
+			});
+
+			expect(result).toMatchObject({
+				ok: true,
+				routedTo: ['Coder'],
+				delivered: false,
+				activated: true,
+			});
+			// No queued field
+			expect((result as { queued?: boolean }).queued).toBeUndefined();
+			expect(injectSubSession).not.toHaveBeenCalled();
+		});
+
+		it('nodeExecutionRepo undefined -> "Workflow agent targeting is unavailable" error', async () => {
+			const mh = createMockMessageHub();
+			hub = mh.hub;
+			handlers = mh.handlers;
+			taskAgentManager = createMockTaskAgentManager(null, mockTaskWithRun);
+			db = createMockDatabase(mockTaskWithRun);
+			daemonHub = { emit: mock(async () => {}) } as unknown as DaemonHub;
+
+			// No nodeExecutionRepo (5th arg = undefined)
+			setupSpaceTaskMessageHandlers(hub, taskAgentManager, db, daemonHub);
+
+			await expect(
+				call('space.task.sendMessage', {
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					message: 'Hello',
+					target: { kind: 'node_agent', agentName: 'Coder' },
+				})
+			).rejects.toThrow('Workflow agent targeting is unavailable');
+		});
+
+		it('injectSubSessionMessage undefined -> "Workflow agent targeting is unavailable" error', async () => {
+			const mh = createMockMessageHub();
+			hub = mh.hub;
+			handlers = mh.handlers;
+			// Manager WITHOUT injectSubSessionMessage
+			taskAgentManager = {
+				ensureTaskAgentSession: mock(async () => mockTaskWithRun),
+				injectTaskAgentMessage: mock(async () => {}),
+				getTaskAgent: mock(() => undefined),
+				// no injectSubSessionMessage
+			};
+			db = createMockDatabase(mockTaskWithRun);
+			daemonHub = { emit: mock(async () => {}) } as unknown as DaemonHub;
+
+			const nodeExecutionRepo = makeNodeExecutionRepo([
+				{ agentName: 'Coder', agentSessionId: 'session-1' },
+			]);
+
+			setupSpaceTaskMessageHandlers(hub, taskAgentManager, db, daemonHub, nodeExecutionRepo);
+
+			await expect(
+				call('space.task.sendMessage', {
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					message: 'Hello',
+					target: { kind: 'node_agent', agentName: 'Coder' },
+				})
+			).rejects.toThrow('Workflow agent targeting is unavailable');
 		});
 	});
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -529,7 +529,7 @@ export interface SessionMetadata {
 	titleGenerated?: boolean; // Flag to track if title has been auto-generated
 	workspaceInitialized?: boolean; // Flag to track if workspace (title + worktree) has been initialized
 	lastContextInfo?: ContextInfo | null; // Last known context info (persisted)
-	inputDraft?: string; // Draft input text (persisted across sessions and devices)
+	inputDraft?: string | null; // Draft input text (null to clear; persisted across sessions and devices)
 	removedOutputs?: string[]; // UUIDs of messages whose tool_result outputs were removed from SDK session file
 	resolvedQuestions?: Record<string, ResolvedQuestion>; // Resolved AskUserQuestion responses, keyed by toolUseId
 	// Cost tracking: SDK reports cumulative cost per run, but resets on agent restart

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -476,7 +476,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 				setEnsuringThread(false);
 			}
 
-			await spaceStore.sendTaskMessage(
+			const result = await spaceStore.sendTaskMessage(
 				task.id,
 				nextMessage,
 				target?.kind === 'node_agent' && target.agentName
@@ -487,6 +487,17 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 						}
 					: { kind: 'task_agent' }
 			);
+
+			// When the daemon queued the message for a not-yet-spawned agent,
+			// keep the draft and surface a user-visible signal so the message
+			// is never silently lost.
+			if (result?.delivered === false && !result?.queued) {
+				setThreadSendError(
+					'Agent is starting — your message could not be delivered. Try again in a moment.'
+				);
+				return false;
+			}
+
 			setTargetLocked(false);
 			setHasComposerDraft(false);
 			draftWasActiveRef.current = false;

--- a/packages/web/src/lib/__tests__/space-store.test.ts
+++ b/packages/web/src/lib/__tests__/space-store.test.ts
@@ -1691,4 +1691,81 @@ describe('SpaceStore — node execution LiveQuery subscriptions', () => {
 		);
 		expect(subscribeCalls).toHaveLength(1);
 	});
+	describe('sendTaskMessage', () => {
+		beforeEach(async () => {
+			await spaceStore.selectSpace('space-1');
+		});
+
+		it('returns daemon response for task_agent target', async () => {
+			mockHub.request.mockImplementation(async (method: string): Promise<any> => {
+				if (method === 'space.task.sendMessage') {
+					return { ok: true };
+				}
+				return {};
+			});
+
+			const result = await spaceStore.sendTaskMessage('task-1', 'Hello', {
+				kind: 'task_agent',
+			});
+
+			expect(result).toEqual({ ok: true });
+			expect(mockHub.request).toHaveBeenCalledWith(
+				'space.task.sendMessage',
+				expect.objectContaining({
+					taskId: 'task-1',
+					message: 'Hello',
+					target: { kind: 'task_agent' },
+				})
+			);
+		});
+
+		it('returns delivered:false when daemon queues for inactive agent', async () => {
+			mockHub.request.mockImplementation(async (method: string): Promise<any> => {
+				if (method === 'space.task.sendMessage') {
+					return {
+						ok: true,
+						routedTo: ['Reviewer'],
+						delivered: false,
+						queued: true,
+						activated: true,
+					};
+				}
+				return {};
+			});
+
+			const result = await spaceStore.sendTaskMessage('task-1', 'Please review', {
+				kind: 'node_agent',
+				agentName: 'Reviewer',
+			});
+
+			expect(result).toMatchObject({
+				ok: true,
+				routedTo: ['Reviewer'],
+				delivered: false,
+				queued: true,
+			});
+		});
+
+		it('returns delivered:false without queued when daemon has no queue', async () => {
+			mockHub.request.mockImplementation(async (method: string): Promise<any> => {
+				if (method === 'space.task.sendMessage') {
+					return {
+						ok: true,
+						routedTo: ['Reviewer'],
+						delivered: false,
+						activated: true,
+					};
+				}
+				return {};
+			});
+
+			const result = await spaceStore.sendTaskMessage('task-1', 'Orphaned', {
+				kind: 'node_agent',
+				agentName: 'Reviewer',
+			});
+
+			expect(result?.delivered).toBe(false);
+			expect((result as { queued?: boolean }).queued).toBeUndefined();
+		});
+	});
 });

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -1646,6 +1646,9 @@ class SpaceStore {
 
 	/**
 	 * Send a human message into a task's agent thread.
+	 *
+	 * Returns the daemon response so callers can inspect delivered /
+	 * queued / activated for non-delivery feedback.
 	 */
 	async sendTaskMessage(
 		taskId: string,
@@ -1653,14 +1656,20 @@ class SpaceStore {
 		target?:
 			| { kind: 'task_agent' }
 			| { kind: 'node_agent'; agentName: string; nodeExecutionId?: string }
-	): Promise<void> {
+	): Promise<{
+		ok: boolean;
+		routedTo?: string[];
+		delivered?: false;
+		activated?: true;
+		queued?: true;
+	}> {
 		const spaceId = this.spaceId.value;
 		if (!spaceId) throw new Error('No space selected');
 
 		const hub = connectionManager.getHubIfConnected();
 		if (!hub) throw new Error('Not connected');
 
-		await hub.request('space.task.sendMessage', {
+		return hub.request('space.task.sendMessage', {
 			taskId,
 			spaceId,
 			message,


### PR DESCRIPTION
Follow-up to PR #1660. Closes #143.

**P1 — Silent message drop fixed:** When targeting an inactive workflow agent, the user's message was silently lost. Now the message is persisted to the pending-message outbox (`PendingAgentMessageQueue`) and delivered when the session spawns. The web client inspects `delivered: false` and surfaces an error when the queue is unavailable.

**P2 — Matcher correctness:** `nodeExecutionId` now requires an exact match — no silent fallback to `agentName` when the execution ID doesn't exist. Agent-name-only fan-out still works when `nodeExecutionId` is absent.

**P3 — Type tightening:** `SpaceTaskMessageTarget` discriminated union now requires at least one of `agentName` / `nodeExecutionId` on `node_agent` targets.

**Tests:** 9 new daemon tests (matcher correctness, activation paths, error branches) + 3 new web tests (sendTaskMessage response propagation).