### PR TITLE
[copilot] Report Copilot context usage from bridge

### DIFF
--- a/packages/daemon/src/lib/providers/anthropic-copilot/context-usage.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/context-usage.ts
@@ -1,0 +1,186 @@
+import { extractSystemText } from './prompt.js';
+import { estimateTokens } from './sse.js';
+import type { AnthropicRequest, AnthropicTool } from './types.js';
+
+export interface CopilotUsageInfoData {
+	conversationTokens?: number;
+	currentTokens: number;
+	isInitial?: boolean;
+	messagesLength: number;
+	systemTokens?: number;
+	tokenLimit: number;
+	toolDefinitionsTokens?: number;
+}
+
+export interface BridgeContextUsageSnapshot {
+	model: string;
+	systemTokens: number;
+	toolDefinitionsTokens: number;
+	conversationTokens: number;
+	totalTokens: number;
+	currentTokens: number;
+	promptTokenLimit: number;
+	limit: number;
+	freeSpaceTokens: number;
+	bufferTokens: number;
+	messagesLength: number;
+	updatedAt: number;
+}
+
+export interface BridgeCountTokensResponse {
+	input_tokens: number;
+	context: BridgeContextUsageSnapshot;
+}
+
+const DEFAULT_CONTEXT_WINDOW = 128_000;
+const DEFAULT_BUFFER_EXHAUSTION_THRESHOLD = 0.95;
+const MAX_DEFAULT_OUTPUT_TOKENS = 32_000;
+const MAX_OPUS_1M_OUTPUT_TOKENS = 64_000;
+
+function positiveInt(value: unknown): number | undefined {
+	if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;
+	return Math.max(0, Math.round(value));
+}
+
+function getBufferExhaustionThreshold(): number {
+	const raw = process.env.COPILOT_BUFFER_EXHAUSTION_THRESHOLD;
+	if (!raw) return DEFAULT_BUFFER_EXHAUSTION_THRESHOLD;
+	const parsed = Number.parseFloat(raw);
+	return Number.isFinite(parsed) ? parsed : DEFAULT_BUFFER_EXHAUSTION_THRESHOLD;
+}
+
+function outputTokenReserve(model: string, outputTokenLimit = 0): number {
+	const maxOutputTokens =
+		model === 'claude-opus-4.6-1m' ? MAX_OPUS_1M_OUTPUT_TOKENS : MAX_DEFAULT_OUTPUT_TOKENS;
+	return Math.min(maxOutputTokens, Math.max(0, outputTokenLimit));
+}
+
+export function computeCopilotBufferTokens(
+	model: string,
+	promptTokenLimit: number,
+	outputTokenLimit = 0
+): number {
+	const outputReserve = outputTokenReserve(model, outputTokenLimit);
+	const exhaustionReserve = Math.floor(
+		promptTokenLimit * Math.max(0, 1 - getBufferExhaustionThreshold())
+	);
+	return outputReserve + exhaustionReserve;
+}
+
+export function snapshotFromUsageInfo(
+	model: string,
+	data: CopilotUsageInfoData,
+	outputTokenLimit = 0
+): BridgeContextUsageSnapshot {
+	const systemTokens = positiveInt(data.systemTokens) ?? 0;
+	const toolDefinitionsTokens = positiveInt(data.toolDefinitionsTokens) ?? 0;
+	const currentTokens = positiveInt(data.currentTokens) ?? 0;
+	const conversationTokens =
+		positiveInt(data.conversationTokens) ??
+		Math.max(0, currentTokens - systemTokens - toolDefinitionsTokens);
+	const promptTokenLimit = positiveInt(data.tokenLimit) ?? DEFAULT_CONTEXT_WINDOW;
+	const bufferTokens = computeCopilotBufferTokens(model, promptTokenLimit, outputTokenLimit);
+	const limit = promptTokenLimit + outputTokenReserve(model, outputTokenLimit);
+	const totalTokens =
+		currentTokens > 0 ? currentTokens : systemTokens + toolDefinitionsTokens + conversationTokens;
+	const freeSpaceTokens = Math.max(
+		0,
+		limit - systemTokens - toolDefinitionsTokens - conversationTokens - bufferTokens
+	);
+
+	return {
+		model,
+		systemTokens,
+		toolDefinitionsTokens,
+		conversationTokens,
+		totalTokens,
+		currentTokens: totalTokens,
+		promptTokenLimit,
+		limit,
+		freeSpaceTokens,
+		bufferTokens,
+		messagesLength: positiveInt(data.messagesLength) ?? 0,
+		updatedAt: Date.now(),
+	};
+}
+
+function toolText(tools: AnthropicTool[] | undefined): string {
+	if (!tools || tools.length === 0) return '';
+	return JSON.stringify(
+		tools.map((tool) => ({
+			name: tool.name,
+			description: tool.description ?? '',
+			input_schema: tool.input_schema ?? {},
+		}))
+	);
+}
+
+export function estimateRequestUsage(body: AnthropicRequest): BridgeContextUsageSnapshot {
+	const systemText = extractSystemText(body.system) ?? '';
+	const systemTokens = estimateTokens(systemText.length);
+	const toolDefinitionsTokens = estimateTokens(toolText(body.tools).length);
+	const conversationTokens = estimateTokens(JSON.stringify(body.messages).length);
+	const promptTokenLimit = DEFAULT_CONTEXT_WINDOW;
+	const outputTokenLimit = positiveInt(body.max_tokens) ?? 0;
+	const bufferTokens = computeCopilotBufferTokens(body.model, promptTokenLimit, outputTokenLimit);
+	const limit = promptTokenLimit + outputTokenReserve(body.model, outputTokenLimit);
+	const totalTokens = systemTokens + toolDefinitionsTokens + conversationTokens;
+
+	return {
+		model: body.model,
+		systemTokens,
+		toolDefinitionsTokens,
+		conversationTokens,
+		totalTokens,
+		currentTokens: totalTokens,
+		promptTokenLimit,
+		limit,
+		freeSpaceTokens: Math.max(
+			0,
+			limit - systemTokens - toolDefinitionsTokens - conversationTokens - bufferTokens
+		),
+		bufferTokens,
+		messagesLength: body.messages.length,
+		updatedAt: Date.now(),
+	};
+}
+
+export class ContextUsageStore {
+	private readonly bySession = new WeakMap<object, BridgeContextUsageSnapshot>();
+	private readonly byRequestKey = new Map<string, BridgeContextUsageSnapshot>();
+
+	updateForSession(
+		session: object,
+		requestKey: string,
+		model: string,
+		data: CopilotUsageInfoData,
+		outputTokenLimit = 0
+	): BridgeContextUsageSnapshot {
+		const snapshot = snapshotFromUsageInfo(model, data, outputTokenLimit);
+		this.bySession.set(session, snapshot);
+		this.byRequestKey.set(requestKey, snapshot);
+		return snapshot;
+	}
+
+	getForSession(session: object): BridgeContextUsageSnapshot | undefined {
+		return this.bySession.get(session);
+	}
+
+	getForRequestKey(requestKey: string): BridgeContextUsageSnapshot | undefined {
+		return this.byRequestKey.get(requestKey);
+	}
+
+	deleteRequestKey(requestKey: string): void {
+		this.byRequestKey.delete(requestKey);
+	}
+}
+
+export function countTokensResponse(
+	tokenSnapshot: BridgeContextUsageSnapshot,
+	contextSnapshot: BridgeContextUsageSnapshot = tokenSnapshot
+): BridgeCountTokensResponse {
+	return {
+		input_tokens: Math.max(1, tokenSnapshot.totalTokens),
+		context: contextSnapshot,
+	};
+}

