### PR TITLE
Fix Space runtime MCP rehydration

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -145,6 +145,18 @@ export interface AgentSessionInit {
 	roomSkillOverrides?: RoomSkillOverride[];
 }
 
+export interface AgentSessionRuntimeOptions {
+	/**
+	 * Whether the constructor should replay persisted pending messages for
+	 * immediate-mode sessions.
+	 *
+	 * Space-owned restored sessions need owner-specific in-process MCP servers
+	 * rebuilt before any query can start, so their managers pass false and call
+	 * replayPendingMessagesForImmediateMode() after runtime provisioning.
+	 */
+	autoReplayPendingMessages?: boolean;
+}
+
 // Extracted components
 import { MessageQueue } from './message-queue';
 import { ProcessingStateManager } from './processing-state-manager';
@@ -232,6 +244,7 @@ export class AgentSession
 	// Session state
 	private _isCleaningUp = false;
 	pendingRestartReason: 'settings.local.json' | null = null;
+	private initialPendingReplayScheduled = false;
 
 	// Services (accessible to handlers)
 	readonly errorManager: ErrorManager;
@@ -268,7 +281,8 @@ export class AgentSession
 		private getApiKey: () => Promise<string | null>,
 		readonly skillsManager?: import('../skills-manager').SkillsManager,
 		readonly appMcpServerRepo?: import('../../storage/repositories/app-mcp-server-repository').AppMcpServerRepository,
-		readonly roomSkillOverrides?: RoomSkillOverride[]
+		readonly roomSkillOverrides?: RoomSkillOverride[],
+		private readonly runtimeOptions: AgentSessionRuntimeOptions = {}
 	) {
 		this.errorManager = new ErrorManager(this.messageHub, this.daemonHub);
 		this.logger = new Logger(`AgentSession ${session.id}`);
@@ -343,15 +357,8 @@ export class AgentSession
 		// Setup event subscriptions (moved callbacks into EventSubscriptionSetup)
 		this.eventSubscriptionSetup.setup();
 
-		// Replay persisted pending messages after startup/recovery in immediate mode.
-		// Priority: enqueued/immediate first, then deferred/defer.
-		const restoredState = this.stateManager.getState();
-		if (session.config.queryMode !== 'manual' && restoredState.status !== 'waiting_for_input') {
-			queueMicrotask(() => {
-				this.queryModeHandler.replayPendingMessagesForImmediateMode().catch((error) => {
-					this.logger.warn('Failed to replay pending messages after startup:', error);
-				});
-			});
+		if (this.runtimeOptions.autoReplayPendingMessages ?? true) {
+			this.scheduleInitialPendingMessageReplay();
 		}
 	}
 
@@ -512,7 +519,8 @@ export class AgentSession
 		daemonHub: DaemonHub,
 		getApiKey: () => Promise<string | null>,
 		skillsManager?: import('../skills-manager').SkillsManager,
-		appMcpServerRepo?: import('../../storage/repositories/app-mcp-server-repository').AppMcpServerRepository
+		appMcpServerRepo?: import('../../storage/repositories/app-mcp-server-repository').AppMcpServerRepository,
+		options?: AgentSessionRuntimeOptions
 	): AgentSession | null {
 		const session = db.getSession(sessionId);
 		if (!session) return null;
@@ -524,7 +532,9 @@ export class AgentSession
 			daemonHub,
 			getApiKey,
 			skillsManager,
-			appMcpServerRepo
+			appMcpServerRepo,
+			undefined,
+			options
 		);
 		return agentSession;
 	}
@@ -616,6 +626,34 @@ export class AgentSession
 
 	async startStreamingQuery(): Promise<void> {
 		await this.queryRunner.start();
+	}
+
+	private scheduleInitialPendingMessageReplay(): void {
+		if (this.initialPendingReplayScheduled) return;
+		const restoredState = this.stateManager.getState();
+		if (this.session.config.queryMode === 'manual') return;
+		if (restoredState.status === 'waiting_for_input') return;
+		this.initialPendingReplayScheduled = true;
+		queueMicrotask(() => {
+			this.replayPendingMessagesForImmediateMode().catch((error) => {
+				this.logger.warn('Failed to replay pending messages after startup:', error);
+			});
+		});
+	}
+
+	/**
+	 * Replay persisted pending messages after runtime-only session provisioning
+	 * has completed.
+	 *
+	 * Space owners call this after attaching live SDK MCP server instances on
+	 * restored sessions. It is also what the constructor schedules for generic
+	 * sessions where no owner-specific provisioning is required.
+	 */
+	async replayPendingMessagesForImmediateMode(): Promise<void> {
+		if (this.session.config.queryMode === 'manual') return;
+		const restoredState = this.stateManager.getState();
+		if (restoredState.status === 'waiting_for_input') return;
+		await this.queryModeHandler.replayPendingMessagesForImmediateMode();
 	}
 
 	async ensureQueryStarted(): Promise<void> {
@@ -746,6 +784,7 @@ export class AgentSession
 			mcpServers,
 		};
 		this.emitMcpAttachLog('replace', Object.keys(mcpServers));
