### PR TITLE
Remove active Room runtime wiring

### DIFF
--- a/packages/daemon/src/lib/neo/neo-agent-manager.ts
+++ b/packages/daemon/src/lib/neo/neo-agent-manager.ts
@@ -404,7 +404,9 @@ export class NeoAgentManager {
 		if (!this.session) return;
 
 		const securityMode = this.getSecurityMode();
-		const systemPromptText = buildNeoSystemPrompt(securityMode);
+		const systemPromptText = buildNeoSystemPrompt(securityMode, {
+			roomRuntimeToolsAvailable: Boolean(this.actionToolsConfig?.runtimeService),
+		});
 		this.session.setRuntimeSystemPrompt(systemPromptText);
 
 		const model = this.getModel();

--- a/packages/daemon/src/lib/neo/neo-system-prompt.ts
+++ b/packages/daemon/src/lib/neo/neo-system-prompt.ts
@@ -14,8 +14,21 @@ export type { NeoSecurityMode };
  *
  * @param securityMode - Active security tier that shapes confirmation behavior.
  */
-export function buildNeoSystemPrompt(securityMode: NeoSecurityMode = 'balanced'): string {
-	const securitySection = buildSecuritySection(securityMode);
+export interface NeoSystemPromptOptions {
+	roomRuntimeToolsAvailable?: boolean;
+}
+
+export function buildNeoSystemPrompt(
+	securityMode: NeoSecurityMode = 'balanced',
+	options: NeoSystemPromptOptions = {}
+): string {
+	const roomRuntimeToolsAvailable = options.roomRuntimeToolsAvailable ?? true;
+	const securitySection = buildSecuritySection(securityMode, {
+		roomRuntimeToolsAvailable,
+	});
+	const roomRuntimeMediumRiskTools = roomRuntimeToolsAvailable
+		? '- `send_message_to_room`, `stop_session`\n- `approve_task`, `reject_task`'
+		: '- `send_message_to_room`';
 
 	return `# Neo — Chief-of-Staff for NeoKai
 
@@ -52,8 +65,7 @@ You have access to tools organized into the following categories. Use the most a
 
 **Medium risk (confirm in balanced mode):**
 - \`delete_room\` (without active tasks)
-- \`send_message_to_room\`, \`stop_session\`
-- \`approve_task\`, \`reject_task\`
+${roomRuntimeMediumRiskTools}
 
 **High risk (require explicit phrasing):**
 - \`delete_room\` when the room has active tasks or sessions
@@ -118,7 +130,10 @@ If you encounter an error during a tool call, report it clearly to the user. Do 
 /**
  * Build the security-tier section of the system prompt based on the active mode.
  */
-function buildSecuritySection(mode: NeoSecurityMode): string {
+function buildSecuritySection(
+	mode: NeoSecurityMode,
+	options: Required<NeoSystemPromptOptions>
+): string {
 	if (mode === 'conservative') {
 		return `## Security Mode: Conservative
 
@@ -136,6 +151,10 @@ Use this mode responsibly — irreversible actions (e.g., deleting a room with a
 	}
 
 	// balanced (default)
+	const runtimeConfirmActions = options.roomRuntimeToolsAvailable
+		? '- Cancel a running session\n'
+		: '';
+
 	return `## Security Mode: Balanced (default)
 
 Apply a three-tier confirmation model based on action risk:
@@ -147,9 +166,9 @@ Apply a three-tier confirmation model based on action risk:
 
 **Confirm before executing (show confirmation card):**
 - Delete a space or room (when no active tasks are present)
-- Cancel a running session or workflow
+${runtimeConfirmActions}- Cancel a running workflow
 - Send a message to a room agent
-- Approve or reject task gates
+- Approve or reject workflow gates
 - Add or remove MCP servers
 
 **Require explicit user phrasing before proceeding:**

--- a/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-action-tools.ts
@@ -2266,36 +2266,50 @@ export function createNeoActionMcpServer(config: NeoActionToolsConfig) {
 				)
 		),
 
-		tool(
-			'approve_task',
-			'Approve a task PR that is currently in review status. Medium risk — requires confirmation in balanced mode.',
-			{
-				room_id: z.string().describe('ID of the room containing the task'),
-				task_id: z.string().describe('ID of the task to approve'),
-			},
-			// Non-undoable: task review decision may have triggered agent actions.
-			(args) =>
-				logged('approve_task', args as Record<string, unknown>, () => handlers.approve_task(args), {
-					targetType: 'task',
-					getTargetId: (a) => (a.task_id as string) ?? null,
-				})
-		),
+		...(config.runtimeService
+			? [
+					tool(
+						'approve_task',
+						'Approve a task PR that is currently in review status. Medium risk — requires confirmation in balanced mode.',
+						{
+							room_id: z.string().describe('ID of the room containing the task'),
+							task_id: z.string().describe('ID of the task to approve'),
+						},
+						// Non-undoable: task review decision may have triggered agent actions.
+						(args) =>
+							logged(
+								'approve_task',
+								args as Record<string, unknown>,
+								() => handlers.approve_task(args),
+								{
+									targetType: 'task',
+									getTargetId: (a) => (a.task_id as string) ?? null,
+								}
+							)
+					),
 
-		tool(
-			'reject_task',
-			'Reject a task PR that is currently in review status, providing feedback for revision. Medium risk — requires confirmation in balanced mode.',
-			{
-				room_id: z.string().describe('ID of the room containing the task'),
-				task_id: z.string().describe('ID of the task to reject'),
-				feedback: z.string().describe('Feedback explaining why the task was rejected'),
-			},
-			// Non-undoable: task review decision may have triggered agent actions.
-			(args) =>
-				logged('reject_task', args as Record<string, unknown>, () => handlers.reject_task(args), {
-					targetType: 'task',
-					getTargetId: (a) => (a.task_id as string) ?? null,
-				})
-		),
+					tool(
+						'reject_task',
+						'Reject a task PR that is currently in review status, providing feedback for revision. Medium risk — requires confirmation in balanced mode.',
+						{
+							room_id: z.string().describe('ID of the room containing the task'),
+							task_id: z.string().describe('ID of the task to reject'),
+							feedback: z.string().describe('Feedback explaining why the task was rejected'),
+						},
+						// Non-undoable: task review decision may have triggered agent actions.
+						(args) =>
+							logged(
+								'reject_task',
+								args as Record<string, unknown>,
+								() => handlers.reject_task(args),
+								{
+									targetType: 'task',
+									getTargetId: (a) => (a.task_id as string) ?? null,
+								}
+							)
+					),
+				]
+			: []),
 
 		// ── Space ─────────────────────────────────────────────────────────────
 		tool(
@@ -2736,20 +2750,29 @@ export function createNeoActionMcpServer(config: NeoActionToolsConfig) {
 				)
 		),
 
-		tool(
-			'stop_session',
-			'Interrupt the running agent session for a task. Only works for in_progress or review tasks. Medium risk — requires confirmation in balanced mode.',
-			{
-				room_id: z.string().describe('ID of the room containing the task'),
-				task_id: z.string().describe('ID of the task whose session to stop'),
-			},
-			// Non-undoable: session interruption may have cascading side effects.
-			(args) =>
-				logged('stop_session', args as Record<string, unknown>, () => handlers.stop_session(args), {
-					targetType: 'task',
-					getTargetId: (a) => (a.task_id as string) ?? null,
-				})
-		),
+		...(config.runtimeService
+			? [
+					tool(
+						'stop_session',
+						'Interrupt the running agent session for a task. Only works for in_progress or review tasks. Medium risk — requires confirmation in balanced mode.',
+						{
+							room_id: z.string().describe('ID of the room containing the task'),
+							task_id: z.string().describe('ID of the task whose session to stop'),
+						},
+						// Non-undoable: session interruption may have cascading side effects.
+						(args) =>
+							logged(
+								'stop_session',
+								args as Record<string, unknown>,
+								() => handlers.stop_session(args),
+								{
+									targetType: 'task',
+									getTargetId: (a) => (a.task_id as string) ?? null,
+								}
+							)
+					),
+				]
+			: []),
 
 		tool(
 			'pause_schedule',

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -30,18 +30,8 @@ import { setupConfigHandlers } from './config-handlers';
 import { setupTestHandlers } from './test-handlers';
 import { setupRewindHandlers } from './rewind-handlers';
 import { RoomManager } from '../room';
-// New split handlers for Neo functionality
-import { setupRoomHandlers, setupRoomRuntimeHandlers } from './room-handlers';
-import { setupTaskHandlers } from './task-handlers';
 import { setupGitHubHandlers } from './github-handlers';
 import type { GitHubService } from '../github/github-service';
-// New handlers for goals
-import {
-	setupGoalHandlers,
-	type GoalManagerFactory,
-	type TaskManagerFactory as GoalTaskManagerFactory,
-} from './goal-handlers';
-import { RoomRuntimeService } from '../room/runtime/room-runtime-service';
 import { Logger } from '../logger';
 import { GoalManager } from '../room/managers/goal-manager';
 import { TaskManager } from '../room/managers/task-manager';
@@ -82,7 +72,6 @@ import { SpaceWorkflowRepository } from '../../storage/repositories/space-workfl
 import { SpaceAgentRepository } from '../../storage/repositories/space-agent-repository';
 import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
 import type { JobQueueProcessor } from '../../storage/job-queue-processor';
-import { enqueueRoomTick } from '../job-handlers/room-tick.handler';
 import { SpaceRuntimeService } from '../space/runtime/space-runtime-service';
 import { setupSpaceWorkflowRunHandlers } from './space-workflow-run-handlers';
 import type { SpaceWorkflowRunTaskManagerFactory } from './space-workflow-run-handlers';
@@ -174,30 +163,10 @@ export interface RPCHandlerSetupResult {
  * Returns a result with cleanup function and exposed services
  */
 export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupResult {
-	// Room handlers (create roomManager first as session handlers depend on it)
+	// Room records are still readable by Neo/reference tooling during migration,
+	// but the legacy Room runtime and public Room RPC handlers are no longer
+	// registered from the daemon entrypoint.
 	const roomManager = new RoomManager(deps.db.getDatabase(), deps.reactiveDb);
-
-	// Create factory function for per-room goal managers
-	const goalManagerFactory: GoalManagerFactory = (roomId: string) => {
-		return new GoalManager(
-			deps.db.getDatabase(),
-			roomId,
-			deps.reactiveDb,
-			deps.db.getShortIdAllocator()
-		);
-	};
-
-	// Create factory function for per-room task managers (used by goal review handlers)
-	const goalTaskManagerFactory: GoalTaskManagerFactory = (roomId: string) => {
-		const taskManager = new TaskManager(
-			deps.db.getDatabase(),
-			roomId,
-			deps.reactiveDb,
-			deps.db.getShortIdAllocator()
-		);
-		const taskRepo = new TaskRepository(deps.db.getDatabase(), deps.reactiveDb);
-		return { taskManager, taskRepo };
-	};
 
 	// setupSessionHandlers is registered below, after spaceRuntimeService is
 	// constructed, so session.create can synchronously attach space-agent-tools
@@ -207,10 +176,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	setupFileHandlers(deps.messageHub, deps.sessionManager);
 	setupSystemHandlers(deps.messageHub, deps.sessionManager, deps.authManager, deps.config);
 	setupAuthHandlers(deps.messageHub, deps.authManager);
-	// Note: setupQuestionHandlers is called after roomRuntimeService is created below
-	// so that it can receive a runtime session lookup function. Room worker/leader
-	// sessions live in RoomRuntimeService.agentSessions (separate from SessionManager),
-	// so the handler needs to check the runtime pool first.
 	registerMcpHandlers(deps.messageHub, deps.sessionManager, deps.appMcpManager);
 	registerSettingsHandlers(
 		deps.messageHub,
@@ -224,97 +189,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	setupTestHandlers(deps.messageHub, deps.reactiveDb.db);
 	setupRewindHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub);
 
-	// Room Runtime Service (must be created before task/goal handlers — messaging + task approval need it)
-	// Also created before setupRoomHandlers so the hasActiveTaskGroups callback can reference it.
-	const roomRuntimeService = new RoomRuntimeService({
-		// Use reactiveDb.db (proxied Database facade) so sdk_messages writes from
-		// room worker/leader sessions trigger LiveQuery invalidation immediately.
-		db: deps.reactiveDb.db,
-		messageHub: deps.messageHub,
-		daemonHub: deps.daemonHub,
-		getApiKey: () => deps.authManager.getCurrentApiKey(),
-		roomManager,
-		sessionManager: deps.sessionManager,
-		defaultWorkspacePath: undefined,
-		defaultModel: deps.config.defaultModel,
-		getGlobalSettings: () => deps.settingsManager.getGlobalSettings(),
-		settingsManager: deps.settingsManager,
-		appMcpManager: deps.appMcpManager,
-		reactiveDb: deps.reactiveDb,
-		jobQueue: deps.jobQueue,
-		jobProcessor: deps.jobProcessor,
-		skillsManager: deps.skillsManager,
-		appMcpServerRepo: deps.reactiveDb.db.appMcpServers,
-		roomSkillOverrideRepo: deps.reactiveDb.db.roomSkillOverrides,
-		dbPath: deps.db.getDatabasePath(),
-		disableGoalProcessing: deps.config.disableGoalProcessing,
-	});
-
-	// Seed an initial room.tick job for every room after startup, and for each
-	// newly created room. The handler's finally block keeps the loop going; this
-	// is the only bootstrap call needed.
-	const seedRoomTick = (roomId: string) => enqueueRoomTick(roomId, deps.jobQueue);
-
-	roomRuntimeService
-		.start()
-		.then(() => {
-			for (const room of roomManager.listRooms()) {
-				seedRoomTick(room.id);
-			}
-		})
-		.catch((error) => {
-			log.error('Failed to start RoomRuntimeService:', error);
-		});
-
-	// Seed a tick for rooms created after startup.
-	const unsubRoomCreated = deps.daemonHub.on(
-		'room.created',
-		(event) => {
-			seedRoomTick(event.room.id);
-		},
-		{ sessionId: 'global' }
-	);
-
-	// Room handlers — registered after roomRuntimeService so hasActiveTaskGroups callback
-	// can reference the service (which queries the DB for active groups, not in-memory state).
-	setupRoomHandlers(
-		deps.messageHub,
-		roomManager,
-		deps.daemonHub,
-		deps.sessionManager,
-		deps.jobQueue,
-		deps.db,
-		{ hasActiveTaskGroups: (roomId) => roomRuntimeService.hasActiveTaskGroups(roomId) }
-	);
-
-	// Wire question handlers now that roomRuntimeService is available.
-	// Pass its session lookup so question.respond reaches the correct live AgentSession
-	// (room worker/leader sessions are stored in RoomRuntimeService.agentSessions,
-	// not in SessionManager's cache).
-	setupQuestionHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub, (sessionId) =>
-		roomRuntimeService.getAgentSession(sessionId)
-	);
-
-	setupRoomRuntimeHandlers(deps.messageHub, deps.daemonHub, roomRuntimeService, deps.jobQueue);
-	setupTaskHandlers(
-		deps.messageHub,
-		roomManager,
-		deps.daemonHub,
-		deps.db,
-		deps.reactiveDb,
-		undefined,
-		roomRuntimeService,
-		deps.sessionManager
-	);
-
-	// Goal handlers (after runtime service — task.approve/task.reject need runtimeService)
-	setupGoalHandlers(
-		deps.messageHub,
-		deps.daemonHub,
-		goalManagerFactory,
-		goalTaskManagerFactory,
-		roomRuntimeService
-	);
+	setupQuestionHandlers(deps.messageHub, deps.sessionManager, deps.daemonHub);
 
 	// GitHub handlers
 	setupGitHubHandlers(
@@ -636,7 +511,6 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 					deps.db.getShortIdAllocator()
 				),
 		},
-		runtimeService: roomRuntimeService,
 		pendingStore: neoPendingActions,
 		workspaceRoot: undefined,
 		getSecurityMode: () => deps.neoAgentManager.getSecurityMode(),
@@ -789,11 +663,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	// Return result with cleanup function and exposed services
 	return {
 		cleanup: async () => {
-			unsubRoomCreated();
 			unsubLiveQuery();
-			// roomRuntimeService.stop() is synchronous today. If it becomes
-			// async in the future, add await here to prevent silent promise discard.
-			roomRuntimeService.stop();
 			await spaceRuntimeService.stop();
 			fileIndex.dispose();
 		},

--- a/packages/daemon/src/lib/rpc-handlers/question-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/question-handlers.ts
@@ -39,32 +39,28 @@ export function setupQuestionHandlers(
 	sessionManager: SessionManager,
 	_daemonHub: DaemonHub,
 	/**
-	 * Optional lookup for room worker/leader sessions.
+	 * Optional lookup for runtime-owned sessions.
 	 *
-	 * Room worker and leader sessions live in RoomRuntimeService.agentSessions,
-	 * a separate in-memory map from SessionManager's cache. If SessionManager is
-	 * used alone it creates a fresh AgentSession from the DB (no live SDK query,
-	 * pendingResolver = null) and handleQuestionResponse always throws.
-	 *
-	 * Pass RoomRuntimeService.getAgentSession.bind(runtimeService) here so the
-	 * handler resolves the correct live instance first.
+	 * Some runtime-owned sessions can live outside SessionManager's cache. If
+	 * SessionManager is used alone it may create a fresh AgentSession from the DB
+	 * with no live SDK query, so question responses cannot resume the pending turn.
 	 */
 	getRuntimeSession?: (sessionId: string) => AgentSession | undefined
 ): void {
 	/**
 	 * Resolve the AgentSession that owns the live SDK query for a given session ID.
 	 *
-	 * Prefers the runtime pool (worker/leader sessions) over SessionManager's cache
-	 * because SessionManager.getSessionAsync() loads a fresh instance from the DB
-	 * when the session is not in its own cache — that instance has no pendingResolver
-	 * and handleQuestionResponse would always throw "No pending question to respond to".
+	 * Prefers a runtime pool over SessionManager's cache because
+	 * SessionManager.getSessionAsync() loads a fresh instance from the DB when the
+	 * session is not in its own cache. That instance has no pendingResolver and
+	 * handleQuestionResponse would throw "No pending question to respond to".
 	 */
 	async function resolveSession(sessionId: string): Promise<AgentSession | null> {
-		// Room worker/leader sessions: check runtime pool first
+		// Runtime-owned sessions: check runtime pool first.
 		const runtimeSession = getRuntimeSession?.(sessionId);
 		if (runtimeSession) return runtimeSession;
 
-		// Lobby/room-chat sessions: fall back to SessionManager
+		// Normal sessions: fall back to SessionManager.
 		return sessionManager.getSessionAsync(sessionId);
 	}
 

--- a/packages/daemon/src/lib/state-manager.ts
+++ b/packages/daemon/src/lib/state-manager.ts
@@ -222,13 +222,6 @@ export class StateManager {
 			});
 		});
 
-		// Runtime state changes (running/paused/stopped)
-		this.eventBus.on('room.runtime.stateChanged', (data) => {
-			this.messageHub.event('room.runtime.stateChanged', data, {
-				channel: data.sessionId, // 'room:${roomId}'
-			});
-		});
-
 		// Goal lifecycle events
 		this.eventBus.on('goal.created', (data) => {
 			this.messageHub.event('goal.created', data, {
@@ -608,10 +601,10 @@ export class StateManager {
 		// Get all session state in one place
 		const sessionData = agentSession.getSessionData();
 		// Prefer event-sourced processingStateCache over the session's in-memory state.
-		// Room leader/worker sessions are live in RoomRuntimeService.agentSessions but are
-		// loaded separately into SessionCache (as "ghosts") when state.session is fetched.
-		// The ghost's in-memory processingState becomes stale once the live session changes
-		// state. processingStateCache is always up-to-date via session.updated DaemonHub events.
+		// Some runtime-owned sessions can be loaded separately into SessionCache
+		// when state.session is fetched. That instance's in-memory processingState
+		// can become stale once the live session changes state; processingStateCache
+		// stays up-to-date via session.updated DaemonHub events.
 		const agentState =
 			this.processingStateCache.get(sessionId) ?? agentSession.getProcessingState();
 		const commands = await agentSession.getSlashCommands();

--- a/packages/daemon/tests/unit/1-core/neo/neo-action-tools.test.ts
+++ b/packages/daemon/tests/unit/1-core/neo/neo-action-tools.test.ts
@@ -38,7 +38,7 @@
  * - stop_session: happy path, wrong status, runtime unavailable, task not found
  * - pause_schedule: happy path, non-recurring goal, goal not found, already paused (idempotent)
  * - resume_schedule: happy path, no schedule, non-recurring goal, already active (idempotent)
- * - MCP server: all 33 tools are registered
+ * - MCP server: runtime-dependent tools are registered only when runtimeService exists
  */
 
 import { mock } from 'bun:test';
@@ -2881,7 +2881,7 @@ describe('createNeoActionMcpServer', () => {
 	let server: ReturnType<typeof createNeoActionMcpServer>;
 
 	beforeEach(() => {
-		server = createNeoActionMcpServer(makeConfig());
+		server = createNeoActionMcpServer(makeConfig({ runtimeService: makeRuntimeService() }));
 	});
 
 	it('names the MCP server "neo-action"', () => {
@@ -3018,5 +3018,13 @@ describe('createNeoActionMcpServer', () => {
 
 	it('registers exactly 33 tools', () => {
 		expect(Object.keys(server.instance._registeredTools)).toHaveLength(33);
+	});
+
+	it('omits runtime-dependent tools when runtimeService is unavailable', () => {
+		const serverWithoutRuntime = createNeoActionMcpServer(makeConfig());
+		expect(serverWithoutRuntime.instance._registeredTools).not.toHaveProperty('approve_task');
+		expect(serverWithoutRuntime.instance._registeredTools).not.toHaveProperty('reject_task');
+		expect(serverWithoutRuntime.instance._registeredTools).not.toHaveProperty('stop_session');
+		expect(Object.keys(serverWithoutRuntime.instance._registeredTools)).toHaveLength(30);
 	});
 });

--- a/packages/daemon/tests/unit/1-core/neo/neo-system-prompt.test.ts
+++ b/packages/daemon/tests/unit/1-core/neo/neo-system-prompt.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'bun:test';
+import { buildNeoSystemPrompt } from '../../../../src/lib/neo/neo-system-prompt';
+
+describe('buildNeoSystemPrompt', () => {
+	it('includes runtime-dependent room task tools when the room runtime is available', () => {
+		const prompt = buildNeoSystemPrompt('balanced', { roomRuntimeToolsAvailable: true });
+
+		expect(prompt).toContain('`stop_session`');
+		expect(prompt).toContain('`approve_task`');
+		expect(prompt).toContain('`reject_task`');
+	});
+
+	it('omits runtime-dependent room task tools when the room runtime is unavailable', () => {
+		const prompt = buildNeoSystemPrompt('balanced', { roomRuntimeToolsAvailable: false });
+
+		expect(prompt).not.toContain('`stop_session`');
+		expect(prompt).not.toContain('`approve_task`');
+		expect(prompt).not.toContain('`reject_task`');
+		expect(prompt).toContain('`send_message_to_room`');
+	});
+});

--- a/packages/daemon/tests/unit/1-core/session/state-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/state-manager.test.ts
@@ -588,7 +588,7 @@ describe('StateManager', () => {
 			it('should register room event handlers on initialization', () => {
 				expect(eventHandlers.has('room.task.update')).toBe(true);
 				expect(eventHandlers.has('room.overview')).toBe(true);
-				expect(eventHandlers.has('room.runtime.stateChanged')).toBe(true);
+				expect(eventHandlers.has('room.runtime.stateChanged')).toBe(false);
 				expect(eventHandlers.has('goal.created')).toBe(true);
 				// goal.updated was removed in PR #695 (emitGoalUpdated dropped from goal handlers)
 				expect(eventHandlers.has('goal.updated')).toBe(false);
@@ -646,25 +646,6 @@ describe('StateManager', () => {
 					handler!(data);
 
 					expect(mockMessageHub.event).toHaveBeenCalledWith('room.overview', data, {
-						channel: 'room:room-123',
-					});
-				});
-			});
-
-			describe('room.runtime.stateChanged', () => {
-				it('should forward runtime state change to room channel', () => {
-					(mockMessageHub.event as ReturnType<typeof mock>).mockClear();
-
-					const handler = eventHandlers.get('room.runtime.stateChanged');
-					const data = {
-						sessionId: 'room:room-123',
-						roomId: 'room-123',
-						state: 'running',
-					};
-
-					handler!(data);
-
-					expect(mockMessageHub.event).toHaveBeenCalledWith('room.runtime.stateChanged', data, {
 						channel: 'room:room-123',
 					});
 				});


### PR DESCRIPTION
Removes the daemon entrypoint wiring that still started the legacy Room runtime and registered Room/task/goal RPC handlers. Room records remain available for Neo/reference migration reads, but active Room runtime jobs and runtime-state websocket forwarding are no longer bootstrapped.

Stacked on #1712.

Tests: bun run lint; bun run typecheck; GIT_CONFIG_GLOBAL=/dev/null ./scripts/test-daemon.sh (requires unsandboxed local port binding)