### PR TITLE
[codex] fix post-approval workflow prompts

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
@@ -104,8 +104,10 @@ function buildTemplateUpdateParams(
 		channels: newChannels,
 		gates: newGates,
 		tags: [...template.tags],
+		completionAutonomyLevel: template.completionAutonomyLevel,
 		templateName: template.name,
 		templateHash,
+		postApproval: template.postApproval ? { ...template.postApproval } : null,
 	};
 }
 
@@ -331,6 +333,7 @@ export function setupSpaceWorkflowHandlers(
 			channels: workflow.channels ? [...workflow.channels] : undefined,
 			gates: workflow.gates ? [...workflow.gates] : undefined,
 			tags: [...workflow.tags],
+			postApproval: workflow.postApproval ? { ...workflow.postApproval } : undefined,
 		}));
 		return { workflows };
 	});

--- a/packages/daemon/src/lib/space/agents/task-agent.ts
+++ b/packages/daemon/src/lib/space/agents/task-agent.ts
@@ -298,8 +298,8 @@ export function buildTaskAgentSystemPrompt(context: TaskAgentContext): string {
 			`error. If you want to move an approved task to done, call \`mark_complete\`.\n` +
 			`- \`[POST_APPROVAL_INSTRUCTIONS]\` arrive as a user-turn message. Treat them as authoritative ` +
 			`work to execute; do not ask for human approval before starting.\n` +
-			`- If the post-approval work fails, call \`submit_for_approval\` (or surface the error via ` +
-			`\`request_human_input\`) rather than swallowing it.`
+			`- If the post-approval work fails or needs a human decision, surface the issue with ` +
+			`\`request_human_input\` rather than swallowing it.`
 	);
 
 	// ---- Behavioral rules ---------------------------------------------------

--- a/packages/daemon/src/lib/space/runtime/post-approval-router.ts
+++ b/packages/daemon/src/lib/space/runtime/post-approval-router.ts
@@ -221,6 +221,17 @@ export type PostApprovalRouteResult =
 // Event shapes (§2.3)
 // ---------------------------------------------------------------------------
 
