### PR TITLE
fix: keep chat composer visible above mobile Safari keyboard

### DIFF
--- a/packages/web/src/components/InputTextarea.tsx
+++ b/packages/web/src/components/InputTextarea.tsx
@@ -26,7 +26,7 @@
 
 import type { ComponentChildren } from 'preact';
 import type { MutableRef } from 'preact/hooks';
-import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
 import { cn } from '../lib/utils.ts';
 import { borderColors } from '../lib/design-tokens.ts';
 import CommandAutocomplete from './CommandAutocomplete.tsx';
@@ -182,6 +182,22 @@ export function InputTextarea({
 		textareaRef.current?.focus();
 	}, []);
 
+	// Mobile Safari: when the textarea is focused and the virtual keyboard opens,
+	// the page may scroll the focused element behind the address bar or the
+	// composer may jump off-screen. We wait for the keyboard animation (~300 ms)
+	// then scroll the textarea into view so the user can see what they are typing.
+	const handleFocus = useCallback(() => {
+		if (!isMobileDevice.current) return;
+		const textarea = textareaRef.current;
+		if (!textarea) return;
+		// Delay to let the keyboard finish its animation; on iOS this is roughly
+		// 250-300 ms. Using 350 ms gives a safe margin.
+		const timer = setTimeout(() => {
+			textarea.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+		}, 350);
+		return () => clearTimeout(timer);
+	}, []);
+
 	const charCount = content.length;
 	const showCharCount = charCount > maxChars * 0.8;
 	const hasContent = content.trim().length > 0;
