### PR TITLE
Fix Responses bridge SSE controller double-close

### DIFF
--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -575,6 +575,14 @@ function functionCallFromEvent(event: OpenAIStreamEvent): PendingFunctionCall | 
 	return null;
 }
 
+function isControllerInvalidStateError(err: unknown): boolean {
+	return (
+		err instanceof TypeError &&
+		((err as { code?: string }).code === 'ERR_INVALID_STATE' ||
+			err.message.includes('Controller is already closed'))
+	);
+}
+
 async function streamResponsesToAnthropic({
 	openAIResponse,
 	controller,
@@ -589,7 +597,31 @@ async function streamResponsesToAnthropic({
 	onFunctionCallResponse?: (callId: string, responseId: string) => void;
 }): Promise<void> {
 	const enc = new TextEncoder();
-	const send = (chunk: string) => controller.enqueue(enc.encode(chunk));
+	let closed = false;
+	const send = (chunk: string): boolean => {
+		if (closed) return false;
+		try {
+			controller.enqueue(enc.encode(chunk));
+			return true;
+		} catch (err) {
+			if (isControllerInvalidStateError(err)) {
+				closed = true;
+				logger.warn('openai-responses: SSE controller was already closed while sending');
+				return false;
+			}
+			throw err;
+		}
+	};
+	const closeController = (): void => {
+		if (closed) return;
+		closed = true;
+		try {
+			controller.close();
+		} catch (err) {
+			if (!isControllerInvalidStateError(err)) throw err;
+			logger.warn('openai-responses: SSE controller was already closed while closing');
+		}
+	};
 	const messageId = generateMsgId();
 	let started = false;
 	let textOpen = false;
@@ -599,26 +631,28 @@ async function streamResponsesToAnthropic({
 	let incomplete = false;
 	const emittedFunctionCalls = new Set<string>();
 
-	const ensureStarted = () => {
-		if (started) return;
+	const ensureStarted = (): boolean => {
+		if (started) return !closed;
 		started = true;
-		send(messageStartSSE(messageId, model, estimatedInputTokens, getModelContextWindow(model)));
+		return send(
+			messageStartSSE(messageId, model, estimatedInputTokens, getModelContextWindow(model))
+		);
 	};
 
 	const closeTextBlock = () => {
 		if (!textOpen) return;
-		send(contentBlockStopSSE(blockIndex));
+		if (!send(contentBlockStopSSE(blockIndex))) return;
 		blockIndex++;
 		textOpen = false;
 	};
 
 	const emitFunctionCall = (call: PendingFunctionCall) => {
 		if (emittedFunctionCalls.has(call.callId)) return;
-		ensureStarted();
+		if (!ensureStarted()) return;
 		closeTextBlock();
-		send(contentBlockStartToolUseSSE(blockIndex, call.callId, call.name));
-		send(inputJsonDeltaSSE(blockIndex, call.argumentsText || '{}'));
-		send(contentBlockStopSSE(blockIndex));
+		if (!send(contentBlockStartToolUseSSE(blockIndex, call.callId, call.name))) return;
+		if (!send(inputJsonDeltaSSE(blockIndex, call.argumentsText || '{}'))) return;
+		if (!send(contentBlockStopSSE(blockIndex))) return;
 		blockIndex++;
 		emittedFunctionCalls.add(call.callId);
 	};
@@ -690,7 +724,7 @@ async function streamResponsesToAnthropic({
 				closeTextBlock();
 				send(errorSSE('api_error', streamErrorMessage(event)));
 				send(messageStopSSE());
-				controller.close();
+				closeController();
 				return;
 			}
 		}
@@ -709,8 +743,13 @@ async function streamResponsesToAnthropic({
 			})
 		);
 		send(messageStopSSE());
-		controller.close();
+		closeController();
 	} catch (err) {
+		if (isControllerInvalidStateError(err)) {
+			closed = true;
+			logger.warn('openai-responses: SSE controller closed during streaming');
+			return;
+		}
 		logger.error('openai-responses: streaming failed:', err);
 		try {
 			ensureStarted();
@@ -718,10 +757,14 @@ async function streamResponsesToAnthropic({
 			send(errorSSE('api_error', err instanceof Error ? err.message : 'OpenAI streaming failed'));
 			send(messageStopSSE());
 		} finally {
-			controller.close();
+			closeController();
 		}
 	}
 }
+
+export const _openAIResponsesBridgeServerTesting = {
+	streamResponsesToAnthropic,
+};
 
 function modelsListResponse(models: OpenAIResponsesBridgeModel[]): object {
 	const data = models.map((model) => {
@@ -927,6 +970,8 @@ export function createOpenAIResponsesBridgeServer(
 				: estimateAnthropicInputTokens(body);
 			const stream = new ReadableStream<Uint8Array>({
 				start(controller) {
+					// Each HTTP request creates its own ReadableStream controller. SDK-level retries issue
+					// a new /v1/messages request, so a timed-out request cannot reuse an aborted controller.
 					void streamResponsesToAnthropic({
 						openAIResponse,
 						controller,

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'bun:test';
 import {
+	_openAIResponsesBridgeServerTesting,
 	anthropicMessagesToResponsesInput,
 	createOpenAIResponsesBridgeServer,
 	type OpenAIResponsesBridgeServer,
@@ -905,6 +906,120 @@ describe('openai-responses-bridge server', () => {
 			'Bearer fresh-token:acct_new',
 			'Bearer fresh-token:acct_new',
 		]);
+	});
+
+	it('uses a fresh stream controller for SDK retry requests', async () => {
+		let upstreamRequests = 0;
+		server = createOpenAIResponsesBridgeServer({
+			auth: { source: 'api_key', apiKey: 'sk-test' },
+			models,
+			fetchImpl: async () => {
+				upstreamRequests += 1;
+				return sse([
+					{
+						event: 'response.output_text.delta',
+						data: { type: 'response.output_text.delta', delta: `try-${upstreamRequests}` },
+					},
+					{
+						event: 'response.completed',
+						data: {
+							type: 'response.completed',
+							response: { usage: { input_tokens: 1, output_tokens: 1 }, output: [] },
+						},
+					},
+				]);
+			},
+		});
+
+		const request = {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [{ role: 'user', content: 'hi' }],
+			}),
+		};
+
+		const firstResp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, request);
+		const firstReader = firstResp.body?.getReader();
+		expect(firstReader).toBeDefined();
+		await firstReader?.read();
+		await firstReader?.cancel('simulate startup timeout abort before SDK retry');
+
+		const retryResp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, request);
+		const retryEvents = await readSSEEvents(retryResp.body);
+
+		expect(firstResp.status).toBe(200);
+		expect(retryResp.status).toBe(200);
+		expect(upstreamRequests).toBe(2);
+		expect(textDeltaEvents(retryEvents).join('')).toBe('try-2');
+		expect(messageDeltaEvent(retryEvents)).toMatchObject({
+			type: 'message_delta',
+			delta: { stop_reason: 'end_turn' },
+		});
+	});
+
+	it('does not throw when the SSE stream controller is already closed', async () => {
+		let capturedController: ReadableStreamDefaultController<Uint8Array> | undefined;
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				capturedController = controller;
+				controller.close();
+			},
+		});
+		await new Response(stream).arrayBuffer();
+		expect(capturedController).toBeDefined();
+
+		await expect(
+			_openAIResponsesBridgeServerTesting.streamResponsesToAnthropic({
+				openAIResponse: sse([
+					{
+						event: 'response.output_text.delta',
+						data: { type: 'response.output_text.delta', delta: 'late' },
+					},
+				]),
+				controller: capturedController as ReadableStreamDefaultController<Uint8Array>,
+				model: 'gpt-5.3-codex',
+				estimatedInputTokens: 1,
+			})
+		).resolves.toBeUndefined();
+	});
+
+	it('closes cleanly when the OpenAI stream errors after starting', async () => {
+		const openAIStream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				const encoder = new TextEncoder();
+				controller.enqueue(
+					encoder.encode(
+						`event: response.output_text.delta\ndata: ${JSON.stringify({
+							type: 'response.output_text.delta',
+							delta: 'hello',
+						})}\n\n`
+					)
+				);
+				setTimeout(() => controller.error(new Error('upstream exploded')), 0);
+			},
+		});
+		const anthropicStream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				void _openAIResponsesBridgeServerTesting.streamResponsesToAnthropic({
+					openAIResponse: new Response(openAIStream),
+					controller,
+					model: 'gpt-5.3-codex',
+					estimatedInputTokens: 1,
+				});
+			},
+		});
+
+		const events = await readSSEEvents(anthropicStream);
+
+		expect(textDeltaEvents(events).join('')).toBe('hello');
+		expect(events.find((event) => event.event === 'error')?.data).toMatchObject({
+			type: 'error',
+			error: { type: 'api_error' },
+		});
+		expect(events.at(-1)?.event).toBe('message_stop');
 	});
 
 	it('propagates the original 401 when ChatGPT OAuth refresh is unavailable', async () => {


### PR DESCRIPTION
Fixes the openai-responses-bridge crash when a client aborts a stream and later upstream events still try to write to the same SSE controller.

Root cause: the first close comes from Bun closing the ReadableStream controller after the client aborts (for example during the SDK startup-timeout retry). The still-running OpenAI stream loop then calls ensureStarted/emitFunctionCall or its final close path, causing ERR_INVALID_STATE to escape and terminate the daemon. Each SDK retry already creates a fresh HTTP request and stream controller; the fix makes the abandoned stream lifecycle idempotent by tracking closed state and swallowing controller invalid-state errors during send/close.

Tests cover retry requests using fresh controllers, already-closed controller handling, and upstream stream errors after output has started.