+const POST_APPROVAL_COMPLETION_INSTRUCTIONS =
+	`When the post-approval work is finished, call mark_complete to transition the\n` +
+	`task from \`approved\` to \`done\`. If you need human input mid-work, call\n` +
+	`request_human_input as usual.\n\n` +
+	`Do NOT call approve_task; the task has already been approved upstream.`;
+
+export function appendPostApprovalCompletionInstructions(interpolatedInstructions: string): string {
+	const trimmed = interpolatedInstructions.trim();
+	return `${trimmed}\n\n${POST_APPROVAL_COMPLETION_INSTRUCTIONS}`;
+}
+
 /**
  * Build the `[TASK_APPROVED]` awareness event body. Emitted on both the
  * end-node and human-review paths, regardless of which mode the router
@@ -259,10 +270,7 @@ export function buildPostApprovalInstructionsEvent(args: {
 }): string {
 	return (
 		`[POST_APPROVAL_INSTRUCTIONS] Task ${args.task.id} post-approval work begins now.\n\n` +
-		`${args.interpolatedInstructions}\n\n` +
-		`When you finish (or need to abort), call mark_complete to transition the\n` +
-		`task from \`approved\` to \`done\`. If you need human input mid-work, call\n` +
-		`request_human_input as usual.`
+		appendPostApprovalCompletionInstructions(args.interpolatedInstructions)
 	);
 }
 
@@ -375,12 +383,13 @@ export class PostApprovalRouter {
 			}
 		}
 
-		// Interpolate the kickoff from the workflow template.
-		const { text: kickoffMessage, missingKeys } = interpolatePostApprovalTemplate(
+		// Interpolate the workflow-specific kickoff, then append the runtime-owned
+		// completion instruction shared by every post-approval route.
+		const { text: interpolatedInstructions, missingKeys } = interpolatePostApprovalTemplate(
 			instructions ?? '',
 			context
 		);
-		if (!kickoffMessage.trim()) {
+		if (!interpolatedInstructions.trim()) {
 			const reason = `task ${task.id}: node-agent post-approval has empty instructions template`;
 			log.warn(`PostApprovalRouter.route: ${reason}`);
 			return { mode: 'skipped', reason };
@@ -395,6 +404,7 @@ export class PostApprovalRouter {
 			log.warn(`PostApprovalRouter.route: ${reason}`);
 			return { mode: 'skipped', reason };
 		}
+		const kickoffMessage = appendPostApprovalCompletionInstructions(interpolatedInstructions);
 
 		const startedAt = Date.now();
 		const { sessionId } = await this.deps.spawner.spawnPostApprovalSubSession({

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -1138,9 +1138,8 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
 	updatedAt: 0,
 	// QA no longer merges the PR — the post-approval reviewer session does that.
 	// Aligned with Coding's autonomy tier (3) since QA-approve is now a plain
-	// "work is good" signal, orthogonal to auto-merge. Auto-merge remains an
-	// autonomy-gated decision enforced by the merge-template's `autonomy_level`
-	// conditional at the post-approval session layer.
+	// "work is good" signal. Post-approval runs only after that approval has
+	// already happened.
 	completionAutonomyLevel: 3,
 	// Post-approval routing (PR 3/5): after QA approves, spawn a fresh
 	// `reviewer` session that runs the PR merge + worktree sync.

--- a/packages/daemon/src/lib/space/workflows/post-approval-merge-template.ts
+++ b/packages/daemon/src/lib/space/workflows/post-approval-merge-template.ts
@@ -14,13 +14,10 @@
  *
  *   - `{{pr_url}}`          — signalled by the end node via
  *                             `send_message(task-agent, …, data:{ pr_url })`.
- *   - `{{autonomy_level}}`  — space autonomy level at routing time.
  *   - `{{approval_source}}` — `'human' | 'agent'` (from
  *                             `SpaceApprovalSource`; `auto_policy` is
  *                             theoretically possible but no caller produces
- *                             it for post-approval). Step 2 uses this to
- *                             skip redundant merge approval when human
- *                             already approved.
+ *                             it for post-approval).
  * NOTE: The `{{reviewer_name}}` token was intentionally replaced with the
  * static string `[end-node reviewer]` in PR 3/5 because nothing in
  * `dispatchPostApproval` currently resolves the approving agent's slot name
@@ -37,16 +34,12 @@
  * `post_approval_action` discriminator was removed — post-approval routing is
  * declarative on the workflow's `postApproval` field, not signalled at runtime.
  *
- * Step 6 MUST instruct the post-approval session to call `mark_complete` (not
- * `approve_task`); this is the hard distinction between the
- * `in_progress → approved` and `approved → done` transitions — see §3.2 of the
- * plan and the `mark_complete` tool docstring in
- * `packages/daemon/src/lib/space/tools/task-agent-tools.ts`.
+ * The runtime appends the universal `mark_complete` instruction in
+ * `PostApprovalRouter`; keep this workflow data focused on PR-specific work.
  */
 export const PR_MERGE_POST_APPROVAL_INSTRUCTIONS: string = [
 	'The task has been approved. Your job is to merge PR {{pr_url}}.',
 	'',
-	'Space autonomy level: {{autonomy_level}} (threshold for auto-merge: 4).',
 	// TODO(PR 4/5 or 5/5): resolve the approving agent's slot name and replace
 	// this static label with `{{reviewer_name}}`. See file-level NOTE.
 	'Reviewer: [end-node reviewer].',
@@ -56,22 +49,13 @@ export const PR_MERGE_POST_APPROVAL_INSTRUCTIONS: string = [
 	'1. Verify the PR is still open and passes CI:',
 	'     gh pr view {{pr_url}} --json state,mergeStateStatus,statusCheckRollup',
 	'   If state is MERGED, record an audit artifact and exit — the work is done.',
-	'2. If approval_source != "human" AND autonomy_level < 4:',
-	'     Call request_human_input with',
-	'       question: "Approve merging PR {{pr_url}}?"',
-	'       context: "Reviewer: [end-node reviewer]. CI: <from step 1>."',
-	'     Wait for the response before proceeding.',
-	'3. Merge:',
+	'2. Merge:',
 	'     gh pr merge {{pr_url}} --squash --delete-branch',
 	'   On a merge conflict, do NOT force — exit, call request_human_input with',
 	'   a clear summary of the conflict, and let the human resolve.',
-	'4. Sync your worktree with main/dev:',
+	'3. Sync your worktree with main/dev:',
 	'     git fetch origin && git checkout dev && git pull --ff-only',
-	'5. Save an audit artifact:',
+	'4. Save an audit artifact:',
 	'     save_artifact({ type: "result", append: true,',
-	'                     data: { merged_pr_url, mergedAt, approval: "auto"|"human" } })',
-	'6. Call mark_complete() to signal post-approval finished',
-	'   (transitions the task from `approved` to `done`).',
-	'   DO NOT call approve_task — that\'s for the initial "work is good"',
-	'   transition (in_progress → approved), which already happened upstream.',
+	'                     data: { merged_pr_url, mergedAt, approval_source: "{{approval_source}}" } })',
 ].join('\n');

--- a/packages/daemon/tests/unit/5-space/runtime/post-approval-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/post-approval-router.test.ts
@@ -252,6 +252,8 @@ describe('PostApprovalRouter.route', () => {
 		expect(delegates.spawned).toHaveLength(1);
 		expect(delegates.spawned[0].targetAgent).toBe('deployer');
 		expect(delegates.spawned[0].kickoffMessage).toContain(task.title ?? '');
+		expect(delegates.spawned[0].kickoffMessage).toContain('mark_complete');
+		expect(delegates.spawned[0].kickoffMessage).toContain('Do NOT call approve_task');
 		expect(delegates.injected).toHaveLength(0);
 
 		const final = taskRepo.getTask(task.id);

--- a/packages/daemon/tests/unit/5-space/runtime/post-approval-routing-integration.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/post-approval-routing-integration.test.ts
@@ -340,14 +340,9 @@ describe('PR 3/5 integration — dispatchPostApproval → spawn → mark_complet
 		expect(h.spawned[0].targetAgent).toBe('reviewer');
 		expect(h.spawned[0].kickoffMessage).toContain(PR_URL);
 		expect(h.spawned[0].kickoffMessage).not.toContain('{{pr_url}}');
-		// All other merge-template tokens MUST also interpolate — historically
-		// the routeContext carried camelCase keys that didn't match the
-		// snake_case template tokens, so `{{autonomy_level}}` /
-		// `{{approval_source}}` survived as literals and the autonomy-gate
-		// step ("If autonomy_level < 4 …") was unenforceable. The fix adds
-		// explicit snake_case aliases to `routeContext`; these assertions
-		// turn the previous "kickoff referenced unknown keys" warning into a
-		// hard test failure on regression.
+		// All merge-template tokens MUST interpolate — historically the
+		// routeContext carried camelCase keys that didn't match the snake_case
+		// template tokens, so placeholders survived all the way to kickoff.
 		expect(h.spawned[0].kickoffMessage).not.toContain('{{autonomy_level}}');
 		expect(h.spawned[0].kickoffMessage).not.toContain('{{approval_source}}');
 		// `{{reviewer_name}}` was collapsed to the static label
@@ -355,10 +350,8 @@ describe('PR 3/5 integration — dispatchPostApproval → spawn → mark_complet
 		// populates routeContext.reviewer_name yet.
 		expect(h.spawned[0].kickoffMessage).not.toContain('{{reviewer_name}}');
 		expect(h.spawned[0].kickoffMessage).toContain('[end-node reviewer]');
-		// Value spot-checks — 4 is seeded by makeDb() so the auto-merge-gate
-		// header reads as a real comparison the LLM can evaluate.
-		expect(h.spawned[0].kickoffMessage).toContain('Space autonomy level: 4');
 		expect(h.spawned[0].kickoffMessage).toContain('Approval source: agent');
+		expect(h.spawned[0].kickoffMessage).toContain('mark_complete');
 
 		// dispatchPostApproval stamped the session on the task.
 		const mid = h.taskRepo.getTask(taskId)!;

--- a/packages/daemon/tests/unit/5-space/workflow/end-node-handoff.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/end-node-handoff.test.ts
@@ -90,8 +90,8 @@ describe('End-node post-approval declarations', () => {
 		test(`${label} declares postApproval targeting the reviewer role`, () => {
 			expect(wf.postApproval).toBeDefined();
 			expect(wf.postApproval!.targetAgent).toBe('reviewer');
-			// Uses the canonical shared merge template — not a bespoke string.
-			// Any edit to the template reaches all three workflows atomically.
+			// Uses the workflow-level merge prompt. The runtime appends the
+			// shared mark_complete instruction separately.
 			expect(wf.postApproval!.instructions).toBe(PR_MERGE_POST_APPROVAL_INSTRUCTIONS);
 		});
 
@@ -271,31 +271,22 @@ describe('Shared merge template canonical content', () => {
 		// sub-session. A follow-up PR will thread the approving agent's slot
 		// name through and restore the token.
 		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).toContain('{{pr_url}}');
-		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).toContain('{{autonomy_level}}');
 		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).toContain('{{approval_source}}');
+		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).not.toContain('{{autonomy_level}}');
 		// Locked: `{{reviewer_name}}` must NOT appear — swap to static label.
 		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).not.toContain('{{reviewer_name}}');
 		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).toContain('[end-node reviewer]');
 	});
 
-	test('template instructs mark_complete (NOT approve_task) for the final step', () => {
-		// Post-approval closes the `approved → done` transition via
-		// `mark_complete`. Using `approve_task` here would be a double-fire
-		// and the MCP tool rejects it anyway, but the prompt must use the
-		// correct verb so the session calls the right tool.
-		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).toContain('mark_complete()');
-		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).toContain('DO NOT call approve_task');
+	test('merge template does not include the runtime-owned completion step', () => {
+		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).not.toContain('mark_complete');
+		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).not.toContain('approve_task');
 	});
 
