### PR TITLE
Make task thread composer fully target-aware: per-agent model, thinking, and tools

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -703,6 +703,18 @@ export function setupSessionHandlers(
 		return { success: true, thinkingLevel };
 	});
 
+	messageHub.onRequest('session.thinking.get', async (data) => {
+		const { sessionId: targetSessionId } = data as { sessionId: string };
+
+		const agentSession = await sessionManager.getSessionAsync(targetSessionId);
+		if (!agentSession) {
+			throw new Error('Session not found');
+		}
+
+		const thinkingLevel = agentSession.getSessionData().config.thinkingLevel ?? 'auto';
+		return { thinkingLevel };
+	});
+
 	// Handle listing available models
 	messageHub.onRequest('models.list', async (data) => {
 		try {

--- a/packages/daemon/tests/unit/2-handlers/rpc/session-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc/session-handlers.test.ts
@@ -1362,6 +1362,49 @@ describe('Session RPC Handlers', () => {
 		});
 	});
 
+	describe('session.thinking.get', () => {
+		it('returns the current thinking level', async () => {
+			const handler = messageHubData.handlers.get('session.thinking.get');
+			expect(handler).toBeDefined();
+
+			const result = await handler!({ sessionId: 'session-123' }, {});
+
+			expect(result).toEqual({ thinkingLevel: 'auto' });
+		});
+
+		it('returns think32k when configured', async () => {
+			const handler = messageHubData.handlers.get('session.thinking.get');
+			expect(handler).toBeDefined();
+
+			// Override the mock session data to have a non-default thinking level
+			const customSession = createMockAgentSession({
+				config: {
+					model: 'claude-sonnet-4-20250514',
+					provider: 'anthropic',
+					coordinatorMode: false,
+					sandbox: { enabled: true },
+					thinkingLevel: 'think32k',
+				},
+			});
+			sessionManagerData.mocks.getSessionAsync.mockResolvedValueOnce(customSession.agentSession);
+
+			const result = await handler!({ sessionId: 'session-123' }, {});
+
+			expect(result).toEqual({ thinkingLevel: 'think32k' });
+		});
+
+		it('throws error when session not found', async () => {
+			const handler = messageHubData.handlers.get('session.thinking.get');
+			expect(handler).toBeDefined();
+
+			sessionManagerData.mocks.getSessionAsync.mockResolvedValueOnce(null);
+
+			await expect(handler!({ sessionId: 'non-existent' }, {})).rejects.toThrow(
+				'Session not found'
+			);
+		});
+	});
+
 	describe('models.list', () => {
 		it('returns list of models', async () => {
 			const handler = messageHubData.handlers.get('models.list');

--- a/packages/web/src/components/ChatComposer.tsx
+++ b/packages/web/src/components/ChatComposer.tsx
@@ -52,6 +52,8 @@ export interface ChatComposerProps {
 	agentMentionCandidates?: Array<{ id: string; name: string }>;
 	/** Override the default placeholder text in the message input */
 	inputPlaceholder?: string;
+	/** Optional callback to intercept thinking-level changes instead of letting SessionStatusBar call the RPC directly */
+	onThinkingLevelChange?: (level: ThinkingLevel) => Promise<void> | void;
 	inputLeadingElement?: ComponentChildren;
 	inputLeadingPaddingClass?: string;
 	onDraftActiveChange?: (hasDraft: boolean) => void;
@@ -98,6 +100,7 @@ export function ChatComposer({
 	inputLeadingElement,
 	inputLeadingPaddingClass,
 	onDraftActiveChange,
+	onThinkingLevelChange,
 	errorMessage,
 }: ChatComposerProps) {
 	return (
@@ -141,6 +144,7 @@ export function ChatComposer({
 					sandboxSwitching={sandboxSwitching}
 					onSandboxModeChange={onSandboxModeChange}
 					thinkingLevel={thinkingLevel}
+					onThinkingLevelChange={onThinkingLevelChange}
 				/>
 
 				{sessionStatus === 'archived' ? (

--- a/packages/web/src/components/SessionStatusBar.tsx
+++ b/packages/web/src/components/SessionStatusBar.tsx
@@ -205,6 +205,7 @@ interface SessionStatusBarProps {
 	onSandboxModeChange: (enabled: boolean) => void;
 	// Thinking level
 	thinkingLevel?: ThinkingLevel;
+	onThinkingLevelChange?: (level: ThinkingLevel) => Promise<void> | void;
 }
 
 export default function SessionStatusBar({
@@ -230,6 +231,7 @@ export default function SessionStatusBar({
 	sandboxSwitching = false,
 	onSandboxModeChange,
 	thinkingLevel: thinkingLevelProp,
+	onThinkingLevelChange,
 }: SessionStatusBarProps) {
 	// Use useState + useSignalEffect to ensure component re-renders on signal change
 	// This is more explicit than relying on implicit signal tracking
@@ -341,13 +343,18 @@ export default function SessionStatusBar({
 			setThinkingLevel(level);
 			thinkingDropdown.close();
 
+			if (onThinkingLevelChange) {
+				await onThinkingLevelChange(level);
+				return;
+			}
+
 			// Persist to session config via RPC
 			await callIfConnected('session.thinking.set', {
 				sessionId: _sessionId,
 				level,
 			});
 		},
-		[_sessionId, callIfConnected, thinkingDropdown]
+		[_sessionId, callIfConnected, thinkingDropdown, onThinkingLevelChange]
 	);
 
 	// Get current model icon

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -27,7 +27,8 @@ import { SpaceTaskUnifiedThread } from './SpaceTaskUnifiedThread';
 import { SubmitForReviewModal } from './SubmitForReviewModal';
 import { TaskArtifactsPanel } from './TaskArtifactsPanel';
 import { TaskBlockedBanner } from './TaskBlockedBanner';
-import { type TaskComposerTarget, TaskSessionChatComposer } from './TaskSessionChatComposer';
+import { TaskSessionChatComposer } from './TaskSessionChatComposer';
+import { type TaskComposerTarget } from '../../hooks';
 import { getTransitionActions } from './TaskStatusActions';
 import { useRunGateSummaries } from './use-run-gate-summaries.ts';
 

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -307,14 +307,15 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 
 	// Extract per-agent default models from the workflow definition so the
 	// composer can show the workflow-defined model as the default for agents
-	// that haven't started yet.
+	// that haven't started yet. Keyed by target ID (node:${nodeId}:${agentName})
+	// to avoid collisions when multiple nodes reuse the same agent slot name.
 	const defaultAgentModels = useMemo(() => {
 		const map = new Map<string, string>();
 		if (!workflow) return map;
 		for (const node of workflow.nodes) {
 			for (const agent of node.agents) {
 				if (agent.model) {
-					map.set(agent.name, agent.model);
+					map.set(`node:${node.id}:${agent.name}`, agent.model);
 				}
 			}
 		}

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -981,6 +981,7 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 								errorMessage={threadSendError}
 								activityMembers={activityMembers}
 								defaultAgentModels={defaultAgentModels}
+								taskId={task.id}
 								onAutoScrollChange={setAutoScrollEnabled}
 								onTargetSelect={(targetId) => {
 									setSelectedTargetId(targetId);

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -304,6 +304,23 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 
 		return nodeTargets.length > 0 ? [...nodeTargets, taskAgentTarget] : [taskAgentTarget];
 	}, [workflow, activityMembers, task.workflowRunId, taskAgentMember, nodeExecutions, spaceAgents]);
+
+	// Extract per-agent default models from the workflow definition so the
+	// composer can show the workflow-defined model as the default for agents
+	// that haven't started yet.
+	const defaultAgentModels = useMemo(() => {
+		const map = new Map<string, string>();
+		if (!workflow) return map;
+		for (const node of workflow.nodes) {
+			for (const agent of node.agents) {
+				if (agent.model) {
+					map.set(agent.name, agent.model);
+				}
+			}
+		}
+		return map;
+	}, [workflow]);
+
 	const mentionCandidates = composerTargets
 		.filter((target) => target.kind === 'node_agent' && target.agentName)
 		.map((target) => ({ id: target.id, name: target.agentName as string }));
@@ -335,7 +352,6 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 		}
 		return labels;
 	}, [activityMembers]);
-	const isAgentActive = activeAgentLabels.size > 0;
 	const hasUnifiedWorkflowThread =
 		!!task.workflowRunId || !!agentSessionId || activityMembers.length > 0;
 	const showInlineComposer = !isTerminalTask;
@@ -959,9 +975,10 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 								hasTaskAgentSession={!!agentSessionId}
 								canSend={canSendThreadMessage}
 								isSending={sendingThread}
-								isProcessing={isAgentActive}
 								autoScroll={autoScrollEnabled}
 								errorMessage={threadSendError}
+								activityMembers={activityMembers}
+								defaultAgentModels={defaultAgentModels}
 								onAutoScrollChange={setAutoScrollEnabled}
 								onTargetSelect={(targetId) => {
 									setSelectedTargetId(targetId);

--- a/packages/web/src/components/space/TaskSessionChatComposer.tsx
+++ b/packages/web/src/components/space/TaskSessionChatComposer.tsx
@@ -80,7 +80,7 @@ export function TaskSessionChatComposer({
 		isProcessing: targetIsProcessing,
 		isStarted,
 		switchModel,
-		setThinkingLevel: _setThinkingLevel,
+		setThinkingLevel,
 	} = useTargetSessionContext({
 		selectedTarget,
 		activityMembers,
@@ -220,6 +220,7 @@ export function TaskSessionChatComposer({
 				onSandboxModeChange={() => {}}
 				onSend={handleSend}
 				onOpenTools={handleOpenTools}
+				onThinkingLevelChange={setThinkingLevel}
 				onEnterRewindMode={() => {}}
 				onExitRewindMode={() => {}}
 				agentMentionCandidates={mentionCandidates}

--- a/packages/web/src/components/space/TaskSessionChatComposer.tsx
+++ b/packages/web/src/components/space/TaskSessionChatComposer.tsx
@@ -23,6 +23,7 @@ interface TaskSessionChatComposerProps {
 	activityMembers: SpaceTaskActivityMember[];
 	/** Workflow-defined default model per agent name (agentName -> modelId) */
 	defaultAgentModels?: Map<string, string>;
+	taskId: string;
 	onAutoScrollChange: (enabled: boolean) => void;
 	onTargetSelect: (targetId: string) => void;
 	onDraftActiveChange?: (hasDraft: boolean) => void;
@@ -43,6 +44,7 @@ export function TaskSessionChatComposer({
 	errorMessage,
 	activityMembers,
 	defaultAgentModels,
+	taskId,
 	onAutoScrollChange,
 	onTargetSelect,
 	onDraftActiveChange,
@@ -72,6 +74,7 @@ export function TaskSessionChatComposer({
 		switchModel,
 		setThinkingLevel,
 	} = useTargetSessionContext({
+		taskId,
 		selectedTarget,
 		activityMembers,
 		taskAgentSessionId: sessionId || null,

--- a/packages/web/src/components/space/TaskSessionChatComposer.tsx
+++ b/packages/web/src/components/space/TaskSessionChatComposer.tsx
@@ -1,11 +1,12 @@
-import type { MessageDeliveryMode, MessageImage } from '@neokai/shared';
+import type { MessageDeliveryMode, MessageImage, SpaceTaskActivityMember } from '@neokai/shared';
 import type { Ref } from 'preact';
 import { useMemo, useState } from 'preact/hooks';
 import { ChatComposer } from '../ChatComposer.tsx';
-import { useModelSwitcher } from '../../hooks';
+import { useTargetSessionContext } from '../../hooks';
 import { cn } from '../../lib/utils.ts';
 import { getAgentColor } from './thread/space-task-thread-agent-colors';
 import { agentInitial } from './thread/minimal/minimal-mock-data';
+import { TaskToolsModal } from './TaskToolsModal.tsx';
 
 export interface TaskComposerTarget {
 	id: string;
@@ -25,9 +26,13 @@ interface TaskSessionChatComposerProps {
 	hasTaskAgentSession: boolean;
 	canSend: boolean;
 	isSending: boolean;
-	isProcessing: boolean;
+	/** @deprecated isProcessing is now computed from the targeted agent's activity */
+	isProcessing?: boolean;
 	autoScroll: boolean;
 	errorMessage?: string | null;
+	activityMembers: SpaceTaskActivityMember[];
+	/** Workflow-defined default model per agent name (agentName -> modelId) */
+	defaultAgentModels?: Map<string, string>;
 	onAutoScrollChange: (enabled: boolean) => void;
 	onTargetSelect: (targetId: string) => void;
 	onDraftActiveChange?: (hasDraft: boolean) => void;
@@ -43,30 +48,45 @@ export function TaskSessionChatComposer({
 	hasTaskAgentSession,
 	canSend,
 	isSending,
-	isProcessing,
+	isProcessing: _isProcessingProp,
 	autoScroll,
 	errorMessage,
+	activityMembers,
+	defaultAgentModels,
 	onAutoScrollChange,
 	onTargetSelect,
 	onDraftActiveChange,
 	onComposerRef,
 	onSend,
 }: TaskSessionChatComposerProps) {
-	const {
-		currentModel,
-		currentModelInfo,
-		availableModels,
-		switching: modelSwitching,
-		loading: modelLoading,
-		switchModel,
-	} = useModelSwitcher(sessionId);
 	const [targetMenuOpen, setTargetMenuOpen] = useState(false);
+	const [toolsModalOpen, setToolsModalOpen] = useState(false);
+
 	const selectedTarget = useMemo(
 		() => targets.find((target) => target.id === selectedTargetId) ?? targets[0] ?? null,
 		[targets, selectedTargetId]
 	);
 	const selectedTargetColor = selectedTarget ? getAgentColor(selectedTarget.label) : '#66A7FF';
 	const selectedTargetInitial = selectedTarget ? agentInitial(selectedTarget.label) : 'A';
+
+	const {
+		targetSessionId,
+		currentModel,
+		currentModelInfo,
+		availableModels,
+		modelSwitching,
+		modelLoading,
+		thinkingLevel,
+		isProcessing: targetIsProcessing,
+		isStarted,
+		switchModel,
+		setThinkingLevel: _setThinkingLevel,
+	} = useTargetSessionContext({
+		selectedTarget,
+		activityMembers,
+		taskAgentSessionId: sessionId || null,
+		defaultAgentModels,
+	});
 
 	// Return the boolean so MessageInput can restore the draft when sending fails
 	const handleSend = async (
@@ -77,12 +97,21 @@ export function TaskSessionChatComposer({
 		return onSend(content, selectedTarget);
 	};
 
+	const handleOpenTools = () => {
+		setToolsModalOpen(true);
+	};
+
+	const isNotStarted = selectedTarget?.kind === 'node_agent' && !isStarted;
+
 	const targetPicker =
 		targets.length > 0 ? (
 			<div class="relative">
 				<button
 					type="button"
-					class="group inline-flex h-9 w-9 items-center justify-center rounded-full border border-dark-900/30 text-sm font-bold text-dark-950 shadow-sm ring-1 ring-white/10 transition-transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-400/70 active:scale-95"
+					class={cn(
+						'group inline-flex h-9 w-9 items-center justify-center rounded-full border border-dark-900/30 text-sm font-bold text-dark-950 shadow-sm ring-1 ring-white/10 transition-transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-400/70 active:scale-95',
+						isNotStarted && 'ring-amber-400/40'
+					)}
 					style={{ backgroundColor: selectedTargetColor }}
 					onClick={() => setTargetMenuOpen((open) => !open)}
 					data-testid="task-composer-target-trigger"
@@ -137,10 +166,34 @@ export function TaskSessionChatComposer({
 
 	return (
 		<div ref={onComposerRef} class="relative z-10" data-testid="task-session-chat-composer">
+			{isNotStarted && (
+				<div class="px-3 pb-1">
+					<div class="flex items-center gap-1.5 rounded border border-amber-500/20 bg-amber-500/10 px-2 py-1">
+						<svg
+							class="w-3 h-3 text-amber-400 flex-shrink-0"
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+						>
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								strokeWidth={2}
+								d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+							/>
+						</svg>
+						<span class="text-[11px] text-amber-300">
+							{selectedTarget?.label} hasn't started yet — model and thinking pre-configuration will
+							apply when the session spawns.
+						</span>
+					</div>
+				</div>
+			)}
 			<ChatComposer
-				sessionId={sessionId}
+				sessionId={targetSessionId ?? sessionId}
 				readonly={false}
-				isProcessing={isProcessing}
+				isProcessing={targetIsProcessing}
+				thinkingLevel={thinkingLevel}
 				features={{
 					coordinator: false,
 					worktree: false,
@@ -166,7 +219,7 @@ export function TaskSessionChatComposer({
 				onCoordinatorModeChange={() => {}}
 				onSandboxModeChange={() => {}}
 				onSend={handleSend}
-				onOpenTools={() => {}}
+				onOpenTools={handleOpenTools}
 				onEnterRewindMode={() => {}}
 				onExitRewindMode={() => {}}
 				agentMentionCandidates={mentionCandidates}
@@ -185,6 +238,12 @@ export function TaskSessionChatComposer({
 				inputLeadingPaddingClass="pl-12"
 				onDraftActiveChange={onDraftActiveChange}
 				errorMessage={errorMessage}
+			/>
+			<TaskToolsModal
+				isOpen={toolsModalOpen}
+				onClose={() => setToolsModalOpen(false)}
+				sessionId={targetSessionId}
+				agentLabel={selectedTarget?.label ?? 'Agent'}
 			/>
 		</div>
 	);

--- a/packages/web/src/components/space/TaskSessionChatComposer.tsx
+++ b/packages/web/src/components/space/TaskSessionChatComposer.tsx
@@ -75,6 +75,7 @@ export function TaskSessionChatComposer({
 		setThinkingLevel,
 	} = useTargetSessionContext({
 		taskId,
+		targets,
 		selectedTarget,
 		activityMembers,
 		taskAgentSessionId: sessionId || null,

--- a/packages/web/src/components/space/TaskSessionChatComposer.tsx
+++ b/packages/web/src/components/space/TaskSessionChatComposer.tsx
@@ -2,21 +2,11 @@ import type { MessageDeliveryMode, MessageImage, SpaceTaskActivityMember } from 
 import type { Ref } from 'preact';
 import { useMemo, useState } from 'preact/hooks';
 import { ChatComposer } from '../ChatComposer.tsx';
-import { useTargetSessionContext } from '../../hooks';
+import { useTargetSessionContext, type TaskComposerTarget } from '../../hooks';
 import { cn } from '../../lib/utils.ts';
 import { getAgentColor } from './thread/space-task-thread-agent-colors';
 import { agentInitial } from './thread/minimal/minimal-mock-data';
 import { TaskToolsModal } from './TaskToolsModal.tsx';
-
-export interface TaskComposerTarget {
-	id: string;
-	kind: 'task_agent' | 'node_agent';
-	label: string;
-	agentName?: string;
-	nodeExecutionId?: string;
-	nodeName?: string;
-	state?: string;
-}
 
 interface TaskSessionChatComposerProps {
 	sessionId: string;

--- a/packages/web/src/components/space/TaskToolsModal.tsx
+++ b/packages/web/src/components/space/TaskToolsModal.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useState } from 'preact/hooks';
+import { Modal } from '../ui/Modal.tsx';
+import { listRuntimeMcpServers } from '../../lib/api-helpers.ts';
+import { borderColors } from '../../lib/design-tokens.ts';
+
+const RUNTIME_MCP_LABELS: Record<string, { title: string; description: string }> = {
+	'space-agent-tools': {
+		title: 'Space coordination',
+		description: 'send_message_to_agent, list_peers, gate I/O, task management',
+	},
+	'db-query': {
+		title: 'Database queries',
+		description: 'Read-only SQLite access scoped to this space',
+	},
+	'task-agent': {
+		title: 'Task agent',
+		description: 'Workflow execution, node activation, sub-agent spawning',
+	},
+	'node-agent': {
+		title: 'Node agent',
+		description: 'Workflow node tools: peers, channels, gates',
+	},
+	'room-tools': {
+		title: 'Room tools',
+		description: 'Room-scoped coordination between co-located agents',
+	},
+};
+
+interface TaskToolsModalProps {
+	isOpen: boolean;
+	onClose: () => void;
+	sessionId: string | null;
+	agentLabel: string;
+}
+
+export function TaskToolsModal({ isOpen, onClose, sessionId, agentLabel }: TaskToolsModalProps) {
+	const [servers, setServers] = useState<Array<{ name: string }>>([]);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (!isOpen || !sessionId) {
+			setServers([]);
+			setError(null);
+			return;
+		}
+
+		let cancelled = false;
+		setLoading(true);
+		setError(null);
+
+		listRuntimeMcpServers(sessionId)
+			.then((res) => {
+				if (cancelled) return;
+				setServers(res.servers ?? []);
+			})
+			.catch((err) => {
+				if (cancelled) return;
+				setError(err instanceof Error ? err.message : 'Failed to load tools');
+			})
+			.finally(() => {
+				if (!cancelled) setLoading(false);
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [isOpen, sessionId]);
+
+	return (
+		<Modal isOpen={isOpen} onClose={onClose} title={`${agentLabel} Tools`} size="sm">
+			<div class="space-y-3">
+				{!sessionId && (
+					<p class="text-sm text-gray-400 text-center py-4">
+						Agent tools will be available after the agent starts.
+					</p>
+				)}
+
+				{sessionId && loading && (
+					<div class="flex items-center justify-center py-4 gap-2">
+						<div class="w-4 h-4 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+						<span class="text-sm text-gray-400">Loading tools...</span>
+					</div>
+				)}
+
+				{sessionId && error && <p class="text-sm text-red-300 text-center py-4">{error}</p>}
+
+				{sessionId && !loading && !error && servers.length === 0 && (
+					<p class="text-sm text-gray-400 text-center py-4">
+						No runtime tools registered for this agent.
+					</p>
+				)}
+
+				{sessionId &&
+					!loading &&
+					!error &&
+					servers.map((server) => {
+						const label = RUNTIME_MCP_LABELS[server.name];
+						return (
+							<div
+								key={server.name}
+								class={`flex items-center gap-3 p-3 rounded-lg bg-dark-800/50 min-w-0 border ${borderColors.ui.secondary}`}
+							>
+								<svg
+									class="w-4 h-4 text-emerald-400 flex-shrink-0"
+									fill="none"
+									viewBox="0 0 24 24"
+									stroke="currentColor"
+								>
+									<path
+										strokeLinecap="round"
+										strokeLinejoin="round"
+										strokeWidth={2}
+										d="M13 10V3L4 14h7v7l9-11h-7z"
+									/>
+								</svg>
+								<div class="flex-1 min-w-0">
+									<div class="text-sm text-gray-200 truncate">{label?.title ?? server.name}</div>
+									<div class="text-xs text-gray-500 truncate">
+										{label?.description ?? server.name}
+									</div>
+								</div>
+							</div>
+						);
+					})}
+			</div>
+		</Modal>
+	);
+}

--- a/packages/web/src/components/space/__tests__/TaskSessionChatComposer.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskSessionChatComposer.test.tsx
@@ -2,8 +2,21 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { cleanup, fireEvent, render } from '@testing-library/preact';
 import type { ChatComposerProps } from '../../ChatComposer';
 
-// Mock useModelSwitcher — avoids real WebSocket/RPC calls in unit tests
+// Mock useTargetSessionContext — avoids real WebSocket/RPC calls in unit tests
 vi.mock('../../../hooks', () => ({
+	useTargetSessionContext: () => ({
+		targetSessionId: 'target-session-id',
+		currentModel: 'claude-sonnet-4-6',
+		currentModelInfo: null,
+		availableModels: [],
+		modelSwitching: false,
+		modelLoading: false,
+		thinkingLevel: 'auto',
+		isProcessing: false,
+		isStarted: true,
+		switchModel: vi.fn(async () => {}),
+		setThinkingLevel: vi.fn(async () => {}),
+	}),
 	useModelSwitcher: () => ({
 		currentModel: 'claude-sonnet-4-6',
 		currentModelInfo: null,
@@ -27,6 +40,7 @@ vi.mock('../../ChatComposer', () => ({
 				data-session-id={props.sessionId}
 				data-is-waiting={String(props.isWaitingForInput)}
 				data-placeholder={props.inputPlaceholder}
+				data-thinking-level={props.thinkingLevel}
 			>
 				{props.inputLeadingElement}
 			</div>
@@ -52,6 +66,19 @@ const targets = [
 	{ id: 'task-agent', kind: 'task_agent' as const, label: 'Task Agent' },
 ];
 
+const activityMembers = [
+	{
+		id: 'member-1',
+		sessionId: 'coder-session-id',
+		kind: 'node_agent' as const,
+		label: 'Coder',
+		role: 'coder',
+		state: 'active' as const,
+		processingStatus: 'idle' as const,
+		messageCount: 0,
+	},
+];
+
 function renderComposer(overrides: Partial<Parameters<typeof TaskSessionChatComposer>[0]> = {}) {
 	const onSend = vi.fn().mockResolvedValue(true);
 	const onTargetSelect = vi.fn();
@@ -64,9 +91,9 @@ function renderComposer(overrides: Partial<Parameters<typeof TaskSessionChatComp
 			hasTaskAgentSession={true}
 			canSend={true}
 			isSending={false}
-			isProcessing={false}
 			autoScroll={true}
 			errorMessage={null}
+			activityMembers={activityMembers}
 			onAutoScrollChange={vi.fn()}
 			onTargetSelect={onTargetSelect}
 			onSend={onSend}
@@ -102,9 +129,9 @@ describe('TaskSessionChatComposer', () => {
 		expect(queryByTestId('task-composer-readability-scrim')).toBeNull();
 	});
 
-	it('passes sessionId to ChatComposer', () => {
+	it('passes target sessionId to ChatComposer', () => {
 		renderComposer({ sessionId: 'my-session' });
-		expect(lastChatComposerProps?.sessionId).toBe('my-session');
+		expect(lastChatComposerProps?.sessionId).toBe('target-session-id');
 	});
 
 	it('passes agentMentionCandidates to ChatComposer', () => {
@@ -147,11 +174,6 @@ describe('TaskSessionChatComposer', () => {
 		expect(lastChatComposerProps?.inputPlaceholder).toBe('Message task agent (auto-start)...');
 	});
 
-	it('forwards isProcessing to ChatComposer', () => {
-		renderComposer({ isProcessing: true });
-		expect(lastChatComposerProps?.isProcessing).toBe(true);
-	});
-
 	it('forwards auto-scroll state to ChatComposer', () => {
 		const onAutoScrollChange = vi.fn();
 		renderComposer({ autoScroll: false, onAutoScrollChange });
@@ -174,5 +196,26 @@ describe('TaskSessionChatComposer', () => {
 		fireEvent.click(getByTestId('task-composer-target-trigger'));
 		fireEvent.click(getAllByTestId('task-composer-target-option')[1]);
 		expect(onTargetSelect).toHaveBeenCalledWith('task-agent');
+	});
+
+	it('passes thinkingLevel to ChatComposer', () => {
+		renderComposer();
+		expect(lastChatComposerProps?.thinkingLevel).toBe('auto');
+	});
+
+	it('passes disabled session features to ChatComposer', () => {
+		renderComposer();
+		expect(lastChatComposerProps?.features).toEqual({
+			coordinator: false,
+			worktree: false,
+			rewind: false,
+			archive: false,
+			sessionInfo: false,
+		});
+	});
+
+	it('wires onOpenTools to ChatComposer', () => {
+		renderComposer();
+		expect(typeof lastChatComposerProps?.onOpenTools).toBe('function');
 	});
 });

--- a/packages/web/src/components/space/__tests__/TaskSessionChatComposer.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskSessionChatComposer.test.tsx
@@ -94,6 +94,7 @@ function renderComposer(overrides: Partial<Parameters<typeof TaskSessionChatComp
 			autoScroll={true}
 			errorMessage={null}
 			activityMembers={activityMembers}
+			taskId="task-1"
 			onAutoScrollChange={vi.fn()}
 			onTargetSelect={onTargetSelect}
 			onSend={onSend}

--- a/packages/web/src/components/space/__tests__/TaskSessionChatComposer.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskSessionChatComposer.test.tsx
@@ -218,4 +218,9 @@ describe('TaskSessionChatComposer', () => {
 		renderComposer();
 		expect(typeof lastChatComposerProps?.onOpenTools).toBe('function');
 	});
+
+	it('wires onThinkingLevelChange to ChatComposer', () => {
+		renderComposer();
+		expect(typeof lastChatComposerProps?.onThinkingLevelChange).toBe('function');
+	});
 });

--- a/packages/web/src/components/space/__tests__/TaskToolsModal.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskToolsModal.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/preact';
+import { TaskToolsModal } from '../TaskToolsModal';
+
+const mockListRuntimeMcpServers = vi.fn();
+
+vi.mock('../../../lib/api-helpers', () => ({
+	listRuntimeMcpServers: (...args: unknown[]) => mockListRuntimeMcpServers(...args),
+}));
+
+vi.mock('../../ui/Modal', () => ({
+	Modal: ({ children, isOpen, title }: { children: any; isOpen: boolean; title: string }) => {
+		if (!isOpen) return null;
+		return (
+			<div data-testid="mock-modal" data-title={title}>
+				{children}
+			</div>
+		);
+	},
+}));
+
+describe('TaskToolsModal', () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	it('shows not-started message when sessionId is null', () => {
+		const { getByText } = render(
+			<TaskToolsModal isOpen={true} onClose={() => {}} sessionId={null} agentLabel="Reviewer" />
+		);
+		expect(getByText('Agent tools will be available after the agent starts.')).toBeTruthy();
+	});
+
+	it('shows loading state while fetching', () => {
+		mockListRuntimeMcpServers.mockReturnValue(new Promise(() => {}));
+		const { getByText } = render(
+			<TaskToolsModal isOpen={true} onClose={() => {}} sessionId="sess-123" agentLabel="Coder" />
+		);
+		expect(getByText('Loading tools...')).toBeTruthy();
+	});
+
+	it('shows tools after loading', async () => {
+		mockListRuntimeMcpServers.mockResolvedValue({
+			servers: [{ name: 'space-agent-tools' }, { name: 'custom-tool' }],
+		});
+		const { getByText, queryByText, container } = render(
+			<TaskToolsModal isOpen={true} onClose={() => {}} sessionId="sess-123" agentLabel="Coder" />
+		);
+
+		await waitFor(() => {
+			expect(queryByText('Loading tools...')).toBeNull();
+		});
+
+		expect(getByText('Space coordination')).toBeTruthy();
+		// custom-tool appears as both title (no label) and description — verify at least one instance
+		expect(container.textContent).toContain('custom-tool');
+		expect(mockListRuntimeMcpServers).toHaveBeenCalledWith('sess-123');
+	});
+
+	it('shows empty state when no tools are registered', async () => {
+		mockListRuntimeMcpServers.mockResolvedValue({ servers: [] });
+		const { getByText, queryByText } = render(
+			<TaskToolsModal isOpen={true} onClose={() => {}} sessionId="sess-123" agentLabel="Coder" />
+		);
+
+		await waitFor(() => {
+			expect(queryByText('Loading tools...')).toBeNull();
+		});
+
+		expect(getByText('No runtime tools registered for this agent.')).toBeTruthy();
+	});
+
+	it('shows error state when fetch fails', async () => {
+		mockListRuntimeMcpServers.mockRejectedValue(new Error('Network error'));
+		const { getByText, queryByText } = render(
+			<TaskToolsModal isOpen={true} onClose={() => {}} sessionId="sess-123" agentLabel="Coder" />
+		);
+
+		await waitFor(() => {
+			expect(queryByText('Loading tools...')).toBeNull();
+		});
+
+		expect(getByText('Network error')).toBeTruthy();
+	});
+
+	it('does not fetch when closed', () => {
+		render(
+			<TaskToolsModal isOpen={false} onClose={() => {}} sessionId="sess-123" agentLabel="Coder" />
+		);
+		expect(mockListRuntimeMcpServers).not.toHaveBeenCalled();
+	});
+
+	it('cancels in-flight request when sessionId changes', async () => {
+		mockListRuntimeMcpServers.mockImplementation((sessionId: string) => {
+			return Promise.resolve({ servers: [{ name: sessionId }] });
+		});
+		const { rerender } = render(
+			<TaskToolsModal isOpen={true} onClose={() => {}} sessionId="sess-a" agentLabel="Coder" />
+		);
+
+		// Immediately change sessionId before the first fetch resolves
+		rerender(
+			<TaskToolsModal isOpen={true} onClose={() => {}} sessionId="sess-b" agentLabel="Coder" />
+		);
+
+		// Should not crash; just verify it re-fetches for the new session
+		await waitFor(() => {
+			expect(mockListRuntimeMcpServers).toHaveBeenCalledWith('sess-b');
+		});
+	});
+});

--- a/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
+++ b/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
@@ -144,6 +144,12 @@ describe('useTargetSessionContext', () => {
 							description: '',
 							provider: 'anthropic',
 						},
+						{
+							id: 'claude-opus-4-5',
+							display_name: 'Claude Opus 4.5',
+							description: '',
+							provider: 'anthropic',
+						},
 					],
 				});
 			}
@@ -157,6 +163,9 @@ describe('useTargetSessionContext', () => {
 						provider: 'anthropic',
 					},
 				});
+			}
+			if (method === 'session.model.switch') {
+				return Promise.resolve({ success: true, model: 'claude-opus-4-5' });
 			}
 			return Promise.resolve({});
 		});
@@ -354,5 +363,184 @@ describe('useTargetSessionContext', () => {
 
 		expect(result.current.thinkingLevel).toBe('think32k');
 		expect(mockRequest).not.toHaveBeenCalledWith('session.thinking.set', expect.anything());
+	});
+
+	it('auto-applies pre-configured model and thinking when session spawns', async () => {
+		const notStartedTarget = {
+			id: 'node:n1:reviewer',
+			kind: 'node_agent' as const,
+			label: 'Reviewer',
+			agentName: 'reviewer',
+		};
+
+		const model: ModelInfo = {
+			id: 'claude-opus-4-5',
+			name: 'Opus 4.5',
+			family: 'opus',
+			provider: 'anthropic',
+			alias: 'opus',
+			contextWindow: 200000,
+			description: '',
+			releaseDate: '',
+			available: true,
+		};
+
+		const { result, rerender } = renderHook(
+			(props: { members: SpaceTaskActivityMember[] }) =>
+				useTargetSessionContext({
+					selectedTarget: notStartedTarget,
+					activityMembers: props.members,
+					taskAgentSessionId: 'task-sess-123',
+				}),
+			{ initialProps: { members: [] as SpaceTaskActivityMember[] } }
+		);
+
+		// Pre-configure model and thinking while agent is not started
+		await act(async () => {
+			await result.current.switchModel(model);
+		});
+		await act(async () => {
+			await result.current.setThinkingLevel('think16k');
+		});
+
+		expect(result.current.currentModel).toBe('claude-opus-4-5');
+		expect(result.current.thinkingLevel).toBe('think16k');
+		expect(mockRequest).not.toHaveBeenCalledWith('session.model.switch', expect.anything());
+		expect(mockRequest).not.toHaveBeenCalledWith('session.thinking.set', expect.anything());
+
+		// Spawn the agent session
+		const spawnedMembers: SpaceTaskActivityMember[] = [
+			{
+				id: 'm-reviewer',
+				sessionId: 'reviewer-session',
+				kind: 'node_agent',
+				label: 'Reviewer',
+				role: 'reviewer',
+				state: 'active',
+				processingStatus: 'idle',
+				messageCount: 0,
+			},
+		];
+
+		rerender({ members: spawnedMembers });
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('session.model.switch', {
+				sessionId: 'reviewer-session',
+				model: 'claude-opus-4-5',
+				provider: 'anthropic',
+			});
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith('session.thinking.set', {
+			sessionId: 'reviewer-session',
+			level: 'think16k',
+		});
+	});
+
+	it('retries auto-apply when pre-config persistence fails', async () => {
+		const notStartedTarget = {
+			id: 'node:n1:reviewer',
+			kind: 'node_agent' as const,
+			label: 'Reviewer',
+			agentName: 'reviewer',
+		};
+
+		const model: ModelInfo = {
+			id: 'claude-opus-4-5',
+			name: 'Opus 4.5',
+			family: 'opus',
+			provider: 'anthropic',
+			alias: 'opus',
+			contextWindow: 200000,
+			description: '',
+			releaseDate: '',
+			available: true,
+		};
+
+		// First call fails, second succeeds
+		let callCount = 0;
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'models.list') {
+				return Promise.resolve({
+					models: [
+						{
+							id: 'claude-opus-4-5',
+							display_name: 'Claude Opus 4.5',
+							description: '',
+							provider: 'anthropic',
+						},
+					],
+				});
+			}
+			if (method === 'session.model.get') {
+				return Promise.resolve({
+					currentModel: 'claude-sonnet-4-6',
+					modelInfo: {
+						id: 'claude-sonnet-4-6',
+						name: 'Claude Sonnet 4.6',
+						family: 'sonnet',
+						provider: 'anthropic',
+					},
+				});
+			}
+			if (method === 'session.model.switch') {
+				callCount++;
+				if (callCount === 1) {
+					return Promise.reject(new Error('Switch failed'));
+				}
+				return Promise.resolve({ success: true, model: 'claude-opus-4-5' });
+			}
+			return Promise.resolve({});
+		});
+
+		const { result, rerender } = renderHook(
+			(props: { members: SpaceTaskActivityMember[] }) =>
+				useTargetSessionContext({
+					selectedTarget: notStartedTarget,
+					activityMembers: props.members,
+					taskAgentSessionId: 'task-sess-123',
+				}),
+			{ initialProps: { members: [] as SpaceTaskActivityMember[] } }
+		);
+
+		await act(async () => {
+			await result.current.switchModel(model);
+		});
+
+		// Spawn session — first attempt fails
+		const spawnedMembers: SpaceTaskActivityMember[] = [
+			{
+				id: 'm-reviewer',
+				sessionId: 'reviewer-session',
+				kind: 'node_agent',
+				label: 'Reviewer',
+				role: 'reviewer',
+				state: 'active',
+				processingStatus: 'idle',
+				messageCount: 0,
+			},
+		];
+
+		rerender({ members: spawnedMembers });
+
+		// Wait for the first auto-apply attempt to run (may be preceded by a
+		// no-op run while switcherModels is still empty from the fresh
+		// useModelSwitcher instance).
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('session.model.switch', {
+				sessionId: 'reviewer-session',
+				model: 'claude-opus-4-5',
+				provider: 'anthropic',
+			});
+		});
+
+		// The first attempt fails, so the target is not marked as applied.
+		// A subsequent re-render should trigger a retry.
+		rerender({ members: [...spawnedMembers] });
+
+		await waitFor(() => {
+			expect(callCount).toBeGreaterThanOrEqual(2);
+		});
 	});
 });

--- a/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
+++ b/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
@@ -67,6 +67,65 @@ describe('resolveTargetSessionId', () => {
 	it('returns null when target is null', () => {
 		expect(resolveTargetSessionId(null, members, 'task-session')).toBeNull();
 	});
+
+	it('prefers nodeExecutionId over agentName when resolving node_agent', () => {
+		const membersWithNodeExecution: SpaceTaskActivityMember[] = [
+			{
+				id: 'm1',
+				sessionId: 'reviewer-a-session',
+				kind: 'node_agent',
+				label: 'Reviewer A',
+				role: 'reviewer',
+				state: 'active',
+				processingStatus: 'idle',
+				messageCount: 0,
+				nodeExecution: {
+					nodeExecutionId: 'ne-a',
+					nodeId: 'n1',
+					agentName: 'reviewer',
+					status: 'in_progress',
+				},
+			},
+			{
+				id: 'm2',
+				sessionId: 'reviewer-b-session',
+				kind: 'node_agent',
+				label: 'Reviewer B',
+				role: 'reviewer',
+				state: 'active',
+				processingStatus: 'idle',
+				messageCount: 0,
+				nodeExecution: {
+					nodeExecutionId: 'ne-b',
+					nodeId: 'n2',
+					agentName: 'reviewer',
+					status: 'in_progress',
+				},
+			},
+		];
+
+		const targetA = {
+			id: 'node:n1:reviewer',
+			kind: 'node_agent' as const,
+			label: 'Reviewer A',
+			agentName: 'reviewer',
+			nodeExecutionId: 'ne-a',
+		};
+		const targetB = {
+			id: 'node:n2:reviewer',
+			kind: 'node_agent' as const,
+			label: 'Reviewer B',
+			agentName: 'reviewer',
+			nodeExecutionId: 'ne-b',
+		};
+
+		expect(resolveTargetSessionId(targetA, membersWithNodeExecution, 'task-session')).toBe(
+			'reviewer-a-session'
+		);
+		expect(resolveTargetSessionId(targetB, membersWithNodeExecution, 'task-session')).toBe(
+			'reviewer-b-session'
+		);
+	});
 });
 
 describe('useTargetSessionContext', () => {
@@ -172,7 +231,7 @@ describe('useTargetSessionContext', () => {
 				selectedTarget: notStartedTarget,
 				activityMembers: members,
 				taskAgentSessionId: 'task-sess-123',
-				defaultAgentModels: new Map([['reviewer', 'claude-opus-4-5']]),
+				defaultAgentModels: new Map([['node:n1:reviewer', 'claude-opus-4-5']]),
 			})
 		);
 
@@ -195,7 +254,7 @@ describe('useTargetSessionContext', () => {
 				selectedTarget: notStartedTarget,
 				activityMembers: members,
 				taskAgentSessionId: 'task-sess-123',
-				defaultAgentModels: new Map([['reviewer', 'claude-opus-4-5']]),
+				defaultAgentModels: new Map([['node:n1:reviewer', 'claude-opus-4-5']]),
 			})
 		);
 

--- a/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
+++ b/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
@@ -857,4 +857,160 @@ describe('useTargetSessionContext', () => {
 			});
 		});
 	});
+
+	it('retries model auto-apply when model info is initially missing but thinking succeeds', async () => {
+		const notStartedTarget = {
+			id: 'node:n1:reviewer',
+			kind: 'node_agent' as const,
+			label: 'Reviewer',
+			agentName: 'reviewer',
+		};
+
+		const model: ModelInfo = {
+			id: 'claude-opus-4-5',
+			name: 'Opus 4.5',
+			family: 'opus',
+			provider: 'anthropic',
+			alias: 'opus',
+			contextWindow: 200000,
+			description: '',
+			releaseDate: '',
+			available: true,
+		};
+
+		// Start with empty models so switcherModels is empty when the session spawns
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'models.list') {
+				return Promise.resolve({ models: [] });
+			}
+			if (method === 'session.thinking.get') {
+				return Promise.resolve({ thinkingLevel: 'auto' });
+			}
+			if (method === 'session.thinking.set') {
+				return Promise.resolve({ success: true });
+			}
+			if (method === 'session.model.switch') {
+				return Promise.resolve({ success: true, model: 'claude-opus-4-5' });
+			}
+			return Promise.resolve({});
+		});
+
+		const { result, rerender } = renderHook(
+			(props: { members: SpaceTaskActivityMember[] }) =>
+				useTargetSessionContext({
+					taskId: 'task-1',
+					targets: [notStartedTarget],
+					selectedTarget: notStartedTarget,
+					activityMembers: props.members,
+					taskAgentSessionId: 'task-sess-123',
+				}),
+			{ initialProps: { members: [] as SpaceTaskActivityMember[] } }
+		);
+
+		// Pre-configure model and thinking while agent is not started
+		await act(async () => {
+			await result.current.switchModel(model);
+		});
+		await act(async () => {
+			await result.current.setThinkingLevel('think16k');
+		});
+
+		// Spawn the agent session — models.list returns empty, so model lookup fails
+		const spawnedMembersA: SpaceTaskActivityMember[] = [
+			{
+				id: 'm-reviewer',
+				sessionId: 'reviewer-session-a',
+				kind: 'node_agent',
+				label: 'Reviewer',
+				role: 'reviewer',
+				state: 'active',
+				processingStatus: 'idle',
+				messageCount: 0,
+			},
+		];
+
+		rerender({ members: spawnedMembersA });
+
+		// Wait a tick for effects to settle
+		await new Promise((r) => setTimeout(r, 10));
+
+		// Thinking should have been applied because hub is connected
+		expect(mockRequest).toHaveBeenCalledWith('session.thinking.set', {
+			sessionId: 'reviewer-session-a',
+			level: 'think16k',
+		});
+
+		// Model should NOT have been applied because switcherModels was empty
+		const modelSwitchCallsBefore = mockRequest.mock.calls.filter(
+			(call) => call[0] === 'session.model.switch'
+		);
+		expect(modelSwitchCallsBefore).toHaveLength(0);
+
+		// Now make models available and spawn a new session (different sessionId
+		// forces useModelSwitcher to reload models)
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'models.list') {
+				return Promise.resolve({
+					models: [
+						{
+							id: 'claude-opus-4-5',
+							display_name: 'Claude Opus 4.5',
+							description: '',
+							provider: 'anthropic',
+						},
+					],
+				});
+			}
+			if (method === 'session.model.get') {
+				return Promise.resolve({
+					currentModel: 'claude-sonnet-4-6',
+					modelInfo: {
+						id: 'claude-sonnet-4-6',
+						name: 'Claude Sonnet 4.6',
+						family: 'sonnet',
+						provider: 'anthropic',
+					},
+				});
+			}
+			if (method === 'session.thinking.get') {
+				return Promise.resolve({ thinkingLevel: 'auto' });
+			}
+			if (method === 'session.thinking.set') {
+				return Promise.resolve({ success: true });
+			}
+			if (method === 'session.model.switch') {
+				return Promise.resolve({ success: true, model: 'claude-opus-4-5' });
+			}
+			return Promise.resolve({});
+		});
+
+		const spawnedMembersB: SpaceTaskActivityMember[] = [
+			{
+				id: 'm-reviewer',
+				sessionId: 'reviewer-session-b',
+				kind: 'node_agent',
+				label: 'Reviewer',
+				role: 'reviewer',
+				state: 'active',
+				processingStatus: 'idle',
+				messageCount: 0,
+			},
+		];
+
+		rerender({ members: spawnedMembersB });
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('session.model.switch', {
+				sessionId: 'reviewer-session-b',
+				model: 'claude-opus-4-5',
+				provider: 'anthropic',
+			});
+		});
+
+		// thinking.set should NOT have been called again for the new session
+		const thinkingSetCallsForB = mockRequest.mock.calls.filter(
+			(call) => call[0] === 'session.thinking.set' && call[1]?.sessionId === 'reviewer-session-b'
+		);
+		expect(thinkingSetCallsForB).toHaveLength(0);
+	});
 });

--- a/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
+++ b/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
@@ -200,6 +200,7 @@ describe('useTargetSessionContext', () => {
 	it('resolves task_agent to taskAgentSessionId', async () => {
 		const { result } = renderHook(() =>
 			useTargetSessionContext({
+				taskId: 'task-1',
 				selectedTarget: taskAgentTarget,
 				activityMembers: [],
 				taskAgentSessionId: 'task-sess-123',
@@ -215,6 +216,7 @@ describe('useTargetSessionContext', () => {
 	it('resolves node_agent to member sessionId', async () => {
 		const { result } = renderHook(() =>
 			useTargetSessionContext({
+				taskId: 'task-1',
 				selectedTarget: coderTarget,
 				activityMembers: members,
 				taskAgentSessionId: 'task-sess-123',
@@ -237,6 +239,7 @@ describe('useTargetSessionContext', () => {
 
 		const { result } = renderHook(() =>
 			useTargetSessionContext({
+				taskId: 'task-1',
 				selectedTarget: notStartedTarget,
 				activityMembers: members,
 				taskAgentSessionId: 'task-sess-123',
@@ -260,6 +263,7 @@ describe('useTargetSessionContext', () => {
 
 		const { result } = renderHook(() =>
 			useTargetSessionContext({
+				taskId: 'task-1',
 				selectedTarget: notStartedTarget,
 				activityMembers: members,
 				taskAgentSessionId: 'task-sess-123',
@@ -275,6 +279,7 @@ describe('useTargetSessionContext', () => {
 	it('derives isProcessing from activity member processingStatus', async () => {
 		const { result } = renderHook(() =>
 			useTargetSessionContext({
+				taskId: 'task-1',
 				selectedTarget: coderTarget,
 				activityMembers: members,
 				taskAgentSessionId: 'task-sess-123',
@@ -308,6 +313,7 @@ describe('useTargetSessionContext', () => {
 
 		const { result } = renderHook(() =>
 			useTargetSessionContext({
+				taskId: 'task-1',
 				selectedTarget: notStartedTarget,
 				activityMembers: members,
 				taskAgentSessionId: 'task-sess-123',
@@ -324,6 +330,7 @@ describe('useTargetSessionContext', () => {
 	it('sets thinking level for started agents via RPC', async () => {
 		const { result } = renderHook(() =>
 			useTargetSessionContext({
+				taskId: 'task-1',
 				selectedTarget: coderTarget,
 				activityMembers: members,
 				taskAgentSessionId: 'task-sess-123',
@@ -351,6 +358,7 @@ describe('useTargetSessionContext', () => {
 
 		const { result } = renderHook(() =>
 			useTargetSessionContext({
+				taskId: 'task-1',
 				selectedTarget: notStartedTarget,
 				activityMembers: members,
 				taskAgentSessionId: 'task-sess-123',
@@ -388,6 +396,7 @@ describe('useTargetSessionContext', () => {
 		const { result, rerender } = renderHook(
 			(props: { members: SpaceTaskActivityMember[] }) =>
 				useTargetSessionContext({
+					taskId: 'task-1',
 					selectedTarget: notStartedTarget,
 					activityMembers: props.members,
 					taskAgentSessionId: 'task-sess-123',
@@ -497,6 +506,7 @@ describe('useTargetSessionContext', () => {
 		const { result, rerender } = renderHook(
 			(props: { members: SpaceTaskActivityMember[] }) =>
 				useTargetSessionContext({
+					taskId: 'task-1',
 					selectedTarget: notStartedTarget,
 					activityMembers: props.members,
 					taskAgentSessionId: 'task-sess-123',
@@ -541,6 +551,54 @@ describe('useTargetSessionContext', () => {
 
 		await waitFor(() => {
 			expect(callCount).toBeGreaterThanOrEqual(2);
+		});
+	});
+
+	it('resets preconfiguration when taskId changes', async () => {
+		const notStartedTarget = {
+			id: 'node:n1:reviewer',
+			kind: 'node_agent' as const,
+			label: 'Reviewer',
+			agentName: 'reviewer',
+		};
+
+		const model: ModelInfo = {
+			id: 'claude-opus-4-5',
+			name: 'Opus 4.5',
+			family: 'opus',
+			provider: 'anthropic',
+			alias: 'opus',
+			contextWindow: 200000,
+			description: '',
+			releaseDate: '',
+			available: true,
+		};
+
+		const { result, rerender } = renderHook(
+			(props: { taskId: string }) =>
+				useTargetSessionContext({
+					taskId: props.taskId,
+					selectedTarget: notStartedTarget,
+					activityMembers: [],
+					taskAgentSessionId: 'task-sess-123',
+				}),
+			{ initialProps: { taskId: 'task-a' } }
+		);
+
+		// Pre-configure model for task-a
+		await act(async () => {
+			await result.current.switchModel(model);
+		});
+
+		expect(result.current.currentModel).toBe('claude-opus-4-5');
+
+		// Switch to a different task — preconfiguration should reset
+		rerender({ taskId: 'task-b' });
+
+		// Default model is empty for this target, so after reset currentModel
+		// should fall back to empty string.
+		await waitFor(() => {
+			expect(result.current.currentModel).toBe('');
 		});
 	});
 });

--- a/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
+++ b/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
@@ -126,6 +126,79 @@ describe('resolveTargetSessionId', () => {
 			'reviewer-b-session'
 		);
 	});
+
+	it('normalizes agent names for fallback matching', () => {
+		const membersWithMixedNames: SpaceTaskActivityMember[] = [
+			{
+				id: 'm1',
+				sessionId: 'code-reviewer-session',
+				kind: 'node_agent',
+				label: 'Code Reviewer',
+				role: 'code-reviewer',
+				state: 'active',
+				processingStatus: 'idle',
+				messageCount: 0,
+			},
+			{
+				id: 'm2',
+				sessionId: 'other-session',
+				kind: 'node_agent',
+				label: 'Other',
+				role: 'other_agent',
+				state: 'active',
+				processingStatus: 'idle',
+				messageCount: 0,
+				nodeExecution: {
+					nodeExecutionId: 'ne-other',
+					nodeId: 'n2',
+					agentName: 'Other Agent',
+					status: 'in_progress',
+				},
+			},
+		];
+
+		// role 'code-reviewer' should match target agentName 'code_reviewer' (underscore vs hyphen)
+		expect(
+			resolveTargetSessionId(
+				{
+					id: 'node:n1:code_reviewer',
+					kind: 'node_agent' as const,
+					label: 'Code Reviewer',
+					agentName: 'code_reviewer',
+				},
+				membersWithMixedNames,
+				'task-session'
+			)
+		).toBe('code-reviewer-session');
+
+		// role 'code-reviewer' should also match target agentName 'CodeReviewer' (casing)
+		expect(
+			resolveTargetSessionId(
+				{
+					id: 'node:n1:CodeReviewer',
+					kind: 'node_agent' as const,
+					label: 'Code Reviewer',
+					agentName: 'CodeReviewer',
+				},
+				membersWithMixedNames,
+				'task-session'
+			)
+		).toBe('code-reviewer-session');
+
+		// nodeExecution.agentName 'Other Agent' should match target 'other_agent' (trailing "agent" stripped)
+		expect(
+			resolveTargetSessionId(
+				{
+					id: 'node:n2:other_agent',
+					kind: 'node_agent' as const,
+					label: 'Other',
+					agentName: 'other_agent',
+				},
+				membersWithMixedNames,
+				'task-session'
+			)
+		).toBe('other-session');
+	});
 });
 
 describe('useTargetSessionContext', () => {

--- a/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
+++ b/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
@@ -167,6 +167,9 @@ describe('useTargetSessionContext', () => {
 			if (method === 'session.model.switch') {
 				return Promise.resolve({ success: true, model: 'claude-opus-4-5' });
 			}
+			if (method === 'session.thinking.get') {
+				return Promise.resolve({ thinkingLevel: 'auto' });
+			}
 			return Promise.resolve({});
 		});
 	});
@@ -344,6 +347,12 @@ describe('useTargetSessionContext', () => {
 			})
 		);
 
+		// Wait for the async live thinking-level load to settle so it doesn't
+		// race with the manual setThinkingLevel call.
+		await waitFor(() => {
+			expect(result.current.thinkingLevel).toBe('auto');
+		});
+
 		await act(async () => {
 			await result.current.setThinkingLevel('think16k');
 		});
@@ -508,6 +517,9 @@ describe('useTargetSessionContext', () => {
 					return Promise.reject(new Error('Switch failed'));
 				}
 				return Promise.resolve({ success: true, model: 'claude-opus-4-5' });
+			}
+			if (method === 'session.thinking.get') {
+				return Promise.resolve({ thinkingLevel: 'auto' });
 			}
 			return Promise.resolve({});
 		});

--- a/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
+++ b/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
@@ -1154,4 +1154,105 @@ describe('useTargetSessionContext', () => {
 			expect(callsAfter).toBeGreaterThan(callsBefore);
 		});
 	});
+
+	it('refreshes model state after successful auto-apply for selected target', async () => {
+		const notStartedTarget = {
+			id: 'node:n1:reviewer',
+			kind: 'node_agent' as const,
+			label: 'Reviewer',
+			agentName: 'reviewer',
+		};
+
+		const model: ModelInfo = {
+			id: 'claude-opus-4-5',
+			name: 'Opus 4.5',
+			family: 'opus',
+			provider: 'anthropic',
+			alias: 'opus',
+			contextWindow: 200000,
+			description: '',
+			releaseDate: '',
+			available: true,
+		};
+
+		let modelGetCallCount = 0;
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'models.list') {
+				return Promise.resolve({
+					models: [
+						{
+							id: 'claude-opus-4-5',
+							display_name: 'Claude Opus 4.5',
+							description: '',
+							provider: 'anthropic',
+						},
+					],
+				});
+			}
+			if (method === 'session.model.get') {
+				modelGetCallCount++;
+				return Promise.resolve({
+					currentModel: 'claude-sonnet-4-6',
+					modelInfo: {
+						id: 'claude-sonnet-4-6',
+						name: 'Claude Sonnet 4.6',
+						family: 'sonnet',
+						provider: 'anthropic',
+					},
+				});
+			}
+			if (method === 'session.thinking.get') {
+				return Promise.resolve({ thinkingLevel: 'auto' });
+			}
+			if (method === 'session.model.switch') {
+				return Promise.resolve({ success: true, model: 'claude-opus-4-5' });
+			}
+			return Promise.resolve({});
+		});
+
+		const { result, rerender } = renderHook(
+			(props: { members: SpaceTaskActivityMember[] }) =>
+				useTargetSessionContext({
+					taskId: 'task-1',
+					targets: [notStartedTarget],
+					selectedTarget: notStartedTarget,
+					activityMembers: props.members,
+					taskAgentSessionId: 'task-sess-123',
+				}),
+			{ initialProps: { members: [] as SpaceTaskActivityMember[] } }
+		);
+
+		await act(async () => {
+			await result.current.switchModel(model);
+		});
+
+		const spawnedMembers: SpaceTaskActivityMember[] = [
+			{
+				id: 'm-reviewer',
+				sessionId: 'reviewer-session',
+				kind: 'node_agent',
+				label: 'Reviewer',
+				role: 'reviewer',
+				state: 'active',
+				processingStatus: 'idle',
+				messageCount: 0,
+			},
+		];
+
+		rerender({ members: spawnedMembers });
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('session.model.switch', {
+				sessionId: 'reviewer-session',
+				model: 'claude-opus-4-5',
+				provider: 'anthropic',
+			});
+		});
+
+		// After auto-apply succeeds, reload() should trigger an additional
+		// session.model.get so the UI reflects the newly applied model.
+		await waitFor(() => {
+			expect(modelGetCallCount).toBeGreaterThanOrEqual(2);
+		});
+	});
 });

--- a/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
+++ b/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
@@ -1013,4 +1013,145 @@ describe('useTargetSessionContext', () => {
 		);
 		expect(thinkingSetCallsForB).toHaveLength(0);
 	});
+	it('retries model auto-apply when session.model.switch returns failure', async () => {
+		const notStartedTarget = {
+			id: 'node:n1:reviewer',
+			kind: 'node_agent' as const,
+			label: 'Reviewer',
+			agentName: 'reviewer',
+		};
+
+		const model: ModelInfo = {
+			id: 'claude-opus-4-5',
+			name: 'Opus 4.5',
+			family: 'opus',
+			provider: 'anthropic',
+			alias: 'opus',
+			contextWindow: 200000,
+			description: '',
+			releaseDate: '',
+			available: true,
+		};
+
+		// Always return failure so the target is never marked applied
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'models.list') {
+				return Promise.resolve({
+					models: [
+						{
+							id: 'claude-opus-4-5',
+							display_name: 'Claude Opus 4.5',
+							description: '',
+							provider: 'anthropic',
+						},
+					],
+				});
+			}
+			if (method === 'session.model.get') {
+				return Promise.resolve({
+					currentModel: 'claude-sonnet-4-6',
+					modelInfo: {
+						id: 'claude-sonnet-4-6',
+						name: 'Claude Sonnet 4.6',
+						family: 'sonnet',
+						provider: 'anthropic',
+					},
+				});
+			}
+			if (method === 'session.thinking.get') {
+				return Promise.resolve({ thinkingLevel: 'auto' });
+			}
+			if (method === 'session.model.switch') {
+				return Promise.resolve({ success: false, error: 'Provider unavailable' });
+			}
+			return Promise.resolve({});
+		});
+
+		const { result, rerender } = renderHook(
+			(props: { members: SpaceTaskActivityMember[] }) =>
+				useTargetSessionContext({
+					taskId: 'task-1',
+					targets: [notStartedTarget],
+					selectedTarget: notStartedTarget,
+					activityMembers: props.members,
+					taskAgentSessionId: 'task-sess-123',
+				}),
+			{ initialProps: { members: [] as SpaceTaskActivityMember[] } }
+		);
+
+		await act(async () => {
+			await result.current.switchModel(model);
+		});
+
+		const spawnedMembers: SpaceTaskActivityMember[] = [
+			{
+				id: 'm-reviewer',
+				sessionId: 'reviewer-session',
+				kind: 'node_agent',
+				label: 'Reviewer',
+				role: 'reviewer',
+				state: 'active',
+				processingStatus: 'idle',
+				messageCount: 0,
+			},
+		];
+
+		rerender({ members: spawnedMembers });
+
+		// Wait for the failure call to happen
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('session.model.switch', {
+				sessionId: 'reviewer-session',
+				model: 'claude-opus-4-5',
+				provider: 'anthropic',
+			});
+		});
+
+		const callsBefore = mockRequest.mock.calls.filter(
+			(call) => call[0] === 'session.model.switch'
+		).length;
+
+		// Now make the mock return success and re-render
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'models.list') {
+				return Promise.resolve({
+					models: [
+						{
+							id: 'claude-opus-4-5',
+							display_name: 'Claude Opus 4.5',
+							description: '',
+							provider: 'anthropic',
+						},
+					],
+				});
+			}
+			if (method === 'session.model.get') {
+				return Promise.resolve({
+					currentModel: 'claude-sonnet-4-6',
+					modelInfo: {
+						id: 'claude-sonnet-4-6',
+						name: 'Claude Sonnet 4.6',
+						family: 'sonnet',
+						provider: 'anthropic',
+					},
+				});
+			}
+			if (method === 'session.thinking.get') {
+				return Promise.resolve({ thinkingLevel: 'auto' });
+			}
+			if (method === 'session.model.switch') {
+				return Promise.resolve({ success: true, model: 'claude-opus-4-5' });
+			}
+			return Promise.resolve({});
+		});
+
+		rerender({ members: [...spawnedMembers] });
+
+		await waitFor(() => {
+			const callsAfter = mockRequest.mock.calls.filter(
+				(call) => call[0] === 'session.model.switch'
+			).length;
+			expect(callsAfter).toBeGreaterThan(callsBefore);
+		});
+	});
 });

--- a/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
+++ b/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
@@ -625,6 +625,74 @@ describe('useTargetSessionContext', () => {
 		});
 	});
 
+	it('does not auto-apply stale preconfiguration after taskId changes', async () => {
+		const sharedTarget = {
+			id: 'node:n1:reviewer',
+			kind: 'node_agent' as const,
+			label: 'Reviewer',
+			agentName: 'reviewer',
+		};
+
+		const model: ModelInfo = {
+			id: 'claude-opus-4-5',
+			name: 'Opus 4.5',
+			family: 'opus',
+			provider: 'anthropic',
+			alias: 'opus',
+			contextWindow: 200000,
+			description: '',
+			releaseDate: '',
+			available: true,
+		};
+
+		const { result, rerender } = renderHook(
+			(props: { taskId: string; members: SpaceTaskActivityMember[] }) =>
+				useTargetSessionContext({
+					taskId: props.taskId,
+					targets: [sharedTarget],
+					selectedTarget: sharedTarget,
+					activityMembers: props.members,
+					taskAgentSessionId: 'task-sess-123',
+				}),
+			{ initialProps: { taskId: 'task-a', members: [] as SpaceTaskActivityMember[] } }
+		);
+
+		// Pre-configure model for task-a while agent is not started
+		await act(async () => {
+			await result.current.switchModel(model);
+		});
+		expect(result.current.currentModel).toBe('claude-opus-4-5');
+		expect(mockRequest).not.toHaveBeenCalledWith('session.model.switch', expect.anything());
+
+		// Switch to task-b where the same target already has a spawned session.
+		// The stale preconfiguration from task-a must NOT trigger auto-apply.
+		const spawnedMembers: SpaceTaskActivityMember[] = [
+			{
+				id: 'm-reviewer',
+				sessionId: 'reviewer-session-b',
+				kind: 'node_agent',
+				label: 'Reviewer',
+				role: 'reviewer',
+				state: 'active',
+				processingStatus: 'idle',
+				messageCount: 0,
+			},
+		];
+
+		rerender({ taskId: 'task-b', members: spawnedMembers });
+
+		// Wait a tick for any effect runs to settle
+		await new Promise((r) => setTimeout(r, 10));
+
+		// The model switch should NOT have been called because the preconfig
+		// belonged to task-a, not task-b.
+		expect(mockRequest).not.toHaveBeenCalledWith('session.model.switch', {
+			sessionId: 'reviewer-session-b',
+			model: 'claude-opus-4-5',
+			provider: 'anthropic',
+		});
+	});
+
 	it('auto-applies preconfiguration for non-selected targets when their session spawns', async () => {
 		const targetA = {
 			id: 'node:n1:coder',

--- a/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
+++ b/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
@@ -201,6 +201,7 @@ describe('useTargetSessionContext', () => {
 		const { result } = renderHook(() =>
 			useTargetSessionContext({
 				taskId: 'task-1',
+				targets: [taskAgentTarget],
 				selectedTarget: taskAgentTarget,
 				activityMembers: [],
 				taskAgentSessionId: 'task-sess-123',
@@ -217,6 +218,7 @@ describe('useTargetSessionContext', () => {
 		const { result } = renderHook(() =>
 			useTargetSessionContext({
 				taskId: 'task-1',
+				targets: [coderTarget],
 				selectedTarget: coderTarget,
 				activityMembers: members,
 				taskAgentSessionId: 'task-sess-123',
@@ -240,6 +242,7 @@ describe('useTargetSessionContext', () => {
 		const { result } = renderHook(() =>
 			useTargetSessionContext({
 				taskId: 'task-1',
+				targets: [notStartedTarget],
 				selectedTarget: notStartedTarget,
 				activityMembers: members,
 				taskAgentSessionId: 'task-sess-123',
@@ -264,6 +267,7 @@ describe('useTargetSessionContext', () => {
 		const { result } = renderHook(() =>
 			useTargetSessionContext({
 				taskId: 'task-1',
+				targets: [notStartedTarget],
 				selectedTarget: notStartedTarget,
 				activityMembers: members,
 				taskAgentSessionId: 'task-sess-123',
@@ -280,6 +284,7 @@ describe('useTargetSessionContext', () => {
 		const { result } = renderHook(() =>
 			useTargetSessionContext({
 				taskId: 'task-1',
+				targets: [coderTarget],
 				selectedTarget: coderTarget,
 				activityMembers: members,
 				taskAgentSessionId: 'task-sess-123',
@@ -314,6 +319,7 @@ describe('useTargetSessionContext', () => {
 		const { result } = renderHook(() =>
 			useTargetSessionContext({
 				taskId: 'task-1',
+				targets: [notStartedTarget],
 				selectedTarget: notStartedTarget,
 				activityMembers: members,
 				taskAgentSessionId: 'task-sess-123',
@@ -331,6 +337,7 @@ describe('useTargetSessionContext', () => {
 		const { result } = renderHook(() =>
 			useTargetSessionContext({
 				taskId: 'task-1',
+				targets: [coderTarget],
 				selectedTarget: coderTarget,
 				activityMembers: members,
 				taskAgentSessionId: 'task-sess-123',
@@ -359,6 +366,7 @@ describe('useTargetSessionContext', () => {
 		const { result } = renderHook(() =>
 			useTargetSessionContext({
 				taskId: 'task-1',
+				targets: [notStartedTarget],
 				selectedTarget: notStartedTarget,
 				activityMembers: members,
 				taskAgentSessionId: 'task-sess-123',
@@ -397,6 +405,7 @@ describe('useTargetSessionContext', () => {
 			(props: { members: SpaceTaskActivityMember[] }) =>
 				useTargetSessionContext({
 					taskId: 'task-1',
+					targets: [notStartedTarget],
 					selectedTarget: notStartedTarget,
 					activityMembers: props.members,
 					taskAgentSessionId: 'task-sess-123',
@@ -507,6 +516,7 @@ describe('useTargetSessionContext', () => {
 			(props: { members: SpaceTaskActivityMember[] }) =>
 				useTargetSessionContext({
 					taskId: 'task-1',
+					targets: [notStartedTarget],
 					selectedTarget: notStartedTarget,
 					activityMembers: props.members,
 					taskAgentSessionId: 'task-sess-123',
@@ -578,6 +588,7 @@ describe('useTargetSessionContext', () => {
 			(props: { taskId: string }) =>
 				useTargetSessionContext({
 					taskId: props.taskId,
+					targets: [notStartedTarget],
 					selectedTarget: notStartedTarget,
 					activityMembers: [],
 					taskAgentSessionId: 'task-sess-123',
@@ -599,6 +610,171 @@ describe('useTargetSessionContext', () => {
 		// should fall back to empty string.
 		await waitFor(() => {
 			expect(result.current.currentModel).toBe('');
+		});
+	});
+
+	it('auto-applies preconfiguration for non-selected targets when their session spawns', async () => {
+		const targetA = {
+			id: 'node:n1:coder',
+			kind: 'node_agent' as const,
+			label: 'Coder',
+			agentName: 'coder',
+		};
+		const targetB = {
+			id: 'node:n1:reviewer',
+			kind: 'node_agent' as const,
+			label: 'Reviewer',
+			agentName: 'reviewer',
+		};
+
+		const model: ModelInfo = {
+			id: 'claude-opus-4-5',
+			name: 'Opus 4.5',
+			family: 'opus',
+			provider: 'anthropic',
+			alias: 'opus',
+			contextWindow: 200000,
+			description: '',
+			releaseDate: '',
+			available: true,
+		};
+
+		// Phase 1: select target A and pre-configure it
+		const { result, rerender } = renderHook(
+			(props: {
+				members: SpaceTaskActivityMember[];
+				selectedTarget: typeof targetA | typeof targetB;
+			}) =>
+				useTargetSessionContext({
+					taskId: 'task-1',
+					targets: [targetA, targetB],
+					selectedTarget: props.selectedTarget,
+					activityMembers: props.members,
+					taskAgentSessionId: 'task-sess-123',
+				}),
+			{ initialProps: { members: [] as SpaceTaskActivityMember[], selectedTarget: targetA } }
+		);
+
+		await act(async () => {
+			await result.current.switchModel(model);
+		});
+		await act(async () => {
+			await result.current.setThinkingLevel('think16k');
+		});
+
+		expect(result.current.currentModel).toBe('claude-opus-4-5');
+		expect(mockRequest).not.toHaveBeenCalledWith('session.model.switch', expect.anything());
+
+		// Phase 2: switch selection to target B
+		rerender({ members: [] as SpaceTaskActivityMember[], selectedTarget: targetB });
+
+		// Phase 3: target A's session spawns in the background
+		const spawnedMembers: SpaceTaskActivityMember[] = [
+			{
+				id: 'm-coder',
+				sessionId: 'coder-session',
+				kind: 'node_agent',
+				label: 'Coder',
+				role: 'coder',
+				state: 'active',
+				processingStatus: 'idle',
+				messageCount: 0,
+			},
+		];
+
+		rerender({ members: spawnedMembers, selectedTarget: targetB });
+
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('session.model.switch', {
+				sessionId: 'coder-session',
+				model: 'claude-opus-4-5',
+				provider: 'anthropic',
+			});
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith('session.thinking.set', {
+			sessionId: 'coder-session',
+			level: 'think16k',
+		});
+	});
+
+	it('does not mark auto-config applied when no RPC was attempted', async () => {
+		const notStartedTarget = {
+			id: 'node:n1:reviewer',
+			kind: 'node_agent' as const,
+			label: 'Reviewer',
+			agentName: 'reviewer',
+		};
+
+		const model: ModelInfo = {
+			id: 'claude-opus-4-5',
+			name: 'Opus 4.5',
+			family: 'opus',
+			provider: 'anthropic',
+			alias: 'opus',
+			contextWindow: 200000,
+			description: '',
+			releaseDate: '',
+			available: true,
+		};
+
+		const { result, rerender } = renderHook(
+			(props: { members: SpaceTaskActivityMember[] }) =>
+				useTargetSessionContext({
+					taskId: 'task-1',
+					targets: [notStartedTarget],
+					selectedTarget: notStartedTarget,
+					activityMembers: props.members,
+					taskAgentSessionId: 'task-sess-123',
+				}),
+			{ initialProps: { members: [] as SpaceTaskActivityMember[] } }
+		);
+
+		// Phase 1: let models load while hub is connected so switcherModels is populated
+		await waitFor(() => {
+			expect(result.current.availableModels.length).toBeGreaterThan(0);
+		});
+
+		// Phase 2: disconnect hub and pre-configure model
+		mockGetHubIfConnected.mockReturnValue(null);
+		await act(async () => {
+			await result.current.switchModel(model);
+		});
+
+		// Phase 3: spawn session while hub is still disconnected
+		const spawnedMembers: SpaceTaskActivityMember[] = [
+			{
+				id: 'm-reviewer',
+				sessionId: 'reviewer-session',
+				kind: 'node_agent',
+				label: 'Reviewer',
+				role: 'reviewer',
+				state: 'active',
+				processingStatus: 'idle',
+				messageCount: 0,
+			},
+		];
+
+		rerender({ members: spawnedMembers });
+
+		// Wait a tick to let any effect runs settle
+		await new Promise((r) => setTimeout(r, 10));
+
+		// No RPCs should have been attempted because hub is null
+		expect(mockRequest).not.toHaveBeenCalledWith('session.model.switch', expect.anything());
+		expect(mockRequest).not.toHaveBeenCalledWith('session.thinking.set', expect.anything());
+
+		// Phase 4: reconnect the hub and re-render
+		mockGetHubIfConnected.mockReturnValue({ request: mockRequest });
+		rerender({ members: [...spawnedMembers] });
+
+		// The effect should retry now that the hub is available
+		await waitFor(() => {
+			expect(mockRequest).toHaveBeenCalledWith('session.model.switch', {
+				sessionId: 'reviewer-session',
+				model: 'claude-opus-4-5',
+				provider: 'anthropic',
+			});
 		});
 	});
 });

--- a/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
+++ b/packages/web/src/hooks/__tests__/useTargetSessionContext.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/preact';
+import type { SpaceTaskActivityMember, ModelInfo } from '@neokai/shared';
+
+const mockRequest = vi.fn();
+const mockGetHubIfConnected = vi.fn();
+
+vi.mock('../../lib/connection-manager', () => ({
+	connectionManager: {
+		getHubIfConnected: () => mockGetHubIfConnected(),
+	},
+}));
+
+vi.mock('../../lib/toast', () => ({
+	toast: {
+		success: vi.fn(),
+		error: vi.fn(),
+		info: vi.fn(),
+	},
+}));
+
+vi.mock('../../lib/state', () => ({
+	connectionState: { value: 'connected' },
+}));
+
+import { useTargetSessionContext, resolveTargetSessionId } from '../useTargetSessionContext';
+
+describe('resolveTargetSessionId', () => {
+	const members: SpaceTaskActivityMember[] = [
+		{
+			id: 'm1',
+			sessionId: 'coder-session',
+			kind: 'node_agent',
+			label: 'Coder',
+			role: 'coder',
+			state: 'active',
+			processingStatus: 'idle',
+			messageCount: 0,
+		},
+	];
+
+	it('returns taskAgentSessionId for task_agent target', () => {
+		const target = { id: 'task-agent', kind: 'task_agent' as const, label: 'Task Agent' };
+		expect(resolveTargetSessionId(target, members, 'task-session')).toBe('task-session');
+	});
+
+	it('returns member sessionId for node_agent target', () => {
+		const target = {
+			id: 'node:n1:coder',
+			kind: 'node_agent' as const,
+			label: 'Coder',
+			agentName: 'coder',
+		};
+		expect(resolveTargetSessionId(target, members, 'task-session')).toBe('coder-session');
+	});
+
+	it('returns null for not-yet-started node_agent', () => {
+		const target = {
+			id: 'node:n1:reviewer',
+			kind: 'node_agent' as const,
+			label: 'Reviewer',
+			agentName: 'reviewer',
+		};
+		expect(resolveTargetSessionId(target, members, 'task-session')).toBeNull();
+	});
+
+	it('returns null when target is null', () => {
+		expect(resolveTargetSessionId(null, members, 'task-session')).toBeNull();
+	});
+});
+
+describe('useTargetSessionContext', () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+		mockGetHubIfConnected.mockReturnValue({
+			request: mockRequest,
+		});
+		mockRequest.mockImplementation((method: string) => {
+			if (method === 'models.list') {
+				return Promise.resolve({
+					models: [
+						{
+							id: 'claude-sonnet-4-6',
+							display_name: 'Claude Sonnet 4.6',
+							description: '',
+							provider: 'anthropic',
+						},
+					],
+				});
+			}
+			if (method === 'session.model.get') {
+				return Promise.resolve({
+					currentModel: 'claude-sonnet-4-6',
+					modelInfo: {
+						id: 'claude-sonnet-4-6',
+						name: 'Claude Sonnet 4.6',
+						family: 'sonnet',
+						provider: 'anthropic',
+					},
+				});
+			}
+			return Promise.resolve({});
+		});
+	});
+
+	const taskAgentTarget = {
+		id: 'task-agent',
+		kind: 'task_agent' as const,
+		label: 'Task Agent',
+	};
+
+	const coderTarget = {
+		id: 'node:n1:coder',
+		kind: 'node_agent' as const,
+		label: 'Coder',
+		agentName: 'coder',
+	};
+
+	const members: SpaceTaskActivityMember[] = [
+		{
+			id: 'm1',
+			sessionId: 'coder-session',
+			kind: 'node_agent',
+			label: 'Coder',
+			role: 'coder',
+			state: 'active',
+			processingStatus: 'processing',
+			messageCount: 0,
+		},
+	];
+
+	it('resolves task_agent to taskAgentSessionId', async () => {
+		const { result } = renderHook(() =>
+			useTargetSessionContext({
+				selectedTarget: taskAgentTarget,
+				activityMembers: [],
+				taskAgentSessionId: 'task-sess-123',
+			})
+		);
+
+		await waitFor(() => {
+			expect(result.current.targetSessionId).toBe('task-sess-123');
+		});
+		expect(result.current.isStarted).toBe(true);
+	});
+
+	it('resolves node_agent to member sessionId', async () => {
+		const { result } = renderHook(() =>
+			useTargetSessionContext({
+				selectedTarget: coderTarget,
+				activityMembers: members,
+				taskAgentSessionId: 'task-sess-123',
+			})
+		);
+
+		await waitFor(() => {
+			expect(result.current.targetSessionId).toBe('coder-session');
+		});
+		expect(result.current.isStarted).toBe(true);
+	});
+
+	it('marks not-yet-started agent as isStarted=false', async () => {
+		const notStartedTarget = {
+			id: 'node:n1:reviewer',
+			kind: 'node_agent' as const,
+			label: 'Reviewer',
+			agentName: 'reviewer',
+		};
+
+		const { result } = renderHook(() =>
+			useTargetSessionContext({
+				selectedTarget: notStartedTarget,
+				activityMembers: members,
+				taskAgentSessionId: 'task-sess-123',
+				defaultAgentModels: new Map([['reviewer', 'claude-opus-4-5']]),
+			})
+		);
+
+		await waitFor(() => {
+			expect(result.current.isStarted).toBe(false);
+		});
+		expect(result.current.targetSessionId).toBeNull();
+	});
+
+	it('uses workflow default model for not-yet-started agents', async () => {
+		const notStartedTarget = {
+			id: 'node:n1:reviewer',
+			kind: 'node_agent' as const,
+			label: 'Reviewer',
+			agentName: 'reviewer',
+		};
+
+		const { result } = renderHook(() =>
+			useTargetSessionContext({
+				selectedTarget: notStartedTarget,
+				activityMembers: members,
+				taskAgentSessionId: 'task-sess-123',
+				defaultAgentModels: new Map([['reviewer', 'claude-opus-4-5']]),
+			})
+		);
+
+		await waitFor(() => {
+			expect(result.current.currentModel).toBe('claude-opus-4-5');
+		});
+	});
+
+	it('derives isProcessing from activity member processingStatus', async () => {
+		const { result } = renderHook(() =>
+			useTargetSessionContext({
+				selectedTarget: coderTarget,
+				activityMembers: members,
+				taskAgentSessionId: 'task-sess-123',
+			})
+		);
+
+		await waitFor(() => {
+			expect(result.current.isProcessing).toBe(true);
+		});
+	});
+
+	it('pre-configures model for not-yet-started agents', async () => {
+		const notStartedTarget = {
+			id: 'node:n1:reviewer',
+			kind: 'node_agent' as const,
+			label: 'Reviewer',
+			agentName: 'reviewer',
+		};
+
+		const model: ModelInfo = {
+			id: 'claude-opus-4-5',
+			name: 'Opus 4.5',
+			family: 'opus',
+			provider: 'anthropic',
+			alias: 'opus',
+			contextWindow: 200000,
+			description: '',
+			releaseDate: '',
+			available: true,
+		};
+
+		const { result } = renderHook(() =>
+			useTargetSessionContext({
+				selectedTarget: notStartedTarget,
+				activityMembers: members,
+				taskAgentSessionId: 'task-sess-123',
+			})
+		);
+
+		await act(async () => {
+			await result.current.switchModel(model);
+		});
+
+		expect(result.current.currentModel).toBe('claude-opus-4-5');
+	});
+
+	it('sets thinking level for started agents via RPC', async () => {
+		const { result } = renderHook(() =>
+			useTargetSessionContext({
+				selectedTarget: coderTarget,
+				activityMembers: members,
+				taskAgentSessionId: 'task-sess-123',
+			})
+		);
+
+		await act(async () => {
+			await result.current.setThinkingLevel('think16k');
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith('session.thinking.set', {
+			sessionId: 'coder-session',
+			level: 'think16k',
+		});
+		expect(result.current.thinkingLevel).toBe('think16k');
+	});
+
+	it('pre-configures thinking level for not-yet-started agents', async () => {
+		const notStartedTarget = {
+			id: 'node:n1:reviewer',
+			kind: 'node_agent' as const,
+			label: 'Reviewer',
+			agentName: 'reviewer',
+		};
+
+		const { result } = renderHook(() =>
+			useTargetSessionContext({
+				selectedTarget: notStartedTarget,
+				activityMembers: members,
+				taskAgentSessionId: 'task-sess-123',
+			})
+		);
+
+		await act(async () => {
+			await result.current.setThinkingLevel('think32k');
+		});
+
+		expect(result.current.thinkingLevel).toBe('think32k');
+		expect(mockRequest).not.toHaveBeenCalledWith('session.thinking.set', expect.anything());
+	});
+});

--- a/packages/web/src/hooks/index.ts
+++ b/packages/web/src/hooks/index.ts
@@ -71,3 +71,8 @@ export {
 export { useViewportSafety } from './useViewportSafety';
 export { useClickOutside } from './useClickOutside';
 export { useIsMobileCanvas, MOBILE_CANVAS_MEDIA_QUERY } from './useIsMobileCanvas';
+export {
+	useTargetSessionContext,
+	type UseTargetSessionContextResult,
+	type TaskComposerTarget,
+} from './useTargetSessionContext';

--- a/packages/web/src/hooks/useModelSwitcher.ts
+++ b/packages/web/src/hooks/useModelSwitcher.ts
@@ -249,7 +249,7 @@ export function useFilteredModelsForPicker(
  *
  * @param sessionId - Current session ID
  */
-export function useModelSwitcher(sessionId: string): UseModelSwitcherResult {
+export function useModelSwitcher(sessionId: string | null): UseModelSwitcherResult {
 	const [currentModel, setCurrentModel] = useState<string>('');
 	const [currentModelInfo, setCurrentModelInfo] = useState<ModelInfo | null>(null);
 	const [availableModels, setAvailableModels] = useState<ModelInfo[]>([]);
@@ -262,18 +262,20 @@ export function useModelSwitcher(sessionId: string): UseModelSwitcherResult {
 			const hub = connectionManager.getHubIfConnected();
 			if (!hub) return;
 
-			// Fetch current model (best effort — session may not exist yet)
-			try {
-				const { currentModel: modelId, modelInfo } = (await hub.request('session.model.get', {
-					sessionId,
-				})) as {
-					currentModel: string;
-					modelInfo: ModelInfo | null;
-				};
-				setCurrentModel(modelId);
-				setCurrentModelInfo(modelInfo);
-			} catch {
-				// Session not found or not started yet — keep defaults
+			// Fetch current model (skip when no sessionId; best effort otherwise)
+			if (sessionId) {
+				try {
+					const { currentModel: modelId, modelInfo } = (await hub.request('session.model.get', {
+						sessionId,
+					})) as {
+						currentModel: string;
+						modelInfo: ModelInfo | null;
+					};
+					setCurrentModel(modelId);
+					setCurrentModelInfo(modelInfo);
+				} catch {
+					// Session not found or not started yet — keep defaults
+				}
 			}
 
 			// Fetch available models (independent of session state)

--- a/packages/web/src/hooks/useModelSwitcher.ts
+++ b/packages/web/src/hooks/useModelSwitcher.ts
@@ -262,18 +262,21 @@ export function useModelSwitcher(sessionId: string): UseModelSwitcherResult {
 			const hub = connectionManager.getHubIfConnected();
 			if (!hub) return;
 
-			// Fetch current model
-			const { currentModel: modelId, modelInfo } = (await hub.request('session.model.get', {
-				sessionId,
-			})) as {
-				currentModel: string;
-				modelInfo: ModelInfo | null;
-			};
+			// Fetch current model (best effort — session may not exist yet)
+			try {
+				const { currentModel: modelId, modelInfo } = (await hub.request('session.model.get', {
+					sessionId,
+				})) as {
+					currentModel: string;
+					modelInfo: ModelInfo | null;
+				};
+				setCurrentModel(modelId);
+				setCurrentModelInfo(modelInfo);
+			} catch {
+				// Session not found or not started yet — keep defaults
+			}
 
-			setCurrentModel(modelId);
-			setCurrentModelInfo(modelInfo);
-
-			// Fetch available models (includes all providers for cross-provider switching)
+			// Fetch available models (independent of session state)
 			const { models } = (await hub.request('models.list', {
 				useCache: true,
 			})) as { models: RawModelEntry[] };

--- a/packages/web/src/hooks/useTargetSessionContext.ts
+++ b/packages/web/src/hooks/useTargetSessionContext.ts
@@ -1,0 +1,220 @@
+import type { ModelInfo, SpaceTaskActivityMember, ThinkingLevel } from '@neokai/shared';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'preact/hooks';
+import { connectionManager } from '../lib/connection-manager.ts';
+import { toast } from '../lib/toast.ts';
+import { useModelSwitcher } from './useModelSwitcher.ts';
+
+export interface TaskComposerTarget {
+	id: string;
+	kind: 'task_agent' | 'node_agent';
+	label: string;
+	agentName?: string;
+	nodeExecutionId?: string;
+	nodeName?: string;
+	state?: string;
+}
+
+export interface UseTargetSessionContextResult {
+	/** Resolved session ID for the targeted agent, or null if not started */
+	targetSessionId: string | null;
+	/** Current model ID (live or pre-configured) */
+	currentModel: string;
+	/** Current model info (live or pre-configured) */
+	currentModelInfo: ModelInfo | null;
+	/** All available models from the server */
+	availableModels: ModelInfo[];
+	/** Whether a model switch is in progress */
+	modelSwitching: boolean;
+	/** Whether models are being loaded */
+	modelLoading: boolean;
+	/** Current thinking level (live or pre-configured) */
+	thinkingLevel: ThinkingLevel;
+	/** Whether the targeted agent is actively processing */
+	isProcessing: boolean;
+	/** Whether the targeted agent has a live session */
+	isStarted: boolean;
+	/** Switch model on the targeted session (or pre-configure) */
+	switchModel: (model: ModelInfo) => Promise<void>;
+	/** Set thinking level on the targeted session (or pre-configure) */
+	setThinkingLevel: (level: ThinkingLevel) => Promise<void>;
+}
+
+/**
+ * Resolve a composer target to its backing session ID.
+ */
+export function resolveTargetSessionId(
+	target: TaskComposerTarget | null,
+	activityMembers: SpaceTaskActivityMember[],
+	taskAgentSessionId: string | null
+): string | null {
+	if (!target) return null;
+	if (target.kind === 'task_agent') return taskAgentSessionId;
+
+	// node_agent: prefer activity member session, fall back to node execution
+	const member = activityMembers.find(
+		(m) =>
+			m.kind === 'node_agent' &&
+			(m.role === target.agentName || m.nodeExecution?.agentName === target.agentName)
+	);
+	return member?.sessionId ?? null;
+}
+
+/**
+ * Hook that resolves the selected task-composer target to a live session
+ * context (model, thinking, processing state) and supports pre-configuration
+ * for agents that haven't started yet.
+ */
+export function useTargetSessionContext({
+	selectedTarget,
+	activityMembers,
+	taskAgentSessionId,
+	defaultAgentModels,
+}: {
+	selectedTarget: TaskComposerTarget | null;
+	activityMembers: SpaceTaskActivityMember[];
+	taskAgentSessionId: string | null;
+	defaultAgentModels?: Map<string, string>;
+}): UseTargetSessionContextResult {
+	const targetSessionId = useMemo(
+		() => resolveTargetSessionId(selectedTarget, activityMembers, taskAgentSessionId),
+		[selectedTarget, activityMembers, taskAgentSessionId]
+	);
+	const isStarted = !!targetSessionId;
+
+	// Use the shared model switcher for the target session.
+	// When the agent hasn't started yet the sessionId is a dummy value,
+	// but models.list still loads the global catalogue.
+	const modelSwitcher = useModelSwitcher(targetSessionId ?? '__not_started__');
+
+	// In-memory pre-configuration for not-yet-started agents.
+	const [preConfiguredModel, setPreConfiguredModel] = useState<Map<string, string>>(new Map());
+	const [preConfiguredThinking, setPreConfiguredThinking] = useState<Map<string, ThinkingLevel>>(
+		new Map()
+	);
+
+	// Track which targets we've already auto-applied so we don't loop.
+	const appliedAutoConfigRef = useRef<Set<string>>(new Set());
+
+	// Default model from workflow definition.
+	const defaultModel = useMemo(() => {
+		if (!selectedTarget || selectedTarget.kind !== 'node_agent' || !selectedTarget.agentName) {
+			return '';
+		}
+		return defaultAgentModels?.get(selectedTarget.agentName) ?? '';
+	}, [selectedTarget, defaultAgentModels]);
+
+	// Effective model: live when started, pre-configured/default when not.
+	const effectiveCurrentModel = isStarted
+		? modelSwitcher.currentModel
+		: (preConfiguredModel.get(selectedTarget?.id ?? '') ?? defaultModel);
+
+	const effectiveCurrentModelInfo = isStarted
+		? modelSwitcher.currentModelInfo
+		: (modelSwitcher.availableModels.find((m) => m.id === effectiveCurrentModel) ?? null);
+
+	// Thinking level — default to auto; sync with pre-configured value when switching targets.
+	const [thinkingLevel, setLocalThinkingLevel] = useState<ThinkingLevel>('auto');
+
+	useEffect(() => {
+		if (!isStarted && selectedTarget) {
+			setLocalThinkingLevel(preConfiguredThinking.get(selectedTarget.id) ?? 'auto');
+		} else if (isStarted) {
+			setLocalThinkingLevel('auto');
+		}
+	}, [selectedTarget?.id, isStarted, preConfiguredThinking]);
+
+	// Auto-apply pre-configured settings when a session spawns.
+	useEffect(() => {
+		if (!targetSessionId || !selectedTarget) return;
+		const targetId = selectedTarget.id;
+		if (appliedAutoConfigRef.current.has(targetId)) return;
+
+		const preModel = preConfiguredModel.get(targetId);
+		const preThinking = preConfiguredThinking.get(targetId);
+		if (!preModel && !preThinking) return;
+
+		appliedAutoConfigRef.current.add(targetId);
+
+		// Apply model switch
+		if (preModel) {
+			const modelInfo = modelSwitcher.availableModels.find((m) => m.id === preModel);
+			if (modelInfo) {
+				modelSwitcher.switchModel(modelInfo).catch(() => {
+					// Best-effort; user can retry manually
+				});
+			}
+		}
+
+		// Apply thinking level
+		if (preThinking) {
+			connectionManager
+				.getHubIfConnected()
+				?.request('session.thinking.set', {
+					sessionId: targetSessionId,
+					level: preThinking,
+				})
+				.catch(() => {});
+		}
+	}, [targetSessionId, selectedTarget, preConfiguredModel, preConfiguredThinking, modelSwitcher]);
+
+	// Derive processing state from the activity member that owns this session.
+	const isProcessing = useMemo(() => {
+		if (!targetSessionId) return false;
+		const member = activityMembers.find((m) => m.sessionId === targetSessionId);
+		if (!member) return false;
+		return member.processingStatus === 'processing' || member.processingStatus === 'queued';
+	}, [targetSessionId, activityMembers]);
+
+	const switchModel = useCallback(
+		async (model: ModelInfo) => {
+			if (!selectedTarget) return;
+			if (!isStarted) {
+				setPreConfiguredModel((prev) => new Map(prev).set(selectedTarget.id, model.id));
+				toast.success(`Pre-configured ${selectedTarget.label} to use ${model.name}`);
+				return;
+			}
+			await modelSwitcher.switchModel(model);
+		},
+		[isStarted, selectedTarget, modelSwitcher]
+	);
+
+	const setThinkingLevel = useCallback(
+		async (level: ThinkingLevel) => {
+			setLocalThinkingLevel(level);
+			if (!isStarted || !targetSessionId) {
+				if (selectedTarget) {
+					setPreConfiguredThinking((prev) => new Map(prev).set(selectedTarget.id, level));
+				}
+				return;
+			}
+			try {
+				const hub = connectionManager.getHubIfConnected();
+				if (!hub) {
+					toast.error('Not connected to server');
+					return;
+				}
+				await hub.request('session.thinking.set', {
+					sessionId: targetSessionId,
+					level,
+				});
+			} catch (err) {
+				toast.error(err instanceof Error ? err.message : 'Failed to set thinking level');
+			}
+		},
+		[isStarted, targetSessionId, selectedTarget]
+	);
+
+	return {
+		targetSessionId,
+		currentModel: effectiveCurrentModel,
+		currentModelInfo: effectiveCurrentModelInfo,
+		availableModels: modelSwitcher.availableModels,
+		modelSwitching: modelSwitcher.switching,
+		modelLoading: modelSwitcher.loading,
+		thinkingLevel,
+		isProcessing,
+		isStarted,
+		switchModel,
+		setThinkingLevel,
+	};
+}

--- a/packages/web/src/hooks/useTargetSessionContext.ts
+++ b/packages/web/src/hooks/useTargetSessionContext.ts
@@ -194,7 +194,7 @@ export function useTargetSessionContext({
 
 	// Destructure stable primitives from modelSwitcher to avoid effect re-runs
 	// caused by the switcher object identity changing every render.
-	const { availableModels: switcherModels } = modelSwitcher;
+	const { availableModels: switcherModels, reload: reloadModelState } = modelSwitcher;
 
 	// Auto-apply pre-configured settings when any target's session spawns.
 	// Iterates over ALL targets so that background spawns (targets not currently
@@ -252,6 +252,11 @@ export function useTargetSessionContext({
 									const { success } = result as { success: boolean };
 									if (success) {
 										appliedModelRef.current.add(targetId);
+										// Refresh useModelSwitcher state so the UI shows the
+										// newly applied model instead of the stale initial one.
+										if (target.id === selectedTargetRef.current?.id) {
+											reloadModelState();
+										}
 									}
 								})
 						);
@@ -291,6 +296,7 @@ export function useTargetSessionContext({
 		preConfiguredModel,
 		preConfiguredThinking,
 		switcherModels,
+		reloadModelState,
 	]);
 
 	// Derive processing state from the activity member that owns this session.

--- a/packages/web/src/hooks/useTargetSessionContext.ts
+++ b/packages/web/src/hooks/useTargetSessionContext.ts
@@ -84,9 +84,9 @@ export function useTargetSessionContext({
 	const isStarted = !!targetSessionId;
 
 	// Use the shared model switcher for the target session.
-	// When the agent hasn't started yet the sessionId is a dummy value,
-	// but models.list still loads the global catalogue.
-	const modelSwitcher = useModelSwitcher(targetSessionId ?? '__not_started__');
+	// When the agent hasn't started yet sessionId is null; useModelSwitcher
+	// skips session.model.get but still loads the global catalogue.
+	const modelSwitcher = useModelSwitcher(targetSessionId);
 
 	// In-memory pre-configuration for not-yet-started agents.
 	const [preConfiguredModel, setPreConfiguredModel] = useState<Map<string, string>>(new Map());
@@ -118,14 +118,17 @@ export function useTargetSessionContext({
 	const [thinkingLevel, setLocalThinkingLevel] = useState<ThinkingLevel>('auto');
 
 	useEffect(() => {
-		if (!isStarted && selectedTarget) {
-			setLocalThinkingLevel(preConfiguredThinking.get(selectedTarget.id) ?? 'auto');
-		} else if (isStarted) {
-			setLocalThinkingLevel('auto');
-		}
+		if (!selectedTarget) return;
+		setLocalThinkingLevel(preConfiguredThinking.get(selectedTarget.id) ?? 'auto');
 	}, [selectedTarget?.id, isStarted, preConfiguredThinking]);
 
+	// Destructure stable primitives from modelSwitcher to avoid effect re-runs
+	// caused by the switcher object identity changing every render.
+	const { availableModels: switcherModels, switchModel: switcherSwitchModel } = modelSwitcher;
+
 	// Auto-apply pre-configured settings when a session spawns.
+	// Only mark the target as applied after both operations succeed so that
+	// transient failures (e.g. missing hub connection) trigger a retry.
 	useEffect(() => {
 		if (!targetSessionId || !selectedTarget) return;
 		const targetId = selectedTarget.id;
@@ -135,29 +138,46 @@ export function useTargetSessionContext({
 		const preThinking = preConfiguredThinking.get(targetId);
 		if (!preModel && !preThinking) return;
 
-		appliedAutoConfigRef.current.add(targetId);
+		let modelPromise: Promise<unknown> = Promise.resolve();
+		let thinkingPromise: Promise<unknown> = Promise.resolve();
 
 		// Apply model switch
 		if (preModel) {
-			const modelInfo = modelSwitcher.availableModels.find((m) => m.id === preModel);
+			const modelInfo = switcherModels.find((m) => m.id === preModel);
 			if (modelInfo) {
-				modelSwitcher.switchModel(modelInfo).catch(() => {
-					// Best-effort; user can retry manually
-				});
+				modelPromise = switcherSwitchModel(modelInfo);
 			}
 		}
 
 		// Apply thinking level
 		if (preThinking) {
-			connectionManager
-				.getHubIfConnected()
-				?.request('session.thinking.set', {
+			const hub = connectionManager.getHubIfConnected();
+			if (hub) {
+				thinkingPromise = hub.request('session.thinking.set', {
 					sessionId: targetSessionId,
 					level: preThinking,
-				})
-				.catch(() => {});
+				});
+			}
 		}
-	}, [targetSessionId, selectedTarget, preConfiguredModel, preConfiguredThinking, modelSwitcher]);
+
+		Promise.all([modelPromise, thinkingPromise])
+			.then(() => {
+				appliedAutoConfigRef.current.add(targetId);
+				if (preThinking) {
+					setLocalThinkingLevel(preThinking);
+				}
+			})
+			.catch(() => {
+				// Leave unmarked so the effect retries on next render
+			});
+	}, [
+		targetSessionId,
+		selectedTarget,
+		preConfiguredModel,
+		preConfiguredThinking,
+		switcherModels,
+		switcherSwitchModel,
+	]);
 
 	// Derive processing state from the activity member that owns this session.
 	const isProcessing = useMemo(() => {

--- a/packages/web/src/hooks/useTargetSessionContext.ts
+++ b/packages/web/src/hooks/useTargetSessionContext.ts
@@ -50,12 +50,14 @@ export function resolveTargetSessionId(
 	if (!target) return null;
 	if (target.kind === 'task_agent') return taskAgentSessionId;
 
-	// node_agent: prefer activity member session, fall back to node execution
-	const member = activityMembers.find(
-		(m) =>
-			m.kind === 'node_agent' &&
-			(m.role === target.agentName || m.nodeExecution?.agentName === target.agentName)
-	);
+	// node_agent: prefer exact nodeExecutionId match, then fall back to agent name
+	const member = activityMembers.find((m) => {
+		if (m.kind !== 'node_agent') return false;
+		if (target.nodeExecutionId) {
+			return m.nodeExecution?.nodeExecutionId === target.nodeExecutionId;
+		}
+		return m.role === target.agentName || m.nodeExecution?.agentName === target.agentName;
+	});
 	return member?.sessionId ?? null;
 }
 
@@ -95,12 +97,12 @@ export function useTargetSessionContext({
 	// Track which targets we've already auto-applied so we don't loop.
 	const appliedAutoConfigRef = useRef<Set<string>>(new Set());
 
-	// Default model from workflow definition.
+	// Default model from workflow definition (keyed by target ID).
 	const defaultModel = useMemo(() => {
-		if (!selectedTarget || selectedTarget.kind !== 'node_agent' || !selectedTarget.agentName) {
+		if (!selectedTarget || selectedTarget.kind !== 'node_agent') {
 			return '';
 		}
-		return defaultAgentModels?.get(selectedTarget.agentName) ?? '';
+		return defaultAgentModels?.get(selectedTarget.id) ?? '';
 	}, [selectedTarget, defaultAgentModels]);
 
 	// Effective model: live when started, pre-configured/default when not.

--- a/packages/web/src/hooks/useTargetSessionContext.ts
+++ b/packages/web/src/hooks/useTargetSessionContext.ts
@@ -68,12 +68,14 @@ export function resolveTargetSessionId(
  */
 export function useTargetSessionContext({
 	taskId,
+	targets,
 	selectedTarget,
 	activityMembers,
 	taskAgentSessionId,
 	defaultAgentModels,
 }: {
 	taskId: string;
+	targets: TaskComposerTarget[];
 	selectedTarget: TaskComposerTarget | null;
 	activityMembers: SpaceTaskActivityMember[];
 	taskAgentSessionId: string | null;
@@ -134,59 +136,81 @@ export function useTargetSessionContext({
 
 	// Destructure stable primitives from modelSwitcher to avoid effect re-runs
 	// caused by the switcher object identity changing every render.
-	const { availableModels: switcherModels, switchModel: switcherSwitchModel } = modelSwitcher;
+	const { availableModels: switcherModels } = modelSwitcher;
 
-	// Auto-apply pre-configured settings when a session spawns.
-	// Only mark the target as applied after both operations succeed so that
-	// transient failures (e.g. missing hub connection) trigger a retry.
+	// Auto-apply pre-configured settings when any target's session spawns.
+	// Iterates over ALL targets so that background spawns (targets not currently
+	// selected) still receive their pending preconfiguration.
+	// Only marks a target as applied when at least one RPC was actually
+	// attempted and all attempts succeeded; if preconditions are missing
+	// (e.g. model info not yet loaded or hub disconnected) the target stays
+	// unmarked and the effect retries on the next render cycle.
 	useEffect(() => {
-		if (!targetSessionId || !selectedTarget) return;
-		const targetId = selectedTarget.id;
-		if (appliedAutoConfigRef.current.has(targetId)) return;
+		for (const target of targets) {
+			const targetId = target.id;
+			if (appliedAutoConfigRef.current.has(targetId)) continue;
 
-		const preModel = preConfiguredModel.get(targetId);
-		const preThinking = preConfiguredThinking.get(targetId);
-		if (!preModel && !preThinking) return;
+			const preModel = preConfiguredModel.get(targetId);
+			const preThinking = preConfiguredThinking.get(targetId);
+			if (!preModel && !preThinking) continue;
 
-		let modelPromise: Promise<unknown> = Promise.resolve();
-		let thinkingPromise: Promise<unknown> = Promise.resolve();
+			const sessionId = resolveTargetSessionId(target, activityMembers, taskAgentSessionId);
+			if (!sessionId) continue;
 
-		// Apply model switch
-		if (preModel) {
-			const modelInfo = switcherModels.find((m) => m.id === preModel);
-			if (modelInfo) {
-				modelPromise = switcherSwitchModel(modelInfo);
-			}
-		}
+			let attempted = false;
+			const promises: Promise<unknown>[] = [];
 
-		// Apply thinking level
-		if (preThinking) {
-			const hub = connectionManager.getHubIfConnected();
-			if (hub) {
-				thinkingPromise = hub.request('session.thinking.set', {
-					sessionId: targetSessionId,
-					level: preThinking,
-				});
-			}
-		}
-
-		Promise.all([modelPromise, thinkingPromise])
-			.then(() => {
-				appliedAutoConfigRef.current.add(targetId);
-				if (preThinking) {
-					setLocalThinkingLevel(preThinking);
+			// Apply model switch
+			if (preModel) {
+				const modelInfo = switcherModels.find((m) => m.id === preModel);
+				if (modelInfo) {
+					attempted = true;
+					const hub = connectionManager.getHubIfConnected();
+					if (hub) {
+						promises.push(
+							hub.request('session.model.switch', {
+								sessionId,
+								model: modelInfo.id,
+								provider: modelInfo.provider,
+							})
+						);
+					} else {
+						promises.push(Promise.reject(new Error('Not connected')));
+					}
 				}
-			})
-			.catch(() => {
-				// Leave unmarked so the effect retries on next render
-			});
+			}
+
+			// Apply thinking level
+			if (preThinking) {
+				const hub = connectionManager.getHubIfConnected();
+				if (hub) {
+					attempted = true;
+					promises.push(
+						hub.request('session.thinking.set', {
+							sessionId,
+							level: preThinking,
+						})
+					);
+				}
+			}
+
+			if (!attempted) continue;
+
+			Promise.all(promises)
+				.then(() => {
+					appliedAutoConfigRef.current.add(targetId);
+				})
+				.catch(() => {
+					// Leave unmarked so the effect retries on next render
+				});
+		}
 	}, [
-		targetSessionId,
-		selectedTarget,
+		targets,
+		activityMembers,
+		taskAgentSessionId,
 		preConfiguredModel,
 		preConfiguredThinking,
 		switcherModels,
-		switcherSwitchModel,
 	]);
 
 	// Derive processing state from the activity member that owns this session.

--- a/packages/web/src/hooks/useTargetSessionContext.ts
+++ b/packages/web/src/hooks/useTargetSessionContext.ts
@@ -1,6 +1,7 @@
 import type { ModelInfo, SpaceTaskActivityMember, ThinkingLevel } from '@neokai/shared';
 import { useState, useEffect, useMemo, useCallback, useRef } from 'preact/hooks';
 import { connectionManager } from '../lib/connection-manager.ts';
+import { connectionState } from '../lib/state.ts';
 import { toast } from '../lib/toast.ts';
 import { useModelSwitcher } from './useModelSwitcher.ts';
 
@@ -157,6 +158,9 @@ export function useTargetSessionContext({
 
 	// Load the live thinking level from the session whenever the target
 	// session changes (e.g. switching to a different started agent).
+	// Also re-fetch when the connection recovers so a transient disconnect
+	// or early render while the hub is still connecting doesn't leave the
+	// dropdown stuck on a stale local default.
 	useEffect(() => {
 		if (!targetSessionId) return;
 		let cancelled = false;
@@ -178,7 +182,7 @@ export function useTargetSessionContext({
 		return () => {
 			cancelled = true;
 		};
-	}, [targetSessionId]);
+	}, [targetSessionId, connectionState.value]);
 
 	// For unstarted targets, sync with pre-configured value (scoped to current task).
 	useEffect(() => {

--- a/packages/web/src/hooks/useTargetSessionContext.ts
+++ b/packages/web/src/hooks/useTargetSessionContext.ts
@@ -244,8 +244,11 @@ export function useTargetSessionContext({
 									model: modelInfo.id,
 									provider: modelInfo.provider,
 								})
-								.then(() => {
-									appliedModelRef.current.add(targetId);
+								.then((result: unknown) => {
+									const { success } = result as { success: boolean };
+									if (success) {
+										appliedModelRef.current.add(targetId);
+									}
 								})
 						);
 					}

--- a/packages/web/src/hooks/useTargetSessionContext.ts
+++ b/packages/web/src/hooks/useTargetSessionContext.ts
@@ -93,17 +93,22 @@ export function useTargetSessionContext({
 	const modelSwitcher = useModelSwitcher(targetSessionId);
 
 	// In-memory pre-configuration for not-yet-started agents.
-	// Model preconfig stores both id and provider so that auto-apply can
-	// disambiguate when multiple providers expose the same model ID.
+	// Model preconfig stores id, provider, and the owning taskId so that
+	// effective reads and auto-apply can guard against stale data after a
+	// task switch.
 	const [preConfiguredModel, setPreConfiguredModel] = useState<
-		Map<string, { id: string; provider: string }>
+		Map<string, { id: string; provider: string; taskId: string }>
 	>(new Map());
-	const [preConfiguredThinking, setPreConfiguredThinking] = useState<Map<string, ThinkingLevel>>(
-		new Map()
-	);
+	const [preConfiguredThinking, setPreConfiguredThinking] = useState<
+		Map<string, { level: ThinkingLevel; taskId: string }>
+	>(new Map());
 
 	// Track which targets we've already auto-applied so we don't loop.
 	const appliedAutoConfigRef = useRef<Set<string>>(new Set());
+	// Track the last taskId we've seen so the auto-apply effect can skip the
+	// first render cycle after a task switch (React batches state updates, so
+	// the reset effect's new Maps won't be visible until the next commit).
+	const lastTaskIdRef = useRef<string>(taskId);
 
 	// Reset pre-configuration state when the active task changes so stale
 	// settings from a previous task don't leak into the new one.
@@ -111,6 +116,7 @@ export function useTargetSessionContext({
 		setPreConfiguredModel(new Map());
 		setPreConfiguredThinking(new Map());
 		appliedAutoConfigRef.current = new Set();
+		lastTaskIdRef.current = taskId;
 	}, [taskId]);
 
 	// Default model from workflow definition (keyed by target ID).
@@ -122,15 +128,18 @@ export function useTargetSessionContext({
 	}, [selectedTarget, defaultAgentModels]);
 
 	// Effective model: live when started, pre-configured/default when not.
+	// Ignore preconfig entries that belong to a different task.
 	const preConfigEntry = preConfiguredModel.get(selectedTarget?.id ?? '');
+	const preConfigForCurrentTask =
+		preConfigEntry && preConfigEntry.taskId === taskId ? preConfigEntry : undefined;
 	const effectiveCurrentModel = isStarted
 		? modelSwitcher.currentModel
-		: (preConfigEntry?.id ?? defaultModel);
+		: (preConfigForCurrentTask?.id ?? defaultModel);
 
 	const effectiveCurrentModelInfo = isStarted
 		? modelSwitcher.currentModelInfo
 		: (modelSwitcher.availableModels.find(
-				(m) => m.id === effectiveCurrentModel && m.provider === preConfigEntry?.provider
+				(m) => m.id === effectiveCurrentModel && m.provider === preConfigForCurrentTask?.provider
 			) ??
 			modelSwitcher.availableModels.find((m) => m.id === effectiveCurrentModel) ??
 			null);
@@ -163,11 +172,13 @@ export function useTargetSessionContext({
 		};
 	}, [targetSessionId]);
 
-	// For unstarted targets, sync with pre-configured value.
+	// For unstarted targets, sync with pre-configured value (scoped to current task).
 	useEffect(() => {
 		if (!selectedTarget || isStarted) return;
-		setLocalThinkingLevel(preConfiguredThinking.get(selectedTarget.id) ?? 'auto');
-	}, [selectedTarget?.id, isStarted, preConfiguredThinking]);
+		const entry = preConfiguredThinking.get(selectedTarget.id);
+		const level = entry && entry.taskId === taskId ? entry.level : 'auto';
+		setLocalThinkingLevel(level);
+	}, [selectedTarget?.id, isStarted, preConfiguredThinking, taskId]);
 
 	// Destructure stable primitives from modelSwitcher to avoid effect re-runs
 	// caused by the switcher object identity changing every render.
@@ -180,14 +191,29 @@ export function useTargetSessionContext({
 	// attempted and all attempts succeeded; if preconditions are missing
 	// (e.g. model info not yet loaded or hub disconnected) the target stays
 	// unmarked and the effect retries on the next render cycle.
+	//
+	// Guard: skip the first render after taskId changes because React batches
+	// the reset-effect's state updates; without this guard the effect would
+	// read stale preconfiguration from the previous task.
 	useEffect(() => {
+		if (lastTaskIdRef.current !== taskId) {
+			// taskId just changed but the reset-effect's state update hasn't
+			// committed yet; defer auto-apply until the next render.
+			lastTaskIdRef.current = taskId;
+			return;
+		}
+
 		for (const target of targets) {
 			const targetId = target.id;
 			if (appliedAutoConfigRef.current.has(targetId)) continue;
 
 			const preModel = preConfiguredModel.get(targetId);
 			const preThinking = preConfiguredThinking.get(targetId);
-			if (!preModel && !preThinking) continue;
+			// Ignore entries that belong to a different task.
+			const preModelCurrent = preModel && preModel.taskId === taskId ? preModel : undefined;
+			const preThinkingCurrent =
+				preThinking && preThinking.taskId === taskId ? preThinking : undefined;
+			if (!preModelCurrent && !preThinkingCurrent) continue;
 
 			const sessionId = resolveTargetSessionId(target, activityMembers, taskAgentSessionId);
 			if (!sessionId) continue;
@@ -196,9 +222,9 @@ export function useTargetSessionContext({
 			const promises: Promise<unknown>[] = [];
 
 			// Apply model switch
-			if (preModel) {
+			if (preModelCurrent) {
 				const modelInfo = switcherModels.find(
-					(m) => m.id === preModel.id && m.provider === preModel.provider
+					(m) => m.id === preModelCurrent.id && m.provider === preModelCurrent.provider
 				);
 				if (modelInfo) {
 					attempted = true;
@@ -218,14 +244,14 @@ export function useTargetSessionContext({
 			}
 
 			// Apply thinking level
-			if (preThinking) {
+			if (preThinkingCurrent) {
 				const hub = connectionManager.getHubIfConnected();
 				if (hub) {
 					attempted = true;
 					promises.push(
 						hub.request('session.thinking.set', {
 							sessionId,
-							level: preThinking,
+							level: preThinkingCurrent.level,
 						})
 					);
 				}
@@ -236,8 +262,8 @@ export function useTargetSessionContext({
 			Promise.all(promises)
 				.then(() => {
 					appliedAutoConfigRef.current.add(targetId);
-					if (preThinking && target.id === selectedTarget?.id) {
-						setLocalThinkingLevel(preThinking);
+					if (preThinkingCurrent && target.id === selectedTarget?.id) {
+						setLocalThinkingLevel(preThinkingCurrent.level);
 					}
 				})
 				.catch(() => {
@@ -245,6 +271,7 @@ export function useTargetSessionContext({
 				});
 		}
 	}, [
+		taskId,
 		targets,
 		activityMembers,
 		taskAgentSessionId,
@@ -266,14 +293,18 @@ export function useTargetSessionContext({
 			if (!selectedTarget) return;
 			if (!isStarted) {
 				setPreConfiguredModel((prev) =>
-					new Map(prev).set(selectedTarget.id, { id: model.id, provider: model.provider })
+					new Map(prev).set(selectedTarget.id, {
+						id: model.id,
+						provider: model.provider,
+						taskId,
+					})
 				);
 				toast.success(`Pre-configured ${selectedTarget.label} to use ${model.name}`);
 				return;
 			}
 			await modelSwitcher.switchModel(model);
 		},
-		[isStarted, selectedTarget, modelSwitcher]
+		[isStarted, selectedTarget, modelSwitcher, taskId]
 	);
 
 	const setThinkingLevel = useCallback(
@@ -281,7 +312,9 @@ export function useTargetSessionContext({
 			setLocalThinkingLevel(level);
 			if (!isStarted || !targetSessionId) {
 				if (selectedTarget) {
-					setPreConfiguredThinking((prev) => new Map(prev).set(selectedTarget.id, level));
+					setPreConfiguredThinking((prev) =>
+						new Map(prev).set(selectedTarget.id, { level, taskId })
+					);
 				}
 				return;
 			}
@@ -299,7 +332,7 @@ export function useTargetSessionContext({
 				toast.error(err instanceof Error ? err.message : 'Failed to set thinking level');
 			}
 		},
-		[isStarted, targetSessionId, selectedTarget]
+		[isStarted, targetSessionId, selectedTarget, taskId]
 	);
 
 	return {

--- a/packages/web/src/hooks/useTargetSessionContext.ts
+++ b/packages/web/src/hooks/useTargetSessionContext.ts
@@ -112,6 +112,10 @@ export function useTargetSessionContext({
 	// first render cycle after a task switch (React batches state updates, so
 	// the reset effect's new Maps won't be visible until the next commit).
 	const lastTaskIdRef = useRef<string>(taskId);
+	// Track the latest selectedTarget so async auto-apply continuations can
+	// read the current selection instead of a stale closure value.
+	const selectedTargetRef = useRef(selectedTarget);
+	selectedTargetRef.current = selectedTarget;
 
 	// Reset pre-configuration state when the active task changes so stale
 	// settings from a previous task don't leak into the new one.
@@ -260,7 +264,7 @@ export function useTargetSessionContext({
 							})
 							.then(() => {
 								appliedThinkingRef.current.add(targetId);
-								if (target.id === selectedTarget?.id) {
+								if (target.id === selectedTargetRef.current?.id) {
 									setLocalThinkingLevel(preThinkingCurrent.level);
 								}
 							})

--- a/packages/web/src/hooks/useTargetSessionContext.ts
+++ b/packages/web/src/hooks/useTargetSessionContext.ts
@@ -67,11 +67,13 @@ export function resolveTargetSessionId(
  * for agents that haven't started yet.
  */
 export function useTargetSessionContext({
+	taskId,
 	selectedTarget,
 	activityMembers,
 	taskAgentSessionId,
 	defaultAgentModels,
 }: {
+	taskId: string;
 	selectedTarget: TaskComposerTarget | null;
 	activityMembers: SpaceTaskActivityMember[];
 	taskAgentSessionId: string | null;
@@ -96,6 +98,14 @@ export function useTargetSessionContext({
 
 	// Track which targets we've already auto-applied so we don't loop.
 	const appliedAutoConfigRef = useRef<Set<string>>(new Set());
+
+	// Reset pre-configuration state when the active task changes so stale
+	// settings from a previous task don't leak into the new one.
+	useEffect(() => {
+		setPreConfiguredModel(new Map());
+		setPreConfiguredThinking(new Map());
+		appliedAutoConfigRef.current = new Set();
+	}, [taskId]);
 
 	// Default model from workflow definition (keyed by target ID).
 	const defaultModel = useMemo(() => {

--- a/packages/web/src/hooks/useTargetSessionContext.ts
+++ b/packages/web/src/hooks/useTargetSessionContext.ts
@@ -103,8 +103,11 @@ export function useTargetSessionContext({
 		Map<string, { level: ThinkingLevel; taskId: string }>
 	>(new Map());
 
-	// Track which targets we've already auto-applied so we don't loop.
-	const appliedAutoConfigRef = useRef<Set<string>>(new Set());
+	// Track which targets have had each specific config type successfully
+	// auto-applied, so we don't loop and so a missing model lookup doesn't
+	// permanently suppress retries for the thinking config (or vice versa).
+	const appliedModelRef = useRef<Set<string>>(new Set());
+	const appliedThinkingRef = useRef<Set<string>>(new Set());
 	// Track the last taskId we've seen so the auto-apply effect can skip the
 	// first render cycle after a task switch (React batches state updates, so
 	// the reset effect's new Maps won't be visible until the next commit).
@@ -115,7 +118,8 @@ export function useTargetSessionContext({
 	useEffect(() => {
 		setPreConfiguredModel(new Map());
 		setPreConfiguredThinking(new Map());
-		appliedAutoConfigRef.current = new Set();
+		appliedModelRef.current = new Set();
+		appliedThinkingRef.current = new Set();
 		lastTaskIdRef.current = taskId;
 	}, [taskId]);
 
@@ -187,10 +191,12 @@ export function useTargetSessionContext({
 	// Auto-apply pre-configured settings when any target's session spawns.
 	// Iterates over ALL targets so that background spawns (targets not currently
 	// selected) still receive their pending preconfiguration.
-	// Only marks a target as applied when at least one RPC was actually
-	// attempted and all attempts succeeded; if preconditions are missing
-	// (e.g. model info not yet loaded or hub disconnected) the target stays
-	// unmarked and the effect retries on the next render cycle.
+	//
+	// Each config type (model, thinking) is tracked independently via
+	// appliedModelRef / appliedThinkingRef. If a model lookup misses because
+	// switcherModels hasn't loaded yet, the model config stays unmarked while
+	// the thinking config can still be applied. The missing model will be
+	// retried on the next render cycle once models are available.
 	//
 	// Guard: skip the first render after taskId changes because React batches
 	// the reset-effect's state updates; without this guard the effect would
@@ -205,7 +211,6 @@ export function useTargetSessionContext({
 
 		for (const target of targets) {
 			const targetId = target.id;
-			if (appliedAutoConfigRef.current.has(targetId)) continue;
 
 			const preModel = preConfiguredModel.get(targetId);
 			const preThinking = preConfiguredThinking.get(targetId);
@@ -218,57 +223,54 @@ export function useTargetSessionContext({
 			const sessionId = resolveTargetSessionId(target, activityMembers, taskAgentSessionId);
 			if (!sessionId) continue;
 
-			let attempted = false;
 			const promises: Promise<unknown>[] = [];
 
 			// Apply model switch
-			if (preModelCurrent) {
+			if (preModelCurrent && !appliedModelRef.current.has(targetId)) {
 				const modelInfo = switcherModels.find(
 					(m) => m.id === preModelCurrent.id && m.provider === preModelCurrent.provider
 				);
 				if (modelInfo) {
-					attempted = true;
 					const hub = connectionManager.getHubIfConnected();
 					if (hub) {
 						promises.push(
-							hub.request('session.model.switch', {
-								sessionId,
-								model: modelInfo.id,
-								provider: modelInfo.provider,
-							})
+							hub
+								.request('session.model.switch', {
+									sessionId,
+									model: modelInfo.id,
+									provider: modelInfo.provider,
+								})
+								.then(() => {
+									appliedModelRef.current.add(targetId);
+								})
 						);
-					} else {
-						promises.push(Promise.reject(new Error('Not connected')));
 					}
 				}
 			}
 
 			// Apply thinking level
-			if (preThinkingCurrent) {
+			if (preThinkingCurrent && !appliedThinkingRef.current.has(targetId)) {
 				const hub = connectionManager.getHubIfConnected();
 				if (hub) {
-					attempted = true;
 					promises.push(
-						hub.request('session.thinking.set', {
-							sessionId,
-							level: preThinkingCurrent.level,
-						})
+						hub
+							.request('session.thinking.set', {
+								sessionId,
+								level: preThinkingCurrent.level,
+							})
+							.then(() => {
+								appliedThinkingRef.current.add(targetId);
+								if (target.id === selectedTarget?.id) {
+									setLocalThinkingLevel(preThinkingCurrent.level);
+								}
+							})
 					);
 				}
 			}
 
-			if (!attempted) continue;
+			if (promises.length === 0) continue;
 
-			Promise.all(promises)
-				.then(() => {
-					appliedAutoConfigRef.current.add(targetId);
-					if (preThinkingCurrent && target.id === selectedTarget?.id) {
-						setLocalThinkingLevel(preThinkingCurrent.level);
-					}
-				})
-				.catch(() => {
-					// Leave unmarked so the effect retries on next render
-				});
+			Promise.allSettled(promises);
 		}
 	}, [
 		taskId,

--- a/packages/web/src/hooks/useTargetSessionContext.ts
+++ b/packages/web/src/hooks/useTargetSessionContext.ts
@@ -93,7 +93,11 @@ export function useTargetSessionContext({
 	const modelSwitcher = useModelSwitcher(targetSessionId);
 
 	// In-memory pre-configuration for not-yet-started agents.
-	const [preConfiguredModel, setPreConfiguredModel] = useState<Map<string, string>>(new Map());
+	// Model preconfig stores both id and provider so that auto-apply can
+	// disambiguate when multiple providers expose the same model ID.
+	const [preConfiguredModel, setPreConfiguredModel] = useState<
+		Map<string, { id: string; provider: string }>
+	>(new Map());
 	const [preConfiguredThinking, setPreConfiguredThinking] = useState<Map<string, ThinkingLevel>>(
 		new Map()
 	);
@@ -118,19 +122,50 @@ export function useTargetSessionContext({
 	}, [selectedTarget, defaultAgentModels]);
 
 	// Effective model: live when started, pre-configured/default when not.
+	const preConfigEntry = preConfiguredModel.get(selectedTarget?.id ?? '');
 	const effectiveCurrentModel = isStarted
 		? modelSwitcher.currentModel
-		: (preConfiguredModel.get(selectedTarget?.id ?? '') ?? defaultModel);
+		: (preConfigEntry?.id ?? defaultModel);
 
 	const effectiveCurrentModelInfo = isStarted
 		? modelSwitcher.currentModelInfo
-		: (modelSwitcher.availableModels.find((m) => m.id === effectiveCurrentModel) ?? null);
+		: (modelSwitcher.availableModels.find(
+				(m) => m.id === effectiveCurrentModel && m.provider === preConfigEntry?.provider
+			) ??
+			modelSwitcher.availableModels.find((m) => m.id === effectiveCurrentModel) ??
+			null);
 
-	// Thinking level — default to auto; sync with pre-configured value when switching targets.
+	// Thinking level — default to auto.
 	const [thinkingLevel, setLocalThinkingLevel] = useState<ThinkingLevel>('auto');
 
+	// Load the live thinking level from the session whenever the target
+	// session changes (e.g. switching to a different started agent).
 	useEffect(() => {
-		if (!selectedTarget) return;
+		if (!targetSessionId) return;
+		let cancelled = false;
+		const loadThinkingLevel = async () => {
+			try {
+				const hub = connectionManager.getHubIfConnected();
+				if (!hub) return;
+				const result = (await hub.request('session.thinking.get', {
+					sessionId: targetSessionId,
+				})) as { thinkingLevel: ThinkingLevel };
+				if (!cancelled) {
+					setLocalThinkingLevel(result.thinkingLevel);
+				}
+			} catch {
+				// Ignore errors — keep current thinking level
+			}
+		};
+		loadThinkingLevel();
+		return () => {
+			cancelled = true;
+		};
+	}, [targetSessionId]);
+
+	// For unstarted targets, sync with pre-configured value.
+	useEffect(() => {
+		if (!selectedTarget || isStarted) return;
 		setLocalThinkingLevel(preConfiguredThinking.get(selectedTarget.id) ?? 'auto');
 	}, [selectedTarget?.id, isStarted, preConfiguredThinking]);
 
@@ -162,7 +197,9 @@ export function useTargetSessionContext({
 
 			// Apply model switch
 			if (preModel) {
-				const modelInfo = switcherModels.find((m) => m.id === preModel);
+				const modelInfo = switcherModels.find(
+					(m) => m.id === preModel.id && m.provider === preModel.provider
+				);
 				if (modelInfo) {
 					attempted = true;
 					const hub = connectionManager.getHubIfConnected();
@@ -199,6 +236,9 @@ export function useTargetSessionContext({
 			Promise.all(promises)
 				.then(() => {
 					appliedAutoConfigRef.current.add(targetId);
+					if (preThinking && target.id === selectedTarget?.id) {
+						setLocalThinkingLevel(preThinking);
+					}
 				})
 				.catch(() => {
 					// Leave unmarked so the effect retries on next render
@@ -225,7 +265,9 @@ export function useTargetSessionContext({
 		async (model: ModelInfo) => {
 			if (!selectedTarget) return;
 			if (!isStarted) {
-				setPreConfiguredModel((prev) => new Map(prev).set(selectedTarget.id, model.id));
+				setPreConfiguredModel((prev) =>
+					new Map(prev).set(selectedTarget.id, { id: model.id, provider: model.provider })
+				);
 				toast.success(`Pre-configured ${selectedTarget.label} to use ${model.name}`);
 				return;
 			}

--- a/packages/web/src/hooks/useTargetSessionContext.ts
+++ b/packages/web/src/hooks/useTargetSessionContext.ts
@@ -40,6 +40,14 @@ export interface UseTargetSessionContextResult {
 	setThinkingLevel: (level: ThinkingLevel) => Promise<void>;
 }
 
+/** Normalize an agent/target name for comparison, stripping suffixes and punctuation. */
+function normalizeTargetName(name: string | null | undefined): string {
+	return (name ?? '')
+		.toLowerCase()
+		.replace(/(?:\s+agent)+$/, '')
+		.replace(/[\s_-]+/g, '');
+}
+
 /**
  * Resolve a composer target to its backing session ID.
  */
@@ -57,7 +65,10 @@ export function resolveTargetSessionId(
 		if (target.nodeExecutionId) {
 			return m.nodeExecution?.nodeExecutionId === target.nodeExecutionId;
 		}
-		return m.role === target.agentName || m.nodeExecution?.agentName === target.agentName;
+		return (
+			normalizeTargetName(m.role) === normalizeTargetName(target.agentName) ||
+			normalizeTargetName(m.nodeExecution?.agentName) === normalizeTargetName(target.agentName)
+		);
 	});
 	return member?.sessionId ?? null;
 }


### PR DESCRIPTION
- Adds `useTargetSessionContext` hook that resolves the composer’s selected target to the agent’s live session ID (via `activityMembers`), with in-memory pre-configuration for agents that haven’t started yet.
- Updates `useModelSwitcher` to always load `models.list` even when `session.model.get` fails, so unstarted agents still see the global catalogue.
- Refactors `TaskSessionChatComposer` to use the new hook: model switch, thinking toggle, and the tools modal now operate on the targeted agent’s session instead of the task agent session.
- Shows an amber banner + ring on the target picker when the selected agent hasn’t started yet; workflow-defined default model is used as the initial pre-configuration.
- Adds `TaskToolsModal` (read-only runtime MCP server list) and tests for `useTargetSessionContext`.

All tests pass (6010 tests, 214 files).