### PR TITLE
Make workflow agent prompts data-driven

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -220,7 +220,6 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	// One-shot startup reconciliation for legacy preset agent rows. This must run
 	// before RPC handlers can serve the configure UI so persisted agent prompts
 	// match the current template seed immediately after daemon restart.
-	await reconcileLegacyPresetAgentsOnStartup(spaceManager, spaceAgentManager, eventBus, logInfo);
 
 	// Initialize application-level MCP and Skills managers before SessionManager
 	// so AgentSession can inject skills into SDK query options.
@@ -699,28 +698,4 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		fileIndex,
 		cleanup,
 	};
-}
-
-async function reconcileLegacyPresetAgentsOnStartup(
-	spaceManager: SpaceManager,
-	spaceAgentManager: SpaceAgentManager,
-	eventBus: ReturnType<typeof createDaemonHub>,
-	logInfo: (message: string) => void
-): Promise<void> {
-	const spaces = await spaceManager.listSpaces(false);
-	let reconciledCount = 0;
-	for (const space of spaces) {
-		const reconciledAgents = spaceAgentManager.reconcileEquivalentLegacyPresetRows(space.id);
-		for (const agent of reconciledAgents) {
-			reconciledCount++;
-			await eventBus.emit('spaceAgent.updated', {
-				sessionId: `space:${agent.spaceId}`,
-				spaceId: agent.spaceId,
-				agent,
-			});
-		}
-	}
-	if (reconciledCount > 0) {
-		logInfo(`[Daemon] Reconciled ${reconciledCount} legacy preset agent prompt(s)`);
-	}
 }

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -217,10 +217,6 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	const eventBus = createDaemonHub('daemon');
 	await eventBus.initialize();
 
-	// One-shot startup reconciliation for legacy preset agent rows. This must run
-	// before RPC handlers can serve the configure UI so persisted agent prompts
-	// match the current template seed immediately after daemon restart.
-
 	// Initialize application-level MCP and Skills managers before SessionManager
 	// so AgentSession can inject skills into SDK query options.
 	const appMcpManager = new AppMcpLifecycleManager(db);

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -99,6 +99,17 @@ import { DEFAULT_WORKER_FEATURES as WORKER_FEATURES } from '@neokai/shared';
  * Used by RoomAgentService and LobbyAgentService to create sessions
  * with custom system prompts, MCP servers, and feature flags.
  */
