### PR TITLE
Graceful socket disconnection handling in UI

### DIFF
--- a/packages/shared/src/message-hub/websocket-client-transport.ts
+++ b/packages/shared/src/message-hub/websocket-client-transport.ts
@@ -272,6 +272,13 @@ export class WebSocketClientTransport implements IMessageTransport {
 	}
 
 	/**
+	 * Get current reconnect attempt count (for UI status progression)
+	 */
+	getReconnectAttempts(): number {
+		return this.reconnectAttempts;
+	}
+
+	/**
 	 * Reset reconnection state to allow fresh reconnection attempts
 	 * Used when user manually triggers reconnect or returns from background
 	 */

--- a/packages/shared/src/message-hub/websocket-client-transport.ts
+++ b/packages/shared/src/message-hub/websocket-client-transport.ts
@@ -308,8 +308,14 @@ export class WebSocketClientTransport implements IMessageTransport {
 		}
 
 		// Trigger handleDisconnect which will start reconnection
-		this.setState('reconnecting');
+		// IMPORTANT: handleDisconnect increments reconnectAttempts before
+		// we emit 'reconnecting' so listeners read the correct count.
 		this.handleDisconnect();
+		// Only set reconnecting if handleDisconnect didn't set 'failed'
+		// (won't happen after resetReconnectState since attempts=0)
+		if (this.state !== 'failed') {
+			this.setState('reconnecting');
+		}
 	}
 
 	/**

--- a/packages/shared/tests/websocket-client-transport.test.ts
+++ b/packages/shared/tests/websocket-client-transport.test.ts
@@ -277,6 +277,16 @@ describe('WebSocketClientTransport - Basic Interface', () => {
 		});
 	});
 
+	describe('getReconnectAttempts', () => {
+		it('should return 0 initially', () => {
+			const transport = new WebSocketClientTransport({
+				url: 'ws://localhost:8080',
+			});
+
+			expect(transport.getReconnectAttempts()).toBe(0);
+		});
+	});
+
 	describe('options validation', () => {
 		it('should work with minimal options', () => {
 			const transport = new WebSocketClientTransport({

--- a/packages/web/src/components/ConnectionOverlay.tsx
+++ b/packages/web/src/components/ConnectionOverlay.tsx
@@ -19,11 +19,11 @@ import { useState, useCallback } from 'preact/hooks';
 import { connectionState, reconnectAttemptCount } from '../lib/state.ts';
 import { connectionManager } from '../lib/connection-manager.ts';
 
-type BannerLevel = 'hidden' | 'reconnecting' | 'lost' | 'failed';
+export type BannerLevel = 'hidden' | 'reconnecting' | 'lost' | 'failed';
 
-function getBannerLevel(state: typeof connectionState.value): BannerLevel {
+export function getBannerLevel(state: typeof connectionState.value, attempts: number): BannerLevel {
 	if (state === 'connected' || state === 'connecting') return 'hidden';
-	if (state === 'reconnecting') return 'reconnecting';
+	if (state === 'reconnecting') return attempts <= 2 ? 'reconnecting' : 'lost';
 	if (state === 'disconnected' || state === 'error') return 'lost';
 	if (state === 'failed') return 'failed';
 	return 'hidden';
@@ -34,7 +34,7 @@ export function ConnectionOverlay() {
 	const attempts = reconnectAttemptCount.value;
 	const [retrying, setRetrying] = useState(false);
 
-	const level = getBannerLevel(state);
+	const level = getBannerLevel(state, attempts);
 
 	const handleReconnect = useCallback(async () => {
 		setRetrying(true);
@@ -49,8 +49,8 @@ export function ConnectionOverlay() {
 
 	if (level === 'hidden') return null;
 
-	// --- Reconnecting (first attempt, amber) ---
-	if (level === 'reconnecting' && attempts <= 2) {
+	// --- Reconnecting (first attempts, amber) ---
+	if (level === 'reconnecting') {
 		return (
 			<div class="fixed top-0 left-0 right-0 z-[9999] flex justify-center pointer-events-none">
 				<div class="mt-2 px-4 py-2 rounded-lg bg-amber-500/90 text-black text-sm font-medium flex items-center gap-2 shadow-lg">
@@ -76,7 +76,7 @@ export function ConnectionOverlay() {
 	}
 
 	// --- Connection lost (repeated failures, amber) ---
-	if (level === 'lost' || (level === 'reconnecting' && attempts > 2)) {
+	if (level === 'lost') {
 		return (
 			<div class="fixed top-0 left-0 right-0 z-[9999] flex justify-center pointer-events-none">
 				<div class="mt-2 px-4 py-2 rounded-lg bg-amber-600/90 text-black text-sm font-medium flex items-center gap-2 shadow-lg">

--- a/packages/web/src/components/ConnectionOverlay.tsx
+++ b/packages/web/src/components/ConnectionOverlay.tsx
@@ -1,94 +1,118 @@
 /**
  * ConnectionOverlay Component
  *
- * Displays a blocking overlay when WebSocket connection is lost or failed.
- * Provides clear messaging and reconnection options to the user.
+ * Non-blocking inline banner that communicates connection state to the user.
  *
- * FIX: Only show overlay for 'failed' state (all auto-reconnect attempts exhausted).
- * Previously showed for 'disconnected' and 'error' too, which caused flashing
- * during auto-reconnect cycles when Safari resumes from background.
+ * State progression:
+ * - 'connected'   → hidden
+ * - 'connecting'  → hidden (initial load)
+ * - 'reconnecting' → amber banner: "Reconnecting…"
+ * - 'disconnected' / 'error' → amber banner: "Connection lost. Retrying…"
+ * - 'failed' → red banner: "Unable to reconnect." + Retry button
  *
- * Auto-reconnect state flow:
- * - 'connected' → 'disconnected' → 'reconnecting' → 'connecting' → (success/fail)
- * - On failure: cycles back through 'disconnected' → 'reconnecting' up to 10 times
- * - After 10 attempts: 'failed' state is set permanently until manual reconnect
- *
- * The overlay should only appear when auto-reconnect has given up ('failed'),
- * not during the transient states while auto-reconnect is still trying.
+ * The banner is positioned at the top of the viewport but does NOT block
+ * interaction with the rest of the UI. Conversation content stays visible
+ * and readable at all times.
  */
 
-import { connectionState } from '../lib/state.ts';
+import { useState, useCallback } from 'preact/hooks';
+import { connectionState, reconnectAttemptCount } from '../lib/state.ts';
 import { connectionManager } from '../lib/connection-manager.ts';
-import { Button } from './ui/Button.tsx';
-import { useState } from 'preact/hooks';
 