-	test('template gates auto-merge behind approval_source != "human" AND autonomy_level < 4', () => {
-		// Section 2 of the template body is the human-approval fallback for
-		// non-human approvals (auto_policy, agent) at autonomy < 4. When
-		// approval_source is "human", step 2 is skipped to avoid redundant
-		// double-approval. Uses != to cover both SpaceApprovalSource
-		// variants ("auto_policy" and "agent").
-		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).toContain('approval_source != "human"');
-		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).toContain('autonomy_level < 4');
-		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).toContain('request_human_input');
+	test('merge template does not ask for redundant approval after task approval', () => {
+		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).not.toContain('Approve merging PR');
+		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).not.toContain('approval_source != "human"');
+		expect(PR_MERGE_POST_APPROVAL_INSTRUCTIONS).not.toContain('autonomy_level < 4');
 	});
 
 	test('template contains the squash-merge command and conflict guard', () => {

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -1112,8 +1112,9 @@ export interface WorkflowNodeInput {
  * signal to a downstream executor that continues work **after** the task is
  * approved (e.g. merging a PR, publishing a release, running a verification
  * script). The route is declarative and lives on the workflow definition; the
- * runtime routes the structured signal to `targetAgent` with an `instructions`
- * string that supports `{{identifier}}` template interpolation.
+ * runtime routes the structured signal to `targetAgent` with a workflow-specific
+ * `instructions` string that supports `{{identifier}}` template interpolation.
+ * The runtime appends the universal `mark_complete` instruction separately.
  *
  * Added in PR 1 of the task-agent-as-post-approval-executor refactor. No
  * runtime consumer reads this field yet — PR 2 wires the
@@ -1134,10 +1135,12 @@ export interface PostApprovalRoute {
 	 */
 	targetAgent: string;
 	/**
-	 * Instruction template delivered to `targetAgent` when the end node signals
-	 * approval. Supports `{{identifier}}` single-pass substitution against the
-	 * runtime context assembled by the PostApprovalRouter. See
-	 * `post-approval-template.ts` for the template grammar.
+	 * Workflow-specific instruction template delivered to `targetAgent` when the
+	 * end node signals approval. Supports `{{identifier}}` single-pass substitution
+	 * against the runtime context assembled by the PostApprovalRouter. See
+	 * `post-approval-template.ts` for the template grammar. Do not include the
+	 * final `mark_complete` instruction here; the runtime appends that for every
+	 * post-approval route.
 	 */
 	instructions: string;
 }
@@ -1229,9 +1232,8 @@ export interface SpaceWorkflow {
 	templateHash?: string;
 	/**
 	 * Optional post-approval route — describes which agent should act on the
-	 * end-node's approval signal, with an instruction template. See
-	 * {@link PostApprovalRoute}. Added in PR 1 of the post-approval refactor;
-	 * no runtime consumer yet (PR 2 wires it up).
+	 * end-node's approval signal, with a workflow-specific instruction template.
+	 * See {@link PostApprovalRoute}.
 	 */
 	postApproval?: PostApprovalRoute;
 }
@@ -1287,7 +1289,6 @@ export interface CreateSpaceWorkflowParams {
 	templateHash?: string;
 	/**
 	 * Optional post-approval route. See {@link PostApprovalRoute}.
-	 * Schema only in PR 1 of the post-approval refactor; no runtime consumer yet.
 	 */
 	postApproval?: PostApprovalRoute;
 }
@@ -1343,7 +1344,6 @@ export interface UpdateSpaceWorkflowParams {
 	templateHash?: string | null;
 	/**
 	 * Update the workflow's post-approval route. Pass `null` to clear.
-	 * Schema only in PR 1 of the post-approval refactor; no runtime consumer yet.
 	 */
 	postApproval?: PostApprovalRoute | null;
 }

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -27,6 +27,7 @@ import type {
 	WorkflowChannel,
 	Gate,
 	SpaceAutonomyLevel,
+	PostApprovalRoute,
 } from '@neokai/shared';
 import { generateUUID, TASK_AGENT_NODE_ID, isChannelCyclic } from '@neokai/shared';
 import { spaceStore } from '../../../lib/space-store';
@@ -69,7 +70,8 @@ function buildTemplateCanvasSignature(
 	channels: WorkflowChannel[],
 	startNodeId: string,
 	gates: Gate[],
-	endNodeId: string | undefined
+	endNodeId: string | undefined,
+	postApproval: PostApprovalRoute | undefined
 ): string {
 	const regularNodes = nodes
 		.filter(
@@ -134,7 +136,20 @@ function buildTemplateCanvasSignature(
 		startNodeId,
 		endNodeId,
 		gates: normalizedGates,
+		postApproval: postApproval ? { ...postApproval } : null,
 	});
+}
+
+function getPostApprovalTargetOptions(nodes: VisualNode[]): string[] {
+	const targets = new Set<string>(['task-agent']);
+	for (const node of nodes) {
+		if (node.step.id === TASK_AGENT_NODE_ID || node.step.localId === TASK_AGENT_NODE_ID) continue;
+		for (const agent of node.step.agents ?? []) {
+			const name = agent.name?.trim();
+			if (name) targets.add(name);
+		}
+	}
+	return Array.from(targets);
 }
 
 function resolveChannelTargetNodeIds(
@@ -235,6 +250,9 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 				workflow?.completionAutonomyLevel ??
 				3) as SpaceAutonomyLevel
 	);
+	const [postApproval, setPostApproval] = useState<PostApprovalRoute | undefined>(() =>
+		initState?.postApproval ? { ...initState.postApproval } : undefined
+	);
 	const [viewportState, setViewportState] = useState<ViewportState>({
 		offsetX: 0,
 		offsetY: 0,
@@ -271,9 +289,26 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			),
 		[nodes]
 	);
+	const postApprovalTargetOptions = useMemo(() => {
+		const options = getPostApprovalTargetOptions(nodes);
+		const currentTarget = postApproval?.targetAgent?.trim();
+		if (currentTarget && !options.includes(currentTarget)) {
+			options.push(currentTarget);
+		}
+		return options;
+	}, [nodes, postApproval?.targetAgent]);
 	const currentTemplateCanvasSignature = useMemo(
-		() => buildTemplateCanvasSignature(nodes, edges, channels, startNodeId, gates, endNodeId),
-		[nodes, edges, channels, startNodeId, gates, endNodeId]
+		() =>
+			buildTemplateCanvasSignature(
+				nodes,
+				edges,
+				channels,
+				startNodeId,
+				gates,
+				endNodeId,
+				postApproval
+			),
+		[nodes, edges, channels, startNodeId, gates, endNodeId, postApproval]
 	);
 	const [templateBaselineSignature, setTemplateBaselineSignature] = useState(() =>
 		buildTemplateCanvasSignature(
@@ -292,7 +327,8 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			initState?.channels ?? [],
 			initState?.startNodeId ?? '',
 			initState?.gates ?? [],
-			initState?.endNodeId
+			initState?.endNodeId,
+			initState?.postApproval
 		)
 	);
 
@@ -1001,6 +1037,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 		setEdges(newEdges);
 		setChannels(nextChannels);
 		setGates(nextGates);
+		setPostApproval(template.postApproval ? { ...template.postApproval } : undefined);
 		if (template.tags) {
 			setTags([...template.tags]);
 		}
@@ -1017,7 +1054,8 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 				nextChannels,
 				resolvedStartLocalId,
 				nextGates,
-				resolvedEndLocalId
+				resolvedEndLocalId,
+				template.postApproval
 			)
 		);
 		if (!name) setName(template.label);
