### PR TITLE
[codex] Reduce daemon live-query churn

### DIFF
--- a/packages/daemon/src/lib/agent/message-queue.ts
+++ b/packages/daemon/src/lib/agent/message-queue.ts
@@ -70,6 +70,11 @@ export class MessageQueue {
 	 */
 	onMessageYielded?: (messageId: string, sentAt: number) => void;
 
+	private wakeWaiters(): void {
+		this.waiters.forEach((waiter) => waiter());
+		this.waiters = [];
+	}
+
 	/**
 	 * Enqueue a message to be sent to Claude via the streaming query
 	 */
@@ -134,8 +139,7 @@ export class MessageQueue {
 			this.queue.push(queuedMessage);
 
 			// Wake up any waiting message generators
-			this.waiters.forEach((waiter) => waiter());
-			this.waiters = [];
+			this.wakeWaiters();
 		});
 	}
 
@@ -169,6 +173,7 @@ export class MessageQueue {
 		this.running = true;
 		// Increment generation when starting - this invalidates any old generators
 		this.generation++;
+		this.wakeWaiters();
 	}
 
 	/**
@@ -185,8 +190,7 @@ export class MessageQueue {
 	stop(): void {
 		this.running = false;
 		// Wake up any waiting generators so they can exit
-		this.waiters.forEach((waiter) => waiter());
-		this.waiters = [];
+		this.wakeWaiters();
 	}
 
 	/**
@@ -276,8 +280,6 @@ export class MessageQueue {
 			// Wait for message to be enqueued
 			await new Promise<void>((resolve) => {
 				this.waiters.push(resolve);
-				// Also wake up after timeout to check running status
-				setTimeout(resolve, 1000);
 			});
 
 			if (!this.running) return null;

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -1068,11 +1068,11 @@ export class QueryRunner {
 	): AsyncGenerator<unknown, void, unknown> {
 		const iterator = queryObj[Symbol.asyncIterator]();
 		const abortResult = { aborted: true } as const;
-		let resolveAbort: ((value: typeof abortResult) => void) | null = null;
+		let resolveAbort!: (value: typeof abortResult) => void;
 		const abortPromise = new Promise<typeof abortResult>((resolve) => {
 			resolveAbort = resolve;
 		});
-		const onAbort = () => resolveAbort?.(abortResult);
+		const onAbort = () => resolveAbort(abortResult);
 
 		try {
 			if (signal.aborted) {

--- a/packages/daemon/src/lib/agent/query-runner.ts
+++ b/packages/daemon/src/lib/agent/query-runner.ts
@@ -1067,49 +1067,37 @@ export class QueryRunner {
 		signal: AbortSignal
 	): AsyncGenerator<unknown, void, unknown> {
 		const iterator = queryObj[Symbol.asyncIterator]();
-		const abortError = new Error('Query aborted');
-
-		let _abortPromiseReject: ((error: Error) => void) | null = null;
-		const setupAbortPromise = (): Promise<never> => {
-			return new Promise<never>((_, reject) => {
-				_abortPromiseReject = reject;
-				if (signal.aborted) {
-					reject(abortError);
-				} else {
-					signal.addEventListener('abort', () => reject(abortError), { once: true });
-				}
-			});
-		};
+		const abortResult = { aborted: true } as const;
+		let resolveAbort: ((value: typeof abortResult) => void) | null = null;
+		const abortPromise = new Promise<typeof abortResult>((resolve) => {
+			resolveAbort = resolve;
+		});
+		const onAbort = () => resolveAbort?.(abortResult);
 
 		try {
 			if (signal.aborted) {
 				return;
 			}
 
+			signal.addEventListener('abort', onAbort, { once: true });
+
 			while (!signal.aborted) {
 				const nextPromise = iterator.next();
-				const abortPromise = setupAbortPromise();
 
-				try {
-					const result = await Promise.race([nextPromise, abortPromise]);
+				const result = await Promise.race([nextPromise, abortPromise]);
 
-					if (signal.aborted) {
-						break;
-					}
-
-					if (result.done) {
-						break;
-					}
-
-					yield result.value;
-				} catch (error) {
-					if ((error as Error).message === 'Query aborted') {
-						break;
-					}
-					throw error;
+				if ('aborted' in result || signal.aborted) {
+					break;
 				}
+
+				if (result.done) {
+					break;
+				}
+
+				yield result.value;
 			}
 		} finally {
+			signal.removeEventListener('abort', onAbort);
 			try {
 				await iterator.return?.();
 			} catch {

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -31,6 +31,12 @@ export interface NamedQuery {
 	/** Number of positional parameters the SQL expects */
 	paramCount: number;
 	/**
+	 * Optional debounce for table-change reevaluation. Use only for expensive
+	 * feeds fed by high-frequency writes, where latest-state delivery matters
+	 * more than one event per row mutation.
+	 */
+	debounceMs?: number;
+	/**
 	 * Optional row transformer applied after every query execution.
 	 * Must return a plain object whose keys match the frontend TypeScript types.
 	 */
