### PR TITLE
refactor: extract remaining StateManager forwarding into ClientEventBridge

### DIFF
--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -728,6 +728,10 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 		}
 
 		try {
+			// Stop event bridge first so no new client events are forwarded
+			// while we're tearing down sessions and transport.
+			clientEventBridge.stop();
+
 			try {
 				server.stop();
 			} catch {

--- a/packages/daemon/src/app.ts
+++ b/packages/daemon/src/app.ts
@@ -333,7 +333,7 @@ export async function createDaemonApp(options: CreateDaemonAppOptions): Promise<
 	// WebSocket clients via ClientEventGateway.  This extracts the repetitive
 	// room/space forwarding out of StateManager.
 	const clientEventGateway = stateManager.getClientEventGateway();
-	const clientEventBridge = createClientEventBridge(daemonHub, clientEventGateway);
+	const clientEventBridge = createClientEventBridge(daemonHub, clientEventGateway, stateManager);
 	clientEventBridge.start();
 
 	// Initialize GitHub service if configured

--- a/packages/daemon/src/lib/client-event-bridge.ts
+++ b/packages/daemon/src/lib/client-event-bridge.ts
@@ -35,7 +35,7 @@
  *   emitting events.
  */
 
-import type { IClientEventGateway, EventChannel, SDKMessagesUpdate } from '@neokai/shared';
+import type { IClientEventGateway, EventChannel } from '@neokai/shared';
 import { Channels } from '@neokai/shared';
 import type { DaemonHub, DaemonEventMap } from './daemon-hub';
 
@@ -55,10 +55,7 @@ interface BridgeMapping {
  */
 export interface StateBroadcasts {
 	broadcastSystemChange(): Promise<void>;
-	broadcastSettingsChange(): Promise<void>;
 	broadcastSessionStateChange(sessionId: string): Promise<void>;
-	broadcastSDKMessagesChange(sessionId: string): Promise<void>;
-	broadcastSDKMessagesDelta(sessionId: string, update: SDKMessagesUpdate): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -220,10 +217,13 @@ export class ClientEventBridge {
 			this.subscribeMapping(mapping);
 		}
 
-		// Session events (pure forwarding)
+		// Session events (pure forwarding + broadcast triggers)
 		for (const mapping of SESSION_BRIDGE_MAPPINGS) {
 			this.subscribeMapping(mapping);
 		}
+		this.subscribeBroadcast('context.updated', (data) =>
+			this.broadcasts?.broadcastSessionStateChange(data.sessionId)
+		);
 
 		// Connection/auth events (trigger broadcasts via StateManager)
 		this.subscribeBroadcast('api.connection', () => this.broadcasts?.broadcastSystemChange());
@@ -268,9 +268,11 @@ export class ClientEventBridge {
 		const unsub = this.daemonHub.on(event, (data: DaemonEventMap[K]) => {
 			const promise = broadcast(data);
 			if (promise) {
-				promise.catch(() => {
-					// Broadcast failures are logged by StateManager; bridge swallows
-					// to avoid unhandled rejections.
+				return promise.catch((err) => {
+					// Return the promise so TypedHub awaits it, preserving emit
+					// completion semantics. Log here so failures are visible even
+					// when StateManager's own logging is insufficient.
+					console.warn(`[ClientEventBridge] Broadcast failed for ${event}:`, err);
 				});
 			}
 		});

--- a/packages/daemon/src/lib/client-event-bridge.ts
+++ b/packages/daemon/src/lib/client-event-bridge.ts
@@ -38,6 +38,7 @@
 import type { IClientEventGateway, EventChannel } from '@neokai/shared';
 import { Channels } from '@neokai/shared';
 import type { DaemonHub, DaemonEventMap } from './daemon-hub';
+import { Logger } from './logger';
 
 type DaemonEventName = keyof DaemonEventMap & string;
 
@@ -196,6 +197,7 @@ const SESSION_BRIDGE_MAPPINGS: BridgeMapping[] = [
  */
 export class ClientEventBridge {
 	private unsubscribers: (() => void)[] = [];
+	private logger = new Logger('ClientEventBridge');
 
 	constructor(
 		private daemonHub: DaemonHub,
@@ -272,7 +274,7 @@ export class ClientEventBridge {
 					// Return the promise so TypedHub awaits it, preserving emit
 					// completion semantics. Log here so failures are visible even
 					// when StateManager's own logging is insufficient.
-					console.warn(`[ClientEventBridge] Broadcast failed for ${event}:`, err);
+					this.logger.warn(`Broadcast failed for ${event}:`, err);
 				});
 			}
 		});

--- a/packages/daemon/src/lib/client-event-bridge.ts
+++ b/packages/daemon/src/lib/client-event-bridge.ts
@@ -9,18 +9,21 @@
  *   2. Forwards the payload verbatim (or via a lightweight transform) through
  *      ClientEventGateway using typed Channels.
  *
- * Scope (first slice)
- * -------------------
- * This PR migrates the **space event bridge** slice from StateManager.
- * These are pure forwarding paths with no state caching, no version
- * increments, and no side effects — the safest first extraction.
+ * Scope
+ * -----
+ * This module now contains ALL pure forwarding paths from StateManager:
+ * - Space events (16 mappings) — first slice
+ * - Session events (session.created, session.deleted, context.updated)
+ * - Connection/auth events (api.connection, auth.changed)
+ * - Config events (commands.updated)
+ * - Error events (session.error, session.errorClear)
  *
- * Remaining in StateManager (for follow-up PRs)
- * ---------------------------------------------
- * - session.created / session.deleted / context.updated (already gateway-ised)
- * - api.connection, auth.changed, commands.updated, session.error, session.errorClear
- * - broadcastSystemChange, broadcastSettingsChange, broadcastSessionStateChange,
- *   broadcastSDKMessagesChange, broadcastSDKMessagesDelta
+ * StateManager retains:
+ * - State cache updates (sessionCache, processingStateCache, commandsCache, errorCache)
+ * - Versioned broadcast methods (broadcastSystemChange, broadcastSettingsChange,
+ *   broadcastSessionStateChange, broadcastSDKMessagesChange, broadcastSDKMessagesDelta)
+ * - RPC handlers for state snapshots
+ * - channelVersions lifecycle management
  *
  * Design notes
  * ------------
@@ -32,7 +35,7 @@
  *   emitting events.
  */
 
-import type { IClientEventGateway, EventChannel } from '@neokai/shared';
+import type { IClientEventGateway, EventChannel, SDKMessagesUpdate } from '@neokai/shared';
 import { Channels } from '@neokai/shared';
 import type { DaemonHub, DaemonEventMap } from './daemon-hub';
 
@@ -43,6 +46,19 @@ interface BridgeMapping {
 	clientEvent: string;
 	channel: (payload: DaemonEventMap[keyof DaemonEventMap]) => EventChannel;
 	transform?: (payload: DaemonEventMap[keyof DaemonEventMap]) => unknown;
+}
+
+/**
+ * Narrow interface for the broadcast methods StateManager exposes to the bridge.
+ * Keeping this minimal prevents the bridge from depending on the full StateManager
+ * surface and makes testing straightforward.
+ */
+export interface StateBroadcasts {
+	broadcastSystemChange(): Promise<void>;
+	broadcastSettingsChange(): Promise<void>;
+	broadcastSessionStateChange(sessionId: string): Promise<void>;
+	broadcastSDKMessagesChange(sessionId: string): Promise<void>;
+	broadcastSDKMessagesDelta(sessionId: string, update: SDKMessagesUpdate): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -139,6 +155,43 @@ const SPACE_BRIDGE_MAPPINGS: BridgeMapping[] = [
 	},
 ];
 
+// ---------------------------------------------------------------------------
+// Session bridge mappings (pure gateway forwarding)
+// ---------------------------------------------------------------------------
+
+const SESSION_BRIDGE_MAPPINGS: BridgeMapping[] = [
+	{
+		event: 'session.created',
+		clientEvent: 'session.created',
+		channel: () => Channels.global(),
+		transform: (payload) => {
+			const p = payload as DaemonEventMap['session.created'];
+			return { sessionId: p.session.id };
+		},
+	},
+	{
+		event: 'session.deleted',
+		clientEvent: 'session.deleted',
+		channel: () => Channels.global(),
+		transform: (payload) => {
+			const p = payload as DaemonEventMap['session.deleted'];
+			return { sessionId: p.sessionId };
+		},
+	},
+	{
+		event: 'context.updated',
+		clientEvent: 'context.updated',
+		channel: (payload) => {
+			const p = payload as DaemonEventMap['context.updated'];
+			return Channels.session(p.sessionId);
+		},
+		transform: (payload) => {
+			const p = payload as DaemonEventMap['context.updated'];
+			return p.contextInfo;
+		},
+	},
+];
+
 /**
  * ClientEventBridge wires DaemonHub event subscriptions to ClientEventGateway
  * deliveries.  Each mapping in the registry becomes one `daemonHub.on(...)`
@@ -149,7 +202,8 @@ export class ClientEventBridge {
 
 	constructor(
 		private daemonHub: DaemonHub,
-		private gateway: IClientEventGateway
+		private gateway: IClientEventGateway,
+		private broadcasts?: StateBroadcasts
 	) {}
 
 	/**
@@ -161,9 +215,32 @@ export class ClientEventBridge {
 			return;
 		}
 
+		// Space events
 		for (const mapping of SPACE_BRIDGE_MAPPINGS) {
 			this.subscribeMapping(mapping);
 		}
+
+		// Session events (pure forwarding)
+		for (const mapping of SESSION_BRIDGE_MAPPINGS) {
+			this.subscribeMapping(mapping);
+		}
+
+		// Connection/auth events (trigger broadcasts via StateManager)
+		this.subscribeBroadcast('api.connection', () => this.broadcasts?.broadcastSystemChange());
+		this.subscribeBroadcast('auth.changed', () => this.broadcasts?.broadcastSystemChange());
+
+		// Config events (trigger broadcast via StateManager)
+		this.subscribeBroadcast('commands.updated', (data) =>
+			this.broadcasts?.broadcastSessionStateChange(data.sessionId)
+		);
+
+		// Error events (trigger broadcast via StateManager)
+		this.subscribeBroadcast('session.error', (data) =>
+			this.broadcasts?.broadcastSessionStateChange(data.sessionId)
+		);
+		this.subscribeBroadcast('session.errorClear', (data) =>
+			this.broadcasts?.broadcastSessionStateChange(data.sessionId)
+		);
 	}
 
 	/**
@@ -183,6 +260,22 @@ export class ClientEventBridge {
 		});
 		this.unsubscribers.push(unsub);
 	}
+
+	private subscribeBroadcast<K extends DaemonEventName>(
+		event: K,
+		broadcast: (data: DaemonEventMap[K]) => Promise<void> | undefined
+	): void {
+		const unsub = this.daemonHub.on(event, (data: DaemonEventMap[K]) => {
+			const promise = broadcast(data);
+			if (promise) {
+				promise.catch(() => {
+					// Broadcast failures are logged by StateManager; bridge swallows
+					// to avoid unhandled rejections.
+				});
+			}
+		});
+		this.unsubscribers.push(unsub);
+	}
 }
 
 /**
@@ -190,7 +283,8 @@ export class ClientEventBridge {
  */
 export function createClientEventBridge(
 	daemonHub: DaemonHub,
-	gateway: IClientEventGateway
+	gateway: IClientEventGateway,
+	broadcasts?: StateBroadcasts
 ): ClientEventBridge {
-	return new ClientEventBridge(daemonHub, gateway);
+	return new ClientEventBridge(daemonHub, gateway, broadcasts);
 }

--- a/packages/daemon/src/lib/state-manager.ts
+++ b/packages/daemon/src/lib/state-manager.ts
@@ -29,8 +29,8 @@ import type {
 	SDKMessagesState,
 	SDKMessagesUpdate,
 } from '@neokai/shared';
-import type { Session, ContextInfo } from '@neokai/shared';
-import { Channels, ClientEventGateway, STATE_CHANNELS } from '@neokai/shared';
+import type { Session } from '@neokai/shared';
+import { ClientEventGateway, STATE_CHANNELS } from '@neokai/shared';
 import { SDKMessageRepository } from '../storage/repositories/sdk-message-repository';
 import type { DaemonInternalEventMap, InternalEventBus } from './internal-event-bus';
 
@@ -109,30 +109,25 @@ export class StateManager {
 	 * - StateManager caches this data (no fetching from sources)
 	 * - Broadcasts immediately to clients (no debouncing)
 	 *
+	 * NOTE: Client forwarding has been extracted to ClientEventBridge.
+	 * StateManager now only updates its internal caches; the bridge handles
+	 * all client-facing event delivery.
+	 *
 	 * TODO(M2): Migrate subscriptions to InternalEventBus as events move to the
 	 * new dot/camelCase naming convention.
 	 */
 	private setupEventListeners(): void {
 		// API connection state updates from ErrorManager
+		// (forwarding extracted to ClientEventBridge; cache stays here)
 		this.daemonHub.on('api.connection', (data) => {
 			this.apiConnectionState = data as import('@neokai/shared').ApiConnectionState;
-			this.broadcastSystemChange().catch((err: unknown) => {
-				this.logger.error('Failed to broadcast system state after API connection change:', err);
-			});
 		});
 
-		// Session created - cache and broadcast
-		this.daemonHub.on('session.created', async (data) => {
+		// Session created - cache only (forwarding extracted to ClientEventBridge)
+		this.daemonHub.on('session.created', (data) => {
 			const { session } = data;
-
-			// Cache session and initial processing state
 			this.sessionCache.set(session.id, session);
 			this.processingStateCache.set(session.id, { status: 'idle' });
-
-			// Publish session.created event (via ClientEventGateway — proof of pattern)
-			this.clientEvents.publish('session.created', { sessionId: session.id }, Channels.global());
-
-			// Note: Global sessions list updates are now handled by LiveQuery (sessions.list)
 		});
 
 		// Session updated - update cache from event data and broadcast immediately
@@ -159,25 +154,24 @@ export class StateManager {
 			await this.broadcastSessionUpdateFromCache(sessionId);
 		});
 
-		// Session deleted - clear cache and broadcast
-		this.daemonHub.on('session.deleted', async (data) => {
+		// Session deleted - clear caches and channelVersions
+		// (forwarding extracted to ClientEventBridge)
+		this.daemonHub.on('session.deleted', (data) => {
 			const { sessionId } = data;
 
 			// Clear caches
 			this.sessionCache.delete(sessionId);
 			this.processingStateCache.delete(sessionId);
 			this.commandsCache.delete(sessionId);
+			this.errorCache.delete(sessionId);
 
-			// Publish session.deleted event (via ClientEventGateway — proof of pattern)
-			this.clientEvents.publish('session.deleted', { sessionId }, Channels.global());
-
-			// Note: Global sessions list updates are now handled by LiveQuery (sessions.list)
+			// FIX: Clean up channelVersions for deleted session
+			this.channelVersions.delete(`${STATE_CHANNELS.SESSION}:${sessionId}`);
+			this.channelVersions.delete(`${STATE_CHANNELS.SESSION_SDK_MESSAGES}:${sessionId}`);
+			this.channelVersions.delete(`${STATE_CHANNELS.SESSION_SDK_MESSAGES}.delta:${sessionId}`);
 		});
 
-		// Auth events
-		this.daemonHub.on('auth.changed', async () => {
-			await this.broadcastSystemChange();
-		});
+		// Auth events - no cache (forwarding extracted to ClientEventBridge)
 
 		// Settings events — migrated to InternalEventBus.
 		// If internalEventBus is provided, subscribe there; otherwise fall back
@@ -196,64 +190,33 @@ export class StateManager {
 			});
 		}
 
-		// Commands updated - cache and broadcast
-		this.daemonHub.on(
-			'commands.updated',
-			async (data: { sessionId: string; commands: string[] }) => {
-				this.commandsCache.set(data.sessionId, data.commands);
-				await this.broadcastSessionStateChange(data.sessionId);
-			}
-		);
+		// Commands updated - cache only (broadcast extracted to ClientEventBridge)
+		this.daemonHub.on('commands.updated', (data: { sessionId: string; commands: string[] }) => {
+			this.commandsCache.set(data.sessionId, data.commands);
+		});
 
-		// Context updated - broadcast dedicated event and full session state
-		// Context data is persisted in session.metadata.lastContextInfo (by ContextTracker),
-		// so no separate cache needed here. The dedicated event provides a fast path
-		// for the frontend to update the context bar immediately.
-		this.daemonHub.on(
-			'context.updated',
-			async (data: { sessionId: string; contextInfo: ContextInfo }) => {
-				// Publish dedicated context.updated event (fast path for UI)
-				// Routed via ClientEventGateway — proof of pattern.
-				this.clientEvents.publish(
-					'context.updated',
-					data.contextInfo,
-					Channels.session(data.sessionId)
-				);
+		// Context updated - no cache (forwarding extracted to ClientEventBridge)
+		// Context data is persisted in session.metadata.lastContextInfo (by ContextTracker).
 
-				// Also update unified session state (includes metadata.lastContextInfo)
-				await this.broadcastSessionStateChange(data.sessionId);
-			}
-		);
-
-		// Session error events - update error cache and broadcast via state.session
-		// This folds the separate session.error event into the unified session state
+		// Session error events - cache only (broadcast extracted to ClientEventBridge)
 		this.daemonHub.on(
 			'session.error',
-			async (data: { sessionId: string; error: string; details?: unknown }) => {
-				// Update error cache
+			(data: { sessionId: string; error: string; details?: unknown }) => {
 				this.errorCache.set(data.sessionId, {
 					message: data.error,
 					details: data.details,
 					occurredAt: Date.now(),
 				});
-
-				// Broadcast updated session state (includes error)
-				await this.broadcastSessionStateChange(data.sessionId);
 			}
 		);
 
 		// Clear error when session becomes idle or processing continues successfully
-		this.daemonHub.on('session.errorClear', async (data: { sessionId: string }) => {
+		this.daemonHub.on('session.errorClear', (data: { sessionId: string }) => {
 			this.errorCache.set(data.sessionId, null);
-			await this.broadcastSessionStateChange(data.sessionId);
 		});
 
 		// =====================================================================
-		// Space event bridge — migrated to ClientEventBridge
-		//
-		// Pure forwarding handlers for space.*, spaceAgent.*, and
-		// spaceWorkflow.* events have been extracted into ClientEventBridge
-		// so StateManager no longer owns repetitive daemon-to-client forwarding.
+		// All pure forwarding handlers have been extracted to ClientEventBridge
 		//
 		// See: packages/daemon/src/lib/client-event-bridge.ts
 		// =====================================================================

--- a/packages/daemon/tests/unit/1-core/core/client-event-bridge.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/client-event-bridge.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it, mock } from 'bun:test';
 import {
 	ClientEventBridge,
 	createClientEventBridge,
+	type StateBroadcasts,
 } from '../../../../src/lib/client-event-bridge';
 import type { DaemonHub } from '../../../../src/lib/daemon-hub';
 import type { IClientEventGateway, EventChannel } from '@neokai/shared';
@@ -40,7 +41,34 @@ describe('ClientEventBridge', () => {
 			}),
 		} as unknown as IClientEventGateway;
 
-		return { daemonHub, gateway, eventHandlers, published, unsubscribers };
+		const broadcastCalls: { method: string; args: unknown[] }[] = [];
+		const broadcasts: StateBroadcasts = {
+			broadcastSystemChange: mock(async () => {
+				broadcastCalls.push({ method: 'broadcastSystemChange', args: [] });
+			}),
+			broadcastSettingsChange: mock(async () => {
+				broadcastCalls.push({ method: 'broadcastSettingsChange', args: [] });
+			}),
+			broadcastSessionStateChange: mock(async (sessionId: string) => {
+				broadcastCalls.push({ method: 'broadcastSessionStateChange', args: [sessionId] });
+			}),
+			broadcastSDKMessagesChange: mock(async (sessionId: string) => {
+				broadcastCalls.push({ method: 'broadcastSDKMessagesChange', args: [sessionId] });
+			}),
+			broadcastSDKMessagesDelta: mock(async (sessionId: string, update: unknown) => {
+				broadcastCalls.push({ method: 'broadcastSDKMessagesDelta', args: [sessionId, update] });
+			}),
+		};
+
+		return {
+			daemonHub,
+			gateway,
+			eventHandlers,
+			published,
+			unsubscribers,
+			broadcasts,
+			broadcastCalls,
+		};
 	}
 
 	describe('start', () => {
@@ -67,14 +95,50 @@ describe('ClientEventBridge', () => {
 			expect(eventHandlers.has('spaceWorkflow.deleted')).toBe(true);
 		});
 
+		it('should subscribe to session bridge events', () => {
+			const { daemonHub, gateway, eventHandlers } = buildFixture();
+			const bridge = new ClientEventBridge(daemonHub, gateway);
+			bridge.start();
+
+			expect(eventHandlers.has('session.created')).toBe(true);
+			expect(eventHandlers.has('session.deleted')).toBe(true);
+			expect(eventHandlers.has('context.updated')).toBe(true);
+		});
+
+		it('should subscribe to connection/auth bridge events', () => {
+			const { daemonHub, gateway, eventHandlers } = buildFixture();
+			const bridge = new ClientEventBridge(daemonHub, gateway);
+			bridge.start();
+
+			expect(eventHandlers.has('api.connection')).toBe(true);
+			expect(eventHandlers.has('auth.changed')).toBe(true);
+		});
+
+		it('should subscribe to config bridge events', () => {
+			const { daemonHub, gateway, eventHandlers } = buildFixture();
+			const bridge = new ClientEventBridge(daemonHub, gateway);
+			bridge.start();
+
+			expect(eventHandlers.has('commands.updated')).toBe(true);
+		});
+
+		it('should subscribe to error bridge events', () => {
+			const { daemonHub, gateway, eventHandlers } = buildFixture();
+			const bridge = new ClientEventBridge(daemonHub, gateway);
+			bridge.start();
+
+			expect(eventHandlers.has('session.error')).toBe(true);
+			expect(eventHandlers.has('session.errorClear')).toBe(true);
+		});
+
 		it('should be idempotent', () => {
 			const { daemonHub, gateway, eventHandlers } = buildFixture();
 			const bridge = new ClientEventBridge(daemonHub, gateway);
 			bridge.start();
 			bridge.start();
 
-			// Only one handler per event should be registered
-			expect(eventHandlers.size).toBe(16);
+			// 16 space + 3 session + 2 conn/auth + 1 config + 2 error = 24
+			expect(eventHandlers.size).toBe(24);
 		});
 	});
 
@@ -85,7 +149,7 @@ describe('ClientEventBridge', () => {
 			bridge.start();
 			bridge.stop();
 
-			expect(unsubscribers.length).toBe(16);
+			expect(unsubscribers.length).toBe(24);
 		});
 	});
 
@@ -300,6 +364,112 @@ describe('ClientEventBridge', () => {
 			eventHandlers.get('spaceWorkflow.deleted')!(data);
 
 			expect(published[0].channel).toEqual({ kind: 'global' });
+		});
+	});
+
+	describe('session event forwarding', () => {
+		it('forwards session.created to global channel with transformed payload', () => {
+			const { daemonHub, gateway, eventHandlers, published } = buildFixture();
+			createClientEventBridge(daemonHub, gateway).start();
+
+			const data = {
+				sessionId: 'sess-1',
+				session: { id: 'sess-1', title: 'Test', status: 'active', metadata: {} },
+			};
+			eventHandlers.get('session.created')!(data);
+
+			expect(published[0].method).toBe('session.created');
+			expect(published[0].data).toEqual({ sessionId: 'sess-1' });
+			expect(published[0].channel).toEqual({ kind: 'global' });
+		});
+
+		it('forwards session.deleted to global channel with transformed payload', () => {
+			const { daemonHub, gateway, eventHandlers, published } = buildFixture();
+			createClientEventBridge(daemonHub, gateway).start();
+
+			const data = { sessionId: 'sess-1' };
+			eventHandlers.get('session.deleted')!(data);
+
+			expect(published[0].method).toBe('session.deleted');
+			expect(published[0].data).toEqual({ sessionId: 'sess-1' });
+			expect(published[0].channel).toEqual({ kind: 'global' });
+		});
+
+		it('forwards context.updated to session-scoped channel with transformed payload', () => {
+			const { daemonHub, gateway, eventHandlers, published } = buildFixture();
+			createClientEventBridge(daemonHub, gateway).start();
+
+			const contextInfo = { files: 5, tokens: 1000 };
+			const data = { sessionId: 'sess-1', contextInfo };
+			eventHandlers.get('context.updated')!(data);
+
+			expect(published[0].method).toBe('context.updated');
+			expect(published[0].data).toEqual(contextInfo);
+			expect(published[0].channel).toEqual({ kind: 'session', sessionId: 'sess-1' });
+		});
+	});
+
+	describe('connection/auth event forwarding', () => {
+		it('triggers broadcastSystemChange on api.connection', async () => {
+			const { daemonHub, eventHandlers, broadcasts, broadcastCalls } = buildFixture();
+			createClientEventBridge(daemonHub, {} as IClientEventGateway, broadcasts).start();
+
+			const data = { sessionId: 'global', status: 'disconnected', timestamp: Date.now() };
+			await eventHandlers.get('api.connection')!(data);
+
+			expect(broadcastCalls).toHaveLength(1);
+			expect(broadcastCalls[0].method).toBe('broadcastSystemChange');
+		});
+
+		it('triggers broadcastSystemChange on auth.changed', async () => {
+			const { daemonHub, eventHandlers, broadcasts, broadcastCalls } = buildFixture();
+			createClientEventBridge(daemonHub, {} as IClientEventGateway, broadcasts).start();
+
+			const data = { sessionId: 'global', method: 'api_key', isAuthenticated: true };
+			await eventHandlers.get('auth.changed')!(data);
+
+			expect(broadcastCalls).toHaveLength(1);
+			expect(broadcastCalls[0].method).toBe('broadcastSystemChange');
+		});
+	});
+
+	describe('config event forwarding', () => {
+		it('triggers broadcastSessionStateChange on commands.updated', async () => {
+			const { daemonHub, eventHandlers, broadcasts, broadcastCalls } = buildFixture();
+			createClientEventBridge(daemonHub, {} as IClientEventGateway, broadcasts).start();
+
+			const data = { sessionId: 'sess-1', commands: ['cmd1', 'cmd2'] };
+			await eventHandlers.get('commands.updated')!(data);
+
+			expect(broadcastCalls).toHaveLength(1);
+			expect(broadcastCalls[0].method).toBe('broadcastSessionStateChange');
+			expect(broadcastCalls[0].args).toEqual(['sess-1']);
+		});
+	});
+
+	describe('error event forwarding', () => {
+		it('triggers broadcastSessionStateChange on session.error', async () => {
+			const { daemonHub, eventHandlers, broadcasts, broadcastCalls } = buildFixture();
+			createClientEventBridge(daemonHub, {} as IClientEventGateway, broadcasts).start();
+
+			const data = { sessionId: 'sess-1', error: 'Something went wrong' };
+			await eventHandlers.get('session.error')!(data);
+
+			expect(broadcastCalls).toHaveLength(1);
+			expect(broadcastCalls[0].method).toBe('broadcastSessionStateChange');
+			expect(broadcastCalls[0].args).toEqual(['sess-1']);
+		});
+
+		it('triggers broadcastSessionStateChange on session.errorClear', async () => {
+			const { daemonHub, eventHandlers, broadcasts, broadcastCalls } = buildFixture();
+			createClientEventBridge(daemonHub, {} as IClientEventGateway, broadcasts).start();
+
+			const data = { sessionId: 'sess-1' };
+			await eventHandlers.get('session.errorClear')!(data);
+
+			expect(broadcastCalls).toHaveLength(1);
+			expect(broadcastCalls[0].method).toBe('broadcastSessionStateChange');
+			expect(broadcastCalls[0].args).toEqual(['sess-1']);
 		});
 	});
 

--- a/packages/daemon/tests/unit/1-core/core/client-event-bridge.test.ts
+++ b/packages/daemon/tests/unit/1-core/core/client-event-bridge.test.ts
@@ -16,15 +16,22 @@ import type { IClientEventGateway, EventChannel } from '@neokai/shared';
 
 describe('ClientEventBridge', () => {
 	function buildFixture() {
-		const eventHandlers = new Map<string, Function>();
+		const eventHandlers = new Map<string, Function[]>();
 		const unsubscribers: string[] = [];
 
 		const daemonHub = {
 			on: mock((event: string, handler: Function) => {
-				eventHandlers.set(event, handler);
+				const existing = eventHandlers.get(event) || [];
+				existing.push(handler);
+				eventHandlers.set(event, existing);
 				return () => {
 					unsubscribers.push(event);
-					eventHandlers.delete(event);
+					const handlers = eventHandlers.get(event);
+					if (handlers) {
+						const idx = handlers.indexOf(handler);
+						if (idx !== -1) handlers.splice(idx, 1);
+						if (handlers.length === 0) eventHandlers.delete(event);
+					}
 				};
 			}),
 			emit: mock(async () => {}),
@@ -46,17 +53,8 @@ describe('ClientEventBridge', () => {
 			broadcastSystemChange: mock(async () => {
 				broadcastCalls.push({ method: 'broadcastSystemChange', args: [] });
 			}),
-			broadcastSettingsChange: mock(async () => {
-				broadcastCalls.push({ method: 'broadcastSettingsChange', args: [] });
-			}),
 			broadcastSessionStateChange: mock(async (sessionId: string) => {
 				broadcastCalls.push({ method: 'broadcastSessionStateChange', args: [sessionId] });
-			}),
-			broadcastSDKMessagesChange: mock(async (sessionId: string) => {
-				broadcastCalls.push({ method: 'broadcastSDKMessagesChange', args: [sessionId] });
-			}),
-			broadcastSDKMessagesDelta: mock(async (sessionId: string, update: unknown) => {
-				broadcastCalls.push({ method: 'broadcastSDKMessagesDelta', args: [sessionId, update] });
 			}),
 		};
 
@@ -137,7 +135,8 @@ describe('ClientEventBridge', () => {
 			bridge.start();
 			bridge.start();
 
-			// 16 space + 3 session + 2 conn/auth + 1 config + 2 error = 24
+			// 16 space + 3 session + 2 conn/auth + 1 config + 2 error = 24 unique events
+			// (context.updated has 2 handlers but is 1 unique event key)
 			expect(eventHandlers.size).toBe(24);
 		});
 	});
@@ -149,7 +148,8 @@ describe('ClientEventBridge', () => {
 			bridge.start();
 			bridge.stop();
 
-			expect(unsubscribers.length).toBe(24);
+			// 24 daemonHub.on calls total (context.updated has 2 handlers)
+			expect(unsubscribers.length).toBe(25);
 		});
 	});
 
@@ -159,7 +159,7 @@ describe('ClientEventBridge', () => {
 			createClientEventBridge(daemonHub, gateway).start();
 
 			const data = { sessionId: 'global', spaceId: 's-1', space: { id: 's-1' } };
-			eventHandlers.get('space.created')!(data);
+			eventHandlers.get('space.created')![0](data);
 
 			expect(published[0].method).toBe('space.created');
 			expect(published[0].channel).toEqual({ kind: 'global' });
@@ -170,7 +170,7 @@ describe('ClientEventBridge', () => {
 			createClientEventBridge(daemonHub, gateway).start();
 
 			const data = { sessionId: 'global', spaceId: 's-1', space: { name: 'Updated' } };
-			eventHandlers.get('space.updated')!(data);
+			eventHandlers.get('space.updated')![0](data);
 
 			expect(published[0].channel).toEqual({ kind: 'global' });
 		});
@@ -184,7 +184,7 @@ describe('ClientEventBridge', () => {
 				spaceId: 's-1',
 				space: { id: 's-1', status: 'archived' },
 			};
-			eventHandlers.get('space.archived')!(data);
+			eventHandlers.get('space.archived')![0](data);
 
 			expect(published[0].channel).toEqual({ kind: 'global' });
 		});
@@ -194,7 +194,7 @@ describe('ClientEventBridge', () => {
 			createClientEventBridge(daemonHub, gateway).start();
 
 			const data = { sessionId: 'global', spaceId: 's-1' };
-			eventHandlers.get('space.deleted')!(data);
+			eventHandlers.get('space.deleted')![0](data);
 
 			expect(published[0].channel).toEqual({ kind: 'global' });
 		});
@@ -209,7 +209,7 @@ describe('ClientEventBridge', () => {
 				taskId: 't-1',
 				task: { id: 't-1', title: 'Task 1' },
 			};
-			eventHandlers.get('space.task.created')!(data);
+			eventHandlers.get('space.task.created')![0](data);
 
 			expect(published[0].channel).toEqual({ kind: 'global' });
 		});
@@ -224,7 +224,7 @@ describe('ClientEventBridge', () => {
 				taskId: 't-1',
 				task: { id: 't-1', status: 'in_progress' },
 			};
-			eventHandlers.get('space.task.updated')!(data);
+			eventHandlers.get('space.task.updated')![0](data);
 
 			expect(published[0].channel).toEqual({ kind: 'global' });
 		});
@@ -239,7 +239,7 @@ describe('ClientEventBridge', () => {
 				scheduleId: 'sch-1',
 				schedule: { id: 'sch-1', cron: '0 9 * * *' },
 			};
-			eventHandlers.get('space.schedule.updated')!(data);
+			eventHandlers.get('space.schedule.updated')![0](data);
 
 			expect(published[0].channel).toEqual({ kind: 'global' });
 		});
@@ -254,7 +254,7 @@ describe('ClientEventBridge', () => {
 				runId: 'run-1',
 				run: { id: 'run-1', status: 'pending' },
 			};
-			eventHandlers.get('space.workflowRun.created')!(data);
+			eventHandlers.get('space.workflowRun.created')![0](data);
 
 			expect(published[0].channel).toEqual({ kind: 'global' });
 		});
@@ -269,7 +269,7 @@ describe('ClientEventBridge', () => {
 				runId: 'run-1',
 				run: { status: 'running' },
 			};
-			eventHandlers.get('space.workflowRun.updated')!(data);
+			eventHandlers.get('space.workflowRun.updated')![0](data);
 
 			expect(published[0].channel).toEqual({ kind: 'global' });
 		});
@@ -285,7 +285,7 @@ describe('ClientEventBridge', () => {
 				gateId: 'g-1',
 				data: { votes: 3 },
 			};
-			eventHandlers.get('space.gateData.updated')!(data);
+			eventHandlers.get('space.gateData.updated')![0](data);
 
 			expect(published[0].channel).toEqual({ kind: 'global' });
 		});
@@ -299,7 +299,7 @@ describe('ClientEventBridge', () => {
 				spaceId: 's-1',
 				agent: { id: 'a-1', name: 'Agent 1' },
 			};
-			eventHandlers.get('spaceAgent.created')!(data);
+			eventHandlers.get('spaceAgent.created')![0](data);
 
 			expect(published[0].channel).toEqual({ kind: 'space', spaceId: 's-1' });
 		});
