### PR TITLE
Fix queued workflow handoff recovery

### DIFF
--- a/packages/daemon/src/lib/space/runtime/agent-message-router.ts
+++ b/packages/daemon/src/lib/space/runtime/agent-message-router.ts
@@ -472,6 +472,9 @@ export class AgentMessageRouter {
 							targetKind: 'node_agent',
 							targetAgentName: agentName,
 							message: rawMessage,
+							idempotencyKey: `${fromSessionId}:${agentName}:${rawMessage}`,
+							ttlMs: 60_000,
+							maxAttempts: 3,
 						});
 						queued.push({ agentName, messageId: record.id });
 						notFound.push(agentName);

--- a/packages/daemon/src/lib/space/runtime/agent-message-router.ts
+++ b/packages/daemon/src/lib/space/runtime/agent-message-router.ts
@@ -472,7 +472,7 @@ export class AgentMessageRouter {
 							targetKind: 'node_agent',
 							targetAgentName: agentName,
 							message: rawMessage,
-							idempotencyKey: `${fromSessionId}:${agentName}:${rawMessage}`,
+							idempotencyKey: JSON.stringify([fromSessionId, agentName, rawMessage]),
 							ttlMs: 60_000,
 							maxAttempts: 3,
 						});

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -21,6 +21,7 @@
 
 import type { Database as BunDatabase } from 'bun:sqlite';
 import type {
+	NodeExecution,
 	Space,
 	SpaceTask,
 	SpaceWorkflow,
@@ -2197,10 +2198,7 @@ export class SpaceRuntime {
 		for (const targetAgentName of targets) {
 			const rowsForTarget = pending.filter((row) => row.targetAgentName === targetAgentName);
 			try {
-				let execution = this.config.nodeExecutionRepo
-					.listByWorkflowRun(runId)
-					.filter((candidate) => candidate.agentName === targetAgentName)
-					.at(-1);
+				let execution = this.resolveQueuedHandoffExecution(runId, meta.workflow, targetAgentName);
 
 				if (!execution) {
 					const resolved = this.resolveQueuedHandoffTarget(meta.workflow, targetAgentName);
@@ -2222,7 +2220,7 @@ export class SpaceRuntime {
 					continue;
 				}
 
-				await tam.tryResumeNodeAgentSession(runId, targetAgentName);
+				await tam.tryResumeNodeAgentSession(runId, execution.agentName);
 				execution = this.config.nodeExecutionRepo.getById(execution.id) ?? execution;
 				if (execution.status === 'waiting_rebind') {
 					continue;
@@ -2298,6 +2296,28 @@ export class SpaceRuntime {
 		return false;
 	}
 
+	private resolveQueuedHandoffExecution(
+		runId: string,
+		workflow: SpaceWorkflow,
+		targetAgentName: string
+	): NodeExecution | undefined {
+		const resolved = this.resolveQueuedHandoffTarget(workflow, targetAgentName);
+		if (resolved) {
+			const nodeExecution = this.config.nodeExecutionRepo
+				.listByNode(runId, resolved.nodeId)
+				.filter(
+					(candidate) => candidate.agentName === resolved.agentName || !!candidate.agentSessionId
+				)
+				.at(-1);
+			if (nodeExecution) return nodeExecution;
+		}
+
+		return this.config.nodeExecutionRepo
+			.listByWorkflowRun(runId)
+			.filter((candidate) => candidate.agentName === targetAgentName)
+			.at(-1);
+	}
+
 	private resolveQueuedHandoffTarget(
 		workflow: SpaceWorkflow,
 		targetAgentName: string
@@ -2312,6 +2332,9 @@ export class SpaceRuntime {
 				return { nodeId: node.id, agentName: direct.name, agentId: direct.agentId ?? null };
 			if (nodeNameMatch && slots[0]) {
 				return { nodeId: node.id, agentName: slots[0].name, agentId: slots[0].agentId ?? null };
+			}
+			if (nodeNameMatch) {
+				return { nodeId: node.id, agentName: targetAgentName, agentId: null };
 			}
 		}
 		return null;

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2048,7 +2048,6 @@ export class SpaceRuntime {
 			if (stoppedAfterQueuedHandoffRepair) {
 				return;
 			}
-			nodeExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
 
 			nodeExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
 			const pendingExecutions = nodeExecutions.filter(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2219,6 +2219,10 @@ export class SpaceRuntime {
 					});
 				}
 
+				if (execution.status === 'waiting_rebind') {
+					continue;
+				}
+
 				if (execution.agentSessionId && tam.isSessionAlive(execution.agentSessionId)) {
 					await tam.flushPendingMessagesForTarget(
 						runId,

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2131,6 +2131,26 @@ export class SpaceRuntime {
 		if (!repo || !tam) return false;
 
 		repo.expireStale(runId);
+		const pending = repo.listPendingForRun(runId).filter((row) => row.targetKind === 'node_agent');
+		const isTerminalTask =
+			canonicalTask.status === 'done' ||
+			canonicalTask.status === 'cancelled' ||
+			canonicalTask.status === 'archived';
+
+		if (isTerminalTask) {
+			const expiredNodeHandoffs = repo
+				.listByRunAndStatus(runId, 'expired')
+				.filter((row) => row.targetKind === 'node_agent');
+			const reason = `Queued workflow handoff cannot be delivered because task ${canonicalTask.id} is terminal (${canonicalTask.status})`;
+			for (const row of pending) repo.markFailed(row.id, reason);
+			if (pending.length > 0 || expiredNodeHandoffs.length > 0) {
+				log.warn(
+					`SpaceRuntime: ignored ${pending.length + expiredNodeHandoffs.length} queued handoff(s) for terminal task: ${reason}`
+				);
+			}
+			return false;
+		}
+
 		const expiredNodeHandoffs = repo
 			.listByRunAndStatus(runId, 'expired')
 			.filter((row) => row.targetKind === 'node_agent');
@@ -2141,21 +2161,7 @@ export class SpaceRuntime {
 			return true;
 		}
 
-		const pending = repo.listPendingForRun(runId).filter((row) => row.targetKind === 'node_agent');
 		if (pending.length === 0) return false;
-
-		if (
-			canonicalTask.status === 'done' ||
-			canonicalTask.status === 'cancelled' ||
-			canonicalTask.status === 'archived'
-		) {
-			const reason = `Queued workflow handoff cannot be delivered because task ${canonicalTask.id} is terminal (${canonicalTask.status})`;
-			for (const row of pending) repo.markFailed(row.id, reason);
-			log.warn(
-				`SpaceRuntime: failed ${pending.length} queued handoff(s) for terminal task: ${reason}`
-			);
-			return false;
-		}
 
 		if (!space) {
 			for (const row of pending) {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -44,6 +44,7 @@ import { Logger } from '../../logger';
 import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
 import { SDKMessageRepository } from '../../../storage/repositories/sdk-message-repository';
 import { ToolContinuationRecoveryRepository } from '../../../storage/repositories/tool-continuation-recovery-repository';
+import type { PendingAgentMessageRepository } from '../../../storage/repositories/pending-agent-message-repository';
 import { type NotificationSink, NullNotificationSink } from './notification-sink';
 import { CompletionDetector } from './completion-detector';
 import type { SelectWorkflowWithLlm } from './llm-workflow-selector';
@@ -127,6 +128,12 @@ export interface SpaceRuntimeConfig {
 	 * provided — tests can inject a stub to assert emissions.
 	 */
 	sdkMessageRepo?: SDKMessageRepository;
+	/**
+	 * Persistent queue for workflow agent handoff messages. SpaceRuntime sweeps
+	 * this queue every tick so queued node-to-node handoffs are retried and either
+	 * delivered or escalated instead of waiting indefinitely for a Task Agent wakeup.
+	 */
+	pendingMessageRepo?: PendingAgentMessageRepository;
 	/**
 	 * Optional callback emitted when runtime mutates a SpaceTask internally.
 	 * Used to fan out `space.task.updated` events for UI synchronization.
@@ -1906,6 +1913,18 @@ export class SpaceRuntime {
 
 			nodeExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
 
+			const stoppedAfterQueuedHandoffRepair = await this.repairQueuedWorkflowNodeHandoffs(
+				runId,
+				run,
+				meta,
+				canonicalTask,
+				space ?? null
+			);
+			if (stoppedAfterQueuedHandoffRepair) {
+				return;
+			}
+			nodeExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
+
 			// Step 1.6: Completion detection.
 			//
 			// Reuses the `runIsComplete` snapshot from above — neither `task.status`
@@ -2086,6 +2105,176 @@ export class SpaceRuntime {
 			// `task.reportedStatus`.
 			return;
 		}
+	}
+
+	private async repairQueuedWorkflowNodeHandoffs(
+		runId: string,
+		run: SpaceWorkflowRun,
+		meta: ExecutorMeta,
+		canonicalTask: SpaceTask,
+		space: Space | null
+	): Promise<boolean> {
+		const repo = this.config.pendingMessageRepo;
+		const tam = this.config.taskAgentManager;
+		if (!repo || !tam) return false;
+
+		repo.expireStale(runId);
+		const pending = repo
+			.listPendingForRun(runId)
+			.filter((row) => row.targetKind === 'node_agent' && row.status === 'pending');
+		if (pending.length === 0) return false;
+
+		if (
+			canonicalTask.status === 'done' ||
+			canonicalTask.status === 'cancelled' ||
+			canonicalTask.status === 'archived'
+		) {
+			const reason = `Queued workflow handoff cannot be delivered because task ${canonicalTask.id} is terminal (${canonicalTask.status})`;
+			for (const row of pending) repo.markFailed(row.id, reason);
+			log.warn(
+				`SpaceRuntime: failed ${pending.length} queued handoff(s) for terminal task: ${reason}`
+			);
+			return false;
+		}
+
+		if (!space) {
+			for (const row of pending) {
+				repo.markAttemptFailed(
+					row.id,
+					`Cannot activate queued handoff target: space ${meta.spaceId} not found`
+				);
+			}
+			return false;
+		}
+
+		let blockedReason: string | null = null;
+		const targets = [...new Set(pending.map((row) => row.targetAgentName))];
+
+		for (const targetAgentName of targets) {
+			const rowsForTarget = pending.filter((row) => row.targetAgentName === targetAgentName);
+			try {
+				await tam.tryResumeNodeAgentSession(runId, targetAgentName);
+				let execution = this.config.nodeExecutionRepo
+					.listByWorkflowRun(runId)
+					.filter((candidate) => candidate.agentName === targetAgentName)
+					.at(-1);
+
+				if (!execution) {
+					const resolved = this.resolveQueuedHandoffTarget(meta.workflow, targetAgentName);
+					if (!resolved) {
+						throw new Error(
+							`Queued workflow handoff target "${targetAgentName}" is not declared in workflow "${meta.workflow.id}"`
+						);
+					}
+					execution = this.config.nodeExecutionRepo.createOrIgnore({
+						workflowRunId: runId,
+						workflowNodeId: resolved.nodeId,
+						agentName: resolved.agentName,
+						agentId: resolved.agentId,
+						status: 'pending',
+					});
+				}
+
+				if (execution.agentSessionId && tam.isSessionAlive(execution.agentSessionId)) {
+					await tam.flushPendingMessagesForTarget(
+						runId,
+						execution.agentName,
+						execution.agentSessionId
+					);
+					continue;
+				}
+
+				if (execution.agentSessionId && !tam.isSessionAlive(execution.agentSessionId)) {
+					this.config.nodeExecutionRepo.update(execution.id, {
+						agentSessionId: null,
+						status: 'pending',
+						result: null,
+						completedAt: null,
+					});
+					execution = this.config.nodeExecutionRepo.getById(execution.id) ?? execution;
+				}
+
+				if (execution.status === 'blocked' || execution.status === 'cancelled') {
+					this.config.nodeExecutionRepo.update(execution.id, {
+						status: 'pending',
+						agentSessionId: null,
+						result: null,
+						completedAt: null,
+					});
+					execution = this.config.nodeExecutionRepo.getById(execution.id) ?? execution;
+				}
+
+				const sessionId = await tam.spawnWorkflowNodeAgentForExecution(
+					canonicalTask,
+					space,
+					meta.workflow,
+					run,
+					execution,
+					{ kickoff: true }
+				);
+				this.config.nodeExecutionRepo.update(execution.id, {
+					status: 'in_progress',
+					agentSessionId: sessionId,
+				});
+				await tam.flushPendingMessagesForTarget(runId, execution.agentName, sessionId);
+			} catch (err) {
+				const errMsg = err instanceof Error ? err.message : String(err);
+				log.warn(
+					`SpaceRuntime: queued workflow handoff repair failed for target ${targetAgentName}: ${errMsg}`
+				);
+				for (const row of rowsForTarget) {
+					const updated = repo.markAttemptFailed(row.id, errMsg);
+					if (updated?.status === 'failed') {
+						blockedReason = `Queued workflow handoff to ${targetAgentName} failed after ${updated.attempts} attempt(s): ${errMsg}`;
+					}
+				}
+			}
+		}
+
+		if (blockedReason) {
+			await this.blockRunForQueuedHandoffFailure(runId, meta.spaceId, canonicalTask, blockedReason);
+			return true;
+		}
+
+		return false;
+	}
+
+	private resolveQueuedHandoffTarget(
+		workflow: SpaceWorkflow,
+		targetAgentName: string
+	): { nodeId: string; agentName: string; agentId: string | null } | null {
+		for (const node of workflow.nodes) {
+			const slots = resolveNodeAgents(node);
+			const direct = slots.find((slot) => slot.name === targetAgentName);
+			if (direct)
+				return { nodeId: node.id, agentName: direct.name, agentId: direct.agentId ?? null };
+			if ((node.name === targetAgentName || node.id === targetAgentName) && slots[0]) {
+				return { nodeId: node.id, agentName: slots[0].name, agentId: slots[0].agentId ?? null };
+			}
+		}
+		return null;
+	}
+
+	private async blockRunForQueuedHandoffFailure(
+		runId: string,
+		spaceId: string,
+		canonicalTask: SpaceTask,
+		reason: string
+	): Promise<void> {
+		await this.transitionRunStatusAndEmit(runId, 'blocked');
+		await this.updateTaskAndEmit(spaceId, canonicalTask.id, {
+			status: 'blocked',
+			result: reason,
+			blockReason: 'execution_failed',
+			completedAt: null,
+		});
+		await this.safeNotify({
+			kind: 'workflow_run_blocked',
+			spaceId,
+			runId,
+			reason,
+			timestamp: new Date().toISOString(),
+		});
 	}
 
 	private async handleWaitingRebindExecutions(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2039,6 +2039,12 @@ export class SpaceRuntime {
 			// still runs so in-flight agents are monitored, but no new agents are started.
 			if (space?.paused || space?.stopped) return;
 
+			const hasQueuedNodeHandoff =
+				this.config.pendingMessageRepo
+					?.listPendingForRun(runId)
+					.some((row) => row.targetKind === 'node_agent') ?? false;
+			if (!space && !hasQueuedNodeHandoff) return;
+
 			const stoppedAfterQueuedHandoffRepair = await this.repairQueuedWorkflowNodeHandoffs(
 				runId,
 				run,
@@ -2173,11 +2179,22 @@ export class SpaceRuntime {
 		if (pending.length === 0) return false;
 
 		if (!space) {
+			let blockedReason: string | null = null;
+			const reason = `Cannot activate queued handoff target: space ${meta.spaceId} not found`;
 			for (const row of pending) {
-				repo.markAttemptFailed(
-					row.id,
-					`Cannot activate queued handoff target: space ${meta.spaceId} not found`
+				const updated = repo.markAttemptFailed(row.id, reason);
+				if (updated?.status === 'failed') {
+					blockedReason = `Queued workflow handoff to ${updated.targetAgentName} failed after ${updated.attempts} attempt(s): ${reason}`;
+				}
+			}
+			if (blockedReason) {
+				await this.blockRunForQueuedHandoffFailure(
+					runId,
+					meta.spaceId,
+					canonicalTask,
+					blockedReason
 				);
+				return true;
 			}
 			return false;
 		}
@@ -2305,9 +2322,7 @@ export class SpaceRuntime {
 		if (resolved) {
 			const nodeExecution = this.config.nodeExecutionRepo
 				.listByNode(runId, resolved.nodeId)
-				.filter(
-					(candidate) => candidate.agentName === resolved.agentName || !!candidate.agentSessionId
-				)
+				.filter((candidate) => candidate.agentName === resolved.agentName)
 				.at(-1);
 			if (nodeExecution) return nodeExecution;
 		}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2197,7 +2197,6 @@ export class SpaceRuntime {
 		for (const targetAgentName of targets) {
 			const rowsForTarget = pending.filter((row) => row.targetAgentName === targetAgentName);
 			try {
-				await tam.tryResumeNodeAgentSession(runId, targetAgentName);
 				let execution = this.config.nodeExecutionRepo
 					.listByWorkflowRun(runId)
 					.filter((candidate) => candidate.agentName === targetAgentName)
@@ -2219,6 +2218,12 @@ export class SpaceRuntime {
 					});
 				}
 
+				if (execution.status === 'waiting_rebind') {
+					continue;
+				}
+
+				await tam.tryResumeNodeAgentSession(runId, targetAgentName);
+				execution = this.config.nodeExecutionRepo.getById(execution.id) ?? execution;
 				if (execution.status === 'waiting_rebind') {
 					continue;
 				}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1425,7 +1425,11 @@ export class SpaceRuntime {
 				ex.status === 'waiting_rebind' ||
 				ex.status === 'blocked'
 		);
-		if (hasDriveableExecution) return 'skipped';
+		const hasQueuedNodeHandoff =
+			this.config.pendingMessageRepo
+				?.listPendingForRun(run.id)
+				.some((row) => row.targetKind === 'node_agent') ?? false;
+		if (hasDriveableExecution || hasQueuedNodeHandoff) return 'skipped';
 
 		// Every execution is `idle` or `cancelled` (true terminal at the
 		// node level — no agent is going to drive further state). Branch on
@@ -1913,17 +1917,13 @@ export class SpaceRuntime {
 
 			nodeExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
 
-			const stoppedAfterQueuedHandoffRepair = await this.repairQueuedWorkflowNodeHandoffs(
-				runId,
-				run,
-				meta,
-				canonicalTask,
-				space ?? null
-			);
-			if (stoppedAfterQueuedHandoffRepair) {
-				return;
+			if (
+				canonicalTask.status === 'done' ||
+				canonicalTask.status === 'cancelled' ||
+				canonicalTask.status === 'archived'
+			) {
+				await this.repairQueuedWorkflowNodeHandoffs(runId, run, meta, canonicalTask, space ?? null);
 			}
-			nodeExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
 
 			// Step 1.6: Completion detection.
 			//
@@ -2024,6 +2024,18 @@ export class SpaceRuntime {
 				return;
 			}
 
+			const stoppedAfterQueuedHandoffRepair = await this.repairQueuedWorkflowNodeHandoffs(
+				runId,
+				run,
+				meta,
+				canonicalTask,
+				space ?? null
+			);
+			if (stoppedAfterQueuedHandoffRepair) {
+				return;
+			}
+			nodeExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
+
 			// Step 2: Spawn workflow node agents for pending executions without sessions.
 			// Skip spawning for paused or stopped spaces — completion/timeout/crash detection above
 			// still runs so in-flight agents are monitored, but no new agents are started.
@@ -2119,9 +2131,17 @@ export class SpaceRuntime {
 		if (!repo || !tam) return false;
 
 		repo.expireStale(runId);
-		const pending = repo
-			.listPendingForRun(runId)
-			.filter((row) => row.targetKind === 'node_agent' && row.status === 'pending');
+		const expiredNodeHandoffs = repo
+			.listByRunAndStatus(runId, 'expired')
+			.filter((row) => row.targetKind === 'node_agent');
+		if (expiredNodeHandoffs.length > 0) {
+			const first = expiredNodeHandoffs[0];
+			const reason = `Queued workflow handoff to ${first.targetAgentName} expired before delivery after ${first.attempts} attempt(s)`;
+			await this.blockRunForQueuedHandoffFailure(runId, meta.spaceId, canonicalTask, reason);
+			return true;
+		}
+
+		const pending = repo.listPendingForRun(runId).filter((row) => row.targetKind === 'node_agent');
 		if (pending.length === 0) return false;
 
 		if (
@@ -2204,6 +2224,10 @@ export class SpaceRuntime {
 					execution = this.config.nodeExecutionRepo.getById(execution.id) ?? execution;
 				}
 
+				if (tam.isExecutionSpawning(execution.id)) {
+					continue;
+				}
+
 				const sessionId = await tam.spawnWorkflowNodeAgentForExecution(
 					canonicalTask,
 					space,
@@ -2245,10 +2269,13 @@ export class SpaceRuntime {
 	): { nodeId: string; agentName: string; agentId: string | null } | null {
 		for (const node of workflow.nodes) {
 			const slots = resolveNodeAgents(node);
-			const direct = slots.find((slot) => slot.name === targetAgentName);
+			const nodeNameMatch = node.name === targetAgentName || node.id === targetAgentName;
+			const direct = slots.find(
+				(slot) => slot.name === targetAgentName || (nodeNameMatch && slot.name === node.name)
+			);
 			if (direct)
 				return { nodeId: node.id, agentName: direct.name, agentId: direct.agentId ?? null };
-			if ((node.name === targetAgentName || node.id === targetAgentName) && slots[0]) {
+			if (nodeNameMatch && slots[0]) {
 				return { nodeId: node.id, agentName: slots[0].name, agentId: slots[0].agentId ?? null };
 			}
 		}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1922,7 +1922,16 @@ export class SpaceRuntime {
 				canonicalTask.status === 'cancelled' ||
 				canonicalTask.status === 'archived'
 			) {
-				await this.repairQueuedWorkflowNodeHandoffs(runId, run, meta, canonicalTask, space ?? null);
+				const stoppedAfterTerminalHandoffCleanup = await this.repairQueuedWorkflowNodeHandoffs(
+					runId,
+					run,
+					meta,
+					canonicalTask,
+					space ?? null
+				);
+				if (stoppedAfterTerminalHandoffCleanup) {
+					return;
+				}
 			}
 
 			// Step 1.6: Completion detection.
@@ -2024,6 +2033,11 @@ export class SpaceRuntime {
 				return;
 			}
 
+			// Step 2: Spawn workflow node agents for pending executions without sessions.
+			// Skip spawning for paused or stopped spaces — completion/timeout/crash detection above
+			// still runs so in-flight agents are monitored, but no new agents are started.
+			if (space?.paused || space?.stopped) return;
+
 			const stoppedAfterQueuedHandoffRepair = await this.repairQueuedWorkflowNodeHandoffs(
 				runId,
 				run,
@@ -2035,11 +2049,6 @@ export class SpaceRuntime {
 				return;
 			}
 			nodeExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
-
-			// Step 2: Spawn workflow node agents for pending executions without sessions.
-			// Skip spawning for paused or stopped spaces — completion/timeout/crash detection above
-			// still runs so in-flight agents are monitored, but no new agents are started.
-			if (space?.paused || space?.stopped) return;
 
 			nodeExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
 			const pendingExecutions = nodeExecutions.filter(
@@ -2175,6 +2184,16 @@ export class SpaceRuntime {
 
 		let blockedReason: string | null = null;
 		const targets = [...new Set(pending.map((row) => row.targetAgentName))];
+		const recordBlockedFlushFailure = (targetAgentName: string): void => {
+			const failedRows = repo
+				.listByRunAndStatus(runId, 'failed')
+				.filter(
+					(row) => row.targetKind === 'node_agent' && row.targetAgentName === targetAgentName
+				);
+			if (failedRows.length === 0) return;
+			const first = failedRows[0];
+			blockedReason = `Queued workflow handoff to ${targetAgentName} failed after ${first.attempts} attempt(s): ${first.lastError ?? 'delivery failed'}`;
+		};
 
 		for (const targetAgentName of targets) {
 			const rowsForTarget = pending.filter((row) => row.targetAgentName === targetAgentName);
@@ -2207,6 +2226,7 @@ export class SpaceRuntime {
 						execution.agentName,
 						execution.agentSessionId
 					);
+					recordBlockedFlushFailure(targetAgentName);
 					continue;
 				}
 
@@ -2247,6 +2267,7 @@ export class SpaceRuntime {
 					agentSessionId: sessionId,
 				});
 				await tam.flushPendingMessagesForTarget(runId, execution.agentName, sessionId);
+				recordBlockedFlushFailure(targetAgentName);
 			} catch (err) {
 				const errMsg = err instanceof Error ? err.message : String(err);
 				log.warn(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2183,14 +2183,14 @@ export class SpaceRuntime {
 
 		let blockedReason: string | null = null;
 		const targets = [...new Set(pending.map((row) => row.targetAgentName))];
-		const recordBlockedFlushFailure = (targetAgentName: string): void => {
-			const failedRows = repo
-				.listByRunAndStatus(runId, 'failed')
-				.filter(
-					(row) => row.targetKind === 'node_agent' && row.targetAgentName === targetAgentName
-				);
-			if (failedRows.length === 0) return;
-			const first = failedRows[0];
+		const recordBlockedFlushFailure = (
+			targetAgentName: string,
+			rowsForCurrentAttempt: typeof pending
+		): void => {
+			const first = rowsForCurrentAttempt
+				.map((row) => repo.getById(row.id))
+				.find((row) => row?.status === 'failed');
+			if (!first) return;
 			blockedReason = `Queued workflow handoff to ${targetAgentName} failed after ${first.attempts} attempt(s): ${first.lastError ?? 'delivery failed'}`;
 		};
 
@@ -2225,7 +2225,7 @@ export class SpaceRuntime {
 						execution.agentName,
 						execution.agentSessionId
 					);
-					recordBlockedFlushFailure(targetAgentName);
+					recordBlockedFlushFailure(targetAgentName, rowsForTarget);
 					continue;
 				}
 
@@ -2266,7 +2266,7 @@ export class SpaceRuntime {
 					agentSessionId: sessionId,
 				});
 				await tam.flushPendingMessagesForTarget(runId, execution.agentName, sessionId);
-				recordBlockedFlushFailure(targetAgentName);
+				recordBlockedFlushFailure(targetAgentName, rowsForTarget);
 			} catch (err) {
 				const errMsg = err instanceof Error ? err.message : String(err);
 				log.warn(

--- a/packages/daemon/src/storage/repositories/pending-agent-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/pending-agent-message-repository.ts
@@ -8,8 +8,8 @@
  *
  * Design goals:
  *   - Ordered delivery per `(workflow_run_id, target_agent_name)` via `created_at`
- *   - Idempotency: `(workflow_run_id, target_agent_name, idempotency_key)` is unique
- *     when `idempotency_key` is set; re-enqueueing returns the existing row
+ *   - Idempotency: pending `(workflow_run_id, target_agent_name, idempotency_key)`
+ *     rows are de-duped; terminal historical rows do not suppress later resends
  *   - Bounded retries: each failed delivery increments `attempts` and records
  *     `last_error`; once `attempts >= max_attempts`, the row is moved to
  *     `status = 'failed'` and no longer drained
@@ -86,9 +86,10 @@ export class PendingAgentMessageRepository {
 	constructor(private db: BunDatabase) {}
 
 	/**
-	 * Insert a new pending message, or return the existing row if the
+	 * Insert a new pending message, or return the existing pending row if the
 	 * `(workflowRunId, targetAgentName, idempotencyKey)` tuple already exists
-	 * (when `idempotencyKey` is set).
+	 * (when `idempotencyKey` is set). Delivered/failed/expired rows are historical
+	 * and do not suppress legitimate later resends with the same message text.
 	 */
 	enqueue(input: EnqueuePendingMessageInput): EnqueueResult {
 		const idempotencyKey = input.idempotencyKey ?? null;
@@ -152,7 +153,7 @@ export class PendingAgentMessageRepository {
 		return row ? rowToRecord(row) : null;
 	}
 
-	/** Find a row by its idempotency tuple. Returns null if none matches or if `idempotencyKey` is empty. */
+	/** Find a pending row by its idempotency tuple. Returns null if none matches or if `idempotencyKey` is empty. */
 	findByIdempotencyKey(
 		workflowRunId: string,
 		targetAgentName: string,
@@ -162,7 +163,8 @@ export class PendingAgentMessageRepository {
 		const row = this.db
 			.prepare(
 				`SELECT * FROM pending_agent_messages
-				 WHERE workflow_run_id = ? AND target_agent_name = ? AND idempotency_key = ?
+				 WHERE workflow_run_id = ? AND target_agent_name = ? AND idempotency_key = ? AND status = 'pending'
+				 ORDER BY created_at ASC, rowid ASC
 				 LIMIT 1`
 			)
 			.get(workflowRunId, targetAgentName, idempotencyKey) as PendingMessageRow | null;

--- a/packages/daemon/src/storage/repositories/pending-agent-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/pending-agent-message-repository.ts
@@ -254,6 +254,21 @@ export class PendingAgentMessageRepository {
 		return this.getById(id);
 	}
 
+	/** Mark a pending row as failed without consuming additional retry ticks. */
+	markFailed(id: string, error: string): PendingAgentMessageRecord | null {
+		const now = Date.now();
+		this.db
+			.prepare(
+				`UPDATE pending_agent_messages
+				 SET status = 'failed',
+				     last_attempt_at = ?,
+				     last_error = ?
+				 WHERE id = ? AND status = 'pending'`
+			)
+			.run(now, error, id);
+		return this.getById(id);
+	}
+
 	/**
 	 * Sweep expired rows in a run — any pending row with `expires_at <= now`
 	 * is moved to `status = 'expired'`. Returns the number of rows updated.

--- a/packages/daemon/src/storage/repositories/pending-agent-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/pending-agent-message-repository.ts
@@ -200,6 +200,21 @@ export class PendingAgentMessageRepository {
 		return rows.map(rowToRecord);
 	}
 
+	/** List rows for a run by status, oldest first. Used by repair/escalation paths. */
+	listByRunAndStatus(
+		workflowRunId: string,
+		status: PendingMessageStatus
+	): PendingAgentMessageRecord[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM pending_agent_messages
+				 WHERE workflow_run_id = ? AND status = ?
+				 ORDER BY created_at ASC, rowid ASC`
+			)
+			.all(workflowRunId, status) as PendingMessageRow[];
+		return rows.map(rowToRecord);
+	}
+
 	/** List all pending rows across every run, oldest first. Used by the global sweeper. */
 	listAllPending(): PendingAgentMessageRecord[] {
 		const rows = this.db

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -528,6 +528,10 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	//   `waiting_rebind` to node_executions and creates persistent tool_use →
 	//   execution mapping plus a per-execution continuation inbox.
 	runMigration109(db);
+
+	// Migration 110: Limit pending-agent-message idempotency to live pending rows.
+	//   Historical delivered/failed/expired rows must not suppress legitimate resends.
+	runMigration110(db);
 }
 
 /**
@@ -7684,5 +7688,24 @@ export function runMigration109(db: BunDatabase): void {
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_tool_continuation_inbox_tool
 		 ON tool_continuation_inbox(tool_use_id, status, expires_at)`
+	);
+}
+
+/**
+ * Migration 110: Limit pending-agent-message idempotency to live pending rows.
+ *
+ * The original M92 unique index covered every historical row with an
+ * idempotency key, including delivered/failed/expired messages. Runtime retry
+ * dedupe only needs to collapse currently pending rows; terminal history must
+ * not suppress a legitimate later resend with the same message text.
+ */
+export function runMigration110(db: BunDatabase): void {
+	if (!tableExists(db, 'pending_agent_messages')) return;
+
+	db.exec('DROP INDEX IF EXISTS idx_pending_agent_messages_idem');
+	db.exec(
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_pending_agent_messages_idem_pending
+		 ON pending_agent_messages(workflow_run_id, target_agent_name, idempotency_key)
+		 WHERE idempotency_key IS NOT NULL AND status = 'pending'`
 	);
 }

--- a/packages/daemon/tests/unit/5-space/agent/agent-message-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-message-router.test.ts
@@ -1433,6 +1433,17 @@ describe('AgentMessageRouter: onMessageQueued callback fires for non-deduped enq
 		expect(pending[0].maxAttempts).toBe(3);
 		expect(pending[0].expiresAt - pending[0].createdAt).toBeLessThanOrEqual(60_000);
 		expect(resumedAgents).toEqual(['reviewer']);
+
+		pendingMessageRepo.markDelivered(pending[0].id, 'session:reviewer:delivered');
+		await router.deliverMessage({
+			fromAgentName: 'coder',
+			fromSessionId: ctx.coderSessionId,
+			target: 'reviewer',
+			message: 'same handoff',
+		});
+		expect(pendingMessageRepo.listPendingForTarget(workflowRunId, 'reviewer')).toHaveLength(1);
+		expect(pendingMessageRepo.listAllForRun(workflowRunId)).toHaveLength(2);
+		expect(resumedAgents).toEqual(['reviewer', 'reviewer']);
 	});
 
 	test('does NOT call onMessageQueued when message is delivered directly (live session)', async () => {

--- a/packages/daemon/tests/unit/5-space/agent/agent-message-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-message-router.test.ts
@@ -1431,6 +1431,9 @@ describe('AgentMessageRouter: onMessageQueued callback fires for non-deduped enq
 		const pending = pendingMessageRepo.listPendingForTarget(workflowRunId, 'reviewer');
 		expect(pending).toHaveLength(1);
 		expect(pending[0].maxAttempts).toBe(3);
+		expect(pending[0].idempotencyKey).toBe(
+			JSON.stringify([ctx.coderSessionId, 'reviewer', 'same handoff'])
+		);
 		expect(pending[0].expiresAt - pending[0].createdAt).toBeLessThanOrEqual(60_000);
 		expect(resumedAgents).toEqual(['reviewer']);
 
@@ -1444,6 +1447,49 @@ describe('AgentMessageRouter: onMessageQueued callback fires for non-deduped enq
 		expect(pendingMessageRepo.listPendingForTarget(workflowRunId, 'reviewer')).toHaveLength(1);
 		expect(pendingMessageRepo.listAllForRun(workflowRunId)).toHaveLength(2);
 		expect(resumedAgents).toEqual(['reviewer', 'reviewer']);
+	});
+
+	test('does not dedupe distinct tuples that contain colon separators', async () => {
+		const { runId: workflowRunId } = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeChannel('coder', 'reviewer:b'),
+			makeChannel('coder', 'b:msg'),
+		]);
+		seedPeerTask(ctx.db, ctx.spaceId, workflowRunId, ctx.nodeId, 'coder', ctx.coderSessionId);
+		for (const agentName of ['reviewer:b', 'b:msg']) {
+			ctx.nodeExecutionRepo.createOrIgnore({
+				workflowRunId,
+				workflowNodeId: ctx.nodeId,
+				agentName,
+				status: 'pending',
+			});
+		}
+		const pendingMessageRepo = new PendingAgentMessageRepository(ctx.db);
+		const router = new AgentMessageRouter({
+			nodeExecutionRepo: ctx.nodeExecutionRepo,
+			workflowRunId,
+			workflowChannels: [makeChannel('coder', 'reviewer:b'), makeChannel('coder', 'b:msg')],
+			messageInjector: async () => {},
+			pendingMessageRepo,
+			spaceId: ctx.spaceId,
+			taskId: null,
+		});
+
+		await router.deliverMessage({
+			fromAgentName: 'coder',
+			fromSessionId: 'session:a',
+			target: 'reviewer:b',
+			message: 'msg',
+		});
+		await router.deliverMessage({
+			fromAgentName: 'coder',
+			fromSessionId: 'session:a:reviewer',
+			target: 'b:msg',
+			message: '',
+		});
+
+		expect(pendingMessageRepo.listPendingForTarget(workflowRunId, 'reviewer:b')).toHaveLength(1);
+		expect(pendingMessageRepo.listPendingForTarget(workflowRunId, 'b:msg')).toHaveLength(1);
+		expect(pendingMessageRepo.listAllForRun(workflowRunId)).toHaveLength(2);
 	});
 
 	test('does NOT call onMessageQueued when message is delivered directly (live session)', async () => {

--- a/packages/daemon/tests/unit/5-space/agent/agent-message-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/agent-message-router.test.ts
@@ -1393,6 +1393,48 @@ describe('AgentMessageRouter: onMessageQueued callback fires for non-deduped enq
 		expect(resumedAgents).toHaveLength(0);
 	});
 
+	test('dedupes repeated queued handoff sends with a stable idempotency key', async () => {
+		const { runId: workflowRunId } = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
+			makeChannel('coder', 'reviewer'),
+		]);
+
+		seedPeerTask(ctx.db, ctx.spaceId, workflowRunId, ctx.nodeId, 'coder', ctx.coderSessionId);
+		ctx.nodeExecutionRepo.createOrIgnore({
+			workflowRunId,
+			workflowNodeId: ctx.nodeId,
+			agentName: 'reviewer',
+			status: 'pending',
+		});
+
+		const pendingMessageRepo = new PendingAgentMessageRepository(ctx.db);
+		const resumedAgents: string[] = [];
+		const router = new AgentMessageRouter({
+			nodeExecutionRepo: ctx.nodeExecutionRepo,
+			workflowRunId,
+			workflowChannels: [makeChannel('coder', 'reviewer')],
+			messageInjector: async () => {},
+			pendingMessageRepo,
+			spaceId: ctx.spaceId,
+			taskId: null,
+			onMessageQueued: (agentName) => resumedAgents.push(agentName),
+		});
+
+		for (let i = 0; i < 2; i++) {
+			await router.deliverMessage({
+				fromAgentName: 'coder',
+				fromSessionId: ctx.coderSessionId,
+				target: 'reviewer',
+				message: 'same handoff',
+			});
+		}
+
+		const pending = pendingMessageRepo.listPendingForTarget(workflowRunId, 'reviewer');
+		expect(pending).toHaveLength(1);
+		expect(pending[0].maxAttempts).toBe(3);
+		expect(pending[0].expiresAt - pending[0].createdAt).toBeLessThanOrEqual(60_000);
+		expect(resumedAgents).toEqual(['reviewer']);
+	});
+
 	test('does NOT call onMessageQueued when message is delivered directly (live session)', async () => {
 		const { runId: workflowRunId } = seedWorkflowRunWithChannels(ctx.db, ctx.spaceId, [
 			makeChannel('coder', 'reviewer'),

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
@@ -1137,6 +1137,70 @@ describe('SpaceRuntime', () => {
 			expect(tam._spawnedExecutionIds).toHaveLength(1);
 		});
 
+		test('resolved handoffs do not bind to a different live slot on the same node', async () => {
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Exact Slot Handoff Repair ${Date.now()}-${Math.random()}`,
+				description: 'Test queued handoff repair exact slot matching',
+				nodes: [
+					{
+						id: 'coding-node',
+						name: 'Coder',
+						agents: [
+							{ name: 'coder-slot', agentId: AGENT_CODER },
+							{ name: 'helper-slot', agentId: AGENT_GENERAL },
+						],
+					},
+					{ id: 'review-node', name: 'Review', agentId: AGENT_GENERAL },
+				],
+				transitions: [],
+				channels: [{ id: 'review-to-coding', from: 'Review', to: 'Coder' }],
+				startNodeId: 'coding-node',
+				endNodeId: 'review-node',
+				rules: [],
+				completionAutonomyLevel: 3,
+			});
+			const { run, tasks } = await runtime.startWorkflowRun(
+				SPACE_ID,
+				workflow.id,
+				'Queued handoff'
+			);
+			const task = tasks[0];
+			taskRepo.updateTask(task.id, { status: 'in_progress' });
+			const coderExec = nodeExecutionRepo
+				.listByWorkflowRun(run.id)
+				.find((execution) => execution.agentName === 'coder-slot')!;
+			nodeExecutionRepo.update(coderExec.id, {
+				status: 'pending',
+				agentSessionId: null,
+				completedAt: null,
+			});
+			const helperExec = nodeExecutionRepo
+				.listByWorkflowRun(run.id)
+				.find((execution) => execution.agentName === 'helper-slot')!;
+			nodeExecutionRepo.update(helperExec.id, {
+				status: 'pending',
+				agentSessionId: 'session:helper-slot',
+				completedAt: null,
+			});
+			const pendingRepo = new PendingAgentMessageRepository(db);
+			pendingRepo.enqueue({
+				workflowRunId: run.id,
+				spaceId: SPACE_ID,
+				taskId: task.id,
+				sourceAgentName: 'reviewer',
+				targetKind: 'node_agent',
+				targetAgentName: 'Coder',
+				message: 'please revise',
+				ttlMs: 60_000,
+				maxAttempts: 3,
+			});
+			const tam = makeRepairTam({ liveSessions: new Set(['session:helper-slot']) });
+			await buildRepairRuntime(tam, pendingRepo).executeTick();
+			expect(tam._spawnedExecutionIds).toEqual([coderExec.id]);
+			expect(nodeExecutionRepo.getById(helperExec.id)!.agentSessionId).toBe('session:helper-slot');
+		});
+
 		test('skips repair while target execution is waiting for rebind recovery', async () => {
 			const { run, pendingRepo } = await setupQueuedHandoff();
 			const targetExec = nodeExecutionRepo
@@ -1170,6 +1234,26 @@ describe('SpaceRuntime', () => {
 			await buildRepairRuntime(tam, pendingRepo).executeTick();
 			expect(tam._spawnedExecutionIds).toHaveLength(0);
 			expect(pendingRepo.listPendingForTarget(run.id, 'Coder')).toHaveLength(1);
+		});
+
+		test('missing space retries and eventually blocks the queued handoff run', async () => {
+			const { run, task, pendingRepo } = await setupQueuedHandoff({ maxAttempts: 1 });
+			await buildRepairRuntime(makeRepairTam(), pendingRepo)['repairQueuedWorkflowNodeHandoffs'](
+				run.id,
+				run,
+				{
+					workflow: workflowManager.getWorkflow(run.workflowId)!,
+					spaceId: 'missing-space',
+					workspacePath: WORKSPACE,
+				},
+				task,
+				null
+			);
+			const row = pendingRepo.listAllForRun(run.id)[0];
+			expect(row.status).toBe('failed');
+			expect(row.lastError).toContain('space missing-space not found');
+			expect(workflowRunRepo.getRun(run.id)!.status).toBe('blocked');
+			expect(taskRepo.getTask(task.id)!.status).toBe('blocked');
 		});
 
 		test('activation failures are retried and eventually block the run', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
@@ -1089,8 +1089,16 @@ describe('SpaceRuntime', () => {
 				agentSessionId: waitingSessionId,
 				lastHeartbeatAt: Date.now(),
 			});
-			const tam = makeRepairTam({ liveSessions: new Set([waitingSessionId]) });
+			let attemptedResume = false;
+			const tam = {
+				...makeRepairTam({ liveSessions: new Set([waitingSessionId]) }),
+				tryResumeNodeAgentSession: async () => {
+					attemptedResume = true;
+					throw new Error('waiting_rebind should skip resume');
+				},
+			};
 			await buildRepairRuntime(tam, pendingRepo).executeTick();
+			expect(attemptedResume).toBe(false);
 			expect(tam._spawnedExecutionIds).toHaveLength(0);
 			expect(pendingRepo.listPendingForTarget(run.id, 'Coder')).toHaveLength(1);
 			expect(nodeExecutionRepo.getById(targetExec.id)!.status).toBe('waiting_rebind');

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
@@ -925,6 +925,7 @@ describe('SpaceRuntime', () => {
 				spawn?: (executionId: string) => Promise<string>;
 				spawningExecutionIds?: Set<string>;
 				liveSessions?: Set<string>;
+				flush?: (runId: string, agentName: string, sessionId: string) => Promise<void>;
 			} = {}
 		) {
 			const spawnedExecutionIds: string[] = [];
@@ -953,6 +954,10 @@ describe('SpaceRuntime', () => {
 					agentName: string,
 					sessionId: string
 				) => {
+					if (overrides.flush) {
+						await overrides.flush(runId, agentName, sessionId);
+						return;
+					}
 					const repo = new PendingAgentMessageRepository(db);
 					for (const row of repo.listPendingForTarget(runId, agentName))
 						repo.markDelivered(row.id, sessionId);
@@ -1073,6 +1078,15 @@ describe('SpaceRuntime', () => {
 			expect(pendingRepo.listPendingForTarget(run.id, 'Coder')).toHaveLength(1);
 		});
 
+		test('does not repair queued handoffs while the space is paused', async () => {
+			const { run, pendingRepo } = await setupQueuedHandoff();
+			await spaceManager.pauseSpace(SPACE_ID);
+			const tam = makeRepairTam();
+			await buildRepairRuntime(tam, pendingRepo).executeTick();
+			expect(tam._spawnedExecutionIds).toHaveLength(0);
+			expect(pendingRepo.listPendingForTarget(run.id, 'Coder')).toHaveLength(1);
+		});
+
 		test('activation failures are retried and eventually block the run', async () => {
 			const { run, task, pendingRepo } = await setupQueuedHandoff({ maxAttempts: 2 });
 			const tam = makeRepairTam({
@@ -1089,6 +1103,23 @@ describe('SpaceRuntime', () => {
 			expect(workflowRunRepo.getRun(run.id)!.status).toBe('blocked');
 			expect(taskRepo.getTask(task.id)!.status).toBe('blocked');
 			expect(taskRepo.getTask(task.id)!.result).toContain('spawn failed');
+		});
+
+		test('flush failures that exhaust retries block the run', async () => {
+			const { run, task, pendingRepo } = await setupQueuedHandoff({ maxAttempts: 1 });
+			const tam = makeRepairTam({
+				flush: async (runId, agentName) => {
+					const repo = new PendingAgentMessageRepository(db);
+					for (const row of repo.listPendingForTarget(runId, agentName)) {
+						repo.markAttemptFailed(row.id, 'inject failed');
+					}
+				},
+			});
+			await buildRepairRuntime(tam, pendingRepo).executeTick();
+			expect(pendingRepo.listAllForRun(run.id)[0].status).toBe('failed');
+			expect(workflowRunRepo.getRun(run.id)!.status).toBe('blocked');
+			expect(taskRepo.getTask(task.id)!.status).toBe('blocked');
+			expect(taskRepo.getTask(task.id)!.result).toContain('inject failed');
 		});
 
 		test('expired queued handoffs block the run instead of being silently dropped', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
@@ -19,6 +19,7 @@ import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
 import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
 import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository';
+import { PendingAgentMessageRepository } from '../../../../src/storage/repositories/pending-agent-message-repository.ts';
 import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
 import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
@@ -895,6 +896,237 @@ describe('SpaceRuntime', () => {
 	// -------------------------------------------------------------------------
 	// Task Agent integration (taskAgentManager configured)
 	// -------------------------------------------------------------------------
+
+	describe('queued workflow node handoff repair', () => {
+		function makeWorkflowForHandoffRepair() {
+			return workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Handoff Repair ${Date.now()}-${Math.random()}`,
+				description: 'Test queued handoff repair',
+				nodes: [
+					{ id: 'coding-node', name: 'Coder', agentId: AGENT_CODER },
+					{ id: 'review-node', name: 'Review', agentId: AGENT_GENERAL },
+					{ id: 'qa-node', name: 'QA', agentId: AGENT_PLANNER },
+				],
+				transitions: [],
+				channels: [
+					{ id: 'review-to-coding', from: 'Review', to: 'Coder' },
+					{ id: 'qa-to-coding', from: 'QA', to: 'Coder' },
+				],
+				startNodeId: 'coding-node',
+				endNodeId: 'coding-node',
+				rules: [],
+				completionAutonomyLevel: 3,
+			});
+		}
+
+		function makeRepairTam(
+			overrides: {
+				spawn?: (executionId: string) => Promise<string>;
+				spawningExecutionIds?: Set<string>;
+				liveSessions?: Set<string>;
+			} = {}
+		) {
+			const spawnedExecutionIds: string[] = [];
+			const liveSessions = overrides.liveSessions ?? new Set<string>();
+			return {
+				isExecutionSpawning: (executionId: string) =>
+					overrides.spawningExecutionIds?.has(executionId) ?? false,
+				isSessionAlive: (sessionId: string) => liveSessions.has(sessionId),
+				tryResumeNodeAgentSession: async () => {},
+				spawnWorkflowNodeAgentForExecution: async (
+					_task: unknown,
+					_space: unknown,
+					_workflow: unknown,
+					_run: unknown,
+					execution: { id: string }
+				) => {
+					spawnedExecutionIds.push(execution.id);
+					const sessionId = overrides.spawn
+						? await overrides.spawn(execution.id)
+						: `session:${execution.id}`;
+					liveSessions.add(sessionId);
+					return sessionId;
+				},
+				flushPendingMessagesForTarget: async (
+					runId: string,
+					agentName: string,
+					sessionId: string
+				) => {
+					const repo = new PendingAgentMessageRepository(db);
+					for (const row of repo.listPendingForTarget(runId, agentName))
+						repo.markDelivered(row.id, sessionId);
+				},
+				cancelBySessionId: () => {},
+				interruptBySessionId: async () => {},
+				getAgentSessionById: () => null,
+				rehydrate: async () => {},
+				_spawnedExecutionIds: spawnedExecutionIds,
+			};
+		}
+
+		async function setupQueuedHandoff(
+			opts: {
+				ttlMs?: number;
+				maxAttempts?: number;
+				createTargetExecution?: boolean;
+				taskStatus?: 'open' | 'in_progress' | 'done' | 'cancelled' | 'archived';
+				message?: string;
+			} = {}
+		) {
+			const workflow = makeWorkflowForHandoffRepair();
+			const { run, tasks } = await runtime.startWorkflowRun(
+				SPACE_ID,
+				workflow.id,
+				'Queued handoff'
+			);
+			const task = tasks[0];
+			taskRepo.updateTask(task.id, {
+				status: opts.taskStatus ?? 'in_progress',
+				completedAt:
+					opts.taskStatus === 'done' || opts.taskStatus === 'cancelled' ? Date.now() : null,
+			});
+			const existing = nodeExecutionRepo.listByWorkflowRun(run.id)[0];
+			nodeExecutionRepo.update(existing.id, { status: 'idle', agentSessionId: null });
+			if (opts.createTargetExecution ?? true) {
+				nodeExecutionRepo.createOrIgnore({
+					workflowRunId: run.id,
+					workflowNodeId: 'coding-node',
+					agentName: 'Coder',
+					agentId: AGENT_CODER,
+					status: 'pending',
+				});
+			}
+			const pendingRepo = new PendingAgentMessageRepository(db);
+			pendingRepo.enqueue({
+				workflowRunId: run.id,
+				spaceId: SPACE_ID,
+				taskId: task.id,
+				sourceAgentName: 'reviewer',
+				targetKind: 'node_agent',
+				targetAgentName: 'Coder',
+				message: opts.message ?? 'please revise',
+				ttlMs: opts.ttlMs ?? 60_000,
+				maxAttempts: opts.maxAttempts ?? 3,
+			});
+			return { run, task, pendingRepo };
+		}
+
+		function buildRepairRuntime(
+			tam: ReturnType<typeof makeRepairTam>,
+			pendingRepo: PendingAgentMessageRepository
+		) {
+			return new SpaceRuntime({
+				db,
+				spaceManager,
+				spaceAgentManager: agentManager,
+				spaceWorkflowManager: workflowManager,
+				workflowRunRepo,
+				taskRepo,
+				nodeExecutionRepo,
+				taskAgentManager: tam as never,
+				pendingMessageRepo: pendingRepo,
+			});
+		}
+
+		test('repairs a queued handoff when target execution has no agentSessionId', async () => {
+			const { run, pendingRepo } = await setupQueuedHandoff();
+			await buildRepairRuntime(makeRepairTam(), pendingRepo).executeTick();
+			const targetExec = nodeExecutionRepo
+				.listByWorkflowRun(run.id)
+				.find((execution) => execution.agentName === 'Coder')!;
+			expect(targetExec.agentSessionId).toBe(`session:${targetExec.id}`);
+			expect(targetExec.status).toBe('in_progress');
+			expect(pendingRepo.listAllForRun(run.id)[0].status).toBe('delivered');
+		});
+
+		test('recovers a stuck handoff after daemon restart by creating the target execution', async () => {
+			const { run, pendingRepo } = await setupQueuedHandoff({ createTargetExecution: false });
+			await buildRepairRuntime(makeRepairTam(), pendingRepo).executeTick();
+			const targetExec = nodeExecutionRepo
+				.listByWorkflowRun(run.id)
+				.find((execution) => execution.agentName === 'Coder')!;
+			expect(targetExec.workflowNodeId).toBe('coding-node');
+			expect(targetExec.agentSessionId).toBe(`session:${targetExec.id}`);
+			expect(pendingRepo.listAllForRun(run.id)[0].status).toBe('delivered');
+		});
+
+		test('duplicate repair ticks do not spawn duplicate sessions or messages', async () => {
+			const { run, pendingRepo } = await setupQueuedHandoff();
+			const tam = makeRepairTam();
+			const rt = buildRepairRuntime(tam, pendingRepo);
+			await rt.executeTick();
+			await rt.executeTick();
+			expect(tam._spawnedExecutionIds).toHaveLength(1);
+			expect(pendingRepo.listAllForRun(run.id)).toHaveLength(1);
+			expect(pendingRepo.listAllForRun(run.id)[0].status).toBe('delivered');
+		});
+
+		test('skips repair spawn while target execution is already spawning', async () => {
+			const { run, pendingRepo } = await setupQueuedHandoff();
+			const targetExec = nodeExecutionRepo
+				.listByWorkflowRun(run.id)
+				.find((execution) => execution.agentName === 'Coder')!;
+			const tam = makeRepairTam({ spawningExecutionIds: new Set([targetExec.id]) });
+			await buildRepairRuntime(tam, pendingRepo).executeTick();
+			expect(tam._spawnedExecutionIds).toHaveLength(0);
+			expect(pendingRepo.listPendingForTarget(run.id, 'Coder')).toHaveLength(1);
+		});
+
+		test('activation failures are retried and eventually block the run', async () => {
+			const { run, task, pendingRepo } = await setupQueuedHandoff({ maxAttempts: 2 });
+			const tam = makeRepairTam({
+				spawn: async () => {
+					throw new Error('spawn failed');
+				},
+			});
+			const rt = buildRepairRuntime(tam, pendingRepo);
+			await rt.executeTick();
+			expect(pendingRepo.listPendingForTarget(run.id, 'Coder')[0].attempts).toBe(1);
+			expect(workflowRunRepo.getRun(run.id)!.status).toBe('in_progress');
+			await rt.executeTick();
+			expect(pendingRepo.listAllForRun(run.id)[0].status).toBe('failed');
+			expect(workflowRunRepo.getRun(run.id)!.status).toBe('blocked');
+			expect(taskRepo.getTask(task.id)!.status).toBe('blocked');
+			expect(taskRepo.getTask(task.id)!.result).toContain('spawn failed');
+		});
+
+		test('expired queued handoffs block the run instead of being silently dropped', async () => {
+			const { run, task, pendingRepo } = await setupQueuedHandoff({ ttlMs: -1 });
+			await buildRepairRuntime(makeRepairTam(), pendingRepo).executeTick();
+			expect(pendingRepo.listAllForRun(run.id)[0].status).toBe('expired');
+			expect(workflowRunRepo.getRun(run.id)!.status).toBe('blocked');
+			expect(taskRepo.getTask(task.id)!.result).toContain('expired before delivery');
+		});
+
+		test('terminal task with queued handoff marks the handoff failed', async () => {
+			const { run, pendingRepo } = await setupQueuedHandoff({ taskStatus: 'done' });
+			const tam = makeRepairTam();
+			await buildRepairRuntime(tam, pendingRepo).executeTick();
+			const row = pendingRepo.listAllForRun(run.id)[0];
+			expect(row.status).toBe('failed');
+			expect(row.lastError).toContain('terminal (done)');
+			expect(tam._spawnedExecutionIds).toHaveLength(0);
+		});
+
+		test('repairs generic Review→Coding and QA→Coding handoffs', async () => {
+			const { run, pendingRepo } = await setupQueuedHandoff({ message: 'review feedback' });
+			pendingRepo.enqueue({
+				workflowRunId: run.id,
+				spaceId: SPACE_ID,
+				sourceAgentName: 'qa',
+				targetKind: 'node_agent',
+				targetAgentName: 'Coder',
+				message: 'qa feedback',
+				idempotencyKey: 'qa-coding',
+			});
+			await buildRepairRuntime(makeRepairTam(), pendingRepo).executeTick();
+			const rows = pendingRepo.listAllForRun(run.id);
+			expect(rows).toHaveLength(2);
+			expect(rows.every((row) => row.status === 'delivered')).toBe(true);
+			expect(rows.map((row) => row.sourceAgentName).sort()).toEqual(['qa', 'reviewer']);
+		});
+	});
 
 	describe('Task Agent integration', () => {
 		/**

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
@@ -1122,6 +1122,25 @@ describe('SpaceRuntime', () => {
 			expect(taskRepo.getTask(task.id)!.result).toContain('inject failed');
 		});
 
+		test('historical failed handoffs do not re-block successful later repairs', async () => {
+			const { run, pendingRepo } = await setupQueuedHandoff();
+			const historical = pendingRepo.enqueue({
+				workflowRunId: run.id,
+				spaceId: SPACE_ID,
+				targetKind: 'node_agent',
+				targetAgentName: 'Coder',
+				message: 'old failed handoff',
+				maxAttempts: 1,
+			});
+			pendingRepo.markAttemptFailed(historical.record.id, 'old inject failed');
+
+			await buildRepairRuntime(makeRepairTam(), pendingRepo).executeTick();
+			const rows = pendingRepo.listAllForRun(run.id);
+			expect(rows.find((row) => row.id === historical.record.id)!.status).toBe('failed');
+			expect(rows.find((row) => row.id !== historical.record.id)!.status).toBe('delivered');
+			expect(workflowRunRepo.getRun(run.id)!.status).toBe('in_progress');
+		});
+
 		test('expired queued handoffs block the run instead of being silently dropped', async () => {
 			const { run, task, pendingRepo } = await setupQueuedHandoff({ ttlMs: -1 });
 			await buildRepairRuntime(makeRepairTam(), pendingRepo).executeTick();

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
@@ -1078,6 +1078,24 @@ describe('SpaceRuntime', () => {
 			expect(pendingRepo.listPendingForTarget(run.id, 'Coder')).toHaveLength(1);
 		});
 
+		test('skips repair while target execution is waiting for rebind recovery', async () => {
+			const { run, pendingRepo } = await setupQueuedHandoff();
+			const targetExec = nodeExecutionRepo
+				.listByWorkflowRun(run.id)
+				.find((execution) => execution.agentName === 'Coder')!;
+			const waitingSessionId = 'session:waiting-rebind';
+			nodeExecutionRepo.update(targetExec.id, {
+				status: 'waiting_rebind',
+				agentSessionId: waitingSessionId,
+				lastHeartbeatAt: Date.now(),
+			});
+			const tam = makeRepairTam({ liveSessions: new Set([waitingSessionId]) });
+			await buildRepairRuntime(tam, pendingRepo).executeTick();
+			expect(tam._spawnedExecutionIds).toHaveLength(0);
+			expect(pendingRepo.listPendingForTarget(run.id, 'Coder')).toHaveLength(1);
+			expect(nodeExecutionRepo.getById(targetExec.id)!.status).toBe('waiting_rebind');
+		});
+
 		test('does not repair queued handoffs while the space is paused', async () => {
 			const { run, pendingRepo } = await setupQueuedHandoff();
 			await spaceManager.pauseSpace(SPACE_ID);

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
@@ -1109,6 +1109,18 @@ describe('SpaceRuntime', () => {
 			expect(tam._spawnedExecutionIds).toHaveLength(0);
 		});
 
+		test('expired handoff for a terminal task does not overwrite completion', async () => {
+			const { run, task, pendingRepo } = await setupQueuedHandoff({
+				taskStatus: 'done',
+				ttlMs: -1,
+			});
+			await buildRepairRuntime(makeRepairTam(), pendingRepo).executeTick();
+			expect(pendingRepo.listAllForRun(run.id)[0].status).toBe('expired');
+			expect(taskRepo.getTask(task.id)!.status).toBe('done');
+			expect(taskRepo.getTask(task.id)!.completedAt).not.toBeNull();
+			expect(workflowRunRepo.getRun(run.id)!.status).not.toBe('blocked');
+		});
+
 		test('repairs generic Review→Coding and QA→Coding handoffs', async () => {
 			const { run, pendingRepo } = await setupQueuedHandoff({ message: 'review feedback' });
 			pendingRepo.enqueue({

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
@@ -925,6 +925,7 @@ describe('SpaceRuntime', () => {
 				spawn?: (executionId: string) => Promise<string>;
 				spawningExecutionIds?: Set<string>;
 				liveSessions?: Set<string>;
+				resume?: (runId: string, agentName: string) => Promise<void>;
 				flush?: (runId: string, agentName: string, sessionId: string) => Promise<void>;
 			} = {}
 		) {
@@ -934,7 +935,9 @@ describe('SpaceRuntime', () => {
 				isExecutionSpawning: (executionId: string) =>
 					overrides.spawningExecutionIds?.has(executionId) ?? false,
 				isSessionAlive: (sessionId: string) => liveSessions.has(sessionId),
-				tryResumeNodeAgentSession: async () => {},
+				tryResumeNodeAgentSession: async (runId: string, agentName: string) => {
+					await overrides.resume?.(runId, agentName);
+				},
 				spawnWorkflowNodeAgentForExecution: async (
 					_task: unknown,
 					_space: unknown,
@@ -1076,6 +1079,62 @@ describe('SpaceRuntime', () => {
 			await buildRepairRuntime(tam, pendingRepo).executeTick();
 			expect(tam._spawnedExecutionIds).toHaveLength(0);
 			expect(pendingRepo.listPendingForTarget(run.id, 'Coder')).toHaveLength(1);
+		});
+
+		test('resumes repaired handoffs with the resolved execution agent name', async () => {
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Multi-slot Handoff Repair ${Date.now()}-${Math.random()}`,
+				description: 'Test queued handoff repair with node-name addressing',
+				nodes: [
+					{
+						id: 'coding-node',
+						name: 'Coder',
+						agents: [{ name: 'coder-slot', agentId: AGENT_CODER }],
+					},
+					{ id: 'review-node', name: 'Review', agentId: AGENT_GENERAL },
+				],
+				transitions: [],
+				channels: [{ id: 'review-to-coding', from: 'Review', to: 'Coder' }],
+				startNodeId: 'coding-node',
+				endNodeId: 'coding-node',
+				rules: [],
+				completionAutonomyLevel: 3,
+			});
+			const { run, tasks } = await runtime.startWorkflowRun(
+				SPACE_ID,
+				workflow.id,
+				'Queued handoff'
+			);
+			const task = tasks[0];
+			taskRepo.updateTask(task.id, { status: 'in_progress' });
+			const existing = nodeExecutionRepo.listByWorkflowRun(run.id)[0];
+			nodeExecutionRepo.update(existing.id, {
+				status: 'pending',
+				agentSessionId: 'session:coder-slot',
+				completedAt: null,
+			});
+			const pendingRepo = new PendingAgentMessageRepository(db);
+			pendingRepo.enqueue({
+				workflowRunId: run.id,
+				spaceId: SPACE_ID,
+				taskId: task.id,
+				sourceAgentName: 'reviewer',
+				targetKind: 'node_agent',
+				targetAgentName: 'Coder',
+				message: 'please revise',
+				ttlMs: 60_000,
+				maxAttempts: 3,
+			});
+			let resumedAgentName: string | null = null;
+			const tam = makeRepairTam({
+				resume: async (_runId, agentName) => {
+					resumedAgentName = agentName;
+				},
+			});
+			await buildRepairRuntime(tam, pendingRepo).executeTick();
+			expect(resumedAgentName).toBe('coder-slot');
+			expect(tam._spawnedExecutionIds).toHaveLength(1);
 		});
 
 		test('skips repair while target execution is waiting for rebind recovery', async () => {


### PR DESCRIPTION
Fixes workflow node handoffs so queued node-agent messages are bounded, idempotent, and actively repaired by runtime ticks instead of waiting indefinitely on Task Agent wakeup.

Adds deterministic enqueue idempotency/retry bounds and runtime repair that spawns or resumes target node agents, flushes pending messages, and blocks with an actionable reason when delivery exhausts retries.

Tests: bun test packages/daemon/tests/unit/5-space/agent/agent-message-router.test.ts packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts; bun run typecheck