### PR TITLE
Add default model picker to Space Settings + Task Agent editor

### DIFF
--- a/packages/daemon/src/lib/space/agents/task-agent.ts
+++ b/packages/daemon/src/lib/space/agents/task-agent.ts
@@ -581,10 +581,12 @@ export interface TaskAgentSessionConfig {
 export function createTaskAgentInit(config: TaskAgentSessionConfig): AgentSessionInit {
 	const { task, space, workflow, workflowRun, sessionId, workspacePath } = config;
 
-	const model = space.defaultModel ?? DEFAULT_TASK_AGENT_MODEL;
+	// Model resolution: task-agent-specific override → space default → hardcoded default.
+	const taskAgentConfig = space.taskAgentConfig;
+	const model = taskAgentConfig?.model ?? space.defaultModel ?? DEFAULT_TASK_AGENT_MODEL;
 	const provider = inferProviderForModel(model);
 
-	const systemPromptText = buildTaskAgentSystemPrompt({
+	let systemPromptText = buildTaskAgentSystemPrompt({
 		task,
 		space,
 		workflow: workflow ?? undefined,
@@ -596,6 +598,11 @@ export function createTaskAgentInit(config: TaskAgentSessionConfig): AgentSessio
 		// The caller must provide agent context via buildTaskAgentInitialMessage() instead.
 		availableAgents: [],
 	});
+
+	// Append custom prompt additions if configured.
+	if (taskAgentConfig?.customPrompt) {
+		systemPromptText += '\n\n## Custom Instructions\n\n' + taskAgentConfig.customPrompt;
+	}
 
 	return {
 		sessionId,

--- a/packages/daemon/src/storage/repositories/space-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-repository.ts
@@ -10,6 +10,7 @@ import type {
 	Space,
 	SpaceAutonomyLevel,
 	SpaceConfig,
+	TaskAgentConfig,
 	CreateSpaceParams,
 	UpdateSpaceParams,
 } from '@neokai/shared';
@@ -285,6 +286,10 @@ export class SpaceRepository {
 		const rawModels = JSON.parse((row.allowed_models as string) ?? '[]') as string[];
 		const rawConfig = row.config as string | null;
 		const config = rawConfig ? (JSON.parse(rawConfig) as SpaceConfig) : undefined;
+		const rawTaskAgentConfig = row.task_agent_config as string | null;
+		const taskAgentConfig = rawTaskAgentConfig
+			? (JSON.parse(rawTaskAgentConfig) as TaskAgentConfig)
+			: undefined;
 		return {
 			id: row.id as string,
 			slug: (row.slug as string) ?? '',
@@ -301,6 +306,7 @@ export class SpaceRepository {
 			stopped: (row.stopped as number) === 1,
 			autonomyLevel: ((row.autonomy_level as number) ?? 1) as SpaceAutonomyLevel,
 			config,
+			taskAgentConfig,
 			createdAt: row.created_at as number,
 			updatedAt: row.updated_at as number,
 		};

--- a/packages/daemon/src/storage/repositories/space-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-repository.ts
@@ -27,8 +27,8 @@ export class SpaceRepository {
 		const now = Date.now();
 
 		const stmt = this.db.prepare(
-			`INSERT INTO spaces (id, slug, workspace_path, name, description, background_context, instructions, default_model, allowed_models, session_ids, status, autonomy_level, config, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			`INSERT INTO spaces (id, slug, workspace_path, name, description, background_context, instructions, default_model, allowed_models, session_ids, status, autonomy_level, config, task_agent_config, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 
 		stmt.run(
@@ -45,6 +45,7 @@ export class SpaceRepository {
 			'active',
 			params.autonomyLevel ?? 1,
 			params.config ? JSON.stringify(params.config) : null,
+			params.taskAgentConfig ? JSON.stringify(params.taskAgentConfig) : null,
 			now,
 			now
 		);
@@ -162,6 +163,10 @@ export class SpaceRepository {
 		if (params.config !== undefined) {
 			fields.push('config = ?');
 			values.push(JSON.stringify(params.config));
+		}
+		if (params.taskAgentConfig !== undefined) {
+			fields.push('task_agent_config = ?');
+			values.push(params.taskAgentConfig ? JSON.stringify(params.taskAgentConfig) : null);
 		}
 
 		if (fields.length > 0) {

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -544,6 +544,10 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 114: Add 'draft' to space_tasks status CHECK constraint.
 	runMigration114(db);
+
+	// Migration 115: Add task_agent_config column to spaces table.
+	//   Stores per-space Task Agent overrides (model and custom prompt) as JSON.
+	runMigration115(db);
 }
 
 /**
@@ -7909,4 +7913,20 @@ function addDraftToStatusCheck(createSql: string): string {
 		throw new Error('Unable to add draft to space_tasks.status CHECK constraint');
 	}
 	return result;
+}
+
+/**
+ * Migration 115: Add `task_agent_config` column to `spaces` table.
+ *
+ * Stores per-space Task Agent overrides (model and custom prompt) as JSON.
+ * Nullable — null means no overrides (use code defaults).
+ */
+export function runMigration115(db: BunDatabase): void {
+	if (!tableExists(db, 'spaces')) return;
+
+	// Idempotent: skip if column already exists.
+	const columns = tableColumnNames(db, 'spaces');
+	if (columns.includes('task_agent_config')) return;
+
+	db.exec(`ALTER TABLE spaces ADD COLUMN task_agent_config TEXT DEFAULT NULL`);
 }

--- a/packages/daemon/tests/unit/5-space/runtime/space-slug.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-slug.test.ts
@@ -32,6 +32,7 @@ function createTestDb(): InstanceType<typeof Database> {
 				CHECK(status IN ('active', 'archived')),
 			autonomy_level TEXT DEFAULT 'supervised',
 			config TEXT,
+			task_agent_config TEXT,
 			slug TEXT,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL

--- a/packages/daemon/tests/unit/helpers/space-agent-schema.ts
+++ b/packages/daemon/tests/unit/helpers/space-agent-schema.ts
@@ -26,6 +26,7 @@ export function createSpaceAgentSchema(db: Database): void {
 			status TEXT NOT NULL DEFAULT 'active',
 			autonomy_level TEXT NOT NULL DEFAULT 'supervised',
 			config TEXT,
+			task_agent_config TEXT,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL
 		)

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -34,6 +34,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			autonomy_level INTEGER NOT NULL DEFAULT 1
 				CHECK(autonomy_level BETWEEN 1 AND 5),
 			config TEXT,
+			task_agent_config TEXT DEFAULT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL
 		)

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -48,6 +48,20 @@ export interface SpaceConfig {
 }
 
 /**
+ * Per-space overrides for the built-in Task Agent.
+ *
+ * The Task Agent is not a seeded SpaceAgent — it has no row in the `space_agents`
+ * table. Its prompt is generated in code at `task-agent.ts`. This config allows
+ * per-space customization of model and prompt additions without mutating code.
+ */
+export interface TaskAgentConfig {
+	/** Model override for the Task Agent. Falls back to `space.defaultModel` then `DEFAULT_TASK_AGENT_MODEL`. */
+	model?: string;
+	/** Custom prompt additions appended after the contract sections (similar to SpaceAgent.customPrompt). */
+	customPrompt?: string;
+}
+
+/**
  * A Space — a workspace-first context for multi-agent workflows.
  * Unlike Rooms, a Space has a single required workspace path and is
  * designed around workflow execution with customizable agents.
@@ -86,6 +100,8 @@ export interface Space {
 	autonomyLevel?: SpaceAutonomyLevel;
 	/** Runtime configuration (maxConcurrentTasks, taskTimeoutMs, etc.) */
 	config?: SpaceConfig;
+	/** Per-space overrides for the built-in Task Agent (model and custom prompt). */
+	taskAgentConfig?: TaskAgentConfig;
 	/** Creation timestamp (milliseconds since epoch) */
 	createdAt: number;
 	/** Last update timestamp (milliseconds since epoch) */
@@ -128,6 +144,8 @@ export interface CreateSpaceParams {
 	autonomyLevel?: SpaceAutonomyLevel;
 	/** Runtime configuration */
 	config?: SpaceConfig;
+	/** Per-space overrides for the built-in Task Agent */
+	taskAgentConfig?: TaskAgentConfig;
 }
 
 /**
@@ -142,6 +160,8 @@ export interface UpdateSpaceParams {
 	allowedModels?: string[];
 	autonomyLevel?: SpaceAutonomyLevel;
 	config?: SpaceConfig;
+	/** Per-space overrides for the built-in Task Agent. Pass null to clear. */
+	taskAgentConfig?: TaskAgentConfig | null;
 }
 
 // ============================================================================

--- a/packages/web/src/components/space/SpaceAgentList.tsx
+++ b/packages/web/src/components/space/SpaceAgentList.tsx
@@ -16,7 +16,7 @@ import { spaceStore } from '../../lib/space-store';
 import { Button } from '../ui/Button';
 import { ConfirmModal } from '../ui/ConfirmModal';
 import { Modal } from '../ui/Modal';
-import type { SpaceAgent, AgentDriftReport, TaskAgentConfig } from '@neokai/shared';
+import type { Space, SpaceAgent, AgentDriftReport, TaskAgentConfig } from '@neokai/shared';
 import { SpaceAgentEditor } from './SpaceAgentEditor';
 import { WorkflowModelSelect } from './visual-editor/WorkflowModelSelect';
 import { connectionManager } from '../../lib/connection-manager';
@@ -162,10 +162,13 @@ function TaskAgentCard({ spaceId, taskAgentConfig, defaultModel }: TaskAgentCard
 			if (model) config.model = model;
 			if (customPrompt.trim()) config.customPrompt = customPrompt.trim();
 			// Send null to clear if both are empty, otherwise send the config
-			await hub.request('space.update', {
+			const updated = await hub.request<Space>('space.update', {
 				id: spaceId,
 				taskAgentConfig: config.model || config.customPrompt ? config : null,
 			});
+			// Apply response directly to avoid stale-state from event spread-merge
+			// (undefined fields like taskAgentConfig are dropped during JSON serialization)
+			spaceStore.space.value = updated;
 			setEditing(false);
 			toast.success('Task Agent config updated');
 		} catch (err) {
@@ -190,10 +193,12 @@ function TaskAgentCard({ spaceId, taskAgentConfig, defaultModel }: TaskAgentCard
 		}
 		try {
 			setSaving(true);
-			await hub.request('space.update', {
+			const updated = await hub.request<Space>('space.update', {
 				id: spaceId,
 				taskAgentConfig: null,
 			});
+			// Apply response directly to avoid stale-state from event spread-merge
+			spaceStore.space.value = updated;
 			setEditing(false);
 			toast.success('Task Agent reset to defaults');
 		} catch (err) {

--- a/packages/web/src/components/space/SpaceAgentList.tsx
+++ b/packages/web/src/components/space/SpaceAgentList.tsx
@@ -16,8 +16,9 @@ import { spaceStore } from '../../lib/space-store';
 import { Button } from '../ui/Button';
 import { ConfirmModal } from '../ui/ConfirmModal';
 import { Modal } from '../ui/Modal';
-import type { SpaceAgent, AgentDriftReport } from '@neokai/shared';
+import type { SpaceAgent, AgentDriftReport, TaskAgentConfig } from '@neokai/shared';
 import { SpaceAgentEditor } from './SpaceAgentEditor';
+import { WorkflowModelSelect } from './visual-editor/WorkflowModelSelect';
 import { connectionManager } from '../../lib/connection-manager';
 import { toast } from '../../lib/toast';
 
@@ -122,6 +123,194 @@ function AgentCard({ agent, drifted, syncing, onEdit, onDelete, onSync }: AgentC
 	);
 }
 
+/**
+ * DEFAULT_TASK_AGENT_MODEL must match the constant in task-agent.ts.
+ * Duplicated here to avoid importing daemon code in the web bundle.
+ */
+const DEFAULT_TASK_AGENT_MODEL = 'claude-sonnet-4-6';
+
+interface TaskAgentCardProps {
+	spaceId: string;
+	taskAgentConfig?: TaskAgentConfig;
+	defaultModel?: string;
+}
+
+function TaskAgentCard({ spaceId, taskAgentConfig, defaultModel }: TaskAgentCardProps) {
+	const [editing, setEditing] = useState(false);
+	const [model, setModel] = useState<string | undefined>(taskAgentConfig?.model);
+	const [customPrompt, setCustomPrompt] = useState(taskAgentConfig?.customPrompt ?? '');
+	const [saving, setSaving] = useState(false);
+
+	// Sync local state when props change (e.g. after save)
+	useEffect(() => {
+		setModel(taskAgentConfig?.model);
+		setCustomPrompt(taskAgentConfig?.customPrompt ?? '');
+	}, [taskAgentConfig?.model, taskAgentConfig?.customPrompt]);
+
+	const resolvedModel = taskAgentConfig?.model ?? defaultModel ?? DEFAULT_TASK_AGENT_MODEL;
+	const hasOverrides = !!(taskAgentConfig?.model || taskAgentConfig?.customPrompt);
+
+	async function handleSave() {
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) {
+			toast.error('Not connected to server');
+			return;
+		}
+		try {
+			setSaving(true);
+			const config: TaskAgentConfig = {};
+			if (model) config.model = model;
+			if (customPrompt.trim()) config.customPrompt = customPrompt.trim();
+			// Send null to clear if both are empty, otherwise send the config
+			await hub.request('space.update', {
+				id: spaceId,
+				taskAgentConfig: config.model || config.customPrompt ? config : null,
+			});
+			setEditing(false);
+			toast.success('Task Agent config updated');
+		} catch (err) {
+			toast.error(`Failed to save: ${err instanceof Error ? err.message : String(err)}`);
+		} finally {
+			setSaving(false);
+		}
+	}
+
+	async function handleReset() {
+		if (
+			!confirm(
+				'Reset Task Agent to defaults? This will clear the model override and custom prompt.'
+			)
+		) {
+			return;
+		}
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) {
+			toast.error('Not connected to server');
+			return;
+		}
+		try {
+			setSaving(true);
+			await hub.request('space.update', {
+				id: spaceId,
+				taskAgentConfig: null,
+			});
+			setEditing(false);
+			toast.success('Task Agent reset to defaults');
+		} catch (err) {
+			toast.error(`Failed to reset: ${err instanceof Error ? err.message : String(err)}`);
+		} finally {
+			setSaving(false);
+		}
+	}
+
+	return (
+		<div class="bg-dark-850 border border-blue-900/30 rounded-lg p-4">
+			<div class="flex items-start justify-between gap-3">
+				<div class="flex-1 min-w-0">
+					<div class="flex items-center gap-2 flex-wrap">
+						<span class="text-xs font-medium text-blue-400 uppercase tracking-wider">Built-in</span>
+						<span class="text-sm font-medium text-gray-100">Task Agent</span>
+						<span class="text-xs text-gray-500 font-mono">{resolvedModel}</span>
+						{hasOverrides && (
+							<span class="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs bg-blue-900/30 border border-blue-700/50 rounded text-blue-400">
+								Customized
+							</span>
+						)}
+					</div>
+					<p class="text-xs text-gray-500 mt-1.5">
+						Orchestration agent that manages task workflows, coordinates node agents, and handles
+						human gates.
+					</p>
+					{taskAgentConfig?.customPrompt && (
+						<p class="text-xs text-gray-400 mt-1 line-clamp-2 italic">
+							{taskAgentConfig.customPrompt}
+						</p>
+					)}
+				</div>
+				<div class="flex items-center gap-1 flex-shrink-0">
+					{hasOverrides && (
+						<button
+							type="button"
+							onClick={handleReset}
+							disabled={saving}
+							class="px-2.5 py-1 text-xs text-gray-400 hover:text-gray-200 bg-dark-800 hover:bg-dark-700 rounded border border-dark-700 hover:border-dark-600 transition-colors disabled:opacity-50"
+							title="Reset to code defaults"
+						>
+							{saving ? 'Resetting...' : 'Reset to defaults'}
+						</button>
+					)}
+					<button
+						type="button"
+						onClick={() => setEditing(!editing)}
+						class="p-1.5 rounded text-gray-500 hover:text-gray-300 hover:bg-dark-700 transition-colors"
+						aria-label="Edit Task Agent"
+					>
+						<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={2}
+								d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+							/>
+						</svg>
+					</button>
+				</div>
+			</div>
+
+			{editing && (
+				<div class="mt-4 pt-3 border-t border-dark-700 space-y-3">
+					<div>
+						<label class="block text-xs font-medium text-gray-400 mb-1">Model Override</label>
+						<p class="text-xs text-gray-500 mb-2">
+							Overrides the model used by the Task Agent. Falls back to the space default or{' '}
+							<span class="font-mono">{DEFAULT_TASK_AGENT_MODEL}</span> when not set.
+						</p>
+						<WorkflowModelSelect
+							value={model}
+							onChange={(val) => setModel(val)}
+							testId="task-agent-model-select"
+							className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-sm text-gray-100 focus:outline-none focus:border-blue-500"
+						/>
+					</div>
+					<div>
+						<label class="block text-xs font-medium text-gray-400 mb-1">
+							Custom Prompt
+							<span class="text-gray-600 ml-1">(optional)</span>
+						</label>
+						<p class="text-xs text-gray-500 mb-1">
+							Appended to the Task Agent system prompt after the contract sections.
+						</p>
+						<textarea
+							value={customPrompt}
+							onInput={(e) => setCustomPrompt((e.target as HTMLTextAreaElement).value)}
+							placeholder="e.g. Always prefer squashing commits..."
+							rows={4}
+							class="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-gray-100 placeholder-gray-600 focus:outline-none focus:border-blue-500 resize-y text-sm"
+						/>
+					</div>
+					<div class="flex gap-2 justify-end">
+						<Button
+							type="button"
+							variant="secondary"
+							size="sm"
+							onClick={() => {
+								setEditing(false);
+								setModel(taskAgentConfig?.model);
+								setCustomPrompt(taskAgentConfig?.customPrompt ?? '');
+							}}
+						>
+							Cancel
+						</Button>
+						<Button type="button" size="sm" loading={saving} onClick={handleSave}>
+							Save
+						</Button>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}
+
 function PlusIcon() {
 	return (
 		<svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -148,6 +337,7 @@ export function SpaceAgentList() {
 	const loading = spaceStore.loading.value;
 	const workflows = spaceStore.workflows.value;
 	const spaceId = spaceStore.spaceId.value;
+	const space = spaceStore.space.value;
 
 	const [editorOpen, setEditorOpen] = useState(false);
 	const [editingAgent, setEditingAgent] = useState<SpaceAgent | null>(null);
@@ -292,6 +482,20 @@ export function SpaceAgentList() {
 				</Button>
 			</div>
 
+			{/* Built-in Task Agent */}
+			{space && (
+				<div class="mb-4">
+					<h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+						Built-in
+					</h3>
+					<TaskAgentCard
+						spaceId={space.id}
+						taskAgentConfig={space.taskAgentConfig}
+						defaultModel={space.defaultModel}
+					/>
+				</div>
+			)}
+
 			{/* Agent list or empty state */}
 			{agents.length === 0 ? (
 				<div class="flex flex-col items-center justify-center flex-1 py-12 text-center">
@@ -309,6 +513,11 @@ export function SpaceAgentList() {
 			) : (
 				<div class="flex-1 overflow-y-auto">
 					<div class="min-h-[calc(100%+1px)] space-y-2">
+						{space && (
+							<h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+								Custom Agents
+							</h3>
+						)}
 						{agents.map((agent) => (
 							<AgentCard
 								key={agent.id}

--- a/packages/web/src/components/space/SpaceSettings.tsx
+++ b/packages/web/src/components/space/SpaceSettings.tsx
@@ -79,7 +79,7 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 		try {
 			setSaving(true);
 			setSaveError(null);
-			await hub.request('space.update', {
+			const updated = await hub.request<Space>('space.update', {
 				id: space.id,
 				name: name.trim(),
 				description: description.trim() || undefined,
@@ -88,6 +88,9 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 				autonomyLevel,
 				defaultModel: defaultModel || null,
 			});
+			// Apply response directly to avoid stale-state from event spread-merge
+			// (undefined fields like defaultModel are dropped during JSON serialization)
+			spaceStore.space.value = updated;
 			toast.success('Space updated');
 		} catch (err) {
 			setSaveError(err instanceof Error ? err.message : 'Failed to save changes');

--- a/packages/web/src/components/space/SpaceSettings.tsx
+++ b/packages/web/src/components/space/SpaceSettings.tsx
@@ -19,6 +19,7 @@ import { Button } from '../ui/Button.tsx';
 import { AUTONOMY_LEVELS } from '../../lib/space-constants.ts';
 import { AutonomyWorkflowSummary } from './AutonomyWorkflowSummary.tsx';
 import { SpaceMcpSettings } from './SpaceMcpSettings.tsx';
+import { WorkflowModelSelect } from './visual-editor/WorkflowModelSelect.tsx';
 
 interface SpaceSettingsProps {
 	space: Space;
@@ -31,6 +32,7 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 	const [instructions, setInstructions] = useState(space.instructions ?? '');
 	const [backgroundContext, setBackgroundContext] = useState(space.backgroundContext ?? '');
 	const [autonomyLevel, setAutonomyLevel] = useState<SpaceAutonomyLevel>(space.autonomyLevel ?? 1);
+	const [defaultModel, setDefaultModel] = useState<string | undefined>(space.defaultModel);
 	const [saving, setSaving] = useState(false);
 	const [saveError, setSaveError] = useState<string | null>(null);
 	const [isArchiving, setIsArchiving] = useState(false);
@@ -43,6 +45,7 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 		setInstructions(space.instructions ?? '');
 		setBackgroundContext(space.backgroundContext ?? '');
 		setAutonomyLevel(space.autonomyLevel ?? 1);
+		setDefaultModel(space.defaultModel);
 		setSaveError(null);
 	}, [
 		space.id,
@@ -51,6 +54,7 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 		space.instructions,
 		space.backgroundContext,
 		space.autonomyLevel,
+		space.defaultModel,
 	]);
 
 	const isDirty =
@@ -58,7 +62,8 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 		description !== (space.description ?? '') ||
 		instructions !== (space.instructions ?? '') ||
 		backgroundContext !== (space.backgroundContext ?? '') ||
-		autonomyLevel !== (space.autonomyLevel ?? 1);
+		autonomyLevel !== (space.autonomyLevel ?? 1) ||
+		defaultModel !== space.defaultModel;
 
 	async function handleSave(e: Event) {
 		e.preventDefault();
@@ -81,6 +86,7 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 				instructions: instructions.trim() || undefined,
 				backgroundContext: backgroundContext.trim() || undefined,
 				autonomyLevel,
+				defaultModel: defaultModel || null,
 			});
 			toast.success('Space updated');
 		} catch (err) {
@@ -287,6 +293,20 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 							/>
 						</div>
 
+						<div>
+							<label class="block text-xs font-medium text-gray-400 mb-1">Default Model</label>
+							<p class="text-xs text-gray-500 mb-2">
+								Default model for agents and sessions in this Space. Falls back to the app-level
+								default when not set.
+							</p>
+							<WorkflowModelSelect
+								value={defaultModel}
+								onChange={(val) => setDefaultModel(val)}
+								testId="default-model-select"
+								className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-sm text-gray-100 focus:outline-none focus:border-blue-500"
+							/>
+						</div>
+
 						{isDirty && (
 							<div class="flex gap-2 justify-end">
 								<Button
@@ -299,6 +319,7 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 										setInstructions(space.instructions ?? '');
 										setBackgroundContext(space.backgroundContext ?? '');
 										setAutonomyLevel(space.autonomyLevel ?? 1);
+										setDefaultModel(space.defaultModel);
 										setSaveError(null);
 									}}
 								>

--- a/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceAgentList.test.tsx
@@ -27,6 +27,7 @@ let mockAgents: ReturnType<typeof signal<SpaceAgent[]>>;
 let mockWorkflows: ReturnType<typeof signal<SpaceWorkflow[]>>;
 let mockLoading: ReturnType<typeof signal<boolean>>;
 let mockSpaceId: ReturnType<typeof signal<string | null>>;
+let mockSpace: ReturnType<typeof signal<any>>;
 
 const mockDeleteAgent = vi.fn();
 const mockCreateAgent = vi.fn();
@@ -39,6 +40,7 @@ vi.mock('../../../lib/space-store', () => ({
 			workflows: mockWorkflows,
 			loading: mockLoading,
 			spaceId: mockSpaceId,
+			space: mockSpace,
 			deleteAgent: mockDeleteAgent,
 			createAgent: mockCreateAgent,
 			updateAgent: mockUpdateAgent,
@@ -64,6 +66,21 @@ vi.mock('../../../lib/toast', () => ({
 
 vi.mock('../../../lib/utils', () => ({
 	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+// Mock WorkflowModelSelect (used by TaskAgentCard)
+vi.mock('../visual-editor/WorkflowModelSelect', () => ({
+	WorkflowModelSelect: ({ value, onChange, testId, className }) => (
+		<select
+			data-testid={testId}
+			value={value ?? ''}
+			onChange={(e) => onChange(e.target.value || undefined)}
+			class={className}
+		>
+			<option value="">-- No override --</option>
+			<option value="claude-sonnet-4-6">Claude Sonnet 4.6</option>
+		</select>
+	),
 }));
 
 // Mock SpaceAgentEditor so tests don't need to set up all of its dependencies
@@ -178,6 +195,7 @@ mockAgents = signal<SpaceAgent[]>([]);
 mockWorkflows = signal<SpaceWorkflow[]>([]);
 mockLoading = signal(false);
 mockSpaceId = signal<string | null>('space-1');
+mockSpace = signal<any>({ id: 'space-1', defaultModel: undefined, taskAgentConfig: undefined });
 
 import { SpaceAgentList } from '../SpaceAgentList';
 
@@ -274,8 +292,13 @@ describe('SpaceAgentList', () => {
 
 	it('does not render model span when model is not set', () => {
 		mockAgents.value = [makeAgent({ model: undefined })];
-		const { queryByText } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
-		expect(queryByText('claude-sonnet-4-6')).toBeNull();
+		const { container } = render(<SpaceAgentList {...DEFAULT_PROPS} />);
+		// The TaskAgentCard shows the resolved model, so check within custom agent cards only.
+		const agentCards = container.querySelectorAll('.bg-dark-850.border.border-dark-700');
+		for (const card of agentCards) {
+			const modelSpans = card.querySelectorAll('span.text-xs.text-gray-500.font-mono');
+			expect(modelSpans.length).toBe(0);
+		}
 	});
 
 	it('renders description preview', () => {

--- a/packages/web/src/components/space/__tests__/SpaceSettings.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceSettings.test.tsx
@@ -54,6 +54,21 @@ vi.mock('../export-import-utils', () => ({
 	downloadBundle: (...args) => mockDownloadBundle(...args),
 }));
 
+vi.mock('../visual-editor/WorkflowModelSelect', () => ({
+	WorkflowModelSelect: ({ value, onChange, testId, className }) => (
+		<select
+			data-testid={testId}
+			value={value ?? ''}
+			onChange={(e) => onChange(e.target.value || undefined)}
+			class={className}
+		>
+			<option value="">-- No override --</option>
+			<option value="claude-sonnet-4-6">Claude Sonnet 4.6</option>
+			<option value="claude-opus-4">Claude Opus 4</option>
+		</select>
+	),
+}));
+
 vi.mock('../../ui/Button', () => ({
 	Button: ({ children, onClick, type, loading, disabled, variant }) => (
 		<button
@@ -152,6 +167,7 @@ describe('SpaceSettings', () => {
 				instructions: 'Use TypeScript strict mode',
 				backgroundContext: undefined,
 				autonomyLevel: 1,
+				defaultModel: null,
 			});
 		});
 	});
@@ -367,6 +383,7 @@ describe('SpaceSettings', () => {
 				instructions: 'Use strict mode',
 				backgroundContext: 'Bun + Hono',
 				autonomyLevel: 1,
+				defaultModel: null,
 			});
 		});
 	});


### PR DESCRIPTION
## Summary

- **Default Model Picker** in SpaceSettings: uses `models.list` RPC via `WorkflowModelSelect` to let users pick a default model for the space. Persisted via existing `space.defaultModel` field.
- **Task Agent Card** in SpaceAgentList: distinct "Built-in" section above custom agents with model override and custom prompt support. Includes "Reset to defaults" button.
- **Backend**: new `TaskAgentConfig` type, migration 115 (`task_agent_config` JSON column on spaces), repository read/write, and overrides applied in `createTaskAgentInit()`.

## Files changed
- `packages/shared/src/types/space.ts` — `TaskAgentConfig` type + field on `Space`, `CreateSpaceParams`, `UpdateSpaceParams`
- `packages/daemon/src/storage/schema/migrations.ts` — migration 115
- `packages/daemon/src/storage/repositories/space-repository.ts` — persist `taskAgentConfig`
- `packages/daemon/src/lib/space/agents/task-agent.ts` — apply model and customPrompt overrides
- `packages/web/src/components/space/SpaceSettings.tsx` — model picker UI
- `packages/web/src/components/space/SpaceAgentList.tsx` — TaskAgentCard component
- Tests updated in both packages