@@ -252,6 +268,7 @@ export function InputTextarea({
 					ref={textareaRef}
 					onInput={(e) => onContentChange((e.target as HTMLTextAreaElement).value)}
 					onKeyDown={onKeyDown}
+					onFocus={handleFocus}
 					onPaste={onPaste}
 					disabled={disabled}
 					placeholder={placeholder}

--- a/packages/web/src/components/InputTextarea.tsx
+++ b/packages/web/src/components/InputTextarea.tsx
@@ -177,6 +177,20 @@ export function InputTextarea({
 		return () => cancelAnimationFrame(rafId);
 	}, [content, onHeightChange]);
 
+	// Ref to track the delayed scroll-into-view timer so we can cancel it on
+	// blur or unmount. Preact DOM event handlers ignore return values, so a
+	// ref + explicit cleanup is required.
+	const focusScrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => {
+		return () => {
+			if (focusScrollTimerRef.current) {
+				clearTimeout(focusScrollTimerRef.current);
+				focusScrollTimerRef.current = null;
+			}
+		};
+	}, []);
+
 	// Focus on mount
 	useEffect(() => {
 		textareaRef.current?.focus();
@@ -190,12 +204,23 @@ export function InputTextarea({
 		if (!isMobileDevice.current) return;
 		const textarea = textareaRef.current;
 		if (!textarea) return;
+		// Cancel any pending scroll from a previous focus
+		if (focusScrollTimerRef.current) {
+			clearTimeout(focusScrollTimerRef.current);
+		}
 		// Delay to let the keyboard finish its animation; on iOS this is roughly
 		// 250-300 ms. Using 350 ms gives a safe margin.
-		const timer = setTimeout(() => {
+		focusScrollTimerRef.current = setTimeout(() => {
+			focusScrollTimerRef.current = null;
 			textarea.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
 		}, 350);
-		return () => clearTimeout(timer);
+	}, []);
+
+	const handleBlur = useCallback(() => {
+		if (focusScrollTimerRef.current) {
+			clearTimeout(focusScrollTimerRef.current);
+			focusScrollTimerRef.current = null;
+		}
 	}, []);
 
 	const charCount = content.length;
@@ -269,6 +294,7 @@ export function InputTextarea({
 					onInput={(e) => onContentChange((e.target as HTMLTextAreaElement).value)}
 					onKeyDown={onKeyDown}
 					onFocus={handleFocus}
+					onBlur={handleBlur}
 					onPaste={onPaste}
 					disabled={disabled}
 					placeholder={placeholder}

--- a/packages/web/src/hooks/__tests__/useViewportSafety.test.ts
+++ b/packages/web/src/hooks/__tests__/useViewportSafety.test.ts
@@ -116,6 +116,7 @@ afterEach(() => {
 	restoreNavigator();
 	restoreVisualViewport();
 	document.documentElement.style.removeProperty('--safe-height');
+	document.documentElement.style.removeProperty('--keyboard-height');
 	document.documentElement.style.removeProperty('--bottom-bar-height');
 	document.documentElement.classList.remove('keyboard-open');
 });
@@ -305,6 +306,7 @@ describe('useViewportSafety — keyboard detection', () => {
 		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe(
 			`${WINDOW_INNER_HEIGHT - 300}px`
 		);
+		expect(document.documentElement.style.getPropertyValue('--keyboard-height')).toBe('300px');
 		expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('0px');
 	});
 
@@ -333,6 +335,8 @@ describe('useViewportSafety — keyboard detection', () => {
 		expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('56px');
 		// --safe-height should be removed on non-iPad
 		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('');
+		// --keyboard-height should be removed when keyboard closes
+		expect(document.documentElement.style.getPropertyValue('--keyboard-height')).toBe('');
 	});
 
 	it('does NOT trigger keyboard detection for small viewport changes (below 50px threshold)', () => {
@@ -397,6 +401,7 @@ describe('useViewportSafety — keyboard detection', () => {
 		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe(
 			`${WINDOW_INNER_HEIGHT - 300}px`
 		);
+		expect(document.documentElement.style.getPropertyValue('--keyboard-height')).toBe('300px');
 		expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('0px');
 
 		// Close keyboard
@@ -408,6 +413,8 @@ describe('useViewportSafety — keyboard detection', () => {
 		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe(
 			`${WINDOW_INNER_HEIGHT}px`
 		);
+		// --keyboard-height is removed when keyboard closes
+		expect(document.documentElement.style.getPropertyValue('--keyboard-height')).toBe('');
 	});
 
 	it('detects initial keyboard state on mount', () => {
@@ -422,6 +429,7 @@ describe('useViewportSafety — keyboard detection', () => {
 		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe(
 			`${WINDOW_INNER_HEIGHT - 300}px`
 		);
+		expect(document.documentElement.style.getPropertyValue('--keyboard-height')).toBe('300px');
 		expect(document.documentElement.style.getPropertyValue('--bottom-bar-height')).toBe('0px');
 	});
 
@@ -461,6 +469,8 @@ describe('useViewportSafety — keyboard detection', () => {
 		expect(document.documentElement.classList.contains('keyboard-open')).toBe(false);
 		// --safe-height should be removed on unmount
 		expect(document.documentElement.style.getPropertyValue('--safe-height')).toBe('');
+		// --keyboard-height should be removed on unmount
+		expect(document.documentElement.style.getPropertyValue('--keyboard-height')).toBe('');
 	});
 
 	it('restores --bottom-bar-height even when it was empty string (desktop)', () => {

--- a/packages/web/src/hooks/__tests__/useViewportSafety.test.ts
+++ b/packages/web/src/hooks/__tests__/useViewportSafety.test.ts
@@ -16,16 +16,18 @@ import { useViewportSafety } from '../useViewportSafety.ts';
 /** Partial VisualViewport mock with trackable event listeners. */
 interface MockVisualViewport {
 	height: number;
+	offsetTop: number;
 	addEventListener: ReturnType<typeof vi.fn>;
 	removeEventListener: ReturnType<typeof vi.fn>;
 	/** Fire all registered listeners for an event (test helper). */
 	_trigger(event: string): void;
 }
 
-function createMockVisualViewport(height: number): MockVisualViewport {
+function createMockVisualViewport(height: number, offsetTop = 0): MockVisualViewport {
 	const listeners: Record<string, Array<EventListenerOrEventListenerObject>> = {};
 	return {
 		height,
+		offsetTop,
 		addEventListener: vi.fn((event: string, cb: EventListenerOrEventListenerObject) => {
 			listeners[event] = listeners[event] ?? [];
 			listeners[event].push(cb);

--- a/packages/web/src/hooks/useViewportSafety.ts
+++ b/packages/web/src/hooks/useViewportSafety.ts
@@ -73,6 +73,16 @@ function updateSafeHeight(vv: VisualViewport): void {
 }
 
 /**
+ * Update the `--keyboard-height` CSS custom property on `document.documentElement`.
+ * This is the difference between the layout viewport and the visual viewport,
+ * representing the area covered by the virtual keyboard.
+ */
+function updateKeyboardHeight(vv: VisualViewport): void {
+	const height = Math.max(0, window.innerHeight - vv.height);
+	document.documentElement.style.setProperty('--keyboard-height', `${height}px`);
+}
+
+/**
  * Check whether the virtual keyboard is currently visible by comparing
  * `visualViewport.height` with `window.innerHeight`. Returns true when the
  * difference exceeds {@link KEYBOARD_THRESHOLD} to avoid false positives from
@@ -131,14 +141,20 @@ export function useViewportSafety(): void {
 				// Shrink the app container to the visible viewport height
 				document.documentElement.style.setProperty('--safe-height', `${vv.height}px`);
 
+				// Record keyboard height so fixed/absolute positioned elements
+				// (e.g. chat composer) can offset themselves above the keyboard
+				updateKeyboardHeight(vv);
+
 				// Remove bottom bar padding — the BottomTabBar is fixed at bottom:0
 				// and hidden behind the keyboard, so reserving space for it creates a gap
 				savedBottomBarHeight =
 					document.documentElement.style.getPropertyValue('--bottom-bar-height');
 				document.documentElement.style.setProperty('--bottom-bar-height', '0px');
 			} else if (kbVisible && keyboardOpen) {
-				// Keep --safe-height in sync as keyboard height may change
+				// Keep --safe-height and --keyboard-height in sync as keyboard
+				// height may change (e.g. switching between emoji and text keyboards)
 				document.documentElement.style.setProperty('--safe-height', `${vv.height}px`);
+				updateKeyboardHeight(vv);
 			} else if (!kbVisible && keyboardOpen) {
 				// Keyboard just closed
 				keyboardOpen = false;
@@ -150,6 +166,9 @@ export function useViewportSafety(): void {
 					document.documentElement.style.removeProperty('--safe-height');
 				}
 				// On iPad, --safe-height is already updated above via updateSafeHeight()
+
+				// Remove keyboard height override
+				document.documentElement.style.removeProperty('--keyboard-height');
 
 				// Restore bottom bar height from saved value.
 				// NOTE: We use !== null instead of truthiness because
@@ -183,6 +202,7 @@ export function useViewportSafety(): void {
 			keyboardOpen = true;
 			document.documentElement.classList.add('keyboard-open');
 			document.documentElement.style.setProperty('--safe-height', `${vv.height}px`);
+			updateKeyboardHeight(vv);
 			savedBottomBarHeight = document.documentElement.style.getPropertyValue('--bottom-bar-height');
 			document.documentElement.style.setProperty('--bottom-bar-height', '0px');
 		}
@@ -200,6 +220,7 @@ export function useViewportSafety(): void {
 			// Cleanup: restore original state
 			document.documentElement.classList.remove('keyboard-open');
 			document.documentElement.style.removeProperty('--safe-height');
+			document.documentElement.style.removeProperty('--keyboard-height');
 			if (savedBottomBarHeight !== null) {
 				document.documentElement.style.setProperty('--bottom-bar-height', savedBottomBarHeight);
 			}

--- a/packages/web/src/hooks/useViewportSafety.ts
+++ b/packages/web/src/hooks/useViewportSafety.ts
@@ -74,11 +74,15 @@ function updateSafeHeight(vv: VisualViewport): void {
 
 /**
  * Update the `--keyboard-height` CSS custom property on `document.documentElement`.
- * This is the difference between the layout viewport and the visual viewport,
- * representing the area covered by the virtual keyboard.
+ *
+ * Computes the area covered by the virtual keyboard using the visual viewport's
+ * bottom edge relative to the layout viewport. When iOS auto-pans the page on
+ * focus, `visualViewport.offsetTop` becomes non-zero; subtracting it prevents
+ * overestimating the keyboard height and avoids an artificial gap above the
+ * composer.
  */
 function updateKeyboardHeight(vv: VisualViewport): void {
-	const height = Math.max(0, window.innerHeight - vv.height);
+	const height = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
 	document.documentElement.style.setProperty('--keyboard-height', `${height}px`);
 }
 

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -682,13 +682,16 @@ html.keyboard-open [data-testid="bottom-tab-bar"] {
    When the virtual keyboard opens, the composer (position:absolute;bottom:0)
    would normally sit behind the keyboard. We offset it by the keyboard height
    so it stays visible and tappable. The transition gives a smooth slide as the
-   keyboard animates in/out. */
-.chat-footer {
-	transition: bottom 0.25s ease;
-}
+   keyboard animates in/out. Scoped to coarse-pointer devices so desktop
+   browsers are not affected. */
+@media (pointer: coarse) {
+	.chat-footer {
+		transition: bottom 0.25s ease;
+	}
 
-html.keyboard-open .chat-footer {
-	bottom: var(--keyboard-height, 0px);
+	html.keyboard-open .chat-footer {
+		bottom: var(--keyboard-height, 0px);
+	}
 }
 
 /* ── Space task thread — compact running-block indicator ─────────────────────

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -678,6 +678,19 @@ html.keyboard-open [data-testid="bottom-tab-bar"] {
    on the main content wrapper. The chat footer does not need its own safe area
    padding — the wrapper already accounts for both the tab bar and home indicator. */
 
+/* ── Mobile Safari keyboard: keep chat composer above the keyboard ───────────
+   When the virtual keyboard opens, the composer (position:absolute;bottom:0)
+   would normally sit behind the keyboard. We offset it by the keyboard height
+   so it stays visible and tappable. The transition gives a smooth slide as the
+   keyboard animates in/out. */
+.chat-footer {
+	transition: bottom 0.25s ease;
+}
+
+html.keyboard-open .chat-footer {
+	bottom: var(--keyboard-height, 0px);
+}
+
 /* ── Space task thread — compact running-block indicator ─────────────────────
    The animated border-light for running (non-terminal) event messages is now
    rendered by the <RunningBorder> Preact component in


### PR DESCRIPTION
When typing in the chat composer on mobile Safari, the screen would jump and the typing area would go behind the virtual keyboard / address bar.

**Changes:**
- `useViewportSafety`: set `--keyboard-height` CSS variable when virtual keyboard is detected via `visualViewport` API, so absolutely-positioned elements can offset themselves.
- `styles.css`: shift `.chat-footer` up by `var(--keyboard-height)` when `html.keyboard-open` is present, with a smooth transition.
- `InputTextarea`: on focus, scroll the textarea into view after a short delay (350ms) to account for the keyboard animation, ensuring the composer stays visible while typing.
- Updated `useViewportSafety` tests to assert `--keyboard-height` behavior.