### PR TITLE
Cancel stale workflow node executions

### DIFF
--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -226,6 +226,11 @@ export interface ChannelRouterConfig {
 	 */
 	isSessionAlive?: (sessionId: string) => boolean;
 	/**
+	 * Optional cancellation hook for live agent sessions when activation discovers
+	 * the backing node execution is permanently invalid and must be detached.
+	 */
+	cancelSessionById?: (sessionId: string) => void;
+	/**
 	 * Optional notification sink for surfacing runtime events (e.g.
 	 * `workflow_run_reopened`). When omitted, the router silently skips
 	 * notification emission — appropriate for tests and other standalone uses.
@@ -366,6 +371,9 @@ export class ChannelRouter {
 			if (existing) {
 				const validation = validateExecutionAgainstWorkflow(existing, workflow);
 				if (!validation.valid) {
+					if (existing.agentSessionId) {
+						this.config.cancelSessionById?.(existing.agentSessionId);
+					}
 					this.config.nodeExecutionRepo.update(existing.id, {
 						status: 'cancelled',
 						agentSessionId: null,

--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -55,6 +55,10 @@ import { executeGateScript } from './gate-script-executor';
 import { getBuiltInGateScript } from '../workflows/built-in-workflows';
 import type { NotificationSink, SpaceNotificationEvent } from './notification-sink';
 import { Logger } from '../../logger';
+import {
+	PermanentSpawnError,
+	validateExecutionAgainstWorkflow,
+} from './workflow-node-execution-validation';
 
 const log = new Logger('channel-router');
 
@@ -360,6 +364,20 @@ export class ChannelRouter {
 			const agentName = agentEntry.name;
 			const existing = existingByAgentName.get(agentName);
 			if (existing) {
+				const validation = validateExecutionAgainstWorkflow(existing, workflow);
+				if (!validation.valid) {
+					this.config.nodeExecutionRepo.update(existing.id, {
+						status: 'cancelled',
+						agentSessionId: null,
+						result: validation.reason,
+						completedAt: Date.now(),
+					});
+					log.warn(
+						`ChannelRouter: cancelled stale workflow node execution ${existing.id}: ${validation.reason}`
+					);
+					throw new PermanentSpawnError(validation.reason);
+				}
+
 				// Re-activation path for cyclic channels.
 				//
 				// Default: preserve `agentSessionId` and flip status to `in_progress`,

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -944,6 +944,9 @@ export class SpaceRuntimeService {
 				return s?.autonomyLevel ?? 1;
 			},
 			isSessionAlive: taskAgentManager ? (sid) => taskAgentManager.isSessionAlive(sid) : undefined,
+			cancelSessionById: taskAgentManager
+				? (sid) => taskAgentManager.cancelBySessionId(sid)
+				: undefined,
 			// Forward the runtime's current sink so a gate-driven reopen still
 			// surfaces `workflow_run_reopened` to the Space Agent session.
 			notificationSink: this.runtime.getNotificationSink(),
@@ -1000,6 +1003,9 @@ export class SpaceRuntimeService {
 				return s?.autonomyLevel ?? 1;
 			},
 			isSessionAlive: taskAgentManager ? (sid) => taskAgentManager.isSessionAlive(sid) : undefined,
+			cancelSessionById: taskAgentManager
+				? (sid) => taskAgentManager.cancelBySessionId(sid)
+				: undefined,
 			// Forward the runtime's current sink so activation-driven reopens of
 			// terminal runs still surface `workflow_run_reopened` to the Space
 			// Agent session (mirrors `notifyGateDataChanged` above).

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -67,10 +67,7 @@ import { evaluateGate } from './gate-evaluator';
 import { executeGateScript } from './gate-script-executor';
 import { getBuiltInGateScript } from '../workflows/built-in-workflows';
 import { classifyLastMessageForIdleAgent } from './last-message-classifier';
-import {
-	isPermanentSpawnError,
-	validateExecutionAgainstWorkflow,
-} from './workflow-node-execution-validation';
+import { isPermanentSpawnError } from './workflow-node-execution-validation';
 
 const log = new Logger('space-runtime');
 
@@ -1304,19 +1301,7 @@ export class SpaceRuntime {
 		if (this.executors.has(run.id)) return true;
 
 		const workflow = this.config.spaceWorkflowManager.getWorkflow(run.workflowId);
-		if (!workflow) {
-			this.cancelInvalidWorkflowNodeExecutions(
-				run.id,
-				null,
-				this.config.nodeExecutionRepo.listByWorkflowRun(run.id)
-			);
-			return false;
-		}
-		this.cancelInvalidWorkflowNodeExecutions(
-			run.id,
-			workflow,
-			this.config.nodeExecutionRepo.listByWorkflowRun(run.id)
-		);
+		if (!workflow) return false;
 
 		const space = knownSpace ?? (await this.config.spaceManager.getSpace(run.spaceId));
 		if (!space) return false;
@@ -1466,11 +1451,8 @@ export class SpaceRuntime {
 		run: SpaceWorkflowRun
 	): Promise<'completion-pending' | 'blocked' | 'skipped'> {
 		const workflow = this.config.spaceWorkflowManager.getWorkflow(run.workflowId);
-		const executions = this.cancelInvalidWorkflowNodeExecutions(
-			run.id,
-			workflow,
-			this.config.nodeExecutionRepo.listByWorkflowRun(run.id)
-		);
+		if (!workflow) return 'skipped';
+		const executions = this.config.nodeExecutionRepo.listByWorkflowRun(run.id);
 		if (executions.length === 0) return 'skipped';
 
 		// If the tick loop has any work it can drive — `pending` (about
@@ -1983,7 +1965,6 @@ export class SpaceRuntime {
 		}
 
 		let nodeExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
-		nodeExecutions = this.cancelInvalidWorkflowNodeExecutions(runId, meta.workflow, nodeExecutions);
 		if (nodeExecutions.length === 0) return;
 
 		// Refresh dedup entries for this run's canonical task.
@@ -2511,31 +2492,6 @@ export class SpaceRuntime {
 		}
 	}
 
-	private cancelInvalidWorkflowNodeExecutions(
-		runId: string,
-		workflow: SpaceWorkflow | null | undefined,
-		executions: NodeExecution[]
-	): NodeExecution[] {
-		let cancelledCount = 0;
-		for (const execution of executions) {
-			if (execution.status === 'cancelled') continue;
-			const validation = validateExecutionAgainstWorkflow(execution, workflow);
-			if (validation.valid) continue;
-			this.config.nodeExecutionRepo.update(execution.id, {
-				status: 'cancelled',
-				agentSessionId: null,
-				result: validation.reason,
-				completedAt: Date.now(),
-			});
-			cancelledCount++;
-			log.warn(
-				`SpaceRuntime: cancelled stale workflow node execution ${execution.id} on run ${runId}: ${validation.reason}`
-			);
-		}
-		if (cancelledCount === 0) return executions;
-		return this.config.nodeExecutionRepo.listByWorkflowRun(runId);
-	}
-
 	private cancelExecutionForPermanentSpawnError(execution: NodeExecution, err: unknown): boolean {
 		if (!isPermanentSpawnError(err)) return false;
 		this.config.nodeExecutionRepo.update(execution.id, {
@@ -2627,15 +2583,6 @@ export class SpaceRuntime {
 			if (!first) return;
 			blockedReason = `Queued workflow handoff to ${targetAgentName} failed after ${first.attempts} attempt(s): ${first.lastError ?? 'delivery failed'}`;
 		};
-		const failQueuedHandoffsForCancelledExecution = (
-			targetAgentName: string,
-			execution: NodeExecution,
-			rowsForCurrentAttempt: typeof pending
-		): void => {
-			const reason = `Queued workflow handoff to ${targetAgentName} cannot be delivered because target execution ${execution.id} is cancelled${execution.result ? `: ${execution.result}` : ''}`;
-			for (const row of rowsForCurrentAttempt) repo.markFailed(row.id, reason);
-			blockedReason = reason;
-		};
 
 		for (const targetAgentName of targets) {
 			const rowsForTarget = pending.filter((row) => row.targetAgentName === targetAgentName);
@@ -2665,10 +2612,6 @@ export class SpaceRuntime {
 				await tam.tryResumeNodeAgentSession(runId, execution.agentName);
 				execution = this.config.nodeExecutionRepo.getById(execution.id) ?? execution;
 				if (execution.status === 'waiting_rebind') {
-					continue;
-				}
-				if (execution.status === 'cancelled') {
-					failQueuedHandoffsForCancelledExecution(targetAgentName, execution, rowsForTarget);
 					continue;
 				}
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2627,6 +2627,15 @@ export class SpaceRuntime {
 			if (!first) return;
 			blockedReason = `Queued workflow handoff to ${targetAgentName} failed after ${first.attempts} attempt(s): ${first.lastError ?? 'delivery failed'}`;
 		};
+		const failQueuedHandoffsForCancelledExecution = (
+			targetAgentName: string,
+			execution: NodeExecution,
+			rowsForCurrentAttempt: typeof pending
+		): void => {
+			const reason = `Queued workflow handoff to ${targetAgentName} cannot be delivered because target execution ${execution.id} is cancelled${execution.result ? `: ${execution.result}` : ''}`;
+			for (const row of rowsForCurrentAttempt) repo.markFailed(row.id, reason);
+			blockedReason = reason;
+		};
 
 		for (const targetAgentName of targets) {
 			const rowsForTarget = pending.filter((row) => row.targetAgentName === targetAgentName);
@@ -2659,6 +2668,7 @@ export class SpaceRuntime {
 					continue;
 				}
 				if (execution.status === 'cancelled') {
+					failQueuedHandoffsForCancelledExecution(targetAgentName, execution, rowsForTarget);
 					continue;
 				}
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2484,6 +2484,7 @@ export class SpaceRuntime {
 						`SpaceRuntime: cannot spawn workflow node agents for run ${runId} — space ${meta.spaceId} not found`
 					);
 				} else {
+					let permanentSpawnFailureReason: string | null = null;
 					for (const execution of pendingExecutions) {
 						if (tam.isExecutionSpawning(execution.id)) continue;
 						try {
@@ -2503,6 +2504,7 @@ export class SpaceRuntime {
 							});
 						} catch (err) {
 							if (this.cancelExecutionForPermanentSpawnError(execution, err)) {
+								permanentSpawnFailureReason = err instanceof Error ? err.message : String(err);
 								continue;
 							}
 							const stale = this.config.nodeExecutionRepo.getById(execution.id);
@@ -2517,6 +2519,25 @@ export class SpaceRuntime {
 							log.warn(
 								`SpaceRuntime: transient spawn failure for workflow node execution ${execution.id}: ${err instanceof Error ? err.message : String(err)}`
 							);
+						}
+					}
+					if (permanentSpawnFailureReason) {
+						const refreshedExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
+						const hasDriveableExecution = refreshedExecutions.some(
+							(execution) =>
+								execution.status === 'pending' ||
+								execution.status === 'in_progress' ||
+								execution.status === 'waiting_rebind' ||
+								execution.status === 'blocked'
+						);
+						if (!hasDriveableExecution) {
+							await this.blockRunForPermanentSpawnFailure(
+								runId,
+								meta.spaceId,
+								canonicalTask,
+								permanentSpawnFailureReason
+							);
+							return;
 						}
 					}
 					if (
@@ -2538,6 +2559,28 @@ export class SpaceRuntime {
 			// `task.reportedStatus`.
 			return;
 		}
+	}
+
+	private async blockRunForPermanentSpawnFailure(
+		runId: string,
+		spaceId: string,
+		canonicalTask: SpaceTask,
+		reason: string
+	): Promise<void> {
+		await this.transitionRunStatusAndEmit(runId, 'blocked');
+		await this.updateTaskAndEmit(spaceId, canonicalTask.id, {
+			status: 'blocked',
+			result: reason,
+			blockReason: 'workflow_invalid',
+			completedAt: null,
+		});
+		await this.safeNotify({
+			kind: 'workflow_run_blocked',
+			spaceId,
+			runId,
+			reason,
+			timestamp: new Date().toISOString(),
+		});
 	}
 
 	private cancelExecutionForPermanentSpawnError(execution: NodeExecution, err: unknown): boolean {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1586,6 +1586,9 @@ export class SpaceRuntime {
 		const now = Date.now();
 		for (const execution of executions) {
 			if (execution.status === 'cancelled') continue;
+			if (execution.agentSessionId) {
+				this.config.taskAgentManager?.cancelBySessionId(execution.agentSessionId);
+			}
 			this.config.nodeExecutionRepo.update(execution.id, {
 				status: 'cancelled',
 				agentSessionId: null,

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1451,8 +1451,11 @@ export class SpaceRuntime {
 		run: SpaceWorkflowRun
 	): Promise<'completion-pending' | 'blocked' | 'skipped'> {
 		const workflow = this.config.spaceWorkflowManager.getWorkflow(run.workflowId);
-		if (!workflow) return 'skipped';
 		const executions = this.config.nodeExecutionRepo.listByWorkflowRun(run.id);
+		if (!workflow) {
+			await this.blockRunWithMissingWorkflow(run, executions);
+			return 'blocked';
+		}
 		if (executions.length === 0) return 'skipped';
 
 		// If the tick loop has any work it can drive — `pending` (about
@@ -1573,6 +1576,51 @@ export class SpaceRuntime {
 				`with all node executions idle/cancelled and no completion signal — flagged blocked`
 		);
 		return 'blocked';
+	}
+
+	private async blockRunWithMissingWorkflow(
+		run: SpaceWorkflowRun,
+		executions: NodeExecution[]
+	): Promise<void> {
+		const reason = `Workflow ${run.workflowId} no longer exists; workflow run cannot continue`;
+		const now = Date.now();
+		for (const execution of executions) {
+			if (execution.status === 'cancelled') continue;
+			this.config.nodeExecutionRepo.update(execution.id, {
+				status: 'cancelled',
+				agentSessionId: null,
+				result: reason,
+				completedAt: now,
+			});
+		}
+		await this.transitionRunStatusAndEmit(run.id, 'blocked');
+		const canonicalTask = this.pickCanonicalTaskForRun(
+			run,
+			this.config.taskRepo.listByWorkflowRun(run.id)
+		);
+		if (canonicalTask) {
+			await this.updateTaskAndEmit(run.spaceId, canonicalTask.id, {
+				status: 'blocked',
+				blockReason: 'workflow_invalid',
+				result: reason,
+				completedAt: null,
+			});
+			await this.safeNotify({
+				kind: 'task_blocked',
+				spaceId: run.spaceId,
+				taskId: canonicalTask.id,
+				reason,
+				timestamp: new Date().toISOString(),
+			});
+		}
+		await this.safeNotify({
+			kind: 'workflow_run_blocked',
+			spaceId: run.spaceId,
+			runId: run.id,
+			reason,
+			timestamp: new Date().toISOString(),
+		});
+		log.warn(`SpaceRuntime.recoverStalledRuns: blocked run ${run.id}: ${reason}`);
 	}
 
 	private async activateRestartRecoveryDownstreamNodes(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2658,6 +2658,9 @@ export class SpaceRuntime {
 				if (execution.status === 'waiting_rebind') {
 					continue;
 				}
+				if (execution.status === 'cancelled') {
+					continue;
+				}
 
 				if (execution.agentSessionId && tam.isSessionAlive(execution.agentSessionId)) {
 					await tam.flushPendingMessagesForTarget(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -67,6 +67,10 @@ import { evaluateGate } from './gate-evaluator';
 import { executeGateScript } from './gate-script-executor';
 import { getBuiltInGateScript } from '../workflows/built-in-workflows';
 import { classifyLastMessageForIdleAgent } from './last-message-classifier';
+import {
+	isPermanentSpawnError,
+	validateExecutionAgainstWorkflow,
+} from './workflow-node-execution-validation';
 
 const log = new Logger('space-runtime');
 
@@ -1300,7 +1304,19 @@ export class SpaceRuntime {
 		if (this.executors.has(run.id)) return true;
 
 		const workflow = this.config.spaceWorkflowManager.getWorkflow(run.workflowId);
-		if (!workflow) return false;
+		if (!workflow) {
+			this.cancelInvalidWorkflowNodeExecutions(
+				run.id,
+				null,
+				this.config.nodeExecutionRepo.listByWorkflowRun(run.id)
+			);
+			return false;
+		}
+		this.cancelInvalidWorkflowNodeExecutions(
+			run.id,
+			workflow,
+			this.config.nodeExecutionRepo.listByWorkflowRun(run.id)
+		);
 
 		const space = knownSpace ?? (await this.config.spaceManager.getSpace(run.spaceId));
 		if (!space) return false;
@@ -1449,7 +1465,12 @@ export class SpaceRuntime {
 	private async recoverSingleRun(
 		run: SpaceWorkflowRun
 	): Promise<'completion-pending' | 'blocked' | 'skipped'> {
-		const executions = this.config.nodeExecutionRepo.listByWorkflowRun(run.id);
+		const workflow = this.config.spaceWorkflowManager.getWorkflow(run.workflowId);
+		const executions = this.cancelInvalidWorkflowNodeExecutions(
+			run.id,
+			workflow,
+			this.config.nodeExecutionRepo.listByWorkflowRun(run.id)
+		);
 		if (executions.length === 0) return 'skipped';
 
 		// If the tick loop has any work it can drive — `pending` (about
@@ -1962,6 +1983,7 @@ export class SpaceRuntime {
 		}
 
 		let nodeExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
+		nodeExecutions = this.cancelInvalidWorkflowNodeExecutions(runId, meta.workflow, nodeExecutions);
 		if (nodeExecutions.length === 0) return;
 
 		// Refresh dedup entries for this run's canonical task.
@@ -2451,6 +2473,9 @@ export class SpaceRuntime {
 								agentSessionId: sessionId,
 							});
 						} catch (err) {
+							if (this.cancelExecutionForPermanentSpawnError(execution, err)) {
+								continue;
+							}
 							const stale = this.config.nodeExecutionRepo.getById(execution.id);
 							if (stale?.agentSessionId) {
 								tam.cancelBySessionId(stale.agentSessionId);
@@ -2460,9 +2485,8 @@ export class SpaceRuntime {
 									result: null,
 								});
 							}
-							log.error(
-								`SpaceRuntime: failed to spawn workflow node agent for execution ${execution.id}:`,
-								err
+							log.warn(
+								`SpaceRuntime: transient spawn failure for workflow node execution ${execution.id}: ${err instanceof Error ? err.message : String(err)}`
 							);
 						}
 					}
@@ -2485,6 +2509,45 @@ export class SpaceRuntime {
 			// `task.reportedStatus`.
 			return;
 		}
+	}
+
+	private cancelInvalidWorkflowNodeExecutions(
+		runId: string,
+		workflow: SpaceWorkflow | null | undefined,
+		executions: NodeExecution[]
+	): NodeExecution[] {
+		let cancelledCount = 0;
+		for (const execution of executions) {
+			if (execution.status === 'cancelled') continue;
+			const validation = validateExecutionAgainstWorkflow(execution, workflow);
+			if (validation.valid) continue;
+			this.config.nodeExecutionRepo.update(execution.id, {
+				status: 'cancelled',
+				agentSessionId: null,
+				result: validation.reason,
+				completedAt: Date.now(),
+			});
+			cancelledCount++;
+			log.warn(
+				`SpaceRuntime: cancelled stale workflow node execution ${execution.id} on run ${runId}: ${validation.reason}`
+			);
+		}
+		if (cancelledCount === 0) return executions;
+		return this.config.nodeExecutionRepo.listByWorkflowRun(runId);
+	}
+
+	private cancelExecutionForPermanentSpawnError(execution: NodeExecution, err: unknown): boolean {
+		if (!isPermanentSpawnError(err)) return false;
+		this.config.nodeExecutionRepo.update(execution.id, {
+			status: 'cancelled',
+			agentSessionId: null,
+			result: err.message,
+			completedAt: Date.now(),
+		});
+		log.warn(
+			`SpaceRuntime: cancelled workflow node execution ${execution.id} after permanent spawn failure: ${err.message}`
+		);
+		return true;
 	}
 
 	private async repairQueuedWorkflowNodeHandoffs(
@@ -2616,7 +2679,7 @@ export class SpaceRuntime {
 					execution = this.config.nodeExecutionRepo.getById(execution.id) ?? execution;
 				}
 
-				if (execution.status === 'blocked' || execution.status === 'cancelled') {
+				if (execution.status === 'blocked') {
 					this.config.nodeExecutionRepo.update(execution.id, {
 						status: 'pending',
 						agentSessionId: null,
@@ -2646,9 +2709,21 @@ export class SpaceRuntime {
 				recordBlockedFlushFailure(targetAgentName, rowsForTarget);
 			} catch (err) {
 				const errMsg = err instanceof Error ? err.message : String(err);
-				log.warn(
-					`SpaceRuntime: queued workflow handoff repair failed for target ${targetAgentName}: ${errMsg}`
+				if (isPermanentSpawnError(err)) {
+					log.warn(
+						`SpaceRuntime: queued workflow handoff target ${targetAgentName} has permanent spawn failure: ${errMsg}`
+					);
+				} else {
+					log.warn(
+						`SpaceRuntime: queued workflow handoff repair failed for target ${targetAgentName}: ${errMsg}`
+					);
+				}
+				const maybeExecution = this.resolveQueuedHandoffExecution(
+					runId,
+					meta.workflow,
+					targetAgentName
 				);
+				if (maybeExecution) this.cancelExecutionForPermanentSpawnError(maybeExecution, err);
 				for (const row of rowsForTarget) {
 					const updated = repo.markAttemptFailed(row.id, errMsg);
 					if (updated?.status === 'failed') {

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1943,6 +1943,7 @@ export class TaskAgentManager {
 					return s?.autonomyLevel ?? 1;
 				},
 				isSessionAlive: (sid) => this.isSessionAlive(sid),
+				cancelSessionById: (sid) => this.cancelBySessionId(sid),
 				notificationSink: this.config.spaceRuntimeService.getSharedRuntime().getNotificationSink(),
 				onGatePendingApproval: (runId, gateId) =>
 					this.config.spaceRuntimeService.handleGatePendingApproval(runId, gateId),
@@ -4094,6 +4095,7 @@ export class TaskAgentManager {
 				return s?.autonomyLevel ?? 1;
 			},
 			isSessionAlive: (sid) => this.isSessionAlive(sid),
+			cancelSessionById: (sid) => this.cancelBySessionId(sid),
 			// Forward the runtime's current sink so a peer-agent `send_message`
 			// that auto-reopens a terminal run still emits `workflow_run_reopened`
 			// into the Space Agent session.

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -78,6 +78,11 @@ import { createNodeAgentMcpServer } from '../tools/node-agent-tools';
 import { createEndNodeHandlers, createMarkCompleteHandler } from '../tools/end-node-handlers';
 import { createSpaceAgentMcpServer } from '../tools/space-agent-tools';
 import { jsonResult } from '../tools/tool-result';
+import {
+	assertExecutionValidAgainstWorkflow,
+	PermanentSpawnError,
+	validateTaskAllowsSpawn,
+} from './workflow-node-execution-validation';
 import { createDbQueryMcpServer, type DbQueryMcpServer } from '../../db-query/tools';
 import { ChannelResolver } from './channel-resolver';
 import { ChannelRouter } from './channel-router';
@@ -882,13 +887,10 @@ export class TaskAgentManager {
 		let spawnedSessionId: string | null = null;
 
 		try {
-			const node = workflow.nodes.find((candidate) => candidate.id === execution.workflowNodeId);
-			if (!node) {
-				throw new Error(
-					`Workflow node "${execution.workflowNodeId}" not found in workflow "${workflow.id}"`
-				);
-			}
+			validateTaskAllowsSpawn(task);
+			assertExecutionValidAgainstWorkflow(execution, workflow);
 
+			const node = workflow.nodes.find((candidate) => candidate.id === execution.workflowNodeId)!;
 			const nodeAgents = resolveNodeAgents(node);
 			const slot =
 				nodeAgents.length === 1
@@ -945,7 +947,7 @@ export class TaskAgentManager {
 				? this.config.spaceAgentManager.getById(slot.agentId)
 				: null;
 			if (shouldKickoff && !customAgent) {
-				throw new Error(`Agent not found: ${slot.agentId}`);
+				throw new PermanentSpawnError(`Agent not found: ${slot.agentId}`);
 			}
 
 			const nodeAgentMcpServer = this.buildNodeAgentMcpServerForSession(

--- a/packages/daemon/src/lib/space/runtime/workflow-node-execution-validation.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-node-execution-validation.ts
@@ -1,0 +1,79 @@
+import type { NodeExecution, SpaceTask, SpaceWorkflow } from '@neokai/shared';
+import { resolveNodeAgents } from '@neokai/shared';
+
+export type ExecutionWorkflowValidationResult =
+	| { valid: true }
+	| { valid: false; reason: string; permanent: true };
+
+export class PermanentSpawnError extends Error {
+	readonly permanent = true;
+
+	constructor(message: string) {
+		super(message);
+		this.name = 'PermanentSpawnError';
+	}
+}
+
+export function isPermanentSpawnError(err: unknown): err is PermanentSpawnError {
+	return err instanceof PermanentSpawnError;
+}
+
+export function validateExecutionAgainstWorkflow(
+	execution: NodeExecution,
+	workflow: SpaceWorkflow | null | undefined
+): ExecutionWorkflowValidationResult {
+	if (!workflow) {
+		return {
+			valid: false,
+			reason: `Workflow for execution ${execution.id} no longer exists`,
+			permanent: true,
+		};
+	}
+
+	const node = workflow.nodes.find((candidate) => candidate.id === execution.workflowNodeId);
+	if (!node) {
+		return {
+			valid: false,
+			reason: `Workflow node ${execution.workflowNodeId} no longer exists in workflow definition`,
+			permanent: true,
+		};
+	}
+
+	let nodeAgents: ReturnType<typeof resolveNodeAgents>;
+	try {
+		nodeAgents = resolveNodeAgents(node);
+	} catch (err) {
+		return {
+			valid: false,
+			reason: `Workflow node ${execution.workflowNodeId} has invalid agent configuration: ${err instanceof Error ? err.message : String(err)}`,
+			permanent: true,
+		};
+	}
+
+	const slot = nodeAgents.find((agentSlot) => agentSlot.name === execution.agentName);
+	if (!slot?.agentId) {
+		return {
+			valid: false,
+			reason: `Agent slot ${execution.agentName} no longer exists on workflow node ${execution.workflowNodeId}`,
+			permanent: true,
+		};
+	}
+
+	return { valid: true };
+}
+
+export function assertExecutionValidAgainstWorkflow(
+	execution: NodeExecution,
+	workflow: SpaceWorkflow | null | undefined
+): void {
+	const validation = validateExecutionAgainstWorkflow(execution, workflow);
+	if (!validation.valid) throw new PermanentSpawnError(validation.reason);
+}
+
+export function validateTaskAllowsSpawn(task: SpaceTask): void {
+	if (task.status === 'archived' || task.status === 'cancelled') {
+		throw new PermanentSpawnError(
+			`Task ${task.id} is ${task.status}; workflow node execution cannot be spawned`
+		);
+	}
+}

--- a/packages/daemon/src/lib/space/runtime/workflow-node-execution-validation.ts
+++ b/packages/daemon/src/lib/space/runtime/workflow-node-execution-validation.ts
@@ -58,6 +58,13 @@ export function validateExecutionAgainstWorkflow(
 			permanent: true,
 		};
 	}
+	if (execution.agentId && slot.agentId !== execution.agentId) {
+		return {
+			valid: false,
+			reason: `Agent slot ${execution.agentName} on workflow node ${execution.workflowNodeId} now references agent ${slot.agentId} instead of ${execution.agentId}`,
+			permanent: true,
+		};
+	}
 
 	return { valid: true };
 }

--- a/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
@@ -45,6 +45,7 @@ import {
 	ActivationError,
 	ChannelGateBlockedError,
 } from '../../../../src/lib/space/runtime/channel-router.ts';
+import { PermanentSpawnError } from '../../../../src/lib/space/runtime/workflow-node-execution-validation.ts';
 import type { Gate, SpaceWorkflow, WorkflowChannel } from '@neokai/shared';
 import { computeGateDefaults } from '@neokai/shared';
 
@@ -423,6 +424,64 @@ describe('ChannelRouter', () => {
 			expect(tasks).toHaveLength(1);
 			expect(tasks[0].workflowRunId).toBe(run.id);
 			expect(nodeExecutionRepo.listByNode(run.id, NODE_A)).toHaveLength(1);
+		});
+
+		test('cancels live session before cancelling stale execution during activation', async () => {
+			const workflow = buildWorkflow(SPACE_ID, workflowManager, [
+				{
+					id: NODE_A,
+					name: 'Node A',
+					agents: [{ agentId: AGENT_CODER, name: 'stale-slot' }],
+				},
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Stale Activation Run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+			const nodeExecutionRepo = new NodeExecutionRepository(db);
+			const stale = nodeExecutionRepo.create({
+				workflowRunId: run.id,
+				workflowNodeId: NODE_A,
+				agentName: 'stale-slot',
+				agentId: AGENT_CODER,
+				agentSessionId: 'session:stale-activation',
+				status: 'cancelled',
+			});
+			workflowManager.updateWorkflow(workflow.id, {
+				nodes: [
+					{ id: NODE_A, name: 'Node A', agents: [{ agentId: AGENT_PLANNER, name: 'stale-slot' }] },
+				],
+				startNodeId: NODE_A,
+				endNodeId: NODE_A,
+				channels: [],
+			});
+			const cancelledSessions: string[] = [];
+			const routerWithCancellation = new ChannelRouter({
+				taskRepo,
+				workflowRunRepo,
+				workflowManager,
+				agentManager,
+				gateDataRepo,
+				channelCycleRepo,
+				db,
+				nodeExecutionRepo,
+				cancelSessionById: (sessionId) => cancelledSessions.push(sessionId),
+			});
+
+			await expect(routerWithCancellation.activateNode(run.id, NODE_A)).rejects.toBeInstanceOf(
+				PermanentSpawnError
+			);
+			expect(cancelledSessions).toEqual(['session:stale-activation']);
+			const after = nodeExecutionRepo.getById(stale.id)!;
+			expect(after.status).toBe('cancelled');
+			expect(after.agentSessionId).toBeNull();
+			expect(after.result).toContain(
+				'Agent slot stale-slot on workflow node node-a now references'
+			);
 		});
 
 		// -----------------------------------------------------------------------

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -1768,6 +1768,28 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 			expect(notifications.length).toBe(0);
 		});
 
+		test('stale pending execution is cancelled during restart recovery', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Stale Pending Exec',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+			const stale = seedExec(run.id, 'deleted-node', 'Step A', 'pending');
+
+			const rt = makeRuntime();
+			await rt.recoverStalledRuns();
+
+			const after = nodeExecutionRepo.getById(stale.id)!;
+			expect(after.status).toBe('cancelled');
+			expect(after.result).toContain('Workflow node deleted-node no longer exists');
+		});
+
 		test('blocked execution → run untouched (existing blocked-recovery path owns it)', async () => {
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: STEP_A, name: 'Step A', agentId: AGENT },

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -1814,7 +1814,7 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 				title: 'Stale Pending Exec',
 			});
 			workflowRunRepo.transitionStatus(run.id, 'in_progress');
-			taskRepo.createTask({
+			const task = taskRepo.createTask({
 				spaceId: SPACE_ID,
 				title: 'Stale Pending Exec',
 				description: '',
@@ -1848,6 +1848,9 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 			const after = nodeExecutionRepo.getById(stale.id)!;
 			expect(after.status).toBe('cancelled');
 			expect(after.result).toContain('Workflow node deleted-node no longer exists');
+			expect(workflowRunRepo.getRun(run.id)!.status).toBe('blocked');
+			expect(taskRepo.getTask(task.id)!.status).toBe('blocked');
+			expect(taskRepo.getTask(task.id)!.blockReason).toBe('workflow_invalid');
 		});
 
 		test('blocked execution → run untouched (existing blocked-recovery path owns it)', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -48,6 +48,7 @@ import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-w
 import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
 import { SpaceRuntime } from '../../../../src/lib/space/runtime/space-runtime.ts';
 import type { SpaceRuntimeConfig } from '../../../../src/lib/space/runtime/space-runtime.ts';
+import { PermanentSpawnError } from '../../../../src/lib/space/runtime/workflow-node-execution-validation.ts';
 import type { SpaceWorkflow, SpaceRuntimeNotification, NodeExecutionStatus } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
@@ -1768,7 +1769,7 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 			expect(notifications.length).toBe(0);
 		});
 
-		test('stale pending execution is cancelled during restart recovery', async () => {
+		test('stale pending execution is cancelled when tick attempts spawn', async () => {
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: STEP_A, name: 'Step A', agentId: AGENT },
 			]);
@@ -1779,11 +1780,36 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 				title: 'Stale Pending Exec',
 			});
 			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Stale Pending Exec',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
 
 			const stale = seedExec(run.id, 'deleted-node', 'Step A', 'pending');
+			const tam = {
+				rehydrate: async () => {},
+				isExecutionSpawning: () => false,
+				isSessionAlive: () => false,
+				tryResumeNodeAgentSession: async () => {},
+				spawnWorkflowNodeAgentForExecution: async () => {
+					throw new PermanentSpawnError(
+						'Workflow node deleted-node no longer exists in workflow definition'
+					);
+				},
+				flushPendingMessagesForTarget: async () => {},
+				cancelBySessionId: () => {},
+				interruptBySessionId: async () => {},
+			};
 
-			const rt = makeRuntime();
+			const rt = makeRuntime({ taskAgentManager: tam as never });
 			await rt.recoverStalledRuns();
+			expect(nodeExecutionRepo.getById(stale.id)!.status).toBe('pending');
+
+			await rt.executeTick();
 
 			const after = nodeExecutionRepo.getById(stale.id)!;
 			expect(after.status).toBe('cancelled');

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -1788,10 +1788,17 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 				workflowNodeId: STEP_A,
 				status: 'in_progress',
 			});
-			const execution = seedExec(run.id, STEP_A, 'Step A', 'pending');
+			const execution = seedExec(run.id, STEP_A, 'Step A', 'in_progress', {
+				agentSessionId: 'session:missing-workflow',
+			});
 			workflowManager.deleteWorkflow(workflow.id);
+			const cancelledSessions: string[] = [];
+			const tam = {
+				rehydrate: async () => {},
+				cancelBySessionId: (sessionId: string) => cancelledSessions.push(sessionId),
+			};
 
-			const rt = makeRuntime();
+			const rt = makeRuntime({ taskAgentManager: tam as never });
 			await rt.recoverStalledRuns();
 
 			const reason = `Workflow ${workflow.id} no longer exists; workflow run cannot continue`;
@@ -1799,7 +1806,9 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 			expect(taskRepo.getTask(task.id)!.status).toBe('blocked');
 			expect(taskRepo.getTask(task.id)!.blockReason).toBe('workflow_invalid');
 			expect(nodeExecutionRepo.getById(execution.id)!.status).toBe('cancelled');
+			expect(nodeExecutionRepo.getById(execution.id)!.agentSessionId).toBeNull();
 			expect(nodeExecutionRepo.getById(execution.id)!.result).toBe(reason);
+			expect(cancelledSessions).toEqual(['session:missing-workflow']);
 			expect(notifications.some((n) => n.kind === 'workflow_run_blocked')).toBe(true);
 		});
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -1769,6 +1769,40 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 			expect(notifications.length).toBe(0);
 		});
 
+		test('run with deleted workflow is blocked during restart recovery', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Step A', agentId: AGENT },
+			]);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Deleted Workflow Run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+			const task = taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Deleted Workflow Run',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				status: 'in_progress',
+			});
+			const execution = seedExec(run.id, STEP_A, 'Step A', 'pending');
+			workflowManager.deleteWorkflow(workflow.id);
+
+			const rt = makeRuntime();
+			await rt.recoverStalledRuns();
+
+			const reason = `Workflow ${workflow.id} no longer exists; workflow run cannot continue`;
+			expect(workflowRunRepo.getRun(run.id)!.status).toBe('blocked');
+			expect(taskRepo.getTask(task.id)!.status).toBe('blocked');
+			expect(taskRepo.getTask(task.id)!.blockReason).toBe('workflow_invalid');
+			expect(nodeExecutionRepo.getById(execution.id)!.status).toBe('cancelled');
+			expect(nodeExecutionRepo.getById(execution.id)!.result).toBe(reason);
+			expect(notifications.some((n) => n.kind === 'workflow_run_blocked')).toBe(true);
+		});
+
 		test('stale pending execution is cancelled when tick attempts spawn', async () => {
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: STEP_A, name: 'Step A', agentId: AGENT },


### PR DESCRIPTION
Cancels workflow node executions that no longer match the current workflow definition before spawn/activation, treating missing workflows/nodes/agent slots as permanent failures instead of retrying forever.

Also adds shared spawn validation/error classification and covers restart cleanup with a unit test.