### PR TITLE
fix: plan & decompose workflow runtime, gate, and prompt issues

### DIFF
--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -546,6 +546,16 @@ export class ChannelRouter {
 			throw new ActivationError(`Run not found: ${runId}`);
 		}
 
+		// Archive is a hard tombstone: if every task on this run has been
+		// archived, no inter-agent activity is permitted. Check this BEFORE
+		// gate evaluation so scripted gates do not run on tombstoned runs and
+		// callers see the canonical archived-task error rather than a gate
+		// closure (which would falsely suggest the work could resume once the
+		// gate opens).
+		if (this.isParentTaskArchived(runId)) {
+			throw new ActivationError(ARCHIVED_TASK_ERROR_MESSAGE);
+		}
+
 		const workflow = this.config.workflowManager.getWorkflow(run.workflowId);
 		if (!workflow) {
 			throw new ActivationError(`Workflow not found: ${run.workflowId}`);
@@ -619,7 +629,27 @@ export class ChannelRouter {
 			});
 		}
 
-		// ── 5. Increment per-channel cycle count and reset cyclic gates ──────
+		// ── 5. Re-check gate AFTER activation ────────────────────────────────
+		// `await this.activateNode(...)` yields to the event loop. A concurrent
+		// `incrementAndResetCyclicChannel` (e.g. on a `resetOnCycle` gate) can
+		// reset gate data during that await, transitioning the gate from open
+		// → closed. Re-evaluate the gate here so a stale-gate race cannot let
+		// the message proceed as if the channel were still open. The pre-
+		// activation check (step 3) is still useful because it short-circuits
+		// the common case without creating pending executions; this second
+		// check is the correctness backstop.
+		if (channel?.gateId) {
+			const postActivationGate = await this.evaluateGateById(runId, channel.gateId, workflow);
+			if (!postActivationGate.open) {
+				throw new ChannelGateBlockedError(
+					postActivationGate.reason ??
+						`Gate "${channel.gateId}" closed during activation; blocking delivery from "${fromRole}" to "${toTarget}"`,
+					channel.gateId
+				);
+			}
+		}
+
+		// ── 6. Increment per-channel cycle count and reset cyclic gates ──────
 		if (channelIsCyclic && channel) {
 			this.incrementAndResetCyclicChannel(runId, channelIndex, channel.maxCycles ?? 5, workflow);
 		}

--- a/packages/daemon/src/lib/space/runtime/channel-router.ts
+++ b/packages/daemon/src/lib/space/runtime/channel-router.ts
@@ -557,9 +557,12 @@ export class ChannelRouter {
 		const channelIsCyclic = match ? this.isChannelCyclicByIndex(channelIndex, workflow) : false;
 
 		// ── 2. Target resolution: agent name → DM, node name → fan-out ────────
-		// Activation is intentionally resolved before gate evaluation below. Gates may
-		// block delivery of the message content, but they must not block spawning or
-		// resuming the target agent session that needs to receive/react to the handoff.
+		// Target resolution itself is non-mutating — only `activateNode` below
+		// creates pending node_executions. For gated channels we evaluate the
+		// gate BEFORE activating so blocked messages do not spawn the target
+		// agent session prematurely. Once the gate opens (via
+		// `onGateDataChanged` or a subsequent send), the target is activated
+		// from the same code path.
 		let targetNode = this.findNodeByAgentName(workflow, toTarget);
 		let isFanOut = false;
 
@@ -587,7 +590,25 @@ export class ChannelRouter {
 			}
 		}
 
-		// ── 3. Lazy activation ─────────────────────────────────────────────────
+		// ── 3. Gate evaluation (BEFORE activation) ───────────────────────────
+		// Evaluate the channel's gate first when one exists. If the gate is
+		// closed, throw without creating any pending node_executions for the
+		// target — otherwise the tick loop would spawn agent sessions for
+		// gates that have not yet opened (e.g. Task Dispatcher activating
+		// before all 4 reviewers approve in plan-approval-gate).
+		if (channel?.gateId) {
+			const gateResult = await this.evaluateGateById(runId, channel.gateId, workflow);
+			if (!gateResult.open) {
+				throw new ChannelGateBlockedError(
+					gateResult.reason ??
+						`Gate "${channel.gateId}" blocked delivery from "${fromRole}" to "${toTarget}"`,
+					channel.gateId
+				);
+			}
+		}
+
+		// ── 4. Lazy activation ─────────────────────────────────────────────────
+		// Only reached when the channel is open (no gate, or gate eval passed).
 		const activeTasks = this.getActiveTasksForNode(runId, targetNode.id);
 		let activatedTasks: SpaceTask[] | undefined;
 
@@ -596,20 +617,6 @@ export class ChannelRouter {
 				reopenBy: `agent:${fromRole}`,
 				reopenReason: `peer send_message from "${fromRole}" to "${toTarget}"`,
 			});
