### PR TITLE
fix(agent): expose Task/Agent tools for non-Anthropic providers

### DIFF
--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -19,40 +19,41 @@
  */
 
 import type {
-	Options,
 	CanUseTool,
 	HookCallback,
+	Options,
 	PreToolUseHookInput,
 } from '@anthropic-ai/claude-agent-sdk';
 import type {
-	Session,
-	ThinkingLevel,
-	ThinkingConfig,
-	SystemPromptConfig,
-	ClaudeCodePreset,
 	AgentDefinition,
+	AppMcpServerSourceType,
+	ClaudeCodePreset,
+	DeclarativeToolGuard,
+	Session,
+	SkillEnablementOverride,
+	SystemPromptConfig,
+	ThinkingConfig,
+	ThinkingLevel,
 } from '@neokai/shared';
-import { getCoordinatorAgents } from './coordinator-agents';
 import { THINKING_LEVEL_TOKENS } from '@neokai/shared';
-import type { PermissionMode } from '@neokai/shared/types/settings';
 import type { McpServerConfig } from '@neokai/shared/types/sdk-config';
-import type { AppMcpServerSourceType } from '@neokai/shared';
-import type { SkillEnablementOverride, DeclarativeToolGuard } from '@neokai/shared';
-import type { SettingsManager } from '../settings-manager';
-import type { SkillsManager } from '../skills-manager';
+import type { PermissionMode } from '@neokai/shared/types/settings';
+import { homedir } from 'os';
+import { join } from 'path';
+import type { Database } from '../../storage/database';
 import type { AppMcpServerRepository } from '../../storage/repositories/app-mcp-server-repository';
 import type { McpEnablementRepository } from '../../storage/repositories/mcp-enablement-repository';
 import { resolveMcpServers, scopeChainForSession } from '../mcp/resolve-mcp-servers';
+import { requireModelContextWindow } from '../providers/codex-anthropic-bridge/model-context-windows';
 import { getProviderContextManager } from '../providers/factory.js';
-import { resolveSDKCliPath, isRunningUnderBun } from './sdk-cli-resolver.js';
+import type { SettingsManager } from '../settings-manager';
+import type { SkillsManager } from '../skills-manager';
 import {
 	builtinSkillPluginPath,
 	defaultBuiltinSkillPluginRoot,
 } from './builtin-skill-plugin-wrapper';
-import { homedir } from 'os';
-import { join } from 'path';
-import type { Database } from '../../storage/database';
-import { requireModelContextWindow } from '../providers/codex-anthropic-bridge/model-context-windows';
+import { getCoordinatorAgents } from './coordinator-agents';
+import { isRunningUnderBun, resolveSDKCliPath } from './sdk-cli-resolver.js';
 
 export const CODEX_BRIDGE_AUTO_COMPACT_WINDOW = 1_000_000;
 
@@ -90,6 +91,75 @@ function compileToolGuard(guard: DeclarativeToolGuard): HookCallback {
 			},
 		};
 	};
