### PR TITLE
Fix OpenAI response usage normalization

### DIFF
--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -465,6 +465,17 @@ function readUsageNumber(record: Record<string, unknown> | undefined, key: strin
 	return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
 
+function readFirstUsageNumber(
+	record: Record<string, unknown> | undefined,
+	keys: string[]
+): number | null {
+	for (const key of keys) {
+		const value = readUsageNumber(record, key);
+		if (value !== null) return value;
+	}
+	return null;
+}
+
 function responseUsage(response: Record<string, unknown> | undefined): {
 	inputTokens?: number | null;
 	outputTokens: number;
@@ -475,8 +486,14 @@ function responseUsage(response: Record<string, unknown> | undefined): {
 			? (usage as Record<string, unknown>)
 			: undefined;
 	return {
-		inputTokens: readUsageNumber(usageRecord, 'input_tokens'),
-		outputTokens: readUsageNumber(usageRecord, 'output_tokens') ?? 0,
+		inputTokens: readFirstUsageNumber(usageRecord, [
+			'input_tokens',
+			'prompt_tokens',
+			'inputTokens',
+		]),
+		outputTokens:
+			readFirstUsageNumber(usageRecord, ['output_tokens', 'completion_tokens', 'outputTokens']) ??
+			0,
 	};
 }
 

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
@@ -633,6 +633,43 @@ describe('openai-responses-bridge server', () => {
 		});
 	});
 
+	it('normalizes OpenAI prompt/completion token usage fields', async () => {
+		server = createOpenAIResponsesBridgeServer({
+			auth: { source: 'api_key', apiKey: 'sk-test' },
+			models,
+			fetchImpl: async () =>
+				sse([
+					{
+						event: 'response.output_text.delta',
+						data: { type: 'response.output_text.delta', delta: 'hello' },
+					},
+					{
+						event: 'response.completed',
+						data: {
+							type: 'response.completed',
+							response: { usage: { prompt_tokens: 11, completion_tokens: 2 }, output: [] },
+						},
+					},
+				]),
+		});
+
+		const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [{ role: 'user', content: 'Say hello.' }],
+			}),
+		});
+
+		const events = await readSSEEvents(resp.body);
+		expect(messageDeltaEvent(events)).toMatchObject({
+			type: 'message_delta',
+			usage: { input_tokens: 11, output_tokens: 2 },
+		});
+	});
+
 	it('returns an Anthropic 502 error when the upstream request fails', async () => {
 		server = createOpenAIResponsesBridgeServer({
 			auth: { source: 'api_key', apiKey: 'sk-test' },


### PR DESCRIPTION
Normalize OpenAI Responses usage fields so prompt/completion token names are emitted as Anthropic-compatible input/output tokens.

Tests: `bun test packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts`; `bun run check`