### PR TITLE
[codex] Fix Codex context window display

### DIFF
--- a/packages/daemon/src/lib/agent/context-fetcher.ts
+++ b/packages/daemon/src/lib/agent/context-fetcher.ts
@@ -23,7 +23,10 @@ import type {
 } from '@neokai/shared';
 import { Logger } from '../logger';
 
-type ContextMetadata = Pick<ModelInfo, 'id' | 'provider' | 'contextWindow'> | null | undefined;
+type ContextMetadata =
+	| Pick<ModelInfo, 'id' | 'contextWindow' | 'preferContextWindowMetadata'>
+	| null
+	| undefined;
 
 function positiveInteger(value: unknown): number | undefined {
 	return typeof value === 'number' && Number.isFinite(value) && value > 0
@@ -80,13 +83,12 @@ export class ContextFetcher {
 		const sdkRawCapacity = positiveInteger(response.rawMaxTokens);
 		const sdkCapacity = positiveInteger(response.maxTokens);
 		const responseModel = response.model || undefined;
-		const isCodexBridgeModel = modelMetadata?.provider === 'anthropic-codex';
 		const metadataCapacity =
 			!responseModel || modelMetadata?.id === responseModel
 				? positiveInteger(modelMetadata?.contextWindow)
 				: undefined;
 		const capacity =
-			isCodexBridgeModel && metadataCapacity
+			modelMetadata?.preferContextWindowMetadata && metadataCapacity
 				? metadataCapacity
 				: (sdkRawCapacity ?? sdkCapacity ?? metadataCapacity ?? 0);
 		for (const category of response.categories ?? []) {

--- a/packages/daemon/src/lib/agent/context-fetcher.ts
+++ b/packages/daemon/src/lib/agent/context-fetcher.ts
@@ -80,11 +80,15 @@ export class ContextFetcher {
 		const sdkRawCapacity = positiveInteger(response.rawMaxTokens);
 		const sdkCapacity = positiveInteger(response.maxTokens);
 		const responseModel = response.model || undefined;
+		const isCodexBridgeModel = modelMetadata?.provider === 'anthropic-codex';
 		const metadataCapacity =
 			!responseModel || modelMetadata?.id === responseModel
 				? positiveInteger(modelMetadata?.contextWindow)
 				: undefined;
-		const capacity = sdkRawCapacity ?? sdkCapacity ?? metadataCapacity ?? 0;
+		const capacity =
+			isCodexBridgeModel && metadataCapacity
+				? metadataCapacity
+				: (sdkRawCapacity ?? sdkCapacity ?? metadataCapacity ?? 0);
 		for (const category of response.categories ?? []) {
 			// Compute percent relative to capacity (SDK response doesn't carry it).
 			// Round to 1 decimal place to match the display the UI already expects.

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/model-context-windows.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/model-context-windows.ts
@@ -91,6 +91,7 @@ export function getCodexBridgeModelInfos(): ModelInfo[] {
 			family: 'gpt',
 			provider: 'anthropic-codex',
 			contextWindow: MODEL_CONTEXT_WINDOWS[id],
+			preferContextWindowMetadata: true,
 			description: details.description,
 			releaseDate: details.releaseDate,
 			available: true,

--- a/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
@@ -166,6 +166,30 @@ describe('ContextFetcher.toContextInfo', () => {
 		expect(info.autoCompactThreshold).toBe(244800);
 	});
 
+	it('uses Codex model metadata when SDK reports the generic 200k capacity', () => {
+		const response = baseResponse({
+			totalTokens: 136000,
+			maxTokens: 200000,
+			rawMaxTokens: 200000,
+			percentage: 68,
+			model: 'gpt-5.5',
+			autoCompactThreshold: 180000,
+			isAutoCompactEnabled: true,
+			categories: [{ name: 'Messages', tokens: 136000, color: 'blue' }],
+		});
+
+		const info = ContextFetcher.toContextInfo(response, {
+			id: 'gpt-5.5',
+			provider: 'anthropic-codex',
+			contextWindow: 272000,
+		});
+
+		expect(info.totalCapacity).toBe(272000);
+		expect(info.percentUsed).toBe(50);
+		expect(info.breakdown.Messages).toEqual({ tokens: 136000, percent: 50 });
+		expect(info.autoCompactThreshold).toBe(244800);
+	});
+
 	it('prefers SDK capacity over session metadata for fallback model usage', () => {
 		const response = baseResponse({
 			totalTokens: 64000,

--- a/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
@@ -180,8 +180,8 @@ describe('ContextFetcher.toContextInfo', () => {
 
 		const info = ContextFetcher.toContextInfo(response, {
 			id: 'gpt-5.5',
-			provider: 'anthropic-codex',
 			contextWindow: 272000,
+			preferContextWindowMetadata: true,
 		});
 
 		expect(info.totalCapacity).toBe(272000);
@@ -204,8 +204,8 @@ describe('ContextFetcher.toContextInfo', () => {
 
 		const info = ContextFetcher.toContextInfo(response, {
 			id: 'gpt-5.5',
-			provider: 'anthropic-codex',
 			contextWindow: 272000,
+			preferContextWindowMetadata: true,
 		});
 
 		expect(info.totalCapacity).toBe(128000);
@@ -228,7 +228,6 @@ describe('ContextFetcher.toContextInfo', () => {
 
 		const info = ContextFetcher.toContextInfo(response, {
 			id: 'gpt-5.5',
-			provider: 'anthropic-codex',
 			contextWindow: 272000,
 		});
 
@@ -252,7 +251,6 @@ describe('ContextFetcher.toContextInfo', () => {
 
 		const info = ContextFetcher.toContextInfo(response, {
 			id: 'gpt-5.5',
-			provider: 'anthropic-codex',
 			contextWindow: 272000,
 		});
 
@@ -361,7 +359,6 @@ describe('ContextFetcher.fetch', () => {
 		const fetcher = new ContextFetcher('test-session');
 		const info = await fetcher.fetch(query, {
 			id: 'gpt-5.5',
-			provider: 'anthropic-codex',
 			contextWindow: 272000,
 		});
 

--- a/packages/daemon/tests/unit/1-core/core/model-service.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/model-service.test.ts
@@ -196,6 +196,7 @@ describe('Model Service', () => {
 			expect(model).not.toBeNull();
 			expect(model?.provider).toBe('anthropic-codex');
 			expect(model?.contextWindow).toBe(272000);
+			expect(model?.preferContextWindowMetadata).toBe(true);
 		});
 
 		it('should resolve Codex aliases from static metadata', async () => {

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -27,6 +27,8 @@ export interface ModelInfo {
 	provider: string;
 	/** Context window size in tokens */
 	contextWindow: number;
+	/** Prefer this metadata value over SDK-reported context capacity for matching models */
+	preferContextWindowMetadata?: boolean;
 	/** Brief description of the model */
 	description: string;
 	/** Release date */


### PR DESCRIPTION
## Summary

Fixes the context usage capacity shown for Codex provider models such as `gpt-5.5` and `gpt-5.3-codex`.

## Root Cause

The Claude Agent SDK reports a generic `200000` context window for these non-Claude model IDs through `getContextUsage()`. NeoKai had correct Codex model metadata (`272000`), but `ContextFetcher` preferred the SDK capacity whenever it was positive, so the UI kept displaying `200000`.

## Changes

- Treat `anthropic-codex` model metadata as authoritative when it matches the SDK-reported active model.
- Keep SDK capacity for fallback/different active model cases.
- Add a regression test covering the SDK `200000` fallback for `gpt-5.5` with Codex metadata `272000`.

## Validation

- `bun test packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts`
- Pre-commit checks: `oxlint`, `biome format`, `tsc --build --noEmit`, `knip --include files,dependencies,exports --no-config-hints`