### PR TITLE
Fix Codex bridge context usage

### DIFF
--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/process-manager.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/process-manager.ts
@@ -310,14 +310,42 @@ function readNumber(record: Record<string, unknown>, keys: string[]): number | u
 	return undefined;
 }
 
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === 'object' && value !== null && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+function selectUsageBreakdown(rawParams: unknown): Record<string, unknown> {
+	const params = asRecord(rawParams) ?? {};
+	const usageContainer =
+		asRecord(params.usage) ??
+		asRecord(params.tokenUsage) ??
+		asRecord(params.token_usage) ??
+		asRecord(params.totalTokenUsage) ??
+		asRecord(params.total_token_usage);
+
+	if (usageContainer) {
+		// Codex app-server v2 sends:
+		//   { tokenUsage: { total: {...}, last: {...}, modelContextWindow } }
+		// `last` is the turn-level usage that best matches Anthropic message usage;
+		// `total` is retained as a fallback for restored/cumulative snapshots.
+		return (
+			asRecord(usageContainer.last) ??
+			asRecord(usageContainer.lastTokenUsage) ??
+			asRecord(usageContainer.last_token_usage) ??
+			asRecord(usageContainer.total) ??
+			asRecord(usageContainer.totalTokenUsage) ??
+			asRecord(usageContainer.total_token_usage) ??
+			usageContainer
+		);
+	}
+
+	return params;
+}
+
 function normalizeTokenUsage(rawParams: unknown): TokenUsage {
-	const params = (rawParams ?? {}) as Record<string, unknown>;
-	const nested = (params.usage ??
-		params.tokenUsage ??
-		params.token_usage ??
-		params.totalTokenUsage ??
-		params.total_token_usage ??
-		params) as Record<string, unknown>;
+	const nested = selectUsageBreakdown(rawParams);
 
 	const outputTokens = readNumber(nested, ['outputTokens', 'output_tokens']) ?? 0;
 	const cacheReadInputTokens =
@@ -429,11 +457,12 @@ export class BridgeSession {
 		// (or around the same time as) turn/completed.  We store it so that
 		// turn/completed can populate turn_done with real counts instead of zeros.
 		this.conn.onNotification('thread/tokenUsage/updated', (rawParams) => {
-			// The Codex app-server may send usage as a nested object or flat:
+			// The Codex app-server sends v2 usage as:
+			//   { tokenUsage: { total, last, modelContextWindow } }
+			// Older builds and tests may send usage as a nested breakdown or flat:
 			//   { threadId, usage: { inputTokens, outputTokens } }
 			//   { threadId, inputTokens, outputTokens }
-			// Newer app-server builds may use snake_case fields and include cache
-			// counters, so normalize both protocol shapes here.
+			// Normalize camelCase and snake_case fields, including cache counters.
 			const usage = normalizeTokenUsage(rawParams);
 			logger.debug(
 				`BridgeSession: thread/tokenUsage/updated inputTokens=${usage.inputTokens} outputTokens=${usage.outputTokens}`

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/process-manager.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/process-manager.ts
@@ -27,7 +27,13 @@ export type BridgeEvent =
 			/** Call this to provide the tool result and resume the Codex turn. */
 			provideResult: (text: string) => void;
 	  }
-	| { type: 'turn_done'; inputTokens: number; outputTokens: number }
+	| {
+			type: 'turn_done';
+			inputTokens: number;
+			outputTokens: number;
+			cacheCreationInputTokens?: number;
+			cacheReadInputTokens?: number;
+	  }
 	| { type: 'error'; message: string };
 
 // ---------------------------------------------------------------------------
@@ -290,7 +296,57 @@ type TurnStartResult = { turn: { id: string } };
 export type TokenUsage = {
 	inputTokens: number;
 	outputTokens: number;
+	cacheCreationInputTokens?: number;
+	cacheReadInputTokens?: number;
 };
+
+function readNumber(record: Record<string, unknown>, keys: string[]): number | undefined {
+	for (const key of keys) {
+		const value = record[key];
+		if (typeof value === 'number' && Number.isFinite(value)) {
+			return value;
+		}
+	}
+	return undefined;
+}
+
+function normalizeTokenUsage(rawParams: unknown): TokenUsage {
+	const params = (rawParams ?? {}) as Record<string, unknown>;
+	const nested = (params.usage ??
+		params.tokenUsage ??
+		params.token_usage ??
+		params.totalTokenUsage ??
+		params.total_token_usage ??
+		params) as Record<string, unknown>;
+
+	const outputTokens = readNumber(nested, ['outputTokens', 'output_tokens']) ?? 0;
+	const cacheReadInputTokens =
+		readNumber(nested, [
+			'cacheReadInputTokens',
+			'cache_read_input_tokens',
+			'cachedInputTokens',
+			'cached_input_tokens',
+		]) ?? 0;
+	const cacheCreationInputTokens =
+		readNumber(nested, ['cacheCreationInputTokens', 'cache_creation_input_tokens']) ?? 0;
+	const explicitInputTokens = readNumber(nested, ['inputTokens', 'input_tokens']);
+	const totalTokens = readNumber(nested, ['totalTokens', 'total_tokens']);
+	const reasoningOutputTokens =
+		readNumber(nested, ['reasoningOutputTokens', 'reasoning_output_tokens']) ?? 0;
+
+	const inputTokens =
+		explicitInputTokens ??
+		(totalTokens !== undefined
+			? Math.max(0, totalTokens - outputTokens - reasoningOutputTokens)
+			: 0);
+
+	return {
+		inputTokens,
+		outputTokens,
+		cacheCreationInputTokens,
+		cacheReadInputTokens,
+	};
+}
 
 export class BridgeSession {
 	private threadId: string | null = null;
@@ -376,17 +432,13 @@ export class BridgeSession {
 			// The Codex app-server may send usage as a nested object or flat:
 			//   { threadId, usage: { inputTokens, outputTokens } }
 			//   { threadId, inputTokens, outputTokens }
-			const params = rawParams as {
-				usage?: { inputTokens?: number; outputTokens?: number };
-				inputTokens?: number;
-				outputTokens?: number;
-			};
-			const inputTokens = params?.usage?.inputTokens ?? params?.inputTokens ?? 0;
-			const outputTokens = params?.usage?.outputTokens ?? params?.outputTokens ?? 0;
+			// Newer app-server builds may use snake_case fields and include cache
+			// counters, so normalize both protocol shapes here.
+			const usage = normalizeTokenUsage(rawParams);
 			logger.debug(
-				`BridgeSession: thread/tokenUsage/updated inputTokens=${inputTokens} outputTokens=${outputTokens}`
+				`BridgeSession: thread/tokenUsage/updated inputTokens=${usage.inputTokens} outputTokens=${usage.outputTokens}`
 			);
-			this.latestUsage = { inputTokens, outputTokens };
+			this.latestUsage = usage;
 		});
 
 		// Wire notification handlers
@@ -415,7 +467,7 @@ export class BridgeSession {
 			// Legacy protocol had usage in this notification; v2 sends it separately.
 			const params = rawParams as {
 				turn?: { id?: string; status?: string; error?: { message?: string } | null };
-				usage?: { inputTokens?: number; outputTokens?: number };
+				usage?: Record<string, unknown>;
 			};
 			const status = params?.turn?.status;
 			logger.debug(`BridgeSession: turn/completed status=${status}`);
@@ -425,9 +477,9 @@ export class BridgeSession {
 			} else {
 				// Prefer token counts from thread/tokenUsage/updated (v2 protocol), then
 				// fall back to inline usage in turn/completed (legacy protocol), then 0.
-				const inputTokens = this.latestUsage?.inputTokens ?? params?.usage?.inputTokens ?? 0;
-				const outputTokens = this.latestUsage?.outputTokens ?? params?.usage?.outputTokens ?? 0;
-				this.queue.push({ type: 'turn_done', inputTokens, outputTokens });
+				const inlineUsage = params?.usage ? normalizeTokenUsage(params.usage) : null;
+				const usage = this.latestUsage ?? inlineUsage ?? { inputTokens: 0, outputTokens: 0 };
+				this.queue.push({ type: 'turn_done', ...usage });
 			}
 		});
 

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -456,7 +456,7 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 						}
 					);
 				} catch {
-					return createAnthropicError(400, 'invalid_request_error', 'Bad Request: invalid JSON');
+					return createAnthropicError(400, 'invalid_request_error', 'Bad Request');
 				}
 			}
 

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -34,6 +34,7 @@ import {
 	messageStopSSE,
 	errorSSE,
 } from './translator.js';