@@ -1652,6 +1658,7 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 		{
 			sql: SESSION_GROUP_MESSAGES_BY_GROUP_SQL,
 			paramCount: 1,
+			debounceMs: 150,
 			mapRow: mapSessionGroupMessageRow,
 		},
 	],
@@ -1660,6 +1667,7 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 		{
 			sql: SPACE_TASK_ACTIVITY_BY_TASK_SQL,
 			paramCount: 1,
+			debounceMs: 250,
 			mapRow: mapSpaceTaskActivityRow,
 		},
 	],
@@ -1668,6 +1676,7 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 		{
 			sql: SPACE_TASK_MESSAGES_BY_TASK_SQL,
 			paramCount: 1,
+			debounceMs: 250,
 			mapRow: mapSpaceTaskMessageRow,
 		},
 	],
@@ -1676,6 +1685,7 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 		{
 			sql: SPACE_TASK_MESSAGES_BY_TASK_COMPACT_SQL,
 			paramCount: 1,
+			debounceMs: 250,
 			mapRow: mapSpaceTaskMessageRow,
 		},
 	],
@@ -1745,6 +1755,7 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 		{
 			sql: MESSAGES_BY_SESSION_SQL,
 			paramCount: 2,
+			debounceMs: 100,
 			mapRow: mapMessageRow,
 		},
 	],
@@ -2012,10 +2023,10 @@ export function setupLiveQueryHandlers(
 					return;
 				}
 
-				// Extract metadata from raw rows (before mapRow strips internal columns).
-				// Params are forwarded so handlers like the compact-thread mapResult can
-				// run a sidecar prepared statement bound to the same task id.
-				const metadata = namedQuery.mapResult?.(diff.rows as Record<string, unknown>[], params);
+				// Metadata is computed by LiveQueryEngine once per cached query
+				// evaluation so identical subscriptions share expensive sidecars
+				// like the compact task feed's active-turn aggregation.
+				const metadata = diff.metadata;
 
 				let message: ReturnType<typeof createEventMessage>;
 
@@ -2068,6 +2079,10 @@ export function setupLiveQueryHandlers(
 						}
 					}
 				}
+			},
+			{
+				debounceMs: namedQuery.debounceMs,
+				getMetadata: namedQuery.mapResult,
 			}
 		);
 

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -57,6 +57,10 @@ export interface NamedQuery {
 	) => Record<string, unknown> | undefined;
 }
 
+const DEBOUNCE_SDK_MESSAGES_MS = 100;
+const DEBOUNCE_SESSION_GROUP_MESSAGES_MS = 150;
+const DEBOUNCE_SPACE_TASK_FEEDS_MS = 250;
+
 // ============================================================================
 // Row mappers
 // ============================================================================
@@ -1658,7 +1662,7 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 		{
 			sql: SESSION_GROUP_MESSAGES_BY_GROUP_SQL,
 			paramCount: 1,
-			debounceMs: 150,
+			debounceMs: DEBOUNCE_SESSION_GROUP_MESSAGES_MS,
 			mapRow: mapSessionGroupMessageRow,
 		},
 	],
