### PR TITLE
Fix Reviewer prompt reset on restart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,8 @@ make test-daemon       # Daemon tests (all shards in parallel, with coverage)
 make test-web          # Web tests only (vitest run) with coverage
 
 # Daemon test runner (scripts/test-daemon.sh)
-./scripts/test-daemon.sh                # All 7 shards in parallel (fast, no coverage)
+# Do NOT run `bun test packages/daemon/tests/unit`; use this shard runner instead.
+./scripts/test-daemon.sh                # All daemon unit shards in parallel (fast, no coverage)
 ./scripts/test-daemon.sh --coverage     # All shards with coverage
 ./scripts/test-daemon.sh 2-handlers     # Run a single shard
 ./scripts/test-daemon.sh --rerun        # Rerun only previously failing files

--- a/packages/daemon/src/lib/space/managers/space-agent-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-agent-manager.ts
@@ -20,8 +20,11 @@ import type {
 import { KNOWN_TOOLS } from '@neokai/shared';
 import type { SpaceAgentRepository } from '../../../storage/repositories/space-agent-repository';
 import { isValidModel, getAvailableModels, getModelInfoUnfiltered } from '../../model-service';
+import { Logger } from '../../logger';
 import { getPresetAgentTemplates } from '../agents/seed-agents';
 import { computeAgentTemplateHash } from '../agents/agent-template-hash';
+
+const log = new Logger('space-agent-manager');
 
 const KNOWN_TOOLS_SET = new Set<string>(KNOWN_TOOLS);
 
@@ -209,11 +212,22 @@ export class SpaceAgentManager {
 			};
 		}
 
