### PR TITLE
Fix stale SDK rewind resume recovery

### DIFF
--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -514,6 +514,7 @@ export class QueryOptionsBuilder {
 	 */
 	private buildSystemPrompt(): Options['systemPrompt'] {
 		const config = this.ctx.session.config;
+		const compactionSummaryText = this.getCompactionSummaryAppendText();
 
 		// Priority 1: Check if SDKConfig systemPrompt is explicitly set
 		if (config.systemPrompt !== undefined) {
@@ -530,9 +531,12 @@ export class QueryOptionsBuilder {
 				preset: 'claude_code',
 			};
 
-			// Append worktree isolation instructions if session uses a worktree
-			if (this.ctx.session.worktree) {
-				presetConfig.append = this.getWorktreeIsolationText();
+			const append = this.joinSystemPromptAppendParts([
+				compactionSummaryText,
+				this.ctx.session.worktree ? this.getWorktreeIsolationText() : undefined,
+			]);
+			if (append) {
+				presetConfig.append = append;
 			}
 
 			return presetConfig;
@@ -541,7 +545,14 @@ export class QueryOptionsBuilder {
 		// No Claude Code preset - use minimal system prompt or undefined
 		// When worktree is used, still append isolation instructions
 		if (this.ctx.session.worktree) {
-			return this.getMinimalWorktreePrompt();
+			return this.joinSystemPromptAppendParts([
+				compactionSummaryText,
+				this.getMinimalWorktreePrompt(),
+			]);
+		}
+
+		if (compactionSummaryText) {
+			return compactionSummaryText;
 		}
 
 		// If no worktree, systemPromptConfig remains undefined (SDK default behavior)
@@ -554,13 +565,15 @@ export class QueryOptionsBuilder {
 	 * Handles both custom string prompts and Claude Code preset configuration
 	 */
 	private buildCustomSystemPrompt(systemPrompt: SystemPromptConfig): Options['systemPrompt'] {
+		const compactionSummaryText = this.getCompactionSummaryAppendText();
+
 		// Custom string prompt
 		if (typeof systemPrompt === 'string') {
-			// Append worktree isolation if needed
-			if (this.ctx.session.worktree) {
-				return systemPrompt + '\n\n' + this.getWorktreeIsolationText();
-			}
-			return systemPrompt;
+			return this.joinSystemPromptAppendParts([
+				systemPrompt,
+				compactionSummaryText,
+				this.ctx.session.worktree ? this.getWorktreeIsolationText() : undefined,
+			]);
 		}
 
 		// Claude Code preset configuration
@@ -570,15 +583,11 @@ export class QueryOptionsBuilder {
 				preset: 'claude_code',
 			};
 
-			// Combine existing append with worktree isolation
-			let append = systemPrompt.append || '';
-			if (this.ctx.session.worktree) {
-				if (append) {
-					append += '\n\n';
-				}
-				append += this.getWorktreeIsolationText();
-			}
-
+			const append = this.joinSystemPromptAppendParts([
+				systemPrompt.append,
+				compactionSummaryText,
+				this.ctx.session.worktree ? this.getWorktreeIsolationText() : undefined,
+			]);
 			if (append) {
 				presetConfig.append = append;
 			}
@@ -588,6 +597,22 @@ export class QueryOptionsBuilder {
 
 		// Unknown format - return as-is
 		return undefined;
+	}
+
+	private getCompactionSummaryAppendText(): string | undefined {
+		const summary = this.ctx.session.metadata.compactionSummary?.trim();
+		if (!summary) {
+			return undefined;
+		}
+
+		return `[Previous conversation summary - context was reset due to SDK compaction]\n${summary}`;
+	}
+
+	private joinSystemPromptAppendParts(parts: Array<string | undefined>): string {
+		return parts
+			.map((part) => part?.trim())
+			.filter((part): part is string => !!part)
+			.join('\n\n');
 	}
 
 	/**

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -546,6 +546,7 @@ export class QueryRunner {
 			const isAbortError = error instanceof Error && error.name === 'AbortError';
 			const isStartupTimeout = errorMessage.includes('SDK startup timeout');
 			const isConversationNotFound = errorMessage.includes('No conversation found');
+			const isMessageNotFound = errorMessage.includes('No message found');
 
 			// Startup timeout is transient — always keep sdkSessionId so resume works.
 			// Never clear sdkSessionId on timeout: the session file is valid and the
@@ -594,6 +595,38 @@ export class QueryRunner {
 					// Best-effort — don't let message emission block cleanup
 				}
 			}
+			if (isMessageNotFound) {
+				// The SDK found the transcript but could not find resumeSessionAt inside it.
+				// This commonly happens after SDK compaction removes old message UUIDs.
+				// Clear both the rewind pointer and SDK transcript identity so the retry
+				// starts with a fresh context instead of looping on stale JSONL state.
+				const oldResumeSessionAt = session.metadata.resumeSessionAt;
+				logger.error(
+					`No message found for resumeSessionAt (${oldResumeSessionAt ?? 'unknown'}). ` +
+						'Clearing resumeSessionAt, sdkSessionId, and sdkOriginPath before retry.'
+				);
+				delete session.metadata.resumeSessionAt;
+				session.sdkSessionId = undefined;
+				session.sdkOriginPath = undefined;
+				this.ctx.db.updateSession(session.id, {
+					metadata: session.metadata,
+					sdkSessionId: undefined,
+					sdkOriginPath: undefined,
+				});
+
+				try {
+					await this.displayErrorAsAssistantMessage(
+						'⚠️ **Conversation context was reset.**\n\n' +
+							'The previous rewind point is no longer present in the Claude SDK transcript. ' +
+							'This can happen after SDK compaction. Your conversation history in NeoKai is ' +
+							'preserved; only the AI context window has been reset.\n\n' +
+							'Retrying your message with a fresh AI session.',
+						{ markAsError: false }
+					);
+				} catch {
+					// Best-effort — don't let message emission block cleanup
+				}
+			}
 
 			// Auto-retry once on startup timeout — the user shouldn't have to resend.
 			// This handles transient SDK startup failures (e.g., after a model switch)
@@ -631,6 +664,30 @@ export class QueryRunner {
 				// Use `return await` so this call's finally{} runs only after the retry
 				// completes. Otherwise finally{} would race the retry and can tear down
 				// shared state (queue/controller/queryObject) while it is still running.
+				return await this.runQuery(queryGeneration, true);
+			}
+			if (isMessageNotFound && !isRetry && !this.ctx.isCleaningUp()) {
+				logger.warn('Auto-retrying query after clearing stale resumeSessionAt.');
+				await stateManager.setIdle();
+
+				if (this.ctx.queryObject) {
+					try {
+						this.ctx.queryObject.close();
+					} catch {
+						// Ignore close errors — transport may already be in a broken state
+					}
+					this.ctx.queryObject = null;
+				}
+
+				const exitPromise = this.ctx.processExitedPromise;
+				if (exitPromise) {
+					await Promise.race([
+						exitPromise,
+						new Promise((resolve) => setTimeout(resolve, RETRY_EXIT_TIMEOUT_MS)),
+					]);
+					this.ctx.processExitedPromise = null;
+				}
+
 				return await this.runQuery(queryGeneration, true);
 			}
 
@@ -702,7 +759,7 @@ export class QueryRunner {
 
 					const processingState = stateManager.getState();
 
-					// For startup timeouts / conversation-not-found, provide actionable recovery hints.
+					// For startup timeouts / resume failures, provide actionable recovery hints.
 					// Keep the hints distinct: NEOKAI_SDK_STARTUP_TIMEOUT_MS is irrelevant to a
 					// missing/corrupt session file — the session ID was already cleared above,
 					// so the next message will automatically start a fresh session.
@@ -719,7 +776,13 @@ export class QueryRunner {
 								`workspace path change, or if the ~/.claude/projects/ directory was cleaned up. ` +
 								`Your message history in NeoKai is preserved; only the AI context window is reset. ` +
 								`Please resend your message — a fresh session starts automatically.`
-							: undefined;
+							: isMessageNotFound
+								? `The AI session could not resume from the previous rewind point ` +
+									`(workspace: ${session.workspacePath ?? 'unbound'}). The Claude SDK transcript no longer ` +
+									`contains that message UUID, likely after SDK compaction. Your message history in NeoKai ` +
+									`is preserved; only the AI context window is reset. Please resend your message — a fresh ` +
+									`session starts automatically.`
+								: undefined;
 
 					await errorManager.handleError(
 						session.id,

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -25,6 +25,7 @@ import type { ProcessingStateManager } from './processing-state-manager';
 import type { QueryOptionsBuilder } from './query-options-builder';
 import type { AskUserQuestionHandler } from './ask-user-question-handler';
 import type { OriginalEnvVars } from '../provider-service';
+import { extractCompactionSummary, getSDKSessionFilePath } from '../sdk-session-file-manager';
 // Re-exported for callers that import OriginalEnvVars from this module — canonical definition lives in provider-service.ts.
 export type { OriginalEnvVars } from '../provider-service';
 
@@ -601,11 +602,17 @@ export class QueryRunner {
 				// Clear both the rewind pointer and SDK transcript identity so the retry
 				// starts with a fresh context instead of looping on stale JSONL state.
 				const oldResumeSessionAt = session.metadata.resumeSessionAt;
+				const compactionSummary = this.extractCompactionSummaryFromCurrentSdkSession();
 				logger.error(
 					`No message found for resumeSessionAt (${oldResumeSessionAt ?? 'unknown'}). ` +
 						'Clearing resumeSessionAt, sdkSessionId, and sdkOriginPath before retry.'
 				);
 				delete session.metadata.resumeSessionAt;
+				if (compactionSummary) {
+					session.metadata.compactionSummary = compactionSummary;
+				} else {
+					delete session.metadata.compactionSummary;
+				}
 				session.sdkSessionId = undefined;
 				session.sdkOriginPath = undefined;
 				this.ctx.db.updateSession(session.id, {
@@ -618,8 +625,10 @@ export class QueryRunner {
 					await this.displayErrorAsAssistantMessage(
 						'⚠️ **Conversation context was reset.**\n\n' +
 							'The previous rewind point is no longer present in the Claude SDK transcript. ' +
-							'This can happen after SDK compaction. Your conversation history in NeoKai is ' +
-							'preserved; only the AI context window has been reset.\n\n' +
+							'This can happen after SDK compaction. Your conversation history in NeoKai is preserved; ' +
+							(compactionSummary
+								? 'a compacted summary from the previous SDK transcript will be carried into the fresh AI session.\n\n'
+								: 'only the AI context window has been reset.\n\n') +
 							'Retrying your message with a fresh AI session.',
 						{ markAsError: false }
 					);
@@ -871,6 +880,29 @@ export class QueryRunner {
 		}
 	}
 
+	private extractCompactionSummaryFromCurrentSdkSession(): string | null {
+		const { session, logger } = this.ctx;
+		if (!session.sdkSessionId) {
+			return null;
+		}
+
+		const workspacePath = session.sdkOriginPath ?? session.workspacePath;
+		if (!workspacePath) {
+			return null;
+		}
+
+		try {
+			const filePath = getSDKSessionFilePath(workspacePath, session.sdkSessionId);
+			return extractCompactionSummary(filePath);
+		} catch (error) {
+			logger.warn(
+				`Failed to extract SDK compaction summary for session ${session.id}: ` +
+					`${error instanceof Error ? error.message : String(error)}`
+			);
+			return null;
+		}
+	}
+
 	private getLiveSdkMcpServerNames(queryOptions: Pick<Options, 'mcpServers'>): string[] {
 		return Object.entries(queryOptions.mcpServers ?? {})
 			.filter(([, config]) => {
@@ -909,6 +941,24 @@ export class QueryRunner {
 		// Delegate to callback
 		await this.ctx.onSDKMessage(message);
 		await this.ctx.onMarkApiSuccess();
+		await this.clearCompactionSummaryAfterCarry();
+	}
+
+	private async clearCompactionSummaryAfterCarry(): Promise<void> {
+		const { session, db, logger } = this.ctx;
+		if (!session.metadata.compactionSummary || this.ctx.isCleaningUp()) {
+			return;
+		}
+
+		delete session.metadata.compactionSummary;
+		try {
+			db.updateSession(session.id, { metadata: session.metadata });
+		} catch (error) {
+			logger.warn(
+				`Failed to clear carried compaction summary for session ${session.id}: ` +
+					`${error instanceof Error ? error.message : String(error)}`
+			);
+		}
 	}
 
 	/**

--- a/packages/daemon/src/lib/agent/rewind-handler.ts
+++ b/packages/daemon/src/lib/agent/rewind-handler.ts
@@ -23,7 +23,10 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import type { Database } from '../../storage/database';
 import type { DaemonHub } from '../daemon-hub';
 import type { Logger } from '../logger';
-import { truncateSessionFileAtMessage } from '../sdk-session-file-manager';
+import {
+	messageUuidExistsInSessionFile,
+	truncateSessionFileAtMessage,
+} from '../sdk-session-file-manager';
 import type { QueryLifecycleManager } from './query-lifecycle-manager';
 
 /**
@@ -329,10 +332,18 @@ export class RewindHandler {
 				? remainingUserMessages[remainingUserMessages.length - 1]
 				: null;
 
-		if (previousUserMessage) {
+		if (
+			previousUserMessage &&
+			messageUuidExistsInSessionFile(
+				sdkWorkspacePath,
+				session.sdkSessionId,
+				session.id,
+				previousUserMessage.uuid
+			)
+		) {
 			session.metadata.resumeSessionAt = previousUserMessage.uuid;
 		} else {
-			// No previous user message - clear resumeSessionAt for fresh start
+			// No resumable previous user message - clear resumeSessionAt for fresh start
 			delete session.metadata.resumeSessionAt;
 		}
 		db.updateSession(session.id, { metadata: session.metadata });
@@ -722,15 +733,16 @@ export class RewindHandler {
 				// Delete messages from DB at and after the earliest timestamp (inclusive)
 				messagesDeleted = db.deleteMessagesAtAndAfter(session.id, earliestTimestamp);
 
+				const rewindSdkPath = session.worktree
+					? session.worktree.worktreePath
+					: session.workspacePath;
+				if (!rewindSdkPath) {
+					throw new Error('Cannot rewind unbound session without a workspace path');
+				}
+
 				// Truncate JSONL at the earliest selected message
 				const jsonlUuid = (earliestMessage as { uuid?: string }).uuid;
 				if (jsonlUuid) {
-					const rewindSdkPath = session.worktree
-						? session.worktree.worktreePath
-						: session.workspacePath;
-					if (!rewindSdkPath) {
-						throw new Error('Cannot rewind unbound session without a workspace path');
-					}
 					const _jsonlResult = truncateSessionFileAtMessage(
 						rewindSdkPath,
 						session.sdkSessionId,
@@ -746,7 +758,15 @@ export class RewindHandler {
 						? remainingUserMessages[remainingUserMessages.length - 1]
 						: null;
 
-				if (previousUserMessage) {
+				if (
+					previousUserMessage &&
+					messageUuidExistsInSessionFile(
+						rewindSdkPath,
+						session.sdkSessionId,
+						session.id,
+						previousUserMessage.uuid
+					)
+				) {
 					session.metadata.resumeSessionAt = previousUserMessage.uuid;
 				} else {
 					delete session.metadata.resumeSessionAt;

--- a/packages/daemon/src/lib/sdk-session-file-manager.ts
+++ b/packages/daemon/src/lib/sdk-session-file-manager.ts
@@ -1138,3 +1138,52 @@ export function truncateSessionFileAtMessage(
 		return { truncated: false, linesRemoved: 0 };
 	}
 }
+
+/**
+ * Check whether a message UUID still exists in the SDK session JSONL file.
+ *
+ * This is used before passing resumeSessionAt back to the SDK. Auto-compaction
+ * can replace older transcript entries with a summary, so a UUID that remains
+ * in NeoKai's DB may no longer be resumable from the SDK transcript.
+ *
+ * @param workspacePath - The session's workspace path
+ * @param sdkSessionId - The SDK session ID (for direct file path lookup)
+ * @param kaiSessionId - The NeoKai session ID (fallback for file search)
+ * @param messageUuid - The UUID of the message to find
+ * @returns true when the UUID exists in the JSONL transcript
+ */
+export function messageUuidExistsInSessionFile(
+	workspacePath: string,
+	sdkSessionId: string | null | undefined,
+	kaiSessionId: string,
+	messageUuid: string
+): boolean {
+	let filePath: string | null = null;
+	if (sdkSessionId) {
+		const candidatePath = getSDKSessionFilePath(workspacePath, sdkSessionId);
+		if (existsSync(candidatePath)) {
+			filePath = candidatePath;
+		}
+	}
+	if (!filePath) {
+		filePath = findSDKSessionFile(workspacePath, kaiSessionId);
+	}
+	if (!filePath || !existsSync(filePath)) {
+		return false;
+	}
+
+	try {
+		const content = readFileSync(filePath, 'utf-8');
+		const lines = content.split('\n');
+
+		for (const line of lines) {
+			if (line.includes(`"uuid":"${messageUuid}"`) || line.includes(`"uuid": "${messageUuid}"`)) {
+				return true;
+			}
+		}
+
+		return lines.some((line) => line.includes(messageUuid));
+	} catch {
+		return false;
+	}
+}

--- a/packages/daemon/src/lib/sdk-session-file-manager.ts
+++ b/packages/daemon/src/lib/sdk-session-file-manager.ts
@@ -1139,6 +1139,104 @@ export function truncateSessionFileAtMessage(
 	}
 }
 
+function isJsonRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function extractTextFromContent(content: unknown): string {
+	if (typeof content === 'string') {
+		return content.trim();
+	}
+
+	if (!Array.isArray(content)) {
+		return '';
+	}
+
+	return content
+		.map((block) => {
+			if (!isJsonRecord(block)) {
+				return '';
+			}
+			const text = block.text;
+			return typeof text === 'string' ? text.trim() : '';
+		})
+		.filter(Boolean)
+		.join('\n\n')
+		.trim();
+}
+
+function extractMessageText(entry: Record<string, unknown>): string {
+	const message = entry.message;
+	if (isJsonRecord(message)) {
+		return extractTextFromContent(message.content);
+	}
+	return extractTextFromContent(entry.content);
+}
+
+/**
+ * Extract the SDK compaction summary from a JSONL session transcript.
+ *
+ * After SDK compaction, the transcript contains a system compact_boundary row
+ * followed by the compacted conversation summary as normal message content.
+ * The most recent boundary is authoritative when a transcript was compacted
+ * multiple times.
+ *
+ * @param filePath - Absolute path to the SDK JSONL transcript
+ * @returns Summary text when found, otherwise null
+ */
+export function extractCompactionSummary(filePath: string): string | null {
+	if (!existsSync(filePath)) {
+		return null;
+	}
+
+	try {
+		const lines = readFileSync(filePath, 'utf-8')
+			.split('\n')
+			.map((line) => line.trim())
+			.filter(Boolean);
+
+		const entries: Record<string, unknown>[] = [];
+		for (const line of lines) {
+			try {
+				const parsed = JSON.parse(line);
+				if (isJsonRecord(parsed)) {
+					entries.push(parsed);
+				}
+			} catch {
+				// Skip unparseable lines. Transcript repair helpers use the same best-effort pattern.
+			}
+		}
+
+		let compactBoundaryIndex = -1;
+		for (let i = 0; i < entries.length; i++) {
+			const entry = entries[i];
+			if (entry.type === 'system' && entry.subtype === 'compact_boundary') {
+				compactBoundaryIndex = i;
+			}
+		}
+
+		if (compactBoundaryIndex === -1) {
+			return null;
+		}
+
+		for (let i = compactBoundaryIndex + 1; i < entries.length; i++) {
+			const entry = entries[i];
+			if (entry.type !== 'assistant' && entry.type !== 'user') {
+				continue;
+			}
+
+			const text = extractMessageText(entry);
+			if (text) {
+				return text;
+			}
+		}
+	} catch {
+		return null;
+	}
+
+	return null;
+}
+
 /**
  * Check whether a message UUID still exists in the SDK session JSONL file.
  *

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -264,6 +264,21 @@ describe('QueryOptionsBuilder', () => {
 			});
 		});
 
+		it('should append carried compaction summary to Claude Code preset', async () => {
+			mockSession.metadata.compactionSummary = 'The user was debugging rewind recovery.';
+			const options = await builder.build();
+
+			expect(options.systemPrompt).toEqual(
+				expect.objectContaining({
+					type: 'preset',
+					preset: 'claude_code',
+					append: expect.stringContaining(
+						'[Previous conversation summary - context was reset due to SDK compaction]\nThe user was debugging rewind recovery.'
+					),
+				})
+			);
+		});
+
 		it('should append worktree isolation text when worktree exists', async () => {
 			mockSession.worktree = {
 				worktreePath: '/worktree/path',
@@ -290,6 +305,17 @@ describe('QueryOptionsBuilder', () => {
 			const options = await builder.build();
 
 			expect(options.systemPrompt).toBe('Custom system prompt');
+		});
+
+		it('should append carried compaction summary to custom string system prompt', async () => {
+			mockSession.config.systemPrompt = 'Custom system prompt';
+			mockSession.metadata.compactionSummary = 'Compact summary text';
+			const options = await builder.build();
+
+			expect(options.systemPrompt).toContain('Custom system prompt');
+			expect(options.systemPrompt).toContain(
+				'[Previous conversation summary - context was reset due to SDK compaction]\nCompact summary text'
+			);
 		});
 
 		it('should combine custom prompt with worktree isolation', async () => {

--- a/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
@@ -42,6 +42,7 @@ describe('QueryRunner', () => {
 	let handleErrorSpy: ReturnType<typeof mock>;
 	let publishSpy: ReturnType<typeof mock>;
 	let saveSDKMessageSpy: ReturnType<typeof mock>;
+	let updateSessionSpy: ReturnType<typeof mock>;
 	let getMessagesByStatusSpy: ReturnType<typeof mock>;
 	let updateMessageStatusSpy: ReturnType<typeof mock>;
 	let buildSpy: ReturnType<typeof mock>;
@@ -90,10 +91,12 @@ describe('QueryRunner', () => {
 
 		// Database spies
 		saveSDKMessageSpy = mock(() => {});
+		updateSessionSpy = mock(() => {});
 		getMessagesByStatusSpy = mock(() => []);
 		updateMessageStatusSpy = mock(() => {});
 		mockDb = {
 			saveSDKMessage: saveSDKMessageSpy,
+			updateSession: updateSessionSpy,
 			getMessagesByStatus: getMessagesByStatusSpy,
 			updateMessageStatus: updateMessageStatusSpy,
 		} as unknown as Database;
@@ -868,6 +871,45 @@ describe('QueryRunner', () => {
 			expect(userMessage).not.toContain('NEOKAI_SDK_STARTUP_TIMEOUT_MS');
 			// Should NOT contain retry count language
 			expect(userMessage).not.toContain('attempt(s)');
+		});
+
+		it('should clear stale resumeSessionAt and SDK session state before retrying no-message-found', async () => {
+			mockSession.sdkSessionId = 'sdk-session-id';
+			mockSession.sdkOriginPath = '/old/sdk/path';
+			mockSession.metadata.resumeSessionAt = 'missing-message-uuid';
+			buildSpy
+				.mockRejectedValueOnce(
+					new Error('No message found with message.uuid of: missing-message-uuid')
+				)
+				.mockRejectedValueOnce(new Error('stop after retry'));
+
+			const ctx = createContext();
+			runner = new QueryRunner(ctx);
+			runner.start();
+			await ctx.queryPromise?.catch(() => {});
+
+			expect(buildSpy).toHaveBeenCalledTimes(2);
+			expect(mockSession.metadata.resumeSessionAt).toBeUndefined();
+			expect(mockSession.sdkSessionId).toBeUndefined();
+			expect(mockSession.sdkOriginPath).toBeUndefined();
+			expect(updateSessionSpy).toHaveBeenCalledWith('test-session-id', {
+				metadata: mockSession.metadata,
+				sdkSessionId: undefined,
+				sdkOriginPath: undefined,
+			});
+			expect(saveSDKMessageSpy).toHaveBeenCalledWith(
+				'test-session-id',
+				expect.objectContaining({
+					type: 'assistant',
+					message: expect.objectContaining({
+						content: expect.arrayContaining([
+							expect.objectContaining({
+								text: expect.stringContaining('Conversation context was reset'),
+							}),
+						]),
+					}),
+				})
+			);
 		});
 
 		it('should call stateManager.setIdle after handling startup timeout error', async () => {

--- a/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
@@ -6,7 +6,10 @@
 
 import { describe, expect, it, beforeEach, afterEach, mock, jest } from 'bun:test';
 import { tmpdir } from 'node:os';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { QueryRunner, type QueryRunnerContext } from '../../../../src/lib/agent/query-runner';
+import { getSDKSessionFilePath } from '../../../../src/lib/sdk-session-file-manager';
 import type { Session, MessageHub } from '@neokai/shared';
 import type { SDKMessage } from '@neokai/shared/sdk';
 import type { Query } from '@anthropic-ai/claude-agent-sdk';
@@ -554,6 +557,25 @@ describe('QueryRunner', () => {
 
 			expect(onMarkApiSuccessSpy).toHaveBeenCalled();
 		});
+
+		it('should clear carried compaction summary after the first handled SDK message', async () => {
+			mockSession.metadata.compactionSummary = 'Temporary compacted context';
+			runner = createRunner();
+
+			const message = {
+				type: 'system',
+				subtype: 'init',
+				uuid: 'init-uuid',
+				session_id: 'sdk-session-123',
+			};
+
+			await runner.handleSDKMessage(message as unknown as SDKMessage);
+
+			expect(mockSession.metadata.compactionSummary).toBeUndefined();
+			expect(updateSessionSpy).toHaveBeenCalledWith('test-session-id', {
+				metadata: mockSession.metadata,
+			});
+		});
 	});
 
 	describe('createAbortableQuery', () => {
@@ -873,43 +895,82 @@ describe('QueryRunner', () => {
 			expect(userMessage).not.toContain('attempt(s)');
 		});
 
-		it('should clear stale resumeSessionAt and SDK session state before retrying no-message-found', async () => {
-			mockSession.sdkSessionId = 'sdk-session-id';
-			mockSession.sdkOriginPath = '/old/sdk/path';
-			mockSession.metadata.resumeSessionAt = 'missing-message-uuid';
-			buildSpy
-				.mockRejectedValueOnce(
-					new Error('No message found with message.uuid of: missing-message-uuid')
-				)
-				.mockRejectedValueOnce(new Error('stop after retry'));
-
-			const ctx = createContext();
-			runner = new QueryRunner(ctx);
-			runner.start();
-			await ctx.queryPromise?.catch(() => {});
-
-			expect(buildSpy).toHaveBeenCalledTimes(2);
-			expect(mockSession.metadata.resumeSessionAt).toBeUndefined();
-			expect(mockSession.sdkSessionId).toBeUndefined();
-			expect(mockSession.sdkOriginPath).toBeUndefined();
-			expect(updateSessionSpy).toHaveBeenCalledWith('test-session-id', {
-				metadata: mockSession.metadata,
-				sdkSessionId: undefined,
-				sdkOriginPath: undefined,
-			});
-			expect(saveSDKMessageSpy).toHaveBeenCalledWith(
-				'test-session-id',
-				expect.objectContaining({
-					type: 'assistant',
-					message: expect.objectContaining({
-						content: expect.arrayContaining([
-							expect.objectContaining({
-								text: expect.stringContaining('Conversation context was reset'),
-							}),
-						]),
-					}),
-				})
+		it('should carry compacted summary while clearing stale resumeSessionAt and SDK state before retrying no-message-found', async () => {
+			const originalTestSdkSessionDir = process.env.TEST_SDK_SESSION_DIR;
+			const testSdkDir = join(
+				tmpdir(),
+				`query-runner-compaction-${Date.now()}-${Math.random().toString(36).slice(2)}`
 			);
+			try {
+				process.env.TEST_SDK_SESSION_DIR = testSdkDir;
+				mockSession.sdkSessionId = 'sdk-session-id';
+				mockSession.metadata.resumeSessionAt = 'missing-message-uuid';
+				const sessionFilePath = getSDKSessionFilePath(
+					mockSession.workspacePath!,
+					mockSession.sdkSessionId
+				);
+				mkdirSync(dirname(sessionFilePath), { recursive: true });
+				writeFileSync(
+					sessionFilePath,
+					[
+						JSON.stringify({
+							type: 'system',
+							subtype: 'compact_boundary',
+							compact_metadata: { trigger: 'auto', pre_tokens: 150000 },
+						}),
+						JSON.stringify({
+							type: 'assistant',
+							message: {
+								role: 'assistant',
+								content: [{ type: 'text', text: 'Recovered compacted context' }],
+							},
+						}),
+					].join('\n') + '\n',
+					'utf-8'
+				);
+
+				buildSpy
+					.mockRejectedValueOnce(
+						new Error('No message found with message.uuid of: missing-message-uuid')
+					)
+					.mockRejectedValueOnce(new Error('stop after retry'));
+
+				const ctx = createContext();
+				runner = new QueryRunner(ctx);
+				runner.start();
+				await ctx.queryPromise?.catch(() => {});
+
+				expect(buildSpy).toHaveBeenCalledTimes(2);
+				expect(mockSession.metadata.resumeSessionAt).toBeUndefined();
+				expect(mockSession.metadata.compactionSummary).toBe('Recovered compacted context');
+				expect(mockSession.sdkSessionId).toBeUndefined();
+				expect(mockSession.sdkOriginPath).toBeUndefined();
+				expect(updateSessionSpy).toHaveBeenCalledWith('test-session-id', {
+					metadata: mockSession.metadata,
+					sdkSessionId: undefined,
+					sdkOriginPath: undefined,
+				});
+				expect(saveSDKMessageSpy).toHaveBeenCalledWith(
+					'test-session-id',
+					expect.objectContaining({
+						type: 'assistant',
+						message: expect.objectContaining({
+							content: expect.arrayContaining([
+								expect.objectContaining({
+									text: expect.stringContaining('compacted summary'),
+								}),
+							]),
+						}),
+					})
+				);
+			} finally {
+				rmSync(testSdkDir, { recursive: true, force: true });
+				if (originalTestSdkSessionDir !== undefined) {
+					process.env.TEST_SDK_SESSION_DIR = originalTestSdkSessionDir;
+				} else {
+					delete process.env.TEST_SDK_SESSION_DIR;
+				}
+			}
 		});
 
 		it('should call stateManager.setIdle after handling startup timeout error', async () => {

--- a/packages/daemon/tests/unit/1-core/agent/rewind-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/rewind-handler.test.ts
@@ -7,6 +7,9 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 import type { Query } from '@anthropic-ai/claude-agent-sdk';
 import type { Session } from '@neokai/shared';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { QueryLifecycleManager } from '../../../../src/lib/agent/query-lifecycle-manager';
 import {
 	RewindHandler,
@@ -35,6 +38,8 @@ describe('RewindHandler', () => {
 	let deleteMessagesAtAndAfterSpy: ReturnType<typeof mock>;
 	let rewindFilesSpy: ReturnType<typeof mock>;
 	let updateSessionSpy: ReturnType<typeof mock>;
+	let testSdkSessionDir: string;
+	let originalTestSdkSessionDir: string | undefined;
 
 	const testTimestamp = Date.now();
 	const testRewindPoint: RewindPoint = {
@@ -49,6 +54,7 @@ describe('RewindHandler', () => {
 			id: 'test-session-id',
 			title: 'Test Session',
 			workspacePath: '/test/path',
+			sdkSessionId: 'test-sdk-session-id',
 			status: 'active',
 			config: { model: 'claude-sonnet-4-20250514' },
 			metadata: {},
@@ -107,6 +113,25 @@ describe('RewindHandler', () => {
 		mockQueryObject = {
 			rewindFiles: rewindFilesSpy,
 		} as unknown as Query;
+
+		originalTestSdkSessionDir = process.env.TEST_SDK_SESSION_DIR;
+		testSdkSessionDir = join(
+			tmpdir(),
+			`rewind-sdk-sessions-${Date.now()}-${Math.random().toString(36).slice(2)}`
+		);
+		process.env.TEST_SDK_SESSION_DIR = testSdkSessionDir;
+	});
+
+	afterEach(() => {
+		if (existsSync(testSdkSessionDir)) {
+			rmSync(testSdkSessionDir, { recursive: true, force: true });
+		}
+
+		if (originalTestSdkSessionDir !== undefined) {
+			process.env.TEST_SDK_SESSION_DIR = originalTestSdkSessionDir;
+		} else {
+			delete process.env.TEST_SDK_SESSION_DIR;
+		}
 	});
 
 	function createContext(overrides: Partial<RewindHandlerContext> = {}): RewindHandlerContext {
@@ -124,6 +149,27 @@ describe('RewindHandler', () => {
 
 	function createHandler(overrides: Partial<RewindHandlerContext> = {}): RewindHandler {
 		return new RewindHandler(createContext(overrides));
+	}
+
+	function writeSdkTranscript(uuids: string[], session = mockSession): void {
+		const workspacePath = session.worktree ? session.worktree.worktreePath : session.workspacePath;
+		if (!workspacePath || !session.sdkSessionId) {
+			throw new Error('Test session requires workspacePath and sdkSessionId');
+		}
+
+		const projectKey = workspacePath.replace(/[/.]/g, '-');
+		const sessionDir = join(testSdkSessionDir, 'projects', projectKey);
+		mkdirSync(sessionDir, { recursive: true });
+		const sessionFile = join(sessionDir, `${session.sdkSessionId}.jsonl`);
+		const lines = uuids.map((uuid) =>
+			JSON.stringify({
+				type: 'user',
+				uuid,
+				sessionId: session.id,
+				message: { role: 'user', content: [{ type: 'text', text: uuid }] },
+			})
+		);
+		writeFileSync(sessionFile, lines.join('\n') + '\n', 'utf-8');
 	}
 
 	describe('constructor', () => {
@@ -344,11 +390,31 @@ describe('RewindHandler', () => {
 				};
 				// getUserMessages is called AFTER deleteMessagesAtAndAfter, so it should return only remaining messages
 				getUserMessagesSpy.mockReturnValue([previousMessage]);
+				writeSdkTranscript([previousMessage.uuid]);
 
 				handler = createHandler();
 				await handler.executeRewind(testRewindPoint.uuid, 'conversation');
 
 				expect(mockSession.metadata.resumeSessionAt).toBe('prev-msg-uuid');
+				expect(updateSessionSpy).toHaveBeenCalledWith(mockSession.id, {
+					metadata: mockSession.metadata,
+				});
+			});
+
+			it('should clear resumeSessionAt when previous user message is missing from SDK transcript', async () => {
+				const previousMessage = {
+					uuid: 'compacted-prev-msg-uuid',
+					timestamp: testTimestamp - 10000,
+					content: 'Previous message',
+				};
+				mockSession.metadata.resumeSessionAt = 'old-resume-uuid';
+				getUserMessagesSpy.mockReturnValue([previousMessage]);
+				writeSdkTranscript(['different-message-uuid']);
+
+				handler = createHandler();
+				await handler.executeRewind(testRewindPoint.uuid, 'conversation');
+
+				expect(mockSession.metadata.resumeSessionAt).toBeUndefined();
 				expect(updateSessionSpy).toHaveBeenCalledWith(mockSession.id, {
 					metadata: mockSession.metadata,
 				});
@@ -610,11 +676,33 @@ describe('RewindHandler', () => {
 			}));
 			// After deletion, getUserMessages returns only the previous message
 			getUserMessagesSpy.mockReturnValue([previousMessage]);
+			writeSdkTranscript([previousMessage.uuid]);
 
 			handler = createHandler();
 			await handler.executeSelectiveRewind([testRewindPoint.uuid]);
 
 			expect(mockSession.metadata.resumeSessionAt).toBe('prev-msg-uuid');
+			expect(updateSessionSpy).toHaveBeenCalled();
+		});
+
+		it('should clear resumeSessionAt after selective rewind when previous UUID is missing from SDK transcript', async () => {
+			const previousMessage = {
+				uuid: 'compacted-prev-msg-uuid',
+				timestamp: testTimestamp - 10000,
+				content: 'Previous message',
+			};
+			mockSession.metadata.resumeSessionAt = 'old-resume-uuid';
+			mockDb.getSDKMessages = mock(() => ({
+				messages: [{ uuid: testRewindPoint.uuid, timestamp: testTimestamp }],
+				hasMore: false,
+			}));
+			getUserMessagesSpy.mockReturnValue([previousMessage]);
+			writeSdkTranscript(['different-message-uuid']);
+
+			handler = createHandler();
+			await handler.executeSelectiveRewind([testRewindPoint.uuid]);
+
+			expect(mockSession.metadata.resumeSessionAt).toBeUndefined();
 			expect(updateSessionSpy).toHaveBeenCalled();
 		});
 	});

--- a/packages/daemon/tests/unit/1-core/core/sdk-session-file-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/sdk-session-file-manager.test.ts
@@ -20,6 +20,7 @@ import {
 	identifyOrphanedSDKFiles,
 	removeToolResultFromSessionFile,
 	truncateSessionFileAtMessage,
+	messageUuidExistsInSessionFile,
 	findSDKSessionFileGlobally,
 	migrateSDKSessionFile,
 } from '../../../../src/lib/sdk-session-file-manager';
@@ -1091,6 +1092,62 @@ describe('SDK Session File Manager', () => {
 
 			expect(userMessage.message.content[0].content[0].text).toContain('Output removed by user');
 			expect(userMessage.message.content[1].content[0].text).toContain('Output removed by user');
+		});
+	});
+
+	describe('messageUuidExistsInSessionFile', () => {
+		test('should return true when UUID exists in direct session file', () => {
+			const messages = [
+				JSON.stringify({ type: 'user', uuid: 'message-uuid-1' }),
+				JSON.stringify({ type: 'assistant', uuid: 'message-uuid-2' }),
+			];
+			writeFileSync(testSessionFile, messages.join('\n') + '\n', 'utf-8');
+
+			const exists = messageUuidExistsInSessionFile(
+				testWorkspacePath,
+				testSdkSessionId,
+				'kai-session-id',
+				'message-uuid-2'
+			);
+
+			expect(exists).toBe(true);
+		});
+
+		test('should return false when UUID is absent from direct session file', () => {
+			writeFileSync(
+				testSessionFile,
+				JSON.stringify({ type: 'user', uuid: 'message-uuid-1' }) + '\n',
+				'utf-8'
+			);
+
+			const exists = messageUuidExistsInSessionFile(
+				testWorkspacePath,
+				testSdkSessionId,
+				'kai-session-id',
+				'missing-message-uuid'
+			);
+
+			expect(exists).toBe(false);
+		});
+
+		test('should fall back to Kai session ID lookup when sdkSessionId is unavailable', () => {
+			writeFileSync(
+				testSessionFile,
+				[
+					JSON.stringify({ type: 'system', sessionId: 'kai-session-fallback' }),
+					JSON.stringify({ type: 'user', uuid: 'fallback-message-uuid' }),
+				].join('\n') + '\n',
+				'utf-8'
+			);
+
+			const exists = messageUuidExistsInSessionFile(
+				testWorkspacePath,
+				undefined,
+				'kai-session-fallback',
+				'fallback-message-uuid'
+			);
+
+			expect(exists).toBe(true);
 		});
 	});
 

--- a/packages/daemon/tests/unit/1-core/core/sdk-session-file-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/sdk-session-file-manager.test.ts
@@ -21,6 +21,7 @@ import {
 	removeToolResultFromSessionFile,
 	truncateSessionFileAtMessage,
 	messageUuidExistsInSessionFile,
+	extractCompactionSummary,
 	findSDKSessionFileGlobally,
 	migrateSDKSessionFile,
 } from '../../../../src/lib/sdk-session-file-manager';
@@ -893,6 +894,88 @@ describe('SDK Session File Manager', () => {
 			const sdkIds = orphaned.map((o) => o.sdkSessionId);
 			expect(sdkIds).toContain('orphan');
 			expect(sdkIds).toContain('unknown');
+		});
+	});
+
+	describe('extractCompactionSummary', () => {
+		test('should return null when file does not exist', () => {
+			const summary = extractCompactionSummary(join(testSessionDir, 'missing.jsonl'));
+
+			expect(summary).toBeNull();
+		});
+
+		test('should return null when transcript has no compact boundary', () => {
+			writeFileSync(
+				testSessionFile,
+				JSON.stringify({
+					type: 'assistant',
+					message: { role: 'assistant', content: [{ type: 'text', text: 'No compaction yet' }] },
+				}) + '\n',
+				'utf-8'
+			);
+
+			const summary = extractCompactionSummary(testSessionFile);
+
+			expect(summary).toBeNull();
+		});
+
+		test('should extract first assistant text after the latest compact boundary', () => {
+			const messages = [
+				JSON.stringify({
+					type: 'system',
+					subtype: 'compact_boundary',
+					compact_metadata: { trigger: 'auto', pre_tokens: 1000 },
+				}),
+				JSON.stringify({
+					type: 'assistant',
+					message: {
+						role: 'assistant',
+						content: [{ type: 'text', text: 'Old compacted summary' }],
+					},
+				}),
+				JSON.stringify({
+					type: 'system',
+					subtype: 'compact_boundary',
+					compact_metadata: { trigger: 'auto', pre_tokens: 2000 },
+				}),
+				JSON.stringify({
+					type: 'assistant',
+					message: {
+						role: 'assistant',
+						content: [
+							{ type: 'text', text: 'Latest compacted summary' },
+							{ type: 'text', text: 'with continuation' },
+						],
+					},
+				}),
+			];
+			writeFileSync(testSessionFile, `${messages.join('\n')}\n`, 'utf-8');
+
+			const summary = extractCompactionSummary(testSessionFile);
+
+			expect(summary).toBe('Latest compacted summary\n\nwith continuation');
+		});
+
+		test('should extract summary text from user message after compact boundary', () => {
+			const messages = [
+				JSON.stringify({
+					type: 'system',
+					subtype: 'compact_boundary',
+					compact_metadata: { trigger: 'auto', pre_tokens: 1000 },
+				}),
+				JSON.stringify({
+					type: 'user',
+					message: {
+						role: 'user',
+						content: 'Previous conversation summary lives here',
+					},
+				}),
+			];
+			writeFileSync(testSessionFile, `${messages.join('\n')}\n`, 'utf-8');
+
+			const summary = extractCompactionSummary(testSessionFile);
+
+			expect(summary).toBe('Previous conversation summary lives here');
 		});
 	});
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -537,6 +537,7 @@ export interface SessionMetadata {
 	lastSdkCost?: number; // Last SDK-reported total_cost_usd (resets when agent restarts)
 	costBaseline?: number; // Accumulated cost from previous runs before last reset
 	resumeSessionAt?: string; // Checkpoint ID to resume conversation from (for rewind feature)
+	compactionSummary?: string; // Temporary carry-over summary when SDK compaction forces a fresh session
 	worktreeChoice?: {
 		status: 'pending' | 'completed';
 		choice?: 'worktree' | 'direct';


### PR DESCRIPTION
Fixes SDK compaction/rewind races by clearing stale resume pointers and SDK session state when the SDK reports a missing message UUID, then retrying with a fresh context.

Adds rewind-time validation that resume targets still exist in the SDK JSONL transcript before persisting resumeSessionAt, with focused unit coverage for the helper and recovery paths.