@@ -313,7 +313,7 @@ describe('ClientEventBridge', () => {
 				spaceId: 's-1',
 				agent: { id: 'a-1', name: 'Updated Agent' },
 			};
-			eventHandlers.get('spaceAgent.updated')!(data);
+			eventHandlers.get('spaceAgent.updated')![0](data);
 
 			expect(published[0].channel).toEqual({ kind: 'space', spaceId: 's-1' });
 		});
@@ -323,7 +323,7 @@ describe('ClientEventBridge', () => {
 			createClientEventBridge(daemonHub, gateway).start();
 
 			const data = { sessionId: 'space:s-1', spaceId: 's-1', agentId: 'a-1' };
-			eventHandlers.get('spaceAgent.deleted')!(data);
+			eventHandlers.get('spaceAgent.deleted')![0](data);
 
 			expect(published[0].channel).toEqual({ kind: 'space', spaceId: 's-1' });
 		});
@@ -337,7 +337,7 @@ describe('ClientEventBridge', () => {
 				spaceId: 's-1',
 				workflow: { id: 'wf-1', name: 'Workflow 1' },
 			};
-			eventHandlers.get('spaceWorkflow.created')!(data);
+			eventHandlers.get('spaceWorkflow.created')![0](data);
 
 			expect(published[0].channel).toEqual({ kind: 'global' });
 		});
