### PR TITLE
Add ability to disable workflows

### DIFF
--- a/packages/daemon/src/lib/neo/tools/neo-query-tools.ts
+++ b/packages/daemon/src/lib/neo/tools/neo-query-tools.ts
@@ -624,6 +624,7 @@ export function createNeoQueryToolHandlers(config: NeoToolsConfig) {
 					description: w.description ?? null,
 					nodeCount: w.nodes?.length ?? 0,
 					tags: w.tags ?? [],
+					disabled: w.disabled ?? false,
 					createdAt: w.createdAt,
 					updatedAt: w.updatedAt,
 				}))

--- a/packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts
@@ -251,6 +251,7 @@ export function buildWorkflowCreateParams(
 	if (endNodeId) params.endNodeId = endNodeId;
 	if (exported.description !== undefined) params.description = exported.description;
 	if (exported.channels && exported.channels.length > 0) params.channels = exported.channels;
+	if (exported.disabled !== undefined) params.disabled = exported.disabled;
 
 	return { params, nodeNameToId, warnings };
 }

--- a/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-workflow-run-handlers.ts
@@ -212,7 +212,9 @@ export function setupSpaceWorkflowRunHandlers(
 		// Resolve workflow: explicit workflowId or auto-select first workflow
 		let workflowId = params.workflowId;
 		if (!workflowId) {
-			const workflows = spaceWorkflowManager.listWorkflows(params.spaceId);
+			const workflows = spaceWorkflowManager
+				.listWorkflows(params.spaceId)
+				.filter((w) => !w.disabled);
 			if (workflows.length === 0) {
 				throw new Error(`No workflows found for space: ${params.spaceId}`);
 			}
@@ -222,6 +224,7 @@ export function setupSpaceWorkflowRunHandlers(
 			const workflow = spaceWorkflowManager.getWorkflow(workflowId);
 			if (!workflow) throw new Error(`Workflow not found: ${workflowId}`);
 			if (workflow.spaceId !== params.spaceId) throw new Error(`Workflow not found: ${workflowId}`);
+			if (workflow.disabled) throw new Error(`Workflow is disabled: ${workflowId}`);
 		}
 
 		// Get or create the runtime for this space (validates space, starts runtime if needed)

--- a/packages/daemon/src/lib/space/export-format.ts
+++ b/packages/daemon/src/lib/space/export-format.ts
@@ -153,6 +153,9 @@ const exportedWorkflowBaseSchema = z.object({
 	// the completionAutonomyLevel field. Import code falls back to a sensible
 	// default when the field is absent.
 	completionAutonomyLevel: z.number().int().min(1).max(5).optional(),
+	// Optional for backward compatibility with v1 exports that predate the
+	// disabled field. When absent the workflow is treated as enabled.
+	disabled: z.boolean().optional(),
 });
 
 const exportBundleBaseSchema = z.object({

--- a/packages/daemon/src/lib/space/export-format.ts
+++ b/packages/daemon/src/lib/space/export-format.ts
@@ -293,6 +293,7 @@ export function exportWorkflow(
 	};
 	if (endNode !== undefined) result.endNode = endNode;
 	if (workflow.description !== undefined) result.description = workflow.description;
+	if (workflow.disabled) result.disabled = true;
 	// Export channels — strip `id` (space-specific) and convert to portable ExportedWorkflowChannel format
 	if (workflow.channels && workflow.channels.length > 0) {
 		const exportedChannels: ExportedWorkflowChannel[] = workflow.channels.map((ch) => {

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1187,7 +1187,9 @@ export class SpaceRuntime {
 	 * DB and delegates to the pure `selectWorkflow()` function.
 	 */
 	resolveWorkflowForRun(spaceId: string, workflowId?: string): SpaceWorkflow | null {
-		const availableWorkflows = this.config.spaceWorkflowManager.listWorkflows(spaceId);
+		const availableWorkflows = this.config.spaceWorkflowManager
+			.listWorkflows(spaceId)
+			.filter((w) => !w.disabled);
 		return selectWorkflow({ spaceId, availableWorkflows, workflowId });
 	}
 
@@ -3772,7 +3774,9 @@ export class SpaceRuntime {
 		const spaces = await this.listActiveSpaces();
 
 		for (const space of spaces) {
-			const workflows = this.config.spaceWorkflowManager.listWorkflows(space.id);
+			const workflows = this.config.spaceWorkflowManager
+				.listWorkflows(space.id)
+				.filter((w) => !w.disabled);
 			if (workflows.length === 0) continue;
 
 			const standaloneOpenTasks = this.config.taskRepo
@@ -3858,12 +3862,12 @@ export class SpaceRuntime {
 
 		// Caller-specified preferred workflow wins over both LLM and deterministic
 		// fallback. Fall through if the id doesn't resolve (e.g. workflow was
-		// deleted between task creation and attachment).
+		// deleted between task creation and attachment) or is disabled.
 		if (task.preferredWorkflowId) {
 			const explicit = this.config.spaceWorkflowManager.getWorkflow(task.preferredWorkflowId);
-			if (explicit) return explicit;
+			if (explicit && !explicit.disabled) return explicit;
 			log.warn(
-				`SpaceRuntime: preferred_workflow_id "${task.preferredWorkflowId}" not found for task ${task.id}; selecting a workflow automatically`
+				`SpaceRuntime: preferred_workflow_id "${task.preferredWorkflowId}" not found or disabled for task ${task.id}; selecting a workflow automatically`
 			);
 		}
 

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -1072,6 +1072,9 @@ export class SpaceRuntime {
 		if (!workflow) {
 			throw new Error(`Workflow not found: ${workflowId}`);
 		}
+		if (workflow.disabled) {
+			throw new Error(`Workflow "${workflow.name}" is disabled and cannot be used for new runs.`);
+		}
 		if (!workflow.endNodeId) {
 			throw new Error(`Workflow "${workflowId}" is missing endNodeId and cannot be executed.`);
 		}

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -254,6 +254,12 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 						error: `Workflow not found: ${args.workflow_id}`,
 					});
 				}
+				if (targetWorkflow.disabled) {
+					return jsonResult({
+						success: false,
+						error: `Workflow is disabled: ${args.workflow_id}`,
+					});
+				}
 
 				workflowRunRepo.transitionStatus(run.id, 'cancelled');
 
@@ -317,7 +323,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		 * read it from structured tool logs for observability.
 		 */
 		async suggest_workflow(_args: { description: string }): Promise<ToolResult> {
-			const allWorkflows = workflowManager.listWorkflows(spaceId);
+			const allWorkflows = workflowManager.listWorkflows(spaceId).filter((w) => !w.disabled);
 			if (allWorkflows.length === 0) {
 				return jsonResult({
 					success: true,

--- a/packages/daemon/src/storage/repositories/space-workflow-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-workflow-repository.ts
@@ -56,6 +56,7 @@ interface WorkflowRow {
 	 * refactor; no runtime consumer reads this yet.
 	 */
 	post_approval?: string | null;
+	disabled: number;
 	created_at: number;
 	updated_at: number;
 }
@@ -169,6 +170,9 @@ function rowToWorkflow(row: WorkflowRow, nodes: WorkflowNode[]): SpaceWorkflow {
 	if (postApproval && typeof postApproval === 'object') {
 		wf.postApproval = postApproval;
 	}
+	if (row.disabled) {
+		wf.disabled = true;
+	}
 	return wf;
 }
 
@@ -213,8 +217,8 @@ export class SpaceWorkflowRepository {
 
 		this.db
 			.prepare(
-				`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, end_node_id, tags, channels, gates, layout, template_name, template_hash, instructions, completion_autonomy_level, post_approval, created_at, updated_at)
-	         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+				`INSERT INTO space_workflows (id, space_id, name, description, start_node_id, end_node_id, tags, channels, gates, layout, template_name, template_hash, instructions, completion_autonomy_level, post_approval, disabled, created_at, updated_at)
+	         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			)
 			.run(
 				workflowId,
@@ -232,6 +236,7 @@ export class SpaceWorkflowRepository {
 				params.instructions ?? null,
 				completionAutonomyLevel,
 				postApprovalJson,
+				params.disabled ? 1 : 0,
 				now,
 				now
 			);
@@ -365,6 +370,10 @@ export class SpaceWorkflowRepository {
 		if (params.postApproval !== undefined) {
 			fields.push('post_approval = ?');
 			values.push(params.postApproval ? JSON.stringify(params.postApproval) : null);
+		}
+		if (params.disabled !== undefined && params.disabled !== null) {
+			fields.push('disabled = ?');
+			values.push(params.disabled ? 1 : 0);
 		}
 
 		const hasNodeReplacement = params.nodes !== undefined;

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -71,6 +71,8 @@ export { runMigration110 } from './migrations';
 export { runMigration111 } from './migrations';
 // knip-ignore-next-line
 export { runMigration112 } from './migrations';
+// knip-ignore-next-line
+export { runMigration117 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -551,6 +551,10 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 
 	// Migration 116: Add thinking_level to space_agents for per-agent thinking overrides.
 	runMigration116(db);
+
+	// Migration 117: Add disabled column to space_workflows.
+	//   When true, the workflow cannot be selected for new tasks.
+	runMigration117(db);
 }
 
 /**
@@ -2272,6 +2276,7 @@ function runMigration29(db: BunDatabase): void {
 			description TEXT NOT NULL DEFAULT '',
 			start_step_id TEXT,
 			config TEXT,
+			disabled INTEGER NOT NULL DEFAULT 0,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
@@ -5588,6 +5593,7 @@ export function runMigration74(db: BunDatabase): void {
 					layout TEXT,
 					channels TEXT,
 					gates TEXT,
+					disabled INTEGER NOT NULL DEFAULT 0,
 					created_at INTEGER NOT NULL,
 					updated_at INTEGER NOT NULL,
 					FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
@@ -7946,4 +7952,20 @@ export function runMigration116(db: BunDatabase): void {
 	if (columns.includes('thinking_level')) return;
 
 	db.exec(`ALTER TABLE space_agents ADD COLUMN thinking_level TEXT DEFAULT NULL`);
+}
+
+/**
+ * Migration 117: Add `disabled` column to `space_workflows` table.
+ *
+ * When true (1), the workflow cannot be selected for new tasks.
+ * Existing workflow runs continue unaffected.
+ * Default 0 (enabled) so all existing workflows remain selectable.
+ */
+export function runMigration117(db: BunDatabase): void {
+	if (!tableExists(db, 'space_workflows')) return;
+
+	const columns = tableColumnNames(db, 'space_workflows');
+	if (columns.includes('disabled')) return;
+
+	db.exec(`ALTER TABLE space_workflows ADD COLUMN disabled INTEGER NOT NULL DEFAULT 0`);
 }

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-export-import-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-export-import-handlers.test.ts
@@ -2350,6 +2350,37 @@ describe('full export→import round-trip', () => {
 		expect(step.agents![0].agentId).toBe(importedAgentId);
 	});
 
+	it('disabled workflow export → import round-trip preserves disabled flag', async () => {
+		const agentSrc: SpaceAgent = {
+			id: 'src-dis',
+			spaceId: 'other-space',
+			name: 'Dis Agent',
+			customPrompt: null,
+			createdAt: 1000,
+			updatedAt: 2000,
+		};
+		const wfSrc: SpaceWorkflow = {
+			id: 'src-wf-dis',
+			spaceId: 'other-space',
+			name: 'Disabled Workflow',
+			nodes: [{ id: 'step-d', name: 'Code', agents: [{ agentId: 'src-dis', name: 'coder' }] }],
+			startNodeId: 'step-d',
+			tags: [],
+			disabled: true,
+			createdAt: 1000,
+			updatedAt: 2000,
+		};
+
+		const bundle = exportBundle([agentSrc], [wfSrc], 'Disabled Export');
+		const result = await call<ImportExecuteResult>(handlers, 'spaceImport.execute', {
+			spaceId: SPACE_ID,
+			bundle,
+		});
+
+		const importedWf = workflowRepo.getWorkflow(result.workflows[0].id)!;
+		expect(importedWf.disabled).toBe(true);
+	});
+
 	it('error: import with unknown agentRef in multi-agent step throws and rolls back', async () => {
 		const agentSrc: SpaceAgent = {
 			id: 'src-known',

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-export-import-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-export-import-handlers.test.ts
@@ -87,6 +87,7 @@ function createSchema(db: Database): void {
 			instructions TEXT DEFAULT NULL,
 			completion_autonomy_level INTEGER NOT NULL DEFAULT 3,
 			post_approval TEXT DEFAULT NULL,
+			disabled INTEGER NOT NULL DEFAULT 0,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-workflow-run-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-workflow-run-handlers.test.ts
@@ -455,6 +455,39 @@ describe('space-workflow-run-handlers', () => {
 			);
 		});
 
+		it('throws if provided workflowId is disabled', async () => {
+			const disabledWorkflow = { ...mockWorkflow, disabled: true };
+			setup({ singleWorkflow: disabledWorkflow });
+			await expect(
+				call('spaceWorkflowRun.start', {
+					spaceId: 'space-1',
+					title: 'Test',
+					workflowId: 'workflow-1',
+				})
+			).rejects.toThrow('Workflow is disabled: workflow-1');
+		});
+
+		it('auto-select skips disabled workflows', async () => {
+			const enabledWf = { ...mockWorkflow, id: 'wf-enabled', name: 'Enabled' };
+			const disabledWf = { ...mockWorkflow, id: 'wf-disabled', name: 'Disabled', disabled: true };
+			setup({ workflows: [disabledWf, enabledWf], singleWorkflow: enabledWf });
+			await call('spaceWorkflowRun.start', { spaceId: 'space-1', title: 'Auto' });
+			expect(runtime.startWorkflowRun).toHaveBeenCalledWith(
+				'space-1',
+				'wf-enabled',
+				'Auto',
+				undefined
+			);
+		});
+
+		it('auto-select throws when all workflows are disabled', async () => {
+			const disabledWf = { ...mockWorkflow, disabled: true };
+			setup({ workflows: [disabledWf], singleWorkflow: disabledWf });
+			await expect(
+				call('spaceWorkflowRun.start', { spaceId: 'space-1', title: 'Auto' })
+			).rejects.toThrow('No workflows found for space: space-1');
+		});
+
 		it('does not pass goalId to startWorkflowRun (removed)', async () => {
 			await call('spaceWorkflowRun.start', {
 				spaceId: 'space-1',

--- a/packages/daemon/tests/unit/4-space-storage/storage/space-workflow-repository-disabled.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/space-workflow-repository-disabled.test.ts
@@ -1,0 +1,120 @@
+/**
+ * SpaceWorkflowRepository — `disabled` round-trip tests.
+ *
+ * Covers the acceptance criterion "Workflow CRUD round-trips preserve
+ * `disabled` field (save → load → assert equal)."
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
+import { createSpaceTables } from '../../helpers/space-test-db.ts';
+
+describe('SpaceWorkflowRepository — disabled', () => {
+	let db: Database;
+	let repo: SpaceWorkflowRepository;
+	const spaceId = 'sp-1';
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		const now = Date.now();
+		db.prepare(
+			`INSERT INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?)`
+		).run(spaceId, spaceId, '/ws/x', 'Test Space', now, now);
+		repo = new SpaceWorkflowRepository(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	test('createWorkflow stores disabled=false by default', () => {
+		const wf = repo.createWorkflow({
+			spaceId,
+			name: 'WF default',
+			nodes: [{ name: 'Only', agentId: 'agent-1' }],
+		});
+		expect(wf.disabled).toBeUndefined();
+
+		const fetched = repo.getWorkflow(wf.id);
+		expect(fetched?.disabled).toBeUndefined();
+	});
+
+	test('createWorkflow stores and reads back disabled=true', () => {
+		const wf = repo.createWorkflow({
+			spaceId,
+			name: 'WF disabled',
+			nodes: [{ name: 'Only', agentId: 'agent-1' }],
+			disabled: true,
+		});
+		expect(wf.disabled).toBe(true);
+
+		const fetched = repo.getWorkflow(wf.id);
+		expect(fetched?.disabled).toBe(true);
+	});
+
+	test('updateWorkflow can disable an existing workflow', () => {
+		const wf = repo.createWorkflow({
+			spaceId,
+			name: 'WF',
+			nodes: [{ name: 'Only', agentId: 'agent-1' }],
+		});
+		expect(wf.disabled).toBeUndefined();
+
+		const updated = repo.updateWorkflow(wf.id, { disabled: true });
+		expect(updated?.disabled).toBe(true);
+
+		const fetched = repo.getWorkflow(wf.id);
+		expect(fetched?.disabled).toBe(true);
+	});
+
+	test('updateWorkflow can re-enable a disabled workflow', () => {
+		const wf = repo.createWorkflow({
+			spaceId,
+			name: 'WF',
+			nodes: [{ name: 'Only', agentId: 'agent-1' }],
+			disabled: true,
+		});
+		expect(wf.disabled).toBe(true);
+
+		const updated = repo.updateWorkflow(wf.id, { disabled: false });
+		expect(updated?.disabled).toBeUndefined();
+
+		const fetched = repo.getWorkflow(wf.id);
+		expect(fetched?.disabled).toBeUndefined();
+	});
+
+	test('updateWorkflow with disabled: null leaves the existing value alone', () => {
+		const wf = repo.createWorkflow({
+			spaceId,
+			name: 'WF',
+			nodes: [{ name: 'Only', agentId: 'agent-1' }],
+			disabled: true,
+		});
+
+		const updated = repo.updateWorkflow(wf.id, { name: 'Renamed' });
+		expect(updated?.name).toBe('Renamed');
+		expect(updated?.disabled).toBe(true);
+	});
+
+	test('listWorkflows surfaces disabled on every row where it is set', () => {
+		repo.createWorkflow({
+			spaceId,
+			name: 'A',
+			nodes: [{ name: 'Only', agentId: 'agent-1' }],
+			disabled: true,
+		});
+		repo.createWorkflow({
+			spaceId,
+			name: 'B',
+			nodes: [{ name: 'Only', agentId: 'agent-1' }],
+		});
+
+		const all = repo.listWorkflows(spaceId);
+		const byName = Object.fromEntries(all.map((w) => [w.name, w.disabled]));
+		expect(byName.A).toBe(true);
+		expect(byName.B).toBeUndefined();
+	});
+});

--- a/packages/daemon/tests/unit/5-space/other/export-format.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/export-format.test.ts
@@ -2072,3 +2072,27 @@ describe('exportWorkflow — endNode', () => {
 		expect(result.ok).toBe(true);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// exportWorkflow — disabled
+// ---------------------------------------------------------------------------
+
+describe('exportWorkflow — disabled', () => {
+	test('exports disabled when true', () => {
+		const workflow = makeWorkflow({ disabled: true });
+		const exported = exportWorkflow(workflow, []);
+		expect(exported.disabled).toBe(true);
+	});
+
+	test('omits disabled when false', () => {
+		const workflow = makeWorkflow({ disabled: false });
+		const exported = exportWorkflow(workflow, []);
+		expect(exported.disabled).toBeUndefined();
+	});
+
+	test('omits disabled when undefined', () => {
+		const workflow = makeWorkflow();
+		const exported = exportWorkflow(workflow, []);
+		expect(exported.disabled).toBeUndefined();
+	});
+});

--- a/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-agent-tools.test.ts
@@ -82,10 +82,11 @@ function buildSingleStepWorkflow(
 	agentId: string,
 	name: string,
 	tags: string[] = [],
-	description = ''
+	description = '',
+	disabled = false
 ): SpaceWorkflow {
 	const stepId = `step-${Math.random().toString(36).slice(2)}`;
-	return workflowManager.createWorkflow({
+	const wf = workflowManager.createWorkflow({
 		spaceId,
 		name,
 		description,
@@ -95,7 +96,9 @@ function buildSingleStepWorkflow(
 		rules: [],
 		tags,
 		completionAutonomyLevel: 3,
+		disabled,
 	});
+	return wf;
 }
 
 // ---------------------------------------------------------------------------
@@ -432,6 +435,37 @@ describe('createSpaceAgentToolHandlers — change_plan', () => {
 
 		const parsed = JSON.parse(result.content[0].text);
 		expect(parsed.success).toBe(false);
+
+		// Original run must still be in_progress — not cancelled
+		const originalRun = ctx.workflowRunRepo.getRun(runId);
+		expect(originalRun?.status).toBe('in_progress');
+	});
+
+	test('returns error when target workflow is disabled', async () => {
+		const wf = buildSingleStepWorkflow(ctx.spaceId, ctx.workflowManager, ctx.agentId, 'WF to keep');
+		const disabledWf = buildSingleStepWorkflow(
+			ctx.spaceId,
+			ctx.workflowManager,
+			ctx.agentId,
+			'Disabled WF',
+			[],
+			'',
+			true
+		);
+		const startResult = await startWorkflowRun(ctx, {
+			workflow_id: wf.id,
+			title: 'run to keep',
+		});
+		const runId = JSON.parse(startResult.content[0].text).run.id;
+
+		const result = await makeHandlers(ctx).change_plan({
+			run_id: runId,
+			workflow_id: disabledWf.id,
+		});
+
+		const parsed = JSON.parse(result.content[0].text);
+		expect(parsed.success).toBe(false);
+		expect(parsed.error).toContain('disabled');
 
 		// Original run must still be in_progress — not cancelled
 		const originalRun = ctx.workflowRunRepo.getRun(runId);

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-disabled-workflow.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-disabled-workflow.test.ts
@@ -158,6 +158,15 @@ describe('SpaceRuntime — disabled workflow filtering', () => {
 		expect(run!.workflowId).toBe(enabledWf.id);
 	});
 
+	test('startWorkflowRun rejects disabled workflows', async () => {
+		const disabledWf = createWorkflow('Disabled', ['default'], true);
+		const runtime = buildRuntime();
+
+		await expect(runtime.startWorkflowRun(SPACE_ID, disabledWf.id, 'Test Run')).rejects.toThrow(
+			'disabled'
+		);
+	});
+
 	test('preferredWorkflowId pointing to disabled workflow falls through to auto-selection', async () => {
 		const enabledWf = createWorkflow('Enabled', ['default']);
 		const disabledWf = createWorkflow('Disabled', ['coding'], true);

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-disabled-workflow.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-disabled-workflow.test.ts
@@ -1,0 +1,183 @@
+/**
+ * SpaceRuntime — disabled workflow filtering
+ *
+ * Covers:
+ * - Disabled workflows are excluded from `resolveWorkflowForRun`
+ * - Disabled workflows are excluded from `attachStandaloneTasksToWorkflows`
+ * - Explicit `preferredWorkflowId` pointing to a disabled workflow falls through
+ *   to automatic selection
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { runMigrations } from '../../../../src/storage/schema/index.ts';
+import { SpaceWorkflowRepository } from '../../../../src/storage/repositories/space-workflow-repository.ts';
+import { SpaceWorkflowRunRepository } from '../../../../src/storage/repositories/space-workflow-run-repository.ts';
+import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository.ts';
+import { SpaceAgentRepository } from '../../../../src/storage/repositories/space-agent-repository.ts';
+import { NodeExecutionRepository } from '../../../../src/storage/repositories/node-execution-repository.ts';
+import { SpaceAgentManager } from '../../../../src/lib/space/managers/space-agent-manager.ts';
+import { SpaceWorkflowManager } from '../../../../src/lib/space/managers/space-workflow-manager.ts';
+import { SpaceManager } from '../../../../src/lib/space/managers/space-manager.ts';
+import { SpaceRuntime } from '../../../../src/lib/space/runtime/space-runtime.ts';
+import type { SpaceRuntimeConfig } from '../../../../src/lib/space/runtime/space-runtime.ts';
+import type { SelectWorkflowWithLlm } from '../../../../src/lib/space/runtime/llm-workflow-selector.ts';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeDb(): BunDatabase {
+	const db = new BunDatabase(':memory:');
+	db.exec('PRAGMA foreign_keys = ON');
+	runMigrations(db, () => {});
+	return db;
+}
+
+function seedSpaceRow(db: BunDatabase, spaceId: string): void {
+	db.prepare(
+		`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+         allowed_models, session_ids, slug, status, created_at, updated_at)
+         VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+	).run(spaceId, '/tmp/disabled-wf-ws', `Space ${spaceId}`, spaceId, Date.now(), Date.now());
+}
+
+function seedAgentRow(db: BunDatabase, agentId: string, spaceId: string, name: string): void {
+	db.prepare(
+		`INSERT INTO space_agents (id, space_id, name, description, model, tools, system_prompt, created_at, updated_at)
+         VALUES (?, ?, ?, '', null, '[]', '', ?, ?)`
+	).run(agentId, spaceId, name, Date.now(), Date.now());
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('SpaceRuntime — disabled workflow filtering', () => {
+	const SPACE_ID = 'space-disabled-wf';
+	const AGENT_ID = 'agent-disabled-wf';
+
+	let db: BunDatabase;
+	let workflowRunRepo: SpaceWorkflowRunRepository;
+	let taskRepo: SpaceTaskRepository;
+	let nodeExecutionRepo: NodeExecutionRepository;
+	let agentManager: SpaceAgentManager;
+	let workflowManager: SpaceWorkflowManager;
+	let spaceManager: SpaceManager;
+
+	beforeEach(() => {
+		db = makeDb();
+		seedSpaceRow(db, SPACE_ID);
+		seedAgentRow(db, AGENT_ID, SPACE_ID, 'Worker');
+
+		workflowRunRepo = new SpaceWorkflowRunRepository(db);
+		taskRepo = new SpaceTaskRepository(db);
+		nodeExecutionRepo = new NodeExecutionRepository(db);
+		agentManager = new SpaceAgentManager(new SpaceAgentRepository(db));
+		workflowManager = new SpaceWorkflowManager(new SpaceWorkflowRepository(db));
+		spaceManager = new SpaceManager(db);
+	});
+
+	afterEach(() => {
+		try {
+			db.close();
+		} catch {
+			/* ignore */
+		}
+	});
+
+	function buildRuntime(selector?: SelectWorkflowWithLlm): SpaceRuntime {
+		const config: SpaceRuntimeConfig = {
+			db,
+			spaceManager,
+			spaceAgentManager: agentManager,
+			spaceWorkflowManager: workflowManager,
+			workflowRunRepo,
+			taskRepo,
+			nodeExecutionRepo,
+			selectWorkflowWithLlm: selector,
+		};
+		return new SpaceRuntime(config);
+	}
+
+	function createWorkflow(name: string, tags: string[] = [], disabled = false) {
+		const stepId = `step-${Math.random().toString(36).slice(2)}`;
+		return workflowManager.createWorkflow({
+			spaceId: SPACE_ID,
+			name,
+			description: `${name} description`,
+			nodes: [{ id: stepId, name: 'Step', agentId: AGENT_ID }],
+			startNodeId: stepId,
+			tags,
+			completionAutonomyLevel: 3,
+			disabled,
+		});
+	}
+
+	test('resolveWorkflowForRun excludes disabled workflows from selection', () => {
+		const enabledWf = createWorkflow('Enabled', ['default']);
+		const disabledWf = createWorkflow('Disabled', ['default'], true);
+
+		const runtime = buildRuntime();
+
+		// Explicit ID for enabled workflow resolves correctly
+		expect(runtime.resolveWorkflowForRun(SPACE_ID, enabledWf.id)!.id).toBe(enabledWf.id);
+
+		// Explicit ID for disabled workflow returns null (filtered out)
+		expect(runtime.resolveWorkflowForRun(SPACE_ID, disabledWf.id)).toBeNull();
+	});
+
+	test('resolveWorkflowForRun returns null when all workflows are disabled', () => {
+		createWorkflow('Disabled A', [], true);
+		createWorkflow('Disabled B', [], true);
+
+		const runtime = buildRuntime();
+		const resolved = runtime.resolveWorkflowForRun(SPACE_ID);
+
+		expect(resolved).toBeNull();
+	});
+
+	test('attachStandaloneTasksToWorkflows skips disabled workflows', async () => {
+		const enabledWf = createWorkflow('Enabled', ['default']);
+		createWorkflow('Disabled', ['default'], true);
+
+		const runtime = buildRuntime();
+
+		const task = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Do work',
+			description: '',
+			status: 'open',
+		});
+
+		await runtime.executeTick();
+
+		const updated = taskRepo.getTask(task.id)!;
+		expect(updated.workflowRunId).not.toBeNull();
+		const run = workflowRunRepo.getRun(updated.workflowRunId!);
+		expect(run!.workflowId).toBe(enabledWf.id);
+	});
+
+	test('preferredWorkflowId pointing to disabled workflow falls through to auto-selection', async () => {
+		const enabledWf = createWorkflow('Enabled', ['default']);
+		const disabledWf = createWorkflow('Disabled', ['coding'], true);
+
+		const runtime = buildRuntime();
+
+		const task = taskRepo.createTask({
+			spaceId: SPACE_ID,
+			title: 'Do work',
+			description: '',
+			status: 'open',
+			preferredWorkflowId: disabledWf.id,
+		});
+
+		await runtime.executeTick();
+
+		const updated = taskRepo.getTask(task.id)!;
+		expect(updated.workflowRunId).not.toBeNull();
+		const run = workflowRunRepo.getRun(updated.workflowRunId!);
+		// Should have fallen through to the enabled default-tagged workflow
+		expect(run!.workflowId).toBe(enabledWf.id);
+	});
+});

--- a/packages/daemon/tests/unit/helpers/space-agent-schema.ts
+++ b/packages/daemon/tests/unit/helpers/space-agent-schema.ts
@@ -72,6 +72,7 @@ export function createSpaceAgentSchema(db: Database): void {
 			instructions TEXT DEFAULT NULL,
 			completion_autonomy_level INTEGER NOT NULL DEFAULT 3,
 			post_approval TEXT DEFAULT NULL,
+			disabled INTEGER NOT NULL DEFAULT 0,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -79,6 +79,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			instructions TEXT DEFAULT NULL,
 			completion_autonomy_level INTEGER NOT NULL DEFAULT 3,
 			post_approval TEXT DEFAULT NULL,
+			disabled INTEGER NOT NULL DEFAULT 0,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -1359,6 +1359,11 @@ export interface SpaceWorkflow {
 	 * See {@link PostApprovalRoute}.
 	 */
 	postApproval?: PostApprovalRoute;
+	/**
+	 * When true, the workflow is disabled and cannot be selected for new tasks.
+	 * Existing workflow runs continue unaffected.
+	 */
+	disabled?: boolean;
 }
 
 /**
@@ -1414,6 +1419,8 @@ export interface CreateSpaceWorkflowParams {
 	 * Optional post-approval route. See {@link PostApprovalRoute}.
 	 */
 	postApproval?: PostApprovalRoute;
+	/** When true, create the workflow as disabled. */
+	disabled?: boolean;
 }
 
 /**
@@ -1469,6 +1476,8 @@ export interface UpdateSpaceWorkflowParams {
 	 * Update the workflow's post-approval route. Pass `null` to clear.
 	 */
 	postApproval?: PostApprovalRoute | null;
+	/** Pass true/false to enable or disable the workflow. Pass null to leave unchanged. */
+	disabled?: boolean | null;
 }
 
 /**
@@ -1673,6 +1682,8 @@ export interface ExportedSpaceWorkflow {
 	 * review. Optional for backward compat with pre-Design-v2 exports.
 	 */
 	completionAutonomyLevel?: SpaceAutonomyLevel;
+	/** When true, the workflow is disabled and cannot be selected for new tasks. */
+	disabled?: boolean;
 }
 
 /**

--- a/packages/web/src/components/space/WorkflowList.tsx
+++ b/packages/web/src/components/space/WorkflowList.tsx
@@ -242,7 +242,12 @@ function WorkflowCard({
 	}
 
 	return (
-		<div class="bg-dark-850 border border-dark-700 rounded-lg p-4 hover:border-dark-600 transition-colors group">
+		<div
+			class={[
+				'bg-dark-850 border rounded-lg p-4 hover:border-dark-600 transition-colors group',
+				workflow.disabled ? 'border-dark-800 opacity-60' : 'border-dark-700',
+			].join(' ')}
+		>
 			{deleteError && (
 				<div class="mb-2 px-3 py-1.5 bg-red-900/20 border border-red-800/40 rounded text-xs text-red-300">
 					{deleteError}
@@ -251,7 +256,14 @@ function WorkflowCard({
 
 			<div class="flex items-start justify-between gap-3">
 				<div class="flex-1 min-w-0">
-					<h3 class="text-sm font-medium text-gray-200 truncate">{workflow.name}</h3>
+					<div class="flex items-center gap-2">
+						<h3 class="text-sm font-medium text-gray-200 truncate">{workflow.name}</h3>
+						{workflow.disabled && (
+							<span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-red-900/20 border border-red-800/40 rounded text-red-400 shrink-0">
+								Disabled
+							</span>
+						)}
+					</div>
 					{workflow.description && (
 						<p class="text-xs text-gray-500 mt-0.5 line-clamp-2">{workflow.description}</p>
 					)}

--- a/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
+++ b/packages/web/src/components/space/visual-editor/VisualWorkflowEditor.tsx
@@ -255,6 +255,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 	const [postApproval, setPostApproval] = useState<PostApprovalRoute | undefined>(() =>
 		initState?.postApproval ? { ...initState.postApproval } : undefined
 	);
+	const [disabled, setDisabled] = useState<boolean>(() => initState?.disabled ?? false);
 	const [viewportState, setViewportState] = useState<ViewportState>({
 		offsetX: 0,
 		offsetY: 0,
@@ -1144,6 +1145,7 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 			gates,
 			completionAutonomyLevel,
 			postApproval,
+			disabled,
 		};
 
 		setSaving(true);
@@ -1225,6 +1227,16 @@ export function VisualWorkflowEditor({ workflow, onSave, onCancel }: VisualWorkf
 					/>
 				</div>
 
+				<label class="flex items-center gap-1.5 text-xs text-gray-400 cursor-pointer select-none">
+					<input
+						type="checkbox"
+						checked={disabled}
+						data-testid="workflow-disabled-checkbox"
+						onChange={(e) => setDisabled((e.currentTarget as HTMLInputElement).checked)}
+						class="w-3 h-3 rounded accent-blue-500"
+					/>
+					<span class={disabled ? 'text-red-400 font-medium' : ''}>Disabled</span>
+				</label>
 				<button
 					onClick={onCancel}
 					class="px-3 py-1.5 text-xs text-gray-400 hover:text-gray-200 transition-colors"

--- a/packages/web/src/components/space/visual-editor/serialization.ts
+++ b/packages/web/src/components/space/visual-editor/serialization.ts
@@ -98,6 +98,8 @@ export interface VisualEditorState {
 	completionAutonomyLevel?: SpaceAutonomyLevel;
 	/** Optional post-approval route configured on the workflow. */
 	postApproval?: PostApprovalRoute;
+	/** When true, the workflow is disabled and cannot be selected for new tasks. */
+	disabled?: boolean;
 }
 
 // ============================================================================
@@ -182,6 +184,7 @@ export function workflowToVisualState(workflow: SpaceWorkflow): VisualEditorStat
 		gates: workflow.gates ?? [],
 		completionAutonomyLevel: workflow.completionAutonomyLevel ?? (3 as SpaceAutonomyLevel),
 		postApproval: workflow.postApproval ? { ...workflow.postApproval } : undefined,
+		disabled: workflow.disabled,
 	};
 }
 
@@ -382,6 +385,7 @@ export function visualStateToCreateParams(
 		gates: fields.gates && fields.gates.length > 0 ? fields.gates : undefined,
 		completionAutonomyLevel: state.completionAutonomyLevel,
 		postApproval: state.postApproval,
+		disabled: state.disabled,
 	};
 }
 
@@ -408,5 +412,6 @@ export function visualStateToUpdateParams(
 		gates: fields.gates && fields.gates.length > 0 ? fields.gates : null,
 		completionAutonomyLevel: state.completionAutonomyLevel,
 		postApproval: state.postApproval ?? null,
+		disabled: state.disabled ?? null,
 	};
 }


### PR DESCRIPTION
Adds a `disabled` boolean field to workflows so they can be temporarily deactivated without deleting them.

**Backend:**
- Adds `disabled` to `SpaceWorkflow`, `CreateSpaceWorkflowParams`, `UpdateSpaceWorkflowParams`, and `ExportedSpaceWorkflow`
- DB migration 117 adds `disabled INTEGER NOT NULL DEFAULT 0` to `space_workflows`
- Repository round-trips the field on create/update/read
- Runtime filters disabled workflows from `resolveWorkflowForRun`, `attachStandaloneTasksToWorkflows`, and rejects disabled workflows when `preferredWorkflowId` is set
- Export/import preserves the `disabled` flag

**Frontend:**
- Visual workflow editor has a "Disabled" checkbox in the header
- Workflow list shows a red "Disabled" badge and dims the card for disabled workflows
- Serialization threads `disabled` through `VisualEditorState`

**Tests:**
- Repository round-trip tests for the disabled field
- Runtime filtering tests for disabled workflows
- Export format tests for the disabled flag
- All 9962 daemon unit tests pass