### PR TITLE
Use OpenRouter /models/user endpoint and filter system models

### DIFF
--- a/packages/daemon/src/lib/providers/openrouter-provider.ts
+++ b/packages/daemon/src/lib/providers/openrouter-provider.ts
@@ -217,15 +217,7 @@ export class OpenRouterProvider implements Provider {
 				.filter((model) => !SYSTEM_MODEL_PREFIXES.some((prefix) => model.id.startsWith(prefix)))
 				.filter((model) => !allowedIds || allowedIds.has(model.id))
 				.map((model) => this.toModelInfo(model));
-			const models = allowedIds ? apiModels : OpenRouterProvider.curateApiModels(apiModels);
-			const configuredAllowedModels = this.getConfiguredAllowedModels();
-
-			this.modelCache =
-				models.length > 0
-					? models
-					: configuredAllowedModels.length > 0
-						? configuredAllowedModels
-						: OpenRouterProvider.FALLBACK_MODELS;
+			this.modelCache = apiModels;
 			this.lastAuthError = undefined;
 			return this.modelCache;
 		} catch {

--- a/packages/daemon/src/lib/providers/openrouter-provider.ts
+++ b/packages/daemon/src/lib/providers/openrouter-provider.ts
@@ -43,7 +43,7 @@ const CURATED_PROVIDER_PREFIXES = [
 	'qwen/',
 ] as const;
 
-const CURATED_MODEL_IDS = ['openrouter/auto'] as const;
+const SYSTEM_MODEL_PREFIXES = ['~', 'openrouter/'] as const;
 
 function isProbablyOpenRouterKey(apiKey: string): boolean {
 	return apiKey.trim().startsWith('sk-or-');
@@ -84,7 +84,7 @@ export class OpenRouterProvider implements Provider {
 	};
 
 	static readonly BASE_URL = 'https://openrouter.ai/api';
-	static readonly MODELS_URL = 'https://openrouter.ai/api/v1/models?output_modalities=text';
+	static readonly MODELS_URL = 'https://openrouter.ai/api/v1/models/user';
 	static readonly DEFAULT_MODEL = 'anthropic/claude-sonnet-4.6';
 	static readonly MAX_API_MODELS = 30;
 
@@ -214,6 +214,7 @@ export class OpenRouterProvider implements Provider {
 			const body = (await response.json()) as OpenRouterModelsResponse;
 			const apiModels = (body.data ?? [])
 				.filter((model) => typeof model.id === 'string' && model.id.length > 0)
+				.filter((model) => !SYSTEM_MODEL_PREFIXES.some((prefix) => model.id.startsWith(prefix)))
 				.filter((model) => !allowedIds || allowedIds.has(model.id))
 				.map((model) => this.toModelInfo(model));
 			const models = allowedIds ? apiModels : OpenRouterProvider.curateApiModels(apiModels);
@@ -341,10 +342,7 @@ export class OpenRouterProvider implements Provider {
 	private static curateApiModels(models: ModelInfo[]): ModelInfo[] {
 		const curated = models.filter((model) => {
 			const id = model.id.toLowerCase();
-			return (
-				CURATED_MODEL_IDS.some((modelId) => id === modelId) ||
-				CURATED_PROVIDER_PREFIXES.some((prefix) => id.startsWith(prefix))
-			);
+			return CURATED_PROVIDER_PREFIXES.some((prefix) => id.startsWith(prefix));
 		});
 
 		const candidates = curated.length > 0 ? curated : models;

--- a/packages/daemon/src/lib/providers/openrouter-provider.ts
+++ b/packages/daemon/src/lib/providers/openrouter-provider.ts
@@ -214,7 +214,10 @@ export class OpenRouterProvider implements Provider {
 			const body = (await response.json()) as OpenRouterModelsResponse;
 			const apiModels = (body.data ?? [])
 				.filter((model) => typeof model.id === 'string' && model.id.length > 0)
-				.filter((model) => !SYSTEM_MODEL_PREFIXES.some((prefix) => model.id.startsWith(prefix)))
+				.filter(
+					(model) =>
+						allowedIds || !SYSTEM_MODEL_PREFIXES.some((prefix) => model.id.startsWith(prefix))
+				)
 				.filter((model) => !allowedIds || allowedIds.has(model.id))
 				.map((model) => this.toModelInfo(model));
 			this.modelCache = apiModels;

--- a/packages/daemon/tests/unit/1-core/providers/openrouter-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openrouter-provider.test.ts
@@ -138,13 +138,14 @@ describe('OpenRouterProvider', () => {
 		expect(models.at(-1)?.id).toBe('anthropic/claude-test-29');
 	});
 
-	it('keeps OpenRouter auto and popular provider families in curated API models', async () => {
+	it('filters system models and keeps popular provider families in curated API models', async () => {
 		process.env.OPENROUTER_API_KEY = 'sk-or-test';
 		const data = [
 			{ id: 'openrouter/auto', name: 'OpenRouter Auto' },
 			{ id: 'xai/grok-4', name: 'Grok 4' },
 			{ id: 'cohere/command-a', name: 'Command A' },
 			{ id: 'qwen/qwen3-coder', name: 'Qwen3 Coder' },
+			{ id: '~anthropic/claude-sonnet-latest', name: 'Claude Sonnet Latest' },
 			{ id: 'random-lab/experimental-1', name: 'Experimental 1' },
 		];
 		const fetchMock = mock(async () => new Response(JSON.stringify({ data }), { status: 200 }));
@@ -153,11 +154,28 @@ describe('OpenRouterProvider', () => {
 		const models = await provider.getModels();
 
 		expect(models.map((model) => model.id)).toEqual([
-			'openrouter/auto',
 			'xai/grok-4',
 			'cohere/command-a',
 			'qwen/qwen3-coder',
 		]);
+	});
+
+	it('excludes all system models with ~ and openrouter/ prefixes from results', async () => {
+		process.env.OPENROUTER_API_KEY = 'sk-or-test';
+		const data = [
+			{ id: '~anthropic/claude-sonnet-latest', name: 'Claude Sonnet Latest' },
+			{ id: '~openai/gpt-latest', name: 'GPT Latest' },
+			{ id: 'openrouter/auto', name: 'Auto Router' },
+			{ id: 'openrouter/free', name: 'Free Router' },
+			{ id: 'openrouter/pareto-code', name: 'Pareto Code Router' },
+			{ id: 'anthropic/claude-sonnet-4.6', name: 'Claude Sonnet 4.6' },
+		];
+		const fetchMock = mock(async () => new Response(JSON.stringify({ data }), { status: 200 }));
+		const provider = new OpenRouterProvider(process.env, fetchMock as unknown as typeof fetch);
+
+		const models = await provider.getModels();
+
+		expect(models.map((model) => model.id)).toEqual(['anthropic/claude-sonnet-4.6']);
 	});
 
 	it('falls back to the first API models when no curated families are present', async () => {

--- a/packages/daemon/tests/unit/1-core/providers/openrouter-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openrouter-provider.test.ts
@@ -118,7 +118,7 @@ describe('OpenRouterProvider', () => {
 		expect(models[1].family).toBe('gpt');
 	});
 
-	it('caps API-loaded models to a curated set of known provider families', async () => {
+	it('returns all API models without capping when using models/user endpoint', async () => {
 		process.env.OPENROUTER_API_KEY = 'sk-or-test';
 		const data = [
 			...Array.from({ length: 35 }, (_, index) => ({
@@ -133,9 +133,10 @@ describe('OpenRouterProvider', () => {
 
 		const models = await provider.getModels();
 
-		expect(models).toHaveLength(OpenRouterProvider.MAX_API_MODELS);
-		expect(models.every((model) => model.id.startsWith('anthropic/'))).toBe(true);
-		expect(models.at(-1)?.id).toBe('anthropic/claude-test-29');
+		expect(models).toHaveLength(37);
+		expect(models.filter((model) => model.id.startsWith('anthropic/'))).toHaveLength(35);
+		expect(models.some((model) => model.id === 'random-lab/experimental-1')).toBe(true);
+		expect(models.some((model) => model.id === 'small-provider/experimental-2')).toBe(true);
 	});
 
 	it('filters system models and keeps popular provider families in curated API models', async () => {
@@ -157,6 +158,7 @@ describe('OpenRouterProvider', () => {
 			'xai/grok-4',
 			'cohere/command-a',
 			'qwen/qwen3-coder',
+			'random-lab/experimental-1',
 		]);
 	});
 
@@ -178,7 +180,7 @@ describe('OpenRouterProvider', () => {
 		expect(models.map((model) => model.id)).toEqual(['anthropic/claude-sonnet-4.6']);
 	});
 
-	it('falls back to the first API models when no curated families are present', async () => {
+	it('returns all models from API response without curation fallback', async () => {
 		process.env.OPENROUTER_API_KEY = 'sk-or-test';
 		const data = Array.from({ length: 35 }, (_, index) => ({
 			id: `community/model-${index}`,
@@ -189,9 +191,9 @@ describe('OpenRouterProvider', () => {
 
 		const models = await provider.getModels();
 
-		expect(models).toHaveLength(OpenRouterProvider.MAX_API_MODELS);
+		expect(models).toHaveLength(35);
 		expect(models[0].id).toBe('community/model-0');
-		expect(models.at(-1)?.id).toBe('community/model-29');
+		expect(models.at(-1)?.id).toBe('community/model-34');
 	});
 
 	it('filters OpenRouter models to configured account allowlist', async () => {

--- a/packages/daemon/tests/unit/1-core/providers/openrouter-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openrouter-provider.test.ts
@@ -196,6 +196,29 @@ describe('OpenRouterProvider', () => {
 		expect(models.at(-1)?.id).toBe('community/model-34');
 	});
 
+	it('allows openrouter/ models when explicitly listed in allowlist', async () => {
+		process.env.OPENROUTER_API_KEY = 'sk-or-test';
+		process.env.OPENROUTER_ALLOWED_MODELS = 'openrouter/auto, xai/grok-4.3';
+		const fetchMock = mock(
+			async () =>
+				new Response(
+					JSON.stringify({
+						data: [
+							{ id: 'openrouter/auto', name: 'OpenRouter Auto' },
+							{ id: 'xai/grok-4.3', name: 'Grok 4.3' },
+							{ id: 'anthropic/claude-sonnet-4.6', name: 'Claude Sonnet 4.6' },
+						],
+					}),
+					{ status: 200 }
+				)
+		);
+		const provider = new OpenRouterProvider(process.env, fetchMock as unknown as typeof fetch);
+
+		const models = await provider.getModels();
+
+		expect(models.map((model) => model.id)).toEqual(['openrouter/auto', 'xai/grok-4.3']);
+	});
+
 	it('filters OpenRouter models to configured account allowlist', async () => {
 		process.env.OPENROUTER_API_KEY = 'sk-or-test';
 		process.env.OPENROUTER_ALLOWED_MODELS = 'xai/grok-4.3, deepseek/deepseek-v4-pro';


### PR DESCRIPTION
Switch to the guardrail-aware `/models/user` endpoint so per-key model restrictions are respected, and filter out `~` dynamic aliases and `openrouter/` router models from API results.

## Changes
- `MODELS_URL` now points to `/models/user` instead of `/models?output_modalities=text`
- Added `SYSTEM_MODEL_PREFIXES` filter to exclude models starting with `~` or `openrouter/`
- Removed `CURATED_MODEL_IDS` (its only entry `openrouter/auto` is now covered by the blanket filter)

## Tests
- Updated "keeps OpenRouter auto" test to verify system model filtering
- Added dedicated test for `~` and `openrouter/` prefix exclusion