+import { estimateAnthropicInputTokens } from './token-estimator.js';
 import { Logger } from '../../logger.js';
 
 const logger = new Logger('codex-bridge-server');
@@ -54,6 +55,11 @@ const BRIDGE_MODELS = [
 		display_name: 'GPT-5.3 Codex',
 		created_at: '2025-12-01T00:00:00Z',
 		max_input_tokens: 200000,
+		context_window: 200000,
+		max_context_window: 200000,
+		model_context_window: 200000,
+		auto_compact_token_limit: 180000,
+		model_auto_compact_token_limit: 180000,
 		max_tokens: 16384,
 	},
 	{
@@ -61,6 +67,11 @@ const BRIDGE_MODELS = [
 		display_name: 'GPT-5.4',
 		created_at: '2026-01-01T00:00:00Z',
 		max_input_tokens: 200000,
+		context_window: 200000,
+		max_context_window: 200000,
+		model_context_window: 200000,
+		auto_compact_token_limit: 180000,
+		model_auto_compact_token_limit: 180000,
 		max_tokens: 16384,
 	},
 	{
@@ -68,6 +79,11 @@ const BRIDGE_MODELS = [
 		display_name: 'GPT-5.5',
 		created_at: '2026-04-01T00:00:00Z',
 		max_input_tokens: 200000,
+		context_window: 200000,
+		max_context_window: 200000,
+		model_context_window: 200000,
+		auto_compact_token_limit: 180000,
+		model_auto_compact_token_limit: 180000,
 		max_tokens: 16384,
 	},
 	{
@@ -75,6 +91,11 @@ const BRIDGE_MODELS = [
 		display_name: 'GPT-5.4 Mini',
 		created_at: '2026-01-01T00:00:00Z',
 		max_input_tokens: 128000,
+		context_window: 128000,
+		max_context_window: 128000,
+		model_context_window: 128000,
+		auto_compact_token_limit: 115200,
+		model_auto_compact_token_limit: 115200,
 		max_tokens: 16384,
 	},
 	{
@@ -82,6 +103,11 @@ const BRIDGE_MODELS = [
 		display_name: 'GPT-5.1 Codex Mini',
 		created_at: '2026-01-01T00:00:00Z',
 		max_input_tokens: 128000,
+		context_window: 128000,
+		max_context_window: 128000,
+		model_context_window: 128000,
+		auto_compact_token_limit: 115200,
+		model_auto_compact_token_limit: 115200,
 		max_tokens: 16384,
 	},
 ] as const;
@@ -209,7 +235,8 @@ export async function drainToSSE(
 	ttlMs: number,
 	sessionId: string,
 	onTurnDone: () => void,
-	onError?: () => void
+	onError?: () => void,
+	initialInputTokens = 0
 ): Promise<void> {
 	const enc = new TextEncoder();
 	const send = (s: string) => controller.enqueue(enc.encode(s));
@@ -221,11 +248,7 @@ export async function drainToSSE(
 
 	try {
 		const msgId = generateMsgId();
-		// TODO: input_tokens is hard-coded to 0 here because thread/tokenUsage/updated
-		// arrives after streaming starts and message_start is already sent by then.
-		// To surface real input token counts, drainToSSE would need to either buffer
-		// events until turn_done is available or emit a corrected usage event afterward.
-		send(messageStartSSE(msgId, model, 0));
+		send(messageStartSSE(msgId, model, initialInputTokens));
 		send(pingSSE());
 
 		// Use gen.next() manually instead of for-await-of.  The for-await-of
@@ -259,8 +282,8 @@ export async function drainToSSE(
 				send(inputJsonDeltaSSE(blockIndex, JSON.stringify(event.toolInput)));
 				send(contentBlockStopSSE(blockIndex));
 				// At tool_call time, thread/tokenUsage/updated has not yet fired (the model
-				// hasn't finished the turn yet), so always use the heuristic count here.
-				send(messageDeltaSSE('tool_use', { outputTokens, inputTokens: 0 }));
+				// hasn't finished the turn yet), so use the request-side estimate here.
+				send(messageDeltaSSE('tool_use', { outputTokens, inputTokens: initialInputTokens }));
 				send(messageStopSSE());
 
 				// Store the session so the next HTTP request can resume it.
@@ -295,10 +318,13 @@ export async function drainToSSE(
 				// event.outputTokens is populated from thread/tokenUsage/updated (v2 protocol)
 				// or from legacy inline usage. Fall back to heuristic count if both are 0.
 				const endOutputTokens = event.outputTokens > 0 ? event.outputTokens : outputTokens;
+				const endInputTokens = event.inputTokens > 0 ? event.inputTokens : initialInputTokens;
 				send(
 					messageDeltaSSE('end_turn', {
 						outputTokens: endOutputTokens,
-						inputTokens: event.inputTokens || 0,
+						inputTokens: endInputTokens,
+						cacheCreationInputTokens: event.cacheCreationInputTokens,
+						cacheReadInputTokens: event.cacheReadInputTokens,
 					})
 				);
 				send(messageStopSSE());
@@ -325,7 +351,9 @@ export async function drainToSSE(
 		if (textBlockOpen) {
 			send(contentBlockStopSSE(blockIndex));
 		}
-		send(messageDeltaSSE('end_turn', { outputTokens: outputTokens, inputTokens: 0 }));
+		send(
+			messageDeltaSSE('end_turn', { outputTokens: outputTokens, inputTokens: initialInputTokens })
+		);
 		send(messageStopSSE());
 		session.kill();
 		onError?.();
@@ -415,13 +443,21 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 				});
 			}
 
-			// Token counting stub — the SDK calls this for context/token
-			// estimation.  It already catches errors, but returning a proper
-			// response avoids unnecessary error noise.
+			// Token counting — the SDK calls this for context usage. Codex
+			// app-server does not expose a count endpoint, so use the bridge-local
+			// deterministic estimator and let real app-server usage win at turn end.
 			if (url.pathname === '/v1/messages/count_tokens' && req.method === 'POST') {
-				return new Response(JSON.stringify({ input_tokens: 0 }), {
-					headers: { 'Content-Type': 'application/json' },
-				});
+				try {
+					const body = (await req.json()) as AnthropicRequest;
+					return new Response(
+						JSON.stringify({ input_tokens: estimateAnthropicInputTokens(body) }),
+						{
+							headers: { 'Content-Type': 'application/json' },
+						}
+					);
+				} catch {
+					return createAnthropicError(400, 'invalid_request_error', 'Bad Request: invalid JSON');
+				}
 			}
 
 			// Catch-all: return 501 instead of 404.  The SDK specifically maps
@@ -511,6 +547,7 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 				}
 
 				const { gen, session, model: sessionModel, sessionId: tsSessionId } = primaryStored;
+				const estimatedInputTokens = estimateAnthropicInputTokens(body);
 				const toolContinuationPs = persistentSessions.get(tsSessionId);
 				const onTurnDone = toolContinuationPs
 					? () => {
@@ -539,7 +576,8 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 									toolContinuationPs.session.kill();
 									persistentSessions.delete(tsSessionId);
 								}
-							}
+							},
+							estimatedInputTokens
 						);
 					},
 				});
