### PR TITLE
Research: Retry injection after dedupe failure

### DIFF
--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -25,7 +25,7 @@ External Event Sources (GitHub webhook, polling, future: Slack, CI)
 │  EventIngestion     │  Normalize → validate → publish to EventBus
 │  (adapter per source│
 └────────┬────────────┘
-         │ publish(event) → hub.emit('space.externalEvent.published', { event })
+         │ publish(event) → hub.emit('space.externalEvent.published', { sessionId: 'global', event })
          ▼
 ┌─────────────────────┐
 │  EventBus           │  In-memory, backed by TypedHub. External topic is payload data.
@@ -284,7 +284,26 @@ export interface EventPublisher {
 export const EXTERNAL_EVENT_PUBLISHED_METHOD = 'space.externalEvent.published';
 
 export interface EventBusHubEventMap {
-  'space.externalEvent.published': { spaceId: string; event: ExternalEvent };
+  'space.externalEvent.published': {
+    /** Fixed channel required by BaseEventData/TypedHub routing. */
+    sessionId: 'global';
+    spaceId: string;
+    event: ExternalEvent;
+  };
+}
+```
+
+The `sessionId: 'global'` field is required because EventBus is backed by TypedHub/DaemonHub, whose payloads satisfy `BaseEventData` for channel routing. External event delivery is still space-scoped by `spaceId`; the fixed session channel is only the transport channel for bus subscribers.
+
+```typescript
+class EventBus implements EventPublisher {
+  async publish(event: ExternalEvent): Promise<void> {
+    await this.hub.emit(EXTERNAL_EVENT_PUBLISHED_METHOD, {
+      sessionId: 'global',
+      spaceId: event.spaceId,
+      event,
+    });
+  }
 }
 ```
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -551,8 +551,10 @@ class EventRouter {
   }
 
   /**
-   * Unregister subscriptions for a specific node execution.
+   * Unregister subscriptions for a specific task-owned node execution.
    * Called when a node execution transitions to `cancelled` state.
+   * Includes taskId so cancelling one task's node does not remove another
+   * task's subscriptions when both tasks share the same workflowRunId/node/agent.
    *
    * Only `cancelled` nodes are removed from the subscription index.
    * All other states (`pending`, `in_progress`, `idle`, `waiting_rebind`,
@@ -565,6 +567,7 @@ class EventRouter {
    */
   unregisterExecution(
     workflowRunId: string,
+    taskId: string,
     nodeId: string,
     agentName: string,
   ): void {
@@ -572,12 +575,15 @@ class EventRouter {
     if (!runSubs) return;
 
     const toRemove = [...runSubs].filter(
-      s => s.nodeId === nodeId && s.agentName === agentName,
+      s => s.taskId === taskId && s.nodeId === nodeId && s.agentName === agentName,
     );
     for (const sub of toRemove) {
       runSubs.delete(sub);
       this.topicTrie.remove(
-        v => v.workflowRunId === workflowRunId && v.agentName === agentName && v.nodeId === nodeId,
+        v => v.workflowRunId === workflowRunId
+          && v.taskId === taskId
+          && v.agentName === agentName
+          && v.nodeId === nodeId,
       );
     }
   }
@@ -960,10 +966,8 @@ class GitHubEventAdapter implements EventAdapter {
       const [repoOwner, repoName] = event.repo.split('/');
 
       // Construct topic from event.
-      // mapEventType returns the full resource.action string from the table below.
-      // For most SpaceGitHubEventKinds, the mapping already includes the action
-      // (e.g., pull_request_review → "pull_request.review_submitted").
-      // For plain pull_request events, the action is appended from event.action.
+      // mapEventType returns the full resource.action string and preserves the
+      // original GitHub action so users can filter created/edited/deleted/etc.
       const topic = `github/${repoOwner}/${repoName}/${mapEventType(event.eventType, event.action)}`;
 
       // Publish to bus
@@ -998,17 +1002,17 @@ The `SpaceGitHubService` already normalizes to `SpaceGitHubEventKind` (`issue_co
 
 | SpaceGitHubEventKind | `mapEventType(kind, action)` returns |
 |---|---|
-| `issue_comment` | `pull_request.comment_created` (PR comments only, already filtered) |
-| `pull_request_review` | `pull_request.review_submitted` |
-| `pull_request_review_comment` | `pull_request.review_comment_created` |
+| `issue_comment` | `pull_request.comment_${action}` (PR comments only; created, edited, deleted) |
+| `pull_request_review` | `pull_request.review_${action}` (submitted, edited, dismissed) |
+| `pull_request_review_comment` | `pull_request.review_comment_${action}` (created, edited, deleted) |
 | `pull_request` | `pull_request.${action}` (opened, synchronize, closed, etc.) |
 
 ```typescript
 function mapEventType(kind: string, action: string): string {
   switch (kind) {
-    case 'issue_comment': return 'pull_request.comment_created';
-    case 'pull_request_review': return 'pull_request.review_submitted';
-    case 'pull_request_review_comment': return 'pull_request.review_comment_created';
+    case 'issue_comment': return `pull_request.comment_${action}`;
+    case 'pull_request_review': return `pull_request.review_${action}`;
+    case 'pull_request_review_comment': return `pull_request.review_comment_${action}`;
     case 'pull_request': return `pull_request.${action}`;
     default: return `${kind}.${action}`;
   }

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -449,8 +449,10 @@ class EventRouter {
   // track which runs have active subscriptions (for lifecycle management)
   private activeRuns: Map<string, Set<Subscription>> = new Map();
 
-  // dedup: (dedupeKey, agentSessionId) → timestamp
+  // dedup: JSON tuple (dedupeKey, taskId, nodeId, agentName, workflowRunId) → timestamp
   private delivered: Map<string, number> = new Map();
+  // pending delivery queue: JSON tuple (workflowRunId, taskId, nodeId, agentName) → events
+  private pendingQueue: Map<string, ExternalEvent[]> = new Map();
   // TTL for dedup entries — entries older than this are evicted on next access
   private static readonly DEDUP_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
@@ -509,6 +511,17 @@ class EventRouter {
     } else {
       this.watchedRepoCache.clear();
     }
+  }
+
+  private makeDeliveryKey(event: ExternalEvent, sub: Subscription): string {
+    // Use a structured tuple key: event.dedupeKey and workflow/node/agent ids are
+    // free-form strings and can contain ':', '/', or other delimiter characters.
+    return JSON.stringify([event.dedupeKey, sub.taskId, sub.nodeId, sub.agentName, sub.workflowRunId]);
+  }
+
+  private makePendingQueueKey(sub: Pick<Subscription, 'workflowRunId' | 'taskId' | 'nodeId' | 'agentName'>): string {
+    // Same collision-safe shape as subscription/delivery keys.
+    return JSON.stringify([sub.workflowRunId, sub.taskId, sub.nodeId, sub.agentName]);
   }
 
   /** Evict stale dedup entries (called periodically or on demand). */
@@ -662,22 +675,20 @@ class EventRouter {
     this.topicTrie.remove(v => v.workflowRunId === workflowRunId);
     this.activeRuns.delete(workflowRunId);
 
-    // Also clean up dedup entries for this run.
-    // Delivery keys are: `${event.dedupeKey}:${sub.taskId}:${sub.nodeId}:${sub.agentName}:${workflowRunId}`
-    // The run ID is the final segment — match with suffix `:${workflowRunId}`.
-    const suffix = `:${workflowRunId}`;
+    // Also clean up dedup entries for this run. Keys are JSON tuples, so parse
+    // structurally rather than suffix-matching delimiter-joined strings.
     for (const key of this.delivered.keys()) {
-      if (key.endsWith(suffix)) {
+      const [, , , , keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string, string];
+      if (keyWorkflowRunId === workflowRunId) {
         this.delivered.delete(key);
       }
     }
 
-    // Clean up in-memory pending queue for this run.
-    // Keys are `${workflowRunId}:${taskId}:${nodeId}:${agentName}` — use the
-    // delimiter to avoid false prefix matches (e.g., run "abc1" matching "abc10:*").
-    const runPrefix = `${workflowRunId}:`;
-    for (const [key, events] of this.pendingQueue.entries()) {
-      if (key.startsWith(runPrefix)) {
+    // Clean up in-memory pending queue for this run. Keys are JSON tuples, so parse
+    // structurally rather than prefix-matching delimiter-joined strings.
+    for (const key of this.pendingQueue.keys()) {
+      const [keyWorkflowRunId] = JSON.parse(key) as [string, string, string, string];
+      if (keyWorkflowRunId === workflowRunId) {
         this.pendingQueue.delete(key);
       }
     }
@@ -719,7 +730,7 @@ class EventRouter {
     // run. Each task/node/agent subscription is deduped independently.
     // Evict before checking so DEDUP_TTL_MS is actually enforced during long runs.
     this.evictStaleDedup();
-    const dedupeKey = `${event.dedupeKey}:${sub.taskId}:${sub.nodeId}:${sub.agentName}:${sub.workflowRunId}`;
+    const dedupeKey = this.makeDeliveryKey(event, sub);
     if (this.delivered.has(dedupeKey)) return;
 
     // Mark dedup BEFORE session resolution / queueing. This prevents the same
@@ -757,6 +768,22 @@ class EventRouter {
       // this run. A fresh event will arrive via the next poll cycle if the
       // underlying external event is still relevant.
     }
+  }
+
+  private queueForDelivery(event: ExternalEvent, sub: Subscription): void {
+    const key = this.makePendingQueueKey(sub);
+    const queue = this.pendingQueue.get(key) ?? [];
+    queue.push(event);
+    if (queue.length > 50) {
+      queue.shift();
+      log.warn('EventRouter: pending external event queue exceeded limit; dropped oldest event', {
+        workflowRunId: sub.workflowRunId,
+        taskId: sub.taskId,
+        nodeId: sub.nodeId,
+        agentName: sub.agentName,
+      });
+    }
+    this.pendingQueue.set(key, queue);
   }
 
   private passesScopeCheck(event: ExternalEvent, sub: Subscription): boolean {
@@ -848,7 +875,7 @@ Event arrives → Match subscriptions → Scope check → Dedup check → Sessio
 
 ### Deduplication
 
-- **Key**: `(event.dedupeKey, subscription.taskId, subscription.nodeId, subscription.agentName, subscription.workflowRunId)` — includes `taskId` to isolate multi-task runs and `nodeId` to handle cases where the same agent name appears in multiple nodes within the same run.
+- **Key**: JSON tuple `[event.dedupeKey, subscription.taskId, subscription.nodeId, subscription.agentName, subscription.workflowRunId]` — includes `taskId` to isolate multi-task runs and `nodeId` to handle cases where the same agent name appears in multiple nodes within the same run. The tuple is encoded structurally rather than delimiter-joined because `dedupeKey`, workflow identifiers, node IDs, and agent names are free-form strings.
 - **Storage**: In-memory `Map<string, number>` (timestamp). Evicted when the workflow run completes.
 - **Guarantee**: Same external event is never delivered twice to the same node agent within a run.
 - The upstream `SpaceGitHubService` already deduplicates by `(spaceId, dedupeKey)` — this is an additional per-node dedup.
@@ -865,7 +892,7 @@ When an event matches a subscription whose node execution is `idle` (agent sessi
 
 When a node execution is `pending` (no session yet):
 
-1. The event is queued in an in-memory `Map<string, ExternalEvent[]>` keyed by `${workflowRunId}:${taskId}:${nodeId}:${agentName}`.
+1. The event is queued in an in-memory `Map<string, ExternalEvent[]>` keyed by a JSON tuple `[workflowRunId, taskId, nodeId, agentName]` so free-form identifiers cannot collide by containing delimiter characters.
 2. When `TaskAgentManager` creates the node's session, it checks for queued events.
 3. Queued events are injected as initial context in the session's first turn.
 4. Queue is bounded: max 50 events per execution, oldest dropped (with a warning log).

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -1,0 +1,851 @@
+# Design: External Event Bus for Space Workflow Nodes
+
+## Status: Draft
+
+## Problem
+
+The Space Agent spends most of its time relaying "check the new review comments" to the coder node. External events (PR reviews, CI failures, etc.) arrive via webhooks/polling but have no path to workflow **nodes** — they only route to Rooms or to the Space Agent's global session (via `SpaceGitHubService`). We need a system where workflow nodes declare interest in event types, and matching events are delivered directly to their agent sessions.
+
+## Current State
+
+Two parallel event pipelines exist today, neither of which routes to individual workflow nodes:
+
+1. **Room pipeline** (`GitHubService`): Webhook → normalize → filter → security → route → `deliverToRoom()` → DaemonHub `room.message`. Routes to **Rooms**, not Spaces.
+2. **Space pipeline** (`SpaceGitHubService`): Webhook → normalize → dedupe → `SpacePrTaskResolver.resolve()` → `injectTaskAgent()`. Routes events to the **Task Agent session** (the orchestrator), which must then manually relay to the coder node.
+
+The Space pipeline already does the hard part — it normalizes events, resolves them to a task by PR number, and injects them into the Task Agent session. But it stops one hop short: the coder node still depends on the Task Agent to forward relevant events.
+
+## Design Overview
+
+```
+External Event Sources (GitHub webhook, polling, future: Slack, CI)
+       │
+       ▼
+┌─────────────────────┐
+│  EventIngestion     │  Normalize → validate → publish to EventBus
+│  (adapter per source│
+└────────┬────────────┘
+         │ publish(topic, payload)
+         ▼
+┌─────────────────────┐
+│  EventBus           │  In-memory, backed by TypedHub. Namespaced topics.
+│  (singleton)        │  O(1) subscriber lookup by topic pattern.
+└────────┬────────────┘
+         │
+         ▼
+┌─────────────────────┐
+│  EventRouter        │  Subscribes to all topics. Matches events to
+│  (per-runtime)      │  active node interests. Delivers via AgentMessageRouter
+│                     │  or injects directly into sessions.
+└─────────────────────┘
+```
+
+## 1. Namespaced Event Topics
+
+Topic format: `{source}/{owner}/{repo}/{resource}.{action}`
+
+Examples:
+```
+github/lsm/neokai/pull_request.review_submitted
+github/lsm/neokai/pull_request.comment_created
+github/lsm/neokai/pull_request.synchronize
+github/lsm/neokai/check_suite.completed
+github/lsm/neokai/issues.opened
+github/lsm/neokai/pull_request.*            ← wildcard: all PR events for this repo
+github/lsm/neokai/*.*                       ← wildcard: all events for this repo
+github/lsm/neokai/pull_request.review_*     ← prefix wildcard: all review events
+```
+
+### Topic construction rules
+
+1. `source` — adapter identifier (`github`, `slack`, `ci`). Lowercase, no slashes.
+2. `owner/repo` — from the event's repository context. Both lowercase for case-insensitive matching.
+3. `resource` — the GitHub resource type: `pull_request`, `issue`, `check_suite`, `pull_request_review`, etc.
+4. `action` — the specific action: `opened`, `review_submitted`, `comment_created`, `completed`, etc.
+5. For resources without a natural `owner/repo` (e.g. a Slack message), the convention is `{source}/{workspace}/{channel}.{action}`.
+
+### Matching rules
+
+Subscriptions use glob-style patterns:
+- `*` matches any single path segment (no slashes)
+- `**` matches any number of path segments
+- Literal segments match exactly (case-insensitive)
+
+We implement matching via a **trie-based prefix index** (see §4), not regex. This keeps matching O(k) where k = topic depth, independent of the number of subscriptions.
+
+## 2. Node-Level Event Subscription (`eventInterests`)
+
+### Schema addition to `WorkflowNodeAgent`
+
+```typescript
+// packages/shared/src/types/space.ts — add to WorkflowNodeAgent
+
+export interface EventInterest {
+  /**
+   * Glob pattern matching event topics.
+   * Examples: 'github/*/*/pull_request.*', 'ci/*/*/check_suite.completed'
+   */
+  topic: string;
+
+  /**
+   * Scoping mode — determines how the router filters events for this node.
+   * - 'task'    — Only events related to THIS TASK (e.g. same PR number, same branch).
+   *               The router uses the task's associated PR/branch to filter.
+   * - 'repo'    — All events for the space's configured repository.
+   * - 'global'  — All events matching the topic pattern, no additional filtering.
+   */
+  scope: 'task' | 'repo' | 'global';
+
+  /**
+   * Optional label for diagnostics. Not used in routing logic.
+   * Example: 'PR review comments', 'CI failures'
+   */
+  label?: string;
+}
+
+// Added to WorkflowNodeAgent:
+export interface WorkflowNodeAgent {
+  // ... existing fields ...
+
+  /**
+   * Events this node is interested in receiving. When matched, the event is
+   * injected into the agent's session as a structured message.
+   * Omit or empty array = no event subscriptions (default).
+   */
+  eventInterests?: EventInterest[];
+}
+```
+
+### Example workflow definition
+
+```json
+{
+  "nodes": [
+    {
+      "id": "coder",
+      "name": "Code",
+      "agents": [{
+        "agentId": "...",
+        "name": "coder",
+        "eventInterests": [
+          {
+            "topic": "github/*/*/pull_request.review_submitted",
+            "scope": "task",
+            "label": "PR reviews on my task's PR"
+          },
+          {
+            "topic": "github/*/*/pull_request.comment_created",
+            "scope": "task",
+            "label": "PR comments on my task's PR"
+          },
+          {
+            "topic": "github/*/*/pull_request_review_comment.*",
+            "scope": "task",
+            "label": "Inline review comments"
+          }
+        ]
+      }]
+    },
+    {
+      "id": "monitor",
+      "name": "CI Monitor",
+      "agents": [{
+        "agentId": "...",
+        "name": "ci-monitor",
+        "eventInterests": [
+          {
+            "topic": "github/*/*/check_suite.completed",
+            "scope": "repo",
+            "label": "All CI completions in the repo"
+          }
+        ]
+      }]
+    }
+  ]
+}
+```
+
+### Scoping details
+
+**`task` scope** is the critical innovation. The router resolves the task's context at match time:
+
+1. The task's `SpaceTask` record has `workflowRunId` and (via `workflow_run_artifacts` or gate data) an associated PR number and branch name.
+2. The router queries the same `SpacePrTaskResolver` that `SpaceGitHubService` already uses to match PR numbers to tasks.
+3. For a `task`-scoped subscription, the router checks: does this event's PR number / branch match the node execution's parent task?
+4. The node author never specifies a PR number — it's implicit from the task context.
+
+**`repo` scope** filters to events from any of the space's watched repositories (`space_github_watched_repos`). The node author doesn't need to know repo names.
+
+**`global` scope** passes through all events matching the topic pattern. Use sparingly (e.g. a "global monitor" node).
+
+### Auto-scoping resolution at runtime
+
+When an event arrives, the router:
+
+1. Extracts `prNumber` and `repoOwner/repoName` from the event payload.
+2. For each active node execution with `eventInterests`:
+   a. Compiles the interest's `topic` glob against the event's topic.
+   b. If matched, checks scope:
+      - `task`: resolves `SpaceTask` → `SpacePrTaskResolver` → does event's PR match this task?
+      - `repo`: does event's repo match any watched repo in the node's space?
+      - `global`: pass.
+   c. If scope check passes, the event is queued for delivery to this node's agent session.
+
+## 3. EventIngestion Adapter Interface
+
+```typescript
+// packages/daemon/src/lib/space/runtime/event-bus/types.ts
+
+/**
+ * A normalized external event on the bus.
+ */
+export interface ExternalEvent {
+  /** Unique event ID (UUID) */
+  id: string;
+  /** Fully qualified topic: 'github/owner/repo/resource.action' */
+  topic: string;
+  /** Timestamp when the event occurred (epoch ms) */
+  occurredAt: number;
+  /** Timestamp when the event was ingested (epoch ms) */
+  ingestedAt: number;
+  /** Source adapter identifier */
+  source: string;
+  /**
+   * For scope resolution. Not all events have a PR number;
+   * absence means 'task'-scoped subscriptions won't match.
+   */
+  prNumber?: number;
+  /** Repository owner (lowercase) */
+  repoOwner?: string;
+  /** Repository name (lowercase) */
+  repoName?: string;
+  /** Branch name, if available */
+  branch?: string;
+  /** Human-readable summary for agent consumption */
+  summary: string;
+  /** External URL (e.g. GitHub PR link) */
+  externalUrl?: string;
+  /** Structured payload — adapter-specific, not constrained */
+  payload: Record<string, unknown>;
+  /**
+   * Deduplication key. The bus tracks delivered events by (eventId, nodeId)
+   * to prevent double delivery.
+   */
+  dedupeKey: string;
+}
+
+/**
+ * Interface that event source adapters must implement.
+ */
+export interface EventAdapter {
+  /** Adapter identifier (used in topic namespace: '{source}/...') */
+  readonly sourceId: string;
+
+  /**
+   * Start the adapter. Called once at daemon startup.
+   * The adapter calls `publisher.publish(event)` whenever it has an event.
+   */
+  start(publisher: EventPublisher): Promise<void>;
+
+  /** Stop the adapter. Called at daemon shutdown. */
+  stop(): Promise<void>;
+}
+
+/**
+ * Callback adapters use to publish events onto the bus.
+ */
+export interface EventPublisher {
+  publish(event: ExternalEvent): Promise<void>;
+}
+```
+
+### GitHub adapter
+
+The GitHub adapter wraps the existing `SpaceGitHubService.ingest()` pipeline. Rather than duplicating normalization logic, the adapter hooks into the point where `SpaceGitHubService` has already normalized and resolved the event:
+
+```typescript
+class GitHubEventAdapter implements EventAdapter {
+  readonly sourceId = 'github';
+
+  constructor(
+    private readonly spaceGitHubService: SpaceGitHubService,
+    private readonly watchedRepoLookup: (owner: string, repo: string) => { spaceId: string }[]
+  ) {}
+
+  async start(publisher: EventPublisher): Promise<void> {
+    // Hook into SpaceGitHubService by intercepting the post-normalization path.
+    // SpaceGitHubService already:
+    //   1. Normalizes the webhook/polling event
+    //   2. Deduplicates via dedupeKey
+    //   3. Resolves PR → taskId via SpacePrTaskResolver
+    //   4. Emits DaemonHub 'space.githubEvent.routed'
+    //
+    // The adapter subscribes to 'space.githubEvent.routed' on DaemonHub
+    // and converts the event to an ExternalEvent for the bus.
+    //
+    // This means:
+    //   - No change to existing webhook/polling normalization
+    //   - Events continue flowing to Task Agent as before
+    //   - Additionally, events appear on the EventBus for node delivery
+  }
+}
+```
+
+The adapter subscribes to the existing `space.githubEvent.routed` DaemonHub event (already emitted by `SpaceGitHubService.appendTaskActivity`). It converts the event to `ExternalEvent` format and publishes to the bus.
+
+**Why this approach:**
+- Zero changes to the existing `SpaceGitHubService` webhook handler or polling pipeline.
+- The existing PR-to-task resolution (`SpacePrTaskResolver`) continues to work.
+- The existing Task Agent injection continues to work (we don't replace it, we supplement it).
+- The adapter is purely additive: it converts an already-normalized event into bus format.
+
+## 4. EventRouter Design
+
+### Architecture
+
+The `EventRouter` subscribes to all topics on the `EventBus`. When an event arrives, it:
+
+1. Looks up all active node executions that have `eventInterests`.
+2. For each matching interest, checks scope.
+3. Delivers the event to the matching node's agent session.
+
+### Trie-based subscription index
+
+For O(1)-ish lookup, we maintain a **topic trie**:
+
+```
+root
+  └── github
+      └── *                    ← matches any owner
+          └── *                ← matches any repo
+              ├── pull_request
+              │   ├── *        ← all PR actions
+              │   │   └── [subscriptions: coder(task), ...]
+              │   ├── review_submitted
+              │   │   └── [subscriptions: coder(task)]
+              │   └── comment_created
+              │       └── [subscriptions: coder(task)]
+              └── check_suite
+                  └── completed
+                      └── [subscriptions: ci-monitor(repo)]
+```
+
+The trie maps topic segments to `Set<Subscription>` at leaf nodes. Wildcard segments (`*`) match any single segment at that depth.
+
+**Build cost**: O(n × k) where n = number of subscriptions, k = topic depth (typically 4-5). Built once when a workflow run starts.
+
+**Lookup cost**: O(k) per event — walk the trie by topic segment, collect subscriptions at each level (exact match + wildcard).
+
+### Subscription index lifecycle
+
+The index is **per-SpaceRuntime instance** and rebuilt when:
+
+1. A workflow run starts (node executions are created with interests from the workflow definition).
+2. A node execution transitions to a new status (e.g. `in_progress` → starts receiving events; `idle`/`cancelled` → removed from index).
+3. A workflow definition is updated (interests may have changed — next run picks up changes).
+
+```typescript
+interface Subscription {
+  workflowRunId: string;
+  nodeId: string;
+  agentName: string;
+  interest: EventInterest;    // from the workflow definition
+  agentSessionId: string | null; // resolved at delivery time
+  spaceId: string;
+}
+```
+
+### EventRouter implementation sketch
+
+```typescript
+class EventRouter {
+  // topic trie for fast lookup
+  private topicTrie: TopicTrie<Subscription[]> = new TopicTrie();
+
+  // track which runs have active subscriptions (for lifecycle management)
+  private activeRuns: Map<string, Set<Subscription>> = new Map();
+
+  // dedup: (dedupeKey, agentSessionId) → timestamp
+  private delivered: Map<string, number> = new Map();
+
+  constructor(
+    private readonly eventBus: EventBus,
+    private readonly nodeExecutionRepo: NodeExecutionRepository,
+    private readonly taskRepo: SpaceTaskRepository,
+    private readonly sessionFactory: SessionFactory,
+    private readonly prResolver: SpacePrTaskResolver,
+  ) {
+    // Subscribe to ALL events on the bus
+    this.eventBus.subscribe('*', this.handleEvent.bind(this));
+  }
+
+  /**
+   * Register all event interests for a workflow run.
+   * Called when a workflow run starts or when node executions change.
+   */
+  registerRunInterests(
+    spaceId: string,
+    workflowRunId: string,
+    workflow: SpaceWorkflow,
+    nodeExecutions: NodeExecution[],
+  ): void {
+    // Clear previous subscriptions for this run
+    this.clearRunInterests(workflowRunId);
+
+    const runSubs = new Set<Subscription>();
+
+    for (const node of workflow.nodes) {
+      for (const agent of node.agents) {
+        if (!agent.eventInterests?.length) continue;
+
+        // Only register if this node has at least one active (non-terminal) execution
+        const exec = nodeExecutions.find(
+          e => e.workflowNodeId === node.id && e.agentName === agent.name
+        );
+        if (!exec || isTerminal(exec.status)) continue;
+
+        for (const interest of agent.eventInterests) {
+          const sub: Subscription = {
+            workflowRunId,
+            nodeId: node.id,
+            agentName: agent.name,
+            interest,
+            agentSessionId: exec.agentSessionId,
+            spaceId,
+          };
+
+          // Insert into trie
+          this.topicTrie.insert(interest.topic, sub);
+          runSubs.add(sub);
+        }
+      }
+    }
+
+    this.activeRuns.set(workflowRunId, runSubs);
+  }
+
+  private async handleEvent(event: ExternalEvent): Promise<void> {
+    // 1. Look up matching subscriptions via trie
+    const matched = this.topicTrie.lookup(event.topic);
+
+    if (matched.length === 0) return;
+
+    // 2. For each matched subscription, check scope and deliver
+    for (const sub of matched) {
+      await this.deliverToSubscription(event, sub);
+    }
+  }
+
+  private async deliverToSubscription(event: ExternalEvent, sub: Subscription): Promise<void> {
+    // Scope check
+    if (!this.passesScopeCheck(event, sub)) return;
+
+    // Dedup check
+    const dedupeKey = `${event.dedupeKey}:${sub.agentName}:${sub.workflowRunId}`;
+    if (this.delivered.has(dedupeKey)) return;
+
+    // Resolve session
+    const sessionId = await this.resolveSession(sub);
+    if (!sessionId) {
+      // Session not active — queue for later delivery
+      this.queueForDelivery(event, sub);
+      return;
+    }
+
+    // Format and inject
+    const message = this.formatEventMessage(event);
+    try {
+      await this.sessionFactory.injectMessage(sessionId, message, {
+        deliveryMode: 'defer',
+      });
+
+      // Mark delivered
+      this.delivered.set(dedupeKey, Date.now());
+    } catch (err) {
+      log.warn(`Failed to deliver event to ${sub.agentName}`, { error: err });
+    }
+  }
+
+  private passesScopeCheck(event: ExternalEvent, sub: Subscription): boolean {
+    switch (sub.interest.scope) {
+      case 'global':
+        return true;
+
+      case 'repo': {
+        // Check if event's repo matches any watched repo in this space
+        if (!event.repoOwner || !event.repoName) return false;
+        return this.isWatchedRepo(sub.spaceId, event.repoOwner, event.repoName);
+      }
+
+      case 'task': {
+        // Check if event's PR number matches the subscription's task
+        if (!event.prNumber) return false;
+        const task = this.taskRepo.getByWorkflowRunId(sub.workflowRunId);
+        if (!task) return false;
+        // Reuse the existing SpacePrTaskResolver logic
+        return this.prResolver.resolve(sub.spaceId, {
+          repoOwner: event.repoOwner ?? '',
+          repoName: event.repoName ?? '',
+          prNumber: event.prNumber,
+          // ... minimal shape for resolver
+        } as any).taskId === task.id;
+      }
+    }
+  }
+}
+```
+
+## 5. Event Delivery Lifecycle
+
+### State machine per event delivery
+
+```
+Event arrives → Match subscriptions → Scope check → Dedup check → Session check
+                                                                         │
+                                                          ┌──────────────┼──────────────┐
+                                                          ▼              ▼              ▼
+                                                    Session live   Session idle   No session
+                                                          │              │              │
+                                                          ▼              ▼              ▼
+                                                    Inject via      Wake + inject  Queue in
+                                                    injectMessage   injectMessage  pending_events
+                                                          │              │              │
+                                                          ▼              ▼              ▼
+                                                    Mark delivered  Mark delivered  Await session
+                                                                                     start
+```
+
+### Deduplication
+
+- **Key**: `(event.dedupeKey, subscription.agentName, subscription.workflowRunId)`
+- **Storage**: In-memory `Map<string, number>` (timestamp). Evicted when the workflow run completes.
+- **Guarantee**: Same external event is never delivered twice to the same node agent within a run.
+- The upstream `SpaceGitHubService` already deduplicates by `(spaceId, dedupeKey)` — this is an additional per-node dedup.
+
+### Wake-on-idle
+
+When an event matches a subscription whose node execution is `idle` (agent session exists but finished its turn):
+
+1. Call `sessionFactory.injectMessage(sessionId, message, { deliveryMode: 'defer' })`.
+2. The existing defer mechanism handles waking: if idle → enqueue immediately; if busy → persist as deferred, replay after current turn.
+3. No new wake mechanism needed — the existing `SessionNotificationSink` pattern already solves this.
+
+### Queue for not-yet-started nodes
+
+When a node execution is `pending` (no session yet):
+
+1. The event is queued in an in-memory `Map<executionId, ExternalEvent[]>`.
+2. When `TaskAgentManager` creates the node's session, it checks for queued events.
+3. Queued events are injected as initial context in the session's first turn.
+4. Queue is bounded: max 50 events per execution, oldest dropped (with a warning log).
+
+### Backpressure
+
+- **Rate limiting**: If a single node receives > 10 events per minute, subsequent events are coalesced into a digest message: "N additional events received in the last minute. Summary: ..."
+- **Event TTL**: Events older than 5 minutes are dropped from the queue (they're likely stale for an agent's decision-making).
+- **Bus overflow**: The `EventBus` uses TypedHub's async-everywhere design — slow consumers don't block publishers. Handlers run via `queueMicrotask`.
+
+## 6. Topic Trie Implementation
+
+```typescript
+/**
+ * Simple trie for topic-pattern matching.
+ * Supports * (single segment wildcard) at any position.
+ */
+class TopicTrie<T> {
+  private root = new TrieNode<T>();
+
+  /**
+   * Insert a value at a glob pattern.
+   * Pattern segments: literal match or '*' for wildcard.
+   */
+  insert(pattern: string, value: T): void {
+    const segments = pattern.split('/');
+    let node = this.root;
+    for (const segment of segments) {
+      const key = segment === '*' ? '__wildcard__' : segment.toLowerCase();
+      if (!node.children.has(key)) {
+        node.children.set(key, new TrieNode());
+      }
+      node = node.children.get(key)!;
+    }
+    if (!node.values) node.values = [];
+    node.values.push(value);
+  }
+
+  /**
+   * Lookup all values whose patterns match the given topic.
+   * Returns all values from exact matches AND wildcard matches at each level.
+   * O(depth) — independent of total number of patterns.
+   */
+  lookup(topic: string): T[] {
+    const segments = topic.split('/');
+    const results: T[] = [];
+
+    const walk = (node: TrieNode<T>, depth: number) => {
+      if (depth === segments.length) {
+        // Terminal node — collect values
+        if (node.values) results.push(...node.values);
+        return;
+      }
+
+      const segment = segments[depth].toLowerCase();
+
+      // Exact match
+      const exact = node.children.get(segment);
+      if (exact) walk(exact, depth + 1);
+
+      // Wildcard match
+      const wildcard = node.children.get('__wildcard__');
+      if (wildcard) walk(wildcard, depth + 1);
+    };
+
+    walk(this.root, 0);
+    return results;
+  }
+
+  /**
+   * Remove all values matching a predicate.
+   */
+  remove(predicate: (value: T) => boolean): void {
+    const clean = (node: TrieNode<T>) => {
+      if (node.values) {
+        node.values = node.values.filter(v => !predicate(v));
+      }
+      for (const child of node.children.values()) {
+        clean(child);
+      }
+    };
+    clean(this.root);
+  }
+}
+
+class TrieNode<T> {
+  children: Map<string, TrieNode<T>> = new Map();
+  values?: T[];
+}
+```
+
+**Complexity**:
+- Insert: O(k) where k = segment count (~4-5)
+- Lookup: O(k) — walks trie by segment, collects from exact + wildcard at each level
+- Memory: O(n × k) where n = number of subscriptions
+
+This is O(1) relative to the number of subscriptions — each lookup traverses at most 2^k paths (2 per level: exact + wildcard), and k is small and constant.
+
+## 7. Wiring the GitHub Adapter
+
+### Changes to existing code
+
+**Minimal.** The adapter hooks into the existing `SpaceGitHubService` via DaemonHub subscription:
+
+```
+SpaceGitHubService.handleWebhook()
+    → normalizeSpaceGitHubWebhook()
+    → ingest(spaceId, normalized)
+        → storeEvent() + dedupe
+        → SpacePrTaskResolver.resolve()
+        → appendTaskActivity()
+            → DaemonHub.emit('space.githubEvent.routed', { taskId, event })
+        → scheduleTaskNotification()
+            → injectTaskAgent(taskId, message)
+```
+
+The GitHub adapter subscribes to `space.githubEvent.routed` and converts it:
+
+```typescript
+// No changes to SpaceGitHubService.
+// The adapter is a new subscriber:
+
+class GitHubEventAdapter implements EventAdapter {
+  async start(publisher: EventPublisher): Promise<void> {
+    this.daemonHub.on('space.githubEvent.routed', async (data) => {
+      const { event, taskId } = data;
+
+      // Construct topic from event
+      const topic = `github/${event.repo.split('/')[0]}/${event.repo.split('/')[1]}/${mapEventType(event.eventType)}.${mapAction(event.action)}`;
+
+      // Publish to bus
+      await publisher.publish({
+        id: crypto.randomUUID(),
+        topic,
+        occurredAt: Date.now(),
+        ingestedAt: Date.now(),
+        source: 'github',
+        prNumber: event.prNumber,
+        repoOwner: event.repo.split('/')[0],
+        repoName: event.repo.split('/')[1],
+        summary: event.summary,
+        externalUrl: event.externalUrl,
+        payload: event,
+        dedupeKey: `github:${event.repo}:${event.prNumber}:${event.eventType}:${event.externalUrl}`,
+      });
+    });
+  }
+}
+```
+
+### Event type mapping
+
+The `SpaceGitHubService` already normalizes to `SpaceGitHubEventKind` (`issue_comment`, `pull_request_review`, `pull_request_review_comment`, `pull_request`). We map these to bus topics:
+
+| SpaceGitHubEventKind | Bus topic resource |
+|---|---|
+| `issue_comment` | `pull_request.comment_created` (PR comments only, already filtered) |
+| `pull_request_review` | `pull_request.review_submitted` |
+| `pull_request_review_comment` | `pull_request.review_comment_created` |
+| `pull_request` | `pull_request.{action}` (opened, synchronize, closed, etc.) |
+
+### Task-scoped resolution optimization
+
+For `task` scope, we already have the `taskId` from `space.githubEvent.routed`. The router can short-circuit:
+
+1. Look up which node executions in that task's run have `eventInterests` matching the event.
+2. Only check scope for those nodes — skip the full trie walk for nodes that don't care about this event type.
+
+This optimization turns the common case (one coder node interested in review comments) into a direct map lookup: `taskId → workflowRunId → nodeExecutions → filter by interest topic match`.
+
+## 8. Migration Path
+
+### DB schema changes
+
+None required for V1. Event interests are stored as part of the workflow definition JSON in `space_workflows.nodes[].agents[].eventInterests`. The existing JSON serialization of workflow nodes already supports arbitrary fields.
+
+### Type changes
+
+1. Add `EventInterest` interface to `packages/shared/src/types/space.ts`.
+2. Add `eventInterests?: EventInterest[]` to `WorkflowNodeAgent`.
+3. Add validation in the workflow create/update path (Zod schema or manual validation):
+   - `topic` must be a valid glob pattern (non-empty, no `..` segments).
+   - `scope` must be one of `'task' | 'repo' | 'global'`.
+   - Max 10 interests per agent slot (prevent abuse).
+
+### New files
+
+```
+packages/daemon/src/lib/space/runtime/event-bus/
+  ├── types.ts              # ExternalEvent, EventAdapter, EventPublisher interfaces
+  ├── event-bus.ts           # EventBus singleton (wraps TypedHub)
+  ├── topic-trie.ts          # TopicTrie<T> implementation
+  ├── event-router.ts        # EventRouter — subscribes to bus, matches, delivers
+  ├── github-adapter.ts      # GitHubEventAdapter — bridges SpaceGitHubService → EventBus
+  └── index.ts               # Public exports
+```
+
+### Wiring into SpaceRuntime
+
+```typescript
+// In SpaceRuntimeConfig, add:
+interface SpaceRuntimeConfig {
+  // ... existing fields ...
+  eventBus?: EventBus;  // Optional — created internally if not provided
+}
+
+// In SpaceRuntime.executeTick(), after node executions are resolved:
+if (this.eventRouter) {
+  this.eventRouter.registerRunInterests(
+    spaceId,
+    workflowRunId,
+    workflow,
+    activeNodeExecutions,
+  );
+}
+
+// In daemon startup (e.g. in SpaceRuntimeService or init function):
+const eventBus = new EventBus(daemonHub);
+const eventRouter = new EventRouter(eventBus, ...dependencies);
+const githubAdapter = new GitHubEventAdapter(daemonHub);
+
+await githubAdapter.start(eventBus);
+```
+
+### Phased rollout
+
+**Phase 1 (MVP — this PR):**
+- Add `EventInterest` type to `WorkflowNodeAgent`.
+- Implement `EventBus`, `TopicTrie`, `EventRouter`, `GitHubEventAdapter`.
+- Wire GitHub adapter to existing `space.githubEvent.routed` events.
+- Deliver events to coder nodes with `task` scope.
+- No UI changes needed — event interests are authored in workflow JSON.
+
+**Phase 2 (follow-up):**
+- Add `eventInterests` editor to the workflow visual editor UI.
+- Add event delivery status to the task activity panel.
+- Add digest/coalescing for high-frequency events.
+- Add metrics: events matched, events delivered, delivery latency.
+
+**Phase 3 (future extensibility):**
+- Slack adapter: subscribe to Slack Events API, normalize to `ExternalEvent`, publish.
+- CI adapter: subscribe to GitHub Check Suite events, normalize, publish.
+- Custom adapter API: allow Space operators to register custom adapters via config.
+
+## 9. Relationship to Existing Systems
+
+| Existing system | Relationship |
+|---|---|
+| **DaemonHub / TypedHub** | `EventBus` is a TypedHub participant on the shared `InProcessTransportBus`. The bus uses the same async-everywhere, session-scoped routing that DaemonHub uses. |
+| **GitHubService** (Room pipeline) | Unchanged. Continues routing to Rooms. The event bus is additive. |
+| **SpaceGitHubService** (Space pipeline) | Unchanged. Continues injecting into Task Agent. The GitHub adapter subscribes to `space.githubEvent.routed` as an additional consumer. |
+| **SessionNotificationSink** | The event bus uses the same `sessionFactory.injectMessage()` with `deliveryMode: 'defer'` pattern. |
+| **AgentMessageRouter** | Not used for event delivery. Events are injected directly via `sessionFactory.injectMessage()`, not via the agent-to-agent messaging channel. Events are not agent-originated messages — they're system-injected context. |
+| **ChannelRouter** | Not involved. Event delivery is not a workflow channel transition. It's an injection into an existing session, not an activation trigger. |
+
+## 10. Key Design Decisions
+
+### Why TypedHub and not a standalone EventEmitter?
+
+TypedHub provides:
+- Async-everywhere design (cluster-ready).
+- Session-scoped subscriptions (O(1) lookup).
+- Already wired into the daemon's lifecycle.
+- No new dependency.
+
+Using TypedHub as the backing transport means the EventBus inherits all of these properties for free.
+
+### Why not route through AgentMessageRouter?
+
+AgentMessageRouter is designed for agent-to-agent communication with channel topology authorization. External events are system-injected context, not agent messages. Routing them through AgentMessageRouter would:
+- Require topology changes (events don't come from a declared node).
+- Conflate system events with agent-to-agent messages in the message history.
+- Add unnecessary authorization overhead.
+
+Direct injection via `sessionFactory.injectMessage()` is simpler and semantically correct.
+
+### Why trie-based matching instead of regex?
+
+1. **Performance**: Trie lookup is O(k) per event regardless of subscription count. Regex matching is O(n) per event where n = number of subscriptions.
+2. **Composability**: Trie supports incremental add/remove (subscriptions change as nodes activate/deactivate). Regex requires rebuilding the full pattern.
+3. **Debuggability**: Trie structure can be inspected and visualized. Regex patterns are opaque.
+
+### Why not extend SpaceGitHubService directly?
+
+The adapter pattern separates concerns:
+- `SpaceGitHubService` owns GitHub-specific normalization, dedup, and PR resolution.
+- The event bus is source-agnostic (GitHub, Slack, CI, etc.).
+- The adapter bridges the two without coupling.
+- Future adapters (Slack, CI) don't touch `SpaceGitHubService`.
+
+### Why `deliveryMode: 'defer'` for event injection?
+
+The existing defer mechanism already handles:
+- Idle sessions: message enqueued immediately, processed on next turn.
+- Busy sessions: message persisted as deferred, replayed after current turn.
+- No dropped messages, no interrupted turns.
+
+This is exactly the behavior we want for external events.
+
+## 11. Testing Strategy
+
+### Unit tests
+
+1. **TopicTrie**: Insert patterns, verify lookup returns correct values for exact and wildcard matches.
+2. **EventRouter**: Given subscriptions and events, verify scope filtering, dedup, and delivery.
+3. **GitHubEventAdapter**: Given a `space.githubEvent.routed` event, verify correct `ExternalEvent` construction.
+4. **Scope resolution**: Test `task` scope with various task/PR associations.
+
+### Integration tests
+
+1. End-to-end: webhook → normalize → ingest → bus → router → session injection.
+2. Dedup: same event delivered twice, verify only one injection.
+3. Wake-on-idle: node idle → event arrives → session receives message.
+4. Pending node: event arrives for pending node → session created → event delivered.

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -67,16 +67,19 @@ github/lsm/neokai/pull_request.review_*     ← prefix wildcard: all review even
 ### Matching rules
 
 Subscriptions use glob-style patterns:
-- `*` matches any single path segment (no slashes)
-- Literal segments match exactly (case-insensitive)
+- `*` matches any sequence of characters inside one path segment (no slashes).
+  - A whole-segment `*` matches any single segment (e.g., owner or repo).
+  - A segment-local wildcard also works inside dotted resource/action segments (e.g., `pull_request.*`, `pull_request.review_*`, `*.*`).
+- Literal characters match exactly (case-insensitive).
 
-> **V1 scope note:** The `**` (multi-segment) wildcard is deferred to a follow-up. All v1 use cases are covered by single-segment `*` wildcards at the `owner`, `repo`, or `action` position (e.g., `github/*/*/pull_request.review_submitted`). Adding `**` support requires a depth-bounded recursive trie walk and is not justified by current subscription patterns.
+> **V1 scope note:** The `**` (multi-segment) wildcard is deferred to a follow-up. All v1 use cases are covered by segment-local `*` wildcards at the `owner`, `repo`, or `action` position (e.g., `github/*/*/pull_request.review_submitted`, `github/*/*/pull_request.*`). Adding `**` support requires a depth-bounded recursive trie walk and is not justified by current subscription patterns.
 
 Pattern validation (enforced at workflow create/update time):
 - Must be non-empty.
 - Must not contain `..` segments.
 - Must not contain empty segments (no double slashes).
-- Each segment must be a literal string or `*`.
+- Must have at least 4 segments (`source/owner/repo/resource.action`) so it can match real event topics.
+- Each segment may contain alphanumeric, dash, underscore, dot, and `*`; `*` must stay within a single segment and cannot cross `/` boundaries.
 - Max 10 interests per agent slot.
 
 We implement matching via a **trie-based prefix index** (see §4), not regex.
@@ -350,25 +353,23 @@ For O(1)-ish lookup, we maintain a **topic trie**:
 ```
 root
   └── github
-      └── *                    ← matches any owner
-          └── *                ← matches any repo
-              ├── pull_request
-              │   ├── *        ← all PR actions
-              │   │   └── [subscriptions: coder(task), ...]
-              │   ├── review_submitted
-              │   │   └── [subscriptions: coder(task)]
-              │   └── comment_created
-              │       └── [subscriptions: coder(task)]
-              └── check_suite
-                  └── completed
-                      └── [subscriptions: ci-monitor(repo)]
+      └── *                          ← matches any owner
+          └── *                      ← matches any repo
+              ├── pull_request.*     ← all PR actions
+              │   └── [subscriptions: coder(task), ...]
+              ├── pull_request.review_submitted
+              │   └── [subscriptions: coder(task)]
+              ├── pull_request.comment_created
+              │   └── [subscriptions: coder(task)]
+              └── check_suite.completed
+                  └── [subscriptions: ci-monitor(repo)]
 ```
 
-The trie maps topic segments to `Set<Subscription>` at leaf nodes. Wildcard segments (`*`) match any single segment at that depth.
+The trie maps topic segments to `Set<Subscription>` at leaf nodes. Each node stores exact children separately from segment-local glob children. A glob segment may be a whole-segment wildcard (`*`) or a dotted segment wildcard (`pull_request.*`, `pull_request.review_*`, `*.*`).
 
 **Build cost**: O(n × k) where n = number of subscriptions, k = topic depth (typically 4-5). Built once when a workflow run starts.
 
-**Lookup cost**: The trie walks both exact-match and wildcard branches at each level. With k levels, this produces at most 2^k paths. At each leaf, m subscriptions are collected. Total cost per lookup is O(2^k × m) where m is the total number of matching subscriptions across all leaves. Since k is small and bounded (4–5 topic segments), 2^k is a small constant (16–32). The real benefit over linear scan is that non-matching subscriptions are never visited — only subscriptions whose pattern segments align with the event's topic are collected.
+**Lookup cost**: The trie walks the exact branch (O(1)) and any glob-child branches at each level. With k bounded to 4–5 segments and max 10 interests per agent slot, the number of glob branches is small. In the common case this remains effectively O(2^k × m), where m is the total number of matching subscriptions across collected leaves. The real benefit over linear scan is that non-matching subscriptions are never visited — only subscriptions whose pattern segments align with the event's topic are collected.
 
 ### Subscription index lifecycle
 
@@ -383,6 +384,8 @@ The index is **per-SpaceRuntime instance** and updated via two distinct operatio
 ```typescript
 interface Subscription {
   workflowRunId: string;
+  /** The specific SpaceTask this node execution belongs to. Used for `task` scope. */
+  taskId: string;
   nodeId: string;
   agentName: string;
   interest: EventInterest;    // from the workflow definition
@@ -470,11 +473,13 @@ class EventRouter {
   registerRunInterests(
     spaceId: string,
     workflowRunId: string,
+    /** The task whose tick/session activation is being processed. */
+    taskId: string,
     workflow: SpaceWorkflow,
     nodeExecutions: NodeExecution[],
   ): void {
     // Build the desired set of subscriptions from current node execution states.
-    const desiredSubs = new Map<string, Subscription>();  // key: `${nodeId}:${agentName}`
+    const desiredSubs = new Map<string, Subscription>();  // key: `${taskId}:${nodeId}:${agentName}:${topic}:${scope}`
 
     for (const node of workflow.nodes) {
       for (const agent of node.agents) {
@@ -485,13 +490,15 @@ class EventRouter {
         );
         if (!exec || !isReceivingStatus(exec.status)) continue;
 
-        const subKey = `${node.id}:${agent.name}`;
+        const subKey = `${taskId}:${node.id}:${agent.name}`;
         for (const interest of agent.eventInterests) {
-          // Include topic AND scope in key — same agent can subscribe to the same topic
-          // with different scopes (e.g., both 'task' and 'repo' scope for the same pattern).
+          // Include taskId, topic, and scope in key — the same run can contain
+          // multiple tasks, and the same agent can subscribe to the same topic
+          // with different scopes (e.g., both 'task' and 'repo' scope).
           const fullKey = `${subKey}:${interest.topic}:${interest.scope}`;
           desiredSubs.set(fullKey, {
             workflowRunId,
+            taskId,
             nodeId: node.id,
             agentName: agent.name,
             interest,
@@ -502,22 +509,26 @@ class EventRouter {
       }
     }
 
-    // Diff against current subscriptions for this run.
-    const currentSubs = this.activeRuns.get(workflowRunId) ?? new Set<Subscription>();
+    // Diff against current subscriptions for THIS task only. A workflow run can
+    // contain multiple tasks, so refreshing task A must not remove task B's
+    // subscriptions from the same run.
+    const currentRunSubs = this.activeRuns.get(workflowRunId) ?? new Set<Subscription>();
+    const currentTaskSubs = [...currentRunSubs].filter(sub => sub.taskId === taskId);
     const currentKeys = new Set<string>();
-    for (const sub of currentSubs) {
-      currentKeys.add(`${sub.nodeId}:${sub.agentName}:${sub.interest.topic}:${sub.interest.scope}`);
+    for (const sub of currentTaskSubs) {
+      currentKeys.add(`${sub.taskId}:${sub.nodeId}:${sub.agentName}:${sub.interest.topic}:${sub.interest.scope}`);
     }
     const desiredKeys = new Set(desiredSubs.keys());
 
-    // Remove subscriptions no longer in the desired set (e.g. node went cancelled).
+    // Remove this task's subscriptions no longer in the desired set (e.g. node went cancelled).
     for (const key of currentKeys) {
       if (!desiredKeys.has(key)) {
-        const [nodeId, agentName, ...rest] = key.split(':');
+        const [subTaskId, nodeId, agentName, ...rest] = key.split(':');
         const scope = rest.pop()!;
         const topic = rest.join(':');
         this.topicTrie.remove(
           v => v.workflowRunId === workflowRunId
+            && v.taskId === subTaskId
             && v.nodeId === nodeId
             && v.agentName === agentName
             && v.interest.topic === topic
@@ -533,8 +544,10 @@ class EventRouter {
       }
     }
 
-    // Replace active run set with the new desired set.
-    this.activeRuns.set(workflowRunId, new Set(desiredSubs.values()));
+    // Replace only this task's active subscriptions while preserving other tasks
+    // in the same workflow run.
+    const preservedOtherTaskSubs = [...currentRunSubs].filter(sub => sub.taskId !== taskId);
+    this.activeRuns.set(workflowRunId, new Set([...preservedOtherTaskSubs, ...desiredSubs.values()]));
   }
 
   /**
@@ -585,7 +598,7 @@ class EventRouter {
     this.activeRuns.delete(workflowRunId);
 
     // Also clean up dedup entries for this run.
-    // Delivery keys are: `${event.dedupeKey}:${sub.nodeId}:${sub.agentName}:${workflowRunId}`
+    // Delivery keys are: `${event.dedupeKey}:${sub.taskId}:${sub.nodeId}:${sub.agentName}:${workflowRunId}`
     // The run ID is the final segment — match with suffix `:${workflowRunId}`.
     const suffix = `:${workflowRunId}`;
     for (const key of this.delivered.keys()) {
@@ -595,8 +608,8 @@ class EventRouter {
     }
 
     // Clean up in-memory pending queue for this run.
-    // Keys are `${workflowRunId}:${nodeId}:${agentName}` — use the delimiter
-    // to avoid false prefix matches (e.g., run "abc1" matching "abc10:*").
+    // Keys are `${workflowRunId}:${taskId}:${nodeId}:${agentName}` — use the
+    // delimiter to avoid false prefix matches (e.g., run "abc1" matching "abc10:*").
     const runPrefix = `${workflowRunId}:`;
     for (const [key, events] of this.pendingQueue.entries()) {
       if (key.startsWith(runPrefix)) {
@@ -621,10 +634,10 @@ class EventRouter {
     // Scope check
     if (!this.passesScopeCheck(event, sub)) return;
 
-    // Dedup check — include nodeId to handle cases where the same agent name
-    // appears in multiple nodes within the same run (e.g., two "Reviewer" agents
-    // in different nodes). Each node-execution is deduped independently.
-    const dedupeKey = `${event.dedupeKey}:${sub.nodeId}:${sub.agentName}:${sub.workflowRunId}`;
+    // Dedup check — include taskId and nodeId to handle multi-task runs and
+    // cases where the same agent name appears in multiple nodes within the same
+    // run. Each task/node/agent subscription is deduped independently.
+    const dedupeKey = `${event.dedupeKey}:${sub.taskId}:${sub.nodeId}:${sub.agentName}:${sub.workflowRunId}`;
     if (this.delivered.has(dedupeKey)) return;
 
     // Mark dedup BEFORE session resolution / queueing. This prevents the same
@@ -684,31 +697,26 @@ class EventRouter {
         // of re-running the resolver, which could match a historical task outside
         // this run (SpacePrTaskResolver searches ALL tasks in the space).
         //
-        // We constrain matching to tasks within THIS workflow run only:
-        // 1. Load all non-archived tasks for this run.
-        // 2. Check if the event's routed taskId is among them.
+        // We constrain matching to the subscription's OWN task, not merely any
+        // task in the same workflow run. This prevents cross-task leakage in
+        // multi-task runs (e.g., two PR tasks sharing a workflowRunId).
         if (!event.prNumber) return false;
 
         // Optimization: the adapter includes the routed taskId in ExternalEvent.payload.
-        // Use it for a direct membership check — no resolver call needed.
+        // Use it for a direct equality check against this subscription's task.
         const routedTaskId = event.payload?.taskId as string | undefined;
         if (routedTaskId) {
-          const tasks = this.taskRepo.listByWorkflowRun(sub.workflowRunId);
-          return tasks.some(t => t.id === routedTaskId);
+          return routedTaskId === sub.taskId;
         }
 
         // Fallback (should rarely happen): if the adapter didn't include taskId,
-        // load run tasks and check if any references the event's PR number.
-        const tasks = this.taskRepo.listByWorkflowRun(sub.workflowRunId);
-        for (const task of tasks) {
-          const resolved = this.prResolver.resolve(sub.spaceId, {
-            repoOwner: event.repoOwner ?? '',
-            repoName: event.repoName ?? '',
-            prNumber: event.prNumber,
-          } as any);
-          if (resolved.taskId === task.id) return true;
-        }
-        return false;
+        // resolve by PR and require that the resolver points to THIS task.
+        const resolved = this.prResolver.resolve(sub.spaceId, {
+          repoOwner: event.repoOwner ?? '',
+          repoName: event.repoName ?? '',
+          prNumber: event.prNumber,
+        } as any);
+        return resolved.taskId === sub.taskId;
       }
     }
   }
@@ -737,7 +745,7 @@ Event arrives → Match subscriptions → Scope check → Dedup check → Sessio
 
 ### Deduplication
 
-- **Key**: `(event.dedupeKey, subscription.nodeId, subscription.agentName, subscription.workflowRunId)` — includes `nodeId` to handle cases where the same agent name appears in multiple nodes within the same run.
+- **Key**: `(event.dedupeKey, subscription.taskId, subscription.nodeId, subscription.agentName, subscription.workflowRunId)` — includes `taskId` to isolate multi-task runs and `nodeId` to handle cases where the same agent name appears in multiple nodes within the same run.
 - **Storage**: In-memory `Map<string, number>` (timestamp). Evicted when the workflow run completes.
 - **Guarantee**: Same external event is never delivered twice to the same node agent within a run.
 - The upstream `SpaceGitHubService` already deduplicates by `(spaceId, dedupeKey)` — this is an additional per-node dedup.
@@ -754,7 +762,7 @@ When an event matches a subscription whose node execution is `idle` (agent sessi
 
 When a node execution is `pending` (no session yet):
 
-1. The event is queued in an in-memory `Map<string, ExternalEvent[]>` keyed by `${workflowRunId}:${nodeId}:${agentName}`.
+1. The event is queued in an in-memory `Map<string, ExternalEvent[]>` keyed by `${workflowRunId}:${taskId}:${nodeId}:${agentName}`.
 2. When `TaskAgentManager` creates the node's session, it checks for queued events.
 3. Queued events are injected as initial context in the session's first turn.
 4. Queue is bounded: max 50 events per execution, oldest dropped (with a warning log).
@@ -784,17 +792,19 @@ class TopicTrie<T> {
 
   /**
    * Insert a value at a glob pattern.
-   * Pattern segments: literal match or '*' for wildcard.
+   * Pattern segments may contain segment-local `*` wildcards, e.g.
+   * `github/*/*/pull_request.*` or `github/*/*/pull_request.review_*`.
    */
   insert(pattern: string, value: T): void {
     const segments = pattern.split('/');
     let node = this.root;
     for (const segment of segments) {
-      const key = segment === '*' ? '__wildcard__' : segment.toLowerCase();
-      if (!node.children.has(key)) {
-        node.children.set(key, new TrieNode());
+      const key = segment.toLowerCase();
+      const children = key.includes('*') ? node.globChildren : node.exactChildren;
+      if (!children.has(key)) {
+        children.set(key, new TrieNode());
       }
-      node = node.children.get(key)!;
+      node = children.get(key)!;
     }
     if (!node.values) node.values = [];
     node.values.push(value);
@@ -820,13 +830,16 @@ class TopicTrie<T> {
 
       const segment = segments[depth].toLowerCase();
 
-      // Exact match
-      const exact = node.children.get(segment);
+      // Exact branch: O(1)
+      const exact = node.exactChildren.get(segment);
       if (exact) walk(exact, depth + 1);
 
-      // Wildcard match
-      const wildcard = node.children.get('__wildcard__');
-      if (wildcard) walk(wildcard, depth + 1);
+      // Glob branches: only patterns that contain segment-local '*'
+      for (const [patternSegment, child] of node.globChildren.entries()) {
+        if (segmentMatches(patternSegment, segment)) {
+          walk(child, depth + 1);
+        }
+      }
     };
 
     walk(this.root, 0);
@@ -841,7 +854,10 @@ class TopicTrie<T> {
       if (node.values) {
         node.values = node.values.filter(v => !predicate(v));
       }
-      for (const child of node.children.values()) {
+      for (const child of node.exactChildren.values()) {
+        clean(child);
+      }
+      for (const child of node.globChildren.values()) {
         clean(child);
       }
     };
@@ -849,8 +865,26 @@ class TopicTrie<T> {
   }
 }
 
+function segmentMatches(pattern: string, segment: string): boolean {
+  if (pattern === segment) return true;
+  if (!pattern.includes('*')) return false;
+
+  // Segment-local glob: '*' matches any characters except '/'. Because callers
+  // split on '/', the segment input never contains '/'. Escape other regex chars.
+  const regex = new RegExp(
+    '^' + pattern.split('*').map(escapeRegex).join('[^/]*') + '$',
+    'i',
+  );
+  return regex.test(segment);
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 class TrieNode<T> {
-  children: Map<string, TrieNode<T>> = new Map();
+  exactChildren: Map<string, TrieNode<T>> = new Map();
+  globChildren: Map<string, TrieNode<T>> = new Map();
   values?: T[];
 }
 ```
@@ -892,7 +926,7 @@ function isReceivingStatus(status: NodeExecutionStatus): boolean {
 
 **Complexity**:
 - Insert: O(k) where k = segment count (~4-5)
-- Lookup: O(2^k × m) — walks at most 2^k paths (exact + wildcard at each level), collects m total matching subscriptions from leaves. Since k is bounded (4–5), 2^k is a small constant.
+- Lookup: Effectively O(2^k × m) in the common case — walks exact + matching glob branches at each level, collects m total matching subscriptions from leaves. Since k is bounded (4–5) and per-agent interest count is capped, glob branching stays small.
 - Memory: O(n × k) where n = number of subscriptions
 
 ## 7. Wiring the GitHub Adapter
@@ -985,23 +1019,23 @@ function mapEventType(kind: string, action: string): string {
 
 For `task` scope, we already have the `taskId` from `space.githubEvent.routed`. The router can short-circuit:
 
-1. Look up which node executions in that task's run have `eventInterests` matching the event.
-2. Only check scope for those nodes — skip the full trie walk for nodes that don't care about this event type.
+1. Look up subscriptions whose `sub.taskId` equals the routed event `taskId` and whose `eventInterests` match the topic.
+2. Only deliver to those task-owned subscriptions — nodes attached to other tasks in the same workflow run do not pass `task` scope.
 
-This optimization turns the common case (one coder node interested in review comments) into a direct map lookup: `taskId → workflowRunId → nodeExecutions → filter by interest topic match`.
+This optimization turns the common case (one coder node interested in review comments) into a direct map lookup: `taskId → subscriptions → filter by interest topic match`.
 
 ## 8. Migration Path
 
 ### DB schema changes
 
-None required for V1. Event interests are stored as part of the workflow definition JSON in `space_workflows.nodes[].agents[].eventInterests`. The existing JSON serialization of workflow nodes already supports arbitrary fields.
+No new tables required for V1. Event interests are stored as part of the workflow definition JSON in `space_workflows.nodes[].agents[].eventInterests`. The existing JSON serialization of workflow nodes already supports arbitrary fields. Task-scoped delivery uses the current `SpaceTask.id` passed into `registerRunInterests(...)` by the runtime and the routed `taskId` already emitted by `space.githubEvent.routed`; no node-execution schema change is required.
 
 ### Type changes
 
 1. Add `EventInterest` interface to `packages/shared/src/types/space.ts`.
 2. Add `eventInterests?: EventInterest[]` to `WorkflowNodeAgent`.
 3. Add validation in the workflow create/update path (Zod schema or manual validation):
-   - `topic` must pass `validateGlobPattern()` (non-empty, no `..` segments, no double slashes, valid characters).
+   - `topic` must pass `validateGlobPattern()` (non-empty, at least 4 segments, no `..` segments, no double slashes, valid characters including segment-local `*`).
    - `scope` must be one of `'task' | 'repo' | 'global'`.
    - Max 10 interests per agent slot (prevent abuse).
    - `validateGlobPattern()` is the single source of truth — called at workflow create/update and again at trie insertion time as a safety net.
@@ -1055,10 +1089,13 @@ export function validateGlobPattern(pattern: string): { valid: boolean; reason?:
     if (segment === '..') {
       return { valid: false, reason: 'Topic pattern must not contain ".." segments' };
     }
-    if (segment !== '*' && !/^[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*$/.test(segment)) {
+    if (segment === '**') {
+      return { valid: false, reason: 'Multi-segment "**" wildcard is not supported in v1' };
+    }
+    if (!/^[a-zA-Z0-9_.*-]+$/.test(segment)) {
       return {
         valid: false,
-        reason: `Segment "${segment}" contains invalid characters. Use alphanumeric, dash, underscore, or dot. Use "*" for wildcard.`,
+        reason: `Segment "${segment}" contains invalid characters. Use alphanumeric, dash, underscore, dot, or segment-local "*" wildcard.`,
       };
     }
   }
@@ -1082,6 +1119,7 @@ if (this.eventRouter) {
   this.eventRouter.registerRunInterests(
     spaceId,
     workflowRunId,
+    taskId, // current task whose tick/session activation is being processed
     workflow,
     activeNodeExecutions,
   );

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -147,7 +147,7 @@ export interface WorkflowNodeAgent {
             "label": "PR comments on my task's PR"
           },
           {
-            "topic": "github/*/*/pull_request_review_comment.*",
+            "topic": "github/*/*/pull_request.review_comment_created",
             "scope": "task",
             "label": "Inline review comments"
           }
@@ -559,8 +559,10 @@ class EventRouter {
     // Scope check
     if (!this.passesScopeCheck(event, sub)) return;
 
-    // Dedup check
-    const dedupeKey = `${event.dedupeKey}:${sub.agentName}:${sub.workflowRunId}`;
+    // Dedup check — include nodeId to handle cases where the same agent name
+    // appears in multiple nodes within the same run (e.g., two "Reviewer" agents
+    // in different nodes). Each node-execution is deduped independently.
+    const dedupeKey = `${event.dedupeKey}:${sub.nodeId}:${sub.agentName}:${sub.workflowRunId}`;
     if (this.delivered.has(dedupeKey)) return;
 
     // Resolve session — re-read from nodeExecutionRepo for latest state
@@ -656,7 +658,7 @@ Event arrives → Match subscriptions → Scope check → Dedup check → Sessio
 
 ### Deduplication
 
-- **Key**: `(event.dedupeKey, subscription.agentName, subscription.workflowRunId)`
+- **Key**: `(event.dedupeKey, subscription.nodeId, subscription.agentName, subscription.workflowRunId)` — includes `nodeId` to handle cases where the same agent name appears in multiple nodes within the same run.
 - **Storage**: In-memory `Map<string, number>` (timestamp). Evicted when the workflow run completes.
 - **Guarantee**: Same external event is never delivered twice to the same node agent within a run.
 - The upstream `SpaceGitHubService` already deduplicates by `(spaceId, dedupeKey)` — this is an additional per-node dedup.

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -78,7 +78,7 @@ Pattern validation (enforced at workflow create/update time):
 - Must be non-empty.
 - Must not contain `..` segments.
 - Must not contain empty segments (no double slashes).
-- Must have at least 4 segments (`source/owner/repo/resource.action`) so it can match real event topics.
+- Must have exactly 4 segments (`source/owner/repo/resource.action`) so it can match real event topics.
 - Each segment may contain alphanumeric, dash, underscore, dot, and `*`; `*` must stay within a single segment and cannot cross `/` boundaries.
 - Max 10 interests per agent slot.
 
@@ -643,6 +643,8 @@ class EventRouter {
     // Dedup check — include taskId and nodeId to handle multi-task runs and
     // cases where the same agent name appears in multiple nodes within the same
     // run. Each task/node/agent subscription is deduped independently.
+    // Evict before checking so DEDUP_TTL_MS is actually enforced during long runs.
+    this.evictStaleDedup();
     const dedupeKey = `${event.dedupeKey}:${sub.taskId}:${sub.nodeId}:${sub.agentName}:${sub.workflowRunId}`;
     if (this.delivered.has(dedupeKey)) return;
 
@@ -1039,7 +1041,7 @@ No new tables required for V1. Event interests are stored as part of the workflo
 1. Add `EventInterest` interface to `packages/shared/src/types/space.ts`.
 2. Add `eventInterests?: EventInterest[]` to `WorkflowNodeAgent`.
 3. Add validation in the workflow create/update path (Zod schema or manual validation):
-   - `topic` must pass `validateGlobPattern()` (non-empty, at least 4 segments, no `..` segments, no double slashes, valid characters including segment-local `*`).
+   - `topic` must pass `validateGlobPattern()` (non-empty, exactly 4 segments, no `..` segments, no double slashes, valid characters including segment-local `*`).
    - `scope` must be one of `'task' | 'repo' | 'global'`.
    - Max 10 interests per agent slot (prevent abuse).
    - `validateGlobPattern()` is the single source of truth — called at workflow create/update and again at trie insertion time as a safety net.
@@ -1067,10 +1069,11 @@ packages/daemon/src/lib/space/runtime/event-bus/
  * Rejects patterns that could corrupt the trie or match unintended topics.
  * Called at workflow create/update time and again at trie insertion time.
  *
- * Requires at least 4 segments because all event topics have the format
- * `{source}/{owner}/{repo}/{resource}.{action}` (4 segments minimum).
- * Patterns like `github/*` would pass validation but never match any event,
- * creating silent misconfigurations.
+ * Requires exactly 4 segments because all v1 event topics have the format
+ * `{source}/{owner}/{repo}/{resource}.{action}`.
+ * Patterns like `github/*` (too shallow) or `github/*/*/pull_request/review_*`
+ * (too deep) would pass validation but never match any event, creating silent
+ * misconfigurations.
  */
 export function validateGlobPattern(pattern: string): { valid: boolean; reason?: string } {
   if (!pattern || pattern.trim().length === 0) {
@@ -1079,10 +1082,10 @@ export function validateGlobPattern(pattern: string): { valid: boolean; reason?:
 
   const segments = pattern.split('/');
 
-  if (segments.length < 4) {
+  if (segments.length !== 4) {
     return {
       valid: false,
-      reason: `Topic pattern must have at least 4 segments (source/owner/repo/resource.action); got ${segments.length}. Example: 'github/*/*/pull_request.review_submitted'`,
+      reason: `Topic pattern must have exactly 4 segments (source/owner/repo/resource.action); got ${segments.length}. Example: 'github/*/*/pull_request.review_submitted'`,
     };
   }
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -424,7 +424,7 @@ interface Subscription {
 ```typescript
 class EventRouter {
   // topic trie for fast lookup
-  private topicTrie: TopicTrie<Subscription[]> = new TopicTrie();
+  private topicTrie: TopicTrie<Subscription> = new TopicTrie();
 
   // track which runs have active subscriptions (for lifecycle management)
   private activeRuns: Map<string, Set<Subscription>> = new Map();

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -453,7 +453,14 @@ class EventRouter {
     this.eventBus.subscribe(EXTERNAL_EVENT_PUBLISHED_METHOD, ({ spaceId, event }) => {
       // Defense in depth: payload spaceId and event.spaceId must agree.
       if (event.spaceId !== spaceId) return;
-      void this.handleEvent(event);
+      void this.handleEvent(event).catch((err) => {
+        log.warn('EventRouter: failed to route external event', {
+          error: err,
+          spaceId,
+          topic: event.topic,
+          eventId: event.id,
+        });
+      });
     });
   }
 
@@ -660,9 +667,24 @@ class EventRouter {
 
     if (matched.length === 0) return;
 
-    // 2. For each matched subscription, check scope and deliver
+    // 2. For each matched subscription, check scope and deliver.
+    // Isolate failures per subscription so one bad repo/task lookup or injection
+    // does not prevent other interested nodes from receiving the same event.
     for (const sub of matched) {
-      await this.deliverToSubscription(event, sub);
+      try {
+        await this.deliverToSubscription(event, sub);
+      } catch (err) {
+        log.warn('EventRouter: failed to deliver external event to subscription', {
+          error: err,
+          spaceId: event.spaceId,
+          topic: event.topic,
+          eventId: event.id,
+          workflowRunId: sub.workflowRunId,
+          taskId: sub.taskId,
+          nodeId: sub.nodeId,
+          agentName: sub.agentName,
+        });
+      }
     }
   }
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -530,10 +530,12 @@ class EventRouter {
     this.topicTrie.remove(v => v.workflowRunId === workflowRunId);
     this.activeRuns.delete(workflowRunId);
 
-    // Also clean up dedup entries for this run
-    const prefix = `:${workflowRunId}:`;
+    // Also clean up dedup entries for this run.
+    // Delivery keys are: `${event.dedupeKey}:${sub.nodeId}:${sub.agentName}:${workflowRunId}`
+    // The run ID is the final segment — match with suffix `:${workflowRunId}`.
+    const suffix = `:${workflowRunId}`;
     for (const key of this.delivered.keys()) {
-      if (key.includes(prefix)) {
+      if (key.endsWith(suffix)) {
         this.delivered.delete(key);
       }
     }

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -372,11 +372,13 @@ The trie maps topic segments to `Set<Subscription>` at leaf nodes. Wildcard segm
 
 ### Subscription index lifecycle
 
-The index is **per-SpaceRuntime instance** and rebuilt when:
+The index is **per-SpaceRuntime instance** and updated via two distinct operations:
 
-1. A workflow run starts (node executions are created with interests from the workflow definition).
-2. A node execution transitions to a new status (e.g. `in_progress` → starts receiving events; `idle`/`cancelled` → removed from index).
-3. A workflow definition is updated (interests may have changed — next run picks up changes).
+1. **`registerRunInterests`** (called on every `executeTick`): Diff-based trie update. Compares current node execution states against existing subscriptions. Adds subscriptions for newly active nodes, removes subscriptions for `cancelled` nodes. Does NOT touch the dedup map or pending queue — those are preserved across tick refreshes.
+
+2. **`clearRunInterests`** (called only on `done`/`cancelled` terminal transitions): Full teardown. Removes all trie subscriptions, dedup entries, and pending queue entries for the run. NOT called on `blocked` transitions because blocked is resumable.
+
+3. A workflow definition is updated (interests may have changed — next `registerRunInterests` call picks up changes via the diff).
 
 ```typescript
 interface Subscription {
@@ -443,8 +445,12 @@ class EventRouter {
   }
 
   /**
-   * Register all event interests for a workflow run.
-   * Called when a workflow run starts or when node executions change.
+   * Refresh event interests for a workflow run based on current node execution states.
+   * Called on every executeTick to keep the trie in sync with node lifecycle changes.
+   *
+   * This is a DIFF-BASED update — it only adds/removes trie subscriptions for nodes
+   * whose status has changed. It does NOT touch the dedup map or pending queue.
+   * Terminal-run cleanup (dedup + pending) is handled exclusively by `clearRunInterests`.
    */
   registerRunInterests(
     spaceId: string,
@@ -452,39 +458,65 @@ class EventRouter {
     workflow: SpaceWorkflow,
     nodeExecutions: NodeExecution[],
   ): void {
-    // Clear previous subscriptions for this run
-    this.clearRunInterests(workflowRunId);
-
-    const runSubs = new Set<Subscription>();
+    // Build the desired set of subscriptions from current node execution states.
+    const desiredSubs = new Map<string, Subscription>();  // key: `${nodeId}:${agentName}`
 
     for (const node of workflow.nodes) {
       for (const agent of node.agents) {
         if (!agent.eventInterests?.length) continue;
 
-        // Only register if this node has at least one active (non-terminal) execution
         const exec = nodeExecutions.find(
           e => e.workflowNodeId === node.id && e.agentName === agent.name
         );
         if (!exec || !isReceivingStatus(exec.status)) continue;
 
+        const subKey = `${node.id}:${agent.name}`;
         for (const interest of agent.eventInterests) {
-          const sub: Subscription = {
+          // Include interest topic in key so a single agent can have multiple interests
+          const fullKey = `${subKey}:${interest.topic}`;
+          desiredSubs.set(fullKey, {
             workflowRunId,
             nodeId: node.id,
             agentName: agent.name,
             interest,
             agentSessionId: exec.agentSessionId,
             spaceId,
-          };
-
-          // Insert into trie
-          this.topicTrie.insert(interest.topic, sub);
-          runSubs.add(sub);
+          });
         }
       }
     }
 
-    this.activeRuns.set(workflowRunId, runSubs);
+    // Diff against current subscriptions for this run.
+    const currentSubs = this.activeRuns.get(workflowRunId) ?? new Set<Subscription>();
+    const currentKeys = new Set<string>();
+    for (const sub of currentSubs) {
+      currentKeys.add(`${sub.nodeId}:${sub.agentName}:${sub.interest.topic}`);
+    }
+    const desiredKeys = new Set(desiredSubs.keys());
+
+    // Remove subscriptions no longer in the desired set (e.g. node went cancelled).
+    for (const key of currentKeys) {
+      if (!desiredKeys.has(key)) {
+        const [nodeId, agentName, ...topicParts] = key.split(':');
+        const topic = topicParts.join(':');
+        this.topicTrie.remove(
+          v => v.workflowRunId === workflowRunId
+            && v.nodeId === nodeId
+            && v.agentName === agentName
+            && v.interest.topic === topic,
+        );
+      }
+    }
+
+    // Add new subscriptions not currently in the trie.
+    for (const [key, sub] of desiredSubs) {
+      if (!currentKeys.has(key)) {
+        this.topicTrie.insert(sub.interest.topic, sub);
+      }
+    }
+
+    // Replace active run set with the new desired set.
+    this.activeRuns.set(workflowRunId, new Set(desiredSubs.values()));
   }
 
   /**
@@ -1019,6 +1051,7 @@ interface SpaceRuntimeConfig {
 }
 
 // In SpaceRuntime.executeTick(), after node executions are resolved:
+// This does a DIFF-BASED update of trie subscriptions. Safe to call on every tick.
 if (this.eventRouter) {
   this.eventRouter.registerRunInterests(
     spaceId,
@@ -1026,6 +1059,12 @@ if (this.eventRouter) {
     workflow,
     activeNodeExecutions,
   );
+}
+
+// In the workflow run status transition handler:
+// Called ONLY on truly terminal transitions (done, cancelled) — NOT on blocked.
+if (newStatus === 'done' || newStatus === 'cancelled') {
+  this.eventRouter.clearRunInterests(workflowRunId);
 }
 
 // In daemon startup (e.g. in SpaceRuntimeService or init function):

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -318,11 +318,13 @@ this.daemonHub?.emit('space.githubEvent.routed', {
         summary: event.summary,
         externalUrl: event.externalUrl,
         rawPayload: event.rawPayload,   // ← ADD THIS (for adapter consumers)
+        dedupeKey: event.dedupeKey,    // ← ADD THIS (for adapter deduplication)
+        deliveryId: event.deliveryId, // ← ADD THIS (unique GitHub delivery ID)
     },
 });
 ```
 
-This is a two-field addition to `appendTaskActivity` — both `action` and `rawPayload` are already available on the `NormalizedSpaceGitHubEvent` at the call site. This is the only change to existing code.
+This is a four-field addition to `appendTaskActivity` — `action`, `rawPayload`, `dedupeKey`, and `deliveryId` are all already available on the `NormalizedSpaceGitHubEvent` at the call site. This is the only change to existing code.
 
 **Why this approach:**
 - Minimal change to the existing `SpaceGitHubService` — two additional fields in an existing DaemonHub emission.
@@ -879,7 +881,7 @@ class GitHubEventAdapter implements EventAdapter {
           taskId,
           rawPayload: event.rawPayload,   // Include original webhook/polling payload
         },
-        dedupeKey: `github:${event.repo}:${event.prNumber}:${event.eventType}:${event.action}:${event.externalUrl}`,
+        dedupeKey: event.dedupeKey,  // Use upstream identity (includes deliveryId); avoids collapsing distinct events that share repo/pr/action/url
       });
     });
   }

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -25,11 +25,11 @@ External Event Sources (GitHub webhook, polling, future: Slack, CI)
 │  EventIngestion     │  Normalize → validate → publish to EventBus
 │  (adapter per source│
 └────────┬────────────┘
-         │ publish(topic, payload)
+         │ publish(event) → hub.emit('space.externalEvent.published', { event })
          ▼
 ┌─────────────────────┐
-│  EventBus           │  In-memory, backed by TypedHub. Namespaced topics.
-│  (singleton)        │  O(1) subscriber lookup by topic pattern.
+│  EventBus           │  In-memory, backed by TypedHub. External topic is payload data.
+│  (singleton)        │  Fixed TypedHub-safe method; router trie matches event.topic.
 └────────┬────────────┘
          │
          ▼
@@ -269,6 +269,20 @@ export interface EventAdapter {
 export interface EventPublisher {
   publish(event: ExternalEvent): Promise<void>;
 }
+
+/**
+ * TypedHub/MessageHub method used by EventBus.
+ *
+ * IMPORTANT: raw external topics (e.g. `github/lsm/neokai/pull_request.opened`)
+ * are NOT used as TypedHub method names because MessageHub validates methods
+ * with `[a-zA-Z0-9._-]`, requires a dot, and rejects `/` and `*`.
+ * The external topic stays in `ExternalEvent.topic` and is matched by EventRouter.
+ */
+export const EXTERNAL_EVENT_PUBLISHED_METHOD = 'space.externalEvent.published';
+
+export interface EventBusHubEventMap {
+  'space.externalEvent.published': { event: ExternalEvent };
+}
 ```
 
 ### GitHub adapter
@@ -347,11 +361,12 @@ This is a payload-contract extension to `appendTaskActivity` using fields alread
 
 ### Architecture
 
-The `EventRouter` subscribes to all topics on the `EventBus`. When an event arrives, it:
+The `EventRouter` subscribes to the fixed TypedHub-safe EventBus method (`space.externalEvent.published`). When an event arrives, it:
 
-1. Looks up all active node executions that have `eventInterests`.
-2. For each matching interest, checks scope.
-3. Delivers the event to the matching node's agent session.
+1. Reads the external topic from `event.topic` in the payload.
+2. Looks up all active node executions that have `eventInterests` matching that payload topic.
+3. For each matching interest, checks scope.
+4. Delivers the event to the matching node's agent session.
 
 ### Trie-based subscription index
 
@@ -430,8 +445,9 @@ class EventRouter {
     private readonly prResolver: SpacePrTaskResolver,
     private readonly spaceGitHubRepo: SpaceGitHubRepository,
   ) {
-    // Subscribe to ALL events on the bus
-    this.eventBus.subscribe('*', this.handleEvent.bind(this));
+    // Subscribe to the fixed TypedHub-safe method. External topic matching happens
+    // inside handleEvent via event.topic, not via the hub method name.
+    this.eventBus.subscribe(EXTERNAL_EVENT_PUBLISHED_METHOD, ({ event }) => this.handleEvent(event));
   }
 
   /** Check if a repo is watched for a given space. Uses cached data. */
@@ -809,7 +825,7 @@ If persistent queuing is needed in a future iteration, events can be persisted t
 
 - **Rate limiting**: If a single node receives > 10 events per minute, subsequent events are coalesced into a digest message: "N additional events received in the last minute. Summary: ..."
 - **Event TTL**: Events older than 5 minutes are dropped from the queue (they're likely stale for an agent's decision-making).
-- **Bus overflow**: The `EventBus` uses TypedHub's async-everywhere design — slow consumers don't block publishers. Handlers run via `queueMicrotask`.
+- **Bus overflow**: The `EventBus` uses TypedHub's async-everywhere design with the fixed method `space.externalEvent.published` — slow consumers don't block publishers. Handlers run via `queueMicrotask`; external slash/glob topics remain payload data and are never used as MessageHub method names.
 
 ## 6. Topic Trie Implementation
 
@@ -1208,7 +1224,7 @@ await githubAdapter.start(eventBus);
 
 | Existing system | Relationship |
 |---|---|
-| **DaemonHub / TypedHub** | `EventBus` is a TypedHub participant on the shared `InProcessTransportBus`. The bus uses the same async-everywhere, session-scoped routing that DaemonHub uses. |
+| **DaemonHub / TypedHub** | `EventBus` is a TypedHub participant on the shared `InProcessTransportBus`. It publishes all external events through the fixed valid method `space.externalEvent.published`; slash-delimited external topics stay in `ExternalEvent.topic` and are matched by the router trie. |
 | **GitHubService** (Room pipeline) | Unchanged. Continues routing to Rooms. The event bus is additive. |
 | **SpaceGitHubService** (Space pipeline) | Unchanged. Continues injecting into Task Agent. The GitHub adapter subscribes to `space.githubEvent.routed` as an additional consumer. |
 | **SessionNotificationSink** | The event bus uses the same `sessionFactory.injectMessage()` with `deliveryMode: 'defer'` pattern. |
@@ -1225,7 +1241,7 @@ TypedHub provides:
 - Already wired into the daemon's lifecycle.
 - No new dependency.
 
-Using TypedHub as the backing transport means the EventBus inherits all of these properties for free.
+Using TypedHub as the backing transport means the EventBus inherits all of these properties for free. The bus does **not** use external topic strings as TypedHub method names: raw topics contain `/` and glob `*`, which violate MessageHub method validation. Instead, EventBus publishes every external event under the fixed valid method `space.externalEvent.published` and places the external topic in `ExternalEvent.topic` for trie matching.
 
 ### Why not route through AgentMessageRouter?
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -62,7 +62,7 @@ github/lsm/neokai/pull_request.review_*     ← prefix wildcard: all review even
 2. `owner/repo` — from the event's repository context. Both lowercase for case-insensitive matching.
 3. `resource` — the GitHub resource type: `pull_request`, `issue`, `check_suite`, `pull_request_review`, etc.
 4. `action` — the specific action: `opened`, `review_submitted`, `comment_created`, `completed`, etc.
-5. For resources without a natural `owner/repo` (e.g. a Slack message), the convention is `{source}/{workspace}/{channel}.{action}`.
+5. All v1 topics use exactly 4 path segments. For resources without a natural `owner/repo` (e.g. a future Slack message), use a source-specific scope pair to preserve the same depth: `{source}/{workspace}/{channel}/{resource}.{action}` (for example, `slack/acme/eng/messages.created`). Adapters that do not have both scope levels should use a reserved placeholder segment such as `_` rather than emitting 3-segment topics.
 
 ### Matching rules
 
@@ -78,7 +78,7 @@ Pattern validation (enforced at workflow create/update time):
 - Must be non-empty.
 - Must not contain `..` segments.
 - Must not contain empty segments (no double slashes).
-- Must have exactly 4 segments (`source/owner/repo/resource.action`) so it can match real event topics.
+- Must have exactly 4 segments (`source/scope1/scope2/resource.action`) so it can match real event topics.
 - Each segment may contain alphanumeric, dash, underscore, dot, and `*`; `*` must stay within a single segment and cannot cross `/` boundaries.
 - Max 10 interests per agent slot.
 
@@ -941,7 +941,7 @@ function isReceivingStatus(status: NodeExecutionStatus): boolean {
 
 ### Changes to existing code
 
-**Two-field addition.** The `appendTaskActivity` method in `space-github.ts` must include `action: event.action` and `rawPayload: event.rawPayload` in the `space.githubEvent.routed` DaemonHub payload. This is the only change to existing code. All other existing behavior (webhook handling, polling, normalization, Task Agent injection) remains unchanged.
+**Four-field addition.** The `appendTaskActivity` method in `space-github.ts` must include `action`, `rawPayload`, `dedupeKey`, and `deliveryId` in the `space.githubEvent.routed` DaemonHub payload. The adapter requires `dedupeKey` as the stable upstream event identity for per-subscription deduplication, and `deliveryId` preserves the unique GitHub delivery identifier used to build that identity. This is the only change to existing code. All other existing behavior (webhook handling, polling, normalization, Task Agent injection) remains unchanged.
 
 ```
 SpaceGitHubService.handleWebhook()
@@ -1070,7 +1070,9 @@ packages/daemon/src/lib/space/runtime/event-bus/
  * Called at workflow create/update time and again at trie insertion time.
  *
  * Requires exactly 4 segments because all v1 event topics have the format
- * `{source}/{owner}/{repo}/{resource}.{action}`.
+ * `{source}/{scope1}/{scope2}/{resource}.{action}`. For GitHub, scope1/scope2
+ * are owner/repo; for future non-repo adapters, they are source-specific scope
+ * segments such as workspace/channel.
  * Patterns like `github/*` (too shallow) or `github/*/*/pull_request/review_*`
  * (too deep) would pass validation but never match any event, creating silent
  * misconfigurations.
@@ -1085,7 +1087,7 @@ export function validateGlobPattern(pattern: string): { valid: boolean; reason?:
   if (segments.length !== 4) {
     return {
       valid: false,
-      reason: `Topic pattern must have exactly 4 segments (source/owner/repo/resource.action); got ${segments.length}. Example: 'github/*/*/pull_request.review_submitted'`,
+      reason: `Topic pattern must have exactly 4 segments (source/scope1/scope2/resource.action); got ${segments.length}. Example: 'github/*/*/pull_request.review_submitted'`,
     };
   }
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -327,7 +327,7 @@ this.daemonHub?.emit('space.githubEvent.routed', {
 This is a four-field addition to `appendTaskActivity` — `action`, `rawPayload`, `dedupeKey`, and `deliveryId` are all already available on the `NormalizedSpaceGitHubEvent` at the call site. This is the only change to existing code.
 
 **Why this approach:**
-- Minimal change to the existing `SpaceGitHubService` — two additional fields in an existing DaemonHub emission.
+- Minimal change to the existing `SpaceGitHubService` — four additional fields (`action`, `deliveryId`, `dedupeKey`, `rawPayload`) in an existing DaemonHub emission.
 - The existing PR-to-task resolution (`SpacePrTaskResolver`) continues to work.
 - The existing Task Agent injection continues to work (we don't replace it, we supplement it).
 - The adapter is purely additive: it converts an already-normalized event into bus format.
@@ -538,10 +538,13 @@ class EventRouter {
       }
     }
 
-    // Clean up in-memory pending queue for this run
-    for (const [execId, events] of this.pendingQueue.entries()) {
-      if (execId.startsWith(workflowRunId)) {
-        this.pendingQueue.delete(execId);
+    // Clean up in-memory pending queue for this run.
+    // Keys are `${workflowRunId}:${nodeId}:${agentName}` — use the delimiter
+    // to avoid false prefix matches (e.g., run "abc1" matching "abc10:*").
+    const runPrefix = `${workflowRunId}:`;
+    for (const [key, events] of this.pendingQueue.entries()) {
+      if (key.startsWith(runPrefix)) {
+        this.pendingQueue.delete(key);
       }
     }
   }

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -188,13 +188,13 @@ export interface WorkflowNodeAgent {
 
 **`repo` scope** filters to events from any of the space's watched repositories (`space_github_watched_repos`). The node author doesn't need to know repo names.
 
-**`global` scope** passes through all events matching the topic pattern. Use sparingly (e.g. a "global monitor" node).
+**`global` scope** passes through all events in the same space matching the topic pattern. It is never cross-space: the router requires `event.spaceId === subscription.spaceId` before any scope-specific logic runs. Use sparingly (e.g. a space-local "global monitor" node).
 
 ### Auto-scoping resolution at runtime
 
 When an event arrives, the router:
 
-1. Extracts `prNumber` and `repoOwner/repoName` from the event payload.
+1. Verifies `event.spaceId` matches the subscription's `spaceId`, then extracts `prNumber` and `repoOwner/repoName` from the event payload.
 2. For each active node execution with `eventInterests`:
    a. Compiles the interest's `topic` glob against the event's topic.
    b. If matched, checks scope:
@@ -214,6 +214,8 @@ When an event arrives, the router:
 export interface ExternalEvent {
   /** Unique event ID (UUID) */
   id: string;
+  /** Space this event was routed for. Required to prevent cross-space delivery. */
+  spaceId: string;
   /** Fully qualified topic: 'github/owner/repo/resource.action' */
   topic: string;
   /** Timestamp when the event occurred (epoch ms) */
@@ -281,7 +283,7 @@ export interface EventPublisher {
 export const EXTERNAL_EVENT_PUBLISHED_METHOD = 'space.externalEvent.published';
 
 export interface EventBusHubEventMap {
-  'space.externalEvent.published': { event: ExternalEvent };
+  'space.externalEvent.published': { spaceId: string; event: ExternalEvent };
 }
 ```
 
@@ -327,6 +329,7 @@ The adapter subscribes to the existing `space.githubEvent.routed` DaemonHub even
 // In space-github.ts, appendTaskActivity():
 this.daemonHub?.emit('space.githubEvent.routed', {
     sessionId: 'global',
+    spaceId,
     taskId,
     event: {
         repo: `${event.repoOwner}/${event.repoName}`,
@@ -348,7 +351,7 @@ this.daemonHub?.emit('space.githubEvent.routed', {
 });
 ```
 
-This is a payload-contract extension to `appendTaskActivity` using fields already available on the `NormalizedSpaceGitHubEvent` at the call site. `dedupeKey` and `deliveryId` are required for stable upstream event identity; `prUrl` and the other normalized fields keep the `SpacePrTaskResolver` fallback functional if `taskId` is absent.
+This is a payload-contract extension to `appendTaskActivity` using fields already available on the `NormalizedSpaceGitHubEvent` at the call site plus the enclosing `spaceId`. `dedupeKey` and `deliveryId` are required for stable upstream event identity; `prUrl` and the other normalized fields keep the `SpacePrTaskResolver` fallback functional if `taskId` is absent; `spaceId` prevents cross-space delivery on the shared daemon event stream.
 
 **Why this approach:**
 - Minimal change to the existing `SpaceGitHubService` — additional normalized fields in an existing DaemonHub emission, with no changes to ingestion/dedup/routing behavior.
@@ -447,7 +450,11 @@ class EventRouter {
   ) {
     // Subscribe to the fixed TypedHub-safe method. External topic matching happens
     // inside handleEvent via event.topic, not via the hub method name.
-    this.eventBus.subscribe(EXTERNAL_EVENT_PUBLISHED_METHOD, ({ event }) => this.handleEvent(event));
+    this.eventBus.subscribe(EXTERNAL_EVENT_PUBLISHED_METHOD, ({ spaceId, event }) => {
+      // Defense in depth: payload spaceId and event.spaceId must agree.
+      if (event.spaceId !== spaceId) return;
+      void this.handleEvent(event);
+    });
   }
 
   /** Check if a repo is watched for a given space. Uses cached data. */
@@ -709,6 +716,11 @@ class EventRouter {
   }
 
   private passesScopeCheck(event: ExternalEvent, sub: Subscription): boolean {
+    // All scopes are bounded to the subscription's space. EventBus is a shared
+    // daemon-wide stream, so even `global` means "global within this space", not
+    // cross-space delivery.
+    if (event.spaceId !== sub.spaceId) return false;
+
     switch (sub.interest.scope) {
       case 'global':
         return true;
@@ -1003,7 +1015,7 @@ The GitHub adapter subscribes to `space.githubEvent.routed` and converts it:
 class GitHubEventAdapter implements EventAdapter {
   async start(publisher: EventPublisher): Promise<void> {
     this.daemonHub.on('space.githubEvent.routed', async (data) => {
-      const { event, taskId } = data;
+      const { event, spaceId, taskId } = data;
       const [repoOwner, repoName] = event.repo.split('/');
 
       // Construct topic from event.
@@ -1013,8 +1025,9 @@ class GitHubEventAdapter implements EventAdapter {
 
       // Publish to bus. Preserve the upstream occurrence time for ordering,
       // queue TTL, and latency diagnostics; only ingestedAt is "now".
-      await publisher.publish({
+      const externalEvent: ExternalEvent = {
         id: crypto.randomUUID(),
+        spaceId,
         topic,
         occurredAt: new Date(event.occurredAt).getTime(),
         ingestedAt: Date.now(),
@@ -1039,7 +1052,9 @@ class GitHubEventAdapter implements EventAdapter {
           rawPayload: event.rawPayload,   // Include original webhook/polling payload
         },
         dedupeKey: event.dedupeKey,  // Use upstream identity (includes deliveryId); avoids collapsing distinct events that share repo/pr/action/url
-      });
+      };
+
+      await publisher.publish(externalEvent);
     });
   }
 }

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -995,11 +995,12 @@ class GitHubEventAdapter implements EventAdapter {
       // original GitHub action so users can filter created/edited/deleted/etc.
       const topic = `github/${repoOwner}/${repoName}/${mapEventType(event.eventType, event.action)}`;
 
-      // Publish to bus
+      // Publish to bus. Preserve the upstream occurrence time for ordering,
+      // queue TTL, and latency diagnostics; only ingestedAt is "now".
       await publisher.publish({
         id: crypto.randomUUID(),
         topic,
-        occurredAt: Date.now(),
+        occurredAt: new Date(event.occurredAt).getTime(),
         ingestedAt: Date.now(),
         source: 'github',
         prNumber: event.prNumber,

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -521,7 +521,11 @@ class EventRouter {
 
   /**
    * Clear all subscriptions for a workflow run.
-   * Called when the workflow run reaches a terminal state (done, cancelled, blocked).
+   * Called when the workflow run reaches a truly terminal state (done or cancelled).
+   *
+   * NOT called for `blocked` runs because blocked is resumable — the run may be
+   * reopened (see WorkflowRunReopenedEvent) and its node subscriptions should
+   * remain active so queued/arriving events can be delivered upon resume.
    */
   clearRunInterests(workflowRunId: string): void {
     const runSubs = this.activeRuns.get(workflowRunId);
@@ -573,6 +577,15 @@ class EventRouter {
     const dedupeKey = `${event.dedupeKey}:${sub.nodeId}:${sub.agentName}:${sub.workflowRunId}`;
     if (this.delivered.has(dedupeKey)) return;
 
+    // Mark dedup BEFORE session resolution / queueing. This prevents the same
+    // event from being queued multiple times for inactive sessions — if the
+    // event arrives again before the queued delivery is flushed, the dedup
+    // check above will catch it. The tradeoff is that if injection fails (e.g.
+    // session crashes during delivery), the event will not be retried; this is
+    // acceptable because the upstream SpaceGitHubService re-polls on restart
+    // and will generate a fresh event.
+    this.delivered.set(dedupeKey, Date.now());
+
     // Resolve session — re-read from nodeExecutionRepo for latest state
     const sessionId = await this.resolveSession(sub);
     if (!sessionId) {
@@ -592,14 +605,12 @@ class EventRouter {
       await this.sessionFactory.injectMessage(sessionId, message, {
         deliveryMode: 'defer',
       });
-
-      // Mark delivered
-      this.delivered.set(dedupeKey, Date.now());
     } catch (err) {
       log.warn(`Failed to deliver event to ${sub.agentName}`, { error: err });
       // Session may have completed between resolution and injection.
-      // This is expected and safe — the event is NOT marked as delivered,
-      // so if the session restarts, the event can be re-attempted.
+      // The event is already dedup-marked so it won't be re-delivered for
+      // this run. A fresh event will arrive via the next poll cycle if the
+      // underlying external event is still relevant.
     }
   }
 
@@ -864,8 +875,12 @@ class GitHubEventAdapter implements EventAdapter {
       const { event, taskId } = data;
       const [repoOwner, repoName] = event.repo.split('/');
 
-      // Construct topic from event
-      const topic = `github/${repoOwner}/${repoName}/${mapEventType(event.eventType)}.${mapAction(event.action)}`;
+      // Construct topic from event.
+      // mapEventType returns the full resource.action string from the table below.
+      // For most SpaceGitHubEventKinds, the mapping already includes the action
+      // (e.g., pull_request_review → "pull_request.review_submitted").
+      // For plain pull_request events, the action is appended from event.action.
+      const topic = `github/${repoOwner}/${repoName}/${mapEventType(event.eventType, event.action)}`;
 
       // Publish to bus
       await publisher.publish({
@@ -897,12 +912,24 @@ class GitHubEventAdapter implements EventAdapter {
 
 The `SpaceGitHubService` already normalizes to `SpaceGitHubEventKind` (`issue_comment`, `pull_request_review`, `pull_request_review_comment`, `pull_request`). We map these to bus topics:
 
-| SpaceGitHubEventKind | Bus topic resource |
+| SpaceGitHubEventKind | `mapEventType(kind, action)` returns |
 |---|---|
 | `issue_comment` | `pull_request.comment_created` (PR comments only, already filtered) |
 | `pull_request_review` | `pull_request.review_submitted` |
 | `pull_request_review_comment` | `pull_request.review_comment_created` |
-| `pull_request` | `pull_request.{action}` (opened, synchronize, closed, etc.) |
+| `pull_request` | `pull_request.${action}` (opened, synchronize, closed, etc.) |
+
+```typescript
+function mapEventType(kind: string, action: string): string {
+  switch (kind) {
+    case 'issue_comment': return 'pull_request.comment_created';
+    case 'pull_request_review': return 'pull_request.review_submitted';
+    case 'pull_request_review_comment': return 'pull_request.review_comment_created';
+    case 'pull_request': return `pull_request.${action}`;
+    default: return `${kind}.${action}`;
+  }
+}
+```
 
 ### Task-scoped resolution optimization
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -68,10 +68,18 @@ github/lsm/neokai/pull_request.review_*     ← prefix wildcard: all review even
 
 Subscriptions use glob-style patterns:
 - `*` matches any single path segment (no slashes)
-- `**` matches any number of path segments
 - Literal segments match exactly (case-insensitive)
 
-We implement matching via a **trie-based prefix index** (see §4), not regex. This keeps matching O(k) where k = topic depth, independent of the number of subscriptions.
+> **V1 scope note:** The `**` (multi-segment) wildcard is deferred to a follow-up. All v1 use cases are covered by single-segment `*` wildcards at the `owner`, `repo`, or `action` position (e.g., `github/*/*/pull_request.review_submitted`). Adding `**` support requires a depth-bounded recursive trie walk and is not justified by current subscription patterns.
+
+Pattern validation (enforced at workflow create/update time):
+- Must be non-empty.
+- Must not contain `..` segments.
+- Must not contain empty segments (no double slashes).
+- Each segment must be a literal string or `*`.
+- Max 10 interests per agent slot.
+
+We implement matching via a **trie-based prefix index** (see §4), not regex.
 
 ## 2. Node-Level Event Subscription (`eventInterests`)
 
@@ -293,11 +301,35 @@ class GitHubEventAdapter implements EventAdapter {
 
 The adapter subscribes to the existing `space.githubEvent.routed` DaemonHub event (already emitted by `SpaceGitHubService.appendTaskActivity`). It converts the event to `ExternalEvent` format and publishes to the bus.
 
+**Note — `action` field gap:** The current `space.githubEvent.routed` payload emitted by `appendTaskActivity` only includes `{ repo, prNumber, eventType, summary, externalUrl }`. It does NOT include `action`. The adapter needs the action to construct proper topics (e.g., `pull_request.review_submitted` vs `pull_request.opened`).
+
+**Fix:** Extend the `appendTaskActivity` payload in `SpaceGitHubService` to include `action`:
+
+```typescript
+// In space-github.ts, appendTaskActivity():
+this.daemonHub?.emit('space.githubEvent.routed', {
+    sessionId: 'global',
+    taskId,
+    event: {
+        repo: `${event.repoOwner}/${event.repoName}`,
+        prNumber: event.prNumber,
+        eventType: event.eventType,
+        action: event.action,           // ← ADD THIS
+        summary: event.summary,
+        externalUrl: event.externalUrl,
+        rawPayload: event.rawPayload,   // ← ADD THIS (for adapter consumers)
+    },
+});
+```
+
+This is a two-field addition to `appendTaskActivity` — both `action` and `rawPayload` are already available on the `NormalizedSpaceGitHubEvent` at the call site. This is the only change to existing code.
+
 **Why this approach:**
-- Zero changes to the existing `SpaceGitHubService` webhook handler or polling pipeline.
+- Minimal change to the existing `SpaceGitHubService` — two additional fields in an existing DaemonHub emission.
 - The existing PR-to-task resolution (`SpacePrTaskResolver`) continues to work.
 - The existing Task Agent injection continues to work (we don't replace it, we supplement it).
 - The adapter is purely additive: it converts an already-normalized event into bus format.
+- `rawPayload` is included so adapter consumers (and future adapters) have access to the full original event data without re-fetching from GitHub.
 
 ## 4. EventRouter Design
 
@@ -334,7 +366,7 @@ The trie maps topic segments to `Set<Subscription>` at leaf nodes. Wildcard segm
 
 **Build cost**: O(n × k) where n = number of subscriptions, k = topic depth (typically 4-5). Built once when a workflow run starts.
 
-**Lookup cost**: O(k) per event — walk the trie by topic segment, collect subscriptions at each level (exact match + wildcard).
+**Lookup cost**: The trie walks both exact-match and wildcard branches at each level. With k levels, this produces at most 2^k paths. At each leaf, m subscriptions are collected. Total cost per lookup is O(2^k × m) where m is the total number of matching subscriptions across all leaves. Since k is small and bounded (4–5 topic segments), 2^k is a small constant (16–32). The real benefit over linear scan is that non-matching subscriptions are never visited — only subscriptions whose pattern segments align with the event's topic are collected.
 
 ### Subscription index lifecycle
 
@@ -367,16 +399,45 @@ class EventRouter {
 
   // dedup: (dedupeKey, agentSessionId) → timestamp
   private delivered: Map<string, number> = new Map();
+  // TTL for dedup entries — entries older than this are evicted on next access
+  private static readonly DEDUP_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+  // Cache: spaceId → Set of "owner/repo" strings for watched repos
+  // Refreshed on spaceWorkflow.updated events (when watched repos change)
+  private watchedRepoCache: Map<string, Set<string>> = new Map();
 
   constructor(
     private readonly eventBus: EventBus,
     private readonly nodeExecutionRepo: NodeExecutionRepository,
     private readonly taskRepo: SpaceTaskRepository,
+    private readonly spaceTaskManager: SpaceTaskManager,
     private readonly sessionFactory: SessionFactory,
     private readonly prResolver: SpacePrTaskResolver,
+    private readonly spaceGitHubRepo: SpaceGitHubRepository,
   ) {
     // Subscribe to ALL events on the bus
     this.eventBus.subscribe('*', this.handleEvent.bind(this));
+  }
+
+  /** Check if a repo is watched for a given space. Uses cached data. */
+  private isWatchedRepo(spaceId: string, owner: string, repo: string): boolean {
+    let cached = this.watchedRepoCache.get(spaceId);
+    if (!cached) {
+      const repos = this.spaceGitHubRepo.listWatchedRepos(spaceId);
+      cached = new Set(
+        repos.filter(r => r.enabled).map(r => `${r.owner.toLowerCase()}/${r.repo.toLowerCase()}`)
+      );
+      this.watchedRepoCache.set(spaceId, cached);
+    }
+    return cached.has(`${owner.toLowerCase()}/${repo.toLowerCase()}`);
+  }
+
+  /** Evict stale dedup entries (called periodically or on demand). */
+  private evictStaleDedup(): void {
+    const cutoff = Date.now() - EventRouter.DEDUP_TTL_MS;
+    for (const [key, ts] of this.delivered.entries()) {
+      if (ts < cutoff) this.delivered.delete(key);
+    }
   }
 
   /**
@@ -424,6 +485,64 @@ class EventRouter {
     this.activeRuns.set(workflowRunId, runSubs);
   }
 
+  /**
+   * Unregister subscriptions for a specific node execution.
+   * Called when a node execution transitions to a non-receiving state.
+   *
+   * Receiving states: in_progress (active agent session)
+   * Non-receiving states: pending, idle, waiting_rebind, blocked, cancelled
+   *
+   * For `idle` and `waiting_rebind`, events may still be relevant (agent
+   * could be re-activated), so we keep subscriptions but skip delivery
+   * (the event is queued in the in-memory pending queue instead).
+   * For `blocked`/`cancelled`, subscriptions are fully removed.
+   */
+  unregisterExecution(
+    workflowRunId: string,
+    nodeId: string,
+    agentName: string,
+  ): void {
+    const runSubs = this.activeRuns.get(workflowRunId);
+    if (!runSubs) return;
+
+    const toRemove = [...runSubs].filter(
+      s => s.nodeId === nodeId && s.agentName === agentName,
+    );
+    for (const sub of toRemove) {
+      runSubs.delete(sub);
+      this.topicTrie.remove(
+        v => v.workflowRunId === workflowRunId && v.agentName === agentName && v.nodeId === nodeId,
+      );
+    }
+  }
+
+  /**
+   * Clear all subscriptions for a workflow run.
+   * Called when the workflow run reaches a terminal state (done, cancelled, blocked).
+   */
+  clearRunInterests(workflowRunId: string): void {
+    const runSubs = this.activeRuns.get(workflowRunId);
+    if (!runSubs) return;
+
+    this.topicTrie.remove(v => v.workflowRunId === workflowRunId);
+    this.activeRuns.delete(workflowRunId);
+
+    // Also clean up dedup entries for this run
+    const prefix = `:${workflowRunId}:`;
+    for (const key of this.delivered.keys()) {
+      if (key.includes(prefix)) {
+        this.delivered.delete(key);
+      }
+    }
+
+    // Clean up in-memory pending queue for this run
+    for (const [execId, events] of this.pendingQueue.entries()) {
+      if (execId.startsWith(workflowRunId)) {
+        this.pendingQueue.delete(execId);
+      }
+    }
+  }
+
   private async handleEvent(event: ExternalEvent): Promise<void> {
     // 1. Look up matching subscriptions via trie
     const matched = this.topicTrie.lookup(event.topic);
@@ -444,7 +563,7 @@ class EventRouter {
     const dedupeKey = `${event.dedupeKey}:${sub.agentName}:${sub.workflowRunId}`;
     if (this.delivered.has(dedupeKey)) return;
 
-    // Resolve session
+    // Resolve session — re-read from nodeExecutionRepo for latest state
     const sessionId = await this.resolveSession(sub);
     if (!sessionId) {
       // Session not active — queue for later delivery
@@ -452,7 +571,12 @@ class EventRouter {
       return;
     }
 
-    // Format and inject
+    // Format and inject.
+    // NOTE: There is a TOCTOU race — the session could complete between our
+    // resolveSession call and injectMessage. This is safe: injectMessage on a
+    // completed/absent session returns a caught error (logged as a warning),
+    // and the dedup map prevents re-delivery if the same event arrives again
+    // after the session restarts. No data loss or corruption occurs.
     const message = this.formatEventMessage(event);
     try {
       await this.sessionFactory.injectMessage(sessionId, message, {
@@ -463,6 +587,9 @@ class EventRouter {
       this.delivered.set(dedupeKey, Date.now());
     } catch (err) {
       log.warn(`Failed to deliver event to ${sub.agentName}`, { error: err });
+      // Session may have completed between resolution and injection.
+      // This is expected and safe — the event is NOT marked as delivered,
+      // so if the session restarts, the event can be re-attempted.
     }
   }
 
@@ -472,23 +599,35 @@ class EventRouter {
         return true;
 
       case 'repo': {
-        // Check if event's repo matches any watched repo in this space
+        // Check if event's repo matches any watched repo in this space.
+        // Uses SpaceGitHubRepository.getEnabledRepos(owner, repo) which queries
+        // the `space_github_watched_repos` table filtered by (spaceId, owner, repo, enabled=1).
+        // The router caches this per-space to avoid DB hits on every event.
         if (!event.repoOwner || !event.repoName) return false;
         return this.isWatchedRepo(sub.spaceId, event.repoOwner, event.repoName);
       }
 
       case 'task': {
-        // Check if event's PR number matches the subscription's task
+        // Check if event's PR number matches any task in this workflow run.
+        // Note: a workflow run CAN have multiple tasks (e.g., sub-tasks created
+        // by the planner). We check ALL non-archived tasks for a PR match.
         if (!event.prNumber) return false;
-        const task = this.taskRepo.getByWorkflowRunId(sub.workflowRunId);
-        if (!task) return false;
-        // Reuse the existing SpacePrTaskResolver logic
-        return this.prResolver.resolve(sub.spaceId, {
-          repoOwner: event.repoOwner ?? '',
-          repoName: event.repoName ?? '',
-          prNumber: event.prNumber,
-          // ... minimal shape for resolver
-        } as any).taskId === task.id;
+        const tasks = this.taskRepo.listByWorkflowRun(sub.workflowRunId);
+        if (tasks.length === 0) return false;
+
+        // The SpacePrTaskResolver already handles the PR → task matching logic.
+        // For the common case (1 task per run), this is a single lookup.
+        // For multi-task runs, we check if any task matches.
+        for (const task of tasks) {
+          const resolved = this.prResolver.resolve(sub.spaceId, {
+            repoOwner: event.repoOwner ?? '',
+            repoName: event.repoName ?? '',
+            prNumber: event.prNumber,
+            // ... minimal shape for resolver
+          } as any);
+          if (resolved.taskId === task.id) return true;
+        }
+        return false;
       }
     }
   }
@@ -534,10 +673,17 @@ When an event matches a subscription whose node execution is `idle` (agent sessi
 
 When a node execution is `pending` (no session yet):
 
-1. The event is queued in an in-memory `Map<executionId, ExternalEvent[]>`.
+1. The event is queued in an in-memory `Map<string, ExternalEvent[]>` keyed by `${workflowRunId}:${nodeId}:${agentName}`.
 2. When `TaskAgentManager` creates the node's session, it checks for queued events.
 3. Queued events are injected as initial context in the session's first turn.
 4. Queue is bounded: max 50 events per execution, oldest dropped (with a warning log).
+
+**Known limitation — daemon restart**: The in-memory pending queue is lost on daemon restart. For v1, this is acceptable because:
+- Events between daemon restarts are also lost (the webhook/polling pipeline itself doesn't guarantee delivery during downtime).
+- The existing `SpaceGitHubService` polling service re-polls on startup, so events that arrived during downtime are re-normalized and re-routed.
+- For nodes that are still `pending` after restart, the next poll cycle will generate fresh events that flow through the bus.
+
+If persistent queuing is needed in a future iteration, events can be persisted to a `space_event_delivery_queue` SQLite table with the same schema as the in-memory map, and drained on node activation.
 
 ### Backpressure
 
@@ -576,7 +722,9 @@ class TopicTrie<T> {
   /**
    * Lookup all values whose patterns match the given topic.
    * Returns all values from exact matches AND wildcard matches at each level.
-   * O(depth) — independent of total number of patterns.
+   * Walks at most 2^k paths where k = topic segment count (bounded, small).
+   * Only collects subscriptions from matching leaves — non-matching patterns
+   * are never visited.
    */
   lookup(topic: string): T[] {
     const segments = topic.split('/');
@@ -626,18 +774,34 @@ class TrieNode<T> {
 }
 ```
 
+### Helper: `isReceivingStatus`
+
+```typescript
+import type { NodeExecutionStatus } from '@neokai/shared';
+
+/** Node execution states that should NOT receive events. */
+const TERMINAL_RECEIVING_STATES: ReadonlySet<NodeExecutionStatus> = new Set([
+  'cancelled',
+  // Note: 'idle' and 'waiting_rebind' keep their subscriptions alive —
+  // the agent session exists and may be re-activated. Events are queued
+  // rather than delivered immediately for these states.
+]);
+
+function isReceivingStatus(status: NodeExecutionStatus): boolean {
+  return !TERMINAL_RECEIVING_STATES.has(status);
+}
+```
+
 **Complexity**:
 - Insert: O(k) where k = segment count (~4-5)
-- Lookup: O(k) — walks trie by segment, collects from exact + wildcard at each level
+- Lookup: O(2^k × m) — walks at most 2^k paths (exact + wildcard at each level), collects m total matching subscriptions from leaves. Since k is bounded (4–5), 2^k is a small constant.
 - Memory: O(n × k) where n = number of subscriptions
-
-This is O(1) relative to the number of subscriptions — each lookup traverses at most 2^k paths (2 per level: exact + wildcard), and k is small and constant.
 
 ## 7. Wiring the GitHub Adapter
 
 ### Changes to existing code
 
-**Minimal.** The adapter hooks into the existing `SpaceGitHubService` via DaemonHub subscription:
+**Two-field addition.** The `appendTaskActivity` method in `space-github.ts` must include `action: event.action` and `rawPayload: event.rawPayload` in the `space.githubEvent.routed` DaemonHub payload. This is the only change to existing code. All other existing behavior (webhook handling, polling, normalization, Task Agent injection) remains unchanged.
 
 ```
 SpaceGitHubService.handleWebhook()
@@ -661,9 +825,10 @@ class GitHubEventAdapter implements EventAdapter {
   async start(publisher: EventPublisher): Promise<void> {
     this.daemonHub.on('space.githubEvent.routed', async (data) => {
       const { event, taskId } = data;
+      const [repoOwner, repoName] = event.repo.split('/');
 
       // Construct topic from event
-      const topic = `github/${event.repo.split('/')[0]}/${event.repo.split('/')[1]}/${mapEventType(event.eventType)}.${mapAction(event.action)}`;
+      const topic = `github/${repoOwner}/${repoName}/${mapEventType(event.eventType)}.${mapAction(event.action)}`;
 
       // Publish to bus
       await publisher.publish({
@@ -673,12 +838,18 @@ class GitHubEventAdapter implements EventAdapter {
         ingestedAt: Date.now(),
         source: 'github',
         prNumber: event.prNumber,
-        repoOwner: event.repo.split('/')[0],
-        repoName: event.repo.split('/')[1],
+        repoOwner,
+        repoName,
         summary: event.summary,
         externalUrl: event.externalUrl,
-        payload: event,
-        dedupeKey: `github:${event.repo}:${event.prNumber}:${event.eventType}:${event.externalUrl}`,
+        payload: {
+          // Full normalized event for adapter consumers
+          eventType: event.eventType,
+          action: event.action,
+          taskId,
+          rawPayload: event.rawPayload,   // Include original webhook/polling payload
+        },
+        dedupeKey: `github:${event.repo}:${event.prNumber}:${event.eventType}:${event.action}:${event.externalUrl}`,
       });
     });
   }
@@ -716,9 +887,10 @@ None required for V1. Event interests are stored as part of the workflow definit
 1. Add `EventInterest` interface to `packages/shared/src/types/space.ts`.
 2. Add `eventInterests?: EventInterest[]` to `WorkflowNodeAgent`.
 3. Add validation in the workflow create/update path (Zod schema or manual validation):
-   - `topic` must be a valid glob pattern (non-empty, no `..` segments).
+   - `topic` must pass `validateGlobPattern()` (non-empty, no `..` segments, no double slashes, valid characters).
    - `scope` must be one of `'task' | 'repo' | 'global'`.
    - Max 10 interests per agent slot (prevent abuse).
+   - `validateGlobPattern()` is the single source of truth — called at workflow create/update and again at trie insertion time as a safety net.
 
 ### New files
 
@@ -727,9 +899,50 @@ packages/daemon/src/lib/space/runtime/event-bus/
   ├── types.ts              # ExternalEvent, EventAdapter, EventPublisher interfaces
   ├── event-bus.ts           # EventBus singleton (wraps TypedHub)
   ├── topic-trie.ts          # TopicTrie<T> implementation
+  ├── topic-validator.ts     # validateGlobPattern() helper
   ├── event-router.ts        # EventRouter — subscribes to bus, matches, delivers
   ├── github-adapter.ts      # GitHubEventAdapter — bridges SpaceGitHubService → EventBus
   └── index.ts               # Public exports
+```
+
+### Topic pattern validation
+
+```typescript
+// topic-validator.ts
+
+/**
+ * Validate a glob pattern for event subscriptions.
+ * Rejects patterns that could corrupt the trie or match unintended topics.
+ * Called at workflow create/update time and again at trie insertion time.
+ */
+export function validateGlobPattern(pattern: string): { valid: boolean; reason?: string } {
+  if (!pattern || pattern.trim().length === 0) {
+    return { valid: false, reason: 'Topic pattern must not be empty' };
+  }
+
+  const segments = pattern.split('/');
+
+  if (segments.length < 2) {
+    return { valid: false, reason: 'Topic pattern must have at least 2 segments (source/resource)' };
+  }
+
+  for (const segment of segments) {
+    if (segment === '') {
+      return { valid: false, reason: 'Topic pattern must not contain empty segments (double slashes)' };
+    }
+    if (segment === '..') {
+      return { valid: false, reason: 'Topic pattern must not contain ".." segments' };
+    }
+    if (segment !== '*' && !/^[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*$/.test(segment)) {
+      return {
+        valid: false,
+        reason: `Segment "${segment}" contains invalid characters. Use alphanumeric, dash, underscore, or dot. Use "*" for wildcard.`,
+      };
+    }
+  }
+
+  return { valid: true };
+}
 ```
 
 ### Wiring into SpaceRuntime
@@ -845,7 +1058,10 @@ This is exactly the behavior we want for external events.
 
 ### Integration tests
 
-1. End-to-end: webhook → normalize → ingest → bus → router → session injection.
-2. Dedup: same event delivered twice, verify only one injection.
-3. Wake-on-idle: node idle → event arrives → session receives message.
-4. Pending node: event arrives for pending node → session created → event delivered.
+1. **End-to-end webhook flow**: Emit a `space.githubEvent.routed` event with a review_submitted action for PR #42 on repo `lsm/neokai`. The coder node in a workflow has `task`-scoped interest in `github/*/*/pull_request.review_submitted`. Verify the event reaches the coder node's session as an injected message.
+
+2. **Dedup across two events with same dedupeKey**: Emit two `space.githubEvent.routed` events for the same PR review (identical `dedupeKey`). Verify `injectMessage` is called exactly once for the coder node — the second event is silently dropped by the dedup check. Also verify that if two *different* nodes subscribe to the same event (e.g., coder + ci-monitor), each node receives exactly one injection independently.
+
+3. **Wake-on-idle delivery**: Set a node execution's session to `idle` state (agent finished its turn). Emit a matching event. Verify `injectMessage` is called with `deliveryMode: 'defer'` and the session processes the message on its next turn (via the existing defer replay mechanism).
+
+4. **Pending node queuing**: Emit an event for a node whose execution is `pending` (no session yet). Verify the event is stored in the in-memory pending queue. Then simulate `TaskAgentManager` creating the session. Verify the queued event is flushed and injected into the new session as part of the first turn.

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -49,8 +49,9 @@ Examples:
 github/lsm/neokai/pull_request.review_submitted
 github/lsm/neokai/pull_request.comment_created
 github/lsm/neokai/pull_request.synchronize
-github/lsm/neokai/check_suite.completed
+github/lsm/neokai/pull_request.closed
 github/lsm/neokai/issues.opened
+# Future CI adapter (Phase 3): github/lsm/neokai/check_suite.completed
 github/lsm/neokai/pull_request.*            ← wildcard: all PR events for this repo
 github/lsm/neokai/*.*                       ← wildcard: all events for this repo
 github/lsm/neokai/pull_request.review_*     ← prefix wildcard: all review events
@@ -60,7 +61,7 @@ github/lsm/neokai/pull_request.review_*     ← prefix wildcard: all review even
 
 1. `source` — adapter identifier (`github`, `slack`, `ci`). Lowercase, no slashes.
 2. `owner/repo` — from the event's repository context. Both lowercase for case-insensitive matching.
-3. `resource` — the GitHub resource type: `pull_request`, `issue`, `check_suite`, `pull_request_review`, etc.
+3. `resource` — the event resource type. V1 GitHub adapter emits PR-related resources (`pull_request`, `pull_request.comment`, `pull_request.review`, `pull_request.review_comment`). CI resources such as `check_suite` are Phase 3/future adapter scope.
 4. `action` — the specific action: `opened`, `review_submitted`, `comment_created`, `completed`, etc.
 5. All v1 topics use exactly 4 path segments. For resources without a natural `owner/repo` (e.g. a future Slack message), use a source-specific scope pair to preserve the same depth: `{source}/{workspace}/{channel}/{resource}.{action}` (for example, `slack/acme/eng/messages.created`). Adapters that do not have both scope levels should use a reserved placeholder segment such as `_` rather than emitting 3-segment topics.
 
@@ -94,7 +95,7 @@ We implement matching via a **trie-based prefix index** (see §4), not regex.
 export interface EventInterest {
   /**
    * Glob pattern matching event topics.
-   * Examples: 'github/*/*/pull_request.*', 'ci/*/*/check_suite.completed'
+   * Examples: 'github/*/*/pull_request.*', 'github/*/*/pull_request.review_*'
    */
   topic: string;
 
@@ -159,15 +160,15 @@ export interface WorkflowNodeAgent {
     },
     {
       "id": "monitor",
-      "name": "CI Monitor",
+      "name": "PR Monitor",
       "agents": [{
         "agentId": "...",
-        "name": "ci-monitor",
+        "name": "pr-monitor",
         "eventInterests": [
           {
-            "topic": "github/*/*/check_suite.completed",
+            "topic": "github/*/*/pull_request.*",
             "scope": "repo",
-            "label": "All CI completions in the repo"
+            "label": "All PR activity in the repo"
           }
         ]
       }]
@@ -304,9 +305,9 @@ class GitHubEventAdapter implements EventAdapter {
 
 The adapter subscribes to the existing `space.githubEvent.routed` DaemonHub event (already emitted by `SpaceGitHubService.appendTaskActivity`). It converts the event to `ExternalEvent` format and publishes to the bus.
 
-**Note — `action` field gap:** The current `space.githubEvent.routed` payload emitted by `appendTaskActivity` only includes `{ repo, prNumber, eventType, summary, externalUrl }`. It does NOT include `action`. The adapter needs the action to construct proper topics (e.g., `pull_request.review_submitted` vs `pull_request.opened`).
+**Note — normalized field gap:** The current `space.githubEvent.routed` payload emitted by `appendTaskActivity` only includes `{ repo, prNumber, eventType, summary, externalUrl }`. It does NOT include the stable dedupe identifiers or the full normalized GitHub fields needed for topic construction and fallback task resolution.
 
-**Fix:** Extend the `appendTaskActivity` payload in `SpaceGitHubService` to include `action`:
+**Fix:** Extend the `appendTaskActivity` payload in `SpaceGitHubService` to include the normalized fields consumed by the adapter:
 
 ```typescript
 // In space-github.ts, appendTaskActivity():
@@ -317,20 +318,26 @@ this.daemonHub?.emit('space.githubEvent.routed', {
         repo: `${event.repoOwner}/${event.repoName}`,
         prNumber: event.prNumber,
         eventType: event.eventType,
-        action: event.action,           // ← ADD THIS
+        action: event.action,
+        source: event.source,
         summary: event.summary,
+        prUrl: event.prUrl,
         externalUrl: event.externalUrl,
-        rawPayload: event.rawPayload,   // ← ADD THIS (for adapter consumers)
-        dedupeKey: event.dedupeKey,    // ← ADD THIS (for adapter deduplication)
-        deliveryId: event.deliveryId, // ← ADD THIS (unique GitHub delivery ID)
+        externalId: event.externalId,
+        actor: event.actor,
+        body: event.body,
+        occurredAt: event.occurredAt,
+        rawPayload: event.rawPayload,
+        dedupeKey: event.dedupeKey,
+        deliveryId: event.deliveryId,
     },
 });
 ```
 
-This is a four-field addition to `appendTaskActivity` — `action`, `rawPayload`, `dedupeKey`, and `deliveryId` are all already available on the `NormalizedSpaceGitHubEvent` at the call site. This is the only change to existing code.
+This is a payload-contract extension to `appendTaskActivity` using fields already available on the `NormalizedSpaceGitHubEvent` at the call site. `dedupeKey` and `deliveryId` are required for stable upstream event identity; `prUrl` and the other normalized fields keep the `SpacePrTaskResolver` fallback functional if `taskId` is absent.
 
 **Why this approach:**
-- Minimal change to the existing `SpaceGitHubService` — four additional fields (`action`, `deliveryId`, `dedupeKey`, `rawPayload`) in an existing DaemonHub emission.
+- Minimal change to the existing `SpaceGitHubService` — additional normalized fields in an existing DaemonHub emission, with no changes to ingestion/dedup/routing behavior.
 - The existing PR-to-task resolution (`SpacePrTaskResolver`) continues to work.
 - The existing Task Agent injection continues to work (we don't replace it, we supplement it).
 - The adapter is purely additive: it converts an already-normalized event into bus format.
@@ -361,8 +368,8 @@ root
               │   └── [subscriptions: coder(task)]
               ├── pull_request.comment_created
               │   └── [subscriptions: coder(task)]
-              └── check_suite.completed
-                  └── [subscriptions: ci-monitor(repo)]
+              └── pull_request.review_comment_created
+                  └── [subscriptions: coder(task)]
 ```
 
 The trie maps topic segments to `Set<Subscription>` at leaf nodes. Each node stores exact children separately from segment-local glob children. A glob segment may be a whole-segment wildcard (`*`) or a dotted segment wildcard (`pull_request.*`, `pull_request.review_*`, `*.*`).
@@ -718,12 +725,28 @@ class EventRouter {
         }
 
         // Fallback (should rarely happen): if the adapter didn't include taskId,
-        // resolve by PR and require that the resolver points to THIS task.
+        // resolve with the full normalized GitHub shape. SpacePrTaskResolver's
+        // primary queries use prUrl, so passing only owner/repo/prNumber would
+        // make this fallback ineffective for older routed payloads.
+        if (event.source !== 'github') return false;
         const resolved = this.prResolver.resolve(sub.spaceId, {
+          deliveryId: event.payload?.deliveryId as string | undefined,
+          dedupeKey: event.dedupeKey,
+          source: 'webhook',
+          eventType: event.payload?.eventType as string,
+          action: event.payload?.action as string,
           repoOwner: event.repoOwner ?? '',
           repoName: event.repoName ?? '',
           prNumber: event.prNumber,
-        } as any);
+          prUrl: (event.payload?.prUrl as string | undefined) ?? event.externalUrl,
+          actor: event.payload?.actor as string | undefined,
+          body: event.payload?.body as string | undefined,
+          summary: event.summary,
+          externalUrl: event.externalUrl,
+          externalId: event.payload?.externalId as string | undefined,
+          occurredAt: (event.payload?.occurredAt as string | undefined) ?? new Date(event.occurredAt).toISOString(),
+          rawPayload: event.payload?.rawPayload,
+        } as NormalizedSpaceGitHubEvent);
         return resolved.taskId === sub.taskId;
       }
     }
@@ -941,7 +964,7 @@ function isReceivingStatus(status: NodeExecutionStatus): boolean {
 
 ### Changes to existing code
 
-**Four-field addition.** The `appendTaskActivity` method in `space-github.ts` must include `action`, `rawPayload`, `dedupeKey`, and `deliveryId` in the `space.githubEvent.routed` DaemonHub payload. The adapter requires `dedupeKey` as the stable upstream event identity for per-subscription deduplication, and `deliveryId` preserves the unique GitHub delivery identifier used to build that identity. This is the only change to existing code. All other existing behavior (webhook handling, polling, normalization, Task Agent injection) remains unchanged.
+**Routed payload contract extension.** The `appendTaskActivity` method in `space-github.ts` must include the normalized fields consumed by the adapter in the `space.githubEvent.routed` DaemonHub payload, including `action`, `source`, `prUrl`, `externalId`, `actor`, `body`, `occurredAt`, `rawPayload`, `dedupeKey`, and `deliveryId`. The adapter requires `dedupeKey` as the stable upstream event identity for per-subscription deduplication, `deliveryId` preserves the unique GitHub delivery identifier used to build that identity, and `prUrl` keeps the `SpacePrTaskResolver` fallback functional. This is the only change to existing code. All other existing behavior (webhook handling, polling, normalization, Task Agent injection) remains unchanged.
 
 ```
 SpaceGitHubService.handleWebhook()
@@ -985,10 +1008,17 @@ class GitHubEventAdapter implements EventAdapter {
         summary: event.summary,
         externalUrl: event.externalUrl,
         payload: {
-          // Full normalized event for adapter consumers
+          // Full normalized event for adapter consumers and resolver fallback
           eventType: event.eventType,
           action: event.action,
+          source: event.source,
           taskId,
+          prUrl: event.prUrl,
+          deliveryId: event.deliveryId,
+          externalId: event.externalId,
+          actor: event.actor,
+          body: event.body,
+          occurredAt: event.occurredAt,
           rawPayload: event.rawPayload,   // Include original webhook/polling payload
         },
         dedupeKey: event.dedupeKey,  // Use upstream identity (includes deliveryId); avoids collapsing distinct events that share repo/pr/action/url

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -463,7 +463,7 @@ class EventRouter {
         const exec = nodeExecutions.find(
           e => e.workflowNodeId === node.id && e.agentName === agent.name
         );
-        if (!exec || isTerminal(exec.status)) continue;
+        if (!exec || !isReceivingStatus(exec.status)) continue;
 
         for (const interest of agent.eventInterests) {
           const sub: Subscription = {
@@ -487,15 +487,16 @@ class EventRouter {
 
   /**
    * Unregister subscriptions for a specific node execution.
-   * Called when a node execution transitions to a non-receiving state.
+   * Called when a node execution transitions to `cancelled` state.
    *
-   * Receiving states: in_progress (active agent session)
-   * Non-receiving states: pending, idle, waiting_rebind, blocked, cancelled
+   * Only `cancelled` nodes are removed from the subscription index.
+   * All other states (`pending`, `in_progress`, `idle`, `waiting_rebind`,
+   * `blocked`) remain subscribed because:
+   * - `in_progress`: live session receives events immediately
+   * - `idle`: session exists and can be woken via injectMessage (defer mode)
+   * - `waiting_rebind`/`blocked`/`pending`: events queued for later delivery
    *
-   * For `idle` and `waiting_rebind`, events may still be relevant (agent
-   * could be re-activated), so we keep subscriptions but skip delivery
-   * (the event is queued in the in-memory pending queue instead).
-   * For `blocked`/`cancelled`, subscriptions are fully removed.
+   * See `isReceivingStatus` helper for the complete state classification.
    */
   unregisterExecution(
     workflowRunId: string,
@@ -610,22 +611,32 @@ class EventRouter {
       }
 
       case 'task': {
-        // Check if event's PR number matches any task in this workflow run.
-        // Note: a workflow run CAN have multiple tasks (e.g., sub-tasks created
-        // by the planner). We check ALL non-archived tasks for a PR match.
+        // The DaemonHub 'space.githubEvent.routed' event already carries the
+        // resolved taskId from SpacePrTaskResolver. We use that directly instead
+        // of re-running the resolver, which could match a historical task outside
+        // this run (SpacePrTaskResolver searches ALL tasks in the space).
+        //
+        // We constrain matching to tasks within THIS workflow run only:
+        // 1. Load all non-archived tasks for this run.
+        // 2. Check if the event's routed taskId is among them.
         if (!event.prNumber) return false;
-        const tasks = this.taskRepo.listByWorkflowRun(sub.workflowRunId);
-        if (tasks.length === 0) return false;
 
-        // The SpacePrTaskResolver already handles the PR → task matching logic.
-        // For the common case (1 task per run), this is a single lookup.
-        // For multi-task runs, we check if any task matches.
+        // Optimization: the adapter includes the routed taskId in ExternalEvent.payload.
+        // Use it for a direct membership check — no resolver call needed.
+        const routedTaskId = event.payload?.taskId as string | undefined;
+        if (routedTaskId) {
+          const tasks = this.taskRepo.listByWorkflowRun(sub.workflowRunId);
+          return tasks.some(t => t.id === routedTaskId);
+        }
+
+        // Fallback (should rarely happen): if the adapter didn't include taskId,
+        // load run tasks and check if any references the event's PR number.
+        const tasks = this.taskRepo.listByWorkflowRun(sub.workflowRunId);
         for (const task of tasks) {
           const resolved = this.prResolver.resolve(sub.spaceId, {
             repoOwner: event.repoOwner ?? '',
             repoName: event.repoName ?? '',
             prNumber: event.prNumber,
-            // ... minimal shape for resolver
           } as any);
           if (resolved.taskId === task.id) return true;
         }
@@ -778,19 +789,36 @@ class TrieNode<T> {
 
 ### Helper: `isReceivingStatus`
 
+Determines whether a node execution should remain in the subscription index.
+This is intentionally different from `TERMINAL_NODE_EXECUTION_STATUSES` in
+`node-execution-manager.ts`, which includes `idle`. For the event bus, `idle`
+nodes MUST stay subscribed because:
+
+1. The agent session still exists and can be woken via `injectMessage`.
+2. The `deliveryMode: 'defer'` mechanism handles idle sessions natively.
+3. Removing idle nodes from the subscription index would prevent wake-on-idle
+   delivery — the core use case for the event bus.
+
 ```typescript
 import type { NodeExecutionStatus } from '@neokai/shared';
 
-/** Node execution states that should NOT receive events. */
-const TERMINAL_RECEIVING_STATES: ReadonlySet<NodeExecutionStatus> = new Set([
+/**
+ * States where the node should be excluded from the subscription index.
+ * Only `cancelled` is excluded — the node has been permanently stopped.
+ *
+ * States that remain subscribed:
+ * - `pending`       — no session yet, events queued for first turn
+ * - `in_progress`   — live session, events injected immediately
+ * - `idle`          — session exists but finished a turn; events wake it
+ * - `waiting_rebind` — session paused for tool recovery; events queued
+ * - `blocked`       — session exists but waiting for human; events queued
+ */
+const NON_RECEIVING_STATES: ReadonlySet<NodeExecutionStatus> = new Set([
   'cancelled',
-  // Note: 'idle' and 'waiting_rebind' keep their subscriptions alive —
-  // the agent session exists and may be re-activated. Events are queued
-  // rather than delivered immediately for these states.
 ]);
 
 function isReceivingStatus(status: NodeExecutionStatus): boolean {
-  return !TERMINAL_RECEIVING_STATES.has(status);
+  return !NON_RECEIVING_STATES.has(status);
 }
 ```
 

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -407,7 +407,8 @@ class EventRouter {
   private static readonly DEDUP_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
   // Cache: spaceId → Set of "owner/repo" strings for watched repos
-  // Refreshed on spaceWorkflow.updated events (when watched repos change)
+  // Invalidated via invalidateWatchedRepoCache() when repos are added/removed
+  // through the `space.github.watchRepo` RPC path.
   private watchedRepoCache: Map<string, Set<string>> = new Map();
 
   constructor(
@@ -434,6 +435,20 @@ class EventRouter {
       this.watchedRepoCache.set(spaceId, cached);
     }
     return cached.has(`${owner.toLowerCase()}/${repo.toLowerCase()}`);
+  }
+
+  /**
+   * Invalidate the watched-repo cache for a given space (or all spaces).
+   * Called when watched repos change via the `space.github.watchRepo` RPC path
+   * (enabling/disabling repos). Without this, `repo`-scoped matching grows stale
+   * until process restart.
+   */
+  invalidateWatchedRepoCache(spaceId?: string): void {
+    if (spaceId) {
+      this.watchedRepoCache.delete(spaceId);
+    } else {
+      this.watchedRepoCache.clear();
+    }
   }
 
   /** Evict stale dedup entries (called periodically or on demand). */
@@ -472,8 +487,9 @@ class EventRouter {
 
         const subKey = `${node.id}:${agent.name}`;
         for (const interest of agent.eventInterests) {
-          // Include interest topic in key so a single agent can have multiple interests
-          const fullKey = `${subKey}:${interest.topic}`;
+          // Include topic AND scope in key — same agent can subscribe to the same topic
+          // with different scopes (e.g., both 'task' and 'repo' scope for the same pattern).
+          const fullKey = `${subKey}:${interest.topic}:${interest.scope}`;
           desiredSubs.set(fullKey, {
             workflowRunId,
             nodeId: node.id,
@@ -490,20 +506,22 @@ class EventRouter {
     const currentSubs = this.activeRuns.get(workflowRunId) ?? new Set<Subscription>();
     const currentKeys = new Set<string>();
     for (const sub of currentSubs) {
-      currentKeys.add(`${sub.nodeId}:${sub.agentName}:${sub.interest.topic}`);
+      currentKeys.add(`${sub.nodeId}:${sub.agentName}:${sub.interest.topic}:${sub.interest.scope}`);
     }
     const desiredKeys = new Set(desiredSubs.keys());
 
     // Remove subscriptions no longer in the desired set (e.g. node went cancelled).
     for (const key of currentKeys) {
       if (!desiredKeys.has(key)) {
-        const [nodeId, agentName, ...topicParts] = key.split(':');
-        const topic = topicParts.join(':');
+        const [nodeId, agentName, ...rest] = key.split(':');
+        const scope = rest.pop()!;
+        const topic = rest.join(':');
         this.topicTrie.remove(
           v => v.workflowRunId === workflowRunId
             && v.nodeId === nodeId
             && v.agentName === agentName
-            && v.interest.topic === topic,
+            && v.interest.topic === topic
+            && v.interest.scope === scope,
         );
       }
     }
@@ -1010,6 +1028,11 @@ packages/daemon/src/lib/space/runtime/event-bus/
  * Validate a glob pattern for event subscriptions.
  * Rejects patterns that could corrupt the trie or match unintended topics.
  * Called at workflow create/update time and again at trie insertion time.
+ *
+ * Requires at least 4 segments because all event topics have the format
+ * `{source}/{owner}/{repo}/{resource}.{action}` (4 segments minimum).
+ * Patterns like `github/*` would pass validation but never match any event,
+ * creating silent misconfigurations.
  */
 export function validateGlobPattern(pattern: string): { valid: boolean; reason?: string } {
   if (!pattern || pattern.trim().length === 0) {
@@ -1018,8 +1041,11 @@ export function validateGlobPattern(pattern: string): { valid: boolean; reason?:
 
   const segments = pattern.split('/');
 
-  if (segments.length < 2) {
-    return { valid: false, reason: 'Topic pattern must have at least 2 segments (source/resource)' };
+  if (segments.length < 4) {
+    return {
+      valid: false,
+      reason: `Topic pattern must have at least 4 segments (source/owner/repo/resource.action); got ${segments.length}. Example: 'github/*/*/pull_request.review_submitted'`,
+    };
   }
 
   for (const segment of segments) {
@@ -1066,6 +1092,11 @@ if (this.eventRouter) {
 if (newStatus === 'done' || newStatus === 'cancelled') {
   this.eventRouter.clearRunInterests(workflowRunId);
 }
+
+// In the `space.github.watchRepo` RPC handler (packages/daemon/src/lib/rpc-handlers/index.ts):
+// After persisting the watch/unwatch change, invalidate the watched-repo cache
+// so that repo-scoped matching reflects the new state immediately.
+await this.eventRouter.invalidateWatchedRepoCache(spaceId);
 
 // In daemon startup (e.g. in SpaceRuntimeService or init function):
 const eventBus = new EventBus(daemonHub);

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -181,7 +181,7 @@ export interface WorkflowNodeAgent {
 
 **`task` scope** is the critical innovation. The router resolves the task's context at match time:
 
-1. The task's `SpaceTask` record has `workflowRunId` and (via `workflow_run_artifacts` or gate data) an associated PR number and branch name.
+1. The task's `SpaceTask` record has `workflowRunId` and (via `space_workflow_run_artifacts` where `key = 'pr_url'` matches the event's `prUrl`, or gate data with `branch_name`) an associated PR number and branch name.
 2. The router queries the same `SpacePrTaskResolver` that `SpaceGitHubService` already uses to match PR numbers to tasks.
 3. For a `task`-scoped subscription, the router checks: does this event's PR number / branch match the node execution's parent task?
 4. The node author never specifies a PR number — it's implicit from the task context.

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -977,20 +977,29 @@ class TopicTrie<T> {
   }
 
   /**
-   * Remove all values matching a predicate.
+   * Remove all values matching a predicate and prune empty child branches.
    */
   remove(predicate: (value: T) => boolean): void {
-    const clean = (node: TrieNode<T>) => {
+    const clean = (node: TrieNode<T>): boolean => {
       if (node.values) {
         node.values = node.values.filter(v => !predicate(v));
+        if (node.values.length === 0) node.values = undefined;
       }
-      for (const child of node.exactChildren.values()) {
-        clean(child);
+
+      for (const [segment, child] of node.exactChildren.entries()) {
+        if (clean(child)) {
+          node.exactChildren.delete(segment);
+        }
       }
-      for (const child of node.globChildren.values()) {
-        clean(child);
+      for (const [segment, child] of node.globChildren.entries()) {
+        if (clean(child)) {
+          node.globChildren.delete(segment);
+        }
       }
+
+      return !node.values && node.exactChildren.size === 0 && node.globChildren.size === 0;
     };
+
     clean(this.root);
   }
 }

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -517,7 +517,13 @@ class EventRouter {
     nodeExecutions: NodeExecution[],
   ): void {
     // Build the desired set of subscriptions from current node execution states.
-    const desiredSubs = new Map<string, Subscription>();  // key: `${taskId}:${nodeId}:${agentName}:${topic}:${scope}`
+    // Use a structured tuple key encoded with JSON.stringify rather than a
+    // delimiter-joined string: task ids, node ids, agent names, topics, and scopes
+    // are free-form enough that ':' or other delimiters can appear in valid input.
+    const makeSubscriptionKey = (sub: Pick<Subscription, 'taskId' | 'nodeId' | 'agentName' | 'interest'>) =>
+      JSON.stringify([sub.taskId, sub.nodeId, sub.agentName, sub.interest.topic, sub.interest.scope]);
+
+    const desiredSubs = new Map<string, Subscription>();
 
     for (const node of workflow.nodes) {
       for (const agent of node.agents) {
@@ -528,13 +534,11 @@ class EventRouter {
         );
         if (!exec || !isReceivingStatus(exec.status)) continue;
 
-        const subKey = `${taskId}:${node.id}:${agent.name}`;
         for (const interest of agent.eventInterests) {
           // Include taskId, topic, and scope in key — the same run can contain
           // multiple tasks, and the same agent can subscribe to the same topic
           // with different scopes (e.g., both 'task' and 'repo' scope).
-          const fullKey = `${subKey}:${interest.topic}:${interest.scope}`;
-          desiredSubs.set(fullKey, {
+          const sub: Subscription = {
             workflowRunId,
             taskId,
             nodeId: node.id,
@@ -542,7 +546,8 @@ class EventRouter {
             interest,
             agentSessionId: exec.agentSessionId,
             spaceId,
-          });
+          };
+          desiredSubs.set(makeSubscriptionKey(sub), sub);
         }
       }
     }
@@ -552,32 +557,29 @@ class EventRouter {
     // subscriptions from the same run.
     const currentRunSubs = this.activeRuns.get(workflowRunId) ?? new Set<Subscription>();
     const currentTaskSubs = [...currentRunSubs].filter(sub => sub.taskId === taskId);
-    const currentKeys = new Set<string>();
+    const currentSubsByKey = new Map<string, Subscription>();
     for (const sub of currentTaskSubs) {
-      currentKeys.add(`${sub.taskId}:${sub.nodeId}:${sub.agentName}:${sub.interest.topic}:${sub.interest.scope}`);
+      currentSubsByKey.set(makeSubscriptionKey(sub), sub);
     }
     const desiredKeys = new Set(desiredSubs.keys());
 
     // Remove this task's subscriptions no longer in the desired set (e.g. node went cancelled).
-    for (const key of currentKeys) {
+    for (const [key, sub] of currentSubsByKey) {
       if (!desiredKeys.has(key)) {
-        const [subTaskId, nodeId, agentName, ...rest] = key.split(':');
-        const scope = rest.pop()!;
-        const topic = rest.join(':');
         this.topicTrie.remove(
           v => v.workflowRunId === workflowRunId
-            && v.taskId === subTaskId
-            && v.nodeId === nodeId
-            && v.agentName === agentName
-            && v.interest.topic === topic
-            && v.interest.scope === scope,
+            && v.taskId === sub.taskId
+            && v.nodeId === sub.nodeId
+            && v.agentName === sub.agentName
+            && v.interest.topic === sub.interest.topic
+            && v.interest.scope === sub.interest.scope,
         );
       }
     }
 
     // Add new subscriptions not currently in the trie.
     for (const [key, sub] of desiredSubs) {
-      if (!currentKeys.has(key)) {
+      if (!currentSubsByKey.has(key)) {
         this.topicTrie.insert(sub.interest.topic, sub);
       }
     }

--- a/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
+++ b/docs/plans/design-external-event-bus-for-space-workflow-nodes.md
@@ -61,7 +61,7 @@ github/lsm/neokai/pull_request.review_*     ← prefix wildcard: all review even
 
 1. `source` — adapter identifier (`github`, `slack`, `ci`). Lowercase, no slashes.
 2. `owner/repo` — from the event's repository context. Both lowercase for case-insensitive matching.
-3. `resource` — the event resource type. V1 GitHub adapter emits PR-related resources (`pull_request`, `pull_request.comment`, `pull_request.review`, `pull_request.review_comment`). CI resources such as `check_suite` are Phase 3/future adapter scope.
+3. `resource.action` — the fourth path segment is always one dotted pair. For V1 GitHub PR events, `resource` is `pull_request`; review/comment variants are encoded in `action` (`review_submitted`, `comment_created`, `review_comment_created`) so examples like `pull_request.review_submitted` remain canonical. CI resources such as `check_suite` are Phase 3/future adapter scope.
 4. `action` — the specific action: `opened`, `review_submitted`, `comment_created`, `completed`, etc.
 5. All v1 topics use exactly 4 path segments. For resources without a natural `owner/repo` (e.g. a future Slack message), use a source-specific scope pair to preserve the same depth: `{source}/{workspace}/{channel}/{resource}.{action}` (for example, `slack/acme/eng/messages.created`). Adapters that do not have both scope levels should use a reserved placeholder segment such as `_` rather than emitting 3-segment topics.
 
@@ -80,6 +80,7 @@ Pattern validation (enforced at workflow create/update time):
 - Must not contain `..` segments.
 - Must not contain empty segments (no double slashes).
 - Must have exactly 4 segments (`source/scope1/scope2/resource.action`) so it can match real event topics.
+- The 4th segment must contain a `resource.action` separator (`.`) with non-empty resource and action sides, allowing segment-local wildcards such as `pull_request.*`, `*.created`, and `*.*`.
 - Each segment may contain alphanumeric, dash, underscore, dot, and `*`; `*` must stay within a single segment and cannot cross `/` boundaries.
 - Max 10 interests per agent slot.
 
@@ -1093,6 +1094,8 @@ The `SpaceGitHubService` already normalizes to `SpaceGitHubEventKind` (`issue_co
 | `pull_request_review_comment` | `pull_request.review_comment_${action}` (created, edited, deleted) |
 | `pull_request` | `pull_request.${action}` (opened, synchronize, closed, etc.) |
 
+These return values are the complete fourth path segment (`resource.action`). For V1 PR events the resource side is always `pull_request`; `comment_*`, `review_*`, and `review_comment_*` are action names, not nested resource segments. The adapter must not emit doubled resource names such as `pull_request.review.review_submitted`.
+
 ```typescript
 function mapEventType(kind: string, action: string): string {
   switch (kind) {
@@ -1191,6 +1194,15 @@ export function validateGlobPattern(pattern: string): { valid: boolean; reason?:
         reason: `Segment "${segment}" contains invalid characters. Use alphanumeric, dash, underscore, dot, or segment-local "*" wildcard.`,
       };
     }
+  }
+
+  const resourceAction = segments[3];
+  const dotIndex = resourceAction.indexOf('.');
+  if (dotIndex <= 0 || dotIndex === resourceAction.length - 1) {
+    return {
+      valid: false,
+      reason: `Topic pattern fourth segment must be resource.action; got "${resourceAction}". Example: 'pull_request.review_submitted'`,
+    };
   }
 
   return { valid: true };

--- a/docs/research/retry-injection-after-dedupe-findings.md
+++ b/docs/research/retry-injection-after-dedupe-findings.md
@@ -1,0 +1,146 @@
+# Research Findings: Retry Delivery When Injection Fails After Dedupe Marking
+
+## Issue Summary
+**P1 Review Comment** on PR #1777 (Design: external event bus for Space workflow nodes):
+> Marking the event as delivered before attempting `injectMessage` creates permanent loss on transient delivery failures. The design justifies this by saying a restart poll will emit a fresh event, but in the current pipeline `SpaceGitHubService.ingest` short-circuits duplicates from `storeEvent` and does not re-route the same `dedupeKey`, so a failed injection will not be retried for that subscription.
+
+## Investigation
+
+### Affected Components
+1. **Design Document**: `docs/plans/design-external-event-bus-for-space-workflow-nodes.md` (PR #1777)
+   - Section 4: `deliverToSubscription` method marks dedup BEFORE injection
+   - Incorrect assumption: "upstream SpaceGitHubService re-polls on restart and will generate a fresh event"
+2. **Implementation Code**: `packages/daemon/src/lib/github/space-github.ts`
+   - `SpaceGitHubService.ingest()` short-circuits ALL duplicates (line 602)
+   - `flushTaskNotification()` marks state as 'delivered' only on success, but duplicate events never reach injection
+
+## Code Analysis
+
+### Dedupe Flow in `SpaceGitHubService`
+1. `ingest()` calls `storeEvent()` which uses `INSERT OR IGNORE` on `dedupe_key` (line 338)
+2. If duplicate: `ingest()` returns immediately (line 602: `if (stored.duplicate) return stored.event`)
+3. This means even if the original event's injection failed, subsequent events with the same `dedupeKey` are ignored entirely
+
+### Injection Failure Scenario
+1. Event arrives via webhook → `ingest()` → `storeEvent()` (new, state: 'received')
+2. Resolved to task → state updated to 'routed'
+3. `flushTaskNotification()` attempts `injectTaskAgent()` → fails (transient error)
+4. State remains 'routed' (not updated to 'delivered' or 'failed')
+5. Later, same event is polled from GitHub → `ingest()` → `storeEvent()` returns duplicate
+6. `ingest()` returns immediately → NO retry of injection → **permanent event loss**
+
+### Design Document Flaw
+The design document's `deliverToSubscription` method contains the same flawed logic:
+```typescript
+// Mark dedup BEFORE session resolution / queueing...
+this.delivered.set(dedupeKey, Date.now());
+
+// Later, on injection failure:
+catch (err) {
+  log.warn(`Failed to deliver event to ${sub.agentName}`, { error: err });
+  // Event is already dedup-marked so it won't be re-delivered for this run.
+  // A fresh event will arrive via the next poll cycle if the underlying external event is still relevant.
+}
+```
+
+This is incorrect because:
+- The "fresh event" from polling will have the same `dedupeKey`
+- `SpaceGitHubService.ingest()` will short-circuit it before it reaches the event bus
+- The event never gets re-delivered to the node
+
+## Root Cause
+1. **Premature dedup marking**: Both `SpaceGitHubService` and the design document mark events as "processed" before confirming successful delivery
+2. **Unconditional duplicate short-circuit**: `ingest()` doesn't distinguish between terminal states (delivered, ignored) and retry-able states (routed, failed)
+3. **No retry mechanism**: Failed injections are logged but never retried
+
+## Recommended Fixes
+
+### Fix 1: Update `SpaceGitHubService` (Implementation)
+1. **Modify `ingest()` to not short-circuit retry-able duplicates**:
+   ```typescript
+   async ingest(spaceId: string, event: NormalizedSpaceGitHubEvent): Promise<StoredSpaceGitHubEvent> {
+     const stored = this.repo.storeEvent({ spaceId, event });
+     if (stored.duplicate) {
+       // Only short-circuit if in terminal state
+       const existing = stored.event;
+       if (['delivered', 'ignored', 'ambiguous'].includes(existing.state)) {
+         return existing;
+       }
+       // For non-terminal states (routed, failed), re-process
+       // (injection will be retried via scheduleTaskNotification)
+     }
+     // ... rest of processing
+   }
+   ```
+
+2. **Add retry logic to `flushTaskNotification()`**:
+   - Track retry count in event state or separate map
+   - Retry with exponential backoff (max 3 retries)
+   - On max retries, update state to 'failed' (terminal)
+
+### Fix 2: Update Design Document (PR #1777)
+1. **Change dedup marking order**: Mark dedup AFTER successful injection, not before
+2. **Add pending state tracking**: Track "pending" deliveries to prevent duplicate queueing without preventing retries
+3. **Remove incorrect assumption**: Re-polling doesn't help because of `ingest()` short-circuit
+4. **Add retry mechanism**: For the event bus, retry failed deliveries with backoff
+
+### Proposed Design Document Changes
+In `deliverToSubscription()`:
+```typescript
+private async deliverToSubscription(event: ExternalEvent, sub: Subscription): Promise<void> {
+  // ... scope check ...
+
+  // Dedup check — use a "pending" set to prevent duplicate queueing, but allow retries
+  this.evictStaleDedup();
+  const dedupeKey = `${event.dedupeKey}:${sub.taskId}:${sub.nodeId}:${sub.agentName}:${sub.workflowRunId}`;
+
+  // Check if already delivered (terminal)
+  if (this.delivered.has(dedupeKey)) {
+    return;
+  }
+
+  // Check if pending (prevents duplicate queueing)
+  if (this.pendingDeliveries.has(dedupeKey)) {
+    return;
+  }
+
+  // Mark as pending (prevents duplicate queueing, but not retriable)
+  this.pendingDeliveries.add(dedupeKey);
+
+  try {
+    // Resolve session
+    const sessionId = await this.resolveSession(sub);
+    if (!sessionId) {
+      this.queueForDelivery(event, sub);
+      return; // Pending remains until queue is drained
+    }
+
+    // Inject
+    const message = this.formatEventMessage(event);
+    await this.sessionFactory.injectMessage(sessionId, message, { deliveryMode: 'defer' });
+
+    // Success: mark as delivered, remove pending
+    this.delivered.set(dedupeKey, Date.now());
+    this.pendingDeliveries.delete(dedupeKey);
+  } catch (err) {
+    // Failure: remove pending so it can be retried
+    this.pendingDeliveries.delete(dedupeKey);
+    log.warn(`Failed to deliver event to ${sub.agentName}`, { error: err });
+
+    // Optional: retry with backoff
+    this.scheduleRetry(event, sub, dedupeKey);
+  }
+}
+```
+
+## Conclusion
+The review comment is **valid**. The current design and implementation permanently lose events when transient injection failures occur. The fix requires:
+1. Not marking events as "processed" before confirming successful delivery
+2. Allowing retries for failed injections
+3. Updating `ingest()` to not short-circuit duplicates in non-terminal states
+
+## Next Steps
+1. Update design document in PR #1777 to reflect correct dedup logic
+2. Fix `SpaceGitHubService.ingest()` and `flushTaskNotification()` in code
+3. Add tests for injection retry scenarios
+4. Update documentation to reflect new delivery guarantees


### PR DESCRIPTION
## Summary
- Documents P1 issue from PR #1777 review comment about permanent event loss when injection fails after dedupe marking
- Details root cause: `SpaceGitHubService.ingest()` short-circuits duplicates unconditionally
- Recommends fixes: don't mark dedup before successful injection, add retry logic

## Findings
Full research document: `docs/research/retry-injection-after-dedupe-findings.md`

Key points:
- Design document incorrectly assumed re-polling would retry failed injections
- `ingest()` returns early for all duplicates, even if injection failed
- Fix requires pending state tracking and retry mechanism

🤖 Generated with [Claude Code](https://claude.com/claude-code)