-		}
-
-		// ── 4. Gate evaluation ───────────────────────────────────────────────
-		if (channel) {
-			if (channel.gateId) {
-				const gateResult = await this.evaluateGateById(runId, channel.gateId, workflow);
-				if (!gateResult.open) {
-					throw new ChannelGateBlockedError(
-						gateResult.reason ??
-							`Gate "${channel.gateId}" blocked delivery from "${fromRole}" to "${toTarget}"`,
-						channel.gateId
-					);
-				}
-			}
 		}
 
 		// ── 5. Increment per-channel cycle count and reset cyclic gates ──────

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -621,10 +621,36 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 							}
 
 							if (Object.keys(authorizedData).length > 0) {
-								const updated = gateDataRepo.merge(workflowRunId, gateId, {
+								// Deep-merge map-type fields: each reviewer in a vote-counting gate
+								// (e.g. plan-approval-gate `approvals: map`) writes a partial map
+								// keyed by their lens/identity. A shallow merge would replace the
+								// entire map with the latest writer's entry only — losing prior
+								// votes. For every authorized field whose definition is `type: map`,
+								// merge the new entries on top of the previously stored entries
+								// before handing off to gateDataRepo.merge.
+								const existingRecord = gateDataRepo.get(workflowRunId, gateId);
+								const existingData = existingRecord?.data ?? {};
+								const partialToMerge: Record<string, unknown> = {
 									...authorizedData,
 									approvalSource: 'agent',
-								});
+								};
+								for (const [key, value] of Object.entries(authorizedData)) {
+									const fieldDef = fieldMap.get(key);
+									if (!fieldDef || fieldDef.type !== 'map') continue;
+									if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+									const existingMap = existingData[key];
+									if (
+										existingMap &&
+										typeof existingMap === 'object' &&
+										!Array.isArray(existingMap)
+									) {
+										partialToMerge[key] = {
+											...(existingMap as Record<string, unknown>),
+											...(value as Record<string, unknown>),
+										};
+									}
+								}
+								const updated = gateDataRepo.merge(workflowRunId, gateId, partialToMerge);
 								const evalResult = await evaluateGate(
 									gateDef,
 									updated.data,

--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -621,36 +621,34 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 							}
 
 							if (Object.keys(authorizedData).length > 0) {
-								// Deep-merge map-type fields: each reviewer in a vote-counting gate
-								// (e.g. plan-approval-gate `approvals: map`) writes a partial map
-								// keyed by their lens/identity. A shallow merge would replace the
-								// entire map with the latest writer's entry only — losing prior
-								// votes. For every authorized field whose definition is `type: map`,
-								// merge the new entries on top of the previously stored entries
-								// before handing off to gateDataRepo.merge.
-								const existingRecord = gateDataRepo.get(workflowRunId, gateId);
-								const existingData = existingRecord?.data ?? {};
+								// Deep-merge map-type fields atomically: each reviewer in a
+								// vote-counting gate (e.g. plan-approval-gate `approvals: map`)
+								// writes a partial map keyed by their lens/identity. A naive
+								// shallow merge would replace the whole map with the latest
+								// writer's entry, losing prior votes. Doing the read-merge-write
+								// in JS would also race with `incrementAndResetCyclicChannel`
+								// (which clears the gate on revision feedback) — if a stale
+								// snapshot was read before the reset and written back after,
+								// cleared votes would resurrect. Push the deep-merge into the
+								// repository so it runs inside a single SQLite transaction.
+								const mapFields = new Set<string>();
+								for (const key of Object.keys(authorizedData)) {
+									const fieldDef = fieldMap.get(key);
+									if (fieldDef?.type === 'map') mapFields.add(key);
+								}
 								const partialToMerge: Record<string, unknown> = {
 									...authorizedData,
 									approvalSource: 'agent',
 								};
-								for (const [key, value] of Object.entries(authorizedData)) {
-									const fieldDef = fieldMap.get(key);
-									if (!fieldDef || fieldDef.type !== 'map') continue;
-									if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
-									const existingMap = existingData[key];
-									if (
-										existingMap &&
-										typeof existingMap === 'object' &&
-										!Array.isArray(existingMap)
-									) {
-										partialToMerge[key] = {
-											...(existingMap as Record<string, unknown>),
-											...(value as Record<string, unknown>),
-										};
-									}
-								}
-								const updated = gateDataRepo.merge(workflowRunId, gateId, partialToMerge);
+								const updated =
+									mapFields.size > 0
+										? gateDataRepo.mergeWithMapFields(
+												workflowRunId,
+												gateId,
+												partialToMerge,
+												mapFields
+											)
+										: gateDataRepo.merge(workflowRunId, gateId, partialToMerge);
 								const evalResult = await evaluateGate(
 									gateDef,
 									updated.data,

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -323,32 +323,45 @@ const PD_PLANNING_PROMPT =
 	'- Out of scope: what is intentionally not included\n' +
 	'- Open questions: anything that needs clarification before tasks are dispatched\n\n' +
 	'Write the plan to `plan.md` at the repo root, commit it, and open/update a PR targeting the ' +
-	'default branch. The plan-pr-gate will automatically verify the PR before Plan Review starts.';
+	'default branch. After the PR is open and mergeable, hand off to Plan Review by calling ' +
+	'`send_message(target="Plan Review", message="<short summary>", data: { pr_url: "<plan PR url>" })`. ' +
+	'The `data: { pr_url }` payload is auto-merged into `plan-pr-gate`; the gate script then ' +
+	'verifies the PR is open and mergeable before Plan Review activates. Without this explicit ' +
+	'`pr_url` write the gate stays closed and Plan Review never starts. Always re-supply ' +
+	'`data: { pr_url }` on every send to Plan Review — `plan-pr-gate` resets each cycle, so the ' +
+	'URL must be reasserted after every revision.';
 
 const PD_PLAN_REVIEW_PROMPT =
 	'You are one of four parallel Reviewers in the Plan Review node of a Plan & Decompose Workflow. ' +
 	'You receive a plan from the Planning node and must evaluate it through your specific lens ' +
 	'before tasks are dispatched. You do not coordinate with other reviewers; vote independently.\n\n' +
 	'TERMINAL ACTION PRE-CONDITIONS:\n' +
-	'Plan Review is NOT the end node in this workflow — the task-completion tools ' +
-	'(`approve_task`, `submit_for_approval`) are not available to you. Your terminal ' +
-	'action is your vote on `plan-approval-gate`. Vote `approved: true` ONLY when your ' +
-	'lens-specific verdict is APPROVE (zero P0–P3 findings under your lens). If ANY ' +
-	'P0–P3 finding exists, you MUST vote `approved: false` AND send_message to the ' +
-	'Planning node describing what to change. Do NOT vote `approved: true` to "let a ' +
-	'human decide" or to defer judgment — that is equivalent to silently passing the ' +
-	'plan through with findings open. The 4-of-4 approval threshold exists precisely ' +
-	'so that no lens can be skipped.\n\n' +
+	'Plan Review is NOT the end node in this workflow. The task-completion tools ' +
+	'(`approve_task`, `submit_for_approval`) ARE technically registered for every node-agent ' +
+	'session, but for reviewers they are STRICTLY OFF-LIMITS — calling either of them closes the ' +
+	'entire Plan & Decompose run before the Task Dispatcher has had a chance to fan the plan out ' +
+	'into standalone tasks. Only the Task Dispatcher (the workflow end node) is allowed to call ' +
+	'them. Your terminal action is your vote on `plan-approval-gate`. Vote `approved` ONLY when ' +
+	'your lens-specific verdict is APPROVE (zero P0–P3 findings under your lens). If ANY P0–P3 ' +
+	'finding exists, you MUST vote `rejected` AND send_message to the Planning node describing ' +
+	'what to change. Do NOT vote `approved` to "let a human decide" or to defer judgment — that ' +
+	'is equivalent to silently passing the plan through with findings open. The 4-of-4 approval ' +
+	'threshold exists precisely so that no lens can be skipped.\n\n' +
 	'Steps:\n' +
 	'1. Read the plan file in the PR (`gh pr diff` and `gh pr view`).\n' +
 	'2. Evaluate the plan against your lens criteria (described below).\n' +
 	'3. Post your review to the PR with `gh pr review <url> --comment --body "<your review>"` so ' +
 	'the Planner and peer reviewers can see your feedback in the PR thread.\n' +
-	'4. Vote by writing to plan-approval-gate: call send_message to the "Task Dispatcher" node ' +
-	'with `data: { reviewer_name: "<your lens>", approved: true|false, comments_url: "<pr url>" }`. ' +
-	'The vote counts toward the 4-of-4 approval threshold.\n' +
-	'5. If you reject, also send a message to the Planning node via the feedback channel ' +
-	'describing what needs to change, so the Planner can revise and re-open.';
+	'4. Vote by writing your lens entry into the `approvals` map on `plan-approval-gate`. Call ' +
+	'`send_message(target="Task Dispatcher", message="<short verdict>", data: { approvals: ' +
+	'{ "<your lens>": "approved" }, pr_url: "<plan PR url>" })`. The `approvals` map is ' +
+	"deep-merged with the existing votes, so each reviewer's entry accumulates " +
+	'independently — write the SAME lens key your prompt assigns you (architecture / security / ' +
+	'correctness / ux). The gate passes when ≥ 4 entries have value `"approved"`.\n' +
+	'5. If you reject, write `{ "<your lens>": "rejected" }` in the same shape AND also send a ' +
+	'message to the Planning node via the feedback channel describing exactly what needs to ' +
+	'change, so the Planner can revise and re-open. Do NOT call `approve_task` or ' +
+	'`submit_for_approval` — they are reserved for the Task Dispatcher.';
 
 const PD_TASK_DISPATCHER_PROMPT =
 	'You are the Task Dispatcher in a Plan & Decompose Workflow. You are the end node. ' +
@@ -1035,7 +1048,9 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
 							'items, long-term maintainability, and whether the decomposition will hold up as ' +
 							'the system grows. Flag items that smuggle unrelated concerns together or create ' +
 							'hidden cross-cutting dependencies.\n\n' +
-							'When voting, use `reviewer_name: "architecture"` in the plan-approval-gate data.',
+							'When voting, your lens key is `"architecture"` — write ' +
+							'`data: { approvals: { architecture: "approved" } }` (or `"rejected"`) on the ' +
+							'`plan-approval-gate`.',
 					},
 				},
 				{
@@ -1049,7 +1064,9 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
 							'authentication/authorization, secrets handling, and supply-chain risk for any ' +
 							'new dependencies. Flag items that expose user data, bypass existing auth checks, ' +
 							'or rely on untrusted input without validation.\n\n' +
-							'When voting, use `reviewer_name: "security"` in the plan-approval-gate data.',
+							'When voting, your lens key is `"security"` — write ' +
+							'`data: { approvals: { security: "approved" } }` (or `"rejected"`) on the ' +
+							'`plan-approval-gate`.',
 					},
 				},
 				{
@@ -1063,7 +1080,9 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
 							'consistency across failures, idempotency, and race conditions. Flag items ' +
 							'whose acceptance criteria are vague, whose failure modes are unclear, or ' +
 							'whose tests would not catch the obvious regressions.\n\n' +
-							'When voting, use `reviewer_name: "correctness"` in the plan-approval-gate data.',
+							'When voting, your lens key is `"correctness"` — write ' +
+							'`data: { approvals: { correctness: "approved" } }` (or `"rejected"`) on the ' +
+							'`plan-approval-gate`.',
 					},
 				},
 				{
@@ -1077,7 +1096,9 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
 							'documentation, error messages, and upgrade/migration experience for ' +
 							'existing users. Flag items that change public interfaces without describing ' +
 							'what users will see or how docs will be updated.\n\n' +
-							'When voting, use `reviewer_name: "ux"` in the plan-approval-gate data.',
+							'When voting, your lens key is `"ux"` — write ' +
+							'`data: { approvals: { ux: "approved" } }` (or `"rejected"`) on the ' +
+							'`plan-approval-gate`.',
 					},
 				},
 			],