@@ -622,6 +660,7 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 				? buildConversationText(body.messages, system)
 				: extractLastUserMessage(body.messages);
 			ps.isFirstTurn = false;
+			const estimatedInputTokens = estimateAnthropicInputTokens(body);
 
 			const gen = bridgeSession.startTurn(userText);
 
@@ -650,7 +689,8 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 							clearTimeout(capturedPs.idleTimer);
 							capturedPs.session.kill();
 							persistentSessions.delete(capturedSessionId);
-						}
+						},
+						estimatedInputTokens
 					);
 				},
 			});

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/token-estimator.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/token-estimator.ts
@@ -1,0 +1,109 @@
+/**
+ * Deterministic bridge-local token estimator for Anthropic-compatible
+ * count_tokens requests.
+ *
+ * Codex app-server reports authoritative usage after a turn via
+ * thread/tokenUsage/updated, but it does not expose a bridge-callable token
+ * count endpoint. This estimator is intentionally conservative and stable: it
+ * accounts for the same request surfaces the SDK sends to /count_tokens
+ * (system text, messages, tool calls/results, and tool schemas) so context
+ * growth is visible before the app-server's final usage notification arrives.
+ */
+
+import type {
+	AnthropicContentBlock,
+	AnthropicContentBlockToolResult,
+	AnthropicRequest,
+	AnthropicTool,
+} from './translator.js';
+
+const MESSAGE_OVERHEAD_TOKENS = 4;
+const SYSTEM_OVERHEAD_TOKENS = 4;
+const TOOL_SCHEMA_OVERHEAD_TOKENS = 12;
+const REQUEST_OVERHEAD_TOKENS = 3;
+
+function stableJson(value: unknown): string {
+	if (value === null || typeof value !== 'object') {
+		return JSON.stringify(value) ?? String(value);
+	}
+	if (Array.isArray(value)) {
+		return `[${value.map((item) => stableJson(item)).join(',')}]`;
+	}
+	const record = value as Record<string, unknown>;
+	const entries = Object.keys(record)
+		.sort()
+		.map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`);
+	return `{${entries.join(',')}}`;
+}
+
+function estimateTextTokens(text: string): number {
+	if (text.length === 0) return 0;
+
+	const characterEstimate = Math.ceil(text.length / 4);
+	const lexicalPieces = text.match(/[\p{L}\p{N}_]+|[^\s\p{L}\p{N}_]/gu)?.length ?? 0;
+
+	return Math.max(1, Math.ceil((characterEstimate + lexicalPieces) / 2));
+}
+
+function estimateToolResultContent(content: AnthropicContentBlockToolResult['content']): number {
+	if (typeof content === 'string') return estimateTextTokens(content);
+	return content.reduce((sum, block) => sum + estimateTextTokens(block.text), 0);
+}
+
+function estimateContentBlockTokens(block: AnthropicContentBlock): number {
+	if (block.type === 'text') {
+		return estimateTextTokens(block.text);
+	}
+	if (block.type === 'tool_use') {
+		return (
+			MESSAGE_OVERHEAD_TOKENS +
+			estimateTextTokens(block.name) +
+			estimateTextTokens(stableJson(block.input))
+		);
+	}
+	if (block.type === 'tool_result') {
+		return MESSAGE_OVERHEAD_TOKENS + estimateToolResultContent(block.content);
+	}
+	return estimateTextTokens(stableJson(block));
+}
+
+function estimateMessageContentTokens(
+	content: AnthropicRequest['messages'][number]['content']
+): number {
+	if (typeof content === 'string') return estimateTextTokens(content);
+	return content.reduce((sum, block) => sum + estimateContentBlockTokens(block), 0);
+}
+
+function estimateSystemTokens(system: AnthropicRequest['system']): number {
+	if (!system) return 0;
+	if (typeof system === 'string') {
+		return SYSTEM_OVERHEAD_TOKENS + estimateTextTokens(system);
+	}
+	return (
+		SYSTEM_OVERHEAD_TOKENS + system.reduce((sum, block) => sum + estimateTextTokens(block.text), 0)
+	);
+}
+
+function estimateToolTokens(tool: AnthropicTool): number {
+	return (
+		TOOL_SCHEMA_OVERHEAD_TOKENS +
+		estimateTextTokens(tool.name) +
+		estimateTextTokens(tool.description ?? '') +
+		estimateTextTokens(stableJson(tool.input_schema))
+	);
+}
+
+export function estimateAnthropicInputTokens(request: AnthropicRequest): number {
+	const systemTokens = estimateSystemTokens(request.system);
+	const messageTokens = request.messages.reduce(
+		(sum, message) =>
+			sum +
+			MESSAGE_OVERHEAD_TOKENS +
+			estimateTextTokens(message.role) +
+			estimateMessageContentTokens(message.content),
+		0
+	);
+	const toolTokens = (request.tools ?? []).reduce((sum, tool) => sum + estimateToolTokens(tool), 0);
+
+	return Math.max(0, REQUEST_OVERHEAD_TOKENS + systemTokens + messageTokens + toolTokens);
+}

--- a/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/process-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/process-manager.test.ts
@@ -363,6 +363,105 @@ describe('BridgeSession thread/tokenUsage/updated', () => {
 		expect(done?.cacheReadInputTokens).toBe(40);
 	});
 
+	it('captures token usage from upstream Codex v2 tokenUsage.last shape', async () => {
+		const { conn, fireNotification } = makeEventableStubConn();
+		const session = new BridgeSession(conn, 'test-model', [], '/tmp');
+		await session.initialize();
+
+		setTimeout(() => {
+			fireNotification('thread/tokenUsage/updated', {
+				threadId: 'thread-1',
+				turnId: 'turn-1',
+				tokenUsage: {
+					total: {
+						totalTokens: 1500,
+						inputTokens: 1100,
+						cachedInputTokens: 100,
+						outputTokens: 200,
+						reasoningOutputTokens: 50,
+					},
+					last: {
+						totalTokens: 700,
+						inputTokens: 540,
+						cachedInputTokens: 40,
+						outputTokens: 80,
+						reasoningOutputTokens: 20,
+					},
+					modelContextWindow: 200000,
+				},
+			});
+			fireNotification('turn/completed', {
+				threadId: 'thread-1',
+				turn: { id: 'turn-1', items: [], status: 'completed', error: null },
+			});
+		}, 5);
+
+		const gen = session.startTurn('test');
+		const events: import('../../../../../src/lib/providers/codex-anthropic-bridge/process-manager').BridgeEvent[] =
+			[];
+		for await (const event of gen) {
+			events.push(event);
+		}
+
+		const done = events.find((e) => e.type === 'turn_done') as
+			| {
+					type: 'turn_done';
+					inputTokens: number;
+					outputTokens: number;
+					cacheReadInputTokens?: number;
+			  }
+			| undefined;
+		expect(done?.inputTokens).toBe(540);
+		expect(done?.outputTokens).toBe(80);
+		expect(done?.cacheReadInputTokens).toBe(40);
+	});
+
+	it('falls back to upstream Codex v2 tokenUsage.total when last usage is absent', async () => {
+		const { conn, fireNotification } = makeEventableStubConn();
+		const session = new BridgeSession(conn, 'test-model', [], '/tmp');
+		await session.initialize();
+
+		setTimeout(() => {
+			fireNotification('thread/tokenUsage/updated', {
+				threadId: 'thread-1',
+				turnId: 'turn-1',
+				tokenUsage: {
+					total: {
+						totalTokens: 900,
+						inputTokens: 760,
+						cachedInputTokens: 60,
+						outputTokens: 100,
+						reasoningOutputTokens: 40,
+					},
+					modelContextWindow: 200000,
+				},
+			});
+			fireNotification('turn/completed', {
+				threadId: 'thread-1',
+				turn: { id: 'turn-1', items: [], status: 'completed', error: null },
+			});
+		}, 5);
+
+		const gen = session.startTurn('test');
+		const events: import('../../../../../src/lib/providers/codex-anthropic-bridge/process-manager').BridgeEvent[] =
+			[];
+		for await (const event of gen) {
+			events.push(event);
+		}
+
+		const done = events.find((e) => e.type === 'turn_done') as
+			| {
+					type: 'turn_done';
+					inputTokens: number;
+					outputTokens: number;
+					cacheReadInputTokens?: number;
+			  }
+			| undefined;
+		expect(done?.inputTokens).toBe(760);
+		expect(done?.outputTokens).toBe(100);
+		expect(done?.cacheReadInputTokens).toBe(60);
+	});
+
 	it('populates turn_done with actual token counts from thread/tokenUsage/updated', async () => {
 		const { conn, fireNotification } = makeEventableStubConn();
 		const session = new BridgeSession(conn, 'test-model', [], '/tmp');

--- a/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/process-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/process-manager.test.ts
@@ -287,6 +287,8 @@ describe('BridgeSession thread/tokenUsage/updated', () => {
 		expect((session as unknown as SessionInternals).latestUsage).toEqual({
 			inputTokens: 150,
 			outputTokens: 75,
+			cacheCreationInputTokens: 0,
+			cacheReadInputTokens: 0,
 		});
 	});
 
@@ -316,7 +318,49 @@ describe('BridgeSession thread/tokenUsage/updated', () => {
 		expect((session as unknown as SessionInternals).latestUsage).toEqual({
 			inputTokens: 200,
 			outputTokens: 100,
+			cacheCreationInputTokens: 0,
+			cacheReadInputTokens: 0,
 		});
+	});
+
+	it('captures token usage from snake_case tokenUsage shape with cache counters', async () => {
+		const { conn, fireNotification } = makeEventableStubConn();
+		const session = new BridgeSession(conn, 'test-model', [], '/tmp');
+		await session.initialize();
+
+		setTimeout(() => {
+			fireNotification('thread/tokenUsage/updated', {
+				threadId: 'thread-1',
+				tokenUsage: {
+					input_tokens: 240,
+					cached_input_tokens: 40,
+					output_tokens: 80,
+				},
+			});
+			fireNotification('turn/completed', {
+				threadId: 'thread-1',
+				turn: { id: 'turn-1', items: [], status: 'completed', error: null },
+			});
+		}, 5);
+
+		const gen = session.startTurn('test');
+		const events: import('../../../../../src/lib/providers/codex-anthropic-bridge/process-manager').BridgeEvent[] =
+			[];
+		for await (const event of gen) {
+			events.push(event);
+		}
+
+		const done = events.find((e) => e.type === 'turn_done') as
+			| {
+					type: 'turn_done';
+					inputTokens: number;
+					outputTokens: number;
+					cacheReadInputTokens?: number;
+			  }
+			| undefined;
+		expect(done?.inputTokens).toBe(240);
+		expect(done?.outputTokens).toBe(80);
+		expect(done?.cacheReadInputTokens).toBe(40);
 	});
 
 	it('populates turn_done with actual token counts from thread/tokenUsage/updated', async () => {

--- a/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/server.test.ts
@@ -966,6 +966,76 @@ describe('Bridge HTTP server', () => {
 		expect(usageOutputTokens).toBe(55);
 	});
 
+	it('drainToSSE sends estimated input_tokens at start and real Codex usage at turn end', async () => {
+		async function* usageGen(): AsyncGenerator<BridgeEvent> {
+			yield { type: 'text_delta', text: 'Hi' };
+			yield { type: 'turn_done', inputTokens: 120, outputTokens: 55 };
+		}
+
+		const mockSession = { kill: () => {} } as unknown as BridgeSession;
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				void drainToSSE(
+					usageGen(),
+					mockSession,
+					'test-model',
+					new Map(),
+					controller,
+					5000,
+					'test-session',
+					() => {},
+					undefined,
+					33
+				);
+			},
+		});
+
+		const events = await readSSEEvents(stream);
+		const msgStart = events.find((e) => e.event === 'message_start');
+		const startUsage = (msgStart?.data as { message?: { usage?: { input_tokens?: number } } })
+			?.message?.usage;
+		expect(startUsage?.input_tokens).toBe(33);
+
+		const msgDelta = events.find((e) => e.event === 'message_delta');
+		const deltaUsage = (
+			msgDelta?.data as { usage?: { input_tokens?: number; output_tokens?: number } }
+		)?.usage;
+		expect(deltaUsage?.input_tokens).toBe(120);
+		expect(deltaUsage?.output_tokens).toBe(55);
+	});
+
+	it('drainToSSE falls back to estimated input_tokens when Codex usage is unavailable', async () => {
+		async function* usageGen(): AsyncGenerator<BridgeEvent> {
+			yield { type: 'text_delta', text: 'fallback' };
+			yield { type: 'turn_done', inputTokens: 0, outputTokens: 0 };
+		}
+
+		const mockSession = { kill: () => {} } as unknown as BridgeSession;
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				void drainToSSE(
+					usageGen(),
+					mockSession,
+					'test-model',
+					new Map(),
+					controller,
+					5000,
+					'test-session',
+					() => {},
+					undefined,
+					44
+				);
+			},
+		});
+
+		const events = await readSSEEvents(stream);
+		const msgDelta = events.find((e) => e.event === 'message_delta');
+		const usage = (msgDelta?.data as { usage?: { input_tokens?: number; output_tokens?: number } })
+			?.usage;
+		expect(usage?.input_tokens).toBe(44);
+		expect(usage?.output_tokens).toBeGreaterThan(0);
+	});
+
 	it('message_delta falls back to heuristic outputTokens when turn_done has 0 tokens', async () => {
 		// Simulate no thread/tokenUsage/updated notification — turn_done carries 0 tokens
 		mockSessionFactory = () =>
@@ -1077,6 +1147,23 @@ describe('createAnthropicError', () => {
 	});
 });
 
+describe('daemon context path guard', () => {
+	it('keeps Codex-specific context fallback logic out of provider-agnostic daemon paths', async () => {
+		const guardedFiles = [
+			`${import.meta.dir}/../../../../../src/lib/agent/context-fetcher.ts`,
+			`${import.meta.dir}/../../../../../src/lib/agent/sdk-message-handler.ts`,
+			`${import.meta.dir}/../../../../../src/lib/agent/context-tracker.ts`,
+			`${import.meta.dir}/../../../../../src/lib/agent/sdk-runtime-config.ts`,
+		];
+
+		const contents = await Promise.all(guardedFiles.map((file) => Bun.file(file).text()));
+		for (const content of contents) {
+			expect(content).not.toContain('anthropic-codex');
+			expect(content).not.toContain('codex-anthropic-bridge');
+		}
+	});
+});
+
 // ---------------------------------------------------------------------------
 // Real createBridgeServer — HTTP error envelope integration tests
 // ---------------------------------------------------------------------------
@@ -1115,7 +1202,13 @@ describe('Bridge HTTP server — Anthropic JSON error envelopes', () => {
 		expect(resp.ok).toBe(true);
 		expect(resp.headers.get('content-type')).toContain('application/json');
 		const body = (await resp.json()) as {
-			data: Array<{ id: string; type: string; display_name: string }>;
+			data: Array<{
+				id: string;
+				type: string;
+				display_name: string;
+				max_input_tokens?: number;
+				model_context_window?: number;
+			}>;
 			has_more: boolean;
 			first_id: string;
 			last_id: string;
@@ -1135,16 +1228,20 @@ describe('Bridge HTTP server — Anthropic JSON error envelopes', () => {
 		expect(ids).toContain('gpt-5.5');
 		expect(ids).toContain('gpt-5.4-mini');
 		expect(ids).toContain('gpt-5.1-codex-mini');
+		const gpt55 = body.data.find((m) => m.id === 'gpt-5.5');
+		expect(gpt55?.max_input_tokens).toBe(200000);
+		expect(gpt55?.model_context_window).toBe(200000);
 		expect(body.first_id).toBe(ids[0]);
 		expect(body.last_id).toBe(ids[ids.length - 1]);
 	});
 
-	it('returns dummy token count for POST /v1/messages/count_tokens', async () => {
+	it('returns a meaningful non-zero token count for POST /v1/messages/count_tokens', async () => {
 		const resp = await fetch(`http://127.0.0.1:${realServer.port}/v1/messages/count_tokens`, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({
 				model: 'gpt-5.3-codex',
+				system: 'You are a concise coding assistant.',
 				messages: [{ role: 'user', content: 'hello' }],
 			}),
 		});
