### PR TITLE
fix: don't store continuations for ChatGPT OAuth endpoint

### DIFF
--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -932,9 +932,13 @@ export function createOpenAIResponsesBridgeServer(
 						controller,
 						model,
 						estimatedInputTokens,
-						onFunctionCallResponse(callId, responseId) {
-							storeContinuation(sessionId, callId, responseId);
-						},
+						...(isChatgptOAuth
+							? {}
+							: {
+									onFunctionCallResponse(callId: string, responseId: string) {
+										storeContinuation(sessionId, callId, responseId);
+									},
+								}),
 					});
 				},
 			});


### PR DESCRIPTION
Follow-up to #1721.

`storeContinuation` was still being called via `onFunctionCallResponse` on every tool call even when `isChatgptOAuth`, causing entries to accumulate and only expire via TTL with warning spam (`continuation TTL expired`). Skip the callback entirely when continuations are disabled for the endpoint.