### PR TITLE
Fix PR comment gate poll notifications

### DIFF
--- a/packages/daemon/src/lib/space/runtime/gate-poll-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/gate-poll-manager.ts
@@ -281,6 +281,7 @@ export class GatePollManager {
 		});
 
 		if (polledGates.length === 0) {
+			log.info(`GatePollManager: no polled gates configured for run "${runId}"`);
 			return;
 		}
 
@@ -734,9 +735,9 @@ export class GatePollManager {
 			const sessionId = this.sessionResolver.getActiveSessionForNode(runId, targetNodeId);
 
 			if (!sessionId) {
-				log.debug(
-					`GatePollManager: no active session for node "${targetNodeId}" in run "${runId}" — ` +
-						`skipping message injection for poll "${gateId}"`
+				log.warn(
+					`GatePollManager: no resumable session for node "${targetNodeId}" in run "${runId}" — ` +
+						`will retry message injection for poll "${gateId}" on the next tick`
 				);
 				return;
 			}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -3502,9 +3502,9 @@ export class SpaceRuntime {
 
 		try {
 			const gateDataRepo = this.config.gateDataRepo ?? new GateDataRepository(this.config.db);
-			const gateRecords = gateDataRepo.listByRun(runId);
-			for (let i = gateRecords.length - 1; i >= 0; i--) {
-				const candidate = fromData(gateRecords[i]?.data);
+			const gateRecords = gateDataRepo.listByRun(runId).sort((a, b) => b.updatedAt - a.updatedAt);
+			for (const record of gateRecords) {
+				const candidate = fromData(record.data);
 				if (candidate) return candidate;
 			}
 		} catch (err) {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -435,7 +435,9 @@ export class SpaceRuntime {
 						);
 						if (active?.agentSessionId) return active.agentSessionId;
 
-						const latestWithSession = executions.filter((e) => e.agentSessionId !== null).at(-1);
+						const latestWithSession = executions
+							.filter((e) => e.status !== 'cancelled' && e.agentSessionId !== null)
+							.at(-1);
 						if (latestWithSession?.agentSessionId) {
 							log.info(
 								`SpaceRuntime: gate poll will wake idle session "${latestWithSession.agentSessionId}" ` +

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -98,6 +98,8 @@ export interface SpaceRuntimeConfig {
 	taskRepo: SpaceTaskRepository;
 	/** Node execution repository for workflow-internal execution state */
 	nodeExecutionRepo: NodeExecutionRepository;
+	/** Optional gate data repository used to resolve PR URLs written through gated channels. */
+	gateDataRepo?: GateDataRepository;
 	/** Optional reactive DB invalidation hooks for task LiveQuery surfaces */
 	reactiveDb?: ReactiveDatabase;
 	/**
@@ -431,29 +433,24 @@ export class SpaceRuntime {
 						const active = executions.find(
 							(e) => e.status !== 'cancelled' && e.status !== 'idle' && e.agentSessionId !== null
 						);
-						return active?.agentSessionId ?? null;
+						if (active?.agentSessionId) return active.agentSessionId;
+
+						const latestWithSession = executions.filter((e) => e.agentSessionId !== null).at(-1);
+						if (latestWithSession?.agentSessionId) {
+							log.info(
+								`SpaceRuntime: gate poll will wake idle session "${latestWithSession.agentSessionId}" ` +
+									`for run "${runId}" node "${nodeId}"`
+							);
+							return latestWithSession.agentSessionId;
+						}
+
+						return null;
 					},
 				},
 				// PR URL resolver: refreshes PR context on each poll tick so polls
 				// discover PR URLs that appear after the run starts.
 				{
-					getPrUrlForRun: async (runId) => {
-						if (!this.config.artifactRepo) return '';
-						try {
-							const artifacts = this.config.artifactRepo.listByRun(runId);
-							for (let i = artifacts.length - 1; i >= 0; i--) {
-								const data = artifacts[i]?.data;
-								if (!data) continue;
-								const candidate =
-									(typeof data.prUrl === 'string' && data.prUrl) ||
-									(typeof data.pr_url === 'string' && data.pr_url);
-								if (candidate) return candidate;
-							}
-						} catch {
-							// Swallow - PR URL resolution is best-effort
-						}
-						return '';
-					},
+					getPrUrlForRun: async (runId) => this.resolvePrUrlForRun(runId),
 				},
 				// Workflow definition provider: enables mid-run poll config pickup
 				// by re-reading the latest workflow definition from the DB.
@@ -1199,6 +1196,11 @@ export class SpaceRuntime {
 		return this.pollManager?.isPollActive(runId, gateId) ?? false;
 	}
 
+	/** @internal — exposed only for unit tests/diagnostics. */
+	getPollPrUrlForRun(runId: string): string {
+		return this.resolvePrUrlForRun(runId);
+	}
+
 	/**
 	 * Reopen or resume a workflow-backed task as one lifecycle operation.
 	 *
@@ -1422,7 +1424,17 @@ export class SpaceRuntime {
 		const workflow =
 			this.config.spaceWorkflowManager.getWorkflow(run.workflowId) ??
 			this.executorMeta.get(run.id)?.workflow;
-		if (!workflow?.gates?.some((gate) => gate.poll)) {
+		if (!workflow) {
+			log.warn(
+				`SpaceRuntime.ensurePollsForRun: cannot ensure gate polls for run ${run.id} — workflow ${run.workflowId} not found`
+			);
+			return;
+		}
+		const pollGateCount = workflow.gates?.filter((gate) => gate.poll).length ?? 0;
+		if (pollGateCount === 0) {
+			log.info(
+				`SpaceRuntime.ensurePollsForRun: stopping gate polls for run ${run.id} — workflow has no polled gates`
+			);
 			this.pollManager.stopPolls(run.id);
 			return;
 		}
@@ -1442,15 +1454,27 @@ export class SpaceRuntime {
 			canonicalTask.status === 'cancelled' ||
 			canonicalTask.status === 'archived'
 		) {
+			log.info(
+				`SpaceRuntime.ensurePollsForRun: not starting gate polls for run ${run.id} — task ${canonicalTask.id} is ${canonicalTask.status}`
+			);
 			return;
 		}
 
 		const space = knownSpace ?? (await this.config.spaceManager.getSpace(run.spaceId));
-		if (!space) return;
+		if (!space) {
+			log.warn(
+				`SpaceRuntime.ensurePollsForRun: cannot ensure gate polls for run ${run.id} — space ${run.spaceId} not found`
+			);
+			return;
+		}
 
 		const pollContext = this.buildPollScriptContext(canonicalTask, run, space.id);
 		if (!pollContext) return;
 
+		log.info(
+			`SpaceRuntime.ensurePollsForRun: starting ${pollGateCount} gate poll(s) for run ${run.id} ` +
+				`(runStatus=${run.status}, taskStatus=${canonicalTask.status}, prUrl=${pollContext.PR_URL ? 'present' : 'missing'})`
+		);
 		// GatePollManager.startPolls replaces activePolls entries but does not clear
 		// any existing interval for the same run/gate key. Stop first so this helper
 		// is idempotent across rehydration + recovery paths in the same tick.
@@ -1480,10 +1504,27 @@ export class SpaceRuntime {
 			// 'blocked' runs are included so a human-gate-blocked run gets its
 			// executor reloaded on restart, allowing it to advance once the gate is resolved.
 			const activeRuns = this.config.workflowRunRepo.getRehydratableRuns(space.id);
+			const reviewRuns = this.config.workflowRunRepo
+				.listBySpace(space.id)
+				.filter(
+					(run) =>
+						!activeRuns.some((activeRun) => activeRun.id === run.id) &&
+						run.status !== 'done' &&
+						run.status !== 'cancelled' &&
+						this.config.taskRepo.listByWorkflowRun(run.id).some((task) => task.status === 'review')
+				);
+			if (reviewRuns.length > 0) {
+				log.info(
+					`SpaceRuntime.rehydrateExecutors: found ${reviewRuns.length} review-pending run(s) with non-terminal status in space ${space.id}`
+				);
+			}
+			activeRuns.push(...reviewRuns);
 
 			for (const run of activeRuns) {
-				// Skip if executor already registered (e.g. called twice)
-				if (this.executors.has(run.id)) continue;
+				if (this.executors.has(run.id)) {
+					await this.ensurePollsForRun(run, space);
+					continue;
+				}
 				const registered = await this.ensureExecutorRegistered(run, space);
 				if (registered) {
 					await this.ensurePollsForRun(run, space);
@@ -3438,27 +3479,7 @@ export class SpaceRuntime {
 		run: SpaceWorkflowRun,
 		spaceId: string
 	): PollScriptContext | null {
-		// Resolve PR URL from artifacts (same pattern as dispatchPostApproval)
-		let prUrl = '';
-		if (this.config.artifactRepo) {
-			try {
-				const artifacts = this.config.artifactRepo.listByRun(run.id);
-				for (let i = artifacts.length - 1; i >= 0; i--) {
-					const data = artifacts[i]?.data;
-					if (!data) continue;
-					const candidate =
-						(typeof data.prUrl === 'string' && data.prUrl) ||
-						(typeof data.pr_url === 'string' && data.pr_url);
-					if (candidate) {
-						prUrl = candidate;
-						break;
-					}
-				}
-			} catch {
-				// Swallow — PR URL is best-effort for polls
-			}
-		}
-
+		const prUrl = this.resolvePrUrlForRun(run.id);
 		const prCtx = extractPrContext(prUrl);
 
 		return {
@@ -3471,6 +3492,42 @@ export class SpaceRuntime {
 			REPO_NAME: prCtx.REPO_NAME,
 			WORKFLOW_RUN_ID: run.id,
 		};
+	}
+
+	private resolvePrUrlForRun(runId: string): string {
+		const fromData = (data: Record<string, unknown> | undefined): string =>
+			(typeof data?.prUrl === 'string' && data.prUrl) ||
+			(typeof data?.pr_url === 'string' && data.pr_url) ||
+			'';
+
+		try {
+			const gateDataRepo = this.config.gateDataRepo ?? new GateDataRepository(this.config.db);
+			const gateRecords = gateDataRepo.listByRun(runId);
+			for (let i = gateRecords.length - 1; i >= 0; i--) {
+				const candidate = fromData(gateRecords[i]?.data);
+				if (candidate) return candidate;
+			}
+		} catch (err) {
+			log.warn(
+				`SpaceRuntime.resolvePrUrlForRun: failed to read gate data for run ${runId}: ${err instanceof Error ? err.message : String(err)}`
+			);
+		}
+
+		if (this.config.artifactRepo) {
+			try {
+				const artifacts = this.config.artifactRepo.listByRun(runId);
+				for (let i = artifacts.length - 1; i >= 0; i--) {
+					const candidate = fromData(artifacts[i]?.data);
+					if (candidate) return candidate;
+				}
+			} catch (err) {
+				log.warn(
+					`SpaceRuntime.resolvePrUrlForRun: failed to read artifacts for run ${runId}: ${err instanceof Error ? err.message : String(err)}`
+				);
+			}
+		}
+
+		return '';
 	}
 
 	private resolveCompletionSummary(runId: string, workflow: SpaceWorkflow): string | undefined {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1426,8 +1426,9 @@ export class SpaceRuntime {
 			this.executorMeta.get(run.id)?.workflow;
 		if (!workflow) {
 			log.warn(
-				`SpaceRuntime.ensurePollsForRun: cannot ensure gate polls for run ${run.id} — workflow ${run.workflowId} not found`
+				`SpaceRuntime.ensurePollsForRun: stopping gate polls for run ${run.id} — workflow ${run.workflowId} not found`
 			);
+			this.pollManager.stopPolls(run.id);
 			return;
 		}
 		const pollGateCount = workflow.gates?.filter((gate) => gate.poll).length ?? 0;

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -80,7 +80,7 @@ const PR_INLINE_COMMENTS_POLL: GatePoll = {
 		'QUERY="query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100){nodes{isResolved comments(last:1){nodes{author{login} body url}}}}}}}"',
 		'gh api graphql -f query="$QUERY" -f owner="$REPO_OWNER" -f name="$REPO_NAME" -F number="$PR_NUMBER" --jq \'[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | .comments.nodes[0] | "- **" + .author.login + "**: " + .body + "\\n  " + .url] | join("\\n\\n")\'',
 	].join('\n'),
-	target: 'to',
+	target: 'from',
 	messageTemplate: 'Unresolved PR review comments:\n{{output}}',
 };
 

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -77,7 +77,7 @@ const PR_INLINE_COMMENTS_POLL: GatePoll = {
 	intervalMs: 30_000,
 	script: [
 		'if [ -z "$PR_URL" ]; then exit 0; fi',
-		'QUERY="query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100){nodes{isResolved comments(last:1){nodes{author{login} body url}}}}}}}"',
+		"QUERY='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100){nodes{isResolved comments(last:1){nodes{author{login} body url}}}}}}}'",
 		'gh api graphql -f query="$QUERY" -f owner="$REPO_OWNER" -f name="$REPO_NAME" -F number="$PR_NUMBER" --jq \'[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | .comments.nodes[0] | "- **" + .author.login + "**: " + .body + "\\n  " + .url] | join("\\n\\n")\'',
 	].join('\n'),
 	target: 'from',

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-rehydration.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-rehydration.test.ts
@@ -416,6 +416,77 @@ describe('SpaceRuntime — crash recovery and rehydration', () => {
 			await runtime.stop();
 		});
 
+		test('gate poll session resolver ignores cancelled fallback sessions', async () => {
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Cancelled Fallback Poll-${Date.now()}-${Math.random()}`,
+				description: 'Test',
+				nodes: [
+					{ id: STEP_A, name: 'Step A', agentId: AGENT },
+					{ id: STEP_B, name: 'Step B', agentId: AGENT },
+				],
+				transitions: [],
+				channels: [
+					{ id: 'channel-cancelled', from: 'Step A', to: 'Step B', gateId: 'gate-cancelled' },
+				],
+				gates: [
+					{
+						id: 'gate-cancelled',
+						resetOnCycle: false,
+						poll: { intervalMs: 60_000, script: 'printf poll', target: 'from' },
+					},
+				],
+				startNodeId: STEP_A,
+				endNodeId: STEP_B,
+				rules: [],
+				tags: [],
+				completionAutonomyLevel: 3,
+			});
+			const run = workflowRunRepo.transitionStatus(
+				workflowRunRepo.createRun({
+					spaceId: SPACE_ID,
+					workflowId: workflow.id,
+					title: 'Cancelled Fallback Poll Run',
+				}).id,
+				'in_progress'
+			);
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Cancelled Fallback Poll Run',
+				description: '',
+				workflowRunId: run.id,
+				status: 'in_progress',
+			});
+			const nodeExecutionRepo = new NodeExecutionRepository(db);
+			const execution = nodeExecutionRepo.create({
+				workflowRunId: run.id,
+				workflowNodeId: STEP_A,
+				agentName: 'agent',
+				agentId: AGENT,
+				agentSessionId: 'session-cancelled',
+				status: 'idle',
+			});
+			nodeExecutionRepo.update(execution.id, { status: 'cancelled' });
+			const injected: string[] = [];
+			const runtime = makeRuntime({ nodeExecutionRepo });
+			runtime.setTaskAgentManager({
+				isExecutionSpawning: () => false,
+				isSessionAlive: () => false,
+				spawnWorkflowNodeAgentForExecution: async () => 'session-1',
+				cancelBySessionId: () => {},
+				interruptBySessionId: async () => {},
+				rehydrate: async () => {},
+				injectSubSessionMessage: (_sessionId: string, message: string) => {
+					injected.push(message);
+				},
+			} as never);
+
+			await runtime.executeTick();
+			await runtime.stop();
+
+			expect(injected).toEqual([]);
+		});
+
 		test('multiple in_progress runs all rehydrated by fresh runtime', async () => {
 			const wfA = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: 'step-multi-a', name: 'Step A', agentId: AGENT },

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-rehydration.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-rehydration.test.ts
@@ -20,6 +20,7 @@ import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories
 import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
 import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
 import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
+import { GateDataRepository } from '../../../../src/storage/repositories/gate-data-repository.ts';
 import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
 import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
@@ -244,6 +245,81 @@ describe('SpaceRuntime — crash recovery and rehydration', () => {
 			expect(freshRuntime.getActiveGatePollCount()).toBe(1);
 			expect(freshRuntime.isGatePollActive(run.id, 'gate-polled')).toBe(true);
 			await freshRuntime.stop();
+		});
+
+		test('fresh runtime restarts gate polls for a review-pending task', async () => {
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Review Polled Workflow-${Date.now()}-${Math.random()}`,
+				description: 'Test',
+				nodes: [
+					{ id: STEP_A, name: 'Step A', agentId: AGENT },
+					{ id: STEP_B, name: 'Step B', agentId: AGENT },
+				],
+				transitions: [],
+				channels: [{ id: 'channel-review', from: 'Step A', to: 'Step B', gateId: 'gate-review' }],
+				gates: [
+					{
+						id: 'gate-review',
+						resetOnCycle: false,
+						poll: { intervalMs: 60_000, script: 'printf poll', target: 'from' },
+					},
+				],
+				startNodeId: STEP_A,
+				endNodeId: STEP_B,
+				rules: [],
+				tags: [],
+				completionAutonomyLevel: 3,
+			});
+
+			const pendingRun = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Review Polled Run',
+			});
+			const run = workflowRunRepo.transitionStatus(pendingRun.id, 'in_progress');
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Review Polled Run',
+				description: '',
+				workflowRunId: run.id,
+				status: 'review',
+			});
+
+			const freshRuntime = makeRuntime();
+			freshRuntime.setTaskAgentManager({
+				isExecutionSpawning: () => false,
+				isSessionAlive: () => true,
+				spawnWorkflowNodeAgentForExecution: async () => 'session-1',
+				cancelBySessionId: () => {},
+				interruptBySessionId: async () => {},
+				rehydrate: async () => {},
+				injectSubSessionMessage: () => {},
+			} as never);
+
+			await freshRuntime.executeTick();
+
+			expect(freshRuntime.getExecutor(run.id)).toBeDefined();
+			expect(freshRuntime.isGatePollActive(run.id, 'gate-review')).toBe(true);
+			await freshRuntime.stop();
+		});
+
+		test('poll context resolves PR URL from gate data when no artifact exists', () => {
+			const run = workflowRunRepo.transitionStatus(
+				workflowRunRepo.createRun({
+					spaceId: SPACE_ID,
+					workflowId: 'workflow-gate-pr',
+					title: 'Gate Data PR Run',
+				}).id,
+				'in_progress'
+			);
+			new GateDataRepository(db).set(run.id, 'code-ready-gate', {
+				pr_url: 'https://github.com/acme/widgets/pull/123',
+			});
+
+			const runtime = makeRuntime({ gateDataRepo: new GateDataRepository(db) });
+
+			expect(runtime.getPollPrUrlForRun(run.id)).toBe('https://github.com/acme/widgets/pull/123');
 		});
 
 		test('multiple in_progress runs all rehydrated by fresh runtime', async () => {

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-rehydration.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-rehydration.test.ts
@@ -353,6 +353,69 @@ describe('SpaceRuntime — crash recovery and rehydration', () => {
 			expect(runtime.getPollPrUrlForRun(run.id)).toBe('https://github.com/acme/widgets/pull/456');
 		});
 
+		test('ensurePollsForRun stops existing polls when workflow lookup fails', async () => {
+			const workflow = workflowManager.createWorkflow({
+				spaceId: SPACE_ID,
+				name: `Missing Workflow Poll-${Date.now()}-${Math.random()}`,
+				description: 'Test',
+				nodes: [
+					{ id: STEP_A, name: 'Step A', agentId: AGENT },
+					{ id: STEP_B, name: 'Step B', agentId: AGENT },
+				],
+				transitions: [],
+				channels: [{ id: 'channel-missing', from: 'Step A', to: 'Step B', gateId: 'gate-missing' }],
+				gates: [
+					{
+						id: 'gate-missing',
+						resetOnCycle: false,
+						poll: { intervalMs: 60_000, script: 'printf poll', target: 'from' },
+					},
+				],
+				startNodeId: STEP_A,
+				endNodeId: STEP_B,
+				rules: [],
+				tags: [],
+				completionAutonomyLevel: 3,
+			});
+			const run = workflowRunRepo.transitionStatus(
+				workflowRunRepo.createRun({
+					spaceId: SPACE_ID,
+					workflowId: workflow.id,
+					title: 'Missing Workflow Poll Run',
+				}).id,
+				'in_progress'
+			);
+			taskRepo.createTask({
+				spaceId: SPACE_ID,
+				title: 'Missing Workflow Poll Run',
+				description: '',
+				workflowRunId: run.id,
+				status: 'in_progress',
+			});
+			const runtime = makeRuntime();
+			runtime.setTaskAgentManager({
+				isExecutionSpawning: () => false,
+				isSessionAlive: () => true,
+				spawnWorkflowNodeAgentForExecution: async () => 'session-1',
+				cancelBySessionId: () => {},
+				interruptBySessionId: async () => {},
+				rehydrate: async () => {},
+				injectSubSessionMessage: () => {},
+			} as never);
+
+			await runtime.executeTick();
+			expect(runtime.isGatePollActive(run.id, 'gate-missing')).toBe(true);
+
+			workflowManager.deleteWorkflow(workflow.id);
+			(runtime as unknown as { executorMeta: Map<string, unknown> }).executorMeta.delete(run.id);
+			await (runtime as unknown as { ensurePollsForRun: (r: typeof run) => Promise<void> })[
+				'ensurePollsForRun'
+			](run);
+
+			expect(runtime.isGatePollActive(run.id, 'gate-missing')).toBe(false);
+			await runtime.stop();
+		});
+
 		test('multiple in_progress runs all rehydrated by fresh runtime', async () => {
 			const wfA = buildLinearWorkflow(SPACE_ID, workflowManager, [
 				{ id: 'step-multi-a', name: 'Step A', agentId: AGENT },

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-rehydration.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-rehydration.test.ts
@@ -21,6 +21,7 @@ import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-
 import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
 import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
 import { GateDataRepository } from '../../../../src/storage/repositories/gate-data-repository.ts';
+import { WorkflowRunArtifactRepository } from '../../../../src/storage/repositories/workflow-run-artifact-repository.ts';
 import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
 import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
 import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
@@ -304,7 +305,7 @@ describe('SpaceRuntime — crash recovery and rehydration', () => {
 			await freshRuntime.stop();
 		});
 
-		test('poll context resolves PR URL from gate data when no artifact exists', () => {
+		test('poll context resolves most recently updated PR URL from gate data', () => {
 			const run = workflowRunRepo.transitionStatus(
 				workflowRunRepo.createRun({
 					spaceId: SPACE_ID,
@@ -313,13 +314,43 @@ describe('SpaceRuntime — crash recovery and rehydration', () => {
 				}).id,
 				'in_progress'
 			);
-			new GateDataRepository(db).set(run.id, 'code-ready-gate', {
+			const gateDataRepo = new GateDataRepository(db);
+			gateDataRepo.set(run.id, 'z-older-gate', {
+				pr_url: 'https://github.com/acme/widgets/pull/1',
+			});
+			gateDataRepo.set(run.id, 'a-newer-gate', {
 				pr_url: 'https://github.com/acme/widgets/pull/123',
 			});
 
-			const runtime = makeRuntime({ gateDataRepo: new GateDataRepository(db) });
+			const runtime = makeRuntime({ gateDataRepo });
 
 			expect(runtime.getPollPrUrlForRun(run.id)).toBe('https://github.com/acme/widgets/pull/123');
+		});
+
+		test('poll context falls back to artifact PR URL when gate data has no PR URL', () => {
+			const run = workflowRunRepo.transitionStatus(
+				workflowRunRepo.createRun({
+					spaceId: SPACE_ID,
+					workflowId: 'workflow-artifact-pr',
+					title: 'Artifact PR Run',
+				}).id,
+				'in_progress'
+			);
+			const gateDataRepo = new GateDataRepository(db);
+			gateDataRepo.set(run.id, 'code-ready-gate', { unrelated: 'value' });
+			const artifactRepo = new WorkflowRunArtifactRepository(db);
+			artifactRepo.upsert({
+				id: 'artifact-pr-url',
+				runId: run.id,
+				nodeId: STEP_A,
+				artifactType: 'result',
+				artifactKey: 'pr',
+				data: { pr_url: 'https://github.com/acme/widgets/pull/456' },
+			});
+
+			const runtime = makeRuntime({ gateDataRepo, artifactRepo });
+
+			expect(runtime.getPollPrUrlForRun(run.id)).toBe('https://github.com/acme/widgets/pull/456');
 		});
 
 		test('multiple in_progress runs all rehydrated by fresh runtime', async () => {

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -2019,6 +2019,7 @@ describe('seedBuiltInWorkflows()', () => {
 		expect(gate.script).toBeDefined();
 		expect(gate.script!.interpreter).toBe('bash');
 		expect(gate.script!.timeoutMs).toBe(30000);
+		expect(gate.poll?.target).toBe('from');
 		expect(gate.resetOnCycle).toBe(true);
 	});
 

--- a/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
+++ b/packages/daemon/tests/unit/5-space/workflow/built-in-workflows.test.ts
@@ -376,6 +376,13 @@ describe('CODING_WORKFLOW template', () => {
 		expect(prField.check.op).toBe('exists');
 	});
 
+	test('code-ready-gate PR comment poll preserves GraphQL variable names for gh', () => {
+		const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'code-ready-gate')!;
+		expect(gate.poll?.script).toContain("QUERY='query($owner:String!,$name:String!,$number:Int!)");
+		expect(gate.poll?.script).toContain('repository(owner:$owner,name:$name)');
+		expect(gate.poll?.script).toContain('pullRequest(number:$number)');
+	});
+
 	test('code-ready-gate has a bash script that checks PR mergeability and outputs pr_url', () => {
 		const gate = CODING_WORKFLOW.gates!.find((g) => g.id === 'code-ready-gate')!;
 		expect(gate.script).toBeDefined();


### PR DESCRIPTION
Fixes gate poll rehydration and routing so PR review comments wake the coding agent automatically.

- restart polls for non-terminal/review-pending runs after daemon restart
- resolve PR URLs from gate data as well as artifacts
- route unresolved PR comment poll messages back to the implementer

Tests: ./scripts/test-daemon.sh 5-space; bun run check; bun run format:check