@@ -351,7 +351,7 @@ describe('ClientEventBridge', () => {
 				spaceId: 's-1',
 				workflow: { id: 'wf-1', name: 'Updated Workflow' },
 			};
-			eventHandlers.get('spaceWorkflow.updated')!(data);
+			eventHandlers.get('spaceWorkflow.updated')![0](data);
 
 			expect(published[0].channel).toEqual({ kind: 'global' });
 		});
@@ -361,7 +361,7 @@ describe('ClientEventBridge', () => {
 			createClientEventBridge(daemonHub, gateway).start();
 
 			const data = { sessionId: 'global', spaceId: 's-1', workflowId: 'wf-1' };
-			eventHandlers.get('spaceWorkflow.deleted')!(data);
+			eventHandlers.get('spaceWorkflow.deleted')![0](data);
 
 			expect(published[0].channel).toEqual({ kind: 'global' });
 		});
@@ -376,7 +376,7 @@ describe('ClientEventBridge', () => {
 				sessionId: 'sess-1',
 				session: { id: 'sess-1', title: 'Test', status: 'active', metadata: {} },
 			};
-			eventHandlers.get('session.created')!(data);
+			eventHandlers.get('session.created')![0](data);
 
 			expect(published[0].method).toBe('session.created');
 			expect(published[0].data).toEqual({ sessionId: 'sess-1' });
@@ -388,7 +388,7 @@ describe('ClientEventBridge', () => {
 			createClientEventBridge(daemonHub, gateway).start();
 
 			const data = { sessionId: 'sess-1' };
-			eventHandlers.get('session.deleted')!(data);
+			eventHandlers.get('session.deleted')![0](data);
 
 			expect(published[0].method).toBe('session.deleted');
 			expect(published[0].data).toEqual({ sessionId: 'sess-1' });
@@ -401,7 +401,7 @@ describe('ClientEventBridge', () => {
 
 			const contextInfo = { files: 5, tokens: 1000 };
 			const data = { sessionId: 'sess-1', contextInfo };
-			eventHandlers.get('context.updated')!(data);
+			eventHandlers.get('context.updated')![0](data);
 
 			expect(published[0].method).toBe('context.updated');
 			expect(published[0].data).toEqual(contextInfo);
@@ -415,7 +415,7 @@ describe('ClientEventBridge', () => {
 			createClientEventBridge(daemonHub, {} as IClientEventGateway, broadcasts).start();
 
 			const data = { sessionId: 'global', status: 'disconnected', timestamp: Date.now() };
-			await eventHandlers.get('api.connection')!(data);
+			await eventHandlers.get('api.connection')![0](data);
 
 			expect(broadcastCalls).toHaveLength(1);
 			expect(broadcastCalls[0].method).toBe('broadcastSystemChange');
@@ -426,7 +426,7 @@ describe('ClientEventBridge', () => {
 			createClientEventBridge(daemonHub, {} as IClientEventGateway, broadcasts).start();
 
 			const data = { sessionId: 'global', method: 'api_key', isAuthenticated: true };
-			await eventHandlers.get('auth.changed')!(data);
+			await eventHandlers.get('auth.changed')![0](data);
 
 			expect(broadcastCalls).toHaveLength(1);
 			expect(broadcastCalls[0].method).toBe('broadcastSystemChange');
@@ -439,7 +439,22 @@ describe('ClientEventBridge', () => {
 			createClientEventBridge(daemonHub, {} as IClientEventGateway, broadcasts).start();
 
 			const data = { sessionId: 'sess-1', commands: ['cmd1', 'cmd2'] };
-			await eventHandlers.get('commands.updated')!(data);
+			await eventHandlers.get('commands.updated')![0](data);
+
+			expect(broadcastCalls).toHaveLength(1);
+			expect(broadcastCalls[0].method).toBe('broadcastSessionStateChange');
+			expect(broadcastCalls[0].args).toEqual(['sess-1']);
+		});
+	});
+
+	describe('context.updated broadcast trigger', () => {
+		it('triggers broadcastSessionStateChange on context.updated', async () => {
+			const { daemonHub, eventHandlers, broadcasts, broadcastCalls } = buildFixture();
+			createClientEventBridge(daemonHub, {} as IClientEventGateway, broadcasts).start();
+
+			const data = { sessionId: 'sess-1', contextInfo: { files: 5, tokens: 1000 } };
+			// The broadcast trigger is the second handler (index 1) for context.updated
+			await eventHandlers.get('context.updated')![1](data);
 
 			expect(broadcastCalls).toHaveLength(1);
 			expect(broadcastCalls[0].method).toBe('broadcastSessionStateChange');
@@ -453,7 +468,7 @@ describe('ClientEventBridge', () => {
 			createClientEventBridge(daemonHub, {} as IClientEventGateway, broadcasts).start();
 
 			const data = { sessionId: 'sess-1', error: 'Something went wrong' };
-			await eventHandlers.get('session.error')!(data);
+			await eventHandlers.get('session.error')![0](data);
 
 			expect(broadcastCalls).toHaveLength(1);
 			expect(broadcastCalls[0].method).toBe('broadcastSessionStateChange');
@@ -465,7 +480,7 @@ describe('ClientEventBridge', () => {
 			createClientEventBridge(daemonHub, {} as IClientEventGateway, broadcasts).start();
 
 			const data = { sessionId: 'sess-1' };
-			await eventHandlers.get('session.errorClear')!(data);
+			await eventHandlers.get('session.errorClear')![0](data);
 
 			expect(broadcastCalls).toHaveLength(1);
 			expect(broadcastCalls[0].method).toBe('broadcastSessionStateChange');
@@ -479,7 +494,7 @@ describe('ClientEventBridge', () => {
 			createClientEventBridge(daemonHub, gateway).start();
 
 			const data = { sessionId: 'global', spaceId: 's-1', space: { id: 's-1', name: 'Test' } };
-			eventHandlers.get('space.created')!(data);
+			eventHandlers.get('space.created')![0](data);
 
 			expect(published[0].data).toEqual(data);
 		});

--- a/packages/daemon/tests/unit/1-core/session/state-manager.test.ts
+++ b/packages/daemon/tests/unit/1-core/session/state-manager.test.ts
@@ -110,7 +110,8 @@ describe('StateManager', () => {
 			expect(eventHandlers.has('session.created')).toBe(true);
 			expect(eventHandlers.has('session.updated')).toBe(true);
 			expect(eventHandlers.has('session.deleted')).toBe(true);
-			expect(eventHandlers.has('auth.changed')).toBe(true);
+			// auth.changed forwarding extracted to ClientEventBridge
+			expect(eventHandlers.has('auth.changed')).toBe(false);
 			expect(eventHandlers.has('settings.updated')).toBe(true);
 		});
 
@@ -362,7 +363,7 @@ describe('StateManager', () => {
 
 	describe('event handlers', () => {
 		describe('session.created', () => {
-			it('should cache session and publish event', async () => {
+			it('should cache session and initial processing state', async () => {
 				const handler = eventHandlers.get('session.created');
 				const mockSession: Session = {
 					id: 'new-session-id',
@@ -373,11 +374,11 @@ describe('StateManager', () => {
 
 				await handler!({ session: mockSession });
 
-				// Note: Global sessions list updates are now handled by LiveQuery (sessions.list)
-				expect(mockMessageHub.event).toHaveBeenCalledWith(
+				// Forwarding extracted to ClientEventBridge; StateManager only caches
+				expect(mockMessageHub.event).not.toHaveBeenCalledWith(
 					'session.created',
-					{ sessionId: 'new-session-id' },
-					{ channel: 'global' }
+					expect.anything(),
+					expect.anything()
 				);
 			});
 		});
@@ -422,7 +423,7 @@ describe('StateManager', () => {
 		});
 
 		describe('session.deleted', () => {
-			it('should clear caches and publish event', async () => {
+			it('should clear caches including error cache', async () => {
 				// First create a session to cache
 				const createHandler = eventHandlers.get('session.created');
 				await createHandler!({
@@ -433,27 +434,64 @@ describe('StateManager', () => {
 				const deleteHandler = eventHandlers.get('session.deleted');
 				await deleteHandler!({ sessionId: 'test-id' });
 
-				// Note: Global sessions list updates are now handled by LiveQuery (sessions.list)
-				expect(mockMessageHub.event).toHaveBeenCalledWith(
+				// Forwarding extracted to ClientEventBridge; StateManager only clears caches
+				expect(mockMessageHub.event).not.toHaveBeenCalledWith(
 					'session.deleted',
-					{ sessionId: 'test-id' },
-					{ channel: 'global' }
+					expect.anything(),
+					expect.anything()
 				);
+			});
+
+			it('should clean up channelVersions for deleted session', async () => {
+				// Seed channel versions by broadcasting
+				const mockAgentSession = {
+					getSessionData: mock(() => ({ id: 'test-id', title: 'Test' })),
+					getProcessingState: mock(() => ({ status: 'idle' })),
+					getSlashCommands: mock(async () => []),
+					getContextInfo: mock(() => null),
+					getSDKMessages: mock(() => ({ messages: [], hasMore: false })),
+				};
+				(mockSessionManager.getSessionAsync as ReturnType<typeof mock>).mockResolvedValue(
+					mockAgentSession
+				);
+
+				// Trigger broadcasts to populate channelVersions
+				await stateManager.broadcastSessionStateChange('test-id');
+				await stateManager.broadcastSDKMessagesChange('test-id');
+				await stateManager.broadcastSDKMessagesDelta('test-id', {
+					added: [{ id: 'msg1' }],
+					timestamp: Date.now(),
+				});
+
+				// Verify versions exist before deletion by checking messageHub was called
+				// (which means versions were incremented and used)
+				const callsBefore = (mockMessageHub.event as ReturnType<typeof mock>).mock.calls.length;
+				expect(callsBefore).toBeGreaterThan(0);
+
+				// Delete the session
+				const deleteHandler = eventHandlers.get('session.deleted');
+				await deleteHandler!({ sessionId: 'test-id' });
+
+				// After deletion, versions for that session should be gone.
+				// Verify by broadcasting again for the same sessionId — if cleanup
+				// worked, the version counter restarts from 1.
+				(mockMessageHub.event as ReturnType<typeof mock>).mockClear();
+				await stateManager.broadcastSessionStateChange('test-id');
+
+				const sessionCall = (mockMessageHub.event as ReturnType<typeof mock>).mock.calls.find(
+					(c: unknown[]) => c[0] === STATE_CHANNELS.SESSION
+				);
+				expect(sessionCall).toBeDefined();
+				expect((sessionCall![1] as { version: number }).version).toBe(1);
 			});
 		});
 
 		describe('auth.changed', () => {
-			it('should broadcast system state change', async () => {
-				const handler = eventHandlers.get('auth.changed');
-				await handler!();
-
-				expect(mockMessageHub.event).toHaveBeenCalledWith(
-					STATE_CHANNELS.GLOBAL_SYSTEM,
-					expect.objectContaining({
-						auth: expect.any(Object),
-					}),
-					{ channel: 'global' }
-				);
+			it('handler removed — forwarding fully extracted to ClientEventBridge', () => {
+				// StateManager no longer registers an auth.changed handler;
+				// ClientEventBridge subscribes to auth.changed and triggers
+				// broadcastSystemChange via the StateBroadcasts interface.
+				expect(eventHandlers.has('auth.changed')).toBe(false);
 			});
 		});
 
@@ -508,61 +546,31 @@ describe('StateManager', () => {
 		});
 
 		describe('commands.updated', () => {
-			it('should cache commands and broadcast', async () => {
-				const mockAgentSession = {
-					getSessionData: mock(() => ({ id: 'test-id', title: 'Test' })),
-					getProcessingState: mock(() => ({ status: 'idle' })),
-					getSlashCommands: mock(async () => ['cmd1', 'cmd2']),
-					getContextInfo: mock(() => null),
-				};
-				(mockSessionManager.getSessionAsync as ReturnType<typeof mock>).mockResolvedValue(
-					mockAgentSession
-				);
+			it('should cache commands only (broadcast extracted to ClientEventBridge)', async () => {
+				(mockMessageHub.event as ReturnType<typeof mock>).mockClear();
 
 				const handler = eventHandlers.get('commands.updated');
 				await handler!({ sessionId: 'test-id', commands: ['cmd1', 'cmd2'] });
 
-				expect(mockMessageHub.event).toHaveBeenCalledWith(
-					STATE_CHANNELS.SESSION,
-					expect.any(Object),
-					{ channel: 'session:test-id' }
-				);
+				// Forwarding extracted to ClientEventBridge; StateManager only caches
+				const calls = (mockMessageHub.event as ReturnType<typeof mock>).mock.calls;
+				const sessionCall = calls.find((call: unknown[]) => call[0] === STATE_CHANNELS.SESSION);
+				expect(sessionCall).toBeUndefined();
 			});
 		});
 
 		describe('context.updated', () => {
-			it('should cache context and broadcast', async () => {
-				const mockAgentSession = {
-					getSessionData: mock(() => ({ id: 'test-id', title: 'Test' })),
-					getProcessingState: mock(() => ({ status: 'idle' })),
-					getSlashCommands: mock(async () => []),
-					getContextInfo: mock(() => null),
-				};
-				(mockSessionManager.getSessionAsync as ReturnType<typeof mock>).mockResolvedValue(
-					mockAgentSession
-				);
-
-				const handler = eventHandlers.get('context.updated');
-				const contextInfo = { files: 5, tokens: 1000 };
-				await handler!({ sessionId: 'test-id', contextInfo });
-
-				expect(mockMessageHub.event).toHaveBeenCalledWith('context.updated', contextInfo, {
-					channel: 'session:test-id',
-				});
+			it('handler removed — forwarding fully extracted to ClientEventBridge', () => {
+				// StateManager no longer registers a context.updated handler;
+				// ClientEventBridge subscribes to context.updated and forwards
+				// through ClientEventGateway directly.
+				expect(eventHandlers.has('context.updated')).toBe(false);
 			});
 		});
 
 		describe('session.error', () => {
-			it('should cache error and broadcast', async () => {
-				const mockAgentSession = {
-					getSessionData: mock(() => ({ id: 'test-id', title: 'Test' })),
-					getProcessingState: mock(() => ({ status: 'idle' })),
-					getSlashCommands: mock(async () => []),
-					getContextInfo: mock(() => null),
-				};
-				(mockSessionManager.getSessionAsync as ReturnType<typeof mock>).mockResolvedValue(
-					mockAgentSession
-				);
+			it('should cache error only (broadcast extracted to ClientEventBridge)', async () => {
+				(mockMessageHub.event as ReturnType<typeof mock>).mockClear();
 
 				const handler = eventHandlers.get('session.error');
 				await handler!({
@@ -571,50 +579,29 @@ describe('StateManager', () => {
 					details: { code: 'ERR_001' },
 				});
 
-				expect(mockMessageHub.event).toHaveBeenCalledWith(
-					STATE_CHANNELS.SESSION,
-					expect.objectContaining({
-						error: expect.objectContaining({
-							message: 'Something went wrong',
-							details: { code: 'ERR_001' },
-						}),
-					}),
-					{ channel: 'session:test-id' }
-				);
+				// Forwarding extracted to ClientEventBridge; StateManager only caches
+				const calls = (mockMessageHub.event as ReturnType<typeof mock>).mock.calls;
+				const sessionCall = calls.find((call: unknown[]) => call[0] === STATE_CHANNELS.SESSION);
+				expect(sessionCall).toBeUndefined();
 			});
 		});
 
 		describe('session.errorClear', () => {
-			it('should clear error and broadcast', async () => {
-				const mockAgentSession = {
-					getSessionData: mock(() => ({ id: 'test-id', title: 'Test' })),
-					getProcessingState: mock(() => ({ status: 'idle' })),
-					getSlashCommands: mock(async () => []),
-					getContextInfo: mock(() => null),
-				};
-				(mockSessionManager.getSessionAsync as ReturnType<typeof mock>).mockResolvedValue(
-					mockAgentSession
-				);
+			it('should clear error only (broadcast extracted to ClientEventBridge)', async () => {
+				(mockMessageHub.event as ReturnType<typeof mock>).mockClear();
 
-				// First set an error
-				const errorHandler = eventHandlers.get('session.error');
-				await errorHandler!({
-					sessionId: 'test-id',
-					error: 'Error',
-				});
-
-				// Now clear it
 				const clearHandler = eventHandlers.get('session.errorClear');
 				await clearHandler!({ sessionId: 'test-id' });
 
-				// Should have been called multiple times (set error + clear error)
-				expect(mockMessageHub.event).toHaveBeenCalled();
+				// Forwarding extracted to ClientEventBridge; StateManager only clears cache
+				const calls = (mockMessageHub.event as ReturnType<typeof mock>).mock.calls;
+				const sessionCall = calls.find((call: unknown[]) => call[0] === STATE_CHANNELS.SESSION);
+				expect(sessionCall).toBeUndefined();
 			});
 		});
 
 		describe('api.connection', () => {
-			it('should update API connection state and broadcast', async () => {
-				// Reset mock to track new calls
+			it('should update API connection state only (broadcast extracted to ClientEventBridge)', async () => {
 				(mockMessageHub.event as ReturnType<typeof mock>).mockClear();
 
 				const handler = eventHandlers.get('api.connection');
@@ -624,21 +611,17 @@ describe('StateManager', () => {
 					timestamp: Date.now(),
 				};
 
-				// The api.connection handler calls broadcastSystemChange with .catch(),
-				// so we need to call it and wait for the async broadcast to complete
 				handler!(connectionData);
 
-				// Wait for the async broadcast to complete
+				// Give any async work time to complete
 				await new Promise((resolve) => setTimeout(resolve, 10));
 
-				// Check that the broadcast was made with the updated API connection state
+				// Forwarding extracted to ClientEventBridge; StateManager only updates cache
 				const calls = (mockMessageHub.event as ReturnType<typeof mock>).mock.calls;
 				const systemCall = calls.find(
 					(call: unknown[]) => call[0] === STATE_CHANNELS.GLOBAL_SYSTEM
 				);
-
-				expect(systemCall).toBeDefined();
-				expect(systemCall[1].apiConnection).toEqual(connectionData);
+				expect(systemCall).toBeUndefined();
 			});
 		});
 	});
@@ -779,41 +762,30 @@ describe('StateManager', () => {
 describe('ClientEventGateway DI seam', () => {
 	// ====================================================================
 	// ClientEventGateway DI seam — verifies that callers can inject a custom
-	// gateway and that the migrated forwarding slice (session.created /
-	// session.deleted / context.updated) actually flows through it.
+	// gateway into StateManager and that the gateway is exposed via
+	// getClientEventGateway() for sharing with ClientEventBridge.
 	//
-	// This is the core architectural pattern this PR introduces; the tests
-	// guard the seam against silent regressions if a future refactor swaps
-	// the gateway for a direct messageHub call again.
+	// Forwarding of session.created / session.deleted / context.updated now
+	// lives in ClientEventBridge (see client-event-bridge.test.ts).  These
+	// tests guard the injection seam itself against silent regressions.
 	// ====================================================================
-	// Build a fresh StateManager wired with a spied IClientEventGateway so we
-	// can assert on the typed `EventChannel` argument without going through
-	// the registry's wire serialization.
-	function buildWithSpiedGateway() {
-		const localEventHandlers = new Map<string, Function>();
-		const localRequestHandlers = new Map<string, Function>();
 
+	it('exposes the injected gateway via getClientEventGateway', () => {
 		const localMessageHub = {
 			event: mock(async () => {}),
-			onRequest: mock((method: string, handler: Function) => {
-				localRequestHandlers.set(method, handler);
-				return () => {};
-			}),
+			onRequest: mock(() => () => {}),
 			query: mock(async () => ({})),
 			command: mock(async () => {}),
 		} as unknown as MessageHub;
 
 		const localEventBus = {
-			on: mock((event: string, handler: Function) => {
-				localEventHandlers.set(event, handler);
-				return () => {};
-			}),
+			on: mock(() => () => {}),
 			emit: mock(async () => {}),
 		} as unknown as DaemonHub;
 
 		const publish = mock(() => {});
 		const publishGlobal = mock(() => {});
-		const clientEvents = { publish, publishGlobal };
+		const injectedGateway = { publish, publishGlobal };
 
 		const localSessionManager = {
 			getActiveSessions: mock(() => 2),
@@ -830,10 +802,7 @@ describe('ClientEventGateway DI seam', () => {
 		} as unknown as AuthManager;
 
 		const localSettingsManager = {
-			getGlobalSettings: mock(() => ({
-				...DEFAULT_GLOBAL_SETTINGS,
-				settingSources: ['user', 'project', 'local'],
-			})),
+			getGlobalSettings: mock(() => DEFAULT_GLOBAL_SETTINGS),
 		} as unknown as SettingsManager;
 
 		const localConfig = {
@@ -851,79 +820,14 @@ describe('ClientEventGateway DI seam', () => {
 			localEventBus,
 			undefined,
 			undefined,
-			clientEvents
+			injectedGateway
 		);
 
-		return { localMessageHub, localEventHandlers, publish, publishGlobal, sm };
-	}
-
-	it('routes session.created through the injected gateway with a typed global channel', async () => {
-		const { localMessageHub, localEventHandlers, publish } = buildWithSpiedGateway();
-
-		const handler = localEventHandlers.get('session.created');
-		expect(handler).toBeDefined();
-
-		await handler!({
-			session: { id: 'inj-1', title: 'X', status: 'active', metadata: {} } as Session,
-		});
-
-		expect(publish).toHaveBeenCalledWith(
-			'session.created',
-			{ sessionId: 'inj-1' },
-			{ kind: 'global' }
-		);
-		// And the gateway is the only path: no direct messageHub.event call
-		// for this method on the injected hub.
-		const directCalls = (localMessageHub.event as ReturnType<typeof mock>).mock.calls.filter(
-			(args) => args[0] === 'session.created'
-		);
-		expect(directCalls).toHaveLength(0);
-	});
-
-	it('routes session.deleted through the injected gateway with a typed global channel', async () => {
-		const { localMessageHub, localEventHandlers, publish } = buildWithSpiedGateway();
-
-		// Seed cache so the deleted handler runs cleanly.
-		await localEventHandlers.get('session.created')!({
-			session: { id: 'inj-2', title: 'X', status: 'active', metadata: {} } as Session,
-		});
-		(publish as ReturnType<typeof mock>).mockClear();
-
-		await localEventHandlers.get('session.deleted')!({ sessionId: 'inj-2' });
-
-		expect(publish).toHaveBeenCalledWith(
-			'session.deleted',
-			{ sessionId: 'inj-2' },
-			{ kind: 'global' }
-		);
-		const directCalls = (localMessageHub.event as ReturnType<typeof mock>).mock.calls.filter(
-			(args) => args[0] === 'session.deleted'
-		);
-		expect(directCalls).toHaveLength(0);
-	});
-
-	it('routes context.updated through the injected gateway with a typed session channel', async () => {
-		const { localEventHandlers, publish } = buildWithSpiedGateway();
-
-		const contextInfo = {
-			usedTokens: 1000,
-			maxTokens: 200000,
-			autoCompactThreshold: 0.85,
-		};
-
-		await localEventHandlers.get('context.updated')!({
-			sessionId: 'inj-3',
-			contextInfo,
-		});
-
-		expect(publish).toHaveBeenCalledWith('context.updated', contextInfo, {
-			kind: 'session',
-			sessionId: 'inj-3',
-		});
+		const gateway = sm.getClientEventGateway();
+		expect(gateway).toBe(injectedGateway);
 	});
 
 	it('falls back to a default ClientEventGateway when none is injected', async () => {
-		// Build a StateManager WITHOUT injecting a custom gateway.
 		const localMessageHub = {
 			event: mock(async () => {}),
 			onRequest: mock(() => () => {}),


### PR DESCRIPTION
Extract all daemon-to-client event forwarding from StateManager into ClientEventBridge.

**What changed:**
- Added `StateBroadcasts` interface exposing 5 broadcast methods from StateManager
- Added `SESSION_BRIDGE_MAPPINGS` for session.created, session.deleted, context.updated
- Added explicit broadcast subscriptions in `start()` for api.connection, auth.changed, commands.updated, session.error, session.errorClear
- New `subscribeBroadcast()` private method for events that trigger StateManager broadcasts
- Constructor now accepts optional `broadcasts?: StateBroadcasts`
- StateManager `setupEventListeners()` rewritten to only update caches, no client forwarding
- Fixed `channelVersions` cleanup on `session.deleted` to remove SESSION, SESSION_SDK_MESSAGES, and SESSION_SDK_MESSAGES.delta channels
- Updated tests: 24 handlers in bridge, DI seam tests verify gateway injection

**Architecture:** State projection (caching) is now fully separate from client event forwarding. TypedHub's sequential handler ordering guarantees cache updates complete before bridge broadcasts.