+		this.syncRuntimeMcpServersToActiveQuery('replace', Object.keys(mcpServers));
 	}
 
 	/**
@@ -777,6 +816,7 @@ export class AgentSession
 			},
 		};
 		this.emitMcpAttachLog('merge', Object.keys(additional));
+		this.syncRuntimeMcpServersToActiveQuery('merge', Object.keys(additional));
 	}
 
 	/**
@@ -796,6 +836,43 @@ export class AgentSession
 			mcpServers: updated,
 		};
 		this.emitMcpAttachLog('detach', [name]);
+		this.syncRuntimeMcpServersToActiveQuery('detach', [name]);
+	}
+
+	private syncRuntimeMcpServersToActiveQuery(
+		action: 'merge' | 'detach' | 'replace',
+		servers: string[]
+	): void {
+		const queryObject = this.queryObject;
+		if (!queryObject) return;
+
+		const setMcpServers = queryObject.setMcpServers?.bind(queryObject);
+		if (!setMcpServers) return;
+
+		const effectiveMcpServers = this.optionsBuilder.getEffectiveMcpServers() ?? {};
+		void setMcpServers(effectiveMcpServers)
+			.then((result) => {
+				this.logger.info(
+					`mcp.attach.live ${JSON.stringify({
+						event: 'mcp.attach.live',
+						sessionId: this.session.id,
+						action,
+						servers: [...servers].sort(),
+						effectiveServers: Object.keys(effectiveMcpServers).sort(),
+						added: result.added,
+						removed: result.removed,
+						errors: result.errors,
+					})}`
+				);
+			})
+			.catch((error) => {
+				this.logger.warn(
+					`mcp.attach.live failed for session ${this.session.id} after ${action} [${servers
+						.slice()
+						.sort()
+						.join(', ')}]: ${error instanceof Error ? error.message : String(error)}`
+				);
+			});
 	}
 
 	/**

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -96,6 +96,23 @@ export class QueryOptionsBuilder {
 	}
 
 	/**
+	 * Return the effective MCP server map for dynamic SDK updates.
+	 *
+	 * This mirrors the `build()` merge path without rebuilding the full SDK
+	 * options object. Runtime MCP attachment can happen after a streaming query
+	 * already exists; callers use this method before `queryObject.setMcpServers()`
+	 * so dynamic updates preserve skill-contributed MCP servers instead of
+	 * replacing the live query with only `session.config.mcpServers`.
+	 */
+	getEffectiveMcpServers(): Record<string, McpServerConfig> | undefined {
+		const mcpServers = this.getMcpServers();
+		const mcpServersFromSkills = this.getMcpServersFromSkills();
+		return this.mergeMcpServers(mcpServers, mcpServersFromSkills) as
+			| Record<string, McpServerConfig>
+			| undefined;
+	}
+
+	/**
 	 * Build complete SDK query options
 	 *
 	 * Maps all SessionConfig (which extends SDKConfig) options to SDK Options

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -11,7 +11,7 @@
  */
 
 import { query } from '@anthropic-ai/claude-agent-sdk';
-import type { Query, SpawnOptions, SpawnedProcess } from '@anthropic-ai/claude-agent-sdk';
+import type { Options, Query, SpawnOptions, SpawnedProcess } from '@anthropic-ai/claude-agent-sdk';
 import { spawn as nodeSpawn } from 'node:child_process';
 import type { UUID } from 'crypto';
 import type { Session, MessageHub } from '@neokai/shared';
