### PR TITLE
[codex] Fix Codex orphan tool continuation recovery

### DIFF
--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -17,6 +17,7 @@ export type { AppServerAuth } from './process-manager.js';
 import {
 	type AnthropicRequest,
 	type AnthropicErrorType,
+	type ToolResult,
 	buildDynamicTools,
 	buildConversationText,
 	extractSystemText,
@@ -224,6 +225,8 @@ type PersistentSession = {
 	isFirstTurn: boolean;
 	/** True while a turn is in progress — prevents concurrent turns on same session. */
 	turnInProgress: boolean;
+	/** Tool call IDs this persistent session is currently suspended on. */
+	suspendedToolCallIds: Set<string>;
 	/** Idle TTL timer — fires when no activity for IDLE_SESSION_TTL_MS. */
 	idleTimer?: ReturnType<typeof setTimeout>;
 };
@@ -475,15 +478,27 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 		return timer;
 	}
 
-	/** Retire a persistent session after its suspended tool call can no longer resume. */
+	/** Retire a persistent session after its own suspended tool call can no longer resume. */
 	function cleanupPersistentSession(sessionId: string, reason: string): void {
 		const ps = persistentSessions.get(sessionId);
 		if (!ps) return;
 		logger.warn(`codex-bridge: cleaning up persistent session ${sessionId}: ${reason}`);
 		ps.turnInProgress = false;
+		ps.suspendedToolCallIds.clear();
 		clearTimeout(ps.idleTimer);
 		ps.session.kill();
 		persistentSessions.delete(sessionId);
+	}
+
+	function shouldCleanupOrphanedContinuation(
+		sessionId: string,
+		toolResults: ToolResult[]
+	): boolean {
+		const ps = persistentSessions.get(sessionId);
+		if (!ps?.turnInProgress || ps.suspendedToolCallIds.size === 0) {
+			return false;
+		}
+		return toolResults.some((tr) => ps.suspendedToolCallIds.has(tr.toolUseId));
 	}
 
 	const server = Bun.serve({
@@ -612,7 +627,9 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 						`codex-bridge: no active sessions found for any tool_use_id in this continuation`
 					);
 					const sessionId = extractSessionId(req);
-					cleanupPersistentSession(sessionId, 'orphaned tool_result continuation');
+					if (shouldCleanupOrphanedContinuation(sessionId, toolResults)) {
+						cleanupPersistentSession(sessionId, 'orphaned tool_result continuation');
+					}
 					return createAnthropicError(
 						409,
 						'api_error',
@@ -721,6 +738,7 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 					toolsKey: currentToolsKey,
 					isFirstTurn: true,
 					turnInProgress: false,
+					suspendedToolCallIds: new Set(),
 					idleTimer: undefined,
 				};
 				persistentSessions.set(neokaiSessionId, ps);
@@ -748,11 +766,13 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 			const capturedSessionId = neokaiSessionId;
 			const onTurnDone = () => {
 				capturedPs.turnInProgress = false;
+				capturedPs.suspendedToolCallIds.clear();
 				capturedPs.idleTimer = scheduleIdle(capturedSessionId);
 			};
 			const onError = () => {
 				// Error: clean up persistent session
 				capturedPs.turnInProgress = false;
+				capturedPs.suspendedToolCallIds.clear();
 				clearTimeout(capturedPs.idleTimer);
 				capturedPs.session.kill();
 				persistentSessions.delete(capturedSessionId);
@@ -798,6 +818,9 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 							);
 
 							if (result.type === 'completed' || result.type === 'tool_call_suspended') {
+								if (result.type === 'tool_call_suspended') {
+									capturedPs.suspendedToolCallIds.add(result.callId);
+								}
 								return;
 							}
 

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -475,6 +475,17 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 		return timer;
 	}
 
