### PR TITLE
Fix Space Agent MCP recovery after resume

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -280,6 +280,14 @@ export class AgentSession
 	onMissingWorkflowMcpServers?: (sessionId: string, missing: string[]) => Promise<void>;
 
 	/**
+	 * Self-heal callback for Space chat sessions: invoked by `QueryRunner.start()`
+	 * when it detects that the `space-agent-tools` MCP server is absent before a
+	 * turn starts (notably after context compaction/session resume). Set by
+	 * SpaceRuntimeService when provisioning the Space Agent session.
+	 */
+	onMissingSpaceChatMcpServers?: (sessionId: string, missing: string[]) => Promise<void>;
+
+	/**
 	 * Unified per-scope MCP enablement repo — exposed on the context so the
 	 * QueryOptionsBuilder can resolve the session > room > space > registry
 	 * precedence for skill-wrapped MCP servers (MCP M6).

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -1104,6 +1104,7 @@ CRITICAL RULES:
 		for (const skill of skills) {
 			if (this.isSkillScopeDisabled(skill.id, overrideDisabled, sessionDisabled)) continue;
 			if (skill.sourceType === 'builtin' && skill.config.type === 'builtin') {
+				if (skill.config.spaceOnly === true && !this.ctx.session.context?.spaceId) continue;
 				const wrapperDir = builtinSkillPluginPath(wrappersRoot, skill.config.commandName);
 				plugins.push({ type: 'local', path: wrapperDir });
 			}

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -81,6 +81,18 @@ function getStartupTimeoutMs(): number {
 // in user-facing error messages reflect these module-load-time snapshots.
 const STARTUP_TIMEOUT_MS = getStartupTimeoutMs();
 
+const REQUIRED_SPACE_CHAT_MCP_SERVERS = ['space-agent-tools'] as const;
+const REQUIRED_SPACE_CHAT_COORDINATION_TOOLS = [
+	'create_standalone_task',
+	'get_task_detail',
+	'retry_task',
+	'cancel_task',
+	'reassign_task',
+	'list_workflows',
+	'suggest_workflow',
+	'get_workflow_detail',
+] as const;
+
 /**
  * Context interface - what QueryRunner needs from AgentSession
  * Handlers take AgentSession instance directly via this context pattern
@@ -130,6 +142,13 @@ export interface QueryRunnerContext {
 	 * not applicable.
 	 */
 	onMissingWorkflowMcpServers?: (sessionId: string, missing: string[]) => Promise<void>;
