### PR TITLE
Add InternalCommandBus facade for semantic daemon commands

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -10,7 +10,8 @@
 		"./config": "./src/config.ts",
 		"./routes/setup-websocket": "./src/routes/setup-websocket.ts",
 		"./sdk-cli-resolver": "./src/lib/agent/sdk-cli-resolver.ts",
-		"./lib/internal-event-bus": "./src/lib/internal-event-bus.ts"
+		"./lib/internal-event-bus": "./src/lib/internal-event-bus.ts",
+		"./lib/internal-command-bus": "./src/lib/internal-command-bus.ts"
 	},
 	"scripts": {
 		"dev": "bun run --watch main.ts",

--- a/packages/daemon/src/lib/internal-command-bus.ts
+++ b/packages/daemon/src/lib/internal-command-bus.ts
@@ -1,0 +1,192 @@
+/**
+ * InternalCommandBus — Semantic daemon command primitive (v1)
+ *
+ * First-class facade for typed internal commands with explicit one-handler-per-command
+ * semantics.  Commands are requests to do work, not facts.
+ *
+ * Design constraints (v1)
+ * -----------------------
+ * • One owner/handler per command — duplicate registration is rejected.
+ * • No middleware — cross-cutting concerns stay explicit in handlers.
+ * • Structured results — every dispatch returns a `CommandResult`.
+ * • Typed command map — domain code defines commands through a `TCommandMap`.
+ *
+ * Future direction
+ * ----------------
+ * See docs/plans/internal-event-command-query-architecture.md for the full
+ * internal-event / command / query architecture plan.
+ */
+
+/**
+ * Structured result returned by every command dispatch.
+ */
+export interface CommandResult {
+	/** Whether the command handler completed successfully. */
+	ok: boolean;
+
+	/** Error payload when `ok` is false. */
+	error?: unknown;
+
+	/** Arbitrary metadata the handler may attach (timings, ids, etc). */
+	metadata?: Record<string, unknown>;
+}
+
+/**
+ * Thrown when a command handler is registered for a name that already
+ * has an owner.
+ */
+export class DuplicateCommandHandlerError extends Error {
+	constructor(public readonly commandName: string) {
+		super(`Command '${commandName}' already has a registered handler`);
+		this.name = 'DuplicateCommandHandlerError';
+	}
+}
+
+/**
+ * Thrown when `dispatch(...)` is called for a command with no registered handler.
+ */
+export class MissingCommandHandlerError extends Error {
+	constructor(public readonly commandName: string) {
+		super(`No handler registered for command '${commandName}'`);
+		this.name = 'MissingCommandHandlerError';
+	}
+}
+
+export type CommandHandler<TCommand> = (command: TCommand) => Promise<CommandResult>;
+
+interface RegisteredCommandHandler {
+	handler: (command: unknown) => Promise<CommandResult>;
+}
+
+/**
+ * InternalCommandBus
+ *
+ * @template TCommandMap — map of dot-separated command names to payload shapes.
+ */
+export class InternalCommandBus<TCommandMap extends object = Record<string, unknown>> {
+	private handlers = new Map<string, RegisteredCommandHandler>();
+
+	/**
+	 * Register a handler for a command.
+	 *
+	 * @param commandName — typed command name
+	 * @param handler     — callback invoked when the command is dispatched
+	 * @returns unsubscribe function
+	 * @throws DuplicateCommandHandlerError if a handler already exists for this command
+	 */
+	register<K extends keyof TCommandMap & string>(
+		commandName: K,
+		handler: CommandHandler<TCommandMap[K]>
+	): () => void {
+		const key = commandName;
+
+		if (this.handlers.has(key)) {
+			throw new DuplicateCommandHandlerError(key);
+		}
+
+		const registered: RegisteredCommandHandler = {
+			handler: handler as (command: unknown) => Promise<CommandResult>,
+		};
+
+		this.handlers.set(key, registered);
+
+		return () => {
+			this.handlers.delete(key);
+		};
+	}
+
+	/**
+	 * Dispatch a command to its registered handler and await the result.
+	 *
+	 * @param commandName — typed command name
+	 * @param command     — command payload
+	 * @returns structured `CommandResult`
+	 * @throws MissingCommandHandlerError if no handler is registered
+	 */
+	async dispatch<K extends keyof TCommandMap & string>(
+		commandName: K,
+		command: TCommandMap[K]
+	): Promise<CommandResult> {
+		const key = commandName;
+		const registered = this.handlers.get(key);
+
+		if (!registered) {
+			throw new MissingCommandHandlerError(key);
+		}
+
+		return registered.handler(command);
+	}
+
+	/**
+	 * Return true if a handler is registered for the given command name.
+	 */
+	hasHandler<K extends keyof TCommandMap & string>(commandName: K): boolean {
+		return this.handlers.has(commandName);
+	}
+
+	/**
+	 * Remove the handler for a specific command.
+	 */
+	unregister<K extends keyof TCommandMap & string>(commandName: K): void {
+		this.handlers.delete(commandName);
+	}
+
+	/**
+	 * Remove all handlers.
+	 */
+	clear(): void {
+		this.handlers.clear();
+	}
+
+	/**
+	 * Return the number of registered handlers.
+	 */
+	getHandlerCount(): number {
+		return this.handlers.size;
+	}
+}
+
+/**
+ * Convenience factory that produces an InternalCommandBus typed with the
+ * caller's command map.
+ *
+ * This is the entry point most daemon code should use:
+ *
+ *   import { createInternalCommandBus } from '@neokai/daemon/lib/internal-command-bus';
+ *   const bus = createInternalCommandBus<MyCommandMap>();
+ */
+export function createInternalCommandBus<
+	TCommandMap extends object = Record<string, unknown>,
+>(): InternalCommandBus<TCommandMap> {
+	return new InternalCommandBus<TCommandMap>();
+}
+
+// ---------------------------------------------------------------------------
+// Command contracts — canonical payloads for commands used across the daemon.
+// Expand this map as new commands are added; keep each domain's commands
+// in a separate interface and intersect them here.
+// ---------------------------------------------------------------------------
+
+/**
+ * Payload for `agent.message.inject` — inject a message into an agent session.
+ */
+export interface AgentMessageInjectCommand {
+	/** Target session ID. */
+	sessionId: string;
+
+	/** Message content to inject (usually a formatted agent envelope). */
+	message: string;
+
+	/** Optional metadata for routing diagnostics. */
+	metadata?: Record<string, unknown>;
+}
+
+/**
+ * Canonical daemon command map.
+ *
+ * Each domain should own its slice; this type is the intersection of all
+ * domain command maps so the bus can be typed with the full surface.
+ */
+export interface DaemonCommandMap {
+	'agent.message.inject': AgentMessageInjectCommand;
+}

--- a/packages/daemon/src/lib/internal-command-bus.ts
+++ b/packages/daemon/src/lib/internal-command-bus.ts
@@ -91,7 +91,10 @@ export class InternalCommandBus<TCommandMap extends object = Record<string, unkn
 		this.handlers.set(key, registered);
 
 		return () => {
-			this.handlers.delete(key);
+			const current = this.handlers.get(key);
+			if (current === registered) {
+				this.handlers.delete(key);
+			}
 		};
 	}
 