@@ -1083,6 +1121,16 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 				return;
 			}
 		}
+		if (postApproval) {
+			if (!postApproval.targetAgent.trim()) {
+				setError('Post-approval target is required.');
+				return;
+			}
+			if (!postApproval.instructions.trim()) {
+				setError('Post-approval instructions are required.');
+				return;
+			}
+		}
 
 		const visualState: VisualEditorState = {
 			nodes,
@@ -1093,6 +1141,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			channels,
 			gates,
 			completionAutonomyLevel,
+			postApproval,
 		};
 
 		setSaving(true);
@@ -1221,6 +1270,68 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 						{label}
 					</button>
 				))}
+			</div>
+
+			{/* ---- Post-approval route ---- */}
+			<div class="px-4 py-2 border-b border-dark-700 flex-shrink-0">
+				<div class="flex items-start gap-3">
+					<label class="flex items-center gap-2 pt-1 text-xs text-gray-400">
+						<input
+							type="checkbox"
+							checked={!!postApproval}
+							data-testid="post-approval-enabled-checkbox"
+							onChange={(e) => {
+								const enabled = (e.currentTarget as HTMLInputElement).checked;
+								if (!enabled) {
+									setPostApproval(undefined);
+									return;
+								}
+								const targetAgent =
+									postApproval?.targetAgent || postApprovalTargetOptions[0] || 'task-agent';
+								setPostApproval({
+									targetAgent,
+									instructions: postApproval?.instructions ?? '',
+								});
+							}}
+							class="w-3 h-3 rounded accent-blue-500"
+						/>
+						<span class="font-medium">Post-Approval</span>
+					</label>
+					{postApproval && (
+						<div class="flex-1 grid grid-cols-[12rem_1fr] gap-2 min-w-0">
+							<select
+								value={postApproval.targetAgent}
+								data-testid="post-approval-target-select"
+								onChange={(e) =>
+									setPostApproval({
+										...postApproval,
+										targetAgent: (e.currentTarget as HTMLSelectElement).value,
+									})
+								}
+								class="w-full text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500"
+							>
+								{postApprovalTargetOptions.map((target) => (
+									<option key={target} value={target}>
+										{target}
+									</option>
+								))}
+							</select>
+							<textarea
+								value={postApproval.instructions}
+								data-testid="post-approval-instructions-textarea"
+								onInput={(e) =>
+									setPostApproval({
+										...postApproval,
+										instructions: (e.currentTarget as HTMLTextAreaElement).value,
+									})
+								}
+								placeholder="Workflow-specific post-approval instructions…"
+								rows={3}
+								class="w-full resize-y min-h-[4.75rem] max-h-40 text-xs bg-dark-800 border border-dark-600 rounded px-2 py-1.5 text-gray-200 focus:outline-none focus:border-blue-500 placeholder-gray-600"
+							/>
+						</div>
+					)}
+				</div>
 			</div>
 
 			{/* ---- Error banner ---- */}

