### PR TITLE
fix: thread image uploads through space task message pipeline

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-message-handlers.ts
@@ -6,7 +6,7 @@
  * - space.task.getMessages — paginated snapshot of messages from a Task Agent session
  */
 
-import type { MessageHub } from '@neokai/shared';
+import type { MessageHub, MessageImage } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
 import type { Database } from '../../storage/database';
 import type { AgentSession } from '../agent/agent-session';
@@ -76,7 +76,8 @@ export interface TaskAgentManagerInterface {
 	injectTaskAgentMessage(
 		taskId: string,
 		message: string,
-		isSyntheticMessage?: boolean
+		isSyntheticMessage?: boolean,
+		images?: MessageImage[]
 	): Promise<void>;
 	/** Returns the live AgentSession for the given task, or undefined if not spawned. */
 	getTaskAgent(taskId: string): AgentSession | undefined;
@@ -87,7 +88,8 @@ export interface TaskAgentManagerInterface {
 	injectSubSessionMessage?(
 		subSessionId: string,
 		message: string,
-		isSyntheticMessage?: boolean
+		isSyntheticMessage?: boolean,
+		images?: MessageImage[]
 	): Promise<void>;
 	/**
 	 * Optional: lazy-activate a workflow-declared node agent for a given task.
@@ -204,7 +206,8 @@ export function setupSpaceTaskMessageHandlers(
 		task: ReturnType<SpaceTaskRepository['getTask']>,
 		taskId: string,
 		message: string,
-		target: { agentName?: string; nodeExecutionId?: string }
+		target: { agentName?: string; nodeExecutionId?: string },
+		images?: MessageImage[]
 	): Promise<{
 		ok: true;
 		routedTo: string[];
@@ -274,7 +277,7 @@ export function setupSpaceTaskMessageHandlers(
 		if (deliverable.length > 0) {
 			await Promise.all(
 				deliverable.map((exec) =>
-					taskAgentManager.injectSubSessionMessage!(exec.agentSessionId!, message, false)
+					taskAgentManager.injectSubSessionMessage!(exec.agentSessionId!, message, false, images)
 				)
 			);
 			return {
@@ -287,7 +290,17 @@ export function setupSpaceTaskMessageHandlers(
 		// No live session after activation — persist the message to the
 		// pending-message queue so it is delivered when the session spawns.
 		// This prevents the user's message from being silently dropped.
+		//
+		// Limitation: the pending-message queue stores text only. If the user
+		// attached images to a message destined for a not-yet-live agent, fail
+		// loudly rather than silently dropping the attachments — the caller can
+		// retry once the agent is online.
 		if (pendingMessageQueue) {
+			if (images && images.length > 0) {
+				throw new Error(
+					'Cannot send images to an agent that is still starting. Wait for the agent to come online and try again.'
+				);
+			}
 			const queuedNames: string[] = [];
 			for (const exec of matches) {
 				const { record } = pendingMessageQueue.enqueue({
@@ -364,6 +377,7 @@ export function setupSpaceTaskMessageHandlers(
 			spaceId: string;
 			taskId: string;
 			message: string;
+			images?: MessageImage[];
 			target?: SpaceTaskMessageTarget | null;
 		};
 
@@ -379,6 +393,11 @@ export function setupSpaceTaskMessageHandlers(
 		if (params.message.length > 100_000) {
 			throw new Error('Message is too long (max 100,000 characters)');
 		}
+		// Defensive: collapse `images: []` (which the web client may send) to
+		// undefined so downstream code can use `images && images.length > 0`
+		// uniformly without re-checking the array length.
+		const images =
+			Array.isArray(params.images) && params.images.length > 0 ? params.images : undefined;
 
 		// Validate task exists and belongs to the given space
 		const task = taskRepo.getTask(params.taskId);
@@ -390,7 +409,13 @@ export function setupSpaceTaskMessageHandlers(
 		}
 
 		if (params.target?.kind === 'node_agent') {
-			const result = await routeToNodeAgents(task, params.taskId, params.message, params.target);
+			const result = await routeToNodeAgents(
+				task,
+				params.taskId,
+				params.message,
+				params.target,
+				images
+			);
 			log.info(
 				`space.task.sendMessage: explicit target routing to [${result.routedTo.join(', ')}] for task ${params.taskId}`
 			);
@@ -430,7 +455,12 @@ export function setupSpaceTaskMessageHandlers(
 					// Inject into all matching sessions in parallel (independent operations)
 					await Promise.all(
 						matches.map((exec) =>
-							taskAgentManager.injectSubSessionMessage!(exec.agentSessionId!, params.message, false)
+							taskAgentManager.injectSubSessionMessage!(
+								exec.agentSessionId!,
+								params.message,
+								false,
+								images
+							)
 						)
 					);
 					routedTo.push(mention);
@@ -476,7 +506,7 @@ export function setupSpaceTaskMessageHandlers(
 			});
 		}
 
-		await taskAgentManager.injectTaskAgentMessage(params.taskId, params.message);
+		await taskAgentManager.injectTaskAgentMessage(params.taskId, params.message, false, images);
 		log.info(`space.task.sendMessage: injected message into task ${params.taskId}`);
 
 		// Human touch: `space.task.sendMessage` is the sole RPC boundary for

--- a/packages/daemon/src/lib/session/message-persistence.ts
+++ b/packages/daemon/src/lib/session/message-persistence.ts
@@ -36,6 +36,33 @@ import {
 
 type MessageImageInput = MessageImage | ImageContent;
 
+/**
+ * Anthropic API limit for base64-encoded image data per attachment.
+ * Exceeding this returns a late, opaque API error, so we validate
+ * server-side before persisting/queueing the SDK user message.
+ */
+export const MAX_IMAGE_BASE64_SIZE = 5 * 1024 * 1024; // 5MB
+
+/**
+ * Validate base64 image sizes against the Anthropic API limit and throw a
+ * user-facing error before any persistence happens. Used by the live-session
+ * persistence path and by space task message injection (where the workflow
+ * agent enqueues the message into a sub-session) so both paths return the
+ * same early "resize image" error instead of a downstream API failure.
+ */
+export function validateImageSizes(images: ReadonlyArray<MessageImageInput>): void {
+	for (const image of images) {
+		const base64SizeBytes = getImageData(image).length;
+		if (base64SizeBytes > MAX_IMAGE_BASE64_SIZE) {
+			const sizeMB = (base64SizeBytes / (1024 * 1024)).toFixed(2);
+			const maxMB = (MAX_IMAGE_BASE64_SIZE / (1024 * 1024)).toFixed(2);
+			throw new Error(
+				`Image base64 size (${sizeMB} MB) exceeds API limit (${maxMB} MB). Please resize the image before uploading.`
+			);
+		}
+	}
+}
+
 export interface MessagePersistenceData {
 	sessionId: string;
 	messageId: string;
@@ -144,17 +171,7 @@ export class MessagePersistence {
 		try {
 			// 1. Validate image sizes (API limit is 5MB for base64-encoded data)
 			if (images && images.length > 0) {
-				const MAX_BASE64_SIZE = 5 * 1024 * 1024; // 5MB
-				for (const image of images) {
-					const base64SizeBytes = getImageData(image).length;
-					if (base64SizeBytes > MAX_BASE64_SIZE) {
-						const sizeMB = (base64SizeBytes / (1024 * 1024)).toFixed(2);
-						const maxMB = (MAX_BASE64_SIZE / (1024 * 1024)).toFixed(2);
-						throw new Error(
-							`Image base64 size (${sizeMB} MB) exceeds API limit (${maxMB} MB). Please resize the image before uploading.`
-						);
-					}
-				}
+				validateImageSizes(images);
 			}
 
 			// 2. Expand built-in commands (e.g., /merge-session → full prompt)

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -58,6 +58,7 @@ import type { UUID } from 'crypto';
 import type { SDKUserMessage } from '@neokai/shared/sdk';
 import type { AgentSessionInit } from '../../../lib/agent/agent-session';
 import { AgentSession } from '../../../lib/agent/agent-session';
+import { validateImageSizes } from '../../session/message-persistence';
 import type { Database } from '../../../storage/database';
 import type { ReactiveDatabase } from '../../../storage/reactive-database';
 import type { DaemonHub } from '../../daemon-hub';
@@ -3739,11 +3740,16 @@ export class TaskAgentManager {
 
 	/**
 	 * Inject a message (optionally with image attachments) into an AgentSession.
-	 * Uses the same pattern as SpaceRuntimeService.injectMessage().
 	 *
-	 * When `images` is non-empty, the SDK message content becomes a multi-modal
-	 * block array (images first, then text) — mirroring the regular non-space
-	 * chat path in `MessagePersistenceService.persistAndDispatchUserMessage`.
+	 * Mirrors the multi-modal content shape produced by `buildMessageContent`
+	 * in `MessagePersistence.persist` (the regular non-space chat path): when
+	 * `images` is non-empty the SDK message content becomes a multi-modal
+	 * block array (images first, then text) and is passed through to
+	 * `MessageQueue.enqueueWithId`, which already accepts
+	 * `string | MessageContent[]`. Image base64 sizes are validated against
+	 * the same Anthropic API limit as the non-space path via
+	 * `validateImageSizes` so users get the same early "resize image" error
+	 * instead of a downstream API failure.
 	 */
 	private async injectMessageIntoSession(
 		session: AgentSession,
@@ -3772,6 +3778,12 @@ export class TaskAgentManager {
 
 		const messageId = generateUUID();
 		const hasImages = !!images && images.length > 0;
+		// Validate base64 size up-front so users get the same early "resize image"
+		// error returned by the live-session persistence path instead of a late,
+		// opaque API failure once the SDK forwards the oversized payload.
+		if (hasImages) {
+			validateImageSizes(images!);
+		}
 		const sdkContent: MessageContent[] = hasImages
 			? [
 					...images!.map((img) => ({

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -46,6 +46,8 @@ import type {
 	NodeExecution,
 	MessageHub,
 	McpServerConfig,
+	MessageContent,
+	MessageImage,
 	MessageOrigin,
 	WorkflowNodeAgent,
 } from '@neokai/shared';
@@ -1782,11 +1784,16 @@ export class TaskAgentManager {
 	/**
 	 * Inject a message into a Task Agent session.
 	 * Used by Space Agent's `send_message_to_task` tool.
+	 *
+	 * `images` is forwarded so human-driven RPCs (`space.task.sendMessage`) can
+	 * deliver image attachments to a Task Agent session. Synthetic injects from
+	 * other agents pass `undefined` and behave exactly as before.
 	 */
 	async injectTaskAgentMessage(
 		taskId: string,
 		message: string,
-		isSyntheticMessage = false
+		isSyntheticMessage = false,
+		images?: MessageImage[]
 	): Promise<void> {
 		let session = this.taskAgentSessions.get(taskId);
 		if (!session) {
@@ -1806,18 +1813,24 @@ export class TaskAgentManager {
 			message,
 			'immediate',
 			undefined,
-			isSyntheticMessage
+			isSyntheticMessage,
+			images
 		);
 	}
 
 	/**
 	 * Inject a message into a sub-session.
 	 * Called by the Task Agent MCP tool handler via the messageInjector callback.
+	 *
+	 * `images` is forwarded so human-driven RPCs (`space.task.sendMessage`) can
+	 * deliver image attachments directly to a node-agent sub-session. Synthetic
+	 * injects from other agents pass `undefined` and behave exactly as before.
 	 */
 	async injectSubSessionMessage(
 		subSessionId: string,
 		message: string,
-		isSyntheticMessage = true
+		isSyntheticMessage = true,
+		images?: MessageImage[]
 	): Promise<void> {
 		const indexed = this.agentSessionIndex.get(subSessionId);
 		if (indexed) {
@@ -1826,7 +1839,8 @@ export class TaskAgentManager {
 				message,
 				'immediate',
 				undefined,
-				isSyntheticMessage
+				isSyntheticMessage,
+				images
 			);
 			return;
 		}
@@ -1840,7 +1854,8 @@ export class TaskAgentManager {
 					message,
 					'immediate',
 					undefined,
-					isSyntheticMessage
+					isSyntheticMessage,
+					images
 				);
 				return;
 			}
@@ -1854,7 +1869,8 @@ export class TaskAgentManager {
 				message,
 				'immediate',
 				undefined,
-				isSyntheticMessage
+				isSyntheticMessage,
+				images
 			);
 			return;
 		}
@@ -3722,15 +3738,20 @@ export class TaskAgentManager {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Inject a plain-text message into an AgentSession.
+	 * Inject a message (optionally with image attachments) into an AgentSession.
 	 * Uses the same pattern as SpaceRuntimeService.injectMessage().
+	 *
+	 * When `images` is non-empty, the SDK message content becomes a multi-modal
+	 * block array (images first, then text) — mirroring the regular non-space
+	 * chat path in `MessagePersistenceService.persistAndDispatchUserMessage`.
 	 */
 	private async injectMessageIntoSession(
 		session: AgentSession,
 		message: string,
 		deliveryMode: 'immediate' | 'defer' = 'immediate',
 		origin?: MessageOrigin,
-		isSyntheticMessage = true
+		isSyntheticMessage = true,
+		images?: MessageImage[]
 	): Promise<void> {
 		const sessionId = session.session.id;
 		const state = session.getProcessingState();
@@ -3750,6 +3771,21 @@ export class TaskAgentManager {
 			state.status === 'interrupted';
 
 		const messageId = generateUUID();
+		const hasImages = !!images && images.length > 0;
+		const sdkContent: MessageContent[] = hasImages
+			? [
+					...images!.map((img) => ({
+						type: 'image' as const,
+						source: {
+							type: 'base64' as const,
+							media_type: img.media_type,
+							data: img.data,
+						},
+					})),
+					{ type: 'text' as const, text: message },
+				]
+			: [{ type: 'text' as const, text: message }];
+
 		const sdkUserMessage: SDKUserMessage & { isSynthetic: boolean } = {
 			type: 'user' as const,
 			uuid: messageId as UUID,
@@ -3758,7 +3794,7 @@ export class TaskAgentManager {
 			isSynthetic: isSyntheticMessage,
 			message: {
 				role: 'user' as const,
-				content: [{ type: 'text' as const, text: message }],
+				content: sdkContent,
 			},
 		};
 
@@ -3770,7 +3806,10 @@ export class TaskAgentManager {
 
 		await session.ensureQueryStarted();
 		this.config.db.saveUserMessage(sessionId, sdkUserMessage, 'enqueued', origin);
-		await session.messageQueue.enqueueWithId(messageId, message);
+		// When images are present, enqueue the multi-modal content array so the SDK
+		// sees image blocks alongside the text. Otherwise pass the plain string to
+		// preserve the existing behaviour for callers that don't supply images.
+		await session.messageQueue.enqueueWithId(messageId, hasImages ? sdkContent : message);
 	}
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/1-core/session/message-persistence.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/message-persistence.test.ts
@@ -6,7 +6,11 @@ import { beforeEach, describe, expect, it, mock } from 'bun:test';
 import type { MessageHub, Session } from '@neokai/shared';
 import type { Database } from '../../../../src/storage/database';
 import type { DaemonHub } from '../../../../src/lib/daemon-hub';
-import { MessagePersistence } from '../../../../src/lib/session/message-persistence';
+import {
+	MAX_IMAGE_BASE64_SIZE,
+	MessagePersistence,
+	validateImageSizes,
+} from '../../../../src/lib/session/message-persistence';
 import type { SessionCache } from '../../../../src/lib/session/session-cache';
 
 describe('MessagePersistence', () => {
@@ -196,5 +200,46 @@ describe('MessagePersistence', () => {
 				skipQueryStart: true,
 			})
 		);
+	});
+});
+
+describe('validateImageSizes', () => {
+	const tinyData = 'AAAA'; // 4 bytes — well under the 5MB cap
+
+	it('returns without error for an empty list', () => {
+		expect(() => validateImageSizes([])).not.toThrow();
+	});
+
+	it('accepts images under the 5MB base64 cap', () => {
+		expect(() => validateImageSizes([{ media_type: 'image/png', data: tinyData }])).not.toThrow();
+	});
+
+	it('throws a user-facing error when an image exceeds the cap', () => {
+		const oversized = 'a'.repeat(MAX_IMAGE_BASE64_SIZE + 1);
+		expect(() => validateImageSizes([{ media_type: 'image/png', data: oversized }])).toThrow(
+			/exceeds API limit.*Please resize the image/i
+		);
+	});
+
+	it('throws when any image in a batch exceeds the cap', () => {
+		const oversized = 'a'.repeat(MAX_IMAGE_BASE64_SIZE + 1);
+		expect(() =>
+			validateImageSizes([
+				{ media_type: 'image/png', data: tinyData },
+				{ media_type: 'image/png', data: oversized },
+			])
+		).toThrow(/exceeds API limit/);
+	});
+
+	it('also handles ImageContent shaped inputs (source.data)', () => {
+		const oversized = 'a'.repeat(MAX_IMAGE_BASE64_SIZE + 1);
+		expect(() =>
+			validateImageSizes([
+				{
+					type: 'image',
+					source: { type: 'base64', media_type: 'image/png', data: oversized },
+				},
+			])
+		).toThrow(/exceeds API limit/);
 	});
 });

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-message-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-message-handlers.test.ts
@@ -293,7 +293,9 @@ describe('setupSpaceTaskMessageHandlers', () => {
 			expect(taskAgentManager.ensureTaskAgentSession).toHaveBeenCalledWith('task-1');
 			expect(taskAgentManager.injectTaskAgentMessage).toHaveBeenCalledWith(
 				'task-1',
-				'Please continue'
+				'Please continue',
+				false,
+				undefined
 			);
 		});
 
@@ -366,7 +368,12 @@ describe('setupSpaceTaskMessageHandlers', () => {
 
 			expect(result).toEqual({ ok: true });
 			expect(taskAgentManager.ensureTaskAgentSession).toHaveBeenCalledWith('task-2');
-			expect(taskAgentManager.injectTaskAgentMessage).toHaveBeenCalledWith('task-2', 'Hello');
+			expect(taskAgentManager.injectTaskAgentMessage).toHaveBeenCalledWith(
+				'task-2',
+				'Hello',
+				false,
+				undefined
+			);
 			expect((daemonHub.emit as ReturnType<typeof mock>).mock.calls[0]?.[0]).toBe(
 				'space.task.updated'
 			);
@@ -468,6 +475,183 @@ describe('setupSpaceTaskMessageHandlers', () => {
 			expect(emitCalls.length).toBe(1);
 			expect(emitCalls[0]?.[0]).toBe('space.task.updated');
 			expect(emitCalls[0]?.[1]).toMatchObject({ task: expect.objectContaining({ id: 'task-2' }) });
+		});
+
+		// ─── Image attachment routing ─────────────────────────────────────────────
+		// Regression coverage for the bug where the space thread / slide-out chat
+		// silently dropped image uploads. The RPC handler must forward `images`
+		// to the underlying inject* call so the agent sees image blocks alongside
+		// the text in the SDK message content.
+		describe('image attachments', () => {
+			const sampleImage = {
+				media_type: 'image/png' as const,
+				data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=',
+			};
+
+			it('forwards images to injectTaskAgentMessage when no target / no @mention', async () => {
+				setup();
+
+				await call('space.task.sendMessage', {
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					message: 'Look at this',
+					images: [sampleImage],
+				});
+
+				expect(taskAgentManager.injectTaskAgentMessage).toHaveBeenCalledWith(
+					'task-1',
+					'Look at this',
+					false,
+					[sampleImage]
+				);
+			});
+
+			it('treats images: [] as no images (passes undefined to injectTaskAgentMessage)', async () => {
+				setup();
+
+				await call('space.task.sendMessage', {
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					message: 'Plain text',
+					images: [],
+				});
+
+				expect(taskAgentManager.injectTaskAgentMessage).toHaveBeenCalledWith(
+					'task-1',
+					'Plain text',
+					false,
+					undefined
+				);
+			});
+
+			it('forwards images to injectSubSessionMessage on @mention routing', async () => {
+				const mockTaskWithWorkflowRun: SpaceTask = {
+					...mockTaskWithSession,
+					workflowRunId: 'run-abc-123',
+				};
+				const mh = createMockMessageHub();
+				hub = mh.hub;
+				handlers = mh.handlers;
+				const injectSubSession = mock(async () => {});
+				taskAgentManager = {
+					...createMockTaskAgentManager(null, mockTaskWithWorkflowRun),
+					injectSubSessionMessage: injectSubSession,
+				};
+				db = createMockDatabase(mockTaskWithWorkflowRun);
+				daemonHub = { emit: mock(async () => {}) } as unknown as DaemonHub;
+				const nodeExecutionRepo = makeNodeExecutionRepo([
+					{ agentName: 'Coder', agentSessionId: 'session-coder-1' },
+				]);
+				setupSpaceTaskMessageHandlers(hub, taskAgentManager, db, daemonHub, nodeExecutionRepo);
+
+				await call('space.task.sendMessage', {
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					message: '@Coder check this screenshot',
+					images: [sampleImage],
+				});
+
+				expect(injectSubSession).toHaveBeenCalledWith(
+					'session-coder-1',
+					'@Coder check this screenshot',
+					false,
+					[sampleImage]
+				);
+			});
+
+			it('forwards images to injectSubSessionMessage on explicit node-agent target', async () => {
+				const mockTaskWithWorkflowRun: SpaceTask = {
+					...mockTaskWithSession,
+					workflowRunId: 'run-abc-123',
+				};
+				const mh = createMockMessageHub();
+				hub = mh.hub;
+				handlers = mh.handlers;
+				const injectSubSession = mock(async () => {});
+				taskAgentManager = {
+					...createMockTaskAgentManager(null, mockTaskWithWorkflowRun),
+					injectSubSessionMessage: injectSubSession,
+				};
+				db = createMockDatabase(mockTaskWithWorkflowRun);
+				daemonHub = { emit: mock(async () => {}) } as unknown as DaemonHub;
+				const nodeExecutionRepo = makeNodeExecutionRepo([
+					{
+						id: 'exec-reviewer',
+						workflowNodeId: 'node-1',
+						agentName: 'Reviewer',
+						agentSessionId: 'session-reviewer-1',
+					},
+				]);
+				setupSpaceTaskMessageHandlers(hub, taskAgentManager, db, daemonHub, nodeExecutionRepo);
+
+				await call('space.task.sendMessage', {
+					spaceId: 'space-1',
+					taskId: 'task-1',
+					message: 'Please review the attached design',
+					target: { kind: 'node_agent', agentName: 'Reviewer' },
+					images: [sampleImage],
+				});
+
+				expect(injectSubSession).toHaveBeenCalledWith(
+					'session-reviewer-1',
+					'Please review the attached design',
+					false,
+					[sampleImage]
+				);
+			});
+
+			it('rejects images destined for a not-yet-spawned node agent rather than silently dropping them', async () => {
+				const mockTaskWithWorkflowRun: SpaceTask = {
+					...mockTaskWithSession,
+					workflowRunId: 'run-abc-123',
+				};
+				const mh = createMockMessageHub();
+				hub = mh.hub;
+				handlers = mh.handlers;
+				const injectSubSession = mock(async () => {});
+				taskAgentManager = {
+					...createMockTaskAgentManager(null, mockTaskWithWorkflowRun),
+					injectSubSessionMessage: injectSubSession,
+				};
+				db = createMockDatabase(mockTaskWithWorkflowRun);
+				daemonHub = { emit: mock(async () => {}) } as unknown as DaemonHub;
+				// Reviewer has no agentSessionId → not spawned yet
+				const nodeExecutionRepo = makeNodeExecutionRepo([
+					{
+						id: 'exec-reviewer',
+						workflowNodeId: 'node-1',
+						agentName: 'Reviewer',
+						agentSessionId: null,
+					},
+				]);
+				const pendingMessageQueue = {
+					enqueue: mock(() => ({ record: { id: 'pending-1' }, deduped: false })),
+				};
+				setupSpaceTaskMessageHandlers(
+					hub,
+					taskAgentManager,
+					db,
+					daemonHub,
+					nodeExecutionRepo,
+					undefined,
+					undefined,
+					pendingMessageQueue
+				);
+
+				await expect(
+					call('space.task.sendMessage', {
+						spaceId: 'space-1',
+						taskId: 'task-1',
+						message: 'Take a look at this',
+						target: { kind: 'node_agent', agentName: 'Reviewer' },
+						images: [sampleImage],
+					})
+				).rejects.toThrow(/images.*starting|starting.*images/i);
+
+				// Did not silently fall through to the text-only pending queue.
+				expect(pendingMessageQueue.enqueue).not.toHaveBeenCalled();
+				expect(injectSubSession).not.toHaveBeenCalled();
+			});
 		});
 	});
 
@@ -672,7 +856,8 @@ describe('setupSpaceTaskMessageHandlers', () => {
 			expect(injectSubSession).toHaveBeenCalledWith(
 				'session-coder-1',
 				'@Coder please fix the bug',
-				false
+				false,
+				undefined
 			);
 			// Should NOT have routed to Task Agent
 			expect(taskAgentManager.injectTaskAgentMessage).not.toHaveBeenCalled();
@@ -741,12 +926,14 @@ describe('setupSpaceTaskMessageHandlers', () => {
 			expect(injectSubSession).toHaveBeenCalledWith(
 				'session-coder-1',
 				'@Coder please check both',
-				false
+				false,
+				undefined
 			);
 			expect(injectSubSession).toHaveBeenCalledWith(
 				'session-coder-2',
 				'@Coder please check both',
-				false
+				false,
+				undefined
 			);
 		});
 
@@ -779,7 +966,12 @@ describe('setupSpaceTaskMessageHandlers', () => {
 			});
 
 			expect(result).toMatchObject({ ok: true, routedTo: ['coder'] });
-			expect(injectSubSession).toHaveBeenCalledWith('session-coder-1', '@coder please fix', false);
+			expect(injectSubSession).toHaveBeenCalledWith(
+				'session-coder-1',
+				'@coder please fix',
+				false,
+				undefined
+			);
 		});
 
 		it('message without @mentions falls back to Task Agent routing', async () => {
@@ -797,7 +989,9 @@ describe('setupSpaceTaskMessageHandlers', () => {
 			expect(injectSubSession).not.toHaveBeenCalled();
 			expect(taskAgentManager.injectTaskAgentMessage).toHaveBeenCalledWith(
 				'task-1',
-				'Please continue the work'
+				'Please continue the work',
+				false,
+				undefined
 			);
 		});
 
@@ -833,7 +1027,8 @@ describe('setupSpaceTaskMessageHandlers', () => {
 			expect(injectSubSession).toHaveBeenCalledWith(
 				'session-reviewer-1',
 				'Please review this',
-				false
+				false,
+				undefined
 			);
 			expect(taskAgentManager.injectTaskAgentMessage).not.toHaveBeenCalled();
 		});
@@ -875,7 +1070,8 @@ describe('setupSpaceTaskMessageHandlers', () => {
 			expect(injectSubSession).toHaveBeenCalledWith(
 				'session-reviewer-idle',
 				'@Reviewer please review',
-				false
+				false,
+				undefined
 			);
 		});
 
@@ -901,22 +1097,26 @@ describe('setupSpaceTaskMessageHandlers', () => {
 			expect(injectSubSession).not.toHaveBeenCalledWith(
 				'session-coder-cancelled',
 				expect.anything(),
-				false
+				false,
+				undefined
 			);
 			expect(injectSubSession).toHaveBeenCalledWith(
 				'session-coder-idle',
 				'@Coder please check',
-				false
+				false,
+				undefined
 			);
 			expect(injectSubSession).toHaveBeenCalledWith(
 				'session-coder-blocked',
 				'@Coder please check',
-				false
+				false,
+				undefined
 			);
 			expect(injectSubSession).toHaveBeenCalledWith(
 				'session-coder-active',
 				'@Coder please check',
-				false
+				false,
+				undefined
 			);
 		});
 
@@ -1115,8 +1315,18 @@ describe('setupSpaceTaskMessageHandlers', () => {
 
 			expect(result).toMatchObject({ ok: true, routedTo: ['Coder'] });
 			expect(injectSubSession).toHaveBeenCalledTimes(2);
-			expect(injectSubSession).toHaveBeenCalledWith('session-coder-a', 'Please check both', false);
-			expect(injectSubSession).toHaveBeenCalledWith('session-coder-b', 'Please check both', false);
+			expect(injectSubSession).toHaveBeenCalledWith(
+				'session-coder-a',
+				'Please check both',
+				false,
+				undefined
+			);
+			expect(injectSubSession).toHaveBeenCalledWith(
+				'session-coder-b',
+				'Please check both',
+				false,
+				undefined
+			);
 		});
 
 		it('activateNode invoked once per unique missing workflowNodeId (deduped)', async () => {
@@ -1225,7 +1435,12 @@ describe('setupSpaceTaskMessageHandlers', () => {
 
 			expect(activateCalls).toEqual(['node-rev']);
 			expect(injectSub).toHaveBeenCalledTimes(1);
-			expect(injectSub).toHaveBeenCalledWith('session-reviewer-live', 'Please review', false);
+			expect(injectSub).toHaveBeenCalledWith(
+				'session-reviewer-live',
+				'Please review',
+				false,
+				undefined
+			);
 			expect(result).toMatchObject({
 				ok: true,
 				routedTo: ['Reviewer'],

--- a/packages/web/src/components/MessageInput.tsx
+++ b/packages/web/src/components/MessageInput.tsx
@@ -139,6 +139,7 @@ export default function MessageInput({
 		handleFileDrop,
 		handleRemove,
 		clear: clearAttachments,
+		restore: restoreAttachments,
 		openFilePicker,
 		getImagesForSend,
 		handlePaste,
@@ -296,8 +297,12 @@ export default function MessageInput({
 			const outgoing = extractOutgoingMessage();
 			if (!outgoing) return;
 
-			// Save content before clearing so we can restore it if the send fails.
+			// Save content + attachments before clearing so we can restore them
+			// if the send fails. `attachments` contains the AttachmentWithMetadata
+			// list (data + media_type + name + size) needed to repopulate the chip
+			// row, while `outgoing.images` is the trimmed-down send payload.
 			const savedContent = outgoing.content;
+			const savedAttachments = attachments;
 
 			// Clear UI optimistically
 			clearDraft();
@@ -306,11 +311,23 @@ export default function MessageInput({
 			// Send message with images; a boolean false return signals failure
 			const result = await onSend(savedContent, outgoing.images, deliveryMode);
 			if (result === false) {
-				// Restore the draft so the user doesn't lose their message
+				// Restore the draft and attachments so the user doesn't lose their work
 				setContent(savedContent);
+				if (savedAttachments.length > 0) {
+					restoreAttachments(savedAttachments);
+				}
 			}
 		},
-		[disabled, extractOutgoingMessage, clearDraft, clearAttachments, setContent, onSend]
+		[
+			disabled,
+			extractOutgoingMessage,
+			attachments,
+			clearDraft,
+			clearAttachments,
+			restoreAttachments,
+			setContent,
+			onSend,
+		]
 	);
 
 	// Destructure stable callback refs to avoid recreating handleKeyDown on every render

--- a/packages/web/src/components/space/AgentOverlayChat.tsx
+++ b/packages/web/src/components/space/AgentOverlayChat.tsx
@@ -10,6 +10,7 @@
  */
 
 import { useEffect, useRef } from 'preact/hooks';
+import type { MessageImage } from '@neokai/shared';
 import { Portal } from '../ui/Portal';
 import { setupFocusTrap } from '../ui/Modal';
 import ChatContainer from '../../islands/ChatContainer';
@@ -59,14 +60,21 @@ export function AgentOverlayChat({
 }: AgentOverlayChatProps) {
 	const panelRef = useRef<HTMLDivElement>(null);
 	const handleTaskContextSend = taskContext
-		? async (message: string, _images?: unknown[]) => {
+		? async (message: string, images?: MessageImage[]) => {
 				const trimmed = message.trim();
 				if (!trimmed) return false;
-				const result = await spaceStore.sendTaskMessage(taskContext.taskId, trimmed, {
-					kind: 'node_agent',
-					agentName: taskContext.agentName,
-					...(taskContext.nodeExecutionId ? { nodeExecutionId: taskContext.nodeExecutionId } : {}),
-				});
+				const result = await spaceStore.sendTaskMessage(
+					taskContext.taskId,
+					trimmed,
+					{
+						kind: 'node_agent',
+						agentName: taskContext.agentName,
+						...(taskContext.nodeExecutionId
+							? { nodeExecutionId: taskContext.nodeExecutionId }
+							: {}),
+					},
+					images
+				);
 				if (result?.delivered === false && !result?.queued) {
 					throw new Error(
 						'Agent is starting — your message could not be delivered. Try again in a moment.'

--- a/packages/web/src/components/space/SpaceTaskPane.tsx
+++ b/packages/web/src/components/space/SpaceTaskPane.tsx
@@ -1,5 +1,6 @@
 import {
 	isWorkflowRecoveryTransition,
+	type MessageImage,
 	type SpaceTaskActivityMember,
 	type SpaceTaskActivityState,
 	type SpaceTaskPriority,
@@ -529,7 +530,8 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 
 	const sendThreadMessage = async (
 		nextMessage: string,
-		target: TaskComposerTarget | null
+		target: TaskComposerTarget | null,
+		images?: MessageImage[]
 	): Promise<boolean> => {
 		if (!nextMessage) return false;
 		if (!runtimeSpaceId || !task) return false;
@@ -554,7 +556,8 @@ export function SpaceTaskPane({ taskId, spaceId, onClose }: SpaceTaskPaneProps) 
 							agentName: target.agentName,
 							...(target.nodeExecutionId ? { nodeExecutionId: target.nodeExecutionId } : {}),
 						}
-					: { kind: 'task_agent' }
+					: { kind: 'task_agent' },
+				images
 			);
 
 			// When the daemon queued the message for a not-yet-spawned agent,

--- a/packages/web/src/components/space/TaskSessionChatComposer.tsx
+++ b/packages/web/src/components/space/TaskSessionChatComposer.tsx
@@ -28,7 +28,11 @@ interface TaskSessionChatComposerProps {
 	onTargetSelect: (targetId: string) => void;
 	onDraftActiveChange?: (hasDraft: boolean) => void;
 	onComposerRef?: Ref<HTMLDivElement>;
-	onSend: (message: string, target: TaskComposerTarget | null) => Promise<boolean>;
+	onSend: (
+		message: string,
+		target: TaskComposerTarget | null,
+		images?: MessageImage[]
+	) => Promise<boolean>;
 }
 
 export function TaskSessionChatComposer({
@@ -85,10 +89,10 @@ export function TaskSessionChatComposer({
 	// Return the boolean so MessageInput can restore the draft when sending fails
 	const handleSend = async (
 		content: string,
-		_images?: MessageImage[],
+		images?: MessageImage[],
 		_deliveryMode?: MessageDeliveryMode
 	): Promise<boolean> => {
-		return onSend(content, selectedTarget);
+		return onSend(content, selectedTarget, images);
 	};
 
 	const handleOpenTools = () => {

--- a/packages/web/src/components/space/__tests__/AgentOverlayChat.test.tsx
+++ b/packages/web/src/components/space/__tests__/AgentOverlayChat.test.tsx
@@ -125,11 +125,16 @@ describe('AgentOverlayChat', () => {
 
 		fireEvent.click(getByTestId('mock-chat-send-override'));
 		await vi.waitFor(() => {
-			expect(mockSendTaskMessage).toHaveBeenCalledWith('task-1', 'hello node', {
-				kind: 'node_agent',
-				agentName: 'coder',
-				nodeExecutionId: 'exec-coder-1',
-			});
+			expect(mockSendTaskMessage).toHaveBeenCalledWith(
+				'task-1',
+				'hello node',
+				{
+					kind: 'node_agent',
+					agentName: 'coder',
+					nodeExecutionId: 'exec-coder-1',
+				},
+				undefined
+			);
 		});
 	});
 

--- a/packages/web/src/components/space/__tests__/AgentOverlayChat.test.tsx
+++ b/packages/web/src/components/space/__tests__/AgentOverlayChat.test.tsx
@@ -32,7 +32,7 @@ vi.mock('../../../islands/ChatContainer', () => ({
 	}: {
 		sessionId: string;
 		onBack?: () => void;
-		onSendOverride?: (message: string) => Promise<boolean>;
+		onSendOverride?: (message: string, images?: unknown) => Promise<boolean>;
 	}) => (
 		<div
 			data-testid="mock-chat-container"
@@ -43,13 +43,26 @@ vi.mock('../../../islands/ChatContainer', () => ({
 				back
 			</button>
 			{onSendOverride ? (
-				<button
-					type="button"
-					data-testid="mock-chat-send-override"
-					onClick={() => void onSendOverride(' hello node ')}
-				>
-					send
-				</button>
+				<>
+					<button
+						type="button"
+						data-testid="mock-chat-send-override"
+						onClick={() => void onSendOverride(' hello node ')}
+					>
+						send
+					</button>
+					<button
+						type="button"
+						data-testid="mock-chat-send-override-with-images"
+						onClick={() =>
+							void onSendOverride(' hello with screenshot ', [
+								{ media_type: 'image/png', data: 'AAAAB' },
+							])
+						}
+					>
+						send-with-images
+					</button>
+				</>
 			) : null}
 			{sessionId}
 		</div>
@@ -134,6 +147,35 @@ describe('AgentOverlayChat', () => {
 					nodeExecutionId: 'exec-coder-1',
 				},
 				undefined
+			);
+		});
+	});
+
+	it('forwards image attachments through onSendOverride to spaceStore.sendTaskMessage', async () => {
+		const { getByTestId } = render(
+			<AgentOverlayChat
+				sessionId={SESSION_ID}
+				onClose={onClose}
+				taskContext={{
+					taskId: 'task-1',
+					agentName: 'coder',
+					nodeExecutionId: 'exec-coder-1',
+				}}
+			/>
+		);
+
+		fireEvent.click(getByTestId('mock-chat-send-override-with-images'));
+
+		await vi.waitFor(() => {
+			expect(mockSendTaskMessage).toHaveBeenCalledWith(
+				'task-1',
+				'hello with screenshot',
+				{
+					kind: 'node_agent',
+					agentName: 'coder',
+					nodeExecutionId: 'exec-coder-1',
+				},
+				[{ media_type: 'image/png', data: 'AAAAB' }]
 			);
 		});
 	});

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.images.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.images.test.tsx
@@ -1,0 +1,204 @@
+// @ts-nocheck
+/**
+ * SpaceTaskPane image passthrough tests
+ *
+ * Verifies the wiring TaskSessionChatComposer.onSend → SpaceTaskPane.sendThreadMessage
+ * → spaceStore.sendTaskMessage forwards images. The image surface is awkward to drive
+ * end-to-end through the real composer (would require File/clipboard mocks), so we
+ * mock TaskSessionChatComposer to capture its onSend prop and invoke it directly.
+ */
+
+import type {
+	NodeExecution,
+	SpaceAgent,
+	SpaceTask,
+	SpaceTaskActivityMember,
+	SpaceWorkflow,
+	SpaceWorkflowRun,
+} from '@neokai/shared';
+import { signal } from '@preact/signals';
+import { cleanup, render, waitFor } from '@testing-library/preact';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+	mockSpaceOverlaySessionIdSignal,
+	mockSpaceOverlayAgentNameSignal,
+	mockSpaceOverlayTaskContextSignal,
+	mockCurrentSpaceTaskViewTabSignal,
+	mockCurrentSpaceIdSignal,
+	captured,
+} = vi.hoisted(() => ({
+	mockSpaceOverlaySessionIdSignal: { value: null as string | null },
+	mockSpaceOverlayAgentNameSignal: { value: null as string | null },
+	mockSpaceOverlayTaskContextSignal: {
+		value: null as { taskId: string; agentName: string; nodeExecutionId?: string | null } | null,
+	},
+	mockCurrentSpaceTaskViewTabSignal: { value: 'thread' as string },
+	mockCurrentSpaceIdSignal: { value: null as string | null },
+	captured: { onSend: null as unknown },
+}));
+
+vi.mock('../TaskSessionChatComposer', () => ({
+	TaskSessionChatComposer: ({ onSend }: { onSend: unknown }) => {
+		captured.onSend = onSend;
+		return <div data-testid="mock-task-session-chat-composer" />;
+	},
+}));
+
+vi.mock('../../../lib/router', () => ({
+	currentRoute: signal({ name: 'space-task' }),
+	navigate: vi.fn(),
+}));
+
+vi.mock('../../../lib/signals', async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		get spaceOverlaySessionIdSignal() {
+			return mockSpaceOverlaySessionIdSignal;
+		},
+		get spaceOverlayAgentNameSignal() {
+			return mockSpaceOverlayAgentNameSignal;
+		},
+		get spaceOverlayTaskContextSignal() {
+			return mockSpaceOverlayTaskContextSignal;
+		},
+		get spaceOverlayPendingTaskIdSignal() {
+			return { value: null };
+		},
+		get currentSpaceTaskViewTabSignal() {
+			return mockCurrentSpaceTaskViewTabSignal;
+		},
+		get currentSpaceIdSignal() {
+			return mockCurrentSpaceIdSignal;
+		},
+	};
+});
+
+let mockTasks: ReturnType<typeof signal<SpaceTask[]>>;
+let mockAgents: ReturnType<typeof signal<SpaceAgent[]>>;
+let mockWorkflows: ReturnType<typeof signal<SpaceWorkflow[]>>;
+let mockWorkflowRuns: ReturnType<typeof signal<SpaceWorkflowRun[]>>;
+let mockTaskActivity: ReturnType<typeof signal<Map<string, SpaceTaskActivityMember[]>>>;
+let mockNodeExecutions: ReturnType<typeof signal<NodeExecution[]>>;
+let mockNodeExecutionsByNodeId: ReturnType<typeof signal<Map<string, unknown[]>>>;
+
+const mockSendTaskMessage = vi.fn();
+const mockEnsureTaskAgentSession = vi.fn();
+
+vi.mock('../../../lib/space-store', () => ({
+	get spaceStore() {
+		return {
+			tasks: mockTasks,
+			agents: mockAgents,
+			workflows: mockWorkflows,
+			workflowRuns: mockWorkflowRuns,
+			taskActivity: mockTaskActivity,
+			nodeExecutions: mockNodeExecutions,
+			nodeExecutionsByNodeId: mockNodeExecutionsByNodeId,
+			updateTask: vi.fn(),
+			recoverWorkflowTask: vi.fn(),
+			submitForReview: vi.fn(),
+			ensureTaskAgentSession: mockEnsureTaskAgentSession,
+			sendTaskMessage: mockSendTaskMessage,
+			subscribeTaskActivity: vi.fn().mockResolvedValue(undefined),
+			unsubscribeTaskActivity: vi.fn(),
+			ensureConfigData: vi.fn().mockResolvedValue(undefined),
+			ensureNodeExecutions: vi.fn().mockResolvedValue(undefined),
+			listGateData: vi.fn().mockResolvedValue([]),
+		};
+	},
+}));
+
+vi.mock('../SpaceTaskUnifiedThread', () => ({
+	SpaceTaskUnifiedThread: () => <div data-testid="space-task-unified-thread" />,
+}));
+
+vi.mock('../ReadOnlyWorkflowCanvas', () => ({
+	ReadOnlyWorkflowCanvas: () => <div data-testid="workflow-canvas" />,
+}));
+
+vi.mock('../../../lib/utils', () => ({
+	cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+mockTasks = signal<SpaceTask[]>([]);
+mockAgents = signal<SpaceAgent[]>([]);
+mockWorkflows = signal<SpaceWorkflow[]>([]);
+mockWorkflowRuns = signal<SpaceWorkflowRun[]>([]);
+mockTaskActivity = signal<Map<string, SpaceTaskActivityMember[]>>(new Map());
+mockNodeExecutions = signal<NodeExecution[]>([]);
+mockNodeExecutionsByNodeId = signal<Map<string, unknown[]>>(new Map());
+
+import { SpaceTaskPane } from '../SpaceTaskPane';
+
+function makeTask(overrides: Partial<SpaceTask> = {}): SpaceTask {
+	return {
+		id: 'task-1',
+		spaceId: 'space-1',
+		taskNumber: 1,
+		title: 'Fix the bug',
+		description: 'Task description',
+		status: 'in_progress',
+		priority: 'normal',
+		dependsOn: [],
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		taskAgentSessionId: 'session-abc',
+		...overrides,
+	};
+}
+
+describe('SpaceTaskPane — image passthrough', () => {
+	beforeEach(() => {
+		cleanup();
+		captured.onSend = null;
+		mockTasks.value = [makeTask()];
+		mockSendTaskMessage.mockReset();
+		mockSendTaskMessage.mockResolvedValue({ delivered: true });
+		mockEnsureTaskAgentSession.mockReset();
+		mockSpaceOverlaySessionIdSignal.value = null;
+		mockSpaceOverlayAgentNameSignal.value = null;
+		mockSpaceOverlayTaskContextSignal.value = null;
+		mockCurrentSpaceTaskViewTabSignal.value = 'thread';
+		mockCurrentSpaceIdSignal.value = null;
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('forwards images from the composer to spaceStore.sendTaskMessage', async () => {
+		render(<SpaceTaskPane taskId="task-1" />);
+
+		await waitFor(() => expect(captured.onSend).toBeTruthy());
+
+		const sampleImage = { media_type: 'image/png' as const, data: 'AAAAB' };
+		const target = { id: 'task-agent', kind: 'task_agent' as const, label: 'Task Agent' };
+
+		await (captured.onSend as Function)('check this screenshot', target, [sampleImage]);
+
+		expect(mockSendTaskMessage).toHaveBeenCalledWith(
+			'task-1',
+			'check this screenshot',
+			{ kind: 'task_agent' },
+			[sampleImage]
+		);
+	});
+
+	it('passes undefined images when the composer fires onSend without attachments', async () => {
+		render(<SpaceTaskPane taskId="task-1" />);
+
+		await waitFor(() => expect(captured.onSend).toBeTruthy());
+
+		const target = { id: 'task-agent', kind: 'task_agent' as const, label: 'Task Agent' };
+		await (captured.onSend as Function)('plain text', target);
+
+		expect(mockSendTaskMessage).toHaveBeenCalledWith(
+			'task-1',
+			'plain text',
+			{ kind: 'task_agent' },
+			undefined
+		);
+	});
+});

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.mention.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.mention.test.tsx
@@ -275,11 +275,16 @@ describe('SpaceTaskPane — @mention autocomplete', () => {
 		fireEvent.click(container.getByTestId('send-button'));
 
 		await waitFor(() =>
-			expect(mockSendTaskMessage).toHaveBeenCalledWith('task-1', 'Can you check this?', {
-				kind: 'node_agent',
-				agentName: 'Coder',
-				nodeExecutionId: 'exec-coder',
-			})
+			expect(mockSendTaskMessage).toHaveBeenCalledWith(
+				'task-1',
+				'Can you check this?',
+				{
+					kind: 'node_agent',
+					agentName: 'Coder',
+					nodeExecutionId: 'exec-coder',
+				},
+				undefined
+			)
 		);
 	});
 
@@ -299,11 +304,16 @@ describe('SpaceTaskPane — @mention autocomplete', () => {
 		fireEvent.click(container.getByTestId('send-button'));
 
 		await waitFor(() =>
-			expect(mockSendTaskMessage).toHaveBeenCalledWith('task-1', 'Please review again', {
-				kind: 'node_agent',
-				agentName: 'Reviewer',
-				nodeExecutionId: 'exec-reviewer',
-			})
+			expect(mockSendTaskMessage).toHaveBeenCalledWith(
+				'task-1',
+				'Please review again',
+				{
+					kind: 'node_agent',
+					agentName: 'Reviewer',
+					nodeExecutionId: 'exec-reviewer',
+				},
+				undefined
+			)
 		);
 		await waitFor(() =>
 			expect(container.getByTestId('task-composer-target-trigger').getAttribute('title')).toBe(

--- a/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTaskPane.test.tsx
@@ -353,9 +353,14 @@ describe('SpaceTaskPane — composer', () => {
 		fireEvent.click(getByTestId('send-button'));
 
 		await waitFor(() =>
-			expect(mockSendTaskMessage).toHaveBeenCalledWith('task-1', 'Looks good to me', {
-				kind: 'task_agent',
-			})
+			expect(mockSendTaskMessage).toHaveBeenCalledWith(
+				'task-1',
+				'Looks good to me',
+				{
+					kind: 'task_agent',
+				},
+				undefined
+			)
 		);
 		expect(mockEnsureTaskAgentSession).not.toHaveBeenCalled();
 	});
@@ -414,9 +419,14 @@ describe('SpaceTaskPane — composer', () => {
 		fireEvent.submit(textarea.form!);
 
 		await waitFor(() =>
-			expect(mockSendTaskMessage).toHaveBeenCalledWith('task-1', 'Approve the PR', {
-				kind: 'task_agent',
-			})
+			expect(mockSendTaskMessage).toHaveBeenCalledWith(
+				'task-1',
+				'Approve the PR',
+				{
+					kind: 'task_agent',
+				},
+				undefined
+			)
 		);
 		await waitFor(() => expect(textarea.value).toBe(''));
 	});
@@ -430,9 +440,14 @@ describe('SpaceTaskPane — composer', () => {
 		fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
 
 		await waitFor(() =>
-			expect(mockSendTaskMessage).toHaveBeenCalledWith('task-1', 'Quick approve', {
-				kind: 'task_agent',
-			})
+			expect(mockSendTaskMessage).toHaveBeenCalledWith(
+				'task-1',
+				'Quick approve',
+				{
+					kind: 'task_agent',
+				},
+				undefined
+			)
 		);
 	});
 

--- a/packages/web/src/components/space/__tests__/TaskSessionChatComposer.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskSessionChatComposer.test.tsx
@@ -224,4 +224,26 @@ describe('TaskSessionChatComposer', () => {
 		renderComposer();
 		expect(typeof lastChatComposerProps?.onThinkingLevelChange).toBe('function');
 	});
+
+	describe('image passthrough', () => {
+		it('forwards image attachments from ChatComposer.onSend to the parent onSend with the selected target', async () => {
+			const { onSend } = renderComposer();
+			const sampleImage = { media_type: 'image/png' as const, data: 'AAAAB' };
+
+			// Simulate ChatComposer firing onSend with a multi-modal payload
+			await lastChatComposerProps?.onSend?.('look at this', [sampleImage], 'immediate');
+
+			expect(onSend).toHaveBeenCalledTimes(1);
+			expect(onSend).toHaveBeenCalledWith('look at this', targets[0], [sampleImage]);
+		});
+
+		it('forwards undefined when ChatComposer.onSend fires without images', async () => {
+			const { onSend } = renderComposer();
+
+			await lastChatComposerProps?.onSend?.('plain text', undefined, 'immediate');
+
+			expect(onSend).toHaveBeenCalledTimes(1);
+			expect(onSend).toHaveBeenCalledWith('plain text', targets[0], undefined);
+		});
+	});
 });

--- a/packages/web/src/hooks/__tests__/useFileAttachments.test.ts
+++ b/packages/web/src/hooks/__tests__/useFileAttachments.test.ts
@@ -96,8 +96,69 @@ describe('useFileAttachments', () => {
 			expect(typeof result.current.handleFileDrop).toBe('function');
 			expect(typeof result.current.handleRemove).toBe('function');
 			expect(typeof result.current.clear).toBe('function');
+			expect(typeof result.current.restore).toBe('function');
 			expect(typeof result.current.openFilePicker).toBe('function');
 			expect(typeof result.current.getImagesForSend).toBe('function');
+		});
+	});
+
+	describe('restore', () => {
+		it('repopulates the attachment list (e.g. after a failed send clear)', () => {
+			const { result } = renderHook(() => useFileAttachments());
+
+			expect(result.current.attachments).toEqual([]);
+
+			const snapshot = [
+				{
+					data: 'AAAA',
+					media_type: 'image/png' as const,
+					name: 'a.png',
+					size: 4,
+				},
+				{
+					data: 'BBBB',
+					media_type: 'image/jpeg' as const,
+					name: 'b.jpg',
+					size: 4,
+				},
+			];
+
+			act(() => {
+				result.current.restore(snapshot);
+			});
+
+			expect(result.current.attachments).toEqual(snapshot);
+		});
+
+		it('clear() then restore() round-trips back to the original attachments', () => {
+			const { result } = renderHook(() => useFileAttachments());
+			const snapshot = [
+				{
+					data: 'AAAA',
+					media_type: 'image/png' as const,
+					name: 'a.png',
+					size: 4,
+				},
+			];
+
+			act(() => {
+				result.current.restore(snapshot);
+			});
+			expect(result.current.attachments).toEqual(snapshot);
+
+			// Snapshot what the composer would save before optimistic clear
+			const saved = result.current.attachments;
+
+			act(() => {
+				result.current.clear();
+			});
+			expect(result.current.attachments).toEqual([]);
+
+			// Failed send → restore
+			act(() => {
+				result.current.restore(saved);
+			});
+			expect(result.current.attachments).toEqual(snapshot);
 		});
 	});
 

--- a/packages/web/src/hooks/useChatBase.ts
+++ b/packages/web/src/hooks/useChatBase.ts
@@ -101,6 +101,7 @@ export interface UseChatBaseReturn {
 	openFilePicker: () => void;
 	handlePaste: (e: ClipboardEvent) => Promise<void>;
 	clearAttachments: () => void;
+	restoreAttachments: (attachments: AttachmentWithMetadata[]) => void;
 
 	// Auto-scroll (compose useAutoScroll)
 	messagesContainerRef: RefObject<HTMLDivElement>;
@@ -337,6 +338,7 @@ export function useChatBase<T = ChatMessage>(options: UseChatBaseOptions<T>): Us
 		openFilePicker: fileAttachments.openFilePicker,
 		handlePaste,
 		clearAttachments: fileAttachments.clear,
+		restoreAttachments: fileAttachments.restore,
 
 		// Auto-scroll
 		messagesContainerRef,

--- a/packages/web/src/hooks/useFileAttachments.ts
+++ b/packages/web/src/hooks/useFileAttachments.ts
@@ -23,6 +23,13 @@ export interface UseFileAttachmentsResult {
 	handleFileDrop: (files: FileList) => Promise<void>;
 	handleRemove: (index: number) => void;
 	clear: () => void;
+	/**
+	 * Re-populate the attachment list after an optimistic `clear()`. Used by
+	 * the message composer to restore attachments when a send fails so the
+	 * user doesn't have to re-attach files. Pass the list snapshotted before
+	 * the optimistic clear.
+	 */
+	restore: (attachments: AttachmentWithMetadata[]) => void;
 	openFilePicker: () => void;
 	getImagesForSend: () => MessageImage[] | undefined;
 	handlePaste: (e: ClipboardEvent) => void;
@@ -104,6 +111,10 @@ export function useFileAttachments(): UseFileAttachmentsResult {
 		setAttachments([]);
 	}, []);
 
+	const restore = useCallback((items: AttachmentWithMetadata[]) => {
+		setAttachments(items);
+	}, []);
+
 	const openFilePicker = useCallback(() => {
 		fileInputRef.current?.click();
 	}, []);
@@ -121,6 +132,7 @@ export function useFileAttachments(): UseFileAttachmentsResult {
 		handleFileDrop,
 		handleRemove,
 		clear,
+		restore,
 		openFilePicker,
 		getImagesForSend,
 		handlePaste,

--- a/packages/web/src/islands/ChatContainer.tsx
+++ b/packages/web/src/islands/ChatContainer.tsx
@@ -96,10 +96,10 @@ export async function sendChatContainerMessage({
 	setLocalError: (message: string | null) => void;
 }): Promise<boolean> {
 	if (onSendOverride) {
-		if (images && images.length > 0) {
-			toast.error('Image attachments are not supported for task agent messages yet.');
-			return false;
-		}
+		// Task-agent overlays don't support deferred / queued sends yet — those are
+		// scoped to the regular session path, where the daemon owns the
+		// "deferred until idle" replay logic. Fail loudly so the caller's draft
+		// is preserved instead of silently dropping the user's message.
 		if (deliveryMode !== 'immediate') {
 			toast.error('Queued sends are not supported for task agent messages yet.');
 			return false;

--- a/packages/web/src/islands/__tests__/ChatContainerSendOverride.test.ts
+++ b/packages/web/src/islands/__tests__/ChatContainerSendOverride.test.ts
@@ -44,22 +44,21 @@ describe('sendChatContainerMessage override path', () => {
 		expect(setLocalError).toHaveBeenCalledWith(null);
 	});
 
-	it('rejects image sends before calling the override', async () => {
+	it('forwards image attachments to the override', async () => {
+		const images = [{ data: 'abc', media_type: 'image/png' as const }];
 		const result = await sendChatContainerMessage({
 			content: 'hello',
-			images: [{ data: 'abc', media_type: 'image/png' }],
+			images,
 			deliveryMode: 'immediate',
 			onSendOverride,
 			sendMessage,
 			setLocalError,
 		});
 
-		expect(result).toBe(false);
-		expect(onSendOverride).not.toHaveBeenCalled();
+		expect(result).toBe(true);
+		expect(onSendOverride).toHaveBeenCalledWith('hello', images);
 		expect(sendMessage).not.toHaveBeenCalled();
-		expect(toast.error).toHaveBeenCalledWith(
-			'Image attachments are not supported for task agent messages yet.'
-		);
+		expect(toast.error).not.toHaveBeenCalled();
 	});
 
 	it('rejects queued delivery before calling the override', async () => {

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -29,6 +29,7 @@ import type {
 	CreateSpaceWorkflowParams,
 	LiveQueryDeltaEvent,
 	LiveQuerySnapshotEvent,
+	MessageImage,
 	NodeExecution,
 	RuntimeState,
 	Space,
@@ -1681,13 +1682,19 @@ class SpaceStore {
 	 *
 	 * Returns the daemon response so callers can inspect delivered /
 	 * queued / activated for non-delivery feedback.
+	 *
+	 * `images` is an optional list of base64-encoded image attachments. The
+	 * daemon threads them into the SDK user-message content array so workflow
+	 * agents see image blocks alongside the text — mirroring the regular
+	 * (non-space) chat path.
 	 */
 	async sendTaskMessage(
 		taskId: string,
 		message: string,
 		target?:
 			| { kind: 'task_agent' }
-			| { kind: 'node_agent'; agentName: string; nodeExecutionId?: string }
+			| { kind: 'node_agent'; agentName: string; nodeExecutionId?: string },
+		images?: MessageImage[]
 	): Promise<{
 		ok: boolean;
 		routedTo?: string[];
@@ -1706,6 +1713,7 @@ class SpaceStore {
 			spaceId,
 			message,
 			...(target ? { target } : {}),
+			...(images && images.length > 0 ? { images } : {}),
 		});
 	}
 


### PR DESCRIPTION
## Summary
Images attached in the space thread composer and slide-out chat were silently dropped at every layer between the composer and the SDK. Threads `MessageImage[]` end-to-end (composer → store → RPC → daemon) and builds a multi-modal `MessageContent` array (image blocks first, then text) matching the existing non-space chat path.

Surfaces an explicit error when images are sent to a not-yet-spawned workflow agent rather than silently dropping them, since the pending-message queue is text-only.

Fixes Task #308.

## Test plan
- [x] Daemon unit tests pass (9596/9596 across 8 shards)
- [x] Web component tests pass (`AgentOverlayChat`, `SpaceTaskPane`, `SpaceTaskPane.mention`, `TaskSessionChatComposer` — 111/111)
- [x] New tests added for: forwards images on default routing / @mention / explicit node-agent target, treats `images: []` as undefined, rejects images destined for not-yet-spawned agent
- [x] `bun run check` passes (lint + typecheck + knip + session-guards)