### PR TITLE
Regroup real API CI tests behind manual workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -762,11 +762,9 @@ jobs:
 
   # ============================================
   # DISCOVER TESTS
-  # Auto-discover and categorize E2E test files
-  # Tests are split into two groups:
-  #   - no-llm: UI-only tests (run fully parallel)
-  #   - llm: Tests requiring LLM round-trips (max 4 parallel)
-  # Run on: workflow_dispatch only (E2E is manual-only)
+  # Auto-discover No-LLM E2E test files
+  # LLM tests are excluded here and run from real-api-tests.yml.
+  # Run on: workflow_dispatch only (No-LLM E2E is manual-only)
   # ============================================
 
   discover:
@@ -775,39 +773,14 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     outputs:
       tests_no_llm: ${{ steps.categorize.outputs.tests_no_llm }}
-      tests_llm: ${{ steps.categorize.outputs.tests_llm }}
     steps:
       - uses: actions/checkout@v6
 
       - name: Categorize E2E test files
         id: categorize
         run: |
-          # Tests that require LLM API round-trips (send messages, wait for agent responses)
-          # Format: subdir/name (matching the subdirectory structure under packages/e2e/tests/)
-          # These tests need a real LLM provider (GLM) to process messages
-          LLM_TESTS=(
-            core/message-flow
-            core/interrupt-button
-            core/interrupt-error-bug
-            core/context-features
-            core/model-selection
-            features/archive
-            features/file-operations
-            features/message-operations
-            features/provider-model-switching
-            features/reviewer-feedback-loop
-            features/rewind-features
-            features/session-operations
-            features/slash-cmd
-            features/space-approval-gate-rejection
-            features/space-artifacts-panel
-            features/space-canvas-mode
-            features/space-happy-path-pipeline
-            features/worktree-isolation
-            responsive/mobile
-            responsive/tablet
-            settings/auto-title
-          )
+          # Tests that require LLM API round-trips are excluded here and run in real-api-tests.yml.
+          LLM_TESTS=(core/message-flow core/interrupt-button core/interrupt-error-bug core/context-features core/model-selection features/archive features/file-operations features/message-operations features/provider-model-switching features/reviewer-feedback-loop features/rewind-features features/session-operations features/slash-cmd features/space-approval-gate-rejection features/space-artifacts-panel features/space-canvas-mode features/space-happy-path-pipeline features/worktree-isolation responsive/mobile responsive/tablet settings/auto-title)
 
           # Tests to exclude entirely (disabled, pending stabilization)
           EXCLUDED_TESTS=(
@@ -822,29 +795,25 @@ jobs:
 
           # Find all test files recursively and extract subdir/name paths
           NO_LLM_JSON="[]"
-          LLM_JSON="[]"
           for file in $(find packages/e2e/tests -name "*.e2e.ts" -type f | sed 's|packages/e2e/tests/||; s|\.e2e\.ts$||' | sort); do
             if [[ -n "${EXCLUDED_SET[$file]}" ]]; then
               echo "EXCLUDED: $file"
               continue
             fi
+            if [[ -n "${LLM_SET[$file]}" ]]; then
+              echo "LLM (real-api-tests.yml): $file"
+              continue
+            fi
             # Create JSON object with path (for test runner) and name (for artifact/display)
             safe_name=$(echo "$file" | tr '/' '-')
             entry=$(jq -n -c --arg path "$file" --arg name "$safe_name" '{path: $path, name: $name}')
-            if [[ -n "${LLM_SET[$file]}" ]]; then
-              LLM_JSON=$(echo "$LLM_JSON" | jq -c ". + [$entry]")
-            else
-              NO_LLM_JSON=$(echo "$NO_LLM_JSON" | jq -c ". + [$entry]")
-            fi
+            NO_LLM_JSON=$(echo "$NO_LLM_JSON" | jq -c ". + [$entry]")
           done
 
           no_llm_count=$(echo "$NO_LLM_JSON" | jq length)
-          llm_count=$(echo "$LLM_JSON" | jq length)
           echo "No-LLM tests ($no_llm_count): $NO_LLM_JSON"
-          echo "LLM tests ($llm_count): $LLM_JSON"
 
           echo "tests_no_llm=$NO_LLM_JSON" >> $GITHUB_OUTPUT
-          echo "tests_llm=$LLM_JSON" >> $GITHUB_OUTPUT
 
   # ============================================
   # E2E TESTS - No LLM (Matrix, fully parallel)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,14 +4,14 @@
 #
 # | Trigger                              | Tests Run                                                    | Rationale                               |
 # |--------------------------------------|--------------------------------------------------------------|-----------------------------------------|
-# | PR to dev                            | check + unit + online + web                                  | Fast feedback for PRs                   |
-# | Push to dev                          | check + unit + online + web                                  | Same checks as PR for merge safety      |
-# | workflow_dispatch (default)          | all tests including E2E                                      | Manual full run including E2E           |
-# | workflow_dispatch (run_e2e_only=true) | discover + build + e2e only                                 | Selective E2E on any branch             |
+# | PR to dev                            | check + unit + mocked online + web                           | Fast feedback without real secrets      |
+# | Push to dev                          | check + unit + mocked online + web                           | Merge safety without real secrets       |
+# | workflow_dispatch (default)          | mocked CI + no-LLM E2E                                       | Manual mocked run on any branch         |
+# | workflow_dispatch (run_e2e_only=true) | discover + build + no-LLM E2E only                          | Selective no-LLM E2E on any branch      |
 #
-# NOTE: E2E tests are NOT run on any automatic trigger (push / PR). They are
-# manual-only via workflow_dispatch on any branch. This keeps the release
-# pipeline and PR feedback loop unblocked by flaky or long-running E2E suites.
+# NOTE: E2E tests are NOT run on any automatic trigger (push / PR). No-LLM E2E
+# remains manual-only here via workflow_dispatch on any branch. Real-API daemon
+# shards and LLM E2E are manual-only in real-api-tests.yml.
 #
 # Release is handled separately in release.yml (triggered by version tags).
 # Test coverage (unit, online, web) is uploaded to Coveralls.
@@ -120,8 +120,9 @@ jobs:
           exit 1
 
   # ============================================
-  # DAEMON ONLINE TESTS (Require API credentials)
-  # Run on: PR to dev, push to dev
+  # DAEMON ONLINE TESTS (Mocked credentials only)
+  # Run on: PR to dev, push to dev, workflow_dispatch
+  # Real-key shards are manual-only in real-api-tests.yml.
   # ============================================
 
   test-daemon-online:
@@ -150,9 +151,6 @@ jobs:
           # - providers-anthropic-copilot
           - rewind-1
           - rewind-2
-          - cross-provider-2
-          - cross-provider-3
-          - cross-provider-4
           # Room tests temporarily disabled during refactoring
           # - room-1
           # - room-multi-agent
@@ -209,7 +207,7 @@ jobs:
           - module: git
             test_path: tests/online/git
             timeout: 10
-            default_provider: minimax
+            mock_sdk: true
           - module: lifecycle
             test_path: tests/online/lifecycle
             mock_sdk: true
@@ -314,22 +312,7 @@ jobs:
           - module: websocket
             test_path: tests/online/websocket
             mock_sdk: true
-          # Cross-provider model switching tests - requires real MiniMax and GLM credentials
-          - module: cross-provider-2
-            test_path: tests/online/cross-provider/cross-provider-model-switch.test.ts
-            mock_sdk: false
-            default_provider: minimax
-            timeout: 10
-          - module: cross-provider-3
-            test_path: tests/online/cross-provider/glm-to-anthropic-resume.test.ts
-            mock_sdk: false
-            default_provider: glm
-            timeout: 10
-          - module: cross-provider-4
-            test_path: tests/online/cross-provider/thinking-block-signatures.test.ts
-            mock_sdk: false
-            default_provider: glm
-            timeout: 10
+          # Real-key cross-provider shards are manual-only in real-api-tests.yml.
 
     steps:
       - uses: actions/checkout@v6
@@ -379,20 +362,15 @@ jobs:
           NEOKAI_TEST_DISABLE_SANDBOX: '1'
           ANTHROPIC_BASE_URL: ${{ matrix.mock_sdk == true && 'http://127.0.0.1:8000' || '' }}
           # For Dev Proxy tests, never pass real Anthropic credentials.
-          ANTHROPIC_API_KEY: ${{ matrix.mock_sdk == true && 'sk-devproxy-test-key' || ((startsWith(matrix.module, 'features') || startsWith(matrix.module, 'room') || matrix.module == 'cross-provider-3' || matrix.module == 'cross-provider-4') && secrets.ANTHROPIC_API_KEY || '') }}
+          ANTHROPIC_API_KEY: ${{ matrix.mock_sdk == true && 'sk-devproxy-test-key' || '' }}
           ANTHROPIC_AUTH_TOKEN: ""
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ matrix.mock_sdk != true && (startsWith(matrix.module, 'features') || startsWith(matrix.module, 'room') || matrix.module == 'cross-provider-3' || matrix.module == 'cross-provider-4') && secrets.CLAUDE_CODE_OAUTH_TOKEN || '' }}
+          CLAUDE_CODE_OAUTH_TOKEN: ""
           OPENAI_API_KEY: ""
