### PR TITLE
Fix Gemini OAuth redirect mismatch

### DIFF
--- a/packages/daemon/src/lib/providers/gemini/gemini-provider.ts
+++ b/packages/daemon/src/lib/providers/gemini/gemini-provider.ts
@@ -321,7 +321,8 @@ export class GeminiOAuthProvider implements Provider {
 		});
 
 		const callbackPort = server.port ?? 0;
-		const redirectUri = `http://localhost:${callbackPort}/callback`;
+		// Match Gemini CLI's loopback redirect path for the default desktop client.
+		const redirectUri = `http://127.0.0.1:${callbackPort}/oauth2callback`;
 
 		// Build the auth URL with the local callback redirect URI.
 		// If URL generation fails (e.g. missing OAuth env vars), stop the

--- a/packages/daemon/src/lib/providers/gemini/oauth-client.ts
+++ b/packages/daemon/src/lib/providers/gemini/oauth-client.ts
@@ -27,21 +27,25 @@ const log = createLogger('kai:providers:gemini:oauth');
  * treated as secrets:
  * https://developers.google.com/identity/protocols/oauth2#installed
  *
- * The default values are the Antigravity/Gemini desktop credentials whose
- * allowed scopes match OAUTH_SCOPES below.
+ * The default values are the Gemini CLI desktop credentials. Gemini CLI uses
+ * these credentials with `https://codeassist.google.com/authcode` for the
+ * manual code-entry flow and loopback redirects for browser callback flows.
  */
 export const DEFAULT_GEMINI_OAUTH_CLIENT_ID = [
-	'1071006060591',
-	'tmhssin2h21lcre235vtolojh4g403ep',
+	'681255809395',
+	'oo8ft2oprdrnp9e3aqf6av3hmdib135j',
 	'apps.googleusercontent.com',
 ]
 	.join('-')
 	.replace('-apps', '.apps');
 
-/** Default Google OAuth client secret for the desktop app flow. */
-export const DEFAULT_GEMINI_OAUTH_CLIENT_SECRET = ['GOCSPX', 'K58FWR486LdLJ1mLB8sXC4z6qDAf'].join(
-	'-'
-);
+/** Default Google OAuth client secret for the Gemini CLI desktop app flow. */
+export const DEFAULT_GEMINI_OAUTH_CLIENT_SECRET = [
+	'GOCSPX',
+	'4uHgMPm',
+	'1o7Sk',
+	'geV6Cu5clXFsxl',
+].join('-');
 
 /** Google OAuth client ID. Env var override is supported. */
 export function getOAuthClientId(): string {

--- a/packages/daemon/tests/unit/1-core/providers/gemini-oauth-client.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/gemini-oauth-client.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it, mock, beforeEach, afterEach } from 'bun:test';
 import {
 	buildAuthUrl,
+	REDIRECT_URI,
 	exchangeAuthCode,
 	refreshAccessToken,
 	fetchUserInfo,
@@ -60,12 +61,20 @@ describe('Google Gemini OAuth Client', () => {
 	});
 
 	describe('OAuth credentials', () => {
-		it('uses default public desktop app credentials when env vars are unset', () => {
+		it('uses Gemini CLI public desktop app credentials when env vars are unset', () => {
 			delete process.env.GOOGLE_GEMINI_CLIENT_ID;
 			delete process.env.GOOGLE_GEMINI_CLIENT_SECRET;
 
 			expect(getOAuthClientId()).toBe(DEFAULT_GEMINI_OAUTH_CLIENT_ID);
 			expect(getOAuthClientSecret()).toBe(DEFAULT_GEMINI_OAUTH_CLIENT_SECRET);
+			expect(DEFAULT_GEMINI_OAUTH_CLIENT_ID).toBe(
+				['681255809395', 'oo8ft2oprdrnp9e3aqf6av3hmdib135j', 'apps.googleusercontent.com']
+					.join('-')
+					.replace('-apps', '.apps')
+			);
+			expect(DEFAULT_GEMINI_OAUTH_CLIENT_SECRET).toBe(
+				['GOCSPX', '4uHgMPm', '1o7Sk', 'geV6Cu5clXFsxl'].join('-')
+			);
 		});
 
 		it('uses env var credentials when provided', () => {
@@ -77,13 +86,15 @@ describe('Google Gemini OAuth Client', () => {
 	describe('buildAuthUrl', () => {
 		it('returns an auth URL with the correct parameters', async () => {
 			const { authUrl, codeVerifier } = await buildAuthUrl();
+			const params = new URL(authUrl).searchParams;
 
 			expect(authUrl).toContain('accounts.google.com/o/oauth2/v2/auth');
-			expect(authUrl).toContain('client_id=');
-			expect(authUrl).toContain('redirect_uri=');
-			expect(authUrl).toContain('code_challenge=');
-			expect(authUrl).toContain('code_challenge_method=S256');
-			expect(authUrl).toContain('access_type=offline');
+			expect(params.get('client_id')).toBe('test-client-id');
+			expect(params.get('redirect_uri')).toBe(REDIRECT_URI);
+			expect(params.get('redirect_uri')).toBe('https://codeassist.google.com/authcode');
+			expect(params.get('code_challenge')).toBeTruthy();
+			expect(params.get('code_challenge_method')).toBe('S256');
+			expect(params.get('access_type')).toBe('offline');
 			expect(codeVerifier).toBeTruthy();
 			expect(codeVerifier.length).toBeGreaterThan(20);
 		});

--- a/packages/daemon/tests/unit/1-core/providers/gemini-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/gemini-provider.test.ts
@@ -109,13 +109,15 @@ describe('GeminiOAuthProvider', () => {
 	});
 
 	describe('startOAuthFlow', () => {
-		it('returns an auth URL', async () => {
+		it('returns an auth URL with the Gemini CLI loopback callback redirect', async () => {
 			const provider = new GeminiOAuthProvider();
 			const flow = await provider.startOAuthFlow();
+			const params = new URL(flow.authUrl!).searchParams;
 
 			expect(flow.type).toBe('redirect');
 			expect(flow.authUrl).toContain('accounts.google.com');
 			expect(flow.authUrl).toContain('client_id=');
+			expect(params.get('redirect_uri')).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/oauth2callback$/);
 			expect(flow.message).toContain('authorize');
 		});
 	});


### PR DESCRIPTION
Switch Gemini OAuth defaults to the Gemini CLI desktop client so the manual code-entry redirect URI matches Google's registered client.

Gemini CLI proof: google-gemini/gemini-cli `packages/core/src/code_assist/oauth2.ts` defines the same desktop client credentials, uses `https://codeassist.google.com/authcode` for the user-code flow, and uses `http://127.0.0.1:${port}/oauth2callback` for the local callback flow.

Tests: bun test --preload=./packages/daemon/tests/unit/setup.ts ./packages/daemon/tests/unit/1-core/providers/gemini-oauth-client.test.ts ./packages/daemon/tests/unit/1-core/providers/gemini-provider.test.ts ./packages/daemon/tests/unit/2-handlers/rpc-handlers/gemini-auth-handlers.test.ts; bun run typecheck; bun run format:check