### PR TITLE
Add OpenAI reasoning.effort support to anthropic-codex bridge

### DIFF
--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -583,8 +583,14 @@ export class QueryOptionsBuilder {
 		// providers that do not support it. Use the static map rather than
 		// instantiating a provider context to avoid API-key failures in CI.
 		const providerId = this.ctx.session.config.provider;
-		const thinkingModes =
+		let thinkingModes =
 			PROVIDER_THINKING_MODES[providerId as keyof typeof PROVIDER_THINKING_MODES] ?? 'granular';
+		// The anthropic-codex provider can run with either the OpenAI Responses
+		// API adapter (supports reasoning) or the legacy Codex app-server adapter
+		// (does not support reasoning). Gate thinking at runtime by env var.
+		if (providerId === 'anthropic-codex' && process.env.NEOKAI_OPENAI_BRIDGE_ADAPTER === 'codex') {
+			thinkingModes = 'off';
+		}
 
 		// Add thinking configuration based on the session override, falling back to the app default.
 		// Backward compatibility: legacy 'auto' is treated as 'off'.

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -588,7 +588,8 @@ export class QueryOptionsBuilder {
 		// The anthropic-codex provider can run with either the OpenAI Responses
 		// API adapter (supports reasoning) or the legacy Codex app-server adapter
 		// (does not support reasoning). Gate thinking at runtime by env var.
-		if (providerId === 'anthropic-codex' && process.env.NEOKAI_OPENAI_BRIDGE_ADAPTER === 'codex') {
+		const bridgeAdapter = process.env.NEOKAI_OPENAI_BRIDGE_ADAPTER?.trim().toLowerCase();
+		if (providerId === 'anthropic-codex' && bridgeAdapter === 'codex') {
 			thinkingModes = 'off';
 		}
 

--- a/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
@@ -220,16 +220,20 @@ export class AnthropicToCodexBridgeProvider implements Provider {
 	readonly id = 'anthropic-codex';
 	readonly displayName = 'OpenAI (Codex)';
 
-	readonly capabilities: ProviderCapabilities = {
-		streaming: true,
-		// GPT-5.5 supports reasoning.effort via the OpenAI Responses API; the bridge
-		// translates OpenAI reasoning events to Anthropic thinking SSE blocks.
-		extendedThinking: true,
-		thinkingModes: 'granular',
-		maxContextWindow: 272000,
-		functionCalling: true,
-		vision: false,
-	};
+	get capabilities(): ProviderCapabilities {
+		const isResponses = this.selectBridgeAdapter() === 'responses';
+		return {
+			streaming: true,
+			// GPT-5.5 supports reasoning.effort via the OpenAI Responses API; the bridge
+			// translates OpenAI reasoning events to Anthropic thinking SSE blocks.
+			// The legacy Codex app-server adapter does not support reasoning.
+			extendedThinking: isResponses,
+			thinkingModes: isResponses ? 'granular' : 'off',
+			maxContextWindow: 272000,
+			functionCalling: true,
+			vision: false,
+		};
+	}
 
 	/** Per-adapter bridge servers. Codex remains workspace-scoped; Responses is shared by auth. */
 	private readonly bridgeServers = new Map<string, BridgeServer | OpenAIResponsesBridgeServer>();

--- a/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
@@ -518,7 +518,8 @@ export class AnthropicToCodexBridgeProvider implements Provider {
 		// UI-only: it gates the Login/Logout buttons but must not hide models from users
 		// who authenticate via OPENAI_API_KEY / CODEX_API_KEY env vars.
 		if (!(await this.isAvailable())) return [];
-		return ANTHROPIC_CODEX_MODELS;
+		const thinkingModes = this.selectBridgeAdapter() === 'responses' ? 'granular' : 'off';
+		return ANTHROPIC_CODEX_MODELS.map((m) => ({ ...m, thinkingModes }));
 	}
 
 	ownsModel(modelId: string): boolean {

--- a/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
@@ -222,10 +222,10 @@ export class AnthropicToCodexBridgeProvider implements Provider {
 
 	readonly capabilities: ProviderCapabilities = {
 		streaming: true,
-		// The Anthropic Agent SDK can ask for extended thinking, but this provider's
-		// OpenAI bridge does not expose Anthropic thinking_delta events.
-		extendedThinking: false,
-		thinkingModes: 'off',
+		// GPT-5.5 supports reasoning.effort via the OpenAI Responses API; the bridge
+		// translates OpenAI reasoning events to Anthropic thinking SSE blocks.
+		extendedThinking: true,
+		thinkingModes: 'granular',
 		maxContextWindow: 272000,
 		functionCalling: true,
 		vision: false,

--- a/packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts
+++ b/packages/daemon/src/lib/providers/codex-anthropic-bridge/translator.ts
@@ -62,6 +62,11 @@ export type AnthropicRequest = {
 	 * A warning is logged when this field is present.
 	 */
 	tool_choice?: ToolChoice;
+	/**
+	 * Extended-thinking configuration emitted by the SDK.
+	 * The bridge maps `budget_tokens` to OpenAI `reasoning.effort`.
+	 */
+	thinking?: { type: 'enabled'; budget_tokens: number } | { type: 'adaptive' };
 };
 
 // ---------------------------------------------------------------------------
@@ -284,6 +289,22 @@ export function contentBlockStartToolUseSSE(
 	});
 }
 
+export function contentBlockStartThinkingSSE(index: number): string {
+	return sseEvent('content_block_start', {
+		type: 'content_block_start',
+		index,
+		content_block: { type: 'thinking', thinking: '' },
+	});
+}
+
+export function thinkingDeltaSSE(index: number, thinking: string): string {
+	return sseEvent('content_block_delta', {
+		type: 'content_block_delta',
+		index,
+		delta: { type: 'thinking_delta', thinking },
+	});
+}
+
 export function textDeltaSSE(index: number, text: string): string {
 	return sseEvent('content_block_delta', {
 		type: 'content_block_delta',
@@ -323,6 +344,8 @@ export type MessageDeltaUsage = {
 	cacheReadInputTokens?: number | null;
 	/** Model context window (from Codex usage events when available). */
 	modelContextWindow?: number | null;
+	/** Thinking / reasoning token count (from OpenAI usage events when available). */
+	thinkingTokens?: number | null;
 };
 
 export function messageDeltaSSE(
@@ -338,6 +361,7 @@ export function messageDeltaSSE(
 			cache_creation_input_tokens: usage.cacheCreationInputTokens ?? null,
 			cache_read_input_tokens: usage.cacheReadInputTokens ?? null,
 			model_context_window: usage.modelContextWindow ?? null,
+			thinking_tokens: usage.thinkingTokens ?? null,
 		},
 	});
 }

--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -26,7 +26,6 @@ import {
 	textDeltaSSE,
 	thinkingDeltaSSE,
 } from '../codex-anthropic-bridge/translator.js';
-import { estimateAnthropicInputTokens } from '../codex-anthropic-bridge/token-estimator.js';
 import { getModelContextWindow as getCodexModelContextWindow } from '../codex-anthropic-bridge/model-context-windows.js';
 import { createAnthropicErrorBody, type AnthropicErrorType } from '../shared/error-envelope.js';
 import { Logger } from '../../logger.js';
@@ -1078,10 +1077,17 @@ export function createOpenAIResponsesBridgeServer(
 			if (route.pathname === '/v1/messages/count_tokens' && req.method === 'POST') {
 				try {
 					const body = (await req.json()) as AnthropicRequest;
-					const continuation = resolveContinuation(route.sessionId, body.messages, continuations);
+					const storedReasoning = sessionReasoningItems.get(route.sessionId);
+					let continuation = resolveContinuation(route.sessionId, body.messages, continuations);
+					if (storedReasoning && storedReasoning.length > 0) {
+						continuation = undefined;
+					}
 					const inputTokens = continuation
 						? estimateResponsesPayloadTokens(body, continuation.input)
-						: estimateAnthropicInputTokens(body);
+						: estimateResponsesPayloadTokens(
+								body,
+								anthropicMessagesToResponsesInput(body.messages, storedReasoning)
+							);
 					return new Response(JSON.stringify({ input_tokens: inputTokens }), {
 						headers: { 'Content-Type': 'application/json' },
 					});
@@ -1128,7 +1134,7 @@ export function createOpenAIResponsesBridgeServer(
 			if (storedReasoning && storedReasoning.length > 0) {
 				continuation = undefined;
 			}
-			const requestBody = buildResponsesRequest(
+			let requestBody = buildResponsesRequest(
 				body,
 				model,
 				continuation,
@@ -1160,12 +1166,11 @@ export function createOpenAIResponsesBridgeServer(
 						logger.warn(
 							'openai-responses: endpoint rejects previous_response_id, retrying with full history'
 						);
+						requestBody = buildResponsesRequest(body, model, undefined, buildOpts, storedReasoning);
 						openAIResponse = await fetchImpl(upstreamUrl, {
 							method: 'POST',
 							headers: buildOpenAIHeaders(config.auth, resolvedAuth),
-							body: JSON.stringify(
-								buildResponsesRequest(body, model, undefined, buildOpts, storedReasoning)
-							),
+							body: JSON.stringify(requestBody),
 						});
 						continuation = undefined;
 					} else {
@@ -1197,7 +1202,7 @@ export function createOpenAIResponsesBridgeServer(
 
 			const estimatedInputTokens = continuation
 				? estimateResponsesPayloadTokens(body, continuation.input)
-				: estimateAnthropicInputTokens(body);
+				: estimateResponsesPayloadTokens(body, requestBody.input);
 			const resolvedModelContextWindow = contextWindowByModelId.get(model);
 			const stream = new ReadableStream<Uint8Array>({
 				start(controller) {

--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -452,17 +452,26 @@ function toolChoiceToResponsesToolChoice(
 }
 
 /**
+ * Models known to support reasoning.effort="xhigh". Mini and older
+ * variants (e.g. gpt-5.1-codex-mini) reject xhigh with a 400 error.
+ */
+const MODELS_SUPPORTING_XHIGH_REASONING = new Set(['gpt-5.3-codex', 'gpt-5.4', 'gpt-5.5']);
+
+/**
  * Map Anthropic SDK thinking config (budget_tokens) to OpenAI reasoning.effort.
+ * Caps xhigh to high for models that do not support it.
  */
 function mapThinkingToReasoningEffort(
-	thinking: AnthropicRequest['thinking']
+	thinking: AnthropicRequest['thinking'],
+	model?: string
 ): ResponsesRequest['reasoning'] {
 	if (!thinking || thinking.type !== 'enabled') return undefined;
 	const tokens = thinking.budget_tokens;
 	if (tokens <= 8000) return { effort: 'low', summary: 'auto' };
 	if (tokens <= 16000) return { effort: 'medium', summary: 'auto' };
 	if (tokens <= 24000) return { effort: 'high', summary: 'auto' };
-	return { effort: 'xhigh', summary: 'auto' };
+	const supportsXHigh = model ? MODELS_SUPPORTING_XHIGH_REASONING.has(model) : true;
+	return { effort: supportsXHigh ? 'xhigh' : 'high', summary: 'auto' };
 }
 
 function buildResponsesRequest(
@@ -477,7 +486,7 @@ function buildResponsesRequest(
 	const tool_choice = toolChoiceToResponsesToolChoice(body.tool_choice);
 	const includeMaxOutputTokens = options.includeMaxOutputTokens ?? true;
 	const includeParallelToolCalls = options.includeParallelToolCalls ?? true;
-	const reasoning = mapThinkingToReasoningEffort(body.thinking);
+	const reasoning = mapThinkingToReasoningEffort(body.thinking, model);
 	return {
 		model,
 		...(instructions ? { instructions } : {}),

--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -393,18 +393,22 @@ export function anthropicMessagesToResponsesInput(
 	reasoningItems?: ResponsesReasoningItem[]
 ): ResponsesInputItem[] {
 	const items: ResponsesInputItem[] = [];
-	let pendingReasoning = reasoningItems ? [...reasoningItems] : [];
+	// Reasoning belongs to the most recent assistant turn, so it must be
+	// inserted immediately before the *last* user message (the current turn).
+	let lastUserIndex = -1;
+	for (let i = 0; i < messages.length; i++) {
+		if (messages[i].role === 'user') {
+			lastUserIndex = i;
+		}
+	}
 	for (let i = 0; i < messages.length; i++) {
 		const message = messages[i];
 		if (typeof message.content === 'string') {
 			if (message.role === 'assistant') {
 				appendAssistantMessage(items, [message.content]);
 			} else {
-				// Insert stored reasoning items before the first user message that
-				// follows an assistant message (i.e. the latest user turn).
-				if (pendingReasoning.length > 0 && i > 0 && messages[i - 1].role === 'assistant') {
-					items.push(...pendingReasoning);
-					pendingReasoning = [];
+				if (reasoningItems && reasoningItems.length > 0 && i === lastUserIndex) {
+					items.push(...reasoningItems);
 				}
 				appendInputMessage(items, 'user', [message.content]);
 			}
@@ -413,9 +417,8 @@ export function anthropicMessagesToResponsesInput(
 		if (message.role === 'assistant') {
 			appendAssistantBlocks(items, message.content);
 		} else {
-			if (pendingReasoning.length > 0 && i > 0 && messages[i - 1].role === 'assistant') {
-				items.push(...pendingReasoning);
-				pendingReasoning = [];
+			if (reasoningItems && reasoningItems.length > 0 && i === lastUserIndex) {
+				items.push(...reasoningItems);
 			}
 			appendUserBlocks(items, message.content);
 		}
@@ -1190,8 +1193,6 @@ export function createOpenAIResponsesBridgeServer(
 				);
 			}
 			consumeContinuation(sessionId, resolvedContinuation);
-			// Reasoning items have been consumed into the input array; clear them.
-			sessionReasoningItems.delete(sessionId);
 
 			const estimatedInputTokens = continuation
 				? estimateResponsesPayloadTokens(body, continuation.input)

--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -149,6 +149,11 @@ type ResponseContinuation = {
 	cleanupTimer: ReturnType<typeof setTimeout>;
 };
 
+type SessionReasoningEntry = {
+	items: ResponsesReasoningItem[];
+	cleanupTimer: ReturnType<typeof setTimeout>;
+};
+
 /**
  * Resolve the context window for a model.
  * Prefers the config-provided context window (from bridge models list, which may
@@ -1018,7 +1023,7 @@ export function createOpenAIResponsesBridgeServer(
 	const continuationTtlMs = config.continuationTtlMs ?? DEFAULT_RESPONSE_CONTINUATION_TTL_MS;
 	const continuations = new Map<string, ResponseContinuation>();
 	// Per-session reasoning items for multi-turn continuation when store: false.
-	const sessionReasoningItems = new Map<string, ResponsesReasoningItem[]>();
+	const sessionReasoningItems = new Map<string, SessionReasoningEntry>();
 	let resolvedAuth: ResolvedResponsesAuth | undefined;
 	// ChatGPT Codex endpoint rejects max_output_tokens and parallel_tool_calls.
 	const isChatgptOAuth = config.auth.source === 'chatgpt_oauth' && !config.openAIBaseUrl;
@@ -1045,6 +1050,22 @@ export function createOpenAIResponsesBridgeServer(
 			continuations.delete(key);
 		}, continuationTtlMs);
 		continuations.set(key, { responseId, cleanupTimer });
+	};
+
+	const deleteReasoningItems = (sessionId: string): void => {
+		const entry = sessionReasoningItems.get(sessionId);
+		if (!entry) return;
+		clearTimeout(entry.cleanupTimer);
+		sessionReasoningItems.delete(sessionId);
+	};
+
+	const storeReasoningItems = (sessionId: string, items: ResponsesReasoningItem[]): void => {
+		deleteReasoningItems(sessionId);
+		const cleanupTimer = setTimeout(() => {
+			logger.warn(`openai-responses: reasoning items TTL expired sessionId=${sessionId}`);
+			sessionReasoningItems.delete(sessionId);
+		}, continuationTtlMs);
+		sessionReasoningItems.set(sessionId, { items, cleanupTimer });
 	};
 
 	const consumeContinuation = (
@@ -1077,7 +1098,7 @@ export function createOpenAIResponsesBridgeServer(
 			if (route.pathname === '/v1/messages/count_tokens' && req.method === 'POST') {
 				try {
 					const body = (await req.json()) as AnthropicRequest;
-					const storedReasoning = sessionReasoningItems.get(route.sessionId);
+					const storedReasoning = sessionReasoningItems.get(route.sessionId)?.items;
 					let continuation = resolveContinuation(route.sessionId, body.messages, continuations);
 					if (storedReasoning && storedReasoning.length > 0) {
 						continuation = undefined;
@@ -1130,7 +1151,7 @@ export function createOpenAIResponsesBridgeServer(
 			let continuation = resolvedContinuation;
 			// When reasoning items are stored for this session, we must send full history
 			// (previous_response_id doesn't work with store:false for reasoning).
-			const storedReasoning = sessionReasoningItems.get(sessionId);
+			const storedReasoning = sessionReasoningItems.get(sessionId)?.items;
 			if (storedReasoning && storedReasoning.length > 0) {
 				continuation = undefined;
 			}
@@ -1224,7 +1245,7 @@ export function createOpenAIResponsesBridgeServer(
 									},
 								}),
 						onReasoningItems(items) {
-							sessionReasoningItems.set(sessionId, items);
+							storeReasoningItems(sessionId, items);
 						},
 					});
 				},
@@ -1254,6 +1275,9 @@ export function createOpenAIResponsesBridgeServer(
 				clearTimeout(continuation.cleanupTimer);
 			}
 			continuations.clear();
+			for (const entry of sessionReasoningItems.values()) {
+				clearTimeout(entry.cleanupTimer);
+			}
 			sessionReasoningItems.clear();
 			server.stop(true);
 		},

--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -14,6 +14,7 @@ import {
 	type AnthropicTool,
 	type ToolChoice,
 	contentBlockStartTextSSE,
+	contentBlockStartThinkingSSE,
 	contentBlockStartToolUseSSE,
 	contentBlockStopSSE,
 	errorSSE,
@@ -23,6 +24,7 @@ import {
 	messageStartSSE,
 	messageStopSSE,
 	textDeltaSSE,
+	thinkingDeltaSSE,
 } from '../codex-anthropic-bridge/translator.js';
 import { estimateAnthropicInputTokens } from '../codex-anthropic-bridge/token-estimator.js';
 import { getModelContextWindow as getCodexModelContextWindow } from '../codex-anthropic-bridge/model-context-windows.js';
@@ -71,6 +73,11 @@ export type OpenAIResponsesBridgeConfig = {
 	fetchImpl?: typeof fetch;
 };
 
+type ResponsesReasoningItem = {
+	type: 'reasoning';
+	encrypted_content: string;
+};
+
 type ResponsesInputItem =
 	| {
 			type: 'message';
@@ -93,7 +100,8 @@ type ResponsesInputItem =
 			type: 'function_call_output';
 			call_id: string;
 			output: string;
-	  };
+	  }
+	| ResponsesReasoningItem;
 
 type ResponsesTool = {
 	type: 'function';
@@ -113,6 +121,11 @@ type ResponsesRequest = {
 	store: false;
 	stream: true;
 	parallel_tool_calls?: false;
+	reasoning?: {
+		effort: 'low' | 'medium' | 'high' | 'xhigh';
+		summary?: 'auto' | 'concise' | 'detailed';
+	};
+	include?: string[];
 };
 
 type OpenAIStreamEvent = {
@@ -226,6 +239,9 @@ function estimateResponsesContentTokens(item: ResponsesInputItem): number {
 	}
 	if (item.type === 'function_call') {
 		return estimateTextTokens(item.name) + estimateTextTokens(item.arguments);
+	}
+	if (item.type === 'reasoning') {
+		return estimateTextTokens(item.encrypted_content);
 	}
 	return item.content.reduce((sum, block) => sum + estimateTextTokens(block.text), 0);
 }
@@ -373,14 +389,23 @@ function resolveContinuation(
 }
 
 export function anthropicMessagesToResponsesInput(
-	messages: AnthropicRequest['messages']
+	messages: AnthropicRequest['messages'],
+	reasoningItems?: ResponsesReasoningItem[]
 ): ResponsesInputItem[] {
 	const items: ResponsesInputItem[] = [];
-	for (const message of messages) {
+	let pendingReasoning = reasoningItems ? [...reasoningItems] : [];
+	for (let i = 0; i < messages.length; i++) {
+		const message = messages[i];
 		if (typeof message.content === 'string') {
 			if (message.role === 'assistant') {
 				appendAssistantMessage(items, [message.content]);
 			} else {
+				// Insert stored reasoning items before the first user message that
+				// follows an assistant message (i.e. the latest user turn).
+				if (pendingReasoning.length > 0 && i > 0 && messages[i - 1].role === 'assistant') {
+					items.push(...pendingReasoning);
+					pendingReasoning = [];
+				}
 				appendInputMessage(items, 'user', [message.content]);
 			}
 			continue;
@@ -388,6 +413,10 @@ export function anthropicMessagesToResponsesInput(
 		if (message.role === 'assistant') {
 			appendAssistantBlocks(items, message.content);
 		} else {
+			if (pendingReasoning.length > 0 && i > 0 && messages[i - 1].role === 'assistant') {
+				items.push(...pendingReasoning);
+				pendingReasoning = [];
+			}
 			appendUserBlocks(items, message.content);
 		}
 	}
@@ -415,21 +444,37 @@ function toolChoiceToResponsesToolChoice(
 	return undefined;
 }
 
+/**
+ * Map Anthropic SDK thinking config (budget_tokens) to OpenAI reasoning.effort.
+ */
+function mapThinkingToReasoningEffort(
+	thinking: AnthropicRequest['thinking']
+): ResponsesRequest['reasoning'] {
+	if (!thinking || thinking.type !== 'enabled') return undefined;
+	const tokens = thinking.budget_tokens;
+	if (tokens <= 8000) return { effort: 'low', summary: 'auto' };
+	if (tokens <= 16000) return { effort: 'medium', summary: 'auto' };
+	if (tokens <= 24000) return { effort: 'high', summary: 'auto' };
+	return { effort: 'xhigh', summary: 'auto' };
+}
+
 function buildResponsesRequest(
 	body: AnthropicRequest,
 	model: string,
 	continuation?: { previousResponseId: string; input: ResponsesInputItem[] },
-	options: { includeMaxOutputTokens?: boolean; includeParallelToolCalls?: boolean } = {}
+	options: { includeMaxOutputTokens?: boolean; includeParallelToolCalls?: boolean } = {},
+	reasoningItems?: ResponsesReasoningItem[]
 ): ResponsesRequest {
 	const instructions = extractSystemText(body.system) || undefined;
 	const tools = toolsToResponsesTools(body.tools);
 	const tool_choice = toolChoiceToResponsesToolChoice(body.tool_choice);
 	const includeMaxOutputTokens = options.includeMaxOutputTokens ?? true;
 	const includeParallelToolCalls = options.includeParallelToolCalls ?? true;
+	const reasoning = mapThinkingToReasoningEffort(body.thinking);
 	return {
 		model,
 		...(instructions ? { instructions } : {}),
-		input: continuation?.input ?? anthropicMessagesToResponsesInput(body.messages),
+		input: continuation?.input ?? anthropicMessagesToResponsesInput(body.messages, reasoningItems),
 		...(continuation ? { previous_response_id: continuation.previousResponseId } : {}),
 		...(tools ? { tools } : {}),
 		...(tool_choice ? { tool_choice } : {}),
@@ -439,6 +484,7 @@ function buildResponsesRequest(
 		store: false,
 		stream: true,
 		...(includeParallelToolCalls ? { parallel_tool_calls: false } : {}),
+		...(reasoning ? { reasoning, include: ['reasoning.encrypted_content'] } : {}),
 	};
 }
 
@@ -499,11 +545,19 @@ function readFirstUsageNumber(
 function responseUsage(response: Record<string, unknown> | undefined): {
 	inputTokens?: number | null;
 	outputTokens: number;
+	reasoningTokens?: number | null;
 } {
 	const usage = response?.usage;
 	const usageRecord =
 		usage && typeof usage === 'object' && !Array.isArray(usage)
 			? (usage as Record<string, unknown>)
+			: undefined;
+	const outputTokensDetails = usageRecord?.output_tokens_details;
+	const detailsRecord =
+		outputTokensDetails &&
+		typeof outputTokensDetails === 'object' &&
+		!Array.isArray(outputTokensDetails)
+			? (outputTokensDetails as Record<string, unknown>)
 			: undefined;
 	return {
 		inputTokens: readFirstUsageNumber(usageRecord, [
@@ -514,6 +568,7 @@ function responseUsage(response: Record<string, unknown> | undefined): {
 		outputTokens:
 			readFirstUsageNumber(usageRecord, ['output_tokens', 'completion_tokens', 'outputTokens']) ??
 			0,
+		reasoningTokens: readFirstUsageNumber(detailsRecord, ['reasoning_tokens']),
 	};
 }
 
@@ -636,6 +691,7 @@ async function streamResponsesToAnthropic({
 	model,
 	estimatedInputTokens,
 	onFunctionCallResponse,
+	onReasoningItems,
 	modelContextWindow,
 }: {
 	openAIResponse: Response;
@@ -643,6 +699,7 @@ async function streamResponsesToAnthropic({
 	model: string;
 	estimatedInputTokens: number;
 	onFunctionCallResponse?: (callId: string, responseId: string) => void;
+	onReasoningItems?: (items: ResponsesReasoningItem[]) => void;
 	/**
 	 * Context window for the active model, resolved from the bridge config's models
 	 * list at session creation time. Takes precedence over the Codex-only
@@ -680,11 +737,18 @@ async function streamResponsesToAnthropic({
 	const messageId = generateMsgId();
 	let started = false;
 	let textOpen = false;
+	let thinkingOpen = false;
+	let thinkingBlockIndex = -1;
 	let blockIndex = 0;
 	let heuristicOutputTokens = 0;
-	let completedUsage: { inputTokens?: number | null; outputTokens: number } | null = null;
+	let completedUsage: {
+		inputTokens?: number | null;
+		outputTokens: number;
+		reasoningTokens?: number | null;
+	} | null = null;
 	let incomplete = false;
 	const emittedFunctionCalls = new Set<string>();
+	const responseReasoningItems: ResponsesReasoningItem[] = [];
 
 	const ensureStarted = (): boolean => {
 		if (started) return !closed;
@@ -706,9 +770,27 @@ async function streamResponsesToAnthropic({
 		textOpen = false;
 	};
 
+	const startThinkingBlock = () => {
+		if (thinkingOpen) return;
+		ensureStarted();
+		closeTextBlock();
+		thinkingBlockIndex = blockIndex;
+		send(contentBlockStartThinkingSSE(thinkingBlockIndex));
+		thinkingOpen = true;
+	};
+
+	const closeThinkingBlock = () => {
+		if (!thinkingOpen) return;
+		send(contentBlockStopSSE(thinkingBlockIndex));
+		blockIndex++;
+		thinkingOpen = false;
+		thinkingBlockIndex = -1;
+	};
+
 	const emitFunctionCall = (call: PendingFunctionCall) => {
 		if (emittedFunctionCalls.has(call.callId)) return;
 		if (!ensureStarted()) return;
+		closeThinkingBlock();
 		closeTextBlock();
 		if (!send(contentBlockStartToolUseSSE(blockIndex, call.callId, call.name))) return;
 		if (!send(inputJsonDeltaSSE(blockIndex, call.argumentsText || '{}'))) return;
@@ -725,6 +807,7 @@ async function streamResponsesToAnthropic({
 		for await (const event of readOpenAIStream(openAIResponse.body)) {
 			if (event.type === 'response.output_text.delta') {
 				ensureStarted();
+				closeThinkingBlock();
 				if (!textOpen) {
 					send(contentBlockStartTextSSE(blockIndex));
 					textOpen = true;
@@ -734,6 +817,34 @@ async function streamResponsesToAnthropic({
 					send(textDeltaSSE(blockIndex, delta));
 					heuristicOutputTokens += Math.max(1, Math.ceil(delta.length / 4));
 				}
+				continue;
+			}
+
+			if (
+				event.type === 'response.reasoning_summary_part.added' ||
+				event.type === 'response.reasoning_summary_text.delta' ||
+				event.type === 'response.reasoning_text.delta'
+			) {
+				startThinkingBlock();
+				if (
+					event.type === 'response.reasoning_summary_text.delta' ||
+					event.type === 'response.reasoning_text.delta'
+				) {
+					const delta = typeof event.delta === 'string' ? event.delta : '';
+					if (delta) {
+						send(thinkingDeltaSSE(thinkingBlockIndex, delta));
+						heuristicOutputTokens += Math.max(1, Math.ceil(delta.length / 4));
+					}
+				}
+				continue;
+			}
+
+			if (
+				event.type === 'response.reasoning_summary_part.done' ||
+				event.type === 'response.reasoning_summary_text.done' ||
+				event.type === 'response.reasoning_text.done'
+			) {
+				closeThinkingBlock();
 				continue;
 			}
 
@@ -763,12 +874,30 @@ async function streamResponsesToAnthropic({
 								});
 							}
 						}
+						if (
+							item &&
+							typeof item === 'object' &&
+							(item as Record<string, unknown>).type === 'reasoning'
+						) {
+							const record = item as Record<string, unknown>;
+							const encrypted =
+								typeof record.encrypted_content === 'string' ? record.encrypted_content : undefined;
+							if (encrypted) {
+								responseReasoningItems.push({
+									type: 'reasoning',
+									encrypted_content: encrypted,
+								});
+							}
+						}
 					}
 				}
 				if (responseId) {
 					for (const callId of emittedFunctionCalls) {
 						onFunctionCallResponse?.(callId, responseId);
 					}
+				}
+				if (responseReasoningItems.length > 0) {
+					onReasoningItems?.(responseReasoningItems);
 				}
 				continue;
 			}
@@ -781,6 +910,7 @@ async function streamResponsesToAnthropic({
 
 			if (event.type === 'response.failed' || event.type === 'error') {
 				ensureStarted();
+				closeThinkingBlock();
 				closeTextBlock();
 				send(errorSSE('api_error', streamErrorMessage(event)));
 				send(messageStopSSE());
@@ -790,6 +920,7 @@ async function streamResponsesToAnthropic({
 		}
 
 		ensureStarted();
+		closeThinkingBlock();
 		closeTextBlock();
 		// If the model emitted tool calls before an incomplete event, let the SDK execute
 		// them; the follow-up turn can carry the continuation forward.
@@ -799,6 +930,7 @@ async function streamResponsesToAnthropic({
 			messageDeltaSSE(stopReason, {
 				inputTokens: completedUsage?.inputTokens ?? estimatedInputTokens,
 				outputTokens: completedUsage?.outputTokens || heuristicOutputTokens,
+				thinkingTokens: completedUsage?.reasoningTokens,
 				modelContextWindow: resolveContextWindow(model, modelContextWindow),
 			})
 		);
@@ -813,6 +945,7 @@ async function streamResponsesToAnthropic({
 		logger.error('openai-responses: streaming failed:', err);
 		try {
 			ensureStarted();
+			closeThinkingBlock();
 			closeTextBlock();
 			send(errorSSE('api_error', err instanceof Error ? err.message : 'OpenAI streaming failed'));
 			send(messageStopSSE());
@@ -881,6 +1014,8 @@ export function createOpenAIResponsesBridgeServer(
 	}
 	const continuationTtlMs = config.continuationTtlMs ?? DEFAULT_RESPONSE_CONTINUATION_TTL_MS;
 	const continuations = new Map<string, ResponseContinuation>();
+	// Per-session reasoning items for multi-turn continuation when store: false.
+	const sessionReasoningItems = new Map<string, ResponsesReasoningItem[]>();
 	let resolvedAuth: ResolvedResponsesAuth | undefined;
 	// ChatGPT Codex endpoint rejects max_output_tokens and parallel_tool_calls.
 	const isChatgptOAuth = config.auth.source === 'chatgpt_oauth' && !config.openAIBaseUrl;
@@ -983,7 +1118,19 @@ export function createOpenAIResponsesBridgeServer(
 				? undefined
 				: resolveContinuation(sessionId, body.messages, continuations);
 			let continuation = resolvedContinuation;
-			const requestBody = buildResponsesRequest(body, model, continuation, buildOpts);
+			// When reasoning items are stored for this session, we must send full history
+			// (previous_response_id doesn't work with store:false for reasoning).
+			const storedReasoning = sessionReasoningItems.get(sessionId);
+			if (storedReasoning && storedReasoning.length > 0) {
+				continuation = undefined;
+			}
+			const requestBody = buildResponsesRequest(
+				body,
+				model,
+				continuation,
+				buildOpts,
+				storedReasoning
+			);
 			const upstreamUrl = `${baseUrl.replace(/\/$/, '')}/responses`;
 			let openAIResponse: Response;
 			try {
@@ -1012,7 +1159,9 @@ export function createOpenAIResponsesBridgeServer(
 						openAIResponse = await fetchImpl(upstreamUrl, {
 							method: 'POST',
 							headers: buildOpenAIHeaders(config.auth, resolvedAuth),
-							body: JSON.stringify(buildResponsesRequest(body, model, undefined, buildOpts)),
+							body: JSON.stringify(
+								buildResponsesRequest(body, model, undefined, buildOpts, storedReasoning)
+							),
 						});
 						continuation = undefined;
 					} else {
@@ -1041,6 +1190,8 @@ export function createOpenAIResponsesBridgeServer(
 				);
 			}
 			consumeContinuation(sessionId, resolvedContinuation);
+			// Reasoning items have been consumed into the input array; clear them.
+			sessionReasoningItems.delete(sessionId);
 
 			const estimatedInputTokens = continuation
 				? estimateResponsesPayloadTokens(body, continuation.input)
@@ -1065,6 +1216,9 @@ export function createOpenAIResponsesBridgeServer(
 										storeContinuation(sessionId, callId, responseId);
 									},
 								}),
+						onReasoningItems(items) {
+							sessionReasoningItems.set(sessionId, items);
+						},
 					});
 				},
 			});
@@ -1093,6 +1247,7 @@ export function createOpenAIResponsesBridgeServer(
 				clearTimeout(continuation.cleanupTimer);
 			}
 			continuations.clear();
+			sessionReasoningItems.clear();
 			server.stop(true);
 		},
 	};

--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -487,7 +487,10 @@ function buildResponsesRequest(
 		store: false,
 		stream: true,
 		...(includeParallelToolCalls ? { parallel_tool_calls: false } : {}),
-		...(reasoning ? { reasoning, include: ['reasoning.encrypted_content'] } : {}),
+		...(reasoning ? { reasoning } : {}),
+		...(reasoning || (reasoningItems && reasoningItems.length > 0)
+			? { include: ['reasoning.encrypted_content'] }
+			: {}),
 	};
 }
 
@@ -899,9 +902,7 @@ async function streamResponsesToAnthropic({
 						onFunctionCallResponse?.(callId, responseId);
 					}
 				}
-				if (responseReasoningItems.length > 0) {
-					onReasoningItems?.(responseReasoningItems);
-				}
+				onReasoningItems?.(responseReasoningItems);
 				continue;
 			}
 

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -369,6 +369,25 @@ describe('QueryOptionsBuilder', () => {
 
 			expect(result.thinking).toBeUndefined();
 		});
+
+		it('should omit thinking config for anthropic-codex when Codex adapter is active', async () => {
+			const originalAdapter = process.env.NEOKAI_OPENAI_BRIDGE_ADAPTER;
+			process.env.NEOKAI_OPENAI_BRIDGE_ADAPTER = 'codex';
+			try {
+				mockSession.config.provider = 'anthropic-codex';
+				mockSession.config.thinkingLevel = 'think32k';
+				const result = builder.addSessionStateOptions(
+					{} as import('@anthropic-ai/claude-agent-sdk').Options
+				);
+				expect(result.thinking).toBeUndefined();
+			} finally {
+				if (originalAdapter === undefined) {
+					delete process.env.NEOKAI_OPENAI_BRIDGE_ADAPTER;
+				} else {
+					process.env.NEOKAI_OPENAI_BRIDGE_ADAPTER = originalAdapter;
+				}
+			}
+		});
 	});
 
 	describe('system prompt configuration', () => {

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -388,6 +388,44 @@ describe('QueryOptionsBuilder', () => {
 				}
 			}
 		});
+
+		it('should omit thinking config for anthropic-codex when Codex adapter env is uppercase', async () => {
+			const originalAdapter = process.env.NEOKAI_OPENAI_BRIDGE_ADAPTER;
+			process.env.NEOKAI_OPENAI_BRIDGE_ADAPTER = 'CODEX';
+			try {
+				mockSession.config.provider = 'anthropic-codex';
+				mockSession.config.thinkingLevel = 'think32k';
+				const result = builder.addSessionStateOptions(
+					{} as import('@anthropic-ai/claude-agent-sdk').Options
+				);
+				expect(result.thinking).toBeUndefined();
+			} finally {
+				if (originalAdapter === undefined) {
+					delete process.env.NEOKAI_OPENAI_BRIDGE_ADAPTER;
+				} else {
+					process.env.NEOKAI_OPENAI_BRIDGE_ADAPTER = originalAdapter;
+				}
+			}
+		});
+
+		it('should omit thinking config for anthropic-codex when Codex adapter env has extra whitespace', async () => {
+			const originalAdapter = process.env.NEOKAI_OPENAI_BRIDGE_ADAPTER;
+			process.env.NEOKAI_OPENAI_BRIDGE_ADAPTER = '  codex  ';
+			try {
+				mockSession.config.provider = 'anthropic-codex';
+				mockSession.config.thinkingLevel = 'think32k';
+				const result = builder.addSessionStateOptions(
+					{} as import('@anthropic-ai/claude-agent-sdk').Options
+				);
+				expect(result.thinking).toBeUndefined();
+			} finally {
+				if (originalAdapter === undefined) {
+					delete process.env.NEOKAI_OPENAI_BRIDGE_ADAPTER;
+				} else {
+					process.env.NEOKAI_OPENAI_BRIDGE_ADAPTER = originalAdapter;
+				}
+			}
+		});
 	});
 
 	describe('system prompt configuration', () => {

--- a/packages/daemon/tests/unit/1-core/providers/anthropic-to-codex-bridge-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/anthropic-to-codex-bridge-provider.test.ts
@@ -841,6 +841,33 @@ describe('AnthropicToCodexBridgeProvider', () => {
 			expect(contextWindows.get('gpt-5.1-codex-mini')).toBe(128000);
 		});
 
+		it('sets thinkingModes to granular when Responses adapter is active', async () => {
+			provider = makeProvider({ OPENAI_API_KEY: 'sk-env-key' }, tmpDir, tmpDir, fakeCodexFound);
+			const models = await provider.getModels();
+			expect(models.length).toBeGreaterThan(0);
+			for (const model of models) {
+				expect(model.thinkingModes).toBe('granular');
+			}
+		});
+
+		it('sets thinkingModes to off when Codex adapter is active', async () => {
+			const p = makeProvider(
+				{ OPENAI_API_KEY: 'sk-env-key', NEOKAI_OPENAI_BRIDGE_ADAPTER: 'codex' },
+				tmpDir,
+				tmpDir,
+				fakeCodexFound
+			);
+			try {
+				const models = await p.getModels();
+				expect(models.length).toBeGreaterThan(0);
+				for (const model of models) {
+					expect(model.thinkingModes).toBe('off');
+				}
+			} finally {
+				p.stopAllBridgeServers();
+			}
+		});
+
 		it('returns models when NeoKai OAuth credentials are in auth.json', async () => {
 			const neokaiDir = path.join(tmpDir, 'neokai');
 			writeNeokaiAuth(neokaiDir, {

--- a/packages/daemon/tests/unit/1-core/providers/anthropic-to-codex-bridge-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/anthropic-to-codex-bridge-provider.test.ts
@@ -159,6 +159,23 @@ describe('AnthropicToCodexBridgeProvider', () => {
 		it('reports the maximum Codex context window', () => {
 			expect(provider.capabilities.maxContextWindow).toBe(272000);
 		});
+
+		it('advertises thinking when the Responses adapter is active', () => {
+			expect(provider.capabilities.extendedThinking).toBe(true);
+			expect(provider.capabilities.thinkingModes).toBe('granular');
+		});
+
+		it('disables thinking when the Codex adapter is active', () => {
+			const p = makeProvider(
+				{ NEOKAI_OPENAI_BRIDGE_ADAPTER: 'codex' },
+				undefined,
+				undefined,
+				fakeCodexFound
+			);
+			expect(p.capabilities.extendedThinking).toBe(false);
+			expect(p.capabilities.thinkingModes).toBe('off');
+			p.stopAllBridgeServers();
+		});
 	});
 
 	describe('getAuthStatus()', () => {

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
@@ -1658,4 +1658,200 @@ describe('openai-responses-bridge server', () => {
 			usage: { output_tokens: 10, thinking_tokens: 7 },
 		});
 	});
+
+	it('clears cached reasoning when response has no reasoning items', async () => {
+		const capturedBodies: Record<string, unknown>[] = [];
+		let requestCount = 0;
+		server = createOpenAIResponsesBridgeServer({
+			auth: { source: 'api_key', apiKey: 'sk-test' },
+			models,
+			fetchImpl: async (_req, init) => {
+				const body = JSON.parse((init?.body as string) ?? '{}');
+				capturedBodies.push(body);
+				requestCount++;
+				if (requestCount === 1) {
+					return sse([
+						{
+							event: 'response.output_text.delta',
+							data: { type: 'response.output_text.delta', delta: 'First.' },
+						},
+						{
+							event: 'response.completed',
+							data: {
+								type: 'response.completed',
+								response: {
+									id: 'resp_first',
+									usage: { input_tokens: 5, output_tokens: 1 },
+									output: [{ type: 'reasoning', encrypted_content: 'enc_first' }],
+								},
+							},
+						},
+					]);
+				}
+				// Second and third requests: no reasoning items returned
+				return sse([
+					{
+						event: 'response.output_text.delta',
+						data: { type: 'response.output_text.delta', delta: 'Later.' },
+					},
+					{
+						event: 'response.completed',
+						data: {
+							type: 'response.completed',
+							response: {
+								id: `resp_${requestCount}`,
+								usage: { input_tokens: 5, output_tokens: 1 },
+								output: [],
+							},
+						},
+					},
+				]);
+			},
+		});
+
+		const first = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [{ role: 'user', content: 'First.' }],
+				thinking: { type: 'enabled', budget_tokens: 16000 },
+			}),
+		});
+		await readSSEEvents(first.body);
+
+		const second = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [
+					{ role: 'assistant', content: 'First response.' },
+					{ role: 'user', content: 'Second.' },
+				],
+				thinking: { type: 'enabled', budget_tokens: 16000 },
+			}),
+		});
+		await readSSEEvents(second.body);
+
+		const third = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [
+					{ role: 'assistant', content: 'First response.' },
+					{ role: 'user', content: 'Second.' },
+					{ role: 'assistant', content: 'Second response.' },
+					{ role: 'user', content: 'Third.' },
+				],
+				thinking: { type: 'enabled', budget_tokens: 16000 },
+			}),
+		});
+		await readSSEEvents(third.body);
+
+		// Second request should include the cached reasoning from first turn
+		const secondInput = capturedBodies[1]?.input as Array<Record<string, unknown>>;
+		expect(
+			secondInput.some(
+				(item) => item.type === 'reasoning' && item.encrypted_content === 'enc_first'
+			)
+		).toBe(true);
+
+		// Third request should NOT contain any reasoning items because second response had none
+		const thirdInput = capturedBodies[2]?.input as Array<Record<string, unknown>>;
+		expect(thirdInput.some((item) => item.type === 'reasoning')).toBe(false);
+	});
+
+	it('includes encrypted reasoning in request when reusing cached reasoning without thinking config', async () => {
+		const capturedBodies: Record<string, unknown>[] = [];
+		let requestCount = 0;
+		server = createOpenAIResponsesBridgeServer({
+			auth: { source: 'api_key', apiKey: 'sk-test' },
+			models,
+			fetchImpl: async (_req, init) => {
+				const body = JSON.parse((init?.body as string) ?? '{}');
+				capturedBodies.push(body);
+				requestCount++;
+				if (requestCount === 1) {
+					return sse([
+						{
+							event: 'response.output_text.delta',
+							data: { type: 'response.output_text.delta', delta: 'First.' },
+						},
+						{
+							event: 'response.completed',
+							data: {
+								type: 'response.completed',
+								response: {
+									id: 'resp_first',
+									usage: { input_tokens: 5, output_tokens: 1 },
+									output: [{ type: 'reasoning', encrypted_content: 'enc_first' }],
+								},
+							},
+						},
+					]);
+				}
+				return sse([
+					{
+						event: 'response.output_text.delta',
+						data: { type: 'response.output_text.delta', delta: 'Second.' },
+					},
+					{
+						event: 'response.completed',
+						data: {
+							type: 'response.completed',
+							response: {
+								id: 'resp_second',
+								usage: { input_tokens: 5, output_tokens: 1 },
+								output: [{ type: 'reasoning', encrypted_content: 'enc_second' }],
+							},
+						},
+					},
+				]);
+			},
+		});
+
+		const first = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [{ role: 'user', content: 'First.' }],
+				thinking: { type: 'enabled', budget_tokens: 16000 },
+			}),
+		});
+		await readSSEEvents(first.body);
+
+		// Second turn WITHOUT thinking field — should still include reasoning and encrypted_content
+		const second = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [
+					{ role: 'assistant', content: 'First response.' },
+					{ role: 'user', content: 'Second.' },
+				],
+				// no thinking field
+			}),
+		});
+		await readSSEEvents(second.body);
+
+		// Second request should include the cached reasoning item
+		const secondBody = capturedBodies[1];
+		expect(secondBody?.reasoning).toBeUndefined();
+		expect(secondBody?.include).toEqual(['reasoning.encrypted_content']);
+		const secondInput = secondBody?.input as Array<Record<string, unknown>>;
+		expect(
+			secondInput.some(
+				(item) => item.type === 'reasoning' && item.encrypted_content === 'enc_first'
+			)
+		).toBe(true);
+	});
 });

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
@@ -1387,4 +1387,275 @@ describe('openai-responses-bridge server', () => {
 		expect(body.error.type).toBe('authentication_error');
 		expect(body.error.message).toBe('expired');
 	});
+
+	it('maps thinking budget_tokens to OpenAI reasoning.effort', async () => {
+		let capturedBody: Record<string, unknown> | undefined;
+		server = createOpenAIResponsesBridgeServer({
+			auth: { source: 'api_key', apiKey: 'sk-test' },
+			models,
+			fetchImpl: async (_url, init) => {
+				capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+				return sse([
+					{
+						event: 'response.completed',
+						data: {
+							type: 'response.completed',
+							response: { usage: { input_tokens: 5, output_tokens: 1 }, output: [] },
+						},
+					},
+				]);
+			},
+		});
+
+		const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [{ role: 'user', content: 'Think deeply.' }],
+				thinking: { type: 'enabled', budget_tokens: 16000 },
+			}),
+		});
+
+		expect(resp.status).toBe(200);
+		expect(capturedBody?.reasoning).toEqual({ effort: 'medium', summary: 'auto' });
+		expect(capturedBody?.include).toEqual(['reasoning.encrypted_content']);
+	});
+
+	it('omits reasoning when thinking is off', async () => {
+		let capturedBody: Record<string, unknown> | undefined;
+		server = createOpenAIResponsesBridgeServer({
+			auth: { source: 'api_key', apiKey: 'sk-test' },
+			models,
+			fetchImpl: async (_url, init) => {
+				capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+				return sse([
+					{
+						event: 'response.completed',
+						data: {
+							type: 'response.completed',
+							response: { usage: { input_tokens: 5, output_tokens: 1 }, output: [] },
+						},
+					},
+				]);
+			},
+		});
+
+		const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [{ role: 'user', content: 'No thinking please.' }],
+			}),
+		});
+
+		expect(resp.status).toBe(200);
+		expect(capturedBody?.reasoning).toBeUndefined();
+		expect(capturedBody?.include).toBeUndefined();
+	});
+
+	it('streams OpenAI reasoning events as Anthropic thinking SSE', async () => {
+		server = createOpenAIResponsesBridgeServer({
+			auth: { source: 'api_key', apiKey: 'sk-test' },
+			models,
+			fetchImpl: async () =>
+				sse([
+					{
+						event: 'response.reasoning_summary_part.added',
+						data: { type: 'response.reasoning_summary_part.added' },
+					},
+					{
+						event: 'response.reasoning_summary_text.delta',
+						data: { type: 'response.reasoning_summary_text.delta', delta: 'Let me' },
+					},
+					{
+						event: 'response.reasoning_summary_text.delta',
+						data: { type: 'response.reasoning_summary_text.delta', delta: ' think...' },
+					},
+					{
+						event: 'response.reasoning_summary_part.done',
+						data: { type: 'response.reasoning_summary_part.done' },
+					},
+					{
+						event: 'response.output_text.delta',
+						data: { type: 'response.output_text.delta', delta: 'Hello!' },
+					},
+					{
+						event: 'response.completed',
+						data: {
+							type: 'response.completed',
+							response: { usage: { input_tokens: 5, output_tokens: 3 }, output: [] },
+						},
+					},
+				]),
+		});
+
+		const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [{ role: 'user', content: 'Say hello.' }],
+				thinking: { type: 'enabled', budget_tokens: 16000 },
+			}),
+		});
+
+		const events = await readSSEEvents(resp.body);
+		const thinkingStart = events.find(
+			(e) =>
+				e.event === 'content_block_start' &&
+				(e.data.content_block as { type: string })?.type === 'thinking'
+		);
+		expect(thinkingStart).toBeDefined();
+
+		const thinkingDeltas = events
+			.filter((e) => e.event === 'content_block_delta')
+			.map((e) => (e.data.delta as { thinking?: string }).thinking)
+			.filter(Boolean);
+		expect(thinkingDeltas.join('')).toBe('Let me think...');
+
+		const textDeltas = textDeltaEvents(events);
+		expect(textDeltas.join('')).toBe('Hello!');
+
+		expect(messageDeltaEvent(events)).toMatchObject({
+			type: 'message_delta',
+			delta: { stop_reason: 'end_turn' },
+		});
+	});
+
+	it('passes encrypted reasoning content through on multi-turn', async () => {
+		const capturedBodies: Record<string, unknown>[] = [];
+		server = createOpenAIResponsesBridgeServer({
+			auth: { source: 'api_key', apiKey: 'sk-test' },
+			models,
+			fetchImpl: async (_url, init) => {
+				const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+				capturedBodies.push(body);
+				if (capturedBodies.length === 1) {
+					return sse([
+						{
+							event: 'response.output_text.delta',
+							data: { type: 'response.output_text.delta', delta: 'First response.' },
+						},
+						{
+							event: 'response.completed',
+							data: {
+								type: 'response.completed',
+								response: {
+									id: 'resp_reasoning',
+									usage: { input_tokens: 5, output_tokens: 3 },
+									output: [
+										{
+											type: 'reasoning',
+											encrypted_content: 'enc_abc123',
+										},
+									],
+								},
+							},
+						},
+					]);
+				}
+				return sse([
+					{
+						event: 'response.output_text.delta',
+						data: { type: 'response.output_text.delta', delta: 'Second response.' },
+					},
+					{
+						event: 'response.completed',
+						data: {
+							type: 'response.completed',
+							response: { usage: { input_tokens: 5, output_tokens: 3 }, output: [] },
+						},
+					},
+				]);
+			},
+		});
+
+		const first = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [{ role: 'user', content: 'First.' }],
+				thinking: { type: 'enabled', budget_tokens: 16000 },
+			}),
+		});
+		await readSSEEvents(first.body);
+
+		const second = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [
+					{ role: 'user', content: 'First.' },
+					{ role: 'assistant', content: 'First response.' },
+					{ role: 'user', content: 'Second.' },
+				],
+				thinking: { type: 'enabled', budget_tokens: 16000 },
+			}),
+		});
+		const events = await readSSEEvents(second.body);
+
+		// Second request should include reasoning item in input
+		const secondInput = capturedBodies[1]?.input as Array<Record<string, unknown>>;
+		expect(
+			secondInput.some(
+				(item) => item.type === 'reasoning' && item.encrypted_content === 'enc_abc123'
+			)
+		).toBe(true);
+		// previous_response_id should not be used when reasoning items are present
+		expect(capturedBodies[1]?.previous_response_id).toBeUndefined();
+		expect(textDeltaEvents(events).join('')).toBe('Second response.');
+	});
+
+	it('reports reasoning_tokens in message_delta usage', async () => {
+		server = createOpenAIResponsesBridgeServer({
+			auth: { source: 'api_key', apiKey: 'sk-test' },
+			models,
+			fetchImpl: async () =>
+				sse([
+					{
+						event: 'response.output_text.delta',
+						data: { type: 'response.output_text.delta', delta: 'hello' },
+					},
+					{
+						event: 'response.completed',
+						data: {
+							type: 'response.completed',
+							response: {
+								usage: {
+									input_tokens: 5,
+									output_tokens: 10,
+									output_tokens_details: { reasoning_tokens: 7 },
+								},
+								output: [],
+							},
+						},
+					},
+				]),
+		});
+
+		const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [{ role: 'user', content: 'hi' }],
+			}),
+		});
+
+		const events = await readSSEEvents(resp.body);
+		expect(messageDeltaEvent(events)).toMatchObject({
+			type: 'message_delta',
+			usage: { output_tokens: 10, thinking_tokens: 7 },
+		});
+	});
 });

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
@@ -1933,4 +1933,130 @@ describe('openai-responses-bridge server', () => {
 		expect(count.input_tokens).toBe(messageStartMessage?.usage?.input_tokens);
 		expect(count.input_tokens).toBeGreaterThan(20);
 	});
+
+	it('evicts stale reasoning items after the TTL', async () => {
+		const capturedBodies: Record<string, unknown>[] = [];
+		server = createOpenAIResponsesBridgeServer({
+			auth: { source: 'api_key', apiKey: 'sk-test' },
+			models,
+			continuationTtlMs: 10,
+			fetchImpl: async (_req, init) => {
+				const body = JSON.parse((init?.body as string) ?? '{}');
+				capturedBodies.push(body);
+				if (capturedBodies.length === 1) {
+					return sse([
+						{
+							event: 'response.output_text.delta',
+							data: { type: 'response.output_text.delta', delta: 'First.' },
+						},
+						{
+							event: 'response.completed',
+							data: {
+								type: 'response.completed',
+								response: {
+									id: 'resp_first',
+									usage: { input_tokens: 5, output_tokens: 1 },
+									output: [{ type: 'reasoning', encrypted_content: 'enc_first' }],
+								},
+							},
+						},
+					]);
+				}
+				return sse([
+					{
+						event: 'response.output_text.delta',
+						data: { type: 'response.output_text.delta', delta: 'Second.' },
+					},
+					{
+						event: 'response.completed',
+						data: {
+							type: 'response.completed',
+							response: {
+								id: 'resp_second',
+								usage: { input_tokens: 5, output_tokens: 1 },
+								output: [],
+							},
+						},
+					},
+				]);
+			},
+		});
+
+		const first = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [{ role: 'user', content: 'First.' }],
+				thinking: { type: 'enabled', budget_tokens: 16000 },
+			}),
+		});
+		await readSSEEvents(first.body);
+
+		// Wait for TTL to expire
+		await new Promise((resolve) => setTimeout(resolve, 25));
+
+		const second = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [
+					{ role: 'assistant', content: 'First response.' },
+					{ role: 'user', content: 'Second.' },
+				],
+				// no thinking field — reasoning items should not appear if evicted
+			}),
+		});
+		await readSSEEvents(second.body);
+
+		// Reasoning items should have been evicted, so second request has no reasoning
+		// item in input and does not request encrypted_content inclusion.
+		expect(capturedBodies[1]?.include).toBeUndefined();
+		const secondInput = capturedBodies[1]?.input as Array<Record<string, unknown>>;
+		expect(secondInput.some((item) => item.type === 'reasoning')).toBe(false);
+	});
+
+	it('clears reasoning item timers on server stop', async () => {
+		server = createOpenAIResponsesBridgeServer({
+			auth: { source: 'api_key', apiKey: 'sk-test' },
+			models,
+			continuationTtlMs: 60000,
+			fetchImpl: async () =>
+				sse([
+					{
+						event: 'response.output_text.delta',
+						data: { type: 'response.output_text.delta', delta: 'First.' },
+					},
+					{
+						event: 'response.completed',
+						data: {
+							type: 'response.completed',
+							response: {
+								id: 'resp_first',
+								usage: { input_tokens: 5, output_tokens: 1 },
+								output: [{ type: 'reasoning', encrypted_content: 'enc_first' }],
+							},
+						},
+					},
+				]),
+		});
+
+		const first = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [{ role: 'user', content: 'First.' }],
+				thinking: { type: 'enabled', budget_tokens: 16000 },
+			}),
+		});
+		await readSSEEvents(first.body);
+
+		// stop() should clear the timer without throwing or leaking
+		expect(() => server?.stop()).not.toThrow();
+	});
 });

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
@@ -1854,4 +1854,83 @@ describe('openai-responses-bridge server', () => {
 			)
 		).toBe(true);
 	});
+
+	it('includes injected reasoning items in count_tokens and message_start estimates', async () => {
+		let requestCount = 0;
+		server = createOpenAIResponsesBridgeServer({
+			auth: { source: 'api_key', apiKey: 'sk-test' },
+			models,
+			fetchImpl: async () => {
+				requestCount++;
+				return sse([
+					{
+						event: 'response.output_text.delta',
+						data: { type: 'response.output_text.delta', delta: 'Hello.' },
+					},
+					{
+						event: 'response.completed',
+						data: {
+							type: 'response.completed',
+							response: {
+								id: `resp_${requestCount}`,
+								usage: { input_tokens: 5, output_tokens: 1 },
+								output: [{ type: 'reasoning', encrypted_content: 'a'.repeat(100) }],
+							},
+						},
+					},
+				]);
+			},
+		});
+
+		// First turn to populate reasoning cache
+		const first = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [{ role: 'user', content: 'Hello.' }],
+				thinking: { type: 'enabled', budget_tokens: 16000 },
+			}),
+		});
+		await readSSEEvents(first.body);
+
+		// count_tokens for second turn
+		const countResp = await fetch(`http://127.0.0.1:${server.port}/v1/messages/count_tokens`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [
+					{ role: 'assistant', content: 'Hello.' },
+					{ role: 'user', content: 'Again.' },
+				],
+			}),
+		});
+		const count = (await countResp.json()) as { input_tokens: number };
+
+		// Actual second turn
+		const second = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [
+					{ role: 'assistant', content: 'Hello.' },
+					{ role: 'user', content: 'Again.' },
+				],
+			}),
+		});
+		const events = await readSSEEvents(second.body);
+		const messageStart = messageStartEvent(events);
+		const messageStartMessage = messageStart?.message as
+			| { usage?: { input_tokens?: number } }
+			| undefined;
+
+		// The estimates should match and should account for the ~100-char reasoning item
+		expect(count.input_tokens).toBe(messageStartMessage?.usage?.input_tokens);
+		expect(count.input_tokens).toBeGreaterThan(20);
+	});
 });

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
@@ -1423,6 +1423,80 @@ describe('openai-responses-bridge server', () => {
 		expect(capturedBody?.include).toEqual(['reasoning.encrypted_content']);
 	});
 
+	it('maps think32k to xhigh on frontier models that support it', async () => {
+		let capturedBody: Record<string, unknown> | undefined;
+		server = createOpenAIResponsesBridgeServer({
+			auth: { source: 'api_key', apiKey: 'sk-test' },
+			models,
+			fetchImpl: async (_url, init) => {
+				capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+				return sse([
+					{
+						event: 'response.completed',
+						data: {
+							type: 'response.completed',
+							response: { usage: { input_tokens: 5, output_tokens: 1 }, output: [] },
+						},
+					},
+				]);
+			},
+		});
+
+		const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [{ role: 'user', content: 'Think deeply.' }],
+				thinking: { type: 'enabled', budget_tokens: 32000 },
+			}),
+		});
+
+		expect(resp.status).toBe(200);
+		expect(capturedBody?.reasoning).toEqual({ effort: 'xhigh', summary: 'auto' });
+	});
+
+	it('caps think32k to high on models that do not support xhigh', async () => {
+		let capturedBody: Record<string, unknown> | undefined;
+		server = createOpenAIResponsesBridgeServer({
+			auth: { source: 'api_key', apiKey: 'sk-test' },
+			models: [
+				{
+					id: 'gpt-5.1-codex-mini',
+					display_name: 'GPT-5.1 Codex Mini',
+					created_at: '2026-01-01T00:00:00Z',
+					context_window: 128000,
+				},
+			],
+			fetchImpl: async (_url, init) => {
+				capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+				return sse([
+					{
+						event: 'response.completed',
+						data: {
+							type: 'response.completed',
+							response: { usage: { input_tokens: 5, output_tokens: 1 }, output: [] },
+						},
+					},
+				]);
+			},
+		});
+
+		const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.1-codex-mini',
+				max_tokens: 128,
+				messages: [{ role: 'user', content: 'Think deeply.' }],
+				thinking: { type: 'enabled', budget_tokens: 32000 },
+			}),
+		});
+
+		expect(resp.status).toBe(200);
+		expect(capturedBody?.reasoning).toEqual({ effort: 'high', summary: 'auto' });
+	});
 	it('omits reasoning when thinking is off', async () => {
 		let capturedBody: Record<string, unknown> | undefined;
 		server = createOpenAIResponsesBridgeServer({

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -36,6 +36,13 @@ export interface ModelInfo {
 	releaseDate: string;
 	/** Whether this model is currently available */
 	available: boolean;
+	/**
+	 * Runtime thinking mode for this model, overriding the static
+	 * PROVIDER_THINKING_MODES map when set. Used by providers whose
+	 * thinking support depends on runtime configuration (e.g. bridge
+	 * adapter selection).
+	 */
+	thinkingModes?: 'off' | 'on' | 'granular';
 }
 
 /**

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -302,10 +302,11 @@ export function normalizeThinkingLevel(level: string | undefined | null): Thinki
  * Returns an empty array for providers that don't support thinking.
  */
 export function getThinkingOptionsForProvider(
-	provider: string | undefined
+	provider: string | undefined,
+	mode?: 'off' | 'on' | 'granular'
 ): Array<{ value: ThinkingLevel; label: string }> {
-	const mode = PROVIDER_THINKING_MODES[provider as Provider] ?? 'granular';
-	switch (mode) {
+	const resolvedMode = mode ?? PROVIDER_THINKING_MODES[provider as Provider] ?? 'granular';
+	switch (resolvedMode) {
 		case 'off':
 			return [];
 		case 'on':

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -282,7 +282,7 @@ export const PROVIDER_THINKING_MODES: Record<Provider, 'off' | 'on' | 'granular'
 	ollama: 'off',
 	'ollama-cloud': 'off',
 	'anthropic-copilot': 'off',
-	'anthropic-codex': 'off',
+	'anthropic-codex': 'granular',
 	'google-gemini-oauth': 'off',
 };
 

--- a/packages/shared/tests/types/thinking-options.test.ts
+++ b/packages/shared/tests/types/thinking-options.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'bun:test';
+import { getThinkingOptionsForProvider } from '../../src/types.ts';
+
+describe('getThinkingOptionsForProvider', () => {
+	test('returns granular options for anthropic provider by default', () => {
+		const options = getThinkingOptionsForProvider('anthropic');
+		expect(options).toEqual([
+			{ value: 'off', label: 'Off' },
+			{ value: 'think8k', label: 'Think 8k' },
+			{ value: 'think16k', label: 'Think 16k' },
+			{ value: 'think24k', label: 'Think 24k' },
+			{ value: 'think32k', label: 'Think 32k' },
+		]);
+	});
+
+	test('returns on/off options for kimi provider by default', () => {
+		const options = getThinkingOptionsForProvider('kimi');
+		expect(options).toEqual([
+			{ value: 'off', label: 'Off' },
+			{ value: 'think32k', label: 'On' },
+		]);
+	});
+
+	test('returns empty array for providers that do not support thinking', () => {
+		const options = getThinkingOptionsForProvider('minimax');
+		expect(options).toEqual([]);
+	});
+
+	test('defaults to granular for unknown providers', () => {
+		const options = getThinkingOptionsForProvider('unknown-provider');
+		expect(options).toEqual([
+			{ value: 'off', label: 'Off' },
+			{ value: 'think8k', label: 'Think 8k' },
+			{ value: 'think16k', label: 'Think 16k' },
+			{ value: 'think24k', label: 'Think 24k' },
+			{ value: 'think32k', label: 'Think 32k' },
+		]);
+	});
+
+	test('explicit off mode overrides provider default', () => {
+		const options = getThinkingOptionsForProvider('anthropic', 'off');
+		expect(options).toEqual([]);
+	});
+
+	test('explicit on mode overrides provider default', () => {
+		const options = getThinkingOptionsForProvider('minimax', 'on');
+		expect(options).toEqual([
+			{ value: 'off', label: 'Off' },
+			{ value: 'think32k', label: 'On' },
+		]);
+	});
+
+	test('explicit granular mode overrides provider default', () => {
+		const options = getThinkingOptionsForProvider('kimi', 'granular');
+		expect(options).toEqual([
+			{ value: 'off', label: 'Off' },
+			{ value: 'think8k', label: 'Think 8k' },
+			{ value: 'think16k', label: 'Think 16k' },
+			{ value: 'think24k', label: 'Think 24k' },
+			{ value: 'think32k', label: 'Think 32k' },
+		]);
+	});
+
+	test('handles undefined provider', () => {
+		const options = getThinkingOptionsForProvider(undefined);
+		expect(options).toEqual([
+			{ value: 'off', label: 'Off' },
+			{ value: 'think8k', label: 'Think 8k' },
+			{ value: 'think16k', label: 'Think 16k' },
+			{ value: 'think24k', label: 'Think 24k' },
+			{ value: 'think32k', label: 'Think 32k' },
+		]);
+	});
+});

--- a/packages/web/src/components/SessionStatusBar.tsx
+++ b/packages/web/src/components/SessionStatusBar.tsx
@@ -332,8 +332,13 @@ export default function SessionStatusBar({
 		setThinkingLevel(thinkingLevelProp || 'off');
 	}, [thinkingLevelProp]);
 
-	// Provider-aware thinking options
-	const thinkingOptions = getThinkingOptionsForProvider(currentModelInfo?.provider);
+	// Provider-aware thinking options — prefer runtime model thinkingModes (set by
+	// providers whose capability depends on runtime config, e.g. bridge adapter)
+	// falling back to the static PROVIDER_THINKING_MODES map.
+	const thinkingOptions = getThinkingOptionsForProvider(
+		currentModelInfo?.provider,
+		currentModelInfo?.thinkingModes
+	);
 
 	// Auto-scroll toggle handler
 	const handleAutoScrollToggle = useCallback(() => {

--- a/packages/web/src/components/__tests__/SessionStatusBar.test.tsx
+++ b/packages/web/src/components/__tests__/SessionStatusBar.test.tsx
@@ -509,6 +509,40 @@ describe('SessionStatusBar', () => {
 	});
 
 	describe('Thinking Dropdown', () => {
+		it('should hide thinking button when model thinkingModes is off', () => {
+			const codexModelInfo: ModelInfo = {
+				...mockModelInfo,
+				provider: 'anthropic-codex',
+				thinkingModes: 'off',
+			};
+			const { container } = render(
+				<SessionStatusBar {...defaultProps} currentModelInfo={codexModelInfo} />
+			);
+
+			const buttons = Array.from(container.querySelectorAll('.control-btn'));
+			const thinkingButton = buttons.find(
+				(btn) => btn.getAttribute('title')?.includes('Thinking:') || false
+			);
+			expect(thinkingButton).toBeUndefined();
+		});
+
+		it('should show thinking button when model thinkingModes is granular', () => {
+			const codexModelInfo: ModelInfo = {
+				...mockModelInfo,
+				provider: 'anthropic-codex',
+				thinkingModes: 'granular',
+			};
+			const { container } = render(
+				<SessionStatusBar {...defaultProps} currentModelInfo={codexModelInfo} />
+			);
+
+			const buttons = Array.from(container.querySelectorAll('.control-btn'));
+			const thinkingButton = buttons.find(
+				(btn) => btn.getAttribute('title')?.includes('Thinking:') || false
+			);
+			expect(thinkingButton).toBeTruthy();
+		});
+
 		it('should open thinking dropdown when clicked', () => {
 			const { container } = render(<SessionStatusBar {...defaultProps} />);
 


### PR DESCRIPTION
Enables full reasoning/thinking support for the anthropic-codex bridge backed by OpenAI's Responses API.

- Provider capabilities: extendedThinking=true, thinkingModes=granular
- Maps ThinkingLevel budget_tokens → OpenAI reasoning.effort (low/medium/high/xhigh) with summary=auto
- Requests include reasoning.encrypted_content for multi-turn continuity with store:false
- Translates 6 new OpenAI SSE reasoning events to Anthropic thinking SSE blocks
- Passes reasoning items back into subsequent turns' input array
- Maps output_tokens_details.reasoning_tokens to thinking_tokens in usage
- Adds unit tests for request mapping, SSE translation, multi-turn pass-through, and token accounting