@@ -1667,7 +1671,7 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 		{
 			sql: SPACE_TASK_ACTIVITY_BY_TASK_SQL,
 			paramCount: 1,
-			debounceMs: 250,
+			debounceMs: DEBOUNCE_SPACE_TASK_FEEDS_MS,
 			mapRow: mapSpaceTaskActivityRow,
 		},
 	],
@@ -1676,7 +1680,7 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 		{
 			sql: SPACE_TASK_MESSAGES_BY_TASK_SQL,
 			paramCount: 1,
-			debounceMs: 250,
+			debounceMs: DEBOUNCE_SPACE_TASK_FEEDS_MS,
 			mapRow: mapSpaceTaskMessageRow,
 		},
 	],
@@ -1685,7 +1689,7 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 		{
 			sql: SPACE_TASK_MESSAGES_BY_TASK_COMPACT_SQL,
 			paramCount: 1,
-			debounceMs: 250,
+			debounceMs: DEBOUNCE_SPACE_TASK_FEEDS_MS,
 			mapRow: mapSpaceTaskMessageRow,
 		},
 	],
@@ -1755,7 +1759,7 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 		{
 			sql: MESSAGES_BY_SESSION_SQL,
 			paramCount: 2,
-			debounceMs: 100,
+			debounceMs: DEBOUNCE_SDK_MESSAGES_MS,
 			mapRow: mapMessageRow,
 		},
 	],

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -18,7 +18,7 @@ import type {
 	LiveQuerySnapshotEvent,
 	LiveQueryDeltaEvent,
 } from '@neokai/shared';
-import type { LiveQueryEngine, LiveQueryHandle } from '../../storage/live-query';
+import type { LiveQueryEngine, LiveQueryHandle, QueryDiff } from '../../storage/live-query';
 import { Logger } from '../logger';
 
 // ============================================================================
