### PR TITLE
Fix chat composer stop button state

### DIFF
--- a/packages/web/src/components/ChatComposer.tsx
+++ b/packages/web/src/components/ChatComposer.tsx
@@ -191,6 +191,7 @@ export function ChatComposer({
 							leadingElement={inputLeadingElement}
 							leadingPaddingClass={inputLeadingPaddingClass}
 							onDraftActiveChange={onDraftActiveChange}
+							isProcessing={isProcessing}
 						/>
 					)
 				)}

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -86,6 +86,8 @@ interface MessageInputProps {
 	leadingPaddingClass?: string;
 	/** Emits whether the current draft has non-whitespace content */
 	onDraftActiveChange?: (hasDraft: boolean) => void;
+	/** Whether the backing agent/session is currently processing or queued. */
+	isProcessing?: boolean;
 }
 
 interface QueuedOverlayMessage {
@@ -112,6 +114,7 @@ export default function MessageInput({
 	leadingElement,
 	leadingPaddingClass,
 	onDraftActiveChange,
+	isProcessing,
 }: MessageInputProps) {
 	// Cache touch device detection — computed once on first render, stable thereafter.
 	// Using useRef (not a module constant) so tests can mock matchMedia before render.
@@ -250,7 +253,7 @@ export default function MessageInput({
 		setAgentMentionSelectedIndex(0);
 	}, []);
 
-	const agentWorking = isAgentWorking.value;
+	const agentWorking = isProcessing ?? isAgentWorking.value;
 	const [queuedForCurrentTurn, setQueuedForCurrentTurn] = useState<QueuedOverlayMessage[]>([]);
 	const [queuedForNextTurn, setQueuedForNextTurn] = useState<QueuedOverlayMessage[]>([]);
 

--- a/packages/web/src/components/__tests__/ChatComposer.test.tsx
+++ b/packages/web/src/components/__tests__/ChatComposer.test.tsx
@@ -3,11 +3,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ChatComposerProps } from '../ChatComposer';
 
 vi.mock('../MessageInput.tsx', () => ({
-	default: (props: { disabled?: boolean; placeholder?: string }) => (
+	default: (props: { disabled?: boolean; placeholder?: string; isProcessing?: boolean }) => (
 		<div
 			data-testid="mock-message-input"
 			data-disabled={String(props.disabled)}
 			data-placeholder={props.placeholder}
+			data-is-processing={String(props.isProcessing)}
 		/>
 	),
 }));
@@ -92,5 +93,11 @@ describe('ChatComposer', () => {
 		expect(getByTestId(CHAT_COMPOSER_READABILITY_SCRIM_TEST_ID)).toBeTruthy();
 		expect(queryByTestId('mock-message-input')).toBeNull();
 		expect(getByTestId('mock-session-status-bar')).toBeTruthy();
+	});
+
+	it('passes processing state to MessageInput so the stop button can render', () => {
+		const { getByTestId } = render(<ChatComposer {...baseProps({ isProcessing: true })} />);
+
+		expect(getByTestId('mock-message-input').dataset.isProcessing).toBe('true');
 	});
 });

--- a/packages/web/src/components/__tests__/InputTextarea.test.tsx
+++ b/packages/web/src/components/__tests__/InputTextarea.test.tsx
@@ -251,6 +251,30 @@ describe('InputTextarea', () => {
 			) as HTMLButtonElement;
 			expect(sendButton?.disabled).toBe(true);
 		});
+
+		it('should show stop button when agent is working and content is empty', () => {
+			const onStop = vi.fn(() => {});
+			const { container } = render(
+				<InputTextarea
+					content=""
+					onContentChange={() => {}}
+					onKeyDown={() => {}}
+					onSubmit={() => {}}
+					isAgentWorking={true}
+					onStop={onStop}
+				/>
+			);
+
+			const sendButton = container.querySelector('[data-testid="send-button"]');
+			const stopButton = container.querySelector(
+				'[data-testid="stop-button"]'
+			) as HTMLButtonElement;
+			expect(sendButton).toBeNull();
+			expect(stopButton).toBeTruthy();
+
+			fireEvent.click(stopButton);
+			expect(onStop).toHaveBeenCalledTimes(1);
+		});
 	});
 
 	describe('Keyboard Events', () => {


### PR DESCRIPTION
Pass composer processing state into the message input so running space, task, and node-agent sessions can show the stop button when the draft is empty.

Tests: bun --cwd packages/web test src/components/__tests__/InputTextarea.test.tsx src/components/__tests__/ChatComposer.test.tsx; bun --cwd packages/web test; bun run typecheck