### PR TITLE
chore(release): bump version to 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to NeoKai will be documented in this file.
 
+## [0.15.0] - 2026-04-27
+
+A stability release fixing session persistence, message routing, and provider bridge issues. 15 commits since v0.14.0.
+
+### Fixed
+
+- **Session persistence**: `AskUserQuestion` survives daemon restart; dead sessions cleaned up; in-process MCP servers preserved across runtime mutations
+- **Message routing**: Guard sub-session MCP servers; prevent silent message drop; tighten matcher in task-composer target picker
+- **Workflow execution**: Lazy-activate stranded executions; clickable not-started entries; skip redundant merge approval when human already approved
+- **Provider bridges**: Fix Codex model routing + stub endpoints; normalize usage on BetaMessages to prevent SDK crash; fix usage.input_tokens crash on bridge providers; upgrade copilot-sdk; fix copilot early error handling
+- **Space sessions**: Drop bogus sessionId filter from session.created/deleted subs; unify Active-tab filter between sidebar and tasks view
+
 ## [0.14.0] - 2026-04-24
 
 A release introducing the Tauri desktop wrapper, server-derived active-turn tracking, and workflow definition improvements. 10 commits since v0.13.0.

--- a/npm/neokai/package.json
+++ b/npm/neokai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neokai",
-	"version": "0.14.0",
+	"version": "0.15.0",
 	"description": "NeoKai - Claude Agent SDK Web Interface",
 	"bin": {
 		"kai": "bin/kai.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/cli",
-	"version": "0.14.0",
+	"version": "0.15.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"bin": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/daemon",
-	"version": "0.14.0",
+	"version": "0.15.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "main.ts",

--- a/packages/daemon/src/lib/providers/anthropic-copilot/conversation.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/conversation.ts
@@ -24,7 +24,7 @@
  * contamination when a NeoKai chat session makes many independent calls).
  */
 
-import type { CopilotClient, CopilotSession } from '@github/copilot-sdk';
+import { approveAll, type CopilotClient, type CopilotSession } from '@github/copilot-sdk';
 import type { AnthropicMessage, AnthropicTool } from './types.js';
 import {
 	extractToolResultIds,
@@ -168,7 +168,7 @@ export class ConversationManager {
 			...(systemMessage
 				? { systemMessage: { mode: 'replace' as const, content: systemMessage } }
 				: {}),
-			onPermissionRequest: () => Promise.resolve({ kind: 'approve-once' as const }),
+			onPermissionRequest: approveAll,
 			onUserInputRequest: () =>
 				Promise.resolve({ answer: 'User input is not available in API mode.', wasFreeform: true }),
 			hooks: {

--- a/packages/daemon/src/lib/providers/anthropic-copilot/server.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/server.ts
@@ -32,7 +32,7 @@
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { isAbsolute, normalize } from 'node:path';
-import type { CopilotClient, SessionConfig } from '@github/copilot-sdk';
+import { approveAll, type CopilotClient, type SessionConfig } from '@github/copilot-sdk';
 import { isAnthropicRequest, type AnthropicRequest } from './types.js';
 import { formatAnthropicPrompt, extractSystemText, extractToolResultIds } from './prompt.js';
 import { ConversationManager } from './conversation.js';
@@ -129,7 +129,7 @@ function buildPlainSessionConfig(
 		...(systemMessage
 			? { systemMessage: { mode: 'replace' as const, content: systemMessage } }
 			: {}),
-		onPermissionRequest: () => Promise.resolve({ kind: 'approve-once' as const }),
+		onPermissionRequest: approveAll,
 		onUserInputRequest: () =>
 			Promise.resolve({
 				answer: 'User input is not available. Ask your question in your response instead.',

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/e2e",
-	"version": "0.14.0",
+	"version": "0.15.0",
 	"private": true,
 	"license": "Apache-2.0",
 	"type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/shared",
-	"version": "0.14.0",
+	"version": "0.15.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "src/mod.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/ui",
-	"version": "0.14.0",
+	"version": "0.15.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"main": "src/mod.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neokai/web",
-	"version": "0.14.0",
+	"version": "0.15.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"scripts": {


### PR DESCRIPTION
Session persistence, message routing, and copilot-sdk type fix.