### PR TITLE
[codex] fix stale resumeSessionAt recovery

### DIFF
--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -54,6 +54,7 @@ import {
 } from '../sdk-session-file-manager';
 
 export const CODEX_BRIDGE_AUTO_COMPACT_WINDOW = 1_000_000;
+const BEST_EFFORT_RESUME_MESSAGE_LIMIT = 10_000;
 
 /**
  * Provider-specific SDK settings overrides.
@@ -497,8 +498,14 @@ export class QueryOptionsBuilder {
 			if (this.isResumeSessionAtValid(resumeSessionAt)) {
 				result.resumeSessionAt = resumeSessionAt;
 			} else {
-				this.clearStaleResumeSessionAt();
-				delete result.resume;
+				const bestEffortResumeSessionAt = this.findBestEffortResumeSessionAt();
+				if (bestEffortResumeSessionAt) {
+					this.replaceStaleResumeSessionAt(bestEffortResumeSessionAt);
+					result.resumeSessionAt = bestEffortResumeSessionAt;
+				} else {
+					this.clearStaleResumeSessionAt();
+					delete result.resume;
+				}
 			}
 		}
 
@@ -522,6 +529,38 @@ export class QueryOptionsBuilder {
 			session.id,
 			messageUuid
 		);
+	}
+
+	private findBestEffortResumeSessionAt(): string | undefined {
+		const { session, db } = this.ctx;
+		if (!db) {
+			return undefined;
+		}
+
+		const { messages } = db.getSDKMessages(session.id, BEST_EFFORT_RESUME_MESSAGE_LIMIT);
+		const candidates = messages
+			.map((message) => ({
+				uuid: typeof message.uuid === 'string' ? message.uuid : undefined,
+				timestamp: message.timestamp,
+			}))
+			.filter((message): message is { uuid: string; timestamp: number } => Boolean(message.uuid))
+			.sort((a, b) => b.timestamp - a.timestamp);
+
+		for (const candidate of candidates) {
+			if (this.isResumeSessionAtValid(candidate.uuid)) {
+				return candidate.uuid;
+			}
+		}
+
+		return undefined;
+	}
+
+	private replaceStaleResumeSessionAt(resumeSessionAt: string): void {
+		const { session, db } = this.ctx;
+		session.metadata.resumeSessionAt = resumeSessionAt;
+		db?.updateSession(session.id, {
+			metadata: session.metadata,
+		});
 	}
 
 	private clearStaleResumeSessionAt(): void {

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -49,12 +49,12 @@ import { join } from 'path';
 import type { Database } from '../../storage/database';
 import {
 	extractCompactionSummary,
+	findBestEffortResumeSessionAt,
 	getSDKSessionFilePath,
 	messageUuidExistsInSessionFile,
 } from '../sdk-session-file-manager';
 
 export const CODEX_BRIDGE_AUTO_COMPACT_WINDOW = 1_000_000;
-const BEST_EFFORT_RESUME_MESSAGE_LIMIT = 10_000;
 
 /**
  * Provider-specific SDK settings overrides.
@@ -498,7 +498,14 @@ export class QueryOptionsBuilder {
 			if (this.isResumeSessionAtValid(resumeSessionAt)) {
 				result.resumeSessionAt = resumeSessionAt;
 			} else {
-				const bestEffortResumeSessionAt = this.findBestEffortResumeSessionAt();
+				const bestEffortResumeSessionAt = this.ctx.db
+					? findBestEffortResumeSessionAt(
+							this.getSdkResumeWorkspacePath(),
+							this.ctx.session.sdkSessionId,
+							this.ctx.session.id,
+							this.ctx.db
+						)
+					: undefined;
 				if (bestEffortResumeSessionAt) {
 					this.replaceStaleResumeSessionAt(bestEffortResumeSessionAt);
 					result.resumeSessionAt = bestEffortResumeSessionAt;
@@ -518,7 +525,7 @@ export class QueryOptionsBuilder {
 
 	private isResumeSessionAtValid(messageUuid: string): boolean {
 		const { session } = this.ctx;
-		const sdkWorkspacePath = this.getCwd();
+		const sdkWorkspacePath = this.getSdkResumeWorkspacePath();
 		if (!sdkWorkspacePath || !session.sdkSessionId) {
 			return false;
 		}
@@ -529,30 +536,6 @@ export class QueryOptionsBuilder {
 			session.id,
 			messageUuid
 		);
-	}
-
-	private findBestEffortResumeSessionAt(): string | undefined {
-		const { session, db } = this.ctx;
-		if (!db) {
-			return undefined;
-		}
-
-		const { messages } = db.getSDKMessages(session.id, BEST_EFFORT_RESUME_MESSAGE_LIMIT);
-		const candidates = messages
-			.map((message) => ({
-				uuid: typeof message.uuid === 'string' ? message.uuid : undefined,
-				timestamp: message.timestamp,
-			}))
-			.filter((message): message is { uuid: string; timestamp: number } => Boolean(message.uuid))
-			.sort((a, b) => b.timestamp - a.timestamp);
-
-		for (const candidate of candidates) {
-			if (this.isResumeSessionAtValid(candidate.uuid)) {
-				return candidate.uuid;
-			}
-		}
-
-		return undefined;
 	}
 
 	private replaceStaleResumeSessionAt(resumeSessionAt: string): void {
@@ -566,7 +549,7 @@ export class QueryOptionsBuilder {
 	private clearStaleResumeSessionAt(): void {
 		const { session, db } = this.ctx;
 		const previousSdkSessionId = session.sdkSessionId;
-		const workspacePath = session.sdkOriginPath ?? this.getCwd();
+		const workspacePath = this.getSdkResumeWorkspacePath();
 
 		delete session.metadata.resumeSessionAt;
 
@@ -589,6 +572,10 @@ export class QueryOptionsBuilder {
 			sdkSessionId: undefined,
 			sdkOriginPath: undefined,
 		});
+	}
+
+	private getSdkResumeWorkspacePath(): string | undefined {
+		return this.ctx.session.sdkOriginPath ?? this.getCwd();
 	}
 
 	/**

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -46,6 +46,12 @@ import {
 } from './builtin-skill-plugin-wrapper';
 import { homedir } from 'os';
 import { join } from 'path';
+import type { Database } from '../../storage/database';
+import {
+	extractCompactionSummary,
+	getSDKSessionFilePath,
+	messageUuidExistsInSessionFile,
+} from '../sdk-session-file-manager';
 
 export const CODEX_BRIDGE_AUTO_COMPACT_WINDOW = 1_000_000;
 
@@ -74,6 +80,7 @@ export function buildProviderSettings(providerId: string): Options['settings'] {
 export interface QueryOptionsBuilderContext {
 	readonly session: Session;
 	readonly settingsManager: SettingsManager;
+	readonly db?: Database;
 	/** Skills manager for injecting plugin/MCP server skills into SDK options. Optional for backwards compatibility. */
 	readonly skillsManager?: SkillsManager;
 	/** App MCP server repo for resolving mcp_server skill configs. Optional for backwards compatibility. */
