### PR TITLE
Redesign mobile space navigation

### DIFF
--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -3,7 +3,9 @@ import {
 	navSectionSignal,
 	contextPanelOpenSignal,
 	currentSpaceIdSignal,
+	currentSpaceConfigureTabSignal,
 	currentSpaceSessionIdSignal,
+	currentSpaceTasksFilterTabSignal,
 	currentSpaceViewModeSignal,
 	settingsSectionSignal,
 	type NavSection,
@@ -172,6 +174,8 @@ export function ContextPanel() {
 	}, [navSection]);
 	const activeSettingsSection = settingsSectionSignal.value;
 	const currentSpaceId = currentSpaceIdSignal.value;
+	const currentSpaceConfigureTab = currentSpaceConfigureTabSignal.value;
+	const currentSpaceTasksFilterTab = currentSpaceTasksFilterTabSignal.value;
 	const currentSpaceViewMode = currentSpaceViewModeSignal.value;
 	const currentSpaceSessionId = currentSpaceSessionIdSignal.value;
 
@@ -284,13 +288,13 @@ export function ContextPanel() {
 		} else {
 			switch (currentSpaceViewMode) {
 				case 'tasks':
-					navigateToSpaceTasks(spaceId);
+					navigateToSpaceTasks(spaceId, currentSpaceTasksFilterTab);
 					break;
 				case 'sessions':
 					navigateToSpaceSessions(spaceId);
 					break;
 				case 'configure':
-					navigateToSpaceConfigure(spaceId);
+					navigateToSpaceConfigure(spaceId, currentSpaceConfigureTab);
 					break;
 				case 'overview':
 				default:

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -444,33 +444,31 @@ export function ContextPanel() {
 					overflow-hidden
 				`}
 			>
-				{/* Mobile nav strip - replaces NavRail on mobile outside in-space spaces. */}
-				{!isSpaceDetail && (
-					<div
-						class={`flex items-center gap-1 px-2 py-2 border-b ${borderColors.ui.default} md:hidden`}
-					>
-						{MAIN_NAV_ITEMS.map((item) => (
-							<NavIconButton
-								key={item.id}
-								active={navSection === item.id}
-								onClick={() => handleMobileNavClick(item.id)}
-								label={item.label}
-							>
-								{item.icon}
-							</NavIconButton>
-						))}
-						<div class="ml-auto flex items-center gap-1">
-							<DaemonStatusIndicator />
-							<NavIconButton
-								active={navSection === SETTINGS_NAV_ITEM.id}
-								onClick={() => handleMobileNavClick(SETTINGS_NAV_ITEM.id)}
-								label={SETTINGS_NAV_ITEM.label}
-							>
-								{SETTINGS_NAV_ITEM.icon}
-							</NavIconButton>
-						</div>
+				{/* Mobile nav strip - replaces NavRail on mobile. */}
+				<div
+					class={`flex items-center gap-1 px-2 py-2 border-b ${borderColors.ui.default} md:hidden`}
+				>
+					{MAIN_NAV_ITEMS.map((item) => (
+						<NavIconButton
+							key={item.id}
+							active={navSection === item.id}
+							onClick={() => handleMobileNavClick(item.id)}
+							label={item.label}
+						>
+							{item.icon}
+						</NavIconButton>
+					))}
+					<div class="ml-auto flex items-center gap-1">
+						<DaemonStatusIndicator />
+						<NavIconButton
+							active={navSection === SETTINGS_NAV_ITEM.id}
+							onClick={() => handleMobileNavClick(SETTINGS_NAV_ITEM.id)}
+							label={SETTINGS_NAV_ITEM.label}
+						>
+							{SETTINGS_NAV_ITEM.icon}
+						</NavIconButton>
 					</div>
-				)}
+				</div>
 
 				{/* Header */}
 				<div class={`px-4 h-[65px] flex items-center border-b ${borderColors.ui.default}`}>

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -3,6 +3,7 @@ import {
 	navSectionSignal,
 	contextPanelOpenSignal,
 	currentSpaceIdSignal,
+	currentSpaceSessionIdSignal,
 	currentSpaceViewModeSignal,
 	settingsSectionSignal,
 	type NavSection,
@@ -17,7 +18,11 @@ import {
 	navigateToSettings,
 	navigateToInbox,
 	navigateToSpaces,
+	navigateToSpace,
+	navigateToSpaceAgent,
 	navigateToSpaceConfigure,
+	navigateToSpaceSessions,
+	navigateToSpaceTasks,
 } from '../lib/router.ts';
 import { borderColors } from '../lib/design-tokens.ts';
 import { cn } from '../lib/utils.ts';
@@ -154,7 +159,8 @@ export function ContextPanel() {
 	const navSection = navSectionSignal.value;
 	const isPanelOpen = contextPanelOpenSignal.value;
 
-	// Initialize the global space list when entering the spaces section
+	// Initialize the global space list when entering the spaces section, including
+	// in-space mobile where the ContextPanel is repurposed as the space switcher.
 	useEffect(() => {
 		if (navSection === 'spaces') {
 			spaceStore.initGlobalList().catch(() => {
@@ -165,6 +171,7 @@ export function ContextPanel() {
 	const activeSettingsSection = settingsSectionSignal.value;
 	const currentSpaceId = currentSpaceIdSignal.value;
 	const currentSpaceViewMode = currentSpaceViewModeSignal.value;
+	const currentSpaceSessionId = currentSpaceSessionIdSignal.value;
 
 	// Inbox takes full content width — no sidebar needed
 	if (navSection === 'inbox') return null;
@@ -269,6 +276,34 @@ export function ContextPanel() {
 		}
 	};
 
+	const handleSpaceSwitch = (spaceId: string) => {
+		if (currentSpaceSessionId === `space:chat:${currentSpaceId}`) {
+			navigateToSpaceAgent(spaceId);
+		} else {
+			switch (currentSpaceViewMode) {
+				case 'tasks':
+					navigateToSpaceTasks(spaceId);
+					break;
+				case 'sessions':
+					navigateToSpaceSessions(spaceId);
+					break;
+				case 'configure':
+					navigateToSpaceConfigure(spaceId);
+					break;
+				case 'overview':
+				default:
+					navigateToSpace(spaceId);
+					break;
+			}
+		}
+		contextPanelOpenSignal.value = false;
+	};
+
+	const handleCreateSpace = () => {
+		navigateToSpaces();
+		contextPanelOpenSignal.value = false;
+	};
+
 	const isActionDisabled =
 		connectionState.value !== 'connected' ||
 		!authStatus.value?.isAuthenticated ||
@@ -276,9 +311,111 @@ export function ContextPanel() {
 
 	const isActionLoading = creatingSession;
 
-	// On the spaces list view (no space selected), hide the desktop sidebar — SpacesPage fills
-	// the full width. On mobile, the panel still slides in so the nav strip is accessible.
-	const hideDesktopPanel = navSection === 'spaces' && !isSpaceDetail;
+	// On the spaces list view (no space selected), hide the panel completely so
+	// SpacesPage fills the viewport. BottomTabBar owns mobile global navigation.
+	if (navSection === 'spaces' && !isSpaceDetail) return null;
+
+	const activeSpaces = spaceStore.spacesWithTasks.value.filter(
+		(space) => space.status === 'active'
+	);
+
+	const spaceSwitcherContent = (
+		<div class="flex-1 overflow-y-auto py-2 md:hidden" data-testid="mobile-space-switcher">
+			{activeSpaces.length === 0 ? (
+				<div class="px-4 py-8 text-center">
+					<svg
+						class="w-10 h-10 mx-auto text-gray-700 mb-3"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width={1.5}
+							d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+						/>
+					</svg>
+					<p class="text-sm font-medium text-gray-300">No spaces yet</p>
+					<p class="text-xs text-gray-500 mt-1">Create a space from the Spaces tab.</p>
+				</div>
+			) : (
+				<nav class="px-2 space-y-1" aria-label="Switch spaces">
+					{activeSpaces.map((space) => {
+						const isCurrent = space.id === currentSpaceId;
+						return (
+							<button
+								key={space.id}
+								type="button"
+								onClick={() => handleSpaceSwitch(space.id)}
+								aria-current={isCurrent ? 'page' : undefined}
+								class={cn(
+									'w-full rounded-lg px-3 py-3 flex items-center gap-3 text-left transition-colors',
+									isCurrent
+										? 'bg-blue-950/40 border border-blue-800/50 text-gray-100'
+										: 'border border-transparent text-gray-400 hover:bg-dark-850 hover:text-gray-100'
+								)}
+							>
+								<svg
+									class="w-5 h-5 flex-shrink-0 text-gray-500"
+									fill="none"
+									viewBox="0 0 24 24"
+									stroke="currentColor"
+								>
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width={1.75}
+										d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+									/>
+								</svg>
+								<div class="min-w-0 flex-1">
+									<div class="text-sm font-medium truncate">{space.name}</div>
+									{space.description && (
+										<div class="text-xs text-gray-500 truncate mt-0.5">{space.description}</div>
+									)}
+								</div>
+								{isCurrent && (
+									<svg
+										class="w-4 h-4 text-blue-400 flex-shrink-0"
+										fill="none"
+										viewBox="0 0 24 24"
+										stroke="currentColor"
+									>
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width={2}
+											d="M5 13l4 4L19 7"
+										/>
+									</svg>
+								)}
+							</button>
+						);
+					})}
+				</nav>
+			)}
+			<div class="px-4 pt-4 pb-6">
+				<button
+					type="button"
+					onClick={handleCreateSpace}
+					class="w-full flex items-center justify-center gap-2 px-3 py-2.5 rounded-lg border border-dashed border-dark-600 hover:border-dark-500 hover:bg-dark-850 text-sm text-gray-400 hover:text-gray-100 transition-colors"
+				>
+					<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width={2}
+							d="M12 4v16m8-8H4"
+						/>
+					</svg>
+					Create Space
+				</button>
+			</div>
+		</div>
+	);
+
+	const hideDesktopPanel = false;
 
 	return (
 		<>
@@ -305,81 +442,88 @@ export function ContextPanel() {
 					overflow-hidden
 				`}
 			>
-				{/* Mobile nav strip - replaces NavRail on mobile */}
-				<div
-					class={`flex items-center gap-1 px-2 py-2 border-b ${borderColors.ui.default} md:hidden`}
-				>
-					{MAIN_NAV_ITEMS.map((item) => (
-						<NavIconButton
-							key={item.id}
-							active={navSection === item.id}
-							onClick={() => handleMobileNavClick(item.id)}
-							label={item.label}
-						>
-							{item.icon}
-						</NavIconButton>
-					))}
-					<div class="ml-auto flex items-center gap-1">
-						<DaemonStatusIndicator />
-						<NavIconButton
-							active={navSection === SETTINGS_NAV_ITEM.id}
-							onClick={() => handleMobileNavClick(SETTINGS_NAV_ITEM.id)}
-							label={SETTINGS_NAV_ITEM.label}
-						>
-							{SETTINGS_NAV_ITEM.icon}
-						</NavIconButton>
+				{/* Mobile nav strip - replaces NavRail on mobile outside in-space spaces. */}
+				{!isSpaceDetail && (
+					<div
+						class={`flex items-center gap-1 px-2 py-2 border-b ${borderColors.ui.default} md:hidden`}
+					>
+						{MAIN_NAV_ITEMS.map((item) => (
+							<NavIconButton
+								key={item.id}
+								active={navSection === item.id}
+								onClick={() => handleMobileNavClick(item.id)}
+								label={item.label}
+							>
+								{item.icon}
+							</NavIconButton>
+						))}
+						<div class="ml-auto flex items-center gap-1">
+							<DaemonStatusIndicator />
+							<NavIconButton
+								active={navSection === SETTINGS_NAV_ITEM.id}
+								onClick={() => handleMobileNavClick(SETTINGS_NAV_ITEM.id)}
+								label={SETTINGS_NAV_ITEM.label}
+							>
+								{SETTINGS_NAV_ITEM.icon}
+							</NavIconButton>
+						</div>
 					</div>
-				</div>
+				)}
 
 				{/* Header */}
 				<div class={`px-4 h-[65px] flex items-center border-b ${borderColors.ui.default}`}>
 					<div class={cn('flex-1 flex items-center justify-between', !isSpaceDetail && 'mb-3')}>
 						{isSpaceDetail ? (
-							<div class="flex items-center gap-1 min-w-0 flex-1 overflow-hidden pointer-events-none">
-								<button
-									onClick={() => navigateToSpaces()}
-									class="p-1 hover:bg-dark-800 rounded-lg transition-colors text-gray-400 hover:text-gray-100 flex-shrink-0 pointer-events-auto"
-									title="Back to Spaces"
-								>
-									<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-										<path
-											stroke-linecap="round"
-											stroke-linejoin="round"
-											stroke-width={2}
-											d="M15 19l-7-7 7-7"
-										/>
-									</svg>
-								</button>
-								<h2 class="min-w-0 flex-1 text-lg font-semibold text-gray-100 truncate pointer-events-none">
-									{headerTitle}
+							<>
+								<h2 class="md:hidden min-w-0 flex-1 text-lg font-semibold text-gray-100 truncate">
+									Switch Space
 								</h2>
-								<button
-									onClick={() => navigateToSpaceConfigure(currentSpaceId!)}
-									class={cn(
-										'ml-1 p-1.5 rounded-lg transition-colors flex-shrink-0 pointer-events-auto',
-										currentSpaceViewMode === 'configure'
-											? 'bg-dark-800 text-gray-100'
-											: 'text-gray-400 hover:bg-dark-800 hover:text-gray-100'
-									)}
-									title="Configure space"
-									aria-label="Configure space"
-								>
-									<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-										<path
-											stroke-linecap="round"
-											stroke-linejoin="round"
-											stroke-width={2}
-											d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
-										/>
-										<path
-											stroke-linecap="round"
-											stroke-linejoin="round"
-											stroke-width={2}
-											d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-										/>
-									</svg>
-								</button>
-							</div>
+								<div class="hidden md:flex items-center gap-1 min-w-0 flex-1 overflow-hidden pointer-events-none">
+									<button
+										onClick={() => navigateToSpaces()}
+										class="p-1 hover:bg-dark-800 rounded-lg transition-colors text-gray-400 hover:text-gray-100 flex-shrink-0 pointer-events-auto"
+										title="Back to Spaces"
+									>
+										<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												stroke-width={2}
+												d="M15 19l-7-7 7-7"
+											/>
+										</svg>
+									</button>
+									<h2 class="min-w-0 flex-1 text-lg font-semibold text-gray-100 truncate pointer-events-none">
+										{headerTitle}
+									</h2>
+									<button
+										onClick={() => navigateToSpaceConfigure(currentSpaceId!)}
+										class={cn(
+											'ml-1 p-1.5 rounded-lg transition-colors flex-shrink-0 pointer-events-auto',
+											currentSpaceViewMode === 'configure'
+												? 'bg-dark-800 text-gray-100'
+												: 'text-gray-400 hover:bg-dark-800 hover:text-gray-100'
+										)}
+										title="Configure space"
+										aria-label="Configure space"
+									>
+										<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												stroke-width={2}
+												d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+											/>
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												stroke-width={2}
+												d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+											/>
+										</svg>
+									</button>
+								</div>
+							</>
 						) : (
 							<h2 class="text-lg font-semibold text-gray-100 truncate mr-2">{headerTitle}</h2>
 						)}
@@ -431,10 +575,15 @@ export function ContextPanel() {
 						<SessionList onSessionSelect={() => (contextPanelOpenSignal.value = false)} />
 					)}
 					{navSection === 'spaces' && isSpaceDetail && (
-						<SpaceDetailPanel
-							spaceId={currentSpaceId!}
-							onNavigate={() => (contextPanelOpenSignal.value = false)}
-						/>
+						<>
+							{spaceSwitcherContent}
+							<div class="hidden md:flex flex-1 overflow-hidden flex-col">
+								<SpaceDetailPanel
+									spaceId={currentSpaceId!}
+									onNavigate={() => (contextPanelOpenSignal.value = false)}
+								/>
+							</div>
+						</>
 					)}
 					{navSection === 'settings' && (
 						<div class="flex-1 flex flex-col overflow-hidden">

--- a/packages/web/src/islands/ContextPanel.tsx
+++ b/packages/web/src/islands/ContextPanel.tsx
@@ -28,6 +28,7 @@ import { borderColors } from '../lib/design-tokens.ts';
 import { cn } from '../lib/utils.ts';
 import { Button } from '../components/ui/Button.tsx';
 import { NavIconButton } from '../components/ui/NavIconButton.tsx';
+import { SpaceCreateDialog } from '../components/space/SpaceCreateDialog.tsx';
 import { DaemonStatusIndicator } from '../components/DaemonStatusIndicator.tsx';
 import { MAIN_NAV_ITEMS, SETTINGS_NAV_ITEM } from '../lib/nav-config.tsx';
 import { SessionList } from './SessionList.tsx';
@@ -155,6 +156,7 @@ function SectionIcon({ type }: { type: string }) {
 
 export function ContextPanel() {
 	const [creatingSession, setCreatingSession] = useState(false);
+	const [createSpaceOpen, setCreateSpaceOpen] = useState(false);
 
 	const navSection = navSectionSignal.value;
 	const isPanelOpen = contextPanelOpenSignal.value;
@@ -300,7 +302,7 @@ export function ContextPanel() {
 	};
 
 	const handleCreateSpace = () => {
-		navigateToSpaces();
+		setCreateSpaceOpen(true);
 		contextPanelOpenSignal.value = false;
 	};
 
@@ -313,7 +315,10 @@ export function ContextPanel() {
 
 	// On the spaces list view (no space selected), hide the panel completely so
 	// SpacesPage fills the viewport. BottomTabBar owns mobile global navigation.
-	if (navSection === 'spaces' && !isSpaceDetail) return null;
+	if (navSection === 'spaces' && !isSpaceDetail) {
+		contextPanelOpenSignal.value = false;
+		return null;
+	}
 
 	const activeSpaces = spaceStore.spacesWithTasks.value.filter(
 		(space) => space.status === 'active'
@@ -415,8 +420,6 @@ export function ContextPanel() {
 		</div>
 	);
 
-	const hideDesktopPanel = false;
-
 	return (
 		<>
 			{/* Mobile backdrop */}
@@ -438,7 +441,6 @@ export function ContextPanel() {
 					z-40 md:z-auto
 					max-md:transition-transform max-md:duration-300 max-md:ease-in-out
 					${isPanelOpen ? 'max-md:translate-x-0' : 'max-md:-translate-x-full'}
-					${hideDesktopPanel ? 'md:hidden' : ''}
 					overflow-hidden
 				`}
 			>
@@ -630,6 +632,7 @@ export function ContextPanel() {
 					)}
 				</div>
 			</div>
+			<SpaceCreateDialog isOpen={createSpaceOpen} onClose={() => setCreateSpaceOpen(false)} />
 		</>
 	);
 }

--- a/packages/web/src/islands/SpacesPage.tsx
+++ b/packages/web/src/islands/SpacesPage.tsx
@@ -11,7 +11,6 @@ import { navigateToSpace } from '../lib/router.ts';
 import { cn, getRelativeTime } from '../lib/utils.ts';
 import type { SpaceSessionSummary, SpaceWithTasks } from '../lib/space-store.ts';
 import type { SpaceTask } from '@neokai/shared';
-import { MobileMenuButton } from '../components/ui/MobileMenuButton.tsx';
 import { borderColors } from '../lib/design-tokens.ts';
 import { SpaceCreateDialog } from '../components/space/SpaceCreateDialog.tsx';
 
@@ -157,7 +156,6 @@ export function SpacesPage() {
 				class={`flex-shrink-0 bg-dark-850 border-b ${borderColors.ui.default} px-4 py-2.5 relative z-10`}
 			>
 				<div class="flex items-center gap-3">
-					<MobileMenuButton />
 					<div class="flex-1 min-w-0 flex items-center justify-between">
 						<h1 class="text-sm font-semibold text-gray-100">Spaces</h1>
 						<div class="flex items-center gap-3">

--- a/packages/web/src/islands/__tests__/ContextPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/ContextPanel.test.tsx
@@ -31,7 +31,11 @@ const {
 let mockNavSectionSignal!: Signal<'chats' | 'inbox' | 'spaces' | 'settings'>;
 let mockContextPanelOpenSignal!: Signal<boolean>;
 let mockCurrentSpaceIdSignal!: Signal<string | null>;
+let mockCurrentSpaceConfigureTabSignal!: Signal<'agents' | 'workflows' | 'settings'>;
 let mockCurrentSpaceSessionIdSignal!: Signal<string | null>;
+let mockCurrentSpaceTasksFilterTabSignal!: Signal<
+	'action' | 'active' | 'completed' | 'archived' | 'draft'
+>;
 let mockCurrentSpaceViewModeSignal!: Signal<'overview' | 'tasks' | 'sessions' | 'configure'>;
 let mockSettingsSectionSignal!: Signal<
 	'general' | 'providers' | 'app-mcp-servers' | 'skills' | 'models' | 'neo' | 'usage' | 'about'
@@ -64,7 +68,9 @@ function initSignals() {
 	mockNavSectionSignal = signal('spaces');
 	mockContextPanelOpenSignal = signal(true);
 	mockCurrentSpaceIdSignal = signal('space-1');
+	mockCurrentSpaceConfigureTabSignal = signal('agents');
 	mockCurrentSpaceSessionIdSignal = signal(null);
+	mockCurrentSpaceTasksFilterTabSignal = signal('active');
 	mockCurrentSpaceViewModeSignal = signal('overview');
 	mockSettingsSectionSignal = signal('general');
 	mockConnectionStateSignal = signal('connected');
@@ -153,8 +159,14 @@ vi.mock('../../lib/signals.ts', async (importOriginal) => {
 		get currentSpaceIdSignal() {
 			return mockCurrentSpaceIdSignal;
 		},
+		get currentSpaceConfigureTabSignal() {
+			return mockCurrentSpaceConfigureTabSignal;
+		},
 		get currentSpaceSessionIdSignal() {
 			return mockCurrentSpaceSessionIdSignal;
+		},
+		get currentSpaceTasksFilterTabSignal() {
+			return mockCurrentSpaceTasksFilterTabSignal;
 		},
 		get currentSpaceViewModeSignal() {
 			return mockCurrentSpaceViewModeSignal;
@@ -207,18 +219,40 @@ describe('ContextPanel', () => {
 	});
 
 	it.each([
-		['overview', mockNavigateToSpace],
-		['tasks', mockNavigateToSpaceTasks],
-		['sessions', mockNavigateToSpaceSessions],
-		['configure', mockNavigateToSpaceConfigure],
-	] as const)('preserves the %s view mode when switching spaces', (viewMode, expectedNavigate) => {
+		['overview', mockNavigateToSpace, ['space-2']],
+		['tasks', mockNavigateToSpaceTasks, ['space-2', 'active']],
+		['sessions', mockNavigateToSpaceSessions, ['space-2']],
+		['configure', mockNavigateToSpaceConfigure, ['space-2', 'agents']],
+	] as const)('preserves the %s view mode when switching spaces', (viewMode, expectedNavigate, args) => {
 		mockCurrentSpaceViewModeSignal.value = viewMode;
 		render(<ContextPanel />);
 
 		fireEvent.click(screen.getByText('Beta'));
 
-		expect(expectedNavigate).toHaveBeenCalledWith('space-2');
+		expect(expectedNavigate).toHaveBeenCalledWith(...args);
 		expect(mockNavigateToSpaceAgent).not.toHaveBeenCalled();
+		expect(mockContextPanelOpenSignal.value).toBe(false);
+	});
+
+	it('preserves the current task filter when switching spaces from tasks', () => {
+		mockCurrentSpaceViewModeSignal.value = 'tasks';
+		mockCurrentSpaceTasksFilterTabSignal.value = 'completed';
+		render(<ContextPanel />);
+
+		fireEvent.click(screen.getByText('Beta'));
+
+		expect(mockNavigateToSpaceTasks).toHaveBeenCalledWith('space-2', 'completed');
+		expect(mockContextPanelOpenSignal.value).toBe(false);
+	});
+
+	it('preserves the current configure subtab when switching spaces from configure', () => {
+		mockCurrentSpaceViewModeSignal.value = 'configure';
+		mockCurrentSpaceConfigureTabSignal.value = 'workflows';
+		render(<ContextPanel />);
+
+		fireEvent.click(screen.getByText('Beta'));
+
+		expect(mockNavigateToSpaceConfigure).toHaveBeenCalledWith('space-2', 'workflows');
 		expect(mockContextPanelOpenSignal.value).toBe(false);
 	});
 
@@ -241,7 +275,7 @@ describe('ContextPanel', () => {
 
 		fireEvent.click(screen.getByText('Beta'));
 
-		expect(mockNavigateToSpaceTasks).toHaveBeenCalledWith('space-2');
+		expect(mockNavigateToSpaceTasks).toHaveBeenCalledWith('space-2', 'active');
 		expect(mockNavigateToSpaceAgent).not.toHaveBeenCalled();
 	});
 

--- a/packages/web/src/islands/__tests__/ContextPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/ContextPanel.test.tsx
@@ -255,6 +255,20 @@ describe('ContextPanel', () => {
 		expect(mockContextPanelOpenSignal.value).toBe(false);
 	});
 
+	it('keeps global mobile navigation available in the in-space switcher', () => {
+		render(<ContextPanel />);
+
+		fireEvent.click(screen.getByLabelText('Spaces'));
+		fireEvent.click(screen.getByLabelText('Chats'));
+		fireEvent.click(screen.getByLabelText('Inbox'));
+		fireEvent.click(screen.getByLabelText('Settings'));
+
+		expect(mockNavigateToSpaces).toHaveBeenCalledTimes(1);
+		expect(mockNavigateToSessions).toHaveBeenCalledTimes(1);
+		expect(mockNavigateToInbox).toHaveBeenCalledTimes(1);
+		expect(mockNavigateToSettings).toHaveBeenCalledTimes(1);
+	});
+
 	it('opens the create space dialog directly from the mobile switcher', () => {
 		render(<ContextPanel />);
 

--- a/packages/web/src/islands/__tests__/ContextPanel.test.tsx
+++ b/packages/web/src/islands/__tests__/ContextPanel.test.tsx
@@ -1,0 +1,268 @@
+import type { Space } from '@neokai/shared';
+import type { ComponentChildren } from 'preact';
+import { type Signal, signal } from '@preact/signals';
+import { cleanup, fireEvent, render, screen } from '@testing-library/preact';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+	mockNavigateToSpace,
+	mockNavigateToSpaceAgent,
+	mockNavigateToSpaceConfigure,
+	mockNavigateToSpaceSessions,
+	mockNavigateToSpaceTasks,
+	mockNavigateToSession,
+	mockNavigateToSessions,
+	mockNavigateToSettings,
+	mockNavigateToInbox,
+	mockNavigateToSpaces,
+} = vi.hoisted(() => ({
+	mockNavigateToSpace: vi.fn(),
+	mockNavigateToSpaceAgent: vi.fn(),
+	mockNavigateToSpaceConfigure: vi.fn(),
+	mockNavigateToSpaceSessions: vi.fn(),
+	mockNavigateToSpaceTasks: vi.fn(),
+	mockNavigateToSession: vi.fn(),
+	mockNavigateToSessions: vi.fn(),
+	mockNavigateToSettings: vi.fn(),
+	mockNavigateToInbox: vi.fn(),
+	mockNavigateToSpaces: vi.fn(),
+}));
+
+let mockNavSectionSignal!: Signal<'chats' | 'inbox' | 'spaces' | 'settings'>;
+let mockContextPanelOpenSignal!: Signal<boolean>;
+let mockCurrentSpaceIdSignal!: Signal<string | null>;
+let mockCurrentSpaceSessionIdSignal!: Signal<string | null>;
+let mockCurrentSpaceViewModeSignal!: Signal<'overview' | 'tasks' | 'sessions' | 'configure'>;
+let mockSettingsSectionSignal!: Signal<
+	'general' | 'providers' | 'app-mcp-servers' | 'skills' | 'models' | 'neo' | 'usage' | 'about'
+>;
+let mockConnectionStateSignal!: Signal<'connecting' | 'connected'>;
+let mockSpacesWithTasksSignal!: Signal<Array<Space & { tasks: unknown[]; sessions: unknown[] }>>;
+let mockSpaceSignal!: Signal<Space | null>;
+const mockInitGlobalList = vi.fn(() => Promise.resolve());
+
+function makeSpace(id: string, overrides: Partial<Space> = {}): Space {
+	return {
+		id,
+		slug: id,
+		workspacePath: `/workspace/${id}`,
+		name: `Space ${id}`,
+		description: '',
+		backgroundContext: '',
+		instructions: '',
+		sessionIds: [],
+		status: 'active',
+		paused: false,
+		stopped: false,
+		createdAt: 0,
+		updatedAt: 0,
+		...overrides,
+	} as Space;
+}
+
+function initSignals() {
+	mockNavSectionSignal = signal('spaces');
+	mockContextPanelOpenSignal = signal(true);
+	mockCurrentSpaceIdSignal = signal('space-1');
+	mockCurrentSpaceSessionIdSignal = signal(null);
+	mockCurrentSpaceViewModeSignal = signal('overview');
+	mockSettingsSectionSignal = signal('general');
+	mockConnectionStateSignal = signal('connected');
+	mockSpacesWithTasksSignal = signal([
+		{ ...makeSpace('space-1', { name: 'Alpha' }), tasks: [], sessions: [] },
+		{ ...makeSpace('space-2', { name: 'Beta' }), tasks: [], sessions: [] },
+	]);
+	mockSpaceSignal = signal(makeSpace('space-1', { name: 'Alpha' }));
+	mockInitGlobalList.mockClear();
+}
+
+initSignals();
+
+vi.mock('../SessionList.tsx', () => ({
+	SessionList: () => <div data-testid="session-list" />,
+}));
+
+vi.mock('../SpaceDetailPanel.tsx', () => ({
+	SpaceDetailPanel: () => <div data-testid="space-detail-panel" />,
+}));
+
+vi.mock('../../components/space/SpaceCreateDialog.tsx', () => ({
+	SpaceCreateDialog: ({ isOpen }: { isOpen: boolean }) =>
+		isOpen ? <div role="dialog">Create Space Dialog</div> : null,
+}));
+
+vi.mock('../../components/DaemonStatusIndicator.tsx', () => ({
+	DaemonStatusIndicator: () => <div data-testid="daemon-status" />,
+}));
+
+vi.mock('../../components/ui/Button.tsx', () => ({
+	Button: ({
+		children,
+		onClick,
+		disabled,
+	}: {
+		children: ComponentChildren;
+		onClick?: () => void;
+		disabled?: boolean;
+	}) => (
+		<button type="button" onClick={onClick} disabled={disabled}>
+			{children}
+		</button>
+	),
+}));
+
+vi.mock('../../components/ui/NavIconButton.tsx', () => ({
+	NavIconButton: ({
+		children,
+		onClick,
+		label,
+	}: {
+		children: ComponentChildren;
+		onClick: () => void;
+		label: string;
+	}) => (
+		<button type="button" onClick={onClick} aria-label={label}>
+			{children}
+		</button>
+	),
+}));
+
+vi.mock('../../lib/router.ts', () => ({
+	navigateToSession: mockNavigateToSession,
+	navigateToSessions: mockNavigateToSessions,
+	navigateToSettings: mockNavigateToSettings,
+	navigateToInbox: mockNavigateToInbox,
+	navigateToSpaces: mockNavigateToSpaces,
+	navigateToSpace: mockNavigateToSpace,
+	navigateToSpaceAgent: mockNavigateToSpaceAgent,
+	navigateToSpaceConfigure: mockNavigateToSpaceConfigure,
+	navigateToSpaceSessions: mockNavigateToSpaceSessions,
+	navigateToSpaceTasks: mockNavigateToSpaceTasks,
+}));
+
+vi.mock('../../lib/signals.ts', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../../lib/signals.ts')>();
+	return {
+		...actual,
+		get navSectionSignal() {
+			return mockNavSectionSignal;
+		},
+		get contextPanelOpenSignal() {
+			return mockContextPanelOpenSignal;
+		},
+		get currentSpaceIdSignal() {
+			return mockCurrentSpaceIdSignal;
+		},
+		get currentSpaceSessionIdSignal() {
+			return mockCurrentSpaceSessionIdSignal;
+		},
+		get currentSpaceViewModeSignal() {
+			return mockCurrentSpaceViewModeSignal;
+		},
+		get settingsSectionSignal() {
+			return mockSettingsSectionSignal;
+		},
+	};
+});
+
+vi.mock('../../lib/state.ts', () => ({
+	get connectionState() {
+		return mockConnectionStateSignal;
+	},
+	authStatus: { value: { isAuthenticated: true } },
+}));
+
+vi.mock('../../lib/space-store.ts', () => ({
+	get spaceStore() {
+		return {
+			spacesWithTasks: mockSpacesWithTasksSignal,
+			space: mockSpaceSignal,
+			initGlobalList: mockInitGlobalList,
+		};
+	},
+}));
+
+vi.mock('../../lib/api-helpers.ts', () => ({
+	createSession: vi.fn(),
+}));
+
+vi.mock('../../lib/toast.ts', () => ({
+	toast: {
+		error: vi.fn(),
+		success: vi.fn(),
+	},
+}));
+
+import { ContextPanel } from '../ContextPanel';
+
+describe('ContextPanel', () => {
+	beforeEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+		initSignals();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it.each([
+		['overview', mockNavigateToSpace],
+		['tasks', mockNavigateToSpaceTasks],
+		['sessions', mockNavigateToSpaceSessions],
+		['configure', mockNavigateToSpaceConfigure],
+	] as const)('preserves the %s view mode when switching spaces', (viewMode, expectedNavigate) => {
+		mockCurrentSpaceViewModeSignal.value = viewMode;
+		render(<ContextPanel />);
+
+		fireEvent.click(screen.getByText('Beta'));
+
+		expect(expectedNavigate).toHaveBeenCalledWith('space-2');
+		expect(mockNavigateToSpaceAgent).not.toHaveBeenCalled();
+		expect(mockContextPanelOpenSignal.value).toBe(false);
+	});
+
+	it('routes to the space agent when the current in-space session is the chat agent', () => {
+		mockCurrentSpaceViewModeSignal.value = 'tasks';
+		mockCurrentSpaceSessionIdSignal.value = 'space:chat:space-1';
+		render(<ContextPanel />);
+
+		fireEvent.click(screen.getByText('Beta'));
+
+		expect(mockNavigateToSpaceAgent).toHaveBeenCalledWith('space-2');
+		expect(mockNavigateToSpaceTasks).not.toHaveBeenCalled();
+		expect(mockContextPanelOpenSignal.value).toBe(false);
+	});
+
+	it('does not treat another space chat session id as the current space agent', () => {
+		mockCurrentSpaceViewModeSignal.value = 'tasks';
+		mockCurrentSpaceSessionIdSignal.value = 'space:chat:space-2';
+		render(<ContextPanel />);
+
+		fireEvent.click(screen.getByText('Beta'));
+
+		expect(mockNavigateToSpaceTasks).toHaveBeenCalledWith('space-2');
+		expect(mockNavigateToSpaceAgent).not.toHaveBeenCalled();
+	});
+
+	it('clears the drawer state when hiding the panel on the spaces list', () => {
+		mockCurrentSpaceIdSignal.value = null;
+		mockContextPanelOpenSignal.value = true;
+
+		const { container } = render(<ContextPanel />);
+
+		expect(container.firstChild).toBeNull();
+		expect(mockContextPanelOpenSignal.value).toBe(false);
+	});
+
+	it('opens the create space dialog directly from the mobile switcher', () => {
+		render(<ContextPanel />);
+
+		fireEvent.click(screen.getByText('Create Space'));
+
+		expect(screen.getByRole('dialog')).toBeTruthy();
+		expect(screen.getByText('Create Space Dialog')).toBeTruthy();
+		expect(mockNavigateToSpaces).not.toHaveBeenCalled();
+		expect(mockContextPanelOpenSignal.value).toBe(false);
+	});
+});


### PR DESCRIPTION
Redesigns the mobile ContextPanel inside spaces into a space switcher and removes the duplicate menu entry from the Spaces list page. Space switching preserves the active in-space tab while desktop ContextPanel behavior remains unchanged.

Checks: bun run check; bun run format:check