+}
+
+/**
+ * Built-in tools exposed when expanding an undefined tool list for
+ * non-Anthropic providers. Matches the coordinator-mode allowlist.
+ */
+const FULL_BUILTIN_TOOL_LIST = [
+	'Read',
+	'Write',
+	'Edit',
+	'Bash',
+	'Grep',
+	'Glob',
+	'WebFetch',
+	'WebSearch',
+	'Task',
+	'TaskOutput',
+	'TaskStop',
+	'NotebookEdit',
+	'TodoWrite',
+	'AskUserQuestion',
+	'EnterPlanMode',
+	'ExitPlanMode',
+	'Skill',
+	'ToolSearch',
+];
+
+/**
+ * Agent invocation tools that must be present when agents are configured.
+ */
+const AGENT_INVOCATION_TOOLS = ['Task', 'TaskOutput', 'TaskStop'];
+
+/**
+ * Ensure agent invocation tools are present in the tool list when agents
+ * are configured. Non-Anthropic SDK presets may omit Task from the function
+ * schema even though the system prompt still describes agents, creating a
+ * mismatch where the model sees agent descriptions but has no callable tool
+ * to invoke them.
+ *
+ * @param tools      Current tools value (array, preset, undefined)
+ * @param agents     Configured agents map
+ * @param providerId Resolved provider identifier
+ * @param sessionType Session type (space_chat is exempt)
+ * @returns Updated tools value
+ */
+export function ensureAgentTools(
+	tools: Options['tools'],
+	agents: Options['agents'],
+	providerId: string,
+	sessionType: string
+): Options['tools'] {
+	const hasAgentsConfigured = agents && Object.keys(agents).length > 0;
+	if (!hasAgentsConfigured || sessionType === 'space_chat') {
+		return tools;
+	}
+
+	if (Array.isArray(tools)) {
+		const missing = AGENT_INVOCATION_TOOLS.filter((t) => !(tools as string[]).includes(t));
+		if (missing.length > 0) {
+			return [...(tools as string[]), ...missing];
+		}
+		return tools;
+	}
+
+	if (!tools && providerId !== 'anthropic' && providerId !== 'anthropic-copilot') {
+		return [...FULL_BUILTIN_TOOL_LIST];
+	}
+
+	return tools;
 }
 
 /**
@@ -447,6 +517,14 @@ export class QueryOptionsBuilder {
 			const existing = queryOptions.allowedTools ?? [];
 			queryOptions.allowedTools = [...new Set([...existing, ...allTools])];
 		}
+
+		// ============ Provider-specific agent tool exposure ============
+		queryOptions.tools = ensureAgentTools(
+			queryOptions.tools,
+			queryOptions.agents,
+			providerId,
+			this.ctx.session.type ?? 'general'
+		);
 
 		// Remove undefined values to use SDK defaults
 		const cleanedOptions = Object.fromEntries(

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -124,6 +124,16 @@ const FULL_BUILTIN_TOOL_LIST = [
 const AGENT_INVOCATION_TOOLS = ['Task', 'TaskOutput', 'TaskStop'];
 
 /**
+ * Providers whose native SDK integration already includes agent tools in the
+ * function schema when agents are configured. All other providers need an
+ * explicit tool list because the SDK preset may omit Task/Agent tools.
+ *
+ * anthropic        — native Anthropic API, SDK handles agent tools correctly.
+ * anthropic-copilot — Copilot bridge still routes to Anthropic API.
+ */
+const NATIVE_AGENT_TOOL_PROVIDERS = ['anthropic', 'anthropic-copilot'];
+
+/**
  * Ensure agent invocation tools are present in the tool list when agents
  * are configured. Non-Anthropic SDK presets may omit Task from the function
  * schema even though the system prompt still describes agents, creating a
@@ -155,7 +165,7 @@ export function ensureAgentTools(
 		return tools;
 	}
 
-	if (!tools && providerId !== 'anthropic' && providerId !== 'anthropic-copilot') {
+	if (!tools && !NATIVE_AGENT_TOOL_PROVIDERS.includes(providerId)) {
 		return [...FULL_BUILTIN_TOOL_LIST];
 	}
 
@@ -494,28 +504,8 @@ export class QueryOptionsBuilder {
 			queryOptions.agents = agents as Options['agents'];
 
 			// Allow all tools at session level so sub-agents can use them under dontAsk
-			const allTools = [
-				'Task',
-				'TaskOutput',
-				'TaskStop',
-				'Bash',
-				'Read',
-				'Edit',
-				'Write',
-				'Glob',
-				'Grep',
-				'NotebookEdit',
-				'WebFetch',
-				'WebSearch',
-				'TodoWrite',
-				'AskUserQuestion',
-				'EnterPlanMode',
-				'ExitPlanMode',
-				'Skill',
-				'ToolSearch',
-			];
 			const existing = queryOptions.allowedTools ?? [];
-			queryOptions.allowedTools = [...new Set([...existing, ...allTools])];
+			queryOptions.allowedTools = [...new Set([...existing, ...FULL_BUILTIN_TOOL_LIST])];
 		}
 
 		// ============ Provider-specific agent tool exposure ============
@@ -523,7 +513,7 @@ export class QueryOptionsBuilder {
 			queryOptions.tools,
 			queryOptions.agents,
 			providerId,
-			this.ctx.session.type ?? 'general'
+			this.ctx.session.type ?? 'worker'
 		);
 
 		// Remove undefined values to use SDK defaults

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -158,6 +158,9 @@ export function ensureAgentTools(
 	}
 
 	if (Array.isArray(tools)) {
+		if (NATIVE_AGENT_TOOL_PROVIDERS.includes(providerId)) {
+			return tools;
+		}
 		const missing = AGENT_INVOCATION_TOOLS.filter((t) => !(tools as string[]).includes(t));
 		if (missing.length > 0) {
 			return [...(tools as string[]), ...missing];

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -4,22 +4,25 @@
  * Tests SDK query options construction from session config.
  */
 
