### PR TITLE
Scope sdk_messages live-query invalidation by session (#1751)

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -18,7 +18,12 @@ import type {
 	LiveQuerySnapshotEvent,
 	LiveQueryDeltaEvent,
 } from '@neokai/shared';
-import type { LiveQueryEngine, LiveQueryHandle, QueryDiff } from '../../storage/live-query';
+import type {
+	LiveQueryEngine,
+	LiveQueryHandle,
+	QueryDiff,
+	ScopeExtractor,
+} from '../../storage/live-query';
 import { Logger } from '../logger';
 
 // ============================================================================
@@ -55,6 +60,19 @@ export interface NamedQuery {
 		rawRows: Record<string, unknown>[],
 		params: ReadonlyArray<unknown>
 	) => Record<string, unknown> | undefined;
+	/**
+	 * Optional scope extractor for scoped invalidation.
+	 *
+	 * When a table change event carries scope information (e.g. the sessionId
+	 * that was written to), the engine compares the extracted scope against
+	 * the event's scope. Queries whose scope does not overlap are skipped,
+	 * avoiding unnecessary SQL re-evaluation.
+	 *
+	 * For example, `messages.bySession` extracts `params[0]` as `sessionId`
+	 * so that writing a message for session A does not re-evaluate queries
+	 * subscribed to session B.
+	 */
+	scopeExtractor?: ScopeExtractor;
 }
 
 const DEBOUNCE_SDK_MESSAGES_MS = 100;