@@ -2004,14 +2004,7 @@ export function setupLiveQueryHandlers(
 		const handle = liveQueries.subscribe(
 			sql,
 			params,
-			(diff: {
-				type: 'snapshot' | 'delta';
-				rows: Record<string, unknown>[];
-				added?: Record<string, unknown>[];
-				removed?: Record<string, unknown>[];
-				updated?: Record<string, unknown>[];
-				version: number;
-			}) => {
+			(diff: QueryDiff<Record<string, unknown>>) => {
 				const router = messageHub.getRouter();
 				if (!router) {
 					// Router not yet registered or already torn down.  Mark snapshot

--- a/packages/daemon/src/storage/live-query.ts
+++ b/packages/daemon/src/storage/live-query.ts
@@ -20,6 +20,25 @@ export interface LiveQueryHandle<T> {
 	dispose(): void;
 }
 
+export interface LiveQuerySubscribeOptions {
+	/**
+	 * Optional debounce for reevaluating this query after a table change.
+	 *
+	 * Default behavior remains microtask-based so normal UI surfaces stay
+	 * immediate. Expensive high-frequency feeds can opt in to a short debounce
+	 * to coalesce bursts of writes into one latest-state delta.
+	 */
+	debounceMs?: number;
+	/**
+	 * Optional metadata builder for the whole result set. It is evaluated once
+	 * per cached query evaluation, not once per subscriber.
+	 */
+	getMetadata?: (
+		rows: Record<string, unknown>[],
+		params: ReadonlyArray<unknown>
+	) => Record<string, unknown> | undefined;
+}
+
 export interface QueryDiff<T = Record<string, unknown>> {
 	type: 'snapshot' | 'delta';
 	rows: T[];
@@ -45,9 +64,26 @@ interface QueryEntry<T extends Record<string, unknown>> {
 	tables: string[];
 	cachedRows: T[];
 	cachedHash: number;
+	cachedRowHashes: Map<unknown, number> | null;
+	cachedMetadata: Record<string, unknown> | undefined;
+	getMetadata:
+		| ((
+				rows: Record<string, unknown>[],
+				params: ReadonlyArray<unknown>
+		  ) => Record<string, unknown> | undefined)
+		| undefined;
 	subscribers: Set<Subscriber<T>>;
-	/** True when a microtask re-evaluation is already queued */
+	/** True when a re-evaluation is already queued */
 	pendingEval: boolean;
+	/** Timer handle when the pending evaluation uses debounceMs instead of a microtask. */
+	pendingTimer: ReturnType<typeof setTimeout> | null;
+	/** Delay used for table-change reevaluations. */
+	debounceMs: number;
+}
+
+interface RowHashSnapshot {
+	hash: number;
+	rowHashes: Map<unknown, number> | null;
 }
 
 // ============================================================================
@@ -104,10 +140,33 @@ export function extractTables(sql: string): string[] {
 	return Array.from(tables);
 }
 
-/** Hash rows using Bun.hash for fast change detection. */
-function hashRows(rows: Record<string, unknown>[]): number {
-	const hash = Bun.hash(JSON.stringify(rows));
+function hashString(value: string): number {
+	const hash = Bun.hash(value);
 	return typeof hash === 'bigint' ? Number(hash) : hash;
+}
+
+/**
+ * Build a compact hash for a result set.
+ *
+ * For the common `id`-keyed path, cache one hash per row so later diffs only
+ * stringify newly fetched rows, not both the previous and next result sets.
+ */
+function hashRows(rows: Record<string, unknown>[]): RowHashSnapshot {
+	const hasId = rows.length > 0 && 'id' in rows[0];
+	if (!hasId) {
+		return { hash: hashString(JSON.stringify(rows)), rowHashes: null };
+	}
+
+	const rowHashes = new Map<unknown, number>();
+	const digestParts: string[] = [String(rows.length)];
+	for (const row of rows) {
+		const id = row['id'];
+		const rowHash = hashString(JSON.stringify(row));
+		rowHashes.set(id, rowHash);
+		digestParts.push(`${String(id).length}:${String(id)}:${rowHash}`);
+	}
+
+	return { hash: hashString(digestParts.join('|')), rowHashes };
 }
 
 /**
@@ -118,7 +177,9 @@ function hashRows(rows: Record<string, unknown>[]): number {
  */
 export function computeDiff<T extends Record<string, unknown>>(
 	oldRows: T[],
-	newRows: T[]
+	newRows: T[],
+	oldRowHashes?: Map<unknown, number> | null,
+	newRowHashes?: Map<unknown, number> | null
 ): { added: T[]; removed: T[]; updated: T[] } {
 	const hasId =
 		(newRows.length > 0 && 'id' in newRows[0]) || (oldRows.length > 0 && 'id' in oldRows[0]);
@@ -149,7 +210,11 @@ export function computeDiff<T extends Record<string, unknown>>(
 		const oldRow = oldById.get(id);
 		if (oldRow === undefined) {
 			added.push(newRow);
-		} else if (JSON.stringify(oldRow) !== JSON.stringify(newRow)) {
+		} else if (
+			oldRowHashes && newRowHashes
+				? oldRowHashes.get(id) !== newRowHashes.get(id)
+				: JSON.stringify(oldRow) !== JSON.stringify(newRow)
+		) {
 			updated.push(newRow);
 		}
 	}
@@ -171,6 +236,8 @@ export class LiveQueryEngine {
 	private queries = new Map<string, QueryEntry<Record<string, unknown>>>();
 	/** Map from table name to set of cache keys that depend on it */
 	private tableIndex = new Map<string, Set<string>>();
+	/** Prepared statements keyed by SQL text, reused across evaluations. */
+	private statements = new Map<string, ReturnType<BunDatabase['prepare']>>();
 	private changeListener: (data: { tables: string[]; versions: Record<string, number> }) => void;
 	private disposed = false;
 
@@ -193,25 +260,33 @@ export class LiveQueryEngine {
 	subscribe<T extends Record<string, unknown>>(
 		sql: string,
 		params: ReadonlyArray<unknown>,
-		onChange: (diff: QueryDiff<T>) => void
+		onChange: (diff: QueryDiff<T>) => void,
+		options: LiveQuerySubscribeOptions = {}
 	): LiveQueryHandle<T> {
 		const cacheKey = sql + '\0' + JSON.stringify(params);
+		const debounceMs = Math.max(0, Math.floor(options.debounceMs ?? 0));
 
 		let entry = this.queries.get(cacheKey) as QueryEntry<T> | undefined;
 
 		if (!entry) {
 			const rows = this.runQuery<T>(sql, params);
-			const hash = hashRows(rows);
+			const hashSnapshot = hashRows(rows);
 			const tables = extractTables(sql);
+			const cachedMetadata = options.getMetadata?.(rows, params);
 
 			entry = {
 				sql,
 				params,
 				tables,
 				cachedRows: rows,
-				cachedHash: hash,
+				cachedHash: hashSnapshot.hash,
+				cachedRowHashes: hashSnapshot.rowHashes,
+				cachedMetadata,
+				getMetadata: options.getMetadata,
 				subscribers: new Set(),
 				pendingEval: false,
+				pendingTimer: null,
+				debounceMs,
 			} as unknown as QueryEntry<T>;
 
 			this.queries.set(cacheKey, entry as unknown as QueryEntry<Record<string, unknown>>);
@@ -224,6 +299,14 @@ export class LiveQueryEngine {
 				}
 				keys.add(cacheKey);
 			}
+		} else {
+			if (debounceMs > entry.debounceMs) {
+				entry.debounceMs = debounceMs;
+			}
+			if (!entry.getMetadata && options.getMetadata) {
+				entry.getMetadata = options.getMetadata;
+				entry.cachedMetadata = options.getMetadata(entry.cachedRows, entry.params);
+			}
 		}
 
 		const subscriber: Subscriber<T> = { onChange, disposed: false };
@@ -235,6 +318,7 @@ export class LiveQueryEngine {
 			type: 'snapshot',
 			rows: (entry as QueryEntry<T>).cachedRows.slice(),
 			version,
+			metadata: (entry as QueryEntry<T>).cachedMetadata,
 		});
 
 		return {
@@ -244,6 +328,9 @@ export class LiveQueryEngine {
 				(entry as QueryEntry<T>).subscribers.delete(subscriber);
 				// Clean up entry if no subscribers remain
 				if ((entry as QueryEntry<T>).subscribers.size === 0) {
+					if ((entry as QueryEntry<T>).pendingTimer) {
+						clearTimeout((entry as QueryEntry<T>).pendingTimer!);
+					}
 					this.queries.delete(cacheKey);
 					for (const table of (entry as QueryEntry<T>).tables) {
 						const keys = this.tableIndex.get(table);
@@ -263,8 +350,14 @@ export class LiveQueryEngine {
 	dispose(): void {
 		this.disposed = true;
 		this.reactiveDb.off('change', this.changeListener as (...args: unknown[]) => void);
+		for (const entry of this.queries.values()) {
+			if (entry.pendingTimer) {
+				clearTimeout(entry.pendingTimer);
+			}
+		}
 		this.queries.clear();
 		this.tableIndex.clear();
+		this.statements.clear();
 	}
 
 	// ============================================================================
@@ -282,7 +375,11 @@ export class LiveQueryEngine {
 			if (!entry || entry.pendingEval) continue;
 
 			entry.pendingEval = true;
-			queueMicrotask(() => this.evaluateQuery(cacheKey));
+			if (entry.debounceMs > 0) {
+				entry.pendingTimer = setTimeout(() => this.evaluateQuery(cacheKey), entry.debounceMs);
+			} else {
+				queueMicrotask(() => this.evaluateQuery(cacheKey));
+			}
 		}
 	}
 
@@ -293,18 +390,27 @@ export class LiveQueryEngine {
 		if (!entry) return;
 
 		entry.pendingEval = false;
+		entry.pendingTimer = null;
 
 		const newRows = this.runQuery(entry.sql, entry.params);
-		const newHash = hashRows(newRows);
+		const newHashSnapshot = hashRows(newRows);
 
-		if (newHash === entry.cachedHash) return;
+		if (newHashSnapshot.hash === entry.cachedHash) return;
 
 		const oldRows = entry.cachedRows;
-		const diff = computeDiff(oldRows, newRows);
+		const newMetadata = entry.getMetadata?.(newRows, entry.params);
+		const diff = computeDiff(
+			oldRows,
+			newRows,
+			entry.cachedRowHashes,
+			newHashSnapshot.rowHashes
+		);
 		const version = this.computeVersion(entry.tables);
 
 		entry.cachedRows = newRows;
-		entry.cachedHash = newHash;
+		entry.cachedHash = newHashSnapshot.hash;
+		entry.cachedRowHashes = newHashSnapshot.rowHashes;
+		entry.cachedMetadata = newMetadata;
 
 		const queryDiff: QueryDiff<Record<string, unknown>> = {
 			type: 'delta',
@@ -313,6 +419,7 @@ export class LiveQueryEngine {
 			removed: diff.removed,
 			updated: diff.updated,
 			version,
+			metadata: newMetadata,
 		};
 
 		for (const subscriber of entry.subscribers) {
@@ -326,7 +433,11 @@ export class LiveQueryEngine {
 		sql: string,
 		params: ReadonlyArray<unknown>
 	): T[] {
-		const stmt = this.db.prepare(sql);
+		let stmt = this.statements.get(sql);
+		if (!stmt) {
+			stmt = this.db.prepare(sql);
+			this.statements.set(sql, stmt);
+		}
 		const paramsArray = Array.from(params) as Parameters<typeof stmt.all>;
 		return stmt.all(...paramsArray) as T[];
 	}

--- a/packages/daemon/src/storage/live-query.ts
+++ b/packages/daemon/src/storage/live-query.ts
@@ -66,6 +66,7 @@ interface QueryEntry<T extends Record<string, unknown>> {
 	cachedHash: number;
 	cachedRowHashes: Map<unknown, number> | null;
 	cachedMetadata: Record<string, unknown> | undefined;
+	cachedMetadataHash: number;
 	getMetadata:
 		| ((
 				rows: Record<string, unknown>[],
@@ -167,6 +168,10 @@ function hashRows(rows: Record<string, unknown>[]): RowHashSnapshot {
 	}
 
 	return { hash: hashString(digestParts.join('|')), rowHashes };
+}
+
+function hashMetadata(metadata: Record<string, unknown> | undefined): number {
+	return metadata === undefined ? 0 : hashString(JSON.stringify(metadata));
 }
 
 /**
@@ -282,6 +287,7 @@ export class LiveQueryEngine {
 				cachedHash: hashSnapshot.hash,
 				cachedRowHashes: hashSnapshot.rowHashes,
 				cachedMetadata,
+				cachedMetadataHash: hashMetadata(cachedMetadata),
 				getMetadata: options.getMetadata,
 				subscribers: new Set(),
 				pendingEval: false,
@@ -306,6 +312,7 @@ export class LiveQueryEngine {
 			if (!entry.getMetadata && options.getMetadata) {
 				entry.getMetadata = options.getMetadata;
 				entry.cachedMetadata = options.getMetadata(entry.cachedRows, entry.params);
+				entry.cachedMetadataHash = hashMetadata(entry.cachedMetadata);
 			}
 		}
 
@@ -394,23 +401,24 @@ export class LiveQueryEngine {
 
 		const newRows = this.runQuery(entry.sql, entry.params);
 		const newHashSnapshot = hashRows(newRows);
+		const newMetadata = entry.getMetadata?.(newRows, entry.params);
+		const newMetadataHash = hashMetadata(newMetadata);
+		const rowsChanged = newHashSnapshot.hash !== entry.cachedHash;
+		const metadataChanged = newMetadataHash !== entry.cachedMetadataHash;
 
-		if (newHashSnapshot.hash === entry.cachedHash) return;
+		if (!rowsChanged && !metadataChanged) return;
 
 		const oldRows = entry.cachedRows;
-		const newMetadata = entry.getMetadata?.(newRows, entry.params);
-		const diff = computeDiff(
-			oldRows,
-			newRows,
-			entry.cachedRowHashes,
-			newHashSnapshot.rowHashes
-		);
+		const diff = rowsChanged
+			? computeDiff(oldRows, newRows, entry.cachedRowHashes, newHashSnapshot.rowHashes)
+			: { added: [], removed: [], updated: [] };
 		const version = this.computeVersion(entry.tables);
 
 		entry.cachedRows = newRows;
 		entry.cachedHash = newHashSnapshot.hash;
 		entry.cachedRowHashes = newHashSnapshot.rowHashes;
 		entry.cachedMetadata = newMetadata;
+		entry.cachedMetadataHash = newMetadataHash;
 
 		const queryDiff: QueryDiff<Record<string, unknown>> = {
 			type: 'delta',

--- a/packages/daemon/src/storage/live-query.ts
+++ b/packages/daemon/src/storage/live-query.ts
@@ -241,7 +241,10 @@ export class LiveQueryEngine {
 	private queries = new Map<string, QueryEntry<Record<string, unknown>>>();
 	/** Map from table name to set of cache keys that depend on it */
 	private tableIndex = new Map<string, Set<string>>();
-	/** Prepared statements keyed by SQL text, reused across evaluations. */
+	/**
+	 * Prepared statements keyed by SQL text. Public subscriptions resolve to
+	 * constant named-query SQL, so this stays bounded by the registry size.
+	 */
 	private statements = new Map<string, ReturnType<BunDatabase['prepare']>>();
 	private changeListener: (data: { tables: string[]; versions: Record<string, number> }) => void;
 	private disposed = false;

--- a/packages/daemon/tests/unit/4-space-storage/storage/live-query.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/live-query.test.ts
@@ -218,6 +218,40 @@ describe('LiveQueryEngine', () => {
 		});
 	});
 
+	describe('debounced reevaluation', () => {
+		const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+		test('coalesces multiple table changes into one latest-state delta', async () => {
+			const diffs: QueryDiff<{ id: string; name: string; val: number }>[] = [];
+			engine.subscribe(SQL, [], (diff) => diffs.push(diff), { debounceMs: 20 });
+
+			insertItem(db, 'a', 'Alpha', 1);
+			mockReactive.bumpAndFire('items');
+			insertItem(db, 'b', 'Beta', 2);
+			mockReactive.bumpAndFire('items');
+
+			await Promise.resolve();
+			expect(diffs.length).toBe(1);
+
+			await wait(35);
+			expect(diffs.length).toBe(2);
+			expect(diffs[1].type).toBe('delta');
+			expect(diffs[1].added?.map((row) => row.id).sort()).toEqual(['a', 'b']);
+		});
+
+		test('clears pending debounced evaluations when last subscriber disposes', async () => {
+			const diffs: QueryDiff<{ id: string; name: string; val: number }>[] = [];
+			const handle = engine.subscribe(SQL, [], (diff) => diffs.push(diff), { debounceMs: 20 });
+
+			insertItem(db, 'a', 'Alpha', 1);
+			mockReactive.bumpAndFire('items');
+			handle.dispose();
+
+			await wait(35);
+			expect(diffs.length).toBe(1);
+		});
+	});
+
 	// -------------------------------------------------------------------------
 	// UPDATE delta
 	// -------------------------------------------------------------------------
@@ -379,6 +413,32 @@ describe('LiveQueryEngine', () => {
 
 			expect(allDiffs.length).toBe(2); // snapshot + delta
 			expect(filteredDiffs.length).toBe(1); // only snapshot; no data change for that query
+		});
+
+		test('shared query metadata is computed once and delivered to all subscribers', async () => {
+			const diffs1: QueryDiff<{ id: string; name: string; val: number }>[] = [];
+			const diffs2: QueryDiff<{ id: string; name: string; val: number }>[] = [];
+			let metadataCalls = 0;
+
+			const getMetadata = (rows: Record<string, unknown>[]) => {
+				metadataCalls += 1;
+				return { count: rows.length };
+			};
+
+			engine.subscribe(SQL, [], (diff) => diffs1.push(diff), { getMetadata });
+			engine.subscribe(SQL, [], (diff) => diffs2.push(diff), { getMetadata });
+
+			expect(metadataCalls).toBe(1);
+			expect(diffs1[0].metadata).toEqual({ count: 0 });
+			expect(diffs2[0].metadata).toEqual({ count: 0 });
+
+			insertItem(db, 'shared', 'Shared', 1);
+			mockReactive.bumpAndFire('items');
+			await Promise.resolve();
+
+			expect(metadataCalls).toBe(2);
+			expect(diffs1[1].metadata).toEqual({ count: 1 });
+			expect(diffs2[1].metadata).toEqual({ count: 1 });
 		});
 	});
 

--- a/packages/daemon/tests/unit/4-space-storage/storage/live-query.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/live-query.test.ts
@@ -440,6 +440,50 @@ describe('LiveQueryEngine', () => {
 			expect(diffs1[1].metadata).toEqual({ count: 1 });
 			expect(diffs2[1].metadata).toEqual({ count: 1 });
 		});
+
+		test('metadata-only changes emit deltas and refresh later snapshots', async () => {
+			insertItem(db, 'meta', 'Metadata', 1);
+
+			const sqlWithSideTable = `
+				SELECT items.id, items.name, items.val
+				FROM items
+				LEFT JOIN other ON other.id = '__never_matches__'
+				ORDER BY items.id
+			`;
+			const diffs1: QueryDiff<{ id: string; name: string; val: number }>[] = [];
+			const diffs2: QueryDiff<{ id: string; name: string; val: number }>[] = [];
+			let metadataCalls = 0;
+
+			const getMetadata = () => {
+				metadataCalls += 1;
+				const row = db.prepare('SELECT COUNT(*) AS count FROM other').get() as { count: number };
+				return { sideCount: row.count };
+			};
+
+			engine.subscribe(sqlWithSideTable, [], (diff) => diffs1.push(diff), { getMetadata });
+
+			expect(metadataCalls).toBe(1);
+			expect(diffs1[0].metadata).toEqual({ sideCount: 0 });
+
+			db.exec(`INSERT INTO other (id, note) VALUES ('side', 'side metadata')`);
+			mockReactive.bumpAndFire('other');
+			await Promise.resolve();
+
+			expect(metadataCalls).toBe(2);
+			expect(diffs1.length).toBe(2);
+			expect(diffs1[1].type).toBe('delta');
+			expect(diffs1[1].rows).toEqual(diffs1[0].rows);
+			expect(diffs1[1].added).toEqual([]);
+			expect(diffs1[1].removed).toEqual([]);
+			expect(diffs1[1].updated).toEqual([]);
+			expect(diffs1[1].metadata).toEqual({ sideCount: 1 });
+
+			engine.subscribe(sqlWithSideTable, [], (diff) => diffs2.push(diff), { getMetadata });
+
+			expect(metadataCalls).toBe(2);
+			expect(diffs2[0].type).toBe('snapshot');
+			expect(diffs2[0].metadata).toEqual({ sideCount: 1 });
+		});
 	});
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Coalesce expensive live-query reevaluations for high-frequency task/message feeds with per-query debounce windows.
- Cache prepared statements and row hashes in the live-query engine to reduce repeated serialization/prepare work.
- Compute live-query metadata once per shared cached query evaluation instead of once per subscriber, reducing duplicate compact-feed active-turn sidecar work.
- Remove the idle 1s wake timer from `MessageQueue` and reduce abort-listener churn in `QueryRunner`.

## Why
The performance review found daemon CPU pressure while tasks are streaming SDK messages, especially around broad `sdk_messages` invalidation and expensive task-feed queries. This PR adds lower-risk mitigations that reduce duplicate work without changing the larger data model.

Follow-up architectural work is tracked in:
- #1751
- #1752
- #1753

## Validation
- `bun test packages/daemon/tests/unit/4-space-storage/storage/live-query.test.ts packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-subscribe.test.ts packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-messages.test.ts packages/daemon/tests/unit/1-core/agent/message-queue.test.ts` — 203 pass, 35 skip, 0 fail
- `bun test packages/daemon/tests/unit/1-core/agent/query-runner.test.ts` — 87 pass, 0 fail
- `bun run typecheck` — pass
- `bun run lint` — pass
- `bunx oxlint .` — pass
- `git diff --check` — pass
- pre-commit hook — pass (`lint`, `biome format`, `typecheck`, `knip`)