### PR TITLE
[codex] fix ChatGPT Codex responses request shape

### DIFF
--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -108,6 +108,7 @@ type ResponsesRequest = {
 	tools?: ResponsesTool[];
 	tool_choice?: 'auto' | 'none' | 'required' | { type: 'function'; name: string };
 	max_output_tokens?: number;
+	store: false;
 	stream: true;
 	parallel_tool_calls: false;
 };
@@ -387,11 +388,13 @@ function toolChoiceToResponsesToolChoice(
 function buildResponsesRequest(
 	body: AnthropicRequest,
 	model: string,
-	continuation?: { previousResponseId: string; input: ResponsesInputItem[] }
+	continuation?: { previousResponseId: string; input: ResponsesInputItem[] },
+	options: { includeMaxOutputTokens?: boolean } = {}
 ): ResponsesRequest {
 	const instructions = extractSystemText(body.system) || undefined;
 	const tools = toolsToResponsesTools(body.tools);
 	const tool_choice = toolChoiceToResponsesToolChoice(body.tool_choice);
+	const includeMaxOutputTokens = options.includeMaxOutputTokens ?? true;
 	return {
 		model,
 		...(instructions ? { instructions } : {}),
@@ -399,7 +402,10 @@ function buildResponsesRequest(
 		...(continuation ? { previous_response_id: continuation.previousResponseId } : {}),
 		...(tools ? { tools } : {}),
 		...(tool_choice ? { tool_choice } : {}),
-		...(typeof body.max_tokens === 'number' ? { max_output_tokens: body.max_tokens } : {}),
+		...(includeMaxOutputTokens && typeof body.max_tokens === 'number'
+			? { max_output_tokens: body.max_tokens }
+			: {}),
+		store: false,
 		stream: true,
 		parallel_tool_calls: false,
 	};
@@ -847,7 +853,9 @@ export function createOpenAIResponsesBridgeServer(
 			const model = resolveModelId(body.model, config.modelAliases);
 			const sessionId = extractSessionId(req);
 			const continuation = resolveContinuation(sessionId, body.messages, continuations);
-			const requestBody = buildResponsesRequest(body, model, continuation);
+			const requestBody = buildResponsesRequest(body, model, continuation, {
+				includeMaxOutputTokens: config.auth.source !== 'chatgpt_oauth',
+			});
 			const upstreamUrl = `${baseUrl.replace(/\/$/, '')}/responses`;
 			let openAIResponse: Response;
 			try {

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
@@ -156,6 +156,8 @@ describe('openai-responses-bridge server', () => {
 		expect(resp.status).toBe(200);
 		expect(capturedBody?.model).toBe('gpt-5.3-codex');
 		expect(capturedBody?.instructions).toBe('Be concise.');
+		expect(capturedBody?.max_output_tokens).toBe(128);
+		expect(capturedBody?.store).toBe(false);
 		expect(capturedBody?.stream).toBe(true);
 		expect(capturedBody?.tools).toEqual([
 			{
@@ -368,6 +370,8 @@ describe('openai-responses-bridge server', () => {
 			| undefined;
 		expect(messageStartMessage?.usage?.input_tokens).toBeGreaterThan(500);
 		expect(messageStartMessage?.usage?.input_tokens).toBeLessThan(1500);
+		expect(capturedBodies[0]?.store).toBe(false);
+		expect(capturedBodies[1]?.store).toBe(false);
 		expect(capturedBodies[1]?.previous_response_id).toBe('resp_tool');
 		expect(capturedBodies[1]?.input).toEqual([
 			{ type: 'function_call_output', call_id: 'call_abc', output: 'found' },
@@ -799,6 +803,7 @@ describe('openai-responses-bridge server', () => {
 	it('uses Codex ChatGPT OAuth endpoint and account header for OAuth auth', async () => {
 		let capturedUrl = '';
 		let capturedHeaders: Headers | undefined;
+		let capturedBody: Record<string, unknown> | undefined;
 		server = createOpenAIResponsesBridgeServer({
 			auth: {
 				source: 'chatgpt_oauth',
@@ -810,6 +815,7 @@ describe('openai-responses-bridge server', () => {
 			fetchImpl: async (url, init) => {
 				capturedUrl = String(url);
 				capturedHeaders = new Headers(init?.headers);
+				capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
 				return sse([
 					{
 						event: 'response.completed',
@@ -836,6 +842,8 @@ describe('openai-responses-bridge server', () => {
 		expect(capturedHeaders?.get('authorization')).toBe('Bearer oauth-token');
 		expect(capturedHeaders?.get('chatgpt-account-id')).toBe('acct_123');
 		expect(capturedHeaders?.get('x-openai-fedramp')).toBe('true');
+		expect(capturedBody?.store).toBe(false);
+		expect(capturedBody?.max_output_tokens).toBeUndefined();
 	});
 
 	it('refreshes ChatGPT OAuth auth once after an upstream 401 and reuses it', async () => {


### PR DESCRIPTION
## Summary

Fixes the direct OpenAI Responses bridge request body for ChatGPT OAuth-backed Codex sessions.

The ChatGPT Codex backend rejects persisted Responses calls, so the bridge now explicitly sends `store: false`. During live verification, the backend also rejected `max_output_tokens`; the bridge now omits that parameter for ChatGPT OAuth requests while preserving it for standard OpenAI API-key Responses calls.

## Root Cause

The merged Responses adapter was sending the default request shape from the Anthropic-compatible bridge without matching Codex's own non-Azure Responses client behavior. Codex sends `store: false`, and its ChatGPT Codex backend path does not include `max_output_tokens`.

## Validation

- `bun test packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts packages/daemon/tests/unit/1-core/providers/anthropic-to-codex-bridge-provider.test.ts`
- `bun run typecheck`
- `bun run lint`
- `git diff --check`
- Live ad-hoc daemon smoke with local Codex checkout on `PATH`, Responses adapter, `gpt-5.3-codex`, and two-turn conversation: `conversation_ok=true`