@@ -309,15 +309,21 @@ export class QueryRunner {
 						sessionId: session.id,
 						spaceId: session.context?.spaceId,
 						sessionType: session.type,
+						requiredServers,
 						missingServers,
 						presentServers: mcpServerNames,
+						liveSdkServers: this.getLiveSdkMcpServerNames(queryOptions),
+						selfHealAttempted: !!this.ctx.onMissingWorkflowMcpServers,
 					};
 
 					logger.error(
 						`QueryRunner.start(): workflow sub-session ${session.id} is MISSING required MCP servers. ` +
 							`Missing: [${missingServers.join(', ')}]. ` +
 							`Present: [${mcpServerNames.join(', ')}]. ` +
-							`Attempting self-heal via onMissingWorkflowMcpServers callback...`
+							`Live SDK servers: [${diagnosticPayload.liveSdkServers.join(', ')}]. ` +
+							`Self-heal attempted: ${diagnosticPayload.selfHealAttempted}. ` +
+							`Attempting self-heal via onMissingWorkflowMcpServers callback... ` +
+							`${JSON.stringify(diagnosticPayload)}`
 					);
 
 					// ── Self-heal: call the registered callback to re-inject servers ─────
@@ -350,6 +356,7 @@ export class QueryRunner {
 							`QueryRunner.start(): workflow sub-session ${session.id} servers still missing after self-heal. ` +
 								`Still absent: [${stillMissing.join(', ')}]. ` +
 								`Present: [${currentServerNames.join(', ')}]. ` +
+								`Live SDK servers: [${this.getLiveSdkMcpServerNames({ mcpServers: currentMcpServers } as Options).join(', ')}]. ` +
 								`Refusing to start.`
 						);
 						throw new Error(
@@ -358,6 +365,25 @@ export class QueryRunner {
 								`Refusing to start — fix the injection logic.`
 						);
 					}
+
+					// The self-heal callback mutates session.config.mcpServers. The
+					// queryOptions object was built before that mutation, so rebuild it
+					// now or the SDK will still start with the stale server map.
+					queryOptions = await optionsBuilder.build();
+					queryOptions = optionsBuilder.addSessionStateOptions(queryOptions);
+					const repairedServerNames = Object.keys(queryOptions.mcpServers ?? {}).sort();
+					logger.info(
+						`QueryRunner.start(): rebuilt query options after MCP self-heal for session ${session.id}. ` +
+							`Present: [${repairedServerNames.join(', ')}]. ` +
+							`${JSON.stringify({
+								event: 'workflow.mcp.self_heal.rebuilt_query_options',
+								sessionId: session.id,
+								sessionType: session.type,
+								requiredServers,
+								presentServers: repairedServerNames,
+								liveSdkServers: this.getLiveSdkMcpServerNames(queryOptions),
+							})}`
+					);
 				}
 			}
 
@@ -780,6 +806,16 @@ export class QueryRunner {
 			}
 			// Stale query: skip all cleanup — new query owns shared state
 		}
