### PR TITLE
perf(daemon): use materialised parent_tool_use_id column in sdk_messages queries

### DIFF
--- a/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
+++ b/packages/daemon/src/lib/rpc-handlers/live-query-handlers.ts
@@ -1819,7 +1819,7 @@ WITH top_level AS (
     origin
   FROM sdk_messages
   WHERE session_id = ?1
-    AND json_extract(sdk_message, '$.parent_tool_use_id') IS NULL
+    AND parent_tool_use_id IS NULL
     AND (message_type != 'user' OR COALESCE(send_status, 'consumed') IN ('consumed', 'failed'))
   ORDER BY timestamp DESC, id DESC
   LIMIT ?2
@@ -1841,11 +1841,7 @@ subagent AS (
     sm.origin AS origin
   FROM sdk_messages sm
   WHERE sm.session_id = ?1
-    AND EXISTS (
-      SELECT 1
-      FROM tool_use_ids tui
-      WHERE tui.id = json_extract(sm.sdk_message, '$.parent_tool_use_id')
-    )
+    AND sm.parent_tool_use_id IN (SELECT id FROM tool_use_ids)
     AND (sm.message_type != 'user' OR COALESCE(sm.send_status, 'consumed') IN ('consumed', 'failed'))
 )
 SELECT

--- a/packages/daemon/src/storage/repositories/sdk-message-repository.ts
+++ b/packages/daemon/src/storage/repositories/sdk-message-repository.ts
@@ -227,7 +227,7 @@ export class SDKMessageRepository {
 		// Show user messages that were consumed to SDK, plus any that failed to deliver.
 		let query = `SELECT sdk_message, timestamp, send_status, origin FROM sdk_messages
       WHERE session_id = ?
-        AND json_extract(sdk_message, '$.parent_tool_use_id') IS NULL
+        AND parent_tool_use_id IS NULL
         AND (message_type != 'user' OR COALESCE(send_status, 'consumed') IN ('consumed', 'failed'))`;
 		const params: SQLiteValue[] = [sessionId];
 
@@ -298,7 +298,7 @@ export class SDKMessageRepository {
 				.join(',');
 			const subagentQuery = `SELECT sdk_message, timestamp FROM sdk_messages
        WHERE session_id = ?
-         AND json_extract(sdk_message, '$.parent_tool_use_id') IN (${placeholders})
+         AND parent_tool_use_id IN (${placeholders})
          AND (message_type != 'user' OR COALESCE(send_status, 'consumed') IN ('consumed', 'failed'))
         ORDER BY timestamp ASC`;
 			const subagentParams: SQLiteValue[] = [sessionId, ...Array.from(toolUseIds)];
@@ -372,7 +372,7 @@ export class SDKMessageRepository {
 		const stmt = this.db.prepare(
 			`SELECT id, sdk_message, timestamp FROM sdk_messages
 	       WHERE session_id = ?
-		       AND json_extract(sdk_message, '$.parent_tool_use_id') IS NULL
+		       AND parent_tool_use_id IS NULL
 		       AND (message_type != 'user' OR COALESCE(send_status, 'consumed') IN ('consumed', 'failed'))
 	       ORDER BY timestamp DESC, rowid DESC
 	       LIMIT 1`
@@ -395,7 +395,7 @@ export class SDKMessageRepository {
 		const stmt = this.db.prepare(
 			`SELECT COUNT(*) as count FROM sdk_messages
        WHERE session_id = ?
-         AND json_extract(sdk_message, '$.parent_tool_use_id') IS NULL
+         AND parent_tool_use_id IS NULL
          AND (message_type != 'user' OR COALESCE(send_status, 'consumed') = 'consumed')`
 		);
 		const result = stmt.get(sessionId) as { count: number };

--- a/packages/daemon/src/storage/schema/index.ts
+++ b/packages/daemon/src/storage/schema/index.ts
@@ -87,6 +87,8 @@ export { runMigration122 } from './migrations';
 export { runMigration123 } from './migrations';
 // knip-ignore-next-line
 export { runMigration124 } from './migrations';
+// knip-ignore-next-line
+export { runMigration126 } from './migrations';
 
 /**
  * Create all database tables and initialize defaults
@@ -641,10 +643,9 @@ function createIndexes(db: BunDatabase): void {
       ON sdk_messages(session_id, timestamp)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_session_timestamp_id
       ON sdk_messages(session_id, timestamp DESC, id DESC)`);
-	db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_parent_tool
-      ON sdk_messages(session_id, json_extract(sdk_message, '$.parent_tool_use_id'))`);
-	// Plain B-tree index over the materialised parent_tool_use_id column —
-	// preferred over idx_sdk_messages_parent_tool for new lookups.
+	// Plain B-tree index over the materialised parent_tool_use_id column.
+	// The earlier json_extract function index (idx_sdk_messages_parent_tool)
+	// was dropped in migration 126 — all callers now use the column directly.
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_parent_tool_use_id
       ON sdk_messages(session_id, parent_tool_use_id)`);
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_renderable_terminal

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -602,6 +602,13 @@ export function runMigrations(db: BunDatabase, createBackup: () => void): void {
 	//   task_schedules — stores template + trigger config + scheduling state.
 	//   Also adds created_by_task_schedule_id column to space_tasks.
 	runMigration125(db);
+
+	// Migration 126: Drop the legacy json_extract function index
+	//   idx_sdk_messages_parent_tool. The column-based equivalent
+	//   idx_sdk_messages_parent_tool_use_id (added by migration 122) covers all
+	//   call sites — keeping both costs write throughput without buying lookup
+	//   speed.
+	runMigration126(db);
 }
 
 /**
@@ -8689,4 +8696,20 @@ export function runMigration125(db: BunDatabase): void {
 	if (columns.length > 0 && !columns.some((c) => c.name === 'created_by_task_schedule_id')) {
 		db.exec(`ALTER TABLE space_tasks ADD COLUMN created_by_task_schedule_id TEXT DEFAULT NULL`);
 	}
+}
+
+/**
+ * Migration 126: Drop the legacy `idx_sdk_messages_parent_tool` function index.
+ *
+ * That index — `(session_id, json_extract(sdk_message, '$.parent_tool_use_id'))` —
+ * was created before `parent_tool_use_id` was materialised as a column. All
+ * call sites now use the column directly and the planner picks
+ * `idx_sdk_messages_parent_tool_use_id (session_id, parent_tool_use_id)`,
+ * making the JSON-extract index dead weight on every INSERT/UPDATE.
+ *
+ * Idempotent via `DROP INDEX IF EXISTS` — databases that never created it
+ * (older dev branches, fresh installs after this migration) are unaffected.
+ */
+export function runMigration126(db: BunDatabase): void {
+	db.exec(`DROP INDEX IF EXISTS idx_sdk_messages_parent_tool`);
 }

--- a/packages/daemon/src/storage/schema/migrations.ts
+++ b/packages/daemon/src/storage/schema/migrations.ts
@@ -7904,8 +7904,9 @@ export function runMigration113(db: BunDatabase): void {
 	if (!tableExists(db, 'sdk_messages')) return;
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_session_timestamp_id
 		ON sdk_messages(session_id, timestamp DESC, id DESC)`);
-	db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_parent_tool
-		ON sdk_messages(session_id, json_extract(sdk_message, '$.parent_tool_use_id'))`);
+	// NOTE: idx_sdk_messages_parent_tool (json_extract function index) was
+	// removed from here in migration 126. The column-based
+	// idx_sdk_messages_parent_tool_use_id added by migration 122 replaces it.
 	db.exec(`CREATE INDEX IF NOT EXISTS idx_sdk_messages_uuid_status
 		ON sdk_messages(session_id, send_status, json_extract(sdk_message, '$.uuid'))`);
 }

--- a/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-messages.test.ts
+++ b/packages/daemon/tests/unit/2-handlers/rpc-handlers/live-query-messages.test.ts
@@ -50,10 +50,14 @@ interface InsertSdkMessageArgs {
 }
 
 function insertSdkMessage(db: BunDatabase, args: InsertSdkMessageArgs): void {
+	const parentToolUseId =
+		typeof args.sdkMessage.parent_tool_use_id === 'string'
+			? args.sdkMessage.parent_tool_use_id
+			: null;
 	db.prepare(
 		`INSERT INTO sdk_messages
-		 (id, session_id, message_type, sdk_message, timestamp, send_status, origin)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)`
+		 (id, session_id, message_type, sdk_message, timestamp, send_status, origin, parent_tool_use_id)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 	).run(
 		args.id,
 		args.sessionId,
@@ -61,7 +65,8 @@ function insertSdkMessage(db: BunDatabase, args: InsertSdkMessageArgs): void {
 		JSON.stringify(args.sdkMessage),
 		args.timestamp ?? '2024-01-01 00:00:00',
 		args.sendStatus ?? 'consumed',
-		args.origin ?? null
+		args.origin ?? null,
+		parentToolUseId
 	);
 }
 
@@ -234,9 +239,9 @@ describe('messages.bySession — SQL behavior', () => {
 		expect(plan).not.toContain('SCAN sdk_messages USING');
 	});
 
-	test('uses the parent tool expression index for subagent lookups', () => {
+	test('uses the materialised parent_tool_use_id index for subagent lookups', () => {
 		const plan = queryPlan(db, 's1', 200);
-		expect(plan).toContain('idx_sdk_messages_parent_tool');
+		expect(plan).toContain('idx_sdk_messages_parent_tool_use_id');
 	});
 
 	test('includes subagent messages whose parent_tool_use_id matches a top-level tool_use', () => {

--- a/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-126_test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/migrations/migration-126_test.ts
@@ -1,0 +1,75 @@
+/**
+ * Migration 126 Tests — drop legacy `idx_sdk_messages_parent_tool` function index.
+ *
+ * Background: migration 122 materialised `parent_tool_use_id` as a column and
+ * added `idx_sdk_messages_parent_tool_use_id (session_id, parent_tool_use_id)`.
+ * The earlier json_extract function index was kept around for compatibility
+ * but no longer has callers, so it just amplifies INSERT/UPDATE cost.
+ *
+ * Covers:
+ *   - Pre-126 schema with the function index present — migration drops it.
+ *   - Re-running the migration is a no-op (idempotent via `IF EXISTS`).
+ *   - Fresh, fully-migrated DB — column index is present and the function
+ *     index is absent (verifies the createIndexes change too).
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { Database as BunDatabase } from 'bun:sqlite';
+import { createTables, runMigration126, runMigrations } from '../../../../../src/storage/schema';
+
+function indexExists(db: BunDatabase, name: string): boolean {
+	const row = db
+		.prepare(`SELECT name FROM sqlite_master WHERE type='index' AND name=?`)
+		.get(name) as { name?: string } | undefined;
+	return !!row?.name;
+}
+
+describe('Migration 126 — drop idx_sdk_messages_parent_tool', () => {
+	test('drops the legacy function index when present', () => {
+		const db = new BunDatabase(':memory:');
+		db.exec(`
+			CREATE TABLE sdk_messages (
+				id TEXT PRIMARY KEY,
+				session_id TEXT NOT NULL,
+				message_type TEXT NOT NULL,
+				sdk_message TEXT NOT NULL,
+				timestamp TEXT NOT NULL,
+				parent_tool_use_id TEXT
+			)
+		`);
+		db.exec(`CREATE INDEX idx_sdk_messages_parent_tool
+			ON sdk_messages(session_id, json_extract(sdk_message, '$.parent_tool_use_id'))`);
+		expect(indexExists(db, 'idx_sdk_messages_parent_tool')).toBe(true);
+
+		runMigration126(db);
+		expect(indexExists(db, 'idx_sdk_messages_parent_tool')).toBe(false);
+		db.close();
+	});
+
+	test('is idempotent — running twice on a DB without the index is a no-op', () => {
+		const db = new BunDatabase(':memory:');
+		db.exec(`
+			CREATE TABLE sdk_messages (
+				id TEXT PRIMARY KEY,
+				session_id TEXT NOT NULL,
+				message_type TEXT NOT NULL,
+				sdk_message TEXT NOT NULL,
+				timestamp TEXT NOT NULL,
+				parent_tool_use_id TEXT
+			)
+		`);
+		runMigration126(db);
+		runMigration126(db);
+		expect(indexExists(db, 'idx_sdk_messages_parent_tool')).toBe(false);
+		db.close();
+	});
+
+	test('fully-migrated DB has the column index but not the legacy function index', () => {
+		const db = new BunDatabase(':memory:');
+		createTables(db);
+		runMigrations(db, () => {});
+		expect(indexExists(db, 'idx_sdk_messages_parent_tool')).toBe(false);
+		expect(indexExists(db, 'idx_sdk_messages_parent_tool_use_id')).toBe(true);
+		db.close();
+	});
+});

--- a/packages/daemon/tests/unit/4-space-storage/storage/scoped-messages-integration.test.ts
+++ b/packages/daemon/tests/unit/4-space-storage/storage/scoped-messages-integration.test.ts
@@ -60,7 +60,7 @@ describe('Scoped invalidation — sdk_messages integration', () => {
 		SELECT id, sdk_message AS content
 		FROM sdk_messages
 		WHERE session_id = ?1
-			AND json_extract(sdk_message, '$.parent_tool_use_id') IS NULL
+			AND parent_tool_use_id IS NULL
 			AND (message_type != 'user' OR COALESCE(send_status, 'consumed') IN ('consumed', 'failed'))
 		ORDER BY timestamp ASC
 	`.trim();


### PR DESCRIPTION
## Why

The daemon's main thread was pegging 99% CPU under sustained SDK message ingest. CPU profile (via `sample`) showed time concentrated in:

```
sqlite3VdbeExec
  └─ vdbeColumnFromOverflow → accessPayload → getOverflowPage → pread   (overflow-page reads)
  └─ sqlite3VdbeRecordCompareWithSkip → binCollFunc → memcmp           (string compares)
```

That's SQLite parsing the fat `sdk_message` JSON blob out of overflow pages for every row scanned. Tracing the predicate: `messages.bySession` (and four `SDKMessageRepository` methods) filter on `json_extract(sdk_message, '$.parent_tool_use_id')` — even though migration 122 already materialised that field as a column and added `idx_sdk_messages_parent_tool_use_id (session_id, parent_tool_use_id)`.

The live daemon DB has one session with **167,972 rows**. Every SDK message arrival re-runs `messages.bySession`, so each evaluation walked the session timestamp-DESC index and JSON-parsed each row's blob.

## What changed

- `MESSAGES_BY_SESSION_SQL`: `top_level` WHERE switches to `parent_tool_use_id IS NULL`; subagent CTE switches from correlated `EXISTS json_extract(...)` to `parent_tool_use_id IN (SELECT id FROM tool_use_ids)` so the planner materialises `tool_use_ids` once and uses the column index with a bloom filter.
- Same swap in `SDKMessageRepository._getSDKMessagesImpl` (top-level + subagent fetch), `getLastSDKMessage`, `getSDKMessageCount`.
- Migration 126 drops the now-unused `idx_sdk_messages_parent_tool` function index — every call site reads the column directly, the function index just amplified write cost.
- Removed the legacy `CREATE INDEX idx_sdk_messages_parent_tool` from `schema/index.ts` so fresh DBs don't recreate it.

## Measured

Against the live 167K-row session, via `EXPLAIN QUERY PLAN` + timing:

| Variant | Time / eval |
|---|---|
| Before (`json_extract` + `EXISTS`) | ~150 ms |
| Naive `JOIN` rewrite (worth noting — does **not** work) | ~39 s |
| After (column + `IN (SELECT)`) | ~10 ms |

The naive `JOIN` form drops the bloom-filter optimisation; `IN (SELECT)` keeps it.

## Test plan
- [x] `bun run check` — clean
- [x] `./scripts/test-daemon.sh 2-handlers` — 1716/1716
- [x] `./scripts/test-daemon.sh 4-space-storage` — 1924/1924 (3 new for migration 126)
- [x] Updated `live-query-messages.test.ts` helper to stamp `parent_tool_use_id` (mirrors prod) and switched the index-usage assertion to the column index