### PR TITLE
fix(shared,agents): add missing tools to KNOWN_TOOLS and specialist agents

### DIFF
--- a/packages/daemon/src/lib/agent/coordinator/coder.ts
+++ b/packages/daemon/src/lib/agent/coordinator/coder.ts
@@ -19,6 +19,8 @@ export const coderAgent: AgentDefinition = {
 		'TaskStop',
 		'EnterPlanMode',
 		'ExitPlanMode',
+		'NotebookEdit',
+		'ToolSearch',
 	],
 	model: 'sonnet',
 	prompt: `You are a focused code implementer. Your job is to achieve the stated goal by making precise, minimal code changes.

--- a/packages/daemon/src/lib/agent/coordinator/debugger.ts
+++ b/packages/daemon/src/lib/agent/coordinator/debugger.ts
@@ -18,6 +18,8 @@ export const debuggerAgent: AgentDefinition = {
 		'TaskStop',
 		'EnterPlanMode',
 		'ExitPlanMode',
+		'NotebookEdit',
+		'ToolSearch',
 	],
 	model: 'sonnet',
 	prompt: `You are a debugging specialist. Your job is to reproduce issues, trace code paths, and find root causes.

--- a/packages/daemon/src/lib/agent/coordinator/reviewer.ts
+++ b/packages/daemon/src/lib/agent/coordinator/reviewer.ts
@@ -3,7 +3,7 @@ import type { AgentDefinition } from '@neokai/shared';
 export const reviewerAgent: AgentDefinition = {
 	description:
 		'Review code for quality, security, and correctness. Use after code changes to verify they are sound.',
-	tools: ['Read', 'Grep', 'Glob', 'Bash', 'WebFetch', 'WebSearch', 'Skill'],
+	tools: ['Read', 'Grep', 'Glob', 'Bash', 'WebFetch', 'WebSearch', 'Skill', 'ToolSearch'],
 	model: 'opus',
 	prompt: `You are a code reviewer. Your job is to review code changes for correctness, quality, security, and alignment with the original goal.
 

--- a/packages/daemon/src/lib/agent/coordinator/tester.ts
+++ b/packages/daemon/src/lib/agent/coordinator/tester.ts
@@ -19,6 +19,8 @@ export const testerAgent: AgentDefinition = {
 		'TaskStop',
 		'EnterPlanMode',
 		'ExitPlanMode',
+		'NotebookEdit',
+		'ToolSearch',
 	],
 	model: 'sonnet',
 	prompt: `You are a testing specialist. Your job is to write comprehensive tests that verify the stated requirements.

--- a/packages/daemon/src/lib/agent/coordinator/vcs.ts
+++ b/packages/daemon/src/lib/agent/coordinator/vcs.ts
@@ -3,7 +3,7 @@ import type { AgentDefinition } from '@neokai/shared';
 export const vcsAgent: AgentDefinition = {
 	description:
 		'Version control specialist. Creates logical commits, pushes to remote, creates PRs, monitors CI status, and reports failures back for resolution.',
-	tools: ['Bash', 'Read', 'Grep', 'Glob', 'WebFetch', 'WebSearch', 'Skill'],
+	tools: ['Bash', 'Read', 'Grep', 'Glob', 'WebFetch', 'WebSearch', 'Skill', 'ToolSearch'],
 	model: 'sonnet',
 	prompt: `You are a version control specialist. Your job is to manage git operations with clean, logical commits and ensure CI passes.
 

--- a/packages/daemon/src/lib/agent/coordinator/verifier.ts
+++ b/packages/daemon/src/lib/agent/coordinator/verifier.ts
@@ -3,7 +3,7 @@ import type { AgentDefinition } from '@neokai/shared';
 export const verifierAgent: AgentDefinition = {
 	description:
 		'Critical result verification. Use as the final step to verify that work actually meets the original requirements. Catches cut corners, incomplete implementations, and claims that do not match reality.',
-	tools: ['Read', 'Grep', 'Glob', 'Bash', 'WebFetch', 'WebSearch', 'Skill'],
+	tools: ['Read', 'Grep', 'Glob', 'Bash', 'WebFetch', 'WebSearch', 'Skill', 'ToolSearch'],
 	model: 'opus',
 	prompt: `You are a critical verification specialist. Your job is to independently verify that completed work actually meets the original requirements. You are skeptical by default - you trust evidence, not claims.
 

--- a/packages/daemon/src/lib/space/agents/seed-agents.ts
+++ b/packages/daemon/src/lib/space/agents/seed-agents.ts
@@ -70,13 +70,24 @@ const REVIEWER_TOOLS: string[] = [
 	'Glob',
 	'WebFetch',
 	'WebSearch',
+	'Skill',
+	'ToolSearch',
 	'Task',
 	'TaskOutput',
 	'TaskStop',
 ];
 
 /** QA: read-only + bash for running tests — no Write or Edit */
-const QA_TOOLS: string[] = ['Read', 'Bash', 'Grep', 'Glob', 'WebFetch', 'WebSearch'];
+const QA_TOOLS: string[] = [
+	'Read',
+	'Bash',
+	'Grep',
+	'Glob',
+	'WebFetch',
+	'WebSearch',
+	'Skill',
+	'ToolSearch',
+];
 
 /**
  * Tool profiles per preset agent name. Exported for testing and external consumption.

--- a/packages/daemon/tests/unit/5-space/other/seed-agents.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/seed-agents.test.ts
@@ -373,7 +373,16 @@ describe('preset agent exact definitions', () => {
 		(t) => !['Task', 'TaskOutput', 'TaskStop'].includes(t)
 	) as unknown as string[];
 
-	const EXPECTED_READONLY_TOOLS = ['Read', 'Bash', 'Grep', 'Glob', 'WebFetch', 'WebSearch'];
+	const EXPECTED_READONLY_TOOLS = [
+		'Read',
+		'Bash',
+		'Grep',
+		'Glob',
+		'WebFetch',
+		'WebSearch',
+		'Skill',
+		'ToolSearch',
+	];
 	// Reviewer has the read-only toolset PLUS Task/TaskOutput/TaskStop so it
 	// can dispatch the built-in `general-purpose` sub-agent for exploration.
 	const EXPECTED_REVIEWER_TOOLS = [...EXPECTED_READONLY_TOOLS, 'Task', 'TaskOutput', 'TaskStop'];
@@ -536,7 +545,16 @@ describe('PRESET_AGENT_TOOLS export', () => {
 		(t) => !['Task', 'TaskOutput', 'TaskStop'].includes(t)
 	) as unknown as string[];
 
-	const EXPECTED_READONLY_TOOLS = ['Read', 'Bash', 'Grep', 'Glob', 'WebFetch', 'WebSearch'];
+	const EXPECTED_READONLY_TOOLS = [
+		'Read',
+		'Bash',
+		'Grep',
+		'Glob',
+		'WebFetch',
+		'WebSearch',
+		'Skill',
+		'ToolSearch',
+	];
 	// Reviewer additionally carries Task/TaskOutput/TaskStop for built-in
 	// `general-purpose` sub-agent delegation.
 	const EXPECTED_REVIEWER_TOOLS = [...EXPECTED_READONLY_TOOLS, 'Task', 'TaskOutput', 'TaskStop'];

--- a/packages/shared/src/types/tools.ts
+++ b/packages/shared/src/types/tools.ts
@@ -17,4 +17,11 @@ export const KNOWN_TOOLS = [
 	'Task',
 	'TaskOutput',
 	'TaskStop',
+	'NotebookEdit',
+	'TodoWrite',
+	'AskUserQuestion',
+	'EnterPlanMode',
+	'ExitPlanMode',
+	'Skill',
+	'ToolSearch',
 ] as const;


### PR DESCRIPTION
Follow-up to #1805. The original PR was squash-merged before the KNOWN_TOOLS and agent seed commits reached the branch.

- Add 7 missing built-in tools to `KNOWN_TOOLS` so the Space agent editor UI can toggle all 18 daemon-exposed tools.
- Enable `NotebookEdit` for Coder, Debugger, Tester (file-editing agents that may work with Jupyter notebooks).
- Enable `ToolSearch` for all specialists for dynamic tool discovery as MCP servers attach at runtime.

🤖 Generated with [Claude Code](https://claude.com/code)