### PR TITLE
Prevent reviewer follow-up after terminal action

### DIFF
--- a/packages/daemon/src/lib/space/agents/seed-agents.ts
+++ b/packages/daemon/src/lib/space/agents/seed-agents.ts
@@ -189,7 +189,7 @@ If your verdict on this round is \`REQUEST_CHANGES\` (ANY P0–P3 finding exists
 
 \`submit_for_approval\` is **NOT** "ask a human to decide for me while findings are open." It carries the same approval semantic as \`approve_task\` — both terminate the loop. Use it only when you'd otherwise call \`approve_task\` but autonomy rules block self-close.
 
-**Important:** \`approve_task\` and \`submit_for_approval\` are your FINAL actions. After calling either tool, do NOT send a message to the coder or any other agent. The workflow handles the transition — sending a message after a terminal action can cause the coder to merge the PR before human approval is granted.
+**Important:** \`approve_task\` and \`submit_for_approval\` are your FINAL actions. After calling either tool, do NOT send a message to any agent or node. The workflow handles the transition — sending a message after a terminal action can reactivate other agents before human approval is granted.
 
 ## Posting the Review
 

--- a/packages/daemon/src/lib/space/agents/seed-agents.ts
+++ b/packages/daemon/src/lib/space/agents/seed-agents.ts
@@ -189,6 +189,8 @@ If your verdict on this round is \`REQUEST_CHANGES\` (ANY P0–P3 finding exists
 
 \`submit_for_approval\` is **NOT** "ask a human to decide for me while findings are open." It carries the same approval semantic as \`approve_task\` — both terminate the loop. Use it only when you'd otherwise call \`approve_task\` but autonomy rules block self-close.
 
+**Important:** \`approve_task\` and \`submit_for_approval\` are your FINAL actions. After calling either tool, do NOT send a message to the coder or any other agent. The workflow handles the transition — sending a message after a terminal action can cause the coder to merge the PR before human approval is granted.
+
 ## Posting the Review
 
 Determine the event deterministically (own-PR detection), then post via the REST API so the response includes the review URL:

--- a/packages/daemon/tests/unit/5-space/other/seed-agents.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/seed-agents.test.ts
@@ -283,7 +283,7 @@ describe('seedPresetAgents', () => {
 		expect(reviewer?.customPrompt).toMatch(/Do NOT call `submit_for_approval`/);
 		expect(reviewer?.customPrompt).toMatch(/same approval semantic/i);
 		expect(reviewer?.customPrompt).toMatch(/FINAL actions/);
-		expect(reviewer?.customPrompt).toMatch(/do NOT send a message to the coder/i);
+		expect(reviewer?.customPrompt).toMatch(/do NOT send a message to any agent/i);
 		expect(reviewer?.customPrompt).toMatch(/before human approval is granted/i);
 	});
 

--- a/packages/daemon/tests/unit/5-space/other/seed-agents.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/seed-agents.test.ts
@@ -282,6 +282,9 @@ describe('seedPresetAgents', () => {
 		expect(reviewer?.customPrompt).toMatch(/Do NOT call `approve_task`/);
 		expect(reviewer?.customPrompt).toMatch(/Do NOT call `submit_for_approval`/);
 		expect(reviewer?.customPrompt).toMatch(/same approval semantic/i);
+		expect(reviewer?.customPrompt).toMatch(/FINAL actions/);
+		expect(reviewer?.customPrompt).toMatch(/do NOT send a message to the coder/i);
+		expect(reviewer?.customPrompt).toMatch(/before human approval is granted/i);
 	});
 
 	it('Reviewer custom prompt includes own-PR detection', async () => {


### PR DESCRIPTION
Updates the seeded reviewer prompt so `approve_task` and `submit_for_approval` are explicitly final actions. This prevents reviewers from sending a follow-up message that can reactivate the coder before human approval completes.

Validation:
- `bun run format:check`
- `bun run check`
- `bun test packages/daemon/tests/unit/5-space/other/seed-agents.test.ts`
- `GIT_CONFIG_GLOBAL=/dev/null bun test packages/daemon/tests/unit/5-space`

Note: plain `bun test` still hits unrelated repo-wide web/UI harness failures (`react/jsx-runtime` missing and Vitest-style `vi.mocked` APIs under Bun).