+	/** Retire a persistent session after its suspended tool call can no longer resume. */
+	function cleanupPersistentSession(sessionId: string, reason: string): void {
+		const ps = persistentSessions.get(sessionId);
+		if (!ps) return;
+		logger.warn(`codex-bridge: cleaning up persistent session ${sessionId}: ${reason}`);
+		ps.turnInProgress = false;
+		clearTimeout(ps.idleTimer);
+		ps.session.kill();
+		persistentSessions.delete(sessionId);
+	}
+
 	const server = Bun.serve({
 		port: 0, // random available port
 		idleTimeout: 0, // disable idle timeout — bridge server handles long-running SSE streams
@@ -600,10 +611,12 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 					logger.error(
 						`codex-bridge: no active sessions found for any tool_use_id in this continuation`
 					);
+					const sessionId = extractSessionId(req);
+					cleanupPersistentSession(sessionId, 'orphaned tool_result continuation');
 					return createAnthropicError(
-						404,
-						'not_found_error',
-						'Session not found for all tool_use_ids in this continuation'
+						409,
+						'api_error',
+						'Tool continuation expired or was already consumed. The Codex turn was reset; resend your message to continue.'
 					);
 				}
 

--- a/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/server.test.ts
@@ -1510,7 +1510,7 @@ describe('Bridge HTTP server — Anthropic JSON error envelopes', () => {
 		expect(body.error.type).toBe('invalid_request_error');
 	});
 
-	it('returns 404 JSON envelope when tool_use_id has no active session', async () => {
+	it('returns non-404 JSON envelope when tool_use_id has no active session', async () => {
 		const resp = await fetch(`http://127.0.0.1:${realServer.port}/v1/messages`, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
@@ -1524,11 +1524,12 @@ describe('Bridge HTTP server — Anthropic JSON error envelopes', () => {
 				],
 			}),
 		});
-		expect(resp.status).toBe(404);
+		expect(resp.status).toBe(409);
 		expect(resp.headers.get('content-type')).toContain('application/json');
 		const body = (await resp.json()) as { type: string; error: { type: string; message: string } };
 		expect(body.type).toBe('error');
-		expect(body.error.type).toBe('not_found_error');
+		expect(body.error.type).toBe('api_error');
+		expect(body.error.message).toContain('Tool continuation expired');
 	});
 
 	it('returns 500 JSON envelope when BridgeSession fails to initialize', async () => {
@@ -1631,6 +1632,109 @@ describe('tool_choice warning — codex bridge', () => {
 		const events = await readSSEEvents(resp.body);
 		const types = events.map((e) => e.event);
 		expect(types).toContain('message_stop');
+	});
+
+	it('returns a non-404 error and resets the persistent session for orphaned tool continuations', async () => {
+		server.stop();
+		server = createBridgeServer({
+			codexBinaryPath: '/fake/codex',
+			cwd: '/tmp',
+			toolSessionTtlMs: 10,
+		}) as BridgeServer & { port: number };
+
+		let turn = 0;
+		startTurnSpy.mockImplementation(
+			// eslint-disable-next-line @typescript-eslint/require-await
+			async function* (): AsyncGenerator<BridgeEvent> {
+				turn++;
+				if (turn === 1) {
+					yield {
+						type: 'tool_call',
+						callId: 'call_orphaned',
+						toolName: 'test_tool',
+						toolInput: { value: true },
+						provideResult: () => {},
+					};
+					return;
+				}
+				yield { type: 'turn_done', inputTokens: 1, outputTokens: 1 };
+			}
+		);
+
+		const headers = {
+			'Content-Type': 'application/json',
+			Authorization: 'Bearer codex-bridge-orphan-recovery',
+		};
+
+		const firstResp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [{ role: 'user', content: 'call a tool' }],
+				tools: [{ name: 'test_tool', input_schema: { type: 'object' } }],
+				stream: true,
+			}),
+		});
+		expect(firstResp.ok).toBe(true);
+		const firstEvents = await readSSEEvents(firstResp.body);
+		expect(firstEvents.map((e) => e.event)).toContain('content_block_start');
+
+		await new Promise((resolve) => setTimeout(resolve, 30));
+
+		const orphanResp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [
+					{
+						role: 'assistant',
+						content: [
+							{
+								type: 'tool_use',
+								id: 'call_orphaned',
+								name: 'test_tool',
+								input: { value: true },
+							},
+						],
+					},
+					{
+						role: 'user',
+						content: [
+							{
+								type: 'tool_result',
+								tool_use_id: 'call_orphaned',
+								content: 'tool output',
+							},
+						],
+					},
+				],
+				stream: true,
+			}),
+		});
+
+		expect(orphanResp.status).toBe(409);
+		const orphanBody = (await orphanResp.json()) as {
+			error?: { type?: string; message?: string };
+		};
+		expect(orphanBody.error?.type).toBe('api_error');
+		expect(orphanBody.error?.message).toContain('Tool continuation expired');
+
+		const recoveryResp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [{ role: 'user', content: 'continue after reset' }],
+				stream: true,
+			}),
+		});
+
+		expect(recoveryResp.ok).toBe(true);
+		const recoveryEvents = await readSSEEvents(recoveryResp.body);
+		expect(recoveryEvents.map((e) => e.event)).toContain('message_stop');
+		expect(startTurnSpy).toHaveBeenCalledTimes(2);
 	});
 
 	it('retries a new turn once when the subprocess crashes before output', async () => {

--- a/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/server.test.ts
@@ -1737,6 +1737,106 @@ describe('tool_choice warning — codex bridge', () => {
 		expect(startTurnSpy).toHaveBeenCalledTimes(2);
 	});
 
+	it('does not reset a healthy persistent session for a duplicate unmatched tool continuation', async () => {
+		let turn = 0;
+		startTurnSpy.mockImplementation(
+			// eslint-disable-next-line @typescript-eslint/require-await
+			async function* (): AsyncGenerator<BridgeEvent> {
+				turn++;
+				if (turn === 1) {
+					yield {
+						type: 'tool_call',
+						callId: 'call_consumed',
+						toolName: 'test_tool',
+						toolInput: { value: true },
+						provideResult: () => {},
+					};
+					yield { type: 'turn_done', inputTokens: 1, outputTokens: 1 };
+					return;
+				}
+				yield { type: 'turn_done', inputTokens: 1, outputTokens: 1 };
+			}
+		);
+
+		const headers = {
+			'Content-Type': 'application/json',
+			Authorization: 'Bearer codex-bridge-duplicate-tool-result',
+		};
+		const continuationBody = {
+			model: 'codex-1',
+			messages: [
+				{
+					role: 'assistant',
+					content: [
+						{
+							type: 'tool_use',
+							id: 'call_consumed',
+							name: 'test_tool',
+							input: { value: true },
+						},
+					],
+				},
+				{
+					role: 'user',
+					content: [
+						{
+							type: 'tool_result',
+							tool_use_id: 'call_consumed',
+							content: 'tool output',
+						},
+					],
+				},
+			],
+			stream: true,
+		};
+
+		const firstResp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [{ role: 'user', content: 'call a tool' }],
+				tools: [{ name: 'test_tool', input_schema: { type: 'object' } }],
+				stream: true,
+			}),
+		});
+		expect(firstResp.ok).toBe(true);
+		await readSSEEvents(firstResp.body);
+
+		const continuationResp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify(continuationBody),
+		});
+		expect(continuationResp.ok).toBe(true);
+		await readSSEEvents(continuationResp.body);
+		expect(connCreateSpy).toHaveBeenCalledTimes(1);
+
+		const duplicateResp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify(continuationBody),
+		});
+		expect(duplicateResp.status).toBe(409);
+		expect(connCreateSpy).toHaveBeenCalledTimes(1);
+
+		const nextResp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [{ role: 'user', content: 'continue on same session' }],
+				tools: [{ name: 'test_tool', input_schema: { type: 'object' } }],
+				stream: true,
+			}),
+		});
+
+		expect(nextResp.ok).toBe(true);
+		await readSSEEvents(nextResp.body);
+		expect(connCreateSpy).toHaveBeenCalledTimes(1);
+		expect(startTurnSpy).toHaveBeenCalledTimes(2);
+	});
+
 	it('retries a new turn once when the subprocess crashes before output', async () => {
 		const warnSpy = spyOn(Logger.prototype, 'warn');
 		let attempt = 0;


### PR DESCRIPTION
## Summary

- Return `409 api_error` instead of `404 not_found_error` when the Codex bridge receives an orphaned `tool_result` continuation.
- Clean up the stale persistent Codex session when a suspended tool continuation can no longer resume.
- Add regression coverage for the stale tool-result path and successful follow-up turn recovery.

## Root Cause

The bridge stored suspended tool calls in memory. If that entry disappeared before the SDK sent the continuation, the bridge returned HTTP 404. The Claude Agent SDK interprets 404s as model-not-found, which surfaced as a misleading `gpt-5.5` availability error even though the actual failure was an orphaned tool continuation.

## Impact

A bad continuation still fails, but the bridge now resets the stale Codex session and the next user turn can start cleanly without restarting NeoKai. The SDK should also stop showing the misleading selected-model error for this path.

## Validation

- `bun test --preload=./tests/unit/setup.ts ./tests/unit/1-core/providers/codex-anthropic-bridge/server.test.ts`
- pre-commit hook: `oxlint`, `biome format`, `tsc --build --noEmit`, `knip`