### PR TITLE
Fix workflow restamp ID preservation

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
@@ -62,17 +62,28 @@ function buildTemplateUpdateParams(
 		return spaceAgents.find((a) => a.name.toLowerCase() === roleName.toLowerCase())?.id;
 	}
 
-	const existingNodeIdsByName = new Map(
-		existingWorkflow?.nodes.map((node) => [node.name, node.id])
-	);
+	const existingNodeIdQueuesByName = new Map<string, string[]>();
+	for (const existingNode of existingWorkflow?.nodes ?? []) {
+		const queue = existingNodeIdQueuesByName.get(existingNode.name) ?? [];
+		queue.push(existingNode.id);
+		existingNodeIdQueuesByName.set(existingNode.name, queue);
+	}
 	const existingNodeIdsInOrder = existingWorkflow?.nodes.map((node) => node.id) ?? [];
+	const usedExistingNodeIds = new Set<string>();
 	const nodeIdMap = new Map<string, string>();
 	for (let i = 0; i < template.nodes.length; i++) {
 		const node = template.nodes[i];
-		nodeIdMap.set(
-			node.id,
-			existingNodeIdsByName.get(node.name) ?? existingNodeIdsInOrder[i] ?? generateUUID()
-		);
+		const nameQueue = existingNodeIdQueuesByName.get(node.name);
+		const existingIdByName = nameQueue?.shift();
+		const existingIdByPosition = existingNodeIdsInOrder[i];
+		const existingId =
+			existingIdByName && !usedExistingNodeIds.has(existingIdByName)
+				? existingIdByName
+				: existingIdByPosition && !usedExistingNodeIds.has(existingIdByPosition)
+					? existingIdByPosition
+					: undefined;
+		if (existingId) usedExistingNodeIds.add(existingId);
+		nodeIdMap.set(node.id, existingId ?? generateUUID());
 	}
 
 	const newNodes = template.nodes.map((node) => {

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-handlers.ts
@@ -54,16 +54,25 @@ function buildTemplateUpdateParams(
 	spaceAgentManager: SpaceAgentManager,
 	spaceId: string,
 	template: SpaceWorkflow,
-	errorVerb: 'sync' | 'resync'
+	errorVerb: 'sync' | 'resync',
+	existingWorkflow?: SpaceWorkflow
 ): UpdateSpaceWorkflowParams {
 	const spaceAgents = spaceAgentManager.listBySpaceId(spaceId);
 	function resolveAgentId(roleName: string): string | undefined {
 		return spaceAgents.find((a) => a.name.toLowerCase() === roleName.toLowerCase())?.id;
 	}
 
+	const existingNodeIdsByName = new Map(
+		existingWorkflow?.nodes.map((node) => [node.name, node.id])
+	);
+	const existingNodeIdsInOrder = existingWorkflow?.nodes.map((node) => node.id) ?? [];
 	const nodeIdMap = new Map<string, string>();
-	for (const node of template.nodes) {
-		nodeIdMap.set(node.id, generateUUID());
+	for (let i = 0; i < template.nodes.length; i++) {
+		const node = template.nodes[i];
+		nodeIdMap.set(
+			node.id,
+			existingNodeIdsByName.get(node.name) ?? existingNodeIdsInOrder[i] ?? generateUUID()
+		);
 	}
 
 	const newNodes = template.nodes.map((node) => {
@@ -568,7 +577,8 @@ export function setupSpaceWorkflowHandlers(
 			spaceAgentManager,
 			params.spaceId,
 			template,
-			'sync'
+			'sync',
+			workflow
 		);
 
 		// Preserve the existing workflow's templateName rather than adopting the
@@ -716,7 +726,8 @@ export function setupSpaceWorkflowHandlers(
 			spaceAgentManager,
 			params.spaceId,
 			template,
-			'resync'
+			'resync',
+			kept
 		);
 
 		// Overwrite the kept row first. If the update fails the duplicates stay

--- a/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
@@ -314,7 +314,10 @@ export class SpaceWorkflowManager {
 		const sameLength =
 			existingIds.length === incomingNodes.length && incomingIds.length === incomingNodes.length;
 		const existingSet = new Set(existingIds);
-		const sameSet = sameLength && incomingIds.every((id) => existingSet.has(id));
+		const sameSet =
+			sameLength &&
+			new Set(incomingIds).size === existingSet.size &&
+			incomingIds.every((id) => existingSet.has(id));
 
 		if (sameSet) return;
 

--- a/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
@@ -157,6 +157,10 @@ export class SpaceWorkflowManager {
 			this.validateName(existing.spaceId, trimmedName, id);
 			params = { ...params, name: trimmedName };
 		}
+		if (params.nodes !== undefined) {
+			this.validateStableNodeIds(id, existing.nodes, params.nodes ?? []);
+		}
+
 		const effectiveNodes: WorkflowNodeInput[] =
 			params.nodes !== undefined
 				? (params.nodes ?? []).map(
@@ -234,6 +238,21 @@ export class SpaceWorkflowManager {
 		return this.repo.updateWorkflow(id, params);
 	}
 
+	/**
+	 * Built-in workflow re-stamping may update structural enforcement metadata on
+	 * existing node-agent slots, but it must never replace node rows. Workflow
+	 * runs and node executions reference node IDs directly, so a template drift
+	 * pass that changes the node ID set would strand in-flight executions.
+	 */
+	updateWorkflowNodeToolGuards(id: string, nodes: SpaceWorkflow['nodes']): void {
+		const existing = this.repo.getWorkflow(id);
+		if (!existing) {
+			throw new WorkflowValidationError(`Workflow not found: ${id}`);
+		}
+		this.validateStableNodeIds(id, existing.nodes, nodes);
+		this.repo.updateWorkflowNodeToolGuards(id, nodes);
+	}
+
 	// -------------------------------------------------------------------------
 	// Delete
 	// -------------------------------------------------------------------------
@@ -283,6 +302,29 @@ export class SpaceWorkflowManager {
 			const node = nodes[i];
 			this.validateNodeAgentRef(spaceId, node, i);
 		}
+	}
+
+	private validateStableNodeIds(
+		workflowId: string,
+		existingNodes: Array<{ id: string }>,
+		incomingNodes: Array<{ id?: string }>
+	): void {
+		const existingIds = existingNodes.map((node) => node.id);
+		const incomingIds = incomingNodes.map((node) => node.id).filter((id): id is string => !!id);
+		const sameLength =
+			existingIds.length === incomingNodes.length && incomingIds.length === incomingNodes.length;
+		const existingSet = new Set(existingIds);
+		const sameSet = sameLength && incomingIds.every((id) => existingSet.has(id));
+
+		if (sameSet) return;
+
+		logger.error(
+			`workflow.idChangeRejected: workflowId=${workflowId} ` +
+				`existingNodeIds=[${existingIds.join(',')}] incomingNodeIds=[${incomingIds.join(',')}]`
+		);
+		throw new WorkflowValidationError(
+			'Workflow node IDs are stable and cannot be added, removed, regenerated, or omitted during update'
+		);
 	}
 
 	private validateNodeAgentRef(spaceId: string, node: WorkflowNodeInput, index: number): void {

--- a/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-workflow-manager.ts
@@ -158,7 +158,9 @@ export class SpaceWorkflowManager {
 			params = { ...params, name: trimmedName };
 		}
 		if (params.nodes !== undefined) {
-			this.validateStableNodeIds(id, existing.nodes, params.nodes ?? []);
+			this.validateStableNodeIds(id, existing.nodes, params.nodes ?? [], {
+				allowStructuralChanges: true,
+			});
 		}
 
 		const effectiveNodes: WorkflowNodeInput[] =
@@ -307,26 +309,29 @@ export class SpaceWorkflowManager {
 	private validateStableNodeIds(
 		workflowId: string,
 		existingNodes: Array<{ id: string }>,
-		incomingNodes: Array<{ id?: string }>
+		incomingNodes: Array<{ id?: string }>,
+		options: { allowStructuralChanges?: boolean } = {}
 	): void {
 		const existingIds = existingNodes.map((node) => node.id);
 		const incomingIds = incomingNodes.map((node) => node.id).filter((id): id is string => !!id);
-		const sameLength =
-			existingIds.length === incomingNodes.length && incomingIds.length === incomingNodes.length;
+		const allIncomingIdsPresent = incomingIds.length === incomingNodes.length;
+		const incomingIdsUnique = new Set(incomingIds).size === incomingIds.length;
 		const existingSet = new Set(existingIds);
 		const sameSet =
-			sameLength &&
+			existingIds.length === incomingNodes.length &&
+			allIncomingIdsPresent &&
 			new Set(incomingIds).size === existingSet.size &&
 			incomingIds.every((id) => existingSet.has(id));
 
 		if (sameSet) return;
+		if (options.allowStructuralChanges && allIncomingIdsPresent && incomingIdsUnique) return;
 
 		logger.error(
 			`workflow.idChangeRejected: workflowId=${workflowId} ` +
 				`existingNodeIds=[${existingIds.join(',')}] incomingNodeIds=[${incomingIds.join(',')}]`
 		);
 		throw new WorkflowValidationError(
-			'Workflow node IDs are stable and cannot be added, removed, regenerated, or omitted during update'
+			'Workflow node IDs are stable and cannot be duplicated, regenerated, or omitted during update'
 		);
 	}
 

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -1430,15 +1430,16 @@ function mergeToolGuardsFromTemplate(
  *   agent name) so structural enforcement metadata stays in sync with the
  *   template. Other node fields (customPrompt, model, disabledSkillIds, etc.)
  *   are preserved.
- * - Channels / gates are NOT re-stamped: changing those would regenerate IDs.
- *   If a future template change adjusts those, extend this list and the
- *   re-stamp payload below accordingly.
+ * - Channels, gates, layout, and node rows are NOT re-stamped. Workflow IDs,
+ *   node IDs, and persisted node-agent slots are stable identifiers for
+ *   in-flight runs, so template drift must never replace node rows. Agent
+ *   `toolGuards` are updated in-place on existing node configs instead.
  */
 const RESTAMP_FIELDS = [
 	'postApproval',
 	'completionAutonomyLevel',
 	'templateHash',
-	'nodes(toolGuards)',
+	'nodes(toolGuards in-place)',
 ] as const;
 
 /**
@@ -1511,9 +1512,9 @@ export function seedBuiltInWorkflows(
 					// so the repository writes the new value rather than leaving the
 					// old one in place.
 					postApproval: template.postApproval ?? null,
-					nodes: mergedNodes,
 					templateHash: expectedHash,
 				});
+				workflowManager.updateWorkflowNodeToolGuards(row.id, mergedNodes);
 				restamped.push(template.name);
 				builtInSeederLog.info(
 					`re-stamped built-in workflow '${template.name}' (id=${row.id}) ` +

--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -380,12 +380,8 @@ export class SpaceWorkflowRepository {
 		}
 
 		if (hasNodeReplacement) {
-			this.db.prepare(`DELETE FROM space_workflow_nodes WHERE workflow_id = ?`).run(id);
 			const nodes = params.nodes ?? [];
-			for (let i = 0; i < nodes.length; i++) {
-				const node = nodes[i];
-				this.insertNode(id, node as WorkflowNodeInput, node.id ?? generateUUID(), i, now);
-			}
+			this.updateWorkflowNodesInPlace(id, nodes as WorkflowNodeInput[], now);
 		}
 
 		return this.getWorkflow(id)!;
@@ -464,13 +460,34 @@ export class SpaceWorkflowRepository {
 		return rows.map((r) => rowToNode(r, ctx));
 	}
 
-	private insertNode(
+	private updateWorkflowNodesInPlace(
 		workflowId: string,
-		input: WorkflowNodeInput,
-		nodeId: string,
-		_index: number,
+		nodes: WorkflowNodeInput[],
 		now: number
 	): void {
+		const updateNode = this.db.prepare(
+			`UPDATE space_workflow_nodes SET name = ?, config = ?, updated_at = ? WHERE workflow_id = ? AND id = ?`
+		);
+
+		for (const node of nodes) {
+			if (!node.id) {
+				log.error(`workflow.node.update.missingStableId: workflowId=${workflowId}`);
+				continue;
+			}
+			const result = updateNode.run(
+				node.name,
+				JSON.stringify(this.buildNodeConfig(node)),
+				now,
+				workflowId,
+				node.id
+			);
+			if (result.changes === 0) {
+				log.error(`workflow.node.update.missingNode: workflowId=${workflowId} nodeId=${node.id}`);
+			}
+		}
+	}
+
+	private buildNodeConfig(input: WorkflowNodeInput): NodeConfigJson {
 		const nodeCfg: NodeConfigJson = {};
 
 		// Normalize agents: use `agents` array if present, otherwise fall back to legacy
@@ -486,12 +503,30 @@ export class SpaceWorkflowRepository {
 			nodeCfg.agents = resolvedAgents;
 		}
 
+		return nodeCfg;
+	}
+
+	private insertNode(
+		workflowId: string,
+		input: WorkflowNodeInput,
+		nodeId: string,
+		_index: number,
+		now: number
+	): void {
 		this.db
 			.prepare(
 				`INSERT INTO space_workflow_nodes
-	           (id, workflow_id, name, description, config, created_at, updated_at)
-	         VALUES (?, ?, ?, ?, ?, ?, ?)`
+		           (id, workflow_id, name, description, config, created_at, updated_at)
+		         VALUES (?, ?, ?, ?, ?, ?, ?)`
 			)
-			.run(nodeId, workflowId, input.name, '', JSON.stringify(nodeCfg), now, now);
+			.run(
+				nodeId,
+				workflowId,
+				input.name,
+				'',
+				JSON.stringify(this.buildNodeConfig(input)),
+				now,
+				now
+			);
 	}
 }

--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -465,8 +465,20 @@ export class SpaceWorkflowRepository {
 		nodes: WorkflowNodeInput[],
 		now: number
 	): void {
+		const existingRows = this.db
+			.prepare(`SELECT id FROM space_workflow_nodes WHERE workflow_id = ? ORDER BY rowid ASC`)
+			.all(workflowId) as Array<{ id: string }>;
+		const existingNodeIds = new Set(existingRows.map((row) => row.id));
+		const incomingNodeIds = new Set(
+			nodes.map((node) => node.id).filter((id): id is string => !!id)
+		);
 		const updateNode = this.db.prepare(
 			`UPDATE space_workflow_nodes SET name = ?, config = ?, updated_at = ? WHERE workflow_id = ? AND id = ?`
+		);
+		const insertNodeRow = this.db.prepare(
+			`INSERT INTO space_workflow_nodes
+				(id, workflow_id, name, description, config, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`
 		);
 		const rowOrderByNodeId = new Map<string, number>();
 
@@ -477,15 +489,22 @@ export class SpaceWorkflowRepository {
 				continue;
 			}
 			rowOrderByNodeId.set(node.id, i + 1);
-			const result = updateNode.run(
-				node.name,
-				JSON.stringify(this.buildNodeConfig(node)),
-				now,
-				workflowId,
-				node.id
-			);
-			if (result.changes === 0) {
-				log.error(`workflow.node.update.missingNode: workflowId=${workflowId} nodeId=${node.id}`);
+			const configJson = JSON.stringify(this.buildNodeConfig(node));
+			if (existingNodeIds.has(node.id)) {
+				const result = updateNode.run(node.name, configJson, now, workflowId, node.id);
+				if (result.changes === 0) {
+					log.error(`workflow.node.update.missingNode: workflowId=${workflowId} nodeId=${node.id}`);
+				}
+			} else {
+				insertNodeRow.run(node.id, workflowId, node.name, '', configJson, now, now);
+			}
+		}
+
+		for (const nodeId of existingNodeIds) {
+			if (!incomingNodeIds.has(nodeId)) {
+				this.db
+					.prepare(`DELETE FROM space_workflow_nodes WHERE workflow_id = ? AND id = ?`)
+					.run(workflowId, nodeId);
 			}
 		}
 

--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -468,12 +468,15 @@ export class SpaceWorkflowRepository {
 		const updateNode = this.db.prepare(
 			`UPDATE space_workflow_nodes SET name = ?, config = ?, updated_at = ? WHERE workflow_id = ? AND id = ?`
 		);
+		const rowOrderByNodeId = new Map<string, number>();
 
-		for (const node of nodes) {
+		for (let i = 0; i < nodes.length; i++) {
+			const node = nodes[i];
 			if (!node.id) {
 				log.error(`workflow.node.update.missingStableId: workflowId=${workflowId}`);
 				continue;
 			}
+			rowOrderByNodeId.set(node.id, i + 1);
 			const result = updateNode.run(
 				node.name,
 				JSON.stringify(this.buildNodeConfig(node)),
@@ -485,6 +488,53 @@ export class SpaceWorkflowRepository {
 				log.error(`workflow.node.update.missingNode: workflowId=${workflowId} nodeId=${node.id}`);
 			}
 		}
+
+		this.reorderWorkflowNodeRows(workflowId, rowOrderByNodeId);
+	}
+
+	private reorderWorkflowNodeRows(workflowId: string, rowOrderByNodeId: Map<string, number>): void {
+		if (rowOrderByNodeId.size === 0) return;
+
+		const existingRows = this.db
+			.prepare(`SELECT id FROM space_workflow_nodes WHERE workflow_id = ? ORDER BY rowid ASC`)
+			.all(workflowId) as Array<{ id: string }>;
+		const sortedIds = [...existingRows]
+			.sort((a, b) => {
+				const aOrder = rowOrderByNodeId.get(a.id) ?? Number.MAX_SAFE_INTEGER;
+				const bOrder = rowOrderByNodeId.get(b.id) ?? Number.MAX_SAFE_INTEGER;
+				return aOrder - bOrder;
+			})
+			.map((row) => row.id);
+		if (sortedIds.every((id, index) => id === existingRows[index]?.id)) return;
+
+		const rowsById = new Map<string, NodeRow>();
+		for (const row of this.db
+			.prepare(`SELECT * FROM space_workflow_nodes WHERE workflow_id = ?`)
+			.all(workflowId) as NodeRow[]) {
+			rowsById.set(row.id, row);
+		}
+
+		this.db.transaction(() => {
+			this.db.prepare(`DELETE FROM space_workflow_nodes WHERE workflow_id = ?`).run(workflowId);
+			const insertNodeRow = this.db.prepare(
+				`INSERT INTO space_workflow_nodes
+					(id, workflow_id, name, description, config, created_at, updated_at)
+				 VALUES (?, ?, ?, ?, ?, ?, ?)`
+			);
+			for (const nodeId of sortedIds) {
+				const row = rowsById.get(nodeId);
+				if (!row) continue;
+				insertNodeRow.run(
+					row.id,
+					row.workflow_id,
+					row.name,
+					row.description,
+					row.config,
+					row.created_at,
+					row.updated_at
+				);
+			}
+		})();
 	}
 
 	private buildNodeConfig(input: WorkflowNodeInput): NodeConfigJson {

--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -391,6 +391,33 @@ export class SpaceWorkflowRepository {
 		return this.getWorkflow(id)!;
 	}
 
+	/**
+	 * Update only persisted node-agent toolGuards for existing workflow nodes.
+	 *
+	 * This intentionally avoids replacing rows in `space_workflow_nodes`: workflow
+	 * IDs, node IDs, and node-agent slots are stable identifiers referenced by
+	 * in-flight workflow runs. Nodes are matched by stable node ID and only the
+	 * JSON config for that node is rewritten.
+	 */
+	updateWorkflowNodeToolGuards(workflowId: string, nodes: WorkflowNode[]): void {
+		const now = Date.now();
+		const updateNode = this.db.prepare(
+			`UPDATE space_workflow_nodes SET config = ?, updated_at = ? WHERE workflow_id = ? AND id = ?`
+		);
+
+		for (const node of nodes) {
+			const cfg: NodeConfigJson = { agents: node.agents };
+			const result = updateNode.run(JSON.stringify(cfg), now, workflowId, node.id);
+			if (result.changes === 0) {
+				log.error(
+					`workflow.nodeToolGuards.update.missingNode: workflowId=${workflowId} nodeId=${node.id}`
+				);
+			}
+		}
+
+		this.db.prepare(`UPDATE space_workflows SET updated_at = ? WHERE id = ?`).run(now, workflowId);
+	}
+
 	// -------------------------------------------------------------------------
 	// Delete
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/1-core/lib/space-workflow-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-workflow-manager.test.ts
@@ -277,7 +277,30 @@ describe('SpaceWorkflowManager', () => {
 			expect(updatedNodeRows).toEqual(createdNodeRows);
 		});
 
-		it('rejects attempts to add, remove, duplicate, regenerate, or omit node IDs on update', () => {
+		it('allows structural node additions and removals when incoming node IDs are unique', () => {
+			const created = manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Structural Workflow',
+				nodes: [
+					{ id: 'node-old', name: 'Old Step', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+					{ id: 'node-other', name: 'Other Step', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+				],
+				completionAutonomyLevel: 3,
+			});
+
+			const updated = manager.updateWorkflow(created.id, {
+				nodes: [
+					{ id: 'node-old', name: 'Old Step', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+					{ id: 'node-new', name: 'New Step', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+				],
+				endNodeId: 'node-new',
+			});
+
+			expect(updated?.nodes.map((node) => node.id)).toEqual(['node-old', 'node-new']);
+			expect(updated?.endNodeId).toBe('node-new');
+		});
+
+		it('rejects attempts to duplicate, regenerate, or omit node IDs on update', () => {
 			const created = manager.createWorkflow({
 				spaceId: 'space-1',
 				name: 'Test Workflow',
@@ -287,22 +310,6 @@ describe('SpaceWorkflowManager', () => {
 				],
 				completionAutonomyLevel: 3,
 			});
-
-			expect(() =>
-				manager.updateWorkflow(created.id, {
-					nodes: [
-						{ id: 'node-new', name: 'New Step', agents: [{ agentId: 'agent-1', name: 'coder' }] },
-						{
-							id: 'node-other',
-							name: 'Other Step',
-							agents: [{ agentId: 'agent-1', name: 'coder' }],
-						},
-					],
-					startNodeId: 'node-new',
-				})
-			).toThrow(
-				'Workflow node IDs are stable and cannot be added, removed, regenerated, or omitted during update'
-			);
 
 			expect(() =>
 				manager.updateWorkflow(created.id, {
@@ -320,7 +327,7 @@ describe('SpaceWorkflowManager', () => {
 					],
 				})
 			).toThrow(
-				'Workflow node IDs are stable and cannot be added, removed, regenerated, or omitted during update'
+				'Workflow node IDs are stable and cannot be duplicated, regenerated, or omitted during update'
 			);
 
 			expect(() =>
@@ -328,7 +335,7 @@ describe('SpaceWorkflowManager', () => {
 					nodes: [{ name: 'Missing ID', agents: [{ agentId: 'agent-1', name: 'coder' }] }],
 				})
 			).toThrow(
-				'Workflow node IDs are stable and cannot be added, removed, regenerated, or omitted during update'
+				'Workflow node IDs are stable and cannot be duplicated, regenerated, or omitted during update'
 			);
 		});
 

--- a/packages/daemon/tests/unit/1-core/lib/space-workflow-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-workflow-manager.test.ts
@@ -277,12 +277,13 @@ describe('SpaceWorkflowManager', () => {
 			expect(updatedNodeRows).toEqual(createdNodeRows);
 		});
 
-		it('rejects attempts to add, remove, regenerate, or omit node IDs on update', () => {
+		it('rejects attempts to add, remove, duplicate, regenerate, or omit node IDs on update', () => {
 			const created = manager.createWorkflow({
 				spaceId: 'space-1',
 				name: 'Test Workflow',
 				nodes: [
 					{ id: 'node-old', name: 'Old Step', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+					{ id: 'node-other', name: 'Other Step', agents: [{ agentId: 'agent-1', name: 'coder' }] },
 				],
 				completionAutonomyLevel: 3,
 			});
@@ -291,8 +292,32 @@ describe('SpaceWorkflowManager', () => {
 				manager.updateWorkflow(created.id, {
 					nodes: [
 						{ id: 'node-new', name: 'New Step', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+						{
+							id: 'node-other',
+							name: 'Other Step',
+							agents: [{ agentId: 'agent-1', name: 'coder' }],
+						},
 					],
 					startNodeId: 'node-new',
+				})
+			).toThrow(
+				'Workflow node IDs are stable and cannot be added, removed, regenerated, or omitted during update'
+			);
+
+			expect(() =>
+				manager.updateWorkflow(created.id, {
+					nodes: [
+						{
+							id: 'node-old',
+							name: 'Duplicate 1',
+							agents: [{ agentId: 'agent-1', name: 'coder' }],
+						},
+						{
+							id: 'node-old',
+							name: 'Duplicate 2',
+							agents: [{ agentId: 'agent-1', name: 'coder' }],
+						},
+					],
 				})
 			).toThrow(
 				'Workflow node IDs are stable and cannot be added, removed, regenerated, or omitted during update'

--- a/packages/daemon/tests/unit/1-core/lib/space-workflow-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-workflow-manager.test.ts
@@ -220,30 +220,31 @@ describe('SpaceWorkflowManager', () => {
 			);
 		});
 
-		it('validates start/end against effective nodes when nodes are replaced', () => {
+		it('validates start/end against effective nodes when stable nodes are updated', () => {
 			const created = manager.createWorkflow({
 				spaceId: 'space-1',
 				name: 'Test Workflow',
 				nodes: [
-					{ id: 'node-old', name: 'Old Step', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+					{ id: 'node-1', name: 'Old Step 1', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+					{ id: 'node-2', name: 'Old Step 2', agents: [{ agentId: 'agent-1', name: 'coder' }] },
 				],
 				completionAutonomyLevel: 3,
 			});
 
 			const updated = manager.updateWorkflow(created.id, {
 				nodes: [
-					{ id: 'node-new-1', name: 'New Step 1', agents: [{ agentId: 'agent-1', name: 'coder' }] },
-					{ id: 'node-new-2', name: 'New Step 2', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+					{ id: 'node-1', name: 'New Step 1', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+					{ id: 'node-2', name: 'New Step 2', agents: [{ agentId: 'agent-1', name: 'coder' }] },
 				],
-				startNodeId: 'node-new-2',
-				endNodeId: 'node-new-1',
+				startNodeId: 'node-2',
+				endNodeId: 'node-1',
 			});
 
-			expect(updated?.startNodeId).toBe('node-new-2');
-			expect(updated?.endNodeId).toBe('node-new-1');
+			expect(updated?.startNodeId).toBe('node-2');
+			expect(updated?.endNodeId).toBe('node-1');
 		});
 
-		it('rejects stale startNodeId/endNodeId when nodes are replaced', () => {
+		it('rejects attempts to add, remove, regenerate, or omit node IDs on update', () => {
 			const created = manager.createWorkflow({
 				spaceId: 'space-1',
 				name: 'Test Workflow',
@@ -252,15 +253,6 @@ describe('SpaceWorkflowManager', () => {
 				],
 				completionAutonomyLevel: 3,
 			});
-
-			expect(() =>
-				manager.updateWorkflow(created.id, {
-					nodes: [
-						{ id: 'node-new', name: 'New Step', agents: [{ agentId: 'agent-1', name: 'coder' }] },
-					],
-					startNodeId: 'node-old',
-				})
-			).toThrow('startNodeId "node-old" does not match any node in this workflow');
 
 			expect(() =>
 				manager.updateWorkflow(created.id, {
@@ -268,9 +260,18 @@ describe('SpaceWorkflowManager', () => {
 						{ id: 'node-new', name: 'New Step', agents: [{ agentId: 'agent-1', name: 'coder' }] },
 					],
 					startNodeId: 'node-new',
-					endNodeId: 'node-old',
 				})
-			).toThrow('endNodeId "node-old" does not match any node in this workflow');
+			).toThrow(
+				'Workflow node IDs are stable and cannot be added, removed, regenerated, or omitted during update'
+			);
+
+			expect(() =>
+				manager.updateWorkflow(created.id, {
+					nodes: [{ name: 'Missing ID', agents: [{ agentId: 'agent-1', name: 'coder' }] }],
+				})
+			).toThrow(
+				'Workflow node IDs are stable and cannot be added, removed, regenerated, or omitted during update'
+			);
 		});
 
 		it('rejects empty string startNodeId/endNodeId on update', () => {
@@ -333,7 +334,7 @@ describe('SpaceWorkflowManager', () => {
 			).toThrow('"ghost"');
 		});
 
-		it('re-validates an existing postApproval route when nodes are replaced', () => {
+		it('re-validates an existing postApproval route when stable nodes are updated', () => {
 			const created = manager.createWorkflow({
 				spaceId: 'space-1',
 				name: 'WF',
@@ -348,12 +349,12 @@ describe('SpaceWorkflowManager', () => {
 				postApproval: { targetAgent: 'reviewer', instructions: '' },
 			});
 
-			// Replace nodes so `reviewer` is no longer a declared agent.
+			// Update the stable node so `reviewer` is no longer a declared agent.
 			expect(() =>
 				manager.updateWorkflow(created.id, {
 					nodes: [
 						{
-							id: 'node-2',
+							id: 'node-1',
 							name: 'Coding',
 							agents: [{ agentId: 'agent-2', name: 'coder' }],
 						},

--- a/packages/daemon/tests/unit/1-core/lib/space-workflow-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-workflow-manager.test.ts
@@ -244,6 +244,39 @@ describe('SpaceWorkflowManager', () => {
 			expect(updated?.endNodeId).toBe('node-1');
 		});
 
+		it('updates stable nodes in place without changing row IDs', () => {
+			const created = manager.createWorkflow({
+				spaceId: 'space-1',
+				name: 'Stable Update Workflow',
+				nodes: [
+					{ id: 'node-1', name: 'Old Step 1', agents: [{ agentId: 'agent-1', name: 'coder' }] },
+					{ id: 'node-2', name: 'Old Step 2', agents: [{ agentId: 'agent-2', name: 'reviewer' }] },
+				],
+				completionAutonomyLevel: 3,
+			});
+			const createdNodeRows = db
+				.prepare(
+					`SELECT id, rowid FROM space_workflow_nodes WHERE workflow_id = ? ORDER BY rowid ASC`
+				)
+				.all(created.id) as Array<{ id: string; rowid: number }>;
+
+			const updated = manager.updateWorkflow(created.id, {
+				nodes: [
+					{ id: 'node-1', name: 'New Step 1', agents: [{ agentId: 'agent-3', name: 'coder' }] },
+					{ id: 'node-2', name: 'New Step 2', agents: [{ agentId: 'agent-4', name: 'reviewer' }] },
+				],
+			});
+			const updatedNodeRows = db
+				.prepare(
+					`SELECT id, rowid FROM space_workflow_nodes WHERE workflow_id = ? ORDER BY rowid ASC`
+				)
+				.all(created.id) as Array<{ id: string; rowid: number }>;
+
+			expect(updated?.nodes.map((node) => node.id)).toEqual(['node-1', 'node-2']);
+			expect(updated?.nodes.map((node) => node.name)).toEqual(['New Step 1', 'New Step 2']);
+			expect(updatedNodeRows).toEqual(createdNodeRows);
+		});
+
 		it('rejects attempts to add, remove, regenerate, or omit node IDs on update', () => {
 			const created = manager.createWorkflow({
 				spaceId: 'space-1',

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-workflow-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-workflow-handlers.test.ts
@@ -653,6 +653,10 @@ describe('space-workflow-handlers', () => {
 			expect(calledParams.name).toBe(template.name);
 			expect(calledParams.templateName).toBe(template.name);
 			expect(calledParams.templateHash).toBe(templateHash);
+			const calledNodes = calledParams.nodes as Array<{ id: string; name: string }>;
+			expect(calledNodes.map((node) => node.id)).toContain('step-1');
+			expect(calledNodes.find((node) => node.id === 'step-1')?.name).toBe(template.nodes[0].name);
+			expect(calledParams.startNodeId).toBe('step-1');
 			expect(daemonHub.emit).toHaveBeenCalledWith(
 				'spaceWorkflow.updated',
 				expect.objectContaining({
@@ -1033,6 +1037,10 @@ describe('space-workflow-handlers', () => {
 			expect(calledParams.name).toBe(template.name);
 			expect(calledParams.templateName).toBe(template.name);
 			expect(calledParams.templateHash).toBe(templateHash);
+			const calledNodes = calledParams.nodes as Array<{ id: string; name: string }>;
+			expect(calledNodes.map((node) => node.id)).toContain('step-1');
+			expect(calledNodes.find((node) => node.id === 'step-1')?.name).toBe(template.nodes[0].name);
+			expect(calledParams.startNodeId).toBe('step-1');
 
 			// Emitted spaceWorkflow.deleted for the older row and spaceWorkflow.updated for the kept row.
 			expect(daemonHub.emit).toHaveBeenCalledWith('spaceWorkflow.deleted', {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-workflow-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-workflow-handlers.test.ts
@@ -666,6 +666,31 @@ describe('space-workflow-handlers', () => {
 			);
 		});
 
+		it('reuses existing node IDs one-by-one when node names are duplicated', async () => {
+			const [template] = getBuiltInWorkflows();
+			const agents = agentsForTemplate(template);
+			const wfLinked: SpaceWorkflow = {
+				...mockWorkflow,
+				nodes: [
+					{ id: 'existing-a', name: template.nodes[0].name, agents: [] },
+					{ id: 'existing-b', name: template.nodes[0].name, agents: [] },
+				],
+				startNodeId: 'existing-a',
+				templateName: template.name,
+				templateHash: 'old-hash',
+			};
+			setup(mockSpace, wfLinked, agents);
+			(workflowManager.updateWorkflow as ReturnType<typeof mock>).mockReturnValue(wfLinked);
+
+			await call('spaceWorkflow.syncFromTemplate', { id: 'wf-1', spaceId: 'space-1' });
+
+			const [, calledParams] = (workflowManager.updateWorkflow as ReturnType<typeof mock>).mock
+				.calls[0] as [string, Record<string, unknown>];
+			const calledNodes = calledParams.nodes as Array<{ id: string }>;
+			expect(calledNodes.map((node) => node.id)).toEqual(['existing-a', 'existing-b']);
+			expect(new Set(calledNodes.map((node) => node.id)).size).toBe(calledNodes.length);
+		});
+
 		it('throws when id is missing', async () => {
 			setup();
 			await expect(call('spaceWorkflow.syncFromTemplate', { spaceId: 'space-1' })).rejects.toThrow(

--- a/packages/daemon/tests/unit/5-space/runtime/space-workflow.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-workflow.test.ts
@@ -213,12 +213,12 @@ describe('SpaceWorkflowRepository', () => {
 		// Small delay to ensure timestamp difference
 		await new Promise((r) => setTimeout(r, 2));
 		const updated = repo.updateWorkflow(wf.id, {
-			nodes: [{ id: 'new-step', name: 'Plan', agentId: 'agent-planner' }],
+			nodes: [{ id: 'node-coder', name: 'Plan', agentId: 'agent-planner' }],
 		});
 		expect(updated?.updatedAt).toBeGreaterThan(before);
 	});
 
-	test('updateWorkflow replaces all steps on steps param', () => {
+	test('updateWorkflow updates stable nodes in place on nodes param', () => {
 		const wf = repo.createWorkflow({
 			spaceId: 'space-1',
 			name: 'WF',
@@ -228,9 +228,10 @@ describe('SpaceWorkflowRepository', () => {
 		expect(wf.nodes).toHaveLength(2);
 
 		const updated = repo.updateWorkflow(wf.id, {
-			nodes: [{ id: 'step-review', name: 'Review', agentId: 'agent-general' }],
+			nodes: [{ id: 'node-coder', name: 'Review', agentId: 'agent-general' }, plannerNode],
 		});
-		expect(updated?.nodes).toHaveLength(1);
+		expect(updated?.nodes).toHaveLength(2);
+		expect(updated?.nodes[0].id).toBe('node-coder');
 		expect(updated?.nodes[0].agents[0].agentId).toBe('agent-general');
 	});
 
@@ -795,7 +796,7 @@ describe('SpaceWorkflowManager', () => {
 		const mgr = new SpaceWorkflowManager(repo, lookup);
 		expect(() =>
 			mgr.updateWorkflow(wf.id, {
-				nodes: [{ id: 'step-x', name: 'Step', agentId: 'non-existent' }],
+				nodes: [{ id: 'node-coder', name: 'Step', agentId: 'non-existent' }],
 			})
 		).toThrow(WorkflowValidationError);
 	});
@@ -923,7 +924,7 @@ describe('SpaceWorkflowManager', () => {
 		});
 		expect(() =>
 			manager.updateWorkflow(wf.id, {
-				nodes: [{ id: 'step-x', name: 'Step', agents: [{ agentId: '' }] }],
+				nodes: [{ id: 'node-coder', name: 'Step', agents: [{ agentId: '' }] }],
 			})
 		).toThrow(WorkflowValidationError);
 	});

--- a/packages/daemon/tests/unit/5-space/runtime/space-workflow.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-workflow.test.ts
@@ -1083,7 +1083,7 @@ describe('SpaceWorkflowManager', () => {
 		expect(wf.channels![0].from).toBe('*');
 	});
 
-	test('updateWorkflow stores channels at workflow level when replacing step', () => {
+	test('updateWorkflow stores channels at workflow level when updating a stable step', () => {
 		const wf = manager.createWorkflow({
 			spaceId: 'space-1',
 			name: 'WF',
@@ -1092,11 +1092,10 @@ describe('SpaceWorkflowManager', () => {
 		});
 		const updated = manager.updateWorkflow(wf.id, {
 			nodes: [
-				{ id: 'n1', name: 'Code', agents: [{ agentId: 'agent-coder-id', name: 'coder' }] },
-				{ id: 'n2', name: 'Review', agents: [{ agentId: 'agent-coder-id', name: 'reviewer' }] },
+				{ id: 'node-coder', name: 'Code', agents: [{ agentId: 'agent-coder-id', name: 'coder' }] },
 			],
 			channels: [{ id: 'ch-1', from: 'Code', to: 'Review' }],
-			startNodeId: 'n1',
+			startNodeId: 'node-coder',
 		});
 		expect(updated!.channels).toHaveLength(1);
 		expect(updated!.channels![0].from).toBe('Code');
@@ -1151,28 +1150,32 @@ describe('SpaceWorkflowManager', () => {
 		});
 	});
 
-	test('updateWorkflow replaces multi-agent step with channels correctly', () => {
+	test('updateWorkflow updates a stable node with multi-agent config correctly', () => {
 		const wf = manager.createWorkflow({
 			spaceId: 'space-1',
 			name: 'Update Multi-Agent',
-			nodes: [coderNode],
+			nodes: [
+				{ id: 'step-parallel', name: 'Code', agents: [{ agentId: 'agent-a', name: 'a' }] },
+				{ id: 'step-end', name: 'End', agents: [{ agentId: 'agent-a', name: 'end' }] },
+			],
+			startNodeId: 'step-parallel',
+			endNodeId: 'step-end',
 			completionAutonomyLevel: 3,
 		});
 
 		const updated = manager.updateWorkflow(wf.id, {
 			nodes: [
 				{
-					id: 'step-new',
+					id: 'step-parallel',
 					name: 'New Parallel Step',
 					agents: [
 						{ agentId: 'agent-a', name: 'a' },
 						{ agentId: 'agent-b', name: 'b' },
 					],
 				},
-				// Synthetic single-agent end node — multi-agent end nodes are forbidden.
 				{ id: 'step-end', name: 'End', agents: [{ agentId: 'agent-a', name: 'end' }] },
 			],
-			startNodeId: 'step-new',
+			startNodeId: 'step-parallel',
 			endNodeId: 'step-end',
 		})!;
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-workflow.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-workflow.test.ts
@@ -226,13 +226,27 @@ describe('SpaceWorkflowRepository', () => {
 			completionAutonomyLevel: 3,
 		});
 		expect(wf.nodes).toHaveLength(2);
+		const originalRows = db
+			.prepare(
+				`SELECT id, rowid FROM space_workflow_nodes WHERE workflow_id = ? ORDER BY rowid ASC`
+			)
+			.all(wf.id) as Array<{ id: string; rowid: number }>;
 
 		const updated = repo.updateWorkflow(wf.id, {
-			nodes: [{ id: 'node-coder', name: 'Review', agentId: 'agent-general' }, plannerNode],
+			nodes: [plannerNode, { id: 'node-coder', name: 'Review', agentId: 'agent-general' }],
 		});
+		const reorderedRows = db
+			.prepare(
+				`SELECT id, rowid FROM space_workflow_nodes WHERE workflow_id = ? ORDER BY rowid ASC`
+			)
+			.all(wf.id) as Array<{ id: string; rowid: number }>;
 		expect(updated?.nodes).toHaveLength(2);
-		expect(updated?.nodes[0].id).toBe('node-coder');
-		expect(updated?.nodes[0].agents[0].agentId).toBe('agent-general');
+		expect(updated?.nodes.map((node) => node.id)).toEqual(['node-planner', 'node-coder']);
+		expect(updated?.nodes[1].agents[0].agentId).toBe('agent-general');
+		expect(reorderedRows.map((row) => row.id)).toEqual(['node-planner', 'node-coder']);
+		expect(new Set(reorderedRows.map((row) => row.rowid))).toEqual(
+			new Set(originalRows.map((row) => row.rowid))
+		);
 	});
 
 	test('updateWorkflow returns null for missing id', () => {

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -1697,23 +1697,61 @@ describe('seedBuiltInWorkflows()', () => {
 		expect(after.templateHash).toBe(computeWorkflowHash(CODING_WORKFLOW));
 	});
 
-	test('re-stamp preserves node UUIDs (safe for in-flight runs)', () => {
+	test('re-stamp preserves node rows, layout, and updates toolGuards in place', () => {
 		// The narrow re-stamp explicitly does NOT regenerate node UUIDs because
-		// live workflow_run rows reference them. This test locks that behaviour
-		// in: forcing a re-stamp must not shift any node ID.
+		// live workflow_run rows reference them. It also must not delete/reinsert
+		// node rows because in-flight executions depend on those row identities.
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 		const coding = manager.listWorkflows(SPACE_ID).find((w) => w.name === CODING_WORKFLOW.name)!;
+		const codingNode = coding.nodes.find((n) => n.name === 'Coding')!;
 		const originalNodeIds = coding.nodes.map((n) => n.id).sort();
+		const originalRows = db
+			.prepare(
+				`SELECT id, rowid FROM space_workflow_nodes WHERE workflow_id = ? ORDER BY rowid ASC`
+			)
+			.all(coding.id) as Array<{ id: string; rowid: number }>;
+		const rowsAfterEditorSave = () =>
+			db
+				.prepare(
+					`SELECT id, rowid FROM space_workflow_nodes WHERE workflow_id = ? ORDER BY rowid ASC`
+				)
+				.all(coding.id) as Array<{ id: string; rowid: number }>;
+		const layout = Object.fromEntries(
+			coding.nodes.map((node, index) => [node.id, { x: index * 100, y: index * 50 }])
+		);
 
+		manager.updateWorkflow(coding.id, {
+			layout,
+			nodes: coding.nodes.map((node) =>
+				node.id !== codingNode.id
+					? node
+					: {
+							...node,
+							agents: node.agents.map((agent) => ({ ...agent, toolGuards: undefined })),
+						}
+			),
+		});
+		const savedRows = rowsAfterEditorSave();
+		expect(savedRows.map((row) => row.id).sort()).toEqual(originalRows.map((row) => row.id).sort());
 		db.prepare(`UPDATE space_workflows SET template_hash = ? WHERE id = ?`).run(
 			'force-drift',
 			coding.id
 		);
+
 		seedBuiltInWorkflows(SPACE_ID, manager, resolveAgentId);
 
 		const after = manager.getWorkflow(coding.id)!;
 		const afterNodeIds = after.nodes.map((n) => n.id).sort();
+		const afterRows = db
+			.prepare(
+				`SELECT id, rowid FROM space_workflow_nodes WHERE workflow_id = ? ORDER BY rowid ASC`
+			)
+			.all(coding.id) as Array<{ id: string; rowid: number }>;
+		const afterCodingAgent = after.nodes.find((n) => n.id === codingNode.id)!.agents[0];
 		expect(afterNodeIds).toEqual(originalNodeIds);
+		expect(afterRows).toEqual(savedRows);
+		expect(after.layout).toEqual(layout);
+		expect(afterCodingAgent.toolGuards).toEqual(CODING_WORKFLOW.nodes[0].agents[0]!.toolGuards);
 	});
 
 	test('is idempotent — leaves user-created workflows untouched', async () => {


### PR DESCRIPTION
Keep built-in workflow re-stamps from replacing workflow node rows, updating tool guards in place instead so in-progress runs retain stable node references.

Also rejects workflow update payloads that would add, remove, omit, or regenerate persisted node IDs.