-import { describe, expect, it, beforeEach, afterEach, mock } from 'bun:test';
 import { Database as BunDatabase } from 'bun:sqlite';
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { Session } from '@neokai/shared';
+import { generateUUID } from '@neokai/shared';
+import type { Provider } from '@neokai/shared/provider';
+import { homedir } from 'os';
 import {
-	QueryOptionsBuilder,
-	CODEX_BRIDGE_AUTO_COMPACT_WINDOW,
 	buildProviderSettings,
+	CODEX_BRIDGE_AUTO_COMPACT_WINDOW,
+	ensureAgentTools,
+	QueryOptionsBuilder,
 	type QueryOptionsBuilderContext,
 } from '../../../../src/lib/agent/query-options-builder';
-import type { Session } from '@neokai/shared';
+import { getProviderRegistry, resetProviderRegistry } from '../../../../src/lib/providers/registry';
 import type { SettingsManager } from '../../../../src/lib/settings-manager';
-import { generateUUID } from '@neokai/shared';
-import { homedir } from 'os';
-import { createTables } from '../../../../src/storage/schema';
-import { SkillRepository } from '../../../../src/storage/repositories/skill-repository';
-import { AppMcpServerRepository } from '../../../../src/storage/repositories/app-mcp-server-repository';
 import { SkillsManager } from '../../../../src/lib/skills-manager';
