### PR TITLE
Fix SDK transcript usage rehydration

### DIFF
--- a/packages/daemon/src/lib/sdk-session-file-manager.ts
+++ b/packages/daemon/src/lib/sdk-session-file-manager.ts
@@ -306,8 +306,107 @@ interface SDKFileMessage {
 			tool_use_id?: string;
 			[key: string]: unknown;
 		}>;
+		usage?: {
+			input_tokens?: unknown;
+			output_tokens?: unknown;
+			[key: string]: unknown;
+		};
+		[key: string]: unknown;
 	};
 	[key: string]: unknown;
+}
+
+export interface SDKSessionUsageSanitizationResult {
+	success: boolean;
+	filePath: string | null;
+	sanitizedCount: number;
+	errors: string[];
+}
+
+function isFiniteTokenCount(value: unknown): value is number {
+	return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+/**
+ * Sanitize legacy Claude SDK JSONL transcripts before daemon-restart resume.
+ *
+ * Older SDK versions persisted assistant messages without message.usage. Current
+ * SDK readMessages expects usage.input_tokens to exist and can crash before our
+ * normal query error handling runs. This function performs the smallest safe
+ * mutation: assistant messages get a usage object and numeric input/output token
+ * counts, preserving any other SDK-owned fields.
+ */
+export function sanitizeAssistantUsageInSDKSessionFile(
+	workspacePath: string,
+	sdkSessionId: string
+): SDKSessionUsageSanitizationResult {
+	const sessionFile = getSDKSessionFilePath(workspacePath, sdkSessionId);
+	const result: SDKSessionUsageSanitizationResult = {
+		success: true,
+		filePath: sessionFile,
+		sanitizedCount: 0,
+		errors: [],
+	};
+
+	if (!existsSync(sessionFile)) {
+		result.filePath = null;
+		return result;
+	}
+
+	try {
+		const content = readFileSync(sessionFile, 'utf-8');
+		const lines = content.split('\n');
+		let changed = false;
+
+		for (let i = 0; i < lines.length; i++) {
+			const line = lines[i];
+			if (!line.trim()) continue;
+
+			let message: SDKFileMessage;
+			try {
+				message = JSON.parse(line) as SDKFileMessage;
+			} catch (parseError) {
+				result.errors.push(`Failed to parse line ${i}: ${parseError}`);
+				continue;
+			}
+
+			if (message.type !== 'assistant' || !message.message) continue;
+
+			const existingUsage =
+				message.message.usage && typeof message.message.usage === 'object'
+					? message.message.usage
+					: {};
+			const nextUsage = {
+				...existingUsage,
+				input_tokens: isFiniteTokenCount(existingUsage.input_tokens)
+					? existingUsage.input_tokens
+					: 0,
+				output_tokens: isFiniteTokenCount(existingUsage.output_tokens)
+					? existingUsage.output_tokens
+					: 0,
+			};
+
+			if (
+				message.message.usage !== existingUsage ||
+				nextUsage.input_tokens !== existingUsage.input_tokens ||
+				nextUsage.output_tokens !== existingUsage.output_tokens
+			) {
+				message.message.usage = nextUsage;
+				lines[i] = JSON.stringify(message);
+				result.sanitizedCount++;
+				changed = true;
+			}
+		}
+
+		if (changed) {
+			writeFileSync(sessionFile, lines.join('\n'), 'utf-8');
+		}
+	} catch (error) {
+		result.success = false;
+		result.errors.push(`Sanitization error: ${error}`);
+	}
+
+	return result;
 }
 
 /**

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -84,6 +84,7 @@ import {
 	validateTaskAllowsSpawn,
 } from './workflow-node-execution-validation';
 import { createDbQueryMcpServer, type DbQueryMcpServer } from '../../db-query/tools';
+import { sanitizeAssistantUsageInSDKSessionFile } from '../../sdk-session-file-manager';
 import { ChannelResolver } from './channel-resolver';
 import { ChannelRouter } from './channel-router';
 import { AgentMessageRouter } from './agent-message-router';
@@ -3129,6 +3130,10 @@ export class TaskAgentManager {
 		// --- Store in map before streaming start
 		this.taskAgentSessions.set(taskId, agentSession);
 
+		// Old SDK transcripts may lack assistant message usage. Sanitize only during
+		// rehydration, before the SDK reads JSONL history while resuming.
+		this.sanitizeSDKSessionTranscriptForRehydration(agentSession, rehydrateWorkspacePath);
+
 		// --- Restart the streaming query (SDK resumes from conversation history in DB)
 		await agentSession.startStreamingQuery();
 		await this.replayPendingMessagesAfterRuntimeProvisioning(agentSession);
@@ -3258,6 +3263,29 @@ export class TaskAgentManager {
 	 * Returns the rehydrated AgentSession, or null if the session cannot be found
 	 * in the DB or its parent context is missing.
 	 */
+	private sanitizeSDKSessionTranscriptForRehydration(
+		agentSession: AgentSession,
+		workspacePath: string
+	): void {
+		const session = agentSession.getSessionData();
+		if (!session.sdkSessionId) return;
+
+		const result = sanitizeAssistantUsageInSDKSessionFile(workspacePath, session.sdkSessionId);
+		if (!result.success) {
+			log.warn(
+				`TaskAgentManager.rehydrate: failed to sanitize SDK transcript for session ${session.id} ` +
+					`(sdkSessionId=${session.sdkSessionId}): ${result.errors.join('; ')}`
+			);
+			return;
+		}
+		if (result.sanitizedCount > 0) {
+			log.info(
+				`TaskAgentManager.rehydrate: sanitized ${result.sanitizedCount} assistant message(s) ` +
+					`in SDK transcript for session ${session.id}`
+			);
+		}
+	}
+
 	private async rehydrateSubSession(subSessionId: string): Promise<AgentSession | null> {
 		log.warn(`TaskAgentManager: rehydrating ghost sub-session ${subSessionId} from DB...`);
 
@@ -3420,6 +3448,10 @@ export class TaskAgentManager {
 					`starting query only after runtime provisioning is complete`
 			);
 		}
+
+		// Old SDK transcripts may lack assistant message usage. Sanitize only during
+		// rehydration, before the SDK reads JSONL history while resuming.
+		this.sanitizeSDKSessionTranscriptForRehydration(agentSession, workspacePath);
 
 		// --- Restart the streaming query (idempotent if already running)
 		await agentSession.startStreamingQuery();

--- a/packages/daemon/tests/unit/1-core/core/sdk-session-file-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/sdk-session-file-manager.test.ts
@@ -134,6 +134,50 @@ describe('SDK Session File Manager', () => {
 			});
 		});
 
