### PR TITLE
feat: add Create Session and Create Task buttons to Space pages

### DIFF
--- a/packages/web/src/components/space/SpacePageHeader.tsx
+++ b/packages/web/src/components/space/SpacePageHeader.tsx
@@ -1,12 +1,14 @@
+import type { ComponentChildren } from 'preact';
 import { borderColors } from '../../lib/design-tokens';
 import { contextPanelOpenSignal } from '../../lib/signals';
 
 interface SpacePageHeaderProps {
 	spaceName: string;
 	pageTitle: string;
+	actions?: ComponentChildren;
 }
 
-export function SpacePageHeader({ spaceName, pageTitle }: SpacePageHeaderProps) {
+export function SpacePageHeader({ spaceName, pageTitle, actions }: SpacePageHeaderProps) {
 	return (
 		<div
 			class={`flex-shrink-0 bg-dark-850 border-b ${borderColors.ui.default} px-4 h-[65px] flex items-center`}
@@ -32,6 +34,7 @@ export function SpacePageHeader({ spaceName, pageTitle }: SpacePageHeaderProps) 
 					<h2 class="text-sm font-semibold text-gray-100 truncate">{pageTitle}</h2>
 				</div>
 			</div>
+			{actions && <div class="flex items-center gap-2 flex-shrink-0">{actions}</div>}
 		</div>
 	);
 }

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -145,6 +145,12 @@ export default function SpaceIsland({
 		}
 	}, [viewMode, spaceId]);
 
+	// Reset session-creation lock when switching spaces so a stale lock
+	// from space A doesn't block valid creates in space B.
+	useEffect(() => {
+		setCreatingSession(false);
+	}, [spaceId]);
+
 	const handleTaskPaneClose = useCallback(() => {
 		navigateToSpace(spaceId);
 	}, [spaceId]);