+		const templateHash = computeAgentTemplateHash(preset);
+		log.info('Syncing space agent from preset template', {
+			agentId,
+			spaceId: existing.spaceId,
+			agentName: existing.name,
+			templateName: existing.templateName,
+			previousTemplateHash: existing.templateHash,
+			templateHash,
+			source: 'user_sync_from_template',
+		});
+
 		const updated = this.repo.update(agentId, {
 			description: preset.description,
 			tools: preset.tools,
 			customPrompt: preset.customPrompt,
-			templateHash: computeAgentTemplateHash(preset),
+			templateHash,
 		});
 		if (!updated) return { ok: false, error: `Agent not found after sync: ${agentId}` };
 		return { ok: true, value: updated };

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -2470,27 +2470,42 @@ function runMigration29(db: BunDatabase): void {
 	// any missing columns here.
 	// -------------------------------------------------------------------------
 
-	// space_agents: role (added in former migration 30)
-	try {
-		db.prepare(`SELECT role FROM space_agents LIMIT 1`).all();
-	} catch {
-		db.exec(`ALTER TABLE space_agents ADD COLUMN role TEXT NOT NULL DEFAULT 'coder'`);
+	// space_agents: role/provider/inject_workflow_context (added by early Space previews)
+	//
+	// These idempotent upgrades live in the original Space schema migration, which
+	// is re-run on every daemon startup. Later migrations (M74/M80) intentionally
+	// remove `role` and `inject_workflow_context` and consolidate legacy
+	// `system_prompt`/`instructions` into `custom_prompt`. Re-adding the removed
+	// columns to an already-modern schema would cause M74 to rebuild the table on
+	// every restart; before this guard, that rebuild dropped `custom_prompt` and
+	// M80 repopulated it from stale `system_prompt`, silently downgrading preset
+	// agent prompts. Only apply the legacy column upgrades to pre-M80 schemas.
+	const spaceAgentsHaveCustomPrompt = tableHasColumn(db, 'space_agents', 'custom_prompt');
+	if (!spaceAgentsHaveCustomPrompt) {
+		// space_agents: role (added in former migration 30)
+		try {
+			db.prepare(`SELECT role FROM space_agents LIMIT 1`).all();
+		} catch {
+			db.exec(`ALTER TABLE space_agents ADD COLUMN role TEXT NOT NULL DEFAULT 'coder'`);
+		}
 	}
 
-	// space_agents: provider (added in former migration 30)
+	// space_agents: provider (added in former migration 30; still part of the current schema)
 	try {
 		db.prepare(`SELECT provider FROM space_agents LIMIT 1`).all();
 	} catch {
 		db.exec(`ALTER TABLE space_agents ADD COLUMN provider TEXT`);
 	}
 
-	// space_agents: inject_workflow_context (added in former migration 33)
-	try {
-		db.prepare(`SELECT inject_workflow_context FROM space_agents LIMIT 1`).all();
-	} catch {
-		db.exec(
-			`ALTER TABLE space_agents ADD COLUMN inject_workflow_context INTEGER NOT NULL DEFAULT 0`
-		);
+	if (!spaceAgentsHaveCustomPrompt) {
+		// space_agents: inject_workflow_context (added in former migration 33)
+		try {
+			db.prepare(`SELECT inject_workflow_context FROM space_agents LIMIT 1`).all();
+		} catch {
+			db.exec(
+				`ALTER TABLE space_agents ADD COLUMN inject_workflow_context INTEGER NOT NULL DEFAULT 0`
+			);
+		}
 	}
 
 	// space_workflows: start_step_id (added in former migration 32)

--- a/packages/daemon/tests/unit/1-core/lib/space-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-agent-manager.test.ts
@@ -580,6 +580,9 @@ describe('SpaceAgentManager', () => {
 			const { getPresetAgentTemplates } = await import(
 				'../../../../src/lib/space/agents/seed-agents'
 			);
+			const { computeAgentTemplateHash } = await import(
+				'../../../../src/lib/space/agents/agent-template-hash'
+			);
 			const coder = getPresetAgentTemplates().find((p) => p.name === 'Coder');
 			if (!coder) throw new Error('Coder preset missing');
 
@@ -601,6 +604,7 @@ describe('SpaceAgentManager', () => {
 			expect(result.value.description).toBe(coder.description);
 			expect(result.value.tools).toEqual(coder.tools);
 			expect(result.value.customPrompt).toBe(coder.customPrompt);
+			expect(result.value.templateHash).toBe(computeAgentTemplateHash(coder));
 		});
 
 		it('preserves id, spaceId, name, model, and provider', async () => {

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-106_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-106_test.ts
@@ -28,6 +28,10 @@ import { join } from 'node:path';
 import { Database as BunDatabase } from 'bun:sqlite';
 import { runMigrations } from '../../../../../src/storage/schema/index.ts';
 import { runMigration106 } from '../../../../../src/storage/schema/migrations.ts';
+import { SpaceAgentRepository } from '../../../../../src/storage/repositories/space-agent-repository.ts';
+import { SpaceAgentManager } from '../../../../../src/lib/space/managers/space-agent-manager.ts';
+import { getPresetAgentTemplates } from '../../../../../src/lib/space/agents/seed-agents.ts';
+import { computeAgentTemplateHash } from '../../../../../src/lib/space/agents/agent-template-hash.ts';
 
 interface AgentRow {
 	id: string;
@@ -86,6 +90,15 @@ function readAgent(db: BunDatabase, id: string): AgentRow | undefined {
 			   FROM space_agents WHERE id = ?`
 		)
 		.get(id) as AgentRow | undefined;
+}
+
+function readAgentTimestamps(
+	db: BunDatabase,
+	id: string
+): { created_at: number; updated_at: number } | undefined {
+	return db.prepare(`SELECT created_at, updated_at FROM space_agents WHERE id = ?`).get(id) as
+		| { created_at: number; updated_at: number }
+		| undefined;
 }
 
 describe('Migration 106: backfill preset agent template tracking', () => {
@@ -250,5 +263,73 @@ describe('Migration 106: backfill preset agent template tracking', () => {
 		expect(() => runMigration106(db)).not.toThrow();
 		const count = (db.prepare(`SELECT COUNT(*) AS c FROM space_agents`).get() as { c: number }).c;
 		expect(count).toBe(0);
+	});
+
+	test('restart migrations preserve a Reviewer prompt synced to the current template', async () => {
+		const reviewer = getPresetAgentTemplates().find((p) => p.name === 'Reviewer');
+		if (!reviewer) throw new Error('Reviewer preset missing');
+
+		insertAgent(db, {
+			id: 'reviewer-agent',
+			spaceId: 'sp-1',
+			name: 'Reviewer',
+			description: reviewer.description,
+			tools: reviewer.tools,
+			customPrompt:
+				'You are an expert code reviewer. You review pull requests for correctness, security, performance, style, and test coverage. You give specific, actionable feedback.\n\nReview the code thoroughly. If satisfied, summarize your findings. If changes are needed, provide specific feedback.',
+			templateName: 'Reviewer',
+			templateHash: 'stale-reviewer-hash',
+		});
+
+		const manager = new SpaceAgentManager(new SpaceAgentRepository(db as any));
+		const sync = await manager.syncFromTemplate('reviewer-agent');
+		expect(sync.ok).toBe(true);
+		if (!sync.ok) throw new Error('sync failed');
+		expect(sync.value.customPrompt).toBe(reviewer.customPrompt);
+		expect(sync.value.templateHash).toBe(computeAgentTemplateHash(reviewer));
+		expect(sync.value.customPrompt).not.toContain('You are an expert code reviewer');
+
+		const beforeRestart = readAgent(db, 'reviewer-agent')!;
+		const beforeTimestamps = readAgentTimestamps(db, 'reviewer-agent')!;
+
+		// Simulate daemon restart/bootstrap: run the full migration stack again on
+		// an already-modern schema. This used to re-add legacy columns, trigger M74's
+		// table rebuild, drop custom_prompt, and let M80 repopulate from stale
+		// system_prompt/instructions data.
+		runMigrations(db, () => {});
+
+		const afterRestart = readAgent(db, 'reviewer-agent')!;
+		const afterTimestamps = readAgentTimestamps(db, 'reviewer-agent')!;
+		expect(afterRestart.custom_prompt).toBe(reviewer.customPrompt);
+		expect(afterRestart.template_hash).toBe(computeAgentTemplateHash(reviewer));
+		expect(afterRestart).toEqual(beforeRestart);
+		expect(afterTimestamps).toEqual(beforeTimestamps);
+	});
+
+	test('restart migrations do not overwrite customized preset prompts', () => {
+		const reviewer = getPresetAgentTemplates().find((p) => p.name === 'Reviewer');
+		if (!reviewer) throw new Error('Reviewer preset missing');
+		const customizedPrompt = `${reviewer.customPrompt}\n\nUser-specific review policy.`;
+
+		insertAgent(db, {
+			id: 'customized-reviewer',
+			spaceId: 'sp-1',
+			name: 'Reviewer',
+			description: reviewer.description,
+			tools: reviewer.tools,
+			customPrompt: customizedPrompt,
+			templateName: 'Reviewer',
+			templateHash: computeAgentTemplateHash({ ...reviewer, customPrompt: customizedPrompt }),
+		});
+		const before = readAgent(db, 'customized-reviewer')!;
+		const beforeTimestamps = readAgentTimestamps(db, 'customized-reviewer')!;
+
+		runMigrations(db, () => {});
+
+		const after = readAgent(db, 'customized-reviewer')!;
+		const afterTimestamps = readAgentTimestamps(db, 'customized-reviewer')!;
+		expect(after.custom_prompt).toBe(customizedPrompt);
+		expect(after).toEqual(before);
+		expect(afterTimestamps).toEqual(beforeTimestamps);
 	});
 });


### PR DESCRIPTION
Fixes daemon restart migrations reintroducing legacy `space_agents` columns, which could trigger a table rebuild and repopulate `custom_prompt` from stale legacy prompt fields.

Adds restart-regression coverage for synced and customized Reviewer prompts, verifies sync-from-template stamps the current hash, and logs explicit user template sync provenance.