--- a/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
+++ b/packages/web/src/components/space/visual-editor/__tests__/VisualWorkflowEditor.test.tsx
@@ -730,6 +730,64 @@ describe('VisualWorkflowEditor', () => {
 	});
 
 	// -------------------------------------------------------------------------
+	// Post-approval route
+	// -------------------------------------------------------------------------
+
+	describe('Post-approval route', () => {
+		it('reflects workflow postApproval in edit mode', () => {
+			const { getByTestId } = render(
+				<VisualWorkflowEditor
+					{...makeProps({
+						workflow: makeWorkflow({
+							postApproval: {
+								targetAgent: 'coder',
+								instructions: 'Deploy {{task_id}}.',
+							},
+						}),
+					})}
+				/>
+			);
+
+			expect((getByTestId('post-approval-enabled-checkbox') as HTMLInputElement).checked).toBe(
+				true
+			);
+			expect((getByTestId('post-approval-target-select') as HTMLSelectElement).value).toBe('coder');
+			expect(
+				(getByTestId('post-approval-instructions-textarea') as HTMLTextAreaElement).value
+			).toBe('Deploy {{task_id}}.');
+		});
+
+		it('includes edited postApproval in updateWorkflow call', async () => {
+			const { getByTestId } = render(
+				<VisualWorkflowEditor
+					{...makeProps({
+						workflow: makeWorkflow({
+							postApproval: {
+								targetAgent: 'coder',
+								instructions: 'Old instructions.',
+							},
+						}),
+					})}
+				/>
+			);
+
+			fireEvent.input(getByTestId('post-approval-instructions-textarea'), {
+				target: { value: 'Deploy {{task_id}}.' },
+			});
+			await act(async () => {
+				fireEvent.click(getByTestId('save-button'));
+			});
+
+			await waitFor(() => expect(mockUpdateWorkflow).toHaveBeenCalledOnce());
+			const params = mockUpdateWorkflow.mock.calls[0][1];
+			expect(params.postApproval).toEqual({
+				targetAgent: 'coder',
+				instructions: 'Deploy {{task_id}}.',
+			});
+		});
+	});
+
+	// -------------------------------------------------------------------------
 	// Tags
 	// -------------------------------------------------------------------------
 

