### PR TITLE
Guard idle node agents with last-message checks

### DIFF
--- a/packages/daemon/src/lib/space/runtime/last-message-classifier.ts
+++ b/packages/daemon/src/lib/space/runtime/last-message-classifier.ts
@@ -1,0 +1,74 @@
+import type { SDKMessage } from '@neokai/shared/sdk';
+
+export type LastMessageClassification =
+	| { terminal: true; reason: string }
+	| { terminal: false; reason: string };
+
+/**
+ * Classify whether an idle node-agent session ended at a safe terminal point.
+ *
+ * Terminal means the SDK stream clearly reached a final result or a clean
+ * assistant end-turn. Non-terminal means the persisted transcript ends in a
+ * state that can indicate interrupted work (plain user/tool_result input,
+ * thinking-only assistant output, or unresolved tool_use blocks).
+ */
+export function classifyLastMessageForIdleAgent(
+	message: SDKMessage | null | undefined
+): LastMessageClassification {
+	if (!message) return { terminal: false, reason: 'no SDK messages were recorded' };
+
+	if (message.type === 'result') {
+		const subtype =
+			typeof (message as { subtype?: unknown }).subtype === 'string'
+				? (message as { subtype: string }).subtype
+				: 'unknown';
+		return { terminal: true, reason: `SDK result message (${subtype})` };
+	}
+
+	if (message.type !== 'assistant') {
+		return { terminal: false, reason: `last SDK message type is ${message.type}` };
+	}
+
+	const assistant = message as {
+		message?: { content?: unknown; stop_reason?: unknown };
+		error?: unknown;
+	};
+	if (typeof assistant.error === 'string' && assistant.error.length > 0) {
+		return { terminal: true, reason: `assistant error (${assistant.error})` };
+	}
+
+	const content = assistant.message?.content;
+	if (!Array.isArray(content)) {
+		return { terminal: false, reason: 'assistant message content is not an array' };
+	}
+
+	let hasToolUse = false;
+	let hasThinking = false;
+	let hasNonEmptyText = false;
+	for (const block of content) {
+		if (!isRecord(block)) continue;
+		if (block.type === 'tool_use') hasToolUse = true;
+		if (block.type === 'thinking') hasThinking = true;
+		if (block.type === 'text' && typeof block.text === 'string' && block.text.trim().length > 0) {
+			hasNonEmptyText = true;
+		}
+	}
+
+	if (hasToolUse) {
+		return { terminal: false, reason: 'assistant message ended with unresolved tool_use block(s)' };
+	}
+	if (hasThinking && !hasNonEmptyText) {
+		return { terminal: false, reason: 'assistant message ended with thinking block only' };
+	}
+
+	const stopReason = assistant.message?.stop_reason;
+	if (stopReason === 'end_turn') {
+		return { terminal: true, reason: 'assistant end_turn with no pending tool_use' };
+	}
+
+	return { terminal: false, reason: 'assistant message has no terminal end_turn/result signal' };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return !!value && typeof value === 'object' && !Array.isArray(value);
+}

--- a/packages/daemon/src/lib/space/runtime/notification-sink.ts
+++ b/packages/daemon/src/lib/space/runtime/notification-sink.ts
@@ -87,6 +87,27 @@ export interface AgentCrashEvent {
 	timestamp: string;
 }
 
