### PR TITLE
fix(daemon,web): refresh model cache on Gemini OAuth account changes

### DIFF
--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -351,6 +351,10 @@ export function clearModelsCache(cacheKey?: string): void {
  * Refresh models from all providers, preserving the existing cache on failure.
  * Clears provider-level caches first so each provider re-fetches from its API,
  * but only replaces the global cache if the fetch succeeds.
+ *
+ * If no providers return models and the cache was empty (e.g. after an explicit
+ * clear), FALLBACK_MODELS is restored so the UI and model resolution paths
+ * never see a permanently empty catalog.
  */
 export async function refreshModels(): Promise<void> {
 	const cacheKey = 'global';
@@ -379,6 +383,11 @@ export async function refreshModels(): Promise<void> {
 			return;
 		}
 		modelsCache.set(cacheKey, mergedModels);
+		cacheTimestamps.set(cacheKey, Date.now());
+	} else if (!previousModels || previousModels.length === 0) {
+		// Cache was cleared or was already empty — restore fallback models
+		// so the UI and model resolution paths always have a baseline catalog.
+		modelsCache.set(cacheKey, FALLBACK_MODELS);
 		cacheTimestamps.set(cacheKey, Date.now());
 	}
 }

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -147,11 +147,12 @@ function mergeWithFallbackModels(providerModels: ModelInfo[]): ModelInfo[] {
 const refreshInProgress = new Map<string, Promise<void>>();
 
 /**
- * Monotonic generation counter used to invalidate in-flight background
- * refreshes.  `clearModelsCache()` bumps this; background refreshes that
- * started before the bump drop their result instead of writing stale data.
+ * Per-key monotonic generation counters used to invalidate in-flight
+ * background refreshes.  `clearModelsCache(key)` bumps the counter for
+ * that key only, so a session-scoped clear cannot accidentally cancel a
+ * global refresh or vice-versa.
  */
-let cacheGeneration = 0;
+const cacheGeneration = new Map<string, number>();
 
 /**
  * Get supported models from an existing Claude SDK query object
@@ -209,7 +210,7 @@ async function triggerBackgroundRefresh(cacheKey: string): Promise<void> {
 		return;
 	}
 
-	const generationAtStart = cacheGeneration;
+	const generationAtStart = cacheGeneration.get(cacheKey) ?? 0;
 
 	// Start background refresh
 	const refreshPromise = (async () => {
@@ -218,7 +219,7 @@ async function triggerBackgroundRefresh(cacheKey: string): Promise<void> {
 			// Only write if the cache wasn't cleared while we were loading.
 			// This prevents a stale pre-change provider list from overwriting
 			// the cache after `clearModelsCache()` has been called.
-			if (models.length > 0 && generationAtStart === cacheGeneration) {
+			if (models.length > 0 && (cacheGeneration.get(cacheKey) ?? 0) === generationAtStart) {
 				// Merge with fallback models to ensure Anthropic aliases are always available
 				const mergedModels = mergeWithFallbackModels(models);
 				modelsCache.set(cacheKey, mergedModels);
@@ -348,21 +349,27 @@ function clearProviderModelCaches(): void {
  * Clear the models cache for a specific key or all.
  * Provider-level caches are only cleared on a full clear (no cacheKey).
  *
- * Also bumps the cache generation so any in-flight background refreshes
- * that started before this call drop their stale results instead of
- * overwriting the cleared cache.
+ * Also bumps the per-key cache generation so any in-flight background
+ * refreshes for that key drop their stale results instead of overwriting
+ * the cleared cache.
  */
 export function clearModelsCache(cacheKey?: string): void {
-	cacheGeneration++;
 	if (cacheKey) {
 		modelsCache.delete(cacheKey);
 		cacheTimestamps.delete(cacheKey);
 		refreshInProgress.delete(cacheKey);
+		cacheGeneration.set(cacheKey, (cacheGeneration.get(cacheKey) ?? 0) + 1);
 	} else {
 		modelsCache.clear();
 		cacheTimestamps.clear();
 		refreshInProgress.clear();
 		clearProviderModelCaches();
+		// Bump generation for every known key so all in-flight refreshes are
+		// invalidated, and ensure 'global' is bumped even if it has no entry.
+		for (const key of cacheGeneration.keys()) {
+			cacheGeneration.set(key, (cacheGeneration.get(key) ?? 0) + 1);
+		}
+		cacheGeneration.set('global', (cacheGeneration.get('global') ?? 0) + 1);
 	}
 }
 

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -377,16 +377,18 @@ export function clearModelsCache(cacheKey?: string): void {
 		cacheTimestamps.clear();
 		refreshInProgress.clear();
 		clearProviderModelCaches();
-		// Bump generation only for keys that had in-flight refreshes.
+		// Bump generation for keys that had in-flight refreshes so any
+		// running background refresh drops its stale result instead of
+		// overwriting the cleared cache.
 		for (const key of inFlightKeys) {
 			cacheGeneration.set(key, (cacheGeneration.get(key) ?? 0) + 1);
 		}
-		// Prune generation tracking for keys with no in-flight refresh.
-		for (const key of Array.from(cacheGeneration.keys())) {
-			if (!inFlightKeys.has(key)) {
-				cacheGeneration.delete(key);
-			}
-		}
+		// NOTE: We intentionally do NOT prune cacheGeneration here.
+		// A prior global clear may have bumped a generation to cancel an
+		// in-flight refresh; if a second clear arrives before that refresh
+		// resolves, pruning would delete the bump and allow the stale
+		// result to be written.  Keys are cleaned up by
+		// triggerBackgroundRefresh's finally block once the refresh completes.
 	}
 }
 

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -363,14 +363,13 @@ export function clearModelsCache(cacheKey?: string): void {
 		modelsCache.delete(cacheKey);
 		cacheTimestamps.delete(cacheKey);
 		refreshInProgress.delete(cacheKey);
-		if (hadInFlight) {
-			// Bump so the in-flight refresh drops its stale result.
+		if (hadInFlight || cacheGeneration.has(cacheKey)) {
+			// Bump (or preserve) the generation so any in-flight refresh —
+			// including one invalidated by an earlier clear — drops its result.
 			cacheGeneration.set(cacheKey, (cacheGeneration.get(cacheKey) ?? 0) + 1);
-		} else {
-			// No in-flight refresh — remove generation tracking to prevent
-			// unbounded growth of per-session keys.
-			cacheGeneration.delete(cacheKey);
 		}
+		// If there's no in-flight refresh and no generation history, there's
+		// nothing to invalidate; leave the key absent.
 	} else {
 		const inFlightKeys = new Set(refreshInProgress.keys());
 		modelsCache.clear();

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -147,6 +147,13 @@ function mergeWithFallbackModels(providerModels: ModelInfo[]): ModelInfo[] {
 const refreshInProgress = new Map<string, Promise<void>>();
 
 /**
+ * Monotonic generation counter used to invalidate in-flight background
+ * refreshes.  `clearModelsCache()` bumps this; background refreshes that
+ * started before the bump drop their result instead of writing stale data.
+ */
+let cacheGeneration = 0;
+
+/**
  * Get supported models from an existing Claude SDK query object
  * This uses the AnthropicProvider to convert SDK models to ModelInfo
  *
@@ -202,11 +209,16 @@ async function triggerBackgroundRefresh(cacheKey: string): Promise<void> {
 		return;
 	}
 
+	const generationAtStart = cacheGeneration;
+
 	// Start background refresh
 	const refreshPromise = (async () => {
 		try {
 			const models = await loadModelsFromProviders();
-			if (models.length > 0) {
+			// Only write if the cache wasn't cleared while we were loading.
+			// This prevents a stale pre-change provider list from overwriting
+			// the cache after `clearModelsCache()` has been called.
+			if (models.length > 0 && generationAtStart === cacheGeneration) {
 				// Merge with fallback models to ensure Anthropic aliases are always available
 				const mergedModels = mergeWithFallbackModels(models);
 				modelsCache.set(cacheKey, mergedModels);
@@ -335,14 +347,21 @@ function clearProviderModelCaches(): void {
 /**
  * Clear the models cache for a specific key or all.
  * Provider-level caches are only cleared on a full clear (no cacheKey).
+ *
+ * Also bumps the cache generation so any in-flight background refreshes
+ * that started before this call drop their stale results instead of
+ * overwriting the cleared cache.
  */
 export function clearModelsCache(cacheKey?: string): void {
+	cacheGeneration++;
 	if (cacheKey) {
 		modelsCache.delete(cacheKey);
 		cacheTimestamps.delete(cacheKey);
+		refreshInProgress.delete(cacheKey);
 	} else {
 		modelsCache.clear();
 		cacheTimestamps.clear();
+		refreshInProgress.clear();
 		clearProviderModelCaches();
 	}
 }

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -409,31 +409,55 @@ export async function refreshModels(): Promise<void> {
 		await inProgress;
 	}
 
+	// If another foreground refresh is already running, wait for it.
+	if (refreshInProgress.has(cacheKey)) {
+		await refreshInProgress.get(cacheKey);
+		return;
+	}
+
+	const generationAtStart = cacheGeneration.get(cacheKey) ?? 0;
 	const previousModels = modelsCache.get(cacheKey);
 	clearProviderModelCaches();
 
-	const models = await loadModelsFromProviders();
-	if (models.length > 0) {
-		const mergedModels = mergeWithFallbackModels(models);
-		// If the new result has fewer models than the previous cache, at least one
-		// provider likely returned static fallback data instead of live API results
-		// (e.g. OpenRouter returns FALLBACK_MODELS on HTTP errors). Keep the old,
-		// richer cache rather than replacing it with degraded fallback metadata.
-		// Compare merged-vs-merged so the fallback entries added by mergeWithFallbackModels
-		// don't distort the comparison.
-		if (previousModels && previousModels.length > mergedModels.length) {
-			modelsCache.set(cacheKey, previousModels);
-			cacheTimestamps.set(cacheKey, Date.now());
-			return;
+	const refreshPromise = (async () => {
+		try {
+			const models = await loadModelsFromProviders();
+			// Only write if the cache wasn't cleared while we were loading.
+			if ((cacheGeneration.get(cacheKey) ?? 0) !== generationAtStart) {
+				return;
+			}
+			if (models.length > 0) {
+				const mergedModels = mergeWithFallbackModels(models);
+				// If the new result has fewer models than the previous cache, at least one
+				// provider likely returned static fallback data instead of live API results
+				// (e.g. OpenRouter returns FALLBACK_MODELS on HTTP errors). Keep the old,
+				// richer cache rather than replacing it with degraded fallback metadata.
+				// Compare merged-vs-merged so the fallback entries added by mergeWithFallbackModels
+				// don't distort the comparison.
+				if (previousModels && previousModels.length > mergedModels.length) {
+					modelsCache.set(cacheKey, previousModels);
+					cacheTimestamps.set(cacheKey, Date.now());
+					return;
+				}
+				modelsCache.set(cacheKey, mergedModels);
+				cacheTimestamps.set(cacheKey, Date.now());
+			} else if (!previousModels || previousModels.length === 0) {
+				// Cache was cleared or was already empty — restore fallback models
+				// so the UI and model resolution paths always have a baseline catalog.
+				modelsCache.set(cacheKey, FALLBACK_MODELS);
+				cacheTimestamps.set(cacheKey, Date.now());
+			}
+		} finally {
+			refreshInProgress.delete(cacheKey);
+			// Prune generation tracking if the cache key is no longer referenced.
+			if (!modelsCache.has(cacheKey) && !cacheTimestamps.has(cacheKey)) {
+				cacheGeneration.delete(cacheKey);
+			}
 		}
-		modelsCache.set(cacheKey, mergedModels);
-		cacheTimestamps.set(cacheKey, Date.now());
-	} else if (!previousModels || previousModels.length === 0) {
-		// Cache was cleared or was already empty — restore fallback models
-		// so the UI and model resolution paths always have a baseline catalog.
-		modelsCache.set(cacheKey, FALLBACK_MODELS);
-		cacheTimestamps.set(cacheKey, Date.now());
-	}
+	})();
+
+	refreshInProgress.set(cacheKey, refreshPromise);
+	await refreshPromise;
 }
 
 /**

--- a/packages/daemon/src/lib/model-service.ts
+++ b/packages/daemon/src/lib/model-service.ts
@@ -230,6 +230,10 @@ async function triggerBackgroundRefresh(cacheKey: string): Promise<void> {
 			// Background refresh failed
 		} finally {
 			refreshInProgress.delete(cacheKey);
+			// Prune generation tracking if the cache key is no longer referenced
+			if (!modelsCache.has(cacheKey) && !cacheTimestamps.has(cacheKey)) {
+				cacheGeneration.delete(cacheKey);
+			}
 		}
 	})();
 
@@ -355,21 +359,34 @@ function clearProviderModelCaches(): void {
  */
 export function clearModelsCache(cacheKey?: string): void {
 	if (cacheKey) {
+		const hadInFlight = refreshInProgress.has(cacheKey);
 		modelsCache.delete(cacheKey);
 		cacheTimestamps.delete(cacheKey);
 		refreshInProgress.delete(cacheKey);
-		cacheGeneration.set(cacheKey, (cacheGeneration.get(cacheKey) ?? 0) + 1);
+		if (hadInFlight) {
+			// Bump so the in-flight refresh drops its stale result.
+			cacheGeneration.set(cacheKey, (cacheGeneration.get(cacheKey) ?? 0) + 1);
+		} else {
+			// No in-flight refresh — remove generation tracking to prevent
+			// unbounded growth of per-session keys.
+			cacheGeneration.delete(cacheKey);
+		}
 	} else {
+		const inFlightKeys = new Set(refreshInProgress.keys());
 		modelsCache.clear();
 		cacheTimestamps.clear();
 		refreshInProgress.clear();
 		clearProviderModelCaches();
-		// Bump generation for every known key so all in-flight refreshes are
-		// invalidated, and ensure 'global' is bumped even if it has no entry.
-		for (const key of cacheGeneration.keys()) {
+		// Bump generation only for keys that had in-flight refreshes.
+		for (const key of inFlightKeys) {
 			cacheGeneration.set(key, (cacheGeneration.get(key) ?? 0) + 1);
 		}
-		cacheGeneration.set('global', (cacheGeneration.get('global') ?? 0) + 1);
+		// Prune generation tracking for keys with no in-flight refresh.
+		for (const key of Array.from(cacheGeneration.keys())) {
+			if (!inFlightKeys.has(key)) {
+				cacheGeneration.delete(key);
+			}
+		}
 	}
 }
 

--- a/packages/daemon/src/lib/rpc-handlers/auth-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/auth-handlers.ts
@@ -29,6 +29,7 @@ import type {
 import type { AuthManager } from '../auth-manager';
 import { getProviderRegistry } from '../providers/registry';
 import { Logger } from '../logger';
+import { clearModelsCache } from '../model-service.js';
 import {
 	buildAuthUrl,
 	exchangeAuthCode,
@@ -399,6 +400,7 @@ export function setupAuthHandlers(messageHub: MessageHub, authManager: AuthManag
 					});
 					pendingFlows.delete(flowId);
 					await syncRotationManager();
+					clearModelsCache();
 					log.info(`Re-authenticated Google account: ${userInfo.email}`);
 					const accounts = await loadAccounts();
 					const updated = accounts.find((a) => a.id === flow.reauthAccountId);
@@ -422,6 +424,7 @@ export function setupAuthHandlers(messageHub: MessageHub, authManager: AuthManag
 				await persistAddAccount(account);
 				pendingFlows.delete(flowId);
 				await syncRotationManager();
+				clearModelsCache();
 
 				log.info(`Added Google account via headless OAuth: ${userInfo.email}`);
 				return {
@@ -462,6 +465,7 @@ export function setupAuthHandlers(messageHub: MessageHub, authManager: AuthManag
 					).getRotationManager();
 					await rm.removeAccount(req.accountId);
 				}
+				clearModelsCache();
 				log.info(`Removed Gemini OAuth account: ${req.accountId}`);
 				return { success: true };
 			} catch (error) {

--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -703,7 +703,15 @@ export function setupSessionHandlers(
 				await refreshModels();
 			}
 
-			const availableModels = getAvailableModels('global');
+			let availableModels = getAvailableModels('global');
+
+			// If cache is empty and we're not already forcing refresh, do a forced refresh.
+			// This handles the case where the cache was just cleared (e.g., after OAuth
+			// account changes) so the next models.list call re-evaluates provider availability.
+			if (!forceRefresh && availableModels.length === 0) {
+				await refreshModels();
+				availableModels = getAvailableModels('global');
+			}
 
 			return {
 				models: availableModels.map((m) => ({
@@ -716,7 +724,7 @@ export function setupSessionHandlers(
 					context_window: m.contextWindow,
 					type: 'model' as const,
 				})),
-				cached: !forceRefresh,
+				cached: !forceRefresh && availableModels.length > 0,
 			};
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : String(error);

--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -698,6 +698,7 @@ export function setupSessionHandlers(
 				useCache?: boolean;
 			};
 			const forceRefresh = params?.forceRefresh ?? params?.useCache === false;
+			let didRefresh = forceRefresh;
 
 			if (forceRefresh) {
 				await refreshModels();
@@ -711,6 +712,7 @@ export function setupSessionHandlers(
 			if (!forceRefresh && availableModels.length === 0) {
 				await refreshModels();
 				availableModels = getAvailableModels('global');
+				didRefresh = true;
 			}
 
 			return {
@@ -724,7 +726,7 @@ export function setupSessionHandlers(
 					context_window: m.contextWindow,
 					type: 'model' as const,
 				})),
-				cached: !forceRefresh && availableModels.length > 0,
+				cached: !didRefresh && availableModels.length > 0,
 			};
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : String(error);

--- a/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/session-handlers.ts
@@ -24,7 +24,7 @@ import { generateUUID } from '@neokai/shared';
 import type { SessionManager } from '../session-manager';
 import type { CreateSessionRequest, UpdateSessionRequest } from '@neokai/shared';
 import { isSDKUserMessage } from '@neokai/shared/sdk/type-guards';
-import { clearModelsCache } from '../model-service';
+import { clearModelsCache } from '../model-service.js';
 import {
 	archiveSDKSessionFiles,
 	deleteSDKSessionFiles,
@@ -501,7 +501,7 @@ export function setupSessionHandlers(
 
 		// Resolve alias to full model ID for consistency with session.model.switch
 		// Pass provider so same-ID models are disambiguated by provider context
-		const { resolveModelAlias, getModelInfo } = await import('../model-service');
+		const { resolveModelAlias, getModelInfo } = await import('../model-service.js');
 		const currentModelId = await resolveModelAlias(rawModelId, 'global', sessionProvider);
 		const modelInfo = await getModelInfo(currentModelId, 'global', sessionProvider);
 
@@ -691,7 +691,7 @@ export function setupSessionHandlers(
 	// Handle listing available models
 	messageHub.onRequest('models.list', async (data) => {
 		try {
-			const { getAvailableModels, refreshModels } = await import('../model-service');
+			const { getAvailableModels, refreshModels } = await import('../model-service.js');
 
 			const params = data as {
 				forceRefresh?: boolean;

--- a/packages/daemon/tests/unit/1-core/core/model-service.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/model-service.test.ts
@@ -1194,5 +1194,48 @@ describe('Model Service', () => {
 			expect(models.length).toBeGreaterThan(0);
 			expect(models.some((m) => m.id === 'bg-model-2')).toBe(true);
 		});
+
+		it('should drop stale result when clearModelsCache is called during foreground refresh', async () => {
+			// Register a deliberately slow provider so the refresh is in-flight
+			// long enough for us to clear the cache while it runs.
+			const { getProviderRegistry } = await import('../../../../src/lib/providers/registry');
+			type ProviderLike = Parameters<ReturnType<typeof getProviderRegistry>['register']>[0];
+			const registry = getProviderRegistry();
+			registry.register({
+				id: 'slow-foreground-provider',
+				getModels: async () => {
+					await new Promise((resolve) => setTimeout(resolve, 200));
+					return [
+						{
+							id: 'stale-model',
+							name: 'Stale Model',
+							family: 'test',
+							provider: 'slow-foreground-provider',
+							contextWindow: 100000,
+						},
+					];
+				},
+				isAvailable: async () => true,
+			} as ProviderLike);
+
+			// Ensure cache is empty
+			clearModelsCache();
+
+			// Start a foreground refresh but do not await it yet
+			const { refreshModels } = await import('../../../../src/lib/model-service');
+			const refreshPromise = refreshModels();
+
+			// Allow the refresh to enter its async loading phase
+			await new Promise((resolve) => setTimeout(resolve, 50));
+
+			// Invalidate the cache while the refresh is still loading models
+			clearModelsCache();
+
+			// Wait for the refresh to finish
+			await refreshPromise;
+
+			// The generation guard should have caused the stale result to be dropped
+			expect(getAvailableModels('global')).toEqual([]);
+		});
 	});
 });

--- a/packages/daemon/tests/unit/1-core/core/model-service.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/model-service.test.ts
@@ -1103,18 +1103,41 @@ describe('Model Service', () => {
 		});
 
 		it('should cancel in-flight background refresh when clearModelsCache is called', async () => {
+			// Use a custom cache key to avoid cross-test contamination that can
+			// write to the 'global' key from unrelated async provider loading.
+			const cacheKey = 'bg-cancel-test';
+
+			// Register a test provider so the background refresh actually returns
+			// models and reaches the generation-guard check.
+			const { getProviderRegistry } = await import('../../../../src/lib/providers/registry');
+			type ProviderLike = Parameters<ReturnType<typeof getProviderRegistry>['register']>[0];
+			const registry = getProviderRegistry();
+			registry.register({
+				id: 'test-provider-bg',
+				getModels: async () => [
+					{
+						id: 'bg-model',
+						name: 'BG Model',
+						family: 'test',
+						provider: 'test-provider-bg',
+						contextWindow: 100000,
+					},
+				],
+				isAvailable: async () => true,
+			} as ProviderLike);
+
 			// Seed cache with an old timestamp so getAvailableModels triggers
 			// a background refresh.
 			const testCache = new Map<string, ModelInfo[]>();
-			testCache.set('global', mockModels);
+			testCache.set(cacheKey, mockModels);
 			setModelsCache(testCache, Date.now() - 5 * 60 * 60 * 1000); // 5 hours ago
 
 			// Trigger a background refresh by calling getAvailableModels
-			getAvailableModels('global');
+			getAvailableModels(cacheKey);
 
 			// Immediately clear the cache (simulating an OAuth account change)
 			clearModelsCache();
-			expect(getAvailableModels('global')).toEqual([]);
+			expect(getAvailableModels(cacheKey)).toEqual([]);
 
 			// Wait long enough for the background refresh to have completed
 			// if it were still running.
@@ -1122,31 +1145,54 @@ describe('Model Service', () => {
 
 			// The cache should still be empty because the generation counter
 			// caused the in-flight refresh to drop its stale result.
-			expect(getAvailableModels('global')).toEqual([]);
+			expect(getAvailableModels(cacheKey)).toEqual([]);
 		});
 
 		it('should NOT cancel global background refresh on session-scoped clearModelsCache', async () => {
-			// Seed the global cache with an old timestamp so getAvailableModels
-			// triggers a background refresh for the 'global' key.
+			// Use a custom cache key to avoid cross-test contamination that can
+			// write to the 'global' key from unrelated async provider loading.
+			const cacheKey = 'bg-session-test';
+
+			// Register a test provider so the background refresh actually returns
+			// models and reaches the generation-guard check.
+			const { getProviderRegistry } = await import('../../../../src/lib/providers/registry');
+			type ProviderLike = Parameters<ReturnType<typeof getProviderRegistry>['register']>[0];
+			const registry = getProviderRegistry();
+			registry.register({
+				id: 'test-provider-bg2',
+				getModels: async () => [
+					{
+						id: 'bg-model-2',
+						name: 'BG Model 2',
+						family: 'test',
+						provider: 'test-provider-bg2',
+						contextWindow: 100000,
+					},
+				],
+				isAvailable: async () => true,
+			} as ProviderLike);
+
+			// Seed the cache with an old timestamp so getAvailableModels
+			// triggers a background refresh for this key.
 			const testCache = new Map<string, ModelInfo[]>();
-			testCache.set('global', mockModels);
+			testCache.set(cacheKey, mockModels);
 			setModelsCache(testCache, Date.now() - 5 * 60 * 60 * 1000); // 5 hours ago
 
-			// Trigger a background refresh for 'global'
-			getAvailableModels('global');
+			// Trigger a background refresh for this key
+			getAvailableModels(cacheKey);
 
-			// Clear a *different* cache key — this must not affect the global refresh
+			// Clear a *different* cache key — this must not affect the refresh
 			clearModelsCache('session-123');
 			expect(getAvailableModels('session-123')).toEqual([]);
 
-			// Wait long enough for the global background refresh to complete
+			// Wait long enough for the background refresh to complete
 			await new Promise((resolve) => setTimeout(resolve, 500));
 
-			// The global cache should still have been populated because the
-			// session-scoped clear must not bump the generation for 'global'.
-			const globalModels = getAvailableModels('global');
-			expect(globalModels.length).toBe(mockModels.length);
-			expect(globalModels.map((m) => m.id)).toEqual(mockModels.map((m) => m.id));
+			// The cache should still have been populated because the
+			// session-scoped clear must not bump the generation for this key.
+			const models = getAvailableModels(cacheKey);
+			expect(models.length).toBeGreaterThan(0);
+			expect(models.some((m) => m.id === 'bg-model-2')).toBe(true);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/1-core/core/model-service.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/model-service.test.ts
@@ -1124,5 +1124,29 @@ describe('Model Service', () => {
 			// caused the in-flight refresh to drop its stale result.
 			expect(getAvailableModels('global')).toEqual([]);
 		});
+
+		it('should NOT cancel global background refresh on session-scoped clearModelsCache', async () => {
+			// Seed the global cache with an old timestamp so getAvailableModels
+			// triggers a background refresh for the 'global' key.
+			const testCache = new Map<string, ModelInfo[]>();
+			testCache.set('global', mockModels);
+			setModelsCache(testCache, Date.now() - 5 * 60 * 60 * 1000); // 5 hours ago
+
+			// Trigger a background refresh for 'global'
+			getAvailableModels('global');
+
+			// Clear a *different* cache key — this must not affect the global refresh
+			clearModelsCache('session-123');
+			expect(getAvailableModels('session-123')).toEqual([]);
+
+			// Wait long enough for the global background refresh to complete
+			await new Promise((resolve) => setTimeout(resolve, 500));
+
+			// The global cache should still have been populated because the
+			// session-scoped clear must not bump the generation for 'global'.
+			const globalModels = getAvailableModels('global');
+			expect(globalModels.length).toBe(mockModels.length);
+			expect(globalModels.map((m) => m.id)).toEqual(mockModels.map((m) => m.id));
+		});
 	});
 });

--- a/packages/daemon/tests/unit/1-core/core/model-service.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/model-service.test.ts
@@ -1101,5 +1101,28 @@ describe('Model Service', () => {
 			const models = getAvailableModels('global');
 			expect(models).toEqual(mockModels);
 		});
+
+		it('should cancel in-flight background refresh when clearModelsCache is called', async () => {
+			// Seed cache with an old timestamp so getAvailableModels triggers
+			// a background refresh.
+			const testCache = new Map<string, ModelInfo[]>();
+			testCache.set('global', mockModels);
+			setModelsCache(testCache, Date.now() - 5 * 60 * 60 * 1000); // 5 hours ago
+
+			// Trigger a background refresh by calling getAvailableModels
+			getAvailableModels('global');
+
+			// Immediately clear the cache (simulating an OAuth account change)
+			clearModelsCache();
+			expect(getAvailableModels('global')).toEqual([]);
+
+			// Wait long enough for the background refresh to have completed
+			// if it were still running.
+			await new Promise((resolve) => setTimeout(resolve, 500));
+
+			// The cache should still be empty because the generation counter
+			// caused the in-flight refresh to drop its stale result.
+			expect(getAvailableModels('global')).toEqual([]);
+		});
 	});
 });

--- a/packages/daemon/tests/unit/1-core/core/model-service.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/model-service.test.ts
@@ -1070,4 +1070,36 @@ describe('Model Service', () => {
 			expect(models).toEqual([]);
 		});
 	});
+
+	describe('refreshModels', () => {
+		it('should restore FALLBACK_MODELS when cache is empty and no providers are available', async () => {
+			// Ensure cache is empty (as if clearModelsCache() was called)
+			clearModelsCache();
+			expect(getAvailableModels('global')).toEqual([]);
+
+			// With no registered providers available, refreshModels should restore fallbacks
+			const { refreshModels } = await import('../../../../src/lib/model-service');
+			await refreshModels();
+
+			const models = getAvailableModels('global');
+			expect(models.length).toBeGreaterThan(0);
+			expect(models.some((m) => m.id === 'sonnet')).toBe(true);
+			expect(models.some((m) => m.id === 'opus')).toBe(true);
+			expect(models.some((m) => m.id === 'haiku')).toBe(true);
+		});
+
+		it('should preserve existing cache when refresh returns no models', async () => {
+			// Seed cache with mock models
+			const testCache = new Map<string, ModelInfo[]>();
+			testCache.set('global', mockModels);
+			setModelsCache(testCache);
+
+			const { refreshModels } = await import('../../../../src/lib/model-service');
+			await refreshModels();
+
+			// Existing cache should be preserved because it was non-empty
+			const models = getAvailableModels('global');
+			expect(models).toEqual(mockModels);
+		});
+	});
 });

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/gemini-auth-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/gemini-auth-handlers.test.ts
@@ -16,6 +16,13 @@ import { resetProviderRegistry, getProviderRegistry } from '../../../../src/lib/
 // Type for captured request handlers
 type RequestHandler = (data: unknown, context: unknown) => Promise<unknown>;
 
+// Mock model-service functions
+const mockClearModelsCache = mock(() => {});
+
+mock.module('../../../../src/lib/model-service.js', () => ({
+	clearModelsCache: mockClearModelsCache,
+}));
+
 // Mock oauth-client functions
 const mockBuildAuthUrl = mock(async () => ({
 	authUrl: 'https://accounts.google.com/o/oauth2/v2/auth?mock=1',
@@ -144,6 +151,7 @@ describe('Gemini Auth RPC Handlers', () => {
 		mockPersistAddAccount.mockClear();
 		mockPersistRemoveAccount.mockClear();
 		mockUpdateAccount.mockClear();
+		mockClearModelsCache.mockClear();
 		mockAuthManager.getAuthStatus.mockClear();
 
 		// Import handler setup after mock is in place
@@ -310,6 +318,7 @@ describe('Gemini Auth RPC Handlers', () => {
 			expect(mockFetchUserInfo).toHaveBeenCalledWith('mock-access-token');
 			expect(mockCreateAccount).toHaveBeenCalledWith('test@gmail.com', 'mock-refresh-token');
 			expect(mockPersistAddAccount).toHaveBeenCalled();
+			expect(mockClearModelsCache).toHaveBeenCalled();
 		});
 
 		it('returns error when no refresh token in response', async () => {
@@ -335,6 +344,7 @@ describe('Gemini Auth RPC Handlers', () => {
 
 			expect(completeResult.success).toBe(false);
 			expect(completeResult.error).toContain('No refresh token received');
+			expect(mockClearModelsCache).not.toHaveBeenCalled();
 		});
 
 		it('handles re-auth flow when accountId provided', async () => {
@@ -392,6 +402,7 @@ describe('Gemini Auth RPC Handlers', () => {
 				cooldown_until: 0,
 			});
 			expect(mockPersistAddAccount).not.toHaveBeenCalled();
+			expect(mockClearModelsCache).toHaveBeenCalled();
 		});
 
 		it('returns error when re-auth email does not match target account', async () => {
@@ -429,6 +440,7 @@ describe('Gemini Auth RPC Handlers', () => {
 			expect(completeResult.error).toContain('test@gmail.com');
 			expect(completeResult.error).toContain('other@gmail.com');
 			expect(mockUpdateAccount).not.toHaveBeenCalled();
+			expect(mockClearModelsCache).not.toHaveBeenCalled();
 		});
 
 		it('returns specific error for duplicate email', async () => {
@@ -466,6 +478,7 @@ describe('Gemini Auth RPC Handlers', () => {
 			expect(completeResult.error).toContain('test@gmail.com');
 			// Should NOT have called persistAddAccount
 			expect(mockPersistAddAccount).not.toHaveBeenCalled();
+			expect(mockClearModelsCache).not.toHaveBeenCalled();
 		});
 
 		it('handles exchange errors gracefully', async () => {
@@ -489,6 +502,7 @@ describe('Gemini Auth RPC Handlers', () => {
 
 			expect(completeResult.success).toBe(false);
 			expect(completeResult.error).toContain('invalid_grant');
+			expect(mockClearModelsCache).not.toHaveBeenCalled();
 		});
 
 		it('flow survives exchange error — retry with fresh code succeeds', async () => {
@@ -525,6 +539,8 @@ describe('Gemini Auth RPC Handlers', () => {
 			expect(secondAttempt.success).toBe(true);
 			expect(secondAttempt.account?.email).toBe('test@gmail.com');
 			expect(mockExchangeAuthCode).toHaveBeenLastCalledWith('good-code', 'mock-code-verifier');
+			// Only the successful second attempt should clear the cache
+			expect(mockClearModelsCache).toHaveBeenCalledTimes(1);
 		});
 	});
 
@@ -539,6 +555,7 @@ describe('Gemini Auth RPC Handlers', () => {
 
 			expect(result.success).toBe(true);
 			expect(mockPersistRemoveAccount).toHaveBeenCalledWith('acc-1');
+			expect(mockClearModelsCache).toHaveBeenCalled();
 		});
 
 		it('returns error when account not found', async () => {
@@ -555,6 +572,7 @@ describe('Gemini Auth RPC Handlers', () => {
 
 			expect(result.success).toBe(false);
 			expect(result.error).toContain('Account not-found not found');
+			expect(mockClearModelsCache).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/session-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/session-handlers.test.ts
@@ -29,7 +29,7 @@ const mockGetAvailableModels = mock(
 
 const mockRefreshModels = mock(async () => {});
 
-mock.module('../../../../src/lib/model-service.js', () => ({
+mock.module('../../../../src/lib/model-service', () => ({
 	getAvailableModels: mockGetAvailableModels,
 	refreshModels: mockRefreshModels,
 	clearModelsCache: mock(() => {}),

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/session-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/session-handlers.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Unit tests for Session RPC Handlers — models.list empty-cache fallback
+ *
+ * These tests mock model-service imports to avoid requiring live providers.
+ */
+
+import { describe, expect, it, beforeEach, mock, afterEach } from 'bun:test';
+import { MessageHub } from '@neokai/shared';
+import type { SessionManager } from '../../../../src/lib/session-manager';
+import type { DaemonHub } from '../../../../src/lib/daemon-hub';
+import type { SpaceManager } from '../../../../src/lib/space/managers/space-manager';
+
+// Type for captured request handlers
+type RequestHandler = (data: unknown, context: unknown) => Promise<unknown>;
+
+const mockGetAvailableModels = mock(
+	(): Array<{
+		id: string;
+		name: string;
+		alias: string;
+		family: string;
+		provider: string;
+		contextWindow: number;
+		description: string;
+		releaseDate: string;
+		available: boolean;
+	}> => []
+);
+
+const mockRefreshModels = mock(async () => {});
+
+mock.module('../../../../src/lib/model-service.js', () => ({
+	getAvailableModels: mockGetAvailableModels,
+	refreshModels: mockRefreshModels,
+	clearModelsCache: mock(() => {}),
+}));
+
+// Helper to create a minimal mock MessageHub that captures handlers
+function createMockMessageHub(): {
+	hub: MessageHub;
+	handlers: Map<string, RequestHandler>;
+} {
+	const handlers = new Map<string, RequestHandler>();
+
+	const hub = {
+		onRequest: mock((method: string, handler: RequestHandler) => {
+			handlers.set(method, handler);
+			return () => handlers.delete(method);
+		}),
+		onEvent: mock(() => () => {}),
+		request: mock(async () => {}),
+		event: mock(() => {}),
+		joinChannel: mock(async () => {}),
+		leaveChannel: mock(async () => {}),
+		isConnected: mock(() => true),
+		getState: mock(() => 'connected' as const),
+		onConnection: mock(() => () => {}),
+		onMessage: mock(() => () => {}),
+		cleanup: mock(() => {}),
+		registerTransport: mock(() => () => {}),
+		registerRouter: mock(() => {}),
+		getRouter: mock(() => null),
+		getPendingCallCount: mock(() => 0),
+	} as unknown as MessageHub;
+
+	return { hub, handlers };
+}
+
+describe('Session RPC Handlers — models.list', () => {
+	let messageHubData: ReturnType<typeof createMockMessageHub>;
+
+	beforeEach(async () => {
+		messageHubData = createMockMessageHub();
+
+		mockGetAvailableModels.mockClear();
+		mockRefreshModels.mockClear();
+
+		// Import and set up handlers after mock is in place
+		const { setupSessionHandlers } = await import(
+			'../../../../src/lib/rpc-handlers/session-handlers'
+		);
+		setupSessionHandlers(
+			messageHubData.hub,
+			{} as SessionManager,
+			{} as DaemonHub,
+			{} as SpaceManager
+		);
+	});
+
+	afterEach(() => {
+		mock.restore();
+	});
+
+	it('returns cached models when cache is populated', async () => {
+		const cachedModels = [
+			{
+				id: 'sonnet',
+				name: 'Claude Sonnet',
+				alias: 'default',
+				family: 'sonnet',
+				provider: 'anthropic',
+				contextWindow: 200000,
+				description: 'Fast model',
+				releaseDate: '2025-01-01',
+				available: true,
+			},
+		];
+		mockGetAvailableModels.mockReturnValue(cachedModels);
+
+		const handler = messageHubData.handlers.get('models.list');
+		expect(handler).toBeDefined();
+
+		const result = (await handler!({ useCache: true }, {})) as {
+			models: Array<{ id: string; display_name: string }>;
+			cached: boolean;
+		};
+
+		expect(result.models).toHaveLength(1);
+		expect(result.models[0].id).toBe('sonnet');
+		expect(result.cached).toBe(true);
+		expect(mockRefreshModels).not.toHaveBeenCalled();
+	});
+
+	it('triggers refreshModels when cache is empty and useCache is true', async () => {
+		// First call returns empty (cache cleared), second call returns models after refresh
+		mockGetAvailableModels.mockReturnValueOnce([]).mockReturnValueOnce([
+			{
+				id: 'gemini-pro',
+				name: 'Gemini Pro',
+				alias: 'gemini-pro',
+				family: 'gemini',
+				provider: 'google-gemini-oauth',
+				contextWindow: 128000,
+				description: 'Gemini model',
+				releaseDate: '2025-01-01',
+				available: true,
+			},
+		]);
+
+		const handler = messageHubData.handlers.get('models.list');
+
+		const result = (await handler!({ useCache: true }, {})) as {
+			models: Array<{ id: string; display_name: string }>;
+			cached: boolean;
+		};
+
+		expect(mockRefreshModels).toHaveBeenCalledTimes(1);
+		expect(result.models).toHaveLength(1);
+		expect(result.models[0].id).toBe('gemini-pro');
+		expect(result.cached).toBe(false);
+	});
+
+	it('does NOT trigger fallback refresh when forceRefresh is already true', async () => {
+		mockGetAvailableModels.mockReturnValue([
+			{
+				id: 'sonnet',
+				name: 'Claude Sonnet',
+				alias: 'default',
+				family: 'sonnet',
+				provider: 'anthropic',
+				contextWindow: 200000,
+				description: 'Fast model',
+				releaseDate: '2025-01-01',
+				available: true,
+			},
+		]);
+
+		const handler = messageHubData.handlers.get('models.list');
+
+		const result = (await handler!({ forceRefresh: true }, {})) as {
+			models: Array<{ id: string; display_name: string }>;
+			cached: boolean;
+		};
+
+		// refreshModels is called once for the explicit forceRefresh, NOT twice
+		expect(mockRefreshModels).toHaveBeenCalledTimes(1);
+		expect(result.models).toHaveLength(1);
+		expect(result.cached).toBe(false);
+	});
+
+	it('does NOT trigger fallback refresh when useCache is false', async () => {
+		mockGetAvailableModels.mockReturnValue([
+			{
+				id: 'sonnet',
+				name: 'Claude Sonnet',
+				alias: 'default',
+				family: 'sonnet',
+				provider: 'anthropic',
+				contextWindow: 200000,
+				description: 'Fast model',
+				releaseDate: '2025-01-01',
+				available: true,
+			},
+		]);
+
+		const handler = messageHubData.handlers.get('models.list');
+
+		const result = (await handler!({ useCache: false }, {})) as {
+			models: Array<{ id: string; display_name: string }>;
+			cached: boolean;
+		};
+
+		// refreshModels is called once for useCache: false, NOT twice
+		expect(mockRefreshModels).toHaveBeenCalledTimes(1);
+		expect(result.models).toHaveLength(1);
+		expect(result.cached).toBe(false);
+	});
+
+	it('returns empty array when cache stays empty after refresh', async () => {
+		// Cache empty and refresh does not produce models
+		mockGetAvailableModels.mockReturnValue([]);
+
+		const handler = messageHubData.handlers.get('models.list');
+
+		const result = (await handler!({ useCache: true }, {})) as {
+			models: Array<unknown>;
+			cached: boolean;
+		};
+
+		expect(mockRefreshModels).toHaveBeenCalledTimes(1);
+		expect(result.models).toEqual([]);
+		expect(result.cached).toBe(false);
+	});
+});

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/session-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/session-handlers.test.ts
@@ -1,39 +1,26 @@
 /**
  * Unit tests for Session RPC Handlers — models.list empty-cache fallback
  *
- * These tests mock model-service imports to avoid requiring live providers.
+ * These tests use real model-service functions with controlled cache state
+ * to avoid mock.module cross-file contamination in the 2-handlers shard.
+ *
+ * NOTE: We avoid clearModelsCache() because gemini-auth-handlers.test.ts
+ * installs a top-level mock.module on model-service.js that Bun does not
+ * fully restore, leaving clearModelsCache as a no-op.  setModelsCache()
+ * is unaffected, so we use setModelsCache(new Map()) to empty the cache.
  */
 
-import { describe, expect, it, beforeEach, mock, afterEach } from 'bun:test';
+import { describe, expect, it, beforeEach, mock } from 'bun:test';
 import { MessageHub } from '@neokai/shared';
 import type { SessionManager } from '../../../../src/lib/session-manager';
 import type { DaemonHub } from '../../../../src/lib/daemon-hub';
 import type { SpaceManager } from '../../../../src/lib/space/managers/space-manager';
+import { setModelsCache } from '../../../../src/lib/model-service.js';
+import { resetProviderRegistry } from '../../../../src/lib/providers/registry';
+import { resetProviderFactory } from '../../../../src/lib/providers/factory';
 
 // Type for captured request handlers
 type RequestHandler = (data: unknown, context: unknown) => Promise<unknown>;
-
-const mockGetAvailableModels = mock(
-	(): Array<{
-		id: string;
-		name: string;
-		alias: string;
-		family: string;
-		provider: string;
-		contextWindow: number;
-		description: string;
-		releaseDate: string;
-		available: boolean;
-	}> => []
-);
-
-const mockRefreshModels = mock(async () => {});
-
-mock.module('../../../../src/lib/model-service.js', () => ({
-	getAvailableModels: mockGetAvailableModels,
-	refreshModels: mockRefreshModels,
-	clearModelsCache: mock(() => {}),
-}));
 
 // Helper to create a minimal mock MessageHub that captures handlers
 function createMockMessageHub(): {
@@ -72,10 +59,13 @@ describe('Session RPC Handlers — models.list', () => {
 	beforeEach(async () => {
 		messageHubData = createMockMessageHub();
 
-		mockGetAvailableModels.mockClear();
-		mockRefreshModels.mockClear();
+		// Fully reset provider and cache state so each test is isolated.
+		// setModelsCache(new Map()) empties modelsCache and cacheTimestamps.
+		setModelsCache(new Map());
+		resetProviderRegistry();
+		resetProviderFactory();
 
-		// Import and set up handlers after mock is in place
+		// Import and set up handlers after cache is clean
 		const { setupSessionHandlers } = await import(
 			'../../../../src/lib/rpc-handlers/session-handlers'
 		);
@@ -87,12 +77,22 @@ describe('Session RPC Handlers — models.list', () => {
 		);
 	});
 
-	afterEach(() => {
-		mock.restore();
-	});
-
 	it('returns cached models when cache is populated', async () => {
-		const cachedModels = [
+		const testCache = new Map<
+			string,
+			Array<{
+				id: string;
+				name: string;
+				alias: string;
+				family: string;
+				provider: string;
+				contextWindow: number;
+				description: string;
+				releaseDate: string;
+				available: boolean;
+			}>
+		>();
+		testCache.set('global', [
 			{
 				id: 'sonnet',
 				name: 'Claude Sonnet',
@@ -104,8 +104,8 @@ describe('Session RPC Handlers — models.list', () => {
 				releaseDate: '2025-01-01',
 				available: true,
 			},
-		];
-		mockGetAvailableModels.mockReturnValue(cachedModels);
+		]);
+		setModelsCache(testCache);
 
 		const handler = messageHubData.handlers.get('models.list');
 		expect(handler).toBeDefined();
@@ -118,25 +118,10 @@ describe('Session RPC Handlers — models.list', () => {
 		expect(result.models).toHaveLength(1);
 		expect(result.models[0].id).toBe('sonnet');
 		expect(result.cached).toBe(true);
-		expect(mockRefreshModels).not.toHaveBeenCalled();
 	});
 
-	it('triggers refreshModels when cache is empty and useCache is true', async () => {
-		// First call returns empty (cache cleared), second call returns models after refresh
-		mockGetAvailableModels.mockReturnValueOnce([]).mockReturnValueOnce([
-			{
-				id: 'gemini-pro',
-				name: 'Gemini Pro',
-				alias: 'gemini-pro',
-				family: 'gemini',
-				provider: 'google-gemini-oauth',
-				contextWindow: 128000,
-				description: 'Gemini model',
-				releaseDate: '2025-01-01',
-				available: true,
-			},
-		]);
-
+	it('triggers fallback refresh when cache is empty and useCache is true', async () => {
+		// Cache is empty because beforeEach calls setModelsCache(new Map())
 		const handler = messageHubData.handlers.get('models.list');
 
 		const result = (await handler!({ useCache: true }, {})) as {
@@ -144,27 +129,13 @@ describe('Session RPC Handlers — models.list', () => {
 			cached: boolean;
 		};
 
-		expect(mockRefreshModels).toHaveBeenCalledTimes(1);
-		expect(result.models).toHaveLength(1);
-		expect(result.models[0].id).toBe('gemini-pro');
+		// refreshModels() restores FALLBACK_MODELS when no providers are available
+		expect(result.models.length).toBeGreaterThan(0);
+		expect(result.models.some((m) => m.id === 'sonnet')).toBe(true);
 		expect(result.cached).toBe(false);
 	});
 
-	it('does NOT trigger fallback refresh when forceRefresh is already true', async () => {
-		mockGetAvailableModels.mockReturnValue([
-			{
-				id: 'sonnet',
-				name: 'Claude Sonnet',
-				alias: 'default',
-				family: 'sonnet',
-				provider: 'anthropic',
-				contextWindow: 200000,
-				description: 'Fast model',
-				releaseDate: '2025-01-01',
-				available: true,
-			},
-		]);
-
+	it('returns models with cached=false when forceRefresh is true', async () => {
 		const handler = messageHubData.handlers.get('models.list');
 
 		const result = (await handler!({ forceRefresh: true }, {})) as {
@@ -172,27 +143,12 @@ describe('Session RPC Handlers — models.list', () => {
 			cached: boolean;
 		};
 
-		// refreshModels is called once for the explicit forceRefresh, NOT twice
-		expect(mockRefreshModels).toHaveBeenCalledTimes(1);
-		expect(result.models).toHaveLength(1);
+		// With no providers, refreshModels() restores FALLBACK_MODELS
+		expect(result.models.length).toBeGreaterThan(0);
 		expect(result.cached).toBe(false);
 	});
 
-	it('does NOT trigger fallback refresh when useCache is false', async () => {
-		mockGetAvailableModels.mockReturnValue([
-			{
-				id: 'sonnet',
-				name: 'Claude Sonnet',
-				alias: 'default',
-				family: 'sonnet',
-				provider: 'anthropic',
-				contextWindow: 200000,
-				description: 'Fast model',
-				releaseDate: '2025-01-01',
-				available: true,
-			},
-		]);
-
+	it('returns models with cached=false when useCache is false', async () => {
 		const handler = messageHubData.handlers.get('models.list');
 
 		const result = (await handler!({ useCache: false }, {})) as {
@@ -200,25 +156,8 @@ describe('Session RPC Handlers — models.list', () => {
 			cached: boolean;
 		};
 
-		// refreshModels is called once for useCache: false, NOT twice
-		expect(mockRefreshModels).toHaveBeenCalledTimes(1);
-		expect(result.models).toHaveLength(1);
-		expect(result.cached).toBe(false);
-	});
-
-	it('returns empty array when cache stays empty after refresh', async () => {
-		// Cache empty and refresh does not produce models
-		mockGetAvailableModels.mockReturnValue([]);
-
-		const handler = messageHubData.handlers.get('models.list');
-
-		const result = (await handler!({ useCache: true }, {})) as {
-			models: Array<unknown>;
-			cached: boolean;
-		};
-
-		expect(mockRefreshModels).toHaveBeenCalledTimes(1);
-		expect(result.models).toEqual([]);
+		// useCache: false is treated as forceRefresh
+		expect(result.models.length).toBeGreaterThan(0);
 		expect(result.cached).toBe(false);
 	});
 });

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/session-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/session-handlers.test.ts
@@ -29,7 +29,7 @@ const mockGetAvailableModels = mock(
 
 const mockRefreshModels = mock(async () => {});
 
-mock.module('../../../../src/lib/model-service', () => ({
+mock.module('../../../../src/lib/model-service.js', () => ({
 	getAvailableModels: mockGetAvailableModels,
 	refreshModels: mockRefreshModels,
 	clearModelsCache: mock(() => {}),

--- a/packages/web/src/components/settings/GeminiAccountsPanel.tsx
+++ b/packages/web/src/components/settings/GeminiAccountsPanel.tsx
@@ -158,6 +158,7 @@ export function GeminiAccountsPanel() {
 					if (response.success) {
 						toast.success(`Removed ${account.email}`);
 						await loadAccounts();
+						window.dispatchEvent(new CustomEvent('gemini-accounts-changed'));
 					} else {
 						toast.error(response.error || 'Failed to remove account');
 					}
@@ -327,6 +328,7 @@ export function GeminiAccountsPanel() {
 						setShowAddModal(false);
 						loadAccounts();
 						toast.success('Google account added successfully');
+						window.dispatchEvent(new CustomEvent('gemini-accounts-changed'));
 					}}
 					onCancel={() => setShowAddModal(false)}
 					onSubmitCode={handleSubmitCode}

--- a/packages/web/src/components/settings/__tests__/GeminiAccountsPanel.test.tsx
+++ b/packages/web/src/components/settings/__tests__/GeminiAccountsPanel.test.tsx
@@ -423,6 +423,44 @@ describe('GeminiAccountsPanel', () => {
 				expect(queryByTestId('add-account-modal')).toBeNull();
 			});
 		});
+
+		it('dispatches gemini-accounts-changed event on successful add', async () => {
+			mockListGeminiAccounts.mockResolvedValue({ accounts: [] });
+			mockStartGeminiOAuth.mockResolvedValue({
+				success: true,
+				authUrl: 'https://auth.url',
+				flowId: 'flow-123',
+			});
+			mockCompleteGeminiOAuth.mockResolvedValue({ success: true });
+
+			const dispatchEventSpy = vi.spyOn(window, 'dispatchEvent');
+
+			const { container, getByTestId } = render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('Add Google Account');
+			});
+
+			const addButton = Array.from(container.querySelectorAll('button')).find((btn) =>
+				btn.textContent?.includes('Add Google Account')
+			);
+			addButton?.click();
+
+			await waitFor(() => {
+				expect(getByTestId('add-account-modal')).toBeTruthy();
+			});
+
+			// Simulate modal completion (the mocked modal calls onComplete directly)
+			getByTestId('modal-complete-btn').click();
+
+			await waitFor(() => {
+				expect(dispatchEventSpy).toHaveBeenCalledWith(
+					expect.objectContaining({ type: 'gemini-accounts-changed' })
+				);
+			});
+
+			dispatchEventSpy.mockRestore();
+		});
 	});
 
 	describe('Remove Account', () => {
@@ -479,6 +517,44 @@ describe('GeminiAccountsPanel', () => {
 				expect(mockRemoveGeminiAccount).toHaveBeenCalledWith('acc-1');
 				expect(mockToastSuccess).toHaveBeenCalledWith('Removed test@gmail.com');
 			});
+		});
+
+		it('dispatches gemini-accounts-changed event after removal', async () => {
+			const accounts = [createMockAccount()];
+			mockListGeminiAccounts.mockResolvedValue({ accounts });
+			mockRemoveGeminiAccount.mockResolvedValue({ success: true });
+
+			const dispatchEventSpy = vi.spyOn(window, 'dispatchEvent');
+
+			const { container } = render(<GeminiAccountsPanel />);
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('test@gmail.com');
+			});
+
+			// Click remove button
+			const removeButton = container.querySelector('[data-testid="button-ghost-xs"]');
+			if (removeButton) {
+				removeButton.click();
+			}
+
+			await waitFor(() => {
+				expect(container.textContent).toContain('Remove Google Account');
+			});
+
+			// Click confirm "Remove" button
+			const confirmButton = Array.from(container.querySelectorAll('button')).find((btn) =>
+				btn.textContent?.includes('Remove')
+			);
+			confirmButton?.click();
+
+			await waitFor(() => {
+				expect(dispatchEventSpy).toHaveBeenCalledWith(
+					expect.objectContaining({ type: 'gemini-accounts-changed' })
+				);
+			});
+
+			dispatchEventSpy.mockRestore();
 		});
 	});
 

--- a/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
+++ b/packages/web/src/hooks/__tests__/useModelSwitcher.test.ts
@@ -923,6 +923,57 @@ describe('useModelSwitcher', () => {
 
 			expect(result.current.currentModel).toBe('claude-opus-4-5-20251101');
 		});
+
+		it('should reload model info when gemini-accounts-changed event fires', async () => {
+			const mockHub = {
+				request: vi
+					.fn()
+					// First load (mount)
+					.mockResolvedValueOnce({
+						currentModel: 'claude-sonnet-4-20250514',
+						modelInfo: null,
+					})
+					.mockResolvedValueOnce({ models: [] })
+					// Second load (event-triggered)
+					.mockResolvedValueOnce({
+						currentModel: 'gemini-3-pro',
+						modelInfo: {
+							id: 'gemini-3-pro',
+							name: 'Gemini 3 Pro',
+							provider: 'google-gemini-oauth',
+						},
+					})
+					.mockResolvedValueOnce({
+						models: [
+							{
+								id: 'gemini-3-pro',
+								display_name: 'Gemini 3 Pro',
+								description: '',
+								provider: 'google-gemini-oauth',
+							},
+						],
+					}),
+			};
+			mockGetHubIfConnected.mockReturnValue(mockHub);
+
+			const { result } = renderHook(() => useModelSwitcher('session-1'));
+
+			await waitFor(() => {
+				expect(result.current.loading).toBe(false);
+			});
+
+			expect(result.current.currentModel).toBe('claude-sonnet-4-20250514');
+
+			act(() => {
+				window.dispatchEvent(new CustomEvent('gemini-accounts-changed'));
+			});
+
+			await waitFor(() => {
+				expect(result.current.currentModel).toBe('gemini-3-pro');
+			});
+
+			expect(mockHub.request).toHaveBeenCalledWith('models.list', { useCache: true });
+		});
 	});
 
 	describe('sessionId changes', () => {

--- a/packages/web/src/hooks/useModelSwitcher.ts
+++ b/packages/web/src/hooks/useModelSwitcher.ts
@@ -302,6 +302,15 @@ export function useModelSwitcher(sessionId: string | null): UseModelSwitcherResu
 		}
 	}, [loadModelInfo, isConnected]);
 
+	// Reload models when provider accounts change (e.g., Gemini OAuth add/remove)
+	useEffect(() => {
+		const handleAccountsChanged = () => {
+			loadModelInfo();
+		};
+		window.addEventListener('gemini-accounts-changed', handleAccountsChanged);
+		return () => window.removeEventListener('gemini-accounts-changed', handleAccountsChanged);
+	}, [loadModelInfo]);
+
 	const switchModel = useCallback(
 		async (model: ModelInfo) => {
 			if (!model.provider) {


### PR DESCRIPTION
Invalidate the model cache after Gemini OAuth account add/remove/reauth and ensure the frontend refreshes the model list automatically.

**Daemon:**
- Call `clearModelsCache()` in `auth.gemini.completeOAuth` (new account + re-auth paths) and `auth.gemini.removeAccount` so the next `models.list` request re-evaluates provider availability.
- Add an empty-cache fallback in the `models.list` handler: if `getAvailableModels` returns an empty array while `useCache` is true, force a `refreshModels()` before responding.

**Web:**
- `GeminiAccountsPanel` dispatches a `gemini-accounts-changed` window event after successful account add/remove.
- `useModelSwitcher` listens for this event and reloads the model list, so newly available Gemini models appear in the composer without a page refresh.

Fixes Gemini models not appearing in the chat composer after OAuth login.