### PR TITLE
fix: make settingSources configurable so CLAUDE.md loads again

### DIFF
--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -178,6 +178,11 @@ export interface AgentSessionInit {
 	 * Compiled into SDK hooks at runtime by the query options builder.
 	 */
 	toolGuards?: DeclarativeToolGuard[];
+	/**
+	 * Setting sources to load for this session (e.g., ['user', 'project']).
+	 * Falls back to global settings when unset.
+	 */
+	settingSources?: import('@neokai/shared').SettingSource[];
 }
 
 export interface AgentSessionRuntimeOptions {
@@ -615,6 +620,8 @@ export class AgentSession
 			disallowedTools: init.disallowedTools,
 			// Persist tool guards so they survive daemon restart / session restore
 			toolGuards: init.toolGuards,
+			// Setting sources for loading CLAUDE.md and settings files
+			settingSources: init.settingSources,
 		};
 
 		const metadata: SessionMetadata = {

--- a/packages/daemon/src/lib/agent/agent-session.ts
+++ b/packages/daemon/src/lib/agent/agent-session.ts
@@ -179,7 +179,7 @@ export interface AgentSessionInit {
 	 */
 	toolGuards?: DeclarativeToolGuard[];
 	/**
-	 * Setting sources to load for this session (e.g., ['user', 'project']).
+	 * Setting sources to load for this session (e.g., ['user', 'project', 'local']).
 	 * Falls back to global settings when unset.
 	 */
 	settingSources?: import('@neokai/shared').SettingSource[];

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -407,10 +407,14 @@ export class QueryOptionsBuilder {
 			pathToClaudeCodeExecutable: sdkCliPath,
 
 			// ============ Settings ============
-			// Always [] — the SDK must never auto-load MCP servers, slash commands,
-			// or other settings from on-disk files. NeoKai is the sole arbiter of
-			// what reaches the SDK. See M5 of `unify-mcp-config-model`.
-			settingSources: [],
+			// settingSources controls which on-disk settings files the SDK loads.
+			// Default to ['user', 'project'] so CLAUDE.md and user/project settings
+			// are loaded. 'local' is off by default because NeoKai writes to
+			// .claude/settings.local.json and loading it back could create circular
+			// settings. strictMcpConfig: true still prevents MCP auto-loading from
+			// any source — the unified app_mcp_servers registry is the sole MCP source.
+			settingSources:
+				config.settingSources ?? this.ctx.settingsManager.getGlobalSettings().settingSources,
 			settings: buildProviderSettings(providerId, config.model),
 
 			// ============ Streaming ============

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -408,11 +408,10 @@ export class QueryOptionsBuilder {
 
 			// ============ Settings ============
 			// settingSources controls which on-disk settings files the SDK loads.
-			// Default to ['user', 'project'] so CLAUDE.md and user/project settings
-			// are loaded. 'local' is off by default because NeoKai writes to
-			// .claude/settings.local.json and loading it back could create circular
-			// settings. strictMcpConfig: true still prevents MCP auto-loading from
-			// any source — the unified app_mcp_servers registry is the sole MCP source.
+			// Default to ['user', 'project', 'local'] so CLAUDE.md and user/project
+			// settings are loaded. strictMcpConfig: true prevents MCP auto-loading
+			// from any source — the unified app_mcp_servers registry is the sole MCP
+			// source.
 			settingSources:
 				config.settingSources ?? this.ctx.settingsManager.getGlobalSettings().settingSources,
 			settings: buildProviderSettings(providerId, config.model),

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -413,7 +413,8 @@ export class QueryOptionsBuilder {
 			// Default to ['user', 'project', 'local'] so CLAUDE.md and user/project
 			// settings are loaded. strictMcpConfig: true prevents MCP auto-loading
 			// from any source — the unified app_mcp_servers registry is the sole MCP
-			// source.
+			// source.  settingSources only affects non-MCP settings (permissions,
+			// output style, etc.); MCP servers are fully isolated by strictMcpConfig.
 			settingSources:
 				config.settingSources ?? this.ctx.settingsManager.getGlobalSettings().settingSources,
 			settings: buildProviderSettings(providerId, config.model),

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -289,7 +289,9 @@ export class QueryOptionsBuilder {
 		// Write file-only settings to .claude/settings.local.json before SDK starts
 		// (permission ask lists, sandbox excludedCommands, outputStyle, attribution).
 		// We no longer derive any SDK options from settings here — strictMcpConfig is
-		// always true and settingSources is always [] (M5: unified MCP registry).
+		// always true (MCP servers are fully controlled by the unified registry).
+		// settingSources is configurable per session/space/agent and defaults to
+		// ['user', 'project', 'local'] so CLAUDE.md and on-disk settings are loaded.
 		await this.ctx.settingsManager.prepareSDKOptions();
 
 		// Translate model ID for SDK compatibility using provider context

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -411,10 +411,14 @@ export class QueryOptionsBuilder {
 			// ============ Settings ============
 			// settingSources controls which on-disk settings files the SDK loads.
 			// Default to ['user', 'project', 'local'] so CLAUDE.md and user/project
-			// settings are loaded. strictMcpConfig: true prevents MCP auto-loading
-			// from any source — the unified app_mcp_servers registry is the sole MCP
-			// source.  settingSources only affects non-MCP settings (permissions,
-			// output style, etc.); MCP servers are fully isolated by strictMcpConfig.
+			// settings are loaded.
+			//
+			// SECURITY: strictMcpConfig is true for ALL sessions. This means the SDK
+			// ONLY accepts MCP servers explicitly placed in the mcpServers map above.
+			// It does NOT auto-load MCP servers from settings files, .mcp.json, or
+			// any other source. The unified app_mcp_servers registry is the sole MCP
+			// source. settingSources only affects non-MCP settings (permissions,
+			// output style, CLAUDE.md content, etc.).
 			settingSources:
 				config.settingSources ?? this.ctx.settingsManager.getGlobalSettings().settingSources,
 			settings: buildProviderSettings(providerId, config.model),

--- a/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-agent-handlers.ts
@@ -49,6 +49,8 @@ export function setupSpaceAgentHandlers(
 			thinkingLevel?: import('@neokai/shared').ThinkingLevel;
 			provider?: string;
 			customPrompt?: string | null;
+			tools?: string[];
+			settingSources?: import('@neokai/shared').SettingSource[];
 		};
 
 		if (!params.spaceId) throw new Error('spaceId is required');
@@ -62,6 +64,8 @@ export function setupSpaceAgentHandlers(
 			thinkingLevel: params.thinkingLevel,
 			provider: params.provider,
 			customPrompt: params.customPrompt,
+			tools: params.tools,
+			settingSources: params.settingSources,
 		});
 
 		if (!result.ok) throw new Error(result.error);
@@ -109,6 +113,8 @@ export function setupSpaceAgentHandlers(
 			thinkingLevel?: import('@neokai/shared').ThinkingLevel | null;
 			provider?: string | null;
 			customPrompt?: string | null;
+			tools?: string[] | null;
+			settingSources?: import('@neokai/shared').SettingSource[] | null;
 		};
 
 		if (!params.id) throw new Error('id is required');
@@ -121,6 +127,8 @@ export function setupSpaceAgentHandlers(
 			thinkingLevel: updateFields.thinkingLevel,
 			provider: updateFields.provider,
 			customPrompt: updateFields.customPrompt,
+			tools: updateFields.tools,
+			settingSources: updateFields.settingSources,
 		});
 
 		if (!result.ok) throw new Error(result.error);

--- a/packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-export-import-handlers.ts
@@ -144,6 +144,7 @@ function buildAgentCreateParams(
 	);
 	if (parts.length > 0) params.customPrompt = parts.join('\n\n');
 	if (exported.tools !== undefined) params.tools = exported.tools;
+	if (exported.settingSources !== undefined) params.settingSources = exported.settingSources;
 	return params;
 }
 
@@ -543,6 +544,7 @@ export function setupSpaceExportImportHandlers(
 							provider: exportedAgent.provider ?? null,
 							customPrompt: replaceParts.length > 0 ? replaceParts.join('\n\n') : null,
 							tools: exportedAgent.tools ?? null,
+							settingSources: exportedAgent.settingSources ?? null,
 						});
 						const id = updated?.id ?? existing.id;
 						importedAgentNameToId.set(exportedAgent.name, id);

--- a/packages/daemon/src/lib/session/session-lifecycle.ts
+++ b/packages/daemon/src/lib/session/session-lifecycle.ts
@@ -223,6 +223,8 @@ export class SessionLifecycle {
 				sandbox: params.config?.sandbox ?? globalSettings.sandbox,
 				// MCP servers: Allow room chat sessions to include room-agent-tools
 				mcpServers: params.config?.mcpServers,
+				// Setting sources: inherit from global settings so CLAUDE.md is loaded by default
+				settingSources: params.config?.settingSources ?? globalSettings.settingSources,
 			},
 			metadata: {
 				messageCount: 0,

--- a/packages/daemon/src/lib/settings-manager.ts
+++ b/packages/daemon/src/lib/settings-manager.ts
@@ -57,9 +57,10 @@ export class SettingsManager {
 	 * Prepare file-only settings for a session.
 	 *
 	 * Writes settings to `.claude/settings.local.json` BEFORE the SDK starts.
-	 * The SDK never reads them anymore (`settingSources: []` is unconditional)
-	 * — they're written for tooling that inspects the file directly (e.g. the
-	 * Claude Code CLI when run by hand against the same workspace).
+	 * The SDK reads this file only when `local` is included in the session's
+	 * `settingSources` (configurable per session/space/agent/global). These
+	 * settings are also written for tooling that inspects the file directly
+	 * (e.g. the Claude Code CLI when run by hand against the same workspace).
 	 *
 	 * No SDK options are derived here. `QueryOptionsBuilder` constructs the
 	 * full Options object on its own.

--- a/packages/daemon/src/lib/space/agents/custom-agent.ts
+++ b/packages/daemon/src/lib/space/agents/custom-agent.ts
@@ -476,6 +476,7 @@ export function createCustomAgentInit(config: CustomAgentConfig): AgentSessionIn
 			skillOverrides,
 			mcpServers: extraMcpServers,
 			toolGuards,
+			settingSources: customAgent.settingSources ?? space.settingSources,
 		};
 	}
 
@@ -497,6 +498,7 @@ export function createCustomAgentInit(config: CustomAgentConfig): AgentSessionIn
 		...customToolPermissions,
 		skillOverrides,
 		mcpServers: extraMcpServers,
+		settingSources: customAgent.settingSources ?? space.settingSources,
 		toolGuards,
 	};
 }

--- a/packages/daemon/src/lib/space/agents/task-agent.ts
+++ b/packages/daemon/src/lib/space/agents/task-agent.ts
@@ -614,5 +614,6 @@ export function createTaskAgentInit(config: TaskAgentSessionConfig): AgentSessio
 		model,
 		provider,
 		thinkingLevel: taskAgentConfig?.thinkingLevel,
+		settingSources: taskAgentConfig?.settingSources ?? space.settingSources,
 	};
 }

