### PR TITLE
Improve large SDK thread performance

### DIFF
--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -77,6 +77,8 @@ export interface SDKMessageHandlerContext {
 	onInitSlashCommands: (commands: string[]) => Promise<void>;
 }
 
+type PersistedUserMessage = SDKMessage & { dbId: string; timestamp: number };
+
 export class SDKMessageHandler {
 	private sdkMessageDeltaVersion: number = 0;
 	private logger: Logger;
@@ -205,6 +207,23 @@ export class SDKMessageHandler {
 		);
 	}
 
+	private withDbChangeBatch<T>(operation: () => T): T {
+		const { db } = this.ctx;
+		if (!db.beginTransaction || !db.commitTransaction || !db.abortTransaction) {
+			return operation();
+		}
+
+		db.beginTransaction();
+		try {
+			const result = operation();
+			db.commitTransaction();
+			return result;
+		} catch (error) {
+			db.abortTransaction();
+			throw error;
+		}
+	}
+
 	/**
 	 * Acknowledge a persisted user message when SDK replays it.
 	 *
@@ -215,88 +234,69 @@ export class SDKMessageHandler {
 	 * 3) avoid inserting a duplicate SDK message row
 	 */
 	private async acknowledgePersistedUserMessage(message: SDKMessage): Promise<boolean> {
-		const { session, db, daemonHub, messageHub } = this.ctx;
+		const { session, db } = this.ctx;
 		if (message.type !== 'user' || !message.uuid) {
 			return false;
 		}
 
-		const enqueuedMessage = db
-			.getMessagesByStatus(session.id, 'enqueued')
-			.find((enqueued) => enqueued.uuid === message.uuid);
+		const enqueuedMessage = db.getMessageByStatusAndUuid(session.id, 'enqueued', message.uuid);
 		if (enqueuedMessage) {
-			db.updateMessageStatus([enqueuedMessage.dbId], 'consumed');
-			// Update DB timestamp to now so the message's position in the DB matches
-			// where the SDK placed it in the conversation (after already-streamed
-			// assistant messages), not when the user originally typed it.
-			db.updateMessageTimestamp(enqueuedMessage.dbId);
-			await daemonHub.emit('messages.statusChanged', {
-				sessionId: session.id,
-				messageIds: [enqueuedMessage.dbId],
-				status: 'consumed',
-			});
-			this.acknowledgedPersistedUserThisTurn = true;
-
-			messageHub.event(
-				'state.sdkMessages.delta',
-				{
-					added: [message],
-					timestamp: Date.now(),
-					version: ++this.sdkMessageDeltaVersion,
-				},
-				{ channel: `session:${session.id}` }
-			);
-
-			// Emit on DaemonHub for server-side listeners (e.g. group message mirroring)
-			// so pre-persisted user messages appear in the group timeline.
-			await daemonHub.emit('sdk.message', {
-				sessionId: session.id,
-				message,
-			});
-
+			await this.consumePersistedUserMessage(enqueuedMessage, message);
 			return true;
 		}
 
-		const deferredMessage = db
-			.getMessagesByStatus(session.id, 'deferred')
-			.find((deferred) => deferred.uuid === message.uuid);
+		const deferredMessage = db.getMessageByStatusAndUuid(session.id, 'deferred', message.uuid);
 		if (deferredMessage) {
-			db.updateMessageStatus([deferredMessage.dbId], 'consumed');
-			db.updateMessageTimestamp(deferredMessage.dbId);
-			await daemonHub.emit('messages.statusChanged', {
-				sessionId: session.id,
-				messageIds: [deferredMessage.dbId],
-				status: 'consumed',
-			});
-			this.acknowledgedPersistedUserThisTurn = true;
-
-			messageHub.event(
-				'state.sdkMessages.delta',
-				{
-					added: [message],
-					timestamp: Date.now(),
-					version: ++this.sdkMessageDeltaVersion,
-				},
-				{ channel: `session:${session.id}` }
-			);
-
-			// Emit on DaemonHub for server-side listeners (e.g. group message mirroring)
-			await daemonHub.emit('sdk.message', {
-				sessionId: session.id,
-				message,
-			});
-
+			await this.consumePersistedUserMessage(deferredMessage, message);
 			return true;
 		}
 
-		const consumedMessage = db
-			.getMessagesByStatus(session.id, 'consumed')
-			.find((consumed) => consumed.uuid === message.uuid);
+		const consumedMessage = db.getMessageByStatusAndUuid(session.id, 'consumed', message.uuid);
 		if (consumedMessage) {
 			this.acknowledgedPersistedUserThisTurn = true;
 			return true;
 		}
 
 		return false;
+	}
+
+	private async consumePersistedUserMessage(
+		persistedMessage: PersistedUserMessage,
+		sdkReplayMessage: SDKMessage
+	): Promise<void> {
+		const { session, db, daemonHub, messageHub } = this.ctx;
+
+		this.withDbChangeBatch(() => {
+			db.updateMessageStatus([persistedMessage.dbId], 'consumed');
+			// Update DB timestamp to now so the message's position in the DB matches
+			// where the SDK placed it in the conversation (after already-streamed
+			// assistant messages), not when the user originally typed it.
+			db.updateMessageTimestamp(persistedMessage.dbId);
+		});
+
+		await daemonHub.emit('messages.statusChanged', {
+			sessionId: session.id,
+			messageIds: [persistedMessage.dbId],
+			status: 'consumed',
+		});
+		this.acknowledgedPersistedUserThisTurn = true;
+
+		messageHub.event(
+			'state.sdkMessages.delta',
+			{
+				added: [sdkReplayMessage],
+				timestamp: Date.now(),
+				version: ++this.sdkMessageDeltaVersion,
+			},
+			{ channel: `session:${session.id}` }
+		);
+
+		// Emit on DaemonHub for server-side listeners (e.g. group message mirroring)
+		// so pre-persisted user messages appear in the group timeline.
+		await daemonHub.emit('sdk.message', {
+			sessionId: session.id,
+			message: sdkReplayMessage,
+		});
 	}
 
 	/**
@@ -314,8 +314,16 @@ export class SDKMessageHandler {
 			.getMessagesByStatus(session.id, 'enqueued')
 			.filter((enqueued) => isSDKUserMessage(enqueued));
 
+		if (enqueuedUsers.length > 0) {
+			this.withDbChangeBatch(() => {
+				db.updateMessageStatus(
+					enqueuedUsers.map((enqueuedUser) => enqueuedUser.dbId),
+					'consumed'
+				);
+			});
+		}
+
 		for (const enqueuedUser of enqueuedUsers) {
-			db.updateMessageStatus([enqueuedUser.dbId], 'consumed');
 			// Don't update timestamp here — keep the original T1 timestamp
 			// since we don't know the exact T_consumed for these edge cases.
 			// The original timestamp (when user consumed it) is a better approximation
@@ -351,21 +359,19 @@ export class SDKMessageHandler {
 	private handleMessageYielded(messageId: string, consumedAt: number): void {
 		const { session, db, daemonHub, messageHub } = this.ctx;
 
-		// Find the enqueued message in DB by UUID
-		const enqueuedMessage = db
-			.getMessagesByStatus(session.id, 'enqueued')
-			.find((enqueued) => enqueued.uuid === messageId);
+		// Find the persisted message in DB by UUID without scanning every queued row.
+		const enqueuedMessage = db.getMessageByStatusAndUuid(session.id, 'enqueued', messageId);
 		if (!enqueuedMessage) {
 			// Could be a 'deferred' message being replayed
-			const deferredMessage = db
-				.getMessagesByStatus(session.id, 'deferred')
-				.find((deferred) => deferred.uuid === messageId);
+			const deferredMessage = db.getMessageByStatusAndUuid(session.id, 'deferred', messageId);
 			if (!deferredMessage) {
 				return; // Not a persisted user message (e.g., already consumed)
 			}
 			// Handle deferred message the same way
-			db.updateMessageStatus([deferredMessage.dbId], 'consumed');
-			db.updateMessageTimestamp(deferredMessage.dbId, consumedAt);
+			this.withDbChangeBatch(() => {
+				db.updateMessageStatus([deferredMessage.dbId], 'consumed');
+				db.updateMessageTimestamp(deferredMessage.dbId, consumedAt);
+			});
 			daemonHub
 				.emit('messages.statusChanged', {
 					sessionId: session.id,
@@ -396,8 +402,10 @@ export class SDKMessageHandler {
 		}
 
 		// Update status and timestamp in DB
-		db.updateMessageStatus([enqueuedMessage.dbId], 'consumed');
-		db.updateMessageTimestamp(enqueuedMessage.dbId, consumedAt);
+		this.withDbChangeBatch(() => {
+			db.updateMessageStatus([enqueuedMessage.dbId], 'consumed');
+			db.updateMessageTimestamp(enqueuedMessage.dbId, consumedAt);
+		});
 
 		// Emit status change event (for queue overlay polling)
 		daemonHub
@@ -509,7 +517,9 @@ export class SDKMessageHandler {
 
 		// Save to DB FIRST before broadcasting to clients
 		// This ensures we only broadcast messages that are successfully persisted
-		const deferredSuccessfully = db.saveSDKMessage(session.id, message);
+		const deferredSuccessfully = this.withDbChangeBatch(() =>
+			db.saveSDKMessage(session.id, message)
+		);
 
 		if (!deferredSuccessfully) {
 			// Log warning but continue - message is already in SDK's memory

--- a/packages/daemon/src/lib/agent/sdk-message-handler.ts
+++ b/packages/daemon/src/lib/agent/sdk-message-handler.ts
@@ -314,16 +314,8 @@ export class SDKMessageHandler {
 			.getMessagesByStatus(session.id, 'enqueued')
 			.filter((enqueued) => isSDKUserMessage(enqueued));
 
-		if (enqueuedUsers.length > 0) {
-			this.withDbChangeBatch(() => {
-				db.updateMessageStatus(
-					enqueuedUsers.map((enqueuedUser) => enqueuedUser.dbId),
-					'consumed'
-				);
-			});
-		}
-
 		for (const enqueuedUser of enqueuedUsers) {
+			db.updateMessageStatus([enqueuedUser.dbId], 'consumed');
 			// Don't update timestamp here — keep the original T1 timestamp
 			// since we don't know the exact T_consumed for these edge cases.
 			// The original timestamp (when user consumed it) is a better approximation

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -1582,7 +1582,11 @@ subagent AS (
     sm.origin AS origin
   FROM sdk_messages sm
   WHERE sm.session_id = ?1
-    AND json_extract(sm.sdk_message, '$.parent_tool_use_id') IN (SELECT id FROM tool_use_ids)
+    AND EXISTS (
+      SELECT 1
+      FROM tool_use_ids tui
+      WHERE tui.id = json_extract(sm.sdk_message, '$.parent_tool_use_id')
+    )
     AND (sm.message_type != 'user' OR COALESCE(sm.send_status, 'consumed') IN ('consumed', 'failed'))
 )
 SELECT

--- a/packages/daemon/src/storage/index.ts
+++ b/packages/daemon/src/storage/index.ts
@@ -209,6 +209,14 @@ export class Database {
 		return this.sdkMessageRepo.getMessagesByStatus(sessionId, status);
 	}
 
+	getMessageByStatusAndUuid(
+		sessionId: string,
+		status: SendStatus,
+		uuid: string
+	): (SDKMessage & { dbId: string; timestamp: number }) | null {
+		return this.sdkMessageRepo.getMessageByStatusAndUuid(sessionId, status, uuid);
+	}
+
 	updateMessageStatus(messageIds: string[], newStatus: SendStatus): void {
 		this.sdkMessageRepo.updateMessageStatus(messageIds, newStatus);
 	}
@@ -216,6 +224,10 @@ export class Database {
 	updateMessageTimestamp(messageId: string, timestampMs?: number): void {
 		this.sdkMessageRepo.updateMessageTimestamp(messageId, timestampMs);
 	}
+
+	beginTransaction?(): void;
+	commitTransaction?(): void;
+	abortTransaction?(): void;
 
 	getMessageCountByStatus(sessionId: string, status: SendStatus): number {
 		return this.sdkMessageRepo.getMessageCountByStatus(sessionId, status);

--- a/packages/daemon/src/storage/reactive-database.ts
+++ b/packages/daemon/src/storage/reactive-database.ts
@@ -122,6 +122,10 @@ export function createReactiveDatabase(db: Database): ReactiveDatabase {
 
 	const proxied = new Proxy(db, {
 		get(target, prop, receiver) {
+			if (prop === 'beginTransaction') return reactiveDb.beginTransaction;
+			if (prop === 'commitTransaction') return reactiveDb.commitTransaction;
+			if (prop === 'abortTransaction') return reactiveDb.abortTransaction;
+
 			const value = Reflect.get(target, prop, receiver);
 
 			if (typeof prop !== 'string' || typeof value !== 'function') {

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -327,12 +327,47 @@ export class SDKMessageRepository {
 			timestamp: string;
 		}>;
 
-		return rows.map((row) => ({
+		return rows.map((row) => this.inflatePersistedMessage(row));
+	}
+
+	/**
+	 * Look up a single persisted user message by UUID and status.
+	 *
+	 * This avoids repeatedly loading and parsing every queued/deferred/consumed
+	 * message during SDK replay acknowledgment, which is on the hot streaming path.
+	 */
+	getMessageByStatusAndUuid(
+		sessionId: string,
+		status: SendStatus,
+		uuid: string
+	): (SDKMessage & { dbId: string; timestamp: number }) | null {
+		const stmt = this.db.prepare(
+			`SELECT id, sdk_message, timestamp FROM sdk_messages
+	       WHERE session_id = ?
+	         AND send_status = ?
+	         AND json_extract(sdk_message, '$.uuid') = ?
+	       ORDER BY timestamp ASC
+	       LIMIT 1`
+		);
+		const row = stmt.get(sessionId, status, uuid) as {
+			id: string;
+			sdk_message: string;
+			timestamp: string;
+		} | null;
+		return row ? this.inflatePersistedMessage(row) : null;
+	}
+
+	private inflatePersistedMessage(row: {
+		id: string;
+		sdk_message: string;
+		timestamp: string;
+	}): SDKMessage & { dbId: string; timestamp: number } {
+		return {
 			...(JSON.parse(row.sdk_message) as SDKMessage),
 			dbId: row.id,
 			// DB timestamp (epoch ms) overrides the SDK's ISO string timestamp for persisted messages
 			timestamp: new Date(row.timestamp).getTime(),
-		})) as Array<SDKMessage & { dbId: string; timestamp: number }>;
+		} as SDKMessage & { dbId: string; timestamp: number };
 	}
 
 	/**

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -609,6 +609,10 @@ function createIndexes(db: BunDatabase): void {
       ON sdk_messages(session_id, timestamp)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_session_timestamp_id
       ON sdk_messages(session_id, timestamp DESC, id DESC)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_parent_tool
+      ON sdk_messages(session_id, json_extract(sdk_message, '$.parent_tool_use_id'))`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_uuid_status
+      ON sdk_messages(session_id, send_status, json_extract(sdk_message, '$.uuid'))`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_type
       ON sdk_messages(message_type, message_subtype)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_send_status

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -607,6 +607,8 @@ export function createTables(db: BunDatabase): void {
 function createIndexes(db: BunDatabase): void {
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_session
       ON sdk_messages(session_id, timestamp)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_session_timestamp_id
+      ON sdk_messages(session_id, timestamp DESC, id DESC)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_type
       ON sdk_messages(message_type, message_subtype)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_send_status

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -539,7 +539,7 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// Migration 112: Normalize Space GitHub dedupe keys after canonical repo casing change.
 	runMigration112(db);
 
-	// Migration 113: Add descending timestamp/id index for large SDK message windows.
+	// Migration 113: Add SDK message indexes for large thread windows and replay lookups.
 	runMigration113(db);
 }
 
@@ -7834,4 +7834,8 @@ export function runMigration113(db: BunDatabase): void {
 	if (!tableExists(db, 'sdk_messages')) return;
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_session_timestamp_id
 		ON sdk_messages(session_id, timestamp DESC, id DESC)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_parent_tool
+		ON sdk_messages(session_id, json_extract(sdk_message, '$.parent_tool_use_id'))`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_uuid_status
+		ON sdk_messages(session_id, send_status, json_extract(sdk_message, '$.uuid'))`);
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -538,6 +538,9 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 112: Normalize Space GitHub dedupe keys after canonical repo casing change.
 	runMigration112(db);
+
+	// Migration 113: Add descending timestamp/id index for large SDK message windows.
+	runMigration113(db);
 }
 
 /**
@@ -7810,4 +7813,10 @@ export function runMigration112(db: BunDatabase): void {
 		)
 	`);
 	db.exec(`UPDATE space_github_events SET dedupe_key = lower(dedupe_key)`);
+}
+
+export function runMigration113(db: BunDatabase): void {
+	if (!tableExists(db, 'sdk_messages')) return;
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_session_timestamp_id
+		ON sdk_messages(session_id, timestamp DESC, id DESC)`);
 }

--- a/packages/daemon/tests/unit/1-core/agent/sdk-message-handler.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/sdk-message-handler.test.ts
@@ -36,6 +36,7 @@ describe('SDKMessageHandler', () => {
 	let saveSDKMessageSpy: ReturnType<typeof mock>;
 	let updateSessionSpy: ReturnType<typeof mock>;
 	let getMessagesByStatusSpy: ReturnType<typeof mock>;
+	let getMessageByStatusAndUuidSpy: ReturnType<typeof mock>;
 	let updateMessageStatusSpy: ReturnType<typeof mock>;
 	let publishSpy: ReturnType<typeof mock>;
 	let emitSpy: ReturnType<typeof mock>;
@@ -77,13 +78,18 @@ describe('SDKMessageHandler', () => {
 		saveSDKMessageSpy = mock(() => true);
 		updateSessionSpy = mock(() => {});
 		getMessagesByStatusSpy = mock(() => []);
+		getMessageByStatusAndUuidSpy = mock(() => null);
 		updateMessageStatusSpy = mock(() => {});
 		mockDb = {
 			saveSDKMessage: saveSDKMessageSpy,
 			updateSession: updateSessionSpy,
 			getMessagesByStatus: getMessagesByStatusSpy,
+			getMessageByStatusAndUuid: getMessageByStatusAndUuidSpy,
 			updateMessageStatus: updateMessageStatusSpy,
 			updateMessageTimestamp: mock(() => {}),
+			beginTransaction: mock(() => {}),
+			commitTransaction: mock(() => {}),
+			abortTransaction: mock(() => {}),
 		} as unknown as Database;
 
 		// MessageHub spies
@@ -314,8 +320,14 @@ describe('SDKMessageHandler', () => {
 		});
 
 		it('should acknowledge persisted enqueued user messages without duplicate save', async () => {
-			getMessagesByStatusSpy.mockImplementation((_sessionId: string, status: string) =>
-				status === 'enqueued' ? [{ dbId: 'db-msg-1', uuid: 'test-uuid' }] : []
+			getMessagesByStatusSpy.mockImplementation(() => {
+				throw new Error('bulk status scan should not be used for direct SDK replay ack');
+			});
+			getMessageByStatusAndUuidSpy.mockImplementation(
+				(_sessionId: string, status: string, uuid: string) =>
+					status === 'enqueued' && uuid === 'test-uuid'
+						? { dbId: 'db-msg-1', uuid: 'test-uuid' }
+						: null
 			);
 
 			const message: SDKMessage = {
@@ -349,8 +361,11 @@ describe('SDKMessageHandler', () => {
 		});
 
 		it('should acknowledge persisted deferred user messages and update timestamp', async () => {
-			getMessagesByStatusSpy.mockImplementation((_sessionId: string, status: string) =>
-				status === 'deferred' ? [{ dbId: 'db-deferred-1', uuid: 'deferred-uuid' }] : []
+			getMessageByStatusAndUuidSpy.mockImplementation(
+				(_sessionId: string, status: string, uuid: string) =>
+					status === 'deferred' && uuid === 'deferred-uuid'
+						? { dbId: 'db-deferred-1', uuid: 'deferred-uuid' }
+						: null
 			);
 
 			const message: SDKMessage = {
@@ -381,8 +396,11 @@ describe('SDKMessageHandler', () => {
 		});
 
 		it('should suppress duplicate SDK replay for already-consumed persisted user message', async () => {
-			getMessagesByStatusSpy.mockImplementation((_sessionId: string, status: string) =>
-				status === 'consumed' ? [{ dbId: 'db-msg-1', uuid: 'consumed-user-uuid' }] : []
+			getMessageByStatusAndUuidSpy.mockImplementation(
+				(_sessionId: string, status: string, uuid: string) =>
+					status === 'consumed' && uuid === 'consumed-user-uuid'
+						? { dbId: 'db-msg-1', uuid: 'consumed-user-uuid' }
+						: null
 			);
 			const message: SDKMessage = {
 				type: 'user',

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-messages.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-messages.test.ts
@@ -234,6 +234,11 @@ describe('messages.bySession — SQL behavior', () => {
 		expect(plan).not.toContain('SCAN sdk_messages USING');
 	});
 
+	test('uses the parent tool expression index for subagent lookups', () => {
+		const plan = queryPlan(db, 's1', 200);
+		expect(plan).toContain('idx_sdk_messages_parent_tool');
+	});
+
 	test('includes subagent messages whose parent_tool_use_id matches a top-level tool_use', () => {
 		// Top-level assistant row with a tool_use in its content.
 		insertSdkMessage(db, {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-messages.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-messages.test.ts
@@ -71,6 +71,14 @@ function query(db: BunDatabase, sessionId: string, limit: number): Record<string
 	return entry.mapRow ? rows.map(entry.mapRow) : rows;
 }
 
+function queryPlan(db: BunDatabase, sessionId: string, limit: number): string {
+	const entry = NAMED_QUERY_REGISTRY.get('messages.bySession')!;
+	const planRows = db.prepare(`EXPLAIN QUERY PLAN ${entry.sql}`).all(sessionId, limit) as Array<{
+		detail: string;
+	}>;
+	return planRows.map((row) => row.detail).join('\n');
+}
+
 // ---------------------------------------------------------------------------
 // Registry metadata
 // ---------------------------------------------------------------------------
@@ -218,6 +226,12 @@ describe('messages.bySession — SQL behavior', () => {
 		// With LIMIT=3, only the 3 most recent top-level rows should be included,
 		// and returned in ascending order (t3, t4, t5).
 		expect(ids).toEqual(['t3', 't4', 't5']);
+	});
+
+	test('uses the session timestamp index for the top-level window', () => {
+		const plan = queryPlan(db, 's1', 200);
+		expect(plan).toContain('idx_sdk_messages_session_timestamp_id');
+		expect(plan).not.toContain('SCAN sdk_messages USING');
 	});
 
 	test('includes subagent messages whose parent_tool_use_id matches a top-level tool_use', () => {

--- a/packages/daemon/tests/unit/4-space-storage/storage/reactive-database.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/reactive-database.test.ts
@@ -367,6 +367,19 @@ describe('ReactiveDatabase', () => {
 			reactiveDb.commitTransaction(); // depth=0 — flush
 			expect(events.length).toBe(1);
 		});
+
+		test('transaction methods are available on the proxied db facade', () => {
+			const events: unknown[] = [];
+			reactiveDb.on('change', () => events.push(1));
+
+			reactiveDb.db.beginTransaction?.();
+			reactiveDb.db.createSession(makeSession('proxied-tx1'));
+			reactiveDb.db.createSession(makeSession('proxied-tx2'));
+			expect(events.length).toBe(0);
+
+			reactiveDb.db.commitTransaction?.();
+			expect(events.length).toBe(1);
+		});
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/web/src/components/sdk/SDKAssistantMessage.tsx
+++ b/packages/web/src/components/sdk/SDKAssistantMessage.tsx
@@ -8,12 +8,7 @@
  * - AskUserQuestion tool blocks with inline QuestionPrompt
  */
 
