### PR TITLE
Fix message type misclassification in unified thread view

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -879,6 +879,7 @@ joined AS (
     ase.task_title AS taskTitle,
     sm.message_type AS messageType,
     sm.sdk_message AS content,
+    sm.origin AS origin,
     CAST((julianday(sm.timestamp) - 2440587.5) * 86400000 AS INTEGER) AS createdAt,
     CAST(COALESCE(json_extract(sm.sdk_message, '$._taskMeta.iteration'), 0) AS INTEGER) AS iteration,
     json_extract(sm.sdk_message, '$.parent_tool_use_id') AS parentToolUseId

--- a/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
@@ -80,7 +80,11 @@ export interface TaskAgentManagerInterface {
 	 * Optional: inject a message directly into a node agent sub-session by its session ID.
 	 * Required for @mention routing to specific agents.
 	 */
-	injectSubSessionMessage?(subSessionId: string, message: string): Promise<void>;
+	injectSubSessionMessage?(
+		subSessionId: string,
+		message: string,
+		isSyntheticMessage?: boolean
+	): Promise<void>;
 	/**
 	 * Optional: lazy-activate a workflow-declared node agent for a given task.
 	 *
@@ -266,7 +270,7 @@ export function setupSpaceTaskMessageHandlers(
 		if (deliverable.length > 0) {
 			await Promise.all(
 				deliverable.map((exec) =>
-					taskAgentManager.injectSubSessionMessage!(exec.agentSessionId!, message)
+					taskAgentManager.injectSubSessionMessage!(exec.agentSessionId!, message, false)
 				)
 			);
 			return {
@@ -422,7 +426,7 @@ export function setupSpaceTaskMessageHandlers(
 					// Inject into all matching sessions in parallel (independent operations)
 					await Promise.all(
 						matches.map((exec) =>
-							taskAgentManager.injectSubSessionMessage!(exec.agentSessionId!, params.message)
+							taskAgentManager.injectSubSessionMessage!(exec.agentSessionId!, params.message, false)
 						)
 					);
 					routedTo.push(mention);
@@ -559,7 +563,7 @@ export function setupSpaceTaskMessageHandlers(
 
 		if (liveSession && params.message && taskAgentManager.injectSubSessionMessage) {
 			const prefixed = `[Message from human]: ${params.message}`;
-			await taskAgentManager.injectSubSessionMessage(liveSession.session.id, prefixed);
+			await taskAgentManager.injectSubSessionMessage(liveSession.session.id, prefixed, false);
 			log.info(
 				`space.task.activateNodeAgent: delivered message to live session ${liveSession.session.id} ` +
 					`(agent=${params.agentName}, task=${params.taskId})`

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1750,10 +1750,20 @@ export class TaskAgentManager {
 	 * Inject a message into a sub-session.
 	 * Called by the Task Agent MCP tool handler via the messageInjector callback.
 	 */
-	async injectSubSessionMessage(subSessionId: string, message: string): Promise<void> {
+	async injectSubSessionMessage(
+		subSessionId: string,
+		message: string,
+		isSyntheticMessage = true
+	): Promise<void> {
 		const indexed = this.agentSessionIndex.get(subSessionId);
 		if (indexed) {
-			await this.injectMessageIntoSession(indexed, message);
+			await this.injectMessageIntoSession(
+				indexed,
+				message,
+				'immediate',
+				undefined,
+				isSyntheticMessage
+			);
 			return;
 		}
 
@@ -1761,7 +1771,13 @@ export class TaskAgentManager {
 		for (const [, nodeMap] of this.subSessions) {
 			const session = nodeMap.get(subSessionId);
 			if (session) {
-				await this.injectMessageIntoSession(session, message);
+				await this.injectMessageIntoSession(
+					session,
+					message,
+					'immediate',
+					undefined,
+					isSyntheticMessage
+				);
 				return;
 			}
 		}
@@ -1769,7 +1785,13 @@ export class TaskAgentManager {
 		// Not in memory — attempt lazy rehydration from DB
 		const rehydrated = await this.rehydrateSubSession(subSessionId);
 		if (rehydrated) {
-			await this.injectMessageIntoSession(rehydrated, message);
+			await this.injectMessageIntoSession(
+				rehydrated,
+				message,
+				'immediate',
+				undefined,
+				isSyntheticMessage
+			);
 			return;
 		}
 		throw new Error(`Sub-session not found: ${subSessionId}`);

--- a/packages/web/src/components/space/thread/space-task-thread-events.ts
+++ b/packages/web/src/components/space/thread/space-task-thread-events.ts
@@ -330,6 +330,7 @@ export function parseThreadRow(row: SpaceTaskThreadMessageRow): ParsedThreadRow 
 		const withTimestamp = {
 			...(parsed as Record<string, unknown>),
 			timestamp: row.createdAt,
+			...(row.origin ? { origin: row.origin } : {}),
 		} as unknown as SDKMessage;
 
 		return {

--- a/packages/web/src/hooks/useSpaceTaskMessages.ts
+++ b/packages/web/src/hooks/useSpaceTaskMessages.ts
@@ -17,6 +17,8 @@ export interface SpaceTaskThreadMessageRow {
 	messageType: string;
 	content: string;
 	createdAt: number;
+	/** Message origin from the DB (human, neo, system). Used to classify sender in the thread UI. */
+	origin?: string | null;
 	parentToolUseId?: string | null;
 	/**
 	 * Server-computed turn index (per session) for compact thread grouping.


### PR DESCRIPTION
## Summary

- Human messages sent to node agents were incorrectly marked as synthetic (`isSynthetic=true`) because `injectSubSessionMessage` always defaulted to `true`, even for human-originated messages routed through the UI
- Runtime messages lost their `origin` classification because the compact query CTE didn't select `sm.origin`, causing the frontend to fall through to `isSynthetic` heuristics and misclassify agent messages as human
- Added `isSyntheticMessage` parameter to `injectSubSessionMessage` with `default true`; human-originated callers (target routing, @mention, activateNodeAgent) now pass `false`
- Added `sm.origin AS origin` to the compact query CTE and merged it into the parsed SDK message in `parseThreadRow`

## Test plan

- [ ] Send a human message to a node agent via the thread view — verify it renders as "User" not synthetic
- [ ] Check that agent-to-agent messages still render with agent labels
- [ ] Verify runtime messages (system, neo origin) are classified correctly in the compact thread feed
- [ ] Confirm @mention routing still works and messages are delivered correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)