### PR TITLE
Fix MinimalThreadFeed active turn drift

### DIFF
--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
@@ -23,6 +23,7 @@ function makeRow(opts: {
 	message: unknown;
 	sessionId?: string;
 	origin?: string | null;
+	turnIndex?: number;
 }) {
 	return parseThreadRow({
 		id: opts.id,
@@ -36,6 +37,7 @@ function makeRow(opts: {
 		content: JSON.stringify(opts.message),
 		createdAt: opts.createdAt,
 		origin: opts.origin,
+		turnIndex: opts.turnIndex,
 	});
 }
 
@@ -1423,7 +1425,7 @@ describe('MinimalThreadFeed', () => {
 		);
 	});
 
-	it('keeps completed stats aligned with transition summary and result timestamp', () => {
+	it('keeps completed stats aligned with a matching transition summary and result timestamp', () => {
 		const t = Date.now();
 		const rows = [
 			makeRow({
@@ -1432,6 +1434,7 @@ describe('MinimalThreadFeed', () => {
 				createdAt: t,
 				message: assistantText('a1', 'visible final text'),
 				sessionId: 'space:s:task:t',
+				turnIndex: 1,
 			}),
 			makeRow({
 				id: 'r1',
@@ -1439,13 +1442,7 @@ describe('MinimalThreadFeed', () => {
 				createdAt: t + 2000,
 				message: resultMessage('r1', 'visible final text'),
 				sessionId: 'space:s:task:t',
-			}),
-			makeRow({
-				id: 'late',
-				label: 'Coder Agent',
-				createdAt: t + 60_000,
-				message: assistantToolUse('late', [{ name: 'Bash', input: { command: 'truncated-only' } }]),
-				sessionId: 'space:s:task:t',
+				turnIndex: 1,
 			}),
 		];
 		const summary: ActiveTurnSummary = {
@@ -1463,5 +1460,56 @@ describe('MinimalThreadFeed', () => {
 		expect(meta.textContent).toContain('3 tool calls');
 		expect(meta.textContent).toContain('2 messages');
 		expect(meta.textContent).toContain('2s');
+	});
+
+	it('does not apply an active summary to an older completed turn in the same session', () => {
+		const t = Date.now();
+		const rows = [
+			makeRow({
+				id: 'old-a1',
+				label: 'Coder Agent',
+				createdAt: t,
+				message: assistantToolUse('old-a1', [{ name: 'Bash', input: { command: 'old only' } }]),
+				sessionId: 'space:s:task:t',
+				turnIndex: 1,
+			}),
+			makeRow({
+				id: 'old-r1',
+				label: 'Coder Agent',
+				createdAt: t + 1000,
+				message: resultMessage('old-r1', 'old complete'),
+				sessionId: 'space:s:task:t',
+				turnIndex: 1,
+			}),
+			makeRow({
+				id: 'new-a1',
+				label: 'Coder Agent',
+				createdAt: t + 2000,
+				message: assistantText('new-a1', 'new active turn'),
+				sessionId: 'space:s:task:t',
+				turnIndex: 2,
+			}),
+		];
+		const summary: ActiveTurnSummary = {
+			sessionId: 'space:s:task:t',
+			turnIndex: 2,
+			entries: [
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'one', ts: t + 2000, uuid: 'new-a1' },
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'two', ts: t + 2001, uuid: 'new-a1' },
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'three', ts: t + 2002, uuid: 'new-a1' },
+			],
+		};
+
+		render(
+			<MinimalThreadFeed
+				parsedRows={rows}
+				activeAgentLabels={new Set(['Coder Agent'])}
+				activeTurnSummaries={[summary]}
+			/>
+		);
+		const completedMeta = screen.getByTestId('minimal-thread-agent-meta');
+		expect(completedMeta.textContent).toContain('1 tool call');
+		expect(completedMeta.textContent).not.toContain('3 tool calls');
+		expect(screen.getByTestId('minimal-thread-active-meta').textContent).toContain('⚙ 3');
 	});
 });

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
@@ -1512,4 +1512,65 @@ describe('MinimalThreadFeed', () => {
 		expect(completedMeta.textContent).not.toContain('3 tool calls');
 		expect(screen.getByTestId('minimal-thread-active-meta').textContent).toContain('⚙ 3');
 	});
+
+	it('only applies summary-derived completed counts to the final result slice', () => {
+		const t = Date.now();
+		const rows = [
+			makeRow({
+				id: 'a1',
+				label: 'Coder Agent',
+				createdAt: t,
+				message: assistantToolUse('a1', [{ name: 'Bash', input: { command: 'early only' } }]),
+				sessionId: 'space:s:task:t',
+				turnIndex: 1,
+			}),
+			makeRow({
+				id: 'a1-text',
+				label: 'Coder Agent',
+				createdAt: t + 500,
+				message: assistantText('a1-text', 'paused before handoff'),
+				sessionId: 'space:s:task:t',
+				turnIndex: 1,
+			}),
+			makeRow({
+				id: 'handoff',
+				label: 'Coder Agent',
+				createdAt: t + 1000,
+				message: replayUserMessage('handoff', 'please continue'),
+				sessionId: 'space:s:task:t',
+				turnIndex: 1,
+			}),
+			makeRow({
+				id: 'a2',
+				label: 'Coder Agent',
+				createdAt: t + 2000,
+				message: assistantText('a2', 'finished after handoff'),
+				sessionId: 'space:s:task:t',
+				turnIndex: 1,
+			}),
+			makeRow({
+				id: 'r1',
+				label: 'Coder Agent',
+				createdAt: t + 3000,
+				message: resultMessage('r1', 'finished after handoff'),
+				sessionId: 'space:s:task:t',
+				turnIndex: 1,
+			}),
+		];
+		const summary: ActiveTurnSummary = {
+			sessionId: 'space:s:task:t',
+			turnIndex: 1,
+			entries: [
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'one', ts: t, uuid: 'a1' },
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'two', ts: t + 1, uuid: 'a1' },
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'three', ts: t + 2, uuid: 'a1' },
+			],
+		};
+
+		render(<MinimalThreadFeed parsedRows={rows} activeTurnSummaries={[summary]} />);
+		const metas = screen.getAllByTestId('minimal-thread-agent-meta');
+		expect(metas[0].textContent).toContain('1 tool call');
+		expect(metas[0].textContent).not.toContain('3 tool calls');
+		expect(metas[1].textContent).toContain('3 tool calls');
+	});
 });

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
@@ -65,11 +65,12 @@ function assistantToolUse(
 	};
 }
 
