### PR TITLE
Fix chat composer stop button state

### DIFF
--- a/packages/web/src/components/ChatComposer.tsx
+++ b/packages/web/src/components/ChatComposer.tsx
@@ -191,6 +191,7 @@ export function ChatComposer({
 							leadingElement={inputLeadingElement}
 							leadingPaddingClass={inputLeadingPaddingClass}
 							onDraftActiveChange={onDraftActiveChange}
+							isProcessing={isProcessing}
 						/>
 					)
 				)}

--- a/packages/web/src/components/ChatComposer.tsx
+++ b/packages/web/src/components/ChatComposer.tsx
@@ -192,6 +192,7 @@ export function ChatComposer({
 							leadingPaddingClass={inputLeadingPaddingClass}
 							onDraftActiveChange={onDraftActiveChange}
 							isProcessing={isProcessing}
+							canQueueMessages={!inputLeadingElement}
 						/>
 					)
 				)}

--- a/packages/web/src/components/InputTextarea.tsx
+++ b/packages/web/src/components/InputTextarea.tsx
@@ -63,6 +63,7 @@ export interface InputTextareaProps {
 	onAgentMentionClose?: () => void;
 	// Agent state - passed as prop to avoid direct signal reads that cause re-renders
 	isAgentWorking?: boolean;
+	canQueueMessages?: boolean;
 	onStop?: () => void;
 	onPaste?: (e: ClipboardEvent) => void;
 	/** Optional control rendered inside the input, on the left side */
@@ -102,6 +103,7 @@ export function InputTextarea({
 	onReferenceSelect,
 	onReferenceClose,
 	isAgentWorking = false,
+	canQueueMessages = false,
 	onStop,
 	onPaste,
 	leadingElement,
@@ -334,7 +336,7 @@ export function InputTextarea({
 						title={
 							isMobileDevice.current
 								? 'Send message'
-								: isAgentWorking
+								: isAgentWorking && canQueueMessages
 									? 'Send message now (Tab queues next turn)'
 									: 'Send message (Enter or Cmd+Enter)'
 						}

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -88,6 +88,8 @@ interface MessageInputProps {
 	onDraftActiveChange?: (hasDraft: boolean) => void;
 	/** Whether the backing agent/session is currently processing or queued. */
 	isProcessing?: boolean;
+	/** Whether this session supports queueing draft text for the next turn via Tab. */
+	canQueueMessages?: boolean;
 }
 
 interface QueuedOverlayMessage {
@@ -115,6 +117,7 @@ export default function MessageInput({
 	leadingPaddingClass,
 	onDraftActiveChange,
 	isProcessing,
+	canQueueMessages = true,
 }: MessageInputProps) {
 	// Cache touch device detection — computed once on first render, stable thereafter.
 	// Using useRef (not a module constant) so tests can mock matchMedia before render.
@@ -436,7 +439,7 @@ export default function MessageInput({
 				return;
 			}
 
-			if (e.key === 'Tab' && !e.shiftKey && agentWorking) {
+			if (e.key === 'Tab' && !e.shiftKey && agentWorking && canQueueMessages) {
 				e.preventDefault();
 				void handleSubmit('defer');
 				return;
@@ -462,6 +465,7 @@ export default function MessageInput({
 			cmdHandleKeyDown,
 			handleSubmit,
 			agentWorking,
+			canQueueMessages,
 			showAgentMentionAutocomplete,
 			filteredAgentMentionCandidates,
 			agentMentionSelectedIndex,
@@ -678,6 +682,7 @@ export default function MessageInput({
 							onReferenceSelect={referenceAutocomplete.handleSelect}
 							onReferenceClose={referenceAutocomplete.close}
 							isAgentWorking={agentWorking}
+							canQueueMessages={canQueueMessages}
 							onStop={handleInterrupt}
 							onPaste={disabled ? undefined : handlePaste}
 							textareaRef={textareaInputRef}

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -86,6 +86,8 @@ interface MessageInputProps {
 	leadingPaddingClass?: string;
 	/** Emits whether the current draft has non-whitespace content */
 	onDraftActiveChange?: (hasDraft: boolean) => void;
+	/** Whether the backing agent/session is currently processing or queued. */
+	isProcessing?: boolean;
 }
 
 interface QueuedOverlayMessage {
@@ -112,6 +114,7 @@ export default function MessageInput({
 	leadingElement,
 	leadingPaddingClass,
 	onDraftActiveChange,
+	isProcessing,
 }: MessageInputProps) {
 	// Cache touch device detection — computed once on first render, stable thereafter.
 	// Using useRef (not a module constant) so tests can mock matchMedia before render.
@@ -250,7 +253,7 @@ export default function MessageInput({
 		setAgentMentionSelectedIndex(0);
 	}, []);
 
-	const agentWorking = isAgentWorking.value;
+	const agentWorking = isProcessing ?? isAgentWorking.value;
 	const [queuedForCurrentTurn, setQueuedForCurrentTurn] = useState<QueuedOverlayMessage[]>([]);
 	const [queuedForNextTurn, setQueuedForNextTurn] = useState<QueuedOverlayMessage[]>([]);
 

--- a/packages/web/src/components/__tests__/ChatComposer.test.tsx
+++ b/packages/web/src/components/__tests__/ChatComposer.test.tsx
@@ -3,11 +3,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ChatComposerProps } from '../ChatComposer';
 
 vi.mock('../MessageInput.tsx', () => ({
-	default: (props: { disabled?: boolean; placeholder?: string }) => (
+	default: (props: { disabled?: boolean; placeholder?: string; isProcessing?: boolean }) => (
 		<div
 			data-testid="mock-message-input"
 			data-disabled={String(props.disabled)}
 			data-placeholder={props.placeholder}
+			data-is-processing={String(props.isProcessing)}
 		/>
 	),
 }));
@@ -92,5 +93,11 @@ describe('ChatComposer', () => {
 		expect(getByTestId(CHAT_COMPOSER_READABILITY_SCRIM_TEST_ID)).toBeTruthy();
 		expect(queryByTestId('mock-message-input')).toBeNull();
 		expect(getByTestId('mock-session-status-bar')).toBeTruthy();
+	});
+
+	it('passes processing state to MessageInput so the stop button can render', () => {
+		const { getByTestId } = render(<ChatComposer {...baseProps({ isProcessing: true })} />);
+
+		expect(getByTestId('mock-message-input').dataset.isProcessing).toBe('true');
 	});
 });

--- a/packages/web/src/components/__tests__/ChatComposer.test.tsx
+++ b/packages/web/src/components/__tests__/ChatComposer.test.tsx
@@ -3,12 +3,18 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ChatComposerProps } from '../ChatComposer';
 
 vi.mock('../MessageInput.tsx', () => ({
-	default: (props: { disabled?: boolean; placeholder?: string; isProcessing?: boolean }) => (
+	default: (props: {
+		disabled?: boolean;
+		placeholder?: string;
+		isProcessing?: boolean;
+		canQueueMessages?: boolean;
+	}) => (
 		<div
 			data-testid="mock-message-input"
 			data-disabled={String(props.disabled)}
 			data-placeholder={props.placeholder}
 			data-is-processing={String(props.isProcessing)}
+			data-can-queue-messages={String(props.canQueueMessages)}
 		/>
 	),
 }));
@@ -99,5 +105,21 @@ describe('ChatComposer', () => {
 		const { getByTestId } = render(<ChatComposer {...baseProps({ isProcessing: true })} />);
 
 		expect(getByTestId('mock-message-input').dataset.isProcessing).toBe('true');
+	});
+
+	it('enables queue shortcuts for regular session composers', () => {
+		const { getByTestId } = render(<ChatComposer {...baseProps()} />);
+
+		expect(getByTestId('mock-message-input').dataset.canQueueMessages).toBe('true');
+	});
+
+	it('disables queue shortcuts when a custom leading control handles task routing', () => {
+		const { getByTestId } = render(
+			<ChatComposer
+				{...baseProps({ inputLeadingElement: <button type="button">Target</button> })}
+			/>
+		);
+
+		expect(getByTestId('mock-message-input').dataset.canQueueMessages).toBe('false');
 	});
 });

--- a/packages/web/src/components/__tests__/InputTextarea.test.tsx
+++ b/packages/web/src/components/__tests__/InputTextarea.test.tsx
@@ -251,6 +251,30 @@ describe('InputTextarea', () => {
 			) as HTMLButtonElement;
 			expect(sendButton?.disabled).toBe(true);
 		});
+
+		it('should show stop button when agent is working and content is empty', () => {
+			const onStop = vi.fn(() => {});
+			const { container } = render(
+				<InputTextarea
+					content=""
+					onContentChange={() => {}}
+					onKeyDown={() => {}}
+					onSubmit={() => {}}
+					isAgentWorking={true}
+					onStop={onStop}
+				/>
+			);
+
+			const sendButton = container.querySelector('[data-testid="send-button"]');
+			const stopButton = container.querySelector(
+				'[data-testid="stop-button"]'
+			) as HTMLButtonElement;
+			expect(sendButton).toBeNull();
+			expect(stopButton).toBeTruthy();
+
+			fireEvent.click(stopButton);
+			expect(onStop).toHaveBeenCalledTimes(1);
+		});
 	});
 
 	describe('Keyboard Events', () => {

--- a/packages/web/src/components/__tests__/MessageInput.queue-mode.test.tsx
+++ b/packages/web/src/components/__tests__/MessageInput.queue-mode.test.tsx
@@ -182,6 +182,23 @@ describe('MessageInput queue mode', () => {
 		expect(onSend).not.toHaveBeenCalled();
 	});
 
+	it('does not queue on Tab when queue shortcuts are disabled', async () => {
+		mockDraftContent = 'send immediately only';
+		mockAgentWorking.value = true;
+		const onSend = vi.fn(async () => {});
+
+		const { container } = render(
+			<MessageInput sessionId="session-1" onSend={onSend} canQueueMessages={false} />
+		);
+		const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+
+		await act(async () => {
+			fireEvent.keyDown(textarea, { key: 'Tab' });
+		});
+
+		expect(onSend).not.toHaveBeenCalled();
+	});
+
 	it('does not queue on Shift+Tab while agent is working', async () => {
 		mockDraftContent = 'shift tab should not queue';
 		mockAgentWorking.value = true;


### PR DESCRIPTION
Pass composer processing state into the message input so running space, task, and node-agent sessions can show the stop button when the draft is empty.

Tests: bun --cwd packages/web test src/components/__tests__/InputTextarea.test.tsx src/components/__tests__/ChatComposer.test.tsx; bun --cwd packages/web test; bun run typecheck