### PR TITLE
Fix Codex bridge subprocess crash retry

### DIFF
--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -23,7 +23,6 @@ import {
 	extractLastUserMessage,
 	isToolResultContinuation,
 	extractToolResults,
-	pingSSE,
 	messageStartSSE,
 	contentBlockStartTextSSE,
 	contentBlockStartToolUseSSE,
@@ -155,6 +154,7 @@ export function createAnthropicError(
 
 /** Default TTL before an unresolved tool-call session is abandoned (5 min). */
 export const DEFAULT_TOOL_SESSION_TTL_MS = 5 * 60 * 1000;
+const MAX_SUBPROCESS_RETRIES = 1;
 
 // ---------------------------------------------------------------------------
 // Session state for tool-call round-trips
@@ -174,6 +174,11 @@ export type ToolSession = {
 	/** TTL timer — fires if the HTTP client never sends the tool result. */
 	cleanupTimer: ReturnType<typeof setTimeout>;
 };
+
+export type DrainResult =
+	| { type: 'completed' }
+	| { type: 'tool_call_suspended'; callId: string }
+	| { type: 'error'; message: string; isSubprocessCrash: boolean };
 
 function generateMsgId(): string {
 	return `msg_${Math.random().toString(36).slice(2, 14)}`;
@@ -203,6 +208,10 @@ function estimateLastMessageInputTokens(body: AnthropicRequest): number {
 		model: body.model,
 		messages: [last],
 	});
+}
+
+function isSubprocessCrashMessage(message: string): boolean {
+	return message.toLowerCase().includes('subprocess closed');
 }
 
 /** Persistent Codex session across multiple conversation turns. */
@@ -236,8 +245,9 @@ export async function drainToSSE(
 	sessionId: string,
 	onTurnDone: () => void,
 	onError?: () => void,
-	initialInputTokens = 0
-): Promise<void> {
+	initialInputTokens = 0,
+	returnUncommittedSubprocessCrash = true
+): Promise<DrainResult> {
 	const enc = new TextEncoder();
 	const send = (s: string) => controller.enqueue(enc.encode(s));
 
@@ -246,12 +256,32 @@ export async function drainToSSE(
 	let outputTokens = 0;
 	let suspendedCallId: string | null = null;
 	let modelContextWindow = getModelContextWindow(model);
+	let messageCommitted = false;
 
-	try {
+	const commitMessage = () => {
+		if (messageCommitted) return;
 		const msgId = generateMsgId();
 		send(messageStartSSE(msgId, model, initialInputTokens, modelContextWindow));
-		send(pingSSE());
+		messageCommitted = true;
+	};
 
+	const sendErrorAndClose = (message: string): DrainResult => {
+		logger.error('codex-bridge: BridgeSession error:', message);
+		if (!messageCommitted) {
+			commitMessage();
+		}
+		if (textBlockOpen) {
+			send(contentBlockStopSSE(blockIndex));
+			textBlockOpen = false;
+		}
+		send(errorSSE('api_error', message));
+		session.kill();
+		onError?.();
+		controller.close();
+		return { type: 'error', message, isSubprocessCrash: false };
+	};
+
+	try {
 		// Use gen.next() manually instead of for-await-of.  The for-await-of
 		// construct calls gen.return() on early exit (break / return), which
 		// permanently closes the generator — preventing the next HTTP request
@@ -265,6 +295,7 @@ export async function drainToSSE(
 			);
 
 			if (event.type === 'text_delta') {
+				commitMessage();
 				if (!textBlockOpen) {
 					send(contentBlockStartTextSSE(blockIndex));
 					textBlockOpen = true;
@@ -272,6 +303,7 @@ export async function drainToSSE(
 				send(textDeltaSSE(blockIndex, event.text));
 				outputTokens += Math.ceil(event.text.length / 4);
 			} else if (event.type === 'tool_call') {
+				commitMessage();
 				// Close any open text block first
 				if (textBlockOpen) {
 					send(contentBlockStopSSE(blockIndex));
@@ -316,8 +348,9 @@ export async function drainToSSE(
 				logger.debug(`codex-bridge: tool_call suspended callId=${callId}`);
 				// End this HTTP response without closing the generator
 				controller.close();
-				return;
+				return { type: 'tool_call_suspended', callId };
 			} else if (event.type === 'turn_done') {
+				commitMessage();
 				if (textBlockOpen) {
 					send(contentBlockStopSSE(blockIndex));
 					textBlockOpen = false;
@@ -339,24 +372,24 @@ export async function drainToSSE(
 				send(messageStopSSE());
 				onTurnDone();
 				controller.close();
-				return;
+				return { type: 'completed' };
 			} else if (event.type === 'error') {
-				logger.error('codex-bridge: BridgeSession error:', event.message);
-				// Close any open text block before emitting the error event
-				if (textBlockOpen) {
-					send(contentBlockStopSSE(blockIndex));
-					textBlockOpen = false;
+				if (
+					returnUncommittedSubprocessCrash &&
+					!messageCommitted &&
+					isSubprocessCrashMessage(event.message)
+				) {
+					logger.error('codex-bridge: BridgeSession error:', event.message);
+					session.kill();
+					onError?.();
+					return { type: 'error', message: event.message, isSubprocessCrash: true };
 				}
-				// Emit an Anthropic-format error SSE event then close the stream
-				send(errorSSE('api_error', event.message));
-				session.kill();
-				onError?.();
-				controller.close();
-				return;
+				return sendErrorAndClose(event.message);
 			}
 		}
 
 		// Generator exhausted without turn_done — close gracefully
+		commitMessage();
 		if (textBlockOpen) {
 			send(contentBlockStopSSE(blockIndex));
 		}
@@ -371,6 +404,7 @@ export async function drainToSSE(
 		session.kill();
 		onError?.();
 		controller.close();
+		return { type: 'completed' };
 	} catch (error) {
 		if (isClosedControllerError(error)) {
 			logger.debug('codex-bridge: SSE controller already closed, ending stream drain');
@@ -383,15 +417,20 @@ export async function drainToSSE(
 			}
 			onError?.();
 			session.kill();
-			return;
+			return { type: 'error', message: String(error), isSubprocessCrash: false };
 		}
-		// Ensure cleanup runs for any error that escapes the drain loop.
-		// This is critical when startTurn throws due to subprocess crash —
-		// without calling onError, turnInProgress stays true and the session
-		// is never deleted, causing subsequent requests to get 409 conflicts.
-		onError?.();
-		session.kill();
-		throw error;
+		const message = error instanceof Error ? error.message : String(error);
+		if (
+			returnUncommittedSubprocessCrash &&
+			!messageCommitted &&
+			isSubprocessCrashMessage(message)
+		) {
+			logger.error('codex-bridge: BridgeSession error:', message);
+			onError?.();
+			session.kill();
+			return { type: 'error', message, isSubprocessCrash: true };
+		}
+		return sendErrorAndClose(message);
 	}
 }
 
@@ -599,7 +638,8 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 									persistentSessions.delete(tsSessionId);
 								}
 							},
-							estimatedInputTokens
+							estimatedInputTokens,
+							false
 						);
 					},
 				});
@@ -616,6 +656,19 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 			const dynamicTools = buildDynamicTools(anthropicTools);
 			const originalToolNames = anthropicTools.map((t) => t.name);
 			const currentToolsKey = toolsKey(anthropicTools);
+			const createInitializedSession = async (): Promise<BridgeSession> => {
+				const conn = AppServerConn.create(config.codexBinaryPath, config.cwd, config.auth);
+				const session = new BridgeSession(
+					conn,
+					model,
+					dynamicTools,
+					config.cwd,
+					config.auth,
+					originalToolNames
+				);
+				await session.initialize();
+				return session;
+			};
 
 			// Look up or create a persistent session
 			let ps = persistentSessions.get(neokaiSessionId);
@@ -643,18 +696,8 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 				bridgeSession = ps.session;
 			} else {
 				// First turn for this NeoKai session — spin up a new Codex subprocess
-				let conn: AppServerConn;
 				try {
-					conn = AppServerConn.create(config.codexBinaryPath, config.cwd, config.auth);
-					bridgeSession = new BridgeSession(
-						conn,
-						model,
-						dynamicTools,
-						config.cwd,
-						config.auth,
-						originalToolNames
-					);
-					await bridgeSession.initialize();
+					bridgeSession = await createInitializedSession();
 				} catch (err) {
 					logger.error('codex-bridge: failed to start BridgeSession:', err);
 					return createAnthropicError(500, 'api_error', `Internal Server Error: ${String(err)}`);
@@ -679,15 +722,13 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 			// Subsequent turns: Codex already has the thread history — send only the new
 			// user message to avoid duplicating context.
 			const isFirstTurn = ps.isFirstTurn;
-			const userText = isFirstTurn
+			let userText = isFirstTurn
 				? buildConversationText(body.messages, system)
 				: extractLastUserMessage(body.messages);
 			ps.isFirstTurn = false;
-			const estimatedInputTokens = isFirstTurn
+			let estimatedInputTokens = isFirstTurn
 				? estimateAnthropicInputTokens(body)
 				: estimateLastMessageInputTokens(body);
-
-			const gen = bridgeSession.startTurn(userText);
 
 			// Schedule idle timer on turn completion
 			const capturedPs = ps!;
@@ -696,27 +737,90 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 				capturedPs.turnInProgress = false;
 				capturedPs.idleTimer = scheduleIdle(capturedSessionId);
 			};
+			const onError = () => {
+				// Error: clean up persistent session
+				capturedPs.turnInProgress = false;
+				clearTimeout(capturedPs.idleTimer);
+				capturedPs.session.kill();
+				persistentSessions.delete(capturedSessionId);
+			};
+			const sendUncommittedError = (
+				controller: ReadableStreamDefaultController<Uint8Array>,
+				message: string
+			) => {
+				const enc = new TextEncoder();
+				const send = (s: string) => controller.enqueue(enc.encode(s));
+				send(
+					messageStartSSE(
+						generateMsgId(),
+						model,
+						estimatedInputTokens,
+						getModelContextWindow(model)
+					)
+				);
+				send(errorSSE('api_error', message));
+				send(messageStopSSE());
+				controller.close();
+			};
 
 			const stream = new ReadableStream<Uint8Array>({
 				start(controller) {
-					void drainToSSE(
-						gen,
-						bridgeSession,
-						model,
-						toolSessions,
-						controller,
-						ttlMs,
-						capturedSessionId,
-						onTurnDone,
-						() => {
-							// Error: clean up persistent session
-							capturedPs.turnInProgress = false;
-							clearTimeout(capturedPs.idleTimer);
-							capturedPs.session.kill();
-							persistentSessions.delete(capturedSessionId);
-						},
-						estimatedInputTokens
-					);
+					void (async () => {
+						let currentSession = bridgeSession;
+						let retriesLeft = MAX_SUBPROCESS_RETRIES;
+
+						while (true) {
+							const gen = currentSession.startTurn(userText);
+							const result = await drainToSSE(
+								gen,
+								currentSession,
+								model,
+								toolSessions,
+								controller,
+								ttlMs,
+								capturedSessionId,
+								onTurnDone,
+								onError,
+								estimatedInputTokens
+							);
+
+							if (result.type === 'completed' || result.type === 'tool_call_suspended') {
+								return;
+							}
+
+							if (!result.isSubprocessCrash) {
+								return;
+							}
+
+							if (retriesLeft <= 0) {
+								sendUncommittedError(controller, result.message);
+								return;
+							}
+
+							retriesLeft--;
+							logger.warn(
+								'codex-bridge: subprocess crashed before output, retrying turn with a fresh session'
+							);
+
+							try {
+								const newSession = await createInitializedSession();
+								capturedPs.session = newSession;
+								capturedPs.turnInProgress = true;
+								capturedPs.isFirstTurn = false;
+								persistentSessions.set(capturedSessionId, capturedPs);
+								currentSession = newSession;
+								userText = buildConversationText(body.messages, system);
+								estimatedInputTokens = estimateAnthropicInputTokens(body);
+							} catch (err) {
+								logger.error('codex-bridge: failed to restart BridgeSession:', err);
+								sendUncommittedError(
+									controller,
+									`Internal Server Error: ${err instanceof Error ? err.message : String(err)}`
+								);
+								return;
+							}
+						}
+					})();
 				},
 			});
 			return new Response(stream, { headers: sseHeaders });

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -802,17 +802,23 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 								'codex-bridge: subprocess crashed before output, retrying turn with a fresh session'
 							);
 
+							capturedPs.turnInProgress = true;
+							clearTimeout(capturedPs.idleTimer);
+							persistentSessions.set(capturedSessionId, capturedPs);
+
 							try {
 								const newSession = await createInitializedSession();
 								capturedPs.session = newSession;
-								capturedPs.turnInProgress = true;
 								capturedPs.isFirstTurn = false;
-								persistentSessions.set(capturedSessionId, capturedPs);
 								currentSession = newSession;
 								userText = buildConversationText(body.messages, system);
 								estimatedInputTokens = estimateAnthropicInputTokens(body);
 							} catch (err) {
 								logger.error('codex-bridge: failed to restart BridgeSession:', err);
+								capturedPs.turnInProgress = false;
+								clearTimeout(capturedPs.idleTimer);
+								capturedPs.session.kill();
+								persistentSessions.delete(capturedSessionId);
 								sendUncommittedError(
 									controller,
 									`Internal Server Error: ${err instanceof Error ? err.message : String(err)}`

--- a/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/server.test.ts
@@ -1682,6 +1682,83 @@ describe('tool_choice warning — codex bridge', () => {
 		warnSpy.mockRestore();
 	});
 
+	it('keeps the persistent session reserved while the retry session initializes', async () => {
+		let markRetryInitializeStarted!: () => void;
+		let resolveRetryInitialize!: () => void;
+		const retryInitializeStarted = new Promise<void>((resolve) => {
+			markRetryInitializeStarted = resolve;
+		});
+		const retryInitializeRelease = new Promise<void>((resolve) => {
+			resolveRetryInitialize = resolve;
+		});
+
+		let initializeCalls = 0;
+		initializeSpy.mockImplementation(() => {
+			initializeCalls++;
+			if (initializeCalls === 2) {
+				markRetryInitializeStarted();
+				return retryInitializeRelease;
+			}
+			return Promise.resolve();
+		});
+
+		let attempt = 0;
+		startTurnSpy.mockImplementation(
+			// eslint-disable-next-line @typescript-eslint/require-await
+			async function* (): AsyncGenerator<BridgeEvent> {
+				attempt++;
+				if (attempt === 1) {
+					yield { type: 'error', message: 'codex app-server subprocess closed unexpectedly' };
+					return;
+				}
+				yield { type: 'text_delta', text: 'recovered' };
+				yield { type: 'turn_done', inputTokens: 4, outputTokens: 1 };
+			}
+		);
+
+		const headers = {
+			'Content-Type': 'application/json',
+			Authorization: 'Bearer codex-bridge-retry-reserved',
+		};
+		const body = JSON.stringify({
+			model: 'codex-1',
+			messages: [{ role: 'user', content: 'Retry while busy' }],
+			stream: true,
+		});
+
+		const respPromise = fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers,
+			body,
+		});
+
+		await retryInitializeStarted;
+
+		const concurrentResp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers,
+			body,
+		});
+		expect(concurrentResp.status).toBe(409);
+		const concurrentBody = (await concurrentResp.json()) as {
+			error?: { message?: string };
+		};
+		expect(concurrentBody.error?.message).toBe('A turn is already in progress for this session');
+		expect(connCreateSpy).toHaveBeenCalledTimes(2);
+		expect(initializeSpy).toHaveBeenCalledTimes(2);
+
+		resolveRetryInitialize();
+		const resp = await respPromise;
+		expect(resp.ok).toBe(true);
+		const eventsPromise = readSSEEvents(resp.body);
+		const events = await eventsPromise;
+		const text = events
+			.filter((e) => e.event === 'content_block_delta')
+			.map((e) => (e.data as { delta?: { text?: string } }).delta?.text ?? '')
+			.join('');
+		expect(text).toBe('recovered');
+	});
+
 	it('sends an error SSE after the one subprocess crash retry is exhausted', async () => {
 		startTurnSpy.mockImplementation(
 			// eslint-disable-next-line @typescript-eslint/require-await

--- a/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/server.test.ts
@@ -45,6 +45,10 @@ async function readSSEEvents(
 		if (done) break;
 		raw += decoder.decode(value, { stream: true });
 	}
+	return parseSSEEvents(raw);
+}
+
+function parseSSEEvents(raw: string): Array<{ event: string; data: unknown }> {
 	const events: Array<{ event: string; data: unknown }> = [];
 	const blocks = raw.split('\n\n').filter((b) => b.trim());
 	for (const block of blocks) {
@@ -59,6 +63,32 @@ async function readSSEEvents(
 		}
 	}
 	return events;
+}
+
+function createCapturingController(): {
+	controller: ReadableStreamDefaultController<Uint8Array>;
+	events: () => Array<{ event: string; data: unknown }>;
+	chunks: string[];
+	isClosed: () => boolean;
+} {
+	const decoder = new TextDecoder();
+	const chunks: string[] = [];
+	let closed = false;
+	const controller = {
+		enqueue: (chunk: Uint8Array) => {
+			chunks.push(decoder.decode(chunk, { stream: true }));
+		},
+		close: () => {
+			closed = true;
+		},
+	} as unknown as ReadableStreamDefaultController<Uint8Array>;
+
+	return {
+		controller,
+		chunks,
+		events: () => parseSSEEvents(chunks.join('')),
+		isClosed: () => closed,
+	};
 }
 
 // ---------------------------------------------------------------------------
@@ -836,6 +866,121 @@ describe('Bridge HTTP server', () => {
 	// Streaming error — drainToSSE emits Anthropic error SSE event (tests real code path)
 	// -------------------------------------------------------------------------
 
+	it('drainToSSE waits to send message_start until the first content event', async () => {
+		let releaseFirstEvent!: () => void;
+		const firstEventReady = new Promise<void>((resolve) => {
+			releaseFirstEvent = resolve;
+		});
+		async function* delayedGen(): AsyncGenerator<BridgeEvent> {
+			await firstEventReady;
+			yield { type: 'text_delta', text: 'hello' };
+			yield { type: 'turn_done', inputTokens: 0, outputTokens: 2 };
+		}
+
+		const mockSession = { kill: () => {} } as unknown as BridgeSession;
+		const { controller, events, chunks } = createCapturingController();
+		const drainPromise = drainToSSE(
+			delayedGen(),
+			mockSession,
+			'test-model',
+			new Map(),
+			controller,
+			5000,
+			'test-session',
+			() => {}
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(chunks).toHaveLength(0);
+
+		releaseFirstEvent();
+		await expect(drainPromise).resolves.toEqual({ type: 'completed' });
+
+		const parsed = events();
+		const messageStartIndex = parsed.findIndex((e) => e.event === 'message_start');
+		const contentStartIndex = parsed.findIndex((e) => e.event === 'content_block_start');
+		expect(messageStartIndex).toBeGreaterThanOrEqual(0);
+		expect(contentStartIndex).toBe(messageStartIndex + 1);
+	});
+
+	it('drainToSSE returns a subprocess crash result before content is committed', async () => {
+		async function* errorGen(): AsyncGenerator<BridgeEvent> {
+			yield { type: 'error', message: 'codex app-server subprocess closed unexpectedly' };
+		}
+
+		let killCalled = false;
+		let onErrorCalled = false;
+		const mockSession = {
+			kill: () => {
+				killCalled = true;
+			},
+		} as unknown as BridgeSession;
+		const { controller, chunks, isClosed } = createCapturingController();
+
+		const result = await drainToSSE(
+			errorGen(),
+			mockSession,
+			'test-model',
+			new Map(),
+			controller,
+			5000,
+			'test-session',
+			() => {},
+			() => {
+				onErrorCalled = true;
+			}
+		);
+
+		expect(result).toEqual({
+			type: 'error',
+			message: 'codex app-server subprocess closed unexpectedly',
+			isSubprocessCrash: true,
+		});
+		expect(chunks).toHaveLength(0);
+		expect(isClosed()).toBe(false);
+		expect(killCalled).toBe(true);
+		expect(onErrorCalled).toBe(true);
+	});
+
+	it('drainToSSE sends error SSE normally when subprocess crashes after content', async () => {
+		async function* errorGen(): AsyncGenerator<BridgeEvent> {
+			yield { type: 'text_delta', text: 'partial' };
+			yield { type: 'error', message: 'codex app-server subprocess closed unexpectedly' };
+		}
+
+		let killCalled = false;
+		const mockSession = {
+			kill: () => {
+				killCalled = true;
+			},
+		} as unknown as BridgeSession;
+		const { controller, events, isClosed } = createCapturingController();
+
+		const result = await drainToSSE(
+			errorGen(),
+			mockSession,
+			'test-model',
+			new Map(),
+			controller,
+			5000,
+			'test-session',
+			() => {}
+		);
+
+		expect(result).toEqual({
+			type: 'error',
+			message: 'codex app-server subprocess closed unexpectedly',
+			isSubprocessCrash: false,
+		});
+		expect(killCalled).toBe(true);
+		expect(isClosed()).toBe(true);
+
+		const errorEvents = events().filter((e) => e.event === 'error');
+		expect(errorEvents).toHaveLength(1);
+		const data = errorEvents[0].data as { error: { message: string } };
+		expect(data.error.message).toBe('codex app-server subprocess closed unexpectedly');
+	});
+
 	it('drainToSSE emits an Anthropic error SSE event on BridgeSession error', async () => {
 		async function* errorGen(): AsyncGenerator<BridgeEvent> {
 			yield { type: 'text_delta', text: 'partial' };
@@ -1124,7 +1269,7 @@ describe('drainToSSE controller lifecycle handling', () => {
 				'test-session',
 				() => {}
 			)
-		).resolves.toBeUndefined();
+		).resolves.toMatchObject({ type: 'error', isSubprocessCrash: false });
 		expect(killCalled).toBe(true);
 	});
 });
@@ -1486,6 +1631,90 @@ describe('tool_choice warning — codex bridge', () => {
 		const events = await readSSEEvents(resp.body);
 		const types = events.map((e) => e.event);
 		expect(types).toContain('message_stop');
+	});
+
+	it('retries a new turn once when the subprocess crashes before output', async () => {
+		const warnSpy = spyOn(Logger.prototype, 'warn');
+		let attempt = 0;
+		startTurnSpy.mockImplementation(
+			// eslint-disable-next-line @typescript-eslint/require-await
+			async function* (text: string): AsyncGenerator<BridgeEvent> {
+				attempt++;
+				if (attempt === 1) {
+					yield { type: 'error', message: 'codex app-server subprocess closed unexpectedly' };
+					return;
+				}
+				yield { type: 'text_delta', text: `recovered:${text.includes('Retry me')}` };
+				yield { type: 'turn_done', inputTokens: 8, outputTokens: 3 };
+			}
+		);
+
+		const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: 'Bearer codex-bridge-retry-success',
+			},
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [{ role: 'user', content: 'Retry me' }],
+				stream: true,
+			}),
+		});
+
+		expect(resp.ok).toBe(true);
+		const events = await readSSEEvents(resp.body);
+		const types = events.map((e) => e.event);
+		expect(types.filter((type) => type === 'message_start')).toHaveLength(1);
+		expect(types).not.toContain('error');
+		expect(startTurnSpy).toHaveBeenCalledTimes(2);
+		expect(connCreateSpy).toHaveBeenCalledTimes(2);
+		expect(initializeSpy).toHaveBeenCalledTimes(2);
+
+		const text = events
+			.filter((e) => e.event === 'content_block_delta')
+			.map((e) => (e.data as { delta?: { text?: string } }).delta?.text ?? '')
+			.join('');
+		expect(text).toBe('recovered:true');
+
+		const warnMessages = warnSpy.mock.calls.map((args) => args.map(String).join(' '));
+		expect(warnMessages.some((m) => m.includes('retrying turn with a fresh session'))).toBe(true);
+		warnSpy.mockRestore();
+	});
+
+	it('sends an error SSE after the one subprocess crash retry is exhausted', async () => {
+		startTurnSpy.mockImplementation(
+			// eslint-disable-next-line @typescript-eslint/require-await
+			async function* (): AsyncGenerator<BridgeEvent> {
+				yield { type: 'error', message: 'codex app-server subprocess closed unexpectedly' };
+			}
+		);
+
+		const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: 'Bearer codex-bridge-retry-exhausted',
+			},
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [{ role: 'user', content: 'Retry once' }],
+				stream: true,
+			}),
+		});
+
+		expect(resp.ok).toBe(true);
+		const events = await readSSEEvents(resp.body);
+		const types = events.map((e) => e.event);
+		expect(startTurnSpy).toHaveBeenCalledTimes(2);
+		expect(connCreateSpy).toHaveBeenCalledTimes(2);
+		expect(types.filter((type) => type === 'message_start')).toHaveLength(1);
+		expect(types.filter((type) => type === 'error')).toHaveLength(1);
+		expect(types.at(-1)).toBe('message_stop');
+
+		const errorEvent = events.find((e) => e.event === 'error');
+		const data = errorEvent?.data as { error?: { message?: string } };
+		expect(data.error?.message).toBe('codex app-server subprocess closed unexpectedly');
 	});
 
 	it('resolves bridge model aliases to canonical Codex model IDs', async () => {


### PR DESCRIPTION
Adds bridge-level recovery when codex app-server exits before any SSE output is committed. The bridge now delays message_start until real output, retries one fresh subprocess for new turns, and keeps normal error propagation for tool continuations or already-committed streams.

Tests:
- bun test --preload=./packages/daemon/tests/unit/setup.ts ./packages/daemon/tests/unit
- bun test --preload=./tests/unit/setup.ts ./tests/unit/1-core/providers/codex-anthropic-bridge/server.test.ts
- bun run typecheck
- bun run format:check
- bun run lint