### PR TITLE
Fix space task thread scroll padding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,11 @@ cd packages/daemon && bun test tests/unit/some-test.test.ts
 cd packages/web && bunx vitest run src/some-test.test.ts
 make run-e2e TEST=tests/features/some-test.e2e.ts
 
+# E2E coverage
+# Do not add or update e2e tests for ordinary code changes unless the task
+# explicitly asks for e2e coverage. Prefer focused unit/component tests for
+# scoped UI behavior changes.
+
 # Quality checks
 bun run check             # All checks: lint + typecheck + knip
 bun run lint              # Oxlint

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -862,6 +862,13 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 												: 'pb-44 sm:pb-36'
 											: 'pb-3'
 									}
+									bottomScrollPaddingClass={
+										showInlineComposer
+											? threadSendError
+												? 'scroll-pb-52 sm:scroll-pb-44'
+												: 'scroll-pb-44 sm:scroll-pb-36'
+											: 'scroll-pb-3'
+									}
 									activeAgentLabels={activeAgentLabels}
 									autoScrollEnabled={autoScrollEnabled}
 									onShowScrollButtonChange={setShowScrollButton}

--- a/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
+++ b/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
@@ -7,6 +7,7 @@ import { parseThreadRow } from './thread/space-task-thread-events';
 interface SpaceTaskUnifiedThreadProps {
 	taskId: string;
 	bottomInsetClass?: string;
+	bottomScrollPaddingClass?: string;
 	/**
 	 * Top padding applied to the scroll container so the first message clears
 	 * any floating overlay (e.g. SpaceTaskPane's tab pill) at scroll-top. Older
@@ -31,6 +32,7 @@ interface SpaceTaskUnifiedThreadProps {
 export function SpaceTaskUnifiedThread({
 	taskId,
 	bottomInsetClass = 'pb-3',
+	bottomScrollPaddingClass = 'scroll-pb-3',
 	topInsetClass = '',
 	activeAgentLabels,
 	autoScrollEnabled = true,
@@ -99,7 +101,10 @@ export function SpaceTaskUnifiedThread({
 
 	return (
 		<div class="h-full min-h-0 flex flex-col relative" data-testid="space-task-unified-thread">
-			<div ref={containerRef} class={`flex-1 overflow-y-auto ${topInsetClass} ${bottomInsetClass}`}>
+			<div
+				ref={containerRef}
+				class={`flex-1 overflow-y-auto ${topInsetClass} ${bottomInsetClass} ${bottomScrollPaddingClass}`}
+			>
 				<div class="min-h-[calc(100%+1px)]">
 					<MinimalThreadFeed
 						parsedRows={parsedRows}

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -144,16 +144,19 @@ vi.mock('../SpaceTaskUnifiedThread', () => ({
 		taskId,
 		topInsetClass,
 		bottomInsetClass,
+		bottomScrollPaddingClass,
 	}: {
 		taskId: string;
 		topInsetClass?: string;
 		bottomInsetClass?: string;
+		bottomScrollPaddingClass?: string;
 	}) => (
 		<div
 			data-testid="space-task-unified-thread"
 			data-task-id={taskId}
 			data-top-inset={topInsetClass ?? ''}
 			data-bottom-inset={bottomInsetClass ?? ''}
+			data-bottom-scroll-padding={bottomScrollPaddingClass ?? ''}
 		/>
 	),
 }));
@@ -343,6 +346,9 @@ describe('SpaceTaskPane — composer', () => {
 		fireEvent.click(getByTestId('send-button'));
 
 		await waitFor(() => expect(getByText('Invalid transition')).toBeTruthy());
+		const thread = getByTestId('space-task-unified-thread');
+		expect(thread.getAttribute('data-bottom-inset')).toBe('pb-52 sm:pb-44');
+		expect(thread.getAttribute('data-bottom-scroll-padding')).toBe('scroll-pb-52 sm:scroll-pb-44');
 	});
 
 	it('does not submit empty message', () => {
@@ -1262,6 +1268,7 @@ describe('SpaceTaskPane — floating tab pill layout', () => {
 		const thread = getByTestId('space-task-unified-thread');
 		expect(thread.getAttribute('data-top-inset')).toBe('pt-12');
 		expect(thread.getAttribute('data-bottom-inset')).toBe('pb-44 sm:pb-36');
+		expect(thread.getAttribute('data-bottom-scroll-padding')).toBe('scroll-pb-44 sm:scroll-pb-36');
 	});
 
 	it('renders the active banner outside task-pane-content so it is visible across tabs', () => {

--- a/packages/web/src/components/space/__tests__/SpaceTaskUnifiedThread.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskUnifiedThread.test.tsx
@@ -98,6 +98,20 @@ describe('SpaceTaskUnifiedThread', () => {
 		expect(onScrollerChange).toHaveBeenCalledWith(scroller);
 	});
 
+	it('applies bottom scroll padding to the scroll container', () => {
+		render(
+			<SpaceTaskUnifiedThread
+				taskId="task-1"
+				bottomInsetClass="pb-44 sm:pb-36"
+				bottomScrollPaddingClass="scroll-pb-44 sm:scroll-pb-36"
+			/>
+		);
+
+		const scroller = screen.getByTestId('space-task-unified-thread').firstElementChild!;
+		expect(scroller.className).toContain('pb-44 sm:pb-36');
+		expect(scroller.className).toContain('scroll-pb-44 sm:scroll-pb-36');
+	});
+
 	it('does not render the legacy floating agent-name tag', () => {
 		// The compact-mode-only sticky agent label has been removed; minimal
 		// rows carry their own per-row header so the floating tag is redundant.


### PR DESCRIPTION
Mirrors the space task composer bottom inset into scroll padding on the thread scroller so auto-scroll positions the newest message above the floating composer instead of behind it.

Validated with focused space thread tests, full web tests, and project checks.