### PR TITLE
feat(space): server-side pagination for task list groups

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/space-task-handlers.ts
@@ -12,7 +12,10 @@ import {
 	isWorkflowRecoveryTransition,
 	type CreateSpaceTaskParams,
 	type MessageHub,
+	type PaginatedSpaceTaskResult,
+	type SpaceBlockReason,
 	type SpaceTask,
+	type SpaceTaskStatus,
 	type UpdateSpaceTaskParams,
 } from '@neokai/shared';
 import type { DaemonHub } from '../daemon-hub';
@@ -85,8 +88,35 @@ export function setupSpaceTaskHandlers(
 	});
 
 	// ─── spaceTask.list ─────────────────────────────────────────────────────────
+	//
+	// Two response shapes for backward compatibility:
+	//
+	//   1. Legacy / overview call: `{ spaceId, includeArchived? }` →
+	//      returns `SpaceTask[]` (full list, no pagination). Used by the
+	//      initial space-overview load, sidebar badge counts, and tab counts.
+	//
+	//   2. Paginated single-group call: any of `status`, `limit`, `offset`,
+	//      or `blockReason` provided → returns `PaginatedSpaceTaskResult`
+	//      `{ tasks, total }`. Used by the Tasks view's per-group Prev/Next
+	//      pagination (10 items per status group).
+	//
+	// `blockReason` is treated as a tri-state filter: omitted (undefined) =
+	// ignore the column; `null` = match rows with no reason set; a value =
+	// match exactly. The Action tab uses this to split blocked rows into
+	// "Needs Input" / "Gate Pending" / generic-"Blocked" buckets. `blockReason`
+	// requires `status === 'blocked'` — combining it with another status
+	// filter would silently return an empty page (the data shape doesn't
+	// support that combination), so we reject it loudly instead.
 	messageHub.onRequest('spaceTask.list', async (data) => {
-		const params = data as { spaceId: string; includeArchived?: boolean };
+		const params = data as {
+			spaceId: string;
+			includeArchived?: boolean;
+			status?: SpaceTaskStatus;
+			blockReason?: SpaceBlockReason | null;
+			blockReasonNotIn?: SpaceBlockReason[];
+			limit?: number;
+			offset?: number;
+		};
 
 		if (!params.spaceId) {
 			throw new Error('spaceId is required');
@@ -99,7 +129,48 @@ export function setupSpaceTaskHandlers(
 		}
 
 		const taskManager = taskManagerFactory(params.spaceId);
-		return taskManager.listTasks(params.includeArchived ?? false);
+
+		const usePagination =
+			params.status !== undefined ||
+			params.limit !== undefined ||
+			params.offset !== undefined ||
+			params.blockReason !== undefined ||
+			params.blockReasonNotIn !== undefined;
+
+		if (!usePagination) {
+			return taskManager.listTasks(params.includeArchived ?? false);
+		}
+
+		if (params.status === undefined) {
+			throw new Error('status is required when paginating spaceTask.list');
+		}
+		if (
+			(params.blockReason !== undefined || params.blockReasonNotIn !== undefined) &&
+			params.status !== 'blocked'
+		) {
+			throw new Error("blockReason / blockReasonNotIn filter requires status === 'blocked'");
+		}
+		if (params.blockReason !== undefined && params.blockReasonNotIn !== undefined) {
+			throw new Error('blockReason and blockReasonNotIn are mutually exclusive');
+		}
+
+		const limit = params.limit ?? 10;
+		const offset = params.offset ?? 0;
+		if (!Number.isFinite(limit) || limit <= 0) {
+			throw new Error('limit must be a positive number');
+		}
+		if (!Number.isFinite(offset) || offset < 0) {
+			throw new Error('offset must be a non-negative number');
+		}
+
+		const result: PaginatedSpaceTaskResult = await taskManager.listTasksByStatusPaginated(
+			params.status,
+			params.blockReason,
+			limit,
+			offset,
+			params.blockReasonNotIn
+		);
+		return result;
 	});
 
 	// ─── spaceTask.get ──────────────────────────────────────────────────────────

--- a/packages/daemon/src/lib/space/managers/space-task-manager.ts
+++ b/packages/daemon/src/lib/space/managers/space-task-manager.ts
@@ -116,6 +116,37 @@ export class SpaceTaskManager {
 	}
 
 	/**
+	 * List tasks by status, paginated, with the total count for the matching set.
+	 *
+	 * Used by the UI Tasks view to render a single TaskGroup card with Prev/Next
+	 * pagination. `blockReason` is an optional secondary filter so the Action
+	 * tab can split blocked tasks into "Needs Input" / "Gate Pending" / generic
+	 * "Blocked" groups without round-tripping the whole status set.
+	 *
+	 * Pass `blockReason: null` to filter for blocked rows with no reason set;
+	 * omit the param to ignore the column entirely. `blockReasonNotIn` is the
+	 * inverse — used by the generic "Blocked" bucket to include every blocked
+	 * row whose reason is NOT one of the attention-required values. The two
+	 * filters are mutually exclusive.
+	 */
+	async listTasksByStatusPaginated(
+		status: SpaceTaskStatus,
+		blockReason: SpaceBlockReason | null | undefined,
+		limit: number,
+		offset = 0,
+		blockReasonNotIn?: SpaceBlockReason[]
+	): Promise<{ tasks: SpaceTask[]; total: number }> {
+		return this.taskRepo.listBySpaceAndStatus(
+			this.spaceId,
+			status,
+			blockReason,
+			limit,
+			offset,
+			blockReasonNotIn
+		);
+	}
+
+	/**
 	 * List tasks belonging to a specific workflow run
 	 */
 	async listTasksByWorkflowRun(workflowRunId: string): Promise<SpaceTask[]> {

--- a/packages/daemon/src/storage/repositories/space-task-repository.ts
+++ b/packages/daemon/src/storage/repositories/space-task-repository.ts
@@ -8,6 +8,7 @@ import type { Database as BunDatabase } from 'bun:sqlite';
 import { generateUUID } from '@neokai/shared';
 import type {
 	SpaceTask,
+	SpaceBlockReason,
 	SpaceTaskStatus,
 	CreateSpaceTaskParams,
 	UpdateSpaceTaskParams,
@@ -165,6 +166,78 @@ export class SpaceTaskRepository {
 		const stmt = this.db.prepare(query);
 		const rows = stmt.all(spaceId, status) as Record<string, unknown>[];
 		return rows.map((r) => this.rowToSpaceTask(r));
+	}
+
+	/**
+	 * List tasks by status within a space, optionally filtered by block reason,
+	 * paginated, returning both the page of tasks and the total count.
+	 *
+	 * Used by the UI Tasks view to render a single status group (e.g.
+	 * "In Progress") with Prev/Next pagination buttons. The total is computed
+	 * with a separate `COUNT(*)` so the caller can render "Showing X–Y of Z" and
+	 * disable Next when the offset reaches the end of the page list.
+	 *
+	 * @param spaceId         Space scope.
+	 * @param status          Status to filter on (required — pagination is per-group).
+	 * @param blockReason     Optional block_reason filter — used by the Action tab to
+	 *                        match the "Needs Input" / "Gate Pending" buckets.
+	 *                        Tri-state: `undefined` ignores the column, `null`
+	 *                        matches rows with no reason set, a value matches
+	 *                        exactly. Mutually exclusive with `blockReasonNotIn`.
+	 * @param blockReasonNotIn Optional negative block_reason filter — used by the
+	 *                        Action tab's generic "Blocked" bucket to include
+	 *                        every blocked row whose reason is NOT one of the
+	 *                        attention-required values, mirroring the original
+	 *                        client-side filter.
+	 * @param limit           Page size (defaults to all matching when 0/undefined).
+	 * @param offset          Page offset.
+	 */
+	listBySpaceAndStatus(
+		spaceId: string,
+		status: SpaceTaskStatus,
+		blockReason: SpaceBlockReason | null | undefined,
+		limit?: number,
+		offset = 0,
+		blockReasonNotIn?: SpaceBlockReason[]
+	): { tasks: SpaceTask[]; total: number } {
+		if (blockReason !== undefined && blockReasonNotIn && blockReasonNotIn.length > 0) {
+			throw new Error('blockReason and blockReasonNotIn are mutually exclusive');
+		}
+
+		const filterParams: SQLiteValue[] = [spaceId, status];
+		let where = `WHERE space_id = ? AND status = ?`;
+		if (blockReason !== undefined) {
+			if (blockReason === null) {
+				// Explicit null filter: no block reason. Used to render the generic
+				// "Blocked" bucket distinctly from the attention-required ones.
+				where += ` AND block_reason IS NULL`;
+			} else {
+				where += ` AND block_reason = ?`;
+				filterParams.push(blockReason);
+			}
+		} else if (blockReasonNotIn && blockReasonNotIn.length > 0) {
+			// IS NULL union with NOT IN — without it SQLite would discard rows
+			// where block_reason is NULL because `NULL NOT IN (...)` yields NULL,
+			// and we want unset-reason blocked rows to land in the generic bucket.
+			const placeholders = blockReasonNotIn.map(() => '?').join(', ');
+			where += ` AND (block_reason IS NULL OR block_reason NOT IN (${placeholders}))`;
+			for (const reason of blockReasonNotIn) filterParams.push(reason);
+		}
+
+		const countRow = this.db
+			.prepare(`SELECT COUNT(*) AS total FROM space_tasks ${where}`)
+			.get(...filterParams) as { total: number } | undefined;
+		const total = countRow?.total ?? 0;
+
+		let pageQuery = `SELECT * FROM space_tasks ${where} ORDER BY updated_at DESC, id DESC`;
+		const pageParams: SQLiteValue[] = [...filterParams];
+		if (limit && limit > 0) {
+			pageQuery += ` LIMIT ? OFFSET ?`;
+			pageParams.push(limit, offset);
+		}
+
+		const rows = this.db.prepare(pageQuery).all(...pageParams) as Record<string, unknown>[];
+		return { tasks: rows.map((r) => this.rowToSpaceTask(r)), total };
 	}
 
 	/**

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/space-task-handlers.test.ts
@@ -103,6 +103,10 @@ function createMockTaskManager(task: SpaceTask | null = mockTask): SpaceTaskMana
 		createTask: mock(async () => task!),
 		getTask: mock(async () => task),
 		listTasks: mock(async () => (task ? [task] : [])),
+		listTasksByStatusPaginated: mock(async () => ({
+			tasks: task ? [task] : [],
+			total: task ? 1 : 0,
+		})),
 		setTaskStatus: mock(async () => ({ ...task!, status: 'in_progress' as const })),
 		updateTask: mock(async () => ({ ...task!, title: 'Updated' })),
 		updateTaskProgress: mock(async () => ({ ...task!, progress: 50 })),
@@ -290,6 +294,128 @@ describe('space-task-handlers', () => {
 			await expect(call('spaceTask.list', { spaceId: 'ghost' })).rejects.toThrow(
 				'Space not found: ghost'
 			);
+		});
+
+		describe('paginated mode', () => {
+			it('routes to listTasksByStatusPaginated with status + limit + offset', async () => {
+				const result = await call('spaceTask.list', {
+					spaceId: 'space-1',
+					status: 'in_progress',
+					limit: 10,
+					offset: 20,
+				});
+
+				expect(taskManager.listTasksByStatusPaginated).toHaveBeenCalledWith(
+					'in_progress',
+					undefined,
+					10,
+					20,
+					undefined
+				);
+				expect(result).toEqual({ tasks: [mockTask], total: 1 });
+			});
+
+			it('forwards a blockReason filter when provided', async () => {
+				await call('spaceTask.list', {
+					spaceId: 'space-1',
+					status: 'blocked',
+					blockReason: 'human_input_requested',
+					limit: 10,
+				});
+
+				expect(taskManager.listTasksByStatusPaginated).toHaveBeenCalledWith(
+					'blocked',
+					'human_input_requested',
+					10,
+					0,
+					undefined
+				);
+			});
+
+			it('forwards an explicit null blockReason', async () => {
+				await call('spaceTask.list', {
+					spaceId: 'space-1',
+					status: 'blocked',
+					blockReason: null,
+				});
+
+				expect(taskManager.listTasksByStatusPaginated).toHaveBeenCalledWith(
+					'blocked',
+					null,
+					10, // default limit
+					0,
+					undefined
+				);
+			});
+
+			it('forwards a blockReasonNotIn filter', async () => {
+				await call('spaceTask.list', {
+					spaceId: 'space-1',
+					status: 'blocked',
+					blockReasonNotIn: ['human_input_requested', 'gate_rejected'],
+				});
+
+				expect(taskManager.listTasksByStatusPaginated).toHaveBeenCalledWith(
+					'blocked',
+					undefined,
+					10,
+					0,
+					['human_input_requested', 'gate_rejected']
+				);
+			});
+
+			it('rejects blockReason without status=blocked', async () => {
+				await expect(
+					call('spaceTask.list', {
+						spaceId: 'space-1',
+						status: 'in_progress',
+						blockReason: 'human_input_requested',
+					})
+				).rejects.toThrow(/status === 'blocked'/);
+			});
+
+			it('rejects combining blockReason and blockReasonNotIn', async () => {
+				await expect(
+					call('spaceTask.list', {
+						spaceId: 'space-1',
+						status: 'blocked',
+						blockReason: 'human_input_requested',
+						blockReasonNotIn: ['gate_rejected'],
+					})
+				).rejects.toThrow(/mutually exclusive/);
+			});
+
+			it('rejects pagination params without a status', async () => {
+				await expect(call('spaceTask.list', { spaceId: 'space-1', limit: 10 })).rejects.toThrow(
+					/status is required/
+				);
+			});
+
+			it('rejects non-positive limit', async () => {
+				await expect(
+					call('spaceTask.list', { spaceId: 'space-1', status: 'open', limit: 0 })
+				).rejects.toThrow(/limit must be a positive number/);
+				await expect(
+					call('spaceTask.list', { spaceId: 'space-1', status: 'open', limit: -1 })
+				).rejects.toThrow(/limit must be a positive number/);
+			});
+
+			it('rejects negative offset', async () => {
+				await expect(
+					call('spaceTask.list', { spaceId: 'space-1', status: 'open', offset: -1 })
+				).rejects.toThrow(/offset must be a non-negative number/);
+			});
+
+			it('defaults limit to 10 and offset to 0 when only status provided', async () => {
+				await call('spaceTask.list', { spaceId: 'space-1', status: 'open' });
+				expect(taskManager.listTasksByStatusPaginated).toHaveBeenCalledWith(
+					'open',
+					undefined,
+					10,
+					0,
+					undefined
+				);
+			});
 		});
 	});
 

--- a/packages/daemon/tests/unit/4-space-storage/storage/space-task-repository.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/space-task-repository.test.ts
@@ -161,6 +161,136 @@ describe('SpaceTaskRepository', () => {
 		});
 	});
 
+	describe('listBySpaceAndStatus (paginated)', () => {
+		// Helper to seed N tasks at the same status; spaces them out by 1ms so
+		// updated_at ordering is stable. Returns tasks in creation order.
+		const seedTasks = (
+			n: number,
+			status: 'open' | 'in_progress' | 'blocked' = 'in_progress',
+			blockReason?: string | null
+		) => {
+			const ids: string[] = [];
+			for (let i = 0; i < n; i++) {
+				const t = repo.createTask({
+					spaceId,
+					title: `Task ${i}`,
+					description: '',
+					status,
+				});
+				if (blockReason !== undefined) {
+					(db as any)
+						.prepare('UPDATE space_tasks SET block_reason = ? WHERE id = ?')
+						.run(blockReason, t.id);
+				}
+				// Force monotonic updated_at so ordering is deterministic.
+				(db as any)
+					.prepare('UPDATE space_tasks SET updated_at = ? WHERE id = ?')
+					.run(Date.now() + i, t.id);
+				ids.push(t.id);
+			}
+			return ids;
+		};
+
+		it('returns the page slice and the total count', () => {
+			seedTasks(15, 'in_progress');
+
+			const page1 = repo.listBySpaceAndStatus(spaceId, 'in_progress', undefined, 10, 0);
+			expect(page1.tasks).toHaveLength(10);
+			expect(page1.total).toBe(15);
+
+			const page2 = repo.listBySpaceAndStatus(spaceId, 'in_progress', undefined, 10, 10);
+			expect(page2.tasks).toHaveLength(5);
+			expect(page2.total).toBe(15);
+
+			// No overlap between pages.
+			const page1Ids = new Set(page1.tasks.map((t) => t.id));
+			for (const t of page2.tasks) expect(page1Ids.has(t.id)).toBe(false);
+		});
+
+		it('returns total=0 and an empty page when no tasks match', () => {
+			seedTasks(3, 'open');
+			const page = repo.listBySpaceAndStatus(spaceId, 'in_progress', undefined, 10, 0);
+			expect(page.tasks).toHaveLength(0);
+			expect(page.total).toBe(0);
+		});
+
+		it('orders by updated_at desc so newest tasks land on page 1', () => {
+			const ids = seedTasks(3, 'in_progress');
+			const page = repo.listBySpaceAndStatus(spaceId, 'in_progress', undefined, 10, 0);
+			expect(page.tasks[0].id).toBe(ids[2]);
+			expect(page.tasks[2].id).toBe(ids[0]);
+		});
+
+		it('filters by an exact block_reason value', () => {
+			seedTasks(2, 'blocked', 'human_input_requested');
+			seedTasks(3, 'blocked', 'gate_rejected');
+			seedTasks(1, 'blocked', null);
+
+			const needsInput = repo.listBySpaceAndStatus(
+				spaceId,
+				'blocked',
+				'human_input_requested' as any,
+				10,
+				0
+			);
+			expect(needsInput.total).toBe(2);
+			expect(needsInput.tasks).toHaveLength(2);
+
+			const gates = repo.listBySpaceAndStatus(spaceId, 'blocked', 'gate_rejected' as any, 10, 0);
+			expect(gates.total).toBe(3);
+		});
+
+		it('filters by null block_reason when blockReason is explicitly null', () => {
+			seedTasks(2, 'blocked', 'human_input_requested');
+			seedTasks(3, 'blocked', null);
+
+			const noReason = repo.listBySpaceAndStatus(spaceId, 'blocked', null, 10, 0);
+			expect(noReason.total).toBe(3);
+			expect(noReason.tasks).toHaveLength(3);
+			for (const t of noReason.tasks) expect(t.blockReason).toBeNull();
+		});
+
+		it('ignores block_reason when blockReason is undefined', () => {
+			seedTasks(2, 'blocked', 'human_input_requested');
+			seedTasks(1, 'blocked', null);
+
+			const all = repo.listBySpaceAndStatus(spaceId, 'blocked', undefined, 10, 0);
+			expect(all.total).toBe(3);
+		});
+
+		it('excludes attention reasons via blockReasonNotIn (and includes null reasons)', () => {
+			seedTasks(2, 'blocked', 'human_input_requested');
+			seedTasks(1, 'blocked', 'gate_rejected');
+			seedTasks(2, 'blocked', 'agent_crashed');
+			seedTasks(1, 'blocked', null);
+
+			const generic = repo.listBySpaceAndStatus(spaceId, 'blocked', undefined, 10, 0, [
+				'human_input_requested' as any,
+				'gate_rejected' as any,
+			]);
+			// Should include 2 agent_crashed + 1 null = 3, excluding the 3 attention rows.
+			expect(generic.total).toBe(3);
+			for (const t of generic.tasks) {
+				expect(t.blockReason === null || t.blockReason === 'agent_crashed').toBe(true);
+			}
+		});
+
+		it('rejects combining blockReason and blockReasonNotIn', () => {
+			expect(() =>
+				repo.listBySpaceAndStatus(spaceId, 'blocked', 'human_input_requested' as any, 10, 0, [
+					'gate_rejected' as any,
+				])
+			).toThrow(/mutually exclusive/);
+		});
+
+		it('returns all matching tasks when limit is omitted', () => {
+			seedTasks(15, 'in_progress');
+			const page = repo.listBySpaceAndStatus(spaceId, 'in_progress', undefined);
+			expect(page.tasks).toHaveLength(15);
+			expect(page.total).toBe(15);
+		});
+	});
+
 	describe('updateTask', () => {
 		it('updates status and sets started_at for in_progress', () => {
 			const task = repo.createTask({ spaceId, title: 'T', description: '' });

--- a/packages/shared/src/types/space.ts
+++ b/packages/shared/src/types/space.ts
@@ -464,6 +464,16 @@ export interface SpaceTask {
 }
 
 /**
+ * Paginated result for `spaceTask.list` when called with pagination params
+ * (`status` + `limit`/`offset`). Returned alongside the legacy bare-array shape
+ * so callers can opt into pagination per-call without breaking existing consumers.
+ */
+export interface PaginatedSpaceTaskResult {
+	tasks: SpaceTask[];
+	total: number;
+}
+
+/**
  * One live participant in a task's execution.
  * This can be the orchestration Task Agent or a spawned node agent sub-session.
  */

--- a/packages/web/src/components/space/SpaceTasks.tsx
+++ b/packages/web/src/components/space/SpaceTasks.tsx
@@ -349,6 +349,8 @@ function TaskGroup({
 	taskById,
 	onTaskClick,
 	pagination,
+	loading,
+	error,
 }: {
 	title: string;
 	count: number;
@@ -369,6 +371,18 @@ function TaskGroup({
 		onNext: () => void;
 		isLoading?: boolean;
 	};
+	/**
+	 * `true` while a paginated fetch is in flight. Used to render a loading
+	 * placeholder in place of (potentially stale) rows so the user can't
+	 * click into a task that no longer belongs to the visible page range.
+	 */
+	loading?: boolean;
+	/**
+	 * Error state for paginated groups. When set, an inline banner replaces
+	 * the rows and surfaces a Retry control. Pagination footer is preserved
+	 * so the user retains a navigation path even after a failed fetch.
+	 */
+	error?: { message: string; onRetry?: () => void } | null;
 }) {
 	const headerStyles: Record<string, string> = {
 		default: '',
@@ -399,6 +413,40 @@ function TaskGroup({
 
 	const showPagination = !!pagination && pagination.total > pagination.limit;
 
+	// Body precedence: error > loading-without-rows > rows. We deliberately
+	// render the loading placeholder when `tasks.length === 0` because the
+	// parent (`PaginatedTaskGroup`) clears the row list while a new page is
+	// fetching to prevent click-through to stale rows.
+	const body = error ? (
+		<div
+			class="px-4 py-6 text-sm text-red-400 flex items-center justify-between gap-3"
+			data-testid="task-group-error"
+			role="alert"
+		>
+			<span>{error.message}</span>
+			{error.onRetry && (
+				<button
+					type="button"
+					class="px-2 py-1 text-xs rounded text-gray-300 hover:bg-dark-700"
+					onClick={error.onRetry}
+					data-testid="task-group-retry"
+				>
+					Retry
+				</button>
+			)}
+		</div>
+	) : loading && tasks.length === 0 ? (
+		<div class="px-4 py-6 text-xs text-gray-500" data-testid="task-group-loading" aria-busy="true">
+			Loading…
+		</div>
+	) : (
+		<div class="divide-y divide-dark-700">
+			{tasks.map((task) => (
+				<TaskItem key={task.id} task={task} taskById={taskById} onClick={onTaskClick} />
+			))}
+		</div>
+	);
+
 	return (
 		<div class={`bg-dark-850 border rounded-xl overflow-hidden ${borderStyles[variant]}`}>
 			<div
@@ -408,11 +456,7 @@ function TaskGroup({
 					{title} ({count})
 				</h3>
 			</div>
-			<div class="divide-y divide-dark-700">
-				{tasks.map((task) => (
-					<TaskItem key={task.id} task={task} taskById={taskById} onClick={onTaskClick} />
-				))}
-			</div>
+			{body}
 			{showPagination && pagination && (
 				<TaskGroupPagination
 					offset={pagination.offset}
@@ -694,6 +738,7 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 						tasks={tasks}
 						taskById={taskById}
 						tab={activeTab as Exclude<TaskFilterTab, 'scheduled'>}
+						spaceId={spaceId}
 						onTaskClick={onSelectTask}
 					/>
 				)}
@@ -809,11 +854,13 @@ function TaskGroupList({
 	tasks,
 	taskById,
 	tab,
+	spaceId,
 	onTaskClick,
 }: {
 	tasks: SpaceTask[];
 	taskById: ReadonlyMap<string, SpaceTask>;
 	tab: Exclude<TaskFilterTab, 'scheduled'>;
+	spaceId: string;
 	onTaskClick?: (taskId: string) => void;
 }) {
 	const groups = TAB_GROUPS_DEF[tab];
@@ -827,18 +874,31 @@ function TaskGroupList({
 				// before the paginated fetch lands). The actual page contents are
 				// fetched server-side from `PaginatedTaskGroup`.
 				const matchFn = group.matchFn ?? ((t: SpaceTask) => t.status === group.status);
-				const localCount = tasks.filter(matchFn).length;
+				const matching = tasks.filter(matchFn);
+				const localCount = matching.length;
 
 				// Skip rendering empty groups, mirroring the legacy behaviour.
 				// Using the local count here means we don't fire a network
 				// request just to learn there's nothing to show.
 				if (localCount === 0) return null;
 
+				// Content signature: changes whenever any task in this group is
+				// added, removed, or mutated (title/result/updatedAt). Triggers a
+				// refetch even when the count is stable, so edits and reorderings
+				// land in the paginated view in real time. Sorted so the order of
+				// updates within `tasks` doesn't churn the signature.
+				const contentSig = matching
+					.map((t) => `${t.id}:${t.updatedAt ?? 0}`)
+					.sort()
+					.join('|');
+
 				return (
 					<PaginatedTaskGroup
 						key={`${tab}-${group.title}`}
+						spaceId={spaceId}
 						group={group}
 						localCount={localCount}
+						contentSig={contentSig}
 						taskById={taskById}
 						onTaskClick={onTaskClick}
 					/>
@@ -850,8 +910,9 @@ function TaskGroupList({
 
 /**
  * Wrapper that owns per-group pagination state. Fetches a single page of
- * tasks for the group's status (and optional `blockReason` filter) on mount
- * and on offset changes via `spaceStore.fetchTaskGroup`.
+ * tasks for the group's status (and optional `blockReason` filter) on mount,
+ * on offset changes, and whenever any task in the group is mutated (title,
+ * result, `updatedAt`, etc.) — see `contentSig`.
  *
  * Parent renders the badge count from the live `tasks` signal so the header
  * updates instantly on real-time task changes; the paginated body is fetched
@@ -860,13 +921,23 @@ function TaskGroupList({
  * the current page so paginated rows reflect the change.
  */
 function PaginatedTaskGroup({
+	spaceId,
 	group,
 	localCount,
+	contentSig,
 	taskById,
 	onTaskClick,
 }: {
+	spaceId: string;
 	group: StatusGroupDef;
 	localCount: number;
+	/**
+	 * Signature derived from the full set of group-matching tasks (ids +
+	 * `updatedAt`). Bumping this re-runs the fetch so edits that don't change
+	 * the count (title/result tweaks, dependency edits, `updatedAt` reorders
+	 * within the same status) still refresh the visible page.
+	 */
+	contentSig: string;
 	taskById: ReadonlyMap<string, SpaceTask>;
 	onTaskClick?: (taskId: string) => void;
 }) {
@@ -876,19 +947,34 @@ function PaginatedTaskGroup({
 		total: 0,
 	});
 	const [loading, setLoading] = useState(false);
+	const [hasError, setHasError] = useState(false);
+	// Tracks whether the in-flight fetch was triggered by a Prev/Next click as
+	// opposed to a real-time content refresh. Only the former should clear the
+	// visible rows so the user can't open a task that no longer belongs to the
+	// page range shown in the footer; real-time refreshes keep rows visible to
+	// avoid flicker on every `space.task.updated` tick.
+	const [pageChanging, setPageChanging] = useState(false);
+	// Bumped by the Retry button to force the fetch effect to rerun on the
+	// same offset. Avoids hand-rolling an out-of-effect fetcher with its own
+	// cancellation logic.
+	const [retryNonce, setRetryNonce] = useState(0);
 
-	// Reset offset to 0 if the group identity changes (e.g. user switches tab).
-	// Using the title + status combo as the key avoids stale offsets when
-	// remounting under a different tab.
-	const groupKey = `${group.title}-${group.status}-${group.blockReason ?? ''}`;
+	// Reset offset to 0 when the group identity changes (tab switch, or — more
+	// importantly — when the user navigates between spaces while staying on
+	// the Tasks view: a stable `(title, status, blockReason)` triple across
+	// spaces would otherwise leak rows from the previous space's first page
+	// until something else churned the deps).
+	const groupKey = `${spaceId}-${group.title}-${group.status}-${group.blockReason ?? ''}`;
 	useEffect(() => {
 		setOffset(0);
 	}, [groupKey]);
 
-	// Re-fetch when the local count changes too — keeps the visible page
-	// fresh when tasks are added, updated, or removed without forcing the
-	// user to click Prev/Next. The local count is derived from the same
-	// real-time `tasks` signal that drives badge counts.
+	// Re-fetch when:
+	//  - `groupKey` changes — different group/space identity
+	//  - `offset` changes — Prev/Next clicks
+	//  - `contentSig` changes — any task in the group was edited or reordered
+	//    (title, result, `updatedAt`); count-stable edits would otherwise be
+	//    invisible until the user paginated.
 	useEffect(() => {
 		let cancelled = false;
 		setLoading(true);
@@ -901,6 +987,7 @@ function PaginatedTaskGroup({
 			})
 			.then((result) => {
 				if (cancelled) return;
+				setHasError(false);
 				setPage(result);
 
 				// Clamp offset if total shrank (e.g. tasks moved to another
@@ -915,41 +1002,66 @@ function PaginatedTaskGroup({
 			})
 			.catch(() => {
 				if (cancelled) return;
-				// Fall back to an empty page on error — group will collapse via
-				// the localCount === 0 check on next render if the count is
-				// also zero, otherwise the user can hit Prev/Next to retry.
-				setPage({ tasks: [], total: 0 });
+				// Keep the previous page's `total` so Prev/Next remain visible
+				// and the user can click them to retry — collapsing to zero
+				// would strand the user on a blank card with no in-UI recovery
+				// after a transient RPC/network failure. Visible rows are
+				// dropped (they may now be stale) and an inline error banner
+				// is rendered in their place.
+				setHasError(true);
+				setPage((prev) => ({ tasks: [], total: prev.total }));
 			})
 			.finally(() => {
 				if (cancelled) return;
 				setLoading(false);
+				setPageChanging(false);
 			});
 		return () => {
 			cancelled = true;
 		};
-		// `groupKey` captures all server-filter inputs; `localCount` triggers
-		// a refresh on real-time changes; `offset` drives Prev/Next.
-	}, [groupKey, offset, localCount]);
+	}, [groupKey, offset, contentSig, retryNonce]);
 
 	// Use the server total once we have it; before the first fetch resolves,
 	// fall back to the local count so the header doesn't flash "(0)" for
 	// non-empty groups during initial load.
 	const headerCount = page.total || localCount;
 
+	// Manual retry handler used by the inline error banner. Bumps a nonce so
+	// the fetch effect reruns on the same `offset` without duplicating
+	// fetch/cancellation logic.
+	const retry = () => {
+		setHasError(false);
+		setRetryNonce((n) => n + 1);
+	};
+
 	return (
 		<TaskGroup
 			title={group.title}
 			count={headerCount}
 			variant={group.variant}
-			tasks={page.tasks}
+			// While a Prev/Next page change is in flight (or after an error),
+			// hide the previous page's rows so the user can't open a task that
+			// no longer belongs to the range shown in the footer ("Showing
+			// 11–20" with rows 1–10 still on screen would mismatch click
+			// targets). Real-time content refreshes (`contentSig` changes)
+			// keep rows visible to avoid flicker on every `task.updated` tick.
+			tasks={pageChanging || hasError ? [] : page.tasks}
 			taskById={taskById}
 			onTaskClick={onTaskClick}
+			loading={pageChanging}
+			error={hasError ? { message: 'Failed to load tasks.', onRetry: retry } : null}
 			pagination={{
 				offset,
 				limit: TASK_GROUP_PAGE_SIZE,
 				total: page.total,
-				onPrev: () => setOffset((o) => Math.max(0, o - TASK_GROUP_PAGE_SIZE)),
-				onNext: () => setOffset((o) => o + TASK_GROUP_PAGE_SIZE),
+				onPrev: () => {
+					setPageChanging(true);
+					setOffset((o) => Math.max(0, o - TASK_GROUP_PAGE_SIZE));
+				},
+				onNext: () => {
+					setPageChanging(true);
+					setOffset((o) => o + TASK_GROUP_PAGE_SIZE);
+				},
 				isLoading: loading,
 			}}
 		/>

--- a/packages/web/src/components/space/SpaceTasks.tsx
+++ b/packages/web/src/components/space/SpaceTasks.tsx
@@ -77,8 +77,29 @@ interface StatusGroupDef {
 	status: SpaceTaskStatus;
 	title: string;
 	variant: 'default' | 'yellow' | 'purple' | 'green' | 'red' | 'gray';
-	/** Optional filter override; when provided, used instead of status-only matching */
-	filterFn?: (task: SpaceTask) => boolean;
+	/**
+	 * Optional secondary `block_reason` filter applied server-side. Used by
+	 * the Action tab to split blocked rows into "Needs Input" /
+	 * "Gate Pending" / generic-"Blocked" groups via the same paginated
+	 * `spaceTask.list` RPC. Tri-state: `undefined` = ignore the column,
+	 * `null` = match rows with no reason set, value = match exactly.
+	 */
+	blockReason?: SpaceBlockReason | null;
+	/**
+	 * Optional negative `block_reason` filter applied server-side. Mutually
+	 * exclusive with `blockReason`. Used by the Action tab's generic
+	 * "Blocked" bucket to include every blocked row whose reason is NOT one
+	 * of the attention-required values, plus rows with no reason set —
+	 * mirroring the legacy client-side filter.
+	 */
+	blockReasonNotIn?: SpaceBlockReason[];
+	/**
+	 * Local predicate run against the full `tasks` signal, used only to
+	 * compute the badge count shown in the group header. Mirrors the
+	 * server-side filter exactly so badge counts match the page total
+	 * the server returns. Defaults to a status-only match.
+	 */
+	matchFn?: (task: SpaceTask) => boolean;
 }
 
 const ACTION_GROUPS: StatusGroupDef[] = [
@@ -86,14 +107,16 @@ const ACTION_GROUPS: StatusGroupDef[] = [
 		status: 'blocked',
 		title: 'Needs Input',
 		variant: 'red',
-		filterFn: (t) =>
+		blockReason: 'human_input_requested',
+		matchFn: (t) =>
 			t.status === 'blocked' && (t.blockReason as SpaceBlockReason) === 'human_input_requested',
 	},
 	{
 		status: 'blocked',
 		title: 'Gate Pending',
 		variant: 'red',
-		filterFn: (t) =>
+		blockReason: 'gate_rejected',
+		matchFn: (t) =>
 			t.status === 'blocked' && (t.blockReason as SpaceBlockReason) === 'gate_rejected',
 	},
 	{ status: 'review', title: 'Awaiting Review', variant: 'purple' },
@@ -101,7 +124,12 @@ const ACTION_GROUPS: StatusGroupDef[] = [
 		status: 'blocked',
 		title: 'Blocked',
 		variant: 'yellow',
-		filterFn: (t) =>
+		// Server-side: include every blocked row whose reason is NOT one of the
+		// attention-required values (plus null reasons). Mirrors the legacy
+		// client-side `!ATTENTION_BLOCK_REASONS.includes(...)` filter so the
+		// totals stay disjoint from the two attention buckets above.
+		blockReasonNotIn: ATTENTION_BLOCK_REASONS,
+		matchFn: (t) =>
 			t.status === 'blocked' &&
 			!ATTENTION_BLOCK_REASONS.includes(t.blockReason as SpaceBlockReason),
 	},
@@ -309,6 +337,9 @@ function TaskDependencyBadges({
 	);
 }
 
+/** Page size for per-group pagination in the Tasks view. */
+const TASK_GROUP_PAGE_SIZE = 10;
+
 /** Task group card with colored header, matching RoomTasks.TaskGroup style */
 function TaskGroup({
 	title,
@@ -317,6 +348,7 @@ function TaskGroup({
 	tasks,
 	taskById,
 	onTaskClick,
+	pagination,
 }: {
 	title: string;
 	count: number;
@@ -324,6 +356,19 @@ function TaskGroup({
 	tasks: SpaceTask[];
 	taskById: ReadonlyMap<string, SpaceTask>;
 	onTaskClick?: (taskId: string) => void;
+	/**
+	 * Optional pagination footer rendered when the group's total exceeds the
+	 * page size. Encapsulates Prev/Next/range-text so the parent group wrapper
+	 * owns offset state while this card stays presentation-only.
+	 */
+	pagination?: {
+		offset: number;
+		limit: number;
+		total: number;
+		onPrev: () => void;
+		onNext: () => void;
+		isLoading?: boolean;
+	};
 }) {
 	const headerStyles: Record<string, string> = {
 		default: '',
@@ -352,6 +397,8 @@ function TaskGroup({
 		gray: 'border-dark-700',
 	};
 
+	const showPagination = !!pagination && pagination.total > pagination.limit;
+
 	return (
 		<div class={`bg-dark-850 border rounded-xl overflow-hidden ${borderStyles[variant]}`}>
 			<div
@@ -366,6 +413,80 @@ function TaskGroup({
 					<TaskItem key={task.id} task={task} taskById={taskById} onClick={onTaskClick} />
 				))}
 			</div>
+			{showPagination && pagination && (
+				<TaskGroupPagination
+					offset={pagination.offset}
+					limit={pagination.limit}
+					total={pagination.total}
+					pageSize={tasks.length}
+					onPrev={pagination.onPrev}
+					onNext={pagination.onNext}
+					isLoading={pagination.isLoading}
+				/>
+			)}
+		</div>
+	);
+}
+
+/**
+ * Footer row rendered below a paginated `TaskGroup` when the total row count
+ * exceeds the page size. Shows "Showing X–Y of Z" with Prev/Next buttons.
+ *
+ * `pageSize` is the actual length of the current page (may be < `limit` on
+ * the last page); used to compute the "Y" of "X–Y of Z" exactly without
+ * needing an extra round-trip to the server.
+ */
+export function TaskGroupPagination({
+	offset,
+	limit,
+	total,
+	pageSize,
+	onPrev,
+	onNext,
+	isLoading,
+}: {
+	offset: number;
+	limit: number;
+	total: number;
+	pageSize: number;
+	onPrev: () => void;
+	onNext: () => void;
+	isLoading?: boolean;
+}) {
+	const start = pageSize === 0 ? 0 : offset + 1;
+	const end = offset + pageSize;
+	const prevDisabled = offset === 0 || isLoading;
+	const nextDisabled = offset + limit >= total || isLoading;
+
+	const buttonClass =
+		'px-2 py-1 text-xs rounded text-gray-300 hover:bg-dark-700 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent';
+
+	return (
+		<div
+			data-testid="task-group-pagination"
+			class="flex items-center justify-between px-4 py-2 border-t border-dark-700 bg-dark-900/30"
+		>
+			<button
+				type="button"
+				class={buttonClass}
+				disabled={prevDisabled}
+				data-testid="task-group-prev"
+				onClick={onPrev}
+			>
+				← Prev
+			</button>
+			<span class="text-xs text-gray-500" data-testid="task-group-range">
+				Showing {start}–{end} of {total}
+			</span>
+			<button
+				type="button"
+				class={buttonClass}
+				disabled={nextDisabled}
+				data-testid="task-group-next"
+				onClick={onNext}
+			>
+				Next →
+			</button>
 		</div>
 	);
 }
@@ -468,7 +589,9 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 		if (activeTab === 'scheduled') return [];
 		const predicate = TAB_PREDICATES[activeTab as Exclude<TaskFilterTab, 'scheduled'>];
 		if (!predicate) return [];
-		return [...tasks].filter(predicate).sort((a, b) => b.updatedAt - a.updatedAt);
+		// Used only to drive the tab-empty-state decision; the per-group
+		// content is fetched server-side by `PaginatedTaskGroup`.
+		return tasks.filter(predicate);
 	}, [tasks, activeTab]);
 
 	// Build the dep lookup once per render of the list — O(N) total rather
@@ -568,7 +691,7 @@ export function SpaceTasks({ spaceId: _spaceId, onSelectTask }: SpaceTasksProps)
 					<EmptyTabState tab={activeTab} />
 				) : (
 					<TaskGroupList
-						tasks={filteredTasks}
+						tasks={tasks}
 						taskById={taskById}
 						tab={activeTab as Exclude<TaskFilterTab, 'scheduled'>}
 						onTaskClick={onSelectTask}
@@ -698,21 +821,137 @@ function TaskGroupList({
 	return (
 		<div class="space-y-4">
 			{groups.map((group) => {
-				const filterFn = group.filterFn ?? ((t: SpaceTask) => t.status === group.status);
-				const groupTasks = tasks.filter(filterFn);
-				if (groupTasks.length === 0) return null;
+				// Compute the badge count from the full `tasks` signal so it stays
+				// in sync with real-time updates (e.g. a task transitions from
+				// `open` to `in_progress` — the new "In Progress" badge updates
+				// before the paginated fetch lands). The actual page contents are
+				// fetched server-side from `PaginatedTaskGroup`.
+				const matchFn = group.matchFn ?? ((t: SpaceTask) => t.status === group.status);
+				const localCount = tasks.filter(matchFn).length;
+
+				// Skip rendering empty groups, mirroring the legacy behaviour.
+				// Using the local count here means we don't fire a network
+				// request just to learn there's nothing to show.
+				if (localCount === 0) return null;
+
 				return (
-					<TaskGroup
-						key={group.title}
-						title={group.title}
-						count={groupTasks.length}
-						variant={group.variant}
-						tasks={groupTasks}
+					<PaginatedTaskGroup
+						key={`${tab}-${group.title}`}
+						group={group}
+						localCount={localCount}
 						taskById={taskById}
 						onTaskClick={onTaskClick}
 					/>
 				);
 			})}
 		</div>
+	);
+}
+
+/**
+ * Wrapper that owns per-group pagination state. Fetches a single page of
+ * tasks for the group's status (and optional `blockReason` filter) on mount
+ * and on offset changes via `spaceStore.fetchTaskGroup`.
+ *
+ * Parent renders the badge count from the live `tasks` signal so the header
+ * updates instantly on real-time task changes; the paginated body is fetched
+ * lazily and shows a loading shim during the round-trip. When a real-time
+ * `space.task.updated` event lands while a page is on screen, we also re-fetch
+ * the current page so paginated rows reflect the change.
+ */
+function PaginatedTaskGroup({
+	group,
+	localCount,
+	taskById,
+	onTaskClick,
+}: {
+	group: StatusGroupDef;
+	localCount: number;
+	taskById: ReadonlyMap<string, SpaceTask>;
+	onTaskClick?: (taskId: string) => void;
+}) {
+	const [offset, setOffset] = useState(0);
+	const [page, setPage] = useState<{ tasks: SpaceTask[]; total: number }>({
+		tasks: [],
+		total: 0,
+	});
+	const [loading, setLoading] = useState(false);
+
+	// Reset offset to 0 if the group identity changes (e.g. user switches tab).
+	// Using the title + status combo as the key avoids stale offsets when
+	// remounting under a different tab.
+	const groupKey = `${group.title}-${group.status}-${group.blockReason ?? ''}`;
+	useEffect(() => {
+		setOffset(0);
+	}, [groupKey]);
+
+	// Re-fetch when the local count changes too — keeps the visible page
+	// fresh when tasks are added, updated, or removed without forcing the
+	// user to click Prev/Next. The local count is derived from the same
+	// real-time `tasks` signal that drives badge counts.
+	useEffect(() => {
+		let cancelled = false;
+		setLoading(true);
+		spaceStore
+			.fetchTaskGroup(group.status, {
+				blockReason: group.blockReason,
+				blockReasonNotIn: group.blockReasonNotIn,
+				limit: TASK_GROUP_PAGE_SIZE,
+				offset,
+			})
+			.then((result) => {
+				if (cancelled) return;
+				setPage(result);
+
+				// Clamp offset if total shrank (e.g. tasks moved to another
+				// status while the user was on a deeper page). If the current
+				// offset now points past the end, jump back one page so the
+				// user keeps seeing content rather than an empty card.
+				if (result.total > 0 && offset >= result.total) {
+					const lastPageOffset =
+						Math.max(0, Math.ceil(result.total / TASK_GROUP_PAGE_SIZE) - 1) * TASK_GROUP_PAGE_SIZE;
+					setOffset(lastPageOffset);
+				}
+			})
+			.catch(() => {
+				if (cancelled) return;
+				// Fall back to an empty page on error — group will collapse via
+				// the localCount === 0 check on next render if the count is
+				// also zero, otherwise the user can hit Prev/Next to retry.
+				setPage({ tasks: [], total: 0 });
+			})
+			.finally(() => {
+				if (cancelled) return;
+				setLoading(false);
+			});
+		return () => {
+			cancelled = true;
+		};
+		// `groupKey` captures all server-filter inputs; `localCount` triggers
+		// a refresh on real-time changes; `offset` drives Prev/Next.
+	}, [groupKey, offset, localCount]);
+
+	// Use the server total once we have it; before the first fetch resolves,
+	// fall back to the local count so the header doesn't flash "(0)" for
+	// non-empty groups during initial load.
+	const headerCount = page.total || localCount;
+
+	return (
+		<TaskGroup
+			title={group.title}
+			count={headerCount}
+			variant={group.variant}
+			tasks={page.tasks}
+			taskById={taskById}
+			onTaskClick={onTaskClick}
+			pagination={{
+				offset,
+				limit: TASK_GROUP_PAGE_SIZE,
+				total: page.total,
+				onPrev: () => setOffset((o) => Math.max(0, o - TASK_GROUP_PAGE_SIZE)),
+				onNext: () => setOffset((o) => o + TASK_GROUP_PAGE_SIZE),
+				isLoading: loading,
+			}}
+		/>
 	);
 }

--- a/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/preact';
 import { signal } from '@preact/signals';
 import type { SpaceTask } from '@neokai/shared';
 
@@ -63,6 +63,39 @@ vi.mock('../../../lib/space-store', () => ({
 			tasks: mockTasks,
 			schedules: mockSchedules,
 			listSchedules: mockListSchedules,
+			// `fetchTaskGroup` mirrors the daemon repository pagination semantics
+			// so the component renders the same task subset it would in production.
+			fetchTaskGroup: async (
+				status: SpaceTask['status'],
+				options?: {
+					blockReason?: SpaceTask['blockReason'] | null;
+					blockReasonNotIn?: string[];
+					limit?: number;
+					offset?: number;
+				}
+			) => {
+				const limit = options?.limit ?? 10;
+				const offset = options?.offset ?? 0;
+				const all = (mockTasks.value as SpaceTask[])
+					.filter((t) => {
+						if (t.status !== status) return false;
+						if (options && 'blockReason' in options) {
+							if ((t.blockReason ?? null) !== (options.blockReason ?? null)) {
+								return false;
+							}
+						}
+						if (options?.blockReasonNotIn && options.blockReasonNotIn.length > 0) {
+							if (t.blockReason && options.blockReasonNotIn.includes(t.blockReason)) {
+								return false;
+							}
+						}
+						return true;
+					})
+					// Match the repository's `ORDER BY updated_at DESC` so tests that
+					// rely on sort order see the same view as production.
+					.sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
+				return { tasks: all.slice(offset, offset + limit), total: all.length };
+			},
 		};
 	},
 }));
@@ -151,47 +184,47 @@ describe('SpaceTasks', () => {
 		expect(getByText('No archived tasks')).toBeTruthy();
 	});
 
-	it('displays tasks in active tab (open + in_progress)', () => {
+	it('displays tasks in active tab (open + in_progress)', async () => {
 		mockTasks.value = [makeTask('t1', 'open'), makeTask('t2', 'in_progress')];
-		const { getByText, queryByText } = render(<SpaceTasks spaceId="space-1" />);
-		expect(getByText('Task t1')).toBeTruthy();
-		expect(getByText('Task t2')).toBeTruthy();
+		const { findByText, queryByText } = render(<SpaceTasks spaceId="space-1" />);
+		expect(await findByText('Task t1')).toBeTruthy();
+		expect(await findByText('Task t2')).toBeTruthy();
 		expect(queryByText('No active tasks')).toBeNull();
 	});
 
-	it("surfaces 'approved' tasks inside the active tab (post-approval running)", () => {
+	it("surfaces 'approved' tasks inside the active tab (post-approval running)", async () => {
 		// `approved` is a transient state between `approve_task` and
 		// `mark_complete`. When stuck (post-approval dispatch fails and
 		// `postApprovalBlockedReason` is populated), the task must remain
 		// visible — routing it to Active keeps it in sight and the
 		// PendingPostApprovalBanner on the detail pane surfaces the error.
 		mockTasks.value = [makeTask('t1', 'approved')];
-		const { getByText } = render(<SpaceTasks spaceId="space-1" />);
-		expect(getByText('Task t1')).toBeTruthy();
-		expect(getByText(/Post-Approval Running/)).toBeTruthy();
+		const { findByText } = render(<SpaceTasks spaceId="space-1" />);
+		expect(await findByText('Task t1')).toBeTruthy();
+		expect(await findByText(/Post-Approval Running/)).toBeTruthy();
 	});
 
-	it('displays tasks in action tab (blocked + review)', () => {
+	it('displays tasks in action tab (blocked + review)', async () => {
 		mockTasks.value = [makeTask('t1', 'blocked'), makeTask('t2', 'review')];
-		const { getByText } = render(<SpaceTasks spaceId="space-1" />);
+		const { getByText, findByText } = render(<SpaceTasks spaceId="space-1" />);
 		fireEvent.click(getByText('Action'));
-		expect(getByText('Task t1')).toBeTruthy();
-		expect(getByText('Task t2')).toBeTruthy();
+		expect(await findByText('Task t1')).toBeTruthy();
+		expect(await findByText('Task t2')).toBeTruthy();
 	});
 
-	it('displays tasks in completed tab (done + cancelled)', () => {
+	it('displays tasks in completed tab (done + cancelled)', async () => {
 		mockTasks.value = [makeTask('t1', 'done'), makeTask('t2', 'cancelled')];
-		const { getByText } = render(<SpaceTasks spaceId="space-1" />);
+		const { getByText, findByText } = render(<SpaceTasks spaceId="space-1" />);
 		fireEvent.click(getByText('Completed'));
-		expect(getByText('Task t1')).toBeTruthy();
-		expect(getByText('Task t2')).toBeTruthy();
+		expect(await findByText('Task t1')).toBeTruthy();
+		expect(await findByText('Task t2')).toBeTruthy();
 	});
 
-	it('displays tasks in archived tab', () => {
+	it('displays tasks in archived tab', async () => {
 		mockTasks.value = [makeTask('t1', 'archived')];
-		const { getByText } = render(<SpaceTasks spaceId="space-1" />);
+		const { getByText, findByText } = render(<SpaceTasks spaceId="space-1" />);
 		fireEvent.click(getByText('Archived'));
-		expect(getByText('Task t1')).toBeTruthy();
+		expect(await findByText('Task t1')).toBeTruthy();
 	});
 
 	it('shows correct tab counts', () => {
@@ -214,7 +247,7 @@ describe('SpaceTasks', () => {
 		expect(text.some((t) => t?.includes('Archived') && t?.includes('1'))).toBe(true);
 	});
 
-	it('sorts tasks by updatedAt descending', () => {
+	it('sorts tasks by updatedAt descending', async () => {
 		const now = Date.now();
 		mockTasks.value = [
 			makeTask('t1', 'open', { updatedAt: now - 60_000 }),
@@ -223,30 +256,35 @@ describe('SpaceTasks', () => {
 		];
 		const { container } = render(<SpaceTasks spaceId="space-1" />);
 		// Task items are inside TaskGroup cards
+		await waitFor(() => {
+			const taskItems = container.querySelectorAll('.divide-y > div');
+			expect(taskItems.length).toBe(3);
+		});
 		const taskItems = container.querySelectorAll('.divide-y > div');
 		expect(taskItems[0].textContent).toContain('Task t2');
 		expect(taskItems[1].textContent).toContain('Task t1');
 		expect(taskItems[2].textContent).toContain('Task t3');
 	});
 
-	it('calls onSelectTask when a task item is clicked', () => {
+	it('calls onSelectTask when a task item is clicked', async () => {
 		mockTasks.value = [makeTask('t1', 'open')];
 		const onSelectTask = vi.fn();
-		const { getByText } = render(<SpaceTasks spaceId="space-1" onSelectTask={onSelectTask} />);
-		fireEvent.click(getByText('Task t1').closest('.border-l-2')!);
+		const { findByText } = render(<SpaceTasks spaceId="space-1" onSelectTask={onSelectTask} />);
+		const node = await findByText('Task t1');
+		fireEvent.click(node.closest('.border-l-2')!);
 		expect(onSelectTask).toHaveBeenCalledWith('t1');
 	});
 
-	it('renders status label and relative time for each task', () => {
+	it('renders status label and relative time for each task', async () => {
 		mockTasks.value = [makeTask('t1', 'in_progress')];
-		const { getByText } = render(<SpaceTasks spaceId="space-1" />);
-		expect(getByText('In Progress')).toBeTruthy();
+		const { findByText } = render(<SpaceTasks spaceId="space-1" />);
+		expect(await findByText('In Progress')).toBeTruthy();
 	});
 
-	it('renders task number badge', () => {
+	it('renders task number badge', async () => {
 		mockTasks.value = [makeTask('t1', 'open', { taskNumber: 42 })];
-		const { getByText } = render(<SpaceTasks spaceId="space-1" />);
-		expect(getByText('#42')).toBeTruthy();
+		const { findByText } = render(<SpaceTasks spaceId="space-1" />);
+		expect(await findByText('#42')).toBeTruthy();
 	});
 
 	it('does not show count badge when count is 0', () => {
@@ -261,18 +299,18 @@ describe('SpaceTasks', () => {
 		expect(activeTab!.textContent).toBe('Active'); // no "(0)" suffix
 	});
 
-	it('switches tabs and shows filtered tasks', () => {
+	it('switches tabs and shows filtered tasks', async () => {
 		mockTasks.value = [makeTask('t1', 'open'), makeTask('t2', 'done')];
-		const { getByText, queryByText } = render(<SpaceTasks spaceId="space-1" />);
+		const { getByText, findByText, queryByText } = render(<SpaceTasks spaceId="space-1" />);
 
 		// Active tab shows t1
-		expect(getByText('Task t1')).toBeTruthy();
+		expect(await findByText('Task t1')).toBeTruthy();
 		expect(queryByText('Task t2')).toBeNull();
 
 		// Switch to completed
 		fireEvent.click(getByText('Completed'));
+		expect(await findByText('Task t2')).toBeTruthy();
 		expect(queryByText('Task t1')).toBeNull();
-		expect(getByText('Task t2')).toBeTruthy();
 	});
 
 	it('groups tasks by status within a tab', () => {
@@ -301,13 +339,13 @@ describe('SpaceTasks', () => {
 			expect(queryByTestId('task-dependency-badges')).toBeNull();
 		});
 
-		it('renders a gray badge when the dependency is not done', () => {
+		it('renders a gray badge when the dependency is not done', async () => {
 			mockTasks.value = [
 				makeTask('t1', 'open', { taskNumber: 1 }),
 				makeTask('t2', 'open', { taskNumber: 2, dependsOn: ['t1'] }),
 			];
-			const { getAllByTestId } = render(<SpaceTasks spaceId="space-1" />);
-			const badges = getAllByTestId('task-dependency-badge');
+			const { findAllByTestId } = render(<SpaceTasks spaceId="space-1" />);
+			const badges = await findAllByTestId('task-dependency-badge');
 			expect(badges).toHaveLength(1);
 			expect(badges[0].textContent).toContain('#1');
 			expect(badges[0].getAttribute('data-dep-status')).toBe('open');
@@ -316,22 +354,22 @@ describe('SpaceTasks', () => {
 			expect(badges[0].className).not.toContain('text-green-300');
 		});
 
-		it('renders a green badge when the dependency is done', () => {
+		it('renders a green badge when the dependency is done', async () => {
 			mockTasks.value = [
 				makeTask('t1', 'done', { taskNumber: 1 }),
 				makeTask('t2', 'open', { taskNumber: 2, dependsOn: ['t1'] }),
 			];
-			const { getAllByTestId } = render(<SpaceTasks spaceId="space-1" />);
-			const badges = getAllByTestId('task-dependency-badge');
+			const { findAllByTestId } = render(<SpaceTasks spaceId="space-1" />);
+			const badges = await findAllByTestId('task-dependency-badge');
 			expect(badges).toHaveLength(1);
 			expect(badges[0].getAttribute('data-dep-status')).toBe('done');
 			expect(badges[0].className).toContain('text-green-300');
 		});
 
-		it('renders a missing-dep badge with ⚠ when the dep id is not found', () => {
+		it('renders a missing-dep badge with ⚠ when the dep id is not found', async () => {
 			mockTasks.value = [makeTask('t2', 'open', { taskNumber: 2, dependsOn: ['missing-id'] })];
-			const { getAllByTestId } = render(<SpaceTasks spaceId="space-1" />);
-			const badges = getAllByTestId('task-dependency-badge');
+			const { findAllByTestId } = render(<SpaceTasks spaceId="space-1" />);
+			const badges = await findAllByTestId('task-dependency-badge');
 			expect(badges).toHaveLength(1);
 			expect(badges[0].getAttribute('data-dep-status')).toBe('missing');
 			expect(badges[0].getAttribute('title')).toBe('task not found');
@@ -342,26 +380,26 @@ describe('SpaceTasks', () => {
 			expect(badges[0].className).not.toMatch(/\bhover:/);
 		});
 
-		it('shows the dep task title as the tooltip', () => {
+		it('shows the dep task title as the tooltip', async () => {
 			mockTasks.value = [
 				makeTask('t1', 'open', { taskNumber: 1, title: 'Set up auth' }),
 				makeTask('t2', 'open', { taskNumber: 2, dependsOn: ['t1'] }),
 			];
-			const { getAllByTestId } = render(<SpaceTasks spaceId="space-1" />);
-			const badges = getAllByTestId('task-dependency-badge');
+			const { findAllByTestId } = render(<SpaceTasks spaceId="space-1" />);
+			const badges = await findAllByTestId('task-dependency-badge');
 			expect(badges[0].getAttribute('title')).toBe('Set up auth');
 		});
 
-		it('navigates to the dependency task when a badge is clicked', () => {
+		it('navigates to the dependency task when a badge is clicked', async () => {
 			mockTasks.value = [
 				makeTask('t1', 'open', { taskNumber: 1 }),
 				makeTask('t2', 'open', { taskNumber: 2, dependsOn: ['t1'] }),
 			];
 			const onSelectTask = vi.fn();
-			const { getAllByTestId } = render(
+			const { findAllByTestId } = render(
 				<SpaceTasks spaceId="space-1" onSelectTask={onSelectTask} />
 			);
-			const badges = getAllByTestId('task-dependency-badge');
+			const badges = await findAllByTestId('task-dependency-badge');
 			fireEvent.click(badges[0]);
 			expect(onSelectTask).toHaveBeenCalledWith('t1');
 			// Must not also select the parent row (stopPropagation)
@@ -370,18 +408,18 @@ describe('SpaceTasks', () => {
 			expect(badges[0].className).toMatch(/\bhover:/);
 		});
 
-		it('does not invoke onSelectTask for a missing dependency', () => {
+		it('does not invoke onSelectTask for a missing dependency', async () => {
 			mockTasks.value = [makeTask('t2', 'open', { taskNumber: 2, dependsOn: ['ghost'] })];
 			const onSelectTask = vi.fn();
-			const { getAllByTestId } = render(
+			const { findAllByTestId } = render(
 				<SpaceTasks spaceId="space-1" onSelectTask={onSelectTask} />
 			);
-			const badges = getAllByTestId('task-dependency-badge');
+			const badges = await findAllByTestId('task-dependency-badge');
 			fireEvent.click(badges[0]);
 			expect(onSelectTask).not.toHaveBeenCalled();
 		});
 
-		it('shows overflow chip when there are more than 3 deps (first 3 + "+N")', () => {
+		it('shows overflow chip when there are more than 3 deps (first 3 + "+N")', async () => {
 			mockTasks.value = [
 				makeTask('t1', 'done', { taskNumber: 1 }),
 				makeTask('t2', 'open', { taskNumber: 2 }),
@@ -393,8 +431,8 @@ describe('SpaceTasks', () => {
 					dependsOn: ['t1', 't2', 't3', 't4', 't5'],
 				}),
 			];
-			const { getAllByTestId, getByTestId } = render(<SpaceTasks spaceId="space-1" />);
-			const badges = getAllByTestId('task-dependency-badge');
+			const { findAllByTestId, getByTestId } = render(<SpaceTasks spaceId="space-1" />);
+			const badges = await findAllByTestId('task-dependency-badge');
 			// Only the first 3 deps render as badges
 			expect(badges).toHaveLength(3);
 			expect(badges.map((b) => b.textContent)).toEqual(['#1', '#2', '#3']);
@@ -402,7 +440,7 @@ describe('SpaceTasks', () => {
 			expect(overflow.textContent).toBe('+2');
 		});
 
-		it('does not show an overflow chip when there are exactly 3 deps', () => {
+		it('does not show an overflow chip when there are exactly 3 deps', async () => {
 			mockTasks.value = [
 				makeTask('t1', 'done', { taskNumber: 1 }),
 				makeTask('t2', 'done', { taskNumber: 2 }),
@@ -412,18 +450,20 @@ describe('SpaceTasks', () => {
 					dependsOn: ['t1', 't2', 't3'],
 				}),
 			];
-			const { getAllByTestId, queryByTestId } = render(<SpaceTasks spaceId="space-1" />);
-			expect(getAllByTestId('task-dependency-badge')).toHaveLength(3);
+			const { findAllByTestId, queryByTestId } = render(<SpaceTasks spaceId="space-1" />);
+			expect(await findAllByTestId('task-dependency-badge')).toHaveLength(3);
 			expect(queryByTestId('task-dependency-overflow')).toBeNull();
 		});
 
-		it('reacts when a dependency transitions to done', () => {
+		it('reacts when a dependency transitions to done', async () => {
 			mockTasks.value = [
 				makeTask('t1', 'in_progress', { taskNumber: 1 }),
 				makeTask('t2', 'open', { taskNumber: 2, dependsOn: ['t1'] }),
 			];
-			const { getAllByTestId, rerender } = render(<SpaceTasks spaceId="space-1" />);
-			let badges = getAllByTestId('task-dependency-badge');
+			const { findAllByTestId, getAllByTestId, rerender } = render(
+				<SpaceTasks spaceId="space-1" />
+			);
+			let badges = await findAllByTestId('task-dependency-badge');
 			expect(badges[0].getAttribute('data-dep-status')).toBe('in_progress');
 			expect(badges[0].className).toContain('text-gray-300');
 
@@ -433,8 +473,10 @@ describe('SpaceTasks', () => {
 				makeTask('t2', 'open', { taskNumber: 2, dependsOn: ['t1'] }),
 			];
 			rerender(<SpaceTasks spaceId="space-1" />);
-			badges = getAllByTestId('task-dependency-badge');
-			expect(badges[0].getAttribute('data-dep-status')).toBe('done');
+			await waitFor(() => {
+				badges = getAllByTestId('task-dependency-badge');
+				expect(badges[0].getAttribute('data-dep-status')).toBe('done');
+			});
 			expect(badges[0].className).toContain('text-green-300');
 		});
 	});

--- a/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
+++ b/packages/web/src/components/space/__tests__/SpaceTasks.test.tsx
@@ -33,6 +33,14 @@ const { mockCurrentSpaceIdSignal } = vi.hoisted(() => ({
 	mockCurrentSpaceIdSignal: { value: null as string | null },
 }));
 
+// Hoisted spy for `fetchTaskGroup` so individual tests can override behaviour
+// (e.g. simulate a transient RPC failure) and assert call counts. The default
+// implementation mirrors the daemon repository pagination semantics so the
+// component renders the same subset it would in production.
+const { mockFetchTaskGroup } = vi.hoisted(() => ({
+	mockFetchTaskGroup: vi.fn(),
+}));
+
 // Real Preact signal for the filter tab (read during render — needs reactivity)
 const mockCurrentSpaceTasksFilterTabSignal = signal<string>('active');
 
@@ -63,42 +71,45 @@ vi.mock('../../../lib/space-store', () => ({
 			tasks: mockTasks,
 			schedules: mockSchedules,
 			listSchedules: mockListSchedules,
-			// `fetchTaskGroup` mirrors the daemon repository pagination semantics
-			// so the component renders the same task subset it would in production.
-			fetchTaskGroup: async (
-				status: SpaceTask['status'],
-				options?: {
-					blockReason?: SpaceTask['blockReason'] | null;
-					blockReasonNotIn?: string[];
-					limit?: number;
-					offset?: number;
-				}
-			) => {
-				const limit = options?.limit ?? 10;
-				const offset = options?.offset ?? 0;
-				const all = (mockTasks.value as SpaceTask[])
-					.filter((t) => {
-						if (t.status !== status) return false;
-						if (options && 'blockReason' in options) {
-							if ((t.blockReason ?? null) !== (options.blockReason ?? null)) {
-								return false;
-							}
-						}
-						if (options?.blockReasonNotIn && options.blockReasonNotIn.length > 0) {
-							if (t.blockReason && options.blockReasonNotIn.includes(t.blockReason)) {
-								return false;
-							}
-						}
-						return true;
-					})
-					// Match the repository's `ORDER BY updated_at DESC` so tests that
-					// rely on sort order see the same view as production.
-					.sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
-				return { tasks: all.slice(offset, offset + limit), total: all.length };
-			},
+			fetchTaskGroup: mockFetchTaskGroup,
 		};
 	},
 }));
+
+// Default implementation: filter `mockTasks` to mirror the daemon repository
+// pagination semantics. Individual tests can override via
+// `mockFetchTaskGroup.mockImplementationOnce(...)` to simulate failures.
+function defaultFetchTaskGroupImpl(
+	status: SpaceTask['status'],
+	options?: {
+		blockReason?: SpaceTask['blockReason'] | null;
+		blockReasonNotIn?: string[];
+		limit?: number;
+		offset?: number;
+	}
+) {
+	const limit = options?.limit ?? 10;
+	const offset = options?.offset ?? 0;
+	const all = (mockTasks.value as SpaceTask[])
+		.filter((t) => {
+			if (t.status !== status) return false;
+			if (options && 'blockReason' in options) {
+				if ((t.blockReason ?? null) !== (options.blockReason ?? null)) {
+					return false;
+				}
+			}
+			if (options?.blockReasonNotIn && options.blockReasonNotIn.length > 0) {
+				if (t.blockReason && options.blockReasonNotIn.includes(t.blockReason)) {
+					return false;
+				}
+			}
+			return true;
+		})
+		// Match the repository's `ORDER BY updated_at DESC` so tests that
+		// rely on sort order see the same view as production.
+		.sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
+	return Promise.resolve({ tasks: all.slice(offset, offset + limit), total: all.length });
+}
 
 vi.mock('../../../lib/utils', () => ({
 	cn: (...args: string[]) => args.filter(Boolean).join(' '),
@@ -142,6 +153,8 @@ describe('SpaceTasks', () => {
 		mockCurrentSpaceTasksFilterTabSignal.value = 'active';
 		mockCurrentSpaceIdSignal.value = null;
 		mockNavigateToSpaceTasks.mockClear();
+		mockFetchTaskGroup.mockReset();
+		mockFetchTaskGroup.mockImplementation(defaultFetchTaskGroupImpl);
 	});
 
 	afterEach(() => {
@@ -538,6 +551,154 @@ describe('SpaceTasks', () => {
 			expect(sidebarIds).toEqual(
 				['t-approved-1', 't-approved-2', 't-inprog', 't-open-1', 't-open-2'].sort()
 			);
+		});
+	});
+
+	describe('Paginated group refresh & error/loading semantics', () => {
+		it('refetches when a task is edited within the same status (count stable)', async () => {
+			// Two tasks in `in_progress`. The user edits one (title changes
+			// without altering status), bumping `updatedAt`. The fetch effect
+			// should re-run because `contentSig` changed, even though
+			// `localCount` stays at 2.
+			const now = Date.now();
+			mockTasks.value = [
+				makeTask('t1', 'in_progress', { taskNumber: 1, updatedAt: now - 1000 }),
+				makeTask('t2', 'in_progress', { taskNumber: 2, updatedAt: now - 2000 }),
+			];
+			const { findByText } = render(<SpaceTasks spaceId="space-1" />);
+			expect(await findByText('Task t1')).toBeTruthy();
+			const callsAfterMount = mockFetchTaskGroup.mock.calls.length;
+			expect(callsAfterMount).toBeGreaterThan(0);
+
+			// Mutate t1 — same status, new updatedAt and title
+			mockTasks.value = [
+				makeTask('t1', 'in_progress', {
+					taskNumber: 1,
+					updatedAt: now,
+					title: 'Task t1 (edited)',
+				}),
+				makeTask('t2', 'in_progress', { taskNumber: 2, updatedAt: now - 2000 }),
+			];
+			await waitFor(() => {
+				expect(mockFetchTaskGroup.mock.calls.length).toBeGreaterThan(callsAfterMount);
+			});
+		});
+
+		it('refetches when the active spaceId changes', async () => {
+			// Render under space-1 with two tasks. Switch the signal to
+			// space-2 and assert the fetch effect re-ran. Without `spaceId`
+			// in the group key, a stable (title, status, blockReason,
+			// localCount, offset) tuple across spaces would silently leak
+			// rows from the previous space.
+			mockCurrentSpaceIdSignal.value = 'space-1';
+			mockTasks.value = [
+				makeTask('t1', 'in_progress', { taskNumber: 1 }),
+				makeTask('t2', 'in_progress', { taskNumber: 2 }),
+			];
+			const { findByText, rerender } = render(<SpaceTasks spaceId="space-1" />);
+			expect(await findByText('Task t1')).toBeTruthy();
+			const callsBefore = mockFetchTaskGroup.mock.calls.length;
+
+			mockCurrentSpaceIdSignal.value = 'space-2';
+			rerender(<SpaceTasks spaceId="space-2" />);
+			await waitFor(() => {
+				expect(mockFetchTaskGroup.mock.calls.length).toBeGreaterThan(callsBefore);
+			});
+		});
+
+		it('preserves pagination footer and surfaces a Retry banner on fetch error', async () => {
+			// Seed >10 tasks so pagination would render. First call resolves
+			// (mount succeeds → footer rendered), second call rejects
+			// (simulated transient RPC failure on Next click). The footer
+			// must still be in the DOM and the body must show a Retry button.
+			const tasks: SpaceTask[] = [];
+			for (let i = 0; i < 15; i++) {
+				tasks.push(makeTask(`t${i}`, 'in_progress', { taskNumber: i }));
+			}
+			mockTasks.value = tasks;
+
+			// First call (mount) uses the default impl. Second call rejects.
+			mockFetchTaskGroup.mockImplementationOnce(defaultFetchTaskGroupImpl);
+			mockFetchTaskGroup.mockImplementationOnce(() => Promise.reject(new Error('network')));
+
+			const { findByTestId, getByTestId } = render(<SpaceTasks spaceId="space-1" />);
+			// Pagination footer renders after the initial fetch.
+			await findByTestId('task-group-pagination');
+
+			fireEvent.click(getByTestId('task-group-next'));
+
+			// Error banner appears and the footer survives the failure.
+			await findByTestId('task-group-error');
+			expect(getByTestId('task-group-pagination')).toBeTruthy();
+			expect(getByTestId('task-group-retry')).toBeTruthy();
+		});
+
+		it('Retry re-issues the fetch after an error and restores rows on success', async () => {
+			const tasks: SpaceTask[] = [];
+			for (let i = 0; i < 15; i++) {
+				tasks.push(makeTask(`t${i}`, 'in_progress', { taskNumber: i }));
+			}
+			mockTasks.value = tasks;
+
+			mockFetchTaskGroup.mockImplementationOnce(defaultFetchTaskGroupImpl);
+			mockFetchTaskGroup.mockImplementationOnce(() => Promise.reject(new Error('network')));
+			// Third call (Retry) succeeds.
+			mockFetchTaskGroup.mockImplementationOnce(defaultFetchTaskGroupImpl);
+
+			const { findByTestId, getByTestId, queryByTestId } = render(<SpaceTasks spaceId="space-1" />);
+			await findByTestId('task-group-pagination');
+			fireEvent.click(getByTestId('task-group-next'));
+			await findByTestId('task-group-error');
+
+			fireEvent.click(getByTestId('task-group-retry'));
+			await waitFor(() => {
+				expect(queryByTestId('task-group-error')).toBeNull();
+			});
+		});
+
+		it('clears visible rows and shows a loading placeholder on Prev/Next click', async () => {
+			// 15 in_progress tasks → pagination renders (limit=10, total=15).
+			// Stage the second fetch (Next click) on a deferred promise so we
+			// can observe the in-between state where rows are cleared and the
+			// loading placeholder is visible.
+			const tasks: SpaceTask[] = [];
+			for (let i = 0; i < 15; i++) {
+				tasks.push(
+					makeTask(`t${String(i).padStart(2, '0')}`, 'in_progress', {
+						taskNumber: i,
+						updatedAt: Date.now() - i * 1000,
+					})
+				);
+			}
+			mockTasks.value = tasks;
+
+			let resolveNext: (value: { tasks: SpaceTask[]; total: number }) => void = () => {};
+			mockFetchTaskGroup.mockImplementationOnce(defaultFetchTaskGroupImpl);
+			mockFetchTaskGroup.mockImplementationOnce(
+				() =>
+					new Promise((resolve) => {
+						resolveNext = resolve;
+					})
+			);
+
+			const { findByText, getByTestId, findByTestId, queryByText } = render(
+				<SpaceTasks spaceId="space-1" />
+			);
+			// First page rendered.
+			expect(await findByText('Task t00')).toBeTruthy();
+
+			fireEvent.click(getByTestId('task-group-next'));
+
+			// While the Next request is pending, the previous page's rows
+			// must be hidden and a loading placeholder shown — otherwise the
+			// user could click into a row that no longer belongs to the
+			// "Showing 11–20" range now reflected in the footer.
+			await findByTestId('task-group-loading');
+			expect(queryByText('Task t00')).toBeNull();
+
+			// Resolve the deferred fetch with the next page.
+			resolveNext({ tasks: tasks.slice(10, 15), total: 15 });
+			expect(await findByText('Task t10')).toBeTruthy();
 		});
 	});
 });

--- a/packages/web/src/components/space/__tests__/TaskGroupPagination.test.tsx
+++ b/packages/web/src/components/space/__tests__/TaskGroupPagination.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for the TaskGroupPagination footer used by paginated TaskGroup
+ * cards in SpaceTasks.
+ *
+ * Covers:
+ *   - "Showing X–Y of Z" text formatting (first page, middle page, last page,
+ *     and zero-results edge case).
+ *   - Prev button disabled at offset 0; enabled otherwise.
+ *   - Next button disabled when offset + limit >= total; enabled otherwise.
+ *   - Loading state disables both buttons.
+ *   - onPrev / onNext invoke their handlers when clicked.
+ */
+
+// @ts-nocheck
+import { cleanup, fireEvent, render } from '@testing-library/preact';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the space-store import chain (TaskGroupPagination itself does not use
+// it, but importing SpaceTasks pulls the store transitively).
+vi.mock('../../../lib/space-store', () => ({
+	spaceStore: {
+		fetchTaskGroup: vi.fn(),
+		updateTask: vi.fn(),
+	},
+}));
+
+import { TaskGroupPagination } from '../SpaceTasks';
+
+afterEach(() => {
+	cleanup();
+});
+
+describe('TaskGroupPagination', () => {
+	it('renders "Showing 1–10 of 25" on the first page', () => {
+		const { getByTestId } = render(
+			<TaskGroupPagination
+				offset={0}
+				limit={10}
+				total={25}
+				pageSize={10}
+				onPrev={() => {}}
+				onNext={() => {}}
+			/>
+		);
+		expect(getByTestId('task-group-range').textContent).toBe('Showing 1–10 of 25');
+	});
+
+	it('renders the correct range on a middle page', () => {
+		const { getByTestId } = render(
+			<TaskGroupPagination
+				offset={10}
+				limit={10}
+				total={25}
+				pageSize={10}
+				onPrev={() => {}}
+				onNext={() => {}}
+			/>
+		);
+		expect(getByTestId('task-group-range').textContent).toBe('Showing 11–20 of 25');
+	});
+
+	it('renders the correct range on the last (partial) page', () => {
+		const { getByTestId } = render(
+			<TaskGroupPagination
+				offset={20}
+				limit={10}
+				total={25}
+				pageSize={5}
+				onPrev={() => {}}
+				onNext={() => {}}
+			/>
+		);
+		expect(getByTestId('task-group-range').textContent).toBe('Showing 21–25 of 25');
+	});
+
+	it('renders "Showing 0–0 of 0" when there are no results', () => {
+		const { getByTestId } = render(
+			<TaskGroupPagination
+				offset={0}
+				limit={10}
+				total={0}
+				pageSize={0}
+				onPrev={() => {}}
+				onNext={() => {}}
+			/>
+		);
+		expect(getByTestId('task-group-range').textContent).toBe('Showing 0–0 of 0');
+	});
+
+	it('disables the Prev button at offset=0', () => {
+		const { getByTestId } = render(
+			<TaskGroupPagination
+				offset={0}
+				limit={10}
+				total={25}
+				pageSize={10}
+				onPrev={() => {}}
+				onNext={() => {}}
+			/>
+		);
+		expect((getByTestId('task-group-prev') as HTMLButtonElement).disabled).toBe(true);
+		expect((getByTestId('task-group-next') as HTMLButtonElement).disabled).toBe(false);
+	});
+
+	it('enables Prev when offset > 0', () => {
+		const { getByTestId } = render(
+			<TaskGroupPagination
+				offset={10}
+				limit={10}
+				total={25}
+				pageSize={10}
+				onPrev={() => {}}
+				onNext={() => {}}
+			/>
+		);
+		expect((getByTestId('task-group-prev') as HTMLButtonElement).disabled).toBe(false);
+	});
+
+	it('disables Next when offset + limit >= total', () => {
+		const { getByTestId } = render(
+			<TaskGroupPagination
+				offset={20}
+				limit={10}
+				total={25}
+				pageSize={5}
+				onPrev={() => {}}
+				onNext={() => {}}
+			/>
+		);
+		expect((getByTestId('task-group-next') as HTMLButtonElement).disabled).toBe(true);
+		expect((getByTestId('task-group-prev') as HTMLButtonElement).disabled).toBe(false);
+	});
+
+	it('disables both buttons when isLoading=true', () => {
+		const { getByTestId } = render(
+			<TaskGroupPagination
+				offset={10}
+				limit={10}
+				total={25}
+				pageSize={10}
+				onPrev={() => {}}
+				onNext={() => {}}
+				isLoading
+			/>
+		);
+		expect((getByTestId('task-group-prev') as HTMLButtonElement).disabled).toBe(true);
+		expect((getByTestId('task-group-next') as HTMLButtonElement).disabled).toBe(true);
+	});
+
+	it('invokes onPrev when Prev is clicked', () => {
+		const onPrev = vi.fn();
+		const { getByTestId } = render(
+			<TaskGroupPagination
+				offset={10}
+				limit={10}
+				total={25}
+				pageSize={10}
+				onPrev={onPrev}
+				onNext={() => {}}
+			/>
+		);
+		fireEvent.click(getByTestId('task-group-prev'));
+		expect(onPrev).toHaveBeenCalledTimes(1);
+	});
+
+	it('invokes onNext when Next is clicked', () => {
+		const onNext = vi.fn();
+		const { getByTestId } = render(
+			<TaskGroupPagination
+				offset={0}
+				limit={10}
+				total={25}
+				pageSize={10}
+				onPrev={() => {}}
+				onNext={onNext}
+			/>
+		);
+		fireEvent.click(getByTestId('task-group-next'));
+		expect(onNext).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not invoke onPrev when the disabled Prev button is clicked', () => {
+		const onPrev = vi.fn();
+		const { getByTestId } = render(
+			<TaskGroupPagination
+				offset={0}
+				limit={10}
+				total={25}
+				pageSize={10}
+				onPrev={onPrev}
+				onNext={() => {}}
+			/>
+		);
+		fireEvent.click(getByTestId('task-group-prev'));
+		expect(onPrev).not.toHaveBeenCalled();
+	});
+});

--- a/packages/web/src/lib/space-store.ts
+++ b/packages/web/src/lib/space-store.ts
@@ -31,11 +31,14 @@ import type {
 	LiveQuerySnapshotEvent,
 	MessageImage,
 	NodeExecution,
+	PaginatedSpaceTaskResult,
 	RuntimeState,
 	Space,
 	SpaceAgent,
+	SpaceBlockReason,
 	SpaceTask,
 	SpaceTaskActivityMember,
+	SpaceTaskStatus,
 	SpaceWorkflow,
 	SpaceWorkflowSummary,
 	SpaceWorkflowRun,
@@ -1706,6 +1709,62 @@ class SpaceStore {
 
 		const task = await hub.request<SpaceTask>('spaceTask.create', { ...params, spaceId });
 		return task;
+	}
+
+	/**
+	 * Fetch a single page of tasks for a status group, used by the per-group
+	 * Prev/Next pagination in `SpaceTasks`. Returns the page of tasks plus the
+	 * total count for the matching status (and optional `blockReason`) so the
+	 * UI can render "Showing X–Y of Z" and disable Next at the end.
+	 *
+	 * Local-state only: this does NOT update `spaceStore.tasks`. Tab badge
+	 * counts and the sidebar continue to read from the real-time `tasks`
+	 * signal so a paginated group view never causes badges to drift.
+	 *
+	 * If the active space changes while the request is in flight, the result
+	 * is still returned to the caller (it's local state, not a stored signal),
+	 * but the caller's effect should ignore stale responses.
+	 */
+	async fetchTaskGroup(
+		status: SpaceTaskStatus,
+		options?: {
+			blockReason?: SpaceBlockReason | null;
+			blockReasonNotIn?: SpaceBlockReason[];
+			limit?: number;
+			offset?: number;
+		}
+	): Promise<PaginatedSpaceTaskResult> {
+		const spaceId = this.spaceId.value;
+		if (!spaceId) throw new Error('No space selected');
+
+		const hub = connectionManager.getHubIfConnected();
+		if (!hub) throw new Error('Not connected');
+
+		const limit = options?.limit ?? 10;
+		const offset = options?.offset ?? 0;
+
+		// `blockReason` is tri-state: `undefined` = ignore the column, `null` =
+		// match rows with no reason set, value = match exactly. Only forward
+		// the field when the caller passes something so the daemon's
+		// `in (params)` check distinguishes omitted from null. The same goes
+		// for `blockReasonNotIn`, which is the inverse filter for the generic
+		// "Blocked" bucket.
+		const payload: {
+			spaceId: string;
+			status: SpaceTaskStatus;
+			limit: number;
+			offset: number;
+			blockReason?: SpaceBlockReason | null;
+			blockReasonNotIn?: SpaceBlockReason[];
+		} = { spaceId, status, limit, offset };
+		if (options && 'blockReason' in options) payload.blockReason = options.blockReason;
+		if (options?.blockReasonNotIn) payload.blockReasonNotIn = options.blockReasonNotIn;
+
+		const result = await hub.request<PaginatedSpaceTaskResult>('spaceTask.list', payload);
+		return {
+			tasks: result?.tasks ?? [],
+			total: result?.total ?? 0,
+		};
 	}
 
 	/**


### PR DESCRIPTION
Replace the all-tasks-at-once render in the Space Tasks page with per-status-group pagination (10 items per page) so spaces with many tasks no longer materialize the full list on every render.

- New repository method `listBySpaceAndStatus` returns `{tasks, total}` with a tri-state `blockReason` filter (undefined / null / value) plus a `blockReasonNotIn` negation for the generic Blocked bucket.
- `spaceTask.list` RPC stays backward-compatible: omitting pagination params yields the legacy bare array; passing any of `status` / `limit` / `offset` / `blockReason` / `blockReasonNotIn` yields `PaginatedSpaceTaskResult`. Illegal combinations are rejected.
- New `spaceStore.fetchTaskGroup(status, options)` is local to each card and does not mutate the rolling `tasks` signal — badges still tick in real time.
- Each `TaskGroup` card now hosts a `TaskGroupPagination` footer with Prev / Next buttons and a "Showing X–Y of Z" range.