### PR TITLE
Add InternalQueryBus facade and preserve Live Query boundary

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -11,7 +11,8 @@
 		"./routes/setup-websocket": "./src/routes/setup-websocket.ts",
 		"./sdk-cli-resolver": "./src/lib/agent/sdk-cli-resolver.ts",
 		"./lib/internal-event-bus": "./src/lib/internal-event-bus.ts",
-		"./lib/internal-command-bus": "./src/lib/internal-command-bus.ts"
+		"./lib/internal-command-bus": "./src/lib/internal-command-bus.ts",
+		"./lib/internal-query-bus": "./src/lib/internal-query-bus.ts"
 	},
 	"scripts": {
 		"dev": "bun run --watch main.ts",

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -9,6 +9,7 @@ import { SettingsManager } from './lib/settings-manager';
 import { StateManager } from './lib/state-manager';
 import { MessageHub, MessageHubRouter } from '@neokai/shared';
 import { createDaemonHub } from './lib/daemon-hub';
+import { createInternalQueryBus } from './lib/internal-query-bus';
 import { setupRPCHandlers } from './lib/rpc-handlers';
 import { applyProviderModelAllowlistsToEnv } from './lib/rpc-handlers/settings-handlers';
 import { WebSocketServerTransport } from './lib/websocket-server-transport';
@@ -60,6 +61,8 @@ export interface DaemonAppContext {
 	stateManager: StateManager;
 	transport: WebSocketServerTransport;
 	eventBus: Awaited<ReturnType<typeof createDaemonHub>>;
+	/** Semantic internal query bus for point-in-time reads */
+	queryBus: ReturnType<typeof createInternalQueryBus>;
 	/**
 	 * GitHub service instance (null if not configured)
 	 */
@@ -221,6 +224,10 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	// Initialize DaemonHub (TypedHub-based event coordination)
 	const eventBus = createDaemonHub('daemon');
 	await eventBus.initialize();
+
+	// Initialize InternalQueryBus for point-in-time reads.
+	// Handlers will be registered by domain services as they migrate.
+	const queryBus = createInternalQueryBus();
 
 	// Initialize application-level MCP and Skills managers before SessionManager
 	// so AgentSession can inject skills into SDK query options.
@@ -704,6 +711,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		stateManager,
 		transport,
 		eventBus,
+		queryBus,
 		gitHubService,
 		spaceGitHubService,
 		reactiveDb,

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -9,7 +9,7 @@ import { SettingsManager } from './lib/settings-manager';
 import { StateManager } from './lib/state-manager';
 import { MessageHub, MessageHubRouter } from '@neokai/shared';
 import { createDaemonHub } from './lib/daemon-hub';
-import { createInternalQueryBus } from './lib/internal-query-bus';
+import { createInternalQueryBus, type DaemonQueryMap } from './lib/internal-query-bus';
 import { setupRPCHandlers } from './lib/rpc-handlers';
 import { applyProviderModelAllowlistsToEnv } from './lib/rpc-handlers/settings-handlers';
 import { WebSocketServerTransport } from './lib/websocket-server-transport';
@@ -62,7 +62,7 @@ export interface DaemonAppContext {
 	transport: WebSocketServerTransport;
 	eventBus: Awaited<ReturnType<typeof createDaemonHub>>;
 	/** Semantic internal query bus for point-in-time reads */
-	queryBus: ReturnType<typeof createInternalQueryBus>;
+	queryBus: ReturnType<typeof createInternalQueryBus<DaemonQueryMap>>;
 	/**
 	 * GitHub service instance (null if not configured)
 	 */
@@ -227,7 +227,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 
 	// Initialize InternalQueryBus for point-in-time reads.
 	// Handlers will be registered by domain services as they migrate.
-	const queryBus = createInternalQueryBus();
+	const queryBus = createInternalQueryBus<DaemonQueryMap>();
 
 	// Initialize application-level MCP and Skills managers before SessionManager
 	// so AgentSession can inject skills into SDK query options.

--- a/packages/daemon/src/lib/internal-query-bus.ts
+++ b/packages/daemon/src/lib/internal-query-bus.ts
@@ -52,9 +52,6 @@ export interface QueryResult<T = unknown> {
 
 	/** Error payload when `ok` is false. */
 	error?: unknown;
-
-	/** Arbitrary metadata the handler may attach (cache hit, latency, etc). */
-	metadata?: Record<string, unknown>;
 }
 
 /**
@@ -86,6 +83,20 @@ interface RegisteredQueryHandler {
 	handler: (query: unknown) => Promise<unknown>;
 }
 
+/** Extract the input type for a given query map entry. */
+type QueryInput<TQueryMap, K extends keyof TQueryMap> = TQueryMap[K] extends {
+	input: infer I;
+}
+	? I
+	: never;
+
+/** Extract the output type for a given query map entry. */
+type QueryOutput<TQueryMap, K extends keyof TQueryMap> = TQueryMap[K] extends {
+	output: infer O;
+}
+	? O
+	: never;
+
 /**
  * InternalQueryBus
  *
@@ -95,10 +106,7 @@ interface RegisteredQueryHandler {
  *   'space.workflowRun.get': { input: { runId: string }; output: WorkflowRun | null }
  */
 export class InternalQueryBus<
-	TQueryMap extends Record<string, { input: unknown; output: unknown }> = Record<
-		string,
-		{ input: unknown; output: unknown }
-	>,
+	TQueryMap extends object = Record<string, { input: unknown; output: unknown }>,
 > {
 	private handlers = new Map<string, RegisteredQueryHandler>();
 
@@ -112,7 +120,7 @@ export class InternalQueryBus<
 	 */
 	register<K extends keyof TQueryMap & string>(
 		queryName: K,
-		handler: QueryHandler<TQueryMap[K]['input'], TQueryMap[K]['output']>
+		handler: QueryHandler<QueryInput<TQueryMap, K>, QueryOutput<TQueryMap, K>>
 	): () => void {
 		const key = queryName;
 
@@ -147,8 +155,8 @@ export class InternalQueryBus<
 	 */
 	async execute<K extends keyof TQueryMap & string>(
 		queryName: K,
-		query: TQueryMap[K]['input']
-	): Promise<QueryResult<TQueryMap[K]['output']>> {
+		query: QueryInput<TQueryMap, K>
+	): Promise<QueryResult<QueryOutput<TQueryMap, K>>> {
 		const key = queryName;
 		const registered = this.handlers.get(key);
 
@@ -157,7 +165,7 @@ export class InternalQueryBus<
 		}
 
 		try {
-			const data = (await registered.handler(query)) as TQueryMap[K]['output'];
+			const data = (await registered.handler(query)) as QueryOutput<TQueryMap, K>;
 			return { ok: true, data };
 		} catch (error) {
 			return { ok: false, error };
@@ -203,10 +211,7 @@ export class InternalQueryBus<
  *   const bus = createInternalQueryBus<MyQueryMap>();
  */
 export function createInternalQueryBus<
-	TQueryMap extends Record<string, { input: unknown; output: unknown }> = Record<
-		string,
-		{ input: unknown; output: unknown }
-	>,
+	TQueryMap extends object = Record<string, { input: unknown; output: unknown }>,
 >(): InternalQueryBus<TQueryMap> {
 	return new InternalQueryBus<TQueryMap>();
 }

--- a/packages/daemon/src/lib/internal-query-bus.ts
+++ b/packages/daemon/src/lib/internal-query-bus.ts
@@ -1,0 +1,263 @@
+/**
+ * InternalQueryBus — Semantic daemon query primitive (v1)
+ *
+ * First-class facade for typed internal queries with explicit one-handler-per-query
+ * semantics. Queries are requests to read state; they are not domain events and
+ * must not produce side effects as part of normal execution.
+ *
+ * Relationship to Live Query
+ * --------------------------
+ * InternalQueryBus serves *explicit* point-in-time reads: a caller asks a
+ * question and receives an answer.  LiveQueryEngine / ReactiveDatabase serve
+ * *reactive* reads: a caller subscribes to a SQL query and receives
+ * snapshot/delta updates whenever underlying tables change.
+ *
+ * These two systems are complementary, not overlapping:
+ *   • InternalQueryBus    → imperative "get me X now" (e.g. `space.workflowRun.get`)
+ *   • LiveQueryEngine     → reactive "tell me when Y changes" (e.g. `sessions.list`)
+ *
+ * Live Query remains reactive read-model/query-update plumbing.  It must not be
+ * used as a general domain event bus, command channel, or side-effect trigger.
+ * InternalQueryBus handlers may read from the same repositories or projected
+ * state that Live Query watches, but they do not replace Live Query's push
+ * semantics.
+ *
+ * Design constraints (v1)
+ * -----------------------
+ * • One owner/handler per query — duplicate registration is rejected.
+ * • No middleware — cross-cutting concerns stay explicit in handlers.
+ * • Structured results — every execute returns a `QueryResult<T>`.
+ * • Typed query map — domain code defines queries through a `TQueryMap`.
+ * • Missing and failed handlers return structured failures (never throw).
+ *
+ * Future direction
+ * ----------------
+ * See docs/plans/internal-event-command-query-architecture.md for the full
+ * internal-event / command / query architecture plan.
+ */
+
+/**
+ * Structured result returned by every query execution.
+ *
+ * On success `ok` is `true` and `data` contains the handler's return value.
+ * On failure `ok` is `false` and `error` carries the reason (missing handler,
+ * handler threw, etc).
+ */
+export interface QueryResult<T = unknown> {
+	/** Whether the query handler completed successfully. */
+	ok: boolean;
+
+	/** The result payload when `ok` is true. */
+	data?: T;
+
+	/** Error payload when `ok` is false. */
+	error?: unknown;
+
+	/** Arbitrary metadata the handler may attach (cache hit, latency, etc). */
+	metadata?: Record<string, unknown>;
+}
+
+/**
+ * Thrown when a query handler is registered for a name that already
+ * has an owner.  This is thrown at registration time, not execution time.
+ */
+export class DuplicateQueryHandlerError extends Error {
+	constructor(public readonly queryName: string) {
+		super(`Query '${queryName}' already has a registered handler`);
+		this.name = 'DuplicateQueryHandlerError';
+	}
+}
+
+/**
+ * Carried in `QueryResult.error` when `execute(...)` is called for a query
+ * with no registered handler.  Returned as a structured failure rather than
+ * thrown so callers can handle missing queries gracefully.
+ */
+export class MissingQueryHandlerError extends Error {
+	constructor(public readonly queryName: string) {
+		super(`No handler registered for query '${queryName}'`);
+		this.name = 'MissingQueryHandlerError';
+	}
+}
+
+export type QueryHandler<TInput, TOutput> = (query: TInput) => Promise<TOutput>;
+
+interface RegisteredQueryHandler {
+	handler: (query: unknown) => Promise<unknown>;
+}
+
+/**
+ * InternalQueryBus
+ *
+ * @template TQueryMap — map of dot-separated query names to `{ input, output }` shapes.
+ *
+ * Example query map entry:
+ *   'space.workflowRun.get': { input: { runId: string }; output: WorkflowRun | null }
+ */
+export class InternalQueryBus<
+	TQueryMap extends Record<string, { input: unknown; output: unknown }> = Record<
+		string,
+		{ input: unknown; output: unknown }
+	>,
+> {
+	private handlers = new Map<string, RegisteredQueryHandler>();
+
+	/**
+	 * Register a handler for a query.
+	 *
+	 * @param queryName — typed query name
+	 * @param handler   — callback invoked when the query is executed
+	 * @returns unsubscribe function
+	 * @throws DuplicateQueryHandlerError if a handler already exists for this query
+	 */
+	register<K extends keyof TQueryMap & string>(
+		queryName: K,
+		handler: QueryHandler<TQueryMap[K]['input'], TQueryMap[K]['output']>
+	): () => void {
+		const key = queryName;
+
+		if (this.handlers.has(key)) {
+			throw new DuplicateQueryHandlerError(key);
+		}
+
+		const registered: RegisteredQueryHandler = {
+			handler: handler as (query: unknown) => Promise<unknown>,
+		};
+
+		this.handlers.set(key, registered);
+
+		return () => {
+			const current = this.handlers.get(key);
+			if (current === registered) {
+				this.handlers.delete(key);
+			}
+		};
+	}
+
+	/**
+	 * Execute a query through its registered handler and await the result.
+	 *
+	 * @param queryName — typed query name
+	 * @param query     — query payload
+	 * @returns structured `QueryResult<TOutput>`
+	 *
+	 * Returns `{ ok: false, error: MissingQueryHandlerError }` when no handler
+	 * is registered.  Handler throws are caught and returned as
+	 * `{ ok: false, error }` so callers never need to try/catch execute().
+	 */
+	async execute<K extends keyof TQueryMap & string>(
+		queryName: K,
+		query: TQueryMap[K]['input']
+	): Promise<QueryResult<TQueryMap[K]['output']>> {
+		const key = queryName;
+		const registered = this.handlers.get(key);
+
+		if (!registered) {
+			return { ok: false, error: new MissingQueryHandlerError(key) };
+		}
+
+		try {
+			const data = (await registered.handler(query)) as TQueryMap[K]['output'];
+			return { ok: true, data };
+		} catch (error) {
+			return { ok: false, error };
+		}
+	}
+
+	/**
+	 * Return true if a handler is registered for the given query name.
+	 */
+	hasHandler<K extends keyof TQueryMap & string>(queryName: K): boolean {
+		return this.handlers.has(queryName);
+	}
+
+	/**
+	 * Remove the handler for a specific query.
+	 */
+	unregister<K extends keyof TQueryMap & string>(queryName: K): void {
+		this.handlers.delete(queryName);
+	}
+
+	/**
+	 * Remove all handlers.
+	 */
+	clear(): void {
+		this.handlers.clear();
+	}
+
+	/**
+	 * Return the number of registered handlers.
+	 */
+	getHandlerCount(): number {
+		return this.handlers.size;
+	}
+}
+
+/**
+ * Convenience factory that produces an InternalQueryBus typed with the
+ * caller's query map.
+ *
+ * This is the entry point most daemon code should use:
+ *
+ *   import { createInternalQueryBus } from '@neokai/daemon/lib/internal-query-bus';
+ *   const bus = createInternalQueryBus<MyQueryMap>();
+ */
+export function createInternalQueryBus<
+	TQueryMap extends Record<string, { input: unknown; output: unknown }> = Record<
+		string,
+		{ input: unknown; output: unknown }
+	>,
+>(): InternalQueryBus<TQueryMap> {
+	return new InternalQueryBus<TQueryMap>();
+}
+
+// ---------------------------------------------------------------------------
+// Query contracts — canonical payloads for queries used across the daemon.
+// Expand this map as new queries are added; keep each domain's queries
+// in a separate interface and intersect them here.
+// ---------------------------------------------------------------------------
+
+/**
+ * Payload for `space.workflowRun.get` — fetch a single workflow run by id.
+ */
+export interface SpaceWorkflowRunGetQuery {
+	/** Workflow run identifier. */
+	runId: string;
+}
+
+/**
+ * Result for `space.workflowRun.get`.
+ */
+export interface SpaceWorkflowRunGetResult {
+	/** The run, or null if not found. */
+	run: Record<string, unknown> | null;
+}
+
+/**
+ * Payload for `room.tasks.list` — list tasks in a room.
+ */
+export interface RoomTasksListQuery {
+	/** Room identifier. */
+	roomId: string;
+	/** Include archived tasks. */
+	includeArchived?: boolean;
+}
+
+/**
+ * Result for `room.tasks.list`.
+ */
+export interface RoomTasksListResult {
+	/** Task summaries. */
+	tasks: Array<Record<string, unknown>>;
+}
+
+/**
+ * Canonical daemon query map.
+ *
+ * Each domain should own its slice; this type is the intersection of all
+ * domain query maps so the bus can be typed with the full surface.
+ */
+export interface DaemonQueryMap {
+	'space.workflowRun.get': { input: SpaceWorkflowRunGetQuery; output: SpaceWorkflowRunGetResult };
+	'room.tasks.list': { input: RoomTasksListQuery; output: RoomTasksListResult };
+}

--- a/packages/daemon/tests/unit/1-core/core/internal-query-bus.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/internal-query-bus.test.ts
@@ -91,7 +91,7 @@ describe('InternalQueryBus', () => {
 			expect(payloads[0].includeArchived).toBe(true);
 		});
 
-		it('should include metadata from a successful handler result', async () => {
+		it('should return data on a successful handler result', async () => {
 			bus.register('app.health', async () => ({ status: 'ok' }));
 
 			const received = await bus.execute('app.health', { component: 'db' });
@@ -244,11 +244,8 @@ describe('InternalQueryBus', () => {
 	});
 
 	describe('structured failure shape', () => {
-		it('should preserve metadata on failure when handler returns ok:false-like object', async () => {
-			// Handlers return raw data; if they throw, we catch it.
-			// This test verifies the catch path preserves the original error.
+		it('should preserve the original error when handler throws', async () => {
 			const err = new Error('downstream failure');
-			(err as Error & { metadata?: unknown }).metadata = { retryAfter: 30 };
 			bus.register('app.health', async () => {
 				throw err;
 			});

--- a/packages/daemon/tests/unit/1-core/core/internal-query-bus.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/internal-query-bus.test.ts
@@ -1,0 +1,269 @@
+/**
+ * InternalQueryBus Unit Tests
+ *
+ * Covers:
+ *   – handler registration and execute
+ *   – structured success/failure results
+ *   – duplicate handler rejection
+ *   – missing handler structured failure
+ *   – handler throw normalization
+ *   – unregister, unsubscribe, clear, diagnostics
+ *
+ * See docs/plans/internal-event-command-query-architecture.md
+ */
+
+import { beforeEach, describe, expect, it } from 'bun:test';
+import {
+	createInternalQueryBus,
+	DuplicateQueryHandlerError,
+	InternalQueryBus,
+	MissingQueryHandlerError,
+	type RoomTasksListQuery,
+	type RoomTasksListResult,
+	type SpaceWorkflowRunGetQuery,
+	type SpaceWorkflowRunGetResult,
+} from '../../../../src/lib/internal-query-bus';
+
+interface TestQueryMap {
+	'space.workflowRun.get': { input: SpaceWorkflowRunGetQuery; output: SpaceWorkflowRunGetResult };
+	'room.tasks.list': { input: RoomTasksListQuery; output: RoomTasksListResult };
+	'app.health': { input: { component?: string }; output: { status: string } };
+}
+
+describe('InternalQueryBus', () => {
+	let bus: InternalQueryBus<TestQueryMap>;
+
+	beforeEach(() => {
+		bus = new InternalQueryBus<TestQueryMap>();
+	});
+
+	describe('register', () => {
+		it('should register a handler and return an unsubscribe function', () => {
+			const unsub = bus.register('space.workflowRun.get', async () => ({ run: null }));
+			expect(typeof unsub).toBe('function');
+			expect(bus.hasHandler('space.workflowRun.get')).toBe(true);
+		});
+
+		it('should reject duplicate handlers for the same query', () => {
+			bus.register('space.workflowRun.get', async () => ({ run: null }));
+
+			expect(() => bus.register('space.workflowRun.get', async () => ({ run: null }))).toThrow(
+				DuplicateQueryHandlerError
+			);
+		});
+
+		it('should include the query name in the duplicate error', () => {
+			bus.register('room.tasks.list', async () => ({ tasks: [] }));
+
+			try {
+				bus.register('room.tasks.list', async () => ({ tasks: [] }));
+				expect.unreachable('should have thrown');
+			} catch (e) {
+				expect(e).toBeInstanceOf(DuplicateQueryHandlerError);
+				const dup = e as DuplicateQueryHandlerError;
+				expect(dup.queryName).toBe('room.tasks.list');
+				expect(dup.message).toContain('room.tasks.list');
+			}
+		});
+	});
+
+	describe('execute', () => {
+		it('should return the handler result on success', async () => {
+			const result: SpaceWorkflowRunGetResult = { run: { id: 'wr-1', status: 'running' } };
+			bus.register('space.workflowRun.get', async () => result);
+
+			const received = await bus.execute('space.workflowRun.get', { runId: 'wr-1' });
+			expect(received.ok).toBe(true);
+			expect(received.data).toEqual(result);
+		});
+
+		it('should pass the query payload to the handler', async () => {
+			const payloads: Array<RoomTasksListQuery> = [];
+			bus.register('room.tasks.list', async (q) => {
+				payloads.push(q);
+				return { tasks: [] };
+			});
+
+			await bus.execute('room.tasks.list', { roomId: 'r1', includeArchived: true });
+
+			expect(payloads).toHaveLength(1);
+			expect(payloads[0].roomId).toBe('r1');
+			expect(payloads[0].includeArchived).toBe(true);
+		});
+
+		it('should include metadata from a successful handler result', async () => {
+			bus.register('app.health', async () => ({ status: 'ok' }));
+
+			const received = await bus.execute('app.health', { component: 'db' });
+			expect(received.ok).toBe(true);
+			expect(received.data).toEqual({ status: 'ok' });
+		});
+
+		it('should return a structured failure when the handler throws', async () => {
+			const err = new Error('db timeout');
+			bus.register('space.workflowRun.get', async () => {
+				throw err;
+			});
+
+			const result = await bus.execute('space.workflowRun.get', { runId: 'wr-1' });
+			expect(result.ok).toBe(false);
+			expect(result.error).toBe(err);
+			expect(result.data).toBeUndefined();
+		});
+
+		it('should return a structured failure for a missing handler', async () => {
+			const result = await bus.execute('space.workflowRun.get', { runId: 'wr-1' });
+			expect(result.ok).toBe(false);
+			expect(result.error).toBeInstanceOf(MissingQueryHandlerError);
+			expect(result.data).toBeUndefined();
+		});
+
+		it('should include the query name in the missing-handler failure', async () => {
+			const result = await bus.execute('room.tasks.list', { roomId: 'r1' });
+			expect(result.ok).toBe(false);
+
+			const missing = result.error as MissingQueryHandlerError;
+			expect(missing.queryName).toBe('room.tasks.list');
+			expect(missing.message).toContain('room.tasks.list');
+		});
+
+		it('should not throw when the handler throws (structured failure instead)', async () => {
+			bus.register('app.health', async () => {
+				throw new Error('unexpected');
+			});
+
+			await expect(bus.execute('app.health', { component: 'x' })).resolves.toMatchObject({
+				ok: false,
+			});
+		});
+
+		it('should not throw when no handler is registered (structured failure instead)', async () => {
+			await expect(bus.execute('app.health', { component: 'x' })).resolves.toMatchObject({
+				ok: false,
+			});
+		});
+	});
+
+	describe('unregister', () => {
+		it('should remove the handler for a specific query', () => {
+			bus.register('space.workflowRun.get', async () => ({ run: null }));
+			expect(bus.hasHandler('space.workflowRun.get')).toBe(true);
+
+			bus.unregister('space.workflowRun.get');
+			expect(bus.hasHandler('space.workflowRun.get')).toBe(false);
+		});
+
+		it('should make the query return missing-handler after unregister', async () => {
+			bus.register('space.workflowRun.get', async () => ({ run: null }));
+			bus.unregister('space.workflowRun.get');
+
+			const result = await bus.execute('space.workflowRun.get', { runId: 'wr-1' });
+			expect(result.ok).toBe(false);
+			expect(result.error).toBeInstanceOf(MissingQueryHandlerError);
+		});
+	});
+
+	describe('unsubscribe returned by register', () => {
+		it('should remove the handler when called', () => {
+			const unsub = bus.register('space.workflowRun.get', async () => ({ run: null }));
+			expect(bus.hasHandler('space.workflowRun.get')).toBe(true);
+
+			unsub();
+			expect(bus.hasHandler('space.workflowRun.get')).toBe(false);
+		});
+
+		it('should allow re-registration after unsubscribe', () => {
+			const unsub = bus.register('space.workflowRun.get', async () => ({ run: null }));
+			unsub();
+
+			expect(() =>
+				bus.register('space.workflowRun.get', async () => ({ run: null }))
+			).not.toThrow();
+			expect(bus.hasHandler('space.workflowRun.get')).toBe(true);
+		});
+
+		it('should not remove a newer handler when a stale unsubscribe is called', async () => {
+			const unsubA = bus.register('space.workflowRun.get', async () => ({
+				run: { id: 'A' },
+			}));
+			unsubA();
+
+			bus.register('space.workflowRun.get', async () => ({ run: { id: 'B' } }));
+
+			// Calling the old unsubscribe should not delete the new handler
+			unsubA();
+			expect(bus.hasHandler('space.workflowRun.get')).toBe(true);
+
+			const result = await bus.execute('space.workflowRun.get', { runId: 'wr-1' });
+			expect(result.ok).toBe(true);
+			expect(result.data).toEqual({ run: { id: 'B' } });
+		});
+	});
+
+	describe('clear', () => {
+		it('should remove all handlers', () => {
+			bus.register('space.workflowRun.get', async () => ({ run: null }));
+			bus.register('room.tasks.list', async () => ({ tasks: [] }));
+
+			bus.clear();
+
+			expect(bus.hasHandler('space.workflowRun.get')).toBe(false);
+			expect(bus.hasHandler('room.tasks.list')).toBe(false);
+			expect(bus.getHandlerCount()).toBe(0);
+		});
+	});
+
+	describe('diagnostics', () => {
+		it('should report correct handler count', () => {
+			expect(bus.getHandlerCount()).toBe(0);
+			bus.register('space.workflowRun.get', async () => ({ run: null }));
+			expect(bus.getHandlerCount()).toBe(1);
+			bus.register('room.tasks.list', async () => ({ tasks: [] }));
+			expect(bus.getHandlerCount()).toBe(2);
+		});
+
+		it('should report hasHandler correctly', () => {
+			expect(bus.hasHandler('space.workflowRun.get')).toBe(false);
+			bus.register('space.workflowRun.get', async () => ({ run: null }));
+			expect(bus.hasHandler('space.workflowRun.get')).toBe(true);
+			expect(bus.hasHandler('room.tasks.list')).toBe(false);
+		});
+	});
+
+	describe('createInternalQueryBus factory', () => {
+		it('should produce a working typed bus', async () => {
+			const factoryBus = createInternalQueryBus<TestQueryMap>();
+			factoryBus.register('space.workflowRun.get', async () => ({
+				run: { id: 'factory-test' },
+			}));
+
+			const result = await factoryBus.execute('space.workflowRun.get', { runId: 'factory-test' });
+			expect(result.ok).toBe(true);
+			expect(result.data).toEqual({ run: { id: 'factory-test' } });
+		});
+	});
+
+	describe('structured failure shape', () => {
+		it('should preserve metadata on failure when handler returns ok:false-like object', async () => {
+			// Handlers return raw data; if they throw, we catch it.
+			// This test verifies the catch path preserves the original error.
+			const err = new Error('downstream failure');
+			(err as Error & { metadata?: unknown }).metadata = { retryAfter: 30 };
+			bus.register('app.health', async () => {
+				throw err;
+			});
+
+			const result = await bus.execute('app.health', {});
+			expect(result.ok).toBe(false);
+			expect(result.error).toBe(err);
+		});
+
+		it('should return ok:true with data when handler returns a falsy value', async () => {
+			bus.register('space.workflowRun.get', async () => ({ run: null }));
+
+			const result = await bus.execute('space.workflowRun.get', { runId: 'missing' });
+			expect(result.ok).toBe(true);
+			expect(result.data).toEqual({ run: null });
+		});
+	});
+});


### PR DESCRIPTION
Adds `InternalQueryBus` as the semantic query primitive alongside the existing event and command bus facades.

**What's included:**
- `QueryResult<T>` structured success/failure shape — missing and failed handlers return `{ ok: false, ... }` instead of throwing.
- One-handler-per-query semantics with `DuplicateQueryHandlerError` at registration time.
- `register`, `execute`, `hasHandler`, `unregister`, `clear`, `getHandlerCount` APIs, plus `createInternalQueryBus` typed factory.
- Canonical example query contracts (`space.workflowRun.get`, `room.tasks.list`) in `DaemonQueryMap`.
- Minimal daemon integration: instantiated in `createDaemonApp` and exposed via `DaemonAppContext`.

**Live Query boundary:** The module header explicitly documents the relationship to `LiveQueryEngine`/`ReactiveDatabase` — InternalQueryBus serves point-in-time reads; Live Query serves reactive reads. Live Query remains read-model plumbing, not a domain event bus.

**Tests:** 22 unit tests covering success/failure/missing-handler paths, duplicate rejection, unsubscribe semantics, and diagnostics.