+import { AppMcpServerRepository } from '../../../../src/storage/repositories/app-mcp-server-repository';
+import { SkillRepository } from '../../../../src/storage/repositories/skill-repository';
+import { createTables } from '../../../../src/storage/schema';
 import { noOpReactiveDb } from '../../../helpers/reactive-database';
 
 describe('QueryOptionsBuilder', () => {
@@ -1031,6 +1034,192 @@ describe('QueryOptionsBuilder', () => {
 
 			// The original callback should be passed through unchanged
 			expect(options.canUseTool).toBe(originalCallback);
+		});
+	});
+
+	describe('provider-specific agent tool exposure', () => {
+		afterEach(() => {
+			resetProviderRegistry();
+		});
+
+		function registerCodexProvider(): void {
+			resetProviderRegistry();
+			const registry = getProviderRegistry();
+			registry.register({
+				id: 'anthropic-codex',
+				displayName: 'OpenAI (Codex)',
+				capabilities: {
+					streaming: true,
+					extendedThinking: false,
+					maxContextWindow: 272000,
+					functionCalling: true,
+					vision: true,
+				},
+				isAvailable: () => true,
+				getModels: async () => [],
+				ownsModel: () => false,
+				buildSdkConfig: () => ({ envVars: {}, isAnthropicCompatible: true }),
+			} as Provider);
+		}
+
+		describe('ensureAgentTools (pure function)', () => {
+			it('returns undefined unchanged for Anthropic provider', () => {
+				const result = ensureAgentTools(
+					undefined,
+					{ Coordinator: { description: 'c', prompt: 'p' } },
+					'anthropic',
+					'general'
+				);
+				expect(result).toBeUndefined();
+			});
+
+			it('returns undefined unchanged for anthropic-copilot provider', () => {
+				const result = ensureAgentTools(
+					undefined,
+					{ Coordinator: { description: 'c', prompt: 'p' } },
+					'anthropic-copilot',
+					'general'
+				);
+				expect(result).toBeUndefined();
+			});
+
+			it('expands undefined to full array for anthropic-codex provider', () => {
+				const result = ensureAgentTools(
+					undefined,
+					{ Coordinator: { description: 'c', prompt: 'p' } },
+					'anthropic-codex',
+					'general'
+				);
+				expect(Array.isArray(result)).toBe(true);
+				expect(result).toContain('Task');
+				expect(result).toContain('TaskOutput');
+				expect(result).toContain('TaskStop');
+				expect(result).toContain('Read');
+				expect(result).toContain('Write');
+			});
+
+			it('expands undefined to full array for glm provider', () => {
+				const result = ensureAgentTools(
+					undefined,
+					{ Coordinator: { description: 'c', prompt: 'p' } },
+					'glm',
+					'general'
+				);
+				expect(Array.isArray(result)).toBe(true);
+				expect(result).toContain('Task');
+			});
+
+			it('appends missing agent tools to explicit array', () => {
+				const result = ensureAgentTools(
+					['Read', 'Write'],
+					{ Coordinator: { description: 'c', prompt: 'p' } },
+					'anthropic-codex',
+					'general'
+				);
+				expect(result).toEqual(['Read', 'Write', 'Task', 'TaskOutput', 'TaskStop']);
+			});
+
+			it('does not duplicate existing agent tools in explicit array', () => {
+				const result = ensureAgentTools(
+					['Read', 'Task', 'TaskOutput', 'TaskStop'],
+					{ Coordinator: { description: 'c', prompt: 'p' } },
+					'anthropic-codex',
+					'general'
+				);
+				expect(result).toEqual(['Read', 'Task', 'TaskOutput', 'TaskStop']);
+			});
+
+			it('leaves space_chat sessions untouched even with agents', () => {
+				const result = ensureAgentTools(
+					undefined,
+					{ Coordinator: { description: 'c', prompt: 'p' } },
+					'anthropic-codex',
+					'space_chat'
+				);
+				expect(result).toBeUndefined();
+			});
+
+			it('returns original tools when no agents are configured', () => {
+				const result = ensureAgentTools(undefined, undefined, 'anthropic-codex', 'general');
+				expect(result).toBeUndefined();
+			});
+
+			it('preserves preset objects unchanged', () => {
+				const preset = { type: 'preset' as const, preset: 'claude_code' as const };
+				const result = ensureAgentTools(
+					preset,
+					{ Coordinator: { description: 'c', prompt: 'p' } },
+					'anthropic-codex',
+					'general'
+				);
+				expect(result).toEqual(preset);
+			});
+		});
+
+		describe('build() with non-Anthropic provider', () => {
+			it('expands tools to full array for OpenAI (codex) when agents are configured', async () => {
+				registerCodexProvider();
+				mockSession.config.provider = 'anthropic-codex';
+				mockSession.config.model = 'gpt-5.5';
+				mockSession.config.agents = {
+					'test-agent': {
+						description: 'Test agent',
+						prompt: 'Test prompt',
+					},
+				};
+				const codexBuilder = new QueryOptionsBuilder(mockContext);
+				const options = await codexBuilder.build();
+
+				expect(Array.isArray(options.tools)).toBe(true);
+				expect(options.tools).toContain('Task');
+				expect(options.tools).toContain('TaskOutput');
+				expect(options.tools).toContain('TaskStop');
+				expect(options.tools).toContain('Read');
+				expect(options.tools).toContain('Write');
+			});
+
+			it('expands tools for OpenAI coordinator mode', async () => {
+				registerCodexProvider();
+				mockSession.config.provider = 'anthropic-codex';
+				mockSession.config.model = 'gpt-5.5';
+				mockSession.config.coordinatorMode = true;
+				const codexBuilder = new QueryOptionsBuilder(mockContext);
+				const options = await codexBuilder.build();
+
+				expect(Array.isArray(options.tools)).toBe(true);
+				expect(options.tools).toContain('Task');
+				expect(options.tools).toContain('TaskOutput');
+				expect(options.tools).toContain('TaskStop');
+			});
+
+			it('leaves tools undefined for Anthropic when agents are configured', async () => {
+				// Default provider is anthropic; no registry setup needed.
+				mockSession.config.agents = {
+					'test-agent': {
+						description: 'Test agent',
+						prompt: 'Test prompt',
+					},
+				};
+				const options = await builder.build();
+				expect(options.tools).toBeUndefined();
+			});
+
+			it('preserves explicit tools array and appends missing agent tools for OpenAI', async () => {
+				registerCodexProvider();
+				mockSession.config.provider = 'anthropic-codex';
+				mockSession.config.model = 'gpt-5.5';
+				mockSession.config.sdkToolsPreset = ['Read', 'Write', 'Edit'];
+				mockSession.config.agents = {
+					'test-agent': {
+						description: 'Test agent',
+						prompt: 'Test prompt',
+					},
+				};
+				const codexBuilder = new QueryOptionsBuilder(mockContext);
+				const options = await codexBuilder.build();
+
+				expect(options.tools).toEqual(['Read', 'Write', 'Edit', 'Task', 'TaskOutput', 'TaskStop']);
+			});
 		});
 	});
 

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -1109,7 +1109,7 @@ describe('QueryOptionsBuilder', () => {
 				expect(result).toContain('Task');
 			});
 
