### PR TITLE
Add Google Gemini OAuth provider with account rotation

### DIFF
--- a/packages/daemon/src/lib/providers/factory.ts
+++ b/packages/daemon/src/lib/providers/factory.ts
@@ -14,6 +14,7 @@ import { OpenRouterProvider } from './openrouter-provider.js';
 import { OllamaProvider } from './ollama-provider.js';
 import { AnthropicToCodexBridgeProvider } from './anthropic-to-codex-bridge-provider.js';
 import { AnthropicToCopilotBridgeProvider } from './anthropic-copilot/index.js';
+import { GeminiOAuthProvider } from './gemini/index.js';
 import { getProviderRegistry, type ProviderRegistry } from './registry.js';
 export { getProviderRegistry };
 import { ProviderContextManager } from './context-manager.js';
@@ -71,6 +72,10 @@ export function initializeProviders(): ProviderRegistry {
 	// process.cwd() is the fallback cwd; per-session workspace is threaded via
 	// ANTHROPIC_AUTH_TOKEN (encoded by buildSdkConfig) and parsed per-request in server.ts.
 	registry.register(new AnthropicToCopilotBridgeProvider(process.cwd()));
+
+	// Register Google Gemini OAuth provider (Cloud Code Assist via OAuth).
+	// Available when one or more Google accounts have been added.
+	registry.register(new GeminiOAuthProvider());
 
 	// Additional built-in providers can be registered here
 	// Example:

--- a/packages/daemon/src/lib/providers/gemini/account-rotation.ts
+++ b/packages/daemon/src/lib/providers/gemini/account-rotation.ts
@@ -247,7 +247,10 @@ export class AccountRotationManager {
 	 */
 	async addAccount(account: GoogleOAuthAccount): Promise<void> {
 		await this.initialize();
-		this.accounts.push(account);
+		// Avoid duplicating if initialize() already loaded this account from storage
+		if (!this.accounts.some((a) => a.id === account.id)) {
+			this.accounts.push(account);
+		}
 	}
 
 	/**

--- a/packages/daemon/src/lib/providers/gemini/account-rotation.ts
+++ b/packages/daemon/src/lib/providers/gemini/account-rotation.ts
@@ -1,0 +1,395 @@
+/**
+ * Account Rotation System for Gemini Provider
+ *
+ * Manages multiple Google OAuth accounts with:
+ * - Session-sticky affinity (once assigned, a session keeps its account)
+ * - Failover on 429 rate limit errors
+ * - Exhaustion detection with daily request counting
+ * - Automatic cooldown period management
+ * - Health checking on startup
+ */
+
+import { createLogger } from '@neokai/shared/logger';
+import type { GoogleOAuthAccount } from './oauth-client.js';
+import { loadAccounts, saveAccounts, updateAccount, validateRefreshToken } from './oauth-client.js';
+
+const log = createLogger('kai:providers:gemini:rotation');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Session affinity map: sessionId → accountId. */
+type SessionAccountMap = Map<string, string>;
+
+/** Account rotation configuration. */
+export interface RotationConfig {
+	/** Default daily request limit per account. */
+	dailyLimit: number;
+	/** Cooldown duration in ms when an account hits rate limit (default: 60 seconds). */
+	rateLimitCooldownMs: number;
+	/** Exhaustion threshold: fraction of daily limit after which account is marked exhausted. */
+	exhaustionThreshold: number;
+	/** Whether to health-check accounts on startup. */
+	healthCheckOnStartup: boolean;
+}
+
+/** Default rotation configuration. */
+export const DEFAULT_ROTATION_CONFIG: RotationConfig = {
+	dailyLimit: 1500,
+	rateLimitCooldownMs: 60_000, // 1 minute
+	exhaustionThreshold: 0.9, // 90% of daily limit
+	healthCheckOnStartup: true,
+};
+
+/** Storage backend interface — allows in-memory storage for testing. */
+export interface AccountStorage {
+	load(): Promise<GoogleOAuthAccount[]>;
+	save(accounts: GoogleOAuthAccount[]): Promise<void>;
+	update(accountId: string, updates: Partial<GoogleOAuthAccount>): Promise<void>;
+}
+
+/** Default file-based storage. */
+class FileAccountStorage implements AccountStorage {
+	async load(): Promise<GoogleOAuthAccount[]> {
+		return loadAccounts();
+	}
+	async save(accounts: GoogleOAuthAccount[]): Promise<void> {
+		return saveAccounts(accounts);
+	}
+	async update(accountId: string, updates: Partial<GoogleOAuthAccount>): Promise<void> {
+		return updateAccount(accountId, updates);
+	}
+}
+
+/** In-memory storage for testing. */
+export class InMemoryAccountStorage implements AccountStorage {
+	private accounts: GoogleOAuthAccount[] = [];
+
+	async load(): Promise<GoogleOAuthAccount[]> {
+		return [...this.accounts];
+	}
+	async save(accounts: GoogleOAuthAccount[]): Promise<void> {
+		this.accounts = [...accounts];
+	}
+	async update(accountId: string, updates: Partial<GoogleOAuthAccount>): Promise<void> {
+		const index = this.accounts.findIndex((a) => a.id === accountId);
+		if (index === -1) return; // Silently skip in-memory
+		this.accounts[index] = { ...this.accounts[index], ...updates };
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Account Rotation Manager
+// ---------------------------------------------------------------------------
+
+export class AccountRotationManager {
+	private sessionAccountMap: SessionAccountMap = new Map();
+	private accounts: GoogleOAuthAccount[] = [];
+	private config: RotationConfig;
+	private storage: AccountStorage;
+	private initialized = false;
+
+	constructor(config?: Partial<RotationConfig>, storage?: AccountStorage) {
+		this.config = { ...DEFAULT_ROTATION_CONFIG, ...config };
+		this.storage = storage ?? new FileAccountStorage();
+	}
+
+	/**
+	 * Initialize the rotation manager by loading accounts from storage.
+	 * Optionally health-checks accounts to flag invalid ones.
+	 */
+	async initialize(): Promise<void> {
+		if (this.initialized) return;
+
+		this.accounts = await this.storage.load();
+		log.info(`Loaded ${this.accounts.length} Google OAuth accounts`);
+
+		// Reset daily counters if they're from a previous day
+		this.resetDayCountersIfNeeded();
+
+		if (this.config.healthCheckOnStartup && this.accounts.length > 0) {
+			await this.healthCheckAccounts();
+		}
+
+		this.initialized = true;
+	}
+
+	/**
+	 * Get the account assigned to a session, or assign a new one.
+	 *
+	 * Session-sticky: once a session is assigned an account, it keeps it
+	 * for the entire session. This avoids confusing the model's conversation state.
+	 *
+	 * @param sessionId - The session identifier
+	 * @returns The account to use, or undefined if no accounts available
+	 */
+	async getAccountForSession(sessionId: string): Promise<GoogleOAuthAccount | undefined> {
+		await this.initialize();
+
+		// Check session affinity first
+		const existingAccountId = this.sessionAccountMap.get(sessionId);
+		if (existingAccountId) {
+			const account = this.accounts.find((a) => a.id === existingAccountId);
+			if (account && account.status === 'active' && !this.isInCooldown(account)) {
+				await this.markUsed(account.id);
+				return account;
+			}
+			// Account is exhausted/invalid — remove affinity and pick a new one
+			this.sessionAccountMap.delete(sessionId);
+			log.info(`Session ${sessionId} account ${existingAccountId} unavailable, reassigning`);
+		}
+
+		// Pick the best available account
+		const account = this.pickBestAccount();
+		if (!account) {
+			log.warn('No available Google OAuth accounts for session');
+			return undefined;
+		}
+
+		// Assign to session
+		this.sessionAccountMap.set(sessionId, account.id);
+		await this.markUsed(account.id);
+		log.info(`Session ${sessionId} assigned to account ${account.email}`);
+		return account;
+	}
+
+	/**
+	 * Handle a 429 (rate limit) error for a specific account.
+	 *
+	 * Marks the account as exhausted for a cooldown period and removes
+	 * any session affinities to it.
+	 */
+	async handleRateLimit(accountId: string): Promise<void> {
+		const account = this.accounts.find((a) => a.id === accountId);
+		if (!account) return;
+
+		const cooldownUntil = Date.now() + this.config.rateLimitCooldownMs;
+		log.warn(
+			`Account ${account.email} hit rate limit. Cooling down until ${new Date(cooldownUntil).toISOString()}`
+		);
+
+		account.status = 'exhausted';
+		account.cooldown_until = cooldownUntil;
+		await this.storage.update(accountId, {
+			status: 'exhausted',
+			cooldown_until: cooldownUntil,
+		});
+
+		// Remove all session affinities for this account
+		for (const [sessionId, accId] of this.sessionAccountMap.entries()) {
+			if (accId === accountId) {
+				this.sessionAccountMap.delete(sessionId);
+				log.info(`Removed session ${sessionId} affinity to rate-limited account`);
+			}
+		}
+	}
+
+	/**
+	 * Record a successful request for an account (for daily counting).
+	 */
+	async recordRequest(accountId: string): Promise<void> {
+		const account = this.accounts.find((a) => a.id === accountId);
+		if (!account) return;
+
+		account.daily_request_count++;
+		account.last_used_at = Date.now();
+
+		// Check exhaustion threshold
+		if (
+			account.status === 'active' &&
+			account.daily_request_count >=
+				Math.floor(account.daily_limit * this.config.exhaustionThreshold)
+		) {
+			account.status = 'exhausted';
+			log.warn(
+				`Account ${account.email} approaching daily limit ` +
+					`(${account.daily_request_count}/${account.daily_limit}), marking exhausted`
+			);
+		}
+
+		await this.storage.update(accountId, {
+			daily_request_count: account.daily_request_count,
+			last_used_at: account.last_used_at,
+			status: account.status,
+		});
+	}
+
+	/**
+	 * Mark an account as invalid (e.g., refresh token revoked).
+	 */
+	async markInvalid(accountId: string): Promise<void> {
+		const account = this.accounts.find((a) => a.id === accountId);
+		if (!account) return;
+
+		account.status = 'invalid';
+		await this.storage.update(accountId, { status: 'invalid' });
+
+		// Remove session affinities
+		for (const [sessionId, accId] of this.sessionAccountMap.entries()) {
+			if (accId === accountId) {
+				this.sessionAccountMap.delete(sessionId);
+			}
+		}
+
+		log.warn(`Account ${account.email} marked as invalid`);
+	}
+
+	/**
+	 * Get all accounts with their current status.
+	 */
+	getAccounts(): GoogleOAuthAccount[] {
+		return [...this.accounts];
+	}
+
+	/**
+	 * Add a new account to the rotation pool.
+	 */
+	async addAccount(account: GoogleOAuthAccount): Promise<void> {
+		await this.initialize();
+		this.accounts.push(account);
+	}
+
+	/**
+	 * Remove an account from the rotation pool.
+	 */
+	async removeAccount(accountId: string): Promise<void> {
+		this.accounts = this.accounts.filter((a) => a.id !== accountId);
+
+		// Remove session affinities
+		for (const [sessionId, accId] of this.sessionAccountMap.entries()) {
+			if (accId === accountId) {
+				this.sessionAccountMap.delete(sessionId);
+			}
+		}
+	}
+
+	/**
+	 * Get the number of active (non-exhausted, non-invalid) accounts.
+	 */
+	getActiveAccountCount(): number {
+		return this.accounts.filter((a) => a.status === 'active' && !this.isInCooldown(a)).length;
+	}
+
+	/**
+	 * Clean up session affinity when a session ends.
+	 */
+	releaseSession(sessionId: string): void {
+		this.sessionAccountMap.delete(sessionId);
+	}
+
+	/**
+	 * Get the session-to-account mapping (for debugging).
+	 */
+	getSessionMap(): Map<string, string> {
+		return new Map(this.sessionAccountMap);
+	}
+
+	// ---------------------------------------------------------------------------
+	// Private methods
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * Pick the best available account using least-recently-used strategy.
+	 */
+	private pickBestAccount(): GoogleOAuthAccount | undefined {
+		const now = Date.now();
+
+		// Filter to active accounts not in cooldown
+		const available = this.accounts.filter(
+			(a) => a.status === 'active' && !this.isInCooldown(a) && a.daily_request_count < a.daily_limit
+		);
+
+		if (available.length === 0) {
+			// Try to recover accounts that are just in cooldown (not exhausted/invalid)
+			const cooledDown = this.accounts.filter(
+				(a) =>
+					(a.status === 'active' || a.status === 'exhausted') &&
+					a.cooldown_until > 0 &&
+					a.cooldown_until <= now &&
+					a.daily_request_count < a.daily_limit
+			);
+
+			if (cooledDown.length > 0) {
+				// Recover the first cooled-down account
+				const account = cooledDown[0];
+				account.status = 'active';
+				account.cooldown_until = 0;
+				return account;
+			}
+
+			return undefined;
+		}
+
+		// Least-recently-used: sort by last_used_at ascending (oldest first)
+		available.sort((a, b) => a.last_used_at - b.last_used_at);
+		return available[0];
+	}
+
+	/**
+	 * Check if an account is currently in cooldown.
+	 */
+	private isInCooldown(account: GoogleOAuthAccount): boolean {
+		return account.cooldown_until > 0 && Date.now() < account.cooldown_until;
+	}
+
+	/**
+	 * Mark an account as used (update last_used_at).
+	 */
+	private async markUsed(accountId: string): Promise<void> {
+		const account = this.accounts.find((a) => a.id === accountId);
+		if (!account) return;
+
+		account.last_used_at = Date.now();
+		// Don't persist every access — that would be too much I/O
+		// The daily_request_count update handles persistence
+	}
+
+	/**
+	 * Reset daily request counters if the day has changed.
+	 */
+	private resetDayCountersIfNeeded(): void {
+		const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+
+		for (const account of this.accounts) {
+			// If last_used_at is from a previous day, reset the counter
+			const lastUsedDate = new Date(account.last_used_at).toISOString().slice(0, 10);
+			if (lastUsedDate !== today && account.daily_request_count > 0) {
+				log.info(
+					`Resetting daily counter for ${account.email} (was ${account.daily_request_count})`
+				);
+				account.daily_request_count = 0;
+				account.status = 'active';
+				account.cooldown_until = 0;
+			}
+		}
+	}
+
+	/**
+	 * Health-check all accounts by validating their refresh tokens.
+	 * Invalid tokens are flagged as 'invalid'.
+	 */
+	private async healthCheckAccounts(): Promise<void> {
+		log.info(`Health-checking ${this.accounts.length} accounts...`);
+
+		const results = await Promise.allSettled(
+			this.accounts.map(async (account) => {
+				const isValid = await validateRefreshToken(account.refresh_token);
+				return { account, isValid };
+			})
+		);
+
+		for (const result of results) {
+			if (result.status === 'fulfilled') {
+				const { account, isValid } = result.value;
+				if (!isValid) {
+					account.status = 'invalid';
+					log.warn(`Account ${account.email} has invalid refresh token`);
+				}
+			}
+		}
+
+		// Persist updated statuses
+		await this.storage.save(this.accounts);
+	}
+}

--- a/packages/daemon/src/lib/providers/gemini/account-rotation.ts
+++ b/packages/daemon/src/lib/providers/gemini/account-rotation.ts
@@ -362,7 +362,10 @@ export class AccountRotationManager {
 					`Resetting daily counter for ${account.email} (was ${account.daily_request_count})`
 				);
 				account.daily_request_count = 0;
-				account.status = 'active';
+				// Only reset to active if not invalid (revoked tokens stay invalid)
+				if (account.status !== 'invalid') {
+					account.status = 'active';
+				}
 				account.cooldown_until = 0;
 			}
 		}

--- a/packages/daemon/src/lib/providers/gemini/bridge-server.ts
+++ b/packages/daemon/src/lib/providers/gemini/bridge-server.ts
@@ -63,6 +63,9 @@ const CODE_ASSIST_ENDPOINT = 'https://cloudcode-pa.googleapis.com/v1internal:str
 /** Maximum retry attempts for transient errors. */
 const MAX_RETRIES = 3;
 
+/** Maximum number of alternative accounts to try on token failure. */
+const MAX_ACCOUNT_FAILOVER = 3;
+
 /** Status codes that trigger a retry. */
 const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
 
@@ -176,7 +179,8 @@ async function handleGeminiRequest(
 	anthropicRequest: AnthropicRequest,
 	rotationManager: AccountRotationManager,
 	sessionId: string,
-	fetchImpl: typeof fetch
+	fetchImpl: typeof fetch,
+	excludedAccountIds: Set<string> = new Set()
 ): Promise<Response> {
 	// Get a fresh access token
 	let accessToken: string;
@@ -184,11 +188,35 @@ async function handleGeminiRequest(
 		const tokenResponse = await refreshAccessToken(account.refresh_token, { fetchImpl });
 		accessToken = tokenResponse.access_token;
 	} catch (error) {
-		// If the token is invalid, mark the account
 		const message = error instanceof Error ? error.message : String(error);
-		if (message.includes('invalid') || message.includes('revoked')) {
+		const isTokenInvalid = message.includes('invalid') || message.includes('revoked');
+
+		if (isTokenInvalid) {
 			await rotationManager.markInvalid(account.id);
 		}
+
+		// Try another available account instead of failing immediately
+		if (isTokenInvalid || message.includes('NetworkError')) {
+			excludedAccountIds.add(account.id);
+			const altAccount = await rotationManager.getAccountForSession(sessionId);
+			if (
+				altAccount &&
+				!excludedAccountIds.has(altAccount.id) &&
+				excludedAccountIds.size <= MAX_ACCOUNT_FAILOVER
+			) {
+				_log.info(`Token refresh failed for ${account.email}, trying account ${altAccount.email}`);
+				return handleGeminiRequest(
+					geminiRequest,
+					altAccount,
+					anthropicRequest,
+					rotationManager,
+					sessionId,
+					fetchImpl,
+					excludedAccountIds
+				);
+			}
+		}
+
 		return new Response(
 			createAnthropicErrorBody(
 				'authentication_error',

--- a/packages/daemon/src/lib/providers/gemini/bridge-server.ts
+++ b/packages/daemon/src/lib/providers/gemini/bridge-server.ts
@@ -485,6 +485,19 @@ async function collectGeminiResponse(geminiResponse: Response, model: string): P
 		}
 	}
 
+	// Flush any trailing SSE payload that arrived at EOF without a
+	// terminating blank line (mirrors the streaming path's EOF handling).
+	if (buffer.startsWith('data: ')) {
+		dataBuffer += buffer.slice(6).trim();
+	}
+	if (dataBuffer) {
+		try {
+			chunks.push(JSON.parse(dataBuffer) as GeminiResponseChunk);
+		} catch {
+			// Skip
+		}
+	}
+
 	// Combine chunks into a single Anthropic response
 	const state = createStreamState(model);
 	const contentBlocks: Array<Record<string, unknown>> = [];

--- a/packages/daemon/src/lib/providers/gemini/bridge-server.ts
+++ b/packages/daemon/src/lib/providers/gemini/bridge-server.ts
@@ -316,6 +316,10 @@ function streamGeminiResponse(geminiResponse: Response, model: string): Response
 			const reader = geminiResponse.body.getReader();
 			const decoder = new TextDecoder();
 			let buffer = '';
+			// dataBuffer persists across network chunks so SSE events
+			// whose blank-line terminator arrives in a later chunk are
+			// not dropped.
+			let dataBuffer = '';
 
 			try {
 				while (true) {
@@ -327,8 +331,6 @@ function streamGeminiResponse(geminiResponse: Response, model: string): Response
 					// Parse SSE lines
 					const lines = buffer.split('\n');
 					buffer = lines.pop() ?? '';
-
-					let dataBuffer = '';
 
 					for (const line of lines) {
 						if (line.startsWith('data: ')) {
@@ -349,10 +351,13 @@ function streamGeminiResponse(geminiResponse: Response, model: string): Response
 					}
 				}
 
-				// Process any remaining buffer
+				// Process any remaining dataBuffer (event without trailing newline)
 				if (buffer.startsWith('data: ')) {
+					dataBuffer += buffer.slice(6).trim();
+				}
+				if (dataBuffer) {
 					try {
-						const chunk = JSON.parse(buffer.slice(6).trim()) as GeminiResponseChunk;
+						const chunk = JSON.parse(dataBuffer) as GeminiResponseChunk;
 						const events = processGeminiChunk(chunk, state);
 						for (const event of events) {
 							controller.enqueue(encoder.encode(event));
@@ -407,6 +412,8 @@ function processGeminiChunk(chunk: GeminiResponseChunk, state: GeminiStreamState
 	for (const candidate of candidates) {
 		if (!candidate.content?.parts) continue;
 
+		let hasFunctionCall = false;
+
 		for (const part of candidate.content.parts) {
 			if (part.text !== undefined) {
 				// Text content
@@ -417,6 +424,7 @@ function processGeminiChunk(chunk: GeminiResponseChunk, state: GeminiStreamState
 				state.outputTokens += Math.ceil(part.text.length / 4);
 			} else if (part.functionCall) {
 				// Function call (tool use)
+				hasFunctionCall = true;
 				const toolUseId = `toolu_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`;
 				const argsJson = JSON.stringify(part.functionCall.args ?? {});
 
@@ -431,7 +439,9 @@ function processGeminiChunk(chunk: GeminiResponseChunk, state: GeminiStreamState
 
 		// Check finish reason
 		if (candidate.finishReason) {
-			const stopReason = convertFinishReason(candidate.finishReason);
+			// When the candidate contains function calls, the stop reason must
+			// be tool_use so Anthropic-compatible clients trigger tool execution.
+			const stopReason = hasFunctionCall ? 'tool_use' : convertFinishReason(candidate.finishReason);
 			events.push(messageDeltaSSE(stopReason, { outputTokens: Math.max(state.outputTokens, 1) }));
 			events.push(messageStopSSE());
 			state.finished = true;
@@ -448,6 +458,7 @@ async function collectGeminiResponse(geminiResponse: Response, model: string): P
 	const reader = geminiResponse.body!.getReader();
 	const decoder = new TextDecoder();
 	let buffer = '';
+	let dataBuffer = '';
 
 	const chunks: GeminiResponseChunk[] = [];
 
@@ -460,7 +471,6 @@ async function collectGeminiResponse(geminiResponse: Response, model: string): P
 		const lines = buffer.split('\n');
 		buffer = lines.pop() ?? '';
 
-		let dataBuffer = '';
 		for (const line of lines) {
 			if (line.startsWith('data: ')) {
 				dataBuffer += line.slice(6).trim();
@@ -481,6 +491,7 @@ async function collectGeminiResponse(geminiResponse: Response, model: string): P
 	let stopReason = 'end_turn';
 	let inputTokens = 0;
 	let outputTokens = 0;
+	let hasFunctionCall = false;
 
 	for (const chunk of chunks) {
 		if (!chunk.response) continue;
@@ -500,18 +511,18 @@ async function collectGeminiResponse(geminiResponse: Response, model: string): P
 						text: part.text,
 					});
 				} else if (part.functionCall) {
+					hasFunctionCall = true;
 					contentBlocks.push({
 						type: 'tool_use',
 						id: `toolu_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`,
 						name: part.functionCall.name,
 						input: part.functionCall.args ?? {},
 					});
-					stopReason = 'tool_use';
 				}
 			}
 
 			if (candidate.finishReason) {
-				stopReason = convertFinishReason(candidate.finishReason);
+				stopReason = hasFunctionCall ? 'tool_use' : convertFinishReason(candidate.finishReason);
 			}
 		}
 	}

--- a/packages/daemon/src/lib/providers/gemini/bridge-server.ts
+++ b/packages/daemon/src/lib/providers/gemini/bridge-server.ts
@@ -375,8 +375,9 @@ function streamGeminiResponse(geminiResponse: Response, model: string): Response
 					buffer = lines.pop() ?? '';
 
 					for (const line of lines) {
-						if (line.startsWith('data: ')) {
-							dataBuffer += line.slice(6).trim();
+						const dataContent = extractSSEData(line);
+						if (dataContent !== undefined) {
+							dataBuffer += dataContent.trim();
 						} else if (line === '' && dataBuffer) {
 							// End of SSE event — process the data
 							try {
@@ -394,8 +395,9 @@ function streamGeminiResponse(geminiResponse: Response, model: string): Response
 				}
 
 				// Process any remaining dataBuffer (event without trailing newline)
-				if (buffer.startsWith('data: ')) {
-					dataBuffer += buffer.slice(6).trim();
+				const trailingData = extractSSEData(buffer);
+				if (trailingData !== undefined) {
+					dataBuffer += trailingData.trim();
 				}
 				if (dataBuffer) {
 					try {
@@ -525,8 +527,9 @@ async function collectGeminiResponse(geminiResponse: Response, model: string): P
 		buffer = lines.pop() ?? '';
 
 		for (const line of lines) {
-			if (line.startsWith('data: ')) {
-				dataBuffer += line.slice(6).trim();
+			const dataContent = extractSSEData(line);
+			if (dataContent !== undefined) {
+				dataBuffer += dataContent.trim();
 			} else if (line === '' && dataBuffer) {
 				try {
 					chunks.push(JSON.parse(dataBuffer) as GeminiResponseChunk);
@@ -540,8 +543,9 @@ async function collectGeminiResponse(geminiResponse: Response, model: string): P
 
 	// Flush any trailing SSE payload that arrived at EOF without a
 	// terminating blank line (mirrors the streaming path's EOF handling).
-	if (buffer.startsWith('data: ')) {
-		dataBuffer += buffer.slice(6).trim();
+	const trailingData = extractSSEData(buffer);
+	if (trailingData !== undefined) {
+		dataBuffer += trailingData.trim();
 	}
 	if (dataBuffer) {
 		try {
@@ -614,6 +618,16 @@ async function collectGeminiResponse(geminiResponse: Response, model: string): P
 }
 
 // ---------------------------------------------------------------------------
+/**
+ * Extract the data payload from an SSE `data:` line.
+ * Handles both `data: value` (with space) and `data:value` (without space).
+ */
+function extractSSEData(line: string): string | undefined {
+	if (line.startsWith('data: ')) return line.slice(6); // 'data: ' = 6 chars
+	if (line.startsWith('data:') && line.length > 5) return line.slice(5); // 'data:' = 5 chars
+	return undefined;
+}
+
 // Utilities
 // ---------------------------------------------------------------------------
 

--- a/packages/daemon/src/lib/providers/gemini/bridge-server.ts
+++ b/packages/daemon/src/lib/providers/gemini/bridge-server.ts
@@ -101,8 +101,16 @@ export function createGeminiBridgeServer(config: GeminiBridgeConfig): GeminiBrid
 				return new Response(
 					JSON.stringify({
 						data: [
-							{ id: 'gemini-2.5-pro', type: 'model', display_name: 'Gemini 2.5 Pro' },
-							{ id: 'gemini-2.5-flash', type: 'model', display_name: 'Gemini 2.5 Flash' },
+							{
+								id: 'gemini-2.5-pro',
+								type: 'model',
+								display_name: 'Gemini 2.5 Pro',
+							},
+							{
+								id: 'gemini-2.5-flash',
+								type: 'model',
+								display_name: 'Gemini 2.5 Flash',
+							},
 						],
 					}),
 					{ headers: { 'Content-Type': 'application/json' } }
@@ -185,7 +193,9 @@ async function handleGeminiRequest(
 	// Get a fresh access token
 	let accessToken: string;
 	try {
-		const tokenResponse = await refreshAccessToken(account.refresh_token, { fetchImpl });
+		const tokenResponse = await refreshAccessToken(account.refresh_token, {
+			fetchImpl,
+		});
 		accessToken = tokenResponse.access_token;
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
@@ -198,6 +208,7 @@ async function handleGeminiRequest(
 		// Try another available account instead of failing immediately
 		if (isTokenInvalid || message.includes('NetworkError')) {
 			excludedAccountIds.add(account.id);
+			rotationManager.releaseSession(sessionId);
 			const altAccount = await rotationManager.getAccountForSession(sessionId);
 			if (
 				altAccount &&
@@ -273,7 +284,10 @@ async function handleGeminiRequest(
 				const errorText = await response.text();
 				return new Response(
 					createAnthropicErrorBody(mapStatusToAnthropicError(response.status), errorText),
-					{ status: response.status, headers: { 'Content-Type': 'application/json' } }
+					{
+						status: response.status,
+						headers: { 'Content-Type': 'application/json' },
+					}
 				);
 			}
 
@@ -356,8 +370,8 @@ function streamGeminiResponse(geminiResponse: Response, model: string): Response
 
 					buffer += decoder.decode(value, { stream: true });
 
-					// Parse SSE lines
-					const lines = buffer.split('\n');
+					// Parse SSE lines (normalize CRLF to LF)
+					const lines = buffer.split('\n').map((l) => l.replace(/\r$/, ''));
 					buffer = lines.pop() ?? '';
 
 					for (const line of lines) {
@@ -402,7 +416,9 @@ function streamGeminiResponse(geminiResponse: Response, model: string): Response
 			if (!state.finished) {
 				controller.enqueue(
 					encoder.encode(
-						messageDeltaSSE('end_turn', { outputTokens: Math.max(state.outputTokens, 1) })
+						messageDeltaSSE('end_turn', {
+							outputTokens: Math.max(state.outputTokens, 1),
+						})
 					)
 				);
 				controller.enqueue(encoder.encode(messageStopSSE()));
@@ -475,7 +491,11 @@ function processGeminiChunk(chunk: GeminiResponseChunk, state: GeminiStreamState
 				chunkHasFunctionCall || state.hasSeenFunctionCall
 					? 'tool_use'
 					: convertFinishReason(candidate.finishReason);
-			events.push(messageDeltaSSE(stopReason, { outputTokens: Math.max(state.outputTokens, 1) }));
+			events.push(
+				messageDeltaSSE(stopReason, {
+					outputTokens: Math.max(state.outputTokens, 1),
+				})
+			);
 			events.push(messageStopSSE());
 			state.finished = true;
 		}
@@ -500,8 +520,8 @@ async function collectGeminiResponse(geminiResponse: Response, model: string): P
 		if (done) break;
 		buffer += decoder.decode(value, { stream: true });
 
-		// Parse SSE lines
-		const lines = buffer.split('\n');
+		// Parse SSE lines (normalize CRLF to LF)
+		const lines = buffer.split('\n').map((l) => l.replace(/\r$/, ''));
 		buffer = lines.pop() ?? '';
 
 		for (const line of lines) {
@@ -548,25 +568,27 @@ async function collectGeminiResponse(geminiResponse: Response, model: string): P
 		}
 
 		for (const candidate of chunk.response.candidates ?? []) {
-			if (!candidate.content?.parts) continue;
-
-			for (const part of candidate.content.parts) {
-				if (part.text !== undefined) {
-					contentBlocks.push({
-						type: 'text',
-						text: part.text,
-					});
-				} else if (part.functionCall) {
-					hasFunctionCall = true;
-					contentBlocks.push({
-						type: 'tool_use',
-						id: `toolu_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`,
-						name: part.functionCall.name,
-						input: part.functionCall.args ?? {},
-					});
+			// Process content parts when present
+			if (candidate.content?.parts) {
+				for (const part of candidate.content.parts) {
+					if (part.text !== undefined) {
+						contentBlocks.push({
+							type: 'text',
+							text: part.text,
+						});
+					} else if (part.functionCall) {
+						hasFunctionCall = true;
+						contentBlocks.push({
+							type: 'tool_use',
+							id: `toolu_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`,
+							name: part.functionCall.name,
+							input: part.functionCall.args ?? {},
+						});
+					}
 				}
 			}
 
+			// Handle finishReason even when parts are absent (finish-only chunks)
 			if (candidate.finishReason) {
 				stopReason = hasFunctionCall ? 'tool_use' : convertFinishReason(candidate.finishReason);
 			}

--- a/packages/daemon/src/lib/providers/gemini/bridge-server.ts
+++ b/packages/daemon/src/lib/providers/gemini/bridge-server.ts
@@ -111,6 +111,11 @@ export function createGeminiBridgeServer(config: GeminiBridgeConfig): GeminiBrid
 								type: 'model',
 								display_name: 'Gemini 2.5 Flash',
 							},
+							{
+								id: 'gemini-2.0-flash',
+								type: 'model',
+								display_name: 'Gemini 2.0 Flash',
+							},
 						],
 					}),
 					{ headers: { 'Content-Type': 'application/json' } }

--- a/packages/daemon/src/lib/providers/gemini/bridge-server.ts
+++ b/packages/daemon/src/lib/providers/gemini/bridge-server.ts
@@ -1,0 +1,551 @@
+/**
+ * Gemini Bridge Server
+ *
+ * A local HTTP server that accepts Anthropic Messages API requests and
+ * translates them to Gemini Code Assist API calls.
+ *
+ * This bridge allows the Claude Agent SDK to talk to Gemini models
+ * as if they were Anthropic models, by:
+ * 1. Receiving Anthropic-format requests on /v1/messages
+ * 2. Converting to Gemini Code Assist format
+ * 3. Making streaming requests to cloudcode-pa.googleapis.com
+ * 4. Converting Gemini SSE responses back to Anthropic SSE format
+ */
+
+import { createLogger } from '@neokai/shared/logger';
+import {
+	contentBlockStartTextSSE,
+	contentBlockStartToolUseSSE,
+	contentBlockStopSSE,
+	inputJsonDeltaSSE,
+	messageDeltaSSE,
+	messageStartSSE,
+	messageStopSSE,
+	textDeltaSSE,
+	type AnthropicRequest,
+} from '../codex-anthropic-bridge/translator.js';
+import { createAnthropicErrorBody, type AnthropicErrorType } from '../shared/error-envelope.js';
+import {
+	type GeminiRequest,
+	type GeminiResponseChunk,
+	type GeminiStreamState,
+	anthropicToGemini,
+	convertFinishReason,
+	createStreamState,
+} from './format-converter.js';
+import type { GoogleOAuthAccount } from './oauth-client.js';
+import { refreshAccessToken } from './oauth-client.js';
+import { AccountRotationManager } from './account-rotation.js';
+
+const _log = createLogger('kai:providers:gemini:bridge');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface GeminiBridgeServer {
+	port: number;
+	stop(): void;
+}
+
+export interface GeminiBridgeConfig {
+	rotationManager: AccountRotationManager;
+	fetchImpl?: typeof fetch;
+	sessionId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Code Assist API endpoint
+// ---------------------------------------------------------------------------
+
+const CODE_ASSIST_ENDPOINT = 'https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent';
+
+/** Maximum retry attempts for transient errors. */
+const MAX_RETRIES = 3;
+
+/** Status codes that trigger a retry. */
+const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
+
+// ---------------------------------------------------------------------------
+// Bridge server (synchronous Bun.serve)
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a Gemini bridge server that speaks the Anthropic Messages API.
+ *
+ * Uses Bun.serve() for synchronous creation (required by the Provider interface).
+ * The server listens on a random available port and translates incoming
+ * Anthropic requests to Gemini Code Assist API calls.
+ */
+export function createGeminiBridgeServer(config: GeminiBridgeConfig): GeminiBridgeServer {
+	const fetchImpl = config.fetchImpl ?? fetch;
+	const rotationManager = config.rotationManager;
+	const sessionId = config.sessionId ?? 'default';
+
+	const server = Bun.serve({
+		port: 0,
+		idleTimeout: 0,
+		async fetch(req: Request): Promise<Response> {
+			const url = new URL(req.url);
+
+			// Health check endpoint
+			if (url.pathname === '/health' || url.pathname === '/v1/health') {
+				return new Response('ok');
+			}
+
+			// Models endpoint (minimal)
+			if (url.pathname === '/v1/models' && req.method === 'GET') {
+				return new Response(
+					JSON.stringify({
+						data: [
+							{ id: 'gemini-2.5-pro', type: 'model', display_name: 'Gemini 2.5 Pro' },
+							{ id: 'gemini-2.5-flash', type: 'model', display_name: 'Gemini 2.5 Flash' },
+						],
+					}),
+					{ headers: { 'Content-Type': 'application/json' } }
+				);
+			}
+
+			// Only handle /v1/messages POST
+			if (url.pathname !== '/v1/messages' && url.pathname !== '/v1/messages/') {
+				return new Response(createAnthropicErrorBody('not_found_error', 'Not found'), {
+					status: 404,
+					headers: { 'Content-Type': 'application/json' },
+				});
+			}
+
+			if (req.method !== 'POST') {
+				return new Response(
+					createAnthropicErrorBody('invalid_request_error', 'Method not allowed'),
+					{ status: 405, headers: { 'Content-Type': 'application/json' } }
+				);
+			}
+
+			// Parse request body
+			let anthropicRequest: AnthropicRequest;
+			try {
+				anthropicRequest = (await req.json()) as AnthropicRequest;
+			} catch {
+				return new Response(createAnthropicErrorBody('invalid_request_error', 'Invalid JSON'), {
+					status: 400,
+					headers: { 'Content-Type': 'application/json' },
+				});
+			}
+
+			// Get an account for this session
+			const account = await rotationManager.getAccountForSession(sessionId);
+
+			if (!account) {
+				return new Response(
+					createAnthropicErrorBody(
+						'api_error',
+						'No Google OAuth accounts available. Add an account via the settings.'
+					),
+					{ status: 503, headers: { 'Content-Type': 'application/json' } }
+				);
+			}
+
+			// Convert Anthropic request to Gemini request
+			const geminiRequest = anthropicToGemini(anthropicRequest);
+
+			// Make the streaming request to Gemini
+			return handleGeminiRequest(
+				geminiRequest,
+				account,
+				anthropicRequest,
+				rotationManager,
+				sessionId,
+				fetchImpl
+			);
+		},
+	});
+
+	return {
+		port: server.port ?? 0,
+		stop: () => server.stop(),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Request handling
+// ---------------------------------------------------------------------------
+
+async function handleGeminiRequest(
+	geminiRequest: GeminiRequest,
+	account: GoogleOAuthAccount,
+	anthropicRequest: AnthropicRequest,
+	rotationManager: AccountRotationManager,
+	sessionId: string,
+	fetchImpl: typeof fetch
+): Promise<Response> {
+	// Get a fresh access token
+	let accessToken: string;
+	try {
+		const tokenResponse = await refreshAccessToken(account.refresh_token, { fetchImpl });
+		accessToken = tokenResponse.access_token;
+	} catch (error) {
+		// If the token is invalid, mark the account
+		const message = error instanceof Error ? error.message : String(error);
+		if (message.includes('invalid') || message.includes('revoked')) {
+			await rotationManager.markInvalid(account.id);
+		}
+		return new Response(
+			createAnthropicErrorBody(
+				'authentication_error',
+				`Failed to refresh token for ${account.email}: ${message}`
+			),
+			{ status: 401, headers: { 'Content-Type': 'application/json' } }
+		);
+	}
+
+	// Make the streaming request with retries
+	for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+		try {
+			const response = await fetchImpl(`${CODE_ASSIST_ENDPOINT}?alt=sse`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${accessToken}`,
+				},
+				body: JSON.stringify(geminiRequest),
+			});
+
+			// Handle rate limiting
+			if (response.status === 429) {
+				await rotationManager.handleRateLimit(account.id);
+
+				// Try to get a different account
+				const newAccount = await rotationManager.getAccountForSession(sessionId);
+				if (newAccount && newAccount.id !== account.id) {
+					return handleGeminiRequest(
+						geminiRequest,
+						newAccount,
+						anthropicRequest,
+						rotationManager,
+						sessionId,
+						fetchImpl
+					);
+				}
+
+				return new Response(
+					createAnthropicErrorBody('rate_limit_error', 'All accounts rate limited'),
+					{ status: 429, headers: { 'Content-Type': 'application/json' } }
+				);
+			}
+
+			// Handle server errors with retry
+			if (!response.ok) {
+				if (RETRYABLE_STATUS_CODES.has(response.status) && attempt < MAX_RETRIES) {
+					await response.text(); // consume body
+					const delay = Math.min(1000 * Math.pow(2, attempt), 5000);
+					await sleep(delay);
+					continue;
+				}
+
+				const errorText = await response.text();
+				return new Response(
+					createAnthropicErrorBody(mapStatusToAnthropicError(response.status), errorText),
+					{ status: response.status, headers: { 'Content-Type': 'application/json' } }
+				);
+			}
+
+			// Record successful request
+			await rotationManager.recordRequest(account.id);
+
+			if (!response.body) {
+				return new Response(
+					createAnthropicErrorBody('api_error', 'No response body from Gemini API'),
+					{ status: 502, headers: { 'Content-Type': 'application/json' } }
+				);
+			}
+
+			const isStreaming = anthropicRequest.stream !== false;
+
+			if (isStreaming) {
+				// Stream the response back in Anthropic SSE format
+				return streamGeminiResponse(response, anthropicRequest.model);
+			} else {
+				// Non-streaming: collect all chunks and return as JSON
+				return collectGeminiResponse(response, anthropicRequest.model);
+			}
+		} catch (error) {
+			if (attempt < MAX_RETRIES && error instanceof TypeError) {
+				// Network error — retry
+				const delay = Math.min(1000 * Math.pow(2, attempt), 5000);
+				await sleep(delay);
+				continue;
+			}
+			return new Response(
+				createAnthropicErrorBody(
+					'api_error',
+					error instanceof Error ? error.message : 'Internal server error'
+				),
+				{ status: 500, headers: { 'Content-Type': 'application/json' } }
+			);
+		}
+	}
+
+	// All retries exhausted
+	return new Response(createAnthropicErrorBody('api_error', 'All retries exhausted'), {
+		status: 502,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Streaming response handling
+// ---------------------------------------------------------------------------
+
+function streamGeminiResponse(geminiResponse: Response, model: string): Response {
+	const state = createStreamState(model);
+
+	const stream = new ReadableStream({
+		async start(controller) {
+			const encoder = new TextEncoder();
+
+			// Send message_start event
+			controller.enqueue(encoder.encode(messageStartSSE(state.messageId, model, 0)));
+
+			if (!geminiResponse.body) {
+				controller.enqueue(encoder.encode(messageDeltaSSE('end_turn', { outputTokens: 1 })));
+				controller.enqueue(encoder.encode(messageStopSSE()));
+				controller.close();
+				return;
+			}
+
+			const reader = geminiResponse.body.getReader();
+			const decoder = new TextDecoder();
+			let buffer = '';
+
+			try {
+				while (true) {
+					const { done, value } = await reader.read();
+					if (done) break;
+
+					buffer += decoder.decode(value, { stream: true });
+
+					// Parse SSE lines
+					const lines = buffer.split('\n');
+					buffer = lines.pop() ?? '';
+
+					let dataBuffer = '';
+
+					for (const line of lines) {
+						if (line.startsWith('data: ')) {
+							dataBuffer += line.slice(6).trim();
+						} else if (line === '' && dataBuffer) {
+							// End of SSE event — process the data
+							try {
+								const chunk = JSON.parse(dataBuffer) as GeminiResponseChunk;
+								const events = processGeminiChunk(chunk, state);
+								for (const event of events) {
+									controller.enqueue(encoder.encode(event));
+								}
+							} catch {
+								// Skip malformed JSON chunks
+							}
+							dataBuffer = '';
+						}
+					}
+				}
+
+				// Process any remaining buffer
+				if (buffer.startsWith('data: ')) {
+					try {
+						const chunk = JSON.parse(buffer.slice(6).trim()) as GeminiResponseChunk;
+						const events = processGeminiChunk(chunk, state);
+						for (const event of events) {
+							controller.enqueue(encoder.encode(event));
+						}
+					} catch {
+						// Skip
+					}
+				}
+			} finally {
+				reader.releaseLock();
+			}
+
+			// Close the message if not already done
+			if (!state.finished) {
+				controller.enqueue(
+					encoder.encode(
+						messageDeltaSSE('end_turn', { outputTokens: Math.max(state.outputTokens, 1) })
+					)
+				);
+				controller.enqueue(encoder.encode(messageStopSSE()));
+			}
+
+			controller.close();
+		},
+	});
+
+	return new Response(stream, {
+		status: 200,
+		headers: {
+			'Content-Type': 'text/event-stream',
+			'Cache-Control': 'no-cache',
+			Connection: 'keep-alive',
+		},
+	});
+}
+
+/**
+ * Process a single Gemini response chunk and return Anthropic SSE events.
+ */
+function processGeminiChunk(chunk: GeminiResponseChunk, state: GeminiStreamState): string[] {
+	const events: string[] = [];
+	const response = chunk.response;
+	if (!response) return events;
+
+	// Update usage metadata
+	if (response.usageMetadata) {
+		state.inputTokens = response.usageMetadata.promptTokenCount ?? state.inputTokens;
+		state.outputTokens = response.usageMetadata.candidatesTokenCount ?? state.outputTokens;
+	}
+
+	const candidates = response.candidates ?? [];
+	for (const candidate of candidates) {
+		if (!candidate.content?.parts) continue;
+
+		for (const part of candidate.content.parts) {
+			if (part.text !== undefined) {
+				// Text content
+				events.push(contentBlockStartTextSSE(state.contentBlockIndex));
+				events.push(textDeltaSSE(state.contentBlockIndex, part.text));
+				events.push(contentBlockStopSSE(state.contentBlockIndex));
+				state.contentBlockIndex++;
+				state.outputTokens += Math.ceil(part.text.length / 4);
+			} else if (part.functionCall) {
+				// Function call (tool use)
+				const toolUseId = `toolu_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`;
+				const argsJson = JSON.stringify(part.functionCall.args ?? {});
+
+				events.push(
+					contentBlockStartToolUseSSE(state.contentBlockIndex, toolUseId, part.functionCall.name)
+				);
+				events.push(inputJsonDeltaSSE(state.contentBlockIndex, argsJson));
+				events.push(contentBlockStopSSE(state.contentBlockIndex));
+				state.contentBlockIndex++;
+			}
+		}
+
+		// Check finish reason
+		if (candidate.finishReason) {
+			const stopReason = convertFinishReason(candidate.finishReason);
+			events.push(messageDeltaSSE(stopReason, { outputTokens: Math.max(state.outputTokens, 1) }));
+			events.push(messageStopSSE());
+			state.finished = true;
+		}
+	}
+
+	return events;
+}
+
+/**
+ * Collect a non-streaming Gemini response.
+ */
+async function collectGeminiResponse(geminiResponse: Response, model: string): Promise<Response> {
+	const reader = geminiResponse.body!.getReader();
+	const decoder = new TextDecoder();
+	let buffer = '';
+
+	const chunks: GeminiResponseChunk[] = [];
+
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		buffer += decoder.decode(value, { stream: true });
+
+		// Parse SSE lines
+		const lines = buffer.split('\n');
+		buffer = lines.pop() ?? '';
+
+		let dataBuffer = '';
+		for (const line of lines) {
+			if (line.startsWith('data: ')) {
+				dataBuffer += line.slice(6).trim();
+			} else if (line === '' && dataBuffer) {
+				try {
+					chunks.push(JSON.parse(dataBuffer) as GeminiResponseChunk);
+				} catch {
+					// Skip
+				}
+				dataBuffer = '';
+			}
+		}
+	}
+
+	// Combine chunks into a single Anthropic response
+	const state = createStreamState(model);
+	const contentBlocks: Array<Record<string, unknown>> = [];
+	let stopReason = 'end_turn';
+	let inputTokens = 0;
+	let outputTokens = 0;
+
+	for (const chunk of chunks) {
+		if (!chunk.response) continue;
+
+		if (chunk.response.usageMetadata) {
+			inputTokens = chunk.response.usageMetadata.promptTokenCount ?? inputTokens;
+			outputTokens = chunk.response.usageMetadata.candidatesTokenCount ?? outputTokens;
+		}
+
+		for (const candidate of chunk.response.candidates ?? []) {
+			if (!candidate.content?.parts) continue;
+
+			for (const part of candidate.content.parts) {
+				if (part.text !== undefined) {
+					contentBlocks.push({
+						type: 'text',
+						text: part.text,
+					});
+				} else if (part.functionCall) {
+					contentBlocks.push({
+						type: 'tool_use',
+						id: `toolu_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`,
+						name: part.functionCall.name,
+						input: part.functionCall.args ?? {},
+					});
+					stopReason = 'tool_use';
+				}
+			}
+
+			if (candidate.finishReason) {
+				stopReason = convertFinishReason(candidate.finishReason);
+			}
+		}
+	}
+
+	return new Response(
+		JSON.stringify({
+			id: state.messageId,
+			type: 'message',
+			role: 'assistant',
+			content: contentBlocks,
+			model,
+			stop_reason: stopReason,
+			stop_sequence: null,
+			usage: {
+				input_tokens: inputTokens,
+				output_tokens: outputTokens,
+			},
+		}),
+		{ status: 200, headers: { 'Content-Type': 'application/json' } }
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function mapStatusToAnthropicError(status: number): AnthropicErrorType {
+	if (status === 401 || status === 403) return 'authentication_error';
+	if (status === 404) return 'not_found_error';
+	if (status === 429) return 'rate_limit_error';
+	if (status >= 500) return 'api_error';
+	return 'invalid_request_error';
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/daemon/src/lib/providers/gemini/bridge-server.ts
+++ b/packages/daemon/src/lib/providers/gemini/bridge-server.ts
@@ -211,7 +211,7 @@ async function handleGeminiRequest(
 		}
 
 		// Try another available account instead of failing immediately
-		if (isTokenInvalid || message.includes('NetworkError')) {
+		if (isTokenInvalid || error instanceof TypeError) {
 			excludedAccountIds.add(account.id);
 			rotationManager.releaseSession(sessionId);
 			const altAccount = await rotationManager.getAccountForSession(sessionId);

--- a/packages/daemon/src/lib/providers/gemini/bridge-server.ts
+++ b/packages/daemon/src/lib/providers/gemini/bridge-server.ts
@@ -438,38 +438,43 @@ function processGeminiChunk(chunk: GeminiResponseChunk, state: GeminiStreamState
 
 	const candidates = response.candidates ?? [];
 	for (const candidate of candidates) {
-		if (!candidate.content?.parts) continue;
+		let chunkHasFunctionCall = false;
 
-		let hasFunctionCall = false;
+		// Process content parts if present
+		if (candidate.content?.parts) {
+			for (const part of candidate.content.parts) {
+				if (part.text !== undefined) {
+					// Text content
+					events.push(contentBlockStartTextSSE(state.contentBlockIndex));
+					events.push(textDeltaSSE(state.contentBlockIndex, part.text));
+					events.push(contentBlockStopSSE(state.contentBlockIndex));
+					state.contentBlockIndex++;
+					state.outputTokens += Math.ceil(part.text.length / 4);
+				} else if (part.functionCall) {
+					// Function call (tool use)
+					chunkHasFunctionCall = true;
+					state.hasSeenFunctionCall = true;
+					const toolUseId = `toolu_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`;
+					const argsJson = JSON.stringify(part.functionCall.args ?? {});
 
-		for (const part of candidate.content.parts) {
-			if (part.text !== undefined) {
-				// Text content
-				events.push(contentBlockStartTextSSE(state.contentBlockIndex));
-				events.push(textDeltaSSE(state.contentBlockIndex, part.text));
-				events.push(contentBlockStopSSE(state.contentBlockIndex));
-				state.contentBlockIndex++;
-				state.outputTokens += Math.ceil(part.text.length / 4);
-			} else if (part.functionCall) {
-				// Function call (tool use)
-				hasFunctionCall = true;
-				const toolUseId = `toolu_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`;
-				const argsJson = JSON.stringify(part.functionCall.args ?? {});
-
-				events.push(
-					contentBlockStartToolUseSSE(state.contentBlockIndex, toolUseId, part.functionCall.name)
-				);
-				events.push(inputJsonDeltaSSE(state.contentBlockIndex, argsJson));
-				events.push(contentBlockStopSSE(state.contentBlockIndex));
-				state.contentBlockIndex++;
+					events.push(
+						contentBlockStartToolUseSSE(state.contentBlockIndex, toolUseId, part.functionCall.name)
+					);
+					events.push(inputJsonDeltaSSE(state.contentBlockIndex, argsJson));
+					events.push(contentBlockStopSSE(state.contentBlockIndex));
+					state.contentBlockIndex++;
+				}
 			}
 		}
 
-		// Check finish reason
+		// Check finish reason — handle finish-only chunks (no parts) too.
+		// Gemini can emit finishReason on a terminal chunk with no content.
 		if (candidate.finishReason) {
-			// When the candidate contains function calls, the stop reason must
-			// be tool_use so Anthropic-compatible clients trigger tool execution.
-			const stopReason = hasFunctionCall ? 'tool_use' : convertFinishReason(candidate.finishReason);
+			// Use tool_use if this chunk or any prior chunk contained a function call
+			const stopReason =
+				chunkHasFunctionCall || state.hasSeenFunctionCall
+					? 'tool_use'
+					: convertFinishReason(candidate.finishReason);
 			events.push(messageDeltaSSE(stopReason, { outputTokens: Math.max(state.outputTokens, 1) }));
 			events.push(messageStopSSE());
 			state.finished = true;

--- a/packages/daemon/src/lib/providers/gemini/format-converter.ts
+++ b/packages/daemon/src/lib/providers/gemini/format-converter.ts
@@ -370,6 +370,8 @@ export interface GeminiStreamState {
 	inputTokens: number;
 	outputTokens: number;
 	finished: boolean;
+	/** True if any functionCall part has been seen across all chunks. */
+	hasSeenFunctionCall: boolean;
 }
 
 /** Create a new stream state tracker. */
@@ -384,6 +386,7 @@ export function createStreamState(model: string): GeminiStreamState {
 		inputTokens: 0,
 		outputTokens: 0,
 		finished: false,
+		hasSeenFunctionCall: false,
 	};
 }
 

--- a/packages/daemon/src/lib/providers/gemini/format-converter.ts
+++ b/packages/daemon/src/lib/providers/gemini/format-converter.ts
@@ -164,6 +164,20 @@ export function convertModelId(modelId: string): string {
 export function convertMessages(messages: AnthropicMessage[]): GeminiContent[] {
 	const contents: GeminiContent[] = [];
 
+	// Build a map of tool_use_id → function name from prior tool_use blocks
+	// so tool_result blocks can reference the correct function name.
+	const toolNameMap = new Map<string, string>();
+
+	// First pass: collect tool names from all tool_use blocks
+	for (const msg of messages) {
+		if (typeof msg.content === 'string') continue;
+		for (const block of msg.content) {
+			if (block.type === 'tool_use') {
+				toolNameMap.set(block.id, block.name);
+			}
+		}
+	}
+
 	for (const msg of messages) {
 		const role = msg.role === 'assistant' ? 'model' : 'user';
 
@@ -191,17 +205,19 @@ export function convertMessages(messages: AnthropicMessage[]): GeminiContent[] {
 				});
 			} else if (block.type === 'tool_result') {
 				// Tool results need to be in a user-turn in Gemini format
-				// with a functionResponse part
+				// with a functionResponse part using the original function name
 				const textContent =
 					typeof block.content === 'string'
 						? block.content
 						: block.content.map((c) => c.text).join('');
 
-				// Parse the tool_use_id to recover the function name if possible
-				// The tool result format in Gemini uses functionResponse
+				// Look up the actual function name from the corresponding tool_use block
+				const functionName =
+					toolNameMap.get(block.tool_use_id) ?? extractToolNameFromId(block.tool_use_id);
+
 				toolResultParts.push({
 					functionResponse: {
-						name: extractToolNameFromId(block.tool_use_id),
+						name: functionName,
 						response: { result: textContent },
 					},
 				});

--- a/packages/daemon/src/lib/providers/gemini/format-converter.ts
+++ b/packages/daemon/src/lib/providers/gemini/format-converter.ts
@@ -1,0 +1,424 @@
+/**
+ * Format Converter — Anthropic Messages API ↔ Gemini Code Assist API
+ *
+ * Translates between the Anthropic Messages API format (used by the Claude Agent SDK)
+ * and the Gemini Code Assist `streamGenerateContent` format.
+ *
+ * Adapted from the Gemini CLI's converter.ts (Apache 2.0).
+ *
+ * Key conversions:
+ * - Anthropic `messages[]` → Gemini `contents[]` (role + parts)
+ * - Anthropic `system` → Gemini `systemInstruction`
+ * - Anthropic `tools[]` → Gemini `tools[]` (function declarations)
+ * - Anthropic `tool_choice` → Gemini `toolConfig`
+ * - Anthropic `max_tokens` → Gemini `generationConfig.maxOutputTokens`
+ */
+
+import type {
+	AnthropicMessage,
+	AnthropicRequest,
+	AnthropicTool,
+	ToolChoice,
+} from '../codex-anthropic-bridge/translator.js';
+
+// ---------------------------------------------------------------------------
+// Gemini Code Assist types
+// ---------------------------------------------------------------------------
+
+/** A single content part in the Gemini format. */
+export interface GeminiPart {
+	text?: string;
+	functionCall?: {
+		name: string;
+		args: Record<string, unknown>;
+	};
+	functionResponse?: {
+		name: string;
+		response: Record<string, unknown>;
+	};
+}
+
+/** A single content message in the Gemini format. */
+export interface GeminiContent {
+	role: 'user' | 'model';
+	parts: GeminiPart[];
+}
+
+/** A Gemini function declaration (tool schema). */
+export interface GeminiFunctionDeclaration {
+	name: string;
+	description?: string;
+	parameters?: Record<string, unknown>;
+}
+
+/** A Gemini tool definition. */
+export interface GeminiTool {
+	functionDeclarations?: GeminiFunctionDeclaration[];
+}
+
+/** Gemini tool config (controls tool use behavior). */
+export interface GeminiToolConfig {
+	functionCallingConfig?: {
+		mode?: 'AUTO' | 'ANY' | 'NONE';
+		allowedFunctionNames?: string[];
+	};
+}
+
+/** Gemini generation config. */
+export interface GeminiGenerationConfig {
+	maxOutputTokens?: number;
+	temperature?: number;
+	topP?: number;
+	stopSequences?: string[];
+}
+
+/** Gemini Code Assist request body. */
+export interface GeminiRequest {
+	model: string;
+	project?: string;
+	request: {
+		contents: GeminiContent[];
+		systemInstruction?: { parts: GeminiPart[] };
+		tools?: GeminiTool[];
+		toolConfig?: GeminiToolConfig;
+		generationConfig?: GeminiGenerationConfig;
+	};
+}
+
+/** A Gemini candidate (response part). */
+export interface GeminiCandidate {
+	content?: GeminiContent;
+	finishReason?: string;
+}
+
+/** Gemini usage metadata. */
+export interface GeminiUsageMetadata {
+	promptTokenCount?: number;
+	candidatesTokenCount?: number;
+	totalTokenCount?: number;
+}
+
+/** Gemini Code Assist streaming response chunk. */
+export interface GeminiResponseChunk {
+	response?: {
+		candidates?: GeminiCandidate[];
+		usageMetadata?: GeminiUsageMetadata;
+		modelVersion?: string;
+	};
+	traceId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic → Gemini conversion
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert an Anthropic Messages API request to a Gemini Code Assist request.
+ */
+export function anthropicToGemini(
+	request: AnthropicRequest,
+	options?: { project?: string; sessionId?: string }
+): GeminiRequest {
+	const contents = convertMessages(request.messages);
+	const systemInstruction = convertSystem(request.system);
+	const tools = convertTools(request.tools);
+	const toolConfig = convertToolChoice(request.tool_choice);
+	const generationConfig = convertGenerationConfig(request);
+
+	return {
+		model: convertModelId(request.model),
+		project: options?.project,
+		request: {
+			contents,
+			...(systemInstruction ? { systemInstruction } : {}),
+			...(tools.length > 0 ? { tools } : {}),
+			...(toolConfig ? { toolConfig } : {}),
+			...(generationConfig ? { generationConfig } : {}),
+		},
+	};
+}
+
+/**
+ * Map Anthropic model IDs to Gemini model IDs.
+ */
+export function convertModelId(modelId: string): string {
+	// Pass through Gemini-style model IDs as-is
+	if (modelId.startsWith('gemini-')) {
+		return modelId;
+	}
+
+	// Map common Anthropic model names to Gemini equivalents
+	const modelMap: Record<string, string> = {
+		default: 'gemini-2.5-pro',
+		sonnet: 'gemini-2.5-pro',
+		opus: 'gemini-2.5-pro',
+		haiku: 'gemini-2.5-flash',
+	};
+
+	return modelMap[modelId] ?? 'gemini-2.5-pro';
+}
+
+/**
+ * Convert Anthropic messages to Gemini contents.
+ */
+export function convertMessages(messages: AnthropicMessage[]): GeminiContent[] {
+	const contents: GeminiContent[] = [];
+
+	for (const msg of messages) {
+		const role = msg.role === 'assistant' ? 'model' : 'user';
+
+		if (typeof msg.content === 'string') {
+			contents.push({
+				role,
+				parts: [{ text: msg.content }],
+			});
+			continue;
+		}
+
+		// Split content blocks into separate Gemini parts
+		const parts: GeminiPart[] = [];
+		const toolResultParts: GeminiPart[] = [];
+
+		for (const block of msg.content) {
+			if (block.type === 'text') {
+				parts.push({ text: block.text });
+			} else if (block.type === 'tool_use') {
+				parts.push({
+					functionCall: {
+						name: block.name,
+						args: block.input as Record<string, unknown>,
+					},
+				});
+			} else if (block.type === 'tool_result') {
+				// Tool results need to be in a user-turn in Gemini format
+				// with a functionResponse part
+				const textContent =
+					typeof block.content === 'string'
+						? block.content
+						: block.content.map((c) => c.text).join('');
+
+				// Parse the tool_use_id to recover the function name if possible
+				// The tool result format in Gemini uses functionResponse
+				toolResultParts.push({
+					functionResponse: {
+						name: extractToolNameFromId(block.tool_use_id),
+						response: { result: textContent },
+					},
+				});
+			}
+		}
+
+		if (parts.length > 0) {
+			contents.push({ role, parts });
+		}
+
+		// Tool results must be in a user-turn
+		if (toolResultParts.length > 0) {
+			contents.push({ role: 'user', parts: toolResultParts });
+		}
+	}
+
+	return contents;
+}
+
+/**
+ * Convert Anthropic system prompt to Gemini systemInstruction.
+ */
+export function convertSystem(
+	system: AnthropicRequest['system']
+): { parts: GeminiPart[] } | undefined {
+	if (!system) return undefined;
+
+	const text = typeof system === 'string' ? system : system.map((b) => b.text).join('\n');
+
+	if (!text) return undefined;
+
+	return { parts: [{ text }] };
+}
+
+/**
+ * Convert Anthropic tools to Gemini function declarations.
+ */
+export function convertTools(tools: AnthropicTool[] | undefined): GeminiTool[] {
+	if (!tools || tools.length === 0) return [];
+
+	return [
+		{
+			functionDeclarations: tools.map((tool) => ({
+				name: tool.name,
+				description: tool.description ?? '',
+				parameters: convertSchema(tool.input_schema),
+			})),
+		},
+	];
+}
+
+/**
+ * Convert JSON Schema from Anthropic format to Gemini format.
+ *
+ * Gemini expects JSON Schema but with some differences:
+ * - No `additionalProperties` field
+ * - `anyOf` instead of `oneOf`
+ */
+export function convertSchema(schema: Record<string, unknown>): Record<string, unknown> {
+	if (!schema) return schema;
+
+	const result = { ...schema };
+
+	// Remove additionalProperties (not supported by Gemini)
+	delete result.additionalProperties;
+
+	// Convert oneOf to anyOf
+	if (result.oneOf) {
+		result.anyOf = result.oneOf;
+		delete result.oneOf;
+	}
+
+	// Recursively convert nested schemas
+	if (result.properties && typeof result.properties === 'object') {
+		const props = result.properties as Record<string, Record<string, unknown>>;
+		result.properties = Object.fromEntries(
+			Object.entries(props).map(([key, value]) => [key, convertSchema(value)])
+		);
+	}
+
+	if (result.items && typeof result.items === 'object') {
+		result.items = convertSchema(result.items as Record<string, unknown>);
+	}
+
+	if (result.anyOf && Array.isArray(result.anyOf)) {
+		result.anyOf = result.anyOf.map((s: Record<string, unknown>) => convertSchema(s));
+	}
+
+	return result;
+}
+
+/**
+ * Convert Anthropic tool_choice to Gemini toolConfig.
+ */
+export function convertToolChoice(
+	toolChoice: ToolChoice | undefined
+): GeminiToolConfig | undefined {
+	if (!toolChoice) return undefined;
+
+	switch (toolChoice.type) {
+		case 'auto':
+			return { functionCallingConfig: { mode: 'AUTO' } };
+		case 'none':
+			return { functionCallingConfig: { mode: 'NONE' } };
+		case 'any':
+			return { functionCallingConfig: { mode: 'ANY' } };
+		case 'tool':
+			return {
+				functionCallingConfig: {
+					mode: 'ANY',
+					allowedFunctionNames: [toolChoice.name],
+				},
+			};
+		default:
+			return undefined;
+	}
+}
+
+/**
+ * Convert Anthropic generation parameters to Gemini generationConfig.
+ */
+export function convertGenerationConfig(
+	request: AnthropicRequest
+): GeminiGenerationConfig | undefined {
+	const config: GeminiGenerationConfig = {};
+
+	if (request.max_tokens) {
+		config.maxOutputTokens = request.max_tokens;
+	}
+
+	if (config.maxOutputTokens === undefined) {
+		return undefined;
+	}
+
+	return config;
+}
+
+// ---------------------------------------------------------------------------
+// Gemini → Anthropic conversion (for streaming responses)
+// ---------------------------------------------------------------------------
+
+/** Track state for converting Gemini streaming chunks to Anthropic SSE events. */
+export interface GeminiStreamState {
+	messageId: string;
+	model: string;
+	contentBlockIndex: number;
+	currentToolUseId: string | null;
+	currentToolName: string | null;
+	toolUseJsonBuffer: string;
+	inputTokens: number;
+	outputTokens: number;
+	finished: boolean;
+}
+
+/** Create a new stream state tracker. */
+export function createStreamState(model: string): GeminiStreamState {
+	return {
+		messageId: `msg_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`,
+		model,
+		contentBlockIndex: 0,
+		currentToolUseId: null,
+		currentToolName: null,
+		toolUseJsonBuffer: '',
+		inputTokens: 0,
+		outputTokens: 0,
+		finished: false,
+	};
+}
+
+/**
+ * Extract finish reason from a Gemini candidate.
+ */
+export function convertFinishReason(
+	reason: string | undefined
+): 'end_turn' | 'tool_use' | 'max_tokens' {
+	switch (reason) {
+		case 'STOP':
+			return 'end_turn';
+		case 'SAFETY':
+		case 'MAX_TOKENS':
+			return 'max_tokens';
+		case 'RECITATION':
+			return 'end_turn';
+		default:
+			return 'end_turn';
+	}
+}
+
+/**
+ * Extract the tool name from a tool_use_id.
+ * Falls back to 'unknown_tool' if parsing fails.
+ */
+function extractToolNameFromId(toolUseId: string): string {
+	// In practice, tool_use_ids are random. We need the actual tool name
+	// from the corresponding tool_use block. This is a fallback.
+	return `tool_${toolUseId.slice(0, 8)}`;
+}
+
+/**
+ * Get text parts from a Gemini candidate.
+ */
+export function extractTextFromCandidate(candidate: GeminiCandidate): string {
+	if (!candidate?.content?.parts) return '';
+	return candidate.content.parts
+		.filter((p) => p.text !== undefined)
+		.map((p) => p.text!)
+		.join('');
+}
+
+/**
+ * Get function call parts from a Gemini candidate.
+ */
+export function extractFunctionCallsFromCandidate(
+	candidate: GeminiCandidate
+): Array<{ name: string; args: Record<string, unknown> }> {
+	if (!candidate?.content?.parts) return [];
+	return candidate.content.parts
+		.filter((p) => p.functionCall !== undefined)
+		.map((p) => p.functionCall!);
+}

--- a/packages/daemon/src/lib/providers/gemini/gemini-provider.ts
+++ b/packages/daemon/src/lib/providers/gemini/gemini-provider.ts
@@ -260,15 +260,15 @@ export class GeminiOAuthProvider implements Provider {
 		// Exchange code for tokens
 		const tokenResponse = await exchangeAuthCode(authCode, codeVerifier, this._deps);
 
+		if (!tokenResponse.refresh_token) {
+			throw new Error('No refresh token received from Google OAuth. Please try again.');
+		}
+
 		// Fetch user info
 		const userInfo = await fetchUserInfo(tokenResponse.access_token, this._deps);
 
 		// Create and store the account
-		const account = createAccount(
-			userInfo.email,
-			tokenResponse.refresh_token ?? '', // Should always be present with offline access
-			1500
-		);
+		const account = createAccount(userInfo.email, tokenResponse.refresh_token, 1500);
 
 		await persistAddAccount(account);
 		await this.rotationManager.addAccount(account);

--- a/packages/daemon/src/lib/providers/gemini/gemini-provider.ts
+++ b/packages/daemon/src/lib/providers/gemini/gemini-provider.ts
@@ -109,6 +109,9 @@ export class GeminiOAuthProvider implements Provider {
 	private _pendingCodeVerifier?: string;
 	private _pendingOAuthState?: string;
 	private _oauthCallbackServer?: { stop(): void };
+	/** Flow ID of the currently active OAuth callback server, used to prevent
+	 *  stale background handlers from tearing down a newer flow's server. */
+	private _activeCallbackFlowId?: string;
 
 	constructor(deps?: OAuthClientDeps) {
 		this._deps = deps;
@@ -212,6 +215,18 @@ export class GeminiOAuthProvider implements Provider {
 			const invalidAccounts = accounts.filter((a) => a.status === 'invalid');
 
 			if (activeAccounts.length === 0) {
+				const exhaustedAccounts = accounts.filter((a) => a.status === 'exhausted');
+				if (exhaustedAccounts.length > 0) {
+					// Accounts exist but are temporarily rate-limited — still authenticated
+					return {
+						isAuthenticated: true,
+						method: 'oauth',
+						user: {
+							email: exhaustedAccounts.map((a) => a.email).join(', '),
+						},
+					};
+				}
+
 				return {
 					isAuthenticated: false,
 					method: 'oauth',
@@ -308,15 +323,32 @@ export class GeminiOAuthProvider implements Provider {
 		const callbackPort = server.port ?? 0;
 		const redirectUri = `http://localhost:${callbackPort}/callback`;
 
-		// Build the auth URL with the local callback redirect URI
-		const { authUrl, codeVerifier, state } = await buildAuthUrlWithRedirect(redirectUri);
+		// Build the auth URL with the local callback redirect URI.
+		// If URL generation fails (e.g. missing OAuth env vars), stop the
+		// server before rethrowing so we don't leak an orphaned server.
+		let authUrl: string;
+		let codeVerifier: string;
+		let state: string;
+		try {
+			({ authUrl, codeVerifier, state } = await buildAuthUrlWithRedirect(redirectUri));
+		} catch (err) {
+			server.stop();
+			this._oauthCallbackServer = undefined;
+			throw err;
+		}
+
 		expectedState = state;
 		this._pendingCodeVerifier = codeVerifier;
 		this._pendingOAuthState = state;
+
+		// Assign a unique flow ID so the background handler only tears down
+		// its own server (not a newer login flow's server).
+		const flowId = crypto.randomUUID();
 		this._oauthCallbackServer = server;
+		this._activeCallbackFlowId = flowId;
 
 		// Start background code exchange — runs after the user authorizes
-		this.handleOAuthCallback(codePromise, codeVerifier, redirectUri);
+		this.handleOAuthCallback(codePromise, codeVerifier, redirectUri, flowId);
 
 		return {
 			type: 'redirect',
@@ -329,11 +361,15 @@ export class GeminiOAuthProvider implements Provider {
 	/**
 	 * Background handler: waits for the OAuth code from the callback server,
 	 * exchanges it for tokens, and saves the account.
+	 *
+	 * @param flowId - Unique ID for this login flow; the finally block only
+	 *   tears down the callback server if it still belongs to this flow.
 	 */
 	private async handleOAuthCallback(
 		codePromise: Promise<string>,
 		codeVerifier: string,
-		redirectUri: string
+		redirectUri: string,
+		flowId: string
 	): Promise<void> {
 		try {
 			// Wait for the code with a 240-second timeout (allows MFA and account switching)
@@ -368,7 +404,12 @@ export class GeminiOAuthProvider implements Provider {
 		} catch (err) {
 			log.error(`OAuth code exchange failed: ${err instanceof Error ? err.message : err}`);
 		} finally {
-			this.stopOAuthCallbackServer();
+			// Only tear down the server if this flow still owns it.
+			// A newer startOAuthFlow() call may have replaced it.
+			if (this._activeCallbackFlowId === flowId) {
+				this.stopOAuthCallbackServer();
+				this._activeCallbackFlowId = undefined;
+			}
 		}
 	}
 

--- a/packages/daemon/src/lib/providers/gemini/gemini-provider.ts
+++ b/packages/daemon/src/lib/providers/gemini/gemini-provider.ts
@@ -287,13 +287,15 @@ export class GeminiOAuthProvider implements Provider {
 	}
 
 	/**
-	 * Logout — removes all accounts.
+	 * Logout — removes all accounts and tears down active bridge servers.
 	 */
 	async logout(): Promise<void> {
 		const accounts = await loadAccounts();
 		for (const account of accounts) {
 			await persistRemoveAccount(account.id);
 		}
+		// Tear down active bridge servers so they stop using the old rotation manager
+		await this.shutdown();
 		this.rotationManager = new AccountRotationManager();
 		log.info('Logged out all Google accounts');
 	}

--- a/packages/daemon/src/lib/providers/gemini/gemini-provider.ts
+++ b/packages/daemon/src/lib/providers/gemini/gemini-provider.ts
@@ -321,14 +321,14 @@ export class GeminiOAuthProvider implements Provider {
 		redirectUri: string
 	): Promise<void> {
 		try {
-			// Wait for the code with a 60-second timeout
+			// Wait for the code with a 240-second timeout (allows MFA and account switching)
 			const code = await Promise.race([
 				codePromise,
-				new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 60_000)),
+				new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 240_000)),
 			]);
 
 			if (!code) {
-				log.warn('OAuth callback timed out — no code received within 60 seconds');
+				log.warn('OAuth callback timed out — no code received within 240 seconds');
 				return;
 			}
 

--- a/packages/daemon/src/lib/providers/gemini/gemini-provider.ts
+++ b/packages/daemon/src/lib/providers/gemini/gemini-provider.ts
@@ -137,10 +137,10 @@ export class GeminiOAuthProvider implements Provider {
 	}
 
 	/**
-	 * Check if a model ID belongs to this provider.
+	 * Check if a model ID belongs to this provider (exact match against catalog).
 	 */
 	ownsModel(modelId: string): boolean {
-		return modelId.startsWith('gemini-');
+		return GEMINI_MODELS.some((m) => m.id === modelId);
 	}
 
 	/**

--- a/packages/daemon/src/lib/providers/gemini/gemini-provider.ts
+++ b/packages/daemon/src/lib/providers/gemini/gemini-provider.ts
@@ -107,6 +107,7 @@ export class GeminiOAuthProvider implements Provider {
 	private bridgeServers = new Map<string, GeminiBridgeServer>();
 	private _deps?: OAuthClientDeps;
 	private _pendingCodeVerifier?: string;
+	private _pendingOAuthState?: string;
 	private _oauthCallbackServer?: { stop(): void };
 
 	constructor(deps?: OAuthClientDeps) {
@@ -249,13 +250,16 @@ export class GeminiOAuthProvider implements Provider {
 		// Tear down any previous callback server
 		this.stopOAuthCallbackServer();
 
+		// Start a local callback server to receive the OAuth redirect
+		// State will be injected after building the auth URL
+		let expectedState = '';
+
 		// Promise that resolves when the OAuth callback delivers the auth code
 		let resolveCode: ((code: string) => void) | undefined;
 		const codePromise = new Promise<string>((resolve) => {
 			resolveCode = resolve;
 		});
 
-		// Start a local callback server to receive the OAuth redirect
 		const server = Bun.serve({
 			port: 0,
 			idleTimeout: 255, // seconds — give the user time to authorize
@@ -270,6 +274,15 @@ export class GeminiOAuthProvider implements Provider {
 				if (error) {
 					return new Response(OAUTH_ERROR_HTML(error), {
 						status: 400,
+						headers: { 'Content-Type': 'text/html' },
+					});
+				}
+
+				// Validate state parameter to prevent CSRF
+				const returnedState = url.searchParams.get('state');
+				if (!returnedState || returnedState !== expectedState) {
+					return new Response(OAUTH_ERROR_HTML('Invalid OAuth state parameter'), {
+						status: 403,
 						headers: { 'Content-Type': 'text/html' },
 					});
 				}
@@ -296,8 +309,10 @@ export class GeminiOAuthProvider implements Provider {
 		const redirectUri = `http://localhost:${callbackPort}/callback`;
 
 		// Build the auth URL with the local callback redirect URI
-		const { authUrl, codeVerifier } = await buildAuthUrlWithRedirect(redirectUri);
+		const { authUrl, codeVerifier, state } = await buildAuthUrlWithRedirect(redirectUri);
+		expectedState = state;
 		this._pendingCodeVerifier = codeVerifier;
+		this._pendingOAuthState = state;
 		this._oauthCallbackServer = server;
 
 		// Start background code exchange — runs after the user authorizes
@@ -333,6 +348,7 @@ export class GeminiOAuthProvider implements Provider {
 			}
 
 			this._pendingCodeVerifier = undefined;
+			this._pendingOAuthState = undefined;
 			this.stopOAuthCallbackServer();
 
 			const tokenResponse = await exchangeAuthCode(code, codeVerifier, this._deps, redirectUri);

--- a/packages/daemon/src/lib/providers/gemini/gemini-provider.ts
+++ b/packages/daemon/src/lib/providers/gemini/gemini-provider.ts
@@ -10,6 +10,7 @@
  * - Account exhaustion detection and cooldown
  * - Invalid token detection and flagging
  * - Anthropic Messages API ↔ Gemini Code Assist format translation
+ * - Self-contained OAuth via local callback server
  */
 
 import type {
@@ -24,7 +25,7 @@ import type {
 import type { ModelInfo } from '@neokai/shared';
 import { createLogger } from '@neokai/shared/logger';
 import {
-	buildAuthUrl,
+	buildAuthUrlWithRedirect,
 	exchangeAuthCode,
 	fetchUserInfo,
 	loadAccounts,
@@ -78,6 +79,14 @@ const GEMINI_MODELS: ModelInfo[] = [
 	},
 ];
 
+/** Success HTML shown in the browser after OAuth completes. */
+const OAUTH_SUCCESS_HTML =
+	'<html><body><h2>Authorization successful!</h2><p>You can close this tab and return to NeoKai.</p></body></html>';
+
+/** Error HTML shown in the browser when OAuth fails. */
+const OAUTH_ERROR_HTML = (reason: string) =>
+	`<html><body><h2>Authorization failed</h2><p>${reason}</p><p>You can close this tab.</p></body></html>`;
+
 // ---------------------------------------------------------------------------
 // Gemini OAuth Provider
 // ---------------------------------------------------------------------------
@@ -97,6 +106,8 @@ export class GeminiOAuthProvider implements Provider {
 	private rotationManager: AccountRotationManager;
 	private bridgeServers = new Map<string, GeminiBridgeServer>();
 	private _deps?: OAuthClientDeps;
+	private _pendingCodeVerifier?: string;
+	private _oauthCallbackServer?: { stop(): void };
 
 	constructor(deps?: OAuthClientDeps) {
 		this._deps = deps;
@@ -226,28 +237,130 @@ export class GeminiOAuthProvider implements Provider {
 	/**
 	 * Start the OAuth flow for adding a new Google account.
 	 *
-	 * Returns a redirect-type flow with the auth URL the user should visit.
+	 * Spins up a local callback server on a random port, builds the Google
+	 * OAuth URL with `http://localhost:{port}/callback` as the redirect URI,
+	 * and returns the URL for the user to visit. When the user authorizes,
+	 * Google redirects to the local server which automatically exchanges the
+	 * code for tokens and persists the account.
+	 *
+	 * The caller polls `getAuthStatus()` to detect completion.
 	 */
 	async startOAuthFlow(): Promise<ProviderOAuthFlowData> {
-		const { authUrl, codeVerifier } = await buildAuthUrl();
+		// Tear down any previous callback server
+		this.stopOAuthCallbackServer();
 
-		// Store the code verifier temporarily for the callback
-		// In a real implementation, this would be stored in session state
+		// Promise that resolves when the OAuth callback delivers the auth code
+		let resolveCode: ((code: string) => void) | undefined;
+		const codePromise = new Promise<string>((resolve) => {
+			resolveCode = resolve;
+		});
+
+		// Start a local callback server to receive the OAuth redirect
+		const server = Bun.serve({
+			port: 0,
+			idleTimeout: 255, // seconds — give the user time to authorize
+			fetch(req: Request): Response {
+				const url = new URL(req.url);
+
+				if (url.pathname === '/favicon.ico') {
+					return new Response('', { status: 204 });
+				}
+
+				const error = url.searchParams.get('error');
+				if (error) {
+					return new Response(OAUTH_ERROR_HTML(error), {
+						status: 400,
+						headers: { 'Content-Type': 'text/html' },
+					});
+				}
+
+				const code = url.searchParams.get('code');
+				if (!code) {
+					return new Response(OAUTH_ERROR_HTML('Missing authorization code'), {
+						status: 400,
+						headers: { 'Content-Type': 'text/html' },
+					});
+				}
+
+				// Resolve the promise so the background exchanger can proceed
+				resolveCode?.(code);
+
+				return new Response(OAUTH_SUCCESS_HTML, {
+					status: 200,
+					headers: { 'Content-Type': 'text/html' },
+				});
+			},
+		});
+
+		const callbackPort = server.port ?? 0;
+		const redirectUri = `http://localhost:${callbackPort}/callback`;
+
+		// Build the auth URL with the local callback redirect URI
+		const { authUrl, codeVerifier } = await buildAuthUrlWithRedirect(redirectUri);
 		this._pendingCodeVerifier = codeVerifier;
+		this._oauthCallbackServer = server;
+
+		// Start background code exchange — runs after the user authorizes
+		this.handleOAuthCallback(codePromise, codeVerifier, redirectUri);
 
 		return {
 			type: 'redirect',
 			authUrl,
 			message:
-				'Visit the URL to authorize your Google account, then provide the authorization code.',
+				'Visit the URL to authorize your Google account. The page will redirect automatically.',
 		};
+	}
+
+	/**
+	 * Background handler: waits for the OAuth code from the callback server,
+	 * exchanges it for tokens, and saves the account.
+	 */
+	private async handleOAuthCallback(
+		codePromise: Promise<string>,
+		codeVerifier: string,
+		redirectUri: string
+	): Promise<void> {
+		try {
+			// Wait for the code with a 60-second timeout
+			const code = await Promise.race([
+				codePromise,
+				new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 60_000)),
+			]);
+
+			if (!code) {
+				log.warn('OAuth callback timed out — no code received within 60 seconds');
+				return;
+			}
+
+			this._pendingCodeVerifier = undefined;
+			this.stopOAuthCallbackServer();
+
+			const tokenResponse = await exchangeAuthCode(code, codeVerifier, this._deps, redirectUri);
+
+			if (!tokenResponse.refresh_token) {
+				log.error('No refresh token received from Google OAuth');
+				return;
+			}
+
+			const userInfo = await fetchUserInfo(tokenResponse.access_token, this._deps);
+			const account = createAccount(userInfo.email, tokenResponse.refresh_token, 1500);
+
+			await persistAddAccount(account);
+			await this.rotationManager.addAccount(account);
+
+			log.info(`Added Google account via OAuth callback: ${userInfo.email}`);
+		} catch (err) {
+			log.error(`OAuth code exchange failed: ${err instanceof Error ? err.message : err}`);
+		} finally {
+			this.stopOAuthCallbackServer();
+		}
 	}
 
 	/**
 	 * Complete the OAuth flow by exchanging the authorization code.
 	 *
-	 * This is called separately after startOAuthFlow() once the user
-	 * provides the authorization code from the Google consent page.
+	 * Kept for backward compatibility and manual code entry scenarios,
+	 * but the primary flow uses the local callback server in startOAuthFlow().
 	 */
 	async completeOAuthFlow(authCode: string): Promise<{ email: string; accountId: string }> {
 		if (!this._pendingCodeVerifier) {
@@ -296,6 +409,7 @@ export class GeminiOAuthProvider implements Provider {
 		}
 		// Tear down active bridge servers so they stop using the old rotation manager
 		await this.shutdown();
+		this.stopOAuthCallbackServer();
 		this.rotationManager = new AccountRotationManager();
 		log.info('Logged out all Google accounts');
 	}
@@ -312,14 +426,21 @@ export class GeminiOAuthProvider implements Provider {
 	}
 
 	/**
+	 * Stop the OAuth callback server if running.
+	 */
+	private stopOAuthCallbackServer(): void {
+		if (this._oauthCallbackServer) {
+			this._oauthCallbackServer.stop();
+			this._oauthCallbackServer = undefined;
+		}
+	}
+
+	/**
 	 * Get the rotation manager (for testing).
 	 */
 	getRotationManager(): AccountRotationManager {
 		return this.rotationManager;
 	}
-
-	/** Pending PKCE code verifier for the in-progress OAuth flow. */
-	private _pendingCodeVerifier?: string;
 
 	/**
 	 * Set the code verifier (for testing or pre-seeded flows).

--- a/packages/daemon/src/lib/providers/gemini/gemini-provider.ts
+++ b/packages/daemon/src/lib/providers/gemini/gemini-provider.ts
@@ -26,6 +26,7 @@ import type { ModelInfo } from '@neokai/shared';
 import { createLogger } from '@neokai/shared/logger';
 import {
 	buildAuthUrlWithRedirect,
+	getOAuthClientId,
 	exchangeAuthCode,
 	fetchUserInfo,
 	loadAccounts,
@@ -126,7 +127,14 @@ export class GeminiOAuthProvider implements Provider {
 	async isAvailable(): Promise<boolean> {
 		try {
 			const accounts = await loadAccounts();
-			return accounts.some((a) => a.status !== 'invalid');
+			if (!accounts.some((a) => a.status !== 'invalid')) return false;
+			// Verify OAuth client env vars are configured
+			try {
+				getOAuthClientId();
+				return true;
+			} catch {
+				return false;
+			}
 		} catch {
 			return false;
 		}
@@ -385,7 +393,11 @@ export class GeminiOAuthProvider implements Provider {
 
 			this._pendingCodeVerifier = undefined;
 			this._pendingOAuthState = undefined;
-			this.stopOAuthCallbackServer();
+			// Only shut down the server if this flow still owns it
+			if (this._activeCallbackFlowId === flowId) {
+				this.stopOAuthCallbackServer();
+				this._activeCallbackFlowId = undefined;
+			}
 
 			const tokenResponse = await exchangeAuthCode(code, codeVerifier, this._deps, redirectUri);
 

--- a/packages/daemon/src/lib/providers/gemini/gemini-provider.ts
+++ b/packages/daemon/src/lib/providers/gemini/gemini-provider.ts
@@ -1,0 +1,328 @@
+/**
+ * Google Gemini OAuth Provider
+ *
+ * Provides Anthropic-compatible bridge for Google Gemini models
+ * authenticated via OAuth (Google Pro subscription credentials).
+ *
+ * Key features:
+ * - Multiple Google account rotation with session affinity
+ * - Automatic failover on rate limits (429)
+ * - Account exhaustion detection and cooldown
+ * - Invalid token detection and flagging
+ * - Anthropic Messages API ↔ Gemini Code Assist format translation
+ */
+
+import type {
+	Provider,
+	ProviderCapabilities,
+	ProviderSdkConfig,
+	ProviderSessionConfig,
+	ProviderAuthStatusInfo,
+	ProviderOAuthFlowData,
+	ModelTier,
+} from '@neokai/shared/provider';
+import type { ModelInfo } from '@neokai/shared';
+import { createLogger } from '@neokai/shared/logger';
+import {
+	buildAuthUrl,
+	exchangeAuthCode,
+	fetchUserInfo,
+	loadAccounts,
+	type OAuthClientDeps,
+	createAccount,
+	addAccount as persistAddAccount,
+	removeAccount as persistRemoveAccount,
+} from './oauth-client.js';
+import { AccountRotationManager } from './account-rotation.js';
+import { createGeminiBridgeServer, type GeminiBridgeServer } from './bridge-server.js';
+
+const log = createLogger('kai:providers:gemini');
+
+// ---------------------------------------------------------------------------
+// Gemini models
+// ---------------------------------------------------------------------------
+
+const GEMINI_MODELS: ModelInfo[] = [
+	{
+		id: 'gemini-2.5-pro',
+		name: 'Gemini 2.5 Pro',
+		alias: 'gemini-2.5-pro',
+		family: 'gemini',
+		provider: 'google-gemini-oauth',
+		contextWindow: 1_000_000,
+		description: 'Google Gemini 2.5 Pro via Code Assist (OAuth)',
+		releaseDate: '2025-01-01',
+		available: true,
+	},
+	{
+		id: 'gemini-2.5-flash',
+		name: 'Gemini 2.5 Flash',
+		alias: 'gemini-2.5-flash',
+		family: 'gemini',
+		provider: 'google-gemini-oauth',
+		contextWindow: 1_000_000,
+		description: 'Google Gemini 2.5 Flash via Code Assist (OAuth)',
+		releaseDate: '2025-01-01',
+		available: true,
+	},
+	{
+		id: 'gemini-2.0-flash',
+		name: 'Gemini 2.0 Flash',
+		alias: 'gemini-2.0-flash',
+		family: 'gemini',
+		provider: 'google-gemini-oauth',
+		contextWindow: 1_000_000,
+		description: 'Google Gemini 2.0 Flash via Code Assist (OAuth)',
+		releaseDate: '2025-01-01',
+		available: true,
+	},
+];
+
+// ---------------------------------------------------------------------------
+// Gemini OAuth Provider
+// ---------------------------------------------------------------------------
+
+export class GeminiOAuthProvider implements Provider {
+	readonly id = 'google-gemini-oauth';
+	readonly displayName = 'Google Gemini (OAuth)';
+
+	readonly capabilities: ProviderCapabilities = {
+		streaming: true,
+		extendedThinking: false,
+		maxContextWindow: 1_000_000,
+		functionCalling: true,
+		vision: false,
+	};
+
+	private rotationManager: AccountRotationManager;
+	private bridgeServers = new Map<string, GeminiBridgeServer>();
+	private _deps?: OAuthClientDeps;
+
+	constructor(deps?: OAuthClientDeps) {
+		this._deps = deps;
+		this.rotationManager = new AccountRotationManager({
+			healthCheckOnStartup: false, // Defer to explicit initialization
+		});
+	}
+
+	/**
+	 * Check if this provider is available (has at least one configured account).
+	 */
+	async isAvailable(): Promise<boolean> {
+		try {
+			const accounts = await loadAccounts();
+			return accounts.some((a) => a.status !== 'invalid');
+		} catch {
+			return false;
+		}
+	}
+
+	/**
+	 * Get list of available Gemini models.
+	 */
+	async getModels(): Promise<ModelInfo[]> {
+		return GEMINI_MODELS;
+	}
+
+	/**
+	 * Check if a model ID belongs to this provider.
+	 */
+	ownsModel(modelId: string): boolean {
+		return modelId.startsWith('gemini-');
+	}
+
+	/**
+	 * Get model for a specific tier.
+	 */
+	getModelForTier(tier: ModelTier): string | undefined {
+		const tierMap: Record<ModelTier, string> = {
+			sonnet: 'gemini-2.5-pro',
+			haiku: 'gemini-2.5-flash',
+			opus: 'gemini-2.5-pro',
+			default: 'gemini-2.5-pro',
+		};
+		return tierMap[tier];
+	}
+
+	/**
+	 * Build SDK configuration for this provider.
+	 *
+	 * Creates a local bridge server that translates Anthropic API calls
+	 * to Gemini Code Assist API calls. Returns the bridge server's URL
+	 * as the ANTHROPIC_BASE_URL so the SDK routes requests through it.
+	 *
+	 * buildSdkConfig() is synchronous per the Provider interface.
+	 * The async rotation manager initialization is deferred to the first request.
+	 */
+	buildSdkConfig(modelId: string, sessionConfig?: ProviderSessionConfig): ProviderSdkConfig {
+		const sessionId = sessionConfig?.sessionId ?? 'default';
+
+		// Create a bridge server for this session (or reuse existing)
+		// Initialization of the rotation manager happens lazily on first request
+		let bridge = this.bridgeServers.get(sessionId);
+		if (!bridge) {
+			bridge = createGeminiBridgeServer({
+				rotationManager: this.rotationManager,
+				fetchImpl: this._deps?.fetchImpl,
+				sessionId,
+			});
+			this.bridgeServers.set(sessionId, bridge);
+			log.info(`Bridge server started on port ${bridge.port} for session ${sessionId}`);
+		}
+
+		return {
+			envVars: {
+				ANTHROPIC_BASE_URL: `http://127.0.0.1:${bridge.port}`,
+				ANTHROPIC_API_KEY: 'gemini-oauth-placeholder',
+			},
+			isAnthropicCompatible: true,
+			apiVersion: 'v1',
+		};
+	}
+
+	/**
+	 * Get authentication status for this provider.
+	 */
+	async getAuthStatus(): Promise<ProviderAuthStatusInfo> {
+		try {
+			await this.rotationManager.initialize();
+			const accounts = this.rotationManager.getAccounts();
+
+			if (accounts.length === 0) {
+				return {
+					isAuthenticated: false,
+					method: 'oauth',
+					error: 'No Google accounts configured',
+				};
+			}
+
+			const activeAccounts = accounts.filter((a) => a.status === 'active');
+			const invalidAccounts = accounts.filter((a) => a.status === 'invalid');
+
+			if (activeAccounts.length === 0) {
+				return {
+					isAuthenticated: false,
+					method: 'oauth',
+					error: `All ${invalidAccounts.length} account(s) have invalid credentials`,
+				};
+			}
+
+			return {
+				isAuthenticated: true,
+				method: 'oauth',
+				user: {
+					email: activeAccounts.map((a) => a.email).join(', '),
+				},
+			};
+		} catch (error) {
+			return {
+				isAuthenticated: false,
+				method: 'oauth',
+				error: error instanceof Error ? error.message : 'Unknown error',
+			};
+		}
+	}
+
+	/**
+	 * Start the OAuth flow for adding a new Google account.
+	 *
+	 * Returns a redirect-type flow with the auth URL the user should visit.
+	 */
+	async startOAuthFlow(): Promise<ProviderOAuthFlowData> {
+		const { authUrl, codeVerifier } = await buildAuthUrl();
+
+		// Store the code verifier temporarily for the callback
+		// In a real implementation, this would be stored in session state
+		this._pendingCodeVerifier = codeVerifier;
+
+		return {
+			type: 'redirect',
+			authUrl,
+			message:
+				'Visit the URL to authorize your Google account, then provide the authorization code.',
+		};
+	}
+
+	/**
+	 * Complete the OAuth flow by exchanging the authorization code.
+	 *
+	 * This is called separately after startOAuthFlow() once the user
+	 * provides the authorization code from the Google consent page.
+	 */
+	async completeOAuthFlow(authCode: string): Promise<{ email: string; accountId: string }> {
+		if (!this._pendingCodeVerifier) {
+			throw new Error('No pending OAuth flow. Call startOAuthFlow() first.');
+		}
+
+		const codeVerifier = this._pendingCodeVerifier;
+		this._pendingCodeVerifier = undefined;
+
+		// Exchange code for tokens
+		const tokenResponse = await exchangeAuthCode(authCode, codeVerifier, this._deps);
+
+		// Fetch user info
+		const userInfo = await fetchUserInfo(tokenResponse.access_token, this._deps);
+
+		// Create and store the account
+		const account = createAccount(
+			userInfo.email,
+			tokenResponse.refresh_token ?? '', // Should always be present with offline access
+			1500
+		);
+
+		await persistAddAccount(account);
+		await this.rotationManager.addAccount(account);
+
+		log.info(`Added Google account: ${userInfo.email}`);
+		return { email: userInfo.email, accountId: account.id };
+	}
+
+	/**
+	 * Remove a Google account.
+	 */
+	async removeAccount(accountId: string): Promise<void> {
+		await persistRemoveAccount(accountId);
+		await this.rotationManager.removeAccount(accountId);
+		log.info(`Removed Google account: ${accountId}`);
+	}
+
+	/**
+	 * Logout — removes all accounts.
+	 */
+	async logout(): Promise<void> {
+		const accounts = await loadAccounts();
+		for (const account of accounts) {
+			await persistRemoveAccount(account.id);
+		}
+		this.rotationManager = new AccountRotationManager();
+		log.info('Logged out all Google accounts');
+	}
+
+	/**
+	 * Shut down all bridge servers.
+	 */
+	async shutdown(): Promise<void> {
+		for (const [sessionId, bridge] of this.bridgeServers.entries()) {
+			log.info(`Shutting down bridge server for session ${sessionId}`);
+			bridge.stop();
+		}
+		this.bridgeServers.clear();
+	}
+
+	/**
+	 * Get the rotation manager (for testing).
+	 */
+	getRotationManager(): AccountRotationManager {
+		return this.rotationManager;
+	}
+
+	/** Pending PKCE code verifier for the in-progress OAuth flow. */
+	private _pendingCodeVerifier?: string;
+
+	/**
+	 * Set the code verifier (for testing or pre-seeded flows).
+	 */
+	setCodeVerifier(verifier: string): void {
+		this._pendingCodeVerifier = verifier;
+	}
+}

--- a/packages/daemon/src/lib/providers/gemini/index.ts
+++ b/packages/daemon/src/lib/providers/gemini/index.ts
@@ -1,0 +1,70 @@
+/**
+ * Google Gemini OAuth Provider
+ *
+ * Public API for the Gemini OAuth provider module.
+ */
+
+export { GeminiOAuthProvider } from './gemini-provider.js';
+export {
+	// OAuth client
+	getOAuthClientId,
+	getOAuthClientSecret,
+	OAUTH_SCOPES,
+	REDIRECT_URI,
+	buildAuthUrl,
+	exchangeAuthCode,
+	refreshAccessToken,
+	fetchUserInfo,
+	validateRefreshToken,
+	loadAccounts,
+	saveAccounts,
+	addAccount,
+	removeAccount,
+	updateAccount,
+	createAccount,
+	InvalidTokenError,
+	type GoogleOAuthAccount,
+	type GoogleTokenResponse,
+	type GoogleUserInfo,
+	type OAuthClientDeps,
+} from './oauth-client.js';
+export {
+	// Format converter
+	anthropicToGemini,
+	convertModelId,
+	convertMessages,
+	convertSystem,
+	convertTools,
+	convertSchema,
+	convertToolChoice,
+	convertGenerationConfig,
+	convertFinishReason,
+	createStreamState,
+	extractTextFromCandidate,
+	extractFunctionCallsFromCandidate,
+	type GeminiPart,
+	type GeminiContent,
+	type GeminiFunctionDeclaration,
+	type GeminiTool,
+	type GeminiToolConfig,
+	type GeminiGenerationConfig,
+	type GeminiRequest,
+	type GeminiCandidate,
+	type GeminiUsageMetadata,
+	type GeminiResponseChunk,
+	type GeminiStreamState,
+} from './format-converter.js';
+export {
+	// Account rotation
+	AccountRotationManager,
+	DEFAULT_ROTATION_CONFIG,
+	type RotationConfig,
+	type AccountStorage,
+	InMemoryAccountStorage,
+} from './account-rotation.js';
+export {
+	// Bridge server
+	createGeminiBridgeServer,
+	type GeminiBridgeServer,
+	type GeminiBridgeConfig,
+} from './bridge-server.js';

--- a/packages/daemon/src/lib/providers/gemini/index.ts
+++ b/packages/daemon/src/lib/providers/gemini/index.ts
@@ -12,6 +12,7 @@ export {
 	OAUTH_SCOPES,
 	REDIRECT_URI,
 	buildAuthUrl,
+	buildAuthUrlWithRedirect,
 	exchangeAuthCode,
 	refreshAccessToken,
 	fetchUserInfo,

--- a/packages/daemon/src/lib/providers/gemini/index.ts
+++ b/packages/daemon/src/lib/providers/gemini/index.ts
@@ -13,6 +13,7 @@ export {
 	REDIRECT_URI,
 	buildAuthUrl,
 	buildAuthUrlWithRedirect,
+	generateStateParameter,
 	exchangeAuthCode,
 	refreshAccessToken,
 	fetchUserInfo,

--- a/packages/daemon/src/lib/providers/gemini/oauth-client.ts
+++ b/packages/daemon/src/lib/providers/gemini/oauth-client.ts
@@ -125,6 +125,13 @@ export function generateCodeVerifier(): string {
 	return base64URLEncode(array);
 }
 
+/** Generate a random state parameter for OAuth CSRF protection. */
+export function generateStateParameter(): string {
+	const array = new Uint8Array(32);
+	crypto.getRandomValues(array);
+	return base64URLEncode(array);
+}
+
 /** Generate a code challenge from a code verifier. */
 export async function generateCodeChallenge(verifier: string): Promise<string> {
 	const encoder = new TextEncoder();
@@ -177,9 +184,10 @@ export async function buildAuthUrl(): Promise<{ authUrl: string; codeVerifier: s
  */
 export async function buildAuthUrlWithRedirect(
 	redirectUri: string
-): Promise<{ authUrl: string; codeVerifier: string }> {
+): Promise<{ authUrl: string; codeVerifier: string; state: string }> {
 	const codeVerifier = generateCodeVerifier();
 	const codeChallenge = await generateCodeChallenge(codeVerifier);
+	const stateParam = generateStateParameter();
 
 	const params = new URLSearchParams({
 		client_id: getOAuthClientId(),
@@ -190,10 +198,11 @@ export async function buildAuthUrlWithRedirect(
 		prompt: 'consent',
 		code_challenge: codeChallenge,
 		code_challenge_method: 'S256',
+		state: stateParam,
 	});
 
 	const authUrl = `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
-	return { authUrl, codeVerifier };
+	return { authUrl, codeVerifier, state: stateParam };
 }
 
 /**

--- a/packages/daemon/src/lib/providers/gemini/oauth-client.ts
+++ b/packages/daemon/src/lib/providers/gemini/oauth-client.ts
@@ -1,0 +1,387 @@
+/**
+ * Google OAuth Client for Gemini Provider
+ *
+ * Handles the OAuth flow for Google Pro subscription accounts.
+ * Extracted and adapted from the Gemini CLI's oauth2.ts (Apache 2.0).
+ *
+ * Flow:
+ * 1. User visits auth URL in browser → copies auth code → pastes into NeoKai UI
+ * 2. Auth code is exchanged for access_token + refresh_token
+ * 3. Access tokens are automatically refreshed when expired (~1 hour)
+ * 4. Refresh tokens are stored persistently for each Google account
+ */
+
+import { createLogger } from '@neokai/shared/logger';
+
+const log = createLogger('kai:providers:gemini:oauth');
+
+// ---------------------------------------------------------------------------
+// OAuth Configuration (Google's public Desktop app credentials)
+// ---------------------------------------------------------------------------
+
+/**
+ * Google OAuth client ID.
+ *
+ * Must be set via GOOGLE_GEMINI_CLIENT_ID env var. These are Google's own
+ * Desktop app OAuth credentials from the Gemini CLI (Apache 2.0).
+ * Google's documentation states that client secrets for installed/desktop
+ * apps are not treated as secrets:
+ * https://developers.google.com/identity/protocols/oauth2#installed
+ *
+ * The default values match those used by the official Gemini CLI.
+ */
+export function getOAuthClientId(): string {
+	const val = process.env.GOOGLE_GEMINI_CLIENT_ID;
+	if (!val) {
+		throw new Error(
+			'GOOGLE_GEMINI_CLIENT_ID env var is required. ' +
+				'Set it to the Google OAuth client ID (see Gemini CLI source for default).'
+		);
+	}
+	return val;
+}
+
+/**
+ * Google OAuth client secret.
+ *
+ * Must be set via GOOGLE_GEMINI_CLIENT_SECRET env var.
+ */
+export function getOAuthClientSecret(): string {
+	const val = process.env.GOOGLE_GEMINI_CLIENT_SECRET;
+	if (!val) {
+		throw new Error(
+			'GOOGLE_GEMINI_CLIENT_SECRET env var is required. ' +
+				'Set it to the Google OAuth client secret (see Gemini CLI source for default).'
+		);
+	}
+	return val;
+}
+
+/** OAuth scopes for Cloud Code authorization. */
+export const OAUTH_SCOPES = [
+	'https://www.googleapis.com/auth/cloud-platform',
+	'https://www.googleapis.com/auth/userinfo.email',
+	'https://www.googleapis.com/auth/userinfo.profile',
+];
+
+/** Redirect URI for headless/code-entry auth flow. */
+export const REDIRECT_URI = 'https://codeassist.google.com/authcode';
+
+/** Google token endpoint. */
+const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+
+/** Google userinfo endpoint. */
+const USERINFO_URL = 'https://www.googleapis.com/oauth2/v2/userinfo';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** OAuth token response from Google. */
+export interface GoogleTokenResponse {
+	access_token: string;
+	refresh_token?: string;
+	expires_in: number;
+	token_type: string;
+	scope?: string;
+}
+
+/** Google user info response. */
+export interface GoogleUserInfo {
+	email: string;
+	name?: string;
+	picture?: string;
+	sub?: string;
+}
+
+/** Stored account credentials. */
+export interface GoogleOAuthAccount {
+	id: string;
+	email: string;
+	refresh_token: string;
+	added_at: number;
+	last_used_at: number;
+	last_token_refresh_at?: number;
+	daily_request_count: number;
+	daily_limit: number;
+	status: 'active' | 'exhausted' | 'invalid';
+	/** Cooldown until timestamp (Unix ms). 0 = no cooldown. */
+	cooldown_until: number;
+}
+
+/** OAuth client dependencies — injectable for testing. */
+export interface OAuthClientDeps {
+	fetchImpl?: typeof fetch;
+}
+
+// ---------------------------------------------------------------------------
+// PKCE helpers
+// ---------------------------------------------------------------------------
+
+/** Generate a code verifier for PKCE (RFC 7636). */
+export function generateCodeVerifier(): string {
+	const array = new Uint8Array(32);
+	crypto.getRandomValues(array);
+	return base64URLEncode(array);
+}
+
+/** Generate a code challenge from a code verifier. */
+export async function generateCodeChallenge(verifier: string): Promise<string> {
+	const encoder = new TextEncoder();
+	const data = encoder.encode(verifier);
+	const hash = await crypto.subtle.digest('SHA-256', data);
+	return base64URLEncode(new Uint8Array(hash));
+}
+
+function base64URLEncode(buffer: Uint8Array): string {
+	return btoa(String.fromCharCode(...buffer))
+		.replace(/\+/g, '-')
+		.replace(/\//g, '_')
+		.replace(/=+$/, '');
+}
+
+// ---------------------------------------------------------------------------
+// OAuth client
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the Google OAuth authorization URL for headless code-entry flow.
+ *
+ * Returns the URL the user should visit in their browser, plus the
+ * code_verifier needed to complete the token exchange.
+ */
+export async function buildAuthUrl(): Promise<{ authUrl: string; codeVerifier: string }> {
+	const codeVerifier = generateCodeVerifier();
+	const codeChallenge = await generateCodeChallenge(codeVerifier);
+
+	const params = new URLSearchParams({
+		client_id: getOAuthClientId(),
+		redirect_uri: REDIRECT_URI,
+		response_type: 'code',
+		scope: OAUTH_SCOPES.join(' '),
+		access_type: 'offline',
+		prompt: 'consent',
+		code_challenge: codeChallenge,
+		code_challenge_method: 'S256',
+	});
+
+	const authUrl = `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
+	return { authUrl, codeVerifier };
+}
+
+/**
+ * Exchange an authorization code for tokens.
+ *
+ * @param code - The authorization code from the user
+ * @param codeVerifier - The PKCE code verifier from buildAuthUrl()
+ * @param deps - Injectable dependencies for testing
+ */
+export async function exchangeAuthCode(
+	code: string,
+	codeVerifier: string,
+	deps?: OAuthClientDeps
+): Promise<GoogleTokenResponse> {
+	const fetchFn = deps?.fetchImpl ?? fetch;
+
+	const response = await fetchFn(TOKEN_URL, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body: new URLSearchParams({
+			code,
+			client_id: getOAuthClientId(),
+			client_secret: getOAuthClientSecret(),
+			redirect_uri: REDIRECT_URI,
+			grant_type: 'authorization_code',
+			code_verifier: codeVerifier,
+		}).toString(),
+	});
+
+	if (!response.ok) {
+		const errorText = await response.text();
+		throw new Error(`Token exchange failed (${response.status}): ${errorText}`);
+	}
+
+	return response.json() as Promise<GoogleTokenResponse>;
+}
+
+/**
+ * Refresh an access token using a refresh token.
+ *
+ * @param refreshToken - The stored refresh token
+ * @param deps - Injectable dependencies for testing
+ */
+export async function refreshAccessToken(
+	refreshToken: string,
+	deps?: OAuthClientDeps
+): Promise<GoogleTokenResponse> {
+	const fetchFn = deps?.fetchImpl ?? fetch;
+
+	const response = await fetchFn(TOKEN_URL, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body: new URLSearchParams({
+			refresh_token: refreshToken,
+			client_id: getOAuthClientId(),
+			client_secret: getOAuthClientSecret(),
+			grant_type: 'refresh_token',
+		}).toString(),
+	});
+
+	if (!response.ok) {
+		const errorText = await response.text();
+
+		// If the refresh token is invalid/revoked, throw a specific error
+		if (response.status === 400 && errorText.includes('invalid_grant')) {
+			throw new InvalidTokenError(`Refresh token is invalid or revoked: ${errorText}`);
+		}
+
+		throw new Error(`Token refresh failed (${response.status}): ${errorText}`);
+	}
+
+	return response.json() as Promise<GoogleTokenResponse>;
+}
+
+/**
+ * Fetch user info from Google using an access token.
+ *
+ * @param accessToken - A valid Google access token
+ * @param deps - Injectable dependencies for testing
+ */
+export async function fetchUserInfo(
+	accessToken: string,
+	deps?: OAuthClientDeps
+): Promise<GoogleUserInfo> {
+	const fetchFn = deps?.fetchImpl ?? fetch;
+
+	const response = await fetchFn(USERINFO_URL, {
+		headers: { Authorization: `Bearer ${accessToken}` },
+	});
+
+	if (!response.ok) {
+		throw new Error(`Failed to fetch user info (${response.status})`);
+	}
+
+	return response.json() as Promise<GoogleUserInfo>;
+}
+
+/**
+ * Check if a refresh token is still valid by attempting a token refresh.
+ *
+ * @param refreshToken - The refresh token to validate
+ * @param deps - Injectable dependencies for testing
+ * @returns true if valid, false if invalid/revoked
+ */
+export async function validateRefreshToken(
+	refreshToken: string,
+	deps?: OAuthClientDeps
+): Promise<boolean> {
+	try {
+		await refreshAccessToken(refreshToken, deps);
+		return true;
+	} catch (error) {
+		if (error instanceof InvalidTokenError) {
+			log.warn(`Refresh token is invalid: ${error.message}`);
+			return false;
+		}
+		// Network errors etc — don't mark as invalid, just unreachable
+		log.warn(`Could not validate refresh token: ${error}`);
+		return true; // Assume valid if we can't reach Google
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+/** Thrown when a refresh token is invalid or has been revoked. */
+export class InvalidTokenError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'InvalidTokenError';
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Credential file storage
+// ---------------------------------------------------------------------------
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+
+/** Get the path to the Gemini OAuth accounts storage file. */
+export function getAccountsFilePath(): string {
+	return path.join(os.homedir(), '.neokai', 'gemini-oauth-accounts.json');
+}
+
+/** Load all stored Google OAuth accounts. */
+export async function loadAccounts(): Promise<GoogleOAuthAccount[]> {
+	try {
+		const filePath = getAccountsFilePath();
+		const data = await fs.readFile(filePath, 'utf-8');
+		return JSON.parse(data) as GoogleOAuthAccount[];
+	} catch {
+		return [];
+	}
+}
+
+/** Save all Google OAuth accounts. */
+export async function saveAccounts(accounts: GoogleOAuthAccount[]): Promise<void> {
+	const filePath = getAccountsFilePath();
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(filePath, JSON.stringify(accounts, null, 2), { mode: 0o600 });
+}
+
+/** Add a new Google OAuth account and persist. */
+export async function addAccount(account: GoogleOAuthAccount): Promise<void> {
+	const accounts = await loadAccounts();
+	// Check for duplicate email
+	if (accounts.some((a) => a.email === account.email)) {
+		throw new Error(`Account ${account.email} already exists`);
+	}
+	accounts.push(account);
+	await saveAccounts(accounts);
+}
+
+/** Remove a Google OAuth account by ID and persist. */
+export async function removeAccount(accountId: string): Promise<void> {
+	const accounts = await loadAccounts();
+	const filtered = accounts.filter((a) => a.id !== accountId);
+	if (filtered.length === accounts.length) {
+		throw new Error(`Account ${accountId} not found`);
+	}
+	await saveAccounts(filtered);
+}
+
+/** Update a Google OAuth account and persist. */
+export async function updateAccount(
+	accountId: string,
+	updates: Partial<GoogleOAuthAccount>
+): Promise<void> {
+	const accounts = await loadAccounts();
+	const index = accounts.findIndex((a) => a.id === accountId);
+	if (index === -1) {
+		throw new Error(`Account ${accountId} not found`);
+	}
+	accounts[index] = { ...accounts[index], ...updates };
+	await saveAccounts(accounts);
+}
+
+/** Create a new GoogleOAuthAccount with defaults. */
+export function createAccount(
+	email: string,
+	refreshToken: string,
+	dailyLimit: number = 1500
+): GoogleOAuthAccount {
+	return {
+		id: crypto.randomUUID(),
+		email,
+		refresh_token: refreshToken,
+		added_at: Date.now(),
+		last_used_at: 0,
+		daily_request_count: 0,
+		daily_limit: dailyLimit,
+		status: 'active',
+		cooldown_until: 0,
+	};
+}

--- a/packages/daemon/src/lib/providers/gemini/oauth-client.ts
+++ b/packages/daemon/src/lib/providers/gemini/oauth-client.ts
@@ -64,7 +64,7 @@ export const OAUTH_SCOPES = [
 	'https://www.googleapis.com/auth/userinfo.profile',
 ];
 
-/** Redirect URI for headless/code-entry auth flow. */
+/** Redirect URI for headless/code-entry auth flow (fallback). */
 export const REDIRECT_URI = 'https://codeassist.google.com/authcode';
 
 /** Google token endpoint. */
@@ -170,6 +170,33 @@ export async function buildAuthUrl(): Promise<{ authUrl: string; codeVerifier: s
 }
 
 /**
+ * Build the Google OAuth authorization URL with a custom redirect URI.
+ *
+ * Used by the local callback server flow where the redirect URI is
+ * `http://localhost:{port}/callback`.
+ */
+export async function buildAuthUrlWithRedirect(
+	redirectUri: string
+): Promise<{ authUrl: string; codeVerifier: string }> {
+	const codeVerifier = generateCodeVerifier();
+	const codeChallenge = await generateCodeChallenge(codeVerifier);
+
+	const params = new URLSearchParams({
+		client_id: getOAuthClientId(),
+		redirect_uri: redirectUri,
+		response_type: 'code',
+		scope: OAUTH_SCOPES.join(' '),
+		access_type: 'offline',
+		prompt: 'consent',
+		code_challenge: codeChallenge,
+		code_challenge_method: 'S256',
+	});
+
+	const authUrl = `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
+	return { authUrl, codeVerifier };
+}
+
+/**
  * Exchange an authorization code for tokens.
  *
  * @param code - The authorization code from the user
@@ -179,7 +206,8 @@ export async function buildAuthUrl(): Promise<{ authUrl: string; codeVerifier: s
 export async function exchangeAuthCode(
 	code: string,
 	codeVerifier: string,
-	deps?: OAuthClientDeps
+	deps?: OAuthClientDeps,
+	redirectUri: string = REDIRECT_URI
 ): Promise<GoogleTokenResponse> {
 	const fetchFn = deps?.fetchImpl ?? fetch;
 
@@ -190,7 +218,7 @@ export async function exchangeAuthCode(
 			code,
 			client_id: getOAuthClientId(),
 			client_secret: getOAuthClientSecret(),
-			redirect_uri: REDIRECT_URI,
+			redirect_uri: redirectUri,
 			grant_type: 'authorization_code',
 			code_verifier: codeVerifier,
 		}).toString(),

--- a/packages/daemon/src/lib/providers/registry.ts
+++ b/packages/daemon/src/lib/providers/registry.ts
@@ -275,5 +275,6 @@ export function inferProviderForModel(modelId: string): ProviderIdStr {
 	if (modelId === 'openrouter/auto' || (modelId.includes('/') && !modelId.startsWith('claude-')))
 		return 'openrouter';
 	if (modelId.startsWith('gpt-')) return 'anthropic-codex';
+	if (modelId.startsWith('gemini-')) return 'google-gemini-oauth';
 	return 'anthropic';
 }

--- a/packages/daemon/src/lib/providers/registry.ts
+++ b/packages/daemon/src/lib/providers/registry.ts
@@ -275,6 +275,6 @@ export function inferProviderForModel(modelId: string): ProviderIdStr {
 	if (modelId === 'openrouter/auto' || (modelId.includes('/') && !modelId.startsWith('claude-')))
 		return 'openrouter';
 	if (modelId.startsWith('gpt-')) return 'anthropic-codex';
-	if (modelId.startsWith('gemini-')) return 'google-gemini-oauth';
+	if (modelId.startsWith('gemini-2.')) return 'google-gemini-oauth';
 	return 'anthropic';
 }

--- a/packages/daemon/tests/unit/1-core/providers/gemini-account-rotation.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/gemini-account-rotation.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Tests for Account Rotation System
+ *
+ * Tests session affinity, failover on 429, exhaustion detection, and cooldown.
+ */
+
+import { describe, expect, it, beforeEach } from 'bun:test';
+import {
+	AccountRotationManager,
+	InMemoryAccountStorage,
+	type RotationConfig,
+} from '../../../../src/lib/providers/gemini/account-rotation.js';
+import type { GoogleOAuthAccount } from '../../../../src/lib/providers/gemini/oauth-client.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function createTestAccount(overrides: Partial<GoogleOAuthAccount> = {}): GoogleOAuthAccount {
+	return {
+		id: `acc-${Math.random().toString(36).slice(2, 8)}`,
+		email: `test-${Math.random().toString(36).slice(2, 8)}@gmail.com`,
+		refresh_token: '1//test-refresh-token',
+		added_at: Date.now() - 86400000,
+		last_used_at: 0,
+		daily_request_count: 0,
+		daily_limit: 1500,
+		status: 'active',
+		cooldown_until: 0,
+		...overrides,
+	};
+}
+
+function createManager(config?: Partial<RotationConfig>): AccountRotationManager {
+	const storage = new InMemoryAccountStorage();
+	return new AccountRotationManager({ healthCheckOnStartup: false, ...config }, storage);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Account Rotation System', () => {
+	describe('session affinity', () => {
+		it('assigns the same account to a session across multiple calls', async () => {
+			const manager = createManager();
+
+			// Pre-populate accounts
+			const acc1 = createTestAccount({ email: 'acc1@gmail.com' });
+			const acc2 = createTestAccount({ email: 'acc2@gmail.com' });
+			await manager.initialize();
+			await manager.addAccount(acc1);
+			await manager.addAccount(acc2);
+
+			const session1 = 'session-1';
+
+			// First call assigns an account
+			const assigned1 = await manager.getAccountForSession(session1);
+			expect(assigned1).toBeDefined();
+
+			// Second call should return the same account
+			const assigned2 = await manager.getAccountForSession(session1);
+			expect(assigned2!.id).toBe(assigned1!.id);
+		});
+
+		it('different sessions can get different accounts', async () => {
+			const manager = createManager();
+
+			const acc1 = createTestAccount({ email: 'acc1@gmail.com' });
+			const acc2 = createTestAccount({ email: 'acc2@gmail.com' });
+			await manager.initialize();
+			await manager.addAccount(acc1);
+			await manager.addAccount(acc2);
+
+			const s1 = await manager.getAccountForSession('session-1');
+			const s2 = await manager.getAccountForSession('session-2');
+
+			// Both should be assigned
+			expect(s1).toBeDefined();
+			expect(s2).toBeDefined();
+		});
+
+		it('releases session affinity on releaseSession', async () => {
+			const manager = createManager();
+
+			const acc = createTestAccount();
+			await manager.initialize();
+			await manager.addAccount(acc);
+
+			const session = 'session-1';
+			const assigned = await manager.getAccountForSession(session);
+			expect(assigned).toBeDefined();
+
+			// Check session map
+			const map = manager.getSessionMap();
+			expect(map.get(session)).toBe(assigned!.id);
+
+			// Release
+			manager.releaseSession(session);
+			const mapAfter = manager.getSessionMap();
+			expect(mapAfter.has(session)).toBe(false);
+		});
+	});
+
+	describe('failover on 429', () => {
+		it('marks account as exhausted and removes session affinity', async () => {
+			const manager = createManager({ rateLimitCooldownMs: 5000 });
+
+			const acc1 = createTestAccount({ email: 'acc1@gmail.com' });
+			await manager.initialize();
+			await manager.addAccount(acc1);
+
+			const session = 'session-1';
+			const assigned = await manager.getAccountForSession(session);
+			expect(assigned!.id).toBe(acc1.id);
+
+			// Simulate 429
+			await manager.handleRateLimit(acc1.id);
+
+			// Account should be exhausted
+			const accounts = manager.getAccounts();
+			expect(accounts.find((a) => a.id === acc1.id)!.status).toBe('exhausted');
+
+			// Session affinity should be removed
+			const map = manager.getSessionMap();
+			expect(map.has(session)).toBe(false);
+		});
+
+		it('fails over to another account on 429', async () => {
+			const manager = createManager({ rateLimitCooldownMs: 60000 });
+
+			const acc1 = createTestAccount({ email: 'acc1@gmail.com' });
+			const acc2 = createTestAccount({ email: 'acc2@gmail.com' });
+			await manager.initialize();
+			await manager.addAccount(acc1);
+			await manager.addAccount(acc2);
+
+			const session = 'session-1';
+
+			// Assign to first account
+			const first = await manager.getAccountForSession(session);
+			expect(first).toBeDefined();
+
+			// Rate limit it
+			await manager.handleRateLimit(first!.id);
+
+			// Should get a different account now
+			const second = await manager.getAccountForSession(session);
+			expect(second).toBeDefined();
+			expect(second!.id).not.toBe(first!.id);
+		});
+	});
+
+	describe('exhaustion detection', () => {
+		it('marks account as exhausted when approaching daily limit', async () => {
+			const manager = createManager({ exhaustionThreshold: 0.9 });
+
+			const acc = createTestAccount({ daily_limit: 1500 });
+			await manager.initialize();
+			await manager.addAccount(acc);
+
+			// Record requests up to threshold
+			for (let i = 0; i < 1350; i++) {
+				await manager.recordRequest(acc.id);
+			}
+
+			// Account should be exhausted
+			const accounts = manager.getAccounts();
+			expect(accounts.find((a) => a.id === acc.id)!.status).toBe('exhausted');
+		});
+
+		it('does not assign exhausted accounts to new sessions', async () => {
+			const manager = createManager();
+
+			const acc = createTestAccount({ status: 'exhausted' });
+			await manager.initialize();
+			await manager.addAccount(acc);
+
+			const result = await manager.getAccountForSession('session-1');
+			expect(result).toBeUndefined();
+		});
+
+		it('does not assign invalid accounts to new sessions', async () => {
+			const manager = createManager();
+
+			const acc = createTestAccount({ status: 'invalid' });
+			await manager.initialize();
+			await manager.addAccount(acc);
+
+			const result = await manager.getAccountForSession('session-1');
+			expect(result).toBeUndefined();
+		});
+	});
+
+	describe('cooldown recovery', () => {
+		it('recovers accounts after cooldown period', async () => {
+			const manager = createManager({ rateLimitCooldownMs: 1 });
+
+			const acc = createTestAccount();
+			await manager.initialize();
+			await manager.addAccount(acc);
+
+			// Rate limit the account
+			await manager.handleRateLimit(acc.id);
+
+			// Should not be available immediately
+			const accounts = manager.getAccounts();
+			const exhausted = accounts.find((a) => a.id === acc.id)!;
+			expect(exhausted.status).toBe('exhausted');
+			expect(exhausted.cooldown_until).toBeGreaterThan(0);
+
+			// Wait for cooldown
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			// Should be available now
+			const result = await manager.getAccountForSession('new-session');
+			expect(result).toBeDefined();
+			expect(result!.id).toBe(acc.id);
+		});
+	});
+
+	describe('getActiveAccountCount', () => {
+		it('returns count of active, non-cooled-down accounts', async () => {
+			const manager = createManager();
+
+			const acc1 = createTestAccount({ status: 'active' });
+			const acc2 = createTestAccount({ status: 'active' });
+			const acc3 = createTestAccount({ status: 'invalid' });
+			const acc4 = createTestAccount({
+				status: 'exhausted',
+				cooldown_until: Date.now() + 60000,
+			});
+
+			await manager.initialize();
+			await manager.addAccount(acc1);
+			await manager.addAccount(acc2);
+			await manager.addAccount(acc3);
+			await manager.addAccount(acc4);
+
+			expect(manager.getActiveAccountCount()).toBe(2);
+		});
+	});
+
+	describe('markInvalid', () => {
+		it('marks an account as invalid and removes session affinity', async () => {
+			const manager = createManager();
+
+			const acc = createTestAccount();
+			await manager.initialize();
+			await manager.addAccount(acc);
+
+			// Assign to session
+			await manager.getAccountForSession('session-1');
+			expect(manager.getSessionMap().get('session-1')).toBe(acc.id);
+
+			// Mark invalid
+			await manager.markInvalid(acc.id);
+
+			// Should be invalid
+			const accounts = manager.getAccounts();
+			expect(accounts.find((a) => a.id === acc.id)!.status).toBe('invalid');
+
+			// Session affinity should be removed
+			expect(manager.getSessionMap().has('session-1')).toBe(false);
+		});
+	});
+
+	describe('removeAccount', () => {
+		it('removes an account from the pool', async () => {
+			const manager = createManager();
+
+			const acc1 = createTestAccount({ email: 'acc1@gmail.com' });
+			const acc2 = createTestAccount({ email: 'acc2@gmail.com' });
+			await manager.initialize();
+			await manager.addAccount(acc1);
+			await manager.addAccount(acc2);
+
+			expect(manager.getAccounts()).toHaveLength(2);
+
+			await manager.removeAccount(acc1.id);
+
+			expect(manager.getAccounts()).toHaveLength(1);
+			expect(manager.getAccounts()[0].id).toBe(acc2.id);
+		});
+	});
+
+	describe('daily counter reset', () => {
+		it('resets counters for stale accounts on initialize', async () => {
+			const storage = new InMemoryAccountStorage();
+
+			// Create an account that was used yesterday
+			const yesterday = Date.now() - 86400000 * 2;
+			const acc = createTestAccount({
+				daily_request_count: 1000,
+				status: 'exhausted',
+				last_used_at: yesterday,
+			});
+
+			// Pre-load the storage with the stale account
+			await storage.save([acc]);
+
+			const manager = new AccountRotationManager({ healthCheckOnStartup: false }, storage);
+
+			await manager.initialize();
+
+			// After initialize, the counter should be reset
+			const accounts = manager.getAccounts();
+			const found = accounts.find((a) => a.id === acc.id)!;
+			expect(found).toBeDefined();
+			expect(found.daily_request_count).toBe(0);
+			expect(found.status).toBe('active');
+			expect(found.cooldown_until).toBe(0);
+		});
+	});
+
+	describe('LRU selection', () => {
+		it('picks least-recently-used account', async () => {
+			const manager = createManager();
+
+			const old = createTestAccount({
+				email: 'old@gmail.com',
+				last_used_at: 1000,
+			});
+			const recent = createTestAccount({
+				email: 'recent@gmail.com',
+				last_used_at: Date.now(),
+			});
+
+			await manager.initialize();
+			await manager.addAccount(old);
+			await manager.addAccount(recent);
+
+			// Should pick the least recently used (oldest)
+			const picked = await manager.getAccountForSession('session-1');
+			expect(picked!.id).toBe(old.id);
+		});
+	});
+});

--- a/packages/daemon/tests/unit/1-core/providers/gemini-format-converter.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/gemini-format-converter.test.ts
@@ -164,6 +164,63 @@ describe('Gemini Format Converter', () => {
 				result: 'Line 1Line 2',
 			});
 		});
+
+		it('maps tool_result to the original function name from prior tool_use block', () => {
+			const messages = [
+				{
+					role: 'assistant' as const,
+					content: [
+						{
+							type: 'tool_use' as const,
+							id: 'toolu_abc123',
+							name: 'read_file',
+							input: { path: '/src/index.ts' },
+						},
+					],
+				},
+				{
+					role: 'user' as const,
+					content: [
+						{
+							type: 'tool_result' as const,
+							tool_use_id: 'toolu_abc123',
+							content: 'export const hello = "world";',
+						},
+					],
+				},
+			];
+
+			const contents = convertMessages(messages);
+
+			// The functionResponse should use "read_file", not a fabricated name
+			expect(contents).toHaveLength(2);
+			const functionResponse = contents[1].parts[0].functionResponse;
+			expect(functionResponse).toBeDefined();
+			expect(functionResponse!.name).toBe('read_file');
+			expect(functionResponse!.response).toEqual({
+				result: 'export const hello = "world";',
+			});
+		});
+
+		it('falls back to extracted name when tool_use_id has no matching tool_use block', () => {
+			const messages = [
+				{
+					role: 'user' as const,
+					content: [
+						{
+							type: 'tool_result' as const,
+							tool_use_id: 'orphan_id_999',
+							content: 'orphaned result',
+						},
+					],
+				},
+			];
+
+			const contents = convertMessages(messages);
+
+			// Should use extractToolNameFromId fallback
+			expect(contents[0].parts[0].functionResponse!.name).toBe('tool_orphan_i');
+		});
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/1-core/providers/gemini-format-converter.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/gemini-format-converter.test.ts
@@ -1,0 +1,503 @@
+/**
+ * Tests for Gemini Format Converter
+ *
+ * Tests the Anthropic Messages API ↔ Gemini Code Assist format translation.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+	anthropicToGemini,
+	convertModelId,
+	convertMessages,
+	convertSystem,
+	convertTools,
+	convertSchema,
+	convertToolChoice,
+	convertFinishReason,
+	createStreamState,
+	extractTextFromCandidate,
+	extractFunctionCallsFromCandidate,
+	type GeminiContent,
+	type GeminiCandidate,
+} from '../../../../src/lib/providers/gemini/format-converter.js';
+import type {
+	AnthropicRequest,
+	AnthropicTool,
+} from '../../../../src/lib/providers/codex-anthropic-bridge/translator.js';
+
+describe('Gemini Format Converter', () => {
+	// -------------------------------------------------------------------------
+	// convertModelId
+	// -------------------------------------------------------------------------
+
+	describe('convertModelId', () => {
+		it('passes through Gemini model IDs unchanged', () => {
+			expect(convertModelId('gemini-2.5-pro')).toBe('gemini-2.5-pro');
+			expect(convertModelId('gemini-2.5-flash')).toBe('gemini-2.5-flash');
+		});
+
+		it('maps Anthropic model IDs to Gemini equivalents', () => {
+			expect(convertModelId('sonnet')).toBe('gemini-2.5-pro');
+			expect(convertModelId('opus')).toBe('gemini-2.5-pro');
+			expect(convertModelId('haiku')).toBe('gemini-2.5-flash');
+			expect(convertModelId('default')).toBe('gemini-2.5-pro');
+		});
+
+		it('defaults unknown models to gemini-2.5-pro', () => {
+			expect(convertModelId('unknown-model')).toBe('gemini-2.5-pro');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// convertMessages
+	// -------------------------------------------------------------------------
+
+	describe('convertMessages', () => {
+		it('converts simple text messages', () => {
+			const messages = [
+				{ role: 'user' as const, content: 'Hello' },
+				{ role: 'assistant' as const, content: 'Hi there' },
+			];
+
+			const contents = convertMessages(messages);
+
+			expect(contents).toHaveLength(2);
+			expect(contents[0]).toEqual({
+				role: 'user',
+				parts: [{ text: 'Hello' }],
+			});
+			expect(contents[1]).toEqual({
+				role: 'model', // assistant → model
+				parts: [{ text: 'Hi there' }],
+			});
+		});
+
+		it('converts content block messages', () => {
+			const messages = [
+				{
+					role: 'user' as const,
+					content: [{ type: 'text' as const, text: 'Hello from blocks' }],
+				},
+			];
+
+			const contents = convertMessages(messages);
+
+			expect(contents).toHaveLength(1);
+			expect(contents[0]).toEqual({
+				role: 'user',
+				parts: [{ text: 'Hello from blocks' }],
+			});
+		});
+
+		it('converts tool_use blocks to functionCall parts', () => {
+			const messages = [
+				{
+					role: 'assistant' as const,
+					content: [
+						{ type: 'text' as const, text: 'Let me check that.' },
+						{
+							type: 'tool_use' as const,
+							id: 'toolu_123',
+							name: 'get_weather',
+							input: { city: 'SF' },
+						},
+					],
+				},
+			];
+
+			const contents = convertMessages(messages);
+
+			expect(contents).toHaveLength(1);
+			expect(contents[0].role).toBe('model');
+			expect(contents[0].parts).toHaveLength(2);
+			expect(contents[0].parts[0]).toEqual({ text: 'Let me check that.' });
+			expect(contents[0].parts[1]).toEqual({
+				functionCall: { name: 'get_weather', args: { city: 'SF' } },
+			});
+		});
+
+		it('converts tool_result blocks to functionResponse parts in user turn', () => {
+			const messages = [
+				{
+					role: 'user' as const,
+					content: [
+						{
+							type: 'tool_result' as const,
+							tool_use_id: 'toolu_123',
+							content: '72°F, sunny',
+						},
+					],
+				},
+			];
+
+			const contents = convertMessages(messages);
+
+			// Tool results should be in a user-turn with functionResponse
+			expect(contents).toHaveLength(1);
+			expect(contents[0].role).toBe('user');
+			expect(contents[0].parts[0].functionResponse).toBeDefined();
+			expect(contents[0].parts[0].functionResponse!.response).toEqual({
+				result: '72°F, sunny',
+			});
+		});
+
+		it('converts tool_result with content blocks', () => {
+			const messages = [
+				{
+					role: 'user' as const,
+					content: [
+						{
+							type: 'tool_result' as const,
+							tool_use_id: 'toolu_456',
+							content: [
+								{ type: 'text' as const, text: 'Line 1' },
+								{ type: 'text' as const, text: 'Line 2' },
+							],
+						},
+					],
+				},
+			];
+
+			const contents = convertMessages(messages);
+
+			expect(contents[0].parts[0].functionResponse!.response).toEqual({
+				result: 'Line 1Line 2',
+			});
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// convertSystem
+	// -------------------------------------------------------------------------
+
+	describe('convertSystem', () => {
+		it('converts string system prompt', () => {
+			const result = convertSystem('You are a helpful assistant.');
+			expect(result).toEqual({
+				parts: [{ text: 'You are a helpful assistant.' }],
+			});
+		});
+
+		it('converts array system prompt', () => {
+			const result = convertSystem([
+				{ type: 'text', text: 'Part 1.' },
+				{ type: 'text', text: 'Part 2.' },
+			]);
+			expect(result).toEqual({
+				parts: [{ text: 'Part 1.\nPart 2.' }],
+			});
+		});
+
+		it('returns undefined for empty system prompt', () => {
+			expect(convertSystem(undefined)).toBeUndefined();
+			expect(convertSystem('')).toBeUndefined();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// convertTools
+	// -------------------------------------------------------------------------
+
+	describe('convertTools', () => {
+		it('converts Anthropic tools to Gemini function declarations', () => {
+			const tools: AnthropicTool[] = [
+				{
+					name: 'get_weather',
+					description: 'Get the weather for a city',
+					input_schema: {
+						type: 'object',
+						properties: {
+							city: { type: 'string', description: 'City name' },
+						},
+						required: ['city'],
+					},
+				},
+			];
+
+			const result = convertTools(tools);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].functionDeclarations).toHaveLength(1);
+			expect(result[0].functionDeclarations![0]).toEqual({
+				name: 'get_weather',
+				description: 'Get the weather for a city',
+				parameters: {
+					type: 'object',
+					properties: {
+						city: { type: 'string', description: 'City name' },
+					},
+					required: ['city'],
+				},
+			});
+		});
+
+		it('returns empty array for no tools', () => {
+			expect(convertTools(undefined)).toEqual([]);
+			expect(convertTools([])).toEqual([]);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// convertSchema
+	// -------------------------------------------------------------------------
+
+	describe('convertSchema', () => {
+		it('removes additionalProperties', () => {
+			const schema = {
+				type: 'object',
+				properties: { name: { type: 'string' } },
+				additionalProperties: false,
+			};
+
+			const result = convertSchema(schema);
+			expect(result.additionalProperties).toBeUndefined();
+		});
+
+		it('converts oneOf to anyOf', () => {
+			const schema = {
+				oneOf: [{ type: 'string' }, { type: 'number' }],
+			};
+
+			const result = convertSchema(schema);
+			expect(result.oneOf).toBeUndefined();
+			expect(result.anyOf).toEqual([{ type: 'string' }, { type: 'number' }]);
+		});
+
+		it('recursively converts nested properties', () => {
+			const schema = {
+				type: 'object',
+				properties: {
+					nested: {
+						type: 'object',
+						properties: {
+							inner: { type: 'string', additionalProperties: true },
+						},
+					},
+				},
+			};
+
+			const result = convertSchema(schema);
+			const nestedProps = result.properties!.nested as Record<string, unknown>;
+			const innerProps = (nestedProps.properties as Record<string, Record<string, unknown>>).inner;
+			expect(innerProps.additionalProperties).toBeUndefined();
+		});
+
+		it('recursively converts array items', () => {
+			const schema = {
+				type: 'array',
+				items: {
+					type: 'object',
+					properties: { name: { type: 'string' } },
+					additionalProperties: false,
+				},
+			};
+
+			const result = convertSchema(schema);
+			const items = result.items as Record<string, unknown>;
+			expect(items.additionalProperties).toBeUndefined();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// convertToolChoice
+	// -------------------------------------------------------------------------
+
+	describe('convertToolChoice', () => {
+		it('converts auto mode', () => {
+			const result = convertToolChoice({ type: 'auto' });
+			expect(result).toEqual({
+				functionCallingConfig: { mode: 'AUTO' },
+			});
+		});
+
+		it('converts none mode', () => {
+			const result = convertToolChoice({ type: 'none' });
+			expect(result).toEqual({
+				functionCallingConfig: { mode: 'NONE' },
+			});
+		});
+
+		it('converts any mode', () => {
+			const result = convertToolChoice({ type: 'any' });
+			expect(result).toEqual({
+				functionCallingConfig: { mode: 'ANY' },
+			});
+		});
+
+		it('converts tool mode with name', () => {
+			const result = convertToolChoice({ type: 'tool', name: 'get_weather' });
+			expect(result).toEqual({
+				functionCallingConfig: {
+					mode: 'ANY',
+					allowedFunctionNames: ['get_weather'],
+				},
+			});
+		});
+
+		it('returns undefined for no tool choice', () => {
+			expect(convertToolChoice(undefined)).toBeUndefined();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// convertFinishReason
+	// -------------------------------------------------------------------------
+
+	describe('convertFinishReason', () => {
+		it('converts Gemini finish reasons to Anthropic stop reasons', () => {
+			expect(convertFinishReason('STOP')).toBe('end_turn');
+			expect(convertFinishReason('MAX_TOKENS')).toBe('max_tokens');
+			expect(convertFinishReason('SAFETY')).toBe('max_tokens');
+			expect(convertFinishReason('RECITATION')).toBe('end_turn');
+			expect(convertFinishReason(undefined)).toBe('end_turn');
+			expect(convertFinishReason('UNKNOWN')).toBe('end_turn');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// createStreamState
+	// -------------------------------------------------------------------------
+
+	describe('createStreamState', () => {
+		it('initializes stream state with defaults', () => {
+			const state = createStreamState('gemini-2.5-pro');
+
+			expect(state.model).toBe('gemini-2.5-pro');
+			expect(state.messageId).toMatch(/^msg_/);
+			expect(state.contentBlockIndex).toBe(0);
+			expect(state.currentToolUseId).toBeNull();
+			expect(state.inputTokens).toBe(0);
+			expect(state.outputTokens).toBe(0);
+			expect(state.finished).toBe(false);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// extractTextFromCandidate
+	// -------------------------------------------------------------------------
+
+	describe('extractTextFromCandidate', () => {
+		it('extracts text from a Gemini candidate', () => {
+			const candidate: GeminiCandidate = {
+				content: {
+					role: 'model',
+					parts: [{ text: 'Hello' }, { text: ' World' }],
+				},
+			};
+
+			expect(extractTextFromCandidate(candidate)).toBe('Hello World');
+		});
+
+		it('returns empty string for candidate with no text parts', () => {
+			const candidate: GeminiCandidate = {
+				content: {
+					role: 'model',
+					parts: [{ functionCall: { name: 'test', args: {} } }],
+				},
+			};
+
+			expect(extractTextFromCandidate(candidate)).toBe('');
+		});
+
+		it('returns empty string for candidate with no content', () => {
+			expect(extractTextFromCandidate({})).toBe('');
+			expect(extractTextFromCandidate({ content: undefined })).toBe('');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// extractFunctionCallsFromCandidate
+	// -------------------------------------------------------------------------
+
+	describe('extractFunctionCallsFromCandidate', () => {
+		it('extracts function calls from a Gemini candidate', () => {
+			const candidate: GeminiCandidate = {
+				content: {
+					role: 'model',
+					parts: [
+						{ functionCall: { name: 'get_weather', args: { city: 'SF' } } },
+						{ functionCall: { name: 'get_time', args: { tz: 'PST' } } },
+					],
+				},
+			};
+
+			const calls = extractFunctionCallsFromCandidate(candidate);
+			expect(calls).toHaveLength(2);
+			expect(calls[0]).toEqual({ name: 'get_weather', args: { city: 'SF' } });
+			expect(calls[1]).toEqual({ name: 'get_time', args: { tz: 'PST' } });
+		});
+
+		it('returns empty array for candidate with no function calls', () => {
+			const candidate: GeminiCandidate = {
+				content: {
+					role: 'model',
+					parts: [{ text: 'Hello' }],
+				},
+			};
+
+			expect(extractFunctionCallsFromCandidate(candidate)).toEqual([]);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// anthropicToGemini (full request conversion)
+	// -------------------------------------------------------------------------
+
+	describe('anthropicToGemini', () => {
+		it('converts a complete Anthropic request', () => {
+			const request: AnthropicRequest = {
+				model: 'gemini-2.5-pro',
+				messages: [{ role: 'user', content: 'What is the weather?' }],
+				system: 'You are a helpful weather assistant.',
+				tools: [
+					{
+						name: 'get_weather',
+						description: 'Get weather',
+						input_schema: { type: 'object', properties: { city: { type: 'string' } } },
+					},
+				],
+				max_tokens: 4096,
+				stream: true,
+			};
+
+			const result = anthropicToGemini(request);
+
+			expect(result.model).toBe('gemini-2.5-pro');
+			expect(result.request.contents).toHaveLength(1);
+			expect(result.request.systemInstruction).toEqual({
+				parts: [{ text: 'You are a helpful weather assistant.' }],
+			});
+			expect(result.request.tools).toHaveLength(1);
+			expect(result.request.generationConfig?.maxOutputTokens).toBe(4096);
+		});
+
+		it('converts a minimal request', () => {
+			const request: AnthropicRequest = {
+				model: 'haiku',
+				messages: [{ role: 'user', content: 'Hi' }],
+			};
+
+			const result = anthropicToGemini(request);
+
+			expect(result.model).toBe('gemini-2.5-flash');
+			expect(result.request.contents).toHaveLength(1);
+			expect(result.request.systemInstruction).toBeUndefined();
+			expect(result.request.tools).toBeUndefined();
+			expect(result.request.generationConfig).toBeUndefined();
+		});
+
+		it('includes project and session options', () => {
+			const request: AnthropicRequest = {
+				model: 'gemini-2.5-pro',
+				messages: [{ role: 'user', content: 'Hi' }],
+			};
+
+			const result = anthropicToGemini(request, {
+				project: 'my-project',
+				sessionId: 'sess-123',
+			});
+
+			expect(result.project).toBe('my-project');
+		});
+	});
+});

--- a/packages/daemon/tests/unit/1-core/providers/gemini-oauth-client.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/gemini-oauth-client.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for Google Gemini OAuth Client
+ */
+
+import { describe, expect, it, mock, beforeEach, afterEach } from 'bun:test';
+import {
+	buildAuthUrl,
+	exchangeAuthCode,
+	refreshAccessToken,
+	fetchUserInfo,
+	validateRefreshToken,
+	createAccount,
+	type GoogleTokenResponse,
+	type GoogleUserInfo,
+	type OAuthClientDeps,
+	InvalidTokenError,
+} from '../../../../src/lib/providers/gemini/oauth-client.js';
+
+// ---------------------------------------------------------------------------
+// Mock fetch for testing
+// ---------------------------------------------------------------------------
+
+function createMockFetch(responses: Array<{ status: number; body: string }>): typeof fetch {
+	let callIndex = 0;
+	return mock(async (url: string | URL | Request, _init?: RequestInit) => {
+		const response = responses[callIndex] ?? responses[responses.length - 1];
+		callIndex++;
+		return new Response(response.body, { status: response.status });
+	}) as unknown as typeof fetch;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Google Gemini OAuth Client', () => {
+	describe('buildAuthUrl', () => {
+		it('returns an auth URL with the correct parameters', async () => {
+			const { authUrl, codeVerifier } = await buildAuthUrl();
+
+			expect(authUrl).toContain('accounts.google.com/o/oauth2/v2/auth');
+			expect(authUrl).toContain('client_id=');
+			expect(authUrl).toContain('redirect_uri=');
+			expect(authUrl).toContain('code_challenge=');
+			expect(authUrl).toContain('code_challenge_method=S256');
+			expect(authUrl).toContain('access_type=offline');
+			expect(codeVerifier).toBeTruthy();
+			expect(codeVerifier.length).toBeGreaterThan(20);
+		});
+
+		it('generates different code verifiers on each call', async () => {
+			const { codeVerifier: v1 } = await buildAuthUrl();
+			const { codeVerifier: v2 } = await buildAuthUrl();
+			expect(v1).not.toBe(v2);
+		});
+	});
+
+	describe('exchangeAuthCode', () => {
+		it('exchanges an auth code for tokens', async () => {
+			const mockResponse: GoogleTokenResponse = {
+				access_token: 'ya29.test-access-token',
+				refresh_token: '1//test-refresh-token',
+				expires_in: 3600,
+				token_type: 'Bearer',
+			};
+
+			const fetchMock = createMockFetch([{ status: 200, body: JSON.stringify(mockResponse) }]);
+
+			const result = await exchangeAuthCode('test-auth-code', 'test-verifier', {
+				fetchImpl: fetchMock,
+			});
+
+			expect(result.access_token).toBe('ya29.test-access-token');
+			expect(result.refresh_token).toBe('1//test-refresh-token');
+			expect(result.expires_in).toBe(3600);
+		});
+
+		it('throws on error response', async () => {
+			const fetchMock = createMockFetch([{ status: 400, body: '{"error":"invalid_grant"}' }]);
+
+			await expect(
+				exchangeAuthCode('bad-code', 'verifier', { fetchImpl: fetchMock })
+			).rejects.toThrow('Token exchange failed (400)');
+		});
+	});
+
+	describe('refreshAccessToken', () => {
+		it('refreshes an access token', async () => {
+			const mockResponse: GoogleTokenResponse = {
+				access_token: 'ya29.new-access-token',
+				expires_in: 3600,
+				token_type: 'Bearer',
+			};
+
+			const fetchMock = createMockFetch([{ status: 200, body: JSON.stringify(mockResponse) }]);
+
+			const result = await refreshAccessToken('1//test-refresh-token', {
+				fetchImpl: fetchMock,
+			});
+
+			expect(result.access_token).toBe('ya29.new-access-token');
+		});
+
+		it('throws InvalidTokenError on invalid_grant', async () => {
+			const fetchMock = createMockFetch([
+				{
+					status: 400,
+					body: '{"error":"invalid_grant","error_description":"Token has been expired or revoked."}',
+				},
+			]);
+
+			await expect(
+				refreshAccessToken('bad-refresh-token', { fetchImpl: fetchMock })
+			).rejects.toThrow(InvalidTokenError);
+		});
+
+		it('throws generic error on other failures', async () => {
+			const fetchMock = createMockFetch([{ status: 500, body: 'Internal Server Error' }]);
+
+			await expect(refreshAccessToken('some-token', { fetchImpl: fetchMock })).rejects.toThrow(
+				'Token refresh failed (500)'
+			);
+		});
+	});
+
+	describe('fetchUserInfo', () => {
+		it('fetches user info from Google', async () => {
+			const mockUserInfo: GoogleUserInfo = {
+				email: 'test@gmail.com',
+				name: 'Test User',
+				picture: 'https://example.com/photo.jpg',
+				sub: '12345',
+			};
+
+			const fetchMock = createMockFetch([{ status: 200, body: JSON.stringify(mockUserInfo) }]);
+
+			const result = await fetchUserInfo('ya29.test-token', { fetchImpl: fetchMock });
+
+			expect(result.email).toBe('test@gmail.com');
+			expect(result.name).toBe('Test User');
+		});
+
+		it('throws on error response', async () => {
+			const fetchMock = createMockFetch([{ status: 401, body: 'Unauthorized' }]);
+
+			await expect(fetchUserInfo('bad-token', { fetchImpl: fetchMock })).rejects.toThrow(
+				'Failed to fetch user info (401)'
+			);
+		});
+	});
+
+	describe('validateRefreshToken', () => {
+		it('returns true for valid tokens', async () => {
+			const mockResponse: GoogleTokenResponse = {
+				access_token: 'ya29.fresh-token',
+				expires_in: 3600,
+				token_type: 'Bearer',
+			};
+
+			const fetchMock = createMockFetch([{ status: 200, body: JSON.stringify(mockResponse) }]);
+
+			const result = await validateRefreshToken('valid-token', { fetchImpl: fetchMock });
+			expect(result).toBe(true);
+		});
+
+		it('returns false for invalid tokens', async () => {
+			const fetchMock = createMockFetch([
+				{
+					status: 400,
+					body: '{"error":"invalid_grant"}',
+				},
+			]);
+
+			const result = await validateRefreshToken('invalid-token', { fetchImpl: fetchMock });
+			expect(result).toBe(false);
+		});
+
+		it('returns true on network errors (assumes valid)', async () => {
+			const fetchMock = mock(async () => {
+				throw new Error('Network error');
+			}) as unknown as typeof fetch;
+
+			const result = await validateRefreshToken('some-token', { fetchImpl: fetchMock });
+			expect(result).toBe(true);
+		});
+	});
+
+	describe('createAccount', () => {
+		it('creates an account with default values', () => {
+			const account = createAccount('test@gmail.com', '1//refresh-token');
+
+			expect(account.email).toBe('test@gmail.com');
+			expect(account.refresh_token).toBe('1//refresh-token');
+			expect(account.status).toBe('active');
+			expect(account.daily_limit).toBe(1500);
+			expect(account.daily_request_count).toBe(0);
+			expect(account.cooldown_until).toBe(0);
+			expect(account.id).toBeTruthy();
+		});
+
+		it('creates an account with custom daily limit', () => {
+			const account = createAccount('test@gmail.com', '1//refresh-token', 2000);
+			expect(account.daily_limit).toBe(2000);
+		});
+	});
+});

--- a/packages/daemon/tests/unit/1-core/providers/gemini-oauth-client.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/gemini-oauth-client.test.ts
@@ -34,6 +34,27 @@ function createMockFetch(responses: Array<{ status: number; body: string }>): ty
 // ---------------------------------------------------------------------------
 
 describe('Google Gemini OAuth Client', () => {
+	const originalClientId = process.env.GOOGLE_GEMINI_CLIENT_ID;
+	const originalClientSecret = process.env.GOOGLE_GEMINI_CLIENT_SECRET;
+
+	beforeEach(() => {
+		process.env.GOOGLE_GEMINI_CLIENT_ID = 'test-client-id';
+		process.env.GOOGLE_GEMINI_CLIENT_SECRET = 'test-client-secret';
+	});
+
+	afterEach(() => {
+		if (originalClientId !== undefined) {
+			process.env.GOOGLE_GEMINI_CLIENT_ID = originalClientId;
+		} else {
+			delete process.env.GOOGLE_GEMINI_CLIENT_ID;
+		}
+		if (originalClientSecret !== undefined) {
+			process.env.GOOGLE_GEMINI_CLIENT_SECRET = originalClientSecret;
+		} else {
+			delete process.env.GOOGLE_GEMINI_CLIENT_SECRET;
+		}
+	});
+
 	describe('buildAuthUrl', () => {
 		it('returns an auth URL with the correct parameters', async () => {
 			const { authUrl, codeVerifier } = await buildAuthUrl();

--- a/packages/daemon/tests/unit/1-core/providers/gemini-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/gemini-provider.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for Gemini OAuth Provider
+ */
+
+import { describe, expect, it, mock, beforeEach, afterEach } from 'bun:test';
+import { GeminiOAuthProvider } from '../../../../src/lib/providers/gemini/gemini-provider.js';
+
+describe('GeminiOAuthProvider', () => {
+	describe('identity', () => {
+		it('exposes correct id and displayName', () => {
+			const provider = new GeminiOAuthProvider();
+			expect(provider.id).toBe('google-gemini-oauth');
+			expect(provider.displayName).toBe('Google Gemini (OAuth)');
+		});
+
+		it('declares correct capabilities', () => {
+			const provider = new GeminiOAuthProvider();
+			expect(provider.capabilities.streaming).toBe(true);
+			expect(provider.capabilities.extendedThinking).toBe(false);
+			expect(provider.capabilities.maxContextWindow).toBe(1_000_000);
+			expect(provider.capabilities.functionCalling).toBe(true);
+			expect(provider.capabilities.vision).toBe(false);
+		});
+	});
+
+	describe('ownsModel', () => {
+		it('claims gemini- model IDs', () => {
+			const provider = new GeminiOAuthProvider();
+			expect(provider.ownsModel('gemini-2.5-pro')).toBe(true);
+			expect(provider.ownsModel('gemini-2.5-flash')).toBe(true);
+			expect(provider.ownsModel('gemini-2.0-flash')).toBe(true);
+		});
+
+		it('does not claim non-gemini model IDs', () => {
+			const provider = new GeminiOAuthProvider();
+			expect(provider.ownsModel('claude-3-opus')).toBe(false);
+			expect(provider.ownsModel('sonnet')).toBe(false);
+			expect(provider.ownsModel('gpt-4')).toBe(false);
+		});
+	});
+
+	describe('getModelForTier', () => {
+		it('maps tiers to Gemini models', () => {
+			const provider = new GeminiOAuthProvider();
+			expect(provider.getModelForTier('sonnet')).toBe('gemini-2.5-pro');
+			expect(provider.getModelForTier('opus')).toBe('gemini-2.5-pro');
+			expect(provider.getModelForTier('haiku')).toBe('gemini-2.5-flash');
+			expect(provider.getModelForTier('default')).toBe('gemini-2.5-pro');
+		});
+	});
+
+	describe('getModels', () => {
+		it('returns the Gemini model list', async () => {
+			const provider = new GeminiOAuthProvider();
+			const models = await provider.getModels();
+
+			expect(models.length).toBeGreaterThan(0);
+			expect(models.some((m) => m.id === 'gemini-2.5-pro')).toBe(true);
+			expect(models.some((m) => m.id === 'gemini-2.5-flash')).toBe(true);
+
+			// All models should have correct provider
+			for (const model of models) {
+				expect(model.provider).toBe('google-gemini-oauth');
+				expect(model.family).toBe('gemini');
+			}
+		});
+	});
+
+	describe('isAvailable', () => {
+		it('returns false when no accounts are configured', async () => {
+			const provider = new GeminiOAuthProvider();
+			// No accounts file exists in test environment
+			const available = await provider.isAvailable();
+			// In test environment, no accounts file exists, so should be false
+			expect(available).toBe(false);
+		});
+	});
+
+	describe('getAuthStatus', () => {
+		it('returns unauthenticated status when no accounts configured', async () => {
+			const provider = new GeminiOAuthProvider();
+			const status = await provider.getAuthStatus();
+
+			expect(status.isAuthenticated).toBe(false);
+			expect(status.method).toBe('oauth');
+			expect(status.error).toContain('No Google accounts');
+		});
+	});
+
+	describe('startOAuthFlow', () => {
+		it('returns an auth URL', async () => {
+			const provider = new GeminiOAuthProvider();
+			const flow = await provider.startOAuthFlow();
+
+			expect(flow.type).toBe('redirect');
+			expect(flow.authUrl).toContain('accounts.google.com');
+			expect(flow.authUrl).toContain('client_id=');
+			expect(flow.message).toContain('authorize');
+		});
+	});
+
+	describe('shutdown', () => {
+		it('can be called without error', async () => {
+			const provider = new GeminiOAuthProvider();
+			await expect(provider.shutdown()).resolves.toBeUndefined();
+		});
+	});
+});

--- a/packages/daemon/tests/unit/1-core/providers/gemini-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/gemini-provider.test.ts
@@ -6,6 +6,27 @@ import { describe, expect, it, mock, beforeEach, afterEach } from 'bun:test';
 import { GeminiOAuthProvider } from '../../../../src/lib/providers/gemini/gemini-provider.js';
 
 describe('GeminiOAuthProvider', () => {
+	const originalClientId = process.env.GOOGLE_GEMINI_CLIENT_ID;
+	const originalClientSecret = process.env.GOOGLE_GEMINI_CLIENT_SECRET;
+
+	beforeEach(() => {
+		process.env.GOOGLE_GEMINI_CLIENT_ID = 'test-client-id';
+		process.env.GOOGLE_GEMINI_CLIENT_SECRET = 'test-client-secret';
+	});
+
+	afterEach(() => {
+		if (originalClientId !== undefined) {
+			process.env.GOOGLE_GEMINI_CLIENT_ID = originalClientId;
+		} else {
+			delete process.env.GOOGLE_GEMINI_CLIENT_ID;
+		}
+		if (originalClientSecret !== undefined) {
+			process.env.GOOGLE_GEMINI_CLIENT_SECRET = originalClientSecret;
+		} else {
+			delete process.env.GOOGLE_GEMINI_CLIENT_SECRET;
+		}
+	});
+
 	describe('identity', () => {
 		it('exposes correct id and displayName', () => {
 			const provider = new GeminiOAuthProvider();

--- a/packages/daemon/tests/unit/1-core/providers/provider-registry.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/provider-registry.test.ts
@@ -320,7 +320,7 @@ describe('ProviderRegistry', () => {
 	describe('initializeProviders — all built-in providers registered', () => {
 		// Outer beforeEach already resets registry+factory; no per-test resets needed.
 
-		it('should register exactly eight built-in providers', () => {
+		it('should register exactly nine built-in providers', () => {
 			const reg = initializeProviders();
 
 			const ids = reg
@@ -333,6 +333,7 @@ describe('ProviderRegistry', () => {
 					'anthropic-codex',
 					'anthropic-copilot',
 					'glm',
+					'google-gemini-oauth',
 					'minimax',
 					'ollama',
 					'ollama-cloud',
@@ -377,18 +378,23 @@ describe('ProviderRegistry', () => {
 			expect(reg.has('anthropic-copilot')).toBe(true);
 		});
 
+		it('should include google-gemini-oauth provider', () => {
+			const reg = initializeProviders();
+			expect(reg.has('google-gemini-oauth')).toBe(true);
+		});
+
 		it('should return the same singleton registry on repeated calls without reset', () => {
 			const reg1 = initializeProviders();
 			const reg2 = initializeProviders();
 			// The global singleton must be the same reference — not a new instance
 			expect(reg1).toBe(reg2);
-			expect(reg2.size).toBe(8);
+			expect(reg2.size).toBe(9);
 		});
 
 		it('should use the global registry singleton', () => {
 			initializeProviders();
 			const globalReg = getProviderRegistry();
-			expect(globalReg.size).toBe(8);
+			expect(globalReg.size).toBe(9);
 		});
 	});
 
@@ -529,5 +535,10 @@ describe('inferProviderForModel', () => {
 	it('defaults unknown models to anthropic', () => {
 		expect(inferProviderForModel('sonnet')).toBe('anthropic');
 		expect(inferProviderForModel('unknown-model')).toBe('anthropic');
+	});
+
+	it('routes gemini- models to google-gemini-oauth', () => {
+		expect(inferProviderForModel('gemini-2.5-pro')).toBe('google-gemini-oauth');
+		expect(inferProviderForModel('gemini-2.5-flash')).toBe('google-gemini-oauth');
 	});
 });

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -218,7 +218,8 @@ export type Provider =
 	| 'ollama'
 	| 'ollama-cloud'
 	| 'anthropic-copilot'
-	| 'anthropic-codex';
+	| 'anthropic-codex'
+	| 'google-gemini-oauth';
 
 /**
  * Provider-specific configuration


### PR DESCRIPTION
## Summary
- Add Google Gemini as a provider backend with OAuth authentication (Google Pro subscription credentials)
- Implement account rotation system with session affinity, 429 failover, and exhaustion detection
- Build format converter for Anthropic Messages API ↔ Gemini Code Assist translation
- Create bridge server (Bun.serve) that translates Anthropic API calls to Gemini Code Assist streaming endpoint

## Modules added
- `providers/gemini/oauth-client.ts` — OAuth client with PKCE headless flow (token exchange, refresh, validation, credential storage)
- `providers/gemini/format-converter.ts` — Request/response translation between Anthropic and Gemini formats
- `providers/gemini/account-rotation.ts` — Multi-account rotation with LRU selection, session stickiness, cooldown recovery
- `providers/gemini/bridge-server.ts` — Local Anthropic-compatible proxy to Gemini Code Assist API
- `providers/gemini/gemini-provider.ts` — Provider implementation registered in the factory

## Tests
- 70 new unit tests across 4 test files (OAuth client, format converter, account rotation, provider)
- All 681 existing provider tests continue to pass
- Tests use injectable storage and fetch for full isolation

## Notes
- OAuth credentials loaded from `GOOGLE_GEMINI_CLIENT_ID` / `GOOGLE_GEMINI_CLIENT_SECRET` env vars
- Credentials stored in `~/.neokai/gemini-oauth-accounts.json`
- Provider ID: `google-gemini-oauth`, model prefix: `gemini-`

🤖 Generated with [Claude Code](https://claude.com/claude-code)