### PR TITLE
Fix space_tasks migration rebuild ordering

### DIFF
--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -1501,6 +1501,191 @@ function tableCreateSql(db: BunDatabase, tableName: string): string | null {
 	return row?.sql ?? null;
 }
 
+function quoteSqlIdent(identifier: string): string {
+	return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+function quoteSqlString(value: string): string {
+	return `'${value.replaceAll("'", "''")}'`;
+}
+
+function tableColumnNames(db: BunDatabase, tableName: string): string[] {
+	return (
+		db.prepare(`PRAGMA table_info(${quoteSqlString(tableName)})`).all() as Array<{ name: string }>
+	).map((r) => r.name);
+}
+
+function replaceCreateTableName(createSql: string, newTableName: string): string {
+	const replaced = createSql.replace(
+		/^CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:"[^"]+"|`[^`]+`|\[[^\]]+\]|\S+)/i,
+		`CREATE TABLE ${quoteSqlIdent(newTableName)}`
+	);
+	if (replaced === createSql) {
+		throw new Error('Unable to rewrite CREATE TABLE statement');
+	}
+	return replaced;
+}
+
+function widenSpaceTasksApprovedStatusCheck(createSql: string): string {
+	let matched = false;
+	const widened = createSql.replace(
+		/CHECK\s*\(\s*status\s+IN\s*\(([^)]*)\)\s*\)/i,
+		(match, values: string) => {
+			matched = true;
+			if (values.includes("'approved'")) {
+				return match;
+			}
+			return `CHECK(status IN (${values.trim()}, 'approved'))`;
+		}
+	);
+	if (!matched) {
+		throw new Error('Unable to widen space_tasks.status CHECK constraint');
+	}
+	return widened;
+}
+
+function matchingParenIndex(sql: string, openIndex: number): number {
+	let depth = 0;
+	let quote: "'" | '"' | '`' | ']' | null = null;
+	for (let i = openIndex; i < sql.length; i++) {
+		const ch = sql[i];
+		if (quote) {
+			if (quote === "'" && ch === "'" && sql[i + 1] === "'") {
+				i++;
+				continue;
+			}
+			if (quote === ']' ? ch === ']' : ch === quote) {
+				quote = null;
+			}
+			continue;
+		}
+		if (ch === "'" || ch === '"' || ch === '`') {
+			quote = ch;
+			continue;
+		}
+		if (ch === '[') {
+			quote = ']';
+			continue;
+		}
+		if (ch === '(') {
+			depth++;
+		} else if (ch === ')') {
+			depth--;
+			if (depth === 0) {
+				return i;
+			}
+		}
+	}
+	throw new Error('Unable to find closing parenthesis in CREATE TABLE statement');
+}
+
+function splitTopLevelSqlList(sql: string): string[] {
+	const parts: string[] = [];
+	let start = 0;
+	let depth = 0;
+	let quote: "'" | '"' | '`' | ']' | null = null;
+	for (let i = 0; i < sql.length; i++) {
+		const ch = sql[i];
+		if (quote) {
+			if (quote === "'" && ch === "'" && sql[i + 1] === "'") {
+				i++;
+				continue;
+			}
+			if (quote === ']' ? ch === ']' : ch === quote) {
+				quote = null;
+			}
+			continue;
+		}
+		if (ch === "'" || ch === '"' || ch === '`') {
+			quote = ch;
+			continue;
+		}
+		if (ch === '[') {
+			quote = ']';
+			continue;
+		}
+		if (ch === '(') {
+			depth++;
+		} else if (ch === ')') {
+			depth--;
+		} else if (ch === ',' && depth === 0) {
+			parts.push(sql.slice(start, i));
+			start = i + 1;
+		}
+	}
+	parts.push(sql.slice(start));
+	return parts;
+}
+
+function createTableSqlWithoutColumn(createSql: string, columnName: string): string {
+	const open = createSql.indexOf('(');
+	if (open < 0) {
+		throw new Error('Unable to parse CREATE TABLE statement');
+	}
+	const close = matchingParenIndex(createSql, open);
+	const prefix = createSql.slice(0, open + 1);
+	const body = createSql.slice(open + 1, close);
+	const suffix = createSql.slice(close);
+	const columnPattern = new RegExp(
+		`^\\s*(?:"${columnName.replaceAll('"', '""')}"|\\[${columnName.replaceAll(']', ']]')}\\]|\\\`${columnName.replaceAll('`', '``')}\\\`|${columnName})\\b`,
+		'i'
+	);
+	const parts = splitTopLevelSqlList(body).filter((part) => !columnPattern.test(part.trimStart()));
+	return `${prefix}${parts.join(',')}${suffix}`;
+}
+
+function tightenPendingCheckpointTypeCheck(createSql: string): string {
+	return createSql.replace(
+		/CHECK\s*\(\s*pending_checkpoint_type\s+IN\s*\([^)]*\)\s*\)/i,
+		"CHECK(pending_checkpoint_type IN ('gate', 'task_completion'))"
+	);
+}
+
+function capturedIndexDdl(
+	db: BunDatabase,
+	tableName: string
+): Array<{ sql: string; columns: string[] }> {
+	const rows = db
+		.prepare(
+			`SELECT name, sql FROM sqlite_master WHERE type='index' AND tbl_name=? AND sql IS NOT NULL`
+		)
+		.all(tableName) as Array<{ name: string; sql: string }>;
+	return rows.map((row) => {
+		const indexColumns = db
+			.prepare(`PRAGMA index_info(${quoteSqlString(row.name)})`)
+			.all() as Array<{ name: string | null }>;
+		return {
+			sql: row.sql,
+			columns: indexColumns.map((col) => col.name).filter((name): name is string => !!name),
+		};
+	});
+}
+
+function recreateCompatibleIndexes(
+	db: BunDatabase,
+	tableName: string,
+	indexes: Array<{ sql: string; columns: string[] }>
+): void {
+	const columns = new Set(tableColumnNames(db, tableName));
+	for (const index of indexes) {
+		if (index.columns.some((column) => !columns.has(column))) {
+			continue;
+		}
+		const normalized = index.sql.replace(
+			/^CREATE (UNIQUE )?INDEX /i,
+			(_m, unique) => `CREATE ${unique ?? ''}INDEX IF NOT EXISTS `
+		);
+		try {
+			db.exec(normalized);
+		} catch (err) {
+			if (err instanceof Error && /\bno such column\b/i.test(err.message)) {
+				continue;
+			}
+			throw err;
+		}
+	}
+}
+
 function statusCheckContains(db: BunDatabase, tableName: string, status: string): boolean {
 	const sql = tableCreateSql(db, tableName);
 	if (!sql) return false;
@@ -6983,121 +7168,27 @@ export function runMigration103(db: BunDatabase): void {
 		currentSql.includes('status IN (') && /status\s+IN\s*\([^)]*'approved'/.test(currentSql);
 
 	if (currentSql && !hasApprovedInCheck) {
-		// Copy every column that exists on the current schema — the intersection
-		// of the post-M99 baseline and any extra columns added by later
-		// migrations. This keeps the rebuild safe when the running DB has a
-		// slightly different shape than the one used in tests.
-		const baseColumns = [
-			'id',
-			'space_id',
-			'task_number',
-			'title',
-			'description',
-			'status',
-			'priority',
-			'labels',
-			'workflow_run_id',
-			'preferred_workflow_id',
-			'created_by_task_id',
-			'result',
-			'depends_on',
-			'active_session',
-			'task_agent_session_id',
-			'approval_source',
-			'approval_reason',
-			'approved_at',
-			'block_reason',
-			'archived_at',
-			'created_at',
-			'started_at',
-			'completed_at',
-			'updated_at',
-			'pending_action_index',
-			'pending_checkpoint_type',
-			'reported_status',
-			'reported_summary',
-			'pending_completion_submitted_by_node_id',
-			'pending_completion_submitted_at',
-			'pending_completion_reason',
-		];
-		const existingColumns = new Set(
-			(db.prepare(`PRAGMA table_info('space_tasks')`).all() as Array<{ name: string }>).map(
-				(r) => r.name
-			)
+		// Rebuild from the live schema, changing only the status CHECK. Some
+		// upgraded databases can already contain columns from later migrations
+		// such as custom_agent_id, goal_id, or slot_role, and their indexes must
+		// keep working after this rebuild.
+		const newTableSql = widenSpaceTasksApprovedStatusCheck(
+			replaceCreateTableName(currentSql, 'space_tasks_m103_new')
 		);
-		const copyColumns = baseColumns.filter((c) => existingColumns.has(c));
-		const copyColsSql = copyColumns.join(', ');
-
-		// Preserve the indexes that exist on the current table so the rebuild
-		// doesn't silently drop them. Mirrors the M99 rebuild.
-		const existingIndexDdl = (
-			db
-				.prepare(
-					`SELECT sql FROM sqlite_master
-					 WHERE type='index' AND tbl_name='space_tasks' AND sql IS NOT NULL`
-				)
-				.all() as Array<{ sql: string }>
-		)
-			.map((r) => r.sql)
-			.filter((sql) => !!sql);
+		const copyColumns = tableColumnNames(db, 'space_tasks');
+		const copyColsSql = copyColumns.map(quoteSqlIdent).join(', ');
+		const existingIndexDdl = capturedIndexDdl(db, 'space_tasks');
 
 		db.exec('PRAGMA foreign_keys = OFF');
 		db.exec('BEGIN');
 		try {
-			db.exec(`
-				CREATE TABLE space_tasks_m103_new (
-					id TEXT PRIMARY KEY,
-					space_id TEXT NOT NULL,
-					task_number INTEGER NOT NULL,
-					title TEXT NOT NULL,
-					description TEXT NOT NULL DEFAULT '',
-					status TEXT NOT NULL DEFAULT 'open'
-						CHECK(status IN ('open', 'in_progress', 'review', 'approved', 'done', 'blocked', 'cancelled', 'archived')),
-					priority TEXT NOT NULL DEFAULT 'normal'
-						CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
-					labels TEXT NOT NULL DEFAULT '[]',
-					workflow_run_id TEXT,
-					preferred_workflow_id TEXT,
-					created_by_task_id TEXT,
-					result TEXT,
-					depends_on TEXT NOT NULL DEFAULT '[]',
-					active_session TEXT
-						CHECK(active_session IN ('worker', 'leader')),
-					task_agent_session_id TEXT,
-					approval_source TEXT,
-					approval_reason TEXT,
-					approved_at INTEGER,
-					block_reason TEXT,
-					archived_at INTEGER,
-					created_at INTEGER NOT NULL,
-					started_at INTEGER,
-					completed_at INTEGER,
-					updated_at INTEGER NOT NULL,
-					pending_action_index INTEGER DEFAULT NULL,
-					pending_checkpoint_type TEXT DEFAULT NULL
-						CHECK(pending_checkpoint_type IN ('completion_action', 'gate', 'task_completion')),
-					reported_status TEXT DEFAULT NULL
-						CHECK(reported_status IS NULL OR reported_status IN ('done', 'blocked', 'cancelled')),
-					reported_summary TEXT DEFAULT NULL,
-					pending_completion_submitted_by_node_id TEXT DEFAULT NULL,
-					pending_completion_submitted_at INTEGER DEFAULT NULL,
-					pending_completion_reason TEXT DEFAULT NULL,
-					FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
-					FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL
-				)
-			`);
+			db.exec(newTableSql);
 			db.exec(
 				`INSERT INTO space_tasks_m103_new (${copyColsSql}) SELECT ${copyColsSql} FROM space_tasks`
 			);
 			db.exec(`DROP TABLE space_tasks`);
 			db.exec(`ALTER TABLE space_tasks_m103_new RENAME TO space_tasks`);
-			for (const ddl of existingIndexDdl) {
-				const normalized = ddl.replace(
-					/^CREATE (UNIQUE )?INDEX /i,
-					(_m, unique) => `CREATE ${unique ?? ''}INDEX IF NOT EXISTS `
-				);
-				db.exec(normalized);
-			}
+			recreateCompatibleIndexes(db, 'space_tasks', existingIndexDdl);
 			db.exec('COMMIT');
 		} catch (err) {
 			db.exec('ROLLBACK');
@@ -7199,122 +7290,31 @@ export function runMigration104(db: BunDatabase): void {
 		const needsRebuild = !!currentSql && (hasLegacyCheckpointCheck || hasActionIndexCol);
 
 		if (needsRebuild) {
-			// Copy every column the new schema expects, intersected with what the
-			// current row actually has — same defensive approach as M103.
-			const baseColumns = [
-				'id',
-				'space_id',
-				'task_number',
-				'title',
-				'description',
-				'status',
-				'priority',
-				'labels',
-				'workflow_run_id',
-				'preferred_workflow_id',
-				'created_by_task_id',
-				'result',
-				'depends_on',
-				'active_session',
-				'task_agent_session_id',
-				'approval_source',
-				'approval_reason',
-				'approved_at',
-				'block_reason',
-				'archived_at',
-				'created_at',
-				'started_at',
-				'completed_at',
-				'updated_at',
-				'pending_checkpoint_type',
-				'reported_status',
-				'reported_summary',
-				'pending_completion_submitted_by_node_id',
-				'pending_completion_submitted_at',
-				'pending_completion_reason',
-				'post_approval_session_id',
-				'post_approval_started_at',
-				'post_approval_blocked_reason',
-			];
-			const existingColumns = new Set(
-				(db.prepare(`PRAGMA table_info('space_tasks')`).all() as Array<{ name: string }>).map(
-					(r) => r.name
+			// Rebuild from the live schema, dropping only pending_action_index
+			// and tightening pending_checkpoint_type. This preserves optional
+			// columns that may exist on real upgraded databases.
+			const newTableSql = tightenPendingCheckpointTypeCheck(
+				createTableSqlWithoutColumn(
+					replaceCreateTableName(currentSql, 'space_tasks_m104_new'),
+					'pending_action_index'
 				)
 			);
-			const copyColumns = baseColumns.filter((c) => existingColumns.has(c));
-			const copyColsSql = copyColumns.join(', ');
-
-			// Preserve indexes — same approach as M103.
-			const existingIndexDdl = (
-				db
-					.prepare(
-						`SELECT sql FROM sqlite_master
-						 WHERE type='index' AND tbl_name='space_tasks' AND sql IS NOT NULL`
-					)
-					.all() as Array<{ sql: string }>
-			)
-				.map((r) => r.sql)
-				.filter((sql) => !!sql);
+			const copyColumns = tableColumnNames(db, 'space_tasks').filter(
+				(c) => c !== 'pending_action_index'
+			);
+			const copyColsSql = copyColumns.map(quoteSqlIdent).join(', ');
+			const existingIndexDdl = capturedIndexDdl(db, 'space_tasks');
 
 			db.exec('PRAGMA foreign_keys = OFF');
 			db.exec('BEGIN');
 			try {
-				db.exec(`
-					CREATE TABLE space_tasks_m104_new (
-						id TEXT PRIMARY KEY,
-						space_id TEXT NOT NULL,
-						task_number INTEGER NOT NULL,
-						title TEXT NOT NULL,
-						description TEXT NOT NULL DEFAULT '',
-						status TEXT NOT NULL DEFAULT 'open'
-							CHECK(status IN ('open', 'in_progress', 'review', 'approved', 'done', 'blocked', 'cancelled', 'archived')),
-						priority TEXT NOT NULL DEFAULT 'normal'
-							CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
-						labels TEXT NOT NULL DEFAULT '[]',
-						workflow_run_id TEXT,
-						preferred_workflow_id TEXT,
-						created_by_task_id TEXT,
-						result TEXT,
-						depends_on TEXT NOT NULL DEFAULT '[]',
-						active_session TEXT
-							CHECK(active_session IN ('worker', 'leader')),
-						task_agent_session_id TEXT,
-						approval_source TEXT,
-						approval_reason TEXT,
-						approved_at INTEGER,
-						block_reason TEXT,
-						archived_at INTEGER,
-						created_at INTEGER NOT NULL,
-						started_at INTEGER,
-						completed_at INTEGER,
-						updated_at INTEGER NOT NULL,
-						pending_checkpoint_type TEXT DEFAULT NULL
-							CHECK(pending_checkpoint_type IN ('gate', 'task_completion')),
-						reported_status TEXT DEFAULT NULL
-							CHECK(reported_status IS NULL OR reported_status IN ('done', 'blocked', 'cancelled')),
-						reported_summary TEXT DEFAULT NULL,
-						pending_completion_submitted_by_node_id TEXT DEFAULT NULL,
-						pending_completion_submitted_at INTEGER DEFAULT NULL,
-						pending_completion_reason TEXT DEFAULT NULL,
-						post_approval_session_id TEXT DEFAULT NULL,
-						post_approval_started_at INTEGER DEFAULT NULL,
-						post_approval_blocked_reason TEXT DEFAULT NULL,
-						FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
-						FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL
-					)
-				`);
+				db.exec(newTableSql);
 				db.exec(
 					`INSERT INTO space_tasks_m104_new (${copyColsSql}) SELECT ${copyColsSql} FROM space_tasks`
 				);
 				db.exec(`DROP TABLE space_tasks`);
 				db.exec(`ALTER TABLE space_tasks_m104_new RENAME TO space_tasks`);
-				for (const ddl of existingIndexDdl) {
-					const normalized = ddl.replace(
-						/^CREATE (UNIQUE )?INDEX /i,
-						(_m, unique) => `CREATE ${unique ?? ''}INDEX IF NOT EXISTS `
-					);
-					db.exec(normalized);
-				}
+				recreateCompatibleIndexes(db, 'space_tasks', existingIndexDdl);
 				db.exec('COMMIT');
 			} catch (err) {
 				db.exec('ROLLBACK');

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-103_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-103_test.ts
@@ -31,7 +31,11 @@ import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
-import { runMigration103, runMigrations } from '../../../../../src/storage/schema/migrations.ts';
+import {
+	runMigration103,
+	runMigration104,
+	runMigrations,
+} from '../../../../../src/storage/schema/migrations.ts';
 
 function columnNames(db: BunDatabase, table: string): string[] {
 	const rows = db.prepare(`PRAGMA table_info('${table}')`).all() as Array<{ name: string }>;
@@ -43,6 +47,13 @@ function indexNames(db: BunDatabase, table: string): string[] {
 		.prepare(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name=? AND sql IS NOT NULL`)
 		.all(table) as Array<{ name: string }>;
 	return rows.map((r) => r.name);
+}
+
+function tableSql(db: BunDatabase, table: string): string {
+	const row = db
+		.prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name=?`)
+		.get(table) as { sql?: string } | undefined;
+	return row?.sql ?? '';
 }
 
 function seedPreM103Schema(db: BunDatabase): void {
@@ -127,6 +138,89 @@ function seedPreM103Schema(db: BunDatabase): void {
 		)
 	`);
 
+	db.exec('PRAGMA foreign_keys = ON');
+}
+
+function seedPreM103SchemaWithLaterColumns(db: BunDatabase): void {
+	db.exec('PRAGMA foreign_keys = OFF');
+	db.exec(`
+		CREATE TABLE spaces (
+			id TEXT PRIMARY KEY,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		)
+	`);
+	db.exec(`
+		CREATE TABLE space_workflow_runs (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			completion_actions_fired_at INTEGER DEFAULT NULL
+		)
+	`);
+	db.exec(`
+		CREATE TABLE space_workflows (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			tags TEXT NOT NULL DEFAULT '[]',
+			completion_autonomy_level INTEGER NOT NULL DEFAULT 3,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+		)
+	`);
+	db.exec(`
+		CREATE TABLE space_tasks (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			task_number INTEGER NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'open'
+				CHECK(status IN ('open', 'in_progress', 'review', 'done', 'blocked', 'cancelled', 'archived')),
+			priority TEXT NOT NULL DEFAULT 'normal'
+				CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+			labels TEXT NOT NULL DEFAULT '[]',
+			workflow_run_id TEXT,
+			preferred_workflow_id TEXT,
+			created_by_task_id TEXT,
+			custom_agent_id TEXT,
+			goal_id TEXT,
+			slot_role TEXT,
+			result TEXT,
+			depends_on TEXT NOT NULL DEFAULT '[]',
+			active_session TEXT
+				CHECK(active_session IN ('worker', 'leader')),
+			task_agent_session_id TEXT,
+			approval_source TEXT,
+			approval_reason TEXT,
+			approved_at INTEGER,
+			block_reason TEXT,
+			archived_at INTEGER,
+			created_at INTEGER NOT NULL,
+			started_at INTEGER,
+			completed_at INTEGER,
+			updated_at INTEGER NOT NULL,
+			pending_action_index INTEGER DEFAULT NULL,
+			pending_checkpoint_type TEXT DEFAULT NULL
+				CHECK(pending_checkpoint_type IN ('completion_action', 'gate', 'task_completion')),
+			pending_completion_submitted_by_node_id TEXT DEFAULT NULL,
+			pending_completion_submitted_at INTEGER DEFAULT NULL,
+			pending_completion_reason TEXT DEFAULT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE,
+			FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE SET NULL
+		)
+	`);
+	db.exec(
+		`CREATE UNIQUE INDEX idx_space_tasks_space_task_number ON space_tasks(space_id, task_number)`
+	);
+	db.exec(`CREATE INDEX idx_space_tasks_custom_agent_id ON space_tasks(custom_agent_id)`);
+	db.exec(`CREATE INDEX idx_space_tasks_goal_id ON space_tasks(goal_id)`);
+	db.exec(`CREATE INDEX idx_space_tasks_slot_role ON space_tasks(slot_role)`);
+	db.exec(`CREATE INDEX idx_space_tasks_pending_action_index ON space_tasks(pending_action_index)`);
 	db.exec('PRAGMA foreign_keys = ON');
 }
 
@@ -381,6 +475,118 @@ describe('Migration 103: task status "approved" + post_approval schema', () => {
 
 			expect(countAfter2).toBe(countAfter1);
 			expect(cols2).toEqual(cols1);
+		});
+	});
+
+	describe('regression — pre-M103 DB with later columns and indexes', () => {
+		beforeEach(() => {
+			seedPreM103SchemaWithLaterColumns(db);
+			const now = Date.now();
+			db.prepare(`INSERT INTO spaces (id, created_at, updated_at) VALUES (?, ?, ?)`).run(
+				'sp-1',
+				now,
+				now
+			);
+			db.prepare(
+				`INSERT INTO space_workflow_runs (
+						id, space_id, created_at, updated_at, completion_actions_fired_at
+					) VALUES (?, ?, ?, ?, ?)`
+			).run('run-1', 'sp-1', now, now, now + 1);
+			db.prepare(
+				`INSERT INTO space_workflows (
+						id, space_id, name, description, tags, completion_autonomy_level,
+						created_at, updated_at
+					) VALUES (?, ?, ?, '', '[]', 3, ?, ?)`
+			).run('wf-1', 'sp-1', 'Workflow', now, now);
+			db.prepare(
+				`INSERT INTO space_tasks (
+						id, space_id, task_number, title, description, status, priority,
+						labels, workflow_run_id, custom_agent_id, goal_id, slot_role,
+						depends_on, created_at, updated_at,
+						pending_checkpoint_type, pending_action_index
+					) VALUES (?, ?, ?, ?, ?, 'review', 'high', '["bug"]', ?, ?, ?, ?, '[]', ?, ?, 'completion_action', 7)`
+			).run(
+				't-legacy',
+				'sp-1',
+				1,
+				'Legacy indexed task',
+				'preserve me',
+				'run-1',
+				'agent-1',
+				'goal-1',
+				'implementer',
+				now,
+				now + 10
+			);
+		});
+
+		test('runs migrations 103 and 104 without dropping later columns or compatible indexes', () => {
+			expect(() => runMigration103(db)).not.toThrow();
+			expect(() => runMigration104(db)).not.toThrow();
+
+			const cols = columnNames(db, 'space_tasks');
+			expect(cols).toContain('custom_agent_id');
+			expect(cols).toContain('goal_id');
+			expect(cols).toContain('slot_role');
+			expect(cols).toContain('post_approval_session_id');
+			expect(cols).toContain('post_approval_started_at');
+			expect(cols).toContain('post_approval_blocked_reason');
+			expect(cols).not.toContain('pending_action_index');
+			expect(columnNames(db, 'space_workflows')).toContain('post_approval');
+			expect(columnNames(db, 'space_workflow_runs')).not.toContain('completion_actions_fired_at');
+
+			const sql = tableSql(db, 'space_tasks');
+			expect(sql).toContain("'approved'");
+			expect(sql).not.toContain("'completion_action'");
+			expect(sql).not.toContain('pending_action_index');
+
+			const indexes = new Set(indexNames(db, 'space_tasks'));
+			expect(indexes).toContain('idx_space_tasks_custom_agent_id');
+			expect(indexes).toContain('idx_space_tasks_goal_id');
+			expect(indexes).toContain('idx_space_tasks_slot_role');
+			expect(indexes).not.toContain('idx_space_tasks_pending_action_index');
+
+			const row = db
+				.prepare(
+					`SELECT title, description, status, priority, labels, workflow_run_id,
+						        custom_agent_id, goal_id, slot_role, pending_checkpoint_type
+						   FROM space_tasks
+						  WHERE id = ?`
+				)
+				.get('t-legacy') as {
+				title: string;
+				description: string;
+				status: string;
+				priority: string;
+				labels: string;
+				workflow_run_id: string;
+				custom_agent_id: string;
+				goal_id: string;
+				slot_role: string;
+				pending_checkpoint_type: string;
+			};
+			expect(row).toEqual({
+				title: 'Legacy indexed task',
+				description: 'preserve me',
+				status: 'review',
+				priority: 'high',
+				labels: '["bug"]',
+				workflow_run_id: 'run-1',
+				custom_agent_id: 'agent-1',
+				goal_id: 'goal-1',
+				slot_role: 'implementer',
+				pending_checkpoint_type: 'task_completion',
+			});
+
+			const now = Date.now();
+			expect(() => {
+				db.prepare(
+					`INSERT INTO space_tasks (
+							id, space_id, task_number, title, description, status, priority,
+							labels, depends_on, created_at, updated_at
+						) VALUES (?, ?, ?, ?, '', 'approved', 'normal', '[]', '[]', ?, ?)`
+				).run('t-approved', 'sp-1', 2, 'Approved', now, now);
+			}).not.toThrow();
 		});
 	});
 


### PR DESCRIPTION
Fix migration 103/104 space_tasks rebuilds to preserve live columns while updating CHECK constraints.

Adds a regression for pre-103 databases with later indexed columns such as custom_agent_id through migrations 103 and 104.

Tests:
- bun test packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-103_test.ts packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-104_test.ts
- bun test tests/unit/4-space-storage/storage/migrations (from packages/daemon)
- bun run typecheck