### PR TITLE
Fix gate poll rehydration after restart

### DIFF
--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1351,6 +1351,9 @@ export class SpaceRuntime {
 
 		const recovered = recoverTx();
 		await this.ensureExecutorRegistered(recovered.run);
+		await this.ensurePollsForRun(
+			this.config.workflowRunRepo.getRun(recovered.run.id) ?? recovered.run
+		);
 		for (const sessionId of liveSessionIds) {
 			const prepared =
 				(await this.config.taskAgentManager?.prepareSubSessionForWorkflowResume(sessionId)) ?? true;
@@ -1405,15 +1408,16 @@ export class SpaceRuntime {
 	}
 
 	/**
-	 * Restart gate polls for a workflow run restored from persisted state.
+	 * Ensure gate polls are running for an active workflow-backed task.
 	 *
-	 * GatePollManager keeps timers in memory, so a daemon restart loses them even
-	 * though the workflow run and definition remain in the database. Rehydration
-	 * must therefore recreate poll timers after the executor and metadata are back.
+	 * GatePollManager keeps timers in memory, so daemon restarts and blocked/manual
+	 * recovery transitions must recreate them from persisted run + workflow state.
+	 * Polls are proactive and should remain active for any non-terminal task; only
+	 * done/cancelled/archived tasks should have polls stopped.
 	 */
-	private startRehydratedGatePolls(run: SpaceWorkflowRun, space: Space): void {
+	private async ensurePollsForRun(run: SpaceWorkflowRun, knownSpace?: Space): Promise<void> {
 		if (!this.pollManager) return;
-		if (run.status === 'done' || run.status === 'cancelled' || run.status === 'blocked') return;
+		if (run.status === 'done' || run.status === 'cancelled') return;
 
 		const workflow = this.executorMeta.get(run.id)?.workflow;
 		if (!workflow?.gates?.some((gate) => gate.poll)) return;
@@ -1424,10 +1428,20 @@ export class SpaceRuntime {
 		);
 		if (!canonicalTask) {
 			log.warn(
-				`SpaceRuntime.rehydrateExecutors: cannot restart gate polls for run ${run.id} — no canonical task found`
+				`SpaceRuntime.ensurePollsForRun: cannot restart gate polls for run ${run.id} — no canonical task found`
 			);
 			return;
 		}
+		if (
+			canonicalTask.status === 'done' ||
+			canonicalTask.status === 'cancelled' ||
+			canonicalTask.status === 'archived'
+		) {
+			return;
+		}
+
+		const space = knownSpace ?? (await this.config.spaceManager.getSpace(run.spaceId));
+		if (!space) return;
 
 		const pollContext = this.buildPollScriptContext(canonicalTask, run, space.id);
 		if (!pollContext) return;
@@ -1463,7 +1477,7 @@ export class SpaceRuntime {
 				if (this.executors.has(run.id)) continue;
 				const registered = await this.ensureExecutorRegistered(run, space);
 				if (registered) {
-					this.startRehydratedGatePolls(run, space);
+					await this.ensurePollsForRun(run, space);
 				}
 			}
 		}
@@ -3359,6 +3373,8 @@ export class SpaceRuntime {
 			// Clear dedup so a re-block can be notified again.
 			this.notifiedTaskSet.delete(`${canonicalTask.id}:blocked`);
 
+			await this.ensurePollsForRun(this.config.workflowRunRepo.getRun(runId) ?? run);
+
 			await this.safeNotify({
 				kind: 'task_retry',
 				spaceId: meta.spaceId,
@@ -3526,12 +3542,10 @@ export class SpaceRuntime {
 		for (const [runId] of this.executors) {
 			const run = this.config.workflowRunRepo.getRun(runId);
 
-			// Blocked runs keep their executor so they remain rehydratable and can
-			// be retried (blocked → in_progress). Stop polls only — do not remove
-			// the executor or prune dedup keys (processRunTick handles dedup clearing
-			// when it observes canonicalTask.status !== 'blocked').
+			// Blocked runs keep their executor and proactive gate polls so they remain
+			// rehydratable and poll timers can detect external conditions that may help
+			// unblock the run. Do not remove the executor or prune dedup keys here.
 			if (run?.status === 'blocked') {
-				this.pollManager?.stopPolls(runId);
 				continue;
 			}
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1419,8 +1419,13 @@ export class SpaceRuntime {
 		if (!this.pollManager) return;
 		if (run.status === 'done' || run.status === 'cancelled') return;
 
-		const workflow = this.executorMeta.get(run.id)?.workflow;
-		if (!workflow?.gates?.some((gate) => gate.poll)) return;
+		const workflow =
+			this.config.spaceWorkflowManager.getWorkflow(run.workflowId) ??
+			this.executorMeta.get(run.id)?.workflow;
+		if (!workflow?.gates?.some((gate) => gate.poll)) {
+			this.pollManager.stopPolls(run.id);
+			return;
+		}
 
 		const canonicalTask = this.pickCanonicalTaskForRun(
 			run,

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1446,6 +1446,10 @@ export class SpaceRuntime {
 		const pollContext = this.buildPollScriptContext(canonicalTask, run, space.id);
 		if (!pollContext) return;
 
+		// GatePollManager.startPolls replaces activePolls entries but does not clear
+		// any existing interval for the same run/gate key. Stop first so this helper
+		// is idempotent across rehydration + recovery paths in the same tick.
+		this.pollManager.stopPolls(run.id);
 		this.pollManager.startPolls(run.id, workflow, space.workspacePath, space.id, pollContext);
 	}
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1189,6 +1189,16 @@ export class SpaceRuntime {
 		return this.executors.get(runId);
 	}
 
+	/** @internal — exposed only for unit tests/diagnostics. */
+	getActiveGatePollCount(): number {
+		return this.pollManager?.activePollCount ?? 0;
+	}
+
+	/** @internal — exposed only for unit tests/diagnostics. */
+	isGatePollActive(runId: string, gateId: string): boolean {
+		return this.pollManager?.isPollActive(runId, gateId) ?? false;
+	}
+
 	/**
 	 * Reopen or resume a workflow-backed task as one lifecycle operation.
 	 *
@@ -1395,6 +1405,37 @@ export class SpaceRuntime {
 	}
 
 	/**
+	 * Restart gate polls for a workflow run restored from persisted state.
+	 *
+	 * GatePollManager keeps timers in memory, so a daemon restart loses them even
+	 * though the workflow run and definition remain in the database. Rehydration
+	 * must therefore recreate poll timers after the executor and metadata are back.
+	 */
+	private startRehydratedGatePolls(run: SpaceWorkflowRun, space: Space): void {
+		if (!this.pollManager) return;
+		if (run.status === 'done' || run.status === 'cancelled' || run.status === 'blocked') return;
+
+		const workflow = this.executorMeta.get(run.id)?.workflow;
+		if (!workflow?.gates?.some((gate) => gate.poll)) return;
+
+		const canonicalTask = this.pickCanonicalTaskForRun(
+			run,
+			this.config.taskRepo.listByWorkflowRun(run.id)
+		);
+		if (!canonicalTask) {
+			log.warn(
+				`SpaceRuntime.rehydrateExecutors: cannot restart gate polls for run ${run.id} — no canonical task found`
+			);
+			return;
+		}
+
+		const pollContext = this.buildPollScriptContext(canonicalTask, run, space.id);
+		if (!pollContext) return;
+
+		this.pollManager.startPolls(run.id, workflow, space.workspacePath, space.id, pollContext);
+	}
+
+	/**
 	 * Rehydrates WorkflowExecutors from the DB for all in-progress workflow runs,
 	 * then rehydrates Task Agent sessions if a TaskAgentManager is configured.
 	 *
@@ -1420,7 +1461,10 @@ export class SpaceRuntime {
 			for (const run of activeRuns) {
 				// Skip if executor already registered (e.g. called twice)
 				if (this.executors.has(run.id)) continue;
-				await this.ensureExecutorRegistered(run, space);
+				const registered = await this.ensureExecutorRegistered(run, space);
+				if (registered) {
+					this.startRehydratedGatePolls(run, space);
+				}
 			}
 		}
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-rehydration.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-rehydration.test.ts
@@ -304,6 +304,64 @@ describe('SpaceRuntime — crash recovery and rehydration', () => {
 			expect(freshRuntime.executorCount).toBe(1);
 			expect(freshRuntime.getExecutor(pendingRun.id)).toBeDefined();
 		});
+
+		test('fresh runtime restarts gate polls for a rehydrated blocked run with a non-terminal task', async () => {
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Blocked Polled Workflow-${Date.now()}-${Math.random()}`,
+				description: 'Test',
+				nodes: [
+					{ id: STEP_A, name: 'Step A', agentId: AGENT },
+					{ id: STEP_B, name: 'Step B', agentId: AGENT },
+				],
+				transitions: [],
+				channels: [{ id: 'channel-blocked', from: 'Step A', to: 'Step B', gateId: 'gate-blocked' }],
+				gates: [
+					{
+						id: 'gate-blocked',
+						resetOnCycle: false,
+						poll: { intervalMs: 60_000, script: 'printf poll', target: 'to' },
+					},
+				],
+				startNodeId: STEP_A,
+				endNodeId: STEP_B,
+				rules: [],
+				tags: [],
+				completionAutonomyLevel: 3,
+			});
+			const pendingRun = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Blocked Polled Run',
+			});
+			const inProgressRun = workflowRunRepo.transitionStatus(pendingRun.id, 'in_progress');
+			const blockedRun = workflowRunRepo.transitionStatus(inProgressRun.id, 'blocked');
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Blocked Polled Run',
+				description: '',
+				workflowRunId: blockedRun.id,
+				status: 'blocked',
+			});
+
+			const freshRuntime = makeRuntime();
+			freshRuntime.setTaskAgentManager({
+				isExecutionSpawning: () => false,
+				isSessionAlive: () => true,
+				spawnWorkflowNodeAgentForExecution: async () => 'session-1',
+				cancelBySessionId: () => {},
+				interruptBySessionId: async () => {},
+				rehydrate: async () => {},
+				injectSubSessionMessage: () => {},
+			} as never);
+
+			await freshRuntime.executeTick();
+			await freshRuntime.executeTick();
+
+			expect(freshRuntime.getExecutor(blockedRun.id)).toBeDefined();
+			expect(freshRuntime.isGatePollActive(blockedRun.id, 'gate-blocked')).toBe(true);
+			await freshRuntime.stop();
+		});
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-rehydration.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-rehydration.test.ts
@@ -184,6 +184,68 @@ describe('SpaceRuntime — crash recovery and rehydration', () => {
 			expect(freshRuntime.getExecutor(runA.id)).toBeDefined();
 		});
 
+		test('fresh runtime restarts gate polls for a rehydrated in_progress run', async () => {
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Polled Workflow-${Date.now()}-${Math.random()}`,
+				description: 'Test',
+				nodes: [
+					{ id: STEP_A, name: 'Step A', agentId: AGENT },
+					{ id: STEP_B, name: 'Step B', agentId: AGENT },
+				],
+				transitions: [],
+				channels: [{ id: 'channel-a-b', from: 'Step A', to: 'Step B', gateId: 'gate-polled' }],
+				gates: [
+					{
+						id: 'gate-polled',
+						resetOnCycle: false,
+						poll: {
+							intervalMs: 60_000,
+							script: 'printf poll',
+							target: 'to',
+						},
+					},
+				],
+				startNodeId: STEP_A,
+				endNodeId: STEP_B,
+				rules: [],
+				tags: [],
+				completionAutonomyLevel: 3,
+			});
+
+			const pendingRun = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Polled Run',
+			});
+			const run = workflowRunRepo.transitionStatus(pendingRun.id, 'in_progress');
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Polled Run',
+				description: '',
+				workflowRunId: run.id,
+				status: 'in_progress',
+			});
+
+			const freshRuntime = makeRuntime();
+			freshRuntime.setTaskAgentManager({
+				isExecutionSpawning: () => false,
+				isSessionAlive: () => true,
+				spawnWorkflowNodeAgentForExecution: async () => 'session-1',
+				cancelBySessionId: () => {},
+				interruptBySessionId: async () => {},
+				rehydrate: async () => {},
+				injectSubSessionMessage: () => {},
+			} as never);
+
+			await freshRuntime.executeTick();
+
+			expect(freshRuntime.getExecutor(run.id)).toBeDefined();
+			expect(freshRuntime.getActiveGatePollCount()).toBe(1);
+			expect(freshRuntime.isGatePollActive(run.id, 'gate-polled')).toBe(true);
+			await freshRuntime.stop();
+		});
+
 		test('multiple in_progress runs all rehydrated by fresh runtime', async () => {
 			const wfA = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: 'step-multi-a', name: 'Step A', agentId: AGENT },

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
@@ -306,7 +306,7 @@ describe('SpaceRuntime', () => {
 			expect(recoveredRun.failureReason).toBeUndefined();
 		});
 
-		test('reopening a blocked workflow task restarts gate polls', async () => {
+		test('reopening a blocked workflow task does not resurrect removed gate polls', async () => {
 			runtime.setTaskAgentManager({
 				isExecutionSpawning: () => false,
 				isSessionAlive: () => true,
@@ -343,12 +343,63 @@ describe('SpaceRuntime', () => {
 
 			workflowRunRepo.transitionStatus(run.id, 'blocked');
 			taskRepo.updateTask(task.id, { status: 'blocked', blockReason: 'human_input_requested' });
-			runtime.stop();
-			expect(runtime.isGatePollActive(run.id, 'recover-gate')).toBe(false);
+			workflowManager.updateWorkflow(workflow.id, { gates: [] });
 
 			await runtime.recoverWorkflowBackedTask(SPACE_ID, task.id, 'open');
 
-			expect(runtime.isGatePollActive(run.id, 'recover-gate')).toBe(true);
+			expect(runtime.isGatePollActive(run.id, 'recover-gate')).toBe(false);
+			expect(runtime.getActiveGatePollCount()).toBe(0);
+			await runtime.stop();
+		});
+
+		test('reopening a blocked workflow task restarts gate polls from latest workflow config', async () => {
+			runtime.setTaskAgentManager({
+				isExecutionSpawning: () => false,
+				isSessionAlive: () => true,
+				spawnWorkflowNodeAgentForExecution: async () => 'session-1',
+				cancelBySessionId: () => {},
+				interruptBySessionId: async () => {},
+				rehydrate: async () => {},
+				injectSubSessionMessage: () => {},
+			} as never);
+
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[],
+				{
+					channels: [
+						{ id: 'recover-polled-channel-2', from: 'Plan', to: 'Code', gateId: 'recover-gate-2' },
+					],
+					gates: [
+						{
+							id: 'recover-gate-2',
+							resetOnCycle: false,
+							poll: { intervalMs: 60_000, script: 'printf poll', target: 'to' },
+						},
+					],
+				}
+			);
+			const { run, tasks } = await runtime.startWorkflowRun(
+				SPACE_ID,
+				workflow.id,
+				'Recover poll latest'
+			);
+			const task = tasks[0];
+
+			workflowRunRepo.transitionStatus(run.id, 'blocked');
+			taskRepo.updateTask(task.id, { status: 'blocked', blockReason: 'human_input_requested' });
+			runtime.stop();
+			expect(runtime.isGatePollActive(run.id, 'recover-gate-2')).toBe(false);
+
+			await runtime.recoverWorkflowBackedTask(SPACE_ID, task.id, 'open');
+
+			expect(runtime.isGatePollActive(run.id, 'recover-gate-2')).toBe(true);
+			expect(runtime.getActiveGatePollCount()).toBe(1);
 			await runtime.stop();
 		});
 

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime.test.ts
@@ -78,7 +78,8 @@ function buildLinearWorkflow(
 	spaceId: string,
 	workflowManager: SpaceWorkflowManager,
 	nodes: Array<{ id: string; name: string; agentId: string; instructions?: string }>,
-	conditions: Array<{ type: 'always' | 'human'; description?: string }> = []
+	conditions: Array<{ type: 'always' | 'human'; description?: string }> = [],
+	opts: { channels?: SpaceWorkflow['channels']; gates?: SpaceWorkflow['gates'] } = {}
 ): SpaceWorkflow {
 	// Build transitions: step[i] → step[i+1] with conditions[i]
 	const transitions = nodes.slice(0, -1).map((step, i) => ({
@@ -94,6 +95,8 @@ function buildLinearWorkflow(
 		description: 'Test',
 		nodes,
 		transitions,
+		channels: opts.channels,
+		gates: opts.gates,
 		startNodeId: nodes[0].id,
 		rules: [],
 		tags: [],
@@ -301,6 +304,52 @@ describe('SpaceRuntime', () => {
 			expect(recoveredRun.status).toBe('in_progress');
 			expect(recoveredRun.completedAt).toBeNull();
 			expect(recoveredRun.failureReason).toBeUndefined();
+		});
+
+		test('reopening a blocked workflow task restarts gate polls', async () => {
+			runtime.setTaskAgentManager({
+				isExecutionSpawning: () => false,
+				isSessionAlive: () => true,
+				spawnWorkflowNodeAgentForExecution: async () => 'session-1',
+				cancelBySessionId: () => {},
+				interruptBySessionId: async () => {},
+				rehydrate: async () => {},
+				injectSubSessionMessage: () => {},
+			} as never);
+
+			const workflow = buildLinearWorkflow(
+				SPACE_ID,
+				workflowManager,
+				[
+					{ id: STEP_A, name: 'Plan', agentId: AGENT_PLANNER },
+					{ id: STEP_B, name: 'Code', agentId: AGENT_CODER },
+				],
+				[],
+				{
+					channels: [
+						{ id: 'recover-polled-channel', from: 'Plan', to: 'Code', gateId: 'recover-gate' },
+					],
+					gates: [
+						{
+							id: 'recover-gate',
+							resetOnCycle: false,
+							poll: { intervalMs: 60_000, script: 'printf poll', target: 'to' },
+						},
+					],
+				}
+			);
+			const { run, tasks } = await runtime.startWorkflowRun(SPACE_ID, workflow.id, 'Recover poll');
+			const task = tasks[0];
+
+			workflowRunRepo.transitionStatus(run.id, 'blocked');
+			taskRepo.updateTask(task.id, { status: 'blocked', blockReason: 'human_input_requested' });
+			runtime.stop();
+			expect(runtime.isGatePollActive(run.id, 'recover-gate')).toBe(false);
+
+			await runtime.recoverWorkflowBackedTask(SPACE_ID, task.id, 'open');
+
+			expect(runtime.isGatePollActive(run.id, 'recover-gate')).toBe(true);
+			await runtime.stop();
 		});
 
 		test('resuming a blocked workflow task moves task and run in progress', async () => {


### PR DESCRIPTION
Fix gate poll timer lifecycle across daemon restarts, blocked-run recovery, and manual task recovery.

Gate polls are proactive timers that should stay active for any non-terminal task (`done`/`cancelled`/`archived`). The previous code only started polls at run creation and stopped them on blocked runs — polls were never restarted after recovery transitions.

Changes:
- Add `ensurePollsForRun()` shared helper that checks task status (not run status) and is idempotent (stop-before-start prevents timer leaks)
- Call it from `rehydrateExecutors()` to restore polls after daemon restart
- Call it from `attemptBlockedRunRecovery()` Tier 1 to restart polls after blocked → in_progress auto-retry
- Call it from `recoverWorkflowBackedTask()` to restart polls after manual task recovery
- Stop killing polls for blocked runs in `cleanupTerminalExecutors()` — proactive polls should keep running