@@ -1134,8 +1155,12 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
 			description:
 				'All four Plan Reviewers must approve the plan before Task Dispatcher activates. ' +
 				'Each reviewer writes to the `approvals` map with their lens name as the key ' +
-				'(architecture, security, correctness, ux) and `approved: true` as the value. ' +
-				'Gate passes when ≥ 4 entries are approved.',
+				'(architecture, security, correctness, ux) and the string `"approved"` as the ' +
+				"value. The auto-gate-write deep-merges map fields, so each reviewer's entry " +
+				'accumulates without overwriting earlier votes. Gate passes when ≥ 4 entries ' +
+				'have value `"approved"`. Note: `resetOnCycle: true` means all approvals are ' +
+				'cleared when Plan Review→Planning revision feedback fires — fresh votes are ' +
+				'collected after each plan revision because the plan diff has changed.',
 			fields: [
 				{
 					name: 'approvals',

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -1034,9 +1034,15 @@ export const PLAN_AND_DECOMPOSE_WORKFLOW: SpaceWorkflow = {
 							'2. Decompose the goal into concrete, small-enough work items\n' +
 							'3. Write `plan.md` — one section per work item with title, description, priority\n' +
 							'4. Commit and open/update a PR against the default branch\n' +
-							'5. Wait for plan-pr-gate to verify mergeability\n\n' +
-							'If re-activated after Plan Review feedback: address each reviewer comment, ' +
-							'update `plan.md`, and push to the same PR branch.',
+							'5. Hand off to Plan Review by calling ' +
+							'`send_message(target="Plan Review", message="<short summary>", ' +
+							'data: { pr_url: "<plan PR url>" })`. The `data: { pr_url }` write is ' +
+							'auto-merged into `plan-pr-gate`, which verifies the PR is open and ' +
+							'mergeable before Plan Review activates. Skipping this call leaves ' +
+							'`plan-pr-gate` closed and Plan Review never starts.\n' +
+							'6. Wait for Plan Review feedback. If re-activated, address each reviewer ' +
+							'comment, update `plan.md`, push to the same PR branch, then repeat step 5 ' +
+							'(re-supply `data: { pr_url }` — `plan-pr-gate` resets each cycle).',
 					},
 				},
 			],