-          # Requires a PAT with the `copilot_requests` scope stored as COPILOT_GITHUB_TOKEN.
-          # secrets.GITHUB_TOKEN is a repo-scoped installation token and cannot authenticate Copilot API calls.
-          # If the secret is absent the env var is empty and the test FAILS (hard-fail, not skip — by design).
-          COPILOT_GITHUB_TOKEN: ${{ matrix.module == 'providers-anthropic-copilot' && secrets.COPILOT_GITHUB_TOKEN || '' }}
-          GLM_API_KEY: ${{ matrix.mock_sdk != true && secrets.GLM_API_KEY || '' }}
-          MINIMAX_API_KEY: ${{ matrix.mock_sdk != true && secrets.MINIMAX_API_KEY || '' }}
-          # Prefer MiniMax for online tests when available; fallback to GLM.
-          DEFAULT_PROVIDER: ${{ matrix.mock_sdk != true && (matrix.default_provider || (secrets.MINIMAX_API_KEY != '' && 'minimax' || 'glm')) || '' }}
-          # Prefer MiniMax highspeed as the default model when using MiniMax.
-          DEFAULT_MODEL: ${{ matrix.mock_sdk != true && secrets.MINIMAX_API_KEY != '' && 'MiniMax-M2.7-highspeed' || '' }}
+          COPILOT_GITHUB_TOKEN: ""
+          GLM_API_KEY: ""
+          MINIMAX_API_KEY: ""
+          DEFAULT_PROVIDER: ""
+          DEFAULT_MODEL: ""
 
       - name: Stop Dev Proxy
         if: always() && matrix.mock_sdk == true
