### PR TITLE
Fix repeated overlay message highlight scroll

### DIFF
--- a/packages/web/src/hooks/__tests__/useScrollToMessage.test.ts
+++ b/packages/web/src/hooks/__tests__/useScrollToMessage.test.ts
@@ -7,7 +7,7 @@
  *   applies the amber highlight classes.
  * - No-ops when `messageId` is falsy or `isInitialLoad` is true.
  * - Cleanup on unmount removes the highlight and clears timers.
- * - Re-runs and re-anchors when `messageCount` changes (streaming).
+ * - Re-runs on `messageCount` changes until the target is found, then latches.
  */
 
 import { renderHook, act } from '@testing-library/preact';
@@ -18,14 +18,17 @@ const HIGHLIGHT_CLASS = 'ring-amber-400/70';
 
 function createTargetEl(id: string) {
 	const scrollIntoViewMock = vi.fn();
+	const classes = new Set<string>();
+	const addMock = vi.fn((...names: string[]) => {
+		for (const n of names) classes.add(n);
+	});
+	const removeMock = vi.fn((...names: string[]) => {
+		for (const n of names) classes.delete(n);
+	});
 	const classList = {
-		_set: new Set<string>(),
-		add(...names: string[]) {
-			for (const n of names) this._set.add(n);
-		},
-		remove(...names: string[]) {
-			for (const n of names) this._set.delete(n);
-		},
+		_set: classes,
+		add: addMock,
+		remove: removeMock,
 		contains(name: string) {
 			return this._set.has(name);
 		},
@@ -35,13 +38,14 @@ function createTargetEl(id: string) {
 		classList,
 		dataset: { messageId: id },
 	} as unknown as HTMLElement;
-	return { el, scrollIntoViewMock, classList };
+	return { el, scrollIntoViewMock, classList, addMock, removeMock };
 }
 
-function createContainer(target: HTMLElement | null) {
+function createContainer(target: HTMLElement | null | (() => HTMLElement | null)) {
+	const getTarget = typeof target === 'function' ? target : () => target;
 	const querySelector = vi.fn((sel: string) => {
 		// Pretend it found the element if the selector matches by id
-		return target;
+		return getTarget();
 	});
 	const container = {
 		querySelector,
@@ -228,9 +232,10 @@ describe('useScrollToMessage', () => {
 		expect(classList.contains(HIGHLIGHT_CLASS)).toBe(false);
 	});
 
-	it('re-runs when messageCount changes (streaming case)', () => {
+	it('re-runs on messageCount changes until a late-rendered target is found', () => {
 		const { el, scrollIntoViewMock } = createTargetEl('msg-1');
-		const { ref } = createContainer(el);
+		let target: HTMLElement | null = null;
+		const { ref } = createContainer(() => target);
 
 		const { rerender } = renderHook(
 			({ messageCount }) =>
@@ -243,13 +248,70 @@ describe('useScrollToMessage', () => {
 			{ initialProps: { messageCount: 3 } }
 		);
 
-		const callsAfterInitial = scrollIntoViewMock.mock.calls.length;
+		expect(scrollIntoViewMock).not.toHaveBeenCalled();
 
-		// New message streams in — hook should re-anchor in case the target was
-		// only just rendered.
+		// New message streams in and the previously missing target is now in the DOM.
+		target = el;
 		rerender({ messageCount: 4 });
 
-		expect(scrollIntoViewMock.mock.calls.length).toBeGreaterThan(callsAfterInitial);
+		expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'auto', block: 'center' });
+	});
+
+	it('does not re-anchor or re-highlight appended messages after a successful anchor', () => {
+		const { el, scrollIntoViewMock, classList, addMock } = createTargetEl('msg-1');
+		const { ref } = createContainer(el);
+
+		const { rerender } = renderHook(
+			({ messageCount }) =>
+				useScrollToMessage({
+					containerRef: ref,
+					messageId: 'msg-1',
+					messageCount,
+					isInitialLoad: false,
+					highlightDurationMs: 5000,
+				}),
+			{ initialProps: { messageCount: 3 } }
+		);
+
+		expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+		expect(classList.contains(HIGHLIGHT_CLASS)).toBe(true);
+
+		act(() => {
+			vi.advanceTimersByTime(5001);
+		});
+		expect(classList.contains(HIGHLIGHT_CLASS)).toBe(false);
+
+		const scrollCallsAfterFade = scrollIntoViewMock.mock.calls.length;
+		const highlightCallsAfterFade = addMock.mock.calls.length;
+
+		rerender({ messageCount: 4 });
+
+		expect(scrollIntoViewMock).toHaveBeenCalledTimes(scrollCallsAfterFade);
+		expect(addMock).toHaveBeenCalledTimes(highlightCallsAfterFade);
+		expect(classList.contains(HIGHLIGHT_CLASS)).toBe(false);
+	});
+
+	it('calls onAnchored once when the target is first found', () => {
+		const { el } = createTargetEl('msg-1');
+		const onAnchored = vi.fn();
+		const { ref } = createContainer(el);
+
+		const { rerender } = renderHook(
+			({ messageCount }) =>
+				useScrollToMessage({
+					containerRef: ref,
+					messageId: 'msg-1',
+					messageCount,
+					isInitialLoad: false,
+					onAnchored,
+				}),
+			{ initialProps: { messageCount: 3 } }
+		);
+
+		rerender({ messageCount: 4 });
+
+		expect(onAnchored).toHaveBeenCalledTimes(1);
+		expect(onAnchored).toHaveBeenCalledWith('msg-1');
 	});
 
 	it('does not throw when target is missing from the DOM', () => {

--- a/packages/web/src/hooks/useScrollToMessage.ts
+++ b/packages/web/src/hooks/useScrollToMessage.ts
@@ -9,9 +9,9 @@
  *   2. Applies a temporary amber ring so the user can spot it.
  *   3. Re-anchors a couple of times during a short settling window to handle
  *      late-arriving layout (lazy-loaded rows, image/font loads, etc.).
- *   4. Re-runs whenever `messageCount` changes, so streamed messages can
- *      still be located if the target row is appended after the deep link
- *      was set.
+ *   4. Re-runs whenever `messageCount` changes until the first successful
+ *      anchor, so streamed messages can still be located if the target row is
+ *      appended after the deep link was set.
  *
  * Robustness considerations:
  *
@@ -38,7 +38,7 @@
  */
 
 import type { RefObject } from 'preact';
-import { useEffect } from 'preact/hooks';
+import { useEffect, useRef } from 'preact/hooks';
 
 export interface UseScrollToMessageOptions {
 	/** Ref to the scrollable container element. */
@@ -70,6 +70,12 @@ export interface UseScrollToMessageOptions {
 	 * 250ms. Kept short so the user can scroll freely after that.
 	 */
 	settleWindowMs?: number;
+	/**
+	 * Called once after the target message is first found and anchored.
+	 * Useful for clearing deep-link state while allowing the highlight timer
+	 * owned by this hook to finish normally.
+	 */
+	onAnchored?: (messageId: string) => void;
 }
 
 const HIGHLIGHT_CLASSES = [
@@ -92,31 +98,101 @@ export function useScrollToMessage({
 	isInitialLoad = false,
 	highlightDurationMs = DEFAULT_HIGHLIGHT_DURATION_MS,
 	settleWindowMs = DEFAULT_SETTLE_WINDOW_MS,
+	onAnchored,
 }: UseScrollToMessageOptions): void {
+	const activeMessageIdRef = useRef<string | null>(null);
+	const anchoredMessageIdRef = useRef<string | null>(null);
+	const highlightedElRef = useRef<HTMLElement | null>(null);
+	const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const settleTimersRef = useRef<Array<ReturnType<typeof setTimeout>>>([]);
+	const runIdRef = useRef(0);
+	const onAnchoredRef = useRef(onAnchored);
+
 	useEffect(() => {
-		if (!messageId) return;
+		onAnchoredRef.current = onAnchored;
+	}, [onAnchored]);
+
+	const clearSettleTimers = () => {
+		for (const id of settleTimersRef.current) clearTimeout(id);
+		settleTimersRef.current = [];
+	};
+
+	const clearFadeTimer = () => {
+		if (fadeTimerRef.current) {
+			clearTimeout(fadeTimerRef.current);
+			fadeTimerRef.current = null;
+		}
+	};
+
+	const clearHighlight = () => {
+		if (highlightedElRef.current) {
+			highlightedElRef.current.classList.remove(...HIGHLIGHT_CLASSES);
+			highlightedElRef.current = null;
+		}
+	};
+
+	useEffect(() => {
+		return () => {
+			runIdRef.current += 1;
+			clearSettleTimers();
+			clearFadeTimer();
+			clearHighlight();
+			activeMessageIdRef.current = null;
+			anchoredMessageIdRef.current = null;
+		};
+	}, []);
+
+	useEffect(() => {
+		if (!messageId) {
+			if (!anchoredMessageIdRef.current) {
+				runIdRef.current += 1;
+				clearSettleTimers();
+				activeMessageIdRef.current = null;
+			}
+			return;
+		}
+
+		if (activeMessageIdRef.current !== messageId) {
+			runIdRef.current += 1;
+			clearSettleTimers();
+			clearFadeTimer();
+			clearHighlight();
+			activeMessageIdRef.current = messageId;
+			anchoredMessageIdRef.current = null;
+		}
+
 		if (isInitialLoad) return;
+		if (anchoredMessageIdRef.current === messageId) return;
 
 		const container = containerRef.current;
 		if (!container) return;
 
-		let cancelled = false;
-		let highlightedEl: HTMLElement | null = null;
-		const settleTimers: Array<ReturnType<typeof setTimeout>> = [];
+		const runId = runIdRef.current + 1;
+		runIdRef.current = runId;
+		clearSettleTimers();
 
 		const findTarget = (): HTMLElement | null =>
 			container.querySelector<HTMLElement>(`[data-message-id="${CSS.escape(messageId)}"]`);
 
 		const anchor = (): HTMLElement | null => {
-			if (cancelled) return null;
+			if (runIdRef.current !== runId) return null;
 			const target = findTarget();
 			if (!target) return null;
 			// Instant scroll — deterministic, can't be cancelled mid-animation.
 			target.scrollIntoView({ behavior: 'auto', block: 'center' });
-			if (highlightedEl !== target) {
-				if (highlightedEl) highlightedEl.classList.remove(...HIGHLIGHT_CLASSES);
+			if (highlightedElRef.current !== target) {
+				clearHighlight();
 				target.classList.add(...HIGHLIGHT_CLASSES);
-				highlightedEl = target;
+				highlightedElRef.current = target;
+			}
+			if (anchoredMessageIdRef.current !== messageId) {
+				anchoredMessageIdRef.current = messageId;
+				clearFadeTimer();
+				fadeTimerRef.current = setTimeout(() => {
+					clearHighlight();
+					fadeTimerRef.current = null;
+				}, highlightDurationMs);
+				onAnchoredRef.current?.(messageId);
 			}
 			return target;
 		};
@@ -131,30 +207,11 @@ export function useScrollToMessage({
 			const delays = [16, 64, settleWindowMs]; // ~next frame, mid-settle, end-of-settle
 			for (const delay of delays) {
 				const id = setTimeout(() => {
-					if (cancelled) return;
 					anchor();
 				}, delay);
-				settleTimers.push(id);
+				settleTimersRef.current.push(id);
 			}
 		};
 		scheduleSettleRetries();
-
-		// Drop the highlight ring after the configured duration.
-		const fadeTimer = setTimeout(() => {
-			if (highlightedEl) {
-				highlightedEl.classList.remove(...HIGHLIGHT_CLASSES);
-				highlightedEl = null;
-			}
-		}, highlightDurationMs);
-
-		return () => {
-			cancelled = true;
-			for (const id of settleTimers) clearTimeout(id);
-			clearTimeout(fadeTimer);
-			if (highlightedEl) {
-				highlightedEl.classList.remove(...HIGHLIGHT_CLASSES);
-				highlightedEl = null;
-			}
-		};
 	}, [messageId, isInitialLoad, messageCount, highlightDurationMs, settleWindowMs, containerRef]);
 }

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -63,7 +63,11 @@ import { connectionManager } from '../lib/connection-manager';
 import { borderColors } from '../lib/design-tokens';
 import { MIN_MESSAGES_BOTTOM_PADDING_PX } from '../lib/layout-metrics.ts';
 import { lobbyStore } from '../lib/lobby-store.ts';
-import { navigateToSettings, replaceOverlayHistory } from '../lib/router.ts';
+import {
+	clearOverlayHighlightMessageId,
+	navigateToSettings,
+	replaceOverlayHistory,
+} from '../lib/router.ts';
 import { sessionStore } from '../lib/session-store.ts';
 import { settingsSectionSignal } from '../lib/signals.ts';
 import { spaceStore } from '../lib/space-store.ts';
@@ -730,8 +734,8 @@ export default function ChatContainer({
 		containerRef: messagesContainerRef,
 		endRef: messagesEndRef,
 		// Disable tail-following auto-scroll while the caller is asking us to
-		// scroll a specific message into view — otherwise late-arriving rows
-		// would yank the viewport away from the highlighted target.
+		// scroll a specific message into view. The highlight id is cleared once
+		// that anchor succeeds, so normal tail-following resumes for new rows.
 		enabled: autoScroll && !highlightMessageId,
 		messageCount: messages.length,
 		isInitialLoad,
@@ -751,6 +755,7 @@ export default function ChatContainer({
 		messageId: highlightMessageId,
 		messageCount: messages.length,
 		isInitialLoad,
+		onAnchored: clearOverlayHighlightMessageId,
 	});
 
 	// ========================================

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -2228,6 +2228,13 @@ export function replaceOverlayHistory(
 }
 
 /**
+ * Clear the one-shot overlay message highlight after the target row anchors.
+ */
+export function clearOverlayHighlightMessageId(): void {
+	spaceOverlayHighlightMessageIdSignal.value = null;
+}
+
+/**
  * Close the overlay and go back in history to the pre-overlay entry.
  */
 export function closeOverlayHistory(): void {


### PR DESCRIPTION
Fixes the agent overlay deep-link highlight so it latches after the target message is first anchored. Late-rendered targets still retry until found, and the overlay clears its highlight id after anchoring so new messages do not scroll back to the old row.

Verified:
- bun --cwd packages/web test src/hooks/__tests__/useScrollToMessage.test.ts
- bun --cwd packages/web test
- bun run check
- bun run format:check