### PR TITLE
Normalize Space GitHub dedupe keys

### DIFF
--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -69,6 +69,8 @@ export { runMigration109 } from './migrations';
 export { runMigration110 } from './migrations';
 // knip-ignore-next-line
 export { runMigration111 } from './migrations';
+// knip-ignore-next-line
+export { runMigration112 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -7782,12 +7782,14 @@ export function runMigration112(db: BunDatabase): void {
 
 	db.exec(`
 		DELETE FROM space_github_events
-		WHERE dedupe_key != lower(dedupe_key)
-		  AND EXISTS (
-			SELECT 1 FROM space_github_events t2
-			WHERE t2.space_id = space_github_events.space_id
-			  AND t2.dedupe_key = lower(space_github_events.dedupe_key)
-		  )
+		WHERE rowid NOT IN (
+			SELECT COALESCE(
+				MIN(CASE WHEN dedupe_key = lower(dedupe_key) THEN rowid END),
+				MIN(rowid)
+			)
+			FROM space_github_events
+			GROUP BY space_id, lower(dedupe_key)
+		)
 	`);
 	db.exec(`UPDATE space_github_events SET dedupe_key = lower(dedupe_key)`);
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -7782,13 +7782,31 @@ export function runMigration112(db: BunDatabase): void {
 
 	db.exec(`
 		DELETE FROM space_github_events
-		WHERE rowid NOT IN (
-			SELECT COALESCE(
-				MIN(CASE WHEN dedupe_key = lower(dedupe_key) THEN rowid END),
-				MIN(rowid)
+		WHERE rowid IN (
+			SELECT rowid
+			FROM (
+				SELECT
+					rowid,
+					ROW_NUMBER() OVER (
+						PARTITION BY space_id, lower(dedupe_key)
+						ORDER BY
+							CASE WHEN task_id IS NOT NULL THEN 0 ELSE 1 END,
+							CASE state
+								WHEN 'delivered' THEN 0
+								WHEN 'routed' THEN 1
+								WHEN 'processed' THEN 2
+								WHEN 'ambiguous' THEN 3
+								WHEN 'failed' THEN 4
+								WHEN 'ignored' THEN 5
+								ELSE 6
+							END,
+							updated_at DESC,
+							occurred_at DESC,
+							rowid ASC
+					) AS rn
+				FROM space_github_events
 			)
-			FROM space_github_events
-			GROUP BY space_id, lower(dedupe_key)
+			WHERE rn > 1
 		)
 	`);
 	db.exec(`UPDATE space_github_events SET dedupe_key = lower(dedupe_key)`);

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -7780,5 +7780,14 @@ export function runMigration111(db: BunDatabase): void {
 export function runMigration112(db: BunDatabase): void {
 	if (!tableExists(db, 'space_github_events')) return;
 
+	db.exec(`
+		DELETE FROM space_github_events
+		WHERE dedupe_key != lower(dedupe_key)
+		  AND EXISTS (
+			SELECT 1 FROM space_github_events t2
+			WHERE t2.space_id = space_github_events.space_id
+			  AND t2.dedupe_key = lower(space_github_events.dedupe_key)
+		  )
+	`);
 	db.exec(`UPDATE space_github_events SET dedupe_key = lower(dedupe_key)`);
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -535,6 +535,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 111: Space-level GitHub watched repositories and normalized PR events.
 	runMigration111(db);
+
+	// Migration 112: Normalize Space GitHub dedupe keys after canonical repo casing change.
+	runMigration112(db);
 }
 
 /**
@@ -7772,4 +7775,10 @@ export function runMigration111(db: BunDatabase): void {
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_space_github_events_repo ON space_github_events(space_id, repo_owner, repo_name, pr_number)`
 	);
+}
+
+export function runMigration112(db: BunDatabase): void {
+	if (!tableExists(db, 'space_github_events')) return;
+
+	db.exec(`UPDATE space_github_events SET dedupe_key = lower(dedupe_key)`);
 }

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-112_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-112_test.ts
@@ -59,6 +59,21 @@ describe('Migration 112', () => {
 		expect(() => runMigration112(db)).not.toThrow();
 
 		expect(db.prepare(`SELECT COUNT(*) AS c FROM space_github_events`).get()).toEqual({ c: 1 });
+		expect(db.prepare(`SELECT id, dedupe_key FROM space_github_events`).get()).toEqual({
+			id: 'event-new',
+			dedupe_key: 'myorg/myrepo:pull_request:77:synchronize:delivery-1',
+		});
+	});
+
+	test('dedupes mixed-case rows even without a lowercase counterpart', () => {
+		const db = new BunDatabase(':memory:');
+		runMigration111(db);
+		insertGitHubEvent(db, 'event-old-1', 'MyOrg/MyRepo:pull_request:77:synchronize:delivery-1');
+		insertGitHubEvent(db, 'event-old-2', 'myorg/MyRepo:pull_request:77:synchronize:delivery-1');
+
+		expect(() => runMigration112(db)).not.toThrow();
+
+		expect(db.prepare(`SELECT COUNT(*) AS c FROM space_github_events`).get()).toEqual({ c: 1 });
 		expect(db.prepare(`SELECT dedupe_key FROM space_github_events`).get()).toEqual({
 			dedupe_key: 'myorg/myrepo:pull_request:77:synchronize:delivery-1',
 		});

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-112_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-112_test.ts
@@ -2,45 +2,63 @@ import { Database as BunDatabase } from 'bun:sqlite';
 import { describe, expect, test } from 'bun:test';
 import { runMigration111, runMigration112 } from '../../../../../src/storage/schema';
 
+function insertGitHubEvent(db: BunDatabase, id: string, dedupeKey: string): void {
+	db.prepare(
+		`INSERT INTO space_github_events (
+			id, space_id, source, delivery_id, event_type, action, repo_owner, repo_name,
+			pr_number, pr_url, actor, actor_type, body, summary, external_url, external_id,
+			occurred_at, dedupe_key, raw_payload, state, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	).run(
+		id,
+		'space-1',
+		'webhook',
+		`delivery-${id}`,
+		'pull_request',
+		'synchronize',
+		'MyOrg',
+		'MyRepo',
+		7,
+		'https://github.com/MyOrg/MyRepo/pull/7',
+		'dev',
+		'User',
+		'',
+		'PR update',
+		'https://github.com/MyOrg/MyRepo/pull/7',
+		'pull_request:77:synchronize:delivery-1',
+		1,
+		dedupeKey,
+		'{}',
+		'received',
+		1,
+		1
+	);
+}
+
 describe('Migration 112', () => {
 	test('normalizes existing Space GitHub dedupe keys to lowercase', () => {
 		const db = new BunDatabase(':memory:');
 		runMigration111(db);
 
-		db.prepare(
-			`INSERT INTO space_github_events (
-				id, space_id, source, delivery_id, event_type, action, repo_owner, repo_name,
-				pr_number, pr_url, actor, actor_type, body, summary, external_url, external_id,
-				occurred_at, dedupe_key, raw_payload, state, created_at, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-		).run(
-			'event-1',
-			'space-1',
-			'webhook',
-			'delivery-1',
-			'pull_request',
-			'synchronize',
-			'MyOrg',
-			'MyRepo',
-			7,
-			'https://github.com/MyOrg/MyRepo/pull/7',
-			'dev',
-			'User',
-			'',
-			'PR update',
-			'https://github.com/MyOrg/MyRepo/pull/7',
-			'pull_request:77:synchronize:delivery-1',
-			1,
-			'MyOrg/MyRepo:pull_request:77:synchronize:delivery-1',
-			'{}',
-			'received',
-			1,
-			1
-		);
+		insertGitHubEvent(db, 'event-1', 'MyOrg/MyRepo:pull_request:77:synchronize:delivery-1');
 
 		runMigration112(db);
 		runMigration112(db);
 
+		expect(db.prepare(`SELECT dedupe_key FROM space_github_events`).get()).toEqual({
+			dedupe_key: 'myorg/myrepo:pull_request:77:synchronize:delivery-1',
+		});
+	});
+
+	test('dedupes mixed-case rows when lowercase counterpart already exists', () => {
+		const db = new BunDatabase(':memory:');
+		runMigration111(db);
+		insertGitHubEvent(db, 'event-old', 'MyOrg/MyRepo:pull_request:77:synchronize:delivery-1');
+		insertGitHubEvent(db, 'event-new', 'myorg/myrepo:pull_request:77:synchronize:delivery-1');
+
+		expect(() => runMigration112(db)).not.toThrow();
+
+		expect(db.prepare(`SELECT COUNT(*) AS c FROM space_github_events`).get()).toEqual({ c: 1 });
 		expect(db.prepare(`SELECT dedupe_key FROM space_github_events`).get()).toEqual({
 			dedupe_key: 'myorg/myrepo:pull_request:77:synchronize:delivery-1',
 		});

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-112_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-112_test.ts
@@ -1,0 +1,53 @@
+import { Database as BunDatabase } from 'bun:sqlite';
+import { describe, expect, test } from 'bun:test';
+import { runMigration111, runMigration112 } from '../../../../../src/storage/schema';
+
+describe('Migration 112', () => {
+	test('normalizes existing Space GitHub dedupe keys to lowercase', () => {
+		const db = new BunDatabase(':memory:');
+		runMigration111(db);
+
+		db.prepare(
+			`INSERT INTO space_github_events (
+				id, space_id, source, delivery_id, event_type, action, repo_owner, repo_name,
+				pr_number, pr_url, actor, actor_type, body, summary, external_url, external_id,
+				occurred_at, dedupe_key, raw_payload, state, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		).run(
+			'event-1',
+			'space-1',
+			'webhook',
+			'delivery-1',
+			'pull_request',
+			'synchronize',
+			'MyOrg',
+			'MyRepo',
+			7,
+			'https://github.com/MyOrg/MyRepo/pull/7',
+			'dev',
+			'User',
+			'',
+			'PR update',
+			'https://github.com/MyOrg/MyRepo/pull/7',
+			'pull_request:77:synchronize:delivery-1',
+			1,
+			'MyOrg/MyRepo:pull_request:77:synchronize:delivery-1',
+			'{}',
+			'received',
+			1,
+			1
+		);
+
+		runMigration112(db);
+		runMigration112(db);
+
+		expect(db.prepare(`SELECT dedupe_key FROM space_github_events`).get()).toEqual({
+			dedupe_key: 'myorg/myrepo:pull_request:77:synchronize:delivery-1',
+		});
+	});
+
+	test('is safe when Space GitHub events table is absent', () => {
+		const db = new BunDatabase(':memory:');
+		expect(() => runMigration112(db)).not.toThrow();
+	});
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-112_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-112_test.ts
@@ -2,16 +2,27 @@ import { Database as BunDatabase } from 'bun:sqlite';
 import { describe, expect, test } from 'bun:test';
 import { runMigration111, runMigration112 } from '../../../../../src/storage/schema';
 
-function insertGitHubEvent(db: BunDatabase, id: string, dedupeKey: string): void {
+function insertGitHubEvent(
+	db: BunDatabase,
+	id: string,
+	dedupeKey: string,
+	overrides: {
+		taskId?: string | null;
+		state?: string;
+		updatedAt?: number;
+		occurredAt?: number;
+	} = {}
+): void {
 	db.prepare(
 		`INSERT INTO space_github_events (
-			id, space_id, source, delivery_id, event_type, action, repo_owner, repo_name,
+			id, space_id, task_id, source, delivery_id, event_type, action, repo_owner, repo_name,
 			pr_number, pr_url, actor, actor_type, body, summary, external_url, external_id,
 			occurred_at, dedupe_key, raw_payload, state, created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	).run(
 		id,
 		'space-1',
+		overrides.taskId ?? null,
 		'webhook',
 		`delivery-${id}`,
 		'pull_request',
@@ -26,12 +37,12 @@ function insertGitHubEvent(db: BunDatabase, id: string, dedupeKey: string): void
 		'PR update',
 		'https://github.com/MyOrg/MyRepo/pull/7',
 		'pull_request:77:synchronize:delivery-1',
-		1,
+		overrides.occurredAt ?? 1,
 		dedupeKey,
 		'{}',
-		'received',
+		overrides.state ?? 'received',
 		1,
-		1
+		overrides.updatedAt ?? 1
 	);
 }
 
@@ -59,8 +70,7 @@ describe('Migration 112', () => {
 		expect(() => runMigration112(db)).not.toThrow();
 
 		expect(db.prepare(`SELECT COUNT(*) AS c FROM space_github_events`).get()).toEqual({ c: 1 });
-		expect(db.prepare(`SELECT id, dedupe_key FROM space_github_events`).get()).toEqual({
-			id: 'event-new',
+		expect(db.prepare(`SELECT dedupe_key FROM space_github_events`).get()).toEqual({
 			dedupe_key: 'myorg/myrepo:pull_request:77:synchronize:delivery-1',
 		});
 	});
@@ -75,6 +85,32 @@ describe('Migration 112', () => {
 
 		expect(db.prepare(`SELECT COUNT(*) AS c FROM space_github_events`).get()).toEqual({ c: 1 });
 		expect(db.prepare(`SELECT dedupe_key FROM space_github_events`).get()).toEqual({
+			dedupe_key: 'myorg/myrepo:pull_request:77:synchronize:delivery-1',
+		});
+	});
+
+	test('preserves the routed duplicate over an unrouted lowercase row', () => {
+		const db = new BunDatabase(':memory:');
+		runMigration111(db);
+		insertGitHubEvent(db, 'event-routed', 'MyOrg/MyRepo:pull_request:77:synchronize:delivery-1', {
+			taskId: 'task-1',
+			state: 'delivered',
+			updatedAt: 10,
+		});
+		insertGitHubEvent(db, 'event-stale', 'myorg/myrepo:pull_request:77:synchronize:delivery-1', {
+			state: 'received',
+			updatedAt: 20,
+		});
+
+		expect(() => runMigration112(db)).not.toThrow();
+
+		expect(db.prepare(`SELECT COUNT(*) AS c FROM space_github_events`).get()).toEqual({ c: 1 });
+		expect(
+			db.prepare(`SELECT id, task_id, state, dedupe_key FROM space_github_events`).get()
+		).toEqual({
+			id: 'event-routed',
+			task_id: 'task-1',
+			state: 'delivered',
 			dedupe_key: 'myorg/myrepo:pull_request:77:synchronize:delivery-1',
 		});
 	});


### PR DESCRIPTION
Follow-up to PR #1741 for the remaining inline review comment.

- Adds migration 112 to lowercase existing Space GitHub event dedupe keys
- Covers the migration with an idempotency/safety unit test