--- a/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
+++ b/packages/daemon/src/lib/space/workflows/built-in-workflows.ts
@@ -358,6 +358,14 @@ const PD_PLAN_REVIEW_PROMPT =
 	"deep-merged with the existing votes, so each reviewer's entry accumulates " +
 	'independently — write the SAME lens key your prompt assigns you (architecture / security / ' +
 	'correctness / ux). The gate passes when ≥ 4 entries have value `"approved"`.\n' +
+	'   IMPORTANT — expected gate-blocked response: until the 4th reviewer writes their entry, ' +
+	'`plan-approval-gate` is still closed and the channel to Task Dispatcher is blocked. The ' +
+	'`send_message` call will return `success: false` with an error like `Gate ' +
+	'"plan-approval-gate" blocked delivery ...`. This is NORMAL and EXPECTED for the first three ' +
+	'reviewers — your vote IS recorded (look for the `gateWrite` field in the response, which ' +
+	'shows `gateOpen: false` until the gate fills). Do NOT treat this as a failure, do NOT retry ' +
+	'the send, and CRUCIALLY do not skip step 5 if you are rejecting. The Task Dispatcher will ' +
+	'be activated automatically the moment the 4th approval lands.\n' +
 	'5. If you reject, write `{ "<your lens>": "rejected" }` in the same shape AND also send a ' +
 	'message to the Planning node via the feedback channel describing exactly what needs to ' +
 	'change, so the Planner can revise and re-open. Do NOT call `approve_task` or ' +

