### PR TITLE
Scope sdk_messages live-query invalidation by session

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -19,6 +19,7 @@ import type {
 	LiveQueryDeltaEvent,
 } from '@neokai/shared';
 import type { LiveQueryEngine, LiveQueryHandle, QueryDiff } from '../../storage/live-query';
+import type { TableChangeScope } from '../../storage/reactive-database';
 import { Logger } from '../logger';
 
 // ============================================================================
@@ -55,6 +56,23 @@ export interface NamedQuery {
 		rawRows: Record<string, unknown>[],
 		params: ReadonlyArray<unknown>
 	) => Record<string, unknown> | undefined;
+	/**
+	 * Optional scope filter builder. Called once per subscribe RPC with the
+	 * subscription's params; returns a `(scope) => boolean` closure that
+	 * decides whether a scoped table-change event is relevant to this
+	 * particular subscription.
+	 *
+	 * When the closure returns `false`, re-evaluation is skipped entirely.
+	 * When no closure is provided (or the event has no scope), the query is
+	 * re-evaluated as usual (backward-compatible fallback).
+	 *
+	 * @param params  The positional parameters the live query was subscribed with.
+	 * @param db      The raw Bun SQLite database for membership lookups.
+	 */
+	buildScopeFilter?: (
+		params: ReadonlyArray<unknown>,
+		db: BunDatabase
+	) => ((scope: TableChangeScope) => boolean) | undefined;
 }
 
 const DEBOUNCE_SDK_MESSAGES_MS = 100;
@@ -1678,6 +1696,38 @@ function mapMessageRow(row: Record<string, unknown>): Record<string, unknown> {
 	return { ...parsed, ...extras };
 }
 
