### PR TITLE
Fix workflow node respawn state tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,10 @@ make run [PORT=8080]             # Production server (PORT optional)
 make test-daemon       # Daemon tests (all shards in parallel, with coverage)
 make test-web          # Web tests only (vitest run) with coverage
 
+# Never run bare `bun test` from the monorepo root. It is too broad/slow and
+# includes suites with expected environment-specific failures. Use focused
+# package commands or explicit test files instead.
+
 # Daemon test runner (scripts/test-daemon.sh)
 # Do NOT run `bun test packages/daemon/tests/unit`; use this shard runner instead.
 ./scripts/test-daemon.sh                # All daemon unit shards in parallel (fast, no coverage)

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2154,36 +2154,7 @@ export class SpaceRuntime {
 			nodeExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
 
 			if (blockedByCrash) {
-				const blockedReason =
-					nodeExecutions.find((execution) => execution.status === 'blocked')?.result ??
-					'One or more workflow agents are blocked';
-				const dedupKey = `${canonicalTask.id}:blocked`;
-				if (!this.notifiedTaskSet.has(dedupKey)) {
-					this.notifiedTaskSet.add(dedupKey);
-					await this.safeNotify({
-						kind: 'task_blocked',
-						spaceId: meta.spaceId,
-						taskId: canonicalTask.id,
-						reason: blockedReason,
-						timestamp: new Date().toISOString(),
-					});
-				}
-				await this.transitionRunStatusAndEmit(runId, 'blocked');
-				if (canonicalTask.status !== 'blocked') {
-					await this.updateTaskAndEmit(meta.spaceId, canonicalTask.id, {
-						status: 'blocked',
-						result: blockedReason,
-						blockReason: 'agent_crashed',
-						completedAt: null,
-					});
-				}
-				await this.safeNotify({
-					kind: 'workflow_run_blocked',
-					spaceId: meta.spaceId,
-					runId,
-					reason: 'One or more tasks require attention',
-					timestamp: new Date().toISOString(),
-				});
+				await this.blockRunForAgentCrash(runId, meta.spaceId, canonicalTask, nodeExecutions);
 				return;
 			}
 
@@ -2521,6 +2492,11 @@ export class SpaceRuntime {
 							);
 						}
 					}
+					if (blockedByCrash) {
+						nodeExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
+						await this.blockRunForAgentCrash(runId, meta.spaceId, canonicalTask, nodeExecutions);
+						return;
+					}
 					if (
 						canonicalTask.status === 'open' ||
 						(canonicalTask.status === 'review' && canonicalTask.pendingCheckpointType === 'gate')
@@ -2761,6 +2737,44 @@ export class SpaceRuntime {
 			}
 		}
 		return null;