--- a/packages/daemon/src/lib/providers/anthropic-copilot/server.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/server.ts
@@ -32,11 +32,17 @@
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { isAbsolute, normalize } from 'node:path';
-import { approveAll, type CopilotClient, type SessionConfig } from '@github/copilot-sdk';
-import { isAnthropicRequest, type AnthropicRequest } from './types.js';
+import {
+	approveAll,
+	type CopilotClient,
+	type ModelInfo,
+	type SessionConfig,
+} from '@github/copilot-sdk';
+import { isAnthropicRequest, type AnthropicMessage, type AnthropicRequest } from './types.js';
 import { formatAnthropicPrompt, extractSystemText, extractToolResultIds } from './prompt.js';
 import { ConversationManager } from './conversation.js';
 import { runSessionStreaming, resumeSessionStreaming } from './streaming.js';
+import { ContextUsageStore, countTokensResponse, estimateRequestUsage } from './context-usage.js';
 import { Logger } from '../../logger.js';
 import { type AnthropicErrorType, createAnthropicErrorBody } from '../shared/error-envelope.js';
 
@@ -44,6 +50,27 @@ const logger = new Logger('anthropic-copilot-server');
 
 /** Maximum request body size (10 MB). */
 const MAX_BODY_BYTES = 10 * 1024 * 1024;
