### PR TITLE
Fix task thread refresh after reconnect

### DIFF
--- a/packages/web/src/hooks/__tests__/useSpaceTaskMessages.test.ts
+++ b/packages/web/src/hooks/__tests__/useSpaceTaskMessages.test.ts
@@ -20,11 +20,12 @@ import { act, renderHook } from '@testing-library/preact';
 // Hoisted mock for useMessageHub
 // ---------------------------------------------------------------------------
 
-const { mockRequest, mockOnEvent, mockIsConnected } = vi.hoisted(() => ({
+const { mockRequest, mockOnEvent, mockGetHub, mockIsConnected } = vi.hoisted(() => ({
 	mockRequest: vi.fn().mockResolvedValue(undefined),
 	mockOnEvent: vi.fn<(method: string, handler: (event: unknown) => void) => () => void>(
 		() => () => {}
 	),
+	mockGetHub: vi.fn(),
 	mockIsConnected: { value: true },
 }));
 
@@ -32,6 +33,7 @@ vi.mock('../useMessageHub', () => ({
 	useMessageHub: () => ({
 		request: mockRequest,
 		onEvent: mockOnEvent,
+		getHub: mockGetHub,
 		get isConnected() {
 			return mockIsConnected.value;
 		},
@@ -62,7 +64,9 @@ describe('useSpaceTaskMessages', () => {
 	beforeEach(() => {
 		mockRequest.mockReset();
 		mockOnEvent.mockReset();
+		mockGetHub.mockReset();
 		mockRequest.mockResolvedValue(undefined);
+		mockGetHub.mockReturnValue({ request: mockRequest, onConnection: vi.fn(() => () => {}) });
 		mockIsConnected.value = true;
 		eventHandlers = {};
 		mockOnEvent.mockImplementation((method: string, handler: EventHandler) => {
@@ -195,6 +199,48 @@ describe('useSpaceTaskMessages', () => {
 				await Promise.resolve();
 			});
 
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		it('re-subscribes and waits for a fresh snapshot after reconnect', () => {
+			let connectionHandler: ((state: string) => void) | null = null;
+			mockGetHub.mockReturnValue({
+				request: mockRequest,
+				onConnection: vi.fn((handler: (state: string) => void) => {
+					connectionHandler = handler;
+					return () => {};
+				}),
+			});
+
+			const { result } = renderHook(() => useSpaceTaskMessages('task-1'));
+			const firstSubId = lastSubscribeSubId();
+			act(() => {
+				fireEvent('liveQuery.snapshot', {
+					subscriptionId: firstSubId,
+					rows: [{ id: 'msg-1', taskId: 'task-1', createdAt: 1 }],
+					version: 1,
+				});
+			});
+			expect(result.current.isLoading).toBe(false);
+			expect(result.current.rows).toHaveLength(1);
+
+			act(() => {
+				connectionHandler?.('connected');
+			});
+
+			expect(
+				mockRequest.mock.calls.filter(([method]) => method === 'liveQuery.subscribe')
+			).toHaveLength(2);
+			expect(result.current.isLoading).toBe(true);
+			expect(result.current.rows).toHaveLength(1);
+
+			act(() => {
+				fireEvent('liveQuery.snapshot', {
+					subscriptionId: firstSubId,
+					rows: [{ id: 'msg-1', taskId: 'task-1', createdAt: 1 }],
+					version: 2,
+				});
+			});
 			expect(result.current.isLoading).toBe(false);
 		});
 	});

--- a/packages/web/src/hooks/useSpaceTaskMessages.ts
+++ b/packages/web/src/hooks/useSpaceTaskMessages.ts
@@ -123,7 +123,7 @@ export function useSpaceTaskMessages(
 	taskId: string | null,
 	variant: SpaceTaskMessagesQueryVariant = 'compact'
 ): UseSpaceTaskMessagesResult {
-	const { request, onEvent, isConnected } = useMessageHub();
+	const { request, onEvent, getHub, isConnected } = useMessageHub();
 	const [rows, setRows] = useState<SpaceTaskThreadMessageRow[]>([]);
 	const [activeTurnSummaries, setActiveTurnSummaries] = useState<ActiveTurnSummary[]>([]);
 	/**
@@ -176,26 +176,42 @@ export function useSpaceTaskMessages(
 			}
 		});
 
-		request('liveQuery.subscribe', {
-			queryName,
-			params: [taskId],
-			subscriptionId,
-		}).catch(() => {
-			// Release the loading gate on subscribe failure so consumers can
-			// surface the empty state (or, more likely, the reconnecting state
-			// once the websocket drops) rather than stalling forever.
-			if (activeSubIdRef.current === subscriptionId) {
-				setLoadedForTaskId(taskId);
-			}
+		const subscribe = () => {
+			const hub = getHub();
+			if (!hub) return;
+			hub
+				.request('liveQuery.subscribe', {
+					queryName,
+					params: [taskId],
+					subscriptionId,
+				})
+				.catch(() => {
+					// Release the loading gate on subscribe failure so consumers can
+					// surface the empty state (or, more likely, the reconnecting state
+					// once the websocket drops) rather than stalling forever.
+					if (activeSubIdRef.current === subscriptionId) {
+						setLoadedForTaskId(taskId);
+					}
+				});
+		};
+
+		const unsubReconnect = getHub()?.onConnection((state) => {
+			if (state !== 'connected') return;
+			if (activeSubIdRef.current !== subscriptionId) return;
+			setLoadedForTaskId(null);
+			subscribe();
 		});
+
+		subscribe();
 
 		return () => {
 			unsubSnapshot();
 			unsubDelta();
+			unsubReconnect?.();
 			activeSubIdRef.current = null;
 			Promise.resolve(request('liveQuery.unsubscribe', { subscriptionId })).catch(() => {});
 		};
-	}, [taskId, isConnected, onEvent, request, queryName]);
+	}, [taskId, isConnected, onEvent, request, getHub, queryName]);
 
 	const sortedRows = useMemo(() => sortRows(rows), [rows]);
 


### PR DESCRIPTION
Re-subscribes the space task message LiveQuery on WebSocket reconnect so existing thread history is fetched again instead of showing an empty activity state.

Tests: focused hook test, typecheck, lint, format check. Full web suite currently hits an unrelated network-dependent SlashCommandOutput failure against example.com/oauth.