+	}
+
+	private getLiveSdkMcpServerNames(queryOptions: Pick<Options, 'mcpServers'>): string[] {
+		return Object.entries(queryOptions.mcpServers ?? {})
+			.filter(([, config]) => {
+				const maybeSdk = config as { type?: unknown; instance?: unknown };
+				return maybeSdk.type === 'sdk' && !!maybeSdk.instance;
+			})
+			.map(([name]) => name)
+			.sort();
 	}
 
 	/**

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -98,7 +98,11 @@ export class SessionManager {
 				eventBus,
 				() => this.authManager.getCurrentApiKey(),
 				this.skillsManager,
-				this.appMcpServerRepo
+				this.appMcpServerRepo,
+				undefined,
+				{
+					autoReplayPendingMessages: !this.needsSpaceRuntimeProvisioning(session),
+				}
 			);
 		};
 
@@ -134,6 +138,12 @@ export class SessionManager {
 
 		// Setup EventBus subscribers for async message processing
 		this.setupEventSubscriptions();
+	}
+
+	private needsSpaceRuntimeProvisioning(session: Session): boolean {
+		if (session.type === 'space_chat') return true;
+		if (session.type === 'space_task_agent') return true;
+		return typeof session.context?.spaceId === 'string';
 	}
 
 	/**

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -620,6 +620,7 @@ export class SpaceRuntimeService {
 		// Merge rather than replace — other subsystems (e.g., room tools) may
 		// have already attached their own MCP servers on this session.
 		agentSession.mergeRuntimeMcpServers(additional);
+		await this.replayPendingMessagesAfterRuntimeProvisioning(agentSession);
 
 		log.info(
 			`Attached space-agent-tools to member session ${session.id} (space ${space.id}, type ${session.type ?? 'worker'})`
@@ -735,6 +736,7 @@ export class SpaceRuntimeService {
 		);
 
 		log.info(`Space chat session provisioned for space ${space.id}`);
+		await this.replayPendingMessagesAfterRuntimeProvisioning(session);
 
 		// Flush any Task Agent → Space Agent messages that were queued before
 		// this session was provisioned (handles the daemon-restart activation race).
@@ -882,6 +884,14 @@ export class SpaceRuntimeService {
 			onGatePendingApproval: (runId, gateId) => this.handleGatePendingApproval(runId, gateId),
 		});
 		return router.onGateDataChanged(runId, gateId);
+	}
+
+	private async replayPendingMessagesAfterRuntimeProvisioning(session: {
+		replayPendingMessagesForImmediateMode?: () => Promise<void>;
+	}): Promise<void> {
+		if (typeof session.replayPendingMessagesForImmediateMode === 'function') {
+			await session.replayPendingMessagesForImmediateMode();
+		}
 	}
 
 	/**

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -2878,7 +2878,8 @@ export class TaskAgentManager {
 			this.config.daemonHub,
 			this.config.getApiKey,
 			this.config.skillsManager,
-			this.config.appMcpServerRepo
+			this.config.appMcpServerRepo,
+			{ autoReplayPendingMessages: false }
 		);
 		if (!agentSession) {
 			log.warn(
@@ -3044,6 +3045,7 @@ export class TaskAgentManager {
 
 		// --- Restart the streaming query (SDK resumes from conversation history in DB)
 		await agentSession.startStreamingQuery();
+		await this.replayPendingMessagesAfterRuntimeProvisioning(agentSession);
 
 		// --- Inject re-orientation message so the agent checks state and continues.
 		const reorientMessage = task.workflowRunId
@@ -3219,7 +3221,8 @@ export class TaskAgentManager {
 			this.config.daemonHub,
 			this.config.getApiKey,
 			this.config.skillsManager,
-			this.config.appMcpServerRepo
+			this.config.appMcpServerRepo,
+			{ autoReplayPendingMessages: false }
 		);
 		if (!agentSession) {
 			log.warn(
@@ -3316,6 +3319,7 @@ export class TaskAgentManager {
 
 		// --- Restart the streaming query (idempotent if already running)
 		await agentSession.startStreamingQuery();
+		await this.replayPendingMessagesAfterRuntimeProvisioning(agentSession);
 
 		// Flush any pending Task Agent → this agent messages that accumulated while
 		// the sub-session was not alive in memory.
@@ -3333,6 +3337,19 @@ export class TaskAgentManager {
 
 		void workflow; // Loaded for context but not needed directly; suppresses unused-var lint.
 		return agentSession;
+	}
+
+	private async replayPendingMessagesAfterRuntimeProvisioning(
+		session: AgentSession
+	): Promise<void> {
+		const replay = (
+			session as AgentSession & {
+				replayPendingMessagesForImmediateMode?: () => Promise<void>;
+			}
+		).replayPendingMessagesForImmediateMode;
+		if (typeof replay === 'function') {
+			await replay.call(session);
+		}
 	}
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
@@ -2655,6 +2655,75 @@ describe('AgentSession', () => {
 				.updateSession.mock.calls;
 			expect(updateSessionCalls.length).toBe(0);
 		});
+
+		it('pushes merged runtime MCP servers into an active SDK query', async () => {
+			const existing = {
+				'task-agent': {
+					type: 'sdk',
+					name: 'task-agent',
+					instance: {},
+				} as unknown as McpServerConfig,
+			};
+			const mockSession = makeMockSession(existing);
+			const { mockDb, mockMessageHub, mockDaemonHub, mockGetApiKey } = makeMocks();
+			const agentSession = new AgentSession(
+				mockSession,
+				mockDb,
+				mockMessageHub,
+				mockDaemonHub,
+				mockGetApiKey
+			);
+			const setMcpServers = mock(async () => ({ added: [], removed: [], errors: {} }));
+			agentSession.queryObject = {
+				setMcpServers,
+			} as unknown as import('@anthropic-ai/claude-agent-sdk').Query;
+
+			const spaceAgent = {
+				type: 'sdk',
+				name: 'space-agent-tools',
+				instance: {},
+			} as unknown as McpServerConfig;
+			agentSession.mergeRuntimeMcpServers({ 'space-agent-tools': spaceAgent });
+			await Promise.resolve();
+
+			expect(setMcpServers).toHaveBeenCalledTimes(1);
+			expect(setMcpServers).toHaveBeenCalledWith({
+				'task-agent': existing['task-agent'],
+				'space-agent-tools': spaceAgent,
+			});
+		});
+
+		it('can defer constructor pending-message replay until runtime provisioning completes', async () => {
+			const mockSession = makeMockSession();
+			const replayStatusReads: string[] = [];
+			const getMessagesByStatus = mock((_sessionId: string, status: string) => {
+				if (status === 'enqueued' || status === 'deferred') {
+					replayStatusReads.push(status);
+				}
+				return [];
+			});
+			const { mockDb, mockMessageHub, mockDaemonHub, mockGetApiKey } = makeMocks();
+			(mockDb as unknown as { getMessagesByStatus: ReturnType<typeof mock> }).getMessagesByStatus =
+				getMessagesByStatus;
+
+			const agentSession = new AgentSession(
+				mockSession,
+				mockDb,
+				mockMessageHub,
+				mockDaemonHub,
+				mockGetApiKey,
+				undefined,
+				undefined,
+				undefined,
+				{ autoReplayPendingMessages: false }
+			);
+
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			expect(replayStatusReads).toEqual([]);
+
+			await agentSession.replayPendingMessagesForImmediateMode();
+			expect(replayStatusReads).toEqual(['enqueued', 'deferred']);
+		});
 	});
 
 	describe('detachRuntimeMcpServer', () => {

--- a/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
@@ -249,6 +249,67 @@ describe('QueryRunner', () => {
 
 			expect(ctx.firstMessageReceived).toBe(false);
 		});
+
+		it('rebuilds query options after workflow MCP self-heal before SDK query creation', async () => {
+			const savedApiKey = process.env.ANTHROPIC_API_KEY;
+			process.env.ANTHROPIC_API_KEY = 'sk-test-key';
+			try {
+				mockSession.id = 'space:s1:task:t1:exec:e1';
+				mockSession.workspacePath = tmpdir();
+				mockSession.type = 'worker';
+				mockSession.context = { spaceId: 's1', taskId: 't1' };
+				mockSession.config.mcpServers = {};
+
+				const repairedServers = {
+					'node-agent': {
+						type: 'sdk',
+						name: 'node-agent',
+						instance: {},
+					},
+					'space-agent-tools': {
+						type: 'sdk',
+						name: 'space-agent-tools',
+						instance: {},
+					},
+				};
+				buildSpy
+					.mockResolvedValueOnce({ model: 'claude-sonnet-4-20250514', mcpServers: {} })
+					.mockResolvedValueOnce({
+						model: 'claude-sonnet-4-20250514',
+						mcpServers: repairedServers,
+					});
+				let addOptionsCalls = 0;
+				addSessionStateOptionsSpy.mockImplementation((options: unknown) => {
+					addOptionsCalls++;
+					if (addOptionsCalls === 2) {
+						throw new Error('stop after rebuilt options');
+					}
+					return options;
+				});
+				const onMissingWorkflowMcpServers = mock(async () => {
+					mockSession.config.mcpServers =
+						repairedServers as unknown as Session['config']['mcpServers'];
+				});
+
+				const ctx = createContext({ onMissingWorkflowMcpServers });
+				runner = new QueryRunner(ctx);
+				runner.start();
+				await ctx.queryPromise?.catch(() => {});
+
+				expect(onMissingWorkflowMcpServers).toHaveBeenCalledWith('space:s1:task:t1:exec:e1', [
+					'node-agent',
+					'space-agent-tools',
+				]);
+				expect(buildSpy).toHaveBeenCalledTimes(2);
+				expect(addSessionStateOptionsSpy).toHaveBeenCalledTimes(2);
+			} finally {
+				if (savedApiKey === undefined) {
+					delete process.env.ANTHROPIC_API_KEY;
+				} else {
+					process.env.ANTHROPIC_API_KEY = savedApiKey;
+				}
+			}
+		});
 	});
 
 	describe('displayErrorAsAssistantMessage', () => {


### PR DESCRIPTION
Fixes restored Space-owned sessions so live runtime MCP servers are reattached before pending-message replay can start a query. Also pushes late runtime MCP changes into active SDK queries and rebuilds QueryRunner options after workflow MCP self-heal.

Tests:
- bun test packages/daemon/tests/unit/1-core/agent/query-runner.test.ts packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts packages/daemon/tests/unit/1-core/session/session-manager.test.ts
- bun test packages/daemon/tests/unit/5-space/agent/task-agent-manager-mcp.test.ts packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
- bun run lint
- bun run format:check
- bun run typecheck