### PR TITLE
Show task numbers in space task headers

### DIFF
--- a/packages/web/src/components/space/SpaceOverview.tsx
+++ b/packages/web/src/components/space/SpaceOverview.tsx
@@ -241,9 +241,14 @@ function RecentTaskItem({ task, onClick }: { task: SpaceTask; onClick?: () => vo
 		>
 			<div class={cn('w-2 h-2 rounded-full flex-shrink-0', statusColor.replace('text-', 'bg-'))} />
 			<div class="flex-1 min-w-0">
-				<span class="text-sm text-gray-200 group-hover:text-gray-100 truncate block">
-					{task.title}
-				</span>
+				<div class="flex items-center gap-2 min-w-0">
+					<span class="text-sm text-gray-200 group-hover:text-gray-100 truncate block">
+						{task.title}
+					</span>
+					<span class="inline-flex items-center text-xs font-mono font-medium text-gray-400 bg-dark-700 border border-dark-600 px-1.5 py-0.5 rounded flex-shrink-0">
+						#{task.taskNumber}
+					</span>
+				</div>
 			</div>
 			<span class="text-xs text-gray-500 flex-shrink-0 tabular-nums">
 				{getRelativeTime(task.updatedAt)}

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -679,9 +679,14 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 						</button>
 					)}
 					<div class="min-w-0 flex-1 sm:flex sm:items-center sm:gap-3">
-						<h2 class="text-sm sm:text-base font-semibold text-gray-100 min-w-0 leading-5 sm:flex-1 overflow-hidden break-words [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]">
-							{task.title}
-						</h2>
+						<div class="flex items-center gap-2 min-w-0 sm:flex-1">
+							<h2 class="text-sm sm:text-base font-semibold text-gray-100 min-w-0 leading-5 flex-1 overflow-hidden break-words [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]">
+								{task.title}
+							</h2>
+							<span class="inline-flex items-center text-xs font-mono font-medium text-gray-400 bg-dark-700 border border-dark-600 px-1.5 py-0.5 rounded flex-shrink-0">
+								#{task.taskNumber}
+							</span>
+						</div>
 						<div class="mt-1 flex items-center gap-1.5 overflow-hidden sm:mt-0 sm:flex-shrink-0">
 							{showHeaderStatusBadge && (
 								<TaskMetaBadge class={cn(STATUS_BADGE_CLASSES[task.status])}>

--- a/packages/web/src/components/space/__tests__/SpaceOverview.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceOverview.test.tsx
@@ -164,6 +164,17 @@ describe('SpaceOverview', () => {
 		expect(getByText('Task t3')).toBeTruthy();
 	});
 
+	it('shows task numbers in recent task items', () => {
+		mockSpace.value = makeSpace();
+		mockTasks.value = [
+			makeTask('task-171', 'open', { title: 'Investigate toolbar state', taskNumber: 171 }),
+		];
+
+		const { getByText } = render(<SpaceOverview spaceId="space-1" />);
+		expect(getByText('Investigate toolbar state')).toBeTruthy();
+		expect(getByText('#171')).toBeTruthy();
+	});
+
 	it('shows empty state when there are no tasks', () => {
 		mockSpace.value = makeSpace();
 		const { getByText } = render(<SpaceOverview spaceId="space-1" />);

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -211,6 +211,7 @@ function makeTask(overrides: Partial<SpaceTask> = {}): SpaceTask {
 	return {
 		id: 'task-1',
 		spaceId: 'space-1',
+		taskNumber: 1,
 		title: 'Fix the bug',
 		description: 'Task description',
 		status: 'open',
@@ -270,6 +271,13 @@ describe('SpaceTaskPane', () => {
 		expect(getByText('My Task')).toBeTruthy();
 		expect(getAllByText('In Progress').length).toBeGreaterThan(0);
 		expect(getByText('High Priority')).toBeTruthy();
+	});
+
+	it('shows the task number in the header', () => {
+		mockTasks.value = [makeTask({ title: 'Review launch checklist', taskNumber: 173 })];
+		const { getByText } = render(<SpaceTaskPane taskId="task-1" />);
+		expect(getByText('Review launch checklist')).toBeTruthy();
+		expect(getByText('#173')).toBeTruthy();
 	});
 
 	it('omits the header status badge for review tasks because the approval banner owns that state', () => {


### PR DESCRIPTION
Shows task number badges in the SpaceOverview recent task list and SpaceTaskPane header using the existing SpaceTasks badge styling.

Validated with:
- bun run test src/components/space/__tests__/SpaceOverview.test.tsx src/components/space/__tests__/SpaceTaskPane.test.tsx
- bun run test
- bun run check