### PR TITLE
Fix Space GitHub polling follow-ups

### DIFF
--- a/packages/daemon/src/lib/github/space-github.ts
+++ b/packages/daemon/src/lib/github/space-github.ts
@@ -23,6 +23,7 @@ export type SpaceGitHubEventState =
 
 export interface PollCursor {
 	lastSeenAt?: number;
+	pendingLastSeenAt?: number;
 	etags?: Record<string, string>;
 	processedPages?: Record<string, number>;
 }
@@ -199,9 +200,11 @@ export function normalizeSpaceGitHubWebhook(
 		title = `PR #${prNumber} ${action}`;
 	}
 	if (!repo.owner || !repo.repo || !prNumber) return null;
+	const canonicalOwner = repo.owner.toLowerCase();
+	const canonicalRepo = repo.repo.toLowerCase();
 	return {
 		deliveryId,
-		dedupeKey: `${repo.owner}/${repo.repo}:${externalId}`,
+		dedupeKey: `${canonicalOwner}/${canonicalRepo}:${externalId}`,
 		source: 'webhook',
 		eventType,
 		action,
@@ -625,10 +628,11 @@ export class SpaceGitHubService {
 			const cursor = watched.pollCursor ?? {};
 			const etags = cursor.etags ?? {};
 			const processedPages = cursor.processedPages ?? {};
-			const since =
-				cursor.lastSeenAt || watched.lastPollAt
-					? new Date(cursor.lastSeenAt ?? watched.lastPollAt ?? 0).toISOString()
-					: undefined;
+			const watermarks = {
+				committed: cursor.lastSeenAt ?? watched.lastPollAt ?? 0,
+				pending: cursor.pendingLastSeenAt ?? cursor.lastSeenAt ?? watched.lastPollAt ?? 0,
+			};
+			const since = watermarks.committed ? new Date(watermarks.committed).toISOString() : undefined;
 			// Poll issue comments, review comments, and PR metadata; all feed the same ingest path.
 			const base = `https://api.github.com/repos/${watched.owner}/${watched.repo}`;
 			const endpoints = [
@@ -636,7 +640,6 @@ export class SpaceGitHubService {
 				{ key: 'review_comments', path: '/pulls/comments' },
 				{ key: 'pulls', path: '/pulls', extra: 'state=all&sort=updated&direction=desc' },
 			];
-			let lastSeenAt = cursor.lastSeenAt ?? watched.lastPollAt ?? 0;
 			for (const endpoint of endpoints) {
 				const page = processedPages[endpoint.key] ?? 1;
 				const query = new URLSearchParams();
@@ -668,13 +671,19 @@ export class SpaceGitHubService {
 					if (event) {
 						event.source = 'polling';
 						await this.ingest(watched.spaceId, event);
-						lastSeenAt = Math.max(lastSeenAt, event.occurredAt);
+						watermarks.pending = Math.max(watermarks.pending, event.occurredAt);
 						count++;
 					}
 				}
 				processedPages[endpoint.key] = rows.length >= 100 ? page + 1 : 1;
 			}
-			const cursorPayload: PollCursor = { lastSeenAt, etags, processedPages };
+			const hasBacklog = Object.values(processedPages).some((page) => page > 1);
+			const cursorPayload: PollCursor = {
+				lastSeenAt: hasBacklog ? watermarks.committed : watermarks.pending,
+				pendingLastSeenAt: hasBacklog ? watermarks.pending : undefined,
+				etags,
+				processedPages,
+			};
 			this.db
 				.prepare(
 					`UPDATE space_github_watched_repos SET last_poll_at = ?, poll_cursor = ?, updated_at = ? WHERE id = ?`
@@ -714,9 +723,11 @@ export class SpaceGitHubService {
 		const dedupeVersion =
 			endpointKey === 'pulls' ? String(updatedAt) : getString(obj.updated_at ?? obj.created_at);
 		const dedupeSuffix = dedupeVersion ? `:${dedupeVersion}` : '';
+		const canonicalOwner = watched.owner.toLowerCase();
+		const canonicalRepo = watched.repo.toLowerCase();
 		return {
 			deliveryId: `poll:${eventType}:${id}${dedupeSuffix}`,
-			dedupeKey: `${watched.owner}/${watched.repo}:${eventType}:${id}${dedupeSuffix}`,
+			dedupeKey: `${canonicalOwner}/${canonicalRepo}:${eventType}:${id}${dedupeSuffix}`,
 			source: 'polling',
 			eventType,
 			action: 'polled',

--- a/packages/daemon/tests/unit/2-handlers/github/space-github.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/github/space-github.test.ts
@@ -362,14 +362,14 @@ describe('Space GitHub integration', () => {
 		expect(db.prepare('SELECT COUNT(*) AS c FROM space_github_events').get()).toEqual({ c: 2 });
 	});
 
-	test('polling ignores issue comments and pages without advancing past unprocessed rows', async () => {
+	test('polling ignores issue comments and keeps watermark stable while draining pages', async () => {
 		const db = setupDb();
 		seedTask(db);
 		const service = new SpaceGitHubService(db, undefined, undefined, 'token');
 		service.repo.upsertWatchedRepo({
 			spaceId: 'space-1',
-			owner: 'acme',
-			repo: 'widgets',
+			owner: 'Acme',
+			repo: 'Widgets',
 			pollingEnabled: true,
 		});
 		const calls: string[] = [];
@@ -392,15 +392,19 @@ describe('Space GitHub integration', () => {
 				);
 			}
 			if (urlText.includes('/pulls?')) {
+				const page = new URL(urlText).searchParams.get('page');
 				return new Response(
 					JSON.stringify(
-						Array.from({ length: 100 }, (_unused, idx) => ({
-							id: 700 + idx,
+						Array.from({ length: page === '1' ? 100 : 1 }, (_unused, idx) => ({
+							id: page === '1' ? 700 + idx : 900,
 							number: 7,
 							title: `PR update ${idx}`,
 							html_url: 'https://github.com/acme/widgets/pull/7',
 							user: { login: 'dev', type: 'User' },
-							updated_at: `2026-01-01T00:${String(idx % 60).padStart(2, '0')}:00Z`,
+							updated_at:
+								page === '1'
+									? `2026-01-01T00:${String(idx % 60).padStart(2, '0')}:00Z`
+									: '2026-01-01T00:59:59Z',
 						}))
 					),
 					{ status: 200 }
@@ -413,14 +417,37 @@ describe('Space GitHub integration', () => {
 
 		expect(db.prepare('SELECT COUNT(*) AS c FROM space_github_events').get()).toEqual({ c: 100 });
 		expect(calls.some((url) => url.includes('per_page=100'))).toBe(true);
+		let cursor = JSON.parse(
+			(
+				db.prepare('SELECT poll_cursor FROM space_github_watched_repos').get() as {
+					poll_cursor: string;
+				}
+			).poll_cursor
+		);
+		expect(cursor.processedPages.pulls).toBe(2);
+		expect(cursor.lastSeenAt).toBe(0);
+		expect(cursor.pendingLastSeenAt).toBeGreaterThan(0);
+
+		await service.pollOnce(fakeFetch as typeof fetch);
+
+		expect(calls.some((url) => url.includes('page=2') && !url.includes('since='))).toBe(true);
+		expect(db.prepare('SELECT COUNT(*) AS c FROM space_github_events').get()).toEqual({ c: 101 });
+		cursor = JSON.parse(
+			(
+				db.prepare('SELECT poll_cursor FROM space_github_watched_repos').get() as {
+					poll_cursor: string;
+				}
+			).poll_cursor
+		);
+		expect(cursor.processedPages.pulls).toBe(1);
+		expect(cursor.pendingLastSeenAt).toBeUndefined();
+		expect(cursor.lastSeenAt).toBeGreaterThan(0);
 		expect(
-			JSON.parse(
-				(
-					db.prepare('SELECT poll_cursor FROM space_github_watched_repos').get() as {
-						poll_cursor: string;
-					}
-				).poll_cursor
-			).processedPages.pulls
-		).toBe(2);
+			(
+				db.prepare('SELECT dedupe_key FROM space_github_events LIMIT 1').get() as {
+					dedupe_key: string;
+				}
+			).dedupe_key.startsWith('acme/widgets:')
+		).toBe(true);
 	});
 });


### PR DESCRIPTION
Follow-up to PR #1740 addressing the remaining inline polling comments.

- Keeps the polling watermark stable until paginated backlog is fully drained
- Canonicalizes repo casing in webhook and polling dedupe keys
- Extends Space GitHub tests for pagination watermark behavior and casing