### PR TITLE
Fix stuck MCP session: repair missing agent_session_id

### DIFF
--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -3156,8 +3156,9 @@ export class TaskAgentManager {
 	private async rehydrateSubSession(subSessionId: string): Promise<AgentSession | null> {
 		log.warn(`TaskAgentManager: rehydrating ghost sub-session ${subSessionId} from DB...`);
 
-		// --- Look up the NodeExecution by agentSessionId
-		const execution = this.config.nodeExecutionRepo.getByAgentSessionId(subSessionId);
+		// --- Look up the NodeExecution by agentSessionId, falling back to the
+		// execution id embedded in deterministic workflow sub-session ids.
+		const execution = this.resolveNodeExecutionForSubSession(subSessionId);
 		if (!execution) {
 			log.warn(
 				`TaskAgentManager.rehydrateSubSession: no NodeExecution found with agentSessionId=${subSessionId}`
@@ -3299,6 +3300,71 @@ export class TaskAgentManager {
 
 		void workflow; // Loaded for context but not needed directly; suppresses unused-var lint.
 		return agentSession;
+	}
+
+	/**
+	 * Resolve the workflow execution that owns a sub-session.
+	 *
+	 * Normal path: NodeExecution.agentSessionId points at the sub-session.
+	 * Recovery path: deterministic workflow sub-session ids include the execution
+	 * id (`space:<spaceId>:task:<taskId>:exec:<nodeExecutionId>`). If a daemon
+	 * restart or spawn race left `agent_session_id` null, use that embedded id to
+	 * repair the row and continue rehydration/self-heal without discarding the
+	 * existing session transcript or queued message.
+	 */
+	private resolveNodeExecutionForSubSession(subSessionId: string): NodeExecution | null {
+		const bySessionId = this.config.nodeExecutionRepo.listByAgentSessionId(subSessionId);
+		const embeddedExecutionId = this.parseExecutionIdFromSubSessionId(subSessionId);
+		const embedded = embeddedExecutionId
+			? this.config.nodeExecutionRepo.getById(embeddedExecutionId)
+			: null;
+
+		if (embedded && !embedded.agentSessionId) {
+			const repaired = this.config.nodeExecutionRepo.updateSessionId(embedded.id, subSessionId);
+			if (repaired) {
+				log.warn(
+					`TaskAgentManager.resolveNodeExecutionForSubSession: repaired missing agent_session_id ` +
+						`for execution ${embedded.id} from sub-session id ${subSessionId}`
+				);
+				return this.pickBestNodeExecution([repaired, ...bySessionId]);
+			}
+		}
+
+		const candidates =
+			embedded?.agentSessionId === subSessionId ? [embedded, ...bySessionId] : bySessionId;
+		return this.pickBestNodeExecution(candidates);
+	}
+
+	private parseExecutionIdFromSubSessionId(subSessionId: string): string | null {
+		const marker = ':exec:';
+		const markerIndex = subSessionId.indexOf(marker);
+		if (markerIndex === -1) return null;
+		const rest = subSessionId.slice(markerIndex + marker.length);
+		const executionId = rest.split(':')[0];
+		return executionId || null;
+	}
+
+	private pickBestNodeExecution(candidates: NodeExecution[]): NodeExecution | null {
+		if (candidates.length === 0) return null;
+		const statusRank = (execution: NodeExecution): number => {
+			switch (execution.status) {
+				case 'in_progress':
+					return 0;
+				case 'blocked':
+					return 1;
+				case 'pending':
+					return 2;
+				default:
+					return 3;
+			}
+		};
+		return [...candidates].sort((a, b) => {
+			const rankDiff = statusRank(a) - statusRank(b);
+			if (rankDiff !== 0) return rankDiff;
+			const updatedDiff = b.updatedAt - a.updatedAt;
+			if (updatedDiff !== 0) return updatedDiff;
+			return b.createdAt - a.createdAt;
+		})[0]!;
 	}
 
 	private async replayPendingMessagesAfterRuntimeProvisioning(
@@ -3560,8 +3626,8 @@ export class TaskAgentManager {
 			`TaskAgentManager.mcpSelfHeal: triggered for session ${sessionId}, missing [${missing.join(', ')}]`
 		);
 
-		// Step 1: Look up the NodeExecution (same lookup as rehydrateSubSession).
-		const execution = this.config.nodeExecutionRepo.getByAgentSessionId(sessionId);
+		// Step 1: Look up the NodeExecution (same resolver as rehydrateSubSession).
+		const execution = this.resolveNodeExecutionForSubSession(sessionId);
 		if (!execution) {
 			log.error(
 				`TaskAgentManager.mcpSelfHeal: no NodeExecution found for agentSessionId=${sessionId} — cannot self-heal`

--- a/packages/daemon/src/storage/repositories/node-execution-repository.ts
+++ b/packages/daemon/src/storage/repositories/node-execution-repository.ts
@@ -243,15 +243,38 @@ export class NodeExecutionRepository {
 
 	/**
 	 * Find a node execution by its agent session ID.
-	 * Returns the first match or null if none exists.
+	 * Returns the most relevant active/latest match or null if none exists.
+	 *
+	 * A long-lived named agent session can be reused across multiple workflow
+	 * node executions. Prefer active executions so runtime MCP self-heal rebuilds
+	 * node-agent with the current node context rather than an older completed row.
 	 */
 	getByAgentSessionId(agentSessionId: string): NodeExecution | null {
-		const row = this.db
-			.prepare(`SELECT * FROM node_executions WHERE agent_session_id = ? LIMIT 1`)
-			.get(agentSessionId) as Record<string, unknown> | undefined;
+		return this.listByAgentSessionId(agentSessionId)[0] ?? null;
+	}
 
-		if (!row) return null;
-		return this.rowToNodeExecution(row);
+	/**
+	 * List node executions bound to an agent session, with active/latest rows first.
+	 */
+	listByAgentSessionId(agentSessionId: string): NodeExecution[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM node_executions
+				 WHERE agent_session_id = ?
+				 ORDER BY
+				   CASE status
+				     WHEN 'in_progress' THEN 0
+				     WHEN 'blocked' THEN 1
+				     WHEN 'pending' THEN 2
+				     ELSE 3
+				   END,
+				   updated_at DESC,
+				   created_at DESC,
+				   id DESC`
+			)
+			.all(agentSessionId) as Record<string, unknown>[];
+
+		return rows.map((row) => this.rowToNodeExecution(row));
 	}
 
 	/**

--- a/packages/daemon/tests/unit/4-space-storage/storage/node-execution-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/node-execution-repository.test.ts
@@ -418,6 +418,28 @@ describe('NodeExecutionRepository', () => {
 		});
 	});
 
+	describe('getByAgentSessionId', () => {
+		it('prefers active executions when a reused session appears on multiple rows', () => {
+			const sessionId = 'session-reused';
+			const idleExec = createExecution({
+				workflowNodeId: 'node-old',
+				agentSessionId: sessionId,
+				status: 'idle',
+			});
+			const activeExec = createExecution({
+				workflowNodeId: 'node-current',
+				agentSessionId: sessionId,
+				status: 'in_progress',
+			});
+
+			expect(repo.getByAgentSessionId(sessionId)?.id).toBe(activeExec.id);
+			expect(repo.listByAgentSessionId(sessionId).map((e) => e.id)).toEqual([
+				activeExec.id,
+				idleExec.id,
+			]);
+		});
+	});
+
 	describe('delete', () => {
 		it('deletes a node execution', () => {
 			const exec = createExecution();

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-mcp.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-mcp.test.ts
@@ -188,6 +188,7 @@ function buildManager(opts: {
 	bunDb: BunDatabase;
 	taskRepo: SpaceTaskRepository;
 	taskManager: SpaceTaskManager;
+	nodeExecutionRepo: NodeExecutionRepository;
 	space: Space;
 	mockSkillsManager: object;
 	mockAppMcpServerRepo: object;
@@ -313,6 +314,7 @@ function buildManager(opts: {
 		bunDb,
 		taskRepo,
 		taskManager,
+		nodeExecutionRepo,
 		space,
 		mockSkillsManager,
 		mockAppMcpServerRepo,
@@ -1359,6 +1361,67 @@ describe('TaskAgentManager.ensureNodeAgentAttached — workflow sub-session inva
 
 		// Servers untouched.
 		expect(session.session.config.mcpServers!['node-agent']).toBeDefined();
+	});
+
+	test('mcpSelfHeal repairs missing node execution session id from embedded exec id', async () => {
+		const { manager, fromInitSpy, bunDb, taskManager, nodeExecutionRepo, space } = buildManager({});
+		spies.push(fromInitSpy);
+
+		const workflow = new SpaceWorkflowRepository(bunDb).createWorkflow({
+			spaceId: space.id,
+			name: 'MCP self-heal workflow',
+			description: '',
+			nodes: [],
+			transitions: [],
+			startNodeId: 'coding',
+			rules: [],
+			completionAutonomyLevel: 3,
+		});
+		const workflowRun = new SpaceWorkflowRunRepository(bunDb).createRun({
+			spaceId: space.id,
+			workflowId: workflow.id,
+			title: 'MCP self-heal run',
+		});
+		const task = await taskManager.createTask({
+			title: 'MCP self-heal task',
+			description: 'desc',
+			taskType: 'coding',
+			status: 'in_progress',
+			workflowRunId: workflowRun.id,
+			taskAgentSessionId: `space:${space.id}:task:task-agent`,
+		});
+		const execution = nodeExecutionRepo.create({
+			workflowRunId: workflowRun.id,
+			workflowNodeId: 'coding',
+			agentName: 'coder',
+			status: 'in_progress',
+		});
+		const subSessionId = `space:${space.id}:task:${task.id}:exec:${execution.id}`;
+		const session = makeMockSession(subSessionId);
+		session.session.config.mcpServers = { 'registry-mcp': { name: 'registry' } };
+
+		const mgr = manager as unknown as {
+			agentSessionIndex: Map<string, MockAgentSession>;
+			mcpSelfHeal: (sessionId: string, missing: string[]) => Promise<void>;
+			reinjectNodeAgentMcpServer: (s: unknown, c: unknown) => void;
+		};
+		mgr.agentSessionIndex.set(subSessionId, session);
+		const originalReinject = mgr.reinjectNodeAgentMcpServer.bind(manager);
+		mgr.reinjectNodeAgentMcpServer = (s) => {
+			(s as MockAgentSession).mergeRuntimeMcpServers({
+				'node-agent': { name: 'node-agent', _stub: true },
+			});
+		};
+
+		try {
+			await mgr.mcpSelfHeal(subSessionId, ['node-agent']);
+		} finally {
+			mgr.reinjectNodeAgentMcpServer = originalReinject;
+		}
+
+		expect(nodeExecutionRepo.getById(execution.id)?.agentSessionId).toBe(subSessionId);
+		expect(session.session.config.mcpServers!['node-agent']).toBeDefined();
+		expect(session.session.config.mcpServers!['registry-mcp']).toBeDefined();
 	});
 });
 


### PR DESCRIPTION
## Problem

Workflow sub-session `space:<spaceId>:task:<taskId>:exec:<nodeExecutionId>` got stuck with:

> MCP invariant … still missing required MCP servers after self-heal: [node-agent]. Refusing to start — fix the injection logic.

**Root cause:** When a spawn race or daemon restart left `agent_session_id` NULL on the NodeExecution row, both `rehydrateSubSession` and `mcpSelfHeal` looked up the execution by `agentSessionId` and found nothing — hard-blocking the session with no recovery path, discarding queued messages and conversation context.

## Fix

- **`resolveNodeExecutionForSubSession`** — new unified resolver that falls back to parsing the `:exec:<id>` segment from the deterministic sub-session id, repairing the NULL `agent_session_id` on the fly so subsequent lookups succeed.
- **`getByAgentSessionId`** — now prefers active (`in_progress`) executions when a reused session appears on multiple rows, so self-heal rebuilds node-agent with the current node context.
- Both `rehydrateSubSession` and `mcpSelfHeal` use the new resolver.

## Tests

- Repository: verifies `getByAgentSessionId` prefers active over idle executions
- Manager: verifies `mcpSelfHeal` repairs a NULL `agent_session_id` from the embedded `:exec:` id and successfully re-injects `node-agent`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>