-			it('appends missing agent tools to explicit array', () => {
+			it('appends missing agent tools to explicit array for non-native providers', () => {
 				const result = ensureAgentTools(
 					['Read', 'Write'],
 					{ Coordinator: { description: 'c', prompt: 'p' } },
@@ -1119,7 +1119,7 @@ describe('QueryOptionsBuilder', () => {
 				expect(result).toEqual(['Read', 'Write', 'Task', 'TaskOutput', 'TaskStop']);
 			});
 
-			it('does not duplicate existing agent tools in explicit array', () => {
+			it('does not duplicate existing agent tools in explicit array for non-native providers', () => {
 				const result = ensureAgentTools(
 					['Read', 'Task', 'TaskOutput', 'TaskStop'],
 					{ Coordinator: { description: 'c', prompt: 'p' } },
@@ -1127,6 +1127,26 @@ describe('QueryOptionsBuilder', () => {
 					'general'
 				);
 				expect(result).toEqual(['Read', 'Task', 'TaskOutput', 'TaskStop']);
+			});
+
+			it('preserves explicit array unchanged for Anthropic provider', () => {
+				const result = ensureAgentTools(
+					['Read', 'Write'],
+					{ Coordinator: { description: 'c', prompt: 'p' } },
+					'anthropic',
+					'general'
+				);
+				expect(result).toEqual(['Read', 'Write']);
+			});
+
+			it('preserves explicit array unchanged for anthropic-copilot provider', () => {
+				const result = ensureAgentTools(
+					['Read', 'Write'],
+					{ Coordinator: { description: 'c', prompt: 'p' } },
+					'anthropic-copilot',
+					'general'
+				);
+				expect(result).toEqual(['Read', 'Write']);
 			});
 
 			it('leaves space_chat sessions untouched even with agents', () => {


### PR DESCRIPTION
Fixes the provider-specific agent tool exposure mismatch where non-Anthropic sessions list agents in the Claude Code context but do not expose a callable Task/Agent tool.

### Problem
The SDK's `claude_code` preset may omit `Task` from the function schema on non-Anthropic providers even though the system prompt still describes agents. This causes the model to see agent descriptions (Explore, general-purpose, Plan, etc.) but have no callable tool to invoke them.

### Solution
- Introduce `ensureAgentTools()` — a pure function that guarantees `Task`, `TaskOutput`, and `TaskStop` are present in the tool list whenever agents are configured.
- For explicit tool arrays: append missing agent tools.
- For undefined tool lists on non-Anthropic providers (`anthropic-codex`, `glm`, `openrouter`, etc.): expand to the full built-in array so the bridge receives agent tools.
- Space chat sessions are explicitly exempt (they restrict `Task` by design).
- Anthropic and `anthropic-copilot` providers are left unchanged — the SDK handles agent tools correctly for native Anthropic APIs.

### Tests
- Pure function unit tests for `ensureAgentTools` covering all provider IDs and edge cases.
- Integration tests for `build()` with a registered `anthropic-codex` provider, verifying:
  - `tools` expands to a full array when agents are configured
  - `tools` preserves explicit arrays and appends missing agent tools
  - `tools` stays `undefined` for Anthropic providers

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>