### PR TITLE
feat: task observability — list_tasks, get_task, list_audit_entries tools and MCP audit trail

### DIFF
--- a/packages/daemon/src/lib/db-query/scope-config.ts
+++ b/packages/daemon/src/lib/db-query/scope-config.ts
@@ -313,6 +313,13 @@ const SPACE_SCOPE_TABLES: ScopeTableConfig[] = [
 		description:
 			'JSON-serialised cache of git-derived artifact data (gate diffs, commit log, per-file diffs) populated by background sync jobs and served to the TaskArtifactsPanel.',
 	},
+	{
+		tableName: 'mcp_audit_log',
+		scopeColumn: 'space_id',
+		blacklistedColumns: [],
+		description:
+			'Audit trail of MCP write operations (create_task, approve_task, send_message, save_artifact) with agent name, session ID, tool name, and parameters.',
+	},
 	// ── Main-DB tables exposed with space-scoped filtering via session ID prefix ──
 	{
 		tableName: 'sessions',

--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -58,7 +58,7 @@ export function setupSpaceTaskHandlers(
 		}
 
 		const taskManager = taskManagerFactory(params.spaceId);
-		const { spaceId, draft, ...rest } = params;
+		const { spaceId, draft, createdBy: _cb, createdBySession: _cbs, ...rest } = params;
 
 		// The draft flag is an alias for status: 'draft'. Reject contradictory
 		// input instead of silently allowing status to override draft: true.

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -22,6 +22,7 @@ import type { ChannelCycleRepository } from '../../../storage/repositories/chann
 import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
 import type { PendingAgentMessageRepository } from '../../../storage/repositories/pending-agent-message-repository';
 import type { ReactiveDatabase } from '../../../storage/reactive-database';
+import { McpAuditLogRepository } from '../../../storage/repositories/mcp-audit-log-repository';
 import type { NotificationSink } from './notification-sink';
 import type { TaskAgentManager } from './task-agent-manager';
 import type { SessionManager } from '../../session-manager';
@@ -108,6 +109,8 @@ export class SpaceRuntimeService {
 	private taskAgentManager: TaskAgentManager | null = null;
 	/** Resolved nodeExecutionRepo — created from db if not provided in config. */
 	private readonly nodeExecutionRepo: NodeExecutionRepository;
+	/** Audit log repository for MCP write operations. */
+	private readonly auditLogRepo: McpAuditLogRepository;
 	/** Stores db-query server instances per space for cleanup on stop. */
 	private readonly spaceDbQueryServers = new Map<string, DbQueryMcpServer>();
 	/**
@@ -141,6 +144,7 @@ export class SpaceRuntimeService {
 		// Ensure nodeExecutionRepo is available — create from db if not provided.
 		this.nodeExecutionRepo =
 			this.config.nodeExecutionRepo ?? new NodeExecutionRepository(this.config.db);
+		this.auditLogRepo = new McpAuditLogRepository(this.config.db);
 		this.runtime = new SpaceRuntime({
 			...config,
 			nodeExecutionRepo: this.nodeExecutionRepo,
@@ -665,6 +669,8 @@ export class SpaceRuntimeService {
 			// means gate writer-authorization paths that rely on matching the
 			// writer name fall through to the autonomy path, which is the
 			// correct gating behavior for non-space-agent callers.
+			mySessionId: session.id,
+			auditLogRepo: this.auditLogRepo,
 		});
 
 		const additional: Record<string, McpServerConfig> = {
@@ -756,6 +762,8 @@ export class SpaceRuntimeService {
 				return s?.autonomyLevel ?? 1;
 			},
 			myAgentName: 'space-agent',
+			mySessionId: spaceChatSessionId,
+			auditLogRepo: this.auditLogRepo,
 		});
 
 		// Create a space-scoped db-query server if dbPath is configured.

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -71,6 +71,7 @@ import type { WorkflowRunArtifactRepository } from '../../../storage/repositorie
 import type { ChannelCycleRepository } from '../../../storage/repositories/channel-cycle-repository';
 import type { PendingAgentMessageRepository } from '../../../storage/repositories/pending-agent-message-repository';
 import type { ToolContinuationRecoveryRepository } from '../../../storage/repositories/tool-continuation-recovery-repository';
+import { McpAuditLogRepository } from '../../../storage/repositories/mcp-audit-log-repository';
 import type { SpaceWorktreeManager } from '../managers/space-worktree-manager';
 import type { SubSessionMemberInfo } from '../tools/task-agent-tools';
 import { createTaskAgentMcpServer } from '../tools/task-agent-tools';
@@ -310,6 +311,8 @@ export class TaskAgentManager {
 	 * Closed when the task agent session is cleaned up.
 	 */
 	private taskDbQueryServers = new Map<string, DbQueryMcpServer>();
+	/** Audit log repository for MCP write operations. */
+	private readonly auditLogRepo: McpAuditLogRepository;
 
 	/**
 	 * Eager sub-session index: taskId → (agentName → sessionId).
@@ -333,6 +336,7 @@ export class TaskAgentManager {
 	private taskArchiveListenerUnsub: (() => void) | null = null;
 
 	constructor(private readonly config: TaskAgentManagerConfig) {
+		this.auditLogRepo = new McpAuditLogRepository(this.config.db.getDatabase());
 		this.subscribeToTaskArchiveEvents();
 	}
 
@@ -4431,6 +4435,8 @@ export class TaskAgentManager {
 					preferredWorkflowId: args.workflow_id ?? null,
 					dependsOn: args.depends_on,
 					status: args.draft ? 'draft' : undefined,
+					createdBy: agentName,
+					createdBySession: subSessionId,
 				});
 				return jsonResult({ success: true, task });
 			} catch (err) {
@@ -4469,6 +4475,8 @@ export class TaskAgentManager {
 			onMarkComplete,
 			onCreateStandaloneTask,
 			artifactRepo: this.config.artifactRepo,
+			taskRepo: this.config.taskRepo,
+			auditLogRepo: this.auditLogRepo,
 			getSpaceAutonomyLevel: async (sid) => {
 				const s = await spaceManager.getSpace(sid);
 				return s?.autonomyLevel ?? 1;

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -782,6 +782,8 @@ export class TaskAgentManager {
 					return s?.autonomyLevel ?? 1;
 				},
 				myAgentName: 'task-agent',
+				mySessionId: sessionId,
+				auditLogRepo: this.auditLogRepo,
 			});
 			taskMcpServers['space-agent-tools'] = spaceAgentMcpServer as unknown as McpServerConfig;
 
@@ -3173,6 +3175,8 @@ export class TaskAgentManager {
 				return s?.autonomyLevel ?? 1;
 			},
 			myAgentName: 'task-agent',
+			mySessionId: sessionId,
+			auditLogRepo: this.auditLogRepo,
 		});
 		rehydrateMcpServers['space-agent-tools'] =
 			rehydrateSpaceAgentMcpServer as unknown as McpServerConfig;
@@ -4177,6 +4181,8 @@ export class TaskAgentManager {
 				return s?.autonomyLevel ?? 1;
 			},
 			myAgentName: ctx.agentName,
+			mySessionId: ctx.subSessionId,
+			auditLogRepo: this.auditLogRepo,
 			// Wire restore_node_agent so it is callable even when node-agent is
 			// missing. The closure captures the rebuild-time values of taskId,
 			// subSessionId, agentName, etc. which are stable for this session.

--- a/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
@@ -224,6 +224,34 @@ export const GetTaskSchema = z.object({
 export type GetTaskInput = z.infer<typeof GetTaskSchema>;
 
 // ---------------------------------------------------------------------------
+// list_audit_entries
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `list_audit_entries` input.
+ * Lists MCP audit log entries for the current space, filtered by task or session.
+ */
+export const ListAuditEntriesSchema = z.object({
+	task_id: z.string().describe('Filter by task ID').optional(),
+	session_id: z.string().describe('Filter by session ID').optional(),
+	limit: z
+		.number()
+		.int()
+		.min(1)
+		.max(100)
+		.describe('Maximum number of entries to return (1-100, default 20)')
+		.optional(),
+	offset: z
+		.number()
+		.int()
+		.min(0)
+		.describe('Number of entries to skip for pagination (default 0)')
+		.optional(),
+});
+
+export type ListAuditEntriesInput = z.infer<typeof ListAuditEntriesSchema>;
+
+// ---------------------------------------------------------------------------
 // create_standalone_task
 // ---------------------------------------------------------------------------
 
@@ -393,6 +421,7 @@ export const NODE_AGENT_TOOL_SCHEMAS = {
 	restore_node_agent: RestoreNodeAgentSchema,
 	list_tasks: ListTasksSchema,
 	get_task: GetTaskSchema,
+	list_audit_entries: ListAuditEntriesSchema,
 } as const;
 
 export type NodeAgentToolName = keyof typeof NODE_AGENT_TOOL_SCHEMAS;

--- a/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
@@ -160,6 +160,57 @@ export const SaveArtifactSchema = z.object({
 export type SaveArtifactInput = z.infer<typeof SaveArtifactSchema>;
 
 // ---------------------------------------------------------------------------
+// list_tasks
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `list_tasks` input.
+ * Lists tasks in the current space. Filterable by status.
+ */
+export const ListTasksSchema = z.object({
+	status: z
+		.enum([
+			'draft',
+			'open',
+			'in_progress',
+			'review',
+			'approved',
+			'done',
+			'blocked',
+			'cancelled',
+			'archived',
+		])
+		.describe('Filter by task status')
+		.optional(),
+	compact: z
+		.boolean()
+		.describe(
+			'Return only summary fields (id, title, status, priority, createdAt) to reduce payload size'
+		)
+		.optional(),
+});
+
+export type ListTasksInput = z.infer<typeof ListTasksSchema>;
+
+// ---------------------------------------------------------------------------
+// get_task
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema for `get_task` input.
+ * Retrieves detailed information about a specific task by UUID or numeric task number.
+ */
+export const GetTaskSchema = z.object({
+	task_id: z.string().describe('UUID of the task to retrieve').optional(),
+	task_number: z
+		.number()
+		.describe('Numeric task ID (e.g. 5 for task #5) — preferred over task_id')
+		.optional(),
+});
+
+export type GetTaskInput = z.infer<typeof GetTaskSchema>;
+
+// ---------------------------------------------------------------------------
 // create_standalone_task
 // ---------------------------------------------------------------------------
 
@@ -327,6 +378,8 @@ export const NODE_AGENT_TOOL_SCHEMAS = {
 	list_gates: ListGatesSchema,
 	read_gate: ReadGateSchema,
 	restore_node_agent: RestoreNodeAgentSchema,
+	list_tasks: ListTasksSchema,
+	get_task: GetTaskSchema,
 } as const;
 
 export type NodeAgentToolName = keyof typeof NODE_AGENT_TOOL_SCHEMAS;

--- a/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tool-schemas.ts
@@ -188,6 +188,19 @@ export const ListTasksSchema = z.object({
 			'Return only summary fields (id, title, status, priority, createdAt) to reduce payload size'
 		)
 		.optional(),
+	limit: z
+		.number()
+		.int()
+		.min(1)
+		.max(100)
+		.describe('Maximum number of tasks to return (1-100, default 20)')
+		.optional(),
+	offset: z
+		.number()
+		.int()
+		.min(0)
+		.describe('Number of tasks to skip for pagination (default 0)')
+		.optional(),
 });
 
 export type ListTasksInput = z.infer<typeof ListTasksSchema>;

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -87,6 +87,22 @@ import type { SpaceTaskRepository } from '../../../storage/repositories/space-ta
 import type { SpaceTask } from '@neokai/shared';
 import type { McpAuditLogRepository } from '../../../storage/repositories/mcp-audit-log-repository';
 
+/**
+ * Decode the JSON payload from a ToolResult created by jsonResult().
+ * Returns the parsed object or null if parsing fails.
+ */
+function decodeToolResultPayload(result: ToolResult): Record<string, unknown> | null {
+	try {
+		const text = result.content?.[0]?.text;
+		if (typeof text === 'string') {
+			return JSON.parse(text) as Record<string, unknown>;
+		}
+	} catch {
+		// Ignore parse errors — caller falls back to no-audit.
+	}
+	return null;
+}
+
 // Re-export for consumers that want the shared type
 export type { ToolResult };
 
@@ -1100,9 +1116,10 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 				});
 			}
 			const result = await config.onCreateStandaloneTask(args);
