### PR TITLE
Refactor OpenAI bridge session routing

### DIFF
--- a/packages/daemon/src/lib/provider-service.ts
+++ b/packages/daemon/src/lib/provider-service.ts
@@ -80,6 +80,7 @@ export interface ProviderEnvVars {
 	ANTHROPIC_DEFAULT_OPUS_MODEL?: string; // Map opus tier to provider model
 	API_TIMEOUT_MS?: string;
 	CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC?: string;
+	CLAUDE_CODE_OAUTH_TOKEN?: string;
 	[key: string]: string | undefined; // Index signature for SDK env option compatibility
 }
 
@@ -98,6 +99,7 @@ export interface OriginalEnvVars {
 	ANTHROPIC_DEFAULT_SONNET_MODEL?: string;
 	ANTHROPIC_DEFAULT_HAIKU_MODEL?: string;
 	ANTHROPIC_DEFAULT_OPUS_MODEL?: string;
+	CLAUDE_CODE_OAUTH_TOKEN?: string;
 	CLAUDE_AGENT_SDK_CLIENT_APP?: string;
 	/** Daemon's listening PORT — cleared from subprocess env to prevent kill-chain via lsof */
 	PORT?: string;
@@ -504,6 +506,14 @@ export class ProviderService {
 		const original: OriginalEnvVars = {};
 
 		// Save and set each env var
+		if (envVars.CLAUDE_CODE_OAUTH_TOKEN !== undefined) {
+			original.CLAUDE_CODE_OAUTH_TOKEN = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+			if (envVars.CLAUDE_CODE_OAUTH_TOKEN === '') {
+				delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+			} else {
+				process.env.CLAUDE_CODE_OAUTH_TOKEN = envVars.CLAUDE_CODE_OAUTH_TOKEN;
+			}
+		}
 		if (envVars.ANTHROPIC_AUTH_TOKEN !== undefined) {
 			original.ANTHROPIC_AUTH_TOKEN = process.env.ANTHROPIC_AUTH_TOKEN;
 			process.env.ANTHROPIC_AUTH_TOKEN = envVars.ANTHROPIC_AUTH_TOKEN;
@@ -575,6 +585,7 @@ export class ProviderService {
 		};
 
 		clear('ANTHROPIC_AUTH_TOKEN');
+		clear('CLAUDE_CODE_OAUTH_TOKEN');
 
 		// Preserve user's custom ANTHROPIC_BASE_URL from environment/settings.json
 		if (process.env.ANTHROPIC_BASE_URL !== undefined) {
@@ -695,6 +706,13 @@ export class ProviderService {
 				process.env.ANTHROPIC_AUTH_TOKEN = original.ANTHROPIC_AUTH_TOKEN;
 			} else {
 				delete process.env.ANTHROPIC_AUTH_TOKEN;
+			}
+		}
+		if (Object.prototype.hasOwnProperty.call(original, 'CLAUDE_CODE_OAUTH_TOKEN')) {
+			if (original.CLAUDE_CODE_OAUTH_TOKEN !== undefined) {
+				process.env.CLAUDE_CODE_OAUTH_TOKEN = original.CLAUDE_CODE_OAUTH_TOKEN;
+			} else {
+				delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
 			}
 		}
 		if (Object.prototype.hasOwnProperty.call(original, 'ANTHROPIC_BASE_URL')) {

--- a/packages/daemon/src/lib/provider-service.ts
+++ b/packages/daemon/src/lib/provider-service.ts
@@ -585,7 +585,6 @@ export class ProviderService {
 		};
 
 		clear('ANTHROPIC_AUTH_TOKEN');
-		clear('CLAUDE_CODE_OAUTH_TOKEN');
 
 		// Preserve user's custom ANTHROPIC_BASE_URL from environment/settings.json
 		if (process.env.ANTHROPIC_BASE_URL !== undefined) {

--- a/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
@@ -38,6 +38,7 @@ import {
 } from './codex-anthropic-bridge/server.js';
 import {
 	type OpenAIResponsesBridgeAuth,
+	type OpenAIResponsesBridgeServer,
 	createOpenAIResponsesBridgeServer,
 } from './openai-responses-bridge/server.js';
 import { getCodexBridgeModelInfos } from './codex-anthropic-bridge/model-context-windows.js';
@@ -229,8 +230,8 @@ export class AnthropicToCodexBridgeProvider implements Provider {
 		vision: false,
 	};
 
-	/** Per-adapter/per-workspace bridge servers. */
-	private readonly bridgeServers = new Map<string, BridgeServer>();
+	/** Per-adapter bridge servers. Codex remains workspace-scoped; Responses is shared by auth. */
+	private readonly bridgeServers = new Map<string, BridgeServer | OpenAIResponsesBridgeServer>();
 	private readonly bridgeServerAuthKeys = new Map<string, string>();
 
 	/** Path to NeoKai's own auth store. */
@@ -565,8 +566,8 @@ export class AnthropicToCodexBridgeProvider implements Provider {
 		const fileAuth = this.cachedCredentials ? this.toBridgeAuth(this.cachedCredentials) : undefined;
 		const auth = envAuth ?? this.cachedBridgeAuth ?? fileAuth ?? undefined;
 		const adapter = this.selectBridgeAdapter();
-		const bridgeKey = `${adapter}:${workspace}`;
 		const authKey = this.bridgeAuthCacheKey(auth);
+		const bridgeKey = adapter === 'responses' ? `responses:${authKey}` : `codex:${workspace}`;
 		let bridgeServer = this.bridgeServers.get(bridgeKey);
 		if (
 			adapter === 'responses' &&
@@ -610,14 +611,21 @@ export class AnthropicToCodexBridgeProvider implements Provider {
 			this.bridgeServers.set(bridgeKey, bridgeServer);
 			this.bridgeServerAuthKeys.set(bridgeKey, authKey);
 			logger.info(
-				`AnthropicToCodexBridgeProvider: ${adapter} bridge server started on port ${bridgeServer.port} for workspace=${workspace}`
+				`AnthropicToCodexBridgeProvider: ${adapter} bridge server started on port ${bridgeServer.port} for key=${bridgeKey}`
 			);
 		}
 
+		const bridgeBaseUrl =
+			adapter === 'responses'
+				? (bridgeServer as OpenAIResponsesBridgeServer).baseUrlForSession?.(sessionId) ||
+					`http://127.0.0.1:${bridgeServer.port}`
+				: `http://127.0.0.1:${bridgeServer.port}`;
+
 		return {
 			envVars: {
-				ANTHROPIC_BASE_URL: `http://127.0.0.1:${bridgeServer.port}`,
+				ANTHROPIC_BASE_URL: bridgeBaseUrl,
 				ANTHROPIC_API_KEY: `codex-bridge-${sessionId}`,
+				CLAUDE_CODE_OAUTH_TOKEN: '',
 				CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
 				// Map SDK model tiers to Codex model IDs so the Claude Agent SDK
 				// subprocess never falls back to Anthropic model names (e.g.

--- a/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
@@ -569,15 +569,13 @@ export class AnthropicToCodexBridgeProvider implements Provider {
 		const authKey = this.bridgeAuthCacheKey(auth);
 		const bridgeKey = adapter === 'responses' ? `responses:${authKey}` : `codex:${workspace}`;
 		let bridgeServer = this.bridgeServers.get(bridgeKey);
-		if (
-			adapter === 'responses' &&
-			bridgeServer &&
-			this.bridgeServerAuthKeys.get(bridgeKey) !== authKey
-		) {
-			bridgeServer.stop();
-			this.bridgeServers.delete(bridgeKey);
-			this.bridgeServerAuthKeys.delete(bridgeKey);
-			bridgeServer = undefined;
+		if (adapter === 'responses') {
+			for (const [key, server] of this.bridgeServers) {
+				if (!key.startsWith('responses:') || key === bridgeKey) continue;
+				server.stop();
+				this.bridgeServers.delete(key);
+				this.bridgeServerAuthKeys.delete(key);
+			}
 		}
 		// Resolve alias (e.g. 'codex' → 'gpt-5.3-codex') so ANTHROPIC_DEFAULT_*_MODEL
 		// receives real OpenAI model IDs that the bridge can forward upstream.

--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -34,6 +34,7 @@ const logger = new Logger('openai-responses-bridge-server');
 const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
 const DEFAULT_CHATGPT_CODEX_BASE_URL = 'https://chatgpt.com/backend-api/codex';
 const DEFAULT_RESPONSE_CONTINUATION_TTL_MS = 5 * 60 * 1000;
+const SESSION_ROUTE_PREFIX = '/_neokai/session/';
 
 export type OpenAIResponsesBridgeAuth = {
 	apiKey: string;
@@ -57,6 +58,7 @@ export type OpenAIResponsesBridgeModel = {
 
 export type OpenAIResponsesBridgeServer = {
 	port: number;
+	baseUrlForSession?(sessionId: string): string;
 	stop(): void;
 };
 
@@ -149,16 +151,34 @@ function generateMsgId(): string {
 	return `msg_${Math.random().toString(36).slice(2, 14)}`;
 }
 
-function extractSessionId(req: Request): string {
+function extractSessionId(req: Request): { sessionId: string; pathname: string } {
+	const url = new URL(req.url);
+	if (url.pathname.startsWith(SESSION_ROUTE_PREFIX)) {
+		const remainder = url.pathname.slice(SESSION_ROUTE_PREFIX.length);
+		const slashIndex = remainder.indexOf('/');
+		if (slashIndex > 0) {
+			const encodedSessionId = remainder.slice(0, slashIndex);
+			try {
+				return {
+					sessionId: decodeURIComponent(encodedSessionId),
+					pathname: remainder.slice(slashIndex) || '/',
+				};
+			} catch {
+				// Fall back to legacy auth-header parsing below for malformed route IDs.
+			}
+		}
+	}
+
 	const auth =
 		req.headers.get('Authorization') ??
 		req.headers.get('authorization') ??
 		req.headers.get('x-api-key') ??
 		'';
 	const token = auth.toLowerCase().startsWith('bearer ') ? auth.slice(7) : auth;
-	if (token.startsWith('codex-bridge-')) return token.slice('codex-bridge-'.length);
-	logger.warn('openai-responses: no session ID in bridge auth header, using default');
-	return 'default';
+	if (token.startsWith('codex-bridge-')) {
+		return { sessionId: token.slice('codex-bridge-'.length), pathname: url.pathname };
+	}
+	return { sessionId: 'default', pathname: url.pathname };
 }
 
 function continuationKey(sessionId: string, callId: string): string {
@@ -904,23 +924,22 @@ export function createOpenAIResponsesBridgeServer(
 		port: 0,
 		idleTimeout: 0,
 		async fetch(req: Request): Promise<Response> {
-			const url = new URL(req.url);
+			const route = extractSessionId(req);
 
-			if (url.pathname === '/health' || url.pathname === '/v1/health') {
+			if (route.pathname === '/health' || route.pathname === '/v1/health') {
 				return new Response('ok');
 			}
 
-			if (url.pathname === '/v1/models' && req.method === 'GET') {
+			if (route.pathname === '/v1/models' && req.method === 'GET') {
 				return new Response(JSON.stringify(modelsResponse), {
 					headers: { 'Content-Type': 'application/json' },
 				});
 			}
 
-			if (url.pathname === '/v1/messages/count_tokens' && req.method === 'POST') {
+			if (route.pathname === '/v1/messages/count_tokens' && req.method === 'POST') {
 				try {
 					const body = (await req.json()) as AnthropicRequest;
-					const sessionId = extractSessionId(req);
-					const continuation = resolveContinuation(sessionId, body.messages, continuations);
+					const continuation = resolveContinuation(route.sessionId, body.messages, continuations);
 					const inputTokens = continuation
 						? estimateResponsesPayloadTokens(body, continuation.input)
 						: estimateAnthropicInputTokens(body);
@@ -932,7 +951,7 @@ export function createOpenAIResponsesBridgeServer(
 				}
 			}
 
-			if (url.pathname !== '/v1/messages' || req.method !== 'POST') {
+			if (route.pathname !== '/v1/messages' || req.method !== 'POST') {
 				return sendJsonError(501, 'api_error', 'Not implemented');
 			}
 
@@ -959,7 +978,7 @@ export function createOpenAIResponsesBridgeServer(
 			}
 
 			const model = resolveModelId(body.model, config.modelAliases);
-			const sessionId = extractSessionId(req);
+			const sessionId = route.sessionId;
 			const resolvedContinuation = isChatgptOAuth
 				? undefined
 				: resolveContinuation(sessionId, body.messages, continuations);
@@ -1067,6 +1086,8 @@ export function createOpenAIResponsesBridgeServer(
 	logger.info(`openai-responses: HTTP server listening on port ${port}`);
 	return {
 		port,
+		baseUrlForSession: (sessionId: string) =>
+			`http://127.0.0.1:${port}${SESSION_ROUTE_PREFIX}${encodeURIComponent(sessionId)}`,
 		stop: () => {
 			for (const continuation of continuations.values()) {
 				clearTimeout(continuation.cleanupTimer);

--- a/packages/daemon/tests/unit/1-core/core/provider-service.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/provider-service.test.ts
@@ -101,6 +101,23 @@ class ThrowingMockProvider extends MockProvider {
 	}
 }
 
+class BridgeMockProvider extends MockProvider {
+	constructor() {
+		super('bridge', 'Bridge Provider', true, 'bridge-');
+	}
+
+	buildSdkConfig(): ProviderSdkConfig {
+		return {
+			envVars: {
+				ANTHROPIC_BASE_URL: 'http://127.0.0.1:12345',
+				ANTHROPIC_API_KEY: 'bridge-session-key',
+				CLAUDE_CODE_OAUTH_TOKEN: '',
+			},
+			isAnthropicCompatible: true,
+		};
+	}
+}
+
 // GLM-like provider for testing
 class GlmMockProvider extends MockProvider {
 	readonly id = 'glm' as const;
@@ -777,6 +794,20 @@ describe('ProviderService', () => {
 			});
 
 			service.restoreEnvVars(original);
+		});
+
+		it('clears CLAUDE_CODE_OAUTH_TOKEN when provider returns empty-string sentinel, restores on restoreEnvVars', () => {
+			registry.register(new BridgeMockProvider());
+			process.env.CLAUDE_CODE_OAUTH_TOKEN = 'real-oauth-token';
+
+			const original = service.applyEnvVarsToProcess('bridge-model', 'bridge');
+
+			expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+			expect(original.CLAUDE_CODE_OAUTH_TOKEN).toBe('real-oauth-token');
+			expect(process.env.ANTHROPIC_BASE_URL).toBe('http://127.0.0.1:12345');
+
+			service.restoreEnvVars(original);
+			expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBe('real-oauth-token');
 		});
 
 		it('blanks ANTHROPIC_API_KEY when provider returns empty-string sentinel, restores on restoreEnvVars', () => {

--- a/packages/daemon/tests/unit/1-core/core/provider-service.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/provider-service.test.ts
@@ -729,10 +729,11 @@ describe('ProviderService', () => {
 			expect(original).toEqual({});
 		});
 
-		it('should clear leaked GLM routing vars for anthropic model', () => {
+		it('should clear leaked GLM routing vars for anthropic model without clearing OAuth auth', () => {
 			process.env.ANTHROPIC_BASE_URL = 'https://api.glm.example.com';
 			process.env.API_TIMEOUT_MS = '120000';
 			process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = 'glm-4';
+			process.env.CLAUDE_CODE_OAUTH_TOKEN = 'user-oauth-token';
 
 			const original = service.applyEnvVarsToProcess('claude-3-opus', 'anthropic');
 
@@ -742,6 +743,7 @@ describe('ProviderService', () => {
 			expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined();
 			expect(process.env.API_TIMEOUT_MS).toBeUndefined();
 			expect(process.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBeUndefined();
+			expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBe('user-oauth-token');
 		});
 
 		it('should apply GLM env vars and return original values', () => {

--- a/packages/daemon/tests/unit/1-core/providers/anthropic-to-codex-bridge-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/anthropic-to-codex-bridge-provider.test.ts
@@ -497,25 +497,33 @@ describe('AnthropicToCodexBridgeProvider', () => {
 					max_tokens: 128,
 					messages: [{ role: 'user', content: 'hi' }],
 				});
-				const fetchLocal = async (baseUrl: unknown) => {
-					const resp = await originalFetch(`${baseUrl}/v1/messages`, {
-						method: 'POST',
-						headers: { 'Content-Type': 'application/json' },
-						body,
-					});
-					await resp.text();
+				const fetchLocal = async (baseUrl: unknown): Promise<number> => {
+					try {
+						const resp = await originalFetch(`${baseUrl}/v1/messages`, {
+							method: 'POST',
+							headers: { 'Content-Type': 'application/json' },
+							body,
+						});
+						await resp.text();
+						return resp.status;
+					} catch {
+						return 0;
+					}
 				};
 
 				const firstCfg = p.buildSdkConfig('gpt-5.3-codex', {
 					workspacePath: '/tmp/workspace-auth-change',
 				});
-				await fetchLocal(firstCfg.envVars.ANTHROPIC_BASE_URL);
+				const firstBaseUrl = firstCfg.envVars.ANTHROPIC_BASE_URL;
+				await fetchLocal(firstBaseUrl);
 
 				env.OPENAI_API_KEY = 'sk-second';
 				const secondCfg = p.buildSdkConfig('gpt-5.3-codex', {
 					workspacePath: '/tmp/workspace-auth-change',
 				});
-				await fetchLocal(secondCfg.envVars.ANTHROPIC_BASE_URL);
+				const secondBaseUrl = secondCfg.envVars.ANTHROPIC_BASE_URL;
+				await fetchLocal(secondBaseUrl);
+				expect(await fetchLocal(firstBaseUrl)).toBe(0);
 
 				env.OPENAI_API_KEY = undefined;
 				writeNeokaiAuth(neokaiDir, {
@@ -527,7 +535,9 @@ describe('AnthropicToCodexBridgeProvider', () => {
 				const oauthCfg = p.buildSdkConfig('gpt-5.3-codex', {
 					workspacePath: '/tmp/workspace-auth-change',
 				});
-				await fetchLocal(oauthCfg.envVars.ANTHROPIC_BASE_URL);
+				const oauthBaseUrl = oauthCfg.envVars.ANTHROPIC_BASE_URL;
+				await fetchLocal(oauthBaseUrl);
+				expect(await fetchLocal(secondBaseUrl)).toBe(0);
 
 				expect(capturedRequests).toMatchObject([
 					{

--- a/packages/daemon/tests/unit/1-core/providers/anthropic-to-codex-bridge-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/anthropic-to-codex-bridge-provider.test.ts
@@ -383,7 +383,7 @@ describe('AnthropicToCodexBridgeProvider', () => {
 	// buildSdkConfig() — workspace isolation
 	// -------------------------------------------------------------------------
 
-	describe('buildSdkConfig() workspace isolation', () => {
+	describe('buildSdkConfig() bridge server routing', () => {
 		beforeEach(() => {
 			provider = makeProvider(
 				{ OPENAI_API_KEY: 'sk-placeholder' },
@@ -393,14 +393,34 @@ describe('AnthropicToCodexBridgeProvider', () => {
 			);
 		});
 
-		it('starts separate bridge servers for different workspace paths', () => {
+		it('shares the Responses bridge server across workspace paths with the same auth', () => {
 			const cfgA = provider.buildSdkConfig('gpt-5.3-codex', { workspacePath: '/tmp/workspace-a' });
 			const cfgB = provider.buildSdkConfig('gpt-5.3-codex', { workspacePath: '/tmp/workspace-b' });
 
 			const urlA = cfgA.envVars.ANTHROPIC_BASE_URL as string;
 			const urlB = cfgB.envVars.ANTHROPIC_BASE_URL as string;
-			expect(urlA).not.toBe(urlB);
-			expect(new URL(urlA).port).not.toBe(new URL(urlB).port);
+			expect(urlA).toBe(urlB);
+			expect(new URL(urlA).port).toBe(new URL(urlB).port);
+		});
+
+		it('keeps Codex adapter bridge servers scoped by workspace path', () => {
+			const p = makeProvider(
+				{ OPENAI_API_KEY: 'sk-placeholder', NEOKAI_OPENAI_BRIDGE_ADAPTER: 'codex' },
+				undefined,
+				undefined,
+				fakeCodexFound
+			);
+			try {
+				const cfgA = p.buildSdkConfig('gpt-5.3-codex', { workspacePath: '/tmp/workspace-a' });
+				const cfgB = p.buildSdkConfig('gpt-5.3-codex', { workspacePath: '/tmp/workspace-b' });
+
+				const urlA = cfgA.envVars.ANTHROPIC_BASE_URL as string;
+				const urlB = cfgB.envVars.ANTHROPIC_BASE_URL as string;
+				expect(urlA).not.toBe(urlB);
+				expect(new URL(urlA).port).not.toBe(new URL(urlB).port);
+			} finally {
+				p.stopAllBridgeServers();
+			}
 		});
 
 		it('reuses the same bridge server for the same workspace path', () => {
@@ -533,11 +553,14 @@ describe('AnthropicToCodexBridgeProvider', () => {
 			}
 		});
 
-		it('returns isAnthropicCompatible=true and a placeholder API key', () => {
+		it('returns isAnthropicCompatible=true and clears OAuth token precedence', () => {
 			const cfg = provider.buildSdkConfig('gpt-5.3-codex', { workspacePath: '/tmp/ws-compat' });
 			expect(cfg.isAnthropicCompatible).toBe(true);
 			expect(cfg.envVars.ANTHROPIC_API_KEY).toBe('codex-bridge-default');
-			expect(cfg.envVars.ANTHROPIC_BASE_URL).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+			expect(cfg.envVars.CLAUDE_CODE_OAUTH_TOKEN).toBe('');
+			expect(cfg.envVars.ANTHROPIC_BASE_URL).toMatch(
+				/^http:\/\/127\.0\.0\.1:\d+\/_neokai\/session\/default$/
+			);
 		});
 
 		it('buildSdkConfig() uses cached API key resolved by prior getApiKey() call', async () => {
@@ -552,7 +575,9 @@ describe('AnthropicToCodexBridgeProvider', () => {
 				// buildSdkConfig() is synchronous but should use the cached key
 				const cfg = p.buildSdkConfig('gpt-5.3-codex', { workspacePath: '/tmp/file-auth-ws' });
 				expect(cfg.isAnthropicCompatible).toBe(true);
-				expect(cfg.envVars.ANTHROPIC_BASE_URL).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+				expect(cfg.envVars.ANTHROPIC_BASE_URL).toMatch(
+					/^http:\/\/127\.0\.0\.1:\d+\/_neokai\/session\/default$/
+				);
 				p.stopAllBridgeServers();
 			} finally {
 				rmSync(tmpDir, { recursive: true, force: true });
@@ -574,7 +599,9 @@ describe('AnthropicToCodexBridgeProvider', () => {
 				await p.getApiKey(); // populates cachedApiKey
 				const cfg = p.buildSdkConfig('gpt-5.3-codex', { workspacePath: '/tmp/empty-env-ws' });
 				expect(cfg.isAnthropicCompatible).toBe(true);
-				expect(cfg.envVars.ANTHROPIC_BASE_URL).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+				expect(cfg.envVars.ANTHROPIC_BASE_URL).toMatch(
+					/^http:\/\/127\.0\.0\.1:\d+\/_neokai\/session\/default$/
+				);
 				p.stopAllBridgeServers();
 			} finally {
 				rmSync(tmpDir, { recursive: true, force: true });

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
@@ -393,6 +393,121 @@ describe('openai-responses-bridge server', () => {
 		expect(capturedBodies[2]?.previous_response_id).toBeUndefined();
 	});
 
+	it('can route continuation mappings with session-scoped URLs instead of auth headers', async () => {
+		const capturedBodies: Record<string, unknown>[] = [];
+		server = createOpenAIResponsesBridgeServer({
+			auth: { source: 'api_key', apiKey: 'sk-test' },
+			models,
+			fetchImpl: async (_url, init) => {
+				const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+				capturedBodies.push(body);
+				if (capturedBodies.length === 1) {
+					return sse([
+						{
+							event: 'response.function_call_arguments.done',
+							data: {
+								type: 'response.function_call_arguments.done',
+								call_id: 'call_shared',
+								name: 'lookup',
+								arguments: '{"q":"weather"}',
+							},
+						},
+						{
+							event: 'response.completed',
+							data: {
+								type: 'response.completed',
+								response: {
+									id: 'resp_session_a',
+									usage: { input_tokens: 10, output_tokens: 4 },
+									output: [],
+								},
+							},
+						},
+					]);
+				}
+				return sse([
+					{
+						event: 'response.completed',
+						data: {
+							type: 'response.completed',
+							response: {
+								id: 'resp_done',
+								usage: { input_tokens: 2, output_tokens: 0 },
+								output: [],
+							},
+						},
+					},
+				]);
+			},
+		});
+
+		const sessionAUrl = server.baseUrlForSession?.('session-a') ?? '';
+		const sessionBUrl = server.baseUrlForSession?.('session-b') ?? '';
+		expect(sessionAUrl).toContain('/_neokai/session/session-a');
+
+		const first = await fetch(`${sessionAUrl}/v1/messages`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: 'Bearer real-sdk-oauth-token',
+			},
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [{ role: 'user', content: 'Use the tool.' }],
+				tools: [{ name: 'lookup', input_schema: { type: 'object' } }],
+			}),
+		});
+		await readSSEEvents(first.body);
+
+		const continuationBody = JSON.stringify({
+			model: 'gpt-5.3-codex',
+			max_tokens: 128,
+			messages: [
+				{ role: 'user', content: 'Use the tool.' },
+				{
+					role: 'assistant',
+					content: [
+						{
+							type: 'tool_use',
+							id: 'call_shared',
+							name: 'lookup',
+							input: { q: 'weather' },
+						},
+					],
+				},
+				{
+					role: 'user',
+					content: [{ type: 'tool_result', tool_use_id: 'call_shared', content: 'found' }],
+				},
+			],
+			tools: [{ name: 'lookup', input_schema: { type: 'object' } }],
+		});
+
+		const second = await fetch(`${sessionBUrl}/v1/messages`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: 'Bearer real-sdk-oauth-token',
+			},
+			body: continuationBody,
+		});
+		await readSSEEvents(second.body);
+
+		const third = await fetch(`${sessionAUrl}/v1/messages`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: 'Bearer real-sdk-oauth-token',
+			},
+			body: continuationBody,
+		});
+		await readSSEEvents(third.body);
+
+		expect(capturedBodies[1]?.previous_response_id).toBeUndefined();
+		expect(capturedBodies[2]?.previous_response_id).toBe('resp_session_a');
+	});
+
 	it('keeps continuation mappings isolated by bridge session', async () => {
 		const capturedBodies: Record<string, unknown>[] = [];
 		server = createOpenAIResponsesBridgeServer({


### PR DESCRIPTION
Routes OpenAI Responses bridge sessions through session-scoped local URLs instead of SDK credential headers.

Also clears inherited Claude OAuth tokens for bridge provider SDK subprocesses and keeps the legacy Codex adapter workspace-scoped.