### PR TITLE
Fix agent activation before message delivery

### DIFF
--- a/packages/daemon/src/lib/space/runtime/agent-message-router.ts
+++ b/packages/daemon/src/lib/space/runtime/agent-message-router.ts
@@ -64,11 +64,17 @@ export interface AgentMessageRouterConfig {
 	 */
 	taskId?: string;
 	/**
+	 * Ensures a workflow-node target has a live session before message delivery.
+	 * This is intentionally separate from gate evaluation: gates may hold message
+	 * content, but they must never prevent the receiving agent from being activated.
+	 */
+	activateTargetSession?: (
+		agentName: string
+	) => Promise<Array<{ agentName: string; sessionId: string }>>;
+	/**
 	 * Optional callback fired after a message is persisted to `pendingMessageRepo`
-	 * for a declared-but-inactive target. Callers can use this to immediately
-	 * attempt to resume the target session if one is known (e.g. a session from a
-	 * previous execution that is currently idle/completed), so the queued message
-	 * is delivered without waiting for the next external activation trigger.
+	 * for a declared-but-inactive target. This is now only a diagnostic/backstop
+	 * path; successful send_message results must reflect live delivery, not queueing.
 	 *
 	 * Fires only for non-deduped enqueues (deduped = message already in queue).
 	 */
@@ -157,6 +163,7 @@ export class AgentMessageRouter {
 			pendingMessageRepo,
 			spaceId,
 			taskId,
+			activateTargetSession,
 			onMessageQueued,
 		} = this.config;
 
@@ -206,7 +213,7 @@ export class AgentMessageRouter {
 					`but none have an agentSessionId yet — will attempt activation/queuing.`
 			);
 		}
