### PR TITLE
Materialize task-thread and active-turn projections (#1752)

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -161,7 +161,9 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	});
 
 	// Initialize Space agent manager
-	const spaceAgentManager = new SpaceAgentManager(new SpaceAgentRepository(db.getDatabase()));
+	const spaceAgentManager = new SpaceAgentManager(
+		new SpaceAgentRepository(db.getDatabase(), reactiveDb)
+	);
 
 	// Initialize Space manager
 	const spaceManager = new SpaceManager(db.getDatabase());

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -458,7 +458,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	// after gate data is written externally (e.g. approveGate RPC, writeGateData RPC).
 	// sessionManager and daemonHub are injected so space:chat:${spaceId} sessions are
 	// provisioned with MCP tools and system prompts on startup and on space.created.
-	const nodeExecutionRepo = new NodeExecutionRepository(deps.db.getDatabase());
+	const nodeExecutionRepo = new NodeExecutionRepository(deps.db.getDatabase(), deps.reactiveDb);
 	const spaceRuntimeService = new SpaceRuntimeService({
 		db: deps.db.getDatabase(),
 		dbPath: deps.db.getDatabasePath(),

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -365,7 +365,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 
 	// Space workflow manager — created early so space.create can call seedBuiltInWorkflows
 	const spaceWorkflowRepo = new SpaceWorkflowRepository(deps.db.getDatabase());
-	const spaceAgentRepo = new SpaceAgentRepository(deps.db.getDatabase());
+	const spaceAgentRepo = new SpaceAgentRepository(deps.db.getDatabase(), deps.reactiveDb);
 	const agentLookup: SpaceAgentLookup = {
 		getAgentById(spaceId: string, id: string) {
 			const agent = spaceAgentRepo.getById(id);

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -712,7 +712,6 @@ const SPACE_TASK_MESSAGES_BASE_CTE = `
 WITH joined AS (
   SELECT
     source_id          AS id,
-    proj_id            AS projId,
     session_id         AS sessionId,
     kind,
     role,
@@ -755,7 +754,7 @@ SELECT
   iteration,
   parentToolUseId
 FROM joined
-ORDER BY createdAt ASC, projId ASC
+ORDER BY createdAt ASC, id ASC
 `.trim();
 
 /** Maximum non-terminal rows to keep per (session, turn) in compact mode. */
@@ -791,7 +790,7 @@ session_turns AS (
     COALESCE(
       SUM(CASE WHEN j.messageType = 'result' THEN 1 ELSE 0 END) OVER (
         PARTITION BY j.sessionId
-        ORDER BY j.createdAt ASC, j.projId ASC
+        ORDER BY j.createdAt ASC, j.id ASC
         ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
       ),
       0
@@ -804,14 +803,14 @@ ranked AS (
     CASE
       WHEN st.isTerminal = 0 AND st.isRenderable = 1 THEN ROW_NUMBER() OVER (
         PARTITION BY st.sessionId, st.turnIndex, st.isTerminal, st.isRenderable
-        ORDER BY st.createdAt DESC, st.projId DESC
+        ORDER BY st.createdAt DESC, st.id DESC
       )
       ELSE NULL
     END AS nonTerminalRankDesc,
     CASE
       WHEN st.isTerminal = 0 AND st.isRenderable = 1 AND st.messageType = 'user' THEN ROW_NUMBER() OVER (
         PARTITION BY st.sessionId, st.turnIndex, st.isTerminal, st.isRenderable, st.messageType
-        ORDER BY st.createdAt ASC, st.projId ASC
+        ORDER BY st.createdAt ASC, st.id ASC
       )
       ELSE NULL
     END AS userRowRankAsc
@@ -891,7 +890,7 @@ SELECT
   iteration,
   parentToolUseId
 FROM selected
-ORDER BY createdAt ASC, projId ASC
+ORDER BY createdAt ASC, id ASC
 `.trim();
 
 /**
@@ -933,7 +932,6 @@ ${SPACE_TASK_MESSAGES_BASE_CTE},
 session_turns AS (
   SELECT
     j.id,
-    j.projId,
     j.sessionId,
     j.kind,
     j.role,
@@ -948,7 +946,7 @@ session_turns AS (
     COALESCE(
       SUM(CASE WHEN j.messageType = 'result' THEN 1 ELSE 0 END) OVER (
         PARTITION BY j.sessionId
-        ORDER BY j.createdAt ASC, j.projId ASC
+        ORDER BY j.createdAt ASC, j.id ASC
         ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
       ),
       0
@@ -988,7 +986,6 @@ assistant_entries AS (
     ar.turnIndex AS turnIndex,
     ar.createdAt AS ts,
     ar.id AS rowId,
-    ar.projId AS projId,
     CAST(je.key AS INTEGER) AS blockIdx,
     json_extract(ar.content, '$.uuid') AS uuid,
     json_extract(je.value, '$.type') AS blockType,
@@ -1019,7 +1016,6 @@ user_entries AS (
     ar.turnIndex AS turnIndex,
     ar.createdAt AS ts,
     ar.id AS rowId,
-    ar.projId AS projId,
     -1 AS blockIdx,
     json_extract(ar.content, '$.uuid') AS uuid,
     CASE
@@ -1075,7 +1071,6 @@ SELECT
   turnIndex,
   ts,
   rowId,
-  projId,
   blockIdx,
   uuid,
   blockType,
@@ -1090,7 +1085,6 @@ SELECT
   turnIndex,
   ts,
   rowId,
-  projId,
   blockIdx,
   uuid,
   blockType,
@@ -1099,7 +1093,7 @@ SELECT
   textValue,
   thinkingValue
 FROM user_entries
-ORDER BY sessionId ASC, ts ASC, projId ASC, blockIdx ASC
+ORDER BY sessionId ASC, ts ASC, rowId ASC, blockIdx ASC
 `.trim();
 
 // ============================================================================

--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -698,104 +698,38 @@ ORDER BY
 /**
  * Shared CTE block for `spaceTaskMessages.byTask*` queries.
  *
- * Produces a `joined` row set — one row per (session, sdk_message) pair — that
- * the variant queries then either emit as-is (full) or slice with window
- * functions (compact).
+ * Reads from the `task_thread_messages` projection (materialised by
+ * triggers in migration 118) and aliases the snake_case columns to the
+ * camelCase shape the row mappers expect. Because all join + JSON work
+ * happens at write time inside the projection, every variant below
+ * resolves to a single indexed scan plus optional window-function
+ * computation — no per-read joins to `sessions` / `node_executions` /
+ * `space_tasks`, no JSON re-extraction for derived flags.
  *
- * The final variant must append its own `SELECT ... FROM ranked|joined ORDER BY`.
+ * The final variant must append its own `SELECT ... FROM joined ORDER BY`.
  */
 const SPACE_TASK_MESSAGES_BASE_CTE = `
-WITH target_task AS (
-  SELECT *
-  FROM space_tasks
-  WHERE id = ?
-),
--- Leg 1: orchestration task (the Task Agent's own task)
-orchestration AS (
+WITH joined AS (
   SELECT
-    tt.task_agent_session_id AS session_id,
-    'task_agent' AS kind,
-    'task-agent' AS role,
-    'Task Agent' AS label,
-    NULL AS node_execution_id,
-    tt.id AS task_id,
-    tt.title AS task_title
-  FROM target_task tt
-  JOIN sessions s ON s.id = tt.task_agent_session_id
-  WHERE tt.task_agent_session_id IS NOT NULL
-    AND s.type = 'space_task_agent'
-),
--- Leg 2: node agents via node_executions
-node_agents AS (
-  SELECT
-    ne.agent_session_id AS session_id,
-    'node_agent' AS kind,
-    ne.agent_name AS role,
-    COALESCE(sa.name, ne.agent_name, 'agent') AS label,
-    ne.id AS node_execution_id,
-    tt.id AS task_id,
-    tt.title AS task_title
-  FROM node_executions ne
-  JOIN target_task tt
-    ON tt.workflow_run_id IS NOT NULL
-   AND ne.workflow_run_id = tt.workflow_run_id
-  LEFT JOIN space_agents sa ON sa.id = ne.agent_id
-  WHERE ne.agent_session_id IS NOT NULL
-),
--- Union both legs
-all_sessions AS (
-  SELECT * FROM orchestration
-  UNION ALL
-  SELECT * FROM node_agents
-),
-github_events AS (
-  SELECT
-    ge.id AS id,
-    NULL AS sessionId,
-    'github' AS kind,
-    'github' AS role,
-    'GitHub' AS label,
-    NULL AS nodeExecutionId,
-    tt.id AS taskId,
-    tt.title AS taskTitle,
-    'github_pr_activity' AS messageType,
-    json_object(
-      'type', 'user',
-      'uuid', ge.id,
-      'message', json_object(
-        'role', 'user',
-        'content', json_array(json_object('type', 'text', 'text', '[GitHub] ' || ge.summary || char(10) || ge.external_url))
-      )
-    ) AS content,
-    'system' AS origin,
-    ge.occurred_at AS createdAt,
-    0 AS iteration,
-    NULL AS parentToolUseId
-  FROM target_task tt
-  JOIN space_github_events ge ON ge.task_id = tt.id
-  WHERE ge.state IN ('routed', 'delivered')
-),
-joined AS (
-  SELECT * FROM github_events
-  UNION ALL
-  SELECT
-    sm.id AS id,
-    sm.session_id AS sessionId,
-    ase.kind AS kind,
-    ase.role AS role,
-    ase.label AS label,
-    ase.node_execution_id AS nodeExecutionId,
-    ase.task_id AS taskId,
-    ase.task_title AS taskTitle,
-    sm.message_type AS messageType,
-    sm.sdk_message AS content,
-    sm.origin AS origin,
-    CAST((julianday(sm.timestamp) - 2440587.5) * 86400000 AS INTEGER) AS createdAt,
-    CAST(COALESCE(json_extract(sm.sdk_message, '$._taskMeta.iteration'), 0) AS INTEGER) AS iteration,
-    json_extract(sm.sdk_message, '$.parent_tool_use_id') AS parentToolUseId
-  FROM all_sessions ase
-  JOIN sdk_messages sm ON sm.session_id = ase.session_id
-  WHERE (sm.message_type != 'user' OR COALESCE(sm.send_status, 'consumed') IN ('consumed', 'failed'))
+    source_id          AS id,
+    proj_id            AS projId,
+    session_id         AS sessionId,
+    kind,
+    role,
+    label,
+    node_execution_id  AS nodeExecutionId,
+    task_id            AS taskId,
+    task_title         AS taskTitle,
+    message_type       AS messageType,
+    content,
+    origin,
+    created_at         AS createdAt,
+    iteration,
+    parent_tool_use_id AS parentToolUseId,
+    is_terminal        AS isTerminal,
+    is_renderable      AS isRenderable
+  FROM task_thread_messages
+  WHERE task_id = ?
 )
 `.trim();
 
@@ -821,7 +755,7 @@ SELECT
   iteration,
   parentToolUseId
 FROM joined
-ORDER BY createdAt ASC, id ASC
+ORDER BY createdAt ASC, projId ASC
 `.trim();
 
 /** Maximum non-terminal rows to keep per (session, turn) in compact mode. */
@@ -854,48 +788,10 @@ ${SPACE_TASK_MESSAGES_BASE_CTE},
 session_turns AS (
   SELECT
     j.*,
-    CASE
-      WHEN j.messageType = 'result' THEN 1
-      ELSE 0
-    END AS isTerminal,
-    CASE
-      -- Drop user rows whose content is exclusively tool_result blocks — they
-      -- render as null in the compact UI and would otherwise consume slots
-      -- in the per-turn cap without contributing visible content.
-      WHEN j.messageType = 'user'
-        AND json_type(j.content, '$.message.content') = 'array'
-        AND EXISTS (
-        SELECT 1
-        FROM json_each(json_extract(j.content, '$.message.content')) AS je
-        WHERE json_extract(je.value, '$.type') = 'tool_result'
-      ) THEN 0
-      -- Drop assistant rows that have *no* renderable content — i.e. the
-      -- content array exists but every block is either an empty/whitespace
-      -- text block or has no non-empty thinking/tool_use sibling. These
-      -- show up rarely in practice but bloat the per-turn cap when they
-      -- do; the active-turn summary applies the same filter so server and
-      -- client agree on what counts as visible activity.
-      WHEN j.messageType = 'assistant'
-        AND json_type(j.content, '$.message.content') = 'array'
-        AND NOT EXISTS (
-          SELECT 1
-          FROM json_each(json_extract(j.content, '$.message.content')) AS je
-          WHERE json_extract(je.value, '$.type') = 'tool_use'
-             OR (
-                json_extract(je.value, '$.type') = 'text'
-                AND TRIM(COALESCE(json_extract(je.value, '$.text'), '')) != ''
-             )
-             OR (
-                json_extract(je.value, '$.type') = 'thinking'
-                AND TRIM(COALESCE(json_extract(je.value, '$.thinking'), '')) != ''
-             )
-        ) THEN 0
-      ELSE 1
-    END AS isRenderable,
     COALESCE(
       SUM(CASE WHEN j.messageType = 'result' THEN 1 ELSE 0 END) OVER (
         PARTITION BY j.sessionId
-        ORDER BY j.createdAt ASC, j.id ASC
+        ORDER BY j.createdAt ASC, j.projId ASC
         ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
       ),
       0
@@ -908,14 +804,14 @@ ranked AS (
     CASE
       WHEN st.isTerminal = 0 AND st.isRenderable = 1 THEN ROW_NUMBER() OVER (
         PARTITION BY st.sessionId, st.turnIndex, st.isTerminal, st.isRenderable
-        ORDER BY st.createdAt DESC, st.id DESC
+        ORDER BY st.createdAt DESC, st.projId DESC
       )
       ELSE NULL
     END AS nonTerminalRankDesc,
     CASE
       WHEN st.isTerminal = 0 AND st.isRenderable = 1 AND st.messageType = 'user' THEN ROW_NUMBER() OVER (
         PARTITION BY st.sessionId, st.turnIndex, st.isTerminal, st.isRenderable, st.messageType
-        ORDER BY st.createdAt ASC, st.id ASC
+        ORDER BY st.createdAt ASC, st.projId ASC
       )
       ELSE NULL
     END AS userRowRankAsc
@@ -995,7 +891,7 @@ SELECT
   iteration,
   parentToolUseId
 FROM selected
-ORDER BY createdAt ASC, id ASC
+ORDER BY createdAt ASC, projId ASC
 `.trim();
 
 /**
@@ -1037,6 +933,7 @@ ${SPACE_TASK_MESSAGES_BASE_CTE},
 session_turns AS (
   SELECT
     j.id,
+    j.projId,
     j.sessionId,
     j.kind,
     j.role,
@@ -1051,7 +948,7 @@ session_turns AS (
     COALESCE(
       SUM(CASE WHEN j.messageType = 'result' THEN 1 ELSE 0 END) OVER (
         PARTITION BY j.sessionId
-        ORDER BY j.createdAt ASC, j.id ASC
+        ORDER BY j.createdAt ASC, j.projId ASC
         ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
       ),
       0
@@ -1091,6 +988,7 @@ assistant_entries AS (
     ar.turnIndex AS turnIndex,
     ar.createdAt AS ts,
     ar.id AS rowId,
+    ar.projId AS projId,
     CAST(je.key AS INTEGER) AS blockIdx,
     json_extract(ar.content, '$.uuid') AS uuid,
     json_extract(je.value, '$.type') AS blockType,
@@ -1121,6 +1019,7 @@ user_entries AS (
     ar.turnIndex AS turnIndex,
     ar.createdAt AS ts,
     ar.id AS rowId,
+    ar.projId AS projId,
     -1 AS blockIdx,
     json_extract(ar.content, '$.uuid') AS uuid,
     CASE
@@ -1176,6 +1075,7 @@ SELECT
   turnIndex,
   ts,
   rowId,
+  projId,
   blockIdx,
   uuid,
   blockType,
@@ -1190,6 +1090,7 @@ SELECT
   turnIndex,
   ts,
   rowId,
+  projId,
   blockIdx,
   uuid,
   blockType,
@@ -1198,7 +1099,7 @@ SELECT
   textValue,
   thinkingValue
 FROM user_entries
-ORDER BY sessionId ASC, ts ASC, rowId ASC, blockIdx ASC
+ORDER BY sessionId ASC, ts ASC, projId ASC, blockIdx ASC
 `.trim();
 
 // ============================================================================

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -140,7 +140,8 @@ export class SpaceRuntimeService {
 	constructor(private readonly config: SpaceRuntimeServiceConfig) {
 		// Ensure nodeExecutionRepo is available — create from db if not provided.
 		this.nodeExecutionRepo =
-			this.config.nodeExecutionRepo ?? new NodeExecutionRepository(this.config.db);
+			this.config.nodeExecutionRepo ??
+			new NodeExecutionRepository(this.config.db, this.config.reactiveDb);
 		this.runtime = new SpaceRuntime({
 			...config,
 			nodeExecutionRepo: this.nodeExecutionRepo,

--- a/packages/daemon/src/storage/reactive-database.ts
+++ b/packages/daemon/src/storage/reactive-database.ts
@@ -126,6 +126,7 @@ const DERIVED_TABLE_MAP: Record<string, ReadonlyArray<string>> = {
 	space_github_events: ['task_thread_messages'],
 	node_executions: ['task_thread_messages'],
 	space_tasks: ['task_thread_messages'],
+	space_agents: ['task_thread_messages'],
 };
 
 export function createReactiveDatabase(db: Database): ReactiveDatabase {

--- a/packages/daemon/src/storage/reactive-database.ts
+++ b/packages/daemon/src/storage/reactive-database.ts
@@ -111,6 +111,23 @@ const METHOD_TABLE_MAP: Record<string, MethodMapping> = {
 	deleteInboxItemsForRepository: { table: 'inbox_items' },
 };
 
+/**
+ * Materialised projections that mirror upstream source tables via SQLite
+ * AFTER INSERT/UPDATE/DELETE triggers. When any source table changes the
+ * proxy must also bump the derived table's version so LiveQuery subscriptions
+ * reading from the projection re-evaluate.
+ *
+ * Fan-out is one-directional and shallow: derived tables are not themselves
+ * sources for further derivations. Order matters only for the emission
+ * timeline — the source change emits first, then the derived change(s).
+ */
+const DERIVED_TABLE_MAP: Record<string, ReadonlyArray<string>> = {
+	sdk_messages: ['task_thread_messages'],
+	space_github_events: ['task_thread_messages'],
+	node_executions: ['task_thread_messages'],
+	space_tasks: ['task_thread_messages'],
+};
+
 export function createReactiveDatabase(db: Database): ReactiveDatabase {
 	const emitter = new EventEmitter();
 	const tableVersions: Record<string, number> = {};
@@ -127,6 +144,17 @@ export function createReactiveDatabase(db: Database): ReactiveDatabase {
 
 		if (transactionDepth > 0) {
 			pendingTables.add(table);
+			// Fan-out: any derived projection mirroring this source must also
+			// re-version so LiveQuery subscriptions reading the projection
+			// re-evaluate. Increment now (so versions are consistent) but defer
+			// emission to the transaction flush.
+			const derived = DERIVED_TABLE_MAP[table];
+			if (derived) {
+				for (const derivedTable of derived) {
+					tableVersions[derivedTable] = getVersion(derivedTable) + 1;
+					pendingTables.add(derivedTable);
+				}
+			}
 			return;
 		}
 
@@ -139,6 +167,32 @@ export function createReactiveDatabase(db: Database): ReactiveDatabase {
 			scope,
 		};
 		emitter.emit('change', changeEvent);
+
+		// Fan-out: SQLite triggers from migration 118 keep the
+		// `task_thread_messages` projection in sync with `sdk_messages`,
+		// `space_github_events`, `node_executions`, and `space_tasks`. Trigger
+		// writes bypass the proxy, so we must emit a parallel change event for
+		// each derived projection — otherwise LiveQuery subscriptions reading
+		// the projection never re-evaluate.
+		const derived = DERIVED_TABLE_MAP[table];
+		if (derived) {
+			for (const derivedTable of derived) {
+				tableVersions[derivedTable] = getVersion(derivedTable) + 1;
+				const derivedVersion = tableVersions[derivedTable];
+				const derivedVersionEvent: TableVersionEvent = {
+					table: derivedTable,
+					version: derivedVersion,
+					scope,
+				};
+				emitter.emit(`change:${derivedTable}`, derivedVersionEvent);
+				const derivedChangeEvent: TableChangeEvent = {
+					tables: [derivedTable],
+					versions: { [derivedTable]: derivedVersion },
+					scope,
+				};
+				emitter.emit('change', derivedChangeEvent);
+			}
+		}
 	}
 
 	function flushPendingTables(): void {

--- a/packages/daemon/src/storage/repositories/node-execution-repository.ts
+++ b/packages/daemon/src/storage/repositories/node-execution-repository.ts
@@ -61,7 +61,13 @@ export class NodeExecutionRepository {
 				now
 			);
 
-		this.reactiveDb?.notifyChange('node_executions');
+		// Only fan out when the row has session linkage — the SQLite trigger
+		// (trg_ttm_after_insert_node_exec) only fires when agent_session_id
+		// IS NOT NULL, so notifying on null bindings causes unnecessary
+		// LiveQuery churn on the common pending/no-session activation path.
+		if (params.agentSessionId != null) {
+			this.reactiveDb?.notifyChange('node_executions');
+		}
 		return this.getById(id)!;
 	}
 
@@ -106,7 +112,10 @@ export class NodeExecutionRepository {
 		// If the insert was ignored (duplicate), return the existing record.
 		const inserted = this.getById(id);
 		if (inserted) {
-			this.reactiveDb?.notifyChange('node_executions');
+			// Only fan out when the row has session linkage (mirrors create()).
+			if (params.agentSessionId != null) {
+				this.reactiveDb?.notifyChange('node_executions');
+			}
 			return inserted;
 		}
 

--- a/packages/daemon/src/storage/repositories/node-execution-repository.ts
+++ b/packages/daemon/src/storage/repositories/node-execution-repository.ts
@@ -20,10 +20,14 @@ import type {
 	CreateNodeExecutionParams,
 	UpdateNodeExecutionParams,
 } from '@neokai/shared';
+import type { ReactiveDatabase } from '../reactive-database';
 import type { SQLiteValue } from '../types';
 
 export class NodeExecutionRepository {
-	constructor(private db: BunDatabase) {}
+	constructor(
+		private db: BunDatabase,
+		private reactiveDb?: ReactiveDatabase
+	) {}
 
 	/**
 	 * Create a new node execution record.
@@ -57,6 +61,7 @@ export class NodeExecutionRepository {
 				now
 			);
 
+		this.reactiveDb?.notifyChange('node_executions');
 		return this.getById(id)!;
 	}
 
@@ -100,7 +105,10 @@ export class NodeExecutionRepository {
 
 		// If the insert was ignored (duplicate), return the existing record.
 		const inserted = this.getById(id);
-		if (inserted) return inserted;
+		if (inserted) {
+			this.reactiveDb?.notifyChange('node_executions');
+			return inserted;
+		}
 
 		// Duplicate — find the existing record by unique key.
 		const existing = this.db
@@ -213,6 +221,7 @@ export class NodeExecutionRepository {
 			this.db
 				.prepare(`UPDATE node_executions SET ${fields.join(', ')} WHERE id = ?`)
 				.run(...values);
+			this.reactiveDb?.notifyChange('node_executions');
 		}
 
 		return this.getById(id);
@@ -238,6 +247,9 @@ export class NodeExecutionRepository {
 	 */
 	delete(id: string): boolean {
 		const result = this.db.prepare(`DELETE FROM node_executions WHERE id = ?`).run(id);
+		if (result.changes > 0) {
+			this.reactiveDb?.notifyChange('node_executions');
+		}
 		return result.changes > 0;
 	}
 
@@ -282,7 +294,12 @@ export class NodeExecutionRepository {
 	 * Delete all node executions for a workflow run
 	 */
 	deleteByWorkflowRun(workflowRunId: string): void {
-		this.db.prepare(`DELETE FROM node_executions WHERE workflow_run_id = ?`).run(workflowRunId);
+		const result = this.db
+			.prepare(`DELETE FROM node_executions WHERE workflow_run_id = ?`)
+			.run(workflowRunId);
+		if (result.changes > 0) {
+			this.reactiveDb?.notifyChange('node_executions');
+		}
 	}
 
 	/**

--- a/packages/daemon/src/storage/repositories/node-execution-repository.ts
+++ b/packages/daemon/src/storage/repositories/node-execution-repository.ts
@@ -221,7 +221,12 @@ export class NodeExecutionRepository {
 			this.db
 				.prepare(`UPDATE node_executions SET ${fields.join(', ')} WHERE id = ?`)
 				.run(...values);
-			this.reactiveDb?.notifyChange('node_executions');
+			// Only invalidate LiveQuery when a projection-relevant field changed.
+			// The SQLite trigger is scoped to agent_session_id / workflow_run_id /
+			// agent_id / agent_name; status-only transitions are ignored.
+			if (params.agentSessionId !== undefined) {
+				this.reactiveDb?.notifyChange('node_executions');
+			}
 		}
 
 		return this.getById(id);

--- a/packages/daemon/src/storage/repositories/space-agent-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-agent-repository.ts
@@ -14,10 +14,14 @@
 import type { Database as BunDatabase } from 'bun:sqlite';
 import { generateUUID } from '@neokai/shared';
 import type { SpaceAgent, CreateSpaceAgentParams, UpdateSpaceAgentParams } from '@neokai/shared';
+import type { ReactiveDatabase } from '../reactive-database';
 import type { SQLiteValue } from '../types';
 
 export class SpaceAgentRepository {
-	constructor(private db: BunDatabase) {}
+	constructor(
+		private db: BunDatabase,
+		private reactiveDb?: ReactiveDatabase
+	) {}
 
 	/**
 	 * Create a new space agent
@@ -49,6 +53,7 @@ export class SpaceAgentRepository {
 				now
 			);
 
+		this.reactiveDb?.notifyChange('space_agents');
 		return this.getById(id)!;
 	}
 
@@ -155,6 +160,7 @@ export class SpaceAgentRepository {
 		values.push(id);
 
 		this.db.prepare(`UPDATE space_agents SET ${fields.join(', ')} WHERE id = ?`).run(...values);
+		this.reactiveDb?.notifyChange('space_agents');
 		return this.getById(id);
 	}
 
@@ -162,7 +168,10 @@ export class SpaceAgentRepository {
 	 * Delete an agent by ID
 	 */
 	delete(id: string): void {
-		this.db.prepare(`DELETE FROM space_agents WHERE id = ?`).run(id);
+		const result = this.db.prepare(`DELETE FROM space_agents WHERE id = ?`).run(id);
+		if (result.changes > 0) {
+			this.reactiveDb?.notifyChange('space_agents');
+		}
 	}
 
 	/**

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -73,6 +73,8 @@ export { runMigration111 } from './migrations';
 export { runMigration112 } from './migrations';
 // knip-ignore-next-line
 export { runMigration117 } from './migrations';
+// knip-ignore-next-line
+export { runMigration118 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults

--- a/packages/daemon/src/storage/schema/m118-task-thread-projection.ts
+++ b/packages/daemon/src/storage/schema/m118-task-thread-projection.ts
@@ -28,6 +28,8 @@
  *     workflow run / agent attribution changes.
  *   - space_tasks DELETE → cascading clear.
  *   - node_executions DELETE → clear node-leg projection rows.
+ *   - space_agents UPDATE OF name → refresh node-agent labels for projection
+ *     rows owned by executions of the renamed agent.
  *
  * The projection key `(task_id, source, source_id)` is unique so the same
  * source row can never produce duplicates, even if a task's session
@@ -107,7 +109,13 @@ function iterationExpr(jsonContentExpr: string): string {
 /**
  * Build the `is_renderable` boolean from the SDK message JSON.
  *
- * Mirrors the predicate inside the previous compact-feed CTE:
+ * Mirrors the predicate inside the previous compact-feed CTE with one
+ * alignment fix: user rows are non-renderable only when the content
+ * array contains **exclusively** tool_result blocks (no visible text).
+ * The original CTE inadvertently marked as non-renderable any user row
+ * that contained even a single tool_result block, including rows with
+ * mixed content (tool_result + text). That divergence is now corrected.
+ *
  *   - User rows whose content is exclusively tool_result blocks are non-
  *     renderable (they render as null in compact UI).
  *   - Assistant rows whose content array exists but lacks any tool_use,
@@ -347,6 +355,7 @@ const TRIGGER_NAMES: ReadonlyArray<string> = [
 	'trg_ttm_after_update_node_exec',
 	'trg_ttm_after_insert_node_exec',
 	'trg_ttm_after_delete_node_exec',
+	'trg_ttm_after_update_space_agent',
 ];
 
 /** Map each trigger DDL to the table it's attached to so we can skip
@@ -482,10 +491,18 @@ END
  * linkage may have moved. Drop every projection row keyed on the OLD task
  * id, then re-project from `sdk_messages` (orchestration leg + node-agent
  * leg) and `space_github_events`.
+ *
+ * The `WHEN` clause limits firing to the columns that affect projection
+ * content (session linkage, run linkage, title). Routine metadata changes
+ * such as `status` or `description` updates are ignored, avoiding a full
+ * re-projection on long-running tasks.
  */
 const TRG_AFTER_UPDATE_SPACE_TASK = `
 CREATE TRIGGER trg_ttm_after_update_space_task
 AFTER UPDATE ON space_tasks
+WHEN COALESCE(OLD.task_agent_session_id, '') IS NOT COALESCE(NEW.task_agent_session_id, '')
+   OR COALESCE(OLD.workflow_run_id, '') IS NOT COALESCE(NEW.workflow_run_id, '')
+   OR OLD.title IS NOT NEW.title
 BEGIN
   DELETE FROM task_thread_messages WHERE task_id = OLD.id;
 
@@ -669,8 +686,79 @@ const TRG_AFTER_DELETE_NODE_EXEC = `
 CREATE TRIGGER trg_ttm_after_delete_node_exec
 AFTER DELETE ON node_executions
 BEGIN
+  -- Step 1: drop projection rows that were attributed to this execution.
+  --
+  -- The projection picks one node_execution as the owner of any given
+  -- (task, sdk message) pair (first insert wins via the unique constraint),
+  -- so the rows tied to OLD.id may include messages whose underlying session
+  -- is still referenced by another live node_execution. We tear down first…
   DELETE FROM task_thread_messages
   WHERE source = 'sdk' AND node_execution_id = OLD.id;
+
+  -- Step 2: …then re-project from any surviving node_execution that still
+  -- references the same agent_session_id.
+  --
+  -- Sessions can be reused across executions: TaskAgentManager.createSubSession()
+  -- creates a fresh node_executions row pointing at an existing
+  -- agent_session_id whenever a named agent is re-activated within the same
+  -- task. Without this re-projection step, deleting one execution would orphan
+  -- still-valid messages even though another execution for that session
+  -- remains. The INSERT OR IGNORE guards against races and the WHEN clause
+  -- avoids touching the projection when there's no session to re-project from.
+  ${buildNodeAgentInsert({
+		tableSource: 'sdk_messages sm',
+		sessionRef: 'OLD.agent_session_id',
+		sdkShape: {
+			taskId: '',
+			kind: '',
+			role: '',
+			label: '',
+			title: '',
+			nodeExecId: '',
+			sessionId: 'sm.session_id',
+			messageId: 'sm.id',
+			messageType: 'sm.message_type',
+			content: 'sm.sdk_message',
+			origin: 'sm.origin',
+			timestamp: 'sm.timestamp',
+		},
+	})}
+  WHERE OLD.agent_session_id IS NOT NULL
+    AND ne.id != OLD.id
+    AND sm.session_id = OLD.agent_session_id
+    AND (sm.message_type != 'user' OR COALESCE(sm.send_status, 'consumed') IN ('consumed', 'failed'));
+END
+`.trim();
+
+/**
+ * `space_agents` UPDATE OF name — keep node-agent labels in sync with the
+ * (mutable) agent's display name. The projection materialises
+ * `COALESCE(sa.name, ne.agent_name, 'agent')` at write time, so without this
+ * trigger an existing projection row keeps its stale label after
+ * `SpaceAgentRepository.update({ name })` mutates the underlying agent.
+ *
+ * Scoped via `OF name` so updates to other columns are no-ops on the
+ * projection. The `WHEN` clause guards against UPDATEs that don't actually
+ * change the name (SQLite still fires the trigger otherwise). Only
+ * `kind = 'node_agent'` rows reference `space_agents`; other kinds use a
+ * literal label and are untouched here.
+ */
+const TRG_AFTER_UPDATE_SPACE_AGENT = `
+CREATE TRIGGER trg_ttm_after_update_space_agent
+AFTER UPDATE OF name ON space_agents
+WHEN COALESCE(OLD.name, '') IS NOT COALESCE(NEW.name, '')
+BEGIN
+  UPDATE task_thread_messages
+  SET label = COALESCE(
+    NEW.name,
+    (SELECT agent_name FROM node_executions WHERE id = task_thread_messages.node_execution_id),
+    'agent'
+  )
+  WHERE source = 'sdk'
+    AND kind = 'node_agent'
+    AND node_execution_id IN (
+      SELECT id FROM node_executions WHERE agent_id = NEW.id
+    );
 END
 `.trim();
 
@@ -717,6 +805,11 @@ const TRIGGER_DDL: ReadonlyArray<TriggerEntry> = [
 		name: 'trg_ttm_after_delete_node_exec',
 		attachedTo: 'node_executions',
 		ddl: TRG_AFTER_DELETE_NODE_EXEC,
+	},
+	{
+		name: 'trg_ttm_after_update_space_agent',
+		attachedTo: 'space_agents',
+		ddl: TRG_AFTER_UPDATE_SPACE_AGENT,
 	},
 ];
 

--- a/packages/daemon/src/storage/schema/m118-task-thread-projection.ts
+++ b/packages/daemon/src/storage/schema/m118-task-thread-projection.ts
@@ -79,11 +79,11 @@ CREATE TABLE IF NOT EXISTS task_thread_messages (
 
 const INDEX_DDL: ReadonlyArray<string> = [
 	`CREATE INDEX IF NOT EXISTS idx_ttm_task_created
-	 ON task_thread_messages(task_id, created_at, proj_id)`,
+	 ON task_thread_messages(task_id, created_at, source_id)`,
 	`CREATE INDEX IF NOT EXISTS idx_ttm_task_session_created
-	 ON task_thread_messages(task_id, session_id, created_at, proj_id)`,
+	 ON task_thread_messages(task_id, session_id, created_at, source_id)`,
 	`CREATE INDEX IF NOT EXISTS idx_ttm_session_created
-	 ON task_thread_messages(session_id, created_at, proj_id)`,
+	 ON task_thread_messages(session_id, created_at, source_id)`,
 	`CREATE INDEX IF NOT EXISTS idx_ttm_source
 	 ON task_thread_messages(source, source_id)`,
 ];

--- a/packages/daemon/src/storage/schema/m118-task-thread-projection.ts
+++ b/packages/daemon/src/storage/schema/m118-task-thread-projection.ts
@@ -610,10 +610,18 @@ END
  * `workflow_run_id` / `agent_id` / `agent_name` changes (rare). We delete
  * any projection rows previously attributed to the OLD execution id and
  * re-project for the NEW shape.
+ *
+ * A `WHEN` clause limits firing to the columns that affect projection
+ * content. High-frequency status transitions (in_progress → idle, etc.)
+ * are ignored, avoiding churn on long-running nodes.
  */
 const TRG_AFTER_UPDATE_NODE_EXEC = `
 CREATE TRIGGER trg_ttm_after_update_node_exec
 AFTER UPDATE ON node_executions
+WHEN COALESCE(OLD.agent_session_id, '') IS NOT COALESCE(NEW.agent_session_id, '')
+   OR COALESCE(OLD.workflow_run_id, '') IS NOT COALESCE(NEW.workflow_run_id, '')
+   OR COALESCE(OLD.agent_id, '') IS NOT COALESCE(NEW.agent_id, '')
+   OR OLD.agent_name IS NOT NEW.agent_name
 BEGIN
   DELETE FROM task_thread_messages
   WHERE source = 'sdk' AND node_execution_id = OLD.id;

--- a/packages/daemon/src/storage/schema/m118-task-thread-projection.ts
+++ b/packages/daemon/src/storage/schema/m118-task-thread-projection.ts
@@ -1,0 +1,905 @@
+/**
+ * Migration 118 — Materialise the task-thread message projection.
+ *
+ * Until this migration the LiveQuery feeds `spaceTaskMessages.byTask` and
+ * `spaceTaskMessages.byTask.compact` rebuilt the per-task timeline on every
+ * read by joining `space_tasks` → `sessions` / `node_executions` →
+ * `sdk_messages` (plus a github leg) and applying window functions for turn
+ * grouping, terminal/renderable classification, and per-turn caps. That
+ * round trip touches the full session history and re-parses every
+ * `sdk_message` JSON blob; on long workflow runs it dominates feed
+ * re-evaluation latency.
+ *
+ * The projection lifts the join + JSON work to *write* time. Each
+ * `sdk_message` and `space_github_event` is fanned out into one row per
+ * matching task in `task_thread_messages` with the derived shape the feed
+ * needs: role/label/title/kind/origin, plus pre-computed `is_terminal` and
+ * `is_renderable` flags, plus the cached `iteration` and
+ * `parent_tool_use_id`. Reads then become indexed scans of one task's worth
+ * of rows with simple window functions for turn grouping.
+ *
+ * Maintenance is via SQLite triggers (no application-level hooks needed):
+ *   - sdk_messages INSERT/UPDATE/DELETE → fan-out / refresh / clear.
+ *   - space_github_events INSERT/UPDATE/DELETE → github leg.
+ *   - space_tasks UPDATE (task_agent_session_id / workflow_run_id / title)
+ *     → reproject when session linkage moves.
+ *   - node_executions UPDATE (agent_session_id / workflow_run_id / agent_id /
+ *     agent_name) → reproject when a node binds to a session, or its
+ *     workflow run / agent attribution changes.
+ *   - space_tasks DELETE → cascading clear.
+ *   - node_executions DELETE → clear node-leg projection rows.
+ *
+ * The projection key `(task_id, source, source_id)` is unique so the same
+ * source row can never produce duplicates, even if a task's session
+ * linkage changes mid-flight (the trigger always deletes-then-reinserts).
+ *
+ * Rewinds and replays are handled implicitly: `deleteMessagesAfter` /
+ * `deleteMessagesAtAndAfter` issue plain `DELETE FROM sdk_messages` which
+ * fires the AFTER DELETE trigger and clears the matching projection rows.
+ *
+ * Backfill: any pre-existing `sdk_messages` / `space_github_events` are
+ * projected once at migration time using the same join semantics as the
+ * triggers. Re-running the migration is a no-op (the table + triggers are
+ * idempotent and the unique constraint means backfill `INSERT OR IGNORE`s).
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+
+// ---------------------------------------------------------------------------
+// Schema DDL
+// ---------------------------------------------------------------------------
+
+const TABLE_DDL = `
+CREATE TABLE IF NOT EXISTS task_thread_messages (
+  proj_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  task_id TEXT NOT NULL,
+  source TEXT NOT NULL CHECK(source IN ('sdk', 'github')),
+  source_id TEXT NOT NULL,
+  session_id TEXT,
+  node_execution_id TEXT,
+  kind TEXT NOT NULL CHECK(kind IN ('task_agent', 'node_agent', 'github')),
+  role TEXT NOT NULL,
+  label TEXT NOT NULL,
+  task_title TEXT NOT NULL,
+  message_type TEXT NOT NULL,
+  content TEXT NOT NULL,
+  origin TEXT,
+  created_at INTEGER NOT NULL,
+  iteration INTEGER NOT NULL DEFAULT 0,
+  parent_tool_use_id TEXT,
+  is_terminal INTEGER NOT NULL DEFAULT 0,
+  is_renderable INTEGER NOT NULL DEFAULT 1,
+  UNIQUE(task_id, source, source_id)
+)
+`.trim();
+
+const INDEX_DDL: ReadonlyArray<string> = [
+	`CREATE INDEX IF NOT EXISTS idx_ttm_task_created
+	 ON task_thread_messages(task_id, created_at, proj_id)`,
+	`CREATE INDEX IF NOT EXISTS idx_ttm_task_session_created
+	 ON task_thread_messages(task_id, session_id, created_at, proj_id)`,
+	`CREATE INDEX IF NOT EXISTS idx_ttm_session_created
+	 ON task_thread_messages(session_id, created_at, proj_id)`,
+	`CREATE INDEX IF NOT EXISTS idx_ttm_source
+	 ON task_thread_messages(source, source_id)`,
+];
+
+// ---------------------------------------------------------------------------
+// Shared SQL fragments
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert an ISO-8601 timestamp text column to milliseconds since the Unix
+ * epoch, matching the `createdAt` shape the live-query SQL emits today.
+ */
+function tsMsExpr(timestampExpr: string): string {
+	return `CAST((julianday(${timestampExpr}) - 2440587.5) * 86400000 AS INTEGER)`;
+}
+
+/**
+ * Iteration metadata is attached to messages by the runtime via the
+ * `_taskMeta.iteration` JSON field. Default to 0 when absent.
+ */
+function iterationExpr(jsonContentExpr: string): string {
+	return `CAST(COALESCE(json_extract(${jsonContentExpr}, '$._taskMeta.iteration'), 0) AS INTEGER)`;
+}
+
+/**
+ * Build the `is_renderable` boolean from the SDK message JSON.
+ *
+ * Mirrors the predicate inside the previous compact-feed CTE:
+ *   - User rows whose content is exclusively tool_result blocks are non-
+ *     renderable (they render as null in compact UI).
+ *   - Assistant rows whose content array exists but lacks any tool_use,
+ *     non-empty text, or non-empty thinking block are non-renderable.
+ *   - Everything else is renderable.
+ */
+function renderableExpr(typeExpr: string, jsonContentExpr: string): string {
+	return `
+CASE
+  WHEN ${typeExpr} = 'user'
+    AND json_type(${jsonContentExpr}, '$.message.content') = 'array'
+    AND EXISTS (
+      SELECT 1
+      FROM json_each(json_extract(${jsonContentExpr}, '$.message.content')) AS je
+      WHERE json_extract(je.value, '$.type') = 'tool_result'
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM json_each(json_extract(${jsonContentExpr}, '$.message.content')) AS je
+      WHERE json_extract(je.value, '$.type') = 'text'
+        AND TRIM(COALESCE(json_extract(je.value, '$.text'), '')) != ''
+    ) THEN 0
+  WHEN ${typeExpr} = 'assistant'
+    AND json_type(${jsonContentExpr}, '$.message.content') = 'array'
+    AND NOT EXISTS (
+      SELECT 1
+      FROM json_each(json_extract(${jsonContentExpr}, '$.message.content')) AS je
+      WHERE json_extract(je.value, '$.type') = 'tool_use'
+         OR (
+           json_extract(je.value, '$.type') = 'text'
+           AND TRIM(COALESCE(json_extract(je.value, '$.text'), '')) != ''
+         )
+         OR (
+           json_extract(je.value, '$.type') = 'thinking'
+           AND TRIM(COALESCE(json_extract(je.value, '$.thinking'), '')) != ''
+         )
+    ) THEN 0
+  ELSE 1
+END
+`.trim();
+}
+
+/**
+ * The compact feed historically excluded user rows that hadn't been
+ * `consumed` (or `failed`) yet — those represent in-flight enqueued
+ * input that the agent hasn't seen. The same predicate gates the
+ * projection so deferred user rows never leak into the feed.
+ */
+function userVisibilityWhereForNew(): string {
+	return `(NEW.message_type != 'user' OR COALESCE(NEW.send_status, 'consumed') IN ('consumed', 'failed'))`;
+}
+
+/**
+ * Common SDK-message column list shared between INSERT and backfill.
+ * `<task>`, `<kind>`, `<role>`, `<label>`, `<title>`, `<nodeExec>` are placeholders
+ * supplied by the caller (e.g. `tt.id`, `'task_agent'`, etc.).
+ */
+interface SdkProjectionShape {
+	taskId: string;
+	kind: string;
+	role: string;
+	label: string;
+	title: string;
+	nodeExecId: string;
+	sessionId: string;
+	messageId: string;
+	messageType: string;
+	content: string;
+	origin: string;
+	timestamp: string;
+}
+
+function sdkSelectColumns(s: SdkProjectionShape): string {
+	return `
+${s.taskId} AS task_id,
+'sdk' AS source,
+${s.messageId} AS source_id,
+${s.sessionId} AS session_id,
+${s.nodeExecId} AS node_execution_id,
+${s.kind} AS kind,
+${s.role} AS role,
+${s.label} AS label,
+${s.title} AS task_title,
+${s.messageType} AS message_type,
+${s.content} AS content,
+${s.origin} AS origin,
+${tsMsExpr(s.timestamp)} AS created_at,
+${iterationExpr(s.content)} AS iteration,
+json_extract(${s.content}, '$.parent_tool_use_id') AS parent_tool_use_id,
+CASE WHEN ${s.messageType} = 'result' THEN 1 ELSE 0 END AS is_terminal,
+${renderableExpr(s.messageType, s.content)} AS is_renderable
+`.trim();
+}
+
+function projectionColumns(): string {
+	return `(
+  task_id, source, source_id, session_id, node_execution_id, kind, role, label,
+  task_title, message_type, content, origin, created_at, iteration,
+  parent_tool_use_id, is_terminal, is_renderable
+)`;
+}
+
+/**
+ * Orchestration leg INSERT body — projects a single sdk_message row into
+ * `task_thread_messages` for every `space_task` whose
+ * `task_agent_session_id` matches `<sessionExpr>`.
+ *
+ * Callers supply the alias for the source-message identity (NEW.id /
+ * sm.id) plus the column expressions that yield the SDK row's payload.
+ */
+function buildOrchestrationInsert(opts: {
+	tableSource: string;
+	sessionRef: string;
+	sdkShape: SdkProjectionShape;
+}): string {
+	return `
+INSERT OR IGNORE INTO task_thread_messages
+${projectionColumns()}
+SELECT
+${sdkSelectColumns({
+	...opts.sdkShape,
+	taskId: 'tt.id',
+	kind: `'task_agent'`,
+	role: `'task-agent'`,
+	label: `'Task Agent'`,
+	title: 'tt.title',
+	nodeExecId: 'NULL',
+})}
+FROM ${opts.tableSource}
+JOIN space_tasks tt ON tt.task_agent_session_id = ${opts.sessionRef}
+JOIN sessions s ON s.id = tt.task_agent_session_id
+WHERE tt.task_agent_session_id IS NOT NULL
+  AND s.type = 'space_task_agent'
+`.trim();
+}
+
+/**
+ * Node-agent leg INSERT body — projects a single sdk_message row into
+ * `task_thread_messages` for every `space_task` whose `workflow_run_id`
+ * matches an existing `node_executions.workflow_run_id` for
+ * `<sessionExpr>`. The agent label resolves to `space_agents.name`
+ * when available; otherwise the `node_executions.agent_name` (or the
+ * literal "agent") is used.
+ */
+function buildNodeAgentInsert(opts: {
+	tableSource: string;
+	sessionRef: string;
+	sdkShape: SdkProjectionShape;
+}): string {
+	return `
+INSERT OR IGNORE INTO task_thread_messages
+${projectionColumns()}
+SELECT
+${sdkSelectColumns({
+	...opts.sdkShape,
+	taskId: 'tt.id',
+	kind: `'node_agent'`,
+	role: 'ne.agent_name',
+	label: `COALESCE(sa.name, ne.agent_name, 'agent')`,
+	title: 'tt.title',
+	nodeExecId: 'ne.id',
+})}
+FROM ${opts.tableSource}
+JOIN node_executions ne ON ne.agent_session_id = ${opts.sessionRef}
+JOIN space_tasks tt
+  ON tt.workflow_run_id IS NOT NULL
+ AND ne.workflow_run_id = tt.workflow_run_id
+LEFT JOIN space_agents sa ON sa.id = ne.agent_id
+`.trim();
+}
+
+/**
+ * GitHub-event leg INSERT body — synthesise the same envelope the original
+ * CTE emits (`type = 'user'` with a single text block carrying the summary +
+ * external_url). `<source>` is either NEW (trigger) or `space_github_events`
+ * (backfill).
+ */
+function buildGithubInsert(opts: {
+	tableSource: string;
+	idRef: string;
+	taskRef: string;
+	stateRef: string;
+	summaryRef: string;
+	urlRef: string;
+	occurredAtRef: string;
+}): string {
+	return `
+INSERT OR IGNORE INTO task_thread_messages
+${projectionColumns()}
+SELECT
+  tt.id AS task_id,
+  'github' AS source,
+  ${opts.idRef} AS source_id,
+  NULL AS session_id,
+  NULL AS node_execution_id,
+  'github' AS kind,
+  'github' AS role,
+  'GitHub' AS label,
+  tt.title AS task_title,
+  'github_pr_activity' AS message_type,
+  json_object(
+    'type', 'user',
+    'uuid', ${opts.idRef},
+    'message', json_object(
+      'role', 'user',
+      'content', json_array(json_object(
+        'type', 'text',
+        'text', '[GitHub] ' || ${opts.summaryRef} || char(10) || ${opts.urlRef}
+      ))
+    )
+  ) AS content,
+  'system' AS origin,
+  ${opts.occurredAtRef} AS created_at,
+  0 AS iteration,
+  NULL AS parent_tool_use_id,
+  0 AS is_terminal,
+  1 AS is_renderable
+FROM ${opts.tableSource}
+JOIN space_tasks tt ON tt.id = ${opts.taskRef}
+WHERE ${opts.stateRef} IN ('routed', 'delivered')
+`.trim();
+}
+
+// ---------------------------------------------------------------------------
+// Triggers
+// ---------------------------------------------------------------------------
+
+const TRIGGER_NAMES: ReadonlyArray<string> = [
+	'trg_ttm_after_insert_sdk',
+	'trg_ttm_after_update_sdk',
+	'trg_ttm_after_delete_sdk',
+	'trg_ttm_after_insert_github',
+	'trg_ttm_after_update_github',
+	'trg_ttm_after_delete_github',
+	'trg_ttm_after_update_space_task',
+	'trg_ttm_after_delete_space_task',
+	'trg_ttm_after_update_node_exec',
+	'trg_ttm_after_insert_node_exec',
+	'trg_ttm_after_delete_node_exec',
+];
+
+/** Map each trigger DDL to the table it's attached to so we can skip
+ *  creation when running against a partial schema (test setups that
+ *  pull in only a subset of the daemon tables).
+ */
+interface TriggerEntry {
+	name: string;
+	attachedTo: string;
+	ddl: string;
+}
+
+const SDK_NEW_SHAPE: SdkProjectionShape = {
+	taskId: '',
+	kind: '',
+	role: '',
+	label: '',
+	title: '',
+	nodeExecId: '',
+	sessionId: 'NEW.session_id',
+	messageId: 'NEW.id',
+	messageType: 'NEW.message_type',
+	content: 'NEW.sdk_message',
+	origin: 'NEW.origin',
+	timestamp: 'NEW.timestamp',
+};
+
+const TRG_AFTER_INSERT_SDK = `
+CREATE TRIGGER trg_ttm_after_insert_sdk
+AFTER INSERT ON sdk_messages
+WHEN ${userVisibilityWhereForNew()}
+BEGIN
+  ${buildOrchestrationInsert({
+		tableSource: '(SELECT 1) AS _',
+		sessionRef: 'NEW.session_id',
+		sdkShape: SDK_NEW_SHAPE,
+	})};
+
+  ${buildNodeAgentInsert({
+		tableSource: '(SELECT 1) AS _',
+		sessionRef: 'NEW.session_id',
+		sdkShape: SDK_NEW_SHAPE,
+	})};
+END
+`.trim();
+
+const TRG_AFTER_UPDATE_SDK = `
+CREATE TRIGGER trg_ttm_after_update_sdk
+AFTER UPDATE ON sdk_messages
+BEGIN
+  -- Always clear the old projection: the message identity is the same but
+  -- payload, status, or session may have shifted. The user-visibility WHEN
+  -- clause that filters INSERTs cannot be applied to an UPDATE-side delete
+  -- (we'd leave a stale projection for rows transitioning back to deferred).
+  DELETE FROM task_thread_messages
+  WHERE source = 'sdk' AND source_id = OLD.id;
+
+  -- Re-project under the post-update payload, applying the same visibility
+  -- predicate the INSERT trigger uses.
+  ${buildOrchestrationInsert({
+		tableSource: `(SELECT 1) AS _`,
+		sessionRef: 'NEW.session_id',
+		sdkShape: SDK_NEW_SHAPE,
+	})}
+  AND ${userVisibilityWhereForNew()};
+
+  ${buildNodeAgentInsert({
+		tableSource: `(SELECT 1) AS _`,
+		sessionRef: 'NEW.session_id',
+		sdkShape: SDK_NEW_SHAPE,
+	})}
+  AND ${userVisibilityWhereForNew()};
+END
+`.trim();
+
+const TRG_AFTER_DELETE_SDK = `
+CREATE TRIGGER trg_ttm_after_delete_sdk
+AFTER DELETE ON sdk_messages
+BEGIN
+  DELETE FROM task_thread_messages
+  WHERE source = 'sdk' AND source_id = OLD.id;
+END
+`.trim();
+
+const TRG_AFTER_INSERT_GITHUB = `
+CREATE TRIGGER trg_ttm_after_insert_github
+AFTER INSERT ON space_github_events
+WHEN NEW.task_id IS NOT NULL AND NEW.state IN ('routed', 'delivered')
+BEGIN
+  ${buildGithubInsert({
+		tableSource: '(SELECT 1) AS _',
+		idRef: 'NEW.id',
+		taskRef: 'NEW.task_id',
+		stateRef: 'NEW.state',
+		summaryRef: 'NEW.summary',
+		urlRef: 'NEW.external_url',
+		occurredAtRef: 'NEW.occurred_at',
+	})};
+END
+`.trim();
+
+const TRG_AFTER_UPDATE_GITHUB = `
+CREATE TRIGGER trg_ttm_after_update_github
+AFTER UPDATE ON space_github_events
+BEGIN
+  DELETE FROM task_thread_messages
+  WHERE source = 'github' AND source_id = OLD.id;
+
+  ${buildGithubInsert({
+		tableSource: '(SELECT 1) AS _',
+		idRef: 'NEW.id',
+		taskRef: 'NEW.task_id',
+		stateRef: 'NEW.state',
+		summaryRef: 'NEW.summary',
+		urlRef: 'NEW.external_url',
+		occurredAtRef: 'NEW.occurred_at',
+	})}
+  AND NEW.task_id IS NOT NULL;
+END
+`.trim();
+
+const TRG_AFTER_DELETE_GITHUB = `
+CREATE TRIGGER trg_ttm_after_delete_github
+AFTER DELETE ON space_github_events
+BEGIN
+  DELETE FROM task_thread_messages
+  WHERE source = 'github' AND source_id = OLD.id;
+END
+`.trim();
+
+/**
+ * `space_tasks` UPDATE — the row identity is unchanged but its session
+ * linkage may have moved. Drop every projection row keyed on the OLD task
+ * id, then re-project from `sdk_messages` (orchestration leg + node-agent
+ * leg) and `space_github_events`.
+ */
+const TRG_AFTER_UPDATE_SPACE_TASK = `
+CREATE TRIGGER trg_ttm_after_update_space_task
+AFTER UPDATE ON space_tasks
+BEGIN
+  DELETE FROM task_thread_messages WHERE task_id = OLD.id;
+
+  -- Orchestration leg: every sdk_message in the (possibly new) task agent
+  -- session, gated by the same user-visibility predicate.
+  INSERT OR IGNORE INTO task_thread_messages
+  ${projectionColumns()}
+  SELECT
+${sdkSelectColumns({
+	taskId: 'NEW.id',
+	kind: `'task_agent'`,
+	role: `'task-agent'`,
+	label: `'Task Agent'`,
+	title: 'NEW.title',
+	nodeExecId: 'NULL',
+	sessionId: 'sm.session_id',
+	messageId: 'sm.id',
+	messageType: 'sm.message_type',
+	content: 'sm.sdk_message',
+	origin: 'sm.origin',
+	timestamp: 'sm.timestamp',
+})}
+  FROM sdk_messages sm
+  JOIN sessions s ON s.id = sm.session_id
+  WHERE NEW.task_agent_session_id IS NOT NULL
+    AND sm.session_id = NEW.task_agent_session_id
+    AND s.type = 'space_task_agent'
+    AND (sm.message_type != 'user' OR COALESCE(sm.send_status, 'consumed') IN ('consumed', 'failed'));
+
+  -- Node-agent leg: every sdk_message reached via the (possibly new)
+  -- workflow_run_id linkage.
+  INSERT OR IGNORE INTO task_thread_messages
+  ${projectionColumns()}
+  SELECT
+${sdkSelectColumns({
+	taskId: 'NEW.id',
+	kind: `'node_agent'`,
+	role: 'ne.agent_name',
+	label: `COALESCE(sa.name, ne.agent_name, 'agent')`,
+	title: 'NEW.title',
+	nodeExecId: 'ne.id',
+	sessionId: 'sm.session_id',
+	messageId: 'sm.id',
+	messageType: 'sm.message_type',
+	content: 'sm.sdk_message',
+	origin: 'sm.origin',
+	timestamp: 'sm.timestamp',
+})}
+  FROM sdk_messages sm
+  JOIN node_executions ne ON ne.agent_session_id = sm.session_id
+  LEFT JOIN space_agents sa ON sa.id = ne.agent_id
+  WHERE NEW.workflow_run_id IS NOT NULL
+    AND ne.workflow_run_id = NEW.workflow_run_id
+    AND ne.agent_session_id IS NOT NULL
+    AND (sm.message_type != 'user' OR COALESCE(sm.send_status, 'consumed') IN ('consumed', 'failed'));
+
+  -- GitHub leg: re-project events whose task_id maps to NEW.id.
+  INSERT OR IGNORE INTO task_thread_messages
+  ${projectionColumns()}
+  SELECT
+    NEW.id AS task_id,
+    'github' AS source,
+    ge.id AS source_id,
+    NULL AS session_id,
+    NULL AS node_execution_id,
+    'github' AS kind,
+    'github' AS role,
+    'GitHub' AS label,
+    NEW.title AS task_title,
+    'github_pr_activity' AS message_type,
+    json_object(
+      'type', 'user',
+      'uuid', ge.id,
+      'message', json_object(
+        'role', 'user',
+        'content', json_array(json_object(
+          'type', 'text',
+          'text', '[GitHub] ' || ge.summary || char(10) || ge.external_url
+        ))
+      )
+    ) AS content,
+    'system' AS origin,
+    ge.occurred_at AS created_at,
+    0 AS iteration,
+    NULL AS parent_tool_use_id,
+    0 AS is_terminal,
+    1 AS is_renderable
+  FROM space_github_events ge
+  WHERE ge.task_id = NEW.id
+    AND ge.state IN ('routed', 'delivered');
+END
+`.trim();
+
+const TRG_AFTER_DELETE_SPACE_TASK = `
+CREATE TRIGGER trg_ttm_after_delete_space_task
+AFTER DELETE ON space_tasks
+BEGIN
+  DELETE FROM task_thread_messages WHERE task_id = OLD.id;
+END
+`.trim();
+
+/**
+ * `node_executions` UPDATE — fired both when an agent first binds to a
+ * session (`agent_session_id` flips from NULL) and when a row's
+ * `workflow_run_id` / `agent_id` / `agent_name` changes (rare). We delete
+ * any projection rows previously attributed to the OLD execution id and
+ * re-project for the NEW shape.
+ */
+const TRG_AFTER_UPDATE_NODE_EXEC = `
+CREATE TRIGGER trg_ttm_after_update_node_exec
+AFTER UPDATE ON node_executions
+BEGIN
+  DELETE FROM task_thread_messages
+  WHERE source = 'sdk' AND node_execution_id = OLD.id;
+
+  INSERT OR IGNORE INTO task_thread_messages
+  ${projectionColumns()}
+  SELECT
+${sdkSelectColumns({
+	taskId: 'tt.id',
+	kind: `'node_agent'`,
+	role: 'NEW.agent_name',
+	label: `COALESCE(sa.name, NEW.agent_name, 'agent')`,
+	title: 'tt.title',
+	nodeExecId: 'NEW.id',
+	sessionId: 'sm.session_id',
+	messageId: 'sm.id',
+	messageType: 'sm.message_type',
+	content: 'sm.sdk_message',
+	origin: 'sm.origin',
+	timestamp: 'sm.timestamp',
+})}
+  FROM sdk_messages sm
+  JOIN space_tasks tt ON tt.workflow_run_id = NEW.workflow_run_id
+  LEFT JOIN space_agents sa ON sa.id = NEW.agent_id
+  WHERE NEW.agent_session_id IS NOT NULL
+    AND sm.session_id = NEW.agent_session_id
+    AND tt.workflow_run_id IS NOT NULL
+    AND (sm.message_type != 'user' OR COALESCE(sm.send_status, 'consumed') IN ('consumed', 'failed'));
+END
+`.trim();
+
+/**
+ * `node_executions` INSERT — projection mirrors UPDATE, but driven on
+ * fresh rows (`agent_session_id` may already be set). Common in tests
+ * that pre-stage a node_execution before the agent has emitted any
+ * messages — but defensive in case messages exist already.
+ */
+const TRG_AFTER_INSERT_NODE_EXEC = `
+CREATE TRIGGER trg_ttm_after_insert_node_exec
+AFTER INSERT ON node_executions
+WHEN NEW.agent_session_id IS NOT NULL
+BEGIN
+  INSERT OR IGNORE INTO task_thread_messages
+  ${projectionColumns()}
+  SELECT
+${sdkSelectColumns({
+	taskId: 'tt.id',
+	kind: `'node_agent'`,
+	role: 'NEW.agent_name',
+	label: `COALESCE(sa.name, NEW.agent_name, 'agent')`,
+	title: 'tt.title',
+	nodeExecId: 'NEW.id',
+	sessionId: 'sm.session_id',
+	messageId: 'sm.id',
+	messageType: 'sm.message_type',
+	content: 'sm.sdk_message',
+	origin: 'sm.origin',
+	timestamp: 'sm.timestamp',
+})}
+  FROM sdk_messages sm
+  JOIN space_tasks tt ON tt.workflow_run_id = NEW.workflow_run_id
+  LEFT JOIN space_agents sa ON sa.id = NEW.agent_id
+  WHERE sm.session_id = NEW.agent_session_id
+    AND tt.workflow_run_id IS NOT NULL
+    AND (sm.message_type != 'user' OR COALESCE(sm.send_status, 'consumed') IN ('consumed', 'failed'));
+END
+`.trim();
+
+const TRG_AFTER_DELETE_NODE_EXEC = `
+CREATE TRIGGER trg_ttm_after_delete_node_exec
+AFTER DELETE ON node_executions
+BEGIN
+  DELETE FROM task_thread_messages
+  WHERE source = 'sdk' AND node_execution_id = OLD.id;
+END
+`.trim();
+
+const TRIGGER_DDL: ReadonlyArray<TriggerEntry> = [
+	{ name: 'trg_ttm_after_insert_sdk', attachedTo: 'sdk_messages', ddl: TRG_AFTER_INSERT_SDK },
+	{ name: 'trg_ttm_after_update_sdk', attachedTo: 'sdk_messages', ddl: TRG_AFTER_UPDATE_SDK },
+	{ name: 'trg_ttm_after_delete_sdk', attachedTo: 'sdk_messages', ddl: TRG_AFTER_DELETE_SDK },
+	{
+		name: 'trg_ttm_after_insert_github',
+		attachedTo: 'space_github_events',
+		ddl: TRG_AFTER_INSERT_GITHUB,
+	},
+	{
+		name: 'trg_ttm_after_update_github',
+		attachedTo: 'space_github_events',
+		ddl: TRG_AFTER_UPDATE_GITHUB,
+	},
+	{
+		name: 'trg_ttm_after_delete_github',
+		attachedTo: 'space_github_events',
+		ddl: TRG_AFTER_DELETE_GITHUB,
+	},
+	{
+		name: 'trg_ttm_after_update_space_task',
+		attachedTo: 'space_tasks',
+		ddl: TRG_AFTER_UPDATE_SPACE_TASK,
+	},
+	{
+		name: 'trg_ttm_after_delete_space_task',
+		attachedTo: 'space_tasks',
+		ddl: TRG_AFTER_DELETE_SPACE_TASK,
+	},
+	{
+		name: 'trg_ttm_after_update_node_exec',
+		attachedTo: 'node_executions',
+		ddl: TRG_AFTER_UPDATE_NODE_EXEC,
+	},
+	{
+		name: 'trg_ttm_after_insert_node_exec',
+		attachedTo: 'node_executions',
+		ddl: TRG_AFTER_INSERT_NODE_EXEC,
+	},
+	{
+		name: 'trg_ttm_after_delete_node_exec',
+		attachedTo: 'node_executions',
+		ddl: TRG_AFTER_DELETE_NODE_EXEC,
+	},
+];
+
+// ---------------------------------------------------------------------------
+// Backfill
+// ---------------------------------------------------------------------------
+
+function backfillSdkOrchestration(): string {
+	return `
+INSERT OR IGNORE INTO task_thread_messages
+${projectionColumns()}
+SELECT
+${sdkSelectColumns({
+	taskId: 'tt.id',
+	kind: `'task_agent'`,
+	role: `'task-agent'`,
+	label: `'Task Agent'`,
+	title: 'tt.title',
+	nodeExecId: 'NULL',
+	sessionId: 'sm.session_id',
+	messageId: 'sm.id',
+	messageType: 'sm.message_type',
+	content: 'sm.sdk_message',
+	origin: 'sm.origin',
+	timestamp: 'sm.timestamp',
+})}
+FROM sdk_messages sm
+JOIN space_tasks tt ON tt.task_agent_session_id = sm.session_id
+JOIN sessions s ON s.id = tt.task_agent_session_id
+WHERE tt.task_agent_session_id IS NOT NULL
+  AND s.type = 'space_task_agent'
+  AND (sm.message_type != 'user' OR COALESCE(sm.send_status, 'consumed') IN ('consumed', 'failed'))
+`.trim();
+}
+
+function backfillSdkNodeAgents(): string {
+	return `
+INSERT OR IGNORE INTO task_thread_messages
+${projectionColumns()}
+SELECT
+${sdkSelectColumns({
+	taskId: 'tt.id',
+	kind: `'node_agent'`,
+	role: 'ne.agent_name',
+	label: `COALESCE(sa.name, ne.agent_name, 'agent')`,
+	title: 'tt.title',
+	nodeExecId: 'ne.id',
+	sessionId: 'sm.session_id',
+	messageId: 'sm.id',
+	messageType: 'sm.message_type',
+	content: 'sm.sdk_message',
+	origin: 'sm.origin',
+	timestamp: 'sm.timestamp',
+})}
+FROM sdk_messages sm
+JOIN node_executions ne ON ne.agent_session_id = sm.session_id
+JOIN space_tasks tt
+  ON tt.workflow_run_id IS NOT NULL
+ AND ne.workflow_run_id = tt.workflow_run_id
+LEFT JOIN space_agents sa ON sa.id = ne.agent_id
+WHERE ne.agent_session_id IS NOT NULL
+  AND (sm.message_type != 'user' OR COALESCE(sm.send_status, 'consumed') IN ('consumed', 'failed'))
+`.trim();
+}
+
+function backfillGithub(): string {
+	return `
+INSERT OR IGNORE INTO task_thread_messages
+${projectionColumns()}
+SELECT
+  tt.id AS task_id,
+  'github' AS source,
+  ge.id AS source_id,
+  NULL AS session_id,
+  NULL AS node_execution_id,
+  'github' AS kind,
+  'github' AS role,
+  'GitHub' AS label,
+  tt.title AS task_title,
+  'github_pr_activity' AS message_type,
+  json_object(
+    'type', 'user',
+    'uuid', ge.id,
+    'message', json_object(
+      'role', 'user',
+      'content', json_array(json_object(
+        'type', 'text',
+        'text', '[GitHub] ' || ge.summary || char(10) || ge.external_url
+      ))
+    )
+  ) AS content,
+  'system' AS origin,
+  ge.occurred_at AS created_at,
+  0 AS iteration,
+  NULL AS parent_tool_use_id,
+  0 AS is_terminal,
+  1 AS is_renderable
+FROM space_github_events ge
+JOIN space_tasks tt ON tt.id = ge.task_id
+WHERE ge.task_id IS NOT NULL
+  AND ge.state IN ('routed', 'delivered')
+`.trim();
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tableExists(db: BunDatabase, tableName: string): boolean {
+	const row = db
+		.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`)
+		.get(tableName);
+	return !!row;
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply migration 118. Idempotent: re-running on a database that already
+ * has the projection table + triggers is a no-op (the table uses CREATE
+ * IF NOT EXISTS, triggers are dropped + recreated, and backfill writes
+ * collide on the unique constraint).
+ *
+ * The order of operations matters:
+ *   1. Create the table.
+ *   2. Create indexes.
+ *   3. Backfill BEFORE the triggers exist — otherwise the
+ *      `INSERT OR IGNORE` no-ops collide with trigger reprojection on
+ *      `space_tasks` UPDATE writes that the application may emit during
+ *      this migration. (Rare but safer.)
+ *   4. Create triggers.
+ */
+export function runMigration118External(db: BunDatabase): void {
+	if (!tableExists(db, 'sdk_messages')) {
+		return;
+	}
+
+	db.exec(TABLE_DDL);
+	for (const ddl of INDEX_DDL) {
+		db.exec(ddl);
+	}
+
+	// Backfill — only run for legs whose source tables exist. Tests that
+	// pull in just a subset of the schema (e.g. live-query smoke tests)
+	// won't have space_tasks/node_executions; the backfill silently skips
+	// those legs.
+	const haveSpaceTasks = tableExists(db, 'space_tasks');
+	const haveSessions = tableExists(db, 'sessions');
+	const haveNodeExec = tableExists(db, 'node_executions');
+	const haveSpaceAgents = tableExists(db, 'space_agents');
+	const haveGithubEvents = tableExists(db, 'space_github_events');
+
+	if (haveSpaceTasks && haveSessions) {
+		db.exec(backfillSdkOrchestration());
+	}
+	if (haveSpaceTasks && haveNodeExec && haveSpaceAgents) {
+		db.exec(backfillSdkNodeAgents());
+	}
+	if (haveSpaceTasks && haveGithubEvents) {
+		db.exec(backfillGithub());
+	}
+
+	// Triggers — drop first for idempotency. CREATE TRIGGER tolerates
+	// missing referenced tables in the *body* (resolved on fire), but
+	// requires the *attached* table (the one in the `ON ...` clause) to
+	// exist. Skip triggers whose attached table isn't present so partial
+	// test schemas don't blow up. Additionally, the projection is
+	// meaningless without `space_tasks` / `node_executions` /
+	// `space_agents` / `sessions` (every body either joins to them or
+	// dispatches into a CTE that does); if any are absent we skip the
+	// whole trigger network so legacy tests inserting into
+	// `sdk_messages` without the full Space schema don't fail at fire
+	// time.
+	for (const name of TRIGGER_NAMES) {
+		db.exec(`DROP TRIGGER IF EXISTS ${name}`);
+	}
+	if (!haveSpaceTasks || !haveSessions || !haveNodeExec || !haveSpaceAgents) {
+		return;
+	}
+	for (const entry of TRIGGER_DDL) {
+		if (!tableExists(db, entry.attachedTo)) continue;
+		db.exec(entry.ddl);
+	}
+}

--- a/packages/daemon/src/storage/schema/m118-task-thread-projection.ts
+++ b/packages/daemon/src/storage/schema/m118-task-thread-projection.ts
@@ -21,6 +21,8 @@
  * Maintenance is via SQLite triggers (no application-level hooks needed):
  *   - sdk_messages INSERT/UPDATE/DELETE → fan-out / refresh / clear.
  *   - space_github_events INSERT/UPDATE/DELETE → github leg.
+ *   - space_tasks INSERT → project existing sdk_messages / github events when
+ *     a task is created with session linkage already present.
  *   - space_tasks UPDATE (task_agent_session_id / workflow_run_id / title)
  *     → reproject when session linkage moves.
  *   - node_executions UPDATE (agent_session_id / workflow_run_id / agent_id /
@@ -350,6 +352,7 @@ const TRIGGER_NAMES: ReadonlyArray<string> = [
 	'trg_ttm_after_insert_github',
 	'trg_ttm_after_update_github',
 	'trg_ttm_after_delete_github',
+	'trg_ttm_after_insert_space_task',
 	'trg_ttm_after_update_space_task',
 	'trg_ttm_after_delete_space_task',
 	'trg_ttm_after_update_node_exec',
@@ -596,6 +599,99 @@ ${sdkSelectColumns({
 END
 `.trim();
 
+const TRG_AFTER_INSERT_SPACE_TASK = `
+CREATE TRIGGER trg_ttm_after_insert_space_task
+AFTER INSERT ON space_tasks
+WHEN NEW.task_agent_session_id IS NOT NULL OR NEW.workflow_run_id IS NOT NULL
+BEGIN
+  -- Orchestration leg: every sdk_message in the task agent session.
+  INSERT OR IGNORE INTO task_thread_messages
+  ${projectionColumns()}
+  SELECT
+${sdkSelectColumns({
+	taskId: 'NEW.id',
+	kind: `'task_agent'`,
+	role: `'task-agent'`,
+	label: `'Task Agent'`,
+	title: 'NEW.title',
+	nodeExecId: 'NULL',
+	sessionId: 'sm.session_id',
+	messageId: 'sm.id',
+	messageType: 'sm.message_type',
+	content: 'sm.sdk_message',
+	origin: 'sm.origin',
+	timestamp: 'sm.timestamp',
+})}
+  FROM sdk_messages sm
+  JOIN sessions s ON s.id = sm.session_id
+  WHERE NEW.task_agent_session_id IS NOT NULL
+    AND sm.session_id = NEW.task_agent_session_id
+    AND s.type = 'space_task_agent'
+    AND (sm.message_type != 'user' OR COALESCE(sm.send_status, 'consumed') IN ('consumed', 'failed'));
+
+  -- Node-agent leg: every sdk_message reached via the workflow_run_id linkage.
+  INSERT OR IGNORE INTO task_thread_messages
+  ${projectionColumns()}
+  SELECT
+${sdkSelectColumns({
+	taskId: 'NEW.id',
+	kind: `'node_agent'`,
+	role: 'ne.agent_name',
+	label: `COALESCE(sa.name, ne.agent_name, 'agent')`,
+	title: 'NEW.title',
+	nodeExecId: 'ne.id',
+	sessionId: 'sm.session_id',
+	messageId: 'sm.id',
+	messageType: 'sm.message_type',
+	content: 'sm.sdk_message',
+	origin: 'sm.origin',
+	timestamp: 'sm.timestamp',
+})}
+  FROM sdk_messages sm
+  JOIN node_executions ne ON ne.agent_session_id = sm.session_id
+  LEFT JOIN space_agents sa ON sa.id = ne.agent_id
+  WHERE NEW.workflow_run_id IS NOT NULL
+    AND ne.workflow_run_id = NEW.workflow_run_id
+    AND ne.agent_session_id IS NOT NULL
+    AND (sm.message_type != 'user' OR COALESCE(sm.send_status, 'consumed') IN ('consumed', 'failed'));
+
+  -- GitHub leg: project events whose task_id maps to NEW.id.
+  INSERT OR IGNORE INTO task_thread_messages
+  ${projectionColumns()}
+  SELECT
+    NEW.id AS task_id,
+    'github' AS source,
+    ge.id AS source_id,
+    NULL AS session_id,
+    NULL AS node_execution_id,
+    'github' AS kind,
+    'github' AS role,
+    'GitHub' AS label,
+    NEW.title AS task_title,
+    'github_pr_activity' AS message_type,
+    json_object(
+      'type', 'user',
+      'uuid', ge.id,
+      'message', json_object(
+        'role', 'user',
+        'content', json_array(json_object(
+          'type', 'text',
+          'text', '[GitHub] ' || ge.summary || char(10) || ge.external_url
+        ))
+      )
+    ) AS content,
+    'system' AS origin,
+    ge.occurred_at AS created_at,
+    0 AS iteration,
+    NULL AS parent_tool_use_id,
+    0 AS is_terminal,
+    1 AS is_renderable
+  FROM space_github_events ge
+  WHERE ge.task_id = NEW.id
+    AND ge.state IN ('routed', 'delivered');
+END
+`.trim();
+
 const TRG_AFTER_DELETE_SPACE_TASK = `
 CREATE TRIGGER trg_ttm_after_delete_space_task
 AFTER DELETE ON space_tasks
@@ -788,6 +884,11 @@ const TRIGGER_DDL: ReadonlyArray<TriggerEntry> = [
 		name: 'trg_ttm_after_delete_github',
 		attachedTo: 'space_github_events',
 		ddl: TRG_AFTER_DELETE_GITHUB,
+	},
+	{
+		name: 'trg_ttm_after_insert_space_task',
+		attachedTo: 'space_tasks',
+		ddl: TRG_AFTER_INSERT_SPACE_TASK,
 	},
 	{
 		name: 'trg_ttm_after_update_space_task',

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -12,6 +12,7 @@
 import type { Database as BunDatabase } from 'bun:sqlite';
 import { runMigration94 as runMigration94External } from './m94-backfill-workflow-templates';
 import { runMigration106 as runMigration106External } from './m106-backfill-agent-templates';
+import { runMigration118External } from './m118-task-thread-projection';
 
 /**
  * Run all database migrations
@@ -555,6 +556,15 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// Migration 117: Add disabled column to space_workflows.
 	//   When true, the workflow cannot be selected for new tasks.
 	runMigration117(db);
+
+	// Migration 118: Materialise the task-thread projection used by the
+	//   `spaceTaskMessages.byTask` and `.compact` LiveQuery feeds.
+	//   Adds the `task_thread_messages` table, supporting indexes, and the
+	//   trigger network that keeps it in sync with `sdk_messages`,
+	//   `space_github_events`, `space_tasks`, and `node_executions`.
+	//   Backfills any pre-existing rows so subscribers see consistent state
+	//   immediately after upgrade.
+	runMigration118(db);
 }
 
 /**
@@ -7968,4 +7978,13 @@ export function runMigration117(db: BunDatabase): void {
 	if (columns.includes('disabled')) return;
 
 	db.exec(`ALTER TABLE space_workflows ADD COLUMN disabled INTEGER NOT NULL DEFAULT 0`);
+}
+
+/**
+ * Migration 118 — delegated to m118-task-thread-projection.ts so the
+ * (large) trigger DDL doesn't bloat this file. The behaviour is documented
+ * in that module. Exported for direct invocation from tests.
+ */
+export function runMigration118(db: BunDatabase): void {
+	runMigration118External(db);
 }

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
@@ -1927,10 +1927,11 @@ describe('NAMED_QUERY_REGISTRY', () => {
 					.replace(/\s+LIMIT\s+\?(\s+OFFSET\s+\?)?/, '')
 					.replace(/\s+/g, ' ')
 					.trim();
-				// Must end with either `id ASC|DESC` or `projId ASC|DESC` (tiebreaker).
-				// `projId` is the autoincrement key on `task_thread_messages` introduced
-				// in migration 118 — same purpose as a plain `id`, just monotonic.
-				const hasIdTiebreaker = /(?:\bID|PROJID)\s+(ASC|DESC)\s*$/.test(sqlForCheck);
+				// Must end with `id ASC|DESC` (tiebreaker). The `id` here is the
+				// immutable `source_id` from the original message table, not the
+				// autoincrement `proj_id`, so reinsertions by triggers (delete+insert
+				// on sdk_messages UPDATE) never shift turn boundaries.
+				const hasIdTiebreaker = /\bID\s+(ASC|DESC)\s*$/.test(sqlForCheck);
 				expect(hasIdTiebreaker).toBe(true, `${name} ORDER BY lacks deterministic id tiebreaker`);
 			}
 		});

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
@@ -11,7 +11,12 @@
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { Database as BunDatabase } from 'bun:sqlite';
-import { createTables, runMigration74, runMigrations } from '../../../../src/storage/schema';
+import {
+	createTables,
+	runMigration74,
+	runMigration118,
+	runMigrations,
+} from '../../../../src/storage/schema';
 import { NAMED_QUERY_REGISTRY } from '../../../../src/lib/rpc-handlers/live-query-handlers';
 import type { NeoTask, RoomGoal } from '@neokai/shared';
 
@@ -229,6 +234,11 @@ describe('NAMED_QUERY_REGISTRY', () => {
 				`INSERT OR IGNORE INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
 				 VALUES ('${spaceId}', '${spaceId}', '/tmp/test-space', 'Test Space', ${now}, ${now})`
 			);
+			// Install the task-thread projection (migration 118). The spaceTaskMessages.byTask*
+			// queries read from `task_thread_messages`, populated by triggers on
+			// `sdk_messages` / `space_github_events` / `space_tasks` / `node_executions`.
+			// Must run AFTER the custom space_tasks / space_agents tables are declared.
+			runMigration118(db);
 		});
 
 		function insertSpaceTask(overrides: Record<string, unknown> = {}): string {
@@ -1917,8 +1927,10 @@ describe('NAMED_QUERY_REGISTRY', () => {
 					.replace(/\s+LIMIT\s+\?(\s+OFFSET\s+\?)?/, '')
 					.replace(/\s+/g, ' ')
 					.trim();
-				// Must end with either `id ASC` or `id DESC` (tiebreaker)
-				const hasIdTiebreaker = /\bID\s+(ASC|DESC)\s*$/.test(sqlForCheck);
+				// Must end with either `id ASC|DESC` or `projId ASC|DESC` (tiebreaker).
+				// `projId` is the autoincrement key on `task_thread_messages` introduced
+				// in migration 118 — same purpose as a plain `id`, just monotonic.
+				const hasIdTiebreaker = /(?:\bID|PROJID)\s+(ASC|DESC)\s*$/.test(sqlForCheck);
 				expect(hasIdTiebreaker).toBe(true, `${name} ORDER BY lacks deterministic id tiebreaker`);
 			}
 		});

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-118_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-118_test.ts
@@ -243,6 +243,7 @@ describe('Migration 118 — task_thread_messages projection', () => {
 		expect(triggerExists(db, 'trg_ttm_after_insert_github')).toBe(true);
 		expect(triggerExists(db, 'trg_ttm_after_update_github')).toBe(true);
 		expect(triggerExists(db, 'trg_ttm_after_delete_github')).toBe(true);
+		expect(triggerExists(db, 'trg_ttm_after_insert_space_task')).toBe(true);
 		expect(triggerExists(db, 'trg_ttm_after_update_space_task')).toBe(true);
 		expect(triggerExists(db, 'trg_ttm_after_delete_space_task')).toBe(true);
 		expect(triggerExists(db, 'trg_ttm_after_insert_node_exec')).toBe(true);
@@ -793,6 +794,67 @@ describe('Migration 118 — task_thread_messages projection', () => {
 
 		const rows = readProjection(db, taskId);
 		expect(rows[0].iteration).toBe(0);
+	});
+
+	// -------------------------------------------------------------------------
+	// space_tasks INSERT — project existing history when linkage is present
+	// -------------------------------------------------------------------------
+
+	test('space_tasks INSERT projects existing sdk_messages when task_agent_session_id is set', () => {
+		const sessionId = 'session-insert-task';
+		const taskId = 'task-insert-task';
+
+		insertSession(db, sessionId, 'space_task_agent', isoNow);
+		runMigration118(db);
+
+		// Messages exist before the task is created.
+		insertSdkMessage(db, { id: 'pre-msg-1', sessionId, isoNow });
+		insertSdkMessage(db, { id: 'pre-msg-2', sessionId, isoNow });
+
+		// Create the task with session linkage already present.
+		insertSpaceTask(db, { id: taskId, title: 'Insert', taskAgentSessionId: sessionId, now });
+
+		const rows = readProjection(db, taskId);
+		expect(rows).toHaveLength(2);
+		expect(rows.map((r) => r.source_id).sort()).toEqual(['pre-msg-1', 'pre-msg-2']);
+	});
+
+	test('space_tasks INSERT projects existing node-agent messages when workflow_run_id is set', () => {
+		const orchSessionId = 'orch-session-insert-task';
+		const nodeSessionId = 'node-session-insert-task';
+		const workflowRunId = 'wr-insert-task';
+		const taskId = 'task-insert-wr';
+
+		insertSession(db, orchSessionId, 'space_task_agent', isoNow);
+		insertSession(db, nodeSessionId, 'space_task_agent', isoNow);
+		runMigration118(db);
+
+		// Pre-stage a node_execution and messages before the task exists.
+		db.exec(`
+			INSERT INTO node_executions (
+				id, workflow_run_id, workflow_node_id, agent_name, agent_id,
+				agent_session_id, status, result, created_at, started_at,
+				completed_at, updated_at
+			) VALUES (
+				'ne-insert', '${workflowRunId}', 'node-1', 'coder', NULL,
+				'${nodeSessionId}', 'in_progress', NULL, ${now}, ${now}, NULL, ${now}
+			)
+		`);
+		insertSdkMessage(db, { id: 'node-pre-msg', sessionId: nodeSessionId, isoNow });
+
+		// Create the task with workflow_run_id already present.
+		insertSpaceTask(db, {
+			id: taskId,
+			title: 'Insert WR',
+			taskAgentSessionId: orchSessionId,
+			workflowRunId,
+			now,
+		});
+
+		const rows = readProjection(db, taskId);
+		const nodeRows = rows.filter((r) => r.kind === 'node_agent');
+		expect(nodeRows).toHaveLength(1);
+		expect(nodeRows[0].source_id).toBe('node-pre-msg');
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-118_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-118_test.ts
@@ -1,0 +1,656 @@
+/**
+ * Migration 118 Tests — Task-thread message projection.
+ *
+ * Migration 118 introduces a materialised projection table
+ * `task_thread_messages` keyed on `(task_id, source, source_id)` that pre-
+ * computes the per-task timeline used by the
+ * `spaceTaskMessages.byTask` and `spaceTaskMessages.byTask.compact` LiveQuery
+ * feeds. Triggers fan out source-table writes (sdk_messages,
+ * space_github_events, node_executions, space_tasks) into the projection so
+ * reads become a single indexed scan.
+ *
+ * Covers:
+ *   - Table + indexes are created.
+ *   - Backfill correctly projects pre-existing sdk_messages for orchestration
+ *     and node-agent legs.
+ *   - Backfill projects pre-existing space_github_events (only for routed/
+ *     delivered events).
+ *   - Re-running the migration is a no-op (idempotent).
+ *   - INSERT trigger fans new sdk_messages into the projection.
+ *   - DELETE trigger clears projection rows when sdk_messages are removed
+ *     (rewind/replay path).
+ *   - UPDATE trigger refreshes projection content when an sdk_message row is
+ *     modified.
+ *   - node_executions UPDATE trigger projects messages once the node binds to
+ *     a session (agent_session_id flips from NULL).
+ *   - space_tasks DELETE trigger cascades projection cleanup.
+ *   - User rows in `deferred` send_status are excluded from the projection
+ *     (the historic compact-feed visibility predicate).
+ *   - The `is_renderable` flag is computed correctly for tool_result-only
+ *     user rows and empty assistant rows.
+ *   - The `is_terminal` flag is set on result rows.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { createTables, runMigration74 } from '../../../../../src/storage/schema/index.ts';
+import { runMigration118 } from '../../../../../src/storage/schema/migrations.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tableExists(db: BunDatabase, name: string): boolean {
+	return !!db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`).get(name);
+}
+
+function indexExists(db: BunDatabase, name: string): boolean {
+	return !!db.prepare(`SELECT name FROM sqlite_master WHERE type='index' AND name=?`).get(name);
+}
+
+function triggerExists(db: BunDatabase, name: string): boolean {
+	return !!db.prepare(`SELECT name FROM sqlite_master WHERE type='trigger' AND name=?`).get(name);
+}
+
+function setupSpaceTables(db: BunDatabase, now: number): void {
+	// `space_github_events` is created by `createTables`. We only need to add
+	// the Space-side tables (spaces, space_agents, space_tasks) the migration's
+	// triggers reference.
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS spaces (
+			id TEXT PRIMARY KEY,
+			slug TEXT,
+			workspace_path TEXT NOT NULL,
+			name TEXT NOT NULL,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS space_agents (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			name TEXT NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS space_tasks (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			task_number INTEGER NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL,
+			status TEXT NOT NULL,
+			priority TEXT NOT NULL,
+			assigned_agent TEXT,
+			custom_agent_id TEXT,
+			agent_name TEXT,
+			completion_summary TEXT,
+			workflow_run_id TEXT,
+			workflow_node_id TEXT,
+			task_agent_session_id TEXT,
+			depends_on TEXT NOT NULL DEFAULT '[]',
+			current_step TEXT,
+			error TEXT,
+			result TEXT,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		);
+	`);
+	db.exec(
+		`INSERT OR IGNORE INTO spaces (id, slug, workspace_path, name, created_at, updated_at)
+		 VALUES ('s1', 's1', '/tmp/test-117', 'Test', ${now}, ${now})`
+	);
+}
+
+function insertSession(db: BunDatabase, id: string, type: string, isoNow: string): void {
+	db.exec(`
+		INSERT INTO sessions (
+			id, title, workspace_path, created_at, last_active_at, status, config, metadata,
+			is_worktree, worktree_path, main_repo_path, worktree_branch, git_branch, sdk_session_id,
+			available_commands, processing_state, archived_at, type, session_context
+		) VALUES (
+			'${id}', 'Session', '/tmp/test-117', '${isoNow}', '${isoNow}', 'active', '{}', '{}',
+			0, NULL, NULL, NULL, NULL, NULL, NULL, '{}', NULL, '${type}', '{}'
+		)
+	`);
+}
+
+function insertSpaceTask(
+	db: BunDatabase,
+	opts: {
+		id: string;
+		title: string;
+		taskAgentSessionId?: string | null;
+		workflowRunId?: string | null;
+		now: number;
+	}
+): void {
+	db.exec(`
+		INSERT INTO space_tasks (
+			id, space_id, task_number, title, description, status, priority, assigned_agent,
+			agent_name, workflow_run_id, workflow_node_id, task_agent_session_id, depends_on,
+			created_at, updated_at
+		) VALUES (
+			'${opts.id}', 's1', 1, '${opts.title}', 'Desc', 'in_progress', 'normal', 'coder',
+			NULL,
+			${opts.workflowRunId ? `'${opts.workflowRunId}'` : 'NULL'},
+			NULL,
+			${opts.taskAgentSessionId ? `'${opts.taskAgentSessionId}'` : 'NULL'},
+			'[]', ${opts.now}, ${opts.now}
+		)
+	`);
+}
+
+function insertSdkMessage(
+	db: BunDatabase,
+	opts: {
+		id: string;
+		sessionId: string;
+		messageType?: string;
+		payload?: Record<string, unknown>;
+		isoNow: string;
+		sendStatus?: string;
+	}
+): void {
+	const messageType = opts.messageType ?? 'assistant';
+	const payload =
+		opts.payload ??
+		({
+			type: 'assistant',
+			uuid: opts.id,
+			message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+		} as Record<string, unknown>);
+	const sendStatus = opts.sendStatus ?? 'consumed';
+	db.exec(`
+		INSERT INTO sdk_messages (
+			id, session_id, message_type, message_subtype, sdk_message, timestamp, send_status, origin
+		) VALUES (
+			'${opts.id}', '${opts.sessionId}', '${messageType}', NULL,
+			'${JSON.stringify(payload).replace(/'/g, "''")}',
+			'${opts.isoNow}', '${sendStatus}', 'system'
+		)
+	`);
+}
+
+interface ProjRow {
+	task_id: string;
+	source: string;
+	source_id: string;
+	session_id: string | null;
+	node_execution_id: string | null;
+	kind: string;
+	role: string;
+	label: string;
+	task_title: string;
+	message_type: string;
+	is_terminal: number;
+	is_renderable: number;
+	iteration: number;
+}
+
+function readProjection(db: BunDatabase, taskId: string): ProjRow[] {
+	return db
+		.prepare(
+			`SELECT task_id, source, source_id, session_id, node_execution_id, kind, role,
+			        label, task_title, message_type, is_terminal, is_renderable, iteration
+			   FROM task_thread_messages
+			  WHERE task_id = ?
+			  ORDER BY proj_id ASC`
+		)
+		.all(taskId) as ProjRow[];
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('Migration 118 — task_thread_messages projection', () => {
+	let db: BunDatabase;
+	const now = Date.now();
+	const isoNow = new Date(now).toISOString();
+
+	beforeEach(() => {
+		db = new BunDatabase(':memory:');
+		createTables(db);
+		runMigration74(db);
+		setupSpaceTables(db, now);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	// -------------------------------------------------------------------------
+	// Schema creation
+	// -------------------------------------------------------------------------
+
+	test('creates task_thread_messages table', () => {
+		expect(tableExists(db, 'task_thread_messages')).toBe(false);
+		runMigration118(db);
+		expect(tableExists(db, 'task_thread_messages')).toBe(true);
+	});
+
+	test('creates expected indexes', () => {
+		runMigration118(db);
+		expect(indexExists(db, 'idx_ttm_task_created')).toBe(true);
+		expect(indexExists(db, 'idx_ttm_task_session_created')).toBe(true);
+		expect(indexExists(db, 'idx_ttm_session_created')).toBe(true);
+		expect(indexExists(db, 'idx_ttm_source')).toBe(true);
+	});
+
+	test('creates expected triggers when full schema is present', () => {
+		runMigration118(db);
+		expect(triggerExists(db, 'trg_ttm_after_insert_sdk')).toBe(true);
+		expect(triggerExists(db, 'trg_ttm_after_update_sdk')).toBe(true);
+		expect(triggerExists(db, 'trg_ttm_after_delete_sdk')).toBe(true);
+		expect(triggerExists(db, 'trg_ttm_after_insert_github')).toBe(true);
+		expect(triggerExists(db, 'trg_ttm_after_update_github')).toBe(true);
+		expect(triggerExists(db, 'trg_ttm_after_delete_github')).toBe(true);
+		expect(triggerExists(db, 'trg_ttm_after_update_space_task')).toBe(true);
+		expect(triggerExists(db, 'trg_ttm_after_delete_space_task')).toBe(true);
+		expect(triggerExists(db, 'trg_ttm_after_insert_node_exec')).toBe(true);
+		expect(triggerExists(db, 'trg_ttm_after_update_node_exec')).toBe(true);
+		expect(triggerExists(db, 'trg_ttm_after_delete_node_exec')).toBe(true);
+	});
+
+	test('skips trigger creation when space_tasks is missing (partial schema)', () => {
+		db.close();
+		db = new BunDatabase(':memory:');
+		createTables(db);
+		runMigration74(db);
+		// Don't call setupSpaceTables — space_tasks is absent
+		runMigration118(db);
+		// Table should be created but triggers should be skipped
+		expect(tableExists(db, 'task_thread_messages')).toBe(true);
+		expect(triggerExists(db, 'trg_ttm_after_insert_sdk')).toBe(false);
+	});
+
+	test('idempotent — re-running the migration is a no-op', () => {
+		runMigration118(db);
+		expect(() => runMigration118(db)).not.toThrow();
+		expect(tableExists(db, 'task_thread_messages')).toBe(true);
+	});
+
+	// -------------------------------------------------------------------------
+	// Backfill — orchestration leg (task_agent_session_id)
+	// -------------------------------------------------------------------------
+
+	test('backfill projects orchestration sdk_messages for an existing task', () => {
+		const sessionId = 'session-orch-1';
+		const taskId = 'task-1';
+
+		insertSession(db, sessionId, 'space_task_agent', isoNow);
+		insertSpaceTask(db, { id: taskId, title: 'Build it', taskAgentSessionId: sessionId, now });
+		insertSdkMessage(db, { id: 'sdk-1', sessionId, isoNow });
+		insertSdkMessage(db, { id: 'sdk-2', sessionId, isoNow });
+
+		runMigration118(db);
+
+		const rows = readProjection(db, taskId);
+		expect(rows).toHaveLength(2);
+		expect(rows[0].task_id).toBe(taskId);
+		expect(rows[0].kind).toBe('task_agent');
+		expect(rows[0].label).toBe('Task Agent');
+		expect(rows[0].task_title).toBe('Build it');
+		expect(rows[0].source).toBe('sdk');
+	});
+
+	test('backfill skips deferred user messages (send_status = "deferred")', () => {
+		const sessionId = 'session-deferred-1';
+		const taskId = 'task-def';
+
+		insertSession(db, sessionId, 'space_task_agent', isoNow);
+		insertSpaceTask(db, { id: taskId, title: 'Wait', taskAgentSessionId: sessionId, now });
+		insertSdkMessage(db, {
+			id: 'user-deferred',
+			sessionId,
+			isoNow,
+			messageType: 'user',
+			payload: {
+				type: 'user',
+				uuid: 'user-deferred',
+				message: { role: 'user', content: 'Pending input' },
+			},
+			sendStatus: 'deferred',
+		});
+
+		runMigration118(db);
+
+		const rows = readProjection(db, taskId);
+		expect(rows).toHaveLength(0);
+	});
+
+	test('backfill projects github events with state in (routed, delivered)', () => {
+		const taskId = 'task-gh';
+		insertSpaceTask(db, { id: taskId, title: 'PR review', now });
+		const baseGhCols = `id, space_id, task_id, source, delivery_id, event_type, action,
+			repo_owner, repo_name, pr_number, pr_url, actor, actor_type, body, summary,
+			external_url, external_id, occurred_at, dedupe_key, raw_payload, state,
+			created_at, updated_at`;
+		const ghValues = (id: string, state: string, summary: string, occurredAt: number): string =>
+			`('${id}', 's1', '${taskId}', 'webhook', '${id}', 'pull_request', 'opened',
+			  'org', 'r', 1, 'https://example/${id}', 'bot', 'User',
+			  '', '${summary}', 'https://example/${id}', '${id}', ${occurredAt}, '${id}',
+			  '{}', '${state}', ${now}, ${now})`;
+		db.exec(`
+			INSERT INTO space_github_events (${baseGhCols}) VALUES
+				${ghValues('gh-pending', 'received', 'Pending', now + 10)},
+				${ghValues('gh-routed', 'routed', 'Routed event', now + 20)},
+				${ghValues('gh-delivered', 'delivered', 'Delivered event', now + 30)}
+		`);
+
+		runMigration118(db);
+
+		const rows = readProjection(db, taskId);
+		expect(rows.map((r) => r.source_id).sort()).toEqual(['gh-delivered', 'gh-routed']);
+		expect(rows.every((r) => r.kind === 'github')).toBe(true);
+	});
+
+	// -------------------------------------------------------------------------
+	// INSERT trigger
+	// -------------------------------------------------------------------------
+
+	test('AFTER INSERT trigger projects new sdk_messages into the projection', () => {
+		const sessionId = 'session-insert-1';
+		const taskId = 'task-ins';
+
+		insertSession(db, sessionId, 'space_task_agent', isoNow);
+		insertSpaceTask(db, { id: taskId, title: 'Trig insert', taskAgentSessionId: sessionId, now });
+
+		runMigration118(db);
+		expect(readProjection(db, taskId)).toHaveLength(0);
+
+		insertSdkMessage(db, { id: 'live-1', sessionId, isoNow });
+		insertSdkMessage(db, { id: 'live-2', sessionId, isoNow });
+
+		const rows = readProjection(db, taskId);
+		expect(rows).toHaveLength(2);
+		expect(rows.map((r) => r.source_id).sort()).toEqual(['live-1', 'live-2']);
+	});
+
+	test('AFTER INSERT trigger excludes deferred user rows', () => {
+		const sessionId = 'session-insert-deferred';
+		const taskId = 'task-ins-def';
+
+		insertSession(db, sessionId, 'space_task_agent', isoNow);
+		insertSpaceTask(db, { id: taskId, title: 't', taskAgentSessionId: sessionId, now });
+		runMigration118(db);
+
+		insertSdkMessage(db, {
+			id: 'user-pending',
+			sessionId,
+			isoNow,
+			messageType: 'user',
+			payload: { type: 'user', uuid: 'user-pending', message: { role: 'user', content: 'Hi' } },
+			sendStatus: 'deferred',
+		});
+
+		expect(readProjection(db, taskId)).toHaveLength(0);
+	});
+
+	// -------------------------------------------------------------------------
+	// DELETE trigger
+	// -------------------------------------------------------------------------
+
+	test('AFTER DELETE trigger removes projection rows for deleted sdk_messages', () => {
+		const sessionId = 'session-delete-1';
+		const taskId = 'task-del';
+
+		insertSession(db, sessionId, 'space_task_agent', isoNow);
+		insertSpaceTask(db, { id: taskId, title: 'Wipe', taskAgentSessionId: sessionId, now });
+		runMigration118(db);
+
+		insertSdkMessage(db, { id: 'rm-1', sessionId, isoNow });
+		insertSdkMessage(db, { id: 'rm-2', sessionId, isoNow });
+		expect(readProjection(db, taskId)).toHaveLength(2);
+
+		db.exec(`DELETE FROM sdk_messages WHERE id = 'rm-1'`);
+		const remaining = readProjection(db, taskId);
+		expect(remaining).toHaveLength(1);
+		expect(remaining[0].source_id).toBe('rm-2');
+	});
+
+	// -------------------------------------------------------------------------
+	// UPDATE trigger
+	// -------------------------------------------------------------------------
+
+	test('AFTER UPDATE trigger reflects changes in projection content', () => {
+		const sessionId = 'session-update-1';
+		const taskId = 'task-upd';
+
+		insertSession(db, sessionId, 'space_task_agent', isoNow);
+		insertSpaceTask(db, { id: taskId, title: 'Mutating', taskAgentSessionId: sessionId, now });
+		runMigration118(db);
+
+		insertSdkMessage(db, {
+			id: 'mut-1',
+			sessionId,
+			isoNow,
+			messageType: 'user',
+			payload: { type: 'user', uuid: 'mut-1', message: { role: 'user', content: 'pending' } },
+			sendStatus: 'deferred',
+		});
+		// Deferred row is filtered out
+		expect(readProjection(db, taskId)).toHaveLength(0);
+
+		// Promote to consumed — UPDATE trigger should re-project
+		db.exec(`UPDATE sdk_messages SET send_status = 'consumed' WHERE id = 'mut-1'`);
+		const rows = readProjection(db, taskId);
+		expect(rows).toHaveLength(1);
+		expect(rows[0].source_id).toBe('mut-1');
+	});
+
+	// -------------------------------------------------------------------------
+	// node_executions trigger — late session binding
+	// -------------------------------------------------------------------------
+
+	test('node_executions trigger projects messages once agent_session_id is set', () => {
+		const orchSessionId = 'orch-session-node';
+		const nodeSessionId = 'node-session-node';
+		const workflowRunId = 'wr-node-1';
+		const taskId = 'task-node-1';
+
+		insertSession(db, orchSessionId, 'space_task_agent', isoNow);
+		insertSession(db, nodeSessionId, 'space_task_agent', isoNow);
+		insertSpaceTask(db, {
+			id: taskId,
+			title: 'Coder leg',
+			taskAgentSessionId: orchSessionId,
+			workflowRunId,
+			now,
+		});
+		runMigration118(db);
+
+		// Insert a node_execution without agent_session_id first; no projection yet.
+		db.exec(`
+			INSERT INTO node_executions (
+				id, workflow_run_id, workflow_node_id, agent_name, agent_id,
+				agent_session_id, status, result, created_at, started_at,
+				completed_at, updated_at
+			) VALUES (
+				'ne-late', '${workflowRunId}', 'node-1', 'coder', NULL,
+				NULL, 'pending', NULL, ${now}, NULL, NULL, ${now}
+			)
+		`);
+
+		// Pre-existing messages on the node session are projected through the
+		// orchestration leg only (none here) — node leg waits for the binding.
+		insertSdkMessage(db, { id: 'node-msg-1', sessionId: nodeSessionId, isoNow });
+		expect(readProjection(db, taskId)).toHaveLength(0);
+
+		// Now bind the node execution to the session — UPDATE trigger should
+		// project the node-leg messages.
+		db.exec(
+			`UPDATE node_executions SET agent_session_id = '${nodeSessionId}' WHERE id = 'ne-late'`
+		);
+
+		const rows = readProjection(db, taskId);
+		expect(rows).toHaveLength(1);
+		expect(rows[0].kind).toBe('node_agent');
+		expect(rows[0].source_id).toBe('node-msg-1');
+		expect(rows[0].node_execution_id).toBe('ne-late');
+	});
+
+	// -------------------------------------------------------------------------
+	// space_tasks DELETE trigger
+	// -------------------------------------------------------------------------
+
+	test('space_tasks DELETE trigger cascades projection cleanup', () => {
+		const sessionId = 'session-task-del';
+		const taskId = 'task-killme';
+
+		insertSession(db, sessionId, 'space_task_agent', isoNow);
+		insertSpaceTask(db, { id: taskId, title: 'Soon dead', taskAgentSessionId: sessionId, now });
+		runMigration118(db);
+
+		insertSdkMessage(db, { id: 'die-1', sessionId, isoNow });
+		insertSdkMessage(db, { id: 'die-2', sessionId, isoNow });
+		expect(readProjection(db, taskId)).toHaveLength(2);
+
+		db.exec(`DELETE FROM space_tasks WHERE id = '${taskId}'`);
+		expect(readProjection(db, taskId)).toHaveLength(0);
+	});
+
+	// -------------------------------------------------------------------------
+	// is_terminal / is_renderable derivation
+	// -------------------------------------------------------------------------
+
+	test('is_terminal flag is set on result rows', () => {
+		const sessionId = 'session-terminal';
+		const taskId = 'task-term';
+
+		insertSession(db, sessionId, 'space_task_agent', isoNow);
+		insertSpaceTask(db, { id: taskId, title: 'Terminal', taskAgentSessionId: sessionId, now });
+		runMigration118(db);
+
+		insertSdkMessage(db, { id: 'asst-1', sessionId, isoNow });
+		insertSdkMessage(db, {
+			id: 'res-1',
+			sessionId,
+			isoNow,
+			messageType: 'result',
+			payload: {
+				type: 'result',
+				uuid: 'res-1',
+				subtype: 'success',
+				duration_ms: 1,
+				duration_api_ms: 1,
+				is_error: false,
+				total_cost_usd: 0,
+			},
+		});
+
+		const rows = readProjection(db, taskId);
+		const asst = rows.find((r) => r.source_id === 'asst-1')!;
+		const res = rows.find((r) => r.source_id === 'res-1')!;
+		expect(asst.is_terminal).toBe(0);
+		expect(res.is_terminal).toBe(1);
+	});
+
+	test('is_renderable = 0 for user rows that are exclusively tool_result blocks', () => {
+		const sessionId = 'session-render';
+		const taskId = 'task-render';
+
+		insertSession(db, sessionId, 'space_task_agent', isoNow);
+		insertSpaceTask(db, { id: taskId, title: 'Render', taskAgentSessionId: sessionId, now });
+		runMigration118(db);
+
+		insertSdkMessage(db, {
+			id: 'tool-result-only',
+			sessionId,
+			isoNow,
+			messageType: 'user',
+			payload: {
+				type: 'user',
+				uuid: 'tool-result-only',
+				message: {
+					role: 'user',
+					content: [{ type: 'tool_result', tool_use_id: 't1', content: 'output' }],
+				},
+			},
+		});
+
+		const rows = readProjection(db, taskId);
+		expect(rows).toHaveLength(1);
+		expect(rows[0].is_renderable).toBe(0);
+	});
+
+	test('is_renderable = 1 for normal assistant/text rows', () => {
+		const sessionId = 'session-render-2';
+		const taskId = 'task-render-2';
+
+		insertSession(db, sessionId, 'space_task_agent', isoNow);
+		insertSpaceTask(db, { id: taskId, title: 'Render2', taskAgentSessionId: sessionId, now });
+		runMigration118(db);
+
+		insertSdkMessage(db, { id: 'asst-render', sessionId, isoNow });
+
+		const rows = readProjection(db, taskId);
+		expect(rows).toHaveLength(1);
+		expect(rows[0].is_renderable).toBe(1);
+	});
+
+	test('iteration is extracted from _taskMeta.iteration in payload', () => {
+		const sessionId = 'session-iter';
+		const taskId = 'task-iter';
+
+		insertSession(db, sessionId, 'space_task_agent', isoNow);
+		insertSpaceTask(db, { id: taskId, title: 'Iter', taskAgentSessionId: sessionId, now });
+		runMigration118(db);
+
+		insertSdkMessage(db, {
+			id: 'iter-1',
+			sessionId,
+			isoNow,
+			payload: {
+				type: 'assistant',
+				uuid: 'iter-1',
+				message: { role: 'assistant', content: [{ type: 'text', text: 'go' }] },
+				_taskMeta: { iteration: 7 },
+			},
+		});
+
+		const rows = readProjection(db, taskId);
+		expect(rows[0].iteration).toBe(7);
+	});
+
+	test('iteration defaults to 0 when _taskMeta.iteration is absent', () => {
+		const sessionId = 'session-iter-default';
+		const taskId = 'task-iter-default';
+
+		insertSession(db, sessionId, 'space_task_agent', isoNow);
+		insertSpaceTask(db, { id: taskId, title: 'IterDef', taskAgentSessionId: sessionId, now });
+		runMigration118(db);
+
+		insertSdkMessage(db, { id: 'plain', sessionId, isoNow });
+
+		const rows = readProjection(db, taskId);
+		expect(rows[0].iteration).toBe(0);
+	});
+
+	// -------------------------------------------------------------------------
+	// space_tasks UPDATE — session re-linking
+	// -------------------------------------------------------------------------
+
+	test('space_tasks UPDATE re-projects when task_agent_session_id changes', () => {
+		const sessionA = 'session-a';
+		const sessionB = 'session-b';
+		const taskId = 'task-relink';
+
+		insertSession(db, sessionA, 'space_task_agent', isoNow);
+		insertSession(db, sessionB, 'space_task_agent', isoNow);
+		insertSpaceTask(db, { id: taskId, title: 'Relink', taskAgentSessionId: sessionA, now });
+		runMigration118(db);
+
+		insertSdkMessage(db, { id: 'a-msg', sessionId: sessionA, isoNow });
+		insertSdkMessage(db, { id: 'b-msg', sessionId: sessionB, isoNow });
+
+		// Initially only sessionA messages are projected
+		let rows = readProjection(db, taskId);
+		expect(rows).toHaveLength(1);
+		expect(rows[0].source_id).toBe('a-msg');
+
+		// Re-link the task to sessionB
+		db.exec(`UPDATE space_tasks SET task_agent_session_id = '${sessionB}' WHERE id = '${taskId}'`);
+		rows = readProjection(db, taskId);
+		expect(rows).toHaveLength(1);
+		expect(rows[0].source_id).toBe('b-msg');
+	});
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-118_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-118_test.ts
@@ -248,6 +248,7 @@ describe('Migration 118 — task_thread_messages projection', () => {
 		expect(triggerExists(db, 'trg_ttm_after_insert_node_exec')).toBe(true);
 		expect(triggerExists(db, 'trg_ttm_after_update_node_exec')).toBe(true);
 		expect(triggerExists(db, 'trg_ttm_after_delete_node_exec')).toBe(true);
+		expect(triggerExists(db, 'trg_ttm_after_update_space_agent')).toBe(true);
 	});
 
 	test('skips trigger creation when space_tasks is missing (partial schema)', () => {
@@ -489,6 +490,103 @@ describe('Migration 118 — task_thread_messages projection', () => {
 	});
 
 	// -------------------------------------------------------------------------
+	// node_executions DELETE — re-project when session is shared
+	// -------------------------------------------------------------------------
+
+	test('node_executions DELETE re-projects rows from a surviving execution sharing the session', () => {
+		const orchSessionId = 'orch-session-share';
+		const sharedSessionId = 'shared-node-session';
+		const workflowRunId = 'wr-share-1';
+		const taskId = 'task-share-1';
+
+		insertSession(db, orchSessionId, 'space_task_agent', isoNow);
+		insertSession(db, sharedSessionId, 'space_task_agent', isoNow);
+		insertSpaceTask(db, {
+			id: taskId,
+			title: 'Reused-session task',
+			taskAgentSessionId: orchSessionId,
+			workflowRunId,
+			now,
+		});
+		runMigration118(db);
+
+		// First execution claims the session and projects messages.
+		// TaskAgentManager re-uses the same agent_session_id across executions
+		// for a named agent — see task-agent-manager.ts createSubSession reuse
+		// path. We model that here with two node_executions pointing at the same
+		// session id.
+		db.exec(`
+			INSERT INTO node_executions (
+				id, workflow_run_id, workflow_node_id, agent_name, agent_id,
+				agent_session_id, status, result, created_at, started_at,
+				completed_at, updated_at
+			) VALUES
+			('ne-1', '${workflowRunId}', 'node-1', 'coder', NULL,
+				'${sharedSessionId}', 'done', NULL, ${now}, ${now}, ${now}, ${now}),
+			('ne-2', '${workflowRunId}', 'node-1', 'coder', NULL,
+				'${sharedSessionId}', 'in_progress', NULL, ${now + 1}, ${now + 1}, NULL, ${now + 1})
+		`);
+
+		insertSdkMessage(db, { id: 'shared-msg-1', sessionId: sharedSessionId, isoNow });
+		insertSdkMessage(db, { id: 'shared-msg-2', sessionId: sharedSessionId, isoNow });
+
+		// First-insert wins on (task_id, source, source_id) — both rows are
+		// attributed to whichever node_execution was created first (ne-1).
+		const beforeDelete = readProjection(db, taskId);
+		expect(beforeDelete).toHaveLength(2);
+		expect(beforeDelete.every((r) => r.node_execution_id === 'ne-1')).toBe(true);
+
+		// Delete ne-1 — naive trigger would orphan both messages even though
+		// ne-2 still references the same session. With the re-projection step,
+		// the rows survive but are now attributed to ne-2.
+		db.exec(`DELETE FROM node_executions WHERE id = 'ne-1'`);
+
+		const afterDelete = readProjection(db, taskId);
+		expect(afterDelete).toHaveLength(2);
+		expect(afterDelete.every((r) => r.node_execution_id === 'ne-2')).toBe(true);
+		const sourceIds = afterDelete.map((r) => r.source_id).sort();
+		expect(sourceIds).toEqual(['shared-msg-1', 'shared-msg-2']);
+	});
+
+	test('node_executions DELETE drops rows when no surviving execution shares the session', () => {
+		const orchSessionId = 'orch-session-solo';
+		const soloSessionId = 'solo-node-session';
+		const workflowRunId = 'wr-solo-1';
+		const taskId = 'task-solo-1';
+
+		insertSession(db, orchSessionId, 'space_task_agent', isoNow);
+		insertSession(db, soloSessionId, 'space_task_agent', isoNow);
+		insertSpaceTask(db, {
+			id: taskId,
+			title: 'Single-execution task',
+			taskAgentSessionId: orchSessionId,
+			workflowRunId,
+			now,
+		});
+		runMigration118(db);
+
+		db.exec(`
+			INSERT INTO node_executions (
+				id, workflow_run_id, workflow_node_id, agent_name, agent_id,
+				agent_session_id, status, result, created_at, started_at,
+				completed_at, updated_at
+			) VALUES
+			('ne-solo', '${workflowRunId}', 'node-1', 'coder', NULL,
+				'${soloSessionId}', 'done', NULL, ${now}, ${now}, ${now}, ${now})
+		`);
+
+		insertSdkMessage(db, { id: 'solo-msg-1', sessionId: soloSessionId, isoNow });
+		expect(readProjection(db, taskId)).toHaveLength(1);
+
+		db.exec(`DELETE FROM node_executions WHERE id = 'ne-solo'`);
+
+		// No surviving execution → re-projection finds no source row, so the
+		// projection ends up empty. (Hard-delete is the right behaviour when
+		// nothing else owns the session.)
+		expect(readProjection(db, taskId)).toHaveLength(0);
+	});
+
+	// -------------------------------------------------------------------------
 	// space_tasks DELETE trigger
 	// -------------------------------------------------------------------------
 
@@ -572,6 +670,37 @@ describe('Migration 118 — task_thread_messages projection', () => {
 		expect(rows[0].is_renderable).toBe(0);
 	});
 
+	test('is_renderable = 1 for user rows with mixed tool_result + text blocks', () => {
+		const sessionId = 'session-render-mix';
+		const taskId = 'task-render-mix';
+
+		insertSession(db, sessionId, 'space_task_agent', isoNow);
+		insertSpaceTask(db, { id: taskId, title: 'RenderMix', taskAgentSessionId: sessionId, now });
+		runMigration118(db);
+
+		insertSdkMessage(db, {
+			id: 'mixed-content',
+			sessionId,
+			isoNow,
+			messageType: 'user',
+			payload: {
+				type: 'user',
+				uuid: 'mixed-content',
+				message: {
+					role: 'user',
+					content: [
+						{ type: 'tool_result', tool_use_id: 't1', content: 'output' },
+						{ type: 'text', text: 'hello' },
+					],
+				},
+			},
+		});
+
+		const rows = readProjection(db, taskId);
+		expect(rows).toHaveLength(1);
+		expect(rows[0].is_renderable).toBe(1);
+	});
+
 	test('is_renderable = 1 for normal assistant/text rows', () => {
 		const sessionId = 'session-render-2';
 		const taskId = 'task-render-2';
@@ -652,5 +781,255 @@ describe('Migration 118 — task_thread_messages projection', () => {
 		rows = readProjection(db, taskId);
 		expect(rows).toHaveLength(1);
 		expect(rows[0].source_id).toBe('b-msg');
+	});
+
+	test('space_tasks UPDATE of unrelated columns is a no-op on the projection', () => {
+		const sessionId = 'session-noop-up';
+		const taskId = 'task-noop-up';
+
+		insertSession(db, sessionId, 'space_task_agent', isoNow);
+		insertSpaceTask(db, {
+			id: taskId,
+			title: 'NoopUp',
+			taskAgentSessionId: sessionId,
+			now,
+		});
+		runMigration118(db);
+
+		insertSdkMessage(db, { id: 'noop-up-msg', sessionId, isoNow });
+		const before = readProjection(db, taskId);
+		expect(before).toHaveLength(1);
+		expect(before[0].source_id).toBe('noop-up-msg');
+
+		// Change status — not in the WHEN clause, so trigger should be a no-op.
+		db.exec(`UPDATE space_tasks SET status = 'completed' WHERE id = '${taskId}'`);
+		const after = readProjection(db, taskId);
+		expect(after).toHaveLength(1);
+		expect(after[0].source_id).toBe('noop-up-msg');
+	});
+
+	// -------------------------------------------------------------------------
+	// space_agents UPDATE — node-agent label refresh
+	// -------------------------------------------------------------------------
+
+	test('space_agents UPDATE OF name refreshes labels on owned node-agent rows', () => {
+		const orchSessionId = 'orch-session-rename';
+		const nodeSessionId = 'node-session-rename';
+		const workflowRunId = 'wr-rename-1';
+		const taskId = 'task-rename-1';
+		const agentId = 'agent-rename';
+
+		insertSession(db, orchSessionId, 'space_task_agent', isoNow);
+		insertSession(db, nodeSessionId, 'space_task_agent', isoNow);
+		insertSpaceTask(db, {
+			id: taskId,
+			title: 'Rename leg',
+			taskAgentSessionId: orchSessionId,
+			workflowRunId,
+			now,
+		});
+		db.exec(
+			`INSERT INTO space_agents (id, space_id, name) VALUES ('${agentId}', 's1', 'Old Name')`
+		);
+		runMigration118(db);
+
+		// Bind a node_execution to the agent and a session, then push a message.
+		db.exec(`
+			INSERT INTO node_executions (
+				id, workflow_run_id, workflow_node_id, agent_name, agent_id,
+				agent_session_id, status, result, created_at, started_at,
+				completed_at, updated_at
+			) VALUES (
+				'ne-rename', '${workflowRunId}', 'node-1', 'fallback', '${agentId}',
+				'${nodeSessionId}', 'in_progress', NULL, ${now}, ${now}, NULL, ${now}
+			)
+		`);
+		insertSdkMessage(db, { id: 'rename-msg-1', sessionId: nodeSessionId, isoNow });
+
+		// Initial projection picks up the original name.
+		let rows = readProjection(db, taskId);
+		expect(rows).toHaveLength(1);
+		expect(rows[0].label).toBe('Old Name');
+
+		// Rename the agent — trigger should refresh the label in place.
+		db.exec(`UPDATE space_agents SET name = 'New Name' WHERE id = '${agentId}'`);
+		rows = readProjection(db, taskId);
+		expect(rows).toHaveLength(1);
+		expect(rows[0].label).toBe('New Name');
+		expect(rows[0].source_id).toBe('rename-msg-1');
+	});
+
+	test('space_agents UPDATE OF name updates the projection in place (no row churn)', () => {
+		const orchSessionId = 'orch-session-stable';
+		const nodeSessionId = 'node-session-stable';
+		const workflowRunId = 'wr-stable-1';
+		const taskId = 'task-stable-1';
+		const agentId = 'agent-stable';
+
+		insertSession(db, orchSessionId, 'space_task_agent', isoNow);
+		insertSession(db, nodeSessionId, 'space_task_agent', isoNow);
+		insertSpaceTask(db, {
+			id: taskId,
+			title: 'Stable proj_id',
+			taskAgentSessionId: orchSessionId,
+			workflowRunId,
+			now,
+		});
+		db.exec(
+			`INSERT INTO space_agents (id, space_id, name) VALUES ('${agentId}', 's1', 'First Name')`
+		);
+		runMigration118(db);
+
+		db.exec(`
+			INSERT INTO node_executions (
+				id, workflow_run_id, workflow_node_id, agent_name, agent_id,
+				agent_session_id, status, result, created_at, started_at,
+				completed_at, updated_at
+			) VALUES (
+				'ne-stable', '${workflowRunId}', 'node-1', 'fallback', '${agentId}',
+				'${nodeSessionId}', 'in_progress', NULL, ${now}, ${now}, NULL, ${now}
+			)
+		`);
+		insertSdkMessage(db, { id: 'stable-msg-1', sessionId: nodeSessionId, isoNow });
+
+		const before = db
+			.prepare(
+				`SELECT proj_id, label FROM task_thread_messages WHERE task_id = ? AND source_id = ?`
+			)
+			.get(taskId, 'stable-msg-1') as { proj_id: number; label: string };
+		expect(before.label).toBe('First Name');
+
+		// Rename — projection should refresh in place. The proj_id stays the same
+		// (UPDATE not DELETE+INSERT) so existing LiveQuery readers don't see a
+		// row churn — just a cell-level update.
+		db.exec(`UPDATE space_agents SET name = 'Second Name' WHERE id = '${agentId}'`);
+		const after = db
+			.prepare(
+				`SELECT proj_id, label FROM task_thread_messages WHERE task_id = ? AND source_id = ?`
+			)
+			.get(taskId, 'stable-msg-1') as { proj_id: number; label: string };
+		expect(after.label).toBe('Second Name');
+		expect(after.proj_id).toBe(before.proj_id);
+	});
+
+	test('space_agents UPDATE leaves orchestration and github rows untouched', () => {
+		const orchSessionId = 'orch-session-iso';
+		const nodeSessionId = 'node-session-iso';
+		const workflowRunId = 'wr-iso-1';
+		const taskId = 'task-iso-1';
+		const agentId = 'agent-iso';
+
+		insertSession(db, orchSessionId, 'space_task_agent', isoNow);
+		insertSession(db, nodeSessionId, 'space_task_agent', isoNow);
+		insertSpaceTask(db, {
+			id: taskId,
+			title: 'Isolation',
+			taskAgentSessionId: orchSessionId,
+			workflowRunId,
+			now,
+		});
+		db.exec(
+			`INSERT INTO space_agents (id, space_id, name) VALUES ('${agentId}', 's1', 'Original')`
+		);
+		runMigration118(db);
+
+		db.exec(`
+			INSERT INTO node_executions (
+				id, workflow_run_id, workflow_node_id, agent_name, agent_id,
+				agent_session_id, status, result, created_at, started_at,
+				completed_at, updated_at
+			) VALUES (
+				'ne-iso', '${workflowRunId}', 'node-1', 'coder', '${agentId}',
+				'${nodeSessionId}', 'in_progress', NULL, ${now}, ${now}, NULL, ${now}
+			)
+		`);
+
+		// Project: an orchestration message, a node-agent message, and a github
+		// event. Only the node-agent row should change after the rename.
+		insertSdkMessage(db, { id: 'orch-iso-1', sessionId: orchSessionId, isoNow });
+		insertSdkMessage(db, { id: 'node-iso-1', sessionId: nodeSessionId, isoNow });
+		const baseGhCols = `id, space_id, task_id, source, delivery_id, event_type, action,
+			repo_owner, repo_name, pr_number, pr_url, actor, actor_type, body, summary,
+			external_url, external_id, occurred_at, dedupe_key, raw_payload, state,
+			created_at, updated_at`;
+		db.exec(`
+			INSERT INTO space_github_events (${baseGhCols}) VALUES (
+				'gh-iso-1', 's1', '${taskId}', 'webhook', 'gh-iso-1', 'pull_request', 'opened',
+				'org', 'r', 1, 'https://example/iso', 'bot', 'User',
+				'', 'Opened PR', 'https://example/iso', 'gh-iso-1', ${now}, 'gh-iso-1',
+				'{}', 'routed', ${now}, ${now}
+			)
+		`);
+
+		const before = readProjection(db, taskId);
+		expect(before).toHaveLength(3);
+		const beforeOrch = before.find((r) => r.kind === 'task_agent');
+		const beforeNode = before.find((r) => r.kind === 'node_agent');
+		const beforeGh = before.find((r) => r.kind === 'github');
+		expect(beforeOrch).toBeDefined();
+		expect(beforeNode).toBeDefined();
+		expect(beforeGh).toBeDefined();
+		expect(beforeOrch?.label).toBe('Task Agent');
+		expect(beforeNode?.label).toBe('Original');
+		expect(beforeGh?.label).toBe('GitHub');
+
+		db.exec(`UPDATE space_agents SET name = 'Renamed' WHERE id = '${agentId}'`);
+
+		const after = readProjection(db, taskId);
+		expect(after).toHaveLength(3);
+		const afterOrch = after.find((r) => r.kind === 'task_agent');
+		const afterNode = after.find((r) => r.kind === 'node_agent');
+		const afterGh = after.find((r) => r.kind === 'github');
+		expect(afterOrch).toBeDefined();
+		expect(afterNode).toBeDefined();
+		expect(afterGh).toBeDefined();
+		expect(afterOrch?.label).toBe('Task Agent');
+		expect(afterNode?.label).toBe('Renamed');
+		expect(afterGh?.label).toBe('GitHub');
+	});
+
+	test('space_agents UPDATE of unrelated columns does not modify the projection', () => {
+		const orchSessionId = 'orch-session-noop';
+		const nodeSessionId = 'node-session-noop';
+		const workflowRunId = 'wr-noop-1';
+		const taskId = 'task-noop-1';
+		const agentId = 'agent-noop';
+
+		insertSession(db, orchSessionId, 'space_task_agent', isoNow);
+		insertSession(db, nodeSessionId, 'space_task_agent', isoNow);
+		insertSpaceTask(db, {
+			id: taskId,
+			title: 'Noop',
+			taskAgentSessionId: orchSessionId,
+			workflowRunId,
+			now,
+		});
+		// Add a description column for the noop UPDATE below.
+		db.exec(`ALTER TABLE space_agents ADD COLUMN description TEXT`);
+		db.exec(
+			`INSERT INTO space_agents (id, space_id, name, description) VALUES ('${agentId}', 's1', 'Stable', 'old desc')`
+		);
+		runMigration118(db);
+
+		db.exec(`
+			INSERT INTO node_executions (
+				id, workflow_run_id, workflow_node_id, agent_name, agent_id,
+				agent_session_id, status, result, created_at, started_at,
+				completed_at, updated_at
+			) VALUES (
+				'ne-noop', '${workflowRunId}', 'node-1', 'coder', '${agentId}',
+				'${nodeSessionId}', 'in_progress', NULL, ${now}, ${now}, NULL, ${now}
+			)
+		`);
+		insertSdkMessage(db, { id: 'noop-msg-1', sessionId: nodeSessionId, isoNow });
+
+		const before = readProjection(db, taskId);
+		expect(before[0].label).toBe('Stable');
+
+		// Update an unrelated column — the trigger is `OF name`, so this must be
+		// a no-op (the WHEN guard would also reject same-name updates anyway).
+		db.exec(`UPDATE space_agents SET description = 'new desc' WHERE id = '${agentId}'`);
+		const after = readProjection(db, taskId);
+		expect(after[0].label).toBe('Stable');
 	});
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-118_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-118_test.ts
@@ -489,6 +489,47 @@ describe('Migration 118 — task_thread_messages projection', () => {
 		expect(rows[0].node_execution_id).toBe('ne-late');
 	});
 
+	test('node_executions UPDATE of status is a no-op on the projection', () => {
+		const orchSessionId = 'orch-session-noop-ne';
+		const nodeSessionId = 'node-session-noop-ne';
+		const workflowRunId = 'wr-noop-ne-1';
+		const taskId = 'task-noop-ne-1';
+
+		insertSession(db, orchSessionId, 'space_task_agent', isoNow);
+		insertSession(db, nodeSessionId, 'space_task_agent', isoNow);
+		insertSpaceTask(db, {
+			id: taskId,
+			title: 'Noop NE',
+			taskAgentSessionId: orchSessionId,
+			workflowRunId,
+			now,
+		});
+		runMigration118(db);
+
+		db.exec(`
+			INSERT INTO node_executions (
+				id, workflow_run_id, workflow_node_id, agent_name, agent_id,
+				agent_session_id, status, result, created_at, started_at,
+				completed_at, updated_at
+			) VALUES (
+				'ne-noop-status', '${workflowRunId}', 'node-1', 'coder', NULL,
+				'${nodeSessionId}', 'in_progress', NULL, ${now}, ${now}, NULL, ${now}
+			)
+		`);
+		insertSdkMessage(db, { id: 'noop-ne-msg-1', sessionId: nodeSessionId, isoNow });
+
+		const before = readProjection(db, taskId);
+		expect(before).toHaveLength(1);
+		expect(before[0].source_id).toBe('noop-ne-msg-1');
+
+		// Status-only update — not in the WHEN clause, trigger should be a no-op.
+		db.exec(`UPDATE node_executions SET status = 'done' WHERE id = 'ne-noop-status'`);
+		const after = readProjection(db, taskId);
+		expect(after).toHaveLength(1);
+		expect(after[0].source_id).toBe('noop-ne-msg-1');
+		expect(after[0].node_execution_id).toBe('ne-noop-status');
+	});
+
 	// -------------------------------------------------------------------------
 	// node_executions DELETE — re-project when session is shared
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/4-space-storage/storage/reactive-database.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/reactive-database.test.ts
@@ -632,8 +632,8 @@ describe('ReactiveDatabase', () => {
 	// -------------------------------------------------------------------------
 	//
 	// SQLite triggers maintaining `task_thread_messages` from `sdk_messages` /
-	// `space_github_events` / `space_tasks` / `node_executions` write to the
-	// projection without going through the proxy. The reactive database compensates
+	// `space_github_events` / `space_tasks` / `node_executions` / `space_agents`
+	// write to the projection without going through the proxy. The reactive database compensates
 	// by fanning out a derived `task_thread_messages` change event whenever an
 	// upstream source table is incremented, so LiveQuery subscriptions reading
 	// from the projection re-evaluate.
@@ -680,6 +680,17 @@ describe('ReactiveDatabase', () => {
 
 			expect(events.length).toBe(2);
 			expect(events[0].tables).toEqual(['node_executions']);
+			expect(events[1].tables).toEqual(['task_thread_messages']);
+		});
+
+		test('notifyChange("space_agents") fans out a task_thread_messages event', () => {
+			const events: Array<{ tables: string[] }> = [];
+			reactiveDb.on('change', (data) => events.push(data));
+
+			reactiveDb.notifyChange('space_agents');
+
+			expect(events.length).toBe(2);
+			expect(events[0].tables).toEqual(['space_agents']);
 			expect(events[1].tables).toEqual(['task_thread_messages']);
 		});
 

--- a/packages/daemon/tests/unit/4-space-storage/storage/reactive-database.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/reactive-database.test.ts
@@ -626,4 +626,129 @@ describe('ReactiveDatabase', () => {
 			expect(events[0].versions).toHaveProperty('sdk_messages');
 		});
 	});
+
+	// -------------------------------------------------------------------------
+	// Derived projection fan-out (migration 118 + future projections)
+	// -------------------------------------------------------------------------
+	//
+	// SQLite triggers maintaining `task_thread_messages` from `sdk_messages` /
+	// `space_github_events` / `space_tasks` / `node_executions` write to the
+	// projection without going through the proxy. The reactive database compensates
+	// by fanning out a derived `task_thread_messages` change event whenever an
+	// upstream source table is incremented, so LiveQuery subscriptions reading
+	// from the projection re-evaluate.
+
+	describe('derived projection fan-out', () => {
+		test('notifyChange("sdk_messages") fans out a task_thread_messages event', () => {
+			const events: Array<{ tables: string[] }> = [];
+			reactiveDb.on('change', (data) => events.push(data));
+
+			reactiveDb.notifyChange('sdk_messages');
+
+			expect(events.length).toBe(2);
+			expect(events[0].tables).toEqual(['sdk_messages']);
+			expect(events[1].tables).toEqual(['task_thread_messages']);
+		});
+
+		test('notifyChange("space_github_events") fans out a task_thread_messages event', () => {
+			const events: Array<{ tables: string[] }> = [];
+			reactiveDb.on('change', (data) => events.push(data));
+
+			reactiveDb.notifyChange('space_github_events');
+
+			expect(events.length).toBe(2);
+			expect(events[0].tables).toEqual(['space_github_events']);
+			expect(events[1].tables).toEqual(['task_thread_messages']);
+		});
+
+		test('notifyChange("space_tasks") fans out a task_thread_messages event', () => {
+			const events: Array<{ tables: string[] }> = [];
+			reactiveDb.on('change', (data) => events.push(data));
+
+			reactiveDb.notifyChange('space_tasks');
+
+			expect(events.length).toBe(2);
+			expect(events[0].tables).toEqual(['space_tasks']);
+			expect(events[1].tables).toEqual(['task_thread_messages']);
+		});
+
+		test('notifyChange("node_executions") fans out a task_thread_messages event', () => {
+			const events: Array<{ tables: string[] }> = [];
+			reactiveDb.on('change', (data) => events.push(data));
+
+			reactiveDb.notifyChange('node_executions');
+
+			expect(events.length).toBe(2);
+			expect(events[0].tables).toEqual(['node_executions']);
+			expect(events[1].tables).toEqual(['task_thread_messages']);
+		});
+
+		test('emits change:task_thread_messages with monotonic version', () => {
+			const events: Array<{ table: string; version: number }> = [];
+			reactiveDb.on('change:task_thread_messages', (data) => events.push(data));
+
+			reactiveDb.notifyChange('sdk_messages');
+			reactiveDb.notifyChange('sdk_messages');
+
+			expect(events.length).toBe(2);
+			expect(events[0].version).toBe(1);
+			expect(events[1].version).toBe(2);
+		});
+
+		test('does not fan-out from unrelated tables', () => {
+			const events: Array<{ table: string }> = [];
+			reactiveDb.on('change:task_thread_messages', (data) => events.push(data));
+
+			reactiveDb.notifyChange('tasks');
+			reactiveDb.notifyChange('sessions');
+
+			expect(events.length).toBe(0);
+		});
+
+		test('transaction batching: derived event fired once on commit, even with multi writes', () => {
+			const perTableEvents: Array<{ table: string; version: number }> = [];
+			reactiveDb.on('change:task_thread_messages', (data) => perTableEvents.push(data));
+
+			reactiveDb.beginTransaction();
+			reactiveDb.notifyChange('sdk_messages');
+			reactiveDb.notifyChange('sdk_messages');
+			reactiveDb.notifyChange('sdk_messages');
+			expect(perTableEvents.length).toBe(0); // no events during txn
+			reactiveDb.commitTransaction();
+
+			// Single per-table event for task_thread_messages flushed at commit,
+			// even though three sdk_messages writes happened.
+			expect(perTableEvents.length).toBe(1);
+		});
+
+		test('transaction batching: aborted txn does not emit derived events', () => {
+			const events: unknown[] = [];
+			reactiveDb.on('change:task_thread_messages', () => events.push(1));
+
+			reactiveDb.beginTransaction();
+			reactiveDb.notifyChange('sdk_messages');
+			reactiveDb.abortTransaction();
+
+			expect(events.length).toBe(0);
+		});
+
+		test('proxy sdk_messages writes via facade fan-out the derived event', () => {
+			const session = makeSession('proxy-fanout-1');
+			db.createSession(session);
+			const sdkMessage = {
+				type: 'assistant',
+				uuid: `msg-${Date.now()}`,
+				message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
+			} as unknown as Parameters<typeof reactiveDb.db.saveSDKMessage>[1];
+
+			const events: Array<{ table: string }> = [];
+			reactiveDb.on('change:task_thread_messages', (data) => events.push(data));
+
+			// saveSDKMessage routes through the proxy → incrementAndEmit → fan-out
+			reactiveDb.db.saveSDKMessage(session.id, sdkMessage, 'system');
+
+			expect(events.length).toBe(1);
+			expect(events[0].table).toBe('task_thread_messages');
+		});
+	});
 });


### PR DESCRIPTION
Replaces the per-read CTE that powers `spaceTaskMessages.byTask` and `.compact` with a `task_thread_messages` projection kept in sync by SQLite triggers. Role/type, ordering, turn boundaries, and compact visibility are all precomputed at write time, and a backfill in migration 118 keeps existing tasks rendering identically after upgrade.

Because the triggers write directly to the projection, the reactive database now fans out `change:task_thread_messages` events whenever a mapped source (`sdk_messages`, `space_github_events`, `node_executions`, `space_tasks`) changes, so LiveQuery subscriptions still re-evaluate.

Closes #1752.