### PR TITLE
fix: set autoCompactWindow for non-native providers with large context windows

### DIFF
--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -48,6 +48,7 @@ import type { Database } from '../../storage/database';
 import type { AppMcpServerRepository } from '../../storage/repositories/app-mcp-server-repository';
 import type { McpEnablementRepository } from '../../storage/repositories/mcp-enablement-repository';
 import { resolveMcpServers, scopeChainForSession } from '../mcp/resolve-mcp-servers';
+import { getSessionModelInfo } from '../model-service.js';
 import { requireModelContextWindow } from '../providers/codex-models';
 import { getProviderContextManager } from '../providers/factory.js';
 import type { SettingsManager } from '../settings-manager';
@@ -180,27 +181,51 @@ export function ensureAgentTools(
 }
 
 /**
- * Provider-specific SDK settings overrides.
+ * Providers whose native SDK integration already knows the correct context
+ * window and auto-compact behavior. No override needed.
+ *
+ * anthropic        — native Anthropic API, SDK knows all model context windows.
+ * anthropic-copilot — Copilot bridge still routes to Anthropic API.
  */
-export function buildProviderSettings(providerId: string, modelId?: string): Options['settings'] {
-	if (providerId !== 'anthropic-codex') {
-		return undefined;
+const NATIVE_CONTEXT_WINDOW_PROVIDERS = ['anthropic', 'anthropic-copilot'];
+
+/**
+ * Provider-specific SDK settings overrides.
+ *
+ * For the Codex bridge, returns a hardcoded 1M autoCompactWindow.
+ * For other non-native providers, the caller should supply the model's
+ * actual contextWindow so the SDK auto-compacts at the right threshold.
+ */
+export function buildProviderSettings(
+	providerId: string,
+	modelId?: string,
+	contextWindow?: number
+): Options['settings'] {
+	if (providerId === 'anthropic-codex') {
+		if (!modelId) {
+			throw new Error(`Unknown Codex model auto-compact window: ${modelId ?? 'missing model'}`);
+		}
+		try {
+			requireModelContextWindow(modelId);
+		} catch {
+			throw new Error(`Unknown Codex model auto-compact window: ${modelId}`);
+		}
+
+		return {
+			// Keep SDK-driven compaction disabled for the Codex bridge. The bridge uses
+			// a single persistent Codex turn per session and rejects overlapping turns.
+			autoCompactWindow: CODEX_BRIDGE_AUTO_COMPACT_WINDOW,
+		};
 	}
 
-	if (!modelId) {
-		throw new Error(`Unknown Codex model auto-compact window: ${modelId ?? 'missing model'}`);
-	}
-	try {
-		requireModelContextWindow(modelId);
-	} catch {
-		throw new Error(`Unknown Codex model auto-compact window: ${modelId}`);
+	// For non-native providers where the SDK can't discover the actual context
+	// window (OpenRouter, Ollama, GLM, etc.), pass the model's contextWindow
+	// so auto-compact triggers at the right percentage of actual capacity.
+	if (!NATIVE_CONTEXT_WINDOW_PROVIDERS.includes(providerId) && contextWindow) {
+		return { autoCompactWindow: contextWindow };
 	}
 
-	return {
-		// Keep SDK-driven compaction disabled for the Codex bridge. The bridge uses
-		// a single persistent Codex turn per session and rejects overlapping turns.
-		autoCompactWindow: CODEX_BRIDGE_AUTO_COMPACT_WINDOW,
-	};
+	return undefined;
 }
 
 /**
@@ -337,6 +362,12 @@ export class QueryOptionsBuilder {
 		// here is the effective set for this session.
 		const mergedMcpServers = this.mergeMcpServers(mcpServers, mcpServersFromSkills);
 
+		// Resolve model metadata so non-native providers get the correct
+		// autoCompactWindow (the SDK defaults to 200k when it can't discover
+		// the real context window, causing premature compaction on 1M models).
+		const modelInfo = await getSessionModelInfo(this.ctx.session);
+		const autoCompactWindow = modelInfo?.contextWindow;
+
 		// Build final query options
 		const queryOptions: Options = {
 			// ============ Model & Execution ============
@@ -421,7 +452,7 @@ export class QueryOptionsBuilder {
 			// output style, CLAUDE.md content, etc.).
 			settingSources:
 				config.settingSources ?? this.ctx.settingsManager.getGlobalSettings().settingSources,
-			settings: buildProviderSettings(providerId, config.model),
+			settings: buildProviderSettings(providerId, config.model, autoCompactWindow),
 
 			// ============ Streaming ============
 			includePartialMessages: config.includePartialMessages,

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -24,6 +24,7 @@ import { AppMcpServerRepository } from '../../../../src/storage/repositories/app
 import { SkillRepository } from '../../../../src/storage/repositories/skill-repository';
 import { createTables } from '../../../../src/storage/schema';
 import { noOpReactiveDb } from '../../../helpers/reactive-database';
+import { setModelsCache } from '../../../../src/lib/model-service';
 
 describe('QueryOptionsBuilder', () => {
 	let builder: QueryOptionsBuilder;
@@ -152,9 +153,9 @@ describe('QueryOptionsBuilder', () => {
 			expect(options.env).toEqual({ MY_VAR: 'value' });
 		});
 
-		it('should not override SDK auto-compaction settings for other providers', async () => {
+		it('should not override SDK auto-compaction settings for native anthropic provider', async () => {
+			// Default provider is anthropic — SDK already knows correct context window
 			const options = await builder.build();
-
 			expect(options.settings).toBeUndefined();
 		});
 
@@ -186,10 +187,123 @@ describe('QueryOptionsBuilder', () => {
 			);
 		});
 
-		it('should not override SDK auto-compaction settings for other providers', () => {
+		it('should not override SDK auto-compaction settings for native anthropic provider', () => {
 			expect(buildProviderSettings('anthropic')).toBeUndefined();
-			expect(buildProviderSettings('glm')).toBeUndefined();
-			expect(buildProviderSettings('anthropic-copilot')).toBeUndefined();
+		});
+
+		it('should not override SDK auto-compaction settings when no contextWindow is known', () => {
+			expect(buildProviderSettings('glm', 'glm-5')).toBeUndefined();
+			expect(buildProviderSettings('openrouter', 'deepseek-v4')).toBeUndefined();
+		});
+
+		it('should set autoCompactWindow for non-native providers when contextWindow is known', () => {
+			expect(buildProviderSettings('openrouter', 'deepseek-v4', 1_000_000)).toEqual({
+				autoCompactWindow: 1_000_000,
+			});
+			expect(buildProviderSettings('glm', 'glm-5', 128_000)).toEqual({
+				autoCompactWindow: 128_000,
+			});
+			expect(buildProviderSettings('ollama', 'llama3', 128_000)).toEqual({
+				autoCompactWindow: 128_000,
+			});
+		});
+
+		it('should still return undefined for anthropic-copilot (native Anthropic API)', () => {
+			// anthropic-copilot routes to Anthropic API — SDK knows the context window
+			expect(
+				buildProviderSettings('anthropic-copilot', 'claude-sonnet-4.6', 200_000)
+			).toBeUndefined();
+		});
+	});
+
+	describe('auto-compact window via build()', () => {
+		function registerOpenRouterProvider(): void {
+			resetProviderRegistry();
+			const registry = getProviderRegistry();
+			registry.register({
+				id: 'openrouter',
+				displayName: 'OpenRouter',
+				capabilities: {
+					streaming: true,
+					extendedThinking: false,
+					maxContextWindow: 1_000_000,
+					functionCalling: true,
+					vision: true,
+				},
+				isAvailable: () => true,
+				getModels: async () => [],
+				ownsModel: () => false,
+				buildSdkConfig: () => ({ envVars: {}, isAnthropicCompatible: true }),
+			} as Provider);
+		}
+
+		afterEach(() => {
+			setModelsCache(new Map());
+			resetProviderRegistry();
+		});
+
+		it('should set autoCompactWindow for OpenRouter 1M context model', async () => {
+			registerOpenRouterProvider();
+			setModelsCache(
+				new Map([
+					[
+						'global',
+						[
+							{
+								id: 'deepseek-v4',
+								name: 'DeepSeek V4',
+								provider: 'openrouter',
+								contextWindow: 1_000_000,
+								available: true,
+							},
+						],
+					],
+				])
+			);
+			mockSession.config.provider = 'openrouter';
+			mockSession.config.model = 'deepseek-v4';
+			const options = await builder.build();
+			expect(options.settings).toEqual({ autoCompactWindow: 1_000_000 });
+		});
+
+		it('should set autoCompactWindow for OpenRouter model with 128k context window', async () => {
+			registerOpenRouterProvider();
+			setModelsCache(
+				new Map([
+					[
+						'global',
+						[
+							{
+								id: 'qwen-2.5-72b',
+								name: 'Qwen 2.5 72B',
+								provider: 'openrouter',
+								contextWindow: 128_000,
+								available: true,
+							},
+						],
+					],
+				])
+			);
+			mockSession.config.provider = 'openrouter';
+			mockSession.config.model = 'qwen-2.5-72b';
+			const options = await builder.build();
+			expect(options.settings).toEqual({ autoCompactWindow: 128_000 });
+		});
+
+		it('should leave settings undefined for native anthropic provider', async () => {
+			// Default mockSession uses anthropic provider
+			const options = await builder.build();
+			expect(options.settings).toBeUndefined();
+		});
+
+		it('should leave settings undefined when model context window is unknown', async () => {
+			registerOpenRouterProvider();
+			// Empty cache — model not found
+			setModelsCache(new Map());
+			mockSession.config.provider = 'openrouter';
+			mockSession.config.model = 'unknown-model';
+			const options = await builder.build();
+			expect(options.settings).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
Fix auto-compact triggering at ~17% for large-context models like DeepSeek v4 (1M) when routed through OpenRouter.

**Root cause:** The SDK defaults to a 200k context window for auto-compact decisions when it can't discover the actual model capacity. For a 1M-context model, this means compaction fires at ~160k tokens (~17% of actual capacity) instead of ~800k (~80%).

**Fix:**
- `QueryOptionsBuilder.build()` now fetches the session's `ModelInfo` and passes `contextWindow` to `buildProviderSettings()`.
- `buildProviderSettings()` sets `autoCompactWindow` for non-native providers (OpenRouter, Ollama, GLM, etc.) when the model's `contextWindow` is known.
- Native Anthropic providers (`anthropic`, `anthropic-copilot`) are skipped since the SDK already knows their correct context windows.
- The Codex bridge's hardcoded 1M `autoCompactWindow` is preserved.

**Test coverage:**
- OpenRouter 1M model → `autoCompactWindow: 1_000_000`
- OpenRouter 128k model → `autoCompactWindow: 128_000`
- Native anthropic provider → settings left undefined
- Unknown model context window → settings left undefined