### PR TITLE
Hard reset agent sessions on reset

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -700,9 +700,10 @@ export class AgentSession
 
 	async resetQuery(options?: {
 		restartQuery?: boolean;
+		hardReset?: boolean;
 	}): Promise<{ success: boolean; error?: string }> {
 		const restartQuery = options?.restartQuery ?? true;
-		if (this.runtimeOptions.hardReset) {
+		if (options?.hardReset && this.runtimeOptions.hardReset) {
 			return await this.runtimeOptions.hardReset(this, { restartQuery });
 		}
 

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -164,6 +164,17 @@ export interface AgentSessionRuntimeOptions {
 	 * replayPendingMessagesForImmediateMode() after runtime provisioning.
 	 */
 	autoReplayPendingMessages?: boolean;
+
+	/**
+	 * Optional owner-provided hard reset primitive.
+	 *
+	 * SessionManager uses this to replace the cached in-memory AgentSession with
+	 * a fresh instance while preserving the persisted session row.
+	 */
+	hardReset?: (
+		session: AgentSession,
+		options: { restartQuery: boolean }
+	) => Promise<{ success: boolean; error?: string }>;
 }
 
 // Extracted components
@@ -690,7 +701,12 @@ export class AgentSession
 	async resetQuery(options?: {
 		restartQuery?: boolean;
 	}): Promise<{ success: boolean; error?: string }> {
-		return await this.lifecycleManager.reset({ restartAfter: options?.restartQuery });
+		const restartQuery = options?.restartQuery ?? true;
+		if (this.runtimeOptions.hardReset) {
+			return await this.runtimeOptions.hardReset(this, { restartQuery });
+		}
+
+		return await this.lifecycleManager.reset({ restartAfter: restartQuery });
 	}
 
 	// ============================================================================

--- a/packages/daemon/src/lib/agent/event-subscription-setup.ts
+++ b/packages/daemon/src/lib/agent/event-subscription-setup.ts
@@ -35,7 +35,10 @@ export interface EventSubscriptionSetupContext {
 	readonly queryModeHandler: QueryModeHandler;
 
 	// Methods for event handling
-	resetQuery(options?: { restartQuery?: boolean }): Promise<{ success: boolean; error?: string }>;
+	resetQuery(options?: {
+		restartQuery?: boolean;
+		hardReset?: boolean;
+	}): Promise<{ success: boolean; error?: string }>;
 	startQueryAndEnqueue(messageId: string, messageContent: string | MessageContent[]): Promise<void>;
 }
 
@@ -94,7 +97,10 @@ export class EventSubscriptionSetup {
 		const unsubReset = daemonHub.on(
 			'agent.resetRequest',
 			async ({ sessionId: sid, restartQuery }) => {
-				const result = await this.ctx.resetQuery({ restartQuery: restartQuery ?? true });
+				const result = await this.ctx.resetQuery({
+					restartQuery: restartQuery ?? true,
+					hardReset: true,
+				});
 
 				await daemonHub.emit('agent.reset', {
 					sessionId: sid,

--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -868,7 +868,7 @@ export function setupSessionHandlers(
 
 		// Call resetQuery directly and return the result
 		// This allows the client to get immediate feedback on success/failure
-		const result = await agentSession.resetQuery({ restartQuery });
+		const result = await agentSession.resetQuery({ restartQuery, hardReset: true });
 
 		// Also emit event for StateManager to update clients
 		await daemonHub.emit('agent.reset', {

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -64,6 +64,7 @@ export class SessionManager {
 
 	// Cleanup state machine - prevents race conditions during shutdown
 	private cleanupState: CleanupState = CleanupState.IDLE;
+	private hardResetInFlight = new Map<string, Promise<{ success: boolean; error?: string }>>();
 
 	// Extracted modules
 	private sessionCache: SessionCache;
@@ -154,37 +155,63 @@ export class SessionManager {
 		);
 	}
 
-	private preserveResetCostBaseline(agentSession: AgentSession): void {
-		const session = agentSession.getSessionData();
-		const lastSdkCost = session.metadata?.lastSdkCost || 0;
-		if (lastSdkCost <= 0) return;
+	private preserveResetCostBaseline(
+		agentSession: AgentSession,
+		persistedSession: Session
+	): Session {
+		const currentSession = agentSession.getSessionData();
+		const currentMetadata = currentSession.metadata ?? {};
+		const lastSdkCost = currentMetadata.lastSdkCost || 0;
+		if (lastSdkCost <= 0) return persistedSession;
 
-		const costBaseline = session.metadata?.costBaseline || 0;
-		session.metadata = {
-			...session.metadata,
+		const costBaseline = currentMetadata.costBaseline || 0;
+		const metadata = {
+			...currentMetadata,
 			costBaseline: costBaseline + lastSdkCost,
 			lastSdkCost: 0,
 		};
-		this.db.updateSession(session.id, { metadata: session.metadata });
+		this.db.updateSession(currentSession.id, { metadata });
+		return { ...persistedSession, metadata };
 	}
 
-	private async hardResetAgentSession(
+	private hardResetAgentSession(
 		agentSession: AgentSession,
 		options: { restartQuery: boolean }
 	): Promise<{ success: boolean; error?: string }> {
 		const sessionId = agentSession.getSessionData().id;
+		const existingReset = this.hardResetInFlight.get(sessionId);
+		if (existingReset) {
+			return existingReset;
+		}
 
+		const resetPromise = this.performHardResetAgentSession(agentSession, options).finally(() => {
+			if (this.hardResetInFlight.get(sessionId) === resetPromise) {
+				this.hardResetInFlight.delete(sessionId);
+			}
+		});
+		this.hardResetInFlight.set(sessionId, resetPromise);
+
+		return resetPromise;
+	}
+
+	private async performHardResetAgentSession(
+		agentSession: AgentSession,
+		options: { restartQuery: boolean }
+	): Promise<{ success: boolean; error?: string }> {
+		const sessionId = agentSession.getSessionData().id;
 		try {
-			this.preserveResetCostBaseline(agentSession);
-
 			const persistedSession = this.db.getSession(sessionId);
 			if (!persistedSession) {
 				throw new Error(`Session not found: ${sessionId}`);
 			}
+			const sessionForFreshInstance = this.preserveResetCostBaseline(
+				agentSession,
+				persistedSession
+			);
 
 			await this.eventBus.emit('session.errorClear', { sessionId });
 
-			const freshSession = this.createAgentSessionFromSession(persistedSession, {
+			const freshSession = this.createAgentSessionFromSession(sessionForFreshInstance, {
 				autoReplayPendingMessages: false,
 			});
 			this.sessionCache.set(sessionId, freshSession);
@@ -544,6 +571,7 @@ export class SessionManager {
 
 			// Clear session cache
 			this.sessionCache.clear();
+			this.hardResetInFlight.clear();
 
 			// Transition to CLEANED state
 			this.cleanupState = CleanupState.CLEANED;

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -15,7 +15,7 @@ import type { Session, MessageHub, MessageDeliveryMode, MessageOrigin } from '@n
 import { generateUUID } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { Database } from '../../storage/database';
-import { AgentSession } from '../agent/agent-session';
+import { AgentSession, type AgentSessionRuntimeOptions } from '../agent/agent-session';
 import type { AuthManager } from '../auth-manager';
 import type { SettingsManager } from '../settings-manager';
 import { WorktreeManager } from '../worktree-manager';
@@ -90,21 +90,8 @@ export class SessionManager {
 		this.toolsConfigManager = new ToolsConfigManager(db);
 
 		// Factory function for creating AgentSession instances
-		const createAgentSession = (session: Session): AgentSession => {
-			return new AgentSession(
-				session,
-				db,
-				messageHub,
-				eventBus,
-				() => this.authManager.getCurrentApiKey(),
-				this.skillsManager,
-				this.appMcpServerRepo,
-				undefined,
-				{
-					autoReplayPendingMessages: !this.needsSpaceRuntimeProvisioning(session),
-				}
-			);
-		};
+		const createAgentSession = (session: Session): AgentSession =>
+			this.createAgentSessionFromSession(session);
 
 		// Initialize session cache with factory and loader
 		this.sessionCache = new SessionCache(createAgentSession, (sessionId: string) =>
@@ -144,6 +131,89 @@ export class SessionManager {
 		if (session.type === 'space_chat') return true;
 		if (session.type === 'space_task_agent') return true;
 		return typeof session.context?.spaceId === 'string';
+	}
+
+	private createAgentSessionFromSession(
+		session: Session,
+		runtimeOptions: AgentSessionRuntimeOptions = {}
+	): AgentSession {
+		return new AgentSession(
+			session,
+			this.db,
+			this.messageHub,
+			this.eventBus,
+			() => this.authManager.getCurrentApiKey(),
+			this.skillsManager,
+			this.appMcpServerRepo,
+			undefined,
+			{
+				autoReplayPendingMessages: !this.needsSpaceRuntimeProvisioning(session),
+				...runtimeOptions,
+				hardReset: (agentSession, options) => this.hardResetAgentSession(agentSession, options),
+			}
+		);
+	}
+
+	private preserveResetCostBaseline(agentSession: AgentSession): void {
+		const session = agentSession.getSessionData();
+		const lastSdkCost = session.metadata?.lastSdkCost || 0;
+		if (lastSdkCost <= 0) return;
+
+		const costBaseline = session.metadata?.costBaseline || 0;
+		session.metadata = {
+			...session.metadata,
+			costBaseline: costBaseline + lastSdkCost,
+			lastSdkCost: 0,
+		};
+		this.db.updateSession(session.id, { metadata: session.metadata });
+	}
+
+	private async hardResetAgentSession(
+		agentSession: AgentSession,
+		options: { restartQuery: boolean }
+	): Promise<{ success: boolean; error?: string }> {
+		const sessionId = agentSession.getSessionData().id;
+
+		try {
+			this.preserveResetCostBaseline(agentSession);
+
+			const persistedSession = this.db.getSession(sessionId);
+			if (!persistedSession) {
+				throw new Error(`Session not found: ${sessionId}`);
+			}
+
+			await this.eventBus.emit('session.errorClear', { sessionId });
+
+			const freshSession = this.createAgentSessionFromSession(persistedSession, {
+				autoReplayPendingMessages: false,
+			});
+			this.sessionCache.set(sessionId, freshSession);
+
+			try {
+				await agentSession.cleanup();
+			} catch (error) {
+				this.logger.error(
+					`[SessionManager] hardResetAgentSession: cleanup failed for ${sessionId}:`,
+					error
+				);
+			}
+
+			if (options.restartQuery) {
+				await freshSession.replayPendingMessagesForImmediateMode();
+			}
+
+			this.messageHub.event(
+				'session.reset',
+				{ message: 'Agent has been reset and is ready for new messages' },
+				{ channel: `session:${sessionId}` }
+			);
+
+			return { success: true };
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+			this.logger.error(`[SessionManager] hardResetAgentSession failed for ${sessionId}:`, error);
+			return { success: false, error: errorMessage };
+		}
 	}
 
 	/**

--- a/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
@@ -618,7 +618,33 @@ describe('AgentSession', () => {
 			expect(result).toEqual({ success: true });
 		});
 
-		it('resetQuery should use hard reset runtime hook when provided', async () => {
+		it('resetQuery should keep lifecycle reset behavior unless hardReset is requested', async () => {
+			const resetSpy = mock(async () => ({ success: true }));
+			const hardResetSpy = mock(async () => ({ success: true }));
+			const sessionWithHardReset = new AgentSession(
+				mockSession,
+				mockDb,
+				mockMessageHub,
+				mockDaemonHub,
+				mockGetApiKey,
+				undefined,
+				undefined,
+				undefined,
+				{ hardReset: hardResetSpy }
+			);
+			// biome-ignore lint: test mock access
+			(sessionWithHardReset as unknown as Record<string, unknown>).lifecycleManager = {
+				reset: resetSpy,
+			};
+
+			const result = await sessionWithHardReset.resetQuery({ restartQuery: true });
+
+			expect(hardResetSpy).not.toHaveBeenCalled();
+			expect(resetSpy).toHaveBeenCalledWith({ restartAfter: true });
+			expect(result).toEqual({ success: true });
+		});
+
+		it('resetQuery should use hard reset runtime hook when explicitly requested', async () => {
 			const hardResetSpy = mock(async () => ({ success: true }));
 			const sessionWithHardReset = new AgentSession(
 				mockSession,
@@ -632,7 +658,10 @@ describe('AgentSession', () => {
 				{ hardReset: hardResetSpy }
 			);
 
-			const result = await sessionWithHardReset.resetQuery({ restartQuery: true });
+			const result = await sessionWithHardReset.resetQuery({
+				restartQuery: true,
+				hardReset: true,
+			});
 
 			expect(hardResetSpy).toHaveBeenCalledWith(sessionWithHardReset, { restartQuery: true });
 			expect(result).toEqual({ success: true });

--- a/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/agent-session.test.ts
@@ -618,6 +618,26 @@ describe('AgentSession', () => {
 			expect(result).toEqual({ success: true });
 		});
 
+		it('resetQuery should use hard reset runtime hook when provided', async () => {
+			const hardResetSpy = mock(async () => ({ success: true }));
+			const sessionWithHardReset = new AgentSession(
+				mockSession,
+				mockDb,
+				mockMessageHub,
+				mockDaemonHub,
+				mockGetApiKey,
+				undefined,
+				undefined,
+				undefined,
+				{ hardReset: hardResetSpy }
+			);
+
+			const result = await sessionWithHardReset.resetQuery({ restartQuery: true });
+
+			expect(hardResetSpy).toHaveBeenCalledWith(sessionWithHardReset, { restartQuery: true });
+			expect(result).toEqual({ success: true });
+		});
+
 		it('updateConfig should delegate to sessionConfigHandler', async () => {
 			const updateConfigSpy = mock(async () => {});
 			// biome-ignore lint: test mock access

--- a/packages/daemon/tests/unit/1-core/agent/event-subscription-setup.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/event-subscription-setup.test.ts
@@ -185,7 +185,10 @@ describe('EventSubscriptionSetup', () => {
 				const callback = registeredCallbacks.get('agent.resetRequest')!;
 				await callback({ sessionId: 'test-session-id', restartQuery: false });
 
-				expect(mockContext.resetQuery).toHaveBeenCalledWith({ restartQuery: false });
+				expect(mockContext.resetQuery).toHaveBeenCalledWith({
+					restartQuery: false,
+					hardReset: true,
+				});
 				expect(emitSpy).toHaveBeenCalledWith('agent.reset', {
 					sessionId: 'test-session-id',
 					success: true,
@@ -199,7 +202,10 @@ describe('EventSubscriptionSetup', () => {
 				const callback = registeredCallbacks.get('agent.resetRequest')!;
 				await callback({ sessionId: 'test-session-id' });
 
-				expect(mockContext.resetQuery).toHaveBeenCalledWith({ restartQuery: true });
+				expect(mockContext.resetQuery).toHaveBeenCalledWith({
+					restartQuery: true,
+					hardReset: true,
+				});
 			});
 
 			it('should handle reset errors', async () => {

--- a/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
@@ -5,8 +5,9 @@
  * SessionCache, SessionLifecycle, ToolsConfigManager, and MessagePersistence.
  */
 
-import { describe, expect, it, beforeEach, mock, afterEach } from 'bun:test';
+import { describe, expect, it, beforeEach, mock, afterEach, spyOn } from 'bun:test';
 import { SessionManager, CleanupState } from '../../../../src/lib/session/session-manager';
+import { AgentSession } from '../../../../src/lib/agent/agent-session';
 import type { Database } from '../../../../src/storage/database';
 import type { DaemonHub } from '../../../../src/lib/daemon-hub';
 import type { AuthManager } from '../../../../src/lib/auth-manager';
@@ -567,6 +568,105 @@ describe('SessionManager', () => {
 			const lifecycle = sessionManager.getSessionLifecycle();
 
 			expect(lifecycle).toBeDefined();
+		});
+	});
+
+	describe('resetQuery hard reset', () => {
+		function makePersistedSession(overrides: Partial<Session> = {}): Session {
+			return {
+				id: 'test-id',
+				title: 'Test',
+				workspacePath: '/test',
+				status: 'active',
+				config: {
+					model: 'claude-sonnet-4-20250514',
+					maxTokens: 8192,
+					temperature: 1.0,
+					queryMode: 'manual',
+				},
+				metadata: {
+					messageCount: 2,
+					totalTokens: 100,
+					inputTokens: 40,
+					outputTokens: 60,
+					totalCost: 0.01,
+					toolCallCount: 1,
+				},
+				sdkSessionId: 'sdk-session-123',
+				...overrides,
+			} as Session;
+		}
+
+		it('replaces the cached AgentSession instance without recreating the DB row', async () => {
+			const persistedSession = makePersistedSession();
+			(mockDb.getSession as ReturnType<typeof mock>).mockReturnValue(persistedSession);
+
+			const oldSession = sessionManager.getSession('test-id');
+			expect(oldSession).toBeInstanceOf(AgentSession);
+			const cleanupSpy = spyOn(oldSession!, 'cleanup');
+
+			const result = await oldSession!.resetQuery({ restartQuery: false });
+			const freshSession = sessionManager.getSession('test-id');
+
+			expect(result).toEqual({ success: true });
+			expect(freshSession).toBeInstanceOf(AgentSession);
+			expect(freshSession).not.toBe(oldSession);
+			expect(freshSession!.getSessionData().id).toBe('test-id');
+			expect(freshSession!.getSessionData().sdkSessionId).toBe('sdk-session-123');
+			expect(mockDb.createSession).not.toHaveBeenCalled();
+			expect(mockDb.deleteSession).not.toHaveBeenCalled();
+			expect(mockDb.deleteMessagesAfter).not.toHaveBeenCalled();
+			expect(mockDb.deleteMessagesAtAndAfter).not.toHaveBeenCalled();
+			expect(cleanupSpy).toHaveBeenCalled();
+
+			await sessionManager.interruptInMemorySession('test-id');
+		});
+
+		it('preserves reset cost baseline on the existing session row', async () => {
+			const persistedSession = makePersistedSession({
+				metadata: {
+					lastSdkCost: 0.05,
+					costBaseline: 0.1,
+				},
+			});
+			(mockDb.getSession as ReturnType<typeof mock>).mockReturnValue(persistedSession);
+
+			const oldSession = sessionManager.getSession('test-id');
+			await oldSession!.resetQuery({ restartQuery: false });
+
+			expect(mockDb.updateSession).toHaveBeenCalled();
+			expect(persistedSession.metadata.costBaseline).toBeCloseTo(0.15, 10);
+			expect(persistedSession.metadata.lastSdkCost).toBe(0);
+			expect(persistedSession.sdkSessionId).toBe('sdk-session-123');
+
+			await sessionManager.interruptInMemorySession('test-id');
+		});
+
+		it('replays pending messages on the fresh AgentSession when restart is requested', async () => {
+			const persistedSession = makePersistedSession();
+			(mockDb.getSession as ReturnType<typeof mock>).mockReturnValue(persistedSession);
+
+			const oldSession = sessionManager.getSession('test-id');
+			let replayedSession: AgentSession | null = null;
+			const replaySpy = spyOn(
+				AgentSession.prototype,
+				'replayPendingMessagesForImmediateMode'
+			).mockImplementation(async function (this: AgentSession) {
+				replayedSession = this;
+			});
+
+			try {
+				const result = await oldSession!.resetQuery({ restartQuery: true });
+				const freshSession = sessionManager.getSession('test-id');
+
+				expect(result).toEqual({ success: true });
+				expect(freshSession).not.toBe(oldSession);
+				expect(replaySpy).toHaveBeenCalledTimes(1);
+				expect(replayedSession).toBe(freshSession);
+			} finally {
+				replaySpy.mockRestore();
+				await sessionManager.interruptInMemorySession('test-id');
+			}
 		});
 	});
 

--- a/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
@@ -597,6 +597,28 @@ describe('SessionManager', () => {
 			} as Session;
 		}
 
+		it('keeps normal resetQuery behavior unless hardReset is explicitly requested', async () => {
+			const persistedSession = makePersistedSession();
+			(mockDb.getSession as ReturnType<typeof mock>).mockReturnValue(persistedSession);
+
+			const oldSession = sessionManager.getSession('test-id');
+			expect(oldSession).toBeInstanceOf(AgentSession);
+			const lifecycleResetSpy = mock(async () => ({ success: true }));
+			// biome-ignore lint: test mock access
+			(oldSession as unknown as Record<string, unknown>).lifecycleManager = {
+				reset: lifecycleResetSpy,
+				cleanup: mock(async () => {}),
+			};
+
+			const result = await oldSession!.resetQuery({ restartQuery: true });
+
+			expect(result).toEqual({ success: true });
+			expect(lifecycleResetSpy).toHaveBeenCalledWith({ restartAfter: true });
+			expect(sessionManager.getSession('test-id')).toBe(oldSession);
+
+			await sessionManager.interruptInMemorySession('test-id');
+		});
+
 		it('replaces the cached AgentSession instance without recreating the DB row', async () => {
 			const persistedSession = makePersistedSession();
 			(mockDb.getSession as ReturnType<typeof mock>).mockReturnValue(persistedSession);
@@ -605,7 +627,7 @@ describe('SessionManager', () => {
 			expect(oldSession).toBeInstanceOf(AgentSession);
 			const cleanupSpy = spyOn(oldSession!, 'cleanup');
 
-			const result = await oldSession!.resetQuery({ restartQuery: false });
+			const result = await oldSession!.resetQuery({ restartQuery: false, hardReset: true });
 			const freshSession = sessionManager.getSession('test-id');
 
 			expect(result).toEqual({ success: true });
@@ -618,6 +640,14 @@ describe('SessionManager', () => {
 			expect(mockDb.deleteMessagesAfter).not.toHaveBeenCalled();
 			expect(mockDb.deleteMessagesAtAndAfter).not.toHaveBeenCalled();
 			expect(cleanupSpy).toHaveBeenCalled();
+			expect(mockEventBus.emit).toHaveBeenCalledWith('session.errorClear', {
+				sessionId: 'test-id',
+			});
+			expect(mockMessageHub.event).toHaveBeenCalledWith(
+				'session.reset',
+				{ message: 'Agent has been reset and is ready for new messages' },
+				{ channel: 'session:test-id' }
+			);
 
 			await sessionManager.interruptInMemorySession('test-id');
 		});
@@ -632,12 +662,24 @@ describe('SessionManager', () => {
 			(mockDb.getSession as ReturnType<typeof mock>).mockReturnValue(persistedSession);
 
 			const oldSession = sessionManager.getSession('test-id');
-			await oldSession!.resetQuery({ restartQuery: false });
+			await oldSession!.resetQuery({ restartQuery: false, hardReset: true });
 
-			expect(mockDb.updateSession).toHaveBeenCalled();
-			expect(persistedSession.metadata.costBaseline).toBeCloseTo(0.15, 10);
-			expect(persistedSession.metadata.lastSdkCost).toBe(0);
+			expect(mockDb.updateSession).toHaveBeenCalledWith(
+				'test-id',
+				expect.objectContaining({
+					metadata: expect.objectContaining({
+						lastSdkCost: 0,
+					}),
+				})
+			);
+			const updateSessionCalls = (mockDb.updateSession as ReturnType<typeof mock>).mock.calls;
+			expect(updateSessionCalls[0][1].metadata.costBaseline).toBeCloseTo(0.15, 10);
+			expect(persistedSession.metadata.costBaseline).toBe(0.1);
+			expect(persistedSession.metadata.lastSdkCost).toBe(0.05);
 			expect(persistedSession.sdkSessionId).toBe('sdk-session-123');
+			expect(
+				sessionManager.getSession('test-id')!.getSessionData().metadata.costBaseline
+			).toBeCloseTo(0.15, 10);
 
 			await sessionManager.interruptInMemorySession('test-id');
 		});
@@ -656,13 +698,52 @@ describe('SessionManager', () => {
 			});
 
 			try {
-				const result = await oldSession!.resetQuery({ restartQuery: true });
+				const result = await oldSession!.resetQuery({ restartQuery: true, hardReset: true });
 				const freshSession = sessionManager.getSession('test-id');
 
 				expect(result).toEqual({ success: true });
 				expect(freshSession).not.toBe(oldSession);
 				expect(replaySpy).toHaveBeenCalledTimes(1);
 				expect(replayedSession).toBe(freshSession);
+			} finally {
+				replaySpy.mockRestore();
+				await sessionManager.interruptInMemorySession('test-id');
+			}
+		});
+
+		it('coalesces concurrent hard resets for the same session', async () => {
+			const persistedSession = makePersistedSession();
+			(mockDb.getSession as ReturnType<typeof mock>).mockReturnValue(persistedSession);
+
+			const oldSession = sessionManager.getSession('test-id');
+			expect(oldSession).toBeInstanceOf(AgentSession);
+			(mockDb.getSession as ReturnType<typeof mock>).mockClear();
+			const replaySpy = spyOn(
+				AgentSession.prototype,
+				'replayPendingMessagesForImmediateMode'
+			).mockImplementation(async () => {});
+
+			let releaseCleanup: () => void = () => {};
+			const cleanupPromise = new Promise<void>((resolve) => {
+				releaseCleanup = resolve;
+			});
+			const cleanupSpy = spyOn(oldSession!, 'cleanup').mockImplementation(async () => {
+				await cleanupPromise;
+			});
+
+			try {
+				const firstReset = oldSession!.resetQuery({ restartQuery: true, hardReset: true });
+				await Promise.resolve();
+				const secondReset = oldSession!.resetQuery({ restartQuery: true, hardReset: true });
+
+				releaseCleanup();
+				const [firstResult, secondResult] = await Promise.all([firstReset, secondReset]);
+
+				expect(firstResult).toEqual({ success: true });
+				expect(secondResult).toEqual({ success: true });
+				expect(cleanupSpy).toHaveBeenCalledTimes(1);
+				expect(replaySpy).toHaveBeenCalledTimes(1);
+				expect(sessionManager.getSession('test-id')).not.toBe(oldSession);
 			} finally {
 				replaySpy.mockRestore();
 				await sessionManager.interruptInMemorySession('test-id');

--- a/packages/daemon/tests/unit/2-handlers/rpc/session-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc/session-handlers.test.ts
@@ -1415,19 +1415,31 @@ describe('Session RPC Handlers', () => {
 		it('resets query with restart', async () => {
 			const handler = messageHubData.handlers.get('session.resetQuery');
 			expect(handler).toBeDefined();
+			const { agentSession, mocks } = createMockAgentSession();
+			sessionManagerData.mocks.getSessionAsync.mockResolvedValueOnce(agentSession);
 
 			const result = await handler!({ sessionId: 'session-123', restartQuery: true }, {});
 
 			expect(result).toHaveProperty('success');
+			expect(mocks.resetQuery).toHaveBeenCalledWith({
+				restartQuery: true,
+				hardReset: true,
+			});
 		});
 
 		it('resets query without restart', async () => {
 			const handler = messageHubData.handlers.get('session.resetQuery');
 			expect(handler).toBeDefined();
+			const { agentSession, mocks } = createMockAgentSession();
+			sessionManagerData.mocks.getSessionAsync.mockResolvedValueOnce(agentSession);
 
 			const result = await handler!({ sessionId: 'session-123', restartQuery: false }, {});
 
 			expect(result).toHaveProperty('success');
+			expect(mocks.resetQuery).toHaveBeenCalledWith({
+				restartQuery: false,
+				hardReset: true,
+			});
 		});
 
 		it('defaults restartQuery to true', async () => {
@@ -1440,7 +1452,10 @@ describe('Session RPC Handlers', () => {
 
 			await handler!({ sessionId: 'session-123' }, {});
 
-			expect(mocks.resetQuery).toHaveBeenCalledWith({ restartQuery: true });
+			expect(mocks.resetQuery).toHaveBeenCalledWith({
+				restartQuery: true,
+				hardReset: true,
+			});
 		});
 
 		it('throws error when session not found', async () => {


### PR DESCRIPTION
Reset Agent now replaces the cached in-memory AgentSession with a fresh instance instead of restarting the query inside the same object.

The reset preserves the persisted session row, sdkSessionId, metadata, and messages, cleans up the old SDK subprocess, and replays pending immediate-mode messages on the fresh session.

Validation: bun run lint; bun run typecheck; focused reset/RPC unit tests passed. The broad daemon unit suite still has unrelated environment failures in keychain, port-binding, git-signing, dev-proxy, and timing-sensitive suites.