+	}
+
+	private async blockRunForAgentCrash(
+		runId: string,
+		spaceId: string,
+		canonicalTask: SpaceTask,
+		nodeExecutions: NodeExecution[]
+	): Promise<void> {
+		const blockedReason =
+			nodeExecutions.find((execution) => execution.status === 'blocked')?.result ??
+			'One or more workflow agents are blocked';
+		const dedupKey = `${canonicalTask.id}:blocked`;
+		if (!this.notifiedTaskSet.has(dedupKey)) {
+			this.notifiedTaskSet.add(dedupKey);
+			await this.safeNotify({
+				kind: 'task_blocked',
+				spaceId,
+				taskId: canonicalTask.id,
+				reason: blockedReason,
+				timestamp: new Date().toISOString(),
+			});
+		}
+		await this.transitionRunStatusAndEmit(runId, 'blocked');
+		if (canonicalTask.status !== 'blocked') {
+			await this.updateTaskAndEmit(spaceId, canonicalTask.id, {
+				status: 'blocked',
+				result: blockedReason,
+				blockReason: 'agent_crashed',
+				completedAt: null,
+			});
+		}
+		await this.safeNotify({
+			kind: 'workflow_run_blocked',
+			spaceId,
+			runId,
+			reason: 'One or more tasks require attention',
+			timestamp: new Date().toISOString(),
+		});
 	}
 
 	private async blockRunForQueuedHandoffFailure(

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1907,7 +1907,7 @@ export class SpaceRuntime {
 		const crashKey = `${runId}:${execution.id}`;
 		const crashCount = (this.taskCrashCounts.get(crashKey) ?? 0) + 1;
 		this.taskCrashCounts.set(crashKey, crashCount);
-		const exhausted = crashCount >= MAX_TASK_AGENT_CRASH_RETRIES;
+		const exhausted = crashCount > MAX_TASK_AGENT_CRASH_RETRIES;
 		if (exhausted) {
 			log.warn(
 				`SpaceRuntime: workflow node agent spawn/retry failed for execution ${execution.id} ` +

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2492,6 +2492,16 @@ export class SpaceRuntime {
 							);
 						} catch (err) {
 							const stale = this.config.nodeExecutionRepo.getById(execution.id) ?? execution;
+							if (
+								stale.status === 'cancelled' ||
+								stale.status === 'blocked' ||
+								stale.status === 'idle'
+							) {
+								log.warn(
+									`SpaceRuntime: preserving terminal execution ${execution.id} (${stale.status}) after spawn failure: ${err instanceof Error ? err.message : String(err)}`
+								);
+								continue;
+							}
 							if (stale.agentSessionId) {
 								tam.cancelBySessionId(stale.agentSessionId);
 							}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1898,6 +1898,46 @@ export class SpaceRuntime {
 	 * Process a single workflow run tick: re-read from DB, recreate executor
 	 * with fresh state, detect issues, and spawn/monitor Task Agent sessions.
 	 */
+	private resetWorkflowNodeExecutionForSpawnRetry(
+		runId: string,
+		execution: NodeExecution,
+		reason: string,
+		sessionId: string | null = execution.agentSessionId
+	): boolean {
+		const crashKey = `${runId}:${execution.id}`;
+		const crashCount = (this.taskCrashCounts.get(crashKey) ?? 0) + 1;
+		this.taskCrashCounts.set(crashKey, crashCount);
+		const exhausted = crashCount >= MAX_TASK_AGENT_CRASH_RETRIES;
+		if (exhausted) {
+			log.warn(
+				`SpaceRuntime: workflow node agent spawn/retry failed for execution ${execution.id} ` +
+					`(session ${sessionId ?? 'none'}); marking blocked after ${crashCount} failures ` +
+					`(limit: ${MAX_TASK_AGENT_CRASH_RETRIES}): ${reason}`
+			);
+			this.config.nodeExecutionRepo.update(execution.id, {
+				agentSessionId: null,
+				startedAt: null,
+				status: 'blocked',
+				result: `Agent session failed to spawn or crashed ${crashCount} times consecutively: ${reason}`,
+			});
+			return true;
+		}
+
+		log.warn(
+			`SpaceRuntime: workflow node agent spawn/retry failed for execution ${execution.id} ` +
+				`(session ${sessionId ?? 'none'}); resetting execution to pending ` +
+				`(failure ${crashCount}/${MAX_TASK_AGENT_CRASH_RETRIES}): ${reason}`
+		);
+		this.config.nodeExecutionRepo.update(execution.id, {
+			agentSessionId: null,
+			startedAt: null,
+			status: 'pending',
+			result: null,
+			completedAt: null,
+		});
+		return false;
+	}
+
 	private async processRunTick(runId: string): Promise<void> {
 		// Always re-read run from DB to pick up external status changes (e.g. human
 		// approval reset, external cancellation).
@@ -2076,10 +2116,6 @@ export class SpaceRuntime {
 					continue;
 				}
 
-				const crashKey = `${runId}:${execution.id}`;
-				const crashCount = (this.taskCrashCounts.get(crashKey) ?? 0) + 1;
-				this.taskCrashCounts.set(crashKey, crashCount);
-
 				// Part C (task #138): if the dead session was sitting in
 				// `waiting_for_input`, the persisted AskUserQuestion card is now
 				// unanswerable. Try to flip it to `cancelled` (cancelReason
@@ -2098,27 +2134,13 @@ export class SpaceRuntime {
 					);
 				}
 
-				if (crashCount <= MAX_TASK_AGENT_CRASH_RETRIES) {
-					log.warn(
-						`SpaceRuntime: workflow node agent crashed for execution ${execution.id} ` +
-							`(session ${execution.agentSessionId}); resetting execution to pending ` +
-							`(crash ${crashCount}/${MAX_TASK_AGENT_CRASH_RETRIES})`
-					);
-					this.config.nodeExecutionRepo.update(execution.id, {
-						agentSessionId: null,
-						status: 'pending',
-					});
-				} else {
-					log.warn(
-						`SpaceRuntime: workflow node agent crashed for execution ${execution.id} ` +
-							`(session ${execution.agentSessionId}); marking blocked ` +
-							`after ${crashCount} crashes (limit: ${MAX_TASK_AGENT_CRASH_RETRIES})`
-					);
-					this.config.nodeExecutionRepo.update(execution.id, {
-						agentSessionId: null,
-						status: 'blocked',
-						result: `Agent session crashed ${crashCount} times consecutively`,
-					});
+				const exhausted = this.resetWorkflowNodeExecutionForSpawnRetry(
+					runId,
+					execution,
+					'agent session is no longer alive',
+					execution.agentSessionId
+				);
+				if (exhausted) {
 					blockedByCrash = true;
 					await this.safeNotify({
 						kind: 'agent_crash',
@@ -2410,6 +2432,28 @@ export class SpaceRuntime {
 			}
 
 			nodeExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
+			for (const execution of nodeExecutions) {
+				if (execution.status !== 'pending' || !execution.agentSessionId) continue;
+				if (tam.isSessionAlive(execution.agentSessionId)) {
+					log.warn(
+						`SpaceRuntime: repaired pending execution ${execution.id} with live session ${execution.agentSessionId}`
+					);
+					this.config.nodeExecutionRepo.update(execution.id, {
+						status: 'in_progress',
+						agentSessionId: execution.agentSessionId,
+						startedAt: execution.startedAt ?? Date.now(),
+						completedAt: null,
+					});
+					continue;
+				}
+				this.resetWorkflowNodeExecutionForSpawnRetry(
+					runId,
+					execution,
+					'pending execution referenced a dead session before spawn',
+					execution.agentSessionId
+				);
+			}
+			nodeExecutions = this.config.nodeExecutionRepo.listByWorkflowRun(runId);
 			const pendingExecutions = nodeExecutions.filter(
 				(execution) => execution.status === 'pending' && !execution.agentSessionId
 			);
@@ -2436,7 +2480,7 @@ export class SpaceRuntime {
 					for (const execution of pendingExecutions) {
 						if (tam.isExecutionSpawning(execution.id)) continue;
 						try {
-							const sessionId = await tam.spawnWorkflowNodeAgentForExecution(
+							await tam.spawnWorkflowNodeAgentForExecution(
 								canonicalTask,
 								space,
 								meta.workflow,
@@ -2446,19 +2490,20 @@ export class SpaceRuntime {
 									kickoff: true,
 								}
 							);
-							this.config.nodeExecutionRepo.update(execution.id, {
-								status: 'in_progress',
-								agentSessionId: sessionId,
-							});
 						} catch (err) {
-							const stale = this.config.nodeExecutionRepo.getById(execution.id);
-							if (stale?.agentSessionId) {
+							const stale = this.config.nodeExecutionRepo.getById(execution.id) ?? execution;
+							if (stale.agentSessionId) {
 								tam.cancelBySessionId(stale.agentSessionId);
-								this.config.nodeExecutionRepo.update(execution.id, {
-									agentSessionId: null,
-									status: 'pending',
-									result: null,
-								});
+							}
+							if (
+								this.resetWorkflowNodeExecutionForSpawnRetry(
+									runId,
+									stale,
+									err instanceof Error ? err.message : String(err),
+									stale.agentSessionId
+								)
+							) {
+								blockedByCrash = true;
 							}
 							log.error(
 								`SpaceRuntime: failed to spawn workflow node agent for execution ${execution.id}:`,
@@ -2607,13 +2652,17 @@ export class SpaceRuntime {
 				}
 
 				if (execution.agentSessionId && !tam.isSessionAlive(execution.agentSessionId)) {
-					this.config.nodeExecutionRepo.update(execution.id, {
-						agentSessionId: null,
-						status: 'pending',
-						result: null,
-						completedAt: null,
-					});
+					this.resetWorkflowNodeExecutionForSpawnRetry(
+						runId,
+						execution,
+						'queued handoff execution referenced a dead session before spawn',
+						execution.agentSessionId
+					);
 					execution = this.config.nodeExecutionRepo.getById(execution.id) ?? execution;
+					if (execution.status === 'blocked') {
+						blockedReason = execution.result ?? 'Queued workflow handoff target failed to spawn';
+						continue;
+					}
 				}
 
 				if (execution.status === 'blocked' || execution.status === 'cancelled') {
@@ -2638,10 +2687,6 @@ export class SpaceRuntime {
 					execution,
 					{ kickoff: true }
 				);
-				this.config.nodeExecutionRepo.update(execution.id, {
-					status: 'in_progress',
-					agentSessionId: sessionId,
-				});
 				await tam.flushPendingMessagesForTarget(runId, execution.agentName, sessionId);
 				recordBlockedFlushFailure(targetAgentName, rowsForTarget);
 			} catch (err) {

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -1015,7 +1015,7 @@ export class TaskAgentManager {
 					actualSessionId: updatedExecution?.agentSessionId ?? null,
 				});
 				this.config.nodeExecutionRepo.update(execution.id, {
-					status: 'cancelled',
+					status: 'blocked',
 					result: 'Execution state corruption after spawn',
 					completedAt: Date.now(),
 				});

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -843,6 +843,13 @@ export class TaskAgentManager {
 		options: SpawnTaskAgentOptions = {}
 	): Promise<string> {
 		if (execution.agentSessionId && this.agentSessionIndex.has(execution.agentSessionId)) {
+			const startedAt = execution.startedAt ?? Date.now();
+			this.config.nodeExecutionRepo.update(execution.id, {
+				status: 'in_progress',
+				agentSessionId: execution.agentSessionId,
+				startedAt,
+				completedAt: null,
+			});
 			return execution.agentSessionId;
 		}
 
@@ -985,6 +992,34 @@ export class TaskAgentManager {
 			const spawned = this.getSubSession(actualSessionId);
 			if (!spawned) {
 				throw new Error(`Spawned node session ${actualSessionId} is not registered in memory`);
+			}
+
+			const startedAt = Date.now();
+			const updatedExecution = this.config.nodeExecutionRepo.update(execution.id, {
+				status: 'in_progress',
+				agentSessionId: actualSessionId,
+				startedAt,
+				completedAt: null,
+			});
+			if (
+				!updatedExecution ||
+				updatedExecution.status !== 'in_progress' ||
+				updatedExecution.agentSessionId !== actualSessionId ||
+				!updatedExecution.startedAt
+			) {
+				log.error('[Spawn] Execution state mismatch after spawn', {
+					executionId: execution.id,
+					expectedStatus: 'in_progress',
+					actualStatus: updatedExecution?.status ?? null,
+					expectedSessionId: actualSessionId,
+					actualSessionId: updatedExecution?.agentSessionId ?? null,
+				});
+				this.config.nodeExecutionRepo.update(execution.id, {
+					status: 'cancelled',
+					result: 'Execution state corruption after spawn',
+					completedAt: Date.now(),
+				});
+				throw new Error(`Execution state corruption after spawn for ${execution.id}`);
 			}
 
 			// Defensive guarantee: verify the node-agent MCP server is present in the
@@ -1305,17 +1340,25 @@ export class TaskAgentManager {
 							`TaskAgentManager: reusing session ${existingSessionId} for agent "${memberInfo.agentName}" (task ${taskId}); skipping new session ${sessionId}`
 						);
 
-						// Point the new NodeExecution at the existing session ID.
+						// Point the new NodeExecution at the existing session ID and mark it active.
 						if (memberInfo.nodeId) {
 							const nodeExecs = this.config.nodeExecutionRepo.listByNode(
 								parentTask.workflowRunId,
 								memberInfo.nodeId
 							);
-							const match = nodeExecs.find(
-								(e) => e.agentName === memberInfo.agentName && !e.agentSessionId
-							);
+							const match =
+								nodeExecs.find((e) => e.agentName === memberInfo.agentName && !e.agentSessionId) ??
+								nodeExecs.find(
+									(e) =>
+										e.agentName === memberInfo.agentName && e.agentSessionId === existingSessionId
+								);
 							if (match) {
-								this.config.nodeExecutionRepo.updateSessionId(match.id, existingSessionId);
+								this.config.nodeExecutionRepo.update(match.id, {
+									status: 'in_progress',
+									agentSessionId: existingSessionId,
+									startedAt: match.startedAt ?? Date.now(),
+									completedAt: null,
+								});
 							}
 						}
 
@@ -1449,9 +1492,9 @@ export class TaskAgentManager {
 		// Register in SessionManager cache to prevent duplicate AgentSession creation.
 		this.config.sessionManager.registerSession(subSession);
 
-		// Write agent_session_id on the matching NodeExecution record so that
-		// AgentMessageRouter, sibling cleanup, and live-query SQL can resolve
-		// the session. Requires nodeId (workflowNodeId) and agentName.
+		// Write active execution state on the matching NodeExecution record so that
+		// AgentMessageRouter, sibling cleanup, timeout tracking, and live-query SQL
+		// can resolve the session. Requires nodeId (workflowNodeId) and agentName.
 		if (memberInfo?.nodeId && memberInfo.agentName) {
 			const parentTask = this.config.taskRepo.getTask(taskId);
 			if (parentTask?.workflowRunId) {
@@ -1461,7 +1504,12 @@ export class TaskAgentManager {
 				);
 				const match = nodeExecs.find((e) => e.agentName === memberInfo.agentName);
 				if (match && !match.agentSessionId) {
-					this.config.nodeExecutionRepo.updateSessionId(match.id, sessionId);
+					this.config.nodeExecutionRepo.update(match.id, {
+						status: 'in_progress',
+						agentSessionId: sessionId,
+						startedAt: match.startedAt ?? Date.now(),
+						completedAt: null,
+					});
 				} else if (match && match.agentSessionId) {
 					log.warn(
 						`TaskAgentManager: NodeExecution ${match.id} already has agentSessionId ${match.agentSessionId}; skipping update for new session ${sessionId}`

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
@@ -2547,6 +2547,82 @@ describe('TaskAgentManager', () => {
 			}
 		});
 
+		test('cancels execution when post-spawn state verification detects mismatch', async () => {
+			const wfId = 'wf-spawn-mismatch';
+			const wfRunId = 'run-spawn-mismatch';
+			const nodeId = 'node-spawn-mismatch';
+			const now = Date.now();
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, tags, layout, created_at, updated_at) VALUES (?, ?, ?, '', ?, '[]', '{}', ?, ?)`
+				)
+				.run(wfId, ctx.spaceId, 'Spawn Mismatch WF', nodeId, now, now);
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO space_workflow_nodes (id, workflow_id, name, description, config, created_at, updated_at) VALUES (?, ?, ?, '', ?, ?, ?)`
+				)
+				.run(
+					nodeId,
+					wfId,
+					'Coding',
+					JSON.stringify({ agents: [{ agentId: ctx.agentId, name: 'coder' }] }),
+					now,
+					now
+				);
+			ctx.bunDb
+				.prepare(
+					`INSERT INTO space_workflow_runs (id, space_id, workflow_id, title, status, created_at, updated_at) VALUES (?, ?, ?, '', 'in_progress', ?, ?)`
+				)
+				.run(wfRunId, ctx.spaceId, wfId, now, now);
+			const task = await ctx.taskManager.createTask({
+				title: 'Spawn mismatch task',
+				description: '',
+				taskType: 'coding',
+				status: 'in_progress',
+				workflowRunId: wfRunId,
+			});
+			const workflow = ctx.workflowManager.getWorkflow(wfId)!;
+			const run = ctx.workflowRunRepo.getRun(wfRunId)!;
+			const execution = ctx.nodeExecutionRepo.create({
+				workflowRunId: wfRunId,
+				workflowNodeId: nodeId,
+				agentName: 'coder',
+				agentId: ctx.agentId,
+				status: 'pending',
+			});
+			const originalUpdate = ctx.nodeExecutionRepo.update.bind(ctx.nodeExecutionRepo);
+			let inProgressUpdates = 0;
+			ctx.nodeExecutionRepo.update = ((executionId, patch) => {
+				if (patch.status === 'in_progress' && ++inProgressUpdates >= 2) {
+					return originalUpdate(executionId, {
+						...patch,
+						status: 'pending',
+						agentSessionId: 'wrong-session',
+					});
+				}
+				return originalUpdate(executionId, patch);
+			}) as typeof ctx.nodeExecutionRepo.update;
+
+			try {
+				await expect(
+					ctx.manager.spawnWorkflowNodeAgentForExecution(
+						task,
+						ctx.space,
+						workflow,
+						run,
+						execution,
+						{ kickoff: false }
+					)
+				).rejects.toThrow('Execution state corruption after spawn');
+				const updated = ctx.nodeExecutionRepo.getById(execution.id)!;
+				expect(updated.status).toBe('cancelled');
+				expect(updated.result).toBe('Execution state corruption after spawn');
+				expect(updated.completedAt).toBeTruthy();
+			} finally {
+				ctx.nodeExecutionRepo.update = originalUpdate;
+			}
+		});
+
 		test('resets stale execution session before spawning target session', async () => {
 			const { wfRunId, reviewNodeId, taskId } = await seedRunWithTwoNodes();
 			const staleSessionId = 'stale-reviewer-session';

--- a/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/task-agent-manager.test.ts
@@ -2547,7 +2547,7 @@ describe('TaskAgentManager', () => {
 			}
 		});
 
-		test('cancels execution when post-spawn state verification detects mismatch', async () => {
+		test('blocks execution when post-spawn state verification detects mismatch', async () => {
 			const wfId = 'wf-spawn-mismatch';
 			const wfRunId = 'run-spawn-mismatch';
 			const nodeId = 'node-spawn-mismatch';
@@ -2615,7 +2615,7 @@ describe('TaskAgentManager', () => {
 					)
 				).rejects.toThrow('Execution state corruption after spawn');
 				const updated = ctx.nodeExecutionRepo.getById(execution.id)!;
-				expect(updated.status).toBe('cancelled');
+				expect(updated.status).toBe('blocked');
 				expect(updated.result).toBe('Execution state corruption after spawn');
 				expect(updated.completedAt).toBeTruthy();
 			} finally {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
@@ -175,6 +175,8 @@ class MockTaskAgentManager {
 	readonly interruptedSessions: string[] = [];
 	readonly spawnedExecutionSessions: string[] = [];
 
+	constructor(private readonly nodeExecutionRepo?: NodeExecutionRepository) {}
+
 	isTaskAgentAlive(_taskId: string): boolean {
 		return false;
 	}
@@ -209,6 +211,12 @@ class MockTaskAgentManager {
 	): Promise<string> {
 		const sessionId = `mock-session:${execution.id}`;
 		this.spawnedExecutionSessions.push(sessionId);
+		this.nodeExecutionRepo?.update(execution.id, {
+			status: 'in_progress',
+			agentSessionId: sessionId,
+			startedAt: Date.now(),
+			completedAt: null,
+		});
 		return sessionId;
 	}
 
@@ -272,7 +280,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			taskRepo,
 			nodeExecutionRepo,
 			notificationSink: sink,
-			taskAgentManager: new MockTaskAgentManager() as unknown as TaskAgentManager,
+			taskAgentManager: new MockTaskAgentManager(nodeExecutionRepo) as unknown as TaskAgentManager,
 			...extraConfig,
 		};
 		return new SpaceRuntime(config);
@@ -1091,7 +1099,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			// their status transitions to `idle` — NOT `cancelled` — so they
 			// remain a valid message target. The session itself is kept alive
 			// in memory; only `archived` triggers full teardown.
-			const mockTam = new MockTaskAgentManager();
+			const mockTam = new MockTaskAgentManager(nodeExecutionRepo);
 			mockTam.isSessionAlive = () => true;
 			const rt = makeRuntimeWithTam({
 				taskAgentManager: mockTam as unknown as TaskAgentManager,
@@ -1157,7 +1165,7 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			// These two invariants are what list_peers / deliverMessage rely on
 			// when the Task Agent asks for a reviewer→coder send_message to
 			// succeed after the coder node has finished.
-			const mockTam = new MockTaskAgentManager();
+			const mockTam = new MockTaskAgentManager(nodeExecutionRepo);
 			mockTam.isSessionAlive = () => true;
 			const rt = makeRuntimeWithTam({
 				taskAgentManager: mockTam as unknown as TaskAgentManager,

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-stalled-recovery.test.ts
@@ -895,6 +895,12 @@ describe('SpaceRuntime — recoverStalledRuns()', () => {
 				) => {
 					const sessionId = `session:${execution.id}`;
 					live.add(sessionId);
+					nodeExecutionRepo.update(execution.id, {
+						status: 'in_progress',
+						agentSessionId: sessionId,
+						startedAt: Date.now(),
+						completedAt: null,
+					});
 					return sessionId;
 				},
 				flushPendingMessagesForTarget: async (

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-tick-loop.test.ts
@@ -91,6 +91,7 @@ function buildLinearWorkflow(
 
 function makeMockTaskAgentManager(
 	taskRepo: SpaceTaskRepository,
+	nodeExecutionRepo: NodeExecutionRepository,
 	overrides: {
 		isSpawning?: (taskId: string) => boolean;
 		isTaskAgentAlive?: (taskId: string) => boolean;
@@ -124,8 +125,17 @@ function makeMockTaskAgentManager(
 			if (overrides.spawnWorkflowNodeAgent) {
 				const legacySessionId = await overrides.spawnWorkflowNodeAgent(task);
 				const t = task as { id?: string };
+				const e = execution as { id?: string };
 				if (t.id && legacySessionId) sessionToTask.set(legacySessionId, t.id);
 				if (t.id) spawned.push(t.id);
+				if (e.id) {
+					nodeExecutionRepo.update(e.id, {
+						status: 'in_progress',
+						agentSessionId: legacySessionId,
+						startedAt: Date.now(),
+						completedAt: null,
+					});
+				}
 				return legacySessionId;
 			}
 			const e = execution as { id?: string };
@@ -135,6 +145,14 @@ function makeMockTaskAgentManager(
 			const sessionId = `session:${executionId}`;
 			sessionToTask.set(sessionId, taskId);
 			spawned.push(taskId);
+			if (e.id) {
+				nodeExecutionRepo.update(e.id, {
+					status: 'in_progress',
+					agentSessionId: sessionId,
+					startedAt: Date.now(),
+					completedAt: null,
+				});
+			}
 			return sessionId;
 		});
 	const spawnImpl =
@@ -255,7 +273,7 @@ describe('SpaceRuntime — tick loop correctness', () => {
 
 	describe('tick picks up new tasks from workflow runs', () => {
 		test('tick spawns agent for task created by startWorkflowRun before first tick', async () => {
-			const tam = makeMockTaskAgentManager(taskRepo);
+			const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo);
 			const rt = new SpaceRuntime(buildConfig(tam));
 
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
@@ -274,7 +292,7 @@ describe('SpaceRuntime — tick loop correctness', () => {
 		});
 
 		test('tick picks up workflow run created between ticks', async () => {
-			const tam = makeMockTaskAgentManager(taskRepo, {
+			const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
 				isTaskAgentAlive: (taskId: string) => {
 					const task = taskRepo.getTask(taskId);
 					return !!task?.taskAgentSessionId;
@@ -300,7 +318,7 @@ describe('SpaceRuntime — tick loop correctness', () => {
 		});
 
 		test('tick picks up tasks added to an existing run between ticks', async () => {
-			const tam = makeMockTaskAgentManager(taskRepo, {
+			const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
 				isTaskAgentAlive: (taskId: string) => {
 					const task = taskRepo.getTask(taskId);
 					return !!task?.taskAgentSessionId;
@@ -349,7 +367,7 @@ describe('SpaceRuntime — tick loop correctness', () => {
 
 	describe('multiple ticks do not duplicate executors', () => {
 		test('executor count stays 1 after multiple ticks for the same active run', async () => {
-			const tam = makeMockTaskAgentManager(taskRepo, {
+			const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
 				isTaskAgentAlive: () => true,
 			});
 			const rt = new SpaceRuntime(buildConfig(tam));
@@ -370,7 +388,7 @@ describe('SpaceRuntime — tick loop correctness', () => {
 		});
 
 		test('two different runs produce exactly two executors across multiple ticks', async () => {
-			const tam = makeMockTaskAgentManager(taskRepo, {
+			const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
 				isTaskAgentAlive: () => true,
 			});
 			const rt = new SpaceRuntime(buildConfig(tam));
@@ -402,7 +420,7 @@ describe('SpaceRuntime — tick loop correctness', () => {
 	describe('tick skips already-running tasks', () => {
 		test('in_progress task with alive agent is not re-spawned', async () => {
 			let spawnCount = 0;
-			const tam = makeMockTaskAgentManager(taskRepo, {
+			const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
 				isTaskAgentAlive: () => true,
 				spawnWorkflowNodeAgent: async (task: unknown) => {
 					const t = task as { id: string };
@@ -441,7 +459,7 @@ describe('SpaceRuntime — tick loop correctness', () => {
 			// The fresh runtime rehydrates both runs on first tick, then
 			// processRunTick throws for run1 but succeeds for run2.
 			const spawned: string[] = [];
-			const tam = makeMockTaskAgentManager(taskRepo, {
+			const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
 				isTaskAgentAlive: (taskId: string) => {
 					const task = taskRepo.getTask(taskId);
 					return !!task?.taskAgentSessionId;
@@ -491,7 +509,7 @@ describe('SpaceRuntime — tick loop correctness', () => {
 
 		test('first error is re-thrown after all runs are processed', async () => {
 			// Create two runs with real spaceManager first
-			const tam = makeMockTaskAgentManager(taskRepo);
+			const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo);
 			const realRt = new SpaceRuntime(buildConfig(tam));
 
 			const wf1 = buildLinearWorkflow(SPACE_ID, workflowManager, [
@@ -676,7 +694,7 @@ describe('SpaceRuntime — tick loop correctness', () => {
 		});
 
 		test('cleanupTerminalExecutors leaves in_progress runs alone', async () => {
-			const tam = makeMockTaskAgentManager(taskRepo, {
+			const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
 				isTaskAgentAlive: () => true,
 			});
 			const rt = new SpaceRuntime(buildConfig(tam));
@@ -708,7 +726,7 @@ describe('SpaceRuntime — tick loop correctness', () => {
 
 	describe('multiple independent workflow runs in same tick', () => {
 		test('tick spawns agents for tasks across multiple runs', async () => {
-			const tam = makeMockTaskAgentManager(taskRepo, {
+			const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
 				isTaskAgentAlive: (taskId: string) => {
 					const task = taskRepo.getTask(taskId);
 					return !!task?.taskAgentSessionId;
@@ -737,7 +755,7 @@ describe('SpaceRuntime — tick loop correctness', () => {
 		});
 
 		test('one run completing does not affect sibling run processing', async () => {
-			const tam = makeMockTaskAgentManager(taskRepo, {
+			const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
 				isTaskAgentAlive: () => true,
 			});
 			const rt = new SpaceRuntime(buildConfig(tam));
@@ -858,7 +876,7 @@ describe('SpaceRuntime — tick loop correctness', () => {
 		test('spawn failure for one task does not prevent spawning another task', async () => {
 			let callCount = 0;
 			const spawned: string[] = [];
-			const tam = makeMockTaskAgentManager(taskRepo, {
+			const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
 				isTaskAgentAlive: (taskId: string) => {
 					const task = taskRepo.getTask(taskId);
 					return !!task?.taskAgentSessionId;
@@ -900,7 +918,7 @@ describe('SpaceRuntime — tick loop correctness', () => {
 
 		test('spawn failure keeps task in open status for retry on next tick', async () => {
 			let failOnce = true;
-			const tam = makeMockTaskAgentManager(taskRepo, {
+			const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
 				isTaskAgentAlive: (taskId: string) => {
 					const task = taskRepo.getTask(taskId);
 					return !!task?.taskAgentSessionId;
@@ -943,7 +961,7 @@ describe('SpaceRuntime — tick loop correctness', () => {
 
 	describe('rehydration does not duplicate executors from startWorkflowRun', () => {
 		test('startWorkflowRun before first tick — rehydration skips already-registered executor', async () => {
-			const tam = makeMockTaskAgentManager(taskRepo, {
+			const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
 				isTaskAgentAlive: () => true,
 			});
 			const rt = new SpaceRuntime(buildConfig(tam));
@@ -970,7 +988,7 @@ describe('SpaceRuntime — tick loop correctness', () => {
 	describe('rehydration happens exactly once', () => {
 		test('rehydrate is called exactly once across multiple ticks', async () => {
 			let rehydrateCount = 0;
-			const tam = makeMockTaskAgentManager(taskRepo, {
+			const tam = makeMockTaskAgentManager(taskRepo, nodeExecutionRepo, {
 				rehydrate: async () => {
 					rehydrateCount++;
 				},

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
@@ -1170,6 +1170,12 @@ describe('SpaceRuntime', () => {
 						? await overrides.spawn(execution.id)
 						: `session:${execution.id}`;
 					liveSessions.add(sessionId);
+					nodeExecutionRepo.update(execution.id, {
+						status: 'in_progress',
+						agentSessionId: sessionId,
+						startedAt: Date.now(),
+						completedAt: null,
+					});
 					return sessionId;
 				},
 				flushPendingMessagesForTarget: async (
@@ -1355,6 +1361,60 @@ describe('SpaceRuntime', () => {
 			await buildRepairRuntime(tam, pendingRepo).executeTick();
 			expect(resumedAgentName).toBe('coder-slot');
 			expect(tam._spawnedExecutionIds).toHaveLength(1);
+		});
+
+		test('repairs pending execution state when it references a live session before spawn', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Coder', agentId: AGENT_CODER },
+			]);
+			const { run, tasks } = await runtime.startWorkflowRun(
+				SPACE_ID,
+				workflow.id,
+				'Respawn repair'
+			);
+			taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+			const execution = nodeExecutionRepo.listByWorkflowRun(run.id)[0]!;
+			nodeExecutionRepo.update(execution.id, {
+				status: 'pending',
+				agentSessionId: 'session:live-respawn',
+				startedAt: null,
+				completedAt: null,
+			});
+			const tam = makeRepairTam({ liveSessions: new Set(['session:live-respawn']) });
+			await buildRepairRuntime(tam, new PendingAgentMessageRepository(db)).executeTick();
+			const updated = nodeExecutionRepo.getById(execution.id)!;
+			expect(updated.status).toBe('in_progress');
+			expect(updated.agentSessionId).toBe('session:live-respawn');
+			expect(updated.startedAt).toBeTruthy();
+			expect(tam._spawnedExecutionIds).toHaveLength(0);
+		});
+
+		test('clears dead pending session references and spawns a fresh session', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Coder', agentId: AGENT_CODER },
+			]);
+			const { run, tasks } = await runtime.startWorkflowRun(
+				SPACE_ID,
+				workflow.id,
+				'Dead respawn repair'
+			);
+			taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+			const execution = nodeExecutionRepo.listByWorkflowRun(run.id)[0]!;
+			nodeExecutionRepo.update(execution.id, {
+				status: 'pending',
+				agentSessionId: 'session:dead-respawn',
+				startedAt: null,
+				result: 'stale error',
+				completedAt: Date.now(),
+			});
+			const tam = makeRepairTam();
+			await buildRepairRuntime(tam, new PendingAgentMessageRepository(db)).executeTick();
+			const updated = nodeExecutionRepo.getById(execution.id)!;
+			expect(tam._spawnedExecutionIds).toEqual([execution.id]);
+			expect(updated.status).toBe('in_progress');
+			expect(updated.agentSessionId).toBe(`session:${execution.id}`);
+			expect(updated.result).toBeNull();
+			expect(updated.completedAt).toBeNull();
 		});
 
 		test('resolved handoffs do not bind to a different live slot on the same node', async () => {
@@ -1627,10 +1687,23 @@ describe('SpaceRuntime', () => {
 					_space: unknown,
 					_workflow: unknown,
 					_run: unknown,
-					_execution: unknown
-				) => spawnImpl(task),
+					execution: unknown
+				) => {
+					const sessionId = await spawnImpl(task);
+					const e = execution as { id?: string };
+					if (e.id) {
+						nodeExecutionRepo.update(e.id, {
+							status: 'in_progress',
+							agentSessionId: sessionId,
+							startedAt: Date.now(),
+							completedAt: null,
+						});
+					}
+					return sessionId;
+				},
 				cancelBySessionId: overrides.cancelBySessionId ?? (() => {}),
 				interruptBySessionId: overrides.interruptBySessionId ?? (async () => {}),
+				getAgentSessionById: () => null,
 				rehydrate: overrides.rehydrate ?? (async () => {}),
 				_spawned: spawned,
 			};

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
@@ -1536,6 +1536,34 @@ describe('SpaceRuntime', () => {
 			expect(taskRepo.getTask(task.id)!.status).toBe('blocked');
 		});
 
+		test('preserves terminal execution state when spawn fails after concurrent cancellation', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Coder', agentId: AGENT_CODER },
+			]);
+			const { run, tasks } = await runtime.startWorkflowRun(
+				SPACE_ID,
+				workflow.id,
+				'Concurrent spawn cancellation'
+			);
+			taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+			const execution = nodeExecutionRepo.listByWorkflowRun(run.id)[0]!;
+			const tam = makeRepairTam({
+				spawn: async (executionId) => {
+					nodeExecutionRepo.update(executionId, {
+						status: 'cancelled',
+						result: 'cancelled concurrently',
+						completedAt: Date.now(),
+					});
+					throw new Error('spawn failed after cancellation');
+				},
+			});
+			await buildRepairRuntime(tam, new PendingAgentMessageRepository(db)).executeTick();
+			const updated = nodeExecutionRepo.getById(execution.id)!;
+			expect(updated.status).toBe('cancelled');
+			expect(updated.result).toBe('cancelled concurrently');
+			expect(updated.agentSessionId).toBeNull();
+		});
+
 		test('activation failures are retried and eventually block the run', async () => {
 			const { run, task, pendingRepo } = await setupQueuedHandoff({ maxAttempts: 2 });
 			const tam = makeRepairTam({

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
@@ -1564,6 +1564,39 @@ describe('SpaceRuntime', () => {
 			expect(updated.agentSessionId).toBeNull();
 		});
 
+		test('spawn retry exhaustion blocks the run in the same tick', async () => {
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: STEP_A, name: 'Coder', agentId: AGENT_CODER },
+			]);
+			const { run, tasks } = await runtime.startWorkflowRun(
+				SPACE_ID,
+				workflow.id,
+				'Spawn retry exhaustion'
+			);
+			taskRepo.updateTask(tasks[0].id, { status: 'in_progress' });
+			const execution = nodeExecutionRepo.listByWorkflowRun(run.id)[0]!;
+			const tam = makeRepairTam({
+				spawn: async () => {
+					throw new Error('spawn keeps failing');
+				},
+			});
+			const rt = buildRepairRuntime(tam, new PendingAgentMessageRepository(db));
+
+			await rt.executeTick();
+			expect(workflowRunRepo.getRun(run.id)!.status).toBe('in_progress');
+			await rt.executeTick();
+			expect(workflowRunRepo.getRun(run.id)!.status).toBe('in_progress');
+			await rt.executeTick();
+
+			const updated = nodeExecutionRepo.getById(execution.id)!;
+			expect(updated.status).toBe('blocked');
+			expect(updated.result).toContain('spawn keeps failing');
+			expect(workflowRunRepo.getRun(run.id)!.status).toBe('blocked');
+			expect(taskRepo.getTask(tasks[0].id)!.status).toBe('blocked');
+			expect(taskRepo.getTask(tasks[0].id)!.blockReason).toBe('agent_crashed');
+			expect(taskRepo.getTask(tasks[0].id)!.result).toContain('spawn keeps failing');
+		});
+
 		test('activation failures are retried and eventually block the run', async () => {
 			const { run, task, pendingRepo } = await setupQueuedHandoff({ maxAttempts: 2 });
 			const tam = makeRepairTam({


### PR DESCRIPTION
Fix workflow node respawn state corruption by marking executions in progress as part of successful spawn, repairing pending rows with live sessions, and counting failed spawn retries while clearing stale session state.

Checks: bun run check