--- a/packages/daemon/src/lib/internal-command-bus.ts
+++ b/packages/daemon/src/lib/internal-command-bus.ts
@@ -117,7 +117,11 @@ export class InternalCommandBus<TCommandMap extends object = Record<string, unkn
 			throw new MissingCommandHandlerError(key);
 		}
 
-		return registered.handler(command);
+		try {
+			return await registered.handler(command);
+		} catch (error) {
+			return { ok: false, error };
+		}
 	}
 
 	/**

--- a/packages/daemon/tests/unit/1-core/core/internal-command-bus.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/internal-command-bus.test.ts
@@ -107,15 +107,15 @@ describe('InternalCommandBus', () => {
 			expect(result.metadata).toEqual({ retryAfter: 60 });
 		});
 
-		it('should propagate handler throws as raw errors (not wrapped)', async () => {
+		it('should normalize handler throws to a structured failure result', async () => {
 			const err = new Error('handler blew up');
 			bus.register('space.workflow.resume', async () => {
 				throw err;
 			});
 
-			await expect(bus.dispatch('space.workflow.resume', { workflowRunId: 'wr-1' })).rejects.toBe(
-				err
-			);
+			const result = await bus.dispatch('space.workflow.resume', { workflowRunId: 'wr-1' });
+			expect(result.ok).toBe(false);
+			expect(result.error).toBe(err);
 		});
 
 		it('should throw MissingCommandHandlerError when no handler is registered', async () => {

--- a/packages/daemon/tests/unit/1-core/core/internal-command-bus.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/internal-command-bus.test.ts
@@ -1,0 +1,218 @@
+/**
+ * InternalCommandBus Unit Tests
+ *
+ * Covers:
+ *   – handler registration and dispatch
+ *   – structured success/failure results
+ *   – duplicate handler rejection
+ *   – missing handler error
+ *   – unregister and clear
+ *
+ * See docs/plans/internal-event-command-query-architecture.md
+ */
+
+import { beforeEach, describe, expect, it } from 'bun:test';
+import {
+	createInternalCommandBus,
+	DuplicateCommandHandlerError,
+	InternalCommandBus,
+	MissingCommandHandlerError,
+	type CommandResult,
+	type AgentMessageInjectCommand,
+} from '../../../../src/lib/internal-command-bus';
+
+interface TestCommandMap {
+	'agent.message.inject': AgentMessageInjectCommand;
+	'space.workflow.resume': { workflowRunId: string };
+	'github.repo.watch': { owner: string; repo: string };
+}
+
+describe('InternalCommandBus', () => {
+	let bus: InternalCommandBus<TestCommandMap>;
+
+	beforeEach(() => {
+		bus = new InternalCommandBus<TestCommandMap>();
+	});
+
+	describe('register', () => {
+		it('should register a handler and return an unsubscribe function', () => {
+			const unsub = bus.register('space.workflow.resume', async () => ({ ok: true }));
+			expect(typeof unsub).toBe('function');
+			expect(bus.hasHandler('space.workflow.resume')).toBe(true);
+		});
+
+		it('should reject duplicate handlers for the same command', () => {
+			bus.register('space.workflow.resume', async () => ({ ok: true }));
+
+			expect(() => bus.register('space.workflow.resume', async () => ({ ok: true }))).toThrow(
+				DuplicateCommandHandlerError
+			);
+		});
+
+		it('should include the command name in the duplicate error', () => {
+			bus.register('github.repo.watch', async () => ({ ok: true }));
+
+			try {
+				bus.register('github.repo.watch', async () => ({ ok: true }));
+				expect.unreachable('should have thrown');
+			} catch (e) {
+				expect(e).toBeInstanceOf(DuplicateCommandHandlerError);
+				const dup = e as DuplicateCommandHandlerError;
+				expect(dup.commandName).toBe('github.repo.watch');
+				expect(dup.message).toContain('github.repo.watch');
+			}
+		});
+	});
+
+	describe('dispatch', () => {
+		it('should return the handler result on success', async () => {
+			const result: CommandResult = { ok: true, metadata: { processedAt: 42 } };
+			bus.register('space.workflow.resume', async () => result);
+
+			const received = await bus.dispatch('space.workflow.resume', { workflowRunId: 'wr-1' });
+			expect(received.ok).toBe(true);
+			expect(received.metadata).toEqual({ processedAt: 42 });
+		});
+
+		it('should pass the command payload to the handler', async () => {
+			const payloads: Array<AgentMessageInjectCommand> = [];
+			bus.register('agent.message.inject', async (cmd) => {
+				payloads.push(cmd);
+				return { ok: true };
+			});
+
+			await bus.dispatch('agent.message.inject', {
+				sessionId: 's1',
+				message: 'hello',
+				metadata: { source: 'test' },
+			});
+
+			expect(payloads).toHaveLength(1);
+			expect(payloads[0].sessionId).toBe('s1');
+			expect(payloads[0].message).toBe('hello');
+			expect(payloads[0].metadata).toEqual({ source: 'test' });
+		});
+
+		it('should return failure results without throwing when the handler returns ok:false', async () => {
+			bus.register('github.repo.watch', async () => ({
+				ok: false,
+				error: new Error('rate limited'),
+				metadata: { retryAfter: 60 },
+			}));
+
+			const result = await bus.dispatch('github.repo.watch', { owner: 'acme', repo: 'demo' });
+			expect(result.ok).toBe(false);
+			expect(result.error).toBeInstanceOf(Error);
+			expect((result.error as Error).message).toBe('rate limited');
+			expect(result.metadata).toEqual({ retryAfter: 60 });
+		});
+
+		it('should propagate handler throws as raw errors (not wrapped)', async () => {
+			const err = new Error('handler blew up');
+			bus.register('space.workflow.resume', async () => {
+				throw err;
+			});
+
+			await expect(bus.dispatch('space.workflow.resume', { workflowRunId: 'wr-1' })).rejects.toBe(
+				err
+			);
+		});
+
+		it('should throw MissingCommandHandlerError when no handler is registered', async () => {
+			await expect(
+				bus.dispatch('space.workflow.resume', { workflowRunId: 'wr-1' })
+			).rejects.toBeInstanceOf(MissingCommandHandlerError);
+		});
+
+		it('should include the command name in the missing-handler error', async () => {
+			try {
+				await bus.dispatch('github.repo.watch', { owner: 'acme', repo: 'demo' });
+				expect.unreachable('should have thrown');
+			} catch (e) {
+				expect(e).toBeInstanceOf(MissingCommandHandlerError);
+				const missing = e as MissingCommandHandlerError;
+				expect(missing.commandName).toBe('github.repo.watch');
+				expect(missing.message).toContain('github.repo.watch');
+			}
+		});
+	});
+
+	describe('unregister', () => {
+		it('should remove the handler for a specific command', async () => {
+			bus.register('space.workflow.resume', async () => ({ ok: true }));
+			expect(bus.hasHandler('space.workflow.resume')).toBe(true);
+
+			bus.unregister('space.workflow.resume');
+			expect(bus.hasHandler('space.workflow.resume')).toBe(false);
+		});
+
+		it('should make the command undispatchable after unregister', async () => {
+			bus.register('space.workflow.resume', async () => ({ ok: true }));
+			bus.unregister('space.workflow.resume');
+
+			await expect(
+				bus.dispatch('space.workflow.resume', { workflowRunId: 'wr-1' })
+			).rejects.toBeInstanceOf(MissingCommandHandlerError);
+		});
+	});
+
+	describe('unsubscribe returned by register', () => {
+		it('should remove the handler when called', async () => {
+			const unsub = bus.register('space.workflow.resume', async () => ({ ok: true }));
+			expect(bus.hasHandler('space.workflow.resume')).toBe(true);
+
+			unsub();
+			expect(bus.hasHandler('space.workflow.resume')).toBe(false);
+		});
+
+		it('should allow re-registration after unsubscribe', () => {
+			const unsub = bus.register('space.workflow.resume', async () => ({ ok: true }));
+			unsub();
+
+			expect(() => bus.register('space.workflow.resume', async () => ({ ok: true }))).not.toThrow();
+			expect(bus.hasHandler('space.workflow.resume')).toBe(true);
+		});
+	});
+
+	describe('clear', () => {
+		it('should remove all handlers', () => {
+			bus.register('space.workflow.resume', async () => ({ ok: true }));
+			bus.register('github.repo.watch', async () => ({ ok: true }));
+
+			bus.clear();
+
+			expect(bus.hasHandler('space.workflow.resume')).toBe(false);
+			expect(bus.hasHandler('github.repo.watch')).toBe(false);
+			expect(bus.getHandlerCount()).toBe(0);
+		});
+	});
+
+	describe('diagnostics', () => {
+		it('should report correct handler count', () => {
+			expect(bus.getHandlerCount()).toBe(0);
+			bus.register('space.workflow.resume', async () => ({ ok: true }));
+			expect(bus.getHandlerCount()).toBe(1);
+			bus.register('github.repo.watch', async () => ({ ok: true }));
+			expect(bus.getHandlerCount()).toBe(2);
+		});
+
+		it('should report hasHandler correctly', () => {
+			expect(bus.hasHandler('space.workflow.resume')).toBe(false);
+			bus.register('space.workflow.resume', async () => ({ ok: true }));
+			expect(bus.hasHandler('space.workflow.resume')).toBe(true);
+			expect(bus.hasHandler('github.repo.watch')).toBe(false);
+		});
+	});
+
+	describe('createInternalCommandBus factory', () => {
+		it('should produce a working typed bus', async () => {
+			const factoryBus = createInternalCommandBus<TestCommandMap>();
+			factoryBus.register('space.workflow.resume', async () => ({ ok: true }));
+
+			const result = await factoryBus.dispatch('space.workflow.resume', {
+				workflowRunId: 'factory-test',
+			});
+			expect(result.ok).toBe(true);
+		});
+	});
+});

