### PR TITLE
fix(space): keep open tasks open when a dependency fails

### DIFF
--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -557,17 +557,22 @@ export class SpaceTaskManager {
 	}
 
 	/**
-	 * Block all open tasks that depend on the given task with 'dependency_failed'.
-	 * Recurses: if task B depends on A and task C depends on B, blocking A
-	 * cascades to both B and C.
+	 * Block in_progress tasks that depend on the given task with 'dependency_failed'.
+	 * Open tasks are intentionally NOT blocked here — they haven't started yet, so
+	 * they should remain `open` and be skipped naturally by `areDependenciesMet()`
+	 * on the next runtime tick. Blocking them would prevent them from ever
+	 * auto-starting once their dependency completes (they'd need a manual retry).
+	 *
+	 * Recurses: if task B (in_progress) depends on A and task C (in_progress)
+	 * depends on B, blocking A cascades to both B and C.
 	 */
 	async blockDependentTasks(taskId: string): Promise<SpaceTask[]> {
 		return this.doBlockCascade(taskId, []);
 	}
 
 	private async doBlockCascade(taskId: string, acc: SpaceTask[]): Promise<SpaceTask[]> {
-		const openTasks = await this.listTasksByStatus('open');
-		for (const t of openTasks) {
+		const inProgressTasks = await this.listTasksByStatus('in_progress');
+		for (const t of inProgressTasks) {
 			// Skip tasks already blocked by a prior recursive path in this cascade
 			if (acc.some((a) => a.id === t.id)) continue;
 			if (t.dependsOn?.includes(taskId)) {

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -557,17 +557,39 @@ export class SpaceTaskManager {
 	}
 
 	/**
-	 * Block in_progress tasks that depend on the given task with 'dependency_failed'.
-	 * Open tasks are intentionally NOT blocked here — they haven't started yet, so
-	 * they should remain `open` and be skipped naturally by `areDependenciesMet()`
-	 * on the next runtime tick. Blocking them would prevent them from ever
-	 * auto-starting once their dependency completes (they'd need a manual retry).
+	 * Block in_progress tasks that depend on the given (failed/blocked) task
+	 * with 'dependency_failed'. Open tasks are intentionally NOT blocked here —
+	 * they haven't started yet, so they should remain `open` and be skipped
+	 * naturally by `areDependenciesMet()` on the next runtime tick. Blocking
+	 * them would prevent them from ever auto-starting once their dependency
+	 * completes (they'd need a manual retry).
+	 *
+	 * For cancellation propagation (a terminal parent that won't be retried),
+	 * use `cancelDependentTasks` instead — it cancels both `open` and
+	 * `in_progress` dependents so they don't wait forever on an unmet dep.
 	 *
 	 * Recurses: if task B (in_progress) depends on A and task C (in_progress)
 	 * depends on B, blocking A cascades to both B and C.
 	 */
 	async blockDependentTasks(taskId: string): Promise<SpaceTask[]> {
 		return this.doBlockCascade(taskId, []);
+	}
+
+	/**
+	 * Cancel both `open` and `in_progress` tasks that depend on the given
+	 * (already-cancelled) task. Cancellation is terminal-but-restartable —
+	 * propagating `cancelled` keeps dependents from waiting forever on a
+	 * parent that will never reach `done`. A user can still retry the chain
+	 * by reactivating from the root.
+	 *
+	 * Use this from runtime paths where the parent has *already* been set to
+	 * `cancelled`. The API-level `cancelTaskCascade` is the one-shot version
+	 * that sets the root and cascades open dependents in a single call.
+	 *
+	 * Recurses through transitive dependents.
+	 */
+	async cancelDependentTasks(taskId: string): Promise<SpaceTask[]> {
+		return this.doCancelDependentsCascade(taskId, []);
 	}
 
 	private async doBlockCascade(taskId: string, acc: SpaceTask[]): Promise<SpaceTask[]> {
@@ -582,6 +604,25 @@ export class SpaceTaskManager {
 				});
 				acc.push(blocked);
 				await this.doBlockCascade(t.id, acc);
+			}
+		}
+		return acc;
+	}
+
+	private async doCancelDependentsCascade(taskId: string, acc: SpaceTask[]): Promise<SpaceTask[]> {
+		const candidates = [
+			...(await this.listTasksByStatus('open')),
+			...(await this.listTasksByStatus('in_progress')),
+		];
+		for (const t of candidates) {
+			// Skip tasks already cancelled by a prior recursive path in this cascade
+			if (acc.some((a) => a.id === t.id)) continue;
+			if (t.dependsOn?.includes(taskId)) {
+				const cancelled = await this.setTaskStatus(t.id, 'cancelled', {
+					result: `Dependency task ${taskId} was cancelled`,
+				});
+				acc.push(cancelled);
+				await this.doCancelDependentsCascade(t.id, acc);
 			}
 		}
 		return acc;

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -609,21 +609,32 @@ export class SpaceTaskManager {
 		return acc;
 	}
 
-	private async doCancelDependentsCascade(taskId: string, acc: SpaceTask[]): Promise<SpaceTask[]> {
-		const candidates = [
-			...(await this.listTasksByStatus('open')),
-			...(await this.listTasksByStatus('in_progress')),
-		];
-		for (const t of candidates) {
-			// Skip tasks already cancelled by a prior recursive path in this cascade
-			if (acc.some((a) => a.id === t.id)) continue;
-			if (t.dependsOn?.includes(taskId)) {
+	private async doCancelDependentsCascade(
+		taskId: string,
+		acc: SpaceTask[],
+		visited: Set<string> = new Set()
+	): Promise<SpaceTask[]> {
+		// Walk through ALL non-archived tasks so we can traverse intermediate
+		// `cancelled` dependents to reach their (still-open) descendants. We
+		// only *transition* `open`/`in_progress` tasks; already-`cancelled`/
+		// `done`/`blocked`/`review`/`approved` tasks are visited solely so the
+		// recursion can continue through them.
+		const allTasks = await this.listTasks(false /* includeArchived */);
+		for (const t of allTasks) {
+			if (visited.has(t.id)) continue;
+			if (!t.dependsOn?.includes(taskId)) continue;
+			visited.add(t.id);
+
+			if (t.status === 'open' || t.status === 'in_progress') {
 				const cancelled = await this.setTaskStatus(t.id, 'cancelled', {
 					result: `Dependency task ${taskId} was cancelled`,
 				});
 				acc.push(cancelled);
-				await this.doCancelDependentsCascade(t.id, acc);
 			}
+			// Recurse through this dependent regardless of whether we
+			// transitioned it — already-cancelled intermediates may still have
+			// open descendants that need to be cancelled.
+			await this.doCancelDependentsCascade(t.id, acc, visited);
 		}
 		return acc;
 	}

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -616,25 +616,35 @@ export class SpaceTaskManager {
 	): Promise<SpaceTask[]> {
 		// Walk through ALL non-archived tasks so we can traverse intermediate
 		// `cancelled` dependents to reach their (still-open) descendants. We
-		// only *transition* `open`/`in_progress` tasks; already-`cancelled`/
-		// `done`/`blocked`/`review`/`approved` tasks are visited solely so the
-		// recursion can continue through them.
+		// only *transition* `open`/`in_progress` tasks. Recursion only continues
+		// through tasks we just cancelled OR that were already `cancelled` —
+		// dependents in `done`/`review`/`approved`/`blocked` represent intact
+		// intermediate state, so their downstream descendants have a satisfied
+		// (or independently-failed) dependency edge and must not be transitively
+		// cancelled. Example: A retried→cancelled, B (deps:[A]) already done,
+		// C (deps:[B]) open — C must remain runnable because B is satisfied.
 		const allTasks = await this.listTasks(false /* includeArchived */);
 		for (const t of allTasks) {
 			if (visited.has(t.id)) continue;
 			if (!t.dependsOn?.includes(taskId)) continue;
 			visited.add(t.id);
 
+			let propagate = false;
 			if (t.status === 'open' || t.status === 'in_progress') {
 				const cancelled = await this.setTaskStatus(t.id, 'cancelled', {
 					result: `Dependency task ${taskId} was cancelled`,
 				});
 				acc.push(cancelled);
+				propagate = true;
+			} else if (t.status === 'cancelled') {
+				// Already-cancelled intermediate: keep traversing so we can reach
+				// any still-open descendants that depend on this branch.
+				propagate = true;
 			}
-			// Recurse through this dependent regardless of whether we
-			// transitioned it — already-cancelled intermediates may still have
-			// open descendants that need to be cancelled.
-			await this.doCancelDependentsCascade(t.id, acc, visited);
+
+			if (propagate) {
+				await this.doCancelDependentsCascade(t.id, acc, visited);
+			}
 		}
 		return acc;
 	}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -744,14 +744,23 @@ export class SpaceRuntime {
 		if (updated) {
 			await this.safeOnTaskUpdated(spaceId, updated, opts);
 
-			// Cascade dependency_failed to in_progress tasks that depend on this one.
-			// Open (not-yet-started) dependents are intentionally left untouched so
-			// they can still run if their dependency is later retried/completed.
-			if (params.status === 'blocked' || params.status === 'cancelled') {
+			// Cascade dependent-task state changes based on the parent's terminal status.
+			//   - `blocked` (transient, retryable): only abort `in_progress` dependents.
+			//     `open` dependents stay `open`, skipped by `areDependenciesMet()` until
+			//     the dependency is retried/completed.
+			//   - `cancelled` (terminal, will not auto-resume): cancel both `open` and
+			//     `in_progress` dependents so they don't wait forever on an unmet dep.
+			if (params.status === 'blocked') {
 				const taskManager = this.getOrCreateTaskManager(spaceId);
 				const cascaded = await taskManager.blockDependentTasks(taskId);
 				for (const blocked of cascaded) {
 					await this.safeOnTaskUpdated(spaceId, blocked);
+				}
+			} else if (params.status === 'cancelled') {
+				const taskManager = this.getOrCreateTaskManager(spaceId);
+				const cascaded = await taskManager.cancelDependentTasks(taskId);
+				for (const cancelled of cascaded) {
+					await this.safeOnTaskUpdated(spaceId, cancelled);
 				}
 			}
 		}
@@ -888,11 +897,15 @@ export class SpaceRuntime {
 
 			// Skip tasks already at a terminal or paused state — matches the
 			// active-tick guard (`taskAlreadyResolved`) at processRunTick.
+			// `blocked` is included so that a task that was cascade-blocked
+			// by a dependency failure isn't pushed through dispatchPostApproval
+			// (which would attempt an invalid `blocked → approved` transition).
 			if (
 				canonicalTask.status !== 'done' &&
 				canonicalTask.status !== 'review' &&
 				canonicalTask.status !== 'cancelled' &&
-				canonicalTask.status !== 'approved'
+				canonicalTask.status !== 'approved' &&
+				canonicalTask.status !== 'blocked'
 			) {
 				// Preserve the computed result on the task before routing —
 				// dispatchPostApproval handles the status transition itself.
@@ -2567,11 +2580,15 @@ export class SpaceRuntime {
 				// status — `done`/`cancelled` are terminal; `approved` means
 				// PostApprovalRouter already ran once. `review` can only occur via
 				// gate-type checkpoints now that completion actions are removed.
+				// `blocked` is also skipped: a task that was cascade-blocked by a
+				// failed dependency can't be transitioned `blocked → approved`
+				// (invalid transition), so we leave it for manual retry.
 				const taskAlreadyResolved =
 					canonicalTask.status === 'done' ||
 					canonicalTask.status === 'review' ||
 					canonicalTask.status === 'cancelled' ||
-					canonicalTask.status === 'approved';
+					canonicalTask.status === 'approved' ||
+					canonicalTask.status === 'blocked';
 
 				// Final status drives sibling cancellation. We only kill siblings when
 				// the task reached a true terminal state (`done`/`cancelled`).

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -73,6 +73,7 @@ import type { TaskAgentManager } from './task-agent-manager';
 import { WorkflowExecutor } from './workflow-executor';
 import { isPermanentSpawnError } from './workflow-node-execution-validation';
 import { selectWorkflow } from './workflow-selector';
+import { canTransition as canTransitionRunStatus } from './workflow-run-status-machine';
 
 const log = new Logger('space-runtime');
 
@@ -761,6 +762,18 @@ export class SpaceRuntime {
 				const cascaded = await taskManager.cancelDependentTasks(taskId);
 				for (const cancelled of cascaded) {
 					await this.safeOnTaskUpdated(spaceId, cancelled);
+					// Cancel the underlying workflow run (if any) so completion
+					// detection on the next tick doesn't finalize the run as
+					// `done` just because the cancelled task signals
+					// completion via `CompletionDetector.isComplete`. Only
+					// in_progress dependents had a live run to begin with;
+					// open dependents have no run attached.
+					if (cancelled.workflowRunId) {
+						const run = this.config.workflowRunRepo.getRun(cancelled.workflowRunId);
+						if (run && canTransitionRunStatus(run.status, 'cancelled')) {
+							await this.transitionRunStatusAndEmit(cancelled.workflowRunId, 'cancelled');
+						}
+					}
 				}
 			}
 		}

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -2641,7 +2641,18 @@ export class SpaceRuntime {
 				// terminal state). This allows post-completion cross-node messaging,
 				// e.g. a reviewer sending follow-up feedback to a coder whose node
 				// already finished while the PR is still being merged.
-				const taskTerminal = finalTaskStatus === 'done' || finalTaskStatus === 'cancelled';
+				//
+				// `blocked` is included alongside `done`/`cancelled` because the run
+				// itself has just been transitioned to `done` (above), so leaving
+				// siblings in `in_progress` would create inconsistent run/execution
+				// lifecycle state. `approved` is included for the same reason — the
+				// task has crossed the post-approval boundary; only `review` keeps
+				// siblings live because the human may still reject the completion.
+				const taskTerminal =
+					finalTaskStatus === 'done' ||
+					finalTaskStatus === 'cancelled' ||
+					finalTaskStatus === 'blocked' ||
+					finalTaskStatus === 'approved';
 				if (taskTerminal) {
 					const siblingsToQuiesce = this.config.nodeExecutionRepo
 						.listByWorkflowRun(runId)

--- a/packages/daemon/src/lib/space/runtime/space-runtime.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime.ts
@@ -744,7 +744,9 @@ export class SpaceRuntime {
 		if (updated) {
 			await this.safeOnTaskUpdated(spaceId, updated, opts);
 
-			// Cascade dependency_failed to open tasks that depend on this one
+			// Cascade dependency_failed to in_progress tasks that depend on this one.
+			// Open (not-yet-started) dependents are intentionally left untouched so
+			// they can still run if their dependency is later retried/completed.
 			if (params.status === 'blocked' || params.status === 'cancelled') {
 				const taskManager = this.getOrCreateTaskManager(spaceId);
 				const cascaded = await taskManager.blockDependentTasks(taskId);

--- a/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
@@ -976,6 +976,29 @@ describe('SpaceTaskManager', () => {
 			expect((await manager.getTask(done.id))!.status).toBe('done');
 		});
 
+		it('traverses through already-cancelled intermediates to reach open descendants', async () => {
+			// Regression: A → B → C, with B already cancelled and C still open.
+			// Calling cancelDependentTasks(A) must walk through B to cancel C,
+			// otherwise C is left stranded with an unmet dependency on B.
+			const a = await manager.createTask({ title: 'A', description: '' });
+			const b = await manager.createTask({ title: 'B', description: '', dependsOn: [a.id] });
+			const c = await manager.createTask({ title: 'C', description: '', dependsOn: [b.id] });
+
+			// B was cancelled before A.
+			await manager.startTask(b.id);
+			await manager.setTaskStatus(b.id, 'cancelled');
+
+			// A is now cancelled; the cascade must reach C through the cancelled B.
+			await manager.startTask(a.id);
+			await manager.setTaskStatus(a.id, 'cancelled');
+
+			const cascaded = await manager.cancelDependentTasks(a.id);
+			// Only C transitions (B was already cancelled and is just a waypoint).
+			expect(cascaded.map((t) => t.id)).toContain(c.id);
+			expect((await manager.getTask(c.id))!.status).toBe('cancelled');
+			expect((await manager.getTask(b.id))!.status).toBe('cancelled');
+		});
+
 		it('returns empty array when no dependents exist', async () => {
 			const a = await manager.createTask({ title: 'A', description: '' });
 			const cascaded = await manager.cancelDependentTasks(a.id);

--- a/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
@@ -812,11 +812,12 @@ describe('SpaceTaskManager', () => {
 	});
 
 	describe('blockDependentTasks (failure cascade)', () => {
-		it('blocks open tasks that depend on the failed task', async () => {
+		it('blocks in_progress tasks that depend on the failed task', async () => {
 			const a = await manager.createTask({ title: 'A', description: '' });
 			const b = await manager.createTask({ title: 'B', description: '', dependsOn: [a.id] });
 
 			await manager.startTask(a.id);
+			await manager.startTask(b.id); // B is in_progress when A fails
 			await manager.failTask(a.id, 'crashed', 'agent_crashed');
 
 			const cascaded = await manager.blockDependentTasks(a.id);
@@ -826,12 +827,34 @@ describe('SpaceTaskManager', () => {
 			expect(cascaded[0].blockReason).toBe('dependency_failed');
 		});
 
-		it('cascades recursively through dependency chain', async () => {
+		it('does NOT block open tasks waiting on the failed dependency', async () => {
+			// Regression: a daemon restart cascades blocked status from a stalled
+			// in_progress task to all dependents. Open tasks waiting on the dep
+			// must remain `open` so the runtime can pick them up once the
+			// dependency eventually completes (manual retry, etc.).
+			const a = await manager.createTask({ title: 'A', description: '' });
+			const b = await manager.createTask({ title: 'B', description: '', dependsOn: [a.id] });
+
+			await manager.startTask(a.id);
+			await manager.failTask(a.id, 'crashed', 'agent_crashed');
+
+			// B is still `open` (never started)
+			const cascaded = await manager.blockDependentTasks(a.id);
+			expect(cascaded).toHaveLength(0);
+			const bAfter = (await manager.getTask(b.id))!;
+			expect(bAfter.status).toBe('open');
+			expect(bAfter.blockReason ?? null).toBeNull();
+		});
+
+		it('cascades recursively through in_progress dependency chain', async () => {
 			const a = await manager.createTask({ title: 'A', description: '' });
 			const b = await manager.createTask({ title: 'B', description: '', dependsOn: [a.id] });
 			const c = await manager.createTask({ title: 'C', description: '', dependsOn: [b.id] });
 
+			// All three are in_progress when A fails.
 			await manager.startTask(a.id);
+			await manager.startTask(b.id);
+			await manager.startTask(c.id);
 			await manager.failTask(a.id, 'crashed');
 
 			const cascaded = await manager.blockDependentTasks(a.id);
@@ -845,13 +868,12 @@ describe('SpaceTaskManager', () => {
 			expect(cBlocked.blockReason).toBe('dependency_failed');
 		});
 
-		it('does not cascade to in_progress or done tasks', async () => {
+		it('does not cascade to open or done tasks', async () => {
 			const a = await manager.createTask({ title: 'A', description: '' });
 			const b = await manager.createTask({ title: 'B', description: '', dependsOn: [a.id] });
 			const c = await manager.createTask({ title: 'C', description: '', dependsOn: [a.id] });
 
-			// Start B (in_progress) and complete C (done) before A fails
-			await manager.startTask(b.id);
+			// Complete C (done); leave B in `open` before A fails.
 			await manager.startTask(c.id);
 			await manager.completeTask(c.id, 'done');
 
@@ -859,9 +881,9 @@ describe('SpaceTaskManager', () => {
 			await manager.failTask(a.id, 'crashed');
 
 			const cascaded = await manager.blockDependentTasks(a.id);
-			// Neither B (in_progress) nor C (done) should be affected
+			// Neither B (open) nor C (done) should be affected.
 			expect(cascaded).toHaveLength(0);
-			expect((await manager.getTask(b.id))!.status).toBe('in_progress');
+			expect((await manager.getTask(b.id))!.status).toBe('open');
 			expect((await manager.getTask(c.id))!.status).toBe('done');
 		});
 
@@ -875,7 +897,10 @@ describe('SpaceTaskManager', () => {
 				dependsOn: [a.id, b.id],
 			});
 
+			// Both B and D are in_progress when A fails.
 			await manager.startTask(a.id);
+			await manager.startTask(b.id);
+			await manager.startTask(d.id);
 			await manager.failTask(a.id, 'crashed');
 
 			// Should not throw; both B and D should end up blocked

--- a/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
@@ -999,6 +999,65 @@ describe('SpaceTaskManager', () => {
 			expect((await manager.getTask(b.id))!.status).toBe('cancelled');
 		});
 
+		it('does not cascade through done/review/approved/blocked intermediates', async () => {
+			// Regression for over-propagation: if A is retried→cancelled, B (deps:[A])
+			// is already `done`, and C (deps:[B]) is still `open`, cancelling A must
+			// NOT cancel C — B is a satisfied dependency for C.
+			const a = await manager.createTask({ title: 'A', description: '' });
+			const bDone = await manager.createTask({
+				title: 'B-done',
+				description: '',
+				dependsOn: [a.id],
+			});
+			const cOpen = await manager.createTask({
+				title: 'C-open',
+				description: '',
+				dependsOn: [bDone.id],
+			});
+
+			// B finished successfully.
+			await manager.startTask(bDone.id);
+			await manager.completeTask(bDone.id, 'ok');
+
+			// A is now cancelled (e.g., retried then aborted).
+			await manager.startTask(a.id);
+			await manager.setTaskStatus(a.id, 'cancelled');
+
+			const cascaded = await manager.cancelDependentTasks(a.id);
+			// Neither B (done) nor C (downstream of done) should be cancelled.
+			expect(cascaded).toHaveLength(0);
+			expect((await manager.getTask(bDone.id))!.status).toBe('done');
+			expect((await manager.getTask(cOpen.id))!.status).toBe('open');
+		});
+
+		it('does not cascade through a blocked intermediate', async () => {
+			// Same shape as above but B is `blocked` (transient/retryable). Its
+			// downstream C must still not be cancelled — once B is unblocked C
+			// becomes runnable again.
+			const a = await manager.createTask({ title: 'A', description: '' });
+			const bBlocked = await manager.createTask({
+				title: 'B-blocked',
+				description: '',
+				dependsOn: [a.id],
+			});
+			const cOpen = await manager.createTask({
+				title: 'C-open',
+				description: '',
+				dependsOn: [bBlocked.id],
+			});
+
+			await manager.startTask(bBlocked.id);
+			await manager.failTask(bBlocked.id, 'transient');
+
+			await manager.startTask(a.id);
+			await manager.setTaskStatus(a.id, 'cancelled');
+
+			const cascaded = await manager.cancelDependentTasks(a.id);
+			expect(cascaded).toHaveLength(0);
+			expect((await manager.getTask(bBlocked.id))!.status).toBe('blocked');
+			expect((await manager.getTask(cOpen.id))!.status).toBe('open');
+		});
+
 		it('returns empty array when no dependents exist', async () => {
 			const a = await manager.createTask({ title: 'A', description: '' });
 			const cascaded = await manager.cancelDependentTasks(a.id);

--- a/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/lib/space-task-manager.test.ts
@@ -917,6 +917,72 @@ describe('SpaceTaskManager', () => {
 		});
 	});
 
+	describe('cancelDependentTasks (cancellation cascade)', () => {
+		it('cancels both open and in_progress dependents when parent is cancelled', async () => {
+			const a = await manager.createTask({ title: 'A', description: '' });
+			const bOpen = await manager.createTask({
+				title: 'B',
+				description: '',
+				dependsOn: [a.id],
+			});
+			const cInProgress = await manager.createTask({
+				title: 'C',
+				description: '',
+				dependsOn: [a.id],
+			});
+			await manager.startTask(cInProgress.id);
+
+			// Cancel the parent.
+			await manager.startTask(a.id);
+			await manager.setTaskStatus(a.id, 'cancelled');
+
+			const cascaded = await manager.cancelDependentTasks(a.id);
+			const ids = cascaded.map((t) => t.id).sort();
+			expect(ids).toEqual([bOpen.id, cInProgress.id].sort());
+
+			expect((await manager.getTask(bOpen.id))!.status).toBe('cancelled');
+			expect((await manager.getTask(cInProgress.id))!.status).toBe('cancelled');
+		});
+
+		it('cascades recursively through dependency chain', async () => {
+			const a = await manager.createTask({ title: 'A', description: '' });
+			const b = await manager.createTask({ title: 'B', description: '', dependsOn: [a.id] });
+			const c = await manager.createTask({ title: 'C', description: '', dependsOn: [b.id] });
+
+			await manager.startTask(a.id);
+			await manager.setTaskStatus(a.id, 'cancelled');
+
+			const cascaded = await manager.cancelDependentTasks(a.id);
+			expect(cascaded).toHaveLength(2);
+			expect((await manager.getTask(b.id))!.status).toBe('cancelled');
+			expect((await manager.getTask(c.id))!.status).toBe('cancelled');
+		});
+
+		it('does not cascade to done tasks', async () => {
+			const a = await manager.createTask({ title: 'A', description: '' });
+			const done = await manager.createTask({
+				title: 'Done',
+				description: '',
+				dependsOn: [a.id],
+			});
+			await manager.startTask(done.id);
+			await manager.completeTask(done.id, 'finished');
+
+			await manager.startTask(a.id);
+			await manager.setTaskStatus(a.id, 'cancelled');
+
+			const cascaded = await manager.cancelDependentTasks(a.id);
+			expect(cascaded).toHaveLength(0);
+			expect((await manager.getTask(done.id))!.status).toBe('done');
+		});
+
+		it('returns empty array when no dependents exist', async () => {
+			const a = await manager.createTask({ title: 'A', description: '' });
+			const cascaded = await manager.cancelDependentTasks(a.id);
+			expect(cascaded).toHaveLength(0);
+		});
+	});
+
 	describe('taskNumber (numeric task IDs)', () => {
 		it('createTask assigns auto-incrementing taskNumber', async () => {
 			const t1 = await manager.createTask({ title: 'A', description: '' });

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
@@ -695,6 +695,54 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			const completedEvents = sink.events.filter((e) => e.kind === 'workflow_run_completed');
 			expect(completedEvents).toHaveLength(1);
 		});
+
+		test('cascade-cancelling an in_progress dependent also cancels its workflow run', async () => {
+			// Regression: when the runtime cancels task A (e.g. via the run-cancel
+			// reconcile path), the cascade transitions in_progress dependent task B
+			// to `cancelled`. Without the run-cancel hook, B's workflow run stays
+			// `in_progress` and CompletionDetector finalizes it as `done` on the
+			// next tick (because a `cancelled` task signals completion). The hook
+			// must transition B's run to `cancelled` so the lifecycle/audit state
+			// is consistent.
+			const rt = makeRuntimeWithTam();
+			const workflowA = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'node-cascade-a', name: 'A', agentId: AGENT_A },
+			]);
+			const workflowB = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'node-cascade-b', name: 'B', agentId: AGENT_A },
+			]);
+
+			const { run: runA, tasks: tasksA } = await rt.startWorkflowRun(
+				SPACE_ID,
+				workflowA.id,
+				'Run A'
+			);
+			const { run: runB, tasks: tasksB } = await rt.startWorkflowRun(
+				SPACE_ID,
+				workflowB.id,
+				'Run B'
+			);
+
+			// Wire B → depends on A.
+			taskRepo.updateTask(tasksB[0].id, { dependsOn: [tasksA[0].id] });
+
+			// Cancel run A externally; the runtime tick will mirror the run
+			// cancellation onto task A (via reconcileTerminalRunTasks /
+			// processRunTick), which calls updateTaskAndEmit and triggers our
+			// cascade.
+			workflowRunRepo.transitionStatus(runA.id, 'cancelled');
+
+			await rt.executeTick();
+
+			// Task A is cancelled.
+			expect(taskRepo.getTask(tasksA[0].id)?.status).toBe('cancelled');
+
+			// Cascade: task B is cancelled too.
+			expect(taskRepo.getTask(tasksB[0].id)?.status).toBe('cancelled');
+
+			// Run B is cancelled (NOT silently finalized to `done`).
+			expect(workflowRunRepo.getRun(runB.id)?.status).toBe('cancelled');
+		});
 	});
 
 	// -------------------------------------------------------------------------

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
@@ -615,6 +615,57 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			expect(runAfter?.completedAt).toBeNull();
 		});
 
+		test('canonical task in `blocked` is not pushed through dispatchPostApproval on run completion', async () => {
+			// Regression for the cascade-block path: if a task was cascade-blocked
+			// (`dependency_failed`) while its workflow run continued and then
+			// completed, the runtime previously tried to transition
+			// `blocked → approved` via dispatchPostApproval, which is invalid.
+			// The completion guard must treat `blocked` as already-resolved.
+			const rt = makeRuntimeWithTam();
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'node-blk-1', name: 'Plan', agentId: AGENT_B },
+				{ id: 'node-blk-2', name: 'Code', agentId: AGENT_A },
+			]);
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			expect(tasks).toHaveLength(1);
+
+			// First-node task completes normally — this is what signals
+			// CompletionDetector that the run is complete.
+			taskRepo.updateTask(tasks[0].id, { status: 'done' });
+
+			// Second-node task is `blocked` (e.g. cascade-blocked by a dependency
+			// failure on a sibling task) when the run reaches completion.
+			const taskManager = rt.getTaskManagerForSpace(SPACE_ID);
+			const blockedTask = await taskManager.createTask({
+				title: 'Code',
+				description: '',
+				workflowRunId: run.id,
+				workflowNodeId: 'node-blk-2',
+				taskType: 'coding',
+				agentName: 'coder',
+				status: 'blocked',
+				blockReason: 'dependency_failed',
+			});
+
+			seedNodeExec(db, run.id, 'node-blk-1', 'agent', 'idle');
+			seedNodeExec(db, run.id, 'node-blk-2', 'coder', 'idle');
+
+			// Should not throw with "Invalid status transition from 'blocked' to 'approved'".
+			await rt.executeTick();
+
+			// Run reaches `done` via CompletionDetector.
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('done');
+
+			// Blocked task is left in `blocked` (or archived alongside the run) —
+			// it must NEVER be transitioned to `approved`/`done`, which would be
+			// an invalid `blocked → approved` transition.
+			const blockedAfter = taskRepo.getTask(blockedTask.id);
+			expect(['blocked', 'archived']).toContain(blockedAfter?.status);
+			expect(blockedAfter?.status).not.toBe('approved');
+			expect(blockedAfter?.status).not.toBe('done');
+		});
+
 		test('blocked → in_progress → done lifecycle via resume', async () => {
 			const rt = makeRuntimeWithTam();
 			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [

--- a/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
+++ b/packages/daemon/tests/unit/5-space/runtime/space-runtime-completion.test.ts
@@ -1254,6 +1254,68 @@ describe('SpaceRuntime — completion detection & status transitions', () => {
 			expect(completedEvents).toHaveLength(1);
 		});
 
+		test('canonical task blocked still quiesces siblings on run completion', async () => {
+			// Regression: when the canonical task is `blocked` (treated as
+			// already-resolved by the completion guard) but the run reaches
+			// `done` via CompletionDetector (a sibling task is `done`/`cancelled`
+			// or `reportedStatus` is set), in-flight sibling NodeExecutions
+			// must still be quiesced. Otherwise the run is `done` while
+			// siblings linger in `in_progress`, creating inconsistent
+			// run/execution lifecycle state.
+			const mockTam = new MockTaskAgentManager(nodeExecutionRepo);
+			mockTam.isSessionAlive = () => true;
+			const rt = makeRuntimeWithTam({
+				taskAgentManager: mockTam as unknown as TaskAgentManager,
+			});
+
+			const workflow = buildLinearWorkflow(SPACE_ID, workflowManager, [
+				{ id: 'blk-sibling', name: 'Sibling', agentId: AGENT_A },
+				{ id: 'blk-end', name: 'End', agentId: AGENT_B },
+			]);
+
+			const { run, tasks } = await rt.startWorkflowRun(SPACE_ID, workflow.id, 'Run');
+			expect(tasks).toHaveLength(1);
+
+			// Canonical task is `blocked` (e.g. cascade-blocked by a dependency
+			// failure) AND has `reportedStatus` set, so CompletionDetector
+			// considers the run complete. The completion guard treats `blocked`
+			// as already-resolved, but sibling quiescing must still fire.
+			taskRepo.updateTask(tasks[0].id, {
+				status: 'blocked',
+				reportedStatus: 'blocked',
+				reportedSummary: 'cascade-blocked',
+			});
+
+			// Sibling exec is in flight with a live session.
+			const siblingExecId = seedNodeExec(db, run.id, 'blk-sibling', 'Sibling', 'in_progress');
+			const siblingSessionId = 'blk-sibling-session-001';
+			db.prepare('UPDATE node_executions SET agent_session_id = ? WHERE id = ?').run(
+				siblingSessionId,
+				siblingExecId
+			);
+			seedNodeExec(db, run.id, 'blk-end', 'End', 'idle');
+
+			await rt.executeTick();
+
+			// Run reaches `done`.
+			expect(workflowRunRepo.getRun(run.id)?.status).toBe('done');
+
+			// Canonical stays in `blocked` (or archived alongside the run) —
+			// must NEVER be transitioned to `approved`/`done`.
+			const canonical = taskRepo.getTask(tasks[0].id);
+			expect(canonical?.status).not.toBe('approved');
+			expect(canonical?.status).not.toBe('done');
+
+			// In-flight sibling must be quiesced to `idle` — not stranded
+			// in `in_progress` while the run is `done`.
+			const execs = nodeExecutionRepo.listByWorkflowRun(run.id);
+			const siblingExec = execs.find((e) => e.workflowNodeId === 'blk-sibling');
+			expect(siblingExec?.status).toBe('idle');
+			expect(siblingExec?.agentSessionId).toBe(siblingSessionId);
+			expect(mockTam.interruptedSessions).toContain(siblingSessionId);
+			expect(mockTam.cancelledSessions).not.toContain(siblingSessionId);
+		});
+
 		test('sibling session remains reachable for send_message after workflow completion (#1515)', async () => {
 			// Regression for issue #1515: when a downstream node (e.g. a reviewer)
 			// tries to resolve peers for send_message AFTER an upstream sibling


### PR DESCRIPTION
## Bug

After daemon restart, standalone open tasks with unmet dependencies were incorrectly cascaded to `blocked` when a stalled `in_progress` run was recovered. They should remain `open` so the runtime can pick them up once the dependency completes.

## Fix

`doBlockCascade` now lists `in_progress` tasks instead of `open` tasks. Open tasks haven't started yet, so they're naturally skipped by `areDependenciesMet()` on the next tick — no need to block them. In-progress dependents already have a workflow run attached, so they genuinely can't proceed and still need the cascade.

## Tests

- Updated existing cascade tests to start dependents before failing the parent (the cases that were previously asserting buggy behavior).
- Added a regression test that fails a parent while its dependent is still `open`, asserting the dependent stays `open` with no `blockReason`.