-function resultMessage(uuid: string) {
+function resultMessage(uuid: string, result = '') {
 	return {
 		type: 'result',
 		uuid,
 		subtype: 'success',
+		result,
 		usage: { input_tokens: 100, output_tokens: 50 },
 	};
 }
@@ -366,11 +367,16 @@ describe('MinimalThreadFeed', () => {
 		expect(text).toContain('provisionExistingSpaces');
 		expect(text).toContain('git status');
 
-		// Status text comes from the active body.
+		// Status text sits in the active header while the rail shows richer live stats.
 		expect(turn.textContent).toContain('Running');
+		const rail = screen.getByTestId('minimal-thread-active-rail');
+		expect(rail.textContent).not.toContain('Running');
+		expect(screen.getByTestId('minimal-thread-active-meta').textContent).toContain('⚙ 4');
+		expect(turn.textContent).toContain('4 messages');
+		expect(screen.getByTestId('minimal-thread-last-event').textContent).toContain('last event');
 	});
 
-	it('caps the active roster at 4 most-recent tool calls', () => {
+	it('caps the active roster at 8 most-recent tool calls', () => {
 		const t = Date.now();
 		const rows = [
 			makeRow({
@@ -381,7 +387,7 @@ describe('MinimalThreadFeed', () => {
 			}),
 		];
 
-		// 6 tool entries in the active-turn summary — only the last 4 should render.
+		// 10 tool entries in the active-turn summary — only the last 8 should render.
 		const summary: ActiveTurnSummary = {
 			sessionId: 'space:s:task:t',
 			turnIndex: 1,
@@ -392,6 +398,10 @@ describe('MinimalThreadFeed', () => {
 				{ kind: 'tool_use', toolName: 'Bash', preview: 'echo 4', ts: t + 4, uuid: 'a1' },
 				{ kind: 'tool_use', toolName: 'Bash', preview: 'echo 5', ts: t + 5, uuid: 'a1' },
 				{ kind: 'tool_use', toolName: 'Bash', preview: 'echo 6', ts: t + 6, uuid: 'a1' },
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'echo 7', ts: t + 7, uuid: 'a1' },
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'echo 8', ts: t + 8, uuid: 'a1' },
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'echo 9', ts: t + 9, uuid: 'a1' },
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'echo 10', ts: t + 10, uuid: 'a1' },
 			],
 		};
 
@@ -403,13 +413,12 @@ describe('MinimalThreadFeed', () => {
 			/>
 		);
 		const entries = screen.getAllByTestId('minimal-thread-roster-entry');
-		expect(entries.length).toBe(4);
+		expect(entries.length).toBe(8);
 		expect(entries[0].textContent).toContain('echo 3');
-		expect(entries[3].textContent).toContain('echo 6');
+		expect(entries[7].textContent).toContain('echo 10');
 		// The very oldest two were trimmed.
-		const allText = entries.map((e) => e.textContent).join('\n');
-		expect(allText).not.toContain('echo 1');
-		expect(allText).not.toContain('echo 2');
+		expect(entries[0].textContent).not.toContain('echo 1');
+		expect(entries[0].textContent).not.toContain('echo 2');
 	});
 
 	it('does not show the active rail on completed blocks', () => {
@@ -752,6 +761,10 @@ describe('MinimalThreadFeed', () => {
 		expect(entries[2].textContent).toContain('Now editing the broken assertion');
 		expect(entries[3].dataset.rosterKind).toBe('tool');
 		expect(entries[3].textContent).toContain('Edit');
+		const meta = screen.getByTestId('minimal-thread-active-meta');
+		expect(meta.textContent).toContain('✦ 0');
+		expect(meta.textContent).toContain('💬 2');
+		expect(meta.textContent).toContain('⚙ 2');
 	});
 
 	it('skips empty/whitespace assistant text entries when building the roster', () => {
@@ -939,7 +952,7 @@ describe('MinimalThreadFeed', () => {
 		});
 	});
 
-	it('caps the active roster at 4 most-recent entries even with mixed kinds', () => {
+	it('caps the active roster at 8 most-recent entries even with mixed kinds', () => {
 		const t = Date.now();
 		const rows = [
 			makeRow({
@@ -950,7 +963,7 @@ describe('MinimalThreadFeed', () => {
 			}),
 		];
 
-		// 6 mixed entries — only the last 4 should render.
+		// 10 mixed entries — only the last 8 should render.
 		const summary: ActiveTurnSummary = {
 			sessionId: 'space:s:task:t',
 			turnIndex: 1,
@@ -961,6 +974,10 @@ describe('MinimalThreadFeed', () => {
 				{ kind: 'tool_use', toolName: 'Bash', preview: 'echo 2', ts: t + 4, uuid: 'a1' },
 				{ kind: 'text', text: 'msg-3', ts: t + 5, uuid: 'a1' },
 				{ kind: 'tool_use', toolName: 'Bash', preview: 'echo 3', ts: t + 6, uuid: 'a1' },
+				{ kind: 'text', text: 'msg-4', ts: t + 7, uuid: 'a1' },
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'echo 4', ts: t + 8, uuid: 'a1' },
+				{ kind: 'text', text: 'msg-5', ts: t + 9, uuid: 'a1' },
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'echo 5', ts: t + 10, uuid: 'a1' },
 			],
 		};
 
@@ -972,16 +989,16 @@ describe('MinimalThreadFeed', () => {
 			/>
 		);
 		const entries = screen.getAllByTestId('minimal-thread-roster-entry');
-		expect(entries.length).toBe(4);
+		expect(entries.length).toBe(8);
 		const allText = entries.map((e) => e.textContent).join('\n');
 		// Oldest two trimmed.
 		expect(allText).not.toContain('msg-1');
 		expect(allText).not.toContain('echo 1');
-		// Latest four kept.
+		// Latest eight kept.
 		expect(allText).toContain('msg-2');
 		expect(allText).toContain('echo 2');
-		expect(allText).toContain('msg-3');
-		expect(allText).toContain('echo 3');
+		expect(allText).toContain('msg-5');
+		expect(allText).toContain('echo 5');
 	});
 
 	describe('Per-agent active rail (multi-session)', () => {
@@ -1361,5 +1378,90 @@ describe('MinimalThreadFeed', () => {
 		// Active rail is still present (the block IS active) — it just has
 		// no entries.
 		expect(screen.getByTestId('minimal-thread-active-rail')).toBeTruthy();
+	});
+
+	it('uses the latest session id for active summary lookup and active open affordance', () => {
+		const t = Date.now();
+		const rows = [
+			makeRow({
+				id: 'a1',
+				label: 'Coder Agent',
+				createdAt: t,
+				message: assistantText('a1', 'earlier text'),
+				sessionId: 'space:s:old:task:t',
+			}),
+			makeRow({
+				id: 'a2',
+				label: 'Coder Agent',
+				createdAt: t + 1000,
+				message: assistantToolUse('a2', [{ name: 'Bash', input: { command: 'bun test' } }]),
+				sessionId: 'space:s:new:task:t',
+			}),
+		];
+		const summary: ActiveTurnSummary = {
+			sessionId: 'space:s:new:task:t',
+			turnIndex: 1,
+			entries: [
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'bun test', ts: t + 1000, uuid: 'a2' },
+			],
+		};
+
+		render(
+			<MinimalThreadFeed
+				parsedRows={rows}
+				activeAgentLabels={new Set(['Coder Agent'])}
+				activeTurnSummaries={[summary]}
+			/>
+		);
+
+		expect(screen.getByText(/bun test/)).toBeTruthy();
+		fireEvent.click(screen.getByTestId('minimal-thread-agent-open'));
+		expect(mockPushOverlayHistory).toHaveBeenCalledWith(
+			'space:s:new:task:t',
+			'Coder Agent',
+			undefined
+		);
+	});
+
+	it('keeps completed stats aligned with transition summary and result timestamp', () => {
+		const t = Date.now();
+		const rows = [
+			makeRow({
+				id: 'a1',
+				label: 'Coder Agent',
+				createdAt: t,
+				message: assistantText('a1', 'visible final text'),
+				sessionId: 'space:s:task:t',
+			}),
+			makeRow({
+				id: 'r1',
+				label: 'Coder Agent',
+				createdAt: t + 2000,
+				message: resultMessage('r1', 'visible final text'),
+				sessionId: 'space:s:task:t',
+			}),
+			makeRow({
+				id: 'late',
+				label: 'Coder Agent',
+				createdAt: t + 60_000,
+				message: assistantToolUse('late', [{ name: 'Bash', input: { command: 'truncated-only' } }]),
+				sessionId: 'space:s:task:t',
+			}),
+		];
+		const summary: ActiveTurnSummary = {
+			sessionId: 'space:s:task:t',
+			turnIndex: 1,
+			entries: [
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'one', ts: t, uuid: 'a1' },
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'two', ts: t + 1, uuid: 'a1' },
+				{ kind: 'tool_use', toolName: 'Bash', preview: 'three', ts: t + 2, uuid: 'a1' },
+			],
+		};
+
+		render(<MinimalThreadFeed parsedRows={rows} activeTurnSummaries={[summary]} />);
+		const meta = screen.getByTestId('minimal-thread-agent-meta');
+		expect(meta.textContent).toContain('3 tool calls');
+		expect(meta.textContent).toContain('2 messages');
+		expect(meta.textContent).toContain('2s');
 	});
 });

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.test.tsx
@@ -372,7 +372,7 @@ describe('MinimalThreadFeed', () => {
 		const rail = screen.getByTestId('minimal-thread-active-rail');
 		expect(rail.textContent).not.toContain('Running');
 		expect(screen.getByTestId('minimal-thread-active-meta').textContent).toContain('⚙ 4');
-		expect(turn.textContent).toContain('4 messages');
+		expect(turn.textContent).toContain('2 messages');
 		expect(screen.getByTestId('minimal-thread-last-event').textContent).toContain('last event');
 	});
 

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -343,11 +343,8 @@ function countSummaryEntries(
 	return n;
 }
 
-function countMessagesForActive(
-	rows: ParsedThreadRow[],
-	summary: ActiveTurnSummary | undefined
-): number {
-	return summary ? summary.entries.length : rows.length;
+function countMessagesForActive(rows: ParsedThreadRow[]): number {
+	return rows.length;
 }
 
 function latestActivityTimestamp(
@@ -485,7 +482,7 @@ function buildActiveTurn(
 		startedAt: rows[0].createdAt,
 		status: 'Running…',
 		toolCalls: countToolCallsForActive(rows, summary),
-		messages: countMessagesForActive(rows, summary),
+		messages: countMessagesForActive(rows),
 		thinkingEntries: countSummaryEntries(summary, 'thinking'),
 		messageEntries: countSummaryEntries(summary, 'text'),
 		toolEntries: countSummaryEntries(summary, 'tool_use'),

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -107,22 +107,27 @@ interface RosterToolEntry {
 	kind: 'tool';
 	tool: string;
 	preview: string;
+	ts: number;
 }
 interface RosterMessageEntry {
 	kind: 'message';
 	text: string;
+	ts: number;
 }
 interface RosterThinkingEntry {
 	kind: 'thinking';
 	preview: string;
+	ts: number;
 }
 interface RosterUserEntry {
 	kind: 'user';
 	text: string;
+	ts: number;
 }
 interface RosterHandoffEntry {
 	kind: 'handoff';
 	text: string;
+	ts: number;
 }
 type ActiveRosterEntry =
 	| RosterToolEntry
@@ -175,6 +180,11 @@ interface ActiveFeedTurn {
 	startedAt: number;
 	status: string;
 	toolCalls: number;
+	messages: number;
+	thinkingEntries: number | null;
+	messageEntries: number | null;
+	toolEntries: number | null;
+	lastEventAt: number;
 	roster: ActiveRosterEntry[];
 	/** Session id for the still-running turn; used by the agent header open affordance. */
 	sessionId: string | null;
@@ -209,7 +219,7 @@ interface MessageFeedTurn {
 
 type FeedTurn = CompletedFeedTurn | ActiveFeedTurn | MessageFeedTurn;
 
-const ROSTER_MAX_ENTRIES = 4;
+const ROSTER_MAX_ENTRIES = 8;
 
 function getToolUseContentBlocks(row: ParsedThreadRow) {
 	if (!row.message || !isSDKAssistantMessage(row.message)) return [];
@@ -263,26 +273,27 @@ function mapActivityEntry(entry: ActivityEntry): ActiveRosterEntry | null {
 				kind: 'tool',
 				tool: typeof entry.toolName === 'string' ? entry.toolName : '',
 				preview: typeof entry.preview === 'string' ? entry.preview : '',
+				ts: entry.ts,
 			};
 		case 'text': {
 			const text = asTrimmedString(entry.text);
 			if (!text) return null;
-			return { kind: 'message', text };
+			return { kind: 'message', text, ts: entry.ts };
 		}
 		case 'thinking': {
 			const preview = asTrimmedString(entry.preview);
 			if (!preview) return null;
-			return { kind: 'thinking', preview };
+			return { kind: 'thinking', preview, ts: entry.ts };
 		}
 		case 'user_message': {
 			const text = asTrimmedString(entry.text);
 			if (!text) return null;
-			return { kind: 'user', text };
+			return { kind: 'user', text, ts: entry.ts };
 		}
 		case 'agent_handoff': {
 			const text = asTrimmedString(entry.text);
 			if (!text) return null;
-			return { kind: 'handoff', text };
+			return { kind: 'handoff', text, ts: entry.ts };
 		}
 		default:
 			return null;
@@ -318,6 +329,33 @@ function countToolCalls(rows: ParsedThreadRow[]): number {
 		n += getToolUseContentBlocks(row).length;
 	}
 	return n;
+}
+
+function countSummaryEntries(
+	summary: ActiveTurnSummary | undefined,
+	kind: ActivityEntry['kind']
+): number | null {
+	if (!summary) return null;
+	let n = 0;
+	for (const entry of summary.entries) {
+		if (entry.kind === kind) n += 1;
+	}
+	return n;
+}
+
+function countMessagesForActive(
+	rows: ParsedThreadRow[],
+	summary: ActiveTurnSummary | undefined
+): number {
+	return summary ? summary.entries.length : rows.length;
+}
+
+function latestActivityTimestamp(
+	summary: ActiveTurnSummary | undefined,
+	rows: ParsedThreadRow[]
+): number {
+	const lastEntry = summary?.entries[summary.entries.length - 1];
+	return lastEntry?.ts ?? rows[rows.length - 1]?.createdAt ?? Date.now();
 }
 
 function latestSessionId(rows: ParsedThreadRow[]): string | null {
@@ -401,11 +439,14 @@ function buildCompletedTurn(
 	block: AgentTurnBlock,
 	rows: ParsedThreadRow[],
 	turnId: string,
-	resultInfo: ResultMessage | undefined
+	resultInfo: ResultMessage | undefined,
+	transitionSummary: ActiveTurnSummary | undefined = undefined
 ): CompletedFeedTurn {
 	const startedAt = rows[0].createdAt;
 	const lastRow = rows[rows.length - 1];
-	const durationMs = Math.max(0, lastRow.createdAt - startedAt);
+	const resultRow = resultInfo ? rows.find((row) => row.message === resultInfo) : undefined;
+	const endedAt = resultRow?.createdAt ?? lastRow.createdAt;
+	const durationMs = Math.max(0, endedAt - startedAt);
 	const durationSec = Math.max(1, Math.round(durationMs / 1000));
 	const { text, fallback, sourceRow } = extractLastAssistantText(rows);
 	const highlightSource = sourceRow ?? lastRow;
@@ -420,7 +461,7 @@ function buildCompletedTurn(
 		agent: block.agentLabel,
 		startedAt,
 		durationSec,
-		toolCalls: countToolCalls(rows),
+		toolCalls: countSummaryEntries(transitionSummary, 'tool_use') ?? countToolCalls(rows),
 		messages: rows.length,
 		lastMessage: text,
 		fallback,
@@ -434,7 +475,8 @@ function buildActiveTurn(
 	block: AgentTurnBlock,
 	rows: ParsedThreadRow[],
 	turnId: string,
-	summary: ActiveTurnSummary | undefined
+	summary: ActiveTurnSummary | undefined,
+	sessionId: string | null
 ): ActiveFeedTurn {
 	return {
 		state: 'active',
@@ -443,8 +485,13 @@ function buildActiveTurn(
 		startedAt: rows[0].createdAt,
 		status: 'Running…',
 		toolCalls: countToolCallsForActive(rows, summary),
+		messages: countMessagesForActive(rows, summary),
+		thinkingEntries: countSummaryEntries(summary, 'thinking'),
+		messageEntries: countSummaryEntries(summary, 'text'),
+		toolEntries: countSummaryEntries(summary, 'tool_use'),
+		lastEventAt: latestActivityTimestamp(summary, rows),
 		roster: rosterEntriesFromSummary(summary, ROSTER_MAX_ENTRIES),
-		sessionId: latestSessionId(rows),
+		sessionId,
 	};
 }
 
@@ -637,7 +684,11 @@ function buildFeedTurns(
 		const flushAgent = () => {
 			if (pendingAgentRows.length === 0) return;
 			const turnId = `${block.id}:${String(pendingAgentRows[0].id)}`;
-			turns.push(buildCompletedTurn(block, pendingAgentRows, turnId, blockResult));
+			const sessionId = latestSessionId(pendingAgentRows);
+			const transitionSummary = sessionId ? summariesBySession.get(sessionId) : undefined;
+			turns.push(
+				buildCompletedTurn(block, pendingAgentRows, turnId, blockResult, transitionSummary)
+			);
 			perAgentTrailing.set(blockKey, {
 				turnIdx: turns.length - 1,
 				rows: pendingAgentRows,
@@ -676,13 +727,14 @@ function buildFeedTurns(
 			if (!normalisedActive.has(key)) continue;
 			if (trailing.block.isTerminal) continue;
 			const completed = turns[trailing.turnIdx] as CompletedFeedTurn;
-			const sessionId = completed.sessionId;
+			const sessionId = latestSessionId(trailing.rows);
 			const summary = sessionId ? summariesBySession.get(sessionId) : undefined;
 			turns[trailing.turnIdx] = buildActiveTurn(
 				trailing.block,
 				trailing.rows,
 				completed.id,
-				summary
+				summary,
+				sessionId
 			);
 		}
 	}
@@ -906,14 +958,27 @@ function CompletedBody({ turn }: { turn: CompletedFeedTurn }) {
 function ActiveBody({ turn, color }: { turn: ActiveFeedTurn; color: string }) {
 	useSecondsTick();
 	const elapsedSec = Math.max(0, Math.round((Date.now() - turn.startedAt) / 1000));
+	const lastEventSec = Math.max(0, Math.round((Date.now() - turn.lastEventAt) / 1000));
+	const hasSummaryCounts =
+		turn.thinkingEntries !== null && turn.messageEntries !== null && turn.toolEntries !== null;
 	return (
 		<div
 			class="mt-1.5 pl-3 border-l-2"
 			style={{ borderColor: color }}
 			data-testid="minimal-thread-active-rail"
 		>
-			<div class="text-[11px] text-gray-500 mt-0.5">
-				{turn.toolCalls} {turn.toolCalls === 1 ? 'tool' : 'tools'} · {formatDuration(elapsedSec)}
+			<div class="text-[11px] text-gray-500 mt-0.5" data-testid="minimal-thread-active-meta">
+				{hasSummaryCounts ? (
+					<>
+						✦ {turn.thinkingEntries} · 💬 {turn.messageEntries} · ⚙ {turn.toolEntries} ·{' '}
+						{formatDuration(elapsedSec)}
+					</>
+				) : (
+					<>
+						{turn.toolCalls} {turn.toolCalls === 1 ? 'tool' : 'tools'} ·{' '}
+						{formatDuration(elapsedSec)}
+					</>
+				)}
 			</div>
 			{turn.roster.length > 0 ? (
 				<div class="mt-2 space-y-0.5">
@@ -926,8 +991,9 @@ function ActiveBody({ turn, color }: { turn: ActiveFeedTurn; color: string }) {
 					))}
 				</div>
 			) : null}
-			<div class="mt-1.5">
-				<StatusPill color={color} status={turn.status} />
+			<div class="mt-1.5 text-[11px] text-gray-600" data-testid="minimal-thread-last-event">
+				last event {lastEventSec < 1 ? 'now' : `${formatDuration(lastEventSec)} ago`} ·{' '}
+				{formatClock(turn.lastEventAt)}
 			</div>
 		</div>
 	);
@@ -967,9 +1033,14 @@ function AgentTurnRow({ turn }: { turn: CompletedFeedTurn | ActiveFeedTurn }) {
 				{initial}
 			</div>
 			<div class="flex flex-col gap-0.5 min-w-0">
-				<span class="font-semibold leading-tight" style={{ color }}>
-					{shortAgentName(turn.agent)}
-				</span>
+				<div class="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 min-w-0">
+					<span class="font-semibold leading-tight" style={{ color }}>
+						{shortAgentName(turn.agent)}
+					</span>
+					{turn.state === 'active' ? (
+						<span class="text-xs text-gray-500 leading-tight">{formatClock(turn.startedAt)}</span>
+					) : null}
+				</div>
 				{turn.state === 'completed' ? (
 					<div
 						class="text-[11px] text-gray-500 leading-tight"
@@ -979,7 +1050,12 @@ function AgentTurnRow({ turn }: { turn: CompletedFeedTurn | ActiveFeedTurn }) {
 						{turn.messages === 1 ? 'message' : 'messages'} · {formatDuration(turn.durationSec)}
 					</div>
 				) : (
-					<span class="text-xs text-gray-500 leading-tight">{formatClock(turn.startedAt)}</span>
+					<div class="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+						<StatusPill color={color} status={turn.status} />
+						<span class="text-[11px] text-gray-500 leading-tight">
+							{turn.messages} {turn.messages === 1 ? 'message' : 'messages'}
+						</span>
+					</div>
 				)}
 			</div>
 		</>

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -355,6 +355,22 @@ function latestActivityTimestamp(
 	return lastEntry?.ts ?? rows[rows.length - 1]?.createdAt ?? Date.now();
 }
 
+function latestTurnIndex(rows: ParsedThreadRow[]): number | undefined {
+	for (let i = rows.length - 1; i >= 0; i--) {
+		if (typeof rows[i].turnIndex === 'number') return rows[i].turnIndex;
+	}
+	return undefined;
+}
+
+function summaryMatchesTurn(
+	summary: ActiveTurnSummary | undefined,
+	rows: ParsedThreadRow[]
+): ActiveTurnSummary | undefined {
+	if (!summary) return undefined;
+	const turnIndex = latestTurnIndex(rows);
+	return turnIndex !== undefined && summary.turnIndex === turnIndex ? summary : undefined;
+}
+
 function latestSessionId(rows: ParsedThreadRow[]): string | null {
 	for (let i = rows.length - 1; i >= 0; i--) {
 		if (rows[i].sessionId) return rows[i].sessionId;
@@ -682,7 +698,10 @@ function buildFeedTurns(
 			if (pendingAgentRows.length === 0) return;
 			const turnId = `${block.id}:${String(pendingAgentRows[0].id)}`;
 			const sessionId = latestSessionId(pendingAgentRows);
-			const transitionSummary = sessionId ? summariesBySession.get(sessionId) : undefined;
+			const transitionSummary = summaryMatchesTurn(
+				sessionId ? summariesBySession.get(sessionId) : undefined,
+				pendingAgentRows
+			);
 			turns.push(
 				buildCompletedTurn(block, pendingAgentRows, turnId, blockResult, transitionSummary)
 			);

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -371,6 +371,13 @@ function summaryMatchesTurn(
 	return turnIndex !== undefined && summary.turnIndex === turnIndex ? summary : undefined;
 }
 
+function rowsContainResult(
+	rows: ParsedThreadRow[],
+	resultInfo: ResultMessage | undefined
+): boolean {
+	return resultInfo !== undefined && rows.some((row) => row.message === resultInfo);
+}
+
 function latestSessionId(rows: ParsedThreadRow[]): string | null {
 	for (let i = rows.length - 1; i >= 0; i--) {
 		if (rows[i].sessionId) return rows[i].sessionId;
@@ -698,10 +705,12 @@ function buildFeedTurns(
 			if (pendingAgentRows.length === 0) return;
 			const turnId = `${block.id}:${String(pendingAgentRows[0].id)}`;
 			const sessionId = latestSessionId(pendingAgentRows);
-			const transitionSummary = summaryMatchesTurn(
-				sessionId ? summariesBySession.get(sessionId) : undefined,
-				pendingAgentRows
-			);
+			const transitionSummary = rowsContainResult(pendingAgentRows, blockResult)
+				? summaryMatchesTurn(
+						sessionId ? summariesBySession.get(sessionId) : undefined,
+						pendingAgentRows
+					)
+				: undefined;
 			turns.push(
 				buildCompletedTurn(block, pendingAgentRows, turnId, blockResult, transitionSummary)
 			);


### PR DESCRIPTION
Fixes MinimalThreadFeed active/completed turn metadata drift and active turn alignment.

- Preserve server-derived tool counts and result timestamp durations when turns complete.
- Use latest session IDs consistently for active summaries and session opens.
- Move active status/header metadata, add active message counts and richer live roster stats, and show up to 8 roster entries.

Tests: bun --filter @neokai/web test src/components/space/thread/minimal/MinimalThreadFeed.test.tsx; bun run lint; bun run typecheck; bun run format:check. Full web test currently has an unrelated existing SlashCommandOutput special-character failure.