### PR TITLE
[codex] Harden orphaned tool continuation recovery

### DIFF
--- a/packages/daemon/src/lib/db-query/scope-config.ts
+++ b/packages/daemon/src/lib/db-query/scope-config.ts
@@ -369,6 +369,9 @@ const EXCLUDED_TABLE_NAMES: string[] = [
 	'task_group_events',
 	// Node execution tracking — transient per-run agent state, not useful for ad-hoc queries
 	'node_executions',
+	// Tool continuation recovery — internal bridge/runtime recovery state for orphaned tool_result chunks
+	'tool_continuation_recovery',
+	'tool_continuation_inbox',
 	// Pending agent messages — internal queue-until-active infrastructure for Task Agent
 	// send_message delivery; flushed by TaskAgentManager when target sessions activate.
 	'pending_agent_messages',

--- a/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
@@ -538,7 +538,12 @@ export class AnthropicToCodexBridgeProvider implements Provider {
 				? this.toBridgeAuth(this.cachedCredentials)
 				: undefined;
 			const auth = envAuth ?? this.cachedBridgeAuth ?? fileAuth ?? undefined;
-			bridgeServer = createBridgeServer({ codexBinaryPath, auth, cwd: workspace });
+			bridgeServer = createBridgeServer({
+				codexBinaryPath,
+				auth,
+				cwd: workspace,
+				dbPath: this.env.DB_PATH,
+			});
 			this.bridgeServers.set(workspace, bridgeServer);
 			logger.info(
 				`AnthropicToCodexBridgeProvider: bridge server started on port ${bridgeServer.port} for workspace=${workspace}`

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -14,6 +14,7 @@
 import { BridgeSession, AppServerConn, type AppServerAuth } from './process-manager.js';
 
 export type { AppServerAuth } from './process-manager.js';
+import { Database as BunDatabase } from 'bun:sqlite';
 import {
 	type AnthropicRequest,
 	type AnthropicErrorType,
@@ -37,6 +38,7 @@ import {
 import { estimateAnthropicInputTokens } from './token-estimator.js';
 import { getModelContextWindow, type CodexBridgeModelId } from './model-context-windows.js';
 import { Logger } from '../../logger.js';
+import { ToolContinuationRecoveryRepository } from '../../../storage/repositories/tool-continuation-recovery-repository.js';
 
 const logger = new Logger('codex-bridge-server');
 
@@ -156,6 +158,7 @@ export function createAnthropicError(
 /** Default TTL before an unresolved tool-call session is abandoned (5 min). */
 export const DEFAULT_TOOL_SESSION_TTL_MS = 5 * 60 * 1000;
 const MAX_SUBPROCESS_RETRIES = 1;
+const MAX_ORPHANED_TOOL_RESULT_409_RETRIES = 3;
 
 // ---------------------------------------------------------------------------
 // Session state for tool-call round-trips
@@ -249,7 +252,8 @@ export async function drainToSSE(
 	onTurnDone: () => void,
 	onError?: () => void,
 	initialInputTokens = 0,
-	returnUncommittedSubprocessCrash = true
+	returnUncommittedSubprocessCrash = true,
+	recoveryRepo?: ToolContinuationRecoveryRepository
 ): Promise<DrainResult> {
 	const enc = new TextEncoder();
 	const send = (s: string) => controller.enqueue(enc.encode(s));
@@ -334,6 +338,10 @@ export async function drainToSSE(
 				const callId = event.callId;
 				const cleanupTimer = setTimeout(() => {
 					logger.warn(`codex-bridge: TTL expired, killing abandoned session callId=${callId}`);
+					recoveryRepo?.markWaitingRebind(
+						callId,
+						'tool_result did not arrive before bridge TTL; execution moved to waiting_rebind'
+					);
 					session.kill();
 					toolSessions.delete(callId);
 				}, ttlMs);
@@ -346,6 +354,14 @@ export async function drainToSSE(
 					sessionId,
 					cleanupTimer,
 				});
+				try {
+					recoveryRepo?.recordToolUse({ toolUseId: callId, sessionId, ttlMs });
+				} catch (err) {
+					logger.warn(
+						`codex-bridge: failed to persist tool_use recovery mapping callId=${callId}:`,
+						err
+					);
+				}
 				suspendedCallId = callId;
 
 				logger.debug(`codex-bridge: tool_call suspended callId=${callId}`);
@@ -450,6 +466,8 @@ export type BridgeServerConfig = {
 	cwd: string;
 	/** Milliseconds before an unresolved tool-call session is abandoned (default 5 min). */
 	toolSessionTtlMs?: number;
+	/** SQLite DB path for durable tool continuation recovery. Defaults to DB_PATH. */
+	dbPath?: string;
 };
 
 export type BridgeServer = {
@@ -463,6 +481,16 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 	/** Persistent Codex sessions across multiple conversation turns. */
 	const persistentSessions = new Map<string, PersistentSession>();
 	const ttlMs = config.toolSessionTtlMs ?? DEFAULT_TOOL_SESSION_TTL_MS;
+	const recoveryDbPath = config.dbPath ?? process.env.DB_PATH;
+	const recoveryDb = recoveryDbPath ? new BunDatabase(recoveryDbPath) : null;
+	const recoveryRepo = recoveryDb ? new ToolContinuationRecoveryRepository(recoveryDb) : null;
+	if (recoveryRepo) {
+		try {
+			recoveryRepo.ensureSchema();
+		} catch (err) {
+			logger.warn('codex-bridge: failed to initialize tool continuation recovery store:', err);
+		}
+	}
 
 	/** Helper: schedule idle cleanup for a persistent session. */
 	function scheduleIdle(sessionId: string): ReturnType<typeof setTimeout> {
@@ -615,6 +643,7 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 					toolSessions.delete(tr.toolUseId);
 					// Cancel the TTL timer — session is being resumed normally
 					clearTimeout(stored.cleanupTimer);
+					recoveryRepo?.markConsumed(tr.toolUseId);
 					// Provide the tool result — this unblocks the Codex read loop for this call
 					stored.provideResult(tr.text);
 					if (!primaryStored) {
@@ -630,10 +659,49 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 					if (shouldCleanupOrphanedContinuation(sessionId, toolResults)) {
 						cleanupPersistentSession(sessionId, 'orphaned tool_result continuation');
 					}
+					let recoveryMessage =
+						'Tool continuation expired or was already consumed. The Codex turn was reset; resend your message to continue.';
+					let recoveryAction = 'unmapped';
+					for (const tr of toolResults) {
+						try {
+							const mappingBefore = recoveryRepo?.getToolUse(tr.toolUseId) ?? null;
+							const reason = mappingBefore
+								? 'orphaned tool_result queued for deterministic recovery'
+								: 'orphaned tool_result has no durable mapping';
+							recoveryRepo?.queueContinuation({
+								toolUseId: tr.toolUseId,
+								sessionId,
+								requestBody: body,
+								reason,
+								ttlMs,
+							});
+							const mappingAfter = recoveryRepo?.increment409(tr.toolUseId, reason) ?? null;
+							if (mappingAfter && Date.now() <= mappingAfter.expiresAt) {
+								if (mappingAfter.attempts409 >= MAX_ORPHANED_TOOL_RESULT_409_RETRIES) {
+									const failReason =
+										`orphaned tool_result circuit breaker tripped after ` +
+										`${mappingAfter.attempts409} HTTP 409 retries`;
+									recoveryRepo?.failToolUse(tr.toolUseId, failReason);
+									recoveryAction = 'fail_forward';
+									recoveryMessage = failReason;
+								} else {
+									recoveryAction = 'waiting_rebind';
+									recoveryMessage =
+										`Tool continuation queued for recovery: execution=${mappingAfter.executionId ?? 'unknown'} ` +
+										`attempt=${mappingAfter.attempts409}/${MAX_ORPHANED_TOOL_RESULT_409_RETRIES}`;
+								}
+							}
+						} catch (err) {
+							logger.warn(
+								`codex-bridge: failed to queue orphaned tool_result tool_use_id=${tr.toolUseId}:`,
+								err
+							);
+						}
+					}
 					return createAnthropicError(
 						409,
 						'api_error',
-						'Tool continuation expired or was already consumed. The Codex turn was reset; resend your message to continue.'
+						`${recoveryMessage} [recovery_action=${recoveryAction}]`
 					);
 				}
 
@@ -669,7 +737,8 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 								}
 							},
 							estimatedInputTokens,
-							false
+							false,
+							recoveryRepo ?? undefined
 						);
 					},
 				});
@@ -814,7 +883,9 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 								capturedSessionId,
 								onTurnDone,
 								onError,
-								estimatedInputTokens
+								estimatedInputTokens,
+								true,
+								recoveryRepo ?? undefined
 							);
 
 							if (result.type === 'completed' || result.type === 'tool_call_suspended') {
@@ -880,6 +951,10 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 			// and kill the underlying codex app-server subprocess.
 			for (const [callId, stored] of toolSessions) {
 				clearTimeout(stored.cleanupTimer);
+				recoveryRepo?.markWaitingRebind(
+					callId,
+					'bridge server stopped while tool_result was in-flight'
+				);
 				stored.session.kill();
 				toolSessions.delete(callId);
 				logger.debug(`codex-bridge: cleaned up suspended session callId=${callId} on stop`);
@@ -891,6 +966,7 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 				persistentSessions.delete(sessionId);
 				logger.debug(`codex-bridge: cleaned up persistent session ${sessionId} on stop`);
 			}
+			recoveryDb?.close();
 			server.stop();
 		},
 	};

--- a/packages/daemon/src/lib/space/managers/node-execution-manager.ts
+++ b/packages/daemon/src/lib/space/managers/node-execution-manager.ts
@@ -24,7 +24,8 @@ import type { NodeExecution, NodeExecutionStatus, UpdateNodeExecutionParams } fr
  *
  * Lifecycle:
  *   pending     → in_progress, cancelled
- *   in_progress → idle, blocked, cancelled
+ *   in_progress → idle, waiting_rebind, blocked, cancelled
+ *   waiting_rebind → pending, in_progress, blocked, cancelled
  *   idle        → in_progress (reactivation)
  *   blocked     → in_progress (retry), cancelled
  *   cancelled   → in_progress (retry)
@@ -32,7 +33,8 @@ import type { NodeExecution, NodeExecutionStatus, UpdateNodeExecutionParams } fr
 export const VALID_NODE_EXECUTION_TRANSITIONS: Record<NodeExecutionStatus, NodeExecutionStatus[]> =
 	{
 		pending: ['in_progress', 'cancelled'],
-		in_progress: ['idle', 'blocked', 'cancelled'],
+		in_progress: ['idle', 'waiting_rebind', 'blocked', 'cancelled'],
+		waiting_rebind: ['pending', 'in_progress', 'blocked', 'cancelled'],
 		idle: ['in_progress'], // Reactivation — allows re-running a completed node
 		blocked: ['in_progress', 'cancelled'],
 		cancelled: ['in_progress'], // Retry

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -916,6 +916,10 @@ export class SpaceRuntime {
 		if (this.tickInFlight) return;
 		this.tickInFlight = true;
 		try {
+			if (hasSqlExec(this.config.db)) {
+				this.toolContinuationRepo.markExpired();
+			}
+
 			if (!this.rehydrated) {
 				await this.rehydrateExecutors();
 				// Run a stalled-run recovery pass right after rehydrate so the

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -43,6 +43,7 @@ import { selectWorkflow } from './workflow-selector';
 import { Logger } from '../../logger';
 import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
 import { SDKMessageRepository } from '../../../storage/repositories/sdk-message-repository';
+import { ToolContinuationRecoveryRepository } from '../../../storage/repositories/tool-continuation-recovery-repository';
 import { type NotificationSink, NullNotificationSink } from './notification-sink';
 import { CompletionDetector } from './completion-detector';
 import type { SelectWorkflowWithLlm } from './llm-workflow-selector';
@@ -268,11 +269,14 @@ export class SpaceRuntime {
 
 	/** In-memory store of resolved channels per run ID. Replaces run.config._resolvedChannels. */
 	private workflowChannelsMap = new Map<string, WorkflowChannel[]>();
+	private readonly toolContinuationRepo: ToolContinuationRecoveryRepository;
 
 	constructor(private config: SpaceRuntimeConfig) {
 		this.notificationSink = config.notificationSink ?? new NullNotificationSink();
 		this.completionDetector = config.completionDetector ?? new CompletionDetector(config.taskRepo);
 		this.sdkMessageRepo = config.sdkMessageRepo ?? null;
+		this.toolContinuationRepo = new ToolContinuationRecoveryRepository(config.db);
+		this.toolContinuationRepo.ensureSchema();
 	}
 
 	/**
@@ -1401,7 +1405,11 @@ export class SpaceRuntime {
 		// alone. Recovery only intervenes when the runtime has nothing it
 		// can act on (every execution is `idle` or `cancelled`).
 		const hasDriveableExecution = executions.some(
-			(ex) => ex.status === 'pending' || ex.status === 'in_progress' || ex.status === 'blocked'
+			(ex) =>
+				ex.status === 'pending' ||
+				ex.status === 'in_progress' ||
+				ex.status === 'waiting_rebind' ||
+				ex.status === 'blocked'
 		);
 		if (hasDriveableExecution) return 'skipped';
 
@@ -1796,6 +1804,9 @@ export class SpaceRuntime {
 				return;
 			}
 
+			await this.handleWaitingRebindExecutions(runId, run, meta.spaceId, canonicalTask);
+			nodeExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
+
 			// Step 1.5: Auto-complete alive agents that have exceeded their timeout.
 			// Transitions to 'idle' — the same state as a naturally completing session.
 			//
@@ -1816,6 +1827,14 @@ export class SpaceRuntime {
 				const referenceTime = execution.startedAt ?? execution.createdAt;
 				const elapsedMs = now - referenceTime;
 				if (elapsedMs <= timeoutMs) continue;
+				const toolGraceMs = Math.min(timeoutMs, 60_000);
+				if (this.toolContinuationRepo.hasActiveToolUseForExecution(execution.id, toolGraceMs)) {
+					const reason =
+						`Agent exceeded timeout with an in-flight tool call; moved to waiting_rebind ` +
+						`for ${Math.round(toolGraceMs / 1000)}s continuation recovery grace`;
+					this.toolContinuationRepo.markExecutionWaitingRebind(execution.id, reason);
+					continue;
+				}
 
 				// Part D guard: spare sessions waiting for user input. The agent is
 				// not stuck — a human is.
@@ -2051,6 +2070,120 @@ export class SpaceRuntime {
 			// Agents drive workflow progression via send_message and
 			// `task.reportedStatus`.
 			return;
+		}
+	}
+
+	private async handleWaitingRebindExecutions(
+		runId: string,
+		run: SpaceWorkflowRun,
+		spaceId: string,
+		canonicalTask: SpaceTask
+	): Promise<void> {
+		const waitingExecutions = this.config.nodeExecutionRepo
+			.listByWorkflowRun(runId)
+			.filter((execution) => execution.status === 'waiting_rebind');
+		if (waitingExecutions.length === 0) return;
+
+		for (const execution of waitingExecutions) {
+			const data = parseNodeExecutionData(execution.data);
+			const recoveryData = isRecord(data.orphanedToolContinuation)
+				? data.orphanedToolContinuation
+				: {};
+			const retryCount = typeof recoveryData.retryCount === 'number' ? recoveryData.retryCount : 0;
+			const pendingInbox = this.toolContinuationRepo.listPendingInboxForExecution(execution.id);
+			const hasActiveTool = this.toolContinuationRepo.hasActiveToolUseForExecution(execution.id);
+
+			if (pendingInbox.length > 0 && retryCount < 1) {
+				const reason =
+					pendingInbox[0]?.recoveryReason ??
+					'orphaned tool_result continuation queued for deterministic retry';
+				data.orphanedToolContinuation = {
+					...recoveryData,
+					state: 'rebound',
+					retryCount: retryCount + 1,
+					reason,
+					queuedContinuations: pendingInbox.length,
+					updatedAt: Date.now(),
+				};
+				this.toolContinuationRepo.markInboxReboundForExecution(
+					execution.id,
+					'queued orphaned tool_result rebound by restarting workflow node execution'
+				);
+				this.config.nodeExecutionRepo.update(execution.id, {
+					status: 'pending',
+					agentSessionId: null,
+					result: null,
+					data,
+					startedAt: null,
+					completedAt: null,
+				});
+				if (run.status !== 'in_progress') {
+					await this.transitionRunStatusAndEmit(run.id, 'in_progress');
+				}
+				if (canonicalTask.status === 'blocked' || canonicalTask.status === 'open') {
+					await this.updateTaskAndEmit(spaceId, canonicalTask.id, {
+						status: 'in_progress',
+						completedAt: null,
+						result: null,
+						blockReason: null,
+					});
+				}
+				await this.safeNotify({
+					kind: 'task_retry',
+					spaceId,
+					taskId: canonicalTask.id,
+					runId,
+					originalReason: reason,
+					attemptNumber: retryCount + 1,
+					maxAttempts: 1,
+					timestamp: new Date().toISOString(),
+				});
+				log.info(
+					`SpaceRuntime: rebound orphaned tool_result continuation for execution ${execution.id}; ` +
+						`reset to pending for retry ${retryCount + 1}/1`
+				);
+				continue;
+			}
+
+			if (hasActiveTool) {
+				continue;
+			}
+
+			const reason =
+				retryCount >= 1
+					? 'orphaned tool_result recovery exhausted its single automatic retry'
+					: 'orphaned tool_result recovery expired before a continuation arrived';
+			data.orphanedToolContinuation = {
+				...recoveryData,
+				state: 'failed',
+				retryCount,
+				reason,
+				updatedAt: Date.now(),
+			};
+			this.config.nodeExecutionRepo.update(execution.id, {
+				status: 'blocked',
+				agentSessionId: null,
+				result: reason,
+				data,
+				completedAt: Date.now(),
+			});
+			await this.transitionRunStatusAndEmit(run.id, 'blocked');
+			await this.updateTaskAndEmit(spaceId, canonicalTask.id, {
+				status: 'blocked',
+				result: reason,
+				blockReason: 'execution_failed',
+				completedAt: null,
+			});
+			await this.safeNotify({
+				kind: 'workflow_run_blocked',
+				spaceId,
+				runId,
+				reason,
+				timestamp: new Date().toISOString(),
+			});
+			log.warn(
+				`SpaceRuntime: failed orphaned tool_result recovery for execution ${execution.id}: ${reason}`
+			);
 		}
 	}
 
@@ -2581,4 +2714,20 @@ export class SpaceRuntime {
 		const workflow = this.config.spaceWorkflowManager.getWorkflow(run.workflowId);
 		return workflow?.channels ?? [];
 	}
+}
+
+function parseNodeExecutionData(value: unknown): Record<string, unknown> {
+	if (!value) return {};
+	if (isRecord(value)) return { ...value };
+	if (typeof value !== 'string') return {};
+	try {
+		const parsed = JSON.parse(value) as unknown;
+		return isRecord(parsed) ? parsed : {};
+	} catch {
+		return {};
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return !!value && typeof value === 'object' && !Array.isArray(value);
 }

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -276,7 +276,9 @@ export class SpaceRuntime {
 		this.completionDetector = config.completionDetector ?? new CompletionDetector(config.taskRepo);
 		this.sdkMessageRepo = config.sdkMessageRepo ?? null;
 		this.toolContinuationRepo = new ToolContinuationRecoveryRepository(config.db);
-		this.toolContinuationRepo.ensureSchema();
+		if (hasSqlExec(config.db)) {
+			this.toolContinuationRepo.ensureSchema();
+		}
 	}
 
 	/**
@@ -2730,4 +2732,8 @@ function parseNodeExecutionData(value: unknown): Record<string, unknown> {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function hasSqlExec(value: unknown): value is { exec: (sql: string) => void } {
+	return isRecord(value) && typeof value.exec === 'function';
 }

--- a/packages/daemon/src/storage/repositories/node-execution-repository.ts
+++ b/packages/daemon/src/storage/repositories/node-execution-repository.ts
@@ -262,12 +262,13 @@ export class NodeExecutionRepository {
 				`SELECT * FROM node_executions
 				 WHERE agent_session_id = ?
 				 ORDER BY
-				   CASE status
-				     WHEN 'in_progress' THEN 0
-				     WHEN 'blocked' THEN 1
-				     WHEN 'pending' THEN 2
-				     ELSE 3
-				   END,
+					   CASE status
+					     WHEN 'in_progress' THEN 0
+					     WHEN 'waiting_rebind' THEN 1
+					     WHEN 'blocked' THEN 2
+					     WHEN 'pending' THEN 3
+					     ELSE 4
+					   END,
 				   updated_at DESC,
 				   created_at DESC,
 				   id DESC`

--- a/packages/daemon/src/storage/repositories/tool-continuation-recovery-repository.ts
+++ b/packages/daemon/src/storage/repositories/tool-continuation-recovery-repository.ts
@@ -1,0 +1,444 @@
+/**
+ * Durable recovery state for Codex Anthropic bridge tool continuations.
+ *
+ * The bridge's live generator map is necessarily process-local, but the
+ * ownership relationship between an Anthropic `tool_use.id` and a workflow node
+ * execution must survive daemon restarts. This repository stores that mapping
+ * plus an inbox for late `tool_result` continuation requests so the runtime can
+ * deterministically re-drive or fail-forward the execution instead of leaving a
+ * run permanently blocked.
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+import { generateUUID } from '@neokai/shared';
+
+export type ToolContinuationStatus =
+	| 'active'
+	| 'waiting_rebind'
+	| 'rebound'
+	| 'failed'
+	| 'expired'
+	| 'consumed';
+
+export type ContinuationInboxStatus = 'pending' | 'rebound' | 'failed' | 'expired';
+
+export interface ToolContinuationRecord {
+	toolUseId: string;
+	sessionId: string;
+	executionId: string | null;
+	workflowRunId: string | null;
+	status: ToolContinuationStatus;
+	attempts409: number;
+	recoveryReason: string | null;
+	createdAt: number;
+	updatedAt: number;
+	expiresAt: number;
+}
+
+export interface ContinuationInboxRecord {
+	id: string;
+	toolUseId: string;
+	sessionId: string;
+	executionId: string | null;
+	workflowRunId: string | null;
+	status: ContinuationInboxStatus;
+	requestJson: string;
+	recoveryReason: string | null;
+	createdAt: number;
+	updatedAt: number;
+	expiresAt: number;
+}
+
+export interface ToolContinuationOwner {
+	executionId: string | null;
+	workflowRunId: string | null;
+}
+
+export class ToolContinuationRecoveryRepository {
+	constructor(private readonly db: BunDatabase) {}
+
+	ensureSchema(): void {
+		this.db.exec(`
+			CREATE TABLE IF NOT EXISTS tool_continuation_recovery (
+				tool_use_id TEXT PRIMARY KEY,
+				session_id TEXT NOT NULL,
+				execution_id TEXT,
+				workflow_run_id TEXT,
+				status TEXT NOT NULL DEFAULT 'active'
+					CHECK(status IN ('active', 'waiting_rebind', 'rebound', 'failed', 'expired', 'consumed')),
+				attempts_409 INTEGER NOT NULL DEFAULT 0,
+				recovery_reason TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				expires_at INTEGER NOT NULL
+			)
+		`);
+		this.db.exec(`
+			CREATE TABLE IF NOT EXISTS tool_continuation_inbox (
+				id TEXT PRIMARY KEY,
+				tool_use_id TEXT NOT NULL,
+				session_id TEXT NOT NULL,
+				execution_id TEXT,
+				workflow_run_id TEXT,
+				status TEXT NOT NULL DEFAULT 'pending'
+					CHECK(status IN ('pending', 'rebound', 'failed', 'expired')),
+				request_json TEXT NOT NULL,
+				recovery_reason TEXT,
+				created_at INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL,
+				expires_at INTEGER NOT NULL
+			)
+		`);
+		this.db.exec(
+			`CREATE INDEX IF NOT EXISTS idx_tool_continuation_recovery_session
+			 ON tool_continuation_recovery(session_id, status, expires_at)`
+		);
+		this.db.exec(
+			`CREATE INDEX IF NOT EXISTS idx_tool_continuation_recovery_execution
+			 ON tool_continuation_recovery(execution_id, status, expires_at)`
+		);
+		this.db.exec(
+			`CREATE INDEX IF NOT EXISTS idx_tool_continuation_inbox_execution
+			 ON tool_continuation_inbox(execution_id, status, expires_at)`
+		);
+		this.db.exec(
+			`CREATE INDEX IF NOT EXISTS idx_tool_continuation_inbox_tool
+			 ON tool_continuation_inbox(tool_use_id, status, expires_at)`
+		);
+	}
+
+	resolveOwnerBySession(sessionId: string): ToolContinuationOwner {
+		const row = this.db
+			.prepare(
+				`SELECT id, workflow_run_id
+				 FROM node_executions
+				 WHERE agent_session_id = ?
+				 ORDER BY
+				   CASE status
+				     WHEN 'in_progress' THEN 0
+				     WHEN 'waiting_rebind' THEN 1
+				     WHEN 'blocked' THEN 2
+				     WHEN 'pending' THEN 3
+				     ELSE 4
+				   END,
+				   updated_at DESC,
+				   created_at DESC
+				 LIMIT 1`
+			)
+			.get(sessionId) as { id: string; workflow_run_id: string } | undefined;
+		return {
+			executionId: row?.id ?? null,
+			workflowRunId: row?.workflow_run_id ?? null,
+		};
+	}
+
+	recordToolUse(params: {
+		toolUseId: string;
+		sessionId: string;
+		ttlMs: number;
+		owner?: ToolContinuationOwner;
+	}): ToolContinuationRecord {
+		const now = Date.now();
+		const owner = params.owner ?? this.resolveOwnerBySession(params.sessionId);
+		const expiresAt = now + params.ttlMs;
+		this.db
+			.prepare(
+				`INSERT INTO tool_continuation_recovery
+				   (tool_use_id, session_id, execution_id, workflow_run_id, status,
+				    attempts_409, recovery_reason, created_at, updated_at, expires_at)
+				 VALUES (?, ?, ?, ?, 'active', 0, NULL, ?, ?, ?)
+				 ON CONFLICT(tool_use_id) DO UPDATE SET
+				   session_id = excluded.session_id,
+				   execution_id = excluded.execution_id,
+				   workflow_run_id = excluded.workflow_run_id,
+				   status = 'active',
+				   attempts_409 = 0,
+				   recovery_reason = NULL,
+				   updated_at = excluded.updated_at,
+				   expires_at = excluded.expires_at`
+			)
+			.run(
+				params.toolUseId,
+				params.sessionId,
+				owner.executionId,
+				owner.workflowRunId,
+				now,
+				now,
+				expiresAt
+			);
+		return this.getToolUse(params.toolUseId)!;
+	}
+
+	getToolUse(toolUseId: string): ToolContinuationRecord | null {
+		const row = this.db
+			.prepare(`SELECT * FROM tool_continuation_recovery WHERE tool_use_id = ?`)
+			.get(toolUseId) as Record<string, unknown> | undefined;
+		return row ? this.rowToToolContinuation(row) : null;
+	}
+
+	markConsumed(toolUseId: string): void {
+		this.updateToolUseStatus(toolUseId, 'consumed', 'tool_result delivered to live bridge session');
+	}
+
+	markWaitingRebind(toolUseId: string, reason: string): ToolContinuationRecord | null {
+		const updated = this.updateToolUseStatus(toolUseId, 'waiting_rebind', reason);
+		if (updated?.executionId) {
+			this.markExecutionWaitingRebind(updated.executionId, reason);
+		}
+		return updated;
+	}
+
+	queueContinuation(params: {
+		toolUseId: string;
+		sessionId: string;
+		requestBody: unknown;
+		reason: string;
+		ttlMs: number;
+	}): { inbox: ContinuationInboxRecord; mapping: ToolContinuationRecord | null } {
+		const now = Date.now();
+		let mapping = this.getToolUse(params.toolUseId);
+		if (mapping) {
+			mapping = this.markWaitingRebind(params.toolUseId, params.reason);
+		}
+		const owner =
+			mapping ??
+			({
+				executionId: null,
+				workflowRunId: null,
+				expiresAt: now + params.ttlMs,
+			} as const);
+		const id = generateUUID();
+		this.db
+			.prepare(
+				`INSERT INTO tool_continuation_inbox
+				   (id, tool_use_id, session_id, execution_id, workflow_run_id, status,
+				    request_json, recovery_reason, created_at, updated_at, expires_at)
+				 VALUES (?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?)`
+			)
+			.run(
+				id,
+				params.toolUseId,
+				params.sessionId,
+				owner.executionId,
+				owner.workflowRunId,
+				JSON.stringify(params.requestBody),
+				params.reason,
+				now,
+				now,
+				owner.expiresAt
+			);
+		return { inbox: this.getInbox(id)!, mapping };
+	}
+
+	increment409(toolUseId: string, reason: string): ToolContinuationRecord | null {
+		const now = Date.now();
+		this.db
+			.prepare(
+				`UPDATE tool_continuation_recovery
+				 SET attempts_409 = attempts_409 + 1,
+				     recovery_reason = ?,
+				     updated_at = ?
+				 WHERE tool_use_id = ?`
+			)
+			.run(reason, now, toolUseId);
+		return this.getToolUse(toolUseId);
+	}
+
+	failToolUse(toolUseId: string, reason: string): ToolContinuationRecord | null {
+		const updated = this.updateToolUseStatus(toolUseId, 'failed', reason);
+		if (updated?.executionId) {
+			this.markExecutionBlocked(updated.executionId, reason);
+		}
+		this.db
+			.prepare(
+				`UPDATE tool_continuation_inbox
+				 SET status = 'failed', recovery_reason = ?, updated_at = ?
+				 WHERE tool_use_id = ? AND status = 'pending'`
+			)
+			.run(reason, Date.now(), toolUseId);
+		return updated;
+	}
+
+	listPendingInboxForExecution(executionId: string): ContinuationInboxRecord[] {
+		const now = Date.now();
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM tool_continuation_inbox
+				 WHERE execution_id = ? AND status = 'pending' AND expires_at >= ?
+				 ORDER BY created_at ASC, id ASC`
+			)
+			.all(executionId, now) as Record<string, unknown>[];
+		return rows.map((row) => this.rowToInbox(row));
+	}
+
+	hasActiveToolUseForExecution(executionId: string, graceMs = 0): boolean {
+		const now = Date.now();
+		const row = this.db
+			.prepare(
+				`SELECT 1
+				 FROM tool_continuation_recovery
+				 WHERE execution_id = ?
+				   AND status IN ('active', 'waiting_rebind')
+				   AND expires_at + ? >= ?
+				 LIMIT 1`
+			)
+			.get(executionId, graceMs, now) as Record<string, unknown> | undefined;
+		return !!row;
+	}
+
+	markInboxReboundForExecution(executionId: string, reason: string): number {
+		const result = this.db
+			.prepare(
+				`UPDATE tool_continuation_inbox
+				 SET status = 'rebound', recovery_reason = ?, updated_at = ?
+				 WHERE execution_id = ? AND status = 'pending'`
+			)
+			.run(reason, Date.now(), executionId);
+		this.db
+			.prepare(
+				`UPDATE tool_continuation_recovery
+				 SET status = 'rebound', recovery_reason = ?, updated_at = ?
+				 WHERE execution_id = ? AND status = 'waiting_rebind'`
+			)
+			.run(reason, Date.now(), executionId);
+		return result.changes;
+	}
+
+	markExpired(now = Date.now()): number {
+		const result = this.db
+			.prepare(
+				`UPDATE tool_continuation_recovery
+				 SET status = 'expired', recovery_reason = COALESCE(recovery_reason, 'TTL expired'),
+				     updated_at = ?
+				 WHERE status IN ('active', 'waiting_rebind') AND expires_at < ?`
+			)
+			.run(now, now);
+		this.db
+			.prepare(
+				`UPDATE tool_continuation_inbox
+				 SET status = 'expired', recovery_reason = COALESCE(recovery_reason, 'TTL expired'),
+				     updated_at = ?
+				 WHERE status = 'pending' AND expires_at < ?`
+			)
+			.run(now, now);
+		return result.changes;
+	}
+
+	markExecutionWaitingRebind(executionId: string, reason: string): void {
+		const now = Date.now();
+		const row = this.db.prepare(`SELECT data FROM node_executions WHERE id = ?`).get(executionId) as
+			| { data: string | null }
+			| undefined;
+		const data = parseExecutionData(row?.data);
+		data.orphanedToolContinuation = {
+			...(isRecord(data.orphanedToolContinuation) ? data.orphanedToolContinuation : {}),
+			state: 'waiting_rebind',
+			reason,
+			updatedAt: now,
+		};
+		this.db
+			.prepare(
+				`UPDATE node_executions
+				 SET status = 'waiting_rebind',
+				     result = ?,
+				     data = ?,
+				     completed_at = NULL,
+				     updated_at = ?
+				 WHERE id = ? AND status IN ('in_progress', 'pending', 'waiting_rebind')`
+			)
+			.run(reason, JSON.stringify(data), now, executionId);
+	}
+
+	private markExecutionBlocked(executionId: string, reason: string): void {
+		const now = Date.now();
+		const row = this.db.prepare(`SELECT data FROM node_executions WHERE id = ?`).get(executionId) as
+			| { data: string | null }
+			| undefined;
+		const data = parseExecutionData(row?.data);
+		data.orphanedToolContinuation = {
+			...(isRecord(data.orphanedToolContinuation) ? data.orphanedToolContinuation : {}),
+			state: 'failed',
+			reason,
+			updatedAt: now,
+		};
+		this.db
+			.prepare(
+				`UPDATE node_executions
+				 SET status = 'blocked',
+				     result = ?,
+				     data = ?,
+				     agent_session_id = NULL,
+				     completed_at = ?,
+				     updated_at = ?
+				 WHERE id = ? AND status IN ('in_progress', 'pending', 'waiting_rebind', 'blocked')`
+			)
+			.run(reason, JSON.stringify(data), now, now, executionId);
+	}
+
+	private updateToolUseStatus(
+		toolUseId: string,
+		status: ToolContinuationStatus,
+		reason: string
+	): ToolContinuationRecord | null {
+		this.db
+			.prepare(
+				`UPDATE tool_continuation_recovery
+				 SET status = ?, recovery_reason = ?, updated_at = ?
+				 WHERE tool_use_id = ?`
+			)
+			.run(status, reason, Date.now(), toolUseId);
+		return this.getToolUse(toolUseId);
+	}
+
+	private getInbox(id: string): ContinuationInboxRecord | null {
+		const row = this.db.prepare(`SELECT * FROM tool_continuation_inbox WHERE id = ?`).get(id) as
+			| Record<string, unknown>
+			| undefined;
+		return row ? this.rowToInbox(row) : null;
+	}
+
+	private rowToToolContinuation(row: Record<string, unknown>): ToolContinuationRecord {
+		return {
+			toolUseId: row.tool_use_id as string,
+			sessionId: row.session_id as string,
+			executionId: (row.execution_id as string | null) ?? null,
+			workflowRunId: (row.workflow_run_id as string | null) ?? null,
+			status: row.status as ToolContinuationStatus,
+			attempts409: row.attempts_409 as number,
+			recoveryReason: (row.recovery_reason as string | null) ?? null,
+			createdAt: row.created_at as number,
+			updatedAt: row.updated_at as number,
+			expiresAt: row.expires_at as number,
+		};
+	}
+
+	private rowToInbox(row: Record<string, unknown>): ContinuationInboxRecord {
+		return {
+			id: row.id as string,
+			toolUseId: row.tool_use_id as string,
+			sessionId: row.session_id as string,
+			executionId: (row.execution_id as string | null) ?? null,
+			workflowRunId: (row.workflow_run_id as string | null) ?? null,
+			status: row.status as ContinuationInboxStatus,
+			requestJson: row.request_json as string,
+			recoveryReason: (row.recovery_reason as string | null) ?? null,
+			createdAt: row.created_at as number,
+			updatedAt: row.updated_at as number,
+			expiresAt: row.expires_at as number,
+		};
+	}
+}
+
+function parseExecutionData(raw: string | null | undefined): Record<string, unknown> {
+	if (!raw) return {};
+	try {
+		const parsed = JSON.parse(raw) as unknown;
+		return isRecord(parsed) ? parsed : {};
+	} catch {
+		return {};
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return !!value && typeof value === 'object' && !Array.isArray(value);
+}

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -63,6 +63,8 @@ export { runMigration99 } from './migrations';
 export { runMigration100 } from './migrations';
 // knip-ignore-next-line
 export { runMigration101 } from './migrations';
+// knip-ignore-next-line
+export { runMigration109 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults
@@ -501,7 +503,42 @@ export function createTables(db: BunDatabase): void {
         last_used_at INTEGER NOT NULL,
         use_count INTEGER NOT NULL DEFAULT 1
       )
-    `);
+	    `);
+
+	// Durable Codex tool continuation recovery state. The full space schema is
+	// migration-owned, so these tables avoid foreign keys here and are also
+	// created by migration 109 for existing databases.
+	db.exec(`
+	      CREATE TABLE IF NOT EXISTS tool_continuation_recovery (
+	        tool_use_id TEXT PRIMARY KEY,
+	        session_id TEXT NOT NULL,
+	        execution_id TEXT,
+	        workflow_run_id TEXT,
+	        status TEXT NOT NULL DEFAULT 'active'
+	          CHECK(status IN ('active', 'waiting_rebind', 'rebound', 'failed', 'expired', 'consumed')),
+	        attempts_409 INTEGER NOT NULL DEFAULT 0,
+	        recovery_reason TEXT,
+	        created_at INTEGER NOT NULL,
+	        updated_at INTEGER NOT NULL,
+	        expires_at INTEGER NOT NULL
+	      )
+	    `);
+	db.exec(`
+	      CREATE TABLE IF NOT EXISTS tool_continuation_inbox (
+	        id TEXT PRIMARY KEY,
+	        tool_use_id TEXT NOT NULL,
+	        session_id TEXT NOT NULL,
+	        execution_id TEXT,
+	        workflow_run_id TEXT,
+	        status TEXT NOT NULL DEFAULT 'pending'
+	          CHECK(status IN ('pending', 'rebound', 'failed', 'expired')),
+	        request_json TEXT NOT NULL,
+	        recovery_reason TEXT,
+	        created_at INTEGER NOT NULL,
+	        updated_at INTEGER NOT NULL,
+	        expires_at INTEGER NOT NULL
+	      )
+	    `);
 
 	// Create indexes
 	createIndexes(db);
@@ -564,5 +601,21 @@ function createIndexes(db: BunDatabase): void {
 	// Workspace history index — supports ORDER BY last_used_at DESC in list()
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_workspace_history_last_used_at ON workspace_history(last_used_at DESC)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_tool_continuation_recovery_session
+		 ON tool_continuation_recovery(session_id, status, expires_at)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_tool_continuation_recovery_execution
+		 ON tool_continuation_recovery(execution_id, status, expires_at)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_tool_continuation_inbox_execution
+		 ON tool_continuation_inbox(execution_id, status, expires_at)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_tool_continuation_inbox_tool
+		 ON tool_continuation_inbox(tool_use_id, status, expires_at)`
 	);
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -523,6 +523,11 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	//   app_mcp_servers, skills, and enablement override tables. Delete those
 	//   legacy rows so settings surfaces no longer display them.
 	runMigration108(db);
+
+	// Migration 109: Durable Codex tool continuation recovery. Adds
+	//   `waiting_rebind` to node_executions and creates persistent tool_use →
+	//   execution mapping plus a per-execution continuation inbox.
+	runMigration109(db);
 }
 
 /**
@@ -7561,4 +7566,123 @@ export function runMigration108(db: BunDatabase): void {
 			}
 		}
 	}
+}
+
+/**
+ * Migration 109: Durable Codex tool continuation recovery.
+ *
+ * Adds a recoverable `waiting_rebind` node execution state and creates durable
+ * bridge tables used to map `tool_use_id` values back to workflow executions
+ * after session timeout/restart races.
+ */
+export function runMigration109(db: BunDatabase): void {
+	if (
+		tableExists(db, 'node_executions') &&
+		!statusCheckContains(db, 'node_executions', 'waiting_rebind')
+	) {
+		db.exec('PRAGMA foreign_keys = OFF');
+		db.exec('BEGIN');
+		try {
+			db.exec(`
+				CREATE TABLE node_executions_m109_new (
+					id TEXT PRIMARY KEY,
+					workflow_run_id TEXT NOT NULL,
+					workflow_node_id TEXT NOT NULL,
+					agent_name TEXT NOT NULL,
+					agent_id TEXT,
+					agent_session_id TEXT,
+					status TEXT NOT NULL DEFAULT 'pending'
+						CHECK(status IN ('pending', 'in_progress', 'idle', 'done', 'waiting_rebind', 'blocked', 'cancelled')),
+					result TEXT,
+					data TEXT,
+					created_at INTEGER NOT NULL,
+					started_at INTEGER,
+					completed_at INTEGER,
+					updated_at INTEGER NOT NULL,
+					FOREIGN KEY (workflow_run_id) REFERENCES space_workflow_runs(id) ON DELETE CASCADE,
+					FOREIGN KEY (agent_id) REFERENCES space_agents(id) ON DELETE SET NULL
+				)
+			`);
+
+			db.exec(`
+				INSERT INTO node_executions_m109_new
+				  (id, workflow_run_id, workflow_node_id, agent_name, agent_id,
+				   agent_session_id, status, result, data, created_at, started_at,
+				   completed_at, updated_at)
+				SELECT
+				  id, workflow_run_id, workflow_node_id, agent_name, agent_id,
+				  agent_session_id, status, result,
+				  ${tableHasColumn(db, 'node_executions', 'data') ? 'data' : 'NULL'},
+				  created_at, started_at, completed_at, updated_at
+				FROM node_executions
+			`);
+
+			db.exec(`DROP TABLE node_executions`);
+			db.exec(`ALTER TABLE node_executions_m109_new RENAME TO node_executions`);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_node_executions_run ON node_executions(workflow_run_id)`
+			);
+			db.exec(
+				`CREATE INDEX IF NOT EXISTS idx_node_executions_node ON node_executions(workflow_run_id, workflow_node_id)`
+			);
+			db.exec(
+				`CREATE UNIQUE INDEX IF NOT EXISTS idx_node_executions_unique_slot
+				 ON node_executions(workflow_run_id, workflow_node_id, agent_name)`
+			);
+			db.exec('COMMIT');
+		} catch (err) {
+			db.exec('ROLLBACK');
+			throw err;
+		} finally {
+			db.exec('PRAGMA foreign_keys = ON');
+		}
+	}
+
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS tool_continuation_recovery (
+			tool_use_id TEXT PRIMARY KEY,
+			session_id TEXT NOT NULL,
+			execution_id TEXT,
+			workflow_run_id TEXT,
+			status TEXT NOT NULL DEFAULT 'active'
+				CHECK(status IN ('active', 'waiting_rebind', 'rebound', 'failed', 'expired', 'consumed')),
+			attempts_409 INTEGER NOT NULL DEFAULT 0,
+			recovery_reason TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			expires_at INTEGER NOT NULL
+		)
+	`);
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS tool_continuation_inbox (
+			id TEXT PRIMARY KEY,
+			tool_use_id TEXT NOT NULL,
+			session_id TEXT NOT NULL,
+			execution_id TEXT,
+			workflow_run_id TEXT,
+			status TEXT NOT NULL DEFAULT 'pending'
+				CHECK(status IN ('pending', 'rebound', 'failed', 'expired')),
+			request_json TEXT NOT NULL,
+			recovery_reason TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			expires_at INTEGER NOT NULL
+		)
+	`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_tool_continuation_recovery_session
+		 ON tool_continuation_recovery(session_id, status, expires_at)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_tool_continuation_recovery_execution
+		 ON tool_continuation_recovery(execution_id, status, expires_at)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_tool_continuation_inbox_execution
+		 ON tool_continuation_inbox(execution_id, status, expires_at)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_tool_continuation_inbox_tool
+		 ON tool_continuation_inbox(tool_use_id, status, expires_at)`
+	);
 }

--- a/packages/daemon/tests/unit/1-core/lib/node-execution-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/node-execution-manager.test.ts
@@ -3,7 +3,7 @@
  *
  * Covers:
  *   Pure-function layer:
- *   1.  VALID_NODE_EXECUTION_TRANSITIONS — has all 5 statuses as keys
+ *   1.  VALID_NODE_EXECUTION_TRANSITIONS — has all 6 statuses as keys
  *   2.  isValidNodeExecutionTransition: pending → in_progress — valid
  *   3.  isValidNodeExecutionTransition: pending → cancelled — valid
  *   4.  isValidNodeExecutionTransition: in_progress → done — valid
@@ -115,14 +115,15 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('VALID_NODE_EXECUTION_TRANSITIONS', () => {
-	test('1. has all 5 statuses as keys', () => {
+	test('1. has all 6 statuses as keys', () => {
 		const keys = Object.keys(VALID_NODE_EXECUTION_TRANSITIONS);
 		expect(keys).toContain('pending');
 		expect(keys).toContain('in_progress');
 		expect(keys).toContain('idle');
+		expect(keys).toContain('waiting_rebind');
 		expect(keys).toContain('blocked');
 		expect(keys).toContain('cancelled');
-		expect(keys).toHaveLength(5);
+		expect(keys).toHaveLength(6);
 	});
 });
 
@@ -163,6 +164,14 @@ describe('isValidNodeExecutionTransition', () => {
 		expect(isValidNodeExecutionTransition('cancelled', 'in_progress')).toBe(true);
 	});
 
+	test('10b. waiting_rebind → pending is valid (rebind retry)', () => {
+		expect(isValidNodeExecutionTransition('waiting_rebind', 'pending')).toBe(true);
+	});
+
+	test('10c. waiting_rebind → blocked is valid (fail-forward)', () => {
+		expect(isValidNodeExecutionTransition('waiting_rebind', 'blocked')).toBe(true);
+	});
+
 	test('11. pending → done is invalid', () => {
 		expect(isValidNodeExecutionTransition('pending', 'done')).toBe(false);
 	});
@@ -191,6 +200,10 @@ describe('isNodeExecutionTerminal', () => {
 
 	test('17. blocked is not terminal', () => {
 		expect(isNodeExecutionTerminal('blocked')).toBe(false);
+	});
+
+	test('17b. waiting_rebind is not terminal', () => {
+		expect(isNodeExecutionTerminal('waiting_rebind')).toBe(false);
 	});
 
 	test('18. TERMINAL_NODE_EXECUTION_STATUSES size=2', () => {

--- a/packages/daemon/tests/unit/4-space-storage/storage/tool-continuation-recovery-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/tool-continuation-recovery-repository.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { Database } from 'bun:sqlite';
+import { SpaceRepository } from '../../../../src/storage/repositories/space-repository';
+import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository';
+import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository';
+import { ToolContinuationRecoveryRepository } from '../../../../src/storage/repositories/tool-continuation-recovery-repository';
+import { createSpaceTables } from '../../helpers/space-test-db';
+
+describe('ToolContinuationRecoveryRepository', () => {
+	let db: Database;
+	let tempDir: string | null = null;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+	});
+
+	afterEach(() => {
+		db.close();
+		if (tempDir) {
+			rmSync(tempDir, { recursive: true, force: true });
+			tempDir = null;
+		}
+	});
+
+	function seedExecution(sessionId = 'agent-session-1') {
+		const space = new SpaceRepository(db as any).createSpace({
+			workspacePath: `/tmp/ws-${Math.random()}`,
+			slug: `space-${Math.random().toString(36).slice(2)}`,
+			name: 'Space',
+		});
+		const now = Date.now();
+		const workflowId = `workflow-${Math.random().toString(36).slice(2)}`;
+		db.prepare(
+			`INSERT INTO space_workflows (id, space_id, name, created_at, updated_at)
+			 VALUES (?, ?, 'Workflow', ?, ?)`
+		).run(workflowId, space.id, now, now);
+		const run = new SpaceWorkflowRunRepository(db as any).createRun({
+			spaceId: space.id,
+			workflowId,
+			title: 'Run',
+		});
+		const repo = new NodeExecutionRepository(db as any);
+		const execution = repo.create({
+			workflowRunId: run.id,
+			workflowNodeId: 'node-1',
+			agentName: 'coder',
+			status: 'in_progress',
+			agentSessionId: sessionId,
+		});
+		return { execution, run };
+	}
+
+	it('persists tool_use ownership and queued continuation across database reopen', () => {
+		tempDir = mkdtempSync(join(tmpdir(), 'neokai-tool-continuation-'));
+		const dbPath = join(tempDir, 'test.sqlite');
+		db.close();
+
+		db = new Database(dbPath);
+		createSpaceTables(db);
+		const { execution, run } = seedExecution('session-a');
+		let repo = new ToolContinuationRecoveryRepository(db as any);
+		repo.ensureSchema();
+		repo.recordToolUse({ toolUseId: 'tool-1', sessionId: 'session-a', ttlMs: 60_000 });
+		repo.queueContinuation({
+			toolUseId: 'tool-1',
+			sessionId: 'session-a',
+			requestBody: { messages: [{ role: 'user', content: [] }] },
+			reason: 'late tool_result',
+			ttlMs: 60_000,
+		});
+		db.close();
+
+		db = new Database(dbPath);
+		repo = new ToolContinuationRecoveryRepository(db as any);
+		const mapping = repo.getToolUse('tool-1');
+		const inbox = repo.listPendingInboxForExecution(execution.id);
+
+		expect(mapping?.executionId).toBe(execution.id);
+		expect(mapping?.workflowRunId).toBe(run.id);
+		expect(mapping?.status).toBe('waiting_rebind');
+		expect(inbox).toHaveLength(1);
+		expect(inbox[0].toolUseId).toBe('tool-1');
+	});
+
+	it('marks execution blocked when the 409 circuit breaker fails forward', () => {
+		const { execution } = seedExecution('session-b');
+		const repo = new ToolContinuationRecoveryRepository(db as any);
+		repo.ensureSchema();
+		repo.recordToolUse({ toolUseId: 'tool-2', sessionId: 'session-b', ttlMs: 60_000 });
+
+		for (let i = 0; i < 3; i++) {
+			repo.increment409('tool-2', 'orphaned tool_result queued');
+		}
+		const failed = repo.failToolUse('tool-2', 'circuit breaker tripped');
+		const updated = new NodeExecutionRepository(db as any).getById(execution.id)!;
+
+		expect(failed?.status).toBe('failed');
+		expect(failed?.attempts409).toBe(3);
+		expect(updated.status).toBe('blocked');
+		expect(updated.result).toBe('circuit breaker tripped');
+	});
+});

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -262,6 +262,70 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 			expect(taskRepo.getTask(task.id)?.status).toBe('in_progress');
 			expect(notifications.some((event) => event.kind === 'task_retry')).toBe(true);
 		});
+
+		test('empty inbox with no active tool_use fails waiting_rebind execution forward to blocked', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+			db.prepare(`UPDATE spaces SET paused = 1 WHERE id = ?`).run(SPACE_ID);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Expired Orphan Recovery Run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Expired Orphan Recovery Run',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			const execution = seedExec(run.id, STEP_A, 'Step A', 'waiting_rebind', {
+				agentSessionId: 'dead-session',
+				result: 'waiting for orphaned tool_result recovery',
+			});
+			const recoveryRepo = new ToolContinuationRecoveryRepository(db);
+			recoveryRepo.ensureSchema();
+
+			const rt = makeRuntime({
+				taskAgentManager: {
+					rehydrate: async () => {},
+					isSessionAlive: () => false,
+					getAgentSessionById: () => null,
+					isExecutionSpawning: () => false,
+				} as any,
+			});
+			await rt.executeTick();
+
+			const reason = 'orphaned tool_result recovery expired before a continuation arrived';
+			const updated = nodeExecutionRepo.getById(execution.id)!;
+			const updatedRun = workflowRunRepo.getRun(run.id)!;
+			const updatedTask = taskRepo.getTask(task.id)!;
+			const runBlockedEvents = notifications.filter(
+				(event) => event.kind === 'workflow_run_blocked'
+			);
+			expect(updated.status).toBe('blocked');
+			expect(updated.result).toBe(reason);
+			expect(updated.data?.orphanedToolContinuation).toMatchObject({
+				state: 'failed',
+				retryCount: 0,
+				reason,
+			});
+			expect(updatedRun.status).toBe('blocked');
+			expect(updatedTask.status).toBe('blocked');
+			expect(updatedTask.blockReason).toBe('execution_failed');
+			expect(updatedTask.result).toBe(reason);
+			expect(recoveryRepo.listPendingInboxForExecution(execution.id)).toHaveLength(0);
+			expect(runBlockedEvents).toHaveLength(1);
+			expect(runBlockedEvents[0]).toMatchObject({
+				kind: 'workflow_run_blocked',
+				spaceId: SPACE_ID,
+				runId: run.id,
+				reason,
+			});
+		});
 	});
 
 	describe('runs with all node executions terminal and no completion signal', () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -39,6 +39,7 @@ import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
 import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
 import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
+import { ToolContinuationRecoveryRepository } from '../../../../src/storage/repositories/tool-continuation-recovery-repository.ts';
 import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
 import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
@@ -197,6 +198,71 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 	// -------------------------------------------------------------------------
 	// 1. Stalled with no completion signal → blocked
 	// -------------------------------------------------------------------------
+
+	describe('orphaned tool_result waiting_rebind recovery', () => {
+		test('queued continuation resets waiting_rebind execution to pending for one deterministic retry', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+			db.prepare(`UPDATE spaces SET paused = 1 WHERE id = ?`).run(SPACE_ID);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Orphan Recovery Run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Orphan Recovery Run',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			const execution = seedExec(run.id, STEP_A, 'Step A', 'waiting_rebind', {
+				agentSessionId: 'dead-session',
+				result: 'waiting for orphaned tool_result recovery',
+			});
+			const recoveryRepo = new ToolContinuationRecoveryRepository(db);
+			recoveryRepo.ensureSchema();
+			recoveryRepo.recordToolUse({
+				toolUseId: 'tool-rebind-1',
+				sessionId: 'dead-session',
+				ttlMs: 60_000,
+				owner: { executionId: execution.id, workflowRunId: run.id },
+			});
+			recoveryRepo.queueContinuation({
+				toolUseId: 'tool-rebind-1',
+				sessionId: 'dead-session',
+				requestBody: { messages: [{ role: 'user', content: [] }] },
+				reason: 'late continuation arrived after session timeout',
+				ttlMs: 60_000,
+			});
+
+			const rt = makeRuntime({
+				taskAgentManager: {
+					rehydrate: async () => {},
+					isSessionAlive: () => false,
+					getAgentSessionById: () => null,
+					isExecutionSpawning: () => false,
+				} as any,
+			});
+			await rt.executeTick();
+
+			const updated = nodeExecutionRepo.getById(execution.id)!;
+			const inbox = recoveryRepo.listPendingInboxForExecution(execution.id);
+			expect(updated.status).toBe('pending');
+			expect(updated.agentSessionId).toBeNull();
+			expect(updated.data?.orphanedToolContinuation).toMatchObject({
+				state: 'rebound',
+				retryCount: 1,
+				queuedContinuations: 1,
+			});
+			expect(inbox).toHaveLength(0);
+			expect(taskRepo.getTask(task.id)?.status).toBe('in_progress');
+			expect(notifications.some((event) => event.kind === 'task_retry')).toBe(true);
+		});
+	});
 
 	describe('runs with all node executions terminal and no completion signal', () => {
 		test('single-node run with idle execution → run blocked, task blocked, notifications emitted', async () => {

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -172,9 +172,9 @@ export function createSpaceTables(db: BunDatabase): void {
 			workflow_node_id TEXT NOT NULL,
 			agent_name TEXT NOT NULL,
 			agent_id TEXT,
-			agent_session_id TEXT,
-			status TEXT NOT NULL DEFAULT 'pending'
-				CHECK(status IN ('pending', 'in_progress', 'idle', 'done', 'blocked', 'cancelled')),
+				agent_session_id TEXT,
+				status TEXT NOT NULL DEFAULT 'pending'
+					CHECK(status IN ('pending', 'in_progress', 'idle', 'done', 'waiting_rebind', 'blocked', 'cancelled')),
 			result TEXT,
 			data TEXT,
 			created_at INTEGER NOT NULL,

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -506,10 +506,17 @@ export interface UpdateSpaceTaskParams {
  * - `pending`     — slot has been created but the agent has not started yet
  * - `in_progress` — agent session is actively running
  * - `idle`        — agent session finished naturally (detected via session idle event)
+ * - `waiting_rebind` — execution is paused while orphaned tool_result recovery rebinds/retries
  * - `blocked`     — execution requires human intervention or a gate has not passed
  * - `cancelled`   — execution was cancelled (workflow run cancelled or error path)
  */
-export type NodeExecutionStatus = 'pending' | 'in_progress' | 'idle' | 'blocked' | 'cancelled';
+export type NodeExecutionStatus =
+	| 'pending'
+	| 'in_progress'
+	| 'idle'
+	| 'waiting_rebind'
+	| 'blocked'
+	| 'cancelled';
 
 /**
  * Records the execution of a single agent slot within a workflow run's node.


### PR DESCRIPTION
Persists Codex tool continuation ownership and late tool_result inbox state so orphaned continuations can move through waiting_rebind, retry once, or fail-forward deterministically instead of leaving runs blocked.

Validated with typecheck, lint, format, focused storage/runtime recovery tests, and the Codex bridge server test suite.