@@ -164,14 +170,18 @@ export default function SpaceIsland({
 			if (creatingSession) return;
 			setCreatingSession(true);
 			const originSpaceId = spaceId;
+			const originViewMode = viewMode;
 			try {
 				const response = await createSession({
 					spaceId,
 					workspacePath: space?.workspacePath,
 				});
-				// Only navigate if the user is still in the same space;
-				// prevents stale async redirect if they navigated elsewhere.
-				if (currentSpaceIdSignal.value === originSpaceId) {
+				// Only navigate if the user is still in the same space and on the
+				// Sessions view; prevents stale async redirect if they navigated elsewhere.
+				if (
+					currentSpaceIdSignal.value === originSpaceId &&
+					currentSpaceViewModeSignal.value === originViewMode
+				) {
 					navigateToSpaceSession(spaceId, response.sessionId);
 				}
 			} catch (err) {
@@ -180,7 +190,7 @@ export default function SpaceIsland({
 				setCreatingSession(false);
 			}
 		},
-		[spaceId, space?.workspacePath, creatingSession]
+		[spaceId, space?.workspacePath, creatingSession, viewMode]
 	);
 
 	// Session/agent chat view — render immediately, don't block on space data

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -21,6 +21,7 @@ import {
 	spaceOverlayPendingTaskIdSignal,
 	spaceOverlayPendingAgentNameSignal,
 	currentSpaceViewModeSignal,
+	currentSpaceIdSignal,
 } from '../lib/signals';
 import { SpacePageHeader } from '../components/space/SpacePageHeader';
 import { SpaceCreateTaskDialog } from '../components/space/SpaceCreateTaskDialog';
@@ -136,6 +137,14 @@ export default function SpaceIsland({
 		});
 	}, [spaceId]);
 
+	// Reset task-dialog state when leaving the Tasks view so it doesn't
+	// reopen unexpectedly when the user later returns.
+	useEffect(() => {
+		if (viewMode !== 'tasks') {
+			setCreateTaskOpen(false);
+		}
+	}, [viewMode, spaceId]);
+
 	const handleTaskPaneClose = useCallback(() => {
 		navigateToSpace(spaceId);
 	}, [spaceId]);
@@ -154,12 +163,17 @@ export default function SpaceIsland({
 			e.stopPropagation();
 			if (creatingSession) return;
 			setCreatingSession(true);
+			const originSpaceId = spaceId;
 			try {
 				const response = await createSession({
 					spaceId,
 					workspacePath: space?.workspacePath,
 				});
-				navigateToSpaceSession(spaceId, response.sessionId);
+				// Only navigate if the user is still in the same space;
+				// prevents stale async redirect if they navigated elsewhere.
+				if (currentSpaceIdSignal.value === originSpaceId) {
+					navigateToSpaceSession(spaceId, response.sessionId);
+				}
 			} catch (err) {
 				toast.error(err instanceof Error ? err.message : 'Failed to create session');
 			} finally {
@@ -252,9 +266,12 @@ export default function SpaceIsland({
 					isOpen={createTaskOpen}
 					onClose={() => setCreateTaskOpen(false)}
 					onCreated={(task) => {
-						// Only navigate if the user is still on the Tasks view;
+						// Only navigate if the user is still on the Tasks view of this space;
 						// prevents stale async redirect if they navigated elsewhere.
-						if (currentSpaceViewModeSignal.value === 'tasks') {
+						if (
+							currentSpaceViewModeSignal.value === 'tasks' &&
+							currentSpaceIdSignal.value === spaceId
+						) {
 							navigateToSpaceTask(spaceId, task.id);
 						}
 					}}

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -132,6 +132,7 @@ export default function SpaceIsland({
 	const error = spaceStore.error.value;
 	const [createTaskOpen, setCreateTaskOpen] = useState(false);
 	const [creatingSession, setCreatingSession] = useState(false);
+	const [, setActiveSessionRequestId] = useState<number | null>(null);
 
 	// For non-session views, show spinner/error while space data loads.
 	// Show spinner if space is not yet loaded and there's no error — this covers
@@ -145,18 +146,22 @@ export default function SpaceIsland({
 		});
 	}, [spaceId]);
 
-	// Reset task-dialog state when leaving the Tasks view so it doesn't
-	// reopen unexpectedly when the user later returns.
+	// Reset task-dialog state when leaving the Tasks view or switching spaces
+	// so it doesn't reopen unexpectedly.
 	useEffect(() => {
 		if (viewMode !== 'tasks') {
 			setCreateTaskOpen(false);
 		}
-	}, [viewMode, spaceId]);
+	}, [viewMode]);
+	useEffect(() => {
+		setCreateTaskOpen(false);
+	}, [spaceId]);
 
 	// Reset session-creation lock when switching spaces so a stale lock
 	// from space A doesn't block valid creates in space B.
 	useEffect(() => {
 		setCreatingSession(false);
+		setActiveSessionRequestId(null);
 	}, [spaceId]);
 
 	const handleTaskPaneClose = useCallback(() => {
@@ -167,7 +172,9 @@ export default function SpaceIsland({
 		async (e: Event) => {
 			e.stopPropagation();
 			if (creatingSession) return;
+			const requestId = Date.now();
 			setCreatingSession(true);
+			setActiveSessionRequestId(requestId);
 			const originSpaceId = spaceId;
 			const originViewMode = viewMode;
 			try {
@@ -186,7 +193,15 @@ export default function SpaceIsland({
 			} catch (err) {
 				toast.error(err instanceof Error ? err.message : 'Failed to create session');
 			} finally {
-				setCreatingSession(false);
+				// Only clear the lock if this request is still the active one.
+				// A newer request in another space will have a different requestId.
+				setActiveSessionRequestId((current) => {
+					if (current === requestId) {
+						setCreatingSession(false);
+						return null;
+					}
+					return current;
+				});
 			}
 		},
 		[spaceId, space?.workspacePath, creatingSession, viewMode]

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -20,6 +20,7 @@ import {
 	spaceOverlayTaskContextSignal,
 	spaceOverlayPendingTaskIdSignal,
 	spaceOverlayPendingAgentNameSignal,
+	currentSpaceViewModeSignal,
 } from '../lib/signals';
 import { SpacePageHeader } from '../components/space/SpacePageHeader';
 import { SpaceCreateTaskDialog } from '../components/space/SpaceCreateTaskDialog';
@@ -33,6 +34,7 @@ import {
 	closeOverlayHistory,
 } from '../lib/router';
 import { createSession } from '../lib/api-helpers';
+import { toast } from '../lib/toast';
 import ChatContainer from './ChatContainer';
 
 const SpaceConfigurePage = lazy(() =>
@@ -139,6 +141,7 @@ export default function SpaceIsland({
 	}, [spaceId]);
 
 	const [createTaskOpen, setCreateTaskOpen] = useState(false);
+	const [creatingSession, setCreatingSession] = useState(false);
 
 	// For non-session views, show spinner/error while space data loads.
 	// Show spinner if space is not yet loaded and there's no error — this covers
@@ -149,17 +152,21 @@ export default function SpaceIsland({
 	const handleCreateSession = useCallback(
 		async (e: Event) => {
 			e.stopPropagation();
+			if (creatingSession) return;
+			setCreatingSession(true);
 			try {
 				const response = await createSession({
 					spaceId,
 					workspacePath: space?.workspacePath,
 				});
 				navigateToSpaceSession(spaceId, response.sessionId);
-			} catch {
-				// Session creation failed silently
+			} catch (err) {
+				toast.error(err instanceof Error ? err.message : 'Failed to create session');
+			} finally {
+				setCreatingSession(false);
 			}
 		},
-		[spaceId, space?.workspacePath]
+		[spaceId, space?.workspacePath, creatingSession]
 	);
 
 	// Session/agent chat view — render immediately, don't block on space data
@@ -244,7 +251,13 @@ export default function SpaceIsland({
 				<SpaceCreateTaskDialog
 					isOpen={createTaskOpen}
 					onClose={() => setCreateTaskOpen(false)}
-					onCreated={(task) => navigateToSpaceTask(spaceId, task.id)}
+					onCreated={(task) => {
+						// Only navigate if the user is still on the Tasks view;
+						// prevents stale async redirect if they navigated elsewhere.
+						if (currentSpaceViewModeSignal.value === 'tasks') {
+							navigateToSpaceTask(spaceId, task.id);
+						}
+					}}
 				/>
 				{overlay}
 			</>
@@ -264,7 +277,8 @@ export default function SpaceIsland({
 						actions={
 							<button
 								onClick={handleCreateSession}
-								class="p-1.5 bg-dark-850 border border-dark-700 rounded-lg hover:bg-dark-800 transition-colors text-gray-400 hover:text-gray-100 flex-shrink-0"
+								disabled={creatingSession}
+								class="p-1.5 bg-dark-850 border border-dark-700 rounded-lg hover:bg-dark-800 transition-colors text-gray-400 hover:text-gray-100 flex-shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
 								aria-label="Create session"
 								title="Create session"
 							>

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -130,6 +130,14 @@ export default function SpaceIsland({
 	}, []);
 
 	const error = spaceStore.error.value;
+	const [createTaskOpen, setCreateTaskOpen] = useState(false);
+	const [creatingSession, setCreatingSession] = useState(false);
+
+	// For non-session views, show spinner/error while space data loads.
+	// Show spinner if space is not yet loaded and there's no error — this covers
+	// both the initial render (loading=false, space=null) before the useEffect has
+	// called selectSpace and the active-loading state (loading=true, space=null).
+	const space = spaceStore.space.value;
 
 	useEffect(() => {
 		spaceStore.selectSpace(spaceId).catch(() => {
@@ -154,15 +162,6 @@ export default function SpaceIsland({
 	const handleTaskPaneClose = useCallback(() => {
 		navigateToSpace(spaceId);
 	}, [spaceId]);
-
-	const [createTaskOpen, setCreateTaskOpen] = useState(false);
-	const [creatingSession, setCreatingSession] = useState(false);
-
-	// For non-session views, show spinner/error while space data loads.
-	// Show spinner if space is not yet loaded and there's no error — this covers
-	// both the initial render (loading=false, space=null) before the useEffect has
-	// called selectSpace and the active-loading state (loading=true, space=null).
-	const space = spaceStore.space.value;
 
 	const handleCreateSession = useCallback(
 		async (e: Event) => {

--- a/packages/web/src/islands/SpaceIsland.tsx
+++ b/packages/web/src/islands/SpaceIsland.tsx
@@ -10,7 +10,7 @@
  * Space navigation is handled by the Context Panel sidebar.
  */
 
-import { useCallback, useEffect } from 'preact/hooks';
+import { useCallback, useEffect, useState } from 'preact/hooks';
 import { lazy, Suspense } from 'preact/compat';
 import type { SpaceViewMode } from '../lib/signals';
 import {
@@ -22,14 +22,17 @@ import {
 	spaceOverlayPendingAgentNameSignal,
 } from '../lib/signals';
 import { SpacePageHeader } from '../components/space/SpacePageHeader';
+import { SpaceCreateTaskDialog } from '../components/space/SpaceCreateTaskDialog';
 import { AgentOverlayChat } from '../components/space/AgentOverlayChat';
 import { spaceStore } from '../lib/space-store';
 import {
 	navigateToSpace,
 	navigateToSpaceTask,
+	navigateToSpaceSession,
 	pushOverlayHistory,
 	closeOverlayHistory,
 } from '../lib/router';
+import { createSession } from '../lib/api-helpers';
 import ChatContainer from './ChatContainer';
 
 const SpaceConfigurePage = lazy(() =>
@@ -135,6 +138,30 @@ export default function SpaceIsland({
 		navigateToSpace(spaceId);
 	}, [spaceId]);
 
+	const [createTaskOpen, setCreateTaskOpen] = useState(false);
+
+	// For non-session views, show spinner/error while space data loads.
+	// Show spinner if space is not yet loaded and there's no error — this covers
+	// both the initial render (loading=false, space=null) before the useEffect has
+	// called selectSpace and the active-loading state (loading=true, space=null).
+	const space = spaceStore.space.value;
+
+	const handleCreateSession = useCallback(
+		async (e: Event) => {
+			e.stopPropagation();
+			try {
+				const response = await createSession({
+					spaceId,
+					workspacePath: space?.workspacePath,
+				});
+				navigateToSpaceSession(spaceId, response.sessionId);
+			} catch {
+				// Session creation failed silently
+			}
+		},
+		[spaceId, space?.workspacePath]
+	);
+
 	// Session/agent chat view — render immediately, don't block on space data
 	// ChatContainer's root is already flex-1 flex-col overflow-hidden.
 	// AgentOverlayChat uses a Portal so it doesn't affect layout.
@@ -146,12 +173,6 @@ export default function SpaceIsland({
 			</>
 		);
 	}
-
-	// For non-session views, show spinner/error while space data loads.
-	// Show spinner if space is not yet loaded and there's no error — this covers
-	// both the initial render (loading=false, space=null) before the useEffect has
-	// called selectSpace and the active-loading state (loading=true, space=null).
-	const space = spaceStore.space.value;
 	if (!space && !error) {
 		return (
 			<div class="flex-1 flex items-center justify-center bg-dark-900">
@@ -190,7 +211,27 @@ export default function SpaceIsland({
 					class="flex-1 flex flex-col overflow-hidden bg-dark-900"
 					data-testid="space-tasks-view"
 				>
-					<SpacePageHeader spaceName={space.name} pageTitle="Tasks" />
+					<SpacePageHeader
+						spaceName={space.name}
+						pageTitle="Tasks"
+						actions={
+							<button
+								onClick={() => setCreateTaskOpen(true)}
+								class="p-1.5 bg-dark-850 border border-dark-700 rounded-lg hover:bg-dark-800 transition-colors text-gray-400 hover:text-gray-100 flex-shrink-0"
+								aria-label="Create task"
+								title="Create task"
+							>
+								<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width={2}
+										d="M12 4v16m8-8H4"
+									/>
+								</svg>
+							</button>
+						}
+					/>
 					<div class="flex-1 min-w-0 overflow-hidden flex flex-col">
 						<Suspense fallback={lazyFallback}>
 							<SpaceTasks
@@ -200,6 +241,11 @@ export default function SpaceIsland({
 						</Suspense>
 					</div>
 				</div>
+				<SpaceCreateTaskDialog
+					isOpen={createTaskOpen}
+					onClose={() => setCreateTaskOpen(false)}
+					onCreated={(task) => navigateToSpaceTask(spaceId, task.id)}
+				/>
 				{overlay}
 			</>
 		);
@@ -212,7 +258,27 @@ export default function SpaceIsland({
 					class="flex-1 flex flex-col overflow-hidden bg-dark-900"
 					data-testid="space-sessions-view"
 				>
-					<SpacePageHeader spaceName={space.name} pageTitle="Sessions" />
+					<SpacePageHeader
+						spaceName={space.name}
+						pageTitle="Sessions"
+						actions={
+							<button
+								onClick={handleCreateSession}
+								class="p-1.5 bg-dark-850 border border-dark-700 rounded-lg hover:bg-dark-800 transition-colors text-gray-400 hover:text-gray-100 flex-shrink-0"
+								aria-label="Create session"
+								title="Create session"
+							>
+								<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width={2}
+										d="M12 4v16m8-8H4"
+									/>
+								</svg>
+							</button>
+						}
+					/>
 					<div class="flex-1 min-w-0 overflow-hidden flex flex-col">
 						<Suspense fallback={lazyFallback}>
 							<SpaceSessionsPage spaceId={spaceId} />

--- a/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
+++ b/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
@@ -43,9 +43,22 @@ const { mockNavigateToSpaceConfigure } = vi.hoisted(() => ({
 	}),
 }));
 
+const { mockNavigateToSpaceSession } = vi.hoisted(() => ({
+	mockNavigateToSpaceSession: vi.fn(),
+}));
+
+const { mockCreateSession } = vi.hoisted(() => ({
+	mockCreateSession: vi.fn(),
+}));
+
+const { mockToastError } = vi.hoisted(() => ({
+	mockToastError: vi.fn(),
+}));
+
 // Real Preact signal for the configure tab (read during render — needs reactivity)
 const mockCurrentSpaceConfigureTabSignal = signal<string>('agents');
 const mockCurrentSpaceIdSignal = signal<string | null>(null);
+const mockCurrentSpaceViewModeSignal = signal<string>('overview');
 
 // Wire bridge so mockNavigateToSpaceConfigure can update the real signal
 configureTabBridge.signal = mockCurrentSpaceConfigureTabSignal;
@@ -60,6 +73,9 @@ vi.mock('../../lib/signals', async (importOriginal) => {
 		},
 		get currentSpaceIdSignal() {
 			return mockCurrentSpaceIdSignal;
+		},
+		get currentSpaceViewModeSignal() {
+			return mockCurrentSpaceViewModeSignal;
 		},
 	};
 });
@@ -135,6 +151,8 @@ vi.mock('../../lib/space-store', () => ({
 			space: mockSpace,
 			workflows: mockWorkflows,
 			agents: mockAgents,
+			sessions: { value: [] },
+			tasks: { value: [] },
 			configDataLoaded: { value: true },
 			ensureConfigData: vi.fn().mockResolvedValue(undefined),
 			ensureNodeExecutions: vi.fn().mockResolvedValue(undefined),
@@ -146,9 +164,20 @@ vi.mock('../../lib/space-store', () => ({
 vi.mock('../../lib/router', () => ({
 	navigateToSpace: vi.fn(),
 	navigateToSpaceTask: vi.fn(),
+	navigateToSpaceSession: mockNavigateToSpaceSession,
 	navigateToSpaceConfigure: mockNavigateToSpaceConfigure,
 	pushOverlayHistory: vi.fn(),
 	closeOverlayHistory: vi.fn(),
+}));
+
+vi.mock('../../lib/api-helpers', () => ({
+	createSession: mockCreateSession,
+}));
+
+vi.mock('../../lib/toast', () => ({
+	toast: {
+		error: mockToastError,
+	},
 }));
 
 import SpaceIsland from '../SpaceIsland';
@@ -206,6 +235,9 @@ beforeEach(() => {
 	configureTabBridge.signal.value = 'agents';
 	idBridge.signal.value = null;
 	mockNavigateToSpaceConfigure.mockClear();
+	mockNavigateToSpaceSession.mockClear();
+	mockCreateSession.mockClear();
+	mockToastError.mockClear();
 });
 
 afterEach(() => {
@@ -353,5 +385,163 @@ describe('SpaceIsland — content priority chain', () => {
 		);
 		await findByTestId('chat-container');
 		expect(queryByTestId('space-task-pane')).toBeNull();
+	});
+});
+
+describe('SpaceIsland — sessions view', () => {
+	it('renders Create Session button in the header', async () => {
+		const { getByLabelText, getByTestId } = render(
+			<SpaceIsland spaceId="space-1" viewMode="sessions" />
+		);
+		await waitFor(
+			() => {
+				expect(getByTestId('space-sessions-view')).toBeTruthy();
+			},
+			{ timeout: LAZY_LOAD_TIMEOUT }
+		);
+		expect(getByLabelText('Create session')).toBeTruthy();
+	});
+
+	it('calls createSession and navigates on success', async () => {
+		mockCreateSession.mockResolvedValueOnce({ sessionId: 'new-session-123' });
+		mockCurrentSpaceIdSignal.value = 'space-1';
+		mockCurrentSpaceViewModeSignal.value = 'sessions';
+
+		const { getByLabelText, getByTestId } = render(
+			<SpaceIsland spaceId="space-1" viewMode="sessions" />
+		);
+		await waitFor(
+			() => {
+				expect(getByTestId('space-sessions-view')).toBeTruthy();
+			},
+			{ timeout: LAZY_LOAD_TIMEOUT }
+		);
+
+		fireEvent.click(getByLabelText('Create session'));
+		await waitFor(() => {
+			expect(mockCreateSession).toHaveBeenCalledTimes(1);
+		});
+		expect(mockCreateSession).toHaveBeenCalledWith({
+			spaceId: 'space-1',
+			workspacePath: undefined,
+		});
+		// Navigation is conditional on currentSpaceIdSignal and currentSpaceViewModeSignal
+		// matching the origin values. In tests these signals are real Preact signals
+		// but the component reads them at resolution time, not via subscription,
+		// so the guard should pass when values match.
+		await waitFor(() => {
+			expect(mockNavigateToSpaceSession).toHaveBeenCalledWith('space-1', 'new-session-123');
+		});
+	});
+
+	it('shows toast.error when createSession fails', async () => {
+		mockCreateSession.mockRejectedValueOnce(new Error('Connection refused'));
+
+		const { getByLabelText, getByTestId } = render(
+			<SpaceIsland spaceId="space-1" viewMode="sessions" />
+		);
+		await waitFor(
+			() => {
+				expect(getByTestId('space-sessions-view')).toBeTruthy();
+			},
+			{ timeout: LAZY_LOAD_TIMEOUT }
+		);
+
+		fireEvent.click(getByLabelText('Create session'));
+		await waitFor(() => {
+			expect(mockToastError).toHaveBeenCalledWith('Connection refused');
+		});
+		expect(mockNavigateToSpaceSession).not.toHaveBeenCalled();
+	});
+
+	it('skips navigation when user has navigated to a different space', async () => {
+		mockCreateSession.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					setTimeout(() => resolve({ sessionId: 'new-session-123' }), 50);
+				})
+		);
+		mockCurrentSpaceIdSignal.value = 'space-1';
+
+		const { getByLabelText, getByTestId } = render(
+			<SpaceIsland spaceId="space-1" viewMode="sessions" />
+		);
+		await waitFor(
+			() => {
+				expect(getByTestId('space-sessions-view')).toBeTruthy();
+			},
+			{ timeout: LAZY_LOAD_TIMEOUT }
+		);
+
+		fireEvent.click(getByLabelText('Create session'));
+		// Simulate user navigating to a different space while request is in flight
+		mockCurrentSpaceIdSignal.value = 'space-2';
+		await waitFor(() => {
+			expect(mockCreateSession).toHaveBeenCalledTimes(1);
+		});
+		expect(mockNavigateToSpaceSession).not.toHaveBeenCalled();
+	});
+
+	it('disables the button while creating session', async () => {
+		mockCreateSession.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					setTimeout(() => resolve({ sessionId: 'new-session-123' }), 50);
+				})
+		);
+
+		const { getByLabelText, getByTestId } = render(
+			<SpaceIsland spaceId="space-1" viewMode="sessions" />
+		);
+		await waitFor(
+			() => {
+				expect(getByTestId('space-sessions-view')).toBeTruthy();
+			},
+			{ timeout: LAZY_LOAD_TIMEOUT }
+		);
+
+		const btn = getByLabelText('Create session') as HTMLButtonElement;
+		fireEvent.click(btn);
+		expect(btn.disabled).toBe(true);
+		await waitFor(() => {
+			expect(mockCreateSession).toHaveBeenCalledTimes(1);
+		});
+		// Wait for the async handler to finish and re-enable the button
+		await waitFor(() => {
+			expect(btn.disabled).toBe(false);
+		});
+	});
+});
+
+describe('SpaceIsland — tasks view', () => {
+	it('renders Create Task button in the header', async () => {
+		const { getByLabelText, getByTestId } = render(
+			<SpaceIsland spaceId="space-1" viewMode="tasks" />
+		);
+		await waitFor(
+			() => {
+				expect(getByTestId('space-tasks-view')).toBeTruthy();
+			},
+			{ timeout: LAZY_LOAD_TIMEOUT }
+		);
+		expect(getByLabelText('Create task')).toBeTruthy();
+	});
+
+	it('opens SpaceCreateTaskDialog when Create Task button is clicked', async () => {
+		const { getByLabelText, getByTestId, getByRole } = render(
+			<SpaceIsland spaceId="space-1" viewMode="tasks" />
+		);
+		await waitFor(
+			() => {
+				expect(getByTestId('space-tasks-view')).toBeTruthy();
+			},
+			{ timeout: LAZY_LOAD_TIMEOUT }
+		);
+
+		fireEvent.click(getByLabelText('Create task'));
+		// Dialog title is a heading; use getByRole to avoid matching the submit button
+		await waitFor(() => {
+			expect(getByRole('heading', { name: 'Create Task' })).toBeTruthy();
+		});
 	});
 });

--- a/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
+++ b/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
@@ -462,6 +462,7 @@ describe('SpaceIsland — sessions view', () => {
 				})
 		);
 		mockCurrentSpaceIdSignal.value = 'space-1';
+		mockCurrentSpaceViewModeSignal.value = 'sessions';
 
 		const { getByLabelText, getByTestId } = render(
 			<SpaceIsland spaceId="space-1" viewMode="sessions" />
@@ -479,7 +480,10 @@ describe('SpaceIsland — sessions view', () => {
 		await waitFor(() => {
 			expect(mockCreateSession).toHaveBeenCalledTimes(1);
 		});
-		expect(mockNavigateToSpaceSession).not.toHaveBeenCalled();
+		// Wait for the delayed promise to fully settle before asserting no navigation
+		await waitFor(() => {
+			expect(mockNavigateToSpaceSession).not.toHaveBeenCalled();
+		});
 	});
 
 	it('disables the button while creating session', async () => {


### PR DESCRIPTION
Add contextual action buttons to the Space Sessions and Tasks page headers.

- **SpacePageHeader**: new optional `actions` prop renders a right-aligned slot for header buttons.
- **Sessions page**: "+" icon button wired to `createSession()` API; on success navigates to the new session.
- **Tasks page**: "+" icon button opens the existing `SpaceCreateTaskDialog`; on creation navigates to the new task.

Both buttons use the same compact icon-button style as the sidebar's create-session button for visual consistency.