@@ -480,10 +487,19 @@ export class QueryOptionsBuilder {
 			result.resume = this.ctx.session.sdkSessionId;
 		}
 
-		// Add resumeSessionAt for conversation rewind
-		// When set, only messages up to and including this UUID are resumed
+		// Add resumeSessionAt for conversation rewind.
+		// When set, only messages up to and including this UUID are resumed.
+		// Validate it immediately before handing options to the SDK: SDK compaction
+		// can remove old UUIDs after NeoKai persisted a rewind pointer, and passing a
+		// stale value makes Claude Code fail startup with "No message found".
 		if (this.ctx.session.metadata?.resumeSessionAt) {
-			result.resumeSessionAt = this.ctx.session.metadata.resumeSessionAt;
+			const resumeSessionAt = this.ctx.session.metadata.resumeSessionAt;
+			if (this.isResumeSessionAtValid(resumeSessionAt)) {
+				result.resumeSessionAt = resumeSessionAt;
+			} else {
+				this.clearStaleResumeSessionAt();
+				delete result.resume;
+			}
 		}
 
 		// Add thinking configuration based on thinkingLevel config
@@ -491,6 +507,49 @@ export class QueryOptionsBuilder {
 		result.thinking = this.thinkingLevelToThinkingConfig(thinkingLevel);
 
 		return result as Options;
+	}
+
+	private isResumeSessionAtValid(messageUuid: string): boolean {
+		const { session } = this.ctx;
+		const sdkWorkspacePath = this.getCwd();
+		if (!sdkWorkspacePath || !session.sdkSessionId) {
+			return false;
+		}
+
+		return messageUuidExistsInSessionFile(
+			sdkWorkspacePath,
+			session.sdkSessionId,
+			session.id,
+			messageUuid
+		);
+	}
+
+	private clearStaleResumeSessionAt(): void {
+		const { session, db } = this.ctx;
+		const previousSdkSessionId = session.sdkSessionId;
+		const workspacePath = session.sdkOriginPath ?? this.getCwd();
+
+		delete session.metadata.resumeSessionAt;
+
+		if (workspacePath && previousSdkSessionId) {
+			const compactionSummary = extractCompactionSummary(
+				getSDKSessionFilePath(workspacePath, previousSdkSessionId)
+			);
+			if (compactionSummary) {
+				session.metadata.compactionSummary = compactionSummary;
+			} else {
+				delete session.metadata.compactionSummary;
+			}
+		}
+
+		session.sdkSessionId = undefined;
+		session.sdkOriginPath = undefined;
+
+		db?.updateSession(session.id, {
+			metadata: session.metadata,
+			sdkSessionId: undefined,
+			sdkOriginPath: undefined,
+		});
 	}
 
 	/**

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -25,7 +25,11 @@ import type { ProcessingStateManager } from './processing-state-manager';
 import type { QueryOptionsBuilder } from './query-options-builder';
 import type { AskUserQuestionHandler } from './ask-user-question-handler';
 import type { OriginalEnvVars } from '../provider-service';
-import { extractCompactionSummary, getSDKSessionFilePath } from '../sdk-session-file-manager';
+import {
+	extractCompactionSummary,
+	getSDKSessionFilePath,
+	messageUuidExistsInSessionFile,
+} from '../sdk-session-file-manager';
 // Re-exported for callers that import OriginalEnvVars from this module — canonical definition lives in provider-service.ts.
 export type { OriginalEnvVars } from '../provider-service';
 
@@ -64,6 +68,7 @@ function defaultSpawn(opts: SpawnOptions): SpawnedProcess {
 const DEFAULT_STARTUP_TIMEOUT_MS = 15000;
 /** Max time to wait for subprocess exit before retrying after startup timeout. */
 const RETRY_EXIT_TIMEOUT_MS = 5000;
