### PR TITLE
Fix Codex context capacity display

### DIFF
--- a/packages/daemon/src/lib/agent/context-fetcher.ts
+++ b/packages/daemon/src/lib/agent/context-fetcher.ts
@@ -21,10 +21,11 @@ import type {
 	ContextAPIUsage,
 	ModelInfo,
 } from '@neokai/shared';
+import { resolveCodexBridgeModelId } from '../providers/codex-anthropic-bridge/model-context-windows';
 import { Logger } from '../logger';
 
 type ContextMetadata =
-	| Pick<ModelInfo, 'id' | 'contextWindow' | 'preferContextWindowMetadata'>
+	| Pick<ModelInfo, 'id' | 'alias' | 'contextWindow' | 'preferContextWindowMetadata'>
 	| null
 	| undefined;
 
@@ -83,10 +84,19 @@ export class ContextFetcher {
 		const sdkRawCapacity = positiveInteger(response.rawMaxTokens);
 		const sdkCapacity = positiveInteger(response.maxTokens);
 		const responseModel = response.model || undefined;
-		const metadataCapacity =
-			!responseModel || modelMetadata?.id === responseModel
-				? positiveInteger(modelMetadata?.contextWindow)
-				: undefined;
+		const responseCodexModel = responseModel ? resolveCodexBridgeModelId(responseModel) : undefined;
+		const metadataCodexModel = modelMetadata?.id
+			? (resolveCodexBridgeModelId(modelMetadata.id) ??
+				(modelMetadata.alias ? resolveCodexBridgeModelId(modelMetadata.alias) : undefined))
+			: undefined;
+		const metadataMatchesResponse =
+			!responseModel ||
+			modelMetadata?.id === responseModel ||
+			modelMetadata?.alias === responseModel ||
+			(!!responseCodexModel && responseCodexModel === metadataCodexModel);
+		const metadataCapacity = metadataMatchesResponse
+			? positiveInteger(modelMetadata?.contextWindow)
+			: undefined;
 		const capacity =
 			modelMetadata?.preferContextWindowMetadata && metadataCapacity
 				? metadataCapacity

--- a/packages/daemon/src/lib/agent/context-fetcher.ts
+++ b/packages/daemon/src/lib/agent/context-fetcher.ts
@@ -21,7 +21,6 @@ import type {
 	ContextAPIUsage,
 	ModelInfo,
 } from '@neokai/shared';
-import { resolveCodexBridgeModelId } from '../providers/codex-anthropic-bridge/model-context-windows';
 import { Logger } from '../logger';
 
 type ContextMetadata =
@@ -84,16 +83,10 @@ export class ContextFetcher {
 		const sdkRawCapacity = positiveInteger(response.rawMaxTokens);
 		const sdkCapacity = positiveInteger(response.maxTokens);
 		const responseModel = response.model || undefined;
-		const responseCodexModel = responseModel ? resolveCodexBridgeModelId(responseModel) : undefined;
-		const metadataCodexModel = modelMetadata?.id
-			? (resolveCodexBridgeModelId(modelMetadata.id) ??
-				(modelMetadata.alias ? resolveCodexBridgeModelId(modelMetadata.alias) : undefined))
-			: undefined;
 		const metadataMatchesResponse =
 			!responseModel ||
 			modelMetadata?.id === responseModel ||
-			modelMetadata?.alias === responseModel ||
-			(!!responseCodexModel && responseCodexModel === metadataCodexModel);
+			modelMetadata?.alias === responseModel;
 		const metadataCapacity = metadataMatchesResponse
 			? positiveInteger(modelMetadata?.contextWindow)
 			: undefined;

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -390,7 +390,13 @@ function overlayCodexStaticMetadata(model: ModelInfo): ModelInfo {
 	const staticModel = resolvedCodexId
 		? findInModels(CODEX_STATIC_MODEL_METADATA, resolvedCodexId)
 		: undefined;
-	return staticModel ? { ...model, ...staticModel, available: model.available } : model;
+	return staticModel
+		? {
+				...model,
+				contextWindow: staticModel.contextWindow,
+				preferContextWindowMetadata: staticModel.preferContextWindowMetadata,
+			}
+		: model;
 }
 
 /**

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -15,7 +15,10 @@ import type { Query } from '@anthropic-ai/claude-agent-sdk';
 import { initializeProviders } from './providers/factory.js';
 import { getProviderRegistry } from './providers/registry.js';
 import type { Provider } from '@neokai/shared/provider';
-import { getCodexBridgeModelInfos } from './providers/codex-anthropic-bridge/model-context-windows.js';
+import {
+	getCodexBridgeModelInfos,
+	resolveCodexBridgeModelId,
+} from './providers/codex-anthropic-bridge/model-context-windows.js';
 
 /**
  * Legacy model ID mappings to SDK model IDs
@@ -106,6 +109,7 @@ const FALLBACK_MODELS: ModelInfo[] = [
  * not make those providers available for use.
  */
 const STATIC_MODEL_METADATA: ModelInfo[] = [...FALLBACK_MODELS, ...getCodexBridgeModelInfos()];
+const CODEX_STATIC_MODEL_METADATA = getCodexBridgeModelInfos();
 
 /**
  * Merge provider-loaded models with FALLBACK_MODELS.
@@ -380,6 +384,15 @@ function findInModels(models: ModelInfo[], idOrAlias: string): ModelInfo | undef
 	return found;
 }
 
+function overlayCodexStaticMetadata(model: ModelInfo): ModelInfo {
+	const resolvedCodexId =
+		resolveCodexBridgeModelId(model.id) ?? resolveCodexBridgeModelId(model.alias);
+	const staticModel = resolvedCodexId
+		? findInModels(CODEX_STATIC_MODEL_METADATA, resolvedCodexId)
+		: undefined;
+	return staticModel ? { ...model, ...staticModel, available: model.available } : model;
+}
+
 /**
  * Get model info by ID or alias, filtered to the specified provider.
  * All three parameters are required — no fallback to unfiltered search.
@@ -397,7 +410,9 @@ export async function getModelInfo(
 	const availableModels = getAvailableModels(cacheKey);
 	const providerModels = availableModels.filter((m) => m.provider === providerId);
 	const fromCache = findInModels(providerModels, idOrAlias);
-	if (fromCache) return fromCache;
+	if (fromCache) {
+		return providerId === 'anthropic-copilot' ? overlayCodexStaticMetadata(fromCache) : fromCache;
+	}
 
 	const staticProviderModels = STATIC_MODEL_METADATA.filter((m) => m.provider === providerId);
 	return findInModels(staticProviderModels, idOrAlias) ?? null;

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/model-context-windows.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/model-context-windows.ts
@@ -15,6 +15,7 @@ const CODEX_MODEL_ALIASES = {
 	'codex-5.4': 'gpt-5.4',
 	'codex-latest': 'gpt-5.5',
 	'codex-mini': 'gpt-5.4-mini',
+	'gpt-5.1-mini': 'gpt-5.1-codex-mini',
 	'codex-5.1-mini': 'gpt-5.1-codex-mini',
 } as const satisfies Record<string, CodexBridgeModelId>;
 

--- a/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
@@ -180,6 +180,7 @@ describe('ContextFetcher.toContextInfo', () => {
 
 		const info = ContextFetcher.toContextInfo(response, {
 			id: 'gpt-5.5',
+			alias: 'codex-latest',
 			contextWindow: 272000,
 			preferContextWindowMetadata: true,
 		});
@@ -188,6 +189,31 @@ describe('ContextFetcher.toContextInfo', () => {
 		expect(info.percentUsed).toBe(50);
 		expect(info.breakdown.Messages).toEqual({ tokens: 136000, percent: 50 });
 		expect(info.autoCompactThreshold).toBe(244800);
+	});
+
+	it('matches GPT-5.1 mini SDK model names to Codex metadata aliases', () => {
+		const response = baseResponse({
+			totalTokens: 64000,
+			maxTokens: 200000,
+			rawMaxTokens: 200000,
+			percentage: 32,
+			model: 'gpt-5.1-mini',
+			autoCompactThreshold: 180000,
+			isAutoCompactEnabled: true,
+			categories: [{ name: 'Messages', tokens: 64000, color: 'blue' }],
+		});
+
+		const info = ContextFetcher.toContextInfo(response, {
+			id: 'gpt-5.1-codex-mini',
+			alias: 'codex-5.1-mini',
+			contextWindow: 128000,
+			preferContextWindowMetadata: true,
+		});
+
+		expect(info.totalCapacity).toBe(128000);
+		expect(info.percentUsed).toBe(50);
+		expect(info.breakdown.Messages).toEqual({ tokens: 64000, percent: 50 });
+		expect(info.autoCompactThreshold).toBe(115200);
 	});
 
 	it('prefers SDK capacity over session metadata for fallback model usage', () => {

--- a/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
@@ -204,8 +204,8 @@ describe('ContextFetcher.toContextInfo', () => {
 		});
 
 		const info = ContextFetcher.toContextInfo(response, {
-			id: 'gpt-5.1-codex-mini',
-			alias: 'codex-5.1-mini',
+			id: 'gpt-5.1-mini',
+			alias: 'copilot-gpt-5-1-mini',
 			contextWindow: 128000,
 			preferContextWindowMetadata: true,
 		});

--- a/packages/daemon/tests/unit/1-core/core/model-service.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/model-service.test.ts
@@ -209,6 +209,49 @@ describe('Model Service', () => {
 			expect(model?.contextWindow).toBe(272000);
 		});
 
+		it('should overlay Codex metadata for matching Copilot OpenAI models', async () => {
+			setModelsCache(
+				new Map([
+					[
+						'global',
+						[
+							{
+								id: 'gpt-5.5',
+								name: 'GPT-5.5 (Copilot API)',
+								alias: 'copilot-gpt-5-5',
+								family: 'gpt',
+								provider: 'anthropic-copilot',
+								contextWindow: 200000,
+								description: 'GPT-5.5 via GitHub Copilot',
+								releaseDate: '2026-04-01',
+								available: true,
+							},
+							{
+								id: 'gpt-5.1-mini',
+								name: 'GPT-5.1 Mini (Copilot API)',
+								alias: 'copilot-gpt-5-1-mini',
+								family: 'gpt',
+								provider: 'anthropic-copilot',
+								contextWindow: 200000,
+								description: 'GPT-5.1 Mini via GitHub Copilot',
+								releaseDate: '2026-01-01',
+								available: true,
+							},
+						],
+					],
+				])
+			);
+
+			const full = await getModelInfo('gpt-5.5', 'global', 'anthropic-copilot');
+			const mini = await getModelInfo('gpt-5.1-mini', 'global', 'anthropic-copilot');
+
+			expect(full?.contextWindow).toBe(272000);
+			expect(full?.preferContextWindowMetadata).toBe(true);
+			expect(mini?.id).toBe('gpt-5.1-codex-mini');
+			expect(mini?.contextWindow).toBe(128000);
+			expect(mini?.preferContextWindowMetadata).toBe(true);
+		});
+
 		it('should not resolve unknown Codex models to fallback metadata', async () => {
 			clearModelsCache();
 

--- a/packages/daemon/tests/unit/1-core/core/model-service.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/model-service.test.ts
@@ -247,7 +247,7 @@ describe('Model Service', () => {
 
 			expect(full?.contextWindow).toBe(272000);
 			expect(full?.preferContextWindowMetadata).toBe(true);
-			expect(mini?.id).toBe('gpt-5.1-codex-mini');
+			expect(mini?.id).toBe('gpt-5.1-mini');
 			expect(mini?.contextWindow).toBe(128000);
 			expect(mini?.preferContextWindowMetadata).toBe(true);
 		});

--- a/packages/web/src/components/__tests__/ContextUsageBar.test.tsx
+++ b/packages/web/src/components/__tests__/ContextUsageBar.test.tsx
@@ -304,13 +304,35 @@ describe('ContextUsageBar', () => {
 			expect(container.textContent).not.toContain('200,000');
 		});
 
-		it('should use custom max context when provided', () => {
+		it('should use SDK capacity over model metadata fallback when SDK capacity is available', () => {
 			const { container } = render(
 				<ContextUsageBar contextUsage={mockContextUsage} maxContextTokens={100000} />
 			);
 
-			const svgText = container.querySelector('svg text');
-			expect(svgText?.textContent).toBe('25');
+			const clickable = container.querySelector('[title="Click for context details"]')!;
+			fireEvent.click(clickable);
+
+			expect(container.textContent).toContain('50,000 / 200,000');
+			expect(container.textContent).not.toContain('100,000');
+		});
+
+		it('should show Codex metadata capacity when context info has corrected capacity', () => {
+			const codexUsage: ContextInfo = {
+				...mockContextUsage,
+				totalUsed: 64000,
+				totalCapacity: 128000,
+				percentUsed: 50,
+				model: 'gpt-5.1-mini',
+			};
+			const { container } = render(
+				<ContextUsageBar contextUsage={codexUsage} maxContextTokens={200000} />
+			);
+
+			const clickable = container.querySelector('[title="Click for context details"]')!;
+			fireEvent.click(clickable);
+
+			expect(container.textContent).toContain('64,000 / 128,000');
+			expect(container.textContent).not.toContain('200,000');
 		});
 	});
 


### PR DESCRIPTION
Fixes OpenAI/Codex context-window display by applying local metadata for gpt-5.5 and gpt-5.1-mini when provider/SDK responses report a generic 200k capacity.

Tests: format, lint, typecheck, targeted daemon/web unit tests.