### PR TITLE
Fix PR ready gate handoff validation

### DIFF
--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -2740,6 +2740,12 @@ export class TaskAgentManager {
 		const node = workflow.nodes.find((candidate) => candidate.id === execution.workflowNodeId);
 		if (!node) return [...aliases];
 
+		if (node.name) {
+			for (const variant of this.agentNameVariants(node.name)) {
+				aliases.add(variant);
+			}
+		}
+
 		const nodeAgents = resolveNodeAgents(node);
 		const slot =
 			nodeAgents.find((agent) => agent.name === execution.agentName) ??

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -250,8 +250,12 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 		getSpaceAutonomyLevel,
 	} = config;
 
+	const myNodeName = workflow
+		? (workflow.nodes.find((node) => node.id === workflowNodeId)?.name ?? myAgentName)
+		: myAgentName;
+
 	const agentNameAliases = new Set(
-		[myAgentName, ...(myAgentNameAliases ?? [])]
+		[myAgentName, myNodeName, ...(myAgentNameAliases ?? [])]
 			.map((value) => normalizeAgentNameToken(value))
 			.filter((value) => value.length > 0)
 	);

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -80,7 +80,7 @@ const PR_READY_BASH_SCRIPT = [
 	'fi',
 	'PR_STATUS=$(jq -r \'.mergeStateStatus\' <<< "$PR_JSON")',
 	'# Block on UNKNOWN — orchestrator retries until GitHub resolves status',
-	'if [ "$PR_STATUS" != "CLEAN" ] && [ "$PR_STATUS" != "HAS_HOOKS" ]; then',
+	'if [ "$PR_STATUS" != "CLEAN" ] && [ "$PR_STATUS" != "HAS_HOOKS" ] && [ "$PR_STATUS" != "BLOCKED" ]; then',
 	'  echo "PR merge checks not satisfied (mergeStateStatus: ${PR_STATUS:-unknown})" >&2',
 	'  exit 1',
 	'fi',

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -522,7 +522,7 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 				{
 					name: 'pr_url',
 					type: 'string',
-					writers: ['coder'],
+					writers: ['Coding'],
 					check: { op: 'exists' },
 				},
 			],
@@ -545,7 +545,7 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 				{
 					name: 'review_url',
 					type: 'string',
-					writers: ['reviewer'],
+					writers: ['Review'],
 					check: { op: 'exists' },
 				},
 			],