--- a/packages/daemon/tests/unit/1-core/core/internal-command-bus.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/internal-command-bus.test.ts
@@ -172,6 +172,24 @@ describe('InternalCommandBus', () => {
 			expect(() => bus.register('space.workflow.resume', async () => ({ ok: true }))).not.toThrow();
 			expect(bus.hasHandler('space.workflow.resume')).toBe(true);
 		});
+
+		it('should not remove a newer handler when a stale unsubscribe is called', async () => {
+			const unsubA = bus.register('space.workflow.resume', async () => ({
+				ok: true,
+				metadata: { version: 'A' },
+			}));
+			unsubA();
+
+			bus.register('space.workflow.resume', async () => ({ ok: true, metadata: { version: 'B' } }));
+
+			// Calling the old unsubscribe should not delete the new handler
+			unsubA();
+			expect(bus.hasHandler('space.workflow.resume')).toBe(true);
+
+			const result = await bus.dispatch('space.workflow.resume', { workflowRunId: 'wr-1' });
+			expect(result.ok).toBe(true);
+			expect(result.metadata).toEqual({ version: 'B' });
+		});
 	});
 
 	describe('clear', () => {


### PR DESCRIPTION
Implements `InternalCommandBus` following the same facade pattern as `InternalEventBus`.

- Commands are requests to do work (not facts).
- One handler per command — duplicate registration throws `DuplicateCommandHandlerError`.
- `dispatch(...)` returns a structured `CommandResult`.
- Missing handlers throw `MissingCommandHandlerError`.
- No middleware in v1.

Registers the first canonical command contract: `agent.message.inject`.

Unit tests cover success, failure, missing handler, duplicate handler, unregister, clear, and diagnostics.