-import type {
-	PendingUserQuestion,
-	QuestionDraftResponse,
-	ResolvedQuestion,
-	ChatMessage,
-} from '@neokai/shared';
+import type { PendingUserQuestion, QuestionDraftResponse, ResolvedQuestion } from '@neokai/shared';
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
 import type { AgentInput } from '@neokai/shared/sdk/sdk-tools.d.ts';
 import {
@@ -54,7 +49,6 @@ interface Props {
 	rewindMode?: boolean;
 	selectedMessages?: Set<string>;
 	onMessageCheckboxChange?: (messageId: string, checked: boolean) => void;
-	allMessages?: ChatMessage[];
 	/**
 	 * When true, child tool / thinking / subagent blocks in this message are
 	 * each wrapped in <RunningBorder> so the animated arc traces their border.
@@ -79,7 +73,6 @@ export function SDKAssistantMessage({
 	rewindMode,
 	selectedMessages,
 	onMessageCheckboxChange,
-	allMessages: _allMessages,
 	isRunning,
 	flattenSubagentTools = false,
 }: Props) {
@@ -242,13 +235,11 @@ export function SDKAssistantMessage({
 			</div>
 		) : null;
 
-	// Check if this assistant message has sub-agent children
-	// If so, we should not show a checkbox for this message (the sub-agent messages will have their own)
-	const hasSubagentChild =
-		_allMessages?.some((msg) => {
-			const msgWithParent = msg as SDKMessage & { parent_tool_use_id?: string | null };
-			return msgWithParent.parent_tool_use_id === message.uuid;
-		}) || false;
+	// Check if this assistant message has sub-agent children.
+	// If so, we should not show a checkbox for this message (the sub-agent messages will have their own).
+	// Use the memoized parent_tool_use_id map instead of scanning the whole message array so
+	// streaming appends do not invalidate every memoized SDKMessageRenderer row.
+	const hasSubagentChild = message.uuid ? subagentMessagesMap?.has(message.uuid) || false : false;
 
 	// Checkbox rendering for rewind mode (using shared function)
 	const renderCheckbox = () =>

--- a/packages/web/src/components/sdk/SDKMessageRenderer.tsx
+++ b/packages/web/src/components/sdk/SDKMessageRenderer.tsx
@@ -3,6 +3,7 @@
  */
 
 import type { JSX } from 'preact';
+import { memo } from 'preact/compat';
 import { useState } from 'preact/hooks';
 import type {
 	SDKAuthStatusMessage,
@@ -181,7 +182,7 @@ function SystemInitPill({ message }: { message: SystemInitMessage }) {
 /**
  * Main SDK message renderer - routes to appropriate sub-renderer
  */
-export function SDKMessageRenderer({
+function SDKMessageRendererImpl({
 	message,
 	toolResultsMap,
 	toolInputsMap,
@@ -324,3 +325,35 @@ export function SDKMessageRenderer({
 	// Checkbox rendering is now handled by individual message components
 	return renderedMessage;
 }
+
+function areMessageRendererPropsEqual(prev: Props, next: Props): boolean {
+	return (
+		prev.message === next.message &&
+		prev.toolResultsMap === next.toolResultsMap &&
+		prev.toolInputsMap === next.toolInputsMap &&
+		prev.subagentMessagesMap === next.subagentMessagesMap &&
+		prev.sessionInfo === next.sessionInfo &&
+		prev.sessionId === next.sessionId &&
+		prev.resolvedQuestions === next.resolvedQuestions &&
+		prev.pendingQuestion === next.pendingQuestion &&
+		prev.onQuestionResolved === next.onQuestionResolved &&
+		prev.onRewind === next.onRewind &&
+		prev.rewindingMessageUuid === next.rewindingMessageUuid &&
+		prev.rewindMode === next.rewindMode &&
+		prev.selectedMessages === next.selectedMessages &&
+		prev.onMessageCheckboxChange === next.onMessageCheckboxChange &&
+		prev.allMessages === next.allMessages &&
+		prev.taskContext === next.taskContext &&
+		prev.showSubagentMessages === next.showSubagentMessages &&
+		prev.flattenSubagentTools === next.flattenSubagentTools &&
+		prev.showToolResultUserMessages === next.showToolResultUserMessages &&
+		prev.isRunning === next.isRunning
+	);
+}
+
+/**
+ * Memoized to keep large SDK threads responsive: streaming appends often update
+ * only one or two message objects, so unchanged rows can skip re-running the
+ * tool/result routing and markdown/tool block rendering work.
+ */
+export const SDKMessageRenderer = memo(SDKMessageRendererImpl, areMessageRendererPropsEqual);

--- a/packages/web/src/components/sdk/SDKMessageRenderer.tsx
+++ b/packages/web/src/components/sdk/SDKMessageRenderer.tsx
@@ -64,7 +64,6 @@ interface Props {
 	rewindMode?: boolean;
 	selectedMessages?: Set<string>;
 	onMessageCheckboxChange?: (messageId: string, checked: boolean) => void;
-	allMessages?: ChatMessage[];
 	/** When true, renders all message types without skipping (for task conversation timelines) */
 	taskContext?: boolean;
 	/**
@@ -197,7 +196,6 @@ function SDKMessageRendererImpl({
 	rewindMode,
 	selectedMessages,
 	onMessageCheckboxChange,
-	allMessages: _allMessages,
 	taskContext,
 	showSubagentMessages = false,
 	flattenSubagentTools = false,
@@ -265,7 +263,6 @@ function SDKMessageRendererImpl({
 				rewindMode={rewindMode}
 				selectedMessages={selectedMessages}
 				onMessageCheckboxChange={onMessageCheckboxChange}
-				allMessages={_allMessages}
 				showToolResultMessages={showToolResultUserMessages}
 			/>
 		);
@@ -282,7 +279,6 @@ function SDKMessageRendererImpl({
 				rewindMode={rewindMode}
 				selectedMessages={selectedMessages}
 				onMessageCheckboxChange={onMessageCheckboxChange}
-				allMessages={_allMessages}
 				flattenSubagentTools={flattenSubagentTools}
 				isRunning={isRunning}
 			/>
@@ -342,7 +338,6 @@ function areMessageRendererPropsEqual(prev: Props, next: Props): boolean {
 		prev.rewindMode === next.rewindMode &&
 		prev.selectedMessages === next.selectedMessages &&
 		prev.onMessageCheckboxChange === next.onMessageCheckboxChange &&
-		prev.allMessages === next.allMessages &&
 		prev.taskContext === next.taskContext &&
 		prev.showSubagentMessages === next.showSubagentMessages &&
 		prev.flattenSubagentTools === next.flattenSubagentTools &&

--- a/packages/web/src/components/sdk/SDKUserMessage.tsx
+++ b/packages/web/src/components/sdk/SDKUserMessage.tsx
@@ -5,7 +5,6 @@
  */
 
 import type { SDKMessage } from '@neokai/shared/sdk/sdk.d.ts';
-import type { ChatMessage } from '@neokai/shared';
 import { useEffect, useState } from 'preact/hooks';
 import { toast } from '../../lib/toast.ts';
 import { borderRadius, messageColors, messageSpacing } from '../../lib/design-tokens.ts';
@@ -89,7 +88,6 @@ interface Props {
 	rewindMode?: boolean;
 	selectedMessages?: Set<string>;
 	onMessageCheckboxChange?: (messageId: string, checked: boolean) => void;
-	allMessages?: ChatMessage[];
 	/** Render user rows whose content is tool_result blocks. */
 	showToolResultMessages?: boolean;
 }
@@ -106,7 +104,6 @@ export function SDKUserMessage({
 	rewindMode,
 	selectedMessages,
 	onMessageCheckboxChange,
-	allMessages: _allMessages,
 	showToolResultMessages = false,
 }: Props) {
 	const { message: apiMessage } = message;

--- a/packages/web/src/components/sdk/__tests__/SDKAssistantMessage.test.tsx
+++ b/packages/web/src/components/sdk/__tests__/SDKAssistantMessage.test.tsx
@@ -1262,8 +1262,7 @@ describe('SDKAssistantMessage', () => {
 		it('should not render checkbox when message has sub-agent children', () => {
 			const message = createTextOnlyMessage('Parent message');
 			const childMessage = createTextOnlyMessage('Child message');
-			(childMessage as unknown as Record<string, unknown>).parent_tool_use_id = message.uuid;
-			const allMessages = [message, childMessage] as SDKMessage[];
+			const subagentMessagesMap = new Map([[message.uuid!, [childMessage as SDKMessage]]]);
 			const selectedMessages = new Set<string>();
 
 			const { container } = render(
@@ -1272,7 +1271,7 @@ describe('SDKAssistantMessage', () => {
 					rewindMode={true}
 					selectedMessages={selectedMessages}
 					onMessageCheckboxChange={onMessageCheckboxChange}
-					allMessages={allMessages}
+					subagentMessagesMap={subagentMessagesMap}
 				/>
 			);
 

--- a/packages/web/src/hooks/__tests__/useMessageMaps.test.ts
+++ b/packages/web/src/hooks/__tests__/useMessageMaps.test.ts
@@ -699,4 +699,50 @@ describe('useMessageMaps', () => {
 			expect(agent2Messages?.[0].uuid).toBe(uuid2);
 		});
 	});
+
+	describe('performance characteristics', () => {
+		it('keeps session init mapping linear for large tool-heavy threads', () => {
+			const messages: SDKMessage[] = [];
+			for (let i = 0; i < 250; i++) {
+				messages.push({
+					type: 'user',
+					uuid: `user-${i}`,
+					session_id: 'session-1',
+					message: { role: 'user', content: `prompt ${i}` },
+				} as unknown as SDKMessage);
+				messages.push({
+					type: 'system',
+					subtype: 'init',
+					uuid: `init-${i}`,
+					session_id: 'session-1',
+					tools: ['Read', 'Bash'],
+				} as unknown as SDKMessage);
+				messages.push({
+					type: 'assistant',
+					uuid: `assistant-${i}`,
+					session_id: 'session-1',
+					message: {
+						role: 'assistant',
+						content: [{ type: 'tool_use', id: `tool-${i}`, name: 'Read', input: {} }],
+					},
+				} as unknown as SDKMessage);
+				messages.push({
+					type: 'user',
+					uuid: `result-${i}`,
+					session_id: 'session-1',
+					message: {
+						role: 'user',
+						content: [{ type: 'tool_result', tool_use_id: `tool-${i}`, content: 'ok' }],
+					},
+				} as unknown as SDKMessage);
+			}
+
+			const { result } = renderHook(() => useMessageMaps(messages, 'session-1'));
+
+			expect(result.current.sessionInfoMap.size).toBe(250);
+			expect(result.current.toolInputsMap.size).toBe(250);
+			expect(result.current.toolResultsMap.size).toBe(250);
+			expect(result.current.sessionInfoMap.get('user-249')?.uuid).toBe('init-249');
+		});
+	});
 });

--- a/packages/web/src/hooks/useMessageMaps.ts
+++ b/packages/web/src/hooks/useMessageMaps.ts
@@ -95,25 +95,29 @@ export function useMessageMaps(
 	// Map of user message UUIDs to their attached session init info
 	const sessionInfoMap = useMemo(() => {
 		const map = new Map<string, SDKSystemMessage>();
-		for (let i = 0; i < sdkMessages.length; i++) {
-			const msg = sdkMessages[i];
-			if (msg.type === 'system' && msg.subtype === 'init') {
-				// Find the most recent user message before this session init
-				for (let j = i - 1; j >= 0; j--) {
-					if (sdkMessages[j].type === 'user' && sdkMessages[j].uuid) {
-						map.set(sdkMessages[j].uuid!, msg as SDKSystemMessage);
-						break;
-					}
+		let lastUserUuid: string | undefined;
+		const pendingLeadingInits: SDKSystemMessage[] = [];
+
+		for (const msg of sdkMessages) {
+			if (msg.type === 'user' && msg.uuid) {
+				lastUserUuid = msg.uuid;
+				// Preserve the previous fallback semantics for init rows that appear
+				// before the first user message, but do it once when that first user
+				// appears instead of scanning forward from each init row. This keeps
+				// large SDK conversations O(n) instead of O(n²) on every message batch.
+				for (const init of pendingLeadingInits) {
+					map.set(msg.uuid, init);
 				}
-				// If no preceding user message, attach to the first user message after
-				if (msg.uuid && !map.has(msg.uuid)) {
-					for (let j = i + 1; j < sdkMessages.length; j++) {
-						if (sdkMessages[j].type === 'user' && sdkMessages[j].uuid) {
-							map.set(sdkMessages[j].uuid!, msg as SDKSystemMessage);
-							break;
-						}
-					}
-				}
+				pendingLeadingInits.length = 0;
+				continue;
+			}
+
+			if (msg.type !== 'system' || msg.subtype !== 'init') continue;
+			const init = msg as SDKSystemMessage;
+			if (lastUserUuid) {
+				map.set(lastUserUuid, init);
+			} else {
+				pendingLeadingInits.push(init);
 			}
 		}
 		return map;

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -20,6 +20,7 @@ import type {
 	ChatMessage,
 	MessageDeliveryMode,
 	MessageImage,
+	QuestionDraftResponse,
 	ResolvedQuestion,
 	SessionFeatures,
 } from '@neokai/shared';
@@ -741,6 +742,30 @@ export default function ChatContainer({
 	const removedOutputs = session?.metadata?.removedOutputs || [];
 	const maps = useMessageMaps(messages, sessionId, removedOutputs);
 
+	const handleQuestionResolved = useCallback(
+		(state: 'submitted' | 'cancelled', responses: QuestionDraftResponse[]) => {
+			// Move question to resolved state locally for immediate UI feedback
+			// (Server also persists this via question.respond/cancel RPC)
+			if (pendingQuestion) {
+				const resolved = {
+					question: pendingQuestion,
+					state,
+					responses,
+					resolvedAt: Date.now(),
+				};
+				// Update ref immediately (synchronous)
+				resolvingQuestionsRef.current.set(pendingQuestion.toolUseId, resolved);
+				// Also schedule update to resolvedQuestions (will be merged with server data)
+				setResolvedQuestions((prev) => {
+					const next = new Map(prev);
+					next.set(pendingQuestion.toolUseId, resolved);
+					return next;
+				});
+			}
+		},
+		[pendingQuestion]
+	);
+
 	// Combined resolved questions map (state + ref)
 	// Includes questions synced from server (state) and questions being resolved (ref)
 	const allResolvedQuestions = useMemo(() => {
@@ -1260,26 +1285,7 @@ export default function ChatContainer({
 										selectedMessages={selectedMessages}
 										onMessageCheckboxChange={handleMessageCheckboxChange}
 										allMessages={messages}
-										onQuestionResolved={(state, responses) => {
-											// Move question to resolved state locally for immediate UI feedback
-											// (Server also persists this via question.respond/cancel RPC)
-											if (pendingQuestion) {
-												const resolved = {
-													question: pendingQuestion,
-													state,
-													responses,
-													resolvedAt: Date.now(),
-												};
-												// Update ref immediately (synchronous)
-												resolvingQuestionsRef.current.set(pendingQuestion.toolUseId, resolved);
-												// Also schedule update to resolvedQuestions (will be merged with server data)
-												setResolvedQuestions((prev) => {
-													const next = new Map(prev);
-													next.set(pendingQuestion.toolUseId, resolved);
-													return next;
-												});
-											}
-										}}
+										onQuestionResolved={handleQuestionResolved}
 									/>
 								</div>
 							))}

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -1284,7 +1284,6 @@ export default function ChatContainer({
 										rewindMode={rewindMode}
 										selectedMessages={selectedMessages}
 										onMessageCheckboxChange={handleMessageCheckboxChange}
-										allMessages={messages}
 										onQuestionResolved={handleQuestionResolved}
 									/>
 								</div>

--- a/packages/web/src/lib/session-store.ts
+++ b/packages/web/src/lib/session-store.ts
@@ -474,15 +474,18 @@ class SessionStore {
 	 */
 	private _applyMessagesDelta(event: LiveQueryDeltaEvent): void {
 		let next = this.sdkMessages.value.slice();
+		let changed = false;
 
 		if (event.removed?.length) {
 			const removedIds = new Set(
 				(event.removed as Array<{ id?: unknown }>).map((r) => r.id).filter((id) => id != null)
 			);
+			const beforeLength = next.length;
 			next = next.filter((m) => {
 				const id = (m as ChatMessage & { id?: unknown }).id;
 				return !(id != null && removedIds.has(id));
 			});
+			changed ||= next.length !== beforeLength;
 		}
 
 		if (event.updated?.length) {
@@ -493,7 +496,11 @@ class SessionStore {
 			}
 			next = next.map((m) => {
 				const id = (m as ChatMessage & { id?: unknown }).id;
-				if (id != null && updatedById.has(id)) return updatedById.get(id)!;
+				if (id != null && updatedById.has(id)) {
+					const updated = updatedById.get(id)!;
+					if (updated !== m) changed = true;
+					return updated;
+				}
 				return m;
 			});
 		}
@@ -509,6 +516,7 @@ class SessionStore {
 				trulyNew.push(row);
 			}
 			if (trulyNew.length) {
+				changed = true;
 				next = [...next, ...trulyNew].sort(
 					(a, b) =>
 						((a as ChatMessage & { timestamp?: number }).timestamp || 0) -
@@ -518,7 +526,9 @@ class SessionStore {
 			this._syncCommandsFromSDKMessages(trulyNew);
 		}
 
-		this.sdkMessages.value = next;
+		if (changed) {
+			this.sdkMessages.value = next;
+		}
 	}
 
 	/**
@@ -693,7 +703,17 @@ class SessionStore {
 	 */
 	prependMessages(messages: ChatMessage[]): void {
 		if (messages.length === 0) return;
-		this.sdkMessages.value = [...messages, ...this.sdkMessages.value];
+		const seenIds = new Set(
+			this.sdkMessages.value
+				.map((message) => (message as ChatMessage & { id?: unknown }).id)
+				.filter((id) => id != null)
+		);
+		const uniqueMessages = messages.filter((message) => {
+			const id = (message as ChatMessage & { id?: unknown }).id;
+			return id == null || !seenIds.has(id);
+		});
+		if (uniqueMessages.length === 0) return;
+		this.sdkMessages.value = [...uniqueMessages, ...this.sdkMessages.value];
 	}
 
 	/**


### PR DESCRIPTION
Reduces large SDK thread CPU/UI churn by fixing both client render invalidation and daemon LiveQuery amplification.

Adds memoized message rendering, linear message-map construction, no-op delta suppression, SDK message window/expression indexes, batched hot-path sdk_messages writes, and direct UUID/status replay lookups to avoid repeated queued-message scans.

Tests: bun test packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-messages.test.ts packages/daemon/tests/unit/1-core/agent/sdk-message-handler.test.ts packages/daemon/tests/unit/4-space-storage/storage/reactive-database.test.ts; bun run check