--- a/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
+++ b/packages/web/src/components/space/visual-editor/__tests__/serialization.test.ts
@@ -202,6 +202,19 @@ describe('workflowToVisualState', () => {
 		});
 	});
 
+	it('passes postApproval through', () => {
+		const wf = makeWorkflow({
+			nodes: [makeStep('s1')],
+			startNodeId: 's1',
+			postApproval: { targetAgent: 'reviewer', instructions: 'Merge PR {{pr_url}}.' },
+		});
+		const state = workflowToVisualState(wf);
+		expect(state.postApproval).toEqual({
+			targetAgent: 'reviewer',
+			instructions: 'Merge PR {{pr_url}}.',
+		});
+	});
+
 	it('assigns fresh localIds to each node (including Task Agent)', () => {
 		const wf = makeWorkflow({
 			nodes: [makeStep('s1'), makeStep('s2')],
@@ -397,6 +410,17 @@ describe('visualStateToCreateParams', () => {
 		expect(params.endNodeId).toBe('s2');
 	});
 
+	it('passes postApproval through to create params', () => {
+		const state = makeState({
+			postApproval: { targetAgent: 'reviewer', instructions: 'Merge PR {{pr_url}}.' },
+		});
+		const params = visualStateToCreateParams(state, 'space-1', 'WF');
+		expect(params.postApproval).toEqual({
+			targetAgent: 'reviewer',
+			instructions: 'Merge PR {{pr_url}}.',
+		});
+	});
+
 	it('endNodeId is undefined when not set on state', () => {
 		const state = makeState();
 		const params = visualStateToCreateParams(state, 'space-1', 'WF');
@@ -585,6 +609,28 @@ describe('visualStateToUpdateParams', () => {
 		};
 		const params = visualStateToUpdateParams(state);
 		expect(params.endNodeId).toBe('s2');
+	});
+
+	it('passes postApproval through to update params', () => {
+		const state: VisualEditorState = {
+			nodes: [
+				{
+					step: { localId: 'l1', id: 's1', name: 'S1', agentId: 'a' },
+					position: { x: 0, y: 0 },
+				},
+			],
+			edges: [],
+			startNodeId: 's1',
+			tags: [],
+			channels: [],
+			gates: [],
+			postApproval: { targetAgent: 'task-agent', instructions: 'Publish release.' },
+		};
+		const params = visualStateToUpdateParams(state);
+		expect(params.postApproval).toEqual({
+			targetAgent: 'task-agent',
+			instructions: 'Publish release.',
+		});
 	});
 
 	it('endNodeId is null when not set on state', () => {

--- a/packages/web/src/components/space/visual-editor/serialization.ts
+++ b/packages/web/src/components/space/visual-editor/serialization.ts
@@ -30,6 +30,7 @@ import type {
 	WorkflowChannel,
 	Gate,
 	SpaceAutonomyLevel,
+	PostApprovalRoute,
 } from '@neokai/shared';
 import type { NodeDraft } from '../WorkflowNodeCard';
 import type { Point, WorkflowCondition } from './types';
@@ -95,6 +96,8 @@ export interface VisualEditorState {
 	 * human approval at each completion gate. Defaults to 3 when not set.
 	 */
 	completionAutonomyLevel?: SpaceAutonomyLevel;
+	/** Optional post-approval route configured on the workflow. */
+	postApproval?: PostApprovalRoute;
 }
 
 // ============================================================================
@@ -178,6 +181,7 @@ export function workflowToVisualState(workflow: SpaceWorkflow): VisualEditorStat
 		})),
 		gates: workflow.gates ?? [],
 		completionAutonomyLevel: workflow.completionAutonomyLevel ?? (3 as SpaceAutonomyLevel),
+		postApproval: workflow.postApproval ? { ...workflow.postApproval } : undefined,
 	};
 }
 
@@ -373,6 +377,7 @@ export function visualStateToCreateParams(
 		channels: fields.channels && fields.channels.length > 0 ? fields.channels : undefined,
 		gates: fields.gates && fields.gates.length > 0 ? fields.gates : undefined,
 		completionAutonomyLevel: state.completionAutonomyLevel,
+		postApproval: state.postApproval,
 	};
 }
 
@@ -398,5 +403,6 @@ export function visualStateToUpdateParams(
 		channels: fields.channels && fields.channels.length > 0 ? fields.channels : null,
 		gates: fields.gates && fields.gates.length > 0 ? fields.gates : null,
 		completionAutonomyLevel: state.completionAutonomyLevel,
+		postApproval: state.postApproval ?? null,
 	};
 }

