### PR TITLE
[codex] Add searchable model picker and cap OpenRouter models

### DIFF
--- a/packages/daemon/src/lib/providers/openrouter-provider.ts
+++ b/packages/daemon/src/lib/providers/openrouter-provider.ts
@@ -38,7 +38,12 @@ const CURATED_PROVIDER_PREFIXES = [
 	'deepseek/',
 	'meta-llama/',
 	'mistralai/',
+	'xai/',
+	'cohere/',
+	'qwen/',
 ] as const;
+
+const CURATED_MODEL_IDS = ['openrouter/auto'] as const;
 
 function isProbablyOpenRouterKey(apiKey: string): boolean {
 	return apiKey.trim().startsWith('sk-or-');
@@ -283,7 +288,10 @@ export class OpenRouterProvider implements Provider {
 	private static curateApiModels(models: ModelInfo[]): ModelInfo[] {
 		const curated = models.filter((model) => {
 			const id = model.id.toLowerCase();
-			return CURATED_PROVIDER_PREFIXES.some((prefix) => id.startsWith(prefix));
+			return (
+				CURATED_MODEL_IDS.some((modelId) => id === modelId) ||
+				CURATED_PROVIDER_PREFIXES.some((prefix) => id.startsWith(prefix))
+			);
 		});
 
 		const candidates = curated.length > 0 ? curated : models;

--- a/packages/daemon/src/lib/providers/openrouter-provider.ts
+++ b/packages/daemon/src/lib/providers/openrouter-provider.ts
@@ -31,6 +31,15 @@ interface OpenRouterModelsResponse {
 	data?: OpenRouterModel[];
 }
 
+const CURATED_PROVIDER_PREFIXES = [
+	'anthropic/',
+	'openai/',
+	'google/',
+	'deepseek/',
+	'meta-llama/',
+	'mistralai/',
+] as const;
+
 function isProbablyOpenRouterKey(apiKey: string): boolean {
 	return apiKey.trim().startsWith('sk-or-');
 }
@@ -72,6 +81,7 @@ export class OpenRouterProvider implements Provider {
 	static readonly BASE_URL = 'https://openrouter.ai/api';
 	static readonly MODELS_URL = 'https://openrouter.ai/api/v1/models?output_modalities=text';
 	static readonly DEFAULT_MODEL = 'anthropic/claude-sonnet-4.6';
+	static readonly MAX_API_MODELS = 30;
 
 	static readonly FALLBACK_MODELS: ModelInfo[] = [
 		{
@@ -160,9 +170,11 @@ export class OpenRouterProvider implements Provider {
 			}
 
 			const body = (await response.json()) as OpenRouterModelsResponse;
-			const models = (body.data ?? [])
-				.filter((model) => typeof model.id === 'string' && model.id.length > 0)
-				.map((model) => this.toModelInfo(model));
+			const models = OpenRouterProvider.curateApiModels(
+				(body.data ?? [])
+					.filter((model) => typeof model.id === 'string' && model.id.length > 0)
+					.map((model) => this.toModelInfo(model))
+			);
 
 			this.modelCache = models.length > 0 ? models : OpenRouterProvider.FALLBACK_MODELS;
 			this.lastAuthError = undefined;
@@ -266,5 +278,15 @@ export class OpenRouterProvider implements Provider {
 			releaseDate: releaseDateFromCreated(model.created),
 			available: true,
 		};
+	}
+
+	private static curateApiModels(models: ModelInfo[]): ModelInfo[] {
+		const curated = models.filter((model) => {
+			const id = model.id.toLowerCase();
+			return CURATED_PROVIDER_PREFIXES.some((prefix) => id.startsWith(prefix));
+		});
+
+		const candidates = curated.length > 0 ? curated : models;
+		return candidates.slice(0, OpenRouterProvider.MAX_API_MODELS);
 	}
 }

--- a/packages/daemon/tests/unit/1-core/providers/openrouter-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openrouter-provider.test.ts
@@ -118,6 +118,42 @@ describe('OpenRouterProvider', () => {
 		expect(models[1].family).toBe('gpt');
 	});
 
+	it('caps API-loaded models to a curated set of known provider families', async () => {
+		process.env.OPENROUTER_API_KEY = 'sk-or-test';
+		const data = [
+			...Array.from({ length: 35 }, (_, index) => ({
+				id: `anthropic/claude-test-${index}`,
+				name: `Claude Test ${index}`,
+			})),
+			{ id: 'random-lab/experimental-1', name: 'Experimental 1' },
+			{ id: 'small-provider/experimental-2', name: 'Experimental 2' },
+		];
+		const fetchMock = mock(async () => new Response(JSON.stringify({ data }), { status: 200 }));
+		const provider = new OpenRouterProvider(process.env, fetchMock as unknown as typeof fetch);
+
+		const models = await provider.getModels();
+
+		expect(models).toHaveLength(OpenRouterProvider.MAX_API_MODELS);
+		expect(models.every((model) => model.id.startsWith('anthropic/'))).toBe(true);
+		expect(models.at(-1)?.id).toBe('anthropic/claude-test-29');
+	});
+
+	it('falls back to the first API models when no curated families are present', async () => {
+		process.env.OPENROUTER_API_KEY = 'sk-or-test';
+		const data = Array.from({ length: 35 }, (_, index) => ({
+			id: `community/model-${index}`,
+			name: `Community Model ${index}`,
+		}));
+		const fetchMock = mock(async () => new Response(JSON.stringify({ data }), { status: 200 }));
+		const provider = new OpenRouterProvider(process.env, fetchMock as unknown as typeof fetch);
+
+		const models = await provider.getModels();
+
+		expect(models).toHaveLength(OpenRouterProvider.MAX_API_MODELS);
+		expect(models[0].id).toBe('community/model-0');
+		expect(models.at(-1)?.id).toBe('community/model-29');
+	});
+
 	it('surfaces rejected API keys through auth status and hides models', async () => {
 		process.env.OPENROUTER_API_KEY = 'sk-or-test';
 		const fetchMock = mock(async () => new Response('Unauthorized', { status: 401 }));

--- a/packages/daemon/tests/unit/1-core/providers/openrouter-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openrouter-provider.test.ts
@@ -138,6 +138,28 @@ describe('OpenRouterProvider', () => {
 		expect(models.at(-1)?.id).toBe('anthropic/claude-test-29');
 	});
 
+	it('keeps OpenRouter auto and popular provider families in curated API models', async () => {
+		process.env.OPENROUTER_API_KEY = 'sk-or-test';
+		const data = [
+			{ id: 'openrouter/auto', name: 'OpenRouter Auto' },
+			{ id: 'xai/grok-4', name: 'Grok 4' },
+			{ id: 'cohere/command-a', name: 'Command A' },
+			{ id: 'qwen/qwen3-coder', name: 'Qwen3 Coder' },
+			{ id: 'random-lab/experimental-1', name: 'Experimental 1' },
+		];
+		const fetchMock = mock(async () => new Response(JSON.stringify({ data }), { status: 200 }));
+		const provider = new OpenRouterProvider(process.env, fetchMock as unknown as typeof fetch);
+
+		const models = await provider.getModels();
+
+		expect(models.map((model) => model.id)).toEqual([
+			'openrouter/auto',
+			'xai/grok-4',
+			'cohere/command-a',
+			'qwen/qwen3-coder',
+		]);
+	});
+
 	it('falls back to the first API models when no curated families are present', async () => {
 		process.env.OPENROUTER_API_KEY = 'sk-or-test';
 		const data = Array.from({ length: 35 }, (_, index) => ({

--- a/packages/web/src/components/SessionStatusBar.tsx
+++ b/packages/web/src/components/SessionStatusBar.tsx
@@ -27,7 +27,7 @@ import {
 	getModelFamilyIcon,
 	getProviderLabel,
 	groupModelsByProvider,
-	filterModelsForPicker,
+	useFilteredModelsForPicker,
 	useMessageHub,
 } from '../hooks';
 import { Spinner } from './ui/Spinner.tsx';
@@ -245,6 +245,7 @@ export default function SessionStatusBar({
 	const [providerAuthStatuses, setProviderAuthStatuses] = useState<Map<string, ProviderAuthStatus>>(
 		new Map()
 	);
+	const [modelSearchQuery, setModelSearchQuery] = useState('');
 
 	useEffect(() => {
 		let cancelled = false;
@@ -280,6 +281,7 @@ export default function SessionStatusBar({
 			modelDropdown.close();
 		} else {
 			thinkingDropdown.close();
+			setModelSearchQuery('');
 			modelDropdown.open();
 		}
 	}, [modelDropdown, thinkingDropdown]);
@@ -320,10 +322,17 @@ export default function SessionStatusBar({
 	const handleModelSwitch = useCallback(
 		async (model: ModelInfo) => {
 			await onModelSwitch(model);
+			setModelSearchQuery('');
 			modelDropdown.close();
 		},
 		[onModelSwitch, modelDropdown]
 	);
+
+	useEffect(() => {
+		if (!modelDropdown.isOpen) {
+			setModelSearchQuery('');
+		}
+	}, [modelDropdown.isOpen]);
 
 	// Thinking level change handler with persistence
 	const handleThinkingLevelChange = useCallback(
@@ -342,6 +351,13 @@ export default function SessionStatusBar({
 
 	// Get current model icon
 	const currentModelIcon = currentModelInfo ? getModelFamilyIcon(currentModelInfo.family) : '💎';
+	const filteredModels = useFilteredModelsForPicker(
+		availableModels,
+		providerAuthStatuses,
+		currentModelInfo?.provider,
+		modelSearchQuery
+	);
+	const groupedFilteredModels = groupModelsByProvider(filteredModels);
 	const glassControlButtonBaseClass =
 		'control-btn w-8 h-8 flex items-center justify-center rounded-full bg-transparent backdrop-blur-sm hover:bg-dark-800/30 transition-all disabled:opacity-50 disabled:cursor-not-allowed';
 
@@ -453,74 +469,85 @@ export default function SessionStatusBar({
 						{modelDropdown.isOpen && (
 							<div
 								data-testid="model-dropdown"
-								class={`absolute bottom-full mb-2 left-0 bg-dark-800 border ${borderColors.ui.secondary} rounded-lg shadow-xl w-52 py-1 z-50 animate-slideIn max-h-[60vh] overflow-y-auto`}
+								class={`absolute bottom-full mb-2 left-0 bg-dark-800 border ${borderColors.ui.secondary} rounded-lg shadow-xl w-72 py-1 z-50 animate-slideIn max-h-[60vh] flex flex-col`}
 							>
 								<div class="px-3 py-1.5 text-xs font-semibold text-gray-400">Select Model</div>
-								{Array.from(
-									groupModelsByProvider(
-										filterModelsForPicker(
-											availableModels,
-											providerAuthStatuses,
-											currentModelInfo?.provider
-										)
-									).entries()
-								).map(([provider, models], groupIndex) => {
-									const authStatus = providerAuthStatuses.get(provider);
-									const isAuthenticated = authStatus?.isAuthenticated;
-									const needsRefresh = authStatus?.needsRefresh ?? false;
-									// Dot: gray = unknown, green = ok, yellow = expiring, red = unauthenticated (only current shown)
-									const dotClass =
-										isAuthenticated === undefined
-											? 'bg-gray-500'
-											: !isAuthenticated
-												? 'bg-red-500'
-												: needsRefresh
-													? 'bg-yellow-500'
-													: 'bg-green-500';
-									return (
-										<div key={provider} data-testid="provider-section">
-											{groupIndex > 0 && <div class="mx-2 my-1 border-t border-gray-700" />}
-											<div class="px-3 py-1 flex items-center gap-1.5">
-												<span class={`w-2 h-2 rounded-full flex-shrink-0 ${dotClass}`} />
-												<span
-													data-testid="provider-group-header"
-													class="text-[10px] font-semibold text-gray-400 uppercase tracking-wide"
-												>
-													{getProviderLabel(provider)}
-												</span>
-												{needsRefresh && (
-													<span class="text-yellow-400 text-[10px]" title="Token expiring soon">
-														⚠
-													</span>
-												)}
-											</div>
-											{models.map((model) => {
-												const isCurrent =
-													model.id === currentModelInfo?.id &&
-													model.provider === currentModelInfo?.provider;
-												return (
-													<button
-														key={`${model.provider}:${model.id}`}
-														class={`w-full text-left px-3 py-1.5 hover:bg-dark-700 text-xs flex items-center gap-2 ${
-															isCurrent ? 'text-blue-400' : 'text-gray-200'
-														}`}
-														onClick={() => handleModelSwitch(model)}
-														disabled={modelSwitching}
-													>
-														<span class="text-base">{getModelFamilyIcon(model.family)}</span>
-														<span class="flex-1 truncate">{model.name}</span>
-														{isCurrent && <span class="text-blue-400 text-[10px]">✓</span>}
+								<div class="px-2 pb-2">
+									<input
+										type="search"
+										value={modelSearchQuery}
+										onInput={(e) => setModelSearchQuery(e.currentTarget.value)}
+										placeholder="Search models..."
+										aria-label="Search models"
+										class="w-full bg-dark-900 border border-dark-600 rounded px-2 py-1.5 text-xs text-gray-100 placeholder:text-gray-500 focus:outline-none focus:border-blue-500"
+									/>
+								</div>
+								<div class="overflow-y-auto">
+									{Array.from(groupedFilteredModels.entries()).map(
+										([provider, models], groupIndex) => {
+											const authStatus = providerAuthStatuses.get(provider);
+											const isAuthenticated = authStatus?.isAuthenticated;
+											const needsRefresh = authStatus?.needsRefresh ?? false;
+											// Dot: gray = unknown, green = ok, yellow = expiring, red = unauthenticated (only current shown)
+											const dotClass =
+												isAuthenticated === undefined
+													? 'bg-gray-500'
+													: !isAuthenticated
+														? 'bg-red-500'
+														: needsRefresh
+															? 'bg-yellow-500'
+															: 'bg-green-500';
+											return (
+												<div key={provider} data-testid="provider-section">
+													{groupIndex > 0 && <div class="mx-2 my-1 border-t border-gray-700" />}
+													<div class="px-3 py-1 flex items-center gap-1.5">
+														<span class={`w-2 h-2 rounded-full flex-shrink-0 ${dotClass}`} />
+														<span
+															data-testid="provider-group-header"
+															class="text-[10px] font-semibold text-gray-400 uppercase tracking-wide"
+														>
+															{getProviderLabel(provider)}
+														</span>
 														{needsRefresh && (
-															<span class="text-yellow-400 text-[10px]" title="Token expiring">
+															<span class="text-yellow-400 text-[10px]" title="Token expiring soon">
 																⚠
 															</span>
 														)}
-													</button>
-												);
-											})}
+													</div>
+													{models.map((model) => {
+														const isCurrent =
+															model.id === currentModelInfo?.id &&
+															model.provider === currentModelInfo?.provider;
+														return (
+															<button
+																key={`${model.provider}:${model.id}`}
+																class={`w-full text-left px-3 py-1.5 hover:bg-dark-700 text-xs flex items-center gap-2 ${
+																	isCurrent ? 'text-blue-400' : 'text-gray-200'
+																}`}
+																onClick={() => handleModelSwitch(model)}
+																disabled={modelSwitching}
+															>
+																<span class="text-base">{getModelFamilyIcon(model.family)}</span>
+																<span class="flex-1 truncate">{model.name}</span>
+																{isCurrent && <span class="text-blue-400 text-[10px]">✓</span>}
+																{needsRefresh && (
+																	<span class="text-yellow-400 text-[10px]" title="Token expiring">
+																		⚠
+																	</span>
+																)}
+															</button>
+														);
+													})}
+												</div>
+											);
+										}
+									)}
+									{filteredModels.length === 0 && (
+										<div class="px-3 py-4 text-xs text-gray-500 text-center">
+											No matching models
 										</div>
-									);
-								})}
+									)}
+								</div>
 							</div>
 						)}
 					</div>

--- a/packages/web/src/components/SessionStatusBar.tsx
+++ b/packages/web/src/components/SessionStatusBar.tsx
@@ -482,7 +482,7 @@ export default function SessionStatusBar({
 										class="w-full bg-dark-900 border border-dark-600 rounded px-2 py-1.5 text-xs text-gray-100 placeholder:text-gray-500 focus:outline-none focus:border-blue-500"
 									/>
 								</div>
-								<div class="overflow-y-auto">
+								<div class="flex-1 min-h-0 overflow-y-auto">
 									{Array.from(groupedFilteredModels.entries()).map(
 										([provider, models], groupIndex) => {
 											const authStatus = providerAuthStatuses.get(provider);

--- a/packages/web/src/components/__tests__/SessionStatusBar.test.tsx
+++ b/packages/web/src/components/__tests__/SessionStatusBar.test.tsx
@@ -424,6 +424,22 @@ describe('SessionStatusBar', () => {
 			expect(container.textContent).toContain('Haiku 4.5');
 		});
 
+		it('should filter model dropdown options by search query', () => {
+			const { container } = render(<SessionStatusBar {...defaultProps} />);
+
+			const modelButton = container.querySelector(
+				'.control-btn[title*="Switch Model"]'
+			) as HTMLButtonElement;
+			fireEvent.click(modelButton);
+
+			const searchInput = container.querySelector('input[aria-label="Search models"]')!;
+			fireEvent.input(searchInput, { target: { value: 'opus' } });
+
+			expect(container.textContent).toContain('Opus 4.5');
+			expect(container.textContent).not.toContain('Sonnet 4.5');
+			expect(container.textContent).not.toContain('Haiku 4.5');
+		});
+
 		it('should show current model indicator', () => {
 			const { container } = render(<SessionStatusBar {...defaultProps} />);
 

--- a/packages/web/src/components/settings/FallbackModelsSettings.tsx
+++ b/packages/web/src/components/settings/FallbackModelsSettings.tsx
@@ -19,6 +19,7 @@ import { connectionManager } from '../../lib/connection-manager';
 import {
 	groupModelsByProvider,
 	filterModelsForPicker,
+	filterModelsBySearch,
 	getModelFamilyIcon,
 	mapRawModelsToModelInfos,
 	PROVIDER_LABELS,
@@ -112,10 +113,16 @@ function ModelPickerModal({
 	onSelect,
 	onClose,
 }: ModelPickerModalProps) {
+	const [searchQuery, setSearchQuery] = useState('');
 	const allModels = Array.from(groupedModels.values()).flat();
-	const remaining = allModels.filter(
+	const searchFilteredModels = filterModelsBySearch(allModels, searchQuery);
+	const remaining = searchFilteredModels.filter(
 		(m) => !excludeModels.some((e) => e.model === m.id && e.provider === m.provider)
 	);
+	const hasUnselectedModels = allModels.some(
+		(m) => !excludeModels.some((e) => e.model === m.id && e.provider === m.provider)
+	);
+	const visibleGroupedModels = groupModelsByProvider(remaining);
 
 	return (
 		<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
@@ -127,8 +134,19 @@ function ModelPickerModal({
 					</button>
 				</div>
 
+				<div class="px-3 py-3 border-b border-dark-700">
+					<input
+						type="search"
+						value={searchQuery}
+						onInput={(e) => setSearchQuery(e.currentTarget.value)}
+						placeholder="Search models..."
+						aria-label="Search models"
+						class="w-full bg-dark-900 border border-dark-600 rounded px-2 py-1.5 text-sm text-gray-100 placeholder:text-gray-500 focus:outline-none focus:border-blue-500"
+					/>
+				</div>
+
 				<div class="flex-1 overflow-y-auto py-2">
-					{Array.from(groupedModels.entries()).map(([provider, models]) => {
+					{Array.from(visibleGroupedModels.entries()).map(([provider, models]) => {
 						const authStatus = providerAuthStatuses.get(provider);
 						const isAuthenticated = authStatus?.isAuthenticated ?? false;
 
@@ -139,10 +157,6 @@ function ModelPickerModal({
 									{!isAuthenticated && <span class="text-gray-600 ml-1">(not authenticated)</span>}
 								</div>
 								{models.map((model) => {
-									if (
-										excludeModels.some((e) => e.model === model.id && e.provider === model.provider)
-									)
-										return null;
 									return (
 										<button
 											key={`${model.provider}:${model.id}`}
@@ -160,7 +174,9 @@ function ModelPickerModal({
 
 					{remaining.length === 0 && (
 						<div class="px-4 py-4 text-sm text-gray-500 text-center">
-							All available models are already selected
+							{searchQuery.trim() && hasUnselectedModels
+								? 'No matching models'
+								: 'All available models are already selected'}
 						</div>
 					)}
 				</div>

--- a/packages/web/src/components/space/visual-editor/WorkflowModelSelect.tsx
+++ b/packages/web/src/components/space/visual-editor/WorkflowModelSelect.tsx
@@ -84,6 +84,8 @@ export function WorkflowModelSelect({
 		);
 	}
 
+	// Native select remains intentionally simple here because OpenRouter is capped server-side;
+	// the primary status-bar and fallback settings pickers provide searchable custom menus.
 	return (
 		<select
 			data-testid={testId}

--- a/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
+++ b/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
@@ -16,6 +16,7 @@ import {
 	mapRawModelsToModelInfos,
 	filterModelsForPicker,
 	filterModelsBySearch,
+	useFilteredModelsForPicker,
 } from '../useModelSwitcher.ts';
 
 // Mock the connection manager
@@ -1262,5 +1263,38 @@ describe('filterModelsBySearch', () => {
 			'openai/gpt-5.4',
 		]);
 		expect(filterModelsBySearch(models, 'openrouter sonnet')).toEqual([]);
+	});
+});
+
+describe('useFilteredModelsForPicker', () => {
+	it('applies auth filtering before search filtering', () => {
+		const anthropicModel = {
+			...makeModel('claude-sonnet', 'anthropic'),
+			name: 'Claude Sonnet',
+		};
+		const copilotModel = {
+			...makeModel('copilot-sonnet', 'anthropic-copilot'),
+			name: 'Copilot Sonnet',
+		};
+		const codexModel = {
+			...makeModel('gpt-codex', 'anthropic-codex'),
+			name: 'Codex GPT',
+		};
+		const authMap = new Map([
+			['anthropic', makeAuth('anthropic', true)],
+			['anthropic-copilot', makeAuth('anthropic-copilot', false)],
+			['anthropic-codex', makeAuth('anthropic-codex', true)],
+		]);
+
+		const { result } = renderHook(() =>
+			useFilteredModelsForPicker(
+				[anthropicModel, copilotModel, codexModel],
+				authMap,
+				undefined,
+				'sonnet'
+			)
+		);
+
+		expect(result.current.map((model) => model.id)).toEqual(['claude-sonnet']);
 	});
 });

--- a/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
+++ b/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
@@ -15,6 +15,7 @@ import {
 	groupModelsByProvider,
 	mapRawModelsToModelInfos,
 	filterModelsForPicker,
+	filterModelsBySearch,
 } from '../useModelSwitcher.ts';
 
 // Mock the connection manager
@@ -1222,5 +1223,44 @@ describe('filterModelsForPicker', () => {
 		]);
 		const result = filterModelsForPicker([anthropicModel, copilotModel], authMap);
 		expect(result).toHaveLength(2);
+	});
+});
+
+describe('filterModelsBySearch', () => {
+	const anthropicModel = {
+		...makeModel('claude-sonnet-4.6', 'anthropic'),
+		name: 'Claude Sonnet 4.6',
+		alias: 'sonnet-latest',
+	};
+	const openRouterModel = {
+		...makeModel('openai/gpt-5.4', 'openrouter'),
+		name: 'GPT-5.4',
+	};
+	const glmModel = {
+		...makeModel('glm-4-plus', 'glm'),
+		name: 'GLM 4 Plus',
+	};
+
+	it('returns all models for an empty search query', () => {
+		const models = [anthropicModel, openRouterModel, glmModel];
+		expect(filterModelsBySearch(models, '   ')).toBe(models);
+	});
+
+	it('filters by model name, id, alias, and provider label', () => {
+		const models = [anthropicModel, openRouterModel, glmModel];
+
+		expect(filterModelsBySearch(models, 'sonnet').map((m) => m.id)).toEqual(['claude-sonnet-4.6']);
+		expect(filterModelsBySearch(models, 'openai').map((m) => m.id)).toEqual(['openai/gpt-5.4']);
+		expect(filterModelsBySearch(models, 'latest').map((m) => m.id)).toEqual(['claude-sonnet-4.6']);
+		expect(filterModelsBySearch(models, 'OpenRouter').map((m) => m.id)).toEqual(['openai/gpt-5.4']);
+	});
+
+	it('matches all search terms across searchable fields', () => {
+		const models = [anthropicModel, openRouterModel, glmModel];
+
+		expect(filterModelsBySearch(models, 'openrouter gpt').map((m) => m.id)).toEqual([
+			'openai/gpt-5.4',
+		]);
+		expect(filterModelsBySearch(models, 'openrouter sonnet')).toEqual([]);
 	});
 });

--- a/packages/web/src/hooks/index.ts
+++ b/packages/web/src/hooks/index.ts
@@ -20,6 +20,8 @@ export {
 	getProviderLabel,
 	groupModelsByProvider,
 	filterModelsForPicker,
+	filterModelsBySearch,
+	useFilteredModelsForPicker,
 } from './useModelSwitcher';
 export {
 	useMessageHub,

--- a/packages/web/src/hooks/useModelSwitcher.ts
+++ b/packages/web/src/hooks/useModelSwitcher.ts
@@ -17,7 +17,7 @@
  * ```
  */
 
-import { useState, useEffect, useCallback } from 'preact/hooks';
+import { useState, useEffect, useCallback, useMemo } from 'preact/hooks';
 import type { ModelInfo } from '@neokai/shared';
 import type { ProviderAuthStatus } from '@neokai/shared/provider';
 import { connectionManager } from '../lib/connection-manager';
@@ -209,6 +209,33 @@ export function filterModelsForPicker(
 		if (m.provider === currentProvider) return true; // always keep active provider
 		return auth.isAuthenticated; // hide unauthenticated (needsRefresh stays visible)
 	});
+}
+
+export function filterModelsBySearch(models: ModelInfo[], searchQuery: string): ModelInfo[] {
+	const terms = searchQuery.trim().toLowerCase().split(/\s+/).filter(Boolean);
+	if (terms.length === 0) return models;
+
+	return models.filter((model) => {
+		const provider = model.provider || 'anthropic';
+		const searchable = [model.name, model.id, model.alias, getProviderLabel(provider), provider]
+			.filter(Boolean)
+			.join(' ')
+			.toLowerCase();
+
+		return terms.every((term) => searchable.includes(term));
+	});
+}
+
+export function useFilteredModelsForPicker(
+	models: ModelInfo[],
+	providerAuthMap: Map<string, ProviderAuthStatus>,
+	currentProvider: string | undefined,
+	searchQuery: string
+): ModelInfo[] {
+	return useMemo(() => {
+		const authFilteredModels = filterModelsForPicker(models, providerAuthMap, currentProvider);
+		return filterModelsBySearch(authFilteredModels, searchQuery);
+	}, [models, providerAuthMap, currentProvider, searchQuery]);
 }
 
 /**


### PR DESCRIPTION
Caps API-loaded OpenRouter models to 30 entries from known high-signal provider families, and adds text search to the status-bar and fallback-settings model pickers. The workflow visual editor remains on a native select with a code note because the OpenRouter list is now capped server-side.

Validation: `bun run check`; `bun run --filter @neokai/web test`; `bun run --filter @neokai/daemon test:unit`; targeted web picker tests and OpenRouter provider tests. CI is green on PR #1715.