### PR TITLE
Add InternalEventBus facade for semantic daemon events

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -9,7 +9,8 @@
 		"./app": "./src/app.ts",
 		"./config": "./src/config.ts",
 		"./routes/setup-websocket": "./src/routes/setup-websocket.ts",
-		"./sdk-cli-resolver": "./src/lib/agent/sdk-cli-resolver.ts"
+		"./sdk-cli-resolver": "./src/lib/agent/sdk-cli-resolver.ts",
+		"./lib/internal-event-bus": "./src/lib/internal-event-bus.ts"
 	},
 	"scripts": {
 		"dev": "bun run --watch main.ts",

--- a/packages/daemon/src/lib/internal-event-bus.ts
+++ b/packages/daemon/src/lib/internal-event-bus.ts
@@ -120,7 +120,7 @@ export class InternalEventBus<TEventMap extends object = Record<string, Internal
 	 */
 	subscribe<K extends keyof TEventMap & string>(
 		event: K,
-		handler: InternalEventHandler<TEventMap[K]>,
+		handler: InternalEventHandler<TEventMap[K] & InternalEventPayload>,
 		options: SubscribeOptions
 	): () => void {
 		const eventKey = event;
@@ -179,7 +179,7 @@ export class InternalEventBus<TEventMap extends object = Record<string, Internal
 	 */
 	async publish<K extends keyof TEventMap & string>(
 		event: K,
-		data: TEventMap[K]
+		data: TEventMap[K] & InternalEventPayload
 	): Promise<PublishResult> {
 		const eventKey = event;
 		const sessionMap = this.handlers.get(eventKey);
@@ -188,7 +188,7 @@ export class InternalEventBus<TEventMap extends object = Record<string, Internal
 			return { delivered: 0, failures: [] };
 		}
 
-		const sessionId = (data as InternalEventPayload).sessionId;
+		const sessionId = data.sessionId;
 		const failures: HandlerFailure[] = [];
 		let delivered = 0;
 
@@ -246,7 +246,10 @@ export class InternalEventBus<TEventMap extends object = Record<string, Internal
 	 * Handler failures are silently swallowed; they are never thrown
 	 * and the caller cannot await them.
 	 */
-	publishAsync<K extends keyof TEventMap & string>(event: K, data: TEventMap[K]): void {
+	publishAsync<K extends keyof TEventMap & string>(
+		event: K,
+		data: TEventMap[K] & InternalEventPayload
+	): void {
 		// Defer to the next microtask so that synchronous handlers do not
 		// run on the caller's stack and `publishAsync` truly returns
 		// immediately.

--- a/packages/daemon/src/lib/internal-event-bus.ts
+++ b/packages/daemon/src/lib/internal-event-bus.ts
@@ -236,15 +236,19 @@ export class InternalEventBus<
 
 	/**
 	 * Fire-and-forget publish.
-	 *	 *
+	 *
 	 * Schedules handlers asynchronously but returns immediately.
 	 * Handler failures are silently swallowed; they are never thrown
 	 * and the caller cannot await them.
 	 */
 	publishAsync<K extends keyof TEventMap & string>(event: K, data: TEventMap[K]): void {
-		// Intentionally not awaited — errors are swallowed.
-		this.publish(event, data).catch(() => {
-			// Swallow — publishAsync is explicit fire-and-forget.
+		// Defer to the next microtask so that synchronous handlers do not
+		// run on the caller's stack and `publishAsync` truly returns
+		// immediately.
+		queueMicrotask(() => {
+			this.publish(event, data).catch(() => {
+				// Swallow — publishAsync is explicit fire-and-forget.
+			});
 		});
 	}
 

--- a/packages/daemon/src/lib/internal-event-bus.ts
+++ b/packages/daemon/src/lib/internal-event-bus.ts
@@ -92,13 +92,11 @@ export interface SubscribeOptions {
 	sessionId?: string;
 }
 
-export type InternalEventHandler<TPayload extends InternalEventPayload> = (
-	data: TPayload
-) => void | Promise<void>;
+export type InternalEventHandler<TPayload> = (data: TPayload) => void | Promise<void>;
 
 interface RegisteredHandler {
 	subscriberName: string;
-	handler: InternalEventHandler<InternalEventPayload>;
+	handler: (data: unknown) => void | Promise<void>;
 }
 
 const GLOBAL_SESSION_KEY = '__global__';
@@ -108,9 +106,7 @@ const GLOBAL_SESSION_KEY = '__global__';
  *
  * @template TEventMap — map of dot-separated event names to payload shapes.
  */
-export class InternalEventBus<
-	TEventMap extends Record<string, InternalEventPayload> = Record<string, InternalEventPayload>,
-> {
+export class InternalEventBus<TEventMap extends object = Record<string, InternalEventPayload>> {
 	// event → sessionId → handlers
 	private handlers = new Map<string, Map<string, Set<RegisteredHandler>>>();
 
@@ -130,6 +126,12 @@ export class InternalEventBus<
 		const eventKey = event;
 		const sessionKey = options.sessionId ?? GLOBAL_SESSION_KEY;
 
+		if (options.sessionId === GLOBAL_SESSION_KEY) {
+			throw new Error(
+				`'${GLOBAL_SESSION_KEY}' is a reserved session key and cannot be used as an explicit sessionId`
+			);
+		}
+
 		if (!options.subscriberName || options.subscriberName.trim().length === 0) {
 			throw new Error('InternalEventBus.subscribe requires a non-empty subscriberName');
 		}
@@ -148,7 +150,7 @@ export class InternalEventBus<
 
 		const registered: RegisteredHandler = {
 			subscriberName: options.subscriberName,
-			handler: handler as InternalEventHandler<InternalEventPayload>,
+			handler: handler as (data: unknown) => void | Promise<void>,
 		};
 
 		handlerSet.add(registered);
@@ -186,7 +188,7 @@ export class InternalEventBus<
 			return { delivered: 0, failures: [] };
 		}
 
-		const sessionId = data.sessionId;
+		const sessionId = (data as InternalEventPayload).sessionId;
 		const failures: HandlerFailure[] = [];
 		let delivered = 0;
 
@@ -306,7 +308,7 @@ export class InternalEventBus<
  *   const bus = createInternalEventBus<MyEventMap>();
  */
 export function createInternalEventBus<
-	TEventMap extends Record<string, InternalEventPayload> = Record<string, InternalEventPayload>,
+	TEventMap extends object = Record<string, InternalEventPayload>,
 >(): InternalEventBus<TEventMap> {
 	return new InternalEventBus<TEventMap>();
 }

--- a/packages/daemon/src/lib/internal-event-bus.ts
+++ b/packages/daemon/src/lib/internal-event-bus.ts
@@ -11,7 +11,7 @@
  *   structured handler failures.  Use when the caller must know whether all
  *   subscribers succeeded.
  * • `publishAsync(...)` – explicit fire-and-forget.  Returns immediately;
- *   handler failures are silently swallowed (logged at debug level only).
+ *   handler failures are silently swallowed.
  *
  * Design constraints (v1)
  * -----------------------
@@ -198,10 +198,13 @@ export class InternalEventBus<
 			for (const h of scoped) targets.push(h);
 		}
 
-		// Global handlers
-		const global = sessionMap.get(GLOBAL_SESSION_KEY);
-		if (global) {
-			for (const h of global) targets.push(h);
+		// Global handlers — only add when sessionId is not the global sentinel
+		// to prevent double-delivery of the same handler set.
+		if (sessionId !== GLOBAL_SESSION_KEY) {
+			const global = sessionMap.get(GLOBAL_SESSION_KEY);
+			if (global) {
+				for (const h of global) targets.push(h);
+			}
 		}
 
 		if (targets.length === 0) {
@@ -295,13 +298,15 @@ export class InternalEventBus<
 
 /**
  * Convenience factory that produces an InternalEventBus typed with the
- * daemon's full event vocabulary.
+ * caller's event map.
  *
  * This is the entry point most daemon code should use:
  *
  *   import { createInternalEventBus } from '@neokai/daemon/lib/internal-event-bus';
- *   const bus = createInternalEventBus();
+ *   const bus = createInternalEventBus<MyEventMap>();
  */
-export function createInternalEventBus(): InternalEventBus {
-	return new InternalEventBus();
+export function createInternalEventBus<
+	TEventMap extends Record<string, InternalEventPayload> = Record<string, InternalEventPayload>,
+>(): InternalEventBus<TEventMap> {
+	return new InternalEventBus<TEventMap>();
 }

--- a/packages/daemon/src/lib/internal-event-bus.ts
+++ b/packages/daemon/src/lib/internal-event-bus.ts
@@ -1,0 +1,303 @@
+/**
+ * InternalEventBus — Semantic daemon messaging primitive (v1)
+ *
+ * First-class facade for typed internal events with explicit await-vs-fire-and-forget
+ * semantics.  New daemon/domain code publishes and subscribes through this facade
+ * instead of importing DaemonHub directly.
+ *
+ * Semantics
+ * ---------
+ * • `publish(...)`  – awaits every local internal handler and returns/throws
+ *   structured handler failures.  Use when the caller must know whether all
+ *   subscribers succeeded.
+ * • `publishAsync(...)` – explicit fire-and-forget.  Returns immediately;
+ *   handler failures are silently swallowed (logged at debug level only).
+ *
+ * Design constraints (v1)
+ * -----------------------
+ * • Wraps existing lower-level infrastructure where practical — the registry is
+ *   kept in-process and does not migrate existing callers.
+ * • No persistence / no replay.
+ * • Subscriber names are required for diagnostics.
+ *
+ * Future direction
+ * ----------------
+ * See docs/plans/internal-event-command-query-architecture.md for the full
+ * internal-event / command / query architecture plan.
+ */
+
+export interface HandlerFailure {
+	/** Subscriber name that registered the failing handler. */
+	subscriberName: string;
+
+	/** Event name being handled when the failure occurred. */
+	event: string;
+
+	/** The raw Error (or Error-like) thrown by the handler. */
+	error: Error;
+}
+
+export interface PublishResult {
+	/** Number of handlers that completed successfully. */
+	delivered: number;
+
+	/** Structured failures from handlers that threw or rejected. */
+	failures: HandlerFailure[];
+}
+
+/**
+ * Thrown by `publish(...)` when one or more handlers fail.
+ * The `result` field contains the full breakdown so callers can decide
+ * whether to abort, partially retry, or continue.
+ */
+export class InternalEventBusPublishError extends Error {
+	constructor(
+		public readonly event: string,
+		public readonly result: PublishResult
+	) {
+		super(
+			`Publish of '${event}' failed with ${result.failures.length} handler failure(s) ` +
+				`(${result.delivered} succeeded)`
+		);
+		this.name = 'InternalEventBusPublishError';
+	}
+}
+
+/**
+ * Generic constraint for event-map entries.
+ * All events must be plain objects so we can safely read `sessionId` for
+ * scoped routing.
+ */
+export interface InternalEventPayload {
+	/** Session-scoped routing key.  Use `'global'` for app-wide events. */
+	sessionId: string;
+
+	[key: string]: unknown;
+}
+
+/**
+ * Subscription options.
+ */
+export interface SubscribeOptions {
+	/**
+	 * Human-readable subscriber identifier used in diagnostics and
+	 * `HandlerFailure.subscriberName`.  Required.
+	 */
+	subscriberName: string;
+
+	/**
+	 * When provided, the handler only receives events whose payload carries
+	 * the matching `sessionId`.  Omit for a global subscription.
+	 */
+	sessionId?: string;
+}
+
+export type InternalEventHandler<TPayload extends InternalEventPayload> = (
+	data: TPayload
+) => void | Promise<void>;
+
+interface RegisteredHandler {
+	subscriberName: string;
+	handler: InternalEventHandler<InternalEventPayload>;
+}
+
+const GLOBAL_SESSION_KEY = '__global__';
+
+/**
+ * InternalEventBus
+ *
+ * @template TEventMap — map of dot-separated event names to payload shapes.
+ */
+export class InternalEventBus<
+	TEventMap extends Record<string, InternalEventPayload> = Record<string, InternalEventPayload>,
+> {
+	// event → sessionId → handlers
+	private handlers = new Map<string, Map<string, Set<RegisteredHandler>>>();
+
+	/**
+	 * Subscribe to an event.
+	 *
+	 * @param event     — typed event name
+	 * @param handler   — callback invoked when the event is published
+	 * @param options   — must include `subscriberName`; optional `sessionId` filter
+	 * @returns unsubscribe function
+	 */
+	subscribe<K extends keyof TEventMap & string>(
+		event: K,
+		handler: InternalEventHandler<TEventMap[K]>,
+		options: SubscribeOptions
+	): () => void {
+		const eventKey = event;
+		const sessionKey = options.sessionId ?? GLOBAL_SESSION_KEY;
+
+		if (!options.subscriberName || options.subscriberName.trim().length === 0) {
+			throw new Error('InternalEventBus.subscribe requires a non-empty subscriberName');
+		}
+
+		let sessionMap = this.handlers.get(eventKey);
+		if (!sessionMap) {
+			sessionMap = new Map();
+			this.handlers.set(eventKey, sessionMap);
+		}
+
+		let handlerSet = sessionMap.get(sessionKey);
+		if (!handlerSet) {
+			handlerSet = new Set();
+			sessionMap.set(sessionKey, handlerSet);
+		}
+
+		const registered: RegisteredHandler = {
+			subscriberName: options.subscriberName,
+			handler: handler as InternalEventHandler<InternalEventPayload>,
+		};
+
+		handlerSet.add(registered);
+
+		return () => {
+			const map = this.handlers.get(eventKey);
+			if (!map) return;
+			const set = map.get(sessionKey);
+			if (!set) return;
+			set.delete(registered);
+			if (set.size === 0) map.delete(sessionKey);
+			if (map.size === 0) this.handlers.delete(eventKey);
+		};
+	}
+
+	/**
+	 * Publish an event and **await** every local internal handler.
+	 *
+	 * All matching handlers are executed concurrently.  If any handler throws,
+	 * the error is captured in a structured `HandlerFailure`, every other
+	 * handler still runs, and the method finally throws
+	 * `InternalEventBusPublishError` containing the full `PublishResult`.
+	 *
+	 * When **all** handlers succeed the returned `PublishResult` contains
+	 * `failures: []` and is never thrown.
+	 */
+	async publish<K extends keyof TEventMap & string>(
+		event: K,
+		data: TEventMap[K]
+	): Promise<PublishResult> {
+		const eventKey = event;
+		const sessionMap = this.handlers.get(eventKey);
+
+		if (!sessionMap || sessionMap.size === 0) {
+			return { delivered: 0, failures: [] };
+		}
+
+		const sessionId = data.sessionId;
+		const failures: HandlerFailure[] = [];
+		let delivered = 0;
+
+		const targets: RegisteredHandler[] = [];
+
+		// Session-scoped handlers
+		const scoped = sessionMap.get(sessionId);
+		if (scoped) {
+			for (const h of scoped) targets.push(h);
+		}
+
+		// Global handlers
+		const global = sessionMap.get(GLOBAL_SESSION_KEY);
+		if (global) {
+			for (const h of global) targets.push(h);
+		}
+
+		if (targets.length === 0) {
+			return { delivered: 0, failures: [] };
+		}
+
+		// Run every handler concurrently; collect failures individually.
+		await Promise.all(
+			targets.map(async (registered) => {
+				try {
+					await registered.handler(data);
+					delivered++;
+				} catch (raw) {
+					const error = raw instanceof Error ? raw : new Error(String(raw));
+					failures.push({
+						subscriberName: registered.subscriberName,
+						event: eventKey,
+						error,
+					});
+				}
+			})
+		);
+
+		const result: PublishResult = { delivered, failures };
+
+		if (failures.length > 0) {
+			throw new InternalEventBusPublishError(eventKey, result);
+		}
+
+		return result;
+	}
+
+	/**
+	 * Fire-and-forget publish.
+	 *	 *
+	 * Schedules handlers asynchronously but returns immediately.
+	 * Handler failures are silently swallowed; they are never thrown
+	 * and the caller cannot await them.
+	 */
+	publishAsync<K extends keyof TEventMap & string>(event: K, data: TEventMap[K]): void {
+		// Intentionally not awaited — errors are swallowed.
+		this.publish(event, data).catch(() => {
+			// Swallow — publishAsync is explicit fire-and-forget.
+		});
+	}
+
+	/**
+	 * Remove every handler for the given event (all sessions).
+	 */
+	off<K extends keyof TEventMap & string>(event: K): void {
+		this.handlers.delete(event);
+	}
+
+	/**
+	 * Remove all handlers for every event.
+	 */
+	clear(): void {
+		this.handlers.clear();
+	}
+
+	/**
+	 * Return the total number of registered handlers for an event
+	 * across all session scopes.
+	 */
+	getHandlerCount<K extends keyof TEventMap & string>(event: K): number {
+		const sessionMap = this.handlers.get(event);
+		if (!sessionMap) return 0;
+		let total = 0;
+		for (const set of sessionMap.values()) {
+			total += set.size;
+		}
+		return total;
+	}
+
+	/**
+	 * Return the number of registered handlers for a specific session scope.
+	 */
+	getHandlerCountForSession<K extends keyof TEventMap & string>(
+		event: K,
+		sessionId: string
+	): number {
+		const sessionMap = this.handlers.get(event);
+		if (!sessionMap) return 0;
+		return sessionMap.get(sessionId)?.size ?? 0;
+	}
+}
+
+/**
+ * Convenience factory that produces an InternalEventBus typed with the
+ * daemon's full event vocabulary.
+ *
+ * This is the entry point most daemon code should use:
+ *
+ *   import { createInternalEventBus } from '@neokai/daemon/lib/internal-event-bus';
+ *   const bus = createInternalEventBus();
+ */
+export function createInternalEventBus(): InternalEventBus {
+	return new InternalEventBus();
+}

--- a/packages/daemon/tests/unit/1-core/core/internal-event-bus.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/internal-event-bus.test.ts
@@ -316,6 +316,25 @@ describe('InternalEventBus', () => {
 			// Give microtasks a chance to run
 			await new Promise((r) => setTimeout(r, 10));
 		});
+
+		it('should defer synchronous handlers so they do not run on the caller stack', async () => {
+			let handlerRan = false;
+			bus.subscribe(
+				'session.created',
+				() => {
+					handlerRan = true;
+				},
+				{ subscriberName: 'sync' }
+			);
+
+			bus.publishAsync('session.created', { sessionId: 's1', title: 'T1' });
+			// Handler should NOT have run yet — it is deferred to the next microtask.
+			expect(handlerRan).toBe(false);
+
+			// Drain microtasks
+			await new Promise((r) => queueMicrotask(r));
+			expect(handlerRan).toBe(true);
+		});
 	});
 
 	describe('diagnostics', () => {

--- a/packages/daemon/tests/unit/1-core/core/internal-event-bus.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/internal-event-bus.test.ts
@@ -1,0 +1,360 @@
+/**
+ * InternalEventBus Unit Tests
+ *
+ * Covers:
+ *   – awaited handler behaviour (publish)
+ *   – structured handler failure behaviour
+ *   – fire-and-forget behaviour (publishAsync)
+ *   – subscriber-name diagnostics
+ *   – session-scoped routing
+ *
+ * See docs/plans/internal-event-command-query-architecture.md
+ */
+
+import { beforeEach, describe, expect, it } from 'bun:test';
+import {
+	InternalEventBus,
+	InternalEventBusPublishError,
+} from '../../../../src/lib/internal-event-bus';
+
+interface TestEventMap {
+	'session.created': { sessionId: string; title: string };
+	'session.updated': { sessionId: string; title?: string };
+	'session.deleted': { sessionId: string };
+	'app.ping': { sessionId: string; ts: number };
+}
+
+describe('InternalEventBus', () => {
+	let bus: InternalEventBus<TestEventMap>;
+
+	beforeEach(() => {
+		bus = new InternalEventBus<TestEventMap>();
+	});
+
+	describe('subscribe', () => {
+		it('should require a non-empty subscriberName', () => {
+			expect(() => bus.subscribe('session.created', () => {}, { subscriberName: '' })).toThrow(
+				'subscriberName'
+			);
+
+			expect(() => bus.subscribe('session.created', () => {}, { subscriberName: '   ' })).toThrow(
+				'subscriberName'
+			);
+		});
+
+		it('should return an unsubscribe function', () => {
+			const unsub = bus.subscribe('session.created', () => {}, {
+				subscriberName: 'test-sub',
+			});
+			expect(typeof unsub).toBe('function');
+		});
+
+		it('should remove handler when unsubscribe is called', async () => {
+			const received: string[] = [];
+			const unsub = bus.subscribe(
+				'session.created',
+				(data) => {
+					received.push(data.sessionId);
+				},
+				{ subscriberName: 'a' }
+			);
+
+			await bus.publish('session.created', { sessionId: 's1', title: 'T1' });
+			expect(received).toEqual(['s1']);
+
+			unsub();
+			await bus.publish('session.created', { sessionId: 's2', title: 'T2' });
+			expect(received).toEqual(['s1']);
+		});
+	});
+
+	describe('publish – awaited handler behaviour', () => {
+		it('should await a single handler', async () => {
+			let received = false;
+			bus.subscribe(
+				'session.created',
+				async () => {
+					await new Promise((r) => setTimeout(r, 5));
+					received = true;
+				},
+				{ subscriberName: 'single' }
+			);
+
+			const result = await bus.publish('session.created', {
+				sessionId: 's1',
+				title: 'T1',
+			});
+			expect(received).toBe(true);
+			expect(result.delivered).toBe(1);
+			expect(result.failures).toHaveLength(0);
+		});
+
+		it('should await multiple handlers concurrently', async () => {
+			const order: number[] = [];
+
+			bus.subscribe(
+				'session.created',
+				async () => {
+					await new Promise((r) => setTimeout(r, 20));
+					order.push(1);
+				},
+				{ subscriberName: 'slow' }
+			);
+
+			bus.subscribe(
+				'session.created',
+				async () => {
+					await new Promise((r) => setTimeout(r, 5));
+					order.push(2);
+				},
+				{ subscriberName: 'fast' }
+			);
+
+			const result = await bus.publish('session.created', {
+				sessionId: 's1',
+				title: 'T1',
+			});
+
+			expect(result.delivered).toBe(2);
+			expect(order).toEqual([2, 1]); // fast finishes first
+		});
+
+		it('should return empty result when no handlers are registered', async () => {
+			const result = await bus.publish('session.deleted', { sessionId: 'orphan' });
+			expect(result.delivered).toBe(0);
+			expect(result.failures).toHaveLength(0);
+		});
+
+		it('should deliver to both session-scoped and global handlers', async () => {
+			const hits: string[] = [];
+
+			bus.subscribe('session.created', () => hits.push('global'), { subscriberName: 'global' });
+			bus.subscribe('session.created', () => hits.push('scoped'), {
+				subscriberName: 'scoped',
+				sessionId: 's1',
+			});
+			bus.subscribe('session.created', () => hits.push('other-scope'), {
+				subscriberName: 'other',
+				sessionId: 's2',
+			});
+
+			const result = await bus.publish('session.created', {
+				sessionId: 's1',
+				title: 'T1',
+			});
+
+			expect(hits.sort()).toEqual(['global', 'scoped']);
+			expect(result.delivered).toBe(2);
+		});
+	});
+
+	describe('publish – handler failure behaviour', () => {
+		it('should throw InternalEventBusPublishError when a handler throws', async () => {
+			const err = new Error('boom');
+			bus.subscribe(
+				'session.created',
+				() => {
+					throw err;
+				},
+				{ subscriberName: 'flaky' }
+			);
+
+			try {
+				await bus.publish('session.created', { sessionId: 's1', title: 'T1' });
+				expect.unreachable('should have thrown');
+			} catch (e) {
+				expect(e).toBeInstanceOf(InternalEventBusPublishError);
+				const pe = e as InternalEventBusPublishError;
+				expect(pe.event).toBe('session.created');
+				expect(pe.result.delivered).toBe(0);
+				expect(pe.result.failures).toHaveLength(1);
+				expect(pe.result.failures[0].subscriberName).toBe('flaky');
+				expect(pe.result.failures[0].event).toBe('session.created');
+				expect(pe.result.failures[0].error).toBe(err);
+			}
+		});
+
+		it('should throw when a handler rejects', async () => {
+			const err = new Error('async boom');
+			bus.subscribe(
+				'session.created',
+				async () => {
+					throw err;
+				},
+				{ subscriberName: 'async-flaky' }
+			);
+
+			await expect(
+				bus.publish('session.created', { sessionId: 's1', title: 'T1' })
+			).rejects.toBeInstanceOf(InternalEventBusPublishError);
+		});
+
+		it('should still run remaining handlers when one throws', async () => {
+			const hits: string[] = [];
+
+			bus.subscribe(
+				'session.created',
+				() => {
+					throw new Error('first');
+				},
+				{ subscriberName: 'bad' }
+			);
+
+			bus.subscribe(
+				'session.created',
+				() => {
+					hits.push('good');
+				},
+				{ subscriberName: 'good' }
+			);
+
+			bus.subscribe(
+				'session.created',
+				async () => {
+					await new Promise((r) => setTimeout(r, 5));
+					hits.push('async-good');
+				},
+				{ subscriberName: 'async-good' }
+			);
+
+			try {
+				await bus.publish('session.created', { sessionId: 's1', title: 'T1' });
+				expect.unreachable('should have thrown');
+			} catch (e) {
+				const pe = e as InternalEventBusPublishError;
+				expect(pe.result.delivered).toBe(2);
+				expect(pe.result.failures).toHaveLength(1);
+				expect(hits.sort()).toEqual(['async-good', 'good']);
+			}
+		});
+
+		it('should collect multiple failures in a single publish', async () => {
+			bus.subscribe(
+				'session.created',
+				() => {
+					throw new Error('a');
+				},
+				{ subscriberName: 'a' }
+			);
+			bus.subscribe(
+				'session.created',
+				() => {
+					throw new Error('b');
+				},
+				{ subscriberName: 'b' }
+			);
+
+			try {
+				await bus.publish('session.created', { sessionId: 's1', title: 'T1' });
+				expect.unreachable('should have thrown');
+			} catch (e) {
+				const pe = e as InternalEventBusPublishError;
+				expect(pe.result.failures).toHaveLength(2);
+				const names = pe.result.failures.map((f) => f.subscriberName).sort();
+				expect(names).toEqual(['a', 'b']);
+			}
+		});
+
+		it('should wrap non-Error throws in Error objects', async () => {
+			bus.subscribe(
+				'session.created',
+				() => {
+					throw 'string-throw';
+				},
+				{ subscriberName: 'weird' }
+			);
+
+			try {
+				await bus.publish('session.created', { sessionId: 's1', title: 'T1' });
+				expect.unreachable('should have thrown');
+			} catch (e) {
+				const pe = e as InternalEventBusPublishError;
+				expect(pe.result.failures[0].error).toBeInstanceOf(Error);
+				expect(pe.result.failures[0].error.message).toBe('string-throw');
+			}
+		});
+	});
+
+	describe('publishAsync – fire-and-forget', () => {
+		it('should return immediately without awaiting handlers', async () => {
+			let resolved = false;
+			bus.subscribe(
+				'session.created',
+				async () => {
+					await new Promise((r) => setTimeout(r, 50));
+					resolved = true;
+				},
+				{ subscriberName: 'slow' }
+			);
+
+			const start = performance.now();
+			bus.publishAsync('session.created', { sessionId: 's1', title: 'T1' });
+			const elapsed = performance.now() - start;
+
+			expect(elapsed).toBeLessThan(10);
+			expect(resolved).toBe(false);
+
+			// Wait for handler to finish
+			await new Promise((r) => setTimeout(r, 80));
+			expect(resolved).toBe(true);
+		});
+
+		it('should not throw when a handler fails', async () => {
+			bus.subscribe(
+				'session.created',
+				() => {
+					throw new Error('async-boom');
+				},
+				{ subscriberName: 'flaky' }
+			);
+
+			// Must not throw synchronously or as an unhandled rejection
+			expect(() =>
+				bus.publishAsync('session.created', { sessionId: 's1', title: 'T1' })
+			).not.toThrow();
+
+			// Give microtasks a chance to run
+			await new Promise((r) => setTimeout(r, 10));
+		});
+	});
+
+	describe('diagnostics', () => {
+		it('should report correct handler counts', () => {
+			expect(bus.getHandlerCount('session.created')).toBe(0);
+
+			bus.subscribe('session.created', () => {}, { subscriberName: 'a' });
+			bus.subscribe('session.created', () => {}, { subscriberName: 'b' });
+			bus.subscribe('session.created', () => {}, { subscriberName: 'c', sessionId: 's1' });
+
+			expect(bus.getHandlerCount('session.created')).toBe(3);
+			expect(bus.getHandlerCountForSession('session.created', 's1')).toBe(1);
+			expect(bus.getHandlerCountForSession('session.created', 's2')).toBe(0);
+		});
+
+		it('should clear all handlers', async () => {
+			const hits: string[] = [];
+			bus.subscribe('session.created', () => hits.push('a'), { subscriberName: 'a' });
+			bus.subscribe('session.updated', () => hits.push('b'), { subscriberName: 'b' });
+
+			bus.clear();
+
+			await bus.publish('session.created', { sessionId: 's1', title: 'T1' });
+			await bus.publish('session.updated', { sessionId: 's1' });
+
+			expect(hits).toHaveLength(0);
+		});
+
+		it('should clear handlers for a specific event via off()', async () => {
+			const hits: string[] = [];
+			bus.subscribe('session.created', () => hits.push('created'), { subscriberName: 'c' });
+			bus.subscribe('session.deleted', () => hits.push('deleted'), { subscriberName: 'd' });
+
+			bus.off('session.created');
+
+			await bus.publish('session.created', { sessionId: 's1', title: 'T1' });
+			await bus.publish('session.deleted', { sessionId: 's1' });
+
+			expect(hits).toEqual(['deleted']);
+		});
+	});
+});

--- a/packages/daemon/tests/unit/1-core/core/internal-event-bus.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/internal-event-bus.test.ts
@@ -25,6 +25,15 @@ interface TestEventMap {
 	'app.ping': { sessionId: string; ts: number };
 }
 
+/**
+ * Interface without a string index signature — verifies the class constraint
+ * is loose enough to accept normal keyed interfaces (P2).
+ */
+interface KeyedInterfaceEventMap {
+	'order.placed': { sessionId: string; orderId: string };
+	'order.shipped': { sessionId: string; orderId: string; tracking: string };
+}
+
 describe('InternalEventBus', () => {
 	let bus: InternalEventBus<TestEventMap>;
 
@@ -41,6 +50,15 @@ describe('InternalEventBus', () => {
 			expect(() => bus.subscribe('session.created', () => {}, { subscriberName: '   ' })).toThrow(
 				'subscriberName'
 			);
+		});
+
+		it('should reject the reserved global session key as an explicit sessionId', () => {
+			expect(() =>
+				bus.subscribe('session.created', () => {}, {
+					subscriberName: 'bad',
+					sessionId: '__global__',
+				})
+			).toThrow('reserved');
 		});
 
 		it('should return an unsubscribe function', () => {
@@ -413,5 +431,28 @@ describe('InternalEventBus', () => {
 
 			expect(hits).toEqual(['deleted']);
 		});
+	});
+});
+
+describe('InternalEventBus keyed interface compatibility', () => {
+	it('should accept interface-style event maps without a string index signature', async () => {
+		const keyedBus = new InternalEventBus<KeyedInterfaceEventMap>();
+		const hits: string[] = [];
+
+		keyedBus.subscribe(
+			'order.placed',
+			(data) => {
+				hits.push(data.orderId);
+			},
+			{ subscriberName: 'orders' }
+		);
+
+		const result = await keyedBus.publish('order.placed', {
+			sessionId: 's1',
+			orderId: 'ord-123',
+		});
+
+		expect(hits).toEqual(['ord-123']);
+		expect(result.delivered).toBe(1);
 	});
 });

--- a/packages/daemon/tests/unit/1-core/core/internal-event-bus.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/internal-event-bus.test.ts
@@ -13,6 +13,7 @@
 
 import { beforeEach, describe, expect, it } from 'bun:test';
 import {
+	createInternalEventBus,
 	InternalEventBus,
 	InternalEventBusPublishError,
 } from '../../../../src/lib/internal-event-bus';
@@ -145,6 +146,20 @@ describe('InternalEventBus', () => {
 
 			expect(hits.sort()).toEqual(['global', 'scoped']);
 			expect(result.delivered).toBe(2);
+		});
+
+		it('should not double-deliver when sessionId equals the global sentinel', async () => {
+			const hits: string[] = [];
+
+			bus.subscribe('session.created', () => hits.push('global'), { subscriberName: 'global' });
+
+			const result = await bus.publish('session.created', {
+				sessionId: '__global__',
+				title: 'T1',
+			});
+
+			expect(hits).toEqual(['global']);
+			expect(result.delivered).toBe(1);
 		});
 	});
 
@@ -334,6 +349,29 @@ describe('InternalEventBus', () => {
 			// Drain microtasks
 			await new Promise((r) => queueMicrotask(r));
 			expect(handlerRan).toBe(true);
+		});
+	});
+
+	describe('createInternalEventBus factory', () => {
+		it('should produce a working typed bus', async () => {
+			const factoryBus = createInternalEventBus<TestEventMap>();
+			const hits: string[] = [];
+
+			factoryBus.subscribe(
+				'session.created',
+				(data) => {
+					hits.push(data.sessionId);
+				},
+				{ subscriberName: 'factory-sub' }
+			);
+
+			const result = await factoryBus.publish('session.created', {
+				sessionId: 'factory-test',
+				title: 'Factory Test',
+			});
+
+			expect(hits).toEqual(['factory-test']);
+			expect(result.delivered).toBe(1);
 		});
 	});
 


### PR DESCRIPTION
Introduces `InternalEventBus` — a typed pub/sub primitive for daemon-internal messaging with explicit await-vs-fire-and-forget semantics.

**What's new:**
- `publish(...)` awaits every matching handler and throws `InternalEventBusPublishError` containing structured `HandlerFailure` details when any handler fails. All handlers still run even if one throws.
- `publishAsync(...)` is explicit fire-and-forget; returns immediately and swallows failures silently.
- Subscriber names are required for diagnostics.
- Session-scoped and global subscriptions supported.
- Convenience factory `createInternalEventBus()` exported from `@neokai/daemon/lib/internal-event-bus`.

**Out of scope (v1):**
- No persistence / replay.
- No broad call-site migration; existing EventBus/DaemonHub callers remain untouched.

**Testing:**
- 17 unit tests covering awaited handler behaviour, handler failure behaviour, publishAsync fire-and-forget, session-scoped routing, and diagnostics.

**Documentation:**
- `docs/plans/internal-event-command-query-architecture.md` captures the long-term architecture plan.