@@ -977,7 +977,7 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
 				{
 					name: 'approvals',
 					type: 'map',
-					writers: ['reviewer'],
+					writers: ['Plan Review'],
 					check: { op: 'count', match: 'approved', min: 4 },
 				},
 			],

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -48,6 +48,7 @@ const FULLSTACK_QA_NODE = 'tpl-fullstack-qa';
 const PR_READY_BASH_SCRIPT = [
 	'# Prefer explicit PR URL from gate data JSON when available; fallback to current branch.',
 	'PR_TARGET=$(jq -r \'.pr_url // empty\' <<< "${NEOKAI_GATE_DATA_JSON:-{}}" 2>/dev/null || true)',
+	'# When pr_url is supplied, validate that exact PR rather than rediscovering via branch filters.',
 	'if [ -n "$PR_TARGET" ]; then',
 	'  PR_VIEW_SCOPE="$PR_TARGET"',
 	'  if ! PR_JSON=$(gh pr view "$PR_TARGET" --json url,state,mergeable,mergeStateStatus) || [ -z "$PR_JSON" ]; then',
@@ -521,7 +522,7 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 				{
 					name: 'pr_url',
 					type: 'string',
-					writers: ['Coding'],
+					writers: ['coder'],
 					check: { op: 'exists' },
 				},
 			],

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -1306,8 +1306,19 @@ describe('node-agent-tools: send_message (gate-write)', () => {
 			spaceId: ctx.spaceId,
 			name: 'Test Workflow',
 			description: '',
-			nodes: [],
-			startNodeId: '',
+			nodes: [
+				{
+					id: ctx.nodeId,
+					name: 'Coding',
+					agents: [{ agentId: 'agent-coder', name: 'coder' }],
+				},
+				{
+					id: 'node-review',
+					name: 'Review',
+					agents: [{ agentId: 'agent-reviewer', name: 'reviewer' }],
+				},
+			],
+			startNodeId: ctx.nodeId,
 			rules: [],
 			tags: [],
 			channels: [{ id: 'ch-coder-reviewer', from: 'coder', to: 'reviewer', gateId: gate.id }],
@@ -1335,6 +1346,30 @@ describe('node-agent-tools: send_message (gate-write)', () => {
 		expect(data.gateWrite).toBeDefined();
 		expect(data.gateWrite.gateId).toBe('gate-writable');
 		expect(data.gateWrite.gateOpen).toBe(true);
+	});
+
+	test('gate-write authorizes fields whose writers reference the current node name', async () => {
+		const gate: Gate = {
+			id: 'gate-node-writer',
+			fields: [{ name: 'pr_url', type: 'string', writers: ['Coding'], check: { op: 'exists' } }],
+			resetOnCycle: false,
+		};
+		const workflow = makeWorkflowWithGatedChannel(gate);
+		const gateDataRepo = new GateDataRepository(ctx.db);
+		const config = makeConfig(ctx, { workflow, gateDataRepo });
+		const handlers = createNodeAgentToolHandlers(config);
+
+		const result = await handlers.send_message({
+			target: 'reviewer',
+			message: 'ready',
+			data: { pr_url: 'https://github.com/test/repo/pull/42' },
+		});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.gateWrite).toEqual({ gateId: 'gate-node-writer', gateOpen: true });
+		expect(gateDataRepo.get(ctx.workflowRunId, 'gate-node-writer')?.data.pr_url).toBe(
+			'https://github.com/test/repo/pull/42'
+		);
 	});
 
 	test('no gateWrite in response when data not provided', async () => {

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -218,6 +218,7 @@ describe('CODING_WORKFLOW template', () => {
 		expect(gate.script!.source).toContain('.mergeStateStatus');
 		expect(gate.script!.source).toContain('"CLEAN"');
 		expect(gate.script!.source).toContain('"HAS_HOOKS"');
+		expect(gate.script!.source).toContain('"BLOCKED"');
 		expect(gate.script!.source).toContain('exit 1');
 		expect(gate.script!.source).toContain('pr_url');
 		expect(gate.script!.source).toContain('not authenticated');
@@ -242,7 +243,7 @@ describe('CODING_WORKFLOW template', () => {
 					'#!/usr/bin/env bash',
 					`printf '%s\\n' "$*" >> ${JSON.stringify(logPath)}`,
 					`if [ "$1" = "pr" ] && [ "$2" = "view" ] && [ "$3" = ${JSON.stringify(prUrl)} ]; then`,
-					`  printf '%s\\n' '{"url":"${prUrl}","state":"OPEN","mergeable":"MERGEABLE","mergeStateStatus":"CLEAN"}'`,
+					`  printf '%s\\n' '{"url":"${prUrl}","state":"OPEN","mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED"}'`,
 					'  exit 0',
 					'fi',
 					'printf "unexpected gh args: %s\\n" "$*" >&2',

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -17,11 +17,15 @@
 
 import { Database as BunDatabase } from 'bun:sqlite';
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { SpaceAgent, SpaceWorkflow } from '@neokai/shared';
 import {
 	exportWorkflow,
 	validateExportedWorkflow,
 } from '../../../../src/lib/space/export-format.ts';
+import { executeGateScript } from '../../../../src/lib/space/runtime/gate-script-executor.ts';
 import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
 import {
 	CODING_WORKFLOW,
@@ -192,11 +196,11 @@ describe('CODING_WORKFLOW template', () => {
 		expect(gate.resetOnCycle).toBe(true);
 	});
 
-	test('code-ready-gate has pr_url field writable only by Coding', () => {
+	test('code-ready-gate has pr_url field writable by coder', () => {
 		const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'code-ready-gate')!;
 		const prField = gate.fields.find((f) => f.name === 'pr_url')!;
 		expect(prField.type).toBe('string');
-		expect(prField.writers).toEqual(['Coding']);
+		expect(prField.writers).toEqual(['coder']);
 		expect(prField.check.op).toBe('exists');
 	});
 
@@ -217,6 +221,55 @@ describe('CODING_WORKFLOW template', () => {
 		expect(gate.script!.source).toContain('exit 1');
 		expect(gate.script!.source).toContain('pr_url');
 		expect(gate.script!.source).toContain('not authenticated');
+		expect(gate.script!.source).not.toContain('gh pr list');
+		expect(gate.script!.source).not.toContain('--base dev');
+		expect(gate.script!.source).toContain('gh pr view "$PR_TARGET"');
+	});
+
+	test('code-ready-gate validates supplied pr_url without branch rediscovery', async () => {
+		const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'code-ready-gate')!;
+		const workspace = mkdtempSync(join(tmpdir(), 'neokai-pr-ready-gate-'));
+		const binDir = join(workspace, 'bin');
+		const ghPath = join(binDir, 'gh');
+		const logPath = join(workspace, 'gh-args.log');
+		const prUrl = 'https://github.com/test/repo/pull/42';
+
+		try {
+			mkdirSync(binDir);
+			writeFileSync(
+				ghPath,
+				[
+					'#!/usr/bin/env bash',
+					`printf '%s\\n' "$*" >> ${JSON.stringify(logPath)}`,
+					`if [ "$1" = "pr" ] && [ "$2" = "view" ] && [ "$3" = ${JSON.stringify(prUrl)} ]; then`,
+					`  printf '%s\\n' '{"url":"${prUrl}","state":"OPEN","mergeable":"MERGEABLE","mergeStateStatus":"CLEAN"}'`,
+					'  exit 0',
+					'fi',
+					'printf "unexpected gh args: %s\\n" "$*" >&2',
+					'exit 2',
+				].join('\n')
+			);
+			chmodSync(ghPath, 0o755);
+
+			const result = await executeGateScript(
+				gate.script!,
+				{
+					workspacePath: workspace,
+					gateId: 'code-ready-gate',
+					runId: 'run-1',
+					gateData: { pr_url: prUrl },
+				},
+				{ PATH: `${binDir}:${process.env.PATH ?? ''}` }
+			);
+
+			expect(result.success).toBe(true);
+			expect(result.data).toEqual({ pr_url: prUrl });
+			expect(readFileSync(logPath, 'utf8').trim()).toBe(
+				`pr view ${prUrl} --json url,state,mergeable,mergeStateStatus`
+			);
+		} finally {
+			rmSync(workspace, { recursive: true, force: true });
+		}
 	});
 
 	test('code-ready-gate resets on cycle', () => {

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -150,11 +150,11 @@ describe('CODING_WORKFLOW template', () => {
 		}
 	});
 
-	test('review-posted-gate has review_url field writable only by reviewer', () => {
+	test('review-posted-gate has review_url field writable only by Review node', () => {
 		const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
 		const field = gate.fields.find((f) => f.name === 'review_url')!;
 		expect(field.type).toBe('string');
-		expect(field.writers).toEqual(['reviewer']);
+		expect(field.writers).toEqual(['Review']);
 		expect(field.check.op).toBe('exists');
 	});
 
@@ -196,11 +196,11 @@ describe('CODING_WORKFLOW template', () => {
 		expect(gate.resetOnCycle).toBe(true);
 	});
 
-	test('code-ready-gate has pr_url field writable by coder', () => {
+	test('code-ready-gate has pr_url field writable by Coding node', () => {
 		const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'code-ready-gate')!;
 		const prField = gate.fields.find((f) => f.name === 'pr_url')!;
 		expect(prField.type).toBe('string');
-		expect(prField.writers).toEqual(['coder']);
+		expect(prField.writers).toEqual(['Coding']);
 		expect(prField.check.op).toBe('exists');
 	});
 
@@ -557,7 +557,7 @@ describe('PLAN_AND_DECOMPOSE_WORKFLOW template', () => {
 		expect(gate.fields[0].name).toBe('approvals');
 		expect(gate.fields[0].type).toBe('map');
 		expect(gate.fields[0].check).toMatchObject({ op: 'count', match: 'approved', min: 4 });
-		expect(gate.fields[0].writers).toContain('reviewer');
+		expect(gate.fields[0].writers).toEqual(['Plan Review']);
 		expect(gate.resetOnCycle).toBe(true);
 	});
 
@@ -1630,7 +1630,7 @@ describe('seedBuiltInWorkflows()', () => {
 		const gate = PLAN_AND_DECOMPOSE_WORKFLOW.gates!.find((g) => g.id === 'plan-approval-gate')!;
 		const approvalsField = gate.fields.find((f) => f.name === 'approvals')!;
 		expect(approvalsField.type).toBe('map');
-		expect(approvalsField.writers).toContain('reviewer');
+		expect(approvalsField.writers).toEqual(['Plan Review']);
 		expect(approvalsField.check).toMatchObject({ op: 'count', match: 'approved', min: 4 });
 	});
 
@@ -1642,7 +1642,7 @@ describe('seedBuiltInWorkflows()', () => {
 		const gate = wf.gates!.find((g) => g.id === 'plan-approval-gate')!;
 		const approvalsField = gate.fields.find((f) => f.name === 'approvals')!;
 		expect(approvalsField.type).toBe('map');
-		expect(approvalsField.writers).toContain('reviewer');
+		expect(approvalsField.writers).toEqual(['Plan Review']);
 		expect(approvalsField.check).toMatchObject({ op: 'count', match: 'approved', min: 4 });
 	});
 


### PR DESCRIPTION
Fixes the Coding → Review PR-ready gate so the coder can write the `pr_url` field and the gate validates the supplied PR URL directly instead of relying on branch-filter discovery.

Tests: `bun test packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts`; `bun test packages/daemon/tests/unit/5-space/other/gate-evaluator.test.ts packages/daemon/tests/unit/5-space/other/gate-script-executor.test.ts packages/daemon/tests/unit/5-space/workflow/workflow-executor.test.ts`; `bun run check`. Full `bun test` still hits unrelated web tests using Vitest helpers missing under Bun (`vi.mocked`, `vi.advanceTimersByTimeAsync`).