+const BEST_EFFORT_RESUME_MESSAGE_LIMIT = 10_000;
 
 function getStartupTimeoutMs(): number {
 	const raw = process.env.NEOKAI_SDK_STARTUP_TIMEOUT_MS;
@@ -599,41 +604,54 @@ export class QueryRunner {
 			if (isMessageNotFound) {
 				// The SDK found the transcript but could not find resumeSessionAt inside it.
 				// This commonly happens after SDK compaction removes old message UUIDs.
-				// Clear both the rewind pointer and SDK transcript identity so the retry
-				// starts with a fresh context instead of looping on stale JSONL state.
 				const oldResumeSessionAt = session.metadata.resumeSessionAt;
-				const compactionSummary = this.extractCompactionSummaryFromCurrentSdkSession();
-				logger.error(
-					`No message found for resumeSessionAt (${oldResumeSessionAt ?? 'unknown'}). ` +
-						'Clearing resumeSessionAt, sdkSessionId, and sdkOriginPath before retry.'
-				);
-				delete session.metadata.resumeSessionAt;
-				if (compactionSummary) {
-					session.metadata.compactionSummary = compactionSummary;
-				} else {
-					delete session.metadata.compactionSummary;
-				}
-				session.sdkSessionId = undefined;
-				session.sdkOriginPath = undefined;
-				this.ctx.db.updateSession(session.id, {
-					metadata: session.metadata,
-					sdkSessionId: undefined,
-					sdkOriginPath: undefined,
-				});
+				const bestEffortResumeSessionAt = this.findBestEffortResumeSessionAt();
 
-				try {
-					await this.displayErrorAsAssistantMessage(
-						'⚠️ **Conversation context was reset.**\n\n' +
-							'The previous rewind point is no longer present in the Claude SDK transcript. ' +
-							'This can happen after SDK compaction. Your conversation history in NeoKai is preserved; ' +
-							(compactionSummary
-								? 'a compacted summary from the previous SDK transcript will be carried into the fresh AI session.\n\n'
-								: 'only the AI context window has been reset.\n\n') +
-							'Retrying your message with a fresh AI session.',
-						{ markAsError: false }
+				if (bestEffortResumeSessionAt) {
+					logger.warn(
+						`No message found for resumeSessionAt (${oldResumeSessionAt ?? 'unknown'}). ` +
+							`Retrying from nearest available message UUID (${bestEffortResumeSessionAt}).`
 					);
-				} catch {
-					// Best-effort — don't let message emission block cleanup
+					session.metadata.resumeSessionAt = bestEffortResumeSessionAt;
+					this.ctx.db.updateSession(session.id, {
+						metadata: session.metadata,
+					});
+				} else {
+					// Clear both the rewind pointer and SDK transcript identity so the retry
+					// starts with a fresh context instead of looping on stale JSONL state.
+					const compactionSummary = this.extractCompactionSummaryFromCurrentSdkSession();
+					logger.error(
+						`No message found for resumeSessionAt (${oldResumeSessionAt ?? 'unknown'}). ` +
+							'No fallback message UUID was available; clearing resumeSessionAt, sdkSessionId, and sdkOriginPath before retry.'
+					);
+					delete session.metadata.resumeSessionAt;
+					if (compactionSummary) {
+						session.metadata.compactionSummary = compactionSummary;
+					} else {
+						delete session.metadata.compactionSummary;
+					}
+					session.sdkSessionId = undefined;
+					session.sdkOriginPath = undefined;
+					this.ctx.db.updateSession(session.id, {
+						metadata: session.metadata,
+						sdkSessionId: undefined,
+						sdkOriginPath: undefined,
+					});
+
+					try {
+						await this.displayErrorAsAssistantMessage(
+							'⚠️ **Conversation context was reset.**\n\n' +
+								'The previous rewind point is no longer present in the Claude SDK transcript. ' +
+								'This can happen after SDK compaction. Your conversation history in NeoKai is preserved; ' +
+								(compactionSummary
+									? 'a compacted summary from the previous SDK transcript will be carried into the fresh AI session.\n\n'
+									: 'only the AI context window has been reset.\n\n') +
+								'Retrying your message with a fresh AI session.',
+							{ markAsError: false }
+						);
+					} catch {
+						// Best-effort — don't let message emission block cleanup
+					}
 				}
 			}
 
@@ -901,6 +919,39 @@ export class QueryRunner {
 			);
 			return null;
 		}
+	}
+
+	private findBestEffortResumeSessionAt(): string | undefined {
+		const { session } = this.ctx;
+		const workspacePath =
+			session.sdkOriginPath ?? session.worktree?.worktreePath ?? session.workspacePath;
+		if (!workspacePath || !session.sdkSessionId) {
+			return undefined;
+		}
+
+		const { messages } = this.ctx.db.getSDKMessages(session.id, BEST_EFFORT_RESUME_MESSAGE_LIMIT);
+		const candidates = messages
+			.map((message) => ({
+				uuid: typeof message.uuid === 'string' ? message.uuid : undefined,
+				timestamp: message.timestamp,
+			}))
+			.filter((message): message is { uuid: string; timestamp: number } => Boolean(message.uuid))
+			.sort((a, b) => b.timestamp - a.timestamp);
+
+		for (const candidate of candidates) {
+			if (
+				messageUuidExistsInSessionFile(
+					workspacePath,
+					session.sdkSessionId,
+					session.id,
+					candidate.uuid
+				)
+			) {
+				return candidate.uuid;
+			}
+		}
+
+		return undefined;
 	}
 
 	private getLiveSdkMcpServerNames(queryOptions: Pick<Options, 'mcpServers'>): string[] {

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -461,10 +461,10 @@ export class QueryRunner {
 			}, STARTUP_TIMEOUT_MS);
 			this.ctx.startupTimeoutTimer = startupTimer;
 
-			// Fetch slash commands and models in background
-			this.ctx.onSlashCommandsFetched().catch((e) => {
-				logger.warn('Background fetch of slash commands failed:', e);
-			});
+			// Models can be fetched from the live query object. Slash commands are
+			// captured from the SDK system:init message by SDKMessageHandler; probing
+			// supportedCommands() here races startup recovery and can duplicate stale
+			// resumeSessionAt errors from an about-to-be-retried query.
 			this.ctx.onModelsFetched().catch((e) => {
 				logger.warn('Background fetch of models failed:', e);
 			});

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -27,8 +27,8 @@ import type { AskUserQuestionHandler } from './ask-user-question-handler';
 import type { OriginalEnvVars } from '../provider-service';
 import {
 	extractCompactionSummary,
+	findBestEffortResumeSessionAt,
 	getSDKSessionFilePath,
-	messageUuidExistsInSessionFile,
 } from '../sdk-session-file-manager';
 // Re-exported for callers that import OriginalEnvVars from this module — canonical definition lives in provider-service.ts.
 export type { OriginalEnvVars } from '../provider-service';
@@ -68,7 +68,6 @@ function defaultSpawn(opts: SpawnOptions): SpawnedProcess {
 const DEFAULT_STARTUP_TIMEOUT_MS = 15000;
 /** Max time to wait for subprocess exit before retrying after startup timeout. */
 const RETRY_EXIT_TIMEOUT_MS = 5000;
-const BEST_EFFORT_RESUME_MESSAGE_LIMIT = 10_000;
 
 function getStartupTimeoutMs(): number {
 	const raw = process.env.NEOKAI_SDK_STARTUP_TIMEOUT_MS;
@@ -605,7 +604,12 @@ export class QueryRunner {
 				// The SDK found the transcript but could not find resumeSessionAt inside it.
 				// This commonly happens after SDK compaction removes old message UUIDs.
 				const oldResumeSessionAt = session.metadata.resumeSessionAt;
-				const bestEffortResumeSessionAt = this.findBestEffortResumeSessionAt();
+				const bestEffortResumeSessionAt = findBestEffortResumeSessionAt(
+					session.sdkOriginPath ?? session.worktree?.worktreePath ?? session.workspacePath,
+					session.sdkSessionId,
+					session.id,
+					this.ctx.db
+				);
 
 				if (bestEffortResumeSessionAt) {
 					logger.warn(
@@ -919,39 +923,6 @@ export class QueryRunner {
 			);
 			return null;
 		}
-	}
-
-	private findBestEffortResumeSessionAt(): string | undefined {
-		const { session } = this.ctx;
-		const workspacePath =
-			session.sdkOriginPath ?? session.worktree?.worktreePath ?? session.workspacePath;
-		if (!workspacePath || !session.sdkSessionId) {
-			return undefined;
-		}
-
-		const { messages } = this.ctx.db.getSDKMessages(session.id, BEST_EFFORT_RESUME_MESSAGE_LIMIT);
-		const candidates = messages
-			.map((message) => ({
-				uuid: typeof message.uuid === 'string' ? message.uuid : undefined,
-				timestamp: message.timestamp,
-			}))
-			.filter((message): message is { uuid: string; timestamp: number } => Boolean(message.uuid))
-			.sort((a, b) => b.timestamp - a.timestamp);
-
-		for (const candidate of candidates) {
-			if (
-				messageUuidExistsInSessionFile(
-					workspacePath,
-					session.sdkSessionId,
-					session.id,
-					candidate.uuid
-				)
-			) {
-				return candidate.uuid;
-			}
-		}
-
-		return undefined;
 	}
 
 	private getLiveSdkMcpServerNames(queryOptions: Pick<Options, 'mcpServers'>): string[] {

--- a/packages/daemon/src/lib/sdk-session-file-manager.ts
+++ b/packages/daemon/src/lib/sdk-session-file-manager.ts
@@ -24,6 +24,13 @@ import { homedir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 import type { Database } from '../storage/database';
 
+export const BEST_EFFORT_RESUME_MESSAGE_LIMIT = 10_000;
+
+interface ResumeMessageCandidate {
+	uuid?: unknown;
+	timestamp: number;
+}
+
 /**
  * Get the SDK project directory for a workspace path
  * SDK replaces both / and . with - (e.g., /.neokai/ -> --neokai-)
@@ -1256,6 +1263,79 @@ export function messageUuidExistsInSessionFile(
 	kaiSessionId: string,
 	messageUuid: string
 ): boolean {
+	const messageUuids = readMessageUuidsFromSessionFile(workspacePath, sdkSessionId, kaiSessionId);
+	return messageUuids?.has(messageUuid) ?? false;
+}
+
+/**
+ * Find the newest remaining NeoKai message UUID that still exists in the SDK transcript.
+ *
+ * This is used when a persisted resumeSessionAt checkpoint is stale. The fallback
+ * stays bounded by NeoKai's remaining DB messages while reading the SDK JSONL once,
+ * avoiding an O(candidates × file-size) scan.
+ */
+export function findBestEffortResumeSessionAt(
+	workspacePath: string | null | undefined,
+	sdkSessionId: string | null | undefined,
+	kaiSessionId: string,
+	db: Pick<Database, 'getSDKMessages'>,
+	limit = BEST_EFFORT_RESUME_MESSAGE_LIMIT
+): string | undefined {
+	if (!workspacePath || !sdkSessionId) {
+		return undefined;
+	}
+
+	const messageUuids = readMessageUuidsFromSessionFile(workspacePath, sdkSessionId, kaiSessionId);
+	if (!messageUuids || messageUuids.size === 0) {
+		return undefined;
+	}
+
+	const { messages } = db.getSDKMessages(kaiSessionId, limit);
+	const candidates = newestMessageUuidCandidates(messages);
+	for (const candidate of candidates) {
+		if (messageUuids.has(candidate.uuid)) {
+			return candidate.uuid;
+		}
+	}
+
+	return undefined;
+}
+
+function newestMessageUuidCandidates(
+	messages: ResumeMessageCandidate[]
+): Array<{ uuid: string; timestamp: number }> {
+	return messages
+		.map((message) => ({
+			uuid: typeof message.uuid === 'string' ? message.uuid : undefined,
+			timestamp: message.timestamp,
+		}))
+		.filter((message): message is { uuid: string; timestamp: number } => Boolean(message.uuid))
+		.sort((a, b) => b.timestamp - a.timestamp);
+}
+
+function readMessageUuidsFromSessionFile(
+	workspacePath: string,
+	sdkSessionId: string | null | undefined,
+	kaiSessionId: string
+): Set<string> | null {
+	const filePath = resolveSDKSessionFilePath(workspacePath, sdkSessionId, kaiSessionId);
+	if (!filePath) {
+		return null;
+	}
+
+	try {
+		const content = readFileSync(filePath, 'utf-8');
+		return extractMessageUuids(content);
+	} catch {
+		return null;
+	}
+}
+
+function resolveSDKSessionFilePath(
+	workspacePath: string,
+	sdkSessionId: string | null | undefined,
+	kaiSessionId: string
+): string | null {
 	let filePath: string | null = null;
 	if (sdkSessionId) {
 		const candidatePath = getSDKSessionFilePath(workspacePath, sdkSessionId);
@@ -1267,21 +1347,31 @@ export function messageUuidExistsInSessionFile(
 		filePath = findSDKSessionFile(workspacePath, kaiSessionId);
 	}
 	if (!filePath || !existsSync(filePath)) {
-		return false;
+		return null;
 	}
 
-	try {
-		const content = readFileSync(filePath, 'utf-8');
-		const lines = content.split('\n');
+	return filePath;
+}
 
-		for (const line of lines) {
-			if (line.includes(`"uuid":"${messageUuid}"`) || line.includes(`"uuid": "${messageUuid}"`)) {
-				return true;
+function extractMessageUuids(content: string): Set<string> {
+	const messageUuids = new Set<string>();
+	for (const line of content.split('\n')) {
+		if (!line.trim()) {
+			continue;
+		}
+		try {
+			const parsed = JSON.parse(line) as { uuid?: unknown };
+			if (typeof parsed.uuid === 'string') {
+				messageUuids.add(parsed.uuid);
+				continue;
 			}
+		} catch {
+			// Fall through to a light regex fallback for partially malformed lines.
 		}
 
-		return lines.some((line) => line.includes(messageUuid));
-	} catch {
-		return false;
+		for (const match of line.matchAll(/"uuid"\s*:\s*"([^"]+)"/g)) {
+			messageUuids.add(match[1]);
+		}
 	}
+	return messageUuids;
 }

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -15,18 +15,22 @@ import {
 import type { Session } from '@neokai/shared';
 import type { SettingsManager } from '../../../../src/lib/settings-manager';
 import { generateUUID } from '@neokai/shared';
-import { homedir } from 'os';
+import { homedir, tmpdir } from 'os';
+import { dirname, join } from 'node:path';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { createTables } from '../../../../src/storage/schema';
 import { SkillRepository } from '../../../../src/storage/repositories/skill-repository';
 import { AppMcpServerRepository } from '../../../../src/storage/repositories/app-mcp-server-repository';
 import { SkillsManager } from '../../../../src/lib/skills-manager';
 import { noOpReactiveDb } from '../../../helpers/reactive-database';
+import { getSDKSessionFilePath } from '../../../../src/lib/sdk-session-file-manager';
 
 describe('QueryOptionsBuilder', () => {
 	let builder: QueryOptionsBuilder;
 	let mockSession: Session;
 	let mockSettingsManager: SettingsManager;
 	let mockContext: QueryOptionsBuilderContext;
+	let updateSessionSpy: ReturnType<typeof mock>;
 
 	beforeEach(() => {
 		mockSession = {
@@ -57,9 +61,14 @@ describe('QueryOptionsBuilder', () => {
 			prepareSDKOptions: mock(async () => ({})),
 		} as unknown as SettingsManager;
 
+		updateSessionSpy = mock(() => {});
+
 		mockContext = {
 			session: mockSession,
 			settingsManager: mockSettingsManager,
+			db: {
+				updateSession: updateSessionSpy,
+			} as QueryOptionsBuilderContext['db'],
 		};
 
 		builder = new QueryOptionsBuilder(mockContext);
@@ -205,6 +214,102 @@ describe('QueryOptionsBuilder', () => {
 			const result = builder.addSessionStateOptions(options);
 
 			expect(result.resume).toBe('sdk-session-123');
+		});
+
+		it('should add resumeSessionAt when the message still exists in the SDK transcript', async () => {
+			const originalTestSdkSessionDir = process.env.TEST_SDK_SESSION_DIR;
+			const testSdkDir = join(
+				tmpdir(),
+				`query-options-resume-valid-${Date.now()}-${Math.random().toString(36).slice(2)}`
+			);
+			try {
+				process.env.TEST_SDK_SESSION_DIR = testSdkDir;
+				mockSession.sdkSessionId = 'sdk-session-valid';
+				mockSession.metadata.resumeSessionAt = 'resumable-message-uuid';
+				const sessionFilePath = getSDKSessionFilePath(
+					mockSession.workspacePath!,
+					mockSession.sdkSessionId
+				);
+				mkdirSync(dirname(sessionFilePath), { recursive: true });
+				writeFileSync(
+					sessionFilePath,
+					`${JSON.stringify({ type: 'user', uuid: 'resumable-message-uuid' })}\n`,
+					'utf-8'
+				);
+
+				const options = await builder.build();
+				const result = builder.addSessionStateOptions(options);
+
+				expect(result.resume).toBe('sdk-session-valid');
+				expect(result.resumeSessionAt).toBe('resumable-message-uuid');
+				expect(updateSessionSpy).not.toHaveBeenCalled();
+			} finally {
+				rmSync(testSdkDir, { recursive: true, force: true });
+				if (originalTestSdkSessionDir !== undefined) {
+					process.env.TEST_SDK_SESSION_DIR = originalTestSdkSessionDir;
+				} else {
+					delete process.env.TEST_SDK_SESSION_DIR;
+				}
+			}
+		});
+
+		it('should clear stale resumeSessionAt before passing options to the SDK', async () => {
+			const originalTestSdkSessionDir = process.env.TEST_SDK_SESSION_DIR;
+			const testSdkDir = join(
+				tmpdir(),
+				`query-options-resume-stale-${Date.now()}-${Math.random().toString(36).slice(2)}`
+			);
+			try {
+				process.env.TEST_SDK_SESSION_DIR = testSdkDir;
+				mockSession.sdkSessionId = 'sdk-session-stale';
+				mockSession.sdkOriginPath = mockSession.workspacePath;
+				mockSession.metadata.resumeSessionAt = 'missing-message-uuid';
+				const sessionFilePath = getSDKSessionFilePath(
+					mockSession.workspacePath!,
+					mockSession.sdkSessionId
+				);
+				mkdirSync(dirname(sessionFilePath), { recursive: true });
+				writeFileSync(
+					sessionFilePath,
+					[
+						JSON.stringify({
+							type: 'system',
+							subtype: 'compact_boundary',
+							compact_metadata: { trigger: 'auto' },
+						}),
+						JSON.stringify({
+							type: 'assistant',
+							message: {
+								role: 'assistant',
+								content: [{ type: 'text', text: 'Compacted context summary' }],
+							},
+						}),
+					].join('\n') + '\n',
+					'utf-8'
+				);
+
+				const options = await builder.build();
+				const result = builder.addSessionStateOptions(options);
+
+				expect(result.resume).toBeUndefined();
+				expect(result.resumeSessionAt).toBeUndefined();
+				expect(mockSession.metadata.resumeSessionAt).toBeUndefined();
+				expect(mockSession.metadata.compactionSummary).toBe('Compacted context summary');
+				expect(mockSession.sdkSessionId).toBeUndefined();
+				expect(mockSession.sdkOriginPath).toBeUndefined();
+				expect(updateSessionSpy).toHaveBeenCalledWith(mockSession.id, {
+					metadata: mockSession.metadata,
+					sdkSessionId: undefined,
+					sdkOriginPath: undefined,
+				});
+			} finally {
+				rmSync(testSdkDir, { recursive: true, force: true });
+				if (originalTestSdkSessionDir !== undefined) {
+					process.env.TEST_SDK_SESSION_DIR = originalTestSdkSessionDir;
+				} else {
+					delete process.env.TEST_SDK_SESSION_DIR;
+				}
+			}
 		});
 
 		it('should not add resume when no SDK session ID', async () => {

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -31,6 +31,7 @@ describe('QueryOptionsBuilder', () => {
 	let mockSettingsManager: SettingsManager;
 	let mockContext: QueryOptionsBuilderContext;
 	let updateSessionSpy: ReturnType<typeof mock>;
+	let getSDKMessagesSpy: ReturnType<typeof mock>;
 
 	beforeEach(() => {
 		mockSession = {
@@ -62,12 +63,14 @@ describe('QueryOptionsBuilder', () => {
 		} as unknown as SettingsManager;
 
 		updateSessionSpy = mock(() => {});
+		getSDKMessagesSpy = mock(() => ({ messages: [], hasMore: false }));
 
 		mockContext = {
 			session: mockSession,
 			settingsManager: mockSettingsManager,
 			db: {
 				updateSession: updateSessionSpy,
+				getSDKMessages: getSDKMessagesSpy,
 			} as QueryOptionsBuilderContext['db'],
 		};
 
@@ -243,6 +246,70 @@ describe('QueryOptionsBuilder', () => {
 				expect(result.resume).toBe('sdk-session-valid');
 				expect(result.resumeSessionAt).toBe('resumable-message-uuid');
 				expect(updateSessionSpy).not.toHaveBeenCalled();
+			} finally {
+				rmSync(testSdkDir, { recursive: true, force: true });
+				if (originalTestSdkSessionDir !== undefined) {
+					process.env.TEST_SDK_SESSION_DIR = originalTestSdkSessionDir;
+				} else {
+					delete process.env.TEST_SDK_SESSION_DIR;
+				}
+			}
+		});
+
+		it('should replace stale resumeSessionAt with the newest remaining message UUID that still exists in the SDK transcript', async () => {
+			const originalTestSdkSessionDir = process.env.TEST_SDK_SESSION_DIR;
+			const testSdkDir = join(
+				tmpdir(),
+				`query-options-resume-fallback-${Date.now()}-${Math.random().toString(36).slice(2)}`
+			);
+			try {
+				process.env.TEST_SDK_SESSION_DIR = testSdkDir;
+				mockSession.sdkSessionId = 'sdk-session-fallback';
+				mockSession.metadata.resumeSessionAt = 'missing-message-uuid';
+				const sessionFilePath = getSDKSessionFilePath(
+					mockSession.workspacePath!,
+					mockSession.sdkSessionId
+				);
+				mkdirSync(dirname(sessionFilePath), { recursive: true });
+				writeFileSync(
+					sessionFilePath,
+					[
+						JSON.stringify({ type: 'user', uuid: 'older-existing-message-uuid' }),
+						JSON.stringify({ type: 'assistant', uuid: 'newer-existing-message-uuid' }),
+					].join('\n') + '\n',
+					'utf-8'
+				);
+				getSDKMessagesSpy.mockImplementation(() => ({
+					messages: [
+						{
+							type: 'user',
+							uuid: 'older-existing-message-uuid',
+							timestamp: 1000,
+						},
+						{
+							type: 'assistant',
+							uuid: 'newer-existing-message-uuid',
+							timestamp: 2000,
+						},
+						{
+							type: 'assistant',
+							uuid: 'newer-missing-message-uuid',
+							timestamp: 3000,
+						},
+					],
+					hasMore: false,
+				}));
+
+				const options = await builder.build();
+				const result = builder.addSessionStateOptions(options);
+
+				expect(result.resume).toBe('sdk-session-fallback');
+				expect(result.resumeSessionAt).toBe('newer-existing-message-uuid');
+				expect(mockSession.metadata.resumeSessionAt).toBe('newer-existing-message-uuid');
+				expect(mockSession.sdkSessionId).toBe('sdk-session-fallback');
+				expect(updateSessionSpy).toHaveBeenCalledWith(mockSession.id, {
+					metadata: mockSession.metadata,
+				});
 			} finally {
 				rmSync(testSdkDir, { recursive: true, force: true });
 				if (originalTestSdkSessionDir !== undefined) {

--- a/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
@@ -47,6 +47,7 @@ describe('QueryRunner', () => {
 	let saveSDKMessageSpy: ReturnType<typeof mock>;
 	let updateSessionSpy: ReturnType<typeof mock>;
 	let getMessagesByStatusSpy: ReturnType<typeof mock>;
+	let getSDKMessagesSpy: ReturnType<typeof mock>;
 	let updateMessageStatusSpy: ReturnType<typeof mock>;
 	let buildSpy: ReturnType<typeof mock>;
 	let addSessionStateOptionsSpy: ReturnType<typeof mock>;
@@ -96,11 +97,13 @@ describe('QueryRunner', () => {
 		saveSDKMessageSpy = mock(() => {});
 		updateSessionSpy = mock(() => {});
 		getMessagesByStatusSpy = mock(() => []);
+		getSDKMessagesSpy = mock(() => ({ messages: [], hasMore: false }));
 		updateMessageStatusSpy = mock(() => {});
 		mockDb = {
 			saveSDKMessage: saveSDKMessageSpy,
 			updateSession: updateSessionSpy,
 			getMessagesByStatus: getMessagesByStatusSpy,
+			getSDKMessages: getSDKMessagesSpy,
 			updateMessageStatus: updateMessageStatusSpy,
 		} as unknown as Database;
 
@@ -961,6 +964,84 @@ describe('QueryRunner', () => {
 								}),
 							]),
 						}),
+					})
+				);
+			} finally {
+				rmSync(testSdkDir, { recursive: true, force: true });
+				if (originalTestSdkSessionDir !== undefined) {
+					process.env.TEST_SDK_SESSION_DIR = originalTestSdkSessionDir;
+				} else {
+					delete process.env.TEST_SDK_SESSION_DIR;
+				}
+			}
+		});
+
+		it('should retry no-message-found from the newest remaining message UUID before clearing SDK state', async () => {
+			const originalTestSdkSessionDir = process.env.TEST_SDK_SESSION_DIR;
+			const testSdkDir = join(
+				tmpdir(),
+				`query-runner-resume-fallback-${Date.now()}-${Math.random().toString(36).slice(2)}`
+			);
+			try {
+				process.env.TEST_SDK_SESSION_DIR = testSdkDir;
+				mockSession.sdkSessionId = 'sdk-session-id';
+				mockSession.metadata.resumeSessionAt = 'missing-message-uuid';
+				const sessionFilePath = getSDKSessionFilePath(
+					mockSession.workspacePath!,
+					mockSession.sdkSessionId
+				);
+				mkdirSync(dirname(sessionFilePath), { recursive: true });
+				writeFileSync(
+					sessionFilePath,
+					[
+						JSON.stringify({ type: 'user', uuid: 'older-existing-message-uuid' }),
+						JSON.stringify({ type: 'assistant', uuid: 'newer-existing-message-uuid' }),
+					].join('\n') + '\n',
+					'utf-8'
+				);
+				getSDKMessagesSpy.mockImplementation(() => ({
+					messages: [
+						{
+							type: 'user',
+							uuid: 'older-existing-message-uuid',
+							timestamp: 1000,
+						},
+						{
+							type: 'assistant',
+							uuid: 'newer-existing-message-uuid',
+							timestamp: 2000,
+						},
+						{
+							type: 'assistant',
+							uuid: 'newer-missing-message-uuid',
+							timestamp: 3000,
+						},
+					],
+					hasMore: false,
+				}));
+
+				buildSpy
+					.mockRejectedValueOnce(
+						new Error('No message found with message.uuid of: missing-message-uuid')
+					)
+					.mockRejectedValueOnce(new Error('stop after retry'));
+
+				const ctx = createContext();
+				runner = new QueryRunner(ctx);
+				runner.start();
+				await ctx.queryPromise?.catch(() => {});
+
+				expect(buildSpy).toHaveBeenCalledTimes(2);
+				expect(mockSession.metadata.resumeSessionAt).toBe('newer-existing-message-uuid');
+				expect(mockSession.sdkSessionId).toBe('sdk-session-id');
+				expect(mockSession.sdkOriginPath).toBeUndefined();
+				expect(updateSessionSpy).toHaveBeenCalledWith('test-session-id', {
+					metadata: mockSession.metadata,
+				});
+				expect(updateSessionSpy).not.toHaveBeenCalledWith(
+					'test-session-id',
+					expect.objectContaining({
+						sdkSessionId: undefined,
 					})
 				);
 			} finally {

--- a/packages/daemon/tests/unit/1-core/core/sdk-session-file-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/sdk-session-file-manager.test.ts
@@ -21,6 +21,7 @@ import {
 	removeToolResultFromSessionFile,
 	truncateSessionFileAtMessage,
 	messageUuidExistsInSessionFile,
+	findBestEffortResumeSessionAt,
 	extractCompactionSummary,
 	findSDKSessionFileGlobally,
 	migrateSDKSessionFile,
@@ -1231,6 +1232,64 @@ describe('SDK Session File Manager', () => {
 			);
 
 			expect(exists).toBe(true);
+		});
+	});
+
+	describe('findBestEffortResumeSessionAt', () => {
+		test('should return the newest DB message UUID that exists in the SDK session file', () => {
+			writeFileSync(
+				testSessionFile,
+				[
+					JSON.stringify({ type: 'user', uuid: 'older-existing-message-uuid' }),
+					JSON.stringify({ type: 'assistant', uuid: 'newer-existing-message-uuid' }),
+				].join('\n') + '\n',
+				'utf-8'
+			);
+			const db = {
+				getSDKMessages: () => ({
+					messages: [
+						{ type: 'user', uuid: 'older-existing-message-uuid', timestamp: 1000 },
+						{ type: 'assistant', uuid: 'newer-existing-message-uuid', timestamp: 2000 },
+						{ type: 'assistant', uuid: 'newer-missing-message-uuid', timestamp: 3000 },
+					],
+					hasMore: false,
+				}),
+			} as unknown as Pick<Database, 'getSDKMessages'>;
+
+			const resumeSessionAt = findBestEffortResumeSessionAt(
+				testWorkspacePath,
+				testSdkSessionId,
+				'kai-session-id',
+				db
+			);
+
+			expect(resumeSessionAt).toBe('newer-existing-message-uuid');
+		});
+
+		test('should return undefined when none of the DB message UUIDs exist in the SDK session file', () => {
+			writeFileSync(
+				testSessionFile,
+				JSON.stringify({ type: 'system', subtype: 'compact_boundary' }) + '\n',
+				'utf-8'
+			);
+			const db = {
+				getSDKMessages: () => ({
+					messages: [
+						{ type: 'user', uuid: 'missing-user-message-uuid', timestamp: 1000 },
+						{ type: 'assistant', uuid: 'missing-assistant-message-uuid', timestamp: 2000 },
+					],
+					hasMore: false,
+				}),
+			} as unknown as Pick<Database, 'getSDKMessages'>;
+
+			const resumeSessionAt = findBestEffortResumeSessionAt(
+				testWorkspacePath,
+				testSdkSessionId,
+				'kai-session-id',
+				db
+			);
+
+			expect(resumeSessionAt).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
## Summary

Fixes startup failures when NeoKai persists a `metadata.resumeSessionAt` UUID that no longer exists in the Claude SDK JSONL transcript.

## Root Cause

NeoKai added `resumeSessionAt` to SDK query options without validating that the referenced message UUID was still present in the current SDK transcript. After SDK compaction or transcript truncation, Claude Code can reject startup with `No message found with message.uuid of: ...`.

Slash-command discovery also probed `supportedCommands()` during query startup. That call waits on the same SDK initialization, so it could log the same stale-resume failure even while the main query recovery path was clearing state and retrying.

## Changes

- Validate `resumeSessionAt` against the SDK transcript immediately before building SDK query options.
- Clear stale `resumeSessionAt`, `sdkSessionId`, and `sdkOriginPath` before the SDK sees invalid resume state.
- Carry a compaction summary into the fresh session when one can be extracted.
- Stop eager slash-command probing during query startup; slash commands continue to be captured from the SDK `system:init` message.
- Add focused unit coverage for valid and stale rewind pointers.

## Validation

- `bun test packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts packages/daemon/tests/unit/1-core/agent/query-runner.test.ts packages/daemon/tests/unit/1-core/agent/sdk-message-handler.test.ts packages/daemon/tests/unit/1-core/agent/slash-command-manager.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`
- pre-commit hook: lint, format, typecheck, knip
