### PR TITLE
Fix review-posted gate URL extraction

### DIFF
--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -102,12 +102,12 @@ const PR_READY_BASH_SCRIPT = [
  * the reviewer can still post comments on the PR thread.
  *
  * Environment variables:
- *   NEOKAI_GATE_DATA_JSON       — current gate data; may contain `pr_url`
+ *   NEOKAI_GATE_DATA_JSON       — current gate data; may contain `pr_url` or `review_url`
  *   NEOKAI_WORKFLOW_START_ISO   — ISO8601 timestamp of workflowRun.createdAt,
  *                                 injected by the gate script runner
  */
 const REVIEW_POSTED_BASH_SCRIPT = [
-	'PR_URL=$(jq -r \'.pr_url // empty\' <<< "${NEOKAI_GATE_DATA_JSON:-{}}" 2>/dev/null || true)',
+	'PR_URL=$(jq -r \'.pr_url // .review_url // empty\' <<< "${NEOKAI_GATE_DATA_JSON:-{}}" 2>/dev/null || true)',
 	'if [ -z "$PR_URL" ]; then',
 	'  PR_URL=$(gh pr view --json url -q .url 2>/dev/null || true)',
 	'fi',
@@ -353,7 +353,7 @@ const FULLSTACK_QA_PROMPT =
 	'post-approval result artifact has been saved for runtime dispatch.\n' +
 	'- `submit_for_approval({ reason? })` — request human sign-off instead of self-closing. ' +
 	'Use when autonomy blocks self-close (and only when QA passes — see pre-conditions above).\n\n' +
-	'If everything passes, `save_artifact({ type: "result", append: true, summary: "QA passed.", data: { prUrl: "<url>" } })` and ' +
+	'If everything passes, `save_artifact({ type: "result", append: true, summary: "QA passed.", data: { pr_url: "<url>" } })` and ' +
 	'`approve_task`. Do NOT merge the PR yourself — a post-approval reviewer session runs ' +
 	'the merge after the task transitions to `approved`. If issues are found, send a detailed ' +
 	'fix list to Coding and record a `save_artifact({ type: "result", append: true, summary: "QA failed: ..." })` ' +
@@ -472,7 +472,7 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'comment_urls: ["<comment #1 url>", "<comment #2 url>"] }). The `data` payload ' +
 							'satisfies the review-posted-gate and gives the coder direct links to each ' +
 							'thread.\n' +
-							'   d. Call `save_artifact({ type: "result", append: true, summary: "Requested changes: ...", data: { prUrl: "<url>", reviewUrl: "<gh pr review url>" } })` so the cycle is recorded.\n' +
+							'   d. Call `save_artifact({ type: "result", append: true, summary: "Requested changes: ...", data: { pr_url: "<url>", review_url: "<gh pr review url>" } })` so the cycle is recorded.\n' +
 							'   e. **STOP. Do NOT call `approve_task`. Do NOT call `submit_for_approval`.** ' +
 							'Both are terminal actions that close the review loop — calling either while ' +
 							'P0–P3 findings are open hands the task off before Coding can address them. ' +
@@ -482,8 +482,8 @@ export const CODING_WORKFLOW: SpaceWorkflow = {
 							'   a. Post an approval review: `gh pr review <pr-url> --approve ' +
 							'--body-file <file>`.\n' +
 							'   b. Verify the PR is still open and mergeable.\n' +
-							'   c. Call `save_artifact({ type: "result", append: true, summary, data: { prUrl: "<url>" } })` ' +
-							'to record the audit entry. The `prUrl` inside `data` is what ' +
+							'   c. Call `save_artifact({ type: "result", append: true, summary, data: { pr_url: "<url>" } })` ' +
+							'to record the audit entry. The `pr_url` inside `data` is what ' +
 							'`dispatchPostApproval` reads when interpolating `{{pr_url}}` into the ' +
 							'merge template — top-level keys outside `data` are silently stripped by ' +
 							'the tool schema, so nest it correctly.\n' +
@@ -651,8 +651,8 @@ export const RESEARCH_WORKFLOW: SpaceWorkflow = {
 							'--body-file <file>`. A visible GitHub review is required — an internal ' +
 							'summary is not enough.\n' +
 							'   b. Verify the PR is still open and mergeable.\n' +
-							'   c. Call `save_artifact({ type: "result", append: true, summary, data: { prUrl: "<url>" } })` ' +
-							'to record the final audit entry. The `prUrl` inside `data` is what ' +
+							'   c. Call `save_artifact({ type: "result", append: true, summary, data: { pr_url: "<url>" } })` ' +
+							'to record the final audit entry. The `pr_url` inside `data` is what ' +
 							'`dispatchPostApproval` reads when interpolating `{{pr_url}}` into the ' +
 							'merge template — top-level keys outside `data` are silently stripped by ' +
 							'the tool schema, so nest it correctly.\n' +
@@ -781,7 +781,7 @@ export const REVIEW_ONLY_WORKFLOW: SpaceWorkflow = {
 							'3. Verify test coverage is adequate\n' +
 							'4. Post your review to the PR via `gh pr review` (+ inline comments via `gh api` ' +
 							'where relevant) — this is required, not optional\n' +
-							'5. Call `save_artifact({ type: "result", append: true, summary, data: { prUrl: "<url>" } })` to record the audit entry. Nest `prUrl` inside `data`; top-level keys outside `data` are stripped by the tool schema\n' +
+							'5. Call `save_artifact({ type: "result", append: true, summary, data: { pr_url: "<url>" } })` to record the audit entry. Nest `pr_url` inside `data`; top-level keys outside `data` are stripped by the tool schema\n' +
 							'6. If your verdict is APPROVE: call `approve_task()` as your final action. If ' +
 							'autonomy blocks self-close, call `submit_for_approval({ reason: "..." })` ' +
 							'instead. If your verdict is REQUEST_CHANGES: stop after step 5 — do NOT call ' +
@@ -1098,8 +1098,8 @@ export const FULLSTACK_QA_LOOP_WORKFLOW: SpaceWorkflow = {
 							'carry the same approval semantic. Leave the workflow open for the next ' +
 							'Coding cycle.\n' +
 							'5. If all green:\n' +
-							'   a. Call `save_artifact({ type: "result", append: true, summary, data: { prUrl: "<url>", testOutput: "<output>" } })` ' +
-							'to record the audit entry. The `prUrl` inside `data` is what ' +
+							'   a. Call `save_artifact({ type: "result", append: true, summary, data: { pr_url: "<url>", test_output: "<output>" } })` ' +
+							'to record the audit entry. The `pr_url` inside `data` is what ' +
 							'`dispatchPostApproval` reads when interpolating `{{pr_url}}` into the ' +
 							'merge template — top-level keys outside `data` are silently stripped by ' +
 							'the tool schema, so nest it correctly.\n' +

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -263,7 +263,7 @@ const PD_TASK_DISPATCHER_PROMPT =
 	'enforce ordering, block dependents until prerequisites are done, and cascade-cancel on ' +
 	'failure. Do NOT rely on prose-only dependency hints — they are informational, not enforced.\n\n' +
 	'   - BOTTOM task (item 1): `depends_on: []` (no prerequisites).\n' +
-	'   - MIDDLE / TOP tasks (item N > 1): `depends_on: [<taskId of item N-1>]`.\n\n' +
+	'   - MIDDLE / TOP tasks (item N > 1): `depends_on: [<task_id of item N-1>]`.\n\n' +
 	'The `description` must contain the original plan item content PLUS a ' +
 	'"## Stacked PR Instructions" section appended at the end.\n\n' +
 	'   For the BOTTOM task (item 1 — PR base is `dev`):\n' +
@@ -288,7 +288,7 @@ const PD_TASK_DISPATCHER_PROMPT =
 	"that task's branch exists.\n" +
 	'   ```\n\n' +
 	'4. Collect the returned task IDs. Build a stack map: ' +
-	'{ prefix, items: [{ title, taskId, branch, baseBranch, position }] }.\n' +
+	'{ prefix, items: [{ title, task_id, branch, base_branch, position }] }.\n' +
 	'5. Call `save_artifact({ type: "result", append: true, summary: "Created N tasks from plan: <short list>", ' +
 	'created_task_ids: [<ids>], stack_prefix: "<prefix>", ' +
 	'stack_branches: ["plan/<prefix>/<item-1-slug>", "plan/<prefix>/<item-2-slug>", ...] })` to record the dispatch audit entry.\n' +

--- a/packages/daemon/src/lib/space/workflows/post-approval-merge-template.ts
+++ b/packages/daemon/src/lib/space/workflows/post-approval-merge-template.ts
@@ -57,5 +57,5 @@ export const PR_MERGE_POST_APPROVAL_INSTRUCTIONS: string = [
 	'     git fetch origin && git checkout dev && git pull --ff-only',
 	'4. Save an audit artifact:',
 	'     save_artifact({ type: "result", append: true,',
-	'                     data: { merged_pr_url, mergedAt, approval_source: "{{approval_source}}" } })',
+	'                     data: { merged_pr_url, merged_at, approval_source: "{{approval_source}}" } })',
 ].join('\n');

--- a/packages/daemon/src/lib/space/workflows/post-approval-merge-template.ts
+++ b/packages/daemon/src/lib/space/workflows/post-approval-merge-template.ts
@@ -29,7 +29,7 @@
  *
  * Workflow authors referencing this template MUST ensure their end node signals
  * `{ pr_url }` (inside the `data` payload of `send_message(target:
- * 'task-agent', …)` and/or `save_artifact({ type: 'result', data: { prUrl } })`)
+ * 'task-agent', …)` and/or `save_artifact({ type: 'result', data: { pr_url } })`)
  * before `approve_task()` / `submit_for_approval()`. The earlier §2.1
  * `post_approval_action` discriminator was removed — post-approval routing is
  * declarative on the workflow's `postApproval` field, not signalled at runtime.

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -191,6 +191,51 @@ describe('CODING_WORKFLOW template', () => {
 		expect(src).toContain('PR comment');
 	});
 
+	test('review-posted-gate uses review_url gate data when pr_url is absent', async () => {
+		const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
+		const workspace = mkdtempSync(join(tmpdir(), 'neokai-review-posted-gate-'));
+		const binDir = join(workspace, 'bin');
+		const ghPath = join(binDir, 'gh');
+		const logPath = join(workspace, 'gh-args.log');
+		const reviewUrl = 'https://github.com/test/repo/pull/42#pullrequestreview-123';
+
+		try {
+			mkdirSync(binDir);
+			writeFileSync(
+				ghPath,
+				[
+					'#!/usr/bin/env bash',
+					`printf '%s\\n' "$*" >> ${JSON.stringify(logPath)}`,
+					`if [ "$1" = "pr" ] && [ "$2" = "view" ] && [ "$3" = ${JSON.stringify(reviewUrl)} ] && [ "$4" = "--json" ] && [ "$5" = "reviews" ]; then`,
+					`  printf '%s\\n' '{"reviews":[{"submittedAt":"2026-05-01T12:00:00Z"}]}'`,
+					'  exit 0',
+					'fi',
+					'printf "unexpected gh args: %s\\n" "$*" >&2',
+					'exit 2',
+				].join('\n')
+			);
+			chmodSync(ghPath, 0o755);
+
+			const result = await executeGateScript(
+				gate.script!,
+				{
+					workspacePath: workspace,
+					gateId: 'review-posted-gate',
+					runId: 'run-1',
+					gateData: { review_url: reviewUrl },
+					workflowStartIso: '2026-05-01T00:00:00Z',
+				},
+				{ PATH: `${binDir}:${process.env.PATH ?? ''}` }
+			);
+
+			expect(result.success).toBe(true);
+			expect(result.data).toEqual({ pr_url: reviewUrl, review_count: 1 });
+			expect(readFileSync(logPath, 'utf8').trim()).toBe(`pr view ${reviewUrl} --json reviews`);
+		} finally {
+			rmSync(workspace, { recursive: true, force: true });
+		}
+	});
+
 	test('review-posted-gate resets on cycle so each feedback round is re-verified', () => {
 		const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
 		expect(gate.resetOnCycle).toBe(true);

--- a/packages/daemon/tests/unit/5-space/workflow/end-node-handoff.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/end-node-handoff.test.ts
@@ -5,7 +5,7 @@
  * the post-approval routing contract:
  *
  *   - Coding / Research / QA end nodes each save a result artifact carrying
- *     `data.prUrl` BEFORE calling `approve_task`. These three workflows MUST also declare a
+ *     `data.pr_url` BEFORE calling `approve_task`. These three workflows MUST also declare a
  *     `postApproval: { targetAgent: 'reviewer', instructions: <merge template> }`
  *     route so the runtime dispatches the merge. PR 5/5 removed the legacy
  *     `post_approval_action: "merge_pr"` discriminator from the data payload —
@@ -115,13 +115,13 @@ describe('End-node post-approval declarations', () => {
 
 describe('End-node prompts save runtime post-approval data before approve_task', () => {
 	for (const [label, wf] of MERGE_ROUTED_WORKFLOWS) {
-		test(`${label} end-node prompt includes save_artifact data.prUrl and no task-agent relay`, () => {
+		test(`${label} end-node prompt includes save_artifact data.pr_url and no task-agent relay`, () => {
 			const prompt = endNodePrompt(wf);
 			// Every merge-routed workflow must instruct its end-node agent to save
 			// a result artifact carrying the PR URL. `dispatchPostApproval` reads
 			// that artifact when interpolating `{{pr_url}}` into the merge template.
 			expect(prompt).toContain('save_artifact');
-			expect(prompt).toContain('prUrl');
+			expect(prompt).toContain('pr_url');
 			expect(prompt).not.toContain('target: "task-agent"');
 			// PR 5/5: the legacy `post_approval_action: "merge_pr"`
 			// discriminator was removed — post-approval routing is fully
@@ -133,7 +133,7 @@ describe('End-node prompts save runtime post-approval data before approve_task',
 		test(`${label} end-node prompt places result artifact BEFORE the final approve_task call`, () => {
 			const prompt = endNodePrompt(wf);
 			// Anchor on the final `save_artifact(` instruction — the runtime reads
-			// its `data.prUrl` before dispatching the post-approval route.
+			// its `data.pr_url` before dispatching the post-approval route.
 			const signalIdx = prompt.lastIndexOf('save_artifact(');
 			// Use lastIndexOf: the first `approve_task()` occurrence in every
 			// prompt lives in the "TOOL CONTRACT" block at the top, which is a


### PR DESCRIPTION
Fixes the review-posted gate so Review-provided review_url data is used when pr_url is absent.

Also updates built-in workflow prompts and handoff docs/tests to use snake_case artifact fields such as pr_url and review_url.

Tested: cd packages/daemon && bun test tests/unit/5-space/workflow/built-in-workflows.test.ts tests/unit/5-space/workflow/end-node-handoff.test.ts