+		test('does not rewrite file when all assistant messages already have valid usage', () => {
+			const original = `${JSON.stringify({
+				type: 'assistant',
+				uuid: 'assistant-1',
+				message: {
+					role: 'assistant',
+					content: [{ type: 'text', text: 'Hi' }],
+					usage: { input_tokens: 10, output_tokens: 5 },
+				},
+			})}\n`;
+			writeFileSync(testSessionFile, original, 'utf-8');
+			const before = readFileSync(testSessionFile, 'utf-8');
+
+			const result = sanitizeAssistantUsageInSDKSessionFile(testWorkspacePath, testSdkSessionId);
+
+			expect(result.success).toBe(true);
+			expect(result.sanitizedCount).toBe(0);
+			expect(readFileSync(testSessionFile, 'utf-8')).toBe(before);
+		});
+
+		test('replaces non-numeric and invalid token values with 0', () => {
+			writeFileSync(
+				testSessionFile,
+				`${JSON.stringify({
+					type: 'assistant',
+					uuid: 'assistant-1',
+					message: {
+						role: 'assistant',
+						content: [{ type: 'text', text: 'Hi' }],
+						usage: { input_tokens: 'not-a-number', output_tokens: Number.NaN },
+					},
+				})}\n`,
+				'utf-8'
+			);
+
+			const result = sanitizeAssistantUsageInSDKSessionFile(testWorkspacePath, testSdkSessionId);
+
+			expect(result.success).toBe(true);
+			expect(result.sanitizedCount).toBe(1);
+			const assistant = JSON.parse(readFileSync(testSessionFile, 'utf-8').trim());
+			expect(assistant.message.usage.input_tokens).toBe(0);
+			expect(assistant.message.usage.output_tokens).toBe(0);
+		});
+
 		test('does not rewrite non-existent session files', () => {
 			const result = sanitizeAssistantUsageInSDKSessionFile(
 				testWorkspacePath,

--- a/packages/daemon/tests/unit/1-core/core/sdk-session-file-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/sdk-session-file-manager.test.ts
@@ -23,6 +23,7 @@ import {
 	messageUuidExistsInSessionFile,
 	findSDKSessionFileGlobally,
 	migrateSDKSessionFile,
+	sanitizeAssistantUsageInSDKSessionFile,
 } from '../../../../src/lib/sdk-session-file-manager';
 import type { Database } from '../../../../src/storage/database';
 
@@ -78,6 +79,70 @@ describe('SDK Session File Manager', () => {
 		test('should handle dots and slashes in workspace path', () => {
 			const path = getSDKSessionFilePath('/Users/test/.hidden/project', 'session-123');
 			expect(path).toContain('projects/-Users-test--hidden-project');
+		});
+	});
+
+	describe('sanitizeAssistantUsageInSDKSessionFile', () => {
+		test('adds default usage to legacy assistant messages', () => {
+			const messages = [
+				JSON.stringify({
+					type: 'user',
+					uuid: 'user-1',
+					message: { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+				}),
+				JSON.stringify({
+					type: 'assistant',
+					uuid: 'assistant-1',
+					message: { role: 'assistant', content: [{ type: 'text', text: 'Hi' }] },
+				}),
+			];
+			writeFileSync(testSessionFile, `${messages.join('\n')}\n`, 'utf-8');
+
+			const result = sanitizeAssistantUsageInSDKSessionFile(testWorkspacePath, testSdkSessionId);
+
+			expect(result.success).toBe(true);
+			expect(result.sanitizedCount).toBe(1);
+			const lines = readFileSync(testSessionFile, 'utf-8').trim().split('\n');
+			const assistant = JSON.parse(lines[1]);
+			expect(assistant.message.usage).toEqual({ input_tokens: 0, output_tokens: 0 });
+		});
+
+		test('preserves existing usage fields while filling missing token counts', () => {
+			writeFileSync(
+				testSessionFile,
+				`${JSON.stringify({
+					type: 'assistant',
+					uuid: 'assistant-1',
+					message: {
+						role: 'assistant',
+						content: [{ type: 'text', text: 'Hi' }],
+						usage: { input_tokens: 42, cache_creation_input_tokens: 7 },
+					},
+				})}\n`,
+				'utf-8'
+			);
+
+			const result = sanitizeAssistantUsageInSDKSessionFile(testWorkspacePath, testSdkSessionId);
+
+			expect(result.success).toBe(true);
+			expect(result.sanitizedCount).toBe(1);
+			const assistant = JSON.parse(readFileSync(testSessionFile, 'utf-8').trim());
+			expect(assistant.message.usage).toEqual({
+				input_tokens: 42,
+				cache_creation_input_tokens: 7,
+				output_tokens: 0,
+			});
+		});
+
+		test('does not rewrite non-existent session files', () => {
+			const result = sanitizeAssistantUsageInSDKSessionFile(
+				testWorkspacePath,
+				'nonexistent-session'
+			);
+
+			expect(result.success).toBe(true);
+			expect(result.filePath).toBeNull();
+			expect(result.sanitizedCount).toBe(0);
 		});
 	});
 


### PR DESCRIPTION
Sanitizes legacy Claude SDK JSONL transcripts during task-agent and sub-session rehydration so assistant messages always have usage token fields before startStreamingQuery resumes.

Tests: bun test packages/daemon/tests/unit/1-core/core/sdk-session-file-manager.test.ts; bunx tsc --noEmit. Full bun test still fails on unrelated UI test environment issues (missing react/jsx-runtime, document is not defined) and existing CLI SIGINT timeouts.