### PR TITLE
Fix autocompact buffer percentage

### DIFF
--- a/packages/daemon/src/lib/agent/context-fetcher.ts
+++ b/packages/daemon/src/lib/agent/context-fetcher.ts
@@ -132,7 +132,20 @@ export class ContextFetcher {
 				? Math.min(100, Math.max(0, Math.round((response.totalTokens / capacity) * 100)))
 				: Math.max(0, Math.round(response.percentage));
 		let autoCompactThreshold = response.autoCompactThreshold;
+		const autoCompactReservedTokens = (response.categories ?? []).find((category) =>
+			category.name.toLowerCase().includes('autocompact')
+		)?.tokens;
 		if (
+			typeof autoCompactReservedTokens === 'number' &&
+			autoCompactReservedTokens > 0 &&
+			capacity > 0 &&
+			autoCompactReservedTokens < capacity
+		) {
+			// The SDK breakdown reports the autocompact row as reserved/free buffer
+			// tokens. Convert that to the used-token threshold so the bar and the
+			// breakdown share the same capacity denominator and visual percentage.
+			autoCompactThreshold = capacity - autoCompactReservedTokens;
+		} else if (
 			typeof autoCompactThreshold === 'number' &&
 			capacity > 0 &&
 			response.maxTokens > 0 &&

--- a/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts
@@ -166,6 +166,30 @@ describe('ContextFetcher.toContextInfo', () => {
 		expect(info.autoCompactThreshold).toBe(244800);
 	});
 
+	it('derives the threshold from reserved autocompact breakdown tokens', () => {
+		const response = baseResponse({
+			totalTokens: 226963,
+			maxTokens: 200000,
+			rawMaxTokens: 272000,
+			percentage: 113.5,
+			autoCompactThreshold: 180000,
+			isAutoCompactEnabled: true,
+			categories: [
+				{ name: 'Messages', tokens: 193926, color: 'blue' },
+				{ name: 'Reserved for Autocompact', tokens: 33037, color: 'gray' },
+			],
+		});
+
+		const info = ContextFetcher.toContextInfo(response);
+
+		expect(info.totalCapacity).toBe(272000);
+		expect(info.breakdown['Reserved for Autocompact']).toEqual({
+			tokens: 33037,
+			percent: 12.1,
+		});
+		expect(info.autoCompactThreshold).toBe(238963);
+	});
+
 	it('uses Codex model metadata when SDK reports the generic 200k capacity', () => {
 		const response = baseResponse({
 			totalTokens: 136000,

--- a/packages/web/src/components/__tests__/ContextUsageBar.test.tsx
+++ b/packages/web/src/components/__tests__/ContextUsageBar.test.tsx
@@ -653,6 +653,36 @@ describe('ContextUsageBar', () => {
 			expect(bufferZone?.style.width).toBe('20%');
 		});
 
+		it('should match the reserved autocompact breakdown percentage', () => {
+			const usage: ContextInfo = {
+				totalUsed: 226963,
+				totalCapacity: 272000,
+				percentUsed: 83,
+				model: 'gpt-5.5',
+				breakdown: {
+					Messages: { tokens: 193926, percent: 71.3 },
+					'Reserved for Autocompact': { tokens: 33037, percent: 12.1 },
+				},
+				autoCompactThreshold: 238963,
+				isAutoCompactEnabled: true,
+			};
+			const { container } = render(<ContextUsageBar contextUsage={usage} />);
+
+			const clickable = container.querySelector('[title="Click for context details"]')!;
+			fireEvent.click(clickable);
+
+			const bufferZone = container.querySelector(
+				'[data-testid="autocompact-buffer-zone"]'
+			) as HTMLElement;
+			const marker = container.querySelector(
+				'[data-testid="autocompact-threshold-marker"]'
+			) as HTMLElement;
+
+			expect(Number.parseFloat(bufferZone?.style.width ?? '')).toBeCloseTo(12.14595588235294, 5);
+			expect(Number.parseFloat(marker?.style.left ?? '')).toBeCloseTo(87.85404411764706, 5);
+			expect(container.textContent).toContain('12.1%');
+		});
+
 		it('should render threshold marker at autoCompactThreshold position', () => {
 			const { container } = render(<ContextUsageBar contextUsage={usageWithAutoCompact} />);
 


### PR DESCRIPTION
Fixes autocompact threshold mapping so the buffer bar uses the same capacity-based percentage as the breakdown.

Tests: bun test packages/daemon/tests/unit/1-core/agent/context-fetcher.test.ts && bun --filter @neokai/web test src/components/__tests__/ContextUsageBar.test.tsx; bun run typecheck; bun run lint; bun run format:check