-		const peers: Array<{ sessionId: string; agentName: string }> = execWithSession.map((e) => ({
+		let peers: Array<{ sessionId: string; agentName: string }> = execWithSession.map((e) => ({
 			sessionId: e.agentSessionId!,
 			agentName: e.agentName,
 		}));
@@ -367,6 +374,30 @@ export class AgentMessageRouter {
 			}
 		}
 
+		// --- Ensure target sessions are live before content delivery ---
+		// ChannelRouter activation above may only create pending node_execution rows.
+		// The runtime callback is responsible for spawning/resuming the actual session;
+		// send_message must not report success until that session can receive content.
+		if (activateTargetSession) {
+			const refreshed = new Map(peers.map((peer) => [`${peer.agentName}:${peer.sessionId}`, peer]));
+			for (const agentName of targetAgentNames) {
+				if (agentName === 'task-agent') continue;
+				if (peers.some((peer) => peer.agentName === agentName)) continue;
+				try {
+					const activatedSessions = await activateTargetSession(agentName);
+					for (const session of activatedSessions) {
+						refreshed.set(`${session.agentName}:${session.sessionId}`, session);
+					}
+				} catch (err) {
+					const errMsg = err instanceof Error ? err.message : String(err);
+					log.warn(
+						`[AgentMessageRouter] failed to activate target session for agent "${agentName}": ${errMsg}`
+					);
+				}
+			}
+			peers = [...refreshed.values()].filter((peer) => peer.sessionId !== fromSessionId);
+		}
+
 		// --- Build the message content (with optional structured-data appendix) ---
 		const dataAppendix =
 			data && Object.keys(data).length > 0
@@ -398,7 +429,9 @@ export class AgentMessageRouter {
 
 			const agentSessions = peers.filter((m) => m.agentName === agentName);
 			if (agentSessions.length === 0) {
-				// No live session for this target. Determine whether to queue or fail.
+				// No live session for this target. This is not a successful delivery:
+				// `delivered: true` requires a live session that received the message.
+				// Keep the legacy queue as a recovery backstop only.
 				// Queue when:
 				//   (a) channelRouter just activated the target node (activatedTargets), OR
 				//   (b) the target is already declared in node_executions (pending spawn), OR
@@ -441,6 +474,7 @@ export class AgentMessageRouter {
 							message: rawMessage,
 						});
 						queued.push({ agentName, messageId: record.id });
+						notFound.push(agentName);
 						log.info(
 							`[AgentMessageRouter] queued message ${record.id} for agent "${agentName}" ` +
 								`(run=${workflowRunId}, from=${fromAgentName})`
@@ -483,28 +517,18 @@ export class AgentMessageRouter {
 			}
 		}
 
-		// All outcomes failed (nothing delivered, queued, or in-flight).
-		// `notFound` here means: target was resolved (it's declared in topology or
-		// node_executions) but no live session existed AND no pendingMessageRepo was
-		// configured for queuing — so the message could not be persisted for later
-		// delivery. We surface a different, less misleading message than the original
-		// "no active sessions / use list_peers" wording, which conflated this case
-		// with the genuinely-unknown-agent case (which now returns earlier with a
-		// "Unknown target" reason).
-		if (
-			notFound.length > 0 &&
-			delivered.length === 0 &&
-			queued.length === 0 &&
-			failed.length === 0
-		) {
+		// All outcomes failed (nothing delivered to a live session). A queued row is
+		// a recovery artifact, not delivery, so success must stay false when the only
+		// outcome was queueing.
+		if (notFound.length > 0 && delivered.length === 0 && failed.length === 0) {
 			return {
 				success: false,
 				delivered: [],
 				failed: [],
 				reason:
 					`Could not deliver message to target agent(s): ${notFound.join(', ')}. ` +
-					`The target is declared but has no active session, and no pending-message ` +
-					`queue is configured for this run.`,
+					`The target is declared but no live session received the message.`,
+				queued: queued.length > 0 ? queued : undefined,
 				notFoundAgentNames: notFound,
 			};
 		}

--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -545,6 +545,17 @@ export class ChannelRouter {
 			}
 		}
 
+		// Cycle caps reject the send itself, so they are enforced before activation.
+		// Gates are evaluated later because they only block message content.
+		if (channelIsCyclic && channel) {
+			const maxCycles = channel.maxCycles ?? 5;
+			if (this.isCycleCapReached(runId, channelIndex, maxCycles)) {
+				throw new ActivationError(
+					`Cyclic channel from "${fromRole}" to "${toTarget}" has reached the maximum cycle count (${maxCycles}). Increase maxCycles to allow more cycles.`
+				);
+			}
+		}
+
 		// ── 3. Lazy activation ─────────────────────────────────────────────────
 		const activeTasks = this.getActiveTasksForNode(runId, targetNode.id);
 		let activatedTasks: SpaceTask[] | undefined;
@@ -556,17 +567,8 @@ export class ChannelRouter {
 			});
 		}
 
-		// ── 4. Gate evaluation and per-channel cycle cap ─────────────────────
+		// ── 4. Gate evaluation ───────────────────────────────────────────────
 		if (channel) {
-			if (channelIsCyclic) {
-				const maxCycles = channel.maxCycles ?? 5;
-				if (this.isCycleCapReached(runId, channelIndex, maxCycles)) {
-					throw new ActivationError(
-						`Cyclic channel from "${fromRole}" to "${toTarget}" has reached the maximum cycle count (${maxCycles}). Increase maxCycles to allow more cycles.`
-					);
-				}
-			}
-
 			if (channel.gateId) {
 				const gateResult = await this.evaluateGateById(runId, channel.gateId, workflow);
 				if (!gateResult.open) {

--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -520,37 +520,15 @@ export class ChannelRouter {
 			throw new ActivationError(`Workflow not found: ${run.workflowId}`);
 		}
 
-		// ── 2. Gate evaluation and per-channel cycle cap ────────────────────────
 		const match = this.findMatchingWorkflowChannel(workflow, fromRole, toTarget);
 		const channel = match?.channel;
 		const channelIndex = match?.index ?? -1;
 		const channelIsCyclic = match ? this.isChannelCyclicByIndex(channelIndex, workflow) : false;
 
-		if (channel) {
-			// Enforce per-channel cycle cap for cyclic channels
-			if (channelIsCyclic) {
-				const maxCycles = channel.maxCycles ?? 5;
-				if (this.isCycleCapReached(runId, channelIndex, maxCycles)) {
-					throw new ActivationError(
-						`Cyclic channel from "${fromRole}" to "${toTarget}" has reached the maximum cycle count (${maxCycles}). Increase maxCycles to allow more cycles.`
-					);
-				}
-			}
-
-			// Gate evaluation via separated Gate entity
-			if (channel.gateId) {
-				const gateResult = await this.evaluateGateById(runId, channel.gateId, workflow);
-				if (!gateResult.open) {
-					throw new ChannelGateBlockedError(
-						gateResult.reason ??
-							`Gate "${channel.gateId}" blocked delivery from "${fromRole}" to "${toTarget}"`,
-						channel.gateId
-					);
-				}
-			}
-		}
-
-		// ── 3. Target resolution: agent name → DM, node name → fan-out ────────
+		// ── 2. Target resolution: agent name → DM, node name → fan-out ────────
+		// Activation is intentionally resolved before gate evaluation below. Gates may
+		// block delivery of the message content, but they must not block spawning or
+		// resuming the target agent session that needs to receive/react to the handoff.
 		let targetNode = this.findNodeByAgentName(workflow, toTarget);
 		let isFanOut = false;
 
@@ -567,7 +545,7 @@ export class ChannelRouter {
 			}
 		}
 
-		// ── 4. Lazy activation ─────────────────────────────────────────────────
+		// ── 3. Lazy activation ─────────────────────────────────────────────────
 		const activeTasks = this.getActiveTasksForNode(runId, targetNode.id);
 		let activatedTasks: SpaceTask[] | undefined;
 
@@ -576,6 +554,29 @@ export class ChannelRouter {
 				reopenBy: `agent:${fromRole}`,
 				reopenReason: `peer send_message from "${fromRole}" to "${toTarget}"`,
 			});
+		}
+
+		// ── 4. Gate evaluation and per-channel cycle cap ─────────────────────
+		if (channel) {
+			if (channelIsCyclic) {
+				const maxCycles = channel.maxCycles ?? 5;
+				if (this.isCycleCapReached(runId, channelIndex, maxCycles)) {
+					throw new ActivationError(
+						`Cyclic channel from "${fromRole}" to "${toTarget}" has reached the maximum cycle count (${maxCycles}). Increase maxCycles to allow more cycles.`
+					);
+				}
+			}
+
+			if (channel.gateId) {
+				const gateResult = await this.evaluateGateById(runId, channel.gateId, workflow);
+				if (!gateResult.open) {
+					throw new ChannelGateBlockedError(
+						gateResult.reason ??
+							`Gate "${channel.gateId}" blocked delivery from "${fromRole}" to "${toTarget}"`,
+						channel.gateId
+					);
+				}
+			}
 		}
 
 		// ── 5. Increment per-channel cycle count and reset cyclic gates ──────

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1858,6 +1858,46 @@ export class TaskAgentManager {
 	 * Returns `false` when the agent is not declared in the workflow, or when
 	 * any required dependency is missing (best-effort — never throws).
 	 */
+	async activateTargetSessionsForMessage(
+		taskId: string,
+		workflowRunId: string,
+		agentName: string,
+		options?: { reopenReason?: string; reopenBy?: string }
+	): Promise<Array<{ agentName: string; sessionId: string }>> {
+		await this.tryResumeNodeAgentSession(workflowRunId, agentName);
+		const existing = this.config.nodeExecutionRepo
+			.listByWorkflowRun(workflowRunId)
+			.filter((execution) => execution.agentName === agentName && execution.agentSessionId)
+			.at(-1);
+		if (existing?.agentSessionId && this.isSessionAlive(existing.agentSessionId)) {
+			return [{ agentName, sessionId: existing.agentSessionId }];
+		}
+
+		await this.ensureWorkflowNodeActivationForAgent(taskId, agentName, options);
+
+		const task = this.config.taskRepo.getTask(taskId);
+		const run = this.config.workflowRunRepo.getRun(workflowRunId);
+		const workflow = run?.workflowId
+			? this.config.spaceWorkflowManager.getWorkflow(run.workflowId)
+			: null;
+		const space = task ? await this.config.spaceManager.getSpace(task.spaceId) : null;
+		if (!task || !run || !workflow || !space) return [];
+
+		const execution = this.config.nodeExecutionRepo
+			.listByWorkflowRun(workflowRunId)
+			.find((candidate) => candidate.agentName === agentName);
+		if (!execution) return [];
+
+		const sessionId = await this.spawnWorkflowNodeAgentForExecution(
+			task,
+			space,
+			workflow,
+			run,
+			execution
+		);
+		return [{ agentName, sessionId }];
+	}
+
 	async ensureWorkflowNodeActivationForAgent(
 		taskId: string,
 		agentName: string,
@@ -3947,6 +3987,11 @@ export class TaskAgentManager {
 			workflowChannels: channels,
 			messageInjector: (targetSessionId, message) =>
 				this.injectSubSessionMessage(targetSessionId, message, true),
+			activateTargetSession: (targetAgentName) =>
+				this.activateTargetSessionsForMessage(taskId, workflowRunId, targetAgentName, {
+					reopenReason: `node-agent send_message to activate "${targetAgentName}"`,
+					reopenBy: `agent:${agentName}`,
+				}),
 			channelRouter: nodeAgentChannelRouter,
 			nodeGroups,
 			taskAgentRouter: async (message) => {

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1895,13 +1895,24 @@ export class TaskAgentManager {
 			.find((candidate) => candidate.agentName === agentName);
 		if (!execution) return [];
 
-		const sessionId = await this.spawnWorkflowNodeAgentForExecution(
+		const spawnPromise = this.spawnWorkflowNodeAgentForExecution(
 			task,
 			space,
 			workflow,
 			run,
 			execution
 		);
+		const timeoutMs = 30_000;
+		const timeoutPromise = new Promise<null>((resolve) => {
+			setTimeout(() => resolve(null), timeoutMs);
+		});
+		const sessionId = await Promise.race([spawnPromise, timeoutPromise]);
+		if (!sessionId) {
+			log.warn(
+				`TaskAgentManager.activateTargetSessionsForMessage: timed out after ${timeoutMs}ms activating agent "${agentName}" for run ${workflowRunId}`
+			);
+			return [];
+		}
 		return [{ agentName, sessionId }];
 	}
 

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1855,8 +1855,14 @@ export class TaskAgentManager {
 			.listByWorkflowRun(workflowRunId)
 			.filter((execution) => execution.agentName === agentName && execution.agentSessionId)
 			.at(-1);
-		if (existing?.agentSessionId && this.isSessionAlive(existing.agentSessionId)) {
-			return [{ agentName, sessionId: existing.agentSessionId }];
+		if (existing?.agentSessionId) {
+			if (this.isSessionAlive(existing.agentSessionId)) {
+				return [{ agentName, sessionId: existing.agentSessionId }];
+			}
+			this.config.nodeExecutionRepo.update(existing.id, {
+				agentSessionId: null,
+				status: 'pending',
+			});
 		}
 
 		await this.ensureWorkflowNodeActivationForAgent(taskId, agentName, options);

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -660,6 +660,7 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 					error: result.reason ?? 'Message delivery failed.',
 					delivered: result.delivered.length > 0 ? result.delivered : undefined,
 					failed: result.failed.length > 0 ? result.failed : undefined,
+					queued: result.queued,
 					unauthorizedAgentNames: result.unauthorizedAgentNames,
 					permittedTargets: result.permittedTargets,
 					notFoundAgentNames: result.notFoundAgentNames,

--- a/packages/daemon/tests/unit/5-space/agent/agent-message-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-message-router.test.ts
@@ -727,7 +727,7 @@ describe('AgentMessageRouter: fromNodeName resolution edge cases', () => {
 
 		// With nodeGroups, the topology resolves correctly → isTopologyDeclared = true
 		// No session exists → message queued (not "unknown target")
-		expect(result.success).toBe(true);
+		expect(result.success).toBe(false);
 		expect(result.queued).toHaveLength(1);
 		expect(result.queued?.[0].agentName).toBe('Review');
 	});
@@ -828,7 +828,7 @@ describe('AgentMessageRouter: queue message for declared-but-inactive target', (
 		});
 
 		// Message should be queued, not failed
-		expect(result.success).toBe(true);
+		expect(result.success).toBe(false);
 		expect(result.queued).toBeDefined();
 		expect(result.queued).toHaveLength(1);
 		expect(result.queued![0].agentName).toBe('reviewer');
@@ -879,7 +879,7 @@ describe('AgentMessageRouter: queue message for declared-but-inactive target', (
 		});
 
 		// Should succeed by queuing, not fail with "Unknown target" or "No active sessions"
-		expect(result.success).toBe(true);
+		expect(result.success).toBe(false);
 		expect(result.queued).toBeDefined();
 		expect(result.queued![0].agentName).toBe('reviewer');
 	});
@@ -926,7 +926,7 @@ describe('AgentMessageRouter: queue message for declared-but-inactive target', (
 			message: 'code ready',
 		});
 
-		expect(result.success).toBe(true);
+		expect(result.success).toBe(false);
 		expect(result.delivered).toHaveLength(0);
 		expect(result.queued).toHaveLength(1);
 		expect(result.queued![0].agentName).toBe('reviewer');
@@ -1015,7 +1015,7 @@ describe('AgentMessageRouter: queue message for declared-but-inactive target', (
 		// Reworded in Task #133: distinguishes "declared but no session" from
 		// "unknown agent". Both pre-pendingRepo paths converge on this message.
 		expect(result.reason).toContain('Could not deliver message to target agent(s): reviewer');
-		expect(result.reason).toContain('declared but has no active session');
+		expect(result.reason).toContain('no live session received the message');
 	});
 });
 
@@ -1138,7 +1138,7 @@ describe('AgentMessageRouter: queue enqueue failure graceful degradation', () =>
 		// Reworded in Task #133: distinguishes "declared but no session" from
 		// "unknown agent". Both pre-pendingRepo paths converge on this message.
 		expect(result.reason).toContain('Could not deliver message to target agent(s): reviewer');
-		expect(result.reason).toContain('declared but has no active session');
+		expect(result.reason).toContain('no live session received the message');
 		expect(result.notFoundAgentNames).toContain('reviewer');
 	});
 });
@@ -1186,13 +1186,13 @@ describe('AgentMessageRouter: workflow-declared (via nodeGroups) slot target wit
 			message: 'lazy activation please',
 		});
 
