### PR TITLE
Add Google OAuth account management UI to provider settings

### DIFF
--- a/packages/daemon/src/lib/providers/gemini/account-rotation.ts
+++ b/packages/daemon/src/lib/providers/gemini/account-rotation.ts
@@ -236,6 +236,19 @@ export class AccountRotationManager {
 	}
 
 	/**
+	 * Force-reload accounts from storage, bypassing the initialized guard.
+	 *
+	 * Use this when accounts are modified externally (e.g., added or re-authed
+	 * via the UI) so the in-memory pool picks up the latest data without
+	 * requiring a daemon restart.
+	 */
+	async reload(): Promise<void> {
+		this.accounts = await this.storage.load();
+		this.resetDayCountersIfNeeded();
+		log.info(`Reloaded ${this.accounts.length} Google OAuth accounts`);
+	}
+
+	/**
 	 * Get all accounts with their current status.
 	 */
 	getAccounts(): GoogleOAuthAccount[] {

--- a/packages/daemon/src/lib/rpc-handlers/auth-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/auth-handlers.ts
@@ -43,8 +43,27 @@ import {
 
 const log = new Logger('auth-handlers');
 
+/** TTL for pending OAuth flows — 10 minutes. */
+const FLOW_TTL_MS = 10 * 60 * 1000;
+
+interface PendingFlow {
+	codeVerifier: string;
+	reauthAccountId?: string;
+	createdAt: number;
+}
+
 /** Active OAuth code verifiers keyed by a flow ID. */
-const pendingFlows = new Map<string, { codeVerifier: string; reauthAccountId?: string }>();
+const pendingFlows = new Map<string, PendingFlow>();
+
+/** Evict expired flows (called lazily on start/complete). */
+function evictExpiredFlows(): void {
+	const now = Date.now();
+	for (const [id, flow] of pendingFlows) {
+		if (now - flow.createdAt > FLOW_TTL_MS) {
+			pendingFlows.delete(id);
+		}
+	}
+}
 
 /**
  * Convert a GoogleOAuthAccount to a GeminiAccountInfo (strips sensitive tokens).
@@ -265,22 +284,28 @@ export function setupAuthHandlers(messageHub: MessageHub, authManager: AuthManag
 	 * Generates an auth URL with the headless redirect URI and stores the
 	 * PKCE code verifier for later exchange. Returns the URL for the UI
 	 * to display to the user.
+	 *
+	 * Note: Flows are held in-process only; a daemon restart mid-flow
+	 * will lose the pending verifier and the user must start a new flow.
 	 */
 	messageHub.onRequest(
 		'auth.gemini.startOAuth',
 		async (req: StartGeminiOAuthRequest): Promise<StartGeminiOAuthResponse> => {
+			evictExpiredFlows();
 			try {
 				const { authUrl, codeVerifier } = await buildAuthUrl();
 				const flowId = crypto.randomUUID();
 				pendingFlows.set(flowId, {
 					codeVerifier,
 					reauthAccountId: req.accountId,
+					createdAt: Date.now(),
 				});
 
 				return {
 					success: true,
 					authUrl,
-					message: flowId,
+					flowId,
+					message: 'Visit the URL to authorize your Google account, then paste the auth code.',
 				};
 			} catch (error) {
 				log.error('Failed to start Gemini OAuth flow:', error);
@@ -296,7 +321,8 @@ export function setupAuthHandlers(messageHub: MessageHub, authManager: AuthManag
 	 * Complete a Gemini OAuth flow by exchanging the auth code for tokens.
 	 *
 	 * The flow ID maps to the stored PKCE verifier. After successful exchange,
-	 * the account is persisted and the flow is cleaned up.
+	 * the account is persisted and the flow is cleaned up. The in-memory
+	 * rotation manager is kept in sync so sessions pick up changes immediately.
 	 */
 	messageHub.onRequest(
 		'auth.gemini.completeOAuth',
@@ -319,6 +345,15 @@ export function setupAuthHandlers(messageHub: MessageHub, authManager: AuthManag
 				};
 			}
 
+			// Check TTL
+			if (Date.now() - flow.createdAt > FLOW_TTL_MS) {
+				pendingFlows.delete(flowId);
+				return {
+					success: false,
+					error: 'OAuth flow expired. Please start a new one.',
+				};
+			}
+
 			try {
 				const tokenResponse = await exchangeAuthCode(authCode, flow.codeVerifier);
 
@@ -332,30 +367,50 @@ export function setupAuthHandlers(messageHub: MessageHub, authManager: AuthManag
 
 				const userInfo = await fetchUserInfo(tokenResponse.access_token);
 
+				// Helper to sync the rotation manager with the updated account list
+				const syncRotationManager = async () => {
+					const registry = getProviderRegistry();
+					const provider = registry.get('google-gemini-oauth');
+					if (provider && 'getRotationManager' in provider) {
+						const rm = (
+							provider as { getRotationManager: () => { initialize: () => Promise<void> } }
+						).getRotationManager();
+						await rm.initialize();
+					}
+				};
+
 				// If this is a re-auth flow, update the existing account
 				if (flow.reauthAccountId) {
+					await updateAccount(flow.reauthAccountId, {
+						refresh_token: tokenResponse.refresh_token,
+						status: 'active',
+						cooldown_until: 0,
+					});
+					pendingFlows.delete(flowId);
+					await syncRotationManager();
+					log.info(`Re-authenticated Google account: ${userInfo.email}`);
 					const accounts = await loadAccounts();
-					const existing = accounts.find((a) => a.id === flow.reauthAccountId);
-					if (existing) {
-						await updateAccount(flow.reauthAccountId, {
-							refresh_token: tokenResponse.refresh_token,
-							status: 'active',
-							cooldown_until: 0,
-						});
-						const updated = (await loadAccounts()).find((a) => a.id === flow.reauthAccountId);
-						pendingFlows.delete(flowId);
-						log.info(`Re-authenticated Google account: ${userInfo.email}`);
-						return {
-							success: true,
-							account: updated ? accountToInfo(updated) : undefined,
-						};
-					}
+					const updated = accounts.find((a) => a.id === flow.reauthAccountId);
+					return {
+						success: true,
+						account: updated ? accountToInfo(updated) : undefined,
+					};
 				}
 
-				// New account
+				// New account — check for duplicate email
+				const existingAccounts = await loadAccounts();
+				if (existingAccounts.some((a) => a.email === userInfo.email)) {
+					pendingFlows.delete(flowId);
+					return {
+						success: false,
+						error: `Account ${userInfo.email} already exists. Remove it first or use re-authenticate.`,
+					};
+				}
+
 				const account = createAccount(userInfo.email, tokenResponse.refresh_token);
 				await persistAddAccount(account);
 				pendingFlows.delete(flowId);
+				await syncRotationManager();
 
 				log.info(`Added Google account via headless OAuth: ${userInfo.email}`);
 				return {
@@ -381,6 +436,17 @@ export function setupAuthHandlers(messageHub: MessageHub, authManager: AuthManag
 		async (req: RemoveGeminiAccountRequest): Promise<RemoveGeminiAccountResponse> => {
 			try {
 				await persistRemoveAccount(req.accountId);
+				// Sync the in-memory rotation manager so active sessions stop using this account
+				const registry = getProviderRegistry();
+				const provider = registry.get('google-gemini-oauth');
+				if (provider && 'getRotationManager' in provider) {
+					const rm = (
+						provider as {
+							getRotationManager: () => { removeAccount: (id: string) => Promise<void> };
+						}
+					).getRotationManager();
+					await rm.removeAccount(req.accountId);
+				}
 				log.info(`Removed Gemini OAuth account: ${req.accountId}`);
 				return { success: true };
 			} catch (error) {

--- a/packages/daemon/src/lib/rpc-handlers/auth-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/auth-handlers.ts
@@ -429,7 +429,11 @@ export function setupAuthHandlers(messageHub: MessageHub, authManager: AuthManag
 					account: accountToInfo(account),
 				};
 			} catch (error) {
-				pendingFlows.delete(flowId);
+				// Do NOT delete the flow here — the PKCE code verifier is still valid.
+				// The exchange may have failed due to a bad/expired auth code or a
+				// transient network error. Keeping the flow alive lets the user visit
+				// the auth URL again (getting a fresh single-use code) and retry with
+				// the same flowId rather than having to restart the whole OAuth flow.
 				log.error('Gemini OAuth code exchange failed:', error);
 				return {
 					success: false,

--- a/packages/daemon/src/lib/rpc-handlers/auth-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/auth-handlers.ts
@@ -326,9 +326,7 @@ export function setupAuthHandlers(messageHub: MessageHub, authManager: AuthManag
 	 */
 	messageHub.onRequest(
 		'auth.gemini.completeOAuth',
-		async (
-			req: CompleteGeminiOAuthRequest & { flowId?: string }
-		): Promise<CompleteGeminiOAuthResponse> => {
+		async (req: CompleteGeminiOAuthRequest): Promise<CompleteGeminiOAuthResponse> => {
 			const { authCode, flowId } = req;
 			if (!authCode) {
 				return { success: false, error: 'Authorization code is required' };
@@ -367,20 +365,33 @@ export function setupAuthHandlers(messageHub: MessageHub, authManager: AuthManag
 
 				const userInfo = await fetchUserInfo(tokenResponse.access_token);
 
-				// Helper to sync the rotation manager with the updated account list
+				// Helper to sync the rotation manager with the updated account list.
+				// Uses reload() (not initialize()) to bypass the one-time initialized guard
+				// so the in-memory pool picks up changes immediately.
 				const syncRotationManager = async () => {
 					const registry = getProviderRegistry();
 					const provider = registry.get('google-gemini-oauth');
 					if (provider && 'getRotationManager' in provider) {
 						const rm = (
-							provider as { getRotationManager: () => { initialize: () => Promise<void> } }
+							provider as { getRotationManager: () => { reload: () => Promise<void> } }
 						).getRotationManager();
-						await rm.initialize();
+						await rm.reload();
 					}
 				};
 
 				// If this is a re-auth flow, update the existing account
 				if (flow.reauthAccountId) {
+					// Verify the authenticated email matches the target account
+					const existingAccounts = await loadAccounts();
+					const targetAccount = existingAccounts.find((a) => a.id === flow.reauthAccountId);
+					if (targetAccount && targetAccount.email !== userInfo.email) {
+						pendingFlows.delete(flowId);
+						return {
+							success: false,
+							error: `Authenticated email (${userInfo.email}) does not match account email (${targetAccount.email}). Please use the correct Google account.`,
+						};
+					}
+
 					await updateAccount(flow.reauthAccountId, {
 						refresh_token: tokenResponse.refresh_token,
 						status: 'active',

--- a/packages/daemon/src/lib/rpc-handlers/auth-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/auth-handlers.ts
@@ -5,6 +5,7 @@
  * - NeoKai auth status (Anthropic API key / OAuth)
  * - Provider auth status (OpenAI, GitHub Copilot, etc.)
  * - Provider OAuth login/logout
+ * - Gemini OAuth account management (add, list, remove, re-auth)
  */
 
 import type { MessageHub } from '@neokai/shared';
@@ -16,12 +17,50 @@ import type {
 	ProviderRefreshRequest,
 	ProviderRefreshResponse,
 	ListProviderAuthStatusResponse,
+	ListGeminiAccountsResponse,
+	GeminiAccountInfo,
+	StartGeminiOAuthRequest,
+	StartGeminiOAuthResponse,
+	CompleteGeminiOAuthRequest,
+	CompleteGeminiOAuthResponse,
+	RemoveGeminiAccountRequest,
+	RemoveGeminiAccountResponse,
 } from '@neokai/shared/provider';
 import type { AuthManager } from '../auth-manager';
 import { getProviderRegistry } from '../providers/registry';
 import { Logger } from '../logger';
+import {
+	buildAuthUrl,
+	exchangeAuthCode,
+	fetchUserInfo,
+	loadAccounts,
+	createAccount,
+	addAccount as persistAddAccount,
+	removeAccount as persistRemoveAccount,
+	updateAccount,
+	type GoogleOAuthAccount,
+} from '../providers/gemini/oauth-client.js';
 
 const log = new Logger('auth-handlers');
+
+/** Active OAuth code verifiers keyed by a flow ID. */
+const pendingFlows = new Map<string, { codeVerifier: string; reauthAccountId?: string }>();
+
+/**
+ * Convert a GoogleOAuthAccount to a GeminiAccountInfo (strips sensitive tokens).
+ */
+function accountToInfo(account: GoogleOAuthAccount): GeminiAccountInfo {
+	return {
+		id: account.id,
+		email: account.email,
+		status: account.status,
+		addedAt: account.added_at,
+		lastUsedAt: account.last_used_at,
+		dailyRequestCount: account.daily_request_count,
+		dailyLimit: account.daily_limit,
+		cooldownUntil: account.cooldown_until,
+	};
+}
 
 /**
  * Setup authentication-related RPC handlers
@@ -199,6 +238,156 @@ export function setupAuthHandlers(messageHub: MessageHub, authManager: AuthManag
 				return {
 					success: false,
 					error: error instanceof Error ? error.message : 'Token refresh failed',
+				};
+			}
+		}
+	);
+
+	// =========================================================================
+	// Gemini OAuth Account Management
+	// =========================================================================
+
+	/**
+	 * List all configured Gemini OAuth accounts (without sensitive tokens).
+	 */
+	messageHub.onRequest('auth.gemini.accounts', async (): Promise<ListGeminiAccountsResponse> => {
+		try {
+			const accounts = await loadAccounts();
+			return { accounts: accounts.map(accountToInfo) };
+		} catch {
+			return { accounts: [] };
+		}
+	});
+
+	/**
+	 * Start a headless Gemini OAuth flow.
+	 *
+	 * Generates an auth URL with the headless redirect URI and stores the
+	 * PKCE code verifier for later exchange. Returns the URL for the UI
+	 * to display to the user.
+	 */
+	messageHub.onRequest(
+		'auth.gemini.startOAuth',
+		async (req: StartGeminiOAuthRequest): Promise<StartGeminiOAuthResponse> => {
+			try {
+				const { authUrl, codeVerifier } = await buildAuthUrl();
+				const flowId = crypto.randomUUID();
+				pendingFlows.set(flowId, {
+					codeVerifier,
+					reauthAccountId: req.accountId,
+				});
+
+				return {
+					success: true,
+					authUrl,
+					message: flowId,
+				};
+			} catch (error) {
+				log.error('Failed to start Gemini OAuth flow:', error);
+				return {
+					success: false,
+					error: error instanceof Error ? error.message : 'Failed to start OAuth flow',
+				};
+			}
+		}
+	);
+
+	/**
+	 * Complete a Gemini OAuth flow by exchanging the auth code for tokens.
+	 *
+	 * The flow ID maps to the stored PKCE verifier. After successful exchange,
+	 * the account is persisted and the flow is cleaned up.
+	 */
+	messageHub.onRequest(
+		'auth.gemini.completeOAuth',
+		async (
+			req: CompleteGeminiOAuthRequest & { flowId?: string }
+		): Promise<CompleteGeminiOAuthResponse> => {
+			const { authCode, flowId } = req;
+			if (!authCode) {
+				return { success: false, error: 'Authorization code is required' };
+			}
+			if (!flowId) {
+				return { success: false, error: 'Flow ID is required' };
+			}
+
+			const flow = pendingFlows.get(flowId);
+			if (!flow) {
+				return {
+					success: false,
+					error: 'No pending OAuth flow found. Please start a new one.',
+				};
+			}
+
+			try {
+				const tokenResponse = await exchangeAuthCode(authCode, flow.codeVerifier);
+
+				if (!tokenResponse.refresh_token) {
+					pendingFlows.delete(flowId);
+					return {
+						success: false,
+						error: 'No refresh token received. Please ensure you grant all permissions.',
+					};
+				}
+
+				const userInfo = await fetchUserInfo(tokenResponse.access_token);
+
+				// If this is a re-auth flow, update the existing account
+				if (flow.reauthAccountId) {
+					const accounts = await loadAccounts();
+					const existing = accounts.find((a) => a.id === flow.reauthAccountId);
+					if (existing) {
+						await updateAccount(flow.reauthAccountId, {
+							refresh_token: tokenResponse.refresh_token,
+							status: 'active',
+							cooldown_until: 0,
+						});
+						const updated = (await loadAccounts()).find((a) => a.id === flow.reauthAccountId);
+						pendingFlows.delete(flowId);
+						log.info(`Re-authenticated Google account: ${userInfo.email}`);
+						return {
+							success: true,
+							account: updated ? accountToInfo(updated) : undefined,
+						};
+					}
+				}
+
+				// New account
+				const account = createAccount(userInfo.email, tokenResponse.refresh_token);
+				await persistAddAccount(account);
+				pendingFlows.delete(flowId);
+
+				log.info(`Added Google account via headless OAuth: ${userInfo.email}`);
+				return {
+					success: true,
+					account: accountToInfo(account),
+				};
+			} catch (error) {
+				pendingFlows.delete(flowId);
+				log.error('Gemini OAuth code exchange failed:', error);
+				return {
+					success: false,
+					error: error instanceof Error ? error.message : 'Failed to exchange auth code',
+				};
+			}
+		}
+	);
+
+	/**
+	 * Remove a Gemini OAuth account by ID.
+	 */
+	messageHub.onRequest(
+		'auth.gemini.removeAccount',
+		async (req: RemoveGeminiAccountRequest): Promise<RemoveGeminiAccountResponse> => {
+			try {
+				await persistRemoveAccount(req.accountId);
+				log.info(`Removed Gemini OAuth account: ${req.accountId}`);
+				return { success: true };
+			} catch (error) {
+				log.error('Failed to remove Gemini OAuth account:', error);
+				return {
+					success: false,
+					error: error instanceof Error ? error.message : 'Failed to remove account',
 				};
 			}
 		}

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/gemini-auth-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/gemini-auth-handlers.test.ts
@@ -338,11 +338,25 @@ describe('Gemini Auth RPC Handlers', () => {
 		});
 
 		it('handles re-auth flow when accountId provided', async () => {
-			// The re-auth path calls updateAccount, then loadAccounts to get updated record
+			// First loadAccounts: email verification (must match mockFetchUserInfo's 'test@gmail.com')
 			mockLoadAccounts.mockImplementationOnce(async () => [
 				{
 					id: 'acc-to-reauth',
-					email: 'reauth@gmail.com',
+					email: 'test@gmail.com',
+					refresh_token: 'old-rt',
+					added_at: Date.now() - 86_400_000,
+					last_used_at: 0,
+					daily_request_count: 0,
+					daily_limit: 1500,
+					status: 'invalid',
+					cooldown_until: 0,
+				},
+			]);
+			// Second loadAccounts: after updateAccount, get updated record
+			mockLoadAccounts.mockImplementationOnce(async () => [
+				{
+					id: 'acc-to-reauth',
+					email: 'test@gmail.com',
 					refresh_token: 'new-rt',
 					added_at: Date.now() - 86_400_000,
 					last_used_at: 0,
@@ -378,6 +392,43 @@ describe('Gemini Auth RPC Handlers', () => {
 				cooldown_until: 0,
 			});
 			expect(mockPersistAddAccount).not.toHaveBeenCalled();
+		});
+
+		it('returns error when re-auth email does not match target account', async () => {
+			// loadAccounts returns account with different email than mockFetchUserInfo will return
+			mockLoadAccounts.mockImplementationOnce(async () => [
+				{
+					id: 'acc-to-reauth',
+					email: 'other@gmail.com', // different from mockFetchUserInfo's 'test@gmail.com'
+					refresh_token: 'old-rt',
+					added_at: Date.now() - 86_400_000,
+					last_used_at: 0,
+					daily_request_count: 0,
+					daily_limit: 1500,
+					status: 'invalid',
+					cooldown_until: 0,
+				},
+			]);
+
+			const startHandler = messageHubData.handlers.get('auth.gemini.startOAuth');
+			const completeHandler = messageHubData.handlers.get('auth.gemini.completeOAuth');
+
+			const startResult = (await startHandler!({ accountId: 'acc-to-reauth' }, {})) as {
+				success: boolean;
+				flowId?: string;
+			};
+			const flowId = startResult.flowId!;
+
+			const completeResult = (await completeHandler!({ authCode: 'code', flowId }, {})) as {
+				success: boolean;
+				error?: string;
+			};
+
+			expect(completeResult.success).toBe(false);
+			expect(completeResult.error).toContain('does not match');
+			expect(completeResult.error).toContain('test@gmail.com');
+			expect(completeResult.error).toContain('other@gmail.com');
+			expect(mockUpdateAccount).not.toHaveBeenCalled();
 		});
 
 		it('returns specific error for duplicate email', async () => {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/gemini-auth-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/gemini-auth-handlers.test.ts
@@ -1,0 +1,450 @@
+/**
+ * Tests for Gemini OAuth Account Management RPC Handlers
+ *
+ * Tests the RPC handlers for Gemini account management:
+ * - auth.gemini.accounts - List Gemini OAuth accounts
+ * - auth.gemini.startOAuth - Start headless OAuth flow
+ * - auth.gemini.completeOAuth - Complete OAuth with auth code
+ * - auth.gemini.removeAccount - Remove an account
+ */
+
+import { describe, expect, it, beforeEach, mock, afterEach } from 'bun:test';
+import { MessageHub } from '@neokai/shared';
+import type { AuthManager } from '../../../../src/lib/auth-manager';
+import { resetProviderRegistry, getProviderRegistry } from '../../../../src/lib/providers/registry';
+
+// Type for captured request handlers
+type RequestHandler = (data: unknown, context: unknown) => Promise<unknown>;
+
+// Mock oauth-client functions
+const mockBuildAuthUrl = mock(async () => ({
+	authUrl: 'https://accounts.google.com/o/oauth2/v2/auth?mock=1',
+	codeVerifier: 'mock-code-verifier',
+}));
+
+const mockExchangeAuthCode = mock(async () => ({
+	access_token: 'mock-access-token',
+	refresh_token: 'mock-refresh-token',
+	expires_in: 3600,
+	token_type: 'Bearer',
+}));
+
+const mockFetchUserInfo = mock(async () => ({
+	email: 'test@gmail.com',
+	name: 'Test User',
+}));
+
+const mockLoadAccounts = mock(async () => [
+	{
+		id: 'acc-1',
+		email: 'user1@gmail.com',
+		refresh_token: 'rt-1',
+		added_at: Date.now() - 86_400_000,
+		last_used_at: Date.now() - 3600_000,
+		daily_request_count: 342,
+		daily_limit: 1500,
+		status: 'active' as const,
+		cooldown_until: 0,
+	},
+	{
+		id: 'acc-2',
+		email: 'user2@gmail.com',
+		refresh_token: 'rt-2',
+		added_at: Date.now() - 172_800_000,
+		last_used_at: 0,
+		daily_request_count: 0,
+		daily_limit: 1500,
+		status: 'invalid' as const,
+		cooldown_until: 0,
+	},
+]);
+
+const mockCreateAccount = mock((email: string, refreshToken: string) => ({
+	id: 'new-acc-id',
+	email,
+	refresh_token: refreshToken,
+	added_at: Date.now(),
+	last_used_at: 0,
+	daily_request_count: 0,
+	daily_limit: 1500,
+	status: 'active' as const,
+	cooldown_until: 0,
+}));
+
+const mockPersistAddAccount = mock(async () => {});
+const mockPersistRemoveAccount = mock(async () => {});
+const mockUpdateAccount = mock(async () => {});
+
+// Mock the module
+mock.module('../../../../src/lib/providers/gemini/oauth-client.js', () => ({
+	buildAuthUrl: mockBuildAuthUrl,
+	exchangeAuthCode: mockExchangeAuthCode,
+	fetchUserInfo: mockFetchUserInfo,
+	loadAccounts: mockLoadAccounts,
+	createAccount: mockCreateAccount,
+	addAccount: mockPersistAddAccount,
+	removeAccount: mockPersistRemoveAccount,
+	updateAccount: mockUpdateAccount,
+}));
+
+// Mock AuthManager
+const mockAuthManager = {
+	getAuthStatus: mock(async () => ({
+		isAuthenticated: true,
+		method: 'api_key' as const,
+	})),
+};
+
+// Helper to create a minimal mock MessageHub that captures handlers
+function createMockMessageHub(): {
+	hub: MessageHub;
+	handlers: Map<string, RequestHandler>;
+} {
+	const handlers = new Map<string, RequestHandler>();
+
+	const hub = {
+		onRequest: mock((method: string, handler: RequestHandler) => {
+			handlers.set(method, handler);
+			return () => handlers.delete(method);
+		}),
+		onEvent: mock(() => () => {}),
+		request: mock(async () => {}),
+		event: mock(() => {}),
+		joinChannel: mock(async () => {}),
+		leaveChannel: mock(async () => {}),
+		isConnected: mock(() => true),
+		getState: mock(() => 'connected' as const),
+		onConnection: mock(() => () => {}),
+		onMessage: mock(() => () => {}),
+		cleanup: mock(() => {}),
+		registerTransport: mock(() => () => {}),
+		registerRouter: mock(() => {}),
+		getRouter: mock(() => null),
+		getPendingCallCount: mock(() => 0),
+	} as unknown as MessageHub;
+
+	return { hub, handlers };
+}
+
+describe('Gemini Auth RPC Handlers', () => {
+	let messageHubData: ReturnType<typeof createMockMessageHub>;
+
+	beforeEach(async () => {
+		messageHubData = createMockMessageHub();
+
+		// Reset provider registry
+		resetProviderRegistry();
+
+		// Clear all mocks
+		mockBuildAuthUrl.mockClear();
+		mockExchangeAuthCode.mockClear();
+		mockFetchUserInfo.mockClear();
+		mockLoadAccounts.mockClear();
+		mockCreateAccount.mockClear();
+		mockPersistAddAccount.mockClear();
+		mockPersistRemoveAccount.mockClear();
+		mockUpdateAccount.mockClear();
+		mockAuthManager.getAuthStatus.mockClear();
+
+		// Import handler setup after mock is in place
+		const { setupAuthHandlers } = await import('../../../../src/lib/rpc-handlers/auth-handlers');
+		setupAuthHandlers(messageHubData.hub, mockAuthManager as unknown as AuthManager);
+	});
+
+	afterEach(() => {
+		mock.restore();
+	});
+
+	describe('auth.gemini.accounts', () => {
+		it('returns account list without sensitive tokens', async () => {
+			const handler = messageHubData.handlers.get('auth.gemini.accounts');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!({}, {})) as {
+				accounts: Array<{
+					id: string;
+					email: string;
+					status: string;
+					dailyRequestCount: number;
+					dailyLimit: number;
+				}>;
+			};
+
+			expect(result.accounts).toHaveLength(2);
+			expect(result.accounts[0].id).toBe('acc-1');
+			expect(result.accounts[0].email).toBe('user1@gmail.com');
+			expect(result.accounts[0].status).toBe('active');
+			expect(result.accounts[0].dailyRequestCount).toBe(342);
+			expect(result.accounts[0].dailyLimit).toBe(1500);
+			// Verify sensitive token is NOT included
+			expect((result.accounts[0] as Record<string, unknown>).refresh_token).toBeUndefined();
+		});
+
+		it('returns empty list when loadAccounts throws', async () => {
+			mockLoadAccounts.mockImplementationOnce(async () => {
+				throw new Error('File not found');
+			});
+
+			const handler = messageHubData.handlers.get('auth.gemini.accounts');
+			const result = (await handler!({}, {})) as { accounts: unknown[] };
+
+			expect(result.accounts).toEqual([]);
+		});
+	});
+
+	describe('auth.gemini.startOAuth', () => {
+		it('starts OAuth flow and returns auth URL', async () => {
+			const handler = messageHubData.handlers.get('auth.gemini.startOAuth');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!({}, {})) as {
+				success: boolean;
+				authUrl?: string;
+				message?: string;
+			};
+
+			expect(result.success).toBe(true);
+			expect(result.authUrl).toBe('https://accounts.google.com/o/oauth2/v2/auth?mock=1');
+			expect(result.message).toBeDefined();
+			// The message field contains the flowId (UUID)
+			expect(result.message!.length).toBeGreaterThan(0);
+		});
+
+		it('stores accountId for re-auth flows', async () => {
+			const handler = messageHubData.handlers.get('auth.gemini.startOAuth');
+
+			const result = (await handler!({ accountId: 'acc-to-reauth' }, {})) as {
+				success: boolean;
+				message?: string;
+			};
+
+			expect(result.success).toBe(true);
+			// The flowId is stored with reauthAccountId — we verify this works
+			// by completing the flow later in the completeOAuth tests
+		});
+
+		it('returns error when buildAuthUrl throws', async () => {
+			mockBuildAuthUrl.mockImplementationOnce(async () => {
+				throw new Error('GOOGLE_GEMINI_CLIENT_ID not set');
+			});
+
+			const handler = messageHubData.handlers.get('auth.gemini.startOAuth');
+
+			const result = (await handler!({}, {})) as {
+				success: boolean;
+				error?: string;
+			};
+
+			expect(result.success).toBe(false);
+			expect(result.error).toBe('GOOGLE_GEMINI_CLIENT_ID not set');
+		});
+	});
+
+	describe('auth.gemini.completeOAuth', () => {
+		it('returns error when authCode is missing', async () => {
+			const handler = messageHubData.handlers.get('auth.gemini.completeOAuth');
+
+			const result = (await handler!({ flowId: 'some-flow-id' }, {})) as {
+				success: boolean;
+				error?: string;
+			};
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Authorization code is required');
+		});
+
+		it('returns error when flowId is missing', async () => {
+			const handler = messageHubData.handlers.get('auth.gemini.completeOAuth');
+
+			const result = (await handler!({ authCode: 'some-code' }, {})) as {
+				success: boolean;
+				error?: string;
+			};
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Flow ID is required');
+		});
+
+		it('returns error when no pending flow found', async () => {
+			const handler = messageHubData.handlers.get('auth.gemini.completeOAuth');
+
+			const result = (await handler!({ authCode: 'code', flowId: 'non-existent-flow' }, {})) as {
+				success: boolean;
+				error?: string;
+			};
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('No pending OAuth flow found');
+		});
+
+		it('completes full OAuth flow: start → complete', async () => {
+			const startHandler = messageHubData.handlers.get('auth.gemini.startOAuth');
+			const completeHandler = messageHubData.handlers.get('auth.gemini.completeOAuth');
+
+			// Start the flow
+			const startResult = (await startHandler!({}, {})) as {
+				success: boolean;
+				authUrl?: string;
+				message?: string;
+			};
+
+			expect(startResult.success).toBe(true);
+			const flowId = startResult.message!;
+
+			// Complete the flow
+			const completeResult = (await completeHandler!(
+				{ authCode: 'test-auth-code', flowId },
+				{}
+			)) as {
+				success: boolean;
+				account?: { email: string; status: string };
+			};
+
+			expect(completeResult.success).toBe(true);
+			expect(completeResult.account).toBeDefined();
+			expect(completeResult.account!.email).toBe('test@gmail.com');
+			expect(completeResult.account!.status).toBe('active');
+
+			// Verify exchange was called with the code verifier
+			expect(mockExchangeAuthCode).toHaveBeenCalledWith('test-auth-code', 'mock-code-verifier');
+			expect(mockFetchUserInfo).toHaveBeenCalledWith('mock-access-token');
+			expect(mockCreateAccount).toHaveBeenCalledWith('test@gmail.com', 'mock-refresh-token');
+			expect(mockPersistAddAccount).toHaveBeenCalled();
+		});
+
+		it('returns error when no refresh token in response', async () => {
+			mockExchangeAuthCode.mockImplementationOnce(async () => ({
+				access_token: 'mock-access-token',
+				expires_in: 3600,
+				token_type: 'Bearer',
+			}));
+
+			const startHandler = messageHubData.handlers.get('auth.gemini.startOAuth');
+			const completeHandler = messageHubData.handlers.get('auth.gemini.completeOAuth');
+
+			const startResult = (await startHandler!({}, {})) as {
+				success: boolean;
+				message?: string;
+			};
+			const flowId = startResult.message!;
+
+			const completeResult = (await completeHandler!({ authCode: 'code', flowId }, {})) as {
+				success: boolean;
+				error?: string;
+			};
+
+			expect(completeResult.success).toBe(false);
+			expect(completeResult.error).toContain('No refresh token received');
+		});
+
+		it('handles re-auth flow when accountId provided', async () => {
+			mockLoadAccounts.mockImplementationOnce(async () => [
+				{
+					id: 'acc-to-reauth',
+					email: 'reauth@gmail.com',
+					refresh_token: 'old-rt',
+					added_at: Date.now() - 86_400_000,
+					last_used_at: 0,
+					daily_request_count: 0,
+					daily_limit: 1500,
+					status: 'invalid',
+					cooldown_until: 0,
+				},
+			]);
+
+			// Return updated account on second load
+			mockLoadAccounts.mockImplementationOnce(async () => [
+				{
+					id: 'acc-to-reauth',
+					email: 'reauth@gmail.com',
+					refresh_token: 'new-rt',
+					added_at: Date.now() - 86_400_000,
+					last_used_at: 0,
+					daily_request_count: 0,
+					daily_limit: 1500,
+					status: 'active',
+					cooldown_until: 0,
+				},
+			]);
+
+			const startHandler = messageHubData.handlers.get('auth.gemini.startOAuth');
+			const completeHandler = messageHubData.handlers.get('auth.gemini.completeOAuth');
+
+			// Start with accountId for re-auth
+			const startResult = (await startHandler!({ accountId: 'acc-to-reauth' }, {})) as {
+				success: boolean;
+				message?: string;
+			};
+			const flowId = startResult.message!;
+
+			const completeResult = (await completeHandler!({ authCode: 'code', flowId }, {})) as {
+				success: boolean;
+				account?: { id: string; email: string; status: string };
+			};
+
+			expect(completeResult.success).toBe(true);
+			expect(completeResult.account).toBeDefined();
+			expect(completeResult.account!.status).toBe('active');
+			// Should update existing account, not create new
+			expect(mockUpdateAccount).toHaveBeenCalledWith('acc-to-reauth', {
+				refresh_token: 'mock-refresh-token',
+				status: 'active',
+				cooldown_until: 0,
+			});
+			expect(mockPersistAddAccount).not.toHaveBeenCalled();
+		});
+
+		it('handles exchange errors gracefully', async () => {
+			mockExchangeAuthCode.mockImplementationOnce(async () => {
+				throw new Error('Token exchange failed (400): invalid_grant');
+			});
+
+			const startHandler = messageHubData.handlers.get('auth.gemini.startOAuth');
+			const completeHandler = messageHubData.handlers.get('auth.gemini.completeOAuth');
+
+			const startResult = (await startHandler!({}, {})) as {
+				success: boolean;
+				message?: string;
+			};
+			const flowId = startResult.message!;
+
+			const completeResult = (await completeHandler!({ authCode: 'bad-code', flowId }, {})) as {
+				success: boolean;
+				error?: string;
+			};
+
+			expect(completeResult.success).toBe(false);
+			expect(completeResult.error).toContain('invalid_grant');
+		});
+	});
+
+	describe('auth.gemini.removeAccount', () => {
+		it('removes account successfully', async () => {
+			const handler = messageHubData.handlers.get('auth.gemini.removeAccount');
+			expect(handler).toBeDefined();
+
+			const result = (await handler!({ accountId: 'acc-1' }, {})) as {
+				success: boolean;
+			};
+
+			expect(result.success).toBe(true);
+			expect(mockPersistRemoveAccount).toHaveBeenCalledWith('acc-1');
+		});
+
+		it('returns error when account not found', async () => {
+			mockPersistRemoveAccount.mockImplementationOnce(async () => {
+				throw new Error('Account not-found not found');
+			});
+
+			const handler = messageHubData.handlers.get('auth.gemini.removeAccount');
+
+			const result = (await handler!({ accountId: 'not-found' }, {})) as {
+				success: boolean;
+				error?: string;
+			};
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Account not-found not found');
+		});
+	});
+});

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/gemini-auth-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/gemini-auth-handlers.test.ts
@@ -193,21 +193,22 @@ describe('Gemini Auth RPC Handlers', () => {
 	});
 
 	describe('auth.gemini.startOAuth', () => {
-		it('starts OAuth flow and returns auth URL', async () => {
+		it('starts OAuth flow and returns auth URL with flowId', async () => {
 			const handler = messageHubData.handlers.get('auth.gemini.startOAuth');
 			expect(handler).toBeDefined();
 
 			const result = (await handler!({}, {})) as {
 				success: boolean;
 				authUrl?: string;
+				flowId?: string;
 				message?: string;
 			};
 
 			expect(result.success).toBe(true);
 			expect(result.authUrl).toBe('https://accounts.google.com/o/oauth2/v2/auth?mock=1');
+			expect(result.flowId).toBeDefined();
+			expect(result.flowId!.length).toBeGreaterThan(0);
 			expect(result.message).toBeDefined();
-			// The message field contains the flowId (UUID)
-			expect(result.message!.length).toBeGreaterThan(0);
 		});
 
 		it('stores accountId for re-auth flows', async () => {
@@ -215,12 +216,11 @@ describe('Gemini Auth RPC Handlers', () => {
 
 			const result = (await handler!({ accountId: 'acc-to-reauth' }, {})) as {
 				success: boolean;
-				message?: string;
+				flowId?: string;
 			};
 
 			expect(result.success).toBe(true);
-			// The flowId is stored with reauthAccountId — we verify this works
-			// by completing the flow later in the completeOAuth tests
+			expect(result.flowId).toBeDefined();
 		});
 
 		it('returns error when buildAuthUrl throws', async () => {
@@ -285,11 +285,11 @@ describe('Gemini Auth RPC Handlers', () => {
 			const startResult = (await startHandler!({}, {})) as {
 				success: boolean;
 				authUrl?: string;
-				message?: string;
+				flowId?: string;
 			};
 
 			expect(startResult.success).toBe(true);
-			const flowId = startResult.message!;
+			const flowId = startResult.flowId!;
 
 			// Complete the flow
 			const completeResult = (await completeHandler!(
@@ -324,9 +324,9 @@ describe('Gemini Auth RPC Handlers', () => {
 
 			const startResult = (await startHandler!({}, {})) as {
 				success: boolean;
-				message?: string;
+				flowId?: string;
 			};
-			const flowId = startResult.message!;
+			const flowId = startResult.flowId!;
 
 			const completeResult = (await completeHandler!({ authCode: 'code', flowId }, {})) as {
 				success: boolean;
@@ -338,21 +338,7 @@ describe('Gemini Auth RPC Handlers', () => {
 		});
 
 		it('handles re-auth flow when accountId provided', async () => {
-			mockLoadAccounts.mockImplementationOnce(async () => [
-				{
-					id: 'acc-to-reauth',
-					email: 'reauth@gmail.com',
-					refresh_token: 'old-rt',
-					added_at: Date.now() - 86_400_000,
-					last_used_at: 0,
-					daily_request_count: 0,
-					daily_limit: 1500,
-					status: 'invalid',
-					cooldown_until: 0,
-				},
-			]);
-
-			// Return updated account on second load
+			// The re-auth path calls updateAccount, then loadAccounts to get updated record
 			mockLoadAccounts.mockImplementationOnce(async () => [
 				{
 					id: 'acc-to-reauth',
@@ -373,9 +359,9 @@ describe('Gemini Auth RPC Handlers', () => {
 			// Start with accountId for re-auth
 			const startResult = (await startHandler!({ accountId: 'acc-to-reauth' }, {})) as {
 				success: boolean;
-				message?: string;
+				flowId?: string;
 			};
-			const flowId = startResult.message!;
+			const flowId = startResult.flowId!;
 
 			const completeResult = (await completeHandler!({ authCode: 'code', flowId }, {})) as {
 				success: boolean;
@@ -394,6 +380,43 @@ describe('Gemini Auth RPC Handlers', () => {
 			expect(mockPersistAddAccount).not.toHaveBeenCalled();
 		});
 
+		it('returns specific error for duplicate email', async () => {
+			// loadAccounts returns an account with the same email the mock user info will return
+			mockLoadAccounts.mockImplementationOnce(async () => [
+				{
+					id: 'existing-acc',
+					email: 'test@gmail.com', // same as mockFetchUserInfo returns
+					refresh_token: 'existing-rt',
+					added_at: Date.now() - 86_400_000,
+					last_used_at: 0,
+					daily_request_count: 0,
+					daily_limit: 1500,
+					status: 'active',
+					cooldown_until: 0,
+				},
+			]);
+
+			const startHandler = messageHubData.handlers.get('auth.gemini.startOAuth');
+			const completeHandler = messageHubData.handlers.get('auth.gemini.completeOAuth');
+
+			const startResult = (await startHandler!({}, {})) as {
+				success: boolean;
+				flowId?: string;
+			};
+			const flowId = startResult.flowId!;
+
+			const completeResult = (await completeHandler!({ authCode: 'code', flowId }, {})) as {
+				success: boolean;
+				error?: string;
+			};
+
+			expect(completeResult.success).toBe(false);
+			expect(completeResult.error).toContain('already exists');
+			expect(completeResult.error).toContain('test@gmail.com');
+			// Should NOT have called persistAddAccount
+			expect(mockPersistAddAccount).not.toHaveBeenCalled();
+		});
+
 		it('handles exchange errors gracefully', async () => {
 			mockExchangeAuthCode.mockImplementationOnce(async () => {
 				throw new Error('Token exchange failed (400): invalid_grant');
@@ -404,9 +427,9 @@ describe('Gemini Auth RPC Handlers', () => {
 
 			const startResult = (await startHandler!({}, {})) as {
 				success: boolean;
-				message?: string;
+				flowId?: string;
 			};
-			const flowId = startResult.message!;
+			const flowId = startResult.flowId!;
 
 			const completeResult = (await completeHandler!({ authCode: 'bad-code', flowId }, {})) as {
 				success: boolean;

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/gemini-auth-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/gemini-auth-handlers.test.ts
@@ -490,6 +490,42 @@ describe('Gemini Auth RPC Handlers', () => {
 			expect(completeResult.success).toBe(false);
 			expect(completeResult.error).toContain('invalid_grant');
 		});
+
+		it('flow survives exchange error — retry with fresh code succeeds', async () => {
+			// First attempt: exchange fails (e.g., bad/expired auth code)
+			mockExchangeAuthCode.mockImplementationOnce(async () => {
+				throw new Error('Token exchange failed (400): invalid_grant');
+			});
+
+			const startHandler = messageHubData.handlers.get('auth.gemini.startOAuth');
+			const completeHandler = messageHubData.handlers.get('auth.gemini.completeOAuth');
+
+			// Start flow once
+			const startResult = (await startHandler!({}, {})) as {
+				success: boolean;
+				flowId?: string;
+			};
+			expect(startResult.success).toBe(true);
+			const flowId = startResult.flowId!;
+
+			// First attempt fails
+			const firstAttempt = (await completeHandler!({ authCode: 'bad-code', flowId }, {})) as {
+				success: boolean;
+				error?: string;
+			};
+			expect(firstAttempt.success).toBe(false);
+
+			// Flow must still be alive — second attempt with a valid code must succeed
+			// (mockExchangeAuthCode is back to its default implementation)
+			const secondAttempt = (await completeHandler!({ authCode: 'good-code', flowId }, {})) as {
+				success: boolean;
+				account?: { email: string };
+			};
+
+			expect(secondAttempt.success).toBe(true);
+			expect(secondAttempt.account?.email).toBe('test@gmail.com');
+			expect(mockExchangeAuthCode).toHaveBeenLastCalledWith('good-code', 'mock-code-verifier');
+		});
 	});
 
 	describe('auth.gemini.removeAccount', () => {

--- a/packages/shared/src/provider/auth-types.ts
+++ b/packages/shared/src/provider/auth-types.ts
@@ -161,7 +161,9 @@ export interface StartGeminiOAuthResponse {
 	success: boolean;
 	/** Auth URL for the user to visit */
 	authUrl?: string;
-	/** Code verifier (stored server-side for exchange) */
+	/** Flow ID used to correlate start → complete (passed back in completeOAuth) */
+	flowId?: string;
+	/** Human-readable message / instructions */
 	message?: string;
 	/** Error message if failed */
 	error?: string;

--- a/packages/shared/src/provider/auth-types.ts
+++ b/packages/shared/src/provider/auth-types.ts
@@ -106,3 +106,101 @@ export interface OAuthFlowData {
 	/** Human-readable message */
 	message: string;
 }
+
+// ---------------------------------------------------------------------------
+// Gemini OAuth Account Management Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Account status indicator for Gemini OAuth accounts
+ */
+export type GeminiAccountStatus = 'active' | 'exhausted' | 'invalid';
+
+/**
+ * Gemini OAuth account info for UI display (excludes sensitive tokens)
+ */
+export interface GeminiAccountInfo {
+	/** Unique account identifier */
+	id: string;
+	/** Google account email */
+	email: string;
+	/** Account status */
+	status: GeminiAccountStatus;
+	/** ISO timestamp when account was added */
+	addedAt: number;
+	/** ISO timestamp when account was last used (0 = never) */
+	lastUsedAt: number;
+	/** Number of requests made today */
+	dailyRequestCount: number;
+	/** Daily request limit for this account */
+	dailyLimit: number;
+	/** Cooldown until timestamp (Unix ms). 0 = no cooldown */
+	cooldownUntil: number;
+}
+
+/**
+ * Response from listing Gemini OAuth accounts
+ */
+export interface ListGeminiAccountsResponse {
+	accounts: GeminiAccountInfo[];
+}
+
+/**
+ * Request to start a headless Gemini OAuth flow
+ */
+export interface StartGeminiOAuthRequest {
+	/** Optional account ID to re-authenticate (for re-auth flows) */
+	accountId?: string;
+}
+
+/**
+ * Response from starting a Gemini OAuth flow
+ */
+export interface StartGeminiOAuthResponse {
+	/** Whether the flow was initiated successfully */
+	success: boolean;
+	/** Auth URL for the user to visit */
+	authUrl?: string;
+	/** Code verifier (stored server-side for exchange) */
+	message?: string;
+	/** Error message if failed */
+	error?: string;
+}
+
+/**
+ * Request to complete a Gemini OAuth flow with auth code
+ */
+export interface CompleteGeminiOAuthRequest {
+	/** The authorization code from Google */
+	authCode: string;
+}
+
+/**
+ * Response from completing a Gemini OAuth flow
+ */
+export interface CompleteGeminiOAuthResponse {
+	/** Whether the account was added successfully */
+	success: boolean;
+	/** Added account info */
+	account?: GeminiAccountInfo;
+	/** Error message if failed */
+	error?: string;
+}
+
+/**
+ * Request to remove a Gemini OAuth account
+ */
+export interface RemoveGeminiAccountRequest {
+	/** Account ID to remove */
+	accountId: string;
+}
+
+/**
+ * Response from removing a Gemini OAuth account
+ */
+export interface RemoveGeminiAccountResponse {
+	/** Whether the account was removed successfully */
+	success: boolean;
+	/** Error message if failed */
+	error?: string;
+}

--- a/packages/shared/src/provider/auth-types.ts
+++ b/packages/shared/src/provider/auth-types.ts
@@ -175,6 +175,8 @@ export interface StartGeminiOAuthResponse {
 export interface CompleteGeminiOAuthRequest {
 	/** The authorization code from Google */
 	authCode: string;
+	/** Flow ID returned by startOAuth, used to look up the stored PKCE verifier */
+	flowId: string;
 }
 
 /**

--- a/packages/shared/src/provider/index.ts
+++ b/packages/shared/src/provider/index.ts
@@ -24,4 +24,13 @@ export type {
 	ProviderRefreshResponse,
 	ListProviderAuthStatusResponse,
 	OAuthFlowData,
+	GeminiAccountStatus,
+	GeminiAccountInfo,
+	ListGeminiAccountsResponse,
+	StartGeminiOAuthRequest,
+	StartGeminiOAuthResponse,
+	CompleteGeminiOAuthRequest,
+	CompleteGeminiOAuthResponse,
+	RemoveGeminiAccountRequest,
+	RemoveGeminiAccountResponse,
 } from './auth-types.js';

--- a/packages/web/src/components/settings/AddGoogleAccountModal.tsx
+++ b/packages/web/src/components/settings/AddGoogleAccountModal.tsx
@@ -268,7 +268,18 @@ export function AddGoogleAccountModal({
 							</div>
 						</div>
 						<div class="flex items-center gap-3">
-							<Button variant="primary" size="sm" onClick={() => setStep('code')}>
+							<Button
+								variant="primary"
+								size="sm"
+								onClick={() => {
+									// Return to the URL step so the user opens the auth URL
+									// again and retrieves a fresh single-use code. The same
+									// flowId / PKCE verifier is reused — only the auth code
+									// needs to be re-fetched from Google.
+									setAuthCode('');
+									setStep('url');
+								}}
+							>
 								Try Again
 							</Button>
 							<Button variant="ghost" size="sm" onClick={onCancel}>

--- a/packages/web/src/components/settings/AddGoogleAccountModal.tsx
+++ b/packages/web/src/components/settings/AddGoogleAccountModal.tsx
@@ -271,8 +271,8 @@ export function AddGoogleAccountModal({
 							<Button variant="primary" size="sm" onClick={() => setStep('code')}>
 								Try Again
 							</Button>
-							<Button variant="ghost" size="sm" onClick={() => setStep('url')}>
-								Start Over
+							<Button variant="ghost" size="sm" onClick={onCancel}>
+								Cancel
 							</Button>
 						</div>
 					</div>

--- a/packages/web/src/components/settings/AddGoogleAccountModal.tsx
+++ b/packages/web/src/components/settings/AddGoogleAccountModal.tsx
@@ -1,0 +1,290 @@
+import { useState } from 'preact/hooks';
+import { Button } from '../ui/Button.tsx';
+
+type Step = 'url' | 'code' | 'success' | 'error';
+
+interface AddGoogleAccountModalProps {
+	authUrl: string;
+	flowId: string;
+	onComplete: () => void;
+	onCancel: () => void;
+	onSubmitCode: (authCode: string, flowId: string) => Promise<{ success: boolean; error?: string }>;
+}
+
+export function AddGoogleAccountModal({
+	authUrl,
+	flowId,
+	onComplete,
+	onCancel,
+	onSubmitCode,
+}: AddGoogleAccountModalProps) {
+	const [step, setStep] = useState<Step>('url');
+	const [authCode, setAuthCode] = useState('');
+	const [urlCopied, setUrlCopied] = useState(false);
+	const [submitting, setSubmitting] = useState(false);
+	const [errorMessage, setErrorMessage] = useState('');
+
+	const copyUrl = async () => {
+		try {
+			await navigator.clipboard.writeText(authUrl);
+			setUrlCopied(true);
+			setTimeout(() => setUrlCopied(false), 2000);
+		} catch {
+			// Clipboard API not available
+		}
+	};
+
+	const openAuthUrl = () => {
+		window.open(authUrl, '_blank');
+		setStep('code');
+	};
+
+	const handleSubmitCode = async () => {
+		if (!authCode.trim()) return;
+
+		setSubmitting(true);
+		setErrorMessage('');
+
+		try {
+			const result = await onSubmitCode(authCode.trim(), flowId);
+			if (result.success) {
+				setStep('success');
+				setTimeout(onComplete, 1500);
+			} else {
+				setStep('error');
+				setErrorMessage(result.error || 'Failed to add account');
+			}
+		} catch (err) {
+			setStep('error');
+			setErrorMessage(err instanceof Error ? err.message : 'Failed to add account');
+		} finally {
+			setSubmitting(false);
+		}
+	};
+
+	const handleKeyDown = (e: KeyboardEvent) => {
+		if (e.key === 'Escape') {
+			onCancel();
+		}
+		if (e.key === 'Enter' && step === 'code' && authCode.trim()) {
+			handleSubmitCode();
+		}
+	};
+
+	return (
+		<div class="fixed inset-0 z-50 flex items-center justify-center">
+			{/* Backdrop */}
+			<div
+				class="absolute inset-0 bg-black/60 backdrop-blur-sm cursor-pointer"
+				onClick={onCancel}
+			/>
+
+			{/* Modal */}
+			<div class="relative bg-dark-900 border border-dark-700 rounded-xl shadow-2xl max-w-lg w-full mx-4 p-6">
+				{/* Header */}
+				<div class="flex items-center justify-between mb-5">
+					<h3 class="text-lg font-semibold text-gray-100">Add Google Account</h3>
+					<button onClick={onCancel} class="text-gray-400 hover:text-gray-200 transition-colors">
+						<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={2}
+								d="M6 18L18 6M6 6l12 12"
+							/>
+						</svg>
+					</button>
+				</div>
+
+				{/* Step 1: Auth URL */}
+				{step === 'url' && (
+					<div class="space-y-4">
+						<p class="text-sm text-gray-300">
+							Visit the Google authorization URL below to get an authorization code. Log in with
+							your Google account (Pro subscription required).
+						</p>
+
+						{/* Auth URL display */}
+						<div class="bg-dark-800 border border-dark-700 rounded-lg p-3">
+							<p class="text-xs text-gray-400 mb-2">Authorization URL:</p>
+							<div class="flex items-start gap-2">
+								<a
+									href={authUrl}
+									target="_blank"
+									rel="noopener noreferrer"
+									class="text-xs text-blue-400 hover:text-blue-300 break-all flex-1"
+								>
+									{authUrl}
+								</a>
+							</div>
+						</div>
+
+						{/* Action buttons */}
+						<div class="flex items-center gap-3">
+							<Button variant="primary" size="sm" onClick={openAuthUrl}>
+								<svg class="w-4 h-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width={2}
+										d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+									/>
+								</svg>
+								Open URL & Continue
+							</Button>
+							<Button variant="secondary" size="sm" onClick={copyUrl}>
+								{urlCopied ? (
+									<>
+										<svg
+											class="w-4 h-4 mr-1.5"
+											fill="none"
+											viewBox="0 0 24 24"
+											stroke="currentColor"
+										>
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												stroke-width={2}
+												d="M5 13l4 4L19 7"
+											/>
+										</svg>
+										Copied!
+									</>
+								) : (
+									<>
+										<svg
+											class="w-4 h-4 mr-1.5"
+											fill="none"
+											viewBox="0 0 24 24"
+											stroke="currentColor"
+										>
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												stroke-width={2}
+												d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+											/>
+										</svg>
+										Copy URL
+									</>
+								)}
+							</Button>
+						</div>
+
+						<p class="text-xs text-gray-500">
+							After authorizing, Google will display an authorization code. Copy it and paste it in
+							the next step.
+						</p>
+					</div>
+				)}
+
+				{/* Step 2: Enter auth code */}
+				{step === 'code' && (
+					<div class="space-y-4">
+						<p class="text-sm text-gray-300">
+							Paste the authorization code from Google below. You can still{' '}
+							<button onClick={openAuthUrl} class="text-blue-400 hover:text-blue-300 underline">
+								open the URL
+							</button>{' '}
+							if you haven't visited it yet.
+						</p>
+
+						<div>
+							<label for="gemini-auth-code" class="block text-sm font-medium text-gray-300 mb-1.5">
+								Authorization Code
+							</label>
+							<input
+								id="gemini-auth-code"
+								type="text"
+								value={authCode}
+								onInput={(e) => setAuthCode((e.target as HTMLInputElement).value)}
+								onKeyDown={handleKeyDown}
+								placeholder="Paste your authorization code here..."
+								class="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent font-mono"
+								autoFocus
+								spellcheck={false}
+							/>
+						</div>
+
+						{errorMessage && <p class="text-sm text-red-400">{errorMessage}</p>}
+
+						<div class="flex items-center gap-3">
+							<Button
+								variant="primary"
+								size="sm"
+								onClick={handleSubmitCode}
+								loading={submitting}
+								disabled={!authCode.trim() || submitting}
+							>
+								Add Account
+							</Button>
+							<Button variant="ghost" size="sm" onClick={() => setStep('url')}>
+								Back
+							</Button>
+						</div>
+					</div>
+				)}
+
+				{/* Step 3: Success */}
+				{step === 'success' && (
+					<div class="space-y-4 text-center py-4">
+						<svg
+							class="w-12 h-12 text-green-400 mx-auto"
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+						>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={2}
+								d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+							/>
+						</svg>
+						<p class="text-sm text-green-400 font-medium">Account added successfully!</p>
+					</div>
+				)}
+
+				{/* Step 4: Error */}
+				{step === 'error' && (
+					<div class="space-y-4">
+						<div class="flex items-start gap-3">
+							<svg
+								class="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke="currentColor"
+							>
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width={2}
+									d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+								/>
+							</svg>
+							<div>
+								<p class="text-sm text-red-400 font-medium">Failed to add account</p>
+								<p class="text-sm text-gray-400 mt-1">{errorMessage}</p>
+							</div>
+						</div>
+						<div class="flex items-center gap-3">
+							<Button variant="primary" size="sm" onClick={() => setStep('code')}>
+								Try Again
+							</Button>
+							<Button variant="ghost" size="sm" onClick={() => setStep('url')}>
+								Start Over
+							</Button>
+						</div>
+					</div>
+				)}
+
+				{/* Footer */}
+				<div class="mt-6 pt-4 border-t border-dark-700 flex justify-end">
+					<Button variant="secondary" onClick={onCancel}>
+						Cancel
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/settings/GeminiAccountsPanel.tsx
+++ b/packages/web/src/components/settings/GeminiAccountsPanel.tsx
@@ -1,0 +1,363 @@
+import { useEffect, useState } from 'preact/hooks';
+import { toast } from '../../lib/toast.ts';
+import type { GeminiAccountInfo } from '@neokai/shared/provider';
+import {
+	listGeminiAccounts,
+	startGeminiOAuth,
+	completeGeminiOAuth,
+	removeGeminiAccount,
+} from '../../lib/api-helpers.ts';
+import { Button } from '../ui/Button.tsx';
+import { AddGoogleAccountModal } from './AddGoogleAccountModal.tsx';
+
+/** Format a timestamp as a relative time string. */
+function relativeTime(ts: number): string {
+	if (ts === 0) return 'Never';
+	const diff = Date.now() - ts;
+	if (diff < 60_000) return 'Just now';
+	if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+	if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+	return new Date(ts).toLocaleDateString();
+}
+
+/** Format daily usage with comma separators. */
+function formatUsage(count: number, limit: number): string {
+	return `${count.toLocaleString()} / ${limit.toLocaleString()} requests`;
+}
+
+/** Status dot color mapping. */
+function statusColor(status: GeminiAccountInfo['status']): string {
+	switch (status) {
+		case 'active':
+			return 'bg-green-400';
+		case 'exhausted':
+			return 'bg-amber-400';
+		case 'invalid':
+			return 'bg-red-400';
+	}
+}
+
+/** Status label. */
+function statusLabel(account: GeminiAccountInfo): string {
+	switch (account.status) {
+		case 'active':
+			return 'Active';
+		case 'exhausted': {
+			if (account.cooldownUntil > 0) {
+				const remaining = Math.max(0, account.cooldownUntil - Date.now());
+				if (remaining > 0) {
+					const mins = Math.ceil(remaining / 60_000);
+					return `Exhausted (${mins}m cooldown)`;
+				}
+			}
+			return 'Exhausted';
+		}
+		case 'invalid':
+			return 'Invalid';
+	}
+}
+
+/** Confirm dialog state. */
+interface ConfirmState {
+	open: boolean;
+	title: string;
+	message: string;
+	onConfirm: () => void;
+}
+
+export function GeminiAccountsPanel() {
+	const [accounts, setAccounts] = useState<GeminiAccountInfo[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [showAddModal, setShowAddModal] = useState(false);
+	const [oauthAuthUrl, setOauthAuthUrl] = useState('');
+	const [oauthFlowId, setOauthFlowId] = useState('');
+	const [startingOAuth, setStartingOAuth] = useState(false);
+	const [confirm, setConfirm] = useState<ConfirmState>({
+		open: false,
+		title: '',
+		message: '',
+		onConfirm: () => {},
+	});
+
+	const loadAccounts = async () => {
+		try {
+			const response = await listGeminiAccounts();
+			setAccounts(response.accounts);
+		} catch {
+			// Failed to load accounts
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	useEffect(() => {
+		loadAccounts();
+	}, []);
+
+	// Auto-refresh accounts every 30 seconds
+	useEffect(() => {
+		const interval = setInterval(loadAccounts, 30_000);
+		return () => clearInterval(interval);
+	}, []);
+
+	const handleAddAccount = async () => {
+		setStartingOAuth(true);
+		try {
+			const response = await startGeminiOAuth();
+			if (response.success && response.authUrl) {
+				setOauthAuthUrl(response.authUrl);
+				setOauthFlowId(response.message || '');
+				setShowAddModal(true);
+			} else {
+				toast.error(response.error || 'Failed to start OAuth flow');
+			}
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : 'Failed to start OAuth flow');
+		} finally {
+			setStartingOAuth(false);
+		}
+	};
+
+	const handleReauth = async (account: GeminiAccountInfo) => {
+		setStartingOAuth(true);
+		try {
+			const response = await startGeminiOAuth(account.id);
+			if (response.success && response.authUrl) {
+				setOauthAuthUrl(response.authUrl);
+				setOauthFlowId(response.message || '');
+				setShowAddModal(true);
+			} else {
+				toast.error(response.error || 'Failed to start re-authentication');
+			}
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : 'Failed to start re-authentication');
+		} finally {
+			setStartingOAuth(false);
+		}
+	};
+
+	const handleSubmitCode = async (
+		authCode: string,
+		flowId: string
+	): Promise<{ success: boolean; error?: string }> => {
+		const response = await completeGeminiOAuth(authCode, flowId);
+		if (response.success) {
+			await loadAccounts();
+		}
+		return { success: response.success, error: response.error };
+	};
+
+	const handleRemoveAccount = (account: GeminiAccountInfo) => {
+		setConfirm({
+			open: true,
+			title: 'Remove Google Account',
+			message: `Remove ${account.email}? Any sessions using this account will failover to another.`,
+			onConfirm: async () => {
+				try {
+					const response = await removeGeminiAccount(account.id);
+					if (response.success) {
+						toast.success(`Removed ${account.email}`);
+						await loadAccounts();
+					} else {
+						toast.error(response.error || 'Failed to remove account');
+					}
+				} catch (err) {
+					toast.error(err instanceof Error ? err.message : 'Failed to remove account');
+				}
+				setConfirm((prev) => ({ ...prev, open: false }));
+			},
+		});
+	};
+
+	// Summary stats
+	const activeCount = accounts.filter((a) => a.status === 'active').length;
+	const totalRequests = accounts.reduce((sum, a) => sum + a.dailyRequestCount, 0);
+	const totalLimit = accounts.reduce((sum, a) => sum + a.dailyLimit, 0);
+	const remaining = totalLimit - totalRequests;
+
+	if (loading) {
+		return <div class="text-gray-500 text-sm py-2">Loading accounts...</div>;
+	}
+
+	return (
+		<div class="space-y-4">
+			{/* Provider summary */}
+			{accounts.length > 0 && (
+				<div class="flex items-center gap-4 text-sm text-gray-400">
+					<span>
+						{accounts.length} account{accounts.length !== 1 ? 's' : ''}
+					</span>
+					<span class="text-gray-600">·</span>
+					<span>
+						{remaining.toLocaleString()} / {totalLimit.toLocaleString()} daily requests remaining
+					</span>
+				</div>
+			)}
+
+			{/* Warnings */}
+			{accounts.length > 0 && activeCount === 0 && (
+				<div class="flex items-start gap-2 p-3 bg-amber-900/30 border border-amber-700/50 rounded-lg">
+					<svg
+						class="w-4 h-4 text-amber-400 flex-shrink-0 mt-0.5"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width={2}
+							d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z"
+						/>
+					</svg>
+					<p class="text-sm text-amber-300">
+						All accounts are exhausted or invalid. Add more accounts or wait for cooldown.
+					</p>
+				</div>
+			)}
+			{accounts.length > 0 && activeCount === 1 && (
+				<div class="flex items-start gap-2 p-3 bg-yellow-900/20 border border-yellow-700/30 rounded-lg">
+					<svg
+						class="w-4 h-4 text-yellow-400 flex-shrink-0 mt-0.5"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width={2}
+							d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+						/>
+					</svg>
+					<p class="text-sm text-yellow-300">
+						Only 1 active account — no failover capacity. Consider adding another account.
+					</p>
+				</div>
+			)}
+
+			{/* Account list */}
+			{accounts.length === 0 ? (
+				<div class="text-gray-500 text-sm py-2">
+					No Google accounts added yet. Add an account to use Gemini models via OAuth.
+				</div>
+			) : (
+				<div class="space-y-2">
+					{accounts.map((account) => (
+						<div
+							key={account.id}
+							class="flex items-center justify-between p-3 bg-dark-800 rounded-lg border border-dark-700"
+						>
+							<div class="flex-1 min-w-0">
+								<div class="flex items-center gap-2">
+									<span
+										class={`w-2 h-2 rounded-full flex-shrink-0 ${statusColor(account.status)}`}
+									/>
+									<span class="text-sm font-medium text-gray-200 truncate">{account.email}</span>
+									<span
+										class={`inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full ${
+											account.status === 'active'
+												? 'bg-green-900/50 text-green-400'
+												: account.status === 'exhausted'
+													? 'bg-amber-900/50 text-amber-400'
+													: 'bg-red-900/50 text-red-400'
+										}`}
+									>
+										{statusLabel(account)}
+									</span>
+								</div>
+								<div class="flex items-center gap-3 mt-1 text-xs text-gray-500">
+									<span>{formatUsage(account.dailyRequestCount, account.dailyLimit)}</span>
+									<span>·</span>
+									<span>Last used: {relativeTime(account.lastUsedAt)}</span>
+								</div>
+							</div>
+							<div class="flex-shrink-0 ml-3 flex items-center gap-2">
+								{account.status === 'invalid' && (
+									<Button
+										variant="warning"
+										size="xs"
+										onClick={() => handleReauth(account)}
+										disabled={startingOAuth}
+									>
+										Re-auth
+									</Button>
+								)}
+								<Button variant="ghost" size="xs" onClick={() => handleRemoveAccount(account)}>
+									<svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width={2}
+											d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+										/>
+									</svg>
+								</Button>
+							</div>
+						</div>
+					))}
+				</div>
+			)}
+
+			{/* Add account button */}
+			<Button
+				variant="secondary"
+				size="sm"
+				onClick={handleAddAccount}
+				loading={startingOAuth}
+				disabled={startingOAuth}
+			>
+				<svg class="w-4 h-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width={2}
+						d="M12 4v16m8-8H4"
+					/>
+				</svg>
+				Add Google Account
+			</Button>
+
+			{/* Add Account Modal */}
+			{showAddModal && (
+				<AddGoogleAccountModal
+					authUrl={oauthAuthUrl}
+					flowId={oauthFlowId}
+					onComplete={() => {
+						setShowAddModal(false);
+						loadAccounts();
+						toast.success('Google account added successfully');
+					}}
+					onCancel={() => setShowAddModal(false)}
+					onSubmitCode={handleSubmitCode}
+				/>
+			)}
+
+			{/* Confirm Dialog */}
+			{confirm.open && (
+				<div class="fixed inset-0 z-50 flex items-center justify-center">
+					<div
+						class="absolute inset-0 bg-black/60 backdrop-blur-sm cursor-pointer"
+						onClick={() => setConfirm((prev) => ({ ...prev, open: false }))}
+					/>
+					<div class="relative bg-dark-900 border border-dark-700 rounded-xl shadow-2xl max-w-sm w-full mx-4 p-6">
+						<h3 class="text-lg font-semibold text-gray-100 mb-2">{confirm.title}</h3>
+						<p class="text-sm text-gray-300 mb-5">{confirm.message}</p>
+						<div class="flex justify-end gap-3">
+							<Button
+								variant="secondary"
+								size="sm"
+								onClick={() => setConfirm((prev) => ({ ...prev, open: false }))}
+							>
+								Cancel
+							</Button>
+							<Button variant="danger" size="sm" onClick={confirm.onConfirm}>
+								Remove
+							</Button>
+						</div>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/packages/web/src/components/settings/GeminiAccountsPanel.tsx
+++ b/packages/web/src/components/settings/GeminiAccountsPanel.tsx
@@ -104,9 +104,9 @@ export function GeminiAccountsPanel() {
 		setStartingOAuth(true);
 		try {
 			const response = await startGeminiOAuth();
-			if (response.success && response.authUrl) {
+			if (response.success && response.authUrl && response.flowId) {
 				setOauthAuthUrl(response.authUrl);
-				setOauthFlowId(response.flowId || '');
+				setOauthFlowId(response.flowId);
 				setShowAddModal(true);
 			} else {
 				toast.error(response.error || 'Failed to start OAuth flow');
@@ -122,9 +122,9 @@ export function GeminiAccountsPanel() {
 		setStartingOAuth(true);
 		try {
 			const response = await startGeminiOAuth(account.id);
-			if (response.success && response.authUrl) {
+			if (response.success && response.authUrl && response.flowId) {
 				setOauthAuthUrl(response.authUrl);
-				setOauthFlowId(response.flowId || '');
+				setOauthFlowId(response.flowId);
 				setShowAddModal(true);
 			} else {
 				toast.error(response.error || 'Failed to start re-authentication');

--- a/packages/web/src/components/settings/GeminiAccountsPanel.tsx
+++ b/packages/web/src/components/settings/GeminiAccountsPanel.tsx
@@ -106,7 +106,7 @@ export function GeminiAccountsPanel() {
 			const response = await startGeminiOAuth();
 			if (response.success && response.authUrl) {
 				setOauthAuthUrl(response.authUrl);
-				setOauthFlowId(response.message || '');
+				setOauthFlowId(response.flowId || '');
 				setShowAddModal(true);
 			} else {
 				toast.error(response.error || 'Failed to start OAuth flow');
@@ -124,7 +124,7 @@ export function GeminiAccountsPanel() {
 			const response = await startGeminiOAuth(account.id);
 			if (response.success && response.authUrl) {
 				setOauthAuthUrl(response.authUrl);
-				setOauthFlowId(response.message || '');
+				setOauthFlowId(response.flowId || '');
 				setShowAddModal(true);
 			} else {
 				toast.error(response.error || 'Failed to start re-authentication');

--- a/packages/web/src/components/settings/ProvidersSettings.tsx
+++ b/packages/web/src/components/settings/ProvidersSettings.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../lib/api-helpers.ts';
 import { SettingsSection } from './SettingsSection.tsx';
 import { OAuthModal } from './OAuthModal.tsx';
+import { GeminiAccountsPanel } from './GeminiAccountsPanel.tsx';
 import { Button } from '../ui/Button.tsx';
 
 interface OAuthFlowState {
@@ -164,6 +165,10 @@ export function ProvidersSettings() {
 		);
 	}
 
+	// Separate Gemini OAuth provider from other providers for custom UI
+	const geminiProvider = providers.find((p) => p.id === 'google-gemini-oauth');
+	const otherProviders = providers.filter((p) => p.id !== 'google-gemini-oauth');
+
 	return (
 		<>
 			<SettingsSection title="Providers">
@@ -172,11 +177,52 @@ export function ProvidersSettings() {
 						Configure authentication for AI providers. Each provider may use OAuth or API keys.
 					</p>
 
-					{providers.length === 0 ? (
+					{/* Gemini OAuth section with account management */}
+					{geminiProvider && (
+						<div class="p-4 bg-dark-800/50 rounded-lg border border-dark-700">
+							<div class="flex items-center justify-between mb-3">
+								<div class="flex items-center gap-2">
+									<span class="text-sm font-medium text-gray-200">
+										{geminiProvider.displayName}
+									</span>
+									{geminiProvider.isAuthenticated && (
+										<span class="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full bg-green-900/50 text-green-400">
+											OAuth
+										</span>
+									)}
+									{!geminiProvider.isAuthenticated && (
+										<span class="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full bg-gray-800 text-gray-400">
+											No accounts
+										</span>
+									)}
+								</div>
+								{!geminiProvider.isAuthenticated && (
+									<Button
+										variant="secondary"
+										size="xs"
+										disabled={!!pendingProvider}
+										onClick={() => {
+											// The GeminiAccountsPanel's Add button handles the actual OAuth
+										}}
+									>
+										Setup
+									</Button>
+								)}
+							</div>
+							{geminiProvider.error && (
+								<p class="text-xs text-red-400 mb-2">{geminiProvider.error}</p>
+							)}
+							<GeminiAccountsPanel />
+						</div>
+					)}
+
+					{/* Other providers */}
+					{otherProviders.length === 0 && !geminiProvider && (
 						<div class="text-gray-500 text-sm">No providers available</div>
-					) : (
+					)}
+					{otherProviders.length > 0 && (
 						<div class="space-y-3">
-							{providers.map((provider) => (
+							{otherProviders.map((provider) => (
 								<div
 									key={provider.id}
 									class="flex items-center justify-between p-3 bg-dark-800 rounded-lg border border-dark-700"
@@ -247,7 +293,7 @@ export function ProvidersSettings() {
 				</div>
 			</SettingsSection>
 
-			{/* OAuth Modal */}
+			{/* OAuth Modal (for non-Gemini providers) */}
 			{oauthFlow && (
 				<OAuthModal
 					providerName={oauthFlow.providerName}

--- a/packages/web/src/components/settings/ProvidersSettings.tsx
+++ b/packages/web/src/components/settings/ProvidersSettings.tsx
@@ -196,18 +196,6 @@ export function ProvidersSettings() {
 										</span>
 									)}
 								</div>
-								{!geminiProvider.isAuthenticated && (
-									<Button
-										variant="secondary"
-										size="xs"
-										disabled={!!pendingProvider}
-										onClick={() => {
-											// The GeminiAccountsPanel's Add button handles the actual OAuth
-										}}
-									>
-										Setup
-									</Button>
-								)}
 							</div>
 							{geminiProvider.error && (
 								<p class="text-xs text-red-400 mb-2">{geminiProvider.error}</p>

--- a/packages/web/src/components/settings/__tests__/AddGoogleAccountModal.test.tsx
+++ b/packages/web/src/components/settings/__tests__/AddGoogleAccountModal.test.tsx
@@ -1,0 +1,251 @@
+// @ts-nocheck
+/**
+ * Tests for AddGoogleAccountModal Component
+ *
+ * Covers the multi-step headless OAuth flow:
+ * - Step 1 (url): Display auth URL and Open/Copy buttons
+ * - Step 2 (code): Enter authorization code
+ * - Step 3 (success): Account added confirmation
+ * - Step 4 (error): Failure state with retry
+ *
+ * Key regression: "Try Again" after a failed exchange must return to the
+ * url step (not the code step) so the user gets a fresh single-use code.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, screen, waitFor, fireEvent } from '@testing-library/preact';
+
+vi.mock('../../ui/Button.tsx', () => ({
+	Button: ({
+		children,
+		variant,
+		size,
+		onClick,
+		disabled,
+		loading,
+	}: {
+		children: import('preact').ComponentChildren;
+		variant?: string;
+		size?: string;
+		onClick?: () => void;
+		disabled?: boolean;
+		loading?: boolean;
+	}) => (
+		<button
+			data-testid={`button-${variant || 'primary'}-${size || 'md'}`}
+			disabled={disabled || loading}
+			onClick={onClick}
+		>
+			{loading && <span data-testid="button-loading">Loading...</span>}
+			{children}
+		</button>
+	),
+}));
+
+import { AddGoogleAccountModal } from '../AddGoogleAccountModal.tsx';
+
+const defaultProps = {
+	authUrl: 'https://accounts.google.com/o/oauth2/v2/auth?mock=1',
+	flowId: 'flow-abc-123',
+	onComplete: vi.fn(),
+	onCancel: vi.fn(),
+	onSubmitCode: vi.fn().mockResolvedValue({ success: true }),
+};
+
+describe('AddGoogleAccountModal', () => {
+	beforeEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+		// jsdom exposes clipboard as a getter-only property; override via defineProperty
+		Object.defineProperty(navigator, 'clipboard', {
+			value: { writeText: vi.fn().mockResolvedValue(undefined) },
+			configurable: true,
+			writable: true,
+		});
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	describe('URL step (initial)', () => {
+		it('renders the auth URL and action buttons', () => {
+			const { container } = render(<AddGoogleAccountModal {...defaultProps} />);
+			expect(container.textContent).toContain('Add Google Account');
+			expect(container.textContent).toContain(defaultProps.authUrl);
+			expect(container.textContent).toContain('Open URL & Continue');
+			expect(container.textContent).toContain('Copy URL');
+		});
+
+		it('advances to code step when "Open URL & Continue" is clicked', async () => {
+			// window.open is not implemented in jsdom
+			vi.spyOn(window, 'open').mockImplementation(() => null);
+
+			const { container } = render(<AddGoogleAccountModal {...defaultProps} />);
+
+			const openBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.includes('Open URL & Continue')
+			);
+			openBtn?.click();
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('Authorization Code');
+			});
+		});
+	});
+
+	describe('Code step', () => {
+		const renderAtCodeStep = async () => {
+			vi.spyOn(window, 'open').mockImplementation(() => null);
+			const utils = render(<AddGoogleAccountModal {...defaultProps} />);
+			const openBtn = Array.from(utils.container.querySelectorAll('button')).find((b) =>
+				b.textContent?.includes('Open URL & Continue')
+			);
+			openBtn?.click();
+			await waitFor(() => {
+				expect(utils.container.textContent).toContain('Authorization Code');
+			});
+			return utils;
+		};
+
+		it('calls onSubmitCode with the entered code and flowId', async () => {
+			const { container } = await renderAtCodeStep();
+
+			const input = container.querySelector('input') as HTMLInputElement;
+			fireEvent.input(input, { target: { value: 'my-auth-code' } });
+
+			const addBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.includes('Add Account')
+			);
+			addBtn?.click();
+
+			await waitFor(() => {
+				expect(defaultProps.onSubmitCode).toHaveBeenCalledWith('my-auth-code', 'flow-abc-123');
+			});
+		});
+
+		it('advances to success step on successful submission', async () => {
+			defaultProps.onSubmitCode.mockResolvedValueOnce({ success: true });
+			const { container } = await renderAtCodeStep();
+
+			const input = container.querySelector('input') as HTMLInputElement;
+			fireEvent.input(input, { target: { value: 'good-code' } });
+
+			const addBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.includes('Add Account')
+			);
+			addBtn?.click();
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('Account added successfully');
+			});
+		});
+
+		it('advances to error step on failed submission', async () => {
+			defaultProps.onSubmitCode.mockResolvedValueOnce({
+				success: false,
+				error: 'Token exchange failed: invalid_grant',
+			});
+			const { container } = await renderAtCodeStep();
+
+			const input = container.querySelector('input') as HTMLInputElement;
+			fireEvent.input(input, { target: { value: 'bad-code' } });
+
+			const addBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.includes('Add Account')
+			);
+			addBtn?.click();
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('Failed to add account');
+				expect(container.textContent).toContain('invalid_grant');
+			});
+		});
+	});
+
+	describe('Error step — "Try Again" restarts from url step', () => {
+		const renderAtErrorStep = async () => {
+			vi.spyOn(window, 'open').mockImplementation(() => null);
+			defaultProps.onSubmitCode.mockResolvedValueOnce({
+				success: false,
+				error: 'Token exchange failed: invalid_grant',
+			});
+			const utils = render(<AddGoogleAccountModal {...defaultProps} />);
+
+			// Navigate: url → code
+			const openBtn = Array.from(utils.container.querySelectorAll('button')).find((b) =>
+				b.textContent?.includes('Open URL & Continue')
+			);
+			openBtn?.click();
+			await waitFor(() => expect(utils.container.textContent).toContain('Authorization Code'));
+
+			// Submit bad code → error step
+			const input = utils.container.querySelector('input') as HTMLInputElement;
+			fireEvent.input(input, { target: { value: 'bad-code' } });
+			const addBtn = Array.from(utils.container.querySelectorAll('button')).find((b) =>
+				b.textContent?.includes('Add Account')
+			);
+			addBtn?.click();
+
+			await waitFor(() => expect(utils.container.textContent).toContain('Failed to add account'));
+			return utils;
+		};
+
+		it('shows "Try Again" and "Cancel" buttons on error', async () => {
+			const { container } = await renderAtErrorStep();
+			expect(container.textContent).toContain('Try Again');
+			expect(container.textContent).toContain('Cancel');
+		});
+
+		it('"Try Again" returns to the url step (not the code step)', async () => {
+			const { container } = await renderAtErrorStep();
+
+			const tryAgainBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.includes('Try Again')
+			);
+			tryAgainBtn?.click();
+
+			await waitFor(() => {
+				// Should be back at the URL step
+				expect(container.textContent).toContain('Open URL & Continue');
+				expect(container.textContent).toContain(defaultProps.authUrl);
+			});
+
+			// Must NOT be showing the code input (would indicate landing on code step)
+			expect(container.querySelector('input[id="gemini-auth-code"]')).toBeNull();
+		});
+
+		it('"Try Again" clears the auth code input for the next attempt', async () => {
+			vi.spyOn(window, 'open').mockImplementation(() => null);
+			const { container } = await renderAtErrorStep();
+
+			const tryAgainBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.includes('Try Again')
+			);
+			tryAgainBtn?.click();
+
+			// Advance to code step again
+			await waitFor(() => expect(container.textContent).toContain('Open URL & Continue'));
+			const openBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+				b.textContent?.includes('Open URL & Continue')
+			);
+			openBtn?.click();
+
+			await waitFor(() => expect(container.textContent).toContain('Authorization Code'));
+			const input = container.querySelector('input') as HTMLInputElement;
+			// Input should be empty — cleared by "Try Again"
+			expect(input.value).toBe('');
+		});
+
+		it('"Cancel" calls onCancel', async () => {
+			const { container } = await renderAtErrorStep();
+
+			const cancelBtn = Array.from(container.querySelectorAll('button')).find(
+				(b) => b.textContent === 'Cancel'
+			);
+			cancelBtn?.click();
+
+			expect(defaultProps.onCancel).toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/web/src/components/settings/__tests__/GeminiAccountsPanel.test.tsx
+++ b/packages/web/src/components/settings/__tests__/GeminiAccountsPanel.test.tsx
@@ -489,7 +489,7 @@ describe('GeminiAccountsPanel', () => {
 			mockStartGeminiOAuth.mockResolvedValue({
 				success: true,
 				authUrl: 'https://reauth.url',
-				message: 'reauth-flow-123',
+				flowId: 'reauth-flow-123',
 			});
 
 			const { container, getByTestId } = render(<GeminiAccountsPanel />);

--- a/packages/web/src/components/settings/__tests__/GeminiAccountsPanel.test.tsx
+++ b/packages/web/src/components/settings/__tests__/GeminiAccountsPanel.test.tsx
@@ -127,7 +127,7 @@ describe('GeminiAccountsPanel', () => {
 		mockStartGeminiOAuth.mockResolvedValue({
 			success: true,
 			authUrl: 'https://mock-oauth.url',
-			message: 'flow-123',
+			flowId: 'flow-123',
 		});
 		mockCompleteGeminiOAuth.mockResolvedValue({ success: true });
 		mockRemoveGeminiAccount.mockResolvedValue({ success: true });
@@ -328,7 +328,7 @@ describe('GeminiAccountsPanel', () => {
 			mockStartGeminiOAuth.mockResolvedValue({
 				success: true,
 				authUrl: 'https://auth.url',
-				message: 'flow-123',
+				flowId: 'flow-123',
 			});
 
 			const { container, getByTestId } = render(<GeminiAccountsPanel />);
@@ -370,12 +370,36 @@ describe('GeminiAccountsPanel', () => {
 			});
 		});
 
+		it('shows error toast when flowId is missing from response', async () => {
+			mockListGeminiAccounts.mockResolvedValue({ accounts: [] });
+			mockStartGeminiOAuth.mockResolvedValue({
+				success: true,
+				authUrl: 'https://auth.url',
+				// flowId is missing
+			});
+
+			const { container } = render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('Add Google Account');
+			});
+
+			const addButton = Array.from(container.querySelectorAll('button')).find((btn) =>
+				btn.textContent?.includes('Add Google Account')
+			);
+			addButton?.click();
+
+			await waitFor(() => {
+				expect(mockToastError).toHaveBeenCalledWith('Failed to start OAuth flow');
+			});
+		});
+
 		it('closes modal on cancel and reloads accounts', async () => {
 			mockListGeminiAccounts.mockResolvedValue({ accounts: [] });
 			mockStartGeminiOAuth.mockResolvedValue({
 				success: true,
 				authUrl: 'https://auth.url',
-				message: 'flow-123',
+				flowId: 'flow-123',
 			});
 
 			const { container, getByTestId, queryByTestId } = render(<GeminiAccountsPanel />);

--- a/packages/web/src/components/settings/__tests__/GeminiAccountsPanel.test.tsx
+++ b/packages/web/src/components/settings/__tests__/GeminiAccountsPanel.test.tsx
@@ -1,0 +1,549 @@
+// @ts-nocheck
+/**
+ * Tests for GeminiAccountsPanel Component
+ *
+ * Tests the Google OAuth account management UI including:
+ * - Account list display
+ * - Status indicators
+ * - Add account flow
+ * - Remove account with confirmation
+ * - Re-authenticate invalid accounts
+ * - Summary stats and warnings
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, screen, waitFor, fireEvent } from '@testing-library/preact';
+import type { GeminiAccountInfo } from '@neokai/shared/provider';
+
+const {
+	mockListGeminiAccounts,
+	mockStartGeminiOAuth,
+	mockCompleteGeminiOAuth,
+	mockRemoveGeminiAccount,
+	mockToastError,
+	mockToastSuccess,
+} = vi.hoisted(() => ({
+	mockListGeminiAccounts: vi.fn(),
+	mockStartGeminiOAuth: vi.fn(),
+	mockCompleteGeminiOAuth: vi.fn(),
+	mockRemoveGeminiAccount: vi.fn(),
+	mockToastError: vi.fn(),
+	mockToastSuccess: vi.fn(),
+}));
+
+vi.mock('../../../lib/api-helpers.ts', () => ({
+	listGeminiAccounts: () => mockListGeminiAccounts(),
+	startGeminiOAuth: (accountId?: string) => mockStartGeminiOAuth(accountId),
+	completeGeminiOAuth: (authCode: string, flowId: string) =>
+		mockCompleteGeminiOAuth(authCode, flowId),
+	removeGeminiAccount: (accountId: string) => mockRemoveGeminiAccount(accountId),
+}));
+
+vi.mock('../../../lib/toast.ts', () => ({
+	toast: {
+		error: (msg: string) => mockToastError(msg),
+		success: (msg: string) => mockToastSuccess(msg),
+		info: vi.fn(),
+		warning: vi.fn(),
+	},
+}));
+
+vi.mock('../../ui/Button.tsx', () => ({
+	Button: ({
+		children,
+		variant,
+		size,
+		onClick,
+		disabled,
+		loading,
+	}: {
+		children: import('preact').ComponentChildren;
+		variant?: string;
+		size?: string;
+		onClick?: () => void;
+		disabled?: boolean;
+		loading?: boolean;
+	}) => (
+		<button
+			data-testid={`button-${variant || 'primary'}-${size || 'md'}`}
+			disabled={disabled || loading}
+			onClick={onClick}
+		>
+			{loading && <span data-testid="button-loading">Loading...</span>}
+			{children}
+		</button>
+	),
+}));
+
+vi.mock('../AddGoogleAccountModal.tsx', () => ({
+	AddGoogleAccountModal: ({
+		authUrl,
+		flowId,
+		onComplete,
+		onCancel,
+	}: {
+		authUrl: string;
+		flowId: string;
+		onComplete: () => void;
+		onCancel: () => void;
+		onSubmitCode: (
+			authCode: string,
+			flowId: string
+		) => Promise<{ success: boolean; error?: string }>;
+	}) => (
+		<div data-testid="add-account-modal">
+			<span data-testid="modal-auth-url">{authUrl}</span>
+			<span data-testid="modal-flow-id">{flowId}</span>
+			<button data-testid="modal-complete-btn" onClick={onComplete}>
+				Complete
+			</button>
+			<button data-testid="modal-cancel-btn" onClick={onCancel}>
+				Cancel
+			</button>
+		</div>
+	),
+}));
+
+import { GeminiAccountsPanel } from '../GeminiAccountsPanel.tsx';
+
+const createMockAccount = (overrides: Partial<GeminiAccountInfo> = {}): GeminiAccountInfo => ({
+	id: 'acc-1',
+	email: 'test@gmail.com',
+	status: 'active',
+	addedAt: Date.now() - 86_400_000,
+	lastUsedAt: Date.now() - 3600_000,
+	dailyRequestCount: 342,
+	dailyLimit: 1500,
+	cooldownUntil: 0,
+	...overrides,
+});
+
+describe('GeminiAccountsPanel', () => {
+	beforeEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+		vi.useFakeTimers();
+		mockListGeminiAccounts.mockResolvedValue({ accounts: [] });
+		mockStartGeminiOAuth.mockResolvedValue({
+			success: true,
+			authUrl: 'https://mock-oauth.url',
+			message: 'flow-123',
+		});
+		mockCompleteGeminiOAuth.mockResolvedValue({ success: true });
+		mockRemoveGeminiAccount.mockResolvedValue({ success: true });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		cleanup();
+	});
+
+	describe('Loading State', () => {
+		it('shows loading state initially', async () => {
+			let resolvePromise: (value: { accounts: GeminiAccountInfo[] }) => void;
+			mockListGeminiAccounts.mockImplementation(
+				() =>
+					new Promise((resolve) => {
+						resolvePromise = resolve;
+					})
+			);
+
+			const { container } = render(<GeminiAccountsPanel />);
+			expect(container.textContent).toContain('Loading accounts...');
+
+			resolvePromise!({ accounts: [] });
+			await waitFor(() => {
+				expect(container.textContent).not.toContain('Loading accounts...');
+			});
+		});
+	});
+
+	describe('Empty State', () => {
+		it('shows empty state when no accounts', async () => {
+			mockListGeminiAccounts.mockResolvedValue({ accounts: [] });
+
+			const { container } = render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('No Google accounts added yet');
+			});
+		});
+	});
+
+	describe('Account List', () => {
+		it('displays accounts with email and status', async () => {
+			const accounts = [
+				createMockAccount({ email: 'user1@gmail.com', status: 'active' }),
+				createMockAccount({
+					id: 'acc-2',
+					email: 'user2@gmail.com',
+					status: 'exhausted',
+					dailyRequestCount: 1400,
+				}),
+			];
+			mockListGeminiAccounts.mockResolvedValue({ accounts });
+
+			const { container } = render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('user1@gmail.com');
+				expect(container.textContent).toContain('user2@gmail.com');
+				expect(container.textContent).toContain('Active');
+				expect(container.textContent).toContain('Exhausted');
+			});
+		});
+
+		it('shows daily usage counts', async () => {
+			const accounts = [createMockAccount({ dailyRequestCount: 342, dailyLimit: 1500 })];
+			mockListGeminiAccounts.mockResolvedValue({ accounts });
+
+			const { container } = render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('342 / 1,500 requests');
+			});
+		});
+
+		it('shows summary stats', async () => {
+			const accounts = [
+				createMockAccount({ dailyRequestCount: 342, dailyLimit: 1500 }),
+				createMockAccount({
+					id: 'acc-2',
+					email: 'user2@gmail.com',
+					dailyRequestCount: 500,
+					dailyLimit: 1500,
+				}),
+			];
+			mockListGeminiAccounts.mockResolvedValue({ accounts });
+
+			const { container } = render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('2 accounts');
+				// remaining = 3000 - 842 = 2158
+				expect(container.textContent).toContain('2,158 / 3,000 daily requests remaining');
+			});
+		});
+
+		it('shows "Never" for unused accounts', async () => {
+			const accounts = [createMockAccount({ lastUsedAt: 0 })];
+			mockListGeminiAccounts.mockResolvedValue({ accounts });
+
+			const { container } = render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('Never');
+			});
+		});
+	});
+
+	describe('Status Indicators', () => {
+		it('shows invalid status with red badge', async () => {
+			const accounts = [createMockAccount({ status: 'invalid' })];
+			mockListGeminiAccounts.mockResolvedValue({ accounts });
+
+			const { container } = render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('Invalid');
+			});
+		});
+
+		it('shows exhausted status with cooldown time', async () => {
+			const cooldownUntil = Date.now() + 180_000; // 3 minutes from now
+			const accounts = [createMockAccount({ status: 'exhausted', cooldownUntil })];
+			mockListGeminiAccounts.mockResolvedValue({ accounts });
+
+			const { container } = render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('Exhausted');
+				expect(container.textContent).toContain('cooldown');
+			});
+		});
+	});
+
+	describe('Warnings', () => {
+		it('shows warning when all accounts exhausted', async () => {
+			const accounts = [
+				createMockAccount({ status: 'exhausted' }),
+				createMockAccount({ id: 'acc-2', email: 'user2@gmail.com', status: 'invalid' }),
+			];
+			mockListGeminiAccounts.mockResolvedValue({ accounts });
+
+			const { container } = render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('All accounts are exhausted or invalid');
+			});
+		});
+
+		it('shows warning when only 1 active account', async () => {
+			const accounts = [
+				createMockAccount({ status: 'active' }),
+				createMockAccount({ id: 'acc-2', email: 'user2@gmail.com', status: 'invalid' }),
+			];
+			mockListGeminiAccounts.mockResolvedValue({ accounts });
+
+			const { container } = render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('no failover capacity');
+			});
+		});
+
+		it('does not show warnings when multiple active accounts', async () => {
+			vi.useRealTimers();
+			const accounts = [
+				createMockAccount({ status: 'active' }),
+				createMockAccount({ id: 'acc-2', email: 'user2@gmail.com', status: 'active' }),
+			];
+			mockListGeminiAccounts.mockResolvedValue({ accounts });
+
+			const { container } = render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('test@gmail.com');
+			});
+
+			expect(container.textContent).not.toContain('no failover capacity');
+			expect(container.textContent).not.toContain('All accounts are exhausted');
+			vi.useFakeTimers();
+		});
+	});
+
+	describe('Add Account', () => {
+		it('shows Add Google Account button', async () => {
+			mockListGeminiAccounts.mockResolvedValue({ accounts: [] });
+
+			const { container } = render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('Add Google Account');
+			});
+		});
+
+		it('opens add account modal on click', async () => {
+			mockListGeminiAccounts.mockResolvedValue({ accounts: [] });
+			mockStartGeminiOAuth.mockResolvedValue({
+				success: true,
+				authUrl: 'https://auth.url',
+				message: 'flow-123',
+			});
+
+			const { container, getByTestId } = render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('Add Google Account');
+			});
+
+			const addButton = Array.from(container.querySelectorAll('button')).find((btn) =>
+				btn.textContent?.includes('Add Google Account')
+			);
+			addButton?.click();
+
+			await waitFor(() => {
+				expect(getByTestId('add-account-modal')).toBeTruthy();
+			});
+		});
+
+		it('shows error toast when startGeminiOAuth fails', async () => {
+			mockListGeminiAccounts.mockResolvedValue({ accounts: [] });
+			mockStartGeminiOAuth.mockResolvedValue({
+				success: false,
+				error: 'Missing client ID',
+			});
+
+			const { container } = render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('Add Google Account');
+			});
+
+			const addButton = Array.from(container.querySelectorAll('button')).find((btn) =>
+				btn.textContent?.includes('Add Google Account')
+			);
+			addButton?.click();
+
+			await waitFor(() => {
+				expect(mockToastError).toHaveBeenCalledWith('Missing client ID');
+			});
+		});
+
+		it('closes modal on cancel and reloads accounts', async () => {
+			mockListGeminiAccounts.mockResolvedValue({ accounts: [] });
+			mockStartGeminiOAuth.mockResolvedValue({
+				success: true,
+				authUrl: 'https://auth.url',
+				message: 'flow-123',
+			});
+
+			const { container, getByTestId, queryByTestId } = render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('Add Google Account');
+			});
+
+			const addButton = Array.from(container.querySelectorAll('button')).find((btn) =>
+				btn.textContent?.includes('Add Google Account')
+			);
+			addButton?.click();
+
+			await waitFor(() => {
+				expect(getByTestId('add-account-modal')).toBeTruthy();
+			});
+
+			getByTestId('modal-cancel-btn').click();
+
+			await waitFor(() => {
+				expect(queryByTestId('add-account-modal')).toBeNull();
+			});
+		});
+	});
+
+	describe('Remove Account', () => {
+		it('shows confirmation dialog on remove click', async () => {
+			const accounts = [createMockAccount()];
+			mockListGeminiAccounts.mockResolvedValue({ accounts });
+
+			const { container } = render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('test@gmail.com');
+			});
+
+			// Find and click the remove button (trash icon button)
+			const removeButton = container.querySelector('[data-testid="button-ghost-xs"]');
+			if (removeButton) {
+				removeButton.click();
+			}
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('Remove Google Account');
+				expect(container.textContent).toContain('test@gmail.com');
+			});
+		});
+
+		it('removes account and shows success toast on confirm', async () => {
+			const accounts = [createMockAccount()];
+			mockListGeminiAccounts.mockResolvedValue({ accounts });
+			mockRemoveGeminiAccount.mockResolvedValue({ success: true });
+
+			const { container } = render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('test@gmail.com');
+			});
+
+			// Click remove button
+			const removeButton = container.querySelector('[data-testid="button-ghost-xs"]');
+			if (removeButton) {
+				removeButton.click();
+			}
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('Remove Google Account');
+			});
+
+			// Click confirm "Remove" button
+			const confirmButton = Array.from(container.querySelectorAll('button')).find((btn) =>
+				btn.textContent?.includes('Remove')
+			);
+			confirmButton?.click();
+
+			await waitFor(() => {
+				expect(mockRemoveGeminiAccount).toHaveBeenCalledWith('acc-1');
+				expect(mockToastSuccess).toHaveBeenCalledWith('Removed test@gmail.com');
+			});
+		});
+	});
+
+	describe('Re-authenticate', () => {
+		it('shows Re-auth button for invalid accounts', async () => {
+			const accounts = [createMockAccount({ status: 'invalid' })];
+			mockListGeminiAccounts.mockResolvedValue({ accounts });
+
+			const { container } = render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('Re-auth');
+			});
+		});
+
+		it('does not show Re-auth button for active accounts', async () => {
+			const accounts = [createMockAccount({ status: 'active' })];
+			mockListGeminiAccounts.mockResolvedValue({ accounts });
+
+			const { container } = render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('test@gmail.com');
+			});
+
+			expect(container.textContent).not.toContain('Re-auth');
+		});
+
+		it('starts re-auth flow when Re-auth clicked', async () => {
+			const accounts = [createMockAccount({ status: 'invalid' })];
+			mockListGeminiAccounts.mockResolvedValue({ accounts });
+			mockStartGeminiOAuth.mockResolvedValue({
+				success: true,
+				authUrl: 'https://reauth.url',
+				message: 'reauth-flow-123',
+			});
+
+			const { container, getByTestId } = render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('Re-auth');
+			});
+
+			const reauthButton = Array.from(container.querySelectorAll('button')).find((btn) =>
+				btn.textContent?.includes('Re-auth')
+			);
+			reauthButton?.click();
+
+			await waitFor(() => {
+				expect(mockStartGeminiOAuth).toHaveBeenCalledWith('acc-1');
+				expect(getByTestId('add-account-modal')).toBeTruthy();
+			});
+		});
+	});
+
+	describe('Auto-refresh', () => {
+		it('sets up auto-refresh interval', async () => {
+			mockListGeminiAccounts.mockResolvedValue({ accounts: [] });
+
+			render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(mockListGeminiAccounts).toHaveBeenCalledTimes(1);
+			});
+
+			// Advance time by 30 seconds
+			vi.advanceTimersByTime(30_000);
+
+			await waitFor(() => {
+				expect(mockListGeminiAccounts).toHaveBeenCalledTimes(2);
+			});
+		});
+
+		it('clears auto-refresh on unmount', async () => {
+			mockListGeminiAccounts.mockResolvedValue({ accounts: [] });
+
+			const { unmount } = render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(mockListGeminiAccounts).toHaveBeenCalledTimes(1);
+			});
+
+			unmount();
+
+			// Advance time - should not trigger another call
+			vi.advanceTimersByTime(60_000);
+
+			// Only called once (initial load)
+			expect(mockListGeminiAccounts).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/packages/web/src/lib/api-helpers.ts
+++ b/packages/web/src/lib/api-helpers.ts
@@ -45,6 +45,10 @@ import type {
 	ProviderAuthResponse,
 	ListProviderAuthStatusResponse,
 	ProviderRefreshResponse,
+	ListGeminiAccountsResponse,
+	StartGeminiOAuthResponse,
+	CompleteGeminiOAuthResponse,
+	RemoveGeminiAccountResponse,
 } from '@neokai/shared/provider';
 import { connectionManager } from './connection-manager.ts';
 import { ConnectionNotReadyError } from './errors.ts';
@@ -156,6 +160,38 @@ export async function logoutProvider(
 export async function refreshProvider(providerId: string): Promise<ProviderRefreshResponse> {
 	const hub = getHubOrThrow();
 	return await hub.request<ProviderRefreshResponse>('auth.refresh', { providerId });
+}
+
+// ==================== Gemini OAuth Account Management ====================
+
+export async function listGeminiAccounts(): Promise<ListGeminiAccountsResponse> {
+	const hub = getHubOrThrow();
+	return await hub.request<ListGeminiAccountsResponse>('auth.gemini.accounts', {});
+}
+
+export async function startGeminiOAuth(accountId?: string): Promise<StartGeminiOAuthResponse> {
+	const hub = getHubOrThrow();
+	return await hub.request<StartGeminiOAuthResponse>('auth.gemini.startOAuth', {
+		accountId,
+	});
+}
+
+export async function completeGeminiOAuth(
+	authCode: string,
+	flowId: string
+): Promise<CompleteGeminiOAuthResponse> {
+	const hub = getHubOrThrow();
+	return await hub.request<CompleteGeminiOAuthResponse>('auth.gemini.completeOAuth', {
+		authCode,
+		flowId,
+	});
+}
+
+export async function removeGeminiAccount(accountId: string): Promise<RemoveGeminiAccountResponse> {
+	const hub = getHubOrThrow();
+	return await hub.request<RemoveGeminiAccountResponse>('auth.gemini.removeAccount', {
+		accountId,
+	});
 }
 
 // ==================== Settings Operations ====================


### PR DESCRIPTION
Adds a complete account management UI for the Gemini OAuth provider in the provider settings panel.

## Changes

**Shared types** — `GeminiAccountInfo`, request/response types for listing, adding, completing, and removing Gemini OAuth accounts.

**Backend RPC handlers** — Four new endpoints in `auth-handlers.ts`:
- `auth.gemini.accounts` — list accounts (strips refresh tokens)
- `auth.gemini.startOAuth` — generate headless auth URL + store PKCE verifier
- `auth.gemini.completeOAuth` — exchange auth code for tokens, persist account
- `auth.gemini.removeAccount` — remove account by ID

**Frontend API helpers** — `listGeminiAccounts`, `startGeminiOAuth`, `completeGeminiOAuth`, `removeGeminiAccount`.

**New components:**
- `AddGoogleAccountModal` — multi-step modal: show auth URL → paste auth code → success/error
- `GeminiAccountsPanel` — account list with status dots, usage counters, summary bar, warning banners, and re-auth/remove actions

**Updated `ProvidersSettings`** — Gemini OAuth provider gets a dedicated card with the accounts panel; other providers render as before.

## Tests
- 14 backend unit tests covering all four Gemini RPC handlers (start flow, complete flow, re-auth, remove, error cases)
- 22 frontend component tests covering account list, status indicators, warnings, add/remove/re-auth flows, auto-refresh