--- a/packages/daemon/src/lib/space/export-format.ts
+++ b/packages/daemon/src/lib/space/export-format.ts
@@ -141,6 +141,7 @@ const exportedAgentBaseSchema = z.object({
 	systemPrompt: z.string().optional(),
 	instructions: z.string().optional(),
 	tools: z.array(z.string()).optional(),
+	settingSources: z.array(z.enum(['user', 'project', 'local'])).optional(),
 });
 
 const exportedWorkflowBaseSchema = z.object({
@@ -219,6 +220,7 @@ export function exportAgent(agent: SpaceAgent): ExportedSpaceAgent {
 	if (agent.customPrompt !== null && agent.customPrompt !== undefined)
 		exported.systemPrompt = agent.customPrompt;
 	if (agent.tools !== undefined) exported.tools = agent.tools;
+	if (agent.settingSources !== undefined) exported.settingSources = agent.settingSources;
 	return exported;
 }
 

--- a/packages/daemon/src/storage/repositories/space-agent-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-agent-repository.ts
@@ -43,7 +43,7 @@ export class SpaceAgentRepository {
 				params.provider ?? null,
 				params.tools && params.tools.length > 0 ? JSON.stringify(params.tools) : '[]',
 				params.customPrompt ?? null,
-				params.settingSources ? JSON.stringify(params.settingSources) : null,
+				params.settingSources != null ? JSON.stringify(params.settingSources) : null,
 				params.templateName ?? null,
 				params.templateHash ?? null,
 				now,
@@ -142,7 +142,7 @@ export class SpaceAgentRepository {
 		}
 		if (params.settingSources !== undefined) {
 			fields.push('setting_sources = ?');
-			values.push(params.settingSources ? JSON.stringify(params.settingSources) : null);
+			values.push(params.settingSources != null ? JSON.stringify(params.settingSources) : null);
 		}
 		if (params.templateName !== undefined) {
 			fields.push('template_name = ?');

--- a/packages/daemon/src/storage/repositories/space-agent-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-agent-repository.ts
@@ -30,8 +30,8 @@ export class SpaceAgentRepository {
 			.prepare(
 				`INSERT INTO space_agents
 					(id, space_id, name, description, model, thinking_level, provider, tools, custom_prompt,
-					 template_name, template_hash, created_at, updated_at)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+					 setting_sources, template_name, template_hash, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 			)
 			.run(
 				id,
@@ -43,6 +43,7 @@ export class SpaceAgentRepository {
 				params.provider ?? null,
 				params.tools && params.tools.length > 0 ? JSON.stringify(params.tools) : '[]',
 				params.customPrompt ?? null,
+				params.settingSources ? JSON.stringify(params.settingSources) : null,
 				params.templateName ?? null,
 				params.templateHash ?? null,
 				now,
@@ -139,6 +140,10 @@ export class SpaceAgentRepository {
 			fields.push('tools = ?');
 			values.push(params.tools && params.tools.length > 0 ? JSON.stringify(params.tools) : '[]');
 		}
+		if (params.settingSources !== undefined) {
+			fields.push('setting_sources = ?');
+			values.push(params.settingSources ? JSON.stringify(params.settingSources) : null);
+		}
 		if (params.templateName !== undefined) {
 			fields.push('template_name = ?');
 			values.push(params.templateName ?? null);
@@ -193,6 +198,12 @@ export class SpaceAgentRepository {
 			tools = parsed.length > 0 ? parsed : undefined;
 		}
 
+		// Parse settingSources: null or missing → undefined
+		let settingSources: SpaceAgent['settingSources'];
+		if (row.setting_sources) {
+			settingSources = JSON.parse(row.setting_sources as string) as SpaceAgent['settingSources'];
+		}
+
 		return {
 			id: row.id as string,
 			spaceId: row.space_id as string,
@@ -204,6 +215,7 @@ export class SpaceAgentRepository {
 			provider: (row.provider as string | null) ?? undefined,
 			customPrompt: (row.custom_prompt as string | null) ?? null,
 			tools,
+			settingSources,
 			// `template_name` / `template_hash` may be missing entirely on
 			// schemas that predate M105 — guard with `??` so older test DBs
 			// (and any pre-migration call paths) don't return `undefined`.

--- a/packages/daemon/src/storage/repositories/space-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-repository.ts
@@ -46,7 +46,7 @@ export class SpaceRepository {
 			params.autonomyLevel ?? 1,
 			params.config ? JSON.stringify(params.config) : null,
 			params.taskAgentConfig ? JSON.stringify(params.taskAgentConfig) : null,
-			params.settingSources ? JSON.stringify(params.settingSources) : null,
+			params.settingSources != null ? JSON.stringify(params.settingSources) : null,
 			now,
 			now
 		);
@@ -171,7 +171,7 @@ export class SpaceRepository {
 		}
 		if (params.settingSources !== undefined) {
 			fields.push('setting_sources = ?');
-			values.push(params.settingSources ? JSON.stringify(params.settingSources) : null);
+			values.push(params.settingSources != null ? JSON.stringify(params.settingSources) : null);
 		}
 
 		if (fields.length > 0) {

--- a/packages/daemon/src/storage/repositories/space-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-repository.ts
@@ -27,8 +27,8 @@ export class SpaceRepository {
 		const now = Date.now();
 
 		const stmt = this.db.prepare(
-			`INSERT INTO spaces (id, slug, workspace_path, name, description, background_context, instructions, default_model, allowed_models, session_ids, status, autonomy_level, config, task_agent_config, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			`INSERT INTO spaces (id, slug, workspace_path, name, description, background_context, instructions, default_model, allowed_models, session_ids, status, autonomy_level, config, task_agent_config, setting_sources, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 
 		stmt.run(
@@ -46,6 +46,7 @@ export class SpaceRepository {
 			params.autonomyLevel ?? 1,
 			params.config ? JSON.stringify(params.config) : null,
 			params.taskAgentConfig ? JSON.stringify(params.taskAgentConfig) : null,
+			params.settingSources ? JSON.stringify(params.settingSources) : null,
 			now,
 			now
 		);
@@ -167,6 +168,10 @@ export class SpaceRepository {
 		if (params.taskAgentConfig !== undefined) {
 			fields.push('task_agent_config = ?');
 			values.push(params.taskAgentConfig ? JSON.stringify(params.taskAgentConfig) : null);
+		}
+		if (params.settingSources !== undefined) {
+			fields.push('setting_sources = ?');
+			values.push(params.settingSources ? JSON.stringify(params.settingSources) : null);
 		}
 
 		if (fields.length > 0) {
@@ -295,6 +300,10 @@ export class SpaceRepository {
 		const taskAgentConfig = rawTaskAgentConfig
 			? (JSON.parse(rawTaskAgentConfig) as TaskAgentConfig)
 			: undefined;
+		const rawSettingSources = row.setting_sources as string | null;
+		const settingSources = rawSettingSources
+			? (JSON.parse(rawSettingSources) as Space['settingSources'])
+			: undefined;
 		return {
 			id: row.id as string,
 			slug: (row.slug as string) ?? '',
@@ -312,6 +321,7 @@ export class SpaceRepository {
 			autonomyLevel: ((row.autonomy_level as number) ?? 1) as SpaceAutonomyLevel,
 			config,
 			taskAgentConfig,
+			settingSources,
 			createdAt: row.created_at as number,
 			updatedAt: row.updated_at as number,
 		};

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -73,6 +73,10 @@ export { runMigration111 } from './migrations';
 export { runMigration112 } from './migrations';
 // knip-ignore-next-line
 export { runMigration117 } from './migrations';
+// knip-ignore-next-line
+export { runMigration118 } from './migrations';
+// knip-ignore-next-line
+export { runMigration119 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -555,6 +555,14 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// Migration 117: Add disabled column to space_workflows.
 	//   When true, the workflow cannot be selected for new tasks.
 	runMigration117(db);
+
+	// Migration 118: Add setting_sources column to space_agents.
+	//   Stores per-agent setting source overrides as JSON.
+	runMigration118(db);
+
+	// Migration 119: Add setting_sources column to spaces.
+	//   Stores per-space default setting sources as JSON.
+	runMigration119(db);
 }
 
 /**
@@ -7968,4 +7976,34 @@ export function runMigration117(db: BunDatabase): void {
 	if (columns.includes('disabled')) return;
 
 	db.exec(`ALTER TABLE space_workflows ADD COLUMN disabled INTEGER NOT NULL DEFAULT 0`);
+}
+
+/**
+ * Migration 118: Add `setting_sources` column to `space_agents` table.
+ *
+ * Stores per-agent setting source overrides as JSON (e.g. ["user","project"]).
+ * Nullable — null means inherit from Space or global default.
+ */
+export function runMigration118(db: BunDatabase): void {
+	if (!tableExists(db, 'space_agents')) return;
+
+	const columns = tableColumnNames(db, 'space_agents');
+	if (columns.includes('setting_sources')) return;
+
+	db.exec(`ALTER TABLE space_agents ADD COLUMN setting_sources TEXT DEFAULT NULL`);
+}
+
+/**
+ * Migration 119: Add `setting_sources` column to `spaces` table.
+ *
+ * Stores per-space default setting sources as JSON (e.g. ["user","project"]).
+ * Nullable — null means inherit from global default.
+ */
+export function runMigration119(db: BunDatabase): void {
+	if (!tableExists(db, 'spaces')) return;
+
+	const columns = tableColumnNames(db, 'spaces');
+	if (columns.includes('setting_sources')) return;
+
+	db.exec(`ALTER TABLE spaces ADD COLUMN setting_sources TEXT DEFAULT NULL`);
 }

--- a/packages/daemon/tests/online/git/archive-session.test.ts
+++ b/packages/daemon/tests/online/git/archive-session.test.ts
@@ -22,11 +22,9 @@ import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
 import { createDaemonServer, type DaemonServerContext } from '../../helpers/daemon-server';
-import { sendMessage, waitForIdle } from '../../helpers/daemon-actions';
 
 // Detect mock mode for faster timeouts (Dev Proxy)
 const IS_MOCK = !!process.env.NEOKAI_USE_DEV_PROXY;
-const IDLE_TIMEOUT = IS_MOCK ? 5000 : 30000;
 const SETUP_TIMEOUT = IS_MOCK ? 10000 : 30000;
 const TEST_TIMEOUT = IS_MOCK ? 30000 : 90000;
 
@@ -97,11 +95,7 @@ describe('Archive Session', () => {
 			mode: 'worktree',
 		});
 
-		// Send a message to trigger workspace initialization (creates the worktree)
-		await sendMessage(daemon, sessionId, 'test worktree setup');
-		await waitForIdle(daemon, sessionId);
-
-		// Get session to find worktree path
+		// Get session to find worktree path (worktree was created synchronously by setWorktreeMode)
 		const session = await getSession(sessionId);
 		const worktree = session.worktree as { worktreePath: string; branch: string } | undefined;
 
@@ -258,7 +252,7 @@ describe('Archive Session', () => {
 
 					// Simulate squash merge to main
 					execSync('git checkout main', { cwd: repoPath });
-					execSync(`git merge --squash ${branch}`, { cwd: repoPath });
+					execSync(`git merge --squash refs/heads/${branch}`, { cwd: repoPath });
 					execSync('git commit -m "feat: add feature (squash merged)"', { cwd: repoPath });
 
 					// Archive should NOT require confirmation
@@ -288,7 +282,7 @@ describe('Archive Session', () => {
 
 					// Squash merge to main
 					execSync('git checkout main', { cwd: repoPath });
-					execSync(`git merge --squash ${branch}`, { cwd: repoPath });
+					execSync(`git merge --squash refs/heads/${branch}`, { cwd: repoPath });
 					execSync('git commit -m "feat: add feature (squash merged)"', { cwd: repoPath });
 
 					// Make another commit in worktree (new work not on main)

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -58,7 +58,7 @@ describe('QueryOptionsBuilder', () => {
 		};
 
 		mockSettingsManager = {
-			getGlobalSettings: mock(() => ({})),
+			getGlobalSettings: mock(() => ({ settingSources: ['user', 'project'] })),
 			prepareSDKOptions: mock(async () => ({})),
 		} as unknown as SettingsManager;
 
@@ -544,15 +544,13 @@ describe('QueryOptionsBuilder', () => {
 	});
 
 	describe('setting sources configuration', () => {
-		// M5 (unify-mcp-config-model): `settingSources` is unconditionally `[]`
-		// so the SDK never auto-loads `.mcp.json` / `settings.json` MCP servers.
-		// The unified `app_mcp_servers` registry (+ `mcp_enablement` overrides)
-		// is now the only source of truth — the legacy `loadSettingSources`
-		// override and the M1 `NEOKAI_LEGACY_MCP_AUTOLOAD` kill switch are both
-		// gone.
-		it('should always emit empty settingSources', async () => {
+		// Post-M5: `settingSources` defaults to the global settings value
+		// (['user', 'project']) so CLAUDE.md and user/project settings are
+		// loaded.  MCP remains locked to `strictMcpConfig: true` (unified
+		// `app_mcp_servers` registry only) regardless of settingSources.
+		it('should default settingSources to global settings', async () => {
 			const options = await builder.build();
-			expect(options.settingSources).toEqual([]);
+			expect(options.settingSources).toEqual(['user', 'project']);
 		});
 	});
 
@@ -568,7 +566,7 @@ describe('QueryOptionsBuilder', () => {
 				'space-agent-tools': { command: 'space-cmd' },
 			});
 			expect(options.strictMcpConfig).toBe(true);
-			expect(options.settingSources).toEqual([]);
+			expect(options.settingSources).toEqual(['user', 'project']);
 		});
 
 		it('should enforce space built-in tool allowlist including Bash', async () => {
@@ -648,12 +646,13 @@ describe('QueryOptionsBuilder', () => {
 	});
 
 	// ============================================================================
-	// M5 (unify-mcp-config-model): strictMcpConfig + settingSources are forced
-	// for ALL session types unconditionally; the M1 `NEOKAI_LEGACY_MCP_AUTOLOAD`
-	// kill switch was removed. These tests pin the post-M5 contract per session
-	// type so any regression that re-introduces auto-loading is caught.
+	// M5 (unify-mcp-config-model): strictMcpConfig is forced unconditionally;
+	// settingSources defaults to global settings (['user', 'project']) but can be
+	// overridden per-session. The M1 `NEOKAI_LEGACY_MCP_AUTOLOAD` kill switch was
+	// removed. These tests pin the post-M5 contract per session type so any
+	// regression that re-introduces auto-loading is caught.
 	// ============================================================================
-	describe('M5: unconditional strict MCP + empty settingSources', () => {
+	describe('M5: unconditional strict MCP + configurable settingSources', () => {
 		const sessionTypes: Array<'worker' | 'space_task_agent' | 'general' | 'coder' | 'planner'> = [
 			'worker',
 			'space_task_agent',
@@ -663,26 +662,27 @@ describe('QueryOptionsBuilder', () => {
 		];
 
 		for (const type of sessionTypes) {
-			it(`forces strictMcpConfig=true and settingSources=[] on ${type} sessions`, async () => {
+			it(`forces strictMcpConfig=true and default settingSources on ${type} sessions`, async () => {
 				mockSession.type = type;
 				const options = await builder.build();
 				expect(options.strictMcpConfig).toBe(true);
-				expect(options.settingSources).toEqual([]);
+				expect(options.settingSources).toEqual(['user', 'project']);
 			});
 		}
 
 		it('does not inject project .mcp.json servers into the mcpServers map (regression)', async () => {
 			// Pre-M1 behavior was for the SDK to auto-load any `.mcp.json` at the
 			// workspace root because `settingSources` defaulted to `['project', 'local']`.
-			// Post-M5 the SDK never looks at `.mcp.json` at all, and an ad-hoc worker
-			// session with no programmatic mcpServers emits an `undefined` mcpServers
-			// option — i.e. nothing to inject.
+			// Post-M5 the SDK still respects settingSources for *settings* files, but
+			// `strictMcpConfig: true` blocks `.mcp.json` auto-loading regardless.
+			// An ad-hoc worker session with no programmatic mcpServers emits an
+			// `undefined` mcpServers option — i.e. nothing to inject.
 			mockSession.type = 'worker';
 			mockSession.config.mcpServers = undefined;
 			const options = await builder.build();
 			expect(options.mcpServers).toBeUndefined();
 			expect(options.strictMcpConfig).toBe(true);
-			expect(options.settingSources).toEqual([]);
+			expect(options.settingSources).toEqual(['user', 'project']);
 		});
 
 		it('preserves explicit mcpServers from session config under strict mode', async () => {
@@ -692,13 +692,14 @@ describe('QueryOptionsBuilder', () => {
 			};
 			const options = await builder.build();
 			expect(options.strictMcpConfig).toBe(true);
-			expect(options.settingSources).toEqual([]);
+			expect(options.settingSources).toEqual(['user', 'project']);
 			expect(options.mcpServers).toEqual({ 'task-agent': { command: 'task-cmd' } });
 		});
 
 		it('ignores NEOKAI_LEGACY_MCP_AUTOLOAD — the M1 kill switch was removed in M5', async () => {
-			// Setting the legacy env var must have no effect; settingSources stays []
-			// and strictMcpConfig stays true regardless of value or session type.
+			// Setting the legacy env var must have no effect; settingSources stays
+			// at the global default and strictMcpConfig stays true regardless of
+			// value or session type.
 			const previous = process.env.NEOKAI_LEGACY_MCP_AUTOLOAD;
 			try {
 				for (const val of ['1', 'true', 'yes']) {
@@ -706,7 +707,7 @@ describe('QueryOptionsBuilder', () => {
 					mockSession.type = 'worker';
 					const options = await builder.build();
 					expect(options.strictMcpConfig).toBe(true);
-					expect(options.settingSources).toEqual([]);
+					expect(options.settingSources).toEqual(['user', 'project']);
 				}
 			} finally {
 				if (previous === undefined) {

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -58,7 +58,7 @@ describe('QueryOptionsBuilder', () => {
 		};
 
 		mockSettingsManager = {
-			getGlobalSettings: mock(() => ({ settingSources: ['user', 'project'] })),
+			getGlobalSettings: mock(() => ({ settingSources: ['user', 'project', 'local'] })),
 			prepareSDKOptions: mock(async () => ({})),
 		} as unknown as SettingsManager;
 
@@ -545,12 +545,12 @@ describe('QueryOptionsBuilder', () => {
 
 	describe('setting sources configuration', () => {
 		// Post-M5: `settingSources` defaults to the global settings value
-		// (['user', 'project']) so CLAUDE.md and user/project settings are
+		// (['user', 'project', 'local']) so CLAUDE.md and user/project settings are
 		// loaded.  MCP remains locked to `strictMcpConfig: true` (unified
 		// `app_mcp_servers` registry only) regardless of settingSources.
 		it('should default settingSources to global settings', async () => {
 			const options = await builder.build();
-			expect(options.settingSources).toEqual(['user', 'project']);
+			expect(options.settingSources).toEqual(['user', 'project', 'local']);
 		});
 	});
 
@@ -566,7 +566,7 @@ describe('QueryOptionsBuilder', () => {
 				'space-agent-tools': { command: 'space-cmd' },
 			});
 			expect(options.strictMcpConfig).toBe(true);
-			expect(options.settingSources).toEqual(['user', 'project']);
+			expect(options.settingSources).toEqual(['user', 'project', 'local']);
 		});
 
 		it('should enforce space built-in tool allowlist including Bash', async () => {
@@ -647,7 +647,7 @@ describe('QueryOptionsBuilder', () => {
 
 	// ============================================================================
 	// M5 (unify-mcp-config-model): strictMcpConfig is forced unconditionally;
-	// settingSources defaults to global settings (['user', 'project']) but can be
+	// settingSources defaults to global settings (['user', 'project', 'local']) but can be
 	// overridden per-session. The M1 `NEOKAI_LEGACY_MCP_AUTOLOAD` kill switch was
 	// removed. These tests pin the post-M5 contract per session type so any
 	// regression that re-introduces auto-loading is caught.
@@ -666,7 +666,7 @@ describe('QueryOptionsBuilder', () => {
 				mockSession.type = type;
 				const options = await builder.build();
 				expect(options.strictMcpConfig).toBe(true);
-				expect(options.settingSources).toEqual(['user', 'project']);
+				expect(options.settingSources).toEqual(['user', 'project', 'local']);
 			});
 		}
 
@@ -682,7 +682,7 @@ describe('QueryOptionsBuilder', () => {
 			const options = await builder.build();
 			expect(options.mcpServers).toBeUndefined();
 			expect(options.strictMcpConfig).toBe(true);
-			expect(options.settingSources).toEqual(['user', 'project']);
+			expect(options.settingSources).toEqual(['user', 'project', 'local']);
 		});
 
 		it('preserves explicit mcpServers from session config under strict mode', async () => {
@@ -692,7 +692,7 @@ describe('QueryOptionsBuilder', () => {
 			};
 			const options = await builder.build();
 			expect(options.strictMcpConfig).toBe(true);
-			expect(options.settingSources).toEqual(['user', 'project']);
+			expect(options.settingSources).toEqual(['user', 'project', 'local']);
 			expect(options.mcpServers).toEqual({ 'task-agent': { command: 'task-cmd' } });
 		});
 
@@ -707,7 +707,7 @@ describe('QueryOptionsBuilder', () => {
 					mockSession.type = 'worker';
 					const options = await builder.build();
 					expect(options.strictMcpConfig).toBe(true);
-					expect(options.settingSources).toEqual(['user', 'project']);
+					expect(options.settingSources).toEqual(['user', 'project', 'local']);
 				}
 			} finally {
 				if (previous === undefined) {

--- a/packages/daemon/tests/unit/1-core/agent/query-options-m1-mcp-leak.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-m1-mcp-leak.test.ts
@@ -12,7 +12,7 @@
  *   2. Run it through `QueryOptionsBuilder.build()` with no other mocks.
  *   3. Assert the resulting SDK options force `strictMcpConfig: true`
  *      (which blocks MCP auto-loading regardless of `settingSources`) and
- *      default `settingSources` to `['user', 'project']` so CLAUDE.md and
+ *      default `settingSources` to `['user', 'project', 'local']` so CLAUDE.md and
  *      user/project settings are loaded.
  *
  * M5 removed the `NEOKAI_LEGACY_MCP_AUTOLOAD=1` escape hatch entirely —
@@ -30,7 +30,7 @@ import type { AgentSessionInit } from '../../../../src/lib/agent/agent-session';
 
 function mockSettingsManager(): SettingsManager {
 	return {
-		getGlobalSettings: mock(() => ({ settingSources: ['user', 'project'] })),
+		getGlobalSettings: mock(() => ({ settingSources: ['user', 'project', 'local'] })),
 		prepareSDKOptions: mock(async () => ({})),
 	} as unknown as SettingsManager;
 }
@@ -137,7 +137,7 @@ describe('MCP leak regression: strictMcpConfig blocks auto-load regardless of se
 			const options = await builder.build();
 
 			expect(options.strictMcpConfig).toBe(true);
-			expect(options.settingSources).toEqual(['user', 'project']);
+			expect(options.settingSources).toEqual(['user', 'project', 'local']);
 			// No programmatic mcpServers were passed → map is absent, so nothing
 			// from a project `.mcp.json` can possibly surface here.
 			expect(options.mcpServers).toBeUndefined();
@@ -161,7 +161,7 @@ describe('MCP leak regression: strictMcpConfig blocks auto-load regardless of se
 				const options = await builder.build();
 
 				expect(options.strictMcpConfig).toBe(true);
-				expect(options.settingSources).toEqual(['user', 'project']);
+				expect(options.settingSources).toEqual(['user', 'project', 'local']);
 			} finally {
 				if (previous === undefined) {
 					delete process.env.NEOKAI_LEGACY_MCP_AUTOLOAD;
@@ -193,7 +193,7 @@ describe('MCP leak regression: strictMcpConfig blocks auto-load regardless of se
 			const options = await builder.build();
 
 			expect(options.strictMcpConfig).toBe(true);
-			expect(options.settingSources).toEqual(['user', 'project']);
+			expect(options.settingSources).toEqual(['user', 'project', 'local']);
 			// A workflow node-agent's `node-agent` MCP server is attached at runtime
 			// via `mergeRuntimeMcpServers` after session creation, not by the init
 			// factory. Without that runtime merge, no ambient `.mcp.json` servers
@@ -249,7 +249,7 @@ describe('MCP leak regression: strictMcpConfig blocks auto-load regardless of se
 				const options = await builder.build();
 
 				expect(options.strictMcpConfig).toBe(true);
-				expect(options.settingSources).toEqual(['user', 'project']);
+				expect(options.settingSources).toEqual(['user', 'project', 'local']);
 			} finally {
 				if (previous === undefined) {
 					delete process.env.NEOKAI_LEGACY_MCP_AUTOLOAD;
@@ -297,7 +297,7 @@ describe('MCP leak regression: strictMcpConfig blocks auto-load regardless of se
 			const options = await builder.build();
 
 			expect(options.strictMcpConfig).toBe(true);
-			expect(options.settingSources).toEqual(['user', 'project']);
+			expect(options.settingSources).toEqual(['user', 'project', 'local']);
 			expect(options.mcpServers).toBeUndefined();
 		});
 	});

--- a/packages/daemon/tests/unit/1-core/agent/query-options-m1-mcp-leak.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-m1-mcp-leak.test.ts
@@ -10,9 +10,10 @@
  *      (`createTaskAgentInit` / `createCustomAgentInit`) or a bare Space
  *      worker shape, then synthesize a `Session` from it.
  *   2. Run it through `QueryOptionsBuilder.build()` with no other mocks.
- *   3. Assert the resulting SDK options force `strictMcpConfig: true` and
- *      `settingSources: []`, so the Claude Agent SDK has no path to
- *      auto-load a project-level `.mcp.json` or `.claude/settings.local.json`.
+ *   3. Assert the resulting SDK options force `strictMcpConfig: true`
+ *      (which blocks MCP auto-loading regardless of `settingSources`) and
+ *      default `settingSources` to `['user', 'project']` so CLAUDE.md and
+ *      user/project settings are loaded.
  *
  * M5 removed the `NEOKAI_LEGACY_MCP_AUTOLOAD=1` escape hatch entirely —
  * setting it has no effect, which is also asserted below so any accidental
@@ -29,7 +30,7 @@ import type { AgentSessionInit } from '../../../../src/lib/agent/agent-session';
 
 function mockSettingsManager(): SettingsManager {
 	return {
-		getGlobalSettings: mock(() => ({})),
+		getGlobalSettings: mock(() => ({ settingSources: ['user', 'project'] })),
 		prepareSDKOptions: mock(async () => ({})),
 	} as unknown as SettingsManager;
 }
@@ -117,9 +118,9 @@ function sessionFromInit(init: AgentSessionInit): Session {
 	} as Session;
 }
 
-describe('MCP leak regression: strictMcpConfig + empty settingSources per spawn path', () => {
+describe('MCP leak regression: strictMcpConfig blocks auto-load regardless of settingSources', () => {
 	describe('space_task_agent (createTaskAgentInit)', () => {
-		it('emits SDK options with strictMcpConfig=true and empty settingSources', async () => {
+		it('emits SDK options with strictMcpConfig=true and default settingSources', async () => {
 			const init = createTaskAgentInit({
 				task: makeTask(),
 				space: makeSpace(),
@@ -136,7 +137,7 @@ describe('MCP leak regression: strictMcpConfig + empty settingSources per spawn 
 			const options = await builder.build();
 
 			expect(options.strictMcpConfig).toBe(true);
-			expect(options.settingSources).toEqual([]);
+			expect(options.settingSources).toEqual(['user', 'project']);
 			// No programmatic mcpServers were passed → map is absent, so nothing
 			// from a project `.mcp.json` can possibly surface here.
 			expect(options.mcpServers).toBeUndefined();
@@ -160,7 +161,7 @@ describe('MCP leak regression: strictMcpConfig + empty settingSources per spawn 
 				const options = await builder.build();
 
 				expect(options.strictMcpConfig).toBe(true);
-				expect(options.settingSources).toEqual([]);
+				expect(options.settingSources).toEqual(['user', 'project']);
 			} finally {
 				if (previous === undefined) {
 					delete process.env.NEOKAI_LEGACY_MCP_AUTOLOAD;
@@ -172,7 +173,7 @@ describe('MCP leak regression: strictMcpConfig + empty settingSources per spawn 
 	});
 
 	describe('node-agent workflow sub-session (createCustomAgentInit)', () => {
-		it('emits SDK options with strictMcpConfig=true and empty settingSources', async () => {
+		it('emits SDK options with strictMcpConfig=true and default settingSources', async () => {
 			const init = createCustomAgentInit({
 				customAgent: makeCustomAgent(),
 				task: makeTask(),
@@ -192,7 +193,7 @@ describe('MCP leak regression: strictMcpConfig + empty settingSources per spawn 
 			const options = await builder.build();
 
 			expect(options.strictMcpConfig).toBe(true);
-			expect(options.settingSources).toEqual([]);
+			expect(options.settingSources).toEqual(['user', 'project']);
 			// A workflow node-agent's `node-agent` MCP server is attached at runtime
 			// via `mergeRuntimeMcpServers` after session creation, not by the init
 			// factory. Without that runtime merge, no ambient `.mcp.json` servers
@@ -248,7 +249,7 @@ describe('MCP leak regression: strictMcpConfig + empty settingSources per spawn 
 				const options = await builder.build();
 
 				expect(options.strictMcpConfig).toBe(true);
-				expect(options.settingSources).toEqual([]);
+				expect(options.settingSources).toEqual(['user', 'project']);
 			} finally {
 				if (previous === undefined) {
 					delete process.env.NEOKAI_LEGACY_MCP_AUTOLOAD;
@@ -260,7 +261,7 @@ describe('MCP leak regression: strictMcpConfig + empty settingSources per spawn 
 	});
 
 	describe('Space ad-hoc (worker session attached to a space by context)', () => {
-		it('emits SDK options with strictMcpConfig=true and empty settingSources', async () => {
+		it('emits SDK options with strictMcpConfig=true and default settingSources', async () => {
 			// Space ad-hoc = any session opened in a Space that is neither the
 			// coordinator (`space_chat`) nor a task-agent. The runtime model uses
 			// `type: 'worker'` with a `spaceId` on the context.
@@ -296,7 +297,7 @@ describe('MCP leak regression: strictMcpConfig + empty settingSources per spawn 
 			const options = await builder.build();
 
 			expect(options.strictMcpConfig).toBe(true);
-			expect(options.settingSources).toEqual([]);
+			expect(options.settingSources).toEqual(['user', 'project']);
 			expect(options.mcpServers).toBeUndefined();
 		});
 	});

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-export-import-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-export-import-handlers.test.ts
@@ -45,6 +45,7 @@ function createSchema(db: Database): void {
 			session_ids TEXT NOT NULL DEFAULT '[]',
 			status TEXT NOT NULL DEFAULT 'active',
 			config TEXT,
+			setting_sources TEXT DEFAULT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL
 		)
@@ -64,6 +65,7 @@ function createSchema(db: Database): void {
 			custom_prompt TEXT,
 			template_name TEXT DEFAULT NULL,
 			template_hash TEXT DEFAULT NULL,
+			setting_sources TEXT DEFAULT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE

--- a/packages/daemon/tests/unit/4-space-storage/storage/settings-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/settings-repository.test.ts
@@ -398,7 +398,7 @@ describe('SettingsRepository', () => {
 		it('should have correct default global settings', () => {
 			const settings = repository.getGlobalSettings();
 
-			expect(settings.settingSources).toEqual(['user', 'project']);
+			expect(settings.settingSources).toEqual(['user', 'project', 'local']);
 			expect(settings.permissionMode).toBe('default');
 			expect(settings.model).toBe('sonnet');
 			expect(settings.autoScroll).toBe(true);

--- a/packages/daemon/tests/unit/4-space-storage/storage/settings-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/settings-repository.test.ts
@@ -398,7 +398,7 @@ describe('SettingsRepository', () => {
 		it('should have correct default global settings', () => {
 			const settings = repository.getGlobalSettings();
 
-			expect(settings.settingSources).toEqual(['user', 'project', 'local']);
+			expect(settings.settingSources).toEqual(['user', 'project']);
 			expect(settings.permissionMode).toBe('default');
 			expect(settings.model).toBe('sonnet');
 			expect(settings.autoScroll).toBe(true);

--- a/packages/daemon/tests/unit/5-space/runtime/space-slug.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-slug.test.ts
@@ -33,6 +33,7 @@ function createTestDb(): InstanceType<typeof Database> {
 			autonomy_level TEXT DEFAULT 'supervised',
 			config TEXT,
 			task_agent_config TEXT,
+			setting_sources TEXT DEFAULT NULL,
 			slug TEXT,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL

--- a/packages/daemon/tests/unit/helpers/space-agent-schema.ts
+++ b/packages/daemon/tests/unit/helpers/space-agent-schema.ts
@@ -27,6 +27,7 @@ export function createSpaceAgentSchema(db: Database): void {
 			autonomy_level TEXT NOT NULL DEFAULT 'supervised',
 			config TEXT,
 			task_agent_config TEXT,
+			setting_sources TEXT DEFAULT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL
 		)
@@ -48,6 +49,7 @@ export function createSpaceAgentSchema(db: Database): void {
 			provider TEXT,
 			template_name TEXT DEFAULT NULL,
 			template_hash TEXT DEFAULT NULL,
+			setting_sources TEXT DEFAULT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -35,6 +35,7 @@ export function createSpaceTables(db: BunDatabase): void {
 				CHECK(autonomy_level BETWEEN 1 AND 5),
 			config TEXT,
 			task_agent_config TEXT DEFAULT NULL,
+			setting_sources TEXT DEFAULT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL
 		)
@@ -56,6 +57,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			provider TEXT,
 			template_name TEXT DEFAULT NULL,
 			template_hash TEXT DEFAULT NULL,
+			setting_sources TEXT DEFAULT NULL,
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL,
 			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE

--- a/packages/shared/src/types/settings.ts
+++ b/packages/shared/src/types/settings.ts
@@ -187,11 +187,7 @@ export interface SessionSettings extends GlobalSettings {
  * Default global settings
  */
 export const DEFAULT_GLOBAL_SETTINGS: GlobalSettings = {
-	// Default to user + project only. 'local' is intentionally OFF by default
-	// because NeoKai writes to .claude/settings.local.json via writeFileOnlySettings()
-	// (permissions, sandbox, attribution). Loading it back could create circular
-	// or conflicting settings.
-	settingSources: ['user', 'project'],
+	settingSources: ['user', 'project', 'local'],
 	permissionMode: 'default',
 	model: 'sonnet', // Default model for new sessions
 	showArchived: false,

--- a/packages/shared/src/types/settings.ts
+++ b/packages/shared/src/types/settings.ts
@@ -187,7 +187,11 @@ export interface SessionSettings extends GlobalSettings {
  * Default global settings
  */
 export const DEFAULT_GLOBAL_SETTINGS: GlobalSettings = {
-	settingSources: ['user', 'project', 'local'],
+	// Default to user + project only. 'local' is intentionally OFF by default
+	// because NeoKai writes to .claude/settings.local.json via writeFileOnlySettings()
+	// (permissions, sandbox, attribution). Loading it back could create circular
+	// or conflicting settings.
+	settingSources: ['user', 'project'],
 	permissionMode: 'default',
 	model: 'sonnet', // Default model for new sessions
 	showArchived: false,

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -65,7 +65,7 @@ export interface TaskAgentConfig {
 	customPrompt?: string;
 	/**
 	 * Setting sources to load for the Task Agent.
-	 * Falls back to the global default (['user', 'project']) when unset.
+	 * Falls back to the global default (['user', 'project', 'local']) when unset.
 	 */
 	settingSources?: SettingSource[];
 }
@@ -720,7 +720,7 @@ export interface SpaceAgent {
 	tools?: string[];
 	/**
 	 * Setting sources to load for this agent.
-	 * Falls back to the global default (['user', 'project']) when unset.
+	 * Falls back to the global default (['user', 'project', 'local']) when unset.
 	 */
 	settingSources?: SettingSource[];
 	/**
@@ -757,7 +757,7 @@ export interface CreateSpaceAgentParams {
 	tools?: string[];
 	/**
 	 * Setting sources to load for this agent.
-	 * Falls back to the global default (['user', 'project']) when unset.
+	 * Falls back to the global default (['user', 'project', 'local']) when unset.
 	 */
 	settingSources?: SettingSource[];
 	/**

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -160,8 +160,11 @@ export interface CreateSpaceParams {
 	config?: SpaceConfig;
 	/** Per-space overrides for the built-in Task Agent */
 	taskAgentConfig?: TaskAgentConfig;
-	/** Default setting sources for all agents in this Space */
-	settingSources?: SettingSource[];
+	/**
+	 * Default setting sources for all agents in this Space.
+	 * Pass `null` to explicitly clear (revert to global default).
+	 */
+	settingSources?: SettingSource[] | null;
 }
 
 /**
@@ -758,8 +761,9 @@ export interface CreateSpaceAgentParams {
 	/**
 	 * Setting sources to load for this agent.
 	 * Falls back to the global default (['user', 'project', 'local']) when unset.
+	 * Pass `null` to explicitly clear (revert to inherited defaults).
 	 */
-	settingSources?: SettingSource[];
+	settingSources?: SettingSource[] | null;
 	/**
 	 * Optional preset template name. Set by `seedPresetAgents()` when seeding
 	 * built-in presets; left undefined for user-created agents.

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ThinkingLevel } from '../types';
+import type { SettingSource } from './settings';
 import type { McpServerConfig } from './sdk-config';
 
 // ============================================================================
@@ -62,6 +63,11 @@ export interface TaskAgentConfig {
 	thinkingLevel?: ThinkingLevel;
 	/** Custom prompt additions appended after the contract sections (similar to SpaceAgent.customPrompt). */
 	customPrompt?: string;
+	/**
+	 * Setting sources to load for the Task Agent.
+	 * Falls back to the global default (['user', 'project']) when unset.
+	 */
+	settingSources?: SettingSource[];
 }
 
 /**
@@ -105,6 +111,11 @@ export interface Space {
 	config?: SpaceConfig;
 	/** Per-space overrides for the built-in Task Agent (model and custom prompt). */
 	taskAgentConfig?: TaskAgentConfig;
+	/**
+	 * Default setting sources for all agents in this Space.
+	 * Used as fallback when an agent (task or custom) does not define its own.
+	 */
+	settingSources?: SettingSource[];
 	/** Creation timestamp (milliseconds since epoch) */
 	createdAt: number;
 	/** Last update timestamp (milliseconds since epoch) */
@@ -149,6 +160,8 @@ export interface CreateSpaceParams {
 	config?: SpaceConfig;
 	/** Per-space overrides for the built-in Task Agent */
 	taskAgentConfig?: TaskAgentConfig;
+	/** Default setting sources for all agents in this Space */
+	settingSources?: SettingSource[];
 }
 
 /**
@@ -165,6 +178,11 @@ export interface UpdateSpaceParams {
 	config?: SpaceConfig;
 	/** Per-space overrides for the built-in Task Agent. Pass null to clear. */
 	taskAgentConfig?: TaskAgentConfig | null;
+	/**
+	 * Default setting sources for all agents in this Space.
+	 * Pass null to clear (revert to global default).
+	 */
+	settingSources?: SettingSource[] | null;
 }
 
 // ============================================================================
@@ -701,6 +719,11 @@ export interface SpaceAgent {
 	 */
 	tools?: string[];
 	/**
+	 * Setting sources to load for this agent.
+	 * Falls back to the global default (['user', 'project']) when unset.
+	 */
+	settingSources?: SettingSource[];
+	/**
 	 * When this agent was seeded from a preset, the canonical preset name
 	 * (e.g. "Reviewer", "Coder"). Null/undefined for user-created agents and
 	 * for any preset row that predates template tracking.
@@ -733,6 +756,11 @@ export interface CreateSpaceAgentParams {
 	/** Tool list override — any entry must be a name from KNOWN_TOOLS */
 	tools?: string[];
 	/**
+	 * Setting sources to load for this agent.
+	 * Falls back to the global default (['user', 'project']) when unset.
+	 */
+	settingSources?: SettingSource[];
+	/**
 	 * Optional preset template name. Set by `seedPresetAgents()` when seeding
 	 * built-in presets; left undefined for user-created agents.
 	 * When set, `templateHash` should also be supplied.
@@ -758,6 +786,11 @@ export interface UpdateSpaceAgentParams {
 	customPrompt?: string | null;
 	/** Tool list override — null clears (reverts to role defaults) */
 	tools?: string[] | null;
+	/**
+	 * Setting sources to load for this agent.
+	 * Pass `null` to clear (revert to global default).
+	 */
+	settingSources?: SettingSource[] | null;
 	/**
 	 * Update the preset template name. Pass `null` to clear template tracking
 	 * (e.g. when a user converts a preset agent into a fully custom one).

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -1677,6 +1677,12 @@ export interface ExportedSpaceAgent {
 	 * Mirrors `SpaceAgent.tools`.
 	 */
 	tools?: string[];
+	/**
+	 * Setting sources override — which on-disk settings files this agent loads.
+	 * When absent, the agent inherits from its parent Space on import.
+	 * Mirrors `SpaceAgent.settingSources`.
+	 */
+	settingSources?: import('./settings').SettingSource[];
 }
 
 /**

--- a/packages/web/src/components/ToolsModal.tsx
+++ b/packages/web/src/components/ToolsModal.tsx
@@ -211,6 +211,11 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 
 	// Advanced settings (hidden by default)
 	const useClaudeCodePreset = useSignal(true);
+	const settingSources = useSignal<import('@neokai/shared').SettingSource[]>(['user', 'project']);
+	const initialSettingSources = useSignal<import('@neokai/shared').SettingSource[]>([
+		'user',
+		'project',
+	]);
 
 	// Has the user staged any change since the modal was opened? Drives the
 	// Save button's enabled state. Computed from the four sources of pending
@@ -229,6 +234,9 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 		}
 		// Advanced: claudeCodePreset toggle.
 		if (useClaudeCodePreset.value !== initialClaudeCodePreset.value) return true;
+		// Advanced: settingSources change.
+		if (JSON.stringify(settingSources.value) !== JSON.stringify(initialSettingSources.value))
+			return true;
 		return false;
 	});
 
@@ -261,6 +269,11 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 		const disabled = new Set<string>(tools?.disabledSkills ?? []);
 		pendingDisabledSkills.value = disabled;
 		initialDisabledSkills.value = new Set(disabled);
+
+		// Load setting sources from session config
+		const sources = session.config.settingSources ?? ['user', 'project'];
+		settingSources.value = sources;
+		initialSettingSources.value = [...sources];
 
 		// Reset MCP overrides — the modal always starts from a clean slate;
 		// it's the daemon's resolved view that drives the initial checkbox
@@ -522,7 +535,15 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 				return;
 			}
 
-			// 3. Refresh the resolved MCP entries so the next open of the modal
+			// 3. Persist settingSources change via session.update.
+			if (JSON.stringify(settingSources.value) !== JSON.stringify(initialSettingSources.value)) {
+				await hub.request('session.update', {
+					sessionId: session.id,
+					config: { settingSources: settingSources.value },
+				});
+			}
+
+			// 4. Refresh the resolved MCP entries so the next open of the modal
 			//    sees the updated `source`/`enabled` flags.
 			await loadSessionMcpEntries();
 			toast.success('Tools configuration saved');
@@ -923,6 +944,56 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 										class="w-4 h-4 rounded border-gray-600 text-blue-500"
 									/>
 								</label>
+							</div>
+							{/* Setting Sources */}
+							<div>
+								<h4 class="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
+									Setting Sources
+								</h4>
+								<div class="space-y-1.5">
+									<label class="flex items-center gap-2 cursor-pointer">
+										<input
+											type="checkbox"
+											checked={settingSources.value.includes('user')}
+											onChange={() =>
+												(settingSources.value = settingSources.value.includes('user')
+													? settingSources.value.filter((s) => s !== 'user')
+													: [...settingSources.value, 'user'])
+											}
+											class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
+										/>
+										<span class="text-sm text-gray-200">User settings</span>
+										<span class="text-xs text-gray-500">(~/.claude/settings.json)</span>
+									</label>
+									<label class="flex items-center gap-2 cursor-pointer">
+										<input
+											type="checkbox"
+											checked={settingSources.value.includes('project')}
+											onChange={() =>
+												(settingSources.value = settingSources.value.includes('project')
+													? settingSources.value.filter((s) => s !== 'project')
+													: [...settingSources.value, 'project'])
+											}
+											class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
+										/>
+										<span class="text-sm text-gray-200">Project settings + CLAUDE.md</span>
+										<span class="text-xs text-gray-500">(.claude/settings.json)</span>
+									</label>
+									<label class="flex items-center gap-2 cursor-pointer">
+										<input
+											type="checkbox"
+											checked={settingSources.value.includes('local')}
+											onChange={() =>
+												(settingSources.value = settingSources.value.includes('local')
+													? settingSources.value.filter((s) => s !== 'local')
+													: [...settingSources.value, 'local'])
+											}
+											class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
+										/>
+										<span class="text-sm text-gray-200">Local settings</span>
+										<span class="text-xs text-gray-500">(.claude/settings.local.json)</span>
+									</label>
+								</div>
 							</div>
 						</div>
 					)}

--- a/packages/web/src/components/ToolsModal.tsx
+++ b/packages/web/src/components/ToolsModal.tsx
@@ -39,6 +39,7 @@ import type {
 } from '@neokai/shared';
 import { listRuntimeMcpServers } from '../lib/api-helpers.ts';
 import { skillsStore } from '../lib/skills-store.ts';
+import { globalSettings } from '../lib/state.ts';
 
 /**
  * Human-friendly labels for runtime-attached (SDK-type) MCP servers.
@@ -276,7 +277,8 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 		initialDisabledSkills.value = new Set(disabled);
 
 		// Load setting sources from session config
-		const sources = session.config.settingSources ?? ['user', 'project', 'local'];
+		const sources = session.config.settingSources ??
+			globalSettings.value?.settingSources ?? ['user', 'project', 'local'];
 		settingSources.value = sources;
 		initialSettingSources.value = [...sources];
 

--- a/packages/web/src/components/ToolsModal.tsx
+++ b/packages/web/src/components/ToolsModal.tsx
@@ -211,10 +211,15 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 
 	// Advanced settings (hidden by default)
 	const useClaudeCodePreset = useSignal(true);
-	const settingSources = useSignal<import('@neokai/shared').SettingSource[]>(['user', 'project']);
+	const settingSources = useSignal<import('@neokai/shared').SettingSource[]>([
+		'user',
+		'project',
+		'local',
+	]);
 	const initialSettingSources = useSignal<import('@neokai/shared').SettingSource[]>([
 		'user',
 		'project',
+		'local',
 	]);
 
 	// Has the user staged any change since the modal was opened? Drives the
@@ -271,7 +276,7 @@ export function ToolsModal({ isOpen, onClose, session }: ToolsModalProps) {
 		initialDisabledSkills.value = new Set(disabled);
 
 		// Load setting sources from session config
-		const sources = session.config.settingSources ?? ['user', 'project'];
+		const sources = session.config.settingSources ?? ['user', 'project', 'local'];
 		settingSources.value = sources;
 		initialSettingSources.value = [...sources];
 

--- a/packages/web/src/components/settings/GeneralSettings.tsx
+++ b/packages/web/src/components/settings/GeneralSettings.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'preact/hooks';
 import { globalSettings } from '../../lib/state.ts';
 import { updateGlobalSettings } from '../../lib/api-helpers.ts';
 import { toast } from '../../lib/toast.ts';
-import type { PermissionMode, ThinkingLevel } from '@neokai/shared';
+import type { PermissionMode, ThinkingLevel, SettingSource } from '@neokai/shared';
 import { normalizeThinkingLevel } from '@neokai/shared';
 import {
 	SettingsSection,
@@ -43,6 +43,9 @@ export function GeneralSettings() {
 		normalizeThinkingLevel(settings?.thinkingLevel)
 	);
 	const [localShowArchived, setLocalShowArchived] = useState(settings?.showArchived ?? false);
+	const [localSettingSources, setLocalSettingSources] = useState<SettingSource[]>(
+		settings?.settingSources ?? ['user', 'project']
+	);
 	const [isUpdating, setIsUpdating] = useState(false);
 
 	// Sync local state when global settings change
@@ -53,6 +56,7 @@ export function GeneralSettings() {
 			setLocalAutoScroll(settings.autoScroll ?? true);
 			setLocalThinkingLevel(normalizeThinkingLevel(settings.thinkingLevel));
 			setLocalShowArchived(settings.showArchived ?? false);
+			setLocalSettingSources(settings.settingSources ?? ['user', 'project']);
 		}
 	}, [settings]);
 
@@ -126,6 +130,22 @@ export function GeneralSettings() {
 		}
 	};
 
+	const toggleSettingSource = async (source: SettingSource) => {
+		const next = localSettingSources.includes(source)
+			? localSettingSources.filter((s) => s !== source)
+			: [...localSettingSources, source];
+		setLocalSettingSources(next);
+		setIsUpdating(true);
+		try {
+			await updateGlobalSettings({ settingSources: next });
+		} catch {
+			toast.error('Failed to update setting sources');
+			setLocalSettingSources(settings?.settingSources ?? ['user', 'project']);
+		} finally {
+			setIsUpdating(false);
+		}
+	};
+
 	return (
 		<SettingsSection title="General">
 			<SettingsRow label="Default Model" description="Model for new sessions">
@@ -169,6 +189,44 @@ export function GeneralSettings() {
 					onChange={handleShowArchivedChange}
 					disabled={isUpdating}
 				/>
+			</SettingsRow>
+
+			<SettingsRow label="Setting Sources" description="Which on-disk settings files the SDK loads">
+				<div class="space-y-2">
+					<label class="flex items-center gap-2 cursor-pointer">
+						<input
+							type="checkbox"
+							checked={localSettingSources.includes('user')}
+							onChange={() => toggleSettingSource('user')}
+							disabled={isUpdating}
+							class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
+						/>
+						<span class="text-sm text-gray-200">User settings</span>
+						<span class="text-xs text-gray-500">(~/.claude/settings.json)</span>
+					</label>
+					<label class="flex items-center gap-2 cursor-pointer">
+						<input
+							type="checkbox"
+							checked={localSettingSources.includes('project')}
+							onChange={() => toggleSettingSource('project')}
+							disabled={isUpdating}
+							class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
+						/>
+						<span class="text-sm text-gray-200">Project settings + CLAUDE.md</span>
+						<span class="text-xs text-gray-500">(.claude/settings.json)</span>
+					</label>
+					<label class="flex items-center gap-2 cursor-pointer">
+						<input
+							type="checkbox"
+							checked={localSettingSources.includes('local')}
+							onChange={() => toggleSettingSource('local')}
+							disabled={isUpdating}
+							class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
+						/>
+						<span class="text-sm text-gray-200">Local settings</span>
+						<span class="text-xs text-gray-500">(.claude/settings.local.json)</span>
+					</label>
+				</div>
 			</SettingsRow>
 		</SettingsSection>
 	);

--- a/packages/web/src/components/settings/GeneralSettings.tsx
+++ b/packages/web/src/components/settings/GeneralSettings.tsx
@@ -44,7 +44,7 @@ export function GeneralSettings() {
 	);
 	const [localShowArchived, setLocalShowArchived] = useState(settings?.showArchived ?? false);
 	const [localSettingSources, setLocalSettingSources] = useState<SettingSource[]>(
-		settings?.settingSources ?? ['user', 'project']
+		settings?.settingSources ?? ['user', 'project', 'local']
 	);
 	const [isUpdating, setIsUpdating] = useState(false);
 
@@ -56,7 +56,7 @@ export function GeneralSettings() {
 			setLocalAutoScroll(settings.autoScroll ?? true);
 			setLocalThinkingLevel(normalizeThinkingLevel(settings.thinkingLevel));
 			setLocalShowArchived(settings.showArchived ?? false);
-			setLocalSettingSources(settings.settingSources ?? ['user', 'project']);
+			setLocalSettingSources(settings.settingSources ?? ['user', 'project', 'local']);
 		}
 	}, [settings]);
 
@@ -140,7 +140,7 @@ export function GeneralSettings() {
 			await updateGlobalSettings({ settingSources: next });
 		} catch {
 			toast.error('Failed to update setting sources');
-			setLocalSettingSources(settings?.settingSources ?? ['user', 'project']);
+			setLocalSettingSources(settings?.settingSources ?? ['user', 'project', 'local']);
 		} finally {
 			setIsUpdating(false);
 		}

--- a/packages/web/src/components/space/SpaceAgentEditor.tsx
+++ b/packages/web/src/components/space/SpaceAgentEditor.tsx
@@ -224,7 +224,9 @@ export function SpaceAgentEditor({
 				model: model.trim(),
 				customPrompt: customPrompt || null,
 				tools: tools.length > 0 ? tools : undefined,
-				...(hadExplicitSettingSources || settingSourcesTouched ? { settingSources } : {}),
+				...(hadExplicitSettingSources || settingSourcesTouched || clearSettingSources
+					? { settingSources: clearSettingSources ? null : settingSources }
+					: {}),
 			};
 
 			if (isEdit && agent) {

--- a/packages/web/src/components/space/SpaceAgentEditor.tsx
+++ b/packages/web/src/components/space/SpaceAgentEditor.tsx
@@ -16,7 +16,7 @@
  * Validation: name required + unique, model required, at least one tool selected.
  */
 
-import type { SpaceAgent, ThinkingLevel } from '@neokai/shared';
+import type { SpaceAgent, ThinkingLevel, SettingSource } from '@neokai/shared';
 import { KNOWN_TOOLS, normalizeThinkingLevel } from '@neokai/shared';
 import { useState } from 'preact/hooks';
 import type { SpaceAgentTemplate } from '../../lib/space-store';
@@ -143,6 +143,9 @@ export function SpaceAgentEditor({
 	);
 	const [tools, setTools] = useState<string[]>(agent?.tools ?? [...TOOL_PRESETS['Full Coding']]);
 	const [customPrompt, setCustomPrompt] = useState(agent?.customPrompt ?? '');
+	const [settingSources, setSettingSources] = useState<SettingSource[]>(
+		agent?.settingSources ?? ['user', 'project']
+	);
 	const [activePreset, setActivePreset] = useState<string>(() => detectPreset(agent?.tools));
 	const [selectedTemplateName, setSelectedTemplateName] = useState<string>('');
 
@@ -218,6 +221,7 @@ export function SpaceAgentEditor({
 				model: model.trim(),
 				customPrompt: customPrompt || null,
 				tools: tools.length > 0 ? tools : undefined,
+				settingSources: settingSources.length > 0 ? settingSources : undefined,
 			};
 
 			if (isEdit && agent) {
@@ -358,6 +362,60 @@ export function SpaceAgentEditor({
 							</option>
 						))}
 					</select>
+				</div>
+
+				{/* Setting Sources */}
+				<div>
+					<label class="block text-sm font-medium text-gray-300 mb-1.5">
+						Setting Sources
+						<span class="text-gray-500 text-xs ml-2">(optional)</span>
+					</label>
+					<div class="space-y-1.5">
+						<label class="flex items-center gap-2 cursor-pointer">
+							<input
+								type="checkbox"
+								checked={settingSources.includes('user')}
+								onChange={() =>
+									setSettingSources((prev) =>
+										prev.includes('user') ? prev.filter((s) => s !== 'user') : [...prev, 'user']
+									)
+								}
+								class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
+							/>
+							<span class="text-sm text-gray-200">User settings</span>
+							<span class="text-xs text-gray-500">(~/.claude/settings.json)</span>
+						</label>
+						<label class="flex items-center gap-2 cursor-pointer">
+							<input
+								type="checkbox"
+								checked={settingSources.includes('project')}
+								onChange={() =>
+									setSettingSources((prev) =>
+										prev.includes('project')
+											? prev.filter((s) => s !== 'project')
+											: [...prev, 'project']
+									)
+								}
+								class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
+							/>
+							<span class="text-sm text-gray-200">Project settings + CLAUDE.md</span>
+							<span class="text-xs text-gray-500">(.claude/settings.json)</span>
+						</label>
+						<label class="flex items-center gap-2 cursor-pointer">
+							<input
+								type="checkbox"
+								checked={settingSources.includes('local')}
+								onChange={() =>
+									setSettingSources((prev) =>
+										prev.includes('local') ? prev.filter((s) => s !== 'local') : [...prev, 'local']
+									)
+								}
+								class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
+							/>
+							<span class="text-sm text-gray-200">Local settings</span>
+							<span class="text-xs text-gray-500">(.claude/settings.local.json)</span>
+						</label>
+					</div>
 				</div>
 
 				{/* Tools */}

--- a/packages/web/src/components/space/SpaceAgentEditor.tsx
+++ b/packages/web/src/components/space/SpaceAgentEditor.tsx
@@ -143,8 +143,13 @@ export function SpaceAgentEditor({
 	);
 	const [tools, setTools] = useState<string[]>(agent?.tools ?? [...TOOL_PRESETS['Full Coding']]);
 	const [customPrompt, setCustomPrompt] = useState(agent?.customPrompt ?? '');
+	const inheritedSettingSources = spaceStore.space.value?.settingSources ?? [
+		'user',
+		'project',
+		'local',
+	];
 	const [settingSources, setSettingSources] = useState<SettingSource[]>(
-		agent?.settingSources ?? ['user', 'project', 'local']
+		agent?.settingSources ?? inheritedSettingSources
 	);
 	const [activePreset, setActivePreset] = useState<string>(() => detectPreset(agent?.tools));
 	const [selectedTemplateName, setSelectedTemplateName] = useState<string>('');
@@ -224,7 +229,7 @@ export function SpaceAgentEditor({
 				tools: tools.length > 0 ? tools : undefined,
 				...(clearSettingSources ||
 				JSON.stringify(settingSources) !==
-					JSON.stringify(agent?.settingSources ?? ['user', 'project', 'local'])
+					JSON.stringify(agent?.settingSources ?? inheritedSettingSources)
 					? { settingSources: clearSettingSources ? null : settingSources }
 					: {}),
 			};

--- a/packages/web/src/components/space/SpaceAgentEditor.tsx
+++ b/packages/web/src/components/space/SpaceAgentEditor.tsx
@@ -144,7 +144,7 @@ export function SpaceAgentEditor({
 	const [tools, setTools] = useState<string[]>(agent?.tools ?? [...TOOL_PRESETS['Full Coding']]);
 	const [customPrompt, setCustomPrompt] = useState(agent?.customPrompt ?? '');
 	const [settingSources, setSettingSources] = useState<SettingSource[]>(
-		agent?.settingSources ?? ['user', 'project']
+		agent?.settingSources ?? ['user', 'project', 'local']
 	);
 	const [activePreset, setActivePreset] = useState<string>(() => detectPreset(agent?.tools));
 	const [selectedTemplateName, setSelectedTemplateName] = useState<string>('');
@@ -153,6 +153,8 @@ export function SpaceAgentEditor({
 	const [saving, setSaving] = useState(false);
 	const [errors, setErrors] = useState<Record<string, string>>({});
 	const [saveError, setSaveError] = useState<string | null>(null);
+	const hadExplicitSettingSources = isEdit && agent?.settingSources !== undefined;
+	const [settingSourcesTouched, setSettingSourcesTouched] = useState(false);
 
 	const applyPreset = (presetName: string) => {
 		setActivePreset(presetName);
@@ -221,7 +223,9 @@ export function SpaceAgentEditor({
 				model: model.trim(),
 				customPrompt: customPrompt || null,
 				tools: tools.length > 0 ? tools : undefined,
-				settingSources: settingSources.length > 0 ? settingSources : undefined,
+				...(hadExplicitSettingSources || settingSourcesTouched || !isEdit
+					? { settingSources: settingSources.length > 0 ? settingSources : undefined }
+					: {}),
 			};
 
 			if (isEdit && agent) {
@@ -375,11 +379,12 @@ export function SpaceAgentEditor({
 							<input
 								type="checkbox"
 								checked={settingSources.includes('user')}
-								onChange={() =>
+								onChange={() => {
 									setSettingSources((prev) =>
 										prev.includes('user') ? prev.filter((s) => s !== 'user') : [...prev, 'user']
-									)
-								}
+									);
+									setSettingSourcesTouched(true);
+								}}
 								class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
 							/>
 							<span class="text-sm text-gray-200">User settings</span>
@@ -389,13 +394,14 @@ export function SpaceAgentEditor({
 							<input
 								type="checkbox"
 								checked={settingSources.includes('project')}
-								onChange={() =>
+								onChange={() => {
 									setSettingSources((prev) =>
 										prev.includes('project')
 											? prev.filter((s) => s !== 'project')
 											: [...prev, 'project']
-									)
-								}
+									);
+									setSettingSourcesTouched(true);
+								}}
 								class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
 							/>
 							<span class="text-sm text-gray-200">Project settings + CLAUDE.md</span>
@@ -405,11 +411,12 @@ export function SpaceAgentEditor({
 							<input
 								type="checkbox"
 								checked={settingSources.includes('local')}
-								onChange={() =>
+								onChange={() => {
 									setSettingSources((prev) =>
 										prev.includes('local') ? prev.filter((s) => s !== 'local') : [...prev, 'local']
-									)
-								}
+									);
+									setSettingSourcesTouched(true);
+								}}
 								class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
 							/>
 							<span class="text-sm text-gray-200">Local settings</span>

--- a/packages/web/src/components/space/SpaceAgentEditor.tsx
+++ b/packages/web/src/components/space/SpaceAgentEditor.tsx
@@ -155,6 +155,7 @@ export function SpaceAgentEditor({
 	const [saveError, setSaveError] = useState<string | null>(null);
 	const hadExplicitSettingSources = isEdit && agent?.settingSources !== undefined;
 	const [settingSourcesTouched, setSettingSourcesTouched] = useState(false);
+	const [clearSettingSources, setClearSettingSources] = useState(false);
 
 	const applyPreset = (presetName: string) => {
 		setActivePreset(presetName);
@@ -372,6 +373,27 @@ export function SpaceAgentEditor({
 						Setting Sources
 						<span class="text-gray-500 text-xs ml-2">(optional)</span>
 					</label>
+					{hadExplicitSettingSources && !clearSettingSources && (
+						<button
+							type="button"
+							onClick={() => setClearSettingSources(true)}
+							class="text-xs text-blue-400 hover:text-blue-300 mb-1.5"
+						>
+							Clear override — use inherited defaults
+						</button>
+					)}
+					{clearSettingSources && (
+						<div class="flex items-center gap-2 mb-1.5">
+							<span class="text-xs text-gray-400">Will revert to inherited defaults on save.</span>
+							<button
+								type="button"
+								onClick={() => setClearSettingSources(false)}
+								class="text-xs text-blue-400 hover:text-blue-300"
+							>
+								Cancel
+							</button>
+						</div>
+					)}
 					<div class="space-y-1.5">
 						<label class="flex items-center gap-2 cursor-pointer">
 							<input
@@ -383,6 +405,7 @@ export function SpaceAgentEditor({
 									);
 									setSettingSourcesTouched(true);
 								}}
+								disabled={clearSettingSources}
 								class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
 							/>
 							<span class="text-sm text-gray-200">User settings</span>
@@ -400,6 +423,7 @@ export function SpaceAgentEditor({
 									);
 									setSettingSourcesTouched(true);
 								}}
+								disabled={clearSettingSources}
 								class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
 							/>
 							<span class="text-sm text-gray-200">Project settings + CLAUDE.md</span>
@@ -415,6 +439,7 @@ export function SpaceAgentEditor({
 									);
 									setSettingSourcesTouched(true);
 								}}
+								disabled={clearSettingSources}
 								class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
 							/>
 							<span class="text-sm text-gray-200">Local settings</span>

--- a/packages/web/src/components/space/SpaceAgentEditor.tsx
+++ b/packages/web/src/components/space/SpaceAgentEditor.tsx
@@ -153,8 +153,6 @@ export function SpaceAgentEditor({
 	const [saving, setSaving] = useState(false);
 	const [errors, setErrors] = useState<Record<string, string>>({});
 	const [saveError, setSaveError] = useState<string | null>(null);
-	const hadExplicitSettingSources = isEdit && agent?.settingSources !== undefined;
-	const [settingSourcesTouched, setSettingSourcesTouched] = useState(false);
 	const [clearSettingSources, setClearSettingSources] = useState(false);
 
 	const applyPreset = (presetName: string) => {
@@ -224,7 +222,9 @@ export function SpaceAgentEditor({
 				model: model.trim(),
 				customPrompt: customPrompt || null,
 				tools: tools.length > 0 ? tools : undefined,
-				...(hadExplicitSettingSources || settingSourcesTouched || clearSettingSources
+				...(clearSettingSources ||
+				JSON.stringify(settingSources) !==
+					JSON.stringify(agent?.settingSources ?? ['user', 'project', 'local'])
 					? { settingSources: clearSettingSources ? null : settingSources }
 					: {}),
 			};
@@ -375,7 +375,7 @@ export function SpaceAgentEditor({
 						Setting Sources
 						<span class="text-gray-500 text-xs ml-2">(optional)</span>
 					</label>
-					{hadExplicitSettingSources && !clearSettingSources && (
+					{isEdit && agent?.settingSources !== undefined && !clearSettingSources && (
 						<button
 							type="button"
 							onClick={() => setClearSettingSources(true)}
@@ -405,7 +405,6 @@ export function SpaceAgentEditor({
 									setSettingSources((prev) =>
 										prev.includes('user') ? prev.filter((s) => s !== 'user') : [...prev, 'user']
 									);
-									setSettingSourcesTouched(true);
 								}}
 								disabled={clearSettingSources}
 								class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
@@ -423,7 +422,6 @@ export function SpaceAgentEditor({
 											? prev.filter((s) => s !== 'project')
 											: [...prev, 'project']
 									);
-									setSettingSourcesTouched(true);
 								}}
 								disabled={clearSettingSources}
 								class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
@@ -439,7 +437,6 @@ export function SpaceAgentEditor({
 									setSettingSources((prev) =>
 										prev.includes('local') ? prev.filter((s) => s !== 'local') : [...prev, 'local']
 									);
-									setSettingSourcesTouched(true);
 								}}
 								disabled={clearSettingSources}
 								class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"

--- a/packages/web/src/components/space/SpaceAgentEditor.tsx
+++ b/packages/web/src/components/space/SpaceAgentEditor.tsx
@@ -223,9 +223,7 @@ export function SpaceAgentEditor({
 				model: model.trim(),
 				customPrompt: customPrompt || null,
 				tools: tools.length > 0 ? tools : undefined,
-				...(hadExplicitSettingSources || settingSourcesTouched || !isEdit
-					? { settingSources: settingSources.length > 0 ? settingSources : undefined }
-					: {}),
+				...(hadExplicitSettingSources || settingSourcesTouched ? { settingSources } : {}),
 			};
 
 			if (isEdit && agent) {

--- a/packages/web/src/components/space/SpaceAgentEditor.tsx
+++ b/packages/web/src/components/space/SpaceAgentEditor.tsx
@@ -143,7 +143,7 @@ export function SpaceAgentEditor({
 	);
 	const [tools, setTools] = useState<string[]>(agent?.tools ?? [...TOOL_PRESETS['Full Coding']]);
 	const [customPrompt, setCustomPrompt] = useState(agent?.customPrompt ?? '');
-	const inheritedSettingSources = spaceStore.space.value?.settingSources ?? [
+	const inheritedSettingSources = spaceStore.space?.value?.settingSources ?? [
 		'user',
 		'project',
 		'local',

--- a/packages/web/src/components/space/SpaceSettings.tsx
+++ b/packages/web/src/components/space/SpaceSettings.tsx
@@ -37,7 +37,6 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 		space.settingSources ?? ['user', 'project', 'local']
 	);
 	const hadExplicitSettingSources = space.settingSources !== undefined;
-	const [settingSourcesTouched, setSettingSourcesTouched] = useState(false);
 	const [clearSettingSources, setClearSettingSources] = useState(false);
 	const [saving, setSaving] = useState(false);
 	const [saveError, setSaveError] = useState<string | null>(null);
@@ -53,7 +52,6 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 		setAutonomyLevel(space.autonomyLevel ?? 1);
 		setDefaultModel(space.defaultModel);
 		setSettingSources(space.settingSources ?? ['user', 'project', 'local']);
-		setSettingSourcesTouched(false);
 		setClearSettingSources(false);
 		setSaveError(null);
 	}, [
@@ -100,7 +98,9 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 				backgroundContext: backgroundContext.trim() || undefined,
 				autonomyLevel,
 				defaultModel: defaultModel || null,
-				...(hadExplicitSettingSources || settingSourcesTouched || clearSettingSources
+				...(clearSettingSources ||
+				JSON.stringify(settingSources) !==
+					JSON.stringify(space.settingSources ?? ['user', 'project', 'local'])
 					? { settingSources: clearSettingSources ? null : settingSources }
 					: {}),
 			});
@@ -331,6 +331,29 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 									Which on-disk settings files agents in this Space load. Inherits the app-level
 									default when not set.
 								</p>
+								{hadExplicitSettingSources && !clearSettingSources && (
+									<button
+										type="button"
+										onClick={() => setClearSettingSources(true)}
+										class="text-xs text-blue-400 hover:text-blue-300 mb-1.5"
+									>
+										Clear override — use inherited defaults
+									</button>
+								)}
+								{clearSettingSources && (
+									<div class="flex items-center gap-2 mb-1.5">
+										<span class="text-xs text-gray-400">
+											Will revert to inherited defaults on save.
+										</span>
+										<button
+											type="button"
+											onClick={() => setClearSettingSources(false)}
+											class="text-xs text-blue-400 hover:text-blue-300"
+										>
+											Cancel
+										</button>
+									</div>
+								)}
 								<div class="space-y-1.5">
 									<label class="flex items-center gap-2 cursor-pointer">
 										<input
@@ -342,7 +365,6 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 														? prev.filter((s) => s !== 'user')
 														: [...prev, 'user']
 												);
-												setSettingSourcesTouched(true);
 											}}
 											disabled={clearSettingSources}
 											class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
@@ -360,7 +382,6 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 														? prev.filter((s) => s !== 'project')
 														: [...prev, 'project']
 												);
-												setSettingSourcesTouched(true);
 											}}
 											disabled={clearSettingSources}
 											class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
@@ -378,7 +399,6 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 														? prev.filter((s) => s !== 'local')
 														: [...prev, 'local']
 												);
-												setSettingSourcesTouched(true);
 											}}
 											disabled={clearSettingSources}
 											class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
@@ -404,7 +424,7 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 										setAutonomyLevel(space.autonomyLevel ?? 1);
 										setDefaultModel(space.defaultModel);
 										setSettingSources(space.settingSources ?? ['user', 'project', 'local']);
-										setSettingSourcesTouched(false);
+										setClearSettingSources(false);
 										setSaveError(null);
 									}}
 								>

--- a/packages/web/src/components/space/SpaceSettings.tsx
+++ b/packages/web/src/components/space/SpaceSettings.tsx
@@ -38,6 +38,7 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 	);
 	const hadExplicitSettingSources = space.settingSources !== undefined;
 	const [settingSourcesTouched, setSettingSourcesTouched] = useState(false);
+	const [clearSettingSources, setClearSettingSources] = useState(false);
 	const [saving, setSaving] = useState(false);
 	const [saveError, setSaveError] = useState<string | null>(null);
 	const [isArchiving, setIsArchiving] = useState(false);
@@ -53,6 +54,7 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 		setDefaultModel(space.defaultModel);
 		setSettingSources(space.settingSources ?? ['user', 'project', 'local']);
 		setSettingSourcesTouched(false);
+		setClearSettingSources(false);
 		setSaveError(null);
 	}, [
 		space.id,
@@ -73,7 +75,8 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 		autonomyLevel !== (space.autonomyLevel ?? 1) ||
 		defaultModel !== space.defaultModel ||
 		JSON.stringify(settingSources) !==
-			JSON.stringify(space.settingSources ?? ['user', 'project', 'local']);
+			JSON.stringify(space.settingSources ?? ['user', 'project', 'local']) ||
+		clearSettingSources;
 
 	async function handleSave(e: Event) {
 		e.preventDefault();
@@ -97,7 +100,9 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 				backgroundContext: backgroundContext.trim() || undefined,
 				autonomyLevel,
 				defaultModel: defaultModel || null,
-				...(hadExplicitSettingSources || settingSourcesTouched ? { settingSources } : {}),
+				...(hadExplicitSettingSources || settingSourcesTouched || clearSettingSources
+					? { settingSources: clearSettingSources ? null : settingSources }
+					: {}),
 			});
 			// Apply response directly to avoid stale-state from event spread-merge
 			// (undefined fields like defaultModel are dropped during JSON serialization)
@@ -339,6 +344,7 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 												);
 												setSettingSourcesTouched(true);
 											}}
+											disabled={clearSettingSources}
 											class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
 										/>
 										<span class="text-sm text-gray-200">User settings</span>
@@ -356,6 +362,7 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 												);
 												setSettingSourcesTouched(true);
 											}}
+											disabled={clearSettingSources}
 											class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
 										/>
 										<span class="text-sm text-gray-200">Project settings + CLAUDE.md</span>
@@ -373,6 +380,7 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 												);
 												setSettingSourcesTouched(true);
 											}}
+											disabled={clearSettingSources}
 											class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
 										/>
 										<span class="text-sm text-gray-200">Local settings</span>

--- a/packages/web/src/components/space/SpaceSettings.tsx
+++ b/packages/web/src/components/space/SpaceSettings.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useState, useEffect } from 'preact/hooks';
-import type { Space, SpaceExportBundle, SpaceAutonomyLevel } from '@neokai/shared';
+import type { Space, SpaceExportBundle, SpaceAutonomyLevel, SettingSource } from '@neokai/shared';
 import { connectionManager } from '../../lib/connection-manager.ts';
 import { spaceStore } from '../../lib/space-store.ts';
 import { toast } from '../../lib/toast.ts';
@@ -33,6 +33,9 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 	const [backgroundContext, setBackgroundContext] = useState(space.backgroundContext ?? '');
 	const [autonomyLevel, setAutonomyLevel] = useState<SpaceAutonomyLevel>(space.autonomyLevel ?? 1);
 	const [defaultModel, setDefaultModel] = useState<string | undefined>(space.defaultModel);
+	const [settingSources, setSettingSources] = useState<SettingSource[]>(
+		space.settingSources ?? ['user', 'project']
+	);
 	const [saving, setSaving] = useState(false);
 	const [saveError, setSaveError] = useState<string | null>(null);
 	const [isArchiving, setIsArchiving] = useState(false);
@@ -46,6 +49,8 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 		setBackgroundContext(space.backgroundContext ?? '');
 		setAutonomyLevel(space.autonomyLevel ?? 1);
 		setDefaultModel(space.defaultModel);
+		setSettingSources(space.settingSources ?? ['user', 'project']);
+		setSettingSources(space.settingSources ?? ['user', 'project']);
 		setSaveError(null);
 	}, [
 		space.id,
@@ -55,6 +60,7 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 		space.backgroundContext,
 		space.autonomyLevel,
 		space.defaultModel,
+		space.settingSources,
 	]);
 
 	const isDirty =
@@ -63,7 +69,8 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 		instructions !== (space.instructions ?? '') ||
 		backgroundContext !== (space.backgroundContext ?? '') ||
 		autonomyLevel !== (space.autonomyLevel ?? 1) ||
-		defaultModel !== space.defaultModel;
+		defaultModel !== space.defaultModel ||
+		JSON.stringify(settingSources) !== JSON.stringify(space.settingSources ?? ['user', 'project']);
 
 	async function handleSave(e: Event) {
 		e.preventDefault();
@@ -87,6 +94,7 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 				backgroundContext: backgroundContext.trim() || undefined,
 				autonomyLevel,
 				defaultModel: defaultModel || null,
+				settingSources,
 			});
 			// Apply response directly to avoid stale-state from event spread-merge
 			// (undefined fields like defaultModel are dropped during JSON serialization)
@@ -308,6 +316,64 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 								testId="default-model-select"
 								className="w-full bg-dark-800 border border-dark-700 rounded-lg px-3 py-2 text-sm text-gray-100 focus:outline-none focus:border-blue-500"
 							/>
+
+							<div>
+								<label class="block text-xs font-medium text-gray-400 mb-1">Setting Sources</label>
+								<p class="text-xs text-gray-500 mb-2">
+									Which on-disk settings files agents in this Space load. Inherits the app-level
+									default when not set.
+								</p>
+								<div class="space-y-1.5">
+									<label class="flex items-center gap-2 cursor-pointer">
+										<input
+											type="checkbox"
+											checked={settingSources.includes('user')}
+											onChange={() =>
+												setSettingSources((prev) =>
+													prev.includes('user')
+														? prev.filter((s) => s !== 'user')
+														: [...prev, 'user']
+												)
+											}
+											class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
+										/>
+										<span class="text-sm text-gray-200">User settings</span>
+										<span class="text-xs text-gray-500">(~/.claude/settings.json)</span>
+									</label>
+									<label class="flex items-center gap-2 cursor-pointer">
+										<input
+											type="checkbox"
+											checked={settingSources.includes('project')}
+											onChange={() =>
+												setSettingSources((prev) =>
+													prev.includes('project')
+														? prev.filter((s) => s !== 'project')
+														: [...prev, 'project']
+												)
+											}
+											class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
+										/>
+										<span class="text-sm text-gray-200">Project settings + CLAUDE.md</span>
+										<span class="text-xs text-gray-500">(.claude/settings.json)</span>
+									</label>
+									<label class="flex items-center gap-2 cursor-pointer">
+										<input
+											type="checkbox"
+											checked={settingSources.includes('local')}
+											onChange={() =>
+												setSettingSources((prev) =>
+													prev.includes('local')
+														? prev.filter((s) => s !== 'local')
+														: [...prev, 'local']
+												)
+											}
+											class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
+										/>
+										<span class="text-sm text-gray-200">Local settings</span>
+										<span class="text-xs text-gray-500">(.claude/settings.local.json)</span>
+									</label>
+								</div>
+							</div>
 						</div>
 
 						{isDirty && (
@@ -323,6 +389,7 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 										setBackgroundContext(space.backgroundContext ?? '');
 										setAutonomyLevel(space.autonomyLevel ?? 1);
 										setDefaultModel(space.defaultModel);
+										setSettingSources(space.settingSources ?? ['user', 'project']);
 										setSaveError(null);
 									}}
 								>

--- a/packages/web/src/components/space/SpaceSettings.tsx
+++ b/packages/web/src/components/space/SpaceSettings.tsx
@@ -10,6 +10,7 @@
 import { useState, useEffect } from 'preact/hooks';
 import type { Space, SpaceExportBundle, SpaceAutonomyLevel, SettingSource } from '@neokai/shared';
 import { connectionManager } from '../../lib/connection-manager.ts';
+import { globalSettings } from '../../lib/state.ts';
 import { spaceStore } from '../../lib/space-store.ts';
 import { toast } from '../../lib/toast.ts';
 import { cn } from '../../lib/utils.ts';
@@ -25,6 +26,10 @@ interface SpaceSettingsProps {
 	space: Space;
 }
 
+function getInheritedSettingSources(): SettingSource[] {
+	return globalSettings.value?.settingSources ?? ['user', 'project', 'local'];
+}
+
 export function SpaceSettings({ space }: SpaceSettingsProps) {
 	// Edit state
 	const [name, setName] = useState(space.name);
@@ -34,7 +39,7 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 	const [autonomyLevel, setAutonomyLevel] = useState<SpaceAutonomyLevel>(space.autonomyLevel ?? 1);
 	const [defaultModel, setDefaultModel] = useState<string | undefined>(space.defaultModel);
 	const [settingSources, setSettingSources] = useState<SettingSource[]>(
-		space.settingSources ?? ['user', 'project', 'local']
+		space.settingSources ?? getInheritedSettingSources()
 	);
 	const hadExplicitSettingSources = space.settingSources !== undefined;
 	const [clearSettingSources, setClearSettingSources] = useState(false);
@@ -51,7 +56,7 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 		setBackgroundContext(space.backgroundContext ?? '');
 		setAutonomyLevel(space.autonomyLevel ?? 1);
 		setDefaultModel(space.defaultModel);
-		setSettingSources(space.settingSources ?? ['user', 'project', 'local']);
+		setSettingSources(space.settingSources ?? getInheritedSettingSources());
 		setClearSettingSources(false);
 		setSaveError(null);
 	}, [
@@ -73,7 +78,7 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 		autonomyLevel !== (space.autonomyLevel ?? 1) ||
 		defaultModel !== space.defaultModel ||
 		JSON.stringify(settingSources) !==
-			JSON.stringify(space.settingSources ?? ['user', 'project', 'local']) ||
+			JSON.stringify(space.settingSources ?? getInheritedSettingSources()) ||
 		clearSettingSources;
 
 	async function handleSave(e: Event) {
@@ -100,7 +105,7 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 				defaultModel: defaultModel || null,
 				...(clearSettingSources ||
 				JSON.stringify(settingSources) !==
-					JSON.stringify(space.settingSources ?? ['user', 'project', 'local'])
+					JSON.stringify(space.settingSources ?? getInheritedSettingSources())
 					? { settingSources: clearSettingSources ? null : settingSources }
 					: {}),
 			});
@@ -423,7 +428,7 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 										setBackgroundContext(space.backgroundContext ?? '');
 										setAutonomyLevel(space.autonomyLevel ?? 1);
 										setDefaultModel(space.defaultModel);
-										setSettingSources(space.settingSources ?? ['user', 'project', 'local']);
+										setSettingSources(space.settingSources ?? getInheritedSettingSources());
 										setClearSettingSources(false);
 										setSaveError(null);
 									}}

--- a/packages/web/src/components/space/SpaceSettings.tsx
+++ b/packages/web/src/components/space/SpaceSettings.tsx
@@ -34,8 +34,10 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 	const [autonomyLevel, setAutonomyLevel] = useState<SpaceAutonomyLevel>(space.autonomyLevel ?? 1);
 	const [defaultModel, setDefaultModel] = useState<string | undefined>(space.defaultModel);
 	const [settingSources, setSettingSources] = useState<SettingSource[]>(
-		space.settingSources ?? ['user', 'project']
+		space.settingSources ?? ['user', 'project', 'local']
 	);
+	const hadExplicitSettingSources = space.settingSources !== undefined;
+	const [settingSourcesTouched, setSettingSourcesTouched] = useState(false);
 	const [saving, setSaving] = useState(false);
 	const [saveError, setSaveError] = useState<string | null>(null);
 	const [isArchiving, setIsArchiving] = useState(false);
@@ -49,8 +51,8 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 		setBackgroundContext(space.backgroundContext ?? '');
 		setAutonomyLevel(space.autonomyLevel ?? 1);
 		setDefaultModel(space.defaultModel);
-		setSettingSources(space.settingSources ?? ['user', 'project']);
-		setSettingSources(space.settingSources ?? ['user', 'project']);
+		setSettingSources(space.settingSources ?? ['user', 'project', 'local']);
+		setSettingSourcesTouched(false);
 		setSaveError(null);
 	}, [
 		space.id,
@@ -70,7 +72,8 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 		backgroundContext !== (space.backgroundContext ?? '') ||
 		autonomyLevel !== (space.autonomyLevel ?? 1) ||
 		defaultModel !== space.defaultModel ||
-		JSON.stringify(settingSources) !== JSON.stringify(space.settingSources ?? ['user', 'project']);
+		JSON.stringify(settingSources) !==
+			JSON.stringify(space.settingSources ?? ['user', 'project', 'local']);
 
 	async function handleSave(e: Event) {
 		e.preventDefault();
@@ -94,7 +97,7 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 				backgroundContext: backgroundContext.trim() || undefined,
 				autonomyLevel,
 				defaultModel: defaultModel || null,
-				settingSources,
+				...(hadExplicitSettingSources || settingSourcesTouched ? { settingSources } : {}),
 			});
 			// Apply response directly to avoid stale-state from event spread-merge
 			// (undefined fields like defaultModel are dropped during JSON serialization)
@@ -328,13 +331,14 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 										<input
 											type="checkbox"
 											checked={settingSources.includes('user')}
-											onChange={() =>
+											onChange={() => {
 												setSettingSources((prev) =>
 													prev.includes('user')
 														? prev.filter((s) => s !== 'user')
 														: [...prev, 'user']
-												)
-											}
+												);
+												setSettingSourcesTouched(true);
+											}}
 											class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
 										/>
 										<span class="text-sm text-gray-200">User settings</span>
@@ -344,13 +348,14 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 										<input
 											type="checkbox"
 											checked={settingSources.includes('project')}
-											onChange={() =>
+											onChange={() => {
 												setSettingSources((prev) =>
 													prev.includes('project')
 														? prev.filter((s) => s !== 'project')
 														: [...prev, 'project']
-												)
-											}
+												);
+												setSettingSourcesTouched(true);
+											}}
 											class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
 										/>
 										<span class="text-sm text-gray-200">Project settings + CLAUDE.md</span>
@@ -360,13 +365,14 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 										<input
 											type="checkbox"
 											checked={settingSources.includes('local')}
-											onChange={() =>
+											onChange={() => {
 												setSettingSources((prev) =>
 													prev.includes('local')
 														? prev.filter((s) => s !== 'local')
 														: [...prev, 'local']
-												)
-											}
+												);
+												setSettingSourcesTouched(true);
+											}}
 											class="w-4 h-4 rounded border-gray-600 text-blue-500 focus:ring-blue-500 focus:ring-offset-dark-900"
 										/>
 										<span class="text-sm text-gray-200">Local settings</span>
@@ -389,7 +395,8 @@ export function SpaceSettings({ space }: SpaceSettingsProps) {
 										setBackgroundContext(space.backgroundContext ?? '');
 										setAutonomyLevel(space.autonomyLevel ?? 1);
 										setDefaultModel(space.defaultModel);
-										setSettingSources(space.settingSources ?? ['user', 'project']);
+										setSettingSources(space.settingSources ?? ['user', 'project', 'local']);
+										setSettingSourcesTouched(false);
 										setSaveError(null);
 									}}
 								>


### PR DESCRIPTION
- Default settingSources to ['user', 'project'] (was hardcoded []) so CLAUDE.md and user/project settings are loaded by the SDK.
- Keep strictMcpConfig: true unconditional — MCP servers remain fully controlled by NeoKai's unified registry.
- Add setting_sources columns to spaces and space_agents tables (migrations 118/119).
- Thread settingSources through AgentSessionInit → SessionConfig → QueryOptionsBuilder.
- Add UI toggles for settingSources in GeneralSettings, SpaceSettings, SpaceAgentEditor, and ToolsModal.
- Update test schemas and expectations to match the new default.