-/**
- * Helper to check if connection state requires overlay
- * FIX: Only 'failed' shows overlay - all auto-reconnect attempts exhausted
- */
-function shouldShowOverlay(state: typeof connectionState.value): state is 'failed' {
-	// Only show overlay when all auto-reconnect attempts have failed
-	// 'disconnected', 'error', 'reconnecting', 'connecting' are transient states
-	// during auto-reconnect and should NOT show the blocking overlay
-	return state === 'failed';
+type BannerLevel = 'hidden' | 'reconnecting' | 'lost' | 'failed';
+
+function getBannerLevel(state: typeof connectionState.value): BannerLevel {
+	if (state === 'connected' || state === 'connecting') return 'hidden';
+	if (state === 'reconnecting') return 'reconnecting';
+	if (state === 'disconnected' || state === 'error') return 'lost';
+	if (state === 'failed') return 'failed';
+	return 'hidden';
 }
 
 export function ConnectionOverlay() {
 	const state = connectionState.value;
-	const [reconnecting, setReconnecting] = useState(false);
+	const attempts = reconnectAttemptCount.value;
+	const [retrying, setRetrying] = useState(false);
 
-	// FIX: Only show overlay for 'failed' state
-	// This prevents flashing during auto-reconnect cycles when Safari resumes
-	if (!shouldShowOverlay(state)) {
-		return null;
-	}
+	const level = getBannerLevel(state);
 
-	const handleReconnect = async () => {
-		setReconnecting(true);
+	const handleReconnect = useCallback(async () => {
+		setRetrying(true);
 		try {
 			await connectionManager.reconnect();
 		} catch {
-			// Reconnect failed - user can try again
+			// Reconnect failed — banner will remain visible
 		} finally {
-			setReconnecting(false);
+			setRetrying(false);
 		}
-	};
+	}, []);
 
-	const handleRefresh = () => {
-		window.location.reload();
-	};
+	if (level === 'hidden') return null;
 
-	// FIX: Simplified since we only show for 'failed' state now
-	const getMessage = () => {
-		return {
-			title: 'Connection Failed',
-			description: 'Unable to establish connection after multiple attempts.',
-			icon: '🔌',
-		};
-	};
-
-	const { title, description, icon } = getMessage();
-
-	return (
-		<div class="fixed inset-0 z-[10000] bg-black/80 backdrop-blur-sm flex items-center justify-center p-4">
-			<div class="bg-dark-800 border border-dark-600 p-6 rounded-xl text-center max-w-md w-full shadow-2xl animate-slideIn">
-				<div class="text-5xl mb-4">{icon}</div>
-				<h2 class="text-xl font-bold text-white mb-2">{title}</h2>
-				<p class="text-gray-400 mb-6">{description}</p>
-
-				<div class="flex gap-3 justify-center">
-					<Button onClick={handleReconnect} loading={reconnecting} disabled={reconnecting}>
-						{reconnecting ? 'Reconnecting...' : 'Reconnect'}
-					</Button>
-					<Button variant="secondary" onClick={handleRefresh} disabled={reconnecting}>
-						Refresh Page
-					</Button>
+	// --- Reconnecting (first attempt, amber) ---
+	if (level === 'reconnecting' && attempts <= 2) {
+		return (
+			<div class="fixed top-0 left-0 right-0 z-[9999] flex justify-center pointer-events-none">
+				<div class="mt-2 px-4 py-2 rounded-lg bg-amber-500/90 text-black text-sm font-medium flex items-center gap-2 shadow-lg">
+					<svg class="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none">
+						<circle
+							class="opacity-25"
+							cx="12"
+							cy="12"
+							r="10"
+							stroke="currentColor"
+							stroke-width="4"
+						/>
+						<path
+							class="opacity-75"
+							fill="currentColor"
+							d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+						/>
+					</svg>
+					Reconnecting…
 				</div>
+			</div>
+		);
+	}
 
-				{/* FIX: Always show hint since we only display for 'failed' state now */}
-				<p class="text-xs text-gray-500 mt-4">
-					If the problem persists, check your network connection or try restarting the server.
-				</p>
+	// --- Connection lost (repeated failures, amber) ---
+	if (level === 'lost' || (level === 'reconnecting' && attempts > 2)) {
+		return (
+			<div class="fixed top-0 left-0 right-0 z-[9999] flex justify-center pointer-events-none">
+				<div class="mt-2 px-4 py-2 rounded-lg bg-amber-600/90 text-black text-sm font-medium flex items-center gap-2 shadow-lg">
+					<svg class="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none">
+						<circle
+							class="opacity-25"
+							cx="12"
+							cy="12"
+							r="10"
+							stroke="currentColor"
+							stroke-width="4"
+						/>
+						<path
+							class="opacity-75"
+							fill="currentColor"
+							d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+						/>
+					</svg>
+					Connection lost. Retrying…
+				</div>
+			</div>
+		);
+	}
+
+	// --- Failed (all retries exhausted, red + retry button) ---
+	return (
+		<div class="fixed top-0 left-0 right-0 z-[9999] flex justify-center pointer-events-auto">
+			<div class="mt-2 px-4 py-2 rounded-lg bg-red-600/90 text-white text-sm font-medium flex items-center gap-3 shadow-lg">
+				<span>Unable to reconnect.</span>
+				<button
+					onClick={handleReconnect}
+					disabled={retrying}
+					class="px-3 py-1 rounded bg-white/20 hover:bg-white/30 text-white text-xs font-semibold transition-colors disabled:opacity-50"
+				>
+					{retrying ? 'Retrying…' : 'Retry'}
+				</button>
 			</div>
 		</div>
 	);

--- a/packages/web/src/components/ConnectionOverlay.tsx
+++ b/packages/web/src/components/ConnectionOverlay.tsx
@@ -15,15 +15,20 @@
  * and readable at all times.
  */
 
-import { useState, useCallback } from 'preact/hooks';
-import { connectionState, reconnectAttemptCount } from '../lib/state.ts';
+import { useCallback, useState } from 'preact/hooks';
 import { connectionManager } from '../lib/connection-manager.ts';
+import { connectionState, reconnectAttemptCount } from '../lib/state.ts';
 
 export type BannerLevel = 'hidden' | 'reconnecting' | 'lost' | 'failed';
 
 export function getBannerLevel(state: typeof connectionState.value, attempts: number): BannerLevel {
-	if (state === 'connected' || state === 'connecting') return 'hidden';
-	if (state === 'reconnecting') return attempts <= 2 ? 'reconnecting' : 'lost';
+	if (state === 'connected') return 'hidden';
+	// Only hide 'connecting' on initial load (attempts === 0).
+	// During reconnect cycles the transport transitions through 'connecting' with
+	// non-zero attempt counts — the banner should stay visible to avoid flicker.
+	if (state === 'connecting' && attempts === 0) return 'hidden';
+	if (state === 'reconnecting' || state === 'connecting')
+		return attempts <= 2 ? 'reconnecting' : 'lost';
 	if (state === 'disconnected' || state === 'error') return 'lost';
 	if (state === 'failed') return 'failed';
 	return 'hidden';

--- a/packages/web/src/components/__tests__/ConnectionOverlay.test.ts
+++ b/packages/web/src/components/__tests__/ConnectionOverlay.test.ts
@@ -2,110 +2,123 @@
 /**
  * Tests for ConnectionOverlay component
  *
- * Verifies that the overlay:
- * - Only shows for 'failed' state (not 'disconnected', 'error', 'connecting', 'reconnecting')
- * - Prevents flashing during auto-reconnect cycles (Safari background tab resume)
+ * Tests the banner visibility logic (getBannerLevel) directly.
+ * The component renders a non-blocking inline banner, not a full-page modal.
+ *
+ * Progression:
+ * - connected/connecting → hidden
+ * - reconnecting (attempts ≤ 2) → "Reconnecting…"
+ * - disconnected/error / reconnecting (attempts > 2) → "Connection lost. Retrying…"
+ * - failed → "Unable to reconnect." + Retry button
  */
 
-import { connectionState } from '../../lib/state';
 import type { ConnectionState } from '@neokai/shared';
 
 /**
- * Helper function that mirrors the ConnectionOverlay logic
- * Tests the shouldShowOverlay condition directly
+ * Mirrors the getBannerLevel logic from ConnectionOverlay.tsx
  */
-function shouldShowOverlay(state: ConnectionState): boolean {
-	return state === 'failed';
+type BannerLevel = 'hidden' | 'reconnecting' | 'lost' | 'failed';
+
+function getBannerLevel(state: ConnectionState, attempts: number): BannerLevel {
+	if (state === 'connected' || state === 'connecting') return 'hidden';
+	if (state === 'reconnecting') return attempts <= 2 ? 'reconnecting' : 'lost';
+	if (state === 'disconnected' || state === 'error') return 'lost';
+	if (state === 'failed') return 'failed';
+	return 'hidden';
 }
 
-describe('ConnectionOverlay - shouldShowOverlay logic', () => {
-	// Store original state value
-	let originalState: ConnectionState;
-
-	beforeEach(() => {
-		originalState = connectionState.value;
-	});
-
-	afterEach(() => {
-		connectionState.value = originalState;
-	});
-
-	describe('States that should NOT show overlay (transient during auto-reconnect)', () => {
-		it('should NOT show overlay for "disconnected" state', () => {
-			// 'disconnected' is a transient state during auto-reconnect
-			expect(shouldShowOverlay('disconnected')).toBe(false);
+describe('ConnectionOverlay - getBannerLevel logic', () => {
+	describe('States that should be hidden', () => {
+		it('should be hidden when connected', () => {
+			expect(getBannerLevel('connected', 0)).toBe('hidden');
 		});
 
-		it('should NOT show overlay for "error" state', () => {
-			// 'error' is a transient state during auto-reconnect
-			expect(shouldShowOverlay('error')).toBe(false);
-		});
-
-		it('should NOT show overlay for "connecting" state', () => {
-			expect(shouldShowOverlay('connecting')).toBe(false);
-		});
-
-		it('should NOT show overlay for "reconnecting" state', () => {
-			expect(shouldShowOverlay('reconnecting')).toBe(false);
-		});
-
-		it('should NOT show overlay for "connected" state', () => {
-			expect(shouldShowOverlay('connected')).toBe(false);
+		it('should be hidden when connecting (initial load)', () => {
+			expect(getBannerLevel('connecting', 0)).toBe('hidden');
 		});
 	});
 
-	describe('States that SHOULD show overlay (permanent failure)', () => {
-		it('should show overlay for "failed" state', () => {
-			// 'failed' means all auto-reconnect attempts exhausted
-			expect(shouldShowOverlay('failed')).toBe(true);
+	describe('Reconnecting progression', () => {
+		it('should show reconnecting level on first attempt', () => {
+			expect(getBannerLevel('reconnecting', 1)).toBe('reconnecting');
+		});
+
+		it('should show reconnecting level on second attempt', () => {
+			expect(getBannerLevel('reconnecting', 2)).toBe('reconnecting');
+		});
+
+		it('should escalate to lost level on third attempt', () => {
+			expect(getBannerLevel('reconnecting', 3)).toBe('lost');
+		});
+
+		it('should escalate to lost level on higher attempts', () => {
+			expect(getBannerLevel('reconnecting', 5)).toBe('lost');
+			expect(getBannerLevel('reconnecting', 10)).toBe('lost');
 		});
 	});
 
-	describe('Safari background tab scenario', () => {
-		it('should not flash overlay during auto-reconnect cycle', () => {
-			// This test simulates the Safari background tab resume scenario
-			// where connection state rapidly cycles through states
+	describe('Connection lost states', () => {
+		it('should show lost level for disconnected', () => {
+			expect(getBannerLevel('disconnected', 0)).toBe('lost');
+		});
 
-			const states: ConnectionState[] = [
-				'disconnected', // Initial disconnect
-				'reconnecting', // Auto-reconnect starts
-				'connecting', // Attempting connection
-				'error', // First attempt fails
-				'reconnecting', // Retry
-				'connecting', // Second attempt
-				'connected', // Success!
+		it('should show lost level for error', () => {
+			expect(getBannerLevel('error', 0)).toBe('lost');
+		});
+	});
+
+	describe('Failed state', () => {
+		it('should show failed level', () => {
+			expect(getBannerLevel('failed', 10)).toBe('failed');
+		});
+	});
+
+	describe('Full state progression', () => {
+		it('should follow: hidden → reconnecting → lost → failed', () => {
+			// 1. Connected
+			expect(getBannerLevel('connected', 0)).toBe('hidden');
+
+			// 2. First reconnect attempt
+			expect(getBannerLevel('reconnecting', 1)).toBe('reconnecting');
+
+			// 3. Multiple failures
+			expect(getBannerLevel('reconnecting', 4)).toBe('lost');
+
+			// 4. Connection temporarily drops to disconnected
+			expect(getBannerLevel('disconnected', 5)).toBe('lost');
+
+			// 5. All retries exhausted
+			expect(getBannerLevel('failed', 10)).toBe('failed');
+
+			// 6. Reconnected!
+			expect(getBannerLevel('connected', 0)).toBe('hidden');
+		});
+	});
+
+	describe('Non-blocking behavior verification', () => {
+		it('should never show "hidden" for non-connected states', () => {
+			const nonConnectedStates: ConnectionState[] = [
+				'disconnected',
+				'error',
+				'reconnecting',
+				'failed',
 			];
 
-			// None of these transient states should show the overlay
-			for (const state of states) {
-				expect(shouldShowOverlay(state)).toBe(false);
+			for (const state of nonConnectedStates) {
+				expect(getBannerLevel(state, 1)).not.toBe('hidden');
 			}
 		});
 
-		it('should show overlay only after all auto-reconnect attempts fail', () => {
-			// Simulate all 10 reconnect attempts failing
-			const states: ConnectionState[] = [
-				'disconnected',
-				'reconnecting',
-				'connecting',
-				'error', // Attempt 1 fails
-				'reconnecting',
-				'connecting',
-				'error', // Attempt 2 fails
-				// ... (attempts 3-9)
-				'reconnecting',
-				'connecting',
-				'error', // Attempt 10 fails
-				'failed', // All attempts exhausted - NOW show overlay
+		it('should never show "failed" for transient states', () => {
+			const transientStates: Array<{ state: ConnectionState; attempts: number }> = [
+				{ state: 'reconnecting', attempts: 1 },
+				{ state: 'reconnecting', attempts: 5 },
+				{ state: 'disconnected', attempts: 0 },
+				{ state: 'error', attempts: 0 },
 			];
 
-			// All states except 'failed' should NOT show overlay
-			for (const state of states) {
-				if (state === 'failed') {
-					expect(shouldShowOverlay(state)).toBe(true);
-				} else {
-					expect(shouldShowOverlay(state)).toBe(false);
-				}
+			for (const { state, attempts } of transientStates) {
+				expect(getBannerLevel(state, attempts)).not.toBe('failed');
 			}
 		});
 	});

--- a/packages/web/src/components/__tests__/ConnectionOverlay.test.ts
+++ b/packages/web/src/components/__tests__/ConnectionOverlay.test.ts
@@ -6,14 +6,15 @@
  * The component renders a non-blocking inline banner, not a full-page modal.
  *
  * Progression:
- * - connected/connecting → hidden
+ * - connected / connecting (initial load, attempts=0) → hidden
+ * - connecting (reconnect, attempts>0) → shows banner (prevents flicker)
  * - reconnecting (attempts ≤ 2) → "Reconnecting…"
  * - disconnected/error / reconnecting (attempts > 2) → "Connection lost. Retrying…"
  * - failed → "Unable to reconnect." + Retry button
  */
 
-import { getBannerLevel } from '../ConnectionOverlay';
 import type { ConnectionState } from '@neokai/shared';
+import { getBannerLevel } from '../ConnectionOverlay';
 
 describe('ConnectionOverlay - getBannerLevel logic', () => {
 	describe('States that should be hidden', () => {
@@ -23,6 +24,18 @@ describe('ConnectionOverlay - getBannerLevel logic', () => {
 
 		it('should be hidden when connecting (initial load)', () => {
 			expect(getBannerLevel('connecting', 0)).toBe('hidden');
+		});
+	});
+
+	describe('Connecting during reconnect cycle', () => {
+		it('should show reconnecting banner when connecting with attempts > 0', () => {
+			expect(getBannerLevel('connecting', 1)).toBe('reconnecting');
+			expect(getBannerLevel('connecting', 2)).toBe('reconnecting');
+		});
+
+		it('should show lost banner when connecting with high attempt count', () => {
+			expect(getBannerLevel('connecting', 3)).toBe('lost');
+			expect(getBannerLevel('connecting', 5)).toBe('lost');
 		});
 	});
 

--- a/packages/web/src/components/__tests__/ConnectionOverlay.test.ts
+++ b/packages/web/src/components/__tests__/ConnectionOverlay.test.ts
@@ -2,7 +2,7 @@
 /**
  * Tests for ConnectionOverlay component
  *
- * Tests the banner visibility logic (getBannerLevel) directly.
+ * Tests the exported getBannerLevel logic directly from the component.
  * The component renders a non-blocking inline banner, not a full-page modal.
  *
  * Progression:
@@ -12,20 +12,8 @@
  * - failed → "Unable to reconnect." + Retry button
  */
 
+import { getBannerLevel } from '../ConnectionOverlay';
 import type { ConnectionState } from '@neokai/shared';
-
-/**
- * Mirrors the getBannerLevel logic from ConnectionOverlay.tsx
- */
-type BannerLevel = 'hidden' | 'reconnecting' | 'lost' | 'failed';
-
-function getBannerLevel(state: ConnectionState, attempts: number): BannerLevel {
-	if (state === 'connected' || state === 'connecting') return 'hidden';
-	if (state === 'reconnecting') return attempts <= 2 ? 'reconnecting' : 'lost';
-	if (state === 'disconnected' || state === 'error') return 'lost';
-	if (state === 'failed') return 'failed';
-	return 'hidden';
-}
 
 describe('ConnectionOverlay - getBannerLevel logic', () => {
 	describe('States that should be hidden', () => {

--- a/packages/web/src/hooks/__tests__/useSendMessage.test.ts
+++ b/packages/web/src/hooks/__tests__/useSendMessage.test.ts
@@ -412,7 +412,7 @@ describe('useSendMessage', () => {
 
 			expect(onSendStart).toHaveBeenCalled();
 			// Hub disappeared mid-send - message is queued for retry
-			expect(mockToastInfo).toHaveBeenCalledWith('Message queued - will send when reconnected.');
+			expect(mockToastInfo).toHaveBeenCalledWith('Message queued — will send when reconnected.');
 			expect(onSendComplete).toHaveBeenCalled();
 		});
 	});

--- a/packages/web/src/hooks/__tests__/useSendMessage.test.ts
+++ b/packages/web/src/hooks/__tests__/useSendMessage.test.ts
@@ -35,11 +35,25 @@ vi.mock('../../lib/connection-manager', () => ({
 // Mock toast
 const mockToastSuccess = vi.fn();
 const mockToastError = vi.fn();
+const mockToastInfo = vi.fn();
 
 vi.mock('../../lib/toast', () => ({
 	toast: {
 		success: (msg: string) => mockToastSuccess(msg),
 		error: (msg: string) => mockToastError(msg),
+		info: (msg: string) => mockToastInfo(msg),
+	},
+}));
+
+vi.mock('../../lib/outbound-queue', () => ({
+	enqueueAction: vi.fn(() => Promise.resolve({ id: 'queue-1', label: 'Test', status: 'pending' })),
+}));
+
+vi.mock('../../lib/user-error', () => ({
+	sanitizeUserError: (err: unknown) => {
+		if (err instanceof Error) return err.message;
+		if (typeof err === 'string') return err;
+		return 'Something went wrong.';
 	},
 }));
 
@@ -243,7 +257,7 @@ describe('useSendMessage', () => {
 			});
 
 			expect(onSendStart).not.toHaveBeenCalled();
-			expect(mockToastError).toHaveBeenCalledWith('Connection lost. Please refresh the page.');
+			expect(mockToastInfo).toHaveBeenCalledWith('Message queued — will send when reconnected.');
 		});
 
 		it('should not send when connecting', async () => {
@@ -267,7 +281,7 @@ describe('useSendMessage', () => {
 			});
 
 			expect(onSendStart).not.toHaveBeenCalled();
-			expect(mockToastError).toHaveBeenCalledWith('Connection lost. Please refresh the page.');
+			expect(mockToastInfo).toHaveBeenCalledWith('Message queued — will send when reconnected.');
 		});
 	});
 
@@ -397,7 +411,9 @@ describe('useSendMessage', () => {
 			});
 
 			expect(onSendStart).toHaveBeenCalled();
-			expect(mockToastError).toHaveBeenCalledWith('Connection lost.');
+			expect(mockToastError).toHaveBeenCalledWith(
+				'Connection lost. Your message will be sent when reconnected.'
+			);
 			expect(onSendComplete).toHaveBeenCalled();
 		});
 	});
@@ -449,7 +465,7 @@ describe('useSendMessage', () => {
 				await result.current.sendMessage('Hello');
 			});
 
-			expect(onError).toHaveBeenCalledWith('Failed to send message');
+			expect(onError).toHaveBeenCalledWith('Unknown error');
 		});
 	});
 

--- a/packages/web/src/hooks/__tests__/useSendMessage.test.ts
+++ b/packages/web/src/hooks/__tests__/useSendMessage.test.ts
@@ -389,7 +389,7 @@ describe('useSendMessage', () => {
 	});
 
 	describe('hub connection handling', () => {
-		it('should handle no hub connection', async () => {
+		it('should queue message when hub disappears during send', async () => {
 			mockGetHubIfConnected.mockReturnValue(null);
 
 			const onSendStart = vi.fn();
@@ -411,9 +411,8 @@ describe('useSendMessage', () => {
 			});
 
 			expect(onSendStart).toHaveBeenCalled();
-			expect(mockToastError).toHaveBeenCalledWith(
-				'Connection lost. Your message will be sent when reconnected.'
-			);
+			// Hub disappeared mid-send - message is queued for retry
+			expect(mockToastInfo).toHaveBeenCalledWith('Message queued - will send when reconnected.');
 			expect(onSendComplete).toHaveBeenCalled();
 		});
 	});

--- a/packages/web/src/hooks/useSendMessage.ts
+++ b/packages/web/src/hooks/useSendMessage.ts
@@ -78,11 +78,16 @@ export function useSendMessage({
 				enqueueAction(label, async () => {
 					const hub = connectionManager.getHubIfConnected();
 					if (!hub) throw new Error('Not connected');
-					await hub.request<{ messageId?: string }>('message.send', {
-						sessionId,
-						content,
-						images,
-					});
+					const payload: {
+						sessionId: string;
+						content: string;
+						images?: MessageImage[];
+						deliveryMode?: MessageDeliveryMode;
+					} = { sessionId, content, images };
+					if (deliveryMode !== 'immediate') {
+						payload.deliveryMode = deliveryMode;
+					}
+					await hub.request<{ messageId?: string }>('message.send', payload);
 				});
 				toast.info('Message queued — will send when reconnected.');
 				return true;

--- a/packages/web/src/hooks/useSendMessage.ts
+++ b/packages/web/src/hooks/useSendMessage.ts
@@ -123,7 +123,7 @@ export function useSendMessage({
 						const res = await h.request<{ messageId?: string }>('message.send', qPayload);
 						if (res?.messageId) onMessageAccepted?.(res.messageId);
 					});
-					toast.info('Message queued - will send when reconnected.');
+					toast.info('Message queued — will send when reconnected.');
 					onSendComplete();
 					clearSendTimeout();
 					return true;

--- a/packages/web/src/hooks/useSendMessage.ts
+++ b/packages/web/src/hooks/useSendMessage.ts
@@ -5,12 +5,12 @@
  * Extracted from ChatContainer.tsx for better separation of concerns.
  */
 
-import { useRef, useCallback } from 'preact/hooks';
-import type { Session, MessageDeliveryMode, MessageImage } from '@neokai/shared';
+import type { MessageDeliveryMode, MessageImage, Session } from '@neokai/shared';
+import { useCallback, useRef } from 'preact/hooks';
 import { connectionManager } from '../lib/connection-manager';
+import { enqueueAction } from '../lib/outbound-queue';
 import { connectionState } from '../lib/state';
 import { toast } from '../lib/toast';
-import { enqueueAction } from '../lib/outbound-queue';
 import { sanitizeUserError } from '../lib/user-error';
 
 export interface UseSendMessageOptions {
@@ -87,7 +87,8 @@ export function useSendMessage({
 					if (deliveryMode !== 'immediate') {
 						payload.deliveryMode = deliveryMode;
 					}
-					await hub.request<{ messageId?: string }>('message.send', payload);
+					const result = await hub.request<{ messageId?: string }>('message.send', payload);
+					if (result?.messageId) onMessageAccepted?.(result.messageId);
 				});
 				toast.info('Message queued — will send when reconnected.');
 				return true;
@@ -104,10 +105,28 @@ export function useSendMessage({
 
 				const hub = connectionManager.getHubIfConnected();
 				if (!hub) {
-					toast.error('Connection lost. Your message will be sent when reconnected.');
+					// Hub disappeared during send (race during socket teardown) - queue for retry
+					const qLabel =
+						content.length > 40 ? `Message: ${content.slice(0, 40)}…` : `Message: ${content}`;
+					const qPayload: {
+						sessionId: string;
+						content: string;
+						images?: MessageImage[];
+						deliveryMode?: MessageDeliveryMode;
+					} = { sessionId, content, images };
+					if (deliveryMode !== 'immediate') {
+						qPayload.deliveryMode = deliveryMode;
+					}
+					enqueueAction(qLabel, async () => {
+						const h = connectionManager.getHubIfConnected();
+						if (!h) throw new Error('Not connected');
+						const res = await h.request<{ messageId?: string }>('message.send', qPayload);
+						if (res?.messageId) onMessageAccepted?.(res.messageId);
+					});
+					toast.info('Message queued - will send when reconnected.');
 					onSendComplete();
 					clearSendTimeout();
-					return false;
+					return true;
 				}
 
 				const requestPayload: {

--- a/packages/web/src/hooks/useSendMessage.ts
+++ b/packages/web/src/hooks/useSendMessage.ts
@@ -10,6 +10,8 @@ import type { Session, MessageDeliveryMode, MessageImage } from '@neokai/shared'
 import { connectionManager } from '../lib/connection-manager';
 import { connectionState } from '../lib/state';
 import { toast } from '../lib/toast';
+import { enqueueAction } from '../lib/outbound-queue';
+import { sanitizeUserError } from '../lib/user-error';
 
 export interface UseSendMessageOptions {
 	sessionId: string;
@@ -70,8 +72,20 @@ export function useSendMessage({
 
 			const isConnected = connectionState.value === 'connected';
 			if (!isConnected) {
-				toast.error('Connection lost. Please refresh the page.');
-				return false;
+				// Queue message for when connection is restored
+				const label =
+					content.length > 40 ? `Message: ${content.slice(0, 40)}…` : `Message: ${content}`;
+				enqueueAction(label, async () => {
+					const hub = connectionManager.getHubIfConnected();
+					if (!hub) throw new Error('Not connected');
+					await hub.request<{ messageId?: string }>('message.send', {
+						sessionId,
+						content,
+						images,
+					});
+				});
+				toast.info('Message queued — will send when reconnected.');
+				return true;
 			}
 
 			try {
@@ -85,7 +99,7 @@ export function useSendMessage({
 
 				const hub = connectionManager.getHubIfConnected();
 				if (!hub) {
-					toast.error('Connection lost.');
+					toast.error('Connection lost. Your message will be sent when reconnected.');
 					onSendComplete();
 					clearSendTimeout();
 					return false;
@@ -111,7 +125,7 @@ export function useSendMessage({
 				clearSendTimeout();
 				return true;
 			} catch (err) {
-				const message = err instanceof Error ? err.message : 'Failed to send message';
+				const message = sanitizeUserError(err);
 				onError(message);
 				toast.error(message);
 				onSendComplete();

--- a/packages/web/src/hooks/useSendMessage.ts
+++ b/packages/web/src/hooks/useSendMessage.ts
@@ -117,12 +117,17 @@ export function useSendMessage({
 					if (deliveryMode !== 'immediate') {
 						qPayload.deliveryMode = deliveryMode;
 					}
-					enqueueAction(qLabel, async () => {
-						const h = connectionManager.getHubIfConnected();
-						if (!h) throw new Error('Not connected');
-						const res = await h.request<{ messageId?: string }>('message.send', qPayload);
-						if (res?.messageId) onMessageAccepted?.(res.messageId);
-					});
+					// Force queue â hub is null so immediate execution would fail
+					enqueueAction(
+						qLabel,
+						async () => {
+							const h = connectionManager.getHubIfConnected();
+							if (!h) throw new Error('Not connected');
+							const res = await h.request<{ messageId?: string }>('message.send', qPayload);
+							if (res?.messageId) onMessageAccepted?.(res.messageId);
+						},
+						{ executeImmediately: false }
+					);
 					toast.info('Message queued — will send when reconnected.');
 					onSendComplete();
 					clearSendTimeout();

--- a/packages/web/src/lib/__tests__/connection-manager-comprehensive.test.ts
+++ b/packages/web/src/lib/__tests__/connection-manager-comprehensive.test.ts
@@ -89,6 +89,7 @@ vi.mock('@neokai/shared', () => ({
 vi.mock('../state', () => ({
 	appState: { value: {} },
 	connectionState: { value: 'disconnected' },
+	reconnectAttemptCount: { value: 0 },
 }));
 
 vi.mock('../global-store', () => ({

--- a/packages/web/src/lib/__tests__/outbound-queue.test.ts
+++ b/packages/web/src/lib/__tests__/outbound-queue.test.ts
@@ -127,6 +127,7 @@ describe('OutboundQueue', () => {
 
 	describe('flushQueue', () => {
 		it('should execute all pending actions', async () => {
+			mockConnectionState.value = 'connected';
 			const executed: string[] = [];
 
 			await enqueueAction('Action 1', async () => {
@@ -142,8 +143,10 @@ describe('OutboundQueue', () => {
 		});
 
 		it('should mark successful actions as sent', async () => {
+			// Queue while disconnected
 			await enqueueAction('Action', async () => {});
-
+			// Connect and flush
+			mockConnectionState.value = 'connected';
 			await flushQueue();
 
 			// Actions are cleaned up after 2s, but status is set immediately
@@ -152,10 +155,12 @@ describe('OutboundQueue', () => {
 		});
 
 		it('should mark failed actions with error', async () => {
+			// Queue while disconnected
 			await enqueueAction('Failing', async () => {
 				throw new Error('Network error');
 			});
-
+			// Connect and flush
+			mockConnectionState.value = 'connected';
 			await flushQueue();
 
 			const actions = getQueuedActions();
@@ -165,6 +170,7 @@ describe('OutboundQueue', () => {
 		});
 
 		it('should process actions sequentially', async () => {
+			mockConnectionState.value = 'connected';
 			const order: number[] = [];
 
 			await enqueueAction('First', async () => {
@@ -177,6 +183,43 @@ describe('OutboundQueue', () => {
 			await flushQueue();
 
 			expect(order).toEqual([1, 2]);
+		});
+
+		it('should not flush when disconnected', async () => {
+			mockConnectionState.value = 'disconnected';
+			const executed = vi.fn();
+
+			await enqueueAction('Action', executed);
+
+			await flushQueue();
+
+			expect(executed).not.toHaveBeenCalled();
+			// Action stays pending for next flush
+			expect(getQueuedActions()[0].status).toBe('pending');
+		});
+
+		it('should leave remaining actions pending if connection drops mid-flush', async () => {
+			let callCount = 0;
+			mockConnectionState.value = 'connected';
+
+			await enqueueAction('Action 1', async () => {
+				callCount++;
+			});
+			await enqueueAction('Action 2', async () => {
+				// Simulate connection dropping during this action
+				mockConnectionState.value = 'disconnected';
+				callCount++;
+			});
+			await enqueueAction('Action 3', async () => {
+				callCount++;
+			});
+
+			await flushQueue();
+
+			// First two actions attempted, third left pending
+			expect(callCount).toBe(2);
+			const actions = getQueuedActions();
+			expect(actions.find((a) => a.label === 'Action 3')?.status).toBe('pending');
 		});
 	});
 });

--- a/packages/web/src/lib/__tests__/outbound-queue.test.ts
+++ b/packages/web/src/lib/__tests__/outbound-queue.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for outbound action queue
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { signal } from '@preact/signals';
+
+// Mock connectionState before importing the module
+const mockConnectionState = signal<'connected' | 'disconnected' | 'reconnecting'>('disconnected');
+
+vi.mock('../state', () => ({
+	connectionState: {
+		get value() {
+			return mockConnectionState.value;
+		},
+	},
+	reconnectAttemptCount: { value: 0 },
+}));
+
+vi.mock('../connection-manager', () => ({
+	connectionManager: {
+		getHubIfConnected: vi.fn(() => ({ request: vi.fn() })),
+	},
+}));
+
+vi.mock('../toast', () => ({
+	toast: {
+		info: vi.fn(),
+		warning: vi.fn(),
+		error: vi.fn(),
+		success: vi.fn(),
+	},
+}));
+
+import {
+	enqueueAction,
+	getQueuedActions,
+	cancelAction,
+	clearQueue,
+	flushQueue,
+	resetQueue,
+} from '../outbound-queue';
+
+describe('OutboundQueue', () => {
+	beforeEach(() => {
+		resetQueue();
+		mockConnectionState.value = 'disconnected';
+		vi.clearAllMocks();
+	});
+
+	describe('enqueueAction', () => {
+		it('should queue action when disconnected', async () => {
+			mockConnectionState.value = 'disconnected';
+
+			const action = await enqueueAction('Test action', async () => {});
+
+			expect(action).toBeDefined();
+			expect(action?.label).toBe('Test action');
+			expect(action?.status).toBe('pending');
+		});
+
+		it('should execute immediately when connected', async () => {
+			mockConnectionState.value = 'connected';
+			const executed = vi.fn();
+
+			const action = await enqueueAction('Test action', executed);
+
+			expect(action).toBeUndefined();
+			expect(executed).toHaveBeenCalledOnce();
+		});
+
+		it('should queue if execution fails due to disconnect', async () => {
+			mockConnectionState.value = 'disconnected';
+			const execute = vi.fn().mockRejectedValue(new Error('Connection lost'));
+
+			const action = await enqueueAction('Test', execute);
+
+			expect(action).toBeDefined();
+			expect(action?.status).toBe('pending');
+		});
+	});
+
+	describe('getQueuedActions', () => {
+		it('should return all queued actions', async () => {
+			await enqueueAction('Action 1', async () => {});
+			await enqueueAction('Action 2', async () => {});
+
+			const actions = getQueuedActions();
+			expect(actions.length).toBe(2);
+			expect(actions[0].label).toBe('Action 1');
+			expect(actions[1].label).toBe('Action 2');
+		});
+
+		it('should return empty array when no actions queued', () => {
+			expect(getQueuedActions().length).toBe(0);
+		});
+	});
+
+	describe('cancelAction', () => {
+		it('should remove action from queue', async () => {
+			const action = await enqueueAction('Test', async () => {});
+			expect(getQueuedActions().length).toBe(1);
+
+			cancelAction(action!.id);
+			expect(getQueuedActions().length).toBe(0);
+		});
+
+		it('should not affect other actions', async () => {
+			const action1 = await enqueueAction('Action 1', async () => {});
+			await enqueueAction('Action 2', async () => {});
+
+			cancelAction(action1!.id);
+			expect(getQueuedActions().length).toBe(1);
+			expect(getQueuedActions()[0].label).toBe('Action 2');
+		});
+	});
+
+	describe('clearQueue', () => {
+		it('should remove all actions', async () => {
+			await enqueueAction('Action 1', async () => {});
+			await enqueueAction('Action 2', async () => {});
+
+			clearQueue();
+			expect(getQueuedActions().length).toBe(0);
+		});
+	});
+
+	describe('flushQueue', () => {
+		it('should execute all pending actions', async () => {
+			const executed: string[] = [];
+
+			await enqueueAction('Action 1', async () => {
+				executed.push('Action 1');
+			});
+			await enqueueAction('Action 2', async () => {
+				executed.push('Action 2');
+			});
+
+			await flushQueue();
+
+			expect(executed).toEqual(['Action 1', 'Action 2']);
+		});
+
+		it('should mark successful actions as sent', async () => {
+			await enqueueAction('Action', async () => {});
+
+			await flushQueue();
+
+			// Actions are cleaned up after 2s, but status is set immediately
+			const actions = getQueuedActions();
+			expect(actions[0].status).toBe('sent');
+		});
+
+		it('should mark failed actions with error', async () => {
+			await enqueueAction('Failing', async () => {
+				throw new Error('Network error');
+			});
+
+			await flushQueue();
+
+			const actions = getQueuedActions();
+			expect(actions[0].status).toBe('failed');
+			// sanitizeUserError passes through user-friendly messages
+			expect(actions[0].error).toBe('Network error');
+		});
+
+		it('should process actions sequentially', async () => {
+			const order: number[] = [];
+
+			await enqueueAction('First', async () => {
+				order.push(1);
+			});
+			await enqueueAction('Second', async () => {
+				order.push(2);
+			});
+
+			await flushQueue();
+
+			expect(order).toEqual([1, 2]);
+		});
+	});
+});

--- a/packages/web/src/lib/__tests__/user-error.test.ts
+++ b/packages/web/src/lib/__tests__/user-error.test.ts
@@ -101,6 +101,10 @@ describe('isAuthError', () => {
 		expect(isAuthError(new Error('ECONNREFUSED'))).toBe(false);
 	});
 
+	it('should NOT flag 403 as auth error (permission denied, not session expiry)', () => {
+		expect(isAuthError(new Error('HTTP 403 Forbidden'))).toBe(false);
+	});
+
 	it('should handle null/undefined', () => {
 		expect(isAuthError(null)).toBe(false);
 		expect(isAuthError(undefined)).toBe(false);

--- a/packages/web/src/lib/__tests__/user-error.test.ts
+++ b/packages/web/src/lib/__tests__/user-error.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for user-facing error sanitization
+ */
+
+import { describe, it, expect } from 'vitest';
+import { sanitizeUserError, isAuthError, isTransientError } from '../user-error';
+
+describe('sanitizeUserError', () => {
+	describe('user-friendly messages pass through', () => {
+		it('should pass through already-friendly messages', () => {
+			expect(sanitizeUserError('Please try again.')).toBe('Please try again.');
+			expect(sanitizeUserError('Cannot send messages to archived sessions')).toBe(
+				'Cannot send messages to archived sessions'
+			);
+		});
+	});
+
+	describe('internal error messages are sanitized', () => {
+		it('should sanitize "WebSocket not connected"', () => {
+			const result = sanitizeUserError(new Error('WebSocket not connected'));
+			expect(result).toBe('Connection lost. Your message will be sent when reconnected.');
+		});
+
+		it('should sanitize "Failed to send message: ..."', () => {
+			const result = sanitizeUserError(new Error('Failed to send message: socket hang up'));
+			expect(result).toBe('Could not send. Please try again.');
+		});
+
+		it('should sanitize fetch errors', () => {
+			const result = sanitizeUserError(new Error('fetch() failed with verbose: true'));
+			expect(result).toBe('Network error. Please check your connection.');
+		});
+
+		it('should sanitize ECONNREFUSED', () => {
+			const result = sanitizeUserError(new Error('connect ECONNREFUSED 127.0.0.1:9283'));
+			expect(result).toBe('Could not reach the server. Please check your connection.');
+		});
+
+		it('should sanitize timeout errors', () => {
+			const result = sanitizeUserError(new Error('Request timed out after 10000ms'));
+			expect(result).toBe('The request timed out. Please try again.');
+		});
+	});
+
+	describe('edge cases', () => {
+		it('should handle null', () => {
+			expect(sanitizeUserError(null)).toBe('Something went wrong.');
+		});
+
+		it('should handle undefined', () => {
+			expect(sanitizeUserError(undefined)).toBe('Something went wrong.');
+		});
+
+		it('should handle non-Error objects', () => {
+			expect(sanitizeUserError({ code: 'ERR_FAIL' })).toBe(
+				'Something went wrong. Please try again.'
+			);
+		});
+
+		it('should handle empty string', () => {
+			expect(sanitizeUserError('')).toBe('Something went wrong.');
+		});
+
+		it('should never surface "verbose: true" suggestion', () => {
+			const raw = new Error('fetch failed. Try setting verbose: true to get more information.');
+			const result = sanitizeUserError(raw);
+			expect(result).not.toContain('verbose');
+			expect(result).not.toContain('VERBOSE');
+		});
+
+		it('should never surface stack traces', () => {
+			const err = new Error('something');
+			err.stack = 'Error: something\n    at Object.<anonymous> (file.js:1:1)';
+			// The .message property is "something" which is fine,
+			// but if someone passes err.stack directly:
+			const result = sanitizeUserError(err.stack);
+			expect(result).not.toContain('at Object');
+		});
+	});
+});
+
+describe('isAuthError', () => {
+	it('should detect "unauthorized"', () => {
+		expect(isAuthError(new Error('Unauthorized access'))).toBe(true);
+	});
+
+	it('should detect "authentication failed"', () => {
+		expect(isAuthError(new Error('Authentication failed'))).toBe(true);
+	});
+
+	it('should detect "session expired"', () => {
+		expect(isAuthError(new Error('Session expired'))).toBe(true);
+	});
+
+	it('should detect "401"', () => {
+		expect(isAuthError(new Error('HTTP 401'))).toBe(true);
+	});
+
+	it('should NOT flag transient errors as auth errors', () => {
+		expect(isAuthError(new Error('Network timeout'))).toBe(false);
+		expect(isAuthError(new Error('ECONNREFUSED'))).toBe(false);
+	});
+
+	it('should handle null/undefined', () => {
+		expect(isAuthError(null)).toBe(false);
+		expect(isAuthError(undefined)).toBe(false);
+	});
+});
+
+describe('isTransientError', () => {
+	it('should detect timeout errors', () => {
+		expect(isTransientError(new Error('Request timeout'))).toBe(true);
+	});
+
+	it('should detect network errors', () => {
+		expect(isTransientError(new Error('Network error'))).toBe(true);
+	});
+
+	it('should detect ECONNRESET', () => {
+		expect(isTransientError(new Error('read ECONNRESET'))).toBe(true);
+	});
+
+	it('should NOT flag auth errors as transient', () => {
+		expect(isTransientError(new Error('Unauthorized'))).toBe(false);
+	});
+
+	it('should handle null as transient (safe default)', () => {
+		expect(isTransientError(null)).toBe(true);
+	});
+});

--- a/packages/web/src/lib/connection-manager.ts
+++ b/packages/web/src/lib/connection-manager.ts
@@ -317,7 +317,12 @@ export class ConnectionManager {
 			// Auth/session expiry detection — redirect to re-auth, don't loop retries
 			if (state === 'error' && error && isAuthError(error)) {
 				connectionState.value = 'error';
-				// Redirect to settings/auth for re-authentication
+				// Stop transport and outbound queue before redirect to prevent
+				// reconnect loop firing between href assignment and navigation
+				stopAutoFlush();
+				if (this.transport) {
+					this.transport.close();
+				}
 				if (typeof window !== 'undefined') {
 					window.location.href = '/settings?tab=providers&reason=session_expired';
 				}

--- a/packages/web/src/lib/connection-manager.ts
+++ b/packages/web/src/lib/connection-manager.ts
@@ -29,13 +29,15 @@
  */
 
 import { MessageHub, WebSocketClientTransport } from '@neokai/shared';
-import { appState, connectionState } from './state';
+import { appState, connectionState, reconnectAttemptCount } from './state';
 import { globalStore } from './global-store';
 import { sessionStore } from './session-store';
 import { spaceStore } from './space-store';
 import { ConnectionNotReadyError, ConnectionTimeoutError } from './errors';
 import { createDeferred } from './timeout';
 import { currentSessionIdSignal, slashCommandsSignal } from './signals';
+import { isAuthError } from './user-error';
+import { startAutoFlush, stopAutoFlush } from './outbound-queue';
 
 // Expose signals immediately when module loads (for E2E testing)
 if (typeof window !== 'undefined') {
@@ -301,7 +303,7 @@ export class ConnectionManager {
 		});
 
 		// Listen to connection state changes and update global state
-		this.messageHub.onConnection((state) => {
+		this.messageHub.onConnection((state, error) => {
 			// During resume validation, don't report 'connected' until validation completes.
 			// This prevents the UI from seeing a false-positive 'connected' state while
 			// the health check and channel rejoin are still in progress.
@@ -311,11 +313,30 @@ export class ConnectionManager {
 				this.notifyConnectionHandlers();
 				return;
 			}
+
+			// Auth/session expiry detection — redirect to re-auth, don't loop retries
+			if (state === 'error' && error && isAuthError(error)) {
+				connectionState.value = 'error';
+				// Redirect to settings/auth for re-authentication
+				if (typeof window !== 'undefined') {
+					window.location.href = '/settings?tab=providers&reason=session_expired';
+				}
+				return;
+			}
+
 			connectionState.value = state;
 
 			// Notify connection handlers when connected
 			if (state === 'connected') {
+				reconnectAttemptCount.value = 0;
 				this.notifyConnectionHandlers();
+			}
+
+			// Track reconnect attempts for UI progression
+			if (state === 'reconnecting' || state === 'connecting') {
+				if (this.transport) {
+					reconnectAttemptCount.value = this.transport.getReconnectAttempts();
+				}
 			}
 		});
 
@@ -356,6 +377,9 @@ export class ConnectionManager {
 
 		// FIX P5: Start periodic state validation
 		this.startPeriodicStateValidation();
+
+		// Start auto-flush for queued outbound actions
+		startAutoFlush();
 
 		// Mark ready for testing
 		if (typeof window !== 'undefined' && window.__messageHub) {
@@ -415,6 +439,9 @@ export class ConnectionManager {
 	async disconnect(): Promise<void> {
 		// FIX P5: Stop periodic state validation
 		this.stopPeriodicStateValidation();
+
+		// Stop outbound queue auto-flush
+		stopAutoFlush();
 
 		// Update connection state
 		connectionState.value = 'disconnected';

--- a/packages/web/src/lib/outbound-queue.ts
+++ b/packages/web/src/lib/outbound-queue.ts
@@ -60,8 +60,17 @@ export async function enqueueAction(
 		}
 	}
 
-	// Not connected — queue for later
-	return enqueueInternal(label, execute);
+	// Not connected (or forced queue) — queue for later
+	const action = enqueueInternal(label, execute);
+
+	// When connected but forced to queue (executeImmediately: false),
+	// the auto-flush effect won't fire since it only watches connectionState.
+	// Schedule a flush so the action isn't stuck pending indefinitely.
+	if (isConnected) {
+		setTimeout(() => flushQueue(), 500);
+	}
+
+	return action;
 }
 
 function enqueueInternal(label: string, execute: () => Promise<void>): QueuedAction {

--- a/packages/web/src/lib/outbound-queue.ts
+++ b/packages/web/src/lib/outbound-queue.ts
@@ -166,6 +166,17 @@ export function stopAutoFlush(): void {
 	}
 }
 
+// HMR cleanup: tear down the old effect subscription before module re-evaluation
+// prevents orphaned subscriptions that fire on every state change
+if (import.meta.hot) {
+	import.meta.hot.dispose(() => {
+		if (cleanupAutoFlush) {
+			cleanupAutoFlush();
+			cleanupAutoFlush = null;
+		}
+	});
+}
+
 // For testing: reset module state
 export function resetQueue(): void {
 	queue = [];

--- a/packages/web/src/lib/outbound-queue.ts
+++ b/packages/web/src/lib/outbound-queue.ts
@@ -1,0 +1,167 @@
+/**
+ * Outbound Action Queue
+ *
+ * Queues user actions (messages, RPC calls) when the WebSocket is disconnected.
+ * Automatically flushes the queue once reconnection succeeds.
+ *
+ * This ensures users don't lose typed messages or actions during transient
+ * network blips — a pattern familiar from chat apps like WhatsApp/Signal.
+ */
+
+import { connectionState } from './state';
+import { sanitizeUserError } from './user-error';
+import { toast } from './toast';
+import { effect } from '@preact/signals';
+
+export interface QueuedAction {
+	/** Unique ID for this queued action */
+	id: string;
+	/** Human-readable label shown in UI ("Message: Hello…") */
+	label: string;
+	/** The async operation to execute */
+	execute: () => Promise<void>;
+	/** Timestamp when queued */
+	queuedAt: number;
+	/** Status: pending, sent, failed */
+	status: 'pending' | 'sent' | 'failed';
+	/** Error message if failed */
+	error?: string;
+}
+
+let queue: QueuedAction[] = [];
+let idCounter = 0;
+let flushInProgress = false;
+
+/**
+ * Add an action to the outbound queue.
+ *
+ * If connected, executes immediately. Otherwise, queues for later.
+ * Returns the queued action (or undefined if executed immediately).
+ */
+export async function enqueueAction(
+	label: string,
+	execute: () => Promise<void>,
+	options?: { executeImmediately?: boolean }
+): Promise<QueuedAction | undefined> {
+	const isConnected = connectionState.value === 'connected';
+
+	// If connected and caller wants immediate execution, try it
+	if (isConnected && options?.executeImmediately !== false) {
+		try {
+			await execute();
+			return undefined;
+		} catch (err) {
+			// If the connection dropped during execution, queue it
+			if (connectionState.value !== 'connected') {
+				return enqueueInternal(label, execute);
+			}
+			// Otherwise, it's a real error — rethrow
+			throw err;
+		}
+	}
+
+	// Not connected — queue for later
+	return enqueueInternal(label, execute);
+}
+
+function enqueueInternal(label: string, execute: () => Promise<void>): QueuedAction {
+	const action: QueuedAction = {
+		id: `queue-${++idCounter}`,
+		label,
+		execute,
+		queuedAt: Date.now(),
+		status: 'pending',
+	};
+	queue.push(action);
+	return action;
+}
+
+/**
+ * Get all queued actions (for UI display)
+ */
+export function getQueuedActions(): readonly QueuedAction[] {
+	return queue;
+}
+
+/**
+ * Remove an action from the queue (user cancelled)
+ */
+export function cancelAction(actionId: string): void {
+	queue = queue.filter((a) => a.id !== actionId);
+}
+
+/**
+ * Clear all pending actions
+ */
+export function clearQueue(): void {
+	queue = [];
+}
+
+/**
+ * Flush all pending actions — called on reconnect.
+ *
+ * Processes actions sequentially to avoid overwhelming the connection.
+ * Failed actions are marked as 'failed' but remain in queue for UI display.
+ */
+export async function flushQueue(): Promise<void> {
+	if (flushInProgress) return;
+
+	const pending = queue.filter((a) => a.status === 'pending');
+	if (pending.length === 0) return;
+
+	flushInProgress = true;
+
+	for (const action of pending) {
+		try {
+			await action.execute();
+			action.status = 'sent';
+		} catch (err) {
+			action.status = 'failed';
+			action.error = sanitizeUserError(err);
+		}
+	}
+
+	flushInProgress = false;
+
+	// Clean up sent actions after a short delay (so UI can show "sent" state)
+	setTimeout(() => {
+		queue = queue.filter((a) => a.status !== 'sent');
+	}, 2000);
+
+	// Notify about failures
+	const failures = queue.filter((a) => a.status === 'failed');
+	if (failures.length > 0) {
+		toast.warning(`${failures.length} action(s) could not be delivered.`);
+	}
+}
+
+/**
+ * Auto-flush when connection is restored.
+ * Sets up a reactive subscription to connection state.
+ */
+let cleanupAutoFlush: (() => void) | null = null;
+
+export function startAutoFlush(): void {
+	if (cleanupAutoFlush) return; // Already started
+
+	cleanupAutoFlush = effect(() => {
+		if (connectionState.value === 'connected' && queue.some((a) => a.status === 'pending')) {
+			// Small delay to let subscriptions settle
+			setTimeout(() => flushQueue(), 500);
+		}
+	});
+}
+
+export function stopAutoFlush(): void {
+	if (cleanupAutoFlush) {
+		cleanupAutoFlush();
+		cleanupAutoFlush = null;
+	}
+}
+
+// For testing: reset module state
+export function resetQueue(): void {
+	queue = [];
+	idCounter = 0;
+	flushInProgress = false;
+}

--- a/packages/web/src/lib/outbound-queue.ts
+++ b/packages/web/src/lib/outbound-queue.ts
@@ -8,10 +8,10 @@
  * network blips — a pattern familiar from chat apps like WhatsApp/Signal.
  */
 
-import { connectionState } from './state';
-import { sanitizeUserError } from './user-error';
-import { toast } from './toast';
 import { effect } from '@preact/signals';
+import { connectionState } from './state';
+import { toast } from './toast';
+import { sanitizeUserError } from './user-error';
 
 export interface QueuedAction {
 	/** Unique ID for this queued action */
@@ -105,6 +105,7 @@ export function clearQueue(): void {
  */
 export async function flushQueue(): Promise<void> {
 	if (flushInProgress) return;
+	if (connectionState.value !== 'connected') return;
 
 	const pending = queue.filter((a) => a.status === 'pending');
 	if (pending.length === 0) return;
@@ -112,10 +113,16 @@ export async function flushQueue(): Promise<void> {
 	flushInProgress = true;
 
 	for (const action of pending) {
+		// Abort flush if connection drops mid-flush — leave remaining actions pending
+		if (connectionState.value !== 'connected') break;
+
 		try {
 			await action.execute();
 			action.status = 'sent';
 		} catch (err) {
+			// If disconnected during execution, stop and leave remaining actions pending
+			if (connectionState.value !== 'connected') break;
+
 			action.status = 'failed';
 			action.error = sanitizeUserError(err);
 		}

--- a/packages/web/src/lib/state.ts
+++ b/packages/web/src/lib/state.ts
@@ -444,6 +444,13 @@ export type ConnectionState =
 export const connectionState = signal<ConnectionState>('connecting');
 
 /**
+ * Tracks how many reconnect attempts have been made in the current cycle.
+ * Reset to 0 on successful connection. Used by UI to show progressive
+ * messaging ("Reconnecting…" vs "Connection lost. Retrying…").
+ */
+export const reconnectAttemptCount = signal<number>(0);
+
+/**
  * Initialize application state
  */
 export async function initializeApplicationState(

--- a/packages/web/src/lib/user-error.ts
+++ b/packages/web/src/lib/user-error.ts
@@ -43,8 +43,7 @@ export function isAuthError(error: unknown): boolean {
 		lower.includes('token expired') ||
 		lower.includes('not authenticated') ||
 		(lower.includes('auth') && lower.includes('fail')) ||
-		lower.includes('401') ||
-		lower.includes('403')
+		lower.includes('401')
 	);
 }
 

--- a/packages/web/src/lib/user-error.ts
+++ b/packages/web/src/lib/user-error.ts
@@ -1,0 +1,118 @@
+/**
+ * User-Facing Error Sanitization
+ *
+ * Maps raw internal error messages to human-readable strings that are
+ * safe to display to end users. Prevents developer-facing hints like
+ * "verbose: true", stack traces, or transport internals from leaking.
+ */
+
+/** Patterns that indicate developer/internal error content */
+const INTERNAL_PATTERNS = [
+	/verbose:\s*true/i,
+	/set VERBOSE=true/i,
+	/fetch\(/i,
+	/stack trace/i,
+	/at\s+[\w.<>]+\s*\(/,
+	/node_modules\//,
+	/ERR_[A-Z_]+/,
+	/ECONNREFUSED/,
+	/ECONNRESET/,
+	/ETIMEDOUT/,
+	/ENOTFOUND/,
+	/socket hang up/i,
+	/WebSocket not connected/i,
+	/Failed to send message:/i,
+	/timed?\s*out\s+(after|waiting)/i,
+	/\d{4,}ms/i,
+];
+
+/** Check if an error message contains internal/developer content */
+function isInternalMessage(msg: string): boolean {
+	return INTERNAL_PATTERNS.some((p) => p.test(msg));
+}
+
+/** Check if an error is an authentication/session-expiry error */
+export function isAuthError(error: unknown): boolean {
+	if (!error) return false;
+	const msg = error instanceof Error ? error.message : String(error);
+	const lower = msg.toLowerCase();
+	return (
+		lower.includes('unauthorized') ||
+		lower.includes('authentication') ||
+		lower.includes('session expired') ||
+		lower.includes('token expired') ||
+		lower.includes('not authenticated') ||
+		(lower.includes('auth') && lower.includes('fail')) ||
+		lower.includes('401') ||
+		lower.includes('403')
+	);
+}
+
+/** Check if error is a network/transient issue (should retry) */
+export function isTransientError(error: unknown): boolean {
+	if (!error) return true;
+	const msg = error instanceof Error ? error.message : String(error);
+	const lower = msg.toLowerCase();
+	return (
+		lower.includes('timeout') ||
+		lower.includes('network') ||
+		lower.includes('econnreset') ||
+		lower.includes('econnrefused') ||
+		lower.includes('etimedout') ||
+		lower.includes('socket') ||
+		lower.includes('fetch') ||
+		lower.includes('disconnected') ||
+		lower.includes('not connected')
+	);
+}
+
+/**
+ * Sanitize any error into a user-friendly message.
+ *
+ * Strips developer-facing content and maps common error types
+ * to readable strings.
+ */
+export function sanitizeUserError(error: unknown): string {
+	if (error == null) return 'Something went wrong.';
+
+	let msg: string;
+
+	if (error instanceof Error) {
+		msg = error.message;
+	} else if (typeof error === 'string') {
+		msg = error;
+	} else {
+		try {
+			msg = JSON.stringify(error);
+		} catch {
+			msg = String(error);
+		}
+	}
+
+	// If already human-friendly, pass through
+	if (!isInternalMessage(msg)) {
+		return msg || 'Something went wrong.';
+	}
+
+	// Map common internal messages to user-friendly ones
+	const lower = msg.toLowerCase();
+
+	if (lower.includes('websocket') || lower.includes('not connected')) {
+		return 'Connection lost. Your message will be sent when reconnected.';
+	}
+	if (lower.includes('timeout') || lower.includes('timed out')) {
+		return 'The request timed out. Please try again.';
+	}
+	if (lower.includes('econnrefused') || lower.includes('econnreset')) {
+		return 'Could not reach the server. Please check your connection.';
+	}
+	if (lower.includes('fetch')) {
+		return 'Network error. Please check your connection.';
+	}
+	if (lower.includes('failed to send')) {
+		return 'Could not send. Please try again.';
+	}
+
+	// Generic fallback for any other internal message
+	return 'Something went wrong. Please try again.';
+}


### PR DESCRIPTION
Replace full-page blocking error overlay with non-blocking inline banner for connection state. Queue outbound messages during disconnection and flush on reconnect. Sanitize internal errors before showing to users. Detect auth expiry and redirect instead of retrying.

- Non-blocking inline banner: Reconnecting → Connection lost → Unable to reconnect + Retry
- Outbound message queue with auto-flush on reconnect
- Error sanitization (no `verbose: true`, stack traces, or transport internals)
- Auth/session expiry detection → redirect to re-auth
- `reconnectAttemptCount` signal for progressive UI messaging