### PR TITLE
feat: add recurring and scheduled task support via TaskSchedule

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "packages/cli": {
       "name": "@neokai/cli",
-      "version": "0.19.0",
+      "version": "0.21.0",
       "bin": {
         "kai": "./main.ts",
       },
@@ -32,11 +32,12 @@
     },
     "packages/daemon": {
       "name": "@neokai/daemon",
-      "version": "0.19.0",
+      "version": "0.21.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.112",
         "@github/copilot-sdk": "0.3.0",
         "@neokai/shared": "workspace:*",
+        "croner": "^10.0.1",
         "simple-git": "3.36.0",
         "zod": "4.3.6",
       },
@@ -50,7 +51,7 @@
     },
     "packages/e2e": {
       "name": "@neokai/e2e",
-      "version": "0.19.0",
+      "version": "0.21.0",
       "devDependencies": {
         "@playwright/test": "1.59.1",
         "@types/node": "25.6.0",
@@ -59,14 +60,14 @@
     },
     "packages/shared": {
       "name": "@neokai/shared",
-      "version": "0.19.0",
+      "version": "0.21.0",
       "devDependencies": {
         "@types/bun": "1.3.13",
       },
     },
     "packages/ui": {
       "name": "@neokai/ui",
-      "version": "0.19.0",
+      "version": "0.21.0",
       "dependencies": {
         "@floating-ui/dom": "1.7.6",
         "preact": "10.29.1",
@@ -86,7 +87,7 @@
     },
     "packages/web": {
       "name": "@neokai/web",
-      "version": "0.19.0",
+      "version": "0.21.0",
       "dependencies": {
         "@preact/signals": "2.9.0",
         "clsx": "2.1.1",
@@ -647,6 +648,8 @@
     "cookies": ["cookies@0.9.1", "", { "dependencies": { "depd": "~2.0.0", "keygrip": "~1.1.0" } }, "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw=="],
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "croner": ["croner@10.0.1", "", {}, "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -28,7 +28,7 @@
 		"@anthropic-ai/claude-agent-sdk": "0.2.112",
 		"@github/copilot-sdk": "0.3.0",
 		"@neokai/shared": "workspace:*",
-		"croner": "^10.0.1",
+		"croner": "10.0.1",
 		"simple-git": "3.36.0",
 		"zod": "4.3.6"
 	},

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -28,6 +28,7 @@
 		"@anthropic-ai/claude-agent-sdk": "0.2.112",
 		"@github/copilot-sdk": "0.3.0",
 		"@neokai/shared": "workspace:*",
+		"croner": "^10.0.1",
 		"simple-git": "3.36.0",
 		"zod": "4.3.6"
 	},

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -608,11 +608,30 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 			}
 
 			// Pass 2: due schedules with no pendingJobId at all (e.g. crashed mid-create).
-			// `listActiveDue(now)` returns schedules whose nextRunAt <= now.
-			const dueSchedules = taskScheduleRepo.listActiveDue(now);
-			for (const schedule of dueSchedules) {
-				if (schedule.pendingJobId) continue; // handled by pass 1
-				reseedSchedule(schedule.id, schedule.nextRunAt);
+			// `listActiveDue(now)` returns schedules whose nextRunAt <= now. The repo
+			// applies a default page size, so loop until a page comes back smaller
+			// than the limit — otherwise a backlog of >100 due schedules would only
+			// be partially recovered until the next restart.
+			const RECOVERY_PAGE_SIZE = 200;
+			let totalReseeded = 0;
+			while (true) {
+				const dueSchedules = taskScheduleRepo.listActiveDue(now, RECOVERY_PAGE_SIZE);
+				let pageReseeded = 0;
+				for (const schedule of dueSchedules) {
+					if (schedule.pendingJobId) continue; // handled by pass 1
+					reseedSchedule(schedule.id, schedule.nextRunAt);
+					pageReseeded++;
+				}
+				totalReseeded += pageReseeded;
+				// Drained the queue when either the page is short or none of the
+				// returned rows actually needed re-seeding (all already had a
+				// pending job linked, e.g. set by pass 1).
+				if (dueSchedules.length < RECOVERY_PAGE_SIZE || pageReseeded === 0) break;
+			}
+			if (totalReseeded > 0) {
+				logInfo('[Daemon] Re-seeded due schedules with no pending job', {
+					count: totalReseeded,
+				});
 			}
 		} catch (err) {
 			logError('[Daemon] Task schedule startup re-seed failed (non-fatal):', err);

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -34,7 +34,10 @@ import { JobQueueRepository } from './storage/repositories/job-queue-repository'
 import { JobQueueProcessor } from './storage/job-queue-processor';
 import { createCleanupHandler } from './lib/job-handlers/cleanup.handler';
 import { createSkillValidateHandler } from './lib/job-handlers/skill-validate.handler';
-import { JOB_QUEUE_CLEANUP, SKILL_VALIDATE } from './lib/job-queue-constants';
+import { JOB_QUEUE_CLEANUP, SKILL_VALIDATE, TASK_SCHEDULE_FIRE } from './lib/job-queue-constants';
+import { handleTaskScheduleFire } from './lib/job-handlers/task-schedule-fire.handler';
+import { TaskScheduleRepository } from './storage/repositories/task-schedule-repository';
+import { SpaceTaskManager } from './lib/space/managers/space-task-manager';
 import { AppMcpLifecycleManager, McpImportService, seedDefaultMcpEntries } from './lib/mcp';
 import { FileIndex } from './lib/file-index';
 import { SkillsManager } from './lib/skills-manager';
@@ -541,6 +544,48 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		createSkillValidateHandler(skillsManager, db.appMcpServers)
 	);
 	jobProcessor.register(JOB_QUEUE_CLEANUP, createCleanupHandler(jobQueue));
+
+	// Register task-schedule.fire handler.
+	const taskScheduleRepo = new TaskScheduleRepository(db.getDatabase());
+	jobProcessor.register(TASK_SCHEDULE_FIRE, async (payload) => {
+		return handleTaskScheduleFire(payload as unknown as { scheduleId: string }, {
+			scheduleRepo: taskScheduleRepo,
+			jobQueue,
+			taskManagerFactory: (spaceId: string) =>
+				new SpaceTaskManager(db.getDatabase(), spaceId, reactiveDb),
+		});
+	});
+
+	// Startup resilience: re-seed active schedules whose pending jobs are missing.
+	// This handles crash recovery — if the daemon restarted while a job was in flight
+	// or was lost, we re-enqueue it so the schedule can continue.
+	if (process.env.NODE_ENV !== 'test') {
+		const now = Date.now();
+		try {
+			const activeSchedules = taskScheduleRepo.listActiveWithPendingJob();
+			for (const schedule of activeSchedules) {
+				if (!schedule.pendingJobId) continue;
+				const job = jobQueue.getJob(schedule.pendingJobId);
+				if (!job || job.status === 'dead' || job.status === 'failed') {
+					// Job is gone — re-enqueue.
+					const runAt =
+						schedule.nextRunAt !== null && schedule.nextRunAt > now ? schedule.nextRunAt : now;
+					const newJob = jobQueue.enqueue({
+						queue: TASK_SCHEDULE_FIRE,
+						payload: { scheduleId: schedule.id },
+						runAt,
+					});
+					taskScheduleRepo.updatePendingJobId(schedule.id, newJob.id);
+					logInfo('[Daemon] Re-seeded lost job for schedule', {
+						scheduleId: schedule.id,
+						newJobId: newJob.id,
+					});
+				}
+			}
+		} catch (err) {
+			logError('[Daemon] Task schedule startup re-seed failed (non-fatal):', err);
+		}
+	}
 
 	// Enqueue the initial cleanup job if none is already pending.
 	const pendingCleanup = jobQueue.listJobs({

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -557,6 +557,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 			jobQueue,
 			spaceRepo: taskScheduleSpaceRepo,
 			taskRepo: taskScheduleTaskRepo,
+			eventHub: eventBus,
 		});
 	});
 

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -37,7 +37,8 @@ import { createSkillValidateHandler } from './lib/job-handlers/skill-validate.ha
 import { JOB_QUEUE_CLEANUP, SKILL_VALIDATE, TASK_SCHEDULE_FIRE } from './lib/job-queue-constants';
 import { handleTaskScheduleFire } from './lib/job-handlers/task-schedule-fire.handler';
 import { TaskScheduleRepository } from './storage/repositories/task-schedule-repository';
-import { SpaceTaskManager } from './lib/space/managers/space-task-manager';
+import { SpaceRepository } from './storage/repositories/space-repository';
+import { SpaceTaskRepository } from './storage/repositories/space-task-repository';
 import { AppMcpLifecycleManager, McpImportService, seedDefaultMcpEntries } from './lib/mcp';
 import { FileIndex } from './lib/file-index';
 import { SkillsManager } from './lib/skills-manager';
@@ -547,40 +548,71 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 
 	// Register task-schedule.fire handler.
 	const taskScheduleRepo = new TaskScheduleRepository(db.getDatabase());
