### PR TITLE
Fix reviewer agent prompt drift on restart

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -217,6 +217,11 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	const eventBus = createDaemonHub('daemon');
 	await eventBus.initialize();
 
+	// One-shot startup reconciliation for legacy preset agent rows. This must run
+	// before RPC handlers can serve the configure UI so persisted agent prompts
+	// match the current template seed immediately after daemon restart.
+	await reconcileLegacyPresetAgentsOnStartup(spaceManager, spaceAgentManager, eventBus, logInfo);
+
 	// Initialize application-level MCP and Skills managers before SessionManager
 	// so AgentSession can inject skills into SDK query options.
 	const appMcpManager = new AppMcpLifecycleManager(db);
@@ -694,4 +699,28 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		fileIndex,
 		cleanup,
 	};
+}
+
+async function reconcileLegacyPresetAgentsOnStartup(
+	spaceManager: SpaceManager,
+	spaceAgentManager: SpaceAgentManager,
+	eventBus: ReturnType<typeof createDaemonHub>,
+	logInfo: (message: string) => void
+): Promise<void> {
+	const spaces = await spaceManager.listSpaces(false);
+	let reconciledCount = 0;
+	for (const space of spaces) {
+		const reconciledAgents = spaceAgentManager.reconcileEquivalentLegacyPresetRows(space.id);
+		for (const agent of reconciledAgents) {
+			reconciledCount++;
+			await eventBus.emit('spaceAgent.updated', {
+				sessionId: `space:${agent.spaceId}`,
+				spaceId: agent.spaceId,
+				agent,
+			});
+		}
+	}
+	if (reconciledCount > 0) {
+		logInfo(`[Daemon] Reconciled ${reconciledCount} legacy preset agent prompt(s)`);
+	}
 }

--- a/packages/daemon/src/lib/space/agents/seed-agents.ts
+++ b/packages/daemon/src/lib/space/agents/seed-agents.ts
@@ -118,6 +118,20 @@ interface PresetDefinition {
  * SDK) are a planned follow-up and will live in workflow templates /
  * SpaceAgent data, not in code.
  */
