### PR TITLE
fix: refresh reviewer prompts after restart

### DIFF
--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -47,6 +47,7 @@ import type {
 	MessageHub,
 	McpServerConfig,
 	MessageOrigin,
+	WorkflowNodeAgent,
 } from '@neokai/shared';
 import type { AppMcpLifecycleManager } from '../../mcp/app-mcp-lifecycle-manager';
 import type { SkillsManager } from '../../skills-manager';
@@ -921,29 +922,7 @@ export class TaskAgentManager {
 				}
 			}
 
-			// Resolve customPrompt from the slot. Support legacy JSON blobs that may still
-			// have the old `systemPrompt`/`instructions` shape from before migration 79.
-			let slotCustomPrompt: string | undefined = slot.customPrompt?.value;
-			if (!slotCustomPrompt) {
-				// Backward compat: combine legacy systemPrompt + instructions into a single string.
-				const legacySlot = slot as {
-					systemPrompt?: { value: string };
-					instructions?: { value: string };
-				};
-				const legacySp = legacySlot.systemPrompt?.value?.trim() ?? '';
-				const legacyInstr = legacySlot.instructions?.value?.trim() ?? '';
-				if (legacySp && legacyInstr) {
-					slotCustomPrompt = `${legacySp}\n\n${legacyInstr}`;
-				} else {
-					slotCustomPrompt = legacySp || legacyInstr || undefined;
-				}
-			}
-			const slotOverrides: SlotOverrides = {
-				model: slot.model,
-				customPrompt: slotCustomPrompt,
-				disabledSkillIds: slot.disabledSkillIds,
-				extraMcpServers: slot.extraMcpServers,
-			};
+			const slotOverrides = this.buildSlotOverrides(slot);
 
 			let init = resolveAgentInit({
 				task,
@@ -3232,6 +3211,26 @@ export class TaskAgentManager {
 		// --- Determine workspace path
 		const workspacePath = this.taskWorktreePaths.get(taskId) ?? space.workspacePath;
 
+		// --- Resolve the current workflow-slot prompt before restarting the SDK.
+		// AgentSession.restore() intentionally keeps persisted DB config as-is; without
+		// re-applying the current workflow/agent prompt here, a node agent that already
+		// existed before a daemon restart would resume with stale instructions. This
+		// shows up most visibly for Reviewer agents after built-in workflow prompt
+		// updates: the spawn path uses the new slot prompt, while the rehydrate path
+		// used to keep the old persisted prompt until the session was recreated.
+		const currentInit = this.resolveCurrentNodeAgentInitForExecution({
+			task: parentTask,
+			space,
+			workflow,
+			workflowRun,
+			execution,
+			sessionId: subSessionId,
+			workspacePath,
+		});
+		if (currentInit.systemPrompt) {
+			agentSession.setRuntimeSystemPrompt(currentInit.systemPrompt);
+		}
+
 		// --- Re-build and attach node-agent MCP server (runtime-only, not persisted)
 		const nodeAgentMcpServer = this.buildNodeAgentMcpServerForSession(
 			taskId,
@@ -3327,8 +3326,74 @@ export class TaskAgentManager {
 			`TaskAgentManager.rehydrateSubSession: rehydrated sub-session ${subSessionId} for task ${taskId} (node ${execution.workflowNodeId})`
 		);
 
-		void workflow; // Loaded for context but not needed directly; suppresses unused-var lint.
 		return agentSession;
+	}
+
+	private buildSlotOverrides(slot: WorkflowNodeAgent): SlotOverrides {
+		// Resolve customPrompt from the slot. Support legacy JSON blobs that may still
+		// have the old `systemPrompt`/`instructions` shape from before migration 79.
+		let slotCustomPrompt: string | undefined = slot.customPrompt?.value;
+		if (!slotCustomPrompt) {
+			// Backward compat: combine legacy systemPrompt + instructions into a single string.
+			const legacySlot = slot as {
+				systemPrompt?: { value: string };
+				instructions?: { value: string };
+			};
+			const legacySp = legacySlot.systemPrompt?.value?.trim() ?? '';
+			const legacyInstr = legacySlot.instructions?.value?.trim() ?? '';
+			if (legacySp && legacyInstr) {
+				slotCustomPrompt = `${legacySp}\n\n${legacyInstr}`;
+			} else {
+				slotCustomPrompt = legacySp || legacyInstr || undefined;
+			}
+		}
+		return {
+			model: slot.model,
+			customPrompt: slotCustomPrompt,
+			disabledSkillIds: slot.disabledSkillIds,
+			extraMcpServers: slot.extraMcpServers,
+		};
+	}
+
+	private resolveCurrentNodeAgentInitForExecution(args: {
+		task: SpaceTask;
+		space: Space;
+		workflow: SpaceWorkflow | null;
+		workflowRun: SpaceWorkflowRun | null;
+		execution: NodeExecution;
+		sessionId: string;
+		workspacePath: string;
+	}): AgentSessionInit {
+		const { task, space, workflow, workflowRun, execution, sessionId, workspacePath } = args;
+		const node = workflow?.nodes.find((candidate) => candidate.id === execution.workflowNodeId);
+		if (!node) {
+			throw new Error(
+				`Workflow node "${execution.workflowNodeId}" not found while rehydrating agent session "${sessionId}"`
+			);
+		}
+
+		const nodeAgents = resolveNodeAgents(node);
+		const slot =
+			nodeAgents.length === 1
+				? nodeAgents[0]
+				: nodeAgents.find((agentSlot) => agentSlot.name === execution.agentName);
+		if (!slot?.agentId) {
+			throw new Error(
+				`No agent slot found for agent name "${execution.agentName}" in node "${execution.workflowNodeId}"`
+			);
+		}
+
+		return resolveAgentInit({
+			task,
+			space,
+			agentManager: this.config.spaceAgentManager,
+			sessionId,
+			workspacePath,
+			workflowRun,
+			workflow,
+			slotOverrides: this.buildSlotOverrides(slot),
+			agentId: slot.agentId,
+		});
 	}
 
 	/**

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -3227,7 +3227,7 @@ export class TaskAgentManager {
 			sessionId: subSessionId,
 			workspacePath,
 		});
-		if (currentInit.systemPrompt) {
+		if (currentInit?.systemPrompt) {
 			agentSession.setRuntimeSystemPrompt(currentInit.systemPrompt);
 		}
 
@@ -3363,13 +3363,15 @@ export class TaskAgentManager {
 		execution: NodeExecution;
 		sessionId: string;
 		workspacePath: string;
-	}): AgentSessionInit {
+	}): AgentSessionInit | null {
 		const { task, space, workflow, workflowRun, execution, sessionId, workspacePath } = args;
 		const node = workflow?.nodes.find((candidate) => candidate.id === execution.workflowNodeId);
 		if (!node) {
-			throw new Error(
-				`Workflow node "${execution.workflowNodeId}" not found while rehydrating agent session "${sessionId}"`
+			log.warn(
+				`TaskAgentManager.rehydrateSubSession: workflow node ${execution.workflowNodeId} ` +
+					`not found for session ${sessionId}; keeping persisted system prompt`
 			);
+			return null;
 		}
 
 		const nodeAgents = resolveNodeAgents(node);
@@ -3378,9 +3380,11 @@ export class TaskAgentManager {
 				? nodeAgents[0]
 				: nodeAgents.find((agentSlot) => agentSlot.name === execution.agentName);
 		if (!slot?.agentId) {
-			throw new Error(
-				`No agent slot found for agent name "${execution.agentName}" in node "${execution.workflowNodeId}"`
+			log.warn(
+				`TaskAgentManager.rehydrateSubSession: no agent slot found for agent ${execution.agentName} ` +
+					`in node ${execution.workflowNodeId}; keeping persisted system prompt`
 			);
+			return null;
 		}
 
 		return resolveAgentInit({

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
@@ -410,10 +410,16 @@ describe('TaskAgentManager.rehydrateSubSession (lazy rehydration)', () => {
 		ctx = makeCtx();
 		// Mock AgentSession.restore to return a mock session for any known DB session
 		restoreSpy = spyOn(AgentSession, 'restore').mockImplementation((sessionId: string) => {
-			if (!ctx.mockDb.getSession(sessionId)) return null;
+			const row = ctx.mockDb.getSession(sessionId) as {
+				config?: { systemPrompt?: unknown };
+			} | null;
+			if (!row) return null;
 			const existing = ctx.createdSessions.get(sessionId);
 			if (existing) return existing as unknown as AgentSession;
 			const mockSession = makeMockSession(sessionId);
+			if (row.config?.systemPrompt) {
+				mockSession.session.config.systemPrompt = row.config.systemPrompt;
+			}
 			ctx.createdSessions.set(sessionId, mockSession);
 			return mockSession as unknown as AgentSession;
 		});
@@ -530,6 +536,54 @@ describe('TaskAgentManager.rehydrateSubSession (lazy rehydration)', () => {
 			type: 'preset',
 			preset: 'claude_code',
 			append: 'current reviewer prompt after template update',
+		});
+	});
+
+	test('rehydrated sub-session keeps persisted prompt when workflow metadata is unavailable', async () => {
+		const wfRunId = 'run-prompt-missing-workflow-1';
+		const wfId = 'wf-prompt-missing-workflow-1';
+		const nodeId = 'node-prompt-missing-workflow-1';
+		seedWorkflowRun(ctx, wfRunId, wfId, nodeId);
+
+		const parentTask = await ctx.taskManager.createTask({
+			title: 'Parent task for missing workflow prompt fallback',
+			description: '',
+			taskType: 'coding',
+			status: 'in_progress',
+			workflowRunId: wfRunId,
+		});
+		const taskAgentSessionId = `space:${ctx.spaceId}:task:${parentTask.id}`;
+		ctx.taskRepo.updateTask(parentTask.id, { taskAgentSessionId, status: 'in_progress' });
+		ctx.mockDb.createSession({ id: taskAgentSessionId, type: 'space_task_agent' });
+
+		const workflow = ctx.workflowManager.listWorkflows(ctx.spaceId)[0];
+		expect(workflow).toBeDefined();
+		ctx.workflowManager.deleteWorkflow(workflow.id);
+
+		const subSessionId = `space:${ctx.spaceId}:task:${parentTask.id}:exec:ghost-exec-missing-workflow`;
+		const execution = ctx.nodeExecutionRepo.create({
+			workflowRunId: wfRunId,
+			workflowNodeId: nodeId,
+			agentName: 'reviewer',
+			agentId: null,
+			status: 'in_progress',
+		});
+		ctx.nodeExecutionRepo.updateSessionId(execution.id, subSessionId);
+		ctx.mockDb.createSession({
+			id: subSessionId,
+			type: 'worker',
+			config: { systemPrompt: { type: 'preset', preset: 'claude_code', append: 'persisted' } },
+		});
+
+		await ctx.manager.injectSubSessionMessage(subSessionId, 'resume review');
+
+		const session = ctx.createdSessions.get(subSessionId)!;
+		expect(session._startCalled).toBe(true);
+		expect(session._enqueuedMessages.at(-1)?.msg).toBe('resume review');
+		expect(session.session.config.systemPrompt).toMatchObject({
+			type: 'preset',
+			preset: 'claude_code',
+			append: 'persisted',
 		});
 	});
 

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager-rehydration.test.ts
@@ -69,7 +69,7 @@ interface MockAgentSession {
 	session: {
 		id: string;
 		context?: Record<string, unknown>;
-		config: { mcpServers?: Record<string, unknown> };
+		config: { mcpServers?: Record<string, unknown>; systemPrompt?: unknown };
 	};
 	getProcessingState: () => AgentProcessingState;
 	getSDKMessageCount: () => number;
@@ -135,7 +135,9 @@ function makeMockSession(sessionId: string): MockAgentSession {
 			this.session.config = { ...this.session.config, mcpServers: updatedCfg };
 		},
 		async restartQuery() {},
-		setRuntimeSystemPrompt(_sp: unknown) {},
+		setRuntimeSystemPrompt(sp: unknown) {
+			this.session.config = { ...this.session.config, systemPrompt: sp };
+		},
 		async startStreamingQuery() {
 			this._startCalled = true;
 		},
@@ -474,6 +476,61 @@ describe('TaskAgentManager.rehydrateSubSession (lazy rehydration)', () => {
 		expect(rehydratedSession._enqueuedMessages.length).toBeGreaterThan(0);
 		const lastMsg = rehydratedSession._enqueuedMessages.at(-1);
 		expect(lastMsg?.msg).toBe('pick up where you left off');
+	});
+
+	test('rehydrated sub-session refreshes workflow slot prompt before restart', async () => {
+		const wfRunId = 'run-prompt-refresh-1';
+		const wfId = 'wf-prompt-refresh-1';
+		const nodeId = 'node-prompt-refresh-1';
+		seedWorkflowRun(ctx, wfRunId, wfId, nodeId);
+
+		const workflow = ctx.workflowManager.listWorkflows(ctx.spaceId)[0];
+		expect(workflow).toBeDefined();
+		ctx.workflowManager.updateWorkflow(workflow.id, {
+			nodes: [
+				{
+					...workflow.nodes[0],
+					agents: [
+						{
+							agentId: ctx.agentId,
+							name: 'reviewer',
+							customPrompt: { value: 'current reviewer prompt after template update' },
+						},
+					],
+				},
+			],
+		});
+
+		const parentTask = await ctx.taskManager.createTask({
+			title: 'Parent task for prompt refresh',
+			description: '',
+			taskType: 'coding',
+			status: 'in_progress',
+			workflowRunId: wfRunId,
+		});
+		const taskAgentSessionId = `space:${ctx.spaceId}:task:${parentTask.id}`;
+		ctx.taskRepo.updateTask(parentTask.id, { taskAgentSessionId, status: 'in_progress' });
+		ctx.mockDb.createSession({ id: taskAgentSessionId, type: 'space_task_agent' });
+
+		const subSessionId = `space:${ctx.spaceId}:task:${parentTask.id}:exec:ghost-exec-prompt`;
+		const execution = ctx.nodeExecutionRepo.create({
+			workflowRunId: wfRunId,
+			workflowNodeId: nodeId,
+			agentName: 'reviewer',
+			agentId: null,
+			status: 'in_progress',
+		});
+		ctx.nodeExecutionRepo.updateSessionId(execution.id, subSessionId);
+		ctx.mockDb.createSession({ id: subSessionId, type: 'worker' });
+
+		await ctx.manager.injectSubSessionMessage(subSessionId, 'resume review');
+
+		const session = ctx.createdSessions.get(subSessionId)!;
+		expect(session.session.config.systemPrompt).toMatchObject({
+			type: 'preset',
+			preset: 'claude_code',
+			append: 'current reviewer prompt after template update',
+		});
 	});
 
 	test('rehydrated sub-session has node-agent MCP server attached', async () => {


### PR DESCRIPTION
Refreshes workflow node-agent system prompts during sub-session rehydration so existing Reviewer sessions pick up the current workflow slot prompt after a daemon restart.

Adds a rehydration regression test covering stale persisted prompts being replaced before the session resumes.