### PR TITLE
Design: external event bus for Space workflow nodes

### DIFF
--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -565,7 +565,12 @@ interface PendingDelivery {
 interface QueuedDeliveryFailure {
   eventId: string;
   deliveryKey: string;
-  reason: 'pending_queue_overflow' | 'run_terminal_cleanup' | 'run_terminal_retry_cancelled';
+  reason:
+    | 'pending_queue_overflow'
+    | 'run_terminal_cleanup'
+    | 'run_terminal_retry_cancelled'
+    | 'node_execution_cancelled'
+    | 'subscription_inactive_retry_skipped';
 }
 
 interface EventRetryState {
@@ -823,6 +828,72 @@ class EventRouter {
           && v.nodeId === nodeId,
       );
     }
+
+    // Node cancellation is terminal for this node's already-registered deliveries
+    // even if the workflow run continues. Fail queued/retrying rows immediately so
+    // they do not block event terminalization until full run teardown.
+    this.failPendingStateForExecution(workflowRunId, taskId, nodeId, agentName, 'node_execution_cancelled');
+  }
+
+  private failPendingStateForExecution(
+    workflowRunId: string,
+    taskId: string,
+    nodeId: string,
+    agentName: string,
+    reason: QueuedDeliveryFailure['reason'],
+  ): void {
+    const queueKey = JSON.stringify([workflowRunId, taskId, nodeId, agentName]);
+    const queuedFailures: QueuedDeliveryFailure[] = [];
+    const queue = this.pendingQueue.get(queueKey) ?? [];
+    for (const pending of queue) {
+      queuedFailures.push({ eventId: pending.event.id, deliveryKey: pending.deliveryKey, reason });
+    }
+    this.pendingQueue.delete(queueKey);
+    this.markQueuedDeliveriesFailed(queuedFailures);
+
+    for (const key of this.pendingDeliveries.keys()) {
+      const [, keyTaskId, keyNodeId, keyAgentName, keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string, string];
+      if (
+        keyWorkflowRunId === workflowRunId
+        && keyTaskId === taskId
+        && keyNodeId === nodeId
+        && keyAgentName === agentName
+      ) {
+        this.pendingDeliveries.delete(key);
+      }
+    }
+
+    for (const key of this.retryCounts.keys()) {
+      const [, keyTaskId, keyNodeId, keyAgentName, keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string, string];
+      if (
+        keyWorkflowRunId === workflowRunId
+        && keyTaskId === taskId
+        && keyNodeId === nodeId
+        && keyAgentName === agentName
+      ) {
+        this.retryCounts.delete(key);
+      }
+    }
+
+    const retryFailures: QueuedDeliveryFailure[] = [];
+    for (const [key, timer] of this.retryTimers.entries()) {
+      const [, keyTaskId, keyNodeId, keyAgentName, keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string, string];
+      if (
+        keyWorkflowRunId === workflowRunId
+        && keyTaskId === taskId
+        && keyNodeId === nodeId
+        && keyAgentName === agentName
+      ) {
+        clearTimeout(timer);
+        this.retryTimers.delete(key);
+        retryFailures.push({
+          eventId: this.eventStore.getEventIdForDeliveryKey(key),
+          deliveryKey: key,
+          reason,
+        });
+      }
+    }
+    this.markQueuedDeliveriesFailed(retryFailures);
   }
 
   /**
@@ -1310,6 +1381,11 @@ class EventRouter {
       if (!stillActive) {
         this.retryCounts.delete(deliveryKey);
         this.pendingDeliveries.delete(deliveryKey);
+        this.eventStore.markDeliveryFailed(event.id, deliveryKey, {
+          terminal: true,
+          reason: 'subscription_inactive_retry_skipped',
+        });
+        this.eventStore.markEventFailedIfAllDeliveriesTerminal(event.id);
         return;
       }
 
@@ -1385,6 +1461,17 @@ When an event matches a subscription whose node execution is `idle` (agent sessi
 1. Call `sessionFactory.injectMessage(sessionId, message, { deliveryMode: 'defer' })`.
 2. The existing defer mechanism handles waking: if idle → enqueue immediately; if busy → persist as deferred, replay after current turn.
 3. No new wake mechanism needed — the existing `SessionNotificationSink` pattern already solves this.
+
+### Node cancellation cleanup
+
+When a node execution transitions to `cancelled`, `unregisterExecution(workflowRunId, taskId, nodeId, agentName)` removes that node's subscriptions from `activeRuns` and the topic trie. Because expected delivery rows may already exist for queued or retrying deliveries owned by that node, cancellation must also call `failPendingStateForExecution(...)`:
+
+1. Remove queued pending-node deliveries for the exact `[workflowRunId, taskId, nodeId, agentName]` key and mark them terminally failed with reason `node_execution_cancelled`.
+2. Cancel per-delivery retry timers for the same tuple, look up each event id from the delivery store, and mark them terminally failed with reason `node_execution_cancelled`.
+3. Clear matching `pendingDeliveries` and retry counts.
+4. Call `markEventFailedIfAllDeliveriesTerminal(eventId)` for each failure so long-running runs do not keep source events retryable until full run teardown.
+
+If a retry timer fires after its subscription has already been removed by another path, the inactive-subscription branch must also mark that delivery terminally failed with reason `subscription_inactive_retry_skipped` before returning.
 
 ### Terminal run cleanup
 
@@ -1734,7 +1821,7 @@ V1 needs one core event-store table plus workflow type additions:
    );
    ```
 
-   `EventRouter` calls `registerExpectedDelivery(...)` for every scope-matched subscription before attempting any injection. This registration must be idempotent for the `(event_id, delivery_key)` primary key: use `INSERT OR IGNORE`, `ON CONFLICT DO NOTHING`, or an equivalent upsert that never downgrades an existing terminal row. Retryable source duplicates and router retries can prepare the same delivery more than once, so duplicate expected-delivery rows are normal and must not become preparation failures. After idempotent registration, the router skips already-terminal delivery rows and only attempts pending/retryable rows. It then records `delivered` after successful `injectMessage` and calls `markEventDeliveredIfAllDeliveriesTerminal(event.id)` so source-level dedup can stop re-emitting already-delivered events after restart or in-memory TTL eviction. When retry budget is exhausted, pending-node queue overflow evicts an expected delivery, terminal run cleanup drops queued deliveries, or terminal run cleanup cancels per-delivery retry timers, the router records terminal delivery failure and calls `markEventFailedIfAllDeliveriesTerminal(event.id)` so duplicate source observations do not restart an exhausted or impossible delivery.
+   `EventRouter` calls `registerExpectedDelivery(...)` for every scope-matched subscription before attempting any injection. This registration must be idempotent for the `(event_id, delivery_key)` primary key: use `INSERT OR IGNORE`, `ON CONFLICT DO NOTHING`, or an equivalent upsert that never downgrades an existing terminal row. Retryable source duplicates and router retries can prepare the same delivery more than once, so duplicate expected-delivery rows are normal and must not become preparation failures. After idempotent registration, the router skips already-terminal delivery rows and only attempts pending/retryable rows. It then records `delivered` after successful `injectMessage` and calls `markEventDeliveredIfAllDeliveriesTerminal(event.id)` so source-level dedup can stop re-emitting already-delivered events after restart or in-memory TTL eviction. When retry budget is exhausted, pending-node queue overflow evicts an expected delivery, node cancellation removes queued/retrying deliveries, a retry fires for an inactive subscription, terminal run cleanup drops queued deliveries, or terminal run cleanup cancels per-delivery retry timers, the router records terminal delivery failure and calls `markEventFailedIfAllDeliveriesTerminal(event.id)` so duplicate source observations do not restart an exhausted or impossible delivery.
 
 3. **Adapter-owned GitHub configuration**: reuse or migrate the existing `space_github_watched_repos` table behind `GitHubEventAdapterRepository`. This table remains source-specific and should not be queried by EventRouter except through cache invalidation hooks for repo-scoped matching.
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -25,7 +25,7 @@ External Event Sources (GitHub webhook, polling, future: Slack, CI)
 │  EventIngestion     │  Normalize → validate → publish to EventBus
 │  (adapter per source│
 └────────┬────────────┘
-         │ publish(event) → hub.emit('space.externalEvent.published', { event })
+         │ publish(event) → hub.emit('space.externalEvent.published', { sessionId: 'global', event })
          ▼
 ┌─────────────────────┐
 │  EventBus           │  In-memory, backed by TypedHub. External topic is payload data.
@@ -284,7 +284,26 @@ export interface EventPublisher {
 export const EXTERNAL_EVENT_PUBLISHED_METHOD = 'space.externalEvent.published';
 
 export interface EventBusHubEventMap {
-  'space.externalEvent.published': { spaceId: string; event: ExternalEvent };
+  'space.externalEvent.published': {
+    /** Fixed channel required by BaseEventData/TypedHub routing. */
+    sessionId: 'global';
+    spaceId: string;
+    event: ExternalEvent;
+  };
+}
+```
+
+The `sessionId: 'global'` field is required because EventBus is backed by TypedHub/DaemonHub, whose payloads satisfy `BaseEventData` for channel routing. External event delivery is still space-scoped by `spaceId`; the fixed session channel is only the transport channel for bus subscribers.
+
+```typescript
+class EventBus implements EventPublisher {
+  async publish(event: ExternalEvent): Promise<void> {
+    await this.hub.emit(EXTERNAL_EVENT_PUBLISHED_METHOD, {
+      sessionId: 'global',
+      spaceId: event.spaceId,
+      event,
+    });
+  }
 }
 ```
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -551,8 +551,10 @@ class EventRouter {
   }
 
   /**
-   * Unregister subscriptions for a specific node execution.
+   * Unregister subscriptions for a specific task-owned node execution.
    * Called when a node execution transitions to `cancelled` state.
+   * Includes taskId so cancelling one task's node does not remove another
+   * task's subscriptions when both tasks share the same workflowRunId/node/agent.
    *
    * Only `cancelled` nodes are removed from the subscription index.
    * All other states (`pending`, `in_progress`, `idle`, `waiting_rebind`,
@@ -565,6 +567,7 @@ class EventRouter {
    */
   unregisterExecution(
     workflowRunId: string,
+    taskId: string,
     nodeId: string,
     agentName: string,
   ): void {
@@ -572,12 +575,15 @@ class EventRouter {
     if (!runSubs) return;
 
     const toRemove = [...runSubs].filter(
-      s => s.nodeId === nodeId && s.agentName === agentName,
+      s => s.taskId === taskId && s.nodeId === nodeId && s.agentName === agentName,
     );
     for (const sub of toRemove) {
       runSubs.delete(sub);
       this.topicTrie.remove(
-        v => v.workflowRunId === workflowRunId && v.agentName === agentName && v.nodeId === nodeId,
+        v => v.workflowRunId === workflowRunId
+          && v.taskId === taskId
+          && v.agentName === agentName
+          && v.nodeId === nodeId,
       );
     }
   }
@@ -960,10 +966,8 @@ class GitHubEventAdapter implements EventAdapter {
       const [repoOwner, repoName] = event.repo.split('/');
 
       // Construct topic from event.
-      // mapEventType returns the full resource.action string from the table below.
-      // For most SpaceGitHubEventKinds, the mapping already includes the action
-      // (e.g., pull_request_review → "pull_request.review_submitted").
-      // For plain pull_request events, the action is appended from event.action.
+      // mapEventType returns the full resource.action string and preserves the
+      // original GitHub action so users can filter created/edited/deleted/etc.
       const topic = `github/${repoOwner}/${repoName}/${mapEventType(event.eventType, event.action)}`;
 
       // Publish to bus
@@ -998,17 +1002,17 @@ The `SpaceGitHubService` already normalizes to `SpaceGitHubEventKind` (`issue_co
 
 | SpaceGitHubEventKind | `mapEventType(kind, action)` returns |
 |---|---|
-| `issue_comment` | `pull_request.comment_created` (PR comments only, already filtered) |
-| `pull_request_review` | `pull_request.review_submitted` |
-| `pull_request_review_comment` | `pull_request.review_comment_created` |
+| `issue_comment` | `pull_request.comment_${action}` (PR comments only; created, edited, deleted) |
+| `pull_request_review` | `pull_request.review_${action}` (submitted, edited, dismissed) |
+| `pull_request_review_comment` | `pull_request.review_comment_${action}` (created, edited, deleted) |
 | `pull_request` | `pull_request.${action}` (opened, synchronize, closed, etc.) |
 
 ```typescript
 function mapEventType(kind: string, action: string): string {
   switch (kind) {
-    case 'issue_comment': return 'pull_request.comment_created';
-    case 'pull_request_review': return 'pull_request.review_submitted';
-    case 'pull_request_review_comment': return 'pull_request.review_comment_created';
+    case 'issue_comment': return `pull_request.comment_${action}`;
+    case 'pull_request_review': return `pull_request.review_${action}`;
+    case 'pull_request_review_comment': return `pull_request.review_comment_${action}`;
     case 'pull_request': return `pull_request.${action}`;
     default: return `${kind}.${action}`;
   }

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -1154,6 +1154,9 @@ class EventRouter {
    * (for example transient watched-repo lookup or delivery-row insert failures).
    * This reruns full matching/preparation instead of allowing partial delivery to
    * mark the source event terminal while an unregistered subscription missed it.
+   * The event-level retry count is cleared after a resolved retry pass so later
+   * independent preparation errors get a fresh budget and this map does not leak
+   * state across retryable source re-emissions of the same non-terminal event.
    */
   private scheduleEventRetry(event: ExternalEvent, matched: Subscription[]): void {
     const retryKey = `${event.id}:${matched.map((sub) => sub.workflowRunId).sort().join(',')}:prepare`;
@@ -1181,9 +1184,19 @@ class EventRouter {
 
     const timer = setTimeout(() => {
       this.eventRetryTimers.delete(retryKey);
-      void this.handleEvent(event).catch((err) => {
-        log.warn('EventRouter: event preparation retry failed', { error: err, eventId: event.id });
-      });
+      void this.handleEvent(event)
+        .then(() => {
+          // A resolved handleEvent means the retry pass either prepared the complete
+          // expected-delivery set or found no matching work left. Clear the event-level
+          // preparation retry count so a later independent transient error gets a full
+          // retry budget and this map does not leak state for non-terminal re-emits.
+          this.eventRetryCounts.delete(retryKey);
+        })
+        .catch((err) => {
+          // Keep the count on failure so the next scheduled retry continues the
+          // same preparation-failure budget instead of starting over.
+          log.warn('EventRouter: event preparation retry failed', { error: err, eventId: event.id });
+        });
     }, backoff);
     this.eventRetryTimers.set(retryKey, timer);
   }

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -449,8 +449,10 @@ class EventRouter {
   // track which runs have active subscriptions (for lifecycle management)
   private activeRuns: Map<string, Set<Subscription>> = new Map();
 
-  // dedup: (dedupeKey, agentSessionId) → timestamp
+  // dedup: JSON tuple (dedupeKey, taskId, nodeId, agentName, workflowRunId) → timestamp
   private delivered: Map<string, number> = new Map();
+  // pending delivery queue: JSON tuple (workflowRunId, taskId, nodeId, agentName) → events
+  private pendingQueue: Map<string, ExternalEvent[]> = new Map();
   // TTL for dedup entries — entries older than this are evicted on next access
   private static readonly DEDUP_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
@@ -509,6 +511,17 @@ class EventRouter {
     } else {
       this.watchedRepoCache.clear();
     }
+  }
+
+  private makeDeliveryKey(event: ExternalEvent, sub: Subscription): string {
+    // Use a structured tuple key: event.dedupeKey and workflow/node/agent ids are
+    // free-form strings and can contain ':', '/', or other delimiter characters.
+    return JSON.stringify([event.dedupeKey, sub.taskId, sub.nodeId, sub.agentName, sub.workflowRunId]);
+  }
+
+  private makePendingQueueKey(sub: Pick<Subscription, 'workflowRunId' | 'taskId' | 'nodeId' | 'agentName'>): string {
+    // Same collision-safe shape as subscription/delivery keys.
+    return JSON.stringify([sub.workflowRunId, sub.taskId, sub.nodeId, sub.agentName]);
   }
 
   /** Evict stale dedup entries (called periodically or on demand). */
@@ -662,22 +675,20 @@ class EventRouter {
     this.topicTrie.remove(v => v.workflowRunId === workflowRunId);
     this.activeRuns.delete(workflowRunId);
 
-    // Also clean up dedup entries for this run.
-    // Delivery keys are: `${event.dedupeKey}:${sub.taskId}:${sub.nodeId}:${sub.agentName}:${workflowRunId}`
-    // The run ID is the final segment — match with suffix `:${workflowRunId}`.
-    const suffix = `:${workflowRunId}`;
+    // Also clean up dedup entries for this run. Keys are JSON tuples, so parse
+    // structurally rather than suffix-matching delimiter-joined strings.
     for (const key of this.delivered.keys()) {
-      if (key.endsWith(suffix)) {
+      const [, , , , keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string, string];
+      if (keyWorkflowRunId === workflowRunId) {
         this.delivered.delete(key);
       }
     }
 
-    // Clean up in-memory pending queue for this run.
-    // Keys are `${workflowRunId}:${taskId}:${nodeId}:${agentName}` — use the
-    // delimiter to avoid false prefix matches (e.g., run "abc1" matching "abc10:*").
-    const runPrefix = `${workflowRunId}:`;
-    for (const [key, events] of this.pendingQueue.entries()) {
-      if (key.startsWith(runPrefix)) {
+    // Clean up in-memory pending queue for this run. Keys are JSON tuples, so parse
+    // structurally rather than prefix-matching delimiter-joined strings.
+    for (const key of this.pendingQueue.keys()) {
+      const [keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string];
+      if (keyWorkflowRunId === workflowRunId) {
         this.pendingQueue.delete(key);
       }
     }
@@ -719,7 +730,7 @@ class EventRouter {
     // run. Each task/node/agent subscription is deduped independently.
     // Evict before checking so DEDUP_TTL_MS is actually enforced during long runs.
     this.evictStaleDedup();
-    const dedupeKey = `${event.dedupeKey}:${sub.taskId}:${sub.nodeId}:${sub.agentName}:${sub.workflowRunId}`;
+    const dedupeKey = this.makeDeliveryKey(event, sub);
     if (this.delivered.has(dedupeKey)) return;
 
     // Mark dedup BEFORE session resolution / queueing. This prevents the same
@@ -757,6 +768,22 @@ class EventRouter {
       // this run. A fresh event will arrive via the next poll cycle if the
       // underlying external event is still relevant.
     }
+  }
+
+  private queueForDelivery(event: ExternalEvent, sub: Subscription): void {
+    const key = this.makePendingQueueKey(sub);
+    const queue = this.pendingQueue.get(key) ?? [];
+    queue.push(event);
+    if (queue.length > 50) {
+      queue.shift();
+      log.warn('EventRouter: pending external event queue exceeded limit; dropped oldest event', {
+        workflowRunId: sub.workflowRunId,
+        taskId: sub.taskId,
+        nodeId: sub.nodeId,
+        agentName: sub.agentName,
+      });
+    }
+    this.pendingQueue.set(key, queue);
   }
 
   private passesScopeCheck(event: ExternalEvent, sub: Subscription): boolean {
@@ -848,7 +875,7 @@ Event arrives → Match subscriptions → Scope check → Dedup check → Sessio
 
 ### Deduplication
 
-- **Key**: `(event.dedupeKey, subscription.taskId, subscription.nodeId, subscription.agentName, subscription.workflowRunId)` — includes `taskId` to isolate multi-task runs and `nodeId` to handle cases where the same agent name appears in multiple nodes within the same run.
+- **Key**: JSON tuple `[event.dedupeKey, subscription.taskId, subscription.nodeId, subscription.agentName, subscription.workflowRunId]` — includes `taskId` to isolate multi-task runs and `nodeId` to handle cases where the same agent name appears in multiple nodes within the same run. The tuple is encoded structurally rather than delimiter-joined because `dedupeKey`, workflow identifiers, node IDs, and agent names are free-form strings.
 - **Storage**: In-memory `Map<string, number>` (timestamp). Evicted when the workflow run completes.
 - **Guarantee**: Same external event is never delivered twice to the same node agent within a run.
 - The upstream `SpaceGitHubService` already deduplicates by `(spaceId, dedupeKey)` — this is an additional per-node dedup.
@@ -865,7 +892,7 @@ When an event matches a subscription whose node execution is `idle` (agent sessi
 
 When a node execution is `pending` (no session yet):
 
-1. The event is queued in an in-memory `Map<string, ExternalEvent[]>` keyed by `${workflowRunId}:${taskId}:${nodeId}:${agentName}`.
+1. The event is queued in an in-memory `Map<string, ExternalEvent[]>` keyed by a JSON tuple `[workflowRunId, taskId, nodeId, agentName]` so free-form identifiers cannot collide by containing delimiter characters.
 2. When `TaskAgentManager` creates the node's session, it checks for queued events.
 3. Queued events are injected as initial context in the session's first turn.
 4. Queue is bounded: max 50 events per execution, oldest dropped (with a warning log).

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -1,0 +1,851 @@
+# Design: External Event Bus for Space Workflow Nodes
+
+## Status: Draft
+
+## Problem
+
+The Space Agent spends most of its time relaying "check the new review comments" to the coder node. External events (PR reviews, CI failures, etc.) arrive via webhooks/polling but have no path to workflow **nodes** — they only route to Rooms or to the Space Agent's global session (via `SpaceGitHubService`). We need a system where workflow nodes declare interest in event types, and matching events are delivered directly to their agent sessions.
+
+## Current State
+
+Two parallel event pipelines exist today, neither of which routes to individual workflow nodes:
+
+1. **Room pipeline** (`GitHubService`): Webhook → normalize → filter → security → route → `deliverToRoom()` → DaemonHub `room.message`. Routes to **Rooms**, not Spaces.
+2. **Space pipeline** (`SpaceGitHubService`): Webhook → normalize → dedupe → `SpacePrTaskResolver.resolve()` → `injectTaskAgent()`. Routes events to the **Task Agent session** (the orchestrator), which must then manually relay to the coder node.
+
+The Space pipeline already does the hard part — it normalizes events, resolves them to a task by PR number, and injects them into the Task Agent session. But it stops one hop short: the coder node still depends on the Task Agent to forward relevant events.
+
+## Design Overview
+
+```
+External Event Sources (GitHub webhook, polling, future: Slack, CI)
+       │
+       ▼
+┌─────────────────────┐
+│  EventIngestion     │  Normalize → validate → publish to EventBus
+│  (adapter per source│
+└────────┬────────────┘
+         │ publish(topic, payload)
+         ▼
+┌─────────────────────┐
+│  EventBus           │  In-memory, backed by TypedHub. Namespaced topics.
+│  (singleton)        │  O(1) subscriber lookup by topic pattern.
+└────────┬────────────┘
+         │
+         ▼
+┌─────────────────────┐
+│  EventRouter        │  Subscribes to all topics. Matches events to
+│  (per-runtime)      │  active node interests. Delivers via AgentMessageRouter
+│                     │  or injects directly into sessions.
+└─────────────────────┘
+```
+
+## 1. Namespaced Event Topics
+
+Topic format: `{source}/{owner}/{repo}/{resource}.{action}`
+
+Examples:
+```
+github/lsm/neokai/pull_request.review_submitted
+github/lsm/neokai/pull_request.comment_created
+github/lsm/neokai/pull_request.synchronize
+github/lsm/neokai/check_suite.completed
+github/lsm/neokai/issues.opened
+github/lsm/neokai/pull_request.*            ← wildcard: all PR events for this repo
+github/lsm/neokai/*.*                       ← wildcard: all events for this repo
+github/lsm/neokai/pull_request.review_*     ← prefix wildcard: all review events
+```
+
+### Topic construction rules
+
+1. `source` — adapter identifier (`github`, `slack`, `ci`). Lowercase, no slashes.
+2. `owner/repo` — from the event's repository context. Both lowercase for case-insensitive matching.
+3. `resource` — the GitHub resource type: `pull_request`, `issue`, `check_suite`, `pull_request_review`, etc.
+4. `action` — the specific action: `opened`, `review_submitted`, `comment_created`, `completed`, etc.
+5. For resources without a natural `owner/repo` (e.g. a Slack message), the convention is `{source}/{workspace}/{channel}.{action}`.
+
+### Matching rules
+
+Subscriptions use glob-style patterns:
+- `*` matches any single path segment (no slashes)
+- `**` matches any number of path segments
+- Literal segments match exactly (case-insensitive)
+
+We implement matching via a **trie-based prefix index** (see §4), not regex. This keeps matching O(k) where k = topic depth, independent of the number of subscriptions.
+
+## 2. Node-Level Event Subscription (`eventInterests`)
+
+### Schema addition to `WorkflowNodeAgent`
+
+```typescript
+// packages/shared/src/types/space.ts — add to WorkflowNodeAgent
+
+export interface EventInterest {
+  /**
+   * Glob pattern matching event topics.
+   * Examples: 'github/*/*/pull_request.*', 'ci/*/*/check_suite.completed'
+   */
+  topic: string;
+
+  /**
+   * Scoping mode — determines how the router filters events for this node.
+   * - 'task'    — Only events related to THIS TASK (e.g. same PR number, same branch).
+   *               The router uses the task's associated PR/branch to filter.
+   * - 'repo'    — All events for the space's configured repository.
+   * - 'global'  — All events matching the topic pattern, no additional filtering.
+   */
+  scope: 'task' | 'repo' | 'global';
+
+  /**
+   * Optional label for diagnostics. Not used in routing logic.
+   * Example: 'PR review comments', 'CI failures'
+   */
+  label?: string;
+}
+
+// Added to WorkflowNodeAgent:
+export interface WorkflowNodeAgent {
+  // ... existing fields ...
+
+  /**
+   * Events this node is interested in receiving. When matched, the event is
+   * injected into the agent's session as a structured message.
+   * Omit or empty array = no event subscriptions (default).
+   */
+  eventInterests?: EventInterest[];
+}
+```
+
+### Example workflow definition
+
+```json
+{
+  "nodes": [
+    {
+      "id": "coder",
+      "name": "Code",
+      "agents": [{
+        "agentId": "...",
+        "name": "coder",
+        "eventInterests": [
+          {
+            "topic": "github/*/*/pull_request.review_submitted",
+            "scope": "task",
+            "label": "PR reviews on my task's PR"
+          },
+          {
+            "topic": "github/*/*/pull_request.comment_created",
+            "scope": "task",
+            "label": "PR comments on my task's PR"
+          },
+          {
+            "topic": "github/*/*/pull_request_review_comment.*",
+            "scope": "task",
+            "label": "Inline review comments"
+          }
+        ]
+      }]
+    },
+    {
+      "id": "monitor",
+      "name": "CI Monitor",
+      "agents": [{
+        "agentId": "...",
+        "name": "ci-monitor",
+        "eventInterests": [
+          {
+            "topic": "github/*/*/check_suite.completed",
+            "scope": "repo",
+            "label": "All CI completions in the repo"
+          }
+        ]
+      }]
+    }
+  ]
+}
+```
+
+### Scoping details
+
+**`task` scope** is the critical innovation. The router resolves the task's context at match time:
+
+1. The task's `SpaceTask` record has `workflowRunId` and (via `workflow_run_artifacts` or gate data) an associated PR number and branch name.
+2. The router queries the same `SpacePrTaskResolver` that `SpaceGitHubService` already uses to match PR numbers to tasks.
+3. For a `task`-scoped subscription, the router checks: does this event's PR number / branch match the node execution's parent task?
+4. The node author never specifies a PR number — it's implicit from the task context.
+
+**`repo` scope** filters to events from any of the space's watched repositories (`space_github_watched_repos`). The node author doesn't need to know repo names.
+
+**`global` scope** passes through all events matching the topic pattern. Use sparingly (e.g. a "global monitor" node).
+
+### Auto-scoping resolution at runtime
+
+When an event arrives, the router:
+
+1. Extracts `prNumber` and `repoOwner/repoName` from the event payload.
+2. For each active node execution with `eventInterests`:
+   a. Compiles the interest's `topic` glob against the event's topic.
+   b. If matched, checks scope:
+      - `task`: resolves `SpaceTask` → `SpacePrTaskResolver` → does event's PR match this task?
+      - `repo`: does event's repo match any watched repo in the node's space?
+      - `global`: pass.
+   c. If scope check passes, the event is queued for delivery to this node's agent session.
+
+## 3. EventIngestion Adapter Interface
+
+```typescript
+// packages/daemon/src/lib/space/runtime/event-bus/types.ts
+
+/**
+ * A normalized external event on the bus.
+ */
+export interface ExternalEvent {
+  /** Unique event ID (UUID) */
+  id: string;
+  /** Fully qualified topic: 'github/owner/repo/resource.action' */
+  topic: string;
+  /** Timestamp when the event occurred (epoch ms) */
+  occurredAt: number;
+  /** Timestamp when the event was ingested (epoch ms) */
+  ingestedAt: number;
+  /** Source adapter identifier */
+  source: string;
+  /**
+   * For scope resolution. Not all events have a PR number;
+   * absence means 'task'-scoped subscriptions won't match.
+   */
+  prNumber?: number;
+  /** Repository owner (lowercase) */
+  repoOwner?: string;
+  /** Repository name (lowercase) */
+  repoName?: string;
+  /** Branch name, if available */
+  branch?: string;
+  /** Human-readable summary for agent consumption */
+  summary: string;
+  /** External URL (e.g. GitHub PR link) */
+  externalUrl?: string;
+  /** Structured payload — adapter-specific, not constrained */
+  payload: Record<string, unknown>;
+  /**
+   * Deduplication key. The bus tracks delivered events by (eventId, nodeId)
+   * to prevent double delivery.
+   */
+  dedupeKey: string;
+}
+
+/**
+ * Interface that event source adapters must implement.
+ */
+export interface EventAdapter {
+  /** Adapter identifier (used in topic namespace: '{source}/...') */
+  readonly sourceId: string;
+
+  /**
+   * Start the adapter. Called once at daemon startup.
+   * The adapter calls `publisher.publish(event)` whenever it has an event.
+   */
+  start(publisher: EventPublisher): Promise<void>;
+
+  /** Stop the adapter. Called at daemon shutdown. */
+  stop(): Promise<void>;
+}
+
+/**
+ * Callback adapters use to publish events onto the bus.
+ */
+export interface EventPublisher {
+  publish(event: ExternalEvent): Promise<void>;
+}
+```
+
+### GitHub adapter
+
+The GitHub adapter wraps the existing `SpaceGitHubService.ingest()` pipeline. Rather than duplicating normalization logic, the adapter hooks into the point where `SpaceGitHubService` has already normalized and resolved the event:
+
+```typescript
+class GitHubEventAdapter implements EventAdapter {
+  readonly sourceId = 'github';
+
+  constructor(
+    private readonly spaceGitHubService: SpaceGitHubService,
+    private readonly watchedRepoLookup: (owner: string, repo: string) => { spaceId: string }[]
+  ) {}
+
+  async start(publisher: EventPublisher): Promise<void> {
+    // Hook into SpaceGitHubService by intercepting the post-normalization path.
+    // SpaceGitHubService already:
+    //   1. Normalizes the webhook/polling event
+    //   2. Deduplicates via dedupeKey
+    //   3. Resolves PR → taskId via SpacePrTaskResolver
+    //   4. Emits DaemonHub 'space.githubEvent.routed'
+    //
+    // The adapter subscribes to 'space.githubEvent.routed' on DaemonHub
+    // and converts the event to an ExternalEvent for the bus.
+    //
+    // This means:
+    //   - No change to existing webhook/polling normalization
+    //   - Events continue flowing to Task Agent as before
+    //   - Additionally, events appear on the EventBus for node delivery
+  }
+}
+```
+
+The adapter subscribes to the existing `space.githubEvent.routed` DaemonHub event (already emitted by `SpaceGitHubService.appendTaskActivity`). It converts the event to `ExternalEvent` format and publishes to the bus.
+
+**Why this approach:**
+- Zero changes to the existing `SpaceGitHubService` webhook handler or polling pipeline.
+- The existing PR-to-task resolution (`SpacePrTaskResolver`) continues to work.
+- The existing Task Agent injection continues to work (we don't replace it, we supplement it).
+- The adapter is purely additive: it converts an already-normalized event into bus format.
+
+## 4. EventRouter Design
+
+### Architecture
+
+The `EventRouter` subscribes to all topics on the `EventBus`. When an event arrives, it:
+
+1. Looks up all active node executions that have `eventInterests`.
+2. For each matching interest, checks scope.
+3. Delivers the event to the matching node's agent session.
+
+### Trie-based subscription index
+
+For O(1)-ish lookup, we maintain a **topic trie**:
+
+```
+root
+  └── github
+      └── *                    ← matches any owner
+          └── *                ← matches any repo
+              ├── pull_request
+              │   ├── *        ← all PR actions
+              │   │   └── [subscriptions: coder(task), ...]
+              │   ├── review_submitted
+              │   │   └── [subscriptions: coder(task)]
+              │   └── comment_created
+              │       └── [subscriptions: coder(task)]
+              └── check_suite
+                  └── completed
+                      └── [subscriptions: ci-monitor(repo)]
+```
+
+The trie maps topic segments to `Set<Subscription>` at leaf nodes. Wildcard segments (`*`) match any single segment at that depth.
+
+**Build cost**: O(n × k) where n = number of subscriptions, k = topic depth (typically 4-5). Built once when a workflow run starts.
+
+**Lookup cost**: O(k) per event — walk the trie by topic segment, collect subscriptions at each level (exact match + wildcard).
+
+### Subscription index lifecycle
+
+The index is **per-SpaceRuntime instance** and rebuilt when:
+
+1. A workflow run starts (node executions are created with interests from the workflow definition).
+2. A node execution transitions to a new status (e.g. `in_progress` → starts receiving events; `idle`/`cancelled` → removed from index).
+3. A workflow definition is updated (interests may have changed — next run picks up changes).
+
+```typescript
+interface Subscription {
+  workflowRunId: string;
+  nodeId: string;
+  agentName: string;
+  interest: EventInterest;    // from the workflow definition
+  agentSessionId: string | null; // resolved at delivery time
+  spaceId: string;
+}
+```
+
+### EventRouter implementation sketch
+
+```typescript
+class EventRouter {
+  // topic trie for fast lookup
+  private topicTrie: TopicTrie<Subscription[]> = new TopicTrie();
+
+  // track which runs have active subscriptions (for lifecycle management)
+  private activeRuns: Map<string, Set<Subscription>> = new Map();
+
+  // dedup: (dedupeKey, agentSessionId) → timestamp
+  private delivered: Map<string, number> = new Map();
+
+  constructor(
+    private readonly eventBus: EventBus,
+    private readonly nodeExecutionRepo: NodeExecutionRepository,
+    private readonly taskRepo: SpaceTaskRepository,
+    private readonly sessionFactory: SessionFactory,
+    private readonly prResolver: SpacePrTaskResolver,
+  ) {
+    // Subscribe to ALL events on the bus
+    this.eventBus.subscribe('*', this.handleEvent.bind(this));
+  }
+
+  /**
+   * Register all event interests for a workflow run.
+   * Called when a workflow run starts or when node executions change.
+   */
+  registerRunInterests(
+    spaceId: string,
+    workflowRunId: string,
+    workflow: SpaceWorkflow,
+    nodeExecutions: NodeExecution[],
+  ): void {
+    // Clear previous subscriptions for this run
+    this.clearRunInterests(workflowRunId);
+
+    const runSubs = new Set<Subscription>();
+
+    for (const node of workflow.nodes) {
+      for (const agent of node.agents) {
+        if (!agent.eventInterests?.length) continue;
+
+        // Only register if this node has at least one active (non-terminal) execution
+        const exec = nodeExecutions.find(
+          e => e.workflowNodeId === node.id && e.agentName === agent.name
+        );
+        if (!exec || isTerminal(exec.status)) continue;
+
+        for (const interest of agent.eventInterests) {
+          const sub: Subscription = {
+            workflowRunId,
+            nodeId: node.id,
+            agentName: agent.name,
+            interest,
+            agentSessionId: exec.agentSessionId,
+            spaceId,
+          };
+
+          // Insert into trie
+          this.topicTrie.insert(interest.topic, sub);
+          runSubs.add(sub);
+        }
+      }
+    }
+
+    this.activeRuns.set(workflowRunId, runSubs);
+  }
+
+  private async handleEvent(event: ExternalEvent): Promise<void> {
+    // 1. Look up matching subscriptions via trie
+    const matched = this.topicTrie.lookup(event.topic);
+
+    if (matched.length === 0) return;
+
+    // 2. For each matched subscription, check scope and deliver
+    for (const sub of matched) {
+      await this.deliverToSubscription(event, sub);
+    }
+  }
+
+  private async deliverToSubscription(event: ExternalEvent, sub: Subscription): Promise<void> {
+    // Scope check
+    if (!this.passesScopeCheck(event, sub)) return;
+
+    // Dedup check
+    const dedupeKey = `${event.dedupeKey}:${sub.agentName}:${sub.workflowRunId}`;
+    if (this.delivered.has(dedupeKey)) return;
+
+    // Resolve session
+    const sessionId = await this.resolveSession(sub);
+    if (!sessionId) {
+      // Session not active — queue for later delivery
+      this.queueForDelivery(event, sub);
+      return;
+    }
+
+    // Format and inject
+    const message = this.formatEventMessage(event);
+    try {
+      await this.sessionFactory.injectMessage(sessionId, message, {
+        deliveryMode: 'defer',
+      });
+
+      // Mark delivered
+      this.delivered.set(dedupeKey, Date.now());
+    } catch (err) {
+      log.warn(`Failed to deliver event to ${sub.agentName}`, { error: err });
+    }
+  }
+
+  private passesScopeCheck(event: ExternalEvent, sub: Subscription): boolean {
+    switch (sub.interest.scope) {
+      case 'global':
+        return true;
+
+      case 'repo': {
+        // Check if event's repo matches any watched repo in this space
+        if (!event.repoOwner || !event.repoName) return false;
+        return this.isWatchedRepo(sub.spaceId, event.repoOwner, event.repoName);
+      }
+
+      case 'task': {
+        // Check if event's PR number matches the subscription's task
+        if (!event.prNumber) return false;
+        const task = this.taskRepo.getByWorkflowRunId(sub.workflowRunId);
+        if (!task) return false;
+        // Reuse the existing SpacePrTaskResolver logic
+        return this.prResolver.resolve(sub.spaceId, {
+          repoOwner: event.repoOwner ?? '',
+          repoName: event.repoName ?? '',
+          prNumber: event.prNumber,
+          // ... minimal shape for resolver
+        } as any).taskId === task.id;
+      }
+    }
+  }
+}
+```
+
+## 5. Event Delivery Lifecycle
+
+### State machine per event delivery
+
+```
+Event arrives → Match subscriptions → Scope check → Dedup check → Session check
+                                                                         │
+                                                          ┌──────────────┼──────────────┐
+                                                          ▼              ▼              ▼
+                                                    Session live   Session idle   No session
+                                                          │              │              │
+                                                          ▼              ▼              ▼
+                                                    Inject via      Wake + inject  Queue in
+                                                    injectMessage   injectMessage  pending_events
+                                                          │              │              │
+                                                          ▼              ▼              ▼
+                                                    Mark delivered  Mark delivered  Await session
+                                                                                     start
+```
+
+### Deduplication
+
+- **Key**: `(event.dedupeKey, subscription.agentName, subscription.workflowRunId)`
+- **Storage**: In-memory `Map<string, number>` (timestamp). Evicted when the workflow run completes.
+- **Guarantee**: Same external event is never delivered twice to the same node agent within a run.
+- The upstream `SpaceGitHubService` already deduplicates by `(spaceId, dedupeKey)` — this is an additional per-node dedup.
+
+### Wake-on-idle
+
+When an event matches a subscription whose node execution is `idle` (agent session exists but finished its turn):
+
+1. Call `sessionFactory.injectMessage(sessionId, message, { deliveryMode: 'defer' })`.
+2. The existing defer mechanism handles waking: if idle → enqueue immediately; if busy → persist as deferred, replay after current turn.
+3. No new wake mechanism needed — the existing `SessionNotificationSink` pattern already solves this.
+
+### Queue for not-yet-started nodes
+
+When a node execution is `pending` (no session yet):
+
+1. The event is queued in an in-memory `Map<executionId, ExternalEvent[]>`.
+2. When `TaskAgentManager` creates the node's session, it checks for queued events.
+3. Queued events are injected as initial context in the session's first turn.
+4. Queue is bounded: max 50 events per execution, oldest dropped (with a warning log).
+
+### Backpressure
+
+- **Rate limiting**: If a single node receives > 10 events per minute, subsequent events are coalesced into a digest message: "N additional events received in the last minute. Summary: ..."
+- **Event TTL**: Events older than 5 minutes are dropped from the queue (they're likely stale for an agent's decision-making).
+- **Bus overflow**: The `EventBus` uses TypedHub's async-everywhere design — slow consumers don't block publishers. Handlers run via `queueMicrotask`.
+
+## 6. Topic Trie Implementation
+
+```typescript
+/**
+ * Simple trie for topic-pattern matching.
+ * Supports * (single segment wildcard) at any position.
+ */
+class TopicTrie<T> {
+  private root = new TrieNode<T>();
+
+  /**
+   * Insert a value at a glob pattern.
+   * Pattern segments: literal match or '*' for wildcard.
+   */
+  insert(pattern: string, value: T): void {
+    const segments = pattern.split('/');
+    let node = this.root;
+    for (const segment of segments) {
+      const key = segment === '*' ? '__wildcard__' : segment.toLowerCase();
+      if (!node.children.has(key)) {
+        node.children.set(key, new TrieNode());
+      }
+      node = node.children.get(key)!;
+    }
+    if (!node.values) node.values = [];
+    node.values.push(value);
+  }
+
+  /**
+   * Lookup all values whose patterns match the given topic.
+   * Returns all values from exact matches AND wildcard matches at each level.
+   * O(depth) — independent of total number of patterns.
+   */
+  lookup(topic: string): T[] {
+    const segments = topic.split('/');
+    const results: T[] = [];
+
+    const walk = (node: TrieNode<T>, depth: number) => {
+      if (depth === segments.length) {
+        // Terminal node — collect values
+        if (node.values) results.push(...node.values);
+        return;
+      }
+
+      const segment = segments[depth].toLowerCase();
+
+      // Exact match
+      const exact = node.children.get(segment);
+      if (exact) walk(exact, depth + 1);
+
+      // Wildcard match
+      const wildcard = node.children.get('__wildcard__');
+      if (wildcard) walk(wildcard, depth + 1);
+    };
+
+    walk(this.root, 0);
+    return results;
+  }
+
+  /**
+   * Remove all values matching a predicate.
+   */
+  remove(predicate: (value: T) => boolean): void {
+    const clean = (node: TrieNode<T>) => {
+      if (node.values) {
+        node.values = node.values.filter(v => !predicate(v));
+      }
+      for (const child of node.children.values()) {
+        clean(child);
+      }
+    };
+    clean(this.root);
+  }
+}
+
+class TrieNode<T> {
+  children: Map<string, TrieNode<T>> = new Map();
+  values?: T[];
+}
+```
+
+**Complexity**:
+- Insert: O(k) where k = segment count (~4-5)
+- Lookup: O(k) — walks trie by segment, collects from exact + wildcard at each level
+- Memory: O(n × k) where n = number of subscriptions
+
+This is O(1) relative to the number of subscriptions — each lookup traverses at most 2^k paths (2 per level: exact + wildcard), and k is small and constant.
+
+## 7. Wiring the GitHub Adapter
+
+### Changes to existing code
+
+**Minimal.** The adapter hooks into the existing `SpaceGitHubService` via DaemonHub subscription:
+
+```
+SpaceGitHubService.handleWebhook()
+    → normalizeSpaceGitHubWebhook()
+    → ingest(spaceId, normalized)
+        → storeEvent() + dedupe
+        → SpacePrTaskResolver.resolve()
+        → appendTaskActivity()
+            → DaemonHub.emit('space.githubEvent.routed', { taskId, event })
+        → scheduleTaskNotification()
+            → injectTaskAgent(taskId, message)
+```
+
+The GitHub adapter subscribes to `space.githubEvent.routed` and converts it:
+
+```typescript
+// No changes to SpaceGitHubService.
+// The adapter is a new subscriber:
+
+class GitHubEventAdapter implements EventAdapter {
+  async start(publisher: EventPublisher): Promise<void> {
+    this.daemonHub.on('space.githubEvent.routed', async (data) => {
+      const { event, taskId } = data;
+
+      // Construct topic from event
+      const topic = `github/${event.repo.split('/')[0]}/${event.repo.split('/')[1]}/${mapEventType(event.eventType)}.${mapAction(event.action)}`;
+
+      // Publish to bus
+      await publisher.publish({
+        id: crypto.randomUUID(),
+        topic,
+        occurredAt: Date.now(),
+        ingestedAt: Date.now(),
+        source: 'github',
+        prNumber: event.prNumber,
+        repoOwner: event.repo.split('/')[0],
+        repoName: event.repo.split('/')[1],
+        summary: event.summary,
+        externalUrl: event.externalUrl,
+        payload: event,
+        dedupeKey: `github:${event.repo}:${event.prNumber}:${event.eventType}:${event.externalUrl}`,
+      });
+    });
+  }
+}
+```
+
+### Event type mapping
+
+The `SpaceGitHubService` already normalizes to `SpaceGitHubEventKind` (`issue_comment`, `pull_request_review`, `pull_request_review_comment`, `pull_request`). We map these to bus topics:
+
+| SpaceGitHubEventKind | Bus topic resource |
+|---|---|
+| `issue_comment` | `pull_request.comment_created` (PR comments only, already filtered) |
+| `pull_request_review` | `pull_request.review_submitted` |
+| `pull_request_review_comment` | `pull_request.review_comment_created` |
+| `pull_request` | `pull_request.{action}` (opened, synchronize, closed, etc.) |
+
+### Task-scoped resolution optimization
+
+For `task` scope, we already have the `taskId` from `space.githubEvent.routed`. The router can short-circuit:
+
+1. Look up which node executions in that task's run have `eventInterests` matching the event.
+2. Only check scope for those nodes — skip the full trie walk for nodes that don't care about this event type.
+
+This optimization turns the common case (one coder node interested in review comments) into a direct map lookup: `taskId → workflowRunId → nodeExecutions → filter by interest topic match`.
+
+## 8. Migration Path
+
+### DB schema changes
+
+None required for V1. Event interests are stored as part of the workflow definition JSON in `space_workflows.nodes[].agents[].eventInterests`. The existing JSON serialization of workflow nodes already supports arbitrary fields.
+
+### Type changes
+
+1. Add `EventInterest` interface to `packages/shared/src/types/space.ts`.
+2. Add `eventInterests?: EventInterest[]` to `WorkflowNodeAgent`.
+3. Add validation in the workflow create/update path (Zod schema or manual validation):
+   - `topic` must be a valid glob pattern (non-empty, no `..` segments).
+   - `scope` must be one of `'task' | 'repo' | 'global'`.
+   - Max 10 interests per agent slot (prevent abuse).
+
+### New files
+
+```
+packages/daemon/src/lib/space/runtime/event-bus/
+  ├── types.ts              # ExternalEvent, EventAdapter, EventPublisher interfaces
+  ├── event-bus.ts           # EventBus singleton (wraps TypedHub)
+  ├── topic-trie.ts          # TopicTrie<T> implementation
+  ├── event-router.ts        # EventRouter — subscribes to bus, matches, delivers
+  ├── github-adapter.ts      # GitHubEventAdapter — bridges SpaceGitHubService → EventBus
+  └── index.ts               # Public exports
+```
+
+### Wiring into SpaceRuntime
+
+```typescript
+// In SpaceRuntimeConfig, add:
+interface SpaceRuntimeConfig {
+  // ... existing fields ...
+  eventBus?: EventBus;  // Optional — created internally if not provided
+}
+
+// In SpaceRuntime.executeTick(), after node executions are resolved:
+if (this.eventRouter) {
+  this.eventRouter.registerRunInterests(
+    spaceId,
+    workflowRunId,
+    workflow,
+    activeNodeExecutions,
+  );
+}
+
+// In daemon startup (e.g. in SpaceRuntimeService or init function):
+const eventBus = new EventBus(daemonHub);
+const eventRouter = new EventRouter(eventBus, ...dependencies);
+const githubAdapter = new GitHubEventAdapter(daemonHub);
+
+await githubAdapter.start(eventBus);
+```
+
+### Phased rollout
+
+**Phase 1 (MVP — this PR):**
+- Add `EventInterest` type to `WorkflowNodeAgent`.
+- Implement `EventBus`, `TopicTrie`, `EventRouter`, `GitHubEventAdapter`.
+- Wire GitHub adapter to existing `space.githubEvent.routed` events.
+- Deliver events to coder nodes with `task` scope.
+- No UI changes needed — event interests are authored in workflow JSON.
+
+**Phase 2 (follow-up):**
+- Add `eventInterests` editor to the workflow visual editor UI.
+- Add event delivery status to the task activity panel.
+- Add digest/coalescing for high-frequency events.
+- Add metrics: events matched, events delivered, delivery latency.
+
+**Phase 3 (future extensibility):**
+- Slack adapter: subscribe to Slack Events API, normalize to `ExternalEvent`, publish.
+- CI adapter: subscribe to GitHub Check Suite events, normalize, publish.
+- Custom adapter API: allow Space operators to register custom adapters via config.
+
+## 9. Relationship to Existing Systems
+
+| Existing system | Relationship |
+|---|---|
+| **DaemonHub / TypedHub** | `EventBus` is a TypedHub participant on the shared `InProcessTransportBus`. The bus uses the same async-everywhere, session-scoped routing that DaemonHub uses. |
+| **GitHubService** (Room pipeline) | Unchanged. Continues routing to Rooms. The event bus is additive. |
+| **SpaceGitHubService** (Space pipeline) | Unchanged. Continues injecting into Task Agent. The GitHub adapter subscribes to `space.githubEvent.routed` as an additional consumer. |
+| **SessionNotificationSink** | The event bus uses the same `sessionFactory.injectMessage()` with `deliveryMode: 'defer'` pattern. |
+| **AgentMessageRouter** | Not used for event delivery. Events are injected directly via `sessionFactory.injectMessage()`, not via the agent-to-agent messaging channel. Events are not agent-originated messages — they're system-injected context. |
+| **ChannelRouter** | Not involved. Event delivery is not a workflow channel transition. It's an injection into an existing session, not an activation trigger. |
+
+## 10. Key Design Decisions
+
+### Why TypedHub and not a standalone EventEmitter?
+
+TypedHub provides:
+- Async-everywhere design (cluster-ready).
+- Session-scoped subscriptions (O(1) lookup).
+- Already wired into the daemon's lifecycle.
+- No new dependency.
+
+Using TypedHub as the backing transport means the EventBus inherits all of these properties for free.
+
+### Why not route through AgentMessageRouter?
+
+AgentMessageRouter is designed for agent-to-agent communication with channel topology authorization. External events are system-injected context, not agent messages. Routing them through AgentMessageRouter would:
+- Require topology changes (events don't come from a declared node).
+- Conflate system events with agent-to-agent messages in the message history.
+- Add unnecessary authorization overhead.
+
+Direct injection via `sessionFactory.injectMessage()` is simpler and semantically correct.
+
+### Why trie-based matching instead of regex?
+
+1. **Performance**: Trie lookup is O(k) per event regardless of subscription count. Regex matching is O(n) per event where n = number of subscriptions.
+2. **Composability**: Trie supports incremental add/remove (subscriptions change as nodes activate/deactivate). Regex requires rebuilding the full pattern.
+3. **Debuggability**: Trie structure can be inspected and visualized. Regex patterns are opaque.
+
+### Why not extend SpaceGitHubService directly?
+
+The adapter pattern separates concerns:
+- `SpaceGitHubService` owns GitHub-specific normalization, dedup, and PR resolution.
+- The event bus is source-agnostic (GitHub, Slack, CI, etc.).
+- The adapter bridges the two without coupling.
+- Future adapters (Slack, CI) don't touch `SpaceGitHubService`.
+
+### Why `deliveryMode: 'defer'` for event injection?
+
+The existing defer mechanism already handles:
+- Idle sessions: message enqueued immediately, processed on next turn.
+- Busy sessions: message persisted as deferred, replayed after current turn.
+- No dropped messages, no interrupted turns.
+
+This is exactly the behavior we want for external events.
+
+## 11. Testing Strategy
+
+### Unit tests
+
+1. **TopicTrie**: Insert patterns, verify lookup returns correct values for exact and wildcard matches.
+2. **EventRouter**: Given subscriptions and events, verify scope filtering, dedup, and delivery.
+3. **GitHubEventAdapter**: Given a `space.githubEvent.routed` event, verify correct `ExternalEvent` construction.
+4. **Scope resolution**: Test `task` scope with various task/PR associations.
+
+### Integration tests
+
+1. End-to-end: webhook → normalize → ingest → bus → router → session injection.
+2. Dedup: same event delivered twice, verify only one injection.
+3. Wake-on-idle: node idle → event arrives → session receives message.
+4. Pending node: event arrives for pending node → session created → event delivered.

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -803,7 +803,10 @@ class EventRouter {
     const queue = this.pendingQueue.get(key) ?? [];
     queue.push(event);
     if (queue.length > 50) {
-      queue.shift();
+      const evicted = queue.shift()!;
+      // Clear pending marker for evicted event so it can be re-queued if needed
+      const evictedKey = this.makeDeliveryKey(evicted, sub);
+      this.pendingDeliveries.delete(evictedKey);
       log.warn('EventRouter: pending external event queue exceeded limit; dropped oldest event', {
         workflowRunId: sub.workflowRunId,
         taskId: sub.taskId,
@@ -899,14 +902,20 @@ class EventRouter {
         return;
       }
       // Use try/catch to prevent unhandled promise rejections in retry path (P2 fix)
-      this.deliverToSubscription(event, sub).catch((err) => {
-        log.warn('EventRouter: retry delivery failed', {
-          error: err,
-          retries,
-          dedupeKey,
-          workflowRunId: sub.workflowRunId,
+      // Also reset retry state on successful delivery (P2 #4 fix)
+      this.deliverToSubscription(event, sub)
+        .then(() => {
+          // Success: clear retry state so this key can be retried fresh if needed later
+          this.retryCounts.delete(dedupeKey);
+        })
+        .catch((err) => {
+          log.warn('EventRouter: retry delivery failed', {
+            error: err,
+            retries,
+            dedupeKey,
+            workflowRunId: sub.workflowRunId,
+          });
         });
-      });
     }, backoff);
   }
   }

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -67,16 +67,19 @@ github/lsm/neokai/pull_request.review_*     ← prefix wildcard: all review even
 ### Matching rules
 
 Subscriptions use glob-style patterns:
-- `*` matches any single path segment (no slashes)
-- Literal segments match exactly (case-insensitive)
+- `*` matches any sequence of characters inside one path segment (no slashes).
+  - A whole-segment `*` matches any single segment (e.g., owner or repo).
+  - A segment-local wildcard also works inside dotted resource/action segments (e.g., `pull_request.*`, `pull_request.review_*`, `*.*`).
+- Literal characters match exactly (case-insensitive).
 
-> **V1 scope note:** The `**` (multi-segment) wildcard is deferred to a follow-up. All v1 use cases are covered by single-segment `*` wildcards at the `owner`, `repo`, or `action` position (e.g., `github/*/*/pull_request.review_submitted`). Adding `**` support requires a depth-bounded recursive trie walk and is not justified by current subscription patterns.
+> **V1 scope note:** The `**` (multi-segment) wildcard is deferred to a follow-up. All v1 use cases are covered by segment-local `*` wildcards at the `owner`, `repo`, or `action` position (e.g., `github/*/*/pull_request.review_submitted`, `github/*/*/pull_request.*`). Adding `**` support requires a depth-bounded recursive trie walk and is not justified by current subscription patterns.
 
 Pattern validation (enforced at workflow create/update time):
 - Must be non-empty.
 - Must not contain `..` segments.
 - Must not contain empty segments (no double slashes).
-- Each segment must be a literal string or `*`.
+- Must have at least 4 segments (`source/owner/repo/resource.action`) so it can match real event topics.
+- Each segment may contain alphanumeric, dash, underscore, dot, and `*`; `*` must stay within a single segment and cannot cross `/` boundaries.
 - Max 10 interests per agent slot.
 
 We implement matching via a **trie-based prefix index** (see §4), not regex.
@@ -350,25 +353,23 @@ For O(1)-ish lookup, we maintain a **topic trie**:
 ```
 root
   └── github
-      └── *                    ← matches any owner
-          └── *                ← matches any repo
-              ├── pull_request
-              │   ├── *        ← all PR actions
-              │   │   └── [subscriptions: coder(task), ...]
-              │   ├── review_submitted
-              │   │   └── [subscriptions: coder(task)]
-              │   └── comment_created
-              │       └── [subscriptions: coder(task)]
-              └── check_suite
-                  └── completed
-                      └── [subscriptions: ci-monitor(repo)]
+      └── *                          ← matches any owner
+          └── *                      ← matches any repo
+              ├── pull_request.*     ← all PR actions
+              │   └── [subscriptions: coder(task), ...]
+              ├── pull_request.review_submitted
+              │   └── [subscriptions: coder(task)]
+              ├── pull_request.comment_created
+              │   └── [subscriptions: coder(task)]
+              └── check_suite.completed
+                  └── [subscriptions: ci-monitor(repo)]
 ```
 
-The trie maps topic segments to `Set<Subscription>` at leaf nodes. Wildcard segments (`*`) match any single segment at that depth.
+The trie maps topic segments to `Set<Subscription>` at leaf nodes. Each node stores exact children separately from segment-local glob children. A glob segment may be a whole-segment wildcard (`*`) or a dotted segment wildcard (`pull_request.*`, `pull_request.review_*`, `*.*`).
 
 **Build cost**: O(n × k) where n = number of subscriptions, k = topic depth (typically 4-5). Built once when a workflow run starts.
 
-**Lookup cost**: The trie walks both exact-match and wildcard branches at each level. With k levels, this produces at most 2^k paths. At each leaf, m subscriptions are collected. Total cost per lookup is O(2^k × m) where m is the total number of matching subscriptions across all leaves. Since k is small and bounded (4–5 topic segments), 2^k is a small constant (16–32). The real benefit over linear scan is that non-matching subscriptions are never visited — only subscriptions whose pattern segments align with the event's topic are collected.
+**Lookup cost**: The trie walks the exact branch (O(1)) and any glob-child branches at each level. With k bounded to 4–5 segments and max 10 interests per agent slot, the number of glob branches is small. In the common case this remains effectively O(2^k × m), where m is the total number of matching subscriptions across collected leaves. The real benefit over linear scan is that non-matching subscriptions are never visited — only subscriptions whose pattern segments align with the event's topic are collected.
 
 ### Subscription index lifecycle
 
@@ -383,6 +384,8 @@ The index is **per-SpaceRuntime instance** and updated via two distinct operatio
 ```typescript
 interface Subscription {
   workflowRunId: string;
+  /** The specific SpaceTask this node execution belongs to. Used for `task` scope. */
+  taskId: string;
   nodeId: string;
   agentName: string;
   interest: EventInterest;    // from the workflow definition
@@ -470,11 +473,13 @@ class EventRouter {
   registerRunInterests(
     spaceId: string,
     workflowRunId: string,
+    /** The task whose tick/session activation is being processed. */
+    taskId: string,
     workflow: SpaceWorkflow,
     nodeExecutions: NodeExecution[],
   ): void {
     // Build the desired set of subscriptions from current node execution states.
-    const desiredSubs = new Map<string, Subscription>();  // key: `${nodeId}:${agentName}`
+    const desiredSubs = new Map<string, Subscription>();  // key: `${taskId}:${nodeId}:${agentName}:${topic}:${scope}`
 
     for (const node of workflow.nodes) {
       for (const agent of node.agents) {
@@ -485,13 +490,15 @@ class EventRouter {
         );
         if (!exec || !isReceivingStatus(exec.status)) continue;
 
-        const subKey = `${node.id}:${agent.name}`;
+        const subKey = `${taskId}:${node.id}:${agent.name}`;
         for (const interest of agent.eventInterests) {
-          // Include topic AND scope in key — same agent can subscribe to the same topic
-          // with different scopes (e.g., both 'task' and 'repo' scope for the same pattern).
+          // Include taskId, topic, and scope in key — the same run can contain
+          // multiple tasks, and the same agent can subscribe to the same topic
+          // with different scopes (e.g., both 'task' and 'repo' scope).
           const fullKey = `${subKey}:${interest.topic}:${interest.scope}`;
           desiredSubs.set(fullKey, {
             workflowRunId,
+            taskId,
             nodeId: node.id,
             agentName: agent.name,
             interest,
@@ -502,22 +509,26 @@ class EventRouter {
       }
     }
 
-    // Diff against current subscriptions for this run.
-    const currentSubs = this.activeRuns.get(workflowRunId) ?? new Set<Subscription>();
+    // Diff against current subscriptions for THIS task only. A workflow run can
+    // contain multiple tasks, so refreshing task A must not remove task B's
+    // subscriptions from the same run.
+    const currentRunSubs = this.activeRuns.get(workflowRunId) ?? new Set<Subscription>();
+    const currentTaskSubs = [...currentRunSubs].filter(sub => sub.taskId === taskId);
     const currentKeys = new Set<string>();
-    for (const sub of currentSubs) {
-      currentKeys.add(`${sub.nodeId}:${sub.agentName}:${sub.interest.topic}:${sub.interest.scope}`);
+    for (const sub of currentTaskSubs) {
+      currentKeys.add(`${sub.taskId}:${sub.nodeId}:${sub.agentName}:${sub.interest.topic}:${sub.interest.scope}`);
     }
     const desiredKeys = new Set(desiredSubs.keys());
 
-    // Remove subscriptions no longer in the desired set (e.g. node went cancelled).
+    // Remove this task's subscriptions no longer in the desired set (e.g. node went cancelled).
     for (const key of currentKeys) {
       if (!desiredKeys.has(key)) {
-        const [nodeId, agentName, ...rest] = key.split(':');
+        const [subTaskId, nodeId, agentName, ...rest] = key.split(':');
         const scope = rest.pop()!;
         const topic = rest.join(':');
         this.topicTrie.remove(
           v => v.workflowRunId === workflowRunId
+            && v.taskId === subTaskId
             && v.nodeId === nodeId
             && v.agentName === agentName
             && v.interest.topic === topic
@@ -533,8 +544,10 @@ class EventRouter {
       }
     }
 
-    // Replace active run set with the new desired set.
-    this.activeRuns.set(workflowRunId, new Set(desiredSubs.values()));
+    // Replace only this task's active subscriptions while preserving other tasks
+    // in the same workflow run.
+    const preservedOtherTaskSubs = [...currentRunSubs].filter(sub => sub.taskId !== taskId);
+    this.activeRuns.set(workflowRunId, new Set([...preservedOtherTaskSubs, ...desiredSubs.values()]));
   }
 
   /**
@@ -585,7 +598,7 @@ class EventRouter {
     this.activeRuns.delete(workflowRunId);
 
     // Also clean up dedup entries for this run.
-    // Delivery keys are: `${event.dedupeKey}:${sub.nodeId}:${sub.agentName}:${workflowRunId}`
+    // Delivery keys are: `${event.dedupeKey}:${sub.taskId}:${sub.nodeId}:${sub.agentName}:${workflowRunId}`
     // The run ID is the final segment — match with suffix `:${workflowRunId}`.
     const suffix = `:${workflowRunId}`;
     for (const key of this.delivered.keys()) {
@@ -595,8 +608,8 @@ class EventRouter {
     }
 
     // Clean up in-memory pending queue for this run.
-    // Keys are `${workflowRunId}:${nodeId}:${agentName}` — use the delimiter
-    // to avoid false prefix matches (e.g., run "abc1" matching "abc10:*").
+    // Keys are `${workflowRunId}:${taskId}:${nodeId}:${agentName}` — use the
+    // delimiter to avoid false prefix matches (e.g., run "abc1" matching "abc10:*").
     const runPrefix = `${workflowRunId}:`;
     for (const [key, events] of this.pendingQueue.entries()) {
       if (key.startsWith(runPrefix)) {
@@ -621,10 +634,10 @@ class EventRouter {
     // Scope check
     if (!this.passesScopeCheck(event, sub)) return;
 
-    // Dedup check — include nodeId to handle cases where the same agent name
-    // appears in multiple nodes within the same run (e.g., two "Reviewer" agents
-    // in different nodes). Each node-execution is deduped independently.
-    const dedupeKey = `${event.dedupeKey}:${sub.nodeId}:${sub.agentName}:${sub.workflowRunId}`;
+    // Dedup check — include taskId and nodeId to handle multi-task runs and
+    // cases where the same agent name appears in multiple nodes within the same
+    // run. Each task/node/agent subscription is deduped independently.
+    const dedupeKey = `${event.dedupeKey}:${sub.taskId}:${sub.nodeId}:${sub.agentName}:${sub.workflowRunId}`;
     if (this.delivered.has(dedupeKey)) return;
 
     // Mark dedup BEFORE session resolution / queueing. This prevents the same
@@ -684,31 +697,26 @@ class EventRouter {
         // of re-running the resolver, which could match a historical task outside
         // this run (SpacePrTaskResolver searches ALL tasks in the space).
         //
-        // We constrain matching to tasks within THIS workflow run only:
-        // 1. Load all non-archived tasks for this run.
-        // 2. Check if the event's routed taskId is among them.
+        // We constrain matching to the subscription's OWN task, not merely any
+        // task in the same workflow run. This prevents cross-task leakage in
+        // multi-task runs (e.g., two PR tasks sharing a workflowRunId).
         if (!event.prNumber) return false;
 
         // Optimization: the adapter includes the routed taskId in ExternalEvent.payload.
-        // Use it for a direct membership check — no resolver call needed.
+        // Use it for a direct equality check against this subscription's task.
         const routedTaskId = event.payload?.taskId as string | undefined;
         if (routedTaskId) {
-          const tasks = this.taskRepo.listByWorkflowRun(sub.workflowRunId);
-          return tasks.some(t => t.id === routedTaskId);
+          return routedTaskId === sub.taskId;
         }
 
         // Fallback (should rarely happen): if the adapter didn't include taskId,
-        // load run tasks and check if any references the event's PR number.
-        const tasks = this.taskRepo.listByWorkflowRun(sub.workflowRunId);
-        for (const task of tasks) {
-          const resolved = this.prResolver.resolve(sub.spaceId, {
-            repoOwner: event.repoOwner ?? '',
-            repoName: event.repoName ?? '',
-            prNumber: event.prNumber,
-          } as any);
-          if (resolved.taskId === task.id) return true;
-        }
-        return false;
+        // resolve by PR and require that the resolver points to THIS task.
+        const resolved = this.prResolver.resolve(sub.spaceId, {
+          repoOwner: event.repoOwner ?? '',
+          repoName: event.repoName ?? '',
+          prNumber: event.prNumber,
+        } as any);
+        return resolved.taskId === sub.taskId;
       }
     }
   }
@@ -737,7 +745,7 @@ Event arrives → Match subscriptions → Scope check → Dedup check → Sessio
 
 ### Deduplication
 
-- **Key**: `(event.dedupeKey, subscription.nodeId, subscription.agentName, subscription.workflowRunId)` — includes `nodeId` to handle cases where the same agent name appears in multiple nodes within the same run.
+- **Key**: `(event.dedupeKey, subscription.taskId, subscription.nodeId, subscription.agentName, subscription.workflowRunId)` — includes `taskId` to isolate multi-task runs and `nodeId` to handle cases where the same agent name appears in multiple nodes within the same run.
 - **Storage**: In-memory `Map<string, number>` (timestamp). Evicted when the workflow run completes.
 - **Guarantee**: Same external event is never delivered twice to the same node agent within a run.
 - The upstream `SpaceGitHubService` already deduplicates by `(spaceId, dedupeKey)` — this is an additional per-node dedup.
@@ -754,7 +762,7 @@ When an event matches a subscription whose node execution is `idle` (agent sessi
 
 When a node execution is `pending` (no session yet):
 
-1. The event is queued in an in-memory `Map<string, ExternalEvent[]>` keyed by `${workflowRunId}:${nodeId}:${agentName}`.
+1. The event is queued in an in-memory `Map<string, ExternalEvent[]>` keyed by `${workflowRunId}:${taskId}:${nodeId}:${agentName}`.
 2. When `TaskAgentManager` creates the node's session, it checks for queued events.
 3. Queued events are injected as initial context in the session's first turn.
 4. Queue is bounded: max 50 events per execution, oldest dropped (with a warning log).
@@ -784,17 +792,19 @@ class TopicTrie<T> {
 
   /**
    * Insert a value at a glob pattern.
-   * Pattern segments: literal match or '*' for wildcard.
+   * Pattern segments may contain segment-local `*` wildcards, e.g.
+   * `github/*/*/pull_request.*` or `github/*/*/pull_request.review_*`.
    */
   insert(pattern: string, value: T): void {
     const segments = pattern.split('/');
     let node = this.root;
     for (const segment of segments) {
-      const key = segment === '*' ? '__wildcard__' : segment.toLowerCase();
-      if (!node.children.has(key)) {
-        node.children.set(key, new TrieNode());
+      const key = segment.toLowerCase();
+      const children = key.includes('*') ? node.globChildren : node.exactChildren;
+      if (!children.has(key)) {
+        children.set(key, new TrieNode());
       }
-      node = node.children.get(key)!;
+      node = children.get(key)!;
     }
     if (!node.values) node.values = [];
     node.values.push(value);
@@ -820,13 +830,16 @@ class TopicTrie<T> {
 
       const segment = segments[depth].toLowerCase();
 
-      // Exact match
-      const exact = node.children.get(segment);
+      // Exact branch: O(1)
+      const exact = node.exactChildren.get(segment);
       if (exact) walk(exact, depth + 1);
 
-      // Wildcard match
-      const wildcard = node.children.get('__wildcard__');
-      if (wildcard) walk(wildcard, depth + 1);
+      // Glob branches: only patterns that contain segment-local '*'
+      for (const [patternSegment, child] of node.globChildren.entries()) {
+        if (segmentMatches(patternSegment, segment)) {
+          walk(child, depth + 1);
+        }
+      }
     };
 
     walk(this.root, 0);
@@ -841,7 +854,10 @@ class TopicTrie<T> {
       if (node.values) {
         node.values = node.values.filter(v => !predicate(v));
       }
-      for (const child of node.children.values()) {
+      for (const child of node.exactChildren.values()) {
+        clean(child);
+      }
+      for (const child of node.globChildren.values()) {
         clean(child);
       }
     };
@@ -849,8 +865,26 @@ class TopicTrie<T> {
   }
 }
 
+function segmentMatches(pattern: string, segment: string): boolean {
+  if (pattern === segment) return true;
+  if (!pattern.includes('*')) return false;
+
+  // Segment-local glob: '*' matches any characters except '/'. Because callers
+  // split on '/', the segment input never contains '/'. Escape other regex chars.
+  const regex = new RegExp(
+    '^' + pattern.split('*').map(escapeRegex).join('[^/]*') + '$',
+    'i',
+  );
+  return regex.test(segment);
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 class TrieNode<T> {
-  children: Map<string, TrieNode<T>> = new Map();
+  exactChildren: Map<string, TrieNode<T>> = new Map();
+  globChildren: Map<string, TrieNode<T>> = new Map();
   values?: T[];
 }
 ```
@@ -892,7 +926,7 @@ function isReceivingStatus(status: NodeExecutionStatus): boolean {
 
 **Complexity**:
 - Insert: O(k) where k = segment count (~4-5)
-- Lookup: O(2^k × m) — walks at most 2^k paths (exact + wildcard at each level), collects m total matching subscriptions from leaves. Since k is bounded (4–5), 2^k is a small constant.
+- Lookup: Effectively O(2^k × m) in the common case — walks exact + matching glob branches at each level, collects m total matching subscriptions from leaves. Since k is bounded (4–5) and per-agent interest count is capped, glob branching stays small.
 - Memory: O(n × k) where n = number of subscriptions
 
 ## 7. Wiring the GitHub Adapter
@@ -985,23 +1019,23 @@ function mapEventType(kind: string, action: string): string {
 
 For `task` scope, we already have the `taskId` from `space.githubEvent.routed`. The router can short-circuit:
 
-1. Look up which node executions in that task's run have `eventInterests` matching the event.
-2. Only check scope for those nodes — skip the full trie walk for nodes that don't care about this event type.
+1. Look up subscriptions whose `sub.taskId` equals the routed event `taskId` and whose `eventInterests` match the topic.
+2. Only deliver to those task-owned subscriptions — nodes attached to other tasks in the same workflow run do not pass `task` scope.
 
-This optimization turns the common case (one coder node interested in review comments) into a direct map lookup: `taskId → workflowRunId → nodeExecutions → filter by interest topic match`.
+This optimization turns the common case (one coder node interested in review comments) into a direct map lookup: `taskId → subscriptions → filter by interest topic match`.
 
 ## 8. Migration Path
 
 ### DB schema changes
 
-None required for V1. Event interests are stored as part of the workflow definition JSON in `space_workflows.nodes[].agents[].eventInterests`. The existing JSON serialization of workflow nodes already supports arbitrary fields.
+No new tables required for V1. Event interests are stored as part of the workflow definition JSON in `space_workflows.nodes[].agents[].eventInterests`. The existing JSON serialization of workflow nodes already supports arbitrary fields. Task-scoped delivery uses the current `SpaceTask.id` passed into `registerRunInterests(...)` by the runtime and the routed `taskId` already emitted by `space.githubEvent.routed`; no node-execution schema change is required.
 
 ### Type changes
 
 1. Add `EventInterest` interface to `packages/shared/src/types/space.ts`.
 2. Add `eventInterests?: EventInterest[]` to `WorkflowNodeAgent`.
 3. Add validation in the workflow create/update path (Zod schema or manual validation):
-   - `topic` must pass `validateGlobPattern()` (non-empty, no `..` segments, no double slashes, valid characters).
+   - `topic` must pass `validateGlobPattern()` (non-empty, at least 4 segments, no `..` segments, no double slashes, valid characters including segment-local `*`).
    - `scope` must be one of `'task' | 'repo' | 'global'`.
    - Max 10 interests per agent slot (prevent abuse).
    - `validateGlobPattern()` is the single source of truth — called at workflow create/update and again at trie insertion time as a safety net.
@@ -1055,10 +1089,13 @@ export function validateGlobPattern(pattern: string): { valid: boolean; reason?:
     if (segment === '..') {
       return { valid: false, reason: 'Topic pattern must not contain ".." segments' };
     }
-    if (segment !== '*' && !/^[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*$/.test(segment)) {
+    if (segment === '**') {
+      return { valid: false, reason: 'Multi-segment "**" wildcard is not supported in v1' };
+    }
+    if (!/^[a-zA-Z0-9_.*-]+$/.test(segment)) {
       return {
         valid: false,
-        reason: `Segment "${segment}" contains invalid characters. Use alphanumeric, dash, underscore, or dot. Use "*" for wildcard.`,
+        reason: `Segment "${segment}" contains invalid characters. Use alphanumeric, dash, underscore, dot, or segment-local "*" wildcard.`,
       };
     }
   }
@@ -1082,6 +1119,7 @@ if (this.eventRouter) {
   this.eventRouter.registerRunInterests(
     spaceId,
     workflowRunId,
+    taskId, // current task whose tick/session activation is being processed
     workflow,
     activeNodeExecutions,
   );

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -147,7 +147,7 @@ export interface WorkflowNodeAgent {
             "label": "PR comments on my task's PR"
           },
           {
-            "topic": "github/*/*/pull_request_review_comment.*",
+            "topic": "github/*/*/pull_request.review_comment_created",
             "scope": "task",
             "label": "Inline review comments"
           }
@@ -559,8 +559,10 @@ class EventRouter {
     // Scope check
     if (!this.passesScopeCheck(event, sub)) return;
 
-    // Dedup check
-    const dedupeKey = `${event.dedupeKey}:${sub.agentName}:${sub.workflowRunId}`;
+    // Dedup check — include nodeId to handle cases where the same agent name
+    // appears in multiple nodes within the same run (e.g., two "Reviewer" agents
+    // in different nodes). Each node-execution is deduped independently.
+    const dedupeKey = `${event.dedupeKey}:${sub.nodeId}:${sub.agentName}:${sub.workflowRunId}`;
     if (this.delivered.has(dedupeKey)) return;
 
     // Resolve session — re-read from nodeExecutionRepo for latest state
@@ -656,7 +658,7 @@ Event arrives → Match subscriptions → Scope check → Dedup check → Sessio
 
 ### Deduplication
 
-- **Key**: `(event.dedupeKey, subscription.agentName, subscription.workflowRunId)`
+- **Key**: `(event.dedupeKey, subscription.nodeId, subscription.agentName, subscription.workflowRunId)` — includes `nodeId` to handle cases where the same agent name appears in multiple nodes within the same run.
 - **Storage**: In-memory `Map<string, number>` (timestamp). Evicted when the workflow run completes.
 - **Guarantee**: Same external event is never delivered twice to the same node agent within a run.
 - The upstream `SpaceGitHubService` already deduplicates by `(spaceId, dedupeKey)` — this is an additional per-node dedup.

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -13,7 +13,7 @@ Two parallel event pipelines exist today, neither of which routes to individual 
 1. **Room pipeline** (`GitHubService`): Webhook → normalize → filter → security → route → `deliverToRoom()` → DaemonHub `room.message`. Routes to **Rooms**, not Spaces.
 2. **Space pipeline** (`SpaceGitHubService`): Webhook → normalize → dedupe → `SpacePrTaskResolver.resolve()` → `injectTaskAgent()`. Routes events to the **Task Agent session** (the orchestrator), which must then manually relay to the coder node.
 
-The Space pipeline already does the hard part — it normalizes events, resolves them to a task by PR number, and injects them into the Task Agent session. But it stops one hop short: the coder node still depends on the Task Agent to forward relevant events.
+The Space pipeline proves the primitives exist, but it is not the right extension boundary: GitHub-specific normalization, dedup, PR-to-task resolution, and Task Agent injection are bundled together in `SpaceGitHubService`. The target design extracts source ingestion into adapters and moves dedup, task enrichment, and node delivery into the core event bus.
 
 ## Design Overview
 
@@ -22,21 +22,20 @@ External Event Sources (GitHub webhook, polling, future: Slack, CI)
        │
        ▼
 ┌─────────────────────┐
-│  EventIngestion     │  Normalize → validate → publish to EventBus
-│  (adapter per source│
+│  EventAdapter       │  Verify → normalize → publish to EventBus
+│  (extension/source) │
 └────────┬────────────┘
          │ publish(event) → hub.emit('space.externalEvent.published', { sessionId: 'global', event })
          ▼
 ┌─────────────────────┐
-│  EventBus           │  In-memory, backed by TypedHub. External topic is payload data.
-│  (singleton)        │  Fixed TypedHub-safe method; router trie matches event.topic.
+│  EventBus           │  Persistent dedup + task enrichment, backed by TypedHub.
+│  (singleton)        │  Fixed TypedHub-safe method; external topic is payload data.
 └────────┬────────────┘
          │
          ▼
 ┌─────────────────────┐
-│  EventRouter        │  Subscribes to all topics. Matches events to
-│  (per-runtime)      │  active node interests. Delivers via AgentMessageRouter
-│                     │  or injects directly into sessions.
+│  EventRouter        │  Subscribes to bus. Matches events to active
+│  (per-runtime)      │  node interests and injects directly into sessions.
 └─────────────────────┘
 ```
 
@@ -50,7 +49,8 @@ github/lsm/neokai/pull_request.review_submitted
 github/lsm/neokai/pull_request.comment_created
 github/lsm/neokai/pull_request.synchronize
 github/lsm/neokai/pull_request.closed
-github/lsm/neokai/issues.opened
+# Not emitted in v1 — mapEventType only handles pull_request variants;
+# issues.* requires a future adapter extension: github/lsm/neokai/issues.opened
 # Future CI adapter (Phase 3): github/lsm/neokai/check_suite.completed
 github/lsm/neokai/pull_request.*            ← wildcard: all PR events for this repo
 github/lsm/neokai/*.*                       ← wildcard: all events for this repo
@@ -180,11 +180,11 @@ export interface WorkflowNodeAgent {
 
 ### Scoping details
 
-**`task` scope** is the critical innovation. The router resolves the task's context at match time:
+**`task` scope** is the critical innovation. Task association is resolved before delivery by the core `EventTaskResolver`:
 
-1. The task's `SpaceTask` record has `workflowRunId` and (via `space_workflow_run_artifacts` where `key = 'pr_url'` matches the event's `prUrl`, or gate data with `branch_name`) an associated PR number and branch name.
-2. The router queries the same `SpacePrTaskResolver` that `SpaceGitHubService` already uses to match PR numbers to tasks.
-3. For a `task`-scoped subscription, the router checks: does this event's PR number / branch match the node execution's parent task?
+1. The task's `SpaceTask` record has `workflowRunId` and (via workflow artifacts or gate data) an associated PR number, PR URL, or branch name.
+2. `EventTaskResolver` enriches matching events with `routedTaskId` using source-normalized metadata such as GitHub PR URL/number/branch.
+3. For a `task`-scoped subscription, the router checks whether `event.routedTaskId === sub.taskId`.
 4. The node author never specifies a PR number — it's implicit from the task context.
 
 **`repo` scope** filters to events from any of the space's watched repositories (`space_github_watched_repos`). The node author doesn't need to know repo names.
@@ -195,16 +195,25 @@ export interface WorkflowNodeAgent {
 
 When an event arrives, the router:
 
-1. Verifies `event.spaceId` matches the subscription's `spaceId`, then extracts `prNumber` and `repoOwner/repoName` from the event payload.
+1. Verifies `event.spaceId` matches the subscription's `spaceId`, then uses normalized event fields (`repoOwner/repoName`, `routedTaskId`, etc.) for scope checks.
 2. For each active node execution with `eventInterests`:
    a. Compiles the interest's `topic` glob against the event's topic.
    b. If matched, checks scope:
-      - `task`: resolves `SpaceTask` → `SpacePrTaskResolver` → does event's PR match this task?
+      - `task`: checks the `EventTaskResolver` enrichment (`event.routedTaskId`) against this subscription's task.
       - `repo`: does event's repo match any watched repo in the node's space?
       - `global`: pass.
    c. If scope check passes, the event is queued for delivery to this node's agent session.
 
 ## 3. EventIngestion Adapter Interface
+
+External sources are modeled as **extensions**. An adapter owns the source-specific work:
+
+1. Receive events from its source (webhook, polling, streaming API, etc.).
+2. Verify source-specific authenticity (e.g. GitHub HMAC signatures).
+3. Normalize raw source payloads into `ExternalEvent`.
+4. Publish directly to the EventBus.
+
+Adapters do **not** resolve Space tasks, inspect workflow nodes, or inject into agent sessions. Those are core daemon responsibilities handled by bus-level services and the `EventRouter`. This keeps GitHub, Slack, CI, and future integrations pluggable without adding source-specific paths to the workflow runtime.
 
 ```typescript
 // packages/daemon/src/lib/space/runtime/event-bus/types.ts
@@ -213,52 +222,57 @@ When an event arrives, the router:
  * A normalized external event on the bus.
  */
 export interface ExternalEvent {
-  /** Unique event ID (UUID) */
+  /** Unique event ID (UUID) assigned by the adapter for this bus publication. */
   id: string;
-  /** Space this event was routed for. Required to prevent cross-space delivery. */
+  /** Space this event belongs to. Required to prevent cross-space delivery. */
   spaceId: string;
   /** Fully qualified topic: 'github/owner/repo/resource.action' */
   topic: string;
-  /** Timestamp when the event occurred (epoch ms) */
+  /** Timestamp when the event occurred at the source (epoch ms). */
   occurredAt: number;
-  /** Timestamp when the event was ingested (epoch ms) */
+  /** Timestamp when the event was accepted by the adapter (epoch ms). */
   ingestedAt: number;
-  /** Source adapter identifier */
+  /** Source adapter identifier. */
   source: string;
-  /**
-   * For scope resolution. Not all events have a PR number;
-   * absence means 'task'-scoped subscriptions won't match.
-   */
+  /** Optional source-native event id/delivery id for diagnostics. */
+  sourceEventId?: string;
+  /** Optional PR number used by core task resolution. */
   prNumber?: number;
-  /** Repository owner (lowercase) */
+  /** Repository owner (lowercase) for repo-scoped matching. */
   repoOwner?: string;
-  /** Repository name (lowercase) */
+  /** Repository name (lowercase) for repo-scoped matching. */
   repoName?: string;
-  /** Branch name, if available */
+  /** Branch name, if available. */
   branch?: string;
-  /** Human-readable summary for agent consumption */
+  /** Human-readable summary for agent consumption. */
   summary: string;
-  /** External URL (e.g. GitHub PR link) */
+  /** External URL (e.g. GitHub PR link). */
   externalUrl?: string;
-  /** Structured payload — adapter-specific, not constrained */
+  /** Structured source payload — adapter-specific, not constrained. */
   payload: Record<string, unknown>;
   /**
-   * Deduplication key. The bus tracks delivered events by (eventId, nodeId)
-   * to prevent double delivery.
+   * Stable source-level identity used by bus dedup. Must be stable across
+   * webhook and polling observations of the same external event.
    */
   dedupeKey: string;
+  /**
+   * Core enrichment filled by EventTaskResolver after publication.
+   * Adapters should leave this unset unless the source itself has a trusted
+   * first-party task id.
+   */
+  routedTaskId?: string;
 }
 
 /**
- * Interface that event source adapters must implement.
+ * Interface that event source extensions must implement.
  */
 export interface EventAdapter {
-  /** Adapter identifier (used in topic namespace: '{source}/...') */
+  /** Adapter identifier (used in topic namespace: '{source}/...'). */
   readonly sourceId: string;
 
   /**
    * Start the adapter. Called once at daemon startup.
-   * The adapter calls `publisher.publish(event)` whenever it has an event.
+   * The adapter calls `publisher.publish(event)` whenever it accepts an event.
    */
   start(publisher: EventPublisher): Promise<void>;
 
@@ -267,10 +281,38 @@ export interface EventAdapter {
 }
 
 /**
+ * Optional interface for adapters that expose HTTP endpoints.
+ * The daemon routes matching requests to the adapter without knowing source
+ * internals such as HMAC verification, event names, or raw payload shape.
+ */
+export interface HttpEventAdapter extends EventAdapter {
+  readonly routes: readonly {
+    method: 'GET' | 'POST' | 'PUT' | 'DELETE';
+    path: string;
+    handle(req: Request, publisher: EventPublisher): Promise<Response>;
+  }[];
+}
+
+/**
+ * Optional interface for adapters that expose daemon RPC methods.
+ * GitHub uses this for watch/list/poll operations; future adapters can expose
+ * source-specific configuration without adding core RPC handler dependencies.
+ */
+export interface RpcEventAdapter extends EventAdapter {
+  registerRpcHandlers(hub: MessageHub, publisher: EventPublisher): void;
+}
+
+/**
  * Callback adapters use to publish events onto the bus.
  */
 export interface EventPublisher {
-  publish(event: ExternalEvent): Promise<void>;
+  publish(event: ExternalEvent): Promise<PublishResult>;
+}
+
+export interface PublishResult {
+  eventId: string;
+  duplicate: boolean;
+  state: 'published' | 'duplicate_terminal' | 'retryable_duplicate' | 'ignored';
 }
 
 /**
@@ -297,88 +339,112 @@ The `sessionId: 'global'` field is required because EventBus is backed by TypedH
 
 ```typescript
 class EventBus implements EventPublisher {
-  async publish(event: ExternalEvent): Promise<void> {
+  constructor(
+    private readonly hub: DaemonHub,
+    private readonly eventStore: ExternalEventStore,
+    private readonly taskResolver: EventTaskResolver,
+  ) {}
+
+  async publish(event: ExternalEvent): Promise<PublishResult> {
+    // 1. Validate topic and required source fields.
+    validateExternalEvent(event);
+
+    // 2. Store and dedupe before emission. Unlike SpaceGitHubService.ingest(),
+    // retryable duplicates are not swallowed: if the prior delivery state is
+    // non-terminal, the event is re-emitted so delivery can retry.
+    const stored = this.eventStore.store(event);
+    if (stored.duplicate && stored.terminal) {
+      return { eventId: stored.event.id, duplicate: true, state: 'duplicate_terminal' };
+    }
+
+    // 3. Core enrichment. For GitHub PR events this resolves PR -> SpaceTask.
+    // Adapters do not query workflow/task/gate tables directly.
+    const enriched = await this.taskResolver.enrich(stored.event);
+
     await this.hub.emit(EXTERNAL_EVENT_PUBLISHED_METHOD, {
       sessionId: 'global',
-      spaceId: event.spaceId,
-      event,
+      spaceId: enriched.spaceId,
+      event: enriched,
     });
+
+    return {
+      eventId: enriched.id,
+      duplicate: stored.duplicate,
+      state: stored.duplicate ? 'retryable_duplicate' : 'published',
+    };
   }
 }
 ```
 
-### GitHub adapter
+### Bus-level middleware/services
 
-The GitHub adapter wraps the existing `SpaceGitHubService.ingest()` pipeline. Rather than duplicating normalization logic, the adapter hooks into the point where `SpaceGitHubService` has already normalized and resolved the event:
+The EventBus owns cross-cutting behavior that applies to every adapter:
+
+1. **Validation** — all topics must satisfy the four-segment topic contract before publication.
+2. **Source-level dedup** — a persistent `ExternalEventStore` tracks `(spaceId, source, dedupeKey)` and delivery state. Terminal duplicates (`delivered`, `ignored`, `ambiguous`) are short-circuited; retryable states (`published`, `routed`, `delivery_failed`) are re-emitted so delivery can retry.
+3. **Task enrichment** — `EventTaskResolver` enriches events with `routedTaskId` for task-scoped matching. For GitHub PR events, it uses PR URL/number/branch fields that were normalized by the adapter. For future Slack/CI events, source-specific resolver plugins can be registered without changing adapters.
+4. **Publication** — only enriched, deduped events are emitted on `space.externalEvent.published`.
+
+This replaces the current GitHub-specific `SpaceGitHubService.ingest()` hot path for new event delivery. In particular, the bus-level dedup store must not use unconditional `INSERT OR IGNORE` short-circuiting for retryable states; otherwise transient delivery failures become permanent event loss.
+
+### GitHub adapter as an extension
+
+The GitHub adapter is a primary source adapter, not a downstream listener on `SpaceGitHubService`:
 
 ```typescript
-class GitHubEventAdapter implements EventAdapter {
+class GitHubEventAdapter implements HttpEventAdapter, RpcEventAdapter {
   readonly sourceId = 'github';
+  readonly routes = [
+    { method: 'POST', path: '/webhook/github/space', handle: this.handleWebhook.bind(this) },
+  ] as const;
 
   constructor(
-    private readonly spaceGitHubService: SpaceGitHubService,
-    private readonly watchedRepoLookup: (owner: string, repo: string) => { spaceId: string }[]
+    private readonly repo: GitHubEventAdapterRepository,
+    private readonly githubToken?: string,
   ) {}
 
   async start(publisher: EventPublisher): Promise<void> {
-    // Hook into SpaceGitHubService by intercepting the post-normalization path.
-    // SpaceGitHubService already:
-    //   1. Normalizes the webhook/polling event
-    //   2. Deduplicates via dedupeKey
-    //   3. Resolves PR → taskId via SpacePrTaskResolver
-    //   4. Emits DaemonHub 'space.githubEvent.routed'
-    //
-    // The adapter subscribes to 'space.githubEvent.routed' on DaemonHub
-    // and converts the event to an ExternalEvent for the bus.
-    //
-    // This means:
-    //   - No change to existing webhook/polling normalization
-    //   - Events continue flowing to Task Agent as before
-    //   - Additionally, events appear on the EventBus for node delivery
+    this.publisher = publisher;
+    this.pollTimer = setInterval(() => void this.pollOnce(), GITHUB_POLL_INTERVAL_MS);
+  }
+
+  async stop(): Promise<void> {
+    if (this.pollTimer) clearInterval(this.pollTimer);
+  }
+
+  registerRpcHandlers(hub: MessageHub, publisher: EventPublisher): void {
+    hub.onRequest('space.github.watchRepo', async (data) => this.watchRepo(data));
+    hub.onRequest('space.github.listWatchedRepos', async (data) => this.listWatchedRepos(data));
+    hub.onRequest('space.github.pollOnce', async () => ({ count: await this.pollOnce() }));
+  }
+
+  private async handleWebhook(req: Request, publisher: EventPublisher): Promise<Response> {
+    const raw = await req.text();
+    const verifiedRepos = this.verifySignatureAgainstWatchedRepos(req, raw);
+    const normalized = normalizeGitHubWebhook(req.headers, JSON.parse(raw));
+    if (!normalized) return Response.json({ ignored: true });
+
+    for (const watched of verifiedRepos) {
+      await publisher.publish(toExternalEvent(watched.spaceId, normalized));
+    }
+
+    return Response.json({ message: 'Webhook received' });
+  }
+
+  async pollOnce(fetchImpl: typeof fetch = fetch): Promise<number> {
+    // Poll GitHub endpoints, normalize rows, and publish ExternalEvent directly.
+    // No SpaceTask lookup and no session injection happen here.
   }
 }
 ```
 
-The adapter subscribes to the existing `space.githubEvent.routed` DaemonHub event (already emitted by `SpaceGitHubService.appendTaskActivity`). It converts the event to `ExternalEvent` format and publishes to the bus.
+The normalization helpers currently living in `space-github.ts` move into this adapter module:
 
-**Note — normalized field gap:** The current `space.githubEvent.routed` payload emitted by `appendTaskActivity` only includes `{ repo, prNumber, eventType, summary, externalUrl }`. It does NOT include the stable dedupe identifiers or the full normalized GitHub fields needed for topic construction and fallback task resolution.
+- `normalizeSpaceGitHubWebhook(...)` → `normalizeGitHubWebhook(...)`
+- `normalizePollingRow(...)` → `normalizeGitHubPollingRow(...)`
+- `mapEventType(...)` stays with the adapter because topic construction is source-specific
 
-**Fix:** Extend the `appendTaskActivity` payload in `SpaceGitHubService` to include the normalized fields consumed by the adapter:
-
-```typescript
-// In space-github.ts, appendTaskActivity():
-this.daemonHub?.emit('space.githubEvent.routed', {
-    sessionId: 'global',
-    spaceId,
-    taskId,
-    event: {
-        repo: `${event.repoOwner}/${event.repoName}`,
-        prNumber: event.prNumber,
-        eventType: event.eventType,
-        action: event.action,
-        source: event.source,
-        summary: event.summary,
-        prUrl: event.prUrl,
-        externalUrl: event.externalUrl,
-        externalId: event.externalId,
-        actor: event.actor,
-        body: event.body,
-        occurredAt: event.occurredAt,
-        rawPayload: event.rawPayload,
-        dedupeKey: event.dedupeKey,
-        deliveryId: event.deliveryId,
-    },
-});
-```
-
-This is a payload-contract extension to `appendTaskActivity` using fields already available on the `NormalizedSpaceGitHubEvent` at the call site plus the enclosing `spaceId`. `dedupeKey` and `deliveryId` are required for stable upstream event identity; `prUrl` and the other normalized fields keep the `SpacePrTaskResolver` fallback functional if `taskId` is absent; `spaceId` prevents cross-space delivery on the shared daemon event stream.
-
-**Why this approach:**
-- Minimal change to the existing `SpaceGitHubService` — additional normalized fields in an existing DaemonHub emission, with no changes to ingestion/dedup/routing behavior.
-- The existing PR-to-task resolution (`SpacePrTaskResolver`) continues to work.
-- The existing Task Agent injection continues to work (we don't replace it, we supplement it).
-- The adapter is purely additive: it converts an already-normalized event into bus format.
-- `rawPayload` is included so adapter consumers (and future adapters) have access to the full original event data without re-fetching from GitHub.
+The adapter may keep source-local tables such as `space_github_watched_repos` and an optional adapter event log for diagnostics, but the authoritative cross-source event lifecycle belongs to the EventBus store.
 
 ## 4. EventRouter Design
 
@@ -442,6 +508,10 @@ interface PendingDelivery {
   event: ExternalEvent;
   deliveryKey: string;
 }
+
+interface WatchedRepoLookup {
+  listWatchedRepos(spaceId: string): { owner: string; repo: string; enabled: boolean }[];
+}
 ```
 
 ### EventRouter implementation sketch
@@ -468,9 +538,8 @@ class EventRouter {
   private static readonly MAX_RETRIES = 3;
   private static readonly RETRY_BACKOFF_MS = 1000; // 1s base, exponential backoff
 
-  // Cache: spaceId → Set of "owner/repo" strings for watched repos
-  // Invalidated via invalidateWatchedRepoCache() when repos are added/removed
-  // through the `space.github.watchRepo` RPC path.
+  // Cache: spaceId → Set of "owner/repo" strings for watched repos.
+  // Invalidated when a source adapter reports watched-repo configuration changes.
   private watchedRepoCache: Map<string, Set<string>> = new Map();
 
   constructor(
@@ -479,8 +548,7 @@ class EventRouter {
     private readonly taskRepo: SpaceTaskRepository,
     private readonly spaceTaskManager: SpaceTaskManager,
     private readonly sessionFactory: SessionFactory,
-    private readonly prResolver: SpacePrTaskResolver,
-    private readonly spaceGitHubRepo: SpaceGitHubRepository,
+    private readonly watchedRepoLookup: WatchedRepoLookup,
   ) {
     // Subscribe to the fixed TypedHub-safe method. External topic matching happens
     // inside handleEvent via event.topic, not via the hub method name.
@@ -502,7 +570,7 @@ class EventRouter {
   private isWatchedRepo(spaceId: string, owner: string, repo: string): boolean {
     let cached = this.watchedRepoCache.get(spaceId);
     if (!cached) {
-      const repos = this.spaceGitHubRepo.listWatchedRepos(spaceId);
+      const repos = this.watchedRepoLookup.listWatchedRepos(spaceId);
       cached = new Set(
         repos.filter(r => r.enabled).map(r => `${r.owner.toLowerCase()}/${r.repo.toLowerCase()}`)
       );
@@ -760,25 +828,23 @@ class EventRouter {
     const dedupeKey = this.makeDeliveryKey(event, sub);
     if (this.delivered.has(dedupeKey)) return;
 
-<<<<<<< HEAD
     // Check if pending (prevents duplicate queueing while allowing retries on failure)
     if (this.pendingDeliveries.has(dedupeKey)) return;
 
-    // Mark as pending to prevent duplicate queueing. Unlike the previous design,
-    // we do NOT mark as delivered until after successful injection. This allows
-    // retrying failed injections without waiting for dedup TTL expiry.
-    // Note: The upstream SpaceGitHubService.ingest() short-circuits duplicates
-    // via storeEvent(), so re-polling does NOT generate a fresh event that
-    // reaches the event bus. Therefore, we must handle retries here.
+    // Mark as pending to prevent duplicate queueing. We do NOT mark as delivered
+    // until after successful injection. Failed injection/session-resolution paths
+    // clear pending and schedule router-level retry rather than relying on a source
+    // adapter to publish the same event again.
     this.pendingDeliveries.add(dedupeKey);
 
     try {
       // Resolve session — re-read from nodeExecutionRepo for latest state
       const sessionId = await this.resolveSession(sub);
       if (!sessionId) {
-        // Session not active — queue for later delivery
-        this.queueForDelivery(event, sub);
-        return; // Pending remains until queue is drained
+        // Session not active — queue for later delivery. Pending remains until
+        // the queue is drained or the entry is evicted.
+        this.queueForDelivery(event, sub, dedupeKey);
+        return;
       }
 
       // Format and inject.
@@ -805,40 +871,10 @@ class EventRouter {
       }
     } catch (err) {
       // Session resolution failed (transient DB/repo error) — clear pending
-      // so this event can be retried. Also schedule retry because
-      // upstream SpaceGitHubService.ingest() short-circuits duplicates.
+      // and schedule retry so transient failures do not permanently drop delivery.
       log.warn(`Session resolution failed for ${sub.agentName}`, { error: err });
       this.pendingDeliveries.delete(dedupeKey);
       this.scheduleRetry(event, sub, dedupeKey);
-=======
-    // Resolve session — re-read from nodeExecutionRepo for latest state
-    const sessionId = await this.resolveSession(sub);
-    if (!sessionId) {
-      // Session not active — queue for later delivery. Mark dedup only after the
-      // event is safely queued; the pending entry carries the same delivery key
-      // and the key is cleared if the eventual flush/injection fails.
-      this.queueForDelivery(event, sub, dedupeKey);
-      this.delivered.set(dedupeKey, Date.now());
-      return;
-    }
-
-    // Format and inject.
-    // Do NOT mark delivered before injectMessage succeeds: SpaceGitHubService
-    // suppresses repeat routing for the same upstream dedupeKey, so pre-marking
-    // would permanently lose the event for this subscription after transient
-    // injection failures or session teardown races.
-    const message = this.formatEventMessage(event);
-    try {
-      await this.sessionFactory.injectMessage(sessionId, message, {
-        deliveryMode: 'defer',
-      });
-      this.delivered.set(dedupeKey, Date.now());
-    } catch (err) {
-      log.warn(`Failed to deliver event to ${sub.agentName}; leaving undelivered for retry`, { error: err });
-      // Leave the dedupe key unset so a retry path (for example a re-emitted bus
-      // event or pending queue flush retry) can attempt delivery again.
-      throw err;
->>>>>>> f60b5780a (Address review: close passesScopeCheck before scheduleRetry, fix restart claim, mark issues.opened out-of-scope)
     }
   }
 
@@ -847,15 +883,8 @@ class EventRouter {
     const queue = this.pendingQueue.get(key) ?? [];
     queue.push({ event, deliveryKey });
     if (queue.length > 50) {
-<<<<<<< HEAD
-      const evicted = queue.shift()!;
-      // Clear pending marker for evicted event so it can be re-queued if needed
-      const evictedKey = this.makeDeliveryKey(evicted, sub);
-      this.pendingDeliveries.delete(evictedKey);
-=======
       const dropped = queue.shift();
-      if (dropped) this.delivered.delete(dropped.deliveryKey);
->>>>>>> f60b5780a (Address review: close passesScopeCheck before scheduleRetry, fix restart claim, mark issues.opened out-of-scope)
+      if (dropped) this.pendingDeliveries.delete(dropped.deliveryKey);
       log.warn('EventRouter: pending external event queue exceeded limit; dropped oldest event', {
         workflowRunId: sub.workflowRunId,
         taskId: sub.taskId,
@@ -875,13 +904,13 @@ class EventRouter {
     const queue = this.pendingQueue.get(key) ?? [];
     this.pendingQueue.delete(key);
 
-    // Clear pendingDeliveries for ALL events in the drained queue
-    for (const event of queue) {
-      const eventKey = this.makeDeliveryKey(event, sub);
-      this.pendingDeliveries.delete(eventKey);
+    // Clear pendingDeliveries for ALL events in the drained queue. Use the queued
+    // wrapper's stored deliveryKey instead of recomputing from the wrapper object.
+    for (const pending of queue) {
+      this.pendingDeliveries.delete(pending.deliveryKey);
     }
 
-    return queue;
+    return queue.map((pending) => pending.event);
   }
 
   private passesScopeCheck(event: ExternalEvent, sub: Subscription): boolean {
@@ -896,57 +925,24 @@ class EventRouter {
 
       case 'repo': {
         // Check if event's repo matches any watched repo in this space.
-        // Uses SpaceGitHubRepository.getEnabledRepos(owner, repo) which queries
-        // the `space_github_watched_repos` table filtered by (spaceId, owner, repo, enabled=1).
-        // The router caches this per-space to avoid DB hits on every event.
+        // Uses an adapter-provided watched-repo lookup filtered by
+        // (spaceId, owner, repo, enabled=true). The router caches this per-space
+        // to avoid DB hits on every event.
         if (!event.repoOwner || !event.repoName) return false;
         return this.isWatchedRepo(sub.spaceId, event.repoOwner, event.repoName);
       }
 
       case 'task': {
-        // The DaemonHub 'space.githubEvent.routed' event already carries the
-        // resolved taskId from SpacePrTaskResolver. We use that directly instead
-        // of re-running the resolver, which could match a historical task outside
-        // this run (SpacePrTaskResolver searches ALL tasks in the space).
-        //
-        // We constrain matching to the subscription's OWN task, not merely any
-        // task in the same workflow run. This prevents cross-task leakage in
-        // multi-task runs (e.g., two PR tasks sharing a workflowRunId).
-        if (!event.prNumber) return false;
-
-        // Optimization: the adapter includes the routed taskId in ExternalEvent.payload.
-        // Use it for a direct equality check against this subscription's task.
-        const routedTaskId = event.payload?.taskId as string | undefined;
-        if (routedTaskId) {
-          return routedTaskId === sub.taskId;
-        }
-
-        // Fallback (should rarely happen): if the adapter didn't include taskId,
-        // resolve with the full normalized GitHub shape. SpacePrTaskResolver's
-        // primary queries use prUrl, so passing only owner/repo/prNumber would
-        // make this fallback ineffective for older routed payloads.
-        if (event.source !== 'github') return false;
-        const resolved = this.prResolver.resolve(sub.spaceId, {
-          deliveryId: event.payload?.deliveryId as string | undefined,
-          dedupeKey: event.dedupeKey,
-          source: 'webhook',
-          eventType: event.payload?.eventType as string,
-          action: event.payload?.action as string,
-          repoOwner: event.repoOwner ?? '',
-          repoName: event.repoName ?? '',
-          prNumber: event.prNumber,
-          prUrl: (event.payload?.prUrl as string | undefined) ?? event.externalUrl,
-          actor: event.payload?.actor as string | undefined,
-          body: event.payload?.body as string | undefined,
-          summary: event.summary,
-          externalUrl: event.externalUrl,
-          externalId: event.payload?.externalId as string | undefined,
-          occurredAt: (event.payload?.occurredAt as string | undefined) ?? new Date(event.occurredAt).toISOString(),
-          rawPayload: event.payload?.rawPayload,
-        } as NormalizedSpaceGitHubEvent);
-        return resolved.taskId === sub.taskId;
+        // EventTaskResolver enriches matching events before publication. The
+        // router uses that trusted enrichment directly and never performs broad
+        // PR/task scans during delivery. This prevents cross-task leakage in
+        // multi-task runs and keeps task/gate/workflow schema access out of
+        // source adapters and delivery hot paths.
+        return event.routedTaskId === sub.taskId;
       }
     }
+  }
+
   /**
    * Schedule a retry for failed delivery with exponential backoff.
    * Retries are bounded by MAX_RETRIES; after that, the event is dropped.
@@ -987,7 +983,6 @@ class EventRouter {
         });
     }, backoff);
   }
-  }
 }
 ```
 
@@ -1014,11 +1009,20 @@ Event arrives → Match subscriptions → Scope check → Dedup check → Sessio
 
 ### Deduplication
 
-- **Key**: JSON tuple `[event.dedupeKey, subscription.taskId, subscription.nodeId, subscription.agentName, subscription.workflowRunId]` — includes `taskId` to isolate multi-task runs and `nodeId` to handle cases where the same agent name appears in multiple nodes within the same run. The tuple is encoded structurally rather than delimiter-joined because `dedupeKey`, workflow identifiers, node IDs, and agent names are free-form strings.
-- **Storage**: In-memory `Map<string, number>` (timestamp). Evicted when the workflow run completes.
-- **Guarantee**: Same external event is never delivered twice to the same node agent within a run after successful injection or durable in-memory queueing.
-- **Retry behavior**: Live/idle session injection marks the key only after `injectMessage` succeeds. If injection throws, the key remains unset so the subscription can be retried; this is required because upstream `SpaceGitHubService.storeEvent` suppresses duplicate upstream dedupe keys and will not necessarily re-route the same event.
-- The upstream `SpaceGitHubService` already deduplicates by `(spaceId, dedupeKey)` — this is an additional per-node dedup.
+Dedup happens at two different layers, each with a different key and responsibility:
+
+1. **Source-level bus dedup** — persistent `(spaceId, source, dedupeKey)` in `ExternalEventStore`.
+   - Purpose: prevent webhook/polling duplicates from becoming separate bus events.
+   - Terminal duplicates (`delivered`, `ignored`, `ambiguous`) are short-circuited.
+   - Retryable duplicates (`published`, `routed`, `delivery_failed`) are re-emitted so transient delivery failures can retry.
+   - This replaces `SpaceGitHubService.storeEvent()` as the authoritative dedup path for new external-event delivery.
+
+2. **Per-subscription delivery dedup** — in-memory JSON tuple `[event.dedupeKey, subscription.taskId, subscription.nodeId, subscription.agentName, subscription.workflowRunId]`.
+   - Purpose: prevent the same external event from being delivered twice to the same node agent within a run.
+   - The tuple includes `taskId` to isolate multi-task runs and `nodeId` to handle cases where the same agent name appears in multiple nodes within the same run.
+   - The tuple is encoded structurally rather than delimiter-joined because `dedupeKey`, workflow identifiers, node IDs, and agent names are free-form strings.
+
+The EventRouter marks per-subscription delivery as `delivered` only after successful injection. Failed injection/session-resolution paths remove `pendingDeliveries` and schedule retry rather than relying on adapters to re-publish the same event.
 
 ### Wake-on-idle
 
@@ -1037,12 +1041,12 @@ When a node execution is `pending` (no session yet):
 3. Queued events are injected as initial context in the session's first turn.
 4. Queue is bounded: max 50 events per execution, oldest dropped (with a warning log).
 
-**Known limitation — daemon restart**: The in-memory pending queue is lost on daemon restart. For v1, this is acceptable because:
-- Events between daemon restarts are also lost (the webhook/polling pipeline itself doesn't guarantee delivery during downtime).
-- The existing `SpaceGitHubService` polling service re-polls on startup, so events that arrived during downtime are re-normalized and re-routed.
-- For nodes that are still `pending` after restart, the next poll cycle will generate fresh events that flow through the bus.
+**Known limitation — daemon restart**: The in-memory per-node pending queue is lost on daemon restart. For v1, this is accepted as a known delivery gap:
+- The bus-level `ExternalEventStore` preserves the source event and can re-emit retryable states, but the per-node in-memory queue itself is not durable.
+- Events queued for `pending` nodes before restart may need explicit replay from the event store once persistent delivery queues are implemented.
+- New events (arriving after restart) flow through the bus normally and are not affected.
 
-If persistent queuing is needed in a future iteration, events can be persisted to a `space_event_delivery_queue` SQLite table with the same schema as the in-memory map, and drained on node activation.
+If persistent queuing is needed in a future iteration, events can be persisted to a `space_event_delivery_queue` SQLite table with the same schema as the in-memory map, and drained on node activation. The table should store the `ExternalEvent.id` plus the subscription key so queued delivery can replay from `ExternalEventStore` without relying on source adapters to re-publish.
 
 ### Backpressure
 
@@ -1210,81 +1214,45 @@ function isReceivingStatus(status: NodeExecutionStatus): boolean {
 
 ## 7. Wiring the GitHub Adapter
 
+### Target architecture
+
+The GitHub integration is extracted into a first-class event adapter. It no longer depends on `SpaceGitHubService.ingest()`, `space.githubEvent.routed`, or Task Agent notification delivery.
+
+```
+GitHub webhook / polling
+    → GitHubEventAdapter
+        → verify signature / fetch API pages
+        → normalize raw GitHub payload
+        → construct topic + dedupeKey
+        → EventBus.publish(ExternalEvent)
+            → ExternalEventStore.store() + retry-aware dedup
+            → EventTaskResolver.enrich()   // PR → SpaceTask when possible
+            → DaemonHub.emit('space.externalEvent.published', { event })
+                → EventRouter.deliverToSubscription()
+                    → sessionFactory.injectMessage(..., { deliveryMode: 'defer' })
+```
+
+There is no intermediate `space.githubEvent.routed` payload contract. The adapter publishes the full normalized event directly to the bus, and the bus owns task enrichment and delivery state.
+
 ### Changes to existing code
 
-**Routed payload contract extension.** The `appendTaskActivity` method in `space-github.ts` must include the normalized fields consumed by the adapter in the `space.githubEvent.routed` DaemonHub payload, including `action`, `source`, `prUrl`, `externalId`, `actor`, `body`, `occurredAt`, `rawPayload`, `dedupeKey`, and `deliveryId`. The adapter requires `dedupeKey` as the stable upstream event identity for per-subscription deduplication, `deliveryId` preserves the unique GitHub delivery identifier used to build that identity, and `prUrl` keeps the `SpacePrTaskResolver` fallback functional. This is the only change to existing code. All other existing behavior (webhook handling, polling, normalization, Task Agent injection) remains unchanged.
+**Extract source-specific GitHub code from `SpaceGitHubService`:**
 
-```
-SpaceGitHubService.handleWebhook()
-    → normalizeSpaceGitHubWebhook()
-    → ingest(spaceId, normalized)
-        → storeEvent() + dedupe
-        → SpacePrTaskResolver.resolve()
-        → appendTaskActivity()
-            → DaemonHub.emit('space.githubEvent.routed', { taskId, event })
-        → scheduleTaskNotification()
-            → injectTaskAgent(taskId, message)
-```
+- Move webhook normalization (`normalizeSpaceGitHubWebhook`) into `github-adapter.ts`.
+- Move polling normalization (`normalizePollingRow`) into `github-adapter.ts`.
+- Move watched-repo configuration access into `GitHubEventAdapterRepository` or keep the existing `space_github_watched_repos` table behind that repository.
+- Move `space.github.watchRepo`, `space.github.listWatchedRepos`, and `space.github.pollOnce` registration behind `RpcEventAdapter.registerRpcHandlers(...)`.
+- Register `/webhook/github/space` through the adapter route registry rather than hard-coding a direct call to `spaceGitHubService.handleWebhook(req)` in `app.ts`.
 
-The GitHub adapter subscribes to `space.githubEvent.routed` and converts it:
+**Do not extend `appendTaskActivity`:** the old plan proposed adding normalized fields to `space.githubEvent.routed`. That is no longer needed because the GitHub adapter publishes `ExternalEvent` directly and no longer treats `SpaceGitHubService` as an upstream source.
 
-```typescript
-// No changes to SpaceGitHubService.
-// The adapter is a new subscriber:
+**Deprecate direct Task Agent injection:** the old `scheduleTaskNotification()` / `flushTaskNotification()` path remains only as a compatibility shim during migration. New node-level delivery goes through `EventRouter`. Once workflows rely on `eventInterests`, the Task Agent relay can be removed.
 
-class GitHubEventAdapter implements EventAdapter {
-  async start(publisher: EventPublisher): Promise<void> {
-    this.daemonHub.on('space.githubEvent.routed', async (data) => {
-      const { event, spaceId, taskId } = data;
-      const [repoOwner, repoName] = event.repo.split('/');
+### GitHub adapter topic construction
 
-      // Construct topic from event.
-      // mapEventType returns the full resource.action string and preserves the
-      // original GitHub action so users can filter created/edited/deleted/etc.
-      const topic = `github/${repoOwner}/${repoName}/${mapEventType(event.eventType, event.action)}`;
+The GitHub adapter normalizes to GitHub event kinds (`issue_comment`, `pull_request_review`, `pull_request_review_comment`, `pull_request`) and maps them to bus topics:
 
-      // Publish to bus. Preserve the upstream occurrence time for ordering,
-      // queue TTL, and latency diagnostics; only ingestedAt is "now".
-      const externalEvent: ExternalEvent = {
-        id: crypto.randomUUID(),
-        spaceId,
-        topic,
-        occurredAt: new Date(event.occurredAt).getTime(),
-        ingestedAt: Date.now(),
-        source: 'github',
-        prNumber: event.prNumber,
-        repoOwner,
-        repoName,
-        summary: event.summary,
-        externalUrl: event.externalUrl,
-        payload: {
-          // Full normalized event for adapter consumers and resolver fallback
-          eventType: event.eventType,
-          action: event.action,
-          source: event.source,
-          taskId,
-          prUrl: event.prUrl,
-          deliveryId: event.deliveryId,
-          externalId: event.externalId,
-          actor: event.actor,
-          body: event.body,
-          occurredAt: event.occurredAt,
-          rawPayload: event.rawPayload,   // Include original webhook/polling payload
-        },
-        dedupeKey: event.dedupeKey,  // Use upstream identity (includes deliveryId); avoids collapsing distinct events that share repo/pr/action/url
-      };
-
-      await publisher.publish(externalEvent);
-    });
-  }
-}
-```
-
-### Event type mapping
-
-The `SpaceGitHubService` already normalizes to `SpaceGitHubEventKind` (`issue_comment`, `pull_request_review`, `pull_request_review_comment`, `pull_request`). We map these to bus topics:
-
-| SpaceGitHubEventKind | `mapEventType(kind, action)` returns |
+| GitHub normalized kind | `mapEventType(kind, action)` returns |
 |---|---|
 | `issue_comment` | `pull_request.comment_${action}` (PR comments only; created, edited, deleted) |
 | `pull_request_review` | `pull_request.review_${action}` (submitted, edited, dismissed) |
@@ -1294,37 +1262,104 @@ The `SpaceGitHubService` already normalizes to `SpaceGitHubEventKind` (`issue_co
 These return values are the complete fourth path segment (`resource.action`). For V1 PR events the resource side is always `pull_request`; `comment_*`, `review_*`, and `review_comment_*` are action names, not nested resource segments. The adapter must not emit doubled resource names such as `pull_request.review.review_submitted`.
 
 ```typescript
-function mapEventType(kind: string, action: string): string {
+function mapEventType(kind: string, action: string): string | null {
   switch (kind) {
     case 'issue_comment': return `pull_request.comment_${action}`;
     case 'pull_request_review': return `pull_request.review_${action}`;
     case 'pull_request_review_comment': return `pull_request.review_comment_${action}`;
     case 'pull_request': return `pull_request.${action}`;
-    default: return `${kind}.${action}`;
+    default: return null; // Non-PR GitHub topics are future adapter scope.
   }
 }
 ```
 
-### Task-scoped resolution optimization
+### ExternalEvent construction
 
-For `task` scope, we already have the `taskId` from `space.githubEvent.routed`. The router can short-circuit:
+```typescript
+function toExternalEvent(spaceId: string, event: NormalizedGitHubEvent): ExternalEvent {
+  const repoOwner = event.repoOwner.toLowerCase();
+  const repoName = event.repoName.toLowerCase();
+  const resourceAction = mapEventType(event.eventType, event.action);
+  if (!resourceAction) throw new Error(`Unsupported GitHub event type: ${event.eventType}`);
 
-1. Look up subscriptions whose `sub.taskId` equals the routed event `taskId` and whose `eventInterests` match the topic.
-2. Only deliver to those task-owned subscriptions — nodes attached to other tasks in the same workflow run do not pass `task` scope.
+  return {
+    id: crypto.randomUUID(),
+    spaceId,
+    topic: `github/${repoOwner}/${repoName}/${resourceAction}`,
+    occurredAt: event.occurredAt,
+    ingestedAt: Date.now(),
+    source: 'github',
+    sourceEventId: event.deliveryId,
+    prNumber: event.prNumber,
+    repoOwner,
+    repoName,
+    summary: event.summary,
+    externalUrl: event.externalUrl,
+    payload: {
+      eventType: event.eventType,
+      action: event.action,
+      source: event.source,
+      prUrl: event.prUrl,
+      deliveryId: event.deliveryId,
+      externalId: event.externalId,
+      actor: event.actor,
+      body: event.body,
+      rawPayload: event.rawPayload,
+    },
+    dedupeKey: event.dedupeKey,
+  };
+}
+```
 
-This optimization turns the common case (one coder node interested in review comments) into a direct map lookup: `taskId → subscriptions → filter by interest topic match`.
+### Task-scoped resolution
+
+For `task` scope, the adapter does not resolve a task. Instead, `EventTaskResolver` enriches PR events after bus dedup and before publication:
+
+1. If the event already has a trusted `routedTaskId`, use it directly.
+2. For GitHub PR events, resolve using normalized `prUrl`, `repoOwner/repoName`, `prNumber`, and optional `branch`.
+3. Store the result in `event.routedTaskId` and `event.payload.taskResolution` for diagnostics.
+4. EventRouter `task` scope checks `event.routedTaskId === sub.taskId` and does not re-run broad task scans during delivery.
+
+This removes duplicate PR→task resolution from the adapter and EventRouter hot paths while preserving the existing auto-scoping behavior.
 
 ## 8. Migration Path
 
 ### DB schema changes
 
-No new tables required for V1. Event interests are stored as part of the workflow definition JSON in `space_workflows.nodes[].agents[].eventInterests`. The existing JSON serialization of workflow nodes already supports arbitrary fields. Task-scoped delivery uses the current `SpaceTask.id` passed into `registerRunInterests(...)` by the runtime and the routed `taskId` already emitted by `space.githubEvent.routed`; no node-execution schema change is required.
+V1 needs one core event-store table plus workflow type additions:
+
+1. **Core bus event store** (`space_external_events`): persistent source-level event lifecycle for retry-aware dedup.
+
+   ```sql
+   CREATE TABLE space_external_events (
+     id TEXT PRIMARY KEY,
+     space_id TEXT NOT NULL,
+     source TEXT NOT NULL,
+     topic TEXT NOT NULL,
+     dedupe_key TEXT NOT NULL,
+     occurred_at INTEGER NOT NULL,
+     ingested_at INTEGER NOT NULL,
+     payload_json TEXT NOT NULL,
+     routed_task_id TEXT,
+     state TEXT NOT NULL DEFAULT 'published',
+     created_at INTEGER NOT NULL,
+     updated_at INTEGER NOT NULL,
+     UNIQUE(space_id, source, dedupe_key)
+   );
+   ```
+
+   `state` values are `published`, `routed`, `delivered`, `delivery_failed`, `ignored`, and `ambiguous`. Duplicate handling depends on state: terminal states short-circuit; retryable states can re-emit.
+
+2. **Adapter-owned GitHub configuration**: reuse or migrate the existing `space_github_watched_repos` table behind `GitHubEventAdapterRepository`. This table remains source-specific and should not be queried by EventRouter except through cache invalidation hooks for repo-scoped matching.
+
+3. **No node-execution schema change**: event interests are stored as part of the workflow definition JSON in `space_workflows.nodes[].agents[].eventInterests`.
 
 ### Type changes
 
 1. Add `EventInterest` interface to `packages/shared/src/types/space.ts`.
 2. Add `eventInterests?: EventInterest[]` to `WorkflowNodeAgent`.
-3. Add validation in the workflow create/update path (Zod schema or manual validation):
+3. Add `ExternalEvent`, `EventAdapter`, `HttpEventAdapter`, `RpcEventAdapter`, and `EventPublisher` types under `packages/daemon/src/lib/space/runtime/event-bus/`.
+4. Add validation in the workflow create/update path (Zod schema or manual validation):
    - `topic` must pass `validateGlobPattern()` (non-empty, exactly 4 segments, no `..` segments, no double slashes, valid characters including segment-local `*`).
    - `scope` must be one of `'task' | 'repo' | 'global'`.
    - Max 10 interests per agent slot (prevent abuse).
@@ -1334,13 +1369,20 @@ No new tables required for V1. Event interests are stored as part of the workflo
 
 ```
 packages/daemon/src/lib/space/runtime/event-bus/
-  ├── types.ts              # ExternalEvent, EventAdapter, EventPublisher interfaces
-  ├── event-bus.ts           # EventBus singleton (wraps TypedHub)
-  ├── topic-trie.ts          # TopicTrie<T> implementation
-  ├── topic-validator.ts     # validateGlobPattern() helper
-  ├── event-router.ts        # EventRouter — subscribes to bus, matches, delivers
-  ├── github-adapter.ts      # GitHubEventAdapter — bridges SpaceGitHubService → EventBus
-  └── index.ts               # Public exports
+  ├── types.ts                 # ExternalEvent, EventAdapter, EventPublisher interfaces
+  ├── event-bus.ts             # EventBus singleton (wraps TypedHub)
+  ├── event-store.ts           # Persistent retry-aware source-level dedup
+  ├── event-task-resolver.ts   # Core event -> SpaceTask enrichment
+  ├── topic-trie.ts            # TopicTrie<T> implementation
+  ├── topic-validator.ts       # validateGlobPattern() helper
+  ├── event-router.ts          # EventRouter — subscribes to bus, matches, delivers
+  └── index.ts                 # Public exports
+
+packages/daemon/src/lib/space/runtime/event-adapters/github/
+  ├── github-adapter.ts        # GitHubEventAdapter — webhook/polling -> EventBus
+  ├── github-normalizer.ts     # GitHub webhook/polling normalization helpers
+  ├── github-repository.ts     # watched repo config + adapter diagnostics
+  └── index.ts
 ```
 
 ### Topic pattern validation
@@ -1418,13 +1460,13 @@ export function validateGlobPattern(pattern: string): { valid: boolean; reason?:
 }
 ```
 
-### Wiring into SpaceRuntime
+### Wiring into SpaceRuntime and daemon startup
 
 ```typescript
 // In SpaceRuntimeConfig, add:
 interface SpaceRuntimeConfig {
   // ... existing fields ...
-  eventBus?: EventBus;  // Optional — created internally if not provided
+  eventRouter?: EventRouter;
 }
 
 // In SpaceRuntime.executeTick(), after node executions are resolved:
@@ -1445,37 +1487,44 @@ if (newStatus === 'done' || newStatus === 'cancelled') {
   this.eventRouter.clearRunInterests(workflowRunId);
 }
 
-// In the `space.github.watchRepo` RPC handler (packages/daemon/src/lib/rpc-handlers/index.ts):
-// After persisting the watch/unwatch change, invalidate the watched-repo cache
-// so that repo-scoped matching reflects the new state immediately.
-await this.eventRouter.invalidateWatchedRepoCache(spaceId);
-
-// In daemon startup (e.g. in SpaceRuntimeService or init function):
-const eventBus = new EventBus(daemonHub);
+// In daemon startup:
+const externalEventStore = new ExternalEventStore(db);
+const eventTaskResolver = new EventTaskResolver(db);
+const eventBus = new EventBus(daemonHub, externalEventStore, eventTaskResolver);
 const eventRouter = new EventRouter(eventBus, ...dependencies);
-const githubAdapter = new GitHubEventAdapter(daemonHub);
 
-await githubAdapter.start(eventBus);
+const adapters: EventAdapter[] = [
+  new GitHubEventAdapter(new GitHubEventAdapterRepository(db), process.env.GITHUB_TOKEN),
+];
+
+for (const adapter of adapters) {
+  if ('routes' in adapter) routeRegistry.register(adapter.routes, eventBus);
+  if ('registerRpcHandlers' in adapter) adapter.registerRpcHandlers(messageHub, eventBus);
+  await adapter.start(eventBus);
+}
 ```
+
+Repo-scoped matching still needs watched-repo cache invalidation. Instead of coupling the RPC handler to `EventRouter`, the GitHub adapter emits a source-config-changed event (or invokes a narrow callback) after watch/unwatch changes; the EventRouter invalidates only the affected space.
 
 ### Phased rollout
 
-**Phase 1 (MVP — this PR):**
+**Phase 1 (target MVP):**
 - Add `EventInterest` type to `WorkflowNodeAgent`.
-- Implement `EventBus`, `TopicTrie`, `EventRouter`, `GitHubEventAdapter`.
-- Wire GitHub adapter to existing `space.githubEvent.routed` events.
-- Deliver events to coder nodes with `task` scope.
+- Implement `EventBus`, `ExternalEventStore`, `EventTaskResolver`, `TopicTrie`, and `EventRouter`.
+- Extract `GitHubEventAdapter` as the primary GitHub event source (webhook + polling + normalization).
+- Route GitHub PR events directly through EventBus to node sessions with `task` scope.
+- Keep `SpaceGitHubService` only as a compatibility path while parity is verified.
 - No UI changes needed — event interests are authored in workflow JSON.
 
-**Phase 2 (follow-up):**
-- Add `eventInterests` editor to the workflow visual editor UI.
-- Add event delivery status to the task activity panel.
-- Add digest/coalescing for high-frequency events.
-- Add metrics: events matched, events delivered, delivery latency.
+**Phase 2 (compatibility removal):**
+- Remove direct Task Agent notification delivery from `SpaceGitHubService` (`scheduleTaskNotification` / `flushTaskNotification`).
+- Migrate remaining `space.github.*` RPC handling into `GitHubEventAdapter`.
+- Remove dependence on `space.githubEvent.routed` for external event delivery.
+- Add persistent per-node delivery queue if restart-safe pending-node delivery is required.
 
 **Phase 3 (future extensibility):**
 - Slack adapter: subscribe to Slack Events API, normalize to `ExternalEvent`, publish.
-- CI adapter: subscribe to GitHub Check Suite events, normalize, publish.
+- CI adapter: subscribe to GitHub Check Suite or other CI events, normalize, publish.
 - Custom adapter API: allow Space operators to register custom adapters via config.
 
 ## 9. Relationship to Existing Systems
@@ -1483,8 +1532,11 @@ await githubAdapter.start(eventBus);
 | Existing system | Relationship |
 |---|---|
 | **DaemonHub / TypedHub** | `EventBus` is a TypedHub participant on the shared `InProcessTransportBus`. It publishes all external events through the fixed valid method `space.externalEvent.published`; slash-delimited external topics stay in `ExternalEvent.topic` and are matched by the router trie. |
-| **GitHubService** (Room pipeline) | Unchanged. Continues routing to Rooms. The event bus is additive. |
-| **SpaceGitHubService** (Space pipeline) | Unchanged. Continues injecting into Task Agent. The GitHub adapter subscribes to `space.githubEvent.routed` as an additional consumer. |
+| **GitHubService** (Room pipeline) | Unchanged for Room compatibility. It is not the source for Space workflow-node events. |
+| **SpaceGitHubService** (legacy Space pipeline) | Deprecated compatibility path. Its source-specific normalization/polling logic is extracted into `GitHubEventAdapter`; task resolution and delivery move to EventBus/EventRouter. The bus must not depend on `space.githubEvent.routed`. |
+| **GitHubEventAdapter** | Source extension that owns GitHub webhook verification, polling, normalization, watched-repo configuration, and direct publication to EventBus. It does not query Space tasks or inject sessions. |
+| **ExternalEventStore** | Core bus persistence and retry-aware source-level dedup across adapters. Replaces GitHub-specific unconditional duplicate short-circuiting for new delivery. |
+| **EventTaskResolver** | Core enrichment service that maps events to Space tasks where possible (e.g. GitHub PR → task). Keeps task/gate/workflow schema access out of adapters. |
 | **SessionNotificationSink** | The event bus uses the same `sessionFactory.injectMessage()` with `deliveryMode: 'defer'` pattern. |
 | **AgentMessageRouter** | Not used for event delivery. Events are injected directly via `sessionFactory.injectMessage()`, not via the agent-to-agent messaging channel. Events are not agent-originated messages — they're system-injected context. |
 | **ChannelRouter** | Not involved. Event delivery is not a workflow channel transition. It's an injection into an existing session, not an activation trigger. |
@@ -1518,11 +1570,15 @@ Direct injection via `sessionFactory.injectMessage()` is simpler and semanticall
 
 ### Why not extend SpaceGitHubService directly?
 
-The adapter pattern separates concerns:
-- `SpaceGitHubService` owns GitHub-specific normalization, dedup, and PR resolution.
-- The event bus is source-agnostic (GitHub, Slack, CI, etc.).
-- The adapter bridges the two without coupling.
-- Future adapters (Slack, CI) don't touch `SpaceGitHubService`.
+`SpaceGitHubService` currently mixes four responsibilities in one class: GitHub source ingestion, source-level dedup, PR-to-task resolution, and Task Agent session injection. Extending it would preserve the same coupling and keep the event bus downstream of an already-routed delivery pipeline.
+
+The target architecture splits those responsibilities:
+- `GitHubEventAdapter` owns only GitHub-specific webhook/polling/normalization.
+- `ExternalEventStore` owns cross-source event lifecycle and retry-aware dedup.
+- `EventTaskResolver` owns Space task enrichment.
+- `EventRouter` owns node subscription matching and session delivery.
+
+This makes GitHub one adapter among many instead of a special core daemon path. Future adapters (Slack, CI, etc.) publish the same `ExternalEvent` shape and reuse the same dedup, task enrichment, and delivery machinery.
 
 ### Why `deliveryMode: 'defer'` for event injection?
 
@@ -1539,14 +1595,16 @@ This is exactly the behavior we want for external events.
 
 1. **TopicTrie**: Insert patterns, verify lookup returns correct values for exact and wildcard matches.
 2. **EventRouter**: Given subscriptions and events, verify scope filtering, dedup, and delivery.
-3. **GitHubEventAdapter**: Given a `space.githubEvent.routed` event, verify correct `ExternalEvent` construction.
-4. **Scope resolution**: Test `task` scope with various task/PR associations.
+3. **ExternalEventStore**: Verify terminal duplicates are short-circuited and retryable duplicates are re-emitted.
+4. **EventTaskResolver**: Given GitHub PR metadata, verify correct task enrichment and ambiguous/unknown states.
+5. **GitHubEventAdapter**: Given webhook and polling payloads, verify signature handling, topic construction, dedupe keys, and `ExternalEvent` construction without querying Space tasks.
+6. **Scope resolution**: Test `task` scope with enriched `routedTaskId` and various task/PR associations.
 
 ### Integration tests
 
-1. **End-to-end webhook flow**: Emit a `space.githubEvent.routed` event with a review_submitted action for PR #42 on repo `lsm/neokai`. The coder node in a workflow has `task`-scoped interest in `github/*/*/pull_request.review_submitted`. Verify the event reaches the coder node's session as an injected message.
+1. **End-to-end webhook flow**: POST a GitHub webhook payload to the adapter route with a `review_submitted` action for PR #42 on repo `lsm/neokai`. Verify the adapter publishes `github/lsm/neokai/pull_request.review_submitted`, `EventTaskResolver` enriches it with the matching task, and the coder node's `task`-scoped subscription receives an injected message.
 
-2. **Dedup across two events with same dedupeKey**: Emit two `space.githubEvent.routed` events for the same PR review (identical `dedupeKey`). Verify `injectMessage` is called exactly once for the coder node — the second event is silently dropped by the dedup check. Also verify that if two *different* nodes subscribe to the same event (e.g., coder + ci-monitor), each node receives exactly one injection independently.
+2. **Dedup across two events with same dedupeKey**: Publish the same GitHub PR review through webhook and polling (identical `dedupeKey`). Verify source-level bus dedup does not create two independent events, and per-subscription delivery dedup calls `injectMessage` exactly once for each interested node. Also verify retryable duplicate states re-emit after a simulated injection failure.
 
 3. **Wake-on-idle delivery**: Set a node execution's session to `idle` state (agent finished its turn). Emit a matching event. Verify `injectMessage` is called with `deliveryMode: 'defer'` and the session processes the message on its next turn (via the existing defer replay mechanism).
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -78,7 +78,7 @@ Pattern validation (enforced at workflow create/update time):
 - Must be non-empty.
 - Must not contain `..` segments.
 - Must not contain empty segments (no double slashes).
-- Must have at least 4 segments (`source/owner/repo/resource.action`) so it can match real event topics.
+- Must have exactly 4 segments (`source/owner/repo/resource.action`) so it can match real event topics.
 - Each segment may contain alphanumeric, dash, underscore, dot, and `*`; `*` must stay within a single segment and cannot cross `/` boundaries.
 - Max 10 interests per agent slot.
 
@@ -643,6 +643,8 @@ class EventRouter {
     // Dedup check — include taskId and nodeId to handle multi-task runs and
     // cases where the same agent name appears in multiple nodes within the same
     // run. Each task/node/agent subscription is deduped independently.
+    // Evict before checking so DEDUP_TTL_MS is actually enforced during long runs.
+    this.evictStaleDedup();
     const dedupeKey = `${event.dedupeKey}:${sub.taskId}:${sub.nodeId}:${sub.agentName}:${sub.workflowRunId}`;
     if (this.delivered.has(dedupeKey)) return;
 
@@ -1039,7 +1041,7 @@ No new tables required for V1. Event interests are stored as part of the workflo
 1. Add `EventInterest` interface to `packages/shared/src/types/space.ts`.
 2. Add `eventInterests?: EventInterest[]` to `WorkflowNodeAgent`.
 3. Add validation in the workflow create/update path (Zod schema or manual validation):
-   - `topic` must pass `validateGlobPattern()` (non-empty, at least 4 segments, no `..` segments, no double slashes, valid characters including segment-local `*`).
+   - `topic` must pass `validateGlobPattern()` (non-empty, exactly 4 segments, no `..` segments, no double slashes, valid characters including segment-local `*`).
    - `scope` must be one of `'task' | 'repo' | 'global'`.
    - Max 10 interests per agent slot (prevent abuse).
    - `validateGlobPattern()` is the single source of truth — called at workflow create/update and again at trie insertion time as a safety net.
@@ -1067,10 +1069,11 @@ packages/daemon/src/lib/space/runtime/event-bus/
  * Rejects patterns that could corrupt the trie or match unintended topics.
  * Called at workflow create/update time and again at trie insertion time.
  *
- * Requires at least 4 segments because all event topics have the format
- * `{source}/{owner}/{repo}/{resource}.{action}` (4 segments minimum).
- * Patterns like `github/*` would pass validation but never match any event,
- * creating silent misconfigurations.
+ * Requires exactly 4 segments because all v1 event topics have the format
+ * `{source}/{owner}/{repo}/{resource}.{action}`.
+ * Patterns like `github/*` (too shallow) or `github/*/*/pull_request/review_*`
+ * (too deep) would pass validation but never match any event, creating silent
+ * misconfigurations.
  */
 export function validateGlobPattern(pattern: string): { valid: boolean; reason?: string } {
   if (!pattern || pattern.trim().length === 0) {
@@ -1079,10 +1082,10 @@ export function validateGlobPattern(pattern: string): { valid: boolean; reason?:
 
   const segments = pattern.split('/');
 
-  if (segments.length < 4) {
+  if (segments.length !== 4) {
     return {
       valid: false,
-      reason: `Topic pattern must have at least 4 segments (source/owner/repo/resource.action); got ${segments.length}. Example: 'github/*/*/pull_request.review_submitted'`,
+      reason: `Topic pattern must have exactly 4 segments (source/owner/repo/resource.action); got ${segments.length}. Example: 'github/*/*/pull_request.review_submitted'`,
     };
   }
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -405,7 +405,13 @@ class GitHubEventAdapter implements HttpEventAdapter, RpcEventAdapter {
 
   async start(publisher: EventPublisher): Promise<void> {
     this.publisher = publisher;
-    this.pollTimer = setInterval(() => void this.pollOnce(), GITHUB_POLL_INTERVAL_MS);
+    this.pollTimer = setInterval(() => {
+      void this.pollOnce().catch((err) => {
+        log.warn('GitHubEventAdapter: polling failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }, GITHUB_POLL_INTERVAL_MS);
   }
 
   async stop(): Promise<void> {
@@ -533,8 +539,9 @@ class EventRouter {
 
   // Track pending deliveries to prevent duplicate queueing while allowing retries
   private pendingDeliveries: Set<string> = new Set();
-  // Retry tracking: dedupeKey → retry count
+  // Retry tracking: dedupeKey → retry count / scheduled timer
   private retryCounts: Map<string, number> = new Map();
+  private retryTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
   private static readonly MAX_RETRIES = 3;
   private static readonly RETRY_BACKOFF_MS = 1000; // 1s base, exponential backoff
 
@@ -749,9 +756,8 @@ class EventRouter {
    * remain active so queued/arriving events can be delivered upon resume.
    */
   clearRunInterests(workflowRunId: string): void {
-    const runSubs = this.activeRuns.get(workflowRunId);
-    if (!runSubs) return;
-
+    // Always run cleanup, even if activeRuns no longer has this run, so retry
+    // timers/pending state cannot survive a terminal transition.
     this.topicTrie.remove(v => v.workflowRunId === workflowRunId);
     this.activeRuns.delete(workflowRunId);
 
@@ -785,6 +791,13 @@ class EventRouter {
       const [, , , , keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string, string];
       if (keyWorkflowRunId === workflowRunId) {
         this.retryCounts.delete(key);
+      }
+    }
+    for (const [key, timer] of this.retryTimers.entries()) {
+      const [, , , , keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string, string];
+      if (keyWorkflowRunId === workflowRunId) {
+        clearTimeout(timer);
+        this.retryTimers.delete(key);
       }
     }
   }
@@ -952,28 +965,54 @@ class EventRouter {
     if (retries > EventRouter.MAX_RETRIES) {
       log.warn(`Max retries exceeded for event ${dedupeKey}, dropping`);
       this.retryCounts.delete(dedupeKey);
+      const existingTimer = this.retryTimers.get(dedupeKey);
+      if (existingTimer) clearTimeout(existingTimer);
+      this.retryTimers.delete(dedupeKey);
       return;
     }
 
     this.retryCounts.set(dedupeKey, retries);
     const backoff = EventRouter.RETRY_BACKOFF_MS * Math.pow(2, retries - 1);
 
-    setTimeout(() => {
+    const existingTimer = this.retryTimers.get(dedupeKey);
+    if (existingTimer) clearTimeout(existingTimer);
+
+    const timer = setTimeout(() => {
+      this.retryTimers.delete(dedupeKey);
+
       // Re-check if delivered while waiting (another delivery might have succeeded)
       if (this.delivered.has(dedupeKey)) {
         this.retryCounts.delete(dedupeKey);
         return;
       }
-      // Use try/catch to prevent unhandled promise rejections in retry path (P2 fix)
+
+      // Do not retry after the run/subscription has been torn down.
+      const runSubs = this.activeRuns.get(sub.workflowRunId);
+      const stillActive = runSubs && [...runSubs].some((active) =>
+        active.taskId === sub.taskId
+          && active.nodeId === sub.nodeId
+          && active.agentName === sub.agentName
+          && active.interest.topic === sub.interest.topic
+          && active.interest.scope === sub.interest.scope,
+      );
+      if (!stillActive) {
+        this.retryCounts.delete(dedupeKey);
+        this.pendingDeliveries.delete(dedupeKey);
+        return;
+      }
+
+      // Use .catch to prevent unhandled promise rejections in retry path.
       this.deliverToSubscription(event, sub)
         .then(() => {
-          // Success: clear retry state so this key can be retried fresh if needed later
-          this.retryCounts.delete(dedupeKey);
-          this.pendingDeliveries.delete(dedupeKey);
+          // deliverToSubscription catches injection failures and may schedule a
+          // follow-up retry, so only clear retry state if delivery is now marked.
+          if (this.delivered.has(dedupeKey)) {
+            this.retryCounts.delete(dedupeKey);
+            this.pendingDeliveries.delete(dedupeKey);
+          }
         })
         .catch((err) => {
-          // Don't clear retryCounts on failure — preserve count for retry logic
-          // (The caller's scheduleRetry already incremented the count before setTimeout)
+          // Don't clear retryCounts on failure — preserve count for retry logic.
           log.warn('EventRouter: retry delivery failed', {
             error: err,
             retries,
@@ -982,6 +1021,8 @@ class EventRouter {
           });
         });
     }, backoff);
+
+    this.retryTimers.set(dedupeKey, timer);
   }
 }
 ```

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -593,7 +593,8 @@ class EventRouter {
   // Retry tracking: deliveryKey → retry count / scheduled timer
   private retryCounts: Map<string, number> = new Map();
   private retryTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
-  // Event-level retry tracking for failures before expected delivery rows exist
+  // Event-level retry tracking for failures before expected delivery rows exist.
+  // Retry keys are JSON tuples: [event.id, sorted workflowRunIds, 'prepare'].
   private eventRetryCounts: Map<string, number> = new Map();
   private eventRetryTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
   private static readonly MAX_RETRIES = 3;
@@ -881,9 +882,12 @@ class EventRouter {
       }
     }
 
-    // Event-level preparation retries may cover multiple subscriptions in the run.
+    // Event-level preparation retries may cover multiple runs. Retry keys are
+    // JSON tuples, so parse the workflowRunIds array structurally instead of using
+    // substring matching (comma-separated run ids are not colon-delimited).
     for (const [key, timer] of this.eventRetryTimers.entries()) {
-      if (key.includes(`:${workflowRunId}:`)) {
+      const [, keyWorkflowRunIds] = JSON.parse(key) as [string, string[], 'prepare'];
+      if (keyWorkflowRunIds.includes(workflowRunId)) {
         clearTimeout(timer);
         this.eventRetryTimers.delete(key);
         this.eventRetryCounts.delete(key);
@@ -927,7 +931,9 @@ class EventRouter {
           nodeId: sub.nodeId,
           agentName: sub.agentName,
         });
-        this.pendingDeliveries.delete(deliveryKey);
+        // Do not clear pendingDeliveries here: preparation does not acquire that
+        // guard. The same delivery may already be pending from an earlier queue or
+        // retry pass, and dropping the guard would allow duplicate queue/injection.
       }
     }
 
@@ -1159,7 +1165,11 @@ class EventRouter {
    * state across retryable source re-emissions of the same non-terminal event.
    */
   private scheduleEventRetry(event: ExternalEvent, matched: Subscription[]): void {
-    const retryKey = `${event.id}:${matched.map((sub) => sub.workflowRunId).sort().join(',')}:prepare`;
+    const retryKey = JSON.stringify([
+      event.id,
+      [...new Set(matched.map((sub) => sub.workflowRunId))].sort(),
+      'prepare',
+    ]);
     const retries = (this.eventRetryCounts.get(retryKey) ?? 0) + 1;
     if (retries > EventRouter.MAX_RETRIES) {
       log.warn('EventRouter: max preparation retries exceeded; marking event failed', {

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -424,7 +424,7 @@ interface Subscription {
 ```typescript
 class EventRouter {
   // topic trie for fast lookup
-  private topicTrie: TopicTrie<Subscription[]> = new TopicTrie();
+  private topicTrie: TopicTrie<Subscription> = new TopicTrie();
 
   // track which runs have active subscriptions (for lifecycle management)
   private activeRuns: Map<string, Set<Subscription>> = new Map();

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -456,6 +456,13 @@ class EventRouter {
   // TTL for dedup entries — entries older than this are evicted on next access
   private static readonly DEDUP_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
+  // Track pending deliveries to prevent duplicate queueing while allowing retries
+  private pendingDeliveries: Set<string> = new Set();
+  // Retry tracking: dedupeKey → retry count
+  private retryCounts: Map<string, number> = new Map();
+  private static readonly MAX_RETRIES = 3;
+  private static readonly RETRY_BACKOFF_MS = 1000; // 1s base, exponential backoff
+
   // Cache: spaceId → Set of "owner/repo" strings for watched repos
   // Invalidated via invalidateWatchedRepoCache() when repos are added/removed
   // through the `space.github.watchRepo` RPC path.
@@ -692,6 +699,21 @@ class EventRouter {
         this.pendingQueue.delete(key);
       }
     }
+
+    // Clean up pending deliveries and retry counts for this run.
+    // Delivery keys are JSON tuples: [dedupeKey, taskId, nodeId, agentName, workflowRunId]
+    for (const key of this.pendingDeliveries.keys()) {
+      const [, , , , keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string, string];
+      if (keyWorkflowRunId === workflowRunId) {
+        this.pendingDeliveries.delete(key);
+      }
+    }
+    for (const key of this.retryCounts.keys()) {
+      const [, , , , keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string, string];
+      if (keyWorkflowRunId === workflowRunId) {
+        this.retryCounts.delete(key);
+      }
+    }
   }
 
   private async handleEvent(event: ExternalEvent): Promise<void> {
@@ -733,40 +755,46 @@ class EventRouter {
     const dedupeKey = this.makeDeliveryKey(event, sub);
     if (this.delivered.has(dedupeKey)) return;
 
-    // Mark dedup BEFORE session resolution / queueing. This prevents the same
-    // event from being queued multiple times for inactive sessions — if the
-    // event arrives again before the queued delivery is flushed, the dedup
-    // check above will catch it. The tradeoff is that if injection fails (e.g.
-    // session crashes during delivery), the event will not be retried; this is
-    // acceptable because the upstream SpaceGitHubService re-polls on restart
-    // and will generate a fresh event.
-    this.delivered.set(dedupeKey, Date.now());
+    // Check if pending (prevents duplicate queueing while allowing retries on failure)
+    if (this.pendingDeliveries.has(dedupeKey)) return;
+
+    // Mark as pending to prevent duplicate queueing. Unlike the previous design,
+    // we do NOT mark as delivered until after successful injection. This allows
+    // retrying failed injections without waiting for dedup TTL expiry.
+    // Note: The upstream SpaceGitHubService.ingest() short-circuits duplicates
+    // via storeEvent(), so re-polling does NOT generate a fresh event that
+    // reaches the event bus. Therefore, we must handle retries here.
+    this.pendingDeliveries.add(dedupeKey);
 
     // Resolve session — re-read from nodeExecutionRepo for latest state
     const sessionId = await this.resolveSession(sub);
     if (!sessionId) {
       // Session not active — queue for later delivery
       this.queueForDelivery(event, sub);
-      return;
+      return; // Pending remains until queue is drained
     }
 
     // Format and inject.
     // NOTE: There is a TOCTOU race — the session could complete between our
     // resolveSession call and injectMessage. This is safe: injectMessage on a
-    // completed/absent session returns a caught error (logged as a warning),
-    // and the dedup map prevents re-delivery if the same event arrives again
-    // after the session restarts. No data loss or corruption occurs.
+    // completed/absent session returns a caught error (logged as a warning).
     const message = this.formatEventMessage(event);
     try {
       await this.sessionFactory.injectMessage(sessionId, message, {
         deliveryMode: 'defer',
       });
+
+      // Success: mark as delivered, remove pending
+      this.delivered.set(dedupeKey, Date.now());
+      this.pendingDeliveries.delete(dedupeKey);
     } catch (err) {
       log.warn(`Failed to deliver event to ${sub.agentName}`, { error: err });
-      // Session may have completed between resolution and injection.
-      // The event is already dedup-marked so it won't be re-delivered for
-      // this run. A fresh event will arrive via the next poll cycle if the
-      // underlying external event is still relevant.
+
+      // Failure: remove pending so it can be retried
+      this.pendingDeliveries.delete(dedupeKey);
+
+      // Schedule retry with backoff if we haven't exceeded max retries
+      this.scheduleRetry(event, sub, dedupeKey);
     }
   }
 
@@ -1250,6 +1278,32 @@ export function validateGlobPattern(pattern: string): { valid: boolean; reason?:
         valid: false,
         reason: `Segment "${segment}" contains invalid characters. Use alphanumeric, dash, underscore, dot, or segment-local "*" wildcard.`,
       };
+
+  /**
+   * Schedule a retry for failed delivery with exponential backoff.
+   * Retries are bounded by MAX_RETRIES; after that, the event is dropped.
+   */
+  private scheduleRetry(event: ExternalEvent, sub: Subscription, dedupeKey: string): void {
+    const retries = (this.retryCounts.get(dedupeKey) ?? 0) + 1;
+    if (retries > EventRouter.MAX_RETRIES) {
+      log.warn(`Max retries exceeded for event ${dedupeKey}, dropping`);
+      this.retryCounts.delete(dedupeKey);
+      return;
+    }
+
+    this.retryCounts.set(dedupeKey, retries);
+    const backoff = EventRouter.RETRY_BACKOFF_MS * Math.pow(2, retries - 1);
+
+    setTimeout(() => {
+      // Re-check if delivered while waiting (another delivery might have succeeded)
+      if (this.delivered.has(dedupeKey)) {
+        this.retryCounts.delete(dedupeKey);
+        return;
+      }
+      void this.deliverToSubscription(event, sub);
+    }, backoff);
+  }
+
     }
   }
 
@@ -1259,6 +1313,17 @@ export function validateGlobPattern(pattern: string): { valid: boolean; reason?:
     return {
       valid: false,
       reason: `Topic pattern fourth segment must be resource.action; got "${resourceAction}". Example: 'pull_request.review_submitted'`,
+    };
+  }
+
+  // Enforce exactly one dot in the 4th segment (resource.action pair).
+  // Patterns like `pull_request.review.submitted` (two dots) are invalid
+  // because V1 topics use exactly one dot to separate resource from action.
+  const dotCount = (resourceAction.match(/\./g) || []).length;
+  if (dotCount !== 1) {
+    return {
+      valid: false,
+      reason: `Topic pattern fourth segment must contain exactly one dot (resource.action), got ${dotCount} dots in "${resourceAction}". Example: 'pull_request.review_submitted'`,
     };
   }
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -453,7 +453,14 @@ class EventRouter {
     this.eventBus.subscribe(EXTERNAL_EVENT_PUBLISHED_METHOD, ({ spaceId, event }) => {
       // Defense in depth: payload spaceId and event.spaceId must agree.
       if (event.spaceId !== spaceId) return;
-      void this.handleEvent(event);
+      void this.handleEvent(event).catch((err) => {
+        log.warn('EventRouter: failed to route external event', {
+          error: err,
+          spaceId,
+          topic: event.topic,
+          eventId: event.id,
+        });
+      });
     });
   }
 
@@ -660,9 +667,24 @@ class EventRouter {
 
     if (matched.length === 0) return;
 
-    // 2. For each matched subscription, check scope and deliver
+    // 2. For each matched subscription, check scope and deliver.
+    // Isolate failures per subscription so one bad repo/task lookup or injection
+    // does not prevent other interested nodes from receiving the same event.
     for (const sub of matched) {
-      await this.deliverToSubscription(event, sub);
+      try {
+        await this.deliverToSubscription(event, sub);
+      } catch (err) {
+        log.warn('EventRouter: failed to deliver external event to subscription', {
+          error: err,
+          spaceId: event.spaceId,
+          topic: event.topic,
+          eventId: event.id,
+          workflowRunId: sub.workflowRunId,
+          taskId: sub.taskId,
+          nodeId: sub.nodeId,
+          agentName: sub.agentName,
+        });
+      }
     }
   }
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -766,35 +766,43 @@ class EventRouter {
     // reaches the event bus. Therefore, we must handle retries here.
     this.pendingDeliveries.add(dedupeKey);
 
-    // Resolve session — re-read from nodeExecutionRepo for latest state
-    const sessionId = await this.resolveSession(sub);
-    if (!sessionId) {
-      // Session not active — queue for later delivery
-      this.queueForDelivery(event, sub);
-      return; // Pending remains until queue is drained
-    }
-
-    // Format and inject.
-    // NOTE: There is a TOCTOU race — the session could complete between our
-    // resolveSession call and injectMessage. This is safe: injectMessage on a
-    // completed/absent session returns a caught error (logged as a warning).
-    const message = this.formatEventMessage(event);
     try {
-      await this.sessionFactory.injectMessage(sessionId, message, {
-        deliveryMode: 'defer',
-      });
+      // Resolve session — re-read from nodeExecutionRepo for latest state
+      const sessionId = await this.resolveSession(sub);
+      if (!sessionId) {
+        // Session not active — queue for later delivery
+        this.queueForDelivery(event, sub);
+        return; // Pending remains until queue is drained
+      }
 
-      // Success: mark as delivered, remove pending
-      this.delivered.set(dedupeKey, Date.now());
-      this.pendingDeliveries.delete(dedupeKey);
+      // Format and inject.
+      // NOTE: There is a TOCTOU race — the session could complete between our
+      // resolveSession call and injectMessage. This is safe: injectMessage on a
+      // completed/absent session returns a caught error (logged as a warning).
+      const message = this.formatEventMessage(event);
+      try {
+        await this.sessionFactory.injectMessage(sessionId, message, {
+          deliveryMode: 'defer',
+        });
+
+        // Success: mark as delivered, remove pending
+        this.delivered.set(dedupeKey, Date.now());
+        this.pendingDeliveries.delete(dedupeKey);
+      } catch (err) {
+        log.warn(`Failed to deliver event to ${sub.agentName}`, { error: err });
+
+        // Failure: remove pending so it can be retried
+        this.pendingDeliveries.delete(dedupeKey);
+
+        // Schedule retry with backoff if we haven't exceeded max retries
+        this.scheduleRetry(event, sub, dedupeKey);
+      }
     } catch (err) {
-      log.warn(`Failed to deliver event to ${sub.agentName}`, { error: err });
-
-      // Failure: remove pending so it can be retried
+      // Session resolution failed (transient DB/repo error) — clear pending
+      // so this event can be retried, but don't schedule retry here
+      // because scheduleRetry will be called by the caller's retry logic.
+      log.warn(`Session resolution failed for ${sub.agentName}`, { error: err });
       this.pendingDeliveries.delete(dedupeKey);
-
-      // Schedule retry with backoff if we haven't exceeded max retries
-      this.scheduleRetry(event, sub, dedupeKey);
     }
   }
 
@@ -902,13 +910,15 @@ class EventRouter {
         return;
       }
       // Use try/catch to prevent unhandled promise rejections in retry path (P2 fix)
-      // Also reset retry state on successful delivery (P2 #4 fix)
       this.deliverToSubscription(event, sub)
         .then(() => {
           // Success: clear retry state so this key can be retried fresh if needed later
           this.retryCounts.delete(dedupeKey);
+          this.pendingDeliveries.delete(dedupeKey);
         })
         .catch((err) => {
+          // Don't clear retryCounts on failure — preserve count for retry logic
+          // (The caller's scheduleRetry already incremented the count before setTimeout)
           log.warn('EventRouter: retry delivery failed', {
             error: err,
             retries,

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -799,10 +799,11 @@ class EventRouter {
       }
     } catch (err) {
       // Session resolution failed (transient DB/repo error) — clear pending
-      // so this event can be retried, but don't schedule retry here
-      // because scheduleRetry will be called by the caller's retry logic.
+      // so this event can be retried. Also schedule retry because
+      // upstream SpaceGitHubService.ingest() short-circuits duplicates.
       log.warn(`Session resolution failed for ${sub.agentName}`, { error: err });
       this.pendingDeliveries.delete(dedupeKey);
+      this.scheduleRetry(event, sub, dedupeKey);
     }
   }
 
@@ -823,6 +824,24 @@ class EventRouter {
       });
     }
     this.pendingQueue.set(key, queue);
+  }
+
+  /**
+   * Drain queued events for a subscription when the node's session is created.
+   * Clears pendingDeliveries markers so events can be re-queued if needed later.
+   */
+  private drainQueue(sub: Subscription): ExternalEvent[] {
+    const key = this.makePendingQueueKey(sub);
+    const queue = this.pendingQueue.get(key) ?? [];
+    this.pendingQueue.delete(key);
+
+    // Clear pendingDeliveries for ALL events in the drained queue
+    for (const event of queue) {
+      const eventKey = this.makeDeliveryKey(event, sub);
+      this.pendingDeliveries.delete(eventKey);
+    }
+
+    return queue;
   }
 
   private passesScopeCheck(event: ExternalEvent, sub: Subscription): boolean {

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -530,10 +530,12 @@ class EventRouter {
     this.topicTrie.remove(v => v.workflowRunId === workflowRunId);
     this.activeRuns.delete(workflowRunId);
 
-    // Also clean up dedup entries for this run
-    const prefix = `:${workflowRunId}:`;
+    // Also clean up dedup entries for this run.
+    // Delivery keys are: `${event.dedupeKey}:${sub.nodeId}:${sub.agentName}:${workflowRunId}`
+    // The run ID is the final segment — match with suffix `:${workflowRunId}`.
+    const suffix = `:${workflowRunId}`;
     for (const key of this.delivered.keys()) {
-      if (key.includes(prefix)) {
+      if (key.endsWith(suffix)) {
         this.delivered.delete(key);
       }
     }

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -298,8 +298,13 @@ export interface HttpEventAdapter extends EventAdapter {
  * GitHub uses this for watch/list/poll operations; future adapters can expose
  * source-specific configuration without adding core RPC handler dependencies.
  */
+export interface EventAdapterContext {
+  /** Notify core services that source configuration changed for a space. */
+  onSourceConfigChanged(change: { source: string; spaceId?: string; kind: 'watched_repo_changed' }): void;
+}
+
 export interface RpcEventAdapter extends EventAdapter {
-  registerRpcHandlers(hub: MessageHub, publisher: EventPublisher): void;
+  registerRpcHandlers(hub: MessageHub, publisher: EventPublisher, context: EventAdapterContext): void;
 }
 
 /**
@@ -418,8 +423,16 @@ class GitHubEventAdapter implements HttpEventAdapter, RpcEventAdapter {
     if (this.pollTimer) clearInterval(this.pollTimer);
   }
 
-  registerRpcHandlers(hub: MessageHub, publisher: EventPublisher): void {
-    hub.onRequest('space.github.watchRepo', async (data) => this.watchRepo(data));
+  registerRpcHandlers(hub: MessageHub, publisher: EventPublisher, context: EventAdapterContext): void {
+    hub.onRequest('space.github.watchRepo', async (data) => {
+      const watchedRepo = await this.watchRepo(data);
+      context.onSourceConfigChanged({
+        source: this.sourceId,
+        spaceId: watchedRepo.spaceId,
+        kind: 'watched_repo_changed',
+      });
+      return watchedRepo;
+    });
     hub.onRequest('space.github.listWatchedRepos', async (data) => this.listWatchedRepos(data));
     hub.onRequest('space.github.pollOnce', async () => ({ count: await this.pollOnce() }));
   }
@@ -589,9 +602,9 @@ class EventRouter {
 
   /**
    * Invalidate the watched-repo cache for a given space (or all spaces).
-   * Called when watched repos change via the `space.github.watchRepo` RPC path
-   * (enabling/disabling repos). Without this, `repo`-scoped matching grows stale
-   * until process restart.
+   * Called from EventAdapterContext.onSourceConfigChanged when a source adapter
+   * changes watched-repo configuration (for example `space.github.watchRepo`).
+   * Without this, `repo`-scoped matching grows stale until process restart.
    */
   invalidateWatchedRepoCache(spaceId?: string): void {
     if (spaceId) {
@@ -1574,18 +1587,26 @@ const eventTaskResolver = new EventTaskResolver(db);
 const eventBus = new EventBus(daemonHub, externalEventStore, eventTaskResolver);
 const eventRouter = new EventRouter(eventBus, ...dependencies);
 
+const adapterContext: EventAdapterContext = {
+  onSourceConfigChanged(change) {
+    if (change.kind === 'watched_repo_changed') {
+      eventRouter.invalidateWatchedRepoCache(change.spaceId);
+    }
+  },
+};
+
 const adapters: EventAdapter[] = [
   new GitHubEventAdapter(new GitHubEventAdapterRepository(db), process.env.GITHUB_TOKEN),
 ];
 
 for (const adapter of adapters) {
   if ('routes' in adapter) routeRegistry.register(adapter.routes, eventBus);
-  if ('registerRpcHandlers' in adapter) adapter.registerRpcHandlers(messageHub, eventBus);
+  if ('registerRpcHandlers' in adapter) adapter.registerRpcHandlers(messageHub, eventBus, adapterContext);
   await adapter.start(eventBus);
 }
 ```
 
-Repo-scoped matching still needs watched-repo cache invalidation. Instead of coupling the RPC handler to `EventRouter`, the GitHub adapter emits a source-config-changed event (or invokes a narrow callback) after watch/unwatch changes; the EventRouter invalidates only the affected space.
+Repo-scoped matching cache invalidation is explicit: `watchRepo` changes call `EventAdapterContext.onSourceConfigChanged(...)`, and daemon startup wires that callback to `eventRouter.invalidateWatchedRepoCache(spaceId)`. This keeps source configuration owned by the adapter while ensuring `repo`-scoped subscriptions observe newly watched or unwatched repos without process restart.
 
 ### Phased rollout
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -322,11 +322,20 @@ export interface PublishResult {
 
 export interface ExternalEventStore {
   store(event: ExternalEvent): { event: ExternalEvent; duplicate: boolean; terminal: boolean };
+  /**
+   * Idempotently register the delivery row expected for an event/subscription.
+   * Must be implemented as INSERT OR IGNORE / ON CONFLICT DO NOTHING (or an
+   * equivalent upsert that preserves terminal state) because retryable source
+   * duplicates and router retries can prepare the same (eventId, deliveryKey)
+   * multiple times before delivery succeeds.
+   */
   registerExpectedDelivery(
     eventId: string,
     deliveryKey: string,
     target: { workflowRunId: string; taskId: string; nodeId: string; agentName: string },
   ): void;
+  /** Returns true when the delivery row is already terminal and should be skipped. */
+  isDeliveryTerminal(eventId: string, deliveryKey: string): boolean;
   markDeliveryDelivered(eventId: string, deliveryKey: string): void;
   markDeliveryFailed(
     eventId: string,
@@ -575,7 +584,7 @@ class EventRouter {
 
   // Track pending deliveries to prevent duplicate queueing while allowing retries
   private pendingDeliveries: Set<string> = new Set();
-  // Retry tracking: dedupeKey → retry count / scheduled timer
+  // Retry tracking: deliveryKey → retry count / scheduled timer
   private retryCounts: Map<string, number> = new Map();
   private retryTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
   // Event-level retry tracking for failures before expected delivery rows exist
@@ -887,6 +896,7 @@ class EventRouter {
           nodeId: sub.nodeId,
           agentName: sub.agentName,
         });
+        if (this.eventStore.isDeliveryTerminal(event.id, deliveryKey)) continue;
         eligible.push(sub);
       } catch (err) {
         preparationFailed = true;
@@ -1144,21 +1154,21 @@ class EventRouter {
 
   /**
    * Schedule a retry for failed delivery with exponential backoff.
-   * Retries are bounded by MAX_RETRIES; after that, the event is dropped.
+   * Retries are bounded by MAX_RETRIES; after that, the delivery is marked failed.
    */
-  private scheduleRetry(event: ExternalEvent, sub: Subscription, dedupeKey: string): void {
-    const retries = (this.retryCounts.get(dedupeKey) ?? 0) + 1;
+  private scheduleRetry(event: ExternalEvent, sub: Subscription, deliveryKey: string): void {
+    const retries = (this.retryCounts.get(deliveryKey) ?? 0) + 1;
     if (retries > EventRouter.MAX_RETRIES) {
-      log.warn(`Max retries exceeded for event ${dedupeKey}, marking delivery failed`);
-      this.retryCounts.delete(dedupeKey);
-      const existingTimer = this.retryTimers.get(dedupeKey);
+      log.warn(`Max retries exceeded for event ${deliveryKey}, marking delivery failed`);
+      this.retryCounts.delete(deliveryKey);
+      const existingTimer = this.retryTimers.get(deliveryKey);
       if (existingTimer) clearTimeout(existingTimer);
-      this.retryTimers.delete(dedupeKey);
-      this.pendingDeliveries.delete(dedupeKey);
+      this.retryTimers.delete(deliveryKey);
+      this.pendingDeliveries.delete(deliveryKey);
 
       // Persist terminal failure so source-level dedup stops re-emitting this
       // delivery after restart or future polling of the same upstream event.
-      this.eventStore.markDeliveryFailed(event.id, dedupeKey, {
+      this.eventStore.markDeliveryFailed(event.id, deliveryKey, {
         terminal: true,
         reason: 'max_retries_exceeded',
       });
@@ -1166,18 +1176,18 @@ class EventRouter {
       return;
     }
 
-    this.retryCounts.set(dedupeKey, retries);
+    this.retryCounts.set(deliveryKey, retries);
     const backoff = EventRouter.RETRY_BACKOFF_MS * Math.pow(2, retries - 1);
 
-    const existingTimer = this.retryTimers.get(dedupeKey);
+    const existingTimer = this.retryTimers.get(deliveryKey);
     if (existingTimer) clearTimeout(existingTimer);
 
     const timer = setTimeout(() => {
-      this.retryTimers.delete(dedupeKey);
+      this.retryTimers.delete(deliveryKey);
 
       // Re-check if delivered while waiting (another delivery might have succeeded)
-      if (this.delivered.has(dedupeKey)) {
-        this.retryCounts.delete(dedupeKey);
+      if (this.delivered.has(deliveryKey) || this.eventStore.isDeliveryTerminal(event.id, deliveryKey)) {
+        this.retryCounts.delete(deliveryKey);
         return;
       }
 
@@ -1191,8 +1201,8 @@ class EventRouter {
           && active.interest.scope === sub.interest.scope,
       );
       if (!stillActive) {
-        this.retryCounts.delete(dedupeKey);
-        this.pendingDeliveries.delete(dedupeKey);
+        this.retryCounts.delete(deliveryKey);
+        this.pendingDeliveries.delete(deliveryKey);
         return;
       }
 
@@ -1201,9 +1211,9 @@ class EventRouter {
         .then(() => {
           // deliverToSubscription catches injection failures and may schedule a
           // follow-up retry, so only clear retry state if delivery is now marked.
-          if (this.delivered.has(dedupeKey)) {
-            this.retryCounts.delete(dedupeKey);
-            this.pendingDeliveries.delete(dedupeKey);
+          if (this.delivered.has(deliveryKey) || this.eventStore.isDeliveryTerminal(event.id, deliveryKey)) {
+            this.retryCounts.delete(deliveryKey);
+            this.pendingDeliveries.delete(deliveryKey);
           }
         })
         .catch((err) => {
@@ -1211,13 +1221,13 @@ class EventRouter {
           log.warn('EventRouter: retry delivery failed', {
             error: err,
             retries,
-            dedupeKey,
+            deliveryKey,
             workflowRunId: sub.workflowRunId,
           });
         });
     }, backoff);
 
-    this.retryTimers.set(dedupeKey, timer);
+    this.retryTimers.set(deliveryKey, timer);
   }
 }
 ```
@@ -1605,7 +1615,7 @@ V1 needs one core event-store table plus workflow type additions:
    );
    ```
 
-   `EventRouter` calls `registerExpectedDelivery(...)` for every scope-matched subscription before attempting any injection. It then records `delivered` after successful `injectMessage` and calls `markEventDeliveredIfAllDeliveriesTerminal(event.id)` so source-level dedup can stop re-emitting already-delivered events after restart or in-memory TTL eviction. When retry budget is exhausted it records terminal delivery failure and calls `markEventFailedIfAllDeliveriesTerminal(event.id)` so duplicate source observations do not restart an exhausted retry loop.
+   `EventRouter` calls `registerExpectedDelivery(...)` for every scope-matched subscription before attempting any injection. This registration must be idempotent for the `(event_id, delivery_key)` primary key: use `INSERT OR IGNORE`, `ON CONFLICT DO NOTHING`, or an equivalent upsert that never downgrades an existing terminal row. Retryable source duplicates and router retries can prepare the same delivery more than once, so duplicate expected-delivery rows are normal and must not become preparation failures. After idempotent registration, the router skips already-terminal delivery rows and only attempts pending/retryable rows. It then records `delivered` after successful `injectMessage` and calls `markEventDeliveredIfAllDeliveriesTerminal(event.id)` so source-level dedup can stop re-emitting already-delivered events after restart or in-memory TTL eviction. When retry budget is exhausted it records terminal delivery failure and calls `markEventFailedIfAllDeliveriesTerminal(event.id)` so duplicate source observations do not restart an exhausted retry loop.
 
 3. **Adapter-owned GitHub configuration**: reuse or migrate the existing `space_github_watched_repos` table behind `GitHubEventAdapterRepository`. This table remains source-specific and should not be queried by EventRouter except through cache invalidation hooks for repo-scoped matching.
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -877,6 +877,38 @@ class EventRouter {
         return resolved.taskId === sub.taskId;
       }
     }
+  /**
+   * Schedule a retry for failed delivery with exponential backoff.
+   * Retries are bounded by MAX_RETRIES; after that, the event is dropped.
+   */
+  private scheduleRetry(event: ExternalEvent, sub: Subscription, dedupeKey: string): void {
+    const retries = (this.retryCounts.get(dedupeKey) ?? 0) + 1;
+    if (retries > EventRouter.MAX_RETRIES) {
+      log.warn(`Max retries exceeded for event ${dedupeKey}, dropping`);
+      this.retryCounts.delete(dedupeKey);
+      return;
+    }
+
+    this.retryCounts.set(dedupeKey, retries);
+    const backoff = EventRouter.RETRY_BACKOFF_MS * Math.pow(2, retries - 1);
+
+    setTimeout(() => {
+      // Re-check if delivered while waiting (another delivery might have succeeded)
+      if (this.delivered.has(dedupeKey)) {
+        this.retryCounts.delete(dedupeKey);
+        return;
+      }
+      // Use try/catch to prevent unhandled promise rejections in retry path (P2 fix)
+      this.deliverToSubscription(event, sub).catch((err) => {
+        log.warn('EventRouter: retry delivery failed', {
+          error: err,
+          retries,
+          dedupeKey,
+          workflowRunId: sub.workflowRunId,
+        });
+      });
+    }, backoff);
+  }
   }
 }
 ```
@@ -1278,31 +1310,6 @@ export function validateGlobPattern(pattern: string): { valid: boolean; reason?:
         valid: false,
         reason: `Segment "${segment}" contains invalid characters. Use alphanumeric, dash, underscore, dot, or segment-local "*" wildcard.`,
       };
-
-  /**
-   * Schedule a retry for failed delivery with exponential backoff.
-   * Retries are bounded by MAX_RETRIES; after that, the event is dropped.
-   */
-  private scheduleRetry(event: ExternalEvent, sub: Subscription, dedupeKey: string): void {
-    const retries = (this.retryCounts.get(dedupeKey) ?? 0) + 1;
-    if (retries > EventRouter.MAX_RETRIES) {
-      log.warn(`Max retries exceeded for event ${dedupeKey}, dropping`);
-      this.retryCounts.delete(dedupeKey);
-      return;
-    }
-
-    this.retryCounts.set(dedupeKey, retries);
-    const backoff = EventRouter.RETRY_BACKOFF_MS * Math.pow(2, retries - 1);
-
-    setTimeout(() => {
-      // Re-check if delivered while waiting (another delivery might have succeeded)
-      if (this.delivered.has(dedupeKey)) {
-        this.retryCounts.delete(dedupeKey);
-        return;
-      }
-      void this.deliverToSubscription(event, sub);
-    }, backoff);
-  }
 
     }
   }

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -372,11 +372,13 @@ The trie maps topic segments to `Set<Subscription>` at leaf nodes. Wildcard segm
 
 ### Subscription index lifecycle
 
-The index is **per-SpaceRuntime instance** and rebuilt when:
+The index is **per-SpaceRuntime instance** and updated via two distinct operations:
 
-1. A workflow run starts (node executions are created with interests from the workflow definition).
-2. A node execution transitions to a new status (e.g. `in_progress` → starts receiving events; `idle`/`cancelled` → removed from index).
-3. A workflow definition is updated (interests may have changed — next run picks up changes).
+1. **`registerRunInterests`** (called on every `executeTick`): Diff-based trie update. Compares current node execution states against existing subscriptions. Adds subscriptions for newly active nodes, removes subscriptions for `cancelled` nodes. Does NOT touch the dedup map or pending queue — those are preserved across tick refreshes.
+
+2. **`clearRunInterests`** (called only on `done`/`cancelled` terminal transitions): Full teardown. Removes all trie subscriptions, dedup entries, and pending queue entries for the run. NOT called on `blocked` transitions because blocked is resumable.
+
+3. A workflow definition is updated (interests may have changed — next `registerRunInterests` call picks up changes via the diff).
 
 ```typescript
 interface Subscription {
@@ -443,8 +445,12 @@ class EventRouter {
   }
 
   /**
-   * Register all event interests for a workflow run.
-   * Called when a workflow run starts or when node executions change.
+   * Refresh event interests for a workflow run based on current node execution states.
+   * Called on every executeTick to keep the trie in sync with node lifecycle changes.
+   *
+   * This is a DIFF-BASED update — it only adds/removes trie subscriptions for nodes
+   * whose status has changed. It does NOT touch the dedup map or pending queue.
+   * Terminal-run cleanup (dedup + pending) is handled exclusively by `clearRunInterests`.
    */
   registerRunInterests(
     spaceId: string,
@@ -452,39 +458,65 @@ class EventRouter {
     workflow: SpaceWorkflow,
     nodeExecutions: NodeExecution[],
   ): void {
-    // Clear previous subscriptions for this run
-    this.clearRunInterests(workflowRunId);
-
-    const runSubs = new Set<Subscription>();
+    // Build the desired set of subscriptions from current node execution states.
+    const desiredSubs = new Map<string, Subscription>();  // key: `${nodeId}:${agentName}`
 
     for (const node of workflow.nodes) {
       for (const agent of node.agents) {
         if (!agent.eventInterests?.length) continue;
 
-        // Only register if this node has at least one active (non-terminal) execution
         const exec = nodeExecutions.find(
           e => e.workflowNodeId === node.id && e.agentName === agent.name
         );
         if (!exec || !isReceivingStatus(exec.status)) continue;
 
+        const subKey = `${node.id}:${agent.name}`;
         for (const interest of agent.eventInterests) {
-          const sub: Subscription = {
+          // Include interest topic in key so a single agent can have multiple interests
+          const fullKey = `${subKey}:${interest.topic}`;
+          desiredSubs.set(fullKey, {
             workflowRunId,
             nodeId: node.id,
             agentName: agent.name,
             interest,
             agentSessionId: exec.agentSessionId,
             spaceId,
-          };
-
-          // Insert into trie
-          this.topicTrie.insert(interest.topic, sub);
-          runSubs.add(sub);
+          });
         }
       }
     }
 
-    this.activeRuns.set(workflowRunId, runSubs);
+    // Diff against current subscriptions for this run.
+    const currentSubs = this.activeRuns.get(workflowRunId) ?? new Set<Subscription>();
+    const currentKeys = new Set<string>();
+    for (const sub of currentSubs) {
+      currentKeys.add(`${sub.nodeId}:${sub.agentName}:${sub.interest.topic}`);
+    }
+    const desiredKeys = new Set(desiredSubs.keys());
+
+    // Remove subscriptions no longer in the desired set (e.g. node went cancelled).
+    for (const key of currentKeys) {
+      if (!desiredKeys.has(key)) {
+        const [nodeId, agentName, ...topicParts] = key.split(':');
+        const topic = topicParts.join(':');
+        this.topicTrie.remove(
+          v => v.workflowRunId === workflowRunId
+            && v.nodeId === nodeId
+            && v.agentName === agentName
+            && v.interest.topic === topic,
+        );
+      }
+    }
+
+    // Add new subscriptions not currently in the trie.
+    for (const [key, sub] of desiredSubs) {
+      if (!currentKeys.has(key)) {
+        this.topicTrie.insert(sub.interest.topic, sub);
+      }
+    }
+
+    // Replace active run set with the new desired set.
+    this.activeRuns.set(workflowRunId, new Set(desiredSubs.values()));
   }
 
   /**
@@ -1019,6 +1051,7 @@ interface SpaceRuntimeConfig {
 }
 
 // In SpaceRuntime.executeTick(), after node executions are resolved:
+// This does a DIFF-BASED update of trie subscriptions. Safe to call on every tick.
 if (this.eventRouter) {
   this.eventRouter.registerRunInterests(
     spaceId,
@@ -1026,6 +1059,12 @@ if (this.eventRouter) {
     workflow,
     activeNodeExecutions,
   );
+}
+
+// In the workflow run status transition handler:
+// Called ONLY on truly terminal transitions (done, cancelled) — NOT on blocked.
+if (newStatus === 'done' || newStatus === 'cancelled') {
+  this.eventRouter.clearRunInterests(workflowRunId);
 }
 
 // In daemon startup (e.g. in SpaceRuntimeService or init function):

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -386,7 +386,7 @@ class EventBus implements EventPublisher {
 The EventBus owns cross-cutting behavior that applies to every adapter:
 
 1. **Validation** — all topics must satisfy the four-segment topic contract before publication.
-2. **Source-level dedup** — a persistent `ExternalEventStore` tracks `(spaceId, source, dedupeKey)` and delivery state. Terminal duplicates (`delivered`, `ignored`, `ambiguous`) are short-circuited; retryable states (`published`, `routed`, `delivery_failed`) are re-emitted so delivery can retry.
+2. **Source-level dedup** — a persistent `ExternalEventStore` tracks `(spaceId, source, dedupeKey)` and delivery state. Terminal duplicates (`delivered`, `failed`, `ignored`, `ambiguous`) are short-circuited; retryable states (`published`, `routed`, `delivery_failed`) are re-emitted so delivery can retry.
 3. **Task enrichment** — `EventTaskResolver` enriches events with `routedTaskId` for task-scoped matching. For GitHub PR events, it uses PR URL/number/branch fields that were normalized by the adapter. For future Slack/CI events, source-specific resolver plugins can be registered without changing adapters.
 4. **Publication** — only enriched, deduped events are emitted on `space.externalEvent.published`.
 
@@ -836,10 +836,40 @@ class EventRouter {
 
     if (matched.length === 0) return;
 
-    // 2. For each matched subscription, check scope and deliver.
-    // Isolate failures per subscription so one bad repo/task lookup or injection
-    // does not prevent other interested nodes from receiving the same event.
+    // 2. First compute all scoped deliveries and persist them as expected
+    // pending deliveries before attempting injection. This prevents the first
+    // successful subscription from marking the source event terminal while other
+    // matched subscriptions have not yet been attempted.
+    const eligible: Subscription[] = [];
     for (const sub of matched) {
+      try {
+        if (!this.passesScopeCheck(event, sub)) continue;
+        const deliveryKey = this.makeDeliveryKey(event, sub);
+        this.eventStore.registerExpectedDelivery(event.id, deliveryKey, {
+          workflowRunId: sub.workflowRunId,
+          taskId: sub.taskId,
+          nodeId: sub.nodeId,
+          agentName: sub.agentName,
+        });
+        eligible.push(sub);
+      } catch (err) {
+        log.warn('EventRouter: failed to prepare external event delivery', {
+          error: err,
+          spaceId: event.spaceId,
+          topic: event.topic,
+          eventId: event.id,
+          workflowRunId: sub.workflowRunId,
+          taskId: sub.taskId,
+          nodeId: sub.nodeId,
+          agentName: sub.agentName,
+        });
+      }
+    }
+
+    // 3. Deliver each prepared subscription. Isolate failures per subscription
+    // so one bad repo/task lookup or injection does not prevent other interested
+    // nodes from receiving the same event.
+    for (const sub of eligible) {
       try {
         await this.deliverToSubscription(event, sub);
       } catch (err) {
@@ -858,8 +888,7 @@ class EventRouter {
   }
 
   private async deliverToSubscription(event: ExternalEvent, sub: Subscription): Promise<void> {
-    // Scope check
-    if (!this.passesScopeCheck(event, sub)) return;
+    // Scope was checked and registered in handleEvent before this method is called.
 
     // Dedup check — include taskId and nodeId to handle multi-task runs and
     // cases where the same agent name appears in multiple nodes within the same
@@ -996,11 +1025,20 @@ class EventRouter {
   private scheduleRetry(event: ExternalEvent, sub: Subscription, dedupeKey: string): void {
     const retries = (this.retryCounts.get(dedupeKey) ?? 0) + 1;
     if (retries > EventRouter.MAX_RETRIES) {
-      log.warn(`Max retries exceeded for event ${dedupeKey}, dropping`);
+      log.warn(`Max retries exceeded for event ${dedupeKey}, marking delivery failed`);
       this.retryCounts.delete(dedupeKey);
       const existingTimer = this.retryTimers.get(dedupeKey);
       if (existingTimer) clearTimeout(existingTimer);
       this.retryTimers.delete(dedupeKey);
+      this.pendingDeliveries.delete(dedupeKey);
+
+      // Persist terminal failure so source-level dedup stops re-emitting this
+      // delivery after restart or future polling of the same upstream event.
+      this.eventStore.markDeliveryFailed(event.id, dedupeKey, {
+        terminal: true,
+        reason: 'max_retries_exceeded',
+      });
+      this.eventStore.markEventFailedIfAllDeliveriesTerminal(event.id);
       return;
     }
 
@@ -1423,7 +1461,7 @@ V1 needs one core event-store table plus workflow type additions:
    );
    ```
 
-   `state` values are `published`, `routed`, `delivered`, `delivery_failed`, `ignored`, and `ambiguous`. Duplicate handling depends on state: terminal states short-circuit; retryable states can re-emit. `delivered` is written only after expected per-subscription deliveries are terminal, not merely after publication.
+   `state` values are `published`, `routed`, `delivered`, `delivery_failed`, `failed`, `ignored`, and `ambiguous`. Duplicate handling depends on state: terminal states (`delivered`, `failed`, `ignored`, `ambiguous`) short-circuit; retryable states can re-emit. `delivered` is written only after expected per-subscription deliveries are terminal, and `failed` is written only after retry budgets are exhausted for all retryable deliveries.
 
 2. **Core bus delivery store** (`space_external_event_deliveries`): persistent per-subscription delivery lifecycle used by EventRouter to advance source events to terminal delivered.
 
@@ -1442,7 +1480,7 @@ V1 needs one core event-store table plus workflow type additions:
    );
    ```
 
-   `EventRouter` records `delivered` after successful `injectMessage` and calls `markEventDeliveredIfAllDeliveriesTerminal(event.id)` so source-level dedup can stop re-emitting already-delivered events after restart or in-memory TTL eviction.
+   `EventRouter` calls `registerExpectedDelivery(...)` for every scope-matched subscription before attempting any injection. It then records `delivered` after successful `injectMessage` and calls `markEventDeliveredIfAllDeliveriesTerminal(event.id)` so source-level dedup can stop re-emitting already-delivered events after restart or in-memory TTL eviction. When retry budget is exhausted it records terminal delivery failure and calls `markEventFailedIfAllDeliveriesTerminal(event.id)` so duplicate source observations do not restart an exhausted retry loop.
 
 3. **Adapter-owned GitHub configuration**: reuse or migrate the existing `space_github_watched_repos` table behind `GitHubEventAdapterRepository`. This table remains source-specific and should not be queried by EventRouter except through cache invalidation hooks for repo-scoped matching.
 
@@ -1697,7 +1735,7 @@ This is exactly the behavior we want for external events.
 
 1. **TopicTrie**: Insert patterns, verify lookup returns correct values for exact and wildcard matches.
 2. **EventRouter**: Given subscriptions and events, verify scope filtering, topic validation before trie insertion, dedup, and delivery.
-3. **ExternalEventStore**: Verify terminal duplicates are short-circuited, retryable duplicates are re-emitted, and successful per-subscription delivery advances the source event to terminal `delivered` only after all expected deliveries are terminal.
+3. **ExternalEventStore**: Verify terminal duplicates are short-circuited, retryable duplicates are re-emitted, expected deliveries are registered before injection, successful per-subscription delivery advances the source event to terminal `delivered` only after all expected deliveries are terminal, and retry exhaustion advances to terminal `failed`.
 4. **EventTaskResolver**: Given GitHub PR metadata, verify correct task enrichment and ambiguous/unknown states.
 5. **GitHubEventAdapter**: Given webhook and polling payloads, verify signature handling, topic construction, dedupe keys, and `ExternalEvent` construction without querying Space tasks.
 6. **Scope resolution**: Test `task` scope with enriched `routedTaskId` and various task/PR associations.

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -318,11 +318,13 @@ this.daemonHub?.emit('space.githubEvent.routed', {
         summary: event.summary,
         externalUrl: event.externalUrl,
         rawPayload: event.rawPayload,   // ← ADD THIS (for adapter consumers)
+        dedupeKey: event.dedupeKey,    // ← ADD THIS (for adapter deduplication)
+        deliveryId: event.deliveryId, // ← ADD THIS (unique GitHub delivery ID)
     },
 });
 ```
 
-This is a two-field addition to `appendTaskActivity` — both `action` and `rawPayload` are already available on the `NormalizedSpaceGitHubEvent` at the call site. This is the only change to existing code.
+This is a four-field addition to `appendTaskActivity` — `action`, `rawPayload`, `dedupeKey`, and `deliveryId` are all already available on the `NormalizedSpaceGitHubEvent` at the call site. This is the only change to existing code.
 
 **Why this approach:**
 - Minimal change to the existing `SpaceGitHubService` — two additional fields in an existing DaemonHub emission.
@@ -879,7 +881,7 @@ class GitHubEventAdapter implements EventAdapter {
           taskId,
           rawPayload: event.rawPayload,   // Include original webhook/polling payload
         },
-        dedupeKey: `github:${event.repo}:${event.prNumber}:${event.eventType}:${event.action}:${event.externalUrl}`,
+        dedupeKey: event.dedupeKey,  // Use upstream identity (includes deliveryId); avoids collapsing distinct events that share repo/pr/action/url
       });
     });
   }

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -25,11 +25,11 @@ External Event Sources (GitHub webhook, polling, future: Slack, CI)
 │  EventIngestion     │  Normalize → validate → publish to EventBus
 │  (adapter per source│
 └────────┬────────────┘
-         │ publish(topic, payload)
+         │ publish(event) → hub.emit('space.externalEvent.published', { event })
          ▼
 ┌─────────────────────┐
-│  EventBus           │  In-memory, backed by TypedHub. Namespaced topics.
-│  (singleton)        │  O(1) subscriber lookup by topic pattern.
+│  EventBus           │  In-memory, backed by TypedHub. External topic is payload data.
+│  (singleton)        │  Fixed TypedHub-safe method; router trie matches event.topic.
 └────────┬────────────┘
          │
          ▼
@@ -269,6 +269,20 @@ export interface EventAdapter {
 export interface EventPublisher {
   publish(event: ExternalEvent): Promise<void>;
 }
+
+/**
+ * TypedHub/MessageHub method used by EventBus.
+ *
+ * IMPORTANT: raw external topics (e.g. `github/lsm/neokai/pull_request.opened`)
+ * are NOT used as TypedHub method names because MessageHub validates methods
+ * with `[a-zA-Z0-9._-]`, requires a dot, and rejects `/` and `*`.
+ * The external topic stays in `ExternalEvent.topic` and is matched by EventRouter.
+ */
+export const EXTERNAL_EVENT_PUBLISHED_METHOD = 'space.externalEvent.published';
+
+export interface EventBusHubEventMap {
+  'space.externalEvent.published': { event: ExternalEvent };
+}
 ```
 
 ### GitHub adapter
@@ -347,11 +361,12 @@ This is a payload-contract extension to `appendTaskActivity` using fields alread
 
 ### Architecture
 
-The `EventRouter` subscribes to all topics on the `EventBus`. When an event arrives, it:
+The `EventRouter` subscribes to the fixed TypedHub-safe EventBus method (`space.externalEvent.published`). When an event arrives, it:
 
-1. Looks up all active node executions that have `eventInterests`.
-2. For each matching interest, checks scope.
-3. Delivers the event to the matching node's agent session.
+1. Reads the external topic from `event.topic` in the payload.
+2. Looks up all active node executions that have `eventInterests` matching that payload topic.
+3. For each matching interest, checks scope.
+4. Delivers the event to the matching node's agent session.
 
 ### Trie-based subscription index
 
@@ -430,8 +445,9 @@ class EventRouter {
     private readonly prResolver: SpacePrTaskResolver,
     private readonly spaceGitHubRepo: SpaceGitHubRepository,
   ) {
-    // Subscribe to ALL events on the bus
-    this.eventBus.subscribe('*', this.handleEvent.bind(this));
+    // Subscribe to the fixed TypedHub-safe method. External topic matching happens
+    // inside handleEvent via event.topic, not via the hub method name.
+    this.eventBus.subscribe(EXTERNAL_EVENT_PUBLISHED_METHOD, ({ event }) => this.handleEvent(event));
   }
 
   /** Check if a repo is watched for a given space. Uses cached data. */
@@ -809,7 +825,7 @@ If persistent queuing is needed in a future iteration, events can be persisted t
 
 - **Rate limiting**: If a single node receives > 10 events per minute, subsequent events are coalesced into a digest message: "N additional events received in the last minute. Summary: ..."
 - **Event TTL**: Events older than 5 minutes are dropped from the queue (they're likely stale for an agent's decision-making).
-- **Bus overflow**: The `EventBus` uses TypedHub's async-everywhere design — slow consumers don't block publishers. Handlers run via `queueMicrotask`.
+- **Bus overflow**: The `EventBus` uses TypedHub's async-everywhere design with the fixed method `space.externalEvent.published` — slow consumers don't block publishers. Handlers run via `queueMicrotask`; external slash/glob topics remain payload data and are never used as MessageHub method names.
 
 ## 6. Topic Trie Implementation
 
@@ -1208,7 +1224,7 @@ await githubAdapter.start(eventBus);
 
 | Existing system | Relationship |
 |---|---|
-| **DaemonHub / TypedHub** | `EventBus` is a TypedHub participant on the shared `InProcessTransportBus`. The bus uses the same async-everywhere, session-scoped routing that DaemonHub uses. |
+| **DaemonHub / TypedHub** | `EventBus` is a TypedHub participant on the shared `InProcessTransportBus`. It publishes all external events through the fixed valid method `space.externalEvent.published`; slash-delimited external topics stay in `ExternalEvent.topic` and are matched by the router trie. |
 | **GitHubService** (Room pipeline) | Unchanged. Continues routing to Rooms. The event bus is additive. |
 | **SpaceGitHubService** (Space pipeline) | Unchanged. Continues injecting into Task Agent. The GitHub adapter subscribes to `space.githubEvent.routed` as an additional consumer. |
 | **SessionNotificationSink** | The event bus uses the same `sessionFactory.injectMessage()` with `deliveryMode: 'defer'` pattern. |
@@ -1225,7 +1241,7 @@ TypedHub provides:
 - Already wired into the daemon's lifecycle.
 - No new dependency.
 
-Using TypedHub as the backing transport means the EventBus inherits all of these properties for free.
+Using TypedHub as the backing transport means the EventBus inherits all of these properties for free. The bus does **not** use external topic strings as TypedHub method names: raw topics contain `/` and glob `*`, which violate MessageHub method validation. Instead, EventBus publishes every external event under the fixed valid method `space.externalEvent.published` and places the external topic in `ExternalEvent.topic` for trie matching.
 
 ### Why not route through AgentMessageRouter?
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -555,6 +555,7 @@ class EventRouter {
     private readonly taskRepo: SpaceTaskRepository,
     private readonly spaceTaskManager: SpaceTaskManager,
     private readonly sessionFactory: SessionFactory,
+    private readonly eventStore: ExternalEventStore,
     private readonly watchedRepoLookup: WatchedRepoLookup,
   ) {
     // Subscribe to the fixed TypedHub-safe method. External topic matching happens
@@ -696,9 +697,23 @@ class EventRouter {
       }
     }
 
-    // Add new subscriptions not currently in the trie.
+    // Add new subscriptions not currently in the trie. Revalidate here as a
+    // safety net for legacy/malformed workflow rows that predate create/update
+    // validation.
     for (const [key, sub] of desiredSubs) {
       if (!currentSubsByKey.has(key)) {
+        const validation = validateGlobPattern(sub.interest.topic);
+        if (!validation.valid) {
+          log.warn('EventRouter: skipping invalid event interest topic', {
+            workflowRunId,
+            taskId: sub.taskId,
+            nodeId: sub.nodeId,
+            agentName: sub.agentName,
+            topic: sub.interest.topic,
+            reason: validation.reason,
+          });
+          continue;
+        }
         this.topicTrie.insert(sub.interest.topic, sub);
       }
     }
@@ -870,8 +885,13 @@ class EventRouter {
           deliveryMode: 'defer',
         });
 
-        // Success: mark as delivered, remove pending
+        // Success: mark as delivered both in-memory and persistently, then
+        // advance the source event to terminal delivered only when all expected
+        // per-subscription deliveries are terminal. This keeps source-level dedup
+        // from re-emitting already-delivered events after restart/TTL expiry.
         this.delivered.set(dedupeKey, Date.now());
+        this.eventStore.markDeliveryDelivered(event.id, dedupeKey);
+        this.eventStore.markEventDeliveredIfAllDeliveriesTerminal(event.id);
         this.pendingDeliveries.delete(dedupeKey);
       } catch (err) {
         log.warn(`Failed to deliver event to ${sub.agentName}`, { error: err });
@@ -1058,12 +1078,13 @@ Dedup happens at two different layers, each with a different key and responsibil
    - Retryable duplicates (`published`, `routed`, `delivery_failed`) are re-emitted so transient delivery failures can retry.
    - This replaces `SpaceGitHubService.storeEvent()` as the authoritative dedup path for new external-event delivery.
 
-2. **Per-subscription delivery dedup** — in-memory JSON tuple `[event.dedupeKey, subscription.taskId, subscription.nodeId, subscription.agentName, subscription.workflowRunId]`.
+2. **Per-subscription delivery dedup** — JSON tuple `[event.dedupeKey, subscription.taskId, subscription.nodeId, subscription.agentName, subscription.workflowRunId]`.
    - Purpose: prevent the same external event from being delivered twice to the same node agent within a run.
    - The tuple includes `taskId` to isolate multi-task runs and `nodeId` to handle cases where the same agent name appears in multiple nodes within the same run.
    - The tuple is encoded structurally rather than delimiter-joined because `dedupeKey`, workflow identifiers, node IDs, and agent names are free-form strings.
+   - It is tracked in-memory for fast duplicate suppression and persisted in `space_external_event_deliveries` after successful injection.
 
-The EventRouter marks per-subscription delivery as `delivered` only after successful injection. Failed injection/session-resolution paths remove `pendingDeliveries` and schedule retry rather than relying on adapters to re-publish the same event.
+The EventRouter marks per-subscription delivery as `delivered` only after successful injection, updates `ExternalEventStore` with the successful delivery key, and advances the source event to terminal `delivered` only once all expected deliveries are terminal. Failed injection/session-resolution paths remove `pendingDeliveries` and schedule retry rather than relying on adapters to re-publish the same event.
 
 ### Wake-on-idle
 
@@ -1389,11 +1410,30 @@ V1 needs one core event-store table plus workflow type additions:
    );
    ```
 
-   `state` values are `published`, `routed`, `delivered`, `delivery_failed`, `ignored`, and `ambiguous`. Duplicate handling depends on state: terminal states short-circuit; retryable states can re-emit.
+   `state` values are `published`, `routed`, `delivered`, `delivery_failed`, `ignored`, and `ambiguous`. Duplicate handling depends on state: terminal states short-circuit; retryable states can re-emit. `delivered` is written only after expected per-subscription deliveries are terminal, not merely after publication.
 
-2. **Adapter-owned GitHub configuration**: reuse or migrate the existing `space_github_watched_repos` table behind `GitHubEventAdapterRepository`. This table remains source-specific and should not be queried by EventRouter except through cache invalidation hooks for repo-scoped matching.
+2. **Core bus delivery store** (`space_external_event_deliveries`): persistent per-subscription delivery lifecycle used by EventRouter to advance source events to terminal delivered.
 
-3. **No node-execution schema change**: event interests are stored as part of the workflow definition JSON in `space_workflows.nodes[].agents[].eventInterests`.
+   ```sql
+   CREATE TABLE space_external_event_deliveries (
+     event_id TEXT NOT NULL,
+     delivery_key TEXT NOT NULL,
+     workflow_run_id TEXT NOT NULL,
+     task_id TEXT NOT NULL,
+     node_id TEXT NOT NULL,
+     agent_name TEXT NOT NULL,
+     state TEXT NOT NULL DEFAULT 'pending',
+     delivered_at INTEGER,
+     updated_at INTEGER NOT NULL,
+     PRIMARY KEY(event_id, delivery_key)
+   );
+   ```
+
+   `EventRouter` records `delivered` after successful `injectMessage` and calls `markEventDeliveredIfAllDeliveriesTerminal(event.id)` so source-level dedup can stop re-emitting already-delivered events after restart or in-memory TTL eviction.
+
+3. **Adapter-owned GitHub configuration**: reuse or migrate the existing `space_github_watched_repos` table behind `GitHubEventAdapterRepository`. This table remains source-specific and should not be queried by EventRouter except through cache invalidation hooks for repo-scoped matching.
+
+4. **No node-execution schema change**: event interests are stored as part of the workflow definition JSON in `space_workflows.nodes[].agents[].eventInterests`.
 
 ### Type changes
 
@@ -1635,8 +1675,8 @@ This is exactly the behavior we want for external events.
 ### Unit tests
 
 1. **TopicTrie**: Insert patterns, verify lookup returns correct values for exact and wildcard matches.
-2. **EventRouter**: Given subscriptions and events, verify scope filtering, dedup, and delivery.
-3. **ExternalEventStore**: Verify terminal duplicates are short-circuited and retryable duplicates are re-emitted.
+2. **EventRouter**: Given subscriptions and events, verify scope filtering, topic validation before trie insertion, dedup, and delivery.
+3. **ExternalEventStore**: Verify terminal duplicates are short-circuited, retryable duplicates are re-emitted, and successful per-subscription delivery advances the source event to terminal `delivered` only after all expected deliveries are terminal.
 4. **EventTaskResolver**: Given GitHub PR metadata, verify correct task enrichment and ambiguous/unknown states.
 5. **GitHubEventAdapter**: Given webhook and polling payloads, verify signature handling, topic construction, dedupe keys, and `ExternalEvent` construction without querying Space tasks.
 6. **Scope resolution**: Test `task` scope with enriched `routedTaskId` and various task/PR associations.

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -62,7 +62,7 @@ github/lsm/neokai/pull_request.review_*     ← prefix wildcard: all review even
 2. `owner/repo` — from the event's repository context. Both lowercase for case-insensitive matching.
 3. `resource` — the GitHub resource type: `pull_request`, `issue`, `check_suite`, `pull_request_review`, etc.
 4. `action` — the specific action: `opened`, `review_submitted`, `comment_created`, `completed`, etc.
-5. For resources without a natural `owner/repo` (e.g. a Slack message), the convention is `{source}/{workspace}/{channel}.{action}`.
+5. All v1 topics use exactly 4 path segments. For resources without a natural `owner/repo` (e.g. a future Slack message), use a source-specific scope pair to preserve the same depth: `{source}/{workspace}/{channel}/{resource}.{action}` (for example, `slack/acme/eng/messages.created`). Adapters that do not have both scope levels should use a reserved placeholder segment such as `_` rather than emitting 3-segment topics.
 
 ### Matching rules
 
@@ -78,7 +78,7 @@ Pattern validation (enforced at workflow create/update time):
 - Must be non-empty.
 - Must not contain `..` segments.
 - Must not contain empty segments (no double slashes).
-- Must have exactly 4 segments (`source/owner/repo/resource.action`) so it can match real event topics.
+- Must have exactly 4 segments (`source/scope1/scope2/resource.action`) so it can match real event topics.
 - Each segment may contain alphanumeric, dash, underscore, dot, and `*`; `*` must stay within a single segment and cannot cross `/` boundaries.
 - Max 10 interests per agent slot.
 
@@ -941,7 +941,7 @@ function isReceivingStatus(status: NodeExecutionStatus): boolean {
 
 ### Changes to existing code
 
-**Two-field addition.** The `appendTaskActivity` method in `space-github.ts` must include `action: event.action` and `rawPayload: event.rawPayload` in the `space.githubEvent.routed` DaemonHub payload. This is the only change to existing code. All other existing behavior (webhook handling, polling, normalization, Task Agent injection) remains unchanged.
+**Four-field addition.** The `appendTaskActivity` method in `space-github.ts` must include `action`, `rawPayload`, `dedupeKey`, and `deliveryId` in the `space.githubEvent.routed` DaemonHub payload. The adapter requires `dedupeKey` as the stable upstream event identity for per-subscription deduplication, and `deliveryId` preserves the unique GitHub delivery identifier used to build that identity. This is the only change to existing code. All other existing behavior (webhook handling, polling, normalization, Task Agent injection) remains unchanged.
 
 ```
 SpaceGitHubService.handleWebhook()
@@ -1070,7 +1070,9 @@ packages/daemon/src/lib/space/runtime/event-bus/
  * Called at workflow create/update time and again at trie insertion time.
  *
  * Requires exactly 4 segments because all v1 event topics have the format
- * `{source}/{owner}/{repo}/{resource}.{action}`.
+ * `{source}/{scope1}/{scope2}/{resource}.{action}`. For GitHub, scope1/scope2
+ * are owner/repo; for future non-repo adapters, they are source-specific scope
+ * segments such as workspace/channel.
  * Patterns like `github/*` (too shallow) or `github/*/*/pull_request/review_*`
  * (too deep) would pass validation but never match any event, creating silent
  * misconfigurations.
@@ -1085,7 +1087,7 @@ export function validateGlobPattern(pattern: string): { valid: boolean; reason?:
   if (segments.length !== 4) {
     return {
       valid: false,
-      reason: `Topic pattern must have exactly 4 segments (source/owner/repo/resource.action); got ${segments.length}. Example: 'github/*/*/pull_request.review_submitted'`,
+      reason: `Topic pattern must have exactly 4 segments (source/scope1/scope2/resource.action); got ${segments.length}. Example: 'github/*/*/pull_request.review_submitted'`,
     };
   }
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -327,7 +327,7 @@ this.daemonHub?.emit('space.githubEvent.routed', {
 This is a four-field addition to `appendTaskActivity` — `action`, `rawPayload`, `dedupeKey`, and `deliveryId` are all already available on the `NormalizedSpaceGitHubEvent` at the call site. This is the only change to existing code.
 
 **Why this approach:**
-- Minimal change to the existing `SpaceGitHubService` — two additional fields in an existing DaemonHub emission.
+- Minimal change to the existing `SpaceGitHubService` — four additional fields (`action`, `deliveryId`, `dedupeKey`, `rawPayload`) in an existing DaemonHub emission.
 - The existing PR-to-task resolution (`SpacePrTaskResolver`) continues to work.
 - The existing Task Agent injection continues to work (we don't replace it, we supplement it).
 - The adapter is purely additive: it converts an already-normalized event into bus format.
@@ -538,10 +538,13 @@ class EventRouter {
       }
     }
 
-    // Clean up in-memory pending queue for this run
-    for (const [execId, events] of this.pendingQueue.entries()) {
-      if (execId.startsWith(workflowRunId)) {
-        this.pendingQueue.delete(execId);
+    // Clean up in-memory pending queue for this run.
+    // Keys are `${workflowRunId}:${nodeId}:${agentName}` — use the delimiter
+    // to avoid false prefix matches (e.g., run "abc1" matching "abc10:*").
+    const runPrefix = `${workflowRunId}:`;
+    for (const [key, events] of this.pendingQueue.entries()) {
+      if (key.startsWith(runPrefix)) {
+        this.pendingQueue.delete(key);
       }
     }
   }

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -188,13 +188,13 @@ export interface WorkflowNodeAgent {
 
 **`repo` scope** filters to events from any of the space's watched repositories (`space_github_watched_repos`). The node author doesn't need to know repo names.
 
-**`global` scope** passes through all events matching the topic pattern. Use sparingly (e.g. a "global monitor" node).
+**`global` scope** passes through all events in the same space matching the topic pattern. It is never cross-space: the router requires `event.spaceId === subscription.spaceId` before any scope-specific logic runs. Use sparingly (e.g. a space-local "global monitor" node).
 
 ### Auto-scoping resolution at runtime
 
 When an event arrives, the router:
 
-1. Extracts `prNumber` and `repoOwner/repoName` from the event payload.
+1. Verifies `event.spaceId` matches the subscription's `spaceId`, then extracts `prNumber` and `repoOwner/repoName` from the event payload.
 2. For each active node execution with `eventInterests`:
    a. Compiles the interest's `topic` glob against the event's topic.
    b. If matched, checks scope:
@@ -214,6 +214,8 @@ When an event arrives, the router:
 export interface ExternalEvent {
   /** Unique event ID (UUID) */
   id: string;
+  /** Space this event was routed for. Required to prevent cross-space delivery. */
+  spaceId: string;
   /** Fully qualified topic: 'github/owner/repo/resource.action' */
   topic: string;
   /** Timestamp when the event occurred (epoch ms) */
@@ -281,7 +283,7 @@ export interface EventPublisher {
 export const EXTERNAL_EVENT_PUBLISHED_METHOD = 'space.externalEvent.published';
 
 export interface EventBusHubEventMap {
-  'space.externalEvent.published': { event: ExternalEvent };
+  'space.externalEvent.published': { spaceId: string; event: ExternalEvent };
 }
 ```
 
@@ -327,6 +329,7 @@ The adapter subscribes to the existing `space.githubEvent.routed` DaemonHub even
 // In space-github.ts, appendTaskActivity():
 this.daemonHub?.emit('space.githubEvent.routed', {
     sessionId: 'global',
+    spaceId,
     taskId,
     event: {
         repo: `${event.repoOwner}/${event.repoName}`,
@@ -348,7 +351,7 @@ this.daemonHub?.emit('space.githubEvent.routed', {
 });
 ```
 
-This is a payload-contract extension to `appendTaskActivity` using fields already available on the `NormalizedSpaceGitHubEvent` at the call site. `dedupeKey` and `deliveryId` are required for stable upstream event identity; `prUrl` and the other normalized fields keep the `SpacePrTaskResolver` fallback functional if `taskId` is absent.
+This is a payload-contract extension to `appendTaskActivity` using fields already available on the `NormalizedSpaceGitHubEvent` at the call site plus the enclosing `spaceId`. `dedupeKey` and `deliveryId` are required for stable upstream event identity; `prUrl` and the other normalized fields keep the `SpacePrTaskResolver` fallback functional if `taskId` is absent; `spaceId` prevents cross-space delivery on the shared daemon event stream.
 
 **Why this approach:**
 - Minimal change to the existing `SpaceGitHubService` — additional normalized fields in an existing DaemonHub emission, with no changes to ingestion/dedup/routing behavior.
@@ -447,7 +450,11 @@ class EventRouter {
   ) {
     // Subscribe to the fixed TypedHub-safe method. External topic matching happens
     // inside handleEvent via event.topic, not via the hub method name.
-    this.eventBus.subscribe(EXTERNAL_EVENT_PUBLISHED_METHOD, ({ event }) => this.handleEvent(event));
+    this.eventBus.subscribe(EXTERNAL_EVENT_PUBLISHED_METHOD, ({ spaceId, event }) => {
+      // Defense in depth: payload spaceId and event.spaceId must agree.
+      if (event.spaceId !== spaceId) return;
+      void this.handleEvent(event);
+    });
   }
 
   /** Check if a repo is watched for a given space. Uses cached data. */
@@ -709,6 +716,11 @@ class EventRouter {
   }
 
   private passesScopeCheck(event: ExternalEvent, sub: Subscription): boolean {
+    // All scopes are bounded to the subscription's space. EventBus is a shared
+    // daemon-wide stream, so even `global` means "global within this space", not
+    // cross-space delivery.
+    if (event.spaceId !== sub.spaceId) return false;
+
     switch (sub.interest.scope) {
       case 'global':
         return true;
@@ -1003,7 +1015,7 @@ The GitHub adapter subscribes to `space.githubEvent.routed` and converts it:
 class GitHubEventAdapter implements EventAdapter {
   async start(publisher: EventPublisher): Promise<void> {
     this.daemonHub.on('space.githubEvent.routed', async (data) => {
-      const { event, taskId } = data;
+      const { event, spaceId, taskId } = data;
       const [repoOwner, repoName] = event.repo.split('/');
 
       // Construct topic from event.
@@ -1013,8 +1025,9 @@ class GitHubEventAdapter implements EventAdapter {
 
       // Publish to bus. Preserve the upstream occurrence time for ordering,
       // queue TTL, and latency diagnostics; only ingestedAt is "now".
-      await publisher.publish({
+      const externalEvent: ExternalEvent = {
         id: crypto.randomUUID(),
+        spaceId,
         topic,
         occurredAt: new Date(event.occurredAt).getTime(),
         ingestedAt: Date.now(),
@@ -1039,7 +1052,9 @@ class GitHubEventAdapter implements EventAdapter {
           rawPayload: event.rawPayload,   // Include original webhook/polling payload
         },
         dedupeKey: event.dedupeKey,  // Use upstream identity (includes deliveryId); avoids collapsing distinct events that share repo/pr/action/url
-      });
+      };
+
+      await publisher.publish(externalEvent);
     });
   }
 }

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -995,11 +995,12 @@ class GitHubEventAdapter implements EventAdapter {
       // original GitHub action so users can filter created/edited/deleted/etc.
       const topic = `github/${repoOwner}/${repoName}/${mapEventType(event.eventType, event.action)}`;
 
-      // Publish to bus
+      // Publish to bus. Preserve the upstream occurrence time for ordering,
+      // queue TTL, and latency diagnostics; only ingestedAt is "now".
       await publisher.publish({
         id: crypto.randomUUID(),
         topic,
-        occurredAt: Date.now(),
+        occurredAt: new Date(event.occurredAt).getTime(),
         ingestedAt: Date.now(),
         source: 'github',
         prNumber: event.prNumber,

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -521,7 +521,11 @@ class EventRouter {
 
   /**
    * Clear all subscriptions for a workflow run.
-   * Called when the workflow run reaches a terminal state (done, cancelled, blocked).
+   * Called when the workflow run reaches a truly terminal state (done or cancelled).
+   *
+   * NOT called for `blocked` runs because blocked is resumable — the run may be
+   * reopened (see WorkflowRunReopenedEvent) and its node subscriptions should
+   * remain active so queued/arriving events can be delivered upon resume.
    */
   clearRunInterests(workflowRunId: string): void {
     const runSubs = this.activeRuns.get(workflowRunId);
@@ -573,6 +577,15 @@ class EventRouter {
     const dedupeKey = `${event.dedupeKey}:${sub.nodeId}:${sub.agentName}:${sub.workflowRunId}`;
     if (this.delivered.has(dedupeKey)) return;
 
+    // Mark dedup BEFORE session resolution / queueing. This prevents the same
+    // event from being queued multiple times for inactive sessions — if the
+    // event arrives again before the queued delivery is flushed, the dedup
+    // check above will catch it. The tradeoff is that if injection fails (e.g.
+    // session crashes during delivery), the event will not be retried; this is
+    // acceptable because the upstream SpaceGitHubService re-polls on restart
+    // and will generate a fresh event.
+    this.delivered.set(dedupeKey, Date.now());
+
     // Resolve session — re-read from nodeExecutionRepo for latest state
     const sessionId = await this.resolveSession(sub);
     if (!sessionId) {
@@ -592,14 +605,12 @@ class EventRouter {
       await this.sessionFactory.injectMessage(sessionId, message, {
         deliveryMode: 'defer',
       });
-
-      // Mark delivered
-      this.delivered.set(dedupeKey, Date.now());
     } catch (err) {
       log.warn(`Failed to deliver event to ${sub.agentName}`, { error: err });
       // Session may have completed between resolution and injection.
-      // This is expected and safe — the event is NOT marked as delivered,
-      // so if the session restarts, the event can be re-attempted.
+      // The event is already dedup-marked so it won't be re-delivered for
+      // this run. A fresh event will arrive via the next poll cycle if the
+      // underlying external event is still relevant.
     }
   }
 
@@ -864,8 +875,12 @@ class GitHubEventAdapter implements EventAdapter {
       const { event, taskId } = data;
       const [repoOwner, repoName] = event.repo.split('/');
 
-      // Construct topic from event
-      const topic = `github/${repoOwner}/${repoName}/${mapEventType(event.eventType)}.${mapAction(event.action)}`;
+      // Construct topic from event.
+      // mapEventType returns the full resource.action string from the table below.
+      // For most SpaceGitHubEventKinds, the mapping already includes the action
+      // (e.g., pull_request_review → "pull_request.review_submitted").
+      // For plain pull_request events, the action is appended from event.action.
+      const topic = `github/${repoOwner}/${repoName}/${mapEventType(event.eventType, event.action)}`;
 
       // Publish to bus
       await publisher.publish({
@@ -897,12 +912,24 @@ class GitHubEventAdapter implements EventAdapter {
 
 The `SpaceGitHubService` already normalizes to `SpaceGitHubEventKind` (`issue_comment`, `pull_request_review`, `pull_request_review_comment`, `pull_request`). We map these to bus topics:
 
-| SpaceGitHubEventKind | Bus topic resource |
+| SpaceGitHubEventKind | `mapEventType(kind, action)` returns |
 |---|---|
 | `issue_comment` | `pull_request.comment_created` (PR comments only, already filtered) |
 | `pull_request_review` | `pull_request.review_submitted` |
 | `pull_request_review_comment` | `pull_request.review_comment_created` |
-| `pull_request` | `pull_request.{action}` (opened, synchronize, closed, etc.) |
+| `pull_request` | `pull_request.${action}` (opened, synchronize, closed, etc.) |
+
+```typescript
+function mapEventType(kind: string, action: string): string {
+  switch (kind) {
+    case 'issue_comment': return 'pull_request.comment_created';
+    case 'pull_request_review': return 'pull_request.review_submitted';
+    case 'pull_request_review_comment': return 'pull_request.review_comment_created';
+    case 'pull_request': return `pull_request.${action}`;
+    default: return `${kind}.${action}`;
+  }
+}
+```
 
 ### Task-scoped resolution optimization
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -1009,8 +1009,8 @@ class EventRouter {
     await this.handleEventForSubscriptions(event, matched);
   }
 
-  private async handleEventForSubscriptions(event: ExternalEvent, matched: Subscription[]): Promise<void> {
-    if (matched.length === 0) return;
+  private async handleEventForSubscriptions(event: ExternalEvent, matched: Subscription[]): Promise<boolean> {
+    if (matched.length === 0) return true;
 
     // 2. First compute all scoped deliveries and persist them as expected
     // pending deliveries before attempting injection. This prevents the first
@@ -1057,7 +1057,7 @@ class EventRouter {
     // subscriptions could all succeed and mark the source event terminal while the
     // failed subscription was never registered. The retry path will re-run matching,
     // scope checks, and expected-delivery registration for the whole event.
-    if (preparationFailed) return;
+    if (preparationFailed) return false;
 
     // 3. Deliver each prepared subscription. Isolate injection failures per
     // subscription after the complete expected-delivery set has been registered.
@@ -1077,6 +1077,8 @@ class EventRouter {
         });
       }
     }
+
+    return true;
   }
 
   private async deliverToSubscription(event: ExternalEvent, sub: Subscription): Promise<void> {
@@ -1271,9 +1273,11 @@ class EventRouter {
    * (for example transient watched-repo lookup or delivery-row insert failures).
    * This reruns full matching/preparation instead of allowing partial delivery to
    * mark the source event terminal while an unregistered subscription missed it.
-   * The event-level retry count is cleared after a resolved retry pass so later
-   * independent preparation errors get a fresh budget and this map does not leak
-   * state across retryable source re-emissions of the same non-terminal event.
+   * handleEventForSubscriptions returns false when preparation failed and another
+   * retry was scheduled. In that case the retry count/state must be preserved so
+   * persistent preparation failures continue toward MAX_RETRIES. Counts are cleared
+   * only after a prepared retry pass, so later independent preparation errors get a
+   * fresh budget and this map does not leak state across retryable re-emissions.
    */
   private scheduleEventRetry(
     event: ExternalEvent,
@@ -1313,8 +1317,15 @@ class EventRouter {
       this.eventRetryTimers.delete(retryKey);
       const retryState = this.eventRetryState.get(retryKey) ?? { event, matched };
       void this.handleEventForSubscriptions(retryState.event, retryState.matched)
-        .then(() => {
-          // A resolved retry pass either prepared the complete expected-delivery
+        .then((prepared) => {
+          if (!prepared) {
+            // handleEventForSubscriptions scheduled the next preparation retry.
+            // Preserve count/state so persistent preparation failures continue
+            // toward MAX_RETRIES instead of restarting from attempt 1 forever.
+            return;
+          }
+
+          // A prepared retry pass either registered the complete expected-delivery
           // set for the still-active matched subscriptions or found no matching
           // work left. Clear event-level retry state so a later independent
           // transient error gets a full budget and this map does not leak state.

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -320,6 +320,29 @@ export interface PublishResult {
   state: 'published' | 'duplicate_terminal' | 'retryable_duplicate' | 'ignored';
 }
 
+export interface ExternalEventStore {
+  store(event: ExternalEvent): { event: ExternalEvent; duplicate: boolean; terminal: boolean };
+  registerExpectedDelivery(
+    eventId: string,
+    deliveryKey: string,
+    target: { workflowRunId: string; taskId: string; nodeId: string; agentName: string },
+  ): void;
+  markDeliveryDelivered(eventId: string, deliveryKey: string): void;
+  markDeliveryFailed(
+    eventId: string,
+    deliveryKey: string,
+    failure: { terminal: boolean; reason: string },
+  ): void;
+  markEventDeliveredIfAllDeliveriesTerminal(eventId: string): void;
+  markEventFailedIfAllDeliveriesTerminal(eventId: string): void;
+  markEventFailed(eventId: string, failure: { terminal: boolean; reason: string }): void;
+}
+
+export interface EventTaskResolver {
+  /** Enrich a normalized event with routedTaskId when a trusted task association exists. */
+  enrich(event: ExternalEvent): Promise<ExternalEvent>;
+}
+
 /**
  * TypedHub/MessageHub method used by EventBus.
  *
@@ -555,6 +578,9 @@ class EventRouter {
   // Retry tracking: dedupeKey → retry count / scheduled timer
   private retryCounts: Map<string, number> = new Map();
   private retryTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
+  // Event-level retry tracking for failures before expected delivery rows exist
+  private eventRetryCounts: Map<string, number> = new Map();
+  private eventRetryTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
   private static readonly MAX_RETRIES = 3;
   private static readonly RETRY_BACKOFF_MS = 1000; // 1s base, exponential backoff
 
@@ -828,6 +854,15 @@ class EventRouter {
         this.retryTimers.delete(key);
       }
     }
+
+    // Event-level preparation retries may cover multiple subscriptions in the run.
+    for (const [key, timer] of this.eventRetryTimers.entries()) {
+      if (key.includes(`:${workflowRunId}:`)) {
+        clearTimeout(timer);
+        this.eventRetryTimers.delete(key);
+        this.eventRetryCounts.delete(key);
+      }
+    }
   }
 
   private async handleEvent(event: ExternalEvent): Promise<void> {
@@ -841,10 +876,11 @@ class EventRouter {
     // successful subscription from marking the source event terminal while other
     // matched subscriptions have not yet been attempted.
     const eligible: Subscription[] = [];
+    let preparationFailed = false;
     for (const sub of matched) {
+      const deliveryKey = this.makeDeliveryKey(event, sub);
       try {
         if (!this.passesScopeCheck(event, sub)) continue;
-        const deliveryKey = this.makeDeliveryKey(event, sub);
         this.eventStore.registerExpectedDelivery(event.id, deliveryKey, {
           workflowRunId: sub.workflowRunId,
           taskId: sub.taskId,
@@ -853,7 +889,8 @@ class EventRouter {
         });
         eligible.push(sub);
       } catch (err) {
-        log.warn('EventRouter: failed to prepare external event delivery', {
+        preparationFailed = true;
+        log.warn('EventRouter: failed to prepare external event delivery; scheduling retry', {
           error: err,
           spaceId: event.spaceId,
           topic: event.topic,
@@ -863,12 +900,23 @@ class EventRouter {
           nodeId: sub.nodeId,
           agentName: sub.agentName,
         });
+        this.pendingDeliveries.delete(deliveryKey);
       }
     }
 
-    // 3. Deliver each prepared subscription. Isolate failures per subscription
-    // so one bad repo/task lookup or injection does not prevent other interested
-    // nodes from receiving the same event.
+    if (preparationFailed) {
+      this.scheduleEventRetry(event, matched);
+    }
+
+    // If any matched subscription failed during scope/registration preparation,
+    // do not partially deliver this event in the same pass. Otherwise the prepared
+    // subscriptions could all succeed and mark the source event terminal while the
+    // failed subscription was never registered. The retry path will re-run matching,
+    // scope checks, and expected-delivery registration for the whole event.
+    if (preparationFailed) return;
+
+    // 3. Deliver each prepared subscription. Isolate injection failures per
+    // subscription after the complete expected-delivery set has been registered.
     for (const sub of eligible) {
       try {
         await this.deliverToSubscription(event, sub);
@@ -917,24 +965,8 @@ class EventRouter {
         return;
       }
 
-      // Format and inject.
-      // NOTE: There is a TOCTOU race — the session could complete between our
-      // resolveSession call and injectMessage. This is safe: injectMessage on a
-      // completed/absent session returns a caught error (logged as a warning).
-      const message = this.formatEventMessage(event);
       try {
-        await this.sessionFactory.injectMessage(sessionId, message, {
-          deliveryMode: 'defer',
-        });
-
-        // Success: mark as delivered both in-memory and persistently, then
-        // advance the source event to terminal delivered only when all expected
-        // per-subscription deliveries are terminal. This keeps source-level dedup
-        // from re-emitting already-delivered events after restart/TTL expiry.
-        this.delivered.set(dedupeKey, Date.now());
-        this.eventStore.markDeliveryDelivered(event.id, dedupeKey);
-        this.eventStore.markEventDeliveredIfAllDeliveriesTerminal(event.id);
-        this.pendingDeliveries.delete(dedupeKey);
+        await this.injectPreparedDelivery(event, sub, dedupeKey, sessionId);
       } catch (err) {
         log.warn(`Failed to deliver event to ${sub.agentName}`, { error: err });
 
@@ -951,6 +983,31 @@ class EventRouter {
       this.pendingDeliveries.delete(dedupeKey);
       this.scheduleRetry(event, sub, dedupeKey);
     }
+  }
+
+  private async injectPreparedDelivery(
+    event: ExternalEvent,
+    sub: Subscription,
+    dedupeKey: string,
+    sessionId: string,
+  ): Promise<void> {
+    // Format and inject.
+    // NOTE: There is a TOCTOU race — the session could complete between our
+    // resolveSession call and injectMessage. This is safe: injectMessage on a
+    // completed/absent session returns a caught error (logged as a warning).
+    const message = this.formatEventMessage(event);
+    await this.sessionFactory.injectMessage(sessionId, message, {
+      deliveryMode: 'defer',
+    });
+
+    // Success: mark as delivered both in-memory and persistently, then advance
+    // the source event to terminal delivered only when all expected per-subscription
+    // deliveries are terminal. This keeps source-level dedup from re-emitting
+    // already-delivered events after restart/TTL expiry.
+    this.delivered.set(dedupeKey, Date.now());
+    this.eventStore.markDeliveryDelivered(event.id, dedupeKey);
+    this.eventStore.markEventDeliveredIfAllDeliveriesTerminal(event.id);
+    this.pendingDeliveries.delete(dedupeKey);
   }
 
   private queueForDelivery(event: ExternalEvent, sub: Subscription, deliveryKey: string): void {
@@ -972,20 +1029,47 @@ class EventRouter {
 
   /**
    * Drain queued events for a subscription when the node's session is created.
-   * Clears pendingDeliveries markers so events can be re-queued if needed later.
+   * Clears pendingDeliveries markers before reinjection so a failed flush can be
+   * retried or re-queued instead of being permanently blocked by stale pending keys.
    */
-  private drainQueue(sub: Subscription): ExternalEvent[] {
+  drainQueueForSession(sub: Subscription): PendingDelivery[] {
     const key = this.makePendingQueueKey(sub);
     const queue = this.pendingQueue.get(key) ?? [];
     this.pendingQueue.delete(key);
 
-    // Clear pendingDeliveries for ALL events in the drained queue. Use the queued
+    // Clear pendingDeliveries for ALL drained events because queueForDelivery keeps
+    // each delivery key marked pending while the node has no session. Use the queued
     // wrapper's stored deliveryKey instead of recomputing from the wrapper object.
     for (const pending of queue) {
       this.pendingDeliveries.delete(pending.deliveryKey);
     }
 
-    return queue.map((pending) => pending.event);
+    return queue;
+  }
+
+  /**
+   * Called by TaskAgentManager immediately after it creates/binds a node session.
+   * Flushes pending-node events through the same injection path as live delivery,
+   * preserving delivery state, retry, and terminal event advancement semantics.
+   */
+  async flushQueuedDeliveriesForSession(sub: Subscription, sessionId: string): Promise<void> {
+    const queued = this.drainQueueForSession(sub);
+    for (const pending of queued) {
+      try {
+        await this.injectPreparedDelivery(pending.event, sub, pending.deliveryKey, sessionId);
+      } catch (err) {
+        log.warn('EventRouter: failed to flush queued external event delivery', {
+          error: err,
+          eventId: pending.event.id,
+          workflowRunId: sub.workflowRunId,
+          taskId: sub.taskId,
+          nodeId: sub.nodeId,
+          agentName: sub.agentName,
+        });
+        this.pendingDeliveries.delete(pending.deliveryKey);
+        this.scheduleRetry(pending.event, sub, pending.deliveryKey);
+      }
+    }
   }
 
   private passesScopeCheck(event: ExternalEvent, sub: Subscription): boolean {
@@ -1012,10 +1096,50 @@ class EventRouter {
         // router uses that trusted enrichment directly and never performs broad
         // PR/task scans during delivery. This prevents cross-task leakage in
         // multi-task runs and keeps task/gate/workflow schema access out of
-        // source adapters and delivery hot paths.
+        // source adapters and delivery hot paths. If routedTaskId is absent, the
+        // event has no associated task, so the scope check returns false.
         return event.routedTaskId === sub.taskId;
       }
     }
+  }
+
+  /**
+   * Schedule an event-level retry for failures before expected delivery rows exist
+   * (for example transient watched-repo lookup or delivery-row insert failures).
+   * This reruns full matching/preparation instead of allowing partial delivery to
+   * mark the source event terminal while an unregistered subscription missed it.
+   */
+  private scheduleEventRetry(event: ExternalEvent, matched: Subscription[]): void {
+    const retryKey = `${event.id}:${matched.map((sub) => sub.workflowRunId).sort().join(',')}:prepare`;
+    const retries = (this.eventRetryCounts.get(retryKey) ?? 0) + 1;
+    if (retries > EventRouter.MAX_RETRIES) {
+      log.warn('EventRouter: max preparation retries exceeded; marking event failed', {
+        eventId: event.id,
+        topic: event.topic,
+      });
+      this.eventRetryCounts.delete(retryKey);
+      const existingTimer = this.eventRetryTimers.get(retryKey);
+      if (existingTimer) clearTimeout(existingTimer);
+      this.eventRetryTimers.delete(retryKey);
+      this.eventStore.markEventFailed(event.id, {
+        terminal: true,
+        reason: 'delivery_preparation_failed',
+      });
+      return;
+    }
+
+    this.eventRetryCounts.set(retryKey, retries);
+    const backoff = EventRouter.RETRY_BACKOFF_MS * Math.pow(2, retries - 1);
+    const existingTimer = this.eventRetryTimers.get(retryKey);
+    if (existingTimer) clearTimeout(existingTimer);
+
+    const timer = setTimeout(() => {
+      this.eventRetryTimers.delete(retryKey);
+      void this.handleEvent(event).catch((err) => {
+        log.warn('EventRouter: event preparation retry failed', { error: err, eventId: event.id });
+      });
+    }, backoff);
+    this.eventRetryTimers.set(retryKey, timer);
   }
 
   /**
@@ -1150,9 +1274,10 @@ When an event matches a subscription whose node execution is `idle` (agent sessi
 When a node execution is `pending` (no session yet):
 
 1. The event is queued in an in-memory `Map<string, ExternalEvent[]>` keyed by a JSON tuple `[workflowRunId, taskId, nodeId, agentName]` so free-form identifiers cannot collide by containing delimiter characters.
-2. When `TaskAgentManager` creates the node's session, it checks for queued events.
-3. Queued events are injected as initial context in the session's first turn.
-4. Queue is bounded: max 50 events per execution, oldest dropped (with a warning log).
+2. When `TaskAgentManager` creates the node's session, it calls `eventRouter.flushQueuedDeliveriesForSession(sub, sessionId)`.
+3. Queued events are injected through the same prepared-delivery path as live events, so successful flush marks the per-subscription delivery delivered and advances the source event only when all expected deliveries are terminal.
+4. If flush injection fails, the router clears the stale pending marker and schedules a normal delivery retry so the queued event is not silently lost.
+5. Queue is bounded: max 50 events per execution, oldest dropped (with a warning log).
 
 **Known limitation — daemon restart**: The in-memory per-node pending queue is lost on daemon restart. For v1, this is accepted as a known delivery gap:
 - The bus-level `ExternalEventStore` preserves the source event and can re-emit retryable states, but the per-node in-memory queue itself is not durable.
@@ -1490,7 +1615,7 @@ V1 needs one core event-store table plus workflow type additions:
 
 1. Add `EventInterest` interface to `packages/shared/src/types/space.ts`.
 2. Add `eventInterests?: EventInterest[]` to `WorkflowNodeAgent`.
-3. Add `ExternalEvent`, `EventAdapter`, `HttpEventAdapter`, `RpcEventAdapter`, and `EventPublisher` types under `packages/daemon/src/lib/space/runtime/event-bus/`.
+3. Add `ExternalEvent`, `EventAdapter`, `HttpEventAdapter`, `RpcEventAdapter`, `EventPublisher`, `ExternalEventStore`, and `EventTaskResolver` types under `packages/daemon/src/lib/space/runtime/event-bus/`.
 4. Add validation in the workflow create/update path (Zod schema or manual validation):
    - `topic` must pass `validateGlobPattern()` (non-empty, exactly 4 segments, no `..` segments, no double slashes, valid characters including segment-local `*`).
    - `scope` must be one of `'task' | 'repo' | 'global'`.
@@ -1704,7 +1829,7 @@ Direct injection via `sessionFactory.injectMessage()` is simpler and semanticall
 
 ### Why trie-based matching instead of regex?
 
-1. **Performance**: Trie lookup is O(k) per event regardless of subscription count. Regex matching is O(n) per event where n = number of subscriptions.
+1. **Performance**: Trie lookup walks O(2^k) paths and collects matching subscriptions from each leaf; non-matching subscriptions are never visited. Regex matching is O(n) per event where n = number of subscriptions.
 2. **Composability**: Trie supports incremental add/remove (subscriptions change as nodes activate/deactivate). Regex requires rebuilding the full pattern.
 3. **Debuggability**: Trie structure can be inspected and visualized. Regex patterns are opaque.
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -68,10 +68,18 @@ github/lsm/neokai/pull_request.review_*     ← prefix wildcard: all review even
 
 Subscriptions use glob-style patterns:
 - `*` matches any single path segment (no slashes)
-- `**` matches any number of path segments
 - Literal segments match exactly (case-insensitive)
 
-We implement matching via a **trie-based prefix index** (see §4), not regex. This keeps matching O(k) where k = topic depth, independent of the number of subscriptions.
+> **V1 scope note:** The `**` (multi-segment) wildcard is deferred to a follow-up. All v1 use cases are covered by single-segment `*` wildcards at the `owner`, `repo`, or `action` position (e.g., `github/*/*/pull_request.review_submitted`). Adding `**` support requires a depth-bounded recursive trie walk and is not justified by current subscription patterns.
+
+Pattern validation (enforced at workflow create/update time):
+- Must be non-empty.
+- Must not contain `..` segments.
+- Must not contain empty segments (no double slashes).
+- Each segment must be a literal string or `*`.
+- Max 10 interests per agent slot.
+
+We implement matching via a **trie-based prefix index** (see §4), not regex.
 
 ## 2. Node-Level Event Subscription (`eventInterests`)
 
@@ -293,11 +301,35 @@ class GitHubEventAdapter implements EventAdapter {
 
 The adapter subscribes to the existing `space.githubEvent.routed` DaemonHub event (already emitted by `SpaceGitHubService.appendTaskActivity`). It converts the event to `ExternalEvent` format and publishes to the bus.
 
+**Note — `action` field gap:** The current `space.githubEvent.routed` payload emitted by `appendTaskActivity` only includes `{ repo, prNumber, eventType, summary, externalUrl }`. It does NOT include `action`. The adapter needs the action to construct proper topics (e.g., `pull_request.review_submitted` vs `pull_request.opened`).
+
+**Fix:** Extend the `appendTaskActivity` payload in `SpaceGitHubService` to include `action`:
+
+```typescript
+// In space-github.ts, appendTaskActivity():
+this.daemonHub?.emit('space.githubEvent.routed', {
+    sessionId: 'global',
+    taskId,
+    event: {
+        repo: `${event.repoOwner}/${event.repoName}`,
+        prNumber: event.prNumber,
+        eventType: event.eventType,
+        action: event.action,           // ← ADD THIS
+        summary: event.summary,
+        externalUrl: event.externalUrl,
+        rawPayload: event.rawPayload,   // ← ADD THIS (for adapter consumers)
+    },
+});
+```
+
+This is a two-field addition to `appendTaskActivity` — both `action` and `rawPayload` are already available on the `NormalizedSpaceGitHubEvent` at the call site. This is the only change to existing code.
+
 **Why this approach:**
-- Zero changes to the existing `SpaceGitHubService` webhook handler or polling pipeline.
+- Minimal change to the existing `SpaceGitHubService` — two additional fields in an existing DaemonHub emission.
 - The existing PR-to-task resolution (`SpacePrTaskResolver`) continues to work.
 - The existing Task Agent injection continues to work (we don't replace it, we supplement it).
 - The adapter is purely additive: it converts an already-normalized event into bus format.
+- `rawPayload` is included so adapter consumers (and future adapters) have access to the full original event data without re-fetching from GitHub.
 
 ## 4. EventRouter Design
 
@@ -334,7 +366,7 @@ The trie maps topic segments to `Set<Subscription>` at leaf nodes. Wildcard segm
 
 **Build cost**: O(n × k) where n = number of subscriptions, k = topic depth (typically 4-5). Built once when a workflow run starts.
 
-**Lookup cost**: O(k) per event — walk the trie by topic segment, collect subscriptions at each level (exact match + wildcard).
+**Lookup cost**: The trie walks both exact-match and wildcard branches at each level. With k levels, this produces at most 2^k paths. At each leaf, m subscriptions are collected. Total cost per lookup is O(2^k × m) where m is the total number of matching subscriptions across all leaves. Since k is small and bounded (4–5 topic segments), 2^k is a small constant (16–32). The real benefit over linear scan is that non-matching subscriptions are never visited — only subscriptions whose pattern segments align with the event's topic are collected.
 
 ### Subscription index lifecycle
 
@@ -367,16 +399,45 @@ class EventRouter {
 
   // dedup: (dedupeKey, agentSessionId) → timestamp
   private delivered: Map<string, number> = new Map();
+  // TTL for dedup entries — entries older than this are evicted on next access
+  private static readonly DEDUP_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+  // Cache: spaceId → Set of "owner/repo" strings for watched repos
+  // Refreshed on spaceWorkflow.updated events (when watched repos change)
+  private watchedRepoCache: Map<string, Set<string>> = new Map();
 
   constructor(
     private readonly eventBus: EventBus,
     private readonly nodeExecutionRepo: NodeExecutionRepository,
     private readonly taskRepo: SpaceTaskRepository,
+    private readonly spaceTaskManager: SpaceTaskManager,
     private readonly sessionFactory: SessionFactory,
     private readonly prResolver: SpacePrTaskResolver,
+    private readonly spaceGitHubRepo: SpaceGitHubRepository,
   ) {
     // Subscribe to ALL events on the bus
     this.eventBus.subscribe('*', this.handleEvent.bind(this));
+  }
+
+  /** Check if a repo is watched for a given space. Uses cached data. */
+  private isWatchedRepo(spaceId: string, owner: string, repo: string): boolean {
+    let cached = this.watchedRepoCache.get(spaceId);
+    if (!cached) {
+      const repos = this.spaceGitHubRepo.listWatchedRepos(spaceId);
+      cached = new Set(
+        repos.filter(r => r.enabled).map(r => `${r.owner.toLowerCase()}/${r.repo.toLowerCase()}`)
+      );
+      this.watchedRepoCache.set(spaceId, cached);
+    }
+    return cached.has(`${owner.toLowerCase()}/${repo.toLowerCase()}`);
+  }
+
+  /** Evict stale dedup entries (called periodically or on demand). */
+  private evictStaleDedup(): void {
+    const cutoff = Date.now() - EventRouter.DEDUP_TTL_MS;
+    for (const [key, ts] of this.delivered.entries()) {
+      if (ts < cutoff) this.delivered.delete(key);
+    }
   }
 
   /**
@@ -424,6 +485,64 @@ class EventRouter {
     this.activeRuns.set(workflowRunId, runSubs);
   }
 
+  /**
+   * Unregister subscriptions for a specific node execution.
+   * Called when a node execution transitions to a non-receiving state.
+   *
+   * Receiving states: in_progress (active agent session)
+   * Non-receiving states: pending, idle, waiting_rebind, blocked, cancelled
+   *
+   * For `idle` and `waiting_rebind`, events may still be relevant (agent
+   * could be re-activated), so we keep subscriptions but skip delivery
+   * (the event is queued in the in-memory pending queue instead).
+   * For `blocked`/`cancelled`, subscriptions are fully removed.
+   */
+  unregisterExecution(
+    workflowRunId: string,
+    nodeId: string,
+    agentName: string,
+  ): void {
+    const runSubs = this.activeRuns.get(workflowRunId);
+    if (!runSubs) return;
+
+    const toRemove = [...runSubs].filter(
+      s => s.nodeId === nodeId && s.agentName === agentName,
+    );
+    for (const sub of toRemove) {
+      runSubs.delete(sub);
+      this.topicTrie.remove(
+        v => v.workflowRunId === workflowRunId && v.agentName === agentName && v.nodeId === nodeId,
+      );
+    }
+  }
+
+  /**
+   * Clear all subscriptions for a workflow run.
+   * Called when the workflow run reaches a terminal state (done, cancelled, blocked).
+   */
+  clearRunInterests(workflowRunId: string): void {
+    const runSubs = this.activeRuns.get(workflowRunId);
+    if (!runSubs) return;
+
+    this.topicTrie.remove(v => v.workflowRunId === workflowRunId);
+    this.activeRuns.delete(workflowRunId);
+
+    // Also clean up dedup entries for this run
+    const prefix = `:${workflowRunId}:`;
+    for (const key of this.delivered.keys()) {
+      if (key.includes(prefix)) {
+        this.delivered.delete(key);
+      }
+    }
+
+    // Clean up in-memory pending queue for this run
+    for (const [execId, events] of this.pendingQueue.entries()) {
+      if (execId.startsWith(workflowRunId)) {
+        this.pendingQueue.delete(execId);
+      }
+    }
+  }
+
   private async handleEvent(event: ExternalEvent): Promise<void> {
     // 1. Look up matching subscriptions via trie
     const matched = this.topicTrie.lookup(event.topic);
@@ -444,7 +563,7 @@ class EventRouter {
     const dedupeKey = `${event.dedupeKey}:${sub.agentName}:${sub.workflowRunId}`;
     if (this.delivered.has(dedupeKey)) return;
 
-    // Resolve session
+    // Resolve session — re-read from nodeExecutionRepo for latest state
     const sessionId = await this.resolveSession(sub);
     if (!sessionId) {
       // Session not active — queue for later delivery
@@ -452,7 +571,12 @@ class EventRouter {
       return;
     }
 
-    // Format and inject
+    // Format and inject.
+    // NOTE: There is a TOCTOU race — the session could complete between our
+    // resolveSession call and injectMessage. This is safe: injectMessage on a
+    // completed/absent session returns a caught error (logged as a warning),
+    // and the dedup map prevents re-delivery if the same event arrives again
+    // after the session restarts. No data loss or corruption occurs.
     const message = this.formatEventMessage(event);
     try {
       await this.sessionFactory.injectMessage(sessionId, message, {
@@ -463,6 +587,9 @@ class EventRouter {
       this.delivered.set(dedupeKey, Date.now());
     } catch (err) {
       log.warn(`Failed to deliver event to ${sub.agentName}`, { error: err });
+      // Session may have completed between resolution and injection.
+      // This is expected and safe — the event is NOT marked as delivered,
+      // so if the session restarts, the event can be re-attempted.
     }
   }
 
@@ -472,23 +599,35 @@ class EventRouter {
         return true;
 
       case 'repo': {
-        // Check if event's repo matches any watched repo in this space
+        // Check if event's repo matches any watched repo in this space.
+        // Uses SpaceGitHubRepository.getEnabledRepos(owner, repo) which queries
+        // the `space_github_watched_repos` table filtered by (spaceId, owner, repo, enabled=1).
+        // The router caches this per-space to avoid DB hits on every event.
         if (!event.repoOwner || !event.repoName) return false;
         return this.isWatchedRepo(sub.spaceId, event.repoOwner, event.repoName);
       }
 
       case 'task': {
-        // Check if event's PR number matches the subscription's task
+        // Check if event's PR number matches any task in this workflow run.
+        // Note: a workflow run CAN have multiple tasks (e.g., sub-tasks created
+        // by the planner). We check ALL non-archived tasks for a PR match.
         if (!event.prNumber) return false;
-        const task = this.taskRepo.getByWorkflowRunId(sub.workflowRunId);
-        if (!task) return false;
-        // Reuse the existing SpacePrTaskResolver logic
-        return this.prResolver.resolve(sub.spaceId, {
-          repoOwner: event.repoOwner ?? '',
-          repoName: event.repoName ?? '',
-          prNumber: event.prNumber,
-          // ... minimal shape for resolver
-        } as any).taskId === task.id;
+        const tasks = this.taskRepo.listByWorkflowRun(sub.workflowRunId);
+        if (tasks.length === 0) return false;
+
+        // The SpacePrTaskResolver already handles the PR → task matching logic.
+        // For the common case (1 task per run), this is a single lookup.
+        // For multi-task runs, we check if any task matches.
+        for (const task of tasks) {
+          const resolved = this.prResolver.resolve(sub.spaceId, {
+            repoOwner: event.repoOwner ?? '',
+            repoName: event.repoName ?? '',
+            prNumber: event.prNumber,
+            // ... minimal shape for resolver
+          } as any);
+          if (resolved.taskId === task.id) return true;
+        }
+        return false;
       }
     }
   }
@@ -534,10 +673,17 @@ When an event matches a subscription whose node execution is `idle` (agent sessi
 
 When a node execution is `pending` (no session yet):
 
-1. The event is queued in an in-memory `Map<executionId, ExternalEvent[]>`.
+1. The event is queued in an in-memory `Map<string, ExternalEvent[]>` keyed by `${workflowRunId}:${nodeId}:${agentName}`.
 2. When `TaskAgentManager` creates the node's session, it checks for queued events.
 3. Queued events are injected as initial context in the session's first turn.
 4. Queue is bounded: max 50 events per execution, oldest dropped (with a warning log).
+
+**Known limitation — daemon restart**: The in-memory pending queue is lost on daemon restart. For v1, this is acceptable because:
+- Events between daemon restarts are also lost (the webhook/polling pipeline itself doesn't guarantee delivery during downtime).
+- The existing `SpaceGitHubService` polling service re-polls on startup, so events that arrived during downtime are re-normalized and re-routed.
+- For nodes that are still `pending` after restart, the next poll cycle will generate fresh events that flow through the bus.
+
+If persistent queuing is needed in a future iteration, events can be persisted to a `space_event_delivery_queue` SQLite table with the same schema as the in-memory map, and drained on node activation.
 
 ### Backpressure
 
@@ -576,7 +722,9 @@ class TopicTrie<T> {
   /**
    * Lookup all values whose patterns match the given topic.
    * Returns all values from exact matches AND wildcard matches at each level.
-   * O(depth) — independent of total number of patterns.
+   * Walks at most 2^k paths where k = topic segment count (bounded, small).
+   * Only collects subscriptions from matching leaves — non-matching patterns
+   * are never visited.
    */
   lookup(topic: string): T[] {
     const segments = topic.split('/');
@@ -626,18 +774,34 @@ class TrieNode<T> {
 }
 ```
 
+### Helper: `isReceivingStatus`
+
+```typescript
+import type { NodeExecutionStatus } from '@neokai/shared';
+
+/** Node execution states that should NOT receive events. */
+const TERMINAL_RECEIVING_STATES: ReadonlySet<NodeExecutionStatus> = new Set([
+  'cancelled',
+  // Note: 'idle' and 'waiting_rebind' keep their subscriptions alive —
+  // the agent session exists and may be re-activated. Events are queued
+  // rather than delivered immediately for these states.
+]);
+
+function isReceivingStatus(status: NodeExecutionStatus): boolean {
+  return !TERMINAL_RECEIVING_STATES.has(status);
+}
+```
+
 **Complexity**:
 - Insert: O(k) where k = segment count (~4-5)
-- Lookup: O(k) — walks trie by segment, collects from exact + wildcard at each level
+- Lookup: O(2^k × m) — walks at most 2^k paths (exact + wildcard at each level), collects m total matching subscriptions from leaves. Since k is bounded (4–5), 2^k is a small constant.
 - Memory: O(n × k) where n = number of subscriptions
-
-This is O(1) relative to the number of subscriptions — each lookup traverses at most 2^k paths (2 per level: exact + wildcard), and k is small and constant.
 
 ## 7. Wiring the GitHub Adapter
 
 ### Changes to existing code
 
-**Minimal.** The adapter hooks into the existing `SpaceGitHubService` via DaemonHub subscription:
+**Two-field addition.** The `appendTaskActivity` method in `space-github.ts` must include `action: event.action` and `rawPayload: event.rawPayload` in the `space.githubEvent.routed` DaemonHub payload. This is the only change to existing code. All other existing behavior (webhook handling, polling, normalization, Task Agent injection) remains unchanged.
 
 ```
 SpaceGitHubService.handleWebhook()
@@ -661,9 +825,10 @@ class GitHubEventAdapter implements EventAdapter {
   async start(publisher: EventPublisher): Promise<void> {
     this.daemonHub.on('space.githubEvent.routed', async (data) => {
       const { event, taskId } = data;
+      const [repoOwner, repoName] = event.repo.split('/');
 
       // Construct topic from event
-      const topic = `github/${event.repo.split('/')[0]}/${event.repo.split('/')[1]}/${mapEventType(event.eventType)}.${mapAction(event.action)}`;
+      const topic = `github/${repoOwner}/${repoName}/${mapEventType(event.eventType)}.${mapAction(event.action)}`;
 
       // Publish to bus
       await publisher.publish({
@@ -673,12 +838,18 @@ class GitHubEventAdapter implements EventAdapter {
         ingestedAt: Date.now(),
         source: 'github',
         prNumber: event.prNumber,
-        repoOwner: event.repo.split('/')[0],
-        repoName: event.repo.split('/')[1],
+        repoOwner,
+        repoName,
         summary: event.summary,
         externalUrl: event.externalUrl,
-        payload: event,
-        dedupeKey: `github:${event.repo}:${event.prNumber}:${event.eventType}:${event.externalUrl}`,
+        payload: {
+          // Full normalized event for adapter consumers
+          eventType: event.eventType,
+          action: event.action,
+          taskId,
+          rawPayload: event.rawPayload,   // Include original webhook/polling payload
+        },
+        dedupeKey: `github:${event.repo}:${event.prNumber}:${event.eventType}:${event.action}:${event.externalUrl}`,
       });
     });
   }
@@ -716,9 +887,10 @@ None required for V1. Event interests are stored as part of the workflow definit
 1. Add `EventInterest` interface to `packages/shared/src/types/space.ts`.
 2. Add `eventInterests?: EventInterest[]` to `WorkflowNodeAgent`.
 3. Add validation in the workflow create/update path (Zod schema or manual validation):
-   - `topic` must be a valid glob pattern (non-empty, no `..` segments).
+   - `topic` must pass `validateGlobPattern()` (non-empty, no `..` segments, no double slashes, valid characters).
    - `scope` must be one of `'task' | 'repo' | 'global'`.
    - Max 10 interests per agent slot (prevent abuse).
+   - `validateGlobPattern()` is the single source of truth — called at workflow create/update and again at trie insertion time as a safety net.
 
 ### New files
 
@@ -727,9 +899,50 @@ packages/daemon/src/lib/space/runtime/event-bus/
   ├── types.ts              # ExternalEvent, EventAdapter, EventPublisher interfaces
   ├── event-bus.ts           # EventBus singleton (wraps TypedHub)
   ├── topic-trie.ts          # TopicTrie<T> implementation
+  ├── topic-validator.ts     # validateGlobPattern() helper
   ├── event-router.ts        # EventRouter — subscribes to bus, matches, delivers
   ├── github-adapter.ts      # GitHubEventAdapter — bridges SpaceGitHubService → EventBus
   └── index.ts               # Public exports
+```
+
+### Topic pattern validation
+
+```typescript
+// topic-validator.ts
+
+/**
+ * Validate a glob pattern for event subscriptions.
+ * Rejects patterns that could corrupt the trie or match unintended topics.
+ * Called at workflow create/update time and again at trie insertion time.
+ */
+export function validateGlobPattern(pattern: string): { valid: boolean; reason?: string } {
+  if (!pattern || pattern.trim().length === 0) {
+    return { valid: false, reason: 'Topic pattern must not be empty' };
+  }
+
+  const segments = pattern.split('/');
+
+  if (segments.length < 2) {
+    return { valid: false, reason: 'Topic pattern must have at least 2 segments (source/resource)' };
+  }
+
+  for (const segment of segments) {
+    if (segment === '') {
+      return { valid: false, reason: 'Topic pattern must not contain empty segments (double slashes)' };
+    }
+    if (segment === '..') {
+      return { valid: false, reason: 'Topic pattern must not contain ".." segments' };
+    }
+    if (segment !== '*' && !/^[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*$/.test(segment)) {
+      return {
+        valid: false,
+        reason: `Segment "${segment}" contains invalid characters. Use alphanumeric, dash, underscore, or dot. Use "*" for wildcard.`,
+      };
+    }
+  }
+
+  return { valid: true };
+}
 ```
 
 ### Wiring into SpaceRuntime
@@ -845,7 +1058,10 @@ This is exactly the behavior we want for external events.
 
 ### Integration tests
 
-1. End-to-end: webhook → normalize → ingest → bus → router → session injection.
-2. Dedup: same event delivered twice, verify only one injection.
-3. Wake-on-idle: node idle → event arrives → session receives message.
-4. Pending node: event arrives for pending node → session created → event delivered.
+1. **End-to-end webhook flow**: Emit a `space.githubEvent.routed` event with a review_submitted action for PR #42 on repo `lsm/neokai`. The coder node in a workflow has `task`-scoped interest in `github/*/*/pull_request.review_submitted`. Verify the event reaches the coder node's session as an injected message.
+
+2. **Dedup across two events with same dedupeKey**: Emit two `space.githubEvent.routed` events for the same PR review (identical `dedupeKey`). Verify `injectMessage` is called exactly once for the coder node — the second event is silently dropped by the dedup check. Also verify that if two *different* nodes subscribe to the same event (e.g., coder + ci-monitor), each node receives exactly one injection independently.
+
+3. **Wake-on-idle delivery**: Set a node execution's session to `idle` state (agent finished its turn). Emit a matching event. Verify `injectMessage` is called with `deliveryMode: 'defer'` and the session processes the message on its next turn (via the existing defer replay mechanism).
+
+4. **Pending node queuing**: Emit an event for a node whose execution is `pending` (no session yet). Verify the event is stored in the in-memory pending queue. Then simulate `TaskAgentManager` creating the session. Verify the queued event is flushed and injected into the new session as part of the first turn.

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -49,8 +49,9 @@ Examples:
 github/lsm/neokai/pull_request.review_submitted
 github/lsm/neokai/pull_request.comment_created
 github/lsm/neokai/pull_request.synchronize
-github/lsm/neokai/check_suite.completed
+github/lsm/neokai/pull_request.closed
 github/lsm/neokai/issues.opened
+# Future CI adapter (Phase 3): github/lsm/neokai/check_suite.completed
 github/lsm/neokai/pull_request.*            ← wildcard: all PR events for this repo
 github/lsm/neokai/*.*                       ← wildcard: all events for this repo
 github/lsm/neokai/pull_request.review_*     ← prefix wildcard: all review events
@@ -60,7 +61,7 @@ github/lsm/neokai/pull_request.review_*     ← prefix wildcard: all review even
 
 1. `source` — adapter identifier (`github`, `slack`, `ci`). Lowercase, no slashes.
 2. `owner/repo` — from the event's repository context. Both lowercase for case-insensitive matching.
-3. `resource` — the GitHub resource type: `pull_request`, `issue`, `check_suite`, `pull_request_review`, etc.
+3. `resource` — the event resource type. V1 GitHub adapter emits PR-related resources (`pull_request`, `pull_request.comment`, `pull_request.review`, `pull_request.review_comment`). CI resources such as `check_suite` are Phase 3/future adapter scope.
 4. `action` — the specific action: `opened`, `review_submitted`, `comment_created`, `completed`, etc.
 5. All v1 topics use exactly 4 path segments. For resources without a natural `owner/repo` (e.g. a future Slack message), use a source-specific scope pair to preserve the same depth: `{source}/{workspace}/{channel}/{resource}.{action}` (for example, `slack/acme/eng/messages.created`). Adapters that do not have both scope levels should use a reserved placeholder segment such as `_` rather than emitting 3-segment topics.
 
@@ -94,7 +95,7 @@ We implement matching via a **trie-based prefix index** (see §4), not regex.
 export interface EventInterest {
   /**
    * Glob pattern matching event topics.
-   * Examples: 'github/*/*/pull_request.*', 'ci/*/*/check_suite.completed'
+   * Examples: 'github/*/*/pull_request.*', 'github/*/*/pull_request.review_*'
    */
   topic: string;
 
@@ -159,15 +160,15 @@ export interface WorkflowNodeAgent {
     },
     {
       "id": "monitor",
-      "name": "CI Monitor",
+      "name": "PR Monitor",
       "agents": [{
         "agentId": "...",
-        "name": "ci-monitor",
+        "name": "pr-monitor",
         "eventInterests": [
           {
-            "topic": "github/*/*/check_suite.completed",
+            "topic": "github/*/*/pull_request.*",
             "scope": "repo",
-            "label": "All CI completions in the repo"
+            "label": "All PR activity in the repo"
           }
         ]
       }]
@@ -304,9 +305,9 @@ class GitHubEventAdapter implements EventAdapter {
 
 The adapter subscribes to the existing `space.githubEvent.routed` DaemonHub event (already emitted by `SpaceGitHubService.appendTaskActivity`). It converts the event to `ExternalEvent` format and publishes to the bus.
 
-**Note — `action` field gap:** The current `space.githubEvent.routed` payload emitted by `appendTaskActivity` only includes `{ repo, prNumber, eventType, summary, externalUrl }`. It does NOT include `action`. The adapter needs the action to construct proper topics (e.g., `pull_request.review_submitted` vs `pull_request.opened`).
+**Note — normalized field gap:** The current `space.githubEvent.routed` payload emitted by `appendTaskActivity` only includes `{ repo, prNumber, eventType, summary, externalUrl }`. It does NOT include the stable dedupe identifiers or the full normalized GitHub fields needed for topic construction and fallback task resolution.
 
-**Fix:** Extend the `appendTaskActivity` payload in `SpaceGitHubService` to include `action`:
+**Fix:** Extend the `appendTaskActivity` payload in `SpaceGitHubService` to include the normalized fields consumed by the adapter:
 
 ```typescript
 // In space-github.ts, appendTaskActivity():
@@ -317,20 +318,26 @@ this.daemonHub?.emit('space.githubEvent.routed', {
         repo: `${event.repoOwner}/${event.repoName}`,
         prNumber: event.prNumber,
         eventType: event.eventType,
-        action: event.action,           // ← ADD THIS
+        action: event.action,
+        source: event.source,
         summary: event.summary,
+        prUrl: event.prUrl,
         externalUrl: event.externalUrl,
-        rawPayload: event.rawPayload,   // ← ADD THIS (for adapter consumers)
-        dedupeKey: event.dedupeKey,    // ← ADD THIS (for adapter deduplication)
-        deliveryId: event.deliveryId, // ← ADD THIS (unique GitHub delivery ID)
+        externalId: event.externalId,
+        actor: event.actor,
+        body: event.body,
+        occurredAt: event.occurredAt,
+        rawPayload: event.rawPayload,
+        dedupeKey: event.dedupeKey,
+        deliveryId: event.deliveryId,
     },
 });
 ```
 
-This is a four-field addition to `appendTaskActivity` — `action`, `rawPayload`, `dedupeKey`, and `deliveryId` are all already available on the `NormalizedSpaceGitHubEvent` at the call site. This is the only change to existing code.
+This is a payload-contract extension to `appendTaskActivity` using fields already available on the `NormalizedSpaceGitHubEvent` at the call site. `dedupeKey` and `deliveryId` are required for stable upstream event identity; `prUrl` and the other normalized fields keep the `SpacePrTaskResolver` fallback functional if `taskId` is absent.
 
 **Why this approach:**
-- Minimal change to the existing `SpaceGitHubService` — four additional fields (`action`, `deliveryId`, `dedupeKey`, `rawPayload`) in an existing DaemonHub emission.
+- Minimal change to the existing `SpaceGitHubService` — additional normalized fields in an existing DaemonHub emission, with no changes to ingestion/dedup/routing behavior.
 - The existing PR-to-task resolution (`SpacePrTaskResolver`) continues to work.
 - The existing Task Agent injection continues to work (we don't replace it, we supplement it).
 - The adapter is purely additive: it converts an already-normalized event into bus format.
@@ -361,8 +368,8 @@ root
               │   └── [subscriptions: coder(task)]
               ├── pull_request.comment_created
               │   └── [subscriptions: coder(task)]
-              └── check_suite.completed
-                  └── [subscriptions: ci-monitor(repo)]
+              └── pull_request.review_comment_created
+                  └── [subscriptions: coder(task)]
 ```
 
 The trie maps topic segments to `Set<Subscription>` at leaf nodes. Each node stores exact children separately from segment-local glob children. A glob segment may be a whole-segment wildcard (`*`) or a dotted segment wildcard (`pull_request.*`, `pull_request.review_*`, `*.*`).
@@ -718,12 +725,28 @@ class EventRouter {
         }
 
         // Fallback (should rarely happen): if the adapter didn't include taskId,
-        // resolve by PR and require that the resolver points to THIS task.
+        // resolve with the full normalized GitHub shape. SpacePrTaskResolver's
+        // primary queries use prUrl, so passing only owner/repo/prNumber would
+        // make this fallback ineffective for older routed payloads.
+        if (event.source !== 'github') return false;
         const resolved = this.prResolver.resolve(sub.spaceId, {
+          deliveryId: event.payload?.deliveryId as string | undefined,
+          dedupeKey: event.dedupeKey,
+          source: 'webhook',
+          eventType: event.payload?.eventType as string,
+          action: event.payload?.action as string,
           repoOwner: event.repoOwner ?? '',
           repoName: event.repoName ?? '',
           prNumber: event.prNumber,
-        } as any);
+          prUrl: (event.payload?.prUrl as string | undefined) ?? event.externalUrl,
+          actor: event.payload?.actor as string | undefined,
+          body: event.payload?.body as string | undefined,
+          summary: event.summary,
+          externalUrl: event.externalUrl,
+          externalId: event.payload?.externalId as string | undefined,
+          occurredAt: (event.payload?.occurredAt as string | undefined) ?? new Date(event.occurredAt).toISOString(),
+          rawPayload: event.payload?.rawPayload,
+        } as NormalizedSpaceGitHubEvent);
         return resolved.taskId === sub.taskId;
       }
     }
@@ -941,7 +964,7 @@ function isReceivingStatus(status: NodeExecutionStatus): boolean {
 
 ### Changes to existing code
 
-**Four-field addition.** The `appendTaskActivity` method in `space-github.ts` must include `action`, `rawPayload`, `dedupeKey`, and `deliveryId` in the `space.githubEvent.routed` DaemonHub payload. The adapter requires `dedupeKey` as the stable upstream event identity for per-subscription deduplication, and `deliveryId` preserves the unique GitHub delivery identifier used to build that identity. This is the only change to existing code. All other existing behavior (webhook handling, polling, normalization, Task Agent injection) remains unchanged.
+**Routed payload contract extension.** The `appendTaskActivity` method in `space-github.ts` must include the normalized fields consumed by the adapter in the `space.githubEvent.routed` DaemonHub payload, including `action`, `source`, `prUrl`, `externalId`, `actor`, `body`, `occurredAt`, `rawPayload`, `dedupeKey`, and `deliveryId`. The adapter requires `dedupeKey` as the stable upstream event identity for per-subscription deduplication, `deliveryId` preserves the unique GitHub delivery identifier used to build that identity, and `prUrl` keeps the `SpacePrTaskResolver` fallback functional. This is the only change to existing code. All other existing behavior (webhook handling, polling, normalization, Task Agent injection) remains unchanged.
 
 ```
 SpaceGitHubService.handleWebhook()
@@ -985,10 +1008,17 @@ class GitHubEventAdapter implements EventAdapter {
         summary: event.summary,
         externalUrl: event.externalUrl,
         payload: {
-          // Full normalized event for adapter consumers
+          // Full normalized event for adapter consumers and resolver fallback
           eventType: event.eventType,
           action: event.action,
+          source: event.source,
           taskId,
+          prUrl: event.prUrl,
+          deliveryId: event.deliveryId,
+          externalId: event.externalId,
+          actor: event.actor,
+          body: event.body,
+          occurredAt: event.occurredAt,
           rawPayload: event.rawPayload,   // Include original webhook/polling payload
         },
         dedupeKey: event.dedupeKey,  // Use upstream identity (includes deliveryId); avoids collapsing distinct events that share repo/pr/action/url

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -463,7 +463,7 @@ class EventRouter {
         const exec = nodeExecutions.find(
           e => e.workflowNodeId === node.id && e.agentName === agent.name
         );
-        if (!exec || isTerminal(exec.status)) continue;
+        if (!exec || !isReceivingStatus(exec.status)) continue;
 
         for (const interest of agent.eventInterests) {
           const sub: Subscription = {
@@ -487,15 +487,16 @@ class EventRouter {
 
   /**
    * Unregister subscriptions for a specific node execution.
-   * Called when a node execution transitions to a non-receiving state.
+   * Called when a node execution transitions to `cancelled` state.
    *
-   * Receiving states: in_progress (active agent session)
-   * Non-receiving states: pending, idle, waiting_rebind, blocked, cancelled
+   * Only `cancelled` nodes are removed from the subscription index.
+   * All other states (`pending`, `in_progress`, `idle`, `waiting_rebind`,
+   * `blocked`) remain subscribed because:
+   * - `in_progress`: live session receives events immediately
+   * - `idle`: session exists and can be woken via injectMessage (defer mode)
+   * - `waiting_rebind`/`blocked`/`pending`: events queued for later delivery
    *
-   * For `idle` and `waiting_rebind`, events may still be relevant (agent
-   * could be re-activated), so we keep subscriptions but skip delivery
-   * (the event is queued in the in-memory pending queue instead).
-   * For `blocked`/`cancelled`, subscriptions are fully removed.
+   * See `isReceivingStatus` helper for the complete state classification.
    */
   unregisterExecution(
     workflowRunId: string,
@@ -610,22 +611,32 @@ class EventRouter {
       }
 
       case 'task': {
-        // Check if event's PR number matches any task in this workflow run.
-        // Note: a workflow run CAN have multiple tasks (e.g., sub-tasks created
-        // by the planner). We check ALL non-archived tasks for a PR match.
+        // The DaemonHub 'space.githubEvent.routed' event already carries the
+        // resolved taskId from SpacePrTaskResolver. We use that directly instead
+        // of re-running the resolver, which could match a historical task outside
+        // this run (SpacePrTaskResolver searches ALL tasks in the space).
+        //
+        // We constrain matching to tasks within THIS workflow run only:
+        // 1. Load all non-archived tasks for this run.
+        // 2. Check if the event's routed taskId is among them.
         if (!event.prNumber) return false;
-        const tasks = this.taskRepo.listByWorkflowRun(sub.workflowRunId);
-        if (tasks.length === 0) return false;
 
-        // The SpacePrTaskResolver already handles the PR → task matching logic.
-        // For the common case (1 task per run), this is a single lookup.
-        // For multi-task runs, we check if any task matches.
+        // Optimization: the adapter includes the routed taskId in ExternalEvent.payload.
+        // Use it for a direct membership check — no resolver call needed.
+        const routedTaskId = event.payload?.taskId as string | undefined;
+        if (routedTaskId) {
+          const tasks = this.taskRepo.listByWorkflowRun(sub.workflowRunId);
+          return tasks.some(t => t.id === routedTaskId);
+        }
+
+        // Fallback (should rarely happen): if the adapter didn't include taskId,
+        // load run tasks and check if any references the event's PR number.
+        const tasks = this.taskRepo.listByWorkflowRun(sub.workflowRunId);
         for (const task of tasks) {
           const resolved = this.prResolver.resolve(sub.spaceId, {
             repoOwner: event.repoOwner ?? '',
             repoName: event.repoName ?? '',
             prNumber: event.prNumber,
-            // ... minimal shape for resolver
           } as any);
           if (resolved.taskId === task.id) return true;
         }
@@ -778,19 +789,36 @@ class TrieNode<T> {
 
 ### Helper: `isReceivingStatus`
 
+Determines whether a node execution should remain in the subscription index.
+This is intentionally different from `TERMINAL_NODE_EXECUTION_STATUSES` in
+`node-execution-manager.ts`, which includes `idle`. For the event bus, `idle`
+nodes MUST stay subscribed because:
+
+1. The agent session still exists and can be woken via `injectMessage`.
+2. The `deliveryMode: 'defer'` mechanism handles idle sessions natively.
+3. Removing idle nodes from the subscription index would prevent wake-on-idle
+   delivery — the core use case for the event bus.
+
 ```typescript
 import type { NodeExecutionStatus } from '@neokai/shared';
 
-/** Node execution states that should NOT receive events. */
-const TERMINAL_RECEIVING_STATES: ReadonlySet<NodeExecutionStatus> = new Set([
+/**
+ * States where the node should be excluded from the subscription index.
+ * Only `cancelled` is excluded — the node has been permanently stopped.
+ *
+ * States that remain subscribed:
+ * - `pending`       — no session yet, events queued for first turn
+ * - `in_progress`   — live session, events injected immediately
+ * - `idle`          — session exists but finished a turn; events wake it
+ * - `waiting_rebind` — session paused for tool recovery; events queued
+ * - `blocked`       — session exists but waiting for human; events queued
+ */
+const NON_RECEIVING_STATES: ReadonlySet<NodeExecutionStatus> = new Set([
   'cancelled',
-  // Note: 'idle' and 'waiting_rebind' keep their subscriptions alive —
-  // the agent session exists and may be re-activated. Events are queued
-  // rather than delivered immediately for these states.
 ]);
 
 function isReceivingStatus(status: NodeExecutionStatus): boolean {
-  return !TERMINAL_RECEIVING_STATES.has(status);
+  return !NON_RECEIVING_STATES.has(status);
 }
 ```
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -407,7 +407,8 @@ class EventRouter {
   private static readonly DEDUP_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
   // Cache: spaceId → Set of "owner/repo" strings for watched repos
-  // Refreshed on spaceWorkflow.updated events (when watched repos change)
+  // Invalidated via invalidateWatchedRepoCache() when repos are added/removed
+  // through the `space.github.watchRepo` RPC path.
   private watchedRepoCache: Map<string, Set<string>> = new Map();
 
   constructor(
@@ -434,6 +435,20 @@ class EventRouter {
       this.watchedRepoCache.set(spaceId, cached);
     }
     return cached.has(`${owner.toLowerCase()}/${repo.toLowerCase()}`);
+  }
+
+  /**
+   * Invalidate the watched-repo cache for a given space (or all spaces).
+   * Called when watched repos change via the `space.github.watchRepo` RPC path
+   * (enabling/disabling repos). Without this, `repo`-scoped matching grows stale
+   * until process restart.
+   */
+  invalidateWatchedRepoCache(spaceId?: string): void {
+    if (spaceId) {
+      this.watchedRepoCache.delete(spaceId);
+    } else {
+      this.watchedRepoCache.clear();
+    }
   }
 
   /** Evict stale dedup entries (called periodically or on demand). */
@@ -472,8 +487,9 @@ class EventRouter {
 
         const subKey = `${node.id}:${agent.name}`;
         for (const interest of agent.eventInterests) {
-          // Include interest topic in key so a single agent can have multiple interests
-          const fullKey = `${subKey}:${interest.topic}`;
+          // Include topic AND scope in key — same agent can subscribe to the same topic
+          // with different scopes (e.g., both 'task' and 'repo' scope for the same pattern).
+          const fullKey = `${subKey}:${interest.topic}:${interest.scope}`;
           desiredSubs.set(fullKey, {
             workflowRunId,
             nodeId: node.id,
@@ -490,20 +506,22 @@ class EventRouter {
     const currentSubs = this.activeRuns.get(workflowRunId) ?? new Set<Subscription>();
     const currentKeys = new Set<string>();
     for (const sub of currentSubs) {
-      currentKeys.add(`${sub.nodeId}:${sub.agentName}:${sub.interest.topic}`);
+      currentKeys.add(`${sub.nodeId}:${sub.agentName}:${sub.interest.topic}:${sub.interest.scope}`);
     }
     const desiredKeys = new Set(desiredSubs.keys());
 
     // Remove subscriptions no longer in the desired set (e.g. node went cancelled).
     for (const key of currentKeys) {
       if (!desiredKeys.has(key)) {
-        const [nodeId, agentName, ...topicParts] = key.split(':');
-        const topic = topicParts.join(':');
+        const [nodeId, agentName, ...rest] = key.split(':');
+        const scope = rest.pop()!;
+        const topic = rest.join(':');
         this.topicTrie.remove(
           v => v.workflowRunId === workflowRunId
             && v.nodeId === nodeId
             && v.agentName === agentName
-            && v.interest.topic === topic,
+            && v.interest.topic === topic
+            && v.interest.scope === scope,
         );
       }
     }
@@ -1010,6 +1028,11 @@ packages/daemon/src/lib/space/runtime/event-bus/
  * Validate a glob pattern for event subscriptions.
  * Rejects patterns that could corrupt the trie or match unintended topics.
  * Called at workflow create/update time and again at trie insertion time.
+ *
+ * Requires at least 4 segments because all event topics have the format
+ * `{source}/{owner}/{repo}/{resource}.{action}` (4 segments minimum).
+ * Patterns like `github/*` would pass validation but never match any event,
+ * creating silent misconfigurations.
  */
 export function validateGlobPattern(pattern: string): { valid: boolean; reason?: string } {
   if (!pattern || pattern.trim().length === 0) {
@@ -1018,8 +1041,11 @@ export function validateGlobPattern(pattern: string): { valid: boolean; reason?:
 
   const segments = pattern.split('/');
 
-  if (segments.length < 2) {
-    return { valid: false, reason: 'Topic pattern must have at least 2 segments (source/resource)' };
+  if (segments.length < 4) {
+    return {
+      valid: false,
+      reason: `Topic pattern must have at least 4 segments (source/owner/repo/resource.action); got ${segments.length}. Example: 'github/*/*/pull_request.review_submitted'`,
+    };
   }
 
   for (const segment of segments) {
@@ -1066,6 +1092,11 @@ if (this.eventRouter) {
 if (newStatus === 'done' || newStatus === 'cancelled') {
   this.eventRouter.clearRunInterests(workflowRunId);
 }
+
+// In the `space.github.watchRepo` RPC handler (packages/daemon/src/lib/rpc-handlers/index.ts):
+// After persisting the watch/unwatch change, invalidate the watched-repo cache
+// so that repo-scoped matching reflects the new state immediately.
+await this.eventRouter.invalidateWatchedRepoCache(spaceId);
 
 // In daemon startup (e.g. in SpaceRuntimeService or init function):
 const eventBus = new EventBus(daemonHub);

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -181,7 +181,7 @@ export interface WorkflowNodeAgent {
 
 **`task` scope** is the critical innovation. The router resolves the task's context at match time:
 
-1. The task's `SpaceTask` record has `workflowRunId` and (via `workflow_run_artifacts` or gate data) an associated PR number and branch name.
+1. The task's `SpaceTask` record has `workflowRunId` and (via `space_workflow_run_artifacts` where `key = 'pr_url'` matches the event's `prUrl`, or gate data with `branch_name`) an associated PR number and branch name.
 2. The router queries the same `SpacePrTaskResolver` that `SpaceGitHubService` already uses to match PR numbers to tasks.
 3. For a `task`-scoped subscription, the router checks: does this event's PR number / branch match the node execution's parent task?
 4. The node author never specifies a PR number — it's implicit from the task context.

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -336,6 +336,8 @@ export interface ExternalEventStore {
   ): void;
   /** Returns true when the delivery row is already terminal and should be skipped. */
   isDeliveryTerminal(eventId: string, deliveryKey: string): boolean;
+  /** Looks up the source event id for a registered delivery key. */
+  getEventIdForDeliveryKey(deliveryKey: string): string;
   markDeliveryDelivered(eventId: string, deliveryKey: string): void;
   markDeliveryFailed(
     eventId: string,
@@ -563,7 +565,12 @@ interface PendingDelivery {
 interface QueuedDeliveryFailure {
   eventId: string;
   deliveryKey: string;
-  reason: 'pending_queue_overflow' | 'run_terminal_cleanup';
+  reason: 'pending_queue_overflow' | 'run_terminal_cleanup' | 'run_terminal_retry_cancelled';
+}
+
+interface EventRetryState {
+  event: ExternalEvent;
+  matched: Subscription[];
 }
 
 interface WatchedRepoLookup {
@@ -597,6 +604,7 @@ class EventRouter {
   // Retry keys are JSON tuples: [event.id, sorted workflowRunIds, 'prepare'].
   private eventRetryCounts: Map<string, number> = new Map();
   private eventRetryTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
+  private eventRetryState: Map<string, EventRetryState> = new Map();
   private static readonly MAX_RETRIES = 3;
   private static readonly RETRY_BACKOFF_MS = 1000; // 1s base, exponential backoff
 
@@ -874,23 +882,52 @@ class EventRouter {
         this.retryCounts.delete(key);
       }
     }
+    // Cancel per-delivery retry timers for this terminal run. These deliveries
+    // were already registered, so cancellation must terminally fail them before
+    // dropping retry bookkeeping; otherwise their rows can block event terminalization.
+    const retryCancellationFailures: QueuedDeliveryFailure[] = [];
     for (const [key, timer] of this.retryTimers.entries()) {
       const [, , , , keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string, string];
       if (keyWorkflowRunId === workflowRunId) {
         clearTimeout(timer);
         this.retryTimers.delete(key);
+        retryCancellationFailures.push({
+          eventId: this.eventStore.getEventIdForDeliveryKey(key),
+          deliveryKey: key,
+          reason: 'run_terminal_retry_cancelled',
+        });
       }
     }
+    this.markQueuedDeliveriesFailed(retryCancellationFailures);
 
-    // Event-level preparation retries may cover multiple runs. Retry keys are
-    // JSON tuples, so parse the workflowRunIds array structurally instead of using
-    // substring matching (comma-separated run ids are not colon-delimited).
+    // Event-level preparation retries may cover multiple runs. If a retry includes
+    // both this terminal run and still-active runs, cancel the old shared timer and
+    // reschedule retry state for surviving runs instead of dropping their retry path.
     for (const [key, timer] of this.eventRetryTimers.entries()) {
-      const [, keyWorkflowRunIds] = JSON.parse(key) as [string, string[], 'prepare'];
-      if (keyWorkflowRunIds.includes(workflowRunId)) {
+      const [eventId, keyWorkflowRunIds] = JSON.parse(key) as [string, string[], 'prepare'];
+      if (!keyWorkflowRunIds.includes(workflowRunId)) continue;
+
+      const remainingRunIds = keyWorkflowRunIds.filter(runId => runId !== workflowRunId);
+      if (remainingRunIds.length === 0) {
         clearTimeout(timer);
         this.eventRetryTimers.delete(key);
         this.eventRetryCounts.delete(key);
+        this.eventRetryState.delete(key);
+        continue;
+      }
+
+      const retryState = this.eventRetryState.get(key);
+      const retryCount = this.eventRetryCounts.get(key) ?? 0;
+      clearTimeout(timer);
+      this.eventRetryTimers.delete(key);
+      this.eventRetryCounts.delete(key);
+      this.eventRetryState.delete(key);
+
+      if (retryState) {
+        const remainingMatched = retryState.matched.filter(sub => sub.workflowRunId !== workflowRunId);
+        if (remainingMatched.length > 0) {
+          this.scheduleEventRetry(retryState.event, remainingMatched, { retryCountOverride: retryCount });
+        }
       }
     }
   }
@@ -898,7 +935,10 @@ class EventRouter {
   private async handleEvent(event: ExternalEvent): Promise<void> {
     // 1. Look up matching subscriptions via trie
     const matched = this.topicTrie.lookup(event.topic);
+    await this.handleEventForSubscriptions(event, matched);
+  }
 
+  private async handleEventForSubscriptions(event: ExternalEvent, matched: Subscription[]): Promise<void> {
     if (matched.length === 0) return;
 
     // 2. First compute all scoped deliveries and persist them as expected
@@ -1164,13 +1204,17 @@ class EventRouter {
    * independent preparation errors get a fresh budget and this map does not leak
    * state across retryable source re-emissions of the same non-terminal event.
    */
-  private scheduleEventRetry(event: ExternalEvent, matched: Subscription[]): void {
+  private scheduleEventRetry(
+    event: ExternalEvent,
+    matched: Subscription[],
+    options: { retryCountOverride?: number } = {},
+  ): void {
     const retryKey = JSON.stringify([
       event.id,
       [...new Set(matched.map((sub) => sub.workflowRunId))].sort(),
       'prepare',
     ]);
-    const retries = (this.eventRetryCounts.get(retryKey) ?? 0) + 1;
+    const retries = options.retryCountOverride ?? ((this.eventRetryCounts.get(retryKey) ?? 0) + 1);
     if (retries > EventRouter.MAX_RETRIES) {
       log.warn('EventRouter: max preparation retries exceeded; marking event failed', {
         eventId: event.id,
@@ -1180,6 +1224,7 @@ class EventRouter {
       const existingTimer = this.eventRetryTimers.get(retryKey);
       if (existingTimer) clearTimeout(existingTimer);
       this.eventRetryTimers.delete(retryKey);
+      this.eventRetryState.delete(retryKey);
       this.eventStore.markEventFailed(event.id, {
         terminal: true,
         reason: 'delivery_preparation_failed',
@@ -1188,22 +1233,25 @@ class EventRouter {
     }
 
     this.eventRetryCounts.set(retryKey, retries);
+    this.eventRetryState.set(retryKey, { event, matched });
     const backoff = EventRouter.RETRY_BACKOFF_MS * Math.pow(2, retries - 1);
     const existingTimer = this.eventRetryTimers.get(retryKey);
     if (existingTimer) clearTimeout(existingTimer);
 
     const timer = setTimeout(() => {
       this.eventRetryTimers.delete(retryKey);
-      void this.handleEvent(event)
+      const retryState = this.eventRetryState.get(retryKey) ?? { event, matched };
+      void this.handleEventForSubscriptions(retryState.event, retryState.matched)
         .then(() => {
-          // A resolved handleEvent means the retry pass either prepared the complete
-          // expected-delivery set or found no matching work left. Clear the event-level
-          // preparation retry count so a later independent transient error gets a full
-          // retry budget and this map does not leak state for non-terminal re-emits.
+          // A resolved retry pass either prepared the complete expected-delivery
+          // set for the still-active matched subscriptions or found no matching
+          // work left. Clear event-level retry state so a later independent
+          // transient error gets a full budget and this map does not leak state.
           this.eventRetryCounts.delete(retryKey);
+          this.eventRetryState.delete(retryKey);
         })
         .catch((err) => {
-          // Keep the count on failure so the next scheduled retry continues the
+          // Keep count/state on failure so the next scheduled retry continues the
           // same preparation-failure budget instead of starting over.
           log.warn('EventRouter: event preparation retry failed', { error: err, eventId: event.id });
         });
@@ -1340,14 +1388,15 @@ When an event matches a subscription whose node execution is `idle` (agent sessi
 
 ### Terminal run cleanup
 
-When a workflow run transitions to `done` or `cancelled`, `clearRunInterests(workflowRunId)` removes subscriptions, retry timers, and in-memory pending queues. Any queued delivery removed during this terminal cleanup was already registered in `space_external_event_deliveries`, so cleanup must mark it terminally failed before deleting the queue entry:
+When a workflow run transitions to `done` or `cancelled`, `clearRunInterests(workflowRunId)` removes subscriptions, retry timers, and in-memory pending queues. Any queued delivery or backoff retry removed during this terminal cleanup was already registered in `space_external_event_deliveries`, so cleanup must mark it terminally failed before deleting the in-memory state:
 
-1. Collect each queued `{ eventId, deliveryKey }` for the terminal run.
-2. Call `markDeliveryFailed(eventId, deliveryKey, { terminal: true, reason: 'run_terminal_cleanup' })`.
-3. Call `markEventFailedIfAllDeliveriesTerminal(eventId)` so the source event can advance once all remaining deliveries are terminal.
-4. Only then delete the in-memory queue and pending markers.
+1. Collect each queued `{ eventId, deliveryKey }` for the terminal run and fail it with reason `run_terminal_cleanup`.
+2. Collect each per-delivery retry timer for the terminal run, look up its source event id from the delivery store, and fail it with reason `run_terminal_retry_cancelled`.
+3. For each failure, call `markDeliveryFailed(eventId, deliveryKey, { terminal: true, reason })` and then `markEventFailedIfAllDeliveriesTerminal(eventId)` so the source event can advance once all remaining deliveries are terminal.
+4. Only then delete the in-memory queue, pending markers, retry counts, and timers.
+5. Event-level preparation retries can span multiple workflow runs. If one run terminates while others remain active, cancel the old shared timer and reschedule a retry for the surviving matched subscriptions with the existing retry count. Cancel without rescheduling only when no matched runs remain.
 
-This keeps run teardown from leaving non-terminal delivery rows for nodes that can no longer be started.
+This keeps run teardown from leaving non-terminal delivery rows for nodes that can no longer be started while preserving retry paths for still-active runs.
 
 ### Queue for not-yet-started nodes
 
@@ -1685,7 +1734,7 @@ V1 needs one core event-store table plus workflow type additions:
    );
    ```
 
-   `EventRouter` calls `registerExpectedDelivery(...)` for every scope-matched subscription before attempting any injection. This registration must be idempotent for the `(event_id, delivery_key)` primary key: use `INSERT OR IGNORE`, `ON CONFLICT DO NOTHING`, or an equivalent upsert that never downgrades an existing terminal row. Retryable source duplicates and router retries can prepare the same delivery more than once, so duplicate expected-delivery rows are normal and must not become preparation failures. After idempotent registration, the router skips already-terminal delivery rows and only attempts pending/retryable rows. It then records `delivered` after successful `injectMessage` and calls `markEventDeliveredIfAllDeliveriesTerminal(event.id)` so source-level dedup can stop re-emitting already-delivered events after restart or in-memory TTL eviction. When retry budget is exhausted, pending-node queue overflow evicts an expected delivery, or terminal run cleanup drops queued deliveries, the router records terminal delivery failure and calls `markEventFailedIfAllDeliveriesTerminal(event.id)` so duplicate source observations do not restart an exhausted or impossible delivery.
+   `EventRouter` calls `registerExpectedDelivery(...)` for every scope-matched subscription before attempting any injection. This registration must be idempotent for the `(event_id, delivery_key)` primary key: use `INSERT OR IGNORE`, `ON CONFLICT DO NOTHING`, or an equivalent upsert that never downgrades an existing terminal row. Retryable source duplicates and router retries can prepare the same delivery more than once, so duplicate expected-delivery rows are normal and must not become preparation failures. After idempotent registration, the router skips already-terminal delivery rows and only attempts pending/retryable rows. It then records `delivered` after successful `injectMessage` and calls `markEventDeliveredIfAllDeliveriesTerminal(event.id)` so source-level dedup can stop re-emitting already-delivered events after restart or in-memory TTL eviction. When retry budget is exhausted, pending-node queue overflow evicts an expected delivery, terminal run cleanup drops queued deliveries, or terminal run cleanup cancels per-delivery retry timers, the router records terminal delivery failure and calls `markEventFailedIfAllDeliveriesTerminal(event.id)` so duplicate source observations do not restart an exhausted or impossible delivery.
 
 3. **Adapter-owned GitHub configuration**: reuse or migrate the existing `space_github_watched_repos` table behind `GitHubEventAdapterRepository`. This table remains source-specific and should not be queried by EventRouter except through cache invalidation hooks for repo-scoped matching.
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -977,20 +977,29 @@ class TopicTrie<T> {
   }
 
   /**
-   * Remove all values matching a predicate.
+   * Remove all values matching a predicate and prune empty child branches.
    */
   remove(predicate: (value: T) => boolean): void {
-    const clean = (node: TrieNode<T>) => {
+    const clean = (node: TrieNode<T>): boolean => {
       if (node.values) {
         node.values = node.values.filter(v => !predicate(v));
+        if (node.values.length === 0) node.values = undefined;
       }
-      for (const child of node.exactChildren.values()) {
-        clean(child);
+
+      for (const [segment, child] of node.exactChildren.entries()) {
+        if (clean(child)) {
+          node.exactChildren.delete(segment);
+        }
       }
-      for (const child of node.globChildren.values()) {
-        clean(child);
+      for (const [segment, child] of node.globChildren.entries()) {
+        if (clean(child)) {
+          node.globChildren.delete(segment);
+        }
       }
+
+      return !node.values && node.exactChildren.size === 0 && node.globChildren.size === 0;
     };
+
     clean(this.root);
   }
 }

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -560,6 +560,12 @@ interface PendingDelivery {
   deliveryKey: string;
 }
 
+interface QueuedDeliveryFailure {
+  eventId: string;
+  deliveryKey: string;
+  reason: 'pending_queue_overflow' | 'run_terminal_cleanup';
+}
+
 interface WatchedRepoLookup {
   listWatchedRepos(spaceId: string): { owner: string; repo: string; enabled: boolean }[];
 }
@@ -833,14 +839,25 @@ class EventRouter {
       }
     }
 
-    // Clean up in-memory pending queue for this run. Keys are JSON tuples, so parse
-    // structurally rather than prefix-matching delimiter-joined strings.
-    for (const key of this.pendingQueue.keys()) {
+    // Clean up in-memory pending queue for this terminal run. Queued deliveries
+    // were already registered in ExternalEventStore, so dropping the in-memory
+    // queue must also mark each queued delivery terminally failed; otherwise the
+    // source event can never reach a terminal all-deliveries state.
+    const terminalQueueFailures: QueuedDeliveryFailure[] = [];
+    for (const [key, queue] of this.pendingQueue.entries()) {
       const [keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string];
       if (keyWorkflowRunId === workflowRunId) {
+        for (const pending of queue) {
+          terminalQueueFailures.push({
+            eventId: pending.event.id,
+            deliveryKey: pending.deliveryKey,
+            reason: 'run_terminal_cleanup',
+          });
+        }
         this.pendingQueue.delete(key);
       }
     }
+    this.markQueuedDeliveriesFailed(terminalQueueFailures);
 
     // Clean up pending deliveries and retry counts for this run.
     // Delivery keys are JSON tuples: [dedupeKey, taskId, nodeId, agentName, workflowRunId]
@@ -1026,7 +1043,10 @@ class EventRouter {
     queue.push({ event, deliveryKey });
     if (queue.length > 50) {
       const dropped = queue.shift();
-      if (dropped) this.pendingDeliveries.delete(dropped.deliveryKey);
+      if (dropped) {
+        this.pendingDeliveries.delete(dropped.deliveryKey);
+        this.markQueuedDeliveryFailed(dropped.event.id, dropped.deliveryKey, 'pending_queue_overflow');
+      }
       log.warn('EventRouter: pending external event queue exceeded limit; dropped oldest event', {
         workflowRunId: sub.workflowRunId,
         taskId: sub.taskId,
@@ -1035,6 +1055,22 @@ class EventRouter {
       });
     }
     this.pendingQueue.set(key, queue);
+  }
+
+  private markQueuedDeliveryFailed(
+    eventId: string,
+    deliveryKey: string,
+    reason: QueuedDeliveryFailure['reason'],
+  ): void {
+    this.eventStore.markDeliveryFailed(eventId, deliveryKey, { terminal: true, reason });
+    this.eventStore.markEventFailedIfAllDeliveriesTerminal(eventId);
+  }
+
+  private markQueuedDeliveriesFailed(failures: QueuedDeliveryFailure[]): void {
+    for (const failure of failures) {
+      this.pendingDeliveries.delete(failure.deliveryKey);
+      this.markQueuedDeliveryFailed(failure.eventId, failure.deliveryKey, failure.reason);
+    }
   }
 
   /**
@@ -1279,6 +1315,17 @@ When an event matches a subscription whose node execution is `idle` (agent sessi
 2. The existing defer mechanism handles waking: if idle → enqueue immediately; if busy → persist as deferred, replay after current turn.
 3. No new wake mechanism needed — the existing `SessionNotificationSink` pattern already solves this.
 
+### Terminal run cleanup
+
+When a workflow run transitions to `done` or `cancelled`, `clearRunInterests(workflowRunId)` removes subscriptions, retry timers, and in-memory pending queues. Any queued delivery removed during this terminal cleanup was already registered in `space_external_event_deliveries`, so cleanup must mark it terminally failed before deleting the queue entry:
+
+1. Collect each queued `{ eventId, deliveryKey }` for the terminal run.
+2. Call `markDeliveryFailed(eventId, deliveryKey, { terminal: true, reason: 'run_terminal_cleanup' })`.
+3. Call `markEventFailedIfAllDeliveriesTerminal(eventId)` so the source event can advance once all remaining deliveries are terminal.
+4. Only then delete the in-memory queue and pending markers.
+
+This keeps run teardown from leaving non-terminal delivery rows for nodes that can no longer be started.
+
 ### Queue for not-yet-started nodes
 
 When a node execution is `pending` (no session yet):
@@ -1287,7 +1334,7 @@ When a node execution is `pending` (no session yet):
 2. When `TaskAgentManager` creates the node's session, it calls `eventRouter.flushQueuedDeliveriesForSession(sub, sessionId)`.
 3. Queued events are injected through the same prepared-delivery path as live events, so successful flush marks the per-subscription delivery delivered and advances the source event only when all expected deliveries are terminal.
 4. If flush injection fails, the router clears the stale pending marker and schedules a normal delivery retry so the queued event is not silently lost.
-5. Queue is bounded: max 50 events per execution, oldest dropped (with a warning log).
+5. Queue is bounded: max 50 events per execution, oldest dropped (with a warning log). Because expected delivery rows are registered before queueing, overflow eviction must call `markDeliveryFailed(..., { terminal: true, reason: 'pending_queue_overflow' })` and then `markEventFailedIfAllDeliveriesTerminal(event.id)`; otherwise the evicted delivery row can block event terminalization forever.
 
 **Known limitation — daemon restart**: The in-memory per-node pending queue is lost on daemon restart. For v1, this is accepted as a known delivery gap:
 - The bus-level `ExternalEventStore` preserves the source event and can re-emit retryable states, but the per-node in-memory queue itself is not durable.
@@ -1615,7 +1662,7 @@ V1 needs one core event-store table plus workflow type additions:
    );
    ```
 
-   `EventRouter` calls `registerExpectedDelivery(...)` for every scope-matched subscription before attempting any injection. This registration must be idempotent for the `(event_id, delivery_key)` primary key: use `INSERT OR IGNORE`, `ON CONFLICT DO NOTHING`, or an equivalent upsert that never downgrades an existing terminal row. Retryable source duplicates and router retries can prepare the same delivery more than once, so duplicate expected-delivery rows are normal and must not become preparation failures. After idempotent registration, the router skips already-terminal delivery rows and only attempts pending/retryable rows. It then records `delivered` after successful `injectMessage` and calls `markEventDeliveredIfAllDeliveriesTerminal(event.id)` so source-level dedup can stop re-emitting already-delivered events after restart or in-memory TTL eviction. When retry budget is exhausted it records terminal delivery failure and calls `markEventFailedIfAllDeliveriesTerminal(event.id)` so duplicate source observations do not restart an exhausted retry loop.
+   `EventRouter` calls `registerExpectedDelivery(...)` for every scope-matched subscription before attempting any injection. This registration must be idempotent for the `(event_id, delivery_key)` primary key: use `INSERT OR IGNORE`, `ON CONFLICT DO NOTHING`, or an equivalent upsert that never downgrades an existing terminal row. Retryable source duplicates and router retries can prepare the same delivery more than once, so duplicate expected-delivery rows are normal and must not become preparation failures. After idempotent registration, the router skips already-terminal delivery rows and only attempts pending/retryable rows. It then records `delivered` after successful `injectMessage` and calls `markEventDeliveredIfAllDeliveriesTerminal(event.id)` so source-level dedup can stop re-emitting already-delivered events after restart or in-memory TTL eviction. When retry budget is exhausted, pending-node queue overflow evicts an expected delivery, or terminal run cleanup drops queued deliveries, the router records terminal delivery failure and calls `markEventFailedIfAllDeliveriesTerminal(event.id)` so duplicate source observations do not restart an exhausted or impossible delivery.
 
 3. **Adapter-owned GitHub configuration**: reuse or migrate the existing `space_github_watched_repos` table behind `GitHubEventAdapterRepository`. This table remains source-specific and should not be queried by EventRouter except through cache invalidation hooks for repo-scoped matching.
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -437,6 +437,11 @@ interface Subscription {
   agentSessionId: string | null; // resolved at delivery time
   spaceId: string;
 }
+
+interface PendingDelivery {
+  event: ExternalEvent;
+  deliveryKey: string;
+}
 ```
 
 ### EventRouter implementation sketch
@@ -451,8 +456,8 @@ class EventRouter {
 
   // dedup: JSON tuple (dedupeKey, taskId, nodeId, agentName, workflowRunId) → timestamp
   private delivered: Map<string, number> = new Map();
-  // pending delivery queue: JSON tuple (workflowRunId, taskId, nodeId, agentName) → events
-  private pendingQueue: Map<string, ExternalEvent[]> = new Map();
+  // pending delivery queue: JSON tuple (workflowRunId, taskId, nodeId, agentName) → events plus delivery keys
+  private pendingQueue: Map<string, PendingDelivery[]> = new Map();
   // TTL for dedup entries — entries older than this are evicted on next access
   private static readonly DEDUP_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
@@ -755,6 +760,7 @@ class EventRouter {
     const dedupeKey = this.makeDeliveryKey(event, sub);
     if (this.delivered.has(dedupeKey)) return;
 
+<<<<<<< HEAD
     // Check if pending (prevents duplicate queueing while allowing retries on failure)
     if (this.pendingDeliveries.has(dedupeKey)) return;
 
@@ -804,18 +810,52 @@ class EventRouter {
       log.warn(`Session resolution failed for ${sub.agentName}`, { error: err });
       this.pendingDeliveries.delete(dedupeKey);
       this.scheduleRetry(event, sub, dedupeKey);
+=======
+    // Resolve session — re-read from nodeExecutionRepo for latest state
+    const sessionId = await this.resolveSession(sub);
+    if (!sessionId) {
+      // Session not active — queue for later delivery. Mark dedup only after the
+      // event is safely queued; the pending entry carries the same delivery key
+      // and the key is cleared if the eventual flush/injection fails.
+      this.queueForDelivery(event, sub, dedupeKey);
+      this.delivered.set(dedupeKey, Date.now());
+      return;
+    }
+
+    // Format and inject.
+    // Do NOT mark delivered before injectMessage succeeds: SpaceGitHubService
+    // suppresses repeat routing for the same upstream dedupeKey, so pre-marking
+    // would permanently lose the event for this subscription after transient
+    // injection failures or session teardown races.
+    const message = this.formatEventMessage(event);
+    try {
+      await this.sessionFactory.injectMessage(sessionId, message, {
+        deliveryMode: 'defer',
+      });
+      this.delivered.set(dedupeKey, Date.now());
+    } catch (err) {
+      log.warn(`Failed to deliver event to ${sub.agentName}; leaving undelivered for retry`, { error: err });
+      // Leave the dedupe key unset so a retry path (for example a re-emitted bus
+      // event or pending queue flush retry) can attempt delivery again.
+      throw err;
+>>>>>>> f60b5780a (Address review: close passesScopeCheck before scheduleRetry, fix restart claim, mark issues.opened out-of-scope)
     }
   }
 
-  private queueForDelivery(event: ExternalEvent, sub: Subscription): void {
+  private queueForDelivery(event: ExternalEvent, sub: Subscription, deliveryKey: string): void {
     const key = this.makePendingQueueKey(sub);
     const queue = this.pendingQueue.get(key) ?? [];
-    queue.push(event);
+    queue.push({ event, deliveryKey });
     if (queue.length > 50) {
+<<<<<<< HEAD
       const evicted = queue.shift()!;
       // Clear pending marker for evicted event so it can be re-queued if needed
       const evictedKey = this.makeDeliveryKey(evicted, sub);
       this.pendingDeliveries.delete(evictedKey);
+=======
+      const dropped = queue.shift();
+      if (dropped) this.delivered.delete(dropped.deliveryKey);
+>>>>>>> f60b5780a (Address review: close passesScopeCheck before scheduleRetry, fix restart claim, mark issues.opened out-of-scope)
       log.warn('EventRouter: pending external event queue exceeded limit; dropped oldest event', {
         workflowRunId: sub.workflowRunId,
         taskId: sub.taskId,
@@ -967,15 +1007,17 @@ Event arrives → Match subscriptions → Scope check → Dedup check → Sessio
                                                     injectMessage   injectMessage  pending_events
                                                           │              │              │
                                                           ▼              ▼              ▼
-                                                    Mark delivered  Mark delivered  Await session
-                                                                                     start
+                                                    Mark delivered  Mark delivered  Mark queued
+                                                                                     delivered
+                                                                                     after flush
 ```
 
 ### Deduplication
 
 - **Key**: JSON tuple `[event.dedupeKey, subscription.taskId, subscription.nodeId, subscription.agentName, subscription.workflowRunId]` — includes `taskId` to isolate multi-task runs and `nodeId` to handle cases where the same agent name appears in multiple nodes within the same run. The tuple is encoded structurally rather than delimiter-joined because `dedupeKey`, workflow identifiers, node IDs, and agent names are free-form strings.
 - **Storage**: In-memory `Map<string, number>` (timestamp). Evicted when the workflow run completes.
-- **Guarantee**: Same external event is never delivered twice to the same node agent within a run.
+- **Guarantee**: Same external event is never delivered twice to the same node agent within a run after successful injection or durable in-memory queueing.
+- **Retry behavior**: Live/idle session injection marks the key only after `injectMessage` succeeds. If injection throws, the key remains unset so the subscription can be retried; this is required because upstream `SpaceGitHubService.storeEvent` suppresses duplicate upstream dedupe keys and will not necessarily re-route the same event.
 - The upstream `SpaceGitHubService` already deduplicates by `(spaceId, dedupeKey)` — this is an additional per-node dedup.
 
 ### Wake-on-idle

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -517,7 +517,13 @@ class EventRouter {
     nodeExecutions: NodeExecution[],
   ): void {
     // Build the desired set of subscriptions from current node execution states.
-    const desiredSubs = new Map<string, Subscription>();  // key: `${taskId}:${nodeId}:${agentName}:${topic}:${scope}`
+    // Use a structured tuple key encoded with JSON.stringify rather than a
+    // delimiter-joined string: task ids, node ids, agent names, topics, and scopes
+    // are free-form enough that ':' or other delimiters can appear in valid input.
+    const makeSubscriptionKey = (sub: Pick<Subscription, 'taskId' | 'nodeId' | 'agentName' | 'interest'>) =>
+      JSON.stringify([sub.taskId, sub.nodeId, sub.agentName, sub.interest.topic, sub.interest.scope]);
+
+    const desiredSubs = new Map<string, Subscription>();
 
     for (const node of workflow.nodes) {
       for (const agent of node.agents) {
@@ -528,13 +534,11 @@ class EventRouter {
         );
         if (!exec || !isReceivingStatus(exec.status)) continue;
 
-        const subKey = `${taskId}:${node.id}:${agent.name}`;
         for (const interest of agent.eventInterests) {
           // Include taskId, topic, and scope in key — the same run can contain
           // multiple tasks, and the same agent can subscribe to the same topic
           // with different scopes (e.g., both 'task' and 'repo' scope).
-          const fullKey = `${subKey}:${interest.topic}:${interest.scope}`;
-          desiredSubs.set(fullKey, {
+          const sub: Subscription = {
             workflowRunId,
             taskId,
             nodeId: node.id,
@@ -542,7 +546,8 @@ class EventRouter {
             interest,
             agentSessionId: exec.agentSessionId,
             spaceId,
-          });
+          };
+          desiredSubs.set(makeSubscriptionKey(sub), sub);
         }
       }
     }
@@ -552,32 +557,29 @@ class EventRouter {
     // subscriptions from the same run.
     const currentRunSubs = this.activeRuns.get(workflowRunId) ?? new Set<Subscription>();
     const currentTaskSubs = [...currentRunSubs].filter(sub => sub.taskId === taskId);
-    const currentKeys = new Set<string>();
+    const currentSubsByKey = new Map<string, Subscription>();
     for (const sub of currentTaskSubs) {
-      currentKeys.add(`${sub.taskId}:${sub.nodeId}:${sub.agentName}:${sub.interest.topic}:${sub.interest.scope}`);
+      currentSubsByKey.set(makeSubscriptionKey(sub), sub);
     }
     const desiredKeys = new Set(desiredSubs.keys());
 
     // Remove this task's subscriptions no longer in the desired set (e.g. node went cancelled).
-    for (const key of currentKeys) {
+    for (const [key, sub] of currentSubsByKey) {
       if (!desiredKeys.has(key)) {
-        const [subTaskId, nodeId, agentName, ...rest] = key.split(':');
-        const scope = rest.pop()!;
-        const topic = rest.join(':');
         this.topicTrie.remove(
           v => v.workflowRunId === workflowRunId
-            && v.taskId === subTaskId
-            && v.nodeId === nodeId
-            && v.agentName === agentName
-            && v.interest.topic === topic
-            && v.interest.scope === scope,
+            && v.taskId === sub.taskId
+            && v.nodeId === sub.nodeId
+            && v.agentName === sub.agentName
+            && v.interest.topic === sub.interest.topic
+            && v.interest.scope === sub.interest.scope,
         );
       }
     }
 
     // Add new subscriptions not currently in the trie.
     for (const [key, sub] of desiredSubs) {
-      if (!currentKeys.has(key)) {
+      if (!currentSubsByKey.has(key)) {
         this.topicTrie.insert(sub.interest.topic, sub);
       }
     }

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -61,7 +61,7 @@ github/lsm/neokai/pull_request.review_*     ← prefix wildcard: all review even
 
 1. `source` — adapter identifier (`github`, `slack`, `ci`). Lowercase, no slashes.
 2. `owner/repo` — from the event's repository context. Both lowercase for case-insensitive matching.
-3. `resource` — the event resource type. V1 GitHub adapter emits PR-related resources (`pull_request`, `pull_request.comment`, `pull_request.review`, `pull_request.review_comment`). CI resources such as `check_suite` are Phase 3/future adapter scope.
+3. `resource.action` — the fourth path segment is always one dotted pair. For V1 GitHub PR events, `resource` is `pull_request`; review/comment variants are encoded in `action` (`review_submitted`, `comment_created`, `review_comment_created`) so examples like `pull_request.review_submitted` remain canonical. CI resources such as `check_suite` are Phase 3/future adapter scope.
 4. `action` — the specific action: `opened`, `review_submitted`, `comment_created`, `completed`, etc.
 5. All v1 topics use exactly 4 path segments. For resources without a natural `owner/repo` (e.g. a future Slack message), use a source-specific scope pair to preserve the same depth: `{source}/{workspace}/{channel}/{resource}.{action}` (for example, `slack/acme/eng/messages.created`). Adapters that do not have both scope levels should use a reserved placeholder segment such as `_` rather than emitting 3-segment topics.
 
@@ -80,6 +80,7 @@ Pattern validation (enforced at workflow create/update time):
 - Must not contain `..` segments.
 - Must not contain empty segments (no double slashes).
 - Must have exactly 4 segments (`source/scope1/scope2/resource.action`) so it can match real event topics.
+- The 4th segment must contain a `resource.action` separator (`.`) with non-empty resource and action sides, allowing segment-local wildcards such as `pull_request.*`, `*.created`, and `*.*`.
 - Each segment may contain alphanumeric, dash, underscore, dot, and `*`; `*` must stay within a single segment and cannot cross `/` boundaries.
 - Max 10 interests per agent slot.
 
@@ -1093,6 +1094,8 @@ The `SpaceGitHubService` already normalizes to `SpaceGitHubEventKind` (`issue_co
 | `pull_request_review_comment` | `pull_request.review_comment_${action}` (created, edited, deleted) |
 | `pull_request` | `pull_request.${action}` (opened, synchronize, closed, etc.) |
 
+These return values are the complete fourth path segment (`resource.action`). For V1 PR events the resource side is always `pull_request`; `comment_*`, `review_*`, and `review_comment_*` are action names, not nested resource segments. The adapter must not emit doubled resource names such as `pull_request.review.review_submitted`.
+
 ```typescript
 function mapEventType(kind: string, action: string): string {
   switch (kind) {
@@ -1191,6 +1194,15 @@ export function validateGlobPattern(pattern: string): { valid: boolean; reason?:
         reason: `Segment "${segment}" contains invalid characters. Use alphanumeric, dash, underscore, dot, or segment-local "*" wildcard.`,
       };
     }
+  }
+
+  const resourceAction = segments[3];
+  const dotIndex = resourceAction.indexOf('.');
+  if (dotIndex <= 0 || dotIndex === resourceAction.length - 1) {
+    return {
+      valid: false,
+      reason: `Topic pattern fourth segment must be resource.action; got "${resourceAction}". Example: 'pull_request.review_submitted'`,
+    };
   }
 
   return { valid: true };

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -677,9 +677,12 @@ class EventRouter {
   }
 
   private makeDeliveryKey(event: ExternalEvent, sub: Subscription): string {
-    // Use a structured tuple key: event.dedupeKey and workflow/node/agent ids are
-    // free-form strings and can contain ':', '/', or other delimiter characters.
-    return JSON.stringify([event.dedupeKey, sub.taskId, sub.nodeId, sub.agentName, sub.workflowRunId]);
+    // Use a structured tuple key. Source-level dedupe is unique by
+    // (spaceId, source, dedupeKey), so include event.source to prevent two adapters
+    // that legitimately emit the same dedupeKey from sharing pending/delivered/retry
+    // bookkeeping for the same subscription. All fields are free-form strings and
+    // can contain ':', '/', or other delimiter characters, so avoid delimiter joins.
+    return JSON.stringify([event.source, event.dedupeKey, sub.taskId, sub.nodeId, sub.agentName, sub.workflowRunId]);
   }
 
   private makePendingQueueKey(sub: Pick<Subscription, 'workflowRunId' | 'taskId' | 'nodeId' | 'agentName'>): string {
@@ -1483,10 +1486,11 @@ Dedup happens at two different layers, each with a different key and responsibil
    - Retryable duplicates (`published`, `routed`, `delivery_failed`) are re-emitted so transient delivery failures can retry.
    - This replaces `SpaceGitHubService.storeEvent()` as the authoritative dedup path for new external-event delivery.
 
-2. **Per-subscription delivery dedup** — JSON tuple `[event.dedupeKey, subscription.taskId, subscription.nodeId, subscription.agentName, subscription.workflowRunId]`.
+2. **Per-subscription delivery dedup** — JSON tuple `[event.source, event.dedupeKey, subscription.taskId, subscription.nodeId, subscription.agentName, subscription.workflowRunId]`.
    - Purpose: prevent the same external event from being delivered twice to the same node agent within a run.
+   - The tuple includes `event.source` because source-level dedupe is scoped by `(spaceId, source, dedupeKey)`: two adapters can legitimately emit the same `dedupeKey` in one space and must not share pending/delivered/retry bookkeeping.
    - The tuple includes `taskId` to isolate multi-task runs and `nodeId` to handle cases where the same agent name appears in multiple nodes within the same run.
-   - The tuple is encoded structurally rather than delimiter-joined because `dedupeKey`, workflow identifiers, node IDs, and agent names are free-form strings.
+   - The tuple is encoded structurally rather than delimiter-joined because `source`, `dedupeKey`, workflow identifiers, node IDs, and agent names are free-form strings.
    - It is tracked in-memory for fast duplicate suppression and persisted in `space_external_event_deliveries` after successful injection.
 
 The EventRouter marks per-subscription delivery as `delivered` only after successful injection, updates `ExternalEventStore` with the successful delivery key, and advances the source event to terminal `delivered` only once all expected deliveries are terminal. Failed injection/session-resolution paths remove `pendingDeliveries` and schedule retry rather than relying on adapters to re-publish the same event. If trie lookup finds no matching subscriptions, or if all matched subscriptions are out of scope/already terminal and no preparation retry is pending, the router marks the source event terminal `ignored` so webhook+polling duplicates do not churn through routing forever.

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -616,11 +616,24 @@ class GitHubEventExtension implements HttpExternalEventExtension, RpcExternalEve
   private async pollEnabledSpaces(): Promise<number> {
     if (!this.context) return 0;
     const spaces = await this.context.config.listEnabledSpaces(this.sourceId);
-    let count = 0;
-    for (const spaceConfig of spaces) {
-      count += await this.pollSpace(spaceConfig.spaceId);
-    }
-    return count;
+    const results = await Promise.allSettled(
+      spaces.map(async (spaceConfig) => {
+        try {
+          return await this.pollSpace(spaceConfig.spaceId);
+        } catch (err) {
+          log.warn('GitHubEventExtension: polling failed for space', {
+            spaceId: spaceConfig.spaceId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          return 0;
+        }
+      }),
+    );
+
+    return results.reduce((count, result) => {
+      if (result.status === 'fulfilled') return count + result.value;
+      return count;
+    }, 0);
   }
 
   async pollSpace(spaceId: string, fetchImpl: typeof fetch = fetch): Promise<number> {
@@ -1350,14 +1363,16 @@ class ExternalEventRouter {
       throw result.error ?? new Error('agent.message.inject command failed');
     }
 
-    // Success: mark as delivered both in-memory and persistently, then advance
-    // the source event to terminal delivered only when every expected
+    // Success: persist durable delivery state first, then mark the in-memory
+    // dedup cache. If persistence throws after successful command dispatch, the
+    // retry path must not be short-circuited by an in-memory delivered marker.
+    // The source event advances to terminal delivered only when every expected
     // per-subscription delivery succeeded. Terminal failures must keep the source
     // event in a failed outcome rather than being masked by later successes.
-    this.delivered.set(dedupeKey, Date.now());
     this.config.eventStore.markDeliveryDelivered(event.id, dedupeKey);
     this.config.eventStore.markEventFailedIfAnyDeliveryTerminalFailed(event.id);
     this.config.eventStore.markEventDeliveredIfAllDeliveriesDelivered(event.id);
+    this.delivered.set(dedupeKey, Date.now());
     this.pendingDeliveries.delete(dedupeKey);
   }
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -659,11 +659,13 @@ The trie maps topic segments to `Set<Subscription>` at leaf nodes. Each node sto
 
 The index is **per-SpaceRuntime instance** and updated via two distinct operations:
 
-1. **`registerRunInterests`** (called on every `executeTick`): Diff-based trie update. Compares current node execution states against existing subscriptions. Adds subscriptions for newly active nodes, removes subscriptions for `cancelled` nodes. Does NOT touch the dedup map or pending queue — those are preserved across tick refreshes.
+1. **`registerRunInterests`** (called on every `executeTick`): Diff-based trie update. Compares current node execution states against existing subscriptions. Adds subscriptions for newly active nodes and removes stale trie entries. Does NOT touch the dedup map or pending queue — those are preserved across tick refreshes.
 
-2. **`clearRunInterests`** (called only on `done`/`cancelled` terminal transitions): Full teardown. Removes all trie subscriptions, dedup entries, and pending queue entries for the run. NOT called on `blocked` transitions because blocked is resumable.
+2. **`unregisterExecution`** (called when an individual node execution transitions to `cancelled`): Node-level terminal cleanup. Removes that node's subscriptions and fails queued/retrying delivery rows for that node so event terminalization is not blocked until full run teardown.
 
-3. A workflow definition is updated (interests may have changed — next `registerRunInterests` call picks up changes via the diff).
+3. **`clearRunInterests`** (called only on `done`/`cancelled` terminal transitions): Full teardown. Removes all trie subscriptions, dedup entries, and pending queue entries for the run. NOT called on `blocked` transitions because blocked is resumable.
+
+4. A workflow definition is updated (interests may have changed — next `registerRunInterests` call picks up changes via the diff).
 
 ```typescript
 interface Subscription {
@@ -1666,7 +1668,7 @@ When an event matches a subscription whose node execution is `idle` (agent sessi
 
 ### Node cancellation cleanup
 
-When a node execution transitions to `cancelled`, `unregisterExecution(workflowRunId, taskId, nodeId, agentName)` removes that node's subscriptions from `activeRuns` and the topic trie. Because expected delivery rows may already exist for queued or retrying deliveries owned by that node, cancellation must also call `failPendingStateForExecution(...)`:
+When a node execution transitions to `cancelled`, runtime status-transition wiring must call `unregisterExecution(workflowRunId, taskId, nodeId, agentName)` immediately; the next tick's diff refresh is not enough because cancellation has terminal side effects for queued/retrying deliveries. `unregisterExecution(...)` removes that node's subscriptions from `activeRuns` and the topic trie. Because expected delivery rows may already exist for queued or retrying deliveries owned by that node, cancellation must also call `failPendingStateForExecution(...)`:
 
 1. Remove queued pending-node deliveries for the exact `[workflowRunId, taskId, nodeId, agentName]` key and mark them terminally failed with reason `node_execution_cancelled`.
 2. Cancel per-delivery retry timers for the same tuple, look up each event id from the delivery store, and mark them terminally failed with reason `node_execution_cancelled`.
@@ -2181,6 +2183,18 @@ if (this.eventRouter) {
     taskId, // current task whose tick/session activation is being processed
     workflow,
     activeNodeExecutions,
+  );
+}
+
+// In the node execution status transition handler:
+// Called when an individual node execution becomes cancelled, even if the
+// workflow run itself remains active or blocked/resumable.
+if (newNodeStatus === 'cancelled') {
+  this.eventRouter.unregisterExecution(
+    workflowRunId,
+    taskId,
+    workflowNodeId,
+    agentName,
   );
 }
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -715,18 +715,19 @@ class ExternalEventRouter {
   private watchedRepoCache: Map<string, Set<string>> = new Map();
 
   constructor(
-    private readonly internalEventBus: InternalEventBus<InternalEventMap>,
-    private readonly commandBus: InternalCommandBus<InternalCommandMap>,
-    private readonly nodeExecutionRepo: NodeExecutionRepository,
-    private readonly taskRepo: SpaceTaskRepository,
-    private readonly spaceTaskManager: SpaceTaskManager,
-    private readonly sessionFactory: SessionFactory,
-    private readonly eventStore: ExternalEventStore,
-    private readonly watchedRepoLookup: WatchedRepoLookup,
+    private readonly config: {
+      internalEventBus: InternalEventBus<InternalEventMap>;
+      commandBus: InternalCommandBus<InternalCommandMap>;
+      nodeExecutionRepo: NodeExecutionRepository;
+      taskRepo: SpaceTaskRepository;
+      spaceTaskManager: SpaceTaskManager;
+      eventStore: ExternalEventStore;
+      watchedRepoLookup: WatchedRepoLookup;
+    },
   ) {
     // Subscribe to the semantic internal fact. External topic matching happens
     // inside handleEvent via event.topic, not via the internal event name.
-    this.internalEventBus.subscribe('externalEvent.published', ({ payload, channel }) => {
+    this.config.internalEventBus.subscribe('externalEvent.published', ({ payload, channel }) => {
       const { event } = payload;
       // Defense in depth: payload spaceId and channel spaceId must agree when channel is space-scoped.
       if (channel.kind === 'space' && event.spaceId !== channel.spaceId) return;
@@ -745,7 +746,7 @@ class ExternalEventRouter {
   private isWatchedRepo(spaceId: string, owner: string, repo: string): boolean {
     let cached = this.watchedRepoCache.get(spaceId);
     if (!cached) {
-      const repos = this.watchedRepoLookup.listWatchedRepos(spaceId);
+      const repos = this.config.watchedRepoLookup.listWatchedRepos(spaceId);
       cached = new Set(
         repos.filter(r => r.enabled).map(r => `${r.owner.toLowerCase()}/${r.repo.toLowerCase()}`)
       );
@@ -1008,7 +1009,7 @@ class ExternalEventRouter {
         clearTimeout(timer);
         this.retryTimers.delete(key);
         retryFailures.push({
-          eventId: this.eventStore.getEventIdForDeliveryKey(key),
+          eventId: this.config.eventStore.getEventIdForDeliveryKey(key),
           deliveryKey: key,
           reason,
         });
@@ -1086,7 +1087,7 @@ class ExternalEventRouter {
         clearTimeout(timer);
         this.retryTimers.delete(key);
         retryCancellationFailures.push({
-          eventId: this.eventStore.getEventIdForDeliveryKey(key),
+          eventId: this.config.eventStore.getEventIdForDeliveryKey(key),
           deliveryKey: key,
           reason: 'run_terminal_retry_cancelled',
         });
@@ -1134,7 +1135,7 @@ class ExternalEventRouter {
 
   private async handleEventForSubscriptions(event: ExternalEvent, matched: Subscription[]): Promise<boolean> {
     if (matched.length === 0) {
-      this.eventStore.markEventIgnored(event.id, 'no_matching_subscriptions');
+      this.config.eventStore.markEventIgnored(event.id, 'no_matching_subscriptions');
       return true;
     }
 
@@ -1148,13 +1149,13 @@ class ExternalEventRouter {
       const deliveryKey = this.makeDeliveryKey(event, sub);
       try {
         if (!this.passesScopeCheck(event, sub)) continue;
-        this.eventStore.registerExpectedDelivery(event.id, deliveryKey, {
+        this.config.eventStore.registerExpectedDelivery(event.id, deliveryKey, {
           workflowRunId: sub.workflowRunId,
           taskId: sub.taskId,
           nodeId: sub.nodeId,
           agentName: sub.agentName,
         });
-        if (this.eventStore.isDeliveryTerminal(event.id, deliveryKey)) continue;
+        if (this.config.eventStore.isDeliveryTerminal(event.id, deliveryKey)) continue;
         eligible.push(sub);
       } catch (err) {
         preparationFailed = true;
@@ -1190,7 +1191,7 @@ class ExternalEventRouter {
     // retries, etc.) do not re-emit and re-route indefinitely when every matched
     // subscription is out of scope or already terminal.
     if (eligible.length === 0) {
-      this.eventStore.markEventIgnored(event.id, 'no_scope_eligible_subscriptions');
+      this.config.eventStore.markEventIgnored(event.id, 'no_scope_eligible_subscriptions');
       return true;
     }
 
@@ -1272,22 +1273,36 @@ class ExternalEventRouter {
     dedupeKey: string,
     sessionId: string,
   ): Promise<void> {
-    // Format and inject.
-    // NOTE: There is a TOCTOU race — the session could complete between our
-    // resolveSession call and injectMessage. This is safe: injectMessage on a
-    // completed/absent session returns a caught error (logged as a warning).
+    // Format and request injection through the command boundary.
+    // The command handler owns authorization, validation, telemetry, standardized
+    // failure mapping, and the concrete sessionFactory.injectMessage(...) call.
     const message = this.formatEventMessage(event);
-    await this.sessionFactory.injectMessage(sessionId, message, {
+    const result = await this.config.commandBus.dispatch('agent.message.inject', {
+      sessionId,
+      message,
       deliveryMode: 'defer',
+      origin: 'system',
+      metadata: {
+        source: 'externalEvent',
+        eventId: event.id,
+        deliveryKey: dedupeKey,
+        workflowRunId: sub.workflowRunId,
+        taskId: sub.taskId,
+        nodeId: sub.nodeId,
+        agentName: sub.agentName,
+      },
     });
+    if (!result.ok) {
+      throw result.error ?? new Error('agent.message.inject command failed');
+    }
 
     // Success: mark as delivered both in-memory and persistently, then advance
     // the source event to terminal delivered only when all expected per-subscription
     // deliveries are terminal. This keeps source-level dedup from re-emitting
     // already-delivered events after restart/TTL expiry.
     this.delivered.set(dedupeKey, Date.now());
-    this.eventStore.markDeliveryDelivered(event.id, dedupeKey);
-    this.eventStore.markEventDeliveredIfAllDeliveriesTerminal(event.id);
+    this.config.eventStore.markDeliveryDelivered(event.id, dedupeKey);
+    this.config.eventStore.markEventDeliveredIfAllDeliveriesTerminal(event.id);
     this.pendingDeliveries.delete(dedupeKey);
   }
 
@@ -1316,8 +1331,8 @@ class ExternalEventRouter {
     deliveryKey: string,
     reason: QueuedDeliveryFailure['reason'],
   ): void {
-    this.eventStore.markDeliveryFailed(eventId, deliveryKey, { terminal: true, reason });
-    this.eventStore.markEventFailedIfAllDeliveriesTerminal(eventId);
+    this.config.eventStore.markDeliveryFailed(eventId, deliveryKey, { terminal: true, reason });
+    this.config.eventStore.markEventFailedIfAllDeliveriesTerminal(eventId);
   }
 
   private markQueuedDeliveriesFailed(failures: QueuedDeliveryFailure[]): void {
@@ -1435,7 +1450,7 @@ class ExternalEventRouter {
       if (existingTimer) clearTimeout(existingTimer);
       this.eventRetryTimers.delete(retryKey);
       this.eventRetryState.delete(retryKey);
-      this.eventStore.markEventFailed(event.id, {
+      this.config.eventStore.markEventFailed(event.id, {
         terminal: true,
         reason: 'delivery_preparation_failed',
       });
@@ -1499,11 +1514,11 @@ class ExternalEventRouter {
 
       // Persist terminal failure so source-level dedup stops re-emitting this
       // delivery after restart or future polling of the same upstream event.
-      this.eventStore.markDeliveryFailed(event.id, deliveryKey, {
+      this.config.eventStore.markDeliveryFailed(event.id, deliveryKey, {
         terminal: true,
         reason: 'max_retries_exceeded',
       });
-      this.eventStore.markEventFailedIfAllDeliveriesTerminal(event.id);
+      this.config.eventStore.markEventFailedIfAllDeliveriesTerminal(event.id);
       return;
     }
 
@@ -1517,7 +1532,7 @@ class ExternalEventRouter {
       this.retryTimers.delete(deliveryKey);
 
       // Re-check if delivered while waiting (another delivery might have succeeded)
-      if (this.delivered.has(deliveryKey) || this.eventStore.isDeliveryTerminal(event.id, deliveryKey)) {
+      if (this.delivered.has(deliveryKey) || this.config.eventStore.isDeliveryTerminal(event.id, deliveryKey)) {
         this.retryCounts.delete(deliveryKey);
         return;
       }
@@ -1534,11 +1549,11 @@ class ExternalEventRouter {
       if (!stillActive) {
         this.retryCounts.delete(deliveryKey);
         this.pendingDeliveries.delete(deliveryKey);
-        this.eventStore.markDeliveryFailed(event.id, deliveryKey, {
+        this.config.eventStore.markDeliveryFailed(event.id, deliveryKey, {
           terminal: true,
           reason: 'subscription_inactive_retry_skipped',
         });
-        this.eventStore.markEventFailedIfAllDeliveriesTerminal(event.id);
+        this.config.eventStore.markEventFailedIfAllDeliveriesTerminal(event.id);
         return;
       }
 
@@ -1547,7 +1562,7 @@ class ExternalEventRouter {
         .then(() => {
           // deliverToSubscription catches injection failures and may schedule a
           // follow-up retry, so only clear retry state if delivery is now marked.
-          if (this.delivered.has(deliveryKey) || this.eventStore.isDeliveryTerminal(event.id, deliveryKey)) {
+          if (this.delivered.has(deliveryKey) || this.config.eventStore.isDeliveryTerminal(event.id, deliveryKey)) {
             this.retryCounts.delete(deliveryKey);
             this.pendingDeliveries.delete(deliveryKey);
           }
@@ -1612,9 +1627,9 @@ The ExternalEventRouter marks per-subscription delivery as `delivered` only afte
 
 When an event matches a subscription whose node execution is `idle` (agent session exists but finished its turn):
 
-1. Call `sessionFactory.injectMessage(sessionId, message, { deliveryMode: 'defer' })`.
-2. The existing defer mechanism handles waking: if idle → enqueue immediately; if busy → persist as deferred, replay after current turn.
-3. No new wake mechanism needed — the existing `SessionNotificationSink` pattern already solves this.
+1. Dispatch `InternalCommandBus.dispatch('agent.message.inject', { sessionId, message, deliveryMode: 'defer', ... })`.
+2. The command handler uses the existing defer mechanism under the hood: if idle → enqueue immediately; if busy → persist as deferred, replay after current turn.
+3. No new wake mechanism needed — the existing deferred injection path already solves this, but the router stays behind the command boundary.
 
 ### Node cancellation cleanup
 
@@ -2150,12 +2165,15 @@ const externalEventService = new ExternalEventService(
   externalEventStore,
   externalEventTaskResolver,
 );
-const externalEventRouter = new ExternalEventRouter(
+const externalEventRouter = new ExternalEventRouter({
   internalEventBus,
-  internalCommandBus,
-  externalEventStore,
-  ...dependencies,
-);
+  commandBus: internalCommandBus,
+  nodeExecutionRepo,
+  taskRepo,
+  spaceTaskManager,
+  eventStore: externalEventStore,
+  watchedRepoLookup,
+});
 
 const extensionContext: ExternalEventExtensionContext = {
   publisher: externalEventService,

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -585,12 +585,32 @@ class GitHubEventExtension implements HttpExternalEventExtension, RpcExternalEve
     if (!normalized) return Response.json({ ignored: true });
 
     const targetSpaces = await this.resolveEnabledSpacesForWebhook(context, req, raw, normalized);
-    for (const spaceConfig of targetSpaces) {
-      if (!spaceConfig.enabled) continue;
-      await context.publisher.publish(toExternalEvent(spaceConfig.spaceId, normalized));
-    }
+    const results = await Promise.allSettled(
+      targetSpaces
+        .filter((spaceConfig) => spaceConfig.enabled)
+        .map(async (spaceConfig) => {
+          try {
+            await context.publisher.publish(toExternalEvent(spaceConfig.spaceId, normalized));
+            return { spaceId: spaceConfig.spaceId, ok: true };
+          } catch (err) {
+            log.warn('GitHubEventExtension: failed to publish webhook for space', {
+              spaceId: spaceConfig.spaceId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+            return { spaceId: spaceConfig.spaceId, ok: false };
+          }
+        }),
+    );
 
-    return Response.json({ message: 'Webhook received' });
+    const failed = results
+      .map((result) => result.status === 'fulfilled' ? result.value : { spaceId: 'unknown', ok: false })
+      .filter((result) => !result.ok);
+
+    return Response.json({
+      message: 'Webhook received',
+      published: results.length - failed.length,
+      failed: failed.length,
+    }, { status: failed.length > 0 ? 207 : 200 });
   }
 
   private async pollEnabledSpaces(): Promise<number> {

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -13,7 +13,7 @@ Two parallel event pipelines exist today, neither of which routes to individual 
 1. **Room pipeline** (`GitHubService`): Webhook → normalize → filter → security → route → `deliverToRoom()` → DaemonHub `room.message`. Routes to **Rooms**, not Spaces.
 2. **Space pipeline** (`SpaceGitHubService`): Webhook → normalize → dedupe → `SpacePrTaskResolver.resolve()` → `injectTaskAgent()`. Routes events to the **Task Agent session** (the orchestrator), which must then manually relay to the coder node.
 
-The Space pipeline proves the primitives exist, but it is not the right extension boundary: GitHub-specific normalization, dedup, PR-to-task resolution, and Task Agent injection are bundled together in `SpaceGitHubService`. The target design extracts source ingestion into adapters and moves dedup, task enrichment, and node delivery into the core event bus.
+The Space pipeline already does the hard part — it normalizes events, resolves them to a task by PR number, and injects them into the Task Agent session. But it stops one hop short: the coder node still depends on the Task Agent to forward relevant events.
 
 ## Design Overview
 
@@ -22,20 +22,21 @@ External Event Sources (GitHub webhook, polling, future: Slack, CI)
        │
        ▼
 ┌─────────────────────┐
-│  EventAdapter       │  Verify → normalize → publish to EventBus
-│  (extension/source) │
+│  EventIngestion     │  Normalize → validate → publish to EventBus
+│  (adapter per source│
 └────────┬────────────┘
-         │ publish(event) → hub.emit('space.externalEvent.published', { sessionId: 'global', event })
+         │ publish(topic, payload)
          ▼
 ┌─────────────────────┐
-│  EventBus           │  Persistent dedup + task enrichment, backed by TypedHub.
-│  (singleton)        │  Fixed TypedHub-safe method; external topic is payload data.
+│  EventBus           │  In-memory, backed by TypedHub. Namespaced topics.
+│  (singleton)        │  O(1) subscriber lookup by topic pattern.
 └────────┬────────────┘
          │
          ▼
 ┌─────────────────────┐
-│  EventRouter        │  Subscribes to bus. Matches events to active
-│  (per-runtime)      │  node interests and injects directly into sessions.
+│  EventRouter        │  Subscribes to all topics. Matches events to
+│  (per-runtime)      │  active node interests. Delivers via AgentMessageRouter
+│                     │  or injects directly into sessions.
 └─────────────────────┘
 ```
 
@@ -48,10 +49,8 @@ Examples:
 github/lsm/neokai/pull_request.review_submitted
 github/lsm/neokai/pull_request.comment_created
 github/lsm/neokai/pull_request.synchronize
-github/lsm/neokai/pull_request.closed
-# Not emitted in v1 — mapEventType only handles pull_request variants;
-# issues.* requires a future adapter extension: github/lsm/neokai/issues.opened
-# Future CI adapter (Phase 3): github/lsm/neokai/check_suite.completed
+github/lsm/neokai/check_suite.completed
+github/lsm/neokai/issues.opened
 github/lsm/neokai/pull_request.*            ← wildcard: all PR events for this repo
 github/lsm/neokai/*.*                       ← wildcard: all events for this repo
 github/lsm/neokai/pull_request.review_*     ← prefix wildcard: all review events
@@ -61,30 +60,18 @@ github/lsm/neokai/pull_request.review_*     ← prefix wildcard: all review even
 
 1. `source` — adapter identifier (`github`, `slack`, `ci`). Lowercase, no slashes.
 2. `owner/repo` — from the event's repository context. Both lowercase for case-insensitive matching.
-3. `resource.action` — the fourth path segment is always one dotted pair. For V1 GitHub PR events, `resource` is `pull_request`; review/comment variants are encoded in `action` (`review_submitted`, `comment_created`, `review_comment_created`) so examples like `pull_request.review_submitted` remain canonical. CI resources such as `check_suite` are Phase 3/future adapter scope.
+3. `resource` — the GitHub resource type: `pull_request`, `issue`, `check_suite`, `pull_request_review`, etc.
 4. `action` — the specific action: `opened`, `review_submitted`, `comment_created`, `completed`, etc.
-5. All v1 topics use exactly 4 path segments. For resources without a natural `owner/repo` (e.g. a future Slack message), use a source-specific scope pair to preserve the same depth: `{source}/{workspace}/{channel}/{resource}.{action}` (for example, `slack/acme/eng/messages.created`). Adapters that do not have both scope levels should use a reserved placeholder segment such as `_` rather than emitting 3-segment topics.
+5. For resources without a natural `owner/repo` (e.g. a Slack message), the convention is `{source}/{workspace}/{channel}.{action}`.
 
 ### Matching rules
 
 Subscriptions use glob-style patterns:
-- `*` matches any sequence of characters inside one path segment (no slashes).
-  - A whole-segment `*` matches any single segment (e.g., owner or repo).
-  - A segment-local wildcard also works inside dotted resource/action segments (e.g., `pull_request.*`, `pull_request.review_*`, `*.*`).
-- Literal characters match exactly (case-insensitive).
+- `*` matches any single path segment (no slashes)
+- `**` matches any number of path segments
+- Literal segments match exactly (case-insensitive)
 
-> **V1 scope note:** The `**` (multi-segment) wildcard is deferred to a follow-up. All v1 use cases are covered by segment-local `*` wildcards at the `owner`, `repo`, or `action` position (e.g., `github/*/*/pull_request.review_submitted`, `github/*/*/pull_request.*`). Adding `**` support requires a depth-bounded recursive trie walk and is not justified by current subscription patterns.
-
-Pattern validation (enforced at workflow create/update time):
-- Must be non-empty.
-- Must not contain `..` segments.
-- Must not contain empty segments (no double slashes).
-- Must have exactly 4 segments (`source/scope1/scope2/resource.action`) so it can match real event topics.
-- The 4th segment must contain a `resource.action` separator (`.`) with non-empty resource and action sides, allowing segment-local wildcards such as `pull_request.*`, `*.created`, and `*.*`.
-- Each segment may contain alphanumeric, dash, underscore, dot, and `*`; `*` must stay within a single segment and cannot cross `/` boundaries.
-- Max 10 interests per agent slot.
-
-We implement matching via a **trie-based prefix index** (see §4), not regex.
+We implement matching via a **trie-based prefix index** (see §4), not regex. This keeps matching O(k) where k = topic depth, independent of the number of subscriptions.
 
 ## 2. Node-Level Event Subscription (`eventInterests`)
 
@@ -96,7 +83,7 @@ We implement matching via a **trie-based prefix index** (see §4), not regex.
 export interface EventInterest {
   /**
    * Glob pattern matching event topics.
-   * Examples: 'github/*/*/pull_request.*', 'github/*/*/pull_request.review_*'
+   * Examples: 'github/*/*/pull_request.*', 'ci/*/*/check_suite.completed'
    */
   topic: string;
 
@@ -152,7 +139,7 @@ export interface WorkflowNodeAgent {
             "label": "PR comments on my task's PR"
           },
           {
-            "topic": "github/*/*/pull_request.review_comment_created",
+            "topic": "github/*/*/pull_request_review_comment.*",
             "scope": "task",
             "label": "Inline review comments"
           }
@@ -161,15 +148,15 @@ export interface WorkflowNodeAgent {
     },
     {
       "id": "monitor",
-      "name": "PR Monitor",
+      "name": "CI Monitor",
       "agents": [{
         "agentId": "...",
-        "name": "pr-monitor",
+        "name": "ci-monitor",
         "eventInterests": [
           {
-            "topic": "github/*/*/pull_request.*",
+            "topic": "github/*/*/check_suite.completed",
             "scope": "repo",
-            "label": "All PR activity in the repo"
+            "label": "All CI completions in the repo"
           }
         ]
       }]
@@ -180,40 +167,31 @@ export interface WorkflowNodeAgent {
 
 ### Scoping details
 
-**`task` scope** is the critical innovation. Task association is resolved before delivery by the core `EventTaskResolver`:
+**`task` scope** is the critical innovation. The router resolves the task's context at match time:
 
-1. The task's `SpaceTask` record has `workflowRunId` and (via workflow artifacts or gate data) an associated PR number, PR URL, or branch name.
-2. `EventTaskResolver` enriches matching events with `routedTaskId` using source-normalized metadata such as GitHub PR URL/number/branch.
-3. For a `task`-scoped subscription, the router checks whether `event.routedTaskId === sub.taskId`.
+1. The task's `SpaceTask` record has `workflowRunId` and (via `workflow_run_artifacts` or gate data) an associated PR number and branch name.
+2. The router queries the same `SpacePrTaskResolver` that `SpaceGitHubService` already uses to match PR numbers to tasks.
+3. For a `task`-scoped subscription, the router checks: does this event's PR number / branch match the node execution's parent task?
 4. The node author never specifies a PR number — it's implicit from the task context.
 
 **`repo` scope** filters to events from any of the space's watched repositories (`space_github_watched_repos`). The node author doesn't need to know repo names.
 
-**`global` scope** passes through all events in the same space matching the topic pattern. It is never cross-space: the router requires `event.spaceId === subscription.spaceId` before any scope-specific logic runs. Use sparingly (e.g. a space-local "global monitor" node).
+**`global` scope** passes through all events matching the topic pattern. Use sparingly (e.g. a "global monitor" node).
 
 ### Auto-scoping resolution at runtime
 
 When an event arrives, the router:
 
-1. Verifies `event.spaceId` matches the subscription's `spaceId`, then uses normalized event fields (`repoOwner/repoName`, `routedTaskId`, etc.) for scope checks.
+1. Extracts `prNumber` and `repoOwner/repoName` from the event payload.
 2. For each active node execution with `eventInterests`:
    a. Compiles the interest's `topic` glob against the event's topic.
    b. If matched, checks scope:
-      - `task`: checks the `EventTaskResolver` enrichment (`event.routedTaskId`) against this subscription's task.
+      - `task`: resolves `SpaceTask` → `SpacePrTaskResolver` → does event's PR match this task?
       - `repo`: does event's repo match any watched repo in the node's space?
       - `global`: pass.
    c. If scope check passes, the event is queued for delivery to this node's agent session.
 
 ## 3. EventIngestion Adapter Interface
-
-External sources are modeled as **extensions**. An adapter owns the source-specific work:
-
-1. Receive events from its source (webhook, polling, streaming API, etc.).
-2. Verify source-specific authenticity (e.g. GitHub HMAC signatures).
-3. Normalize raw source payloads into `ExternalEvent`.
-4. Publish directly to the EventBus.
-
-Adapters do **not** resolve Space tasks, inspect workflow nodes, or inject into agent sessions. Those are core daemon responsibilities handled by bus-level services and the `EventRouter`. This keeps GitHub, Slack, CI, and future integrations pluggable without adding source-specific paths to the workflow runtime.
 
 ```typescript
 // packages/daemon/src/lib/space/runtime/event-bus/types.ts
@@ -222,57 +200,50 @@ Adapters do **not** resolve Space tasks, inspect workflow nodes, or inject into 
  * A normalized external event on the bus.
  */
 export interface ExternalEvent {
-  /** Unique event ID (UUID) assigned by the adapter for this bus publication. */
+  /** Unique event ID (UUID) */
   id: string;
-  /** Space this event belongs to. Required to prevent cross-space delivery. */
-  spaceId: string;
   /** Fully qualified topic: 'github/owner/repo/resource.action' */
   topic: string;
-  /** Timestamp when the event occurred at the source (epoch ms). */
+  /** Timestamp when the event occurred (epoch ms) */
   occurredAt: number;
-  /** Timestamp when the event was accepted by the adapter (epoch ms). */
+  /** Timestamp when the event was ingested (epoch ms) */
   ingestedAt: number;
-  /** Source adapter identifier. */
+  /** Source adapter identifier */
   source: string;
-  /** Optional source-native event id/delivery id for diagnostics. */
-  sourceEventId?: string;
-  /** Optional PR number used by core task resolution. */
+  /**
+   * For scope resolution. Not all events have a PR number;
+   * absence means 'task'-scoped subscriptions won't match.
+   */
   prNumber?: number;
-  /** Repository owner (lowercase) for repo-scoped matching. */
+  /** Repository owner (lowercase) */
   repoOwner?: string;
-  /** Repository name (lowercase) for repo-scoped matching. */
+  /** Repository name (lowercase) */
   repoName?: string;
-  /** Branch name, if available. */
+  /** Branch name, if available */
   branch?: string;
-  /** Human-readable summary for agent consumption. */
+  /** Human-readable summary for agent consumption */
   summary: string;
-  /** External URL (e.g. GitHub PR link). */
+  /** External URL (e.g. GitHub PR link) */
   externalUrl?: string;
-  /** Structured source payload — adapter-specific, not constrained. */
+  /** Structured payload — adapter-specific, not constrained */
   payload: Record<string, unknown>;
   /**
-   * Stable source-level identity used by bus dedup. Must be stable across
-   * webhook and polling observations of the same external event.
+   * Deduplication key. The bus tracks delivered events by (eventId, nodeId)
+   * to prevent double delivery.
    */
   dedupeKey: string;
-  /**
-   * Core enrichment filled by EventTaskResolver after publication.
-   * Adapters should leave this unset unless the source itself has a trusted
-   * first-party task id.
-   */
-  routedTaskId?: string;
 }
 
 /**
- * Interface that event source extensions must implement.
+ * Interface that event source adapters must implement.
  */
 export interface EventAdapter {
-  /** Adapter identifier (used in topic namespace: '{source}/...'). */
+  /** Adapter identifier (used in topic namespace: '{source}/...') */
   readonly sourceId: string;
 
   /**
    * Start the adapter. Called once at daemon startup.
-   * The adapter calls `publisher.publish(event)` whenever it accepts an event.
+   * The adapter calls `publisher.publish(event)` whenever it has an event.
    */
   start(publisher: EventPublisher): Promise<void>;
 
@@ -281,181 +252,62 @@ export interface EventAdapter {
 }
 
 /**
- * Optional interface for adapters that expose HTTP endpoints.
- * The daemon routes matching requests to the adapter without knowing source
- * internals such as HMAC verification, event names, or raw payload shape.
- */
-export interface HttpEventAdapter extends EventAdapter {
-  readonly routes: readonly {
-    method: 'GET' | 'POST' | 'PUT' | 'DELETE';
-    path: string;
-    handle(req: Request, publisher: EventPublisher): Promise<Response>;
-  }[];
-}
-
-/**
- * Optional interface for adapters that expose daemon RPC methods.
- * GitHub uses this for watch/list/poll operations; future adapters can expose
- * source-specific configuration without adding core RPC handler dependencies.
- */
-export interface RpcEventAdapter extends EventAdapter {
-  registerRpcHandlers(hub: MessageHub, publisher: EventPublisher): void;
-}
-
-/**
  * Callback adapters use to publish events onto the bus.
  */
 export interface EventPublisher {
-  publish(event: ExternalEvent): Promise<PublishResult>;
-}
-
-export interface PublishResult {
-  eventId: string;
-  duplicate: boolean;
-  state: 'published' | 'duplicate_terminal' | 'retryable_duplicate' | 'ignored';
-}
-
-/**
- * TypedHub/MessageHub method used by EventBus.
- *
- * IMPORTANT: raw external topics (e.g. `github/lsm/neokai/pull_request.opened`)
- * are NOT used as TypedHub method names because MessageHub validates methods
- * with `[a-zA-Z0-9._-]`, requires a dot, and rejects `/` and `*`.
- * The external topic stays in `ExternalEvent.topic` and is matched by EventRouter.
- */
-export const EXTERNAL_EVENT_PUBLISHED_METHOD = 'space.externalEvent.published';
-
-export interface EventBusHubEventMap {
-  'space.externalEvent.published': {
-    /** Fixed channel required by BaseEventData/TypedHub routing. */
-    sessionId: 'global';
-    spaceId: string;
-    event: ExternalEvent;
-  };
+  publish(event: ExternalEvent): Promise<void>;
 }
 ```
 
-The `sessionId: 'global'` field is required because EventBus is backed by TypedHub/DaemonHub, whose payloads satisfy `BaseEventData` for channel routing. External event delivery is still space-scoped by `spaceId`; the fixed session channel is only the transport channel for bus subscribers.
+### GitHub adapter
+
+The GitHub adapter wraps the existing `SpaceGitHubService.ingest()` pipeline. Rather than duplicating normalization logic, the adapter hooks into the point where `SpaceGitHubService` has already normalized and resolved the event:
 
 ```typescript
-class EventBus implements EventPublisher {
-  constructor(
-    private readonly hub: DaemonHub,
-    private readonly eventStore: ExternalEventStore,
-    private readonly taskResolver: EventTaskResolver,
-  ) {}
-
-  async publish(event: ExternalEvent): Promise<PublishResult> {
-    // 1. Validate topic and required source fields.
-    validateExternalEvent(event);
-
-    // 2. Store and dedupe before emission. Unlike SpaceGitHubService.ingest(),
-    // retryable duplicates are not swallowed: if the prior delivery state is
-    // non-terminal, the event is re-emitted so delivery can retry.
-    const stored = this.eventStore.store(event);
-    if (stored.duplicate && stored.terminal) {
-      return { eventId: stored.event.id, duplicate: true, state: 'duplicate_terminal' };
-    }
-
-    // 3. Core enrichment. For GitHub PR events this resolves PR -> SpaceTask.
-    // Adapters do not query workflow/task/gate tables directly.
-    const enriched = await this.taskResolver.enrich(stored.event);
-
-    await this.hub.emit(EXTERNAL_EVENT_PUBLISHED_METHOD, {
-      sessionId: 'global',
-      spaceId: enriched.spaceId,
-      event: enriched,
-    });
-
-    return {
-      eventId: enriched.id,
-      duplicate: stored.duplicate,
-      state: stored.duplicate ? 'retryable_duplicate' : 'published',
-    };
-  }
-}
-```
-
-### Bus-level middleware/services
-
-The EventBus owns cross-cutting behavior that applies to every adapter:
-
-1. **Validation** — all topics must satisfy the four-segment topic contract before publication.
-2. **Source-level dedup** — a persistent `ExternalEventStore` tracks `(spaceId, source, dedupeKey)` and delivery state. Terminal duplicates (`delivered`, `ignored`, `ambiguous`) are short-circuited; retryable states (`published`, `routed`, `delivery_failed`) are re-emitted so delivery can retry.
-3. **Task enrichment** — `EventTaskResolver` enriches events with `routedTaskId` for task-scoped matching. For GitHub PR events, it uses PR URL/number/branch fields that were normalized by the adapter. For future Slack/CI events, source-specific resolver plugins can be registered without changing adapters.
-4. **Publication** — only enriched, deduped events are emitted on `space.externalEvent.published`.
-
-This replaces the current GitHub-specific `SpaceGitHubService.ingest()` hot path for new event delivery. In particular, the bus-level dedup store must not use unconditional `INSERT OR IGNORE` short-circuiting for retryable states; otherwise transient delivery failures become permanent event loss.
-
-### GitHub adapter as an extension
-
-The GitHub adapter is a primary source adapter, not a downstream listener on `SpaceGitHubService`:
-
-```typescript
-class GitHubEventAdapter implements HttpEventAdapter, RpcEventAdapter {
+class GitHubEventAdapter implements EventAdapter {
   readonly sourceId = 'github';
-  readonly routes = [
-    { method: 'POST', path: '/webhook/github/space', handle: this.handleWebhook.bind(this) },
-  ] as const;
 
   constructor(
-    private readonly repo: GitHubEventAdapterRepository,
-    private readonly githubToken?: string,
+    private readonly spaceGitHubService: SpaceGitHubService,
+    private readonly watchedRepoLookup: (owner: string, repo: string) => { spaceId: string }[]
   ) {}
 
   async start(publisher: EventPublisher): Promise<void> {
-    this.publisher = publisher;
-    this.pollTimer = setInterval(() => void this.pollOnce(), GITHUB_POLL_INTERVAL_MS);
-  }
-
-  async stop(): Promise<void> {
-    if (this.pollTimer) clearInterval(this.pollTimer);
-  }
-
-  registerRpcHandlers(hub: MessageHub, publisher: EventPublisher): void {
-    hub.onRequest('space.github.watchRepo', async (data) => this.watchRepo(data));
-    hub.onRequest('space.github.listWatchedRepos', async (data) => this.listWatchedRepos(data));
-    hub.onRequest('space.github.pollOnce', async () => ({ count: await this.pollOnce() }));
-  }
-
-  private async handleWebhook(req: Request, publisher: EventPublisher): Promise<Response> {
-    const raw = await req.text();
-    const verifiedRepos = this.verifySignatureAgainstWatchedRepos(req, raw);
-    const normalized = normalizeGitHubWebhook(req.headers, JSON.parse(raw));
-    if (!normalized) return Response.json({ ignored: true });
-
-    for (const watched of verifiedRepos) {
-      await publisher.publish(toExternalEvent(watched.spaceId, normalized));
-    }
-
-    return Response.json({ message: 'Webhook received' });
-  }
-
-  async pollOnce(fetchImpl: typeof fetch = fetch): Promise<number> {
-    // Poll GitHub endpoints, normalize rows, and publish ExternalEvent directly.
-    // No SpaceTask lookup and no session injection happen here.
+    // Hook into SpaceGitHubService by intercepting the post-normalization path.
+    // SpaceGitHubService already:
+    //   1. Normalizes the webhook/polling event
+    //   2. Deduplicates via dedupeKey
+    //   3. Resolves PR → taskId via SpacePrTaskResolver
+    //   4. Emits DaemonHub 'space.githubEvent.routed'
+    //
+    // The adapter subscribes to 'space.githubEvent.routed' on DaemonHub
+    // and converts the event to an ExternalEvent for the bus.
+    //
+    // This means:
+    //   - No change to existing webhook/polling normalization
+    //   - Events continue flowing to Task Agent as before
+    //   - Additionally, events appear on the EventBus for node delivery
   }
 }
 ```
 
-The normalization helpers currently living in `space-github.ts` move into this adapter module:
+The adapter subscribes to the existing `space.githubEvent.routed` DaemonHub event (already emitted by `SpaceGitHubService.appendTaskActivity`). It converts the event to `ExternalEvent` format and publishes to the bus.
 
-- `normalizeSpaceGitHubWebhook(...)` → `normalizeGitHubWebhook(...)`
-- `normalizePollingRow(...)` → `normalizeGitHubPollingRow(...)`
-- `mapEventType(...)` stays with the adapter because topic construction is source-specific
-
-The adapter may keep source-local tables such as `space_github_watched_repos` and an optional adapter event log for diagnostics, but the authoritative cross-source event lifecycle belongs to the EventBus store.
+**Why this approach:**
+- Zero changes to the existing `SpaceGitHubService` webhook handler or polling pipeline.
+- The existing PR-to-task resolution (`SpacePrTaskResolver`) continues to work.
+- The existing Task Agent injection continues to work (we don't replace it, we supplement it).
+- The adapter is purely additive: it converts an already-normalized event into bus format.
 
 ## 4. EventRouter Design
 
 ### Architecture
 
-The `EventRouter` subscribes to the fixed TypedHub-safe EventBus method (`space.externalEvent.published`). When an event arrives, it:
+The `EventRouter` subscribes to all topics on the `EventBus`. When an event arrives, it:
 
-1. Reads the external topic from `event.topic` in the payload.
-2. Looks up all active node executions that have `eventInterests` matching that payload topic.
-3. For each matching interest, checks scope.
-4. Delivers the event to the matching node's agent session.
+1. Looks up all active node executions that have `eventInterests`.
+2. For each matching interest, checks scope.
+3. Delivers the event to the matching node's agent session.
 
 ### Trie-based subscription index
 
@@ -464,53 +316,42 @@ For O(1)-ish lookup, we maintain a **topic trie**:
 ```
 root
   └── github
-      └── *                          ← matches any owner
-          └── *                      ← matches any repo
-              ├── pull_request.*     ← all PR actions
-              │   └── [subscriptions: coder(task), ...]
-              ├── pull_request.review_submitted
-              │   └── [subscriptions: coder(task)]
-              ├── pull_request.comment_created
-              │   └── [subscriptions: coder(task)]
-              └── pull_request.review_comment_created
-                  └── [subscriptions: coder(task)]
+      └── *                    ← matches any owner
+          └── *                ← matches any repo
+              ├── pull_request
+              │   ├── *        ← all PR actions
+              │   │   └── [subscriptions: coder(task), ...]
+              │   ├── review_submitted
+              │   │   └── [subscriptions: coder(task)]
+              │   └── comment_created
+              │       └── [subscriptions: coder(task)]
+              └── check_suite
+                  └── completed
+                      └── [subscriptions: ci-monitor(repo)]
 ```
 
-The trie maps topic segments to `Set<Subscription>` at leaf nodes. Each node stores exact children separately from segment-local glob children. A glob segment may be a whole-segment wildcard (`*`) or a dotted segment wildcard (`pull_request.*`, `pull_request.review_*`, `*.*`).
+The trie maps topic segments to `Set<Subscription>` at leaf nodes. Wildcard segments (`*`) match any single segment at that depth.
 
 **Build cost**: O(n × k) where n = number of subscriptions, k = topic depth (typically 4-5). Built once when a workflow run starts.
 
-**Lookup cost**: The trie walks the exact branch (O(1)) and any glob-child branches at each level. With k bounded to 4–5 segments and max 10 interests per agent slot, the number of glob branches is small. In the common case this remains effectively O(2^k × m), where m is the total number of matching subscriptions across collected leaves. The real benefit over linear scan is that non-matching subscriptions are never visited — only subscriptions whose pattern segments align with the event's topic are collected.
+**Lookup cost**: O(k) per event — walk the trie by topic segment, collect subscriptions at each level (exact match + wildcard).
 
 ### Subscription index lifecycle
 
-The index is **per-SpaceRuntime instance** and updated via two distinct operations:
+The index is **per-SpaceRuntime instance** and rebuilt when:
 
-1. **`registerRunInterests`** (called on every `executeTick`): Diff-based trie update. Compares current node execution states against existing subscriptions. Adds subscriptions for newly active nodes, removes subscriptions for `cancelled` nodes. Does NOT touch the dedup map or pending queue — those are preserved across tick refreshes.
-
-2. **`clearRunInterests`** (called only on `done`/`cancelled` terminal transitions): Full teardown. Removes all trie subscriptions, dedup entries, and pending queue entries for the run. NOT called on `blocked` transitions because blocked is resumable.
-
-3. A workflow definition is updated (interests may have changed — next `registerRunInterests` call picks up changes via the diff).
+1. A workflow run starts (node executions are created with interests from the workflow definition).
+2. A node execution transitions to a new status (e.g. `in_progress` → starts receiving events; `idle`/`cancelled` → removed from index).
+3. A workflow definition is updated (interests may have changed — next run picks up changes).
 
 ```typescript
 interface Subscription {
   workflowRunId: string;
-  /** The specific SpaceTask this node execution belongs to. Used for `task` scope. */
-  taskId: string;
   nodeId: string;
   agentName: string;
   interest: EventInterest;    // from the workflow definition
   agentSessionId: string | null; // resolved at delivery time
   spaceId: string;
-}
-
-interface PendingDelivery {
-  event: ExternalEvent;
-  deliveryKey: string;
-}
-
-interface WatchedRepoLookup {
-  listWatchedRepos(spaceId: string): { owner: string; repo: string; enabled: boolean }[];
 }
 ```
 
@@ -519,274 +360,68 @@ interface WatchedRepoLookup {
 ```typescript
 class EventRouter {
   // topic trie for fast lookup
-  private topicTrie: TopicTrie<Subscription> = new TopicTrie();
+  private topicTrie: TopicTrie<Subscription[]> = new TopicTrie();
 
   // track which runs have active subscriptions (for lifecycle management)
   private activeRuns: Map<string, Set<Subscription>> = new Map();
 
-  // dedup: JSON tuple (dedupeKey, taskId, nodeId, agentName, workflowRunId) → timestamp
+  // dedup: (dedupeKey, agentSessionId) → timestamp
   private delivered: Map<string, number> = new Map();
-  // pending delivery queue: JSON tuple (workflowRunId, taskId, nodeId, agentName) → events plus delivery keys
-  private pendingQueue: Map<string, PendingDelivery[]> = new Map();
-  // TTL for dedup entries — entries older than this are evicted on next access
-  private static readonly DEDUP_TTL_MS = 10 * 60 * 1000; // 10 minutes
-
-  // Track pending deliveries to prevent duplicate queueing while allowing retries
-  private pendingDeliveries: Set<string> = new Set();
-  // Retry tracking: dedupeKey → retry count
-  private retryCounts: Map<string, number> = new Map();
-  private static readonly MAX_RETRIES = 3;
-  private static readonly RETRY_BACKOFF_MS = 1000; // 1s base, exponential backoff
-
-  // Cache: spaceId → Set of "owner/repo" strings for watched repos.
-  // Invalidated when a source adapter reports watched-repo configuration changes.
-  private watchedRepoCache: Map<string, Set<string>> = new Map();
 
   constructor(
     private readonly eventBus: EventBus,
     private readonly nodeExecutionRepo: NodeExecutionRepository,
     private readonly taskRepo: SpaceTaskRepository,
-    private readonly spaceTaskManager: SpaceTaskManager,
     private readonly sessionFactory: SessionFactory,
-    private readonly watchedRepoLookup: WatchedRepoLookup,
+    private readonly prResolver: SpacePrTaskResolver,
   ) {
-    // Subscribe to the fixed TypedHub-safe method. External topic matching happens
-    // inside handleEvent via event.topic, not via the hub method name.
-    this.eventBus.subscribe(EXTERNAL_EVENT_PUBLISHED_METHOD, ({ spaceId, event }) => {
-      // Defense in depth: payload spaceId and event.spaceId must agree.
-      if (event.spaceId !== spaceId) return;
-      void this.handleEvent(event).catch((err) => {
-        log.warn('EventRouter: failed to route external event', {
-          error: err,
-          spaceId,
-          topic: event.topic,
-          eventId: event.id,
-        });
-      });
-    });
-  }
-
-  /** Check if a repo is watched for a given space. Uses cached data. */
-  private isWatchedRepo(spaceId: string, owner: string, repo: string): boolean {
-    let cached = this.watchedRepoCache.get(spaceId);
-    if (!cached) {
-      const repos = this.watchedRepoLookup.listWatchedRepos(spaceId);
-      cached = new Set(
-        repos.filter(r => r.enabled).map(r => `${r.owner.toLowerCase()}/${r.repo.toLowerCase()}`)
-      );
-      this.watchedRepoCache.set(spaceId, cached);
-    }
-    return cached.has(`${owner.toLowerCase()}/${repo.toLowerCase()}`);
+    // Subscribe to ALL events on the bus
+    this.eventBus.subscribe('*', this.handleEvent.bind(this));
   }
 
   /**
-   * Invalidate the watched-repo cache for a given space (or all spaces).
-   * Called when watched repos change via the `space.github.watchRepo` RPC path
-   * (enabling/disabling repos). Without this, `repo`-scoped matching grows stale
-   * until process restart.
-   */
-  invalidateWatchedRepoCache(spaceId?: string): void {
-    if (spaceId) {
-      this.watchedRepoCache.delete(spaceId);
-    } else {
-      this.watchedRepoCache.clear();
-    }
-  }
-
-  private makeDeliveryKey(event: ExternalEvent, sub: Subscription): string {
-    // Use a structured tuple key: event.dedupeKey and workflow/node/agent ids are
-    // free-form strings and can contain ':', '/', or other delimiter characters.
-    return JSON.stringify([event.dedupeKey, sub.taskId, sub.nodeId, sub.agentName, sub.workflowRunId]);
-  }
-
-  private makePendingQueueKey(sub: Pick<Subscription, 'workflowRunId' | 'taskId' | 'nodeId' | 'agentName'>): string {
-    // Same collision-safe shape as subscription/delivery keys.
-    return JSON.stringify([sub.workflowRunId, sub.taskId, sub.nodeId, sub.agentName]);
-  }
-
-  /** Evict stale dedup entries (called periodically or on demand). */
-  private evictStaleDedup(): void {
-    const cutoff = Date.now() - EventRouter.DEDUP_TTL_MS;
-    for (const [key, ts] of this.delivered.entries()) {
-      if (ts < cutoff) this.delivered.delete(key);
-    }
-  }
-
-  /**
-   * Refresh event interests for a workflow run based on current node execution states.
-   * Called on every executeTick to keep the trie in sync with node lifecycle changes.
-   *
-   * This is a DIFF-BASED update — it only adds/removes trie subscriptions for nodes
-   * whose status has changed. It does NOT touch the dedup map or pending queue.
-   * Terminal-run cleanup (dedup + pending) is handled exclusively by `clearRunInterests`.
+   * Register all event interests for a workflow run.
+   * Called when a workflow run starts or when node executions change.
    */
   registerRunInterests(
     spaceId: string,
     workflowRunId: string,
-    /** The task whose tick/session activation is being processed. */
-    taskId: string,
     workflow: SpaceWorkflow,
     nodeExecutions: NodeExecution[],
   ): void {
-    // Build the desired set of subscriptions from current node execution states.
-    // Use a structured tuple key encoded with JSON.stringify rather than a
-    // delimiter-joined string: task ids, node ids, agent names, topics, and scopes
-    // are free-form enough that ':' or other delimiters can appear in valid input.
-    const makeSubscriptionKey = (sub: Pick<Subscription, 'taskId' | 'nodeId' | 'agentName' | 'interest'>) =>
-      JSON.stringify([sub.taskId, sub.nodeId, sub.agentName, sub.interest.topic, sub.interest.scope]);
+    // Clear previous subscriptions for this run
+    this.clearRunInterests(workflowRunId);
 
-    const desiredSubs = new Map<string, Subscription>();
+    const runSubs = new Set<Subscription>();
 
     for (const node of workflow.nodes) {
       for (const agent of node.agents) {
         if (!agent.eventInterests?.length) continue;
 
+        // Only register if this node has at least one active (non-terminal) execution
         const exec = nodeExecutions.find(
           e => e.workflowNodeId === node.id && e.agentName === agent.name
         );
-        if (!exec || !isReceivingStatus(exec.status)) continue;
+        if (!exec || isTerminal(exec.status)) continue;
 
         for (const interest of agent.eventInterests) {
-          // Include taskId, topic, and scope in key — the same run can contain
-          // multiple tasks, and the same agent can subscribe to the same topic
-          // with different scopes (e.g., both 'task' and 'repo' scope).
           const sub: Subscription = {
             workflowRunId,
-            taskId,
             nodeId: node.id,
             agentName: agent.name,
             interest,
             agentSessionId: exec.agentSessionId,
             spaceId,
           };
-          desiredSubs.set(makeSubscriptionKey(sub), sub);
+
+          // Insert into trie
+          this.topicTrie.insert(interest.topic, sub);
+          runSubs.add(sub);
         }
       }
     }
 
-    // Diff against current subscriptions for THIS task only. A workflow run can
-    // contain multiple tasks, so refreshing task A must not remove task B's
-    // subscriptions from the same run.
-    const currentRunSubs = this.activeRuns.get(workflowRunId) ?? new Set<Subscription>();
-    const currentTaskSubs = [...currentRunSubs].filter(sub => sub.taskId === taskId);
-    const currentSubsByKey = new Map<string, Subscription>();
-    for (const sub of currentTaskSubs) {
-      currentSubsByKey.set(makeSubscriptionKey(sub), sub);
-    }
-    const desiredKeys = new Set(desiredSubs.keys());
-
-    // Remove this task's subscriptions no longer in the desired set (e.g. node went cancelled).
-    for (const [key, sub] of currentSubsByKey) {
-      if (!desiredKeys.has(key)) {
-        this.topicTrie.remove(
-          v => v.workflowRunId === workflowRunId
-            && v.taskId === sub.taskId
-            && v.nodeId === sub.nodeId
-            && v.agentName === sub.agentName
-            && v.interest.topic === sub.interest.topic
-            && v.interest.scope === sub.interest.scope,
-        );
-      }
-    }
-
-    // Add new subscriptions not currently in the trie.
-    for (const [key, sub] of desiredSubs) {
-      if (!currentSubsByKey.has(key)) {
-        this.topicTrie.insert(sub.interest.topic, sub);
-      }
-    }
-
-    // Replace only this task's active subscriptions while preserving other tasks
-    // in the same workflow run.
-    const preservedOtherTaskSubs = [...currentRunSubs].filter(sub => sub.taskId !== taskId);
-    this.activeRuns.set(workflowRunId, new Set([...preservedOtherTaskSubs, ...desiredSubs.values()]));
-  }
-
-  /**
-   * Unregister subscriptions for a specific task-owned node execution.
-   * Called when a node execution transitions to `cancelled` state.
-   * Includes taskId so cancelling one task's node does not remove another
-   * task's subscriptions when both tasks share the same workflowRunId/node/agent.
-   *
-   * Only `cancelled` nodes are removed from the subscription index.
-   * All other states (`pending`, `in_progress`, `idle`, `waiting_rebind`,
-   * `blocked`) remain subscribed because:
-   * - `in_progress`: live session receives events immediately
-   * - `idle`: session exists and can be woken via injectMessage (defer mode)
-   * - `waiting_rebind`/`blocked`/`pending`: events queued for later delivery
-   *
-   * See `isReceivingStatus` helper for the complete state classification.
-   */
-  unregisterExecution(
-    workflowRunId: string,
-    taskId: string,
-    nodeId: string,
-    agentName: string,
-  ): void {
-    const runSubs = this.activeRuns.get(workflowRunId);
-    if (!runSubs) return;
-
-    const toRemove = [...runSubs].filter(
-      s => s.taskId === taskId && s.nodeId === nodeId && s.agentName === agentName,
-    );
-    for (const sub of toRemove) {
-      runSubs.delete(sub);
-      this.topicTrie.remove(
-        v => v.workflowRunId === workflowRunId
-          && v.taskId === taskId
-          && v.agentName === agentName
-          && v.nodeId === nodeId,
-      );
-    }
-  }
-
-  /**
-   * Clear all subscriptions for a workflow run.
-   * Called when the workflow run reaches a truly terminal state (done or cancelled).
-   *
-   * NOT called for `blocked` runs because blocked is resumable — the run may be
-   * reopened (see WorkflowRunReopenedEvent) and its node subscriptions should
-   * remain active so queued/arriving events can be delivered upon resume.
-   */
-  clearRunInterests(workflowRunId: string): void {
-    const runSubs = this.activeRuns.get(workflowRunId);
-    if (!runSubs) return;
-
-    this.topicTrie.remove(v => v.workflowRunId === workflowRunId);
-    this.activeRuns.delete(workflowRunId);
-
-    // Also clean up dedup entries for this run. Keys are JSON tuples, so parse
-    // structurally rather than suffix-matching delimiter-joined strings.
-    for (const key of this.delivered.keys()) {
-      const [, , , , keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string, string];
-      if (keyWorkflowRunId === workflowRunId) {
-        this.delivered.delete(key);
-      }
-    }
-
-    // Clean up in-memory pending queue for this run. Keys are JSON tuples, so parse
-    // structurally rather than prefix-matching delimiter-joined strings.
-    for (const key of this.pendingQueue.keys()) {
-      const [keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string];
-      if (keyWorkflowRunId === workflowRunId) {
-        this.pendingQueue.delete(key);
-      }
-    }
-
-    // Clean up pending deliveries and retry counts for this run.
-    // Delivery keys are JSON tuples: [dedupeKey, taskId, nodeId, agentName, workflowRunId]
-    for (const key of this.pendingDeliveries.keys()) {
-      const [, , , , keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string, string];
-      if (keyWorkflowRunId === workflowRunId) {
-        this.pendingDeliveries.delete(key);
-      }
-    }
-    for (const key of this.retryCounts.keys()) {
-      const [, , , , keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string, string];
-      if (keyWorkflowRunId === workflowRunId) {
-        this.retryCounts.delete(key);
-      }
-    }
+    this.activeRuns.set(workflowRunId, runSubs);
   }
 
   private async handleEvent(event: ExternalEvent): Promise<void> {
@@ -795,24 +430,9 @@ class EventRouter {
 
     if (matched.length === 0) return;
 
-    // 2. For each matched subscription, check scope and deliver.
-    // Isolate failures per subscription so one bad repo/task lookup or injection
-    // does not prevent other interested nodes from receiving the same event.
+    // 2. For each matched subscription, check scope and deliver
     for (const sub of matched) {
-      try {
-        await this.deliverToSubscription(event, sub);
-      } catch (err) {
-        log.warn('EventRouter: failed to deliver external event to subscription', {
-          error: err,
-          spaceId: event.spaceId,
-          topic: event.topic,
-          eventId: event.id,
-          workflowRunId: sub.workflowRunId,
-          taskId: sub.taskId,
-          nodeId: sub.nodeId,
-          agentName: sub.agentName,
-        });
-      }
+      await this.deliverToSubscription(event, sub);
     }
   }
 
@@ -820,168 +440,57 @@ class EventRouter {
     // Scope check
     if (!this.passesScopeCheck(event, sub)) return;
 
-    // Dedup check — include taskId and nodeId to handle multi-task runs and
-    // cases where the same agent name appears in multiple nodes within the same
-    // run. Each task/node/agent subscription is deduped independently.
-    // Evict before checking so DEDUP_TTL_MS is actually enforced during long runs.
-    this.evictStaleDedup();
-    const dedupeKey = this.makeDeliveryKey(event, sub);
+    // Dedup check
+    const dedupeKey = `${event.dedupeKey}:${sub.agentName}:${sub.workflowRunId}`;
     if (this.delivered.has(dedupeKey)) return;
 
-    // Check if pending (prevents duplicate queueing while allowing retries on failure)
-    if (this.pendingDeliveries.has(dedupeKey)) return;
+    // Resolve session
+    const sessionId = await this.resolveSession(sub);
+    if (!sessionId) {
+      // Session not active — queue for later delivery
+      this.queueForDelivery(event, sub);
+      return;
+    }
 
-    // Mark as pending to prevent duplicate queueing. We do NOT mark as delivered
-    // until after successful injection. Failed injection/session-resolution paths
-    // clear pending and schedule router-level retry rather than relying on a source
-    // adapter to publish the same event again.
-    this.pendingDeliveries.add(dedupeKey);
-
+    // Format and inject
+    const message = this.formatEventMessage(event);
     try {
-      // Resolve session — re-read from nodeExecutionRepo for latest state
-      const sessionId = await this.resolveSession(sub);
-      if (!sessionId) {
-        // Session not active — queue for later delivery. Pending remains until
-        // the queue is drained or the entry is evicted.
-        this.queueForDelivery(event, sub, dedupeKey);
-        return;
-      }
-
-      // Format and inject.
-      // NOTE: There is a TOCTOU race — the session could complete between our
-      // resolveSession call and injectMessage. This is safe: injectMessage on a
-      // completed/absent session returns a caught error (logged as a warning).
-      const message = this.formatEventMessage(event);
-      try {
-        await this.sessionFactory.injectMessage(sessionId, message, {
-          deliveryMode: 'defer',
-        });
-
-        // Success: mark as delivered, remove pending
-        this.delivered.set(dedupeKey, Date.now());
-        this.pendingDeliveries.delete(dedupeKey);
-      } catch (err) {
-        log.warn(`Failed to deliver event to ${sub.agentName}`, { error: err });
-
-        // Failure: remove pending so it can be retried
-        this.pendingDeliveries.delete(dedupeKey);
-
-        // Schedule retry with backoff if we haven't exceeded max retries
-        this.scheduleRetry(event, sub, dedupeKey);
-      }
-    } catch (err) {
-      // Session resolution failed (transient DB/repo error) — clear pending
-      // and schedule retry so transient failures do not permanently drop delivery.
-      log.warn(`Session resolution failed for ${sub.agentName}`, { error: err });
-      this.pendingDeliveries.delete(dedupeKey);
-      this.scheduleRetry(event, sub, dedupeKey);
-    }
-  }
-
-  private queueForDelivery(event: ExternalEvent, sub: Subscription, deliveryKey: string): void {
-    const key = this.makePendingQueueKey(sub);
-    const queue = this.pendingQueue.get(key) ?? [];
-    queue.push({ event, deliveryKey });
-    if (queue.length > 50) {
-      const dropped = queue.shift();
-      if (dropped) this.pendingDeliveries.delete(dropped.deliveryKey);
-      log.warn('EventRouter: pending external event queue exceeded limit; dropped oldest event', {
-        workflowRunId: sub.workflowRunId,
-        taskId: sub.taskId,
-        nodeId: sub.nodeId,
-        agentName: sub.agentName,
+      await this.sessionFactory.injectMessage(sessionId, message, {
+        deliveryMode: 'defer',
       });
+
+      // Mark delivered
+      this.delivered.set(dedupeKey, Date.now());
+    } catch (err) {
+      log.warn(`Failed to deliver event to ${sub.agentName}`, { error: err });
     }
-    this.pendingQueue.set(key, queue);
-  }
-
-  /**
-   * Drain queued events for a subscription when the node's session is created.
-   * Clears pendingDeliveries markers so events can be re-queued if needed later.
-   */
-  private drainQueue(sub: Subscription): ExternalEvent[] {
-    const key = this.makePendingQueueKey(sub);
-    const queue = this.pendingQueue.get(key) ?? [];
-    this.pendingQueue.delete(key);
-
-    // Clear pendingDeliveries for ALL events in the drained queue. Use the queued
-    // wrapper's stored deliveryKey instead of recomputing from the wrapper object.
-    for (const pending of queue) {
-      this.pendingDeliveries.delete(pending.deliveryKey);
-    }
-
-    return queue.map((pending) => pending.event);
   }
 
   private passesScopeCheck(event: ExternalEvent, sub: Subscription): boolean {
-    // All scopes are bounded to the subscription's space. EventBus is a shared
-    // daemon-wide stream, so even `global` means "global within this space", not
-    // cross-space delivery.
-    if (event.spaceId !== sub.spaceId) return false;
-
     switch (sub.interest.scope) {
       case 'global':
         return true;
 
       case 'repo': {
-        // Check if event's repo matches any watched repo in this space.
-        // Uses an adapter-provided watched-repo lookup filtered by
-        // (spaceId, owner, repo, enabled=true). The router caches this per-space
-        // to avoid DB hits on every event.
+        // Check if event's repo matches any watched repo in this space
         if (!event.repoOwner || !event.repoName) return false;
         return this.isWatchedRepo(sub.spaceId, event.repoOwner, event.repoName);
       }
 
       case 'task': {
-        // EventTaskResolver enriches matching events before publication. The
-        // router uses that trusted enrichment directly and never performs broad
-        // PR/task scans during delivery. This prevents cross-task leakage in
-        // multi-task runs and keeps task/gate/workflow schema access out of
-        // source adapters and delivery hot paths.
-        return event.routedTaskId === sub.taskId;
+        // Check if event's PR number matches the subscription's task
+        if (!event.prNumber) return false;
+        const task = this.taskRepo.getByWorkflowRunId(sub.workflowRunId);
+        if (!task) return false;
+        // Reuse the existing SpacePrTaskResolver logic
+        return this.prResolver.resolve(sub.spaceId, {
+          repoOwner: event.repoOwner ?? '',
+          repoName: event.repoName ?? '',
+          prNumber: event.prNumber,
+          // ... minimal shape for resolver
+        } as any).taskId === task.id;
       }
     }
-  }
-
-  /**
-   * Schedule a retry for failed delivery with exponential backoff.
-   * Retries are bounded by MAX_RETRIES; after that, the event is dropped.
-   */
-  private scheduleRetry(event: ExternalEvent, sub: Subscription, dedupeKey: string): void {
-    const retries = (this.retryCounts.get(dedupeKey) ?? 0) + 1;
-    if (retries > EventRouter.MAX_RETRIES) {
-      log.warn(`Max retries exceeded for event ${dedupeKey}, dropping`);
-      this.retryCounts.delete(dedupeKey);
-      return;
-    }
-
-    this.retryCounts.set(dedupeKey, retries);
-    const backoff = EventRouter.RETRY_BACKOFF_MS * Math.pow(2, retries - 1);
-
-    setTimeout(() => {
-      // Re-check if delivered while waiting (another delivery might have succeeded)
-      if (this.delivered.has(dedupeKey)) {
-        this.retryCounts.delete(dedupeKey);
-        return;
-      }
-      // Use try/catch to prevent unhandled promise rejections in retry path (P2 fix)
-      this.deliverToSubscription(event, sub)
-        .then(() => {
-          // Success: clear retry state so this key can be retried fresh if needed later
-          this.retryCounts.delete(dedupeKey);
-          this.pendingDeliveries.delete(dedupeKey);
-        })
-        .catch((err) => {
-          // Don't clear retryCounts on failure — preserve count for retry logic
-          // (The caller's scheduleRetry already incremented the count before setTimeout)
-          log.warn('EventRouter: retry delivery failed', {
-            error: err,
-            retries,
-            dedupeKey,
-            workflowRunId: sub.workflowRunId,
-          });
-        });
-    }, backoff);
   }
 }
 ```
@@ -1002,27 +511,16 @@ Event arrives → Match subscriptions → Scope check → Dedup check → Sessio
                                                     injectMessage   injectMessage  pending_events
                                                           │              │              │
                                                           ▼              ▼              ▼
-                                                    Mark delivered  Mark delivered  Mark queued
-                                                                                     delivered
-                                                                                     after flush
+                                                    Mark delivered  Mark delivered  Await session
+                                                                                     start
 ```
 
 ### Deduplication
 
-Dedup happens at two different layers, each with a different key and responsibility:
-
-1. **Source-level bus dedup** — persistent `(spaceId, source, dedupeKey)` in `ExternalEventStore`.
-   - Purpose: prevent webhook/polling duplicates from becoming separate bus events.
-   - Terminal duplicates (`delivered`, `ignored`, `ambiguous`) are short-circuited.
-   - Retryable duplicates (`published`, `routed`, `delivery_failed`) are re-emitted so transient delivery failures can retry.
-   - This replaces `SpaceGitHubService.storeEvent()` as the authoritative dedup path for new external-event delivery.
-
-2. **Per-subscription delivery dedup** — in-memory JSON tuple `[event.dedupeKey, subscription.taskId, subscription.nodeId, subscription.agentName, subscription.workflowRunId]`.
-   - Purpose: prevent the same external event from being delivered twice to the same node agent within a run.
-   - The tuple includes `taskId` to isolate multi-task runs and `nodeId` to handle cases where the same agent name appears in multiple nodes within the same run.
-   - The tuple is encoded structurally rather than delimiter-joined because `dedupeKey`, workflow identifiers, node IDs, and agent names are free-form strings.
-
-The EventRouter marks per-subscription delivery as `delivered` only after successful injection. Failed injection/session-resolution paths remove `pendingDeliveries` and schedule retry rather than relying on adapters to re-publish the same event.
+- **Key**: `(event.dedupeKey, subscription.agentName, subscription.workflowRunId)`
+- **Storage**: In-memory `Map<string, number>` (timestamp). Evicted when the workflow run completes.
+- **Guarantee**: Same external event is never delivered twice to the same node agent within a run.
+- The upstream `SpaceGitHubService` already deduplicates by `(spaceId, dedupeKey)` — this is an additional per-node dedup.
 
 ### Wake-on-idle
 
@@ -1036,23 +534,16 @@ When an event matches a subscription whose node execution is `idle` (agent sessi
 
 When a node execution is `pending` (no session yet):
 
-1. The event is queued in an in-memory `Map<string, ExternalEvent[]>` keyed by a JSON tuple `[workflowRunId, taskId, nodeId, agentName]` so free-form identifiers cannot collide by containing delimiter characters.
+1. The event is queued in an in-memory `Map<executionId, ExternalEvent[]>`.
 2. When `TaskAgentManager` creates the node's session, it checks for queued events.
 3. Queued events are injected as initial context in the session's first turn.
 4. Queue is bounded: max 50 events per execution, oldest dropped (with a warning log).
-
-**Known limitation — daemon restart**: The in-memory per-node pending queue is lost on daemon restart. For v1, this is accepted as a known delivery gap:
-- The bus-level `ExternalEventStore` preserves the source event and can re-emit retryable states, but the per-node in-memory queue itself is not durable.
-- Events queued for `pending` nodes before restart may need explicit replay from the event store once persistent delivery queues are implemented.
-- New events (arriving after restart) flow through the bus normally and are not affected.
-
-If persistent queuing is needed in a future iteration, events can be persisted to a `space_event_delivery_queue` SQLite table with the same schema as the in-memory map, and drained on node activation. The table should store the `ExternalEvent.id` plus the subscription key so queued delivery can replay from `ExternalEventStore` without relying on source adapters to re-publish.
 
 ### Backpressure
 
 - **Rate limiting**: If a single node receives > 10 events per minute, subsequent events are coalesced into a digest message: "N additional events received in the last minute. Summary: ..."
 - **Event TTL**: Events older than 5 minutes are dropped from the queue (they're likely stale for an agent's decision-making).
-- **Bus overflow**: The `EventBus` uses TypedHub's async-everywhere design with the fixed method `space.externalEvent.published` — slow consumers don't block publishers. Handlers run via `queueMicrotask`; external slash/glob topics remain payload data and are never used as MessageHub method names.
+- **Bus overflow**: The `EventBus` uses TypedHub's async-everywhere design — slow consumers don't block publishers. Handlers run via `queueMicrotask`.
 
 ## 6. Topic Trie Implementation
 
@@ -1066,19 +557,17 @@ class TopicTrie<T> {
 
   /**
    * Insert a value at a glob pattern.
-   * Pattern segments may contain segment-local `*` wildcards, e.g.
-   * `github/*/*/pull_request.*` or `github/*/*/pull_request.review_*`.
+   * Pattern segments: literal match or '*' for wildcard.
    */
   insert(pattern: string, value: T): void {
     const segments = pattern.split('/');
     let node = this.root;
     for (const segment of segments) {
-      const key = segment.toLowerCase();
-      const children = key.includes('*') ? node.globChildren : node.exactChildren;
-      if (!children.has(key)) {
-        children.set(key, new TrieNode());
+      const key = segment === '*' ? '__wildcard__' : segment.toLowerCase();
+      if (!node.children.has(key)) {
+        node.children.set(key, new TrieNode());
       }
-      node = children.get(key)!;
+      node = node.children.get(key)!;
     }
     if (!node.values) node.values = [];
     node.values.push(value);
@@ -1087,9 +576,7 @@ class TopicTrie<T> {
   /**
    * Lookup all values whose patterns match the given topic.
    * Returns all values from exact matches AND wildcard matches at each level.
-   * Walks at most 2^k paths where k = topic segment count (bounded, small).
-   * Only collects subscriptions from matching leaves — non-matching patterns
-   * are never visited.
+   * O(depth) — independent of total number of patterns.
    */
   lookup(topic: string): T[] {
     const segments = topic.split('/');
@@ -1104,16 +591,13 @@ class TopicTrie<T> {
 
       const segment = segments[depth].toLowerCase();
 
-      // Exact branch: O(1)
-      const exact = node.exactChildren.get(segment);
+      // Exact match
+      const exact = node.children.get(segment);
       if (exact) walk(exact, depth + 1);
 
-      // Glob branches: only patterns that contain segment-local '*'
-      for (const [patternSegment, child] of node.globChildren.entries()) {
-        if (segmentMatches(patternSegment, segment)) {
-          walk(child, depth + 1);
-        }
-      }
+      // Wildcard match
+      const wildcard = node.children.get('__wildcard__');
+      if (wildcard) walk(wildcard, depth + 1);
     };
 
     walk(this.root, 0);
@@ -1121,422 +605,187 @@ class TopicTrie<T> {
   }
 
   /**
-   * Remove all values matching a predicate and prune empty child branches.
+   * Remove all values matching a predicate.
    */
   remove(predicate: (value: T) => boolean): void {
-    const clean = (node: TrieNode<T>): boolean => {
+    const clean = (node: TrieNode<T>) => {
       if (node.values) {
         node.values = node.values.filter(v => !predicate(v));
-        if (node.values.length === 0) node.values = undefined;
       }
-
-      for (const [segment, child] of node.exactChildren.entries()) {
-        if (clean(child)) {
-          node.exactChildren.delete(segment);
-        }
+      for (const child of node.children.values()) {
+        clean(child);
       }
-      for (const [segment, child] of node.globChildren.entries()) {
-        if (clean(child)) {
-          node.globChildren.delete(segment);
-        }
-      }
-
-      return !node.values && node.exactChildren.size === 0 && node.globChildren.size === 0;
     };
-
     clean(this.root);
   }
 }
 
-function segmentMatches(pattern: string, segment: string): boolean {
-  if (pattern === segment) return true;
-  if (!pattern.includes('*')) return false;
-
-  // Segment-local glob: '*' matches any characters except '/'. Because callers
-  // split on '/', the segment input never contains '/'. Escape other regex chars.
-  const regex = new RegExp(
-    '^' + pattern.split('*').map(escapeRegex).join('[^/]*') + '$',
-    'i',
-  );
-  return regex.test(segment);
-}
-
-function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
 class TrieNode<T> {
-  exactChildren: Map<string, TrieNode<T>> = new Map();
-  globChildren: Map<string, TrieNode<T>> = new Map();
+  children: Map<string, TrieNode<T>> = new Map();
   values?: T[];
-}
-```
-
-### Helper: `isReceivingStatus`
-
-Determines whether a node execution should remain in the subscription index.
-This is intentionally different from `TERMINAL_NODE_EXECUTION_STATUSES` in
-`node-execution-manager.ts`, which includes `idle`. For the event bus, `idle`
-nodes MUST stay subscribed because:
-
-1. The agent session still exists and can be woken via `injectMessage`.
-2. The `deliveryMode: 'defer'` mechanism handles idle sessions natively.
-3. Removing idle nodes from the subscription index would prevent wake-on-idle
-   delivery — the core use case for the event bus.
-
-```typescript
-import type { NodeExecutionStatus } from '@neokai/shared';
-
-/**
- * States where the node should be excluded from the subscription index.
- * Only `cancelled` is excluded — the node has been permanently stopped.
- *
- * States that remain subscribed:
- * - `pending`       — no session yet, events queued for first turn
- * - `in_progress`   — live session, events injected immediately
- * - `idle`          — session exists but finished a turn; events wake it
- * - `waiting_rebind` — session paused for tool recovery; events queued
- * - `blocked`       — session exists but waiting for human; events queued
- */
-const NON_RECEIVING_STATES: ReadonlySet<NodeExecutionStatus> = new Set([
-  'cancelled',
-]);
-
-function isReceivingStatus(status: NodeExecutionStatus): boolean {
-  return !NON_RECEIVING_STATES.has(status);
 }
 ```
 
 **Complexity**:
 - Insert: O(k) where k = segment count (~4-5)
-- Lookup: Effectively O(2^k × m) in the common case — walks exact + matching glob branches at each level, collects m total matching subscriptions from leaves. Since k is bounded (4–5) and per-agent interest count is capped, glob branching stays small.
+- Lookup: O(k) — walks trie by segment, collects from exact + wildcard at each level
 - Memory: O(n × k) where n = number of subscriptions
+
+This is O(1) relative to the number of subscriptions — each lookup traverses at most 2^k paths (2 per level: exact + wildcard), and k is small and constant.
 
 ## 7. Wiring the GitHub Adapter
 
-### Target architecture
-
-The GitHub integration is extracted into a first-class event adapter. It no longer depends on `SpaceGitHubService.ingest()`, `space.githubEvent.routed`, or Task Agent notification delivery.
-
-```
-GitHub webhook / polling
-    → GitHubEventAdapter
-        → verify signature / fetch API pages
-        → normalize raw GitHub payload
-        → construct topic + dedupeKey
-        → EventBus.publish(ExternalEvent)
-            → ExternalEventStore.store() + retry-aware dedup
-            → EventTaskResolver.enrich()   // PR → SpaceTask when possible
-            → DaemonHub.emit('space.externalEvent.published', { event })
-                → EventRouter.deliverToSubscription()
-                    → sessionFactory.injectMessage(..., { deliveryMode: 'defer' })
-```
-
-There is no intermediate `space.githubEvent.routed` payload contract. The adapter publishes the full normalized event directly to the bus, and the bus owns task enrichment and delivery state.
-
 ### Changes to existing code
 
-**Extract source-specific GitHub code from `SpaceGitHubService`:**
+**Minimal.** The adapter hooks into the existing `SpaceGitHubService` via DaemonHub subscription:
 
-- Move webhook normalization (`normalizeSpaceGitHubWebhook`) into `github-adapter.ts`.
-- Move polling normalization (`normalizePollingRow`) into `github-adapter.ts`.
-- Move watched-repo configuration access into `GitHubEventAdapterRepository` or keep the existing `space_github_watched_repos` table behind that repository.
-- Move `space.github.watchRepo`, `space.github.listWatchedRepos`, and `space.github.pollOnce` registration behind `RpcEventAdapter.registerRpcHandlers(...)`.
-- Register `/webhook/github/space` through the adapter route registry rather than hard-coding a direct call to `spaceGitHubService.handleWebhook(req)` in `app.ts`.
+```
+SpaceGitHubService.handleWebhook()
+    → normalizeSpaceGitHubWebhook()
+    → ingest(spaceId, normalized)
+        → storeEvent() + dedupe
+        → SpacePrTaskResolver.resolve()
+        → appendTaskActivity()
+            → DaemonHub.emit('space.githubEvent.routed', { taskId, event })
+        → scheduleTaskNotification()
+            → injectTaskAgent(taskId, message)
+```
 
-**Do not extend `appendTaskActivity`:** the old plan proposed adding normalized fields to `space.githubEvent.routed`. That is no longer needed because the GitHub adapter publishes `ExternalEvent` directly and no longer treats `SpaceGitHubService` as an upstream source.
-
-**Deprecate direct Task Agent injection:** the old `scheduleTaskNotification()` / `flushTaskNotification()` path remains only as a compatibility shim during migration. New node-level delivery goes through `EventRouter`. Once workflows rely on `eventInterests`, the Task Agent relay can be removed.
-
-### GitHub adapter topic construction
-
-The GitHub adapter normalizes to GitHub event kinds (`issue_comment`, `pull_request_review`, `pull_request_review_comment`, `pull_request`) and maps them to bus topics:
-
-| GitHub normalized kind | `mapEventType(kind, action)` returns |
-|---|---|
-| `issue_comment` | `pull_request.comment_${action}` (PR comments only; created, edited, deleted) |
-| `pull_request_review` | `pull_request.review_${action}` (submitted, edited, dismissed) |
-| `pull_request_review_comment` | `pull_request.review_comment_${action}` (created, edited, deleted) |
-| `pull_request` | `pull_request.${action}` (opened, synchronize, closed, etc.) |
-
-These return values are the complete fourth path segment (`resource.action`). For V1 PR events the resource side is always `pull_request`; `comment_*`, `review_*`, and `review_comment_*` are action names, not nested resource segments. The adapter must not emit doubled resource names such as `pull_request.review.review_submitted`.
+The GitHub adapter subscribes to `space.githubEvent.routed` and converts it:
 
 ```typescript
-function mapEventType(kind: string, action: string): string | null {
-  switch (kind) {
-    case 'issue_comment': return `pull_request.comment_${action}`;
-    case 'pull_request_review': return `pull_request.review_${action}`;
-    case 'pull_request_review_comment': return `pull_request.review_comment_${action}`;
-    case 'pull_request': return `pull_request.${action}`;
-    default: return null; // Non-PR GitHub topics are future adapter scope.
+// No changes to SpaceGitHubService.
+// The adapter is a new subscriber:
+
+class GitHubEventAdapter implements EventAdapter {
+  async start(publisher: EventPublisher): Promise<void> {
+    this.daemonHub.on('space.githubEvent.routed', async (data) => {
+      const { event, taskId } = data;
+
+      // Construct topic from event
+      const topic = `github/${event.repo.split('/')[0]}/${event.repo.split('/')[1]}/${mapEventType(event.eventType)}.${mapAction(event.action)}`;
+
+      // Publish to bus
+      await publisher.publish({
+        id: crypto.randomUUID(),
+        topic,
+        occurredAt: Date.now(),
+        ingestedAt: Date.now(),
+        source: 'github',
+        prNumber: event.prNumber,
+        repoOwner: event.repo.split('/')[0],
+        repoName: event.repo.split('/')[1],
+        summary: event.summary,
+        externalUrl: event.externalUrl,
+        payload: event,
+        dedupeKey: `github:${event.repo}:${event.prNumber}:${event.eventType}:${event.externalUrl}`,
+      });
+    });
   }
 }
 ```
 
-### ExternalEvent construction
+### Event type mapping
 
-```typescript
-function toExternalEvent(spaceId: string, event: NormalizedGitHubEvent): ExternalEvent {
-  const repoOwner = event.repoOwner.toLowerCase();
-  const repoName = event.repoName.toLowerCase();
-  const resourceAction = mapEventType(event.eventType, event.action);
-  if (!resourceAction) throw new Error(`Unsupported GitHub event type: ${event.eventType}`);
+The `SpaceGitHubService` already normalizes to `SpaceGitHubEventKind` (`issue_comment`, `pull_request_review`, `pull_request_review_comment`, `pull_request`). We map these to bus topics:
 
-  return {
-    id: crypto.randomUUID(),
-    spaceId,
-    topic: `github/${repoOwner}/${repoName}/${resourceAction}`,
-    occurredAt: event.occurredAt,
-    ingestedAt: Date.now(),
-    source: 'github',
-    sourceEventId: event.deliveryId,
-    prNumber: event.prNumber,
-    repoOwner,
-    repoName,
-    summary: event.summary,
-    externalUrl: event.externalUrl,
-    payload: {
-      eventType: event.eventType,
-      action: event.action,
-      source: event.source,
-      prUrl: event.prUrl,
-      deliveryId: event.deliveryId,
-      externalId: event.externalId,
-      actor: event.actor,
-      body: event.body,
-      rawPayload: event.rawPayload,
-    },
-    dedupeKey: event.dedupeKey,
-  };
-}
-```
+| SpaceGitHubEventKind | Bus topic resource |
+|---|---|
+| `issue_comment` | `pull_request.comment_created` (PR comments only, already filtered) |
+| `pull_request_review` | `pull_request.review_submitted` |
+| `pull_request_review_comment` | `pull_request.review_comment_created` |
+| `pull_request` | `pull_request.{action}` (opened, synchronize, closed, etc.) |
 
-### Task-scoped resolution
+### Task-scoped resolution optimization
 
-For `task` scope, the adapter does not resolve a task. Instead, `EventTaskResolver` enriches PR events after bus dedup and before publication:
+For `task` scope, we already have the `taskId` from `space.githubEvent.routed`. The router can short-circuit:
 
-1. If the event already has a trusted `routedTaskId`, use it directly.
-2. For GitHub PR events, resolve using normalized `prUrl`, `repoOwner/repoName`, `prNumber`, and optional `branch`.
-3. Store the result in `event.routedTaskId` and `event.payload.taskResolution` for diagnostics.
-4. EventRouter `task` scope checks `event.routedTaskId === sub.taskId` and does not re-run broad task scans during delivery.
+1. Look up which node executions in that task's run have `eventInterests` matching the event.
+2. Only check scope for those nodes — skip the full trie walk for nodes that don't care about this event type.
 
-This removes duplicate PR→task resolution from the adapter and EventRouter hot paths while preserving the existing auto-scoping behavior.
+This optimization turns the common case (one coder node interested in review comments) into a direct map lookup: `taskId → workflowRunId → nodeExecutions → filter by interest topic match`.
 
 ## 8. Migration Path
 
 ### DB schema changes
 
-V1 needs one core event-store table plus workflow type additions:
-
-1. **Core bus event store** (`space_external_events`): persistent source-level event lifecycle for retry-aware dedup.
-
-   ```sql
-   CREATE TABLE space_external_events (
-     id TEXT PRIMARY KEY,
-     space_id TEXT NOT NULL,
-     source TEXT NOT NULL,
-     topic TEXT NOT NULL,
-     dedupe_key TEXT NOT NULL,
-     occurred_at INTEGER NOT NULL,
-     ingested_at INTEGER NOT NULL,
-     payload_json TEXT NOT NULL,
-     routed_task_id TEXT,
-     state TEXT NOT NULL DEFAULT 'published',
-     created_at INTEGER NOT NULL,
-     updated_at INTEGER NOT NULL,
-     UNIQUE(space_id, source, dedupe_key)
-   );
-   ```
-
-   `state` values are `published`, `routed`, `delivered`, `delivery_failed`, `ignored`, and `ambiguous`. Duplicate handling depends on state: terminal states short-circuit; retryable states can re-emit.
-
-2. **Adapter-owned GitHub configuration**: reuse or migrate the existing `space_github_watched_repos` table behind `GitHubEventAdapterRepository`. This table remains source-specific and should not be queried by EventRouter except through cache invalidation hooks for repo-scoped matching.
-
-3. **No node-execution schema change**: event interests are stored as part of the workflow definition JSON in `space_workflows.nodes[].agents[].eventInterests`.
+None required for V1. Event interests are stored as part of the workflow definition JSON in `space_workflows.nodes[].agents[].eventInterests`. The existing JSON serialization of workflow nodes already supports arbitrary fields.
 
 ### Type changes
 
 1. Add `EventInterest` interface to `packages/shared/src/types/space.ts`.
 2. Add `eventInterests?: EventInterest[]` to `WorkflowNodeAgent`.
-3. Add `ExternalEvent`, `EventAdapter`, `HttpEventAdapter`, `RpcEventAdapter`, and `EventPublisher` types under `packages/daemon/src/lib/space/runtime/event-bus/`.
-4. Add validation in the workflow create/update path (Zod schema or manual validation):
-   - `topic` must pass `validateGlobPattern()` (non-empty, exactly 4 segments, no `..` segments, no double slashes, valid characters including segment-local `*`).
+3. Add validation in the workflow create/update path (Zod schema or manual validation):
+   - `topic` must be a valid glob pattern (non-empty, no `..` segments).
    - `scope` must be one of `'task' | 'repo' | 'global'`.
    - Max 10 interests per agent slot (prevent abuse).
-   - `validateGlobPattern()` is the single source of truth — called at workflow create/update and again at trie insertion time as a safety net.
 
 ### New files
 
 ```
 packages/daemon/src/lib/space/runtime/event-bus/
-  ├── types.ts                 # ExternalEvent, EventAdapter, EventPublisher interfaces
-  ├── event-bus.ts             # EventBus singleton (wraps TypedHub)
-  ├── event-store.ts           # Persistent retry-aware source-level dedup
-  ├── event-task-resolver.ts   # Core event -> SpaceTask enrichment
-  ├── topic-trie.ts            # TopicTrie<T> implementation
-  ├── topic-validator.ts       # validateGlobPattern() helper
-  ├── event-router.ts          # EventRouter — subscribes to bus, matches, delivers
-  └── index.ts                 # Public exports
-
-packages/daemon/src/lib/space/runtime/event-adapters/github/
-  ├── github-adapter.ts        # GitHubEventAdapter — webhook/polling -> EventBus
-  ├── github-normalizer.ts     # GitHub webhook/polling normalization helpers
-  ├── github-repository.ts     # watched repo config + adapter diagnostics
-  └── index.ts
+  ├── types.ts              # ExternalEvent, EventAdapter, EventPublisher interfaces
+  ├── event-bus.ts           # EventBus singleton (wraps TypedHub)
+  ├── topic-trie.ts          # TopicTrie<T> implementation
+  ├── event-router.ts        # EventRouter — subscribes to bus, matches, delivers
+  ├── github-adapter.ts      # GitHubEventAdapter — bridges SpaceGitHubService → EventBus
+  └── index.ts               # Public exports
 ```
 
-### Topic pattern validation
-
-```typescript
-// topic-validator.ts
-
-/**
- * Validate a glob pattern for event subscriptions.
- * Rejects patterns that could corrupt the trie or match unintended topics.
- * Called at workflow create/update time and again at trie insertion time.
- *
- * Requires exactly 4 segments because all v1 event topics have the format
- * `{source}/{scope1}/{scope2}/{resource}.{action}`. For GitHub, scope1/scope2
- * are owner/repo; for future non-repo adapters, they are source-specific scope
- * segments such as workspace/channel.
- * Patterns like `github/*` (too shallow) or `github/*/*/pull_request/review_*`
- * (too deep) would pass validation but never match any event, creating silent
- * misconfigurations.
- */
-export function validateGlobPattern(pattern: string): { valid: boolean; reason?: string } {
-  if (!pattern || pattern.trim().length === 0) {
-    return { valid: false, reason: 'Topic pattern must not be empty' };
-  }
-
-  const segments = pattern.split('/');
-
-  if (segments.length !== 4) {
-    return {
-      valid: false,
-      reason: `Topic pattern must have exactly 4 segments (source/scope1/scope2/resource.action); got ${segments.length}. Example: 'github/*/*/pull_request.review_submitted'`,
-    };
-  }
-
-  for (const segment of segments) {
-    if (segment === '') {
-      return { valid: false, reason: 'Topic pattern must not contain empty segments (double slashes)' };
-    }
-    if (segment === '..') {
-      return { valid: false, reason: 'Topic pattern must not contain ".." segments' };
-    }
-    if (segment === '**') {
-      return { valid: false, reason: 'Multi-segment "**" wildcard is not supported in v1' };
-    }
-    if (!/^[a-zA-Z0-9_.*-]+$/.test(segment)) {
-      return {
-        valid: false,
-        reason: `Segment "${segment}" contains invalid characters. Use alphanumeric, dash, underscore, dot, or segment-local "*" wildcard.`,
-      };
-
-    }
-  }
-
-  const resourceAction = segments[3];
-  const dotIndex = resourceAction.indexOf('.');
-  if (dotIndex <= 0 || dotIndex === resourceAction.length - 1) {
-    return {
-      valid: false,
-      reason: `Topic pattern fourth segment must be resource.action; got "${resourceAction}". Example: 'pull_request.review_submitted'`,
-    };
-  }
-
-  // Enforce exactly one dot in the 4th segment (resource.action pair).
-  // Patterns like `pull_request.review.submitted` (two dots) are invalid
-  // because V1 topics use exactly one dot to separate resource from action.
-  const dotCount = (resourceAction.match(/\./g) || []).length;
-  if (dotCount !== 1) {
-    return {
-      valid: false,
-      reason: `Topic pattern fourth segment must contain exactly one dot (resource.action), got ${dotCount} dots in "${resourceAction}". Example: 'pull_request.review_submitted'`,
-    };
-  }
-
-  return { valid: true };
-}
-```
-
-### Wiring into SpaceRuntime and daemon startup
+### Wiring into SpaceRuntime
 
 ```typescript
 // In SpaceRuntimeConfig, add:
 interface SpaceRuntimeConfig {
   // ... existing fields ...
-  eventRouter?: EventRouter;
+  eventBus?: EventBus;  // Optional — created internally if not provided
 }
 
 // In SpaceRuntime.executeTick(), after node executions are resolved:
-// This does a DIFF-BASED update of trie subscriptions. Safe to call on every tick.
 if (this.eventRouter) {
   this.eventRouter.registerRunInterests(
     spaceId,
     workflowRunId,
-    taskId, // current task whose tick/session activation is being processed
     workflow,
     activeNodeExecutions,
   );
 }
 
-// In the workflow run status transition handler:
-// Called ONLY on truly terminal transitions (done, cancelled) — NOT on blocked.
-if (newStatus === 'done' || newStatus === 'cancelled') {
-  this.eventRouter.clearRunInterests(workflowRunId);
-}
-
-// In daemon startup:
-const externalEventStore = new ExternalEventStore(db);
-const eventTaskResolver = new EventTaskResolver(db);
-const eventBus = new EventBus(daemonHub, externalEventStore, eventTaskResolver);
+// In daemon startup (e.g. in SpaceRuntimeService or init function):
+const eventBus = new EventBus(daemonHub);
 const eventRouter = new EventRouter(eventBus, ...dependencies);
+const githubAdapter = new GitHubEventAdapter(daemonHub);
 
-const adapters: EventAdapter[] = [
-  new GitHubEventAdapter(new GitHubEventAdapterRepository(db), process.env.GITHUB_TOKEN),
-];
-
-for (const adapter of adapters) {
-  if ('routes' in adapter) routeRegistry.register(adapter.routes, eventBus);
-  if ('registerRpcHandlers' in adapter) adapter.registerRpcHandlers(messageHub, eventBus);
-  await adapter.start(eventBus);
-}
+await githubAdapter.start(eventBus);
 ```
-
-Repo-scoped matching still needs watched-repo cache invalidation. Instead of coupling the RPC handler to `EventRouter`, the GitHub adapter emits a source-config-changed event (or invokes a narrow callback) after watch/unwatch changes; the EventRouter invalidates only the affected space.
 
 ### Phased rollout
 
-**Phase 1 (target MVP):**
+**Phase 1 (MVP — this PR):**
 - Add `EventInterest` type to `WorkflowNodeAgent`.
-- Implement `EventBus`, `ExternalEventStore`, `EventTaskResolver`, `TopicTrie`, and `EventRouter`.
-- Extract `GitHubEventAdapter` as the primary GitHub event source (webhook + polling + normalization).
-- Route GitHub PR events directly through EventBus to node sessions with `task` scope.
-- Keep `SpaceGitHubService` only as a compatibility path while parity is verified.
+- Implement `EventBus`, `TopicTrie`, `EventRouter`, `GitHubEventAdapter`.
+- Wire GitHub adapter to existing `space.githubEvent.routed` events.
+- Deliver events to coder nodes with `task` scope.
 - No UI changes needed — event interests are authored in workflow JSON.
 
-**Phase 2 (compatibility removal):**
-- Remove direct Task Agent notification delivery from `SpaceGitHubService` (`scheduleTaskNotification` / `flushTaskNotification`).
-- Migrate remaining `space.github.*` RPC handling into `GitHubEventAdapter`.
-- Remove dependence on `space.githubEvent.routed` for external event delivery.
-- Add persistent per-node delivery queue if restart-safe pending-node delivery is required.
+**Phase 2 (follow-up):**
+- Add `eventInterests` editor to the workflow visual editor UI.
+- Add event delivery status to the task activity panel.
+- Add digest/coalescing for high-frequency events.
+- Add metrics: events matched, events delivered, delivery latency.
 
 **Phase 3 (future extensibility):**
 - Slack adapter: subscribe to Slack Events API, normalize to `ExternalEvent`, publish.
-- CI adapter: subscribe to GitHub Check Suite or other CI events, normalize, publish.
+- CI adapter: subscribe to GitHub Check Suite events, normalize, publish.
 - Custom adapter API: allow Space operators to register custom adapters via config.
 
 ## 9. Relationship to Existing Systems
 
 | Existing system | Relationship |
 |---|---|
-| **DaemonHub / TypedHub** | `EventBus` is a TypedHub participant on the shared `InProcessTransportBus`. It publishes all external events through the fixed valid method `space.externalEvent.published`; slash-delimited external topics stay in `ExternalEvent.topic` and are matched by the router trie. |
-| **GitHubService** (Room pipeline) | Unchanged for Room compatibility. It is not the source for Space workflow-node events. |
-| **SpaceGitHubService** (legacy Space pipeline) | Deprecated compatibility path. Its source-specific normalization/polling logic is extracted into `GitHubEventAdapter`; task resolution and delivery move to EventBus/EventRouter. The bus must not depend on `space.githubEvent.routed`. |
-| **GitHubEventAdapter** | Source extension that owns GitHub webhook verification, polling, normalization, watched-repo configuration, and direct publication to EventBus. It does not query Space tasks or inject sessions. |
-| **ExternalEventStore** | Core bus persistence and retry-aware source-level dedup across adapters. Replaces GitHub-specific unconditional duplicate short-circuiting for new delivery. |
-| **EventTaskResolver** | Core enrichment service that maps events to Space tasks where possible (e.g. GitHub PR → task). Keeps task/gate/workflow schema access out of adapters. |
+| **DaemonHub / TypedHub** | `EventBus` is a TypedHub participant on the shared `InProcessTransportBus`. The bus uses the same async-everywhere, session-scoped routing that DaemonHub uses. |
+| **GitHubService** (Room pipeline) | Unchanged. Continues routing to Rooms. The event bus is additive. |
+| **SpaceGitHubService** (Space pipeline) | Unchanged. Continues injecting into Task Agent. The GitHub adapter subscribes to `space.githubEvent.routed` as an additional consumer. |
 | **SessionNotificationSink** | The event bus uses the same `sessionFactory.injectMessage()` with `deliveryMode: 'defer'` pattern. |
 | **AgentMessageRouter** | Not used for event delivery. Events are injected directly via `sessionFactory.injectMessage()`, not via the agent-to-agent messaging channel. Events are not agent-originated messages — they're system-injected context. |
 | **ChannelRouter** | Not involved. Event delivery is not a workflow channel transition. It's an injection into an existing session, not an activation trigger. |
@@ -1551,7 +800,7 @@ TypedHub provides:
 - Already wired into the daemon's lifecycle.
 - No new dependency.
 
-Using TypedHub as the backing transport means the EventBus inherits all of these properties for free. The bus does **not** use external topic strings as TypedHub method names: raw topics contain `/` and glob `*`, which violate MessageHub method validation. Instead, EventBus publishes every external event under the fixed valid method `space.externalEvent.published` and places the external topic in `ExternalEvent.topic` for trie matching.
+Using TypedHub as the backing transport means the EventBus inherits all of these properties for free.
 
 ### Why not route through AgentMessageRouter?
 
@@ -1570,15 +819,11 @@ Direct injection via `sessionFactory.injectMessage()` is simpler and semanticall
 
 ### Why not extend SpaceGitHubService directly?
 
-`SpaceGitHubService` currently mixes four responsibilities in one class: GitHub source ingestion, source-level dedup, PR-to-task resolution, and Task Agent session injection. Extending it would preserve the same coupling and keep the event bus downstream of an already-routed delivery pipeline.
-
-The target architecture splits those responsibilities:
-- `GitHubEventAdapter` owns only GitHub-specific webhook/polling/normalization.
-- `ExternalEventStore` owns cross-source event lifecycle and retry-aware dedup.
-- `EventTaskResolver` owns Space task enrichment.
-- `EventRouter` owns node subscription matching and session delivery.
-
-This makes GitHub one adapter among many instead of a special core daemon path. Future adapters (Slack, CI, etc.) publish the same `ExternalEvent` shape and reuse the same dedup, task enrichment, and delivery machinery.
+The adapter pattern separates concerns:
+- `SpaceGitHubService` owns GitHub-specific normalization, dedup, and PR resolution.
+- The event bus is source-agnostic (GitHub, Slack, CI, etc.).
+- The adapter bridges the two without coupling.
+- Future adapters (Slack, CI) don't touch `SpaceGitHubService`.
 
 ### Why `deliveryMode: 'defer'` for event injection?
 
@@ -1595,17 +840,12 @@ This is exactly the behavior we want for external events.
 
 1. **TopicTrie**: Insert patterns, verify lookup returns correct values for exact and wildcard matches.
 2. **EventRouter**: Given subscriptions and events, verify scope filtering, dedup, and delivery.
-3. **ExternalEventStore**: Verify terminal duplicates are short-circuited and retryable duplicates are re-emitted.
-4. **EventTaskResolver**: Given GitHub PR metadata, verify correct task enrichment and ambiguous/unknown states.
-5. **GitHubEventAdapter**: Given webhook and polling payloads, verify signature handling, topic construction, dedupe keys, and `ExternalEvent` construction without querying Space tasks.
-6. **Scope resolution**: Test `task` scope with enriched `routedTaskId` and various task/PR associations.
+3. **GitHubEventAdapter**: Given a `space.githubEvent.routed` event, verify correct `ExternalEvent` construction.
+4. **Scope resolution**: Test `task` scope with various task/PR associations.
 
 ### Integration tests
 
-1. **End-to-end webhook flow**: POST a GitHub webhook payload to the adapter route with a `review_submitted` action for PR #42 on repo `lsm/neokai`. Verify the adapter publishes `github/lsm/neokai/pull_request.review_submitted`, `EventTaskResolver` enriches it with the matching task, and the coder node's `task`-scoped subscription receives an injected message.
-
-2. **Dedup across two events with same dedupeKey**: Publish the same GitHub PR review through webhook and polling (identical `dedupeKey`). Verify source-level bus dedup does not create two independent events, and per-subscription delivery dedup calls `injectMessage` exactly once for each interested node. Also verify retryable duplicate states re-emit after a simulated injection failure.
-
-3. **Wake-on-idle delivery**: Set a node execution's session to `idle` state (agent finished its turn). Emit a matching event. Verify `injectMessage` is called with `deliveryMode: 'defer'` and the session processes the message on its next turn (via the existing defer replay mechanism).
-
-4. **Pending node queuing**: Emit an event for a node whose execution is `pending` (no session yet). Verify the event is stored in the in-memory pending queue. Then simulate `TaskAgentManager` creating the session. Verify the queued event is flushed and injected into the new session as part of the first turn.
+1. End-to-end: webhook → normalize → ingest → bus → router → session injection.
+2. Dedup: same event delivered twice, verify only one injection.
+3. Wake-on-idle: node idle → event arrives → session receives message.
+4. Pending node: event arrives for pending node → session created → event delivered.

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -1488,27 +1488,31 @@ class ExternalEventRouter {
     }
   }
 
+  private makeEventRetryKey(event: ExternalEvent, matched: Subscription[]): string {
+    return JSON.stringify([
+      event.id,
+      [...new Set(matched.map((sub) => sub.workflowRunId))].sort(),
+      'prepare',
+    ]);
+  }
+
   /**
    * Schedule an event-level retry for failures before expected delivery rows exist
    * (for example transient watched-repo lookup or delivery-row insert failures).
    * This reruns full matching/preparation instead of allowing partial delivery to
    * mark the source event terminal while an unregistered subscription missed it.
    * handleEventForSubscriptions returns false when preparation failed and another
-   * retry was scheduled. In that case the retry count/state must be preserved so
-   * persistent preparation failures continue toward MAX_RETRIES. Counts are cleared
-   * only after a prepared retry pass, so later independent preparation errors get a
-   * fresh budget and this map does not leak state across retryable re-emissions.
+   * retry was scheduled. If the retry key is unchanged, the count/state is preserved
+   * so persistent preparation failures continue toward MAX_RETRIES. If current
+   * matching changed the retry key, the old key is cleared before returning because
+   * the newly scheduled retry owns the updated state.
    */
   private scheduleEventRetry(
     event: ExternalEvent,
     matched: Subscription[],
     options: { retryCountOverride?: number } = {},
   ): void {
-    const retryKey = JSON.stringify([
-      event.id,
-      [...new Set(matched.map((sub) => sub.workflowRunId))].sort(),
-      'prepare',
-    ]);
+    const retryKey = this.makeEventRetryKey(event, matched);
     const retries = options.retryCountOverride ?? ((this.eventRetryCounts.get(retryKey) ?? 0) + 1);
     if (retries > ExternalEventRouter.MAX_RETRIES) {
       log.warn('ExternalEventRouter: max preparation retries exceeded; marking event failed', {
@@ -1547,8 +1551,14 @@ class ExternalEventRouter {
         .then((prepared) => {
           if (!prepared) {
             // handleEventForSubscriptions scheduled the next preparation retry.
-            // Preserve count/state so persistent preparation failures continue
-            // toward MAX_RETRIES instead of restarting from attempt 1 forever.
+            // If matching changed while this timer was waiting, that retry is now
+            // stored under a different key. Clear this superseded key so stale
+            // counts/state do not leak or later exhaust a reappearing key early.
+            const nextRetryKey = this.makeEventRetryKey(retryState.event, currentMatched);
+            if (nextRetryKey !== retryKey) {
+              this.eventRetryCounts.delete(retryKey);
+              this.eventRetryState.delete(retryKey);
+            }
             return;
           }
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -13,31 +13,72 @@ Two parallel event pipelines exist today, neither of which routes to individual 
 1. **Room pipeline** (`GitHubService`): Webhook → normalize → filter → security → route → `deliverToRoom()` → DaemonHub `room.message`. Routes to **Rooms**, not Spaces.
 2. **Space pipeline** (`SpaceGitHubService`): Webhook → normalize → dedupe → `SpacePrTaskResolver.resolve()` → `injectTaskAgent()`. Routes events to the **Task Agent session** (the orchestrator), which must then manually relay to the coder node.
 
-The Space pipeline proves the primitives exist, but it is not the right extension boundary: GitHub-specific normalization, dedup, PR-to-task resolution, and Task Agent injection are bundled together in `SpaceGitHubService`. The target design extracts source ingestion into adapters and moves dedup, task enrichment, and node delivery into the core event bus.
+The Space pipeline proves the primitives exist, but it is not the right extension boundary: GitHub-specific normalization, dedup, PR-to-task resolution, and Task Agent injection are bundled together in `SpaceGitHubService`. The target design extracts source ingestion into extensions and moves dedup, task enrichment, and node delivery into reusable core external-event services.
 
 ## Design Overview
 
+This design treats GitHub as the first external-event **extension** rather than a special-case Space service. The extension owns source-specific concerns — GitHub auth, webhook verification, polling, raw payload normalization, and source configuration. Core Space infrastructure owns durable external-event lifecycle, task enrichment, subscription matching, retry behavior, and delivery to workflow nodes.
+
+The target flow aligns with the broader internal event/command/query refactor:
+
+```text
+GitHubEventExtension
+  ├─ enabled globally? enabled for this space?
+  ├─ verifies webhook / polls GitHub
+  ├─ normalizes GitHub payload → ExternalEvent
+  └─ publishes to ExternalEventService
+
+ExternalEventService
+  ├─ validates topic/source contract
+  ├─ dedupes by (spaceId, source, dedupeKey)
+  ├─ persists source event lifecycle
+  ├─ enriches via ExternalEventTaskResolver
+  └─ publishes InternalEventBus fact: externalEvent.published
+
+ExternalEventRouter
+  ├─ subscribes to externalEvent.published
+  ├─ matches active workflow-node eventInterests
+  ├─ records per-subscription delivery lifecycle
+  └─ dispatches InternalCommandBus command: agent.message.inject
+
+Agent session
+  └─ receives structured external-event message
 ```
-External Event Sources (GitHub webhook, polling, future: Slack, CI)
-       │
-       ▼
-┌─────────────────────┐
-│  EventAdapter       │  Verify → normalize → publish to EventBus
-│  (extension/source) │
-└────────┬────────────┘
-         │ publish(event) → hub.emit('space.externalEvent.published', { sessionId: 'global', event })
-         ▼
-┌─────────────────────┐
-│  EventBus           │  Persistent dedup + task enrichment, backed by TypedHub.
-│  (singleton)        │  Fixed TypedHub-safe method; external topic is payload data.
-└────────┬────────────┘
-         │
-         ▼
-┌─────────────────────┐
-│  EventRouter        │  Subscribes to bus. Matches events to active
-│  (per-runtime)      │  node interests and injects directly into sessions.
-└─────────────────────┘
+
+The design should make adding a third-party source boring:
+
+```text
+SlackEventExtension / JiraEventExtension / CIEventExtension
+  → normalize source payloads into ExternalEvent
+  → publish to ExternalEventService
+  → reuse the same store, task resolver, router, retry, and command delivery path
 ```
+
+No third-party extension should inspect workflow node state, resolve Space tasks directly, or inject messages into agent sessions.
+
+### Extension enablement and configuration
+
+External event sources should be configurable at two levels:
+
+1. **Global extension configuration** — installed/enabled daemon-wide, with shared secrets or app credentials.
+2. **Space extension configuration** — enabled/disabled per space, with source-specific routing scope such as watched GitHub repositories, Slack channels, Jira projects, or CI pipelines.
+
+GitHub is the reference implementation:
+
+```text
+Global GitHub config
+  ├─ extension enabled/disabled
+  ├─ GitHub App / token / webhook secret configuration
+  └─ allowed capabilities: webhooks, polling, repo watching
+
+Per-space GitHub config
+  ├─ extension enabled/disabled for the space
+  ├─ watched repositories
+  ├─ optional event filters
+  └─ optional polling/webhook preferences
+```
+
+The extension manager should prevent disabled sources from accepting webhooks, scheduling polling, or publishing events for disabled spaces. Existing source-specific tables such as `space_github_watched_repos` can remain as GitHub extension configuration during migration, but the cross-source event lifecycle belongs to `ExternalEventStore`.
 
 ## 1. Namespaced Event Topics
 
@@ -50,8 +91,8 @@ github/lsm/neokai/pull_request.comment_created
 github/lsm/neokai/pull_request.synchronize
 github/lsm/neokai/pull_request.closed
 # Not emitted in v1 — mapEventType only handles pull_request variants;
-# issues.* requires a future adapter extension: github/lsm/neokai/issues.opened
-# Future CI adapter (Phase 3): github/lsm/neokai/check_suite.completed
+# issues.* requires a future GitHub extension expansion: github/lsm/neokai/issues.opened
+# Future CI extension (Phase 3): github/lsm/neokai/check_suite.completed
 github/lsm/neokai/pull_request.*            ← wildcard: all PR events for this repo
 github/lsm/neokai/*.*                       ← wildcard: all events for this repo
 github/lsm/neokai/pull_request.review_*     ← prefix wildcard: all review events
@@ -59,9 +100,9 @@ github/lsm/neokai/pull_request.review_*     ← prefix wildcard: all review even
 
 ### Topic construction rules
 
-1. `source` — adapter identifier (`github`, `slack`, `ci`). Lowercase, no slashes.
+1. `source` — extension/source identifier (`github`, `slack`, `ci`). Lowercase, no slashes.
 2. `owner/repo` — from the event's repository context. Both lowercase for case-insensitive matching.
-3. `resource.action` — the fourth path segment is always one dotted pair. For V1 GitHub PR events, `resource` is `pull_request`; review/comment variants are encoded in `action` (`review_submitted`, `comment_created`, `review_comment_created`) so examples like `pull_request.review_submitted` remain canonical. CI resources such as `check_suite` are Phase 3/future adapter scope.
+3. `resource.action` — the fourth path segment is always one dotted pair. For V1 GitHub PR events, `resource` is `pull_request`; review/comment variants are encoded in `action` (`review_submitted`, `comment_created`, `review_comment_created`) so examples like `pull_request.review_submitted` remain canonical. CI resources such as `check_suite` are Phase 3/future extension scope.
 4. `action` — the specific action: `opened`, `review_submitted`, `comment_created`, `completed`, etc.
 5. All v1 topics use exactly 4 path segments. For resources without a natural `owner/repo` (e.g. a future Slack message), use a source-specific scope pair to preserve the same depth: `{source}/{workspace}/{channel}/{resource}.{action}` (for example, `slack/acme/eng/messages.created`). Adapters that do not have both scope levels should use a reserved placeholder segment such as `_` rather than emitting 3-segment topics.
 
@@ -180,10 +221,10 @@ export interface WorkflowNodeAgent {
 
 ### Scoping details
 
-**`task` scope** is the critical innovation. Task association is resolved before delivery by the core `EventTaskResolver`:
+**`task` scope** is the critical innovation. Task association is resolved before delivery by the core `ExternalEventTaskResolver`:
 
 1. The task's `SpaceTask` record has `workflowRunId` and (via workflow artifacts or gate data) an associated PR number, PR URL, or branch name.
-2. `EventTaskResolver` enriches matching events with `routedTaskId` using source-normalized metadata such as GitHub PR URL/number/branch.
+2. `ExternalEventTaskResolver` enriches matching events with `routedTaskId` using source-normalized metadata such as GitHub PR URL/number/branch.
 3. For a `task`-scoped subscription, the router checks whether `event.routedTaskId === sub.taskId`.
 4. The node author never specifies a PR number — it's implicit from the task context.
 
@@ -199,30 +240,32 @@ When an event arrives, the router:
 2. For each active node execution with `eventInterests`:
    a. Compiles the interest's `topic` glob against the event's topic.
    b. If matched, checks scope:
-      - `task`: checks the `EventTaskResolver` enrichment (`event.routedTaskId`) against this subscription's task.
+      - `task`: checks the `ExternalEventTaskResolver` enrichment (`event.routedTaskId`) against this subscription's task.
       - `repo`: does event's repo match any watched repo in the node's space?
       - `global`: pass.
    c. If scope check passes, the event is queued for delivery to this node's agent session.
 
-## 3. EventIngestion Adapter Interface
+## 3. External Event Extension Interface
 
-External sources are modeled as **extensions**. An adapter owns the source-specific work:
+External sources are modeled as **extensions**. An extension owns the source-specific work:
 
 1. Receive events from its source (webhook, polling, streaming API, etc.).
-2. Verify source-specific authenticity (e.g. GitHub HMAC signatures).
-3. Normalize raw source payloads into `ExternalEvent`.
-4. Publish directly to the EventBus.
+2. Check global and per-space enablement before accepting or polling events.
+3. Verify source-specific authenticity (e.g. GitHub HMAC signatures).
+4. Load source-specific configuration (for GitHub: watched repositories and webhook/polling settings).
+5. Normalize raw source payloads into `ExternalEvent`.
+6. Publish directly to `ExternalEventService`.
 
-Adapters do **not** resolve Space tasks, inspect workflow nodes, or inject into agent sessions. Those are core daemon responsibilities handled by bus-level services and the `EventRouter`. This keeps GitHub, Slack, CI, and future integrations pluggable without adding source-specific paths to the workflow runtime.
+Extensions do **not** resolve Space tasks, inspect workflow nodes, or inject into agent sessions. Those are core daemon responsibilities handled by `ExternalEventService`, `ExternalEventTaskResolver`, `ExternalEventRouter`, and `InternalCommandBus`. This keeps GitHub, Slack, Jira, CI, and future integrations pluggable without adding source-specific paths to the workflow runtime.
 
 ```typescript
-// packages/daemon/src/lib/space/runtime/event-bus/types.ts
+// packages/daemon/src/lib/external-events/types.ts
 
 /**
  * A normalized external event on the bus.
  */
 export interface ExternalEvent {
-  /** Unique event ID (UUID) assigned by the adapter for this bus publication. */
+  /** Unique event ID (UUID) assigned by the extension for this publication. */
   id: string;
   /** Space this event belongs to. Required to prevent cross-space delivery. */
   spaceId: string;
@@ -230,9 +273,9 @@ export interface ExternalEvent {
   topic: string;
   /** Timestamp when the event occurred at the source (epoch ms). */
   occurredAt: number;
-  /** Timestamp when the event was accepted by the adapter (epoch ms). */
+  /** Timestamp when the event was accepted by the extension (epoch ms). */
   ingestedAt: number;
-  /** Source adapter identifier. */
+  /** Source extension identifier. */
   source: string;
   /** Optional source-native event id/delivery id for diagnostics. */
   sourceEventId?: string;
@@ -248,7 +291,7 @@ export interface ExternalEvent {
   summary: string;
   /** External URL (e.g. GitHub PR link). */
   externalUrl?: string;
-  /** Structured source payload — adapter-specific, not constrained. */
+  /** Structured source payload — extension-specific, not constrained. */
   payload: Record<string, unknown>;
   /**
    * Stable source-level identity used by bus dedup. Must be stable across
@@ -256,61 +299,90 @@ export interface ExternalEvent {
    */
   dedupeKey: string;
   /**
-   * Core enrichment filled by EventTaskResolver after publication.
+   * Core enrichment filled by ExternalEventTaskResolver after publication.
    * Adapters should leave this unset unless the source itself has a trusted
    * first-party task id.
    */
   routedTaskId?: string;
 }
 
+export interface ExternalEventExtensionConfig {
+  source: string;
+  globallyEnabled: boolean;
+  capabilities: {
+    webhooks?: boolean;
+    polling?: boolean;
+    rpcConfig?: boolean;
+  };
+  secretsRef?: string;
+  settings?: Record<string, unknown>;
+}
+
+export interface SpaceExternalEventSourceConfig {
+  spaceId: string;
+  source: string;
+  enabled: boolean;
+  settings: Record<string, unknown>;
+}
+
+export interface ExternalEventExtensionContext {
+  /** Publish a normalized event into the shared external-event subsystem. */
+  publisher: ExternalEventPublisher;
+  /** Read global extension config, secrets references, and per-space config. */
+  config: ExternalEventExtensionConfigStore;
+  /** Notify core services that source configuration changed for a space. */
+  onSourceConfigChanged(change: { source: string; spaceId?: string; kind: string }): void;
+}
+
+export interface ExternalEventExtensionConfigStore {
+  getGlobalConfig(source: string): Promise<ExternalEventExtensionConfig>;
+  getSpaceConfig(spaceId: string, source: string): Promise<SpaceExternalEventSourceConfig | null>;
+  listEnabledSpaces(source: string): Promise<SpaceExternalEventSourceConfig[]>;
+}
+
 /**
  * Interface that event source extensions must implement.
  */
-export interface EventAdapter {
-  /** Adapter identifier (used in topic namespace: '{source}/...'). */
+export interface ExternalEventExtension {
+  /** Source identifier used in topic namespace: '{source}/...'. */
   readonly sourceId: string;
 
   /**
-   * Start the adapter. Called once at daemon startup.
-   * The adapter calls `publisher.publish(event)` whenever it accepts an event.
+   * Start the extension. Called once at daemon startup if the source is globally enabled.
+   * The extension calls `context.publisher.publish(event)` whenever it accepts an event.
    */
-  start(publisher: EventPublisher): Promise<void>;
+  start(context: ExternalEventExtensionContext): Promise<void>;
 
-  /** Stop the adapter. Called at daemon shutdown. */
+  /** Stop the extension. Called at daemon shutdown or when globally disabled. */
   stop(): Promise<void>;
 }
 
 /**
- * Optional interface for adapters that expose HTTP endpoints.
- * The daemon routes matching requests to the adapter without knowing source
+ * Optional interface for extensions that expose HTTP endpoints.
+ * The daemon routes matching requests to the extension without knowing source
  * internals such as HMAC verification, event names, or raw payload shape.
  */
-export interface HttpEventAdapter extends EventAdapter {
+export interface HttpExternalEventExtension extends ExternalEventExtension {
   readonly routes: readonly {
     method: 'GET' | 'POST' | 'PUT' | 'DELETE';
     path: string;
-    handle(req: Request, publisher: EventPublisher): Promise<Response>;
+    handle(req: Request, context: ExternalEventExtensionContext): Promise<Response>;
   }[];
 }
 
 /**
- * Optional interface for adapters that expose daemon RPC methods.
- * GitHub uses this for watch/list/poll operations; future adapters can expose
+ * Optional interface for extensions that expose daemon RPC methods.
+ * GitHub uses this for watch/list/poll operations; future extensions can expose
  * source-specific configuration without adding core RPC handler dependencies.
  */
-export interface EventAdapterContext {
-  /** Notify core services that source configuration changed for a space. */
-  onSourceConfigChanged(change: { source: string; spaceId?: string; kind: 'watched_repo_changed' }): void;
-}
-
-export interface RpcEventAdapter extends EventAdapter {
-  registerRpcHandlers(hub: MessageHub, publisher: EventPublisher, context: EventAdapterContext): void;
+export interface RpcExternalEventExtension extends ExternalEventExtension {
+  registerRpcHandlers(hub: MessageHub, context: ExternalEventExtensionContext): void;
 }
 
 /**
- * Callback adapters use to publish events onto the bus.
+ * Callback extensions use to publish events into the shared external-event subsystem.
  */
-export interface EventPublisher {
+export interface ExternalEventPublisher {
   publish(event: ExternalEvent): Promise<PublishResult>;
 }
 
@@ -350,39 +422,18 @@ export interface ExternalEventStore {
   markEventIgnored(eventId: string, reason: 'no_matching_subscriptions' | 'no_scope_eligible_subscriptions'): void;
 }
 
-export interface EventTaskResolver {
+export interface ExternalEventTaskResolver {
   /** Enrich a normalized event with routedTaskId when a trusted task association exists. */
   enrich(event: ExternalEvent): Promise<ExternalEvent>;
 }
-
-/**
- * TypedHub/MessageHub method used by EventBus.
- *
- * IMPORTANT: raw external topics (e.g. `github/lsm/neokai/pull_request.opened`)
- * are NOT used as TypedHub method names because MessageHub validates methods
- * with `[a-zA-Z0-9._-]`, requires a dot, and rejects `/` and `*`.
- * The external topic stays in `ExternalEvent.topic` and is matched by EventRouter.
- */
-export const EXTERNAL_EVENT_PUBLISHED_METHOD = 'space.externalEvent.published';
-
-export interface EventBusHubEventMap {
-  'space.externalEvent.published': {
-    /** Fixed channel required by BaseEventData/TypedHub routing. */
-    sessionId: 'global';
-    spaceId: string;
-    event: ExternalEvent;
-  };
-}
 ```
 
-The `sessionId: 'global'` field is required because EventBus is backed by TypedHub/DaemonHub, whose payloads satisfy `BaseEventData` for channel routing. External event delivery is still space-scoped by `spaceId`; the fixed session channel is only the transport channel for bus subscribers.
-
 ```typescript
-class EventBus implements EventPublisher {
+class ExternalEventService implements ExternalEventPublisher {
   constructor(
-    private readonly hub: DaemonHub,
+    private readonly internalEventBus: InternalEventBus<InternalEventMap>,
     private readonly eventStore: ExternalEventStore,
-    private readonly taskResolver: EventTaskResolver,
+    private readonly taskResolver: ExternalEventTaskResolver,
   ) {}
 
   async publish(event: ExternalEvent): Promise<PublishResult> {
@@ -401,10 +452,9 @@ class EventBus implements EventPublisher {
     // Adapters do not query workflow/task/gate tables directly.
     const enriched = await this.taskResolver.enrich(stored.event);
 
-    await this.hub.emit(EXTERNAL_EVENT_PUBLISHED_METHOD, {
-      sessionId: 'global',
-      spaceId: enriched.spaceId,
-      event: enriched,
+    await this.internalEventBus.publish('externalEvent.published', {
+      channel: Channels.space(enriched.spaceId),
+      payload: { event: enriched },
     });
 
     return {
@@ -416,38 +466,52 @@ class EventBus implements EventPublisher {
 }
 ```
 
-### Bus-level middleware/services
+### ExternalEventService responsibilities
 
-The EventBus owns cross-cutting behavior that applies to every adapter:
+`ExternalEventService` owns cross-cutting behavior that applies to every extension:
 
 1. **Validation** — all topics must satisfy the four-segment topic contract before publication.
 2. **Source-level dedup** — a persistent `ExternalEventStore` tracks `(spaceId, source, dedupeKey)` and delivery state. Terminal duplicates (`delivered`, `failed`, `ignored`, `ambiguous`) are short-circuited; retryable states (`published`, `routed`, `delivery_failed`) are re-emitted so delivery can retry.
-3. **Task enrichment** — `EventTaskResolver` enriches events with `routedTaskId` for task-scoped matching. For GitHub PR events, it uses PR URL/number/branch fields that were normalized by the adapter. For future Slack/CI events, source-specific resolver plugins can be registered without changing adapters.
-4. **Publication** — only enriched, deduped events are emitted on `space.externalEvent.published`.
+3. **Task enrichment** — `ExternalEventTaskResolver` enriches events with `routedTaskId` for task-scoped matching. For GitHub PR events, it uses PR URL/number/branch fields that were normalized by the extension. For future Slack/Jira/CI events, source-specific resolver plugins can be registered without changing extensions.
+4. **Publication** — only enriched, deduped events are published as the internal fact `externalEvent.published`.
 
-This replaces the current GitHub-specific `SpaceGitHubService.ingest()` hot path for new event delivery. In particular, the bus-level dedup store must not use unconditional `INSERT OR IGNORE` short-circuiting for retryable states; otherwise transient delivery failures become permanent event loss.
+This replaces the current GitHub-specific `SpaceGitHubService.ingest()` hot path for new event delivery. In particular, the service-level dedup store must not use unconditional `INSERT OR IGNORE` short-circuiting for retryable states; otherwise transient delivery failures become permanent event loss.
 
-### GitHub adapter as an extension
+### GitHub extension as the reference implementation
 
-The GitHub adapter is a primary source adapter, not a downstream listener on `SpaceGitHubService`:
+The GitHub extension is a primary source extension, not a downstream listener on `SpaceGitHubService`. It is the example future third-party integrations should copy:
 
 ```typescript
-class GitHubEventAdapter implements HttpEventAdapter, RpcEventAdapter {
+interface GitHubSpaceConfig {
+  enabled: boolean;
+  watchedRepos: { owner: string; repo: string; enabled: boolean }[];
+  eventFilters?: {
+    pullRequests?: boolean;
+    reviews?: boolean;
+    comments?: boolean;
+    checks?: boolean;
+  };
+  polling?: { enabled: boolean; intervalMs?: number };
+  webhooks?: { enabled: boolean };
+}
+
+class GitHubEventExtension implements HttpExternalEventExtension, RpcExternalEventExtension {
   readonly sourceId = 'github';
   readonly routes = [
     { method: 'POST', path: '/webhook/github/space', handle: this.handleWebhook.bind(this) },
   ] as const;
 
-  constructor(
-    private readonly repo: GitHubEventAdapterRepository,
-    private readonly githubToken?: string,
-  ) {}
+  private context?: ExternalEventExtensionContext;
+  private pollTimer?: ReturnType<typeof setInterval>;
 
-  async start(publisher: EventPublisher): Promise<void> {
-    this.publisher = publisher;
+  async start(context: ExternalEventExtensionContext): Promise<void> {
+    this.context = context;
+    const global = await context.config.getGlobalConfig(this.sourceId);
+    if (!global.globallyEnabled || !global.capabilities.polling) return;
+
     this.pollTimer = setInterval(() => {
-      void this.pollOnce().catch((err) => {
-        log.warn('GitHubEventAdapter: polling failed', {
+      void this.pollEnabledSpaces().catch((err) => {
+        log.warn('GitHubEventExtension: polling failed', {
           error: err instanceof Error ? err.message : String(err),
         });
       });
@@ -458,58 +522,84 @@ class GitHubEventAdapter implements HttpEventAdapter, RpcEventAdapter {
     if (this.pollTimer) clearInterval(this.pollTimer);
   }
 
-  registerRpcHandlers(hub: MessageHub, publisher: EventPublisher, context: EventAdapterContext): void {
+  registerRpcHandlers(hub: MessageHub, context: ExternalEventExtensionContext): void {
+    hub.onRequest('space.github.enable', async (data) => {
+      const config = await this.enableForSpace(data);
+      context.onSourceConfigChanged({ source: this.sourceId, spaceId: config.spaceId, kind: 'space_enabled' });
+      return config;
+    });
+
+    hub.onRequest('space.github.disable', async (data) => {
+      const config = await this.disableForSpace(data);
+      context.onSourceConfigChanged({ source: this.sourceId, spaceId: config.spaceId, kind: 'space_disabled' });
+      return config;
+    });
+
     hub.onRequest('space.github.watchRepo', async (data) => {
       const watchedRepo = await this.watchRepo(data);
-      context.onSourceConfigChanged({
-        source: this.sourceId,
-        spaceId: watchedRepo.spaceId,
-        kind: 'watched_repo_changed',
-      });
+      context.onSourceConfigChanged({ source: this.sourceId, spaceId: watchedRepo.spaceId, kind: 'watched_repo_changed' });
       return watchedRepo;
     });
-    hub.onRequest('space.github.listWatchedRepos', async (data) => this.listWatchedRepos(data));
-    hub.onRequest('space.github.pollOnce', async () => ({ count: await this.pollOnce() }));
+
+    hub.onRequest('space.github.listConfig', async (data) => this.listSpaceConfig(data));
+    hub.onRequest('space.github.pollOnce', async (data) => ({ count: await this.pollSpace(data.spaceId) }));
   }
 
-  private async handleWebhook(req: Request, publisher: EventPublisher): Promise<Response> {
+  private async handleWebhook(req: Request, context: ExternalEventExtensionContext): Promise<Response> {
+    const global = await context.config.getGlobalConfig(this.sourceId);
+    if (!global.globallyEnabled || !global.capabilities.webhooks) {
+      return Response.json({ ignored: true, reason: 'github_extension_disabled' }, { status: 202 });
+    }
+
     const raw = await req.text();
-    const verifiedRepos = this.verifySignatureAgainstWatchedRepos(req, raw);
     const normalized = normalizeGitHubWebhook(req.headers, JSON.parse(raw));
     if (!normalized) return Response.json({ ignored: true });
 
-    for (const watched of verifiedRepos) {
-      await publisher.publish(toExternalEvent(watched.spaceId, normalized));
+    const targetSpaces = await this.resolveEnabledSpacesForWebhook(context, req, raw, normalized);
+    for (const spaceConfig of targetSpaces) {
+      if (!spaceConfig.enabled) continue;
+      await context.publisher.publish(toExternalEvent(spaceConfig.spaceId, normalized));
     }
 
     return Response.json({ message: 'Webhook received' });
   }
 
-  async pollOnce(fetchImpl: typeof fetch = fetch): Promise<number> {
-    // Poll GitHub endpoints, normalize rows, and publish ExternalEvent directly.
-    // No SpaceTask lookup and no session injection happen here.
+  private async pollEnabledSpaces(): Promise<number> {
+    if (!this.context) return 0;
+    const spaces = await this.context.config.listEnabledSpaces(this.sourceId);
+    let count = 0;
+    for (const spaceConfig of spaces) {
+      count += await this.pollSpace(spaceConfig.spaceId);
+    }
+    return count;
+  }
+
+  async pollSpace(spaceId: string, fetchImpl: typeof fetch = fetch): Promise<number> {
+    // Load this space's GitHub config, poll its enabled watched repos, normalize rows,
+    // and publish ExternalEvent directly. No SpaceTask lookup and no session injection happen here.
   }
 }
 ```
 
-The normalization helpers currently living in `space-github.ts` move into this adapter module:
+The normalization helpers currently living in `space-github.ts` move into this extension module:
 
 - `normalizeSpaceGitHubWebhook(...)` → `normalizeGitHubWebhook(...)`
 - `normalizePollingRow(...)` → `normalizeGitHubPollingRow(...)`
-- `mapEventType(...)` stays with the adapter because topic construction is source-specific
+- `mapEventType(...)` stays with the extension because topic construction is source-specific
 
-The adapter may keep source-local tables such as `space_github_watched_repos` and an optional adapter event log for diagnostics, but the authoritative cross-source event lifecycle belongs to the EventBus store.
+The extension may keep source-local tables such as `space_github_watched_repos` and an optional extension event log for diagnostics, but the authoritative cross-source event lifecycle belongs to `ExternalEventStore`. During migration, existing GitHub RPC names can remain as compatibility aliases, but new extension APIs should use a generic shape where possible: global source enablement, per-space source enablement, source-specific settings, and watched-resource configuration.
 
-## 4. EventRouter Design
+## 4. ExternalEventRouter Design
 
 ### Architecture
 
-The `EventRouter` subscribes to the fixed TypedHub-safe EventBus method (`space.externalEvent.published`). When an event arrives, it:
+The `ExternalEventRouter` subscribes to the internal fact `externalEvent.published` on `InternalEventBus`. When an event arrives, it:
 
 1. Reads the external topic from `event.topic` in the payload.
 2. Looks up all active node executions that have `eventInterests` matching that payload topic.
 3. For each matching interest, checks scope.
-4. Delivers the event to the matching node's agent session.
+4. Records/updates per-subscription delivery lifecycle.
+5. Dispatches `InternalCommandBus.dispatch('agent.message.inject', ...)` for the matching node's agent session.
 
 ### Trie-based subscription index
 
@@ -590,10 +680,10 @@ interface WatchedRepoLookup {
 }
 ```
 
-### EventRouter implementation sketch
+### ExternalEventRouter implementation sketch
 
 ```typescript
-class EventRouter {
+class ExternalEventRouter {
   // topic trie for fast lookup
   private topicTrie: TopicTrie<Subscription> = new TopicTrie();
 
@@ -621,11 +711,12 @@ class EventRouter {
   private static readonly RETRY_BACKOFF_MS = 1000; // 1s base, exponential backoff
 
   // Cache: spaceId → Set of "owner/repo" strings for watched repos.
-  // Invalidated when a source adapter reports watched-repo configuration changes.
+  // Invalidated when a source extension reports watched-repo configuration changes.
   private watchedRepoCache: Map<string, Set<string>> = new Map();
 
   constructor(
-    private readonly eventBus: EventBus,
+    private readonly internalEventBus: InternalEventBus<InternalEventMap>,
+    private readonly commandBus: InternalCommandBus<InternalCommandMap>,
     private readonly nodeExecutionRepo: NodeExecutionRepository,
     private readonly taskRepo: SpaceTaskRepository,
     private readonly spaceTaskManager: SpaceTaskManager,
@@ -633,20 +724,21 @@ class EventRouter {
     private readonly eventStore: ExternalEventStore,
     private readonly watchedRepoLookup: WatchedRepoLookup,
   ) {
-    // Subscribe to the fixed TypedHub-safe method. External topic matching happens
-    // inside handleEvent via event.topic, not via the hub method name.
-    this.eventBus.subscribe(EXTERNAL_EVENT_PUBLISHED_METHOD, ({ spaceId, event }) => {
-      // Defense in depth: payload spaceId and event.spaceId must agree.
-      if (event.spaceId !== spaceId) return;
+    // Subscribe to the semantic internal fact. External topic matching happens
+    // inside handleEvent via event.topic, not via the internal event name.
+    this.internalEventBus.subscribe('externalEvent.published', ({ payload, channel }) => {
+      const { event } = payload;
+      // Defense in depth: payload spaceId and channel spaceId must agree when channel is space-scoped.
+      if (channel.kind === 'space' && event.spaceId !== channel.spaceId) return;
       void this.handleEvent(event).catch((err) => {
-        log.warn('EventRouter: failed to route external event', {
+        log.warn('ExternalEventRouter: failed to route external event', {
           error: err,
-          spaceId,
+          spaceId: event.spaceId,
           topic: event.topic,
           eventId: event.id,
         });
       });
-    });
+    }, { subscriberName: 'ExternalEventRouter' });
   }
 
   /** Check if a repo is watched for a given space. Uses cached data. */
@@ -664,7 +756,7 @@ class EventRouter {
 
   /**
    * Invalidate the watched-repo cache for a given space (or all spaces).
-   * Called from EventAdapterContext.onSourceConfigChanged when a source adapter
+   * Called from ExternalEventExtensionContext.onSourceConfigChanged when a source extension
    * changes watched-repo configuration (for example `space.github.watchRepo`).
    * Without this, `repo`-scoped matching grows stale until process restart.
    */
@@ -678,7 +770,7 @@ class EventRouter {
 
   private makeDeliveryKey(event: ExternalEvent, sub: Subscription): string {
     // Use a structured tuple key. Source-level dedupe is unique by
-    // (spaceId, source, dedupeKey), so include event.source to prevent two adapters
+    // (spaceId, source, dedupeKey), so include event.source to prevent two extensions
     // that legitimately emit the same dedupeKey from sharing pending/delivered/retry
     // bookkeeping for the same subscription. All fields are free-form strings and
     // can contain ':', '/', or other delimiter characters, so avoid delimiter joins.
@@ -711,7 +803,7 @@ class EventRouter {
 
   /** Evict stale dedup entries (called periodically or on demand). */
   private evictStaleDedup(): void {
-    const cutoff = Date.now() - EventRouter.DEDUP_TTL_MS;
+    const cutoff = Date.now() - ExternalEventRouter.DEDUP_TTL_MS;
     for (const [key, ts] of this.delivered.entries()) {
       if (ts < cutoff) this.delivered.delete(key);
     }
@@ -801,7 +893,7 @@ class EventRouter {
       if (!currentSubsByKey.has(key)) {
         const validation = validateGlobPattern(sub.interest.topic);
         if (!validation.valid) {
-          log.warn('EventRouter: skipping invalid event interest topic', {
+          log.warn('ExternalEventRouter: skipping invalid event interest topic', {
             workflowRunId,
             taskId: sub.taskId,
             nodeId: sub.nodeId,
@@ -1066,7 +1158,7 @@ class EventRouter {
         eligible.push(sub);
       } catch (err) {
         preparationFailed = true;
-        log.warn('EventRouter: failed to prepare external event delivery; scheduling retry', {
+        log.warn('ExternalEventRouter: failed to prepare external event delivery; scheduling retry', {
           error: err,
           spaceId: event.spaceId,
           topic: event.topic,
@@ -1094,7 +1186,7 @@ class EventRouter {
     if (preparationFailed) return false;
 
     // No prepared, non-terminal delivery remains for this event. Mark the source
-    // event terminal so retryable source duplicates (webhook + polling, adapter
+    // event terminal so retryable source duplicates (webhook + polling, extension
     // retries, etc.) do not re-emit and re-route indefinitely when every matched
     // subscription is out of scope or already terminal.
     if (eligible.length === 0) {
@@ -1108,7 +1200,7 @@ class EventRouter {
       try {
         await this.deliverToSubscription(event, sub);
       } catch (err) {
-        log.warn('EventRouter: failed to deliver external event to subscription', {
+        log.warn('ExternalEventRouter: failed to deliver external event to subscription', {
           error: err,
           spaceId: event.spaceId,
           topic: event.topic,
@@ -1141,7 +1233,7 @@ class EventRouter {
     // Mark as pending to prevent duplicate queueing. We do NOT mark as delivered
     // until after successful injection. Failed injection/session-resolution paths
     // clear pending and schedule router-level retry rather than relying on a source
-    // adapter to publish the same event again.
+    // extension to publish the same event again.
     this.pendingDeliveries.add(dedupeKey);
 
     try {
@@ -1209,7 +1301,7 @@ class EventRouter {
         this.pendingDeliveries.delete(dropped.deliveryKey);
         this.markQueuedDeliveryFailed(dropped.event.id, dropped.deliveryKey, 'pending_queue_overflow');
       }
-      log.warn('EventRouter: pending external event queue exceeded limit; dropped oldest event', {
+      log.warn('ExternalEventRouter: pending external event queue exceeded limit; dropped oldest event', {
         workflowRunId: sub.workflowRunId,
         taskId: sub.taskId,
         nodeId: sub.nodeId,
@@ -1266,7 +1358,7 @@ class EventRouter {
       try {
         await this.injectPreparedDelivery(pending.event, sub, pending.deliveryKey, sessionId);
       } catch (err) {
-        log.warn('EventRouter: failed to flush queued external event delivery', {
+        log.warn('ExternalEventRouter: failed to flush queued external event delivery', {
           error: err,
           eventId: pending.event.id,
           workflowRunId: sub.workflowRunId,
@@ -1281,7 +1373,7 @@ class EventRouter {
   }
 
   private passesScopeCheck(event: ExternalEvent, sub: Subscription): boolean {
-    // All scopes are bounded to the subscription's space. EventBus is a shared
+    // All scopes are bounded to the subscription's space. ExternalEventRouter handles a shared
     // daemon-wide stream, so even `global` means "global within this space", not
     // cross-space delivery.
     if (event.spaceId !== sub.spaceId) return false;
@@ -1292,7 +1384,7 @@ class EventRouter {
 
       case 'repo': {
         // Check if event's repo matches any watched repo in this space.
-        // Uses an adapter-provided watched-repo lookup filtered by
+        // Uses an extension-provided watched-repo lookup filtered by
         // (spaceId, owner, repo, enabled=true). The router caches this per-space
         // to avoid DB hits on every event.
         if (!event.repoOwner || !event.repoName) return false;
@@ -1300,11 +1392,11 @@ class EventRouter {
       }
 
       case 'task': {
-        // EventTaskResolver enriches matching events before publication. The
+        // ExternalEventTaskResolver enriches matching events before publication. The
         // router uses that trusted enrichment directly and never performs broad
         // PR/task scans during delivery. This prevents cross-task leakage in
         // multi-task runs and keeps task/gate/workflow schema access out of
-        // source adapters and delivery hot paths. If routedTaskId is absent, the
+        // source extensions and delivery hot paths. If routedTaskId is absent, the
         // event has no associated task, so the scope check returns false.
         return event.routedTaskId === sub.taskId;
       }
@@ -1333,8 +1425,8 @@ class EventRouter {
       'prepare',
     ]);
     const retries = options.retryCountOverride ?? ((this.eventRetryCounts.get(retryKey) ?? 0) + 1);
-    if (retries > EventRouter.MAX_RETRIES) {
-      log.warn('EventRouter: max preparation retries exceeded; marking event failed', {
+    if (retries > ExternalEventRouter.MAX_RETRIES) {
+      log.warn('ExternalEventRouter: max preparation retries exceeded; marking event failed', {
         eventId: event.id,
         topic: event.topic,
       });
@@ -1352,7 +1444,7 @@ class EventRouter {
 
     this.eventRetryCounts.set(retryKey, retries);
     this.eventRetryState.set(retryKey, { event, matched });
-    const backoff = EventRouter.RETRY_BACKOFF_MS * Math.pow(2, retries - 1);
+    const backoff = ExternalEventRouter.RETRY_BACKOFF_MS * Math.pow(2, retries - 1);
     const existingTimer = this.eventRetryTimers.get(retryKey);
     if (existingTimer) clearTimeout(existingTimer);
 
@@ -1385,7 +1477,7 @@ class EventRouter {
         .catch((err) => {
           // Keep count/state on failure so the next scheduled retry continues the
           // same preparation-failure budget instead of starting over.
-          log.warn('EventRouter: event preparation retry failed', { error: err, eventId: event.id });
+          log.warn('ExternalEventRouter: event preparation retry failed', { error: err, eventId: event.id });
         });
     }, backoff);
     this.eventRetryTimers.set(retryKey, timer);
@@ -1397,7 +1489,7 @@ class EventRouter {
    */
   private scheduleRetry(event: ExternalEvent, sub: Subscription, deliveryKey: string): void {
     const retries = (this.retryCounts.get(deliveryKey) ?? 0) + 1;
-    if (retries > EventRouter.MAX_RETRIES) {
+    if (retries > ExternalEventRouter.MAX_RETRIES) {
       log.warn(`Max retries exceeded for event ${deliveryKey}, marking delivery failed`);
       this.retryCounts.delete(deliveryKey);
       const existingTimer = this.retryTimers.get(deliveryKey);
@@ -1416,7 +1508,7 @@ class EventRouter {
     }
 
     this.retryCounts.set(deliveryKey, retries);
-    const backoff = EventRouter.RETRY_BACKOFF_MS * Math.pow(2, retries - 1);
+    const backoff = ExternalEventRouter.RETRY_BACKOFF_MS * Math.pow(2, retries - 1);
 
     const existingTimer = this.retryTimers.get(deliveryKey);
     if (existingTimer) clearTimeout(existingTimer);
@@ -1462,7 +1554,7 @@ class EventRouter {
         })
         .catch((err) => {
           // Don't clear retryCounts on failure — preserve count for retry logic.
-          log.warn('EventRouter: retry delivery failed', {
+          log.warn('ExternalEventRouter: retry delivery failed', {
             error: err,
             retries,
             deliveryKey,
@@ -1509,12 +1601,12 @@ Dedup happens at two different layers, each with a different key and responsibil
 
 2. **Per-subscription delivery dedup** — JSON tuple `[event.source, event.dedupeKey, subscription.taskId, subscription.nodeId, subscription.agentName, subscription.workflowRunId]`.
    - Purpose: prevent the same external event from being delivered twice to the same node agent within a run.
-   - The tuple includes `event.source` because source-level dedupe is scoped by `(spaceId, source, dedupeKey)`: two adapters can legitimately emit the same `dedupeKey` in one space and must not share pending/delivered/retry bookkeeping.
+   - The tuple includes `event.source` because source-level dedupe is scoped by `(spaceId, source, dedupeKey)`: two extensions can legitimately emit the same `dedupeKey` in one space and must not share pending/delivered/retry bookkeeping.
    - The tuple includes `taskId` to isolate multi-task runs and `nodeId` to handle cases where the same agent name appears in multiple nodes within the same run.
    - The tuple is encoded structurally rather than delimiter-joined because `source`, `dedupeKey`, workflow identifiers, node IDs, and agent names are free-form strings.
    - It is tracked in-memory for fast duplicate suppression and persisted in `space_external_event_deliveries` after successful injection.
 
-The EventRouter marks per-subscription delivery as `delivered` only after successful injection, updates `ExternalEventStore` with the successful delivery key, and advances the source event to terminal `delivered` only once all expected deliveries are terminal. Failed injection/session-resolution paths remove `pendingDeliveries` and schedule retry rather than relying on adapters to re-publish the same event. If trie lookup finds no matching subscriptions, or if all matched subscriptions are out of scope/already terminal and no preparation retry is pending, the router marks the source event terminal `ignored` so webhook+polling duplicates do not churn through routing forever.
+The ExternalEventRouter marks per-subscription delivery as `delivered` only after successful injection, updates `ExternalEventStore` with the successful delivery key, and advances the source event to terminal `delivered` only once all expected deliveries are terminal. Failed injection/session-resolution paths remove `pendingDeliveries` and schedule retry rather than relying on adapters to re-publish the same event. If trie lookup finds no matching subscriptions, or if all matched subscriptions are out of scope/already terminal and no preparation retry is pending, the router marks the source event terminal `ignored` so webhook+polling duplicates do not churn through routing forever.
 
 ### Wake-on-idle
 
@@ -1562,13 +1654,13 @@ When a node execution is `pending` (no session yet):
 - Events queued for `pending` nodes before restart may need explicit replay from the event store once persistent delivery queues are implemented.
 - New events (arriving after restart) flow through the bus normally and are not affected.
 
-If persistent queuing is needed in a future iteration, events can be persisted to a `space_event_delivery_queue` SQLite table with the same schema as the in-memory map, and drained on node activation. The table should store the `ExternalEvent.id` plus the subscription key so queued delivery can replay from `ExternalEventStore` without relying on source adapters to re-publish.
+If persistent queuing is needed in a future iteration, events can be persisted to a `space_event_delivery_queue` SQLite table with the same schema as the in-memory map, and drained on node activation. The table should store the `ExternalEvent.id` plus the subscription key so queued delivery can replay from `ExternalEventStore` without relying on source extensions to re-publish.
 
 ### Backpressure
 
 - **Rate limiting**: If a single node receives > 10 events per minute, subsequent events are coalesced into a digest message: "N additional events received in the last minute. Summary: ..."
 - **Event TTL**: Events older than 5 minutes are dropped from the queue (they're likely stale for an agent's decision-making).
-- **Bus overflow**: The `EventBus` uses TypedHub's async-everywhere design with the fixed method `space.externalEvent.published` — slow consumers don't block publishers. Handlers run via `queueMicrotask`; external slash/glob topics remain payload data and are never used as MessageHub method names.
+- **Router/handler overflow**: `ExternalEventService.publish(...)` uses `InternalEventBus.publish('externalEvent.published', ...)`. In v1, use the awaited `publish(...)` path for observability; if later throughput requires fire-and-forget behavior, use explicit `publishAsync(...)` and ensure handler failures are logged with event/subscriber context.
 
 ## 6. Topic Trie Implementation
 
@@ -1728,45 +1820,47 @@ function isReceivingStatus(status: NodeExecutionStatus): boolean {
 - Lookup: Effectively O(2^k × m) in the common case — walks exact + matching glob branches at each level, collects m total matching subscriptions from leaves. Since k is bounded (4–5) and per-agent interest count is capped, glob branching stays small.
 - Memory: O(n × k) where n = number of subscriptions
 
-## 7. Wiring the GitHub Adapter
+## 7. Wiring the GitHub Extension
 
 ### Target architecture
 
-The GitHub integration is extracted into a first-class event adapter. It no longer depends on `SpaceGitHubService.ingest()`, `space.githubEvent.routed`, or Task Agent notification delivery.
+The GitHub integration is extracted into a first-class event extension. It no longer depends on `SpaceGitHubService.ingest()`, `space.githubEvent.routed`, or Task Agent notification delivery.
 
-```
+```text
 GitHub webhook / polling
-    → GitHubEventAdapter
+    → GitHubEventExtension
+        → check global + per-space enablement
         → verify signature / fetch API pages
         → normalize raw GitHub payload
         → construct topic + dedupeKey
-        → EventBus.publish(ExternalEvent)
+        → ExternalEventService.publish(ExternalEvent)
             → ExternalEventStore.store() + retry-aware dedup
-            → EventTaskResolver.enrich()   // PR → SpaceTask when possible
-            → DaemonHub.emit('space.externalEvent.published', { event })
-                → EventRouter.deliverToSubscription()
-                    → sessionFactory.injectMessage(..., { deliveryMode: 'defer' })
+            → ExternalEventTaskResolver.enrich()   // PR → SpaceTask when possible
+            → InternalEventBus.publish('externalEvent.published', ...)
+                → ExternalEventRouter
+                    → InternalCommandBus.dispatch('agent.message.inject', ...)
 ```
 
-There is no intermediate `space.githubEvent.routed` payload contract. The adapter publishes the full normalized event directly to the bus, and the bus owns task enrichment and delivery state.
+There is no intermediate `space.githubEvent.routed` payload contract. The extension publishes the full normalized event directly to `ExternalEventService`, and core external-event services own task enrichment and delivery state.
 
 ### Changes to existing code
 
 **Extract source-specific GitHub code from `SpaceGitHubService`:**
 
-- Move webhook normalization (`normalizeSpaceGitHubWebhook`) into `github-adapter.ts`.
-- Move polling normalization (`normalizePollingRow`) into `github-adapter.ts`.
-- Move watched-repo configuration access into `GitHubEventAdapterRepository` or keep the existing `space_github_watched_repos` table behind that repository.
-- Move `space.github.watchRepo`, `space.github.listWatchedRepos`, and `space.github.pollOnce` registration behind `RpcEventAdapter.registerRpcHandlers(...)`.
-- Register `/webhook/github/space` through the adapter route registry rather than hard-coding a direct call to `spaceGitHubService.handleWebhook(req)` in `app.ts`.
+- Move webhook normalization (`normalizeSpaceGitHubWebhook`) into `github-event-extension.ts` / `github-normalizer.ts`.
+- Move polling normalization (`normalizePollingRow`) into `github-event-extension.ts` / `github-normalizer.ts`.
+- Move watched-repo configuration access into `GitHubEventExtensionRepository` or keep the existing `space_github_watched_repos` table behind that repository.
+- Move `space.github.watchRepo`, `space.github.listWatchedRepos`, and `space.github.pollOnce` registration behind `RpcExternalEventExtension.registerRpcHandlers(...)` as compatibility RPCs.
+- Add generic extension configuration APIs for global enablement, per-space enablement, and source settings; GitHub-specific RPCs can delegate to those APIs where practical.
+- Register `/webhook/github/space` through the extension route registry rather than hard-coding a direct call to `spaceGitHubService.handleWebhook(req)` in `app.ts`.
 
-**Do not extend `appendTaskActivity`:** the old plan proposed adding normalized fields to `space.githubEvent.routed`. That is no longer needed because the GitHub adapter publishes `ExternalEvent` directly and no longer treats `SpaceGitHubService` as an upstream source.
+**Do not extend `appendTaskActivity`:** the old plan proposed adding normalized fields to `space.githubEvent.routed`. That is no longer needed because the GitHub extension publishes `ExternalEvent` directly and no longer treats `SpaceGitHubService` as an upstream source.
 
-**Deprecate direct Task Agent injection:** the old `scheduleTaskNotification()` / `flushTaskNotification()` path remains only as a compatibility shim during migration. New node-level delivery goes through `EventRouter`. Once workflows rely on `eventInterests`, the Task Agent relay can be removed.
+**Deprecate direct Task Agent injection:** the old `scheduleTaskNotification()` / `flushTaskNotification()` path remains only as a compatibility shim during migration. New node-level delivery goes through `ExternalEventRouter` and the `agent.message.inject` command. Once workflows rely on `eventInterests`, the Task Agent relay can be removed.
 
-### GitHub adapter topic construction
+### GitHub extension topic construction
 
-The GitHub adapter normalizes to GitHub event kinds (`issue_comment`, `pull_request_review`, `pull_request_review_comment`, `pull_request`) and maps them to bus topics:
+The GitHub extension normalizes to GitHub event kinds (`issue_comment`, `pull_request_review`, `pull_request_review_comment`, `pull_request`) and maps them to bus topics:
 
 | GitHub normalized kind | `mapEventType(kind, action)` returns |
 |---|---|
@@ -1775,7 +1869,7 @@ The GitHub adapter normalizes to GitHub event kinds (`issue_comment`, `pull_requ
 | `pull_request_review_comment` | `pull_request.review_comment_${action}` (created, edited, deleted) |
 | `pull_request` | `pull_request.${action}` (opened, synchronize, closed, etc.) |
 
-These return values are the complete fourth path segment (`resource.action`). For V1 PR events the resource side is always `pull_request`; `comment_*`, `review_*`, and `review_comment_*` are action names, not nested resource segments. The adapter must not emit doubled resource names such as `pull_request.review.review_submitted`.
+These return values are the complete fourth path segment (`resource.action`). For V1 PR events the resource side is always `pull_request`; `comment_*`, `review_*`, and `review_comment_*` are action names, not nested resource segments. The extension must not emit doubled resource names such as `pull_request.review.review_submitted`.
 
 ```typescript
 function mapEventType(kind: string, action: string): string | null {
@@ -1784,7 +1878,7 @@ function mapEventType(kind: string, action: string): string | null {
     case 'pull_request_review': return `pull_request.review_${action}`;
     case 'pull_request_review_comment': return `pull_request.review_comment_${action}`;
     case 'pull_request': return `pull_request.${action}`;
-    default: return null; // Non-PR GitHub topics are future adapter scope.
+    default: return null; // Non-PR GitHub topics are future extension scope.
   }
 }
 ```
@@ -1829,20 +1923,20 @@ function toExternalEvent(spaceId: string, event: NormalizedGitHubEvent): Externa
 
 ### Task-scoped resolution
 
-For `task` scope, the adapter does not resolve a task. Instead, `EventTaskResolver` enriches PR events after bus dedup and before publication:
+For `task` scope, the extension does not resolve a task. Instead, `ExternalEventTaskResolver` enriches PR events after bus dedup and before publication:
 
 1. If the event already has a trusted `routedTaskId`, use it directly.
 2. For GitHub PR events, resolve using normalized `prUrl`, `repoOwner/repoName`, `prNumber`, and optional `branch`.
 3. Store the result in `event.routedTaskId` and `event.payload.taskResolution` for diagnostics.
-4. EventRouter `task` scope checks `event.routedTaskId === sub.taskId` and does not re-run broad task scans during delivery.
+4. ExternalEventRouter `task` scope checks `event.routedTaskId === sub.taskId` and does not re-run broad task scans during delivery.
 
-This removes duplicate PR→task resolution from the adapter and EventRouter hot paths while preserving the existing auto-scoping behavior.
+This removes duplicate PR→task resolution from the extension and ExternalEventRouter hot paths while preserving the existing auto-scoping behavior.
 
 ## 8. Migration Path
 
 ### DB schema changes
 
-V1 needs one core event-store table plus workflow type additions:
+V1 needs core event lifecycle tables, extension configuration storage, and workflow type additions:
 
 1. **Core bus event store** (`space_external_events`): persistent source-level event lifecycle for retry-aware dedup.
 
@@ -1866,7 +1960,7 @@ V1 needs one core event-store table plus workflow type additions:
 
    `state` values are `published`, `routed`, `delivered`, `delivery_failed`, `failed`, `ignored`, and `ambiguous`. Duplicate handling depends on state: terminal states (`delivered`, `failed`, `ignored`, `ambiguous`) short-circuit; retryable states can re-emit. `delivered` is written only after expected per-subscription deliveries are terminal, `failed` is written only after retry budgets are exhausted for all retryable deliveries, and `ignored` is written when routing finds no matching subscriptions or no eligible non-terminal delivery after scope checks.
 
-2. **Core bus delivery store** (`space_external_event_deliveries`): persistent per-subscription delivery lifecycle used by EventRouter to advance source events to terminal delivered.
+2. **Core bus delivery store** (`space_external_event_deliveries`): persistent per-subscription delivery lifecycle used by ExternalEventRouter to advance source events to terminal delivered.
 
    ```sql
    CREATE TABLE space_external_event_deliveries (
@@ -1883,17 +1977,41 @@ V1 needs one core event-store table plus workflow type additions:
    );
    ```
 
-   `EventRouter` calls `registerExpectedDelivery(...)` for every scope-matched subscription before attempting any injection. This registration must be idempotent for the `(event_id, delivery_key)` primary key: use `INSERT OR IGNORE`, `ON CONFLICT DO NOTHING`, or an equivalent upsert that never downgrades an existing terminal row. Retryable source duplicates and router retries can prepare the same delivery more than once, so duplicate expected-delivery rows are normal and must not become preparation failures. After idempotent registration, the router skips already-terminal delivery rows and only attempts pending/retryable rows. It then records `delivered` after successful `injectMessage` and calls `markEventDeliveredIfAllDeliveriesTerminal(event.id)` so source-level dedup can stop re-emitting already-delivered events after restart or in-memory TTL eviction. When retry budget is exhausted, pending-node queue overflow evicts an expected delivery, node cancellation removes queued/retrying deliveries, a retry fires for an inactive subscription, terminal run cleanup drops queued deliveries, or terminal run cleanup cancels per-delivery retry timers, the router records terminal delivery failure and calls `markEventFailedIfAllDeliveriesTerminal(event.id)` so duplicate source observations do not restart an exhausted or impossible delivery.
+   `ExternalEventRouter` calls `registerExpectedDelivery(...)` for every scope-matched subscription before attempting any injection. This registration must be idempotent for the `(event_id, delivery_key)` primary key: use `INSERT OR IGNORE`, `ON CONFLICT DO NOTHING`, or an equivalent upsert that never downgrades an existing terminal row. Retryable source duplicates and router retries can prepare the same delivery more than once, so duplicate expected-delivery rows are normal and must not become preparation failures. After idempotent registration, the router skips already-terminal delivery rows and only attempts pending/retryable rows. It then records `delivered` after successful `injectMessage` and calls `markEventDeliveredIfAllDeliveriesTerminal(event.id)` so source-level dedup can stop re-emitting already-delivered events after restart or in-memory TTL eviction. When retry budget is exhausted, pending-node queue overflow evicts an expected delivery, node cancellation removes queued/retrying deliveries, a retry fires for an inactive subscription, terminal run cleanup drops queued deliveries, or terminal run cleanup cancels per-delivery retry timers, the router records terminal delivery failure and calls `markEventFailedIfAllDeliveriesTerminal(event.id)` so duplicate source observations do not restart an exhausted or impossible delivery.
 
-3. **Adapter-owned GitHub configuration**: reuse or migrate the existing `space_github_watched_repos` table behind `GitHubEventAdapterRepository`. This table remains source-specific and should not be queried by EventRouter except through cache invalidation hooks for repo-scoped matching.
+3. **Extension configuration**: store global and per-space source configuration so sources can be enabled/disabled and configured independently.
 
-4. **No node-execution schema change**: event interests are stored as part of the workflow definition JSON in `space_workflows.nodes[].agents[].eventInterests`.
+   ```sql
+   CREATE TABLE external_event_source_configs (
+     source TEXT PRIMARY KEY,
+     enabled INTEGER NOT NULL DEFAULT 0,
+     capabilities_json TEXT NOT NULL,
+     settings_json TEXT NOT NULL,
+     secrets_ref TEXT,
+     created_at INTEGER NOT NULL,
+     updated_at INTEGER NOT NULL
+   );
+
+   CREATE TABLE space_external_event_source_configs (
+     space_id TEXT NOT NULL,
+     source TEXT NOT NULL,
+     enabled INTEGER NOT NULL DEFAULT 0,
+     settings_json TEXT NOT NULL,
+     created_at INTEGER NOT NULL,
+     updated_at INTEGER NOT NULL,
+     PRIMARY KEY(space_id, source)
+   );
+   ```
+
+4. **Extension-owned GitHub configuration**: reuse or migrate the existing `space_github_watched_repos` table behind `GitHubEventExtensionRepository`. This table remains source-specific and should not be queried by `ExternalEventRouter` except through cache invalidation hooks for repo-scoped matching. Over time, GitHub watched repositories can move into `space_external_event_source_configs.settings_json` if that becomes simpler.
+
+5. **No node-execution schema change**: event interests are stored as part of the workflow definition JSON in `space_workflows.nodes[].agents[].eventInterests`.
 
 ### Type changes
 
 1. Add `EventInterest` interface to `packages/shared/src/types/space.ts`.
 2. Add `eventInterests?: EventInterest[]` to `WorkflowNodeAgent`.
-3. Add `ExternalEvent`, `EventAdapter`, `HttpEventAdapter`, `RpcEventAdapter`, `EventPublisher`, `ExternalEventStore`, and `EventTaskResolver` types under `packages/daemon/src/lib/space/runtime/event-bus/`.
+3. Add `ExternalEvent`, `ExternalEventExtension`, `HttpExternalEventExtension`, `RpcExternalEventExtension`, `ExternalEventPublisher`, `ExternalEventStore`, and `ExternalEventTaskResolver` types under `packages/daemon/src/lib/external-events/`.
 4. Add validation in the workflow create/update path (Zod schema or manual validation):
    - `topic` must pass `validateGlobPattern()` (non-empty, exactly 4 segments, no `..` segments, no double slashes, valid characters including segment-local `*`).
    - `scope` must be one of `'task' | 'repo' | 'global'`.
@@ -1903,20 +2021,22 @@ V1 needs one core event-store table plus workflow type additions:
 ### New files
 
 ```
-packages/daemon/src/lib/space/runtime/event-bus/
-  ├── types.ts                 # ExternalEvent, EventAdapter, EventPublisher interfaces
-  ├── event-bus.ts             # EventBus singleton (wraps TypedHub)
-  ├── event-store.ts           # Persistent retry-aware source-level dedup
-  ├── event-task-resolver.ts   # Core event -> SpaceTask enrichment
-  ├── topic-trie.ts            # TopicTrie<T> implementation
-  ├── topic-validator.ts       # validateGlobPattern() helper
-  ├── event-router.ts          # EventRouter — subscribes to bus, matches, delivers
-  └── index.ts                 # Public exports
+packages/daemon/src/lib/external-events/
+  ├── types.ts                    # ExternalEvent, extension, publisher interfaces
+  ├── external-event-service.ts   # ExternalEventService publishes externalEvent.published
+  ├── external-event-store.ts     # Persistent retry-aware source-level dedup
+  ├── external-event-task-resolver.ts # Core event -> SpaceTask enrichment
+  ├── external-event-router.ts    # Subscribes to InternalEventBus, matches, dispatches commands
+  ├── extension-manager.ts        # Global/per-space enablement + route/RPC registration
+  ├── extension-config-store.ts   # Global + per-space source config
+  ├── topic-trie.ts               # TopicTrie<T> implementation
+  ├── topic-validator.ts          # validateGlobPattern() helper
+  └── index.ts                    # Public exports
 
-packages/daemon/src/lib/space/runtime/event-adapters/github/
-  ├── github-adapter.ts        # GitHubEventAdapter — webhook/polling -> EventBus
-  ├── github-normalizer.ts     # GitHub webhook/polling normalization helpers
-  ├── github-repository.ts     # watched repo config + adapter diagnostics
+packages/daemon/src/lib/external-events/github/
+  ├── github-event-extension.ts   # GitHub webhook/polling -> ExternalEventService
+  ├── github-normalizer.ts        # GitHub webhook/polling normalization helpers
+  ├── github-repository.ts        # watched repo config + extension diagnostics
   └── index.ts
 ```
 
@@ -1932,7 +2052,7 @@ packages/daemon/src/lib/space/runtime/event-adapters/github/
  *
  * Requires exactly 4 segments because all v1 event topics have the format
  * `{source}/{scope1}/{scope2}/{resource}.{action}`. For GitHub, scope1/scope2
- * are owner/repo; for future non-repo adapters, they are source-specific scope
+ * are owner/repo; for future non-repo extensions, they are source-specific scope
  * segments such as workspace/channel.
  * Patterns like `github/*` (too shallow) or `github/*/*/pull_request/review_*`
  * (too deep) would pass validation but never match any event, creating silent
@@ -2001,7 +2121,7 @@ export function validateGlobPattern(pattern: string): { valid: boolean; reason?:
 // In SpaceRuntimeConfig, add:
 interface SpaceRuntimeConfig {
   // ... existing fields ...
-  eventRouter?: EventRouter;
+  eventRouter?: ExternalEventRouter;
 }
 
 // In SpaceRuntime.executeTick(), after node executions are resolved:
@@ -2024,86 +2144,109 @@ if (newStatus === 'done' || newStatus === 'cancelled') {
 
 // In daemon startup:
 const externalEventStore = new ExternalEventStore(db);
-const eventTaskResolver = new EventTaskResolver(db);
-const eventBus = new EventBus(daemonHub, externalEventStore, eventTaskResolver);
-const eventRouter = new EventRouter(eventBus, ...dependencies);
+const externalEventTaskResolver = new ExternalEventTaskResolver(db);
+const externalEventService = new ExternalEventService(
+  internalEventBus,
+  externalEventStore,
+  externalEventTaskResolver,
+);
+const externalEventRouter = new ExternalEventRouter(
+  internalEventBus,
+  internalCommandBus,
+  externalEventStore,
+  ...dependencies,
+);
 
-const adapterContext: EventAdapterContext = {
+const extensionContext: ExternalEventExtensionContext = {
+  publisher: externalEventService,
+  config: externalEventExtensionConfigStore,
   onSourceConfigChanged(change) {
     if (change.kind === 'watched_repo_changed') {
-      eventRouter.invalidateWatchedRepoCache(change.spaceId);
+      externalEventRouter.invalidateWatchedRepoCache(change.spaceId);
     }
   },
 };
 
-const adapters: EventAdapter[] = [
-  new GitHubEventAdapter(new GitHubEventAdapterRepository(db), process.env.GITHUB_TOKEN),
+const extensions: ExternalEventExtension[] = [
+  new GitHubEventExtension(new GitHubEventExtensionRepository(db)),
 ];
 
-for (const adapter of adapters) {
-  if ('routes' in adapter) routeRegistry.register(adapter.routes, eventBus);
-  if ('registerRpcHandlers' in adapter) adapter.registerRpcHandlers(messageHub, eventBus, adapterContext);
-  await adapter.start(eventBus);
+for (const extension of extensions) {
+  const globalConfig = await extensionContext.config.getGlobalConfig(extension.sourceId);
+  if (!globalConfig.globallyEnabled) continue;
+  if ('routes' in extension) routeRegistry.register(extension.routes, extensionContext);
+  if ('registerRpcHandlers' in extension) extension.registerRpcHandlers(messageHub, extensionContext);
+  await extension.start(extensionContext);
 }
 ```
 
-Repo-scoped matching cache invalidation is explicit: `watchRepo` changes call `EventAdapterContext.onSourceConfigChanged(...)`, and daemon startup wires that callback to `eventRouter.invalidateWatchedRepoCache(spaceId)`. This keeps source configuration owned by the adapter while ensuring `repo`-scoped subscriptions observe newly watched or unwatched repos without process restart.
+Repo-scoped matching cache invalidation is explicit: watched-resource changes call `ExternalEventExtensionContext.onSourceConfigChanged(...)`, and daemon startup wires that callback to `externalEventRouter.invalidateWatchedRepoCache(spaceId)`. This keeps source configuration owned by the extension while ensuring `repo`-scoped subscriptions observe newly watched or unwatched repos without process restart.
 
 ### Phased rollout
 
 **Phase 1 (target MVP):**
 - Add `EventInterest` type to `WorkflowNodeAgent`.
-- Implement `EventBus`, `ExternalEventStore`, `EventTaskResolver`, `TopicTrie`, and `EventRouter`.
-- Extract `GitHubEventAdapter` as the primary GitHub event source (webhook + polling + normalization).
-- Route GitHub PR events directly through EventBus to node sessions with `task` scope.
+- Implement `ExternalEventService`, `ExternalEventStore`, `ExternalEventTaskResolver`, `TopicTrie`, and `ExternalEventRouter`.
+- Implement `ExternalEventExtension` interfaces and a minimal extension manager/config store.
+- Extract `GitHubEventExtension` as the primary GitHub event source (webhook + polling + normalization).
+- Add global GitHub enablement and per-space GitHub enablement/watched-repo configuration.
+- Route GitHub PR events through `ExternalEventService` → `InternalEventBus` → `ExternalEventRouter` → `InternalCommandBus` with `task` scope.
 - Keep `SpaceGitHubService` only as a compatibility path while parity is verified.
-- No UI changes needed — event interests are authored in workflow JSON.
+- No UI changes needed for node subscriptions — event interests are authored in workflow JSON. Basic config can be exposed through existing/admin RPCs first.
 
 **Phase 2 (compatibility removal):**
 - Remove direct Task Agent notification delivery from `SpaceGitHubService` (`scheduleTaskNotification` / `flushTaskNotification`).
-- Migrate remaining `space.github.*` RPC handling into `GitHubEventAdapter`.
+- Migrate remaining `space.github.*` RPC handling into `GitHubEventExtension` or generic external-source config APIs.
 - Remove dependence on `space.githubEvent.routed` for external event delivery.
 - Add persistent per-node delivery queue if restart-safe pending-node delivery is required.
 
 **Phase 3 (future extensibility):**
-- Slack adapter: subscribe to Slack Events API, normalize to `ExternalEvent`, publish.
-- CI adapter: subscribe to GitHub Check Suite or other CI events, normalize, publish.
-- Custom adapter API: allow Space operators to register custom adapters via config.
+- Slack extension: subscribe to Slack Events API, normalize to `ExternalEvent`, publish.
+- Jira extension: subscribe to issue/project webhooks, normalize to `ExternalEvent`, publish.
+- CI extension: subscribe to GitHub Check Suite or other CI events, normalize, publish.
+- Custom extension API: allow Space operators to register custom extensions via global/per-space config.
+- UI for global and per-space extension enablement/configuration.
 
 ## 9. Relationship to Existing Systems
 
 | Existing system | Relationship |
 |---|---|
-| **DaemonHub / TypedHub** | `EventBus` is a TypedHub participant on the shared `InProcessTransportBus`. It publishes all external events through the fixed valid method `space.externalEvent.published`; slash-delimited external topics stay in `ExternalEvent.topic` and are matched by the router trie. |
+| **InternalEventBus** | Carries the internal fact `externalEvent.published`. It does not persist external events; durability remains in `ExternalEventStore`. |
+| **InternalCommandBus** | Owns the `agent.message.inject` command used by `ExternalEventRouter` to request delivery into an agent session. |
+| **MessageHub** | Remains client/RPC transport infrastructure for extension configuration RPCs and client delivery; it is not the external-event domain bus. |
 | **GitHubService** (Room pipeline) | Unchanged for Room compatibility. It is not the source for Space workflow-node events. |
-| **SpaceGitHubService** (legacy Space pipeline) | Deprecated compatibility path. Its source-specific normalization/polling logic is extracted into `GitHubEventAdapter`; task resolution and delivery move to EventBus/EventRouter. The bus must not depend on `space.githubEvent.routed`. |
-| **GitHubEventAdapter** | Source extension that owns GitHub webhook verification, polling, normalization, watched-repo configuration, and direct publication to EventBus. It does not query Space tasks or inject sessions. |
-| **ExternalEventStore** | Core bus persistence and retry-aware source-level dedup across adapters. Replaces GitHub-specific unconditional duplicate short-circuiting for new delivery. |
-| **EventTaskResolver** | Core enrichment service that maps events to Space tasks where possible (e.g. GitHub PR → task). Keeps task/gate/workflow schema access out of adapters. |
-| **SessionNotificationSink** | The event bus uses the same `sessionFactory.injectMessage()` with `deliveryMode: 'defer'` pattern. |
-| **AgentMessageRouter** | Not used for event delivery. Events are injected directly via `sessionFactory.injectMessage()`, not via the agent-to-agent messaging channel. Events are not agent-originated messages — they're system-injected context. |
-| **ChannelRouter** | Not involved. Event delivery is not a workflow channel transition. It's an injection into an existing session, not an activation trigger. |
+| **SpaceGitHubService** (legacy Space pipeline) | Deprecated compatibility path. Its source-specific normalization/polling logic is extracted into `GitHubEventExtension`; task resolution and delivery move to `ExternalEventService`/`ExternalEventRouter`. The new path must not depend on `space.githubEvent.routed`. |
+| **GitHubEventExtension** | Source extension that owns GitHub webhook verification, polling, normalization, global/per-space enablement, watched-repo configuration, and direct publication to `ExternalEventService`. It does not query Space tasks or inject sessions. |
+| **ExternalEventStore** | Core persistence and retry-aware source-level dedup across extensions. Replaces GitHub-specific unconditional duplicate short-circuiting for new delivery. |
+| **ExternalEventTaskResolver** | Core enrichment service that maps events to Space tasks where possible (e.g. GitHub PR → task). Keeps task/gate/workflow schema access out of extensions. |
+| **SessionNotificationSink** | Compatibility notification path for existing Space Agent notifications. External event delivery should move to `InternalCommandBus.dispatch('agent.message.inject', ...)`. |
+| **AgentMessageRouter** | Not used for event delivery. Events are system-injected context, not agent-originated messages. |
+| **ChannelRouter** | Not involved. Event delivery is not a workflow channel transition. It is delivery into an existing/queued agent session, not a graph activation trigger. |
 
 ## 10. Key Design Decisions
 
-### Why TypedHub and not a standalone EventEmitter?
+### Why InternalEventBus instead of a source-specific hub?
 
-TypedHub provides:
-- Async-everywhere design (cluster-ready).
-- Session-scoped subscriptions (O(1) lookup).
-- Already wired into the daemon's lifecycle.
-- No new dependency.
+The broader messaging refactor introduces `InternalEventBus` as the daemon-side semantic event layer. External source events should use that layer instead of introducing another generic bus or making GitHub own delivery semantics.
 
-Using TypedHub as the backing transport means the EventBus inherits all of these properties for free. The bus does **not** use external topic strings as TypedHub method names: raw topics contain `/` and glob `*`, which violate MessageHub method validation. Instead, EventBus publishes every external event under the fixed valid method `space.externalEvent.published` and places the external topic in `ExternalEvent.topic` for trie matching.
+Using `InternalEventBus` means:
 
-### Why not route through AgentMessageRouter?
+- `externalEvent.published` is a normal internal fact, not a raw external topic.
+- External slash/glob topics stay in `ExternalEvent.topic` and are matched by `ExternalEventRouter`.
+- Publish semantics and handler failure observability come from the shared internal event layer.
+- Client delivery, state projection, audit, metrics, and agent notification can subscribe independently.
+- The external-event subsystem owns durability through `ExternalEventStore`; the internal bus itself does not become a persistence/replay layer.
 
-AgentMessageRouter is designed for agent-to-agent communication with channel topology authorization. External events are system-injected context, not agent messages. Routing them through AgentMessageRouter would:
-- Require topology changes (events don't come from a declared node).
-- Conflate system events with agent-to-agent messages in the message history.
-- Add unnecessary authorization overhead.
+This keeps GitHub as an extension and keeps routing/delivery behavior in reusable core services.
 
-Direct injection via `sessionFactory.injectMessage()` is simpler and semantically correct.
+### Why deliver through `agent.message.inject` instead of AgentMessageRouter?
+
+AgentMessageRouter is designed for agent-to-agent communication with channel topology authorization. External events are system-injected context, not agent-originated messages. Routing them through AgentMessageRouter would:
+- Require topology changes because events do not come from a declared workflow node.
+- Conflate system events with peer agent messages in the message history.
+- Add unnecessary channel authorization overhead.
+
+The target design uses `InternalCommandBus.dispatch('agent.message.inject', ...)` so delivery remains explicit, testable, and observable without giving external extensions direct access to session injection. The command handler can still use the existing `sessionFactory.injectMessage(..., { deliveryMode: 'defer' })` mechanism under the hood.
 
 ### Why trie-based matching instead of regex?
 
@@ -2116,12 +2259,12 @@ Direct injection via `sessionFactory.injectMessage()` is simpler and semanticall
 `SpaceGitHubService` currently mixes four responsibilities in one class: GitHub source ingestion, source-level dedup, PR-to-task resolution, and Task Agent session injection. Extending it would preserve the same coupling and keep the event bus downstream of an already-routed delivery pipeline.
 
 The target architecture splits those responsibilities:
-- `GitHubEventAdapter` owns only GitHub-specific webhook/polling/normalization.
+- `GitHubEventExtension` owns only GitHub-specific webhook/polling/normalization/configuration.
 - `ExternalEventStore` owns cross-source event lifecycle and retry-aware dedup.
-- `EventTaskResolver` owns Space task enrichment.
-- `EventRouter` owns node subscription matching and session delivery.
+- `ExternalEventTaskResolver` owns Space task enrichment.
+- `ExternalEventRouter` owns node subscription matching and command-based delivery.
 
-This makes GitHub one adapter among many instead of a special core daemon path. Future adapters (Slack, CI, etc.) publish the same `ExternalEvent` shape and reuse the same dedup, task enrichment, and delivery machinery.
+This makes GitHub one extension among many instead of a special core daemon path. Future extensions (Slack, Jira, CI, etc.) publish the same `ExternalEvent` shape and reuse the same dedup, task enrichment, and delivery machinery.
 
 ### Why `deliveryMode: 'defer'` for event injection?
 
@@ -2137,15 +2280,15 @@ This is exactly the behavior we want for external events.
 ### Unit tests
 
 1. **TopicTrie**: Insert patterns, verify lookup returns correct values for exact and wildcard matches.
-2. **EventRouter**: Given subscriptions and events, verify scope filtering, topic validation before trie insertion, dedup, and delivery.
+2. **ExternalEventRouter**: Given subscriptions and events, verify scope filtering, topic validation before trie insertion, dedup, and delivery.
 3. **ExternalEventStore**: Verify terminal duplicates are short-circuited, retryable duplicates are re-emitted, expected deliveries are registered before injection, successful per-subscription delivery advances the source event to terminal `delivered` only after all expected deliveries are terminal, and retry exhaustion advances to terminal `failed`.
-4. **EventTaskResolver**: Given GitHub PR metadata, verify correct task enrichment and ambiguous/unknown states.
-5. **GitHubEventAdapter**: Given webhook and polling payloads, verify signature handling, topic construction, dedupe keys, and `ExternalEvent` construction without querying Space tasks.
+4. **ExternalEventTaskResolver**: Given GitHub PR metadata, verify correct task enrichment and ambiguous/unknown states.
+5. **GitHubEventExtension**: Given webhook and polling payloads, verify enablement checks, signature handling, topic construction, dedupe keys, and `ExternalEvent` construction without querying Space tasks.
 6. **Scope resolution**: Test `task` scope with enriched `routedTaskId` and various task/PR associations.
 
 ### Integration tests
 
-1. **End-to-end webhook flow**: POST a GitHub webhook payload to the adapter route with a `review_submitted` action for PR #42 on repo `lsm/neokai`. Verify the adapter publishes `github/lsm/neokai/pull_request.review_submitted`, `EventTaskResolver` enriches it with the matching task, and the coder node's `task`-scoped subscription receives an injected message.
+1. **End-to-end webhook flow**: POST a GitHub webhook payload to the extension route with a `review_submitted` action for PR #42 on repo `lsm/neokai`. Verify the extension publishes `github/lsm/neokai/pull_request.review_submitted`, `ExternalEventTaskResolver` enriches it with the matching task, and the coder node's `task`-scoped subscription receives an injected message.
 
 2. **Dedup across two events with same dedupeKey**: Publish the same GitHub PR review through webhook and polling (identical `dedupeKey`). Verify source-level bus dedup does not create two independent events, and per-subscription delivery dedup calls `injectMessage` exactly once for each interested node. Also verify retryable duplicate states re-emit after a simulated injection failure.
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -503,24 +503,42 @@ class GitHubEventExtension implements HttpExternalEventExtension, RpcExternalEve
   ] as const;
 
   private context?: ExternalEventExtensionContext;
-  private pollTimer?: ReturnType<typeof setInterval>;
+  private pollTimer?: ReturnType<typeof setTimeout>;
+  private stopped = false;
 
   async start(context: ExternalEventExtensionContext): Promise<void> {
     this.context = context;
+    this.stopped = false;
     const global = await context.config.getGlobalConfig(this.sourceId);
     if (!global.globallyEnabled || !global.capabilities.polling) return;
 
-    this.pollTimer = setInterval(() => {
-      void this.pollEnabledSpaces().catch((err) => {
-        log.warn('GitHubEventExtension: polling failed', {
-          error: err instanceof Error ? err.message : String(err),
-        });
-      });
-    }, GITHUB_POLL_INTERVAL_MS);
+    // Use completion-scheduled polling instead of setInterval so a slow poll cycle
+    // cannot overlap the next one and amplify duplicate fetches/rate-limit pressure.
+    this.scheduleNextPoll();
   }
 
   async stop(): Promise<void> {
-    if (this.pollTimer) clearInterval(this.pollTimer);
+    this.stopped = true;
+    if (this.pollTimer) clearTimeout(this.pollTimer);
+  }
+
+  private scheduleNextPoll(): void {
+    if (this.stopped) return;
+    this.pollTimer = setTimeout(() => {
+      void this.runPollCycle();
+    }, GITHUB_POLL_INTERVAL_MS);
+  }
+
+  private async runPollCycle(): Promise<void> {
+    try {
+      await this.pollEnabledSpaces();
+    } catch (err) {
+      log.warn('GitHubEventExtension: polling failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      this.scheduleNextPoll();
+    }
   }
 
   registerRpcHandlers(hub: MessageHub, context: ExternalEventExtensionContext): void {
@@ -553,7 +571,17 @@ class GitHubEventExtension implements HttpExternalEventExtension, RpcExternalEve
     }
 
     const raw = await req.text();
-    const normalized = normalizeGitHubWebhook(req.headers, JSON.parse(raw));
+    let payload: unknown;
+    try {
+      payload = JSON.parse(raw);
+    } catch (err) {
+      log.warn('GitHubEventExtension: invalid webhook JSON', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return Response.json({ ignored: true, reason: 'invalid_json' }, { status: 400 });
+    }
+
+    const normalized = normalizeGitHubWebhook(req.headers, payload);
     if (!normalized) return Response.json({ ignored: true });
 
     const targetSpaces = await this.resolveEnabledSpacesForWebhook(context, req, raw, normalized);

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -690,6 +690,25 @@ class EventRouter {
     return JSON.stringify([sub.workflowRunId, sub.taskId, sub.nodeId, sub.agentName]);
   }
 
+  private parseDeliveryKey(key: string): {
+    source: string;
+    dedupeKey: string;
+    taskId: string;
+    nodeId: string;
+    agentName: string;
+    workflowRunId: string;
+  } {
+    const [source, dedupeKey, taskId, nodeId, agentName, workflowRunId] = JSON.parse(key) as [
+      string,
+      string,
+      string,
+      string,
+      string,
+      string,
+    ];
+    return { source, dedupeKey, taskId, nodeId, agentName, workflowRunId };
+  }
+
   /** Evict stale dedup entries (called periodically or on demand). */
   private evictStaleDedup(): void {
     const cutoff = Date.now() - EventRouter.DEDUP_TTL_MS;
@@ -862,24 +881,24 @@ class EventRouter {
     this.markQueuedDeliveriesFailed(queuedFailures);
 
     for (const key of this.pendingDeliveries.keys()) {
-      const [, keyTaskId, keyNodeId, keyAgentName, keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string, string];
+      const parsed = this.parseDeliveryKey(key);
       if (
-        keyWorkflowRunId === workflowRunId
-        && keyTaskId === taskId
-        && keyNodeId === nodeId
-        && keyAgentName === agentName
+        parsed.workflowRunId === workflowRunId
+        && parsed.taskId === taskId
+        && parsed.nodeId === nodeId
+        && parsed.agentName === agentName
       ) {
         this.pendingDeliveries.delete(key);
       }
     }
 
     for (const key of this.retryCounts.keys()) {
-      const [, keyTaskId, keyNodeId, keyAgentName, keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string, string];
+      const parsed = this.parseDeliveryKey(key);
       if (
-        keyWorkflowRunId === workflowRunId
-        && keyTaskId === taskId
-        && keyNodeId === nodeId
-        && keyAgentName === agentName
+        parsed.workflowRunId === workflowRunId
+        && parsed.taskId === taskId
+        && parsed.nodeId === nodeId
+        && parsed.agentName === agentName
       ) {
         this.retryCounts.delete(key);
       }
@@ -887,12 +906,12 @@ class EventRouter {
 
     const retryFailures: QueuedDeliveryFailure[] = [];
     for (const [key, timer] of this.retryTimers.entries()) {
-      const [, keyTaskId, keyNodeId, keyAgentName, keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string, string];
+      const parsed = this.parseDeliveryKey(key);
       if (
-        keyWorkflowRunId === workflowRunId
-        && keyTaskId === taskId
-        && keyNodeId === nodeId
-        && keyAgentName === agentName
+        parsed.workflowRunId === workflowRunId
+        && parsed.taskId === taskId
+        && parsed.nodeId === nodeId
+        && parsed.agentName === agentName
       ) {
         clearTimeout(timer);
         this.retryTimers.delete(key);
@@ -923,8 +942,8 @@ class EventRouter {
     // Also clean up dedup entries for this run. Keys are JSON tuples, so parse
     // structurally rather than suffix-matching delimiter-joined strings.
     for (const key of this.delivered.keys()) {
-      const [, , , , keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string, string];
-      if (keyWorkflowRunId === workflowRunId) {
+      const parsed = this.parseDeliveryKey(key);
+      if (parsed.workflowRunId === workflowRunId) {
         this.delivered.delete(key);
       }
     }
@@ -950,16 +969,18 @@ class EventRouter {
     this.markQueuedDeliveriesFailed(terminalQueueFailures);
 
     // Clean up pending deliveries and retry counts for this run.
-    // Delivery keys are JSON tuples: [dedupeKey, taskId, nodeId, agentName, workflowRunId]
+    // Delivery keys are JSON tuples:
+    // [source, dedupeKey, taskId, nodeId, agentName, workflowRunId]. Always parse
+    // through parseDeliveryKey so cleanup stays aligned with makeDeliveryKey.
     for (const key of this.pendingDeliveries.keys()) {
-      const [, , , , keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string, string];
-      if (keyWorkflowRunId === workflowRunId) {
+      const parsed = this.parseDeliveryKey(key);
+      if (parsed.workflowRunId === workflowRunId) {
         this.pendingDeliveries.delete(key);
       }
     }
     for (const key of this.retryCounts.keys()) {
-      const [, , , , keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string, string];
-      if (keyWorkflowRunId === workflowRunId) {
+      const parsed = this.parseDeliveryKey(key);
+      if (parsed.workflowRunId === workflowRunId) {
         this.retryCounts.delete(key);
       }
     }
@@ -968,8 +989,8 @@ class EventRouter {
     // dropping retry bookkeeping; otherwise their rows can block event terminalization.
     const retryCancellationFailures: QueuedDeliveryFailure[] = [];
     for (const [key, timer] of this.retryTimers.entries()) {
-      const [, , , , keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string, string];
-      if (keyWorkflowRunId === workflowRunId) {
+      const parsed = this.parseDeliveryKey(key);
+      if (parsed.workflowRunId === workflowRunId) {
         clearTimeout(timer);
         this.retryTimers.delete(key);
         retryCancellationFailures.push({

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -712,7 +712,9 @@ class ExternalEventRouter {
   private static readonly RETRY_BACKOFF_MS = 1000; // 1s base, exponential backoff
 
   // Cache: spaceId → Set of "owner/repo" strings for watched repos.
-  // Invalidated when a source extension reports watched-repo configuration changes.
+  // Invalidated when a source extension reports watched-repo configuration
+  // changes, including space-level enable/disable transitions that can change
+  // which repos are eligible for repo-scoped routing.
   private watchedRepoCache: Map<string, Set<string>> = new Map();
 
   constructor(
@@ -759,8 +761,9 @@ class ExternalEventRouter {
   /**
    * Invalidate the watched-repo cache for a given space (or all spaces).
    * Called from ExternalEventExtensionContext.onSourceConfigChanged when a source extension
-   * changes watched-repo configuration (for example `space.github.watchRepo`).
-   * Without this, `repo`-scoped matching grows stale until process restart.
+   * changes watched-repo configuration or space-level source enablement.
+   * Without this, `repo`-scoped matching can use stale enabled/watched repo sets
+   * until process restart or a later watch mutation.
    */
   invalidateWatchedRepoCache(spaceId?: string): void {
     if (spaceId) {
@@ -2181,7 +2184,11 @@ const extensionContext: ExternalEventExtensionContext = {
   publisher: externalEventService,
   config: externalEventExtensionConfigStore,
   onSourceConfigChanged(change) {
-    if (change.kind === 'watched_repo_changed') {
+    if (change.source === 'github' && [
+      'watched_repo_changed',
+      'space_enabled',
+      'space_disabled',
+    ].includes(change.kind)) {
       externalEventRouter.invalidateWatchedRepoCache(change.spaceId);
     }
   },
@@ -2200,7 +2207,7 @@ for (const extension of extensions) {
 }
 ```
 
-Repo-scoped matching cache invalidation is explicit: watched-resource changes call `ExternalEventExtensionContext.onSourceConfigChanged(...)`, and daemon startup wires that callback to `externalEventRouter.invalidateWatchedRepoCache(spaceId)`. This keeps source configuration owned by the extension while ensuring `repo`-scoped subscriptions observe newly watched or unwatched repos without process restart.
+Repo-scoped matching cache invalidation is explicit: watched-resource changes and per-space source enable/disable transitions call `ExternalEventExtensionContext.onSourceConfigChanged(...)`, and daemon startup wires those GitHub change kinds to `externalEventRouter.invalidateWatchedRepoCache(spaceId)`. This keeps source configuration owned by the extension while ensuring `repo`-scoped subscriptions observe newly watched, unwatched, disabled, or re-enabled repos without process restart.
 
 ### Phased rollout
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -347,6 +347,7 @@ export interface ExternalEventStore {
   markEventDeliveredIfAllDeliveriesTerminal(eventId: string): void;
   markEventFailedIfAllDeliveriesTerminal(eventId: string): void;
   markEventFailed(eventId: string, failure: { terminal: boolean; reason: string }): void;
+  markEventIgnored(eventId: string, reason: 'no_matching_subscriptions' | 'no_scope_eligible_subscriptions'): void;
 }
 
 export interface EventTaskResolver {
@@ -1010,7 +1011,10 @@ class EventRouter {
   }
 
   private async handleEventForSubscriptions(event: ExternalEvent, matched: Subscription[]): Promise<boolean> {
-    if (matched.length === 0) return true;
+    if (matched.length === 0) {
+      this.eventStore.markEventIgnored(event.id, 'no_matching_subscriptions');
+      return true;
+    }
 
     // 2. First compute all scoped deliveries and persist them as expected
     // pending deliveries before attempting injection. This prevents the first
@@ -1058,6 +1062,15 @@ class EventRouter {
     // failed subscription was never registered. The retry path will re-run matching,
     // scope checks, and expected-delivery registration for the whole event.
     if (preparationFailed) return false;
+
+    // No prepared, non-terminal delivery remains for this event. Mark the source
+    // event terminal so retryable source duplicates (webhook + polling, adapter
+    // retries, etc.) do not re-emit and re-route indefinitely when every matched
+    // subscription is out of scope or already terminal.
+    if (eligible.length === 0) {
+      this.eventStore.markEventIgnored(event.id, 'no_scope_eligible_subscriptions');
+      return true;
+    }
 
     // 3. Deliver each prepared subscription. Isolate injection failures per
     // subscription after the complete expected-delivery set has been registered.
@@ -1463,7 +1476,7 @@ Dedup happens at two different layers, each with a different key and responsibil
    - The tuple is encoded structurally rather than delimiter-joined because `dedupeKey`, workflow identifiers, node IDs, and agent names are free-form strings.
    - It is tracked in-memory for fast duplicate suppression and persisted in `space_external_event_deliveries` after successful injection.
 
-The EventRouter marks per-subscription delivery as `delivered` only after successful injection, updates `ExternalEventStore` with the successful delivery key, and advances the source event to terminal `delivered` only once all expected deliveries are terminal. Failed injection/session-resolution paths remove `pendingDeliveries` and schedule retry rather than relying on adapters to re-publish the same event.
+The EventRouter marks per-subscription delivery as `delivered` only after successful injection, updates `ExternalEventStore` with the successful delivery key, and advances the source event to terminal `delivered` only once all expected deliveries are terminal. Failed injection/session-resolution paths remove `pendingDeliveries` and schedule retry rather than relying on adapters to re-publish the same event. If trie lookup finds no matching subscriptions, or if all matched subscriptions are out of scope/already terminal and no preparation retry is pending, the router marks the source event terminal `ignored` so webhook+polling duplicates do not churn through routing forever.
 
 ### Wake-on-idle
 
@@ -1813,7 +1826,7 @@ V1 needs one core event-store table plus workflow type additions:
    );
    ```
 
-   `state` values are `published`, `routed`, `delivered`, `delivery_failed`, `failed`, `ignored`, and `ambiguous`. Duplicate handling depends on state: terminal states (`delivered`, `failed`, `ignored`, `ambiguous`) short-circuit; retryable states can re-emit. `delivered` is written only after expected per-subscription deliveries are terminal, and `failed` is written only after retry budgets are exhausted for all retryable deliveries.
+   `state` values are `published`, `routed`, `delivered`, `delivery_failed`, `failed`, `ignored`, and `ambiguous`. Duplicate handling depends on state: terminal states (`delivered`, `failed`, `ignored`, `ambiguous`) short-circuit; retryable states can re-emit. `delivered` is written only after expected per-subscription deliveries are terminal, `failed` is written only after retry budgets are exhausted for all retryable deliveries, and `ignored` is written when routing finds no matching subscriptions or no eligible non-terminal delivery after scope checks.
 
 2. **Core bus delivery store** (`space_external_event_deliveries`): persistent per-subscription delivery lifecycle used by EventRouter to advance source events to terminal delivered.
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -416,7 +416,8 @@ export interface ExternalEventStore {
     deliveryKey: string,
     failure: { terminal: boolean; reason: string },
   ): void;
-  markEventDeliveredIfAllDeliveriesTerminal(eventId: string): void;
+  markEventDeliveredIfAllDeliveriesDelivered(eventId: string): void;
+  markEventFailedIfAnyDeliveryTerminalFailed(eventId: string): void;
   markEventFailedIfAllDeliveriesTerminal(eventId: string): void;
   markEventFailed(eventId: string, failure: { terminal: boolean; reason: string }): void;
   markEventIgnored(eventId: string, reason: 'no_matching_subscriptions' | 'no_scope_eligible_subscriptions'): void;
@@ -1297,12 +1298,13 @@ class ExternalEventRouter {
     }
 
     // Success: mark as delivered both in-memory and persistently, then advance
-    // the source event to terminal delivered only when all expected per-subscription
-    // deliveries are terminal. This keeps source-level dedup from re-emitting
-    // already-delivered events after restart/TTL expiry.
+    // the source event to terminal delivered only when every expected
+    // per-subscription delivery succeeded. Terminal failures must keep the source
+    // event in a failed outcome rather than being masked by later successes.
     this.delivered.set(dedupeKey, Date.now());
     this.config.eventStore.markDeliveryDelivered(event.id, dedupeKey);
-    this.config.eventStore.markEventDeliveredIfAllDeliveriesTerminal(event.id);
+    this.config.eventStore.markEventFailedIfAnyDeliveryTerminalFailed(event.id);
+    this.config.eventStore.markEventDeliveredIfAllDeliveriesDelivered(event.id);
     this.pendingDeliveries.delete(dedupeKey);
   }
 
@@ -1621,7 +1623,7 @@ Dedup happens at two different layers, each with a different key and responsibil
    - The tuple is encoded structurally rather than delimiter-joined because `source`, `dedupeKey`, workflow identifiers, node IDs, and agent names are free-form strings.
    - It is tracked in-memory for fast duplicate suppression and persisted in `space_external_event_deliveries` after successful injection.
 
-The ExternalEventRouter marks per-subscription delivery as `delivered` only after successful injection, updates `ExternalEventStore` with the successful delivery key, and advances the source event to terminal `delivered` only once all expected deliveries are terminal. Failed injection/session-resolution paths remove `pendingDeliveries` and schedule retry rather than relying on adapters to re-publish the same event. If trie lookup finds no matching subscriptions, or if all matched subscriptions are out of scope/already terminal and no preparation retry is pending, the router marks the source event terminal `ignored` so webhook+polling duplicates do not churn through routing forever.
+The ExternalEventRouter marks per-subscription delivery as `delivered` only after successful injection, updates `ExternalEventStore` with the successful delivery key, and advances the source event to terminal `delivered` only once all expected deliveries are `delivered`. Failed injection/session-resolution paths remove `pendingDeliveries` and schedule retry rather than relying on extensions to re-publish the same event. If a delivery reaches terminal `failed`, the source event must be `failed` rather than later reclassified as `delivered` by another subscription's success. If trie lookup finds no matching subscriptions, or if all matched subscriptions are out of scope/already terminal and no preparation retry is pending, the router marks the source event terminal `ignored` so webhook+polling duplicates do not churn through routing forever.
 
 ### Wake-on-idle
 
@@ -1660,7 +1662,7 @@ When a node execution is `pending` (no session yet):
 
 1. The event is queued in an in-memory `Map<string, ExternalEvent[]>` keyed by a JSON tuple `[workflowRunId, taskId, nodeId, agentName]` so free-form identifiers cannot collide by containing delimiter characters.
 2. When `TaskAgentManager` creates the node's session, it calls `eventRouter.flushQueuedDeliveriesForSession(sub, sessionId)`.
-3. Queued events are injected through the same prepared-delivery path as live events, so successful flush marks the per-subscription delivery delivered and advances the source event only when all expected deliveries are terminal.
+3. Queued events are injected through the same prepared-delivery path as live events, so successful flush marks the per-subscription delivery delivered and advances the source event only when all expected deliveries are delivered.
 4. If flush injection fails, the router clears the stale pending marker and schedules a normal delivery retry so the queued event is not silently lost.
 5. Queue is bounded: max 50 events per execution, oldest dropped (with a warning log). Because expected delivery rows are registered before queueing, overflow eviction must call `markDeliveryFailed(..., { terminal: true, reason: 'pending_queue_overflow' })` and then `markEventFailedIfAllDeliveriesTerminal(event.id)`; otherwise the evicted delivery row can block event terminalization forever.
 
@@ -1973,9 +1975,9 @@ V1 needs core event lifecycle tables, extension configuration storage, and workf
    );
    ```
 
-   `state` values are `published`, `routed`, `delivered`, `delivery_failed`, `failed`, `ignored`, and `ambiguous`. Duplicate handling depends on state: terminal states (`delivered`, `failed`, `ignored`, `ambiguous`) short-circuit; retryable states can re-emit. `delivered` is written only after expected per-subscription deliveries are terminal, `failed` is written only after retry budgets are exhausted for all retryable deliveries, and `ignored` is written when routing finds no matching subscriptions or no eligible non-terminal delivery after scope checks.
+   `state` values are `published`, `routed`, `delivered`, `delivery_failed`, `failed`, `ignored`, and `ambiguous`. Duplicate handling depends on state: terminal states (`delivered`, `failed`, `ignored`, `ambiguous`) short-circuit; retryable states can re-emit. `delivered` is written only after every expected per-subscription delivery is `delivered`; terminal delivery failures must instead move or keep the source event in `failed` so later successful deliveries cannot mask partial failure. `failed` is written after any delivery reaches terminal failure, or after retry budgets are exhausted for all retryable deliveries, and `ignored` is written when routing finds no matching subscriptions or no eligible non-terminal delivery after scope checks.
 
-2. **Core bus delivery store** (`space_external_event_deliveries`): persistent per-subscription delivery lifecycle used by ExternalEventRouter to advance source events to terminal delivered.
+2. **Core bus delivery store** (`space_external_event_deliveries`): persistent per-subscription delivery lifecycle used by ExternalEventRouter to advance source events to terminal delivered only when every expected delivery succeeds.
 
    ```sql
    CREATE TABLE space_external_event_deliveries (
@@ -1992,7 +1994,7 @@ V1 needs core event lifecycle tables, extension configuration storage, and workf
    );
    ```
 
-   `ExternalEventRouter` calls `registerExpectedDelivery(...)` for every scope-matched subscription before attempting any injection. This registration must be idempotent for the `(event_id, delivery_key)` primary key: use `INSERT OR IGNORE`, `ON CONFLICT DO NOTHING`, or an equivalent upsert that never downgrades an existing terminal row. Retryable source duplicates and router retries can prepare the same delivery more than once, so duplicate expected-delivery rows are normal and must not become preparation failures. After idempotent registration, the router skips already-terminal delivery rows and only attempts pending/retryable rows. It then records `delivered` after successful `injectMessage` and calls `markEventDeliveredIfAllDeliveriesTerminal(event.id)` so source-level dedup can stop re-emitting already-delivered events after restart or in-memory TTL eviction. When retry budget is exhausted, pending-node queue overflow evicts an expected delivery, node cancellation removes queued/retrying deliveries, a retry fires for an inactive subscription, terminal run cleanup drops queued deliveries, or terminal run cleanup cancels per-delivery retry timers, the router records terminal delivery failure and calls `markEventFailedIfAllDeliveriesTerminal(event.id)` so duplicate source observations do not restart an exhausted or impossible delivery.
+   `ExternalEventRouter` calls `registerExpectedDelivery(...)` for every scope-matched subscription before attempting any injection. This registration must be idempotent for the `(event_id, delivery_key)` primary key: use `INSERT OR IGNORE`, `ON CONFLICT DO NOTHING`, or an equivalent upsert that never downgrades an existing terminal row. Retryable source duplicates and router retries can prepare the same delivery more than once, so duplicate expected-delivery rows are normal and must not become preparation failures. After idempotent registration, the router skips already-terminal delivery rows and only attempts pending/retryable rows. It then records `delivered` after successful command-bus injection and calls `markEventDeliveredIfAllDeliveriesDelivered(event.id)` so source-level dedup can stop re-emitting fully delivered events after restart or in-memory TTL eviction. That transition must check for all expected delivery rows being `delivered`, not merely terminal; if any delivery row is terminal `failed`, `markEventFailedIfAnyDeliveryTerminalFailed(event.id)` keeps the source event failed and prevents a later successful subscription from incorrectly reclassifying the source event as delivered. When retry budget is exhausted, pending-node queue overflow evicts an expected delivery, node cancellation removes queued/retrying deliveries, a retry fires for an inactive subscription, terminal run cleanup drops queued deliveries, or terminal run cleanup cancels per-delivery retry timers, the router records terminal delivery failure and calls `markEventFailedIfAllDeliveriesTerminal(event.id)` so duplicate source observations do not restart an exhausted or impossible delivery.
 
 3. **Extension configuration**: store global and per-space source configuration so sources can be enabled/disabled and configured independently.
 
@@ -2299,7 +2301,7 @@ This is exactly the behavior we want for external events.
 
 1. **TopicTrie**: Insert patterns, verify lookup returns correct values for exact and wildcard matches.
 2. **ExternalEventRouter**: Given subscriptions and events, verify scope filtering, topic validation before trie insertion, dedup, and delivery.
-3. **ExternalEventStore**: Verify terminal duplicates are short-circuited, retryable duplicates are re-emitted, expected deliveries are registered before injection, successful per-subscription delivery advances the source event to terminal `delivered` only after all expected deliveries are terminal, and retry exhaustion advances to terminal `failed`.
+3. **ExternalEventStore**: Verify terminal duplicates are short-circuited, retryable duplicates are re-emitted, expected deliveries are registered before injection, successful per-subscription delivery advances the source event to terminal `delivered` only after all expected deliveries are `delivered`, any terminal per-subscription failure prevents/reverts a delivered outcome and marks the source event `failed`, and retry exhaustion advances to terminal `failed`.
 4. **ExternalEventTaskResolver**: Given GitHub PR metadata, verify correct task enrichment and ambiguous/unknown states.
 5. **GitHubEventExtension**: Given webhook and polling payloads, verify enablement checks, signature handling, topic construction, dedupe keys, and `ExternalEvent` construction without querying Space tasks.
 6. **Scope resolution**: Test `task` scope with enriched `routedTaskId` and various task/PR associations.

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -576,6 +576,12 @@ interface QueuedDeliveryFailure {
 
 interface EventRetryState {
   event: ExternalEvent;
+  /**
+   * Last matched subscriptions are retained only for lifecycle cleanup/reschedule
+   * when a run terminates while a preparation retry is pending. The retry timer
+   * must recompute current matches from the trie before preparing delivery so it
+   * never targets subscriptions removed or changed after the retry was scheduled.
+   */
   matched: Subscription[];
 }
 
@@ -1329,7 +1335,14 @@ class EventRouter {
     const timer = setTimeout(() => {
       this.eventRetryTimers.delete(retryKey);
       const retryState = this.eventRetryState.get(retryKey) ?? { event, matched };
-      void this.handleEventForSubscriptions(retryState.event, retryState.matched)
+      // Recompute against the current trie/active subscription set at retry time.
+      // The originally matched subscriptions may have been removed or changed by
+      // unregisterExecution(), clearRunInterests(), or a tick diff refresh while the
+      // timer was waiting. Reusing them would recreate queue/retry state for nodes
+      // that are no longer subscribed and could register delivery rows that should
+      // not exist.
+      const currentMatched = this.topicTrie.lookup(retryState.event.topic);
+      void this.handleEventForSubscriptions(retryState.event, currentMatched)
         .then((prepared) => {
           if (!prepared) {
             // handleEventForSubscriptions scheduled the next preparation retry.
@@ -1507,7 +1520,7 @@ When a workflow run transitions to `done` or `cancelled`, `clearRunInterests(wor
 4. Only then delete the in-memory queue, pending markers, retry counts, and timers.
 5. Event-level preparation retries can span multiple workflow runs. If one run terminates while others remain active, cancel the old shared timer and reschedule a retry for the surviving matched subscriptions with the existing retry count. Cancel without rescheduling only when no matched runs remain.
 
-This keeps run teardown from leaving non-terminal delivery rows for nodes that can no longer be started while preserving retry paths for still-active runs.
+This keeps run teardown from leaving non-terminal delivery rows for nodes that can no longer be started while preserving retry paths for still-active runs. When an event-level preparation retry timer actually fires, it must re-run `topicTrie.lookup(event.topic)` and prepare only the current active subscriptions rather than reusing the stale list captured when the timer was scheduled. This prevents canceled or diff-removed nodes from being reintroduced by retry.
 
 ### Queue for not-yet-started nodes
 

--- a/docs/plans/internal-event-command-query-architecture.md
+++ b/docs/plans/internal-event-command-query-architecture.md
@@ -129,6 +129,21 @@ interface InternalEventEnvelope<TPayload> {
   payload: TPayload;
 }
 
+interface EventPublishAccepted {
+  eventId: string;
+  accepted: true;
+  handlerCount: number;
+}
+
+interface EventHandlerFailure {
+  subscriberName?: string;
+  error: unknown;
+}
+
+interface EventPublishResult extends EventPublishAccepted {
+  failures: EventHandlerFailure[];
+}
+
 interface InternalEventBus<TEventMap> {
   publish<K extends keyof TEventMap>(
     name: K,
@@ -153,6 +168,12 @@ interface InternalEventBus<TEventMap> {
 ### InternalCommandBus
 
 ```ts
+interface CommandResult {
+  ok: boolean;
+  error?: unknown;
+  metadata?: Record<string, unknown>;
+}
+
 interface InternalCommandBus<TCommandMap> {
   dispatch<K extends keyof TCommandMap>(name: K, command: TCommandMap[K]): Promise<CommandResult>;
   register<K extends keyof TCommandMap>(
@@ -249,7 +270,7 @@ const CLIENT_EVENT_BRIDGE = defineClientEventBridge<InternalEventMap, ClientEven
 });
 ```
 
-The bridge should be the only default way for internal events to become client-visible. This keeps authorization, payload filtering, and channel selection auditable.
+The bridge should be the only default way for internal events to become client-visible. This keeps authorization, payload filtering, and channel selection auditable. `ClientEventMap` is defined separately by the client transport/API contract so internal event payloads can be transformed, filtered, or versioned before they become client-visible.
 
 ## External Event Subsystem Alignment
 
@@ -266,6 +287,17 @@ GitHubEventAdapter
 ```
 
 Do not introduce another generic `EventBus`. The domain service should be `ExternalEventService`, and node delivery should be `ExternalEventRouter`.
+
+During migration, the existing external workflow-node design document may still use the earlier names. Interpret them as aliases for the target names below:
+
+| Earlier design name | Target name | Reason |
+| --- | --- | --- |
+| `EventBus` | `ExternalEventService` | Avoids conflict with the dead legacy `EventBus` and makes the component domain-specific. |
+| `EventPublisher` | `ExternalEventPublisher` | Clarifies that adapters publish external source events, not arbitrary internal events. |
+| `EventRouter` | `ExternalEventRouter` | Clarifies that routing is for external source events matched to workflow node interests. |
+| `EventAdapter` | `ExternalEventAdapter` | Makes the source-extension boundary explicit; short `EventAdapter` is acceptable only inside the external-event module. |
+| `EventTaskResolver` | `ExternalEventTaskResolver` | Clarifies that task enrichment applies to normalized external events. |
+| `space.externalEvent.published` | `externalEvent.published` on `InternalEventBus` | Keeps external event publication as an internal fact while avoiding raw source topics as event names. |
 
 ## Progressive Migration Milestones
 

--- a/docs/plans/internal-event-command-query-architecture.md
+++ b/docs/plans/internal-event-command-query-architecture.md
@@ -57,6 +57,38 @@ Supporting services:
 10. **External event delivery is durable and idempotent**. Source dedupe and per-subscription delivery lifecycle belong to the external event subsystem, not source-specific services.
 11. **Current infrastructure can remain under the hood during migration**. The clean APIs should wrap existing `DaemonHub`/`MessageHub` first, then progressively replace legacy concepts.
 
+## Existing Infrastructure Disposition
+
+The migration should be explicit about which existing primitives are removed, which are hidden behind new semantic APIs, and which remain as lower-level infrastructure.
+
+| Component | Target disposition | Migration rule |
+| --- | --- | --- |
+| Legacy `EventBus` | Remove or deprecate first. | No new production usage. Remove exports/imports and delete once compatibility permits. |
+| `DaemonHub` | Compatibility implementation detail behind `InternalEventBus`. | New application/domain code must not import or inject `DaemonHub` directly once the façade exists. Existing call sites migrate incrementally to `InternalEventBus`. |
+| `TypedHub` | Lower-level implementation detail or temporary wrapper. | Fix or wrap delivery semantics, but do not keep it as the daemon application-facing event API. Direct usage should be hidden behind `InternalEventBus` or transport-specific modules. |
+| `MessageHub` | Keep as transport/RPC/client infrastructure. | Do not remove as part of the internal messaging cleanup. Keep it behind `ClientEventGateway`, WebSocket transport, and RPC/client-facing services. |
+| `StateManager` forwarding | Extract into `ClientEventBridge`/`ClientEventGateway`. | Remove repetitive daemon-to-client forwarding handlers from state projection code. |
+| `StateManager` projection | Move toward `StateProjectionService`. | Keep state/read-model updates separate from client delivery and other side effects. |
+| `NotificationSink` | Short-lived compatibility adapter only. | Remove after Space runtime events and replacement subscribers cover the migrated transitions. |
+| Direct `SpaceGitHubService` task-agent injection | Remove after external event routing is primary. | Replace with `ExternalEventService` → `ExternalEventRouter` → `InternalCommandBus.dispatch('agent.message.inject', ...)`. |
+| Live Query / `ReactiveDatabase` reactivity | Keep as reactive read-model/query update mechanism. | Do not use as a general event bus. It cooperates with state projection and query paths. |
+
+## Live Query Boundary
+
+Live Query is adjacent to `StateProjectionService` and `InternalQueryBus`; it is not a replacement for `InternalEventBus`.
+
+```text
+Command handler / domain service
+  ├─ writes durable state
+  ├─ publishes InternalEventBus fact
+  │    ├─ StateProjectionService updates read models/caches
+  │    ├─ ClientEventBridge may send selected client-safe events
+  │    └─ other subscribers run side effects
+  └─ Live Query observes/query-refreshes persisted or projected state
+```
+
+Use Live Query for reactive reads such as current task lists, workflow run state, artifact cache state, and other queryable data. Use `InternalEventBus` for facts and side-effect coordination, `InternalCommandBus` for requested actions, and `InternalQueryBus`/repositories for explicit reads. Live Query may notify consumers that queryable state changed after projections or repositories update, but it should not route agent messages, external events, audit hooks, cleanup flows, or domain side effects.
+
 ## Target Architecture
 
 ```text
@@ -71,6 +103,9 @@ InternalEventBus
   ├─ AgentNotificationService     turns domain events into agent-facing messages
   ├─ Audit/metrics subscribers    record observability data
   └─ ExternalEventRouter          routes external events to workflow node agents
+
+StateProjectionService / repositories
+  └─ Live Query                   updates reactive read/query subscribers
 
 ClientEventGateway
   └─ WebSocket/MessageHub clients
@@ -315,12 +350,14 @@ Tasks:
 3. Mark the class and tests as deprecated or delete them if package compatibility permits.
 4. Add a short replacement note pointing to `InternalEventBus`/current `DaemonHub` wrapper.
 5. Rename variables typed as `DaemonHub` from `eventBus` to `daemonHub` where practical.
+6. Add or update lint/code-review guidance so new production code does not import legacy `EventBus`.
 
 Exit criteria:
 
 - no production code references legacy `EventBus`;
 - docs explain that legacy `EventBus` is not the path forward;
-- common daemon services no longer call a `DaemonHub` instance `eventBus`.
+- common daemon services no longer call a `DaemonHub` instance `eventBus`;
+- either the legacy source/tests are deleted, or they are explicitly deprecated with a removal follow-up if package compatibility blocks immediate deletion.
 
 ### Milestone 2 — Introduce compatibility façades
 
@@ -333,14 +370,16 @@ Tasks:
 3. Add `Channels` helpers that serialize to existing channel strings.
 4. Add a small architecture doc comment in each module explaining event/command/query semantics.
 5. Define canonical daemon event names under the new convention and begin migrating existing names as soon as the façade exists.
-6. Add tests for registration, dispatch, query execution, unsubscribe, duplicate command/query handler handling, and temporary event-name aliases used during migration.
+6. Document that `DaemonHub` and `TypedHub` are compatibility/infrastructure details after this milestone, not application-facing APIs for new daemon/domain code.
+7. Add tests for registration, dispatch, query execution, unsubscribe, duplicate command/query handler handling, and temporary event-name aliases used during migration.
 
 Exit criteria:
 
 - new code can depend on `InternalEventBus`, `InternalCommandBus`, and `InternalQueryBus`;
 - existing behavior remains backed by current hub infrastructure;
 - channels are constructed through helpers in new code;
-- daemon event names start moving to the canonical dot/camelCase convention, with only short-lived aliases for surgical migration PRs.
+- daemon event names start moving to the canonical dot/camelCase convention, with only short-lived aliases for surgical migration PRs;
+- new application/domain code no longer imports `DaemonHub` or `TypedHub` directly unless it is implementing compatibility infrastructure.
 
 ### Milestone 3 — Fix event delivery semantics and observability
 
@@ -372,13 +411,15 @@ Tasks:
 4. Keep payloads/channels behavior-compatible at first.
 5. Add authorization/filtering hooks even if initial implementation delegates to existing checks.
 6. Fix `channelVersions` cleanup while touching StateManager/channel lifecycle.
+7. Document that `MessageHub` remains transport/RPC/client infrastructure and is intentionally not removed by the internal messaging cleanup.
 
 Exit criteria:
 
 - `StateManager` no longer owns repetitive daemon-to-client forwarding;
 - all client-visible internal events are listed in one bridge registry;
 - channel construction uses `Channels` helpers;
-- state cache cleanup includes channel version cleanup.
+- state cache cleanup includes channel version cleanup;
+- client delivery flows go through `ClientEventGateway`, with `MessageHub` hidden behind that transport boundary.
 
 ### Milestone 5 — Split state projections from runtime side effects
 
@@ -389,13 +430,15 @@ Tasks:
 1. Rename or split `StateManager` responsibilities into `StateProjectionService` plus bridge/gateway services.
 2. Route state-cache updates through `InternalEventBus` subscriptions.
 3. Ensure side effects such as agent notification, audit logging, and client delivery are separate subscribers.
-4. Add projection-focused tests for session, room, space, and workflow state.
+4. Keep Live Query as the reactive read-model/query update mechanism and wire it to repository/projection changes rather than treating it as an event bus.
+5. Add projection-focused tests for session, room, space, and workflow state.
 
 Exit criteria:
 
 - state projection code is not responsible for client broadcasting;
 - side-effect subscribers are separately named/tested;
-- read-model queries can be served through `InternalQueryBus`.
+- read-model queries can be served through `InternalQueryBus`;
+- Live Query remains responsible for reactive query updates, while `InternalEventBus` remains responsible for domain facts and side-effect coordination.
 
 ### Milestone 6 — Normalize Space runtime notifications
 
@@ -443,15 +486,21 @@ Tasks:
 
 1. Remove legacy `EventBus` source/tests if still present.
 2. Remove or hide direct `DaemonHub` usage behind `InternalEventBus` where feasible.
-3. Remove `NotificationSink` compatibility adapters.
-4. Remove direct SpaceGitHub task-agent injection once `ExternalEventRouter` is primary.
-5. Consolidate architecture docs around event/command/query semantics.
+3. Remove or hide direct `TypedHub` usage from daemon application/domain code; keep it only in lower-level infrastructure if still needed.
+4. Remove temporary daemon event-name aliases after call sites have migrated to canonical dot/camelCase names.
+5. Remove `NotificationSink` compatibility adapters.
+6. Remove direct SpaceGitHub task-agent injection once `ExternalEventRouter` is primary.
+7. Keep `MessageHub` as transport/RPC/client infrastructure behind `ClientEventGateway`; do not expose it as the domain event API.
+8. Consolidate architecture docs around event/command/query semantics and the Live Query boundary.
 
 Exit criteria:
 
 - production code uses `InternalEventBus`, `InternalCommandBus`, and `InternalQueryBus` as the semantic entry points;
+- direct `DaemonHub`/`TypedHub` usage is gone from application/domain code or explicitly isolated in compatibility infrastructure;
 - client delivery is through `ClientEventGateway`/`ClientEventBridge`;
-- external source delivery is through `ExternalEventService`/`ExternalEventRouter`.
+- external source delivery is through `ExternalEventService`/`ExternalEventRouter`;
+- legacy `EventBus`, `NotificationSink`, direct SpaceGitHub injection, and temporary event-name aliases are removed;
+- `MessageHub` remains only as transport/RPC/client infrastructure, not the semantic event bus.
 
 ## Risk Management
 

--- a/docs/plans/internal-event-command-query-architecture.md
+++ b/docs/plans/internal-event-command-query-architecture.md
@@ -1,0 +1,445 @@
+# Plan: Internal Event, Command, and Query Architecture
+
+## Status
+
+Draft proposal for progressive migration.
+
+## Problem
+
+Neokai currently has several overlapping messaging/event mechanisms:
+
+- legacy `EventBus` in `packages/shared/src/event-bus.ts`;
+- `TypedHub` and `MessageHub` infrastructure;
+- daemon-wide `DaemonHub` built as `TypedHub<DaemonEventMap>`;
+- manual daemon-to-client event forwarding in `StateManager`;
+- `NotificationSink` for Space runtime notifications;
+- direct service-to-session delivery paths such as `SpaceGitHubService.injectTaskAgent(...)`;
+- storage-local eventing via `ReactiveDatabase`.
+
+This makes the event-driven architecture hard to reason about. Developers need to know which bus/hub/sink to use, whether a message is internal or client-visible, whether a handler is awaited, and whether `sessionId` is an actual session or a channel string such as `room:${roomId}` or `space:${spaceId}`.
+
+The target model should be semantic and boring:
+
+- **Event**: a fact that already happened.
+- **Command**: a request for the system to do something.
+- **Query**: a request to read state.
+
+## Target Naming
+
+Use one consistent internal trio:
+
+- `InternalEventBus`
+- `InternalCommandBus`
+- `InternalQueryBus`
+
+The names are intentionally internal because they describe trusted daemon-side application messaging. Client delivery and external source ingestion are separate layers.
+
+Supporting services:
+
+- `Channels` / `ChannelRegistry` — canonical channel construction and parsing.
+- `ClientEventGateway` — sends client-safe events over WebSocket or a future client transport.
+- `ClientEventBridge` — declaratively maps selected internal events to client events/channels.
+- `StateProjectionService` — listens to events and maintains daemon read models/caches.
+- `ExternalEventService` — normalizes, dedupes, persists, and publishes external source events.
+- `ExternalEventRouter` — routes external events to workflow node subscriptions and agent sessions.
+
+## Design Principles
+
+1. **Events are facts**. Event names should be past tense or state-change facts, for example `space.task.blocked`, `session.created`, `externalEvent.published`.
+2. **Commands request actions**. Command names should be imperative/action-oriented, for example `agent.message.inject`, `space.workflow.resume`, `github.repo.watch`.
+3. **Queries read state**. Query names should return data and avoid side effects, for example `space.workflowRun.get`, `room.tasks.list`.
+4. **No silent failures**. Handler errors must be logged, returned, or surfaced through a failure result/event.
+5. **Publish semantics are explicit**. Fire-and-forget and wait-for-handlers behavior must be separate APIs or clearly documented.
+6. **Channels are first-class**. Do not overload `sessionId` as a generic channel field in new APIs.
+7. **Internal events are not automatically client events**. Client visibility is explicit through `ClientEventBridge`.
+8. **State projection is not event forwarding**. State caches and client broadcasting are separate responsibilities.
+9. **External event delivery is durable and idempotent**. Source dedupe and per-subscription delivery lifecycle belong to the external event subsystem, not source-specific services.
+10. **Current infrastructure can remain under the hood during migration**. The clean APIs should wrap existing `DaemonHub`/`MessageHub` first, then progressively replace legacy concepts.
+
+## Target Architecture
+
+```text
+Internal producers
+  ├─ publish facts ───────────────▶ InternalEventBus
+  ├─ dispatch requested actions ──▶ InternalCommandBus
+  └─ execute reads ───────────────▶ InternalQueryBus
+
+InternalEventBus
+  ├─ StateProjectionService       updates read models/caches
+  ├─ ClientEventBridge            maps selected events to ClientEventGateway
+  ├─ AgentNotificationService     turns domain events into agent-facing messages
+  ├─ Audit/metrics subscribers    record observability data
+  └─ ExternalEventRouter          routes external events to workflow node agents
+
+ClientEventGateway
+  └─ WebSocket/MessageHub clients
+```
+
+## Core APIs
+
+### Channels
+
+New code should construct channels through helpers rather than inline strings.
+
+```ts
+export type EventChannel =
+  | { kind: 'global' }
+  | { kind: 'session'; sessionId: string }
+  | { kind: 'room'; roomId: string }
+  | { kind: 'space'; spaceId: string }
+  | { kind: 'workflowRun'; spaceId: string; workflowRunId: string }
+  | { kind: 'task'; spaceId: string; taskId: string };
+
+export const Channels = {
+  global: (): EventChannel => ({ kind: 'global' }),
+  session: (sessionId: string): EventChannel => ({ kind: 'session', sessionId }),
+  room: (roomId: string): EventChannel => ({ kind: 'room', roomId }),
+  space: (spaceId: string): EventChannel => ({ kind: 'space', spaceId }),
+  workflowRun: (spaceId: string, workflowRunId: string): EventChannel => ({
+    kind: 'workflowRun',
+    spaceId,
+    workflowRunId,
+  }),
+  task: (spaceId: string, taskId: string): EventChannel => ({ kind: 'task', spaceId, taskId }),
+};
+```
+
+During migration, channels can serialize to the existing route strings:
+
+```text
+global
+session:${sessionId} or the legacy bare session id
+room:${roomId}
+space:${spaceId}
+workflowRun:${spaceId}:${workflowRunId}
+task:${spaceId}:${taskId}
+```
+
+### InternalEventBus
+
+```ts
+interface InternalEventEnvelope<TPayload> {
+  id: string;
+  name: string;
+  channel: EventChannel;
+  occurredAt: number;
+  correlationId?: string;
+  causationId?: string;
+  actor?: EventActor;
+  payload: TPayload;
+}
+
+interface InternalEventBus<TEventMap> {
+  publish<K extends keyof TEventMap>(
+    name: K,
+    event: { channel: EventChannel; payload: TEventMap[K]; correlationId?: string; causationId?: string },
+  ): Promise<EventPublishAccepted>;
+
+  publishAndWait<K extends keyof TEventMap>(
+    name: K,
+    event: { channel: EventChannel; payload: TEventMap[K]; correlationId?: string; causationId?: string },
+  ): Promise<EventPublishResult>;
+
+  subscribe<K extends keyof TEventMap>(
+    name: K,
+    handler: (event: InternalEventEnvelope<TEventMap[K]>) => void | Promise<void>,
+    options?: { subscriberName?: string },
+  ): UnsubscribeFn;
+}
+```
+
+`publish(...)` means accepted/enqueued. `publishAndWait(...)` means all local internal handlers have completed or reported failure. Neither mode may swallow handler failures silently.
+
+### InternalCommandBus
+
+```ts
+interface InternalCommandBus<TCommandMap> {
+  dispatch<K extends keyof TCommandMap>(name: K, command: TCommandMap[K]): Promise<CommandResult>;
+  register<K extends keyof TCommandMap>(
+    name: K,
+    handler: (command: TCommandMap[K]) => Promise<CommandResult>,
+  ): UnsubscribeFn;
+}
+```
+
+Commands should normally have one owner/handler. Duplicate command handlers should be rejected unless explicitly configured as middleware.
+
+### InternalQueryBus
+
+```ts
+interface InternalQueryBus<TQueryMap> {
+  execute<K extends keyof TQueryMap>(name: K, query: TQueryMap[K]['input']): Promise<TQueryMap[K]['output']>;
+  register<K extends keyof TQueryMap>(
+    name: K,
+    handler: (query: TQueryMap[K]['input']) => Promise<TQueryMap[K]['output']>,
+  ): UnsubscribeFn;
+}
+```
+
+Queries should be side-effect free and should not publish events as part of normal execution.
+
+## Event Naming Convention
+
+Use dot-separated names with lower camel case inside each segment.
+
+Recommended patterns:
+
+```text
+session.created
+session.updated
+room.task.updated
+space.task.blocked
+space.workflowRun.completed
+externalEvent.published
+externalEvent.deliveryFailed
+github.repoWatched
+```
+
+Rules for new names:
+
+- use dots, not colons;
+- use camelCase, not snake_case;
+- group by domain first;
+- use fact/state-change wording for events;
+- do not use raw external topics as internal event names.
+
+## Domain Event Maps
+
+Avoid one giant event map file. Compose the internal map from domain-owned maps.
+
+```ts
+export interface SessionEvents { /* session.* */ }
+export interface RoomEvents { /* room.* */ }
+export interface SpaceEvents { /* space.* */ }
+export interface ExternalEvents { /* externalEvent.* */ }
+export interface GitHubEvents { /* github.* */ }
+export interface StorageEvents { /* storage.* */ }
+
+export type InternalEventMap = SessionEvents
+  & RoomEvents
+  & SpaceEvents
+  & ExternalEvents
+  & GitHubEvents
+  & StorageEvents;
+```
+
+This gives each subsystem a clear owner and makes additions reviewable.
+
+## Client Event Boundary
+
+Internal events are trusted daemon facts. Client events are UI/API contracts. They must remain separated.
+
+```ts
+const CLIENT_EVENT_BRIDGE = defineClientEventBridge<InternalEventMap, ClientEventMap>({
+  'space.workflowRun.updated': {
+    clientEvent: 'space.workflowRun.updated',
+    channel: (event) => Channels.space(event.payload.spaceId),
+    transform: (event) => ({
+      spaceId: event.payload.spaceId,
+      workflowRunId: event.payload.workflowRunId,
+      status: event.payload.status,
+    }),
+  },
+
+  'room.task.updated': {
+    clientEvent: 'room.task.updated',
+    channel: (event) => Channels.room(event.payload.roomId),
+    transform: (event) => event.payload,
+  },
+});
+```
+
+The bridge should be the only default way for internal events to become client-visible. This keeps authorization, payload filtering, and channel selection auditable.
+
+## External Event Subsystem Alignment
+
+The Space external event design should be renamed and aligned with this architecture:
+
+```text
+GitHubEventAdapter
+  → ExternalEventService.publish(...)
+  → ExternalEventStore dedupe/enrich/persist
+  → InternalEventBus.publish('externalEvent.published', ...)
+  → ExternalEventRouter
+  → InternalCommandBus.dispatch('agent.message.inject', ...)
+  → agent session
+```
+
+Do not introduce another generic `EventBus`. The domain service should be `ExternalEventService`, and node delivery should be `ExternalEventRouter`.
+
+## Progressive Migration Milestones
+
+### Milestone 1 — Remove legacy `EventBus` confusion
+
+Goal: make it impossible for new production code to choose the dead event primitive.
+
+Tasks:
+
+1. Verify production imports of `packages/shared/src/event-bus.ts` remain zero.
+2. Remove it from any public/shared barrel exports if present.
+3. Mark the class and tests as deprecated or delete them if package compatibility permits.
+4. Add a short replacement note pointing to `InternalEventBus`/current `DaemonHub` wrapper.
+5. Rename variables typed as `DaemonHub` from `eventBus` to `daemonHub` where practical.
+
+Exit criteria:
+
+- no production code references legacy `EventBus`;
+- docs explain that legacy `EventBus` is not the path forward;
+- common daemon services no longer call a `DaemonHub` instance `eventBus`.
+
+### Milestone 2 — Introduce compatibility façades
+
+Goal: add clean API names without changing runtime behavior.
+
+Tasks:
+
+1. Add `InternalEventBus` as a wrapper around current `DaemonHub`.
+2. Add initial `InternalCommandBus` and `InternalQueryBus` implementations.
+3. Add `Channels` helpers that serialize to existing channel strings.
+4. Add a small architecture doc comment in each module explaining event/command/query semantics.
+5. Add tests for registration, dispatch, query execution, unsubscribe, and duplicate command/query handler handling.
+
+Exit criteria:
+
+- new code can depend on `InternalEventBus`, `InternalCommandBus`, and `InternalQueryBus`;
+- existing behavior remains backed by current hub infrastructure;
+- channels are constructed through helpers in new code.
+
+### Milestone 3 — Fix event delivery semantics and observability
+
+Goal: make the internal event layer safe for critical workflows.
+
+Tasks:
+
+1. Fix or wrap `TypedHub` local dispatch so async handlers can be awaited.
+2. Add explicit APIs for accepted/enqueued publish vs publish-and-wait.
+3. Stop silently swallowing handler errors; log event name, channel, subscriber name, and error.
+4. Return structured publish results with handler counts and failures for wait mode.
+5. Add tests for async handler completion, error reporting, unsubscribe cleanup, and session/channel filtering.
+
+Exit criteria:
+
+- event handler failures are observable;
+- tests prove awaited mode waits for async handlers;
+- fire-and-forget semantics are explicit rather than accidental.
+
+### Milestone 4 — Extract client forwarding from `StateManager`
+
+Goal: separate state projection from client event delivery.
+
+Tasks:
+
+1. Create `ClientEventGateway` around the existing WebSocket/MessageHub client path.
+2. Create `ClientEventBridge` with declarative internal-event-to-client-event mappings.
+3. Move the repetitive `StateManager` forwarding handlers into bridge config.
+4. Keep payloads/channels behavior-compatible at first.
+5. Add authorization/filtering hooks even if initial implementation delegates to existing checks.
+6. Fix `channelVersions` cleanup while touching StateManager/channel lifecycle.
+
+Exit criteria:
+
+- `StateManager` no longer owns repetitive daemon-to-client forwarding;
+- all client-visible internal events are listed in one bridge registry;
+- channel construction uses `Channels` helpers;
+- state cache cleanup includes channel version cleanup.
+
+### Milestone 5 — Split state projections from runtime side effects
+
+Goal: turn `StateManager` into a read-model/projection service rather than an event side-effect hub.
+
+Tasks:
+
+1. Rename or split `StateManager` responsibilities into `StateProjectionService` plus bridge/gateway services.
+2. Route state-cache updates through `InternalEventBus` subscriptions.
+3. Ensure side effects such as agent notification, audit logging, and client delivery are separate subscribers.
+4. Add projection-focused tests for session, room, space, and workflow state.
+
+Exit criteria:
+
+- state projection code is not responsible for client broadcasting;
+- side-effect subscribers are separately named/tested;
+- read-model queries can be served through `InternalQueryBus`.
+
+### Milestone 6 — Normalize Space runtime notifications
+
+Goal: remove the parallel `NotificationSink` hierarchy as the primary integration pattern.
+
+Tasks:
+
+1. Define Space runtime domain events, for example `space.task.blocked`, `space.agent.crashed`, `space.workflowRun.completed`.
+2. Publish these events through `InternalEventBus`.
+3. Implement `SpaceAgentNotificationService` as a subscriber that turns selected Space events into agent-facing messages.
+4. Implement client bridge mappings for client-visible Space events.
+5. Keep `NotificationSink` as a compatibility adapter during migration.
+
+Exit criteria:
+
+- new Space runtime state transitions publish domain events;
+- agent notifications and UI updates are subscribers, not parallel direct pipes;
+- compatibility sink can be removed after callers migrate.
+
+### Milestone 7 — Align GitHub and external event ingestion
+
+Goal: prepare for multi-source external events without copying GitHub-specific pipelines.
+
+Tasks:
+
+1. Split shared GitHub ingress concerns from room/space routing: webhook verification, polling, raw normalization.
+2. Rename the proposed external event design from generic `EventBus` to `ExternalEventService`.
+3. Add `ExternalEventStore` for source dedupe and delivery lifecycle.
+4. Add `ExternalEventTaskResolver` for task enrichment.
+5. Publish `externalEvent.published` through `InternalEventBus`.
+6. Route delivery through `ExternalEventRouter` and `InternalCommandBus` command `agent.message.inject`.
+7. Keep current `SpaceGitHubService` direct injection path as a migration compatibility path until the new route proves stable.
+
+Exit criteria:
+
+- GitHub is one adapter/source for the external event subsystem;
+- external event delivery is observable, retryable, and persistent;
+- no new generic bus/hub abstraction is introduced.
+
+### Milestone 8 — Retire legacy names and compatibility paths
+
+Goal: remove the old conceptual clutter once migrations are complete.
+
+Tasks:
+
+1. Remove legacy `EventBus` source/tests if still present.
+2. Remove or hide direct `DaemonHub` usage behind `InternalEventBus` where feasible.
+3. Remove `NotificationSink` compatibility adapters.
+4. Remove direct SpaceGitHub task-agent injection once `ExternalEventRouter` is primary.
+5. Consolidate architecture docs around event/command/query semantics.
+
+Exit criteria:
+
+- production code uses `InternalEventBus`, `InternalCommandBus`, and `InternalQueryBus` as the semantic entry points;
+- client delivery is through `ClientEventGateway`/`ClientEventBridge`;
+- external source delivery is through `ExternalEventService`/`ExternalEventRouter`.
+
+## Risk Management
+
+- **Avoid big-bang transport rewrites.** Start with wrappers around current infrastructure.
+- **Keep client and internal boundaries explicit.** Do not automatically expose all internal events to clients.
+- **Use compatibility adapters.** Let old paths and new paths coexist while tests and telemetry build confidence.
+- **Preserve behavior in bridge extraction.** First move should be structural, not semantic.
+- **Instrument failures early.** Event-driven systems are hard to debug if handler failures vanish.
+
+## Open Questions
+
+1. Should `publish(...)` default to fire-and-forget or should only an explicitly named `publishAsync(...)` do that?
+2. Should internal event envelopes be persisted for selected durable event classes, or should persistence remain domain-specific?
+3. Should `InternalCommandBus` support middleware, or only one handler per command?
+4. How aggressively should existing daemon event names be migrated to the new naming convention versus grandfathered?
+5. What is the minimum compatibility period for `NotificationSink` and `SpaceGitHubService` direct delivery?
+
+## Summary
+
+The target architecture is not another hub. It is a semantic messaging layer:
+
+```text
+InternalEventBus   facts that happened
+InternalCommandBus requests to do work
+InternalQueryBus   requests to read state
+```
+
+Built around explicit channels, explicit client bridging, observable handler behavior, and progressive migration from the current `DaemonHub`/`MessageHub`/`StateManager`/`NotificationSink` mix.

--- a/docs/plans/internal-event-command-query-architecture.md
+++ b/docs/plans/internal-event-command-query-architecture.md
@@ -73,6 +73,21 @@ The migration should be explicit about which existing primitives are removed, wh
 | Direct `SpaceGitHubService` task-agent injection | Remove after external event routing is primary. | Replace with `ExternalEventService` → `ExternalEventRouter` → `InternalCommandBus.dispatch('agent.message.inject', ...)`. |
 | Live Query / `ReactiveDatabase` reactivity | Keep as reactive read-model/query update mechanism. | Do not use as a general event bus. It cooperates with state projection and query paths. |
 
+## Current Code Fact-Check Notes
+
+These notes reflect the current codebase state and should guide migration PRs:
+
+- Legacy `EventBus` still exists in `packages/shared/src/event-bus.ts`, but current imports are test-only; production code appears to have moved to `DaemonHub`/`TypedHub` paths.
+- Legacy `EventBus` is not currently exported from `packages/shared/src/mod.ts`; Milestone 1 should verify this remains true rather than assuming a barrel-export removal is required.
+- `DaemonHub` is a type alias for `TypedHub<DaemonEventMap>`, and `createDaemonHub(...)` constructs a `TypedHub<DaemonEventMap>`.
+- `TypedHub` is still exported from `packages/shared/src/mod.ts`. Do not remove that export immediately; first migrate daemon application/domain code away from direct `TypedHub` usage, then decide whether it remains public infrastructure.
+- `TypedHub` local dispatch currently queues handlers in a microtask and does not await handler promises; handler failures are swallowed. Milestone 3 must fix this in the wrapper or in `TypedHub` itself before critical workflows depend on awaited event delivery.
+- `StateManager` currently combines state caches/read models with many direct `messageHub.event(...)` forwarding calls. The bridge/projection split is valid, but implementation should be broken into smaller PRs because this surface is broad.
+- `StateManager` maintains `channelVersions`; cleanup should be handled while extracting channel lifecycle/client delivery code.
+- `NotificationSink` is actively used by Space runtime paths. It should be treated as a compatibility path, not deleted until replacement event subscribers cover the same notifications.
+- `SpaceGitHubService` still accepts an `injectTaskAgent` callback and directly injects GitHub activity into task-agent sessions. This confirms the need for the `ExternalEventService`/`ExternalEventRouter`/`agent.message.inject` replacement path.
+- Live Query is implemented as `ReactiveDatabase` table-change notifications plus `LiveQueryEngine` SQL re-evaluation/diff delivery over `liveQuery.snapshot` and `liveQuery.delta`. It is a reactive read-model mechanism, not a domain event bus.
+
 ## Live Query Boundary
 
 Live Query is adjacent to `StateProjectionService` and `InternalQueryBus`; it is not a replacement for `InternalEventBus`.
@@ -346,7 +361,7 @@ Goal: make it impossible for new production code to choose the dead event primit
 Tasks:
 
 1. Verify production imports of `packages/shared/src/event-bus.ts` remain zero.
-2. Remove it from any public/shared barrel exports if present.
+2. Verify it remains absent from public/shared barrel exports; remove it if a barrel export is reintroduced before migration starts.
 3. Mark the class and tests as deprecated or delete them if package compatibility permits.
 4. Add a short replacement note pointing to `InternalEventBus`/current `DaemonHub` wrapper.
 5. Rename variables typed as `DaemonHub` from `eventBus` to `daemonHub` where practical.
@@ -371,7 +386,8 @@ Tasks:
 4. Add a small architecture doc comment in each module explaining event/command/query semantics.
 5. Define canonical daemon event names under the new convention and begin migrating existing names as soon as the façade exists.
 6. Document that `DaemonHub` and `TypedHub` are compatibility/infrastructure details after this milestone, not application-facing APIs for new daemon/domain code.
-7. Add tests for registration, dispatch, query execution, unsubscribe, duplicate command/query handler handling, and temporary event-name aliases used during migration.
+7. Keep the current shared `TypedHub` export stable during this milestone; direct daemon application usage should move first, and any public export cleanup should be a later compatibility decision.
+8. Add tests for registration, dispatch, query execution, unsubscribe, duplicate command/query handler handling, and temporary event-name aliases used during migration.
 
 Exit criteria:
 
@@ -407,7 +423,7 @@ Tasks:
 
 1. Create `ClientEventGateway` around the existing WebSocket/MessageHub client path.
 2. Create `ClientEventBridge` with declarative internal-event-to-client-event mappings.
-3. Move the repetitive `StateManager` forwarding handlers into bridge config.
+3. Move the repetitive `StateManager` forwarding handlers into bridge config in small groups rather than one large rewrite.
 4. Keep payloads/channels behavior-compatible at first.
 5. Add authorization/filtering hooks even if initial implementation delegates to existing checks.
 6. Fix `channelVersions` cleanup while touching StateManager/channel lifecycle.

--- a/docs/plans/internal-event-command-query-architecture.md
+++ b/docs/plans/internal-event-command-query-architecture.md
@@ -49,12 +49,13 @@ Supporting services:
 2. **Commands request actions**. Command names should be imperative/action-oriented, for example `agent.message.inject`, `space.workflow.resume`, `github.repo.watch`.
 3. **Queries read state**. Query names should return data and avoid side effects, for example `space.workflowRun.get`, `room.tasks.list`.
 4. **No silent failures**. Handler errors must be logged, returned, or surfaced through a failure result/event.
-5. **Publish semantics are explicit**. Fire-and-forget and wait-for-handlers behavior must be separate APIs or clearly documented.
+5. **Publish semantics are explicit and safe by default**. `publish(...)` waits for local internal handlers to settle; fire-and-forget must use the explicitly named `publishAsync(...)` API.
 6. **Channels are first-class**. Do not overload `sessionId` as a generic channel field in new APIs.
 7. **Internal events are not automatically client events**. Client visibility is explicit through `ClientEventBridge`.
 8. **State projection is not event forwarding**. State caches and client broadcasting are separate responsibilities.
-9. **External event delivery is durable and idempotent**. Source dedupe and per-subscription delivery lifecycle belong to the external event subsystem, not source-specific services.
-10. **Current infrastructure can remain under the hood during migration**. The clean APIs should wrap existing `DaemonHub`/`MessageHub` first, then progressively replace legacy concepts.
+9. **The internal bus is not a persistence layer**. `InternalEventBus` does not persist envelopes or provide replay in v1; durability stays domain-specific.
+10. **External event delivery is durable and idempotent**. Source dedupe and per-subscription delivery lifecycle belong to the external event subsystem, not source-specific services.
+11. **Current infrastructure can remain under the hood during migration**. The clean APIs should wrap existing `DaemonHub`/`MessageHub` first, then progressively replace legacy concepts.
 
 ## Target Architecture
 
@@ -129,31 +130,33 @@ interface InternalEventEnvelope<TPayload> {
   payload: TPayload;
 }
 
-interface EventPublishAccepted {
-  eventId: string;
-  accepted: true;
-  handlerCount: number;
-}
-
 interface EventHandlerFailure {
   subscriberName?: string;
   error: unknown;
 }
 
-interface EventPublishResult extends EventPublishAccepted {
+interface EventPublishResult {
+  eventId: string;
+  handlerCount: number;
   failures: EventHandlerFailure[];
+}
+
+interface EventPublishAccepted {
+  eventId: string;
+  accepted: true;
+  queuedAt: number;
 }
 
 interface InternalEventBus<TEventMap> {
   publish<K extends keyof TEventMap>(
     name: K,
     event: { channel: EventChannel; payload: TEventMap[K]; correlationId?: string; causationId?: string },
-  ): Promise<EventPublishAccepted>;
+  ): Promise<EventPublishResult>;
 
-  publishAndWait<K extends keyof TEventMap>(
+  publishAsync<K extends keyof TEventMap>(
     name: K,
     event: { channel: EventChannel; payload: TEventMap[K]; correlationId?: string; causationId?: string },
-  ): Promise<EventPublishResult>;
+  ): Promise<EventPublishAccepted>;
 
   subscribe<K extends keyof TEventMap>(
     name: K,
@@ -163,7 +166,7 @@ interface InternalEventBus<TEventMap> {
 }
 ```
 
-`publish(...)` means accepted/enqueued. `publishAndWait(...)` means all local internal handlers have completed or reported failure. Neither mode may swallow handler failures silently.
+`publish(...)` is the safe default: it waits for all local internal handlers to settle and returns handler counts/failures. `publishAsync(...)` is the explicit fire-and-forget API: it only accepts/enqueues delivery and returns before handlers finish. Neither mode may swallow handler failures silently; async failures must be logged with event name, channel, and subscriber context.
 
 ### InternalCommandBus
 
@@ -183,7 +186,7 @@ interface InternalCommandBus<TCommandMap> {
 }
 ```
 
-Commands should normally have one owner/handler. Duplicate command handlers should be rejected unless explicitly configured as middleware.
+Commands have one owner/handler in v1. Duplicate command handlers are rejected, and the command bus does not support middleware initially. Cross-cutting concerns such as validation, authorization, logging, transactions, and metrics should stay explicit in command handlers or nearby services until repeated patterns justify a later middleware design.
 
 ### InternalQueryBus
 
@@ -329,13 +332,15 @@ Tasks:
 2. Add initial `InternalCommandBus` and `InternalQueryBus` implementations.
 3. Add `Channels` helpers that serialize to existing channel strings.
 4. Add a small architecture doc comment in each module explaining event/command/query semantics.
-5. Add tests for registration, dispatch, query execution, unsubscribe, and duplicate command/query handler handling.
+5. Define canonical daemon event names under the new convention and begin migrating existing names as soon as the façade exists.
+6. Add tests for registration, dispatch, query execution, unsubscribe, duplicate command/query handler handling, and temporary event-name aliases used during migration.
 
 Exit criteria:
 
 - new code can depend on `InternalEventBus`, `InternalCommandBus`, and `InternalQueryBus`;
 - existing behavior remains backed by current hub infrastructure;
-- channels are constructed through helpers in new code.
+- channels are constructed through helpers in new code;
+- daemon event names start moving to the canonical dot/camelCase convention, with only short-lived aliases for surgical migration PRs.
 
 ### Milestone 3 — Fix event delivery semantics and observability
 
@@ -344,7 +349,7 @@ Goal: make the internal event layer safe for critical workflows.
 Tasks:
 
 1. Fix or wrap `TypedHub` local dispatch so async handlers can be awaited.
-2. Add explicit APIs for accepted/enqueued publish vs publish-and-wait.
+2. Implement `publish(...)` as awaited local-handler delivery and `publishAsync(...)` as the explicit fire-and-forget/accepted-only API.
 3. Stop silently swallowing handler errors; log event name, channel, subscriber name, and error.
 4. Return structured publish results with handler counts and failures for wait mode.
 5. Add tests for async handler completion, error reporting, unsubscribe cleanup, and session/channel filtering.
@@ -352,8 +357,8 @@ Tasks:
 Exit criteria:
 
 - event handler failures are observable;
-- tests prove awaited mode waits for async handlers;
-- fire-and-forget semantics are explicit rather than accidental.
+- tests prove `publish(...)` waits for async handlers;
+- fire-and-forget semantics are explicit through `publishAsync(...)` rather than accidental.
 
 ### Milestone 4 — Extract client forwarding from `StateManager`
 
@@ -402,13 +407,13 @@ Tasks:
 2. Publish these events through `InternalEventBus`.
 3. Implement `SpaceAgentNotificationService` as a subscriber that turns selected Space events into agent-facing messages.
 4. Implement client bridge mappings for client-visible Space events.
-5. Keep `NotificationSink` as a compatibility adapter during migration.
+5. Keep `NotificationSink` only as a short-lived compatibility adapter until replacement subscribers exist, then remove it in the same migration track.
 
 Exit criteria:
 
 - new Space runtime state transitions publish domain events;
 - agent notifications and UI updates are subscribers, not parallel direct pipes;
-- compatibility sink can be removed after callers migrate.
+- `NotificationSink` compatibility is removed as soon as replacement subscribers cover the migrated transitions.
 
 ### Milestone 7 — Align GitHub and external event ingestion
 
@@ -422,7 +427,7 @@ Tasks:
 4. Add `ExternalEventTaskResolver` for task enrichment.
 5. Publish `externalEvent.published` through `InternalEventBus`.
 6. Route delivery through `ExternalEventRouter` and `InternalCommandBus` command `agent.message.inject`.
-7. Keep current `SpaceGitHubService` direct injection path as a migration compatibility path until the new route proves stable.
+7. Remove the current `SpaceGitHubService` direct injection path as soon as the `ExternalEventService`/`ExternalEventRouter` replacement path is available and covered by tests.
 
 Exit criteria:
 
@@ -456,13 +461,13 @@ Exit criteria:
 - **Preserve behavior in bridge extraction.** First move should be structural, not semantic.
 - **Instrument failures early.** Event-driven systems are hard to debug if handler failures vanish.
 
-## Open Questions
+## Decisions
 
-1. Should `publish(...)` default to fire-and-forget or should only an explicitly named `publishAsync(...)` do that?
-2. Should internal event envelopes be persisted for selected durable event classes, or should persistence remain domain-specific?
-3. Should `InternalCommandBus` support middleware, or only one handler per command?
-4. How aggressively should existing daemon event names be migrated to the new naming convention versus grandfathered?
-5. What is the minimum compatibility period for `NotificationSink` and `SpaceGitHubService` direct delivery?
+1. `publish(...)` waits for local internal handlers to settle and returns an `EventPublishResult`; fire-and-forget must use the explicitly named `publishAsync(...)` API.
+2. `InternalEventBus` does not persist event envelopes in v1. Durability remains domain-specific: for example, `ExternalEventStore` persists external event lifecycle, while message/domain repositories persist their own state.
+3. `InternalCommandBus` does not support middleware in v1. Commands have one owner/handler; duplicate handlers are rejected.
+4. Existing daemon event names should migrate to the canonical dot/camelCase convention as soon as the `InternalEventBus` façade exists. Temporary aliases are acceptable only to keep migration PRs surgical and should be removed quickly.
+5. `NotificationSink` and direct `SpaceGitHubService` delivery are compatibility paths only. Remove them as soon as their `InternalEventBus`/`InternalCommandBus` replacement paths are available and tested.
 
 ## Summary
 

--- a/docs/research/retry-injection-after-dedupe-findings.md
+++ b/docs/research/retry-injection-after-dedupe-findings.md
@@ -1,0 +1,146 @@
+# Research Findings: Retry Delivery When Injection Fails After Dedupe Marking
+
+## Issue Summary
+**P1 Review Comment** on PR #1777 (Design: external event bus for Space workflow nodes):
+> Marking the event as delivered before attempting `injectMessage` creates permanent loss on transient delivery failures. The design justifies this by saying a restart poll will emit a fresh event, but in the current pipeline `SpaceGitHubService.ingest` short-circuits duplicates from `storeEvent` and does not re-route the same `dedupeKey`, so a failed injection will not be retried for that subscription.
+
+## Investigation
+
+### Affected Components
+1. **Design Document**: `docs/plans/design-external-event-bus-for-space-workflow-nodes.md` (PR #1777)
+   - Section 4: `deliverToSubscription` method marks dedup BEFORE injection
+   - Incorrect assumption: "upstream SpaceGitHubService re-polls on restart and will generate a fresh event"
+2. **Implementation Code**: `packages/daemon/src/lib/github/space-github.ts`
+   - `SpaceGitHubService.ingest()` short-circuits ALL duplicates (line 602)
+   - `flushTaskNotification()` marks state as 'delivered' only on success, but duplicate events never reach injection
+
+## Code Analysis
+
+### Dedupe Flow in `SpaceGitHubService`
+1. `ingest()` calls `storeEvent()` which uses `INSERT OR IGNORE` on `dedupe_key` (line 338)
+2. If duplicate: `ingest()` returns immediately (line 602: `if (stored.duplicate) return stored.event`)
+3. This means even if the original event's injection failed, subsequent events with the same `dedupeKey` are ignored entirely
+
+### Injection Failure Scenario
+1. Event arrives via webhook → `ingest()` → `storeEvent()` (new, state: 'received')
+2. Resolved to task → state updated to 'routed'
+3. `flushTaskNotification()` attempts `injectTaskAgent()` → fails (transient error)
+4. State remains 'routed' (not updated to 'delivered' or 'failed')
+5. Later, same event is polled from GitHub → `ingest()` → `storeEvent()` returns duplicate
+6. `ingest()` returns immediately → NO retry of injection → **permanent event loss**
+
+### Design Document Flaw
+The design document's `deliverToSubscription` method contains the same flawed logic:
+```typescript
+// Mark dedup BEFORE session resolution / queueing...
+this.delivered.set(dedupeKey, Date.now());
+
+// Later, on injection failure:
+catch (err) {
+  log.warn(`Failed to deliver event to ${sub.agentName}`, { error: err });
+  // Event is already dedup-marked so it won't be re-delivered for this run.
+  // A fresh event will arrive via the next poll cycle if the underlying external event is still relevant.
+}
+```
+
+This is incorrect because:
+- The "fresh event" from polling will have the same `dedupeKey`
+- `SpaceGitHubService.ingest()` will short-circuit it before it reaches the event bus
+- The event never gets re-delivered to the node
+
+## Root Cause
+1. **Premature dedup marking**: Both `SpaceGitHubService` and the design document mark events as "processed" before confirming successful delivery
+2. **Unconditional duplicate short-circuit**: `ingest()` doesn't distinguish between terminal states (delivered, ignored) and retry-able states (routed, failed)
+3. **No retry mechanism**: Failed injections are logged but never retried
+
+## Recommended Fixes
+
+### Fix 1: Update `SpaceGitHubService` (Implementation)
+1. **Modify `ingest()` to not short-circuit retry-able duplicates**:
+   ```typescript
+   async ingest(spaceId: string, event: NormalizedSpaceGitHubEvent): Promise<StoredSpaceGitHubEvent> {
+     const stored = this.repo.storeEvent({ spaceId, event });
+     if (stored.duplicate) {
+       // Only short-circuit if in terminal state
+       const existing = stored.event;
+       if (['delivered', 'ignored', 'ambiguous'].includes(existing.state)) {
+         return existing;
+       }
+       // For non-terminal states (routed, failed), re-process
+       // (injection will be retried via scheduleTaskNotification)
+     }
+     // ... rest of processing
+   }
+   ```
+
+2. **Add retry logic to `flushTaskNotification()`**:
+   - Track retry count in event state or separate map
+   - Retry with exponential backoff (max 3 retries)
+   - On max retries, update state to 'failed' (terminal)
+
+### Fix 2: Update Design Document (PR #1777)
+1. **Change dedup marking order**: Mark dedup AFTER successful injection, not before
+2. **Add pending state tracking**: Track "pending" deliveries to prevent duplicate queueing without preventing retries
+3. **Remove incorrect assumption**: Re-polling doesn't help because of `ingest()` short-circuit
+4. **Add retry mechanism**: For the event bus, retry failed deliveries with backoff
+
+### Proposed Design Document Changes
+In `deliverToSubscription()`:
+```typescript
+private async deliverToSubscription(event: ExternalEvent, sub: Subscription): Promise<void> {
+  // ... scope check ...
+
+  // Dedup check — use a "pending" set to prevent duplicate queueing, but allow retries
+  this.evictStaleDedup();
+  const dedupeKey = `${event.dedupeKey}:${sub.taskId}:${sub.nodeId}:${sub.agentName}:${sub.workflowRunId}`;
+
+  // Check if already delivered (terminal)
+  if (this.delivered.has(dedupeKey)) {
+    return;
+  }
+
+  // Check if pending (prevents duplicate queueing)
+  if (this.pendingDeliveries.has(dedupeKey)) {
+    return;
+  }
+
+  // Mark as pending (prevents duplicate queueing, but not retriable)
+  this.pendingDeliveries.add(dedupeKey);
+
+  try {
+    // Resolve session
+    const sessionId = await this.resolveSession(sub);
+    if (!sessionId) {
+      this.queueForDelivery(event, sub);
+      return; // Pending remains until queue is drained
+    }
+
+    // Inject
+    const message = this.formatEventMessage(event);
+    await this.sessionFactory.injectMessage(sessionId, message, { deliveryMode: 'defer' });
+
+    // Success: mark as delivered, remove pending
+    this.delivered.set(dedupeKey, Date.now());
+    this.pendingDeliveries.delete(dedupeKey);
+  } catch (err) {
+    // Failure: remove pending so it can be retried
+    this.pendingDeliveries.delete(dedupeKey);
+    log.warn(`Failed to deliver event to ${sub.agentName}`, { error: err });
+
+    // Optional: retry with backoff
+    this.scheduleRetry(event, sub, dedupeKey);
+  }
+}
+```
+
+## Conclusion
+The review comment is **valid**. The current design and implementation permanently lose events when transient injection failures occur. The fix requires:
+1. Not marking events as "processed" before confirming successful delivery
+2. Allowing retries for failed injections
+3. Updating `ingest()` to not short-circuit duplicates in non-terminal states
+
+## Next Steps
+1. Update design document in PR #1777 to reflect correct dedup logic
+2. Fix `SpaceGitHubService.ingest()` and `flushTaskNotification()` in code
+3. Add tests for injection retry scenarios
+4. Update documentation to reflect new delivery guarantees


### PR DESCRIPTION
Design documents for external Space workflow node events and the messaging cleanup needed to support them.

Updates:
- Adds a target `InternalEventBus` / `InternalCommandBus` / `InternalQueryBus` architecture and progressive migration plan
- Renames the external-events direction conceptually toward a domain `ExternalEventService` instead of another generic bus
- Keeps GitHub as a first-class source adapter while core services own dedup, task enrichment, topic matching, and node-session delivery
- Documents persistent delivery lifecycle, retry/terminalization behavior, and migration away from `SpaceGitHubService` direct injection