+
+const FALLBACK_MODELS = [
+	{ id: 'claude-opus-4.6', display_name: 'Claude Opus 4.6', max_input_tokens: 200000 },
+	{ id: 'claude-sonnet-4.6', display_name: 'Claude Sonnet 4.6', max_input_tokens: 200000 },
+	{ id: 'gpt-5.3-codex', display_name: 'GPT-5.3 Codex', max_input_tokens: 272000 },
+	{ id: 'gpt-5-mini', display_name: 'GPT-5 Mini', max_input_tokens: 128000 },
+	{
+		id: 'gemini-3.1-pro-preview',
+		display_name: 'Gemini 3.1 Pro Preview',
+		max_input_tokens: 128000,
+	},
+] as const;
+
+interface CountTokensRequest {
+	model: string;
+	messages: AnthropicMessage[];
+	max_tokens?: number;
+	system?: AnthropicRequest['system'];
+	tools?: AnthropicRequest['tools'];
+	tool_choice?: AnthropicRequest['tool_choice'];
+}
 
 // ---------------------------------------------------------------------------
 // HTTP helpers
@@ -81,6 +108,42 @@ function sendJsonError(
 ): void {
 	res.writeHead(status, { 'Content-Type': 'application/json' });
 	res.end(createAnthropicErrorBody(type, message));
+}
+
+function sendJson(res: ServerResponse, status: number, body: object): void {
+	res.writeHead(status, { 'Content-Type': 'application/json' });
+	res.end(JSON.stringify(body));
+}
+
+function requestUsageKey(req: IncomingMessage, cwd: string, model: string): string {
+	return `${resolveRequestCwd(req, cwd)}:${model}`;
+}
+
+function isCountTokensRequest(body: unknown): body is CountTokensRequest {
+	if (typeof body !== 'object' || body === null) return false;
+	const b = body as Record<string, unknown>;
+	return typeof b['model'] === 'string' && Array.isArray(b['messages']);
+}
+
+function toAnthropicModel(model: ModelInfo): object {
+	return {
+		id: model.id,
+		type: 'model',
+		display_name: model.name,
+		created_at: '2026-01-01T00:00:00Z',
+		max_input_tokens: model.capabilities?.limits?.max_context_window_tokens ?? 128000,
+		max_tokens: model.capabilities?.limits?.max_prompt_tokens ?? 16384,
+	};
+}
+
+function modelsListResponse(models: object[]): object {
+	const data = models.length > 0 ? models : FALLBACK_MODELS.map((m) => ({ ...m, type: 'model' }));
+	return {
+		data,
+		has_more: false,
+		first_id: (data[0] as { id: string }).id,
+		last_id: (data[data.length - 1] as { id: string }).id,
+	};
 }
 
 // ---------------------------------------------------------------------------
