### PR TITLE
fix: sync textarea height before auto-scroll

### DIFF
--- a/packages/web/src/components/InputTextarea.tsx
+++ b/packages/web/src/components/InputTextarea.tsx
@@ -154,27 +154,21 @@ export function InputTextarea({
 		}
 	}, [content]);
 
-	// Auto-resize textarea
-	// Uses requestAnimationFrame to avoid forced synchronous reflow:
-	// the height reset and scrollHeight read happen in separate frames,
-	// allowing the browser to batch layout calculations naturally.
-	useEffect(() => {
+	// Auto-resize textarea.
+	// Uses useLayoutEffect so the height is recalculated synchronously
+	// before paint. This ensures the composer padding (driven by
+	// syncMessagesContainerPadding in MessageInput) always measures the
+	// correct footer height before auto-scroll fires on a new message.
+	useLayoutEffect(() => {
 		const textarea = textareaRef.current;
 		if (!textarea) return;
 
-		// Frame 1: Reset height so scrollHeight reflects actual content
 		textarea.style.height = 'auto';
 		textarea.style.minHeight = '40px';
-
-		// Frame 2: Read natural height and apply clamped value
-		const rafId = requestAnimationFrame(() => {
-			const newHeight = Math.min(Math.max(40, textarea.scrollHeight), 200);
-			textarea.style.height = `${newHeight}px`;
-			setIsMultiline(newHeight > 45);
-			onHeightChange?.(newHeight);
-		});
-
-		return () => cancelAnimationFrame(rafId);
+		const newHeight = Math.min(Math.max(40, textarea.scrollHeight), 200);
+		textarea.style.height = `${newHeight}px`;
+		setIsMultiline(newHeight > 45);
+		onHeightChange?.(newHeight);
 	}, [content, onHeightChange]);
 
 	// Ref to track the delayed scroll-into-view timer so we can cancel it on

--- a/packages/web/src/components/__tests__/InputTextarea.test.tsx
+++ b/packages/web/src/components/__tests__/InputTextarea.test.tsx
@@ -914,4 +914,69 @@ describe('InputTextarea', () => {
 			}).not.toThrow();
 		});
 	});
+
+	describe('Auto-resize timing (autoscroll race regression)', () => {
+		/**
+		 * Regression test for: messages appearing behind the chat composer
+		 * when sending multiline messages with autoscroll enabled.
+		 *
+		 * Root cause: the textarea height was previously updated inside a
+		 * requestAnimationFrame callback (one frame later). When a new message
+		 * caused the parent to recompute scroll/footer padding, the footer height
+		 * still reflected the OLD textarea size, so the scroller stopped short
+		 * and the new message was hidden behind the composer.
+		 *
+		 * Fix: switched to useLayoutEffect with a synchronous height update so
+		 * onHeightChange fires before the browser paints — the parent's
+		 * syncMessagesContainerPadding always sees the up-to-date footer height.
+		 *
+		 * What this test guarantees:
+		 * - onHeightChange is invoked synchronously during render commit
+		 *   (no rAF, no setTimeout). If anyone reverts to a deferred resize,
+		 *   this test fails.
+		 */
+		it('invokes onHeightChange synchronously when content changes', () => {
+			const onHeightChange = vi.fn();
+			const { rerender } = render(
+				<InputTextarea
+					content="line one"
+					onContentChange={() => {}}
+					onKeyDown={() => {}}
+					onSubmit={() => {}}
+					onHeightChange={onHeightChange}
+				/>
+			);
+
+			// Cleared after initial mount so we can observe the next pass cleanly
+			onHeightChange.mockClear();
+
+			rerender(
+				<InputTextarea
+					content={'line one\nline two\nline three'}
+					onContentChange={() => {}}
+					onKeyDown={() => {}}
+					onSubmit={() => {}}
+					onHeightChange={onHeightChange}
+				/>
+			);
+
+			// Must be called synchronously — no awaiting frames or timers.
+			expect(onHeightChange).toHaveBeenCalled();
+		});
+
+		it('invokes onHeightChange on initial mount (sync, before paint)', () => {
+			const onHeightChange = vi.fn();
+			render(
+				<InputTextarea
+					content="hello"
+					onContentChange={() => {}}
+					onKeyDown={() => {}}
+					onSubmit={() => {}}
+					onHeightChange={onHeightChange}
+				/>
+			);
+
+			expect(onHeightChange).toHaveBeenCalled();
+		});
+	});
 });


### PR DESCRIPTION
## Summary
- Switch the textarea auto-resize from `useEffect` + `requestAnimationFrame` to `useLayoutEffect` so the height update happens synchronously before paint.
- This eliminates the timing race where the parent's `syncMessagesContainerPadding` would measure a stale footer height after sending a new multiline message, leaving the message hidden behind the floating composer.
- Adds two regression tests asserting `onHeightChange` fires synchronously on mount and on content change.

## Test plan
- [x] `bunx vitest run src/components/__tests__/InputTextarea.test.tsx` — 40 passed
- [x] `bun run check` — lint, typecheck, knip, session-guard
- [x] Manual browser check: typed a 5-line message in a Space Agent chat with autoscroll enabled. Composer expanded to 140px, `--messages-bottom-padding` updated to 222px synchronously. After Enter, the user bubble (all 5 lines plus timestamp + actions) rendered fully visible above the composer — not clipped behind it.