### PR TITLE
feat(daemon): detect and recover from dead loops in agent execution

### DIFF
--- a/packages/daemon/src/lib/agent/loop-detector-hook.ts
+++ b/packages/daemon/src/lib/agent/loop-detector-hook.ts
@@ -1,0 +1,199 @@
+/**
+ * Loop Detector Hook
+ *
+ * Detects and recovers from "dead loops" where the agent calls the same
+ * idempotent inspection tool (Read / Grep / Glob) repeatedly with identical
+ * arguments without making any forward progress.
+ *
+ * Real-world trigger (task #324, see task #328): the coder agent called
+ * `Read` on `client-event-bridge.ts` ~60 times in a single turn before the
+ * user intervened. The file content was unchanged across every read; the
+ * agent had entered a degenerate planning state.
+ *
+ * Strategy: a `PreToolUse` hook keeps a per-session ledger of consecutive
+ * identical tool invocations. Once the count crosses a per-tool threshold
+ * within a sliding window, the hook denies the call with a
+ * `permissionDecisionReason` that the SDK delivers back to the model as the
+ * tool result. The reason text instructs the model to stop re-running the
+ * tool and proceed to the next step (e.g. its TodoWrite list).
+ *
+ * Bash is intentionally NOT tracked — bash output can legitimately change
+ * across calls (e.g. polling `git status`, tailing logs) and false positives
+ * here would be far worse than the rare degenerate loop. Read / Grep / Glob
+ * are pure functions of the file system at a point in time, so two identical
+ * invocations seconds apart almost never produce different output.
+ */
+
+import type { HookCallback, PreToolUseHookInput } from '@anthropic-ai/claude-agent-sdk';
+import { resolve as resolvePath } from 'node:path';
+import { Logger } from '../logger';
+
+/**
+ * Per-tool detection thresholds and overall hook configuration.
+ *
+ * `thresholds[toolName]` is the consecutive count at which we trigger.
+ * A tool absent from `thresholds` is never tracked (passes through).
+ */
+export interface LoopDetectorConfig {
+	enabled: boolean;
+	/** Sliding window in milliseconds; entries older than this are forgotten. */
+	windowMs: number;
+	/** Per-tool consecutive-call threshold. Tools omitted here are not tracked. */
+	thresholds: Record<string, number>;
+}
+
+export const DEFAULT_LOOP_DETECTOR_CONFIG: LoopDetectorConfig = {
+	enabled: true,
+	windowMs: 60_000,
+	thresholds: {
+		// Read identity is strong: the SDK already surfaces "File unchanged
+		// since last read", so 3 consecutive identical reads is unambiguous.
+		Read: 3,
+		// Grep / Glob are slightly noisier (developers genuinely re-run them
+		// while exploring), so we set a more permissive threshold.
+		Grep: 5,
+		Glob: 5,
+	},
+};
+
+interface LedgerEntry {
+	count: number;
+	lastSeenMs: number;
+}
+
+/**
+ * Stable JSON stringification: sorts object keys so `{a:1,b:2}` and
+ * `{b:2,a:1}` collide in the ledger.
+ */
+function stableStringify(value: unknown): string {
+	if (value === null || typeof value !== 'object') {
+		return JSON.stringify(value);
+	}
+	if (Array.isArray(value)) {
+		return `[${value.map(stableStringify).join(',')}]`;
+	}
+	const obj = value as Record<string, unknown>;
+	const keys = Object.keys(obj).sort();
+	return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(',')}}`;
+}
+
+/**
+ * Normalise tool input into a stable key used to detect duplicates.
+ *
+ * - Read: resolve `file_path` against `cwd` so `./foo` and `foo` collide;
+ *   keep `offset`/`limit` as identity (different ranges should not collide).
+ * - Grep / Glob: pass through, sorted via stableStringify.
+ *
+ * The `description` field (Bash/etc) is irrelevant to identity but Bash is
+ * not tracked anyway so we don't bother stripping it generically.
+ */
+function buildArgKey(toolName: string, input: Record<string, unknown>, cwd?: string): string {
+	if (toolName === 'Read' && typeof input.file_path === 'string') {
+		const normalisedPath = cwd ? resolvePath(cwd, input.file_path) : input.file_path;
+		const normalised = { ...input, file_path: normalisedPath };
+		return stableStringify(normalised);
+	}
+	return stableStringify(input);
+}
+
+/**
+ * A short human-readable summary of the duplicate args, for the recovery
+ * message. Truncated to keep the model-facing message tight.
+ */
+function summariseArgs(toolName: string, input: Record<string, unknown>): string {
+	const candidates: string[] = [];
+	if (typeof input.file_path === 'string') candidates.push(`file_path=${input.file_path}`);
+	if (typeof input.pattern === 'string') candidates.push(`pattern=${input.pattern}`);
+	if (typeof input.path === 'string' && toolName !== 'Read') {
+		candidates.push(`path=${input.path}`);
+	}
+	if (typeof input.glob === 'string') candidates.push(`glob=${input.glob}`);
+	if (candidates.length === 0) return JSON.stringify(input).slice(0, 120);
+	return candidates.join(', ').slice(0, 200);
+}
+
+function buildRecoveryMessage(toolName: string, count: number, argSummary: string): string {
+	return [
+		`Loop detected: ${toolName} was called ${count} times in a row with identical arguments (${argSummary}).`,
+		'The result has not changed since the previous call. STOP re-running this tool — move on to the next step in your task.',
+		'If you have a TodoWrite list, mark progress and proceed to the next item.',
+		'If you genuinely need fresh data, perform a *different* action (edit a file, run a command, ask a question) before retrying.',
+	].join(' ');
+}
+
+/**
+ * Create a PreToolUse hook that detects dead loops and short-circuits them.
+ *
+ * @example
+ * ```ts
+ * const hook = createLoopDetectorHook();
+ * options.hooks = { PreToolUse: [{ hooks: [hook] }] };
+ * ```
+ */
+export function createLoopDetectorHook(config: Partial<LoopDetectorConfig> = {}): HookCallback {
+	const finalConfig: LoopDetectorConfig = {
+		...DEFAULT_LOOP_DETECTOR_CONFIG,
+		...config,
+		thresholds: {
+			...DEFAULT_LOOP_DETECTOR_CONFIG.thresholds,
+			...config.thresholds,
+		},
+	};
+	const logger = new Logger('LoopDetectorHook');
+	// One ledger per hook instance — each session gets its own hook (the
+	// builder constructs hooks per-query), so we don't need to key by session.
+	const ledger = new Map<string, LedgerEntry>();
+
+	return async (input, _toolUseID, { signal: _signal }) => {
+		if (!finalConfig.enabled) return {};
+		if (input.hook_event_name !== 'PreToolUse') return {};
+
+		const preInput = input as PreToolUseHookInput;
+		const { tool_name, tool_input, cwd } = preInput;
+
+		const threshold = finalConfig.thresholds[tool_name];
+		if (typeof threshold !== 'number') {
+			// Tool not tracked — pass through.
+			return {};
+		}
+
+		const args = (tool_input ?? {}) as Record<string, unknown>;
+		const key = `${tool_name}:${buildArgKey(tool_name, args, cwd)}`;
+		const now = Date.now();
+
+		const existing = ledger.get(key);
+		const withinWindow = existing && now - existing.lastSeenMs <= finalConfig.windowMs;
+
+		const nextCount = withinWindow ? existing.count + 1 : 1;
+		ledger.set(key, { count: nextCount, lastSeenMs: now });
+
+		// Opportunistically drop stale entries so the ledger doesn't grow
+		// unbounded across long-lived sessions.
+		if (ledger.size > 256) {
+			for (const [k, v] of ledger) {
+				if (now - v.lastSeenMs > finalConfig.windowMs) ledger.delete(k);
+			}
+		}
+
+		if (nextCount >= threshold) {
+			const argSummary = summariseArgs(tool_name, args);
+			const reason = buildRecoveryMessage(tool_name, nextCount, argSummary);
+			logger.warn(
+				`Dead-loop detected: ${tool_name} called ${nextCount}x in a row with identical args (${argSummary}); denying.`
+			);
+			// Reset the counter so the agent isn't permanently denied — if it
+			// later legitimately retries (e.g. after editing the file), the
+			// ledger starts fresh.
+			ledger.delete(key);
+			return {
+				hookSpecificOutput: {
+					hookEventName: 'PreToolUse' as const,
+					permissionDecision: 'deny' as const,
+					permissionDecisionReason: reason,
+				},
+			};
+		}
+
+		return {};
+	};
+}

--- a/packages/daemon/src/lib/agent/loop-detector-hook.ts
+++ b/packages/daemon/src/lib/agent/loop-detector-hook.ts
@@ -10,11 +10,12 @@
  * user intervened. The file content was unchanged across every read; the
  * agent had entered a degenerate planning state.
  *
- * Strategy: a `PreToolUse` hook keeps a per-session ledger of accumulated
- * identical tool invocations within a sliding window. The counter is NOT
- * strictly consecutive — unrelated tool calls in between do not reset it,
- * only window expiry (or a deny) does. Once the count crosses a per-tool
- * threshold, the hook denies the call with a `permissionDecisionReason`
+ * Strategy: a `PreToolUse` hook keeps a per-agent ledger of the *current
+ * consecutive streak* — i.e. successive invocations of the same
+ * `(tool_name, args)` key with no intervening call to a different
+ * tracked-tool key. As soon as the agent invokes any other tracked call,
+ * the streak resets. Once the streak crosses a per-tool threshold within a
+ * sliding window, the hook denies the call with a `permissionDecisionReason`
  * that the SDK delivers back to the model as the tool result. The reason
  * text instructs the model to stop re-running the tool and proceed to the
  * next step (e.g. its TodoWrite list).
@@ -24,6 +25,17 @@
  * here would be far worse than the rare degenerate loop. Read / Grep / Glob
  * are pure functions of the file system at a point in time, so two identical
  * invocations seconds apart almost never produce different output.
+ *
+ * Scoping: streaks are tracked per `(session_id, agent_id)` pair, so parallel
+ * subagents under the same parent session cannot contribute to each other's
+ * counters and a subagent's reads do not pollute the main thread's streak.
+ *
+ * Repeat denies: when a stuck agent keeps hammering the same call after a
+ * deny, the streak does NOT reset on a deny — every retry without an
+ * intervening different action continues to deny. This is intentional: the
+ * goal is to break the loop, not just throttle it. The streak only resets
+ * when the agent performs a *different* tracked tool call (or the sliding
+ * window expires).
  */
 
 import type { HookCallback, PreToolUseHookInput } from '@anthropic-ai/claude-agent-sdk';
@@ -33,28 +45,30 @@ import { Logger } from '../logger';
 /**
  * Per-tool detection thresholds and overall hook configuration.
  *
- * `thresholds[toolName]` is the count of accumulated identical invocations
- * (within the sliding window) at which we trigger. A tool absent from
- * `thresholds` is never tracked (passes through).
+ * `thresholds[toolName]` is the consecutive-streak length at which we
+ * trigger. A tool absent from `thresholds` is NEVER tracked (passes
+ * through). Callers that pass a partial config — e.g. `{ thresholds: {
+ * Read: 2 } }` — REPLACE the tracked-tool set; defaults are not merged in.
+ * Pass `undefined` (or omit `thresholds`) to inherit
+ * `DEFAULT_LOOP_DETECTOR_CONFIG.thresholds` wholesale.
  */
 export interface LoopDetectorConfig {
 	enabled: boolean;
 	/** Sliding window in milliseconds; entries older than this are forgotten. */
 	windowMs: number;
 	/**
-	 * Per-tool accumulated-call threshold within the sliding window. Tools
-	 * omitted here are not tracked.
+	 * Per-tool consecutive-streak threshold. Tools omitted here are not
+	 * tracked. Pass `undefined` to inherit the defaults wholesale.
 	 */
-	thresholds: Record<string, number>;
+	thresholds?: Record<string, number>;
 }
 
-export const DEFAULT_LOOP_DETECTOR_CONFIG: LoopDetectorConfig = {
+export const DEFAULT_LOOP_DETECTOR_CONFIG: Required<LoopDetectorConfig> = {
 	enabled: true,
 	windowMs: 60_000,
 	thresholds: {
 		// Read identity is strong: the SDK already surfaces "File unchanged
-		// since last read", so 3 accumulated identical reads in 60s is
-		// unambiguous.
+		// since last read", so 3 consecutive identical reads is unambiguous.
 		Read: 3,
 		// Grep / Glob are slightly noisier (developers genuinely re-run them
 		// while exploring), so we set a more permissive threshold.
@@ -64,8 +78,20 @@ export const DEFAULT_LOOP_DETECTOR_CONFIG: LoopDetectorConfig = {
 };
 
 interface LedgerEntry {
+	/** Current consecutive-streak count for this key. */
 	count: number;
+	/** Last time this key was invoked (ms). Used for window expiry. */
 	lastSeenMs: number;
+}
+
+/**
+ * Per-(session, agent) state: the last tracked key invoked, plus the streak
+ * counter for that key. We only need to remember one entry per (session,
+ * agent) because a different-key call resets the streak.
+ */
+interface AgentState {
+	lastKey: string;
+	entry: LedgerEntry;
 }
 
 /**
@@ -121,7 +147,7 @@ function summariseArgs(toolName: string, input: Record<string, unknown>): string
 
 function buildRecoveryMessage(toolName: string, count: number, argSummary: string): string {
 	return [
-		`Loop detected: ${toolName} was called ${count} times with identical arguments (${argSummary}) in a short window.`,
+		`Loop detected: ${toolName} was called ${count} times in a row with identical arguments (${argSummary}).`,
 		'The result has not changed since the previous call. STOP re-running this tool — move on to the next step in your task.',
 		'If you have a TodoWrite list, mark progress and proceed to the next item.',
 		'If you genuinely need fresh data, perform a *different* action (edit a file, run a command, ask a question) before retrying.',
@@ -133,10 +159,12 @@ function buildRecoveryMessage(toolName: string, count: number, argSummary: strin
  *
  * The `config` parameter is reserved for testing and override use. Production
  * callers (see `QueryOptionsBuilder.buildHooks`) instantiate the hook with no
- * arguments so the defaults in `DEFAULT_LOOP_DETECTOR_CONFIG` apply. Partial
- * configs are merged with the defaults: any threshold left unspecified keeps
- * its default (e.g. passing `{ thresholds: { Read: 2 } }` overrides Read but
- * preserves Grep=5 and Glob=5).
+ * arguments so the defaults in `DEFAULT_LOOP_DETECTOR_CONFIG` apply.
+ *
+ * Threshold overrides REPLACE the tracked-tool set: e.g. passing
+ * `{ thresholds: { Read: 2 } }` tracks only Read at 2, and Grep/Glob are no
+ * longer tracked. Omit `thresholds` (or pass `undefined`) to inherit the
+ * defaults wholesale.
  *
  * @example
  * ```ts
