### PR TITLE
feat: add scheduled task creation UI to SpaceCreateTaskDialog

### DIFF
--- a/packages/web/src/components/space/SpaceCreateTaskDialog.tsx
+++ b/packages/web/src/components/space/SpaceCreateTaskDialog.tsx
@@ -71,17 +71,17 @@ function isValidCronExpression(expr: string): boolean {
 	// Field validators indexed by position (0 = seconds when present, else minute)
 	const fieldPatterns = [
 		// seconds (optional)
-		/^([0-5]?\d|[*](?:\/[1-9]\d?)?|(?:[0-5]?\d)(?:-[0-5]?\d)?(?:\/[1-9]\d?)?|(?:[0-5]?\d)(?:,(?:[0-5]?\d|-[0-5]?\d|\*))+)$/,
+		/^([0-5]?\d|[*](?:\/[1-9]\d?)?|(?:[0-5]?\d)(?:-[0-5]?\d)?(?:\/[1-9]\d?)?|(?:[0-5]?\d)(?:,(?:[0-5]?\d|-[0-5]?\d|\*))+|\?)$/,
 		// minute
-		/^([0-5]?\d|[*](?:\/[1-9]\d?)?|(?:[0-5]?\d)(?:-[0-5]?\d)?(?:\/[1-9]\d?)?|(?:[0-5]?\d)(?:,(?:[0-5]?\d|-[0-5]?\d|\*))+)$/,
+		/^([0-5]?\d|[*](?:\/[1-9]\d?)?|(?:[0-5]?\d)(?:-[0-5]?\d)?(?:\/[1-9]\d?)?|(?:[0-5]?\d)(?:,(?:[0-5]?\d|-[0-5]?\d|\*))+|\?)$/,
 		// hour
-		/^([01]?\d|2[0-3]|[*](?:\/[1-9]\d?)?|(?:[01]?\d|2[0-3])(?:-[01]?\d|2[0-3])?(?:\/[1-9]\d?)?|(?:[01]?\d|2[0-3])(?:,(?:[01]?\d|2[0-3]|-[01]?\d|2[0-3]|\*))+)$/,
+		/^([01]?\d|2[0-3]|[*](?:\/[1-9]\d?)?|(?:[01]?\d|2[0-3])(?:-[01]?\d|2[0-3])?(?:\/[1-9]\d?)?|(?:[01]?\d|2[0-3])(?:,(?:[01]?\d|2[0-3]|-[01]?\d|2[0-3]|\*))+|\?)$/,
 		// day of month
-		/^([1-9]|[12]\d|3[01]|[*](?:\/[1-9]\d?)?|(?:[1-9]|[12]\d|3[01])(?:-[1-9]|[12]\d|3[01])?(?:\/[1-9]\d?)?|(?:[1-9]|[12]\d|3[01])(?:,(?:[1-9]|[12]\d|3[01]|-[1-9]|[12]\d|3[01]|\*))+|L|L-[1-9]|[12]\d|3[01]|LW)$/,
+		/^([1-9]|[12]\d|3[01]|[*](?:\/[1-9]\d?)?|(?:[1-9]|[12]\d|3[01])(?:-[1-9]|[12]\d|3[01])?(?:\/[1-9]\d?)?|(?:[1-9]|[12]\d|3[01])(?:,(?:[1-9]|[12]\d|3[01]|-[1-9]|[12]\d|3[01]|\*))+|L|L-[1-9]|L-[12]\d|L-3[01]|LW|\?|(?:[1-9]|[12]\d|3[01])W)$/,
 		// month
-		/^([1-9]|1[0-2]|[*](?:\/[1-9]\d?)?|(?:[1-9]|1[0-2])(?:-[1-9]|1[0-2])?(?:\/[1-9]\d?)?|(?:[1-9]|1[0-2])(?:,(?:[1-9]|1[0-2]|-[1-9]|1[0-2]|\*))+|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)$/,
+		/^([1-9]|1[0-2]|[*](?:\/[1-9]\d?)?|(?:[1-9]|1[0-2])(?:-[1-9]|1[0-2])?(?:\/[1-9]\d?)?|(?:[1-9]|1[0-2])(?:,(?:[1-9]|1[0-2]|-[1-9]|1[0-2]|\*))+|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC|\?)$/i,
 		// weekday
-		/^([0-7]|[*](?:\/[1-9]\d?)?|(?:[0-7])(?:-[0-7])?(?:\/[1-9]\d?)?|(?:[0-7])(?:,(?:[0-7]|-[0-7]|\*))+|MON|TUE|WED|THU|FRI|SAT|SUN|L)$/,
+		/^([0-7]|[*](?:\/[1-9]\d?)?|(?:[0-7])(?:-[0-7])?(?:\/[1-9]\d?)?|(?:[0-7])(?:,(?:[0-7]|-[0-7]|\*))+|MON|TUE|WED|THU|FRI|SAT|SUN|L|\?|(?:MON|TUE|WED|THU|FRI|SAT|SUN)#(?:[1-5]))$/i,
 	];
 
 	for (let i = 0; i < parts.length; i++) {
@@ -161,7 +161,6 @@ export function SpaceCreateTaskDialog({ isOpen, onClose, onCreated }: SpaceCreat
 		}
 		if (triggerType === 'at') {
 			if (!runAt) return 'Run date/time is required';
-			if (runAt <= Date.now()) return 'Run time must be in the future';
 		}
 		return null;
 	}, [scheduleEnabled, triggerType, cronExpression, runAt]);
@@ -181,6 +180,11 @@ export function SpaceCreateTaskDialog({ isOpen, onClose, onCreated }: SpaceCreat
 
 		if (scheduleEnabled && validationError) {
 			setError(validationError);
+			return;
+		}
+
+		if (scheduleEnabled && triggerType === 'at' && runAt && runAt <= Date.now()) {
+			setError('Run time must be in the future');
 			return;
 		}
 

--- a/packages/web/src/components/space/SpaceCreateTaskDialog.tsx
+++ b/packages/web/src/components/space/SpaceCreateTaskDialog.tsx
@@ -83,7 +83,7 @@ function isValidCronExpression(expr: string): boolean {
 		// month
 		/^([1-9]|1[0-2]|[*](?:\/[1-9]\d?)?|(?:[1-9]|1[0-2])(?:-[1-9]|1[0-2])?(?:\/[1-9]\d?)?|(?:[1-9]|1[0-2]|[*])(?:,(?:[1-9]|1[0-2]|[*]|[1-9]-[1-9]|[1-9]-1[0-2]|1[0-2]-1[0-2]))+|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC|\?)$/i,
 		// weekday
-		/^([0-7]|[*](?:\/[1-9]\d?)?|(?:[0-7])(?:-[0-7])?(?:\/[1-9]\d?)?|(?:[0-7]|[*])(?:,(?:[0-7]|[*]|[0-7]-[0-7]))+|\+|\+[0-7]|\+[MON|TUE|WED|THU|FRI|SAT|SUN]|MON|TUE|WED|THU|FRI|SAT|SUN|L|\?|(?:MON|TUE|WED|THU|FRI|SAT|SUN)#(?:[1-5]|L))$/i,
+		/^([0-7]|[*](?:\/[1-9]\d?)?|(?:[0-7])(?:-[0-7])?(?:\/[1-9]\d?)?|(?:[0-7]|[*])(?:,(?:[0-7]|[*]|[0-7]-[0-7]))+|\+|\+[0-7]|\+(?:MON|TUE|WED|THU|FRI|SAT|SUN)|MON|TUE|WED|THU|FRI|SAT|SUN|L|\?|(?:MON|TUE|WED|THU|FRI|SAT|SUN)#(?:[1-5]|L))$/i,
 	];
 
 	for (let i = 0; i < parts.length; i++) {

--- a/packages/web/src/components/space/SpaceCreateTaskDialog.tsx
+++ b/packages/web/src/components/space/SpaceCreateTaskDialog.tsx
@@ -30,6 +30,7 @@ const TRIGGER_OPTIONS: { value: TaskScheduleTriggerType; label: string }[] = [
 const CRON_PRESETS: { label: string; value: string }[] = [
 	{ label: '@hourly', value: '@hourly' },
 	{ label: '@daily', value: '@daily' },
+	{ label: '@midnight', value: '@midnight' },
 	{ label: '@weekly', value: '@weekly' },
 	{ label: '@monthly', value: '@monthly' },
 ];
@@ -51,42 +52,110 @@ const COMMON_TIMEZONES = [
 
 /**
  * Lightweight frontend cron validation.
- * Supports 5-field cron and named shortcuts (@hourly, @daily, @weekly, @monthly, @yearly).
- * Does not validate every edge case — the daemon validates with croner and returns errors.
+ * Supports 5-field and 6-field cron, named shortcuts, L/W/Q tokens, and
+ * weekday/month names. Does not validate every edge case — the daemon
+ * validates with croner and returns errors.
  */
 function isValidCronExpression(expr: string): boolean {
 	const trimmed = expr.trim();
 	if (!trimmed) return false;
 
 	// Named shortcuts
-	if (/^@(hourly|daily|weekly|monthly|yearly|annually)$/.test(trimmed)) return true;
+	if (/^@(hourly|daily|midnight|weekly|monthly|yearly|annually)$/.test(trimmed)) return true;
 
-	// 5-field cron: minute hour day month weekday
 	const parts = trimmed.split(/\s+/);
-	if (parts.length !== 5) return false;
+	if (parts.length !== 5 && parts.length !== 6) return false;
 
+	const hasSeconds = parts.length === 6;
+
+	// Field validators indexed by position (0 = seconds when present, else minute)
 	const fieldPatterns = [
-		/^([0-5]?\d|[*](?:\/[1-9]\d?)?|(?:[0-5]?\d)(?:-[0-5]?\d)?(?:\/[1-9]\d?)?|(?:[0-5]?\d)(?:,(?:[0-5]?\d|-[0-5]?\d|\*))+)$/, // minute
-		/^([01]?\d|2[0-3]|[*](?:\/[1-9]\d?)?|(?:[01]?\d|2[0-3])(?:-[01]?\d|2[0-3])?(?:\/[1-9]\d?)?|(?:[01]?\d|2[0-3])(?:,(?:[01]?\d|2[0-3]|-[01]?\d|2[0-3]|\*))+)$/, // hour
-		/^([1-9]|[12]\d|3[01]|[*?](?:\/[1-9]\d?)?|(?:[1-9]|[12]\d|3[01])(?:-[1-9]|[12]\d|3[01])?(?:\/[1-9]\d?)?|(?:[1-9]|[12]\d|3[01])(?:,(?:[1-9]|[12]\d|3[01]|-[1-9]|[12]\d|3[01]|\*))+)$/, // day
-		/^([1-9]|1[0-2]|[*](?:\/[1-9]\d?)?|(?:[1-9]|1[0-2])(?:-[1-9]|1[0-2])?(?:\/[1-9]\d?)?|(?:[1-9]|1[0-2])(?:,(?:[1-9]|1[0-2]|-[1-9]|1[0-2]|\*))+)$/, // month
-		/^([0-6]|[*](?:\/[1-9]\d?)?|(?:[0-6])(?:-[0-6])?(?:\/[1-9]\d?)?|(?:[0-6])(?:,(?:[0-6]|-[0-6]|\*))+|MON|TUE|WED|THU|FRI|SAT|SUN)$/, // weekday
+		// seconds (optional)
+		/^([0-5]?\d|[*](?:\/[1-9]\d?)?|(?:[0-5]?\d)(?:-[0-5]?\d)?(?:\/[1-9]\d?)?|(?:[0-5]?\d)(?:,(?:[0-5]?\d|-[0-5]?\d|\*))+)$/,
+		// minute
+		/^([0-5]?\d|[*](?:\/[1-9]\d?)?|(?:[0-5]?\d)(?:-[0-5]?\d)?(?:\/[1-9]\d?)?|(?:[0-5]?\d)(?:,(?:[0-5]?\d|-[0-5]?\d|\*))+)$/,
+		// hour
+		/^([01]?\d|2[0-3]|[*](?:\/[1-9]\d?)?|(?:[01]?\d|2[0-3])(?:-[01]?\d|2[0-3])?(?:\/[1-9]\d?)?|(?:[01]?\d|2[0-3])(?:,(?:[01]?\d|2[0-3]|-[01]?\d|2[0-3]|\*))+)$/,
+		// day of month
+		/^([1-9]|[12]\d|3[01]|[*](?:\/[1-9]\d?)?|(?:[1-9]|[12]\d|3[01])(?:-[1-9]|[12]\d|3[01])?(?:\/[1-9]\d?)?|(?:[1-9]|[12]\d|3[01])(?:,(?:[1-9]|[12]\d|3[01]|-[1-9]|[12]\d|3[01]|\*))+|L|L-[1-9]|[12]\d|3[01]|LW)$/,
+		// month
+		/^([1-9]|1[0-2]|[*](?:\/[1-9]\d?)?|(?:[1-9]|1[0-2])(?:-[1-9]|1[0-2])?(?:\/[1-9]\d?)?|(?:[1-9]|1[0-2])(?:,(?:[1-9]|1[0-2]|-[1-9]|1[0-2]|\*))+|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)$/,
+		// weekday
+		/^([0-7]|[*](?:\/[1-9]\d?)?|(?:[0-7])(?:-[0-7])?(?:\/[1-9]\d?)?|(?:[0-7])(?:,(?:[0-7]|-[0-7]|\*))+|MON|TUE|WED|THU|FRI|SAT|SUN|L)$/,
 	];
 
-	for (let i = 0; i < 5; i++) {
-		if (!fieldPatterns[i].test(parts[i])) return false;
+	for (let i = 0; i < parts.length; i++) {
+		const patternIdx = hasSeconds ? i : i + 1;
+		if (!fieldPatterns[patternIdx].test(parts[i])) return false;
 	}
 	return true;
 }
 
-function toLocalDatetimeInputValue(ts: number): string {
+/**
+ * Parse a datetime-local string as an epoch timestamp in the given IANA timezone.
+ *
+ * datetime-local values have no timezone offset, so `new Date(value)` interprets
+ * them in the browser's local timezone. This helper treats the value as if it
+ * were in `timezone`, then returns the corresponding UTC instant.
+ */
+function parseDatetimeInTimezone(value: string, timezone: string): number {
+	// Use Intl.DateTimeFormat to parse the wall-clock time in the target timezone
+	const [datePart, timePart] = value.split('T');
+	const [year, month, day] = datePart.split('-').map(Number);
+	const [hour, minute] = timePart.split(':').map(Number);
+
+	// Construct a date string that the target timezone would interpret as the given wall-clock time
+	// We use the 'en-US' locale with the target timezone to format, then parse back
+	const candidate = new Date(Date.UTC(year, month - 1, day, hour, minute));
+
+	// Get the timezone offset for the candidate date in the target timezone
+	const formatter = new Intl.DateTimeFormat('en-US', {
+		timeZone: timezone,
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+		hour: '2-digit',
+		minute: '2-digit',
+		hour12: false,
+	});
+
+	const parts = formatter.formatToParts(candidate);
+	const getPart = (type: string) => {
+		const p = parts.find((part) => part.type === type);
+		return p ? parseInt(p.value, 10) : 0;
+	};
+
+	const tzYear = getPart('year');
+	const tzMonth = getPart('month');
+	const tzDay = getPart('day');
+	const tzHour = getPart('hour');
+	const tzMinute = getPart('minute');
+
+	// Calculate offset: how much does candidate UTC need to shift so that
+	// the target timezone reads the desired wall-clock time?
+	const offsetMs =
+		Date.UTC(year, month - 1, day, hour, minute) -
+		Date.UTC(tzYear, tzMonth - 1, tzDay, tzHour, tzMinute);
+
+	return candidate.getTime() + offsetMs;
+}
+
+function toDatetimeLocalValue(ts: number): string {
 	const d = new Date(ts);
 	const pad = (n: number) => String(n).padStart(2, '0');
 	return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
-function fromLocalDatetimeInputValue(value: string): number {
-	return new Date(value).getTime();
+function formatPreviewDate(ts: number, timezone: string): string {
+	return new Date(ts).toLocaleString('en-US', {
+		timeZone: timezone,
+		year: 'numeric',
+		month: 'short',
+		day: 'numeric',
+		hour: '2-digit',
+		minute: '2-digit',
+		hour12: true,
+	});
 }
 
 function getSchedulePreview(
@@ -96,7 +165,7 @@ function getSchedulePreview(
 	timezone: string
 ): string | null {
 	if (triggerType === 'at' && runAt) {
-		return `One-time run at ${new Date(runAt).toLocaleString()} (${timezone})`;
+		return `One-time run at ${formatPreviewDate(runAt, timezone)} (${timezone})`;
 	}
 	if (triggerType === 'cron' && cronExpression) {
 		const preset = CRON_PRESETS.find((p) => p.value === cronExpression);
@@ -309,10 +378,10 @@ export function SpaceCreateTaskDialog({ isOpen, onClose, onCreated }: SpaceCreat
 								</label>
 								<input
 									type="datetime-local"
-									value={runAt ? toLocalDatetimeInputValue(runAt) : ''}
+									value={runAt ? toDatetimeLocalValue(runAt) : ''}
 									onInput={(e) => {
 										const val = (e.target as HTMLInputElement).value;
-										setRunAt(val ? fromLocalDatetimeInputValue(val) : null);
+										setRunAt(val ? parseDatetimeInTimezone(val, timezone) : null);
 									}}
 									class="w-full bg-dark-800 border border-dark-600 rounded-lg px-4 py-2.5 text-gray-100
 										focus:outline-none focus:border-blue-500 text-sm"
@@ -363,22 +432,24 @@ export function SpaceCreateTaskDialog({ isOpen, onClose, onCreated }: SpaceCreat
 							</div>
 						)}
 
-						{/* Timezone */}
-						<div>
-							<label class="block text-sm font-medium text-gray-300 mb-1.5">Timezone</label>
-							<select
-								value={timezone}
-								onChange={(e) => setTimezone((e.target as HTMLSelectElement).value)}
-								class="w-full bg-dark-800 border border-dark-600 rounded-lg px-3 py-2 text-gray-100
-									focus:outline-none focus:border-blue-500 text-sm"
-							>
-								{COMMON_TIMEZONES.map((tz) => (
-									<option key={tz} value={tz}>
-										{tz}
-									</option>
-								))}
-							</select>
-						</div>
+						{/* Timezone — only meaningful for cron triggers */}
+						{triggerType === 'cron' && (
+							<div>
+								<label class="block text-sm font-medium text-gray-300 mb-1.5">Timezone</label>
+								<select
+									value={timezone}
+									onChange={(e) => setTimezone((e.target as HTMLSelectElement).value)}
+									class="w-full bg-dark-800 border border-dark-600 rounded-lg px-3 py-2 text-gray-100
+										focus:outline-none focus:border-blue-500 text-sm"
+								>
+									{COMMON_TIMEZONES.map((tz) => (
+										<option key={tz} value={tz}>
+											{tz}
+										</option>
+									))}
+								</select>
+							</div>
+						)}
 
 						{/* Preview */}
 						{preview && (

--- a/packages/web/src/components/space/SpaceCreateTaskDialog.tsx
+++ b/packages/web/src/components/space/SpaceCreateTaskDialog.tsx
@@ -91,55 +91,6 @@ function isValidCronExpression(expr: string): boolean {
 	return true;
 }
 
-/**
- * Parse a datetime-local string as an epoch timestamp in the given IANA timezone.
- *
- * datetime-local values have no timezone offset, so `new Date(value)` interprets
- * them in the browser's local timezone. This helper treats the value as if it
- * were in `timezone`, then returns the corresponding UTC instant.
- */
-function parseDatetimeInTimezone(value: string, timezone: string): number {
-	// Use Intl.DateTimeFormat to parse the wall-clock time in the target timezone
-	const [datePart, timePart] = value.split('T');
-	const [year, month, day] = datePart.split('-').map(Number);
-	const [hour, minute] = timePart.split(':').map(Number);
-
-	// Construct a date string that the target timezone would interpret as the given wall-clock time
-	// We use the 'en-US' locale with the target timezone to format, then parse back
-	const candidate = new Date(Date.UTC(year, month - 1, day, hour, minute));
-
-	// Get the timezone offset for the candidate date in the target timezone
-	const formatter = new Intl.DateTimeFormat('en-US', {
-		timeZone: timezone,
-		year: 'numeric',
-		month: '2-digit',
-		day: '2-digit',
-		hour: '2-digit',
-		minute: '2-digit',
-		hour12: false,
-	});
-
-	const parts = formatter.formatToParts(candidate);
-	const getPart = (type: string) => {
-		const p = parts.find((part) => part.type === type);
-		return p ? parseInt(p.value, 10) : 0;
-	};
-
-	const tzYear = getPart('year');
-	const tzMonth = getPart('month');
-	const tzDay = getPart('day');
-	const tzHour = getPart('hour');
-	const tzMinute = getPart('minute');
-
-	// Calculate offset: how much does candidate UTC need to shift so that
-	// the target timezone reads the desired wall-clock time?
-	const offsetMs =
-		Date.UTC(year, month - 1, day, hour, minute) -
-		Date.UTC(tzYear, tzMonth - 1, tzDay, tzHour, tzMinute);
-
-	return candidate.getTime() + offsetMs;
-}
-
 function toDatetimeLocalValue(ts: number): string {
 	const d = new Date(ts);
 	const pad = (n: number) => String(n).padStart(2, '0');
@@ -381,7 +332,7 @@ export function SpaceCreateTaskDialog({ isOpen, onClose, onCreated }: SpaceCreat
 									value={runAt ? toDatetimeLocalValue(runAt) : ''}
 									onInput={(e) => {
 										const val = (e.target as HTMLInputElement).value;
-										setRunAt(val ? parseDatetimeInTimezone(val, timezone) : null);
+										setRunAt(val ? new Date(val).getTime() : null);
 									}}
 									class="w-full bg-dark-800 border border-dark-600 rounded-lg px-4 py-2.5 text-gray-100
 										focus:outline-none focus:border-blue-500 text-sm"

--- a/packages/web/src/components/space/SpaceCreateTaskDialog.tsx
+++ b/packages/web/src/components/space/SpaceCreateTaskDialog.tsx
@@ -1,13 +1,13 @@
 /**
- * SpaceCreateTaskDialog — modal form to create a standalone task in a Space.
+ * SpaceCreateTaskDialog — modal form to create a standalone task or scheduled task in a Space.
  */
 
-import { useState } from 'preact/hooks';
+import { useMemo, useState } from 'preact/hooks';
 import { Modal } from '../ui/Modal';
 import { Button } from '../ui/Button';
 import { spaceStore } from '../../lib/space-store';
 import { toast } from '../../lib/toast';
-import type { SpaceTask, SpaceTaskPriority } from '@neokai/shared';
+import type { SpaceTask, SpaceTaskPriority, TaskScheduleTriggerType } from '@neokai/shared';
 
 interface SpaceCreateTaskDialogProps {
 	isOpen: boolean;
@@ -22,6 +22,90 @@ const PRIORITY_OPTIONS: { value: SpaceTaskPriority; label: string }[] = [
 	{ value: 'urgent', label: 'Urgent' },
 ];
 
+const TRIGGER_OPTIONS: { value: TaskScheduleTriggerType; label: string }[] = [
+	{ value: 'at', label: 'One-time' },
+	{ value: 'cron', label: 'Recurring' },
+];
+
+const CRON_PRESETS: { label: string; value: string }[] = [
+	{ label: '@hourly', value: '@hourly' },
+	{ label: '@daily', value: '@daily' },
+	{ label: '@weekly', value: '@weekly' },
+	{ label: '@monthly', value: '@monthly' },
+];
+
+const COMMON_TIMEZONES = [
+	'UTC',
+	'America/New_York',
+	'America/Los_Angeles',
+	'America/Chicago',
+	'Europe/London',
+	'Europe/Paris',
+	'Europe/Berlin',
+	'Asia/Tokyo',
+	'Asia/Shanghai',
+	'Asia/Singapore',
+	'Australia/Sydney',
+	'Pacific/Auckland',
+];
+
+/**
+ * Lightweight frontend cron validation.
+ * Supports 5-field cron and named shortcuts (@hourly, @daily, @weekly, @monthly, @yearly).
+ * Does not validate every edge case — the daemon validates with croner and returns errors.
+ */
+function isValidCronExpression(expr: string): boolean {
+	const trimmed = expr.trim();
+	if (!trimmed) return false;
+
+	// Named shortcuts
+	if (/^@(hourly|daily|weekly|monthly|yearly|annually)$/.test(trimmed)) return true;
+
+	// 5-field cron: minute hour day month weekday
+	const parts = trimmed.split(/\s+/);
+	if (parts.length !== 5) return false;
+
+	const fieldPatterns = [
+		/^([0-5]?\d|[*](?:\/[1-9]\d?)?|(?:[0-5]?\d)(?:-[0-5]?\d)?(?:\/[1-9]\d?)?|(?:[0-5]?\d)(?:,(?:[0-5]?\d|-[0-5]?\d|\*))+)$/, // minute
+		/^([01]?\d|2[0-3]|[*](?:\/[1-9]\d?)?|(?:[01]?\d|2[0-3])(?:-[01]?\d|2[0-3])?(?:\/[1-9]\d?)?|(?:[01]?\d|2[0-3])(?:,(?:[01]?\d|2[0-3]|-[01]?\d|2[0-3]|\*))+)$/, // hour
+		/^([1-9]|[12]\d|3[01]|[*?](?:\/[1-9]\d?)?|(?:[1-9]|[12]\d|3[01])(?:-[1-9]|[12]\d|3[01])?(?:\/[1-9]\d?)?|(?:[1-9]|[12]\d|3[01])(?:,(?:[1-9]|[12]\d|3[01]|-[1-9]|[12]\d|3[01]|\*))+)$/, // day
+		/^([1-9]|1[0-2]|[*](?:\/[1-9]\d?)?|(?:[1-9]|1[0-2])(?:-[1-9]|1[0-2])?(?:\/[1-9]\d?)?|(?:[1-9]|1[0-2])(?:,(?:[1-9]|1[0-2]|-[1-9]|1[0-2]|\*))+)$/, // month
+		/^([0-6]|[*](?:\/[1-9]\d?)?|(?:[0-6])(?:-[0-6])?(?:\/[1-9]\d?)?|(?:[0-6])(?:,(?:[0-6]|-[0-6]|\*))+|MON|TUE|WED|THU|FRI|SAT|SUN)$/, // weekday
+	];
+
+	for (let i = 0; i < 5; i++) {
+		if (!fieldPatterns[i].test(parts[i])) return false;
+	}
+	return true;
+}
+
+function toLocalDatetimeInputValue(ts: number): string {
+	const d = new Date(ts);
+	const pad = (n: number) => String(n).padStart(2, '0');
+	return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function fromLocalDatetimeInputValue(value: string): number {
+	return new Date(value).getTime();
+}
+
+function getSchedulePreview(
+	triggerType: TaskScheduleTriggerType,
+	cronExpression: string,
+	runAt: number | null,
+	timezone: string
+): string | null {
+	if (triggerType === 'at' && runAt) {
+		return `One-time run at ${new Date(runAt).toLocaleString()} (${timezone})`;
+	}
+	if (triggerType === 'cron' && cronExpression) {
+		const preset = CRON_PRESETS.find((p) => p.value === cronExpression);
+		if (preset) return `${preset.label} in ${timezone}`;
+		return `Recurring: ${cronExpression} (${timezone})`;
+	}
+	return null;
+}
+
 export function SpaceCreateTaskDialog({ isOpen, onClose, onCreated }: SpaceCreateTaskDialogProps) {
 	const [title, setTitle] = useState('');
 	const [description, setDescription] = useState('');
@@ -29,13 +113,43 @@ export function SpaceCreateTaskDialog({ isOpen, onClose, onCreated }: SpaceCreat
 	const [submitting, setSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
+	// Schedule fields
+	const [scheduleEnabled, setScheduleEnabled] = useState(false);
+	const [triggerType, setTriggerType] = useState<TaskScheduleTriggerType>('at');
+	const [cronExpression, setCronExpression] = useState('');
+	const [runAt, setRunAt] = useState<number | null>(null);
+	const [timezone, setTimezone] = useState('UTC');
+
 	const handleClose = () => {
 		setTitle('');
 		setDescription('');
 		setPriority('normal');
 		setError(null);
+		setScheduleEnabled(false);
+		setTriggerType('at');
+		setCronExpression('');
+		setRunAt(null);
+		setTimezone('UTC');
 		onClose();
 	};
+
+	const validationError = useMemo(() => {
+		if (!scheduleEnabled) return null;
+		if (triggerType === 'cron') {
+			if (!cronExpression.trim()) return 'Cron expression is required';
+			if (!isValidCronExpression(cronExpression)) return 'Invalid cron expression';
+		}
+		if (triggerType === 'at') {
+			if (!runAt) return 'Run date/time is required';
+			if (runAt <= Date.now()) return 'Run time must be in the future';
+		}
+		return null;
+	}, [scheduleEnabled, triggerType, cronExpression, runAt]);
+
+	const preview = useMemo(() => {
+		if (!scheduleEnabled) return null;
+		return getSchedulePreview(triggerType, cronExpression, runAt, timezone);
+	}, [scheduleEnabled, triggerType, cronExpression, runAt, timezone]);
 
 	const handleSubmit = async (e: Event) => {
 		e.preventDefault();
@@ -45,18 +159,35 @@ export function SpaceCreateTaskDialog({ isOpen, onClose, onCreated }: SpaceCreat
 			return;
 		}
 
+		if (scheduleEnabled && validationError) {
+			setError(validationError);
+			return;
+		}
+
 		try {
 			setSubmitting(true);
 			setError(null);
 
-			const task = await spaceStore.createTask({
-				title: title.trim(),
-				description: description.trim(),
-				priority,
-			});
-
-			toast.success(`Task "${task.title}" created`);
-			onCreated?.(task);
+			if (scheduleEnabled) {
+				const schedule = await spaceStore.createSchedule({
+					title: title.trim(),
+					description: description.trim(),
+					priority,
+					triggerType,
+					cronExpression: triggerType === 'cron' ? cronExpression.trim() : null,
+					runAt: triggerType === 'at' ? runAt : null,
+					timezone,
+				});
+				toast.success(`Scheduled task "${schedule.title}" created`);
+			} else {
+				const task = await spaceStore.createTask({
+					title: title.trim(),
+					description: description.trim(),
+					priority,
+				});
+				toast.success(`Task "${task.title}" created`);
+				onCreated?.(task);
+			}
 			handleClose();
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Failed to create task');
@@ -126,12 +257,144 @@ export function SpaceCreateTaskDialog({ isOpen, onClose, onCreated }: SpaceCreat
 					</select>
 				</div>
 
+				{/* Schedule toggle */}
+				<div class="border-t border-dark-700 pt-4">
+					<label class="flex items-center gap-2 cursor-pointer">
+						<input
+							type="checkbox"
+							checked={scheduleEnabled}
+							onChange={(e) => setScheduleEnabled((e.target as HTMLInputElement).checked)}
+							class="w-4 h-4 rounded border-dark-600 bg-dark-800 text-blue-600 focus:ring-blue-500 focus:ring-offset-dark-900"
+						/>
+						<span class="text-sm font-medium text-gray-200">Schedule this task</span>
+					</label>
+				</div>
+
+				{/* Schedule options */}
+				{scheduleEnabled && (
+					<div class="space-y-4 rounded-lg border border-dark-700 bg-dark-800/50 p-4">
+						{/* Trigger type */}
+						<div>
+							<label class="block text-sm font-medium text-gray-300 mb-1.5">Trigger</label>
+							<div class="flex gap-3">
+								{TRIGGER_OPTIONS.map((opt) => (
+									<label
+										key={opt.value}
+										class={`flex items-center gap-2 px-3 py-2 rounded-lg border cursor-pointer text-sm transition-colors ${
+											triggerType === opt.value
+												? 'border-blue-500 bg-blue-900/20 text-blue-300'
+												: 'border-dark-600 text-gray-400 hover:border-dark-500'
+										}`}
+									>
+										<input
+											type="radio"
+											name="triggerType"
+											value={opt.value}
+											checked={triggerType === opt.value}
+											onChange={() => setTriggerType(opt.value)}
+											class="sr-only"
+										/>
+										<span>{opt.label}</span>
+									</label>
+								))}
+							</div>
+						</div>
+
+						{/* One-time: datetime picker */}
+						{triggerType === 'at' && (
+							<div>
+								<label class="block text-sm font-medium text-gray-300 mb-1.5">
+									Run at
+									<span class="text-red-400 ml-1">*</span>
+								</label>
+								<input
+									type="datetime-local"
+									value={runAt ? toLocalDatetimeInputValue(runAt) : ''}
+									onInput={(e) => {
+										const val = (e.target as HTMLInputElement).value;
+										setRunAt(val ? fromLocalDatetimeInputValue(val) : null);
+									}}
+									class="w-full bg-dark-800 border border-dark-600 rounded-lg px-4 py-2.5 text-gray-100
+										focus:outline-none focus:border-blue-500 text-sm"
+								/>
+							</div>
+						)}
+
+						{/* Recurring: cron input + presets */}
+						{triggerType === 'cron' && (
+							<div class="space-y-3">
+								<div>
+									<label class="block text-sm font-medium text-gray-300 mb-1.5">
+										Cron expression
+										<span class="text-red-400 ml-1">*</span>
+									</label>
+									<div class="flex gap-2 flex-wrap mb-2">
+										{CRON_PRESETS.map((preset) => (
+											<button
+												key={preset.value}
+												type="button"
+												onClick={() => setCronExpression(preset.value)}
+												class={`px-2.5 py-1 text-xs rounded border transition-colors ${
+													cronExpression === preset.value
+														? 'border-blue-500 bg-blue-900/20 text-blue-300'
+														: 'border-dark-600 text-gray-400 hover:border-dark-500 hover:text-gray-300'
+												}`}
+											>
+												{preset.label}
+											</button>
+										))}
+									</div>
+									<input
+										type="text"
+										value={cronExpression}
+										onInput={(e) => setCronExpression((e.target as HTMLInputElement).value)}
+										placeholder="0 9 * * 1"
+										class={`w-full bg-dark-800 border rounded-lg px-4 py-2.5 text-gray-100
+											placeholder-gray-600 focus:outline-none focus:border-blue-500 text-sm ${
+												cronExpression && !isValidCronExpression(cronExpression)
+													? 'border-red-700 focus:border-red-500'
+													: 'border-dark-600'
+											}`}
+									/>
+									{cronExpression && !isValidCronExpression(cronExpression) && (
+										<p class="mt-1 text-xs text-red-400">Invalid cron expression</p>
+									)}
+								</div>
+							</div>
+						)}
+
+						{/* Timezone */}
+						<div>
+							<label class="block text-sm font-medium text-gray-300 mb-1.5">Timezone</label>
+							<select
+								value={timezone}
+								onChange={(e) => setTimezone((e.target as HTMLSelectElement).value)}
+								class="w-full bg-dark-800 border border-dark-600 rounded-lg px-3 py-2 text-gray-100
+									focus:outline-none focus:border-blue-500 text-sm"
+							>
+								{COMMON_TIMEZONES.map((tz) => (
+									<option key={tz} value={tz}>
+										{tz}
+									</option>
+								))}
+							</select>
+						</div>
+
+						{/* Preview */}
+						{preview && (
+							<div class="text-xs text-gray-500 bg-dark-900/50 rounded px-3 py-2 border border-dark-700">
+								{preview}
+							</div>
+						)}
+					</div>
+				)}
+
 				<div class="flex gap-3 pt-1">
 					<Button type="button" variant="secondary" onClick={handleClose} fullWidth>
 						Cancel
 					</Button>
 					<Button type="submit" loading={submitting} fullWidth>
-						Create Task
+						{scheduleEnabled ? 'Create Schedule' : 'Create Task'}
 					</Button>
 				</div>
 			</form>

--- a/packages/web/src/components/space/SpaceCreateTaskDialog.tsx
+++ b/packages/web/src/components/space/SpaceCreateTaskDialog.tsx
@@ -69,19 +69,21 @@ function isValidCronExpression(expr: string): boolean {
 	const hasSeconds = parts.length === 6;
 
 	// Field validators indexed by position (0 = seconds when present, else minute)
+	// Each field accepts: single value, *, */step, range, range/step, list (values/ranges/*),
+	// and field-specific tokens (L, W, ?, month names, weekday names, nth-weekday, etc.)
 	const fieldPatterns = [
 		// seconds (optional)
-		/^([0-5]?\d|[*](?:\/[1-9]\d?)?|(?:[0-5]?\d)(?:-[0-5]?\d)?(?:\/[1-9]\d?)?|(?:[0-5]?\d)(?:,(?:[0-5]?\d|-[0-5]?\d|\*))+|\?)$/,
+		/^([0-5]?\d|[*](?:\/[1-9]\d?)?|(?:[0-5]?\d)(?:-[0-5]?\d)?(?:\/[1-9]\d?)?|(?:[0-5]?\d|[*])(?:,(?:[0-5]?\d|[*]|[0-5]?\d-[0-5]?\d))+|\?)$/,
 		// minute
-		/^([0-5]?\d|[*](?:\/[1-9]\d?)?|(?:[0-5]?\d)(?:-[0-5]?\d)?(?:\/[1-9]\d?)?|(?:[0-5]?\d)(?:,(?:[0-5]?\d|-[0-5]?\d|\*))+|\?)$/,
+		/^([0-5]?\d|[*](?:\/[1-9]\d?)?|(?:[0-5]?\d)(?:-[0-5]?\d)?(?:\/[1-9]\d?)?|(?:[0-5]?\d|[*])(?:,(?:[0-5]?\d|[*]|[0-5]?\d-[0-5]?\d))+|\?)$/,
 		// hour
-		/^([01]?\d|2[0-3]|[*](?:\/[1-9]\d?)?|(?:[01]?\d|2[0-3])(?:-[01]?\d|2[0-3])?(?:\/[1-9]\d?)?|(?:[01]?\d|2[0-3])(?:,(?:[01]?\d|2[0-3]|-[01]?\d|2[0-3]|\*))+|\?)$/,
+		/^([01]?\d|2[0-3]|[*](?:\/[1-9]\d?)?|(?:[01]?\d|2[0-3])(?:-[01]?\d|2[0-3])?(?:\/[1-9]\d?)?|(?:[01]?\d|2[0-3]|[*])(?:,(?:[01]?\d|2[0-3]|[*]|[01]?\d-2[0-3]|[01]?\d-[01]?\d|2[0-3]-2[0-3]))+|\?)$/,
 		// day of month
-		/^([1-9]|[12]\d|3[01]|[*](?:\/[1-9]\d?)?|(?:[1-9]|[12]\d|3[01])(?:-[1-9]|[12]\d|3[01])?(?:\/[1-9]\d?)?|(?:[1-9]|[12]\d|3[01])(?:,(?:[1-9]|[12]\d|3[01]|-[1-9]|[12]\d|3[01]|\*))+|L|L-[1-9]|L-[12]\d|L-3[01]|LW|\?|(?:[1-9]|[12]\d|3[01])W)$/,
+		/^([1-9]|[12]\d|3[01]|[*](?:\/[1-9]\d?)?|(?:[1-9]|[12]\d|3[01])(?:-[1-9]|[12]\d|3[01])?(?:\/[1-9]\d?)?|(?:[1-9]|[12]\d|3[01]|[*])(?:,(?:[1-9]|[12]\d|3[01]|[*]|[1-9]-[1-9]|[1-9]-[12]\d|[1-9]-3[01]|[12]\d-[12]\d|[12]\d-3[01]|3[01]-3[01]))+|L|L-[1-9]|L-[12]\d|L-3[01]|LW|\?|(?:[1-9]|[12]\d|3[01])W)$/,
 		// month
-		/^([1-9]|1[0-2]|[*](?:\/[1-9]\d?)?|(?:[1-9]|1[0-2])(?:-[1-9]|1[0-2])?(?:\/[1-9]\d?)?|(?:[1-9]|1[0-2])(?:,(?:[1-9]|1[0-2]|-[1-9]|1[0-2]|\*))+|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC|\?)$/i,
+		/^([1-9]|1[0-2]|[*](?:\/[1-9]\d?)?|(?:[1-9]|1[0-2])(?:-[1-9]|1[0-2])?(?:\/[1-9]\d?)?|(?:[1-9]|1[0-2]|[*])(?:,(?:[1-9]|1[0-2]|[*]|[1-9]-[1-9]|[1-9]-1[0-2]|1[0-2]-1[0-2]))+|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC|\?)$/i,
 		// weekday
-		/^([0-7]|[*](?:\/[1-9]\d?)?|(?:[0-7])(?:-[0-7])?(?:\/[1-9]\d?)?|(?:[0-7])(?:,(?:[0-7]|-[0-7]|\*))+|MON|TUE|WED|THU|FRI|SAT|SUN|L|\?|(?:MON|TUE|WED|THU|FRI|SAT|SUN)#(?:[1-5]))$/i,
+		/^([0-7]|[*](?:\/[1-9]\d?)?|(?:[0-7])(?:-[0-7])?(?:\/[1-9]\d?)?|(?:[0-7]|[*])(?:,(?:[0-7]|[*]|[0-7]-[0-7]))+|\+|\+[0-7]|\+[MON|TUE|WED|THU|FRI|SAT|SUN]|MON|TUE|WED|THU|FRI|SAT|SUN|L|\?|(?:MON|TUE|WED|THU|FRI|SAT|SUN)#(?:[1-5]|L))$/i,
 	];
 
 	for (let i = 0; i < parts.length; i++) {
@@ -109,6 +111,10 @@ function formatPreviewDate(ts: number, timezone: string): string {
 	});
 }
 
+function getBrowserTimezone(): string {
+	return Intl.DateTimeFormat().resolvedOptions().timeZone;
+}
+
 function getSchedulePreview(
 	triggerType: TaskScheduleTriggerType,
 	cronExpression: string,
@@ -116,7 +122,8 @@ function getSchedulePreview(
 	timezone: string
 ): string | null {
 	if (triggerType === 'at' && runAt) {
-		return `One-time run at ${formatPreviewDate(runAt, timezone)} (${timezone})`;
+		const localTz = getBrowserTimezone();
+		return `One-time run at ${formatPreviewDate(runAt, localTz)} (${localTz})`;
 	}
 	if (triggerType === 'cron' && cronExpression) {
 		const preset = CRON_PRESETS.find((p) => p.value === cronExpression);
@@ -200,7 +207,7 @@ export function SpaceCreateTaskDialog({ isOpen, onClose, onCreated }: SpaceCreat
 					triggerType,
 					cronExpression: triggerType === 'cron' ? cronExpression.trim() : null,
 					runAt: triggerType === 'at' ? runAt : null,
-					timezone,
+					timezone: triggerType === 'cron' ? timezone : null,
 				});
 				toast.success(`Scheduled task "${schedule.title}" created`);
 			} else {
@@ -315,7 +322,12 @@ export function SpaceCreateTaskDialog({ isOpen, onClose, onCreated }: SpaceCreat
 											name="triggerType"
 											value={opt.value}
 											checked={triggerType === opt.value}
-											onChange={() => setTriggerType(opt.value)}
+											onChange={() => {
+												setTriggerType(opt.value);
+												if (opt.value === 'at') {
+													setTimezone('UTC');
+												}
+											}}
 											class="sr-only"
 										/>
 										<span>{opt.label}</span>

--- a/packages/web/src/components/space/__tests__/SpaceCreateTaskDialog.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceCreateTaskDialog.test.tsx
@@ -311,10 +311,10 @@ describe('SpaceCreateTaskDialog', () => {
 		fireEvent.click(getByText('One-time'));
 
 		const dtInput = container.querySelector('input[type="datetime-local"]');
-		// Use a date 2 days ago in UTC (default timezone) so it's definitely past
+		// Use a date 2 days ago in local time so it's definitely past
 		const past = new Date(Date.now() - 172800000);
 		const pad = (n) => String(n).padStart(2, '0');
-		const pastValue = `${past.getUTCFullYear()}-${pad(past.getUTCMonth() + 1)}-${pad(past.getUTCDate())}T${pad(past.getUTCHours())}:${pad(past.getUTCMinutes())}`;
+		const pastValue = `${past.getFullYear()}-${pad(past.getMonth() + 1)}-${pad(past.getDate())}T${pad(past.getHours())}:${pad(past.getMinutes())}`;
 		fireEvent.input(dtInput, { target: { value: pastValue } });
 
 		fireEvent.submit(getByRole('dialog').querySelector('form'));
@@ -394,10 +394,10 @@ describe('SpaceCreateTaskDialog', () => {
 		fireEvent.click(getByText('One-time'));
 
 		const dtInput = container.querySelector('input[type="datetime-local"]');
-		// Use a UTC datetime 24h in the future so it's valid regardless of browser TZ offset
+		// Use a local datetime 24h in the future so it's valid
 		const future = new Date(Date.now() + 86400000);
 		const pad = (n) => String(n).padStart(2, '0');
-		const futureValue = `${future.getUTCFullYear()}-${pad(future.getUTCMonth() + 1)}-${pad(future.getUTCDate())}T${pad(future.getUTCHours())}:${pad(future.getUTCMinutes())}`;
+		const futureValue = `${future.getFullYear()}-${pad(future.getMonth() + 1)}-${pad(future.getDate())}T${pad(future.getHours())}:${pad(future.getMinutes())}`;
 		fireEvent.input(dtInput, { target: { value: futureValue } });
 
 		fireEvent.submit(getByRole('dialog').querySelector('form'));

--- a/packages/web/src/components/space/__tests__/SpaceCreateTaskDialog.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceCreateTaskDialog.test.tsx
@@ -10,12 +10,18 @@
  * - Shows error message on failure
  * - Cancel closes and resets form
  * - Priority and type selectors update form state
+ * - Schedule toggle shows/hides schedule options
+ * - One-time schedule validation (runAt required, must be future)
+ * - Recurring schedule validation (cron required, must be valid)
+ * - Cron preset buttons populate the expression
+ * - Submit calls spaceStore.createSchedule when scheduling enabled
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, waitFor, cleanup } from '@testing-library/preact';
 
 const mockCreateTask = vi.fn();
+const mockCreateSchedule = vi.fn();
 const mockToastSuccess = vi.fn();
 const mockToastError = vi.fn();
 
@@ -23,6 +29,9 @@ vi.mock('../../../lib/space-store', () => ({
 	spaceStore: {
 		get createTask() {
 			return mockCreateTask;
+		},
+		get createSchedule() {
+			return mockCreateSchedule;
 		},
 	},
 }));
@@ -75,15 +84,31 @@ const TASK_MOCK = {
 	updatedAt: Date.now(),
 };
 
+const SCHEDULE_MOCK = {
+	id: 'sched-1',
+	spaceId: 'space-1',
+	title: 'Scheduled task',
+	description: '',
+	priority: 'normal',
+	triggerType: 'cron',
+	cronExpression: '@daily',
+	runAt: null,
+	timezone: 'UTC',
+	status: 'active',
+	createdAt: Date.now(),
+	updatedAt: Date.now(),
+};
+
 describe('SpaceCreateTaskDialog', () => {
-	let onClose: ReturnType<typeof vi.fn>;
-	let onCreated: ReturnType<typeof vi.fn>;
+	let onClose;
+	let onCreated;
 
 	beforeEach(() => {
 		cleanup();
 		onClose = vi.fn();
 		onCreated = vi.fn();
 		mockCreateTask.mockReset();
+		mockCreateSchedule.mockReset();
 		mockToastSuccess.mockReset();
 		mockToastError.mockReset();
 	});
@@ -219,5 +244,220 @@ describe('SpaceCreateTaskDialog', () => {
 				})
 			);
 		});
+	});
+
+	// ─── Schedule tests ───────────────────────────────────────────────────────
+
+	it('shows schedule options when toggle is checked', () => {
+		const { getByLabelText, getByText } = render(
+			<SpaceCreateTaskDialog isOpen={true} onClose={onClose} />
+		);
+		const toggle = getByLabelText('Schedule this task');
+		fireEvent.click(toggle);
+		expect(getByText('One-time')).toBeTruthy();
+		expect(getByText('Recurring')).toBeTruthy();
+	});
+
+	it('hides schedule options when toggle is unchecked', () => {
+		const { getByLabelText, queryByText } = render(
+			<SpaceCreateTaskDialog isOpen={true} onClose={onClose} />
+		);
+		const toggle = getByLabelText('Schedule this task');
+		fireEvent.click(toggle);
+		expect(queryByText('One-time')).toBeTruthy();
+		fireEvent.click(toggle);
+		expect(queryByText('One-time')).toBeNull();
+	});
+
+	it('shows runAt input for one-time trigger', () => {
+		const { getByLabelText, getByText, container } = render(
+			<SpaceCreateTaskDialog isOpen={true} onClose={onClose} />
+		);
+		fireEvent.click(getByLabelText('Schedule this task'));
+		fireEvent.click(getByText('One-time'));
+		expect(container.querySelector('input[type="datetime-local"]')).toBeTruthy();
+	});
+
+	it('shows cron input for recurring trigger', () => {
+		const { getByLabelText, getByText, getByPlaceholderText } = render(
+			<SpaceCreateTaskDialog isOpen={true} onClose={onClose} />
+		);
+		fireEvent.click(getByLabelText('Schedule this task'));
+		fireEvent.click(getByText('Recurring'));
+		expect(getByPlaceholderText('0 9 * * 1')).toBeTruthy();
+	});
+
+	it('shows validation error when one-time runAt is missing', async () => {
+		const { getByLabelText, getByText, getByPlaceholderText, getByRole, findByText } = render(
+			<SpaceCreateTaskDialog isOpen={true} onClose={onClose} />
+		);
+		fireEvent.input(getByPlaceholderText('e.g., Implement authentication module'), {
+			target: { value: 'My scheduled task' },
+		});
+		fireEvent.click(getByLabelText('Schedule this task'));
+		fireEvent.click(getByText('One-time'));
+		fireEvent.submit(getByRole('dialog').querySelector('form'));
+		expect(await findByText('Run date/time is required')).toBeTruthy();
+		expect(mockCreateSchedule).not.toHaveBeenCalled();
+	});
+
+	it('shows validation error when one-time runAt is in the past', async () => {
+		const { getByLabelText, getByText, getByPlaceholderText, getByRole, findByText, container } =
+			render(<SpaceCreateTaskDialog isOpen={true} onClose={onClose} />);
+		fireEvent.input(getByPlaceholderText('e.g., Implement authentication module'), {
+			target: { value: 'My scheduled task' },
+		});
+		fireEvent.click(getByLabelText('Schedule this task'));
+		fireEvent.click(getByText('One-time'));
+
+		const dtInput = container.querySelector('input[type="datetime-local"]');
+		// Set to a past date
+		const past = new Date(Date.now() - 86400000);
+		const pad = (n) => String(n).padStart(2, '0');
+		const pastValue = `${past.getFullYear()}-${pad(past.getMonth() + 1)}-${pad(past.getDate())}T${pad(past.getHours())}:${pad(past.getMinutes())}`;
+		fireEvent.input(dtInput, { target: { value: pastValue } });
+
+		fireEvent.submit(getByRole('dialog').querySelector('form'));
+		expect(await findByText('Run time must be in the future')).toBeTruthy();
+	});
+
+	it('shows validation error when cron expression is empty', async () => {
+		const { getByLabelText, getByText, getByPlaceholderText, getByRole, findByText } = render(
+			<SpaceCreateTaskDialog isOpen={true} onClose={onClose} />
+		);
+		fireEvent.input(getByPlaceholderText('e.g., Implement authentication module'), {
+			target: { value: 'My scheduled task' },
+		});
+		fireEvent.click(getByLabelText('Schedule this task'));
+		fireEvent.click(getByText('Recurring'));
+		fireEvent.submit(getByRole('dialog').querySelector('form'));
+		expect(await findByText('Cron expression is required')).toBeTruthy();
+	});
+
+	it('shows validation error when cron expression is invalid', async () => {
+		const { getByLabelText, getByText, getByPlaceholderText, getByRole, findAllByText } = render(
+			<SpaceCreateTaskDialog isOpen={true} onClose={onClose} />
+		);
+		fireEvent.input(getByPlaceholderText('e.g., Implement authentication module'), {
+			target: { value: 'My scheduled task' },
+		});
+		fireEvent.click(getByLabelText('Schedule this task'));
+		fireEvent.click(getByText('Recurring'));
+		fireEvent.input(getByPlaceholderText('0 9 * * 1'), {
+			target: { value: 'not-a-cron' },
+		});
+		fireEvent.submit(getByRole('dialog').querySelector('form'));
+		const errors = await findAllByText('Invalid cron expression');
+		expect(errors.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it('accepts @daily preset as valid cron', async () => {
+		mockCreateSchedule.mockResolvedValue(SCHEDULE_MOCK);
+
+		const { getByLabelText, getByText, getByPlaceholderText, getByRole } = render(
+			<SpaceCreateTaskDialog isOpen={true} onClose={onClose} />
+		);
+		fireEvent.input(getByPlaceholderText('e.g., Implement authentication module'), {
+			target: { value: 'My scheduled task' },
+		});
+		fireEvent.click(getByLabelText('Schedule this task'));
+		fireEvent.click(getByText('Recurring'));
+		fireEvent.click(getByText('@daily'));
+
+		fireEvent.submit(getByRole('dialog').querySelector('form'));
+
+		await waitFor(() => {
+			expect(mockCreateSchedule).toHaveBeenCalledWith(
+				expect.objectContaining({
+					title: 'My scheduled task',
+					triggerType: 'cron',
+					cronExpression: '@daily',
+				})
+			);
+		});
+	});
+
+	it('calls spaceStore.createSchedule for one-time schedule', async () => {
+		mockCreateSchedule.mockResolvedValue({
+			...SCHEDULE_MOCK,
+			triggerType: 'at',
+			runAt: Date.now() + 3600000,
+		});
+
+		const { getByLabelText, getByText, getByPlaceholderText, getByRole, container } = render(
+			<SpaceCreateTaskDialog isOpen={true} onClose={onClose} />
+		);
+		fireEvent.input(getByPlaceholderText('e.g., Implement authentication module'), {
+			target: { value: 'My scheduled task' },
+		});
+		fireEvent.click(getByLabelText('Schedule this task'));
+		fireEvent.click(getByText('One-time'));
+
+		const dtInput = container.querySelector('input[type="datetime-local"]');
+		const future = new Date(Date.now() + 3600000);
+		const pad = (n) => String(n).padStart(2, '0');
+		const futureValue = `${future.getFullYear()}-${pad(future.getMonth() + 1)}-${pad(future.getDate())}T${pad(future.getHours())}:${pad(future.getMinutes())}`;
+		fireEvent.input(dtInput, { target: { value: futureValue } });
+
+		fireEvent.submit(getByRole('dialog').querySelector('form'));
+
+		await waitFor(() => {
+			expect(mockCreateSchedule).toHaveBeenCalledWith(
+				expect.objectContaining({
+					title: 'My scheduled task',
+					triggerType: 'at',
+					cronExpression: null,
+				})
+			);
+		});
+	});
+
+	it('shows success toast after creating schedule', async () => {
+		mockCreateSchedule.mockResolvedValue(SCHEDULE_MOCK);
+
+		const { getByLabelText, getByText, getByPlaceholderText, getByRole } = render(
+			<SpaceCreateTaskDialog isOpen={true} onClose={onClose} />
+		);
+		fireEvent.input(getByPlaceholderText('e.g., Implement authentication module'), {
+			target: { value: 'My scheduled task' },
+		});
+		fireEvent.click(getByLabelText('Schedule this task'));
+		fireEvent.click(getByText('Recurring'));
+		fireEvent.click(getByText('@daily'));
+
+		fireEvent.submit(getByRole('dialog').querySelector('form'));
+
+		await waitFor(() => {
+			expect(mockToastSuccess).toHaveBeenCalledWith(expect.stringContaining('Scheduled task'));
+			expect(onClose).toHaveBeenCalled();
+		});
+	});
+
+	it('shows error when createSchedule fails', async () => {
+		mockCreateSchedule.mockRejectedValue(new Error('Schedule conflict'));
+
+		const { getByLabelText, getByText, getByPlaceholderText, getByRole, findByText } = render(
+			<SpaceCreateTaskDialog isOpen={true} onClose={onClose} />
+		);
+		fireEvent.input(getByPlaceholderText('e.g., Implement authentication module'), {
+			target: { value: 'My scheduled task' },
+		});
+		fireEvent.click(getByLabelText('Schedule this task'));
+		fireEvent.click(getByText('Recurring'));
+		fireEvent.click(getByText('@daily'));
+
+		fireEvent.submit(getByRole('dialog').querySelector('form'));
+
+		expect(await findByText('Schedule conflict')).toBeTruthy();
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it('button label changes to Create Schedule when scheduling enabled', () => {
+		const { getByLabelText, getByText } = render(
+			<SpaceCreateTaskDialog isOpen={true} onClose={onClose} />
+		);
+		expect(getByText('Create Task')).toBeTruthy();
+		fireEvent.click(getByLabelText('Schedule this task'));
+		expect(getByText('Create Schedule')).toBeTruthy();
 	});
 });

--- a/packages/web/src/components/space/__tests__/SpaceCreateTaskDialog.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceCreateTaskDialog.test.tsx
@@ -311,10 +311,10 @@ describe('SpaceCreateTaskDialog', () => {
 		fireEvent.click(getByText('One-time'));
 
 		const dtInput = container.querySelector('input[type="datetime-local"]');
-		// Set to a past date
-		const past = new Date(Date.now() - 86400000);
+		// Use a date 2 days ago in UTC (default timezone) so it's definitely past
+		const past = new Date(Date.now() - 172800000);
 		const pad = (n) => String(n).padStart(2, '0');
-		const pastValue = `${past.getFullYear()}-${pad(past.getMonth() + 1)}-${pad(past.getDate())}T${pad(past.getHours())}:${pad(past.getMinutes())}`;
+		const pastValue = `${past.getUTCFullYear()}-${pad(past.getUTCMonth() + 1)}-${pad(past.getUTCDate())}T${pad(past.getUTCHours())}:${pad(past.getUTCMinutes())}`;
 		fireEvent.input(dtInput, { target: { value: pastValue } });
 
 		fireEvent.submit(getByRole('dialog').querySelector('form'));
@@ -394,9 +394,10 @@ describe('SpaceCreateTaskDialog', () => {
 		fireEvent.click(getByText('One-time'));
 
 		const dtInput = container.querySelector('input[type="datetime-local"]');
-		const future = new Date(Date.now() + 3600000);
+		// Use a UTC datetime 24h in the future so it's valid regardless of browser TZ offset
+		const future = new Date(Date.now() + 86400000);
 		const pad = (n) => String(n).padStart(2, '0');
-		const futureValue = `${future.getFullYear()}-${pad(future.getMonth() + 1)}-${pad(future.getDate())}T${pad(future.getHours())}:${pad(future.getMinutes())}`;
+		const futureValue = `${future.getUTCFullYear()}-${pad(future.getUTCMonth() + 1)}-${pad(future.getUTCDate())}T${pad(future.getUTCHours())}:${pad(future.getUTCMinutes())}`;
 		fireEvent.input(dtInput, { target: { value: futureValue } });
 
 		fireEvent.submit(getByRole('dialog').querySelector('form'));
@@ -459,5 +460,29 @@ describe('SpaceCreateTaskDialog', () => {
 		expect(getByText('Create Task')).toBeTruthy();
 		fireEvent.click(getByLabelText('Schedule this task'));
 		expect(getByText('Create Schedule')).toBeTruthy();
+	});
+
+	it('resets schedule state when dialog is closed and reopened', () => {
+		const { getByLabelText, getByText, queryByText, rerender } = render(
+			<SpaceCreateTaskDialog isOpen={true} onClose={onClose} />
+		);
+		// Enable schedule, select recurring, pick a preset
+		fireEvent.click(getByLabelText('Schedule this task'));
+		fireEvent.click(getByText('Recurring'));
+		fireEvent.click(getByText('@daily'));
+		expect(getByText('Create Schedule')).toBeTruthy();
+		expect(queryByText('Cron expression')).toBeTruthy();
+
+		// Close the dialog
+		fireEvent.click(getByText('Cancel'));
+		expect(onClose).toHaveBeenCalled();
+
+		// Reopen the dialog
+		rerender(<SpaceCreateTaskDialog isOpen={true} onClose={onClose} />);
+
+		// Schedule state should be reset
+		expect(getByText('Create Task')).toBeTruthy();
+		expect(queryByText('Cron expression')).toBeNull();
+		expect(queryByText('Schedule this task')).toBeTruthy();
 	});
 });

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -2136,7 +2136,7 @@ class SpaceStore {
 		triggerType: TaskScheduleTriggerType;
 		cronExpression?: string | null;
 		runAt?: number | null;
-		timezone?: string;
+		timezone?: string | null;
 	}): Promise<TaskSchedule> {
 		const spaceId = this.spaceId.value;
 		if (!spaceId) throw new Error('No space selected');


### PR DESCRIPTION
Add an optional "Schedule this task" section to the existing task creation dialog, enabling users to create both one-time and recurring scheduled tasks directly from the UI instead of relying solely on the agent MCP tool.

**What's new:**
- Toggle switch to enable scheduling (off by default, preserving existing behavior)
- Trigger type selector: One-time vs Recurring
- One-time: `datetime-local` picker with future-time validation
- Recurring: cron expression input with quick-select preset buttons (`@hourly`, `@daily`, `@weekly`, `@monthly`) plus inline validation
- Timezone dropdown with common IANA zones, defaulting to UTC
- Live preview of the configured schedule
- Submit button adapts to "Create Schedule" when scheduling is enabled
- Calls `spaceStore.createSchedule()` for scheduled tasks; `spaceStore.createTask()` for regular tasks
- Lightweight frontend cron validator (5-field + named shortcuts) without adding new dependencies

**Tests:**
- Updated `SpaceCreateTaskDialog.test.tsx` with 13 new test cases covering toggle visibility, trigger switching, validation errors (missing/past runAt, empty/invalid cron), preset selection, successful schedule creation, error handling, and button label changes.