### PR TITLE
fix: skip previous_response_id continuation for ChatGPT OAuth endpoint

### DIFF
--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -859,7 +859,9 @@ export function createOpenAIResponsesBridgeServer(
 
 			const model = resolveModelId(body.model, config.modelAliases);
 			const sessionId = extractSessionId(req);
-			const resolvedContinuation = resolveContinuation(sessionId, body.messages, continuations);
+			const resolvedContinuation = isChatgptOAuth
+				? undefined
+				: resolveContinuation(sessionId, body.messages, continuations);
 			let continuation = resolvedContinuation;
 			const requestBody = buildResponsesRequest(body, model, continuation, buildOpts);
 			const upstreamUrl = `${baseUrl.replace(/\/$/, '')}/responses`;


### PR DESCRIPTION
The ChatGPT Codex endpoint never supports `previous_response_id`, so the retry fallback from #1720 was firing on every tool-result turn, producing a log warning each time.

Fix: skip `resolveContinuation` entirely when `isChatgptOAuth` so we always send full history upfront instead of attempting the optimisation and falling back.