### PR TITLE
fix: scope task live-query invalidation to reduce daemon CPU

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -1319,6 +1319,7 @@ user_entries AS (
     )
 )
 SELECT
+  sessionId || ':' || turnIndex || ':' || rowId || ':' || blockIdx AS id,
   sessionId,
   turnIndex,
   ts,
@@ -1333,6 +1334,7 @@ SELECT
 FROM assistant_entries
 UNION ALL
 SELECT
+  sessionId || ':' || turnIndex || ':' || rowId || ':' || blockIdx AS id,
   sessionId,
   turnIndex,
   ts,
@@ -1345,7 +1347,7 @@ SELECT
   textValue,
   thinkingValue
 FROM user_entries
-ORDER BY sessionId ASC, ts ASC, rowId ASC, blockIdx ASC
+ORDER BY sessionId ASC, ts ASC, rowId ASC, blockIdx ASC, id ASC
 `.trim();
 
 // ============================================================================
@@ -1571,6 +1573,64 @@ export function buildActiveTurnSummariesFromRows(
 	}
 
 	return Array.from(bySession.values());
+}
+
+function mapActiveTurnEntryRow(row: Record<string, unknown>): Record<string, unknown> {
+	const sessionId = typeof row.sessionId === 'string' ? row.sessionId : '';
+	const turnIndex = Number(row.turnIndex ?? 0);
+	const ts = Number(row.ts ?? 0);
+	const uuid = typeof row.uuid === 'string' ? row.uuid : '';
+	const blockType = typeof row.blockType === 'string' ? row.blockType : '';
+	const rowId = typeof row.rowId === 'string' || typeof row.rowId === 'number' ? row.rowId : '';
+	const blockIdx = Number(row.blockIdx ?? -1);
+	const rawId = row.id;
+	const id = typeof rawId === 'string' ? rawId : `${sessionId}:${turnIndex}:${rowId}:${blockIdx}`;
+
+	let entry: Record<string, unknown> | null = null;
+	if (blockType === 'tool_use') {
+		const toolName = typeof row.toolName === 'string' ? row.toolName : '';
+		const rawInput = row.toolInput;
+		let parsedInput: Record<string, unknown> = {};
+		if (typeof rawInput === 'string') {
+			try {
+				const maybe = JSON.parse(rawInput);
+				if (maybe && typeof maybe === 'object') parsedInput = maybe as Record<string, unknown>;
+			} catch {
+				parsedInput = {};
+			}
+		} else if (rawInput && typeof rawInput === 'object') {
+			parsedInput = rawInput as Record<string, unknown>;
+		}
+		entry = {
+			kind: 'tool_use',
+			toolName,
+			preview: activityPreviewFromToolInput(toolName, parsedInput),
+			ts,
+			uuid,
+		};
+	} else if (blockType === 'text') {
+		const text = typeof row.textValue === 'string' ? row.textValue : '';
+		if (text.trim().length > 0) entry = { kind: 'text', text: activityOneLine(text), ts, uuid };
+	} else if (blockType === 'thinking') {
+		const thinking = typeof row.thinkingValue === 'string' ? row.thinkingValue : '';
+		if (thinking.trim().length > 0) {
+			entry = { kind: 'thinking', preview: thinking.trim(), ts, uuid };
+		}
+	} else if (blockType === '__user_message') {
+		const text = typeof row.textValue === 'string' ? row.textValue : '';
+		entry = { kind: 'user_message', text: activityOneLine(text), ts, uuid };
+	} else if (blockType === '__user_replay') {
+		const text = typeof row.textValue === 'string' ? row.textValue : '';
+		entry = { kind: 'agent_handoff', text: activityOneLine(text), ts, uuid };
+	}
+
+	return {
+		id,
+		sessionId,
+		turnIndex,
+		ts,
+		entry,
+	};
 }
 
 // ============================================================================
@@ -1925,6 +1985,7 @@ function buildTaskScopeFilter(
 		 LIMIT 1`
 	);
 	return (scope) => {
+		if (scope.taskId) return scope.taskId === taskId;
 		if (!scope.sessionId) return true;
 		if (linkedSessions.has(scope.sessionId)) return true;
 		if (messageStmt.get(taskId, scope.sessionId)) return true;
@@ -1980,6 +2041,16 @@ export const NAMED_QUERY_REGISTRY = new Map<string, NamedQuery>([
 			paramCount: 1,
 			debounceMs: DEBOUNCE_SPACE_TASK_FEEDS_MS,
 			mapRow: mapSpaceTaskMessageRow,
+			buildScopeFilter: buildTaskScopeFilter,
+		},
+	],
+	[
+		'spaceTaskActiveTurn.byTask',
+		{
+			sql: SPACE_TASK_ACTIVE_TURN_ENTRIES_BY_TASK_SQL,
+			paramCount: 1,
+			debounceMs: DEBOUNCE_SPACE_TASK_FEEDS_MS,
+			mapRow: mapActiveTurnEntryRow,
 			buildScopeFilter: buildTaskScopeFilter,
 		},
 	],
@@ -2115,43 +2186,8 @@ export function setupLiveQueryHandlers(
 	const stmtSessionsTotalCount = db.prepare(SESSIONS_TOTAL_COUNT_SQL);
 	const stmtSessionsArchivedCount = db.prepare(SESSIONS_ARCHIVED_COUNT_SQL);
 
-	// Sidecar prepared statement for the compact-thread mapResult: emits one
-	// row per activity entry in each session's currently-active turn. The
-	// compact thread query itself caps rows per turn at 5; this sidecar is
-	// the uncapped feed used to drive the running roster on the task view.
-	//
-	// Prepared lazily on first use so daemon startup doesn't depend on every
-	// table referenced by the CTE chain (e.g. `node_executions`) being live
-	// yet. Preparing eagerly here regressed test setups whose minimal schema
-	// hadn't run the migration that creates that table.
-	let _stmtActiveTurnEntries: ReturnType<BunDatabase['prepare']> | null = null;
-	const getStmtActiveTurnEntries = () => {
-		if (!_stmtActiveTurnEntries) {
-			_stmtActiveTurnEntries = db.prepare(SPACE_TASK_ACTIVE_TURN_ENTRIES_BY_TASK_SQL);
-		}
-		return _stmtActiveTurnEntries;
-	};
-
 	const sessionsListBase = NAMED_QUERY_REGISTRY.get('sessions.list')!;
 	const activeRegistry = new Map(NAMED_QUERY_REGISTRY);
-
-	// Override the compact-thread query so each evaluation also computes the
-	// active-turn activity summary alongside the compact rows. Wired through
-	// the metadata channel so existing snapshot/delta plumbing carries it
-	// without a parallel subscription.
-	const compactThreadBase = NAMED_QUERY_REGISTRY.get('spaceTaskMessages.byTask.compact')!;
-	activeRegistry.set('spaceTaskMessages.byTask.compact', {
-		...compactThreadBase,
-		mapResult: (_rawRows, params) => {
-			const taskId = params[0];
-			if (typeof taskId !== 'string' || taskId.length === 0) return undefined;
-			const entryRows = getStmtActiveTurnEntries().all(taskId) as Record<string, unknown>[];
-			const summaries = buildActiveTurnSummariesFromRows(entryRows);
-			// Always emit the field so the client sees an authoritative empty
-			// list rather than a stale value from a prior snapshot.
-			return { activeTurnSummaries: summaries };
-		},
-	});
 
 	activeRegistry.set('sessions.list', {
 		...sessionsListBase,
@@ -2234,7 +2270,8 @@ export function setupLiveQueryHandlers(
 		} else if (
 			queryName === 'spaceTaskActivity.byTask' ||
 			queryName === 'spaceTaskMessages.byTask' ||
-			queryName === 'spaceTaskMessages.byTask.compact'
+			queryName === 'spaceTaskMessages.byTask.compact' ||
+			queryName === 'spaceTaskActiveTurn.byTask'
 		) {
 			const taskId = params[0] as string;
 			let spaceTask: { space_id: string } | null = null;

--- a/packages/daemon/src/storage/reactive-database.ts
+++ b/packages/daemon/src/storage/reactive-database.ts
@@ -20,7 +20,13 @@ export interface TableChangeScope {
 export interface TableChangeEvent {
 	tables: string[];
 	versions: Record<string, number>;
-	/** Scope metadata for the change. Only populated for single-table, non-transaction events. */
+	/**
+	 * Scope metadata for the change. Populated for single-table, non-transaction
+	 * events, and also for transaction-flush events when every pending write to a
+	 * given table shares a compatible scope (see `addPendingScope` /
+	 * `mergeScopes`). Left unset when transaction batches contain conflicting or
+	 * unscoped writes.
+	 */
 	scope?: TableChangeScope;
 }
 

--- a/packages/daemon/src/storage/reactive-database.ts
+++ b/packages/daemon/src/storage/reactive-database.ts
@@ -13,6 +13,8 @@ import { Database } from './index';
 export interface TableChangeScope {
 	/** The session that produced the write, when known. */
 	sessionId?: string;
+	/** The Space task affected by the write, when known. */
+	taskId?: string;
 }
 
 export interface TableChangeEvent {
@@ -65,7 +67,90 @@ export interface ReactiveDatabase {
 interface MethodMapping {
 	table: string;
 	/** Extract scope from the method's positional arguments. */
-	extractScope?: (args: unknown[]) => TableChangeScope;
+	extractScope?: (args: unknown[], db: Database) => TableChangeScope;
+}
+
+function resolveTaskIdForSession(db: Database, sessionId: string): string | undefined {
+	try {
+		const row = db
+			.getDatabase()
+			.prepare(
+				`SELECT
+					CASE
+						WHEN session_context IS NULL THEN NULL
+						WHEN NOT json_valid(session_context) THEN NULL
+						ELSE json_extract(session_context, '$.taskId')
+					END AS task_id,
+					type
+				 FROM sessions WHERE id = ?`
+			)
+			.get(sessionId) as { task_id: string | null; type: string | null } | undefined;
+		if (!row?.type || !['space_task_agent', 'worker'].includes(row.type)) return undefined;
+		return row.task_id ?? undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function sdkMessageScope(db: Database, sessionId: unknown): TableChangeScope {
+	if (typeof sessionId !== 'string') return {};
+	return { sessionId, taskId: resolveTaskIdForSession(db, sessionId) };
+}
+
+function messageIdsScope(db: Database, messageIds: unknown): TableChangeScope {
+	if (!Array.isArray(messageIds) || messageIds.length === 0) return {};
+	try {
+		const ids = messageIds.filter((id): id is string => typeof id === 'string');
+		if (ids.length === 0) return {};
+		const placeholders = ids.map(() => '?').join(',');
+		const rows = db
+			.getDatabase()
+			.prepare(
+				`SELECT DISTINCT session_id, task_id FROM sdk_messages WHERE id IN (${placeholders})`
+			)
+			.all(...ids) as Array<{ session_id: string | null; task_id: string | null }>;
+		return (
+			mergeScopes(
+				rows.map((row) => ({
+					sessionId: row.session_id ?? undefined,
+					taskId: row.task_id ?? undefined,
+				}))
+			) ?? {}
+		);
+	} catch {
+		return {};
+	}
+}
+
+function messageIdScope(db: Database, messageId: unknown): TableChangeScope {
+	if (typeof messageId !== 'string') return {};
+	try {
+		const row = db
+			.getDatabase()
+			.prepare(`SELECT session_id, task_id FROM sdk_messages WHERE id = ?`)
+			.get(messageId) as { session_id: string | null; task_id: string | null } | undefined;
+		return { sessionId: row?.session_id ?? undefined, taskId: row?.task_id ?? undefined };
+	} catch {
+		return {};
+	}
+}
+
+function mergeScopes(scopes: TableChangeScope[]): TableChangeScope | undefined {
+	if (scopes.length === 0) return undefined;
+	let sessionId: string | undefined;
+	let taskId: string | undefined;
+	for (const scope of scopes) {
+		if (scope.sessionId) {
+			if (sessionId && sessionId !== scope.sessionId) return undefined;
+			sessionId = scope.sessionId;
+		}
+		if (scope.taskId) {
+			if (taskId && taskId !== scope.taskId) return undefined;
+			taskId = scope.taskId;
+		}
+	}
+	if (!sessionId && !taskId) return undefined;
+	return { sessionId, taskId };
 }
 
 const METHOD_TABLE_MAP: Record<string, MethodMapping> = {
@@ -76,14 +161,20 @@ const METHOD_TABLE_MAP: Record<string, MethodMapping> = {
 	// SDK Message operations — scoped by sessionId where available
 	saveSDKMessage: {
 		table: 'sdk_messages',
-		extractScope: (args) => ({ sessionId: args[0] as string }),
+		extractScope: (args, db) => sdkMessageScope(db, args[0]),
 	},
 	saveUserMessage: {
 		table: 'sdk_messages',
-		extractScope: (args) => ({ sessionId: args[0] as string }),
+		extractScope: (args, db) => sdkMessageScope(db, args[0]),
 	},
-	updateMessageStatus: { table: 'sdk_messages' }, // args are messageIds, no sessionId
-	updateMessageTimestamp: { table: 'sdk_messages' }, // args are messageId, no sessionId
+	updateMessageStatus: {
+		table: 'sdk_messages',
+		extractScope: (args, db) => messageIdsScope(db, args[0]),
+	},
+	updateMessageTimestamp: {
+		table: 'sdk_messages',
+		extractScope: (args, db) => messageIdScope(db, args[0]),
+	},
 	deleteMessagesAfter: {
 		table: 'sdk_messages',
 		extractScope: (args) => ({ sessionId: args[0] as string }),
@@ -116,9 +207,24 @@ export function createReactiveDatabase(db: Database): ReactiveDatabase {
 	const tableVersions: Record<string, number> = {};
 	let transactionDepth = 0;
 	const pendingTables = new Set<string>();
+	const pendingTableScopes = new Map<string, TableChangeScope | null>();
 
 	function getVersion(table: string): number {
 		return tableVersions[table] ?? 0;
+	}
+
+	function addPendingScope(table: string, scope?: TableChangeScope): void {
+		if (!scope?.sessionId && !scope?.taskId) {
+			pendingTableScopes.set(table, null);
+			return;
+		}
+		const current = pendingTableScopes.get(table);
+		if (current === null) return;
+		if (!current) {
+			pendingTableScopes.set(table, scope);
+			return;
+		}
+		pendingTableScopes.set(table, mergeScopes([current, scope]) ?? null);
 	}
 
 	function incrementAndEmit(table: string, scope?: TableChangeScope): void {
@@ -127,6 +233,7 @@ export function createReactiveDatabase(db: Database): ReactiveDatabase {
 
 		if (transactionDepth > 0) {
 			pendingTables.add(table);
+			addPendingScope(table, scope);
 			return;
 		}
 
@@ -148,16 +255,23 @@ export function createReactiveDatabase(db: Database): ReactiveDatabase {
 		pendingTables.clear();
 
 		const versions: Record<string, number> = {};
+		const tableScopes = new Map(pendingTableScopes);
+		pendingTableScopes.clear();
+		const hasUnscopedTable = tables.some((table) => tableScopes.get(table) === null);
+		const scopes = tables.map((table) => tableScopes.get(table) ?? undefined);
+		const eventScope = hasUnscopedTable
+			? undefined
+			: mergeScopes(scopes.filter((scope): scope is TableChangeScope => !!scope));
+
 		for (const table of tables) {
 			const version = getVersion(table);
 			versions[table] = version;
-			const versionEvent: TableVersionEvent = { table, version };
+			const tableScope = tableScopes.get(table) ?? eventScope;
+			const versionEvent: TableVersionEvent = { table, version, scope: tableScope };
 			emitter.emit(`change:${table}`, versionEvent);
 		}
 
-		// Transaction flushes do not carry scope — multiple writes may target
-		// different sessions, making single-scope attribution inaccurate.
-		const changeEvent: TableChangeEvent = { tables, versions };
+		const changeEvent: TableChangeEvent = { tables, versions, scope: eventScope };
 		emitter.emit('change', changeEvent);
 	}
 
@@ -185,7 +299,7 @@ export function createReactiveDatabase(db: Database): ReactiveDatabase {
 			return function (this: Database, ...args: unknown[]) {
 				const result = (value as (...a: unknown[]) => unknown).apply(target, args);
 				// Only emit if the call didn't throw
-				const scope = mapping.extractScope?.(args);
+				const scope = mapping.extractScope?.(args, target);
 				incrementAndEmit(mapping.table, scope);
 				return result;
 			};
@@ -218,6 +332,7 @@ export function createReactiveDatabase(db: Database): ReactiveDatabase {
 			transactionDepth -= 1;
 			if (transactionDepth === 0) {
 				pendingTables.clear();
+				pendingTableScopes.clear();
 			}
 		},
 		notifyChange(table: string): void {

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-handlers.test.ts
@@ -56,6 +56,7 @@ describe('NAMED_QUERY_REGISTRY', () => {
 		expect(NAMED_QUERY_REGISTRY.has('spaceTaskActivity.byTask')).toBe(true);
 		expect(NAMED_QUERY_REGISTRY.has('spaceTaskMessages.byTask')).toBe(true);
 		expect(NAMED_QUERY_REGISTRY.has('spaceTaskMessages.byTask.compact')).toBe(true);
+		expect(NAMED_QUERY_REGISTRY.has('spaceTaskActiveTurn.byTask')).toBe(true);
 		expect(NAMED_QUERY_REGISTRY.has('skills.byRoom')).toBe(false);
 		expect(NAMED_QUERY_REGISTRY.has('neo.messages')).toBe(true);
 		expect(NAMED_QUERY_REGISTRY.has('neo.activity')).toBe(true);
@@ -66,6 +67,7 @@ describe('NAMED_QUERY_REGISTRY', () => {
 		expect(NAMED_QUERY_REGISTRY.get('spaceTaskActivity.byTask')!.paramCount).toBe(1);
 		expect(NAMED_QUERY_REGISTRY.get('spaceTaskMessages.byTask')!.paramCount).toBe(1);
 		expect(NAMED_QUERY_REGISTRY.get('spaceTaskMessages.byTask.compact')!.paramCount).toBe(1);
+		expect(NAMED_QUERY_REGISTRY.get('spaceTaskActiveTurn.byTask')!.paramCount).toBe(1);
 		expect(NAMED_QUERY_REGISTRY.get('neo.messages')!.paramCount).toBe(2);
 		expect(NAMED_QUERY_REGISTRY.get('neo.activity')!.paramCount).toBe(2);
 	});
@@ -881,7 +883,7 @@ describe('NAMED_QUERY_REGISTRY', () => {
 
 		// -----------------------------------------------------------------------
 		// SPACE_TASK_ACTIVE_TURN_ENTRIES_BY_TASK_SQL — server-derived running
-		// roster source. Drives `metadata.activeTurnSummaries` on the compact
+		// roster source. Backing SQL for the separate `spaceTaskActiveTurn.byTask`
 		// LiveQuery; the client renders this directly without re-deriving from
 		// the (potentially truncated) compact rows.
 		// -----------------------------------------------------------------------

--- a/packages/daemon/tests/unit/4-space-storage/storage/scoped-invalidation.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/scoped-invalidation.test.ts
@@ -32,7 +32,11 @@ function makeTempDbPath(): string {
 	return join(tmpdir(), `scoped-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
 }
 
-function makeSession(id: string): Session {
+function makeSession(
+	id: string,
+	context?: Session['context'],
+	type: Session['type'] = 'worker'
+): Session {
 	const now = new Date().toISOString();
 	const config: SessionConfig = {
 		model: 'claude-sonnet-4-5-20250929',
@@ -56,6 +60,8 @@ function makeSession(id: string): Session {
 		status: 'active',
 		config,
 		metadata,
+		type,
+		context,
 	};
 }
 
@@ -172,15 +178,29 @@ describe('ReactiveDatabase — scope extraction', () => {
 		expect(sdkEvent!.scope).toEqual({ sessionId: 'sess-3' });
 	});
 
-	test('updateMessageStatus emits change event WITHOUT scope (no sessionId in args)', () => {
+	test('updateMessageStatus emits scope when message ids resolve to one scope', () => {
 		const events: TableChangeEvent[] = [];
 		reactiveDb.on('change', (data) => events.push(data));
 
-		reactiveDb.db.updateMessageStatus(['msg-id-1', 'msg-id-2'], 'consumed');
+		reactiveDb.db.createSession(makeSession('sess-status', { taskId: 'task-status' }));
+		const messageId = reactiveDb.db.saveUserMessage(
+			'sess-status',
+			{
+				type: 'user',
+				uuid: 'test-uuid-status',
+				session_id: 'sess-status',
+				parent_tool_use_id: null,
+				message: { role: 'user', content: [{ type: 'text', text: 'status' }] },
+			} as any,
+			'enqueued'
+		);
+		events.length = 0;
+
+		reactiveDb.db.updateMessageStatus([messageId], 'consumed');
 
 		const sdkEvent = events.find((e) => e.tables.includes('sdk_messages'));
 		expect(sdkEvent).toBeDefined();
-		expect(sdkEvent!.scope).toBeUndefined();
+		expect(sdkEvent!.scope).toEqual({ sessionId: 'sess-status', taskId: 'task-status' });
 	});
 
 	test('change:<table> event includes scope', () => {
@@ -203,7 +223,7 @@ describe('ReactiveDatabase — scope extraction', () => {
 		expect(scopedEvent!.scope).toEqual({ sessionId: 'sess-4' });
 	});
 
-	test('transaction flush does NOT carry scope', () => {
+	test('transaction flush preserves compatible scope', () => {
 		const events: TableChangeEvent[] = [];
 		reactiveDb.on('change', (data) => events.push(data));
 
@@ -220,11 +240,54 @@ describe('ReactiveDatabase — scope extraction', () => {
 		reactiveDb.db.saveSDKMessage('sess-5', message as any);
 		reactiveDb.commitTransaction();
 
-		// Transaction flush event
-		const txEvent =
-			events.find((e) => e.tables.includes('sdk_messages') && e.tables.length > 1) ||
-			events[events.length - 1];
-		// Scope should be undefined for transaction commits
+		const txEvent = events[events.length - 1];
+		expect(txEvent.scope).toEqual({ sessionId: 'sess-5' });
+	});
+
+	test('sdk message scope includes taskId for task sessions', () => {
+		const events: TableChangeEvent[] = [];
+		reactiveDb.on('change', (data) => events.push(data));
+
+		reactiveDb.db.createSession(makeSession('sess-task', { taskId: 'task-1' }));
+		const message = {
+			type: 'assistant',
+			uuid: 'test-uuid-task',
+			session_id: 'sess-task',
+			parent_tool_use_id: null,
+			message: { role: 'assistant', content: [{ type: 'text', text: 'task' }] },
+		};
+		reactiveDb.db.saveSDKMessage('sess-task', message as any);
+
+		const sdkEvent = events.find((e) => e.tables.includes('sdk_messages'));
+		expect(sdkEvent).toBeDefined();
+		expect(sdkEvent!.scope).toEqual({ sessionId: 'sess-task', taskId: 'task-1' });
+	});
+
+	test('transaction flush drops scope for mixed sessions', () => {
+		const events: TableChangeEvent[] = [];
+		reactiveDb.on('change', (data) => events.push(data));
+
+		reactiveDb.db.createSession(makeSession('sess-a', { taskId: 'task-a' }));
+		reactiveDb.db.createSession(makeSession('sess-b', { taskId: 'task-b' }));
+
+		reactiveDb.beginTransaction();
+		reactiveDb.db.saveSDKMessage('sess-a', {
+			type: 'assistant',
+			uuid: 'test-uuid-a',
+			session_id: 'sess-a',
+			parent_tool_use_id: null,
+			message: { role: 'assistant', content: [{ type: 'text', text: 'a' }] },
+		} as any);
+		reactiveDb.db.saveSDKMessage('sess-b', {
+			type: 'assistant',
+			uuid: 'test-uuid-b',
+			session_id: 'sess-b',
+			parent_tool_use_id: null,
+			message: { role: 'assistant', content: [{ type: 'text', text: 'b' }] },
+		} as any);
+		reactiveDb.commitTransaction();
+
+		const txEvent = events[events.length - 1];
 		expect(txEvent.scope).toBeUndefined();
 	});
 

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -1820,9 +1820,9 @@ export interface ApprovalRecord {
 // the client derived the roster from the same compacted feed rows used by the
 // minimal thread renderer — capped at the last 5 non-terminal renderable rows
 // per turn — so long turns under-reported their activity. The server now
-// computes the full chronological activity list per active turn alongside the
-// compact feed and ships it as `activeTurnSummaries` on the LiveQuery
-// metadata channel; the client display cap is applied at render time.
+// computes the full chronological activity list per active turn via the
+// `spaceTaskActiveTurn.byTask` LiveQuery; the client display cap is applied at
+// render time.
 
 /** A single chronological activity entry within an active turn. */
 export type ActivityEntry =
@@ -1839,9 +1839,7 @@ export type ActivityEntry =
 
 /**
  * Per-(session, turn) summary of activity entries within an active (incomplete)
- * turn. Emitted on the `liveQuery.snapshot`/`liveQuery.delta` `metadata` field
- * for the `spaceTaskMessages.byTask.compact` query under
- * `metadata.activeTurnSummaries`.
+ * turn. Derived client-side from `spaceTaskActiveTurn.byTask` rows.
  *
  * The server only emits a summary for the highest turnIndex per session that
  * has not yet seen a terminal `result` row. Closed turns are excluded —

--- a/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
+++ b/packages/web/src/components/space/thread/minimal/MinimalThreadFeed.tsx
@@ -271,10 +271,10 @@ function rosterEntriesFromSummary(
 
 /**
  * Defensive string coercion for fields that the typed `ActivityEntry` shape
- * declares as `string`. `parseActiveTurnSummaries` validates the wrapper but
- * intentionally trusts entry-level fields (the daemon already normalises
- * them), so we coerce here as a belt-and-braces guard against a malformed
- * entry crashing the renderer with a `TypeError` on `.trim()`.
+ * declares as `string`. The daemon already normalises entry-level fields when
+ * it builds `ActiveTurnSummary`, but we coerce here as a belt-and-braces guard
+ * against a malformed entry crashing the renderer with a `TypeError` on
+ * `.trim()`.
  */
 function asTrimmedString(value: unknown): string {
 	return typeof value === 'string' ? value.trim() : '';

--- a/packages/web/src/hooks/__tests__/useSpaceTaskMessages.test.ts
+++ b/packages/web/src/hooks/__tests__/useSpaceTaskMessages.test.ts
@@ -49,9 +49,22 @@ function fireEvent(method: string, payload: unknown): void {
 	(eventHandlers[method] ?? []).forEach((h) => h(payload));
 }
 
-function lastSubscribeSubId(): string {
-	const subscribeCalls = mockRequest.mock.calls.filter((call) => call[0] === 'liveQuery.subscribe');
-	return subscribeCalls[subscribeCalls.length - 1][1].subscriptionId;
+function subscribeCalls() {
+	return mockRequest.mock.calls.filter((call) => call[0] === 'liveQuery.subscribe');
+}
+
+function lastMessageSubscribeSubId(): string {
+	const calls = subscribeCalls().filter((call) =>
+		String(call[1].queryName).startsWith('spaceTaskMessages.')
+	);
+	return calls[calls.length - 1][1].subscriptionId;
+}
+
+function lastActiveTurnSubscribeSubId(): string {
+	const calls = subscribeCalls().filter(
+		(call) => call[1].queryName === 'spaceTaskActiveTurn.byTask'
+	);
+	return calls[calls.length - 1][1].subscriptionId;
 }
 
 // ---------------------------------------------------------------------------
@@ -78,13 +91,19 @@ describe('useSpaceTaskMessages', () => {
 		});
 	});
 
-	it('subscribes to the compact query name by default', () => {
+	it('subscribes to compact messages and active-turn queries by default', () => {
 		renderHook(() => useSpaceTaskMessages('task-abc'));
 
-		const subscribe = mockRequest.mock.calls.find(([method]) => method === 'liveQuery.subscribe');
-		expect(subscribe).toBeDefined();
-		expect(subscribe![1]).toMatchObject({
+		expect(subscribeCalls().map((call) => call[1].queryName)).toEqual([
+			'spaceTaskMessages.byTask.compact',
+			'spaceTaskActiveTurn.byTask',
+		]);
+		expect(subscribeCalls()[0][1]).toMatchObject({
 			queryName: 'spaceTaskMessages.byTask.compact',
+			params: ['task-abc'],
+		});
+		expect(subscribeCalls()[1][1]).toMatchObject({
+			queryName: 'spaceTaskActiveTurn.byTask',
 			params: ['task-abc'],
 		});
 	});
@@ -92,17 +111,17 @@ describe('useSpaceTaskMessages', () => {
 	it('subscribes to the compact query name when variant="compact"', () => {
 		renderHook(() => useSpaceTaskMessages('task-abc', 'compact'));
 
-		const subscribe = mockRequest.mock.calls.find(([method]) => method === 'liveQuery.subscribe');
-		expect(subscribe![1]).toMatchObject({
-			queryName: 'spaceTaskMessages.byTask.compact',
-		});
+		expect(subscribeCalls().map((call) => call[1].queryName)).toEqual([
+			'spaceTaskMessages.byTask.compact',
+			'spaceTaskActiveTurn.byTask',
+		]);
 	});
 
 	it('subscribes to the legacy full query name when variant="full"', () => {
 		renderHook(() => useSpaceTaskMessages('task-abc', 'full'));
 
-		const subscribe = mockRequest.mock.calls.find(([method]) => method === 'liveQuery.subscribe');
-		expect(subscribe![1]).toMatchObject({
+		expect(subscribeCalls()).toHaveLength(1);
+		expect(subscribeCalls()[0][1]).toMatchObject({
 			queryName: 'spaceTaskMessages.byTask',
 			params: ['task-abc'],
 		});
@@ -113,6 +132,41 @@ describe('useSpaceTaskMessages', () => {
 
 		const subscribe = mockRequest.mock.calls.find(([method]) => method === 'liveQuery.subscribe');
 		expect(subscribe).toBeUndefined();
+	});
+
+	it('builds active-turn summaries from the separate active-turn query', () => {
+		const { result } = renderHook(() => useSpaceTaskMessages('task-abc'));
+		const messageSubId = lastMessageSubscribeSubId();
+		const activeTurnSubId = lastActiveTurnSubscribeSubId();
+
+		act(() => {
+			fireEvent('liveQuery.snapshot', {
+				subscriptionId: messageSubId,
+				rows: [],
+				version: 1,
+			});
+			fireEvent('liveQuery.snapshot', {
+				subscriptionId: activeTurnSubId,
+				rows: [
+					{
+						id: 'sess-1:1:row-1:0',
+						sessionId: 'sess-1',
+						turnIndex: 1,
+						ts: 10,
+						entry: { kind: 'text', text: 'Working', ts: 10, uuid: 'u1' },
+					},
+				],
+				version: 1,
+			});
+		});
+
+		expect(result.current.activeTurnSummaries).toEqual([
+			{
+				sessionId: 'sess-1',
+				turnIndex: 1,
+				entries: [{ kind: 'text', text: 'Working', ts: 10, uuid: 'u1' }],
+			},
+		]);
 	});
 
 	// Regression coverage for the empty-state flash reported against
@@ -138,7 +192,7 @@ describe('useSpaceTaskMessages', () => {
 		it('flips isLoading to false once the LiveQuery snapshot arrives', () => {
 			const { result } = renderHook(() => useSpaceTaskMessages('task-1'));
 
-			const subId = lastSubscribeSubId();
+			const subId = lastMessageSubscribeSubId();
 			expect(result.current.isLoading).toBe(true);
 
 			act(() => {
@@ -159,7 +213,7 @@ describe('useSpaceTaskMessages', () => {
 			);
 
 			// Finish loading task-1.
-			const firstSubId = lastSubscribeSubId();
+			const firstSubId = lastMessageSubscribeSubId();
 			act(() => {
 				fireEvent('liveQuery.snapshot', {
 					subscriptionId: firstSubId,
@@ -175,7 +229,7 @@ describe('useSpaceTaskMessages', () => {
 			expect(result.current.isLoading).toBe(true);
 
 			// Snapshot for task-2 closes the gate.
-			const secondSubId = lastSubscribeSubId();
+			const secondSubId = lastMessageSubscribeSubId();
 			expect(secondSubId).not.toBe(firstSubId);
 			act(() => {
 				fireEvent('liveQuery.snapshot', {
@@ -213,7 +267,7 @@ describe('useSpaceTaskMessages', () => {
 			});
 
 			const { result } = renderHook(() => useSpaceTaskMessages('task-1'));
-			const firstSubId = lastSubscribeSubId();
+			const firstSubId = lastMessageSubscribeSubId();
 			act(() => {
 				fireEvent('liveQuery.snapshot', {
 					subscriptionId: firstSubId,
@@ -228,9 +282,7 @@ describe('useSpaceTaskMessages', () => {
 				connectionHandler?.('connected');
 			});
 
-			expect(
-				mockRequest.mock.calls.filter(([method]) => method === 'liveQuery.subscribe')
-			).toHaveLength(2);
+			expect(subscribeCalls()).toHaveLength(4);
 			expect(result.current.isLoading).toBe(true);
 			expect(result.current.rows).toHaveLength(1);
 

--- a/packages/web/src/hooks/useSpaceTaskMessages.ts
+++ b/packages/web/src/hooks/useSpaceTaskMessages.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import type {
 	ActiveTurnSummary,
+	ActivityEntry,
 	LiveQueryDeltaEvent,
 	LiveQuerySnapshotEvent,
 } from '@neokai/shared';
@@ -41,52 +42,22 @@ export interface SpaceTaskThreadMessageRow {
 	sessionMessageCount?: number;
 }
 
+interface ActiveTurnEntryRow {
+	id: string;
+	sessionId: string;
+	turnIndex: number;
+	ts: number;
+	entry: ActivityEntry | null;
+}
+
 export type SpaceTaskMessagesQueryVariant = 'compact' | 'full';
 
 export interface UseSpaceTaskMessagesResult {
 	rows: SpaceTaskThreadMessageRow[];
-	/**
-	 * Server-computed activity summary for the currently-active turn of each
-	 * session in the task. Empty array when no session has an open turn.
-	 *
-	 * Populated only by the `compact` query variant — the daemon ships this
-	 * alongside the compacted rows on the LiveQuery `metadata` channel so the
-	 * running roster on the task view can surface activity from the *full*
-	 * active turn (not the compacted slice). Closed turns are intentionally
-	 * absent.
-	 */
+	/** Server-computed activity summary for the currently-active turn of each session. */
 	activeTurnSummaries: ActiveTurnSummary[];
 	isLoading: boolean;
 	isReconnecting: boolean;
-}
-
-/**
- * Coerce a raw `metadata.activeTurnSummaries` payload into the typed
- * `ActiveTurnSummary[]` shape. The daemon already produces well-formed entries,
- * but defensive parsing here means a malformed snapshot can never crash the
- * thread renderer — it just falls back to an empty roster.
- */
-function parseActiveTurnSummaries(value: unknown): ActiveTurnSummary[] {
-	if (!Array.isArray(value)) return [];
-	const out: ActiveTurnSummary[] = [];
-	for (const raw of value) {
-		if (!raw || typeof raw !== 'object') continue;
-		const r = raw as Record<string, unknown>;
-		const sessionId = typeof r.sessionId === 'string' ? r.sessionId : null;
-		if (!sessionId) continue;
-		const turnIndex = typeof r.turnIndex === 'number' ? r.turnIndex : 0;
-		const entries = Array.isArray(r.entries)
-			? (r.entries as Record<string, unknown>[]).filter(
-					(e): e is Record<string, unknown> => !!e && typeof e === 'object'
-				)
-			: [];
-		out.push({
-			sessionId,
-			turnIndex,
-			entries: entries as ActiveTurnSummary['entries'],
-		});
-	}
-	return out;
 }
 
 let _taskMessageSubCounter = 0;
@@ -95,10 +66,24 @@ function nextTaskMessageSubId(taskId: string): string {
 	return `space-task-messages-${taskId}-${_taskMessageSubCounter}`;
 }
 
+let _activeTurnSubCounter = 0;
+function nextActiveTurnSubId(taskId: string): string {
+	_activeTurnSubCounter += 1;
+	return `space-task-active-turn-${taskId}-${_activeTurnSubCounter}`;
+}
+
 function sortRows(rows: SpaceTaskThreadMessageRow[]): SpaceTaskThreadMessageRow[] {
 	return [...rows].sort((a, b) => {
 		if (a.createdAt !== b.createdAt) return a.createdAt - b.createdAt;
 		return String(a.id).localeCompare(String(b.id));
+	});
+}
+
+function sortActiveTurnRows(rows: ActiveTurnEntryRow[]): ActiveTurnEntryRow[] {
+	return [...rows].sort((a, b) => {
+		if (a.sessionId !== b.sessionId) return a.sessionId.localeCompare(b.sessionId);
+		if (a.ts !== b.ts) return a.ts - b.ts;
+		return a.id.localeCompare(b.id);
 	});
 }
 
@@ -119,13 +104,44 @@ function applyDelta(
 	return sortRows(Array.from(next.values()));
 }
 
+function applyActiveTurnDelta(
+	currentRows: ActiveTurnEntryRow[],
+	event: LiveQueryDeltaEvent
+): ActiveTurnEntryRow[] {
+	const next = new Map(currentRows.map((row) => [row.id, row]));
+	for (const row of (event.removed ?? []) as ActiveTurnEntryRow[]) {
+		next.delete(row.id);
+	}
+	for (const row of (event.updated ?? []) as ActiveTurnEntryRow[]) {
+		next.set(row.id, row);
+	}
+	for (const row of (event.added ?? []) as ActiveTurnEntryRow[]) {
+		next.set(row.id, row);
+	}
+	return sortActiveTurnRows(Array.from(next.values()));
+}
+
+function buildActiveTurnSummaries(rows: ActiveTurnEntryRow[]): ActiveTurnSummary[] {
+	const bySession = new Map<string, ActiveTurnSummary>();
+	for (const row of sortActiveTurnRows(rows)) {
+		if (!row.sessionId || !row.entry) continue;
+		let summary = bySession.get(row.sessionId);
+		if (!summary) {
+			summary = { sessionId: row.sessionId, turnIndex: row.turnIndex, entries: [] };
+			bySession.set(row.sessionId, summary);
+		}
+		summary.entries.push(row.entry);
+	}
+	return Array.from(bySession.values());
+}
+
 export function useSpaceTaskMessages(
 	taskId: string | null,
 	variant: SpaceTaskMessagesQueryVariant = 'compact'
 ): UseSpaceTaskMessagesResult {
 	const { request, onEvent, getHub, isConnected } = useMessageHub();
 	const [rows, setRows] = useState<SpaceTaskThreadMessageRow[]>([]);
-	const [activeTurnSummaries, setActiveTurnSummaries] = useState<ActiveTurnSummary[]>([]);
+	const [activeTurnRows, setActiveTurnRows] = useState<ActiveTurnEntryRow[]>([]);
 	/**
 	 * The task id whose LiveQuery snapshot has been applied to `rows`.
 	 * `null` means either no subscription is active or we are still waiting
@@ -137,6 +153,7 @@ export function useSpaceTaskMessages(
 	 */
 	const [loadedForTaskId, setLoadedForTaskId] = useState<string | null>(null);
 	const activeSubIdRef = useRef<string | null>(null);
+	const activeTurnSubIdRef = useRef<string | null>(null);
 
 	const queryName =
 		variant === 'full' ? 'spaceTaskMessages.byTask' : 'spaceTaskMessages.byTask.compact';
@@ -144,35 +161,43 @@ export function useSpaceTaskMessages(
 	useEffect(() => {
 		if (!taskId || !isConnected) {
 			setRows([]);
-			setActiveTurnSummaries([]);
+			setActiveTurnRows([]);
 			setLoadedForTaskId(null);
 			activeSubIdRef.current = null;
+			activeTurnSubIdRef.current = null;
 			return;
 		}
 
 		const subscriptionId = nextTaskMessageSubId(taskId);
+		const activeTurnSubscriptionId = nextActiveTurnSubId(taskId);
+		const shouldSubscribeActiveTurn = variant === 'compact';
 		activeSubIdRef.current = subscriptionId;
+		activeTurnSubIdRef.current = shouldSubscribeActiveTurn ? activeTurnSubscriptionId : null;
 		// Clear stale rows from a previous subscription synchronously. The
 		// empty-state UI is still suppressed because `loadedForTaskId` is now
 		// out of sync with `taskId`, so consumers see the loading state.
 		setRows([]);
-		setActiveTurnSummaries([]);
+		setActiveTurnRows([]);
 		setLoadedForTaskId(null);
 
 		const unsubSnapshot = onEvent<LiveQuerySnapshotEvent>('liveQuery.snapshot', (event) => {
-			if (event.subscriptionId !== activeSubIdRef.current) return;
-			setRows(sortRows((event.rows as SpaceTaskThreadMessageRow[]) ?? []));
-			setActiveTurnSummaries(parseActiveTurnSummaries(event.metadata?.activeTurnSummaries));
-			setLoadedForTaskId(taskId);
+			if (event.subscriptionId === activeSubIdRef.current) {
+				setRows(sortRows((event.rows as SpaceTaskThreadMessageRow[]) ?? []));
+				setLoadedForTaskId(taskId);
+				return;
+			}
+			if (event.subscriptionId === activeTurnSubIdRef.current) {
+				setActiveTurnRows(sortActiveTurnRows((event.rows as ActiveTurnEntryRow[]) ?? []));
+			}
 		});
 
 		const unsubDelta = onEvent<LiveQueryDeltaEvent>('liveQuery.delta', (event) => {
-			if (event.subscriptionId !== activeSubIdRef.current) return;
-			setRows((prev) => applyDelta(prev, event));
-			// `metadata` is recomputed every evaluation, so a delta carries the
-			// current active-turn summary for the task — overwrite, don't merge.
-			if (event.metadata && 'activeTurnSummaries' in event.metadata) {
-				setActiveTurnSummaries(parseActiveTurnSummaries(event.metadata.activeTurnSummaries));
+			if (event.subscriptionId === activeSubIdRef.current) {
+				setRows((prev) => applyDelta(prev, event));
+				return;
+			}
+			if (event.subscriptionId === activeTurnSubIdRef.current) {
+				setActiveTurnRows((prev) => applyActiveTurnDelta(prev, event));
 			}
 		});
 
@@ -193,6 +218,19 @@ export function useSpaceTaskMessages(
 						setLoadedForTaskId(taskId);
 					}
 				});
+			if (shouldSubscribeActiveTurn) {
+				hub
+					.request('liveQuery.subscribe', {
+						queryName: 'spaceTaskActiveTurn.byTask',
+						params: [taskId],
+						subscriptionId: activeTurnSubscriptionId,
+					})
+					.catch(() => {
+						if (activeTurnSubIdRef.current === activeTurnSubscriptionId) {
+							setActiveTurnRows([]);
+						}
+					});
+			}
 		};
 
 		const unsubReconnect = getHub()?.onConnection((state) => {
@@ -209,11 +247,21 @@ export function useSpaceTaskMessages(
 			unsubDelta();
 			unsubReconnect?.();
 			activeSubIdRef.current = null;
+			activeTurnSubIdRef.current = null;
 			Promise.resolve(request('liveQuery.unsubscribe', { subscriptionId })).catch(() => {});
+			if (shouldSubscribeActiveTurn) {
+				Promise.resolve(
+					request('liveQuery.unsubscribe', { subscriptionId: activeTurnSubscriptionId })
+				).catch(() => {});
+			}
 		};
-	}, [taskId, isConnected, onEvent, request, getHub, queryName]);
+	}, [taskId, isConnected, onEvent, request, getHub, queryName, variant]);
 
 	const sortedRows = useMemo(() => sortRows(rows), [rows]);
+	const activeTurnSummaries = useMemo(
+		() => buildActiveTurnSummaries(activeTurnRows),
+		[activeTurnRows]
+	);
 
 	// Derived: we are loading whenever we have an active taskId but have not
 	// yet applied a snapshot for it. Computing this (instead of tracking it


### PR DESCRIPTION
Reduces high Bun daemon CPU usage while Space tasks are running by scoping live-query invalidation more precisely.

## Changes
- Preserve compatible `TableChangeScope` through reactive DB batches so scope info isn't lost.
- Add `taskId` to live-query invalidation scope for `sdk_messages` writes.
- Split active-turn summary out of `spaceTaskMessages.byTask.compact` into a separate `spaceTaskActiveTurn.byTask` LiveQuery so the compact message query stops re-firing on every turn-status change.
- Update `useSpaceTaskMessages` to subscribe to the compact query plus the new active-turn query.

## Tests
- `packages/daemon` unit: live-query-handlers, live-query-subscribe, scoped-invalidation — all passing.
- `packages/web` hook: `useSpaceTaskMessages.test.ts` — 11/11 passing.
- `bun run check` (lint + typecheck + knip + session guards) clean.