--- a/packages/web/src/components/space/workflow-templates.ts
+++ b/packages/web/src/components/space/workflow-templates.ts
@@ -13,6 +13,7 @@ import type {
 	WorkflowChannel,
 	Gate,
 	WorkflowNodeAgent,
+	PostApprovalRoute,
 } from '@neokai/shared';
 import { generateUUID } from '@neokai/shared';
 import type { NodeDraft } from './WorkflowNodeCard';
@@ -38,6 +39,8 @@ export interface WorkflowTemplate {
 	gates?: Gate[];
 	/** Optional tags to seed with the template. */
 	tags?: string[];
+	/** Optional workflow-level post-approval route to seed with the template. */
+	postApproval?: PostApprovalRoute;
 }
 
 export interface WorkflowTemplateStep {
@@ -216,6 +219,7 @@ export function workflowToTemplate(workflow: SpaceWorkflow): WorkflowTemplate {
 			fields: [...(gate.fields ?? [])],
 		})),
 		tags: [...(workflow.tags ?? [])],
+		postApproval: workflow.postApproval ? { ...workflow.postApproval } : undefined,
 	};
 }
 


### PR DESCRIPTION
Splits workflow-specific post-approval PR merge instructions from the runtime-owned completion guidance, so post-approval sessions consistently get the `mark_complete` instruction without duplicating it in workflow templates.

Also preserves and edits `postApproval` routes through workflow RPCs and the visual workflow editor.

Validation: focused daemon and visual-editor tests pass locally; typecheck, lint, knip, format check, and `git diff --check` pass locally; GitHub CI is green on `6c1cc551f`.
