### PR TITLE
fix(daemon): explicitly disable thinking when level is 'off' for thinking-capable providers

### DIFF
--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -547,9 +547,10 @@ export class QueryOptionsBuilder {
 
 		const tokens = THINKING_LEVEL_TOKENS[level];
 
-		// 'off' level: no thinking budget
+		// 'off' level: explicitly disable thinking so the SDK does not fall back
+		// to its default behavior of enabling thinking when the property is absent.
 		if (tokens === undefined) {
-			return undefined;
+			return { type: 'disabled' };
 		}
 
 		// Preserve the selected budget for all providers that support thinking.

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -318,11 +318,12 @@ describe('QueryOptionsBuilder', () => {
 			expect(result.thinking).toEqual({ type: 'enabled', budgetTokens: 16000 });
 		});
 
-		it('should use off as default thinking level when no session or global override exists', async () => {
+		it('should explicitly disable thinking for thinking-capable providers when level is off', async () => {
 			const options = await builder.build();
 			const result = builder.addSessionStateOptions(options);
 
-			expect(result.thinking).toBeUndefined();
+			// Default provider (anthropic) supports thinking — 'off' must emit explicit disable
+			expect(result.thinking).toEqual({ type: 'disabled' });
 		});
 
 		it('should omit thinking config for providers with thinkingModes=off', async () => {
@@ -347,6 +348,26 @@ describe('QueryOptionsBuilder', () => {
 			);
 
 			expect(result.thinking).toEqual({ type: 'enabled', budgetTokens: 8000 });
+		});
+
+		it('should explicitly disable thinking for kimi when level is off', async () => {
+			mockSession.config.provider = 'kimi';
+			mockSession.config.thinkingLevel = 'off';
+			const result = builder.addSessionStateOptions(
+				{} as import('@anthropic-ai/claude-agent-sdk').Options
+			);
+
+			expect(result.thinking).toEqual({ type: 'disabled' });
+		});
+
+		it('should omit thinking config for providers with thinkingModes=off even when level is off', async () => {
+			mockSession.config.provider = 'minimax';
+			mockSession.config.thinkingLevel = 'off';
+			const result = builder.addSessionStateOptions(
+				{} as import('@anthropic-ai/claude-agent-sdk').Options
+			);
+
+			expect(result.thinking).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
`thinkingLevelToThinkingConfig()` returned `undefined` when the thinking level was 'off', causing the SDK to omit the `thinking` property and fall back to enabling thinking automatically for supported models. Providers like Kimi therefore continued emitting thinking blocks even when the user set the level to Off.

The fix returns `{ type: 'disabled' }` for all providers that support thinking (`thinkingModes !== 'off'`), so the SDK receives an explicit disable signal. Providers without thinking support still get `undefined`.

Updated unit tests verify:
- `thinkingModes='on'` (Kimi) + level 'off' → `{ type: 'disabled' }`
- `thinkingModes='granular'` (Anthropic) + level 'off' → `{ type: 'disabled' }`
- `thinkingModes='off'` (MiniMax) + any level → `undefined`