### PR TITLE
Fix Codex MCP elicitation responses

### DIFF
--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/process-manager.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/process-manager.ts
@@ -37,6 +37,41 @@ export type BridgeEvent =
 	  }
 	| { type: 'error'; message: string };
 
+export type McpElicitationAction = 'accept' | 'decline' | 'cancel';
+
+export type McpElicitationResponse = {
+	action: McpElicitationAction;
+	content?: Record<string, unknown>;
+};
+
+const MCP_ELICITATION_REQUEST_METHOD = 'mcpServer/elicitation/request';
+const MCP_ELICITATION_ACTIONS = new Set<McpElicitationAction>(['accept', 'decline', 'cancel']);
+
+export function parseMcpElicitationResponse(
+	value: unknown,
+	context = 'MCP elicitation response'
+): McpElicitationResponse {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		throw new Error(`${context} must be an object with action`);
+	}
+
+	const response = value as Record<string, unknown>;
+	const action = response.action;
+	if (typeof action !== 'string' || !MCP_ELICITATION_ACTIONS.has(action as McpElicitationAction)) {
+		throw new Error(`${context} action must be one of: accept, decline, cancel`);
+	}
+
+	const content = response.content;
+	if (content !== undefined) {
+		if (!content || typeof content !== 'object' || Array.isArray(content)) {
+			throw new Error(`${context} content must be an object when provided`);
+		}
+		return { action: action as McpElicitationAction, content: content as Record<string, unknown> };
+	}
+
+	return { action: action as McpElicitationAction };
+}
+
 // ---------------------------------------------------------------------------
 // AsyncQueue — decouples the push-based read loop from the pull-based generator
 // ---------------------------------------------------------------------------
