### PR TITLE
fix(space): queue messages for not-started workflow nodes

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -506,6 +506,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		sessionManager: deps.sessionManager,
 		daemonHub: deps.daemonHub,
 		artifactRepo,
+		pendingMessageRepo,
 	});
 
 	// Session handlers — registered here (after spaceRuntimeService is built) so

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -20,6 +20,7 @@ import { NodeExecutionRepository } from '../../../storage/repositories/node-exec
 import type { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
 import type { ChannelCycleRepository } from '../../../storage/repositories/channel-cycle-repository';
 import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
+import type { PendingAgentMessageRepository } from '../../../storage/repositories/pending-agent-message-repository';
 import type { ReactiveDatabase } from '../../../storage/reactive-database';
 import type { NotificationSink } from './notification-sink';
 import type { TaskAgentManager } from './task-agent-manager';
@@ -66,6 +67,11 @@ export interface SpaceRuntimeServiceConfig {
 	 * activation after gate data is written externally (e.g. human approval via RPC).
 	 */
 	gateDataRepo?: GateDataRepository;
+	/**
+	 * Optional pending message repository for queueing messages to not-yet-spawned
+	 * workflow node agents.
+	 */
+	pendingMessageRepo?: PendingAgentMessageRepository;
 	channelCycleRepo?: ChannelCycleRepository;
 	/**
 	 * Optional SessionManager for provisioning space:chat:${spaceId} sessions.
@@ -589,6 +595,7 @@ export class SpaceRuntimeService {
 			onGateChanged: (runId, gateId) => {
 				void this.notifyGateDataChanged(runId, gateId).catch(() => {});
 			},
+			pendingMessageQueue: this.config.pendingMessageRepo,
 			getSpaceAutonomyLevel: async (sid) => {
 				const s = await spaceManagerForApproval.getSpace(sid);
 				return s?.autonomyLevel ?? 1;
@@ -677,6 +684,7 @@ export class SpaceRuntimeService {
 			activateNode: async (runId, nodeId) => {
 				await this.activateWorkflowNode(runId, nodeId);
 			},
+			pendingMessageQueue: this.config.pendingMessageRepo,
 			getSpaceAutonomyLevel: async (sid) => {
 				const s = await spaceManagerForApproval.getSpace(sid);
 				return s?.autonomyLevel ?? 1;

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -719,6 +719,7 @@ export class TaskAgentManager {
 				onGateChanged: (runId, gateId) => {
 					void this.config.spaceRuntimeService.notifyGateDataChanged(runId, gateId).catch(() => {});
 				},
+				pendingMessageQueue: this.config.pendingMessageRepo,
 				getSpaceAutonomyLevel: async (sid) => {
 					const s = await this.config.spaceManager.getSpace(sid);
 					return s?.autonomyLevel ?? 1;
@@ -3012,6 +3013,7 @@ export class TaskAgentManager {
 			onGateChanged: (runId, gateId) => {
 				void this.config.spaceRuntimeService.notifyGateDataChanged(runId, gateId).catch(() => {});
 			},
+			pendingMessageQueue: this.config.pendingMessageRepo,
 			getSpaceAutonomyLevel: async (sid) => {
 				const s = await this.config.spaceManager.getSpace(sid);
 				return s?.autonomyLevel ?? 1;
@@ -3822,6 +3824,7 @@ export class TaskAgentManager {
 			onGateChanged: (runId, gateId) => {
 				void this.config.spaceRuntimeService.notifyGateDataChanged(runId, gateId).catch(() => {});
 			},
+			pendingMessageQueue: this.config.pendingMessageRepo,
 			getSpaceAutonomyLevel: async (sid) => {
 				const s = await this.config.spaceManager.getSpace(sid);
 				return s?.autonomyLevel ?? 1;

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -34,6 +34,7 @@ import type { SpaceTaskManager } from '../managers/space-task-manager';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
 import type { TaskAgentManager } from '../runtime/task-agent-manager';
 import type { DaemonHub } from '../../daemon-hub';
+import type { PendingAgentMessageQueue } from '../../rpc-handlers/space-task-message-handlers';
 import { jsonResult } from './tool-result';
 import type { ToolResult } from './tool-result';
 import { canTransition } from '../runtime/workflow-run-status-machine';
@@ -115,6 +116,11 @@ export interface SpaceAgentToolsConfig {
 	 */
 	activateNode?: (runId: string, nodeId: string) => Promise<void>;
 	/**
+	 * Pending message queue for messages addressed to workflow node agents that
+	 * have been activated but do not have a live session yet.
+	 */
+	pendingMessageQueue?: PendingAgentMessageQueue;
+	/**
 	 * Resolves the space's current autonomy level.
 	 * Required for approve_gate autonomy enforcement: agent approvals are rejected
 	 * when space autonomy < gate.requiredLevel (default 5 if gate has no requiredLevel).
@@ -168,6 +174,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		daemonHub,
 		onGateChanged,
 		activateNode,
+		pendingMessageQueue,
 		getSpaceAutonomyLevel,
 		myAgentName,
 		myAgentNameAliases,
@@ -647,8 +654,22 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 				}
 			}
 
-			// No live session yet — the tick loop will spawn one. Surface that state so
-			// the caller knows activation succeeded but delivery is deferred.
+			let queuedMessageId: string | null = null;
+			if (pendingMessageQueue) {
+				const { record } = pendingMessageQueue.enqueue({
+					workflowRunId: task.workflowRunId,
+					spaceId,
+					taskId: task.id,
+					sourceAgentName: myAgentName,
+					targetKind: 'node_agent',
+					targetAgentName: resolved.agentName,
+					message: args.message,
+				});
+				queuedMessageId = record.id;
+			}
+
+			// No live session yet — the tick loop will spawn one. When a queue is
+			// available, the queued row will be flushed into that session on activation.
 			return jsonResult({
 				success: true,
 				task_id: task.id,
@@ -657,9 +678,13 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 				agent_name: resolved.agentName,
 				activated: true,
 				delivered: false,
+				queued: queuedMessageId !== null,
+				...(queuedMessageId !== null ? { queuedMessageId } : {}),
 				message:
-					`Node "${resolved.agentName}" was activated but does not yet have a live session; ` +
-					`the message was not injected. Retry after the node starts.`,
+					queuedMessageId !== null
+						? `Node "${resolved.agentName}" was activated and the message was queued; it will be delivered once the session spawns.`
+						: `Node "${resolved.agentName}" was activated but does not yet have a live session; ` +
+							`the message was not queued because no pending message queue is configured. Retry after the node starts.`,
 			});
 		},
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -1577,10 +1577,31 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 		return created;
 	}
 
+	interface FakePendingMessageQueue {
+		enqueued: Array<{
+			workflowRunId: string;
+			spaceId: string;
+			taskId?: string | null;
+			sourceAgentName?: string;
+			targetKind: 'node_agent' | 'space_agent';
+			targetAgentName: string;
+			message: string;
+			idempotencyKey?: string | null;
+		}>;
+	}
+
+	function makeFakePendingMessageQueue(): FakePendingMessageQueue {
+		return { enqueued: [] };
+	}
+
 	function makeHandlersWith(
 		tam: FakeTaskAgentManager,
-		opts: { activateNode?: (runId: string, nodeId: string) => Promise<void> } = {}
+		opts: {
+			activateNode?: (runId: string, nodeId: string) => Promise<void>;
+			pendingMessageQueue?: FakePendingMessageQueue;
+		} = {}
 	) {
+		const fakeQueue = opts.pendingMessageQueue;
 		return createSpaceAgentToolHandlers({
 			spaceId: ctx.spaceId,
 			runtime: ctx.runtime,
@@ -1592,6 +1613,18 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 			nodeExecutionRepo: ctx.nodeExecutionRepo,
 			taskAgentManager: tam.manager,
 			activateNode: opts.activateNode,
+			pendingMessageQueue: fakeQueue
+				? {
+						enqueue(input) {
+							const index = fakeQueue.enqueued.length;
+							fakeQueue.enqueued.push(input);
+							return {
+								record: { id: `pending-message-${index}` },
+								deduped: false,
+							};
+						},
+					}
+				: undefined,
 		});
 	}
 
@@ -1880,8 +1913,58 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 		expect(parsed.success).toBe(true);
 		expect(parsed.activated).toBe(true);
 		expect(parsed.delivered).toBe(false);
+		expect(parsed.queued).toBe(false);
+		expect(parsed.queuedMessageId).toBeUndefined();
 		expect(parsed.node_execution_id).toBe(exec.id);
 		expect(tam.subSessionInjects).toHaveLength(0);
+	});
+
+	test('queues the message when activation creates no live session and a pending queue is configured', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'WF Queued');
+		const { run, tasks } = await ctx.runtime.startWorkflowRun(ctx.spaceId, wf.id, 'Queued');
+		const task = tasks[0];
+		const exec = ctx.nodeExecutionRepo.createOrIgnore({
+			workflowRunId: run.id,
+			workflowNodeId: wf.startNodeId,
+			agentName: 'reviewer',
+			status: 'pending',
+		});
+
+		const tam = makeFakeTaskAgentManager(ctx);
+		const fakeQueue = makeFakePendingMessageQueue();
+		const handlers = makeHandlersWith(tam, {
+			activateNode: async () => {
+				// Activation succeeded but the tick loop has not spawned the session yet.
+			},
+			pendingMessageQueue: fakeQueue,
+		});
+
+		const result = await handlers.send_message_to_task({
+			task_id: task.id,
+			node_id: 'reviewer',
+			message: 'please review this PR',
+		});
+		const parsed = JSON.parse(result.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		expect(parsed.activated).toBe(true);
+		expect(parsed.delivered).toBe(false);
+		expect(parsed.queued).toBe(true);
+		expect(parsed.queuedMessageId).toBe('pending-message-0');
+		expect(parsed.node_execution_id).toBe(exec.id);
+		expect(tam.subSessionInjects).toHaveLength(0);
+
+		expect(fakeQueue.enqueued).toEqual([
+			{
+				workflowRunId: run.id,
+				spaceId: ctx.spaceId,
+				taskId: task.id,
+				sourceAgentName: undefined,
+				targetKind: 'node_agent',
+				targetAgentName: 'reviewer',
+				message: 'please review this PR',
+			},
+		]);
 	});
 
 	test('returns an error when node_id does not match any execution', async () => {


### PR DESCRIPTION
Re-evaluated the old PR against current dev.

The PendingAgentOverlay replacement is already on dev via later work, so this refresh keeps only the still-needed daemon fix: send_message_to_task(node_id=...) now queues messages when a workflow node is activated but does not have a live session yet.

Verified with daemon space-agent-tools tests, the original web overlay test scope, format check, and bun run check.