+
+	/**
+	 * Self-heal hook for Space chat sessions missing their in-process coordination
+	 * MCP server. SpaceRuntimeService wires this so context compaction/session
+	 * resume cannot silently start a degraded Space Agent turn.
+	 */
+	onMissingSpaceChatMcpServers?: (sessionId: string, missing: string[]) => Promise<void>;
 }
 
 /**
@@ -294,6 +313,8 @@ export class QueryRunner {
 					(isWorkflowSubSession ? ' (workflow sub-session)' : '') +
 					` ${JSON.stringify(snapshotPayload)}`
 			);
+
+			queryOptions = await this.ensureSpaceChatMcpInvariant(queryOptions);
 			// P2-6 / P1-5: Self-heal — detect a missing required MCP server for
 			// workflow sub-sessions and recover via the registered callback.
 			// Required server:
@@ -933,6 +954,48 @@ export class QueryRunner {
 			})
 			.map(([name]) => name)
 			.sort();
+	}
+
+	private async ensureSpaceChatMcpInvariant(queryOptions: Options): Promise<Options> {
+		const { session, logger } = this.ctx;
+		if (session.type !== 'space_chat') return queryOptions;
+
+		const serverNames = Object.keys(queryOptions.mcpServers ?? {}).sort();
+		const missingServers = REQUIRED_SPACE_CHAT_MCP_SERVERS.filter(
+			(name) => !serverNames.includes(name)
+		);
+		if (missingServers.length === 0) return queryOptions;
+
+		const payload = {
+			event: 'space_chat.mcp.missing',
+			sessionId: session.id,
+			spaceId: session.context?.spaceId,
+			sessionType: session.type,
+			requiredServers: REQUIRED_SPACE_CHAT_MCP_SERVERS,
+			requiredTools: REQUIRED_SPACE_CHAT_COORDINATION_TOOLS,
+			missingServers,
+			presentServers: serverNames,
+			liveSdkServers: this.getLiveSdkMcpServerNames(queryOptions),
+			selfHealAttempted: !!this.ctx.onMissingSpaceChatMcpServers,
+		};
+
+		logger.error(
+			`QueryRunner.start(): Space chat session ${session.id} is MISSING required MCP servers. ` +
+				`Missing: [${missingServers.join(', ')}]. Present: [${serverNames.join(', ')}]. ` +
+				`This would remove Space coordination tools after compaction/resume. ${JSON.stringify(payload)}`
+		);
+
+		if (this.ctx.onMissingSpaceChatMcpServers) {
+			await this.ctx.onMissingSpaceChatMcpServers(session.id, missingServers);
+			const rebuilt = await this.ctx.optionsBuilder.build();
+			return this.ctx.optionsBuilder.addSessionStateOptions(rebuilt);
+		}
+
+		throw new Error(
+			`[MCP invariant] Space chat session ${session.id} missing required MCP servers: ` +
+				`[${missingServers.join(', ')}]. Refusing to start a degraded Space Agent turn. ` +
+				`Expected coordination tools: ${REQUIRED_SPACE_CHAT_COORDINATION_TOOLS.join(', ')}.`
+		);
 	}
 
 	/**

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -988,7 +988,19 @@ export class QueryRunner {
 		if (this.ctx.onMissingSpaceChatMcpServers) {
 			await this.ctx.onMissingSpaceChatMcpServers(session.id, missingServers);
 			const rebuilt = await this.ctx.optionsBuilder.build();
-			return this.ctx.optionsBuilder.addSessionStateOptions(rebuilt);
+			const repairedOptions = this.ctx.optionsBuilder.addSessionStateOptions(rebuilt);
+			const repairedServerNames = Object.keys(repairedOptions.mcpServers ?? {});
+			const stillMissing = REQUIRED_SPACE_CHAT_MCP_SERVERS.filter(
+				(name) => !repairedServerNames.includes(name)
+			);
+			if (stillMissing.length > 0) {
+				throw new Error(
+					`[MCP invariant] Space chat session ${session.id} still missing required MCP servers ` +
+						`after self-heal: [${stillMissing.join(', ')}]. Refusing to start a degraded ` +
+						`Space Agent turn.`
+				);
+			}
+			return repairedOptions;
 		}
 
 		throw new Error(

--- a/packages/daemon/src/lib/builtins.ts
+++ b/packages/daemon/src/lib/builtins.ts
@@ -76,6 +76,8 @@ export type BuiltinSkill =
 			description: string;
 			commandName: string;
 			enabled: boolean;
+			/** Restrict this built-in skill to sessions with Space context. */
+			spaceOnly?: boolean;
 	  };
 
 /**
@@ -154,5 +156,6 @@ export const BUILTIN_SKILLS: readonly BuiltinSkill[] = [
 			'POC fallback for Space task/workflow coordination through local runtime APIs instead of MCP.',
 		commandName: 'space-coordination',
 		enabled: true,
+		spaceOnly: true,
 	},
 ] as const;

--- a/packages/daemon/src/lib/builtins.ts
+++ b/packages/daemon/src/lib/builtins.ts
@@ -146,4 +146,13 @@ export const BUILTIN_SKILLS: readonly BuiltinSkill[] = [
 		commandName: 'playwright-interactive',
 		enabled: true,
 	},
+	{
+		kind: 'builtin-command',
+		name: 'space-coordination',
+		displayName: 'Space Coordination (POC)',
+		description:
+			'POC fallback for Space task/workflow coordination through local runtime APIs instead of MCP.',
+		commandName: 'space-coordination',
+		enabled: true,
+	},
 ] as const;

--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -50,6 +50,7 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 		processingState?: AgentProcessingState;
 	};
 	'session.deleted': { sessionId: string };
+	'session.reset': { sessionId: string; session: Session; restartQuery: boolean };
 
 	// SDK events — message may carry a neokai-injected `timestamp` from the DB layer.
 	// The SDK defines timestamp?: string (ISO 8601) on user messages; the daemon overrides it

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -67,6 +67,9 @@ export class SessionManager {
 	private logger: Logger;
 	private worktreeManager: WorktreeManager;
 	private eventBusUnsubscribers: Array<() => void> = [];
+	private sessionResetSubscribers: Array<
+		(event: { sessionId: string; session: Session; restartQuery: boolean }) => Promise<void> | void
+	> = [];
 	private started = false;
 
 	// Cleanup state machine - prevents race conditions during shutdown
@@ -201,6 +204,33 @@ export class SessionManager {
 		return resetPromise;
 	}
 
+	registerSessionResetSubscriber(
+		subscriber: (event: {
+			sessionId: string;
+			session: Session;
+			restartQuery: boolean;
+		}) => Promise<void> | void
+	): () => void {
+		this.sessionResetSubscribers.push(subscriber);
+		return () => {
+			const index = this.sessionResetSubscribers.indexOf(subscriber);
+			if (index !== -1) {
+				this.sessionResetSubscribers.splice(index, 1);
+			}
+		};
+	}
+
+	private async emitSessionReset(event: {
+		sessionId: string;
+		session: Session;
+		restartQuery: boolean;
+	}): Promise<void> {
+		await this.eventBus.emit('session.reset', event);
+		for (const subscriber of this.sessionResetSubscribers) {
+			await subscriber(event);
+		}
+	}
+
 	private async performHardResetAgentSession(
 		agentSession: AgentSession,
 		options: { restartQuery: boolean }
@@ -223,7 +253,7 @@ export class SessionManager {
 			});
 			this.sessionCache.set(sessionId, freshSession);
 
-			await this.eventBus.emit('session.reset', {
+			await this.emitSessionReset({
 				sessionId,
 				session: sessionForFreshInstance,
 				restartQuery: options.restartQuery,
@@ -560,6 +590,7 @@ export class SessionManager {
 				}
 			}
 			this.eventBusUnsubscribers = [];
+			this.sessionResetSubscribers = [];
 
 			// PHASE 2: Cleanup all in-memory sessions in parallel
 			// CRITICAL: Each AgentSession.cleanup() now properly stops SDK queries

--- a/packages/daemon/src/lib/session/session-manager.ts
+++ b/packages/daemon/src/lib/session/session-manager.ts
@@ -223,6 +223,12 @@ export class SessionManager {
 			});
 			this.sessionCache.set(sessionId, freshSession);
 
+			await this.eventBus.emit('session.reset', {
+				sessionId,
+				session: sessionForFreshInstance,
+				restartQuery: options.restartQuery,
+			});
+
 			try {
 				await agentSession.cleanup();
 			} catch (error) {

--- a/packages/daemon/src/lib/skills-manager.ts
+++ b/packages/daemon/src/lib/skills-manager.ts
@@ -540,7 +540,11 @@ export class SkillsManager {
 			displayName: def.displayName,
 			description: def.description,
 			sourceType: 'builtin',
-			config: { type: 'builtin', commandName: def.commandName },
+			config: {
+				type: 'builtin',
+				commandName: def.commandName,
+				...(def.spaceOnly ? { spaceOnly: true } : {}),
+			},
 			enabled: def.enabled,
 			builtIn: true,
 			validationStatus: 'valid',
@@ -624,11 +628,20 @@ export class SkillsManager {
 
 		const destDir = join(skillsRoot, commandName);
 		await mkdir(destDir, { recursive: true });
-		await cp(sourceDir, destDir, {
-			recursive: true,
-			force: false,
-			errorOnExist: false,
-		});
+		try {
+			// Preserve local edits and avoid surprising users by overwriting an already
+			// installed bundled skill. This means daemon upgrades do not update an
+			// existing SKILL.md in place; productionising this POC should add a version
+			// stamp/checksum path for intentional migrations.
+			await cp(sourceDir, destDir, {
+				recursive: true,
+				force: false,
+				errorOnExist: false,
+			});
+		} catch {
+			// Keep wrapper generation best-effort per skill: a missing/corrupt bundled
+			// asset must not prevent unrelated built-in skills from registering.
+		}
 	}
 
 	/**

--- a/packages/daemon/src/lib/skills-manager.ts
+++ b/packages/daemon/src/lib/skills-manager.ts
@@ -627,8 +627,8 @@ export class SkillsManager {
 		if (!sourceDir) return;
 
 		const destDir = join(skillsRoot, commandName);
-		await mkdir(destDir, { recursive: true });
 		try {
+			await mkdir(destDir, { recursive: true });
 			// Preserve local edits and avoid surprising users by overwriting an already
 			// installed bundled skill. This means daemon upgrades do not update an
 			// existing SKILL.md in place; productionising this POC should add a version
@@ -640,7 +640,7 @@ export class SkillsManager {
 			});
 		} catch {
 			// Keep wrapper generation best-effort per skill: a missing/corrupt bundled
-			// asset must not prevent unrelated built-in skills from registering.
+			// asset path must not prevent unrelated built-in skills from registering.
 		}
 	}
 

--- a/packages/daemon/src/lib/skills-manager.ts
+++ b/packages/daemon/src/lib/skills-manager.ts
@@ -6,8 +6,9 @@
  */
 
 import { homedir } from 'node:os';
