### PR TITLE
fix: resolve agent-name target to node-name channel for gate data writes

### DIFF
--- a/packages/daemon/src/lib/space/tools/node-agent-tools.ts
+++ b/packages/daemon/src/lib/space/tools/node-agent-tools.ts
@@ -289,6 +289,24 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 		? (workflow.nodes.find((node) => node.id === workflowNodeId)?.name ?? myAgentName)
 		: myAgentName;
 
+	// Build a slot-to-node map so we can resolve agent names to node names when
+	// matching channels for gate data writes. Channels use node names as addresses,
+	// but agents often send to other agents by their slot/agent name.
+	const slotToNode = new Map<string, string>();
+	if (workflow) {
+		for (const node of workflow.nodes) {
+			try {
+				for (const agent of resolveNodeAgents(node)) {
+					slotToNode.set(agent.name, node.name);
+				}
+			} catch {
+				// If resolveNodeAgents throws (e.g. empty agents array with no legacy
+				// agentId), skip this node — there are no agent slots to map anyway.
+			}
+		}
+	}
+	const resolveNodeName = (slotOrNode: string) => slotToNode.get(slotOrNode) ?? slotOrNode;
+
 	const agentNameAliases = new Set(
 		[myAgentName, myNodeName, ...(myAgentNameAliases ?? [])]
 			.map((value) => normalizeAgentNameToken(value))
@@ -580,7 +598,14 @@ export function createNodeAgentToolHandlers(config: NodeAgentToolsConfig) {
 						if (!ch.gateId) return false;
 						if (ch.from !== '*' && !fromRefs.has(ch.from)) return false;
 						const tos = Array.isArray(ch.to) ? ch.to : [ch.to];
-						return tos.some((to) => to === targetName || to === myNodeName || to === myAgentName);
+						const resolvedTarget = resolveNodeName(targetName);
+						return tos.some(
+							(to) =>
+								to === resolvedTarget ||
+								to === targetName ||
+								to === myNodeName ||
+								to === myAgentName
+						);
 					});
 
 					if (gatedChannel?.gateId) {

--- a/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
+++ b/packages/daemon/tests/unit/5-space/agent/node-agent-tools.test.ts
@@ -1636,6 +1636,62 @@ describe('node-agent-tools: send_message (gate-write)', () => {
 		expect(gateEvent).toBeDefined();
 		expect(gateEvent!.payload.gateId).toBe('gate-event');
 	});
+
+	test('gate-write resolves agent-name target to node-name channel (Coding -> Review)', async () => {
+		// Regression test for GitHub issue #1842 / Task #321:
+		// When channels use node names (e.g. 'Coding' -> 'Review') but the agent
+		// sends to an agent name (e.g. 'reviewer'), the gate data write must still
+		// find the correct channel and write pr_url to gate data. Previously the
+		// channel match failed because it compared 'reviewer' against the channel
+		// 'to' value 'Review', causing pr_url to never reach gate data and the
+		// PR_READY_BASH_SCRIPT to fall back to current-branch lookup (creating
+		// duplicate PRs in stacked-branch workflows).
+		const gate: Gate = {
+			id: 'review-posted-gate',
+			fields: [{ name: 'pr_url', type: 'string', writers: ['coder'], check: { op: 'exists' } }],
+			resetOnCycle: false,
+		};
+		const workflow: SpaceWorkflow = {
+			id: 'wf-1',
+			spaceId: ctx.spaceId,
+			name: 'Test Workflow',
+			description: '',
+			nodes: [
+				{
+					id: ctx.nodeId,
+					name: 'Coding',
+					agents: [{ agentId: 'agent-coder', name: 'coder' }],
+				},
+				{
+					id: 'node-review',
+					name: 'Review',
+					agents: [{ agentId: 'agent-reviewer', name: 'reviewer' }],
+				},
+			],
+			startNodeId: ctx.nodeId,
+			rules: [],
+			tags: [],
+			// Channel uses node names, not agent names
+			channels: [{ id: 'ch-coding-review', from: 'Coding', to: 'Review', gateId: gate.id }],
+			gates: [gate],
+		};
+		const gateDataRepo = new GateDataRepository(ctx.db);
+		const config = makeConfig(ctx, { workflow, gateDataRepo });
+		const handlers = createNodeAgentToolHandlers(config);
+
+		// Agent targets 'reviewer' (agent name) not 'Review' (node name)
+		const result = await handlers.send_message({
+			target: 'reviewer',
+			message: 'PR ready',
+			data: { pr_url: 'https://github.com/test/repo/pull/42' },
+		});
+		const data = JSON.parse(result.content[0].text);
+
+		expect(data.gateWrite).toEqual({ gateId: 'review-posted-gate', gateOpen: true });
+		expect(gateDataRepo.get(ctx.workflowRunId, 'review-posted-gate')?.data.pr_url).toBe(
+			'https://github.com/test/repo/pull/42'
+		);
+	});
 });
 
 describe('node-agent-tools: list_reachable_agents', () => {


### PR DESCRIPTION
Fixes the Coding→Review workflow gate (Task #321, GitHub issue #1842) to prefer an explicit `pr_url` supplied in `send_message` data over looking up a PR for the current local branch.

**Root cause:** When channels use node names (e.g. `Coding` → `Review`) but the agent sends to an agent name (e.g. `reviewer`), the gate data write path in `send_message` failed to find the matching channel because it compared the raw agent name against the channel's node-name `to` value. This caused `pr_url` (and any other gate data) to never be written to gate data. The `PR_READY_BASH_SCRIPT` then fell back to current-branch lookup, creating duplicate PRs in stacked-branch workflows.

**Fix:** Build a `slotToNode` map in `createNodeAgentToolHandlers` (mirroring `AgentMessageRouter`) and resolve the target name before channel matching for gate data writes.

**Test:** Added regression test `gate-write resolves agent-name target to node-name channel (Coding -> Review)` that verifies `pr_url` is correctly written to gate data when channels use node names but the agent targets by agent name.