+export const LEGACY_REVIEWER_PROMPT = `You are a code reviewer. Your job is to review code changes for correctness, quality, security, and alignment with the original goal.
+
+When given a review task:
+1. Understand the original goal and requirements
+2. Read the changed files carefully
+3. Check alignment: do the changes actually achieve the stated goal?
+4. Check for bugs, logic errors, and edge cases
+5. Look for security issues (injection, XSS, etc.)
+6. Verify the changes follow existing codebase patterns
+7. Check for unnecessary complexity or over-engineering
+8. Report issues with specific file paths and line numbers
+
+Be constructive and specific. Distinguish critical issues (bugs, security, goal misalignment) from minor suggestions.`;
+
 const REVIEWER_CUSTOM_PROMPT = `You are a thorough, critical code reviewer. Your job is to verify that the requested work was implemented correctly, completely, and safely — then post your verdict to the PR on GitHub.
 
 ## Reviewer Identity

--- a/packages/daemon/src/lib/space/managers/space-agent-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-agent-manager.ts
@@ -21,7 +21,8 @@ import { KNOWN_TOOLS } from '@neokai/shared';
 import type { SpaceAgentRepository } from '../../../storage/repositories/space-agent-repository';
 import { isValidModel, getAvailableModels, getModelInfoUnfiltered } from '../../model-service';
 import { getPresetAgentTemplates } from '../agents/seed-agents';
-import { computeAgentTemplateHash } from '../agents/agent-template-hash';
+import { computeAgentTemplateHash, agentTemplatesMatch } from '../agents/agent-template-hash';
+import { reviewerAgent } from '../../agent/coordinator/reviewer';
 
 const KNOWN_TOOLS_SET = new Set<string>(KNOWN_TOOLS);
 
@@ -132,6 +133,7 @@ export class SpaceAgentManager {
 	 * List all agents for a space.
 	 */
 	listBySpaceId(spaceId: string): SpaceAgent[] {
+		this.reconcileEquivalentLegacyPresetRows(spaceId);
 		return this.repo.getBySpaceId(spaceId);
 	}
 
@@ -166,13 +168,15 @@ export class SpaceAgentManager {
 
 			const currentHash = computeAgentTemplateHash(preset);
 			const storedHash = agent.templateHash ?? null;
+			const drifted =
+				storedHash !== currentHash && !this.isEquivalentLegacyPresetRow(agent, preset);
 			entries.push({
 				agentId: agent.id,
 				agentName: agent.name,
 				templateName: agent.templateName,
 				storedHash,
 				currentHash,
-				drifted: storedHash !== currentHash,
+				drifted,
 			});
 		}
 
@@ -231,6 +235,40 @@ export class SpaceAgentManager {
 	 * path includes legacy model ID mappings (e.g. 'claude-3-5-sonnet-20241022'
 	 * → 'sonnet') consistent with how the rest of the codebase resolves models.
 	 */
+	private reconcileEquivalentLegacyPresetRows(spaceId: string): void {
+		const presetByName = new Map(getPresetAgentTemplates().map((p) => [p.name.toLowerCase(), p]));
+		for (const agent of this.repo.getBySpaceId(spaceId)) {
+			if (!agent.templateName) continue;
+			const preset = presetByName.get(agent.templateName.toLowerCase());
+			if (!preset) continue;
+			const currentHash = computeAgentTemplateHash(preset);
+			if (agent.templateHash === currentHash) continue;
+			if (!this.isEquivalentLegacyPresetRow(agent, preset)) continue;
+			this.repo.update(agent.id, {
+				customPrompt: preset.customPrompt,
+				templateHash: currentHash,
+			});
+		}
+	}
+
+	private isEquivalentLegacyPresetRow(
+		agent: SpaceAgent,
+		preset: ReturnType<typeof getPresetAgentTemplates>[number]
+	): boolean {
+		if (preset.name !== 'Reviewer') return false;
+		if (agent.name.trim().toLowerCase() !== preset.name.toLowerCase()) return false;
+		if ((agent.description ?? '') !== preset.description) return false;
+		if (
+			!agentTemplatesMatch(
+				{ ...preset, customPrompt: reviewerAgent.prompt },
+				agentTemplateInput(agent)
+			)
+		) {
+			return false;
+		}
+		return true;
+	}
+
 	private async validateModel(model: string, provider?: string | null): Promise<string | null> {
 		// Skip all validation if the models cache is not yet populated
 		const available = getAvailableModels('global');
@@ -256,6 +294,15 @@ export class SpaceAgentManager {
  * Validate that all tool names in the array are in KNOWN_TOOLS.
  * Returns a descriptive error string on failure, or null if all names are valid.
  */
+function agentTemplateInput(agent: SpaceAgent) {
+	return {
+		name: agent.templateName ?? agent.name,
+		description: agent.description ?? '',
+		tools: agent.tools ?? [],
+		customPrompt: agent.customPrompt ?? '',
+	};
+}
+
 function validateTools(tools: string[]): string | null {
 	const invalid = tools.filter((t) => !KNOWN_TOOLS_SET.has(t));
 	if (invalid.length === 0) return null;

--- a/packages/daemon/src/lib/space/managers/space-agent-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-agent-manager.ts
@@ -20,9 +20,8 @@ import type {
 import { KNOWN_TOOLS } from '@neokai/shared';
 import type { SpaceAgentRepository } from '../../../storage/repositories/space-agent-repository';
 import { isValidModel, getAvailableModels, getModelInfoUnfiltered } from '../../model-service';
-import { getPresetAgentTemplates } from '../agents/seed-agents';
+import { getPresetAgentTemplates, LEGACY_REVIEWER_PROMPT } from '../agents/seed-agents';
 import { computeAgentTemplateHash, agentTemplatesMatch } from '../agents/agent-template-hash';
-import { reviewerAgent } from '../../agent/coordinator/reviewer';
 
 const KNOWN_TOOLS_SET = new Set<string>(KNOWN_TOOLS);
 
@@ -258,7 +257,7 @@ export class SpaceAgentManager {
 		if ((agent.description ?? '') !== preset.description) return false;
 		if (
 			!agentTemplatesMatch(
-				{ ...preset, customPrompt: reviewerAgent.prompt },
+				{ ...preset, customPrompt: LEGACY_REVIEWER_PROMPT },
 				agentTemplateInput(agent)
 			)
 		) {

--- a/packages/daemon/src/lib/space/managers/space-agent-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-agent-manager.ts
@@ -133,7 +133,6 @@ export class SpaceAgentManager {
 	 * List all agents for a space.
 	 */
 	listBySpaceId(spaceId: string): SpaceAgent[] {
-		this.reconcileEquivalentLegacyPresetRows(spaceId);
 		return this.repo.getBySpaceId(spaceId);
 	}
 
@@ -227,15 +226,12 @@ export class SpaceAgentManager {
 	// ---------------------------------------------------------------------------
 
 	/**
-	 * Validate that a model is recognized.
-	 * Skips validation entirely when the models cache is empty (not yet loaded).
-	 * When a provider is known, uses the provider-aware isValidModel() API so
-	 * that e.g. a GLM model cannot be validated as an Anthropic model.
-	 * Falls back to getModelInfoUnfiltered() when no provider is given — this
-	 * path includes legacy model ID mappings (e.g. 'claude-3-5-sonnet-20241022'
-	 * → 'sonnet') consistent with how the rest of the codebase resolves models.
+	 * One-shot startup reconciliation for preset rows that were correctly seeded
+	 * from the old coordinator Reviewer prompt before the full Reviewer template
+	 * existed. Returns updated rows so callers can emit subscription events.
 	 */
-	private reconcileEquivalentLegacyPresetRows(spaceId: string): void {
+	reconcileEquivalentLegacyPresetRows(spaceId: string): SpaceAgent[] {
+		const updated: SpaceAgent[] = [];
 		const presetByName = new Map(getPresetAgentTemplates().map((p) => [p.name.toLowerCase(), p]));
 		for (const agent of this.repo.getBySpaceId(spaceId)) {
 			if (!agent.templateName) continue;
@@ -244,11 +240,13 @@ export class SpaceAgentManager {
 			const currentHash = computeAgentTemplateHash(preset);
 			if (agent.templateHash === currentHash) continue;
 			if (!this.isEquivalentLegacyPresetRow(agent, preset)) continue;
-			this.repo.update(agent.id, {
+			const reconciled = this.repo.update(agent.id, {
 				customPrompt: preset.customPrompt,
 				templateHash: currentHash,
 			});
+			if (reconciled) updated.push(reconciled);
 		}
+		return updated;
 	}
 
 	private isEquivalentLegacyPresetRow(
@@ -269,6 +267,15 @@ export class SpaceAgentManager {
 		return true;
 	}
 
+	/**
+	 * Validate that a model is recognized.
+	 * Skips validation entirely when the models cache is empty (not yet loaded).
+	 * When a provider is known, uses the provider-aware isValidModel() API so
+	 * that e.g. a GLM model cannot be validated as an Anthropic model.
+	 * Falls back to getModelInfoUnfiltered() when no provider is given — this
+	 * path includes legacy model ID mappings (e.g. 'claude-3-5-sonnet-20241022'
+	 * → 'sonnet') consistent with how the rest of the codebase resolves models.
+	 */
 	private async validateModel(model: string, provider?: string | null): Promise<string | null> {
 		// Skip all validation if the models cache is not yet populated
 		const available = getAvailableModels('global');

--- a/packages/daemon/tests/unit/1-core/lib/space-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-agent-manager.test.ts
@@ -457,10 +457,9 @@ describe('SpaceAgentManager', () => {
 		});
 
 		it('treats legacy coordinator Reviewer prompt as equivalent to the current preset', async () => {
-			const { getPresetAgentTemplates } = await import(
+			const { getPresetAgentTemplates, LEGACY_REVIEWER_PROMPT } = await import(
 				'../../../../src/lib/space/agents/seed-agents'
 			);
-			const { reviewerAgent } = await import('../../../../src/lib/agent/coordinator/reviewer');
 			const { computeAgentTemplateHash } = await import(
 				'../../../../src/lib/space/agents/agent-template-hash'
 			);
@@ -468,7 +467,7 @@ describe('SpaceAgentManager', () => {
 			if (!reviewer) throw new Error('Reviewer preset missing');
 			const legacyHash = computeAgentTemplateHash({
 				...reviewer,
-				customPrompt: reviewerAgent.prompt,
+				customPrompt: LEGACY_REVIEWER_PROMPT,
 			});
 
 			await manager.create({
@@ -476,7 +475,7 @@ describe('SpaceAgentManager', () => {
 				name: 'Reviewer',
 				description: reviewer.description,
 				tools: reviewer.tools,
-				customPrompt: reviewerAgent.prompt,
+				customPrompt: LEGACY_REVIEWER_PROMPT,
 				templateName: 'Reviewer',
 				templateHash: legacyHash,
 			});
@@ -489,16 +488,15 @@ describe('SpaceAgentManager', () => {
 		});
 
 		it('reports user-edited legacy Reviewer prompts as drifted', async () => {
-			const { getPresetAgentTemplates } = await import(
+			const { getPresetAgentTemplates, LEGACY_REVIEWER_PROMPT } = await import(
 				'../../../../src/lib/space/agents/seed-agents'
 			);
-			const { reviewerAgent } = await import('../../../../src/lib/agent/coordinator/reviewer');
 			const { computeAgentTemplateHash } = await import(
 				'../../../../src/lib/space/agents/agent-template-hash'
 			);
 			const reviewer = getPresetAgentTemplates().find((p) => p.name === 'Reviewer');
 			if (!reviewer) throw new Error('Reviewer preset missing');
-			const editedPrompt = `${reviewerAgent.prompt}\n\nUser customization`;
+			const editedPrompt = `${LEGACY_REVIEWER_PROMPT}\n\nUser customization`;
 			const editedLegacyHash = computeAgentTemplateHash({
 				...reviewer,
 				customPrompt: editedPrompt,
@@ -548,10 +546,9 @@ describe('SpaceAgentManager', () => {
 
 	describe('reconcileEquivalentLegacyPresetRows', () => {
 		it('reconciles legacy coordinator Reviewer prompts to the current preset prompt', async () => {
-			const { getPresetAgentTemplates } = await import(
+			const { getPresetAgentTemplates, LEGACY_REVIEWER_PROMPT } = await import(
 				'../../../../src/lib/space/agents/seed-agents'
 			);
-			const { reviewerAgent } = await import('../../../../src/lib/agent/coordinator/reviewer');
 			const { computeAgentTemplateHash } = await import(
 				'../../../../src/lib/space/agents/agent-template-hash'
 			);
@@ -559,7 +556,7 @@ describe('SpaceAgentManager', () => {
 			if (!reviewer) throw new Error('Reviewer preset missing');
 			const legacyHash = computeAgentTemplateHash({
 				...reviewer,
-				customPrompt: reviewerAgent.prompt,
+				customPrompt: LEGACY_REVIEWER_PROMPT,
 			});
 
 			const created = await manager.create({
@@ -567,7 +564,7 @@ describe('SpaceAgentManager', () => {
 				name: 'Reviewer',
 				description: reviewer.description,
 				tools: reviewer.tools,
-				customPrompt: reviewerAgent.prompt,
+				customPrompt: LEGACY_REVIEWER_PROMPT,
 				templateName: 'Reviewer',
 				templateHash: legacyHash,
 			});

--- a/packages/daemon/tests/unit/1-core/lib/space-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-agent-manager.test.ts
@@ -291,6 +291,37 @@ describe('SpaceAgentManager', () => {
 			const agents = manager.listBySpaceId('space-1');
 			expect(agents).toHaveLength(2);
 		});
+		it('reconciles legacy coordinator Reviewer prompts to the current preset prompt', async () => {
+			const { getPresetAgentTemplates } = await import(
+				'../../../../src/lib/space/agents/seed-agents'
+			);
+			const { reviewerAgent } = await import('../../../../src/lib/agent/coordinator/reviewer');
+			const { computeAgentTemplateHash } = await import(
+				'../../../../src/lib/space/agents/agent-template-hash'
+			);
+			const reviewer = getPresetAgentTemplates().find((p) => p.name === 'Reviewer');
+			if (!reviewer) throw new Error('Reviewer preset missing');
+			const legacyHash = computeAgentTemplateHash({
+				...reviewer,
+				customPrompt: reviewerAgent.prompt,
+			});
+
+			const created = await manager.create({
+				spaceId: 'space-1',
+				name: 'Reviewer',
+				description: reviewer.description,
+				tools: reviewer.tools,
+				customPrompt: reviewerAgent.prompt,
+				templateName: 'Reviewer',
+				templateHash: legacyHash,
+			});
+			if (!created.ok) throw new Error('create failed');
+
+			const agents = manager.listBySpaceId('space-1');
+			const reconciled = agents.find((agent) => agent.id === created.value.id);
+			expect(reconciled?.customPrompt).toBe(reviewer.customPrompt);
+			expect(reconciled?.templateHash).toBe(computeAgentTemplateHash(reviewer));
+		});
 	});
 
 	describe('getAgentsByIds', () => {
@@ -454,6 +485,38 @@ describe('SpaceAgentManager', () => {
 			expect(report.agents[0].drifted).toBe(true);
 			expect(report.agents[0].storedHash).toBe('stale-hash-value');
 			expect(report.agents[0].currentHash).not.toBe('stale-hash-value');
+		});
+
+		it('treats legacy coordinator Reviewer prompt as equivalent to the current preset', async () => {
+			const { getPresetAgentTemplates } = await import(
+				'../../../../src/lib/space/agents/seed-agents'
+			);
+			const { reviewerAgent } = await import('../../../../src/lib/agent/coordinator/reviewer');
+			const { computeAgentTemplateHash } = await import(
+				'../../../../src/lib/space/agents/agent-template-hash'
+			);
+			const reviewer = getPresetAgentTemplates().find((p) => p.name === 'Reviewer');
+			if (!reviewer) throw new Error('Reviewer preset missing');
+			const legacyHash = computeAgentTemplateHash({
+				...reviewer,
+				customPrompt: reviewerAgent.prompt,
+			});
+
+			await manager.create({
+				spaceId: 'space-1',
+				name: 'Reviewer',
+				description: reviewer.description,
+				tools: reviewer.tools,
+				customPrompt: reviewerAgent.prompt,
+				templateName: 'Reviewer',
+				templateHash: legacyHash,
+			});
+
+			const report = manager.getAgentDriftReport('space-1');
+			expect(report.agents).toHaveLength(1);
+			expect(report.agents[0].drifted).toBe(false);
+			expect(report.agents[0].storedHash).toBe(legacyHash);
+			expect(report.agents[0].currentHash).not.toBe(legacyHash);
 		});
 
 		it('reports drifted=true when storedHash is null (post-backfill unmatchable rows)', async () => {

--- a/packages/daemon/tests/unit/1-core/lib/space-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-agent-manager.test.ts
@@ -291,37 +291,6 @@ describe('SpaceAgentManager', () => {
 			const agents = manager.listBySpaceId('space-1');
 			expect(agents).toHaveLength(2);
 		});
-		it('reconciles legacy coordinator Reviewer prompts to the current preset prompt', async () => {
-			const { getPresetAgentTemplates } = await import(
-				'../../../../src/lib/space/agents/seed-agents'
-			);
-			const { reviewerAgent } = await import('../../../../src/lib/agent/coordinator/reviewer');
-			const { computeAgentTemplateHash } = await import(
-				'../../../../src/lib/space/agents/agent-template-hash'
-			);
-			const reviewer = getPresetAgentTemplates().find((p) => p.name === 'Reviewer');
-			if (!reviewer) throw new Error('Reviewer preset missing');
-			const legacyHash = computeAgentTemplateHash({
-				...reviewer,
-				customPrompt: reviewerAgent.prompt,
-			});
-
-			const created = await manager.create({
-				spaceId: 'space-1',
-				name: 'Reviewer',
-				description: reviewer.description,
-				tools: reviewer.tools,
-				customPrompt: reviewerAgent.prompt,
-				templateName: 'Reviewer',
-				templateHash: legacyHash,
-			});
-			if (!created.ok) throw new Error('create failed');
-
-			const agents = manager.listBySpaceId('space-1');
-			const reconciled = agents.find((agent) => agent.id === created.value.id);
-			expect(reconciled?.customPrompt).toBe(reviewer.customPrompt);
-			expect(reconciled?.templateHash).toBe(computeAgentTemplateHash(reviewer));
-		});
 	});
 
 	describe('getAgentsByIds', () => {
@@ -519,6 +488,37 @@ describe('SpaceAgentManager', () => {
 			expect(report.agents[0].currentHash).not.toBe(legacyHash);
 		});
 
+		it('reports user-edited legacy Reviewer prompts as drifted', async () => {
+			const { getPresetAgentTemplates } = await import(
+				'../../../../src/lib/space/agents/seed-agents'
+			);
+			const { reviewerAgent } = await import('../../../../src/lib/agent/coordinator/reviewer');
+			const { computeAgentTemplateHash } = await import(
+				'../../../../src/lib/space/agents/agent-template-hash'
+			);
+			const reviewer = getPresetAgentTemplates().find((p) => p.name === 'Reviewer');
+			if (!reviewer) throw new Error('Reviewer preset missing');
+			const editedPrompt = `${reviewerAgent.prompt}\n\nUser customization`;
+			const editedLegacyHash = computeAgentTemplateHash({
+				...reviewer,
+				customPrompt: editedPrompt,
+			});
+
+			await manager.create({
+				spaceId: 'space-1',
+				name: 'Reviewer',
+				description: reviewer.description,
+				tools: reviewer.tools,
+				customPrompt: editedPrompt,
+				templateName: 'Reviewer',
+				templateHash: editedLegacyHash,
+			});
+
+			const report = manager.getAgentDriftReport('space-1');
+			expect(report.agents).toHaveLength(1);
+			expect(report.agents[0].drifted).toBe(true);
+		});
+
 		it('reports drifted=true when storedHash is null (post-backfill unmatchable rows)', async () => {
 			await manager.create({
 				spaceId: 'space-1',
@@ -543,6 +543,41 @@ describe('SpaceAgentManager', () => {
 
 			const report = manager.getAgentDriftReport('space-1');
 			expect(report.agents).toEqual([]);
+		});
+	});
+
+	describe('reconcileEquivalentLegacyPresetRows', () => {
+		it('reconciles legacy coordinator Reviewer prompts to the current preset prompt', async () => {
+			const { getPresetAgentTemplates } = await import(
+				'../../../../src/lib/space/agents/seed-agents'
+			);
+			const { reviewerAgent } = await import('../../../../src/lib/agent/coordinator/reviewer');
+			const { computeAgentTemplateHash } = await import(
+				'../../../../src/lib/space/agents/agent-template-hash'
+			);
+			const reviewer = getPresetAgentTemplates().find((p) => p.name === 'Reviewer');
+			if (!reviewer) throw new Error('Reviewer preset missing');
+			const legacyHash = computeAgentTemplateHash({
+				...reviewer,
+				customPrompt: reviewerAgent.prompt,
+			});
+
+			const created = await manager.create({
+				spaceId: 'space-1',
+				name: 'Reviewer',
+				description: reviewer.description,
+				tools: reviewer.tools,
+				customPrompt: reviewerAgent.prompt,
+				templateName: 'Reviewer',
+				templateHash: legacyHash,
+			});
+			if (!created.ok) throw new Error('create failed');
+
+			const updated = manager.reconcileEquivalentLegacyPresetRows('space-1');
+			expect(updated).toHaveLength(1);
+			expect(updated[0].customPrompt).toBe(reviewer.customPrompt);
+			expect(updated[0].templateHash).toBe(computeAgentTemplateHash(reviewer));
+			expect(manager.getById(created.value.id)?.customPrompt).toBe(reviewer.customPrompt);
 		});
 	});
 


### PR DESCRIPTION
Fixes Reviewer preset rows that still carry the legacy short coordinator prompt by reconciling them to the current full Reviewer template when agent config is loaded.

Adds regression coverage for legacy Reviewer prompt drift and startup/list reconciliation.