### PR TITLE
Fix own-PR review handoffs

### DIFF
--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -294,8 +294,11 @@ export class SpaceTaskManager {
 
 		// Inline transition validation. Mirrors the check in `setTaskStatus` —
 		// kept here (rather than delegating) so the status flip and the pending-*
-		// stamp can happen in a single SQL UPDATE.
-		if (!isValidSpaceTaskTransition(task.status, 'review')) {
+		// stamp can happen in a single SQL UPDATE. Re-submitting while already in
+		// `review` is intentionally idempotent for multi-cycle workflows: each cycle
+		// refreshes the pending-completion metadata instead of failing with a
+		// misleading `review → review` transition error.
+		if (task.status !== 'review' && !isValidSpaceTaskTransition(task.status, 'review')) {
 			throw new Error(
 				`Invalid status transition from '${task.status}' to 'review'. ` +
 					`Allowed: ${VALID_SPACE_TASK_TRANSITIONS[task.status].join(', ') || 'none'}`

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -294,11 +294,22 @@ export class SpaceTaskManager {
 
 		// Inline transition validation. Mirrors the check in `setTaskStatus` —
 		// kept here (rather than delegating) so the status flip and the pending-*
-		// stamp can happen in a single SQL UPDATE. Re-submitting while already in
-		// `review` is intentionally idempotent for multi-cycle workflows: each cycle
-		// refreshes the pending-completion metadata instead of failing with a
-		// misleading `review → review` transition error.
-		if (task.status !== 'review' && !isValidSpaceTaskTransition(task.status, 'review')) {
+		// stamp can happen in a single SQL UPDATE.
+		//
+		// Re-submitting while already in `review` is intentionally idempotent ONLY
+		// when the existing checkpoint is `task_completion` (multi-cycle workflows
+		// where the agent re-submits after a prior submit_for_approval).  Other
+		// checkpoint types — notably `gate` set by handleGatePendingApproval — must
+		// NOT be overwritten because the runtime relies on `pendingCheckpointType:
+		// 'gate'` to reactivate the task when the gate opens.
+		if (task.status === 'review') {
+			if (task.pendingCheckpointType !== 'task_completion' && task.pendingCheckpointType != null) {
+				throw new Error(
+					`Cannot re-submit task in 'review' with pendingCheckpointType '${task.pendingCheckpointType}'. ` +
+						`Only 'task_completion' checkpoints can be refreshed.`
+				);
+			}
+		} else if (!isValidSpaceTaskTransition(task.status, 'review')) {
 			throw new Error(
 				`Invalid status transition from '${task.status}' to 'review'. ` +
 					`Allowed: ${VALID_SPACE_TASK_TRANSITIONS[task.status].join(', ') || 'none'}`

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -184,11 +184,11 @@ const PR_READY_BASH_SCRIPT = [
  * channel: the runtime refuses to deliver a "changes requested" message until
  * a formal review or at least one PR comment is visible on GitHub.
  *
- * Primary check: formal GitHub review (gh pr review / pulls/{n}/reviews).
- * Fallback check: PR conversation comments since workflow start. This covers
- * the edge case where reviewer and coder share the same GitHub account —
- * GitHub blocks self-reviews, so a formal review can never be posted, but
- * the reviewer can still post comments on the PR thread.
+ * Primary check: formal GitHub review (gh pr review / pulls/{n}/reviews)
+ * with APPROVED or CHANGES_REQUESTED state.
+ * Own-PR fallback: COMMENTED reviews or PR conversation comments since workflow
+ * start. GitHub blocks APPROVE/REQUEST_CHANGES on your own PR, so comment-only
+ * evidence is accepted only when the authenticated GitHub user is the PR author.
  *
  * Environment variables:
  *   NEOKAI_GATE_DATA_JSON       — current gate data; may contain `pr_url` or `review_url`
@@ -209,26 +209,29 @@ const REVIEW_POSTED_BASH_SCRIPT = [
 	'  echo "NEOKAI_WORKFLOW_START_ISO not injected — cannot determine review window" >&2',
 	'  exit 1',
 	'fi',
-	'if ! REVIEW_JSON=$(gh pr view "$PR_URL" --json reviews); then',
-	'  echo "Failed to fetch reviews for ${PR_URL}" >&2',
+	'if ! PR_JSON=$(gh pr view "$PR_URL" --json reviews,comments,author); then',
+	'  echo "Failed to fetch review evidence for ${PR_URL}" >&2',
 	'  exit 1',
 	'fi',
-	'REVIEW_COUNT=$(jq --arg since "$START_ISO" \'[.reviews[] | select(.submittedAt > $since)] | length\' <<< "$REVIEW_JSON")',
-	'if [ "$REVIEW_COUNT" != "0" ] && [ -n "$REVIEW_COUNT" ]; then',
-	'  jq -n --arg url "$PR_URL" --argjson n "$REVIEW_COUNT" \'{"pr_url":$url,"review_count":$n}\'',
+	'FORMAL_REVIEW_COUNT=$(jq --arg since "$START_ISO" \'[.reviews[] | select(.submittedAt > $since) | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED")] | length\' <<< "$PR_JSON")',
+	'if [ "$FORMAL_REVIEW_COUNT" != "0" ] && [ -n "$FORMAL_REVIEW_COUNT" ]; then',
+	'  jq -n --arg url "$PR_URL" --argjson n "$FORMAL_REVIEW_COUNT" \'{"pr_url":$url,"review_count":$n,"review_evidence":"formal_review"}\'',
 	'  exit 0',
 	'fi',
-	'# No formal review found — fall back to PR comments (handles same-account self-review restriction)',
-	'if ! COMMENTS_JSON=$(gh pr view "$PR_URL" --json comments); then',
-	'  echo "No formal review on ${PR_URL} since ${START_ISO}; also failed to fetch PR comments" >&2',
+	'AUTHOR_LOGIN=$(jq -r \'.author.login // empty\' <<< "$PR_JSON")',
+	'VIEWER_LOGIN=$(gh api user --jq .login 2>/dev/null || true)',
+	'if [ -z "$AUTHOR_LOGIN" ] || [ -z "$VIEWER_LOGIN" ] || [ "$AUTHOR_LOGIN" != "$VIEWER_LOGIN" ]; then',
+	'  echo "No APPROVED or CHANGES_REQUESTED review found on ${PR_URL} since workflow start (${START_ISO}); comment-only evidence is accepted only for own PRs" >&2',
 	'  exit 1',
 	'fi',
-	'COMMENT_COUNT=$(jq --arg since "$START_ISO" \'[.comments[] | select(.createdAt > $since)] | length\' <<< "$COMMENTS_JSON")',
+	'COMMENT_REVIEW_COUNT=$(jq --arg since "$START_ISO" \'[.reviews[] | select(.submittedAt > $since) | select(.state == "COMMENTED")] | length\' <<< "$PR_JSON")',
+	'PR_COMMENT_COUNT=$(jq --arg since "$START_ISO" \'[.comments[] | select(.createdAt > $since)] | length\' <<< "$PR_JSON")',
+	'COMMENT_COUNT=$((COMMENT_REVIEW_COUNT + PR_COMMENT_COUNT))',
 	'if [ "$COMMENT_COUNT" = "0" ] || [ -z "$COMMENT_COUNT" ]; then',
-	'  echo "No review or PR comment found on ${PR_URL} since workflow start (${START_ISO})" >&2',
+	'  echo "No review or PR comment found on own PR ${PR_URL} since workflow start (${START_ISO})" >&2',
 	'  exit 1',
 	'fi',
-	'jq -n --arg url "$PR_URL" --argjson n "$COMMENT_COUNT" \'{"pr_url":$url,"review_count":$n}\'',
+	'jq -n --arg url "$PR_URL" --argjson n "$COMMENT_COUNT" \'{"pr_url":$url,"review_count":$n,"review_evidence":"own_pr_comment"}\'',
 ].join('\n');
 
 /**

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -227,7 +227,7 @@ const REVIEW_POSTED_BASH_SCRIPT = [
 	'COMMENT_REVIEW_COUNT=$(jq --arg since "$START_ISO" \'[.reviews[] | select(.submittedAt > $since) | select(.state == "COMMENTED")] | length\' <<< "$PR_JSON")',
 	'PR_COMMENT_COUNT=$(jq --arg since "$START_ISO" \'[.comments[] | select(.createdAt > $since)] | length\' <<< "$PR_JSON")',
 	'COMMENT_COUNT=$((COMMENT_REVIEW_COUNT + PR_COMMENT_COUNT))',
-	'if [ "$COMMENT_COUNT" = "0" ] || [ -z "$COMMENT_COUNT" ]; then',
+	'if [ "$COMMENT_COUNT" = "0" ]; then',
 	'  echo "No review or PR comment found on own PR ${PR_URL} since workflow start (${START_ISO})" >&2',
 	'  exit 1',
 	'fi',

--- a/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
@@ -1005,6 +1005,35 @@ describe('SpaceTaskManager', () => {
 			);
 		});
 
+		it('rejects review→review when pendingCheckpointType is gate', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+
+			// Simulate handleGatePendingApproval: put task in review with gate checkpoint
+			await manager.submitTaskForReview(task.id, {
+				submittedByNodeId: null,
+				reason: null,
+			});
+			// Directly update to simulate gate pending state
+			const repo: any = (manager as any).taskRepo;
+			repo.updateTask(task.id, {
+				status: 'review',
+				pendingCheckpointType: 'gate',
+			});
+
+			await expect(
+				manager.submitTaskForReview(task.id, {
+					submittedByNodeId: null,
+					reason: null,
+				})
+			).rejects.toThrow(/Cannot re-submit task in 'review' with pendingCheckpointType 'gate'/);
+
+			// Confirm gate checkpoint was not overwritten
+			const after = await manager.getTask(task.id);
+			expect(after?.status).toBe('review');
+			expect(after?.pendingCheckpointType).toBe('gate');
+		});
+
 		it('rejects illegal source statuses before any pending-* fields get written', async () => {
 			// `done → review` is not in VALID_SPACE_TASK_TRANSITIONS — the helper
 			// must surface the transition error from `setTaskStatus` *before*

--- a/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
@@ -982,6 +982,29 @@ describe('SpaceTaskManager', () => {
 			expect(reviewing.pendingCompletionReason).toBeNull();
 		});
 
+		it('allows repeated review→review submissions and refreshes pending-completion metadata', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+
+			const first = await manager.submitTaskForReview(task.id, {
+				submittedByNodeId: 'node-A',
+				reason: 'cycle one',
+			});
+
+			const second = await manager.submitTaskForReview(task.id, {
+				submittedByNodeId: 'node-B',
+				reason: 'cycle two',
+			});
+
+			expect(second.status).toBe('review');
+			expect(second.pendingCheckpointType).toBe('task_completion');
+			expect(second.pendingCompletionSubmittedByNodeId).toBe('node-B');
+			expect(second.pendingCompletionReason).toBe('cycle two');
+			expect(second.pendingCompletionSubmittedAt).toBeGreaterThanOrEqual(
+				first.pendingCompletionSubmittedAt ?? 0
+			);
+		});
+
 		it('rejects illegal source statuses before any pending-* fields get written', async () => {
 			// `done → review` is not in VALID_SPACE_TASK_TRANSITIONS — the helper
 			// must surface the transition error from `setTaskStatus` *before*

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -182,9 +182,11 @@ describe('CODING_WORKFLOW template', () => {
 		expect(gate.script!.timeoutMs).toBe(30000);
 		// The script must consult the workflow start timestamp injected by the runner.
 		expect(gate.script!.source).toContain('NEOKAI_WORKFLOW_START_ISO');
-		// Primary check: query GitHub for the formal reviews list via the PR URL.
-		expect(gate.script!.source).toContain('gh pr view "$PR_URL" --json reviews');
+		// Primary check: query GitHub for formal approval / changes-requested reviews.
+		expect(gate.script!.source).toContain('gh pr view "$PR_URL" --json reviews,comments,author');
 		expect(gate.script!.source).toContain('submittedAt');
+		expect(gate.script!.source).toContain('APPROVED');
+		expect(gate.script!.source).toContain('CHANGES_REQUESTED');
 		// Must fail loudly when neither review nor PR comment has landed since start.
 		expect(gate.script!.source).toContain('exit 1');
 		// Must echo pr_url/review_count on success for downstream consumers.
@@ -192,18 +194,24 @@ describe('CODING_WORKFLOW template', () => {
 		expect(gate.script!.source).toContain('review_count');
 	});
 
-	test('review-posted-gate falls back to PR comments when no formal review exists', () => {
+	test('review-posted-gate accepts comment-only evidence only for own PRs', () => {
 		const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
 		const src = gate.script!.source;
-		// Fallback: check PR conversation comments when no formal review is found.
-		// This handles same-account setups where GitHub blocks self-reviews.
-		expect(src).toContain('gh pr view "$PR_URL" --json comments');
+		// Fallback: check COMMENTED reviews and PR conversation comments only after
+		// confirming the authenticated account owns the PR. Non-own PRs must still
+		// provide APPROVED or CHANGES_REQUESTED review events.
+		expect(src).toContain('gh api user --jq .login');
+		expect(src).toContain('AUTHOR_LOGIN');
+		expect(src).toContain('VIEWER_LOGIN');
+		expect(src).toContain('[ "$AUTHOR_LOGIN" != "$VIEWER_LOGIN" ]');
+		expect(src).toContain('COMMENTED');
 		expect(src).toContain('createdAt');
 		// Must also filter comments by workflow start timestamp.
 		expect(src).toContain('NEOKAI_WORKFLOW_START_ISO');
 		// Gate passes via comments fallback — outputs the same pr_url/review_count shape.
 		expect(src).toContain('pr_url');
 		expect(src).toContain('review_count');
+		expect(src).toContain('own_pr_comment');
 		// Error message must mention both "review" and "PR comment" so operators understand what was checked.
 		expect(src).toContain('PR comment');
 	});

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -231,8 +231,8 @@ describe('CODING_WORKFLOW template', () => {
 				[
 					'#!/usr/bin/env bash',
 					`printf '%s\\n' "$*" >> ${JSON.stringify(logPath)}`,
-					`if [ "$1" = "pr" ] && [ "$2" = "view" ] && [ "$3" = ${JSON.stringify(reviewUrl)} ] && [ "$4" = "--json" ] && [ "$5" = "reviews" ]; then`,
-					`  printf '%s\\n' '{"reviews":[{"submittedAt":"2026-05-01T12:00:00Z"}]}'`,
+					`if [ "$1" = "pr" ] && [ "$2" = "view" ] && [ "$3" = ${JSON.stringify(reviewUrl)} ] && [ "$4" = "--json" ] && [ "$5" = "reviews,comments,author" ]; then`,
+					`  printf '%s\\n' '{"reviews":[{"submittedAt":"2026-05-01T12:00:00Z","state":"CHANGES_REQUESTED"}],"comments":[],"author":{"login":"other"}}'`,
 					'  exit 0',
 					'fi',
 					'printf "unexpected gh args: %s\\n" "$*" >&2',
@@ -254,8 +254,14 @@ describe('CODING_WORKFLOW template', () => {
 			);
 
 			expect(result.success).toBe(true);
-			expect(result.data).toEqual({ pr_url: reviewUrl, review_count: 1 });
-			expect(readFileSync(logPath, 'utf8').trim()).toBe(`pr view ${reviewUrl} --json reviews`);
+			expect(result.data).toEqual({
+				pr_url: reviewUrl,
+				review_count: 1,
+				review_evidence: 'formal_review',
+			});
+			expect(readFileSync(logPath, 'utf8').trim()).toBe(
+				`pr view ${reviewUrl} --json reviews,comments,author`
+			);
 		} finally {
 			rmSync(workspace, { recursive: true, force: true });
 		}

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -216,6 +216,102 @@ describe('CODING_WORKFLOW template', () => {
 		expect(src).toContain('PR comment');
 	});
 
+	test('review-posted-gate passes own-PR COMMENTED reviews', async () => {
+		const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
+		const workspace = mkdtempSync(join(tmpdir(), 'neokai-review-posted-gate-own-pr-'));
+		const binDir = join(workspace, 'bin');
+		const ghPath = join(binDir, 'gh');
+		const prUrl = 'https://github.com/test/repo/pull/42';
+
+		try {
+			mkdirSync(binDir);
+			writeFileSync(
+				ghPath,
+				[
+					'#!/usr/bin/env bash',
+					`if [ "$1" = "pr" ] && [ "$2" = "view" ] && [ "$3" = ${JSON.stringify(prUrl)} ] && [ "$4" = "--json" ] && [ "$5" = "reviews,comments,author" ]; then`,
+					`  printf '%s\\n' '{"reviews":[{"submittedAt":"2026-05-01T12:00:00Z","state":"COMMENTED"}],"comments":[],"author":{"login":"lsm"}}'`,
+					'  exit 0',
+					'fi',
+					'if [ "$1" = "api" ] && [ "$2" = "user" ] && [ "$3" = "--jq" ] && [ "$4" = ".login" ]; then',
+					`  printf '%s\\n' 'lsm'`,
+					'  exit 0',
+					'fi',
+					'printf "unexpected gh args: %s\\n" "$*" >&2',
+					'exit 2',
+				].join('\n')
+			);
+			chmodSync(ghPath, 0o755);
+
+			const result = await executeGateScript(
+				gate.script!,
+				{
+					workspacePath: workspace,
+					gateId: 'review-posted-gate',
+					runId: 'run-1',
+					gateData: { pr_url: prUrl },
+					workflowStartIso: '2026-05-01T00:00:00Z',
+				},
+				{ PATH: `${binDir}:${process.env.PATH ?? ''}` }
+			);
+
+			expect(result.success).toBe(true);
+			expect(result.data).toEqual({
+				pr_url: prUrl,
+				review_count: 1,
+				review_evidence: 'own_pr_comment',
+			});
+		} finally {
+			rmSync(workspace, { recursive: true, force: true });
+		}
+	});
+
+	test('review-posted-gate rejects comment-only evidence on non-own PRs', async () => {
+		const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
+		const workspace = mkdtempSync(join(tmpdir(), 'neokai-review-posted-gate-non-own-pr-'));
+		const binDir = join(workspace, 'bin');
+		const ghPath = join(binDir, 'gh');
+		const prUrl = 'https://github.com/test/repo/pull/42';
+
+		try {
+			mkdirSync(binDir);
+			writeFileSync(
+				ghPath,
+				[
+					'#!/usr/bin/env bash',
+					`if [ "$1" = "pr" ] && [ "$2" = "view" ] && [ "$3" = ${JSON.stringify(prUrl)} ] && [ "$4" = "--json" ] && [ "$5" = "reviews,comments,author" ]; then`,
+					`  printf '%s\\n' '{"reviews":[],"comments":[{"createdAt":"2026-05-01T12:00:00Z"}],"author":{"login":"someone-else"}}'`,
+					'  exit 0',
+					'fi',
+					'if [ "$1" = "api" ] && [ "$2" = "user" ] && [ "$3" = "--jq" ] && [ "$4" = ".login" ]; then',
+					`  printf '%s\\n' 'lsm'`,
+					'  exit 0',
+					'fi',
+					'printf "unexpected gh args: %s\\n" "$*" >&2',
+					'exit 2',
+				].join('\n')
+			);
+			chmodSync(ghPath, 0o755);
+
+			const result = await executeGateScript(
+				gate.script!,
+				{
+					workspacePath: workspace,
+					gateId: 'review-posted-gate',
+					runId: 'run-1',
+					gateData: { pr_url: prUrl },
+					workflowStartIso: '2026-05-01T00:00:00Z',
+				},
+				{ PATH: `${binDir}:${process.env.PATH ?? ''}` }
+			);
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('comment-only evidence is accepted only for own PRs');
+		} finally {
+			rmSync(workspace, { recursive: true, force: true });
+		}
+	});
+
 	test('review-posted-gate uses review_url gate data when pr_url is absent', async () => {
 		const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'review-posted-gate')!;
 		const workspace = mkdtempSync(join(tmpdir(), 'neokai-review-posted-gate-'));


### PR DESCRIPTION
Fixes the review-posted gate so own-PR comment reviews can unblock coder feedback while non-own PRs still require formal approval/request-changes reviews.

Also makes repeated submit_for_approval calls refresh review metadata instead of failing on review→review cycles.

Tests: bun test packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts; bun run typecheck; bun run lint.