### PR TITLE
fix: forward image attachments through OpenAI Responses bridge

### DIFF
--- a/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
+++ b/packages/daemon/src/lib/providers/anthropic-to-codex-bridge-provider.ts
@@ -154,7 +154,7 @@ export class AnthropicToCodexBridgeProvider implements Provider {
 			thinkingModes: 'granular',
 			maxContextWindow: 272000,
 			functionCalling: true,
-			vision: false,
+			vision: true,
 		};
 	}
 

--- a/packages/daemon/src/lib/providers/gemini/format-converter.ts
+++ b/packages/daemon/src/lib/providers/gemini/format-converter.ts
@@ -209,7 +209,7 @@ export function convertMessages(messages: AnthropicMessage[]): GeminiContent[] {
 				const textContent =
 					typeof block.content === 'string'
 						? block.content
-						: block.content.map((c) => c.text).join('');
+						: block.content.map((c) => (c.type === 'text' ? c.text : `[${c.type}]`)).join('');
 
 				// Look up the actual function name from the corresponding tool_use block
 				const functionName =

--- a/packages/daemon/src/lib/providers/ollama-bridge-server.ts
+++ b/packages/daemon/src/lib/providers/ollama-bridge-server.ts
@@ -96,7 +96,9 @@ function estimateTokens(text: string): number {
 
 function toolResultText(toolResult: AnthropicContentBlockToolResult): string {
 	if (typeof toolResult.content === 'string') return toolResult.content;
-	return toolResult.content.map((part) => part.text).join('');
+	return toolResult.content
+		.map((part) => (part.type === 'text' ? part.text : `[${part.type}]`))
+		.join('');
 }
 
 function extractText(content: string | AnthropicRequest['messages'][number]['content']): string {

--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -249,11 +249,11 @@ function estimateTextTokens(text: string): number {
  *
  * OpenAI bills vision tokens based on image dimensions and detail level,
  * not base64 payload size. Without access to actual image dimensions,
- * we use a conservative fixed estimate (low-detail ~85 tokens plus
- * overhead) rather than a base64-length heuristic that would inflate
- * estimates for large encoded payloads.
+ * we use a conservative fixed estimate (~300 tokens) that covers the
+ * common auto/high-detail case rather than a base64-length heuristic
+ * that would inflate estimates for large encoded payloads.
  */
-const ESTIMATED_IMAGE_TOKENS = 100;
+const ESTIMATED_IMAGE_TOKENS = 300;
 
 function estimateResponsesContentTokens(item: ResponsesInputItem): number {
 	if (item.type === 'function_call_output') {
@@ -309,7 +309,17 @@ function estimateResponsesPayloadTokens(
 
 function toolResultText(content: AnthropicContentBlockToolResult['content']): string {
 	if (typeof content === 'string') return content;
-	return content.map((block) => block.text).join('\n');
+	return content
+		.map((block) => {
+			if (block.type === 'text') return block.text;
+			if (block.type === 'image') {
+				const sourceType =
+					'source' in block && block.source?.type === 'url' ? 'URL' : 'base64 image';
+				return `[Image: ${sourceType}]`;
+			}
+			return `[Unsupported content block: ${(block as { type?: string }).type ?? 'unknown'}]`;
+		})
+		.join('\n');
 }
 
 function appendInputMessage(
@@ -360,8 +370,13 @@ function imageBlockToInputImage(block: AnthropicContentBlockImage): ResponsesInp
 	if (block.source.type === 'url') {
 		return { type: 'input_image', image_url: block.source.url };
 	}
-	const dataUrl = `data:${block.source.media_type};base64,${block.source.data}`;
-	return { type: 'input_image', image_url: dataUrl };
+	if (block.source.type === 'base64') {
+		const dataUrl = `data:${block.source.media_type};base64,${block.source.data}`;
+		return { type: 'input_image', image_url: dataUrl };
+	}
+	throw new Error(
+		`Unsupported image source type: ${(block.source as { type?: string }).type ?? 'unknown'}`
+	);
 }
 
 function appendUserBlocks(items: ResponsesInputItem[], blocks: AnthropicContentBlock[]): void {
@@ -385,7 +400,9 @@ function appendUserBlocks(items: ResponsesInputItem[], blocks: AnthropicContentB
 				call_id: result.tool_use_id,
 				output: result.is_error ? `[Tool error]\n${output}` : output,
 			});
+			continue;
 		}
+		throw new Error(`Unsupported user content block type: ${block.type}`);
 	}
 	appendInputMessage(items, 'user', contentParts);
 }

--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -106,7 +106,7 @@ type ResponsesInputItem =
 	| {
 			type: 'function_call_output';
 			call_id: string;
-			output: string | Array<{ type: 'text'; text: string } | ResponsesInputImage>;
+			output: string | Array<ResponsesInputText | ResponsesInputImage>;
 	  }
 	| ResponsesReasoningItem;
 
@@ -317,16 +317,16 @@ function estimateResponsesPayloadTokens(
 
 function toolResultContent(
 	content: AnthropicContentBlockToolResult['content']
-): string | Array<{ type: 'text'; text: string } | ResponsesInputImage> {
+): string | Array<ResponsesInputText | ResponsesInputImage> {
 	if (typeof content === 'string') return content;
 	const hasNonText = content.some((block) => block.type !== 'text');
 	if (!hasNonText) {
 		return content.map((block) => (block.type === 'text' ? block.text : '')).join('\n');
 	}
-	const result: Array<{ type: 'text'; text: string } | ResponsesInputImage> = [];
+	const result: Array<ResponsesInputText | ResponsesInputImage> = [];
 	for (const block of content) {
 		if (block.type === 'text') {
-			result.push({ type: 'text', text: block.text });
+			result.push({ type: 'input_text', text: block.text });
 			continue;
 		}
 		if (block.type === 'image') {
@@ -334,7 +334,7 @@ function toolResultContent(
 			continue;
 		}
 		result.push({
-			type: 'text',
+			type: 'input_text',
 			text: `[Unsupported content block: ${(block as { type?: string }).type ?? 'unknown'}]`,
 		});
 	}
@@ -420,7 +420,7 @@ function appendUserBlocks(items: ResponsesInputItem[], blocks: AnthropicContentB
 				output: result.is_error
 					? typeof output === 'string'
 						? `[Tool error]\n${output}`
-						: [{ type: 'text' as const, text: `[Tool error]` }, ...output]
+						: [{ type: 'input_text' as const, text: `[Tool error]` }, ...output]
 					: output,
 			});
 			continue;
@@ -1295,7 +1295,21 @@ export function createOpenAIResponsesBridgeServer(
 						logger.warn(
 							'openai-responses: endpoint rejects previous_response_id, retrying with full history'
 						);
-						requestBody = buildResponsesRequest(body, model, undefined, buildOpts, storedReasoning);
+						try {
+							requestBody = buildResponsesRequest(
+								body,
+								model,
+								undefined,
+								buildOpts,
+								storedReasoning
+							);
+						} catch (err) {
+							return sendJsonError(
+								400,
+								'invalid_request_error',
+								err instanceof Error ? err.message : 'Bad Request'
+							);
+						}
 						openAIResponse = await fetchImpl(upstreamUrl, {
 							method: 'POST',
 							headers: buildOpenAIHeaders(config.auth, resolvedAuth),

--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -106,7 +106,7 @@ type ResponsesInputItem =
 	| {
 			type: 'function_call_output';
 			call_id: string;
-			output: string;
+			output: string | Array<{ type: 'text'; text: string } | ResponsesInputImage>;
 	  }
 	| ResponsesReasoningItem;
 
@@ -257,7 +257,15 @@ const ESTIMATED_IMAGE_TOKENS = 300;
 
 function estimateResponsesContentTokens(item: ResponsesInputItem): number {
 	if (item.type === 'function_call_output') {
-		return estimateTextTokens(item.output);
+		if (typeof item.output === 'string') {
+			return estimateTextTokens(item.output);
+		}
+		return item.output.reduce((sum, block) => {
+			if (block.type === 'input_image') {
+				return sum + ESTIMATED_IMAGE_TOKENS;
+			}
+			return sum + estimateTextTokens(block.text);
+		}, 0);
 	}
 	if (item.type === 'function_call') {
 		return estimateTextTokens(item.name) + estimateTextTokens(item.arguments);
@@ -307,19 +315,30 @@ function estimateResponsesPayloadTokens(
 	);
 }
 
-function toolResultText(content: AnthropicContentBlockToolResult['content']): string {
+function toolResultContent(
+	content: AnthropicContentBlockToolResult['content']
+): string | Array<{ type: 'text'; text: string } | ResponsesInputImage> {
 	if (typeof content === 'string') return content;
-	return content
-		.map((block) => {
-			if (block.type === 'text') return block.text;
-			if (block.type === 'image') {
-				const sourceType =
-					'source' in block && block.source?.type === 'url' ? 'URL' : 'base64 image';
-				return `[Image: ${sourceType}]`;
-			}
-			return `[Unsupported content block: ${(block as { type?: string }).type ?? 'unknown'}]`;
-		})
-		.join('\n');
+	const hasNonText = content.some((block) => block.type !== 'text');
+	if (!hasNonText) {
+		return content.map((block) => (block.type === 'text' ? block.text : '')).join('\n');
+	}
+	const result: Array<{ type: 'text'; text: string } | ResponsesInputImage> = [];
+	for (const block of content) {
+		if (block.type === 'text') {
+			result.push({ type: 'text', text: block.text });
+			continue;
+		}
+		if (block.type === 'image') {
+			result.push(imageBlockToInputImage(block));
+			continue;
+		}
+		result.push({
+			type: 'text',
+			text: `[Unsupported content block: ${(block as { type?: string }).type ?? 'unknown'}]`,
+		});
+	}
+	return result;
 }
 
 function appendInputMessage(
@@ -392,13 +411,17 @@ function appendUserBlocks(items: ResponsesInputItem[], blocks: AnthropicContentB
 		}
 		if (block.type === 'tool_result') {
 			const result = block as AnthropicContentBlockToolResult & { is_error?: boolean };
-			const output = toolResultText(result.content);
+			const output = toolResultContent(result.content);
 			appendInputMessage(items, 'user', contentParts);
 			contentParts.length = 0;
 			items.push({
 				type: 'function_call_output',
 				call_id: result.tool_use_id,
-				output: result.is_error ? `[Tool error]\n${output}` : output,
+				output: result.is_error
+					? typeof output === 'string'
+						? `[Tool error]\n${output}`
+						: [{ type: 'text' as const, text: `[Tool error]` }, ...output]
+					: output,
 			});
 			continue;
 		}
@@ -1237,13 +1260,16 @@ export function createOpenAIResponsesBridgeServer(
 			if (storedReasoning && storedReasoning.length > 0) {
 				continuation = undefined;
 			}
-			let requestBody = buildResponsesRequest(
-				body,
-				model,
-				continuation,
-				buildOpts,
-				storedReasoning
-			);
+			let requestBody: ResponsesRequest;
+			try {
+				requestBody = buildResponsesRequest(body, model, continuation, buildOpts, storedReasoning);
+			} catch (err) {
+				return sendJsonError(
+					400,
+					'invalid_request_error',
+					err instanceof Error ? err.message : 'Bad Request'
+				);
+			}
 			const upstreamUrl = `${baseUrl.replace(/\/$/, '')}/responses`;
 			let openAIResponse: Response;
 			try {

--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -245,6 +245,16 @@ function estimateTextTokens(text: string): number {
 	return Math.max(1, Math.ceil((characterEstimate + lexicalPieces) / 2));
 }
 
+/** Fixed token estimate per image for OpenAI vision models.
+ *
+ * OpenAI bills vision tokens based on image dimensions and detail level,
+ * not base64 payload size. Without access to actual image dimensions,
+ * we use a conservative fixed estimate (low-detail ~85 tokens plus
+ * overhead) rather than a base64-length heuristic that would inflate
+ * estimates for large encoded payloads.
+ */
+const ESTIMATED_IMAGE_TOKENS = 100;
+
 function estimateResponsesContentTokens(item: ResponsesInputItem): number {
 	if (item.type === 'function_call_output') {
 		return estimateTextTokens(item.output);
@@ -257,8 +267,7 @@ function estimateResponsesContentTokens(item: ResponsesInputItem): number {
 	}
 	return item.content.reduce((sum, block) => {
 		if (block.type === 'input_image') {
-			// Rough heuristic: base64 data URL ~4/3 of raw bytes, ~1 token per 4 chars
-			return sum + Math.max(1, Math.ceil(block.image_url.length / 4));
+			return sum + ESTIMATED_IMAGE_TOKENS;
 		}
 		return sum + estimateTextTokens(block.text);
 	}, 0);
@@ -306,20 +315,34 @@ function toolResultText(content: AnthropicContentBlockToolResult['content']): st
 function appendInputMessage(
 	items: ResponsesInputItem[],
 	role: 'user' | 'system' | 'developer',
-	textParts: string[],
-	imageParts: ResponsesInputImage[] = []
+	contentParts: Array<ResponsesInputText | ResponsesInputImage>
 ): void {
-	const text = textParts.filter(Boolean).join('\n\n');
-	if (!text && imageParts.length === 0) return;
-	const content: Array<ResponsesInputText | ResponsesInputImage> = [];
-	if (text) {
-		content.push({ type: 'input_text', text });
+	if (contentParts.length === 0) return;
+	// Merge consecutive input_text blocks into a single block so the upstream
+	// API receives clean, consolidated text rather than fragmented pieces.
+	const merged: Array<ResponsesInputText | ResponsesInputImage> = [];
+	let pendingText: string[] = [];
+	const flushText = () => {
+		const text = pendingText.filter(Boolean).join('\n\n');
+		if (text) {
+			merged.push({ type: 'input_text', text });
+		}
+		pendingText = [];
+	};
+	for (const part of contentParts) {
+		if (part.type === 'input_text') {
+			pendingText.push(part.text);
+		} else {
+			flushText();
+			merged.push(part);
+		}
 	}
-	content.push(...imageParts);
+	flushText();
+	if (merged.length === 0) return;
 	items.push({
 		type: 'message',
 		role,
-		content,
+		content: merged,
 	});
 }
 
@@ -334,26 +357,29 @@ function appendAssistantMessage(items: ResponsesInputItem[], textParts: string[]
 }
 
 function imageBlockToInputImage(block: AnthropicContentBlockImage): ResponsesInputImage {
+	if (block.source.type === 'url') {
+		return { type: 'input_image', image_url: block.source.url };
+	}
 	const dataUrl = `data:${block.source.media_type};base64,${block.source.data}`;
 	return { type: 'input_image', image_url: dataUrl };
 }
 
 function appendUserBlocks(items: ResponsesInputItem[], blocks: AnthropicContentBlock[]): void {
-	const textParts: string[] = [];
-	const imageParts: ResponsesInputImage[] = [];
+	const contentParts: Array<ResponsesInputText | ResponsesInputImage> = [];
 	for (const block of blocks) {
 		if (block.type === 'text') {
-			textParts.push(block.text);
+			contentParts.push({ type: 'input_text', text: block.text });
 			continue;
 		}
 		if (block.type === 'image') {
-			imageParts.push(imageBlockToInputImage(block));
+			contentParts.push(imageBlockToInputImage(block));
 			continue;
 		}
 		if (block.type === 'tool_result') {
 			const result = block as AnthropicContentBlockToolResult & { is_error?: boolean };
 			const output = toolResultText(result.content);
-			appendInputMessage(items, 'user', textParts.splice(0), imageParts.splice(0));
+			appendInputMessage(items, 'user', contentParts);
+			contentParts.length = 0;
 			items.push({
 				type: 'function_call_output',
 				call_id: result.tool_use_id,
@@ -361,7 +387,7 @@ function appendUserBlocks(items: ResponsesInputItem[], blocks: AnthropicContentB
 			});
 		}
 	}
-	appendInputMessage(items, 'user', textParts, imageParts);
+	appendInputMessage(items, 'user', contentParts);
 }
 
 function appendAssistantBlocks(items: ResponsesInputItem[], blocks: AnthropicContentBlock[]): void {
@@ -444,7 +470,7 @@ export function anthropicMessagesToResponsesInput(
 				if (reasoningItems && reasoningItems.length > 0 && i === lastUserIndex) {
 					items.push(...reasoningItems);
 				}
-				appendInputMessage(items, 'user', [message.content]);
+				appendInputMessage(items, 'user', [{ type: 'input_text', text: message.content }]);
 			}
 			continue;
 		}

--- a/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
+++ b/packages/daemon/src/lib/providers/openai-responses-bridge/server.ts
@@ -9,6 +9,7 @@
 
 import {
 	type AnthropicContentBlock,
+	type AnthropicContentBlockImage,
 	type AnthropicContentBlockToolResult,
 	type AnthropicRequest,
 	type AnthropicTool,
@@ -77,11 +78,18 @@ type ResponsesReasoningItem = {
 	encrypted_content: string;
 };
 
+type ResponsesInputText = { type: 'input_text'; text: string };
+type ResponsesInputImage = {
+	type: 'input_image';
+	image_url: string;
+	detail?: 'low' | 'high' | 'auto' | 'original';
+};
+
 type ResponsesInputItem =
 	| {
 			type: 'message';
 			role: 'user' | 'system' | 'developer';
-			content: Array<{ type: 'input_text'; text: string }>;
+			content: Array<ResponsesInputText | ResponsesInputImage>;
 	  }
 	| {
 			type: 'message';
@@ -247,7 +255,13 @@ function estimateResponsesContentTokens(item: ResponsesInputItem): number {
 	if (item.type === 'reasoning') {
 		return estimateTextTokens(item.encrypted_content);
 	}
-	return item.content.reduce((sum, block) => sum + estimateTextTokens(block.text), 0);
+	return item.content.reduce((sum, block) => {
+		if (block.type === 'input_image') {
+			// Rough heuristic: base64 data URL ~4/3 of raw bytes, ~1 token per 4 chars
+			return sum + Math.max(1, Math.ceil(block.image_url.length / 4));
+		}
+		return sum + estimateTextTokens(block.text);
+	}, 0);
 }
 
 function estimateResponsesInputTokens(items: ResponsesInputItem[]): number {
@@ -292,14 +306,20 @@ function toolResultText(content: AnthropicContentBlockToolResult['content']): st
 function appendInputMessage(
 	items: ResponsesInputItem[],
 	role: 'user' | 'system' | 'developer',
-	textParts: string[]
+	textParts: string[],
+	imageParts: ResponsesInputImage[] = []
 ): void {
 	const text = textParts.filter(Boolean).join('\n\n');
-	if (!text) return;
+	if (!text && imageParts.length === 0) return;
+	const content: Array<ResponsesInputText | ResponsesInputImage> = [];
+	if (text) {
+		content.push({ type: 'input_text', text });
+	}
+	content.push(...imageParts);
 	items.push({
 		type: 'message',
 		role,
-		content: [{ type: 'input_text', text }],
+		content,
 	});
 }
 
@@ -313,17 +333,27 @@ function appendAssistantMessage(items: ResponsesInputItem[], textParts: string[]
 	});
 }
 
+function imageBlockToInputImage(block: AnthropicContentBlockImage): ResponsesInputImage {
+	const dataUrl = `data:${block.source.media_type};base64,${block.source.data}`;
+	return { type: 'input_image', image_url: dataUrl };
+}
+
 function appendUserBlocks(items: ResponsesInputItem[], blocks: AnthropicContentBlock[]): void {
 	const textParts: string[] = [];
+	const imageParts: ResponsesInputImage[] = [];
 	for (const block of blocks) {
 		if (block.type === 'text') {
 			textParts.push(block.text);
 			continue;
 		}
+		if (block.type === 'image') {
+			imageParts.push(imageBlockToInputImage(block));
+			continue;
+		}
 		if (block.type === 'tool_result') {
 			const result = block as AnthropicContentBlockToolResult & { is_error?: boolean };
 			const output = toolResultText(result.content);
-			appendInputMessage(items, 'user', textParts.splice(0));
+			appendInputMessage(items, 'user', textParts.splice(0), imageParts.splice(0));
 			items.push({
 				type: 'function_call_output',
 				call_id: result.tool_use_id,
@@ -331,7 +361,7 @@ function appendUserBlocks(items: ResponsesInputItem[], blocks: AnthropicContentB
 			});
 		}
 	}
-	appendInputMessage(items, 'user', textParts);
+	appendInputMessage(items, 'user', textParts, imageParts);
 }
 
 function appendAssistantBlocks(items: ResponsesInputItem[], blocks: AnthropicContentBlock[]): void {

--- a/packages/daemon/src/lib/providers/provider-anthropic-compat/token-estimator.ts
+++ b/packages/daemon/src/lib/providers/provider-anthropic-compat/token-estimator.ts
@@ -46,7 +46,11 @@ function estimateTextTokens(text: string): number {
 
 function estimateToolResultContent(content: AnthropicContentBlockToolResult['content']): number {
 	if (typeof content === 'string') return estimateTextTokens(content);
-	return content.reduce((sum, block) => sum + estimateTextTokens(block.text), 0);
+	return content.reduce(
+		(sum, block) =>
+			sum + estimateTextTokens(block.type === 'text' ? block.text : `[${block.type}]`),
+		0
+	);
 }
 
 function estimateContentBlockTokens(block: AnthropicContentBlock): number {

--- a/packages/daemon/src/lib/providers/provider-anthropic-compat/token-estimator.ts
+++ b/packages/daemon/src/lib/providers/provider-anthropic-compat/token-estimator.ts
@@ -44,13 +44,17 @@ function estimateTextTokens(text: string): number {
 	return Math.max(1, Math.ceil((characterEstimate + lexicalPieces) / 2));
 }
 
+const ESTIMATED_IMAGE_TOKENS = 300;
+
 function estimateToolResultContent(content: AnthropicContentBlockToolResult['content']): number {
 	if (typeof content === 'string') return estimateTextTokens(content);
-	return content.reduce(
-		(sum, block) =>
-			sum + estimateTextTokens(block.type === 'text' ? block.text : `[${block.type}]`),
-		0
-	);
+	return content.reduce((sum, block) => {
+		if (block.type === 'text') return sum + estimateTextTokens(block.text);
+		if (block.type === 'image') return sum + ESTIMATED_IMAGE_TOKENS;
+		return (
+			sum + estimateTextTokens(`[Unsupported: ${(block as { type?: string }).type ?? 'unknown'}]`)
+		);
+	}, 0);
 }
 
 function estimateContentBlockTokens(block: AnthropicContentBlock): number {

--- a/packages/daemon/src/lib/providers/provider-anthropic-compat/token-estimator.ts
+++ b/packages/daemon/src/lib/providers/provider-anthropic-compat/token-estimator.ts
@@ -71,6 +71,9 @@ function estimateContentBlockTokens(block: AnthropicContentBlock): number {
 	if (block.type === 'tool_result') {
 		return MESSAGE_OVERHEAD_TOKENS + estimateToolResultContent(block.content);
 	}
+	if (block.type === 'image') {
+		return ESTIMATED_IMAGE_TOKENS;
+	}
 	return estimateTextTokens(stableJson(block));
 }
 

--- a/packages/daemon/src/lib/providers/provider-anthropic-compat/translator.ts
+++ b/packages/daemon/src/lib/providers/provider-anthropic-compat/translator.ts
@@ -27,14 +27,22 @@ export type AnthropicContentBlockToolResult = {
 	content: string | Array<{ type: 'text'; text: string }>;
 };
 
-export type AnthropicContentBlockImage = {
-	type: 'image';
-	source: {
-		type: 'base64';
-		media_type: 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp';
-		data: string;
-	};
-};
+export type AnthropicContentBlockImage =
+	| {
+			type: 'image';
+			source: {
+				type: 'base64';
+				media_type: 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp';
+				data: string;
+			};
+	  }
+	| {
+			type: 'image';
+			source: {
+				type: 'url';
+				url: string;
+			};
+	  };
 
 export type AnthropicContentBlock =
 	| AnthropicContentBlockText

--- a/packages/daemon/src/lib/providers/provider-anthropic-compat/translator.ts
+++ b/packages/daemon/src/lib/providers/provider-anthropic-compat/translator.ts
@@ -24,7 +24,7 @@ export type AnthropicContentBlockToolUse = {
 export type AnthropicContentBlockToolResult = {
 	type: 'tool_result';
 	tool_use_id: string;
-	content: string | Array<{ type: 'text'; text: string }>;
+	content: string | Array<{ type: 'text'; text: string } | AnthropicContentBlockImage>;
 };
 
 export type AnthropicContentBlockImage =

--- a/packages/daemon/src/lib/providers/provider-anthropic-compat/translator.ts
+++ b/packages/daemon/src/lib/providers/provider-anthropic-compat/translator.ts
@@ -27,10 +27,20 @@ export type AnthropicContentBlockToolResult = {
 	content: string | Array<{ type: 'text'; text: string }>;
 };
 
+export type AnthropicContentBlockImage = {
+	type: 'image';
+	source: {
+		type: 'base64';
+		media_type: 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp';
+		data: string;
+	};
+};
+
 export type AnthropicContentBlock =
 	| AnthropicContentBlockText
 	| AnthropicContentBlockToolUse
-	| AnthropicContentBlockToolResult;
+	| AnthropicContentBlockToolResult
+	| AnthropicContentBlockImage;
 
 export type AnthropicMessage = {
 	role: 'user' | 'assistant';

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
@@ -321,7 +321,7 @@ describe('openai-responses-bridge server', () => {
 				type: 'function_call_output',
 				call_id: 'call_1',
 				output: [
-					{ type: 'text', text: 'Screenshot taken.' },
+					{ type: 'input_text', text: 'Screenshot taken.' },
 					{ type: 'input_image', image_url: 'data:image/png;base64,screendata' },
 				],
 			},

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
@@ -285,6 +285,82 @@ describe('openai-responses-bridge server', () => {
 		]);
 	});
 
+	it('preserves non-text blocks in tool_result content as placeholders', () => {
+		const input = anthropicMessagesToResponsesInput([
+			{
+				role: 'assistant',
+				content: [{ type: 'tool_use', id: 'call_1', name: 'screenshot', input: {} }],
+			},
+			{
+				role: 'user',
+				content: [
+					{
+						type: 'tool_result',
+						tool_use_id: 'call_1',
+						content: [
+							{ type: 'text', text: 'Screenshot taken.' },
+							{
+								type: 'image',
+								source: { type: 'base64', media_type: 'image/png', data: 'screendata' },
+							},
+						],
+					},
+				],
+			},
+		]);
+
+		expect(input).toEqual([
+			{
+				type: 'function_call',
+				call_id: 'call_1',
+				name: 'screenshot',
+				arguments: '{}',
+				status: 'completed',
+			},
+			{
+				type: 'function_call_output',
+				call_id: 'call_1',
+				output: 'Screenshot taken.\n[Image: base64 image]',
+			},
+		]);
+	});
+
+	it('throws on unsupported image source types', () => {
+		expect(() =>
+			anthropicMessagesToResponsesInput([
+				{
+					role: 'user',
+					content: [
+						{
+							type: 'image',
+							source: { type: 'file', media_type: 'image/png', data: 'filedata' } as unknown as {
+								type: 'base64';
+								media_type: string;
+								data: string;
+							},
+						},
+					],
+				},
+			])
+		).toThrow('Unsupported image source type: file');
+	});
+
+	it('throws on unsupported user content block types', () => {
+		expect(() =>
+			anthropicMessagesToResponsesInput([
+				{
+					role: 'user',
+					content: [
+						{
+							type: 'document',
+							source: { type: 'base64', media_type: 'application/pdf', data: 'pdfdata' },
+						} as unknown as { type: 'text'; text: string },
+					],
+				},
+			])
+		).toThrow('Unsupported user content block type: document');
+	});
+
 	it('streams OpenAI text deltas as Anthropic text SSE', async () => {
 		let capturedBody: Record<string, unknown> | undefined;
 		server = createOpenAIResponsesBridgeServer({

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
@@ -285,7 +285,7 @@ describe('openai-responses-bridge server', () => {
 		]);
 	});
 
-	it('preserves non-text blocks in tool_result content as placeholders', () => {
+	it('preserves non-text blocks in tool_result content as structured output', () => {
 		const input = anthropicMessagesToResponsesInput([
 			{
 				role: 'assistant',
@@ -320,7 +320,47 @@ describe('openai-responses-bridge server', () => {
 			{
 				type: 'function_call_output',
 				call_id: 'call_1',
-				output: 'Screenshot taken.\n[Image: base64 image]',
+				output: [
+					{ type: 'text', text: 'Screenshot taken.' },
+					{ type: 'input_image', image_url: 'data:image/png;base64,screendata' },
+				],
+			},
+		]);
+	});
+
+	it('flattens text-only tool_result content to a string', () => {
+		const input = anthropicMessagesToResponsesInput([
+			{
+				role: 'assistant',
+				content: [{ type: 'tool_use', id: 'call_1', name: 'lookup', input: {} }],
+			},
+			{
+				role: 'user',
+				content: [
+					{
+						type: 'tool_result',
+						tool_use_id: 'call_1',
+						content: [
+							{ type: 'text', text: 'Line 1' },
+							{ type: 'text', text: 'Line 2' },
+						],
+					},
+				],
+			},
+		]);
+
+		expect(input).toEqual([
+			{
+				type: 'function_call',
+				call_id: 'call_1',
+				name: 'lookup',
+				arguments: '{}',
+				status: 'completed',
+			},
+			{
+				type: 'function_call_output',
+				call_id: 'call_1',
+				output: 'Line 1\nLine 2',
 			},
 		]);
 	});
@@ -1240,6 +1280,86 @@ describe('openai-responses-bridge server', () => {
 		});
 		expect(events.at(-1)?.event).toBe('message_stop');
 		expect(messageDeltaEvent(events)).toBeUndefined();
+	});
+
+	it('returns 400 for unsupported user content blocks', async () => {
+		server = createOpenAIResponsesBridgeServer({
+			auth: { source: 'api_key', apiKey: 'sk-test' },
+			models,
+			fetchImpl: async () =>
+				new Response(JSON.stringify({ error: { message: 'should not reach upstream' } }), {
+					status: 500,
+				}),
+		});
+
+		const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [
+					{
+						role: 'user',
+						content: [
+							{
+								type: 'document',
+								source: {
+									type: 'base64',
+									media_type: 'application/pdf',
+									data: 'pdfdata',
+								},
+							} as unknown as { type: 'text'; text: string },
+						],
+					},
+				],
+			}),
+		});
+
+		const body = (await resp.json()) as { error: { type: string; message: string } };
+		expect(resp.status).toBe(400);
+		expect(body.error.type).toBe('invalid_request_error');
+		expect(body.error.message).toContain('Unsupported user content block type: document');
+	});
+
+	it('returns 400 for unsupported image source types', async () => {
+		server = createOpenAIResponsesBridgeServer({
+			auth: { source: 'api_key', apiKey: 'sk-test' },
+			models,
+			fetchImpl: async () =>
+				new Response(JSON.stringify({ error: { message: 'should not reach upstream' } }), {
+					status: 500,
+				}),
+		});
+
+		const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [
+					{
+						role: 'user',
+						content: [
+							{
+								type: 'image',
+								source: { type: 'file', media_type: 'image/png', data: 'filedata' } as unknown as {
+									type: 'base64';
+									media_type: string;
+									data: string;
+								},
+							},
+						],
+					},
+				],
+			}),
+		});
+
+		const body = (await resp.json()) as { error: { type: string; message: string } };
+		expect(resp.status).toBe(400);
+		expect(body.error.type).toBe('invalid_request_error');
+		expect(body.error.message).toContain('Unsupported image source type: file');
 	});
 
 	it('maps upstream 429 responses to Anthropic rate_limit_error', async () => {

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
@@ -119,13 +119,14 @@ describe('openai-responses-bridge server', () => {
 			},
 		]);
 
+		// Source order is preserved: image first, then text
 		expect(input).toEqual([
 			{
 				type: 'message',
 				role: 'user',
 				content: [
-					{ type: 'input_text', text: 'What is in this image?' },
 					{ type: 'input_image', image_url: 'data:image/jpeg;base64,abc123' },
+					{ type: 'input_text', text: 'What is in this image?' },
 				],
 			},
 		]);
@@ -184,6 +185,67 @@ describe('openai-responses-bridge server', () => {
 		]);
 	});
 
+	it('preserves interleaved text/image order in user messages', () => {
+		const input = anthropicMessagesToResponsesInput([
+			{
+				role: 'user',
+				content: [
+					{ type: 'text', text: 'Before' },
+					{
+						type: 'image',
+						source: { type: 'base64', media_type: 'image/jpeg', data: 'img1' },
+					},
+					{ type: 'text', text: 'Between' },
+					{
+						type: 'image',
+						source: { type: 'base64', media_type: 'image/png', data: 'img2' },
+					},
+					{ type: 'text', text: 'After' },
+				],
+			},
+		]);
+
+		expect(input).toEqual([
+			{
+				type: 'message',
+				role: 'user',
+				content: [
+					{ type: 'input_text', text: 'Before' },
+					{ type: 'input_image', image_url: 'data:image/jpeg;base64,img1' },
+					{ type: 'input_text', text: 'Between' },
+					{ type: 'input_image', image_url: 'data:image/png;base64,img2' },
+					{ type: 'input_text', text: 'After' },
+				],
+			},
+		]);
+	});
+
+	it('translates URL-based image blocks to input_image with direct URL', () => {
+		const input = anthropicMessagesToResponsesInput([
+			{
+				role: 'user',
+				content: [
+					{
+						type: 'image',
+						source: { type: 'url', url: 'https://example.com/cat.jpg' },
+					},
+					{ type: 'text', text: 'What is this?' },
+				],
+			},
+		]);
+
+		expect(input).toEqual([
+			{
+				type: 'message',
+				role: 'user',
+				content: [
+					{ type: 'input_image', image_url: 'https://example.com/cat.jpg' },
+					{ type: 'input_text', text: 'What is this?' },
+				],
+			},
+		]);
+	});
+
 	it('handles images mixed with tool_results in user messages', () => {
 		const input = anthropicMessagesToResponsesInput([
 			{
@@ -216,8 +278,8 @@ describe('openai-responses-bridge server', () => {
 				type: 'message',
 				role: 'user',
 				content: [
-					{ type: 'input_text', text: 'What do you see?' },
 					{ type: 'input_image', image_url: 'data:image/png;base64,screendata' },
+					{ type: 'input_text', text: 'What do you see?' },
 				],
 			},
 		]);
@@ -345,8 +407,8 @@ describe('openai-responses-bridge server', () => {
 				type: 'message',
 				role: 'user',
 				content: [
-					{ type: 'input_text', text: 'What is in this image?' },
 					{ type: 'input_image', image_url: 'data:image/jpeg;base64,abc123' },
+					{ type: 'input_text', text: 'What is in this image?' },
 				],
 			},
 		]);

--- a/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
+++ b/packages/daemon/tests/unit/1-core/providers/openai-responses-bridge/server.test.ts
@@ -105,6 +105,124 @@ describe('openai-responses-bridge server', () => {
 		]);
 	});
 
+	it('translates Anthropic image blocks into Responses input_image items', () => {
+		const input = anthropicMessagesToResponsesInput([
+			{
+				role: 'user',
+				content: [
+					{
+						type: 'image',
+						source: { type: 'base64', media_type: 'image/jpeg', data: 'abc123' },
+					},
+					{ type: 'text', text: 'What is in this image?' },
+				],
+			},
+		]);
+
+		expect(input).toEqual([
+			{
+				type: 'message',
+				role: 'user',
+				content: [
+					{ type: 'input_text', text: 'What is in this image?' },
+					{ type: 'input_image', image_url: 'data:image/jpeg;base64,abc123' },
+				],
+			},
+		]);
+	});
+
+	it('handles image-only user messages without text', () => {
+		const input = anthropicMessagesToResponsesInput([
+			{
+				role: 'user',
+				content: [
+					{
+						type: 'image',
+						source: { type: 'base64', media_type: 'image/png', data: 'pngdata' },
+					},
+				],
+			},
+		]);
+
+		expect(input).toEqual([
+			{
+				type: 'message',
+				role: 'user',
+				content: [{ type: 'input_image', image_url: 'data:image/png;base64,pngdata' }],
+			},
+		]);
+	});
+
+	it('handles multiple images in a single user message', () => {
+		const input = anthropicMessagesToResponsesInput([
+			{
+				role: 'user',
+				content: [
+					{ type: 'text', text: 'Compare these:' },
+					{
+						type: 'image',
+						source: { type: 'base64', media_type: 'image/jpeg', data: 'img1' },
+					},
+					{
+						type: 'image',
+						source: { type: 'base64', media_type: 'image/webp', data: 'img2' },
+					},
+				],
+			},
+		]);
+
+		expect(input).toEqual([
+			{
+				type: 'message',
+				role: 'user',
+				content: [
+					{ type: 'input_text', text: 'Compare these:' },
+					{ type: 'input_image', image_url: 'data:image/jpeg;base64,img1' },
+					{ type: 'input_image', image_url: 'data:image/webp;base64,img2' },
+				],
+			},
+		]);
+	});
+
+	it('handles images mixed with tool_results in user messages', () => {
+		const input = anthropicMessagesToResponsesInput([
+			{
+				role: 'assistant',
+				content: [{ type: 'tool_use', id: 'call_1', name: 'screenshot', input: {} }],
+			},
+			{
+				role: 'user',
+				content: [
+					{ type: 'tool_result', tool_use_id: 'call_1', content: 'took screenshot' },
+					{
+						type: 'image',
+						source: { type: 'base64', media_type: 'image/png', data: 'screendata' },
+					},
+					{ type: 'text', text: 'What do you see?' },
+				],
+			},
+		]);
+
+		expect(input).toEqual([
+			{
+				type: 'function_call',
+				call_id: 'call_1',
+				name: 'screenshot',
+				arguments: '{}',
+				status: 'completed',
+			},
+			{ type: 'function_call_output', call_id: 'call_1', output: 'took screenshot' },
+			{
+				type: 'message',
+				role: 'user',
+				content: [
+					{ type: 'input_text', text: 'What do you see?' },
+					{ type: 'input_image', image_url: 'data:image/png;base64,screendata' },
+				],
+			},
+		]);
+	});
+
 	it('streams OpenAI text deltas as Anthropic text SSE', async () => {
 		let capturedBody: Record<string, unknown> | undefined;
 		server = createOpenAIResponsesBridgeServer({
@@ -174,6 +292,66 @@ describe('openai-responses-bridge server', () => {
 			type: 'message_delta',
 			delta: { stop_reason: 'end_turn' },
 		});
+	});
+
+	it('forwards image attachments to the OpenAI Responses API', async () => {
+		let capturedBody: Record<string, unknown> | undefined;
+		server = createOpenAIResponsesBridgeServer({
+			auth: { source: 'api_key', apiKey: 'sk-test' },
+			models,
+			fetchImpl: async (_url, init) => {
+				capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+				return sse([
+					{
+						event: 'response.output_text.delta',
+						data: { type: 'response.output_text.delta', delta: 'A cat.' },
+					},
+					{
+						event: 'response.completed',
+						data: {
+							type: 'response.completed',
+							response: { usage: { input_tokens: 100, output_tokens: 2 }, output: [] },
+						},
+					},
+				]);
+			},
+		});
+
+		const resp = await fetch(`http://127.0.0.1:${server.port}/v1/messages`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-5.3-codex',
+				max_tokens: 128,
+				messages: [
+					{
+						role: 'user',
+						content: [
+							{
+								type: 'image',
+								source: { type: 'base64', media_type: 'image/jpeg', data: 'abc123' },
+							},
+							{ type: 'text', text: 'What is in this image?' },
+						],
+					},
+				],
+			}),
+		});
+
+		expect(resp.status).toBe(200);
+		const input = capturedBody?.input as Array<Record<string, unknown>>;
+		expect(input).toEqual([
+			{
+				type: 'message',
+				role: 'user',
+				content: [
+					{ type: 'input_text', text: 'What is in this image?' },
+					{ type: 'input_image', image_url: 'data:image/jpeg;base64,abc123' },
+				],
+			},
+		]);
+		const events = await readSSEEvents(resp.body);
+		expect(textDeltaEvents(events).join('')).toBe('A cat.');
 	});
 
 	it('streams OpenAI function calls as Anthropic tool_use blocks', async () => {


### PR DESCRIPTION
Fixes the OpenAI (Codex) provider silently dropping image attachments sent with user messages.

**Root cause:** `appendUserBlocks` in the Responses bridge only handled `text` and `tool_result` content blocks. Image blocks (`AnthropicContentBlockImage`) were iterated over and ignored with no conversion or error.

**Fix:**
- Add `AnthropicContentBlockImage` to the translator types
- Extend `ResponsesInputItem` message content to include `input_image` blocks
- Convert image blocks to OpenAI Responses API `input_image` format using base64 data URLs (`data:image/jpeg;base64,...`)
- Update token estimation heuristic to account for image content
- Add unit tests covering: single image, image-only message, multiple images, images mixed with tool results, and end-to-end forwarding through the bridge server