### PR TITLE
feat: add GLM-5V-Turbo model to GLM/Zhipu provider

### DIFF
--- a/packages/daemon/src/lib/providers/glm-provider.ts
+++ b/packages/daemon/src/lib/providers/glm-provider.ts
@@ -78,6 +78,17 @@ export class GlmProvider implements Provider {
 			available: true,
 		},
 		{
+			id: 'glm-5v-turbo',
+			name: 'GLM-5V-Turbo',
+			alias: 'glm-5v-turbo',
+			family: 'glm',
+			provider: 'glm',
+			contextWindow: 200000,
+			description: 'GLM-5V-Turbo · Vision-capable turbo model optimized for multimodal agent tasks',
+			releaseDate: '2026-05-01',
+			available: true,
+		},
+		{
 			id: 'glm-4.7',
 			name: 'GLM-4.7',
 			alias: 'glm-4.7',

--- a/packages/daemon/tests/unit/1-core/providers/glm-provider.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/glm-provider.test.ts
@@ -73,8 +73,14 @@ describe('GlmProvider', () => {
 
 			const models = await provider.getModels();
 
-			expect(models).toHaveLength(4);
-			expect(models.map((m) => m.id)).toEqual(['glm-5', 'glm-5.1', 'glm-5-turbo', 'glm-4.7']);
+			expect(models).toHaveLength(5);
+			expect(models.map((m) => m.id)).toEqual([
+				'glm-5',
+				'glm-5.1',
+				'glm-5-turbo',
+				'glm-5v-turbo',
+				'glm-4.7',
+			]);
 		});
 
 		it('should return empty array when API key is not available', async () => {
@@ -100,6 +106,7 @@ describe('GlmProvider', () => {
 		it('should own glm- prefixed models', () => {
 			expect(provider.ownsModel('glm-5')).toBe(true);
 			expect(provider.ownsModel('glm-5-turbo')).toBe(true);
+			expect(provider.ownsModel('glm-5v-turbo')).toBe(true);
 			expect(provider.ownsModel('glm-4.7')).toBe(true);
 			expect(provider.ownsModel('GLM-4')).toBe(true); // case insensitive
 		});
@@ -171,6 +178,19 @@ describe('GlmProvider', () => {
 			expect(config.isAnthropicCompatible).toBe(true);
 		});
 
+		it('should build correct config for glm-5v-turbo', () => {
+			process.env.GLM_API_KEY = 'test-key';
+
+			const config = provider.buildSdkConfig('glm-5v-turbo');
+
+			expect(config.envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('glm-5v-turbo');
+			expect(config.envVars.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('glm-5v-turbo');
+			expect(config.envVars.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('glm-5v-turbo');
+			expect(config.envVars.ANTHROPIC_BASE_URL).toBe('https://open.bigmodel.cn/api/anthropic');
+			expect(config.envVars.ANTHROPIC_AUTH_TOKEN).toBe('test-key');
+			expect(config.isAnthropicCompatible).toBe(true);
+		});
+
 		it('should use session config API key override', () => {
 			process.env.GLM_API_KEY = 'env-key';
 
@@ -208,6 +228,10 @@ describe('GlmProvider', () => {
 			expect(provider.translateModelIdForSdk('glm-5-turbo')).toBe('default');
 		});
 
+		it('should translate glm-5v-turbo to default', () => {
+			expect(provider.translateModelIdForSdk('glm-5v-turbo')).toBe('default');
+		});
+
 		it('should translate other GLM models to default', () => {
 			expect(provider.translateModelIdForSdk('glm-4')).toBe('default');
 		});
@@ -221,11 +245,12 @@ describe('GlmProvider', () => {
 
 	describe('static models', () => {
 		it('should have static models defined', () => {
-			expect(GlmProvider.MODELS).toHaveLength(4);
+			expect(GlmProvider.MODELS).toHaveLength(5);
 			expect(GlmProvider.MODELS.map((m) => m.id)).toEqual([
 				'glm-5',
 				'glm-5.1',
 				'glm-5-turbo',
+				'glm-5v-turbo',
 				'glm-4.7',
 			]);
 		});
@@ -239,6 +264,21 @@ describe('GlmProvider', () => {
 			expect(turbo!.provider).toBe('glm');
 			expect(turbo!.contextWindow).toBe(200000);
 			expect(turbo!.available).toBe(true);
+		});
+
+		it('should have correct glm-5v-turbo model definition', () => {
+			const vision = GlmProvider.MODELS.find((m) => m.id === 'glm-5v-turbo');
+			expect(vision).toBeDefined();
+			expect(vision!.name).toBe('GLM-5V-Turbo');
+			expect(vision!.alias).toBe('glm-5v-turbo');
+			expect(vision!.family).toBe('glm');
+			expect(vision!.provider).toBe('glm');
+			expect(vision!.contextWindow).toBe(200000);
+			expect(vision!.available).toBe(true);
+			expect(vision!.description).toBe(
+				'GLM-5V-Turbo · Vision-capable turbo model optimized for multimodal agent tasks'
+			);
+			expect(vision!.releaseDate).toBe('2026-05-01');
 		});
 
 		it('should have correct base URL', () => {


### PR DESCRIPTION
Add the new `GLM-5V-Turbo` vision model to the GLM/Zhipu provider's static `MODELS` array.

- Model ID: `glm-5v-turbo`
- 200K context window, vision-capable (provider already advertises `vision: true`)
- No changes needed to `ownsModel()` or `inferProviderForModel()` — the existing `glm-` prefix heuristics cover it
- Updated unit tests to cover the new entry