### PR TITLE
Fix ghost tool continuation rehydrate race

### DIFF
--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/server.ts
@@ -123,6 +123,8 @@ export function createAnthropicError(
 export const DEFAULT_TOOL_SESSION_TTL_MS = 5 * 60 * 1000;
 const MAX_SUBPROCESS_RETRIES = 1;
 const MAX_ORPHANED_TOOL_RESULT_409_RETRIES = 3;
+const TOOL_SESSION_REATTACH_WAIT_MS = 2_000;
+const TOOL_SESSION_REATTACH_POLL_MS = 25;
 
 // ---------------------------------------------------------------------------
 // Session state for tool-call round-trips
@@ -176,6 +178,59 @@ function estimateLastMessageInputTokens(body: AnthropicRequest): number {
 		model: body.model,
 		messages: [last],
 	});
+}
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function hasAnyToolSession(
+	toolSessions: Map<string, ToolSession>,
+	toolResults: ToolResult[]
+): boolean {
+	return toolResults.some((tr) => toolSessions.has(tr.toolUseId));
+}
+
+function hasRecoverableToolMapping(
+	recoveryRepo: ToolContinuationRecoveryRepository | null,
+	toolResults: ToolResult[],
+	sessionId: string
+): boolean {
+	if (!recoveryRepo) return false;
+	const now = Date.now();
+	return toolResults.some((tr) => {
+		const mapping = recoveryRepo.getToolUse(tr.toolUseId);
+		return (
+			!!mapping &&
+			mapping.sessionId === sessionId &&
+			(mapping.status === 'active' || mapping.status === 'waiting_rebind') &&
+			mapping.expiresAt >= now
+		);
+	});
+}
+
+async function waitForToolSessionReattach(params: {
+	toolSessions: Map<string, ToolSession>;
+	toolResults: ToolResult[];
+	recoveryRepo: ToolContinuationRecoveryRepository | null;
+	sessionId: string;
+	waitMs?: number;
+	pollMs?: number;
+}): Promise<boolean> {
+	if (hasAnyToolSession(params.toolSessions, params.toolResults)) return true;
+	if (!hasRecoverableToolMapping(params.recoveryRepo, params.toolResults, params.sessionId)) {
+		return false;
+	}
+
+	const deadline = Date.now() + (params.waitMs ?? TOOL_SESSION_REATTACH_WAIT_MS);
+	while (Date.now() < deadline) {
+		await delay(params.pollMs ?? TOOL_SESSION_REATTACH_POLL_MS);
+		if (hasAnyToolSession(params.toolSessions, params.toolResults)) return true;
+		if (!hasRecoverableToolMapping(params.recoveryRepo, params.toolResults, params.sessionId)) {
+			return false;
+		}
+	}
+	return hasAnyToolSession(params.toolSessions, params.toolResults);
 }
 
 function isSubprocessCrashMessage(message: string): boolean {
@@ -595,6 +650,19 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 				// All matched sessions have their Deferreds resolved. Unmatched tool_use_ids
 				// produce a warning and are skipped (not silently dropped).
 				let primaryStored: ToolSession | null = null;
+				const sessionId = extractSessionId(req);
+				const reattached = await waitForToolSessionReattach({
+					toolSessions,
+					toolResults,
+					recoveryRepo,
+					sessionId,
+				});
+				if (reattached) {
+					logger.info(
+						`codex-bridge: recovered delayed tool_use correlation for continuation ` +
+							`tool_use_ids=${toolResults.map((tr) => tr.toolUseId).join(',')}`
+					);
+				}
 
 				for (const tr of toolResults) {
 					const stored = toolSessions.get(tr.toolUseId);
@@ -619,7 +687,6 @@ export function createBridgeServer(config: BridgeServerConfig): BridgeServer {
 					logger.error(
 						`codex-bridge: no active sessions found for any tool_use_id in this continuation`
 					);
-					const sessionId = extractSessionId(req);
 					if (shouldCleanupOrphanedContinuation(sessionId, toolResults)) {
 						cleanupPersistentSession(sessionId, 'orphaned tool_result continuation');
 					}

--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -859,9 +859,7 @@ export function createOpenAIResponsesBridgeServer(
 
 			const model = resolveModelId(body.model, config.modelAliases);
 			const sessionId = extractSessionId(req);
-			const resolvedContinuation = isChatgptOAuth
-				? undefined
-				: resolveContinuation(sessionId, body.messages, continuations);
+			const resolvedContinuation = resolveContinuation(sessionId, body.messages, continuations);
 			let continuation = resolvedContinuation;
 			const requestBody = buildResponsesRequest(body, model, continuation, buildOpts);
 			const upstreamUrl = `${baseUrl.replace(/\/$/, '')}/responses`;

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -372,6 +372,7 @@ export class SpaceRuntime {
 	 */
 	setTaskAgentManager(manager: TaskAgentManager): void {
 		this.config.taskAgentManager = manager;
+		manager.attachToolContinuationRepo?.(this.toolContinuationRepo);
 	}
 
 	/**

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -69,6 +69,7 @@ import type { GateDataRepository } from '../../../storage/repositories/gate-data
 import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
 import type { ChannelCycleRepository } from '../../../storage/repositories/channel-cycle-repository';
 import type { PendingAgentMessageRepository } from '../../../storage/repositories/pending-agent-message-repository';
+import type { ToolContinuationRecoveryRepository } from '../../../storage/repositories/tool-continuation-recovery-repository';
 import type { SpaceWorktreeManager } from '../managers/space-worktree-manager';
 import type { SubSessionMemberInfo } from '../tools/task-agent-tools';
 import { createTaskAgentMcpServer } from '../tools/task-agent-tools';
@@ -176,6 +177,8 @@ export interface TaskAgentManagerConfig {
 	 * enqueue instead of failing when the target is declared but not yet active.
 	 */
 	pendingMessageRepo?: PendingAgentMessageRepository;
+	/** Durable recovery store for pending Codex tool_result continuations. */
+	toolContinuationRepo?: ToolContinuationRecoveryRepository;
 	/**
 	 * Callback to inject a message into the Space Agent chat session for a space.
 	 * Used for Task Agent → Space Agent escalation via `send_message`.
@@ -203,6 +206,10 @@ interface SpawnTaskAgentOptions {
 // ---------------------------------------------------------------------------
 
 export class TaskAgentManager {
+	attachToolContinuationRepo(repo: ToolContinuationRecoveryRepository): void {
+		this.config.toolContinuationRepo = repo;
+	}
+
 	/**
 	 * Maps taskId → AgentSession for active Task Agent sessions.
 	 * One entry per task while the Task Agent is running.
@@ -3279,6 +3286,22 @@ export class TaskAgentManager {
 		agentSession.onMissingWorkflowMcpServers = async (cbSessionId: string, missing: string[]) => {
 			await this.mcpSelfHeal(cbSessionId, missing);
 		};
+
+		// Rehydration must publish the AgentSession in every runtime map before any
+		// continuation replay can run. Starting the SDK query is intentionally last:
+		// a pending Anthropic tool_result retry may arrive while this method is still
+		// restoring MCP/runtime state, and the Codex bridge now waits for the live
+		// tool_use correlation map instead of treating that transient window as an
+		// unrecoverable orphan.
+		const pendingToolContinuations =
+			this.config.toolContinuationRepo?.listPendingInboxForSession(subSessionId) ?? [];
+		if (pendingToolContinuations.length > 0) {
+			log.warn(
+				`TaskAgentManager.rehydrateSubSession: session ${subSessionId} has ` +
+					`${pendingToolContinuations.length} queued tool_result continuation(s); ` +
+					`starting query only after runtime provisioning is complete`
+			);
+		}
 
 		// --- Restart the streaming query (idempotent if already running)
 		await agentSession.startStreamingQuery();

--- a/packages/daemon/src/storage/repositories/tool-continuation-recovery-repository.ts
+++ b/packages/daemon/src/storage/repositories/tool-continuation-recovery-repository.ts
@@ -284,6 +284,18 @@ export class ToolContinuationRecoveryRepository {
 		return rows.map((row) => this.rowToInbox(row));
 	}
 
+	listPendingInboxForSession(sessionId: string): ContinuationInboxRecord[] {
+		const now = Date.now();
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM tool_continuation_inbox
+				 WHERE session_id = ? AND status = 'pending' AND expires_at >= ?
+				 ORDER BY created_at ASC, id ASC`
+			)
+			.all(sessionId, now) as Record<string, unknown>[];
+		return rows.map((row) => this.rowToInbox(row));
+	}
+
 	hasActiveToolUseForExecution(executionId: string, graceMs = 0): boolean {
 		const now = Date.now();
 		const row = this.db

--- a/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/server.test.ts
@@ -15,6 +15,10 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import {
 	createBridgeServer,
 	createAnthropicError,
@@ -28,6 +32,7 @@ import {
 	type BridgeEvent,
 } from '../../../../../src/lib/providers/codex-anthropic-bridge/process-manager';
 import { Logger } from '../../../../../src/lib/logger';
+import { ToolContinuationRecoveryRepository } from '../../../../../src/storage/repositories/tool-continuation-recovery-repository';
 
 // ---------------------------------------------------------------------------
 // Helper: parse SSE response body into an array of events
@@ -1835,6 +1840,118 @@ describe('tool_choice warning — codex bridge', () => {
 		await readSSEEvents(nextResp.body);
 		expect(connCreateSpy).toHaveBeenCalledTimes(1);
 		expect(startTurnSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it('waits for delayed tool_use map restore before accepting a continuation', async () => {
+		server.stop();
+		const tempDir = mkdtempSync(join(tmpdir(), 'neokai-bridge-rehydrate-'));
+		const dbPath = join(tempDir, 'bridge.sqlite');
+		const db = new Database(dbPath);
+		try {
+			db.exec(`
+				CREATE TABLE node_executions (
+					id TEXT PRIMARY KEY,
+					workflow_run_id TEXT NOT NULL,
+					agent_session_id TEXT,
+					status TEXT NOT NULL,
+					updated_at INTEGER NOT NULL,
+					created_at INTEGER NOT NULL
+				)
+			`);
+			db.prepare(
+				`INSERT INTO node_executions
+				 (id, workflow_run_id, agent_session_id, status, updated_at, created_at)
+				 VALUES ('exec-delayed-map', 'run-delayed-map', 'delayed-map', 'in_progress', ?, ?)`
+			).run(Date.now(), Date.now());
+			const repo = new ToolContinuationRecoveryRepository(db as never);
+			repo.ensureSchema();
+			repo.recordToolUse({
+				toolUseId: 'call_delayed_restore',
+				sessionId: 'delayed-map',
+				ttlMs: 60_000,
+			});
+		} finally {
+			db.close();
+		}
+
+		let releaseToolCall!: () => void;
+		const toolCallRelease = new Promise<void>((resolve) => {
+			releaseToolCall = resolve;
+		});
+		let provideResultText: string | null = null;
+		startTurnSpy.mockImplementation(async function* (): AsyncGenerator<BridgeEvent> {
+			await toolCallRelease;
+			yield {
+				type: 'tool_call',
+				callId: 'call_delayed_restore',
+				toolName: 'test_tool',
+				toolInput: { value: true },
+				provideResult: (text: string) => {
+					provideResultText = text;
+				},
+			};
+			yield { type: 'turn_done', inputTokens: 1, outputTokens: 1 };
+		});
+
+		server = createBridgeServer({
+			codexBinaryPath: '/fake/codex',
+			cwd: '/tmp',
+			dbPath,
+		}) as BridgeServer & { port: number };
+
+		const headers = {
+			'Content-Type': 'application/json',
+			Authorization: 'Bearer codex-bridge-delayed-map',
+		};
+		const firstRespPromise = fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [{ role: 'user', content: 'call a tool' }],
+				tools: [{ name: 'test_tool', input_schema: { type: 'object' } }],
+				stream: true,
+			}),
+		});
+
+		const continuationPromise = fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify({
+				model: 'codex-1',
+				messages: [
+					{
+						role: 'assistant',
+						content: [
+							{ type: 'tool_use', id: 'call_delayed_restore', name: 'test_tool', input: {} },
+						],
+					},
+					{
+						role: 'user',
+						content: [
+							{
+								type: 'tool_result',
+								tool_use_id: 'call_delayed_restore',
+								content: 'delayed output',
+							},
+						],
+					},
+				],
+				stream: true,
+			}),
+		});
+
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		releaseToolCall();
+		const firstResp = await firstRespPromise;
+		expect(firstResp.ok).toBe(true);
+		await readSSEEvents(firstResp.body);
+
+		const continuationResp = await continuationPromise;
+		expect(continuationResp.ok).toBe(true);
+		await readSSEEvents(continuationResp.body);
+		expect(provideResultText).toBe('delayed output');
+		rmSync(tempDir, { recursive: true, force: true });
 	});
 
 	it('retries a new turn once when the subprocess crashes before output', async () => {

--- a/packages/daemon/tests/unit/4-space-storage/storage/tool-continuation-recovery-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/tool-continuation-recovery-repository.test.ts
@@ -133,6 +133,32 @@ describe('ToolContinuationRecoveryRepository', () => {
 		expect(updated.result).toBeNull();
 	});
 
+	it('lists pending continuations by session during ghost sub-session rehydrate', () => {
+		const { execution } = seedExecution('session-rehydrate');
+		const repo = new ToolContinuationRecoveryRepository(db as any);
+		repo.ensureSchema();
+		repo.recordToolUse({
+			toolUseId: 'tool-rehydrate',
+			sessionId: 'session-rehydrate',
+			ttlMs: 60_000,
+		});
+		repo.queueContinuation({
+			toolUseId: 'tool-rehydrate',
+			sessionId: 'session-rehydrate',
+			requestBody: { messages: [{ role: 'user', content: [] }] },
+			reason: 'continuation arrived while sub-session was rehydrating',
+			ttlMs: 60_000,
+		});
+
+		const bySession = repo.listPendingInboxForSession('session-rehydrate');
+		const byExecution = repo.listPendingInboxForExecution(execution.id);
+
+		expect(bySession).toHaveLength(1);
+		expect(bySession[0].toolUseId).toBe('tool-rehydrate');
+		expect(bySession[0].executionId).toBe(execution.id);
+		expect(bySession[0].id).toBe(byExecution[0].id);
+	});
+
 	it('moves expired mappings to waiting_rebind for TTL cleanup races', () => {
 		const { execution } = seedExecution('session-d');
 		const repo = new ToolContinuationRecoveryRepository(db as any);


### PR DESCRIPTION
Fixes the ghost sub-session continuation race where a restarted workflow could rehydrate the node session while a persisted `tool_result` retry arrived before the Codex bridge had restored its in-memory `tool_use` map.

Root cause: the bridge treated an empty live tool-session map as authoritative even when durable recovery still showed an active/waiting mapping for the same session. That ordering window produced orphaned `tool_result` diagnostics and repeated 409 retries instead of waiting for rehydrate/startup to republish the correlation.

Changes:
- Wait briefly for recoverable `tool_use` mappings to reattach before classifying a continuation as orphaned.
- Surface queued continuations during sub-session rehydrate and wire the shared recovery repo into TaskAgentManager.
- Add regression coverage for delayed map restore and session-scoped pending continuation lookup.

Tests:
- `bun run lint`
- `bun run typecheck`
- `bun test packages/daemon/tests/unit/4-space-storage/storage/tool-continuation-recovery-repository.test.ts packages/daemon/tests/unit/1-core/providers/codex-anthropic-bridge/server.test.ts`