### PR TITLE
Remove Awaiting Approval filter chip from tasks Action tab

### DIFF
--- a/packages/web/src/components/space/SpaceOverview.tsx
+++ b/packages/web/src/components/space/SpaceOverview.tsx
@@ -16,7 +16,6 @@ import {
 	navigateToSpaceSession,
 	navigateToSpaceTasks,
 } from '../../lib/router';
-import { currentSpaceTasksFilterSignal } from '../../lib/signals';
 import { createSession } from '../../lib/api-helpers';
 import { cn, getRelativeTime } from '../../lib/utils';
 import { toast } from '../../lib/toast';
@@ -371,8 +370,7 @@ export function SpaceOverview({ spaceId, onSelectTask }: SpaceOverviewProps) {
 		onSelectTask ?? ((taskId: string) => navigateToSpaceTask(spaceId, taskId));
 
 	const handleAwaitingApprovalClick = () => {
-		currentSpaceTasksFilterSignal.value = 'awaiting_task_completion';
-		navigateToSpaceTasks(spaceId);
+		navigateToSpaceTasks(spaceId, 'action');
 	};
 
 	return (

--- a/packages/web/src/components/space/SpaceTasks.tsx
+++ b/packages/web/src/components/space/SpaceTasks.tsx
@@ -11,28 +11,14 @@
  */
 
 import type { SpaceBlockReason, SpaceTask, SpaceTaskStatus } from '@neokai/shared';
-import { useEffect, useMemo, useState } from 'preact/hooks';
+import { useMemo } from 'preact/hooks';
 import { navigateToSpaceTasks } from '../../lib/router';
-import {
-	currentSpaceIdSignal,
-	currentSpaceTasksFilterSignal,
-	currentSpaceTasksFilterTabSignal,
-} from '../../lib/signals';
+import { currentSpaceIdSignal, currentSpaceTasksFilterTabSignal } from '../../lib/signals';
 import { spaceStore } from '../../lib/space-store';
 import { isActionRequired, isActiveTask, isDraftTask } from '../../lib/task-filters';
 import { getRelativeTime } from '../../lib/utils';
 
 type TaskFilterTab = 'action' | 'active' | 'draft' | 'completed' | 'archived';
-
-/**
- * Predicate for the "Awaiting Approval" pre-filter chip — tasks paused at a
- * `submit_for_approval` (`task_completion`) checkpoint. Matches
- * `SpaceOverview`'s summary count exactly so both surfaces stay in sync when
- * the filter is activated via click-through.
- */
-function isAwaitingTaskCompletion(task: SpaceTask): boolean {
-	return task.pendingCheckpointType === 'task_completion';
-}
 
 /** Block reasons that indicate a task needs human attention */
 const ATTENTION_BLOCK_REASONS: SpaceBlockReason[] = ['human_input_requested', 'gate_rejected'];
@@ -434,31 +420,8 @@ interface SpaceTasksProps {
 
 export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps) {
 	const tasks = spaceStore.tasks.value;
-	const preFilter = currentSpaceTasksFilterSignal.value;
-	// When the pre-filter is set (e.g. deep-link from the Overview summary),
-	// land on the Action tab so the filtered list is non-empty by default.
-	// Otherwise keep the default of "Active" — matches historical behavior for
-	// users coming in without a filter.
 	const activeTab: TaskFilterTab = currentSpaceTasksFilterTabSignal.value;
 	const spaceId = currentSpaceIdSignal.value ?? '';
-	const [activeFilter, setActiveFilter] = useState<'awaiting_task_completion' | null>(preFilter);
-
-	// Sync from the signal once, then clear it so the filter doesn't re-apply on
-	// re-renders or when the component remounts from an unrelated cause. The
-	// chip's own state is what persists for the duration of this view.
-	// Intentionally run once at mount; the signal is a one-shot hand-off.
-	useEffect(() => {
-		if (preFilter) {
-			setActiveFilter(preFilter);
-			navigateToSpaceTasks(spaceId, 'action');
-			currentSpaceTasksFilterSignal.value = null;
-		}
-	}, []);
-
-	const awaitingApprovalCount = useMemo(
-		() => tasks.filter(isAwaitingTaskCompletion).length,
-		[tasks]
-	);
 
 	const counts = useMemo(() => {
 		const c: Record<TaskFilterTab, number> = {
@@ -484,12 +447,8 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 
 	const filteredTasks = useMemo(() => {
 		const predicate = TAB_PREDICATES[activeTab];
-		let list = [...tasks].filter(predicate);
-		if (activeFilter === 'awaiting_task_completion') {
-			list = list.filter(isAwaitingTaskCompletion);
-		}
-		return list.sort((a, b) => b.updatedAt - a.updatedAt);
-	}, [tasks, activeTab, activeFilter]);
+		return [...tasks].filter(predicate).sort((a, b) => b.updatedAt - a.updatedAt);
+	}, [tasks, activeTab]);
 
 	// Build the dep lookup once per render of the list — O(N) total rather
 	// than O(N) per row inside the badge component.
@@ -561,43 +520,6 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 						variant="gray"
 					/>
 				</div>
-
-				{/* Awaiting-approval filter chip — visible when at least one task is
-				paused at a `submit_for_approval` checkpoint. Toggling on narrows the
-				list to those tasks only; toggling off restores the full tab view. The
-				count here matches the Overview summary verbatim so click-through
-				parity holds. */}
-				{awaitingApprovalCount > 0 && (
-					<div class="flex items-center gap-2" data-testid="space-tasks-filter-bar">
-						<button
-							type="button"
-							onClick={() =>
-								setActiveFilter((f) =>
-									f === 'awaiting_task_completion' ? null : 'awaiting_task_completion'
-								)
-							}
-							data-testid="tasks-filter-awaiting-approval"
-							aria-pressed={activeFilter === 'awaiting_task_completion'}
-							class={`px-2.5 py-1 text-xs font-medium rounded-full border transition-colors ${
-								activeFilter === 'awaiting_task_completion'
-									? 'bg-amber-900/40 text-amber-200 border-amber-700/60'
-									: 'bg-dark-800 text-gray-300 border-dark-600 hover:bg-dark-700'
-							}`}
-						>
-							⏸ Awaiting Approval ({awaitingApprovalCount})
-						</button>
-						{activeFilter === 'awaiting_task_completion' && (
-							<button
-								type="button"
-								onClick={() => setActiveFilter(null)}
-								data-testid="tasks-filter-clear"
-								class="text-xs text-gray-500 hover:text-gray-300"
-							>
-								Clear filter
-							</button>
-						)}
-					</div>
-				)}
 
 				{filteredTasks.length === 0 ? (
 					<EmptyTabState tab={activeTab} />

--- a/packages/web/src/components/space/__tests__/SpaceOverview.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceOverview.test.tsx
@@ -509,7 +509,7 @@ describe('SpaceOverview', () => {
 			expect(getByTestId('awaiting-approval-summary').textContent).toContain('1 task');
 		});
 
-		it('clicking the summary navigates to the tasks view', () => {
+		it('clicking the summary navigates to the tasks Action tab', () => {
 			mockSpace.value = makeSpace();
 			mockTasks.value = [
 				makeTask('t1', 'review', {
@@ -518,7 +518,7 @@ describe('SpaceOverview', () => {
 			];
 			const { getByTestId } = render(<SpaceOverview spaceId="space-1" />);
 			fireEvent.click(getByTestId('awaiting-approval-summary'));
-			expect(navigateToSpaceTasksMock).toHaveBeenCalledWith('space-1');
+			expect(navigateToSpaceTasksMock).toHaveBeenCalledWith('space-1', 'action');
 		});
 	});
 });

--- a/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
@@ -12,9 +12,8 @@ let mockTasks: ReturnType<typeof signal<SpaceTask[]>>;
 
 // Bridge pattern: hoisted bridge objects allow mockNavigateToSpaceTasks to update
 // the real Preact signals (which are created after import).
-const { filterTabBridge, filterBridge, idBridge } = vi.hoisted(() => ({
+const { filterTabBridge, idBridge } = vi.hoisted(() => ({
 	filterTabBridge: { signal: null as ReturnType<typeof signal<string>> | null },
-	filterBridge: { signal: null as ReturnType<typeof signal<string | null>> | null },
 	idBridge: { signal: null as ReturnType<typeof signal<string | null>> | null },
 }));
 
@@ -27,9 +26,8 @@ const { mockNavigateToSpaceTasks } = vi.hoisted(() => ({
 	}),
 }));
 
-// Plain holders for non-reactive signals (only read in useEffect, not render)
-const { mockCurrentSpaceTasksFilterSignal, mockCurrentSpaceIdSignal } = vi.hoisted(() => ({
-	mockCurrentSpaceTasksFilterSignal: { value: null as string | null },
+// Plain holders for non-reactive signals (only read, not render)
+const { mockCurrentSpaceIdSignal } = vi.hoisted(() => ({
 	mockCurrentSpaceIdSignal: { value: null as string | null },
 }));
 
@@ -38,7 +36,6 @@ const mockCurrentSpaceTasksFilterTabSignal = signal<string>('active');
 
 // Wire bridge so mockNavigateToSpaceTasks can update the real signal
 filterTabBridge.signal = mockCurrentSpaceTasksFilterTabSignal;
-filterBridge.signal = mockCurrentSpaceTasksFilterSignal;
 idBridge.signal = mockCurrentSpaceIdSignal;
 
 vi.mock('../../../lib/signals', async (importOriginal) => {
@@ -47,9 +44,6 @@ vi.mock('../../../lib/signals', async (importOriginal) => {
 		...actual,
 		get currentSpaceTasksFilterTabSignal() {
 			return mockCurrentSpaceTasksFilterTabSignal;
-		},
-		get currentSpaceTasksFilterSignal() {
-			return mockCurrentSpaceTasksFilterSignal;
 		},
 		get currentSpaceIdSignal() {
 			return mockCurrentSpaceIdSignal;
@@ -107,7 +101,6 @@ describe('SpaceTasks', () => {
 		cleanup();
 		mockTasks.value = [];
 		mockCurrentSpaceTasksFilterTabSignal.value = 'active';
-		mockCurrentSpaceTasksFilterSignal.value = null;
 		mockCurrentSpaceIdSignal.value = null;
 		mockNavigateToSpaceTasks.mockClear();
 	});
@@ -434,52 +427,6 @@ describe('SpaceTasks', () => {
 			badges = getAllByTestId('task-dependency-badge');
 			expect(badges[0].getAttribute('data-dep-status')).toBe('done');
 			expect(badges[0].className).toContain('text-green-300');
-		});
-	});
-
-	describe('Awaiting-approval filter chip', () => {
-		it('is hidden when no tasks are paused at a submit_for_approval checkpoint', () => {
-			mockTasks.value = [makeTask('t1', 'review')];
-			const { queryByTestId, getByText } = render(<SpaceTasks spaceId="space-1" />);
-			fireEvent.click(getByText('Action'));
-			expect(queryByTestId('tasks-filter-awaiting-approval')).toBeNull();
-		});
-
-		it('shows chip with count when at least one task is paused at a submit_for_approval checkpoint', () => {
-			mockTasks.value = [
-				makeTask('t1', 'review', {
-					pendingCheckpointType: 'task_completion',
-				}),
-				makeTask('t2', 'review'),
-			];
-			const { getByTestId, getByText } = render(<SpaceTasks spaceId="space-1" />);
-			fireEvent.click(getByText('Action'));
-			const chip = getByTestId('tasks-filter-awaiting-approval');
-			expect(chip.textContent).toContain('Awaiting Approval');
-			expect(chip.textContent).toContain('1');
-		});
-
-		it('filters the list to awaiting-approval tasks only when toggled on', () => {
-			mockTasks.value = [
-				makeTask('t1', 'review', {
-					pendingCheckpointType: 'task_completion',
-				}),
-				makeTask('t2', 'review'),
-			];
-			const { getByTestId, getByText, queryByText } = render(<SpaceTasks spaceId="space-1" />);
-			fireEvent.click(getByText('Action'));
-			// Both tasks visible by default (action tab: blocked + review)
-			expect(getByText('Task t1')).toBeTruthy();
-			expect(getByText('Task t2')).toBeTruthy();
-
-			// Toggle the filter chip on
-			fireEvent.click(getByTestId('tasks-filter-awaiting-approval'));
-			expect(getByText('Task t1')).toBeTruthy();
-			expect(queryByText('Task t2')).toBeNull();
-
-			// Toggle off via Clear filter
-			fireEvent.click(getByTestId('tasks-filter-clear'));
-			expect(getByText('Task t2')).toBeTruthy();
 		});
 	});
 

--- a/packages/web/src/lib/signals.ts
+++ b/packages/web/src/lib/signals.ts
@@ -42,14 +42,6 @@ export const currentSpaceTasksFilterTabSignal = signal<SpaceTasksFilterTab>('act
 export type SpaceTaskViewTab = 'thread' | 'canvas' | 'artifacts';
 export const currentSpaceTaskViewTabSignal = signal<SpaceTaskViewTab>('thread');
 
-// Tasks-view pre-filter, used by callers like the SpaceOverview awaiting-approval
-// summary to deep-link into a filtered tasks list (e.g. "task-completion pauses
-// only"). Set on navigation; SpaceTasks consumes it and reverts to null on the
-// next explicit tab click to avoid sticky filters. Kept as a signal rather than
-// a URL query param to avoid URL churn when the count drops to zero.
-export type SpaceTasksFilter = 'awaiting_task_completion' | null;
-export const currentSpaceTasksFilterSignal = signal<SpaceTasksFilter>(null);
-
 // Overlay signals — session shown in slide-over panel on top of the current view
 // When spaceOverlaySessionIdSignal is set, opens AgentOverlayChat without replacing the task/overview view
 export const spaceOverlaySessionIdSignal = signal<string | null>(null);


### PR DESCRIPTION
Removes the "⏸ Awaiting Approval" filter chip from the tasks Action tab. Task status already conveys what needs attention, so the filter chip added unnecessary UI complexity.

Changes:
- Remove `isAwaitingTaskCompletion` predicate, `activeFilter` state, `awaitingApprovalCount` memo, and the filter chip JSX from `SpaceTasks.tsx`
- Remove `currentSpaceTasksFilterSignal` signal and `SpaceTasksFilter` type from `signals.ts`
- Update `SpaceOverview` awaiting-approval summary card to navigate directly to the Action tab instead of setting a pre-filter
- Remove related test assertions for `tasks-filter-awaiting-approval` and `tasks-filter-clear` data-testid attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)