@@ -145,47 +173,59 @@ function buildRecoveryMessage(toolName: string, count: number, argSummary: strin
  * ```
  */
 export function createLoopDetectorHook(config: Partial<LoopDetectorConfig> = {}): HookCallback {
-	const finalConfig: LoopDetectorConfig = {
-		...DEFAULT_LOOP_DETECTOR_CONFIG,
-		...config,
-		thresholds: {
-			...DEFAULT_LOOP_DETECTOR_CONFIG.thresholds,
-			...config.thresholds,
-		},
+	const finalConfig: Required<LoopDetectorConfig> = {
+		enabled: config.enabled ?? DEFAULT_LOOP_DETECTOR_CONFIG.enabled,
+		windowMs: config.windowMs ?? DEFAULT_LOOP_DETECTOR_CONFIG.windowMs,
+		// REPLACE — do not merge. A caller passing { Read: 2 } means "track
+		// only Read." This is what the contract on LoopDetectorConfig
+		// promises. Pass undefined / omit to keep the defaults wholesale.
+		thresholds: config.thresholds ?? DEFAULT_LOOP_DETECTOR_CONFIG.thresholds,
 	};
 	const logger = new Logger('LoopDetectorHook');
-	// One ledger per hook instance — each session gets its own hook (the
-	// builder constructs hooks per-query), so we don't need to key by session.
-	const ledger = new Map<string, LedgerEntry>();
+	// One ledger per (session_id, agent_id). Each subagent gets its own
+	// streak; the main thread's streak is also isolated from any subagents
+	// it spawns.
+	const ledger = new Map<string, AgentState>();
 
 	return async (input, _toolUseID, { signal: _signal }) => {
 		if (!finalConfig.enabled) return {};
 		if (input.hook_event_name !== 'PreToolUse') return {};
 
 		const preInput = input as PreToolUseHookInput;
-		const { tool_name, tool_input, cwd } = preInput;
+		const { tool_name, tool_input, cwd, session_id, agent_id } = preInput;
 
 		const threshold = finalConfig.thresholds[tool_name];
 		if (typeof threshold !== 'number') {
-			// Tool not tracked — pass through.
+			// Tool not tracked — pass through without disturbing any
+			// existing streak (an untracked call should not reset a streak
+			// for a tracked tool).
 			return {};
 		}
 
 		const args = (tool_input ?? {}) as Record<string, unknown>;
 		const key = `${tool_name}:${buildArgKey(tool_name, args, cwd)}`;
+		const scope = `${session_id}::${agent_id ?? 'main'}`;
 		const now = Date.now();
 
-		const existing = ledger.get(key);
-		const withinWindow = existing && now - existing.lastSeenMs <= finalConfig.windowMs;
+		const state = ledger.get(scope);
+		const sameKey = state?.lastKey === key;
+		const withinWindow = state && now - state.entry.lastSeenMs <= finalConfig.windowMs;
 
-		const nextCount = withinWindow ? existing.count + 1 : 1;
-		ledger.set(key, { count: nextCount, lastSeenMs: now });
+		// Strict consecutive semantics: streak only continues when the same
+		// key is invoked AND we are still within the sliding window. A
+		// different tracked-tool key, or window expiry, resets the count.
+		const nextCount = sameKey && withinWindow ? state.entry.count + 1 : 1;
+		ledger.set(scope, {
+			lastKey: key,
+			entry: { count: nextCount, lastSeenMs: now },
+		});
 
-		// Opportunistically drop stale entries so the ledger doesn't grow
-		// unbounded across long-lived sessions.
+		// Opportunistically drop scopes whose last activity is past the
+		// window, so the ledger doesn't grow unbounded across long-lived
+		// daemons.
 		if (ledger.size > 256) {
 			for (const [k, v] of ledger) {
-				if (now - v.lastSeenMs > finalConfig.windowMs) ledger.delete(k);
+				if (now - v.entry.lastSeenMs > finalConfig.windowMs) ledger.delete(k);
 			}
 		}
 
@@ -193,12 +233,14 @@ export function createLoopDetectorHook(config: Partial<LoopDetectorConfig> = {})
 			const argSummary = summariseArgs(tool_name, args);
 			const reason = buildRecoveryMessage(tool_name, nextCount, argSummary);
 			logger.warn(
-				`Dead-loop detected: ${tool_name} called ${nextCount}x with identical args (${argSummary}) in a short window; denying.`
+				`Dead-loop detected (scope=${scope}): ${tool_name} called ${nextCount}x in a row with identical args (${argSummary}); denying.`
 			);
-			// Reset the counter so the agent isn't permanently denied — if it
-			// later legitimately retries (e.g. after editing the file), the
-			// ledger starts fresh.
-			ledger.delete(key);
+			// IMPORTANT: do NOT reset the streak on a deny. If the agent
+			// retries the same key without doing anything different, the
+			// streak continues to grow and every retry continues to deny.
+			// The streak only resets when the agent performs a *different*
+			// tracked call (or the window expires). This is what actually
+			// breaks the loop rather than just throttling it.
 			return {
 				hookSpecificOutput: {
 					hookEventName: 'PreToolUse' as const,

--- a/packages/daemon/src/lib/agent/loop-detector-hook.ts
+++ b/packages/daemon/src/lib/agent/loop-detector-hook.ts
@@ -10,12 +10,14 @@
  * user intervened. The file content was unchanged across every read; the
  * agent had entered a degenerate planning state.
  *
- * Strategy: a `PreToolUse` hook keeps a per-session ledger of consecutive
- * identical tool invocations. Once the count crosses a per-tool threshold
- * within a sliding window, the hook denies the call with a
- * `permissionDecisionReason` that the SDK delivers back to the model as the
- * tool result. The reason text instructs the model to stop re-running the
- * tool and proceed to the next step (e.g. its TodoWrite list).
+ * Strategy: a `PreToolUse` hook keeps a per-session ledger of accumulated
+ * identical tool invocations within a sliding window. The counter is NOT
+ * strictly consecutive — unrelated tool calls in between do not reset it,
+ * only window expiry (or a deny) does. Once the count crosses a per-tool
+ * threshold, the hook denies the call with a `permissionDecisionReason`
+ * that the SDK delivers back to the model as the tool result. The reason
+ * text instructs the model to stop re-running the tool and proceed to the
+ * next step (e.g. its TodoWrite list).
  *
  * Bash is intentionally NOT tracked — bash output can legitimately change
  * across calls (e.g. polling `git status`, tailing logs) and false positives
@@ -31,14 +33,18 @@ import { Logger } from '../logger';
 /**
  * Per-tool detection thresholds and overall hook configuration.
  *
- * `thresholds[toolName]` is the consecutive count at which we trigger.
- * A tool absent from `thresholds` is never tracked (passes through).
+ * `thresholds[toolName]` is the count of accumulated identical invocations
+ * (within the sliding window) at which we trigger. A tool absent from
+ * `thresholds` is never tracked (passes through).
  */
 export interface LoopDetectorConfig {
 	enabled: boolean;
 	/** Sliding window in milliseconds; entries older than this are forgotten. */
 	windowMs: number;
-	/** Per-tool consecutive-call threshold. Tools omitted here are not tracked. */
+	/**
+	 * Per-tool accumulated-call threshold within the sliding window. Tools
+	 * omitted here are not tracked.
+	 */
 	thresholds: Record<string, number>;
 }
 
@@ -47,7 +53,8 @@ export const DEFAULT_LOOP_DETECTOR_CONFIG: LoopDetectorConfig = {
 	windowMs: 60_000,
 	thresholds: {
 		// Read identity is strong: the SDK already surfaces "File unchanged
-		// since last read", so 3 consecutive identical reads is unambiguous.
+		// since last read", so 3 accumulated identical reads in 60s is
+		// unambiguous.
 		Read: 3,
 		// Grep / Glob are slightly noisier (developers genuinely re-run them
 		// while exploring), so we set a more permissive threshold.
@@ -114,7 +121,7 @@ function summariseArgs(toolName: string, input: Record<string, unknown>): string
 
 function buildRecoveryMessage(toolName: string, count: number, argSummary: string): string {
 	return [
-		`Loop detected: ${toolName} was called ${count} times in a row with identical arguments (${argSummary}).`,
+		`Loop detected: ${toolName} was called ${count} times with identical arguments (${argSummary}) in a short window.`,
 		'The result has not changed since the previous call. STOP re-running this tool — move on to the next step in your task.',
 		'If you have a TodoWrite list, mark progress and proceed to the next item.',
 		'If you genuinely need fresh data, perform a *different* action (edit a file, run a command, ask a question) before retrying.',
@@ -123,6 +130,13 @@ function buildRecoveryMessage(toolName: string, count: number, argSummary: strin
 
 /**
  * Create a PreToolUse hook that detects dead loops and short-circuits them.
+ *
+ * The `config` parameter is reserved for testing and override use. Production
+ * callers (see `QueryOptionsBuilder.buildHooks`) instantiate the hook with no
+ * arguments so the defaults in `DEFAULT_LOOP_DETECTOR_CONFIG` apply. Partial
+ * configs are merged with the defaults: any threshold left unspecified keeps
+ * its default (e.g. passing `{ thresholds: { Read: 2 } }` overrides Read but
+ * preserves Grep=5 and Glob=5).
  *
  * @example
  * ```ts
@@ -179,7 +193,7 @@ export function createLoopDetectorHook(config: Partial<LoopDetectorConfig> = {})
 			const argSummary = summariseArgs(tool_name, args);
 			const reason = buildRecoveryMessage(tool_name, nextCount, argSummary);
 			logger.warn(
-				`Dead-loop detected: ${tool_name} called ${nextCount}x in a row with identical args (${argSummary}); denying.`
+				`Dead-loop detected: ${tool_name} called ${nextCount}x with identical args (${argSummary}) in a short window; denying.`
 			);
 			// Reset the counter so the agent isn't permanently denied — if it
 			// later legitimately retries (e.g. after editing the file), the

--- a/packages/daemon/src/lib/agent/loop-detector-hook.ts
+++ b/packages/daemon/src/lib/agent/loop-detector-hook.ts
@@ -12,19 +12,24 @@
  *
  * Strategy: a `PreToolUse` hook keeps a per-agent ledger of the *current
  * consecutive streak* — i.e. successive invocations of the same
- * `(tool_name, args)` key with no intervening call to a different
- * tracked-tool key. As soon as the agent invokes any other tracked call,
- * the streak resets. Once the streak crosses a per-tool threshold within a
- * sliding window, the hook denies the call with a `permissionDecisionReason`
+ * `(tool_name, args)` key with no intervening different tool call. The hook
+ * is registered for ALL tools (not just tracked ones) so that any other
+ * action — running a Bash command, editing a file, even calling a
+ * non-tracked inspection tool — counts as a "different action" and resets
+ * the streak. Once the streak crosses a per-tool threshold within a sliding
+ * window (computed over the *full* streak duration, not just the gap to the
+ * previous call), the hook denies the call with a `permissionDecisionReason`
  * that the SDK delivers back to the model as the tool result. The reason
  * text instructs the model to stop re-running the tool and proceed to the
  * next step (e.g. its TodoWrite list).
  *
- * Bash is intentionally NOT tracked — bash output can legitimately change
- * across calls (e.g. polling `git status`, tailing logs) and false positives
- * here would be far worse than the rare degenerate loop. Read / Grep / Glob
- * are pure functions of the file system at a point in time, so two identical
- * invocations seconds apart almost never produce different output.
+ * Bash is intentionally NOT tracked for *deny* decisions — bash output can
+ * legitimately change across calls (e.g. polling `git status`, tailing logs)
+ * and false positives here would be far worse than the rare degenerate loop.
+ * The hook still observes Bash so it can use it as a streak-reset signal.
+ * Read / Grep / Glob are pure functions of the file system at a point in
+ * time, so two identical invocations seconds apart almost never produce
+ * different output.
  *
  * Scoping: streaks are tracked per `(session_id, agent_id)` pair, so parallel
  * subagents under the same parent session cannot contribute to each other's
@@ -33,9 +38,9 @@
  * Repeat denies: when a stuck agent keeps hammering the same call after a
  * deny, the streak does NOT reset on a deny — every retry without an
  * intervening different action continues to deny. This is intentional: the
- * goal is to break the loop, not just throttle it. The streak only resets
- * when the agent performs a *different* tracked tool call (or the sliding
- * window expires).
+ * goal is to break the loop, not just throttle it. The streak resets when
+ * the agent performs a *different* tool call (tracked OR untracked) or the
+ * sliding window elapses over the streak's lifetime.
  */
 
 import type { HookCallback, PreToolUseHookInput } from '@anthropic-ai/claude-agent-sdk';
@@ -80,7 +85,13 @@ export const DEFAULT_LOOP_DETECTOR_CONFIG: Required<LoopDetectorConfig> = {
 interface LedgerEntry {
 	/** Current consecutive-streak count for this key. */
 	count: number;
-	/** Last time this key was invoked (ms). Used for window expiry. */
+	/** When this streak started (ms). Used to enforce the sliding window
+	 * over the full streak duration: if `now - firstSeenMs > windowMs`,
+	 * the streak is treated as expired and the next identical call
+	 * starts a new streak from 1. */
+	firstSeenMs: number;
+	/** Most recent invocation time for this key (ms). Used for ledger
+	 * eviction, not for streak-window enforcement. */
 	lastSeenMs: number;
 }
 
@@ -194,30 +205,43 @@ export function createLoopDetectorHook(config: Partial<LoopDetectorConfig> = {})
 		const preInput = input as PreToolUseHookInput;
 		const { tool_name, tool_input, cwd, session_id, agent_id } = preInput;
 
+		const scope = `${session_id}::${agent_id ?? 'main'}`;
 		const threshold = finalConfig.thresholds[tool_name];
+		const now = Date.now();
+
+		// Untracked tool (Bash, Edit, Write, …) is treated as a *different
+		// action*: it resets any in-flight streak for this scope so that a
+		// genuine corrective step (e.g. `Edit foo.ts` after a denied
+		// `Read foo.ts`) lets the next identical Read pass through. We
+		// then short-circuit — there is nothing to deny on an untracked
+		// tool.
 		if (typeof threshold !== 'number') {
-			// Tool not tracked — pass through without disturbing any
-			// existing streak (an untracked call should not reset a streak
-			// for a tracked tool).
+			ledger.delete(scope);
 			return {};
 		}
 
 		const args = (tool_input ?? {}) as Record<string, unknown>;
 		const key = `${tool_name}:${buildArgKey(tool_name, args, cwd)}`;
-		const scope = `${session_id}::${agent_id ?? 'main'}`;
-		const now = Date.now();
 
 		const state = ledger.get(scope);
 		const sameKey = state?.lastKey === key;
-		const withinWindow = state && now - state.entry.lastSeenMs <= finalConfig.windowMs;
+		// Sliding window is enforced over the *full streak duration*, not
+		// just the gap between successive calls. A sequence at t=0,59s,118s
+		// with a 60s window has duration 118s > 60s on the third call, so
+		// the streak resets to 1 — matching "N repeats within window"
+		// semantics rather than "max inter-call gap".
+		const withinWindow = state && now - state.entry.firstSeenMs <= finalConfig.windowMs;
 
 		// Strict consecutive semantics: streak only continues when the same
-		// key is invoked AND we are still within the sliding window. A
-		// different tracked-tool key, or window expiry, resets the count.
-		const nextCount = sameKey && withinWindow ? state.entry.count + 1 : 1;
+		// key is invoked AND the *whole* streak still fits in the sliding
+		// window. A different tracked-tool key, untracked tool call, or
+		// window expiry resets the count.
+		const continueStreak = sameKey && withinWindow;
+		const nextCount = continueStreak ? state!.entry.count + 1 : 1;
+		const firstSeenMs = continueStreak ? state!.entry.firstSeenMs : now;
 		ledger.set(scope, {
 			lastKey: key,
-			entry: { count: nextCount, lastSeenMs: now },
+			entry: { count: nextCount, firstSeenMs, lastSeenMs: now },
 		});
 
 		// Opportunistically drop scopes whose last activity is past the
@@ -239,8 +263,9 @@ export function createLoopDetectorHook(config: Partial<LoopDetectorConfig> = {})
 			// retries the same key without doing anything different, the
 			// streak continues to grow and every retry continues to deny.
 			// The streak only resets when the agent performs a *different*
-			// tracked call (or the window expires). This is what actually
-			// breaks the loop rather than just throttling it.
+			// tool call (tracked OR untracked) or the window expires. This
+			// is what actually breaks the loop rather than just throttling
+			// it.
 			return {
 				hookSpecificOutput: {
 					hookEventName: 'PreToolUse' as const,

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -58,7 +58,7 @@ import {
 	defaultBuiltinSkillPluginRoot,
 } from './builtin-skill-plugin-wrapper';
 import { getCoordinatorAgents } from './coordinator-agents';
-import { createLoopDetectorHook, DEFAULT_LOOP_DETECTOR_CONFIG } from './loop-detector-hook';
+import { createLoopDetectorHook } from './loop-detector-hook';
 import { isRunningUnderBun, resolveSDKCliPath } from './sdk-cli-resolver.js';
 
 export const CODEX_BRIDGE_AUTO_COMPACT_WINDOW = 1_000_000;
@@ -1023,26 +1023,30 @@ CRITICAL RULES:
 	/**
 	 * Build hooks configuration
 	 *
-	 * Always installs the loop-detector hook (one shared matcher across the
-	 * tracked tools — see DEFAULT_LOOP_DETECTOR_CONFIG.thresholds). Tool guards
-	 * from the workflow definition are appended on top.
+	 * Always installs the loop-detector hook with NO matcher so it observes
+	 * every PreToolUse event. This is intentional: the hook needs to see
+	 * untracked tool calls (Bash, Edit, Write, …) so they can reset the
+	 * streak after a deny — otherwise an agent that takes a real corrective
+	 * step (e.g. `Edit foo.ts` then re-Read it) would stay permanently
+	 * blocked. The hook itself filters internally on
+	 * `DEFAULT_LOOP_DETECTOR_CONFIG.thresholds`. Tool guards from the
+	 * workflow definition are appended on top.
 	 */
 	private buildHooks(): Options['hooks'] {
 		const hooks: NonNullable<Options['hooks']> = {};
 		const preToolUse: NonNullable<Options['hooks']>['PreToolUse'] = [];
 
-		// Loop detector: matcher is a regex of the tracked tool names so the
-		// SDK only invokes the hook for those tools. The hook itself is also
-		// defensive (it no-ops for untracked tools). Production wires this
-		// with no arguments — the hook's `config` parameter exists only so
-		// unit tests can exercise alternative thresholds and disabled mode.
-		const trackedTools = Object.keys(DEFAULT_LOOP_DETECTOR_CONFIG.thresholds);
-		if (trackedTools.length > 0) {
-			preToolUse.push({
-				matcher: trackedTools.join('|'),
-				hooks: [createLoopDetectorHook()],
-			});
-		}
+		// Loop detector: NO matcher — the hook must observe every tool call
+		// so that untracked tools (Edit, Write, Bash, …) can serve as the
+		// "different action" that breaks a denied streak. The hook decides
+		// internally whether to track a tool (DEFAULT_LOOP_DETECTOR_CONFIG.
+		// thresholds) or merely use the call as a streak-reset signal.
+		// Production wires this with no arguments — the hook's `config`
+		// parameter exists only so unit tests can exercise alternative
+		// thresholds and disabled mode.
+		preToolUse.push({
+			hooks: [createLoopDetectorHook()],
+		});
 
 		// Workflow tool guards (declarative deny/allow rules) layered on top.
 		const guards = this.ctx.toolGuards;

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -1033,7 +1033,9 @@ CRITICAL RULES:
 
 		// Loop detector: matcher is a regex of the tracked tool names so the
 		// SDK only invokes the hook for those tools. The hook itself is also
-		// defensive (it no-ops for untracked tools).
+		// defensive (it no-ops for untracked tools). Production wires this
+		// with no arguments — the hook's `config` parameter exists only so
+		// unit tests can exercise alternative thresholds and disabled mode.
 		const trackedTools = Object.keys(DEFAULT_LOOP_DETECTOR_CONFIG.thresholds);
 		if (trackedTools.length > 0) {
 			preToolUse.push({

--- a/packages/daemon/src/lib/agent/query-options-builder.ts
+++ b/packages/daemon/src/lib/agent/query-options-builder.ts
@@ -58,6 +58,7 @@ import {
 	defaultBuiltinSkillPluginRoot,
 } from './builtin-skill-plugin-wrapper';
 import { getCoordinatorAgents } from './coordinator-agents';
+import { createLoopDetectorHook, DEFAULT_LOOP_DETECTOR_CONFIG } from './loop-detector-hook';
 import { isRunningUnderBun, resolveSDKCliPath } from './sdk-cli-resolver.js';
 
 export const CODEX_BRIDGE_AUTO_COMPACT_WINDOW = 1_000_000;
@@ -1021,29 +1022,46 @@ CRITICAL RULES:
 
 	/**
 	 * Build hooks configuration
+	 *
+	 * Always installs the loop-detector hook (one shared matcher across the
+	 * tracked tools — see DEFAULT_LOOP_DETECTOR_CONFIG.thresholds). Tool guards
+	 * from the workflow definition are appended on top.
 	 */
 	private buildHooks(): Options['hooks'] {
-		const guards = this.ctx.toolGuards;
-		if (!guards?.length) return {};
-
 		const hooks: NonNullable<Options['hooks']> = {};
-		// Group guards by matcher (tool name) to create one matcher entry per tool.
-		// Skip malformed entries (null, non-object) so a bad persisted workflow
-		// cannot crash query startup.
-		const byMatcher = new Map<string, DeclarativeToolGuard[]>();
-		for (const guard of guards) {
-			if (!guard || typeof guard !== 'object' || !guard.matcher) continue;
-			const existing = byMatcher.get(guard.matcher) ?? [];
-			existing.push(guard);
-			byMatcher.set(guard.matcher, existing);
+		const preToolUse: NonNullable<Options['hooks']>['PreToolUse'] = [];
+
+		// Loop detector: matcher is a regex of the tracked tool names so the
+		// SDK only invokes the hook for those tools. The hook itself is also
+		// defensive (it no-ops for untracked tools).
+		const trackedTools = Object.keys(DEFAULT_LOOP_DETECTOR_CONFIG.thresholds);
+		if (trackedTools.length > 0) {
+			preToolUse.push({
+				matcher: trackedTools.join('|'),
+				hooks: [createLoopDetectorHook()],
+			});
 		}
 
-		const preToolUse: NonNullable<Options['hooks']>['PreToolUse'] = [];
-		for (const [matcher, matcherGuards] of byMatcher) {
-			preToolUse.push({
-				matcher,
-				hooks: matcherGuards.map(compileToolGuard),
-			});
+		// Workflow tool guards (declarative deny/allow rules) layered on top.
+		const guards = this.ctx.toolGuards;
+		if (guards?.length) {
+			// Group guards by matcher (tool name) to create one matcher entry per tool.
+			// Skip malformed entries (null, non-object) so a bad persisted workflow
+			// cannot crash query startup.
+			const byMatcher = new Map<string, DeclarativeToolGuard[]>();
+			for (const guard of guards) {
+				if (!guard || typeof guard !== 'object' || !guard.matcher) continue;
+				const existing = byMatcher.get(guard.matcher) ?? [];
+				existing.push(guard);
+				byMatcher.set(guard.matcher, existing);
+			}
+
+			for (const [matcher, matcherGuards] of byMatcher) {
+				preToolUse.push({
+					matcher,
+					hooks: matcherGuards.map(compileToolGuard),
+				});
+			}
 		}
 
 		if (preToolUse.length > 0) {

--- a/packages/daemon/tests/unit/1-core/agent/loop-detector-hook.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/loop-detector-hook.test.ts
@@ -194,18 +194,26 @@ describe('LoopDetectorHook', () => {
 			}
 		});
 
-		it('does not track tools with no configured threshold', async () => {
-			const trimmed = createLoopDetectorHook({
+		it('merges partial threshold overrides with defaults (Grep stays tracked at the default)', async () => {
+			const merged = createLoopDetectorHook({
 				thresholds: { Read: 3 },
 			});
-			// Grep would normally trigger at 5; with our config it should pass through forever.
-			// (Note: createLoopDetectorHook merges with DEFAULT, so we need a way to drop Grep.
-			//  Verify intended behaviour: defaults are inherited unless overridden.)
-			// Here we just confirm that an explicit override of Read sticks at 3.
-			const input = makePreToolUse('Read', { file_path: '/abs/foo.ts' });
-			expect(await call(trimmed, input)).toEqual({});
-			expect(await call(trimmed, input)).toEqual({});
-			expect(await call(trimmed, input)).toMatchObject({
+			// Read override sticks at 3.
+			const readInput = makePreToolUse('Read', { file_path: '/abs/foo.ts' });
+			expect(await call(merged, readInput)).toEqual({});
+			expect(await call(merged, readInput)).toEqual({});
+			expect(await call(merged, readInput)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+
+			// Grep was NOT overridden, so the default threshold of 5 is preserved.
+			// (This is the merge-with-defaults behaviour documented on
+			// `createLoopDetectorHook`.)
+			const grepInput = makePreToolUse('Grep', { pattern: 'TODO', path: 'src' });
+			for (let i = 0; i < 4; i++) {
+				expect(await call(merged, grepInput)).toEqual({});
+			}
+			expect(await call(merged, grepInput)).toMatchObject({
 				hookSpecificOutput: { permissionDecision: 'deny' },
 			});
 		});

--- a/packages/daemon/tests/unit/1-core/agent/loop-detector-hook.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/loop-detector-hook.test.ts
@@ -162,29 +162,59 @@ describe('LoopDetectorHook', () => {
 	});
 
 	describe('untracked tools', () => {
-		it('does not track Bash even when called many times with identical args', async () => {
+		it('does not deny on Bash even when called many times with identical args', async () => {
 			const input = makePreToolUse('Bash', { command: 'git status', description: 'status' });
 			for (let i = 0; i < 20; i++) {
 				expect(await call(hook, input)).toEqual({});
 			}
 		});
 
-		it('passes through unknown tools', async () => {
+		it('passes through unknown tools without denying', async () => {
 			const input = makePreToolUse('SomeRandomTool', { foo: 'bar' });
 			for (let i = 0; i < 10; i++) {
 				expect(await call(hook, input)).toEqual({});
 			}
 		});
 
-		it('untracked tools do not reset a tracked streak', async () => {
+		it('an untracked tool call DOES reset a tracked streak (Bash counts as a different action)', async () => {
 			const read = makePreToolUse('Read', { file_path: '/abs/foo.ts' });
 			const bash = makePreToolUse('Bash', { command: 'echo hi' });
-			// Read, Bash (untracked, should NOT reset), Read, Read => the 3rd Read denies.
+			// Read, Bash (untracked, counts as a different action), Read, Read
+			// — must NOT deny. Bash reset the streak so we are only on the
+			// 2nd consecutive Read here.
 			expect(await call(hook, read)).toEqual({});
 			expect(await call(hook, bash)).toEqual({});
 			expect(await call(hook, read)).toEqual({});
-			const result = await call(hook, read);
-			expect(result).toMatchObject({
+			expect(await call(hook, read)).toEqual({});
+			// One more identical Read makes it three in a row — denies.
+			expect(await call(hook, read)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+		});
+
+		it('an untracked tool call breaks a denied streak (edit-then-read flow)', async () => {
+			// Real-world recovery flow: agent reads X three times and gets
+			// denied; agent edits X (untracked tool); next read of X must
+			// pass because the edit IS the "different action" the recovery
+			// message asked for.
+			const read = makePreToolUse('Read', { file_path: '/abs/foo.ts' });
+			const edit = makePreToolUse('Edit', {
+				file_path: '/abs/foo.ts',
+				old_string: 'a',
+				new_string: 'b',
+			});
+			await call(hook, read);
+			await call(hook, read);
+			expect(await call(hook, read)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+			// Corrective action via an untracked tool.
+			expect(await call(hook, edit)).toEqual({});
+			// Streak reset — next two Reads pass.
+			expect(await call(hook, read)).toEqual({});
+			expect(await call(hook, read)).toEqual({});
+			// Third in a row again denies, as expected.
+			expect(await call(hook, read)).toMatchObject({
 				hookSpecificOutput: { permissionDecision: 'deny' },
 			});
 		});
@@ -334,6 +364,48 @@ describe('LoopDetectorHook', () => {
 			await new Promise((r) => setTimeout(r, 5));
 			// Third call is treated as the first in a new window — no deny.
 			expect(await call(shortWindowHook, input)).toEqual({});
+		});
+
+		it('enforces the window over the FULL streak duration (slow periodic retries are not penalised)', async () => {
+			// Fake `Date.now` so we can simulate calls spaced 4ms apart with a
+			// 5ms window. Streak duration grows past 5ms on the 3rd call, so
+			// it must reset to 1 — matching "N within window" semantics, not
+			// "no gap > windowMs".
+			const original = Date.now;
+			let now = 1_000_000;
+			Date.now = () => now;
+			try {
+				const slowHook = createLoopDetectorHook({ windowMs: 5 });
+				const input = makePreToolUse('Read', { file_path: '/abs/foo.ts' });
+
+				// t = 0: streak count = 1
+				expect(await call(slowHook, input)).toEqual({});
+				// t = 4: gap is 4 (<= 5), streak duration is 4 (<= 5) → count = 2
+				now += 4;
+				expect(await call(slowHook, input)).toEqual({});
+				// t = 8: gap is 4 (<= 5) BUT streak duration is 8 (> 5).
+				// Old "max-gap" logic would advance to count = 3 and deny.
+				// Correct "window over full duration" logic resets to 1.
+				now += 4;
+				expect(await call(slowHook, input)).toEqual({});
+				// t = 12: gap 4, duration 4 since reset → count = 2, no deny.
+				now += 4;
+				expect(await call(slowHook, input)).toEqual({});
+			} finally {
+				Date.now = original;
+			}
+		});
+
+		it('still denies bursty repeats well within the window', async () => {
+			// Sanity check that a tight burst (much less than windowMs apart)
+			// continues to deny — the previous test must not have over-corrected.
+			const tightHook = createLoopDetectorHook({ windowMs: 60_000 });
+			const input = makePreToolUse('Read', { file_path: '/abs/foo.ts' });
+			await call(tightHook, input);
+			await call(tightHook, input);
+			expect(await call(tightHook, input)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
 		});
 	});
 });

--- a/packages/daemon/tests/unit/1-core/agent/loop-detector-hook.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/loop-detector-hook.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import type { HookCallback, PreToolUseHookInput } from '@anthropic-ai/claude-agent-sdk';
+import { createLoopDetectorHook } from '../../../../src/lib/agent/loop-detector-hook';
+
+const signal = new AbortController().signal;
+
+function makePreToolUse(
+	tool_name: string,
+	tool_input: Record<string, unknown>,
+	cwd = '/test/cwd'
+): PreToolUseHookInput {
+	return {
+		hook_event_name: 'PreToolUse',
+		tool_name,
+		tool_input,
+		session_id: 'test-session',
+		transcript_path: '/test/path',
+		cwd,
+		tool_use_id: 'test-id',
+	};
+}
+
+async function call(hook: HookCallback, input: PreToolUseHookInput) {
+	return hook(input, 'test-id', { signal });
+}
+
+describe('LoopDetectorHook', () => {
+	let hook: HookCallback;
+
+	beforeEach(() => {
+		hook = createLoopDetectorHook();
+	});
+
+	describe('Read', () => {
+		it('passes through below the threshold', async () => {
+			const input = makePreToolUse('Read', { file_path: '/abs/foo.ts' });
+			expect(await call(hook, input)).toEqual({});
+			expect(await call(hook, input)).toEqual({});
+		});
+
+		it('denies on the third consecutive identical Read', async () => {
+			const input = makePreToolUse('Read', { file_path: '/abs/foo.ts' });
+			await call(hook, input);
+			await call(hook, input);
+			const result = await call(hook, input);
+
+			expect(result).toMatchObject({
+				hookSpecificOutput: {
+					hookEventName: 'PreToolUse',
+					permissionDecision: 'deny',
+				},
+			});
+			const reason = (
+				result as {
+					hookSpecificOutput: { permissionDecisionReason: string };
+				}
+			).hookSpecificOutput.permissionDecisionReason;
+			expect(reason).toContain('Loop detected');
+			expect(reason).toContain('Read');
+			expect(reason).toContain('/abs/foo.ts');
+			expect(reason).toContain('TodoWrite');
+		});
+
+		it('normalises relative file paths against cwd so ./foo and foo collide', async () => {
+			const a = makePreToolUse('Read', { file_path: './foo.ts' }, '/work');
+			const b = makePreToolUse('Read', { file_path: 'foo.ts' }, '/work');
+			const c = makePreToolUse('Read', { file_path: '/work/foo.ts' }, '/work');
+
+			expect(await call(hook, a)).toEqual({});
+			expect(await call(hook, b)).toEqual({});
+			const result = await call(hook, c);
+			expect(result).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+		});
+
+		it('different file paths reset the counter', async () => {
+			expect(await call(hook, makePreToolUse('Read', { file_path: '/abs/a.ts' }))).toEqual({});
+			expect(await call(hook, makePreToolUse('Read', { file_path: '/abs/b.ts' }))).toEqual({});
+			expect(await call(hook, makePreToolUse('Read', { file_path: '/abs/c.ts' }))).toEqual({});
+			// Still no loop on any single file, so all pass through.
+		});
+
+		it('treats different offsets as different keys (paginated reads not penalised)', async () => {
+			const a = makePreToolUse('Read', { file_path: '/abs/foo.ts', offset: 0 });
+			const b = makePreToolUse('Read', { file_path: '/abs/foo.ts', offset: 100 });
+			expect(await call(hook, a)).toEqual({});
+			expect(await call(hook, b)).toEqual({});
+			expect(await call(hook, a)).toEqual({});
+			expect(await call(hook, b)).toEqual({});
+			// Both stay below threshold: no deny.
+		});
+
+		it('resets the counter after a deny so the agent can recover', async () => {
+			const input = makePreToolUse('Read', { file_path: '/abs/foo.ts' });
+			await call(hook, input);
+			await call(hook, input);
+			const denied = await call(hook, input);
+			expect(denied).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+			// Next call is fresh — passes through, doesn't immediately deny again.
+			expect(await call(hook, input)).toEqual({});
+			expect(await call(hook, input)).toEqual({});
+		});
+	});
+
+	describe('Grep / Glob', () => {
+		it('uses a higher threshold (5) for Grep', async () => {
+			const input = makePreToolUse('Grep', { pattern: 'TODO', path: 'src' });
+			for (let i = 0; i < 4; i++) {
+				expect(await call(hook, input)).toEqual({});
+			}
+			const result = await call(hook, input);
+			expect(result).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+		});
+
+		it('uses a higher threshold (5) for Glob', async () => {
+			const input = makePreToolUse('Glob', { pattern: '**/*.ts' });
+			for (let i = 0; i < 4; i++) {
+				expect(await call(hook, input)).toEqual({});
+			}
+			const result = await call(hook, input);
+			expect(result).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+		});
+
+		it('treats key-order as identical for Grep args', async () => {
+			const a = makePreToolUse('Grep', { pattern: 'TODO', path: 'src' });
+			const b = makePreToolUse('Grep', { path: 'src', pattern: 'TODO' });
+			for (let i = 0; i < 4; i++) {
+				expect(await call(hook, i % 2 === 0 ? a : b)).toEqual({});
+			}
+			const result = await call(hook, a);
+			expect(result).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+		});
+	});
+
+	describe('untracked tools', () => {
+		it('does not track Bash even when called many times with identical args', async () => {
+			const input = makePreToolUse('Bash', { command: 'git status', description: 'status' });
+			for (let i = 0; i < 20; i++) {
+				expect(await call(hook, input)).toEqual({});
+			}
+		});
+
+		it('passes through unknown tools', async () => {
+			const input = makePreToolUse('SomeRandomTool', { foo: 'bar' });
+			for (let i = 0; i < 10; i++) {
+				expect(await call(hook, input)).toEqual({});
+			}
+		});
+
+		it('ignores non-PreToolUse events', async () => {
+			const result = await hook(
+				{
+					hook_event_name: 'PostToolUse',
+					tool_name: 'Read',
+					tool_input: { file_path: '/abs/foo.ts' },
+					tool_response: 'whatever',
+					session_id: 's',
+					transcript_path: '/t',
+					cwd: '/c',
+					tool_use_id: 'x',
+				} as unknown as PreToolUseHookInput,
+				'x',
+				{ signal }
+			);
+			expect(result).toEqual({});
+		});
+	});
+
+	describe('configuration', () => {
+		it('respects a custom threshold', async () => {
+			const customHook = createLoopDetectorHook({ thresholds: { Read: 2 } });
+			const input = makePreToolUse('Read', { file_path: '/abs/foo.ts' });
+			expect(await call(customHook, input)).toEqual({});
+			const result = await call(customHook, input);
+			expect(result).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+		});
+
+		it('disables entirely when enabled=false', async () => {
+			const offHook = createLoopDetectorHook({ enabled: false });
+			const input = makePreToolUse('Read', { file_path: '/abs/foo.ts' });
+			for (let i = 0; i < 10; i++) {
+				expect(await call(offHook, input)).toEqual({});
+			}
+		});
+
+		it('does not track tools with no configured threshold', async () => {
+			const trimmed = createLoopDetectorHook({
+				thresholds: { Read: 3 },
+			});
+			// Grep would normally trigger at 5; with our config it should pass through forever.
+			// (Note: createLoopDetectorHook merges with DEFAULT, so we need a way to drop Grep.
+			//  Verify intended behaviour: defaults are inherited unless overridden.)
+			// Here we just confirm that an explicit override of Read sticks at 3.
+			const input = makePreToolUse('Read', { file_path: '/abs/foo.ts' });
+			expect(await call(trimmed, input)).toEqual({});
+			expect(await call(trimmed, input)).toEqual({});
+			expect(await call(trimmed, input)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+		});
+	});
+
+	describe('sliding window', () => {
+		it('resets the counter when the window expires', async () => {
+			const shortWindowHook = createLoopDetectorHook({ windowMs: 1 });
+			const input = makePreToolUse('Read', { file_path: '/abs/foo.ts' });
+
+			expect(await call(shortWindowHook, input)).toEqual({});
+			expect(await call(shortWindowHook, input)).toEqual({});
+			// Wait so the window expires before the third call.
+			await new Promise((r) => setTimeout(r, 5));
+			// Third call is treated as the first in a new window — no deny.
+			expect(await call(shortWindowHook, input)).toEqual({});
+		});
+	});
+});

--- a/packages/daemon/tests/unit/1-core/agent/loop-detector-hook.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/loop-detector-hook.test.ts
@@ -7,7 +7,7 @@ const signal = new AbortController().signal;
 function makePreToolUse(
 	tool_name: string,
 	tool_input: Record<string, unknown>,
-	cwd = '/test/cwd'
+	overrides: Partial<PreToolUseHookInput> = {}
 ): PreToolUseHookInput {
 	return {
 		hook_event_name: 'PreToolUse',
@@ -15,8 +15,9 @@ function makePreToolUse(
 		tool_input,
 		session_id: 'test-session',
 		transcript_path: '/test/path',
-		cwd,
+		cwd: '/test/cwd',
 		tool_use_id: 'test-id',
+		...overrides,
 	};
 }
 
@@ -31,7 +32,7 @@ describe('LoopDetectorHook', () => {
 		hook = createLoopDetectorHook();
 	});
 
-	describe('Read', () => {
+	describe('Read — consecutive streak semantics', () => {
 		it('passes through below the threshold', async () => {
 			const input = makePreToolUse('Read', { file_path: '/abs/foo.ts' });
 			expect(await call(hook, input)).toEqual({});
@@ -62,9 +63,9 @@ describe('LoopDetectorHook', () => {
 		});
 
 		it('normalises relative file paths against cwd so ./foo and foo collide', async () => {
-			const a = makePreToolUse('Read', { file_path: './foo.ts' }, '/work');
-			const b = makePreToolUse('Read', { file_path: 'foo.ts' }, '/work');
-			const c = makePreToolUse('Read', { file_path: '/work/foo.ts' }, '/work');
+			const a = makePreToolUse('Read', { file_path: './foo.ts' }, { cwd: '/work' });
+			const b = makePreToolUse('Read', { file_path: 'foo.ts' }, { cwd: '/work' });
+			const c = makePreToolUse('Read', { file_path: '/work/foo.ts' }, { cwd: '/work' });
 
 			expect(await call(hook, a)).toEqual({});
 			expect(await call(hook, b)).toEqual({});
@@ -74,32 +75,51 @@ describe('LoopDetectorHook', () => {
 			});
 		});
 
-		it('different file paths reset the counter', async () => {
-			expect(await call(hook, makePreToolUse('Read', { file_path: '/abs/a.ts' }))).toEqual({});
-			expect(await call(hook, makePreToolUse('Read', { file_path: '/abs/b.ts' }))).toEqual({});
-			expect(await call(hook, makePreToolUse('Read', { file_path: '/abs/c.ts' }))).toEqual({});
-			// Still no loop on any single file, so all pass through.
+		it('a different tracked call in between resets the consecutive streak', async () => {
+			const a = makePreToolUse('Read', { file_path: '/abs/a.ts' });
+			const b = makePreToolUse('Read', { file_path: '/abs/b.ts' });
+			// Read(a) -> Read(b) -> Read(a) -> Read(a) should NOT deny:
+			// only two Read(a) calls are consecutive.
+			expect(await call(hook, a)).toEqual({});
+			expect(await call(hook, b)).toEqual({});
+			expect(await call(hook, a)).toEqual({});
+			expect(await call(hook, a)).toEqual({});
+			// One more identical Read(a) makes it three in a row — denies.
+			const result = await call(hook, a);
+			expect(result).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
 		});
 
 		it('treats different offsets as different keys (paginated reads not penalised)', async () => {
 			const a = makePreToolUse('Read', { file_path: '/abs/foo.ts', offset: 0 });
 			const b = makePreToolUse('Read', { file_path: '/abs/foo.ts', offset: 100 });
-			expect(await call(hook, a)).toEqual({});
-			expect(await call(hook, b)).toEqual({});
-			expect(await call(hook, a)).toEqual({});
-			expect(await call(hook, b)).toEqual({});
-			// Both stay below threshold: no deny.
+			// Alternating offsets — never two in a row of the same key.
+			for (let i = 0; i < 6; i++) {
+				expect(await call(hook, i % 2 === 0 ? a : b)).toEqual({});
+			}
 		});
 
-		it('resets the counter after a deny so the agent can recover', async () => {
+		it('continues to deny on every retry of the same key after a deny (until a different action)', async () => {
 			const input = makePreToolUse('Read', { file_path: '/abs/foo.ts' });
 			await call(hook, input);
 			await call(hook, input);
-			const denied = await call(hook, input);
-			expect(denied).toMatchObject({
+			// First deny.
+			expect(await call(hook, input)).toMatchObject({
 				hookSpecificOutput: { permissionDecision: 'deny' },
 			});
-			// Next call is fresh — passes through, doesn't immediately deny again.
+			// Repeated identical retries keep denying — the loop is broken,
+			// not just throttled.
+			expect(await call(hook, input)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+			expect(await call(hook, input)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+
+			// A different action resets the streak; the next identical Read passes.
+			const other = makePreToolUse('Read', { file_path: '/abs/other.ts' });
+			expect(await call(hook, other)).toEqual({});
 			expect(await call(hook, input)).toEqual({});
 			expect(await call(hook, input)).toEqual({});
 		});
@@ -156,6 +176,19 @@ describe('LoopDetectorHook', () => {
 			}
 		});
 
+		it('untracked tools do not reset a tracked streak', async () => {
+			const read = makePreToolUse('Read', { file_path: '/abs/foo.ts' });
+			const bash = makePreToolUse('Bash', { command: 'echo hi' });
+			// Read, Bash (untracked, should NOT reset), Read, Read => the 3rd Read denies.
+			expect(await call(hook, read)).toEqual({});
+			expect(await call(hook, bash)).toEqual({});
+			expect(await call(hook, read)).toEqual({});
+			const result = await call(hook, read);
+			expect(result).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+		});
+
 		it('ignores non-PreToolUse events', async () => {
 			const result = await hook(
 				{
@@ -194,26 +227,97 @@ describe('LoopDetectorHook', () => {
 			}
 		});
 
-		it('merges partial threshold overrides with defaults (Grep stays tracked at the default)', async () => {
-			const merged = createLoopDetectorHook({
-				thresholds: { Read: 3 },
-			});
-			// Read override sticks at 3.
-			const readInput = makePreToolUse('Read', { file_path: '/abs/foo.ts' });
-			expect(await call(merged, readInput)).toEqual({});
-			expect(await call(merged, readInput)).toEqual({});
-			expect(await call(merged, readInput)).toMatchObject({
+		it('threshold overrides REPLACE the default tracked-tool set', async () => {
+			// Caller asked to track only Read at 2. Grep and Glob must NOT be
+			// tracked, even though defaults include them.
+			const narrow = createLoopDetectorHook({ thresholds: { Read: 2 } });
+
+			// Read still triggers at 2.
+			const read = makePreToolUse('Read', { file_path: '/abs/foo.ts' });
+			expect(await call(narrow, read)).toEqual({});
+			expect(await call(narrow, read)).toMatchObject({
 				hookSpecificOutput: { permissionDecision: 'deny' },
 			});
 
-			// Grep was NOT overridden, so the default threshold of 5 is preserved.
-			// (This is the merge-with-defaults behaviour documented on
-			// `createLoopDetectorHook`.)
-			const grepInput = makePreToolUse('Grep', { pattern: 'TODO', path: 'src' });
-			for (let i = 0; i < 4; i++) {
-				expect(await call(merged, grepInput)).toEqual({});
+			// Grep is no longer tracked at all — even 50 identical calls pass.
+			const grep = makePreToolUse('Grep', { pattern: 'TODO', path: 'src' });
+			for (let i = 0; i < 50; i++) {
+				expect(await call(narrow, grep)).toEqual({});
 			}
-			expect(await call(merged, grepInput)).toMatchObject({
+
+			// Glob likewise.
+			const glob = makePreToolUse('Glob', { pattern: '**/*.ts' });
+			for (let i = 0; i < 50; i++) {
+				expect(await call(narrow, glob)).toEqual({});
+			}
+		});
+
+		it('omitting thresholds inherits the defaults wholesale', async () => {
+			const inheritsDefaults = createLoopDetectorHook({ windowMs: 30_000 });
+			// Read still triggers at the default 3.
+			const read = makePreToolUse('Read', { file_path: '/abs/foo.ts' });
+			expect(await call(inheritsDefaults, read)).toEqual({});
+			expect(await call(inheritsDefaults, read)).toEqual({});
+			expect(await call(inheritsDefaults, read)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+		});
+	});
+
+	describe('per-(session, agent) isolation', () => {
+		it("does not pollute one session's streak with another session's reads", async () => {
+			const a = makePreToolUse('Read', { file_path: '/abs/foo.ts' }, { session_id: 'sess-A' });
+			const b = makePreToolUse('Read', { file_path: '/abs/foo.ts' }, { session_id: 'sess-B' });
+			// Two reads in sess-A interleaved with one read in sess-B. The
+			// sess-A streak must stay at 2 (no deny) because sess-B should
+			// not contribute.
+			expect(await call(hook, a)).toEqual({});
+			expect(await call(hook, b)).toEqual({});
+			expect(await call(hook, a)).toEqual({});
+			// One more makes sess-A's third consecutive — should deny.
+			expect(await call(hook, a)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+			// sess-B should still be on count=1 (only one read) — no deny.
+			expect(await call(hook, b)).toEqual({});
+		});
+
+		it('isolates main thread from subagent (different agent_id)', async () => {
+			const main = makePreToolUse('Read', { file_path: '/abs/foo.ts' }, { agent_id: undefined });
+			const subagent = makePreToolUse('Read', { file_path: '/abs/foo.ts' }, { agent_id: 'sub-1' });
+			// Subagent reads the same file twice — no deny, its own ledger.
+			expect(await call(hook, subagent)).toEqual({});
+			expect(await call(hook, subagent)).toEqual({});
+			// Main thread also reads twice — independent of subagent.
+			expect(await call(hook, main)).toEqual({});
+			expect(await call(hook, main)).toEqual({});
+			// Main's 3rd read triggers main's deny only.
+			expect(await call(hook, main)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+			// Subagent's 3rd read independently triggers its own deny.
+			expect(await call(hook, subagent)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+		});
+
+		it('isolates two subagents from each other', async () => {
+			const subA = makePreToolUse('Read', { file_path: '/abs/foo.ts' }, { agent_id: 'sub-A' });
+			const subB = makePreToolUse('Read', { file_path: '/abs/foo.ts' }, { agent_id: 'sub-B' });
+			// Two reads each, interleaved. Neither should deny.
+			expect(await call(hook, subA)).toEqual({});
+			expect(await call(hook, subB)).toEqual({});
+			expect(await call(hook, subA)).toEqual({});
+			expect(await call(hook, subB)).toEqual({});
+			// subA's 3rd consecutive in its own scope. subB has 2 reads then
+			// a subA in between in the GLOBAL stream — but per-(session,agent)
+			// isolation means subB's streak is 2. So neither denies on this
+			// next subA call (subA streak = 3 here).
+			expect(await call(hook, subA)).toMatchObject({
+				hookSpecificOutput: { permissionDecision: 'deny' },
+			});
+			// subB is still on 2 — one more makes 3 in its own scope.
+			expect(await call(hook, subB)).toMatchObject({
 				hookSpecificOutput: { permissionDecision: 'deny' },
 			});
 		});

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -850,10 +850,14 @@ describe('QueryOptionsBuilder', () => {
 				'Coder-role agents must not merge PRs. Their job is implementation only; the reviewer handles the merge after approval.',
 		};
 
-		it('should return empty hooks when no toolGuards provided', async () => {
+		it('should always install the loop-detector hook even with no toolGuards', async () => {
 			const options = await builder.build();
 
-			expect(options.hooks).toEqual({});
+			expect(options.hooks?.PreToolUse).toBeDefined();
+			expect(options.hooks?.PreToolUse).toHaveLength(1);
+			// Matcher targets the read-only inspection tools.
+			expect(options.hooks?.PreToolUse?.[0]?.matcher).toBe('Read|Grep|Glob');
+			expect(options.hooks?.PreToolUse?.[0]?.hooks).toHaveLength(1);
 		});
 
 		it('compiles declarative tool guards into PreToolUse hooks', async () => {
@@ -863,7 +867,8 @@ describe('QueryOptionsBuilder', () => {
 			});
 			const options = await guardBuilder.build();
 
-			const hook = options.hooks?.PreToolUse?.[0]?.hooks[0];
+			const bashEntry = options.hooks?.PreToolUse?.find((e) => e.matcher === 'Bash');
+			const hook = bashEntry?.hooks[0];
 			expect(hook).toBeDefined();
 
 			for (const command of [
@@ -905,7 +910,8 @@ describe('QueryOptionsBuilder', () => {
 				toolGuards: [NO_MERGE_GUARD],
 			});
 			const options = await guardBuilder.build();
-			const hook = options.hooks?.PreToolUse?.[0]?.hooks[0];
+			const bashEntry = options.hooks?.PreToolUse?.find((e) => e.matcher === 'Bash');
+			const hook = bashEntry?.hooks[0];
 
 			const result = await hook!(
 				{
@@ -939,10 +945,11 @@ describe('QueryOptionsBuilder', () => {
 			});
 			const options = await guardBuilder.build();
 
-			// Both guards share the same matcher, so they should be under one entry
-			expect(options.hooks?.PreToolUse).toHaveLength(1);
-			expect(options.hooks?.PreToolUse?.[0]?.matcher).toBe('Bash');
-			expect(options.hooks?.PreToolUse?.[0]?.hooks).toHaveLength(2);
+			// Both guards share the same matcher, so they should be under one entry.
+			// (The loop-detector matcher is also present at a different index.)
+			const bashEntries = options.hooks?.PreToolUse?.filter((e) => e.matcher === 'Bash');
+			expect(bashEntries).toHaveLength(1);
+			expect(bashEntries?.[0]?.hooks).toHaveLength(2);
 		});
 
 		it('gracefully skips guards with invalid regex patterns', async () => {
@@ -960,7 +967,8 @@ describe('QueryOptionsBuilder', () => {
 			const options = await guardBuilder.build();
 
 			// Hook is compiled (no crash), but the no-op callback returns {}
-			const hook = options.hooks?.PreToolUse?.[0]?.hooks[0];
+			const bashEntry = options.hooks?.PreToolUse?.find((e) => e.matcher === 'Bash');
+			const hook = bashEntry?.hooks[0];
 			expect(hook).toBeDefined();
 			const result = await hook!(
 				{

--- a/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
+++ b/packages/daemon/tests/unit/1-core/agent/query-options-builder.test.ts
@@ -855,8 +855,12 @@ describe('QueryOptionsBuilder', () => {
 
 			expect(options.hooks?.PreToolUse).toBeDefined();
 			expect(options.hooks?.PreToolUse).toHaveLength(1);
-			// Matcher targets the read-only inspection tools.
-			expect(options.hooks?.PreToolUse?.[0]?.matcher).toBe('Read|Grep|Glob');
+			// No matcher: the loop detector observes every PreToolUse so that
+			// untracked tools (Edit, Write, Bash, …) can serve as the
+			// "different action" that breaks a denied streak. Decision logic
+			// (which tools to deny, which to merely use as reset signals)
+			// lives inside the hook itself.
+			expect(options.hooks?.PreToolUse?.[0]?.matcher).toBeUndefined();
 			expect(options.hooks?.PreToolUse?.[0]?.hooks).toHaveLength(1);
 		});
 


### PR DESCRIPTION
Adds a PreToolUse hook that detects when the agent calls `Read`/`Grep`/`Glob` repeatedly with identical arguments — the failure mode observed in task #324 where the coder agent re-read `client-event-bridge.ts` ~60 times in one turn — and short-circuits the duplicate call with `permissionDecision: 'deny'` carrying a recovery message that the SDK delivers back to the model as the tool result.

Thresholds: `Read` at 3, `Grep`/`Glob` at 5, within a 60s sliding window. `Bash` is intentionally not tracked because legitimate output (`git status`, `tail -f`) changes between calls. Counters reset after a deny so the agent can retry once it has performed a different action.

Closes task #328.