-		expect(result.success).toBe(true);
+		expect(result.success).toBe(false);
 		expect(result.queued).toHaveLength(1);
 		expect(result.queued![0].agentName).toBe('reviewer');
 		expect(result.delivered).toHaveLength(0);
-		// The hard-error path was NOT taken — no notFoundAgentNames and no
-		// "Unknown target" reason.
-		expect(result.notFoundAgentNames).toBeUndefined();
+		// The hard-error path was NOT taken — no "Unknown target" reason.
+		// The missing live session is still surfaced for delivery accuracy.
+		expect(result.notFoundAgentNames).toContain('reviewer');
 
 		const pending = pendingMessageRepo.listPendingForTarget(workflowRunId, 'reviewer');
 		expect(pending).toHaveLength(1);
@@ -1266,7 +1266,7 @@ describe('AgentMessageRouter: pure topology target (no execution, no nodeGroups)
 			message: 'activate and review',
 		});
 
-		expect(result.success).toBe(true);
+		expect(result.success).toBe(false);
 		expect(result.queued).toHaveLength(1);
 		expect(result.queued![0].agentName).toBe('reviewer');
 		expect(result.delivered).toHaveLength(0);

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -685,7 +685,7 @@ describe('node-agent-tools: send_message', () => {
 
 		expect(data.success).toBe(false);
 		expect(data.error).toContain('Could not deliver message to target agent(s): tester');
-		expect(data.error).toContain('declared but has no active session');
+		expect(data.error).toContain('no live session received the message');
 	});
 
 	test('returns unknown-target when role is not in topology or any execution', async () => {
@@ -3068,12 +3068,12 @@ describe('node-agent-tools: send_message — queue-when-inactive', () => {
 		});
 		const data = JSON.parse(result.content[0].text);
 
-		// Message should be queued, not failed
-		expect(data.success).toBe(true);
+		// Message should be queued as a backstop, but not reported as delivered.
+		expect(data.success).toBe(false);
 		expect(data.queued).toBeDefined();
 		expect(data.queued).toHaveLength(1);
 		expect(data.queued[0].agentName).toBe('reviewer');
-		expect(data.delivered).toHaveLength(0);
+		expect(data.delivered ?? []).toHaveLength(0);
 
 		// Verify the message is in the queue
 		const pending = pendingMessageRepo.listPendingForTarget(isolatedRunId, 'reviewer');
@@ -3118,7 +3118,7 @@ describe('node-agent-tools: send_message — queue-when-inactive', () => {
 		});
 		const data = JSON.parse(result.content[0].text);
 
-		expect(data.success).toBe(true);
+		expect(data.success).toBe(false);
 		expect(data.queued).toHaveLength(1);
 
 		// Queued message should include the structured data appendix

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
@@ -2547,6 +2547,47 @@ describe('TaskAgentManager', () => {
 			}
 		});
 
+		test('resets stale execution session before spawning target session', async () => {
+			const { wfRunId, reviewNodeId, taskId } = await seedRunWithTwoNodes();
+			const staleSessionId = 'stale-reviewer-session';
+			const staleExec = ctx.nodeExecutionRepo.create({
+				workflowRunId: wfRunId,
+				workflowNodeId: reviewNodeId,
+				agentName: 'reviewer',
+				agentId: ctx.agentId,
+				agentSessionId: staleSessionId,
+				status: 'in_progress',
+			});
+			const staleSession = makeMockSession(staleSessionId);
+			staleSession._processingState = { status: 'error' } as AgentProcessingState;
+			ctx.manager['agentSessionIndex'].set(staleSessionId, staleSession as unknown as AgentSession);
+			const spawnSpy = spyOn(ctx.manager, 'spawnWorkflowNodeAgentForExecution').mockImplementation(
+				async (_task, _space, _workflow, _run, execution) => {
+					expect(execution.id).toBe(staleExec.id);
+					expect(execution.agentSessionId).toBeNull();
+					expect(execution.status).toBe('pending');
+					return 'fresh-reviewer-session';
+				}
+			);
+
+			try {
+				const sessions = await ctx.manager.activateTargetSessionsForMessage(
+					taskId,
+					wfRunId,
+					'reviewer'
+				);
+
+				expect(sessions).toEqual([{ agentName: 'reviewer', sessionId: 'fresh-reviewer-session' }]);
+				expect(spawnSpy).toHaveBeenCalledTimes(1);
+				const updated = ctx.nodeExecutionRepo.getById(staleExec.id);
+				expect(updated?.agentSessionId).toBeNull();
+				expect(updated?.status).toBe('pending');
+			} finally {
+				spawnSpy.mockRestore();
+				ctx.manager['agentSessionIndex'].delete(staleSessionId);
+			}
+		});
+
 		test('returns false and skips activateNode when agentName is not in any workflow node', async () => {
 			const { taskId } = await seedRunWithTwoNodes();
 

--- a/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
@@ -1097,7 +1097,7 @@ describe('ChannelRouter', () => {
 		// Gated channels — check condition
 		// -----------------------------------------------------------------------
 
-		test('gated channel (check): blocks delivery when condition not satisfied', async () => {
+		test('gated channel (check): activates target before blocking content when condition not satisfied', async () => {
 			const gate: Gate = {
 				id: 'plan-gate',
 				fields: [{ name: 'plan', type: 'string', writers: ['planner'], check: { op: 'exists' } }],
@@ -1129,10 +1129,15 @@ describe('ChannelRouter', () => {
 			});
 			workflowRunRepo.transitionStatus(run.id, 'in_progress');
 
-			// No gate data written → field does not exist → gate is closed
+			// No gate data written → field does not exist → gate is closed.
+			// The target agent is still activated first; the gate only blocks message content.
 			await expect(router.deliverMessage(run.id, 'planner', 'coder', 'msg')).rejects.toBeInstanceOf(
 				ChannelGateBlockedError
 			);
+			const executions = new NodeExecutionRepository(db).listByNode(run.id, NODE_B);
+			expect(executions).toHaveLength(1);
+			expect(executions[0].agentName).toBe('coder');
+			expect(executions[0].status).toBe('pending');
 		});
 
 		test('gated channel (check): allows delivery when condition satisfied', async () => {

--- a/packages/daemon/tests/unit/5-space/other/cross-agent-messaging.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/cross-agent-messaging.test.ts
@@ -1150,6 +1150,70 @@ describe('Error cases — non-existent targets and injection failures', () => {
 		expect((result.error as string).toLowerCase()).toContain('ghost');
 	});
 
+	test('send_message activates a missing target session before delivery', async () => {
+		ctx = makeStepCtx([{ sessionId: 'sess-coder', agentName: 'coder' }]);
+		const activated: string[] = [];
+		const channels = [ch('coder', 'reviewer')];
+		const cfg = makeStepConfig(ctx, 'sess-coder', 'coder', {
+			channelResolver: new ChannelResolver(channels),
+			agentMessageRouter: new AgentMessageRouter({
+				nodeExecutionRepo: ctx.nodeExecutionRepo,
+				workflowRunId: ctx.workflowRunId,
+				workflowChannels: channels,
+				messageInjector: async (sessionId, message) => {
+					cfg.injectedMessages.push({ sessionId, message });
+				},
+				activateTargetSession: async (agentName) => {
+					activated.push(agentName);
+					return [{ agentName, sessionId: 'sess-reviewer-activated' }];
+				},
+			}),
+		});
+		const handlers = createNodeAgentToolHandlers(cfg);
+
+		const result = parse(
+			await handlers.send_message({ target: 'reviewer', message: 'Please review' })
+		);
+		expect(result.success).toBe(true);
+		expect(activated).toEqual(['reviewer']);
+		expect(cfg.injectedMessages).toHaveLength(1);
+		expect(cfg.injectedMessages[0].sessionId).toBe('sess-reviewer-activated');
+	});
+
+	test('send_message queues as backstop but reports failure when activation does not produce a live session', async () => {
+		ctx = makeStepCtx([{ sessionId: 'sess-coder', agentName: 'coder' }]);
+		const queued: Array<{ agentName: string; messageId: string }> = [];
+		const pendingMessageRepo = {
+			enqueue: (input: { targetAgentName: string }) => {
+				const record = { id: `msg-${input.targetAgentName}` };
+				queued.push({ agentName: input.targetAgentName, messageId: record.id });
+				return { record, deduped: false };
+			},
+		} as unknown as import('../../../../src/storage/repositories/pending-agent-message-repository.ts').PendingAgentMessageRepository;
+		const channels = [ch('coder', 'reviewer')];
+		const cfg = makeStepConfig(ctx, 'sess-coder', 'coder', {
+			channelResolver: new ChannelResolver(channels),
+			agentMessageRouter: new AgentMessageRouter({
+				nodeExecutionRepo: ctx.nodeExecutionRepo,
+				workflowRunId: ctx.workflowRunId,
+				workflowChannels: channels,
+				messageInjector: async () => {},
+				activateTargetSession: async () => [],
+				pendingMessageRepo,
+				spaceId: ctx.spaceId,
+			}),
+		});
+		const handlers = createNodeAgentToolHandlers(cfg);
+
+		const result = parse(
+			await handlers.send_message({ target: 'reviewer', message: 'Please review' })
+		);
+		expect(result.success).toBe(false);
+		expect((result.error as string).toLowerCase()).toContain('no live session received');
+		expect(result.queued).toEqual(queued);
+		expect(cfg.injectedMessages).toHaveLength(0);
+	});
+
 	test('send_message injection failure returns all-failed error', async () => {
 		ctx = makeStepCtx([
 			{ sessionId: 'sess-coder', agentName: 'coder' },


### PR DESCRIPTION
Fixes the send_message activation path so target node agents are activated/resumed before content delivery, and success is only reported after a live session receives the message.

Root cause: peer send_message could treat a queued pending message as a successful handoff while the target session was still absent/idle; gated channels also evaluated gates before activation, so gate closure could prevent the target agent from spawning.

Design: separate activation from message-content delivery. Gates may block message content, but activation now happens first; the pending queue remains a recovery backstop and is surfaced on failed delivery instead of being counted as success.

Tests: bun test packages/daemon/tests/unit/5-space/other/cross-agent-messaging.test.ts packages/daemon/tests/unit/5-space/other/channel-router.test.ts