### PR TITLE
Fix OpenRouter model allowlist filtering

### DIFF
--- a/packages/daemon/src/lib/providers/openrouter-provider.ts
+++ b/packages/daemon/src/lib/providers/openrouter-provider.ts
@@ -162,10 +162,7 @@ export class OpenRouterProvider implements Provider {
 
 	private getAllowedModelIds(): Set<string> | null {
 		const envConfigured = this.env.OPENROUTER_ALLOWED_MODELS ?? this.env.OPENROUTER_MODEL_ALLOWLIST;
-		const configured =
-			envConfigured ??
-			this.env.NEOKAI_PROVIDER_MODEL_ALLOWLISTS ??
-			this.env.NEOKAI_PROVIDER_MODEL_ALLOWLIST;
+		const configured = envConfigured ?? this.env.NEOKAI_PROVIDER_MODEL_ALLOWLISTS;
 		if (!configured?.trim()) return null;
 
 		const ids = configured
@@ -210,7 +207,8 @@ export class OpenRouterProvider implements Provider {
 
 			if (!response.ok) {
 				const fallback = this.getConfiguredAllowedModels();
-				return fallback.length > 0 ? fallback : OpenRouterProvider.FALLBACK_MODELS;
+				this.modelCache = fallback.length > 0 ? fallback : OpenRouterProvider.FALLBACK_MODELS;
+				return this.modelCache;
 			}
 
 			const body = (await response.json()) as OpenRouterModelsResponse;
@@ -231,7 +229,8 @@ export class OpenRouterProvider implements Provider {
 			return this.modelCache;
 		} catch {
 			const fallback = this.getConfiguredAllowedModels();
-			return fallback.length > 0 ? fallback : OpenRouterProvider.FALLBACK_MODELS;
+			this.modelCache = fallback.length > 0 ? fallback : OpenRouterProvider.FALLBACK_MODELS;
+			return this.modelCache;
 		}
 	}
 
@@ -268,7 +267,7 @@ export class OpenRouterProvider implements Provider {
 		const allowedIds = this.getAllowedModelIds();
 		if (allowedIds && !allowedIds.has(modelId)) {
 			throw new Error(
-				`OpenRouter model '${modelId}' is not in OPENROUTER_ALLOWED_MODELS. Add it to the allowlist or choose an enabled OpenRouter model.`
+				`OpenRouter model '${modelId}' is not in the configured allowlist. Update it in Settings → Models → OpenRouter Model Allowlist.`
 			);
 		}
 

--- a/packages/daemon/src/lib/providers/openrouter-provider.ts
+++ b/packages/daemon/src/lib/providers/openrouter-provider.ts
@@ -160,9 +160,40 @@ export class OpenRouterProvider implements Provider {
 		return apiKey || undefined;
 	}
 
+	private getAllowedModelIds(): Set<string> | null {
+		const envConfigured = this.env.OPENROUTER_ALLOWED_MODELS ?? this.env.OPENROUTER_MODEL_ALLOWLIST;
+		const configured =
+			envConfigured ??
+			this.env.NEOKAI_PROVIDER_MODEL_ALLOWLISTS ??
+			this.env.NEOKAI_PROVIDER_MODEL_ALLOWLIST;
+		if (!configured?.trim()) return null;
+
+		const ids = configured
+			.split(/[\n,]/)
+			.map((id) => id.trim())
+			.filter(Boolean)
+			.map((entry) => {
+				if (envConfigured !== undefined) return entry;
+				const [provider, ...rest] = entry.split(':');
+				return provider === this.id && rest.length > 0 ? rest.join(':') : '';
+			})
+			.filter(Boolean);
+
+		return ids.length > 0 ? new Set(ids) : null;
+	}
+
+	private getConfiguredAllowedModels(): ModelInfo[] {
+		const allowedIds = this.getAllowedModelIds();
+		if (!allowedIds) return [];
+
+		return Array.from(allowedIds).map((id) => this.toModelInfo({ id }));
+	}
+
 	async getModels(): Promise<ModelInfo[]> {
 		if (!this.isAvailable()) return [];
 		if (this.modelCache) return this.modelCache;
+
+		const allowedIds = this.getAllowedModelIds();
 
 		try {
 			const response = await this.fetchImpl(OpenRouterProvider.MODELS_URL, {
@@ -178,21 +209,29 @@ export class OpenRouterProvider implements Provider {
 			}
 
 			if (!response.ok) {
-				return OpenRouterProvider.FALLBACK_MODELS;
+				const fallback = this.getConfiguredAllowedModels();
+				return fallback.length > 0 ? fallback : OpenRouterProvider.FALLBACK_MODELS;
 			}
 
 			const body = (await response.json()) as OpenRouterModelsResponse;
-			const models = OpenRouterProvider.curateApiModels(
-				(body.data ?? [])
-					.filter((model) => typeof model.id === 'string' && model.id.length > 0)
-					.map((model) => this.toModelInfo(model))
-			);
+			const apiModels = (body.data ?? [])
+				.filter((model) => typeof model.id === 'string' && model.id.length > 0)
+				.filter((model) => !allowedIds || allowedIds.has(model.id))
+				.map((model) => this.toModelInfo(model));
+			const models = allowedIds ? apiModels : OpenRouterProvider.curateApiModels(apiModels);
+			const configuredAllowedModels = this.getConfiguredAllowedModels();
 
-			this.modelCache = models.length > 0 ? models : OpenRouterProvider.FALLBACK_MODELS;
+			this.modelCache =
+				models.length > 0
+					? models
+					: configuredAllowedModels.length > 0
+						? configuredAllowedModels
+						: OpenRouterProvider.FALLBACK_MODELS;
 			this.lastAuthError = undefined;
 			return this.modelCache;
 		} catch {
-			return OpenRouterProvider.FALLBACK_MODELS;
+			const fallback = this.getConfiguredAllowedModels();
+			return fallback.length > 0 ? fallback : OpenRouterProvider.FALLBACK_MODELS;
 		}
 	}
 
@@ -223,6 +262,13 @@ export class OpenRouterProvider implements Provider {
 		if (!isProbablyOpenRouterKey(apiKey)) {
 			throw new Error(
 				'OPENROUTER_API_KEY does not look like an OpenRouter key (expected sk-or-...).'
+			);
+		}
+
+		const allowedIds = this.getAllowedModelIds();
+		if (allowedIds && !allowedIds.has(modelId)) {
+			throw new Error(
+				`OpenRouter model '${modelId}' is not in OPENROUTER_ALLOWED_MODELS. Add it to the allowlist or choose an enabled OpenRouter model.`
 			);
 		}
 

--- a/packages/daemon/src/lib/rpc-handlers/settings-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/settings-handlers.ts
@@ -11,6 +11,12 @@ import type { SettingsManager } from '../settings-manager';
 import type { Database } from '../../storage/database';
 import type { McpImportService } from '../mcp';
 
+async function syncProviderModelAllowlists(allowlists?: Record<string, string[]>): Promise<void> {
+	applyProviderModelAllowlistsToEnv(allowlists);
+	const { clearModelsCache } = await import('../model-service');
+	clearModelsCache();
+}
+
 function applyProviderModelAllowlistsToEnv(allowlists?: Record<string, string[]>): void {
 	if (!allowlists || Object.keys(allowlists).length === 0) {
 		delete process.env.NEOKAI_PROVIDER_MODEL_ALLOWLISTS;
@@ -53,9 +59,7 @@ export function registerSettingsHandlers(
 		async (data: { updates: Partial<GlobalSettings> }) => {
 			const updated = settingsManager.updateGlobalSettings(data.updates);
 			if (data.updates.providerModelAllowlists !== undefined) {
-				applyProviderModelAllowlistsToEnv(data.updates.providerModelAllowlists);
-				const { clearModelsCache } = await import('../model-service');
-				clearModelsCache();
+				await syncProviderModelAllowlists(data.updates.providerModelAllowlists);
 			}
 			// Emit event for StateManager to broadcast (global event)
 			daemonHub.emit('settings.updated', {
@@ -74,6 +78,9 @@ export function registerSettingsHandlers(
 	 */
 	messageHub.onRequest('settings.global.save', async (data: { settings: GlobalSettings }) => {
 		settingsManager.saveGlobalSettings(data.settings);
+		if (data.settings.providerModelAllowlists !== undefined) {
+			await syncProviderModelAllowlists(data.settings.providerModelAllowlists);
+		}
 		// Emit event for StateManager to broadcast (global event)
 		daemonHub.emit('settings.updated', {
 			sessionId: 'global',

--- a/packages/daemon/src/lib/rpc-handlers/settings-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/settings-handlers.ts
@@ -11,6 +11,26 @@ import type { SettingsManager } from '../settings-manager';
 import type { Database } from '../../storage/database';
 import type { McpImportService } from '../mcp';
 
+function applyProviderModelAllowlistsToEnv(allowlists?: Record<string, string[]>): void {
+	if (!allowlists || Object.keys(allowlists).length === 0) {
+		delete process.env.NEOKAI_PROVIDER_MODEL_ALLOWLISTS;
+		return;
+	}
+
+	const entries = Object.entries(allowlists).flatMap(([provider, models]) =>
+		models
+			.map((model) => model.trim())
+			.filter(Boolean)
+			.map((model) => `${provider}:${model}`)
+	);
+
+	if (entries.length === 0) {
+		delete process.env.NEOKAI_PROVIDER_MODEL_ALLOWLISTS;
+	} else {
+		process.env.NEOKAI_PROVIDER_MODEL_ALLOWLISTS = entries.join('\n');
+	}
+}
+
 export function registerSettingsHandlers(
 	messageHub: MessageHub,
 	settingsManager: SettingsManager,
@@ -32,6 +52,11 @@ export function registerSettingsHandlers(
 		'settings.global.update',
 		async (data: { updates: Partial<GlobalSettings> }) => {
 			const updated = settingsManager.updateGlobalSettings(data.updates);
+			if (data.updates.providerModelAllowlists !== undefined) {
+				applyProviderModelAllowlistsToEnv(data.updates.providerModelAllowlists);
+				const { clearModelsCache } = await import('../model-service');
+				clearModelsCache();
+			}
 			// Emit event for StateManager to broadcast (global event)
 			daemonHub.emit('settings.updated', {
 				sessionId: 'global',

--- a/packages/daemon/tests/unit/1-core/providers/openrouter-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openrouter-provider.test.ts
@@ -176,6 +176,57 @@ describe('OpenRouterProvider', () => {
 		expect(models.at(-1)?.id).toBe('community/model-29');
 	});
 
+	it('filters OpenRouter models to configured account allowlist', async () => {
+		process.env.OPENROUTER_API_KEY = 'sk-or-test';
+		process.env.OPENROUTER_ALLOWED_MODELS = 'xai/grok-4.3, deepseek/deepseek-v4-pro';
+		const fetchMock = mock(
+			async () =>
+				new Response(
+					JSON.stringify({
+						data: [
+							{ id: 'xai/grok-4.3', name: 'Grok 4.3' },
+							{ id: 'deepseek/deepseek-v4-pro', name: 'DeepSeek V4 Pro' },
+							{ id: 'anthropic/claude-sonnet-4.6', name: 'Claude Sonnet 4.6' },
+						],
+					}),
+					{ status: 200 }
+				)
+		);
+		const provider = new OpenRouterProvider(process.env, fetchMock as unknown as typeof fetch);
+
+		const models = await provider.getModels();
+
+		expect(models.map((model) => model.id)).toEqual(['xai/grok-4.3', 'deepseek/deepseek-v4-pro']);
+	});
+
+	it('uses configured account allowlist when OpenRouter model metadata cannot be fetched', async () => {
+		process.env.OPENROUTER_API_KEY = 'sk-or-test';
+		process.env.OPENROUTER_ALLOWED_MODELS = 'qwen/qwen3.6-max-preview\ngoogle/gemma-4-31b:free';
+		const fetchMock = mock(async () => new Response('Bad gateway', { status: 502 }));
+		const provider = new OpenRouterProvider(process.env, fetchMock as unknown as typeof fetch);
+
+		const models = await provider.getModels();
+
+		expect(models.map((model) => model.id)).toEqual([
+			'qwen/qwen3.6-max-preview',
+			'google/gemma-4-31b:free',
+		]);
+		expect(models.every((model) => model.provider === 'openrouter')).toBe(true);
+	});
+
+	it('rejects SDK config for OpenRouter models outside the configured allowlist', () => {
+		process.env.OPENROUTER_API_KEY = 'sk-or-test';
+		process.env.OPENROUTER_ALLOWED_MODELS = 'xai/grok-4.3';
+		const provider = new OpenRouterProvider();
+
+		expect(() => provider.buildSdkConfig('anthropic/claude-sonnet-4.6')).toThrow(
+			"OpenRouter model 'anthropic/claude-sonnet-4.6' is not in OPENROUTER_ALLOWED_MODELS"
+		);
+		expect(provider.buildSdkConfig('xai/grok-4.3').envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe(
+			'xai/grok-4.3'
+		);
+	});
+
 	it('surfaces rejected API keys through auth status and hides models', async () => {
 		process.env.OPENROUTER_API_KEY = 'sk-or-test';
 		const fetchMock = mock(async () => new Response('Unauthorized', { status: 401 }));

--- a/packages/daemon/tests/unit/1-core/providers/openrouter-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openrouter-provider.test.ts
@@ -199,18 +199,45 @@ describe('OpenRouterProvider', () => {
 		expect(models.map((model) => model.id)).toEqual(['xai/grok-4.3', 'deepseek/deepseek-v4-pro']);
 	});
 
-	it('uses configured account allowlist when OpenRouter model metadata cannot be fetched', async () => {
+	it('parses UI-driven provider-prefixed OpenRouter allowlist', async () => {
+		process.env.OPENROUTER_API_KEY = 'sk-or-test';
+		process.env.NEOKAI_PROVIDER_MODEL_ALLOWLISTS =
+			'openrouter:xai/grok-4.3\nanthropic:claude-sonnet-4.6\nopenrouter:qwen/qwen3.6-max-preview';
+		const fetchMock = mock(
+			async () =>
+				new Response(
+					JSON.stringify({
+						data: [
+							{ id: 'xai/grok-4.3', name: 'Grok 4.3' },
+							{ id: 'qwen/qwen3.6-max-preview', name: 'Qwen3.6 Max Preview' },
+							{ id: 'anthropic/claude-sonnet-4.6', name: 'Claude Sonnet 4.6' },
+						],
+					}),
+					{ status: 200 }
+				)
+		);
+		const provider = new OpenRouterProvider(process.env, fetchMock as unknown as typeof fetch);
+
+		const models = await provider.getModels();
+
+		expect(models.map((model) => model.id)).toEqual(['xai/grok-4.3', 'qwen/qwen3.6-max-preview']);
+	});
+
+	it('uses and caches configured account allowlist when OpenRouter model metadata cannot be fetched', async () => {
 		process.env.OPENROUTER_API_KEY = 'sk-or-test';
 		process.env.OPENROUTER_ALLOWED_MODELS = 'qwen/qwen3.6-max-preview\ngoogle/gemma-4-31b:free';
 		const fetchMock = mock(async () => new Response('Bad gateway', { status: 502 }));
 		const provider = new OpenRouterProvider(process.env, fetchMock as unknown as typeof fetch);
 
 		const models = await provider.getModels();
+		const cachedModels = await provider.getModels();
 
 		expect(models.map((model) => model.id)).toEqual([
 			'qwen/qwen3.6-max-preview',
 			'google/gemma-4-31b:free',
 		]);
+		expect(cachedModels).toBe(models);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
 		expect(models.every((model) => model.provider === 'openrouter')).toBe(true);
 	});
 
@@ -220,7 +247,7 @@ describe('OpenRouterProvider', () => {
 		const provider = new OpenRouterProvider();
 
 		expect(() => provider.buildSdkConfig('anthropic/claude-sonnet-4.6')).toThrow(
-			"OpenRouter model 'anthropic/claude-sonnet-4.6' is not in OPENROUTER_ALLOWED_MODELS"
+			"OpenRouter model 'anthropic/claude-sonnet-4.6' is not in the configured allowlist"
 		);
 		expect(provider.buildSdkConfig('xai/grok-4.3').envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe(
 			'xai/grok-4.3'

--- a/packages/shared/src/types/settings.ts
+++ b/packages/shared/src/types/settings.ts
@@ -125,6 +125,15 @@ export interface GlobalSettings extends SDKSupportedSettings, FileOnlySettings {
 	// Setting sources to load (all enabled by default)
 	settingSources: SettingSource[];
 
+	/**
+	 * Optional per-provider model allowlists. When a provider has entries here,
+	 * model selection UIs and runtime validation only allow the listed model IDs.
+	 * This is needed for providers such as OpenRouter where account-enabled model
+	 * restrictions are configured in the provider dashboard but are not exposed by
+	 * the provider's public models API.
+	 */
+	providerModelAllowlists?: Record<string, string[]>;
+
 	// Default thinking level for new sessions
 	// Maps to maxThinkingTokens in SDK options
 	thinkingLevel?: ThinkingLevel;

--- a/packages/web/src/components/settings/ModelsSettings.tsx
+++ b/packages/web/src/components/settings/ModelsSettings.tsx
@@ -675,7 +675,7 @@ export function ModelsSettings() {
 				<textarea
 					value={openRouterAllowlistText}
 					onInput={(e) => setOpenRouterAllowlistText(e.currentTarget.value)}
-					placeholder="xai/grok-4.3\nqwen/qwen3.6-max-preview\ndeepseek/deepseek-v4-pro"
+					placeholder={`xai/grok-4.3\nqwen/qwen3.6-max-preview\ndeepseek/deepseek-v4-pro`}
 					class="w-full h-28 bg-dark-900 border border-dark-600 rounded px-3 py-2 text-sm text-gray-100 placeholder:text-gray-600 focus:outline-none focus:border-blue-500 font-mono"
 				/>
 				<Button

--- a/packages/web/src/components/settings/ModelsSettings.tsx
+++ b/packages/web/src/components/settings/ModelsSettings.tsx
@@ -462,6 +462,9 @@ export function ModelsSettings() {
 	const [modelFallbackMap, setModelFallbackMap] = useState<Record<string, FallbackModelEntry[]>>(
 		settings?.modelFallbackMap ?? {}
 	);
+	const [openRouterAllowlistText, setOpenRouterAllowlistText] = useState(
+		(settings?.providerModelAllowlists?.openrouter ?? []).join('\n')
+	);
 	const [availableModels, setAvailableModels] = useState<ModelInfo[]>([]);
 	const [providerAuthStatuses, setProviderAuthStatuses] = useState<Map<string, ProviderAuthStatus>>(
 		new Map()
@@ -484,6 +487,7 @@ export function ModelsSettings() {
 		if (settings) {
 			setFallbackModels(settings.fallbackModels ?? []);
 			setModelFallbackMap(settings.modelFallbackMap ?? {});
+			setOpenRouterAllowlistText((settings.providerModelAllowlists?.openrouter ?? []).join('\n'));
 		}
 	}, [settings]);
 
@@ -507,6 +511,35 @@ export function ModelsSettings() {
 			authMap.set(p.id, p);
 		}
 		setProviderAuthStatuses(authMap);
+	};
+
+	const saveOpenRouterAllowlist = async () => {
+		const openrouter = Array.from(
+			new Set(
+				openRouterAllowlistText
+					.split(/[\n,]/)
+					.map((id) => id.trim())
+					.filter(Boolean)
+			)
+		);
+		const nextAllowlists = { ...settings?.providerModelAllowlists };
+		if (openrouter.length > 0) {
+			nextAllowlists.openrouter = openrouter;
+		} else {
+			delete nextAllowlists.openrouter;
+		}
+
+		setIsUpdating(true);
+		try {
+			await updateGlobalSettings({ providerModelAllowlists: nextAllowlists });
+			setOpenRouterAllowlistText(openrouter.join('\n'));
+			toast.success('OpenRouter model allowlist updated');
+			await fetchModels(true);
+		} catch {
+			toast.error('Failed to update OpenRouter model allowlist');
+		} finally {
+			setIsUpdating(false);
+		}
 	};
 
 	const handleRefresh = async () => {
@@ -630,6 +663,31 @@ export function ModelsSettings() {
 
 	return (
 		<SettingsSection title="Models">
+			<div class="mb-6 space-y-2">
+				<div>
+					<h4 class="text-sm font-medium text-gray-300">OpenRouter Model Allowlist</h4>
+					<p class="text-xs text-gray-500 mt-0.5">
+						OpenRouter does not expose dashboard-enabled account models through its public API. Add
+						one model ID per line to limit model pickers and runtime validation to models you have
+						enabled on OpenRouter.
+					</p>
+				</div>
+				<textarea
+					value={openRouterAllowlistText}
+					onInput={(e) => setOpenRouterAllowlistText(e.currentTarget.value)}
+					placeholder="xai/grok-4.3\nqwen/qwen3.6-max-preview\ndeepseek/deepseek-v4-pro"
+					class="w-full h-28 bg-dark-900 border border-dark-600 rounded px-3 py-2 text-sm text-gray-100 placeholder:text-gray-600 focus:outline-none focus:border-blue-500 font-mono"
+				/>
+				<Button
+					variant="primary"
+					size="xs"
+					onClick={saveOpenRouterAllowlist}
+					disabled={isUpdating}
+					loading={isUpdating}
+				>
+					Save OpenRouter allowlist
+				</Button>
+			</div>
 			<div class="flex items-center gap-2 mb-4">
 				<Button
 					variant="ghost"


### PR DESCRIPTION
Fixes the OpenRouter model picker showing the global model catalog when users only enabled a smaller dashboard allowlist.

Adds a settings-managed OpenRouter allowlist, filters returned OpenRouter models to that list, clears model caches on allowlist changes, and rejects runtime SDK config for disallowed OpenRouter models.

Tests: bun run typecheck && bun run lint && bun test packages/daemon/tests/unit/1-core/providers/openrouter-provider.test.ts