@@ -1744,6 +1762,8 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 		{
 			sql: NEO_MESSAGES_SQL,
 			paramCount: 2,
+			// neo.messages always queries session_id = 'neo:global'
+			scopeExtractor: () => ({ sessionId: 'neo:global' }),
 		},
 	],
 	[
@@ -1783,6 +1803,7 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 			paramCount: 2,
 			debounceMs: DEBOUNCE_SDK_MESSAGES_MS,
 			mapRow: mapMessageRow,
+			scopeExtractor: (params) => ({ sessionId: params[0] as string }),
 		},
 	],
 	[
@@ -2102,6 +2123,7 @@ export function setupLiveQueryHandlers(
 			{
 				debounceMs: namedQuery.debounceMs,
 				getMetadata: namedQuery.mapResult,
+				scopeExtractor: namedQuery.scopeExtractor,
 			}
 		);
 

--- a/packages/daemon/src/storage/live-query.ts
+++ b/packages/daemon/src/storage/live-query.ts
@@ -7,7 +7,7 @@
  */
 
 import { Database as BunDatabase } from 'bun:sqlite';
-import type { ReactiveDatabase } from './reactive-database';
+import type { ReactiveDatabase, TableChangeScope } from './reactive-database';
 
 // ============================================================================
 // Public API types
@@ -19,6 +19,19 @@ export interface LiveQueryHandle<T> {
 	/** Stop receiving updates */
 	dispose(): void;
 }
+
+/**
+ * Extracts a scope key from a query's parameters.
+ *
+ * When a table change event carries scope information (e.g. the `sessionId`
+ * that was written to), the engine compares it against each query entry's
+ * scope key. Queries whose scope does not overlap are skipped, avoiding
+ * unnecessary re-evaluation.
+ *
+ * Return `undefined` to indicate the query should always be re-evaluated
+ * (fallback / scope-agnostic).
+ */
+export type ScopeExtractor = (params: ReadonlyArray<unknown>) => TableChangeScope | undefined;
 
 export interface LiveQuerySubscribeOptions {
 	/**
@@ -37,6 +50,14 @@ export interface LiveQuerySubscribeOptions {
 		rows: Record<string, unknown>[],
 		params: ReadonlyArray<unknown>
 	) => Record<string, unknown> | undefined;
+	/**
+	 * Optional scope key extractor. Given a query's bound parameters, returns
+	 * the scope this query is interested in (e.g. `{ sessionId: params[0] }`).
+	 *
+	 * When a scoped table change event arrives, the engine skips re-evaluation
+	 * for queries whose extracted scope does not match the event's scope.
+	 */
+	scopeExtractor?: ScopeExtractor;
 }
 
 export interface QueryDiff<T = Record<string, unknown>> {
@@ -80,6 +101,8 @@ interface QueryEntry<T extends Record<string, unknown>> {
 	pendingTimer: ReturnType<typeof setTimeout> | null;
 	/** Delay used for table-change reevaluations. */
 	debounceMs: number;
+	/** Optional scope extractor for scoped invalidation. */
+	scopeExtractor?: ScopeExtractor;
 }
 
 interface RowHashSnapshot {
@@ -246,8 +269,23 @@ export class LiveQueryEngine {
 	 * constant named-query SQL, so this stays bounded by the registry size.
 	 */
 	private statements = new Map<string, ReturnType<BunDatabase['prepare']>>();
-	private changeListener: (data: { tables: string[]; versions: Record<string, number> }) => void;
+	private changeListener: (data: {
+		tables: string[];
+		versions: Record<string, number>;
+		scope?: TableChangeScope;
+	}) => void;
 	private disposed = false;
+	/**
+	 * Instrumentation counters for tracking scoped invalidation effectiveness.
+	 * Reset on each `onTableChange` call for per-event granularity.
+	 */
+	private _lastInvalidationStats = {
+		table: '',
+		scope: undefined as TableChangeScope | undefined,
+		candidates: 0,
+		skipped: 0,
+		reevaluated: 0,
+	};
 
 	constructor(
 		private db: BunDatabase,
@@ -255,7 +293,7 @@ export class LiveQueryEngine {
 	) {
 		this.changeListener = (data) => {
 			for (const table of data.tables) {
-				this.onTableChange(table);
+				this.onTableChange(table, data.scope);
 			}
 		};
 		this.reactiveDb.on('change', this.changeListener);
@@ -296,6 +334,7 @@ export class LiveQueryEngine {
 				pendingEval: false,
 				pendingTimer: null,
 				debounceMs,
+				scopeExtractor: options.scopeExtractor,
 			} as unknown as QueryEntry<T>;
 
 			this.queries.set(cacheKey, entry as unknown as QueryEntry<Record<string, unknown>>);
@@ -316,6 +355,9 @@ export class LiveQueryEngine {
 				entry.getMetadata = options.getMetadata;
 				entry.cachedMetadata = options.getMetadata(entry.cachedRows, entry.params);
 				entry.cachedMetadataHash = hashMetadata(entry.cachedMetadata);
+			}
+			if (!entry.scopeExtractor && options.scopeExtractor) {
+				entry.scopeExtractor = options.scopeExtractor;
 			}
 		}
 
@@ -370,20 +412,54 @@ export class LiveQueryEngine {
 		this.statements.clear();
 	}
 
+	/**
+	 * Return instrumentation stats from the most recent invalidation event.
+	 *
+	 * Useful for logging and diagnostics to verify scoped invalidation is
+	 * working correctly.
+	 */
+	getLastInvalidationStats(): {
+		table: string;
+		scope: TableChangeScope | undefined;
+		candidates: number;
+		skipped: number;
+		reevaluated: number;
+	} {
+		return { ...this._lastInvalidationStats };
+	}
+
 	// ============================================================================
 	// Private
 	// ============================================================================
 
-	private onTableChange(table: string): void {
+	private onTableChange(table: string, scope?: TableChangeScope): void {
 		if (this.disposed) return;
 
 		const keys = this.tableIndex.get(table.toLowerCase());
 		if (!keys || keys.size === 0) return;
 
+		// Instrumentation tracking for this invalidation event
+		let candidates = 0;
+		let skipped = 0;
+		let reevaluated = 0;
+
 		for (const cacheKey of keys) {
 			const entry = this.queries.get(cacheKey);
 			if (!entry || entry.pendingEval) continue;
 
+			candidates++;
+
+			// Scope-based filtering: if the change carries scope info and this
+			// query entry has a scope extractor, check whether they overlap.
+			if (scope?.sessionId && entry.scopeExtractor) {
+				const queryScope = entry.scopeExtractor(entry.params);
+				if (queryScope?.sessionId && queryScope.sessionId !== scope.sessionId) {
+					skipped++;
+					continue; // Scope mismatch — skip re-evaluation
+				}
+			}
+
+			reevaluated++;
 			entry.pendingEval = true;
 			if (entry.debounceMs > 0) {
 				entry.pendingTimer = setTimeout(() => this.evaluateQuery(cacheKey), entry.debounceMs);
@@ -391,6 +467,9 @@ export class LiveQueryEngine {
 				queueMicrotask(() => this.evaluateQuery(cacheKey));
 			}
 		}
+
+		// Store instrumentation data for external consumers
+		this._lastInvalidationStats = { table, scope, candidates, skipped, reevaluated };
 	}
 
 	private evaluateQuery(cacheKey: string): void {

--- a/packages/daemon/src/storage/reactive-database.ts
+++ b/packages/daemon/src/storage/reactive-database.ts
@@ -1,9 +1,26 @@
 import { EventEmitter } from 'node:events';
 import { Database } from './index';
 
+/**
+ * Scope metadata carried by table change events.
+ *
+ * When a write method can identify which entity (session, task, etc.) was
+ * affected, the scope is populated so that `LiveQueryEngine` can skip
+ * re-evaluating queries that are scoped to unrelated entities.
+ */
+export interface TableChangeScope {
+	sessionId?: string;
+}
+
 export interface TableChangeEvent {
 	tables: string[];
 	versions: Record<string, number>;
+	/**
+	 * When present, describes the entity that triggered this change.
+	 * Consumers (e.g. LiveQueryEngine) can use this to skip re-evaluation
+	 * of queries whose scope does not overlap.
+	 */
+	scope?: TableChangeScope;
 }
 
 export interface TableVersionEvent {
@@ -37,8 +54,10 @@ export interface ReactiveDatabase {
 	/**
 	 * Manually notify that a table has changed.
 	 * Used for tables whose writes bypass the proxy (e.g., direct SQL via external repos).
+	 *
+	 * @param scope - Optional scope info identifying the affected entity.
 	 */
-	notifyChange(table: string): void;
+	notifyChange(table: string, scope?: TableChangeScope): void;
 }
 
 // Static mapping from facade method name to table name
@@ -73,22 +92,61 @@ const METHOD_TABLE_MAP: Record<string, string> = {
 	deleteInboxItemsForRepository: 'inbox_items',
 };
 
+/**
+ * Scope extractors for write methods.
+ *
+ * When a method writes to a scoped table, the extractor returns a
+ * `TableChangeScope` identifying the affected entity. This allows
+ * `LiveQueryEngine` to skip re-evaluating queries whose scope does
+ * not overlap (e.g. writing a message for session A should not
+ * re-evaluate queries scoped to session B).
+ *
+ * Methods without an extractor fall back to table-wide invalidation.
+ */
+const METHOD_SCOPE_EXTRACTORS: Record<string, (args: unknown[]) => TableChangeScope> = {
+	// SDK Message operations — first argument is always `sessionId`
+	saveSDKMessage: (args) => ({ sessionId: args[0] as string }),
+	saveUserMessage: (args) => ({ sessionId: args[0] as string }),
+	deleteMessagesAfter: (args) => ({ sessionId: args[0] as string }),
+	deleteMessagesAtAndAfter: (args) => ({ sessionId: args[0] as string }),
+};
+
 export function createReactiveDatabase(db: Database): ReactiveDatabase {
 	const emitter = new EventEmitter();
 	const tableVersions: Record<string, number> = {};
 	let transactionDepth = 0;
 	const pendingTables = new Set<string>();
+	/** Scope accumulated during a transaction. Multiple scoped writes merge. */
+	let pendingScope: TableChangeScope | undefined;
 
 	function getVersion(table: string): number {
 		return tableVersions[table] ?? 0;
 	}
 
-	function incrementAndEmit(table: string): void {
+	function mergeScope(
+		into: TableChangeScope | undefined,
+		from: TableChangeScope | undefined
+	): TableChangeScope | undefined {
+		if (!from) return into;
+		if (!into) return { ...from };
+		// If both have sessionId and they differ, clear it (indeterminate scope)
+		if (
+			into.sessionId !== undefined &&
+			from.sessionId !== undefined &&
+			into.sessionId !== from.sessionId
+		) {
+			return undefined;
+		}
+		return { sessionId: from.sessionId ?? into.sessionId };
+	}
+
+	function incrementAndEmit(table: string, scope?: TableChangeScope): void {
 		tableVersions[table] = getVersion(table) + 1;
 		const version = tableVersions[table];
 
 		if (transactionDepth > 0) {
 			pendingTables.add(table);
+			pendingScope = mergeScope(pendingScope, scope);
 			return;
 		}
 
@@ -98,6 +156,7 @@ export function createReactiveDatabase(db: Database): ReactiveDatabase {
 		const changeEvent: TableChangeEvent = {
 			tables: [table],
 			versions: { [table]: version },
+			scope,
 		};
 		emitter.emit('change', changeEvent);
 	}
@@ -107,6 +166,8 @@ export function createReactiveDatabase(db: Database): ReactiveDatabase {
 
 		const tables = Array.from(pendingTables);
 		pendingTables.clear();
+		const scope = pendingScope;
+		pendingScope = undefined;
 
 		const versions: Record<string, number> = {};
 		for (const table of tables) {
@@ -116,7 +177,7 @@ export function createReactiveDatabase(db: Database): ReactiveDatabase {
 			emitter.emit(`change:${table}`, versionEvent);
 		}
 
-		const changeEvent: TableChangeEvent = { tables, versions };
+		const changeEvent: TableChangeEvent = { tables, versions, scope };
 		emitter.emit('change', changeEvent);
 	}
 
@@ -144,7 +205,9 @@ export function createReactiveDatabase(db: Database): ReactiveDatabase {
 			return function (this: Database, ...args: unknown[]) {
 				const result = (value as (...a: unknown[]) => unknown).apply(target, args);
 				// Only emit if the call didn't throw
-				incrementAndEmit(table);
+				const scopeExtractor = METHOD_SCOPE_EXTRACTORS[prop];
+				const scope = scopeExtractor ? scopeExtractor(args) : undefined;
+				incrementAndEmit(table, scope);
 				return result;
 			};
 		},
@@ -176,10 +239,11 @@ export function createReactiveDatabase(db: Database): ReactiveDatabase {
 			transactionDepth -= 1;
 			if (transactionDepth === 0) {
 				pendingTables.clear();
+				pendingScope = undefined;
 			}
 		},
-		notifyChange(table: string): void {
-			incrementAndEmit(table);
+		notifyChange(table: string, scope?: TableChangeScope): void {
+			incrementAndEmit(table, scope);
 		},
 	};
 	return reactiveDb as ReactiveDatabase;

--- a/packages/daemon/tests/unit/4-space-storage/storage/live-query-integration.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/live-query-integration.test.ts
@@ -554,4 +554,104 @@ describe('LiveQuery Integration (Database + ReactiveDatabase + LiveQueryEngine)'
 			expect(finalState.status).toBe('idle');
 		});
 	});
+
+	// -------------------------------------------------------------------------
+	// Scoped invalidation — full pipeline
+	// -------------------------------------------------------------------------
+
+	describe('scoped invalidation — full pipeline', () => {
+		const MESSAGES_SQL =
+			'SELECT id, session_id, message_type FROM sdk_messages WHERE session_id = ? ORDER BY timestamp';
+
+		test('writing to session A does NOT re-evaluate scoped query for session B', async () => {
+			reactiveDb.db.createSession(makeSession('scoped-a'));
+			reactiveDb.db.createSession(makeSession('scoped-b'));
+			await Promise.resolve();
+
+			const diffsA: QueryDiff<{ id: string; session_id: string; message_type: string }>[] = [];
+			const diffsB: QueryDiff<{ id: string; session_id: string; message_type: string }>[] = [];
+
+			engine.subscribe(MESSAGES_SQL, ['scoped-a'], (diff) => diffsA.push(diff), {
+				scopeExtractor: (params) => ({ sessionId: params[0] as string }),
+			});
+			engine.subscribe(MESSAGES_SQL, ['scoped-b'], (diff) => diffsB.push(diff), {
+				scopeExtractor: (params) => ({ sessionId: params[0] as string }),
+			});
+
+			expect(diffsA.length).toBe(1);
+			expect(diffsB.length).toBe(1);
+
+			// Write a message for session A
+			reactiveDb.db.saveSDKMessage(
+				'scoped-a',
+				makeUserMessage(crypto.randomUUID(), 'Hello from A')
+			);
+			await Promise.resolve();
+
+			// A should get a delta; B should NOT
+			expect(diffsA.length).toBe(2);
+			expect(diffsA[1].type).toBe('delta');
+			expect(diffsA[1].added?.length).toBe(1);
+
+			expect(diffsB.length).toBe(1); // still only snapshot
+		});
+
+		test('writing to both sessions triggers their respective queries', async () => {
+			reactiveDb.db.createSession(makeSession('scoped-c'));
+			reactiveDb.db.createSession(makeSession('scoped-d'));
+			await Promise.resolve();
+
+			const diffsC: QueryDiff<{ id: string; session_id: string; message_type: string }>[] = [];
+			const diffsD: QueryDiff<{ id: string; session_id: string; message_type: string }>[] = [];
+
+			engine.subscribe(MESSAGES_SQL, ['scoped-c'], (diff) => diffsC.push(diff), {
+				scopeExtractor: (params) => ({ sessionId: params[0] as string }),
+			});
+			engine.subscribe(MESSAGES_SQL, ['scoped-d'], (diff) => diffsD.push(diff), {
+				scopeExtractor: (params) => ({ sessionId: params[0] as string }),
+			});
+
+			// Write to C
+			reactiveDb.db.saveSDKMessage('scoped-c', makeUserMessage(crypto.randomUUID(), 'Hello C'));
+			await Promise.resolve();
+
+			// Write to D
+			reactiveDb.db.saveSDKMessage('scoped-d', makeUserMessage(crypto.randomUUID(), 'Hello D'));
+			await Promise.resolve();
+
+			// Each should have received only their own delta
+			expect(diffsC.length).toBe(2);
+			expect(diffsD.length).toBe(2);
+		});
+
+		test('deleteMessagesAfter carries scope and only invalidates affected query', async () => {
+			reactiveDb.db.createSession(makeSession('scoped-f'));
+			reactiveDb.db.createSession(makeSession('scoped-g'));
+			await Promise.resolve();
+
+			// Insert messages for both
+			reactiveDb.db.saveSDKMessage('scoped-f', makeUserMessage(crypto.randomUUID(), 'F msg'));
+			reactiveDb.db.saveSDKMessage('scoped-g', makeUserMessage(crypto.randomUUID(), 'G msg'));
+			await Promise.resolve();
+
+			const diffsF: QueryDiff<{ id: string; session_id: string; message_type: string }>[] = [];
+			const diffsG: QueryDiff<{ id: string; session_id: string; message_type: string }>[] = [];
+
+			engine.subscribe(MESSAGES_SQL, ['scoped-f'], (diff) => diffsF.push(diff), {
+				scopeExtractor: (params) => ({ sessionId: params[0] as string }),
+			});
+			engine.subscribe(MESSAGES_SQL, ['scoped-g'], (diff) => diffsG.push(diff), {
+				scopeExtractor: (params) => ({ sessionId: params[0] as string }),
+			});
+
+			// Delete messages for session F
+			reactiveDb.db.deleteMessagesAfter('scoped-f', 0);
+			await Promise.resolve();
+
+			// F should get a delta (removed messages); G should NOT
+			expect(diffsF.length).toBe(2);
+			expect(diffsF[1].type).toBe('delta');
+			expect(diffsG.length).toBe(1); // only snapshot
+		});
+	});
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/reactive-database.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/reactive-database.test.ts
@@ -626,4 +626,171 @@ describe('ReactiveDatabase', () => {
 			expect(events[0].versions).toHaveProperty('sdk_messages');
 		});
 	});
+
+	// -------------------------------------------------------------------------
+	// Scope in change events
+	// -------------------------------------------------------------------------
+
+	describe('scope in change events', () => {
+		test('saveSDKMessage carries sessionId in scope', () => {
+			const events: Array<{ tables: string[]; scope?: { sessionId?: string } }> = [];
+			reactiveDb.on('change', (data) => events.push(data));
+
+			const session = makeSession('scope-s1');
+			db.createSession(session); // create via raw db so we don't pollute events
+			reactiveDb.db.saveSDKMessage('scope-s1', {
+				type: 'user',
+				uuid: 'test-uuid',
+				message: { role: 'user', content: 'hello' },
+			} as any);
+
+			expect(events.length).toBe(1);
+			expect(events[0].scope).toBeDefined();
+			expect(events[0].scope?.sessionId).toBe('scope-s1');
+		});
+
+		test('saveUserMessage carries sessionId in scope', () => {
+			const events: Array<{ tables: string[]; scope?: { sessionId?: string } }> = [];
+			reactiveDb.on('change', (data) => events.push(data));
+
+			const session = makeSession('scope-s2');
+			db.createSession(session);
+			reactiveDb.db.saveUserMessage(
+				'scope-s2',
+				{
+					type: 'user',
+					uuid: 'test-uuid',
+					message: { role: 'user', content: 'hello' },
+				} as any,
+				'consumed'
+			);
+
+			expect(events.length).toBe(1);
+			expect(events[0].scope?.sessionId).toBe('scope-s2');
+		});
+
+		test('deleteMessagesAfter carries sessionId in scope', () => {
+			const session = makeSession('scope-s3');
+			db.createSession(session);
+
+			const events: Array<{ tables: string[]; scope?: { sessionId?: string } }> = [];
+			reactiveDb.on('change', (data) => events.push(data));
+
+			reactiveDb.db.deleteMessagesAfter('scope-s3', Date.now());
+
+			expect(events.length).toBe(1);
+			expect(events[0].scope?.sessionId).toBe('scope-s3');
+		});
+
+		test('deleteMessagesAtAndAfter carries sessionId in scope', () => {
+			const session = makeSession('scope-s4');
+			db.createSession(session);
+
+			const events: Array<{ tables: string[]; scope?: { sessionId?: string } }> = [];
+			reactiveDb.on('change', (data) => events.push(data));
+
+			reactiveDb.db.deleteMessagesAtAndAfter('scope-s4', Date.now());
+
+			expect(events.length).toBe(1);
+			expect(events[0].scope?.sessionId).toBe('scope-s4');
+		});
+
+		test('session writes do NOT carry scope', () => {
+			const events: Array<{ tables: string[]; scope?: { sessionId?: string } }> = [];
+			reactiveDb.on('change', (data) => events.push(data));
+
+			reactiveDb.db.createSession(makeSession('no-scope'));
+
+			expect(events.length).toBe(1);
+			expect(events[0].scope).toBeUndefined();
+		});
+
+		test('notifyChange with explicit scope carries it in event', () => {
+			const events: Array<{ tables: string[]; scope?: { sessionId?: string } }> = [];
+			reactiveDb.on('change', (data) => events.push(data));
+
+			reactiveDb.notifyChange('sdk_messages', { sessionId: 'explicit-session' });
+
+			expect(events.length).toBe(1);
+			expect(events[0].scope?.sessionId).toBe('explicit-session');
+		});
+
+		test('notifyChange without scope has undefined scope', () => {
+			const events: Array<{ tables: string[]; scope?: { sessionId?: string } }> = [];
+			reactiveDb.on('change', (data) => events.push(data));
+
+			reactiveDb.notifyChange('tasks');
+
+			expect(events.length).toBe(1);
+			expect(events[0].scope).toBeUndefined();
+		});
+
+		test('transaction merges scope — different sessionIds → undefined scope', () => {
+			const session1 = makeSession('tx-scope1');
+			const session2 = makeSession('tx-scope2');
+			db.createSession(session1);
+			db.createSession(session2);
+
+			const events: Array<{ tables: string[]; scope?: { sessionId?: string } }> = [];
+			reactiveDb.on('change', (data) => events.push(data));
+
+			reactiveDb.beginTransaction();
+			reactiveDb.db.saveSDKMessage('tx-scope1', {
+				type: 'user',
+				uuid: 'u1',
+				message: { role: 'user', content: 'a' },
+			} as any);
+			reactiveDb.db.saveSDKMessage('tx-scope2', {
+				type: 'user',
+				uuid: 'u2',
+				message: { role: 'user', content: 'b' },
+			} as any);
+			reactiveDb.commitTransaction();
+
+			expect(events.length).toBe(1);
+			// Scope should be undefined because the two writes have different sessionIds
+			// (indeterminate scope)
+			expect(events[0].scope).toBeUndefined();
+		});
+
+		test('transaction preserves scope when all writes share same sessionId', () => {
+			const session = makeSession('tx-same');
+			db.createSession(session);
+
+			const events: Array<{ tables: string[]; scope?: { sessionId?: string } }> = [];
+			reactiveDb.on('change', (data) => events.push(data));
+
+			reactiveDb.beginTransaction();
+			reactiveDb.db.saveSDKMessage('tx-same', {
+				type: 'user',
+				uuid: 'u1',
+				message: { role: 'user', content: 'a' },
+			} as any);
+			reactiveDb.db.saveSDKMessage('tx-same', {
+				type: 'user',
+				uuid: 'u2',
+				message: { role: 'user', content: 'b' },
+			} as any);
+			reactiveDb.commitTransaction();
+
+			expect(events.length).toBe(1);
+			expect(events[0].scope?.sessionId).toBe('tx-same');
+		});
+
+		test('transaction abort clears pending scope', () => {
+			const events: Array<{ tables: string[]; scope?: { sessionId?: string } }> = [];
+			reactiveDb.on('change', (data) => events.push(data));
+
+			reactiveDb.beginTransaction();
+			reactiveDb.notifyChange('sdk_messages', { sessionId: 'aborted-scope' });
+			reactiveDb.abortTransaction();
+
+			expect(events.length).toBe(0);
+
+			// After abort, a new write should not carry stale scope
+			reactiveDb.notifyChange('sdk_messages', { sessionId: 'fresh-scope' });
+			expect(events.length).toBe(1);
+			expect(events[0].scope?.sessionId).toBe('fresh-scope');
+		});
+	});
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/scoped-invalidation.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/scoped-invalidation.test.ts
@@ -1,0 +1,409 @@
+/**
+ * Scoped Invalidation Tests
+ *
+ * Tests for the scoped invalidation feature:
+ *   - ReactiveDatabase carries scope in change events
+ *   - LiveQueryEngine skips re-evaluation for scope-mismatched queries
+ *   - Fallback to table-wide invalidation when scope is unknown
+ *   - Transaction batching preserves scope
+ *   - Instrumentation stats are accurate
+ */
+
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { EventEmitter } from 'node:events';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { LiveQueryEngine, computeDiff, extractTables } from '../../../../src/storage/live-query';
+import type { QueryDiff, ScopeExtractor } from '../../../../src/storage/live-query';
+import type { TableChangeScope } from '../../../../src/storage/reactive-database';
+
+// ---------------------------------------------------------------------------
+// Mock ReactiveDatabase with scope support
+// ---------------------------------------------------------------------------
+
+interface MockReactiveDatabase {
+	on(
+		event: 'change',
+		listener: (data: {
+			tables: string[];
+			versions: Record<string, number>;
+			scope?: TableChangeScope;
+		}) => void
+	): void;
+	off(event: string, listener: (...args: unknown[]) => void): void;
+	getTableVersion(table: string): number;
+	/** Test helper — fire a synthetic change event for the given tables. */
+	fireChange(tables: string[], scope?: TableChangeScope): void;
+	/** Test helper — bump + fire change for a table. */
+	bumpAndFire(table: string, scope?: TableChangeScope): void;
+}
+
+function createMockReactiveDatabase(): MockReactiveDatabase {
+	const emitter = new EventEmitter();
+	const versions: Record<string, number> = {};
+
+	return {
+		on(
+			event: 'change',
+			listener: (data: {
+				tables: string[];
+				versions: Record<string, number>;
+				scope?: TableChangeScope;
+			}) => void
+		): void {
+			emitter.on(event, listener);
+		},
+		off(event: string, listener: (...args: unknown[]) => void): void {
+			emitter.off(event, listener);
+		},
+		getTableVersion(table: string): number {
+			return versions[table] ?? 0;
+		},
+		fireChange(tables: string[], scope?: TableChangeScope): void {
+			const v: Record<string, number> = {};
+			for (const t of tables) {
+				v[t] = versions[t] ?? 0;
+			}
+			emitter.emit('change', { tables, versions: v, scope });
+		},
+		bumpAndFire(table: string, scope?: TableChangeScope): void {
+			versions[table] = (versions[table] ?? 0) + 1;
+			this.fireChange([table], scope);
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Table setup helpers
+// ---------------------------------------------------------------------------
+
+function createTestDb(): BunDatabase {
+	const db = new BunDatabase(':memory:');
+	db.exec(`
+		CREATE TABLE items (
+			id   TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			val  INTEGER DEFAULT 0,
+			owner TEXT
+		);
+	`);
+	return db;
+}
+
+function insertItem(db: BunDatabase, id: string, name: string, val = 0, owner = 'default'): void {
+	db.exec(
+		`INSERT INTO items (id, name, val, owner) VALUES ('${id}', '${name}', ${val}, '${owner}')`
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Scoped Invalidation', () => {
+	let db: BunDatabase;
+	let mockReactive: MockReactiveDatabase;
+	let engine: LiveQueryEngine;
+
+	const SQL_ALL = 'SELECT id, name, val FROM items ORDER BY id';
+	const SQL_BY_OWNER = 'SELECT id, name, val FROM items WHERE owner = ? ORDER BY id';
+
+	// Scope extractor that extracts `owner` from params[0]
+	const ownerScopeExtractor: ScopeExtractor = (params) => ({ sessionId: params[0] as string });
+
+	beforeEach(() => {
+		db = createTestDb();
+		mockReactive = createMockReactiveDatabase();
+		engine = new LiveQueryEngine(db, mockReactive as any);
+	});
+
+	afterEach(() => {
+		engine.dispose();
+		db.close();
+	});
+
+	// -------------------------------------------------------------------------
+	// Scope filtering — core behaviour
+	// -------------------------------------------------------------------------
+
+	describe('scope filtering', () => {
+		test('scoped query is NOT re-evaluated when scope does not match', async () => {
+			// Subscribe to items for owner=A
+			const diffsA: QueryDiff<{ id: string; name: string; val: number }>[] = [];
+			engine.subscribe(SQL_BY_OWNER, ['A'], (diff) => diffsA.push(diff), {
+				scopeExtractor: ownerScopeExtractor,
+			});
+
+			// Subscribe to items for owner=B
+			const diffsB: QueryDiff<{ id: string; name: string; val: number }>[] = [];
+			engine.subscribe(SQL_BY_OWNER, ['B'], (diff) => diffsB.push(diff), {
+				scopeExtractor: ownerScopeExtractor,
+			});
+
+			expect(diffsA.length).toBe(1); // snapshot
+			expect(diffsB.length).toBe(1); // snapshot
+
+			// Insert item for owner A, fire event scoped to session A
+			insertItem(db, 'item-a', 'ItemA', 1, 'A');
+			mockReactive.bumpAndFire('items', { sessionId: 'A' });
+
+			await Promise.resolve();
+
+			// Query A should be re-evaluated (scope matches)
+			expect(diffsA.length).toBe(2);
+			expect(diffsA[1].type).toBe('delta');
+
+			// Query B should NOT be re-evaluated (scope mismatch)
+			expect(diffsB.length).toBe(1); // still only snapshot
+		});
+
+		test('scoped query IS re-evaluated when scope matches', async () => {
+			insertItem(db, 'existing', 'Existing', 1, 'A');
+
+			const diffs: QueryDiff<{ id: string; name: string; val: number }>[] = [];
+			engine.subscribe(SQL_BY_OWNER, ['A'], (diff) => diffs.push(diff), {
+				scopeExtractor: ownerScopeExtractor,
+			});
+
+			expect(diffs.length).toBe(1);
+			expect(diffs[0].rows.length).toBe(1);
+
+			// Insert another item for owner A
+			insertItem(db, 'new-a', 'NewA', 2, 'A');
+			mockReactive.bumpAndFire('items', { sessionId: 'A' });
+
+			await Promise.resolve();
+
+			expect(diffs.length).toBe(2);
+			expect(diffs[1].type).toBe('delta');
+			expect(diffs[1].added?.length).toBe(1);
+			expect(diffs[1].added?.[0].id).toBe('new-a');
+		});
+
+		test('unscoped query (no scopeExtractor) IS always re-evaluated', async () => {
+			const diffsAll: QueryDiff<{ id: string; name: string; val: number }>[] = [];
+			engine.subscribe(SQL_ALL, [], (diff) => diffsAll.push(diff)); // no scopeExtractor
+
+			insertItem(db, 'x', 'X', 1, 'A');
+			mockReactive.bumpAndFire('items', { sessionId: 'A' });
+
+			await Promise.resolve();
+
+			// Unscoped query is always re-evaluated regardless of event scope
+			expect(diffsAll.length).toBe(2);
+			expect(diffsAll[1].type).toBe('delta');
+		});
+
+		test('scoped event without scopeExtractor falls back to table-wide', async () => {
+			const diffs: QueryDiff<{ id: string; name: string; val: number }>[] = [];
+			engine.subscribe(SQL_BY_OWNER, ['A'], (diff) => diffs.push(diff)); // no scopeExtractor
+
+			// Event scoped to A, query also watches A — should re-evaluate even without scopeExtractor
+			insertItem(db, 'item-a', 'ItemA', 1, 'A');
+			mockReactive.bumpAndFire('items', { sessionId: 'A' });
+
+			await Promise.resolve();
+
+			// No scopeExtractor → always re-evaluate → data changed for A → delta emitted
+			expect(diffs.length).toBe(2);
+			expect(diffs[1].type).toBe('delta');
+			expect(diffs[1].added?.length).toBe(1);
+		});
+
+		test('scoped query with unscoped event (no scope) IS re-evaluated', async () => {
+			const diffs: QueryDiff<{ id: string; name: string; val: number }>[] = [];
+			engine.subscribe(SQL_BY_OWNER, ['A'], (diff) => diffs.push(diff), {
+				scopeExtractor: ownerScopeExtractor,
+			});
+
+			// Fire unscoped event (no scope info)
+			insertItem(db, 'item-a', 'ItemA', 1, 'A');
+			mockReactive.bumpAndFire('items'); // no scope
+
+			await Promise.resolve();
+
+			// No scope → cannot filter → re-evaluate
+			expect(diffs.length).toBe(2);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Multiple concurrent sessions
+	// -------------------------------------------------------------------------
+
+	describe('multiple concurrent sessions', () => {
+		test('three sessions: write to one only re-evaluates that session', async () => {
+			// Subscribe for 3 different "sessions"
+			const diffsA: QueryDiff<{ id: string; name: string; val: number }>[] = [];
+			const diffsB: QueryDiff<{ id: string; name: string; val: number }>[] = [];
+			const diffsC: QueryDiff<{ id: string; name: string; val: number }>[] = [];
+
+			engine.subscribe(SQL_BY_OWNER, ['A'], (diff) => diffsA.push(diff), {
+				scopeExtractor: ownerScopeExtractor,
+			});
+			engine.subscribe(SQL_BY_OWNER, ['B'], (diff) => diffsB.push(diff), {
+				scopeExtractor: ownerScopeExtractor,
+			});
+			engine.subscribe(SQL_BY_OWNER, ['C'], (diff) => diffsC.push(diff), {
+				scopeExtractor: ownerScopeExtractor,
+			});
+
+			// Write to session B
+			insertItem(db, 'b1', 'B1', 1, 'B');
+			mockReactive.bumpAndFire('items', { sessionId: 'B' });
+			await Promise.resolve();
+
+			// Only B's query is re-evaluated
+			expect(diffsA.length).toBe(1); // snapshot only
+			expect(diffsB.length).toBe(2); // snapshot + delta
+			expect(diffsC.length).toBe(1); // snapshot only
+		});
+
+		test('rapid writes to different sessions are independently scoped', async () => {
+			const diffsA: QueryDiff<{ id: string; name: string; val: number }>[] = [];
+			const diffsB: QueryDiff<{ id: string; name: string; val: number }>[] = [];
+
+			engine.subscribe(SQL_BY_OWNER, ['A'], (diff) => diffsA.push(diff), {
+				scopeExtractor: ownerScopeExtractor,
+			});
+			engine.subscribe(SQL_BY_OWNER, ['B'], (diff) => diffsB.push(diff), {
+				scopeExtractor: ownerScopeExtractor,
+			});
+
+			// Rapid writes to A and B
+			insertItem(db, 'a1', 'A1', 1, 'A');
+			mockReactive.bumpAndFire('items', { sessionId: 'A' });
+
+			insertItem(db, 'b1', 'B1', 1, 'B');
+			mockReactive.bumpAndFire('items', { sessionId: 'B' });
+
+			await Promise.resolve();
+
+			// A should have 2 callbacks: snapshot + delta (from its write)
+			expect(diffsA.length).toBe(2);
+			// B should have 2 callbacks: snapshot + delta (from its write)
+			expect(diffsB.length).toBe(2);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// ScopeExtractor undefined / edge cases
+	// -------------------------------------------------------------------------
+
+	describe('scopeExtractor edge cases', () => {
+		test('scopeExtractor returning undefined always re-evaluates', async () => {
+			const diffs: QueryDiff<{ id: string; name: string; val: number }>[] = [];
+			engine.subscribe(SQL_BY_OWNER, ['A'], (diff) => diffs.push(diff), {
+				scopeExtractor: () => undefined, // always returns undefined
+			});
+
+			// Insert matching data so the delta is actually emitted (not hash-deduped)
+			insertItem(db, 'x', 'X', 1, 'A');
+			mockReactive.bumpAndFire('items', { sessionId: 'B' });
+
+			await Promise.resolve();
+
+			// Undefined scope from extractor → cannot filter → re-evaluate → data changed → delta
+			expect(diffs.length).toBe(2);
+			expect(diffs[1].type).toBe('delta');
+		});
+
+		test('scopeExtractor returning empty object always re-evaluates', async () => {
+			const diffs: QueryDiff<{ id: string; name: string; val: number }>[] = [];
+			engine.subscribe(SQL_BY_OWNER, ['A'], (diff) => diffs.push(diff), {
+				scopeExtractor: () => ({}), // empty scope
+			});
+
+			// Insert matching data so the delta is actually emitted (not hash-deduped)
+			insertItem(db, 'x', 'X', 1, 'A');
+			mockReactive.bumpAndFire('items', { sessionId: 'B' });
+
+			await Promise.resolve();
+
+			// Empty scope from extractor → no sessionId to compare → re-evaluate → data changed → delta
+			expect(diffs.length).toBe(2);
+			expect(diffs[1].type).toBe('delta');
+		});
+
+		test('event with empty scope always re-evaluates scoped queries', async () => {
+			const diffs: QueryDiff<{ id: string; name: string; val: number }>[] = [];
+			engine.subscribe(SQL_BY_OWNER, ['A'], (diff) => diffs.push(diff), {
+				scopeExtractor: ownerScopeExtractor,
+			});
+
+			insertItem(db, 'x', 'X', 1, 'A');
+			mockReactive.bumpAndFire('items', {}); // empty scope
+
+			await Promise.resolve();
+
+			// Empty event scope → cannot filter → re-evaluate
+			expect(diffs.length).toBe(2);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Instrumentation stats
+	// -------------------------------------------------------------------------
+
+	describe('invalidation stats', () => {
+		test('stats show skipped queries when scope mismatches', async () => {
+			engine.subscribe(SQL_BY_OWNER, ['A'], () => {}, {
+				scopeExtractor: ownerScopeExtractor,
+			});
+			engine.subscribe(SQL_BY_OWNER, ['B'], () => {}, {
+				scopeExtractor: ownerScopeExtractor,
+			});
+			// Unscoped query
+			engine.subscribe(SQL_ALL, [], () => {});
+
+			// Fire scoped event for session A
+			mockReactive.bumpAndFire('items', { sessionId: 'A' });
+
+			const stats = engine.getLastInvalidationStats();
+			expect(stats.table).toBe('items');
+			expect(stats.scope).toEqual({ sessionId: 'A' });
+			expect(stats.candidates).toBe(3); // 3 queries total
+			expect(stats.skipped).toBe(1); // B's scoped query was skipped
+			expect(stats.reevaluated).toBe(2); // A's scoped + unscoped
+
+			await Promise.resolve(); // flush pending evaluations
+		});
+
+		test('stats show all re-evaluated when no scope info', () => {
+			engine.subscribe(SQL_BY_OWNER, ['A'], () => {}, {
+				scopeExtractor: ownerScopeExtractor,
+			});
+			engine.subscribe(SQL_BY_OWNER, ['B'], () => {}, {
+				scopeExtractor: ownerScopeExtractor,
+			});
+
+			// Fire unscoped event
+			mockReactive.bumpAndFire('items');
+
+			const stats = engine.getLastInvalidationStats();
+			expect(stats.skipped).toBe(0);
+			expect(stats.reevaluated).toBe(2);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Disposal behaviour with scope
+	// -------------------------------------------------------------------------
+
+	describe('disposal with scoped queries', () => {
+		test('disposed scoped handle no longer receives deltas', async () => {
+			const diffs: QueryDiff<{ id: string; name: string; val: number }>[] = [];
+			const handle = engine.subscribe(SQL_BY_OWNER, ['A'], (diff) => diffs.push(diff), {
+				scopeExtractor: ownerScopeExtractor,
+			});
+
+			handle.dispose();
+
+			insertItem(db, 'x', 'X', 1, 'A');
+			mockReactive.bumpAndFire('items', { sessionId: 'A' });
+
+			await Promise.resolve();
+
+			expect(diffs.length).toBe(1); // only snapshot
+		});
+	});
+});


### PR DESCRIPTION
## Summary

When an SDK message is written for one session, the reactive database now carries `scope: { sessionId }` in the change event. `LiveQueryEngine` uses registered scope extractors to skip re-evaluating queries whose scope doesn't match — writing to session A no longer re-evaluates the `messages.bySession` query subscribed to session B.

This is a major performance improvement for multi-session workloads (1-2 running tasks) where the daemon was previously re-evaluating every `sdk_messages`-dependent query on every write.

## Changes

- **`reactive-database.ts`**: Extend `TableChangeEvent` with optional `scope` carrying `sessionId`. Add `METHOD_SCOPE_EXTRACTORS` for `saveSDKMessage`, `saveUserMessage`, `deleteMessagesAfter`, `deleteMessagesAtAndAfter` (all have `sessionId` as first arg). Transaction batching merges scope across writes; conflicting sessionIds produce undefined scope (fallback to table-wide).
- **`live-query.ts`**: Add `ScopeExtractor` type and `scopeExtractor` option to `LiveQuerySubscribeOptions`. When a scoped change event arrives, queries with matching `scopeExtractor` are filtered — only those whose extracted scope overlaps the event's scope are re-evaluated. Add `getLastInvalidationStats()` for instrumentation.
- **`live-query-handlers.ts`**: Register scope extractors for `messages.bySession` (extracts `params[0]` as sessionId) and `neo.messages` (constant `'neo:global'`). Pass scopeExtractor through the named query registry and subscribe call.

## Test plan

- [x] Scoped invalidation: writing to session A does NOT re-evaluate scoped query for session B
- [x] Scoped query IS re-evaluated when scope matches
- [x] Unscoped queries always re-evaluate (backward compatible)
- [x] Fallback: scoped event + no scopeExtractor → table-wide
- [x] Fallback: unscoped event + scopeExtractor → table-wide
- [x] Transaction scope merging (same sessionId preserved, different → undefined)
- [x] Transaction abort clears pending scope
- [x] Instrumentation stats accurate (candidates, skipped, reevaluated)
- [x] Full pipeline integration test with real ReactiveDatabase + saveSDKMessage
- [x] deleteMessagesAfter carries scope and only invalidates affected query
- [x] All 2050+ existing tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)