@@ -1152,9 +1249,60 @@ describe('Bridge HTTP server — Anthropic JSON error envelopes', () => {
 		expect(resp.headers.get('content-type')).toContain('application/json');
 		const body = (await resp.json()) as { input_tokens: number };
 		expect(typeof body.input_tokens).toBe('number');
+		expect(body.input_tokens).toBeGreaterThan(0);
 	});
 
-	it('returns dummy token count for POST /v1/messages/count_tokens?beta=true', async () => {
+	it('returns a larger token count as messages, tool schemas, and tool results grow', async () => {
+		const count = async (requestBody: unknown) => {
+			const resp = await fetch(`http://127.0.0.1:${realServer.port}/v1/messages/count_tokens`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(requestBody),
+			});
+			expect(resp.ok).toBe(true);
+			return ((await resp.json()) as { input_tokens: number }).input_tokens;
+		};
+
+		const small = await count({
+			model: 'gpt-5.3-codex',
+			messages: [{ role: 'user', content: 'hello' }],
+		});
+		const large = await count({
+			model: 'gpt-5.3-codex',
+			system: [{ type: 'text', text: 'Follow the repository conventions and explain failures.' }],
+			messages: [
+				{ role: 'user', content: 'hello' },
+				{ role: 'assistant', content: 'I can help with that.' },
+				{
+					role: 'user',
+					content: [
+						{ type: 'text', text: 'Run the formatter and summarize the output.' },
+						{
+							type: 'tool_result',
+							tool_use_id: 'toolu_1',
+							content: 'Formatted 24 files and left 2 files unchanged.',
+						},
+					],
+				},
+			],
+			tools: [
+				{
+					name: 'bash',
+					description: 'Run a shell command in the workspace',
+					input_schema: {
+						type: 'object',
+						properties: { command: { type: 'string' }, timeout_ms: { type: 'number' } },
+						required: ['command'],
+					},
+				},
+			],
+		});
+
+		expect(small).toBeGreaterThan(0);
+		expect(large).toBeGreaterThan(small);
+	});
+
+	it('returns token count for POST /v1/messages/count_tokens?beta=true', async () => {
 		const resp = await fetch(
 			`http://127.0.0.1:${realServer.port}/v1/messages/count_tokens?beta=true`,
 			{
@@ -1169,6 +1317,7 @@ describe('Bridge HTTP server — Anthropic JSON error envelopes', () => {
 		expect(resp.ok).toBe(true);
 		const body = (await resp.json()) as { input_tokens: number };
 		expect(typeof body.input_tokens).toBe('number');
+		expect(body.input_tokens).toBeGreaterThan(0);
 	});
 
 	it('returns 400 JSON envelope for invalid JSON body', async () => {


### PR DESCRIPTION
Fixes Codex context reporting in the Anthropic-compatible bridge by replacing zero count_tokens with a bridge-local deterministic estimate, sending estimated input usage at stream start, and preserving real app-server token usage at turn end. Adds bridge model context-window metadata and regression coverage that keeps daemon context paths provider-agnostic.

Tests:
- bun test --preload=./packages/daemon/tests/unit/setup.ts ./packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/server.test.ts
- bun test --preload=./packages/daemon/tests/unit/setup.ts ./packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/process-manager.test.ts
- bun test --preload=./packages/daemon/tests/unit/setup.ts ./packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/translator.test.ts
- bun run typecheck
- pre-commit: lint, format, typecheck, knip