-	jobProcessor.register(TASK_SCHEDULE_FIRE, async (payload) => {
-		return handleTaskScheduleFire(payload as unknown as { scheduleId: string }, {
+	const taskScheduleSpaceRepo = new SpaceRepository(db.getDatabase());
+	const taskScheduleTaskRepo = new SpaceTaskRepository(db.getDatabase(), reactiveDb);
+	jobProcessor.register(TASK_SCHEDULE_FIRE, async (job) => {
+		return handleTaskScheduleFire(job, {
+			db: db.getDatabase(),
 			scheduleRepo: taskScheduleRepo,
 			jobQueue,
-			taskManagerFactory: (spaceId: string) =>
-				new SpaceTaskManager(db.getDatabase(), spaceId, reactiveDb),
+			spaceRepo: taskScheduleSpaceRepo,
+			taskRepo: taskScheduleTaskRepo,
 		});
 	});
 
 	// Startup resilience: re-seed active schedules whose pending jobs are missing.
-	// This handles crash recovery — if the daemon restarted while a job was in flight
-	// or was lost, we re-enqueue it so the schedule can continue.
+	// This handles crash recovery in two cases:
+	//   1) Schedule has a pendingJobId, but the underlying job is gone OR has reached
+	//      a terminal state (completed/failed/dead) without `updateAfterFire` advancing
+	//      the schedule. This can happen if the daemon crashed between job completion
+	//      and the schedule update.
+	//   2) Schedule has pendingJobId = null and is due — this happens when the daemon
+	//      crashed between scheduleRepo.create() and jobQueue.enqueue(), leaving an
+	//      orphaned schedule that listActiveWithPendingJob() would never see.
 	if (process.env.NODE_ENV !== 'test') {
 		const now = Date.now();
+
+		// A job is considered "lost" for recovery purposes if it's missing OR in any
+		// terminal state. `pending` and `processing` are still in flight and should
+		// not be re-enqueued.
+		const isJobLost = (status: string | undefined): boolean =>
+			status === undefined ||
+			status === 'completed' ||
+			status === 'failed' ||
+			status === 'dead' ||
+			status === 'cancelled';
+
+		const reseedSchedule = (scheduleId: string, scheduleNextRunAt: number | null): void => {
+			const runAt = scheduleNextRunAt !== null && scheduleNextRunAt > now ? scheduleNextRunAt : now;
+			const newJob = jobQueue.enqueue({
+				queue: TASK_SCHEDULE_FIRE,
+				payload: { scheduleId },
+				runAt,
+			});
+			taskScheduleRepo.updatePendingJobId(scheduleId, newJob.id);
+			logInfo('[Daemon] Re-seeded lost job for schedule', {
+				scheduleId,
+				newJobId: newJob.id,
+			});
+		};
+
 		try {
+			// Pass 1: schedules with a pendingJobId pointing to a missing/terminal job.
 			const activeSchedules = taskScheduleRepo.listActiveWithPendingJob();
 			for (const schedule of activeSchedules) {
 				if (!schedule.pendingJobId) continue;
 				const job = jobQueue.getJob(schedule.pendingJobId);
-				if (!job || job.status === 'dead' || job.status === 'failed') {
-					// Job is gone — re-enqueue.
-					const runAt =
-						schedule.nextRunAt !== null && schedule.nextRunAt > now ? schedule.nextRunAt : now;
-					const newJob = jobQueue.enqueue({
-						queue: TASK_SCHEDULE_FIRE,
-						payload: { scheduleId: schedule.id },
-						runAt,
-					});
-					taskScheduleRepo.updatePendingJobId(schedule.id, newJob.id);
-					logInfo('[Daemon] Re-seeded lost job for schedule', {
-						scheduleId: schedule.id,
-						newJobId: newJob.id,
-					});
+				if (isJobLost(job?.status)) {
+					reseedSchedule(schedule.id, schedule.nextRunAt);
 				}
+			}
+
+			// Pass 2: due schedules with no pendingJobId at all (e.g. crashed mid-create).
+			// `listActiveDue(now)` returns schedules whose nextRunAt <= now.
+			const dueSchedules = taskScheduleRepo.listActiveDue(now);
+			for (const schedule of dueSchedules) {
+				if (schedule.pendingJobId) continue; // handled by pass 1
+				reseedSchedule(schedule.id, schedule.nextRunAt);
 			}
 		} catch (err) {
 			logError('[Daemon] Task schedule startup re-seed failed (non-fatal):', err);

--- a/packages/daemon/src/lib/daemon-hub.ts
+++ b/packages/daemon/src/lib/daemon-hub.ts
@@ -494,6 +494,14 @@ export interface DaemonEventMap extends Record<string, BaseEventData> {
 		archiveSource?: 'user' | 'system_reconcile';
 	};
 
+	// Space schedule events (global events - use 'global' as sessionId)
+	'space.schedule.updated': {
+		sessionId: string;
+		spaceId: string;
+		scheduleId: string;
+		schedule: import('@neokai/shared').TaskSchedule;
+	};
+
 	// Space Task Agent completion events (use 'global' as sessionId)
 	/** Emitted when a Task Agent marks a task as done via `task.reportedStatus`. */
 	'space.task.done': {

--- a/packages/daemon/src/lib/db-query/scope-config.ts
+++ b/packages/daemon/src/lib/db-query/scope-config.ts
@@ -320,6 +320,13 @@ const SPACE_SCOPE_TABLES: ScopeTableConfig[] = [
 		description:
 			'Audit trail of MCP write operations (create_task, approve_task, send_message, save_artifact) with agent name, session ID, tool name, and parameters.',
 	},
+	{
+		tableName: 'task_schedules',
+		scopeColumn: 'space_id',
+		blacklistedColumns: [],
+		description:
+			'Recurring (cron) and one-shot (at) task schedule templates with trigger config, status, and last-run tracking.',
+	},
 	// ── Main-DB tables exposed with space-scoped filtering via session ID prefix ──
 	{
 		tableName: 'sessions',

--- a/packages/daemon/src/lib/job-handlers/task-schedule-fire.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/task-schedule-fire.handler.ts
@@ -59,6 +59,16 @@ export interface TaskScheduleFireHandlerDeps {
 	jobQueue: JobQueueRepository;
 	spaceRepo: SpaceRepository;
 	taskRepo: SpaceTaskRepository;
+	/**
+	 * Optional event emitter for broadcasting schedule/task changes.
+	 * When provided, the handler emits `space.task.created` and
+	 * `space.schedule.updated` after a successful fire so the web
+	 * client can refresh its state without polling.
+	 */
+	eventHub?: {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		emit: (event: string, data: any) => Promise<void>;
+	};
 }
 
 export async function handleTaskScheduleFire(
@@ -66,7 +76,7 @@ export async function handleTaskScheduleFire(
 	deps: TaskScheduleFireHandlerDeps
 ): Promise<TaskScheduleFireResult> {
 	const { scheduleId } = job.payload as TaskScheduleFirePayload;
-	const { db, scheduleRepo, jobQueue, spaceRepo, taskRepo } = deps;
+	const { db, scheduleRepo, jobQueue, spaceRepo, taskRepo, eventHub } = deps;
 
 	const schedule = scheduleRepo.getById(scheduleId);
 
@@ -225,6 +235,37 @@ export async function handleTaskScheduleFire(
 		taskId = result.taskId;
 		nextRunAt = result.nextRunAt;
 		log.debug('task-schedule-fire: created task', { scheduleId, taskId, nextRunAt });
+
+		// Emit events so the web client can refresh its state without polling.
+		// Fire-and-forget — handler success must not depend on event delivery.
+		if (eventHub) {
+			const emittedTask = taskRepo.getTask(taskId);
+			if (emittedTask) {
+				eventHub
+					.emit('space.task.created', {
+						sessionId: 'global',
+						spaceId: schedule.spaceId,
+						taskId,
+						task: emittedTask,
+					})
+					.catch(() => {
+						// Swallow — event emission is best-effort.
+					});
+			}
+			const emittedSchedule = scheduleRepo.getById(scheduleId);
+			if (emittedSchedule) {
+				eventHub
+					.emit('space.schedule.updated', {
+						sessionId: 'global',
+						spaceId: schedule.spaceId,
+						scheduleId,
+						schedule: emittedSchedule,
+					})
+					.catch(() => {
+						// Swallow — event emission is best-effort.
+					});
+			}
+		}
 	} catch (err) {
 		// A concurrent pause/delete invalidated our pending_job_id mid-flight;
 		// the transaction rolled back the task and any next-job enqueue, so

--- a/packages/daemon/src/lib/job-handlers/task-schedule-fire.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/task-schedule-fire.handler.ts
@@ -27,6 +27,20 @@ import type { SpaceTaskRepository } from '../../storage/repositories/space-task-
 
 const log = new Logger('task-schedule-fire-handler');
 
+/**
+ * Internal sentinel thrown inside the fire transaction when the
+ * compare-and-swap on `pending_job_id` fails — i.e. a concurrent
+ * pause/delete/reschedule invalidated our claim on this fire. The handler
+ * catches this and converts it to a normal `job_superseded` skip; the queue
+ * does not retry it.
+ */
+class ScheduleSupersededError extends Error {
+	constructor(scheduleId: string, jobId: string) {
+		super(`Schedule ${scheduleId} superseded; job ${jobId} no longer the pending fire`);
+		this.name = 'ScheduleSupersededError';
+	}
+}
+
 export interface TaskScheduleFirePayload extends Record<string, unknown> {
 	scheduleId: string;
 }
@@ -68,14 +82,18 @@ export async function handleTaskScheduleFire(
 		};
 	}
 
-	// Guard: skip if the host space is archived or missing. Without this an
-	// archived space would still spawn fresh tasks every cron tick.
+	// Guard: skip if the host space is archived, missing, paused, or stopped.
+	// Without this, a non-active space would still spawn fresh tasks every cron
+	// tick, violating the space lifecycle contract (paused/stopped must prevent
+	// new scheduled work).
 	const space = spaceRepo.getSpace(schedule.spaceId);
-	if (!space || space.status !== 'active') {
+	if (!space || space.status !== 'active' || space.paused || space.stopped) {
 		log.debug('task-schedule-fire: skipping schedule for non-active space', {
 			scheduleId,
 			spaceId: schedule.spaceId,
 			spaceStatus: space?.status,
+			paused: space?.paused,
+			stopped: space?.stopped,
 		});
 		return {
 			scheduleId,
@@ -147,13 +165,21 @@ export async function handleTaskScheduleFire(
 				}
 			}
 
-			scheduleRepo.updateAfterFire(scheduleId, {
+			// Compare-and-swap: only commit if the schedule's pending_job_id is
+			// still our job id. If a concurrent pause/delete/reschedule happened
+			// between the initial read and now, the precondition fails and we
+			// throw — the surrounding transaction rolls back, including the
+			// just-created task and the just-enqueued next job.
+			const applied = scheduleRepo.updateAfterFireIfPending(scheduleId, job.id, {
 				lastCreatedTaskId: task.id,
 				lastRunAt: now,
 				nextRunAt: computedNextRunAt,
 				status: nextStatus,
 				pendingJobId,
 			});
+			if (!applied) {
+				throw new ScheduleSupersededError(scheduleId, job.id);
+			}
 
 			return { taskId: task.id, nextRunAt: computedNextRunAt };
 		})();
@@ -162,6 +188,23 @@ export async function handleTaskScheduleFire(
 		nextRunAt = result.nextRunAt;
 		log.debug('task-schedule-fire: created task', { scheduleId, taskId, nextRunAt });
 	} catch (err) {
+		// A concurrent pause/delete invalidated our pending_job_id mid-flight;
+		// the transaction rolled back the task and any next-job enqueue, so
+		// nothing was persisted. Surface this as a normal skip — the job queue
+		// should not retry it (the schedule is no longer wanting this fire).
+		if (err instanceof ScheduleSupersededError) {
+			log.debug('task-schedule-fire: skipping — superseded mid-flight', {
+				scheduleId,
+				jobId: job.id,
+			});
+			return {
+				scheduleId,
+				taskId: null,
+				skipped: true,
+				skipReason: 'job_superseded',
+				nextRunAt: null,
+			};
+		}
 		log.error('task-schedule-fire: transaction failed', {
 			scheduleId,
 			error: err instanceof Error ? err.message : err,

--- a/packages/daemon/src/lib/job-handlers/task-schedule-fire.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/task-schedule-fire.handler.ts
@@ -86,6 +86,14 @@ export async function handleTaskScheduleFire(
 	// Without this, a non-active space would still spawn fresh tasks every cron
 	// tick, violating the space lifecycle contract (paused/stopped must prevent
 	// new scheduled work).
+	//
+	// We don't just bail here: if we leave the schedule with `pendingJobId`
+	// pointing at *this* (now-consumed) job, the next cron tick never lands
+	// because the schedule has no future job linked. Instead we advance the
+	// schedule forward — for cron, we recompute `nextRunAt` and enqueue a fresh
+	// fire job; for `at`, we leave the schedule "unwired" by clearing
+	// pendingJobId so SpaceManager.resumeSpace/startSpace can recover it. The
+	// space-resume path then re-seeds any missed schedules.
 	const space = spaceRepo.getSpace(schedule.spaceId);
 	if (!space || space.status !== 'active' || space.paused || space.stopped) {
 		log.debug('task-schedule-fire: skipping schedule for non-active space', {
@@ -95,6 +103,36 @@ export async function handleTaskScheduleFire(
 			paused: space?.paused,
 			stopped: space?.stopped,
 		});
+
+		// Clear pendingJobId / advance nextRunAt so the space-resume reseed has
+		// a clean handle. Do this in a CAS transaction so a concurrent
+		// pause/delete/reschedule mid-handler still wins.
+		try {
+			db.transaction(() => {
+				const fresh = scheduleRepo.getById(scheduleId);
+				if (!fresh || fresh.status !== 'active') return;
+				if (fresh.pendingJobId !== job.id) return; // someone else moved on
+
+				if (fresh.triggerType === 'cron' && fresh.cronExpression) {
+					const next = getNextRunAt(fresh.cronExpression, fresh.timezone, Date.now());
+					// On cron-config errors (null next), just clear the pending linkage so
+					// resume / operator-fix can re-seed; the schedule stays active.
+					scheduleRepo.update(scheduleId, { nextRunAt: next ?? undefined });
+					scheduleRepo.updatePendingJobId(scheduleId, null);
+				} else {
+					// `at` schedule — clear pending so resume re-evaluates whether the
+					// deadline has passed and either completes or re-enqueues.
+					scheduleRepo.updatePendingJobId(scheduleId, null);
+				}
+			})();
+		} catch (err) {
+			log.error('task-schedule-fire: clearing pending linkage failed', {
+				scheduleId,
+				error: err instanceof Error ? err.message : err,
+			});
+			// Non-fatal — the next space-resume reseed will pick this up.
+		}
+
 		return {
 			scheduleId,
 			taskId: null,

--- a/packages/daemon/src/lib/job-handlers/task-schedule-fire.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/task-schedule-fire.handler.ts
@@ -1,0 +1,115 @@
+/**
+ * Job handler for taskSchedule.fire queue.
+ *
+ * When a schedule fires:
+ *   1. Look up the schedule — skip if not 'active'.
+ *   2. Create a SpaceTask using the template fields.
+ *   3. If cron: compute nextRunAt, re-enqueue self, update schedule.
+ *   4. If at: mark schedule 'completed'.
+ *
+ * Uses the self-scheduling pattern from github-poll.handler.ts.
+ */
+
+import { TASK_SCHEDULE_FIRE } from '../job-queue-constants';
+import { Logger } from '../logger';
+import { getNextRunAt } from '../space/schedule/cron-utils';
+import type { TaskScheduleRepository } from '../../storage/repositories/task-schedule-repository';
+import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
+import type { SpaceTaskManager } from '../space/managers/space-task-manager';
+
+const log = new Logger('task-schedule-fire-handler');
+
+export interface TaskScheduleFirePayload extends Record<string, unknown> {
+	scheduleId: string;
+}
+
+export interface TaskScheduleFireResult extends Record<string, unknown> {
+	scheduleId: string;
+	taskId: string | null;
+	skipped: boolean;
+	nextRunAt: number | null;
+}
+
+export interface TaskScheduleFireHandlerDeps {
+	scheduleRepo: TaskScheduleRepository;
+	jobQueue: JobQueueRepository;
+	/** Factory that returns a SpaceTaskManager bound to a given spaceId. */
+	taskManagerFactory: (spaceId: string) => SpaceTaskManager;
+}
+
+export async function handleTaskScheduleFire(
+	payload: TaskScheduleFirePayload,
+	deps: TaskScheduleFireHandlerDeps
+): Promise<TaskScheduleFireResult> {
+	const { scheduleId } = payload;
+	const { scheduleRepo, jobQueue, taskManagerFactory } = deps;
+
+	const schedule = scheduleRepo.getById(scheduleId);
+
+	// Guard: skip if schedule doesn't exist or is no longer active.
+	if (!schedule || schedule.status !== 'active') {
+		log.debug('task-schedule-fire: skipping inactive/missing schedule', { scheduleId });
+		return { scheduleId, taskId: null, skipped: true, nextRunAt: null };
+	}
+
+	// 1. Create the SpaceTask from the template.
+	let taskId: string | null = null;
+	try {
+		const taskManager = taskManagerFactory(schedule.spaceId);
+		const task = await taskManager.createTask({
+			title: schedule.title,
+			description: schedule.description,
+			priority: schedule.priority,
+			preferredWorkflowId: schedule.preferredWorkflowId,
+			labels: schedule.labels,
+			createdByTaskScheduleId: schedule.id,
+		});
+		taskId = task.id;
+		log.debug('task-schedule-fire: created task', { scheduleId, taskId });
+	} catch (err) {
+		log.error('task-schedule-fire: failed to create task', {
+			scheduleId,
+			error: err instanceof Error ? err.message : err,
+		});
+		// Re-throw so the job queue can retry with backoff.
+		throw err;
+	}
+
+	const now = Date.now();
+
+	// 2. Reschedule (cron) or complete (at).
+	if (schedule.triggerType === 'cron' && schedule.cronExpression) {
+		const nextRunAt = getNextRunAt(schedule.cronExpression, schedule.timezone, now);
+
+		let pendingJobId: string | null = null;
+		if (nextRunAt !== null) {
+			const nextJob = jobQueue.enqueue({
+				queue: TASK_SCHEDULE_FIRE,
+				payload: { scheduleId } satisfies TaskScheduleFirePayload,
+				runAt: nextRunAt,
+			});
+			pendingJobId = nextJob.id;
+		}
+
+		scheduleRepo.updateAfterFire(scheduleId, {
+			lastCreatedTaskId: taskId!,
+			lastRunAt: now,
+			nextRunAt: nextRunAt ?? null,
+			status: 'active',
+			pendingJobId,
+		});
+
+		return { scheduleId, taskId, skipped: false, nextRunAt };
+	}
+
+	// One-shot ('at'): mark as completed.
+	scheduleRepo.updateAfterFire(scheduleId, {
+		lastCreatedTaskId: taskId!,
+		lastRunAt: now,
+		nextRunAt: null,
+		status: 'completed',
+		pendingJobId: null,
+	});
+
+	return { scheduleId, taskId, skipped: false, nextRunAt: null };
+}

--- a/packages/daemon/src/lib/job-handlers/task-schedule-fire.handler.ts
+++ b/packages/daemon/src/lib/job-handlers/task-schedule-fire.handler.ts
@@ -2,20 +2,28 @@
  * Job handler for taskSchedule.fire queue.
  *
  * When a schedule fires:
- *   1. Look up the schedule — skip if not 'active'.
- *   2. Create a SpaceTask using the template fields.
- *   3. If cron: compute nextRunAt, re-enqueue self, update schedule.
- *   4. If at: mark schedule 'completed'.
+ *   1. Look up the schedule — skip if not 'active', missing, or its host space
+ *      is archived/missing.
+ *   2. Idempotency check — skip if `schedule.pendingJobId` no longer matches
+ *      this job (a previous attempt already advanced the schedule).
+ *   3. Atomically: create a SpaceTask, compute the next fire time, enqueue the
+ *      next fire job (cron) and write all of `lastCreatedTaskId`, `lastRunAt`,
+ *      `nextRunAt`, `pendingJobId`, `status` in one SQLite transaction. If any
+ *      step throws, the rollback ensures we never leave a half-fired schedule
+ *      (e.g. task created but pendingJobId not advanced) — the queue's retry
+ *      will then re-run the handler cleanly.
  *
  * Uses the self-scheduling pattern from github-poll.handler.ts.
  */
 
+import type { Database as BunDatabase } from 'bun:sqlite';
 import { TASK_SCHEDULE_FIRE } from '../job-queue-constants';
 import { Logger } from '../logger';
 import { getNextRunAt } from '../space/schedule/cron-utils';
 import type { TaskScheduleRepository } from '../../storage/repositories/task-schedule-repository';
-import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
-import type { SpaceTaskManager } from '../space/managers/space-task-manager';
+import type { JobQueueRepository, Job } from '../../storage/repositories/job-queue-repository';
+import type { SpaceRepository } from '../../storage/repositories/space-repository';
+import type { SpaceTaskRepository } from '../../storage/repositories/space-task-repository';
 
 const log = new Logger('task-schedule-fire-handler');
 
@@ -27,89 +35,147 @@ export interface TaskScheduleFireResult extends Record<string, unknown> {
 	scheduleId: string;
 	taskId: string | null;
 	skipped: boolean;
+	skipReason?: string;
 	nextRunAt: number | null;
 }
 
 export interface TaskScheduleFireHandlerDeps {
+	db: BunDatabase;
 	scheduleRepo: TaskScheduleRepository;
 	jobQueue: JobQueueRepository;
-	/** Factory that returns a SpaceTaskManager bound to a given spaceId. */
-	taskManagerFactory: (spaceId: string) => SpaceTaskManager;
+	spaceRepo: SpaceRepository;
+	taskRepo: SpaceTaskRepository;
 }
 
 export async function handleTaskScheduleFire(
-	payload: TaskScheduleFirePayload,
+	job: Job,
 	deps: TaskScheduleFireHandlerDeps
 ): Promise<TaskScheduleFireResult> {
-	const { scheduleId } = payload;
-	const { scheduleRepo, jobQueue, taskManagerFactory } = deps;
+	const { scheduleId } = job.payload as TaskScheduleFirePayload;
+	const { db, scheduleRepo, jobQueue, spaceRepo, taskRepo } = deps;
 
 	const schedule = scheduleRepo.getById(scheduleId);
 
 	// Guard: skip if schedule doesn't exist or is no longer active.
 	if (!schedule || schedule.status !== 'active') {
 		log.debug('task-schedule-fire: skipping inactive/missing schedule', { scheduleId });
-		return { scheduleId, taskId: null, skipped: true, nextRunAt: null };
+		return {
+			scheduleId,
+			taskId: null,
+			skipped: true,
+			skipReason: 'inactive_or_missing',
+			nextRunAt: null,
+		};
 	}
 
-	// 1. Create the SpaceTask from the template.
-	let taskId: string | null = null;
-	try {
-		const taskManager = taskManagerFactory(schedule.spaceId);
-		const task = await taskManager.createTask({
-			title: schedule.title,
-			description: schedule.description,
-			priority: schedule.priority,
-			preferredWorkflowId: schedule.preferredWorkflowId,
-			labels: schedule.labels,
-			createdByTaskScheduleId: schedule.id,
-		});
-		taskId = task.id;
-		log.debug('task-schedule-fire: created task', { scheduleId, taskId });
-	} catch (err) {
-		log.error('task-schedule-fire: failed to create task', {
+	// Guard: skip if the host space is archived or missing. Without this an
+	// archived space would still spawn fresh tasks every cron tick.
+	const space = spaceRepo.getSpace(schedule.spaceId);
+	if (!space || space.status !== 'active') {
+		log.debug('task-schedule-fire: skipping schedule for non-active space', {
 			scheduleId,
-			error: err instanceof Error ? err.message : err,
+			spaceId: schedule.spaceId,
+			spaceStatus: space?.status,
 		});
-		// Re-throw so the job queue can retry with backoff.
-		throw err;
+		return {
+			scheduleId,
+			taskId: null,
+			skipped: true,
+			skipReason: 'space_not_active',
+			nextRunAt: null,
+		};
+	}
+
+	// Idempotency fence: if `pendingJobId` no longer matches this job's id, a
+	// previous successful attempt already advanced the schedule (and recorded
+	// the task) — re-running here would create a duplicate. This catches the
+	// case where a transient post-success error caused the queue to retry, or
+	// where startup recovery re-seeded a job we ended up running too.
+	if (schedule.pendingJobId !== null && schedule.pendingJobId !== job.id) {
+		log.debug('task-schedule-fire: skipping — pendingJobId moved past this job', {
+			scheduleId,
+			jobId: job.id,
+			currentPendingJobId: schedule.pendingJobId,
+		});
+		return {
+			scheduleId,
+			taskId: schedule.lastCreatedTaskId,
+			skipped: true,
+			skipReason: 'job_superseded',
+			nextRunAt: schedule.nextRunAt,
+		};
 	}
 
 	const now = Date.now();
 
-	// 2. Reschedule (cron) or complete (at).
-	if (schedule.triggerType === 'cron' && schedule.cronExpression) {
-		const nextRunAt = getNextRunAt(schedule.cronExpression, schedule.timezone, now);
+	// Atomically create the task, compute the next fire, enqueue it, and update
+	// the schedule's bookkeeping fields. SpaceTaskRepository.createTask already
+	// runs synchronously against `db`, so wrapping the whole sequence in a
+	// single SQLite transaction is safe — and crucial: a partial failure (e.g.
+	// task inserted but no `lastRunAt` recorded) would otherwise allow the
+	// retry to spawn a duplicate task.
+	let taskId: string | null = null;
+	let nextRunAt: number | null = null;
 
-		let pendingJobId: string | null = null;
-		if (nextRunAt !== null) {
-			const nextJob = jobQueue.enqueue({
-				queue: TASK_SCHEDULE_FIRE,
-				payload: { scheduleId } satisfies TaskScheduleFirePayload,
-				runAt: nextRunAt,
+	try {
+		const result = db.transaction(() => {
+			const task = taskRepo.createTask({
+				spaceId: schedule.spaceId,
+				title: schedule.title,
+				description: schedule.description,
+				priority: schedule.priority,
+				preferredWorkflowId: schedule.preferredWorkflowId,
+				labels: schedule.labels,
+				createdByTaskScheduleId: schedule.id,
 			});
-			pendingJobId = nextJob.id;
-		}
 
-		scheduleRepo.updateAfterFire(scheduleId, {
-			lastCreatedTaskId: taskId!,
-			lastRunAt: now,
-			nextRunAt: nextRunAt ?? null,
-			status: 'active',
-			pendingJobId,
+			let computedNextRunAt: number | null = null;
+			let pendingJobId: string | null = null;
+			let nextStatus: 'active' | 'completed' = 'completed';
+
+			if (schedule.triggerType === 'cron' && schedule.cronExpression) {
+				computedNextRunAt = getNextRunAt(schedule.cronExpression, schedule.timezone, now);
+
+				if (computedNextRunAt !== null) {
+					const nextJob = jobQueue.enqueue({
+						queue: TASK_SCHEDULE_FIRE,
+						payload: { scheduleId } satisfies TaskScheduleFirePayload,
+						runAt: computedNextRunAt,
+					});
+					pendingJobId = nextJob.id;
+					nextStatus = 'active';
+				}
+			}
+
+			scheduleRepo.updateAfterFire(scheduleId, {
+				lastCreatedTaskId: task.id,
+				lastRunAt: now,
+				nextRunAt: computedNextRunAt,
+				status: nextStatus,
+				pendingJobId,
+			});
+
+			return { taskId: task.id, nextRunAt: computedNextRunAt };
+		})();
+
+		taskId = result.taskId;
+		nextRunAt = result.nextRunAt;
+		log.debug('task-schedule-fire: created task', { scheduleId, taskId, nextRunAt });
+	} catch (err) {
+		log.error('task-schedule-fire: transaction failed', {
+			scheduleId,
+			error: err instanceof Error ? err.message : err,
 		});
-
-		return { scheduleId, taskId, skipped: false, nextRunAt };
+		// Re-throw so the job queue retries with backoff. The transaction
+		// rolled back so no half-state was persisted; the next attempt sees
+		// the same `pendingJobId === job.id` and proceeds cleanly.
+		throw err;
 	}
 
-	// One-shot ('at'): mark as completed.
-	scheduleRepo.updateAfterFire(scheduleId, {
-		lastCreatedTaskId: taskId!,
-		lastRunAt: now,
-		nextRunAt: null,
-		status: 'completed',
-		pendingJobId: null,
-	});
+	if (taskId === null) {
+		// Defensive: the transaction body always assigns taskId on the success path.
+		throw new Error(`task-schedule-fire: taskId unexpectedly null for ${scheduleId}`);
+	}
 
-	return { scheduleId, taskId, skipped: false, nextRunAt: null };
+	return { scheduleId, taskId, skipped: false, nextRunAt };
 }

--- a/packages/daemon/src/lib/job-queue-constants.ts
+++ b/packages/daemon/src/lib/job-queue-constants.ts
@@ -9,6 +9,9 @@ export const ROOM_TICK = 'room.tick';
 export const JOB_QUEUE_CLEANUP = 'job_queue.cleanup';
 export const SKILL_VALIDATE = 'skill.validate';
 
+// ─── Task schedule ────────────────────────────────────────────────────────────
+export const TASK_SCHEDULE_FIRE = 'taskSchedule.fire';
+
 // ─── Space workflow run artifact sync queues ──────────────────────────────────
 // Background jobs that populate the workflow_run_artifact_cache table with
 // git-derived data (gate artifacts, commit log, per-file diffs). Running these

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -93,6 +93,8 @@ import { NeoActivityLogger } from '../neo/activity-logger';
 import { PendingActionStore } from '../neo/security-tier';
 import type { NeoToolsConfig } from '../neo/tools/neo-query-tools';
 import type { NeoActionToolsConfig, NeoWorkflowRun } from '../neo/tools/neo-action-tools';
+import { TaskScheduleRepository } from '../../storage/repositories/task-schedule-repository';
+import { setupTaskScheduleHandlers } from './task-schedule-handlers';
 
 export interface RPCHandlerDependencies {
 	messageHub: MessageHub;
@@ -305,6 +307,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	const artifactCacheRepo = new WorkflowRunArtifactCacheRepository(deps.db.getDatabase());
 	const channelCycleRepo = new ChannelCycleRepository(deps.db.getDatabase());
 	const pendingMessageRepo = new PendingAgentMessageRepository(deps.db.getDatabase());
+	const taskScheduleRepo = new TaskScheduleRepository(deps.db.getDatabase());
 
 	// Space workflow manager — created early so space.create can call seedBuiltInWorkflows
 	const spaceWorkflowRepo = new SpaceWorkflowRepository(deps.db.getDatabase());
@@ -417,6 +420,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		daemonHub: deps.daemonHub,
 		artifactRepo,
 		pendingMessageRepo,
+		taskScheduleRepo,
+		jobQueue: deps.jobQueue,
 	});
 
 	// Session handlers — registered here (after spaceRuntimeService is built) so
@@ -441,6 +446,13 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		deps.daemonHub,
 		spaceRuntimeService
 	);
+
+	// Task schedule handlers — create/list/get/update/pause/resume/delete schedules.
+	setupTaskScheduleHandlers(deps.messageHub, {
+		scheduleRepo: taskScheduleRepo,
+		jobQueue: deps.jobQueue,
+		spaceManager: deps.spaceManager,
+	});
 
 	// Register Space RPC handlers now that spaceRuntimeService exists.
 	// spaceRuntimeService is passed so space.create can call setupSpaceAgentSession()
@@ -516,6 +528,8 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		artifactRepo,
 		pendingMessageRepo,
 		spaceAgentInjector,
+		jobQueue: deps.jobQueue,
+		taskScheduleRepo,
 	});
 
 	// Wire TaskAgentManager into the SpaceRuntime so the tick loop can spawn

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -320,6 +320,20 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		jobQueue: deps.jobQueue,
 	});
 
+	// When a space is resumed/started, re-seed any of its active schedules
+	// whose fire jobs were skipped during the inactive window so cron/at
+	// schedules pick up forward progress without waiting for daemon restart.
+	deps.spaceManager.onSpaceResumedRegister((spaceId) => {
+		try {
+			const recovered = scheduleService.recoverSchedulesForSpace(spaceId);
+			if (recovered > 0) {
+				log.info('recovered schedules after space resume', { spaceId, recovered });
+			}
+		} catch (err) {
+			log.error('schedule recovery after space resume failed (non-fatal)', err);
+		}
+	});
+
 	// Space workflow manager — created early so space.create can call seedBuiltInWorkflows
 	const spaceWorkflowRepo = new SpaceWorkflowRepository(deps.db.getDatabase());
 	const spaceAgentRepo = new SpaceAgentRepository(deps.db.getDatabase());

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -94,6 +94,7 @@ import { PendingActionStore } from '../neo/security-tier';
 import type { NeoToolsConfig } from '../neo/tools/neo-query-tools';
 import type { NeoActionToolsConfig, NeoWorkflowRun } from '../neo/tools/neo-action-tools';
 import { TaskScheduleRepository } from '../../storage/repositories/task-schedule-repository';
+import { SpaceRepository } from '../../storage/repositories/space-repository';
 import { setupTaskScheduleHandlers } from './task-schedule-handlers';
 import { ScheduleService } from '../space/schedule/schedule-service';
 
@@ -309,6 +310,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	const channelCycleRepo = new ChannelCycleRepository(deps.db.getDatabase());
 	const pendingMessageRepo = new PendingAgentMessageRepository(deps.db.getDatabase());
 	const taskScheduleRepo = new TaskScheduleRepository(deps.db.getDatabase());
+	const spaceRepo = new SpaceRepository(deps.db.getDatabase());
 
 	// Centralised TaskSchedule lifecycle service — used by both the RPC
 	// handlers (`taskSchedule.*`) and the agent-facing MCP tools so validation,
@@ -318,6 +320,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		db: deps.db.getDatabase(),
 		scheduleRepo: taskScheduleRepo,
 		jobQueue: deps.jobQueue,
+		spaceRepo,
 	});
 
 	// When a space is resumed/started, re-seed any of its active schedules

--- a/packages/daemon/src/lib/rpc-handlers/index.ts
+++ b/packages/daemon/src/lib/rpc-handlers/index.ts
@@ -95,6 +95,7 @@ import type { NeoToolsConfig } from '../neo/tools/neo-query-tools';
 import type { NeoActionToolsConfig, NeoWorkflowRun } from '../neo/tools/neo-action-tools';
 import { TaskScheduleRepository } from '../../storage/repositories/task-schedule-repository';
 import { setupTaskScheduleHandlers } from './task-schedule-handlers';
+import { ScheduleService } from '../space/schedule/schedule-service';
 
 export interface RPCHandlerDependencies {
 	messageHub: MessageHub;
@@ -309,6 +310,16 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 	const pendingMessageRepo = new PendingAgentMessageRepository(deps.db.getDatabase());
 	const taskScheduleRepo = new TaskScheduleRepository(deps.db.getDatabase());
 
+	// Centralised TaskSchedule lifecycle service — used by both the RPC
+	// handlers (`taskSchedule.*`) and the agent-facing MCP tools so validation,
+	// the atomic create+enqueue transaction, and pendingJobId bookkeeping live
+	// in exactly one place.
+	const scheduleService = new ScheduleService({
+		db: deps.db.getDatabase(),
+		scheduleRepo: taskScheduleRepo,
+		jobQueue: deps.jobQueue,
+	});
+
 	// Space workflow manager — created early so space.create can call seedBuiltInWorkflows
 	const spaceWorkflowRepo = new SpaceWorkflowRepository(deps.db.getDatabase());
 	const spaceAgentRepo = new SpaceAgentRepository(deps.db.getDatabase());
@@ -420,8 +431,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		daemonHub: deps.daemonHub,
 		artifactRepo,
 		pendingMessageRepo,
-		taskScheduleRepo,
-		jobQueue: deps.jobQueue,
+		scheduleService,
 	});
 
 	// Session handlers — registered here (after spaceRuntimeService is built) so
@@ -449,8 +459,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 
 	// Task schedule handlers — create/list/get/update/pause/resume/delete schedules.
 	setupTaskScheduleHandlers(deps.messageHub, {
-		scheduleRepo: taskScheduleRepo,
-		jobQueue: deps.jobQueue,
+		scheduleService,
 		spaceManager: deps.spaceManager,
 	});
 
@@ -528,8 +537,7 @@ export function setupRPCHandlers(deps: RPCHandlerDependencies): RPCHandlerSetupR
 		artifactRepo,
 		pendingMessageRepo,
 		spaceAgentInjector,
-		jobQueue: deps.jobQueue,
-		taskScheduleRepo,
+		scheduleService,
 	});
 
 	// Wire TaskAgentManager into the SpaceRuntime so the tick loop can spawn

--- a/packages/daemon/src/lib/rpc-handlers/task-schedule-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-schedule-handlers.ts
@@ -38,6 +38,22 @@ export function setupTaskScheduleHandlers(
 ): void {
 	const { scheduleService, spaceManager } = deps;
 
+	// Helper: load a schedule and verify it belongs to the supplied spaceId.
+	// All mutating handlers go through this so cross-space mutation by ID is
+	// not possible — even for callers holding a stale schedule ID from another
+	// space.
+	function requireScheduleInSpace(scheduleId: string, spaceId: string) {
+		if (!scheduleId) throw new Error('scheduleId is required');
+		if (!spaceId) throw new Error('spaceId is required');
+		const schedule = scheduleService.getSchedule(scheduleId);
+		if (!schedule || schedule.spaceId !== spaceId) {
+			// Use the same error message regardless of cause so callers cannot
+			// probe for the existence of schedules in spaces they don't own.
+			throw new Error(`Schedule not found: ${scheduleId}`);
+		}
+		return schedule;
+	}
+
 	// ─── taskSchedule.create ───────────────────────────────────────────────────
 
 	messageHub.onRequest('taskSchedule.create', async (data) => {
@@ -81,11 +97,8 @@ export function setupTaskScheduleHandlers(
 	// ─── taskSchedule.get ──────────────────────────────────────────────────────
 
 	messageHub.onRequest('taskSchedule.get', async (data) => {
-		const params = data as { scheduleId: string };
-		if (!params.scheduleId) throw new Error('scheduleId is required');
-
-		const schedule = scheduleService.getSchedule(params.scheduleId);
-		if (!schedule) throw new Error(`Schedule not found: ${params.scheduleId}`);
+		const params = data as { scheduleId: string; spaceId: string };
+		const schedule = requireScheduleInSpace(params.scheduleId, params.spaceId);
 		return { schedule };
 	});
 
@@ -94,6 +107,7 @@ export function setupTaskScheduleHandlers(
 	messageHub.onRequest('taskSchedule.update', async (data) => {
 		const params = data as {
 			scheduleId: string;
+			spaceId: string;
 			title?: string;
 			description?: string;
 			priority?: SpaceTaskPriority;
@@ -104,9 +118,9 @@ export function setupTaskScheduleHandlers(
 			timezone?: string;
 		};
 
-		if (!params.scheduleId) throw new Error('scheduleId is required');
-
-		const { scheduleId, ...input } = params;
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		const _existing = requireScheduleInSpace(params.scheduleId, params.spaceId);
+		const { scheduleId, spaceId: _spaceId, ...input } = params;
 		const schedule = scheduleService.updateSchedule(scheduleId, input);
 		return { schedule };
 	});
@@ -114,9 +128,8 @@ export function setupTaskScheduleHandlers(
 	// ─── taskSchedule.pause ────────────────────────────────────────────────────
 
 	messageHub.onRequest('taskSchedule.pause', async (data) => {
-		const params = data as { scheduleId: string };
-		if (!params.scheduleId) throw new Error('scheduleId is required');
-
+		const params = data as { scheduleId: string; spaceId: string };
+		requireScheduleInSpace(params.scheduleId, params.spaceId);
 		const schedule = scheduleService.pauseSchedule(params.scheduleId);
 		return { schedule };
 	});
@@ -124,9 +137,8 @@ export function setupTaskScheduleHandlers(
 	// ─── taskSchedule.resume ───────────────────────────────────────────────────
 
 	messageHub.onRequest('taskSchedule.resume', async (data) => {
-		const params = data as { scheduleId: string };
-		if (!params.scheduleId) throw new Error('scheduleId is required');
-
+		const params = data as { scheduleId: string; spaceId: string };
+		requireScheduleInSpace(params.scheduleId, params.spaceId);
 		const schedule = scheduleService.resumeSchedule(params.scheduleId);
 		return { schedule };
 	});
@@ -134,9 +146,8 @@ export function setupTaskScheduleHandlers(
 	// ─── taskSchedule.delete ───────────────────────────────────────────────────
 
 	messageHub.onRequest('taskSchedule.delete', async (data) => {
-		const params = data as { scheduleId: string };
-		if (!params.scheduleId) throw new Error('scheduleId is required');
-
+		const params = data as { scheduleId: string; spaceId: string };
+		requireScheduleInSpace(params.scheduleId, params.spaceId);
 		const ok = scheduleService.deleteSchedule(params.scheduleId);
 		if (!ok) throw new Error(`Schedule not found: ${params.scheduleId}`);
 		log.debug('taskSchedule.delete', { scheduleId: params.scheduleId });

--- a/packages/daemon/src/lib/rpc-handlers/task-schedule-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-schedule-handlers.ts
@@ -1,8 +1,12 @@
 /**
  * Task Schedule RPC Handlers
  *
+ * Thin wrappers over `ScheduleService`. The service holds the validation,
+ * atomic create+enqueue, and reschedule logic so the RPC handlers and the
+ * agent-facing MCP tools both call into one place.
+ *
  * Exposes CRUD operations for TaskSchedule over the MessageHub:
- *   taskSchedule.create  — create schedule + enqueue first job
+ *   taskSchedule.create  — create schedule + enqueue first job (atomic)
  *   taskSchedule.list    — list schedules for a space
  *   taskSchedule.get     — get schedule by id
  *   taskSchedule.update  — edit template/cron (cancel old job, enqueue new)
@@ -18,18 +22,13 @@ import type {
 	SpaceTaskPriority,
 } from '@neokai/shared';
 import { Logger } from '../logger';
-import { isValidCronExpression, getNextRunAt } from '../space/schedule/cron-utils';
-import { TASK_SCHEDULE_FIRE } from '../job-queue-constants';
-import type { TaskScheduleRepository } from '../../storage/repositories/task-schedule-repository';
-import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
+import type { ScheduleService } from '../space/schedule/schedule-service';
 import type { SpaceManager } from '../space/managers/space-manager';
-import type { TaskScheduleFirePayload } from '../job-handlers/task-schedule-fire.handler';
 
 const log = new Logger('task-schedule-handlers');
 
 export interface TaskScheduleHandlerDeps {
-	scheduleRepo: TaskScheduleRepository;
-	jobQueue: JobQueueRepository;
+	scheduleService: ScheduleService;
 	spaceManager: SpaceManager;
 }
 
@@ -37,7 +36,7 @@ export function setupTaskScheduleHandlers(
 	messageHub: MessageHub,
 	deps: TaskScheduleHandlerDeps
 ): void {
-	const { scheduleRepo, jobQueue, spaceManager } = deps;
+	const { scheduleService, spaceManager } = deps;
 
 	// ─── taskSchedule.create ───────────────────────────────────────────────────
 
@@ -57,67 +56,16 @@ export function setupTaskScheduleHandlers(
 			createdBySession?: string | null;
 		};
 
-		if (!params.spaceId) throw new Error('spaceId is required');
-		if (!params.title?.trim()) throw new Error('title is required');
-		if (!params.triggerType) throw new Error('triggerType is required');
-
 		const space = await spaceManager.getSpace(params.spaceId);
 		if (!space) throw new Error(`Space not found: ${params.spaceId}`);
 
-		// Validate trigger config.
-		if (params.triggerType === 'cron') {
-			if (!params.cronExpression) throw new Error('cronExpression is required for cron triggers');
-			if (!isValidCronExpression(params.cronExpression)) {
-				throw new Error(`Invalid cron expression: ${params.cronExpression}`);
-			}
-		} else if (params.triggerType === 'at') {
-			if (!params.runAt) throw new Error('runAt is required for at triggers');
-			if (params.runAt < Date.now()) throw new Error('runAt must be in the future');
-		}
-
-		// Compute first nextRunAt.
-		const tz = params.timezone ?? 'UTC';
-		let nextRunAt: number | null;
-		if (params.triggerType === 'cron') {
-			nextRunAt = getNextRunAt(params.cronExpression!, tz);
-		} else {
-			nextRunAt = params.runAt!;
-		}
-
-		if (nextRunAt === null) {
-			throw new Error('Could not compute next run time from the provided expression');
-		}
-
-		// Create the schedule row.
-		const schedule = scheduleRepo.create({
-			spaceId: params.spaceId,
-			title: params.title,
-			description: params.description,
-			priority: params.priority,
-			preferredWorkflowId: params.preferredWorkflowId,
-			labels: params.labels,
-			triggerType: params.triggerType,
-			cronExpression: params.cronExpression,
-			runAt: params.runAt,
-			timezone: tz,
-			nextRunAt,
-			createdByAgent: params.createdByAgent,
-			createdBySession: params.createdBySession,
+		const schedule = scheduleService.createSchedule(params);
+		log.debug('taskSchedule.create', {
+			scheduleId: schedule.id,
+			nextRunAt: schedule.nextRunAt,
+			jobId: schedule.pendingJobId,
 		});
-
-		// Enqueue the first job.
-		const job = jobQueue.enqueue({
-			queue: TASK_SCHEDULE_FIRE,
-			payload: { scheduleId: schedule.id } satisfies TaskScheduleFirePayload,
-			runAt: nextRunAt,
-		});
-
-		// Store the pending job ID on the schedule.
-		scheduleRepo.updatePendingJobId(schedule.id, job.id);
-		const updated = scheduleRepo.getById(schedule.id);
-
-		log.debug('taskSchedule.create', { scheduleId: schedule.id, nextRunAt, jobId: job.id });
-		return { schedule: updated };
+		return { schedule };
 	});
 
 	// ─── taskSchedule.list ─────────────────────────────────────────────────────
@@ -126,7 +74,7 @@ export function setupTaskScheduleHandlers(
 		const params = data as { spaceId: string; status?: TaskScheduleStatus };
 		if (!params.spaceId) throw new Error('spaceId is required');
 
-		const schedules = scheduleRepo.listBySpace(params.spaceId, params.status);
+		const schedules = scheduleService.listSchedules(params.spaceId, params.status);
 		return { schedules };
 	});
 
@@ -136,7 +84,7 @@ export function setupTaskScheduleHandlers(
 		const params = data as { scheduleId: string };
 		if (!params.scheduleId) throw new Error('scheduleId is required');
 
-		const schedule = scheduleRepo.getById(params.scheduleId);
+		const schedule = scheduleService.getSchedule(params.scheduleId);
 		if (!schedule) throw new Error(`Schedule not found: ${params.scheduleId}`);
 		return { schedule };
 	});
@@ -158,70 +106,9 @@ export function setupTaskScheduleHandlers(
 
 		if (!params.scheduleId) throw new Error('scheduleId is required');
 
-		const schedule = scheduleRepo.getById(params.scheduleId);
-		if (!schedule) throw new Error(`Schedule not found: ${params.scheduleId}`);
-
-		// If updating cron or runAt, validate.
-		if (params.cronExpression !== undefined && params.cronExpression !== null) {
-			if (!isValidCronExpression(params.cronExpression)) {
-				throw new Error(`Invalid cron expression: ${params.cronExpression}`);
-			}
-		}
-		if (params.runAt !== undefined && params.runAt !== null) {
-			if (params.runAt < Date.now()) throw new Error('runAt must be in the future');
-		}
-
-		// Apply the update.
-		scheduleRepo.update(params.scheduleId, {
-			title: params.title,
-			description: params.description,
-			priority: params.priority,
-			preferredWorkflowId: params.preferredWorkflowId,
-			labels: params.labels,
-			cronExpression: params.cronExpression,
-			runAt: params.runAt,
-			timezone: params.timezone,
-		});
-
-		// If the schedule is active and timing changed, cancel the old job and re-enqueue.
-		const updatedSchedule = scheduleRepo.getById(params.scheduleId)!;
-		const timingChanged =
-			params.cronExpression !== undefined ||
-			params.runAt !== undefined ||
-			params.timezone !== undefined;
-
-		if (updatedSchedule.status === 'active' && timingChanged) {
-			// Cancel the old pending job if present.
-			if (updatedSchedule.pendingJobId) {
-				jobQueue.deleteJob(updatedSchedule.pendingJobId);
-			}
-
-			const tz = updatedSchedule.timezone;
-			let nextRunAt: number | null;
-			if (updatedSchedule.triggerType === 'cron' && updatedSchedule.cronExpression) {
-				nextRunAt = getNextRunAt(updatedSchedule.cronExpression, tz);
-			} else if (updatedSchedule.triggerType === 'at' && updatedSchedule.runAt) {
-				nextRunAt = updatedSchedule.runAt;
-			} else {
-				nextRunAt = null;
-			}
-
-			let pendingJobId: string | null = null;
-			if (nextRunAt !== null) {
-				const job = jobQueue.enqueue({
-					queue: TASK_SCHEDULE_FIRE,
-					payload: { scheduleId: params.scheduleId } satisfies TaskScheduleFirePayload,
-					runAt: nextRunAt,
-				});
-				pendingJobId = job.id;
-			}
-
-			scheduleRepo.update(params.scheduleId, { nextRunAt: nextRunAt ?? undefined });
-			scheduleRepo.updatePendingJobId(params.scheduleId, pendingJobId);
-		}
-
-		const final = scheduleRepo.getById(params.scheduleId);
-		return { schedule: final };
+		const { scheduleId, ...input } = params;
+		const schedule = scheduleService.updateSchedule(scheduleId, input);
+		return { schedule };
 	});
 
 	// ─── taskSchedule.pause ────────────────────────────────────────────────────
@@ -230,21 +117,8 @@ export function setupTaskScheduleHandlers(
 		const params = data as { scheduleId: string };
 		if (!params.scheduleId) throw new Error('scheduleId is required');
 
-		const schedule = scheduleRepo.getById(params.scheduleId);
-		if (!schedule) throw new Error(`Schedule not found: ${params.scheduleId}`);
-		if (schedule.status !== 'active') {
-			throw new Error(`Schedule is not active (current: ${schedule.status})`);
-		}
-
-		// Cancel the pending job.
-		if (schedule.pendingJobId) {
-			jobQueue.deleteJob(schedule.pendingJobId);
-		}
-		scheduleRepo.updatePendingJobId(params.scheduleId, null);
-		scheduleRepo.updateStatus(params.scheduleId, 'paused');
-
-		const updated = scheduleRepo.getById(params.scheduleId);
-		return { schedule: updated };
+		const schedule = scheduleService.pauseSchedule(params.scheduleId);
+		return { schedule };
 	});
 
 	// ─── taskSchedule.resume ───────────────────────────────────────────────────
@@ -253,46 +127,8 @@ export function setupTaskScheduleHandlers(
 		const params = data as { scheduleId: string };
 		if (!params.scheduleId) throw new Error('scheduleId is required');
 
-		const schedule = scheduleRepo.getById(params.scheduleId);
-		if (!schedule) throw new Error(`Schedule not found: ${params.scheduleId}`);
-		if (schedule.status !== 'paused') {
-			throw new Error(`Schedule is not paused (current: ${schedule.status})`);
-		}
-
-		// Compute next run.
-		const tz = schedule.timezone;
-		let nextRunAt: number | null;
-		if (schedule.triggerType === 'cron' && schedule.cronExpression) {
-			nextRunAt = getNextRunAt(schedule.cronExpression, tz);
-		} else if (schedule.triggerType === 'at' && schedule.runAt) {
-			nextRunAt = schedule.runAt < Date.now() ? null : schedule.runAt;
-		} else {
-			nextRunAt = null;
-		}
-
-		// If nextRunAt is null for an 'at' trigger that already passed, mark completed.
-		if (nextRunAt === null && schedule.triggerType === 'at') {
-			scheduleRepo.updateStatus(params.scheduleId, 'completed');
-			const updated = scheduleRepo.getById(params.scheduleId);
-			return { schedule: updated };
-		}
-
-		let pendingJobId: string | null = null;
-		if (nextRunAt !== null) {
-			const job = jobQueue.enqueue({
-				queue: TASK_SCHEDULE_FIRE,
-				payload: { scheduleId: params.scheduleId } satisfies TaskScheduleFirePayload,
-				runAt: nextRunAt,
-			});
-			pendingJobId = job.id;
-		}
-
-		scheduleRepo.update(params.scheduleId, { nextRunAt: nextRunAt ?? undefined });
-		scheduleRepo.updatePendingJobId(params.scheduleId, pendingJobId);
-		scheduleRepo.updateStatus(params.scheduleId, 'active');
-
-		const updated = scheduleRepo.getById(params.scheduleId);
-		return { schedule: updated };
+		const schedule = scheduleService.resumeSchedule(params.scheduleId);
+		return { schedule };
 	});
 
 	// ─── taskSchedule.delete ───────────────────────────────────────────────────
@@ -301,15 +137,8 @@ export function setupTaskScheduleHandlers(
 		const params = data as { scheduleId: string };
 		if (!params.scheduleId) throw new Error('scheduleId is required');
 
-		const schedule = scheduleRepo.getById(params.scheduleId);
-		if (!schedule) throw new Error(`Schedule not found: ${params.scheduleId}`);
-
-		// Cancel the pending job.
-		if (schedule.pendingJobId) {
-			jobQueue.deleteJob(schedule.pendingJobId);
-		}
-
-		scheduleRepo.delete(params.scheduleId);
+		const ok = scheduleService.deleteSchedule(params.scheduleId);
+		if (!ok) throw new Error(`Schedule not found: ${params.scheduleId}`);
 		log.debug('taskSchedule.delete', { scheduleId: params.scheduleId });
 		return { success: true };
 	});

--- a/packages/daemon/src/lib/rpc-handlers/task-schedule-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/task-schedule-handlers.ts
@@ -1,0 +1,316 @@
+/**
+ * Task Schedule RPC Handlers
+ *
+ * Exposes CRUD operations for TaskSchedule over the MessageHub:
+ *   taskSchedule.create  — create schedule + enqueue first job
+ *   taskSchedule.list    — list schedules for a space
+ *   taskSchedule.get     — get schedule by id
+ *   taskSchedule.update  — edit template/cron (cancel old job, enqueue new)
+ *   taskSchedule.pause   — cancel pending job, set paused
+ *   taskSchedule.resume  — re-enqueue, set active
+ *   taskSchedule.delete  — cancel pending job + delete schedule row
+ */
+
+import type { MessageHub } from '@neokai/shared';
+import type {
+	TaskScheduleStatus,
+	TaskScheduleTriggerType,
+	SpaceTaskPriority,
+} from '@neokai/shared';
+import { Logger } from '../logger';
+import { isValidCronExpression, getNextRunAt } from '../space/schedule/cron-utils';
+import { TASK_SCHEDULE_FIRE } from '../job-queue-constants';
+import type { TaskScheduleRepository } from '../../storage/repositories/task-schedule-repository';
+import type { JobQueueRepository } from '../../storage/repositories/job-queue-repository';
+import type { SpaceManager } from '../space/managers/space-manager';
+import type { TaskScheduleFirePayload } from '../job-handlers/task-schedule-fire.handler';
+
+const log = new Logger('task-schedule-handlers');
+
+export interface TaskScheduleHandlerDeps {
+	scheduleRepo: TaskScheduleRepository;
+	jobQueue: JobQueueRepository;
+	spaceManager: SpaceManager;
+}
+
+export function setupTaskScheduleHandlers(
+	messageHub: MessageHub,
+	deps: TaskScheduleHandlerDeps
+): void {
+	const { scheduleRepo, jobQueue, spaceManager } = deps;
+
+	// ─── taskSchedule.create ───────────────────────────────────────────────────
+
+	messageHub.onRequest('taskSchedule.create', async (data) => {
+		const params = data as {
+			spaceId: string;
+			title: string;
+			description?: string;
+			priority?: SpaceTaskPriority;
+			preferredWorkflowId?: string | null;
+			labels?: string[];
+			triggerType: TaskScheduleTriggerType;
+			cronExpression?: string | null;
+			runAt?: number | null;
+			timezone?: string;
+			createdByAgent?: string | null;
+			createdBySession?: string | null;
+		};
+
+		if (!params.spaceId) throw new Error('spaceId is required');
+		if (!params.title?.trim()) throw new Error('title is required');
+		if (!params.triggerType) throw new Error('triggerType is required');
+
+		const space = await spaceManager.getSpace(params.spaceId);
+		if (!space) throw new Error(`Space not found: ${params.spaceId}`);
+
+		// Validate trigger config.
+		if (params.triggerType === 'cron') {
+			if (!params.cronExpression) throw new Error('cronExpression is required for cron triggers');
+			if (!isValidCronExpression(params.cronExpression)) {
+				throw new Error(`Invalid cron expression: ${params.cronExpression}`);
+			}
+		} else if (params.triggerType === 'at') {
+			if (!params.runAt) throw new Error('runAt is required for at triggers');
+			if (params.runAt < Date.now()) throw new Error('runAt must be in the future');
+		}
+
+		// Compute first nextRunAt.
+		const tz = params.timezone ?? 'UTC';
+		let nextRunAt: number | null;
+		if (params.triggerType === 'cron') {
+			nextRunAt = getNextRunAt(params.cronExpression!, tz);
+		} else {
+			nextRunAt = params.runAt!;
+		}
+
+		if (nextRunAt === null) {
+			throw new Error('Could not compute next run time from the provided expression');
+		}
+
+		// Create the schedule row.
+		const schedule = scheduleRepo.create({
+			spaceId: params.spaceId,
+			title: params.title,
+			description: params.description,
+			priority: params.priority,
+			preferredWorkflowId: params.preferredWorkflowId,
+			labels: params.labels,
+			triggerType: params.triggerType,
+			cronExpression: params.cronExpression,
+			runAt: params.runAt,
+			timezone: tz,
+			nextRunAt,
+			createdByAgent: params.createdByAgent,
+			createdBySession: params.createdBySession,
+		});
+
+		// Enqueue the first job.
+		const job = jobQueue.enqueue({
+			queue: TASK_SCHEDULE_FIRE,
+			payload: { scheduleId: schedule.id } satisfies TaskScheduleFirePayload,
+			runAt: nextRunAt,
+		});
+
+		// Store the pending job ID on the schedule.
+		scheduleRepo.updatePendingJobId(schedule.id, job.id);
+		const updated = scheduleRepo.getById(schedule.id);
+
+		log.debug('taskSchedule.create', { scheduleId: schedule.id, nextRunAt, jobId: job.id });
+		return { schedule: updated };
+	});
+
+	// ─── taskSchedule.list ─────────────────────────────────────────────────────
+
+	messageHub.onRequest('taskSchedule.list', async (data) => {
+		const params = data as { spaceId: string; status?: TaskScheduleStatus };
+		if (!params.spaceId) throw new Error('spaceId is required');
+
+		const schedules = scheduleRepo.listBySpace(params.spaceId, params.status);
+		return { schedules };
+	});
+
+	// ─── taskSchedule.get ──────────────────────────────────────────────────────
+
+	messageHub.onRequest('taskSchedule.get', async (data) => {
+		const params = data as { scheduleId: string };
+		if (!params.scheduleId) throw new Error('scheduleId is required');
+
+		const schedule = scheduleRepo.getById(params.scheduleId);
+		if (!schedule) throw new Error(`Schedule not found: ${params.scheduleId}`);
+		return { schedule };
+	});
+
+	// ─── taskSchedule.update ───────────────────────────────────────────────────
+
+	messageHub.onRequest('taskSchedule.update', async (data) => {
+		const params = data as {
+			scheduleId: string;
+			title?: string;
+			description?: string;
+			priority?: SpaceTaskPriority;
+			preferredWorkflowId?: string | null;
+			labels?: string[];
+			cronExpression?: string | null;
+			runAt?: number | null;
+			timezone?: string;
+		};
+
+		if (!params.scheduleId) throw new Error('scheduleId is required');
+
+		const schedule = scheduleRepo.getById(params.scheduleId);
+		if (!schedule) throw new Error(`Schedule not found: ${params.scheduleId}`);
+
+		// If updating cron or runAt, validate.
+		if (params.cronExpression !== undefined && params.cronExpression !== null) {
+			if (!isValidCronExpression(params.cronExpression)) {
+				throw new Error(`Invalid cron expression: ${params.cronExpression}`);
+			}
+		}
+		if (params.runAt !== undefined && params.runAt !== null) {
+			if (params.runAt < Date.now()) throw new Error('runAt must be in the future');
+		}
+
+		// Apply the update.
+		scheduleRepo.update(params.scheduleId, {
+			title: params.title,
+			description: params.description,
+			priority: params.priority,
+			preferredWorkflowId: params.preferredWorkflowId,
+			labels: params.labels,
+			cronExpression: params.cronExpression,
+			runAt: params.runAt,
+			timezone: params.timezone,
+		});
+
+		// If the schedule is active and timing changed, cancel the old job and re-enqueue.
+		const updatedSchedule = scheduleRepo.getById(params.scheduleId)!;
+		const timingChanged =
+			params.cronExpression !== undefined ||
+			params.runAt !== undefined ||
+			params.timezone !== undefined;
+
+		if (updatedSchedule.status === 'active' && timingChanged) {
+			// Cancel the old pending job if present.
+			if (updatedSchedule.pendingJobId) {
+				jobQueue.deleteJob(updatedSchedule.pendingJobId);
+			}
+
+			const tz = updatedSchedule.timezone;
+			let nextRunAt: number | null;
+			if (updatedSchedule.triggerType === 'cron' && updatedSchedule.cronExpression) {
+				nextRunAt = getNextRunAt(updatedSchedule.cronExpression, tz);
+			} else if (updatedSchedule.triggerType === 'at' && updatedSchedule.runAt) {
+				nextRunAt = updatedSchedule.runAt;
+			} else {
+				nextRunAt = null;
+			}
+
+			let pendingJobId: string | null = null;
+			if (nextRunAt !== null) {
+				const job = jobQueue.enqueue({
+					queue: TASK_SCHEDULE_FIRE,
+					payload: { scheduleId: params.scheduleId } satisfies TaskScheduleFirePayload,
+					runAt: nextRunAt,
+				});
+				pendingJobId = job.id;
+			}
+
+			scheduleRepo.update(params.scheduleId, { nextRunAt: nextRunAt ?? undefined });
+			scheduleRepo.updatePendingJobId(params.scheduleId, pendingJobId);
+		}
+
+		const final = scheduleRepo.getById(params.scheduleId);
+		return { schedule: final };
+	});
+
+	// ─── taskSchedule.pause ────────────────────────────────────────────────────
+
+	messageHub.onRequest('taskSchedule.pause', async (data) => {
+		const params = data as { scheduleId: string };
+		if (!params.scheduleId) throw new Error('scheduleId is required');
+
+		const schedule = scheduleRepo.getById(params.scheduleId);
+		if (!schedule) throw new Error(`Schedule not found: ${params.scheduleId}`);
+		if (schedule.status !== 'active') {
+			throw new Error(`Schedule is not active (current: ${schedule.status})`);
+		}
+
+		// Cancel the pending job.
+		if (schedule.pendingJobId) {
+			jobQueue.deleteJob(schedule.pendingJobId);
+		}
+		scheduleRepo.updatePendingJobId(params.scheduleId, null);
+		scheduleRepo.updateStatus(params.scheduleId, 'paused');
+
+		const updated = scheduleRepo.getById(params.scheduleId);
+		return { schedule: updated };
+	});
+
+	// ─── taskSchedule.resume ───────────────────────────────────────────────────
+
+	messageHub.onRequest('taskSchedule.resume', async (data) => {
+		const params = data as { scheduleId: string };
+		if (!params.scheduleId) throw new Error('scheduleId is required');
+
+		const schedule = scheduleRepo.getById(params.scheduleId);
+		if (!schedule) throw new Error(`Schedule not found: ${params.scheduleId}`);
+		if (schedule.status !== 'paused') {
+			throw new Error(`Schedule is not paused (current: ${schedule.status})`);
+		}
+
+		// Compute next run.
+		const tz = schedule.timezone;
+		let nextRunAt: number | null;
+		if (schedule.triggerType === 'cron' && schedule.cronExpression) {
+			nextRunAt = getNextRunAt(schedule.cronExpression, tz);
+		} else if (schedule.triggerType === 'at' && schedule.runAt) {
+			nextRunAt = schedule.runAt < Date.now() ? null : schedule.runAt;
+		} else {
+			nextRunAt = null;
+		}
+
+		// If nextRunAt is null for an 'at' trigger that already passed, mark completed.
+		if (nextRunAt === null && schedule.triggerType === 'at') {
+			scheduleRepo.updateStatus(params.scheduleId, 'completed');
+			const updated = scheduleRepo.getById(params.scheduleId);
+			return { schedule: updated };
+		}
+
+		let pendingJobId: string | null = null;
+		if (nextRunAt !== null) {
+			const job = jobQueue.enqueue({
+				queue: TASK_SCHEDULE_FIRE,
+				payload: { scheduleId: params.scheduleId } satisfies TaskScheduleFirePayload,
+				runAt: nextRunAt,
+			});
+			pendingJobId = job.id;
+		}
+
+		scheduleRepo.update(params.scheduleId, { nextRunAt: nextRunAt ?? undefined });
+		scheduleRepo.updatePendingJobId(params.scheduleId, pendingJobId);
+		scheduleRepo.updateStatus(params.scheduleId, 'active');
+
+		const updated = scheduleRepo.getById(params.scheduleId);
+		return { schedule: updated };
+	});
+
+	// ─── taskSchedule.delete ───────────────────────────────────────────────────
+
+	messageHub.onRequest('taskSchedule.delete', async (data) => {
+		const params = data as { scheduleId: string };
+		if (!params.scheduleId) throw new Error('scheduleId is required');
+
+		const schedule = scheduleRepo.getById(params.scheduleId);
+		if (!schedule) throw new Error(`Schedule not found: ${params.scheduleId}`);
+
+		// Cancel the pending job.
+		if (schedule.pendingJobId) {
+			jobQueue.deleteJob(schedule.pendingJobId);
+		}
+
+		scheduleRepo.delete(params.scheduleId);
+		log.debug('taskSchedule.delete', { scheduleId: params.scheduleId });
+		return { success: true };
+	});
+}

--- a/packages/daemon/src/lib/space/managers/space-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-manager.ts
@@ -21,9 +21,20 @@ const log = new Logger('SpaceManager');
 
 export class SpaceManager {
 	private spaceRepo: SpaceRepository;
+	private onSpaceResumed: ((spaceId: string) => void) | null = null;
 
 	constructor(private db: BunDatabase) {
 		this.spaceRepo = new SpaceRepository(db);
+	}
+
+	/**
+	 * Register a callback invoked after a space transitions back to an active
+	 * runtime (resume from paused or start from stopped). Used to re-seed task
+	 * schedules whose fire jobs were skipped during the inactive window so they
+	 * can resume firing without a daemon restart.
+	 */
+	onSpaceResumedRegister(cb: (spaceId: string) => void): void {
+		this.onSpaceResumed = cb;
 	}
 
 	/**
@@ -119,6 +130,14 @@ export class SpaceManager {
 			throw new Error(`Failed to resume space: ${id}`);
 		}
 
+		// Re-seed any active schedules whose fire jobs were skipped while the
+		// space was paused so they pick up forward progress.
+		try {
+			this.onSpaceResumed?.(id);
+		} catch (err) {
+			log.error('resumeSpace: schedule recovery hook failed (non-fatal)', err);
+		}
+
 		return resumed;
 	}
 
@@ -153,6 +172,12 @@ export class SpaceManager {
 		const started = this.spaceRepo.startSpace(id);
 		if (!started) {
 			throw new Error(`Failed to start space: ${id}`);
+		}
+
+		try {
+			this.onSpaceResumed?.(id);
+		} catch (err) {
+			log.error('startSpace: schedule recovery hook failed (non-fatal)', err);
 		}
 
 		return started;

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -99,15 +99,11 @@ export interface SpaceRuntimeServiceConfig {
 	 */
 	selectWorkflowWithLlm?: SelectWorkflowWithLlm;
 	/**
-	 * Task schedule repository — passed to space-agent-tools so Space Agent
-	 * and member sessions can manage scheduled tasks. Optional.
+	 * Schedule service — shared business logic for task schedule lifecycle.
+	 * Passed to space-agent-tools so Space Agent and member sessions can manage
+	 * scheduled tasks via the same code path as the RPC handlers. Optional.
 	 */
-	taskScheduleRepo?: import('../../../storage/repositories/task-schedule-repository').TaskScheduleRepository;
-	/**
-	 * Job queue repository — paired with taskScheduleRepo for enqueuing fire jobs.
-	 * Optional.
-	 */
-	jobQueue?: import('../../../storage/repositories/job-queue-repository').JobQueueRepository;
+	scheduleService?: import('../schedule/schedule-service').ScheduleService;
 }
 
 export class SpaceRuntimeService {
@@ -681,8 +677,7 @@ export class SpaceRuntimeService {
 			// correct gating behavior for non-space-agent callers.
 			mySessionId: session.id,
 			auditLogRepo: this.auditLogRepo,
-			scheduleRepo: this.config.taskScheduleRepo,
-			jobQueue: this.config.jobQueue,
+			scheduleService: this.config.scheduleService,
 		});
 
 		const additional: Record<string, McpServerConfig> = {
@@ -776,8 +771,7 @@ export class SpaceRuntimeService {
 			myAgentName: 'space-agent',
 			mySessionId: spaceChatSessionId,
 			auditLogRepo: this.auditLogRepo,
-			scheduleRepo: this.config.taskScheduleRepo,
-			jobQueue: this.config.jobQueue,
+			scheduleService: this.config.scheduleService,
 		});
 
 		// Create a space-scoped db-query server if dbPath is configured.

--- a/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
+++ b/packages/daemon/src/lib/space/runtime/space-runtime-service.ts
@@ -98,6 +98,16 @@ export interface SpaceRuntimeServiceConfig {
 	 * calls the Claude Agent SDK. Tests should supply a deterministic stub.
 	 */
 	selectWorkflowWithLlm?: SelectWorkflowWithLlm;
+	/**
+	 * Task schedule repository — passed to space-agent-tools so Space Agent
+	 * and member sessions can manage scheduled tasks. Optional.
+	 */
+	taskScheduleRepo?: import('../../../storage/repositories/task-schedule-repository').TaskScheduleRepository;
+	/**
+	 * Job queue repository — paired with taskScheduleRepo for enqueuing fire jobs.
+	 * Optional.
+	 */
+	jobQueue?: import('../../../storage/repositories/job-queue-repository').JobQueueRepository;
 }
 
 export class SpaceRuntimeService {
@@ -671,6 +681,8 @@ export class SpaceRuntimeService {
 			// correct gating behavior for non-space-agent callers.
 			mySessionId: session.id,
 			auditLogRepo: this.auditLogRepo,
+			scheduleRepo: this.config.taskScheduleRepo,
+			jobQueue: this.config.jobQueue,
 		});
 
 		const additional: Record<string, McpServerConfig> = {
@@ -764,6 +776,8 @@ export class SpaceRuntimeService {
 			myAgentName: 'space-agent',
 			mySessionId: spaceChatSessionId,
 			auditLogRepo: this.auditLogRepo,
+			scheduleRepo: this.config.taskScheduleRepo,
+			jobQueue: this.config.jobQueue,
 		});
 
 		// Create a space-scoped db-query server if dbPath is configured.

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -75,6 +75,8 @@ import type { ChannelCycleRepository } from '../../../storage/repositories/chann
 import type { PendingAgentMessageRepository } from '../../../storage/repositories/pending-agent-message-repository';
 import type { ToolContinuationRecoveryRepository } from '../../../storage/repositories/tool-continuation-recovery-repository';
 import { McpAuditLogRepository } from '../../../storage/repositories/mcp-audit-log-repository';
+import type { JobQueueRepository } from '../../../storage/repositories/job-queue-repository';
+import type { TaskScheduleRepository } from '../../../storage/repositories/task-schedule-repository';
 import type { SpaceWorktreeManager } from '../managers/space-worktree-manager';
 import type { SubSessionMemberInfo } from '../tools/task-agent-tools';
 import { createTaskAgentMcpServer } from '../tools/task-agent-tools';
@@ -231,6 +233,17 @@ export interface TaskAgentManagerConfig {
 	 * Used for Task Agent → Space Agent escalation via `send_message`.
 	 */
 	spaceAgentInjector?: (spaceId: string, message: string) => Promise<void>;
+	/**
+	 * Job queue repository — injected into `space-agent-tools` so space agent sessions
+	 * can create scheduled tasks via `create_scheduled_task`.
+	 * Optional — when absent, schedule management tools are not registered.
+	 */
+	jobQueue?: JobQueueRepository;
+	/**
+	 * Task schedule repository — injected into `space-agent-tools` for schedule management.
+	 * Optional — when absent, schedule management tools are not registered.
+	 */
+	taskScheduleRepo?: TaskScheduleRepository;
 }
 
 // ---------------------------------------------------------------------------
@@ -4234,6 +4247,8 @@ export class TaskAgentManager {
 			myAgentName: ctx.agentName,
 			mySessionId: ctx.subSessionId,
 			auditLogRepo: this.auditLogRepo,
+			scheduleRepo: this.config.taskScheduleRepo,
+			jobQueue: this.config.jobQueue,
 			// Wire restore_node_agent so it is callable even when node-agent is
 			// missing. The closure captures the rebuild-time values of taskId,
 			// subSessionId, agentName, etc. which are stable for this session.

--- a/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
+++ b/packages/daemon/src/lib/space/runtime/task-agent-manager.ts
@@ -75,8 +75,6 @@ import type { ChannelCycleRepository } from '../../../storage/repositories/chann
 import type { PendingAgentMessageRepository } from '../../../storage/repositories/pending-agent-message-repository';
 import type { ToolContinuationRecoveryRepository } from '../../../storage/repositories/tool-continuation-recovery-repository';
 import { McpAuditLogRepository } from '../../../storage/repositories/mcp-audit-log-repository';
-import type { JobQueueRepository } from '../../../storage/repositories/job-queue-repository';
-import type { TaskScheduleRepository } from '../../../storage/repositories/task-schedule-repository';
 import type { SpaceWorktreeManager } from '../managers/space-worktree-manager';
 import type { SubSessionMemberInfo } from '../tools/task-agent-tools';
 import { createTaskAgentMcpServer } from '../tools/task-agent-tools';
@@ -234,16 +232,13 @@ export interface TaskAgentManagerConfig {
 	 */
 	spaceAgentInjector?: (spaceId: string, message: string) => Promise<void>;
 	/**
-	 * Job queue repository — injected into `space-agent-tools` so space agent sessions
-	 * can create scheduled tasks via `create_scheduled_task`.
-	 * Optional — when absent, schedule management tools are not registered.
+	 * Schedule service — shared business logic for managing task schedules.
+	 * Injected into `space-agent-tools` so task agent sessions can create /
+	 * pause / resume / delete schedules via the same code path as the RPC
+	 * handlers. Optional — when absent, schedule management tools are not
+	 * registered.
 	 */
-	jobQueue?: JobQueueRepository;
-	/**
-	 * Task schedule repository — injected into `space-agent-tools` for schedule management.
-	 * Optional — when absent, schedule management tools are not registered.
-	 */
-	taskScheduleRepo?: TaskScheduleRepository;
+	scheduleService?: import('../schedule/schedule-service').ScheduleService;
 }
 
 // ---------------------------------------------------------------------------
@@ -4247,8 +4242,7 @@ export class TaskAgentManager {
 			myAgentName: ctx.agentName,
 			mySessionId: ctx.subSessionId,
 			auditLogRepo: this.auditLogRepo,
-			scheduleRepo: this.config.taskScheduleRepo,
-			jobQueue: this.config.jobQueue,
+			scheduleService: this.config.scheduleService,
 			// Wire restore_node_agent so it is callable even when node-agent is
 			// missing. The closure captures the rebuild-time values of taskId,
 			// subSessionId, agentName, etc. which are stable for this session.

--- a/packages/daemon/src/lib/space/schedule/cron-utils.ts
+++ b/packages/daemon/src/lib/space/schedule/cron-utils.ts
@@ -1,0 +1,47 @@
+/**
+ * Cron utilities — thin wrapper around `croner` for schedule validation and next-run computation.
+ *
+ * Provides:
+ *   isValidCronExpression(expr)       — validate a cron expression (5 or 6 fields + named shortcuts)
+ *   getNextRunAt(expr, tz, afterMs?)  — compute the next fire timestamp (ms since epoch)
+ */
+
+import { Cron } from 'croner';
+
+/**
+ * Check whether a cron expression is syntactically valid.
+ *
+ * Accepts standard 5-field cron expressions and named shortcuts:
+ *   @hourly, @daily, @weekly, @monthly, @yearly / @annually
+ *
+ * Returns false for any expression that croner cannot parse.
+ */
+export function isValidCronExpression(expr: string): boolean {
+	try {
+		// dry-run with a sentinel date so croner parses but never actually schedules
+		new Cron(expr, { timezone: 'UTC', startAt: new Date(0), stopAt: new Date(0) });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Compute the next fire timestamp (ms since epoch) for a cron expression.
+ *
+ * @param expr     - cron expression (5-field or @shortcut)
+ * @param tz       - IANA timezone string (default: 'UTC')
+ * @param afterMs  - compute next run after this timestamp (default: now)
+ * @returns        - ms since epoch of next scheduled run, or null if the expression
+ *                   has no future occurrence (e.g. stopped)
+ */
+export function getNextRunAt(expr: string, tz = 'UTC', afterMs?: number): number | null {
+	const after = afterMs !== undefined ? new Date(afterMs) : new Date();
+	try {
+		const job = new Cron(expr, { timezone: tz, startAt: after });
+		const next = job.nextRun(after);
+		return next ? next.getTime() : null;
+	} catch {
+		return null;
+	}
+}

--- a/packages/daemon/src/lib/space/schedule/schedule-service.ts
+++ b/packages/daemon/src/lib/space/schedule/schedule-service.ts
@@ -80,6 +80,14 @@ export class ScheduleService {
 		} else if (input.triggerType === 'at') {
 			if (!input.runAt) throw new Error('runAt is required for at triggers');
 			if (input.runAt < Date.now()) throw new Error('runAt must be in the future');
+		} else {
+			// RPC payloads are cast from `unknown` and the agent MCP tool also
+			// dispatches into this service. TypeScript's narrowing isn't enforced
+			// at runtime, so explicitly reject any other value rather than
+			// silently falling through and creating an inconsistent schedule.
+			throw new Error(
+				`Unsupported triggerType: ${String(input.triggerType)} (expected 'cron' or 'at')`
+			);
 		}
 	}
 
@@ -168,6 +176,14 @@ export class ScheduleService {
 
 		const existing = scheduleRepo.getById(scheduleId);
 		if (!existing) throw new Error(`Schedule not found: ${scheduleId}`);
+
+		// Match create-time data quality: a schedule fires tasks whose title is
+		// inherited from the schedule template, so a blank title would spawn
+		// nameless tasks. Reject explicit empty/whitespace updates here rather
+		// than silently persisting them.
+		if (input.title !== undefined && !input.title.trim()) {
+			throw new Error('title must be a non-empty string');
+		}
 
 		// Trigger-config consistency: a `cron` schedule must always have a cron
 		// expression. Setting it to `null` would orphan the schedule.
@@ -353,5 +369,72 @@ export class ScheduleService {
 
 	listSchedules(spaceId: string, status?: TaskScheduleStatus): TaskSchedule[] {
 		return this.deps.scheduleRepo.listBySpace(spaceId, status);
+	}
+
+	/**
+	 * Recover active schedules for a space whose fire jobs were skipped while
+	 * the space was paused or stopped. Called by SpaceManager when a space is
+	 * resumed or restarted so cron schedules pick up forward progress without
+	 * waiting for a daemon restart.
+	 *
+	 * For each active schedule with `pending_job_id IS NULL`:
+	 *   - cron: advance `next_run_at` to the next tick from now, enqueue a fresh
+	 *     fire job at that time. We do not fire missed ticks retroactively — the
+	 *     space was intentionally inactive during that window.
+	 *   - at:   if the target time has passed, mark the schedule `completed`
+	 *     (the deadline expired during the outage). Otherwise re-enqueue at
+	 *     the original runAt.
+	 *
+	 * Schedules that already have a pending job are left alone — startup
+	 * recovery (Pass 1) handles dangling job IDs.
+	 *
+	 * Returns the number of schedules re-seeded.
+	 */
+	recoverSchedulesForSpace(spaceId: string): number {
+		const { db, scheduleRepo, jobQueue } = this.deps;
+
+		const schedules = scheduleRepo.listActiveBySpace(spaceId);
+		let recovered = 0;
+
+		for (const schedule of schedules) {
+			if (schedule.pendingJobId) continue; // already linked
+
+			db.transaction(() => {
+				if (schedule.triggerType === 'cron' && schedule.cronExpression) {
+					const next = getNextRunAt(schedule.cronExpression, schedule.timezone);
+					if (next === null) {
+						// Unrecoverable cron config — leave for operator to fix; do not
+						// terminally complete a recurring schedule on transient errors.
+						return;
+					}
+					const job = jobQueue.enqueue({
+						queue: TASK_SCHEDULE_FIRE,
+						payload: { scheduleId: schedule.id } satisfies TaskScheduleFirePayload,
+						runAt: next,
+					});
+					scheduleRepo.update(schedule.id, { nextRunAt: next });
+					scheduleRepo.updatePendingJobId(schedule.id, job.id);
+					recovered++;
+					return;
+				}
+
+				if (schedule.triggerType === 'at' && schedule.runAt) {
+					if (schedule.runAt < Date.now()) {
+						// Deadline expired while the space was inactive — terminal.
+						scheduleRepo.updateStatus(schedule.id, 'completed');
+						return;
+					}
+					const job = jobQueue.enqueue({
+						queue: TASK_SCHEDULE_FIRE,
+						payload: { scheduleId: schedule.id } satisfies TaskScheduleFirePayload,
+						runAt: schedule.runAt,
+					});
+					scheduleRepo.updatePendingJobId(schedule.id, job.id);
+					recovered++;
+				}
+			})();
+		}
+
+		return recovered;
 	}
 }

--- a/packages/daemon/src/lib/space/schedule/schedule-service.ts
+++ b/packages/daemon/src/lib/space/schedule/schedule-service.ts
@@ -21,6 +21,7 @@ import type {
 } from '@neokai/shared';
 import type { TaskScheduleRepository } from '../../../storage/repositories/task-schedule-repository';
 import type { JobQueueRepository } from '../../../storage/repositories/job-queue-repository';
+import type { SpaceRepository } from '../../../storage/repositories/space-repository';
 import { getNextRunAt, isValidCronExpression } from './cron-utils';
 import { TASK_SCHEDULE_FIRE } from '../../job-queue-constants';
 import type { TaskScheduleFirePayload } from '../../job-handlers/task-schedule-fire.handler';
@@ -55,6 +56,7 @@ export interface ScheduleServiceDeps {
 	db: BunDatabase;
 	scheduleRepo: TaskScheduleRepository;
 	jobQueue: JobQueueRepository;
+	spaceRepo: SpaceRepository;
 }
 
 export class ScheduleService {
@@ -121,10 +123,15 @@ export class ScheduleService {
 	createSchedule(input: CreateScheduleInput): TaskSchedule {
 		this.validateCreateTrigger(input);
 
+		const { spaceRepo, db, scheduleRepo, jobQueue } = this.deps;
+		const space = spaceRepo.getSpace(input.spaceId);
+		if (!space) throw new Error(`Space not found: ${input.spaceId}`);
+		if (space.status !== 'active') {
+			throw new Error(`Cannot create schedule in a non-active space (current: ${space.status})`);
+		}
+
 		const tz = input.timezone ?? 'UTC';
 		const nextRunAt = this.computeInitialNextRun(input, tz);
-
-		const { db, scheduleRepo, jobQueue } = this.deps;
 
 		// Wrap create + enqueue + updatePendingJobId in a single SQLite
 		// transaction so a failure in any step rolls back the schedule row.
@@ -225,7 +232,11 @@ export class ScheduleService {
 		};
 
 		let plannedNextRunAt: number | null = null;
-		if (timingChanged && existing.status === 'active') {
+		// Validate timing edits for both active and paused schedules. A paused
+		// cron schedule with an invalid timezone would fail at resume time,
+		// leaving the operator stuck. Reject bad config at write time so the
+		// caller gets immediate feedback.
+		if (timingChanged) {
 			if (merged.triggerType === 'cron' && merged.cronExpression) {
 				plannedNextRunAt = getNextRunAt(merged.cronExpression, merged.timezone);
 				if (plannedNextRunAt === null) {
@@ -290,6 +301,10 @@ export class ScheduleService {
 	/**
 	 * Pause an active schedule — cancels the pending job, sets status=paused,
 	 * clears pendingJobId.
+	 *
+	 * Uses a compare-and-swap update so a concurrent fire/reschedule that
+	 * advanced the pending job between our read and write wins safely instead
+	 * of being overwritten.
 	 */
 	pauseSchedule(scheduleId: string): TaskSchedule {
 		const { scheduleRepo, jobQueue } = this.deps;
@@ -299,9 +314,17 @@ export class ScheduleService {
 			throw new Error(`Schedule is not active (current: ${schedule.status})`);
 		}
 
-		if (schedule.pendingJobId) jobQueue.deleteJob(schedule.pendingJobId);
-		scheduleRepo.updatePendingJobId(scheduleId, null);
-		scheduleRepo.updateStatus(scheduleId, 'paused');
+		const observedPendingJobId = schedule.pendingJobId;
+		if (observedPendingJobId) jobQueue.deleteJob(observedPendingJobId);
+
+		const ok = scheduleRepo.pauseIfPending(scheduleId, 'active', observedPendingJobId);
+		if (!ok) {
+			// Concurrent fire/reschedule won — re-read and return current state
+			// so the caller sees the truth rather than stale data.
+			const fresh = scheduleRepo.getById(scheduleId);
+			if (!fresh) throw new Error(`Schedule not found: ${scheduleId}`);
+			return fresh;
+		}
 		return scheduleRepo.getById(scheduleId) as TaskSchedule;
 	}
 
@@ -317,6 +340,10 @@ export class ScheduleService {
 	 *     throw, leaving the schedule paused so the operator can fix the
 	 *     config. We do NOT silently complete a recurring schedule, because that
 	 *     would terminally end its lifecycle on a recoverable error.
+	 *
+	 * Uses a compare-and-swap update so a concurrent resume/delete that changed
+	 * the schedule between our read and write wins safely instead of leaving an
+	 * orphan queued job behind.
 	 */
 	resumeSchedule(scheduleId: string): TaskSchedule {
 		const { scheduleRepo, jobQueue } = this.deps;
@@ -343,7 +370,18 @@ export class ScheduleService {
 
 		// One-shot whose target time already passed → mark completed.
 		if (nextRunAt === null && schedule.triggerType === 'at') {
-			scheduleRepo.updateStatus(scheduleId, 'completed');
+			// CAS: only complete if still paused (concurrent resume would have
+			// already enqueued a job; we must not overwrite that).
+			const ok = scheduleRepo.resumeIfPaused(scheduleId, {
+				nextRunAt: null,
+				pendingJobId: null,
+				status: 'completed',
+			});
+			if (!ok) {
+				const fresh = scheduleRepo.getById(scheduleId);
+				if (!fresh) throw new Error(`Schedule not found: ${scheduleId}`);
+				return fresh;
+			}
 			return scheduleRepo.getById(scheduleId) as TaskSchedule;
 		}
 
@@ -354,21 +392,42 @@ export class ScheduleService {
 			runAt: nextRunAt as number,
 		});
 
-		scheduleRepo.update(scheduleId, { nextRunAt: nextRunAt ?? undefined });
-		scheduleRepo.updatePendingJobId(scheduleId, job.id);
-		scheduleRepo.updateStatus(scheduleId, 'active');
+		const ok = scheduleRepo.resumeIfPaused(scheduleId, {
+			nextRunAt,
+			pendingJobId: job.id,
+			status: 'active',
+		});
+		if (!ok) {
+			// Another caller won the race — delete the orphan job we just enqueued.
+			jobQueue.deleteJob(job.id);
+			const fresh = scheduleRepo.getById(scheduleId);
+			if (!fresh) throw new Error(`Schedule not found: ${scheduleId}`);
+			return fresh;
+		}
 		return scheduleRepo.getById(scheduleId) as TaskSchedule;
 	}
 
 	/**
 	 * Delete a schedule permanently — also cancels its pending fire job if any.
+	 *
+	 * Uses a compare-and-swap delete keyed on the observed pending_job_id so
+	 * a concurrent fire that advanced the schedule between our read and delete
+	 * wins safely instead of leaving an orphan queued job behind.
 	 */
 	deleteSchedule(scheduleId: string): boolean {
 		const { scheduleRepo, jobQueue } = this.deps;
 		const schedule = scheduleRepo.getById(scheduleId);
 		if (!schedule) return false;
-		if (schedule.pendingJobId) jobQueue.deleteJob(schedule.pendingJobId);
-		return scheduleRepo.delete(scheduleId);
+		const observedPendingJobId = schedule.pendingJobId;
+		if (observedPendingJobId) jobQueue.deleteJob(observedPendingJobId);
+		const ok = scheduleRepo.deleteIfPending(scheduleId, observedPendingJobId);
+		if (!ok) {
+			// Concurrent fire/reschedule won — the schedule still exists with a
+			// new pending job. Don't leave it in a broken state; let the caller
+			// know so they can retry or investigate.
+			return false;
+		}
+		return true;
 	}
 
 	getSchedule(scheduleId: string): TaskSchedule | null {

--- a/packages/daemon/src/lib/space/schedule/schedule-service.ts
+++ b/packages/daemon/src/lib/space/schedule/schedule-service.ts
@@ -1,0 +1,322 @@
+/**
+ * ScheduleService — shared business logic for TaskSchedule lifecycle.
+ *
+ * Wraps the repository + job queue so that the validation, enqueue, and
+ * pendingJobId bookkeeping happens in one place. Both the RPC handlers
+ * (`task-schedule-handlers.ts`) and the agent MCP tools (`space-agent-tools.ts`)
+ * call into this service so a bug fix or behavior change happens once.
+ *
+ * Atomicity: create + first enqueue + pending-job linkage run inside a single
+ * SQLite transaction. If the enqueue throws (e.g. transient DB error), the
+ * schedule row is rolled back so the caller never sees an `active` schedule
+ * with no pending job.
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+import type {
+	SpaceTaskPriority,
+	TaskSchedule,
+	TaskScheduleStatus,
+	TaskScheduleTriggerType,
+} from '@neokai/shared';
+import type { TaskScheduleRepository } from '../../../storage/repositories/task-schedule-repository';
+import type { JobQueueRepository } from '../../../storage/repositories/job-queue-repository';
+import { getNextRunAt, isValidCronExpression } from './cron-utils';
+import { TASK_SCHEDULE_FIRE } from '../../job-queue-constants';
+import type { TaskScheduleFirePayload } from '../../job-handlers/task-schedule-fire.handler';
+
+export interface CreateScheduleInput {
+	spaceId: string;
+	title: string;
+	description?: string;
+	priority?: SpaceTaskPriority;
+	preferredWorkflowId?: string | null;
+	labels?: string[];
+	triggerType: TaskScheduleTriggerType;
+	cronExpression?: string | null;
+	runAt?: number | null;
+	timezone?: string;
+	createdByAgent?: string | null;
+	createdBySession?: string | null;
+}
+
+export interface UpdateScheduleInput {
+	title?: string;
+	description?: string;
+	priority?: SpaceTaskPriority;
+	preferredWorkflowId?: string | null;
+	labels?: string[];
+	cronExpression?: string | null;
+	runAt?: number | null;
+	timezone?: string;
+}
+
+export interface ScheduleServiceDeps {
+	db: BunDatabase;
+	scheduleRepo: TaskScheduleRepository;
+	jobQueue: JobQueueRepository;
+}
+
+export class ScheduleService {
+	constructor(private readonly deps: ScheduleServiceDeps) {}
+
+	// ─── Validation helpers ──────────────────────────────────────────────────
+
+	/**
+	 * Validate trigger config for a CREATE — rejects missing/invalid cron and
+	 * past `runAt`. Throws on validation failure so callers can return a clean
+	 * error to the user.
+	 */
+	private validateCreateTrigger(input: CreateScheduleInput): void {
+		if (!input.spaceId) throw new Error('spaceId is required');
+		if (!input.title?.trim()) throw new Error('title is required');
+		if (!input.triggerType) throw new Error('triggerType is required');
+
+		if (input.triggerType === 'cron') {
+			if (!input.cronExpression) throw new Error('cronExpression is required for cron triggers');
+			if (!isValidCronExpression(input.cronExpression)) {
+				throw new Error(`Invalid cron expression: ${input.cronExpression}`);
+			}
+		} else if (input.triggerType === 'at') {
+			if (!input.runAt) throw new Error('runAt is required for at triggers');
+			if (input.runAt < Date.now()) throw new Error('runAt must be in the future');
+		}
+	}
+
+	/**
+	 * Compute the first nextRunAt for a freshly-created schedule. Throws if the
+	 * cron expression cannot produce a future run.
+	 */
+	private computeInitialNextRun(input: CreateScheduleInput, tz: string): number {
+		let nextRunAt: number | null;
+		if (input.triggerType === 'cron') {
+			// validateCreateTrigger guarantees cronExpression is set + valid here.
+			nextRunAt = getNextRunAt(input.cronExpression as string, tz);
+		} else {
+			nextRunAt = input.runAt as number;
+		}
+		if (nextRunAt === null) {
+			throw new Error('Could not compute next run time from the provided expression');
+		}
+		return nextRunAt;
+	}
+
+	// ─── Public API ──────────────────────────────────────────────────────────
+
+	/**
+	 * Create a schedule and enqueue its first fire job atomically.
+	 *
+	 * If enqueue fails (or any step after the schedule INSERT throws), the
+	 * surrounding transaction rolls back, so callers either get a fully-wired
+	 * schedule (row + job + pendingJobId) or a clean failure.
+	 */
+	createSchedule(input: CreateScheduleInput): TaskSchedule {
+		this.validateCreateTrigger(input);
+
+		const tz = input.timezone ?? 'UTC';
+		const nextRunAt = this.computeInitialNextRun(input, tz);
+
+		const { db, scheduleRepo, jobQueue } = this.deps;
+
+		// Wrap create + enqueue + updatePendingJobId in a single SQLite
+		// transaction so a failure in any step rolls back the schedule row.
+		// `db.transaction(...)` returns a callable that runs the body atomically;
+		// calling it `()` immediately executes inside a BEGIN/COMMIT.
+		const scheduleId = db.transaction(() => {
+			const schedule = scheduleRepo.create({
+				spaceId: input.spaceId,
+				title: input.title,
+				description: input.description,
+				priority: input.priority,
+				preferredWorkflowId: input.preferredWorkflowId,
+				labels: input.labels,
+				triggerType: input.triggerType,
+				cronExpression: input.cronExpression,
+				runAt: input.runAt,
+				timezone: tz,
+				nextRunAt,
+				createdByAgent: input.createdByAgent,
+				createdBySession: input.createdBySession,
+			});
+
+			const job = jobQueue.enqueue({
+				queue: TASK_SCHEDULE_FIRE,
+				payload: { scheduleId: schedule.id } satisfies TaskScheduleFirePayload,
+				runAt: nextRunAt,
+			});
+
+			scheduleRepo.updatePendingJobId(schedule.id, job.id);
+			return schedule.id;
+		})();
+
+		return scheduleRepo.getById(scheduleId) as TaskSchedule;
+	}
+
+	/**
+	 * Update a schedule's template and/or trigger config.
+	 *
+	 * Rejects edits that would leave the schedule in an unfireable state — in
+	 * particular, setting `cronExpression: null` on a `cron` schedule. If the
+	 * timing fields change and the schedule is `active`, the existing pending
+	 * job is cancelled and a fresh one enqueued.
+	 */
+	updateSchedule(scheduleId: string, input: UpdateScheduleInput): TaskSchedule {
+		const { scheduleRepo, jobQueue } = this.deps;
+
+		const existing = scheduleRepo.getById(scheduleId);
+		if (!existing) throw new Error(`Schedule not found: ${scheduleId}`);
+
+		// Trigger-config consistency: a `cron` schedule must always have a cron
+		// expression. Setting it to `null` would orphan the schedule.
+		if (
+			existing.triggerType === 'cron' &&
+			'cronExpression' in input &&
+			input.cronExpression === null
+		) {
+			throw new Error(
+				'Cannot clear cronExpression on a cron schedule. Delete and recreate, or change triggerType.'
+			);
+		}
+
+		// Validate cron expression / runAt if supplied.
+		if (input.cronExpression !== undefined && input.cronExpression !== null) {
+			if (!isValidCronExpression(input.cronExpression)) {
+				throw new Error(`Invalid cron expression: ${input.cronExpression}`);
+			}
+		}
+		if (input.runAt !== undefined && input.runAt !== null) {
+			if (input.runAt < Date.now()) throw new Error('runAt must be in the future');
+		}
+
+		// Apply field updates (does not touch pendingJobId / nextRunAt unless requested).
+		scheduleRepo.update(scheduleId, {
+			title: input.title,
+			description: input.description,
+			priority: input.priority,
+			preferredWorkflowId: input.preferredWorkflowId,
+			labels: input.labels,
+			cronExpression: input.cronExpression,
+			runAt: input.runAt,
+			timezone: input.timezone,
+		});
+
+		const updated = scheduleRepo.getById(scheduleId) as TaskSchedule;
+
+		// If timing changed and the schedule is active, reschedule.
+		const timingChanged =
+			input.cronExpression !== undefined ||
+			input.runAt !== undefined ||
+			input.timezone !== undefined;
+
+		if (updated.status === 'active' && timingChanged) {
+			if (updated.pendingJobId) jobQueue.deleteJob(updated.pendingJobId);
+
+			const tz = updated.timezone;
+			let nextRunAt: number | null;
+			if (updated.triggerType === 'cron' && updated.cronExpression) {
+				nextRunAt = getNextRunAt(updated.cronExpression, tz);
+			} else if (updated.triggerType === 'at' && updated.runAt) {
+				nextRunAt = updated.runAt;
+			} else {
+				nextRunAt = null;
+			}
+
+			let pendingJobId: string | null = null;
+			if (nextRunAt !== null) {
+				const job = jobQueue.enqueue({
+					queue: TASK_SCHEDULE_FIRE,
+					payload: { scheduleId } satisfies TaskScheduleFirePayload,
+					runAt: nextRunAt,
+				});
+				pendingJobId = job.id;
+			}
+
+			scheduleRepo.update(scheduleId, { nextRunAt: nextRunAt ?? undefined });
+			scheduleRepo.updatePendingJobId(scheduleId, pendingJobId);
+		}
+
+		return scheduleRepo.getById(scheduleId) as TaskSchedule;
+	}
+
+	/**
+	 * Pause an active schedule — cancels the pending job, sets status=paused,
+	 * clears pendingJobId.
+	 */
+	pauseSchedule(scheduleId: string): TaskSchedule {
+		const { scheduleRepo, jobQueue } = this.deps;
+		const schedule = scheduleRepo.getById(scheduleId);
+		if (!schedule) throw new Error(`Schedule not found: ${scheduleId}`);
+		if (schedule.status !== 'active') {
+			throw new Error(`Schedule is not active (current: ${schedule.status})`);
+		}
+
+		if (schedule.pendingJobId) jobQueue.deleteJob(schedule.pendingJobId);
+		scheduleRepo.updatePendingJobId(scheduleId, null);
+		scheduleRepo.updateStatus(scheduleId, 'paused');
+		return scheduleRepo.getById(scheduleId) as TaskSchedule;
+	}
+
+	/**
+	 * Resume a paused schedule — recomputes nextRunAt, enqueues a fresh fire job.
+	 * For an `at` trigger whose `runAt` already passed, the schedule transitions
+	 * to `completed` instead.
+	 */
+	resumeSchedule(scheduleId: string): TaskSchedule {
+		const { scheduleRepo, jobQueue } = this.deps;
+		const schedule = scheduleRepo.getById(scheduleId);
+		if (!schedule) throw new Error(`Schedule not found: ${scheduleId}`);
+		if (schedule.status !== 'paused') {
+			throw new Error(`Schedule is not paused (current: ${schedule.status})`);
+		}
+
+		const tz = schedule.timezone;
+		let nextRunAt: number | null;
+		if (schedule.triggerType === 'cron' && schedule.cronExpression) {
+			nextRunAt = getNextRunAt(schedule.cronExpression, tz);
+		} else if (schedule.triggerType === 'at' && schedule.runAt) {
+			nextRunAt = schedule.runAt < Date.now() ? null : schedule.runAt;
+		} else {
+			nextRunAt = null;
+		}
+
+		// One-shot whose target time already passed → mark completed.
+		if (nextRunAt === null && schedule.triggerType === 'at') {
+			scheduleRepo.updateStatus(scheduleId, 'completed');
+			return scheduleRepo.getById(scheduleId) as TaskSchedule;
+		}
+
+		let pendingJobId: string | null = null;
+		if (nextRunAt !== null) {
+			const job = jobQueue.enqueue({
+				queue: TASK_SCHEDULE_FIRE,
+				payload: { scheduleId } satisfies TaskScheduleFirePayload,
+				runAt: nextRunAt,
+			});
+			pendingJobId = job.id;
+		}
+
+		scheduleRepo.update(scheduleId, { nextRunAt: nextRunAt ?? undefined });
+		scheduleRepo.updatePendingJobId(scheduleId, pendingJobId);
+		scheduleRepo.updateStatus(scheduleId, nextRunAt !== null ? 'active' : 'completed');
+		return scheduleRepo.getById(scheduleId) as TaskSchedule;
+	}
+
+	/**
+	 * Delete a schedule permanently — also cancels its pending fire job if any.
+	 */
+	deleteSchedule(scheduleId: string): boolean {
+		const { scheduleRepo, jobQueue } = this.deps;
+		const schedule = scheduleRepo.getById(scheduleId);
+		if (!schedule) return false;
+		if (schedule.pendingJobId) jobQueue.deleteJob(schedule.pendingJobId);
+		return scheduleRepo.delete(scheduleId);
+	}
+
+	getSchedule(scheduleId: string): TaskSchedule | null {
+		return this.deps.scheduleRepo.getById(scheduleId);
+	}
+
+	listSchedules(spaceId: string, status?: TaskScheduleStatus): TaskSchedule[] {
+		return this.deps.scheduleRepo.listBySpace(spaceId, status);
+	}
+}

--- a/packages/daemon/src/lib/space/schedule/schedule-service.ts
+++ b/packages/daemon/src/lib/space/schedule/schedule-service.ts
@@ -156,12 +156,15 @@ export class ScheduleService {
 	 * Update a schedule's template and/or trigger config.
 	 *
 	 * Rejects edits that would leave the schedule in an unfireable state — in
-	 * particular, setting `cronExpression: null` on a `cron` schedule. If the
-	 * timing fields change and the schedule is `active`, the existing pending
-	 * job is cancelled and a fresh one enqueued.
+	 * particular, setting `cronExpression: null` on a `cron` schedule, or
+	 * applying timing fields whose combined result yields no next run (e.g. an
+	 * invalid timezone). If the timing fields change and the schedule is
+	 * `active`, the existing pending job is cancelled and a fresh one is
+	 * enqueued **inside a single SQLite transaction**, so an enqueue failure
+	 * cannot orphan the schedule with no pending job.
 	 */
 	updateSchedule(scheduleId: string, input: UpdateScheduleInput): TaskSchedule {
-		const { scheduleRepo, jobQueue } = this.deps;
+		const { db, scheduleRepo, jobQueue } = this.deps;
 
 		const existing = scheduleRepo.getById(scheduleId);
 		if (!existing) throw new Error(`Schedule not found: ${scheduleId}`);
@@ -188,52 +191,74 @@ export class ScheduleService {
 			if (input.runAt < Date.now()) throw new Error('runAt must be in the future');
 		}
 
-		// Apply field updates (does not touch pendingJobId / nextRunAt unless requested).
-		scheduleRepo.update(scheduleId, {
-			title: input.title,
-			description: input.description,
-			priority: input.priority,
-			preferredWorkflowId: input.preferredWorkflowId,
-			labels: input.labels,
-			cronExpression: input.cronExpression,
-			runAt: input.runAt,
-			timezone: input.timezone,
-		});
-
-		const updated = scheduleRepo.getById(scheduleId) as TaskSchedule;
-
-		// If timing changed and the schedule is active, reschedule.
 		const timingChanged =
 			input.cronExpression !== undefined ||
 			input.runAt !== undefined ||
 			input.timezone !== undefined;
 
-		if (updated.status === 'active' && timingChanged) {
-			if (updated.pendingJobId) jobQueue.deleteJob(updated.pendingJobId);
+		// Pre-compute the post-update view so we can validate next-run *before*
+		// committing anything. If timing changed, derive the merged trigger
+		// fields and confirm we can compute a next run; if not, fail fast and
+		// leave the schedule untouched so the caller can correct the input.
+		const merged = {
+			triggerType: existing.triggerType,
+			cronExpression:
+				input.cronExpression !== undefined ? input.cronExpression : existing.cronExpression,
+			runAt: input.runAt !== undefined ? input.runAt : existing.runAt,
+			timezone: input.timezone ?? existing.timezone,
+		};
 
-			const tz = updated.timezone;
-			let nextRunAt: number | null;
-			if (updated.triggerType === 'cron' && updated.cronExpression) {
-				nextRunAt = getNextRunAt(updated.cronExpression, tz);
-			} else if (updated.triggerType === 'at' && updated.runAt) {
-				nextRunAt = updated.runAt;
+		let plannedNextRunAt: number | null = null;
+		if (timingChanged && existing.status === 'active') {
+			if (merged.triggerType === 'cron' && merged.cronExpression) {
+				plannedNextRunAt = getNextRunAt(merged.cronExpression, merged.timezone);
+				if (plannedNextRunAt === null) {
+					throw new Error(
+						`Could not compute next run from cronExpression "${merged.cronExpression}" with timezone "${merged.timezone}"`
+					);
+				}
+			} else if (merged.triggerType === 'at' && merged.runAt) {
+				plannedNextRunAt = merged.runAt;
 			} else {
-				nextRunAt = null;
+				throw new Error(
+					'Cannot apply update: resulting trigger configuration has no next run time.'
+				);
 			}
-
-			let pendingJobId: string | null = null;
-			if (nextRunAt !== null) {
-				const job = jobQueue.enqueue({
-					queue: TASK_SCHEDULE_FIRE,
-					payload: { scheduleId } satisfies TaskScheduleFirePayload,
-					runAt: nextRunAt,
-				});
-				pendingJobId = job.id;
-			}
-
-			scheduleRepo.update(scheduleId, { nextRunAt: nextRunAt ?? undefined });
-			scheduleRepo.updatePendingJobId(scheduleId, pendingJobId);
 		}
+
+		// Wrap field-update + cancel-old + enqueue-new + link-new in a single
+		// transaction. If `jobQueue.enqueue` throws (e.g. a transient DB error),
+		// the rollback restores the prior pending job linkage so the schedule
+		// continues to fire on its original cadence.
+		db.transaction(() => {
+			scheduleRepo.update(scheduleId, {
+				title: input.title,
+				description: input.description,
+				priority: input.priority,
+				preferredWorkflowId: input.preferredWorkflowId,
+				labels: input.labels,
+				cronExpression: input.cronExpression,
+				runAt: input.runAt,
+				timezone: input.timezone,
+			});
+
+			if (existing.status === 'active' && timingChanged) {
+				if (existing.pendingJobId) jobQueue.deleteJob(existing.pendingJobId);
+
+				let pendingJobId: string | null = null;
+				if (plannedNextRunAt !== null) {
+					const job = jobQueue.enqueue({
+						queue: TASK_SCHEDULE_FIRE,
+						payload: { scheduleId } satisfies TaskScheduleFirePayload,
+						runAt: plannedNextRunAt,
+					});
+					pendingJobId = job.id;
+				}
+
+				scheduleRepo.update(scheduleId, { nextRunAt: plannedNextRunAt ?? undefined });
+				scheduleRepo.updatePendingJobId(scheduleId, pendingJobId);
+			}
+		})();
 
 		return scheduleRepo.getById(scheduleId) as TaskSchedule;
 	}
@@ -258,8 +283,16 @@ export class ScheduleService {
 
 	/**
 	 * Resume a paused schedule — recomputes nextRunAt, enqueues a fresh fire job.
-	 * For an `at` trigger whose `runAt` already passed, the schedule transitions
-	 * to `completed` instead.
+	 *
+	 * Behavior depends on triggerType:
+	 *   - `at` whose runAt already passed → transition to `completed` (one-shot
+	 *     schedules are intentionally terminal once their target time is in the
+	 *     past).
+	 *   - `cron` that cannot produce a next run (e.g. invalid timezone or
+	 *     malformed expression persisted via a path that didn't validate) →
+	 *     throw, leaving the schedule paused so the operator can fix the
+	 *     config. We do NOT silently complete a recurring schedule, because that
+	 *     would terminally end its lifecycle on a recoverable error.
 	 */
 	resumeSchedule(scheduleId: string): TaskSchedule {
 		const { scheduleRepo, jobQueue } = this.deps;
@@ -273,6 +306,11 @@ export class ScheduleService {
 		let nextRunAt: number | null;
 		if (schedule.triggerType === 'cron' && schedule.cronExpression) {
 			nextRunAt = getNextRunAt(schedule.cronExpression, tz);
+			if (nextRunAt === null) {
+				throw new Error(
+					`Cannot resume cron schedule: no next run computable from "${schedule.cronExpression}" with timezone "${tz}". Fix the trigger config and try again.`
+				);
+			}
 		} else if (schedule.triggerType === 'at' && schedule.runAt) {
 			nextRunAt = schedule.runAt < Date.now() ? null : schedule.runAt;
 		} else {
@@ -285,19 +323,16 @@ export class ScheduleService {
 			return scheduleRepo.getById(scheduleId) as TaskSchedule;
 		}
 
-		let pendingJobId: string | null = null;
-		if (nextRunAt !== null) {
-			const job = jobQueue.enqueue({
-				queue: TASK_SCHEDULE_FIRE,
-				payload: { scheduleId } satisfies TaskScheduleFirePayload,
-				runAt: nextRunAt,
-			});
-			pendingJobId = job.id;
-		}
+		// At this point, nextRunAt is non-null for both cron and at paths.
+		const job = jobQueue.enqueue({
+			queue: TASK_SCHEDULE_FIRE,
+			payload: { scheduleId } satisfies TaskScheduleFirePayload,
+			runAt: nextRunAt as number,
+		});
 
 		scheduleRepo.update(scheduleId, { nextRunAt: nextRunAt ?? undefined });
-		scheduleRepo.updatePendingJobId(scheduleId, pendingJobId);
-		scheduleRepo.updateStatus(scheduleId, nextRunAt !== null ? 'active' : 'completed');
+		scheduleRepo.updatePendingJobId(scheduleId, job.id);
+		scheduleRepo.updateStatus(scheduleId, 'active');
 		return scheduleRepo.getById(scheduleId) as TaskSchedule;
 	}
 

--- a/packages/daemon/src/lib/space/schedule/schedule-service.ts
+++ b/packages/daemon/src/lib/space/schedule/schedule-service.ts
@@ -247,16 +247,24 @@ export class ScheduleService {
 		// the rollback restores the prior pending job linkage so the schedule
 		// continues to fire on its original cadence.
 		db.transaction(() => {
-			scheduleRepo.update(scheduleId, {
-				title: input.title,
-				description: input.description,
-				priority: input.priority,
-				preferredWorkflowId: input.preferredWorkflowId,
-				labels: input.labels,
-				cronExpression: input.cronExpression,
-				runAt: input.runAt,
-				timezone: input.timezone,
-			});
+			// Only forward fields the caller actually provided. The repository's
+			// update method uses `'key' in params` to decide whether to write a
+			// column, so spreading `key: undefined` would coerce to NULL and
+			// silently clear cron expression / runAt / workflow linkage on a
+			// metadata-only edit (e.g. `{ title: 'New' }`). Build the params
+			// object key-by-key so untouched columns are left alone.
+			const updateParams: Parameters<typeof scheduleRepo.update>[1] = {};
+			if (input.title !== undefined) updateParams.title = input.title;
+			if (input.description !== undefined) updateParams.description = input.description;
+			if (input.priority !== undefined) updateParams.priority = input.priority;
+			if ('preferredWorkflowId' in input) {
+				updateParams.preferredWorkflowId = input.preferredWorkflowId;
+			}
+			if (input.labels !== undefined) updateParams.labels = input.labels;
+			if ('cronExpression' in input) updateParams.cronExpression = input.cronExpression;
+			if ('runAt' in input) updateParams.runAt = input.runAt;
+			if (input.timezone !== undefined) updateParams.timezone = input.timezone;
+			scheduleRepo.update(scheduleId, updateParams);
 
 			if (existing.status === 'active' && timingChanged) {
 				if (existing.pendingJobId) jobQueue.deleteJob(existing.pendingJobId);
@@ -396,10 +404,21 @@ export class ScheduleService {
 		const schedules = scheduleRepo.listActiveBySpace(spaceId);
 		let recovered = 0;
 
-		for (const schedule of schedules) {
-			if (schedule.pendingJobId) continue; // already linked
+		for (const candidate of schedules) {
+			if (candidate.pendingJobId) continue; // already linked at snapshot time
 
 			db.transaction(() => {
+				// Re-read fresh inside the transaction to defend against concurrent
+				// pause/delete/edit between snapshot and reseed. The recovery loop
+				// is fired from SpaceManager hooks, but agents and operators can
+				// still mutate schedules during the scan. If the schedule was
+				// paused, deleted, or already re-seeded by another path, leave
+				// it alone — pausing should not be silently overridden.
+				const schedule = scheduleRepo.getById(candidate.id);
+				if (!schedule) return;
+				if (schedule.status !== 'active') return;
+				if (schedule.pendingJobId) return;
+
 				if (schedule.triggerType === 'cron' && schedule.cronExpression) {
 					const next = getNextRunAt(schedule.cronExpression, schedule.timezone);
 					if (next === null) {

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -1224,7 +1224,14 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 				if (!existing || existing.spaceId !== spaceId) {
 					return jsonResult({ success: false, error: `Schedule not found: ${args.schedule_id}` });
 				}
-				config.scheduleService.deleteSchedule(args.schedule_id);
+				const ok = config.scheduleService.deleteSchedule(args.schedule_id);
+				if (!ok) {
+					return jsonResult({
+						success: false,
+						error:
+							'Schedule was modified concurrently (e.g. a fire job advanced it). Please retry.',
+					});
+				}
 				logAudit('delete_scheduled_task', { schedule_id: args.schedule_id });
 				return jsonResult({ success: true });
 			} catch (err) {

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -46,11 +46,6 @@ import type { DaemonHub } from '../../daemon-hub';
 import type { PendingAgentMessageQueue } from '../../rpc-handlers/space-task-message-handlers';
 import { jsonResult } from './tool-result';
 import type { ToolResult } from './tool-result';
-import type { TaskScheduleRepository } from '../../../storage/repositories/task-schedule-repository';
-import type { JobQueueRepository } from '../../../storage/repositories/job-queue-repository';
-import { isValidCronExpression, getNextRunAt } from '../schedule/cron-utils';
-import { TASK_SCHEDULE_FIRE } from '../../job-queue-constants';
-import type { TaskScheduleFirePayload } from '../../job-handlers/task-schedule-fire.handler';
 import { formatAgentMessage } from '../agent-message-envelope';
 import { canTransition } from '../runtime/workflow-run-status-machine';
 function normalizeAgentNameToken(value: string): string {
@@ -176,16 +171,13 @@ export interface SpaceAgentToolsConfig {
 	 */
 	auditLogRepo?: McpAuditLogRepository;
 	/**
-	 * Task schedule repository — required for the schedule management tools
-	 * (create_scheduled_task, list_scheduled_tasks, etc.).
+	 * Schedule management service — required for the schedule management tools
+	 * (create_scheduled_task, list_scheduled_tasks, etc.). Encapsulates the
+	 * atomic create+enqueue, validation, and reschedule logic shared with the
+	 * RPC handlers.
 	 * Optional — when absent, schedule tools are not registered.
 	 */
-	scheduleRepo?: TaskScheduleRepository;
-	/**
-	 * Job queue repository — required for the schedule management tools.
-	 * Optional — when absent, schedule tools are not registered.
-	 */
-	jobQueue?: JobQueueRepository;
+	scheduleService?: import('../schedule/schedule-service').ScheduleService;
 }
 
 // ---------------------------------------------------------------------------
@@ -1110,43 +1102,11 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 			run_at?: number;
 			timezone?: string;
 		}): Promise<ToolResult> {
-			if (!config.scheduleRepo || !config.jobQueue) {
+			if (!config.scheduleService) {
 				return jsonResult({ success: false, error: 'Schedule management not available' });
 			}
 			try {
-				if (!args.title?.trim()) return jsonResult({ success: false, error: 'title is required' });
-				if (!args.trigger_type)
-					return jsonResult({ success: false, error: 'trigger_type is required' });
-
-				if (args.trigger_type === 'cron') {
-					if (!args.cron_expression) {
-						return jsonResult({
-							success: false,
-							error: 'cron_expression is required for cron triggers',
-						});
-					}
-					if (!isValidCronExpression(args.cron_expression)) {
-						return jsonResult({
-							success: false,
-							error: `Invalid cron expression: ${args.cron_expression}`,
-						});
-					}
-				} else {
-					if (!args.run_at)
-						return jsonResult({ success: false, error: 'run_at is required for at triggers' });
-					if (args.run_at < Date.now())
-						return jsonResult({ success: false, error: 'run_at must be in the future' });
-				}
-
-				const tz = args.timezone ?? 'UTC';
-				const nextRunAt =
-					args.trigger_type === 'cron' ? getNextRunAt(args.cron_expression!, tz) : args.run_at!;
-
-				if (nextRunAt === null) {
-					return jsonResult({ success: false, error: 'Could not compute next run time' });
-				}
-
-				const schedule = config.scheduleRepo.create({
+				const schedule = config.scheduleService.createSchedule({
 					spaceId,
 					title: args.title,
 					description: args.description ?? '',
@@ -1156,28 +1116,18 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 					triggerType: args.trigger_type,
 					cronExpression: args.cron_expression ?? null,
 					runAt: args.run_at ?? null,
-					timezone: tz,
-					nextRunAt,
+					timezone: args.timezone,
 					createdByAgent: myAgentName ?? null,
 					createdBySession: mySessionId ?? null,
 				});
-
-				const job = config.jobQueue.enqueue({
-					queue: TASK_SCHEDULE_FIRE,
-					payload: { scheduleId: schedule.id } satisfies TaskScheduleFirePayload,
-					runAt: nextRunAt,
-				});
-				config.scheduleRepo.updatePendingJobId(schedule.id, job.id);
-				const updated = config.scheduleRepo.getById(schedule.id);
-
 				logAudit('create_scheduled_task', {
 					title: args.title,
 					trigger_type: args.trigger_type,
 					cron_expression: args.cron_expression,
 					run_at: args.run_at,
-					timezone: tz,
+					timezone: args.timezone,
 				});
-				return jsonResult({ success: true, schedule: updated });
+				return jsonResult({ success: true, schedule });
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
 				return jsonResult({ success: false, error: message });
@@ -1188,11 +1138,11 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		 * List all scheduled tasks for this space.
 		 */
 		async list_scheduled_tasks(args: { status?: TaskScheduleStatus }): Promise<ToolResult> {
-			if (!config.scheduleRepo) {
+			if (!config.scheduleService) {
 				return jsonResult({ success: false, error: 'Schedule management not available' });
 			}
 			try {
-				const schedules = config.scheduleRepo.listBySpace(spaceId, args.status);
+				const schedules = config.scheduleService.listSchedules(spaceId, args.status);
 				return jsonResult({ success: true, schedules });
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
@@ -1204,11 +1154,11 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		 * Get schedule details including last spawned task.
 		 */
 		async get_scheduled_task(args: { schedule_id: string }): Promise<ToolResult> {
-			if (!config.scheduleRepo) {
+			if (!config.scheduleService) {
 				return jsonResult({ success: false, error: 'Schedule management not available' });
 			}
 			try {
-				const schedule = config.scheduleRepo.getById(args.schedule_id);
+				const schedule = config.scheduleService.getSchedule(args.schedule_id);
 				if (!schedule || schedule.spaceId !== spaceId) {
 					return jsonResult({ success: false, error: `Schedule not found: ${args.schedule_id}` });
 				}
@@ -1223,28 +1173,18 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		 * Pause a schedule — stops creating new tasks.
 		 */
 		async pause_scheduled_task(args: { schedule_id: string }): Promise<ToolResult> {
-			if (!config.scheduleRepo || !config.jobQueue) {
+			if (!config.scheduleService) {
 				return jsonResult({ success: false, error: 'Schedule management not available' });
 			}
 			try {
-				const schedule = config.scheduleRepo.getById(args.schedule_id);
-				if (!schedule || schedule.spaceId !== spaceId) {
+				// Space-scope guard: callers can only pause schedules in their own space.
+				const existing = config.scheduleService.getSchedule(args.schedule_id);
+				if (!existing || existing.spaceId !== spaceId) {
 					return jsonResult({ success: false, error: `Schedule not found: ${args.schedule_id}` });
 				}
-				if (schedule.status !== 'active') {
-					return jsonResult({
-						success: false,
-						error: `Schedule is not active (current: ${schedule.status})`,
-					});
-				}
-				if (schedule.pendingJobId) {
-					config.jobQueue.deleteJob(schedule.pendingJobId);
-				}
-				config.scheduleRepo.updatePendingJobId(args.schedule_id, null);
-				config.scheduleRepo.updateStatus(args.schedule_id, 'paused');
-				const updated = config.scheduleRepo.getById(args.schedule_id);
+				const schedule = config.scheduleService.pauseSchedule(args.schedule_id);
 				logAudit('pause_scheduled_task', { schedule_id: args.schedule_id });
-				return jsonResult({ success: true, schedule: updated });
+				return jsonResult({ success: true, schedule });
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
 				return jsonResult({ success: false, error: message });
@@ -1255,47 +1195,17 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		 * Resume a paused schedule.
 		 */
 		async resume_scheduled_task(args: { schedule_id: string }): Promise<ToolResult> {
-			if (!config.scheduleRepo || !config.jobQueue) {
+			if (!config.scheduleService) {
 				return jsonResult({ success: false, error: 'Schedule management not available' });
 			}
 			try {
-				const schedule = config.scheduleRepo.getById(args.schedule_id);
-				if (!schedule || schedule.spaceId !== spaceId) {
+				const existing = config.scheduleService.getSchedule(args.schedule_id);
+				if (!existing || existing.spaceId !== spaceId) {
 					return jsonResult({ success: false, error: `Schedule not found: ${args.schedule_id}` });
 				}
-				if (schedule.status !== 'paused') {
-					return jsonResult({
-						success: false,
-						error: `Schedule is not paused (current: ${schedule.status})`,
-					});
-				}
-				const tz = schedule.timezone;
-				let nextRunAt: number | null;
-				if (schedule.triggerType === 'cron' && schedule.cronExpression) {
-					nextRunAt = getNextRunAt(schedule.cronExpression, tz);
-				} else if (schedule.triggerType === 'at' && schedule.runAt) {
-					nextRunAt = schedule.runAt < Date.now() ? null : schedule.runAt;
-				} else {
-					nextRunAt = null;
-				}
-				let pendingJobId: string | null = null;
-				if (nextRunAt !== null) {
-					const job = config.jobQueue.enqueue({
-						queue: TASK_SCHEDULE_FIRE,
-						payload: { scheduleId: args.schedule_id } satisfies TaskScheduleFirePayload,
-						runAt: nextRunAt,
-					});
-					pendingJobId = job.id;
-				}
-				config.scheduleRepo.update(args.schedule_id, { nextRunAt: nextRunAt ?? undefined });
-				config.scheduleRepo.updatePendingJobId(args.schedule_id, pendingJobId);
-				config.scheduleRepo.updateStatus(
-					args.schedule_id,
-					nextRunAt !== null ? 'active' : 'completed'
-				);
-				const updated = config.scheduleRepo.getById(args.schedule_id);
+				const schedule = config.scheduleService.resumeSchedule(args.schedule_id);
 				logAudit('resume_scheduled_task', { schedule_id: args.schedule_id });
-				return jsonResult({ success: true, schedule: updated });
+				return jsonResult({ success: true, schedule });
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
 				return jsonResult({ success: false, error: message });
@@ -1306,18 +1216,15 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 		 * Delete a schedule permanently.
 		 */
 		async delete_scheduled_task(args: { schedule_id: string }): Promise<ToolResult> {
-			if (!config.scheduleRepo || !config.jobQueue) {
+			if (!config.scheduleService) {
 				return jsonResult({ success: false, error: 'Schedule management not available' });
 			}
 			try {
-				const schedule = config.scheduleRepo.getById(args.schedule_id);
-				if (!schedule || schedule.spaceId !== spaceId) {
+				const existing = config.scheduleService.getSchedule(args.schedule_id);
+				if (!existing || existing.spaceId !== spaceId) {
 					return jsonResult({ success: false, error: `Schedule not found: ${args.schedule_id}` });
 				}
-				if (schedule.pendingJobId) {
-					config.jobQueue.deleteJob(schedule.pendingJobId);
-				}
-				config.scheduleRepo.delete(args.schedule_id);
+				config.scheduleService.deleteSchedule(args.schedule_id);
 				logAudit('delete_scheduled_task', { schedule_id: args.schedule_id });
 				return jsonResult({ success: true });
 			} catch (err) {
@@ -1587,8 +1494,8 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 		),
 	];
 
-	// Schedule management tools — only registered when scheduleRepo + jobQueue are provided.
-	if (config.scheduleRepo && config.jobQueue) {
+	// Schedule management tools — only registered when scheduleService is provided.
+	if (config.scheduleService) {
 		tools.push(
 			tool(
 				'create_scheduled_task',

--- a/packages/daemon/src/lib/space/tools/space-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/space-agent-tools.ts
@@ -23,7 +23,14 @@
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
 import type { SdkMcpToolDefinition } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
-import type { NodeExecution, SpaceTask, SpaceTaskStatus, SpaceTaskPriority } from '@neokai/shared';
+import type {
+	NodeExecution,
+	SpaceTask,
+	SpaceTaskStatus,
+	SpaceTaskPriority,
+	TaskScheduleTriggerType,
+	TaskScheduleStatus,
+} from '@neokai/shared';
 import type { SpaceRuntime } from '../runtime/space-runtime';
 import type { SpaceWorkflowManager } from '../managers/space-workflow-manager';
 import type { SpaceTaskRepository } from '../../../storage/repositories/space-task-repository';
@@ -39,6 +46,11 @@ import type { DaemonHub } from '../../daemon-hub';
 import type { PendingAgentMessageQueue } from '../../rpc-handlers/space-task-message-handlers';
 import { jsonResult } from './tool-result';
 import type { ToolResult } from './tool-result';
+import type { TaskScheduleRepository } from '../../../storage/repositories/task-schedule-repository';
+import type { JobQueueRepository } from '../../../storage/repositories/job-queue-repository';
+import { isValidCronExpression, getNextRunAt } from '../schedule/cron-utils';
+import { TASK_SCHEDULE_FIRE } from '../../job-queue-constants';
+import type { TaskScheduleFirePayload } from '../../job-handlers/task-schedule-fire.handler';
 import { formatAgentMessage } from '../agent-message-envelope';
 import { canTransition } from '../runtime/workflow-run-status-machine';
 function normalizeAgentNameToken(value: string): string {
@@ -163,6 +175,17 @@ export interface SpaceAgentToolsConfig {
 	 * Optional — when absent, no audit entries are written.
 	 */
 	auditLogRepo?: McpAuditLogRepository;
+	/**
+	 * Task schedule repository — required for the schedule management tools
+	 * (create_scheduled_task, list_scheduled_tasks, etc.).
+	 * Optional — when absent, schedule tools are not registered.
+	 */
+	scheduleRepo?: TaskScheduleRepository;
+	/**
+	 * Job queue repository — required for the schedule management tools.
+	 * Optional — when absent, schedule tools are not registered.
+	 */
+	jobQueue?: JobQueueRepository;
 }
 
 // ---------------------------------------------------------------------------
@@ -1072,6 +1095,236 @@ export function createSpaceAgentToolHandlers(config: SpaceAgentToolsConfig) {
 				return jsonResult({ success: false, error: message });
 			}
 		},
+
+		/**
+		 * Create a recurring (cron) or one-shot (at) scheduled task.
+		 */
+		async create_scheduled_task(args: {
+			title: string;
+			description: string;
+			priority?: SpaceTaskPriority;
+			workflow_id?: string;
+			labels?: string[];
+			trigger_type: TaskScheduleTriggerType;
+			cron_expression?: string;
+			run_at?: number;
+			timezone?: string;
+		}): Promise<ToolResult> {
+			if (!config.scheduleRepo || !config.jobQueue) {
+				return jsonResult({ success: false, error: 'Schedule management not available' });
+			}
+			try {
+				if (!args.title?.trim()) return jsonResult({ success: false, error: 'title is required' });
+				if (!args.trigger_type)
+					return jsonResult({ success: false, error: 'trigger_type is required' });
+
+				if (args.trigger_type === 'cron') {
+					if (!args.cron_expression) {
+						return jsonResult({
+							success: false,
+							error: 'cron_expression is required for cron triggers',
+						});
+					}
+					if (!isValidCronExpression(args.cron_expression)) {
+						return jsonResult({
+							success: false,
+							error: `Invalid cron expression: ${args.cron_expression}`,
+						});
+					}
+				} else {
+					if (!args.run_at)
+						return jsonResult({ success: false, error: 'run_at is required for at triggers' });
+					if (args.run_at < Date.now())
+						return jsonResult({ success: false, error: 'run_at must be in the future' });
+				}
+
+				const tz = args.timezone ?? 'UTC';
+				const nextRunAt =
+					args.trigger_type === 'cron' ? getNextRunAt(args.cron_expression!, tz) : args.run_at!;
+
+				if (nextRunAt === null) {
+					return jsonResult({ success: false, error: 'Could not compute next run time' });
+				}
+
+				const schedule = config.scheduleRepo.create({
+					spaceId,
+					title: args.title,
+					description: args.description ?? '',
+					priority: args.priority,
+					preferredWorkflowId: args.workflow_id ?? null,
+					labels: args.labels,
+					triggerType: args.trigger_type,
+					cronExpression: args.cron_expression ?? null,
+					runAt: args.run_at ?? null,
+					timezone: tz,
+					nextRunAt,
+					createdByAgent: myAgentName ?? null,
+					createdBySession: mySessionId ?? null,
+				});
+
+				const job = config.jobQueue.enqueue({
+					queue: TASK_SCHEDULE_FIRE,
+					payload: { scheduleId: schedule.id } satisfies TaskScheduleFirePayload,
+					runAt: nextRunAt,
+				});
+				config.scheduleRepo.updatePendingJobId(schedule.id, job.id);
+				const updated = config.scheduleRepo.getById(schedule.id);
+
+				logAudit('create_scheduled_task', {
+					title: args.title,
+					trigger_type: args.trigger_type,
+					cron_expression: args.cron_expression,
+					run_at: args.run_at,
+					timezone: tz,
+				});
+				return jsonResult({ success: true, schedule: updated });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		/**
+		 * List all scheduled tasks for this space.
+		 */
+		async list_scheduled_tasks(args: { status?: TaskScheduleStatus }): Promise<ToolResult> {
+			if (!config.scheduleRepo) {
+				return jsonResult({ success: false, error: 'Schedule management not available' });
+			}
+			try {
+				const schedules = config.scheduleRepo.listBySpace(spaceId, args.status);
+				return jsonResult({ success: true, schedules });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		/**
+		 * Get schedule details including last spawned task.
+		 */
+		async get_scheduled_task(args: { schedule_id: string }): Promise<ToolResult> {
+			if (!config.scheduleRepo) {
+				return jsonResult({ success: false, error: 'Schedule management not available' });
+			}
+			try {
+				const schedule = config.scheduleRepo.getById(args.schedule_id);
+				if (!schedule || schedule.spaceId !== spaceId) {
+					return jsonResult({ success: false, error: `Schedule not found: ${args.schedule_id}` });
+				}
+				return jsonResult({ success: true, schedule });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		/**
+		 * Pause a schedule — stops creating new tasks.
+		 */
+		async pause_scheduled_task(args: { schedule_id: string }): Promise<ToolResult> {
+			if (!config.scheduleRepo || !config.jobQueue) {
+				return jsonResult({ success: false, error: 'Schedule management not available' });
+			}
+			try {
+				const schedule = config.scheduleRepo.getById(args.schedule_id);
+				if (!schedule || schedule.spaceId !== spaceId) {
+					return jsonResult({ success: false, error: `Schedule not found: ${args.schedule_id}` });
+				}
+				if (schedule.status !== 'active') {
+					return jsonResult({
+						success: false,
+						error: `Schedule is not active (current: ${schedule.status})`,
+					});
+				}
+				if (schedule.pendingJobId) {
+					config.jobQueue.deleteJob(schedule.pendingJobId);
+				}
+				config.scheduleRepo.updatePendingJobId(args.schedule_id, null);
+				config.scheduleRepo.updateStatus(args.schedule_id, 'paused');
+				const updated = config.scheduleRepo.getById(args.schedule_id);
+				logAudit('pause_scheduled_task', { schedule_id: args.schedule_id });
+				return jsonResult({ success: true, schedule: updated });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		/**
+		 * Resume a paused schedule.
+		 */
+		async resume_scheduled_task(args: { schedule_id: string }): Promise<ToolResult> {
+			if (!config.scheduleRepo || !config.jobQueue) {
+				return jsonResult({ success: false, error: 'Schedule management not available' });
+			}
+			try {
+				const schedule = config.scheduleRepo.getById(args.schedule_id);
+				if (!schedule || schedule.spaceId !== spaceId) {
+					return jsonResult({ success: false, error: `Schedule not found: ${args.schedule_id}` });
+				}
+				if (schedule.status !== 'paused') {
+					return jsonResult({
+						success: false,
+						error: `Schedule is not paused (current: ${schedule.status})`,
+					});
+				}
+				const tz = schedule.timezone;
+				let nextRunAt: number | null;
+				if (schedule.triggerType === 'cron' && schedule.cronExpression) {
+					nextRunAt = getNextRunAt(schedule.cronExpression, tz);
+				} else if (schedule.triggerType === 'at' && schedule.runAt) {
+					nextRunAt = schedule.runAt < Date.now() ? null : schedule.runAt;
+				} else {
+					nextRunAt = null;
+				}
+				let pendingJobId: string | null = null;
+				if (nextRunAt !== null) {
+					const job = config.jobQueue.enqueue({
+						queue: TASK_SCHEDULE_FIRE,
+						payload: { scheduleId: args.schedule_id } satisfies TaskScheduleFirePayload,
+						runAt: nextRunAt,
+					});
+					pendingJobId = job.id;
+				}
+				config.scheduleRepo.update(args.schedule_id, { nextRunAt: nextRunAt ?? undefined });
+				config.scheduleRepo.updatePendingJobId(args.schedule_id, pendingJobId);
+				config.scheduleRepo.updateStatus(
+					args.schedule_id,
+					nextRunAt !== null ? 'active' : 'completed'
+				);
+				const updated = config.scheduleRepo.getById(args.schedule_id);
+				logAudit('resume_scheduled_task', { schedule_id: args.schedule_id });
+				return jsonResult({ success: true, schedule: updated });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
+
+		/**
+		 * Delete a schedule permanently.
+		 */
+		async delete_scheduled_task(args: { schedule_id: string }): Promise<ToolResult> {
+			if (!config.scheduleRepo || !config.jobQueue) {
+				return jsonResult({ success: false, error: 'Schedule management not available' });
+			}
+			try {
+				const schedule = config.scheduleRepo.getById(args.schedule_id);
+				if (!schedule || schedule.spaceId !== spaceId) {
+					return jsonResult({ success: false, error: `Schedule not found: ${args.schedule_id}` });
+				}
+				if (schedule.pendingJobId) {
+					config.jobQueue.deleteJob(schedule.pendingJobId);
+				}
+				config.scheduleRepo.delete(args.schedule_id);
+				logAudit('delete_scheduled_task', { schedule_id: args.schedule_id });
+				return jsonResult({ success: true });
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				return jsonResult({ success: false, error: message });
+			}
+		},
 	};
 }
 
@@ -1333,6 +1586,92 @@ export function createSpaceAgentMcpServer(config: SpaceAgentToolsConfig) {
 			(args) => handlers.approve_task(args)
 		),
 	];
+
+	// Schedule management tools — only registered when scheduleRepo + jobQueue are provided.
+	if (config.scheduleRepo && config.jobQueue) {
+		tools.push(
+			tool(
+				'create_scheduled_task',
+				'Create a recurring (cron) or one-shot (at) scheduled task. When it fires, a real SpaceTask is created automatically.',
+				{
+					title: z.string().describe('Short title for the task template'),
+					description: z.string().describe('Detailed description for the task template'),
+					priority: z
+						.enum(['low', 'normal', 'high', 'urgent'])
+						.optional()
+						.describe('Task priority (default: normal)'),
+					workflow_id: z
+						.string()
+						.optional()
+						.describe('Preferred workflow ID to attach to created tasks'),
+					labels: z.array(z.string()).optional().describe('Labels to apply to created tasks'),
+					trigger_type: z
+						.enum(['cron', 'at'])
+						.describe('Trigger type: "cron" for recurring, "at" for one-shot'),
+					cron_expression: z
+						.string()
+						.optional()
+						.describe(
+							'Cron expression (e.g. "0 9 * * 1" for every Monday at 9am, "@daily", "@hourly"). Required when trigger_type is "cron".'
+						),
+					run_at: z
+						.number()
+						.optional()
+						.describe(
+							'Unix timestamp in ms when the task should fire. Required when trigger_type is "at".'
+						),
+					timezone: z
+						.string()
+						.optional()
+						.describe('IANA timezone string (default: "UTC"). Example: "America/New_York"'),
+				},
+				(args) => handlers.create_scheduled_task(args)
+			),
+			tool(
+				'list_scheduled_tasks',
+				'List all scheduled tasks for this space.',
+				{
+					status: z
+						.enum(['active', 'paused', 'completed'])
+						.optional()
+						.describe('Filter by schedule status (default: all)'),
+				},
+				(args) => handlers.list_scheduled_tasks(args)
+			),
+			tool(
+				'get_scheduled_task',
+				'Get details of a specific scheduled task including last spawned task ID and next run time.',
+				{
+					schedule_id: z.string().describe('ID of the scheduled task to retrieve'),
+				},
+				(args) => handlers.get_scheduled_task(args)
+			),
+			tool(
+				'pause_scheduled_task',
+				'Pause a schedule — stops creating new tasks until resumed.',
+				{
+					schedule_id: z.string().describe('ID of the scheduled task to pause'),
+				},
+				(args) => handlers.pause_scheduled_task(args)
+			),
+			tool(
+				'resume_scheduled_task',
+				'Resume a paused schedule, computing the next run time and re-enqueueing the job.',
+				{
+					schedule_id: z.string().describe('ID of the scheduled task to resume'),
+				},
+				(args) => handlers.resume_scheduled_task(args)
+			),
+			tool(
+				'delete_scheduled_task',
+				'Permanently delete a scheduled task. Any pending job is cancelled.',
+				{
+					schedule_id: z.string().describe('ID of the scheduled task to delete'),
+				},
+				(args) => handlers.delete_scheduled_task(args)
+			)
+		);
+	}
 
 	// Optional legacy restore mirror. Workflow node sessions should use the
 	// node-agent namespace directly; space-agent-tools is no longer attached there.

--- a/packages/daemon/src/lib/state-manager.ts
+++ b/packages/daemon/src/lib/state-manager.ts
@@ -337,6 +337,13 @@ export class StateManager {
 			});
 		});
 
+		// Space schedule events (global channel)
+		this.eventBus.on('space.schedule.updated', (data) => {
+			this.messageHub.event('space.schedule.updated', data, {
+				channel: data.sessionId, // 'global'
+			});
+		});
+
 		// Space workflow run events (global channel)
 		this.eventBus.on('space.workflowRun.created', (data) => {
 			this.messageHub.event('space.workflowRun.created', data, {

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -43,8 +43,8 @@ export class SpaceTaskRepository {
 
 			this.db
 				.prepare(
-					`INSERT INTO space_tasks (id, space_id, task_number, title, description, status, priority, labels, workflow_run_id, preferred_workflow_id, created_by_task_id, depends_on, task_agent_session_id, created_by, created_by_session, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+					`INSERT INTO space_tasks (id, space_id, task_number, title, description, status, priority, labels, workflow_run_id, preferred_workflow_id, created_by_task_id, depends_on, task_agent_session_id, created_by, created_by_session, created_by_task_schedule_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 				)
 				.run(
 					id,
@@ -62,6 +62,7 @@ export class SpaceTaskRepository {
 					params.taskAgentSessionId ?? null,
 					params.createdBy ?? null,
 					params.createdBySession ?? null,
+					params.createdByTaskScheduleId ?? null,
 					now,
 					now
 				);
@@ -500,6 +501,7 @@ export class SpaceTaskRepository {
 			createdByTaskId: (row.created_by_task_id as string | null) ?? undefined,
 			createdBy: (row.created_by as string | null) ?? undefined,
 			createdBySession: (row.created_by_session as string | null) ?? undefined,
+			createdByTaskScheduleId: (row.created_by_task_schedule_id as string | null) ?? undefined,
 			result: (row.result as string | null) ?? null,
 			dependsOn: JSON.parse((row.depends_on as string | null) ?? '[]') as string[],
 			activeSession: (row.active_session as 'worker' | 'leader' | null) ?? null,

--- a/packages/daemon/src/storage/repositories/task-schedule-repository.ts
+++ b/packages/daemon/src/storage/repositories/task-schedule-repository.ts
@@ -108,14 +108,24 @@ export class TaskScheduleRepository {
 	}
 
 	/**
-	 * List active schedules whose nextRunAt <= now.
-	 * Used for startup re-seeding to recover lost jobs.
+	 * List active schedules whose nextRunAt <= now AND have no pending job
+	 * linked. Used for startup re-seeding to recover lost jobs.
+	 *
+	 * The `pending_job_id IS NULL` filter is important for paginated recovery:
+	 * after a page is re-seeded (each schedule gets a new pending job linked),
+	 * those rows must drop out of subsequent pages so the loop can advance to
+	 * the next batch of orphaned schedules. Without it, the first page would
+	 * be returned again with no actionable rows and the loop would stop early
+	 * even though further due schedules remain.
 	 */
 	listActiveDue(now: number, limit = 100): TaskSchedule[] {
 		const rows = this.db
 			.prepare(
 				`SELECT * FROM task_schedules
-				 WHERE status = 'active' AND next_run_at IS NOT NULL AND next_run_at <= ?
+				 WHERE status = 'active'
+				   AND next_run_at IS NOT NULL
+				   AND next_run_at <= ?
+				   AND pending_job_id IS NULL
 				 ORDER BY next_run_at ASC
 				 LIMIT ?`
 			)
@@ -134,6 +144,21 @@ export class TaskScheduleRepository {
 				 WHERE status = 'active' AND pending_job_id IS NOT NULL`
 			)
 			.all() as Record<string, unknown>[];
+		return rows.map((r) => this.rowToSchedule(r));
+	}
+
+	/**
+	 * List active schedules belonging to a specific space.
+	 * Used by SpaceManager.resumeSpace / startSpace to re-seed schedules whose
+	 * fire jobs were skipped while the space was paused/stopped.
+	 */
+	listActiveBySpace(spaceId: string): TaskSchedule[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM task_schedules
+				 WHERE status = 'active' AND space_id = ?`
+			)
+			.all(spaceId) as Record<string, unknown>[];
 		return rows.map((r) => this.rowToSchedule(r));
 	}
 

--- a/packages/daemon/src/storage/repositories/task-schedule-repository.ts
+++ b/packages/daemon/src/storage/repositories/task-schedule-repository.ts
@@ -300,10 +300,66 @@ export class TaskScheduleRepository {
 		return result.changes > 0;
 	}
 
+	/**
+	 * Compare-and-swap pause: only transitions to paused and clears the pending
+	 * job when the row's `pending_job_id` still equals `expectedPendingJobId` and
+	 * the status is still `expectedStatus`. Returns true on success, false when
+	 * the precondition failed (concurrent fire/reschedule/delete won).
+	 */
+	pauseIfPending(
+		id: string,
+		expectedStatus: TaskScheduleStatus,
+		expectedPendingJobId: string | null
+	): boolean {
+		const result = this.db
+			.prepare(
+				`UPDATE task_schedules
+				 SET status = 'paused', pending_job_id = NULL, updated_at = ?
+				 WHERE id = ? AND status = ? AND pending_job_id IS ?`
+			)
+			.run(Date.now(), id, expectedStatus, expectedPendingJobId);
+		return result.changes > 0;
+	}
+
+	/**
+	 * Compare-and-swap resume: only transitions to active and sets the pending
+	 * job when the row's `status` is still `paused`. Returns true on success,
+	 * false when the schedule is no longer paused (concurrent resume/delete won).
+	 */
+	resumeIfPaused(
+		id: string,
+		opts: {
+			nextRunAt: number | null;
+			pendingJobId: string | null;
+			status: TaskScheduleStatus;
+		}
+	): boolean {
+		const result = this.db
+			.prepare(
+				`UPDATE task_schedules
+				 SET next_run_at = ?, pending_job_id = ?, status = ?, updated_at = ?
+				 WHERE id = ? AND status = 'paused'`
+			)
+			.run(opts.nextRunAt, opts.pendingJobId, opts.status, Date.now(), id);
+		return result.changes > 0;
+	}
+
 	// ─── Delete ───────────────────────────────────────────────────────────────────
 
 	delete(id: string): boolean {
 		const result = this.db.prepare(`DELETE FROM task_schedules WHERE id = ?`).run(id);
+		return result.changes > 0;
+	}
+
+	/**
+	 * Compare-and-swap delete: only removes the row when its `pending_job_id`
+	 * still equals `expectedPendingJobId`. Returns true on success, false when
+	 * the precondition failed (concurrent fire/reschedule already advanced it).
+	 */
+	deleteIfPending(id: string, expectedPendingJobId: string | null): boolean {
+		const result = this.db
+			.prepare(`DELETE FROM task_schedules WHERE id = ? AND pending_job_id IS ?`)
+			.run(id, expectedPendingJobId);
 		return result.changes > 0;
 	}
 

--- a/packages/daemon/src/storage/repositories/task-schedule-repository.ts
+++ b/packages/daemon/src/storage/repositories/task-schedule-repository.ts
@@ -1,0 +1,270 @@
+/**
+ * TaskScheduleRepository — CRUD for the `task_schedules` table.
+ *
+ * Schedules are immutable after creation except through the explicit mutation
+ * methods (update, updateStatus, updateAfterFire, updatePendingJobId).
+ */
+
+import type { Database as BunDatabase } from 'bun:sqlite';
+import { generateUUID } from '@neokai/shared';
+import type {
+	TaskSchedule,
+	TaskScheduleStatus,
+	TaskScheduleTriggerType,
+	SpaceTaskPriority,
+} from '@neokai/shared';
+
+export interface CreateTaskScheduleParams {
+	spaceId: string;
+	title: string;
+	description?: string;
+	priority?: SpaceTaskPriority;
+	preferredWorkflowId?: string | null;
+	labels?: string[];
+	triggerType: TaskScheduleTriggerType;
+	cronExpression?: string | null;
+	runAt?: number | null;
+	timezone?: string;
+	nextRunAt?: number | null;
+	createdByAgent?: string | null;
+	createdBySession?: string | null;
+}
+
+export interface UpdateTaskScheduleParams {
+	title?: string;
+	description?: string;
+	priority?: SpaceTaskPriority;
+	preferredWorkflowId?: string | null;
+	labels?: string[];
+	cronExpression?: string | null;
+	runAt?: number | null;
+	timezone?: string;
+	nextRunAt?: number | null;
+}
+
+export class TaskScheduleRepository {
+	constructor(private db: BunDatabase) {}
+
+	// ─── Create ──────────────────────────────────────────────────────────────────
+
+	create(params: CreateTaskScheduleParams): TaskSchedule {
+		const id = generateUUID();
+		const now = Date.now();
+
+		this.db
+			.prepare(
+				`INSERT INTO task_schedules (
+					id, space_id, title, description, priority, preferred_workflow_id,
+					labels, trigger_type, cron_expression, run_at, timezone,
+					next_run_at, last_run_at, last_created_task_id, pending_job_id,
+					status, created_by_agent, created_by_session, created_at, updated_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+			)
+			.run(
+				id,
+				params.spaceId,
+				params.title,
+				params.description ?? '',
+				params.priority ?? 'normal',
+				params.preferredWorkflowId ?? null,
+				JSON.stringify(params.labels ?? []),
+				params.triggerType,
+				params.cronExpression ?? null,
+				params.runAt ?? null,
+				params.timezone ?? 'UTC',
+				params.nextRunAt ?? null,
+				null, // last_run_at
+				null, // last_created_task_id
+				null, // pending_job_id
+				'active',
+				params.createdByAgent ?? null,
+				params.createdBySession ?? null,
+				now,
+				now
+			);
+
+		return this.getById(id)!;
+	}
+
+	// ─── Read ─────────────────────────────────────────────────────────────────────
+
+	getById(id: string): TaskSchedule | null {
+		const row = this.db.prepare(`SELECT * FROM task_schedules WHERE id = ?`).get(id) as
+			| Record<string, unknown>
+			| undefined;
+		return row ? this.rowToSchedule(row) : null;
+	}
+
+	listBySpace(spaceId: string, status?: TaskScheduleStatus): TaskSchedule[] {
+		let query = `SELECT * FROM task_schedules WHERE space_id = ?`;
+		const params: (string | number)[] = [spaceId];
+		if (status !== undefined) {
+			query += ` AND status = ?`;
+			params.push(status);
+		}
+		query += ` ORDER BY created_at DESC`;
+		const rows = this.db.prepare(query).all(...params) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToSchedule(r));
+	}
+
+	/**
+	 * List active schedules whose nextRunAt <= now.
+	 * Used for startup re-seeding to recover lost jobs.
+	 */
+	listActiveDue(now: number, limit = 100): TaskSchedule[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM task_schedules
+				 WHERE status = 'active' AND next_run_at IS NOT NULL AND next_run_at <= ?
+				 ORDER BY next_run_at ASC
+				 LIMIT ?`
+			)
+			.all(now, limit) as Record<string, unknown>[];
+		return rows.map((r) => this.rowToSchedule(r));
+	}
+
+	/**
+	 * List active schedules with a pendingJobId set.
+	 * Used during startup to verify pending jobs still exist.
+	 */
+	listActiveWithPendingJob(): TaskSchedule[] {
+		const rows = this.db
+			.prepare(
+				`SELECT * FROM task_schedules
+				 WHERE status = 'active' AND pending_job_id IS NOT NULL`
+			)
+			.all() as Record<string, unknown>[];
+		return rows.map((r) => this.rowToSchedule(r));
+	}
+
+	// ─── Update ───────────────────────────────────────────────────────────────────
+
+	update(id: string, params: UpdateTaskScheduleParams): TaskSchedule | null {
+		const now = Date.now();
+		const sets: string[] = ['updated_at = ?'];
+		const values: (string | number | null)[] = [now];
+
+		if (params.title !== undefined) {
+			sets.push('title = ?');
+			values.push(params.title);
+		}
+		if (params.description !== undefined) {
+			sets.push('description = ?');
+			values.push(params.description);
+		}
+		if (params.priority !== undefined) {
+			sets.push('priority = ?');
+			values.push(params.priority);
+		}
+		if ('preferredWorkflowId' in params) {
+			sets.push('preferred_workflow_id = ?');
+			values.push(params.preferredWorkflowId ?? null);
+		}
+		if (params.labels !== undefined) {
+			sets.push('labels = ?');
+			values.push(JSON.stringify(params.labels));
+		}
+		if ('cronExpression' in params) {
+			sets.push('cron_expression = ?');
+			values.push(params.cronExpression ?? null);
+		}
+		if ('runAt' in params) {
+			sets.push('run_at = ?');
+			values.push(params.runAt ?? null);
+		}
+		if (params.timezone !== undefined) {
+			sets.push('timezone = ?');
+			values.push(params.timezone);
+		}
+		if ('nextRunAt' in params) {
+			sets.push('next_run_at = ?');
+			values.push(params.nextRunAt ?? null);
+		}
+
+		if (sets.length === 1) return this.getById(id); // nothing changed
+
+		values.push(id);
+		this.db.prepare(`UPDATE task_schedules SET ${sets.join(', ')} WHERE id = ?`).run(...values);
+		return this.getById(id);
+	}
+
+	/** Update the pending job ID (called after each enqueue / cancel). */
+	updatePendingJobId(id: string, pendingJobId: string | null): void {
+		this.db
+			.prepare(`UPDATE task_schedules SET pending_job_id = ?, updated_at = ? WHERE id = ?`)
+			.run(pendingJobId, Date.now(), id);
+	}
+
+	/** Update status (active / paused / completed). */
+	updateStatus(id: string, status: TaskScheduleStatus): void {
+		this.db
+			.prepare(`UPDATE task_schedules SET status = ?, updated_at = ? WHERE id = ?`)
+			.run(status, Date.now(), id);
+	}
+
+	/**
+	 * Called after a schedule fires — records last fire time, the created task ID,
+	 * updates nextRunAt, and optionally marks as completed (for 'at' triggers).
+	 */
+	updateAfterFire(
+		id: string,
+		opts: {
+			lastCreatedTaskId: string;
+			lastRunAt: number;
+			nextRunAt: number | null;
+			status: TaskScheduleStatus;
+			pendingJobId: string | null;
+		}
+	): void {
+		this.db
+			.prepare(
+				`UPDATE task_schedules
+				 SET last_created_task_id = ?, last_run_at = ?, next_run_at = ?,
+				     status = ?, pending_job_id = ?, updated_at = ?
+				 WHERE id = ?`
+			)
+			.run(
+				opts.lastCreatedTaskId,
+				opts.lastRunAt,
+				opts.nextRunAt,
+				opts.status,
+				opts.pendingJobId,
+				Date.now(),
+				id
+			);
+	}
+
+	// ─── Delete ───────────────────────────────────────────────────────────────────
+
+	delete(id: string): boolean {
+		const result = this.db.prepare(`DELETE FROM task_schedules WHERE id = ?`).run(id);
+		return result.changes > 0;
+	}
+
+	// ─── Private helpers ──────────────────────────────────────────────────────────
+
+	private rowToSchedule(row: Record<string, unknown>): TaskSchedule {
+		return {
+			id: row.id as string,
+			spaceId: row.space_id as string,
+			title: row.title as string,
+			description: (row.description as string) ?? '',
+			priority: (row.priority as SpaceTaskPriority) ?? 'normal',
+			preferredWorkflowId: (row.preferred_workflow_id as string | null) ?? null,
+			labels: JSON.parse((row.labels as string) ?? '[]') as string[],
+			triggerType: row.trigger_type as TaskScheduleTriggerType,
+			cronExpression: (row.cron_expression as string | null) ?? null,
+			runAt: (row.run_at as number | null) ?? null,
+			timezone: (row.timezone as string) ?? 'UTC',
+			nextRunAt: (row.next_run_at as number | null) ?? null,
+			lastRunAt: (row.last_run_at as number | null) ?? null,
+			lastCreatedTaskId: (row.last_created_task_id as string | null) ?? null,
+			pendingJobId: (row.pending_job_id as string | null) ?? null,
+			status: row.status as TaskScheduleStatus,
+			createdByAgent: (row.created_by_agent as string | null) ?? null,
+			createdBySession: (row.created_by_session as string | null) ?? null,
+			createdAt: row.created_at as number,
+			updatedAt: row.updated_at as number,
+		};
+	}
+}

--- a/packages/daemon/src/storage/repositories/task-schedule-repository.ts
+++ b/packages/daemon/src/storage/repositories/task-schedule-repository.ts
@@ -234,6 +234,47 @@ export class TaskScheduleRepository {
 			);
 	}
 
+	/**
+	 * Compare-and-swap variant of `updateAfterFire`: only applies the update
+	 * when the row's `pending_job_id` still equals `expectedPendingJobId`. This
+	 * lets the fire handler detect concurrent pause/delete/reschedule that
+	 * happened between the initial read and the post-task commit, and roll back
+	 * the in-flight transaction so we don't overwrite the new state.
+	 *
+	 * Returns true when the row was updated, false when the precondition failed
+	 * (status changed, schedule deleted, pending_job_id moved).
+	 */
+	updateAfterFireIfPending(
+		id: string,
+		expectedPendingJobId: string,
+		opts: {
+			lastCreatedTaskId: string;
+			lastRunAt: number;
+			nextRunAt: number | null;
+			status: TaskScheduleStatus;
+			pendingJobId: string | null;
+		}
+	): boolean {
+		const result = this.db
+			.prepare(
+				`UPDATE task_schedules
+				 SET last_created_task_id = ?, last_run_at = ?, next_run_at = ?,
+				     status = ?, pending_job_id = ?, updated_at = ?
+				 WHERE id = ? AND pending_job_id = ?`
+			)
+			.run(
+				opts.lastCreatedTaskId,
+				opts.lastRunAt,
+				opts.nextRunAt,
+				opts.status,
+				opts.pendingJobId,
+				Date.now(),
+				id,
+				expectedPendingJobId
+			);
+		return result.changes > 0;
+	}
+
 	// ─── Delete ───────────────────────────────────────────────────────────────────
 
 	delete(id: string): boolean {

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -85,6 +85,8 @@ export { runMigration121 } from './migrations';
 export { runMigration122 } from './migrations';
 // knip-ignore-next-line
 export { runMigration123 } from './migrations';
+// knip-ignore-next-line
+export { runMigration124 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -590,6 +590,11 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	//   space_external_events — source-level dedup + state machine.
 	//   space_external_event_deliveries — per-subscription delivery lifecycle.
 	runMigration123(db);
+
+	// Migration 124: Add task_schedules table for recurring/one-shot scheduled tasks.
+	//   task_schedules — stores template + trigger config + scheduling state.
+	//   Also adds created_by_task_schedule_id column to space_tasks.
+	runMigration124(db);
 }
 
 /**
@@ -8420,4 +8425,63 @@ export function runMigration123(db: BunDatabase): void {
 		CREATE UNIQUE INDEX IF NOT EXISTS idx_space_external_event_deliveries_key
 		ON space_external_event_deliveries(delivery_key)
 	`);
+}
+
+/**
+ * Migration 124: Add `task_schedules` table for recurring/one-shot scheduled tasks.
+ *
+ * task_schedules
+ *   - Stores template fields (title, description, priority, etc.) + trigger config.
+ *   - triggerType: 'cron' for recurring (cronExpression), 'at' for one-shot (runAt).
+ *   - pendingJobId: O(1) lookup of the pending job in job_queue for cancel/pause.
+ *   - Status machine: active → paused → active (or completed for one-shot).
+ *
+ * Also adds created_by_task_schedule_id column to space_tasks so spawned tasks
+ * can be linked back to their schedule.
+ */
+export function runMigration124(db: BunDatabase): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS task_schedules (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			priority TEXT NOT NULL DEFAULT 'normal'
+				CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+			preferred_workflow_id TEXT DEFAULT NULL,
+			labels TEXT NOT NULL DEFAULT '[]',
+			trigger_type TEXT NOT NULL CHECK(trigger_type IN ('cron', 'at')),
+			cron_expression TEXT DEFAULT NULL,
+			run_at INTEGER DEFAULT NULL,
+			timezone TEXT NOT NULL DEFAULT 'UTC',
+			next_run_at INTEGER DEFAULT NULL,
+			last_run_at INTEGER DEFAULT NULL,
+			last_created_task_id TEXT DEFAULT NULL,
+			pending_job_id TEXT DEFAULT NULL,
+			status TEXT NOT NULL DEFAULT 'active'
+				CHECK(status IN ('active', 'paused', 'completed')),
+			created_by_agent TEXT DEFAULT NULL,
+			created_by_session TEXT DEFAULT NULL,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+		)
+	`);
+
+	db.exec(`
+		CREATE INDEX IF NOT EXISTS idx_task_schedules_space
+		ON task_schedules(space_id, status)
+	`);
+
+	db.exec(`
+		CREATE INDEX IF NOT EXISTS idx_task_schedules_active_due
+		ON task_schedules(status, next_run_at)
+		WHERE status = 'active'
+	`);
+
+	// Add created_by_task_schedule_id column to space_tasks (nullable, no FK).
+	const columns = db.prepare(`PRAGMA table_info(space_tasks)`).all() as { name: string }[];
+	if (columns.length > 0 && !columns.some((c) => c.name === 'created_by_task_schedule_id')) {
+		db.exec(`ALTER TABLE space_tasks ADD COLUMN created_by_task_schedule_id TEXT DEFAULT NULL`);
+	}
 }

--- a/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/db-query/scope-config.test.ts
@@ -70,13 +70,14 @@ describe('scope-config', () => {
 				'workflow_run_artifacts',
 				'workflow_run_artifact_cache',
 				'mcp_audit_log',
+				'task_schedules',
 				// Main-DB tables exposed with space-scoped filtering via session ID prefix:
 				'sessions',
 				'sdk_messages',
 				'session_groups',
 				'session_group_members',
 			]);
-			expect(names).toHaveLength(15);
+			expect(names).toHaveLength(16);
 		});
 
 		it('all table configs have a description', () => {

--- a/packages/daemon/tests/unit/2-handlers/job-handlers/task-schedule-fire.handler.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/job-handlers/task-schedule-fire.handler.test.ts
@@ -197,6 +197,69 @@ describe('handleTaskScheduleFire', () => {
 		expect(after?.lastCreatedTaskId).toBeNull();
 	});
 
+	it('skips when host space is paused (no task created)', async () => {
+		const scheduleId = createCronSchedule();
+		scheduleRepo.updatePendingJobId(scheduleId, 'job-1');
+		spaceRepo.pauseSpace(spaceId);
+
+		const job = makeJob({ payload: { scheduleId } });
+		const result = await handleTaskScheduleFire(job, makeDeps());
+
+		expect(result.skipped).toBe(true);
+		expect(result.skipReason).toBe('space_not_active');
+		expect(taskRepo.listBySpace(spaceId)).toHaveLength(0);
+	});
+
+	it('skips when host space is stopped (no task created)', async () => {
+		const scheduleId = createCronSchedule();
+		scheduleRepo.updatePendingJobId(scheduleId, 'job-1');
+		spaceRepo.stopSpace(spaceId);
+
+		const job = makeJob({ payload: { scheduleId } });
+		const result = await handleTaskScheduleFire(job, makeDeps());
+
+		expect(result.skipped).toBe(true);
+		expect(result.skipReason).toBe('space_not_active');
+		expect(taskRepo.listBySpace(spaceId)).toHaveLength(0);
+	});
+
+	it('rolls back when a concurrent pause invalidates pendingJobId mid-fire', async () => {
+		const scheduleId = createCronSchedule();
+		scheduleRepo.updatePendingJobId(scheduleId, 'job-1');
+
+		// Simulate the compare-and-swap path by injecting a scheduleRepo wrapper
+		// that returns false from `updateAfterFireIfPending` — the handler must
+		// then throw ScheduleSupersededError, the surrounding transaction
+		// rolls back, and we surface a `job_superseded` skip.
+		//
+		// (We can't simulate a true concurrent pause from another connection
+		// because bun:sqlite uses a single in-process handle; mutations inside
+		// the open transaction would just be rolled back too. Returning false
+		// from the CAS exercises the same control flow.)
+		const wrappedScheduleRepo = new Proxy(scheduleRepo, {
+			get(target, prop, recv) {
+				if (prop === 'updateAfterFireIfPending') {
+					return () => false;
+				}
+				return Reflect.get(target, prop, recv);
+			},
+		}) as typeof scheduleRepo;
+
+		const result = await handleTaskScheduleFire(makeJob({ payload: { scheduleId } }), {
+			...makeDeps(),
+			scheduleRepo: wrappedScheduleRepo,
+		});
+
+		expect(result.skipped).toBe(true);
+		expect(result.skipReason).toBe('job_superseded');
+		// Transaction was rolled back — the inserted task is gone.
+		expect(taskRepo.listBySpace(spaceId)).toHaveLength(0);
+		// Schedule's bookkeeping fields were not advanced.
+		const after = scheduleRepo.getById(scheduleId);
+		expect(after?.lastCreatedTaskId).toBeNull();
+		expect(after?.lastRunAt).toBeNull();
+	});
+
 	it('skips on retry once pendingJobId has been advanced past this job (idempotency fence)', async () => {
 		const scheduleId = createCronSchedule();
 		scheduleRepo.updatePendingJobId(scheduleId, 'job-1');

--- a/packages/daemon/tests/unit/2-handlers/job-handlers/task-schedule-fire.handler.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/job-handlers/task-schedule-fire.handler.test.ts
@@ -197,7 +197,7 @@ describe('handleTaskScheduleFire', () => {
 		expect(after?.lastCreatedTaskId).toBeNull();
 	});
 
-	it('skips when host space is paused (no task created)', async () => {
+	it('skips when host space is paused (no task created, pending linkage cleared)', async () => {
 		const scheduleId = createCronSchedule();
 		scheduleRepo.updatePendingJobId(scheduleId, 'job-1');
 		spaceRepo.pauseSpace(spaceId);
@@ -208,9 +208,16 @@ describe('handleTaskScheduleFire', () => {
 		expect(result.skipped).toBe(true);
 		expect(result.skipReason).toBe('space_not_active');
 		expect(taskRepo.listBySpace(spaceId)).toHaveLength(0);
+
+		// Pending linkage cleared so SpaceManager.resumeSpace can re-seed without
+		// the dangling job-1 reference, and `next_run_at` advanced so the schedule
+		// keeps moving forward when the space resumes.
+		const after = scheduleRepo.getById(scheduleId);
+		expect(after?.pendingJobId).toBeNull();
+		expect(after?.status).toBe('active');
 	});
 
-	it('skips when host space is stopped (no task created)', async () => {
+	it('skips when host space is stopped (no task created, pending linkage cleared)', async () => {
 		const scheduleId = createCronSchedule();
 		scheduleRepo.updatePendingJobId(scheduleId, 'job-1');
 		spaceRepo.stopSpace(spaceId);
@@ -221,6 +228,10 @@ describe('handleTaskScheduleFire', () => {
 		expect(result.skipped).toBe(true);
 		expect(result.skipReason).toBe('space_not_active');
 		expect(taskRepo.listBySpace(spaceId)).toHaveLength(0);
+
+		const after = scheduleRepo.getById(scheduleId);
+		expect(after?.pendingJobId).toBeNull();
+		expect(after?.status).toBe('active');
 	});
 
 	it('rolls back when a concurrent pause invalidates pendingJobId mid-fire', async () => {

--- a/packages/daemon/tests/unit/2-handlers/job-handlers/task-schedule-fire.handler.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/job-handlers/task-schedule-fire.handler.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for taskSchedule.fire job handler
+ */
+
+import { describe, expect, it, mock, beforeEach } from 'bun:test';
+import { handleTaskScheduleFire } from '../../../../src/lib/job-handlers/task-schedule-fire.handler';
+import { TASK_SCHEDULE_FIRE } from '../../../../src/lib/job-queue-constants';
+import type { TaskSchedule } from '@neokai/shared';
+import type { Job } from '../../../../src/storage/repositories/job-queue-repository';
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+	return {
+		id: 'job-1',
+		queue: TASK_SCHEDULE_FIRE,
+		status: 'pending',
+		payload: {},
+		result: null,
+		error: null,
+		priority: 0,
+		maxRetries: 3,
+		retryCount: 0,
+		runAt: Date.now() + 60000,
+		createdAt: Date.now(),
+		startedAt: null,
+		completedAt: null,
+		...overrides,
+	};
+}
+
+function makeSchedule(overrides: Partial<TaskSchedule> = {}): TaskSchedule {
+	const now = Date.now();
+	return {
+		id: 'schedule-1',
+		spaceId: 'space-1',
+		title: 'Daily Standup',
+		description: 'Create daily standup task',
+		priority: 'normal',
+		preferredWorkflowId: null,
+		labels: [],
+		triggerType: 'cron',
+		cronExpression: '0 9 * * 1-5', // Mon-Fri at 9am
+		runAt: null,
+		timezone: 'UTC',
+		nextRunAt: now + 3600000,
+		lastRunAt: null,
+		lastCreatedTaskId: null,
+		pendingJobId: null,
+		status: 'active',
+		createdByAgent: null,
+		createdBySession: null,
+		createdAt: now,
+		updatedAt: now,
+		...overrides,
+	};
+}
+
+describe('handleTaskScheduleFire', () => {
+	let getByIdMock: ReturnType<typeof mock>;
+	let createTaskMock: ReturnType<typeof mock>;
+	let enqueueMock: ReturnType<typeof mock>;
+	let updateAfterFireMock: ReturnType<typeof mock>;
+	let updatePendingJobIdMock: ReturnType<typeof mock>;
+	let updateStatusMock: ReturnType<typeof mock>;
+
+	beforeEach(() => {
+		getByIdMock = mock(() => makeSchedule());
+		createTaskMock = mock(async () => ({ id: 'task-1', title: 'Daily Standup' }));
+		enqueueMock = mock(() => makeJob({ id: 'job-2' }));
+		updateAfterFireMock = mock(() => {});
+		updatePendingJobIdMock = mock(() => {});
+		updateStatusMock = mock(() => {});
+	});
+
+	function makeDeps() {
+		return {
+			scheduleRepo: {
+				getById: getByIdMock,
+				updateAfterFire: updateAfterFireMock,
+				updatePendingJobId: updatePendingJobIdMock,
+				updateStatus: updateStatusMock,
+			} as never,
+			jobQueue: {
+				enqueue: enqueueMock,
+			} as never,
+			taskManagerFactory: () =>
+				({
+					createTask: createTaskMock,
+				}) as never,
+		};
+	}
+
+	it('creates a SpaceTask from the schedule template', async () => {
+		const result = await handleTaskScheduleFire({ scheduleId: 'schedule-1' }, makeDeps());
+
+		expect(createTaskMock).toHaveBeenCalledTimes(1);
+		const createArgs = (createTaskMock.mock.calls[0] as [Record<string, unknown>])[0];
+		expect(createArgs.title).toBe('Daily Standup');
+		expect(createArgs.createdByTaskScheduleId).toBe('schedule-1');
+		expect(result.taskId).toBe('task-1');
+		expect(result.skipped).toBe(false);
+	});
+
+	it('re-enqueues itself for cron schedules', async () => {
+		const result = await handleTaskScheduleFire({ scheduleId: 'schedule-1' }, makeDeps());
+
+		expect(enqueueMock).toHaveBeenCalledTimes(1);
+		const enqueueArg = (enqueueMock.mock.calls[0] as [Record<string, unknown>])[0];
+		expect(enqueueArg.queue).toBe(TASK_SCHEDULE_FIRE);
+		expect((enqueueArg.payload as { scheduleId: string }).scheduleId).toBe('schedule-1');
+		expect(typeof enqueueArg.runAt).toBe('number');
+		expect(result.nextRunAt).not.toBeNull();
+	});
+
+	it('calls updateAfterFire with the created task ID', async () => {
+		await handleTaskScheduleFire({ scheduleId: 'schedule-1' }, makeDeps());
+
+		expect(updateAfterFireMock).toHaveBeenCalledTimes(1);
+		const [id, opts] = updateAfterFireMock.mock.calls[0] as [string, Record<string, unknown>];
+		expect(id).toBe('schedule-1');
+		expect(opts.lastCreatedTaskId).toBe('task-1');
+		expect(opts.status).toBe('active');
+		expect(typeof opts.lastRunAt).toBe('number');
+	});
+
+	it('marks one-shot schedule as completed and does not re-enqueue', async () => {
+		getByIdMock = mock(() =>
+			makeSchedule({
+				triggerType: 'at',
+				cronExpression: null,
+				runAt: Date.now() - 1000,
+			})
+		);
+
+		const deps = makeDeps();
+		deps.scheduleRepo.getById = getByIdMock as never;
+
+		const result = await handleTaskScheduleFire({ scheduleId: 'schedule-1' }, deps);
+
+		expect(enqueueMock).not.toHaveBeenCalled();
+		expect(result.nextRunAt).toBeNull();
+
+		const [, opts] = updateAfterFireMock.mock.calls[0] as [string, Record<string, unknown>];
+		expect(opts.status).toBe('completed');
+		expect(opts.pendingJobId).toBeNull();
+	});
+
+	it('skips when schedule is not found', async () => {
+		getByIdMock = mock(() => null);
+		const deps = makeDeps();
+		deps.scheduleRepo.getById = getByIdMock as never;
+
+		const result = await handleTaskScheduleFire({ scheduleId: 'schedule-1' }, deps);
+
+		expect(result.skipped).toBe(true);
+		expect(result.taskId).toBeNull();
+		expect(createTaskMock).not.toHaveBeenCalled();
+		expect(enqueueMock).not.toHaveBeenCalled();
+	});
+
+	it('skips when schedule is paused', async () => {
+		getByIdMock = mock(() => makeSchedule({ status: 'paused' }));
+		const deps = makeDeps();
+		deps.scheduleRepo.getById = getByIdMock as never;
+
+		const result = await handleTaskScheduleFire({ scheduleId: 'schedule-1' }, deps);
+
+		expect(result.skipped).toBe(true);
+		expect(createTaskMock).not.toHaveBeenCalled();
+	});
+
+	it('re-throws createTask errors so the job queue can retry', async () => {
+		createTaskMock = mock(async () => {
+			throw new Error('Task creation failed');
+		});
+		const deps = makeDeps();
+		deps.taskManagerFactory = () => ({ createTask: createTaskMock }) as never;
+
+		await expect(handleTaskScheduleFire({ scheduleId: 'schedule-1' }, deps)).rejects.toThrow(
+			'Task creation failed'
+		);
+	});
+});

--- a/packages/daemon/tests/unit/2-handlers/job-handlers/task-schedule-fire.handler.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/job-handlers/task-schedule-fire.handler.test.ts
@@ -2,181 +2,254 @@
  * Tests for taskSchedule.fire job handler
  */
 
-import { describe, expect, it, mock, beforeEach } from 'bun:test';
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
 import { handleTaskScheduleFire } from '../../../../src/lib/job-handlers/task-schedule-fire.handler';
 import { TASK_SCHEDULE_FIRE } from '../../../../src/lib/job-queue-constants';
-import type { TaskSchedule } from '@neokai/shared';
 import type { Job } from '../../../../src/storage/repositories/job-queue-repository';
+import { JobQueueRepository } from '../../../../src/storage/repositories/job-queue-repository';
+import { TaskScheduleRepository } from '../../../../src/storage/repositories/task-schedule-repository';
+import { SpaceRepository } from '../../../../src/storage/repositories/space-repository';
+import { SpaceTaskRepository } from '../../../../src/storage/repositories/space-task-repository';
+import { createSpaceTables } from '../../helpers/space-test-db';
 
 function makeJob(overrides: Partial<Job> = {}): Job {
 	return {
 		id: 'job-1',
 		queue: TASK_SCHEDULE_FIRE,
-		status: 'pending',
-		payload: {},
+		status: 'processing',
+		payload: { scheduleId: 'placeholder' },
 		result: null,
 		error: null,
 		priority: 0,
 		maxRetries: 3,
 		retryCount: 0,
-		runAt: Date.now() + 60000,
+		runAt: Date.now(),
 		createdAt: Date.now(),
-		startedAt: null,
+		startedAt: Date.now(),
 		completedAt: null,
 		...overrides,
 	};
 }
 
-function makeSchedule(overrides: Partial<TaskSchedule> = {}): TaskSchedule {
-	const now = Date.now();
-	return {
-		id: 'schedule-1',
-		spaceId: 'space-1',
-		title: 'Daily Standup',
-		description: 'Create daily standup task',
-		priority: 'normal',
-		preferredWorkflowId: null,
-		labels: [],
-		triggerType: 'cron',
-		cronExpression: '0 9 * * 1-5', // Mon-Fri at 9am
-		runAt: null,
-		timezone: 'UTC',
-		nextRunAt: now + 3600000,
-		lastRunAt: null,
-		lastCreatedTaskId: null,
-		pendingJobId: null,
-		status: 'active',
-		createdByAgent: null,
-		createdBySession: null,
-		createdAt: now,
-		updatedAt: now,
-		...overrides,
-	};
-}
-
 describe('handleTaskScheduleFire', () => {
-	let getByIdMock: ReturnType<typeof mock>;
-	let createTaskMock: ReturnType<typeof mock>;
-	let enqueueMock: ReturnType<typeof mock>;
-	let updateAfterFireMock: ReturnType<typeof mock>;
-	let updatePendingJobIdMock: ReturnType<typeof mock>;
-	let updateStatusMock: ReturnType<typeof mock>;
+	let db: Database;
+	let scheduleRepo: TaskScheduleRepository;
+	let jobQueue: JobQueueRepository;
+	let spaceRepo: SpaceRepository;
+	let taskRepo: SpaceTaskRepository;
+	let spaceId: string;
 
 	beforeEach(() => {
-		getByIdMock = mock(() => makeSchedule());
-		createTaskMock = mock(async () => ({ id: 'task-1', title: 'Daily Standup' }));
-		enqueueMock = mock(() => makeJob({ id: 'job-2' }));
-		updateAfterFireMock = mock(() => {});
-		updatePendingJobIdMock = mock(() => {});
-		updateStatusMock = mock(() => {});
+		db = new Database(':memory:');
+		createSpaceTables(db);
+
+		// Add the job_queue table — not part of createSpaceTables.
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS job_queue (
+				id TEXT PRIMARY KEY,
+				queue TEXT NOT NULL,
+				status TEXT NOT NULL DEFAULT 'pending'
+					CHECK(status IN ('pending', 'processing', 'completed', 'failed', 'dead')),
+				payload TEXT NOT NULL DEFAULT '{}',
+				result TEXT,
+				error TEXT,
+				priority INTEGER NOT NULL DEFAULT 0,
+				max_retries INTEGER NOT NULL DEFAULT 3,
+				retry_count INTEGER NOT NULL DEFAULT 0,
+				run_at INTEGER NOT NULL,
+				created_at INTEGER NOT NULL,
+				started_at INTEGER,
+				completed_at INTEGER
+			);
+			CREATE INDEX IF NOT EXISTS idx_job_queue_dequeue ON job_queue(queue, status, priority DESC, run_at ASC);
+		`);
+
+		spaceRepo = new SpaceRepository(db as never);
+		scheduleRepo = new TaskScheduleRepository(db as never);
+		jobQueue = new JobQueueRepository(db as never);
+		taskRepo = new SpaceTaskRepository(db as never);
+
+		const space = spaceRepo.createSpace({
+			slug: 'test',
+			workspacePath: '/workspace/test',
+			name: 'Test',
+			description: 'Test space',
+		});
+		spaceId = space.id;
+	});
+
+	afterEach(() => {
+		db.close();
 	});
 
 	function makeDeps() {
-		return {
-			scheduleRepo: {
-				getById: getByIdMock,
-				updateAfterFire: updateAfterFireMock,
-				updatePendingJobId: updatePendingJobIdMock,
-				updateStatus: updateStatusMock,
-			} as never,
-			jobQueue: {
-				enqueue: enqueueMock,
-			} as never,
-			taskManagerFactory: () =>
-				({
-					createTask: createTaskMock,
-				}) as never,
-		};
+		return { db: db as never, scheduleRepo, jobQueue, spaceRepo, taskRepo };
 	}
 
-	it('creates a SpaceTask from the schedule template', async () => {
-		const result = await handleTaskScheduleFire({ scheduleId: 'schedule-1' }, makeDeps());
+	function createCronSchedule(): string {
+		const future = Date.now() + 60_000;
+		const schedule = scheduleRepo.create({
+			spaceId,
+			title: 'Daily Standup',
+			description: 'Standup task',
+			triggerType: 'cron',
+			cronExpression: '0 9 * * 1-5',
+			timezone: 'UTC',
+			nextRunAt: future,
+		});
+		return schedule.id;
+	}
 
-		expect(createTaskMock).toHaveBeenCalledTimes(1);
-		const createArgs = (createTaskMock.mock.calls[0] as [Record<string, unknown>])[0];
-		expect(createArgs.title).toBe('Daily Standup');
-		expect(createArgs.createdByTaskScheduleId).toBe('schedule-1');
-		expect(result.taskId).toBe('task-1');
+	function createAtSchedule(runAt: number): string {
+		const schedule = scheduleRepo.create({
+			spaceId,
+			title: 'One Shot',
+			triggerType: 'at',
+			runAt,
+			nextRunAt: runAt,
+		});
+		return schedule.id;
+	}
+
+	it('creates a SpaceTask from the cron schedule template and re-enqueues itself', async () => {
+		const scheduleId = createCronSchedule();
+		// Set pendingJobId so idempotency check sees a match.
+		scheduleRepo.updatePendingJobId(scheduleId, 'job-1');
+
+		const job = makeJob({ payload: { scheduleId } });
+		const result = await handleTaskScheduleFire(job, makeDeps());
+
 		expect(result.skipped).toBe(false);
-	});
-
-	it('re-enqueues itself for cron schedules', async () => {
-		const result = await handleTaskScheduleFire({ scheduleId: 'schedule-1' }, makeDeps());
-
-		expect(enqueueMock).toHaveBeenCalledTimes(1);
-		const enqueueArg = (enqueueMock.mock.calls[0] as [Record<string, unknown>])[0];
-		expect(enqueueArg.queue).toBe(TASK_SCHEDULE_FIRE);
-		expect((enqueueArg.payload as { scheduleId: string }).scheduleId).toBe('schedule-1');
-		expect(typeof enqueueArg.runAt).toBe('number');
+		expect(result.taskId).not.toBeNull();
 		expect(result.nextRunAt).not.toBeNull();
-	});
 
-	it('calls updateAfterFire with the created task ID', async () => {
-		await handleTaskScheduleFire({ scheduleId: 'schedule-1' }, makeDeps());
+		// Task was created with createdByTaskScheduleId pointing back at the schedule.
+		const task = taskRepo.getTask(result.taskId as string);
+		expect(task).not.toBeNull();
+		expect(task?.createdByTaskScheduleId).toBe(scheduleId);
+		expect(task?.title).toBe('Daily Standup');
 
-		expect(updateAfterFireMock).toHaveBeenCalledTimes(1);
-		const [id, opts] = updateAfterFireMock.mock.calls[0] as [string, Record<string, unknown>];
-		expect(id).toBe('schedule-1');
-		expect(opts.lastCreatedTaskId).toBe('task-1');
-		expect(opts.status).toBe('active');
-		expect(typeof opts.lastRunAt).toBe('number');
+		// A new fire job was enqueued.
+		const updated = scheduleRepo.getById(scheduleId);
+		expect(updated?.pendingJobId).not.toBeNull();
+		expect(updated?.pendingJobId).not.toBe('job-1');
+		expect(updated?.lastCreatedTaskId).toBe(result.taskId);
+		expect(updated?.status).toBe('active');
 	});
 
 	it('marks one-shot schedule as completed and does not re-enqueue', async () => {
-		getByIdMock = mock(() =>
-			makeSchedule({
-				triggerType: 'at',
-				cronExpression: null,
-				runAt: Date.now() - 1000,
-			})
-		);
+		const future = Date.now() + 60_000;
+		const scheduleId = createAtSchedule(future);
+		scheduleRepo.updatePendingJobId(scheduleId, 'job-1');
 
-		const deps = makeDeps();
-		deps.scheduleRepo.getById = getByIdMock as never;
+		const beforeJobs = jobQueue.listJobs({}).length;
 
-		const result = await handleTaskScheduleFire({ scheduleId: 'schedule-1' }, deps);
+		const job = makeJob({ payload: { scheduleId } });
+		const result = await handleTaskScheduleFire(job, makeDeps());
 
-		expect(enqueueMock).not.toHaveBeenCalled();
+		expect(result.skipped).toBe(false);
+		expect(result.taskId).not.toBeNull();
 		expect(result.nextRunAt).toBeNull();
 
-		const [, opts] = updateAfterFireMock.mock.calls[0] as [string, Record<string, unknown>];
-		expect(opts.status).toBe('completed');
-		expect(opts.pendingJobId).toBeNull();
+		const updated = scheduleRepo.getById(scheduleId);
+		expect(updated?.status).toBe('completed');
+		expect(updated?.pendingJobId).toBeNull();
+
+		const afterJobs = jobQueue.listJobs({}).length;
+		expect(afterJobs).toBe(beforeJobs);
 	});
 
-	it('skips when schedule is not found', async () => {
-		getByIdMock = mock(() => null);
-		const deps = makeDeps();
-		deps.scheduleRepo.getById = getByIdMock as never;
-
-		const result = await handleTaskScheduleFire({ scheduleId: 'schedule-1' }, deps);
+	it('skips when schedule is missing', async () => {
+		const job = makeJob({ payload: { scheduleId: 'nonexistent' } });
+		const result = await handleTaskScheduleFire(job, makeDeps());
 
 		expect(result.skipped).toBe(true);
+		expect(result.skipReason).toBe('inactive_or_missing');
 		expect(result.taskId).toBeNull();
-		expect(createTaskMock).not.toHaveBeenCalled();
-		expect(enqueueMock).not.toHaveBeenCalled();
 	});
 
 	it('skips when schedule is paused', async () => {
-		getByIdMock = mock(() => makeSchedule({ status: 'paused' }));
-		const deps = makeDeps();
-		deps.scheduleRepo.getById = getByIdMock as never;
+		const scheduleId = createCronSchedule();
+		scheduleRepo.updateStatus(scheduleId, 'paused');
 
-		const result = await handleTaskScheduleFire({ scheduleId: 'schedule-1' }, deps);
+		const job = makeJob({ payload: { scheduleId } });
+		const result = await handleTaskScheduleFire(job, makeDeps());
 
 		expect(result.skipped).toBe(true);
-		expect(createTaskMock).not.toHaveBeenCalled();
+		expect(result.skipReason).toBe('inactive_or_missing');
 	});
 
-	it('re-throws createTask errors so the job queue can retry', async () => {
-		createTaskMock = mock(async () => {
-			throw new Error('Task creation failed');
-		});
-		const deps = makeDeps();
-		deps.taskManagerFactory = () => ({ createTask: createTaskMock }) as never;
+	it('skips when host space is archived (no task created)', async () => {
+		const scheduleId = createCronSchedule();
+		scheduleRepo.updatePendingJobId(scheduleId, 'job-1');
+		spaceRepo.archiveSpace(spaceId);
 
-		await expect(handleTaskScheduleFire({ scheduleId: 'schedule-1' }, deps)).rejects.toThrow(
-			'Task creation failed'
+		const job = makeJob({ payload: { scheduleId } });
+		const result = await handleTaskScheduleFire(job, makeDeps());
+
+		expect(result.skipped).toBe(true);
+		expect(result.skipReason).toBe('space_not_active');
+		expect(result.taskId).toBeNull();
+
+		// Schedule was not advanced.
+		const after = scheduleRepo.getById(scheduleId);
+		expect(after?.lastCreatedTaskId).toBeNull();
+	});
+
+	it('skips on retry once pendingJobId has been advanced past this job (idempotency fence)', async () => {
+		const scheduleId = createCronSchedule();
+		scheduleRepo.updatePendingJobId(scheduleId, 'job-1');
+
+		// First fire: succeeds, pendingJobId moves to a new job id.
+		const firstResult = await handleTaskScheduleFire(
+			makeJob({ payload: { scheduleId } }),
+			makeDeps()
 		);
+		expect(firstResult.skipped).toBe(false);
+		const tasksAfterFirst = taskRepo.listBySpace(spaceId).length;
+
+		// Now simulate the queue retrying the original `job-1`. Because pendingJobId
+		// has advanced to a new id, the handler should skip task creation.
+		const retryResult = await handleTaskScheduleFire(
+			makeJob({ id: 'job-1', payload: { scheduleId } }),
+			makeDeps()
+		);
+		expect(retryResult.skipped).toBe(true);
+		expect(retryResult.skipReason).toBe('job_superseded');
+
+		// And no extra task was created.
+		const tasksAfterRetry = taskRepo.listBySpace(spaceId).length;
+		expect(tasksAfterRetry).toBe(tasksAfterFirst);
+	});
+
+	it('rolls back the transaction if any step throws (no half-fired state)', async () => {
+		const scheduleId = createCronSchedule();
+		scheduleRepo.updatePendingJobId(scheduleId, 'job-1');
+
+		// Force jobQueue.enqueue to throw to simulate a failure between
+		// task creation and updating the schedule.
+		const brokenJobQueue = {
+			...jobQueue,
+			enqueue: () => {
+				throw new Error('synthetic enqueue failure');
+			},
+		} as unknown as typeof jobQueue;
+
+		await expect(
+			handleTaskScheduleFire(makeJob({ payload: { scheduleId } }), {
+				db: db as never,
+				scheduleRepo,
+				jobQueue: brokenJobQueue,
+				spaceRepo,
+				taskRepo,
+			})
+		).rejects.toThrow('synthetic enqueue failure');
+
+		// Transaction rolled back — no orphan task, schedule unchanged.
+		const after = scheduleRepo.getById(scheduleId);
+		expect(after?.lastCreatedTaskId).toBeNull();
+		expect(after?.status).toBe('active');
+		expect(taskRepo.listBySpace(spaceId)).toHaveLength(0);
 	});
 });

--- a/packages/daemon/tests/unit/4-space-storage/schedule-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/schedule-service.test.ts
@@ -157,6 +157,64 @@ describe('ScheduleService', () => {
 			expect(updated.title).toBe('Renamed');
 			expect(updated.pendingJobId).toBe(oldJobId);
 		});
+
+		it('rejects timing edits whose merged trigger config produces no nextRunAt', () => {
+			const schedule = service.createSchedule({
+				spaceId,
+				title: 'Cron',
+				triggerType: 'cron',
+				cronExpression: '0 9 * * *',
+				timezone: 'UTC',
+			});
+			const oldJobId = schedule.pendingJobId as string;
+
+			// Bogus IANA timezone. croner should refuse and getNextRunAt returns null.
+			expect(() => service.updateSchedule(schedule.id, { timezone: 'Not/A_Real_Zone' })).toThrow(
+				/Could not compute next run/
+			);
+
+			// Schedule and original job must be untouched on failure.
+			const after = scheduleRepo.getById(schedule.id);
+			expect(after?.pendingJobId).toBe(oldJobId);
+			expect(after?.timezone).toBe('UTC');
+			expect(jobQueue.getJob(oldJobId)).not.toBeNull();
+		});
+
+		it('rolls back the old pending job linkage if enqueue throws mid-update', () => {
+			const schedule = service.createSchedule({
+				spaceId,
+				title: 'Cron',
+				triggerType: 'cron',
+				cronExpression: '0 9 * * *',
+			});
+			const oldJobId = schedule.pendingJobId as string;
+
+			// Wrap jobQueue.enqueue to throw on the first reschedule call.
+			const breakingService = new ScheduleService({
+				db: db as never,
+				scheduleRepo,
+				jobQueue: {
+					...jobQueue,
+					enqueue: () => {
+						throw new Error('synthetic enqueue failure');
+					},
+					deleteJob: jobQueue.deleteJob.bind(jobQueue),
+					getJob: jobQueue.getJob.bind(jobQueue),
+				} as unknown as typeof jobQueue,
+			});
+
+			expect(() =>
+				breakingService.updateSchedule(schedule.id, { cronExpression: '0 10 * * *' })
+			).toThrow('synthetic enqueue failure');
+
+			// Schedule must still be active with the original pending job intact.
+			const after = scheduleRepo.getById(schedule.id);
+			expect(after?.status).toBe('active');
+			expect(after?.pendingJobId).toBe(oldJobId);
+			expect(jobQueue.getJob(oldJobId)).not.toBeNull();
+			// And the cronExpression update was also rolled back.
+			expect(after?.cronExpression).toBe('0 9 * * *');
+		});
 	});
 
 	describe('pause/resume/delete', () => {
@@ -209,6 +267,25 @@ describe('ScheduleService', () => {
 			const resumed = service.resumeSchedule(schedule.id);
 			expect(resumed.status).toBe('completed');
 			expect(resumed.pendingJobId).toBeNull();
+		});
+
+		it('resume of a cron schedule with an unrecoverable timezone throws (preserves paused)', () => {
+			const schedule = service.createSchedule({
+				spaceId,
+				title: 'Cron',
+				triggerType: 'cron',
+				cronExpression: '0 9 * * *',
+			});
+			service.pauseSchedule(schedule.id);
+
+			// Corrupt the timezone directly via the repo so getNextRunAt can't compute.
+			scheduleRepo.update(schedule.id, { timezone: 'Not/A_Real_Zone' });
+
+			expect(() => service.resumeSchedule(schedule.id)).toThrow(/Cannot resume cron schedule/);
+			// Schedule remains paused — operator can fix and retry.
+			const after = scheduleRepo.getById(schedule.id);
+			expect(after?.status).toBe('paused');
+			expect(after?.pendingJobId).toBeNull();
 		});
 
 		it('delete cancels the pending job and removes the schedule row', () => {

--- a/packages/daemon/tests/unit/4-space-storage/schedule-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/schedule-service.test.ts
@@ -48,7 +48,7 @@ describe('ScheduleService', () => {
 		spaceRepo = new SpaceRepository(db as never);
 		scheduleRepo = new TaskScheduleRepository(db as never);
 		jobQueue = new JobQueueRepository(db as never);
-		service = new ScheduleService({ db: db as never, scheduleRepo, jobQueue });
+		service = new ScheduleService({ db: db as never, scheduleRepo, jobQueue, spaceRepo });
 
 		const space = spaceRepo.createSpace({
 			slug: 'test',
@@ -122,6 +122,18 @@ describe('ScheduleService', () => {
 					triggerType: 'webhook' as any,
 				})
 			).toThrow(/Unsupported triggerType/);
+		});
+
+		it('rejects creation in an archived space', () => {
+			spaceRepo.archiveSpace(spaceId);
+			expect(() =>
+				service.createSchedule({
+					spaceId,
+					title: 'Archived',
+					triggerType: 'cron',
+					cronExpression: '0 9 * * *',
+				})
+			).toThrow(/non-active space/);
 		});
 	});
 
@@ -228,6 +240,25 @@ describe('ScheduleService', () => {
 			expect(jobQueue.getJob(oldJobId)).not.toBeNull();
 		});
 
+		it('rejects invalid timezone edits even when the schedule is paused', () => {
+			const schedule = service.createSchedule({
+				spaceId,
+				title: 'Cron',
+				triggerType: 'cron',
+				cronExpression: '0 9 * * *',
+				timezone: 'UTC',
+			});
+			service.pauseSchedule(schedule.id);
+
+			expect(() => service.updateSchedule(schedule.id, { timezone: 'Not/A_Real_Zone' })).toThrow(
+				/Could not compute next run/
+			);
+
+			const after = scheduleRepo.getById(schedule.id);
+			expect(after?.timezone).toBe('UTC');
+			expect(after?.status).toBe('paused');
+		});
+
 		it('rolls back the old pending job linkage if enqueue throws mid-update', () => {
 			const schedule = service.createSchedule({
 				spaceId,
@@ -280,6 +311,55 @@ describe('ScheduleService', () => {
 			expect(paused.status).toBe('paused');
 			expect(paused.pendingJobId).toBeNull();
 			expect(jobQueue.getJob(jobId)).toBeNull();
+		});
+
+		it('pause CAS tolerates a concurrent fire that advanced pendingJobId', () => {
+			const schedule = service.createSchedule({
+				spaceId,
+				title: 'Cron',
+				triggerType: 'cron',
+				cronExpression: '0 9 * * *',
+			});
+			const originalJobId = schedule.pendingJobId as string;
+
+			// Simulate a concurrent fire: the DB row now has a new pending job,
+			// but we inject a stale read so pauseSchedule sees the old value.
+			const newJob = jobQueue.enqueue({
+				queue: 'taskSchedule.fire',
+				payload: { scheduleId: schedule.id },
+				runAt: Date.now() + 3600_000,
+			});
+			scheduleRepo.updatePendingJobId(schedule.id, newJob.id);
+
+			const staleRepo = new Proxy(scheduleRepo, {
+				get(target, prop, recv) {
+					if (prop === 'getById') {
+						return (id: string) => {
+							const fresh = target.getById(id);
+							if (!fresh) return fresh;
+							// Return stale pendingJobId so the CAS precondition fails.
+							return { ...fresh, pendingJobId: originalJobId };
+						};
+					}
+					return Reflect.get(target, prop, recv);
+				},
+			}) as typeof scheduleRepo;
+
+			const casService = new ScheduleService({
+				db: db as never,
+				scheduleRepo: staleRepo,
+				jobQueue,
+				spaceRepo,
+			});
+
+			// Pause should detect the CAS miss and leave the schedule untouched.
+			const result = casService.pauseSchedule(schedule.id);
+			// The service returns the stale read (test artifact of the Proxy),
+			// but the DB row must remain active with the new pending job.
+			const dbState = scheduleRepo.getById(schedule.id);
+			expect(dbState?.status).toBe('active');
+			expect(dbState?.pendingJobId).toBe(newJob.id);
+			expect(jobQueue.getJob(newJob.id)).not.toBeNull();
 		});
 
 		it('resume re-enqueues a fresh fire job', () => {
@@ -350,6 +430,59 @@ describe('ScheduleService', () => {
 			expect(ok).toBe(true);
 			expect(scheduleRepo.getById(schedule.id)).toBeNull();
 			expect(jobQueue.getJob(jobId)).toBeNull();
+		});
+
+		it('delete CAS tolerates a concurrent fire that advanced pendingJobId', () => {
+			const schedule = service.createSchedule({
+				spaceId,
+				title: 'Cron',
+				triggerType: 'cron',
+				cronExpression: '0 9 * * *',
+			});
+			const originalJobId = schedule.pendingJobId as string;
+
+			// Simulate a concurrent fire: the DB row now has a new pending job,
+			// but we inject a stale read so deleteSchedule sees the old value.
+			const newJob = jobQueue.enqueue({
+				queue: 'taskSchedule.fire',
+				payload: { scheduleId: schedule.id },
+				runAt: Date.now() + 3600_000,
+			});
+			scheduleRepo.updatePendingJobId(schedule.id, newJob.id);
+
+			const staleRepo = new Proxy(scheduleRepo, {
+				get(target, prop, recv) {
+					if (prop === 'getById') {
+						return (id: string) => {
+							const fresh = target.getById(id);
+							if (!fresh) return fresh;
+							// Return stale pendingJobId so the CAS precondition fails.
+							return { ...fresh, pendingJobId: originalJobId };
+						};
+					}
+					return Reflect.get(target, prop, recv);
+				},
+			}) as typeof scheduleRepo;
+
+			const casService = new ScheduleService({
+				db: db as never,
+				scheduleRepo: staleRepo,
+				jobQueue,
+				spaceRepo,
+			});
+
+			// Delete should detect the CAS miss and return false.
+			const ok = casService.deleteSchedule(schedule.id);
+			expect(ok).toBe(false);
+
+			// Schedule still exists with the new pending job intact.
+			const after = scheduleRepo.getById(schedule.id);
+			expect(after).not.toBeNull();
+			expect(after?.pendingJobId).toBe(newJob.id);
+			expect(jobQueue.getJob(newJob.id)).not.toBeNull();
+			// The stale original job was deleted (expected — it was the observed
+			// pending job at the time deleteSchedule read the schedule).
+			expect(jobQueue.getJob(originalJobId)).toBeNull();
 		});
 	});
 

--- a/packages/daemon/tests/unit/4-space-storage/schedule-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/schedule-service.test.ts
@@ -190,6 +190,22 @@ describe('ScheduleService', () => {
 			expect(updated.pendingJobId).toBe(oldJobId);
 		});
 
+		it('does not clear trigger fields when updating unrelated metadata', () => {
+			const schedule = service.createSchedule({
+				spaceId,
+				title: 'Cron',
+				triggerType: 'cron',
+				cronExpression: '0 9 * * *',
+				preferredWorkflowId: 'wf-1',
+			});
+
+			const updated = service.updateSchedule(schedule.id, { title: 'Renamed' });
+
+			expect(updated.title).toBe('Renamed');
+			expect(updated.cronExpression).toBe('0 9 * * *');
+			expect(updated.preferredWorkflowId).toBe('wf-1');
+		});
+
 		it('rejects timing edits whose merged trigger config produces no nextRunAt', () => {
 			const schedule = service.createSchedule({
 				spaceId,
@@ -431,6 +447,28 @@ describe('ScheduleService', () => {
 
 			const after = scheduleRepo.getById(schedule.id);
 			expect(after?.status).toBe('active'); // not terminally completed
+			expect(after?.pendingJobId).toBeNull();
+		});
+
+		it('skips schedules that were paused between snapshot and reseed', () => {
+			const schedule = service.createSchedule({
+				spaceId,
+				title: 'Cron',
+				triggerType: 'cron',
+				cronExpression: '0 9 * * *',
+			});
+			scheduleRepo.updatePendingJobId(schedule.id, null);
+
+			// Simulate a concurrent pause: the snapshot says active+no-pending,
+			// but by the time the recovery loop reaches this schedule it has been
+			// paused. The reseed must not override the operator's pause.
+			scheduleRepo.updateStatus(schedule.id, 'paused');
+
+			const recovered = service.recoverSchedulesForSpace(spaceId);
+			expect(recovered).toBe(0);
+
+			const after = scheduleRepo.getById(schedule.id);
+			expect(after?.status).toBe('paused');
 			expect(after?.pendingJobId).toBeNull();
 		});
 	});

--- a/packages/daemon/tests/unit/4-space-storage/schedule-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/schedule-service.test.ts
@@ -111,9 +111,41 @@ describe('ScheduleService', () => {
 				})
 			).toThrow(/runAt must be in the future/);
 		});
+
+		it('rejects an unsupported triggerType', () => {
+			expect(() =>
+				service.createSchedule({
+					spaceId,
+					title: 'Bad trigger',
+					// biome-ignore lint/suspicious/noExplicitAny: deliberately bypassing TS to simulate
+					// a malformed RPC payload.
+					triggerType: 'webhook' as any,
+				})
+			).toThrow(/Unsupported triggerType/);
+		});
 	});
 
 	describe('updateSchedule', () => {
+		it('rejects clearing the title to empty/whitespace', () => {
+			const schedule = service.createSchedule({
+				spaceId,
+				title: 'Cron',
+				triggerType: 'cron',
+				cronExpression: '0 9 * * *',
+			});
+
+			expect(() => service.updateSchedule(schedule.id, { title: '' })).toThrow(
+				/title must be a non-empty string/
+			);
+			expect(() => service.updateSchedule(schedule.id, { title: '   ' })).toThrow(
+				/title must be a non-empty string/
+			);
+
+			// Schedule's title is unchanged after the rejected updates.
+			const after = scheduleRepo.getById(schedule.id);
+			expect(after?.title).toBe('Cron');
+		});
+
 		it('rejects setting cronExpression to null on a cron schedule', () => {
 			const schedule = service.createSchedule({
 				spaceId,
@@ -302,6 +334,104 @@ describe('ScheduleService', () => {
 			expect(ok).toBe(true);
 			expect(scheduleRepo.getById(schedule.id)).toBeNull();
 			expect(jobQueue.getJob(jobId)).toBeNull();
+		});
+	});
+
+	describe('recoverSchedulesForSpace', () => {
+		it('re-enqueues active cron schedules whose pendingJobId was cleared', () => {
+			const schedule = service.createSchedule({
+				spaceId,
+				title: 'Cron',
+				triggerType: 'cron',
+				cronExpression: '0 9 * * *',
+				timezone: 'UTC',
+			});
+
+			// Simulate the fire-handler's space-paused branch clearing pending linkage.
+			scheduleRepo.updatePendingJobId(schedule.id, null);
+
+			const recovered = service.recoverSchedulesForSpace(spaceId);
+			expect(recovered).toBe(1);
+
+			const after = scheduleRepo.getById(schedule.id);
+			expect(after?.pendingJobId).not.toBeNull();
+			expect(after?.status).toBe('active');
+			expect(jobQueue.getJob(after?.pendingJobId as string)).not.toBeNull();
+		});
+
+		it('re-enqueues `at` schedules whose runAt is still in the future', () => {
+			const future = Date.now() + 60_000;
+			const schedule = service.createSchedule({
+				spaceId,
+				title: 'One Shot',
+				triggerType: 'at',
+				runAt: future,
+			});
+			scheduleRepo.updatePendingJobId(schedule.id, null);
+
+			const recovered = service.recoverSchedulesForSpace(spaceId);
+			expect(recovered).toBe(1);
+
+			const after = scheduleRepo.getById(schedule.id);
+			expect(after?.pendingJobId).not.toBeNull();
+			expect(after?.status).toBe('active');
+		});
+
+		it('marks `at` schedules whose deadline expired during the outage as completed', () => {
+			const future = Date.now() + 60_000;
+			const schedule = service.createSchedule({
+				spaceId,
+				title: 'One Shot',
+				triggerType: 'at',
+				runAt: future,
+			});
+			scheduleRepo.updatePendingJobId(schedule.id, null);
+			// Move runAt into the past directly via the repo (bypass validation).
+			scheduleRepo.update(schedule.id, { runAt: Date.now() - 60_000 });
+
+			const recovered = service.recoverSchedulesForSpace(spaceId);
+			expect(recovered).toBe(0); // expired schedule wasn't re-enqueued
+
+			const after = scheduleRepo.getById(schedule.id);
+			expect(after?.status).toBe('completed');
+			expect(after?.pendingJobId).toBeNull();
+		});
+
+		it('skips schedules that already have a pending job linked', () => {
+			const schedule = service.createSchedule({
+				spaceId,
+				title: 'Cron',
+				triggerType: 'cron',
+				cronExpression: '0 9 * * *',
+			});
+			const originalJobId = schedule.pendingJobId;
+
+			const recovered = service.recoverSchedulesForSpace(spaceId);
+			expect(recovered).toBe(0);
+
+			// Existing linkage untouched.
+			const after = scheduleRepo.getById(schedule.id);
+			expect(after?.pendingJobId).toBe(originalJobId);
+		});
+
+		it('leaves an unrecoverable cron config alone for the operator to fix', () => {
+			const schedule = service.createSchedule({
+				spaceId,
+				title: 'Cron',
+				triggerType: 'cron',
+				cronExpression: '0 9 * * *',
+				timezone: 'UTC',
+			});
+			scheduleRepo.updatePendingJobId(schedule.id, null);
+			// Corrupt timezone so getNextRunAt returns null.
+			scheduleRepo.update(schedule.id, { timezone: 'Not/A_Real_Zone' });
+
+			const recovered = service.recoverSchedulesForSpace(spaceId);
+			expect(recovered).toBe(0);
+
+			const after = scheduleRepo.getById(schedule.id);
+			expect(after?.status).toBe('active'); // not terminally completed
+			expect(after?.pendingJobId).toBeNull();
 		});
 	});
 });

--- a/packages/daemon/tests/unit/4-space-storage/schedule-service.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/schedule-service.test.ts
@@ -1,0 +1,230 @@
+/**
+ * ScheduleService unit tests
+ *
+ * Exercises the centralized schedule lifecycle behavior shared by both the
+ * RPC handlers and the agent-facing MCP tools: validation, atomic
+ * create+enqueue, edit-time consistency, pause/resume, and delete.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { JobQueueRepository } from '../../../src/storage/repositories/job-queue-repository';
+import { TaskScheduleRepository } from '../../../src/storage/repositories/task-schedule-repository';
+import { SpaceRepository } from '../../../src/storage/repositories/space-repository';
+import { ScheduleService } from '../../../src/lib/space/schedule/schedule-service';
+import { createSpaceTables } from '../helpers/space-test-db';
+
+describe('ScheduleService', () => {
+	let db: Database;
+	let scheduleRepo: TaskScheduleRepository;
+	let jobQueue: JobQueueRepository;
+	let spaceRepo: SpaceRepository;
+	let service: ScheduleService;
+	let spaceId: string;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS job_queue (
+				id TEXT PRIMARY KEY,
+				queue TEXT NOT NULL,
+				status TEXT NOT NULL DEFAULT 'pending'
+					CHECK(status IN ('pending', 'processing', 'completed', 'failed', 'dead')),
+				payload TEXT NOT NULL DEFAULT '{}',
+				result TEXT,
+				error TEXT,
+				priority INTEGER NOT NULL DEFAULT 0,
+				max_retries INTEGER NOT NULL DEFAULT 3,
+				retry_count INTEGER NOT NULL DEFAULT 0,
+				run_at INTEGER NOT NULL,
+				created_at INTEGER NOT NULL,
+				started_at INTEGER,
+				completed_at INTEGER
+			);
+			CREATE INDEX IF NOT EXISTS idx_job_queue_dequeue ON job_queue(queue, status, priority DESC, run_at ASC);
+		`);
+
+		spaceRepo = new SpaceRepository(db as never);
+		scheduleRepo = new TaskScheduleRepository(db as never);
+		jobQueue = new JobQueueRepository(db as never);
+		service = new ScheduleService({ db: db as never, scheduleRepo, jobQueue });
+
+		const space = spaceRepo.createSpace({
+			slug: 'test',
+			workspacePath: '/workspace/test',
+			name: 'Test',
+			description: 'Test space',
+		});
+		spaceId = space.id;
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	describe('createSchedule', () => {
+		it('atomically creates the schedule, enqueues the first fire job, and links pendingJobId', () => {
+			const schedule = service.createSchedule({
+				spaceId,
+				title: 'Daily Standup',
+				triggerType: 'cron',
+				cronExpression: '0 9 * * 1-5',
+				timezone: 'UTC',
+			});
+
+			expect(schedule.status).toBe('active');
+			expect(schedule.nextRunAt).not.toBeNull();
+			expect(schedule.pendingJobId).not.toBeNull();
+
+			// The job actually exists and points back at the schedule.
+			const job = jobQueue.getJob(schedule.pendingJobId as string);
+			expect(job).not.toBeNull();
+			expect(job?.queue).toBe('taskSchedule.fire');
+			expect((job?.payload as { scheduleId: string }).scheduleId).toBe(schedule.id);
+		});
+
+		it('rejects an invalid cron expression', () => {
+			expect(() =>
+				service.createSchedule({
+					spaceId,
+					title: 'Bad cron',
+					triggerType: 'cron',
+					cronExpression: 'not-a-cron',
+				})
+			).toThrow(/Invalid cron expression/);
+		});
+
+		it('rejects an `at` schedule without a runAt', () => {
+			expect(() =>
+				service.createSchedule({ spaceId, title: 'No runAt', triggerType: 'at' })
+			).toThrow(/runAt is required/);
+		});
+
+		it('rejects an `at` schedule whose runAt is in the past', () => {
+			expect(() =>
+				service.createSchedule({
+					spaceId,
+					title: 'Past',
+					triggerType: 'at',
+					runAt: Date.now() - 60_000,
+				})
+			).toThrow(/runAt must be in the future/);
+		});
+	});
+
+	describe('updateSchedule', () => {
+		it('rejects setting cronExpression to null on a cron schedule', () => {
+			const schedule = service.createSchedule({
+				spaceId,
+				title: 'Cron',
+				triggerType: 'cron',
+				cronExpression: '0 9 * * *',
+			});
+
+			expect(() => service.updateSchedule(schedule.id, { cronExpression: null })).toThrow(
+				/Cannot clear cronExpression/
+			);
+		});
+
+		it('cancels the previous pending job and enqueues a new one when timing changes', () => {
+			const schedule = service.createSchedule({
+				spaceId,
+				title: 'Cron',
+				triggerType: 'cron',
+				cronExpression: '0 9 * * *',
+			});
+			const oldJobId = schedule.pendingJobId as string;
+
+			const updated = service.updateSchedule(schedule.id, { cronExpression: '0 10 * * *' });
+
+			expect(updated.pendingJobId).not.toBeNull();
+			expect(updated.pendingJobId).not.toBe(oldJobId);
+			expect(jobQueue.getJob(oldJobId)).toBeNull();
+		});
+
+		it('does not touch the pending job when only descriptive fields change', () => {
+			const schedule = service.createSchedule({
+				spaceId,
+				title: 'Cron',
+				triggerType: 'cron',
+				cronExpression: '0 9 * * *',
+			});
+			const oldJobId = schedule.pendingJobId;
+
+			const updated = service.updateSchedule(schedule.id, { title: 'Renamed' });
+
+			expect(updated.title).toBe('Renamed');
+			expect(updated.pendingJobId).toBe(oldJobId);
+		});
+	});
+
+	describe('pause/resume/delete', () => {
+		it('pause cancels the pending job and clears pendingJobId', () => {
+			const schedule = service.createSchedule({
+				spaceId,
+				title: 'Cron',
+				triggerType: 'cron',
+				cronExpression: '0 9 * * *',
+			});
+			const jobId = schedule.pendingJobId as string;
+
+			const paused = service.pauseSchedule(schedule.id);
+
+			expect(paused.status).toBe('paused');
+			expect(paused.pendingJobId).toBeNull();
+			expect(jobQueue.getJob(jobId)).toBeNull();
+		});
+
+		it('resume re-enqueues a fresh fire job', () => {
+			const schedule = service.createSchedule({
+				spaceId,
+				title: 'Cron',
+				triggerType: 'cron',
+				cronExpression: '0 9 * * *',
+			});
+			service.pauseSchedule(schedule.id);
+
+			const resumed = service.resumeSchedule(schedule.id);
+
+			expect(resumed.status).toBe('active');
+			expect(resumed.pendingJobId).not.toBeNull();
+			expect(jobQueue.getJob(resumed.pendingJobId as string)).not.toBeNull();
+		});
+
+		it('resume of an already-passed `at` schedule transitions to completed (no job)', () => {
+			// Create with a future runAt to satisfy validation.
+			const future = Date.now() + 60_000;
+			const schedule = service.createSchedule({
+				spaceId,
+				title: 'One Shot',
+				triggerType: 'at',
+				runAt: future,
+			});
+			service.pauseSchedule(schedule.id);
+
+			// Move runAt into the past directly via the repo (bypassing validation).
+			scheduleRepo.update(schedule.id, { runAt: Date.now() - 60_000 });
+
+			const resumed = service.resumeSchedule(schedule.id);
+			expect(resumed.status).toBe('completed');
+			expect(resumed.pendingJobId).toBeNull();
+		});
+
+		it('delete cancels the pending job and removes the schedule row', () => {
+			const schedule = service.createSchedule({
+				spaceId,
+				title: 'Cron',
+				triggerType: 'cron',
+				cronExpression: '0 9 * * *',
+			});
+			const jobId = schedule.pendingJobId as string;
+
+			const ok = service.deleteSchedule(schedule.id);
+
+			expect(ok).toBe(true);
+			expect(scheduleRepo.getById(schedule.id)).toBeNull();
+			expect(jobQueue.getJob(jobId)).toBeNull();
+		});
+	});
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/task-schedule-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/task-schedule-repository.test.ts
@@ -1,0 +1,372 @@
+/**
+ * TaskScheduleRepository unit tests
+ *
+ * Exercises all CRUD and query methods against an in-memory SQLite database
+ * using the shared space-test-db helper (same schema as production after all
+ * migrations).
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SpaceRepository } from '../../../../src/storage/repositories/space-repository';
+import { TaskScheduleRepository } from '../../../../src/storage/repositories/task-schedule-repository';
+import { createSpaceTables } from '../../helpers/space-test-db';
+import type { CreateTaskScheduleParams } from '../../../../src/storage/repositories/task-schedule-repository';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeCronParams(
+	overrides: Partial<CreateTaskScheduleParams> = {}
+): CreateTaskScheduleParams {
+	return {
+		spaceId: 'space-1',
+		title: 'Daily Standup',
+		description: 'Create daily standup task',
+		priority: 'normal',
+		triggerType: 'cron',
+		cronExpression: '0 9 * * 1-5',
+		timezone: 'UTC',
+		nextRunAt: Date.now() + 3600_000,
+		...overrides,
+	};
+}
+
+function makeAtParams(overrides: Partial<CreateTaskScheduleParams> = {}): CreateTaskScheduleParams {
+	return {
+		spaceId: 'space-1',
+		title: 'One-Shot Task',
+		triggerType: 'at',
+		runAt: Date.now() + 60_000,
+		nextRunAt: Date.now() + 60_000,
+		...overrides,
+	};
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('TaskScheduleRepository', () => {
+	let db: Database;
+	let spaceRepo: SpaceRepository;
+	let repo: TaskScheduleRepository;
+	let spaceId: string;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+		createSpaceTables(db);
+		spaceRepo = new SpaceRepository(db as never);
+		repo = new TaskScheduleRepository(db as never);
+
+		const space = spaceRepo.createSpace({
+			workspacePath: '/workspace/test',
+			slug: 'test',
+			name: 'Test Space',
+		});
+		spaceId = space.id;
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	// ─── create ───────────────────────────────────────────────────────────────
+
+	describe('create', () => {
+		it('creates a cron schedule with all fields populated', () => {
+			const now = Date.now();
+			const nextRunAt = now + 3600_000;
+
+			const schedule = repo.create(makeCronParams({ spaceId, nextRunAt }));
+
+			expect(schedule.id).toBeString();
+			expect(schedule.spaceId).toBe(spaceId);
+			expect(schedule.title).toBe('Daily Standup');
+			expect(schedule.description).toBe('Create daily standup task');
+			expect(schedule.priority).toBe('normal');
+			expect(schedule.triggerType).toBe('cron');
+			expect(schedule.cronExpression).toBe('0 9 * * 1-5');
+			expect(schedule.runAt).toBeNull();
+			expect(schedule.timezone).toBe('UTC');
+			expect(schedule.nextRunAt).toBe(nextRunAt);
+			expect(schedule.lastRunAt).toBeNull();
+			expect(schedule.lastCreatedTaskId).toBeNull();
+			expect(schedule.pendingJobId).toBeNull();
+			expect(schedule.status).toBe('active');
+			expect(schedule.createdByAgent).toBeNull();
+			expect(schedule.createdBySession).toBeNull();
+			expect(schedule.createdAt).toBeGreaterThan(0);
+			expect(schedule.updatedAt).toBeGreaterThan(0);
+		});
+
+		it('creates a one-shot (at) schedule', () => {
+			const runAt = Date.now() + 60_000;
+			const schedule = repo.create(makeAtParams({ spaceId, runAt, nextRunAt: runAt }));
+
+			expect(schedule.triggerType).toBe('at');
+			expect(schedule.runAt).toBe(runAt);
+			expect(schedule.cronExpression).toBeNull();
+		});
+
+		it('applies defaults for optional fields', () => {
+			const schedule = repo.create({
+				spaceId,
+				title: 'Minimal',
+				triggerType: 'cron',
+			});
+
+			expect(schedule.description).toBe('');
+			expect(schedule.priority).toBe('normal');
+			expect(schedule.labels).toEqual([]);
+			expect(schedule.preferredWorkflowId).toBeNull();
+			expect(schedule.timezone).toBe('UTC');
+			expect(schedule.nextRunAt).toBeNull();
+		});
+
+		it('stores labels as a JSON array', () => {
+			const schedule = repo.create(makeCronParams({ spaceId, labels: ['bug', 'recurring'] }));
+			expect(schedule.labels).toEqual(['bug', 'recurring']);
+		});
+
+		it('stores createdByAgent and createdBySession', () => {
+			const schedule = repo.create(
+				makeCronParams({ spaceId, createdByAgent: 'agent-1', createdBySession: 'session-1' })
+			);
+			expect(schedule.createdByAgent).toBe('agent-1');
+			expect(schedule.createdBySession).toBe('session-1');
+		});
+	});
+
+	// ─── getById ──────────────────────────────────────────────────────────────
+
+	describe('getById', () => {
+		it('returns the schedule by ID', () => {
+			const created = repo.create(makeCronParams({ spaceId }));
+			const found = repo.getById(created.id);
+			expect(found).not.toBeNull();
+			expect(found!.id).toBe(created.id);
+		});
+
+		it('returns null for an unknown ID', () => {
+			expect(repo.getById('no-such-id')).toBeNull();
+		});
+	});
+
+	// ─── listBySpace ──────────────────────────────────────────────────────────
+
+	describe('listBySpace', () => {
+		it('lists all schedules for a space', () => {
+			repo.create(makeCronParams({ spaceId, title: 'A' }));
+			repo.create(makeCronParams({ spaceId, title: 'B' }));
+
+			const list = repo.listBySpace(spaceId);
+			expect(list.length).toBe(2);
+		});
+
+		it('filters by status', () => {
+			const s1 = repo.create(makeCronParams({ spaceId }));
+			repo.updateStatus(s1.id, 'paused');
+			repo.create(makeCronParams({ spaceId, title: 'Active' }));
+
+			const active = repo.listBySpace(spaceId, 'active');
+			expect(active.length).toBe(1);
+			expect(active[0].status).toBe('active');
+
+			const paused = repo.listBySpace(spaceId, 'paused');
+			expect(paused.length).toBe(1);
+			expect(paused[0].status).toBe('paused');
+		});
+
+		it('returns empty array for a space with no schedules', () => {
+			expect(repo.listBySpace('unknown-space')).toEqual([]);
+		});
+
+		it('does not return schedules from another space', () => {
+			const otherSpace = spaceRepo.createSpace({
+				workspacePath: '/workspace/other',
+				slug: 'other',
+				name: 'Other',
+			});
+			repo.create(makeCronParams({ spaceId: otherSpace.id }));
+
+			expect(repo.listBySpace(spaceId)).toEqual([]);
+		});
+	});
+
+	// ─── listActiveDue ────────────────────────────────────────────────────────
+
+	describe('listActiveDue', () => {
+		it('returns schedules whose nextRunAt is in the past or now', () => {
+			const now = Date.now();
+			const s1 = repo.create(makeCronParams({ spaceId, nextRunAt: now - 1000 }));
+			const s2 = repo.create(makeCronParams({ spaceId, nextRunAt: now - 1 }));
+			repo.create(makeCronParams({ spaceId, nextRunAt: now + 60_000 })); // future — not due
+
+			const due = repo.listActiveDue(now);
+			const ids = due.map((s) => s.id);
+			expect(ids).toContain(s1.id);
+			expect(ids).toContain(s2.id);
+			expect(due.length).toBe(2);
+		});
+
+		it('excludes paused and completed schedules', () => {
+			const now = Date.now();
+			const s1 = repo.create(makeCronParams({ spaceId, nextRunAt: now - 1 }));
+			repo.updateStatus(s1.id, 'paused');
+
+			expect(repo.listActiveDue(now)).toHaveLength(0);
+		});
+
+		it('respects the limit parameter', () => {
+			const now = Date.now();
+			for (let i = 0; i < 5; i++) {
+				repo.create(makeCronParams({ spaceId, nextRunAt: now - 1000 }));
+			}
+			expect(repo.listActiveDue(now, 3)).toHaveLength(3);
+		});
+	});
+
+	// ─── listActiveWithPendingJob ──────────────────────────────────────────────
+
+	describe('listActiveWithPendingJob', () => {
+		it('returns active schedules that have a pendingJobId set', () => {
+			const s1 = repo.create(makeCronParams({ spaceId }));
+			repo.updatePendingJobId(s1.id, 'job-abc');
+			repo.create(makeCronParams({ spaceId })); // no pending job
+
+			const withJob = repo.listActiveWithPendingJob();
+			expect(withJob.length).toBe(1);
+			expect(withJob[0].id).toBe(s1.id);
+			expect(withJob[0].pendingJobId).toBe('job-abc');
+		});
+
+		it('excludes paused schedules even if they have a pendingJobId', () => {
+			const s1 = repo.create(makeCronParams({ spaceId }));
+			repo.updatePendingJobId(s1.id, 'job-xyz');
+			repo.updateStatus(s1.id, 'paused');
+
+			expect(repo.listActiveWithPendingJob()).toHaveLength(0);
+		});
+	});
+
+	// ─── update ───────────────────────────────────────────────────────────────
+
+	describe('update', () => {
+		it('updates title and description', () => {
+			const s = repo.create(makeCronParams({ spaceId }));
+			const updated = repo.update(s.id, { title: 'New Title', description: 'New desc' });
+
+			expect(updated!.title).toBe('New Title');
+			expect(updated!.description).toBe('New desc');
+		});
+
+		it('updates nextRunAt to null', () => {
+			const s = repo.create(makeCronParams({ spaceId, nextRunAt: Date.now() + 3600_000 }));
+			const updated = repo.update(s.id, { nextRunAt: null });
+			expect(updated!.nextRunAt).toBeNull();
+		});
+
+		it('returns null for unknown ID', () => {
+			expect(repo.update('no-such-id', { title: 'X' })).toBeNull();
+		});
+
+		it('returns the schedule unchanged when no fields are provided', () => {
+			const s = repo.create(makeCronParams({ spaceId }));
+			const result = repo.update(s.id, {});
+			expect(result!.title).toBe(s.title);
+		});
+	});
+
+	// ─── updatePendingJobId ───────────────────────────────────────────────────
+
+	describe('updatePendingJobId', () => {
+		it('sets a pendingJobId', () => {
+			const s = repo.create(makeCronParams({ spaceId }));
+			repo.updatePendingJobId(s.id, 'job-1');
+			expect(repo.getById(s.id)!.pendingJobId).toBe('job-1');
+		});
+
+		it('clears the pendingJobId to null', () => {
+			const s = repo.create(makeCronParams({ spaceId }));
+			repo.updatePendingJobId(s.id, 'job-1');
+			repo.updatePendingJobId(s.id, null);
+			expect(repo.getById(s.id)!.pendingJobId).toBeNull();
+		});
+	});
+
+	// ─── updateStatus ─────────────────────────────────────────────────────────
+
+	describe('updateStatus', () => {
+		it('transitions active → paused', () => {
+			const s = repo.create(makeCronParams({ spaceId }));
+			repo.updateStatus(s.id, 'paused');
+			expect(repo.getById(s.id)!.status).toBe('paused');
+		});
+
+		it('transitions paused → active', () => {
+			const s = repo.create(makeCronParams({ spaceId }));
+			repo.updateStatus(s.id, 'paused');
+			repo.updateStatus(s.id, 'active');
+			expect(repo.getById(s.id)!.status).toBe('active');
+		});
+
+		it('transitions active → completed', () => {
+			const s = repo.create(makeCronParams({ spaceId }));
+			repo.updateStatus(s.id, 'completed');
+			expect(repo.getById(s.id)!.status).toBe('completed');
+		});
+	});
+
+	// ─── updateAfterFire ──────────────────────────────────────────────────────
+
+	describe('updateAfterFire', () => {
+		it('records fire state for a cron schedule (stays active)', () => {
+			const s = repo.create(makeCronParams({ spaceId }));
+			const nextRunAt = Date.now() + 3600_000;
+
+			repo.updateAfterFire(s.id, {
+				lastCreatedTaskId: 'task-abc',
+				lastRunAt: Date.now(),
+				nextRunAt,
+				status: 'active',
+				pendingJobId: 'job-next',
+			});
+
+			const updated = repo.getById(s.id)!;
+			expect(updated.lastCreatedTaskId).toBe('task-abc');
+			expect(updated.lastRunAt).toBeGreaterThan(0);
+			expect(updated.nextRunAt).toBe(nextRunAt);
+			expect(updated.status).toBe('active');
+			expect(updated.pendingJobId).toBe('job-next');
+		});
+
+		it('records fire state for a one-shot schedule (marks completed)', () => {
+			const s = repo.create(makeAtParams({ spaceId }));
+
+			repo.updateAfterFire(s.id, {
+				lastCreatedTaskId: 'task-xyz',
+				lastRunAt: Date.now(),
+				nextRunAt: null,
+				status: 'completed',
+				pendingJobId: null,
+			});
+
+			const updated = repo.getById(s.id)!;
+			expect(updated.status).toBe('completed');
+			expect(updated.nextRunAt).toBeNull();
+			expect(updated.pendingJobId).toBeNull();
+		});
+	});
+
+	// ─── delete ───────────────────────────────────────────────────────────────
+
+	describe('delete', () => {
+		it('deletes an existing schedule and returns true', () => {
+			const s = repo.create(makeCronParams({ spaceId }));
+			expect(repo.delete(s.id)).toBe(true);
+			expect(repo.getById(s.id)).toBeNull();
+		});
+
+		it('returns false for an unknown ID', () => {
+			expect(repo.delete('no-such-id')).toBe(false);
+		});
+	});
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/task-schedule-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/task-schedule-repository.test.ts
@@ -222,6 +222,19 @@ describe('TaskScheduleRepository', () => {
 			}
 			expect(repo.listActiveDue(now, 3)).toHaveLength(3);
 		});
+
+		it('excludes schedules that already have a pendingJobId linked', () => {
+			// Recovery scans iterate the due-list; once a schedule is reseeded its
+			// pending_job_id is non-null and it must drop out of subsequent pages so
+			// pagination advances through later rows instead of looping forever.
+			const now = Date.now();
+			const s1 = repo.create(makeCronParams({ spaceId, nextRunAt: now - 1000 }));
+			const s2 = repo.create(makeCronParams({ spaceId, nextRunAt: now - 500 }));
+			repo.updatePendingJobId(s1.id, 'job-already-linked');
+
+			const due = repo.listActiveDue(now);
+			expect(due.map((s) => s.id)).toEqual([s2.id]);
+		});
 	});
 
 	// ─── listActiveWithPendingJob ──────────────────────────────────────────────
@@ -244,6 +257,28 @@ describe('TaskScheduleRepository', () => {
 			repo.updateStatus(s1.id, 'paused');
 
 			expect(repo.listActiveWithPendingJob()).toHaveLength(0);
+		});
+	});
+
+	// ─── listActiveBySpace ─────────────────────────────────────────────────────
+
+	describe('listActiveBySpace', () => {
+		it('returns only active schedules for the given space', () => {
+			const s1 = repo.create(makeCronParams({ spaceId }));
+			const s2 = repo.create(makeCronParams({ spaceId }));
+			const paused = repo.create(makeCronParams({ spaceId }));
+			repo.updateStatus(paused.id, 'paused');
+
+			const otherSpace = spaceRepo.createSpace({
+				workspacePath: '/workspace/other',
+				slug: 'other',
+				name: 'Other',
+			});
+			repo.create(makeCronParams({ spaceId: otherSpace.id }));
+
+			const active = repo.listActiveBySpace(spaceId);
+			const ids = active.map((s) => s.id).sort();
+			expect(ids).toEqual([s1.id, s2.id].sort());
 		});
 	});
 

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -31,6 +31,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			status TEXT NOT NULL DEFAULT 'active'
 				CHECK(status IN ('active', 'archived')),
 			paused INTEGER NOT NULL DEFAULT 0,
+			stopped INTEGER NOT NULL DEFAULT 0,
 			autonomy_level INTEGER NOT NULL DEFAULT 1
 				CHECK(autonomy_level BETWEEN 1 AND 5),
 			config TEXT,

--- a/packages/daemon/tests/unit/helpers/space-test-db.ts
+++ b/packages/daemon/tests/unit/helpers/space-test-db.ts
@@ -229,6 +229,7 @@ export function createSpaceTables(db: BunDatabase): void {
 			post_approval_blocked_reason TEXT DEFAULT NULL,
 			created_by TEXT DEFAULT NULL,
 			created_by_session TEXT DEFAULT NULL,
+			created_by_task_schedule_id TEXT DEFAULT NULL,
 			archived_at INTEGER,
 			created_at INTEGER NOT NULL,
 			started_at INTEGER,
@@ -453,4 +454,42 @@ export function createSpaceTables(db: BunDatabase): void {
 	db.exec(
 		`CREATE INDEX IF NOT EXISTS idx_mcp_audit_log_session ON mcp_audit_log (session_id, timestamp)`
 	);
+
+	// Task schedules (migration 124)
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS task_schedules (
+			id TEXT PRIMARY KEY,
+			space_id TEXT NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			priority TEXT NOT NULL DEFAULT 'normal'
+				CHECK(priority IN ('low', 'normal', 'high', 'urgent')),
+			preferred_workflow_id TEXT DEFAULT NULL,
+			labels TEXT NOT NULL DEFAULT '[]',
+			trigger_type TEXT NOT NULL CHECK(trigger_type IN ('cron', 'at')),
+			cron_expression TEXT DEFAULT NULL,
+			run_at INTEGER DEFAULT NULL,
+			timezone TEXT NOT NULL DEFAULT 'UTC',
+			next_run_at INTEGER DEFAULT NULL,
+			last_run_at INTEGER DEFAULT NULL,
+			last_created_task_id TEXT DEFAULT NULL,
+			pending_job_id TEXT DEFAULT NULL,
+			status TEXT NOT NULL DEFAULT 'active'
+				CHECK(status IN ('active', 'paused', 'completed')),
+			created_by_agent TEXT DEFAULT NULL,
+			created_by_session TEXT DEFAULT NULL,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL,
+			FOREIGN KEY (space_id) REFERENCES spaces(id) ON DELETE CASCADE
+		)
+	`);
+	db.exec(`
+		CREATE INDEX IF NOT EXISTS idx_task_schedules_space
+		ON task_schedules(space_id, status)
+	`);
+	db.exec(`
+		CREATE INDEX IF NOT EXISTS idx_task_schedules_active_due
+		ON task_schedules(status, next_run_at)
+		WHERE status = 'active'
+	`);
 }

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -252,6 +252,63 @@ export type SpaceBlockReason =
  */
 export type SpaceTaskPriority = 'low' | 'normal' | 'high' | 'urgent';
 
+// ============================================================================
+// TaskSchedule Types
+// ============================================================================
+
+/** Trigger type for a task schedule */
+export type TaskScheduleTriggerType = 'cron' | 'at';
+
+/** Status of a task schedule */
+export type TaskScheduleStatus = 'active' | 'paused' | 'completed';
+
+/**
+ * A scheduled task template — defines a recurring (cron) or one-shot (at)
+ * schedule that creates real SpaceTasks when it fires.
+ */
+export interface TaskSchedule {
+	/** Unique identifier */
+	id: string;
+	/** Space this schedule belongs to */
+	spaceId: string;
+	/** Task title template */
+	title: string;
+	/** Task description template */
+	description: string;
+	/** Task priority to use when creating the task */
+	priority: SpaceTaskPriority;
+	/** Preferred workflow ID to attach to created tasks */
+	preferredWorkflowId: string | null;
+	/** Labels to apply to created tasks */
+	labels: string[];
+	/** Trigger type — 'cron' for recurring, 'at' for one-shot */
+	triggerType: TaskScheduleTriggerType;
+	/** Cron expression (e.g. '0 9 * * 1') — used when triggerType is 'cron' */
+	cronExpression: string | null;
+	/** Unix ms timestamp for one-shot triggers — used when triggerType is 'at' */
+	runAt: number | null;
+	/** IANA timezone string (default: 'UTC') */
+	timezone: string;
+	/** Computed timestamp of next scheduled fire (ms since epoch) */
+	nextRunAt: number | null;
+	/** Timestamp of last successful fire (ms since epoch) */
+	lastRunAt: number | null;
+	/** ID of the most recently spawned SpaceTask */
+	lastCreatedTaskId: string | null;
+	/** Job ID of the pending job in the queue (for O(1) cancel/pause) */
+	pendingJobId: string | null;
+	/** Current schedule status */
+	status: TaskScheduleStatus;
+	/** Agent name that created this schedule */
+	createdByAgent: string | null;
+	/** Session ID of the agent that created this schedule */
+	createdBySession: string | null;
+	/** Creation timestamp (ms since epoch) */
+	createdAt: number;
+	/** Last update timestamp (ms since epoch) */
+	updatedAt: number;
+}
+
 /**
  * Runtime activity state for a live task-agent member.
  * This is more user-facing than raw session processing states.
@@ -311,6 +368,12 @@ export interface SpaceTask {
 	 * Set when a task is created via `create_standalone_task` tool.
 	 */
 	createdBySession?: string | null;
+	/**
+	 * ID of the TaskSchedule that spawned this task.
+	 * Set when a task is created by the task-schedule.fire job handler.
+	 * Null for manually created tasks.
+	 */
+	createdByTaskScheduleId?: string | null;
 	/**
 	 * Which agent session is currently active (generating output).
 	 * Cleared when the session reaches a terminal state.
@@ -490,6 +553,11 @@ export interface CreateSpaceTaskParams {
 	 * Set when the task transitions from 'open' to 'in_progress'.
 	 */
 	taskAgentSessionId?: string | null;
+	/**
+	 * ID of the TaskSchedule that spawned this task.
+	 * Set by the task-schedule.fire job handler.
+	 */
+	createdByTaskScheduleId?: string | null;
 }
 
 /**

--- a/packages/web/src/components/space/SpaceTasks.tsx
+++ b/packages/web/src/components/space/SpaceTasks.tsx
@@ -10,15 +10,15 @@
  * matching the RoomTasks component style.
  */
 
-import type { SpaceBlockReason, SpaceTask, SpaceTaskStatus } from '@neokai/shared';
-import { useMemo } from 'preact/hooks';
+import type { SpaceBlockReason, SpaceTask, SpaceTaskStatus, TaskSchedule } from '@neokai/shared';
+import { useEffect, useMemo, useState } from 'preact/hooks';
 import { navigateToSpaceTasks } from '../../lib/router';
 import { currentSpaceIdSignal, currentSpaceTasksFilterTabSignal } from '../../lib/signals';
 import { spaceStore } from '../../lib/space-store';
 import { isActionRequired, isActiveTask, isDraftTask } from '../../lib/task-filters';
 import { getRelativeTime } from '../../lib/utils';
 
-type TaskFilterTab = 'action' | 'active' | 'draft' | 'completed' | 'archived';
+type TaskFilterTab = 'action' | 'active' | 'draft' | 'completed' | 'archived' | 'scheduled';
 
 /** Block reasons that indicate a task needs human attention */
 const ATTENTION_BLOCK_REASONS: SpaceBlockReason[] = ['human_input_requested', 'gate_rejected'];
@@ -36,7 +36,11 @@ const ATTENTION_BLOCK_REASONS: SpaceBlockReason[] = ['human_input_requested', 'g
  * a regression guard: if someone later re-inlines the predicate here,
  * the parity test in `task-filters.test.ts` will fail.
  */
-export const TAB_PREDICATES: Record<TaskFilterTab, (task: SpaceTask) => boolean> = {
+// Note: 'scheduled' tab is handled separately in the component (schedules, not tasks)
+export const TAB_PREDICATES: Record<
+	Exclude<TaskFilterTab, 'scheduled'>,
+	(task: SpaceTask) => boolean
+> = {
 	action: isActionRequired,
 	active: isActiveTask,
 	draft: isDraftTask,
@@ -124,7 +128,7 @@ const ARCHIVED_GROUPS: StatusGroupDef[] = [
 
 const DRAFT_GROUPS: StatusGroupDef[] = [{ status: 'draft', title: 'Drafts', variant: 'default' }];
 
-const TAB_GROUPS_DEF: Record<TaskFilterTab, StatusGroupDef[]> = {
+const TAB_GROUPS_DEF: Record<Exclude<TaskFilterTab, 'scheduled'>, StatusGroupDef[]> = {
 	action: ACTION_GROUPS,
 	active: ACTIVE_GROUPS,
 	draft: DRAFT_GROUPS,
@@ -205,6 +209,10 @@ function EmptyTabState({ tab }: { tab: TaskFilterTab }) {
 		draft: { title: 'No draft tasks', description: 'Tasks created as drafts will appear here' },
 		completed: { title: 'No completed tasks', description: 'Completed tasks will appear here' },
 		archived: { title: 'No archived tasks', description: 'Archived tasks will appear here' },
+		scheduled: {
+			title: 'No scheduled tasks',
+			description: 'Recurring and one-shot scheduled tasks will appear here',
+		},
 	};
 
 	const { title, description } = messages[tab];
@@ -420,8 +428,16 @@ interface SpaceTasksProps {
 
 export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps) {
 	const tasks = spaceStore.tasks.value;
-	const activeTab: TaskFilterTab = currentSpaceTasksFilterTabSignal.value;
+	const schedules = spaceStore.schedules.value;
+	const activeTab: TaskFilterTab = currentSpaceTasksFilterTabSignal.value as TaskFilterTab;
 	const spaceId = currentSpaceIdSignal.value ?? '';
+
+	// Load schedules when the tab is switched to 'scheduled'
+	useEffect(() => {
+		if (activeTab === 'scheduled') {
+			spaceStore.listSchedules().catch(() => {});
+		}
+	}, [activeTab]);
 
 	const counts = useMemo(() => {
 		const c: Record<TaskFilterTab, number> = {
@@ -430,10 +446,11 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 			draft: 0,
 			completed: 0,
 			archived: 0,
+			scheduled: schedules.filter((s) => s.status !== 'completed').length,
 		};
 		for (const task of tasks) {
 			for (const [tab, predicate] of Object.entries(TAB_PREDICATES) as [
-				TaskFilterTab,
+				Exclude<TaskFilterTab, 'scheduled'>,
 				(t: SpaceTask) => boolean,
 			][]) {
 				if (predicate(task)) {
@@ -443,10 +460,12 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 			}
 		}
 		return c;
-	}, [tasks]);
+	}, [tasks, schedules]);
 
 	const filteredTasks = useMemo(() => {
-		const predicate = TAB_PREDICATES[activeTab];
+		if (activeTab === 'scheduled') return [];
+		const predicate = TAB_PREDICATES[activeTab as Exclude<TaskFilterTab, 'scheduled'>];
+		if (!predicate) return [];
 		return [...tasks].filter(predicate).sort((a, b) => b.updatedAt - a.updatedAt);
 	}, [tasks, activeTab]);
 
@@ -519,19 +538,128 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 						onClick={() => navigateToSpaceTasks(spaceId, 'archived')}
 						variant="gray"
 					/>
+					<TabButton
+						label="Scheduled"
+						count={counts.scheduled}
+						isActive={activeTab === 'scheduled'}
+						onClick={() => navigateToSpaceTasks(spaceId, 'scheduled')}
+						variant="default"
+					/>
 				</div>
 
-				{filteredTasks.length === 0 ? (
+				{activeTab === 'scheduled' ? (
+					schedules.length === 0 ? (
+						<EmptyTabState tab="scheduled" />
+					) : (
+						<ScheduleList
+							schedules={schedules}
+							onPause={(id) => spaceStore.pauseSchedule(id).catch(() => {})}
+							onResume={(id) => spaceStore.resumeSchedule(id).catch(() => {})}
+							onDelete={(id) => spaceStore.deleteSchedule(id).catch(() => {})}
+						/>
+					)
+				) : filteredTasks.length === 0 ? (
 					<EmptyTabState tab={activeTab} />
 				) : (
 					<TaskGroupList
 						tasks={filteredTasks}
 						taskById={taskById}
-						tab={activeTab}
+						tab={activeTab as Exclude<TaskFilterTab, 'scheduled'>}
 						onTaskClick={onSelectTask}
 					/>
 				)}
 			</div>
+		</div>
+	);
+}
+
+/** Schedule list for the Scheduled tab */
+function ScheduleList({
+	schedules,
+	onPause,
+	onResume,
+	onDelete,
+}: {
+	schedules: TaskSchedule[];
+	onPause: (id: string) => void;
+	onResume: (id: string) => void;
+	onDelete: (id: string) => void;
+}) {
+	const [deletingId, setDeletingId] = useState<string | null>(null);
+
+	const handleDelete = (id: string) => {
+		setDeletingId(id);
+		onDelete(id);
+	};
+
+	const formatNextRun = (nextRunAt: number | null) => {
+		if (!nextRunAt) return 'N/A';
+		return getRelativeTime(nextRunAt);
+	};
+
+	const formatTrigger = (s: TaskSchedule) => {
+		if (s.triggerType === 'cron') return s.cronExpression ?? 'cron';
+		if (s.runAt) return `once at ${new Date(s.runAt).toLocaleString()}`;
+		return 'one-shot';
+	};
+
+	return (
+		<div class="space-y-2">
+			{schedules.map((s) => (
+				<div
+					key={s.id}
+					class="flex items-start gap-3 rounded-lg border border-dark-700 bg-dark-800 p-3"
+				>
+					<div class="flex-1 min-w-0">
+						<div class="flex items-center gap-2">
+							<span class="text-sm font-medium text-gray-200 truncate">{s.title}</span>
+							<span
+								class={`text-xs px-1.5 py-0.5 rounded ${
+									s.status === 'active'
+										? 'bg-green-900/40 text-green-400'
+										: s.status === 'paused'
+											? 'bg-amber-900/40 text-amber-400'
+											: 'bg-gray-800 text-gray-500'
+								}`}
+							>
+								{s.status}
+							</span>
+						</div>
+						<div class="mt-1 flex items-center gap-3 text-xs text-gray-500">
+							<span title="Trigger">{formatTrigger(s)}</span>
+							{s.nextRunAt && s.status === 'active' && (
+								<span>next: {formatNextRun(s.nextRunAt)}</span>
+							)}
+							{s.lastRunAt && <span>last: {getRelativeTime(s.lastRunAt)}</span>}
+						</div>
+					</div>
+					<div class="flex items-center gap-1 shrink-0">
+						{s.status === 'active' && (
+							<button
+								class="px-2 py-1 text-xs rounded text-amber-400 hover:bg-amber-900/20"
+								onClick={() => onPause(s.id)}
+							>
+								Pause
+							</button>
+						)}
+						{s.status === 'paused' && (
+							<button
+								class="px-2 py-1 text-xs rounded text-green-400 hover:bg-green-900/20"
+								onClick={() => onResume(s.id)}
+							>
+								Resume
+							</button>
+						)}
+						<button
+							class="px-2 py-1 text-xs rounded text-red-400 hover:bg-red-900/20"
+							onClick={() => handleDelete(s.id)}
+							disabled={deletingId === s.id}
+						>
+							Delete
+						</button>
+					</div>
+				</div>
+			))}
 		</div>
 	);
 }
@@ -545,7 +673,7 @@ function TaskGroupList({
 }: {
 	tasks: SpaceTask[];
 	taskById: ReadonlyMap<string, SpaceTask>;
-	tab: TaskFilterTab;
+	tab: Exclude<TaskFilterTab, 'scheduled'>;
 	onTaskClick?: (taskId: string) => void;
 }) {
 	const groups = TAB_GROUPS_DEF[tab];

--- a/packages/web/src/components/space/SpaceTasks.tsx
+++ b/packages/web/src/components/space/SpaceTasks.tsx
@@ -432,12 +432,14 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 	const activeTab: TaskFilterTab = currentSpaceTasksFilterTabSignal.value as TaskFilterTab;
 	const spaceId = currentSpaceIdSignal.value ?? '';
 
-	// Load schedules when the tab is switched to 'scheduled'
+	// Load schedules when the tab is switched to 'scheduled' or the active space changes.
+	// Including spaceId in deps prevents stale schedules from a previous space lingering
+	// when the user navigates between spaces while staying on the scheduled tab.
 	useEffect(() => {
-		if (activeTab === 'scheduled') {
+		if (activeTab === 'scheduled' && spaceId) {
 			spaceStore.listSchedules().catch(() => {});
 		}
-	}, [activeTab]);
+	}, [activeTab, spaceId]);
 
 	const counts = useMemo(() => {
 		const c: Record<TaskFilterTab, number> = {

--- a/packages/web/src/components/space/SpaceTasks.tsx
+++ b/packages/web/src/components/space/SpaceTasks.tsx
@@ -16,7 +16,7 @@ import { navigateToSpaceTasks } from '../../lib/router';
 import { currentSpaceIdSignal, currentSpaceTasksFilterTabSignal } from '../../lib/signals';
 import { spaceStore } from '../../lib/space-store';
 import { isActionRequired, isActiveTask, isDraftTask } from '../../lib/task-filters';
-import { getRelativeTime } from '../../lib/utils';
+import { getRelativeTime, formatRelativeFuture } from '../../lib/utils';
 
 type TaskFilterTab = 'action' | 'active' | 'draft' | 'completed' | 'archived' | 'scheduled';
 
@@ -561,7 +561,7 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 							schedules={schedules}
 							onPause={(id) => spaceStore.pauseSchedule(id).catch(() => {})}
 							onResume={(id) => spaceStore.resumeSchedule(id).catch(() => {})}
-							onDelete={(id) => spaceStore.deleteSchedule(id).catch(() => {})}
+							onDelete={(id) => spaceStore.deleteSchedule(id)}
 						/>
 					)
 				) : filteredTasks.length === 0 ? (
@@ -589,18 +589,25 @@ function ScheduleList({
 	schedules: TaskSchedule[];
 	onPause: (id: string) => void;
 	onResume: (id: string) => void;
-	onDelete: (id: string) => void;
+	onDelete: (id: string) => Promise<unknown>;
 }) {
 	const [deletingId, setDeletingId] = useState<string | null>(null);
 
 	const handleDelete = (id: string) => {
 		setDeletingId(id);
-		onDelete(id);
+		// Always clear `deletingId` once the RPC settles so a transient failure
+		// (network blip, daemon restart) doesn't permanently disable the row's
+		// Delete button for the rest of the session. The store throws on failure;
+		// we swallow it here because the user-visible feedback is the row staying
+		// in place — a follow-up retry just clicks Delete again.
+		onDelete(id).finally(() => {
+			setDeletingId((curr) => (curr === id ? null : curr));
+		});
 	};
 
 	const formatNextRun = (nextRunAt: number | null) => {
 		if (!nextRunAt) return 'N/A';
-		return getRelativeTime(nextRunAt);
+		return formatRelativeFuture(nextRunAt);
 	};
 
 	const formatTrigger = (s: TaskSchedule) => {

--- a/packages/web/src/components/space/SpaceTasks.tsx
+++ b/packages/web/src/components/space/SpaceTasks.tsx
@@ -483,27 +483,9 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 	// when `tasks` is empty (a freshly-created schedule that hasn't fired yet).
 	// Falling through to the global "No tasks yet" placeholder would hide the
 	// schedule list, leaving users with no way to view/manage their schedules.
-	if (tasks.length === 0 && activeTab !== 'scheduled') {
-		return (
-			<div class="w-full px-8 flex flex-col items-center justify-center py-16 text-center">
-				<svg
-					class="w-10 h-10 text-gray-700 mb-3"
-					fill="none"
-					viewBox="0 0 24 24"
-					stroke="currentColor"
-				>
-					<path
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						stroke-width={1.5}
-						d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
-					/>
-				</svg>
-				<p class="text-sm text-gray-400 font-medium">No tasks yet</p>
-				<p class="text-xs text-gray-600 mt-1">Create a task to get started</p>
-			</div>
-		);
-	}
+	// We always render the tab strip so users can navigate to the Scheduled tab
+	// even when no tasks have been spawned yet.
+	const showGlobalEmpty = tasks.length === 0 && activeTab !== 'scheduled';
 
 	return (
 		<div class="flex-1 min-h-0 w-full px-4 py-4 sm:px-8 sm:py-6 overflow-y-auto">
@@ -553,7 +535,25 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 					/>
 				</div>
 
-				{activeTab === 'scheduled' ? (
+				{showGlobalEmpty ? (
+					<div class="flex flex-col items-center justify-center py-16 text-center">
+						<svg
+							class="w-10 h-10 text-gray-700 mb-3"
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+						>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width={1.5}
+								d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+							/>
+						</svg>
+						<p class="text-sm text-gray-400 font-medium">No tasks yet</p>
+						<p class="text-xs text-gray-600 mt-1">Create a task to get started</p>
+					</div>
+				) : activeTab === 'scheduled' ? (
 					schedules.length === 0 ? (
 						<EmptyTabState tab="scheduled" />
 					) : (
@@ -600,9 +600,13 @@ function ScheduleList({
 		// Delete button for the rest of the session. The store throws on failure;
 		// we swallow it here because the user-visible feedback is the row staying
 		// in place — a follow-up retry just clicks Delete again.
-		onDelete(id).finally(() => {
-			setDeletingId((curr) => (curr === id ? null : curr));
-		});
+		onDelete(id)
+			.catch(() => {
+				/* silently ignore — UI state stays as-is, user can retry */
+			})
+			.finally(() => {
+				setDeletingId((curr) => (curr === id ? null : curr));
+			});
 	};
 
 	const formatNextRun = (nextRunAt: number | null) => {

--- a/packages/web/src/components/space/SpaceTasks.tsx
+++ b/packages/web/src/components/space/SpaceTasks.tsx
@@ -479,7 +479,11 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 		return map;
 	}, [tasks]);
 
-	if (tasks.length === 0) {
+	// Empty-state guard is tab-aware: the Scheduled tab can have content even
+	// when `tasks` is empty (a freshly-created schedule that hasn't fired yet).
+	// Falling through to the global "No tasks yet" placeholder would hide the
+	// schedule list, leaving users with no way to view/manage their schedules.
+	if (tasks.length === 0 && activeTab !== 'scheduled') {
 		return (
 			<div class="w-full px-8 flex flex-col items-center justify-center py-16 text-center">
 				<svg

--- a/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
@@ -252,10 +252,13 @@ describe('SpaceTasks', () => {
 	it('does not show count badge when count is 0', () => {
 		mockTasks.value = [];
 		const { container } = render(<SpaceTasks spaceId="space-1" />);
-		// The active tab button should not have a count badge
+		// The tab strip is always visible (so users can reach the Scheduled tab
+		// even when no tasks exist yet), but the Active tab should not have a
+		// count badge when its count is zero.
 		const activeButtons = Array.from(container.querySelectorAll('button'));
 		const activeTab = activeButtons.find((b) => b.textContent?.includes('Active'));
-		expect(activeTab).toBeFalsy();
+		expect(activeTab).toBeTruthy();
+		expect(activeTab!.textContent).toBe('Active'); // no "(0)" suffix
 	});
 
 	it('switches tabs and shows filtered tasks', () => {

--- a/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
@@ -9,6 +9,8 @@ import { signal } from '@preact/signals';
 import type { SpaceTask } from '@neokai/shared';
 
 let mockTasks: ReturnType<typeof signal<SpaceTask[]>>;
+const mockSchedules = signal<unknown[]>([]);
+const mockListSchedules = vi.fn(async () => {});
 
 // Bridge pattern: hoisted bridge objects allow mockNavigateToSpaceTasks to update
 // the real Preact signals (which are created after import).
@@ -57,7 +59,11 @@ vi.mock('../../../lib/router', () => ({
 
 vi.mock('../../../lib/space-store', () => ({
 	get spaceStore() {
-		return { tasks: mockTasks };
+		return {
+			tasks: mockTasks,
+			schedules: mockSchedules,
+			listSchedules: mockListSchedules,
+		};
 	},
 }));
 

--- a/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
+++ b/packages/web/src/islands/__tests__/SpaceIsland.test.tsx
@@ -153,6 +153,8 @@ vi.mock('../../lib/space-store', () => ({
 			agents: mockAgents,
 			sessions: { value: [] },
 			tasks: { value: [] },
+			schedules: { value: [] },
+			listSchedules: vi.fn().mockResolvedValue(undefined),
 			configDataLoaded: { value: true },
 			ensureConfigData: vi.fn().mockResolvedValue(undefined),
 			ensureNodeExecutions: vi.fn().mockResolvedValue(undefined),

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -393,7 +393,7 @@ export function navigateToSpaceConfigure(
 
 export function navigateToSpaceTasks(
 	spaceId: string,
-	tab?: 'action' | 'active' | 'completed' | 'archived' | 'draft',
+	tab?: 'action' | 'active' | 'completed' | 'archived' | 'draft' | 'scheduled',
 	replace = false
 ): void {
 	if (routerState.isNavigating) return;

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -37,7 +37,7 @@ const SPACE_CONFIGURE_TAB_ROUTE_PATTERN =
 	/^\/space\/([a-z0-9-]+)\/configure\/(agents|workflows|settings)$/;
 const SPACE_TASKS_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/tasks$/;
 const SPACE_TASKS_TAB_ROUTE_PATTERN =
-	/^\/space\/([a-z0-9-]+)\/tasks\/(action|active|draft|completed|archived)$/;
+	/^\/space\/([a-z0-9-]+)\/tasks\/(action|active|draft|completed|archived|scheduled)$/;
 const SPACE_AGENT_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/agent$/;
 const SPACE_SESSION_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/session\/([a-fA-F0-9-]+)$/;
 const SPACE_TASK_ROUTE_PATTERN = /^\/space\/([a-z0-9-]+)\/task\/([a-fA-F0-9-]+|[a-z]-[1-9]\d*)$/;

--- a/packages/web/src/lib/router.ts
+++ b/packages/web/src/lib/router.ts
@@ -115,14 +115,15 @@ export function getSpaceTasksFromPath(path: string): string | null {
 	return match ? match[1] : null;
 }
 
-export function getSpaceTasksTabFromPath(
-	path: string
-): { spaceId: string; tab: 'action' | 'active' | 'draft' | 'completed' | 'archived' } | null {
+export function getSpaceTasksTabFromPath(path: string): {
+	spaceId: string;
+	tab: 'action' | 'active' | 'draft' | 'completed' | 'archived' | 'scheduled';
+} | null {
 	const match = path.match(SPACE_TASKS_TAB_ROUTE_PATTERN);
 	if (!match) return null;
 	return {
 		spaceId: match[1],
-		tab: match[2] as 'action' | 'active' | 'draft' | 'completed' | 'archived',
+		tab: match[2] as 'action' | 'active' | 'draft' | 'completed' | 'archived' | 'scheduled',
 	};
 }
 

--- a/packages/web/src/lib/signals.ts
+++ b/packages/web/src/lib/signals.ts
@@ -34,8 +34,14 @@ export const currentSpaceViewModeSignal = signal<SpaceViewMode>('overview');
 export type SpaceConfigureTab = 'agents' | 'workflows' | 'settings';
 export const currentSpaceConfigureTabSignal = signal<SpaceConfigureTab>('agents');
 
-// Tasks filter tab (action | active | draft | completed | archived) — driven by URL
-export type SpaceTasksFilterTab = 'action' | 'active' | 'completed' | 'archived' | 'draft';
+// Tasks filter tab (action | active | draft | completed | archived | scheduled) — driven by URL
+export type SpaceTasksFilterTab =
+	| 'action'
+	| 'active'
+	| 'completed'
+	| 'archived'
+	| 'draft'
+	| 'scheduled';
 export const currentSpaceTasksFilterTabSignal = signal<SpaceTasksFilterTab>('active');
 
 // Task detail sub-view (thread | canvas | artifacts) — driven by URL

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -578,6 +578,7 @@ class SpaceStore {
 		this.nodeExecLoaded.value = false;
 		this.nodeExecPromise = null;
 		this.sessions.value = [];
+		this.schedules.value = [];
 		this.clearWorkflowDetailCache();
 		this.workflowVersions.value = new Map();
 		this.disposeSpaceSessionsSubscription();
@@ -711,6 +712,21 @@ class SpaceStore {
 			}
 		});
 		this.cleanupFunctions.push(unsubTaskUpdated);
+
+		// --- space.schedule.updated ---
+		const unsubScheduleUpdated = hub.onEvent<{
+			sessionId: string;
+			spaceId: string;
+			scheduleId: string;
+			schedule: TaskSchedule;
+		}>('space.schedule.updated', (event) => {
+			if (event.spaceId === spaceId) {
+				this.schedules.value = this.schedules.value.map((s) =>
+					s.id === event.scheduleId ? event.schedule : s
+				);
+			}
+		});
+		this.cleanupFunctions.push(unsubScheduleUpdated);
 
 		// --- space.workflowRun.created ---
 		const unsubRunCreated = hub.onEvent<{

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -2104,6 +2104,12 @@ class SpaceStore {
 
 	/**
 	 * Create a recurring (cron) or one-shot (at) task schedule.
+	 *
+	 * If the user switches spaces while the request is in flight, the late
+	 * response is dropped from the local signal so a schedule belonging to
+	 * space A can't surface in space B's Scheduled tab. The schedule itself
+	 * was still created on the daemon — the next list refresh will pick it
+	 * up when the user returns to space A.
 	 */
 	async createSchedule(params: {
 		title: string;
@@ -2126,6 +2132,8 @@ class SpaceStore {
 			...params,
 			spaceId,
 		});
+		// Drop the response if the active space changed while we were awaiting.
+		if (this.spaceId.value !== spaceId) return schedule;
 		this.schedules.value = [...this.schedules.value, schedule];
 		return schedule;
 	}

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -2132,6 +2132,11 @@ class SpaceStore {
 
 	/**
 	 * List schedules for the current space, optionally filtered by status.
+	 *
+	 * Captures the spaceId before the await and re-checks it after; if the user
+	 * has navigated away to another space while the request was in flight, the
+	 * stale response is dropped so the new space's schedule state isn't
+	 * overwritten.
 	 */
 	async listSchedules(status?: TaskScheduleStatus): Promise<TaskSchedule[]> {
 		const spaceId = this.spaceId.value;
@@ -2144,6 +2149,8 @@ class SpaceStore {
 			spaceId,
 			status,
 		});
+		// Drop the response if the active space changed while we were awaiting.
+		if (this.spaceId.value !== spaceId) return schedules;
 		this.schedules.value = schedules;
 		return schedules;
 	}
@@ -2152,11 +2159,14 @@ class SpaceStore {
 	 * Pause a schedule.
 	 */
 	async pauseSchedule(scheduleId: string): Promise<TaskSchedule> {
+		const spaceId = this.spaceId.value;
+		if (!spaceId) throw new Error('No space selected');
 		const hub = connectionManager.getHubIfConnected();
 		if (!hub) throw new Error('Not connected');
 
 		const { schedule } = await hub.request<{ schedule: TaskSchedule }>('taskSchedule.pause', {
 			scheduleId,
+			spaceId,
 		});
 		this.schedules.value = this.schedules.value.map((s) => (s.id === scheduleId ? schedule : s));
 		return schedule;
@@ -2166,11 +2176,14 @@ class SpaceStore {
 	 * Resume a paused schedule.
 	 */
 	async resumeSchedule(scheduleId: string): Promise<TaskSchedule> {
+		const spaceId = this.spaceId.value;
+		if (!spaceId) throw new Error('No space selected');
 		const hub = connectionManager.getHubIfConnected();
 		if (!hub) throw new Error('Not connected');
 
 		const { schedule } = await hub.request<{ schedule: TaskSchedule }>('taskSchedule.resume', {
 			scheduleId,
+			spaceId,
 		});
 		this.schedules.value = this.schedules.value.map((s) => (s.id === scheduleId ? schedule : s));
 		return schedule;
@@ -2180,10 +2193,12 @@ class SpaceStore {
 	 * Delete a schedule.
 	 */
 	async deleteSchedule(scheduleId: string): Promise<void> {
+		const spaceId = this.spaceId.value;
+		if (!spaceId) throw new Error('No space selected');
 		const hub = connectionManager.getHubIfConnected();
 		if (!hub) throw new Error('Not connected');
 
-		await hub.request('taskSchedule.delete', { scheduleId });
+		await hub.request('taskSchedule.delete', { scheduleId, spaceId });
 		this.schedules.value = this.schedules.value.filter((s) => s.id !== scheduleId);
 	}
 }

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -39,6 +39,10 @@ import type {
 	SpaceWorkflow,
 	SpaceWorkflowSummary,
 	SpaceWorkflowRun,
+	TaskSchedule,
+	TaskScheduleStatus,
+	TaskScheduleTriggerType,
+	SpaceTaskPriority,
 	UpdateSpaceAgentParams,
 	UpdateSpaceParams,
 	UpdateSpaceTaskParams,
@@ -132,6 +136,9 @@ class SpaceStore {
 
 	/** Runtime state for this space */
 	readonly runtimeState = signal<RuntimeState | null>(null);
+
+	/** Task schedules for this space */
+	readonly schedules = signal<TaskSchedule[]>([]);
 
 	/** Live task-agent activity rows keyed by task ID */
 	readonly taskActivity = signal<Map<string, SpaceTaskActivityMember[]>>(new Map());
@@ -2089,6 +2096,95 @@ class SpaceStore {
 			{ id: workflowId, spaceId }
 		);
 		return workflow;
+	}
+
+	// ========================================
+	// Task Schedule Methods
+	// ========================================
+
+	/**
+	 * Create a recurring (cron) or one-shot (at) task schedule.
+	 */
+	async createSchedule(params: {
+		title: string;
+		description?: string;
+		priority?: SpaceTaskPriority;
+		preferredWorkflowId?: string | null;
+		labels?: string[];
+		triggerType: TaskScheduleTriggerType;
+		cronExpression?: string | null;
+		runAt?: number | null;
+		timezone?: string;
+	}): Promise<TaskSchedule> {
+		const spaceId = this.spaceId.value;
+		if (!spaceId) throw new Error('No space selected');
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		const { schedule } = await hub.request<{ schedule: TaskSchedule }>('taskSchedule.create', {
+			...params,
+			spaceId,
+		});
+		this.schedules.value = [...this.schedules.value, schedule];
+		return schedule;
+	}
+
+	/**
+	 * List schedules for the current space, optionally filtered by status.
+	 */
+	async listSchedules(status?: TaskScheduleStatus): Promise<TaskSchedule[]> {
+		const spaceId = this.spaceId.value;
+		if (!spaceId) throw new Error('No space selected');
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		const { schedules } = await hub.request<{ schedules: TaskSchedule[] }>('taskSchedule.list', {
+			spaceId,
+			status,
+		});
+		this.schedules.value = schedules;
+		return schedules;
+	}
+
+	/**
+	 * Pause a schedule.
+	 */
+	async pauseSchedule(scheduleId: string): Promise<TaskSchedule> {
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		const { schedule } = await hub.request<{ schedule: TaskSchedule }>('taskSchedule.pause', {
+			scheduleId,
+		});
+		this.schedules.value = this.schedules.value.map((s) => (s.id === scheduleId ? schedule : s));
+		return schedule;
+	}
+
+	/**
+	 * Resume a paused schedule.
+	 */
+	async resumeSchedule(scheduleId: string): Promise<TaskSchedule> {
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		const { schedule } = await hub.request<{ schedule: TaskSchedule }>('taskSchedule.resume', {
+			scheduleId,
+		});
+		this.schedules.value = this.schedules.value.map((s) => (s.id === scheduleId ? schedule : s));
+		return schedule;
+	}
+
+	/**
+	 * Delete a schedule.
+	 */
+	async deleteSchedule(scheduleId: string): Promise<void> {
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		await hub.request('taskSchedule.delete', { scheduleId });
+		this.schedules.value = this.schedules.value.filter((s) => s.id !== scheduleId);
 	}
 }
 

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -93,6 +93,27 @@ export function getRelativeTime(ts: number): string {
 }
 
 /**
+ * Format a relative time that may be in the past OR the future.
+ *
+ * Used by the Scheduled tab's `nextRunAt` column where timestamps are normally
+ * future-dated but may briefly land in the past (clock drift, schedule fired
+ * but not yet advanced, etc.). `getRelativeTime` is past-only and would render
+ * future timestamps as "just now", which is misleading.
+ */
+export function formatRelativeFuture(ts: number): string {
+	const diff = ts - Date.now();
+	const future = diff >= 0;
+	const abs = Math.abs(diff);
+	const minutes = Math.floor(abs / 60_000);
+	if (minutes < 1) return future ? 'in <1m' : 'just now';
+	if (minutes < 60) return future ? `in ${minutes}m` : `${minutes}m ago`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return future ? `in ${hours}h` : `${hours}h ago`;
+	const days = Math.floor(hours / 24);
+	return future ? `in ${days}d` : `${days}d ago`;
+}
+
+/**
  * Format token count in k format (e.g., 16500 -> "16.5k")
  */
 export function formatTokens(tokens: number): string {


### PR DESCRIPTION
Implements recurring (cron) and one-shot (at) task scheduling for Spaces via a new `TaskSchedule` entity.

**Architecture** — self-scheduling job pattern (same as github-poll): the `taskSchedule.fire` handler creates a SpaceTask from the schedule template, then re-enqueues itself at the next cron interval or marks the schedule `completed` for one-shot triggers.

**What's included:**

- Migration 124: `task_schedules` table + `created_by_task_schedule_id` column on `space_tasks`
- `croner` for cron expression validation and next-run computation
- `TaskScheduleRepository` (CRUD + `updateAfterFire` / `listActiveDue`)
- `taskSchedule.fire` job handler (error re-throw for queue retries)
- 7 RPC handlers: create / list / get / update / pause / resume / delete
- 6 space-agent MCP tools (`create_scheduled_task`, `list_scheduled_tasks`, `get_scheduled_task`, `pause_scheduled_task`, `resume_scheduled_task`, `delete_scheduled_task`)
- `task_schedules` added to space scope in `scope-config.ts` for agent ad-hoc queries
- Startup resilience: re-enqueues active schedules whose pending job was lost
- Frontend: `schedules` signal in space-store, "Scheduled" tab in SpaceTasks UI
- Tests: 29 repository tests + 7 fire-handler tests; all 9,751 daemon tests pass