+/** A node agent went idle without a terminal SDK message or reported status. */
+export interface AgentIdleNonTerminalEvent {
+	kind: 'agent_idle_non_terminal';
+	/** Space the task belongs to. */
+	spaceId: string;
+	/** Task whose node agent stopped ambiguously. */
+	taskId: string;
+	/** Workflow run containing the node execution. */
+	runId: string;
+	/** Node execution that went idle ambiguously. */
+	executionId: string;
+	/** Node ID for diagnostics. */
+	nodeId: string;
+	/** Agent slot/name that went idle. */
+	agentName: string;
+	/** Human-readable classifier reason. */
+	reason: string;
+	/** ISO-8601 timestamp when the event was emitted. */
+	timestamp: string;
+}
+
 /** A blocked execution is being automatically retried by the runtime. */
 export interface TaskRetryEvent {
 	kind: 'task_retry';
@@ -252,6 +273,7 @@ export type SpaceNotificationEvent =
 	| WorkflowRunReopenedEvent
 	| AgentAutoCompletedEvent
 	| AgentCrashEvent
+	| AgentIdleNonTerminalEvent
 	| TaskRetryEvent
 	| WorkflowRunNeedsAttentionEvent
 	| TaskAwaitingApprovalEvent;

--- a/packages/daemon/src/lib/space/runtime/session-notification-sink.ts
+++ b/packages/daemon/src/lib/space/runtime/session-notification-sink.ts
@@ -115,6 +115,8 @@ export function formatEventMessage(
 			return formatAgentAutoCompleted(event, autonomyLevel);
 		case 'agent_crash':
 			return formatAgentCrash(event, autonomyLevel);
+		case 'agent_idle_non_terminal':
+			return formatAgentIdleNonTerminal(event, autonomyLevel);
 		case 'task_retry':
 			return formatTaskRetry(event, autonomyLevel);
 		case 'workflow_run_needs_attention':
@@ -299,6 +301,37 @@ function formatAgentCrash(
 		autonomyLevel,
 	};
 	return buildMessage(event.kind, humanReadable, payload);
+}
+
+function formatAgentIdleNonTerminal(
+	event: {
+		kind: 'agent_idle_non_terminal';
+		spaceId: string;
+		taskId: string;
+		runId: string;
+		executionId: string;
+		nodeId: string;
+		agentName: string;
+		reason: string;
+		timestamp: string;
+	},
+	autonomyLevel: SpaceAutonomyLevel
+): string {
+	const humanReadable =
+		`Node ${event.nodeId} (${event.agentName}) in workflow run ${event.runId} went idle with a non-terminal last message. ` +
+		`The runtime will not advance the workflow from this idle state. Reason: ${event.reason}`;
+	return buildMessage(event.kind, humanReadable, {
+		kind: event.kind,
+		spaceId: event.spaceId,
+		taskId: event.taskId,
+		runId: event.runId,
+		executionId: event.executionId,
+		nodeId: event.nodeId,
+		agentName: event.agentName,
+		reason: event.reason,
+		timestamp: event.timestamp,
+		autonomyLevel,
+	});
 }
 
 function formatTaskRetry(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2229,6 +2229,7 @@ export class SpaceRuntime {
 
 				this.config.nodeExecutionRepo.update(execution.id, {
 					status: 'idle',
+					agentSessionId: null,
 					result: `Auto-completed: agent timed out after ${timeoutMinutes} minutes`,
 				});
 				await this.safeNotify({

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -66,6 +66,7 @@ import { GateDataRepository } from '../../../storage/repositories/gate-data-repo
 import { evaluateGate } from './gate-evaluator';
 import { executeGateScript } from './gate-script-executor';
 import { getBuiltInGateScript } from '../workflows/built-in-workflows';
+import { classifyLastMessageForIdleAgent } from './last-message-classifier';
 
 const log = new Logger('space-runtime');
 
@@ -282,6 +283,14 @@ export class SpaceRuntime {
 
 	/** In-memory store of resolved channels per run ID. Replaces run.config._resolvedChannels. */
 	private workflowChannelsMap = new Map<string, WorkflowChannel[]>();
+
+	/**
+	 * Tracks idle executions whose last SDK message was non-terminal.
+	 *
+	 * The counter is intentionally in-memory like crash recovery: transient idle
+	 * ambiguity gets one automatic re-spawn, then escalates if it repeats.
+	 */
+	private nonTerminalIdleCounts = new Map<string, number>();
 	private readonly toolContinuationRepo: ToolContinuationRecoveryRepository;
 
 	constructor(private config: SpaceRuntimeConfig) {
@@ -1491,6 +1500,16 @@ export class SpaceRuntime {
 				canonicalTask.status === 'approved' ||
 				canonicalTask.reportedStatus !== null);
 
+		if (!completionSignalled && canonicalTask) {
+			const nonTerminalIdleOutcome = await this.handleNonTerminalIdleExecutions(
+				run.id,
+				run.spaceId,
+				canonicalTask
+			);
+			if (nonTerminalIdleOutcome === 'blocked') return 'blocked';
+			if (nonTerminalIdleOutcome === 'retried') return 'skipped';
+		}
+
 		if (completionSignalled) {
 			// Tick loop's CompletionDetector + processRunTick will fire on the
 			// next pass and transition the run to `done` (or pick up the
@@ -2234,6 +2253,16 @@ export class SpaceRuntime {
 
 			nodeExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
 
+			const nonTerminalIdleOutcome = await this.handleNonTerminalIdleExecutions(
+				runId,
+				meta.spaceId,
+				canonicalTask
+			);
+			if (nonTerminalIdleOutcome === 'blocked') {
+				return;
+			}
+			nodeExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
+
 			if (
 				canonicalTask.status === 'done' ||
 				canonicalTask.status === 'cancelled' ||
@@ -2691,6 +2720,119 @@ export class SpaceRuntime {
 			reason,
 			timestamp: new Date().toISOString(),
 		});
+	}
+
+	private async handleNonTerminalIdleExecutions(
+		runId: string,
+		spaceId: string,
+		canonicalTask: SpaceTask
+	): Promise<'none' | 'retried' | 'blocked'> {
+		// Explicit task completion or pause signals are authoritative. A final tool
+		// call may have set reportedStatus or parked the task for human/post-approval
+		// review even if the SDK result row has not been persisted yet, so never
+		// retry/block when the task already carries one of those lifecycle signals.
+		if (
+			canonicalTask.reportedStatus !== null ||
+			canonicalTask.status === 'review' ||
+			canonicalTask.status === 'approved' ||
+			canonicalTask.status === 'done' ||
+			canonicalTask.status === 'cancelled'
+		) {
+			return 'none';
+		}
+
+		const idleExecutions = this.config.nodeExecutionRepo
+			.listByWorkflowRun(runId)
+			.filter((execution) => execution.status === 'idle' && execution.agentSessionId);
+		for (const execution of idleExecutions) {
+			const sessionId = execution.agentSessionId;
+			if (!sessionId) continue;
+			const lastMessage = this.getSdkMessageRepo().getLastSDKMessage(sessionId);
+			const classification = classifyLastMessageForIdleAgent(lastMessage);
+			if (classification.terminal) {
+				this.nonTerminalIdleCounts.delete(`${runId}:${execution.id}`);
+				continue;
+			}
+
+			const key = `${runId}:${execution.id}`;
+			const retryCount = (this.nonTerminalIdleCounts.get(key) ?? 0) + 1;
+			this.nonTerminalIdleCounts.set(key, retryCount);
+			const reason = `Agent went idle without completing — non-terminal last message (${classification.reason})`;
+			log.warn(
+				`Node ${execution.workflowNodeId} went idle with non-terminal last message, not advancing: ` +
+					`execution=${execution.id} agent=${execution.agentName} session=${sessionId} reason=${classification.reason}`
+			);
+			await this.safeNotify({
+				kind: 'agent_idle_non_terminal',
+				spaceId,
+				taskId: canonicalTask.id,
+				runId,
+				executionId: execution.id,
+				nodeId: execution.workflowNodeId,
+				agentName: execution.agentName,
+				reason,
+				timestamp: new Date().toISOString(),
+			});
+
+			if (retryCount <= MAX_TASK_AGENT_CRASH_RETRIES) {
+				this.config.nodeExecutionRepo.update(execution.id, {
+					status: 'pending',
+					agentSessionId: null,
+					result: reason,
+					completedAt: null,
+					startedAt: null,
+				});
+				await this.safeNotify({
+					kind: 'task_retry',
+					spaceId,
+					taskId: canonicalTask.id,
+					runId,
+					originalReason: reason,
+					attemptNumber: retryCount,
+					maxAttempts: MAX_TASK_AGENT_CRASH_RETRIES,
+					timestamp: new Date().toISOString(),
+				});
+				return 'retried';
+			}
+
+			this.config.nodeExecutionRepo.update(execution.id, {
+				status: 'blocked',
+				agentSessionId: null,
+				result: reason,
+			});
+			await this.transitionRunStatusAndEmit(runId, 'blocked');
+			await this.updateTaskAndEmit(spaceId, canonicalTask.id, {
+				status: 'blocked',
+				result: reason,
+				blockReason: 'execution_failed',
+				completedAt: null,
+			});
+			await this.safeNotify({
+				kind: 'task_blocked',
+				spaceId,
+				taskId: canonicalTask.id,
+				reason,
+				timestamp: new Date().toISOString(),
+			});
+			await this.safeNotify({
+				kind: 'workflow_run_blocked',
+				spaceId,
+				runId,
+				reason,
+				timestamp: new Date().toISOString(),
+			});
+			await this.safeNotify({
+				kind: 'workflow_run_needs_attention',
+				spaceId,
+				runId,
+				taskId: canonicalTask.id,
+				reason,
+				retriesExhausted: retryCount - 1,
+				timestamp: new Date().toISOString(),
+			});
+			return 'blocked';
+		}
+		return 'none';
 	}
 
 	private async handleWaitingRebindExecutions(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1145,6 +1145,13 @@ export class SpaceRuntime {
 				this.config.pendingMessageRepo.clearTerminalForRun(preTxRunId);
 			}
 			this.blockedRetryCounts.delete(preTxRunId);
+			// Clear non-terminal idle retry counters so a manually recovered run
+			// starts with a fresh retry budget instead of re-blocking immediately.
+			for (const key of this.nonTerminalIdleCounts.keys()) {
+				if (key.startsWith(preTxRunId + ':')) {
+					this.nonTerminalIdleCounts.delete(key);
+				}
+			}
 		}
 
 		const liveSessionIds = new Set<string>();

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2744,7 +2744,8 @@ export class SpaceRuntime {
 			canonicalTask.status === 'review' ||
 			canonicalTask.status === 'approved' ||
 			canonicalTask.status === 'done' ||
-			canonicalTask.status === 'cancelled'
+			canonicalTask.status === 'cancelled' ||
+			canonicalTask.status === 'archived'
 		) {
 			return 'none';
 		}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2831,6 +2831,9 @@ export class SpaceRuntime {
 				retriesExhausted: retryCount - 1,
 				timestamp: new Date().toISOString(),
 			});
+			// Exhaust the blocked-run auto-retry budget so attemptBlockedRunRecovery
+			// escalates immediately instead of re-spawning the agent.
+			this.blockedRetryCounts.set(runId, MAX_BLOCKED_RUN_RETRIES);
 			return 'blocked';
 		}
 		return 'none';

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -239,6 +239,28 @@ export class SDKMessageRepository {
 	}
 
 	/**
+	 * Get the most recently persisted SDK message for a session.
+	 *
+	 * Used by workflow runtime safety checks that need to know whether a node
+	 * agent went idle after a terminal SDK result / clear end-turn, or stopped
+	 * mid-turn (for example after a tool_use without a matching tool_result).
+	 */
+	getLastSDKMessage(sessionId: string): (SDKMessage & { dbId: string; timestamp: number }) | null {
+		const stmt = this.db.prepare(
+			`SELECT id, sdk_message, timestamp FROM sdk_messages
+	       WHERE session_id = ?
+	       ORDER BY timestamp DESC, rowid DESC
+	       LIMIT 1`
+		);
+		const row = stmt.get(sessionId) as {
+			id: string;
+			sdk_message: string;
+			timestamp: string;
+		} | null;
+		return row ? this.inflatePersistedMessage(row) : null;
+	}
+
+	/**
 	 * Get the count of SDK messages for a session
 	 *
 	 * Only counts top-level messages (excludes nested subagent messages with parent_tool_use_id)

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -241,8 +241,10 @@ export class SDKMessageRepository {
 	/**
 	 * Get the most recently persisted top-level SDK message for a session.
 	 *
-	 * Excludes subagent/tool-linked rows (those with a `parent_tool_use_id`)
-	 * so that a subagent `result` cannot shadow a stalled main-thread message.
+	 * Excludes:
+	 * - Subagent/tool-linked rows (those with a `parent_tool_use_id`).
+	 * - User messages still in `deferred`/`enqueued` send_status (not yet consumed
+	 *   by the SDK), so an unsent injectMessage doesn't shadow the real last message.
 	 *
 	 * Used by workflow runtime safety checks that need to know whether a node
 	 * agent went idle after a terminal SDK result / clear end-turn, or stopped
@@ -253,6 +255,7 @@ export class SDKMessageRepository {
 			`SELECT id, sdk_message, timestamp FROM sdk_messages
 	       WHERE session_id = ?
 		       AND json_extract(sdk_message, '$.parent_tool_use_id') IS NULL
+		       AND (message_type != 'user' OR COALESCE(send_status, 'consumed') IN ('consumed', 'failed'))
 	       ORDER BY timestamp DESC, rowid DESC
 	       LIMIT 1`
 		);

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -239,7 +239,10 @@ export class SDKMessageRepository {
 	}
 
 	/**
-	 * Get the most recently persisted SDK message for a session.
+	 * Get the most recently persisted top-level SDK message for a session.
+	 *
+	 * Excludes subagent/tool-linked rows (those with a `parent_tool_use_id`)
+	 * so that a subagent `result` cannot shadow a stalled main-thread message.
 	 *
 	 * Used by workflow runtime safety checks that need to know whether a node
 	 * agent went idle after a terminal SDK result / clear end-turn, or stopped
@@ -249,6 +252,7 @@ export class SDKMessageRepository {
 		const stmt = this.db.prepare(
 			`SELECT id, sdk_message, timestamp FROM sdk_messages
 	       WHERE session_id = ?
+		       AND json_extract(sdk_message, '$.parent_tool_use_id') IS NULL
 	       ORDER BY timestamp DESC, rowid DESC
 	       LIMIT 1`
 		);

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -39,6 +39,20 @@ function makeDb(): BunDatabase {
 	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
+
+	// runMigrations() applies migrations only; these unit fixtures need the base
+	// sdk_messages table because runtime recovery inspects persisted SDK output.
+	db.exec(`CREATE TABLE IF NOT EXISTS sdk_messages (
+		id TEXT PRIMARY KEY,
+		session_id TEXT NOT NULL,
+		message_type TEXT NOT NULL,
+		message_subtype TEXT,
+		sdk_message TEXT NOT NULL,
+		timestamp TEXT NOT NULL,
+		send_status TEXT,
+		origin TEXT
+	)`);
+
 	return db;
 }
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
@@ -65,6 +65,20 @@ function makeDb(): BunDatabase {
 	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
+
+	// runMigrations() applies migrations only; these unit fixtures need the base
+	// sdk_messages table because runtime recovery inspects persisted SDK output.
+	db.exec(`CREATE TABLE IF NOT EXISTS sdk_messages (
+		id TEXT PRIMARY KEY,
+		session_id TEXT NOT NULL,
+		message_type TEXT NOT NULL,
+		message_subtype TEXT,
+		sdk_message TEXT NOT NULL,
+		timestamp TEXT NOT NULL,
+		send_status TEXT,
+		origin TEXT
+	)`);
+
 	return db;
 }
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-notifications.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-notifications.test.ts
@@ -70,6 +70,20 @@ function makeDb(): BunDatabase {
 	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
+
+	// runMigrations() applies migrations only; these unit fixtures need the base
+	// sdk_messages table because runtime recovery inspects persisted SDK output.
+	db.exec(`CREATE TABLE IF NOT EXISTS sdk_messages (
+		id TEXT PRIMARY KEY,
+		session_id TEXT NOT NULL,
+		message_type TEXT NOT NULL,
+		message_subtype TEXT,
+		sdk_message TEXT NOT NULL,
+		timestamp TEXT NOT NULL,
+		send_status TEXT,
+		origin TEXT
+	)`);
+
 	return db;
 }
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-orphan-question.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-orphan-question.test.ts
@@ -40,6 +40,20 @@ function makeDb(): BunDatabase {
 	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
+
+	// runMigrations() applies migrations only; these unit fixtures need the base
+	// sdk_messages table because runtime recovery inspects persisted SDK output.
+	db.exec(`CREATE TABLE IF NOT EXISTS sdk_messages (
+		id TEXT PRIMARY KEY,
+		session_id TEXT NOT NULL,
+		message_type TEXT NOT NULL,
+		message_subtype TEXT,
+		sdk_message TEXT NOT NULL,
+		timestamp TEXT NOT NULL,
+		send_status TEXT,
+		origin TEXT
+	)`);
+
 	return db;
 }
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -389,6 +389,50 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 				true
 			);
 		});
+
+		test('blocked non-terminal idle run sets blockedRetryCounts to prevent auto-retry', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Block retry budget test',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Block retry budget test',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			const execution = seedExec(run.id, STEP_A, 'Step A', 'idle', {
+				agentSessionId: 'non-terminal-blocked-session',
+			});
+			saveAssistantMessage(
+				'non-terminal-blocked-session',
+				[{ type: 'tool_use', id: 'tu-1', name: 'test', input: {} }],
+				null
+			);
+
+			const rt = makeRuntime();
+			// Exhaust retry budget so handleNonTerminalIdleExecutions blocks immediately
+			(rt as any).nonTerminalIdleCounts.set(`${run.id}:${execution.id}`, 3);
+			// Simulate the handler being called directly (as it would be from processRunTick)
+			const outcome = await (rt as any).handleNonTerminalIdleExecutions(
+				run.id,
+				SPACE_ID,
+				taskRepo.getTask(task.id)!
+			);
+
+			expect(outcome).toBe('blocked');
+			expect(nodeExecutionRepo.getById(execution.id)?.status).toBe('blocked');
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
+			// Verify blockedRetryCounts is exhausted so attemptBlockedRunRecovery won't auto-retry
+			expect((rt as any).blockedRetryCounts.get(run.id)).toBeGreaterThanOrEqual(1);
+		});
 	});
 
 	describe('orphaned tool_result waiting_rebind recovery', () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -39,6 +39,7 @@ import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
 import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
 import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
+import { SDKMessageRepository } from '../../../../src/storage/repositories/sdk-message-repository.ts';
 import { ToolContinuationRecoveryRepository } from '../../../../src/storage/repositories/tool-continuation-recovery-repository.ts';
 import { PendingAgentMessageRepository } from '../../../../src/storage/repositories/pending-agent-message-repository.ts';
 import { ChannelCycleRepository } from '../../../../src/storage/repositories/channel-cycle-repository.ts';
@@ -57,6 +58,18 @@ function makeDb(): BunDatabase {
 	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
+	// runMigrations() applies migrations only; these unit fixtures need the base
+	// sdk_messages table because runtime recovery inspects persisted SDK output.
+	db.exec(`CREATE TABLE IF NOT EXISTS sdk_messages (
+		id TEXT PRIMARY KEY,
+		session_id TEXT NOT NULL,
+		message_type TEXT NOT NULL,
+		message_subtype TEXT,
+		sdk_message TEXT NOT NULL,
+		timestamp TEXT NOT NULL,
+		send_status TEXT,
+		origin TEXT
+	)`);
 	return db;
 }
 
@@ -126,6 +139,7 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 	let workflowManager: SpaceWorkflowManager;
 	let spaceManager: SpaceManager;
 	let nodeExecutionRepo: NodeExecutionRepository;
+	let sdkMessageRepo: SDKMessageRepository;
 	let notifications: SpaceRuntimeNotification[];
 
 	const SPACE_ID = 'space-recovery-1';
@@ -142,6 +156,7 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 			workflowRunRepo,
 			taskRepo,
 			nodeExecutionRepo,
+			sdkMessageRepo,
 			...overrides,
 		});
 		rt.setNotificationSink({
@@ -200,6 +215,7 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 		workflowManager = new SpaceWorkflowManager(workflowRepo);
 		spaceManager = new SpaceManager(db);
 		nodeExecutionRepo = new NodeExecutionRepository(db);
+		sdkMessageRepo = new SDKMessageRepository(db);
 		notifications = [];
 	});
 
@@ -211,9 +227,169 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 		}
 	});
 
+	function saveAssistantMessage(sessionId: string, content: unknown[], stopReason: string | null) {
+		sdkMessageRepo.saveSDKMessage(sessionId, {
+			type: 'assistant',
+			session_id: sessionId,
+			uuid: `${sessionId}-assistant-${Date.now()}-${Math.random()}`,
+			parent_tool_use_id: null,
+			message: {
+				id: `${sessionId}-message`,
+				type: 'message',
+				role: 'assistant',
+				model: 'claude-test',
+				content,
+				stop_reason: stopReason,
+				stop_sequence: null,
+				usage: { input_tokens: 1, output_tokens: 1 },
+			},
+		} as any);
+	}
+
 	// -------------------------------------------------------------------------
 	// 1. Stalled with no completion signal → blocked
 	// -------------------------------------------------------------------------
+
+	describe('non-terminal idle last-message recovery', () => {
+		test('idle execution with unresolved tool_use is retried and not advanced', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+			db.prepare(`UPDATE spaces SET paused = 1 WHERE id = ?`).run(SPACE_ID);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Non Terminal Idle Run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Non Terminal Idle Run',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			const execution = seedExec(run.id, STEP_A, 'Step A', 'idle', {
+				agentSessionId: 'non-terminal-session',
+			});
+			saveAssistantMessage(
+				'non-terminal-session',
+				[{ type: 'tool_use', id: 'tool-1', name: 'do_work', input: {} }],
+				'tool_use'
+			);
+
+			const rt = makeRuntime({
+				taskAgentManager: {
+					rehydrate: async () => {},
+					isSessionAlive: () => false,
+					getAgentSessionById: () => null,
+					isExecutionSpawning: () => false,
+				} as any,
+			});
+			(rt as any).recoveryDone = true;
+			await rt.executeTick();
+
+			const updated = nodeExecutionRepo.getById(execution.id)!;
+			expect(updated.status).toBe('pending');
+			expect(updated.agentSessionId).toBeNull();
+			expect(updated.result ?? '').toContain('non-terminal last message');
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
+			expect(taskRepo.getTask(task.id)?.status).toBe('in_progress');
+			expect(notifications.some((event) => event.kind === 'agent_idle_non_terminal')).toBe(true);
+			expect(notifications.some((event) => event.kind === 'task_retry')).toBe(true);
+		});
+
+		test('recoverStalledRuns retries non-terminal idle execution instead of blocking immediately', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+			db.prepare(`UPDATE spaces SET paused = 1 WHERE id = ?`).run(SPACE_ID);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Restart Non Terminal Idle Run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Restart Non Terminal Idle Run',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			const execution = seedExec(run.id, STEP_A, 'Step A', 'idle', {
+				agentSessionId: 'restart-non-terminal-session',
+			});
+			saveAssistantMessage(
+				'restart-non-terminal-session',
+				[{ type: 'tool_use', id: 'tool-restart', name: 'do_work', input: {} }],
+				'tool_use'
+			);
+
+			const rt = makeRuntime();
+			await rt.recoverStalledRuns();
+
+			const updated = nodeExecutionRepo.getById(execution.id)!;
+			expect(updated.status).toBe('pending');
+			expect(updated.agentSessionId).toBeNull();
+			expect(updated.result ?? '').toContain('non-terminal last message');
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('in_progress');
+			expect(taskRepo.getTask(task.id)?.status).toBe('in_progress');
+			expect(notifications.some((event) => event.kind === 'agent_idle_non_terminal')).toBe(true);
+			expect(notifications.some((event) => event.kind === 'task_retry')).toBe(true);
+			expect(notifications.some((event) => event.kind === 'workflow_run_needs_attention')).toBe(
+				false
+			);
+		});
+
+		test('repeated non-terminal idle blocks and escalates after retry limit', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+			db.prepare(`UPDATE spaces SET paused = 1 WHERE id = ?`).run(SPACE_ID);
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Repeated Non Terminal Idle Run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Repeated Non Terminal Idle Run',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			const execution = seedExec(run.id, STEP_A, 'Step A', 'idle', {
+				agentSessionId: 'non-terminal-repeat',
+			});
+			saveAssistantMessage('non-terminal-repeat', [{ type: 'thinking', thinking: 'hmm' }], null);
+			const rt = makeRuntime({
+				taskAgentManager: {
+					rehydrate: async () => {},
+					isSessionAlive: () => false,
+					getAgentSessionById: () => null,
+					isExecutionSpawning: () => false,
+				} as any,
+			});
+			(rt as any).recoveryDone = true;
+			(rt as any).nonTerminalIdleCounts.set(`${run.id}:${execution.id}`, 3);
+			await rt.executeTick();
+
+			const updated = nodeExecutionRepo.getById(execution.id)!;
+			expect(updated.status).toBe('blocked');
+			expect(updated.result).toContain('Agent went idle without completing');
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('blocked');
+			expect(taskRepo.getTask(task.id)?.status).toBe('blocked');
+			expect(taskRepo.getTask(task.id)?.blockReason).toBe('execution_failed');
+			expect(notifications.some((event) => event.kind === 'workflow_run_needs_attention')).toBe(
+				true
+			);
+		});
+	});
 
 	describe('orphaned tool_result waiting_rebind recovery', () => {
 		test('queued continuation resets waiting_rebind execution to pending for one deterministic retry', async () => {
@@ -578,6 +754,13 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 				agentSessionId: 'dead-review-session',
 				result: 'previous review finished',
 			});
+			// Seed a terminal SDK message so the non-terminal idle handler skips
+			// this execution — downstream recovery should reset it instead.
+			saveAssistantMessage(
+				'dead-review-session',
+				[{ type: 'text', text: 'Review complete' }],
+				'end_turn'
+			);
 
 			await makeRuntime({
 				pendingMessageRepo: new PendingAgentMessageRepository(db),
@@ -933,6 +1116,12 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 				agentSessionId: 'dead-reviewer-a-session',
 				result: 'reviewer A already exited',
 			});
+			// Terminal SDK message so non-terminal idle handler skips this execution.
+			saveAssistantMessage(
+				'dead-reviewer-a-session',
+				[{ type: 'text', text: 'Reviewer A done' }],
+				'end_turn'
+			);
 
 			await makeRuntime({
 				pendingMessageRepo: new PendingAgentMessageRepository(db),
@@ -985,6 +1174,13 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 				agentSessionId: 'dead-docs-session',
 				result: 'docs branch already finished',
 			});
+			// Terminal SDK message so non-terminal idle handler skips Docs — it is
+			// a sibling branch that already finished and should stay idle.
+			saveAssistantMessage(
+				'dead-docs-session',
+				[{ type: 'text', text: 'Docs complete' }],
+				'end_turn'
+			);
 
 			await makeRuntime({
 				pendingMessageRepo: new PendingAgentMessageRepository(db),
@@ -1034,6 +1230,18 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 				agentSessionId: 'dead-review-session',
 				result: 'review branch already finished',
 			});
+			// Terminal SDK messages for both sessions so the non-terminal idle
+			// handler skips them — downstream recovery should leave them idle.
+			saveAssistantMessage(
+				'dead-docs-session',
+				[{ type: 'text', text: 'Docs complete' }],
+				'end_turn'
+			);
+			saveAssistantMessage(
+				'dead-review-session',
+				[{ type: 'text', text: 'Review complete' }],
+				'end_turn'
+			);
 
 			await makeRuntime({
 				pendingMessageRepo: new PendingAgentMessageRepository(db),

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
@@ -38,6 +38,20 @@ function makeDb(): BunDatabase {
 	const db = new BunDatabase(':memory:');
 	db.exec('PRAGMA foreign_keys = ON');
 	runMigrations(db, () => {});
+
+	// runMigrations() applies migrations only; these unit fixtures need the base
+	// sdk_messages table because runtime recovery inspects persisted SDK output.
+	db.exec(`CREATE TABLE IF NOT EXISTS sdk_messages (
+		id TEXT PRIMARY KEY,
+		session_id TEXT NOT NULL,
+		message_type TEXT NOT NULL,
+		message_subtype TEXT,
+		sdk_message TEXT NOT NULL,
+		timestamp TEXT NOT NULL,
+		send_status TEXT,
+		origin TEXT
+	)`);
+
 	return db;
 }
 


### PR DESCRIPTION
Classifies idle node-agent sessions by their final SDK message and prevents ambiguous non-terminal exits from advancing silently.

Adds retry/block/escalation handling plus notifications for non-terminal idle exits, with restart recovery coverage and runtime unit tests.