### PR TITLE
Fix Codex context usage normalization

### DIFF
--- a/packages/daemon/src/lib/agent/context-fetcher.ts
+++ b/packages/daemon/src/lib/agent/context-fetcher.ts
@@ -53,10 +53,10 @@ export class ContextFetcher {
 	 * Convert an SDK `getContextUsage()` response into NeoKai's `ContextInfo`.
 	 *
 	 * Mapping rules:
-	 * - `totalTokens → totalUsed`, `maxTokens → totalCapacity`,
-	 *   `percentage → percentUsed`, `model → model`
+	 * - `totalTokens → totalUsed`, `rawMaxTokens/maxTokens → totalCapacity`,
+	 *   recomputed percentage → percentUsed, `model → model`
 	 * - `categories[] → breakdown` (flattened into `Record<name, {tokens, percent}>`);
-	 *   percentages are recomputed relative to `maxTokens` because the SDK
+	 *   percentages are recomputed relative to capacity because the SDK
 	 *   response doesn't include them per-category.
 	 * - `apiUsage` on the SDK response (which uses snake_case) is mapped to
 	 *   our camelCase `ContextAPIUsage` shape.
@@ -65,7 +65,12 @@ export class ContextFetcher {
 	 */
 	static toContextInfo(response: SDKControlGetContextUsageResponse): ContextInfo {
 		const breakdown: Record<string, ContextCategoryBreakdown> = {};
-		const capacity = response.maxTokens > 0 ? response.maxTokens : 0;
+		const capacity =
+			response.rawMaxTokens > 0
+				? response.rawMaxTokens
+				: response.maxTokens > 0
+					? response.maxTokens
+					: 0;
 		for (const category of response.categories ?? []) {
 			// Compute percent relative to capacity (SDK response doesn't carry it).
 			// Round to 1 decimal place to match the display the UI already expects.
@@ -99,16 +104,29 @@ export class ContextFetcher {
 				}
 			: undefined;
 
+		const percentUsed =
+			capacity > 0
+				? Math.min(100, Math.max(0, Math.round((response.totalTokens / capacity) * 100)))
+				: Math.max(0, Math.round(response.percentage));
+		let autoCompactThreshold = response.autoCompactThreshold;
+		if (
+			typeof autoCompactThreshold === 'number' &&
+			capacity > 0 &&
+			response.maxTokens > 0 &&
+			response.maxTokens !== capacity &&
+			Math.abs(autoCompactThreshold - Math.floor(response.maxTokens * 0.9)) <= 1
+		) {
+			autoCompactThreshold = Math.floor(capacity * 0.9);
+		}
+
 		return {
 			model: response.model ?? null,
 			totalUsed: response.totalTokens,
-			totalCapacity: response.maxTokens,
-			// SDK returns fractional percent (e.g. 10.5). Round to nearest whole
-			// to match the legacy shape and what ContextUsageBar renders today.
-			percentUsed: Math.round(response.percentage),
+			totalCapacity: capacity,
+			percentUsed,
 			breakdown,
 			apiUsage,
-			autoCompactThreshold: response.autoCompactThreshold,
+			autoCompactThreshold,
 			isAutoCompactEnabled: response.isAutoCompactEnabled,
 			messageBreakdown,
 			lastUpdated: Date.now(),

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -196,6 +196,15 @@ function toolsKey(anthropicTools: { name: string }[]): string {
 		.join(',');
 }
 
+function estimateLastMessageInputTokens(body: AnthropicRequest): number {
+	const last = body.messages.at(-1);
+	if (!last) return 0;
+	return estimateAnthropicInputTokens({
+		model: body.model,
+		messages: [last],
+	});
+}
+
 /** Persistent Codex session across multiple conversation turns. */
 type PersistentSession = {
 	session: BridgeSession;
@@ -551,7 +560,7 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 				}
 
 				const { gen, session, model: sessionModel, sessionId: tsSessionId } = primaryStored;
-				const estimatedInputTokens = estimateAnthropicInputTokens(body);
+				const estimatedInputTokens = estimateLastMessageInputTokens(body);
 				const toolContinuationPs = persistentSessions.get(tsSessionId);
 				const onTurnDone = toolContinuationPs
 					? () => {
@@ -660,11 +669,14 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 			// has context from any messages that pre-date the persistent session.
 			// Subsequent turns: Codex already has the thread history — send only the new
 			// user message to avoid duplicating context.
-			const userText = ps.isFirstTurn
+			const isFirstTurn = ps.isFirstTurn;
+			const userText = isFirstTurn
 				? buildConversationText(body.messages, system)
 				: extractLastUserMessage(body.messages);
 			ps.isFirstTurn = false;
-			const estimatedInputTokens = estimateAnthropicInputTokens(body);
+			const estimatedInputTokens = isFirstTurn
+				? estimateAnthropicInputTokens(body)
+				: estimateLastMessageInputTokens(body);
 
 			const gen = bridgeSession.startTurn(userText);
 

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -462,12 +462,21 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 			if (url.pathname === '/v1/messages/count_tokens' && req.method === 'POST') {
 				try {
 					const body = (await req.json()) as AnthropicRequest;
-					return new Response(
-						JSON.stringify({ input_tokens: estimateAnthropicInputTokens(body) }),
-						{
-							headers: { 'Content-Type': 'application/json' },
-						}
-					);
+					const sessionId = extractSessionId(req);
+					const ps = persistentSessions.get(sessionId);
+					const resolvedModel = resolveBridgeModelId(body.model);
+					const currentToolsKey = toolsKey(body.tools ?? []);
+					const shouldCountOnlyCurrentTurn =
+						ps !== undefined &&
+						!ps.isFirstTurn &&
+						ps.model === resolvedModel &&
+						ps.toolsKey === currentToolsKey;
+					const inputTokens = shouldCountOnlyCurrentTurn
+						? estimateLastMessageInputTokens(body)
+						: estimateAnthropicInputTokens(body);
+					return new Response(JSON.stringify({ input_tokens: inputTokens }), {
+						headers: { 'Content-Type': 'application/json' },
+					});
 				} catch {
 					return createAnthropicError(400, 'invalid_request_error', 'Bad Request');
 				}

--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -721,6 +721,8 @@ export function setupSessionHandlers(
 					description: m.description,
 					alias: m.alias,
 					provider: m.provider,
+					contextWindow: m.contextWindow,
+					context_window: m.contextWindow,
 					type: 'model' as const,
 				})),
 				// If forceRefresh is true, indicate that this is a fresh fetch

--- a/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
@@ -90,6 +90,7 @@ describe('ContextFetcher.toContextInfo', () => {
 		const response = baseResponse({
 			totalTokens: 0,
 			maxTokens: 0,
+			rawMaxTokens: 0,
 			percentage: 0,
 			categories: [{ name: 'System prompt', tokens: 0, color: 'gray' }],
 		});
@@ -144,6 +145,38 @@ describe('ContextFetcher.toContextInfo', () => {
 
 		expect(info.autoCompactThreshold).toBe(160000);
 		expect(info.isAutoCompactEnabled).toBe(true);
+	});
+
+	it('uses rawMaxTokens and recomputes percentage when SDK percentage is inconsistent', () => {
+		const response = baseResponse({
+			totalTokens: 210000,
+			maxTokens: 200000,
+			rawMaxTokens: 272000,
+			percentage: 140,
+			autoCompactThreshold: 180000,
+			isAutoCompactEnabled: true,
+			categories: [{ name: 'Messages', tokens: 210000, color: 'blue' }],
+		});
+
+		const info = ContextFetcher.toContextInfo(response);
+
+		expect(info.totalCapacity).toBe(272000);
+		expect(info.percentUsed).toBe(77);
+		expect(info.breakdown.Messages).toEqual({ tokens: 210000, percent: 77.2 });
+		expect(info.autoCompactThreshold).toBe(244800);
+	});
+
+	it('caps recomputed percentUsed at 100 when usage exceeds capacity', () => {
+		const response = baseResponse({
+			totalTokens: 300000,
+			maxTokens: 200000,
+			rawMaxTokens: 272000,
+			percentage: 150,
+		});
+
+		const info = ContextFetcher.toContextInfo(response);
+
+		expect(info.percentUsed).toBe(100);
 	});
 
 	it('passes through messageBreakdown when present', () => {

--- a/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/server.test.ts
@@ -1554,6 +1554,43 @@ describe('tool_choice warning — codex bridge', () => {
 		expect(deltaUsage?.input_tokens).toBe(startUsage?.input_tokens);
 	});
 
+	it('counts later persistent Codex turns from the sent user message, not replayed history', async () => {
+		const headers = {
+			'Content-Type': 'application/json',
+			Authorization: 'Bearer codex-bridge-count-estimate',
+		};
+
+		const firstResp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify({
+				model: 'gpt-5.5',
+				messages: [{ role: 'user', content: 'Start' }],
+				stream: true,
+			}),
+		});
+		expect(firstResp.ok).toBe(true);
+		await readSSEEvents(firstResp.body);
+
+		const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages/count_tokens`, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify({
+				model: 'gpt-5.5',
+				messages: [
+					{ role: 'user', content: 'x '.repeat(20_000) },
+					{ role: 'assistant', content: 'ok' },
+					{ role: 'user', content: 'Hey' },
+				],
+			}),
+		});
+
+		expect(resp.ok).toBe(true);
+		const body = (await resp.json()) as { input_tokens: number };
+		expect(body.input_tokens).toBeGreaterThan(0);
+		expect(body.input_tokens).toBeLessThan(50);
+	});
+
 	it('does NOT log a tool_choice warning when tool_choice is absent', async () => {
 		const warnSpy = spyOn(Logger.prototype, 'warn');
 

--- a/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/server.test.ts
@@ -1507,6 +1507,53 @@ describe('tool_choice warning — codex bridge', () => {
 		).toBe('gpt-5.5');
 	});
 
+	it('estimates later persistent turns from the sent user message, not full history', async () => {
+		const headers = {
+			'Content-Type': 'application/json',
+			Authorization: 'Bearer codex-bridge-usage-estimate',
+		};
+
+		const firstResp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [{ role: 'user', content: 'Start' }],
+				stream: true,
+			}),
+		});
+		expect(firstResp.ok).toBe(true);
+		await readSSEEvents(firstResp.body);
+
+		const secondResp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [
+					{ role: 'user', content: 'x '.repeat(20_000) },
+					{ role: 'assistant', content: 'ok' },
+					{ role: 'user', content: 'Hey' },
+				],
+				stream: true,
+			}),
+		});
+
+		expect(secondResp.ok).toBe(true);
+		const events = await readSSEEvents(secondResp.body);
+		expect(startTurnSpy.mock.calls[1]?.[0]).toBe('Hey');
+
+		const msgStart = events.find((e) => e.event === 'message_start');
+		const startUsage = (msgStart?.data as { message?: { usage?: { input_tokens?: number } } })
+			?.message?.usage;
+		expect(startUsage?.input_tokens).toBeGreaterThan(0);
+		expect(startUsage?.input_tokens).toBeLessThan(50);
+
+		const msgDelta = events.find((e) => e.event === 'message_delta');
+		const deltaUsage = (msgDelta?.data as { usage?: { input_tokens?: number } })?.usage;
+		expect(deltaUsage?.input_tokens).toBe(startUsage?.input_tokens);
+	});
+
 	it('does NOT log a tool_choice warning when tool_choice is absent', async () => {
 		const warnSpy = spyOn(Logger.prototype, 'warn');
 

--- a/packages/daemon/tests/unit/2-handlers/rpc/session-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc/session-handlers.test.ts
@@ -36,7 +36,8 @@ import type { AgentSession } from '../../../../src/lib/agent/agent-session';
 import type { DaemonHub } from '../../../../src/lib/daemon-hub';
 import type { RoomManager } from '../../../../src/lib/room/managers/room-manager';
 import type { SpaceManager } from '../../../../src/lib/space/managers/space-manager';
-import type { Session } from '@neokai/shared';
+import { clearModelsCache, setModelsCache } from '../../../../src/lib/model-service';
+import type { ModelInfo, Session } from '@neokai/shared';
 
 // Type for captured request handlers
 type RequestHandler = (data: unknown, context: unknown) => Promise<unknown>;
@@ -256,6 +257,7 @@ describe('Session RPC Handlers', () => {
 	});
 
 	afterEach(() => {
+		clearModelsCache();
 		mock.restore();
 	});
 
@@ -1281,6 +1283,31 @@ describe('Session RPC Handlers', () => {
 
 			expect(Array.isArray(result.models)).toBe(true);
 			expect(result).toHaveProperty('cached');
+		});
+
+		it('includes model context window metadata', async () => {
+			const gpt55Model: ModelInfo = {
+				id: 'gpt-5.5',
+				name: 'GPT-5.5',
+				alias: 'codex-latest',
+				family: 'gpt',
+				provider: 'anthropic-codex',
+				contextWindow: 272000,
+				description: 'Latest Codex model',
+				releaseDate: '2026-04-01',
+				available: true,
+			};
+			setModelsCache(new Map([['global', [gpt55Model]]]));
+			const handler = messageHubData.handlers.get('models.list');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!({}, {})) as {
+				models: Array<{ id: string; contextWindow?: number; context_window?: number }>;
+			};
+
+			const model = result.models.find((entry) => entry.id === 'gpt-5.5');
+			expect(model?.contextWindow).toBe(272000);
+			expect(model?.context_window).toBe(272000);
 		});
 
 		it('accepts forceRefresh parameter', async () => {

--- a/packages/web/src/components/ChatComposer.tsx
+++ b/packages/web/src/components/ChatComposer.tsx
@@ -124,7 +124,7 @@ export function ChatComposer({
 					currentAction={currentAction}
 					streamingPhase={streamingPhase}
 					contextUsage={contextUsage}
-					maxContextTokens={200000}
+					maxContextTokens={currentModelInfo?.contextWindow ?? 200000}
 					features={features}
 					currentModel={currentModel}
 					currentModelInfo={currentModelInfo}

--- a/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
+++ b/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
@@ -1028,6 +1028,20 @@ describe('mapRawModelsToModelInfos', () => {
 		expect(result[0].provider).toBe('anthropic');
 	});
 
+	it('preserves GPT-5.5 context window metadata from models.list', () => {
+		const result = mapRawModelsToModelInfos([
+			{
+				id: 'gpt-5.5',
+				display_name: 'GPT-5.5',
+				description: 'Latest Codex model',
+				provider: 'anthropic-codex',
+				contextWindow: 272000,
+			},
+		]);
+
+		expect(result[0].contextWindow).toBe(272000);
+	});
+
 	it('sorts by PROVIDER_ORDER: anthropic before copilot before codex', () => {
 		const result = mapRawModelsToModelInfos([
 			{ id: 'codex-sonnet', display_name: 'Codex', description: '', provider: 'anthropic-codex' },

--- a/packages/web/src/hooks/useModelSwitcher.ts
+++ b/packages/web/src/hooks/useModelSwitcher.ts
@@ -88,6 +88,8 @@ export interface RawModelEntry {
 	description: string;
 	alias?: string;
 	provider?: string;
+	contextWindow?: number;
+	context_window?: number;
 }
 
 /**
@@ -120,7 +122,7 @@ export function mapRawModelsToModelInfos(models: RawModelEntry[]): ModelInfo[] {
 			alias: m.alias || m.id,
 			family,
 			provider: m.provider || 'anthropic',
-			contextWindow: 200000,
+			contextWindow: m.contextWindow ?? m.context_window ?? 200000,
 			description: m.description || '',
 			releaseDate: '',
 			available: true,


### PR DESCRIPTION
Fixes Codex context usage math so tiny follow-up turns do not inflate context percentages or repeatedly trigger compaction.

Also carries GPT-5.5's 272k context window through bridge/model-list metadata and the UI context fallback.

Tested: focused daemon context tests, focused web model-switcher test, bun run check.