+/**
+ * Build a scope filter for task-scoped queries (`spaceTaskMessages.byTask*`,
+ * `spaceTaskActivity.byTask`). Returns `false` when the writing session is
+ * not part of the target task, so the live query engine can skip re-evaluation.
+ *
+ * The prepared statement checks both the task_agent_session_id and any
+ * node_execution agent_session_ids linked to the task's workflow_run.
+ */
+function buildTaskScopeFilter(
+	params: ReadonlyArray<unknown>,
+	db: BunDatabase
+): ((scope: TableChangeScope) => boolean) | undefined {
+	const taskId = params[0] as string;
+	const stmt = db.prepare(`
+		SELECT 1 FROM space_tasks st
+		WHERE st.id = ?
+			AND (
+				st.task_agent_session_id = ?
+				OR EXISTS (
+					SELECT 1 FROM node_executions ne
+					JOIN space_tasks st2 ON st2.workflow_run_id = ne.workflow_run_id
+					WHERE st2.id = ? AND ne.agent_session_id = ?
+				)
+			)
+		LIMIT 1
+	`);
+	return (scope) => {
+		if (!scope.sessionId) return true;
+		return !!stmt.get(taskId, scope.sessionId, taskId, scope.sessionId);
+	};
+}
+
 export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 	[
 		'sessionGroupMessages.byGroup',
@@ -1686,6 +1736,16 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 			paramCount: 1,
 			debounceMs: DEBOUNCE_SESSION_GROUP_MESSAGES_MS,
 			mapRow: mapSessionGroupMessageRow,
+			buildScopeFilter: (params, db) => {
+				const groupId = params[0] as string;
+				const stmt = db.prepare(
+					'SELECT 1 FROM session_group_members WHERE group_id = ? AND session_id = ? LIMIT 1'
+				);
+				return (scope) => {
+					if (!scope.sessionId) return true;
+					return !!stmt.get(groupId, scope.sessionId);
+				};
+			},
 		},
 	],
 	[
@@ -1695,6 +1755,7 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 			paramCount: 1,
 			debounceMs: DEBOUNCE_SPACE_TASK_FEEDS_MS,
 			mapRow: mapSpaceTaskActivityRow,
+			buildScopeFilter: buildTaskScopeFilter,
 		},
 	],
 	[
@@ -1704,6 +1765,7 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 			paramCount: 1,
 			debounceMs: DEBOUNCE_SPACE_TASK_FEEDS_MS,
 			mapRow: mapSpaceTaskMessageRow,
+			buildScopeFilter: buildTaskScopeFilter,
 		},
 	],
 	[
@@ -1713,6 +1775,7 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 			paramCount: 1,
 			debounceMs: DEBOUNCE_SPACE_TASK_FEEDS_MS,
 			mapRow: mapSpaceTaskMessageRow,
+			buildScopeFilter: buildTaskScopeFilter,
 		},
 	],
 	[
@@ -1744,6 +1807,12 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 		{
 			sql: NEO_MESSAGES_SQL,
 			paramCount: 2,
+			buildScopeFilter: () => {
+				return (scope) => {
+					if (!scope.sessionId) return true;
+					return scope.sessionId === 'neo:global';
+				};
+			},
 		},
 	],
 	[
@@ -1783,6 +1852,13 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 			paramCount: 2,
 			debounceMs: DEBOUNCE_SDK_MESSAGES_MS,
 			mapRow: mapMessageRow,
+			buildScopeFilter: (params) => {
+				const targetSessionId = params[0] as string;
+				return (scope) => {
+					if (!scope.sessionId) return true;
+					return scope.sessionId === targetSessionId;
+				};
+			},
 		},
 	],
 	[
@@ -2102,6 +2178,7 @@ export function setupLiveQueryHandlers(
 			{
 				debounceMs: namedQuery.debounceMs,
 				getMetadata: namedQuery.mapResult,
+				scopeFilter: namedQuery.buildScopeFilter?.(params, db),
 			}
 		);
 

--- a/packages/daemon/src/storage/live-query.ts
+++ b/packages/daemon/src/storage/live-query.ts
@@ -7,7 +7,10 @@
  */
 
 import { Database as BunDatabase } from 'bun:sqlite';
+import { Logger } from '../lib/logger';
 import type { ReactiveDatabase, TableChangeScope } from './reactive-database';
+
+const log = new Logger('live-query');
 
 // ============================================================================
 // Public API types
@@ -402,14 +405,21 @@ export class LiveQueryEngine {
 		const keys = this.tableIndex.get(table.toLowerCase());
 		if (!keys || keys.size === 0) return;
 
+		let evaluated = 0;
+		let skipped = 0;
+
 		for (const cacheKey of keys) {
 			const entry = this.queries.get(cacheKey);
 			if (!entry || entry.pendingEval) continue;
 
 			// Scope filtering: when scope metadata is available and the entry
 			// has a filter, skip re-evaluation if the change is unrelated.
-			if (scope && entry.scopeFilter && !entry.scopeFilter(scope)) continue;
+			if (scope && entry.scopeFilter && !entry.scopeFilter(scope)) {
+				skipped++;
+				continue;
+			}
 
+			evaluated++;
 			entry.pendingEval = true;
 			if (entry.debounceMs > 0) {
 				entry.pendingTimer = setTimeout(() => this.evaluateQuery(cacheKey), entry.debounceMs);
@@ -417,6 +427,10 @@ export class LiveQueryEngine {
 				queueMicrotask(() => this.evaluateQuery(cacheKey));
 			}
 		}
+
+		log.debug(
+			`table=${table} scope=${scope ? 'present' : 'none'} evaluated=${evaluated} skipped=${skipped} total=${keys.size}`
+		);
 	}
 
 	private evaluateQuery(cacheKey: string): void {

--- a/packages/daemon/src/storage/live-query.ts
+++ b/packages/daemon/src/storage/live-query.ts
@@ -7,7 +7,7 @@
  */
 
 import { Database as BunDatabase } from 'bun:sqlite';
-import type { ReactiveDatabase } from './reactive-database';
+import type { ReactiveDatabase, TableChangeScope } from './reactive-database';
 
 // ============================================================================
 // Public API types
@@ -37,6 +37,21 @@ export interface LiveQuerySubscribeOptions {
 		rows: Record<string, unknown>[],
 		params: ReadonlyArray<unknown>
 	) => Record<string, unknown> | undefined;
+	/**
+	 * Optional scope filter. When a table-change event carries scope metadata,
+	 * this function decides whether the change is relevant to this particular
+	 * query subscription. Return `false` to skip re-evaluation entirely.
+	 *
+	 * When the scope is absent (e.g. transaction flushes, methods without scope
+	 * extraction) the filter is NOT called and the query is re-evaluated as
+	 * usual — this preserves the existing fallback-to-full-reevaluation
+	 * behaviour.
+	 *
+	 * Example: a `messages.bySession` subscription with `params[0] = "sess-A"`
+	 * would provide `(scope) => scope.sessionId === "sess-A"` so that writes
+	 * for session B skip re-evaluation of session A's feed.
+	 */
+	scopeFilter?: (scope: TableChangeScope) => boolean;
 }
 
 export interface QueryDiff<T = Record<string, unknown>> {
@@ -80,6 +95,8 @@ interface QueryEntry<T extends Record<string, unknown>> {
 	pendingTimer: ReturnType<typeof setTimeout> | null;
 	/** Delay used for table-change reevaluations. */
 	debounceMs: number;
+	/** Scope filter — when set, skips re-evaluation for unrelated scopes. */
+	scopeFilter: ((scope: TableChangeScope) => boolean) | undefined;
 }
 
 interface RowHashSnapshot {
@@ -246,7 +263,11 @@ export class LiveQueryEngine {
 	 * constant named-query SQL, so this stays bounded by the registry size.
 	 */
 	private statements = new Map<string, ReturnType<BunDatabase['prepare']>>();
-	private changeListener: (data: { tables: string[]; versions: Record<string, number> }) => void;
+	private changeListener: (data: {
+		tables: string[];
+		versions: Record<string, number>;
+		scope?: TableChangeScope;
+	}) => void;
 	private disposed = false;
 
 	constructor(
@@ -255,7 +276,7 @@ export class LiveQueryEngine {
 	) {
 		this.changeListener = (data) => {
 			for (const table of data.tables) {
-				this.onTableChange(table);
+				this.onTableChange(table, data.scope);
 			}
 		};
 		this.reactiveDb.on('change', this.changeListener);
@@ -296,6 +317,7 @@ export class LiveQueryEngine {
 				pendingEval: false,
 				pendingTimer: null,
 				debounceMs,
+				scopeFilter: options.scopeFilter,
 			} as unknown as QueryEntry<T>;
 
 			this.queries.set(cacheKey, entry as unknown as QueryEntry<Record<string, unknown>>);
@@ -374,7 +396,7 @@ export class LiveQueryEngine {
 	// Private
 	// ============================================================================
 
-	private onTableChange(table: string): void {
+	private onTableChange(table: string, scope?: TableChangeScope): void {
 		if (this.disposed) return;
 
 		const keys = this.tableIndex.get(table.toLowerCase());
@@ -383,6 +405,10 @@ export class LiveQueryEngine {
 		for (const cacheKey of keys) {
 			const entry = this.queries.get(cacheKey);
 			if (!entry || entry.pendingEval) continue;
+
+			// Scope filtering: when scope metadata is available and the entry
+			// has a filter, skip re-evaluation if the change is unrelated.
+			if (scope && entry.scopeFilter && !entry.scopeFilter(scope)) continue;
 
 			entry.pendingEval = true;
 			if (entry.debounceMs > 0) {

--- a/packages/daemon/src/storage/reactive-database.ts
+++ b/packages/daemon/src/storage/reactive-database.ts
@@ -1,14 +1,31 @@
 import { EventEmitter } from 'node:events';
 import { Database } from './index';
 
+/**
+ * Scope metadata attached to table-change events when the change can be
+ * attributed to a specific context (e.g. a single session).
+ *
+ * When present, LiveQueryEngine can skip re-evaluating queries that are
+ * clearly unrelated to the scope — for example, a `messages.bySession`
+ * subscription for session B should not re-evaluate when session A writes a
+ * message.
+ */
+export interface TableChangeScope {
+	/** The session that produced the write, when known. */
+	sessionId?: string;
+}
+
 export interface TableChangeEvent {
 	tables: string[];
 	versions: Record<string, number>;
+	/** Scope metadata for the change. Only populated for single-table, non-transaction events. */
+	scope?: TableChangeScope;
 }
 
 export interface TableVersionEvent {
 	table: string;
 	version: number;
+	scope?: TableChangeScope;
 }
 
 export interface ReactiveDatabase {
@@ -41,36 +58,57 @@ export interface ReactiveDatabase {
 	notifyChange(table: string): void;
 }
 
-// Static mapping from facade method name to table name
-const METHOD_TABLE_MAP: Record<string, string> = {
+// Mapping from facade method name to table name + optional scope extractor.
+// When a scope extractor is provided, the proxy extracts scope metadata from
+// the method arguments and attaches it to the emitted change event. This
+// allows LiveQueryEngine to skip re-evaluating unrelated queries.
+interface MethodMapping {
+	table: string;
+	/** Extract scope from the method's positional arguments. */
+	extractScope?: (args: unknown[]) => TableChangeScope;
+}
+
+const METHOD_TABLE_MAP: Record<string, MethodMapping> = {
 	// Session operations
-	createSession: 'sessions',
-	updateSession: 'sessions',
-	deleteSession: 'sessions',
-	// SDK Message operations
-	saveSDKMessage: 'sdk_messages',
-	saveUserMessage: 'sdk_messages',
-	updateMessageStatus: 'sdk_messages',
-	updateMessageTimestamp: 'sdk_messages',
-	deleteMessagesAfter: 'sdk_messages',
-	deleteMessagesAtAndAfter: 'sdk_messages',
+	createSession: { table: 'sessions' },
+	updateSession: { table: 'sessions' },
+	deleteSession: { table: 'sessions' },
+	// SDK Message operations — scoped by sessionId where available
+	saveSDKMessage: {
+		table: 'sdk_messages',
+		extractScope: (args) => ({ sessionId: args[0] as string }),
+	},
+	saveUserMessage: {
+		table: 'sdk_messages',
+		extractScope: (args) => ({ sessionId: args[0] as string }),
+	},
+	updateMessageStatus: { table: 'sdk_messages' }, // args are messageIds, no sessionId
+	updateMessageTimestamp: { table: 'sdk_messages' }, // args are messageId, no sessionId
+	deleteMessagesAfter: {
+		table: 'sdk_messages',
+		extractScope: (args) => ({ sessionId: args[0] as string }),
+	},
+	deleteMessagesAtAndAfter: {
+		table: 'sdk_messages',
+		extractScope: (args) => ({ sessionId: args[0] as string }),
+	},
 	// Settings operations
-	saveGlobalToolsConfig: 'global_tools_config',
-	saveGlobalSettings: 'global_settings',
-	updateGlobalSettings: 'global_settings',
+	saveGlobalToolsConfig: { table: 'global_tools_config' },
+	saveGlobalSettings: { table: 'global_settings' },
+	updateGlobalSettings: { table: 'global_settings' },
 	// GitHub Mapping operations
-	createGitHubMapping: 'room_github_mappings',
-	updateGitHubMapping: 'room_github_mappings',
-	deleteGitHubMapping: 'room_github_mappings',
-	deleteGitHubMappingByRoomId: 'room_github_mappings',
+	createGitHubMapping: { table: 'room_github_mappings' },
+	updateGitHubMapping: { table: 'room_github_mappings' },
+	deleteGitHubMapping: { table: 'room_github_mappings' },
+	deleteGitHubMappingByRoomId: { table: 'room_github_mappings' },
 	// Inbox Item operations
-	createInboxItem: 'inbox_items',
-	updateInboxItemStatus: 'inbox_items',
-	dismissInboxItem: 'inbox_items',
-	routeInboxItem: 'inbox_items',
-	blockInboxItem: 'inbox_items',
-	deleteInboxItem: 'inbox_items',
-	deleteInboxItemsForRepository: 'inbox_items',
+	createInboxItem: { table: 'inbox_items' },
+	updateInboxItemStatus: { table: 'inbox_items' },
+	dismissInboxItem: { table: 'inbox_items' },
+	routeInboxItem: { table: 'inbox_items' },
+	blockInboxItem: { table: 'inbox_items' },
+	deleteInboxItem: { table: 'inbox_items' },
+	deleteInboxItemsForRepository: { table: 'inbox_items' },
 };
 
 export function createReactiveDatabase(db: Database): ReactiveDatabase {
@@ -83,7 +121,7 @@ export function createReactiveDatabase(db: Database): ReactiveDatabase {
 		return tableVersions[table] ?? 0;
 	}
 
-	function incrementAndEmit(table: string): void {
+	function incrementAndEmit(table: string, scope?: TableChangeScope): void {
 		tableVersions[table] = getVersion(table) + 1;
 		const version = tableVersions[table];
 
@@ -92,12 +130,13 @@ export function createReactiveDatabase(db: Database): ReactiveDatabase {
 			return;
 		}
 
-		const versionEvent: TableVersionEvent = { table, version };
+		const versionEvent: TableVersionEvent = { table, version, scope };
 		emitter.emit(`change:${table}`, versionEvent);
 
 		const changeEvent: TableChangeEvent = {
 			tables: [table],
 			versions: { [table]: version },
+			scope,
 		};
 		emitter.emit('change', changeEvent);
 	}
@@ -116,6 +155,8 @@ export function createReactiveDatabase(db: Database): ReactiveDatabase {
 			emitter.emit(`change:${table}`, versionEvent);
 		}
 
+		// Transaction flushes do not carry scope — multiple writes may target
+		// different sessions, making single-scope attribution inaccurate.
 		const changeEvent: TableChangeEvent = { tables, versions };
 		emitter.emit('change', changeEvent);
 	}
@@ -132,8 +173,8 @@ export function createReactiveDatabase(db: Database): ReactiveDatabase {
 				return value;
 			}
 
-			const table = METHOD_TABLE_MAP[prop];
-			if (!table) {
+			const mapping = METHOD_TABLE_MAP[prop];
+			if (!mapping) {
 				// Bind to original target so methods that access private fields (e.g.
 				// Database#rawDb or BunDatabase's internal Statement constructor) work
 				// correctly when called through the proxy.
@@ -144,7 +185,8 @@ export function createReactiveDatabase(db: Database): ReactiveDatabase {
 			return function (this: Database, ...args: unknown[]) {
 				const result = (value as (...a: unknown[]) => unknown).apply(target, args);
 				// Only emit if the call didn't throw
-				incrementAndEmit(table);
+				const scope = mapping.extractScope?.(args);
+				incrementAndEmit(mapping.table, scope);
 				return result;
 			};
 		},

--- a/packages/daemon/tests/unit/4-space-storage/storage/scoped-invalidation.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/scoped-invalidation.test.ts
@@ -1,0 +1,454 @@
+/**
+ * Scoped Invalidation Tests
+ *
+ * Tests for the scope-aware live-query invalidation feature:
+ * - TableChangeScope extraction from ReactiveDatabase proxy
+ * - Scope-based filtering in LiveQueryEngine
+ * - Fallback to full reevaluation when scope is absent
+ */
+
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { EventEmitter } from 'node:events';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rmSync } from 'node:fs';
+import { Database } from '../../../../src/storage/index';
+import { createReactiveDatabase } from '../../../../src/storage/reactive-database';
+import type {
+	ReactiveDatabase,
+	TableChangeScope,
+	TableChangeEvent,
+} from '../../../../src/storage/reactive-database';
+import { LiveQueryEngine } from '../../../../src/storage/live-query';
+import type { QueryDiff } from '../../../../src/storage/live-query';
+import type { Session, SessionConfig, SessionMetadata } from '@neokai/shared';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTempDbPath(): string {
+	return join(tmpdir(), `scoped-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+function makeSession(id: string): Session {
+	const now = new Date().toISOString();
+	const config: SessionConfig = {
+		model: 'claude-sonnet-4-5-20250929',
+		maxTokens: 4096,
+		temperature: 0.7,
+	};
+	const metadata: SessionMetadata = {
+		messageCount: 0,
+		totalTokens: 0,
+		inputTokens: 0,
+		outputTokens: 0,
+		totalCost: 0,
+		toolCallCount: 0,
+	};
+	return {
+		id,
+		title: `Session ${id}`,
+		workspacePath: '/workspace/test',
+		createdAt: now,
+		lastActiveAt: now,
+		status: 'active',
+		config,
+		metadata,
+	};
+}
+
+/** Create a mock ReactiveDatabase that can fire scoped change events. */
+function createMockReactiveDatabase() {
+	const emitter = new EventEmitter();
+	const versions: Record<string, number> = {};
+
+	return {
+		on(
+			event: 'change',
+			listener: (data: {
+				tables: string[];
+				versions: Record<string, number>;
+				scope?: TableChangeScope;
+			}) => void
+		): void {
+			emitter.on(event, listener);
+		},
+		off(event: string, listener: (...args: unknown[]) => void): void {
+			emitter.off(event, listener);
+		},
+		getTableVersion(table: string): number {
+			return versions[table] ?? 0;
+		},
+		/** Bump version and fire change event with optional scope. */
+		bumpAndFire(table: string, scope?: TableChangeScope): void {
+			versions[table] = (versions[table] ?? 0) + 1;
+			const v = versions[table];
+			emitter.emit('change', { tables: [table], versions: { [table]: v }, scope });
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests: ReactiveDatabase scope extraction
+// ---------------------------------------------------------------------------
+
+describe('ReactiveDatabase — scope extraction', () => {
+	let dbPath: string;
+	let db: Database;
+	let reactiveDb: ReactiveDatabase;
+
+	beforeEach(async () => {
+		dbPath = makeTempDbPath();
+		db = new Database(dbPath);
+		reactiveDb = createReactiveDatabase(db);
+		await db.initialize(reactiveDb);
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			// already closed
+		}
+		try {
+			rmSync(dbPath, { force: true });
+			rmSync(dbPath + '-wal', { force: true });
+			rmSync(dbPath + '-shm', { force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	test('saveSDKMessage emits change event with sessionId scope', () => {
+		const events: TableChangeEvent[] = [];
+		reactiveDb.on('change', (data) => events.push(data));
+
+		reactiveDb.db.createSession(makeSession('sess-1'));
+		const message = {
+			type: 'assistant',
+			uuid: 'test-uuid',
+			session_id: 'sess-1',
+			parent_tool_use_id: null,
+			message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
+		};
+		reactiveDb.db.saveSDKMessage('sess-1', message as any);
+
+		// First event is for sessions (no scope), second is sdk_messages with scope
+		const sdkEvent = events.find((e) => e.tables.includes('sdk_messages'));
+		expect(sdkEvent).toBeDefined();
+		expect(sdkEvent!.scope).toEqual({ sessionId: 'sess-1' });
+	});
+
+	test('saveUserMessage emits change event with sessionId scope', () => {
+		const events: TableChangeEvent[] = [];
+		reactiveDb.on('change', (data) => events.push(data));
+
+		reactiveDb.db.createSession(makeSession('sess-2'));
+		const userMsg = {
+			type: 'user',
+			uuid: 'test-uuid-2',
+			session_id: 'sess-2',
+			parent_tool_use_id: null,
+			message: { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+		};
+		reactiveDb.db.saveUserMessage('sess-2', userMsg as any, 'consumed');
+
+		const sdkEvent = events.find((e) => e.tables.includes('sdk_messages'));
+		expect(sdkEvent).toBeDefined();
+		expect(sdkEvent!.scope).toEqual({ sessionId: 'sess-2' });
+	});
+
+	test('deleteMessagesAfter emits change event with sessionId scope', () => {
+		const events: TableChangeEvent[] = [];
+		reactiveDb.on('change', (data) => events.push(data));
+
+		reactiveDb.db.createSession(makeSession('sess-3'));
+		reactiveDb.db.deleteMessagesAfter('sess-3', Date.now());
+
+		const sdkEvent = events.find((e) => e.tables.includes('sdk_messages'));
+		expect(sdkEvent).toBeDefined();
+		expect(sdkEvent!.scope).toEqual({ sessionId: 'sess-3' });
+	});
+
+	test('updateMessageStatus emits change event WITHOUT scope (no sessionId in args)', () => {
+		const events: TableChangeEvent[] = [];
+		reactiveDb.on('change', (data) => events.push(data));
+
+		reactiveDb.db.updateMessageStatus(['msg-id-1', 'msg-id-2'], 'consumed');
+
+		const sdkEvent = events.find((e) => e.tables.includes('sdk_messages'));
+		expect(sdkEvent).toBeDefined();
+		expect(sdkEvent!.scope).toBeUndefined();
+	});
+
+	test('change:<table> event includes scope', () => {
+		const events: Array<{ table: string; version: number; scope?: TableChangeScope }> = [];
+		reactiveDb.on('change:sdk_messages', (data) => events.push(data));
+
+		reactiveDb.db.createSession(makeSession('sess-4'));
+		const message = {
+			type: 'assistant',
+			uuid: 'test-uuid-4',
+			session_id: 'sess-4',
+			parent_tool_use_id: null,
+			message: { role: 'assistant', content: [{ type: 'text', text: 'test' }] },
+		};
+		reactiveDb.db.saveSDKMessage('sess-4', message as any);
+
+		// Should find the sdk_messages per-table event with scope
+		const scopedEvent = events.find((e) => e.scope?.sessionId === 'sess-4');
+		expect(scopedEvent).toBeDefined();
+		expect(scopedEvent!.scope).toEqual({ sessionId: 'sess-4' });
+	});
+
+	test('transaction flush does NOT carry scope', () => {
+		const events: TableChangeEvent[] = [];
+		reactiveDb.on('change', (data) => events.push(data));
+
+		reactiveDb.db.createSession(makeSession('sess-5'));
+
+		reactiveDb.beginTransaction();
+		const message = {
+			type: 'assistant',
+			uuid: 'test-uuid-5',
+			session_id: 'sess-5',
+			parent_tool_use_id: null,
+			message: { role: 'assistant', content: [{ type: 'text', text: 'tx' }] },
+		};
+		reactiveDb.db.saveSDKMessage('sess-5', message as any);
+		reactiveDb.commitTransaction();
+
+		// Transaction flush event
+		const txEvent =
+			events.find((e) => e.tables.includes('sdk_messages') && e.tables.length > 1) ||
+			events[events.length - 1];
+		// Scope should be undefined for transaction commits
+		expect(txEvent.scope).toBeUndefined();
+	});
+
+	test('createSession does NOT carry scope', () => {
+		const events: TableChangeEvent[] = [];
+		reactiveDb.on('change', (data) => events.push(data));
+
+		reactiveDb.db.createSession(makeSession('sess-no-scope'));
+
+		const sessionEvent = events.find((e) => e.tables.includes('sessions'));
+		expect(sessionEvent).toBeDefined();
+		expect(sessionEvent!.scope).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: LiveQueryEngine scope filtering
+// ---------------------------------------------------------------------------
+
+describe('LiveQueryEngine — scope filtering', () => {
+	let db: BunDatabase;
+	let mockReactive: ReturnType<typeof createMockReactiveDatabase>;
+	let engine: LiveQueryEngine;
+
+	const SQL_SESSION_A = 'SELECT id, name FROM items WHERE session_id = ? ORDER BY id';
+	const SQL_SESSION_B = 'SELECT id, name FROM items WHERE session_id = ? ORDER BY id';
+
+	beforeEach(() => {
+		db = new BunDatabase(':memory:');
+		db.exec(`
+			CREATE TABLE items (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				session_id TEXT NOT NULL
+			);
+		`);
+		mockReactive = createMockReactiveDatabase();
+		engine = new LiveQueryEngine(db, mockReactive as any);
+	});
+
+	afterEach(() => {
+		engine.dispose();
+		db.close();
+	});
+
+	test('scoped change only re-evaluates matching query', async () => {
+		// Set up data for two sessions
+		db.exec(`INSERT INTO items (id, name, session_id) VALUES ('a1', 'Alpha', 'sess-A')`);
+		db.exec(`INSERT INTO items (id, name, session_id) VALUES ('b1', 'Beta', 'sess-B')`);
+
+		const diffsA: QueryDiff<{ id: string; name: string }>[] = [];
+		const diffsB: QueryDiff<{ id: string; name: string }>[] = [];
+
+		// Subscribe for both sessions with scope filters
+		engine.subscribe(SQL_SESSION_A, ['sess-A'], (diff) => diffsA.push(diff), {
+			scopeFilter: (scope) => {
+				if (!scope.sessionId) return true;
+				return scope.sessionId === 'sess-A';
+			},
+		});
+		engine.subscribe(SQL_SESSION_B, ['sess-B'], (diff) => diffsB.push(diff), {
+			scopeFilter: (scope) => {
+				if (!scope.sessionId) return true;
+				return scope.sessionId === 'sess-B';
+			},
+		});
+
+		// Both should have initial snapshots
+		expect(diffsA.length).toBe(1);
+		expect(diffsB.length).toBe(1);
+
+		// Write for sess-A
+		db.exec(`INSERT INTO items (id, name, session_id) VALUES ('a2', 'Alpha2', 'sess-A')`);
+		mockReactive.bumpAndFire('items', { sessionId: 'sess-A' });
+
+		await Promise.resolve();
+
+		// Only sess-A should have a delta
+		expect(diffsA.length).toBe(2);
+		expect(diffsB.length).toBe(1); // No change for sess-B
+	});
+
+	test('unscoped change re-evaluates all queries (fallback)', async () => {
+		db.exec(`INSERT INTO items (id, name, session_id) VALUES ('a1', 'Alpha', 'sess-A')`);
+		db.exec(`INSERT INTO items (id, name, session_id) VALUES ('b1', 'Beta', 'sess-B')`);
+
+		const diffsA: QueryDiff<{ id: string; name: string }>[] = [];
+		const diffsB: QueryDiff<{ id: string; name: string }>[] = [];
+
+		engine.subscribe(SQL_SESSION_A, ['sess-A'], (diff) => diffsA.push(diff), {
+			scopeFilter: (scope) => {
+				if (!scope.sessionId) return true;
+				return scope.sessionId === 'sess-A';
+			},
+		});
+		engine.subscribe(SQL_SESSION_B, ['sess-B'], (diff) => diffsB.push(diff), {
+			scopeFilter: (scope) => {
+				if (!scope.sessionId) return true;
+				return scope.sessionId === 'sess-B';
+			},
+		});
+
+		// Write for sess-A without scope — both queries should be re-evaluated
+		db.exec(`INSERT INTO items (id, name, session_id) VALUES ('a2', 'Alpha2', 'sess-A')`);
+		mockReactive.bumpAndFire('items'); // no scope → both queries re-evaluate
+
+		await Promise.resolve();
+
+		// sess-A sees new data → delta
+		expect(diffsA.length).toBe(2);
+		expect(diffsA[1].type).toBe('delta');
+		// sess-B is re-evaluated but data is unchanged → no callback (hash dedup)
+		// This is the expected behavior: unscoped changes always trigger re-evaluation
+		expect(diffsB.length).toBe(1);
+	});
+
+	test('query without scopeFilter is always re-evaluated', async () => {
+		db.exec(`INSERT INTO items (id, name, session_id) VALUES ('a1', 'Alpha', 'sess-A')`);
+
+		const diffs: QueryDiff<{ id: string; name: string }>[] = [];
+
+		engine.subscribe(SQL_SESSION_A, ['sess-A'], (diff) => diffs.push(diff));
+		// No scopeFilter — always re-evaluate
+
+		expect(diffs.length).toBe(1);
+
+		// Change for sess-A with scoped event — should re-evaluate and produce delta
+		db.exec(`INSERT INTO items (id, name, session_id) VALUES ('a2', 'Alpha2', 'sess-A')`);
+		mockReactive.bumpAndFire('items', { sessionId: 'sess-A' });
+
+		await Promise.resolve();
+
+		// Without scopeFilter, the query is always re-evaluated regardless of scope
+		expect(diffs.length).toBe(2);
+		expect(diffs[1].type).toBe('delta');
+	});
+
+	test('scopeFilter=false for unrelated session prevents re-evaluation', async () => {
+		db.exec(`INSERT INTO items (id, name, session_id) VALUES ('a1', 'Alpha', 'sess-A')`);
+
+		let evalCount = 0;
+		const diffs: QueryDiff<{ id: string; name: string }>[] = [];
+
+		engine.subscribe(
+			SQL_SESSION_A,
+			['sess-A'],
+			(diff) => {
+				evalCount++;
+				diffs.push(diff);
+			},
+			{
+				scopeFilter: (scope) => {
+					if (!scope.sessionId) return true;
+					return scope.sessionId === 'sess-A';
+				},
+			}
+		);
+
+		expect(diffs.length).toBe(1); // initial snapshot
+
+		// Write 10 messages for a completely different session
+		for (let i = 0; i < 10; i++) {
+			db.exec(`INSERT INTO items (id, name, session_id) VALUES ('x${i}', 'X${i}', 'sess-X')`);
+			mockReactive.bumpAndFire('items', { sessionId: 'sess-X' });
+		}
+
+		await Promise.resolve();
+
+		// Should still be just the snapshot — no deltas from unrelated session
+		expect(diffs.length).toBe(1);
+	});
+
+	test('scoped change triggers delta when scope matches', async () => {
+		db.exec(`INSERT INTO items (id, name, session_id) VALUES ('a1', 'Alpha', 'sess-A')`);
+
+		const diffs: QueryDiff<{ id: string; name: string }>[] = [];
+		engine.subscribe(SQL_SESSION_A, ['sess-A'], (diff) => diffs.push(diff), {
+			scopeFilter: (scope) => {
+				if (!scope.sessionId) return true;
+				return scope.sessionId === 'sess-A';
+			},
+		});
+
+		expect(diffs.length).toBe(1);
+
+		// Write for sess-A — should trigger re-evaluation
+		db.exec(`INSERT INTO items (id, name, session_id) VALUES ('a2', 'Alpha2', 'sess-A')`);
+		mockReactive.bumpAndFire('items', { sessionId: 'sess-A' });
+
+		await Promise.resolve();
+
+		expect(diffs.length).toBe(2);
+		expect(diffs[1].type).toBe('delta');
+		expect(diffs[1].added?.length).toBe(1);
+		expect(diffs[1].added?.[0].id).toBe('a2');
+	});
+
+	test('multiple scope-filtered queries react independently', async () => {
+		db.exec(`INSERT INTO items (id, name, session_id) VALUES ('a1', 'Alpha', 'sess-A')`);
+		db.exec(`INSERT INTO items (id, name, session_id) VALUES ('b1', 'Beta', 'sess-B')`);
+		db.exec(`INSERT INTO items (id, name, session_id) VALUES ('c1', 'Charlie', 'sess-C')`);
+
+		const diffsA: QueryDiff<{ id: string; name: string }>[] = [];
+		const diffsB: QueryDiff<{ id: string; name: string }>[] = [];
+		const diffsC: QueryDiff<{ id: string; name: string }>[] = [];
+
+		engine.subscribe(SQL_SESSION_A, ['sess-A'], (diff) => diffsA.push(diff), {
+			scopeFilter: (s) => !s.sessionId || s.sessionId === 'sess-A',
+		});
+		engine.subscribe(SQL_SESSION_A, ['sess-B'], (diff) => diffsB.push(diff), {
+			scopeFilter: (s) => !s.sessionId || s.sessionId === 'sess-B',
+		});
+		engine.subscribe(SQL_SESSION_A, ['sess-C'], (diff) => diffsC.push(diff), {
+			scopeFilter: (s) => !s.sessionId || s.sessionId === 'sess-C',
+		});
+
+		// Write for sess-B
+		db.exec(`INSERT INTO items (id, name, session_id) VALUES ('b2', 'Beta2', 'sess-B')`);
+		mockReactive.bumpAndFire('items', { sessionId: 'sess-B' });
+
+		await Promise.resolve();
+
+		expect(diffsA.length).toBe(1); // Only snapshot
+		expect(diffsB.length).toBe(2); // Snapshot + delta
+		expect(diffsC.length).toBe(1); // Only snapshot
+	});
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/scoped-messages-integration.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/scoped-messages-integration.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Scoped Invalidation Integration Tests
+ *
+ * End-to-end test using real ReactiveDatabase + LiveQueryEngine + real sdk_messages
+ * table to verify that writing SDK messages for one session does not re-evaluate
+ * live queries subscribed to a different session.
+ */
+
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rmSync } from 'node:fs';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { Database } from '../../../../src/storage/index';
+import { createReactiveDatabase } from '../../../../src/storage/reactive-database';
+import type { ReactiveDatabase } from '../../../../src/storage/reactive-database';
+import { LiveQueryEngine } from '../../../../src/storage/live-query';
+import type { QueryDiff } from '../../../../src/storage/live-query';
+import type { Session, SessionConfig, SessionMetadata } from '@neokai/shared';
+
+function makeTempDbPath(): string {
+	return join(tmpdir(), `scoped-integ-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+function makeSession(id: string): Session {
+	const now = new Date().toISOString();
+	const config: SessionConfig = {
+		model: 'claude-sonnet-4-5-20250929',
+		maxTokens: 4096,
+		temperature: 0.7,
+	};
+	const metadata: SessionMetadata = {
+		messageCount: 0,
+		totalTokens: 0,
+		inputTokens: 0,
+		outputTokens: 0,
+		totalCost: 0,
+		toolCallCount: 0,
+	};
+	return {
+		id,
+		title: `Session ${id}`,
+		workspacePath: '/workspace/test',
+		createdAt: now,
+		lastActiveAt: now,
+		status: 'active',
+		config,
+		metadata,
+	};
+}
+
+describe('Scoped invalidation — sdk_messages integration', () => {
+	let dbPath: string;
+	let db: Database;
+	let bunDb: BunDatabase;
+	let reactiveDb: ReactiveDatabase;
+	let engine: LiveQueryEngine;
+
+	const SQL = `
+		SELECT id, sdk_message AS content
+		FROM sdk_messages
+		WHERE session_id = ?1
+			AND json_extract(sdk_message, '$.parent_tool_use_id') IS NULL
+			AND (message_type != 'user' OR COALESCE(send_status, 'consumed') IN ('consumed', 'failed'))
+		ORDER BY timestamp ASC
+	`.trim();
+
+	beforeEach(async () => {
+		dbPath = makeTempDbPath();
+		db = new Database(dbPath);
+		reactiveDb = createReactiveDatabase(db);
+		await db.initialize(reactiveDb);
+		bunDb = db.getDatabase();
+		engine = new LiveQueryEngine(bunDb, reactiveDb);
+	});
+
+	afterEach(() => {
+		engine.dispose();
+		try {
+			db.close();
+		} catch {
+			// already closed
+		}
+		try {
+			rmSync(dbPath, { force: true });
+			rmSync(dbPath + '-wal', { force: true });
+			rmSync(dbPath + '-shm', { force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	test('writing message for sess-B does NOT trigger delta for sess-A subscription', async () => {
+		// Create two sessions
+		reactiveDb.db.createSession(makeSession('sess-A'));
+		reactiveDb.db.createSession(makeSession('sess-B'));
+
+		// Subscribe to messages for sess-A with scope filter
+		const diffsA: QueryDiff<Record<string, unknown>>[] = [];
+		engine.subscribe(SQL, ['sess-A'], (diff) => diffsA.push(diff), {
+			debounceMs: 0,
+			scopeFilter: (scope) => {
+				if (!scope.sessionId) return true;
+				return scope.sessionId === 'sess-A';
+			},
+		});
+
+		expect(diffsA.length).toBe(1); // initial snapshot (empty)
+
+		// Write 5 messages for sess-B
+		for (let i = 0; i < 5; i++) {
+			reactiveDb.db.saveSDKMessage('sess-B', {
+				type: 'assistant',
+				uuid: `b-msg-${i}`,
+				session_id: 'sess-B',
+				parent_tool_use_id: null,
+				message: { role: 'assistant', content: [{ type: 'text', text: `B ${i}` }] },
+			} as any);
+		}
+
+		await Promise.resolve();
+
+		// sess-A should NOT have been re-evaluated at all
+		expect(diffsA.length).toBe(1);
+	});
+
+	test('writing message for sess-A DOES trigger delta for sess-A subscription', async () => {
+		reactiveDb.db.createSession(makeSession('sess-A'));
+
+		const diffsA: QueryDiff<Record<string, unknown>>[] = [];
+		engine.subscribe(SQL, ['sess-A'], (diff) => diffsA.push(diff), {
+			debounceMs: 0,
+			scopeFilter: (scope) => {
+				if (!scope.sessionId) return true;
+				return scope.sessionId === 'sess-A';
+			},
+		});
+
+		expect(diffsA.length).toBe(1);
+
+		reactiveDb.db.saveSDKMessage('sess-A', {
+			type: 'assistant',
+			uuid: 'a-msg-1',
+			session_id: 'sess-A',
+			parent_tool_use_id: null,
+			message: { role: 'assistant', content: [{ type: 'text', text: 'Hello' }] },
+		} as any);
+
+		await Promise.resolve();
+
+		expect(diffsA.length).toBe(2);
+		expect(diffsA[1].type).toBe('delta');
+		expect(diffsA[1].added?.length).toBe(1);
+	});
+
+	test('unscoped change (updateMessageStatus) re-evaluates all queries', async () => {
+		reactiveDb.db.createSession(makeSession('sess-A'));
+		reactiveDb.db.createSession(makeSession('sess-B'));
+
+		// Insert a message for sess-A via raw db to get its ID
+		const msgId = reactiveDb.db.saveUserMessage(
+			'sess-A',
+			{
+				type: 'user',
+				uuid: 'a-user-1',
+				session_id: 'sess-A',
+				parent_tool_use_id: null,
+				message: { role: 'user', content: [{ type: 'text', text: 'Hi' }] },
+			} as any,
+			'enqueued'
+		);
+
+		// Subscribe to sess-A and sess-B with scope filters
+		const diffsA: QueryDiff<Record<string, unknown>>[] = [];
+		const diffsB: QueryDiff<Record<string, unknown>>[] = [];
+		engine.subscribe(SQL, ['sess-A'], (diff) => diffsA.push(diff), {
+			debounceMs: 0,
+			scopeFilter: (scope) => !scope.sessionId || scope.sessionId === 'sess-A',
+		});
+		engine.subscribe(SQL, ['sess-B'], (diff) => diffsB.push(diff), {
+			debounceMs: 0,
+			scopeFilter: (scope) => !scope.sessionId || scope.sessionId === 'sess-B',
+		});
+
+		expect(diffsA.length).toBe(1);
+
+		// updateMessageStatus has NO scope extractor → both queries re-evaluate
+		reactiveDb.db.updateMessageStatus([msgId], 'consumed');
+
+		await Promise.resolve();
+
+		// sess-A sees the status change (message appears because send_status changed)
+		expect(diffsA.length).toBe(2);
+		// sess-B is re-evaluated too (unscoped change) but result unchanged → no callback
+		expect(diffsB.length).toBe(1);
+	});
+
+	test('concurrent sessions with scope filters have independent feeds', async () => {
+		reactiveDb.db.createSession(makeSession('sess-A'));
+		reactiveDb.db.createSession(makeSession('sess-B'));
+
+		const diffsA: QueryDiff<Record<string, unknown>>[] = [];
+		const diffsB: QueryDiff<Record<string, unknown>>[] = [];
+
+		engine.subscribe(SQL, ['sess-A'], (diff) => diffsA.push(diff), {
+			debounceMs: 0,
+			scopeFilter: (scope) => !scope.sessionId || scope.sessionId === 'sess-A',
+		});
+		engine.subscribe(SQL, ['sess-B'], (diff) => diffsB.push(diff), {
+			debounceMs: 0,
+			scopeFilter: (scope) => !scope.sessionId || scope.sessionId === 'sess-B',
+		});
+
+		// Interleave writes
+		reactiveDb.db.saveSDKMessage('sess-A', {
+			type: 'assistant',
+			uuid: 'a1',
+			session_id: 'sess-A',
+			parent_tool_use_id: null,
+			message: { role: 'assistant', content: [{ type: 'text', text: 'A1' }] },
+		} as any);
+
+		reactiveDb.db.saveSDKMessage('sess-B', {
+			type: 'assistant',
+			uuid: 'b1',
+			session_id: 'sess-B',
+			parent_tool_use_id: null,
+			message: { role: 'assistant', content: [{ type: 'text', text: 'B1' }] },
+		} as any);
+
+		reactiveDb.db.saveSDKMessage('sess-A', {
+			type: 'assistant',
+			uuid: 'a2',
+			session_id: 'sess-A',
+			parent_tool_use_id: null,
+			message: { role: 'assistant', content: [{ type: 'text', text: 'A2' }] },
+		} as any);
+
+		await Promise.resolve();
+
+		// sess-A should have 1 delta (2 messages coalesced into 1 re-evaluation)
+		expect(diffsA.length).toBe(2); // snapshot + 1 delta
+		expect(diffsA[1].added?.length).toBe(2);
+
+		// sess-B should have 1 delta
+		expect(diffsB.length).toBe(2);
+		expect(diffsB[1].added?.length).toBe(1);
+	});
+});


### PR DESCRIPTION
## Summary

- Extend ReactiveDatabase change events with `TableChangeScope` (sessionId) so LiveQueryEngine can skip re-evaluating unrelated queries when an SDK message is written for a specific session
- Add `scopeFilter` option to `LiveQueryEngine.subscribe()` and `buildScopeFilter` to `NamedQuery` for `messages.bySession`, task queries, group queries, and `neo.messages`
- Methods without sessionId (updateMessageStatus, updateMessageTimestamp) and transaction flushes fall back to table-wide invalidation

Fixes #1751

## Test plan

- [x] `scoped-invalidation.test.ts` — ReactiveDatabase scope extraction (7 tests), LiveQueryEngine scope filtering (6 tests)
- [x] `scoped-messages-integration.test.ts` — End-to-end with real sdk_messages table (4 tests)
- [x] All 145 existing storage tests pass
- [x] All 153 existing live-query handler tests pass
- [x] lint, format, typecheck, knip all clean