+export interface PromptProvenanceInit {
+	source: string;
+	hash: string;
+	agentId?: string;
+	agentName?: string;
+	workflowRunId?: string;
+	workflowId?: string;
+	nodeId?: string;
+	nodeName?: string;
+}
+
 export interface AgentSessionInit {
 	/** Session ID (e.g., 'room:abc123', 'lobby:default', or UUID for worker) */
 	sessionId: string;
@@ -108,6 +119,9 @@ export interface AgentSessionInit {
 
 	/** System prompt configuration - provided by caller */
 	systemPrompt?: SystemPromptConfig;
+
+	/** Non-secret prompt provenance for observability; never contains full prompt text. */
+	promptProvenance?: PromptProvenanceInit;
 
 	/** MCP servers configuration - provided by caller (merged with user config) */
 	mcpServers?: Record<string, McpServerConfig>;
@@ -460,6 +474,20 @@ export class AgentSession
 			}
 
 			if (
+				init.promptProvenance &&
+				JSON.stringify(session.metadata.promptProvenance ?? null) !==
+					JSON.stringify(init.promptProvenance)
+			) {
+				const nextMetadata: SessionMetadata = {
+					...session.metadata,
+					promptProvenance: init.promptProvenance,
+				};
+				updates.metadata = nextMetadata;
+				session = { ...session, metadata: nextMetadata };
+				hasUpdates = true;
+			}
+
+			if (
 				runtimeInitFingerprint &&
 				session.metadata.runtimeInitFingerprint !== runtimeInitFingerprint
 			) {
@@ -608,6 +636,7 @@ export class AgentSession
 			totalCost: 0,
 			toolCallCount: 0,
 			...(runtimeInitFingerprint ? { runtimeInitFingerprint } : {}),
+			...(init.promptProvenance ? { promptProvenance: init.promptProvenance } : {}),
 		};
 
 		return {

--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -6,7 +6,7 @@
  * behavior comes only from visible prompt fields on the agent or workflow node.
  */
 
-import type { AgentSessionInit } from '../../agent/agent-session';
+import type { AgentSessionInit, PromptProvenanceInit } from '../../agent/agent-session';
 import type {
 	AgentDefinition,
 	McpServerConfig,
@@ -55,6 +55,23 @@ const log = new Logger('custom-agent');
  *   It cannot replace the base prompt — the NeoKai contract sections remain intact.
  * - absent (undefined) — uses the agent's base value unchanged.
  */
+export type PromptSource = 'workflow_node_custom_prompt' | 'space_agent_custom_prompt' | 'empty';
+
+export interface ResolvedAgentPrompt {
+	value: string;
+	source: PromptSource;
+	hash: string;
+}
+
+export interface SlotResolutionContext {
+	agentId?: string;
+	agentName?: string;
+	workflowRunId?: string;
+	workflowId?: string;
+	nodeId?: string;
+	nodeName?: string;
+}
+
 export interface SlotOverrides {
 	/** Override the agent's default model for this slot */
 	model?: string;
@@ -64,6 +81,8 @@ export interface SlotOverrides {
 	disabledSkillIds?: string[];
 	/** Extra MCP servers to add for this slot */
 	extraMcpServers?: Record<string, McpServerConfig>;
+	/** Runtime metadata used to make prompt provenance observable without prompt content. */
+	resolutionContext?: SlotResolutionContext;
 }
 
 /**
@@ -144,7 +163,46 @@ export function buildCustomAgentSystemPrompt(
 	customAgent: SpaceAgent,
 	slotOverrides?: SlotOverrides
 ): string {
-	return expandPrompt(customAgent.customPrompt, slotOverrides?.customPrompt);
+	return resolveCustomAgentPrompt(customAgent, slotOverrides).value;
+}
+
+export function resolveCustomAgentPrompt(
+	customAgent: SpaceAgent,
+	slotOverrides?: SlotOverrides
+): ResolvedAgentPrompt {
+	const basePrompt = customAgent.customPrompt?.trim() ?? '';
+	const slotPrompt = slotOverrides?.customPrompt?.trim() ?? '';
+	const value = expandPrompt(basePrompt, slotPrompt);
+	const source: PromptSource = slotPrompt
+		? 'workflow_node_custom_prompt'
+		: basePrompt
+			? 'space_agent_custom_prompt'
+			: 'empty';
+	return { value, source, hash: hashPrompt(value) };
+}
+
+function buildPromptProvenance(
+	resolved: ResolvedAgentPrompt,
+	customAgent: SpaceAgent,
+	slotOverrides?: SlotOverrides
+): PromptProvenanceInit {
+	const ctx = slotOverrides?.resolutionContext;
+	return {
+		source: resolved.source,
+		hash: resolved.hash,
+		agentId: ctx?.agentId ?? customAgent.id,
+		agentName: ctx?.agentName ?? customAgent.name,
+		workflowRunId: ctx?.workflowRunId,
+		workflowId: ctx?.workflowId,
+		nodeId: ctx?.nodeId,
+		nodeName: ctx?.nodeName,
+	};
+}
+
+function hashPrompt(prompt: string): string {
+	const hasher = new Bun.CryptoHasher('sha256');
+	hasher.update(prompt);
+	return hasher.digest('hex');
 }
 
 /**
@@ -366,7 +424,10 @@ export function createCustomAgentInit(config: CustomAgentConfig): AgentSessionIn
 		slotOverrides?.model ?? customAgent.model ?? space.defaultModel ?? DEFAULT_CUSTOM_AGENT_MODEL;
 	const provider = inferProviderForModel(model);
 
-	const visiblePrompt = buildCustomAgentSystemPrompt(customAgent, slotOverrides);
+	const resolvedPrompt = resolveCustomAgentPrompt(customAgent, slotOverrides);
+	const visiblePrompt = resolvedPrompt.value;
+	const promptProvenance = buildPromptProvenance(resolvedPrompt, customAgent, slotOverrides);
+	emitPromptProvenance('createCustomAgentInit', promptProvenance);
 
 	const skillOverrides: SkillEnablementOverride[] | undefined = slotOverrides?.disabledSkillIds
 		?.length
@@ -398,6 +459,7 @@ export function createCustomAgentInit(config: CustomAgentConfig): AgentSessionIn
 			// See `AgentSession.fromInit` for the preservation guard.
 			context: { spaceId: space.id, taskId: task.id },
 			type: 'worker',
+			promptProvenance,
 			model,
 			provider,
 			agent: agentKey,
@@ -417,8 +479,9 @@ export function createCustomAgentInit(config: CustomAgentConfig): AgentSessionIn
 			append: visiblePrompt,
 		},
 		features: SUB_SESSION_FEATURES,
-		context: { spaceId: space.id },
+		context: { spaceId: space.id, taskId: task.id },
 		type: 'worker',
+		promptProvenance,
 		model,
 		provider,
 		...customToolPermissions,
@@ -486,6 +549,15 @@ export function resolveAgentInit(config: ResolveAgentInitConfig): AgentSessionIn
 		previousTaskSummaries,
 		slotOverrides,
 	});
+}
+
+function emitPromptProvenance(event: string, provenance: PromptProvenanceInit): void {
+	log.info(
+		`${event}: prompt source=${provenance.source} hash=${provenance.hash} ` +
+			`agentId=${provenance.agentId ?? 'unknown'} agentName=${provenance.agentName ?? 'unknown'} ` +
+			`workflowRunId=${provenance.workflowRunId ?? 'none'} nodeId=${provenance.nodeId ?? 'none'} ` +
+			`nodeName=${provenance.nodeName ?? 'none'}`
+	);
 }
 
 function sanitizeAgentKey(name: string): string {

--- a/packages/daemon/src/lib/space/managers/space-agent-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-agent-manager.ts
@@ -20,8 +20,8 @@ import type {
 import { KNOWN_TOOLS } from '@neokai/shared';
 import type { SpaceAgentRepository } from '../../../storage/repositories/space-agent-repository';
 import { isValidModel, getAvailableModels, getModelInfoUnfiltered } from '../../model-service';
-import { getPresetAgentTemplates, LEGACY_REVIEWER_PROMPT } from '../agents/seed-agents';
-import { computeAgentTemplateHash, agentTemplatesMatch } from '../agents/agent-template-hash';
+import { getPresetAgentTemplates } from '../agents/seed-agents';
+import { computeAgentTemplateHash } from '../agents/agent-template-hash';
 
 const KNOWN_TOOLS_SET = new Set<string>(KNOWN_TOOLS);
 
@@ -166,8 +166,7 @@ export class SpaceAgentManager {
 
 			const currentHash = computeAgentTemplateHash(preset);
 			const storedHash = agent.templateHash ?? null;
-			const drifted =
-				storedHash !== currentHash && !this.isEquivalentLegacyPresetRow(agent, preset);
+			const drifted = storedHash !== currentHash;
 			entries.push({
 				agentId: agent.id,
 				agentName: agent.name,
@@ -225,48 +224,6 @@ export class SpaceAgentManager {
 	// ---------------------------------------------------------------------------
 
 	/**
-	 * One-shot startup reconciliation for preset rows that were correctly seeded
-	 * from the old coordinator Reviewer prompt before the full Reviewer template
-	 * existed. Returns updated rows so callers can emit subscription events.
-	 */
-	reconcileEquivalentLegacyPresetRows(spaceId: string): SpaceAgent[] {
-		const updated: SpaceAgent[] = [];
-		const presetByName = new Map(getPresetAgentTemplates().map((p) => [p.name.toLowerCase(), p]));
-		for (const agent of this.repo.getBySpaceId(spaceId)) {
-			if (!agent.templateName) continue;
-			const preset = presetByName.get(agent.templateName.toLowerCase());
-			if (!preset) continue;
-			const currentHash = computeAgentTemplateHash(preset);
-			if (agent.templateHash === currentHash) continue;
-			if (!this.isEquivalentLegacyPresetRow(agent, preset)) continue;
-			const reconciled = this.repo.update(agent.id, {
-				customPrompt: preset.customPrompt,
-				templateHash: currentHash,
-			});
-			if (reconciled) updated.push(reconciled);
-		}
-		return updated;
-	}
-
-	private isEquivalentLegacyPresetRow(
-		agent: SpaceAgent,
-		preset: ReturnType<typeof getPresetAgentTemplates>[number]
-	): boolean {
-		if (preset.name !== 'Reviewer') return false;
-		if (agent.name.trim().toLowerCase() !== preset.name.toLowerCase()) return false;
-		if ((agent.description ?? '') !== preset.description) return false;
-		if (
-			!agentTemplatesMatch(
-				{ ...preset, customPrompt: LEGACY_REVIEWER_PROMPT },
-				agentTemplateInput(agent)
-			)
-		) {
-			return false;
-		}
-		return true;
-	}
-
-	/**
 	 * Validate that a model is recognized.
 	 * Skips validation entirely when the models cache is empty (not yet loaded).
 	 * When a provider is known, uses the provider-aware isValidModel() API so
@@ -300,15 +257,6 @@ export class SpaceAgentManager {
  * Validate that all tool names in the array are in KNOWN_TOOLS.
  * Returns a descriptive error string on failure, or null if all names are valid.
  */
-function agentTemplateInput(agent: SpaceAgent) {
-	return {
-		name: agent.templateName ?? agent.name,
-		description: agent.description ?? '',
-		tools: agent.tools ?? [],
-		customPrompt: agent.customPrompt ?? '',
-	};
-}
-
 function validateTools(tools: string[]): string | null {
 	const invalid = tools.filter((t) => !KNOWN_TOOLS_SET.has(t));
 	if (invalid.length === 0) return null;

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1114,21 +1114,6 @@ export class TaskAgentManager {
 				const baseSessionId = `space:${spaceId}:task:${taskId}:agent:${this.sanitizeAgentNameForId(agentName)}`;
 				const sessionId = this.resolveSessionId(baseSessionId);
 
-				// Resolve slot overrides (same shape as spawnWorkflowNodeAgentForExecution).
-				let slotCustomPrompt: string | undefined = slot.customPrompt?.value;
-				if (!slotCustomPrompt) {
-					const legacySlot = slot as {
-						systemPrompt?: { value: string };
-						instructions?: { value: string };
-					};
-					const legacySp = legacySlot.systemPrompt?.value?.trim() ?? '';
-					const legacyInstr = legacySlot.instructions?.value?.trim() ?? '';
-					if (legacySp && legacyInstr) {
-						slotCustomPrompt = `${legacySp}\n\n${legacyInstr}`;
-					} else {
-						slotCustomPrompt = legacySp || legacyInstr || undefined;
-					}
-				}
 				const node = workflow.nodes.find((candidate) => candidate.id === nodeId);
 				const slotOverrides = this.buildSlotOverrides(slot, {
 					node,

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -922,7 +922,11 @@ export class TaskAgentManager {
 				}
 			}
 
-			const slotOverrides = this.buildSlotOverrides(slot);
+			const slotOverrides = this.buildSlotOverrides(slot, {
+				node,
+				workflow,
+				workflowRun,
+			});
 
 			let init = resolveAgentInit({
 				task,
@@ -1125,12 +1129,12 @@ export class TaskAgentManager {
 						slotCustomPrompt = legacySp || legacyInstr || undefined;
 					}
 				}
-				const slotOverrides: SlotOverrides = {
-					model: slot.model,
-					customPrompt: slotCustomPrompt,
-					disabledSkillIds: slot.disabledSkillIds,
-					extraMcpServers: slot.extraMcpServers,
-				};
+				const node = workflow.nodes.find((candidate) => candidate.id === nodeId);
+				const slotOverrides = this.buildSlotOverrides(slot, {
+					node,
+					workflow,
+					workflowRun,
+				});
 
 				let init = resolveAgentInit({
 					task,
@@ -3386,7 +3390,14 @@ export class TaskAgentManager {
 		return agentSession;
 	}
 
-	private buildSlotOverrides(slot: WorkflowNodeAgent): SlotOverrides {
+	private buildSlotOverrides(
+		slot: WorkflowNodeAgent,
+		context?: {
+			node?: { id: string; name: string };
+			workflow?: { id: string };
+			workflowRun?: { id: string };
+		}
+	): SlotOverrides {
 		// Resolve customPrompt from the slot. Support legacy JSON blobs that may still
 		// have the old `systemPrompt`/`instructions` shape from before migration 79.
 		let slotCustomPrompt: string | undefined = slot.customPrompt?.value;
@@ -3409,6 +3420,14 @@ export class TaskAgentManager {
 			customPrompt: slotCustomPrompt,
 			disabledSkillIds: slot.disabledSkillIds,
 			extraMcpServers: slot.extraMcpServers,
+			resolutionContext: {
+				agentId: slot.agentId,
+				agentName: slot.name,
+				workflowRunId: context?.workflowRun?.id,
+				workflowId: context?.workflow?.id,
+				nodeId: context?.node?.id,
+				nodeName: context?.node?.name,
+			},
 		};
 	}
 
@@ -3452,7 +3471,11 @@ export class TaskAgentManager {
 			workspacePath,
 			workflowRun,
 			workflow,
-			slotOverrides: this.buildSlotOverrides(slot),
+			slotOverrides: this.buildSlotOverrides(slot, {
+				node,
+				workflow: workflow ?? undefined,
+				workflowRun: workflowRun ?? undefined,
+			}),
 			agentId: slot.agentId,
 		});
 	}
@@ -4394,27 +4417,12 @@ export class TaskAgentManager {
 
 		const workspacePath = this.taskWorktreePaths.get(taskId) ?? space.workspacePath;
 
-		// Build slot overrides + init in the same shape as spawnWorkflowNodeAgentForExecution.
-		let slotCustomPrompt: string | undefined = matchedSlot.customPrompt?.value;
-		if (!slotCustomPrompt) {
-			const legacySlot = matchedSlot as {
-				systemPrompt?: { value: string };
-				instructions?: { value: string };
-			};
-			const legacySp = legacySlot.systemPrompt?.value?.trim() ?? '';
-			const legacyInstr = legacySlot.instructions?.value?.trim() ?? '';
-			if (legacySp && legacyInstr) {
-				slotCustomPrompt = `${legacySp}\n\n${legacyInstr}`;
-			} else {
-				slotCustomPrompt = legacySp || legacyInstr || undefined;
-			}
-		}
-		const slotOverrides: SlotOverrides = {
-			model: matchedSlot.model,
-			customPrompt: slotCustomPrompt,
-			disabledSkillIds: matchedSlot.disabledSkillIds,
-			extraMcpServers: matchedSlot.extraMcpServers,
-		};
+		const matchedNode = workflow.nodes.find((node) => node.id === matchedNodeId);
+		const slotOverrides = this.buildSlotOverrides(matchedSlot, {
+			node: matchedNode,
+			workflow,
+			workflowRun: workflowRun ?? undefined,
+		});
 
 		const baseSessionId = `space:${spaceId}:task:${taskId}:post-approval:${this.sanitizeAgentNameForId(matchedSlot.name)}`;
 		const sessionId = this.resolveSessionId(baseSessionId);

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -20,7 +20,7 @@
  *   `resolveChannels()` matches node names via the `nodeNameToAgents` lookup.
  */
 
-import type { GateScript, SpaceWorkflow, WorkflowNode } from '@neokai/shared';
+import type { GateScript, SpaceWorkflow } from '@neokai/shared';
 import { generateUUID } from '@neokai/shared';
 import { Logger } from '../../logger';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
@@ -1263,22 +1263,16 @@ export interface SeedBuiltInWorkflowsResult {
  * Fields that the built-in seeder re-stamps when it detects template drift
  * on an already-seeded row.
  *
- * - `postApproval`, `completionAutonomyLevel`, `templateHash`, `nodes` are
- *   updated; `nodes` carries the refreshed `customPrompt.value` for every
- *   agent slot (matched by node name + agent name) while preserving the
- *   existing node `id` and agent `agentId`. Preserving the node UUID keeps
- *   in-flight workflow runs valid — their references continue to resolve.
- * - Channels / gates are NOT re-stamped here: this PR did not change
+ * - `postApproval`, `completionAutonomyLevel`, and `templateHash` are
+ *   updated. Persisted node definitions, including workflow-node agent
+ *   `customPrompt.value`, are deliberately left untouched so daemon restart /
+ *   startup seed passes cannot replace user-configured runtime prompts.
+ * - Nodes / channels / gates are NOT re-stamped here: changing those fields
  *   channel or gate structure on any built-in template, and re-stamping
  *   them would regenerate IDs. If a future template change adjusts those,
  *   extend this list and the re-stamp payload below accordingly.
  */
-const RESTAMP_FIELDS = [
-	'postApproval',
-	'completionAutonomyLevel',
-	'templateHash',
-	'nodes',
-] as const;
+const RESTAMP_FIELDS = ['postApproval', 'completionAutonomyLevel', 'templateHash'] as const;
 
 /**
  * Seeds all built-in workflow templates into the given space.
@@ -1339,76 +1333,15 @@ export function seedBuiltInWorkflows(
 			if (row.templateHash === expectedHash) continue;
 
 			try {
-				// Build the re-stamped `nodes` array: walk the template node-by-node,
-				// look up the corresponding persisted row by node name, and rebuild
-				// the agent list keeping the persisted `agentId` UUID but adopting
-				// the template's `customPrompt` (and `model` / skills / MCP overrides).
-				// Matching is done by name because template nodes are defined with
-				// placeholder template-local IDs that don't match the real UUIDs
-				// stored on the row.
-				const existingNodesByName = new Map(row.nodes.map((n) => [n.name, n]));
-				const mergedNodes: WorkflowNode[] = [];
-				let abortReStamp: string | null = null;
-
-				for (const tNode of template.nodes) {
-					const eNode = existingNodesByName.get(tNode.name);
-					if (!eNode) {
-						// Template added a new node since this row was seeded. Node
-						// structure changes are out of scope for in-place re-stamp
-						// (would require channel/gate coordination + new UUIDs). Log
-						// and skip this row — `checkBuiltInWorkflowDriftOnStartup`
-						// will continue to surface it as drifted.
-						abortReStamp = `template node '${tNode.name}' missing from persisted row`;
-						break;
-					}
-
-					const existingAgentsByName = new Map(eNode.agents.map((a) => [a.name, a]));
-					const mergedAgents = tNode.agents.map((tAgent) => {
-						const eAgent = existingAgentsByName.get(tAgent.name);
-						// Keep the persisted agent UUID so the row passes validation.
-						// If the template added a new agent slot, we fall back to
-						// resolving the template's placeholder via `resolveAgentId` —
-						// same path Branch 2 uses for fresh seeds.
-						const persistedAgentId = eAgent?.agentId ?? resolveAgentId(tAgent.agentId);
-						if (!persistedAgentId) {
-							throw new Error(
-								`re-stamp: node '${tNode.name}' agent slot '${tAgent.name}' ` +
-									`has no persisted agentId and template placeholder ` +
-									`'${tAgent.agentId}' could not be resolved in space '${spaceId}'`
-							);
-						}
-						return {
-							...tAgent,
-							agentId: persistedAgentId,
-						};
-					});
-
-					mergedNodes.push({
-						id: eNode.id,
-						name: tNode.name,
-						agents: mergedAgents,
-					});
-				}
-
-				if (abortReStamp !== null) {
-					builtInSeederLog.warn(
-						`skipping re-stamp of built-in workflow '${template.name}' ` +
-							`(id=${row.id}) in space ${spaceId}: ${abortReStamp}. ` +
-							`Row will continue to surface as drifted until fixed manually.`
-					);
-					continue;
-				}
-
 				workflowManager.updateWorkflow(row.id, {
 					completionAutonomyLevel: template.completionAutonomyLevel,
 					// Pass `null` (not `undefined`) when the template clears the route,
 					// so the repository writes the new value rather than leaving the
 					// old one in place.
 					postApproval: template.postApproval ?? null,
-					// Re-stamp node prompt content in-place. UUIDs for each node
-					// are preserved above (see `eNode.id`), so node-execution rows
-					// and workflow-run state on live sessions remain valid.
-					nodes: mergedNodes,
+					// Never re-stamp nodes/prompts during startup/idempotent seed reruns.
+					// User/workflow configuration is runtime data and must not be silently
+					// replaced by built-in template text outside an explicit sync action.
 					templateHash: expectedHash,
 				});
 				restamped.push(template.name);

--- a/packages/daemon/tests/unit/1-core/lib/space-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-agent-manager.test.ts
@@ -456,7 +456,7 @@ describe('SpaceAgentManager', () => {
 			expect(report.agents[0].currentHash).not.toBe('stale-hash-value');
 		});
 
-		it('treats legacy coordinator Reviewer prompt as equivalent to the current preset', async () => {
+		it('reports legacy coordinator Reviewer prompt rows as drifted without mutating them', async () => {
 			const { getPresetAgentTemplates, LEGACY_REVIEWER_PROMPT } = await import(
 				'../../../../src/lib/space/agents/seed-agents'
 			);
@@ -470,7 +470,7 @@ describe('SpaceAgentManager', () => {
 				customPrompt: LEGACY_REVIEWER_PROMPT,
 			});
 
-			await manager.create({
+			const created = await manager.create({
 				spaceId: 'space-1',
 				name: 'Reviewer',
 				description: reviewer.description,
@@ -479,12 +479,14 @@ describe('SpaceAgentManager', () => {
 				templateName: 'Reviewer',
 				templateHash: legacyHash,
 			});
+			if (!created.ok) throw new Error('create failed');
 
 			const report = manager.getAgentDriftReport('space-1');
 			expect(report.agents).toHaveLength(1);
-			expect(report.agents[0].drifted).toBe(false);
+			expect(report.agents[0].drifted).toBe(true);
 			expect(report.agents[0].storedHash).toBe(legacyHash);
 			expect(report.agents[0].currentHash).not.toBe(legacyHash);
+			expect(manager.getById(created.value.id)?.customPrompt).toBe(LEGACY_REVIEWER_PROMPT);
 		});
 
 		it('reports user-edited legacy Reviewer prompts as drifted', async () => {
@@ -541,40 +543,6 @@ describe('SpaceAgentManager', () => {
 
 			const report = manager.getAgentDriftReport('space-1');
 			expect(report.agents).toEqual([]);
-		});
-	});
-
-	describe('reconcileEquivalentLegacyPresetRows', () => {
-		it('reconciles legacy coordinator Reviewer prompts to the current preset prompt', async () => {
-			const { getPresetAgentTemplates, LEGACY_REVIEWER_PROMPT } = await import(
-				'../../../../src/lib/space/agents/seed-agents'
-			);
-			const { computeAgentTemplateHash } = await import(
-				'../../../../src/lib/space/agents/agent-template-hash'
-			);
-			const reviewer = getPresetAgentTemplates().find((p) => p.name === 'Reviewer');
-			if (!reviewer) throw new Error('Reviewer preset missing');
-			const legacyHash = computeAgentTemplateHash({
-				...reviewer,
-				customPrompt: LEGACY_REVIEWER_PROMPT,
-			});
-
-			const created = await manager.create({
-				spaceId: 'space-1',
-				name: 'Reviewer',
-				description: reviewer.description,
-				tools: reviewer.tools,
-				customPrompt: LEGACY_REVIEWER_PROMPT,
-				templateName: 'Reviewer',
-				templateHash: legacyHash,
-			});
-			if (!created.ok) throw new Error('create failed');
-
-			const updated = manager.reconcileEquivalentLegacyPresetRows('space-1');
-			expect(updated).toHaveLength(1);
-			expect(updated[0].customPrompt).toBe(reviewer.customPrompt);
-			expect(updated[0].templateHash).toBe(computeAgentTemplateHash(reviewer));
-			expect(manager.getById(created.value.id)?.customPrompt).toBe(reviewer.customPrompt);
 		});
 	});
 

--- a/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts
@@ -7,6 +7,7 @@ import {
 	expandPrompt,
 	createCustomAgentInit,
 	resolveAgentInit,
+	resolveCustomAgentPrompt,
 	type CustomAgentConfig,
 	type SlotOverrides,
 } from '../../../../src/lib/space/agents/custom-agent';
@@ -166,6 +167,28 @@ describe('buildCustomAgentSystemPrompt', () => {
 
 	it('returns empty string when no prompt is configured', () => {
 		expect(buildCustomAgentSystemPrompt(makeAgent({ customPrompt: null }))).toBe('');
+	});
+});
+
+describe('resolveCustomAgentPrompt', () => {
+	it('resolves workflow node overrides before the persisted agent prompt', () => {
+		const resolved = resolveCustomAgentPrompt(makeAgent({ customPrompt: 'Base prompt' }), {
+			customPrompt: 'Node override',
+		});
+
+		expect(resolved.value).toBe('Base prompt\n\nNode override');
+		expect(resolved.source).toBe('workflow_node_custom_prompt');
+		expect(resolved.hash).toMatch(/^[a-f0-9]{64}$/);
+	});
+
+	it('does not substitute the generic reviewer prompt when no prompt is configured', () => {
+		const resolved = resolveCustomAgentPrompt(makeAgent({ name: 'Reviewer', customPrompt: null }));
+
+		expect(resolved.value).toBe('');
+		expect(resolved.source).toBe('empty');
+		expect(resolved.value).not.toContain(
+			'You are an expert code reviewer. You review pull requests'
+		);
 	});
 });
 
@@ -449,6 +472,66 @@ describe('createCustomAgentInit', () => {
 		);
 
 		expect(init.systemPrompt?.append).toBe('Agent base prompt');
+	});
+
+	it('records workflow-node prompt provenance for sentinel prompts', () => {
+		const init = createCustomAgentInit(
+			makeConfig({
+				customAgent: makeAgent({
+					id: 'reviewer-agent-id',
+					name: 'Reviewer',
+					customPrompt: 'Base reviewer prompt',
+				}),
+				workflowRun: makeWorkflowRun({ id: 'run-review' }),
+				workflow: makeWorkflow({ id: 'workflow-review' }),
+				slotOverrides: {
+					customPrompt: 'SENTINEL REVIEW NODE PROMPT',
+					resolutionContext: {
+						agentId: 'reviewer-agent-id',
+						agentName: 'reviewer',
+						workflowRunId: 'run-review',
+						workflowId: 'workflow-review',
+						nodeId: 'review-node',
+						nodeName: 'Review',
+					},
+				},
+			})
+		);
+
+		expect(init.systemPrompt?.append).toContain('SENTINEL REVIEW NODE PROMPT');
+		expect(init.systemPrompt?.append).not.toContain(
+			'You are an expert code reviewer. You review pull requests'
+		);
+		expect(init.promptProvenance).toMatchObject({
+			source: 'workflow_node_custom_prompt',
+			agentId: 'reviewer-agent-id',
+			agentName: 'reviewer',
+			workflowRunId: 'run-review',
+			workflowId: 'workflow-review',
+			nodeId: 'review-node',
+			nodeName: 'Review',
+		});
+		expect(init.promptProvenance?.hash).toMatch(/^[a-f0-9]{64}$/);
+	});
+
+	it('records agent prompt provenance for non-reviewer agents without node overrides', () => {
+		const init = createCustomAgentInit(
+			makeConfig({
+				customAgent: makeAgent({
+					id: 'qa-agent-id',
+					name: 'QA',
+					customPrompt: 'SENTINEL QA PROMPT',
+				}),
+				workflowRun: makeWorkflowRun({ id: 'run-qa' }),
+			})
+		);
+
+		expect(init.systemPrompt?.append).toBe('SENTINEL QA PROMPT');
+		expect(init.promptProvenance).toMatchObject({
+			source: 'space_agent_custom_prompt',
+			agentId: 'qa-agent-id',
+			agentName: 'QA',
+		});
 	});
 
 	it('uses tool-restricted agent mode when tools are configured', () => {

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -1233,35 +1233,22 @@ describe('seedBuiltInWorkflows()', () => {
 		expect(after.postApproval).toBeUndefined();
 	});
 
-	test('re-stamp updates each node agent `customPrompt.value` in-place', () => {
-		// Regression guard for PR 3/5: without this, existing spaces get the
-		// new `postApproval` wired but keep stale end-node prompts — so the
-		// reviewer sub-session fires the merge template against a task-agent
-		// that never sent `{ pr_url }` in its handoff, leaving `{{pr_url}}`
-		// uninterpolated. Proof: force-drift the stored hash AND manually
-		// stomp the end-node's customPrompt to an old value; after re-stamp
-		// the prompt must match the current template verbatim.
+	test('re-stamp does not overwrite persisted node agent custom prompts', () => {
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const coding = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
+		const reviewNode = coding.nodes.find((n) => n.name === 'Review')!;
+		const reviewAgent = reviewNode.agents[0];
+		const sentinel = 'SENTINEL REVIEW PROMPT - must survive startup re-stamp';
 
-		// Find the end node and its first (task-agent) slot on the persisted row.
-		const endNode = coding.nodes.find((n) => n.id === coding.endNodeId)!;
-		const endAgent = endNode.agents[0];
-		const originalPrompt = endAgent.customPrompt?.value ?? '';
-		const staleMarker = '### STALE PROMPT FROM A PRIOR PR ###';
-		expect(originalPrompt).not.toContain(staleMarker);
-
-		// Simulate an old-template row: rewrite this node's agent prompt and
-		// mark the row's hash stale so the seeder takes the re-stamp branch.
 		manager.updateWorkflow(coding.id, {
 			nodes: coding.nodes.map((n) =>
-				n.id !== endNode.id
+				n.id !== reviewNode.id
 					? n
 					: {
 							id: n.id,
 							name: n.name,
 							agents: n.agents.map((a, i) =>
-								i === 0 ? { ...a, customPrompt: { value: staleMarker } } : a
+								i === 0 ? { ...a, customPrompt: { value: sentinel } } : a
 							),
 						}
 			),
@@ -1271,32 +1258,16 @@ describe('seedBuiltInWorkflows()', () => {
 			coding.id
 		);
 
-		// Sanity: the stale write landed.
-		const stalled = manager.getWorkflow(coding.id)!;
-		const stalledAgent = stalled.nodes.find((n) => n.id === endNode.id)!.agents[0];
-		expect(stalledAgent.customPrompt?.value).toBe(staleMarker);
-
-		// Re-run the seeder — should take the re-stamp branch.
 		const result = seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		expect(result.restamped).toContain(CODING_WORKFLOW.name);
 
-		// Prompt restored to the current template verbatim (not the stale marker).
 		const after = manager.getWorkflow(coding.id)!;
-		const afterEndNode = after.nodes.find((n) => n.id === endNode.id)!;
-		const afterAgent = afterEndNode.agents[0];
-		expect(afterAgent.customPrompt?.value).not.toContain(staleMarker);
-		expect(afterAgent.customPrompt?.value).toBe(originalPrompt);
-
-		// Critical invariant: the node UUID and agent UUID were preserved, so
-		// any in-flight run referencing them continues to resolve.
-		expect(afterEndNode.id).toBe(endNode.id);
-		expect(afterAgent.agentId).toBe(endAgent.agentId);
-
-		// And after the re-stamp, the drift detector's hash check matches: the
-		// full-template hash (which includes nodePrompts) now aligns with the
-		// re-stamped row, so operators are not spammed with false drift warnings.
-		const expectedHash = computeWorkflowHash(CODING_WORKFLOW);
-		expect(after.templateHash).toBe(expectedHash);
+		const afterReviewNode = after.nodes.find((n) => n.id === reviewNode.id)!;
+		const afterAgent = afterReviewNode.agents[0];
+		expect(afterAgent.customPrompt?.value).toBe(sentinel);
+		expect(afterAgent.agentId).toBe(reviewAgent.agentId);
+		expect(afterReviewNode.id).toBe(reviewNode.id);
+		expect(after.templateHash).toBe(computeWorkflowHash(CODING_WORKFLOW));
 	});
 
 	test('re-stamp preserves node UUIDs (safe for in-flight runs)', () => {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -563,6 +563,17 @@ export interface SessionMetadata {
 	};
 	/** Runtime init fingerprint for non-worker sessions (used to invalidate stale SDK resume state) */
 	runtimeInitFingerprint?: string;
+	/** Non-secret provenance for the configured system prompt used when a session was spawned. */
+	promptProvenance?: {
+		source: string;
+		hash: string;
+		agentId?: string;
+		agentName?: string;
+		workflowRunId?: string;
+		workflowId?: string;
+		nodeId?: string;
+		nodeName?: string;
+	};
 }
 
 // Message content types for streaming input (supports images and tool results)


### PR DESCRIPTION
Stops daemon startup seed/reconcile paths from overwriting persisted agent and workflow-node prompts, centralizes workflow-node prompt provenance, and keeps tool permissions sourced from persisted agent config.

Legitimate hardcoded agent/workflow definitions remain only in seed/template data (`seed-agents.ts`, `built-in-workflows.ts`) plus the explicit `task-agent` post-approval sentinel used by persisted route config.

Tests: `bun run typecheck`; `bun run lint`; `bun test packages/daemon/tests/unit/1-core/lib/space-agent-manager.test.ts packages/daemon/tests/unit/5-space/agent/custom-agent.test.ts packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts`. Full `bun test packages/daemon/tests/unit` still hits existing mock-shape failures around SpaceRuntime recovery repos.