@@ -250,7 +285,13 @@ export class AppServerConn {
 			logger.debug(`AppServerConn: server request method=${req.method}`);
 			const handler = this.serverRequestHandlers.get(req.method);
 			try {
-				const result = handler ? await handler(req.params) : {};
+				if (!handler) {
+					const message = `Unsupported Codex app-server request method: ${req.method}`;
+					logger.warn(`AppServerConn: ${message}`);
+					this.write({ id: req.id, error: { code: -32601, message } });
+					return;
+				}
+				const result = await handler(req.params);
 				this.write({ id: req.id, result: result ?? {} });
 			} catch (err) {
 				this.write({ id: req.id, error: { code: -32603, message: String(err) } });
@@ -575,6 +616,25 @@ export class BridgeSession {
 		this.conn.onServerRequest('item/commandExecution/requestApproval', autoAccept);
 		this.conn.onServerRequest('item/fileChange/requestApproval', autoAccept);
 		this.conn.onServerRequest('item/permissions/requestApproval', autoAccept);
+
+		this.conn.onServerRequest(MCP_ELICITATION_REQUEST_METHOD, async (rawParams) => {
+			const params = rawParams as {
+				serverName?: string;
+				server_name?: string;
+				elicitationId?: string;
+				elicitation_id?: string;
+				message?: string;
+			};
+			const serverName = params?.serverName ?? params?.server_name ?? 'unknown';
+			const elicitationId = params?.elicitationId ?? params?.elicitation_id ?? 'unknown';
+			logger.warn(
+				`BridgeSession: declining unsupported MCP elicitation request server=${serverName} elicitationId=${elicitationId}`
+			);
+			return parseMcpElicitationResponse(
+				{ action: 'decline' },
+				`Default response for ${MCP_ELICITATION_REQUEST_METHOD}`
+			);
+		});
 	}
 
 	/** Start a new turn and return an async generator of BridgeEvents. */

--- a/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/process-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/process-manager.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'bun:test';
 import {
 	BridgeSession,
 	AppServerConn,
+	parseMcpElicitationResponse,
 } from '../../../../../src/lib/providers/codex-anthropic-bridge/process-manager';
 
 // ---------------------------------------------------------------------------
@@ -81,8 +82,93 @@ function makeEventableStubConn() {
 		fireNotification: (method: string, params: unknown) => {
 			notificationHandlers.get(method)?.(params);
 		},
+		callServerRequest: async (method: string, params: unknown) => {
+			const handler = serverRequestHandlers.get(method);
+			if (!handler) throw new Error(`No server request handler registered for ${method}`);
+			return handler(params);
+		},
 	};
 }
+
+// ---------------------------------------------------------------------------
+// mcpServer/elicitation/request — response schema regression guard
+// ---------------------------------------------------------------------------
+
+describe('BridgeSession mcpServer/elicitation/request', () => {
+	it('returns an action-bearing decline response for Codex MCP elicitation requests', async () => {
+		const { conn, callServerRequest } = makeEventableStubConn();
+		const session = new BridgeSession(conn, 'test-model', [], '/tmp');
+		await session.initialize();
+
+		const response = await callServerRequest('mcpServer/elicitation/request', {
+			serverName: 'node-agent',
+			elicitationId: 'elicit-1',
+			message: 'Need input',
+		});
+
+		expect(response).toEqual({ action: 'decline' });
+	});
+
+	it('accepts valid MCP elicitation response payloads', () => {
+		expect(
+			parseMcpElicitationResponse({
+				action: 'accept',
+				content: { choice: 'yes' },
+			})
+		).toEqual({
+			action: 'accept',
+			content: { choice: 'yes' },
+		});
+	});
+
+	it('rejects malformed MCP elicitation responses with actionable diagnostics', () => {
+		expect(() => parseMcpElicitationResponse({ content: {} })).toThrow(
+			'action must be one of: accept, decline, cancel'
+		);
+		expect(() => parseMcpElicitationResponse({ action: 'accept', content: [] })).toThrow(
+			'content must be an object when provided'
+		);
+	});
+});
+
+describe('AppServerConn server request dispatch', () => {
+	it('returns JSON-RPC method-not-found instead of malformed empty success for unhandled requests', async () => {
+		const written: string[] = [];
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(
+					new TextEncoder().encode(
+						JSON.stringify({ id: 'srv-req-1', method: 'unknown/request', params: {} }) + '\n'
+					)
+				);
+				controller.close();
+			},
+		});
+		const proc = {
+			stdout: stream,
+			kill: () => {},
+			stdin: {
+				write: (data: string) => written.push(data),
+				flush: () => {},
+			},
+		};
+		const TestableConn = AppServerConn as unknown as new (proc: typeof proc) => AppServerConn;
+		const conn = new TestableConn(proc);
+
+		await conn.closed;
+
+		expect(written).toHaveLength(1);
+		const response = JSON.parse(written[0].trim()) as {
+			id: string;
+			error?: { code?: number; message?: string };
+			result?: unknown;
+		};
+		expect(response.id).toBe('srv-req-1');
+		expect(response.result).toBeUndefined();
+		expect(response.error?.code).toBe(-32601);
+		expect(response.error?.message).toContain('Unsupported Codex app-server request method');
+	});
+});
 
 describe('BridgeSession item/agentMessage/delta', () => {
 	it('emits text_delta BridgeEvent for codex 0.114+ plain-string delta format', async () => {

--- a/packages/daemon/tests/unit/5-space/agent/agent-message-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-message-router.test.ts
@@ -884,6 +884,59 @@ describe('AgentMessageRouter: queue message for declared-but-inactive target', (
 		expect(result.queued![0].agentName).toBe('reviewer');
 	});
 
+	test('activates and queues during pre-session window when the only execution has no session', async () => {
+		const { runId: workflowRunId } = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeChannel('coder', 'reviewer'),
+		]);
+
+		// Mirrors the runtime log path: the run has a node_execution row, but no
+		// agentSessionId has been assigned yet.
+		ctx.nodeExecutionRepo.createOrIgnore({
+			workflowRunId,
+			workflowNodeId: ctx.nodeId,
+			agentName: 'reviewer',
+			status: 'pending',
+		});
+
+		const pendingMessageRepo = new PendingAgentMessageRepository(ctx.db);
+		const activated: Array<{ runId: string; from: string; to: string; message: string }> = [];
+		const injected: Array<{ sessionId: string; message: string }> = [];
+		const router = makeRouter(ctx, workflowRunId, injected, [makeChannel('coder', 'reviewer')], {
+			pendingMessageRepo,
+			spaceId: ctx.spaceId,
+			channelRouter: {
+				deliverMessage: async (runId: string, from: string, to: string, msg: string) => {
+					activated.push({ runId, from, to, message: msg });
+					return {
+						fromRole: from,
+						toRole: to,
+						message: msg,
+						targetNodeId: 'review-node',
+						isFanOut: false,
+						activatedTasks: [{}],
+					};
+				},
+			} as AgentMessageRouterConfig['channelRouter'],
+		});
+
+		const result = await router.deliverMessage({
+			fromAgentName: 'coder',
+			fromSessionId: ctx.coderSessionId,
+			target: 'reviewer',
+			message: 'code ready',
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.delivered).toHaveLength(0);
+		expect(result.queued).toHaveLength(1);
+		expect(result.queued![0].agentName).toBe('reviewer');
+		expect(injected).toHaveLength(0);
+		expect(activated).toEqual([
+			{ runId: workflowRunId, from: 'coder', to: 'reviewer', message: 'code ready' },
+		]);
+		expect(pendingMessageRepo.listPendingForTarget(workflowRunId, 'reviewer')).toHaveLength(1);
+	});
+
 	test('delivers to live session if available, queues for inactive declared agents', async () => {
 		const { runId: workflowRunId } = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
 			makeChannel('coder', 'reviewer'),


### PR DESCRIPTION
Root cause: Codex app-server sends `mcpServer/elicitation/request`, but the bridge had no handler and returned `{}` for unknown server requests. Codex deserialized that empty success as `McpServerElicitationRequestResponse` and failed because `action` was missing.

Fix: add a validated MCP elicitation response parser, decline unsupported elicitation requests with `{ action: "decline" }`, and return JSON-RPC method-not-found for unhandled server requests instead of malformed success payloads. Also covers the AgentMessageRouter pre-session window where node executions exist before `agentSessionId` is assigned.

Tests: `./scripts/test-daemon.sh` passed (11,403 tests, 0 failures, 1 skipped).