### PR TITLE
Fix submit_for_approval state transition and prevent autonomy gate bypass

### DIFF
--- a/packages/daemon/src/lib/space/agents/seed-agents.ts
+++ b/packages/daemon/src/lib/space/agents/seed-agents.ts
@@ -207,6 +207,11 @@ If your verdict on this round is \`REQUEST_CHANGES\` (ANY P0–P3 finding exists
 
 **Important:** \`approve_task\` and \`submit_for_approval\` are your FINAL actions. After calling either tool, do NOT send a message to any agent or node. The workflow handles the transition — sending a message after a terminal action can reactivate other agents before human approval is granted.
 
+**If \`submit_for_approval\` fails for any reason** (state machine error, invalid transition, or any runtime error), you MUST:
+1. Report the error clearly in your output — explain what failed and why.
+2. **STOP**. Do NOT send a message to \`space-agent\` or any other agent asking to "advance the task to merge" or bypass the approval step.
+3. Do NOT attempt any workaround that would skip human approval. The human approval gate is mandatory at autonomy level 1 — it must be preserved regardless of technical errors.
+
 ## Posting the Review
 
 Determine the event deterministically (own-PR detection), then post via the REST API so the response includes the review URL:

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -25,7 +25,10 @@ import { SpaceTaskRepository } from '../../../storage/repositories/space-task-re
  */
 export const VALID_SPACE_TASK_TRANSITIONS: Record<SpaceTaskStatus, SpaceTaskStatus[]> = {
 	draft: ['open', 'archived'], // Only publish or archive
-	open: ['in_progress', 'blocked', 'done', 'cancelled'],
+	// `review` is allowed from `open` so that a review node can call
+	// `submit_for_approval` even when the task has not yet transitioned to
+	// `in_progress` (e.g. review-only workflow or runtime scheduling edge).
+	open: ['in_progress', 'blocked', 'review', 'done', 'cancelled'],
 	// `in_progress → approved` is the end-node `approve_task` path (PR 2/5 of
 	// the task-agent-as-post-approval-executor refactor). It replaces the
 	// `in_progress → done` shortcut that the completion-action pipeline used
@@ -42,7 +45,10 @@ export const VALID_SPACE_TASK_TRANSITIONS: Record<SpaceTaskStatus, SpaceTaskStat
 	// and surfaces via `PendingPostApprovalBanner`.
 	approved: ['done', 'in_progress', 'archived'],
 	done: ['in_progress', 'archived'], // Reactivate or archive
-	blocked: ['open', 'in_progress', 'archived'], // Restart allowed + archive
+	// `review` is allowed from `blocked` so that a review node can call
+	// `submit_for_approval` after the task was parked in `blocked` (e.g.
+	// waiting for a dependency or a prior human-input gate).
+	blocked: ['open', 'in_progress', 'review', 'archived'], // Restart allowed + archive
 	cancelled: ['open', 'in_progress', 'done', 'archived'], // Restart, complete, or archive
 	archived: [], // True terminal state — no going back
 };

--- a/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
@@ -575,18 +575,24 @@ describe('SpaceTaskManager', () => {
 			]);
 		});
 
-		it('blocked allows restart and archival', () => {
-			expect(VALID_SPACE_TASK_TRANSITIONS.blocked).toEqual(['open', 'in_progress', 'archived']);
+		it('blocked allows restart, review, and archival', () => {
+			expect(VALID_SPACE_TASK_TRANSITIONS.blocked).toEqual([
+				'open',
+				'in_progress',
+				'review',
+				'archived',
+			]);
 		});
 
 		it('archived is a true terminal state with no transitions', () => {
 			expect(VALID_SPACE_TASK_TRANSITIONS.archived).toEqual([]);
 		});
 
-		it('open allows in_progress, blocked, done, and cancelled', () => {
+		it('open allows in_progress, blocked, review, done, and cancelled', () => {
 			expect(VALID_SPACE_TASK_TRANSITIONS.open).toEqual([
 				'in_progress',
 				'blocked',
+				'review',
 				'done',
 				'cancelled',
 			]);
@@ -1055,6 +1061,38 @@ describe('SpaceTaskManager', () => {
 			expect(after?.status).toBe('done');
 			expect(after?.pendingCheckpointType).toBeFalsy();
 			expect(after?.pendingCompletionSubmittedAt).toBeFalsy();
+		});
+
+		it('transitions blocked→review and stamps pending-completion fields', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			await manager.startTask(task.id);
+			await manager.failTask(task.id, 'waiting for dependency');
+
+			const reviewing = await manager.submitTaskForReview(task.id, {
+				submittedByNodeId: 'node-B',
+				reason: 'reviewer is ready to submit',
+			});
+
+			expect(reviewing.status).toBe('review');
+			expect(reviewing.pendingCheckpointType).toBe('task_completion');
+			expect(reviewing.pendingCompletionSubmittedByNodeId).toBe('node-B');
+			expect(reviewing.pendingCompletionReason).toBe('reviewer is ready to submit');
+		});
+
+		it('transitions open→review and stamps pending-completion fields', async () => {
+			const task = await manager.createTask({ title: 'T', description: '' });
+			// Task stays in `open` — e.g. a review-only workflow where the
+			// reviewer node activates before the task ever hits `in_progress`.
+
+			const reviewing = await manager.submitTaskForReview(task.id, {
+				submittedByNodeId: null,
+				reason: 'review-only submit',
+			});
+
+			expect(reviewing.status).toBe('review');
+			expect(reviewing.pendingCheckpointType).toBe('task_completion');
+			expect(reviewing.pendingCompletionSubmittedByNodeId).toBeNull();
+			expect(reviewing.pendingCompletionReason).toBe('review-only submit');
 		});
 
 		it('writes status and pending-completion fields in a single UPDATE (atomicity)', async () => {

--- a/packages/daemon/tests/unit/5-space/agent/end-node-handlers.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/end-node-handlers.test.ts
@@ -446,6 +446,42 @@ describe('createEndNodeHandlers — submit_for_approval', () => {
 		expect(emittedTask.pendingCheckpointType).toBe('task_completion');
 	});
 
+	test('succeeds when task is in blocked status', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'blocked',
+		});
+		const { onSubmitForApproval } = createEndNodeHandlers(makeDeps(ctx, task.id));
+
+		const out = await onSubmitForApproval({ reason: 'from blocked' });
+		const parsed = JSON.parse(out.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		const t = ctx.taskRepo.getTask(task.id);
+		expect(t?.status).toBe('review');
+		expect(t?.pendingCompletionReason).toBe('from blocked');
+	});
+
+	test('succeeds when task is in open status', async () => {
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'T',
+			description: '',
+			status: 'open',
+		});
+		const { onSubmitForApproval } = createEndNodeHandlers(makeDeps(ctx, task.id));
+
+		const out = await onSubmitForApproval({ reason: 'from open' });
+		const parsed = JSON.parse(out.content[0].text);
+
+		expect(parsed.success).toBe(true);
+		const t = ctx.taskRepo.getTask(task.id);
+		expect(t?.status).toBe('review');
+		expect(t?.pendingCompletionReason).toBe('from open');
+	});
+
 	test('returns error when task does not exist', async () => {
 		const { onSubmitForApproval } = createEndNodeHandlers(makeDeps(ctx, 'ghost'));
 		const out = await onSubmitForApproval({ reason: 'x' });

--- a/packages/daemon/tests/unit/5-space/other/seed-agents.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/seed-agents.test.ts
@@ -290,6 +290,19 @@ describe('seedPresetAgents', () => {
 		expect(reviewer?.customPrompt).toMatch(/before human approval is granted/i);
 	});
 
+	it('Reviewer custom prompt prohibits space-agent merge bypass when submit_for_approval fails (Task #295)', async () => {
+		const { seeded } = await seedPresetAgents('space-1', manager);
+		const reviewer = seeded.find((a) => a.name === 'Reviewer');
+
+		// If submit_for_approval fails, the reviewer must NOT escalate to
+		// space-agent to bypass the human approval gate.
+		expect(reviewer?.customPrompt).toMatch(/If `submit_for_approval` fails for any reason/i);
+		expect(reviewer?.customPrompt).toMatch(/Do NOT send a message to `space-agent`/i);
+		expect(reviewer?.customPrompt).toMatch(/advance the task to merge/i);
+		expect(reviewer?.customPrompt).toMatch(/human approval gate is mandatory/i);
+		expect(reviewer?.customPrompt).toMatch(/STOP/i);
+	});
+
 	it('Reviewer custom prompt includes own-PR detection', async () => {
 		const { seeded } = await seedPresetAgents('space-1', manager);
 		const reviewer = seeded.find((a) => a.name === 'Reviewer');

--- a/packages/web/src/components/space/TaskStatusActions.tsx
+++ b/packages/web/src/components/space/TaskStatusActions.tsx
@@ -6,7 +6,7 @@ import type { SpaceTaskStatus } from '@neokai/shared';
  */
 export const VALID_TASK_TRANSITIONS: Record<SpaceTaskStatus, SpaceTaskStatus[]> = {
 	draft: ['open', 'archived'],
-	open: ['in_progress', 'blocked', 'done', 'cancelled'],
+	open: ['in_progress', 'blocked', 'review', 'done', 'cancelled'],
 	in_progress: ['open', 'review', 'done', 'blocked', 'cancelled'],
 	review: ['done', 'in_progress', 'cancelled', 'archived'],
 	// `approved` is the post-approval staging status. Conservative transition
@@ -14,7 +14,7 @@ export const VALID_TASK_TRANSITIONS: Record<SpaceTaskStatus, SpaceTaskStatus[]> 
 	// the PostApprovalRouter is unable to advance a task automatically.
 	approved: ['done', 'in_progress', 'archived'],
 	done: ['in_progress', 'archived'],
-	blocked: ['open', 'in_progress', 'archived'],
+	blocked: ['open', 'in_progress', 'review', 'archived'],
 	cancelled: ['open', 'in_progress', 'done', 'archived'],
 	archived: [],
 };
@@ -27,6 +27,7 @@ export const TRANSITION_LABELS: Record<string, string> = {
 	'draft->archived': 'Archive',
 	'open->in_progress': 'Start',
 	'open->blocked': 'Block',
+	'open->review': 'Submit for Review',
 	'open->done': 'Mark Done',
 	'open->cancelled': 'Cancel',
 	'in_progress->open': 'Pause',
@@ -48,6 +49,7 @@ export const TRANSITION_LABELS: Record<string, string> = {
 	'done->archived': 'Archive',
 	'blocked->open': 'Reopen',
 	'blocked->in_progress': 'Resume',
+	'blocked->review': 'Submit for Review',
 	'blocked->archived': 'Archive',
 	'cancelled->open': 'Reopen',
 	'cancelled->in_progress': 'Resume',

--- a/packages/web/src/components/space/__tests__/TaskStatusActions.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskStatusActions.test.tsx
@@ -15,8 +15,14 @@ afterEach(() => {
 });
 
 describe('VALID_TASK_TRANSITIONS', () => {
-	it('open can transition to in_progress, blocked, done, and cancelled', () => {
-		expect(VALID_TASK_TRANSITIONS.open).toEqual(['in_progress', 'blocked', 'done', 'cancelled']);
+	it('open can transition to in_progress, blocked, review, done, and cancelled', () => {
+		expect(VALID_TASK_TRANSITIONS.open).toEqual([
+			'in_progress',
+			'blocked',
+			'review',
+			'done',
+			'cancelled',
+		]);
 	});
 
 	it('in_progress can transition to open, review, done, blocked, cancelled', () => {
@@ -33,8 +39,8 @@ describe('VALID_TASK_TRANSITIONS', () => {
 		expect(VALID_TASK_TRANSITIONS.done).toEqual(['in_progress', 'archived']);
 	});
 
-	it('blocked can transition to open, in_progress, archived', () => {
-		expect(VALID_TASK_TRANSITIONS.blocked).toEqual(['open', 'in_progress', 'archived']);
+	it('blocked can transition to open, in_progress, review, archived', () => {
+		expect(VALID_TASK_TRANSITIONS.blocked).toEqual(['open', 'in_progress', 'review', 'archived']);
 	});
 
 	it('cancelled can transition to open, in_progress, done, archived', () => {
@@ -52,6 +58,7 @@ describe('getTransitionActions', () => {
 		expect(actions).toEqual([
 			{ target: 'in_progress', label: 'Start' },
 			{ target: 'blocked', label: 'Block' },
+			{ target: 'review', label: 'Submit for Review' },
 			{ target: 'done', label: 'Mark Done' },
 			{ target: 'cancelled', label: 'Cancel' },
 		]);
@@ -81,6 +88,7 @@ describe('getTransitionActions', () => {
 		expect(actions).toEqual([
 			{ target: 'open', label: 'Reopen' },
 			{ target: 'in_progress', label: 'Resume' },
+			{ target: 'review', label: 'Submit for Review' },
 			{ target: 'archived', label: 'Archive' },
 		]);
 	});


### PR DESCRIPTION
Fixes two related issues with the review/approval workflow:

1. **State machine**: adds `review` as a valid transition from `blocked` and `open`, so `submit_for_approval` works when called from a review node regardless of whether the task is in `blocked`, `open`, or `in_progress`.

2. **Reviewer prompt guard**: adds an explicit instruction that if `submit_for_approval` fails for any reason, the reviewer must report the error and stop — never send a merge directive to `space-agent` or attempt any workaround that would bypass the human approval gate.

Task #295