@@ -171,6 +234,7 @@ async function handleMessages(
 	res: ServerResponse,
 	client: CopilotClient,
 	manager: ConversationManager,
+	contextUsageStore: ContextUsageStore,
 	cwd: string
 ): Promise<void> {
 	// 1. Read and parse body.
@@ -227,6 +291,7 @@ async function handleMessages(
 		const continuation = manager.findContinuation(body.messages);
 		if (continuation) {
 			const { conv, toolResults } = continuation;
+			const usageKey = requestUsageKey(req, cwd, body.model);
 			// Remove routing entries and cancel the TTL timer before resuming.
 			// Actual Promise resolution happens inside resumeSessionStreaming.
 			manager.acknowledgeContinuation(
@@ -253,7 +318,12 @@ async function handleMessages(
 					// Heuristic input_tokens for the continuation turn: the full
 					// conversation history (system + all messages including tool results)
 					// is re-serialised on every request, so we use that as the input text.
-					(extractSystemText(body.system) ?? '') + formatAnthropicPrompt(body.messages)
+					(extractSystemText(body.system) ?? '') + formatAnthropicPrompt(body.messages),
+					{
+						store: contextUsageStore,
+						requestKey: usageKey,
+						outputTokenLimit: body.max_tokens,
+					}
 				);
 				if (outcome.kind === 'completed') {
 					// streamSession already called session.disconnect() — use
@@ -302,12 +372,22 @@ async function handleMessages(
 			body,
 			client,
 			manager,
+			contextUsageStore,
 			systemMessage,
 			prompt,
 			requestCwd
 		);
 	} else {
-		await handlePlainRequest(req, res, body, client, systemMessage, prompt, requestCwd);
+		await handlePlainRequest(
+			req,
+			res,
+			body,
+			client,
+			contextUsageStore,
+			systemMessage,
+			prompt,
+			requestCwd
+		);
 	}
 }
 
@@ -321,6 +401,7 @@ async function handleNewToolConversation(
 	body: AnthropicRequest,
 	client: CopilotClient,
 	manager: ConversationManager,
+	contextUsageStore: ContextUsageStore,
 	systemMessage: string | undefined,
 	prompt: string,
 	cwd: string
@@ -348,7 +429,12 @@ async function handleNewToolConversation(
 			res,
 			conv.registry,
 			() => {},
-			(systemMessage ?? '') + prompt
+			(systemMessage ?? '') + prompt,
+			{
+				store: contextUsageStore,
+				requestKey: requestUsageKey(req, cwd, body.model),
+				outputTokenLimit: body.max_tokens,
+			}
 		);
 		if (outcome.kind === 'completed') {
 			// streamSession already called session.disconnect() — use
@@ -376,6 +462,7 @@ async function handlePlainRequest(
 	res: ServerResponse,
 	body: AnthropicRequest,
 	client: CopilotClient,
+	contextUsageStore: ContextUsageStore,
 	systemMessage: string | undefined,
 	prompt: string,
 	cwd: string
@@ -405,7 +492,12 @@ async function handlePlainRequest(
 			res,
 			undefined,
 			() => {},
-			(systemMessage ?? '') + prompt
+			(systemMessage ?? '') + prompt,
+			{
+				store: contextUsageStore,
+				requestKey: requestUsageKey(req, cwd, body.model),
+				outputTokenLimit: body.max_tokens,
+			}
 		);
 	} catch (err) {
 		logger.error('Streaming failed:', err);
@@ -415,6 +507,66 @@ async function handlePlainRequest(
 		if (!res.headersSent) {
 			sendJsonError(res, 500, 'api_error', err instanceof Error ? err.message : 'Internal error');
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic compatibility endpoints used by Claude Agent SDK context retrieval
+// ---------------------------------------------------------------------------
+
+async function handleCountTokens(
+	req: IncomingMessage,
+	res: ServerResponse,
+	contextUsageStore: ContextUsageStore,
+	cwd: string
+): Promise<void> {
+	let bodyText: string;
+	try {
+		bodyText = await readBody(req);
+	} catch (err) {
+		const status = (err as { code?: number }).code === 413 ? 413 : 400;
+		sendJsonError(
+			res,
+			status,
+			status === 413 ? 'request_too_large' : 'invalid_request_error',
+			status === 413 ? 'Request body exceeds 10 MB limit' : 'Failed to read request body'
+		);
+		return;
+	}
+
+	let body: unknown;
+	try {
+		body = JSON.parse(bodyText);
+	} catch {
+		sendJsonError(res, 400, 'invalid_request_error', 'Request body must be valid JSON');
+		return;
+	}
+
+	if (!isCountTokensRequest(body)) {
+		sendJsonError(res, 400, 'invalid_request_error', 'Missing required fields: model, messages');
+		return;
+	}
+
+	const usageKey = requestUsageKey(req, cwd, body.model);
+	const estimated = estimateRequestUsage({
+		model: body.model,
+		max_tokens: body.max_tokens ?? 0,
+		messages: body.messages,
+		system: body.system,
+		tools: body.tools,
+		tool_choice: body.tool_choice,
+	});
+	const latest = contextUsageStore.getForRequestKey(usageKey);
+	sendJson(res, 200, countTokensResponse(estimated, latest ?? estimated));
+}
+
+async function handleModels(res: ServerResponse, client: CopilotClient): Promise<void> {
+	try {
+		const models = await client.listModels();
+		sendJson(res, 200, modelsListResponse(models.map(toAnthropicModel)));
+	} catch (err) {
+		logger.warn('Failed to list Copilot models for /v1/models; using fallback metadata:', err);
+		sendJson(res, 200, modelsListResponse([]));
 	}
 }
 
@@ -444,14 +596,38 @@ export function startEmbeddedServer(
 	cwd = process.cwd()
 ): Promise<EmbeddedServer> {
 	const manager = new ConversationManager();
+	const contextUsageStore = new ContextUsageStore();
 
 	const server: Server = createServer((req: IncomingMessage, res: ServerResponse) => {
 		const url = req.url ?? '';
 		const method = req.method ?? '';
 
 		if (method === 'POST' && (url === '/v1/messages' || url.startsWith('/v1/messages?'))) {
-			handleMessages(req, res, client, manager, cwd).catch((err: unknown) => {
+			handleMessages(req, res, client, manager, contextUsageStore, cwd).catch((err: unknown) => {
 				logger.error('Unhandled error in handleMessages:', err);
+				if (!res.headersSent) {
+					sendJsonError(res, 500, 'api_error', 'Internal server error');
+				}
+			});
+			return;
+		}
+
+		if (
+			method === 'POST' &&
+			(url === '/v1/messages/count_tokens' || url.startsWith('/v1/messages/count_tokens?'))
+		) {
+			handleCountTokens(req, res, contextUsageStore, cwd).catch((err: unknown) => {
+				logger.error('Unhandled error in handleCountTokens:', err);
+				if (!res.headersSent) {
+					sendJsonError(res, 500, 'api_error', 'Internal server error');
+				}
+			});
+			return;
+		}
+
+		if (method === 'GET' && (url === '/v1/models' || url.startsWith('/v1/models?'))) {
+			handleModels(res, client).catch((err: unknown) => {
+				logger.error('Unhandled error in handleModels:', err);
 				if (!res.headersSent) {
 					sendJsonError(res, 500, 'api_error', 'Internal server error');
 				}

--- a/packages/daemon/src/lib/providers/anthropic-copilot/sse.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/sse.ts
@@ -69,6 +69,12 @@ export class AnthropicStreamWriter {
 		this.inputTokens = inputTokens;
 	}
 
+	updateInputTokens(inputTokens: number): void {
+		if (Number.isFinite(inputTokens) && inputTokens > 0) {
+			this.inputTokens = Math.round(inputTokens);
+		}
+	}
+
 	hasStarted(): boolean {
 		return this.streamStarted;
 	}
@@ -113,7 +119,7 @@ export class AnthropicStreamWriter {
 			delta: { stop_reason: stopReason, stop_sequence: null },
 			usage: {
 				output_tokens: estimateTokens(this.outputCharCount),
-				input_tokens: 0,
+				input_tokens: this.inputTokens,
 				cache_read_input_tokens: 0,
 				cache_creation_input_tokens: 0,
 			},

--- a/packages/daemon/src/lib/providers/anthropic-copilot/streaming.ts
+++ b/packages/daemon/src/lib/providers/anthropic-copilot/streaming.ts
@@ -33,6 +33,7 @@ import type { CopilotSession, SessionEvent } from '@github/copilot-sdk';
 import type { ToolBridgeRegistry } from './tool-bridge.js';
 import type { ToolResult } from './conversation.js';
 import { AnthropicStreamWriter, estimateTokens } from './sse.js';
+import type { ContextUsageStore, CopilotUsageInfoData } from './context-usage.js';
 import { type AnthropicErrorType, createAnthropicErrorBody } from '../shared/error-envelope.js';
 import { Logger } from '../../logger.js';
 
@@ -57,6 +58,12 @@ export type StreamingOutcome =
 	 * these IDs — the caller does not need to enumerate them.
 	 */
 	| { kind: 'tool_use'; toolCallIds: string[] };
+
+export interface StreamingContextUsageOptions {
+	store: ContextUsageStore;
+	requestKey: string;
+	outputTokenLimit?: number;
+}
 
 function classifyError(message: string): { status: number; type: AnthropicErrorType } {
 	const status = Number(message.match(/\b([45]\d{2})\b/)?.[1] ?? 500);
@@ -108,7 +115,8 @@ function streamSession(
 	startFn: (finish: () => void, writeFailed: () => void) => void,
 	onDone: () => void,
 	/** Raw input text used for heuristic token estimation (system prompt + formatted messages). */
-	inputText = ''
+	inputText = '',
+	contextUsage?: StreamingContextUsageOptions
 ): Promise<StreamingOutcome> {
 	const writer = new AnthropicStreamWriter();
 	writer.configure(model, estimateTokens(inputText.length));
@@ -172,6 +180,18 @@ function streamSession(
 				}
 				flushDeltas();
 				break;
+
+			case 'session.usage_info': {
+				const snapshot = contextUsage?.store.updateForSession(
+					session as object,
+					contextUsage.requestKey,
+					model,
+					event.data as CopilotUsageInfoData,
+					contextUsage.outputTokenLimit
+				);
+				if (snapshot) writer.updateInputTokens(snapshot.totalTokens);
+				break;
+			}
 
 			case 'session.idle':
 				flushDeltas();
@@ -283,7 +303,8 @@ export function runSessionStreaming(
 	registry?: ToolBridgeRegistry,
 	onDone: () => void = () => {},
 	/** Raw input text (system prompt + formatted messages) for heuristic token estimation. */
-	inputText = ''
+	inputText = '',
+	contextUsage?: StreamingContextUsageOptions
 ): Promise<StreamingOutcome> {
 	return streamSession(
 		session,
@@ -303,7 +324,8 @@ export function runSessionStreaming(
 			});
 		},
 		onDone,
-		inputText
+		inputText,
+		contextUsage
 	);
 }
 
@@ -322,7 +344,8 @@ export function resumeSessionStreaming(
 	toolResults: ToolResult[],
 	onDone: () => void = () => {},
 	/** Raw input text (system prompt + full message history) for heuristic token estimation. */
-	inputText = ''
+	inputText = '',
+	contextUsage?: StreamingContextUsageOptions
 ): Promise<StreamingOutcome> {
 	return streamSession(
 		session,
@@ -338,6 +361,7 @@ export function resumeSessionStreaming(
 			}
 		},
 		onDone,
-		inputText
+		inputText,
+		contextUsage
 	);
 }

--- a/packages/daemon/tests/unit/1-core/providers/anthropic-copilot/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/anthropic-copilot/server.test.ts
@@ -11,6 +11,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import { EventEmitter } from 'node:events';
+import { readFileSync } from 'node:fs';
 import type { CopilotClient, CopilotSession } from '@github/copilot-sdk';
 import {
 	startEmbeddedServer,
@@ -111,6 +112,18 @@ function makeMockClient(
 			mock.lastSession = s;
 			return s as unknown as CopilotSession;
 		},
+		async listModels() {
+			return [
+				{
+					id: 'gpt-5-mini',
+					name: 'GPT-5 Mini',
+					capabilities: {
+						supports: { vision: false, reasoningEffort: true },
+						limits: { max_context_window_tokens: 160000, max_prompt_tokens: 32000 },
+					},
+				},
+			];
+		},
 	};
 	return mock as unknown as CopilotClient & { lastSession?: MockCopilotSession };
 }
@@ -149,6 +162,21 @@ async function postMessages(
 	return { status: resp.status, events };
 }
 
+async function postCountTokens(
+	url: string,
+	body: object
+): Promise<{
+	status: number;
+	body: Record<string, unknown>;
+}> {
+	const resp = await fetch(`${url}/v1/messages/count_tokens`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body),
+	});
+	return { status: resp.status, body: (await resp.json()) as Record<string, unknown> };
+}
+
 // ---------------------------------------------------------------------------
 // startEmbeddedServer — integration tests
 // ---------------------------------------------------------------------------
@@ -183,6 +211,73 @@ describe('startEmbeddedServer', () => {
 		const resp = await fetch(`${serverUrl}/health`);
 		expect(resp.status).toBe(200);
 		expect(((await resp.json()) as Record<string, unknown>)['ok']).toBe(true);
+	});
+
+	it('models endpoint returns Anthropic-compatible model metadata', async () => {
+		const resp = await fetch(`${serverUrl}/v1/models`);
+		expect(resp.status).toBe(200);
+		const body = (await resp.json()) as Record<string, unknown>;
+		const data = body['data'] as Array<Record<string, unknown>>;
+		expect(data[0]['id']).toBe('gpt-5-mini');
+		expect(data[0]['type']).toBe('model');
+		expect(data[0]['max_input_tokens']).toBe(160000);
+	});
+
+	it('count_tokens returns non-zero values that grow with system, messages, tools, and tool results', async () => {
+		const base = await postCountTokens(serverUrl, {
+			model: 'gpt-5-mini',
+			messages: [{ role: 'user', content: 'hi' }],
+		});
+		const richer = await postCountTokens(serverUrl, {
+			model: 'gpt-5-mini',
+			system: 'Use concise answers and inspect tool output carefully.',
+			messages: [
+				{ role: 'user', content: 'hi' },
+				{
+					role: 'user',
+					content: [
+						{
+							type: 'tool_result',
+							tool_use_id: 'tu_1',
+							content: 'a fairly long tool result that should increase token estimates',
+						},
+					],
+				},
+			],
+			tools: [
+				{
+					name: 'bash',
+					description: 'Run shell commands',
+					input_schema: { type: 'object', properties: { command: { type: 'string' } } },
+				},
+			],
+		});
+
+		expect(base.status).toBe(200);
+		expect(richer.status).toBe(200);
+		expect(base.body['input_tokens']).toBeGreaterThan(0);
+		expect(richer.body['input_tokens']).toBeGreaterThan(base.body['input_tokens'] as number);
+		const context = richer.body['context'] as Record<string, unknown>;
+		expect(context['systemTokens']).toBeGreaterThan(0);
+		expect(context['toolDefinitionsTokens']).toBeGreaterThan(0);
+		expect(context['conversationTokens']).toBeGreaterThan(0);
+		expect(context['freeSpaceTokens']).toBeGreaterThan(0);
+		expect(context['bufferTokens']).toBeGreaterThan(0);
+	});
+
+	it('keeps Copilot context integration out of daemon and UI context retrieval paths', () => {
+		const files = [
+			'packages/daemon/src/lib/agent/context-fetcher.ts',
+			'packages/daemon/src/lib/agent/context-tracker.ts',
+			'packages/web/src/components/ContextUsageBar.tsx',
+			'packages/web/src/islands/ContextPanel.tsx',
+		];
+
+		for (const file of files) {
+			const source = readFileSync(file, 'utf8');
+			expect(source).not.toContain('anthropic-copilot');
+			expect(source.toLowerCase()).not.toContain('copilot');
+		}
 	});
 
 	it('returns 404 for unknown paths', async () => {
@@ -357,6 +452,46 @@ describe('startEmbeddedServer', () => {
 		const start = r.events.find((e) => e.type === 'message_start');
 		const msg = (start!.data as Record<string, unknown>)['message'] as Record<string, unknown>;
 		expect(msg['model']).toBe('claude-sonnet-4.6');
+	});
+
+	it('surfaces SDK usage_info through final SSE usage and later count_tokens responses', async () => {
+		session.send = async function (opts) {
+			this.capturedPrompt = opts.prompt;
+			Promise.resolve().then(() => {
+				this.emit('session.usage_info', {
+					currentTokens: 18000,
+					tokenLimit: 160000,
+					messagesLength: 4,
+					systemTokens: 2500,
+					toolDefinitionsTokens: 1500,
+					conversationTokens: 14000,
+				});
+				this.emit('assistant.message_delta', { deltaContent: 'Done' });
+				this.emit('assistant.message', { content: 'Done' });
+				this.emit('session.idle', {});
+			});
+			return 'send-result';
+		};
+
+		const request = {
+			model: 'gpt-5-mini',
+			max_tokens: 100,
+			messages: [{ role: 'user', content: 'hello' }],
+		};
+		const r = await postMessages(serverUrl, request);
+		const msgDelta = r.events.find((e) => e.type === 'message_delta');
+		const usage = (msgDelta!.data as Record<string, unknown>)['usage'] as Record<string, unknown>;
+		expect(usage['input_tokens']).toBe(18000);
+
+		const counted = await postCountTokens(serverUrl, request);
+		expect(counted.body['input_tokens']).toBeGreaterThan(0);
+		expect(counted.body['input_tokens']).toBeLessThan(18000);
+		const context = counted.body['context'] as Record<string, unknown>;
+		expect(context['totalTokens']).toBe(18000);
+		expect(context['systemTokens']).toBe(2500);
+		expect(context['toolDefinitionsTokens']).toBe(1500);
+		expect(context['conversationTokens']).toBe(14000);
+		expect(context['promptTokenLimit']).toBe(160000);
 	});
 
 	it('extracts string system message and passes to session config', async () => {

--- a/packages/daemon/tests/unit/1-core/providers/anthropic-copilot/streaming.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/anthropic-copilot/streaming.test.ts
@@ -16,6 +16,7 @@ import {
 	STREAMING_TIMEOUT_MS,
 } from '../../../../../src/lib/providers/anthropic-copilot/streaming';
 import { estimateTokens } from '../../../../../src/lib/providers/anthropic-copilot/sse';
+import { ContextUsageStore } from '../../../../../src/lib/providers/anthropic-copilot/context-usage';
 import { ToolBridgeRegistry } from '../../../../../src/lib/providers/anthropic-copilot/tool-bridge';
 
 // ---------------------------------------------------------------------------
@@ -414,6 +415,50 @@ describe('runSessionStreaming — inputText / input_tokens', () => {
 			'usage'
 		] as Record<string, unknown>;
 		expect(usage['input_tokens']).toBe(0);
+	});
+
+	it('consumes session.usage_info and uses it for final input_tokens', async () => {
+		const session = new MockSession();
+		const { written, res } = makeMockRes();
+		const { req } = makeMockReq();
+		const store = new ContextUsageStore();
+
+		const p = runSessionStreaming(
+			session as unknown as CopilotSession,
+			'prompt',
+			'gpt-5-mini',
+			req,
+			res,
+			undefined,
+			() => {},
+			'heuristic input',
+			{ store, requestKey: '/tmp:gpt-5-mini', outputTokenLimit: 100 }
+		);
+		await Promise.resolve();
+		session.emit('session.usage_info', {
+			currentTokens: 18_000,
+			tokenLimit: 160_000,
+			messagesLength: 12,
+			systemTokens: 3_000,
+			toolDefinitionsTokens: 2_000,
+			conversationTokens: 13_000,
+		});
+		session.emit('assistant.message_delta', { deltaContent: 'done' });
+		session.emit('session.idle');
+		await p;
+
+		const snapshot = store.getForRequestKey('/tmp:gpt-5-mini');
+		expect(snapshot?.systemTokens).toBe(3_000);
+		expect(snapshot?.toolDefinitionsTokens).toBe(2_000);
+		expect(snapshot?.conversationTokens).toBe(13_000);
+		expect(snapshot?.totalTokens).toBe(18_000);
+		expect(snapshot?.promptTokenLimit).toBe(160_000);
+		expect(snapshot?.bufferTokens).toBeGreaterThan(0);
+
+		const events = parseEvents(written);
+		const delta = events.find((e) => e.type === 'message_delta');
+		const usage = (delta!.data as Record<string, unknown>)['usage'] as Record<string, unknown>;
+		expect(usage['input_tokens']).toBe(18_000);
 	});
 });
 

--- a/packages/daemon/tests/unit/1-core/providers/anthropic-copilot/token-accounting.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/anthropic-copilot/token-accounting.test.ts
@@ -225,4 +225,17 @@ describe('message_delta output_tokens', () => {
 		// ceil(11/4) = 3
 		expect(usage['output_tokens']).toBe(3);
 	});
+
+	it('message_delta preserves the best known input_tokens value', () => {
+		const { written, res } = makeRes();
+		const writer = new AnthropicStreamWriter();
+		writer.start(res, 'model', 12);
+		writer.updateInputTokens(345);
+		writer.flushDeltas(res, ['hello']);
+		writer.sendCompleted(res);
+		const events = parseEvents(written);
+		const delta = events.find((e) => e.type === 'message_delta');
+		const usage = (delta!.data as Record<string, unknown>)['usage'] as Record<string, unknown>;
+		expect(usage['input_tokens']).toBe(345);
+	});
 });


### PR DESCRIPTION
Consume Copilot SDK `session.usage_info` events in the bridge to provide accurate context/token reporting through the Anthropic-compatible wire format, without touching daemon context retrieval or UI.

**What changed:**

- **`context-usage.ts`** (new) — bridge-owned module that snapshots Copilot `usage_info` fields (`systemTokens`, `toolDefinitionsTokens`, `conversationTokens`, `currentTokens`, `tokenLimit`) into `BridgeContextUsageSnapshot` objects. Includes a `ContextUsageStore` keyed by session/request, `estimateRequestUsage()` for `/count_tokens`, and `countTokensResponse()` builder.
- **`streaming.ts`** — subscribes to `session.usage_info` events; updates the store and calls `writer.updateInputTokens()` so the final `message_delta` carries real Copilot-reported input tokens instead of resetting to 0.
- **`sse.ts`** — added `updateInputTokens()` method to `AnthropicStreamWriter` so mid-stream usage updates are reflected in the epilogue.
- **`server.ts`** — added `POST /v1/messages/count_tokens` (returns request-scoped estimate + latest Copilot context snapshot) and `GET /v1/models` (returns Anthropic-compatible model metadata from `client.listModels()` with fallback list).

**What did NOT change:**

- No daemon `ContextFetcher`, `context-tracker`, UI `ContextUsageBar`, or `ContextPanel` modifications. The bridge is the sole integration boundary.
- No provider-specific fallback logic anywhere outside the bridge.

**Tests (240 pass across 10 files):**

- `session.usage_info` updates are consumed, stored, and surfaced in SSE `message_delta`
- `/count_tokens` returns non-zero values that grow with system/messages/tools/tool results
- `/models` returns Anthropic-compatible metadata with `max_input_tokens`
- Final SSE usage does not reset `input_tokens` to zero after Copilot context is known
- Daemon context files contain no Copilot-specific imports