-			// Only audit after successful creation; stamp the new task ID, not the current session task.
-			const createdTask = result.task as { id: string } | undefined;
-			if (result.success && createdTask?.id) {
+			// Decode the JSON payload from the ToolResult content to check success and extract the task ID.
+			const payload = decodeToolResultPayload(result);
+			const createdTask = payload?.task as { id: string } | undefined;
+			if (payload?.success && createdTask?.id) {
 				logAudit(
 					'create_standalone_task',
 					{
@@ -1114,6 +1131,21 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 					},
 					createdTask.id
 				);
+			}
+			return result;
+		},
+
+		async approve_task(args: ApproveTaskInput): Promise<ToolResult> {
+			if (!config.onApproveTask) {
+				return jsonResult({
+					success: false,
+					error: 'approve_task is not available in this node-agent session.',
+				});
+			}
+			const result = await config.onApproveTask(args);
+			const payload = decodeToolResultPayload(result);
+			if (payload?.success) {
+				logAudit('approve_task', {}, config.taskId);
 			}
 			return result;
 		},
@@ -1350,7 +1382,7 @@ export function createNodeAgentMcpServer(config: NodeAgentToolsConfig) {
 							'runs and resolves the terminal status. Use this as your final action when you are ' +
 							'authorized to self-close; otherwise use submit_for_approval.',
 						ApproveTaskSchema.shape,
-						(args) => config.onApproveTask!(args)
+						(args) => handlers.approve_task(args)
 					),
 				]
 			: []),

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -1164,11 +1164,13 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 				return jsonResult({ success: false, error: 'Task repository not available.' });
 			}
 			try {
+				const limit = Math.min(args.limit ?? 20, 100);
+				const offset = args.offset ?? 0;
 				let tasks: SpaceTask[];
 				if (args.status) {
-					tasks = taskRepo.listByStatus(spaceId, args.status);
+					tasks = taskRepo.listByStatus(spaceId, args.status, limit, offset);
 				} else {
-					tasks = taskRepo.listBySpace(spaceId);
+					tasks = taskRepo.listBySpace(spaceId, false, limit, offset);
 				}
 				if (args.compact) {
 					const compactTasks = tasks.map((t) => ({

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -1155,6 +1155,10 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 				task = taskRepo.getTaskByNumber(spaceId, args.task_number);
 			} else if (args.task_id) {
 				task = taskRepo.getTask(args.task_id);
+				// Scope by space: getTask resolves by UUID only, so verify ownership.
+				if (task && task.spaceId !== spaceId) {
+					task = null;
+				}
 			} else {
 				return jsonResult({
 					success: false,

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -1166,6 +1166,7 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 			try {
 				const limit = Math.min(args.limit ?? 20, 100);
 				const offset = args.offset ?? 0;
+				const total = taskRepo.countBySpace(spaceId, args.status ?? undefined, false);
 				let tasks: SpaceTask[];
 				if (args.status) {
 					tasks = taskRepo.listByStatus(spaceId, args.status, limit, offset);
@@ -1180,9 +1181,14 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 						priority: t.priority,
 						createdAt: t.createdAt,
 					}));
-					return jsonResult({ success: true, total: compactTasks.length, tasks: compactTasks });
+					return jsonResult({
+						success: true,
+						total,
+						tasks: compactTasks,
+						has_more: offset + tasks.length < total,
+					});
 				}
-				return jsonResult({ success: true, total: tasks.length, tasks });
+				return jsonResult({ success: true, total, tasks, has_more: offset + tasks.length < total });
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
 				return jsonResult({ success: false, error: message });

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -1095,14 +1095,20 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 					error: 'create_standalone_task is not available in this node-agent session.',
 				});
 			}
-			logAudit('create_standalone_task', {
-				title: args.title,
-				priority: args.priority,
-				workflow_id: args.workflow_id,
-				depends_on: args.depends_on,
-				draft: args.draft,
-			});
-			return config.onCreateStandaloneTask(args);
+			const result = await config.onCreateStandaloneTask(args);
+			// Only audit after successful creation; stamp the new task ID, not the current session task.
+			const createdTask = result.task as { id: string } | undefined;
+			if (result.success && createdTask?.id) {
+				logAudit('create_standalone_task', {
+					title: args.title,
+					taskId: createdTask.id,
+					priority: args.priority,
+					workflow_id: args.workflow_id,
+					depends_on: args.depends_on,
+					draft: args.draft,
+				});
+			}
+			return result;
 		},
 
 		// ── Task read tools ──────────────────────────────────────────────

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -67,6 +67,7 @@ import {
 	RestoreNodeAgentSchema,
 	ListTasksSchema,
 	GetTaskSchema,
+	ListAuditEntriesSchema,
 } from './node-agent-tool-schemas';
 import type {
 	ListPeersInput,
@@ -81,6 +82,7 @@ import type {
 	RestoreNodeAgentInput,
 	ListTasksInput,
 	GetTaskInput,
+	ListAuditEntriesInput,
 } from './node-agent-tool-schemas';
 import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
@@ -1225,6 +1227,50 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 			return jsonResult({ success: true, task });
 		},
 
+		/**
+		 * List MCP audit log entries for this space, filtered by task or session.
+		 *
+		 * Returns entries ordered by timestamp descending (newest first).
+		 * Use this to inspect the audit trail of tool operations performed
+		 * by agents in this workflow.
+		 */
+		async list_audit_entries(args: ListAuditEntriesInput): Promise<ToolResult> {
+			const { auditLogRepo } = config;
+			if (!auditLogRepo) {
+				return jsonResult({ success: false, error: 'Audit log repository not available.' });
+			}
+			try {
+				const limit = Math.min(args.limit ?? 20, 100);
+				const offset = args.offset ?? 0;
+				let entries;
+				if (args.task_id) {
+					entries = auditLogRepo.listByTask(args.task_id, limit, offset);
+				} else if (args.session_id) {
+					entries = auditLogRepo.listBySession(args.session_id, limit, offset);
+				} else {
+					entries = auditLogRepo.listBySpace(spaceId, limit, offset);
+				}
+				return jsonResult({
+					success: true,
+					entries: entries.map((e) => ({
+						id: e.id,
+						timestamp: e.timestamp,
+						agentName: e.agentName,
+						sessionId: e.sessionId,
+						toolName: e.toolName,
+						paramsSummary: e.paramsSummary,
+						spaceId: e.spaceId,
+						taskId: e.taskId,
+						workflowRunId: e.workflowRunId,
+					})),
+					total: entries.length,
+				});
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
 		// ── Self-heal ────────────────────────────────────────────────────
 
 		/**
@@ -1434,9 +1480,21 @@ export function createNodeAgentMcpServer(config: NodeAgentToolsConfig) {
 					tool(
 						'get_task',
 						'Retrieve detailed information about a specific task including its status, result, and metadata. ' +
-							'Provide either task_id (UUID) or task_number (numeric, e.g. 5 for task #5).',
+							'Provide either task_number (numeric ID like 5 for task #5, preferred) or task_id (UUID).',
 						GetTaskSchema.shape,
 						(args) => handlers.get_task(args)
+					),
+				]
+			: []),
+		...(config.auditLogRepo
+			? [
+					tool(
+						'list_audit_entries',
+						'List MCP audit log entries for this space. Filter by task_id or session_id. ' +
+							'Returns entries ordered by timestamp descending (newest first). ' +
+							'Use this to inspect the audit trail of tool operations performed by agents.',
+						ListAuditEntriesSchema.shape,
+						(args) => handlers.list_audit_entries(args)
 					),
 				]
 			: []),

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -1243,12 +1243,16 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 				const limit = Math.min(args.limit ?? 20, 100);
 				const offset = args.offset ?? 0;
 				let entries;
+				let total: number;
 				if (args.task_id) {
 					entries = auditLogRepo.listByTask(args.task_id, limit, offset);
+					total = auditLogRepo.countByTask(args.task_id);
 				} else if (args.session_id) {
 					entries = auditLogRepo.listBySession(args.session_id, limit, offset);
+					total = auditLogRepo.countBySession(args.session_id);
 				} else {
 					entries = auditLogRepo.listBySpace(spaceId, limit, offset);
+					total = auditLogRepo.countBySpace(spaceId);
 				}
 				return jsonResult({
 					success: true,
@@ -1263,7 +1267,8 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 						taskId: e.taskId,
 						workflowRunId: e.workflowRunId,
 					})),
-					total: entries.length,
+					total,
+					has_more: offset + entries.length < total,
 				});
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -278,7 +278,11 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 	);
 
 	/** Helper to log MCP write operations to the audit log. */
-	function logAudit(toolName: string, paramsSummary: Record<string, unknown>): void {
+	function logAudit(
+		toolName: string,
+		paramsSummary: Record<string, unknown>,
+		taskId?: string
+	): void {
 		if (config.auditLogRepo) {
 			try {
 				config.auditLogRepo.createEntry({
@@ -287,7 +291,7 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 					toolName,
 					paramsSummary: JSON.stringify(paramsSummary),
 					spaceId,
-					taskId: config.taskId,
+					taskId: taskId ?? config.taskId,
 					workflowRunId,
 				});
 			} catch {
@@ -1099,14 +1103,17 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 			// Only audit after successful creation; stamp the new task ID, not the current session task.
 			const createdTask = result.task as { id: string } | undefined;
 			if (result.success && createdTask?.id) {
-				logAudit('create_standalone_task', {
-					title: args.title,
-					taskId: createdTask.id,
-					priority: args.priority,
-					workflow_id: args.workflow_id,
-					depends_on: args.depends_on,
-					draft: args.draft,
-				});
+				logAudit(
+					'create_standalone_task',
+					{
+						title: args.title,
+						priority: args.priority,
+						workflow_id: args.workflow_id,
+						depends_on: args.depends_on,
+						draft: args.draft,
+					},
+					createdTask.id
+				);
 			}
 			return result;
 		},

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -65,6 +65,8 @@ import {
 	ListGatesSchema,
 	ReadGateSchema,
 	RestoreNodeAgentSchema,
+	ListTasksSchema,
+	GetTaskSchema,
 } from './node-agent-tool-schemas';
 import type {
 	ListPeersInput,
@@ -77,8 +79,13 @@ import type {
 	ListGatesInput,
 	ReadGateInput,
 	RestoreNodeAgentInput,
+	ListTasksInput,
+	GetTaskInput,
 } from './node-agent-tool-schemas';
 import type { WorkflowRunArtifactRepository } from '../../../storage/repositories/workflow-run-artifact-repository';
+import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
+import type { SpaceTask } from '@neokai/shared';
+import type { McpAuditLogRepository } from '../../../storage/repositories/mcp-audit-log-repository';
 
 // Re-export for consumers that want the shared type
 export type { ToolResult };
@@ -209,6 +216,16 @@ export interface NodeAgentToolsConfig {
 	 */
 	artifactRepo?: WorkflowRunArtifactRepository;
 	/**
+	 * Task repository for list_tasks and get_task tools.
+	 * Optional — when absent, task read tools are not registered.
+	 */
+	taskRepo?: SpaceTaskRepository;
+	/**
+	 * MCP audit log repository for recording write operations.
+	 * Optional — when absent, no audit entries are written.
+	 */
+	auditLogRepo?: McpAuditLogRepository;
+	/**
 	 * Optional callback invoked when the agent calls `restore_node_agent`.
 	 *
 	 * Wired by TaskAgentManager to re-attach the per-session node-agent MCP server
@@ -259,6 +276,25 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 			.map((value) => normalizeAgentNameToken(value))
 			.filter((value) => value.length > 0)
 	);
+
+	/** Helper to log MCP write operations to the audit log. */
+	function logAudit(toolName: string, paramsSummary: Record<string, unknown>): void {
+		if (config.auditLogRepo) {
+			try {
+				config.auditLogRepo.createEntry({
+					agentName: myAgentName,
+					sessionId: mySessionId,
+					toolName,
+					paramsSummary: JSON.stringify(paramsSummary),
+					spaceId,
+					taskId: config.taskId,
+					workflowRunId,
+				});
+			} catch {
+				// Audit logging is best-effort; never block the tool operation.
+			}
+		}
+	}
 
 	return {
 		/**
@@ -652,6 +688,16 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 				}
 			}
 
+			// Audit log: gate data writes via send_message
+			if (gateWriteResult) {
+				logAudit('send_message', {
+					target,
+					gateId: gateWriteResult.gateId,
+					gateOpen: gateWriteResult.gateOpen,
+					dataKeys: data ? Object.keys(data) : undefined,
+				});
+			}
+
 			const result = await agentMessageRouter.deliverMessage({
 				fromAgentName: myAgentName,
 				fromSessionId: mySessionId,
@@ -989,6 +1035,14 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 					data: artifactData,
 				});
 
+				logAudit('save_artifact', {
+					type,
+					key: artifactKey,
+					append: append ?? false,
+					summary: summary ?? undefined,
+					dataKeys: data ? Object.keys(data) : undefined,
+				});
+
 				return jsonResult({
 					success: true,
 					artifact: {
@@ -1041,7 +1095,77 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 					error: 'create_standalone_task is not available in this node-agent session.',
 				});
 			}
+			logAudit('create_standalone_task', {
+				title: args.title,
+				priority: args.priority,
+				workflow_id: args.workflow_id,
+				depends_on: args.depends_on,
+				draft: args.draft,
+			});
 			return config.onCreateStandaloneTask(args);
+		},
+
+		// ── Task read tools ──────────────────────────────────────────────
+
+		/**
+		 * List tasks in the current space, optionally filtered by status.
+		 *
+		 * Use `compact: true` to return a trimmed projection (id, title, status,
+		 * priority, createdAt) suitable for dense lists.
+		 */
+		async list_tasks(args: ListTasksInput): Promise<ToolResult> {
+			const { taskRepo } = config;
+			if (!taskRepo) {
+				return jsonResult({ success: false, error: 'Task repository not available.' });
+			}
+			try {
+				let tasks: SpaceTask[];
+				if (args.status) {
+					tasks = taskRepo.listByStatus(spaceId, args.status);
+				} else {
+					tasks = taskRepo.listBySpace(spaceId);
+				}
+				if (args.compact) {
+					const compactTasks = tasks.map((t) => ({
+						id: t.id,
+						title: t.title,
+						status: t.status,
+						priority: t.priority,
+						createdAt: t.createdAt,
+					}));
+					return jsonResult({ success: true, total: compactTasks.length, tasks: compactTasks });
+				}
+				return jsonResult({ success: true, total: tasks.length, tasks });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		/**
+		 * Get the full detail of a task by UUID or by numeric task number (e.g. #5).
+		 */
+		async get_task(args: GetTaskInput): Promise<ToolResult> {
+			const { taskRepo } = config;
+			if (!taskRepo) {
+				return jsonResult({ success: false, error: 'Task repository not available.' });
+			}
+			let task: SpaceTask | null = null;
+			if (args.task_number !== undefined) {
+				task = taskRepo.getTaskByNumber(spaceId, args.task_number);
+			} else if (args.task_id) {
+				task = taskRepo.getTask(args.task_id);
+			} else {
+				return jsonResult({
+					success: false,
+					error: 'Either task_id or task_number is required',
+				});
+			}
+			if (!task) {
+				const ref = args.task_number !== undefined ? `#${args.task_number}` : args.task_id;
+				return jsonResult({ success: false, error: `Task not found: ${ref}` });
+			}
+			return jsonResult({ success: true, task });
 		},
 
 		// ── Self-heal ────────────────────────────────────────────────────
@@ -1238,6 +1362,24 @@ export function createNodeAgentMcpServer(config: NodeAgentToolsConfig) {
 							'`approved → done`. Rejected if the task is not currently in `approved`.',
 						MarkCompleteSchema.shape,
 						(args) => config.onMarkComplete!(args)
+					),
+				]
+			: []),
+		...(config.taskRepo
+			? [
+					tool(
+						'list_tasks',
+						'List tasks in this space. Filterable by status. Use compact:true to reduce payload size. ' +
+							'Use this to discover existing tasks before creating new ones or to check on task progress.',
+						ListTasksSchema.shape,
+						(args) => handlers.list_tasks(args)
+					),
+					tool(
+						'get_task',
+						'Retrieve detailed information about a specific task including its status, result, and metadata. ' +
+							'Provide either task_id (UUID) or task_number (numeric, e.g. 5 for task #5).',
+						GetTaskSchema.shape,
+						(args) => handlers.get_task(args)
 					),
 				]
 			: []),

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -1245,11 +1245,11 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 				let entries;
 				let total: number;
 				if (args.task_id) {
-					entries = auditLogRepo.listByTask(args.task_id, limit, offset);
-					total = auditLogRepo.countByTask(args.task_id);
+					entries = auditLogRepo.listByTaskAndSpace(args.task_id, spaceId, limit, offset);
+					total = auditLogRepo.countByTaskAndSpace(args.task_id, spaceId);
 				} else if (args.session_id) {
-					entries = auditLogRepo.listBySession(args.session_id, limit, offset);
-					total = auditLogRepo.countBySession(args.session_id);
+					entries = auditLogRepo.listBySessionAndSpace(args.session_id, spaceId, limit, offset);
+					total = auditLogRepo.countBySessionAndSpace(args.session_id, spaceId);
 				} else {
 					entries = auditLogRepo.listBySpace(spaceId, limit, offset);
 					total = auditLogRepo.countBySpace(spaceId);

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -207,7 +207,11 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		outboundSenderName === 'space-agent' ? 'Space Agent' : outboundSenderName;
 
 	/** Helper to log MCP write operations to the audit log. */
-	function logAudit(toolName: string, paramsSummary: Record<string, unknown>): void {
+	function logAudit(
+		toolName: string,
+		paramsSummary: Record<string, unknown>,
+		taskId?: string
+	): void {
 		if (config.auditLogRepo) {
 			try {
 				config.auditLogRepo.createEntry({
@@ -216,6 +220,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 					toolName,
 					paramsSummary: JSON.stringify(paramsSummary),
 					spaceId,
+					taskId,
 				});
 			} catch {
 				// Audit logging is best-effort; never block the tool operation.
@@ -437,14 +442,17 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 					createdBy: myAgentName ?? null,
 					createdBySession: mySessionId ?? null,
 				});
-				logAudit('create_standalone_task', {
-					title: args.title,
-					taskId: task.id,
-					priority: args.priority,
-					workflow_id: args.workflow_id,
-					depends_on: args.depends_on,
-					draft: args.draft,
-				});
+				logAudit(
+					'create_standalone_task',
+					{
+						title: args.title,
+						priority: args.priority,
+						workflow_id: args.workflow_id,
+						depends_on: args.depends_on,
+						draft: args.draft,
+					},
+					task.id
+				);
 				return jsonResult({ success: true, task });
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
@@ -1036,11 +1044,14 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 					approvalReason: args.reason,
 				});
 
-				logAudit('approve_task', {
-					taskId: args.task_id,
-					reason: args.reason,
-					previousStatus: task.status,
-				});
+				logAudit(
+					'approve_task',
+					{
+						reason: args.reason,
+						previousStatus: task.status,
+					},
+					args.task_id
+				);
 
 				if (daemonHub) {
 					void daemonHub

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -434,7 +434,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 					preferredWorkflowId: args.workflow_id ?? null,
 					dependsOn: args.depends_on,
 					status: args.draft ? 'draft' : undefined,
-					createdBy: myAgentName ?? 'space-agent',
+					createdBy: myAgentName ?? null,
 					createdBySession: mySessionId ?? null,
 				});
 				logAudit('create_standalone_task', {

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -30,6 +30,7 @@ import type { SpaceTaskRepository } from '../../../storage/repositories/space-ta
 import type { NodeExecutionRepository } from '../../../storage/repositories/node-execution-repository';
 import type { SpaceWorkflowRunRepository } from '../../../storage/repositories/space-workflow-run-repository';
 import type { GateDataRepository } from '../../../storage/repositories/gate-data-repository';
+import type { McpAuditLogRepository } from '../../../storage/repositories/mcp-audit-log-repository';
 import type { SpaceTaskManager } from '../managers/space-task-manager';
 import type { SpaceAgentManager } from '../managers/space-agent-manager';
 import type { SpaceManager } from '../managers/space-manager';
@@ -141,6 +142,11 @@ export interface SpaceAgentToolsConfig {
 	 * writer authorization.
 	 */
 	myAgentNameAliases?: string[];
+	/**
+	 * Session ID of the calling agent. Used to stamp `createdBySession` on tasks
+	 * created via `create_standalone_task`.
+	 */
+	mySessionId?: string;
 
 	/**
 	 * Optional self-heal callback exposed as the `restore_node_agent` tool.
@@ -152,6 +158,11 @@ export interface SpaceAgentToolsConfig {
 	 * Only set for specialised sessions that intentionally mirror this restore hook.
 	 */
 	onRestoreNodeAgent?: (args: { reason?: string }) => Promise<void> | void;
+	/**
+	 * MCP audit log repository for recording write operations.
+	 * Optional — when absent, no audit entries are written.
+	 */
+	auditLogRepo?: McpAuditLogRepository;
 }
 
 // ---------------------------------------------------------------------------
@@ -181,6 +192,7 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		getSpaceAutonomyLevel,
 		myAgentName,
 		myAgentNameAliases,
+		mySessionId,
 	} = config;
 
 	const agentNameAliases = new Set(
@@ -193,6 +205,23 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 	const outboundSenderLevel = outboundSenderName === 'task-agent' ? 'task-agent' : 'space-agent';
 	const outboundSenderDisplayName =
 		outboundSenderName === 'space-agent' ? 'Space Agent' : outboundSenderName;
+
+	/** Helper to log MCP write operations to the audit log. */
+	function logAudit(toolName: string, paramsSummary: Record<string, unknown>): void {
+		if (config.auditLogRepo) {
+			try {
+				config.auditLogRepo.createEntry({
+					agentName: myAgentName,
+					sessionId: mySessionId,
+					toolName,
+					paramsSummary: JSON.stringify(paramsSummary),
+					spaceId,
+				});
+			} catch {
+				// Audit logging is best-effort; never block the tool operation.
+			}
+		}
+	}
 
 	return {
 		/**
@@ -405,6 +434,16 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 					preferredWorkflowId: args.workflow_id ?? null,
 					dependsOn: args.depends_on,
 					status: args.draft ? 'draft' : undefined,
+					createdBy: myAgentName ?? 'space-agent',
+					createdBySession: mySessionId ?? null,
+				});
+				logAudit('create_standalone_task', {
+					title: args.title,
+					taskId: task.id,
+					priority: args.priority,
+					workflow_id: args.workflow_id,
+					depends_on: args.depends_on,
+					draft: args.draft,
 				});
 				return jsonResult({ success: true, task });
 			} catch (err) {
@@ -995,6 +1034,12 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 					result: task.result ?? undefined,
 					approvalSource: 'agent',
 					approvalReason: args.reason,
+				});
+
+				logAudit('approve_task', {
+					taskId: args.task_id,
+					reason: args.reason,
+					previousStatus: task.status,
 				});
 
 				if (daemonHub) {

--- a/packages/daemon/src/storage/repositories/mcp-audit-log-repository.ts
+++ b/packages/daemon/src/storage/repositories/mcp-audit-log-repository.ts
@@ -1,0 +1,123 @@
+/**
+ * MCP Audit Log Repository
+ *
+ * Records MCP write operations for observability and audit trail.
+ * Each entry captures: timestamp, agent identity, tool name, params summary,
+ * and optional context (space_id, task_id, workflow_run_id).
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+import { generateUUID } from '@neokai/shared';
+
+export interface McpAuditLogEntry {
+	id: string;
+	timestamp: number;
+	agentName: string | null;
+	sessionId: string | null;
+	toolName: string;
+	paramsSummary: string | null;
+	spaceId: string | null;
+	taskId: string | null;
+	workflowRunId: string | null;
+}
+
+export interface CreateMcpAuditLogParams {
+	agentName?: string | null;
+	sessionId?: string | null;
+	toolName: string;
+	paramsSummary?: string | null;
+	spaceId?: string | null;
+	taskId?: string | null;
+	workflowRunId?: string | null;
+}
+
+export class McpAuditLogRepository {
+	constructor(private db: BunDatabase) {}
+
+	/**
+	 * Create a new audit log entry
+	 */
+	createEntry(params: CreateMcpAuditLogParams): McpAuditLogEntry {
+		const id = generateUUID();
+		const now = Date.now();
+
+		this.db
+			.prepare(
+				`INSERT INTO mcp_audit_log (id, timestamp, agent_name, session_id, tool_name, params_summary, space_id, task_id, workflow_run_id)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			)
+			.run(
+				id,
+				now,
+				params.agentName ?? null,
+				params.sessionId ?? null,
+				params.toolName,
+				params.paramsSummary ?? null,
+				params.spaceId ?? null,
+				params.taskId ?? null,
+				params.workflowRunId ?? null
+			);
+
+		return {
+			id,
+			timestamp: now,
+			agentName: params.agentName ?? null,
+			sessionId: params.sessionId ?? null,
+			toolName: params.toolName,
+			paramsSummary: params.paramsSummary ?? null,
+			spaceId: params.spaceId ?? null,
+			taskId: params.taskId ?? null,
+			workflowRunId: params.workflowRunId ?? null,
+		};
+	}
+
+	/**
+	 * List audit log entries for a space, ordered by timestamp desc
+	 */
+	listBySpace(spaceId: string, limit = 100, offset = 0): McpAuditLogEntry[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM mcp_audit_log WHERE space_id = ? ORDER BY timestamp DESC LIMIT ? OFFSET ?`
+			)
+			.all(spaceId, limit, offset) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToEntry(r));
+	}
+
+	/**
+	 * List audit log entries for a task, ordered by timestamp desc
+	 */
+	listByTask(taskId: string, limit = 100, offset = 0): McpAuditLogEntry[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM mcp_audit_log WHERE task_id = ? ORDER BY timestamp DESC LIMIT ? OFFSET ?`
+			)
+			.all(taskId, limit, offset) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToEntry(r));
+	}
+
+	/**
+	 * List audit log entries for a session, ordered by timestamp desc
+	 */
+	listBySession(sessionId: string, limit = 100, offset = 0): McpAuditLogEntry[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM mcp_audit_log WHERE session_id = ? ORDER BY timestamp DESC LIMIT ? OFFSET ?`
+			)
+			.all(sessionId, limit, offset) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToEntry(r));
+	}
+
+	private rowToEntry(row: Record<string, unknown>): McpAuditLogEntry {
+		return {
+			id: row.id as string,
+			timestamp: row.timestamp as number,
+			agentName: (row.agent_name as string | null) ?? null,
+			sessionId: (row.session_id as string | null) ?? null,
+			toolName: row.tool_name as string,
+			paramsSummary: (row.params_summary as string | null) ?? null,
+			spaceId: (row.space_id as string | null) ?? null,
+			taskId: (row.task_id as string | null) ?? null,
+			workflowRunId: (row.workflow_run_id as string | null) ?? null,
+		};
+	}
+}

--- a/packages/daemon/src/storage/repositories/mcp-audit-log-repository.ts
+++ b/packages/daemon/src/storage/repositories/mcp-audit-log-repository.ts
@@ -107,6 +107,36 @@ export class McpAuditLogRepository {
 		return rows.map((r) => this.rowToEntry(r));
 	}
 
+	/**
+	 * Count audit log entries for a space.
+	 */
+	countBySpace(spaceId: string): number {
+		const row = this.db
+			.prepare(`SELECT COUNT(*) as count FROM mcp_audit_log WHERE space_id = ?`)
+			.get(spaceId) as { count: number } | undefined;
+		return row?.count ?? 0;
+	}
+
+	/**
+	 * Count audit log entries for a task.
+	 */
+	countByTask(taskId: string): number {
+		const row = this.db
+			.prepare(`SELECT COUNT(*) as count FROM mcp_audit_log WHERE task_id = ?`)
+			.get(taskId) as { count: number } | undefined;
+		return row?.count ?? 0;
+	}
+
+	/**
+	 * Count audit log entries for a session.
+	 */
+	countBySession(sessionId: string): number {
+		const row = this.db
+			.prepare(`SELECT COUNT(*) as count FROM mcp_audit_log WHERE session_id = ?`)
+			.get(sessionId) as { count: number } | undefined;
+		return row?.count ?? 0;
+	}
+
 	private rowToEntry(row: Record<string, unknown>): McpAuditLogEntry {
 		return {
 			id: row.id as string,

--- a/packages/daemon/src/storage/repositories/mcp-audit-log-repository.ts
+++ b/packages/daemon/src/storage/repositories/mcp-audit-log-repository.ts
@@ -72,38 +72,68 @@ export class McpAuditLogRepository {
 	}
 
 	/**
-	 * List audit log entries for a space, ordered by timestamp desc
+	 * List audit log entries for a space, ordered by timestamp desc, id desc
+	 * (id is the tie-breaker for deterministic ordering when timestamps collide).
 	 */
 	listBySpace(spaceId: string, limit = 100, offset = 0): McpAuditLogEntry[] {
 		const rows = this.db
 			.prepare(
-				`SELECT * FROM mcp_audit_log WHERE space_id = ? ORDER BY timestamp DESC LIMIT ? OFFSET ?`
+				`SELECT * FROM mcp_audit_log WHERE space_id = ? ORDER BY timestamp DESC, id DESC LIMIT ? OFFSET ?`
 			)
 			.all(spaceId, limit, offset) as Record<string, unknown>[];
 		return rows.map((r) => this.rowToEntry(r));
 	}
 
 	/**
-	 * List audit log entries for a task, ordered by timestamp desc
+	 * List audit log entries for a task within a space, ordered by timestamp desc, id desc.
 	 */
 	listByTask(taskId: string, limit = 100, offset = 0): McpAuditLogEntry[] {
 		const rows = this.db
 			.prepare(
-				`SELECT * FROM mcp_audit_log WHERE task_id = ? ORDER BY timestamp DESC LIMIT ? OFFSET ?`
+				`SELECT * FROM mcp_audit_log WHERE task_id = ? ORDER BY timestamp DESC, id DESC LIMIT ? OFFSET ?`
 			)
 			.all(taskId, limit, offset) as Record<string, unknown>[];
 		return rows.map((r) => this.rowToEntry(r));
 	}
 
 	/**
-	 * List audit log entries for a session, ordered by timestamp desc
+	 * List audit log entries for a task scoped to a specific space.
+	 */
+	listByTaskAndSpace(taskId: string, spaceId: string, limit = 100, offset = 0): McpAuditLogEntry[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM mcp_audit_log WHERE task_id = ? AND space_id = ? ORDER BY timestamp DESC, id DESC LIMIT ? OFFSET ?`
+			)
+			.all(taskId, spaceId, limit, offset) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToEntry(r));
+	}
+
+	/**
+	 * List audit log entries for a session, ordered by timestamp desc, id desc.
 	 */
 	listBySession(sessionId: string, limit = 100, offset = 0): McpAuditLogEntry[] {
 		const rows = this.db
 			.prepare(
-				`SELECT * FROM mcp_audit_log WHERE session_id = ? ORDER BY timestamp DESC LIMIT ? OFFSET ?`
+				`SELECT * FROM mcp_audit_log WHERE session_id = ? ORDER BY timestamp DESC, id DESC LIMIT ? OFFSET ?`
 			)
 			.all(sessionId, limit, offset) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToEntry(r));
+	}
+
+	/**
+	 * List audit log entries for a session scoped to a specific space.
+	 */
+	listBySessionAndSpace(
+		sessionId: string,
+		spaceId: string,
+		limit = 100,
+		offset = 0
+	): McpAuditLogEntry[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM mcp_audit_log WHERE session_id = ? AND space_id = ? ORDER BY timestamp DESC, id DESC LIMIT ? OFFSET ?`
+			)
+			.all(sessionId, spaceId, limit, offset) as Record<string, unknown>[];
 		return rows.map((r) => this.rowToEntry(r));
 	}
 
@@ -128,12 +158,32 @@ export class McpAuditLogRepository {
 	}
 
 	/**
+	 * Count audit log entries for a task within a specific space.
+	 */
+	countByTaskAndSpace(taskId: string, spaceId: string): number {
+		const row = this.db
+			.prepare(`SELECT COUNT(*) as count FROM mcp_audit_log WHERE task_id = ? AND space_id = ?`)
+			.get(taskId, spaceId) as { count: number } | undefined;
+		return row?.count ?? 0;
+	}
+
+	/**
 	 * Count audit log entries for a session.
 	 */
 	countBySession(sessionId: string): number {
 		const row = this.db
 			.prepare(`SELECT COUNT(*) as count FROM mcp_audit_log WHERE session_id = ?`)
 			.get(sessionId) as { count: number } | undefined;
+		return row?.count ?? 0;
+	}
+
+	/**
+	 * Count audit log entries for a session within a specific space.
+	 */
+	countBySessionAndSpace(sessionId: string, spaceId: string): number {
+		const row = this.db
+			.prepare(`SELECT COUNT(*) as count FROM mcp_audit_log WHERE session_id = ? AND space_id = ?`)
+			.get(sessionId, spaceId) as { count: number } | undefined;
 		return row?.count ?? 0;
 	}
 

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -85,17 +85,23 @@ export class SpaceTaskRepository {
 	}
 
 	/**
-	 * List tasks for a space, with optional status filter and pagination
+	 * List tasks for a space, with optional status filter and pagination.
+	 * When limit is not provided (or 0), returns all matching tasks (unbounded).
 	 */
-	listBySpace(spaceId: string, includeArchived = false, limit = 100, offset = 0): SpaceTask[] {
+	listBySpace(spaceId: string, includeArchived = false, limit?: number, offset = 0): SpaceTask[] {
 		let query = `SELECT * FROM space_tasks WHERE space_id = ?`;
 		if (!includeArchived) {
 			query += ` AND status != 'archived'`;
 		}
-		query += ` ORDER BY updated_at DESC LIMIT ? OFFSET ?`;
-
+		query += ` ORDER BY updated_at DESC`;
+		if (limit && limit > 0) {
+			query += ` LIMIT ? OFFSET ?`;
+			const stmt = this.db.prepare(query);
+			const rows = stmt.all(spaceId, limit, offset) as Record<string, unknown>[];
+			return rows.map((r) => this.rowToSpaceTask(r));
+		}
 		const stmt = this.db.prepare(query);
-		const rows = stmt.all(spaceId, limit, offset) as Record<string, unknown>[];
+		const rows = stmt.all(spaceId) as Record<string, unknown>[];
 		return rows.map((r) => this.rowToSpaceTask(r));
 	}
 
@@ -144,14 +150,38 @@ export class SpaceTaskRepository {
 	}
 
 	/**
-	 * List tasks by status within a space, with optional pagination
+	 * List tasks by status within a space, with optional pagination.
+	 * When limit is not provided (or 0), returns all matching tasks (unbounded).
 	 */
-	listByStatus(spaceId: string, status: SpaceTaskStatus, limit = 100, offset = 0): SpaceTask[] {
-		const stmt = this.db.prepare(
-			`SELECT * FROM space_tasks WHERE space_id = ? AND status = ? ORDER BY updated_at DESC LIMIT ? OFFSET ?`
-		);
-		const rows = stmt.all(spaceId, status, limit, offset) as Record<string, unknown>[];
+	listByStatus(spaceId: string, status: SpaceTaskStatus, limit?: number, offset = 0): SpaceTask[] {
+		let query = `SELECT * FROM space_tasks WHERE space_id = ? AND status = ? ORDER BY updated_at DESC`;
+		if (limit && limit > 0) {
+			query += ` LIMIT ? OFFSET ?`;
+			const stmt = this.db.prepare(query);
+			const rows = stmt.all(spaceId, status, limit, offset) as Record<string, unknown>[];
+			return rows.map((r) => this.rowToSpaceTask(r));
+		}
+		const stmt = this.db.prepare(query);
+		const rows = stmt.all(spaceId, status) as Record<string, unknown>[];
 		return rows.map((r) => this.rowToSpaceTask(r));
+	}
+
+	/**
+	 * Count tasks for a space, optionally filtered by status (excluding archived by default).
+	 */
+	countBySpace(spaceId: string, status?: SpaceTaskStatus, includeArchived = false): number {
+		let query = `SELECT COUNT(*) as count FROM space_tasks WHERE space_id = ?`;
+		const params: SQLiteValue[] = [spaceId];
+		if (!includeArchived) {
+			query += ` AND status != 'archived'`;
+		}
+		if (status) {
+			query += ` AND status = ?`;
+			params.push(status);
+		}
+		const stmt = this.db.prepare(query);
+		const row = stmt.get(...params) as { count: number } | undefined;
+		return row?.count ?? 0;
 	}
 
 	/**

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -93,7 +93,7 @@ export class SpaceTaskRepository {
 		if (!includeArchived) {
 			query += ` AND status != 'archived'`;
 		}
-		query += ` ORDER BY updated_at DESC`;
+		query += ` ORDER BY updated_at DESC, id DESC`;
 		if (limit && limit > 0) {
 			query += ` LIMIT ? OFFSET ?`;
 			const stmt = this.db.prepare(query);
@@ -154,7 +154,7 @@ export class SpaceTaskRepository {
 	 * When limit is not provided (or 0), returns all matching tasks (unbounded).
 	 */
 	listByStatus(spaceId: string, status: SpaceTaskStatus, limit?: number, offset = 0): SpaceTask[] {
-		let query = `SELECT * FROM space_tasks WHERE space_id = ? AND status = ? ORDER BY updated_at DESC`;
+		let query = `SELECT * FROM space_tasks WHERE space_id = ? AND status = ? ORDER BY updated_at DESC, id DESC`;
 		if (limit && limit > 0) {
 			query += ` LIMIT ? OFFSET ?`;
 			const stmt = this.db.prepare(query);

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -167,12 +167,15 @@ export class SpaceTaskRepository {
 	}
 
 	/**
-	 * Count tasks for a space, optionally filtered by status (excluding archived by default).
+	 * Count tasks for a space, optionally filtered by status.
+	 * Excludes archived by default, unless status is explicitly 'archived'.
 	 */
 	countBySpace(spaceId: string, status?: SpaceTaskStatus, includeArchived = false): number {
 		let query = `SELECT COUNT(*) as count FROM space_tasks WHERE space_id = ?`;
 		const params: SQLiteValue[] = [spaceId];
-		if (!includeArchived) {
+		// When the caller explicitly filters by 'archived', include archived rows
+		// even if includeArchived is false — the status filter is the intent.
+		if (!includeArchived && status !== 'archived') {
 			query += ` AND status != 'archived'`;
 		}
 		if (status) {

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -85,17 +85,17 @@ export class SpaceTaskRepository {
 	}
 
 	/**
-	 * List tasks for a space, with optional status filter
+	 * List tasks for a space, with optional status filter and pagination
 	 */
-	listBySpace(spaceId: string, includeArchived = false): SpaceTask[] {
+	listBySpace(spaceId: string, includeArchived = false, limit = 100, offset = 0): SpaceTask[] {
 		let query = `SELECT * FROM space_tasks WHERE space_id = ?`;
 		if (!includeArchived) {
 			query += ` AND status != 'archived'`;
 		}
-		query += ` ORDER BY updated_at DESC`;
+		query += ` ORDER BY updated_at DESC LIMIT ? OFFSET ?`;
 
 		const stmt = this.db.prepare(query);
-		const rows = stmt.all(spaceId) as Record<string, unknown>[];
+		const rows = stmt.all(spaceId, limit, offset) as Record<string, unknown>[];
 		return rows.map((r) => this.rowToSpaceTask(r));
 	}
 
@@ -144,13 +144,13 @@ export class SpaceTaskRepository {
 	}
 
 	/**
-	 * List tasks by status within a space
+	 * List tasks by status within a space, with optional pagination
 	 */
-	listByStatus(spaceId: string, status: SpaceTaskStatus): SpaceTask[] {
+	listByStatus(spaceId: string, status: SpaceTaskStatus, limit = 100, offset = 0): SpaceTask[] {
 		const stmt = this.db.prepare(
-			`SELECT * FROM space_tasks WHERE space_id = ? AND status = ? ORDER BY updated_at DESC`
+			`SELECT * FROM space_tasks WHERE space_id = ? AND status = ? ORDER BY updated_at DESC LIMIT ? OFFSET ?`
 		);
-		const rows = stmt.all(spaceId, status) as Record<string, unknown>[];
+		const rows = stmt.all(spaceId, status, limit, offset) as Record<string, unknown>[];
 		return rows.map((r) => this.rowToSpaceTask(r));
 	}
 

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -43,8 +43,8 @@ export class SpaceTaskRepository {
 
 			this.db
 				.prepare(
-					`INSERT INTO space_tasks (id, space_id, task_number, title, description, status, priority, labels, workflow_run_id, preferred_workflow_id, created_by_task_id, depends_on, task_agent_session_id, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+					`INSERT INTO space_tasks (id, space_id, task_number, title, description, status, priority, labels, workflow_run_id, preferred_workflow_id, created_by_task_id, depends_on, task_agent_session_id, created_by, created_by_session, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 				)
 				.run(
 					id,
@@ -60,6 +60,8 @@ export class SpaceTaskRepository {
 					params.createdByTaskId ?? null,
 					JSON.stringify(params.dependsOn ?? []),
 					params.taskAgentSessionId ?? null,
+					params.createdBy ?? null,
+					params.createdBySession ?? null,
 					now,
 					now
 				);
@@ -462,6 +464,8 @@ export class SpaceTaskRepository {
 			workflowRunId: (row.workflow_run_id as string | null) ?? undefined,
 			preferredWorkflowId: (row.preferred_workflow_id as string | null) ?? undefined,
 			createdByTaskId: (row.created_by_task_id as string | null) ?? undefined,
+			createdBy: (row.created_by as string | null) ?? undefined,
+			createdBySession: (row.created_by_session as string | null) ?? undefined,
 			result: (row.result as string | null) ?? null,
 			dependsOn: JSON.parse((row.depends_on as string | null) ?? '[]') as string[],
 			activeSession: (row.active_session as 'worker' | 'leader' | null) ?? null,

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -8046,21 +8046,21 @@ export function runMigration120(db: BunDatabase): void {
  * - space_id, task_id, workflow_run_id: optional context
  */
 export function runMigration121(db: BunDatabase): void {
-	if (tableExists(db, 'mcp_audit_log')) return;
-
-	db.exec(`
-		CREATE TABLE mcp_audit_log (
-			id TEXT PRIMARY KEY,
-			timestamp INTEGER NOT NULL,
-			agent_name TEXT DEFAULT NULL,
-			session_id TEXT DEFAULT NULL,
-			tool_name TEXT NOT NULL,
-			params_summary TEXT DEFAULT NULL,
-			space_id TEXT DEFAULT NULL,
-			task_id TEXT DEFAULT NULL,
-			workflow_run_id TEXT DEFAULT NULL
-		)
-	`);
+	if (!tableExists(db, 'mcp_audit_log')) {
+		db.exec(`
+			CREATE TABLE mcp_audit_log (
+				id TEXT PRIMARY KEY,
+				timestamp INTEGER NOT NULL,
+				agent_name TEXT DEFAULT NULL,
+				session_id TEXT DEFAULT NULL,
+				tool_name TEXT NOT NULL,
+				params_summary TEXT DEFAULT NULL,
+				space_id TEXT DEFAULT NULL,
+				task_id TEXT DEFAULT NULL,
+				workflow_run_id TEXT DEFAULT NULL
+			)
+		`);
+	}
 
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_mcp_audit_log_space ON mcp_audit_log (space_id, timestamp)`

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -563,6 +563,15 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	// Migration 119: Add setting_sources column to spaces.
 	//   Stores per-space default setting sources as JSON.
 	runMigration119(db);
+
+	// Migration 120: Add created_by and created_by_session columns to space_tasks.
+	//   Tracks which agent and session created a task for audit trail.
+	runMigration120(db);
+
+	// Migration 121: Create mcp_audit_log table.
+	//   General audit trail for MCP write operations (create_task, approve_task,
+	//   send_message with gate data, save_artifact, etc.).
+	runMigration121(db);
 }
 
 /**
@@ -8006,4 +8015,60 @@ export function runMigration119(db: BunDatabase): void {
 	if (columns.includes('setting_sources')) return;
 
 	db.exec(`ALTER TABLE spaces ADD COLUMN setting_sources TEXT DEFAULT NULL`);
+}
+
+/**
+ * Migration 120: Add `created_by` and `created_by_session` columns to `space_tasks` table.
+ *
+ * Tracks which agent and session created a task for audit trail.
+ * - `created_by`: agent name (e.g. 'space-agent', 'coder', 'task-agent')
+ * - `created_by_session`: session ID of the creator
+ * Both are nullable — existing rows get NULL.
+ */
+export function runMigration120(db: BunDatabase): void {
+	if (!tableExists(db, 'space_tasks')) return;
+
+	const columns = tableColumnNames(db, 'space_tasks');
+	if (!columns.includes('created_by')) {
+		db.exec(`ALTER TABLE space_tasks ADD COLUMN created_by TEXT DEFAULT NULL`);
+	}
+	if (!columns.includes('created_by_session')) {
+		db.exec(`ALTER TABLE space_tasks ADD COLUMN created_by_session TEXT DEFAULT NULL`);
+	}
+}
+
+/**
+ * Migration 121: Create `mcp_audit_log` table.
+ *
+ * General audit trail for MCP write operations. Each entry records:
+ * - timestamp, agent_name, session_id, tool_name
+ * - params_summary: JSON summary of the tool call parameters
+ * - space_id, task_id, workflow_run_id: optional context
+ */
+export function runMigration121(db: BunDatabase): void {
+	if (tableExists(db, 'mcp_audit_log')) return;
+
+	db.exec(`
+		CREATE TABLE mcp_audit_log (
+			id TEXT PRIMARY KEY,
+			timestamp INTEGER NOT NULL,
+			agent_name TEXT DEFAULT NULL,
+			session_id TEXT DEFAULT NULL,
+			tool_name TEXT NOT NULL,
+			params_summary TEXT DEFAULT NULL,
+			space_id TEXT DEFAULT NULL,
+			task_id TEXT DEFAULT NULL,
+			workflow_run_id TEXT DEFAULT NULL
+		)
+	`);
+
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_mcp_audit_log_space ON mcp_audit_log (space_id, timestamp)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_mcp_audit_log_task ON mcp_audit_log (task_id, timestamp)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_mcp_audit_log_session ON mcp_audit_log (session_id, timestamp)`
+	);
 }

--- a/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
@@ -69,13 +69,14 @@ describe('scope-config', () => {
 				'channel_cycles',
 				'workflow_run_artifacts',
 				'workflow_run_artifact_cache',
+				'mcp_audit_log',
 				// Main-DB tables exposed with space-scoped filtering via session ID prefix:
 				'sessions',
 				'sdk_messages',
 				'session_groups',
 				'session_group_members',
 			]);
-			expect(names).toHaveLength(14);
+			expect(names).toHaveLength(15);
 		});
 
 		it('all table configs have a description', () => {

--- a/packages/daemon/tests/unit/4-space-storage/storage/mcp-audit-log-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/mcp-audit-log-repository.test.ts
@@ -81,15 +81,16 @@ describe('McpAuditLogRepository', () => {
 	});
 
 	describe('listBySpace', () => {
-		it('returns entries for the given space ordered by timestamp desc', () => {
+		it('returns entries for the given space', () => {
 			repo.createEntry({ toolName: 't1', spaceId: 'space-a' });
 			repo.createEntry({ toolName: 't2', spaceId: 'space-a' });
 			repo.createEntry({ toolName: 't3', spaceId: 'space-b' });
 
 			const results = repo.listBySpace('space-a');
 			expect(results).toHaveLength(2);
-			expect(results[0].toolName).toBe('t2');
-			expect(results[1].toolName).toBe('t1');
+			const toolNames = results.map((e) => e.toolName);
+			expect(toolNames).toContain('t1');
+			expect(toolNames).toContain('t2');
 		});
 
 		it('returns empty array when no entries match', () => {
@@ -102,27 +103,28 @@ describe('McpAuditLogRepository', () => {
 			repo.createEntry({ toolName: 't2', spaceId: 'space-a' });
 			repo.createEntry({ toolName: 't3', spaceId: 'space-a' });
 
+			const all = repo.listBySpace('space-a');
+			expect(all).toHaveLength(3);
+
 			const page1 = repo.listBySpace('space-a', 2, 0);
 			expect(page1).toHaveLength(2);
-			expect(page1[0].toolName).toBe('t3');
-			expect(page1[1].toolName).toBe('t2');
 
 			const page2 = repo.listBySpace('space-a', 2, 2);
 			expect(page2).toHaveLength(1);
-			expect(page2[0].toolName).toBe('t1');
 		});
 	});
 
 	describe('listByTask', () => {
-		it('returns entries for the given task ordered by timestamp desc', () => {
+		it('returns entries for the given task', () => {
 			repo.createEntry({ toolName: 't1', taskId: 'task-a' });
 			repo.createEntry({ toolName: 't2', taskId: 'task-a' });
 			repo.createEntry({ toolName: 't3', taskId: 'task-b' });
 
 			const results = repo.listByTask('task-a');
 			expect(results).toHaveLength(2);
-			expect(results[0].toolName).toBe('t2');
-			expect(results[1].toolName).toBe('t1');
+			const toolNames = results.map((e) => e.toolName);
+			expect(toolNames).toContain('t1');
+			expect(toolNames).toContain('t2');
 		});
 
 		it('returns empty array when no entries match', () => {
@@ -135,25 +137,28 @@ describe('McpAuditLogRepository', () => {
 			repo.createEntry({ toolName: 't2', taskId: 'task-a' });
 			repo.createEntry({ toolName: 't3', taskId: 'task-a' });
 
+			const all = repo.listByTask('task-a');
+			expect(all).toHaveLength(3);
+
 			const page1 = repo.listByTask('task-a', 2, 0);
 			expect(page1).toHaveLength(2);
 
 			const page2 = repo.listByTask('task-a', 2, 2);
 			expect(page2).toHaveLength(1);
-			expect(page2[0].toolName).toBe('t1');
 		});
 	});
 
 	describe('listBySession', () => {
-		it('returns entries for the given session ordered by timestamp desc', () => {
+		it('returns entries for the given session', () => {
 			repo.createEntry({ toolName: 't1', sessionId: 'sess-a' });
 			repo.createEntry({ toolName: 't2', sessionId: 'sess-a' });
 			repo.createEntry({ toolName: 't3', sessionId: 'sess-b' });
 
 			const results = repo.listBySession('sess-a');
 			expect(results).toHaveLength(2);
-			expect(results[0].toolName).toBe('t2');
-			expect(results[1].toolName).toBe('t1');
+			const toolNames = results.map((e) => e.toolName);
+			expect(toolNames).toContain('t1');
+			expect(toolNames).toContain('t2');
 		});
 
 		it('returns empty array when no entries match', () => {
@@ -166,12 +171,14 @@ describe('McpAuditLogRepository', () => {
 			repo.createEntry({ toolName: 't2', sessionId: 'sess-a' });
 			repo.createEntry({ toolName: 't3', sessionId: 'sess-a' });
 
+			const all = repo.listBySession('sess-a');
+			expect(all).toHaveLength(3);
+
 			const page1 = repo.listBySession('sess-a', 2, 0);
 			expect(page1).toHaveLength(2);
 
 			const page2 = repo.listBySession('sess-a', 2, 2);
 			expect(page2).toHaveLength(1);
-			expect(page2[0].toolName).toBe('t1');
 		});
 	});
 
@@ -217,6 +224,52 @@ describe('McpAuditLogRepository', () => {
 
 		it('returns 0 when no entries match', () => {
 			expect(repo.countBySession('nonexistent')).toBe(0);
+		});
+	});
+
+	describe('listByTaskAndSpace', () => {
+		it('returns only entries matching both task and space', () => {
+			repo.createEntry({ toolName: 't1', spaceId: 'space-a', taskId: 'task-x' });
+			repo.createEntry({ toolName: 't2', spaceId: 'space-a', taskId: 'task-x' });
+			repo.createEntry({ toolName: 't3', spaceId: 'space-b', taskId: 'task-x' });
+
+			const results = repo.listByTaskAndSpace('task-x', 'space-a');
+			expect(results).toHaveLength(2);
+			expect(results.every((e) => e.spaceId === 'space-a')).toBe(true);
+		});
+	});
+
+	describe('listBySessionAndSpace', () => {
+		it('returns only entries matching both session and space', () => {
+			repo.createEntry({ toolName: 't1', spaceId: 'space-a', sessionId: 'sess-x' });
+			repo.createEntry({ toolName: 't2', spaceId: 'space-a', sessionId: 'sess-x' });
+			repo.createEntry({ toolName: 't3', spaceId: 'space-b', sessionId: 'sess-x' });
+
+			const results = repo.listBySessionAndSpace('sess-x', 'space-a');
+			expect(results).toHaveLength(2);
+			expect(results.every((e) => e.spaceId === 'space-a')).toBe(true);
+		});
+	});
+
+	describe('countByTaskAndSpace', () => {
+		it('counts only entries matching both task and space', () => {
+			repo.createEntry({ toolName: 't1', spaceId: 'space-a', taskId: 'task-x' });
+			repo.createEntry({ toolName: 't2', spaceId: 'space-a', taskId: 'task-x' });
+			repo.createEntry({ toolName: 't3', spaceId: 'space-b', taskId: 'task-x' });
+
+			expect(repo.countByTaskAndSpace('task-x', 'space-a')).toBe(2);
+			expect(repo.countByTaskAndSpace('task-x', 'space-b')).toBe(1);
+		});
+	});
+
+	describe('countBySessionAndSpace', () => {
+		it('counts only entries matching both session and space', () => {
+			repo.createEntry({ toolName: 't1', spaceId: 'space-a', sessionId: 'sess-x' });
+			repo.createEntry({ toolName: 't2', spaceId: 'space-a', sessionId: 'sess-x' });
+			repo.createEntry({ toolName: 't3', spaceId: 'space-b', sessionId: 'sess-x' });
+
+			expect(repo.countBySessionAndSpace('sess-x', 'space-a')).toBe(2);
+			expect(repo.countBySessionAndSpace('sess-x', 'space-b')).toBe(1);
 		});
 	});
 });

--- a/packages/daemon/tests/unit/4-space-storage/storage/mcp-audit-log-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/mcp-audit-log-repository.test.ts
@@ -1,0 +1,177 @@
+/**
+ * McpAuditLogRepository Tests
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { McpAuditLogRepository } from '../../../../src/storage/repositories/mcp-audit-log-repository';
+import { createSpaceTables } from '../../helpers/space-test-db';
+
+describe('McpAuditLogRepository', () => {
+	let db: Database;
+	let repo: McpAuditLogRepository;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		repo = new McpAuditLogRepository(db as any);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	describe('createEntry', () => {
+		it('creates an entry with all fields', () => {
+			const entry = repo.createEntry({
+				agentName: 'coder',
+				sessionId: 'sess-1',
+				toolName: 'send_message',
+				paramsSummary: JSON.stringify({ target: 'reviewer' }),
+				spaceId: 'space-1',
+				taskId: 'task-1',
+				workflowRunId: 'run-1',
+			});
+
+			expect(entry.id).toBeDefined();
+			expect(entry.timestamp).toBeGreaterThan(0);
+			expect(entry.agentName).toBe('coder');
+			expect(entry.sessionId).toBe('sess-1');
+			expect(entry.toolName).toBe('send_message');
+			expect(entry.paramsSummary).toBe(JSON.stringify({ target: 'reviewer' }));
+			expect(entry.spaceId).toBe('space-1');
+			expect(entry.taskId).toBe('task-1');
+			expect(entry.workflowRunId).toBe('run-1');
+		});
+
+		it('creates an entry with minimal fields', () => {
+			const entry = repo.createEntry({
+				toolName: 'save_artifact',
+			});
+
+			expect(entry.id).toBeDefined();
+			expect(entry.timestamp).toBeGreaterThan(0);
+			expect(entry.agentName).toBeNull();
+			expect(entry.sessionId).toBeNull();
+			expect(entry.toolName).toBe('save_artifact');
+			expect(entry.paramsSummary).toBeNull();
+			expect(entry.spaceId).toBeNull();
+			expect(entry.taskId).toBeNull();
+			expect(entry.workflowRunId).toBeNull();
+		});
+
+		it('stores null for undefined optional fields', () => {
+			const entry = repo.createEntry({
+				agentName: undefined,
+				sessionId: undefined,
+				toolName: 'approve_task',
+				paramsSummary: undefined,
+				spaceId: undefined,
+				taskId: undefined,
+				workflowRunId: undefined,
+			});
+
+			expect(entry.agentName).toBeNull();
+			expect(entry.sessionId).toBeNull();
+			expect(entry.paramsSummary).toBeNull();
+			expect(entry.spaceId).toBeNull();
+			expect(entry.taskId).toBeNull();
+			expect(entry.workflowRunId).toBeNull();
+		});
+	});
+
+	describe('listBySpace', () => {
+		it('returns entries for the given space ordered by timestamp desc', () => {
+			repo.createEntry({ toolName: 't1', spaceId: 'space-a' });
+			repo.createEntry({ toolName: 't2', spaceId: 'space-a' });
+			repo.createEntry({ toolName: 't3', spaceId: 'space-b' });
+
+			const results = repo.listBySpace('space-a');
+			expect(results).toHaveLength(2);
+			expect(results[0].toolName).toBe('t2');
+			expect(results[1].toolName).toBe('t1');
+		});
+
+		it('returns empty array when no entries match', () => {
+			const results = repo.listBySpace('nonexistent');
+			expect(results).toEqual([]);
+		});
+
+		it('respects limit and offset', () => {
+			repo.createEntry({ toolName: 't1', spaceId: 'space-a' });
+			repo.createEntry({ toolName: 't2', spaceId: 'space-a' });
+			repo.createEntry({ toolName: 't3', spaceId: 'space-a' });
+
+			const page1 = repo.listBySpace('space-a', 2, 0);
+			expect(page1).toHaveLength(2);
+			expect(page1[0].toolName).toBe('t3');
+			expect(page1[1].toolName).toBe('t2');
+
+			const page2 = repo.listBySpace('space-a', 2, 2);
+			expect(page2).toHaveLength(1);
+			expect(page2[0].toolName).toBe('t1');
+		});
+	});
+
+	describe('listByTask', () => {
+		it('returns entries for the given task ordered by timestamp desc', () => {
+			repo.createEntry({ toolName: 't1', taskId: 'task-a' });
+			repo.createEntry({ toolName: 't2', taskId: 'task-a' });
+			repo.createEntry({ toolName: 't3', taskId: 'task-b' });
+
+			const results = repo.listByTask('task-a');
+			expect(results).toHaveLength(2);
+			expect(results[0].toolName).toBe('t2');
+			expect(results[1].toolName).toBe('t1');
+		});
+
+		it('returns empty array when no entries match', () => {
+			const results = repo.listByTask('nonexistent');
+			expect(results).toEqual([]);
+		});
+
+		it('respects limit and offset', () => {
+			repo.createEntry({ toolName: 't1', taskId: 'task-a' });
+			repo.createEntry({ toolName: 't2', taskId: 'task-a' });
+			repo.createEntry({ toolName: 't3', taskId: 'task-a' });
+
+			const page1 = repo.listByTask('task-a', 2, 0);
+			expect(page1).toHaveLength(2);
+
+			const page2 = repo.listByTask('task-a', 2, 2);
+			expect(page2).toHaveLength(1);
+			expect(page2[0].toolName).toBe('t1');
+		});
+	});
+
+	describe('listBySession', () => {
+		it('returns entries for the given session ordered by timestamp desc', () => {
+			repo.createEntry({ toolName: 't1', sessionId: 'sess-a' });
+			repo.createEntry({ toolName: 't2', sessionId: 'sess-a' });
+			repo.createEntry({ toolName: 't3', sessionId: 'sess-b' });
+
+			const results = repo.listBySession('sess-a');
+			expect(results).toHaveLength(2);
+			expect(results[0].toolName).toBe('t2');
+			expect(results[1].toolName).toBe('t1');
+		});
+
+		it('returns empty array when no entries match', () => {
+			const results = repo.listBySession('nonexistent');
+			expect(results).toEqual([]);
+		});
+
+		it('respects limit and offset', () => {
+			repo.createEntry({ toolName: 't1', sessionId: 'sess-a' });
+			repo.createEntry({ toolName: 't2', sessionId: 'sess-a' });
+			repo.createEntry({ toolName: 't3', sessionId: 'sess-a' });
+
+			const page1 = repo.listBySession('sess-a', 2, 0);
+			expect(page1).toHaveLength(2);
+
+			const page2 = repo.listBySession('sess-a', 2, 2);
+			expect(page2).toHaveLength(1);
+			expect(page2[0].toolName).toBe('t1');
+		});
+	});
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/mcp-audit-log-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/mcp-audit-log-repository.test.ts
@@ -174,4 +174,49 @@ describe('McpAuditLogRepository', () => {
 			expect(page2[0].toolName).toBe('t1');
 		});
 	});
+
+	describe('countBySpace', () => {
+		it('returns the total count of entries for a space', () => {
+			repo.createEntry({ toolName: 't1', spaceId: 'space-a' });
+			repo.createEntry({ toolName: 't2', spaceId: 'space-a' });
+			repo.createEntry({ toolName: 't3', spaceId: 'space-b' });
+
+			expect(repo.countBySpace('space-a')).toBe(2);
+			expect(repo.countBySpace('space-b')).toBe(1);
+		});
+
+		it('returns 0 when no entries match', () => {
+			expect(repo.countBySpace('nonexistent')).toBe(0);
+		});
+	});
+
+	describe('countByTask', () => {
+		it('returns the total count of entries for a task', () => {
+			repo.createEntry({ toolName: 't1', taskId: 'task-a' });
+			repo.createEntry({ toolName: 't2', taskId: 'task-a' });
+			repo.createEntry({ toolName: 't3', taskId: 'task-b' });
+
+			expect(repo.countByTask('task-a')).toBe(2);
+			expect(repo.countByTask('task-b')).toBe(1);
+		});
+
+		it('returns 0 when no entries match', () => {
+			expect(repo.countByTask('nonexistent')).toBe(0);
+		});
+	});
+
+	describe('countBySession', () => {
+		it('returns the total count of entries for a session', () => {
+			repo.createEntry({ toolName: 't1', sessionId: 'sess-a' });
+			repo.createEntry({ toolName: 't2', sessionId: 'sess-a' });
+			repo.createEntry({ toolName: 't3', sessionId: 'sess-b' });
+
+			expect(repo.countBySession('sess-a')).toBe(2);
+			expect(repo.countBySession('sess-b')).toBe(1);
+		});
+
+		it('returns 0 when no entries match', () => {
+			expect(repo.countBySession('nonexistent')).toBe(0);
+		});
+	});
 });

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -29,6 +29,7 @@ import {
 import { AgentMessageRouter } from '../../../../src/lib/space/runtime/agent-message-router.ts';
 import { ChannelResolver } from '../../../../src/lib/space/runtime/channel-resolver.ts';
 import { PendingAgentMessageRepository } from '../../../../src/storage/repositories/pending-agent-message-repository.ts';
+import { McpAuditLogRepository } from '../../../../src/storage/repositories/mcp-audit-log-repository.ts';
 import type { SpaceWorkflow, Gate, WorkflowChannel } from '@neokai/shared';
 
 // ---------------------------------------------------------------------------
@@ -3240,5 +3241,319 @@ describe('node-agent-tools: send_message — queue-when-inactive', () => {
 		expect(data.queued[0].agentName).toBe('security');
 		const securityPending = pendingMessageRepo.listPendingForTarget(isolatedRunId, 'security');
 		expect(securityPending).toHaveLength(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: list_tasks / get_task
+// ---------------------------------------------------------------------------
+
+describe('node-agent-tools: list_tasks', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.db.close();
+	});
+
+	test('lists tasks in the space', async () => {
+		const config = makeConfig(ctx, { taskRepo: ctx.taskRepo });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.list_tasks({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.tasks.length).toBeGreaterThanOrEqual(2);
+		expect(data.has_more).toBe(false);
+	});
+
+	test('filters tasks by status', async () => {
+		const config = makeConfig(ctx, { taskRepo: ctx.taskRepo });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.list_tasks({ status: 'in_progress' });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.tasks.every((t: { status: string }) => t.status === 'in_progress')).toBe(true);
+	});
+
+	test('returns compact tasks when compact:true', async () => {
+		const config = makeConfig(ctx, { taskRepo: ctx.taskRepo });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.list_tasks({ compact: true });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.tasks[0]).toHaveProperty('id');
+		expect(data.tasks[0]).toHaveProperty('title');
+		expect(data.tasks[0]).toHaveProperty('status');
+		expect(data.tasks[0]).toHaveProperty('priority');
+		expect(data.tasks[0]).toHaveProperty('createdAt');
+		expect(data.tasks[0]).not.toHaveProperty('description');
+	});
+
+	test('paginates with limit and offset', async () => {
+		const config = makeConfig(ctx, { taskRepo: ctx.taskRepo });
+		const handlers = createNodeAgentToolHandlers(config);
+
+		// Get first page
+		const page1 = await handlers.list_tasks({ limit: 1, offset: 0 });
+		const data1 = JSON.parse(page1.content[0].text);
+		expect(data1.tasks).toHaveLength(1);
+		expect(data1.has_more).toBe(true);
+
+		// Get second page
+		const page2 = await handlers.list_tasks({ limit: 1, offset: 1 });
+		const data2 = JSON.parse(page2.content[0].text);
+		expect(data2.tasks).toHaveLength(1);
+		expect(data2.tasks[0].id).not.toBe(data1.tasks[0].id);
+	});
+
+	test('returns error when taskRepo is not available', async () => {
+		const config = makeConfig(ctx, { taskRepo: undefined });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.list_tasks({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('Task repository not available');
+	});
+});
+
+describe('node-agent-tools: get_task', () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+	});
+
+	afterEach(() => {
+		ctx.db.close();
+	});
+
+	test('gets task by task_number', async () => {
+		const config = makeConfig(ctx, { taskRepo: ctx.taskRepo });
+		const handlers = createNodeAgentToolHandlers(config);
+
+		// Create a task with a known number
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Task by number',
+			description: '',
+		});
+
+		const result = await handlers.get_task({ task_number: task.taskNumber });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.task.id).toBe(task.id);
+		expect(data.task.title).toBe('Task by number');
+	});
+
+	test('gets task by task_id', async () => {
+		const config = makeConfig(ctx, { taskRepo: ctx.taskRepo });
+		const handlers = createNodeAgentToolHandlers(config);
+
+		const task = ctx.taskRepo.createTask({
+			spaceId: ctx.spaceId,
+			title: 'Task by ID',
+			description: '',
+		});
+
+		const result = await handlers.get_task({ task_id: task.id });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.task.id).toBe(task.id);
+	});
+
+	test('scopes task_id lookup to current space', async () => {
+		const config = makeConfig(ctx, { taskRepo: ctx.taskRepo });
+		const handlers = createNodeAgentToolHandlers(config);
+
+		// Create another space and task
+		const otherSpaceId = 'other-space';
+		ctx.db
+			.prepare(
+				`INSERT INTO spaces (id, workspace_path, name, description, background_context, instructions,
+				 allowed_models, session_ids, slug, status, created_at, updated_at)
+				 VALUES (?, ?, ?, '', '', '', '[]', '[]', ?, 'active', ?, ?)`
+			)
+			.run(otherSpaceId, '/tmp/other', 'Other', 'other', Date.now(), Date.now());
+
+		const otherTask = ctx.taskRepo.createTask({
+			spaceId: otherSpaceId,
+			title: 'Other space task',
+			description: '',
+		});
+
+		// Should not find the task from the other space
+		const result = await handlers.get_task({ task_id: otherTask.id });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('Task not found');
+	});
+
+	test('returns error when neither task_id nor task_number is provided', async () => {
+		const config = makeConfig(ctx, { taskRepo: ctx.taskRepo });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.get_task({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('Either task_id or task_number is required');
+	});
+
+	test('returns error for non-existent task', async () => {
+		const config = makeConfig(ctx, { taskRepo: ctx.taskRepo });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.get_task({ task_number: 99999 });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('Task not found');
+	});
+
+	test('returns error when taskRepo is not available', async () => {
+		const config = makeConfig(ctx, { taskRepo: undefined });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.get_task({ task_id: 'some-id' });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('Task repository not available');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: list_audit_entries
+// ---------------------------------------------------------------------------
+
+describe('node-agent-tools: list_audit_entries', () => {
+	let ctx: TestCtx;
+	let auditLogRepo: McpAuditLogRepository;
+
+	beforeEach(() => {
+		ctx = makeCtx();
+		auditLogRepo = new McpAuditLogRepository(ctx.db);
+	});
+
+	afterEach(() => {
+		ctx.db.close();
+	});
+
+	test('lists audit entries by space', async () => {
+		auditLogRepo.createEntry({ toolName: 'send_message', spaceId: ctx.spaceId });
+		auditLogRepo.createEntry({ toolName: 'save_artifact', spaceId: ctx.spaceId });
+
+		const config = makeConfig(ctx, { auditLogRepo });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.list_audit_entries({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.entries).toHaveLength(2);
+		expect(data.entries[0].toolName).toBe('save_artifact');
+		expect(data.entries[1].toolName).toBe('send_message');
+	});
+
+	test('filters audit entries by task_id', async () => {
+		const taskA = 'task-a';
+		const taskB = 'task-b';
+		auditLogRepo.createEntry({ toolName: 't1', spaceId: ctx.spaceId, taskId: taskA });
+		auditLogRepo.createEntry({ toolName: 't2', spaceId: ctx.spaceId, taskId: taskA });
+		auditLogRepo.createEntry({ toolName: 't3', spaceId: ctx.spaceId, taskId: taskB });
+
+		const config = makeConfig(ctx, { auditLogRepo });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.list_audit_entries({ task_id: taskA });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.entries).toHaveLength(2);
+		expect(data.entries.every((e: { taskId: string }) => e.taskId === taskA)).toBe(true);
+	});
+
+	test('filters audit entries by session_id', async () => {
+		const sessA = 'sess-a';
+		const sessB = 'sess-b';
+		auditLogRepo.createEntry({ toolName: 't1', spaceId: ctx.spaceId, sessionId: sessA });
+		auditLogRepo.createEntry({ toolName: 't2', spaceId: ctx.spaceId, sessionId: sessA });
+		auditLogRepo.createEntry({ toolName: 't3', spaceId: ctx.spaceId, sessionId: sessB });
+
+		const config = makeConfig(ctx, { auditLogRepo });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.list_audit_entries({ session_id: sessA });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.entries).toHaveLength(2);
+		expect(data.entries.every((e: { sessionId: string }) => e.sessionId === sessA)).toBe(true);
+	});
+
+	test('task_id filter takes precedence over session_id', async () => {
+		auditLogRepo.createEntry({
+			toolName: 't1',
+			spaceId: ctx.spaceId,
+			taskId: 'task-x',
+			sessionId: 'sess-a',
+		});
+		auditLogRepo.createEntry({
+			toolName: 't2',
+			spaceId: ctx.spaceId,
+			taskId: 'task-y',
+			sessionId: 'sess-a',
+		});
+
+		const config = makeConfig(ctx, { auditLogRepo });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.list_audit_entries({ task_id: 'task-x', session_id: 'sess-a' });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.entries).toHaveLength(1);
+		expect(data.entries[0].taskId).toBe('task-x');
+	});
+
+	test('paginates with limit and offset', async () => {
+		auditLogRepo.createEntry({ toolName: 't1', spaceId: ctx.spaceId });
+		auditLogRepo.createEntry({ toolName: 't2', spaceId: ctx.spaceId });
+		auditLogRepo.createEntry({ toolName: 't3', spaceId: ctx.spaceId });
+
+		const config = makeConfig(ctx, { auditLogRepo });
+		const handlers = createNodeAgentToolHandlers(config);
+
+		const page1 = await handlers.list_audit_entries({ limit: 2, offset: 0 });
+		const data1 = JSON.parse(page1.content[0].text);
+		expect(data1.entries).toHaveLength(2);
+
+		const page2 = await handlers.list_audit_entries({ limit: 2, offset: 2 });
+		const data2 = JSON.parse(page2.content[0].text);
+		expect(data2.entries).toHaveLength(1);
+		expect(data2.entries[0].toolName).toBe('t1');
+	});
+
+	test('returns empty array when no entries match', async () => {
+		const config = makeConfig(ctx, { auditLogRepo });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.list_audit_entries({ task_id: 'nonexistent' });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.entries).toEqual([]);
+	});
+
+	test('returns error when auditLogRepo is not available', async () => {
+		const config = makeConfig(ctx, { auditLogRepo: undefined });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.list_audit_entries({});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(false);
+		expect(data.error).toContain('Audit log repository not available');
 	});
 });

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -3459,8 +3459,9 @@ describe('node-agent-tools: list_audit_entries', () => {
 		expect(data.entries).toHaveLength(2);
 		expect(data.total).toBe(2);
 		expect(data.has_more).toBe(false);
-		expect(data.entries[0].toolName).toBe('save_artifact');
-		expect(data.entries[1].toolName).toBe('send_message');
+		const toolNames = data.entries.map((e: { toolName: string }) => e.toolName);
+		expect(toolNames).toContain('send_message');
+		expect(toolNames).toContain('save_artifact');
 	});
 
 	test('filters audit entries by task_id with real total', async () => {
@@ -3499,6 +3500,42 @@ describe('node-agent-tools: list_audit_entries', () => {
 		expect(data.total).toBe(2);
 		expect(data.has_more).toBe(false);
 		expect(data.entries.every((e: { sessionId: string }) => e.sessionId === sessA)).toBe(true);
+	});
+
+	test('task_id filter is scoped to current space', async () => {
+		const sharedTaskId = 'shared-task';
+		auditLogRepo.createEntry({ toolName: 't1', spaceId: ctx.spaceId, taskId: sharedTaskId });
+		auditLogRepo.createEntry({ toolName: 't2', spaceId: 'other-space', taskId: sharedTaskId });
+
+		const config = makeConfig(ctx, { auditLogRepo });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.list_audit_entries({ task_id: sharedTaskId });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.entries).toHaveLength(1);
+		expect(data.entries[0].toolName).toBe('t1');
+		expect(data.total).toBe(1);
+	});
+
+	test('session_id filter is scoped to current space', async () => {
+		const sharedSessionId = 'shared-session';
+		auditLogRepo.createEntry({ toolName: 't1', spaceId: ctx.spaceId, sessionId: sharedSessionId });
+		auditLogRepo.createEntry({
+			toolName: 't2',
+			spaceId: 'other-space',
+			sessionId: sharedSessionId,
+		});
+
+		const config = makeConfig(ctx, { auditLogRepo });
+		const handlers = createNodeAgentToolHandlers(config);
+		const result = await handlers.list_audit_entries({ session_id: sharedSessionId });
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.success).toBe(true);
+		expect(data.entries).toHaveLength(1);
+		expect(data.entries[0].toolName).toBe('t1');
+		expect(data.total).toBe(1);
 	});
 
 	test('task_id filter takes precedence over session_id', async () => {

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -3446,7 +3446,7 @@ describe('node-agent-tools: list_audit_entries', () => {
 		ctx.db.close();
 	});
 
-	test('lists audit entries by space', async () => {
+	test('lists audit entries by space with real total and has_more', async () => {
 		auditLogRepo.createEntry({ toolName: 'send_message', spaceId: ctx.spaceId });
 		auditLogRepo.createEntry({ toolName: 'save_artifact', spaceId: ctx.spaceId });
 
@@ -3457,11 +3457,13 @@ describe('node-agent-tools: list_audit_entries', () => {
 
 		expect(data.success).toBe(true);
 		expect(data.entries).toHaveLength(2);
+		expect(data.total).toBe(2);
+		expect(data.has_more).toBe(false);
 		expect(data.entries[0].toolName).toBe('save_artifact');
 		expect(data.entries[1].toolName).toBe('send_message');
 	});
 
-	test('filters audit entries by task_id', async () => {
+	test('filters audit entries by task_id with real total', async () => {
 		const taskA = 'task-a';
 		const taskB = 'task-b';
 		auditLogRepo.createEntry({ toolName: 't1', spaceId: ctx.spaceId, taskId: taskA });
@@ -3475,10 +3477,12 @@ describe('node-agent-tools: list_audit_entries', () => {
 
 		expect(data.success).toBe(true);
 		expect(data.entries).toHaveLength(2);
+		expect(data.total).toBe(2);
+		expect(data.has_more).toBe(false);
 		expect(data.entries.every((e: { taskId: string }) => e.taskId === taskA)).toBe(true);
 	});
 
-	test('filters audit entries by session_id', async () => {
+	test('filters audit entries by session_id with real total', async () => {
 		const sessA = 'sess-a';
 		const sessB = 'sess-b';
 		auditLogRepo.createEntry({ toolName: 't1', spaceId: ctx.spaceId, sessionId: sessA });
@@ -3492,6 +3496,8 @@ describe('node-agent-tools: list_audit_entries', () => {
 
 		expect(data.success).toBe(true);
 		expect(data.entries).toHaveLength(2);
+		expect(data.total).toBe(2);
+		expect(data.has_more).toBe(false);
 		expect(data.entries.every((e: { sessionId: string }) => e.sessionId === sessA)).toBe(true);
 	});
 
@@ -3519,7 +3525,7 @@ describe('node-agent-tools: list_audit_entries', () => {
 		expect(data.entries[0].taskId).toBe('task-x');
 	});
 
-	test('paginates with limit and offset', async () => {
+	test('paginates with limit and offset, reporting real total and has_more', async () => {
 		auditLogRepo.createEntry({ toolName: 't1', spaceId: ctx.spaceId });
 		auditLogRepo.createEntry({ toolName: 't2', spaceId: ctx.spaceId });
 		auditLogRepo.createEntry({ toolName: 't3', spaceId: ctx.spaceId });
@@ -3530,14 +3536,18 @@ describe('node-agent-tools: list_audit_entries', () => {
 		const page1 = await handlers.list_audit_entries({ limit: 2, offset: 0 });
 		const data1 = JSON.parse(page1.content[0].text);
 		expect(data1.entries).toHaveLength(2);
+		expect(data1.total).toBe(3);
+		expect(data1.has_more).toBe(true);
 
 		const page2 = await handlers.list_audit_entries({ limit: 2, offset: 2 });
 		const data2 = JSON.parse(page2.content[0].text);
 		expect(data2.entries).toHaveLength(1);
+		expect(data2.total).toBe(3);
+		expect(data2.has_more).toBe(false);
 		expect(data2.entries[0].toolName).toBe('t1');
 	});
 
-	test('returns empty array when no entries match', async () => {
+	test('returns empty array with total=0 and has_more=false when no entries match', async () => {
 		const config = makeConfig(ctx, { auditLogRepo });
 		const handlers = createNodeAgentToolHandlers(config);
 		const result = await handlers.list_audit_entries({ task_id: 'nonexistent' });
@@ -3545,6 +3555,8 @@ describe('node-agent-tools: list_audit_entries', () => {
 
 		expect(data.success).toBe(true);
 		expect(data.entries).toEqual([]);
+		expect(data.total).toBe(0);
+		expect(data.has_more).toBe(false);
 	});
 
 	test('returns error when auditLogRepo is not available', async () => {

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -227,6 +227,8 @@ export function createSpaceTables(db: BunDatabase): void {
 			post_approval_session_id TEXT DEFAULT NULL,
 			post_approval_started_at INTEGER DEFAULT NULL,
 			post_approval_blocked_reason TEXT DEFAULT NULL,
+			created_by TEXT DEFAULT NULL,
+			created_by_session TEXT DEFAULT NULL,
 			archived_at INTEGER,
 			created_at INTEGER NOT NULL,
 			started_at INTEGER,
@@ -329,4 +331,22 @@ export function createSpaceTables(db: BunDatabase): void {
 			`ON pending_agent_messages(workflow_run_id, target_agent_name, idempotency_key) ` +
 			`WHERE idempotency_key IS NOT NULL`
 	);
+
+	// MCP audit log (migration 121)
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS mcp_audit_log (
+			id TEXT PRIMARY KEY,
+			timestamp INTEGER NOT NULL,
+			agent_name TEXT,
+			session_id TEXT,
+			tool_name TEXT NOT NULL,
+			params_summary TEXT,
+			space_id TEXT,
+			task_id TEXT,
+			workflow_run_id TEXT
+		)
+	`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_mcp_audit_log_space_id ON mcp_audit_log(space_id)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_mcp_audit_log_task_id ON mcp_audit_log(task_id)`);
+	db.exec(`CREATE INDEX IF NOT EXISTS idx_mcp_audit_log_session_id ON mcp_audit_log(session_id)`);
 }

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -346,7 +346,13 @@ export function createSpaceTables(db: BunDatabase): void {
 			workflow_run_id TEXT
 		)
 	`);
-	db.exec(`CREATE INDEX IF NOT EXISTS idx_mcp_audit_log_space_id ON mcp_audit_log(space_id)`);
-	db.exec(`CREATE INDEX IF NOT EXISTS idx_mcp_audit_log_task_id ON mcp_audit_log(task_id)`);
-	db.exec(`CREATE INDEX IF NOT EXISTS idx_mcp_audit_log_session_id ON mcp_audit_log(session_id)`);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_mcp_audit_log_space ON mcp_audit_log (space_id, timestamp)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_mcp_audit_log_task ON mcp_audit_log (task_id, timestamp)`
+	);
+	db.exec(
+		`CREATE INDEX IF NOT EXISTS idx_mcp_audit_log_session ON mcp_audit_log (session_id, timestamp)`
+	);
 }

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -302,6 +302,16 @@ export interface SpaceTask {
 	/** ID of the planning task that created this task */
 	createdByTaskId?: string | null;
 	/**
+	 * Agent name that created this task (e.g. 'space-agent', 'coder', 'task-agent').
+	 * Set when a task is created via `create_standalone_task` tool.
+	 */
+	createdBy?: string | null;
+	/**
+	 * Session ID of the agent that created this task.
+	 * Set when a task is created via `create_standalone_task` tool.
+	 */
+	createdBySession?: string | null;
+	/**
 	 * Which agent session is currently active (generating output).
 	 * Cleared when the session reaches a terminal state.
 	 */
@@ -465,6 +475,16 @@ export interface CreateSpaceTaskParams {
 	preferredWorkflowId?: string | null;
 	/** ID of planning task that created this task */
 	createdByTaskId?: string | null;
+	/**
+	 * Agent name that created this task (e.g. 'space-agent', 'coder', 'task-agent').
+	 * Set when a task is created via `create_standalone_task` tool.
+	 */
+	createdBy?: string | null;
+	/**
+	 * Session ID of the agent that created this task.
+	 * Set when a task is created via `create_standalone_task` tool.
+	 */
+	createdBySession?: string | null;
 	/**
 	 * ID of the Task Agent session that orchestrates this task's workflow execution.
 	 * Set when the task transitions from 'open' to 'in_progress'.


### PR DESCRIPTION
Adds task read tools and audit trail for MCP write operations, making task provenance queryable from within the agent system.

**New tools (node-agent)**
- `list_tasks` — list space tasks with status filter, compact mode, and pagination (`total` + `has_more`)
- `get_task` — resolve a task by numeric task number or UUID, space-scoped
- `list_audit_entries` — query MCP audit log by task, session, or space with pagination

**Creator attribution (migration 120)**
- `created_by` / `created_by_session` columns on `space_tasks`
- Stamped by `create_standalone_task` in both space-agent and node-agent tool sets
- RPC handler strips these fields to prevent caller-controlled attribution

**MCP audit log (migration 121)**
- `mcp_audit_log` table with composite indexes on `(space_id, timestamp)`, `(task_id, timestamp)`, `(session_id, timestamp)`
- `McpAuditLogRepository` with CRUD + space-scoped list/count methods
- Audit entries for: `create_standalone_task`, `approve_task`, `send_message` (gate writes), `save_artifact`
- All queries space-scoped to prevent cross-space data leakage
- Deterministic ordering via `ORDER BY timestamp DESC, id DESC`

**Wiring**
- `mySessionId` + `auditLogRepo` passed through all 6 production call sites in `SpaceRuntimeService` and `TaskAgentManager`
- Registered in `SPACE_SCOPE_TABLES` for db-query access