@@ -986,10 +964,10 @@ jobs:
           # Set a dummy API key so provider availability check passes.
           # No-LLM tests don't need real API calls; the key just satisfies isAvailable().
           ANTHROPIC_API_KEY: "sk-devproxy-test-key"
-          # Clear other auth tokens to avoid credential conflicts
+          # Clear real auth tokens to avoid credential conflicts.
           ANTHROPIC_AUTH_TOKEN: ""
           CLAUDE_CODE_OAUTH_TOKEN: ""
-          GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
+          GLM_API_KEY: ""
           DEFAULT_MODEL: sonnet
           # Signal that the LLM will not respond in this environment.
           # neo.isProvisioned checks this flag so AI-dependent tests are skipped
@@ -1002,151 +980,6 @@ jobs:
         if: failure()
         with:
           name: e2e-no-llm-results-${{ matrix.test.name }}
-          path: |
-            packages/e2e/test-results/
-            packages/e2e/playwright-report/
-          retention-days: 7
-
-  # ============================================
-  # E2E TESTS - LLM Required (Matrix, max 4 parallel)
-  # Tests that send messages and wait for LLM responses
-  # Run on: workflow_dispatch only (E2E is manual-only on any branch)
-  # ============================================
-
-  e2e-llm:
-    name: E2E LLM (${{ matrix.test.name }})
-    runs-on: ubuntu-latest
-    needs: [build, discover]
-    # Manual-only: E2E must be explicitly triggered via workflow_dispatch.
-    if: >-
-      always() &&
-      github.event_name == 'workflow_dispatch' &&
-      needs.build.result == 'success' &&
-      needs.discover.result == 'success'
-    timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      max-parallel: 8
-      matrix:
-        test: ${{ fromJson(needs.discover.outputs.tests_llm) }}
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Setup Bun
-        uses: ./.github/actions/setup-bun
-        with:
-          bun-version: 1.3.13
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-
-      - name: Install sandbox dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo find /etc/apt/sources.list.d/ \( -name "*microsoft*" -o -name "*azure*" \) -delete 2>/dev/null || true
-          sudo apt-get update
-          sudo apt-get install -y bubblewrap socat ripgrep
-
-      - name: Setup Dev Proxy
-        if: runner.os == 'Linux'
-        uses: ./.github/actions/setup-devproxy
-
-      - name: Cache node_modules
-        uses: actions/cache@v5
-        with:
-          path: |
-            node_modules
-            packages/*/node_modules
-          key: bun-deps-${{ runner.os }}-${{ hashFiles('bun.lock', 'package.json') }}
-          restore-keys: |
-            bun-deps-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: |
-          echo "Starting bun install at $(date)"
-          timeout 180 bun install --frozen-lockfile --verbose 2>&1 || {
-            echo "bun install timed out or failed (lockfile may be stale — run 'bun install' locally and commit the updated bun.lock)"
-            exit 1
-          }
-          echo "Finished bun install at $(date)"
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('packages/e2e/package.json') }}
-          restore-keys: |
-            playwright-chromium-${{ runner.os }}-
-
-      - name: Install Playwright browsers
-        run: cd packages/e2e && bunx playwright install chromium
-
-      - name: Download binary
-        uses: actions/download-artifact@v8
-        with:
-          name: kai-linux-x64-e2e
-          path: dist/bin/
-
-      - name: Run E2E LLM test (${{ matrix.test.name }})
-        run: |
-          chmod +x dist/bin/kai-linux-x64
-          WORKSPACE=$(mktemp -d)
-
-          # Get a free port via a short-lived Python socket with SO_REUSEADDR.
-          # SO_REUSEADDR shrinks the reuse window on Linux so the binary can
-          # re-bind quickly even if the port is briefly in TIME_WAIT state.
-          PORT=$(python3 -c 'import socket; s=socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1); s.bind(("",0)); print(s.getsockname()[1])')
-          echo "Reserved port $PORT for binary"
-
-          NEOKAI_WORKSPACE_ROOT="$WORKSPACE" ./dist/bin/kai-linux-x64 --port "$PORT" &
-          BINARY_PID=$!
-          trap 'kill $BINARY_PID 2>/dev/null; rm -rf "$WORKSPACE"' EXIT
-
-          for i in $(seq 1 60); do
-            if curl -s "http://localhost:$PORT/" > /dev/null 2>&1; then
-              echo "Server ready on port $PORT (PID $BINARY_PID)"
-              break
-            fi
-            if ! kill -0 $BINARY_PID 2>/dev/null; then
-              echo "Binary process died unexpectedly"
-              exit 1
-            fi
-            sleep 0.5
-          done
-
-          if ! curl -s "http://localhost:$PORT/" > /dev/null 2>&1; then
-            echo "Server failed to start within 30s"
-            exit 1
-          fi
-
-          export PLAYWRIGHT_BASE_URL="http://localhost:$PORT"
-          cd packages/e2e
-          xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" \
-            bunx playwright test "tests/${{ matrix.test.path }}.e2e.ts"
-        env:
-          NEOKAI_USE_DEV_PROXY: "1"
-          ANTHROPIC_BASE_URL: "http://127.0.0.1:8000"
-          ANTHROPIC_API_KEY: "sk-devproxy-test-key"
-          ANTHROPIC_AUTH_TOKEN: ""
-          CLAUDE_CODE_OAUTH_TOKEN: ""
-          GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
-          CI: true
-
-      - name: Stop Dev Proxy
-        if: always()
-        run: |
-          if [ -n "$DEVPROXY_PID" ]; then
-            kill $DEVPROXY_PID 2>/dev/null || true
-          fi
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v7
-        if: failure()
-        with:
-          name: e2e-results-llm-${{ matrix.test.name }}
           path: |
             packages/e2e/test-results/
             packages/e2e/playwright-report/
@@ -1171,7 +1004,6 @@ jobs:
       - build
       - discover
       - e2e-no-llm
-      - e2e-llm
 
     steps:
       - name: Check all jobs passed
@@ -1232,12 +1064,6 @@ jobs:
             FAILED=1
           fi
 
-          # e2e-llm: workflow_dispatch only (E2E is manual-only)
-          if [[ "${{ needs.e2e-llm.result }}" == "failure" ]]; then
-            echo "❌ e2e-llm failed"
-            FAILED=1
-          fi
-
           if [ $FAILED -eq 1 ]; then
             echo ""
             echo "One or more required jobs failed:"
@@ -1250,7 +1076,6 @@ jobs:
             echo "  build: ${{ needs.build.result }}"
             echo "  discover: ${{ needs.discover.result }}"
             echo "  e2e-no-llm: ${{ needs.e2e-no-llm.result }}"
-            echo "  e2e-llm: ${{ needs.e2e-llm.result }}"
             exit 1
           fi
           echo "All tests passed!"

--- a/.github/workflows/real-api-tests.yml
+++ b/.github/workflows/real-api-tests.yml
@@ -52,6 +52,7 @@ jobs:
             default_provider: minimax
             secrets_used: MINIMAX_API_KEY, GLM_API_KEY/ZHIPU_API_KEY
             reason: Cross-provider model switching between MiniMax and GLM requires real provider round-trips.
+          # Currently describe.skip'd in-code; kept here so manual coverage resumes automatically when re-enabled.
           - module: cross-provider-3
             test_path: tests/online/cross-provider/glm-to-anthropic-resume.test.ts
             default_provider: glm

--- a/.github/workflows/real-api-tests.yml
+++ b/.github/workflows/real-api-tests.yml
@@ -1,0 +1,420 @@
+# Real API Tests - Manual-only integration and LLM/E2E coverage
+#
+# Audit findings:
+# - .github/workflows/release.yml uses only dummy GLM_API_KEY=smoke-test; no real API secrets.
+# - .github/workflows/main.yml now runs automatic push/PR CI with mocked credentials only.
+# - Real-key test coverage is collected here and can only run via workflow_dispatch.
+#
+# Manual-only jobs requiring real secrets:
+# - daemon-real-api (cross-provider-2): MINIMAX_API_KEY + GLM_API_KEY/ZHIPU_API_KEY
+#   for tests/online/cross-provider/cross-provider-model-switch.test.ts.
+# - daemon-real-api (cross-provider-3): GLM_API_KEY/ZHIPU_API_KEY + ANTHROPIC_API_KEY or
+#   CLAUDE_CODE_OAUTH_TOKEN, plus MINIMAX_API_KEY as enforced by the test preflight,
+#   for tests/online/cross-provider/glm-to-anthropic-resume.test.ts.
+# - daemon-real-api (cross-provider-4): GLM_API_KEY/ZHIPU_API_KEY + MINIMAX_API_KEY +
+#   ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN for
+#   tests/online/cross-provider/thinking-block-signatures.test.ts.
+# - e2e-llm: GLM_API_KEY for the Playwright tests categorized by discover as requiring
+#   LLM round-trips; Anthropic calls are routed to Dev Proxy with a dummy key.
+# - Disabled but documented real-key shards: providers-anthropic-to-codex-bridge needs
+#   OPENAI_API_KEY/CODEX_API_KEY, and providers-anthropic-copilot needs COPILOT_GITHUB_TOKEN.
+
+name: Real API Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_e2e_only:
+        description: 'Skip daemon real-API shards and run only E2E LLM tests (any branch)'
+        required: false
+        default: 'false'
+        type: boolean
+
+concurrency:
+  group: real-api-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  daemon-real-api:
+    name: Daemon Real API (${{ matrix.module }})
+    runs-on: ubuntu-latest
+    if: github.event.inputs.run_e2e_only != 'true'
+    timeout-minutes: ${{ matrix.timeout || 10 }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - module: cross-provider-2
+            test_path: tests/online/cross-provider/cross-provider-model-switch.test.ts
+            default_provider: minimax
+            secrets_used: MINIMAX_API_KEY, GLM_API_KEY/ZHIPU_API_KEY
+            reason: Cross-provider model switching between MiniMax and GLM requires real provider round-trips.
+          - module: cross-provider-3
+            test_path: tests/online/cross-provider/glm-to-anthropic-resume.test.ts
+            default_provider: glm
+            secrets_used: GLM_API_KEY/ZHIPU_API_KEY, MINIMAX_API_KEY, ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN
+            reason: Resume flow crosses GLM and Anthropic providers and validates real provider payload handling.
+          - module: cross-provider-4
+            test_path: tests/online/cross-provider/thinking-block-signatures.test.ts
+            default_provider: glm
+            secrets_used: GLM_API_KEY/ZHIPU_API_KEY, MINIMAX_API_KEY, ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN
+            reason: Thinking-block signature handling is validated across real GLM, MiniMax, and Anthropic responses.
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Document real API requirements
+        run: |
+          echo "Module: ${{ matrix.module }}"
+          echo "Secrets: ${{ matrix.secrets_used }}"
+          echo "Why: ${{ matrix.reason }}"
+          echo "Tests: ${{ matrix.test_path }}"
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+        with:
+          bun-version: 1.3.13
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Install sandbox dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo find /etc/apt/sources.list.d/ \( -name "*microsoft*" -o -name "*azure*" \) -delete 2>/dev/null || true
+          sudo apt-get update
+          sudo apt-get install -y bubblewrap socat ripgrep
+
+      - name: Cache node_modules
+        uses: actions/cache@v5
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: bun-deps-${{ runner.os }}-${{ hashFiles('bun.lock', 'package.json') }}
+          restore-keys: |
+            bun-deps-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run daemon real API tests (${{ matrix.module }})
+        working-directory: packages/daemon
+        run: bun test ${{ matrix.test_path }}
+        env:
+          NEOKAI_TEST_DISABLE_SANDBOX: '1'
+          ANTHROPIC_API_KEY: ${{ (matrix.module == 'cross-provider-3' || matrix.module == 'cross-provider-4') && secrets.ANTHROPIC_API_KEY || '' }}
+          ANTHROPIC_AUTH_TOKEN: ""
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ (matrix.module == 'cross-provider-3' || matrix.module == 'cross-provider-4') && secrets.CLAUDE_CODE_OAUTH_TOKEN || '' }}
+          OPENAI_API_KEY: ""
+          COPILOT_GITHUB_TOKEN: ""
+          GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
+          ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+          DEFAULT_PROVIDER: ${{ matrix.default_provider }}
+          DEFAULT_MODEL: ${{ matrix.default_provider == 'minimax' && 'MiniMax-M2.7-highspeed' || '' }}
+
+  build-e2e:
+    name: Build Binary for Real API E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+        with:
+          bun-version: 1.3.13
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Install sandbox dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo find /etc/apt/sources.list.d/ \( -name "*microsoft*" -o -name "*azure*" \) -delete 2>/dev/null || true
+          sudo apt-get update
+          sudo apt-get install -y bubblewrap socat ripgrep
+
+      - name: Cache node_modules
+        uses: actions/cache@v5
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: bun-deps-${{ runner.os }}-${{ hashFiles('bun.lock', 'package.json') }}
+          restore-keys: |
+            bun-deps-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build web frontend
+        run: cd packages/web && bun run build
+
+      - name: Generate embedded assets
+        run: bun run scripts/generate-embedded-assets.ts
+
+      - name: Compile binary
+        run: bun build --compile --target=bun-linux-x64 --outfile=dist/bin/kai-linux-x64 packages/cli/prod-entry.ts
+
+      - name: Smoke test
+        run: bun run scripts/smoke-test.ts ./dist/bin/kai-linux-x64
+        env:
+          GLM_API_KEY: smoke-test
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: kai-linux-x64-real-api-e2e
+          path: dist/bin/kai-linux-x64
+
+  discover-e2e:
+    name: Discover LLM E2E Tests
+    runs-on: ubuntu-latest
+    outputs:
+      tests_llm: ${{ steps.categorize.outputs.tests_llm }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Categorize E2E test files
+        id: categorize
+        run: |
+          LLM_TESTS=(
+            core/message-flow
+            core/interrupt-button
+            core/interrupt-error-bug
+            core/context-features
+            core/model-selection
+            features/archive
+            features/file-operations
+            features/message-operations
+            features/provider-model-switching
+            features/reviewer-feedback-loop
+            features/rewind-features
+            features/session-operations
+            features/slash-cmd
+            features/space-approval-gate-rejection
+            features/space-artifacts-panel
+            features/space-canvas-mode
+            features/space-happy-path-pipeline
+            features/worktree-isolation
+            responsive/mobile
+            responsive/tablet
+            settings/auto-title
+          )
+
+          EXCLUDED_TESTS=(
+            features/space-export-import
+            features/space-workflow-rules
+          )
+
+          declare -A LLM_SET EXCLUDED_SET
+          for t in "${LLM_TESTS[@]}"; do LLM_SET[$t]=1; done
+          for t in "${EXCLUDED_TESTS[@]}"; do EXCLUDED_SET[$t]=1; done
+
+          LLM_JSON="[]"
+          for file in $(find packages/e2e/tests -name "*.e2e.ts" -type f | sed 's|packages/e2e/tests/||; s|\.e2e\.ts$||' | sort); do
+            if [[ -n "${EXCLUDED_SET[$file]}" ]]; then
+              echo "EXCLUDED: $file"
+              continue
+            fi
+            if [[ -z "${LLM_SET[$file]}" ]]; then
+              continue
+            fi
+            safe_name=$(echo "$file" | tr '/' '-')
+            entry=$(jq -n -c --arg path "$file" --arg name "$safe_name" '{path: $path, name: $name}')
+            LLM_JSON=$(echo "$LLM_JSON" | jq -c ". + [$entry]")
+          done
+
+          llm_count=$(echo "$LLM_JSON" | jq length)
+          echo "LLM tests ($llm_count): $LLM_JSON"
+          echo "tests_llm=$LLM_JSON" >> $GITHUB_OUTPUT
+
+  e2e-llm:
+    name: E2E LLM (${{ matrix.test.name }})
+    runs-on: ubuntu-latest
+    needs: [build-e2e, discover-e2e]
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix:
+        test: ${{ fromJson(needs.discover-e2e.outputs.tests_llm) }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Document real API requirements
+        run: |
+          echo "Secrets: GLM_API_KEY"
+          echo "Why: LLM E2E tests send messages and wait for real GLM-backed agent responses. Anthropic traffic uses Dev Proxy."
+          echo "Test: packages/e2e/tests/${{ matrix.test.path }}.e2e.ts"
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+        with:
+          bun-version: 1.3.13
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Install sandbox dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo find /etc/apt/sources.list.d/ \( -name "*microsoft*" -o -name "*azure*" \) -delete 2>/dev/null || true
+          sudo apt-get update
+          sudo apt-get install -y bubblewrap socat ripgrep
+
+      - name: Setup Dev Proxy
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/setup-devproxy
+
+      - name: Cache node_modules
+        uses: actions/cache@v5
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: bun-deps-${{ runner.os }}-${{ hashFiles('bun.lock', 'package.json') }}
+          restore-keys: |
+            bun-deps-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: |
+          echo "Starting bun install at $(date)"
+          timeout 180 bun install --frozen-lockfile --verbose 2>&1 || {
+            echo "bun install timed out or failed (lockfile may be stale — run 'bun install' locally and commit the updated bun.lock)"
+            exit 1
+          }
+          echo "Finished bun install at $(date)"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('packages/e2e/package.json') }}
+          restore-keys: |
+            playwright-chromium-${{ runner.os }}-
+
+      - name: Install Playwright browsers
+        run: cd packages/e2e && bunx playwright install chromium
+
+      - name: Download binary
+        uses: actions/download-artifact@v8
+        with:
+          name: kai-linux-x64-real-api-e2e
+          path: dist/bin/
+
+      - name: Run E2E LLM test (${{ matrix.test.name }})
+        run: |
+          chmod +x dist/bin/kai-linux-x64
+          WORKSPACE=$(mktemp -d)
+
+          PORT=$(python3 -c 'import socket; s=socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1); s.bind(("",0)); print(s.getsockname()[1])')
+          echo "Reserved port $PORT for binary"
+
+          NEOKAI_WORKSPACE_ROOT="$WORKSPACE" ./dist/bin/kai-linux-x64 --port "$PORT" &
+          BINARY_PID=$!
+          trap 'kill $BINARY_PID 2>/dev/null; rm -rf "$WORKSPACE"' EXIT
+
+          for i in $(seq 1 60); do
+            if curl -s "http://localhost:$PORT/" > /dev/null 2>&1; then
+              echo "Server ready on port $PORT (PID $BINARY_PID)"
+              break
+            fi
+            if ! kill -0 $BINARY_PID 2>/dev/null; then
+              echo "Binary process died unexpectedly"
+              exit 1
+            fi
+            sleep 0.5
+          done
+
+          if ! curl -s "http://localhost:$PORT/" > /dev/null 2>&1; then
+            echo "Server failed to start within 30s"
+            exit 1
+          fi
+
+          export PLAYWRIGHT_BASE_URL="http://localhost:$PORT"
+          cd packages/e2e
+          xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" \
+            bunx playwright test "tests/${{ matrix.test.path }}.e2e.ts"
+        env:
+          NEOKAI_USE_DEV_PROXY: "1"
+          ANTHROPIC_BASE_URL: "http://127.0.0.1:8000"
+          ANTHROPIC_API_KEY: "sk-devproxy-test-key"
+          ANTHROPIC_AUTH_TOKEN: ""
+          CLAUDE_CODE_OAUTH_TOKEN: ""
+          GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
+          CI: true
+
+      - name: Stop Dev Proxy
+        if: always()
+        run: |
+          if [ -n "$DEVPROXY_PID" ]; then
+            kill $DEVPROXY_PID 2>/dev/null || true
+          fi
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: e2e-results-llm-${{ matrix.test.name }}
+          path: |
+            packages/e2e/test-results/
+            packages/e2e/playwright-report/
+          retention-days: 7
+
+  all-real-api-tests-pass:
+    name: All Real API Tests Pass
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    if: always()
+    needs:
+      - daemon-real-api
+      - build-e2e
+      - discover-e2e
+      - e2e-llm
+
+    steps:
+      - name: Check all real API jobs passed
+        run: |
+          FAILED=0
+
+          if [[ "${{ needs.daemon-real-api.result }}" == "failure" ]]; then
+            echo "❌ daemon-real-api failed"
+            FAILED=1
+          fi
+          if [[ "${{ needs.build-e2e.result }}" == "failure" ]]; then
+            echo "❌ build-e2e failed"
+            FAILED=1
+          fi
+          if [[ "${{ needs.discover-e2e.result }}" == "failure" ]]; then
+            echo "❌ discover-e2e failed"
+            FAILED=1
+          fi
+          if [[ "${{ needs.e2e-llm.result }}" == "failure" ]]; then
+            echo "❌ e2e-llm failed"
+            FAILED=1
+          fi
+
+          if [ $FAILED -eq 1 ]; then
+            echo ""
+            echo "One or more required real API jobs failed:"
+            echo "  daemon-real-api: ${{ needs.daemon-real-api.result }}"
+            echo "  build-e2e: ${{ needs.build-e2e.result }}"
+            echo "  discover-e2e: ${{ needs.discover-e2e.result }}"
+            echo "  e2e-llm: ${{ needs.e2e-llm.result }}"
+            exit 1
+          fi
+          echo "All real API tests passed!"

--- a/scripts/validate-online-test-matrix.sh
+++ b/scripts/validate-online-test-matrix.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
-# Validates that all daemon online test files are covered by the CI matrix.
+# Validates that all daemon online test files are covered by the CI matrices.
 #
-# The CI matrix in .github/workflows/main.yml splits some modules (rpc, room,
-# features, rewind, space) into shards with explicit file lists. This script catches new test
-# files that were added but not included in any shard.
+# The mocked CI matrix in .github/workflows/main.yml splits some modules (rpc, room,
+# features, rewind, space) into shards with explicit file lists. Real-key shards
+# live in .github/workflows/real-api-tests.yml. This script catches new test
+# files that were added but not included in either matrix.
 #
 # NOTE: providers-anthropic-to-codex-bridge shard is disabled (requires OPENAI_API_KEY).
 #
@@ -16,9 +17,10 @@ cd "$(git rev-parse --show-toplevel)"
 ONLINE_DIR="packages/daemon/tests/online"
 ERRORS=0
 
-# --- 1. Check split modules: every *.test.ts must appear in the matrix ---
+# --- 1. Check split modules: every *.test.ts must appear in a CI matrix ---
 # These arrays must stay in sync with the test_path values in
-# .github/workflows/main.yml  test-daemon-online matrix.
+# .github/workflows/main.yml test-daemon-online matrix and
+# .github/workflows/real-api-tests.yml daemon-real-api matrix.
 
 RPC_FILES=(
   rpc-agent-handlers.test.ts
@@ -60,6 +62,7 @@ PROVIDERS_FILES=(
   anthropic-to-codex-bridge-provider.test.ts  # CI shard disabled — kept here so validator doesn't flag it
 )
 
+# Real-key cross-provider tests must be present in .github/workflows/real-api-tests.yml.
 CROSS_PROVIDER_FILES=(
   cross-provider-model-switch.test.ts
   glm-to-anthropic-resume.test.ts
@@ -82,9 +85,26 @@ SPACE_FILES=(
   task-agent-skills.test.ts
 )
 
+check_workflow_references() {
+  local module_name=$1
+  local workflow=$2
+  shift 2
+  local expected=("$@")
+
+  for f in "${expected[@]}"; do
+    local test_path="tests/online/$module_name/$f"
+    if ! grep -qF "$test_path" "$workflow"; then
+      echo "ERROR: $test_path is not referenced in $workflow"
+      echo "  -> Add it to the appropriate CI matrix in $workflow"
+      ERRORS=$((ERRORS + 1))
+    fi
+  done
+}
+
 check_split_module() {
   local module_name=$1
-  shift
+  local workflow=$2
+  shift 2
   local expected=("$@")
 
   local dir="$ONLINE_DIR/$module_name"
@@ -105,7 +125,7 @@ check_split_module() {
     name=$(basename "$file")
     if ! echo "$expected_list" | grep -qxF "$name"; then
       echo "ERROR: $file is not in any CI matrix shard for '$module_name'"
-      echo "  -> Add it to a '$module_name-*' entry in .github/workflows/main.yml"
+      echo "  -> Add it to the appropriate matrix in $workflow"
       ERRORS=$((ERRORS + 1))
     fi
   done < <(find "$dir" -name "*.test.ts" -type f | sort)
@@ -114,19 +134,24 @@ check_split_module() {
   for f in "${expected[@]}"; do
     if [ ! -f "$dir/$f" ]; then
       echo "ERROR: $dir/$f is listed in matrix but does not exist on disk"
-      echo "  -> Remove it from the matrix in .github/workflows/main.yml"
+      echo "  -> Remove it from the matrix in $workflow"
       ERRORS=$((ERRORS + 1))
     fi
   done
+
+  check_workflow_references "$module_name" "$workflow" "${expected[@]}"
 }
 
-check_split_module "rpc" "${RPC_FILES[@]}"
-check_split_module "room" "${ROOM_FILES[@]:-}"
-check_split_module "features" "${FEATURES_FILES[@]}"
-check_split_module "providers" "${PROVIDERS_FILES[@]}"
-check_split_module "cross-provider" "${CROSS_PROVIDER_FILES[@]}"
-check_split_module "rewind" "${REWIND_FILES[@]}"
-check_split_module "space" "${SPACE_FILES[@]}"
+MAIN_WORKFLOW=".github/workflows/main.yml"
+REAL_API_WORKFLOW=".github/workflows/real-api-tests.yml"
+
+check_split_module "rpc" "$MAIN_WORKFLOW" "${RPC_FILES[@]}"
+check_split_module "room" "$MAIN_WORKFLOW" "${ROOM_FILES[@]:-}"
+check_split_module "features" "$MAIN_WORKFLOW" "${FEATURES_FILES[@]}"
+check_split_module "providers" "$MAIN_WORKFLOW" "${PROVIDERS_FILES[@]}"
+check_split_module "cross-provider" "$REAL_API_WORKFLOW" "${CROSS_PROVIDER_FILES[@]}"
+check_split_module "rewind" "$MAIN_WORKFLOW" "${REWIND_FILES[@]}"
+check_split_module "space" "$MAIN_WORKFLOW" "${SPACE_FILES[@]}"
 
 # --- 2. Check for new module directories not in the CI matrix ---
 # These are directories covered by directory-level test_path (auto-discover).
@@ -150,4 +175,4 @@ if [ "$ERRORS" -gt 0 ]; then
   exit 1
 fi
 
-echo "All online test files are covered by the CI matrix."
+echo "All online test files are covered by the CI matrices."


### PR DESCRIPTION
Moves real-provider daemon shards and LLM E2E into a workflow_dispatch-only Real API Tests workflow, with audit notes for required secrets.

Keeps push/PR CI on mocked credentials only while preserving manual E2E dispatch behavior.

Tests: bun run lint; bun run typecheck; bun run format:check; bash scripts/validate-online-test-matrix.sh; parsed workflow YAML.