### PR TITLE
Fix message type misclassification in unified thread view

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -879,6 +879,7 @@ joined AS (
     ase.task_title AS taskTitle,
     sm.message_type AS messageType,
     sm.sdk_message AS content,
+    sm.origin AS origin,
     CAST((julianday(sm.timestamp) - 2440587.5) * 86400000 AS INTEGER) AS createdAt,
     CAST(COALESCE(json_extract(sm.sdk_message, '$._taskMeta.iteration'), 0) AS INTEGER) AS iteration,
     json_extract(sm.sdk_message, '$.parent_tool_use_id') AS parentToolUseId

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -167,6 +167,7 @@ function mapSpaceTaskMessageRow(row: Record<string, unknown>): Record<string, un
 	const rawId = row.id;
 	const id = typeof rawId === 'string' || typeof rawId === 'number' ? rawId : `row-${createdAt}`;
 	const parentToolUseId = typeof row.parentToolUseId === 'string' ? row.parentToolUseId : null;
+	const origin = typeof row.origin === 'string' ? row.origin : null;
 	// Optional backward-compat field from older compact-query variants.
 	// Current compact SQL no longer emits this, but keep tolerant parsing so
 	// historical rows/tests and alternate query variants remain safe.
@@ -218,6 +219,7 @@ function mapSpaceTaskMessageRow(row: Record<string, unknown>): Record<string, un
 		messageType,
 		content,
 		createdAt,
+		origin,
 		parentToolUseId,
 	};
 	if (sessionMessageCount !== undefined) {
@@ -905,6 +907,7 @@ SELECT
   taskTitle,
   messageType,
   content,
+  origin,
   createdAt,
   iteration,
   parentToolUseId
@@ -1071,6 +1074,7 @@ SELECT
   taskTitle,
   messageType,
   content,
+  origin,
   createdAt,
   turnIndex,
   CASE

--- a/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
@@ -80,7 +80,11 @@ export interface TaskAgentManagerInterface {
 	 * Optional: inject a message directly into a node agent sub-session by its session ID.
 	 * Required for @mention routing to specific agents.
 	 */
-	injectSubSessionMessage?(subSessionId: string, message: string): Promise<void>;
+	injectSubSessionMessage?(
+		subSessionId: string,
+		message: string,
+		isSyntheticMessage?: boolean
+	): Promise<void>;
 	/**
 	 * Optional: lazy-activate a workflow-declared node agent for a given task.
 	 *
@@ -266,7 +270,7 @@ export function setupSpaceTaskMessageHandlers(
 		if (deliverable.length > 0) {
 			await Promise.all(
 				deliverable.map((exec) =>
-					taskAgentManager.injectSubSessionMessage!(exec.agentSessionId!, message)
+					taskAgentManager.injectSubSessionMessage!(exec.agentSessionId!, message, false)
 				)
 			);
 			return {
@@ -422,7 +426,7 @@ export function setupSpaceTaskMessageHandlers(
 					// Inject into all matching sessions in parallel (independent operations)
 					await Promise.all(
 						matches.map((exec) =>
-							taskAgentManager.injectSubSessionMessage!(exec.agentSessionId!, params.message)
+							taskAgentManager.injectSubSessionMessage!(exec.agentSessionId!, params.message, false)
 						)
 					);
 					routedTo.push(mention);
@@ -559,7 +563,7 @@ export function setupSpaceTaskMessageHandlers(
 
 		if (liveSession && params.message && taskAgentManager.injectSubSessionMessage) {
 			const prefixed = `[Message from human]: ${params.message}`;
-			await taskAgentManager.injectSubSessionMessage(liveSession.session.id, prefixed);
+			await taskAgentManager.injectSubSessionMessage(liveSession.session.id, prefixed, false);
 			log.info(
 				`space.task.activateNodeAgent: delivered message to live session ${liveSession.session.id} ` +
 					`(agent=${params.agentName}, task=${params.taskId})`

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -638,7 +638,7 @@ export class TaskAgentManager {
 				nodeExecutionRepo: this.config.nodeExecutionRepo,
 				taskManager,
 				messageInjector: (subSessionId, message) =>
-					this.injectSubSessionMessage(subSessionId, message),
+					this.injectSubSessionMessage(subSessionId, message, true),
 				daemonHub: this.config.daemonHub,
 				gateDataRepo: this.config.gateDataRepo,
 				workflowRunRepo: this.config.workflowRunRepo,
@@ -1571,8 +1571,9 @@ export class TaskAgentManager {
 
 		for (const row of pending) {
 			const prefixed = `[Message from ${row.sourceAgentName}]: ${row.message}`;
+			const isSyntheticMessage = row.sourceAgentName !== 'human';
 			try {
-				await this.injectSubSessionMessage(sessionId, prefixed);
+				await this.injectSubSessionMessage(sessionId, prefixed, isSyntheticMessage);
 				repo.markDelivered(row.id, sessionId);
 				this.emitPendingDelivered(row.id, sessionId, row);
 			} catch (err) {
@@ -2909,7 +2910,7 @@ export class TaskAgentManager {
 			nodeExecutionRepo: this.config.nodeExecutionRepo,
 			taskManager,
 			messageInjector: (subSessionId, message) =>
-				this.injectSubSessionMessage(subSessionId, message),
+				this.injectSubSessionMessage(subSessionId, message, true),
 			daemonHub: this.config.daemonHub,
 			gateDataRepo: this.config.gateDataRepo,
 			workflowRunRepo: this.config.workflowRunRepo,
@@ -3873,7 +3874,7 @@ export class TaskAgentManager {
 			workflowRunId,
 			workflowChannels: channels,
 			messageInjector: (targetSessionId, message) =>
-				this.injectSubSessionMessage(targetSessionId, message),
+				this.injectSubSessionMessage(targetSessionId, message, true),
 			channelRouter: nodeAgentChannelRouter,
 			nodeGroups,
 			taskAgentRouter: async (message) => {

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1711,10 +1711,20 @@ export class TaskAgentManager {
 	 * Inject a message into a sub-session.
 	 * Called by the Task Agent MCP tool handler via the messageInjector callback.
 	 */
-	async injectSubSessionMessage(subSessionId: string, message: string): Promise<void> {
+	async injectSubSessionMessage(
+		subSessionId: string,
+		message: string,
+		isSyntheticMessage = true
+	): Promise<void> {
 		const indexed = this.agentSessionIndex.get(subSessionId);
 		if (indexed) {
-			await this.injectMessageIntoSession(indexed, message);
+			await this.injectMessageIntoSession(
+				indexed,
+				message,
+				'immediate',
+				undefined,
+				isSyntheticMessage
+			);
 			return;
 		}
 
@@ -1722,7 +1732,13 @@ export class TaskAgentManager {
 		for (const [, nodeMap] of this.subSessions) {
 			const session = nodeMap.get(subSessionId);
 			if (session) {
-				await this.injectMessageIntoSession(session, message);
+				await this.injectMessageIntoSession(
+					session,
+					message,
+					'immediate',
+					undefined,
+					isSyntheticMessage
+				);
 				return;
 			}
 		}
@@ -1730,7 +1746,13 @@ export class TaskAgentManager {
 		// Not in memory — attempt lazy rehydration from DB
 		const rehydrated = await this.rehydrateSubSession(subSessionId);
 		if (rehydrated) {
-			await this.injectMessageIntoSession(rehydrated, message);
+			await this.injectMessageIntoSession(
+				rehydrated,
+				message,
+				'immediate',
+				undefined,
+				isSyntheticMessage
+			);
 			return;
 		}
 		throw new Error(`Sub-session not found: ${subSessionId}`);

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -601,7 +601,11 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			// Attempt direct injection when the execution already has a live session.
 			if (resolved.agentSessionId) {
 				try {
-					await taskAgentManager.injectSubSessionMessage(resolved.agentSessionId, args.message);
+					await taskAgentManager.injectSubSessionMessage(
+						resolved.agentSessionId,
+						args.message,
+						true
+					);
 					return jsonResult({
 						success: true,
 						task_id: task.id,
@@ -638,7 +642,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			const sessionIdAfter = refreshedExecution?.agentSessionId ?? null;
 			if (sessionIdAfter) {
 				try {
-					await taskAgentManager.injectSubSessionMessage(sessionIdAfter, args.message);
+					await taskAgentManager.injectSubSessionMessage(sessionIdAfter, args.message, true);
 					return jsonResult({
 						success: true,
 						task_id: task.id,

--- a/packages/daemon/src/lib/space/tools/task-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/task-agent-tools.ts
@@ -108,10 +108,14 @@ export interface TaskAgentToolsConfig {
 	/** Task manager for validated status transitions. */
 	taskManager: SpaceTaskManager;
 	/**
-	 * Injects a message into an existing sub-session as a user turn.
-	 * Used by send_message to deliver messages to node agents.
+	 * Injects a message into an existing sub-session as an SDK user turn.
+	 * Used by send_message to deliver synthetic agent-originated messages to node agents.
 	 */
-	messageInjector: (sessionId: string, message: string) => Promise<void>;
+	messageInjector: (
+		sessionId: string,
+		message: string,
+		isSyntheticMessage?: boolean
+	) => Promise<void>;
 	/**
 	 * DaemonHub instance for emitting task completion/failure events.
 	 * Optional — if omitted, no events are emitted (e.g. in unit tests that don't need them).
@@ -807,7 +811,7 @@ export function createTaskAgentToolHandlers(config: TaskAgentToolsConfig) {
 				// Deliver directly to the live session. injectSubSessionMessage calls
 				// ensureQueryStarted() so an idle session is automatically restarted.
 				try {
-					await messageInjector(liveSession.session.id, prefixedMessage);
+					await messageInjector(liveSession.session.id, prefixedMessage, true);
 					delivered.push({ agentName: targetAgentName, sessionId: liveSession.session.id });
 				} catch (err) {
 					const errMsg = err instanceof Error ? err.message : String(err);

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
@@ -466,6 +466,17 @@ describe('NAMED_QUERY_REGISTRY', () => {
 				return entry.mapRow ? rows.map(entry.mapRow) : rows;
 			}
 
+			test('includes DB message origin in compact rows', () => {
+				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
+				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');
+				insertSdkMessageAt('system-origin', sessionId, now + 1000);
+
+				const rows = queryCompact(taskId);
+
+				expect(rows).toHaveLength(1);
+				expect(rows[0].origin).toBe('system');
+			});
+
 			test('keeps last 5 non-terminal rows per turn and always keeps terminal rows', () => {
 				const taskId = insertSpaceTask({ taskAgentSessionId: sessionId });
 				insertSession(sessionId, 'space_task_agent', '{"status":"processing"}');

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-message-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-message-handlers.test.ts
@@ -669,7 +669,11 @@ describe('setupSpaceTaskMessageHandlers', () => {
 
 			expect(result).toMatchObject({ ok: true, routedTo: ['Coder'] });
 			expect(injectSubSession).toHaveBeenCalledTimes(1);
-			expect(injectSubSession).toHaveBeenCalledWith('session-coder-1', '@Coder please fix the bug');
+			expect(injectSubSession).toHaveBeenCalledWith(
+				'session-coder-1',
+				'@Coder please fix the bug',
+				false
+			);
 			// Should NOT have routed to Task Agent
 			expect(taskAgentManager.injectTaskAgentMessage).not.toHaveBeenCalled();
 		});
@@ -734,8 +738,16 @@ describe('setupSpaceTaskMessageHandlers', () => {
 			expect(result).toMatchObject({ ok: true, routedTo: ['Coder'] });
 			// Should have injected into both Coder sessions
 			expect(injectSubSession).toHaveBeenCalledTimes(2);
-			expect(injectSubSession).toHaveBeenCalledWith('session-coder-1', '@Coder please check both');
-			expect(injectSubSession).toHaveBeenCalledWith('session-coder-2', '@Coder please check both');
+			expect(injectSubSession).toHaveBeenCalledWith(
+				'session-coder-1',
+				'@Coder please check both',
+				false
+			);
+			expect(injectSubSession).toHaveBeenCalledWith(
+				'session-coder-2',
+				'@Coder please check both',
+				false
+			);
 		});
 
 		it('partial routing: valid mentions route, invalid mentions listed in notFound', async () => {
@@ -767,7 +779,7 @@ describe('setupSpaceTaskMessageHandlers', () => {
 			});
 
 			expect(result).toMatchObject({ ok: true, routedTo: ['coder'] });
-			expect(injectSubSession).toHaveBeenCalledWith('session-coder-1', '@coder please fix');
+			expect(injectSubSession).toHaveBeenCalledWith('session-coder-1', '@coder please fix', false);
 		});
 
 		it('message without @mentions falls back to Task Agent routing', async () => {
@@ -818,7 +830,11 @@ describe('setupSpaceTaskMessageHandlers', () => {
 
 			expect(result).toMatchObject({ ok: true, routedTo: ['Reviewer'] });
 			expect(injectSubSession).toHaveBeenCalledTimes(1);
-			expect(injectSubSession).toHaveBeenCalledWith('session-reviewer-1', 'Please review this');
+			expect(injectSubSession).toHaveBeenCalledWith(
+				'session-reviewer-1',
+				'Please review this',
+				false
+			);
 			expect(taskAgentManager.injectTaskAgentMessage).not.toHaveBeenCalled();
 		});
 
@@ -858,7 +874,8 @@ describe('setupSpaceTaskMessageHandlers', () => {
 			expect(result).toMatchObject({ ok: true, routedTo: ['Reviewer'] });
 			expect(injectSubSession).toHaveBeenCalledWith(
 				'session-reviewer-idle',
-				'@Reviewer please review'
+				'@Reviewer please review',
+				false
 			);
 		});
 
@@ -883,11 +900,24 @@ describe('setupSpaceTaskMessageHandlers', () => {
 			expect(injectSubSession).toHaveBeenCalledTimes(3); // idle + blocked + in_progress
 			expect(injectSubSession).not.toHaveBeenCalledWith(
 				'session-coder-cancelled',
-				expect.anything()
+				expect.anything(),
+				false
 			);
-			expect(injectSubSession).toHaveBeenCalledWith('session-coder-idle', '@Coder please check');
-			expect(injectSubSession).toHaveBeenCalledWith('session-coder-blocked', '@Coder please check');
-			expect(injectSubSession).toHaveBeenCalledWith('session-coder-active', '@Coder please check');
+			expect(injectSubSession).toHaveBeenCalledWith(
+				'session-coder-idle',
+				'@Coder please check',
+				false
+			);
+			expect(injectSubSession).toHaveBeenCalledWith(
+				'session-coder-blocked',
+				'@Coder please check',
+				false
+			);
+			expect(injectSubSession).toHaveBeenCalledWith(
+				'session-coder-active',
+				'@Coder please check',
+				false
+			);
 		});
 
 		it('@mention throws when all matching agents are cancelled', async () => {
@@ -1085,8 +1115,8 @@ describe('setupSpaceTaskMessageHandlers', () => {
 
 			expect(result).toMatchObject({ ok: true, routedTo: ['Coder'] });
 			expect(injectSubSession).toHaveBeenCalledTimes(2);
-			expect(injectSubSession).toHaveBeenCalledWith('session-coder-a', 'Please check both');
-			expect(injectSubSession).toHaveBeenCalledWith('session-coder-b', 'Please check both');
+			expect(injectSubSession).toHaveBeenCalledWith('session-coder-a', 'Please check both', false);
+			expect(injectSubSession).toHaveBeenCalledWith('session-coder-b', 'Please check both', false);
 		});
 
 		it('activateNode invoked once per unique missing workflowNodeId (deduped)', async () => {
@@ -1195,7 +1225,7 @@ describe('setupSpaceTaskMessageHandlers', () => {
 
 			expect(activateCalls).toEqual(['node-rev']);
 			expect(injectSub).toHaveBeenCalledTimes(1);
-			expect(injectSub).toHaveBeenCalledWith('session-reviewer-live', 'Please review');
+			expect(injectSub).toHaveBeenCalledWith('session-reviewer-live', 'Please review', false);
 			expect(result).toMatchObject({
 				ok: true,
 				routedTo: ['Reviewer'],

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
@@ -945,6 +945,70 @@ describe('TaskAgentManager.tryResumeNodeAgentSession', () => {
 		);
 		expect(fastPathMsg).toBeDefined();
 	});
+
+	test('flushes human-originated pending messages as non-synthetic', async () => {
+		const pendingRepo = new PendingAgentMessageRepository(ctx.bunDb);
+
+		const wfRunId = 'run-resume-human-pending-1';
+		const wfId = 'wf-resume-human-pending-1';
+		const nodeId = 'node-resume-human-pending-1';
+		seedWorkflowRun(ctx, wfRunId, wfId, nodeId);
+
+		const parentTask = await ctx.taskManager.createTask({
+			title: 'Parent task for human pending delivery',
+			description: '',
+			taskType: 'coding',
+			status: 'in_progress',
+			workflowRunId: wfRunId,
+		});
+		const taskAgentSessionId = `space:${ctx.spaceId}:task:${parentTask.id}`;
+		ctx.taskRepo.updateTask(parentTask.id, { taskAgentSessionId, status: 'in_progress' });
+		ctx.mockDb.createSession({ id: taskAgentSessionId, type: 'space_task_agent' });
+
+		const subSessionId = `space:${ctx.spaceId}:task:${parentTask.id}:exec:human-pending-exec`;
+		const execution = ctx.nodeExecutionRepo.create({
+			workflowRunId: wfRunId,
+			workflowNodeId: nodeId,
+			agentName: 'coder',
+			agentId: null,
+			status: 'in_progress',
+		});
+		ctx.nodeExecutionRepo.updateSessionId(execution.id, subSessionId);
+		ctx.mockDb.createSession({ id: subSessionId, type: 'worker' });
+
+		const manager = makeManagerWithPendingRepo(ctx, pendingRepo);
+		await manager.injectSubSessionMessage(subSessionId, 'prime session');
+
+		pendingRepo.enqueue({
+			workflowRunId: wfRunId,
+			spaceId: ctx.spaceId,
+			taskId: parentTask.id,
+			sourceAgentName: 'human',
+			targetKind: 'node_agent',
+			targetAgentName: 'coder',
+			message: 'please handle this',
+		});
+
+		const savedMessages: unknown[] = [];
+		const originalSave = ctx.mockDb.saveUserMessage;
+		ctx.mockDb.saveUserMessage = (
+			_sid: string,
+			msg: unknown,
+			status: string
+		): ReturnType<typeof ctx.mockDb.saveUserMessage> => {
+			savedMessages.push(msg);
+			return originalSave.call(ctx.mockDb, _sid, msg, status);
+		};
+
+		await manager.flushPendingMessagesForTarget(wfRunId, 'coder', subSessionId);
+
+		ctx.mockDb.saveUserMessage = originalSave;
+
+		const delivered = savedMessages.find((msg) =>
+			JSON.stringify(msg).includes('please handle this')
+		) as { isSynthetic?: boolean } | undefined;
+		expect(delivered?.isSynthetic).toBe(false);
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
@@ -1633,6 +1633,64 @@ describe('TaskAgentManager', () => {
 
 			expect(subSession._enqueuedMessages.length).toBeGreaterThan(before);
 		});
+
+		test('defaults sub-session injections to synthetic agent-originated messages', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			const subSessionId = `space:${ctx.spaceId}:task:${task.id}:step:synthetic-default`;
+			await ctx.manager.createSubSession(task.id, subSessionId, {
+				sessionId: subSessionId,
+				workspacePath: '/tmp/ws',
+			} as unknown as import('../../../../src/lib/agent/agent-session.ts').AgentSessionInit);
+
+			const savedMessages: unknown[] = [];
+			const originalSave = ctx.mockDb.saveUserMessage;
+			ctx.mockDb.saveUserMessage = (
+				_sid: string,
+				msg: unknown,
+				status: string
+			): ReturnType<typeof ctx.mockDb.saveUserMessage> => {
+				savedMessages.push(msg);
+				return originalSave.call(ctx.mockDb, _sid, msg, status);
+			};
+
+			await ctx.manager.injectSubSessionMessage(subSessionId, 'agent handoff');
+
+			ctx.mockDb.saveUserMessage = originalSave;
+
+			const lastSaved = savedMessages.at(-1) as { isSynthetic?: boolean } | undefined;
+			expect(lastSaved?.isSynthetic).toBe(true);
+		});
+
+		test('can mark sub-session injections as human-originated', async () => {
+			const task = await makeTask(ctx.taskManager);
+			await ctx.manager.spawnTaskAgent(task, ctx.space, null, null);
+
+			const subSessionId = `space:${ctx.spaceId}:task:${task.id}:step:human-injection`;
+			await ctx.manager.createSubSession(task.id, subSessionId, {
+				sessionId: subSessionId,
+				workspacePath: '/tmp/ws',
+			} as unknown as import('../../../../src/lib/agent/agent-session.ts').AgentSessionInit);
+
+			const savedMessages: unknown[] = [];
+			const originalSave = ctx.mockDb.saveUserMessage;
+			ctx.mockDb.saveUserMessage = (
+				_sid: string,
+				msg: unknown,
+				status: string
+			): ReturnType<typeof ctx.mockDb.saveUserMessage> => {
+				savedMessages.push(msg);
+				return originalSave.call(ctx.mockDb, _sid, msg, status);
+			};
+
+			await ctx.manager.injectSubSessionMessage(subSessionId, 'human directed message', false);
+
+			ctx.mockDb.saveUserMessage = originalSave;
+
+			const lastSaved = savedMessages.at(-1) as { isSynthetic?: boolean } | undefined;
+			expect(lastSaved?.isSynthetic).toBe(false);
+		});
 	});
 
 	// -----------------------------------------------------------------------

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-tools.test.ts
@@ -294,7 +294,11 @@ function makeConfig(
 	taskId: string,
 	workflowRunId: string,
 	options?: {
-		messageInjector?: (sessionId: string, message: string) => Promise<void>;
+		messageInjector?: (
+			sessionId: string,
+			message: string,
+			isSyntheticMessage?: boolean
+		) => Promise<void>;
 	}
 ): TaskAgentToolsConfig {
 	return {
@@ -1431,11 +1435,15 @@ describe('createTaskAgentToolHandlers — send_message queue-until-active', () =
 			ensureWorkflowNodeActivationForAgent: async () => false,
 		} as unknown as TaskAgentToolsConfig['taskAgentManager'];
 
-		const delivered: Array<{ sessionId: string; message: string }> = [];
+		const delivered: Array<{
+			sessionId: string;
+			message: string;
+			isSyntheticMessage?: boolean;
+		}> = [];
 		const config: TaskAgentToolsConfig = {
 			...makeConfig(ctx, mainTask.id, run.id, {
-				messageInjector: async (sessionId, message) => {
-					delivered.push({ sessionId, message });
+				messageInjector: async (sessionId, message, isSyntheticMessage) => {
+					delivered.push({ sessionId, message, isSyntheticMessage });
 				},
 			}),
 			pendingMessageRepo: pendingRepo,
@@ -1458,6 +1466,7 @@ describe('createTaskAgentToolHandlers — send_message queue-until-active', () =
 		// The coder got the message right away.
 		expect(delivered).toHaveLength(1);
 		expect(delivered[0].message).toBe('[Message from task-agent]: hi all');
+		expect(delivered[0].isSyntheticMessage).toBe(true);
 
 		// The reviewer message is queued.
 		const pending = pendingRepo.listPendingForTarget(run.id, 'reviewer');

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -1520,7 +1520,7 @@ interface FakeTaskAgentManager {
 	manager: TaskAgentManager;
 	ensureCalls: string[];
 	taskAgentInjects: Array<{ taskId: string; message: string }>;
-	subSessionInjects: Array<{ sessionId: string; message: string }>;
+	subSessionInjects: Array<{ sessionId: string; message: string; isSyntheticMessage?: boolean }>;
 	/** Session IDs that should throw `Sub-session not found` on inject. */
 	deadSessionIds: Set<string>;
 	/** Hook invoked before ensureTaskAgentSession resolves. Allows simulating
@@ -1553,11 +1553,15 @@ function makeFakeTaskAgentManager(ctx: TestCtx): FakeTaskAgentManager {
 		async injectTaskAgentMessage(taskId: string, message: string): Promise<void> {
 			state.taskAgentInjects.push({ taskId, message });
 		},
-		async injectSubSessionMessage(sessionId: string, message: string): Promise<void> {
+		async injectSubSessionMessage(
+			sessionId: string,
+			message: string,
+			isSyntheticMessage?: boolean
+		): Promise<void> {
 			if (state.deadSessionIds.has(sessionId)) {
 				throw new Error(`Sub-session not found: ${sessionId}`);
 			}
-			state.subSessionInjects.push({ sessionId, message });
+			state.subSessionInjects.push({ sessionId, message, isSyntheticMessage });
 		},
 	} as unknown as TaskAgentManager;
 	return { manager, ...state };
@@ -1793,7 +1797,11 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 		// Direct-injection path must skip activateNode.
 		expect(activateCalls).toHaveLength(0);
 		expect(tam.subSessionInjects).toEqual([
-			{ sessionId: 'coder-session-live', message: 'refactor the parser' },
+			{
+				sessionId: 'coder-session-live',
+				message: 'refactor the parser',
+				isSyntheticMessage: true,
+			},
 		]);
 		// The Task Agent path was not touched.
 		expect(tam.ensureCalls).toHaveLength(0);
@@ -1833,7 +1841,11 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 		expect(parsed.success).toBe(true);
 		expect(parsed.node_execution_id).toBe(reviewerB.id);
 		expect(tam.subSessionInjects).toEqual([
-			{ sessionId: 'reviewer-b-session', message: 'please re-review' },
+			{
+				sessionId: 'reviewer-b-session',
+				message: 'please re-review',
+				isSyntheticMessage: true,
+			},
 		]);
 		// Ensure the other reviewer was never touched.
 		expect(tam.subSessionInjects.some((r) => r.sessionId === reviewerA.agentSessionId)).toBe(false);
@@ -1879,6 +1891,7 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 			{
 				sessionId: 'reviewer-session-newly-restored',
 				message: 'please re-review',
+				isSyntheticMessage: true,
 			},
 		]);
 	});
@@ -2033,7 +2046,11 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 		expect(parsed.success).toBe(true);
 		expect(parsed.node_execution_id).toBe(exec.id);
 		expect(tam.subSessionInjects).toEqual([
-			{ sessionId: 'reviewer-session-1', message: 'please look again' },
+			{
+				sessionId: 'reviewer-session-1',
+				message: 'please look again',
+				isSyntheticMessage: true,
+			},
 		]);
 	});
 
@@ -2090,7 +2107,9 @@ describe('createSpaceAgentToolHandlers — send_message_to_task', () => {
 		expect(parsed.success).toBe(true);
 		expect(parsed.activated).toBe(true);
 		expect(activateCalls).toEqual([[run.id, wf.startNodeId]]);
-		expect(tam.subSessionInjects).toEqual([{ sessionId: 'coder-new', message: 'retry' }]);
+		expect(tam.subSessionInjects).toEqual([
+			{ sessionId: 'coder-new', message: 'retry', isSyntheticMessage: true },
+		]);
 	});
 
 	test('returns an error when the target task belongs to a different space', async () => {

--- a/packages/web/src/components/space/__tests__/space-task-thread-events.test.ts
+++ b/packages/web/src/components/space/__tests__/space-task-thread-events.test.ts
@@ -68,6 +68,23 @@ describe('parseThreadRow', () => {
 		expect((parsed.message as Record<string, unknown>)?.timestamp).toBe(1_710_000_999_000);
 	});
 
+	it('injects DB origin from the row into the parsed message', () => {
+		const row = makeRow({
+			id: 'system-row',
+			origin: 'system',
+			content: JSON.stringify({
+				type: 'user',
+				uuid: 'u-system',
+				session_id: 'session-1',
+				message: { content: 'runtime notification' },
+			}),
+		});
+
+		const parsed = parseThreadRow(row);
+
+		expect((parsed.message as Record<string, unknown>)?.origin).toBe('system');
+	});
+
 	it('returns fallbackText when content is not valid JSON', () => {
 		const invalidContent = 'not json {{{';
 		const row = makeRow({ id: 'bad', content: invalidContent });

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
@@ -22,6 +22,7 @@ function makeRow(opts: {
 	createdAt: number;
 	message: unknown;
 	sessionId?: string;
+	origin?: string | null;
 }) {
 	return parseThreadRow({
 		id: opts.id,
@@ -34,6 +35,7 @@ function makeRow(opts: {
 		messageType: 'assistant',
 		content: JSON.stringify(opts.message),
 		createdAt: opts.createdAt,
+		origin: opts.origin,
 	});
 }
 
@@ -551,6 +553,27 @@ describe('MinimalThreadFeed', () => {
 		expect(messageTurn.dataset.fromLabel).toBe('Neo');
 		expect(messageTurn.dataset.toLabel).toBe('Task Agent');
 		// Synthetic badge replaces the older "handoff" wording.
+		expect(messageTurn.textContent?.toLowerCase()).toContain('synthetic');
+	});
+
+	it('uses row origin to classify runtime user messages when content has no origin', () => {
+		const t = Date.now();
+		const rows = [
+			makeRow({
+				id: 'u1',
+				label: 'Task Agent',
+				createdAt: t,
+				message: humanUserMessage('u1', 'runtime handoff'),
+				origin: 'system',
+			}),
+		];
+
+		render(<MinimalThreadFeed parsedRows={rows} />);
+		const messageTurn = screen.getByTestId('minimal-thread-turn');
+		expect(messageTurn.dataset.turnState).toBe('message');
+		expect(messageTurn.dataset.fromLabel).toBe('System');
+		expect(messageTurn.dataset.toLabel).toBe('Task Agent');
+		expect(messageTurn.dataset.messageKind).toBe('synthetic');
 		expect(messageTurn.textContent?.toLowerCase()).toContain('synthetic');
 	});
 

--- a/packages/web/src/components/space/thread/space-task-thread-events.ts
+++ b/packages/web/src/components/space/thread/space-task-thread-events.ts
@@ -330,6 +330,7 @@ export function parseThreadRow(row: SpaceTaskThreadMessageRow): ParsedThreadRow 
 		const withTimestamp = {
 			...(parsed as Record<string, unknown>),
 			timestamp: row.createdAt,
+			...(row.origin ? { origin: row.origin } : {}),
 		} as unknown as SDKMessage;
 
 		return {

--- a/packages/web/src/hooks/useSpaceTaskMessages.ts
+++ b/packages/web/src/hooks/useSpaceTaskMessages.ts
@@ -17,6 +17,8 @@ export interface SpaceTaskThreadMessageRow {
 	messageType: string;
 	content: string;
 	createdAt: number;
+	/** Message origin from the DB (human, neo, system). Used to classify sender in the thread UI. */
+	origin?: string | null;
 	parentToolUseId?: string | null;
 	/**
 	 * Server-computed turn index (per session) for compact thread grouping.


### PR DESCRIPTION
Replays the PR #1695 message classification fix onto current dev, then completes the remaining origin plumbing and coverage.

This preserves sdk_messages.origin through the compact/full task thread LiveQuery rows, keeps human-originated direct and pending node-agent deliveries non-synthetic, and makes agent-originated injection paths explicit.

Validation: root static checks pass; targeted daemon/web regression tests pass. Full daemon/web/UI suites still have unrelated environment failures: git commit signing cannot reach 1Password in artifact tests, local server bind on port 0 fails in bridge tests, web tests attempt DNS to example.com/GitHub, and UI demo tests fail/hang independently.