### PR TITLE
Fix chat autoscroll padding

### DIFF
--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -7,8 +7,6 @@
  * Refactored to use shared hooks for better separation of concerns.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
-import type { ComponentChildren } from 'preact';
 import type {
 	MessageDeliveryMode,
 	MessageImage,
@@ -16,22 +14,24 @@ import type {
 	ReferenceMention,
 	SessionType,
 } from '@neokai/shared';
-import { isAgentWorking } from '../lib/state.ts';
+import type { ComponentChildren } from 'preact';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks';
+import {
+	useCommandAutocomplete,
+	useFileAttachments,
+	useInputDraft,
+	useInterrupt,
+	useModal,
+	useModelSwitcher,
+	useReferenceAutocomplete,
+} from '../hooks';
 import { connectionManager } from '../lib/connection-manager';
 import { getMessagesBottomPaddingPx } from '../lib/layout-metrics.ts';
+import { isAgentWorking } from '../lib/state.ts';
 import { AttachmentPreview } from './AttachmentPreview.tsx';
 import { InputActionsMenu } from './InputActionsMenu.tsx';
 import { InputTextarea } from './InputTextarea.tsx';
 import { ContentContainer } from './ui/ContentContainer.tsx';
-import {
-	useInputDraft,
-	useModelSwitcher,
-	useModal,
-	useCommandAutocomplete,
-	useReferenceAutocomplete,
-	useFileAttachments,
-	useInterrupt,
-} from '../hooks';
 
 /**
  * Replace the active @query at the end of `content` with a formatted reference token.
@@ -309,7 +309,7 @@ export default function MessageInput({
 		void refreshQueuedMessages();
 	}, [refreshQueuedMessages]);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		syncMessagesContainerPadding();
 	}, [syncMessagesContainerPadding]);
 

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -6,7 +6,7 @@ import {
 	type SpaceTaskStatus,
 } from '@neokai/shared';
 import type { ComponentChildren } from 'preact';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { borderColors } from '../../lib/design-tokens';
 import {
 	navigateToSpaceTask,
@@ -17,8 +17,8 @@ import { currentSpaceIdSignal, currentSpaceTaskViewTabSignal } from '../../lib/s
 import { spaceStore } from '../../lib/space-store';
 import { resolveActiveTaskBanner } from '../../lib/task-banner.ts';
 import { cn } from '../../lib/utils';
-import { Dropdown, type DropdownMenuItem } from '../ui/Dropdown';
 import { ScrollToBottomButton } from '../ScrollToBottomButton';
+import { Dropdown, type DropdownMenuItem } from '../ui/Dropdown';
 import { PendingGateBanner } from './PendingGateBanner';
 import { PendingPostApprovalBanner } from './PendingPostApprovalBanner';
 import { PendingTaskCompletionBanner } from './PendingTaskCompletionBanner';
@@ -27,7 +27,7 @@ import { SpaceTaskUnifiedThread } from './SpaceTaskUnifiedThread';
 import { SubmitForReviewModal } from './SubmitForReviewModal';
 import { TaskArtifactsPanel } from './TaskArtifactsPanel';
 import { TaskBlockedBanner } from './TaskBlockedBanner';
-import { TaskSessionChatComposer, type TaskComposerTarget } from './TaskSessionChatComposer';
+import { type TaskComposerTarget, TaskSessionChatComposer } from './TaskSessionChatComposer';
 import { getTransitionActions } from './TaskStatusActions';
 import { useRunGateSummaries } from './use-run-gate-summaries.ts';
 
@@ -173,7 +173,9 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	const [autoScrollEnabled, setAutoScrollEnabled] = useState(true);
 	const [showScrollButton, setShowScrollButton] = useState(false);
 	const [threadScroller, setThreadScroller] = useState<HTMLDivElement | null>(null);
+	const [taskComposerPaddingPx, setTaskComposerPaddingPx] = useState(144);
 	const threadPanelRef = useRef<HTMLDivElement>(null);
+	const taskComposerRef = useRef<HTMLDivElement>(null);
 	const scrollToBottomRef = useRef<((smooth?: boolean) => void) | null>(null);
 	const draftWasActiveRef = useRef(false);
 	// Modal-local error feedback. Separate from `threadSendError` because
@@ -335,6 +337,32 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	const hasUnifiedWorkflowThread =
 		!!task.workflowRunId || !!agentSessionId || activityMembers.length > 0;
 	const showInlineComposer = !isTerminalTask;
+
+	useLayoutEffect(() => {
+		if (!showInlineComposer) {
+			setTaskComposerPaddingPx(12);
+			return;
+		}
+
+		const composer = taskComposerRef.current;
+		if (!composer) return;
+
+		const syncComposerPadding = () => {
+			const composerHeight = Math.max(
+				composer.getBoundingClientRect().height,
+				composer.scrollHeight
+			);
+			setTaskComposerPaddingPx(Math.max(144, Math.ceil(composerHeight) + 16));
+		};
+
+		syncComposerPadding();
+
+		const resizeObserver = new ResizeObserver(syncComposerPadding);
+		resizeObserver.observe(composer);
+
+		return () => resizeObserver.disconnect();
+	}, [showInlineComposer, threadSendError]);
+
 	const canSendThreadMessage = !isTerminalTask && !ensuringThread && !sendingThread;
 	const canShowCanvasTab = !!task.workflowRunId && !!canvasWorkflowId;
 	const canShowArtifactsTab = !!task.workflowRunId;
@@ -854,26 +882,16 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 						class="h-full"
 					/>
 				) : (
-					<div class="h-full flex flex-col relative">
+					<div
+						class="h-full flex flex-col relative"
+						style={`--task-composer-offset: ${taskComposerPaddingPx}px;`}
+					>
 						<div ref={threadPanelRef} class="flex-1 min-h-0" data-testid="task-thread-panel">
 							{hasUnifiedWorkflowThread ? (
 								<SpaceTaskUnifiedThread
 									taskId={task.id}
 									topInsetClass="pt-12"
-									bottomInsetClass={
-										showInlineComposer
-											? threadSendError
-												? 'pb-52 sm:pb-44'
-												: 'pb-44 sm:pb-36'
-											: 'pb-3'
-									}
-									bottomScrollPaddingClass={
-										showInlineComposer
-											? threadSendError
-												? 'scroll-pb-52 sm:scroll-pb-44'
-												: 'scroll-pb-44 sm:scroll-pb-36'
-											: 'scroll-pb-3'
-									}
+									bottomInsetPx={taskComposerPaddingPx}
 									activeAgentLabels={activeAgentLabels}
 									autoScrollEnabled={autoScrollEnabled}
 									onShowScrollButtonChange={setShowScrollButton}
@@ -903,35 +921,37 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 						{showScrollButton && (
 							<ScrollToBottomButton
 								onClick={handleScrollToBottom}
-								bottomClass={threadSendError ? 'bottom-52 sm:bottom-44' : 'bottom-44 sm:bottom-36'}
+								bottomClass="bottom-[var(--task-composer-offset)]"
 								autoScroll={autoScrollEnabled}
 							/>
 						)}
 
 						{showInlineComposer && (
-							<TaskSessionChatComposer
-								sessionId={agentSessionId ?? ''}
-								mentionCandidates={mentionCandidates}
-								targets={composerTargets}
-								selectedTargetId={selectedTarget?.id ?? null}
-								hasTaskAgentSession={!!agentSessionId}
-								canSend={canSendThreadMessage}
-								isSending={sendingThread}
-								isProcessing={isAgentActive}
-								autoScroll={autoScrollEnabled}
-								errorMessage={threadSendError}
-								onAutoScrollChange={setAutoScrollEnabled}
-								onTargetSelect={(targetId) => {
-									setSelectedTargetId(targetId);
-									setTargetLocked(true);
-								}}
-								onDraftActiveChange={(hasDraft) => {
-									setHasComposerDraft(hasDraft);
-									if (draftWasActiveRef.current && !hasDraft) setTargetLocked(false);
-									draftWasActiveRef.current = hasDraft;
-								}}
-								onSend={sendThreadMessage}
-							/>
+							<div ref={taskComposerRef}>
+								<TaskSessionChatComposer
+									sessionId={agentSessionId ?? ''}
+									mentionCandidates={mentionCandidates}
+									targets={composerTargets}
+									selectedTargetId={selectedTarget?.id ?? null}
+									hasTaskAgentSession={!!agentSessionId}
+									canSend={canSendThreadMessage}
+									isSending={sendingThread}
+									isProcessing={isAgentActive}
+									autoScroll={autoScrollEnabled}
+									errorMessage={threadSendError}
+									onAutoScrollChange={setAutoScrollEnabled}
+									onTargetSelect={(targetId) => {
+										setSelectedTargetId(targetId);
+										setTargetLocked(true);
+									}}
+									onDraftActiveChange={(hasDraft) => {
+										setHasComposerDraft(hasDraft);
+										if (draftWasActiveRef.current && !hasDraft) setTargetLocked(false);
+										draftWasActiveRef.current = hasDraft;
+									}}
+									onSend={sendThreadMessage}
+								/>
+							</div>
 						)}
 					</div>
 				)}

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -173,9 +173,9 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 	const [autoScrollEnabled, setAutoScrollEnabled] = useState(true);
 	const [showScrollButton, setShowScrollButton] = useState(false);
 	const [threadScroller, setThreadScroller] = useState<HTMLDivElement | null>(null);
+	const [taskComposerElement, setTaskComposerElement] = useState<HTMLDivElement | null>(null);
 	const [taskComposerPaddingPx, setTaskComposerPaddingPx] = useState(144);
 	const threadPanelRef = useRef<HTMLDivElement>(null);
-	const taskComposerRef = useRef<HTMLDivElement>(null);
 	const scrollToBottomRef = useRef<((smooth?: boolean) => void) | null>(null);
 	const draftWasActiveRef = useRef(false);
 	// Modal-local error feedback. Separate from `threadSendError` because
@@ -344,7 +344,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 			return;
 		}
 
-		const composer = taskComposerRef.current;
+		const composer = taskComposerElement;
 		if (!composer) return;
 
 		const syncComposerPadding = () => {
@@ -361,7 +361,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 		resizeObserver.observe(composer);
 
 		return () => resizeObserver.disconnect();
-	}, [showInlineComposer, threadSendError]);
+	}, [showInlineComposer, taskComposerElement, threadSendError]);
 
 	const canSendThreadMessage = !isTerminalTask && !ensuringThread && !sendingThread;
 	const canShowCanvasTab = !!task.workflowRunId && !!canvasWorkflowId;
@@ -927,31 +927,30 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 						)}
 
 						{showInlineComposer && (
-							<div ref={taskComposerRef}>
-								<TaskSessionChatComposer
-									sessionId={agentSessionId ?? ''}
-									mentionCandidates={mentionCandidates}
-									targets={composerTargets}
-									selectedTargetId={selectedTarget?.id ?? null}
-									hasTaskAgentSession={!!agentSessionId}
-									canSend={canSendThreadMessage}
-									isSending={sendingThread}
-									isProcessing={isAgentActive}
-									autoScroll={autoScrollEnabled}
-									errorMessage={threadSendError}
-									onAutoScrollChange={setAutoScrollEnabled}
-									onTargetSelect={(targetId) => {
-										setSelectedTargetId(targetId);
-										setTargetLocked(true);
-									}}
-									onDraftActiveChange={(hasDraft) => {
-										setHasComposerDraft(hasDraft);
-										if (draftWasActiveRef.current && !hasDraft) setTargetLocked(false);
-										draftWasActiveRef.current = hasDraft;
-									}}
-									onSend={sendThreadMessage}
-								/>
-							</div>
+							<TaskSessionChatComposer
+								sessionId={agentSessionId ?? ''}
+								mentionCandidates={mentionCandidates}
+								targets={composerTargets}
+								selectedTargetId={selectedTarget?.id ?? null}
+								hasTaskAgentSession={!!agentSessionId}
+								canSend={canSendThreadMessage}
+								isSending={sendingThread}
+								isProcessing={isAgentActive}
+								autoScroll={autoScrollEnabled}
+								errorMessage={threadSendError}
+								onAutoScrollChange={setAutoScrollEnabled}
+								onTargetSelect={(targetId) => {
+									setSelectedTargetId(targetId);
+									setTargetLocked(true);
+								}}
+								onDraftActiveChange={(hasDraft) => {
+									setHasComposerDraft(hasDraft);
+									if (draftWasActiveRef.current && !hasDraft) setTargetLocked(false);
+									draftWasActiveRef.current = hasDraft;
+								}}
+								onComposerRef={setTaskComposerElement}
+								onSend={sendThreadMessage}
+							/>
 						)}
 					</div>
 				)}

--- a/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
+++ b/packages/web/src/components/space/SpaceTaskUnifiedThread.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from 'preact/hooks';
-import { useSpaceTaskMessages } from '../../hooks/useSpaceTaskMessages';
 import { useAutoScroll } from '../../hooks/useAutoScroll';
+import { useSpaceTaskMessages } from '../../hooks/useSpaceTaskMessages';
 import { MinimalThreadFeed } from './thread/minimal/MinimalThreadFeed';
 import { parseThreadRow } from './thread/space-task-thread-events';
 
@@ -8,6 +8,7 @@ interface SpaceTaskUnifiedThreadProps {
 	taskId: string;
 	bottomInsetClass?: string;
 	bottomScrollPaddingClass?: string;
+	bottomInsetPx?: number;
 	/**
 	 * Top padding applied to the scroll container so the first message clears
 	 * any floating overlay (e.g. SpaceTaskPane's tab pill) at scroll-top. Older
@@ -33,6 +34,7 @@ export function SpaceTaskUnifiedThread({
 	taskId,
 	bottomInsetClass = 'pb-3',
 	bottomScrollPaddingClass = 'scroll-pb-3',
+	bottomInsetPx,
 	topInsetClass = '',
 	activeAgentLabels,
 	autoScrollEnabled = true,
@@ -99,11 +101,22 @@ export function SpaceTaskUnifiedThread({
 		);
 	}
 
+	const dynamicBottomInsetStyle =
+		bottomInsetPx === undefined
+			? undefined
+			: {
+					paddingBottom: `${bottomInsetPx}px`,
+					scrollPaddingBottom: `${bottomInsetPx}px`,
+				};
+	const bottomInsetClasses =
+		bottomInsetPx === undefined ? `${bottomInsetClass} ${bottomScrollPaddingClass}` : '';
+
 	return (
 		<div class="h-full min-h-0 flex flex-col relative" data-testid="space-task-unified-thread">
 			<div
 				ref={containerRef}
-				class={`flex-1 overflow-y-auto ${topInsetClass} ${bottomInsetClass} ${bottomScrollPaddingClass}`}
+				class={`flex-1 overflow-y-auto ${topInsetClass} ${bottomInsetClasses}`}
+				style={dynamicBottomInsetStyle}
 			>
 				<div class="min-h-[calc(100%+1px)]">
 					<MinimalThreadFeed

--- a/packages/web/src/components/space/TaskSessionChatComposer.tsx
+++ b/packages/web/src/components/space/TaskSessionChatComposer.tsx
@@ -1,4 +1,5 @@
 import type { MessageDeliveryMode, MessageImage } from '@neokai/shared';
+import type { Ref } from 'preact';
 import { useMemo, useState } from 'preact/hooks';
 import { ChatComposer } from '../ChatComposer.tsx';
 import { useModelSwitcher } from '../../hooks';
@@ -30,6 +31,7 @@ interface TaskSessionChatComposerProps {
 	onAutoScrollChange: (enabled: boolean) => void;
 	onTargetSelect: (targetId: string) => void;
 	onDraftActiveChange?: (hasDraft: boolean) => void;
+	onComposerRef?: Ref<HTMLDivElement>;
 	onSend: (message: string, target: TaskComposerTarget | null) => Promise<boolean>;
 }
 
@@ -47,6 +49,7 @@ export function TaskSessionChatComposer({
 	onAutoScrollChange,
 	onTargetSelect,
 	onDraftActiveChange,
+	onComposerRef,
 	onSend,
 }: TaskSessionChatComposerProps) {
 	const {
@@ -133,7 +136,7 @@ export function TaskSessionChatComposer({
 		) : null;
 
 	return (
-		<div class="relative z-10" data-testid="task-session-chat-composer">
+		<div ref={onComposerRef} class="relative z-10" data-testid="task-session-chat-composer">
 			<ChatComposer
 				sessionId={sessionId}
 				readonly={false}

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -1282,6 +1282,28 @@ describe('SpaceTaskPane — floating tab pill layout', () => {
 		expect(thread.getAttribute('data-bottom-scroll-padding')).toBe('');
 	});
 
+	it('rebinds dynamic inset measurement when returning to the thread view', () => {
+		const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+		HTMLElement.prototype.getBoundingClientRect = function () {
+			if (this.getAttribute('data-testid') === 'task-session-chat-composer') {
+				return { height: 220 } as DOMRect;
+			}
+			return originalGetBoundingClientRect.call(this);
+		};
+		try {
+			mockTasks.value = [makeTask({ workflowRunId: 'run-1', taskAgentSessionId: 'session-abc' })];
+			mockWorkflowRuns.value = [makeWorkflowRun({ id: 'run-1', workflowId: 'workflow-1' })];
+			const { getByTestId } = render(<SpaceTaskPane taskId="task-1" spaceId="space-1" />);
+			fireEvent.click(getByTestId('canvas-toggle'));
+			fireEvent.click(getByTestId('thread-toggle'));
+
+			const thread = getByTestId('space-task-unified-thread');
+			expect(Number(thread.getAttribute('data-bottom-inset-px'))).toBe(236);
+		} finally {
+			HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+		}
+	});
+
 	it('renders the active banner outside task-pane-content so it is visible across tabs', () => {
 		mockTasks.value = [
 			makeTask({

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -145,11 +145,13 @@ vi.mock('../SpaceTaskUnifiedThread', () => ({
 		topInsetClass,
 		bottomInsetClass,
 		bottomScrollPaddingClass,
+		bottomInsetPx,
 	}: {
 		taskId: string;
 		topInsetClass?: string;
 		bottomInsetClass?: string;
 		bottomScrollPaddingClass?: string;
+		bottomInsetPx?: number;
 	}) => (
 		<div
 			data-testid="space-task-unified-thread"
@@ -157,6 +159,7 @@ vi.mock('../SpaceTaskUnifiedThread', () => ({
 			data-top-inset={topInsetClass ?? ''}
 			data-bottom-inset={bottomInsetClass ?? ''}
 			data-bottom-scroll-padding={bottomScrollPaddingClass ?? ''}
+			data-bottom-inset-px={bottomInsetPx ?? ''}
 		/>
 	),
 }));
@@ -355,8 +358,7 @@ describe('SpaceTaskPane — composer', () => {
 
 		await waitFor(() => expect(getByText('Invalid transition')).toBeTruthy());
 		const thread = getByTestId('space-task-unified-thread');
-		expect(thread.getAttribute('data-bottom-inset')).toBe('pb-52 sm:pb-44');
-		expect(thread.getAttribute('data-bottom-scroll-padding')).toBe('scroll-pb-52 sm:scroll-pb-44');
+		expect(Number(thread.getAttribute('data-bottom-inset-px'))).toBeGreaterThanOrEqual(144);
 	});
 
 	it('does not submit empty message', () => {
@@ -1269,14 +1271,15 @@ describe('SpaceTaskPane — floating tab pill layout', () => {
 		expect(mockNavigateToSpaceTask).toHaveBeenCalledWith('task-space', 'task-1', 'canvas');
 	});
 
-	it('passes insets to SpaceTaskUnifiedThread so messages clear floating controls', () => {
+	it('passes dynamic inset pixels to SpaceTaskUnifiedThread so messages clear floating controls', () => {
 		mockTasks.value = [makeTask({ taskAgentSessionId: 'session-abc' })];
 		const { getByTestId } = render(<SpaceTaskPane taskId="task-1" spaceId="space-1" />);
 
 		const thread = getByTestId('space-task-unified-thread');
 		expect(thread.getAttribute('data-top-inset')).toBe('pt-12');
-		expect(thread.getAttribute('data-bottom-inset')).toBe('pb-44 sm:pb-36');
-		expect(thread.getAttribute('data-bottom-scroll-padding')).toBe('scroll-pb-44 sm:scroll-pb-36');
+		expect(Number(thread.getAttribute('data-bottom-inset-px'))).toBeGreaterThanOrEqual(144);
+		expect(thread.getAttribute('data-bottom-inset')).toBe('');
+		expect(thread.getAttribute('data-bottom-scroll-padding')).toBe('');
 	});
 
 	it('renders the active banner outside task-pane-content so it is visible across tabs', () => {

--- a/packages/web/src/hooks/__tests__/useAutoScroll.test.ts
+++ b/packages/web/src/hooks/__tests__/useAutoScroll.test.ts
@@ -728,13 +728,12 @@ describe('useAutoScroll', () => {
 
 			// Re-pin through scrollIntoView so CSS scroll-padding-bottom is honored.
 			expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'instant', block: 'end' });
-			expect(containerRef.current!.scrollTop).toBe(500);
 		});
 
 		it('should NOT re-pin to bottom when user has scrolled away from bottom', () => {
 			// User intentionally scrolled up to read older content. Even if
 			// content grows, we must not yank them back to the bottom.
-			const { containerRef, endRef } = createMockRefs();
+			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
 
 			// User is well above the bottom.
 			containerRef.current!.scrollTop = 0;
@@ -750,6 +749,7 @@ describe('useAutoScroll', () => {
 					messageCount: 5,
 				})
 			);
+			scrollIntoViewMock.mockClear();
 
 			// Content grows.
 			containerRef.current!.scrollHeight = 1500;
@@ -761,7 +761,7 @@ describe('useAutoScroll', () => {
 			});
 			vi.useRealTimers();
 
-			// Container scrollTop must NOT have been touched.
+			expect(scrollIntoViewMock).not.toHaveBeenCalled();
 			expect(containerRef.current!.scrollTop).toBe(0);
 		});
 
@@ -769,7 +769,7 @@ describe('useAutoScroll', () => {
 			// During load-older, ChatContainer's own useLayoutEffect is
 			// preserving the user's anchored read position. The auto-scroll
 			// hook must keep its hands off.
-			const { containerRef, endRef } = createMockRefs();
+			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
 
 			containerRef.current!.scrollTop = 500;
 			containerRef.current!.scrollHeight = 1000;
@@ -788,6 +788,7 @@ describe('useAutoScroll', () => {
 			);
 
 			rerender({ loadingOlder: true });
+			scrollIntoViewMock.mockClear();
 
 			containerRef.current!.scrollHeight = 2000;
 
@@ -798,6 +799,7 @@ describe('useAutoScroll', () => {
 			});
 			vi.useRealTimers();
 
+			expect(scrollIntoViewMock).not.toHaveBeenCalled();
 			expect(containerRef.current!.scrollTop).toBe(500);
 		});
 	});

--- a/packages/web/src/hooks/__tests__/useAutoScroll.test.ts
+++ b/packages/web/src/hooks/__tests__/useAutoScroll.test.ts
@@ -691,13 +691,13 @@ describe('useAutoScroll', () => {
 	});
 
 	describe('content-growth re-anchor', () => {
-		it('should re-pin to bottom when content grows while user is near bottom', () => {
+		it('should re-pin via scrollIntoView when content grows while user is near bottom', () => {
 			// Reproduces the "lands somewhere random" symptom: an initial
 			// scroll-to-bottom fires, but then async content (markdown,
 			// syntax highlighting, image loads) grows the scrollHeight after
 			// the scroll, leaving the last messages stranded above the actual
 			// bottom. The ResizeObserver path catches the growth and re-pins.
-			const { containerRef, endRef } = createMockRefs();
+			const { containerRef, endRef, scrollIntoViewMock } = createMockRefs();
 
 			// Container is initially at bottom.
 			containerRef.current!.scrollTop = 500;
@@ -726,8 +726,9 @@ describe('useAutoScroll', () => {
 			});
 			vi.useRealTimers();
 
-			// Container should have been scrolled to the new bottom.
-			expect(containerRef.current!.scrollTop).toBe(1500);
+			// Re-pin through scrollIntoView so CSS scroll-padding-bottom is honored.
+			expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'instant', block: 'end' });
+			expect(containerRef.current!.scrollTop).toBe(500);
 		});
 
 		it('should NOT re-pin to bottom when user has scrolled away from bottom', () => {

--- a/packages/web/src/hooks/useAutoScroll.ts
+++ b/packages/web/src/hooks/useAutoScroll.ts
@@ -21,7 +21,7 @@
  */
 
 import type { RefObject } from 'preact';
-import { useState, useEffect, useLayoutEffect, useCallback, useRef } from 'preact/hooks';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
 
 export interface UseAutoScrollOptions {
 	/** Ref to the scrollable container element */
@@ -159,7 +159,7 @@ export function useAutoScroll({
 						!loadingOlderRef.current &&
 						(enabledRef.current || !hasScrolledOnMountRef.current)
 					) {
-						container.scrollTop = container.scrollHeight;
+						scrollToBottom();
 					}
 					handleScroll();
 				});

--- a/packages/web/src/hooks/useAutoScroll.ts
+++ b/packages/web/src/hooks/useAutoScroll.ts
@@ -175,7 +175,7 @@ export function useAutoScroll({
 		}
 
 		return setupScrollDetection(container);
-	}, [nearBottomThreshold, messageCount]);
+	}, [nearBottomThreshold, messageCount, scrollToBottom]);
 
 	// When loadingOlder transitions from true to false, skip the message-count delta
 	// that was introduced by revealing older messages so that auto-scroll doesn't fire.


### PR DESCRIPTION
Fixes chat autoscroll paths so content-growth re-pins honor scroll padding, composer padding sync happens before paint, and space task threads use measured composer insets instead of hardcoded padding.

Tests: bun run --cwd packages/web test src/hooks/__tests__/useAutoScroll.test.ts src/components/space/__tests__/SpaceTaskPane.test.tsx src/components/space/__tests__/SpaceTaskUnifiedThread.test.tsx; bun run --cwd packages/web typecheck; bun run lint