--- a/packages/daemon/src/storage/repositories/gate-data-repository.ts
+++ b/packages/daemon/src/storage/repositories/gate-data-repository.ts
@@ -78,11 +78,64 @@ export class GateDataRepository {
 	 * Nested objects are replaced wholesale, not merged recursively.
 	 * Example: merging `{ nested: { b: 2 } }` into `{ nested: { a: 1 } }`
 	 * yields `{ nested: { b: 2 } }` — `a` is lost.
+	 *
+	 * Atomic within `bun:sqlite`: read, merge, and write run inside a single
+	 * SQLite transaction so a concurrent `reset()` (e.g. from
+	 * `incrementAndResetCyclicChannel`) cannot interleave between the read and
+	 * the write and resurrect cleared keys. JS is single-threaded so this is
+	 * already safe today, but the transaction is cheap and prevents future
+	 * regressions if `await` boundaries are added between read and write.
 	 */
 	merge(runId: string, gateId: string, partial: Record<string, unknown>): GateDataRecord {
-		const existing = this.get(runId, gateId);
-		const merged = existing ? { ...existing.data, ...partial } : { ...partial };
-		return this.set(runId, gateId, merged);
+		return this.db.transaction(() => {
+			const existing = this.get(runId, gateId);
+			const merged = existing ? { ...existing.data, ...partial } : { ...partial };
+			return this.set(runId, gateId, merged);
+		})();
+	}
+
+	/**
+	 * Merge partial data into an existing gate data record, deep-merging
+	 * nominated map-typed fields instead of replacing them wholesale.
+	 *
+	 * Top-level keys in `partial` shallow-overwrite existing keys, *except*
+	 * for keys listed in `mapFields` — for those, if both the existing value
+	 * and the new value are plain (non-array) objects, their entries are
+	 * shallow-merged so per-writer entries (e.g. each reviewer's lens entry
+	 * in `plan-approval-gate.approvals`) accumulate instead of clobbering
+	 * each other.
+	 *
+	 * The whole read-merge-write sequence runs inside a SQLite transaction
+	 * so a concurrent `reset()` cannot interleave between the read and the
+	 * write — without this, a cyclic reset (e.g. on revision feedback) could
+	 * be silently undone by a stale snapshot from a peer reviewer's
+	 * gate-write that started before the reset.
+	 */
+	mergeWithMapFields(
+		runId: string,
+		gateId: string,
+		partial: Record<string, unknown>,
+		mapFields: ReadonlySet<string>
+	): GateDataRecord {
+		return this.db.transaction(() => {
+			const existing = this.get(runId, gateId);
+			const existingData = existing?.data ?? {};
+			const next: Record<string, unknown> = { ...existingData };
+			for (const [key, value] of Object.entries(partial)) {
+				if (mapFields.has(key) && value && typeof value === 'object' && !Array.isArray(value)) {
+					const existingMap = existingData[key];
+					if (existingMap && typeof existingMap === 'object' && !Array.isArray(existingMap)) {
+						next[key] = {
+							...(existingMap as Record<string, unknown>),
+							...(value as Record<string, unknown>),
+						};
+						continue;
+					}
+				}
+				next[key] = value;
+			}
+			return this.set(runId, gateId, next);
+		})();
 	}
 
 	/**

--- a/packages/daemon/tests/unit/4-space-storage/storage/gate-data-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/gate-data-repository.test.ts
@@ -106,6 +106,112 @@ describe('GateDataRepository — merge', () => {
 });
 
 // ---------------------------------------------------------------------------
+// mergeWithMapFields
+// ---------------------------------------------------------------------------
+
+describe('GateDataRepository — mergeWithMapFields', () => {
+	test('creates record if none exists', () => {
+		const result = repo.mergeWithMapFields(
+			RUN_ID,
+			GATE_ID_A,
+			{ approvals: { architecture: 'approved' } },
+			new Set(['approvals'])
+		);
+		expect(result.data).toEqual({ approvals: { architecture: 'approved' } });
+	});
+
+	test('deep-merges nominated map field across multiple writes', () => {
+		repo.mergeWithMapFields(
+			RUN_ID,
+			GATE_ID_A,
+			{ approvals: { architecture: 'approved' } },
+			new Set(['approvals'])
+		);
+		repo.mergeWithMapFields(
+			RUN_ID,
+			GATE_ID_A,
+			{ approvals: { security: 'approved' } },
+			new Set(['approvals'])
+		);
+		repo.mergeWithMapFields(
+			RUN_ID,
+			GATE_ID_A,
+			{ approvals: { ux: 'rejected' } },
+			new Set(['approvals'])
+		);
+
+		expect(repo.get(RUN_ID, GATE_ID_A)!.data).toEqual({
+			approvals: {
+				architecture: 'approved',
+				security: 'approved',
+				ux: 'rejected',
+			},
+		});
+	});
+
+	test('shallow-overwrites keys not in the mapFields set', () => {
+		repo.set(RUN_ID, GATE_ID_A, { approvals: { architecture: 'approved' }, status: 'pending' });
+		repo.mergeWithMapFields(
+			RUN_ID,
+			GATE_ID_A,
+			{ approvals: { security: 'approved' }, status: 'reviewing' },
+			new Set(['approvals'])
+		);
+
+		expect(repo.get(RUN_ID, GATE_ID_A)!.data).toEqual({
+			approvals: { architecture: 'approved', security: 'approved' },
+			status: 'reviewing',
+		});
+	});
+
+	test('replaces non-object existing value with new object even when key is in mapFields', () => {
+		repo.set(RUN_ID, GATE_ID_A, { approvals: 'invalid-string' });
+		repo.mergeWithMapFields(
+			RUN_ID,
+			GATE_ID_A,
+			{ approvals: { architecture: 'approved' } },
+			new Set(['approvals'])
+		);
+
+		expect(repo.get(RUN_ID, GATE_ID_A)!.data).toEqual({
+			approvals: { architecture: 'approved' },
+		});
+	});
+
+	test('reset between writes wipes prior entries (cyclic feedback semantics)', () => {
+		// Simulates the race-defensive behaviour: a reset() must not be
+		// silently undone by a stale snapshot composed in JS.
+		repo.mergeWithMapFields(
+			RUN_ID,
+			GATE_ID_A,
+			{ approvals: { architecture: 'approved' } },
+			new Set(['approvals'])
+		);
+		repo.mergeWithMapFields(
+			RUN_ID,
+			GATE_ID_A,
+			{ approvals: { security: 'approved' } },
+			new Set(['approvals'])
+		);
+
+		// Cyclic reset clears all approvals.
+		repo.reset(RUN_ID, GATE_ID_A, { approvals: {} });
+
+		// Next reviewer in the new cycle writes — must NOT bring back prior cycle's votes.
+		repo.mergeWithMapFields(
+			RUN_ID,
+			GATE_ID_A,
+			{ approvals: { ux: 'approved' } },
+			new Set(['approvals'])
+		);
+
+		expect(repo.get(RUN_ID, GATE_ID_A)!.data).toEqual({
+			approvals: { ux: 'approved' },
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
 // delete
 // ---------------------------------------------------------------------------
 

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -1540,6 +1540,52 @@ describe('node-agent-tools: send_message (gate-write)', () => {
 		expect(record?.data.y).toBe('val2');
 	});
 
+	test('map-type field deep-merges entries from multiple writers (vote-counting)', async () => {
+		// Simulates plan-approval-gate: multiple reviewers each write a partial
+		// `approvals` map keyed by their lens. A shallow merge would replace the
+		// whole map with the latest writer's entry, losing prior votes. Deep
+		// merge of map-type fields must preserve all entries.
+		const gate: Gate = {
+			id: 'gate-votes',
+			fields: [
+				{
+					name: 'approvals',
+					type: 'map',
+					writers: ['*'],
+					check: { op: 'count', match: 'approved', min: 2 },
+				},
+			],
+			resetOnCycle: false,
+		};
+		const workflow = makeWorkflowWithGatedChannel(gate);
+		const gateDataRepo = new GateDataRepository(ctx.db);
+		const config = makeConfig(ctx, { workflow, gateDataRepo });
+		const handlers = createNodeAgentToolHandlers(config);
+
+		// First write (lens "architecture")
+		const r1 = await handlers.send_message({
+			target: 'reviewer',
+			message: 'lens=architecture',
+			data: { approvals: { architecture: 'approved' } },
+		});
+		expect(JSON.parse(r1.content[0].text).gateWrite.gateOpen).toBe(false);
+
+		// Second write (lens "security") — must NOT overwrite the first vote.
+		// The auto-gate-write deep-merges map-type fields keyed by writer lens.
+		const r2 = await handlers.send_message({
+			target: 'reviewer',
+			message: 'lens=security',
+			data: { approvals: { security: 'approved' } },
+		});
+		expect(JSON.parse(r2.content[0].text).gateWrite.gateOpen).toBe(true);
+
+		const record = gateDataRepo.get(ctx.workflowRunId, 'gate-votes');
+		expect(record?.data.approvals).toEqual({
+			architecture: 'approved',
+			security: 'approved',
+		});
+	});
+
 	test('onGateDataChanged fires after gate-write via send_message', async () => {
 		const gate: Gate = {
 			id: 'gate-callback',

--- a/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
@@ -1200,6 +1200,116 @@ describe('ChannelRouter', () => {
 			expect(executions).toHaveLength(0);
 		});
 
+		test('gated channel: throws ActivationError when parent task is archived (no gate eval)', async () => {
+			// Archived runs are tombstones — gates must not be evaluated and
+			// scripted gates must not run. The archive guard short-circuits
+			// before gate evaluation and before activation.
+			const gate: Gate = {
+				id: 'archived-run-gate',
+				fields: [{ name: 'plan', type: 'string', writers: ['planner'], check: { op: 'exists' } }],
+				resetOnCycle: false,
+			};
+			const channels: WorkflowChannel[] = [
+				{ id: 'ch-1', from: 'planner', to: 'coder', gateId: 'archived-run-gate' },
+			];
+			const workflow = buildWorkflowWithGates(
+				SPACE_ID,
+				workflowManager,
+				[
+					{
+						id: NODE_A,
+						name: 'Planner Node',
+						agents: [{ agentId: AGENT_PLANNER, name: 'planner' }],
+					},
+					{ id: NODE_B, name: 'Coder Node', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+				],
+				channels,
+				[gate]
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Archived Run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+			// Even with the gate satisfied, the archived guard must trump it.
+			gateDataRepo.set(run.id, 'archived-run-gate', { plan: 'something' });
+			for (const t of taskRepo.listByWorkflowRunIncludingArchived(run.id)) {
+				taskRepo.archiveTask(t.id);
+			}
+
+			await expect(router.deliverMessage(run.id, 'planner', 'coder', 'msg')).rejects.toBeInstanceOf(
+				ActivationError
+			);
+			await expect(router.deliverMessage(run.id, 'planner', 'coder', 'msg')).rejects.toThrow(
+				/archived/
+			);
+		});
+
+		test('gated channel: re-checks gate after activation and throws when closed mid-await', async () => {
+			// Race coverage: deliverMessage performs an `await activateNode(...)`
+			// after the first gate eval. If a concurrent cycle reset clears the
+			// gate during that await, the post-activation re-check must catch
+			// the stale-gate condition and throw.
+			const gate: Gate = {
+				id: 'race-gate',
+				fields: [{ name: 'plan', type: 'string', writers: ['planner'], check: { op: 'exists' } }],
+				resetOnCycle: false,
+			};
+			const channels: WorkflowChannel[] = [
+				{ id: 'ch-1', from: 'planner', to: 'coder', gateId: 'race-gate' },
+			];
+			const workflow = buildWorkflowWithGates(
+				SPACE_ID,
+				workflowManager,
+				[
+					{
+						id: NODE_A,
+						name: 'Planner Node',
+						agents: [{ agentId: AGENT_PLANNER, name: 'planner' }],
+					},
+					{ id: NODE_B, name: 'Coder Node', agents: [{ agentId: AGENT_CODER, name: 'coder' }] },
+				],
+				channels,
+				[gate]
+			);
+
+			const run = workflowRunRepo.createRun({
+				spaceId: SPACE_ID,
+				workflowId: workflow.id,
+				title: 'Race Gate Run',
+			});
+			workflowRunRepo.transitionStatus(run.id, 'in_progress');
+
+			// Simulate the race by clearing the gate after the first eval but
+			// before the post-activation re-check. We do this by stubbing
+			// `activateNode` to clear gate data while it awaits.
+			gateDataRepo.set(run.id, 'race-gate', { plan: 'initial value' });
+
+			const realActivate = router.activateNode.bind(router);
+			let activateCalls = 0;
+			(router as unknown as { activateNode: typeof router.activateNode }).activateNode = async (
+				...args: Parameters<typeof router.activateNode>
+			) => {
+				activateCalls += 1;
+				// Clear gate data mid-activation to simulate a concurrent reset
+				gateDataRepo.set(run.id, 'race-gate', {});
+				return realActivate(...args);
+			};
+
+			try {
+				await expect(
+					router.deliverMessage(run.id, 'planner', 'coder', 'msg')
+				).rejects.toBeInstanceOf(ChannelGateBlockedError);
+				expect(activateCalls).toBe(1);
+			} finally {
+				(router as unknown as { activateNode: typeof router.activateNode }).activateNode =
+					realActivate;
+			}
+		});
+
 		test('gated channel (check): allows delivery when condition satisfied', async () => {
 			const gate: Gate = {
 				id: 'plan-gate',

--- a/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
+++ b/packages/daemon/tests/unit/5-space/other/channel-router.test.ts
@@ -1156,7 +1156,7 @@ describe('ChannelRouter', () => {
 		// Gated channels — check condition
 		// -----------------------------------------------------------------------
 
-		test('gated channel (check): activates target before blocking content when condition not satisfied', async () => {
+		test('gated channel (check): does NOT activate target when condition not satisfied', async () => {
 			const gate: Gate = {
 				id: 'plan-gate',
 				fields: [{ name: 'plan', type: 'string', writers: ['planner'], check: { op: 'exists' } }],
@@ -1189,14 +1189,15 @@ describe('ChannelRouter', () => {
 			workflowRunRepo.transitionStatus(run.id, 'in_progress');
 
 			// No gate data written → field does not exist → gate is closed.
-			// The target agent is still activated first; the gate only blocks message content.
+			// Gate evaluation runs BEFORE lazy activation, so the target node is
+			// NOT activated and no node execution is created. This is the fix
+			// for the premature-activation bug — the tick loop must not see a
+			// pending execution for a blocked target.
 			await expect(router.deliverMessage(run.id, 'planner', 'coder', 'msg')).rejects.toBeInstanceOf(
 				ChannelGateBlockedError
 			);
 			const executions = new NodeExecutionRepository(db).listByNode(run.id, NODE_B);
-			expect(executions).toHaveLength(1);
-			expect(executions[0].agentName).toBe('coder');
-			expect(executions[0].status).toBe('pending');
+			expect(executions).toHaveLength(0);
 		});
 
 		test('gated channel (check): allows delivery when condition satisfied', async () => {


### PR DESCRIPTION
## Summary

Fixes six interlocking issues in the Plan & Decompose workflow that prevented it from completing on its own.

### Runtime
- **`ChannelRouter.deliverMessage` activated targets before evaluating their gate** — the tick loop then spawned blocked-target sessions (e.g. Task Dispatcher firing before all 4 reviewers voted). Gate evaluation now runs first; activation only happens once the gate is open.
- **Auto-gate-write shallow-merged map-type fields** — each reviewer's vote on `plan-approval-gate.approvals` replaced the prior writer's entry. The auto-write now deep-merges any field whose definition is `type: 'map'` before delegating to `gateDataRepo.merge`.

### Prompts
- Planner prompt now explicitly instructs the planner to call `send_message(target="Plan Review", data: { pr_url })` after the PR is open. Without this the `plan-pr-gate` stayed closed forever.
- Reviewer prompts no longer falsely claim `approve_task` / `submit_for_approval` are unavailable; they're registered for every node-agent session but strictly off-limits to reviewers (calling them prematurely closes the run). Only the Task Dispatcher may use them.
- Lens-specific reviewer prompts and the central reviewer prompt now describe the actual gate payload: `data: { approvals: { "<lens>": "approved" }, pr_url: "..." }`. The previous `reviewer_name`/`approved` shape was silently stripped by the auto-write because no such gate fields exist.
- `plan-approval-gate` description now documents the deep-merge contract, the string vote values, and intentional `resetOnCycle: true` semantics.

## Test plan

- [x] `bun test tests/unit/5-space/other/channel-router.test.ts` — gate-before-activation case asserts no premature node execution
- [x] `bun test tests/unit/5-space/agent/node-agent-tools.test.ts` — new map-type deep-merge test
- [x] `./scripts/test-daemon.sh` — full suite green (9592 pass)
- [x] `bun run check` — lint + typecheck + knip clean