-import { join } from 'node:path';
-import { access, mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { access, cp, mkdir, writeFile } from 'node:fs/promises';
 import { generateUUID, isBuiltinSkillConfig } from '@neokai/shared';
 import type {
 	AppSkill,
@@ -142,6 +143,15 @@ const SKILL_FETCH_MAX_DEPTH = 5;
 
 /** Maximum total number of files written by a single fetchGitHubDirectory call tree. */
 const SKILL_FETCH_MAX_FILES = 100;
+
+const BUILTIN_SKILL_ASSET_DIRS: Record<string, string> = {
+	'space-coordination': join(
+		dirname(fileURLToPath(import.meta.url)),
+		'space',
+		'skills',
+		'space-coordination'
+	),
+};
 
 /**
  * Validate that a name is safe to use as a single filesystem path component
@@ -592,6 +602,7 @@ export class SkillsManager {
 		for (const skill of this.repo.findAll()) {
 			if (skill.sourceType !== 'builtin') continue;
 			if (!isBuiltinSkillConfig(skill.config)) continue;
+			await this.ensureBundledBuiltinSkillAssets(skill.config.commandName, skillsRoot);
 			entries.push({
 				commandName: skill.config.commandName,
 				description: skill.description,
@@ -603,6 +614,22 @@ export class SkillsManager {
 	// ---------------------------------------------------------------------------
 	// Private helpers
 	// ---------------------------------------------------------------------------
+
+	private async ensureBundledBuiltinSkillAssets(
+		commandName: string,
+		skillsRoot: string
+	): Promise<void> {
+		const sourceDir = BUILTIN_SKILL_ASSET_DIRS[commandName];
+		if (!sourceDir) return;
+
+		const destDir = join(skillsRoot, commandName);
+		await mkdir(destDir, { recursive: true });
+		await cp(sourceDir, destDir, {
+			recursive: true,
+			force: false,
+			errorOnExist: false,
+		});
+	}
 
 	/**
 	 * Enqueue an async validation job for a skill.

--- a/packages/daemon/src/lib/space/agents/space-chat-agent.ts
+++ b/packages/daemon/src/lib/space/agents/space-chat-agent.ts
@@ -283,6 +283,16 @@ export function buildSpaceChatSystemPrompt(context: SpaceChatAgentContext = {}):
 
 	// Coordination tools section
 	sections.push(`\n## Coordination Tools\n`);
+	sections.push(
+		`Critical invariant: the \`space-agent-tools\` MCP server must be available every turn, ` +
+			`including after context compaction or session resume. If coordination MCP tools such as ` +
+			`\`create_standalone_task\`, \`get_task_detail\`, \`retry_task\`, \`cancel_task\`, ` +
+			`\`reassign_task\`, \`list_workflows\`, \`suggest_workflow\`, or ` +
+			`\`get_workflow_detail\` are missing, do not silently continue. Tell the user ` +
+			`the Space MCP surface is unavailable and use the \`space-coordination\` skill POC ` +
+			`as a fallback only when direct coordination is still required.`
+	);
+	sections.push('');
 	sections.push(`Use these tools to manage tasks and respond to events:`);
 	sections.push('');
 	sections.push(

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -723,6 +723,12 @@ export class SpaceRuntimeService {
 		// MCP servers on this space_chat session. `mergeRuntimeMcpServers` is the
 		// additive variant already used by `attachSpaceToolsToMemberSession`.
 		session.mergeRuntimeMcpServers(mcpServers);
+		session.onMissingSpaceChatMcpServers = async (_sessionId, missing) => {
+			log.warn(
+				`Space chat session ${spaceChatSessionId} missing MCP servers [${missing.join(', ')}]; re-attaching space-agent-tools before query start`
+			);
+			await this.setupSpaceAgentSession(space);
+		};
 
 		session.setRuntimeSystemPrompt(
 			buildSpaceChatSystemPrompt({

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -425,11 +425,16 @@ export class SpaceRuntimeService {
 		// Hard resets replace the cached AgentSession with a fresh instance built
 		// only from persisted DB state, so runtime-only MCP servers, Space prompts,
 		// and self-heal callbacks must be re-attached before replay restarts a query.
-		const unsubSessionReset = daemonHub.on('session.reset', async (event) => {
-			await this.reprovisionResetSession(event.session).catch((err) => {
-				log.error(`Failed to re-provision reset session ${event.sessionId}:`, err);
-			});
-		});
+		const unsubSessionReset =
+			typeof sessionManager.registerSessionResetSubscriber === 'function'
+				? sessionManager.registerSessionResetSubscriber(async (event) => {
+						await this.reprovisionResetSession(event.session, {
+							replayPendingMessages: event.restartQuery,
+						}).catch((err) => {
+							log.error(`Failed to re-provision reset session ${event.sessionId}:`, err);
+						});
+					})
+				: () => {};
 		this.unsubscribers.push(unsubSessionReset);
 	}
 
@@ -439,7 +444,10 @@ export class SpaceRuntimeService {
 	 * `space-agent-tools` server and the QueryRunner invariant would hard-fail
 	 * before its self-heal callback could exist.
 	 */
-	private async reprovisionResetSession(session: Session): Promise<void> {
+	private async reprovisionResetSession(
+		session: Session,
+		options: { replayPendingMessages: boolean }
+	): Promise<void> {
 		if (session.type === 'space_chat') {
 			const spaceId = session.context?.spaceId ?? session.id.match(/^space:chat:(.+)$/)?.[1];
 			if (!spaceId) return;
@@ -448,11 +456,11 @@ export class SpaceRuntimeService {
 				log.warn(`reprovisionResetSession: space "${spaceId}" not found (session ${session.id})`);
 				return;
 			}
-			await this.setupSpaceAgentSession(space);
+			await this.setupSpaceAgentSession(space, options);
 			return;
 		}
 
-		await this.attachSpaceToolsToMemberSession(session);
+		await this.attachSpaceToolsToMemberSession(session, options);
 	}
 
 	/**
@@ -577,7 +585,10 @@ export class SpaceRuntimeService {
 	 * the session (e.g., room tools) are preserved. The session's system
 	 * prompt is **not** touched.
 	 */
-	async attachSpaceToolsToMemberSession(session: Session): Promise<void> {
+	async attachSpaceToolsToMemberSession(
+		session: Session,
+		options: { replayPendingMessages?: boolean } = {}
+	): Promise<void> {
 		const { sessionManager } = this.config;
 		if (!sessionManager) return;
 		const spaceId = session.context?.spaceId;
@@ -660,7 +671,9 @@ export class SpaceRuntimeService {
 		// Merge rather than replace — other subsystems (e.g., room tools) may
 		// have already attached their own MCP servers on this session.
 		agentSession.mergeRuntimeMcpServers(additional);
-		await this.replayPendingMessagesAfterRuntimeProvisioning(agentSession);
+		if (options.replayPendingMessages !== false) {
+			await this.replayPendingMessagesAfterRuntimeProvisioning(agentSession);
+		}
 
 		log.info(
 			`Attached space-agent-tools to member session ${session.id} (space ${space.id}, type ${session.type ?? 'worker'})`
@@ -676,7 +689,10 @@ export class SpaceRuntimeService {
 	 *
 	 * No-op when sessionManager is absent.
 	 */
-	async setupSpaceAgentSession(space: Space): Promise<void> {
+	async setupSpaceAgentSession(
+		space: Space,
+		options: { replayPendingMessages?: boolean } = {}
+	): Promise<void> {
 		const {
 			sessionManager,
 			db,
@@ -784,7 +800,9 @@ export class SpaceRuntimeService {
 		);
 
 		log.info(`Space chat session provisioned for space ${space.id}`);
-		await this.replayPendingMessagesAfterRuntimeProvisioning(session);
+		if (options.replayPendingMessages !== false) {
+			await this.replayPendingMessagesAfterRuntimeProvisioning(session);
+		}
 
 		// Flush any Task Agent → Space Agent messages that were queued before
 		// this session was provisioned (handles the daemon-restart activation race).

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -421,6 +421,38 @@ export class SpaceRuntimeService {
 			this.releaseMemberSessionDbQuery(event.sessionId);
 		});
 		this.unsubscribers.push(unsubSessionDeleted);
+
+		// Hard resets replace the cached AgentSession with a fresh instance built
+		// only from persisted DB state, so runtime-only MCP servers, Space prompts,
+		// and self-heal callbacks must be re-attached before replay restarts a query.
+		const unsubSessionReset = daemonHub.on('session.reset', async (event) => {
+			await this.reprovisionResetSession(event.session).catch((err) => {
+				log.error(`Failed to re-provision reset session ${event.sessionId}:`, err);
+			});
+		});
+		this.unsubscribers.push(unsubSessionReset);
+	}
+
+	/**
+	 * Re-attach runtime-only Space configuration after SessionManager hard resets
+	 * a cached AgentSession. Without this hook, reset Space chats would lose their
+	 * `space-agent-tools` server and the QueryRunner invariant would hard-fail
+	 * before its self-heal callback could exist.
+	 */
+	private async reprovisionResetSession(session: Session): Promise<void> {
+		if (session.type === 'space_chat') {
+			const spaceId = session.context?.spaceId ?? session.id.match(/^space:chat:(.+)$/)?.[1];
+			if (!spaceId) return;
+			const space = await this.config.spaceManager.getSpace(spaceId);
+			if (!space) {
+				log.warn(`reprovisionResetSession: space "${spaceId}" not found (session ${session.id})`);
+				return;
+			}
+			await this.setupSpaceAgentSession(space);
+			return;
+		}
+
+		await this.attachSpaceToolsToMemberSession(session);
 	}
 
 	/**

--- a/packages/daemon/src/lib/space/skills/space-coordination/SKILL.md
+++ b/packages/daemon/src/lib/space/skills/space-coordination/SKILL.md
@@ -1,0 +1,72 @@
+# Space Coordination (POC)
+
+Use this skill when MCP coordination tools are unavailable or when you need the resilient, non-MCP path for Space task/workflow coordination.
+
+## Why this exists
+
+The primary Space coordination surface is the in-process `space-agent-tools` MCP server. It is re-attached by NeoKai runtime on every Space turn. This skill is a proof-of-concept fallback that does not depend on MCP tool schemas being present in the model context: it calls the local Space runtime HTTP/RPC API directly from Bash.
+
+`fetch-mcp` survives context compaction because it is a registry-backed MCP-server skill that is re-resolved into `mcpServers` during every SDK query build. Runtime Space MCP servers are in-process objects with closures and must be re-attached by the Space runtime before a query starts. If that invariant fails, use this skill and report the missing MCP surface.
+
+## Endpoint discovery
+
+Use the local daemon URL from the environment when present:
+
+```bash
+BASE_URL="${NEOKAI_BASE_URL:-${KAI_BASE_URL:-http://127.0.0.1:${NEOKAI_PORT:-${PORT:-8383}}}}"
+```
+
+Space context is normally available in the session id (`space:chat:<space_id>`) or task metadata. If you do not know the Space id, ask the user or inspect the current session/task context.
+
+## JSON-RPC call helper
+
+The exact API route may differ by runtime build. Prefer the same JSON-RPC endpoint used by the web client for Space RPCs. A typical invocation shape is:
+
+```bash
+curl -sS "$BASE_URL/rpc" \
+  -H 'content-type: application/json' \
+  --data '{"jsonrpc":"2.0","id":"space-skill-1","method":"space.task.createStandalone","params":{"spaceId":"<space_id>","title":"...","description":"...","priority":"normal","workflowId":"<optional_workflow_id>"}}'
+```
+
+If `/rpc` is not available in the current build, inspect the daemon's RPC route definitions and use the equivalent local endpoint. This POC intentionally keeps the transport in Bash/HTTP rather than MCP.
+
+## Capability mapping
+
+### create_standalone_task(title, description, priority, agent, workflow_id?)
+
+Call the Space task creation RPC with `spaceId`, `title`, `description`, `priority`, optional `workflowId`, and optional agent/custom agent assignment. Use this for all new work.
+
+### get_task_detail(task_id)
+
+Call the task detail RPC with `taskId` and present the task status, result, assigned agent, workflow run id, and error/blocking fields.
+
+### retry_task(task_id, updated_description?)
+
+Call the task retry RPC with `taskId` and optional replacement/updated description. Only use after confirming the retry is valid for the current task status.
+
+### cancel_task(task_id)
+
+Call the task cancel RPC with `taskId`. If the user wants the workflow run cancelled too, include the API's cancel-workflow flag when available.
+
+### reassign_task(task_id, agent)
+
+Call the task reassign RPC with `taskId` and either a built-in agent type or custom agent id.
+
+### list_workflows()
+
+Call the workflow list RPC with `spaceId`. Return workflow ids, names, descriptions, tags, and node counts.
+
+### suggest_workflow(description)
+
+The MCP tool intentionally returns all workflows and lets the model reason over them. Do the same here: list workflows, compare them against the description, and explain your recommended workflow.
+
+### get_workflow_detail(workflow_id)
+
+Call the workflow detail RPC with `workflowId`. Return nodes, transitions, gates, completion/autonomy levels, and relevant instructions.
+
+## Reliability guidance
+
+- Prefer MCP tools when present; they are typed and audited.
+- If MCP tools are missing, use this skill's HTTP path rather than continuing without coordination capability.
+- After using the fallback, tell the user that the MCP tool surface was missing and include enough detail for debugging.
+- The skill is available as a plugin/built-in skill and is re-declared through the SDK plugin mechanism on each query, so it remains discoverable across compaction/session resume independently of MCP server tool schemas.

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -1444,6 +1444,40 @@ describe('QueryOptionsBuilder', () => {
 			expect(options.mcpServers).toBeUndefined();
 		});
 
+		it('should inject space-only builtin skills only for sessions scoped to a Space', async () => {
+			const spaceSkill = {
+				id: 'skill-builtin-space-1',
+				name: 'space-coordination',
+				displayName: 'Space Coordination',
+				description: 'Space-only coordination fallback',
+				sourceType: 'builtin' as const,
+				config: { type: 'builtin' as const, commandName: 'space-coordination', spaceOnly: true },
+				enabled: true,
+				builtIn: true,
+				validationStatus: 'valid' as const,
+				createdAt: Date.now(),
+			};
+			const mockSkillsManager = {
+				getEnabledSkills: mock(() => [spaceSkill]),
+			};
+			const context: QueryOptionsBuilderContext = {
+				session: mockSession,
+				settingsManager: mockSettingsManager,
+				skillsManager:
+					mockSkillsManager as unknown as import('../../../../src/lib/skills-manager').SkillsManager,
+			};
+
+			let options = await new QueryOptionsBuilder(context).build();
+			expect(options.plugins).toBeUndefined();
+
+			mockSession.context = { spaceId: 'space-1' };
+			options = await new QueryOptionsBuilder(context).build();
+			expect(options.plugins).toBeDefined();
+			expect(options.plugins).toHaveLength(1);
+			const pluginPath = (options.plugins![0] as { type: string; path: string }).path;
+			expect(pluginPath).toContain('.neokai/skill-plugins/space-coordination');
+		});
+
 		it('should not inject a disabled builtin skill', async () => {
 			const builtinSkill = {
 				id: 'skill-builtin-2',

--- a/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-runner.test.ts
@@ -226,6 +226,20 @@ describe('QueryRunner', () => {
 	});
 
 	describe('start', () => {
+		async function withAnthropicApiKey(fn: () => Promise<void>): Promise<void> {
+			const savedApiKey = process.env.ANTHROPIC_API_KEY;
+			process.env.ANTHROPIC_API_KEY = 'sk-test-key';
+			try {
+				await fn();
+			} finally {
+				if (savedApiKey === undefined) {
+					delete process.env.ANTHROPIC_API_KEY;
+				} else {
+					process.env.ANTHROPIC_API_KEY = savedApiKey;
+				}
+			}
+		}
+
 		it('should skip start if query already running', async () => {
 			isRunningSpy.mockReturnValue(true);
 			runner = createRunner();
@@ -259,10 +273,19 @@ describe('QueryRunner', () => {
 			expect(ctx.firstMessageReceived).toBe(false);
 		});
 
+		function stopAfterRebuiltOptions() {
+			let addOptionsCalls = 0;
+			addSessionStateOptionsSpy.mockImplementation((options: unknown) => {
+				addOptionsCalls++;
+				if (addOptionsCalls === 2) {
+					throw new Error('stop after rebuilt options');
+				}
+				return options;
+			});
+		}
+
 		it('rebuilds query options after workflow MCP self-heal before SDK query creation', async () => {
-			const savedApiKey = process.env.ANTHROPIC_API_KEY;
-			process.env.ANTHROPIC_API_KEY = 'sk-test-key';
-			try {
+			await withAnthropicApiKey(async () => {
 				mockSession.id = 'space:s1:task:t1:exec:e1';
 				mockSession.workspacePath = tmpdir();
 				mockSession.type = 'worker';
@@ -282,14 +305,7 @@ describe('QueryRunner', () => {
 						model: 'claude-sonnet-4-20250514',
 						mcpServers: repairedServers,
 					});
-				let addOptionsCalls = 0;
-				addSessionStateOptionsSpy.mockImplementation((options: unknown) => {
-					addOptionsCalls++;
-					if (addOptionsCalls === 2) {
-						throw new Error('stop after rebuilt options');
-					}
-					return options;
-				});
+				stopAfterRebuiltOptions();
 				const onMissingWorkflowMcpServers = mock(async () => {
 					mockSession.config.mcpServers =
 						repairedServers as unknown as Session['config']['mcpServers'];
@@ -305,13 +321,101 @@ describe('QueryRunner', () => {
 				]);
 				expect(buildSpy).toHaveBeenCalledTimes(2);
 				expect(addSessionStateOptionsSpy).toHaveBeenCalledTimes(2);
-			} finally {
-				if (savedApiKey === undefined) {
-					delete process.env.ANTHROPIC_API_KEY;
-				} else {
-					process.env.ANTHROPIC_API_KEY = savedApiKey;
-				}
-			}
+			});
+		});
+
+		it('rebuilds query options after Space chat MCP self-heal before SDK query creation', async () => {
+			await withAnthropicApiKey(async () => {
+				mockSession.id = 'space:chat:s1';
+				mockSession.workspacePath = tmpdir();
+				mockSession.type = 'space_chat';
+				mockSession.context = { spaceId: 's1' };
+				mockSession.config.mcpServers = {};
+
+				const repairedServers = {
+					'space-agent-tools': {
+						type: 'sdk',
+						name: 'space-agent-tools',
+						instance: {},
+					},
+				};
+				buildSpy
+					.mockResolvedValueOnce({ model: 'claude-sonnet-4-20250514', mcpServers: {} })
+					.mockResolvedValueOnce({
+						model: 'claude-sonnet-4-20250514',
+						mcpServers: repairedServers,
+					});
+				stopAfterRebuiltOptions();
+				const onMissingSpaceChatMcpServers = mock(async () => {
+					mockSession.config.mcpServers =
+						repairedServers as unknown as Session['config']['mcpServers'];
+				});
+
+				const ctx = createContext({ onMissingSpaceChatMcpServers });
+				runner = new QueryRunner(ctx);
+				runner.start();
+				await ctx.queryPromise?.catch(() => {});
+
+				expect(onMissingSpaceChatMcpServers).toHaveBeenCalledWith('space:chat:s1', [
+					'space-agent-tools',
+				]);
+				expect(buildSpy).toHaveBeenCalledTimes(2);
+				expect(addSessionStateOptionsSpy).toHaveBeenCalledTimes(2);
+			});
+		});
+
+		it('throws when a Space chat MCP invariant is missing and no self-heal callback exists', async () => {
+			await withAnthropicApiKey(async () => {
+				mockSession.id = 'space:chat:s1';
+				mockSession.workspacePath = tmpdir();
+				mockSession.type = 'space_chat';
+				mockSession.context = { spaceId: 's1' };
+				mockSession.config.mcpServers = {};
+				buildSpy.mockResolvedValueOnce({ model: 'claude-sonnet-4-20250514', mcpServers: {} });
+
+				const ctx = createContext();
+				runner = new QueryRunner(ctx);
+				runner.start();
+				await ctx.queryPromise?.catch(() => {});
+
+				expect(buildSpy).toHaveBeenCalledTimes(1);
+				expect(addSessionStateOptionsSpy).toHaveBeenCalledTimes(1);
+				expect(handleErrorSpy).toHaveBeenCalled();
+				const error = handleErrorSpy.mock.calls[0][1] as Error;
+				expect(error.message).toContain('[MCP invariant]');
+				expect(error.message).toContain('space-agent-tools');
+			});
+		});
+
+		it('does not self-heal when a Space chat already has its required MCP server', async () => {
+			await withAnthropicApiKey(async () => {
+				mockSession.id = 'space:chat:s1';
+				mockSession.workspacePath = tmpdir();
+				mockSession.type = 'space_chat';
+				mockSession.context = { spaceId: 's1' };
+				const servers = {
+					'space-agent-tools': {
+						type: 'sdk',
+						name: 'space-agent-tools',
+						instance: {},
+					},
+				};
+				mockSession.config.mcpServers = servers as unknown as Session['config']['mcpServers'];
+				buildSpy.mockResolvedValueOnce({
+					model: 'claude-sonnet-4-20250514',
+					mcpServers: servers,
+				});
+				const onMissingSpaceChatMcpServers = mock(async () => {});
+
+				const ctx = createContext({ onMissingSpaceChatMcpServers });
+				runner = new QueryRunner(ctx);
+				runner.start();
+				await ctx.queryPromise?.catch(() => {});
+
+				expect(onMissingSpaceChatMcpServers).not.toHaveBeenCalled();
+				expect(buildSpy).toHaveBeenCalledTimes(1);
+				expect(addSessionStateOptionsSpy).toHaveBeenCalledTimes(1);
+			});
 		});
 	});
 

--- a/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
@@ -643,6 +643,11 @@ describe('SessionManager', () => {
 			expect(mockEventBus.emit).toHaveBeenCalledWith('session.errorClear', {
 				sessionId: 'test-id',
 			});
+			expect(mockEventBus.emit).toHaveBeenCalledWith('session.reset', {
+				sessionId: 'test-id',
+				session: expect.objectContaining({ id: 'test-id' }),
+				restartQuery: false,
+			});
 			expect(mockMessageHub.event).toHaveBeenCalledWith(
 				'session.reset',
 				{ message: 'Agent has been reset and is ready for new messages' },
@@ -703,6 +708,11 @@ describe('SessionManager', () => {
 
 				expect(result).toEqual({ success: true });
 				expect(freshSession).not.toBe(oldSession);
+				expect(mockEventBus.emit).toHaveBeenCalledWith('session.reset', {
+					sessionId: 'test-id',
+					session: expect.objectContaining({ id: 'test-id' }),
+					restartQuery: true,
+				});
 				expect(replaySpy).toHaveBeenCalledTimes(1);
 				expect(replayedSession).toBe(freshSession);
 			} finally {

--- a/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/session-manager.test.ts
@@ -694,11 +694,18 @@ describe('SessionManager', () => {
 			(mockDb.getSession as ReturnType<typeof mock>).mockReturnValue(persistedSession);
 
 			const oldSession = sessionManager.getSession('test-id');
+			const order: string[] = [];
+			const unregister = sessionManager.registerSessionResetSubscriber(async () => {
+				order.push('subscriber:start');
+				await Promise.resolve();
+				order.push('subscriber:end');
+			});
 			let replayedSession: AgentSession | null = null;
 			const replaySpy = spyOn(
 				AgentSession.prototype,
 				'replayPendingMessagesForImmediateMode'
 			).mockImplementation(async function (this: AgentSession) {
+				order.push('replay');
 				replayedSession = this;
 			});
 
@@ -715,7 +722,9 @@ describe('SessionManager', () => {
 				});
 				expect(replaySpy).toHaveBeenCalledTimes(1);
 				expect(replayedSession).toBe(freshSession);
+				expect(order).toEqual(['subscriber:start', 'subscriber:end', 'replay']);
 			} finally {
+				unregister();
 				replaySpy.mockRestore();
 				await sessionManager.interruptInMemorySession('test-id');
 			}

--- a/packages/daemon/tests/unit/4-space-storage/skills-manager.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/skills-manager.test.ts
@@ -1021,6 +1021,30 @@ describe('SkillsManager', () => {
 		}
 	});
 
+	test('ensureBuiltinPluginWrappers survives bundled asset directory setup failures', async () => {
+		const { mkdtemp, rm, writeFile } = await import('node:fs/promises');
+		const { tmpdir } = await import('node:os');
+		const tmpRoot = await mkdtemp(join(tmpdir(), 'kai-skills-mgr-bad-asset-'));
+		try {
+			const wrappersRoot = join(tmpRoot, 'skill-plugins');
+			const skillsRoot = join(tmpRoot, 'skills');
+
+			mgr.initializeBuiltins();
+			await writeFile(skillsRoot, 'not a directory');
+
+			const result = await mgr.ensureBuiltinPluginWrappers(wrappersRoot, skillsRoot);
+
+			// The bundled space-coordination asset cannot create its destination under
+			// a file-valued skillsRoot, but wrapper generation remains best-effort and
+			// still materialises unrelated builtin command wrappers.
+			expect(result.has('playwright')).toBe(true);
+			expect(result.has('playwright-interactive')).toBe(true);
+			expect(result.has('space-coordination')).toBe(true);
+		} finally {
+			await rm(tmpRoot, { recursive: true, force: true });
+		}
+	});
+
 	test('ensureBuiltinPluginWrappers is safe when no builtin skills are registered', async () => {
 		const { mkdtemp, rm } = await import('node:fs/promises');
 		const { tmpdir } = await import('node:os');

--- a/packages/daemon/tests/unit/4-space-storage/skills-manager.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/skills-manager.test.ts
@@ -957,16 +957,17 @@ describe('SkillsManager', () => {
 
 	// --- total built-in count ---
 
-	test('initializeBuiltins registers all four built-in skills total', () => {
+	test('initializeBuiltins registers all five built-in skills total', () => {
 		mgr.initializeBuiltins();
 
 		const builtIns = mgr.listSkills().filter((s) => s.builtIn);
-		expect(builtIns).toHaveLength(4);
+		expect(builtIns).toHaveLength(5);
 		const names = builtIns.map((s) => s.name);
 		expect(names).toContain('fetch-mcp');
 		expect(names).toContain('chrome-devtools-mcp');
 		expect(names).toContain('playwright');
 		expect(names).toContain('playwright-interactive');
+		expect(names).toContain('space-coordination');
 	});
 
 	// --- ensureBuiltinPluginWrappers ---
@@ -988,13 +989,14 @@ describe('SkillsManager', () => {
 			mgr.initializeBuiltins();
 			const result = await mgr.ensureBuiltinPluginWrappers(wrappersRoot, skillsRoot);
 
-			// Only the two `sourceType: 'builtin'` skills (playwright,
-			// playwright-interactive) should get wrappers — fetch-mcp and
-			// chrome-devtools-mcp are mcp_server-typed and must be skipped
-			// (they're loaded via mcpServers, not the SDK plugin loader).
-			expect(result.size).toBe(2);
+			// Only `sourceType: 'builtin'` skills (playwright,
+			// playwright-interactive, and the Space coordination POC) should get
+			// wrappers — fetch-mcp and chrome-devtools-mcp are mcp_server-typed and
+			// must be skipped (they're loaded via mcpServers, not the SDK plugin loader).
+			expect(result.size).toBe(3);
 			expect(result.has('playwright')).toBe(true);
 			expect(result.has('playwright-interactive')).toBe(true);
+			expect(result.has('space-coordination')).toBe(true);
 			expect(result.has('fetch-mcp')).toBe(false);
 			expect(result.has('chrome-devtools-mcp')).toBe(false);
 			expect(result.has('chrome-devtools')).toBe(false);
@@ -1005,6 +1007,10 @@ describe('SkillsManager', () => {
 				await readFile(join(wrappersRoot, 'playwright', '.claude-plugin', 'plugin.json'), 'utf8')
 			);
 			expect(manifest.name).toBe('playwright');
+
+			const spaceSkill = await readFile(join(skillsRoot, 'space-coordination', 'SKILL.md'), 'utf8');
+			expect(spaceSkill).toContain('Space Coordination (POC)');
+			expect(spaceSkill).toContain('create_standalone_task');
 
 			// The wrappers directory must be a real directory, not a symlink into
 			// the skills root, so regenerating never touches user content.

--- a/packages/daemon/tests/unit/5-space/runtime/space-chat-agent.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-chat-agent.test.ts
@@ -208,6 +208,13 @@ describe('buildSpaceChatSystemPrompt — workflow vs task guidance', () => {
 		expect(prompt).toContain('get_workflow_detail');
 	});
 
+	test('warns not to silently continue when Space MCP tools are missing', () => {
+		const prompt = buildSpaceChatSystemPrompt(makeContext());
+		expect(prompt).toContain('must be available every turn');
+		expect(prompt).toContain('context compaction');
+		expect(prompt).toContain('space-coordination');
+	});
+
 	test('includes guidance not to create tasks immediately', () => {
 		const prompt = buildSpaceChatSystemPrompt(makeContext());
 		expect(prompt).toContain('Never create tasks immediately');

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -422,6 +422,7 @@ describe('SpaceRuntimeService', () => {
 				// member-session sweep. Default to empty — tests that care
 				// override this mock.
 				listSessions: mock(() => [] as Session[]),
+				registerSessionResetSubscriber: mock(() => () => {}),
 			} as unknown as SessionManager;
 		}
 
@@ -594,19 +595,21 @@ describe('SpaceRuntimeService', () => {
 			const session = makeSession();
 			const sessionManager = makeSessionManager(session);
 			let resetHandler:
-				| ((event: { sessionId: string; session: Session }) => Promise<void>)
+				| ((event: { sessionId: string; session: Session; restartQuery: boolean }) => Promise<void>)
 				| undefined;
-			const daemonHub: DaemonHub = {
-				on: mock((event: string, handler: unknown) => {
-					if (event === 'session.reset') {
-						resetHandler = handler as typeof resetHandler;
-					}
+			const sessionManagerWithSubscriber = {
+				...sessionManager,
+				registerSessionResetSubscriber: mock((handler: typeof resetHandler) => {
+					resetHandler = handler;
 					return () => {};
 				}),
+			} as unknown as SessionManager;
+			const daemonHub: DaemonHub = {
+				on: mock(() => () => {}),
 				emit: mock(async () => {}),
 			} as unknown as DaemonHub;
 			const config: SpaceRuntimeServiceConfig = {
-				...buildConfigWithSession(sessionManager),
+				...buildConfigWithSession(sessionManagerWithSubscriber),
 				daemonHub,
 			};
 			const svc = new SpaceRuntimeService(config);
@@ -621,6 +624,7 @@ describe('SpaceRuntimeService', () => {
 					type: 'space_chat',
 					context: { spaceId: 'space-1' },
 				} as Session,
+				restartQuery: true,
 			});
 
 			expect(sessionManager.getSessionAsync).toHaveBeenCalledWith('space:chat:space-1');
@@ -652,10 +656,11 @@ describe('SpaceRuntimeService', () => {
 			svc.start();
 			await svc.stop();
 
-			// Four subscriptions are registered: space.created, session.created,
-			// session.deleted (which releases per-session db-query servers), and
-			// session.reset (which re-provisions hard-reset Space sessions).
-			expect(unsubFn).toHaveBeenCalledTimes(4);
+			// Three DaemonHub subscriptions are registered: space.created,
+			// session.created, and session.deleted (which releases per-session db-query
+			// servers). Hard-reset reprovisioning uses SessionManager's awaited
+			// in-process subscriber instead of DaemonHub.
+			expect(unsubFn).toHaveBeenCalledTimes(3);
 		});
 	});
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -590,6 +590,51 @@ describe('SpaceRuntimeService', () => {
 			await svc.stop();
 		});
 
+		test('session.reset re-provisions reset Space chats before query replay', async () => {
+			const session = makeSession();
+			const sessionManager = makeSessionManager(session);
+			let resetHandler:
+				| ((event: { sessionId: string; session: Session }) => Promise<void>)
+				| undefined;
+			const daemonHub: DaemonHub = {
+				on: mock((event: string, handler: unknown) => {
+					if (event === 'session.reset') {
+						resetHandler = handler as typeof resetHandler;
+					}
+					return () => {};
+				}),
+				emit: mock(async () => {}),
+			} as unknown as DaemonHub;
+			const config: SpaceRuntimeServiceConfig = {
+				...buildConfigWithSession(sessionManager),
+				daemonHub,
+			};
+			const svc = new SpaceRuntimeService(config);
+
+			svc.start();
+			expect(resetHandler).toBeDefined();
+
+			await resetHandler?.({
+				sessionId: 'space:chat:space-1',
+				session: {
+					id: 'space:chat:space-1',
+					type: 'space_chat',
+					context: { spaceId: 'space-1' },
+				} as Session,
+			});
+
+			expect(sessionManager.getSessionAsync).toHaveBeenCalledWith('space:chat:space-1');
+			expect(session.mergeRuntimeMcpServers).toHaveBeenCalled();
+			const [mcpArg] = (
+				session.mergeRuntimeMcpServers as Mock<typeof session.mergeRuntimeMcpServers>
+			).mock.calls.at(-1)!;
+			expect(mcpArg).toHaveProperty('space-agent-tools');
+			expect(typeof session.onMissingSpaceChatMcpServers).toBe('function');
+			expect(session.setRuntimeSystemPrompt).toHaveBeenCalled();
+
+			await svc.stop();
+		});
+
 		test('stop() unsubscribes from space.created events', async () => {
 			const unsubFn = mock(() => {});
 			const session = makeSession();
@@ -607,9 +652,10 @@ describe('SpaceRuntimeService', () => {
 			svc.start();
 			await svc.stop();
 
-			// Three subscriptions are registered: space.created, session.created,
-			// and session.deleted (which releases per-session db-query servers).
-			expect(unsubFn).toHaveBeenCalledTimes(3);
+			// Four subscriptions are registered: space.created, session.created,
+			// session.deleted (which releases per-session db-query servers), and
+			// session.reset (which re-provisions hard-reset Space sessions).
+			expect(unsubFn).toHaveBeenCalledTimes(4);
 		});
 	});
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -480,6 +480,25 @@ describe('SpaceRuntimeService', () => {
 			expect(promptArg.length).toBeGreaterThan(0);
 		});
 
+		test('missing Space chat MCP callback re-runs setup and re-attaches tools', async () => {
+			const session = makeSession();
+			const sessionManager = makeSessionManager(session);
+			const svc = new SpaceRuntimeService(buildConfigWithSession(sessionManager));
+
+			await svc.setupSpaceAgentSession(mockSpace);
+			expect(session.mergeRuntimeMcpServers).toHaveBeenCalledTimes(1);
+			expect(typeof session.onMissingSpaceChatMcpServers).toBe('function');
+
+			await session.onMissingSpaceChatMcpServers?.('space:chat:space-1', ['space-agent-tools']);
+
+			expect(sessionManager.getSessionAsync).toHaveBeenCalledTimes(2);
+			expect(session.mergeRuntimeMcpServers).toHaveBeenCalledTimes(2);
+			const [repairedMcpArg] = (
+				session.mergeRuntimeMcpServers as Mock<typeof session.mergeRuntimeMcpServers>
+			).mock.calls[1];
+			expect(repairedMcpArg).toHaveProperty('space-agent-tools');
+		});
+
 		test('no-op when session does not exist in DB', async () => {
 			const sessionManager = makeSessionManager(null); // session not found
 			const svc = new SpaceRuntimeService(buildConfigWithSession(sessionManager));

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-service.test.ts
@@ -470,6 +470,7 @@ describe('SpaceRuntimeService', () => {
 				session.mergeRuntimeMcpServers as Mock<typeof session.mergeRuntimeMcpServers>
 			).mock.calls[0];
 			expect(mcpArg).toHaveProperty('space-agent-tools');
+			expect(typeof session.onMissingSpaceChatMcpServers).toBe('function');
 
 			expect(session.setRuntimeSystemPrompt).toHaveBeenCalledTimes(1);
 			const [promptArg] = (

--- a/packages/shared/src/types/skills.ts
+++ b/packages/shared/src/types/skills.ts
@@ -22,6 +22,8 @@ export interface BuiltinSkillConfig {
 	type: 'builtin';
 	/** The slash-command name (e.g. "update-config", "claude-api"). */
 	commandName: string;
+	/** Restrict this built-in skill to sessions scoped to a Space. */
+	spaceOnly?: boolean;
 }
 
 /**


### PR DESCRIPTION
Fixes Space chat turns that can lose runtime MCP coordination after compaction/resume by detecting a missing `space-agent-tools` server before query start, re-attaching it, and refusing degraded startup if recovery is unavailable.

Also adds a `space-coordination` built-in skill POC documenting direct local-runtime coordination as a non-MCP fallback, with tests covering the recovery hook and skill registration.

Tests: `bun run check`; `bun test`; targeted Space/skills unit tests.