### PR TITLE
Recover stalled workflow handoffs after restart

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -29,7 +29,7 @@ import type {
 	UpdateSpaceTaskParams,
 	WorkflowChannel,
 } from '@neokai/shared';
-import { computeGateDefaults, resolveNodeAgents } from '@neokai/shared';
+import { computeGateDefaults, isChannelCyclic, resolveNodeAgents } from '@neokai/shared';
 import type { SpaceManager } from '../managers/space-manager';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
@@ -46,6 +46,7 @@ import type { WorkflowRunArtifactRepository } from '../../../storage/repositorie
 import { SDKMessageRepository } from '../../../storage/repositories/sdk-message-repository';
 import { ToolContinuationRecoveryRepository } from '../../../storage/repositories/tool-continuation-recovery-repository';
 import type { PendingAgentMessageRepository } from '../../../storage/repositories/pending-agent-message-repository';
+import { ChannelCycleRepository } from '../../../storage/repositories/channel-cycle-repository';
 import { type NotificationSink, NullNotificationSink } from './notification-sink';
 import { CompletionDetector } from './completion-detector';
 import type { SelectWorkflowWithLlm } from './llm-workflow-selector';
@@ -64,6 +65,7 @@ import { resolveTimeoutForExecution } from './resolve-node-timeout';
 import { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
 import { evaluateGate } from './gate-evaluator';
 import { executeGateScript } from './gate-script-executor';
+import { getBuiltInGateScript } from '../workflows/built-in-workflows';
 
 const log = new Logger('space-runtime');
 
@@ -1554,15 +1556,51 @@ export class SpaceRuntime {
 		if (channels.length === 0) return false;
 
 		const nodeByName = new Map(workflow.nodes.map((node) => [node.name, node]));
+		const idleExecutions = executions.filter((execution) => execution.status === 'idle');
+		const idleNodeIds = new Set(idleExecutions.map((execution) => execution.workflowNodeId));
+		const candidateSourceNodeIds = new Set<string>();
+		for (const execution of idleExecutions) {
+			const node = workflow.nodes.find((candidate) => candidate.id === execution.workflowNodeId);
+			if (!node) continue;
+			for (const channel of channels) {
+				if (channel.from !== '*' && channel.from !== node.name) continue;
+				for (const targetName of this.resolveRestartRecoveryTargetNames(
+					channel,
+					workflow,
+					node.name
+				)) {
+					const targetNode = nodeByName.get(targetName);
+					if (
+						!targetNode ||
+						!idleNodeIds.has(targetNode.id) ||
+						targetNode.id === workflow.endNodeId
+					) {
+						candidateSourceNodeIds.add(node.id);
+					}
+				}
+			}
+		}
+		const sourceExecutions = idleExecutions.filter((execution) =>
+			candidateSourceNodeIds.has(execution.workflowNodeId)
+		);
 		const createdOrReset: string[] = [];
 		const blockedGateReasons: string[] = [];
 
-		for (const sourceExecution of executions) {
-			if (sourceExecution.status !== 'idle') continue;
+		for (const sourceExecution of sourceExecutions) {
 			const sourceNode = workflow.nodes.find((node) => node.id === sourceExecution.workflowNodeId);
 			if (!sourceNode) continue;
-			for (const channel of channels) {
+			for (const [channelIndex, channel] of channels.entries()) {
 				if (channel.from !== '*' && channel.from !== sourceNode.name) continue;
+				const cycleResult = this.evaluateRestartRecoveryCycle(
+					run.id,
+					workflow,
+					channel,
+					channelIndex
+				);
+				if (!cycleResult.open) {
+					blockedGateReasons.push(cycleResult.reason);
+					continue;
+				}
 				const targetNames = this.resolveRestartRecoveryTargetNames(
 					channel,
 					workflow,
@@ -1645,6 +1683,27 @@ export class SpaceRuntime {
 		return false;
 	}
 
+	private evaluateRestartRecoveryCycle(
+		runId: string,
+		workflow: SpaceWorkflow,
+		channel: WorkflowChannel,
+		channelIndex: number
+	): { open: true } | { open: false; reason: string } {
+		if (!isChannelCyclic(channelIndex, workflow.channels ?? [], workflow.nodes)) {
+			return { open: true };
+		}
+		const maxCycles = channel.maxCycles ?? 5;
+		const cycleRepo = new ChannelCycleRepository(this.config.db);
+		const record = cycleRepo.get(runId, channelIndex);
+		if (record && record.count >= maxCycles) {
+			return {
+				open: false,
+				reason: `Cyclic channel "${channel.id ?? channelIndex}" has reached the maximum cycle count (${maxCycles}). Increase maxCycles to allow more cycles.`,
+			};
+		}
+		return { open: true };
+	}
+
 	private resolveRestartRecoveryTargetNames(
 		channel: WorkflowChannel,
 		workflow: SpaceWorkflow,
@@ -1663,24 +1722,29 @@ export class SpaceRuntime {
 		channel: WorkflowChannel
 	): Promise<{ open: boolean; reason?: string }> {
 		if (!channel.gateId) return { open: true };
-		const gate = (workflow.gates ?? []).find((candidate) => candidate.id === channel.gateId);
-		if (!gate) {
+		const storedGate = (workflow.gates ?? []).find((candidate) => candidate.id === channel.gateId);
+		if (!storedGate) {
 			return {
 				open: false,
 				reason: `Gate "${channel.gateId}" not found — channel "${channel.id}" is closed (misconfiguration)`,
 			};
 		}
+		let gate = storedGate;
+		if (workflow.templateName && storedGate.script) {
+			const liveScript = getBuiltInGateScript(workflow.templateName, storedGate.id);
+			if (liveScript) gate = { ...storedGate, script: liveScript };
+		}
 		const gateDataRepo = new GateDataRepository(this.config.db);
 		const runtimeData =
 			gateDataRepo.get(runId, gate.id)?.data ?? computeGateDefaults(gate.fields ?? []);
+		const run = this.config.workflowRunRepo.getRun(runId);
+		const space = await this.config.spaceManager.getSpace(workflow.spaceId);
 		const result = await evaluateGate(gate, runtimeData, executeGateScript, {
-			workspacePath: process.cwd(),
+			workspacePath: space?.workspacePath ?? process.cwd(),
 			gateId: gate.id,
 			runId,
 			gateData: runtimeData,
-			workflowStartIso: this.config.workflowRunRepo.getRun(runId)
-				? new Date(this.config.workflowRunRepo.getRun(runId)!.createdAt).toISOString()
-				: undefined,
+			workflowStartIso: run ? new Date(run.createdAt).toISOString() : undefined,
 		});
 		return { open: result.open, reason: result.reason };
 	}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -63,6 +63,7 @@ import {
 import { resolveTimeoutForExecution } from './resolve-node-timeout';
 import { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
 import { evaluateGate } from './gate-evaluator';
+import { executeGateScript } from './gate-script-executor';
 
 const log = new Logger('space-runtime');
 
@@ -1557,6 +1558,7 @@ export class SpaceRuntime {
 		const blockedGateReasons: string[] = [];
 
 		for (const sourceExecution of executions) {
+			if (sourceExecution.status !== 'idle') continue;
 			const sourceNode = workflow.nodes.find((node) => node.id === sourceExecution.workflowNodeId);
 			if (!sourceNode) continue;
 			for (const channel of channels) {
@@ -1584,6 +1586,7 @@ export class SpaceRuntime {
 					}
 
 					let activatedForTarget = false;
+					let resetExistingTarget = false;
 					for (const agentEntry of resolveNodeAgents(targetNode)) {
 						const existing = this.config.nodeExecutionRepo
 							.listByNode(run.id, targetNode.id)
@@ -1598,6 +1601,7 @@ export class SpaceRuntime {
 									completedAt: null,
 								});
 								activatedForTarget = true;
+								resetExistingTarget = true;
 							}
 							continue;
 						}
@@ -1612,7 +1616,12 @@ export class SpaceRuntime {
 					}
 					if (activatedForTarget) {
 						createdOrReset.push(targetNode.name);
-						this.enqueueRestartRecoveryMessage(run, sourceExecution.agentName, targetNode);
+						this.enqueueRestartRecoveryMessage(
+							run,
+							sourceExecution.agentName,
+							targetNode,
+							resetExistingTarget
+						);
 					}
 				}
 			}
@@ -1664,20 +1673,31 @@ export class SpaceRuntime {
 		const gateDataRepo = new GateDataRepository(this.config.db);
 		const runtimeData =
 			gateDataRepo.get(runId, gate.id)?.data ?? computeGateDefaults(gate.fields ?? []);
-		const result = await evaluateGate(gate, runtimeData);
+		const result = await evaluateGate(gate, runtimeData, executeGateScript, {
+			workspacePath: process.cwd(),
+			gateId: gate.id,
+			runId,
+			gateData: runtimeData,
+			workflowStartIso: this.config.workflowRunRepo.getRun(runId)
+				? new Date(this.config.workflowRunRepo.getRun(runId)!.createdAt).toISOString()
+				: undefined,
+		});
 		return { open: result.open, reason: result.reason };
 	}
 
 	private enqueueRestartRecoveryMessage(
 		run: SpaceWorkflowRun,
 		lastAgentName: string,
-		targetNode: SpaceWorkflow['nodes'][number]
+		targetNode: SpaceWorkflow['nodes'][number],
+		resetExistingTarget: boolean
 	): void {
 		const repo = this.config.pendingMessageRepo;
 		if (!repo) return;
 		const tasks = this.config.taskRepo.listByWorkflowRun(run.id);
 		const task = this.pickCanonicalTaskForRun(run, tasks);
-		const message = `[Daemon restart recovery] The previous agent (${lastAgentName}) completed but the handoff message was not delivered. Please check the PR and review status, then continue.`;
+		const message = resetExistingTarget
+			? `[Daemon restart recovery] The ${targetNode.name} node's previous session ended before completing the workflow. Please check the PR and review status, then continue.`
+			: `[Daemon restart recovery] The previous agent (${lastAgentName}) completed but the handoff message was not delivered. Please check the PR and review status, then continue.`;
 		for (const agentEntry of resolveNodeAgents(targetNode)) {
 			repo.enqueue({
 				workflowRunId: run.id,

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1569,17 +1569,15 @@ export class SpaceRuntime {
 			if (!node) continue;
 			for (const [channelIndex, channel] of channels.entries()) {
 				if (!this.matchesRestartRecoveryChannelSource(channel, node, execution.agentName)) continue;
-				const targetNames = this.resolveRestartRecoveryTargetNames(
-					channel,
-					workflow,
-					node.name
-				).filter((targetName) => {
-					const targetNode = nodeByName.get(targetName);
-					return (
-						!targetNode ||
-						this.shouldRecoverRestartRecoveryTarget(targetNode, executions, workflow.endNodeId)
-					);
-				});
+				const targetNames = this.resolveRestartRecoveryTargetNames(channel, workflow).filter(
+					(targetName) => {
+						const targetNode = nodeByName.get(targetName);
+						return (
+							!targetNode ||
+							this.shouldRecoverRestartRecoveryTarget(targetNode, executions, workflow.endNodeId)
+						);
+					}
+				);
 				if (targetNames.length === 0) continue;
 				stalledTransitions.push({
 					sourceExecution: execution,
@@ -1762,13 +1760,9 @@ export class SpaceRuntime {
 
 	private resolveRestartRecoveryTargetNames(
 		channel: WorkflowChannel,
-		workflow: SpaceWorkflow,
-		sourceNodeName: string
+		workflow: SpaceWorkflow
 	): string[] {
 		const rawTargets = Array.isArray(channel.to) ? channel.to : [channel.to];
-		if (rawTargets.includes('*')) {
-			return workflow.nodes.map((node) => node.name).filter((name) => name !== sourceNodeName);
-		}
 		const resolvedTargets = new Set<string>();
 		for (const rawTarget of rawTargets) {
 			const targetNode = workflow.nodes.find(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1569,7 +1569,7 @@ export class SpaceRuntime {
 			const node = workflow.nodes.find((candidate) => candidate.id === execution.workflowNodeId);
 			if (!node) continue;
 			for (const [channelIndex, channel] of channels.entries()) {
-				if (channel.from !== '*' && channel.from !== node.name) continue;
+				if (!this.matchesRestartRecoveryChannelSource(channel, node, execution.agentName)) continue;
 				const targetNames = this.resolveRestartRecoveryTargetNames(
 					channel,
 					workflow,
@@ -1733,6 +1733,16 @@ export class SpaceRuntime {
 		}
 	}
 
+	private matchesRestartRecoveryChannelSource(
+		channel: WorkflowChannel,
+		sourceNode: SpaceWorkflow['nodes'][number],
+		sourceAgentName: string
+	): boolean {
+		return (
+			channel.from === '*' || channel.from === sourceNode.name || channel.from === sourceAgentName
+		);
+	}
+
 	private resolveRestartRecoveryTargetNames(
 		channel: WorkflowChannel,
 		workflow: SpaceWorkflow,
@@ -1742,7 +1752,17 @@ export class SpaceRuntime {
 		if (rawTargets.includes('*')) {
 			return workflow.nodes.map((node) => node.name).filter((name) => name !== sourceNodeName);
 		}
-		return rawTargets;
+		const resolvedTargets = new Set<string>();
+		for (const rawTarget of rawTargets) {
+			const targetNode = workflow.nodes.find(
+				(node) =>
+					node.name === rawTarget ||
+					node.id === rawTarget ||
+					resolveNodeAgents(node).some((agent) => agent.name === rawTarget)
+			);
+			resolvedTargets.add(targetNode?.name ?? rawTarget);
+		}
+		return [...resolvedTargets];
 	}
 
 	private async evaluateRestartRecoveryChannelGate(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1558,110 +1558,113 @@ export class SpaceRuntime {
 		const nodeByName = new Map(workflow.nodes.map((node) => [node.name, node]));
 		const idleExecutions = executions.filter((execution) => execution.status === 'idle');
 		const idleNodeIds = new Set(idleExecutions.map((execution) => execution.workflowNodeId));
-		const candidateSourceNodeIds = new Set<string>();
+		const stalledTransitions: Array<{
+			sourceExecution: NodeExecution;
+			sourceNode: SpaceWorkflow['nodes'][number];
+			channel: WorkflowChannel;
+			channelIndex: number;
+			targetNames: string[];
+		}> = [];
 		for (const execution of idleExecutions) {
 			const node = workflow.nodes.find((candidate) => candidate.id === execution.workflowNodeId);
 			if (!node) continue;
-			for (const channel of channels) {
-				if (channel.from !== '*' && channel.from !== node.name) continue;
-				for (const targetName of this.resolveRestartRecoveryTargetNames(
-					channel,
-					workflow,
-					node.name
-				)) {
-					const targetNode = nodeByName.get(targetName);
-					if (
-						!targetNode ||
-						!idleNodeIds.has(targetNode.id) ||
-						targetNode.id === workflow.endNodeId
-					) {
-						candidateSourceNodeIds.add(node.id);
-					}
-				}
-			}
-		}
-		const sourceExecutions = idleExecutions.filter((execution) =>
-			candidateSourceNodeIds.has(execution.workflowNodeId)
-		);
-		const createdOrReset: string[] = [];
-		const blockedGateReasons: string[] = [];
-
-		for (const sourceExecution of sourceExecutions) {
-			const sourceNode = workflow.nodes.find((node) => node.id === sourceExecution.workflowNodeId);
-			if (!sourceNode) continue;
 			for (const [channelIndex, channel] of channels.entries()) {
-				if (channel.from !== '*' && channel.from !== sourceNode.name) continue;
-				const cycleResult = this.evaluateRestartRecoveryCycle(
-					run.id,
-					workflow,
-					channel,
-					channelIndex
-				);
-				if (!cycleResult.open) {
-					blockedGateReasons.push(cycleResult.reason);
-					continue;
-				}
+				if (channel.from !== '*' && channel.from !== node.name) continue;
 				const targetNames = this.resolveRestartRecoveryTargetNames(
 					channel,
 					workflow,
-					sourceNode.name
-				);
-				for (const targetName of targetNames) {
+					node.name
+				).filter((targetName) => {
 					const targetNode = nodeByName.get(targetName);
-					if (!targetNode || targetNode.id === sourceNode.id) continue;
-
-					const gateResult = await this.evaluateRestartRecoveryChannelGate(
-						run.id,
-						workflow,
-						channel
+					return (
+						!targetNode || !idleNodeIds.has(targetNode.id) || targetNode.id === workflow.endNodeId
 					);
-					if (!gateResult.open) {
-						blockedGateReasons.push(
-							gateResult.reason ??
-								`Gate ${channel.gateId ?? 'unknown'} blocked channel ${channel.id}`
-						);
+				});
+				if (targetNames.length === 0) continue;
+				stalledTransitions.push({
+					sourceExecution: execution,
+					sourceNode: node,
+					channel,
+					channelIndex,
+					targetNames,
+				});
+			}
+		}
+		const createdOrReset: string[] = [];
+		const blockedGateReasons: string[] = [];
+
+		for (const {
+			sourceExecution,
+			sourceNode,
+			channel,
+			channelIndex,
+			targetNames,
+		} of stalledTransitions) {
+			const cycleResult = this.evaluateRestartRecoveryCycle(
+				run.id,
+				workflow,
+				channel,
+				channelIndex
+			);
+			if (!cycleResult.open) {
+				blockedGateReasons.push(cycleResult.reason);
+				continue;
+			}
+			let activatedOnChannel = false;
+			for (const targetName of targetNames) {
+				const targetNode = nodeByName.get(targetName);
+				if (!targetNode || targetNode.id === sourceNode.id) continue;
+
+				const gateResult = await this.evaluateRestartRecoveryChannelGate(run.id, workflow, channel);
+				if (!gateResult.open) {
+					blockedGateReasons.push(
+						gateResult.reason ?? `Gate ${channel.gateId ?? 'unknown'} blocked channel ${channel.id}`
+					);
+					continue;
+				}
+
+				let activatedForTarget = false;
+				let resetExistingTarget = false;
+				for (const agentEntry of resolveNodeAgents(targetNode)) {
+					const existing = this.config.nodeExecutionRepo
+						.listByNode(run.id, targetNode.id)
+						.find((execution) => execution.agentName === agentEntry.name);
+					if (existing) {
+						if (existing.status === 'idle') {
+							this.config.nodeExecutionRepo.update(existing.id, {
+								status: 'pending',
+								agentSessionId: null,
+								result: null,
+								startedAt: null,
+								completedAt: null,
+							});
+							activatedForTarget = true;
+							resetExistingTarget = true;
+						}
 						continue;
 					}
-
-					let activatedForTarget = false;
-					let resetExistingTarget = false;
-					for (const agentEntry of resolveNodeAgents(targetNode)) {
-						const existing = this.config.nodeExecutionRepo
-							.listByNode(run.id, targetNode.id)
-							.find((execution) => execution.agentName === agentEntry.name);
-						if (existing) {
-							if (existing.status === 'idle') {
-								this.config.nodeExecutionRepo.update(existing.id, {
-									status: 'pending',
-									agentSessionId: null,
-									result: null,
-									startedAt: null,
-									completedAt: null,
-								});
-								activatedForTarget = true;
-								resetExistingTarget = true;
-							}
-							continue;
-						}
-						this.config.nodeExecutionRepo.createOrIgnore({
-							workflowRunId: run.id,
-							workflowNodeId: targetNode.id,
-							agentName: agentEntry.name,
-							agentId: agentEntry.agentId ?? null,
-							status: 'pending',
-						});
-						activatedForTarget = true;
-					}
-					if (activatedForTarget) {
-						createdOrReset.push(targetNode.name);
-						this.enqueueRestartRecoveryMessage(
-							run,
-							sourceExecution.agentName,
-							targetNode,
-							resetExistingTarget
-						);
-					}
+					this.config.nodeExecutionRepo.createOrIgnore({
+						workflowRunId: run.id,
+						workflowNodeId: targetNode.id,
+						agentName: agentEntry.name,
+						agentId: agentEntry.agentId ?? null,
+						status: 'pending',
+					});
+					activatedForTarget = true;
 				}
+				if (activatedForTarget) {
+					createdOrReset.push(targetNode.name);
+					activatedOnChannel = true;
+					this.enqueueRestartRecoveryMessage(
+						run,
+						sourceExecution.agentName,
+						targetNode,
+						resetExistingTarget
+					);
+				}
+			}
+			if (activatedOnChannel) {
+				this.recordRestartRecoveryCycleTraversal(run.id, workflow, channel, channelIndex);
 			}
 		}
 
@@ -1702,6 +1705,32 @@ export class SpaceRuntime {
 			};
 		}
 		return { open: true };
+	}
+
+	private recordRestartRecoveryCycleTraversal(
+		runId: string,
+		workflow: SpaceWorkflow,
+		channel: WorkflowChannel,
+		channelIndex: number
+	): void {
+		if (!isChannelCyclic(channelIndex, workflow.channels ?? [], workflow.nodes)) return;
+		const maxCycles = channel.maxCycles ?? 5;
+		const cycleRepo = new ChannelCycleRepository(this.config.db);
+		const gateDataRepo = new GateDataRepository(this.config.db);
+		const cyclicGates = (workflow.gates ?? []).filter((gate) => gate.resetOnCycle);
+		const increment = () => {
+			for (const gate of cyclicGates) {
+				gateDataRepo.reset(runId, gate.id, computeGateDefaults(gate.fields ?? []));
+			}
+			return cycleRepo.incrementCycleCount(runId, channelIndex, maxCycles);
+		};
+		const incremented =
+			cyclicGates.length > 0 ? this.config.db.transaction(increment)() : increment();
+		if (!incremented) {
+			log.warn(
+				`SpaceRuntime.recoverStalledRuns: cyclic channel "${channel.id ?? channelIndex}" reached maxCycles during recovery activation`
+			);
+		}
 	}
 
 	private resolveRestartRecoveryTargetNames(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -29,7 +29,7 @@ import type {
 	UpdateSpaceTaskParams,
 	WorkflowChannel,
 } from '@neokai/shared';
-import { resolveNodeAgents } from '@neokai/shared';
+import { computeGateDefaults, resolveNodeAgents } from '@neokai/shared';
 import type { SpaceManager } from '../managers/space-manager';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
@@ -61,6 +61,8 @@ import {
 	MAX_TASK_AGENT_CRASH_RETRIES,
 } from './constants';
 import { resolveTimeoutForExecution } from './resolve-node-timeout';
+import { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
+import { evaluateGate } from './gate-evaluator';
 
 const log = new Logger('space-runtime');
 
@@ -1495,6 +1497,9 @@ export class SpaceRuntime {
 			return 'completion-pending';
 		}
 
+		const activated = await this.activateRestartRecoveryDownstreamNodes(run, executions);
+		if (activated) return 'skipped';
+
 		// Genuinely stalled with no completion signal — flag the run
 		// as blocked so the user-facing task surfaces in the "Needs Attention"
 		// group rather than appearing in_progress forever.
@@ -1536,6 +1541,155 @@ export class SpaceRuntime {
 				`with all node executions idle/cancelled and no completion signal — flagged blocked`
 		);
 		return 'blocked';
+	}
+
+	private async activateRestartRecoveryDownstreamNodes(
+		run: SpaceWorkflowRun,
+		executions: NodeExecution[]
+	): Promise<boolean> {
+		const workflow = this.config.spaceWorkflowManager.getWorkflow(run.workflowId);
+		if (!workflow) return false;
+		const channels = workflow.channels ?? [];
+		if (channels.length === 0) return false;
+
+		const nodeByName = new Map(workflow.nodes.map((node) => [node.name, node]));
+		const createdOrReset: string[] = [];
+		const blockedGateReasons: string[] = [];
+
+		for (const sourceExecution of executions) {
+			const sourceNode = workflow.nodes.find((node) => node.id === sourceExecution.workflowNodeId);
+			if (!sourceNode) continue;
+			for (const channel of channels) {
+				if (channel.from !== '*' && channel.from !== sourceNode.name) continue;
+				const targetNames = this.resolveRestartRecoveryTargetNames(
+					channel,
+					workflow,
+					sourceNode.name
+				);
+				for (const targetName of targetNames) {
+					const targetNode = nodeByName.get(targetName);
+					if (!targetNode || targetNode.id === sourceNode.id) continue;
+
+					const gateResult = await this.evaluateRestartRecoveryChannelGate(
+						run.id,
+						workflow,
+						channel
+					);
+					if (!gateResult.open) {
+						blockedGateReasons.push(
+							gateResult.reason ??
+								`Gate ${channel.gateId ?? 'unknown'} blocked channel ${channel.id}`
+						);
+						continue;
+					}
+
+					let activatedForTarget = false;
+					for (const agentEntry of resolveNodeAgents(targetNode)) {
+						const existing = this.config.nodeExecutionRepo
+							.listByNode(run.id, targetNode.id)
+							.find((execution) => execution.agentName === agentEntry.name);
+						if (existing) {
+							if (existing.status === 'idle') {
+								this.config.nodeExecutionRepo.update(existing.id, {
+									status: 'pending',
+									agentSessionId: null,
+									result: null,
+									startedAt: null,
+									completedAt: null,
+								});
+								activatedForTarget = true;
+							}
+							continue;
+						}
+						this.config.nodeExecutionRepo.createOrIgnore({
+							workflowRunId: run.id,
+							workflowNodeId: targetNode.id,
+							agentName: agentEntry.name,
+							agentId: agentEntry.agentId ?? null,
+							status: 'pending',
+						});
+						activatedForTarget = true;
+					}
+					if (activatedForTarget) {
+						createdOrReset.push(targetNode.name);
+						this.enqueueRestartRecoveryMessage(run, sourceExecution.agentName, targetNode);
+					}
+				}
+			}
+		}
+
+		if (createdOrReset.length > 0) {
+			log.warn(
+				`SpaceRuntime.recoverStalledRuns: recovered run ${run.id} by activating downstream node(s): ${[
+					...new Set(createdOrReset),
+				].join(', ')}`
+			);
+			return true;
+		}
+		if (blockedGateReasons.length > 0) {
+			log.warn(
+				`SpaceRuntime.recoverStalledRuns: run ${run.id} has downstream transition(s) but gate(s) are closed: ${[
+					...new Set(blockedGateReasons),
+				].join('; ')}`
+			);
+		}
+		return false;
+	}
+
+	private resolveRestartRecoveryTargetNames(
+		channel: WorkflowChannel,
+		workflow: SpaceWorkflow,
+		sourceNodeName: string
+	): string[] {
+		const rawTargets = Array.isArray(channel.to) ? channel.to : [channel.to];
+		if (rawTargets.includes('*')) {
+			return workflow.nodes.map((node) => node.name).filter((name) => name !== sourceNodeName);
+		}
+		return rawTargets;
+	}
+
+	private async evaluateRestartRecoveryChannelGate(
+		runId: string,
+		workflow: SpaceWorkflow,
+		channel: WorkflowChannel
+	): Promise<{ open: boolean; reason?: string }> {
+		if (!channel.gateId) return { open: true };
+		const gate = (workflow.gates ?? []).find((candidate) => candidate.id === channel.gateId);
+		if (!gate) {
+			return {
+				open: false,
+				reason: `Gate "${channel.gateId}" not found — channel "${channel.id}" is closed (misconfiguration)`,
+			};
+		}
+		const gateDataRepo = new GateDataRepository(this.config.db);
+		const runtimeData =
+			gateDataRepo.get(runId, gate.id)?.data ?? computeGateDefaults(gate.fields ?? []);
+		const result = await evaluateGate(gate, runtimeData);
+		return { open: result.open, reason: result.reason };
+	}
+
+	private enqueueRestartRecoveryMessage(
+		run: SpaceWorkflowRun,
+		lastAgentName: string,
+		targetNode: SpaceWorkflow['nodes'][number]
+	): void {
+		const repo = this.config.pendingMessageRepo;
+		if (!repo) return;
+		const tasks = this.config.taskRepo.listByWorkflowRun(run.id);
+		const task = this.pickCanonicalTaskForRun(run, tasks);
+		const message = `[Daemon restart recovery] The previous agent (${lastAgentName}) completed but the handoff message was not delivered. Please check the PR and review status, then continue.`;
+		for (const agentEntry of resolveNodeAgents(targetNode)) {
+			repo.enqueue({
+				workflowRunId: run.id,
+				spaceId: run.spaceId,
+				taskId: task?.id ?? null,
+				sourceAgentName: lastAgentName,
+				targetKind: 'node_agent',
+				targetAgentName: agentEntry.name,
+				message,
+				idempotencyKey: `daemon-restart-recovery:${targetNode.id}:${agentEntry.name}`,
+			});
+		}
 	}
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1557,7 +1557,6 @@ export class SpaceRuntime {
 
 		const nodeByName = new Map(workflow.nodes.map((node) => [node.name, node]));
 		const idleExecutions = executions.filter((execution) => execution.status === 'idle');
-		const idleNodeIds = new Set(idleExecutions.map((execution) => execution.workflowNodeId));
 		const stalledTransitions: Array<{
 			sourceExecution: NodeExecution;
 			sourceNode: SpaceWorkflow['nodes'][number];
@@ -1577,7 +1576,8 @@ export class SpaceRuntime {
 				).filter((targetName) => {
 					const targetNode = nodeByName.get(targetName);
 					return (
-						!targetNode || !idleNodeIds.has(targetNode.id) || targetNode.id === workflow.endNodeId
+						!targetNode ||
+						this.shouldRecoverRestartRecoveryTarget(targetNode, executions, workflow.endNodeId)
 					);
 				});
 				if (targetNames.length === 0) continue;
@@ -1741,6 +1741,23 @@ export class SpaceRuntime {
 		return (
 			channel.from === '*' || channel.from === sourceNode.name || channel.from === sourceAgentName
 		);
+	}
+
+	private shouldRecoverRestartRecoveryTarget(
+		targetNode: SpaceWorkflow['nodes'][number],
+		executions: NodeExecution[],
+		endNodeId?: string
+	): boolean {
+		if (targetNode.id === endNodeId) return true;
+		const executionsByAgent = new Map(
+			executions
+				.filter((execution) => execution.workflowNodeId === targetNode.id)
+				.map((execution) => [execution.agentName, execution])
+		);
+		return resolveNodeAgents(targetNode).some((agentEntry) => {
+			const execution = executionsByAgent.get(agentEntry.name);
+			return !execution || execution.status !== 'idle';
+		});
 	}
 
 	private resolveRestartRecoveryTargetNames(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1630,7 +1630,7 @@ export class SpaceRuntime {
 						.listByNode(run.id, targetNode.id)
 						.find((execution) => execution.agentName === agentEntry.name);
 					if (existing) {
-						if (existing.status === 'idle') {
+						if (existing.status === 'idle' || existing.status === 'cancelled') {
 							this.config.nodeExecutionRepo.update(existing.id, {
 								status: 'pending',
 								agentSessionId: null,

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -788,6 +788,42 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
 		});
 
+		test('coder idle and reviewer cancelled from prior activation → reviewer resets pending', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Coding', agentId: AGENT },
+				{ id: STEP_B, name: 'Review', agentId: AGENT },
+			]);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Recover cancelled reviewer',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Recover cancelled reviewer',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			seedExec(run.id, STEP_A, 'Coding', 'idle');
+			const cancelledReviewer = seedExec(run.id, STEP_B, 'Review', 'cancelled', {
+				agentSessionId: 'cancelled-review-session',
+				result: 'review cancelled during restart',
+			});
+
+			await makeRuntime({
+				pendingMessageRepo: new PendingAgentMessageRepository(db),
+			}).recoverStalledRuns();
+
+			const reviewer = nodeExecutionRepo.getById(cancelledReviewer.id)!;
+			expect(reviewer.status).toBe('pending');
+			expect(reviewer.agentSessionId).toBeNull();
+			expect(reviewer.result).toBeNull();
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
+		});
+
 		test('linear run stalled after later node → only latest handoff is recovered', async () => {
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: STEP_A, name: 'Plan', agentId: AGENT },
@@ -1163,7 +1199,7 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 			});
 		});
 
-		test('multi-node run with all idle/cancelled executions → blocked', async () => {
+		test('multi-node run with no idle source execution → blocked', async () => {
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: STEP_A, name: 'Step A', agentId: AGENT },
 				{ id: STEP_B, name: 'Step B', agentId: AGENT },
@@ -1185,7 +1221,7 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 				status: 'in_progress',
 			});
 
-			seedExec(run.id, STEP_A, 'Step A', 'idle');
+			seedExec(run.id, STEP_A, 'Step A', 'cancelled');
 			seedExec(run.id, STEP_B, 'Step B', 'cancelled');
 
 			const rt = makeRuntime();

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -998,6 +998,57 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
 		});
 
+		test('wildcard target recovery does not broadcast to unrelated nodes', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Coding', agentId: AGENT },
+					{ id: STEP_B, name: 'Docs', agentId: AGENT },
+					{ id: 'step-c', name: 'Review', agentId: AGENT },
+				],
+				{
+					channels: [{ id: 'coding-to-any', from: 'Coding', to: '*' }],
+				}
+			);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Do not broadcast wildcard target',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Do not broadcast wildcard target',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			const coder = seedExec(run.id, STEP_A, 'Coding', 'idle');
+			const docs = seedExec(run.id, STEP_B, 'Docs', 'idle', {
+				agentSessionId: 'dead-docs-session',
+				result: 'docs branch already finished',
+			});
+			const reviewer = seedExec(run.id, 'step-c', 'Review', 'idle', {
+				agentSessionId: 'dead-review-session',
+				result: 'review branch already finished',
+			});
+
+			await makeRuntime({
+				pendingMessageRepo: new PendingAgentMessageRepository(db),
+			}).recoverStalledRuns();
+
+			expect(nodeExecutionRepo.getById(coder.id)?.status).toBe('idle');
+			expect(nodeExecutionRepo.getById(docs.id)?.status).toBe('idle');
+			expect(nodeExecutionRepo.getById(docs.id)?.agentSessionId).toBe('dead-docs-session');
+			expect(nodeExecutionRepo.getById(docs.id)?.result).toBe('docs branch already finished');
+			expect(nodeExecutionRepo.getById(reviewer.id)?.status).toBe('idle');
+			expect(nodeExecutionRepo.getById(reviewer.id)?.agentSessionId).toBe('dead-review-session');
+			expect(nodeExecutionRepo.getById(reviewer.id)?.result).toBe('review branch already finished');
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
+		});
+
 		test('cyclic recovery increments cycle count and resets cycle gates', async () => {
 			const workflow = buildLinearWorkflow(
 				SPACE_ID,

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -862,6 +862,58 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
 		});
 
+		test('multi-agent target recovers missing slot when sibling slot is idle', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Coding', agentId: AGENT },
+					{ id: STEP_B, name: 'Review', agentId: AGENT },
+					{ id: 'step-done', name: 'Done', agentId: AGENT },
+				],
+				{ endNodeId: 'step-done' }
+			);
+			workflow.nodes[1].agents = [
+				{ agentId: AGENT, name: 'Reviewer A' },
+				{ agentId: AGENT, name: 'Reviewer B' },
+			];
+			workflowManager.updateWorkflow(workflow.id, { nodes: workflow.nodes });
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Recover missing reviewer slot',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Recover missing reviewer slot',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			seedExec(run.id, STEP_A, 'Coding', 'idle');
+			const reviewerA = seedExec(run.id, STEP_B, 'Reviewer A', 'idle', {
+				agentSessionId: 'dead-reviewer-a-session',
+				result: 'reviewer A already exited',
+			});
+
+			await makeRuntime({
+				pendingMessageRepo: new PendingAgentMessageRepository(db),
+			}).recoverStalledRuns();
+
+			const reviewExecutions = nodeExecutionRepo.listByNode(run.id, STEP_B);
+			expect(nodeExecutionRepo.getById(reviewerA.id)?.status).toBe('pending');
+			expect(reviewExecutions.map((execution) => execution.agentName)).toContain('Reviewer A');
+			expect(reviewExecutions.map((execution) => execution.agentName)).toContain('Reviewer B');
+			expect(
+				nodeExecutionRepo
+					.listByNode(run.id, STEP_B)
+					.find((execution) => execution.agentName === 'Reviewer B')?.status
+			).toBe('pending');
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
+		});
+
 		test('fan-out recovery only activates the stalled target branch', async () => {
 			const workflow = buildLinearWorkflow(
 				SPACE_ID,

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -41,6 +41,7 @@ import { SpaceAgentRepository } from '../../../../src/storage/repositories/space
 import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
 import { ToolContinuationRecoveryRepository } from '../../../../src/storage/repositories/tool-continuation-recovery-repository.ts';
 import { PendingAgentMessageRepository } from '../../../../src/storage/repositories/pending-agent-message-repository.ts';
+import { ChannelCycleRepository } from '../../../../src/storage/repositories/channel-cycle-repository.ts';
 import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
 import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
@@ -785,6 +786,79 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 
 			expect(findExec(run.id, STEP_B).status).toBe('pending');
 			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
+		});
+
+		test('linear run stalled after later node → only latest handoff is recovered', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Plan', agentId: AGENT },
+				{ id: STEP_B, name: 'Code', agentId: AGENT },
+				{ id: 'step-c', name: 'Review', agentId: AGENT },
+			]);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Recover latest handoff only',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Recover latest handoff only',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			const plan = seedExec(run.id, STEP_A, 'Plan', 'idle');
+			const code = seedExec(run.id, STEP_B, 'Code', 'idle');
+
+			await makeRuntime({
+				pendingMessageRepo: new PendingAgentMessageRepository(db),
+			}).recoverStalledRuns();
+
+			expect(nodeExecutionRepo.getById(plan.id)?.status).toBe('idle');
+			expect(nodeExecutionRepo.getById(code.id)?.status).toBe('idle');
+			expect(findExec(run.id, 'step-c').status).toBe('pending');
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
+		});
+
+		test('cyclic channel at maxCycles → run blocked', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Coding', agentId: AGENT },
+					{ id: STEP_B, name: 'Review', agentId: AGENT },
+				],
+				{
+					channels: [{ id: 'review-to-coding', from: 'Review', to: 'Coding', maxCycles: 1 }],
+				}
+			);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Cycle cap handoff',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Cycle cap handoff',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			seedExec(run.id, STEP_A, 'Coding', 'idle');
+			seedExec(run.id, STEP_B, 'Review', 'idle');
+			new ChannelCycleRepository(db).incrementCycleCount(run.id, 0, 1);
+
+			await makeRuntime({
+				pendingMessageRepo: new PendingAgentMessageRepository(db),
+			}).recoverStalledRuns();
+
+			expect(findExec(run.id, STEP_A).status).toBe('idle');
+			expect(findExec(run.id, STEP_B).status).toBe('idle');
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
+			expect(taskRepo.getTask(task.id)?.blockReason).toBe('execution_failed');
 		});
 
 		test('coder idle with closed script gate → run blocked', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -821,6 +821,112 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
 		});
 
+		test('fan-out recovery only activates the stalled target branch', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Coding', agentId: AGENT },
+					{ id: STEP_B, name: 'Docs', agentId: AGENT },
+					{ id: 'step-c', name: 'Review', agentId: AGENT },
+				],
+				{
+					channels: [
+						{ id: 'coding-to-docs', from: 'Coding', to: 'Docs' },
+						{ id: 'coding-to-review', from: 'Coding', to: 'Review' },
+					],
+				}
+			);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Recover one fan-out branch',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Recover one fan-out branch',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			const coder = seedExec(run.id, STEP_A, 'Coding', 'idle');
+			const docs = seedExec(run.id, STEP_B, 'Docs', 'idle', {
+				agentSessionId: 'dead-docs-session',
+				result: 'docs branch already finished',
+			});
+
+			await makeRuntime({
+				pendingMessageRepo: new PendingAgentMessageRepository(db),
+			}).recoverStalledRuns();
+
+			expect(nodeExecutionRepo.getById(coder.id)?.status).toBe('idle');
+			expect(nodeExecutionRepo.getById(docs.id)?.status).toBe('idle');
+			expect(nodeExecutionRepo.getById(docs.id)?.agentSessionId).toBe('dead-docs-session');
+			expect(nodeExecutionRepo.getById(docs.id)?.result).toBe('docs branch already finished');
+			expect(findExec(run.id, 'step-c').status).toBe('pending');
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
+		});
+
+		test('cyclic recovery increments cycle count and resets cycle gates', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Coding', agentId: AGENT },
+					{ id: STEP_B, name: 'Review', agentId: AGENT },
+				],
+				{
+					channels: [
+						{ id: 'coding-to-review', from: 'Coding', to: 'Review' },
+						{ id: 'review-to-coding', from: 'Review', to: 'Coding', maxCycles: 2 },
+					],
+					gates: [
+						{
+							id: 'cycle-votes',
+							resetOnCycle: true,
+							fields: [{ name: 'votes', type: 'map' }],
+						},
+					],
+					endNodeId: STEP_B,
+				}
+			);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Recover cyclic handoff',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Recover cyclic handoff',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			seedExec(run.id, STEP_B, 'Review', 'idle');
+			db.prepare(
+				`INSERT INTO gate_data (run_id, gate_id, data, updated_at) VALUES (?, ?, ?, ?)`
+			).run(run.id, 'cycle-votes', JSON.stringify({ votes: { reviewer: true } }), Date.now());
+
+			await makeRuntime({
+				pendingMessageRepo: new PendingAgentMessageRepository(db),
+			}).recoverStalledRuns();
+
+			expect(findExec(run.id, STEP_A).status).toBe('pending');
+			expect(new ChannelCycleRepository(db).get(run.id, 1)?.count).toBe(1);
+			expect(
+				JSON.parse(
+					db
+						.prepare(`SELECT data FROM gate_data WHERE run_id = ? AND gate_id = ?`)
+						.get(run.id, 'cycle-votes')?.data as string
+				)
+			).toEqual({ votes: {} });
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
+		});
+
 		test('cyclic channel at maxCycles → run blocked', async () => {
 			const workflow = buildLinearWorkflow(
 				SPACE_ID,

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -821,6 +821,47 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
 		});
 
+		test('agent-name channel recovers handoff when node names differ', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Implementation', agentId: AGENT },
+					{ id: STEP_B, name: 'Verification', agentId: AGENT },
+				],
+				{
+					channels: [{ id: 'coder-to-reviewer', from: 'coder', to: 'reviewer' }],
+				}
+			);
+			workflow.nodes[0].agents[0].name = 'coder';
+			workflow.nodes[1].agents[0].name = 'reviewer';
+			workflowManager.updateWorkflow(workflow.id, { nodes: workflow.nodes });
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Recover agent-name channel',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Recover agent-name channel',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			const coder = seedExec(run.id, STEP_A, 'coder', 'idle');
+
+			await makeRuntime({
+				pendingMessageRepo: new PendingAgentMessageRepository(db),
+			}).recoverStalledRuns();
+
+			expect(nodeExecutionRepo.getById(coder.id)?.status).toBe('idle');
+			expect(findExec(run.id, STEP_B).status).toBe('pending');
+			expect(findExec(run.id, STEP_B).agentName).toBe('reviewer');
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
+		});
+
 		test('fan-out recovery only activates the stalled target branch', async () => {
 			const workflow = buildLinearWorkflow(
 				SPACE_ID,

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -40,6 +40,7 @@ import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-
 import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
 import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
 import { ToolContinuationRecoveryRepository } from '../../../../src/storage/repositories/tool-continuation-recovery-repository.ts';
+import { PendingAgentMessageRepository } from '../../../../src/storage/repositories/pending-agent-message-repository.ts';
 import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
 import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
@@ -76,7 +77,12 @@ function seedAgentRow(db: BunDatabase, agentId: string, spaceId: string): void {
 function buildLinearWorkflow(
 	spaceId: string,
 	workflowManager: SpaceWorkflowManager,
-	nodes: Array<{ id: string; name: string; agentId: string }>
+	nodes: Array<{ id: string; name: string; agentId: string }>,
+	opts: {
+		channels?: SpaceWorkflow['channels'];
+		gates?: SpaceWorkflow['gates'];
+		endNodeId?: string;
+	} = {}
 ): SpaceWorkflow {
 	const transitions = nodes.slice(0, -1).map((step, i) => ({
 		from: step.id,
@@ -90,7 +96,16 @@ function buildLinearWorkflow(
 		description: 'Test',
 		nodes,
 		transitions,
+		channels:
+			opts.channels ??
+			nodes.slice(0, -1).map((step, i) => ({
+				id: `${step.id}-to-${nodes[i + 1].id}`,
+				from: step.name,
+				to: nodes[i + 1].name,
+			})),
+		gates: opts.gates,
 		startNodeId: nodes[0].id,
+		endNodeId: opts.endNodeId ?? nodes.at(-1)?.id,
 		rules: [],
 		tags: [],
 		completionAutonomyLevel: 3,
@@ -504,6 +519,242 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 	});
 
 	describe('runs with all node executions terminal and no completion signal', () => {
+		test('coder idle and reviewer never created → reviewer is activated pending on daemon restart', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Coding', agentId: AGENT },
+				{ id: STEP_B, name: 'Review', agentId: AGENT },
+			]);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Recover missing reviewer',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Recover missing reviewer',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			seedExec(run.id, STEP_A, 'Coding', 'idle');
+			const pendingRepo = new PendingAgentMessageRepository(db);
+
+			await makeRuntime({ pendingMessageRepo: pendingRepo }).recoverStalledRuns();
+
+			const reviewer = findExec(run.id, STEP_B);
+			expect(reviewer.status).toBe('pending');
+			expect(reviewer.agentSessionId).toBeNull();
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
+			expect(taskRepo.getTask(task.id)?.status).toBe('in_progress');
+			expect(pendingRepo.listPendingForTarget(run.id, 'Review')[0].message).toContain(
+				'Daemon restart recovery'
+			);
+		});
+
+		test('coder idle and reviewer idle from previous cycle → reviewer resets to pending', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Coding', agentId: AGENT },
+				{ id: STEP_B, name: 'Review', agentId: AGENT },
+			]);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Recover idle reviewer',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Recover idle reviewer',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			seedExec(run.id, STEP_A, 'Coding', 'idle');
+			const previousReviewer = seedExec(run.id, STEP_B, 'Review', 'idle', {
+				agentSessionId: 'dead-review-session',
+				result: 'previous review finished',
+			});
+
+			await makeRuntime({
+				pendingMessageRepo: new PendingAgentMessageRepository(db),
+			}).recoverStalledRuns();
+
+			const reviewer = nodeExecutionRepo.getById(previousReviewer.id)!;
+			expect(reviewer.status).toBe('pending');
+			expect(reviewer.agentSessionId).toBeNull();
+			expect(reviewer.result).toBeNull();
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
+		});
+
+		test('coder idle with queued handoff and reviewer never created → tick repair creates and spawns reviewer', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Coding', agentId: AGENT },
+				{ id: STEP_B, name: 'Review', agentId: AGENT },
+			]);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Queued handoff repair',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Queued handoff repair',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			seedExec(run.id, STEP_A, 'Coding', 'idle');
+			const pendingRepo = new PendingAgentMessageRepository(db);
+			pendingRepo.enqueue({
+				workflowRunId: run.id,
+				spaceId: SPACE_ID,
+				taskId: task.id,
+				sourceAgentName: 'Coding',
+				targetKind: 'node_agent',
+				targetAgentName: 'Review',
+				message: 'please review',
+			});
+			const live = new Set<string>();
+			const tam = {
+				rehydrate: async () => {},
+				isSessionAlive: (sessionId: string) => live.has(sessionId),
+				getAgentSessionById: () => null,
+				isExecutionSpawning: () => false,
+				tryResumeNodeAgentSession: async () => {},
+				spawnWorkflowNodeAgentForExecution: async (
+					_task: unknown,
+					_space: unknown,
+					_workflow: unknown,
+					_run: unknown,
+					execution: { id: string }
+				) => {
+					const sessionId = `session:${execution.id}`;
+					live.add(sessionId);
+					return sessionId;
+				},
+				flushPendingMessagesForTarget: async (
+					runId: string,
+					agentName: string,
+					sessionId: string
+				) => {
+					for (const row of pendingRepo.listPendingForTarget(runId, agentName))
+						pendingRepo.markDelivered(row.id, sessionId);
+				},
+				cancelBySessionId: () => {},
+				interruptBySessionId: async () => {},
+			};
+
+			await makeRuntime({
+				pendingMessageRepo: pendingRepo,
+				taskAgentManager: tam as any,
+			}).executeTick();
+
+			const reviewer = findExec(run.id, STEP_B);
+			expect(reviewer.status).toBe('in_progress');
+			expect(reviewer.agentSessionId).toBe(`session:${reviewer.id}`);
+			expect(pendingRepo.listAllForRun(run.id)[0].status).toBe('delivered');
+		});
+
+		test('coder idle with blocked coder→reviewer gate → run blocked', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Coding', agentId: AGENT },
+					{ id: STEP_B, name: 'Review', agentId: AGENT },
+				],
+				{
+					channels: [{ id: 'coding-to-review', from: 'Coding', to: 'Review', gateId: 'ready' }],
+					gates: [
+						{
+							id: 'ready',
+							resetOnCycle: false,
+							fields: [{ name: 'pr_url', type: 'string', check: { op: 'exists' as const } }],
+						},
+					],
+				}
+			);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Gate blocked handoff',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Gate blocked handoff',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			seedExec(run.id, STEP_A, 'Coding', 'idle');
+
+			await makeRuntime({
+				pendingMessageRepo: new PendingAgentMessageRepository(db),
+			}).recoverStalledRuns();
+
+			expect(findExec(run.id, STEP_B)).toBeUndefined();
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
+			expect(taskRepo.getTask(task.id)?.blockReason).toBe('execution_failed');
+		});
+
+		test('coder idle with open coder→reviewer gate → reviewer is activated', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Coding', agentId: AGENT },
+					{ id: STEP_B, name: 'Review', agentId: AGENT },
+				],
+				{
+					channels: [{ id: 'coding-to-review', from: 'Coding', to: 'Review', gateId: 'ready' }],
+					gates: [
+						{
+							id: 'ready',
+							resetOnCycle: false,
+							fields: [{ name: 'pr_url', type: 'string', check: { op: 'exists' as const } }],
+						},
+					],
+				}
+			);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Gate open handoff',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Gate open handoff',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			seedExec(run.id, STEP_A, 'Coding', 'idle');
+			db.prepare(
+				`INSERT INTO gate_data (run_id, gate_id, data, updated_at) VALUES (?, ?, ?, ?)`
+			).run(
+				run.id,
+				'ready',
+				JSON.stringify({ pr_url: 'https://github.com/acme/repo/pull/1' }),
+				Date.now()
+			);
+
+			await makeRuntime({
+				pendingMessageRepo: new PendingAgentMessageRepository(db),
+			}).recoverStalledRuns();
+
+			expect(findExec(run.id, STEP_B).status).toBe('pending');
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
+		});
+
 		test('single-node run with idle execution → run blocked, task blocked, notifications emitted', async () => {
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: STEP_A, name: 'Step A', agentId: AGENT },

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -830,7 +830,11 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 					{ id: STEP_B, name: 'Review', agentId: AGENT },
 				],
 				{
-					channels: [{ id: 'review-to-coding', from: 'Review', to: 'Coding', maxCycles: 1 }],
+					channels: [
+						{ id: 'coding-to-review', from: 'Coding', to: 'Review' },
+						{ id: 'review-to-coding', from: 'Review', to: 'Coding', maxCycles: 1 },
+					],
+					endNodeId: STEP_B,
 				}
 			);
 			const run = workflowRunRepo.createRun({
@@ -847,15 +851,14 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 				workflowNodeId: STEP_A,
 				status: 'in_progress',
 			});
-			seedExec(run.id, STEP_A, 'Coding', 'idle');
 			seedExec(run.id, STEP_B, 'Review', 'idle');
-			new ChannelCycleRepository(db).incrementCycleCount(run.id, 0, 1);
+			new ChannelCycleRepository(db).incrementCycleCount(run.id, 1, 1);
 
 			await makeRuntime({
 				pendingMessageRepo: new PendingAgentMessageRepository(db),
 			}).recoverStalledRuns();
 
-			expect(findExec(run.id, STEP_A).status).toBe('idle');
+			expect(findExec(run.id, STEP_A)).toBeUndefined();
 			expect(findExec(run.id, STEP_B).status).toBe('idle');
 			expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
 			expect(taskRepo.getTask(task.id)?.blockReason).toBe('execution_failed');

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -587,6 +587,38 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 			expect(reviewer.agentSessionId).toBeNull();
 			expect(reviewer.result).toBeNull();
 			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
+			const pending = new PendingAgentMessageRepository(db).listPendingForTarget(run.id, 'Review');
+			expect(pending[0].message).toContain("Review node's previous session ended");
+		});
+
+		test('coder cancelled and reviewer never created → run blocked', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Coding', agentId: AGENT },
+				{ id: STEP_B, name: 'Review', agentId: AGENT },
+			]);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Do not recover cancelled source',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Do not recover cancelled source',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			seedExec(run.id, STEP_A, 'Coding', 'cancelled');
+
+			await makeRuntime({
+				pendingMessageRepo: new PendingAgentMessageRepository(db),
+			}).recoverStalledRuns();
+
+			expect(findExec(run.id, STEP_B)).toBeUndefined();
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
+			expect(taskRepo.getTask(task.id)?.blockReason).toBe('execution_failed');
 		});
 
 		test('coder idle with queued handoff and reviewer never created → tick repair creates and spawns reviewer', async () => {
@@ -753,6 +785,53 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 
 			expect(findExec(run.id, STEP_B).status).toBe('pending');
 			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
+		});
+
+		test('coder idle with closed script gate → run blocked', async () => {
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Coding', agentId: AGENT },
+					{ id: STEP_B, name: 'Review', agentId: AGENT },
+				],
+				{
+					channels: [
+						{ id: 'coding-to-review', from: 'Coding', to: 'Review', gateId: 'script-ready' },
+					],
+					gates: [
+						{
+							id: 'script-ready',
+							resetOnCycle: false,
+							fields: [],
+							script: { interpreter: 'bash', source: 'exit 1' },
+						},
+					],
+				}
+			);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Script gate blocked handoff',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Script gate blocked handoff',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			seedExec(run.id, STEP_A, 'Coding', 'idle');
+
+			await makeRuntime({
+				pendingMessageRepo: new PendingAgentMessageRepository(db),
+			}).recoverStalledRuns();
+
+			expect(findExec(run.id, STEP_B)).toBeUndefined();
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
+			expect(taskRepo.getTask(task.id)?.blockReason).toBe('execution_failed');
 		});
 
 		test('single-node run with idle execution → run blocked, task blocked, notifications emitted', async () => {


### PR DESCRIPTION
Recover stalled Coding→Review handoffs after daemon restart by activating downstream node executions when a completed node lost its handoff.

Adds coverage for missing reviewer executions, previous-cycle reviewer resets, queued handoff repair, gated transitions, and genuine no-transition stalls.