### PR TITLE
Disable Codex bridge SDK auto-compaction

### DIFF
--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -47,6 +47,26 @@ import {
 import { homedir } from 'os';
 import { join } from 'path';
 
+export const CODEX_BRIDGE_AUTO_COMPACT_WINDOW = 1_000_000;
+
+/**
+ * Provider-specific SDK settings overrides.
+ */
+export function buildProviderSettings(providerId: string): Options['settings'] {
+	if (providerId !== 'anthropic-codex') {
+		return undefined;
+	}
+
+	// The Claude Agent SDK can auto-compact by starting a second /v1/messages
+	// request while the original turn is still streaming. The Codex bridge
+	// fronts one Codex subprocess per session and intentionally rejects that
+	// concurrent turn with 409, so raise the SDK threshold above every Codex
+	// bridge context window and let Codex manage its own context.
+	return {
+		autoCompactWindow: CODEX_BRIDGE_AUTO_COMPACT_WINDOW,
+	};
+}
+
 /**
  * Context interface - what QueryOptionsBuilder needs from AgentSession
  * Using interface instead of importing AgentSession to avoid circular deps
@@ -132,6 +152,7 @@ export class QueryOptionsBuilder {
 		// (default, haiku, opus) since the SDK only knows Anthropic model IDs
 		const contextManager = getProviderContextManager();
 		const providerContext = contextManager.createContext(this.ctx.session);
+		const providerId = providerContext.provider.id;
 		const sdkModelId = providerContext.getSdkModelId();
 		let sdkFallbackModel: string | undefined;
 		if (config.fallbackModel) {
@@ -244,6 +265,7 @@ export class QueryOptionsBuilder {
 			// or other settings from on-disk files. NeoKai is the sole arbiter of
 			// what reaches the SDK. See M5 of `unify-mcp-config-model`.
 			settingSources: [],
+			settings: buildProviderSettings(providerId),
 
 			// ============ Streaming ============
 			includePartialMessages: config.includePartialMessages,

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -7,7 +7,9 @@
 import { describe, expect, it, beforeEach, afterEach, mock } from 'bun:test';
 import { Database as BunDatabase } from 'bun:sqlite';
 import {
+	CODEX_BRIDGE_AUTO_COMPACT_WINDOW,
 	QueryOptionsBuilder,
+	buildProviderSettings,
 	type QueryOptionsBuilderContext,
 } from '../../../../src/lib/agent/query-options-builder';
 import type { Session } from '@neokai/shared';
@@ -138,12 +140,32 @@ describe('QueryOptionsBuilder', () => {
 			expect(options.env).toEqual({ MY_VAR: 'value' });
 		});
 
+		it('should not override SDK auto-compaction settings for other providers', async () => {
+			const options = await builder.build();
+
+			expect(options.settings).toBeUndefined();
+		});
+
 		it('should remove undefined values from options', async () => {
 			const options = await builder.build();
 			// Should not have undefined values
 			for (const [_key, value] of Object.entries(options)) {
 				expect(value).not.toBeUndefined();
 			}
+		});
+	});
+
+	describe('provider settings', () => {
+		it('should disable SDK auto-compaction for Codex bridge provider sessions', () => {
+			expect(buildProviderSettings('anthropic-codex')).toEqual({
+				autoCompactWindow: CODEX_BRIDGE_AUTO_COMPACT_WINDOW,
+			});
+		});
+
+		it('should not override SDK auto-compaction settings for other providers', () => {
+			expect(buildProviderSettings('anthropic')).toBeUndefined();
+			expect(buildProviderSettings('glm')).toBeUndefined();
+			expect(buildProviderSettings('anthropic-copilot')).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
Disables Claude Agent SDK auto-compaction for Anthropic Codex bridge sessions by setting the SDK auto-compact window above the bridge context window.

Adds provider-specific regression coverage while leaving other providers on the SDK default behavior.